### PR TITLE
feat: 人类可@昵称(handle) + 被@浏览器通知

### DIFF
--- a/docs/superpowers/plans/2026-07-08-human-handle-mention-notify.md
+++ b/docs/superpowers/plans/2026-07-08-human-handle-mention-notify.md
@@ -1,0 +1,589 @@
+# 人类可@昵称(handle) + 被@浏览器通知 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 让人类账号设置全局唯一、可读、可被 @ 的 handle（取代 email/sub 显示），并在被 @ 且标签页未聚焦时弹浏览器通知。
+
+**Architecture:** Approach A —— handle 是"显示 + 被@检测"别名，不改核心 `name` 身份键、不动 ACL。新表 `account_profiles(account, handle)`；worker 查出 handle 经 `x-ap-handle` 头下发给 DO（沿用 `x-ap-owner` 套路），DO 盖到 presence 并 stamp 到消息（沿用 `sender_owner` 套路）。R5 纯客户端：`/api/me` 返回 handle，客户端检测 `msg.mentions` 是否含自己的 handle。
+
+**Tech Stack:** Cloudflare Worker + Hono + partyserver(Durable Object) + D1；shared TS 协议；web React 19 + Vite；worker 测试 vitest(`@cloudflare/vitest-pool-workers`)，web 纯函数测试 bun:test。包管理 bun。
+
+## Global Constraints
+
+- 设计源：`docs/superpowers/specs/2026-07-08-human-handle-mention-notify-design.md`（逐条对照）。
+- **不改身份/ACL 键**：account(email) 仍是唯一 ACL 锚点；handle 不授予任何权限。
+- 协议新增字段全部**可选**，旧客户端忽略（向后兼容）。migration 纯新增（新表 + 新列）。
+- handle 校验：正则 `^[a-z0-9][a-z0-9._-]{1,31}$`；不得等于任何 `tokens.name`；拒绝 `RESERVED_NAMES`（含 `system`）。**唯一性两侧校验**：PUT handle 与铸 token 路径都要查对方命名空间。
+- **提交约定**：commit message 与 PR 正文**不加任何 Claude 署名**（无 `Co-Authored-By: Claude`、无 `Claude-Session`、无 `Generated with Claude Code`）。git 身份用项目本地已配的 `Evan233 <45483911+Tewii233@users.noreply.github.com>`。
+- 默认无 handle = 零破坏（人类照旧显示 email）。
+- 每个任务：先写失败测试 → 跑到失败 → 最小实现 → 跑到通过 → 提交。改 worker 后 `cd worker && bunx tsc --noEmit`；改 web 后 `cd web && bunx tsc --noEmit && bunx vite build`。
+- 高风险任务（migration / 协议 / DO / 铸 token 唯一性）实现后启用独立 Claude-Critic 复审。
+
+---
+
+## Phase A — 后端：handle 落库与下发
+
+### Task A1: migration 0014 + DO schema 加列
+
+**Files:**
+- Create: `worker/migrations/0014_account_profiles.sql`
+- Modify: `worker/src/do.ts`（DO 建表/迁移块，加 `messages.sender_handle`、`presence.handle` 列，与现有 `sender_owner`/`presence.account` 的 ALTER 同处）
+- Test: `worker/test/profile.spec.ts`（新建，后续 A4 复用）；`worker/scripts/verify-remote-schema.mjs`（若枚举了列则补）
+
+**Interfaces:**
+- Produces: 表 `account_profiles(account TEXT PRIMARY KEY, handle TEXT NOT NULL UNIQUE, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL)`；DO `messages.sender_handle TEXT`、`presence.handle TEXT`。
+
+- [ ] **Step 1: 写 migration**
+
+`worker/migrations/0014_account_profiles.sql`：
+```sql
+-- 人类全局唯一 handle（可@昵称，spec 2026-07-08）。handle 是显示+被@检测别名，不授予权限。
+CREATE TABLE account_profiles (
+  account    TEXT PRIMARY KEY,
+  handle     TEXT NOT NULL UNIQUE,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+CREATE INDEX idx_account_profiles_handle ON account_profiles(handle);
+```
+
+- [ ] **Step 2: DO schema 加列**
+
+在 `worker/src/do.ts` 现有 `messages`/`presence` 的迁移块（搜 `ADD COLUMN sender_owner` / `ADD COLUMN account`）后追加幂等 ALTER：
+```ts
+// sender_handle：发送时快照人类 handle（同 sender_owner 手法）
+"ALTER TABLE messages ADD COLUMN sender_handle TEXT",
+// presence.handle：当前连接的人类 handle
+"ALTER TABLE presence ADD COLUMN handle TEXT",
+```
+（按该文件既有 try/catch 逐条 ALTER 的幂等写法照抄。）
+
+- [ ] **Step 3: 应用本地 migration 验证**
+
+Run: `cd worker && echo y | bunx wrangler d1 migrations apply agentparty --local`
+Expected: `0014_account_profiles.sql ✅`
+
+- [ ] **Step 4: 提交**
+
+```bash
+git add worker/migrations/0014_account_profiles.sql worker/src/do.ts
+git commit -m "feat(worker): account_profiles 表 + DO sender_handle/presence.handle 列"
+```
+
+---
+
+### Task A2: 协议字段
+
+**Files:**
+- Modify: `shared/src/protocol.ts`（`Sender`、`PresenceEntry` 加 `handle?`）
+
+**Interfaces:**
+- Produces: `Sender.handle?: string`；`PresenceEntry.handle?: string`。
+
+- [ ] **Step 1: 加字段**
+
+`Sender` 接口加：
+```ts
+  /** 人类全局唯一昵称（可@别名）。仅人类且已设置时下发；agent/未设置省略。旧客户端忽略。 */
+  handle?: string;
+```
+`PresenceEntry` 接口加同样的 `handle?: string`（附注释）。
+
+- [ ] **Step 2: tsc**
+
+Run: `cd shared && bunx tsc --noEmit`  Expected: 通过（纯类型新增）
+Run: `cd worker && bunx tsc --noEmit`  Expected: 通过
+
+- [ ] **Step 3: 提交**
+
+```bash
+git add shared/src/protocol.ts
+git commit -m "feat(shared): Sender/PresenceEntry 增可选 handle 字段"
+```
+
+---
+
+### Task A3: handle 校验 + 唯一性纯逻辑
+
+**Files:**
+- Create: `worker/src/handle.ts`（`HANDLE_RE`、`validateHandleFormat`、`isHandleTaken`）
+- Test: `worker/test/handle.spec.ts`
+
+**Interfaces:**
+- Produces:
+  - `export const HANDLE_RE = /^[a-z0-9][a-z0-9._-]{1,31}$/`
+  - `export function validateHandleFormat(input: unknown): string | null`（合法返回规范化 handle，否则 null）
+  - `export async function handleConflict(db: D1Database, handle: string, forAccount: string | null): Promise<"token_name" | "taken" | "reserved" | null>`（无冲突返回 null）
+
+- [ ] **Step 1: 写失败测试**
+
+`worker/test/handle.spec.ts`：
+```ts
+import { describe, it, expect } from "vitest";
+import { validateHandleFormat, HANDLE_RE } from "../src/handle";
+
+describe("validateHandleFormat", () => {
+  it("接受合法 handle", () => {
+    expect(validateHandleFormat("leo")).toBe("leo");
+    expect(validateHandleFormat("a1._-b")).toBe("a1._-b");
+  });
+  it("拒绝非法：大写/太短/太长/非法首字/非串", () => {
+    expect(validateHandleFormat("Leo")).toBeNull();
+    expect(validateHandleFormat("a")).toBeNull();
+    expect(validateHandleFormat("-abc")).toBeNull();
+    expect(validateHandleFormat("a".repeat(33))).toBeNull();
+    expect(validateHandleFormat(123)).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: 跑到失败**
+
+Run: `cd worker && bunx vitest run test/handle.spec.ts`  Expected: FAIL（模块不存在）
+
+- [ ] **Step 3: 实现**
+
+`worker/src/handle.ts`：
+```ts
+import { RESERVED_NAMES } from "@agentparty/shared";
+
+export const HANDLE_RE = /^[a-z0-9][a-z0-9._-]{1,31}$/;
+
+export function validateHandleFormat(input: unknown): string | null {
+  if (typeof input !== "string") return null;
+  const h = input.trim();
+  return HANDLE_RE.test(h) ? h : null;
+}
+
+// 冲突检查：撞保留名 / 撞任意 token 名 / 已被别的账号占用。无冲突返回 null。
+export async function handleConflict(
+  db: D1Database,
+  handle: string,
+  forAccount: string | null,
+): Promise<"reserved" | "token_name" | "taken" | null> {
+  if (RESERVED_NAMES.includes(handle)) return "reserved";
+  const tok = await db.prepare("SELECT 1 FROM tokens WHERE name = ?").bind(handle).first();
+  if (tok) return "token_name";
+  const owner = await db
+    .prepare("SELECT account FROM account_profiles WHERE handle = ?")
+    .bind(handle)
+    .first<{ account: string }>();
+  if (owner && owner.account !== forAccount) return "taken";
+  return null;
+}
+```
+
+- [ ] **Step 4: 跑到通过**
+
+Run: `cd worker && bunx vitest run test/handle.spec.ts`  Expected: PASS
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add worker/src/handle.ts worker/test/handle.spec.ts
+git commit -m "feat(worker): handle 格式校验 + 命名空间冲突检查"
+```
+
+---
+
+### Task A4: `PUT /api/me/handle` + `GET /api/me` 带 handle
+
+**Files:**
+- Modify: `worker/src/index.ts`（`GET /api/me` 约 `:482`；新增 `PUT /api/me/handle`）
+- Test: `worker/test/profile.spec.ts`
+
+**Interfaces:**
+- Consumes: `validateHandleFormat`、`handleConflict`（Task A3）。
+- Produces: `GET /api/me` 响应含 `handle: string | null`；`PUT /api/me/handle` body `{handle}` → `{handle}` / 400 / 403 / 409。
+
+- [ ] **Step 1: 写失败测试**
+
+`worker/test/profile.spec.ts`（用仓库既有 worker 测试 harness / helpers.ts 建 human 账号会话 token）：
+```ts
+import { describe, it, expect } from "vitest";
+// 参照 worker/test/helpers.ts 的既有工具铸 human 账号 token、发起请求
+import { newHumanToken, app, env } from "./helpers";
+
+describe("PUT /api/me/handle", () => {
+  it("设置合法 handle 后 /api/me 返回它", async () => {
+    const token = await newHumanToken({ owner: "leo@x.com" });
+    const put = await app.request("/api/me/handle", {
+      method: "PUT",
+      headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+      body: JSON.stringify({ handle: "leo" }),
+    }, env);
+    expect(put.status).toBe(200);
+    const me = await (await app.request("/api/me", { headers: { authorization: `Bearer ${token}` } }, env)).json();
+    expect(me.handle).toBe("leo");
+  });
+  it("撞已存在 token 名 → 409", async () => {
+    // 先铸个 agent token 名 "bob"，再让人类想占 handle "bob"
+    const token = await newHumanToken({ owner: "z@x.com" });
+    // ...铸 agent "bob"（参照 helpers）...
+    const put = await app.request("/api/me/handle", {
+      method: "PUT",
+      headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+      body: JSON.stringify({ handle: "bob" }),
+    }, env);
+    expect(put.status).toBe(409);
+  });
+});
+```
+> 注：`helpers.ts` 的确切工具名以仓库现状为准（实现时先读 `worker/test/helpers.ts`），保持与既有 spec 一致的建 token/发请求方式。
+
+- [ ] **Step 2: 跑到失败**
+
+Run: `cd worker && bunx vitest run test/profile.spec.ts`  Expected: FAIL
+
+- [ ] **Step 3: 实现**
+
+`GET /api/me`（`index.ts:482` 内）：查 `account_profiles` 加字段：
+```ts
+const profile = id.account == null ? null : await c.env.DB
+  .prepare("SELECT handle FROM account_profiles WHERE account = ?").bind(id.account)
+  .first<{ handle: string }>();
+// ...原返回对象里加：
+handle: profile?.handle ?? null,
+```
+新增端点（放在 `/api/me` 附近）：
+```ts
+app.put("/api/me/handle", requireBearer, async (c) => {
+  const id = c.get("identity");
+  if (id.role === "readonly" || id.account == null) {
+    return c.json(errorBody("forbidden", "setting a handle requires a human account session"), 403);
+  }
+  const body = (await c.req.json().catch(() => null)) as { handle?: unknown } | null;
+  const handle = validateHandleFormat(body?.handle);
+  if (handle === null) {
+    return c.json(errorBody("bad_request", "handle must match ^[a-z0-9][a-z0-9._-]{1,31}$"), 400);
+  }
+  const conflict = await handleConflict(c.env.DB, handle, id.account);
+  if (conflict !== null) {
+    return c.json(errorBody("conflict", `handle unavailable (${conflict})`), 409);
+  }
+  const now = Date.now();
+  await c.env.DB.prepare(
+    `INSERT INTO account_profiles (account, handle, created_at, updated_at)
+     VALUES (?, ?, ?, ?)
+     ON CONFLICT(account) DO UPDATE SET handle = excluded.handle, updated_at = excluded.updated_at`,
+  ).bind(id.account, handle, now, now).run();
+  return c.json({ handle });
+});
+```
+
+- [ ] **Step 4: 跑到通过**
+
+Run: `cd worker && bunx vitest run test/profile.spec.ts && bunx tsc --noEmit`  Expected: PASS
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add worker/src/index.ts worker/test/profile.spec.ts
+git commit -m "feat(worker): PUT /api/me/handle + GET /api/me 返回 handle"
+```
+
+---
+
+### Task A5: 铸 token 侧唯一性（反向冲突）
+
+**Files:**
+- Modify: `worker/src/index.ts`（`persistToken` 或其调用点 `/api/tokens`、`/api/agents`、`/api/spawn`：铸名前查 `account_profiles.handle`）
+- Test: `worker/test/tokens.spec.ts`（追加）
+
+**Interfaces:**
+- Consumes: `account_profiles`（Task A1）。
+- Produces: 铸 token 名若等于某已存在 handle → 409（与现有 name 冲突同样处理）。
+
+- [ ] **Step 1: 写失败测试**：先设 handle "leo"，再尝试铸名为 "leo" 的 agent token → 期望 409。
+
+- [ ] **Step 2: 跑到失败** — Run: `cd worker && bunx vitest run test/tokens.spec.ts`
+
+- [ ] **Step 3: 实现**：在 `persistToken`（`index.ts` 内）插入/复用行之前加一查：
+```ts
+const handleOwner = await db.prepare("SELECT 1 FROM account_profiles WHERE handle = ?")
+  .bind(opts.name).first();
+if (handleOwner) return { conflict: true };
+```
+（放在现有同名活 token 检查旁，保证 `/api/tokens`、`/api/agents`、`/api/spawn` 三入口都覆盖。）
+
+- [ ] **Step 4: 跑到通过** — Run: `cd worker && bunx vitest run test/tokens.spec.ts && bunx tsc --noEmit`
+
+- [ ] **Step 5: 提交**
+```bash
+git add worker/src/index.ts worker/test/tokens.spec.ts
+git commit -m "feat(worker): 铸 token 名不得撞已存在 handle（双向唯一性）"
+```
+
+---
+
+### Task A6: worker 转发 `x-ap-handle` 给 DO
+
+**Files:**
+- Modify: `worker/src/index.ts`（WS 升级转发 + `POST /api/channels/:slug/messages` 转发，加 `x-ap-handle` 头 + 计入 `AP_FORWARD_HEADERS` 剥离清单）
+- Test: `worker/test/ws-header-injection.spec.ts`（追加：客户端注入 `x-ap-handle` 被剥离）
+
+**Interfaces:**
+- Consumes: `account_profiles`。
+- Produces: DO 收到权威 `x-ap-handle`（仅当发送者是有 handle 的人类）。
+
+- [ ] **Step 1: 写失败测试**：客户端连接时自带伪造 `x-ap-handle: evil` → DO 侧 presence/sender 不应采信（应为该账号真实 handle 或空）。
+
+- [ ] **Step 2: 跑到失败**
+
+- [ ] **Step 3: 实现**：
+  - 把 `"x-ap-handle"` 加入 `AP_FORWARD_HEADERS` 剥离清单（`index.ts:57` 附近）。
+  - 加辅助 `async function handleHeader(db, account): Promise<Record<string,string>>`：account 非空则查 handle，返回 `{ "x-ap-handle": handle }` 或 `{}`。
+  - 在 WS 升级转发与 `POST .../messages` 转发处 `...(await handleHeader(c.env.DB, identity.account))`。
+
+- [ ] **Step 4: 跑到通过** — Run: `cd worker && bunx vitest run test/ws-header-injection.spec.ts && bunx tsc --noEmit`
+
+- [ ] **Step 5: 提交**
+```bash
+git add worker/src/index.ts worker/test/ws-header-injection.spec.ts
+git commit -m "feat(worker): 转发权威 x-ap-handle 给 DO（剥离客户端注入）"
+```
+
+---
+
+### Task A7: DO 消费 handle → presence + 消息 + 下发
+
+**Files:**
+- Modify: `worker/src/do.ts`（onConnect 读 `x-ap-handle` 存 conn state + presence.handle；handleSend stamp `sender_handle`；`senderFromIdentity` / presence 构造带 handle；`rowToFrame` 回填 `sender.handle`）
+- Test: `worker/test/history.spec.ts` 或新 `worker/test/handle-wire.spec.ts`
+
+**Interfaces:**
+- Consumes: `x-ap-handle` 头（Task A6）、`sender_handle`/`presence.handle` 列（Task A1）。
+- Produces: 下发的 `MsgFrame.sender.handle`、`PresenceEntry.handle`。
+
+- [ ] **Step 1: 写失败测试**：带 `x-ap-handle: leo` 发一条消息 → 该消息 `sender.handle === "leo"`；presence 该 name 的 `handle === "leo"`；历史拉取仍带 handle。
+
+- [ ] **Step 2: 跑到失败**
+
+- [ ] **Step 3: 实现**（按 do.ts 既有 sender_owner/context 的存取镜像）：
+  - `ConnState` 加 `handle?: string`；onConnect 读 `h.get("x-ap-handle")` 存入。
+  - `senderFromIdentity`（或消息 insert 处）把 handle 写入 `sender.handle` 与 `sender_handle` 列。
+  - presence upsert 写 `handle` 列；`presenceFor`/`PresenceEntry` 构造带 handle。
+  - `rowToFrame` 读 `sender_handle` 回填 `sender.handle`。
+
+- [ ] **Step 4: 跑到通过** — Run: `cd worker && bunx vitest run test/handle-wire.spec.ts && bunx tsc --noEmit`
+
+- [ ] **Step 5: 提交**
+```bash
+git add worker/src/do.ts worker/test/handle-wire.spec.ts
+git commit -m "feat(worker): DO 盖 presence.handle + stamp sender_handle + 下发 handle"
+```
+
+---
+
+## Phase B — 前端 R4：显示 / 设置 / mention
+
+### Task B1: api.ts setHandle + me.handle 类型
+
+**Files:**
+- Modify: `web/src/lib/api.ts`（`Me` 类型加 `handle: string | null`；新增 `setHandle(handle): Promise<{handle:string}>`）
+
+**Interfaces:**
+- Produces: `setHandle(handle: string)` → `PUT /api/me/handle`；409→`ConflictError`、400→`ValidationError`、403→`ForbiddenError`。
+
+- [ ] **Step 1: 实现**（复用现有错误类与 `getToken()`，仿 `reviseMessage` 风格）：
+```ts
+export async function setHandle(handle: string): Promise<{ handle: string }> {
+  const token = getToken();
+  if (token === null) throw new AuthError("missing token");
+  const res = await fetch("/api/me/handle", {
+    method: "PUT",
+    headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+    body: JSON.stringify({ handle }),
+  });
+  if (res.status === 401) throw new AuthError("invalid or revoked token");
+  if (res.status === 403) throw new ForbiddenError("forbidden");
+  if (res.status === 400) throw new ValidationError("invalid handle");
+  if (res.status === 409) throw new ConflictError("handle unavailable");
+  if (!res.ok) throw new Error(`PUT /api/me/handle failed (${res.status})`);
+  return (await res.json()) as { handle: string };
+}
+```
+并把 `Me`（`fetchMe` 返回类型）加 `handle: string | null`。
+
+- [ ] **Step 2: tsc** — Run: `cd web && bunx tsc --noEmit`  Expected: 通过
+- [ ] **Step 3: 提交**
+```bash
+git add web/src/lib/api.ts
+git commit -m "feat(web): api.setHandle + Me.handle 类型"
+```
+
+### Task B2: 设置 handle 的 UI（非强制提示 + 改名入口）
+
+**Files:**
+- Create: `web/src/components/HandleSetup.tsx`（设置/改名表单：输入 + 保存 + 内联错误）
+- Modify: `web/src/App.tsx`（me chip 处放"设置显示名"入口；人类无 handle 时显眼但可关的提示）
+- Modify: `web/src/i18n/strings/App.ts`（+ 新文案 en/zh）
+
+**Interfaces:**
+- Consumes: `setHandle`（B1）、`me.handle`。
+- Produces: 用户可设置/修改 handle；成功后本地刷新 me.handle。
+
+- [ ] Step 1: 实现 HandleSetup（输入校验前端也提示 `^[a-z0-9][a-z0-9._-]{1,31}$`；ConflictError→"已被占用"、ValidationError→"格式不符"）。
+- [ ] Step 2: App.tsx 接入：人类 `me.handle === null` 时在顶栏显示可关闭的"设置显示名"提示；me chip 下拉/按钮打开 HandleSetup。i18n 走现有机制（en+zh，默认 en）。
+- [ ] Step 3: tsc + build — Run: `cd web && bunx tsc --noEmit && bunx vite build`
+- [ ] Step 4: 提交
+```bash
+git add web/src/components/HandleSetup.tsx web/src/App.tsx web/src/i18n/strings/App.ts
+git commit -m "feat(web): 人类设置/修改 handle 的 UI（非强制提示）"
+```
+
+### Task B3: mention 候选把人类 handle 作 @ 目标
+
+**Files:**
+- Modify: `web/src/lib/mentions.ts`（人类候选：有 handle 时 `name`(@插入token)=handle、`display`=handle）
+- Test: `web/src/lib/mentions.test.ts`（追加）
+
+**Interfaces:**
+- Consumes: `PresenceEntry.handle`（协议已加）。
+- Produces: mention 候选中人类以 handle 作 @ 目标。
+
+- [ ] Step 1: 写失败测试：presence 含一个 `{name:<uuid>, kind:"human", handle:"leo"}` → `mentionCandidates(...)` 产出一条 `name==="leo"`（可 @）且 `display==="leo"`。
+- [ ] Step 2: 跑到失败 — Run: `cd web && bun test src/lib/mentions.test.ts`
+- [ ] Step 3: 实现：在候选构造处，人类且有 `handle` 时用 handle 覆盖 `name`/`display`（无 handle 维持现状）。
+- [ ] Step 4: 跑到通过 — Run: `cd web && bun test src/lib/mentions.test.ts`
+- [ ] Step 5: 提交
+```bash
+git add web/src/lib/mentions.ts web/src/lib/mentions.test.ts
+git commit -m "feat(web): mention 候选以 handle 作人类的 @ 目标"
+```
+
+### Task B4: 显示层用 handle（MessageCard / PresenceBar）
+
+**Files:**
+- Modify: `web/src/components/MessageCard.tsx`（sender 显示优先 `msg.sender.handle`，回退现有 name/owner 逻辑；email 进 title 锚点）
+- Modify: `web/src/components/PresenceBar.tsx`（参与者优先显示 `entry.handle`）
+
+**Interfaces:**
+- Consumes: `Sender.handle` / `PresenceEntry.handle`。
+
+- [ ] Step 1: 实现：`const shown = msg.sender.handle ?? <现有显示>`；`title` 里保留 sender/account/email（防冒充锚点）。PresenceBar 同理。
+- [ ] Step 2: tsc + build — Run: `cd web && bunx tsc --noEmit && bunx vite build`
+- [ ] Step 3: 提交
+```bash
+git add web/src/components/MessageCard.tsx web/src/components/PresenceBar.tsx
+git commit -m "feat(web): 消息卡/presence 优先显示 handle，email 作锚点"
+```
+
+---
+
+## Phase C — 前端 R5：被@浏览器通知
+
+### Task C1: `shouldNotify` 纯函数
+
+**Files:**
+- Create: `web/src/lib/notify.ts`
+- Test: `web/src/lib/notify.test.ts`
+
+**Interfaces:**
+- Produces: `export function shouldNotify(msg: MsgFrame, myHandle: string | null, documentHidden: boolean, permissionGranted: boolean): boolean`
+
+- [ ] **Step 1: 写失败测试**
+
+`web/src/lib/notify.test.ts`：
+```ts
+import { test, expect } from "bun:test";
+import { shouldNotify } from "./notify";
+const base = (over = {}) => ({ type:"msg", kind:"message", seq:5, mentions:["leo"], retracted:undefined,
+  sender:{name:"bob",kind:"agent"}, body:"hi @leo", ...over } as any);
+
+test("被@ + 隐藏 + 已授权 → true", () => {
+  expect(shouldNotify(base(), "leo", true, true)).toBe(true);
+});
+test("标签页可见 → false", () => {
+  expect(shouldNotify(base(), "leo", false, true)).toBe(false);
+});
+test("未授权 → false", () => {
+  expect(shouldNotify(base(), "leo", true, false)).toBe(false);
+});
+test("没@我 → false", () => {
+  expect(shouldNotify(base({mentions:["carol"]}), "leo", true, true)).toBe(false);
+});
+test("我没 handle → false", () => {
+  expect(shouldNotify(base(), null, true, true)).toBe(false);
+});
+test("已撤回 / status / 自己发 → false", () => {
+  expect(shouldNotify(base({retracted:true}), "leo", true, true)).toBe(false);
+  expect(shouldNotify(base({kind:"status"}), "leo", true, true)).toBe(false);
+  expect(shouldNotify(base({sender:{name:"leo",kind:"human",handle:"leo"}}), "leo", true, true)).toBe(false);
+});
+```
+
+- [ ] **Step 2: 跑到失败** — Run: `cd web && bun test src/lib/notify.test.ts`  Expected: FAIL
+
+- [ ] **Step 3: 实现**
+
+`web/src/lib/notify.ts`：
+```ts
+import type { MsgFrame } from "@agentparty/shared";
+
+export function shouldNotify(
+  msg: MsgFrame, myHandle: string | null, documentHidden: boolean, permissionGranted: boolean,
+): boolean {
+  if (!permissionGranted || !documentHidden || myHandle === null) return false;
+  if (msg.kind !== "message" || msg.retracted) return false;
+  if (msg.sender.handle === myHandle) return false; // 自己发的
+  return msg.mentions.includes(myHandle);
+}
+```
+
+- [ ] **Step 4: 跑到通过** — Run: `cd web && bun test src/lib/notify.test.ts`  Expected: PASS
+
+- [ ] **Step 5: 提交**
+```bash
+git add web/src/lib/notify.ts web/src/lib/notify.test.ts
+git commit -m "feat(web): shouldNotify 纯函数（被@通知判定）"
+```
+
+### Task C2: 通知铃铛开关 + hook + 点击跳转
+
+**Files:**
+- Create: `web/src/components/NotifyToggle.tsx`（铃铛：off→点开请求权限、on/off 存 localStorage）
+- Modify: `web/src/pages/Channel.tsx`（入帧处调用 `shouldNotify`，命中则 `new Notification(...)`；点通知 `window.focus()`+跳 `#msg-<seq>`；�reçu铛放频道头）
+- Modify: `web/src/i18n/strings/Channel.ts`（+ 文案）
+
+**Interfaces:**
+- Consumes: `shouldNotify`（C1）、`me.handle`。
+- Produces: 未聚焦被@时弹通知。opt-in 全局存 localStorage key `ap_notify_optin`。
+
+- [ ] Step 1: 实现 NotifyToggle：读/写 `localStorage.ap_notify_optin`；点开时 `Notification.requestPermission()`，拒绝则回落 off + 提示。
+- [ ] Step 2: Channel.tsx：在处理入 `msg` 帧处（reducer 外的副作用点，如 `dispatch` 后的 effect 或帧回调），`if (shouldNotify(frame, me.handle, document.hidden, optin && Notification.permission==="granted")) { const n = new Notification(...); n.onclick = ()=>{ window.focus(); location.hash = "#msg-"+frame.seq; }; }`；按 seq 去重。
+- [ ] Step 3: tsc + build — Run: `cd web && bunx tsc --noEmit && bunx vite build`
+- [ ] Step 4: 提交
+```bash
+git add web/src/components/NotifyToggle.tsx web/src/pages/Channel.tsx web/src/i18n/strings/Channel.ts
+git commit -m "feat(web): 被@浏览器通知（铃铛 opt-in + 未聚焦弹 + 点击跳转）"
+```
+
+---
+
+## Phase D — 集成验证（不改产品码，除非修 bug）
+
+### Task D1: 全量 check + 本地全栈 chrome-use
+
+- [ ] Step 1: `cd worker && bunx tsc --noEmit && bunx vitest run`  Expected: 全绿
+- [ ] Step 2: `cd web && bunx tsc --noEmit && bun test && bunx vite build`  Expected: 全绿
+- [ ] Step 3: 本地 wrangler dev 全栈 + chrome-use（参照上批做法）逐条验：
+  - 设置 handle → me chip/消息/presence 显示 handle
+  - 另一账号 @handle → 出现在 @ 菜单、消息带 mention
+  - 被@ + 切走标签页 + 铃铛已开 → 收到通知；点通知跳到该消息
+  - 撞 token 名 / 撞已占 handle → 409 内联提示
+  - 未设 handle 的人类照旧显示 email（零破坏）
+- [ ] Step 4: 记录到 `.claude/context/runtime/verification.md`
+- [ ] Step 5（可选）：改动 worker 后 remote schema 验证 `cd worker && bun run verify:test-runtime`
+
+---
+
+## Self-Review（对照 spec）
+
+**Spec 覆盖**：§4 数据模型→A1；§5 协议→A2；§6 端点→A4/A5/A6；§7 DO→A7；§8 前端 R4→B1-B4；§9 前端 R5→C1-C2；§10 防冒充→A3(校验)+A5(反向)+B4(锚点)；§11 历史显示→A7(sender_handle)+B4；§13 测试→各任务 + D1；§14 命名空间双向唯一→A3+A4+A5。✅ 无遗漏。
+
+**Placeholder 扫描**：A4 测试里 `helpers.ts` 工具名标注"以仓库现状为准"（实现时先读 helpers），非占位而是显式适配点；其余步骤含实际代码。✅
+
+**类型一致**：`validateHandleFormat`/`handleConflict`(A3) 在 A4/A5 一致引用；`setHandle`(B1) 在 B2 引用；`shouldNotify`(C1) 签名在 C2 引用一致。✅
+
+**风险复审点**：A1/A2/A6/A7（migration/协议/DO/转发）与 A5（铸 token 唯一性）实现后各跑一次独立 Claude-Critic（防冒充、命名空间、ACL 不受影响、向后兼容）。

--- a/docs/superpowers/specs/2026-07-08-human-handle-mention-notify-design.md
+++ b/docs/superpowers/specs/2026-07-08-human-handle-mention-notify-design.md
@@ -1,0 +1,130 @@
+# 人类可 @ 昵称（handle）+ 被 @ 浏览器通知 — 设计
+
+- 日期：2026-07-08
+- 状态：设计已评审，待实现
+- 关联需求：R4（人类可设置昵称，现用 email/sub 不好认）+ R5（当前人类被 @ 时弹浏览器通知）
+- 风险等级：**高**（触及协议 + worker + D1 migration + Durable Object + 身份/mention 相关）。实现时一树一 worktree 隔离，实现前后启用独立评审（Claude-Critic）。
+
+## 1. 动机与现状
+
+- 人类身份（OIDC 网页会话）当前 `name = OIDC sub`（不可读 ID），`owner/account = email`。前端到处显示 sub/email，不好认（R4）。
+- mention 候选（`web/src/lib/mentions.ts`）目前"human 只在当前在线时才作 @ 目标"，但其 name 是 UUID/sub，`@<uuid>` 实际打不出、@ 不到人类。
+- 没有任何"被 @ 时通知"的机制（R5）。
+
+因此 R4 与 R5 是一条链路：**人类先要有一个可读、可 @ 的 handle，"被 @ 通知"才有意义。**
+
+## 2. 目标 / 非目标
+
+**目标**
+- 人类账号可设置一个**全局唯一、可读、可被 @** 的 handle。
+- handle 在 mention 菜单中作为人类的 @ 目标；显示层用 handle 取代 email/sub。
+- 当前登录人类被 @（消息 mentions 含其 handle）且标签页未聚焦时，弹浏览器通知。
+
+**非目标**
+- 不改 agent 的命名/ mention（agent 已有 name）。
+- 不做 per-channel 昵称（作用域=全局账号级）。
+- 不改身份/账号 ACL 模型：account(email) 仍是唯一 ACL 锚点；handle 只是显示+被@检测别名。
+- 不做硬删除、不动 markdown img 白名单等无关项。
+
+## 3. 方案（Approach A：handle 作显示 + 被@检测别名）
+
+handle 是**附加层**，不改核心 `name` 身份键：
+- 人类内部身份键仍是 account/sub 不变。
+- handle 经 worker 查出后随连接/消息以 `x-ap-handle` 头下发给 DO（沿用现有 `x-ap-owner` 套路）；DO 盖到 presence 并 stamp 到每条消息（沿用现有 `sender_owner` 套路）。
+- @ 别人：mention 菜单里人类以 handle 出现，`@<handle>` 是普通 mention 字符串。
+- 被 @ 检测（R5）：`/api/me` 返回我的 handle，客户端看新消息 mentions 是否含我的 handle → 纯客户端，无需服务端为人类 mention 路由（人类无 wake/loop-guard）。
+
+（否决 Approach B：让 handle 直接变成人类 `name`——需改身份键、presence 键、历史 sender_name，且 OIDC 人类无 tokens 行、唯一性需另建机制，改动大、风险高。）
+
+## 4. 数据模型（migration `0014`）
+
+新表：
+```sql
+CREATE TABLE account_profiles (
+  account    TEXT PRIMARY KEY,      -- principal.account（人类 = email/sub）
+  handle     TEXT NOT NULL UNIQUE,  -- 全局唯一 handle
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+```
+
+DO 侧（`worker/src/do.ts` 建表/ALTER，随连接首次访问迁移，与现有 `sender_owner`/`presence.account` 同款）：
+- `messages` 加列 `sender_handle TEXT`（发送时快照）。
+- `presence` 加列 `handle TEXT`。
+
+**handle 校验规则**
+- 格式：`^[a-z0-9][a-z0-9._-]{1,31}$`（name-like，可被 `@` 打出；2–32 字符）。
+- 唯一性：`account_profiles.handle` 全局唯一；且**不得等于任何 `tokens.name`**（handle 与 agent/token 名共用 @ 命名空间，避免撞名/冒充 agent）。
+- 保留名：拒绝 `RESERVED_NAMES`（如 `system`）。
+- 一个账号至多一个 handle（PRIMARY KEY account）；可改名（UPDATE，新 handle 仍须过全部校验）。
+
+## 5. 协议（`shared/src/protocol.ts`，全部可选字段，旧客户端忽略）
+
+- `Sender` 增 `handle?: string`。
+- `PresenceEntry` 增 `handle?: string`。
+- `/api/me` 响应增 `handle: string | null`。
+
+向后兼容：字段缺失 → 前端回退 email/sub 显示、handle 视为未设。
+
+## 6. Worker 端点（`worker/src/index.ts`）
+
+- `GET /api/me`（现 `index.ts:482`）→ 增 `handle`（按 `identity.account` 查 `account_profiles`）。
+- `PUT /api/me/handle`（新）：
+  - 前置：人类账号会话（`identity.account != null`）；readonly/无账号 → 403。
+  - body `{ handle }`；跑第 4 节全部校验：格式不合 400；等于某 token 名 / 已被别的账号占 / 保留名 → 409。
+  - upsert `account_profiles(account, handle)`；返回 `{ handle }`。
+- 转发人类的 WS 升级 + REST 发消息给 DO 时，按 `identity.account` 查 handle，带 `x-ap-handle` 头（与 `x-ap-owner` 并列；worker 权威、剥离客户端注入值）。
+- （不新增 availability check 端点；UI 靠 PUT 的 409 反馈——YAGNI。）
+
+## 7. Durable Object（`worker/src/do.ts`）
+
+- 读 `x-ap-handle`：写入 presence.handle；每条 insert 的消息 stamp `sender_handle`。
+- 下发的 `Sender` / `PresenceEntry` 带 handle（存在时）。
+- 历史消息经 `rowToFrame` 回填 `sender.handle = sender_handle`。
+
+## 8. 前端 R4（`web`）
+
+- `/api/me` 有 handle 后：
+  - **进频道时若人类还没 handle → 显眼提示可设置显示名**（非强制打断弹窗；一个可关闭的 banner/按钮）。另在 me chip / 资料处放随时改名入口。
+  - `lib/api.ts` 增 `setHandle(handle)` → `PUT /api/me/handle`；映射 409（被占/撞名）/400（非法）为内联提示。
+- **mention 候选**（`lib/mentions.ts`）：人类候选的 @ 插入 token 用 handle（有 handle 时）；无 handle 的人类维持现状（在线才留、显示 account）。display=handle。
+- **显示**（`MessageCard` / `PresenceBar`）：有 handle 时显示 handle，email 作 tooltip 可信锚点（沿用现有 owner 显示位）；无 handle 回退 email/sub。
+
+## 9. 前端 R5（`web`）
+
+- 纯函数 `shouldNotify(msg, myHandle, documentHidden, permissionGranted): boolean`：
+  - `msg.kind === "message"` 且非 retracted 且非自己发；
+  - `myHandle !== null` 且 `msg.mentions` 含 `myHandle`；
+  - `documentHidden === true`（标签页未聚焦）；
+  - `permissionGranted === true`。
+- Hook：订阅入帧，命中 `shouldNotify` → `new Notification("有人在 #<频道> @了你", { body: <正文预览> })`；去重（按 seq）。
+- **授权（opt-in）**：不自动请求。频道头放"通知铃铛"开关，用户点开时才 `Notification.requestPermission()`；opt-in 状态存 localStorage，**全局生效**（一次开启对所有频道有效）。
+- 点通知 → `window.focus()` + 跳 `#msg-<seq>`（锚点已存在）。
+
+## 10. 防冒充
+
+- handle 全局唯一（只一个 "leo"）+ 不得撞 token 名 + 保留名拒绝。
+- 展示始终把 account/email 作可信锚点（tooltip/副标签）——底层是谁永远可查。
+- handle 只影响显示与"被@检测"，**不授予任何权限**；ACL 判定完全不看 handle。
+
+## 11. 历史消息显示
+
+- 靠 stamp 的 `sender_handle`：老消息显示**发送当时**的 handle；设 handle 之前的老消息无 stamp → 回退 email/sub。
+- 改名不回溯改写老消息（简单；"显示当时是谁"也更合理）。
+
+## 12. 向后兼容 / 灰度
+
+- 默认无 handle → 人类照旧显示 email，**零破坏**。
+- 协议字段全可选；migration 纯新增（新表 + 新列）。
+- 旧 worker 响应缺字段 → 前端回退。
+
+## 13. 测试
+
+- worker（vitest）：`account_profiles` upsert；handle 校验（格式/唯一/撞 token 名/保留名/改名）；`/api/me` 带 handle；转发 `x-ap-handle`；DO stamp `sender_handle` + presence.handle。migration 幂等 + `verify:remote-schema`。
+- web（bun:test）：`shouldNotify` 纯函数全分支；mention 候选含人类 handle 且插入 token 正确；MessageCard/PresenceBar 显示 handle/回退。
+- chrome-use（真实页面）：设置 handle 流程、改名 409 提示、别人 @handle 后显示、R5 检测+权限 gating（通知本体在无头难验，重点验检测逻辑与 opt-in 门）。
+
+## 14. 风险 / 待实现时确认
+
+- mention 命名空间冲突：handle 与 token 名唯一性需在 `PUT` 和铸 token（`persistToken` / `/api/tokens` / `/api/agents` / `/api/spawn`）**两侧都校验**，避免 A 先占 handle "leo"、B 再铸 token "leo"（或反向）。实现时需在铸 token 路径也查 `account_profiles.handle`。
+- 改名后老 presence/连接的 handle 刷新时机（下次连接/下条消息才更新；可接受）。

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -783,6 +783,8 @@ export interface PresenceFrame {
   wake?: WakeInfo;
   context?: AgentContext;
   lineage?: AgentLineage;
+  /** 人类全局唯一昵称（可@别名）。仅人类且已设置时下发；旧客户端忽略。 */
+  handle?: string;
 }
 
 export interface ErrorFrame {

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -182,6 +182,8 @@ export interface Sender {
   /** 所属人：机器 ap_ token 铸造时写入的标签，人类 OIDC token 为其 email。无则省略（旧客户端忽略） */
   owner?: string;
   lineage?: AgentLineage;
+  /** 人类全局唯一昵称（可@别名）。仅人类且已设置时下发；agent/未设置省略。旧客户端忽略。 */
+  handle?: string;
   /** 同一身份当前活跃连接数。仅 >1 时下发，用于提示 token/session 被重复使用。 */
   connection_count?: number;
 }
@@ -205,6 +207,8 @@ export interface PresenceEntry {
   wake?: WakeInfo;
   context?: AgentContext;
   lineage?: AgentLineage;
+  /** 人类全局唯一昵称（可@别名）。仅人类且已设置时下发；旧客户端忽略。 */
+  handle?: string;
   /** 同一身份当前活跃连接数。仅 >1 时下发，用于提示 token/session 被重复使用。 */
   connection_count?: number;
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -540,6 +540,7 @@ export function App() {
               agentNamePrefix={(me?.email ?? me?.name ?? slug).split("@")[0] ?? slug}
               accountKey={me?.email ?? me?.owner ?? me?.name ?? null}
               inviterName={me?.name ?? slug}
+              selfHandle={me?.handle ?? null}
               onAuthFailed={onAuthFailed}
             />
           ) : (

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,7 +1,8 @@
 // 应用骨架：登录闸 → 头部 + 左侧频道列表 + 右侧（首页 | 频道页）
-import { useCallback, useEffect, useRef, useState } from "react";
+import { type CSSProperties, useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { ChannelList } from "./components/ChannelList";
 import { CreateChannel } from "./components/CreateChannel";
+import { HandleSetup } from "./components/HandleSetup";
 import { TokenGate } from "./components/TokenGate";
 import { LanguageSwitcher } from "./components/LanguageSwitcher";
 import {
@@ -60,6 +61,35 @@ export function App() {
   const [joinStatus, setJoinStatus] = useState<{ phase: "joining" | "error"; message?: string } | null>(null);
   // 命中 /auth/callback 时先挂起，避免闪一下登录闸；换 token 成功/失败后落定
   const [oidcPending, setOidcPending] = useState<boolean>(() => isCallbackPath());
+
+  // 人类账号设置/修改 @handle（Task B2）：me chip 旁的入口开关 + 浮层定位（fixed + 视口内钳制，
+  // 手法同 AgentTokens 那次 viewport 修复）；banner 关闭态只在本次会话内记，不落盘。
+  const [handleSetupOpen, setHandleSetupOpen] = useState(false);
+  const [handlePanelStyle, setHandlePanelStyle] = useState<CSSProperties>({});
+  const [handleBannerDismissed, setHandleBannerDismissed] = useState(false);
+  const handleAnchorRef = useRef<HTMLSpanElement | null>(null);
+
+  useLayoutEffect(() => {
+    if (!handleSetupOpen) return;
+    const update = () => {
+      const anchor = handleAnchorRef.current?.getBoundingClientRect();
+      if (!anchor) return;
+      const gap = 6;
+      const margin = 12;
+      const width = Math.min(320, window.innerWidth - margin * 2);
+      const top = Math.min(anchor.bottom + gap, window.innerHeight - margin);
+      const left = Math.max(margin, Math.min(anchor.right - width, window.innerWidth - width - margin));
+      const maxHeight = Math.max(160, window.innerHeight - top - margin);
+      setHandlePanelStyle({ left, top, width, maxHeight });
+    };
+    update();
+    window.addEventListener("resize", update);
+    window.addEventListener("scroll", update, true);
+    return () => {
+      window.removeEventListener("resize", update);
+      window.removeEventListener("scroll", update, true);
+    };
+  }, [handleSetupOpen]);
 
   // oidc 配置存 ref，供 onAuthFailed/续期在稳定回调里读到最新值（避免进 effect 依赖引发重跑）
   const oidcRef = useRef<OidcConfig | null>(null);
@@ -213,6 +243,8 @@ export function App() {
   useEffect(() => {
     if (token === null) {
       setMe(null);
+      setHandleSetupOpen(false);
+      setHandleBannerDismissed(false);
       return;
     }
     let alive = true;
@@ -369,6 +401,8 @@ export function App() {
   };
   // 建频道入口只给能建的人（登录人类、非分享只读）；scoped agent token 铸不了频道
   const canCreate = !isShareMode() && me?.role === "human";
+  // 设置/修改 @handle 只给登录人类账号（agent token 会话、分享只读链接都不显示，Task B2）
+  const canSetHandle = !isShareMode() && me?.role === "human";
   const channelPending = slug !== null && channels === null && listError === null;
   const unknownChannel =
     slug !== null && channels !== null && !channels.some((c) => c.slug === slug);
@@ -402,6 +436,32 @@ export function App() {
             )}
           </span>
         )}
+        {canSetHandle && me !== null && (
+          <span className="handlesetup-anchor" ref={handleAnchorRef}>
+            <button
+              type="button"
+              className={"d-btn handlesetup-trigger" + (me.handle === null ? " handlesetup-trigger--cta" : "")}
+              onClick={() => setHandleSetupOpen((v) => !v)}
+              aria-expanded={handleSetupOpen}
+              title={me.handle !== null ? t("App.handle.editHint") : t("App.handle.setCta")}
+            >
+              {me.handle !== null ? `@${me.handle}` : t("App.handle.setCta")}
+            </button>
+          </span>
+        )}
+        {handleSetupOpen && me !== null && (
+          <div className="handlesetup-panel" style={handlePanelStyle}>
+            <HandleSetup
+              current={me.handle}
+              onSaved={(handle) => {
+                setMe((prev) => (prev ? { ...prev, handle } : prev));
+                setHandleSetupOpen(false);
+                setHandleBannerDismissed(true);
+              }}
+              onClose={() => setHandleSetupOpen(false)}
+            />
+          </div>
+        )}
         <LanguageSwitcher />
         {!isShareMode() && (
           <button
@@ -413,6 +473,8 @@ export function App() {
               setChannels(null);
               setListError(null);
               setMe(null);
+              setHandleSetupOpen(false);
+              setHandleBannerDismissed(false);
               setToken(null);
             }}
           >
@@ -420,6 +482,24 @@ export function App() {
           </button>
         )}
       </header>
+      {canSetHandle && me !== null && me.handle === null && !handleBannerDismissed && !handleSetupOpen && (
+        <p className="banner banner--yellow handle-banner" role="status">
+          <span className="handle-banner-text">{t("App.handle.banner")}</span>
+          <span className="handle-banner-actions">
+            <button type="button" className="d-btn" onClick={() => setHandleSetupOpen(true)}>
+              {t("App.handle.bannerAction")}
+            </button>
+            <button
+              type="button"
+              className="d-btn handle-banner-dismiss"
+              onClick={() => setHandleBannerDismissed(true)}
+              aria-label={t("App.handle.bannerDismiss")}
+            >
+              ✕
+            </button>
+          </span>
+        </p>
+      )}
       <div className="app-shell">
         <aside className="app-side">
           {canCreate && token !== null && (

--- a/web/src/components/HandleSetup.tsx
+++ b/web/src/components/HandleSetup.tsx
@@ -1,0 +1,91 @@
+// 人类账号设置/修改 @handle（Task B2）。纯表单：输入 + 保存 + 内联错误行，不含自己的开关按钮/
+// 定位逻辑——由调用方（App.tsx 的 me chip 入口）决定何时挂载、挂在哪。
+import { useCallback, useState } from "react";
+import { AuthError, ConflictError, ForbiddenError, setHandle, ValidationError } from "../lib/api";
+import { useT } from "../i18n/useT";
+import "../i18n/strings/HandleSetup";
+
+// spec：小写字母/数字开头，后随小写字母/数字/._- ，总长 2–32
+const HANDLE_RE = /^[a-z0-9][a-z0-9._-]{1,31}$/;
+
+interface Props {
+  current: string | null;
+  onSaved(handle: string): void;
+  onClose?(): void;
+}
+
+export function HandleSetup({ current, onSaved, onClose }: Props) {
+  const t = useT();
+  const [value, setValue] = useState(current ?? "");
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const trimmed = value.trim().toLowerCase();
+  const formatOk = HANDLE_RE.test(trimmed);
+
+  const submit = useCallback(async () => {
+    if (!formatOk || busy) return;
+    setErr(null);
+    setBusy(true);
+    try {
+      const res = await setHandle(trimmed);
+      setBusy(false);
+      onSaved(res.handle);
+    } catch (e) {
+      setBusy(false);
+      setErr(
+        e instanceof ConflictError
+          ? t("HandleSetup.errConflict")
+          : e instanceof ValidationError
+            ? t("HandleSetup.errValidation")
+            : e instanceof ForbiddenError
+              ? t("HandleSetup.errForbidden")
+              : e instanceof AuthError
+                ? t("HandleSetup.errGeneric")
+                : t("HandleSetup.errGeneric"),
+      );
+    }
+  }, [formatOk, busy, trimmed, onSaved, t]);
+
+  return (
+    <div className="handlesetup">
+      <p className="handlesetup-title">{t("HandleSetup.title")}</p>
+      <input
+        className="t-mono handlesetup-input"
+        value={value}
+        autoFocus
+        spellCheck={false}
+        placeholder={t("HandleSetup.placeholder")}
+        onChange={(e) => setValue(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") void submit();
+          if (e.key === "Escape") onClose?.();
+        }}
+        disabled={busy}
+      />
+      {value.trim().length > 0 && !formatOk && (
+        <p className="handlesetup-hint">{t("HandleSetup.formatHint")}</p>
+      )}
+      {err !== null && (
+        <p className="banner banner--red handlesetup-err" role="alert">
+          {err}
+        </p>
+      )}
+      <div className="handlesetup-actions">
+        {onClose !== undefined && (
+          <button type="button" className="d-btn handlesetup-cancel" onClick={onClose} disabled={busy}>
+            {t("HandleSetup.cancel")}
+          </button>
+        )}
+        <button
+          type="button"
+          className="d-btn d-btn--primary"
+          onClick={submit}
+          disabled={busy || !formatOk}
+        >
+          {busy ? t("HandleSetup.saving") : t("HandleSetup.save")}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/MessageCard.tsx
+++ b/web/src/components/MessageCard.tsx
@@ -115,14 +115,20 @@ export function MessageCard({
     msg.kind === "message" && readCursors !== undefined
       ? readStateFor(msg.seq, msg.sender.name, participants ?? [], readCursors)
       : { readers: [], unread: [] };
-  const senderLabel =
-    msg.sender.kind === "human" && msg.sender.owner ? msg.sender.owner : displayForIdentity(msg.sender.name, identityDisplay);
+  // 显示优先级：人类 handle（可 @ 昵称）> owner（email，人类专属）> 常规 identity 回退（agent 天然无 handle，不受影响）。
+  // owner/email 无论是否被 handle 取代，都作为防冒充锚点保留在下方副标签 + tooltip 中（见 senderTitle）。
+  const senderLabel = msg.sender.handle
+    ? msg.sender.handle
+    : msg.sender.kind === "human" && msg.sender.owner
+      ? msg.sender.owner
+      : displayForIdentity(msg.sender.name, identityDisplay);
   const owner = msg.sender.owner && msg.sender.owner !== senderLabel ? msg.sender.owner : null;
   const lineage = msg.sender.lineage ?? null;
   const lineageLabel = lineage === null ? null : `child of ${lineage.parent_agent}`;
   const senderTitle = [
     `sender: ${msg.sender.name}`,
     `kind: ${msg.sender.kind}`,
+    msg.sender.handle ? `handle: ${msg.sender.handle}` : null,
     owner ? `owner: ${owner}` : null,
     lineage ? `parent: ${lineage.parent_agent}` : null,
     lineage ? `root: ${lineage.root_agent}` : null,

--- a/web/src/components/NotifyToggle.tsx
+++ b/web/src/components/NotifyToggle.tsx
@@ -1,0 +1,79 @@
+// 被@浏览器通知的铃铛开关（Task C2）。opt-in 是全局设置（跨频道生效），落 localStorage；
+// 真正的“要不要弹”判定在纯函数 shouldNotify（lib/notify.ts）里，本组件只管开关本身：
+// 读/写 opt-in、申请浏览器通知权限、把结果上报给持有 optin state 的父组件（ChannelPage）。
+import { useState } from "react";
+import { useT } from "../i18n/useT";
+import "../i18n/strings/Channel";
+
+const OPTIN_KEY = "ap_notify_optin";
+
+export function readNotifyOptin(): boolean {
+  try {
+    return localStorage.getItem(OPTIN_KEY) === "1";
+  } catch {
+    return false; // 私有模式等场景 localStorage 不可用时，默认关闭（不静默弹通知）
+  }
+}
+
+function writeNotifyOptin(on: boolean) {
+  try {
+    localStorage.setItem(OPTIN_KEY, on ? "1" : "0");
+  } catch {
+    // 写入失败不阻断本次切换，只是刷新/换标签页后会回落到默认关闭
+  }
+}
+
+interface Props {
+  optin: boolean;
+  onChange(next: boolean): void;
+}
+
+export function NotifyToggle({ optin, onChange }: Props) {
+  const t = useT();
+  const [hint, setHint] = useState<string | null>(null);
+  const supported = typeof window !== "undefined" && "Notification" in window;
+
+  const toggle = () => {
+    setHint(null);
+    if (!supported) return;
+    if (optin) {
+      // 关闭不需要权限往返，立即生效
+      writeNotifyOptin(false);
+      onChange(false);
+      return;
+    }
+    if (Notification.permission === "granted") {
+      writeNotifyOptin(true);
+      onChange(true);
+      return;
+    }
+    void Notification.requestPermission().then((permission) => {
+      if (permission === "granted") {
+        writeNotifyOptin(true);
+        onChange(true);
+      } else {
+        // denied / default 都保持关闭；denied 时浏览器不会再弹权限框，给一次内联提示说明原因
+        writeNotifyOptin(false);
+        onChange(false);
+        setHint(t("Channel.notify.denied"));
+      }
+    });
+  };
+
+  return (
+    <span className="notify-toggle">
+      <button
+        type="button"
+        className={"d-btn notify-toggle-btn" + (optin ? " is-active" : "")}
+        disabled={!supported}
+        onClick={toggle}
+        aria-pressed={optin}
+        title={supported ? (optin ? t("Channel.notify.onTitle") : t("Channel.notify.offTitle")) : t("Channel.notify.unsupported")}
+      >
+        {optin ? "🔔" : "🔕"}
+      </button>
+      {!supported && <span className="notify-toggle-hint t-mono">{t("Channel.notify.unsupported")}</span>}
+      {supported && hint !== null && <span className="notify-toggle-hint t-mono">{hint}</span>}
+    </span>
+  );
+}

--- a/web/src/components/PresenceBar.tsx
+++ b/web/src/components/PresenceBar.tsx
@@ -36,6 +36,7 @@ interface Item {
   lineage: NonNullable<PresenceEntry["lineage"]> | null;
   workflow: NonNullable<NonNullable<PresenceEntry["status"]>["workflow"]> | null;
   owner: string | null; // 所属人：agent 的操作者 / 人类的 email，仅连接中的参与者可知
+  handle: string | null; // 人类全局昵称，仅人类且已设置时有值；agent 恒为 null，天然回退 owner/name
   display: string;
   responsibility: string | null;
   connectionCount: number;
@@ -107,6 +108,8 @@ function ownerKey(item: Item): string {
 }
 
 function ownerLabel(item: Item): string {
+  // 显示优先级：handle > owner/account（email）> 原始 name。agent 恒无 handle，不受影响。
+  if (item.handle !== null && item.handle !== "") return item.handle;
   if (item.owner !== null && item.owner !== "") return item.owner;
   return item.name;
 }
@@ -144,6 +147,8 @@ export function PresenceBar({
     const sender = byName.get(name);
     const assigned = roleByName.get(name);
     const owner = sender?.owner ?? entry?.account ?? assigned?.account ?? null;
+    // 人类全局昵称：仅人类且已设置时有值，agent 恒为 null（协议层保证）。
+    const handle = sender?.handle ?? entry?.handle ?? null;
     const kind = sender?.kind ?? entry?.kind ?? assigned?.kind ?? "agent";
     const connected = byName.has(name);
     const meta = {
@@ -156,17 +161,19 @@ export function PresenceBar({
       context: entry?.context ?? null,
       lineage: entry?.lineage ?? sender?.lineage ?? null,
       workflow: entry?.status?.workflow ?? null,
-      display: assigned?.display ?? (kind === "human" && owner !== null ? owner : name),
+      display: assigned?.display ?? handle ?? (kind === "human" && owner !== null ? owner : name),
       responsibility: assigned?.responsibility ?? null,
       connectionCount: sender?.connection_count ?? entry?.connection_count ?? (connected ? 1 : 0),
     };
     if (!connected) {
-      return { name, kind, state: "offline", note: null, ts: entry?.ts ?? null, owner: null, ...meta };
+      // owner 本就仅连接中的参与者可知（见上方字段注释）；handle 依赖同一份可信度，一并置空，
+      // 避免"显示 handle 但锚点缺失"的半可信状态——离线态照旧回退原始 name，行为与改动前一致。
+      return { name, kind, state: "offline", note: null, ts: entry?.ts ?? null, owner: null, handle: null, ...meta };
     }
     if (entry && entry.state !== "offline") {
-      return { name, kind, state: entry.state, note: entry.note, ts: entry.ts, owner, ...meta };
+      return { name, kind, state: entry.state, note: entry.note, ts: entry.ts, owner, handle, ...meta };
     }
-    return { name, kind, state: "online", note: null, ts: entry?.ts ?? null, owner, ...meta };
+    return { name, kind, state: "online", note: null, ts: entry?.ts ?? null, owner, handle, ...meta };
   });
   const groupMap = new Map<string, PresenceGroup>();
   for (const item of items) {
@@ -185,6 +192,12 @@ export function PresenceBar({
     if (item.kind === "human" && group.human === null) group.human = item;
     else group.agents.push(item);
     groupMap.set(key, group);
+  }
+  // label 初值取自分组时第一个遇到的成员，但 handle 只可能来自人类成员——
+  // 若同一账号下 agent 先于人类出现在 names 排序里，初值会漏掉 handle。
+  // 分组结束后统一用「人类优先」的 representative 重算，和 renderGroup 里的口径保持一致、且与遍历顺序无关。
+  for (const group of groupMap.values()) {
+    group.label = ownerLabel(group.human ?? group.items[0]!);
   }
   const sortedGroups = [...groupMap.values()].sort((a, b) => {
     const rank = groupRank(a, now) - groupRank(b, now);
@@ -205,6 +218,7 @@ export function PresenceBar({
     const full = mode === "full";
     const titleParts = [
       it.owner !== null && it.owner !== it.name ? `${it.name} · ${it.owner}` : it.name,
+      it.handle !== null && it.handle !== "" ? `handle: ${it.handle}` : null,
       it.role !== null ? `role: ${it.role}` : null,
       it.responsibility !== null && it.responsibility !== "" ? `responsibility: ${it.responsibility}` : null,
       it.roleSource !== null ? `role source: ${it.roleSource}` : null,
@@ -303,6 +317,8 @@ export function PresenceBar({
     const hiddenAgents = group.agents.length - previewAgents.length;
     const title = [
       group.label,
+      // group.label 优先显示 handle 时，account/email 锚点在这里补回来，保证底层身份始终可查。
+      representative.owner !== null && representative.owner !== group.label ? `account: ${representative.owner}` : null,
       `${live}/${group.items.length} live`,
       duplicateSessions > 0 ? `${duplicateSessions} extra live session${duplicateSessions === 1 ? "" : "s"}` : null,
       group.human !== null ? `human: ${group.human.name}` : null,

--- a/web/src/i18n/strings/App.ts
+++ b/web/src/i18n/strings/App.ts
@@ -6,12 +6,22 @@ export const AppStrings: LocaleDict = {
     "App.join.loginFailed": "Couldn't start sign-in",
     "App.join.backHome": "Back to home",
     "App.join.joining": "Joining channel…",
+    "App.handle.setCta": "set display name",
+    "App.handle.editHint": "change display name",
+    "App.handle.banner": "You haven't set a display name yet — pick one so others can @mention you easily.",
+    "App.handle.bannerAction": "set now",
+    "App.handle.bannerDismiss": "dismiss",
   },
   zh: {
     "App.join.failed": "加入失败",
     "App.join.loginFailed": "无法开始登录",
     "App.join.backHome": "返回首页",
     "App.join.joining": "正在加入频道…",
+    "App.handle.setCta": "设置显示名",
+    "App.handle.editHint": "修改显示名",
+    "App.handle.banner": "你还没有设置显示名——设置后其他人可以更方便地 @提到你",
+    "App.handle.bannerAction": "现在设置",
+    "App.handle.bannerDismiss": "关闭",
   },
 };
 

--- a/web/src/i18n/strings/Channel.ts
+++ b/web/src/i18n/strings/Channel.ts
@@ -48,6 +48,11 @@ export const ChannelStrings: LocaleDict = {
     "Channel.revise.retract.confirm": "Retract message #{seq}?",
     "Channel.revise.retract.forbidden": "only the sender or a moderator can retract this message",
     "Channel.revise.retract.failed": "message retract failed",
+    "Channel.notify.title": "You were @mentioned in #{channel}",
+    "Channel.notify.onTitle": "Mention notifications on — click to turn off",
+    "Channel.notify.offTitle": "Get a browser notification when you're @mentioned (while this tab isn't focused)",
+    "Channel.notify.denied": "Browser blocked notification permission",
+    "Channel.notify.unsupported": "This browser doesn't support notifications",
   },
   zh: {
     "Channel.charter.label": "📌 公告",
@@ -96,6 +101,11 @@ export const ChannelStrings: LocaleDict = {
     "Channel.revise.retract.confirm": "撤回消息 #{seq}？",
     "Channel.revise.retract.forbidden": "只有发送者或 moderator 可以撤回这条消息",
     "Channel.revise.retract.failed": "消息撤回失败",
+    "Channel.notify.title": "有人在 #{channel} @了你",
+    "Channel.notify.onTitle": "被@提醒已开启，点击关闭",
+    "Channel.notify.offTitle": "开启被@浏览器提醒（仅在标签页未聚焦时弹出）",
+    "Channel.notify.denied": "浏览器已拒绝通知权限",
+    "Channel.notify.unsupported": "此浏览器不支持通知",
   },
 };
 

--- a/web/src/i18n/strings/HandleSetup.ts
+++ b/web/src/i18n/strings/HandleSetup.ts
@@ -1,0 +1,30 @@
+import { registerDict, type LocaleDict } from "../dict";
+
+export const HandleSetupStrings: LocaleDict = {
+  en: {
+    "HandleSetup.title": "Display name",
+    "HandleSetup.placeholder": "handle (e.g. jane_doe)",
+    "HandleSetup.formatHint": "lowercase letters/digits/._-, starting with a letter or digit, 2–32 chars",
+    "HandleSetup.save": "save",
+    "HandleSetup.saving": "saving…",
+    "HandleSetup.cancel": "cancel",
+    "HandleSetup.errConflict": "That handle is already taken — try another",
+    "HandleSetup.errValidation": "Invalid handle format",
+    "HandleSetup.errForbidden": "Only human accounts can set a handle",
+    "HandleSetup.errGeneric": "Couldn't save, try again shortly",
+  },
+  zh: {
+    "HandleSetup.title": "显示名",
+    "HandleSetup.placeholder": "显示名（如 jane_doe）",
+    "HandleSetup.formatHint": "小写字母/数字/._-，字母或数字开头，2–32 位",
+    "HandleSetup.save": "保存",
+    "HandleSetup.saving": "保存中…",
+    "HandleSetup.cancel": "取消",
+    "HandleSetup.errConflict": "该显示名已被占用，换一个试试",
+    "HandleSetup.errValidation": "显示名格式不合法",
+    "HandleSetup.errForbidden": "只有人类账号能设置显示名",
+    "HandleSetup.errGeneric": "保存失败，请稍后重试",
+  },
+};
+
+registerDict(HandleSetupStrings);

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -134,6 +134,7 @@ export interface MeInfo {
   name: string;
   email: string | null;
   kind: "agent" | "human";
+  handle: string | null;
   role: "agent" | "human" | "readonly";
   owner: string | null;
   channel_scope?: string | null;
@@ -363,6 +364,23 @@ export async function reviseMessage(
   if (res.status === 400) throw new ValidationError("invalid message revision");
   if (!res.ok) throw new Error(`POST /api/channels/${slug}/messages/${seq}/${action} failed (${res.status})`);
   return (await res.json()) as { message: MsgFrame };
+}
+
+// 人类账号设置 @handle（PUT /api/me/handle）：400 格式非法 / 403 非人类账号 / 409 冲突。
+export async function setHandle(handle: string): Promise<{ handle: string }> {
+  const token = getToken();
+  if (token === null) throw new AuthError("missing token");
+  const res = await fetch("/api/me/handle", {
+    method: "PUT",
+    headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+    body: JSON.stringify({ handle }),
+  });
+  if (res.status === 401) throw new AuthError("invalid or revoked token");
+  if (res.status === 403) throw new ForbiddenError("forbidden");
+  if (res.status === 400) throw new ValidationError("invalid handle");
+  if (res.status === 409) throw new ConflictError("handle unavailable");
+  if (!res.ok) throw new Error(`PUT /api/me/handle failed (${res.status})`);
+  return (await res.json()) as { handle: string };
 }
 
 export async function fetchChannelCharter(token: string, slug: string): Promise<ChannelCharter> {

--- a/web/src/lib/identityDisplay.test.ts
+++ b/web/src/lib/identityDisplay.test.ts
@@ -25,4 +25,37 @@ describe("buildIdentityDisplay", () => {
 
     expect(map[uuid]).toEqual({ display: "thejacks@163.com", kind: "human", account: "thejacks@163.com" });
   });
+
+  it("prefers a human's handle over owner/email for participants, presence and message senders", () => {
+    const uuid = "61ec302c-6c31-4bca-a1df-88152372f6d9";
+    const map = buildIdentityDisplay({
+      channelIdentities: [],
+      mentionOptions: [],
+      messages: [
+        {
+          seq: 1,
+          kind: "message",
+          body: "hi",
+          ts: 1,
+          sender: { name: uuid, kind: "human", owner: "thejacks@163.com", handle: "leo" },
+          mentions: [],
+          reply_to: null,
+        } as MsgFrame,
+      ],
+      participants: [{ name: uuid, kind: "human", owner: "thejacks@163.com", handle: "leo" }],
+      presence: {
+        [uuid]: {
+          name: uuid,
+          kind: "human",
+          account: "thejacks@163.com",
+          handle: "leo",
+          state: "working",
+          note: null,
+          ts: 1,
+        },
+      },
+    });
+
+    expect(map[uuid]).toEqual({ display: "leo", kind: "human", account: "thejacks@163.com" });
+  });
 });

--- a/web/src/lib/identityDisplay.ts
+++ b/web/src/lib/identityDisplay.ts
@@ -49,25 +49,30 @@ export function buildIdentityDisplay(input: {
 }): IdentityDisplayMap {
   const map: IdentityDisplayMap = {};
 
+  // 显示优先级：人类 handle > owner/account（email）> 原始 name，与 MessageCard/PresenceBar 一致。
+  // agent 恒无 handle，天然回退 name，不受影响。map 的 key 仍是原始 name/UUID，不受此优先级影响。
   for (const sender of input.participants) {
     addIdentity(map, sender.name, {
       kind: sender.kind,
       account: sender.owner,
-      display: sender.kind === "human" && sender.owner ? sender.owner : sender.name,
+      display: sender.kind === "human" ? sender.handle || sender.owner || sender.name : sender.name,
     });
   }
   for (const entry of Object.values(input.presence)) {
     addIdentity(map, entry.name, {
       kind: entry.kind,
       account: entry.account,
-      display: entry.kind === "human" && entry.account ? entry.account : entry.name,
+      display: entry.kind === "human" ? entry.handle || entry.account || entry.name : entry.name,
     });
   }
   for (const message of input.messages) {
     addIdentity(map, message.sender.name, {
       kind: message.sender.kind,
       account: message.sender.owner,
-      display: message.sender.kind === "human" && message.sender.owner ? message.sender.owner : message.sender.name,
+      display:
+        message.sender.kind === "human"
+          ? message.sender.handle || message.sender.owner || message.sender.name
+          : message.sender.name,
     });
   }
   for (const option of input.mentionOptions) {

--- a/web/src/lib/mentions.test.ts
+++ b/web/src/lib/mentions.test.ts
@@ -141,6 +141,28 @@ describe("mentionCandidates", () => {
     expect(mentionCandidates([], pres, null, NOW).map((c) => c.name)).toEqual(["real-agent"]);
   });
 
+  test("online human with a handle uses the handle as the @ token + display (Task B3)", () => {
+    const uuid = "7f1a302c-6c31-4bca-a1df-88152372f6d9";
+    const participants: Sender[] = [{ name: uuid, kind: "human", handle: "leo" }];
+    const pres = {
+      [uuid]: presence({ name: uuid, kind: "human", handle: "leo", account: "leo@x.com", state: "working" }),
+    };
+    const c = mentionCandidates(participants, pres, null, NOW)[0]!;
+    expect(c.name).toBe("leo"); // @ 插入 token 必须是 handle 才能真正 @ 到（服务端按 handle 检测被@）
+    expect(c.display).toBe("leo"); // 显示名也用 handle，而非账号 email 或 UUID
+  });
+
+  test("online human without a handle keeps existing behavior (name=UUID, display=account)", () => {
+    const uuid = "8b2b302c-6c31-4bca-a1df-88152372f6d9";
+    const participants: Sender[] = [{ name: uuid, kind: "human" }];
+    const pres = {
+      [uuid]: presence({ name: uuid, kind: "human", account: "noHandle@x.com" }),
+    };
+    const c = mentionCandidates(participants, pres, null, NOW)[0]!;
+    expect(c.name).toBe(uuid);
+    expect(c.display).toBe("noHandle@x.com");
+  });
+
   test("recent agent (days old) is kept; only long-dead (>14d) ghost dropped", () => {
     const DAY = 24 * 60 * 60 * 1000;
     const pres = {

--- a/web/src/lib/mentions.ts
+++ b/web/src/lib/mentions.ts
@@ -65,6 +65,7 @@ export function mentionCandidates(
   roles: ChannelRoleAssignment[] = [],
 ): MentionCandidate[] {
   const online = new Set(participants.map((p) => p.name));
+  const participantByName = new Map(participants.map((p) => [p.name, p]));
   const identityByName = new Map(identities.map((identity) => [identity.name, identity]));
   const roleByName = new Map(roles.map((role) => [role.name, role]));
   const kindOf = new Map<string, "agent" | "human">();
@@ -92,9 +93,13 @@ export function mentionCandidates(
       const identity = identityByName.get(name);
       const assigned = roleByName.get(name);
       const account = identity?.account ?? assigned?.account ?? p?.account;
+      // 人类全局唯一昵称（handle）：有则用它做 @ 插入 token 和显示名——UUID 会话名打不出来，
+      // handle 才能被后端 R5 按 handle 识别为「被 @」。agent 不适用（其 name 本身就是可读 handle）。
+      const handle = kind === "human" ? (participantByName.get(name)?.handle ?? p?.handle) : undefined;
       // 人类网页会话名是 UUID，显示账号 email 才认得出「是谁」；agent 名本身可读，用 name。
-      const display =
-        identity?.display && identity.display !== ""
+      const display = handle
+        ? handle
+        : identity?.display && identity.display !== ""
           ? identity.display
           : assigned?.display && assigned.display !== ""
             ? assigned.display
@@ -103,7 +108,7 @@ export function mentionCandidates(
               : name;
       const group = account ?? (kind === "human" ? "human sessions" : "unowned agents");
       return {
-        name,
+        name: handle ?? name,
         display,
         kind,
         tier: tierFor(name, online, presence, now),

--- a/web/src/lib/notify.test.ts
+++ b/web/src/lib/notify.test.ts
@@ -1,0 +1,25 @@
+import { test, expect } from "bun:test";
+import { shouldNotify } from "./notify";
+const base = (over = {}) => ({ type:"msg", kind:"message", seq:5, mentions:["leo"], retracted:undefined,
+  sender:{name:"bob",kind:"agent"}, body:"hi @leo", ...over } as any);
+
+test("被@ + 隐藏 + 已授权 → true", () => {
+  expect(shouldNotify(base(), "leo", true, true)).toBe(true);
+});
+test("标签页可见 → false", () => {
+  expect(shouldNotify(base(), "leo", false, true)).toBe(false);
+});
+test("未授权 → false", () => {
+  expect(shouldNotify(base(), "leo", true, false)).toBe(false);
+});
+test("没@我 → false", () => {
+  expect(shouldNotify(base({mentions:["carol"]}), "leo", true, true)).toBe(false);
+});
+test("我没 handle → false", () => {
+  expect(shouldNotify(base(), null, true, true)).toBe(false);
+});
+test("已撤回 / status / 自己发 → false", () => {
+  expect(shouldNotify(base({retracted:true}), "leo", true, true)).toBe(false);
+  expect(shouldNotify(base({kind:"status"}), "leo", true, true)).toBe(false);
+  expect(shouldNotify(base({sender:{name:"leo",kind:"human",handle:"leo"}}), "leo", true, true)).toBe(false);
+});

--- a/web/src/lib/notify.ts
+++ b/web/src/lib/notify.ts
@@ -1,0 +1,10 @@
+import type { MsgFrame } from "@agentparty/shared";
+
+export function shouldNotify(
+  msg: MsgFrame, myHandle: string | null, documentHidden: boolean, permissionGranted: boolean,
+): boolean {
+  if (!permissionGranted || !documentHidden || myHandle === null) return false;
+  if (msg.kind !== "message" || msg.retracted) return false;
+  if (msg.sender.handle === myHandle) return false; // 自己发的
+  return msg.mentions.includes(myHandle);
+}

--- a/web/src/pages/Channel.tsx
+++ b/web/src/pages/Channel.tsx
@@ -10,6 +10,7 @@ import { JoinLink } from "../components/JoinLink";
 import { Composer } from "../components/Composer";
 import { Markdown } from "../components/Markdown";
 import { MessageCard } from "../components/MessageCard";
+import { NotifyToggle, readNotifyOptin } from "../components/NotifyToggle";
 import { PresenceBar } from "../components/PresenceBar";
 import {
   archiveChannel,
@@ -46,6 +47,7 @@ import {
   type AgentFilter,
   type AgentFilterMode,
 } from "../lib/filters";
+import { shouldNotify } from "../lib/notify";
 import { fmtTime } from "../lib/time";
 import { groupTeamMessages, summarizeTeams, type TeamMessageThread, type TeamSummary } from "../lib/teams";
 import { ChannelSocket } from "../lib/ws";
@@ -67,6 +69,7 @@ interface Props {
   agentNamePrefix: string; // 生成 agent 名的前缀来源（email/name 前缀，退回 slug）
   accountKey: string | null;
   inviterName: string; // 当前邀请人的频道身份名，接入包报到时 @ 他
+  selfHandle: string | null; // 当前人类账号的 @handle（Task C2 被@通知用；agent/未设置 handle 时为 null）
   onAuthFailed(message: string): void;
 }
 
@@ -860,6 +863,7 @@ export function ChannelPage({
   agentNamePrefix,
   accountKey,
   inviterName,
+  selfHandle,
   onAuthFailed,
 }: Props) {
   const t = useT();
@@ -906,6 +910,17 @@ export function ChannelPage({
   const [editSaving, setEditSaving] = useState(false);
   const [messageActionError, setMessageActionError] = useState<{ seq: number; message: string } | null>(null);
   const [messageActionBusySeq, setMessageActionBusySeq] = useState<number | null>(null);
+  // 被@浏览器通知（Task C2）：opt-in 是全局 localStorage 设置，铃铛开关组件读/写；这里只持有一份
+  // 供 ws 入帧点判定用。optin/selfHandle/t 都放 ref：onFrame 挂在 socket 连接的 effect 里，
+  // 若把它们放进依赖数组，切铃铛/切语言会连累整个 ws 重连——用 ref 让判定读到最新值又不触发重连。
+  const [optin, setOptin] = useState<boolean>(() => readNotifyOptin());
+  const optinRef = useRef(optin);
+  optinRef.current = optin;
+  const selfHandleRef = useRef(selfHandle);
+  selfHandleRef.current = selfHandle;
+  const tRef = useRef(t);
+  tRef.current = t;
+  const notifiedSeqRef = useRef<Set<number>>(new Set()); // seq 去重：防同一帧被重复处理时重复弹通知
   const sockRef = useRef<ChannelSocket | null>(null);
   const streamRef = useRef<HTMLDivElement | null>(null);
   const pendingSendsRef = useRef<Array<{ draft: string; replyTo: number | null }>>([]);
@@ -1062,6 +1077,28 @@ export function ChannelPage({
           if (floor > 0) {
             if ((frame.type === "msg" || frame.type === "status") && frame.seq < floor) return;
             if (frame.type === "message_update" && frame.message.seq < floor) return;
+          }
+          // 被@浏览器通知（Task C2）：每条 ws 入帧只处理一次，天然按 seq 去重；notifiedSeqRef 兜底
+          // 防万一同一帧被重复送进这个回调（例如未来重连语义变化）时重复弹窗。
+          if (
+            frame.type === "msg" &&
+            !notifiedSeqRef.current.has(frame.seq) &&
+            shouldNotify(
+              frame,
+              selfHandleRef.current,
+              document.hidden,
+              optinRef.current && typeof Notification !== "undefined" && Notification.permission === "granted",
+            )
+          ) {
+            notifiedSeqRef.current.add(frame.seq);
+            const n = new Notification(tRef.current("Channel.notify.title", { channel: slug }), {
+              body: summarizeReplyPreview(frame.body),
+            });
+            n.onclick = () => {
+              window.focus();
+              window.location.hash = `#msg-${frame.seq}`;
+              n.close();
+            };
           }
           dispatch({ type: "frame", frame });
         },
@@ -1656,6 +1693,11 @@ export function ChannelPage({
         onRemoveParticipant={removeParticipant}
         roles={channelRoles}
       />
+      {/* 被@浏览器通知铃铛：与「能否铸 agent / 能否 moderate」无关，任何登录人类账号都能开关，
+          所以单独一条工具条，不挂在下面 canMintAgent/canModerate 才渲染的 chan-toolbar 里。 */}
+      <div className="chan-toolbar chan-toolbar--notify">
+        <NotifyToggle optin={optin} onChange={setOptin} />
+      </div>
       {kickError !== null && <p className="banner banner--red">{kickError}</p>}
       {archiveError !== null && <p className="banner banner--red">{archiveError}</p>}
       {(canMintAgent || canModerate) && !state.archived && (

--- a/web/src/state.test.ts
+++ b/web/src/state.test.ts
@@ -119,4 +119,20 @@ describe("channel state", () => {
     expect(next.presence["child-a"]?.kind).toBe("human");
     expect(next.presence["child-a"]?.account).toBe("owner@example.com");
   });
+
+  test("carries handle through standalone presence frames", () => {
+    const frame: PresenceFrame = {
+      type: "presence",
+      name: "child-a",
+      kind: "human",
+      account: "owner@example.com",
+      state: "working",
+      note: null,
+      ts: 1_725_000_000_000,
+      handle: "leo",
+    };
+    const next = channelReducer(initialChannelState, { type: "frame", frame });
+
+    expect(next.presence["child-a"]?.handle).toBe("leo");
+  });
 });

--- a/web/src/state.ts
+++ b/web/src/state.ts
@@ -189,6 +189,7 @@ function applyFrame(state: ChannelState, frame: ServerFrame): ChannelState {
             wake: frame.wake,
             context: frame.context,
             lineage: frame.lineage,
+            handle: frame.handle,
           },
         },
       };

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -118,6 +118,57 @@
 .app-me + .app-signout { margin-left: 12px; }
 .app-signout:hover { color: var(--t-accent); }
 
+/* ---- @handle 设置/修改入口（me chip 旁，仅登录人类，Task B2） ---- */
+.handlesetup-anchor { position: relative; flex: none; }
+.handlesetup-trigger {
+  font-size: 11px;
+  padding: 2px 8px;
+  max-width: 110px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.handlesetup-trigger--cta { background: var(--d-yellow); color: var(--d-ink); font-weight: 700; }
+/* fixed + JS 算好的 left/top/width/maxHeight（手法同 AgentTokens 的视口钳制修复），
+   避免贴在顶栏右侧时在窄屏/滚动下溢出视口。 */
+.handlesetup-panel {
+  position: fixed;
+  z-index: 30;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  background: var(--t-panel);
+  border: 2.5px solid var(--d-ink);
+  border-radius: 12px 8px 13px 7px / 8px 12px 7px 11px;
+  box-shadow: 4px 5px 0 var(--d-shadow);
+  padding: 12px 14px;
+}
+.handlesetup { display: flex; flex-direction: column; gap: 8px; min-width: 220px; }
+.handlesetup-title { margin: 0; font-size: 13px; font-weight: 700; }
+.handlesetup-input {
+  font: inherit;
+  padding: 5px 8px;
+  border: 2px solid var(--d-ink);
+  border-radius: 8px 5px 9px 4px / 5px 9px 4px 8px;
+  background: var(--t-panel);
+  color: var(--fg, inherit);
+}
+.handlesetup-input:focus { outline: none; border-color: var(--t-accent); }
+.handlesetup-hint { margin: 0; font-size: 11px; color: var(--t-dim); }
+.handlesetup-err { margin: 0; }
+.handlesetup-actions { display: flex; justify-content: flex-end; gap: 8px; }
+
+/* ---- 未设置显示名提示条（顶栏下方，非强制/可关，Task B2） ---- */
+.handle-banner {
+  margin: 0 24px 10px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.handle-banner-text { flex: 1 1 auto; min-width: 0; }
+.handle-banner-actions { display: flex; align-items: center; gap: 8px; flex: none; }
+.handle-banner-dismiss { font-size: 12px; padding: 2px 8px; }
+
 .app-shell {
   flex: 1;
   min-height: 0;
@@ -2665,6 +2716,13 @@
   .app-me-owner,
   .app-signout {
     display: none;
+  }
+  .handlesetup-trigger {
+    max-width: 68px;
+    font-size: 10px;
+  }
+  .handle-banner {
+    margin: 0 10px 8px;
   }
   .lang-switch {
     flex: none;

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -1916,6 +1916,13 @@
 .vis-badge--public { background: var(--d-yellow); color: var(--d-ink); }
 .vis-badge--private { background: var(--d-ink); color: var(--t-panel); }
 .vis-btn { font-size: 13px; }
+
+/* ---- 被@浏览器通知铃铛（Task C2） ---- */
+.chan-toolbar--notify { padding-bottom: 0; }
+.notify-toggle { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.notify-toggle-btn { font-size: 15px; line-height: 1; padding: 4px 9px; }
+.notify-toggle-btn.is-active { border-color: var(--d-yellow); background: var(--d-yellow); }
+.notify-toggle-hint { font-size: 12px; color: var(--t-dim); }
 .vis-confirm {
   display: flex;
   align-items: center;

--- a/worker/migrations/0014_account_profiles.sql
+++ b/worker/migrations/0014_account_profiles.sql
@@ -1,0 +1,8 @@
+-- 人类全局唯一 handle（可@昵称，spec 2026-07-08）。handle 是显示+被@检测别名，不授予权限。
+CREATE TABLE account_profiles (
+  account    TEXT PRIMARY KEY,
+  handle     TEXT NOT NULL UNIQUE,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+CREATE INDEX idx_account_profiles_handle ON account_profiles(handle);

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -792,6 +792,8 @@ export class ChannelDO extends Server<Env> {
         WHERE rev_seq IS NULL
           AND (edited_at IS NOT NULL OR retracted_at IS NOT NULL OR supersedes IS NOT NULL OR superseded_by IS NOT NULL
                OR completion_review_state IS NOT NULL OR completion_review_replaced_by_seq IS NOT NULL)`,
+      // 发送时快照人类 handle，同 sender_owner 手法
+      "ALTER TABLE messages ADD COLUMN sender_handle TEXT",
     ]) {
       try {
         sql.exec(ddl);
@@ -836,6 +838,8 @@ export class ChannelDO extends Server<Env> {
       "ALTER TABLE presence ADD COLUMN status_context_json TEXT",
       "ALTER TABLE presence ADD COLUMN status_decision_json TEXT",
       "ALTER TABLE presence ADD COLUMN status_workflow_json TEXT",
+      // 当前连接的人类 handle
+      "ALTER TABLE presence ADD COLUMN handle TEXT",
     ]) {
       try {
         sql.exec(ddl);

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -55,6 +55,7 @@ interface ConnState {
   kind: SenderKind;
   role: TokenRole;
   owner?: string;
+  handle?: string;
   lineage?: AgentLineage;
   tokenHash: string;
   collabRole?: CollaborationRole;
@@ -68,6 +69,7 @@ interface Identity {
   kind: SenderKind;
   role: TokenRole;
   owner?: string;
+  handle?: string;
   lineage?: AgentLineage;
   tokenHash: string;
   collabRole?: CollaborationRole;
@@ -515,12 +517,13 @@ function lineageFromHeaders(headers: Headers): AgentLineage | undefined {
   return lineage ?? undefined;
 }
 
-function senderFromIdentity(identity: Pick<Identity, "name" | "kind" | "owner" | "lineage">): Sender {
+function senderFromIdentity(identity: Pick<Identity, "name" | "kind" | "owner" | "handle" | "lineage">): Sender {
   return {
     name: identity.name,
     kind: identity.kind,
     ...(identity.owner === undefined ? {} : { owner: identity.owner }),
     ...(identity.lineage === undefined ? {} : { lineage: identity.lineage }),
+    ...(identity.handle === undefined ? {} : { handle: identity.handle }),
   };
 }
 
@@ -937,6 +940,7 @@ export class ChannelDO extends Server<Env> {
       kind: h.get("x-ap-kind") === "agent" ? "agent" : "human",
       role: (h.get("x-ap-role") ?? "readonly") as TokenRole,
       owner: h.get("x-ap-owner") ?? undefined,
+      handle: h.get("x-ap-handle") ?? undefined,
       lineage: lineageFromHeaders(h),
       tokenHash: h.get("x-ap-token-hash") ?? "",
       collabRole: parseCollaborationRole(h.get("x-ap-collab-role") ?? undefined) ?? undefined,
@@ -1072,6 +1076,7 @@ export class ChannelDO extends Server<Env> {
           kind: st.kind,
           role: st.role,
           owner: st.owner,
+          handle: st.handle,
           lineage: st.lineage,
           tokenHash: st.tokenHash,
           collabRole: st.collabRole,
@@ -1548,16 +1553,17 @@ export class ChannelDO extends Server<Env> {
     const roleSource: CollaborationRoleSource | undefined = identity.collabRole === undefined ? undefined : "assigned";
     this.ctx.storage.sql.exec(
       `INSERT INTO messages (
-         seq, sender_name, sender_kind, sender_owner, sender_lineage_json, kind, body, mentions_json, reply_to,
+         seq, sender_name, sender_kind, sender_owner, sender_handle, sender_lineage_json, kind, body, mentions_json, reply_to,
          state, note, status_scope_json, status_summary_seq, status_blocked_reason, status_context_json,
          status_decision_json, status_workflow_json,
          sender_role, sender_role_source, completion_artifact_json, ts
        )
-       VALUES (?, ?, ?, ?, ?, 'message', ?, ?, ?, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, ?, ?, NULL, ?)`,
+       VALUES (?, ?, ?, ?, ?, ?, 'message', ?, ?, ?, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, ?, ?, NULL, ?)`,
       seq,
       identity.name,
       identity.kind,
       identity.owner ?? null,
+      identity.handle ?? null,
       identity.lineage === undefined ? null : JSON.stringify(identity.lineage),
       body,
       JSON.stringify(mentions),
@@ -1751,6 +1757,7 @@ export class ChannelDO extends Server<Env> {
         kind: request.headers.get("x-ap-kind") === "agent" ? "agent" : "human",
         role: (request.headers.get("x-ap-role") ?? "readonly") as TokenRole,
         owner: request.headers.get("x-ap-owner") ?? undefined,
+        handle: request.headers.get("x-ap-handle") ?? undefined,
         lineage: lineageFromHeaders(request.headers),
         tokenHash: request.headers.get("x-ap-token-hash") ?? "",
         collabRole: parseCollaborationRole(request.headers.get("x-ap-collab-role") ?? undefined) ?? undefined,
@@ -1885,6 +1892,7 @@ export class ChannelDO extends Server<Env> {
         kind: request.headers.get("x-ap-kind") === "agent" ? "agent" : "human",
         role: (request.headers.get("x-ap-role") ?? "readonly") as TokenRole,
         owner: request.headers.get("x-ap-owner") ?? undefined,
+        handle: request.headers.get("x-ap-handle") ?? undefined,
         lineage: lineageFromHeaders(request.headers),
         tokenHash: request.headers.get("x-ap-token-hash") ?? "",
         collabRole: parseCollaborationRole(request.headers.get("x-ap-collab-role") ?? undefined) ?? undefined,
@@ -2059,6 +2067,7 @@ export class ChannelDO extends Server<Env> {
         kind: request.headers.get("x-ap-kind") === "agent" ? "agent" : "human",
         role: (request.headers.get("x-ap-role") ?? "readonly") as TokenRole,
         owner: request.headers.get("x-ap-owner") ?? undefined,
+        handle: request.headers.get("x-ap-handle") ?? undefined,
         lineage: lineageFromHeaders(request.headers),
         tokenHash: request.headers.get("x-ap-token-hash") ?? "",
         collabRole: parseCollaborationRole(request.headers.get("x-ap-collab-role") ?? undefined) ?? undefined,
@@ -2377,17 +2386,18 @@ export class ChannelDO extends Server<Env> {
           };
     sql.exec(
       `INSERT INTO messages (
-         seq, sender_name, sender_kind, sender_owner, sender_lineage_json, kind, body, mentions_json, reply_to,
+         seq, sender_name, sender_kind, sender_owner, sender_handle, sender_lineage_json, kind, body, mentions_json, reply_to,
          state, note, status_scope_json, status_summary_seq, status_blocked_reason, status_context_json,
          status_decision_json, status_workflow_json, message_workflow_json,
          sender_role, sender_role_source, completion_artifact_json, completion_review_state, completion_review_policy,
          completion_review_replaces_seq, ts
        )
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       seq,
       identity.name,
       identity.kind,
       identity.owner ?? null,
+      identity.handle ?? null,
       identity.lineage === undefined ? null : JSON.stringify(identity.lineage),
       msg.kind,
       msg.body,
@@ -2448,14 +2458,15 @@ export class ChannelDO extends Server<Env> {
       const wakeProvided = frame.wake !== undefined ? 1 : 0;
       sql.exec(
         `INSERT INTO presence (
-           name, kind, account, state, note, updated_at, status_scope_json, status_summary_seq, status_blocked_reason,
+           name, kind, account, handle, state, note, updated_at, status_scope_json, status_summary_seq, status_blocked_reason,
            status_context_json, status_decision_json, status_workflow_json, role, role_source, residency, wake_kind, wake_verified_at, context_json,
            lineage_json
          )
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
          ON CONFLICT(name) DO UPDATE SET
            kind = excluded.kind,
            account = COALESCE(excluded.account, presence.account),
+           handle = COALESCE(excluded.handle, presence.handle),
            state = excluded.state,
            note = excluded.note,
            updated_at = excluded.updated_at,
@@ -2475,6 +2486,7 @@ export class ChannelDO extends Server<Env> {
         identity.name,
         identity.kind,
         identity.owner ?? null, // 人类会话 = email，agent = 所属账号；presence.account 存它供前端显示「是谁」
+        identity.handle ?? null, // 当前连接的人类 handle；同 account 手法，presence.handle 供前端展示/被 @
         frame.state,
         frame.note,
         now,
@@ -3010,7 +3022,7 @@ export class ChannelDO extends Server<Env> {
     const liveCounts = this.liveConnectionCounts();
     return this.ctx.storage.sql
       .exec(
-        `SELECT name, kind, account, state, note, updated_at, status_scope_json, status_summary_seq, status_blocked_reason,
+        `SELECT name, kind, account, handle, state, note, updated_at, status_scope_json, status_summary_seq, status_blocked_reason,
                 status_context_json, status_decision_json, status_workflow_json, role, role_source, residency, wake_kind, wake_verified_at,
                 context_json, lineage_json
          FROM presence ORDER BY name`,
@@ -3023,7 +3035,7 @@ export class ChannelDO extends Server<Env> {
     const liveCounts = this.liveConnectionCounts();
     const rows = this.ctx.storage.sql
       .exec(
-        `SELECT name, kind, account, state, note, updated_at, status_scope_json, status_summary_seq, status_blocked_reason,
+        `SELECT name, kind, account, handle, state, note, updated_at, status_scope_json, status_summary_seq, status_blocked_reason,
                 status_context_json, status_decision_json, status_workflow_json, role, role_source, residency, wake_kind, wake_verified_at,
                 context_json, lineage_json
          FROM presence WHERE name = ?`,
@@ -3055,6 +3067,7 @@ export class ChannelDO extends Server<Env> {
       name: String(r.name),
       ...(r.kind === "agent" || r.kind === "human" ? { kind: r.kind as SenderKind } : {}),
       ...(typeof r.account === "string" && r.account !== "" ? { account: r.account } : {}),
+      ...(typeof r.handle === "string" && r.handle !== "" ? { handle: r.handle } : {}),
       state,
       note: r.note === null ? null : String(r.note),
       ts,
@@ -3097,6 +3110,7 @@ export class ChannelDO extends Server<Env> {
           const lineage = parseStoredLineage(r.sender_lineage_json);
           return lineage === undefined ? {} : { lineage };
         })(),
+        ...(r.sender_handle === null || r.sender_handle === undefined ? {} : { handle: String(r.sender_handle) }),
       },
       kind,
       body: String(r.body),

--- a/worker/src/handle.ts
+++ b/worker/src/handle.ts
@@ -1,0 +1,26 @@
+import { RESERVED_NAMES } from "@agentparty/shared";
+
+export const HANDLE_RE = /^[a-z0-9][a-z0-9._-]{1,31}$/;
+
+export function validateHandleFormat(input: unknown): string | null {
+  if (typeof input !== "string") return null;
+  const h = input.trim();
+  return HANDLE_RE.test(h) ? h : null;
+}
+
+// 冲突检查：撞保留名 / 撞任意 token 名 / 已被别的账号占用。无冲突返回 null。
+export async function handleConflict(
+  db: D1Database,
+  handle: string,
+  forAccount: string | null,
+): Promise<"reserved" | "token_name" | "taken" | null> {
+  if (RESERVED_NAMES.includes(handle)) return "reserved";
+  const tok = await db.prepare("SELECT 1 FROM tokens WHERE name = ?").bind(handle).first();
+  if (tok) return "token_name";
+  const owner = await db
+    .prepare("SELECT account FROM account_profiles WHERE handle = ?")
+    .bind(handle)
+    .first<{ account: string }>();
+  if (owner && owner.account !== forAccount) return "taken";
+  return null;
+}

--- a/worker/src/handle.ts
+++ b/worker/src/handle.ts
@@ -15,7 +15,7 @@ export async function handleConflict(
   forAccount: string | null,
 ): Promise<"reserved" | "token_name" | "taken" | null> {
   if (RESERVED_NAMES.includes(handle)) return "reserved";
-  const tok = await db.prepare("SELECT 1 FROM tokens WHERE name = ?").bind(handle).first();
+  const tok = await db.prepare("SELECT 1 FROM tokens WHERE name = ? COLLATE NOCASE").bind(handle).first();
   if (tok) return "token_name";
   const owner = await db
     .prepare("SELECT account FROM account_profiles WHERE handle = ?")

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -180,6 +180,10 @@ async function persistToken(
     .bind(opts.name)
     .first<{ id: number; revoked_at: number | null }>();
   if (existing && existing.revoked_at === null) return { conflict: true };
+  // 反向唯一性：token 名不得撞已存在的人类 handle（二者共用 @ 命名空间）
+  const handleOwner = await db.prepare("SELECT 1 FROM account_profiles WHERE handle = ?")
+    .bind(opts.name).first();
+  if (handleOwner) return { conflict: true };
   const token = randomToken();
   const hash = await sha256Hex(token);
   const now = Date.now();

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -28,6 +28,7 @@ import {
   type TokenIdentity,
 } from "./auth";
 import { ChannelDO } from "./do";
+import { handleConflict, validateHandleFormat } from "./handle";
 import { openapiDocument } from "./openapi";
 
 export { ChannelDO };
@@ -479,10 +480,16 @@ app.get("/api/config", (c) => {
 });
 
 // 当前登录身份：web topbar 显示 "signed in as <email 或 name>"（spec §10）
-app.get("/api/me", requireBearer, (c) => {
+app.get("/api/me", requireBearer, async (c) => {
   const id = c.get("identity");
   // 权限自省（whoami --caps / 网页）：从 role + channel_scope + account 派生，让工具提前知道能干什么
   const scoped = id.channel_scope != null;
+  // handle（spec 2026-07-08）：全局唯一昵称，仅 human 账号会话（有 account）才可能设置过
+  const profile = id.account == null
+    ? null
+    : await c.env.DB.prepare("SELECT handle FROM account_profiles WHERE account = ?")
+        .bind(id.account)
+        .first<{ handle: string }>();
   return c.json({
     name: id.name,
     email: id.email ?? null,
@@ -491,6 +498,7 @@ app.get("/api/me", requireBearer, (c) => {
     owner: id.owner ?? null,
     channel_scope: id.channel_scope ?? null,
     lineage: id.lineage ?? null,
+    handle: profile?.handle ?? null,
     caps: {
       send: id.role !== "readonly",
       // scoped token 不得建频道（会逃出 scope）；readonly 也不行
@@ -503,6 +511,33 @@ app.get("/api/me", requireBearer, (c) => {
       scoped_to: id.channel_scope ?? null,
     },
   });
+});
+
+// 设置/更新本账号的全局唯一 handle（spec 2026-07-08，Task A4）：仅 human 账号会话（有 account）可用，
+// readonly/legacy 无账号 token 一律 403。撞保留名 / 撞任意 token 名 / 已被别的账号占用 → 409。
+app.put("/api/me/handle", requireBearer, async (c) => {
+  const id = c.get("identity");
+  if (id.role === "readonly" || id.account == null) {
+    return c.json(errorBody("forbidden", "setting a handle requires a human account session"), 403);
+  }
+  const body = (await c.req.json().catch(() => null)) as { handle?: unknown } | null;
+  const handle = validateHandleFormat(body?.handle);
+  if (handle === null) {
+    return c.json(errorBody("bad_request", "handle must match ^[a-z0-9][a-z0-9._-]{1,31}$"), 400);
+  }
+  const conflict = await handleConflict(c.env.DB, handle, id.account);
+  if (conflict !== null) {
+    return c.json(errorBody("conflict", `handle unavailable (${conflict})`), 409);
+  }
+  const now = Date.now();
+  await c.env.DB.prepare(
+    `INSERT INTO account_profiles (account, handle, created_at, updated_at)
+     VALUES (?, ?, ?, ?)
+     ON CONFLICT(account) DO UPDATE SET handle = excluded.handle, updated_at = excluded.updated_at`,
+  )
+    .bind(id.account, handle, now, now)
+    .run();
+  return c.json({ handle });
 });
 
 app.post("/api/tokens", requireAdmin, async (c) => {

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -399,12 +399,13 @@ function assignedRoleHeaders(role: CollaborationRole | null): Record<string, str
   return role === null ? {} : { "x-ap-collab-role": role, "x-ap-role-source": "assigned" };
 }
 
-// 人类 handle 头：account 非空且已设 handle 才带（权威值，供 do 盖 presence + stamp 消息，Task A6）。
+// 人类 handle 头：仅当身份是人类且已设 handle 才带（权威值，供 do 盖 presence + stamp 消息，Task A6/A7）。
+// agent 即使与 human 共享 account 也不继承其 handle——handle 是按 account 存的，但只对人类身份生效。
 // export 仅供 test 直接单测（do 尚不消费这个头，spec 里现有的"观察 do 副作用"手法在这没有可观察点）。
-export async function handleHeader(db: D1Database, account: string | null | undefined): Promise<Record<string, string>> {
-  if (account == null) return {};
+export async function handleHeader(db: D1Database, identity: TokenIdentity): Promise<Record<string, string>> {
+  if (identity.kind !== "human" || identity.account == null) return {};
   const row = await db.prepare("SELECT handle FROM account_profiles WHERE account = ?")
-    .bind(account).first<{ handle: string }>();
+    .bind(identity.account).first<{ handle: string }>();
   return row?.handle ? { "x-ap-handle": row.handle } : {};
 }
 
@@ -1704,6 +1705,7 @@ app.post("/api/channels/:slug/messages/:seq/review", async (c) => {
         ...lineageHeaders(identity),
         ...assignedRoleHeaders(assignedRole),
         ...channelHeaders(channel, c.req.url),
+        ...(await handleHeader(c.env.DB, identity)),
       },
     }),
   );
@@ -1744,6 +1746,7 @@ app.post("/api/channels/:slug/messages/:seq/:action", async (c) => {
         ...lineageHeaders(identity),
         ...assignedRoleHeaders(assignedRole),
         ...channelHeaders(channel, c.req.url),
+        ...(await handleHeader(c.env.DB, identity)),
       },
     }),
   );
@@ -1795,7 +1798,7 @@ app.post("/api/channels/:slug/messages", async (c) => {
         ...lineageHeaders(identity),
         ...assignedRoleHeaders(assignedRole),
         ...channelHeaders(channel, c.req.url),
-        ...(await handleHeader(c.env.DB, identity.account)),
+        ...(await handleHeader(c.env.DB, identity)),
       },
     }),
   );
@@ -2072,7 +2075,7 @@ app.get("/api/channels/:slug/ws", async (c) => {
   fwd.headers.set("x-ap-host", new URL(c.req.url).host);
   // 无条件写：未归档也显式置 "0"，堵住"客户端注入 1、未归档分支不覆盖"的透传
   fwd.headers.set("x-ap-archived", channel.archived_at !== null ? "1" : "0");
-  for (const [key, value] of Object.entries(await handleHeader(c.env.DB, identity.account))) fwd.headers.set(key, value);
+  for (const [key, value] of Object.entries(await handleHeader(c.env.DB, identity))) fwd.headers.set(key, value);
   const upgrade = await stub.fetch(fwd);
   const requestedProtocols = c.req
     .header("sec-websocket-protocol")

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -91,6 +91,7 @@ const AP_FORWARD_HEADERS = [
   "x-ap-archive-at",
   "x-ap-collab-role",
   "x-ap-role-source",
+  "x-ap-handle",
 ] as const;
 // 所属人标签：铸造时可选写入，须 header-safe（可打印 ASCII，含空格）以便经 x-ap-owner 转发给 do
 const OWNER_MAX = 128;
@@ -396,6 +397,15 @@ async function loadAssignedRole(db: D1Database, slug: string, name: string): Pro
 
 function assignedRoleHeaders(role: CollaborationRole | null): Record<string, string> {
   return role === null ? {} : { "x-ap-collab-role": role, "x-ap-role-source": "assigned" };
+}
+
+// 人类 handle 头：account 非空且已设 handle 才带（权威值，供 do 盖 presence + stamp 消息，Task A6）。
+// export 仅供 test 直接单测（do 尚不消费这个头，spec 里现有的"观察 do 副作用"手法在这没有可观察点）。
+export async function handleHeader(db: D1Database, account: string | null | undefined): Promise<Record<string, string>> {
+  if (account == null) return {};
+  const row = await db.prepare("SELECT handle FROM account_profiles WHERE account = ?")
+    .bind(account).first<{ handle: string }>();
+  return row?.handle ? { "x-ap-handle": row.handle } : {};
 }
 
 function lineageHeaders(identity: TokenIdentity): Record<string, string> {
@@ -1785,6 +1795,7 @@ app.post("/api/channels/:slug/messages", async (c) => {
         ...lineageHeaders(identity),
         ...assignedRoleHeaders(assignedRole),
         ...channelHeaders(channel, c.req.url),
+        ...(await handleHeader(c.env.DB, identity.account)),
       },
     }),
   );
@@ -2061,6 +2072,7 @@ app.get("/api/channels/:slug/ws", async (c) => {
   fwd.headers.set("x-ap-host", new URL(c.req.url).host);
   // 无条件写：未归档也显式置 "0"，堵住"客户端注入 1、未归档分支不覆盖"的透传
   fwd.headers.set("x-ap-archived", channel.archived_at !== null ? "1" : "0");
+  for (const [key, value] of Object.entries(await handleHeader(c.env.DB, identity.account))) fwd.headers.set(key, value);
   const upgrade = await stub.fetch(fwd);
   const requestedProtocols = c.req
     .header("sec-websocket-protocol")

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -530,13 +530,22 @@ app.put("/api/me/handle", requireBearer, async (c) => {
     return c.json(errorBody("conflict", `handle unavailable (${conflict})`), 409);
   }
   const now = Date.now();
-  await c.env.DB.prepare(
-    `INSERT INTO account_profiles (account, handle, created_at, updated_at)
-     VALUES (?, ?, ?, ?)
-     ON CONFLICT(account) DO UPDATE SET handle = excluded.handle, updated_at = excluded.updated_at`,
-  )
-    .bind(id.account, handle, now, now)
-    .run();
+  try {
+    await c.env.DB.prepare(
+      `INSERT INTO account_profiles (account, handle, created_at, updated_at)
+       VALUES (?, ?, ?, ?)
+       ON CONFLICT(account) DO UPDATE SET handle = excluded.handle, updated_at = excluded.updated_at`,
+    )
+      .bind(id.account, handle, now, now)
+      .run();
+  } catch (e) {
+    // 竞态：handleConflict 通过后、另一账号抢先占了同一 handle → UNIQUE(handle) 冲突。转 409（非 500）。
+    const msg = e instanceof Error ? e.message : String(e);
+    if (msg.includes("UNIQUE")) {
+      return c.json(errorBody("conflict", "handle unavailable (taken)"), 409);
+    }
+    throw e; // 其它未预期错误保持原样（让它 500，不掩盖真问题）
+  }
   return c.json({ handle });
 });
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -181,7 +181,7 @@ async function persistToken(
     .first<{ id: number; revoked_at: number | null }>();
   if (existing && existing.revoked_at === null) return { conflict: true };
   // 反向唯一性：token 名不得撞已存在的人类 handle（二者共用 @ 命名空间）
-  const handleOwner = await db.prepare("SELECT 1 FROM account_profiles WHERE handle = ?")
+  const handleOwner = await db.prepare("SELECT 1 FROM account_profiles WHERE handle = ? COLLATE NOCASE")
     .bind(opts.name).first();
   if (handleOwner) return { conflict: true };
   const token = randomToken();

--- a/worker/test/handle-wire.spec.ts
+++ b/worker/test/handle-wire.spec.ts
@@ -1,0 +1,123 @@
+// do 消费 x-ap-handle（Task A7）：presence.handle + sender_handle 落库/回填 + 端到端防注入。
+// 手法完全镜像 owner.spec.ts —— 走真实 worker 路径（SELF.fetch 升级 ws / 发消息），
+// 不直接绕过 worker 给 do 发内部请求，因为权威 x-ap-handle 是 worker 层算出来再转发的（Task A6）。
+import { SELF } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import { api, createChannel, seedToken, uniq, WsClient } from "./helpers";
+
+// 带自定义头做 ws 升级（同 ws-header-injection.spec.ts 的 openRaw），用于模拟客户端在升级请求里
+// 夹带伪造 x-ap-handle。worker 会先剥离所有客户端注入的 x-ap-* 头，再按账号的真实 handle（若有）
+// 补权威值（Task A6），所以这条路径测的是「经 worker 转发」这一层，不是绕过 worker 直连 do 那一层。
+async function openWithForgedHeader(
+  slug: string,
+  token: string,
+  extra: Record<string, string>,
+): Promise<{ ws: WebSocket; first: Record<string, unknown> }> {
+  const res = await SELF.fetch(`http://ap.test/api/channels/${slug}/ws`, {
+    headers: { upgrade: "websocket", authorization: `Bearer ${token}`, ...extra },
+  });
+  if (res.status !== 101 || !res.webSocket) throw new Error(`ws upgrade failed: ${res.status}`);
+  const ws = res.webSocket;
+  ws.accept();
+  const first = await new Promise<Record<string, unknown>>((resolve) => {
+    ws.addEventListener("message", (e) => resolve(JSON.parse(e.data as string)), { once: true });
+  });
+  return { ws, first };
+}
+
+async function nextRawFrame(ws: WebSocket, type: string): Promise<Record<string, unknown>> {
+  for (;;) {
+    const frame = await new Promise<Record<string, unknown>>((resolve) => {
+      ws.addEventListener("message", (e) => resolve(JSON.parse(e.data as string)), { once: true });
+    });
+    if (frame.type === type) return frame;
+  }
+}
+
+async function setHandle(token: string, handle: string) {
+  const res = await api("/api/me/handle", token, { method: "PUT", body: JSON.stringify({ handle }) });
+  expect(res.status).toBe(200);
+}
+
+describe("do consumes x-ap-handle (Task A7)", () => {
+  it("stamps sender.handle on send, mirrors it into presence, and keeps it through history replay", async () => {
+    const owner = uniq("acct");
+    const human = await seedToken("human", uniq("h"), { owner });
+    const handle = uniq("leo");
+    await setHandle(human.token, handle);
+    const slug = await createChannel(human.token);
+
+    const ws = await WsClient.open(slug, human.token);
+    const welcome = await ws.nextOfType("welcome");
+    // welcome.participants 走 ConnState → senderFromIdentity 同一条镜像路径，顺手断言一次
+    expect(welcome.participants).toContainEqual({ name: human.name, kind: "human", owner, handle });
+
+    ws.send({ type: "send", kind: "message", body: "hi", mentions: [], reply_to: null });
+    await ws.nextOfType("sent");
+    const msg = await ws.nextOfType("msg");
+    expect(msg.sender.handle).toBe(handle);
+
+    // presence 表只在 status 帧时 upsert（同 owner/account 的既有手法），补发一条 status 才能看到 presence.handle
+    ws.send({ type: "send", kind: "status", state: "working", note: "", mentions: [] });
+    await ws.nextOfType("sent");
+    const presence = await ws.nextOfType("presence");
+    // PresenceFrame（shared/src/protocol.ts）目前的类型声明里没带 handle 字段（A2 只加到了
+    // PresenceEntry 上），但 do.ts 的 `{ type: "presence", ...entry }` 运行时确实会把 entry
+    // （PresenceEntry）里的 handle 一并展开出来。这里用类型断言绕开这个类型层的既有缺口，
+    // 不在本任务范围内顺手改 shared 协议类型（那是另一处遗留，见任务报告 concern）。
+    expect((presence as unknown as { handle?: string }).handle).toBe(handle);
+    ws.close();
+
+    // 历史补拉（hello since=0）：新连接读回同一条消息，sender.handle 仍在 —— 证明落库了，不是只在内存里现算
+    const reader = await WsClient.open(slug, human.token);
+    await reader.nextOfType("welcome");
+    reader.send({ type: "hello", since: 0 });
+    const back = await reader.nextOfType("msg");
+    expect(back.sender.handle).toBe(handle);
+    reader.close();
+
+    // GET /api/channels/:slug/messages（/internal/messages 的公开出口，同一条 rowToFrame）也带 handle
+    const history = await api(`/api/channels/${slug}/messages`, human.token);
+    const historyBody = (await history.json()) as { messages: { sender: { handle?: string } }[] };
+    expect(historyBody.messages.some((m) => m.sender.handle === handle)).toBe(true);
+  });
+
+  // 端到端防注入（A6 交接）：账号从未设置过 handle 时，worker 的 handleHeader() 不会补任何 x-ap-handle，
+  // 客户端在 ws 升级请求里自带的 x-ap-handle 会被 AP_FORWARD_HEADERS 无条件剥离。这里测的是
+  // 「经 worker 路径」这一层：最终落到 sender.handle 上的必须是空，而不是客户端伪造的 "evil"。
+  it("never lets a client-forged x-ap-handle become sender.handle when the account has none set", async () => {
+    const owner = uniq("acct-nohandle");
+    const human = await seedToken("human", uniq("h"), { owner });
+    const slug = await createChannel(human.token);
+
+    const { ws, first } = await openWithForgedHeader(slug, human.token, { "x-ap-handle": "evil" });
+    expect(first.type).toBe("welcome");
+    const me = (first.participants as { name: string; handle?: string }[]).find((p) => p.name === human.name);
+    expect(me).not.toHaveProperty("handle");
+
+    ws.send(JSON.stringify({ type: "send", kind: "message", body: "hi", mentions: [], reply_to: null }));
+    const msg = await nextRawFrame(ws, "msg");
+    const sender = msg.sender as { handle?: string };
+    expect(sender.handle).not.toBe("evil");
+    expect(sender).not.toHaveProperty("handle");
+    ws.close();
+  });
+
+  // 同一层再补一条：账号确实设置过 handle，客户端仍夹带伪造值，最终必须是真实 handle，绝不是伪造值。
+  it("uses the account's real handle even when the client forges a different one", async () => {
+    const owner = uniq("acct-realhandle");
+    const human = await seedToken("human", uniq("h"), { owner });
+    const handle = uniq("real");
+    await setHandle(human.token, handle);
+    const slug = await createChannel(human.token);
+
+    const { ws, first } = await openWithForgedHeader(slug, human.token, { "x-ap-handle": "evil" });
+    expect(first.type).toBe("welcome");
+
+    ws.send(JSON.stringify({ type: "send", kind: "message", body: "hi", mentions: [], reply_to: null }));
+    const msg = await nextRawFrame(ws, "msg");
+    const sender = msg.sender as { handle?: string };
+    expect(sender.handle).toBe(handle);
+    ws.close();
+  });
+});

--- a/worker/test/handle-wire.spec.ts
+++ b/worker/test/handle-wire.spec.ts
@@ -3,7 +3,7 @@
 // 不直接绕过 worker 给 do 发内部请求，因为权威 x-ap-handle 是 worker 层算出来再转发的（Task A6）。
 import { SELF } from "cloudflare:test";
 import { describe, expect, it } from "vitest";
-import { api, createChannel, seedToken, uniq, WsClient } from "./helpers";
+import { api, createChannel, postMessage, seedToken, uniq, WsClient } from "./helpers";
 
 // 带自定义头做 ws 升级（同 ws-header-injection.spec.ts 的 openRaw），用于模拟客户端在升级请求里
 // 夹带伪造 x-ap-handle。worker 会先剥离所有客户端注入的 x-ap-* 头，再按账号的真实 handle（若有）
@@ -119,5 +119,101 @@ describe("do consumes x-ap-handle (Task A7)", () => {
     const sender = msg.sender as { handle?: string };
     expect(sender.handle).toBe(handle);
     ws.close();
+  });
+});
+
+// Task A7 review 发现的两个 Important 修复的回归证据：
+//  ① handleHeader 只按 account 查 D1、不看调用方 kind → human 和其自铸 agent 共享 account 时，
+//     agent 自己发的消息会被错误打上 human 的 handle（协议要求 agent 恒省略 handle）。
+//  ② review / edit|retract|supersede 两条转发路径漏调 handleHeader()，导致 supersede 新消息、
+//     reviewer 审核回复的 sender.handle 永远缺失，即使发送方/审核方账号已设置过真实 handle。
+describe("x-ap-handle review fixes (Task A7)", () => {
+  it("does not let an agent inherit the handle of the human it shares an account with", async () => {
+    const acct = uniq("shared-acct");
+    const human = await seedToken("human", uniq("h"), { owner: acct });
+    const handle = uniq("humanhandle");
+    await setHandle(human.token, handle);
+    // 自铸 agent：与 human 共享同一 account（典型场景——human 给自己铸的 agent token）
+    const agent = await seedToken("agent", uniq("a"), { owner: acct });
+    const slug = await createChannel(human.token);
+
+    const sent = await postMessage(slug, agent.token, "hi from agent");
+    expect(sent.status).toBe(200);
+    const seq = ((await sent.json()) as { seq: number }).seq;
+
+    const history = await api(`/api/channels/${slug}/messages`, human.token);
+    const messages = ((await history.json()) as {
+      messages: { seq: number; sender: { kind: string; handle?: string } }[];
+    }).messages;
+    const msg = messages.find((m) => m.seq === seq);
+    expect(msg?.sender.kind).toBe("agent");
+    expect(msg?.sender).not.toHaveProperty("handle");
+  });
+
+  it("forwards the actor's real handle onto the new message when superseding (edit|retract|supersede path)", async () => {
+    const acct = uniq("acct-supersede");
+    const human = await seedToken("human", uniq("h"), { owner: acct });
+    const handle = uniq("supersedehandle");
+    await setHandle(human.token, handle);
+    const slug = await createChannel(human.token);
+
+    const sent = await postMessage(slug, human.token, "old claim");
+    const seq = ((await sent.json()) as { seq: number }).seq;
+
+    const supersede = await api(`/api/channels/${slug}/messages/${seq}/supersede`, human.token, {
+      method: "POST",
+      body: JSON.stringify({ body: "new claim" }),
+    });
+    expect(supersede.status).toBe(200);
+    const body = (await supersede.json()) as { message: { sender: { handle?: string } } };
+    expect(body.message.sender.handle).toBe(handle);
+  });
+
+  it("forwards the reviewer's real handle onto the reviewer reply (review path)", async () => {
+    const acct = `${uniq("acct")}@leeguoo.com`;
+    const owner = await seedToken("agent", uniq("owner"), { owner: acct });
+    const slug = await createChannel(owner.token);
+    const writer = await seedToken("agent", uniq("writer"), { owner: acct, channelScope: slug });
+    const reviewerAcct = uniq("reviewer-acct");
+    const reviewer = await seedToken("human", uniq("reviewer"), { owner: reviewerAcct, channelScope: slug });
+    const handle = uniq("reviewerhandle");
+    await setHandle(reviewer.token, handle);
+
+    const gate = await api(`/api/channels/${slug}/completion-gate`, owner.token, {
+      method: "PUT",
+      body: JSON.stringify({ gate: "reviewer", policy: "sender" }),
+    });
+    expect(gate.status).toBe(200);
+
+    const kickoff = await postMessage(slug, writer.token, "please do the work");
+    const kickoffSeq = ((await kickoff.json()) as { seq: number }).seq;
+
+    const completion = await api(`/api/channels/${slug}/messages`, writer.token, {
+      method: "POST",
+      body: JSON.stringify({
+        kind: "message",
+        body: "final synthesis",
+        mentions: [],
+        reply_to: kickoffSeq,
+        completion_artifact: {
+          kind: "final_synthesis",
+          kickoff_seq: kickoffSeq,
+          replies_count: 1,
+          timeout: false,
+          related_issues: [],
+          related_prs: [],
+        },
+      }),
+    });
+    expect(completion.status).toBe(200);
+    const completionSeq = ((await completion.json()) as { seq: number }).seq;
+
+    const approved = await api(`/api/channels/${slug}/messages/${completionSeq}/review`, reviewer.token, {
+      method: "POST",
+      body: JSON.stringify({ action: "approve" }),
+    });
+    expect(approved.status).toBe(200);
+    const body = (await approved.json()) as { reply: { sender: { handle?: string } } };
+    expect(body.reply.sender.handle).toBe(handle);
   });
 });

--- a/worker/test/handle.spec.ts
+++ b/worker/test/handle.spec.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { validateHandleFormat, HANDLE_RE } from "../src/handle";
+
+describe("validateHandleFormat", () => {
+  it("接受合法 handle", () => {
+    expect(validateHandleFormat("leo")).toBe("leo");
+    expect(validateHandleFormat("a1._-b")).toBe("a1._-b");
+  });
+  it("拒绝非法：大写/太短/太长/非法首字/非串", () => {
+    expect(validateHandleFormat("Leo")).toBeNull();
+    expect(validateHandleFormat("a")).toBeNull();
+    expect(validateHandleFormat("-abc")).toBeNull();
+    expect(validateHandleFormat("a".repeat(33))).toBeNull();
+    expect(validateHandleFormat(123)).toBeNull();
+  });
+});

--- a/worker/test/oidc.spec.ts
+++ b/worker/test/oidc.spec.ts
@@ -179,6 +179,7 @@ describe("oidc end-to-end via SELF.fetch", () => {
       owner: "u@leeguoo.com",
       channel_scope: null,
       lineage: null,
+      handle: null,
       // OIDC 人类：非 readonly 能发/建频道；有 account 能自助铸 agent；无 scope；spawn 只给 scoped parent agent
       caps: { send: true, create_channel: true, mint_agents: true, spawn_children: false, scoped_to: null },
     });

--- a/worker/test/profile.spec.ts
+++ b/worker/test/profile.spec.ts
@@ -1,0 +1,39 @@
+// PUT /api/me/handle + GET /api/me 返回 handle（spec 2026-07-08，Task A4）：human 账号会话可设置/更新
+// 自己的全局唯一 handle；撞已存在 token 名（含别的 agent token）时 409。
+import { describe, expect, it } from "vitest";
+import { api, seedToken, uniq } from "./helpers";
+
+describe("PUT /api/me/handle + GET /api/me handle", () => {
+  it("human 账号设置 handle 后，GET /api/me 回显该 handle", async () => {
+    const owner = uniq("acct");
+    const { token } = await seedToken("human", uniq("tok-human"), { owner });
+
+    const put = await api("/api/me/handle", token, {
+      method: "PUT",
+      body: JSON.stringify({ handle: "leo" }),
+    });
+    expect(put.status).toBe(200);
+    expect(await put.json()).toMatchObject({ handle: "leo" });
+
+    const me = await api("/api/me", token);
+    expect(me.status).toBe(200);
+    expect(await me.json()).toMatchObject({ handle: "leo" });
+  });
+
+  it("handle 撞已存在的 token 名时返回 409", async () => {
+    // 名字须满足 HANDLE_RE（全小写字母数字，uniq() 生成的即是）才能验证「撞 token 名」这条冲突路径，
+    // 而不是先撞 validateHandleFormat 的格式校验；不用字面量 "bob" 避免跟其它 spec 文件已铸的同名 token 撞车
+    // （isolatedStorage: false，D1 在整个 vitest run 内跨文件共享）。
+    const tokenName = uniq("agentname");
+    await seedToken("agent", tokenName);
+
+    const owner = uniq("acct");
+    const { token } = await seedToken("human", uniq("tok-human"), { owner });
+
+    const put = await api("/api/me/handle", token, {
+      method: "PUT",
+      body: JSON.stringify({ handle: tokenName }),
+    });
+    expect(put.status).toBe(409);
+  });
+});

--- a/worker/test/profile.spec.ts
+++ b/worker/test/profile.spec.ts
@@ -36,4 +36,20 @@ describe("PUT /api/me/handle + GET /api/me handle", () => {
     });
     expect(put.status).toBe(409);
   });
+
+  // 命名空间大小写未闭合兜底：先铸一个带大写字母的 token 名，再设同名小写 handle——
+  // handleConflict 若按精确大小写匹配 tokens.name，会漏放这条撞车路径。
+  it("handle 撞已存在 token 名的大小写变体时返回 409", async () => {
+    const tokenName = uniq("CaseTok");
+    await seedToken("agent", tokenName);
+
+    const owner = uniq("acct");
+    const { token } = await seedToken("human", uniq("tok-human"), { owner });
+
+    const put = await api("/api/me/handle", token, {
+      method: "PUT",
+      body: JSON.stringify({ handle: tokenName.toLowerCase() }),
+    });
+    expect(put.status).toBe(409);
+  });
 });

--- a/worker/test/tokens.spec.ts
+++ b/worker/test/tokens.spec.ts
@@ -70,4 +70,21 @@ describe("tokens", () => {
     const res = await api("/api/channels", "ap_deadbeefdeadbeefdeadbeefdeadbeef");
     expect(res.status).toBe(401);
   });
+
+  // 反向唯一性（Task A5）：human 账号先占了某个 handle，之后铸一个同名的 token 必须 409——
+  // handle 与 token name 共用 @ 命名空间，两个方向都得挡撞车。
+  it("409 when minting a token whose name collides with an existing handle", async () => {
+    const handle = uniq("leohandle");
+    const owner = uniq("acct");
+    const { token: humanToken } = await seedToken("human", uniq("tok-human"), { owner });
+
+    const put = await api("/api/me/handle", humanToken, {
+      method: "PUT",
+      body: JSON.stringify({ handle }),
+    });
+    expect(put.status).toBe(200);
+
+    const res = await mint(handle, "agent");
+    expect(res.status).toBe(409);
+  });
 });

--- a/worker/test/tokens.spec.ts
+++ b/worker/test/tokens.spec.ts
@@ -87,4 +87,23 @@ describe("tokens", () => {
     const res = await mint(handle, "agent");
     expect(res.status).toBe(409);
   });
+
+  // 命名空间大小写未闭合兜底：NAME_RE 允许大写字母、HANDLE_RE 强制全小写，
+  // account_profiles.handle 是大小写敏感 UNIQUE——若反向冲突查询按精确大小写匹配，
+  // 已占 handle "casehandle-xxxx" 时仍能铸出大小写变体的同名 token（look-alike 冒充）。
+  it("409 when minting a token whose name is a case-variant of an existing handle", async () => {
+    const handle = uniq("casehandle");
+    const owner = uniq("acct");
+    const { token: humanToken } = await seedToken("human", uniq("tok-human"), { owner });
+
+    const put = await api("/api/me/handle", humanToken, {
+      method: "PUT",
+      body: JSON.stringify({ handle }),
+    });
+    expect(put.status).toBe(200);
+
+    const nameVariant = handle[0].toUpperCase() + handle.slice(1);
+    const res = await mint(nameVariant, "agent");
+    expect(res.status).toBe(409);
+  });
 });

--- a/worker/test/ws-header-injection.spec.ts
+++ b/worker/test/ws-header-injection.spec.ts
@@ -1,7 +1,13 @@
+import type { TokenIdentity } from "../src/auth";
 import { env, fetchMock, SELF } from "cloudflare:test";
 import { afterEach, beforeAll, describe, expect, it } from "vitest";
 import { handleHeader } from "../src/index";
 import { api, createChannel, postMessage, seedToken, uniq } from "./helpers";
+
+// handleHeader 现在按 identity（含 kind）过滤（Task A7 修复 #2），单测传最小可用 identity。
+function humanIdentity(account: string | null | undefined): TokenIdentity {
+  return { name: "test", role: "human", kind: "human", hash: "test-hash", account: account ?? undefined };
+}
 
 beforeAll(() => {
   fetchMock.activate();
@@ -139,16 +145,21 @@ describe("x-ap-handle forwarding (Task A6)", () => {
     expect(put.status).toBe(200);
 
     // 真实 handle：与客户端可能伪造的 "evil" 无关，只看 D1
-    await expect(handleHeader(env.DB, owner)).resolves.toEqual({ "x-ap-handle": handle });
+    await expect(handleHeader(env.DB, humanIdentity(owner))).resolves.toEqual({ "x-ap-handle": handle });
 
     // 有账号但从未设置过 handle → 空对象（不会把伪造值当权威值透传）
     const ownerNoHandle = uniq("acct-nohandle");
     await seedToken("human", uniq("tok-human2"), { owner: ownerNoHandle });
-    await expect(handleHeader(env.DB, ownerNoHandle)).resolves.toEqual({});
+    await expect(handleHeader(env.DB, humanIdentity(ownerNoHandle))).resolves.toEqual({});
 
     // 无账号会话（legacy token / readonly）→ 空对象
-    await expect(handleHeader(env.DB, null)).resolves.toEqual({});
-    await expect(handleHeader(env.DB, undefined)).resolves.toEqual({});
+    await expect(handleHeader(env.DB, humanIdentity(null))).resolves.toEqual({});
+    await expect(handleHeader(env.DB, humanIdentity(undefined))).resolves.toEqual({});
+
+    // kind !== "human"（agent）→ 即使账号设了 handle 也不带（Task A7 修复 #2）
+    await expect(
+      handleHeader(env.DB, { ...humanIdentity(owner), kind: "agent" }),
+    ).resolves.toEqual({});
   });
 
   it("ws upgrade still succeeds when a client sends a forged x-ap-handle header", async () => {

--- a/worker/test/ws-header-injection.spec.ts
+++ b/worker/test/ws-header-injection.spec.ts
@@ -1,6 +1,7 @@
 import { env, fetchMock, SELF } from "cloudflare:test";
 import { afterEach, beforeAll, describe, expect, it } from "vitest";
-import { api, createChannel, postMessage, seedToken } from "./helpers";
+import { handleHeader } from "../src/index";
+import { api, createChannel, postMessage, seedToken, uniq } from "./helpers";
 
 beforeAll(() => {
   fetchMock.activate();
@@ -116,5 +117,64 @@ describe("ws upgrade header injection", () => {
     expect(status).toMatchObject({ type: "status", kind: "status", note: "forged host" });
     expect(status.role).toBeUndefined();
     expect(status.role_source).toBeUndefined();
+  });
+});
+
+// Task A6：worker 把权威 x-ap-handle 转发给 do，同时剥离客户端伪造值。
+// do 侧目前尚不消费 x-ap-handle（消费是后续任务），因此这条 spec 已有的
+// "断言 do 收到头" 手法（观察归档态/webhook permalink/status.role 等副作用）在这里无副作用可观察——
+// do 完全不读这个头，客户端伪造它也不会产生任何可见行为差异。
+// 改用等价力度的验证：直接单测 handleHeader（worker/src/index.ts 新导出的权威 handle 计算逻辑），
+// 证明 worker 组装转发头时用的是账号在 D1 里的真实 handle，而不是任何客户端传入值；
+// 再补两条端到端回归，确认 ws 升级 / REST 发消息两条路径在夹带伪造 x-ap-handle 时都正常放行、不炸。
+describe("x-ap-handle forwarding (Task A6)", () => {
+  it("handleHeader resolves the account's real handle from D1, never a client-supplied value", async () => {
+    const owner = uniq("acct");
+    const human = await seedToken("human", uniq("tok-human"), { owner });
+    const handle = uniq("realhandle");
+    const put = await api("/api/me/handle", human.token, {
+      method: "PUT",
+      body: JSON.stringify({ handle }),
+    });
+    expect(put.status).toBe(200);
+
+    // 真实 handle：与客户端可能伪造的 "evil" 无关，只看 D1
+    await expect(handleHeader(env.DB, owner)).resolves.toEqual({ "x-ap-handle": handle });
+
+    // 有账号但从未设置过 handle → 空对象（不会把伪造值当权威值透传）
+    const ownerNoHandle = uniq("acct-nohandle");
+    await seedToken("human", uniq("tok-human2"), { owner: ownerNoHandle });
+    await expect(handleHeader(env.DB, ownerNoHandle)).resolves.toEqual({});
+
+    // 无账号会话（legacy token / readonly）→ 空对象
+    await expect(handleHeader(env.DB, null)).resolves.toEqual({});
+    await expect(handleHeader(env.DB, undefined)).resolves.toEqual({});
+  });
+
+  it("ws upgrade still succeeds when a client sends a forged x-ap-handle header", async () => {
+    const owner = uniq("acct");
+    const human = await seedToken("human", uniq("tok-human"), { owner });
+    const handle = uniq("wshandle");
+    expect((await api("/api/me/handle", human.token, { method: "PUT", body: JSON.stringify({ handle }) })).status).toBe(200);
+    const slug = await createChannel(human.token);
+
+    const { ws, first } = await openRaw(slug, human.token, { "x-ap-handle": "evil" });
+    expect(first.type).toBe("welcome");
+    ws.close();
+  });
+
+  it("POST .../messages still succeeds when a client sends a forged x-ap-handle header", async () => {
+    const owner = uniq("acct");
+    const human = await seedToken("human", uniq("tok-human"), { owner });
+    const handle = uniq("resthandle");
+    expect((await api("/api/me/handle", human.token, { method: "PUT", body: JSON.stringify({ handle }) })).status).toBe(200);
+    const slug = await createChannel(human.token);
+
+    const res = await api(`/api/channels/${slug}/messages`, human.token, {
+      method: "POST",
+      headers: { "x-ap-handle": "evil" },
+      body: JSON.stringify({ kind: "message", body: "hi", mentions: [], reply_to: null }),
+    });
+    expect(res.status).toBe(200);
   });
 });


### PR DESCRIPTION
## 概述

让人类账号设置一个**全局唯一、可读、可被 @** 的 handle（取代 email/sub 显示），并在被 @ 且标签页未聚焦时弹浏览器通知。

- 设计 spec：`docs/superpowers/specs/2026-07-08-human-handle-mention-notify-design.md`
- 实施计划：`docs/superpowers/plans/2026-07-08-human-handle-mention-notify.md`

## R4 · 人类可 @ 昵称（handle）

- 新表 `account_profiles(account, handle)`（migration `0014`）；handle 全局唯一、name-like、与 token 名**共用 @ 命名空间**——两侧唯一性校验 + **大小写不敏感**（`COLLATE NOCASE`），防 look-alike 冒充。
- handle 是**显示 + 被@检测别名**，**不动身份/ACL 键**（account/email 仍是唯一 ACL 锚点、不参与任何权限判定）。
- worker 按 **human 身份**查出 handle → `x-ap-handle` 头下发 DO（剥离客户端注入、仅人类，agent 即使共享 account 也不继承）→ DO 盖 `presence.handle` + stamp `sender_handle`（历史消息快照当时 handle）。
- 前端：`PUT /api/me/handle` + 设置/改名 UI（非强制提示）；mention 候选用 handle 作人类 @ 目标；消息卡 / presence / 读未读回执弹层显示 handle，**email 作可信锚点保留在 tooltip/副标签**。

## R5 · 被 @ 浏览器通知

- 纯函数 `shouldNotify(msg, myHandle, documentHidden, permissionGranted)`：被 @ 且标签页未聚焦且已授权才弹。
- 频道头"通知铃铛"**手动 opt-in**（不自动请求权限，localStorage 全局生效）；点通知 `focus()` + 跳 `#msg-<seq>`。

## 协议 / 兼容

- `Sender.handle?` / `PresenceEntry.handle?` / `PresenceFrame.handle?` 全部**可选字段**，旧客户端忽略；migration 纯新增（新表 + 新列）；默认无 handle = 人类照旧显示 email，**零破坏**。

## 验证

- **自动化门禁全绿**：worker 204 测试 + web 76 测试；shared/web/worker `tsc` 0；`vite build` 成功。含 handle 校验/冲突、端到端防注入（经真实 worker→DO 路径）、`shouldNotify`、mention with/without handle、reducer/display。
- **chrome-use 真实页面**：设 handle（CTA→表单→保存）→ 消息/presence 显示 handle（email 作锚点）→ R5 铃铛渲染 + 权限门控 → R2 右键菜单回归，均通过。
- 逐任务对抗性 review + 最终整分支 review，抓出并修复 **5 个真实问题**：`PUT me/handle` 竞态 500→409、大小写绕过、review/supersede 转发漏 handle、agent 继承共享账号 human handle、读未读回执显示不一致。

## 已知非阻塞（可后续小版本）

跨表 TOCTOU（既有架构限制，handle 不控 ACL）、409 提示文案、点通知在已切换频道时不导航回、"离线但有 handle 的人类可@"的产品决策。
