### PR TITLE
feat(web): 引用升级为可预览可跳转的真·引用

### DIFF
--- a/web/src/components/MessageCard.tsx
+++ b/web/src/components/MessageCard.tsx
@@ -7,6 +7,7 @@ import { agentHue } from "../lib/agentColor";
 import type { IdentityDisplayMap } from "../lib/identityDisplay";
 import { replaceMentionLabels } from "../lib/mentionMarkup";
 import { readStateFor } from "../lib/readList";
+import { summarizeReplyPreview } from "../lib/replyPreview";
 import { useT } from "../i18n/useT";
 import "../i18n/strings/MessageCard";
 import { fmtTime } from "../lib/time";
@@ -21,6 +22,10 @@ interface Props {
   receipts?: MentionReceipt[]; // 本条被 @ 的 agent 目标的唤醒/回执状态（Phase 1）
   readCursors?: Record<string, ReadCursor>; // 已读游标（Phase 2）
   participants?: Sender[]; // 当前连着的身份，用于算未读
+  // 引用预览：reply_to 解析出的完整原消息（Channel 用 seq → msg 的 Map 查出来的）。
+  // null 有两种含义——没有引用（reply_to 本身就是 null）或引用目标不在已加载窗口内；
+  // 后一种情况下面渲染时会降级回纯编号 ↩ #N，不强行伪造内容。
+  quotedMessage: MsgFrame | null;
   // 消息右键菜单（PR #49）：引用/编辑/撤回/复制
   canModerate: boolean;
   onReply(seq: number): void;
@@ -38,6 +43,16 @@ interface Props {
 
 function displayForIdentity(name: string, identities: IdentityDisplayMap | undefined): string {
   return identities?.[name]?.display ?? name;
+}
+
+// 显示优先级：人类 handle（可 @ 昵称）> owner（人类专属，email）> 常规 identity 回退。
+// 消息头的 senderLabel 与引用预览块里"被引用者"的名字共用同一份逻辑，保证两处一致。
+function resolveSenderLabel(sender: Sender, identities: IdentityDisplayMap | undefined): string {
+  return sender.handle
+    ? sender.handle
+    : sender.kind === "human" && sender.owner
+      ? sender.owner
+      : displayForIdentity(sender.name, identities);
 }
 
 function contextBits(ctx: AgentContext | undefined): string[] {
@@ -90,6 +105,7 @@ export function MessageCard({
   receipts,
   readCursors,
   participants,
+  quotedMessage,
   canModerate,
   onReply,
   onEdit,
@@ -115,13 +131,8 @@ export function MessageCard({
     msg.kind === "message" && readCursors !== undefined
       ? readStateFor(msg.seq, msg.sender.name, participants ?? [], readCursors)
       : { readers: [], unread: [] };
-  // 显示优先级：人类 handle（可 @ 昵称）> owner（email，人类专属）> 常规 identity 回退（agent 天然无 handle，不受影响）。
   // owner/email 无论是否被 handle 取代，都作为防冒充锚点保留在下方副标签 + tooltip 中（见 senderTitle）。
-  const senderLabel = msg.sender.handle
-    ? msg.sender.handle
-    : msg.sender.kind === "human" && msg.sender.owner
-      ? msg.sender.owner
-      : displayForIdentity(msg.sender.name, identityDisplay);
+  const senderLabel = resolveSenderLabel(msg.sender, identityDisplay);
   const owner = msg.sender.owner && msg.sender.owner !== senderLabel ? msg.sender.owner : null;
   const lineage = msg.sender.lineage ?? null;
   const lineageLabel = lineage === null ? null : `child of ${lineage.parent_agent}`;
@@ -155,6 +166,23 @@ export function MessageCard({
   const canRetract = canReply && canRevise;
   const saveDisabled = editSaving || editDraft.trim() === "" || editDraft === msg.body;
   const menuItemCount = Number(canReply) + Number(canEdit) + Number(canRetract) + 1;
+  // 引用预览：quotedMessage 为 null 有两种含义——没引用，或引用目标不在已加载窗口内；
+  // 后者在渲染处降级回纯编号 ↩ #N（见下方 JSX），这里只在真有内容时才算标签/预览文字。
+  const quotedSenderLabel = quotedMessage !== null ? resolveSenderLabel(quotedMessage.sender, identityDisplay) : null;
+  const quotedPreviewText =
+    quotedMessage !== null
+      ? quotedMessage.retracted
+        ? t("MessageCard.reply.retracted")
+        : summarizeReplyPreview(quotedMessage.body)
+      : null;
+  const jumpToQuoted = () => {
+    if (msg.reply_to === null) return;
+    const target = document.getElementById(`msg-${msg.reply_to}`);
+    if (target === null) return;
+    target.scrollIntoView({ behavior: "smooth", block: "center" });
+    target.classList.add("msg-jump-highlight");
+    window.setTimeout(() => target.classList.remove("msg-jump-highlight"), 1200);
+  };
 
   useEffect(() => {
     if (menu === null) return;
@@ -294,7 +322,7 @@ export function MessageCard({
             @{displayForIdentity(m, identityDisplay)}
           </span>
         ))}
-        {msg.reply_to !== null && <span className="msg-reply">↩ #{msg.reply_to}</span>}
+        {msg.reply_to !== null && quotedMessage === null && <span className="msg-reply">↩ #{msg.reply_to}</span>}
         {revisionBadges.map((badge) => (
           <span key={badge} className="msg-revision">
             {badge}
@@ -327,6 +355,19 @@ export function MessageCard({
         <span>#{msg.seq}</span>
         <time>{fmtTime(msg.ts)}</time>
       </header>
+      {msg.reply_to !== null && quotedMessage !== null && (
+        <button
+          type="button"
+          className="msg-quote"
+          onClick={jumpToQuoted}
+          title={quotedMessage.retracted ? undefined : quotedMessage.body}
+          aria-label={t("MessageCard.reply.jump", { seq: msg.reply_to })}
+        >
+          <span className="msg-quote-icon" aria-hidden="true">↩</span>
+          <span className="msg-quote-sender">{quotedSenderLabel}</span>
+          <span className="msg-quote-text">{quotedPreviewText}</span>
+        </button>
+      )}
       <MessageStatus
         receipts={receipts ?? []}
         readers={read.readers}

--- a/web/src/i18n/strings/MessageCard.ts
+++ b/web/src/i18n/strings/MessageCard.ts
@@ -14,6 +14,8 @@ export const MessageCardStrings: LocaleDict = {
     "MessageCard.edit.save": "save",
     "MessageCard.edit.saving": "saving…",
     "MessageCard.edit.cancel": "cancel",
+    "MessageCard.reply.retracted": "original message retracted",
+    "MessageCard.reply.jump": "jump to original message #{seq}",
   },
   zh: {
     "MessageCard.badge.edited": "已编辑",
@@ -28,6 +30,8 @@ export const MessageCardStrings: LocaleDict = {
     "MessageCard.edit.save": "保存",
     "MessageCard.edit.saving": "保存中…",
     "MessageCard.edit.cancel": "取消",
+    "MessageCard.reply.retracted": "原消息已撤回",
+    "MessageCard.reply.jump": "跳转到原消息 #{seq}",
   },
 };
 

--- a/web/src/lib/replyPreview.test.ts
+++ b/web/src/lib/replyPreview.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { summarizeReplyPreview } from "./replyPreview";
+
+describe("summarizeReplyPreview", () => {
+  test("collapses internal whitespace/newlines to single spaces", () => {
+    expect(summarizeReplyPreview("hello\n\n  world\tagain")).toBe("hello world again");
+  });
+
+  test("trims leading/trailing whitespace", () => {
+    expect(summarizeReplyPreview("   padded   ")).toBe("padded");
+  });
+
+  test("passes short bodies through unchanged", () => {
+    const body = "a".repeat(96);
+    expect(summarizeReplyPreview(body)).toBe(body);
+  });
+
+  test("truncates long bodies to 93 chars + ellipsis", () => {
+    const body = "a".repeat(200);
+    const out = summarizeReplyPreview(body);
+    expect(out).toBe(`${"a".repeat(93)}...`);
+    expect(out.length).toBe(96);
+  });
+
+  test("empty body stays empty", () => {
+    expect(summarizeReplyPreview("")).toBe("");
+  });
+});

--- a/web/src/lib/replyPreview.ts
+++ b/web/src/lib/replyPreview.ts
@@ -1,0 +1,7 @@
+// 引用预览文字：把正文压成单行、截断到定长。Channel 插话框的"回复中"提示条与
+// MessageCard 的引用预览块共用同一份实现，避免两处截断规则各写各的、慢慢跑偏。
+export function summarizeReplyPreview(body: string): string {
+  const collapsed = body.replace(/\s+/g, " ").trim();
+  if (collapsed.length <= 96) return collapsed;
+  return `${collapsed.slice(0, 93)}...`;
+}

--- a/web/src/pages/Channel.tsx
+++ b/web/src/pages/Channel.tsx
@@ -48,6 +48,7 @@ import {
   type AgentFilterMode,
 } from "../lib/filters";
 import { shouldNotify } from "../lib/notify";
+import { summarizeReplyPreview } from "../lib/replyPreview";
 import { fmtTime } from "../lib/time";
 import { groupTeamMessages, summarizeTeams, type TeamMessageThread, type TeamSummary } from "../lib/teams";
 import { ChannelSocket } from "../lib/ws";
@@ -81,12 +82,6 @@ const MESSAGE_CAP = 300;
 const COLLAB_ROLES: CollaborationRole[] = ["host", "worker", "reviewer", "observer"];
 // 触顶阈值：滚动到离顶部这么近就预取上一页
 const TOP_LOAD_PX = 80;
-
-function summarizeReplyPreview(body: string): string {
-  const collapsed = body.replace(/\s+/g, " ").trim();
-  if (collapsed.length <= 96) return collapsed;
-  return `${collapsed.slice(0, 93)}...`;
-}
 
 function positiveInt(value: string, fallback: number, max: number): number | null {
   if (value.trim() === "") return fallback;
@@ -872,6 +867,7 @@ function TeamThread({
   editSaving,
   actionError,
   busySeq,
+  messageBySeq,
   onReply,
   onEdit,
   onRetract,
@@ -891,6 +887,8 @@ function TeamThread({
   editSaving: boolean;
   actionError: { seq: number; message: string } | null;
   busySeq: number | null;
+  // seq → 消息，用于把 reply_to 解析成完整的被引用消息（同一份 Map 从 ChannelPage 传下来，不在这里重建）
+  messageBySeq: Map<number, MsgFrame>;
   onReply: (seq: number) => void;
   onEdit: (seq: number) => void;
   onRetract: (seq: number) => void;
@@ -931,6 +929,7 @@ function TeamThread({
             readCursors={readCursors}
             participants={participants}
             canModerate={canModerate}
+            quotedMessage={message.reply_to !== null ? messageBySeq.get(message.reply_to) ?? null : null}
             onReply={onReply}
             onEdit={onEdit}
             onRetract={onRetract}
@@ -1597,6 +1596,9 @@ export function ChannelPage({
     ]),
   ].sort((a, b) => a.localeCompare(b));
   const senderListId = `senders-${slug}`;
+  // seq → 消息：给引用预览用，把 reply_to 解析成完整消息（含发送者/正文/撤回状态）而不止一个编号。
+  // 只在已加载窗口内查得到——超出 MESSAGE_CAP 或翻页边界外的历史引用会查不到，MessageCard 侧降级回纯编号。
+  const messageBySeq = useMemo(() => new Map(state.messages.map((m) => [m.seq, m])), [state.messages]);
   const completions = useMemo(() => completionMessages(state.messages), [state.messages]);
   const timelineMessages = completionOnly ? completions : state.messages;
   const visibleMessages = useMemo(() => filterByAgent(timelineMessages, agentFilter), [agentFilter, timelineMessages]);
@@ -2055,6 +2057,7 @@ export function ChannelPage({
                   readCursors={state.readCursors}
                   participants={state.participants}
                   canModerate={canModerate}
+                  quotedMessage={item.message.reply_to !== null ? messageBySeq.get(item.message.reply_to) ?? null : null}
                   onReply={startReply}
                   onEdit={startEdit}
                   onRetract={retractMessage}
@@ -2082,6 +2085,7 @@ export function ChannelPage({
                   editSaving={editSaving}
                   actionError={messageActionError}
                   busySeq={messageActionBusySeq}
+                  messageBySeq={messageBySeq}
                   onReply={startReply}
                   onEdit={startEdit}
                   onRetract={retractMessage}

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -1823,6 +1823,67 @@
 }
 .msg-mention { color: var(--t-accent); }
 .msg-reply { color: var(--t-dim); }
+/* 引用预览块：真·引用取代裸 ↩#N —— 左竖条 + 淡底，点了跳到原消息并短暂高亮。
+   quotedMessage 查不到（不在已加载窗口内）时降级回上面那行 .msg-reply，不渲染这块。 */
+.msg-quote {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  width: 100%;
+  max-width: 100%;
+  margin: 2px 0 6px;
+  padding: 5px 9px;
+  border: 0;
+  border-left: 3px solid var(--t-faint);
+  border-radius: 3px 7px 7px 3px / 3px 9px 9px 3px;
+  background: var(--t-panel2);
+  color: var(--t-body);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 120ms ease, background 120ms ease, transform 80ms ease;
+}
+.msg-quote:hover,
+.msg-quote:focus-visible {
+  border-left-color: var(--t-accent);
+  background: color-mix(in srgb, var(--t-accent) 8%, var(--t-panel2));
+  transform: translateX(1px);
+}
+.msg-quote:focus-visible { outline: 2px solid var(--t-accent); outline-offset: 1px; }
+.msg-quote-icon { flex: none; color: var(--t-dim); }
+.msg-quote-sender {
+  flex: none;
+  font-family: var(--d-marker);
+  font-size: 12.5px;
+  color: hsl(var(--ah, 220) 58% var(--agent-l-name));
+  max-width: 30%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.msg-quote-text {
+  flex: 1;
+  min-width: 0;
+  color: var(--t-dim);
+  font-size: 12.5px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+/* 跳转命中高亮：目标消息短暂描边闪一下，告诉用户"就是这条"，~1.2s 后 MessageCard 自己摘掉这个 class。 */
+.msg-jump-highlight { animation: msg-jump-flash 1.2s ease-out; }
+@keyframes msg-jump-flash {
+  0% {
+    outline: 3px solid var(--t-accent);
+    outline-offset: 2px;
+    background-color: color-mix(in srgb, var(--t-accent) 16%, transparent);
+  }
+  100% {
+    outline: 3px solid transparent;
+    outline-offset: 2px;
+    background-color: transparent;
+  }
+}
 .msg-revision {
   font-size: 10px;
   padding: 0 6px;


### PR DESCRIPTION
## 背景

之前消息的"引用"只显示一个裸 `↩ #N` 编号——看不到被引用消息的内容、点了也不跳转，容易让人以为"引用没生效"。功能本身是通的（按 seq 引用），本 PR 把它升级为真正可用的引用。

## 改动（纯前端）

- 消息有 `reply_to` 时，在正文上方渲染一个**可点击的引用预览块**：`↩ <被引用者> · <内容预览>`
  - 被引用者显示名走 **handle 优先**（抽出 `resolveSenderLabel`，与消息头一致；避免给 agent 引用误显示 owner）
  - 内容预览复用抽出的 `summarizeReplyPreview`（`lib/replyPreview.ts`，Channel 的"回复中"提示条与此块共用同一份截断，+ 5 条 bun:test）
  - 点击 → `scrollIntoView` 平滑滚动到原消息 + 1.2s 高亮（`#msg-<seq>` 锚点已存在）；`<button>` 可键盘触达
  - 被引用消息已撤回 → 显示"原消息已撤回"
  - 引用目标不在已加载窗口（分页裁剪/超出上限）→ 降级回原来的裸 `↩ #N`
- `Channel` 用 `messageBySeq`（`useMemo` Map）按 seq 解析被引用消息，传给 `MessageCard`（主时间线 + `TeamThread` 两处渲染点）

## 验证

- web `tsc --noEmit` 0 + `bun test` 82 过（含 5 条 `replyPreview` 纯函数测试）+ `vite build` 成功
- chrome-use 真实页面：右键引用 → 回复条 → 发送后消息带引用预览块（显示被引用内容）→ 点击 → 滚动跳转 + 高亮原消息，均通过

## 已知非阻塞

被引用消息若在**折叠的 team thread** 内，点击会滚过去但目标默认折叠，视觉上像"跳空"——后续可在展开 thread 后再定位。
