### PR TITLE
feat(web): 协调面板 agent 筛选新增全人类/全机器人（按 kind）

### DIFF
--- a/web/src/i18n/strings/Channel.ts
+++ b/web/src/i18n/strings/Channel.ts
@@ -64,6 +64,8 @@ export const ChannelStrings: LocaleDict = {
     "Channel.notify.offTitle": "Get a browser notification when you're @mentioned (while this tab isn't focused)",
     "Channel.notify.denied": "Browser blocked notification permission",
     "Channel.notify.unsupported": "This browser doesn't support notifications",
+    "Channel.filter.humans": "Humans",
+    "Channel.filter.agents": "Agents",
   },
   zh: {
     "Channel.charter.label": "📌 公告",
@@ -128,6 +130,8 @@ export const ChannelStrings: LocaleDict = {
     "Channel.notify.offTitle": "开启被@浏览器提醒（仅在标签页未聚焦时弹出）",
     "Channel.notify.denied": "浏览器已拒绝通知权限",
     "Channel.notify.unsupported": "此浏览器不支持通知",
+    "Channel.filter.humans": "全人类",
+    "Channel.filter.agents": "全机器人",
   },
 };
 

--- a/web/src/lib/filters.test.ts
+++ b/web/src/lib/filters.test.ts
@@ -4,6 +4,7 @@ import {
   filterByAgent,
   matchesAgentFilter,
   parseAgentFilter,
+  setKind,
   toggleAgent,
   type AgentFilter,
 } from "./filters";
@@ -13,6 +14,7 @@ describe("agent filters", () => {
     expect(parseAgentFilter("?agent=bob,alice&agent=alice&agentMode=except")).toEqual({
       mode: "except",
       agents: ["alice", "bob"],
+      kind: null,
     });
   });
 
@@ -20,33 +22,111 @@ describe("agent filters", () => {
     expect(parseAgentFilter("?agent=ok&agent=bad/name&agentMode=wat")).toEqual({
       mode: "only",
       agents: ["ok"],
+      kind: null,
     });
   });
 
+  test("parses agentKind from url, ignoring unknown values", () => {
+    expect(parseAgentFilter("?agentKind=human")).toEqual({ mode: "only", agents: [], kind: "human" });
+    expect(parseAgentFilter("?agentKind=agent")).toEqual({ mode: "only", agents: [], kind: "agent" });
+    expect(parseAgentFilter("?agentKind=robot")).toEqual({ mode: "only", agents: [], kind: null });
+    expect(parseAgentFilter("")).toEqual({ mode: "only", agents: [], kind: null });
+  });
+
   test("serializes only and except modes", () => {
-    expect(agentFilterSearch({ mode: "only", agents: ["alice", "bob"] })).toBe("agent=alice%2Cbob");
-    expect(agentFilterSearch({ mode: "except", agents: ["alice"] })).toBe("agent=alice&agentMode=except");
-    expect(agentFilterSearch({ mode: "except", agents: [] })).toBe("");
+    expect(agentFilterSearch({ mode: "only", agents: ["alice", "bob"], kind: null })).toBe("agent=alice%2Cbob");
+    expect(agentFilterSearch({ mode: "except", agents: ["alice"], kind: null })).toBe("agent=alice&agentMode=except");
+    expect(agentFilterSearch({ mode: "except", agents: [], kind: null })).toBe("");
+  });
+
+  test("serializes agentKind, and stays non-empty with only a kind filter set", () => {
+    expect(agentFilterSearch({ mode: "only", agents: [], kind: "human" })).toBe("agentKind=human");
+    expect(agentFilterSearch({ mode: "only", agents: [], kind: "agent" })).toBe("agentKind=agent");
+    expect(agentFilterSearch({ mode: "except", agents: ["alice"], kind: "human" })).toBe(
+      "agent=alice&agentMode=except&agentKind=human",
+    );
   });
 
   test("toggles agents deterministically", () => {
-    const filter: AgentFilter = { mode: "only", agents: ["bob"] };
-    expect(toggleAgent(filter, "alice")).toEqual({ mode: "only", agents: ["alice", "bob"] });
-    expect(toggleAgent(filter, "bob")).toEqual({ mode: "only", agents: [] });
+    const filter: AgentFilter = { mode: "only", agents: ["bob"], kind: null };
+    expect(toggleAgent(filter, "alice")).toEqual({ mode: "only", agents: ["alice", "bob"], kind: null });
+    expect(toggleAgent(filter, "bob")).toEqual({ mode: "only", agents: [], kind: null });
   });
 
-  test("matches only and except filters", () => {
-    expect(matchesAgentFilter("alice", { mode: "only", agents: ["alice"] })).toBe(true);
-    expect(matchesAgentFilter("bob", { mode: "only", agents: ["alice"] })).toBe(false);
-    expect(matchesAgentFilter("alice", { mode: "except", agents: ["alice"] })).toBe(false);
-    expect(matchesAgentFilter("bob", { mode: "except", agents: ["alice"] })).toBe(true);
+  test("setKind sets the kind and is mutually exclusive with the other kind", () => {
+    const filter: AgentFilter = { mode: "only", agents: [], kind: null };
+    const human = setKind(filter, "human");
+    expect(human).toEqual({ mode: "only", agents: [], kind: "human" });
+    const agent = setKind(human, "agent");
+    expect(agent).toEqual({ mode: "only", agents: [], kind: "agent" });
   });
 
-  test("filters sender-shaped items", () => {
+  test("setKind toggles back to null when re-applying the same kind (mutual exclusivity)", () => {
+    const filter: AgentFilter = { mode: "only", agents: [], kind: "human" };
+    expect(setKind(filter, "human")).toEqual({ mode: "only", agents: [], kind: null });
+  });
+
+  test("matches only and except filters by name", () => {
+    expect(matchesAgentFilter({ name: "alice", kind: "agent" }, { mode: "only", agents: ["alice"], kind: null })).toBe(
+      true,
+    );
+    expect(matchesAgentFilter({ name: "bob", kind: "agent" }, { mode: "only", agents: ["alice"], kind: null })).toBe(
+      false,
+    );
+    expect(
+      matchesAgentFilter({ name: "alice", kind: "agent" }, { mode: "except", agents: ["alice"], kind: null }),
+    ).toBe(false);
+    expect(matchesAgentFilter({ name: "bob", kind: "agent" }, { mode: "except", agents: ["alice"], kind: null })).toBe(
+      true,
+    );
+  });
+
+  test("matches by kind alone", () => {
+    const humanOnly: AgentFilter = { mode: "only", agents: [], kind: "human" };
+    expect(matchesAgentFilter({ name: "alice", kind: "human" }, humanOnly)).toBe(true);
+    expect(matchesAgentFilter({ name: "bob", kind: "agent" }, humanOnly)).toBe(false);
+
+    const agentOnly: AgentFilter = { mode: "only", agents: [], kind: "agent" };
+    expect(matchesAgentFilter({ name: "bob", kind: "agent" }, agentOnly)).toBe(true);
+    expect(matchesAgentFilter({ name: "alice", kind: "human" }, agentOnly)).toBe(false);
+  });
+
+  test("combines name and kind filters with AND", () => {
+    const filter: AgentFilter = { mode: "only", agents: ["alice"], kind: "human" };
+    // name matches, kind matches -> true
+    expect(matchesAgentFilter({ name: "alice", kind: "human" }, filter)).toBe(true);
+    // name matches, kind doesn't -> false
+    expect(matchesAgentFilter({ name: "alice", kind: "agent" }, filter)).toBe(false);
+    // name doesn't match, kind matches -> false
+    expect(matchesAgentFilter({ name: "bob", kind: "human" }, filter)).toBe(false);
+    // neither matches -> false
+    expect(matchesAgentFilter({ name: "bob", kind: "agent" }, filter)).toBe(false);
+  });
+
+  test("filters sender-shaped items by name", () => {
     const items = [
-      { seq: 1, sender: { name: "alice" } },
-      { seq: 2, sender: { name: "bob" } },
+      { seq: 1, sender: { name: "alice", kind: "agent" as const } },
+      { seq: 2, sender: { name: "bob", kind: "agent" as const } },
     ];
-    expect(filterByAgent(items, { mode: "only", agents: ["bob"] })).toEqual([items[1]]);
+    expect(filterByAgent(items, { mode: "only", agents: ["bob"], kind: null })).toEqual([items[1]]);
+  });
+
+  test("filters sender-shaped items by kind, unaffected by agents when unset", () => {
+    const items = [
+      { seq: 1, sender: { name: "alice", kind: "human" as const } },
+      { seq: 2, sender: { name: "bob", kind: "agent" as const } },
+    ];
+    expect(filterByAgent(items, { mode: "only", agents: [], kind: "human" })).toEqual([items[0]]);
+    expect(filterByAgent(items, { mode: "only", agents: [], kind: "agent" })).toEqual([items[1]]);
+    expect(filterByAgent(items, { mode: "only", agents: [], kind: null })).toEqual(items);
+  });
+
+  test("filters sender-shaped items by name AND kind together", () => {
+    const items = [
+      { seq: 1, sender: { name: "alice", kind: "human" as const } },
+      { seq: 2, sender: { name: "alice", kind: "agent" as const } },
+      { seq: 3, sender: { name: "bob", kind: "human" as const } },
+    ];
+    expect(filterByAgent(items, { mode: "only", agents: ["alice"], kind: "human" })).toEqual([items[0]]);
   });
 });

--- a/web/src/lib/filters.ts
+++ b/web/src/lib/filters.ts
@@ -1,8 +1,10 @@
 export type AgentFilterMode = "only" | "except";
+export type AgentFilterKind = "human" | "agent";
 
 export interface AgentFilter {
   mode: AgentFilterMode;
   agents: string[];
+  kind: AgentFilterKind | null;
 }
 
 const NAME_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$/;
@@ -13,18 +15,25 @@ function cleanAgents(values: string[]): string[] {
   );
 }
 
+function cleanKind(value: string | null): AgentFilterKind | null {
+  return value === "human" || value === "agent" ? value : null;
+}
+
 export function parseAgentFilter(search: string): AgentFilter {
   const params = new URLSearchParams(search);
   const rawAgents = params.getAll("agent").flatMap((value) => value.split(","));
   const mode = params.get("agentMode") === "except" ? "except" : "only";
-  return { mode, agents: cleanAgents(rawAgents) };
+  return { mode, agents: cleanAgents(rawAgents), kind: cleanKind(params.get("agentKind")) };
 }
 
 export function agentFilterSearch(filter: AgentFilter): string {
   const params = new URLSearchParams();
-  if (filter.agents.length === 0) return "";
-  params.set("agent", filter.agents.join(","));
-  if (filter.mode === "except") params.set("agentMode", "except");
+  if (filter.agents.length === 0 && filter.kind === null) return "";
+  if (filter.agents.length > 0) {
+    params.set("agent", filter.agents.join(","));
+    if (filter.mode === "except") params.set("agentMode", "except");
+  }
+  if (filter.kind !== null) params.set("agentKind", filter.kind);
   return params.toString();
 }
 
@@ -35,13 +44,21 @@ export function toggleAgent(filter: AgentFilter, agent: string): AgentFilter {
   return { ...filter, agents: cleanAgents(agents) };
 }
 
-export function matchesAgentFilter(senderName: string, filter: AgentFilter): boolean {
+export function setKind(filter: AgentFilter, kind: AgentFilterKind): AgentFilter {
+  return { ...filter, kind: filter.kind === kind ? null : kind };
+}
+
+export function matchesAgentFilter(sender: { name: string; kind: "agent" | "human" }, filter: AgentFilter): boolean {
+  if (filter.kind !== null && sender.kind !== filter.kind) return false;
   if (filter.agents.length === 0) return true;
-  const selected = filter.agents.includes(senderName);
+  const selected = filter.agents.includes(sender.name);
   return filter.mode === "only" ? selected : !selected;
 }
 
-export function filterByAgent<T extends { sender: { name: string } }>(items: T[], filter: AgentFilter): T[] {
-  if (filter.agents.length === 0) return items;
-  return items.filter((item) => matchesAgentFilter(item.sender.name, filter));
+export function filterByAgent<T extends { sender: { name: string; kind: "agent" | "human" } }>(
+  items: T[],
+  filter: AgentFilter,
+): T[] {
+  if (filter.agents.length === 0 && filter.kind === null) return items;
+  return items.filter((item) => matchesAgentFilter(item.sender, filter));
 }

--- a/web/src/pages/Channel.tsx
+++ b/web/src/pages/Channel.tsx
@@ -43,8 +43,10 @@ import {
   agentFilterSearch,
   filterByAgent,
   parseAgentFilter,
+  setKind,
   toggleAgent,
   type AgentFilter,
+  type AgentFilterKind,
   type AgentFilterMode,
 } from "../lib/filters";
 import { shouldNotify } from "../lib/notify";
@@ -514,6 +516,7 @@ function AgentFilterPanel({
   total,
   onMode,
   onToggle,
+  onKind,
   onClear,
 }: {
   senders: string[];
@@ -522,9 +525,11 @@ function AgentFilterPanel({
   total: number;
   onMode: (mode: AgentFilterMode) => void;
   onToggle: (agent: string) => void;
+  onKind: (kind: AgentFilterKind) => void;
   onClear: () => void;
 }) {
-  const active = filter.agents.length > 0;
+  const t = useT();
+  const active = filter.agents.length > 0 || filter.kind !== null;
   return (
     <section className="agent-filter-panel" aria-label="agent filters">
       <div className="agent-filter-head">
@@ -544,6 +549,24 @@ function AgentFilterPanel({
             onClick={() => onMode("except")}
           >
             <span>Hide</span>
+          </button>
+        </div>
+        <div className="agent-filter-kinds" role="group" aria-label="agent filter kind">
+          <button
+            className={"d-btn agent-filter-kind" + (filter.kind === "human" ? " is-active" : "")}
+            type="button"
+            aria-pressed={filter.kind === "human"}
+            onClick={() => onKind("human")}
+          >
+            <span>{t("Channel.filter.humans")}</span>
+          </button>
+          <button
+            className={"d-btn agent-filter-kind" + (filter.kind === "agent" ? " is-active" : "")}
+            type="button"
+            aria-pressed={filter.kind === "agent"}
+            onClick={() => onKind("agent")}
+          >
+            <span>{t("Channel.filter.agents")}</span>
           </button>
         </div>
         <span className="t-mono agent-filter-count">
@@ -1231,6 +1254,7 @@ export function ChannelPage({
     const url = new URL(window.location.href);
     url.searchParams.delete("agent");
     url.searchParams.delete("agentMode");
+    url.searchParams.delete("agentKind");
     const filterSearch = agentFilterSearch(agentFilter);
     if (filterSearch !== "") {
       const params = new URLSearchParams(filterSearch);
@@ -1700,7 +1724,7 @@ export function ChannelPage({
       window.clearInterval(id);
     };
   }, [token, slug, shareMode]);
-  const agentFilterActive = agentFilter.agents.length > 0;
+  const agentFilterActive = agentFilter.agents.length > 0 || agentFilter.kind !== null;
   const totalInView = q === "" ? timelineMessages.length : searchHits.length;
   const visibleInView = q === "" ? visibleMessages.length : visibleSearchHits.length;
   const structuredRoleCount = channelRoles.length + selfReportedRoles(channelRoles, state.presence, channelIdentities).length;
@@ -1713,8 +1737,12 @@ export function ChannelPage({
     setAgentFilter((current) => toggleAgent(current, agent));
   }, []);
 
+  const setAgentKind = useCallback((kind: AgentFilterKind) => {
+    setAgentFilter((current) => setKind(current, kind));
+  }, []);
+
   const clearAgentFilter = useCallback(() => {
-    setAgentFilter((current) => ({ ...current, agents: [] }));
+    setAgentFilter((current) => ({ ...current, agents: [], kind: null }));
   }, []);
 
   const jumpToCompletion = useCallback((seq: number) => {
@@ -1798,6 +1826,7 @@ export function ChannelPage({
           total={totalInView}
           onMode={setAgentMode}
           onToggle={toggleAgentFilter}
+          onKind={setAgentKind}
           onClear={clearAgentFilter}
         />
       )}

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -1179,6 +1179,30 @@
   background: var(--d-yellow);
   box-shadow: 1.5px 2px 0 var(--d-shadow);
 }
+.agent-filter-kinds {
+  display: inline-flex;
+  gap: 4px;
+  padding: 2px;
+  background: var(--t-panel2);
+  border: 1.5px solid var(--d-ink);
+  border-radius: 8px;
+}
+.agent-filter-kind {
+  font-size: 11px;
+  padding: 3px 9px 4px;
+  background: transparent;
+  box-shadow: none;
+  border-width: 1.5px;
+}
+.agent-filter-kind:first-child.is-active {
+  background: var(--d-green-soft);
+  color: #2e7d46;
+  box-shadow: 1.5px 2px 0 var(--d-shadow);
+}
+.agent-filter-kind:last-child.is-active {
+  background: var(--d-yellow);
+  box-shadow: 1.5px 2px 0 var(--d-shadow);
+}
 .agent-filter-count {
   flex: none;
   color: var(--t-dim);


### PR DESCRIPTION
## 需求
协调面板(Coordination)的 agent 筛选原来只能按 agent 名 only/except 过滤，新增按发送者类型筛选：全人类 / 全机器人。

## 改动（纯前端）
- `lib/filters.ts`：`AgentFilter` 加 `kind: "human"|"agent"|null`；`matchesAgentFilter` 先判 kind 再判名字（与名字过滤 **AND 组合**）；`setKind` 互斥切换（点已选的→取消回全部）；`parseAgentFilter`/`agentFilterSearch` 读写 URL `agentKind`。
- `AgentFilterPanel`（Channel.tsx）：加 Humans / Agents 两个互斥切换按钮；`active` 计入 kind；Clear 一并清 kind；URL 同步补删 `agentKind`。
- i18n：Humans/Agents（全人类/全机器人）en+zh。

## 验证
- `bun test` 85 过（`filters.test.ts` 14，含 6 条 kind + AND 组合专项）；tsc 0；vite build 成功。
- chrome-use 真实页面：Humans→时间线只剩人类消息(1/2)、Agents→只剩机器人消息(1/2)、互斥、再点取消回全部，均通过。