### PR TITLE
feat: 昵称允许大写并保留显示，唯一性仍不分大小写

### DIFF
--- a/web/src/components/HandleSetup.tsx
+++ b/web/src/components/HandleSetup.tsx
@@ -5,8 +5,8 @@ import { AuthError, ConflictError, ForbiddenError, setHandle, ValidationError } 
 import { useT } from "../i18n/useT";
 import "../i18n/strings/HandleSetup";
 
-// spec：小写字母/数字开头，后随小写字母/数字/._- ，总长 2–32
-const HANDLE_RE = /^[a-z0-9][a-z0-9._-]{1,31}$/;
+// spec：字母/数字开头，后随字母/数字/._- ，总长 2–32；大小写原样保留显示，唯一性由后端按不分大小写判定
+const HANDLE_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]{1,31}$/;
 
 interface Props {
   current: string | null;
@@ -20,7 +20,7 @@ export function HandleSetup({ current, onSaved, onClose }: Props) {
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
 
-  const trimmed = value.trim().toLowerCase();
+  const trimmed = value.trim();
   const formatOk = HANDLE_RE.test(trimmed);
 
   const submit = useCallback(async () => {

--- a/web/src/i18n/strings/HandleSetup.ts
+++ b/web/src/i18n/strings/HandleSetup.ts
@@ -4,7 +4,7 @@ export const HandleSetupStrings: LocaleDict = {
   en: {
     "HandleSetup.title": "Display name",
     "HandleSetup.placeholder": "handle (e.g. jane_doe)",
-    "HandleSetup.formatHint": "lowercase letters/digits/._-, starting with a letter or digit, 2–32 chars",
+    "HandleSetup.formatHint": "letters/digits/._-, starting with a letter or digit, 2–32 chars (case is kept, but uniqueness ignores case)",
     "HandleSetup.save": "save",
     "HandleSetup.saving": "saving…",
     "HandleSetup.cancel": "cancel",
@@ -16,7 +16,7 @@ export const HandleSetupStrings: LocaleDict = {
   zh: {
     "HandleSetup.title": "显示名",
     "HandleSetup.placeholder": "显示名（如 jane_doe）",
-    "HandleSetup.formatHint": "小写字母/数字/._-，字母或数字开头，2–32 位",
+    "HandleSetup.formatHint": "字母/数字/._-，字母或数字开头，2–32 位（保留大小写显示，但唯一性不分大小写）",
     "HandleSetup.save": "保存",
     "HandleSetup.saving": "保存中…",
     "HandleSetup.cancel": "取消",

--- a/worker/migrations/0016_account_profiles_handle_nocase.sql
+++ b/worker/migrations/0016_account_profiles_handle_nocase.sql
@@ -1,0 +1,3 @@
+-- handle 唯一性改为大小写不敏感（Option A：允许大写显示 + 不分大小写唯一，防 race 下 "Evan"/"evan" 并存）。
+-- 现有数据均为小写（旧 HANDLE_RE 限制），无 case 变体冲突，可安全建索引。列级 BINARY UNIQUE 保留，NOCASE 更严格、生效为准。
+CREATE UNIQUE INDEX idx_account_profiles_handle_nocase ON account_profiles(handle COLLATE NOCASE);

--- a/worker/src/handle.ts
+++ b/worker/src/handle.ts
@@ -1,6 +1,6 @@
 import { RESERVED_NAMES } from "@agentparty/shared";
 
-export const HANDLE_RE = /^[a-z0-9][a-z0-9._-]{1,31}$/;
+export const HANDLE_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]{1,31}$/;
 
 export function validateHandleFormat(input: unknown): string | null {
   if (typeof input !== "string") return null;

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -795,7 +795,7 @@ app.put("/api/me/handle", requireBearer, async (c) => {
   const body = (await c.req.json().catch(() => null)) as { handle?: unknown } | null;
   const handle = validateHandleFormat(body?.handle);
   if (handle === null) {
-    return c.json(errorBody("bad_request", "handle must match ^[a-z0-9][a-z0-9._-]{1,31}$"), 400);
+    return c.json(errorBody("bad_request", "handle must match ^[a-zA-Z0-9][a-zA-Z0-9._-]{1,31}$"), 400);
   }
   const conflict = await handleConflict(c.env.DB, handle, id.account);
   if (conflict !== null) {

--- a/worker/test/handle.spec.ts
+++ b/worker/test/handle.spec.ts
@@ -2,12 +2,13 @@ import { describe, it, expect } from "vitest";
 import { validateHandleFormat, HANDLE_RE } from "../src/handle";
 
 describe("validateHandleFormat", () => {
-  it("接受合法 handle", () => {
+  it("接受合法 handle，大小写原样保留（GitHub 式：允许大写显示，唯一性另由 COLLATE NOCASE 判定）", () => {
     expect(validateHandleFormat("leo")).toBe("leo");
     expect(validateHandleFormat("a1._-b")).toBe("a1._-b");
+    expect(validateHandleFormat("Evan")).toBe("Evan");
+    expect(validateHandleFormat("a1._-Bc")).toBe("a1._-Bc");
   });
-  it("拒绝非法：大写/太短/太长/非法首字/非串", () => {
-    expect(validateHandleFormat("Leo")).toBeNull();
+  it("拒绝非法：太短/太长/非法首字/非串", () => {
     expect(validateHandleFormat("a")).toBeNull();
     expect(validateHandleFormat("-abc")).toBeNull();
     expect(validateHandleFormat("a".repeat(33))).toBeNull();

--- a/worker/test/profile.spec.ts
+++ b/worker/test/profile.spec.ts
@@ -52,4 +52,31 @@ describe("PUT /api/me/handle + GET /api/me handle", () => {
     });
     expect(put.status).toBe(409);
   });
+
+  // Option A（GitHub 式，spec 2026-07-08 更新）：handle 允许大写、原样保留显示，但唯一性仍不分
+  // 大小写——"Evan" 已被占用后，另一账号设同一 handle 的大小写变体（"evan"）必须 409，不能并存。
+  it("设置 handle 后原样保留大小写回显，另一账号设其大小写变体时返回 409", async () => {
+    const base = uniq("evan");
+    const handle = base[0].toUpperCase() + base.slice(1); // 如 Evan-xxxxxxxx
+
+    const owner1 = uniq("acct");
+    const { token: token1 } = await seedToken("human", uniq("tok-human"), { owner: owner1 });
+    const put1 = await api("/api/me/handle", token1, {
+      method: "PUT",
+      body: JSON.stringify({ handle }),
+    });
+    expect(put1.status).toBe(200);
+    expect(await put1.json()).toMatchObject({ handle }); // 保留原大小写，不被强制转小写
+
+    const me1 = await api("/api/me", token1);
+    expect(await me1.json()).toMatchObject({ handle });
+
+    const owner2 = uniq("acct");
+    const { token: token2 } = await seedToken("human", uniq("tok-human"), { owner: owner2 });
+    const put2 = await api("/api/me/handle", token2, {
+      method: "PUT",
+      body: JSON.stringify({ handle: handle.toLowerCase() }),
+    });
+    expect(put2.status).toBe(409);
+  });
 });

--- a/worker/test/tokens.spec.ts
+++ b/worker/test/tokens.spec.ts
@@ -88,9 +88,9 @@ describe("tokens", () => {
     expect(res.status).toBe(409);
   });
 
-  // 命名空间大小写未闭合兜底：NAME_RE 允许大写字母、HANDLE_RE 强制全小写，
-  // account_profiles.handle 是大小写敏感 UNIQUE——若反向冲突查询按精确大小写匹配，
-  // 已占 handle "casehandle-xxxx" 时仍能铸出大小写变体的同名 token（look-alike 冒充）。
+  // 命名空间大小写未闭合兜底：NAME_RE 和 HANDLE_RE 现在都允许大写字母（handle 大小写原样保留显示），
+  // 若反向冲突查询按精确大小写匹配 account_profiles.handle，已占 handle "casehandle-xxxx" 时仍能
+  // 铸出大小写变体的同名 token（look-alike 冒充）——这条查询显式带 COLLATE NOCASE（index.ts）挡住。
   it("409 when minting a token whose name is a case-variant of an existing handle", async () => {
     const handle = uniq("casehandle");
     const owner = uniq("acct");


### PR DESCRIPTION
## 需求
昵称(handle)之前强制全小写、且前端自动转小写，无法用 \"Evan\" 这种好看的大小写。改为 **GitHub 式**：允许大写、保留原样显示，但唯一性仍**不分大小写**（\"Evan\" 占了 \"evan\" 就不能再注册，@Evan / @evan 指同一人，不引入 look-alike 冒充）。

## 改动
- `HANDLE_RE` 放开大写 `^[a-zA-Z0-9][a-zA-Z0-9._-]{1,31}$`（`worker/src/handle.ts` + `web/src/components/HandleSetup.tsx`）。
- `HandleSetup` 去掉 `.toLowerCase()`，原样发送/显示；`validateHandleFormat` 本就只 trim 不 lowercase → 后端自动保留大小写。
- **保留** COLLATE NOCASE 冲突检查（唯一性不分大小写）。
- migration `0016`：`account_profiles.handle` 加 **NOCASE 唯一索引** → DB 层也保证大小写不敏感唯一（防 race 下 \"Evan\"/\"evan\" 并存）。现有数据均小写、无冲突，安全。
- 修正原来写死的 \"只能小写\" 报错/提示文案（en/zh）。

## 验证
- worker vitest 210 过、web bun test 77 过、两端 tsc clean、vite build 成功、migration 0016 幂等应用。
- chrome-use + API：设 \"Evan\" → 显示 @Evan、后端存 \"Evan\"；另一账号设 \"evan\"→409、\"EVAN\"→409、\"Karl\"→200（保留大写）。

## 已知小项（非阻塞）
`handleConflict` 查 `account_profiles.handle` 的预检查 SQL 未带 NOCASE，靠 0016 的 NOCASE 唯一索引 + catch→409 兜底（已端到端测到返回 409）。可后续把预检查也加 NOCASE，少依赖错误兜底。