### PR TITLE
feat: 频道列表加分类（全部/我创建的/我加入的）

### DIFF
--- a/web/src/components/ChannelList.tsx
+++ b/web/src/components/ChannelList.tsx
@@ -11,6 +11,20 @@ interface Props {
   onOpen(slug: string): void;
 }
 
+// 分类筛选：全部 / 我创建的（owned）/ 我加入的（member）。只筛 live 段，archived 段独立不受影响。
+type ChannelCategory = "all" | "created" | "joined";
+
+const CATEGORY_LABEL_KEY: Record<ChannelCategory, string> = {
+  all: "Home.channelCategoryAll",
+  created: "Home.channelCategoryCreated",
+  joined: "Home.channelCategoryJoined",
+};
+
+const CATEGORY_EMPTY_KEY: Record<Exclude<ChannelCategory, "all">, string> = {
+  created: "Home.channelCategoryEmptyCreated",
+  joined: "Home.channelCategoryEmptyJoined",
+};
+
 const MAX_DOTS = 4;
 
 // 参与者状态点：每人一个蜡笔点，色 = presence 状态；没人报过 presence 给一颗灰点占位
@@ -69,20 +83,55 @@ function ChannelPill({
 
 export function ChannelList({ channels, active, error, onOpen }: Props) {
   const [showArchived, setShowArchived] = useState(false);
+  const [category, setCategory] = useState<ChannelCategory>("all");
   const t = useT();
   // 默认只显示活跃频道；归档的（联调用完的 temp 等）折叠起来，避免刷屏
   const live = channels?.filter((c) => c.archived_at === null) ?? null;
   const archived = channels?.filter((c) => c.archived_at !== null) ?? [];
+  // 分类只筛 live，archived 段保持独立不受影响。owned/member 缺字段（旧 worker）按 false 处理。
+  const createdCount = live?.filter((c) => c.owned === true).length ?? 0;
+  const joinedCount = live?.filter((c) => c.member === true).length ?? 0;
+  const categoryCount: Record<ChannelCategory, number> = {
+    all: live?.length ?? 0,
+    created: createdCount,
+    joined: joinedCount,
+  };
+  const filteredLive =
+    live === null
+      ? null
+      : live.filter((c) => {
+          if (category === "created") return c.owned === true;
+          if (category === "joined") return c.member === true;
+          return true;
+        });
   return (
     <nav className="side" aria-label="channels">
       <p className="side-label t-mono">{t("Home.channelsLabel")}</p>
       {channels === null && error === null && <p className="side-note t-mono">{t("Home.loading")}</p>}
       {error !== null && <p className="side-note side-note--err t-mono">{error}</p>}
-      {live?.map((c) => (
+      {channels !== null && (
+        <div className="chan-cat-switch" role="group" aria-label="channel categories">
+          {(Object.keys(CATEGORY_LABEL_KEY) as ChannelCategory[]).map((cat) => (
+            <button
+              key={cat}
+              type="button"
+              className={"chan-cat-btn" + (cat === category ? " is-active" : "")}
+              aria-pressed={cat === category}
+              onClick={() => setCategory(cat)}
+            >
+              {t(CATEGORY_LABEL_KEY[cat], { count: categoryCount[cat] })}
+            </button>
+          ))}
+        </div>
+      )}
+      {filteredLive?.map((c) => (
         <ChannelPill key={c.slug} c={c} active={active} onOpen={onOpen} />
       ))}
       {live !== null && live.length === 0 && archived.length === 0 && (
         <p className="side-note t-mono">$ party channel create</p>
+      )}
+      {category !== "all" && filteredLive !== null && filteredLive.length === 0 && live !== null && live.length > 0 && (
+        <p className="side-note t-mono">{t(CATEGORY_EMPTY_KEY[category])}</p>
       )}
       {archived.length > 0 && (
         <>

--- a/web/src/i18n/strings/Home.ts
+++ b/web/src/i18n/strings/Home.ts
@@ -6,12 +6,22 @@ export const HomeStrings: LocaleDict = {
     "Home.channelsLabel": "# channels",
     "Home.noParticipants": "no participants yet",
     "Home.loading": "loading…",
+    "Home.channelCategoryAll": "All ({count})",
+    "Home.channelCategoryCreated": "Created ({count})",
+    "Home.channelCategoryJoined": "Joined ({count})",
+    "Home.channelCategoryEmptyCreated": "No channels created by you yet.",
+    "Home.channelCategoryEmptyJoined": "You haven't joined any channels yet.",
   },
   zh: {
     "Home.archivedToggle": "已归档 ({count})",
     "Home.channelsLabel": "# 频道",
     "Home.noParticipants": "尚无参与者",
     "Home.loading": "加载中…",
+    "Home.channelCategoryAll": "全部 ({count})",
+    "Home.channelCategoryCreated": "我创建的 ({count})",
+    "Home.channelCategoryJoined": "我加入的 ({count})",
+    "Home.channelCategoryEmptyCreated": "我创建的：暂无频道。",
+    "Home.channelCategoryEmptyJoined": "我加入的：暂无频道。",
   },
 };
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -106,6 +106,10 @@ export interface ChannelInfo {
   // 当前身份能否管理本频道（转可见性/踢人/归档）。服务端按 isChannelModerator 算好的布尔，
   // 不含 owner 身份本身。旧 worker 缺此字段 → undefined，前端按「不可管理」处理（不渲染管理控件）。
   can_moderate?: boolean;
+  // 我创建的（owner_account===我）；不回 owner_account 本身。旧 worker 缺此字段 → undefined 按 false 处理。
+  owned?: boolean;
+  // 我加入的（在 channel_members 里）。旧 worker 缺此字段 → undefined 按 false 处理。
+  member?: boolean;
   charter_rev?: number;
   created_at: number;
   archived_at: number | null;

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -233,6 +233,32 @@
 .side-note { font-size: 12px; color: var(--t-dim); margin: 0 0 0 4px; }
 .side-note--err { color: var(--d-red); }
 
+/* ---- 频道分类切换：全部 / 我创建的 / 我加入的 ---- */
+.chan-cat-switch {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 2px;
+  border: 1.5px solid var(--t-faint);
+  border-radius: 8px 5px 9px 4px / 5px 9px 4px 8px;
+}
+.chan-cat-btn {
+  flex: 1;
+  background: none;
+  border: none;
+  padding: 4px 6px;
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--t-dim);
+  cursor: pointer;
+  border-radius: 6px 4px 7px 3px / 4px 6px 3px 5px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.chan-cat-btn:hover { color: var(--t-accent); }
+.chan-cat-btn.is-active { background: var(--d-yellow); color: var(--d-ink); }
+
 .chan-pill {
   border: none;
   width: 100%;

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1804,6 +1804,9 @@ app.get("/api/channels", async (c) => {
       // can_moderate：当前身份能否管理（转可见性/踢人/归档）。不回 owner 身份本身，只回布尔，
       // 前端据此决定渲不渲染可见性切换等管理控件（非 owner 不该看见会 403 的按钮）。
       const canModerate = isChannelModerator(identity, full);
+      // owned/member：分类筛选用的布尔标记，不泄露 owner_account 本身。
+      const owned = full.owner_account != null && full.owner_account === identity.account;
+      const member = memberSlugs.has(full.slug);
       const { created_by, owner_account, ...row } = full;
       let summary: ChannelSummary = { last: null, presence: [] };
       if (includeSummary) {
@@ -1818,7 +1821,7 @@ app.get("/api/channels", async (c) => {
           // do 不可达时列表仍可用，摘要降级为空
         }
       }
-      return { ...row, can_moderate: canModerate, last_message: summary.last, presence: summary.presence };
+      return { ...row, can_moderate: canModerate, owned, member, last_message: summary.last, presence: summary.presence };
     }),
   );
   return c.json({ channels });

--- a/worker/test/channels.spec.ts
+++ b/worker/test/channels.spec.ts
@@ -58,6 +58,58 @@ describe("channels", () => {
     expect(found?.presence).toContainEqual(expect.objectContaining({ name, state: "working" }));
   });
 
+  it("list returns owned/member booleans per identity without leaking owner_account (频道分类)", async () => {
+    const ownerAccount = uniq("owner");
+    const memberAccount = uniq("member");
+    const thirdAccount = uniq("third");
+    const { token: ownerToken } = await seedToken("agent", uniq("tok-owner"), { owner: ownerAccount });
+    const { token: memberToken } = await seedToken("agent", uniq("tok-member"), { owner: memberAccount });
+    const { token: thirdToken } = await seedToken("agent", uniq("tok-third"), { owner: thirdAccount });
+
+    const slug = uniq("ch");
+    const created = await api("/api/channels", ownerToken, {
+      method: "POST",
+      body: JSON.stringify({ slug, kind: "standing" }), // 默认 private
+    });
+    expect(created.status).toBe(201);
+
+    type Listed = { slug: string; owned?: boolean; member?: boolean; owner_account?: string; created_by?: string };
+
+    // 房主自己看：owned=true；未显式加自己进 channel_members 时 member=false（建频道不会自动写会员表）
+    let list = await api("/api/channels", ownerToken);
+    let found = ((await list.json()) as { channels: Listed[] }).channels.find((c) => c.slug === slug);
+    expect(found).toMatchObject({ owned: true, member: false });
+    expect(found?.owner_account).toBeUndefined();
+    expect(found?.created_by).toBeUndefined();
+
+    // 加入前：私有频道对未加入的其它账号不可见（不在列表里）
+    list = await api("/api/channels", memberToken);
+    found = ((await list.json()) as { channels: Listed[] }).channels.find((c) => c.slug === slug);
+    expect(found).toBeUndefined();
+
+    // 房主把另一账号加为 member
+    const add = await api(`/api/channels/${slug}/members/${encodeURIComponent(memberAccount)}`, ownerToken, {
+      method: "PUT",
+    });
+    expect(add.status).toBe(200);
+
+    // 加入后：该账号看到 member=true、owned=false
+    list = await api("/api/channels", memberToken);
+    found = ((await list.json()) as { channels: Listed[] }).channels.find((c) => c.slug === slug);
+    expect(found).toMatchObject({ owned: false, member: true });
+
+    // 公开频道：没建也没加入的第三个账号看到 owned=false && member=false
+    const publicSlug = uniq("pub");
+    const createdPublic = await api("/api/channels", ownerToken, {
+      method: "POST",
+      body: JSON.stringify({ slug: publicSlug, kind: "standing", visibility: "public" }),
+    });
+    expect(createdPublic.status).toBe(201);
+    list = await api("/api/channels", thirdToken);
+    found = ((await list.json()) as { channels: Listed[] }).channels.find((c) => c.slug === publicSlug);
+    expect(found).toMatchObject({ owned: false, member: false });
+  });
+
   it("409 on slug conflict", async () => {
     const { token } = await seedToken("agent");
     const slug = uniq("ch");


### PR DESCRIPTION
## 需求
在侧栏频道列表加分类筛选：**全部 / 我创建的 / 我加入的**。

## 改动
- **后端** `GET /api/channels`：每个频道加 `owned`（owner_account===我的账号）+ `member`（我在 channel_members）两个布尔（在剥离 owner_account 前取值，**不泄露 owner_account 本身**）。后端本就已算 owner_account + memberSlugs，只是没回。
- **前端** `ChannelList`：加分段切换（全部/我创建的/我加入的）+ 计数；**只筛 live 段，archived 段独立不受影响**；空态文案。`ChannelInfo` 加 `owned?`/`member?`。i18n en+zh。CSS 复用 lang-switch 分段胶囊风格。

## 语义
- 房主不算成员（channel_members 不含房主）→ "我创建的" 与 "我加入的" 基本互斥。
- 公开但既没建也没加入的频道 → 只在"全部"。
- owned 严格按账号匹配（不走 legacy-admin 过渡放行）。

## 验证
- worker vitest 210 过（channels.spec 新增房主/加入者/路人三视角用例）、web bun test 77 过、两端 tsc 0、vite build 成功。
- chrome-use：X 建 mychan(owned) + 被加入 otherchan(member)；侧栏 All(8)/Created(1→My Chan)/Joined(1→Other Chan) 筛选正确。

## 备注
分类作用于侧栏 "# CHANNELS" 列表；首页 grid 是另一个视图，本次未加。