### PR TITLE
feat(web): presence 条默认折叠、点击展开全部参与者（人多不挤）

### DIFF
--- a/web/src/components/PresenceBar.tsx
+++ b/web/src/components/PresenceBar.tsx
@@ -162,6 +162,25 @@ function groupRank(group: PresenceGroup, now: number): number {
   return Math.min(...group.items.map((item) => presenceRank(item, now)));
 }
 
+// 展开/折叠偏好：默认折叠（人多时顶部不挤），记住用户上次选择。
+const PRESENCE_EXPANDED_KEY = "ap_presence_expanded";
+
+export function readPresenceExpanded(): boolean {
+  try {
+    return localStorage.getItem(PRESENCE_EXPANDED_KEY) === "1";
+  } catch {
+    return false; // 私有模式等场景 localStorage 不可用时，默认折叠
+  }
+}
+
+function writePresenceExpanded(expanded: boolean): void {
+  try {
+    localStorage.setItem(PRESENCE_EXPANDED_KEY, expanded ? "1" : "0");
+  } catch {
+    // 写入失败不阻断本次切换，只是刷新/换标签页后会回落到默认折叠
+  }
+}
+
 export function PresenceBar({
   presence,
   participants,
@@ -181,6 +200,9 @@ export function PresenceBar({
     return () => clearInterval(t);
   }, []);
   const now = Date.now();
+
+  // 默认折叠，展开态记 localStorage（记住偏好）。
+  const [expanded, setExpanded] = useState(() => readPresenceExpanded());
 
   // 在线 sender 带 owner；离线/最近 presence 带 account。两者都归到同一账号块。
   const byName = new Map(participants.map((p) => [p.name, p]));
@@ -243,13 +265,21 @@ export function PresenceBar({
     return a.label.localeCompare(b.label);
   });
   const [hoveredGroup, setHoveredGroup] = useState<{ key: string; left: number; top: number; width: number } | null>(null);
-  const visibleGroups = sortedGroups.slice(0, 4);
-  const overflowGroups = sortedGroups.slice(4);
+  function toggleExpanded() {
+    setHoveredGroup(null); // 折叠会把 chip 移出 DOM，先关掉可能悬着的 popover
+    setExpanded((prev) => {
+      const next = !prev;
+      writePresenceExpanded(next);
+      return next;
+    });
+  }
   // 顶部计数按账号折叠后的人数（非会话行数）——离线会话已在 buildGroups 里按 account 归并。
   const { live: liveGroups, total: totalGroups } = countLiveGroups(sortedGroups);
   const blockedCount = items.filter((it) => it.state === "blocked").length;
   const duplicateCount = items.filter((it) => it.connectionCount > 1).length;
-  const activePopoverGroup = hoveredGroup === null ? null : sortedGroups.find((group) => group.key === hoveredGroup.key) ?? null;
+  // 折叠态下 chip 不在 DOM 里，popover 也不该跟着冒出来。
+  const activePopoverGroup =
+    !expanded || hoveredGroup === null ? null : sortedGroups.find((group) => group.key === hoveredGroup.key) ?? null;
 
   function showGroupPopover(group: PresenceGroup, rect: DOMRect) {
     const margin = 10;
@@ -429,26 +459,29 @@ export function PresenceBar({
   }
 
   return (
-    <div className="presence-bar">
+    <div className={`presence-bar${expanded ? "" : " presence-bar--collapsed"}`}>
       <div className="presence-meta" aria-label="channel presence summary">
         {isPublic && <span className="d-hl public-badge">PUBLIC</span>}
         {party && <span className="d-hl party-badge">PARTY</span>}
-        <span className="t-mono presence-summary">
-          {liveGroups}/{totalGroups} live
-        </span>
+        <button
+          type="button"
+          className="presence-toggle"
+          aria-expanded={expanded}
+          aria-label={t(expanded ? "PresenceBar.collapse" : "PresenceBar.expand")}
+          onClick={toggleExpanded}
+        >
+          <span className="t-mono presence-summary">
+            {liveGroups}/{totalGroups} live
+          </span>
+          <span className="presence-toggle-arrow" aria-hidden="true">{expanded ? "▾" : "▸"}</span>
+        </button>
         {blockedCount > 0 && <span className="t-mono presence-alert">{blockedCount} blocked</span>}
         {duplicateCount > 0 && <span className="t-mono presence-alert presence-alert--duplicate">{duplicateCount} duplicate</span>}
       </div>
-      <div className="presence-strip" aria-label="participant groups by owner">
-        {visibleGroups.map((group) => renderGroup(group, "compact"))}
-      </div>
-      {overflowGroups.length > 0 && (
-        <details className="presence-more">
-          <summary className="t-mono" title={`${overflowGroups.length} more owners`}>
-            +{overflowGroups.length}
-          </summary>
-          <div className="presence-more-list">{overflowGroups.map((group) => renderGroup(group, "full"))}</div>
-        </details>
+      {expanded && (
+        <div className="presence-strip" aria-label="participant groups by owner">
+          {sortedGroups.map((group) => renderGroup(group, "compact"))}
+        </div>
       )}
       {items.length === 0 && (
         <span className="t-mono presence-empty" role="status" aria-live="polite">

--- a/web/src/i18n/strings/PresenceBar.ts
+++ b/web/src/i18n/strings/PresenceBar.ts
@@ -4,10 +4,14 @@ export const PresenceBarStrings: LocaleDict = {
   en: {
     "PresenceBar.kickTitle": "Kick {name}",
     "PresenceBar.kick": "kick",
+    "PresenceBar.expand": "expand participants",
+    "PresenceBar.collapse": "collapse",
   },
   zh: {
     "PresenceBar.kickTitle": "踢出 {name}",
     "PresenceBar.kick": "踢出",
+    "PresenceBar.expand": "展开参与者",
+    "PresenceBar.collapse": "收起",
   },
 };
 

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -653,6 +653,10 @@
   padding: 4px 4px 8px;
   flex: none;
 }
+/* 折叠态（默认）：没有 chip 条，收紧一点垂直空间 */
+.presence-bar--collapsed {
+  padding-bottom: 4px;
+}
 .presence-meta,
 .presence-strip {
   display: flex;
@@ -811,6 +815,43 @@
   font-size: 11px;
   color: var(--t-dim);
   white-space: nowrap;
+}
+/* 展开/折叠 toggle：计数本身就是按钮，旁边一个箭头，涂鸦风格的轻量小 pill */
+.presence-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  flex: none;
+  padding: 2px 8px 3px;
+  border: 1.5px solid var(--t-faint);
+  border-radius: 999px 8px 999px 8px / 8px 999px 8px 999px;
+  background: var(--t-panel2);
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 0.12s ease, background 0.12s ease, border-color 0.12s ease;
+}
+.presence-toggle:hover {
+  border-color: var(--d-ink);
+  background: var(--d-yellow);
+  color: var(--d-ink);
+  transform: translate(-1px, -1px) rotate(-1deg);
+}
+.presence-toggle:focus-visible {
+  outline: 2px solid var(--d-ink);
+  outline-offset: 2px;
+}
+.presence-toggle[aria-expanded="true"] {
+  border-color: var(--d-ink);
+  background: var(--t-panel);
+}
+.presence-toggle .presence-summary {
+  color: inherit;
+}
+.presence-toggle-arrow {
+  font-size: 10px;
+  line-height: 1;
+  color: inherit;
 }
 .presence-alert {
   padding: 1px 6px;
@@ -1008,46 +1049,6 @@
   background: var(--d-green-soft);
 }
 .presence-ts { font-size: 10px; font-weight: 400; color: var(--t-dim); }
-.presence-more {
-  position: relative;
-  flex: none;
-}
-.presence-more > summary {
-  display: inline-flex;
-  align-items: center;
-  min-height: 30px;
-  padding: 2px 8px;
-  border: 1.5px solid var(--t-faint);
-  border-radius: 8px;
-  color: var(--t-muted);
-  background: var(--t-panel2);
-  cursor: pointer;
-  user-select: none;
-  white-space: nowrap;
-}
-.presence-more > summary::-webkit-details-marker { display: none; }
-.presence-more[open] > summary {
-  border-color: var(--d-ink);
-  background: var(--d-yellow);
-  color: var(--d-ink);
-}
-.presence-more-list {
-  position: absolute;
-  z-index: 20;
-  right: 0;
-  top: calc(100% + 8px);
-  display: grid;
-  grid-template-columns: minmax(0, 1fr);
-  gap: 8px;
-  width: min(520px, calc(100vw - 48px));
-  max-height: 44vh;
-  overflow: auto;
-  padding: 10px;
-  border: 2px solid var(--d-ink);
-  border-radius: 10px 8px 12px 7px / 8px 12px 7px 10px;
-  background: var(--t-panel);
-  box-shadow: 4px 5px 0 var(--d-shadow);
-}
 .presence-kick {
   flex: none;
   min-height: 22px;
@@ -1114,6 +1115,9 @@
   font-size: 11px;
   color: var(--t-dim);
   white-space: nowrap;
+  /* presence-strip 折叠时中间列少了 chip，conn 会落进那个 1fr 空列——
+     强制贴右边，不然折叠态看着像挤在中间。 */
+  justify-self: end;
 }
 .conn[data-s="open"] { color: var(--d-green); }
 .conn[data-s="reconnecting"] { color: var(--d-red); }
@@ -3203,7 +3207,11 @@
     gap: 6px;
     padding: 0 2px 2px;
   }
-  .presence-meta { display: none; }
+  /* 小屏也要留 toggle（chip 条折叠时全靠它展开），只是不再强制隐藏 meta —— 折叠态默认只占一行 */
+  .presence-meta {
+    flex-wrap: wrap;
+    gap: 5px;
+  }
   .presence-strip {
     grid-column: 1 / -1;
     flex-wrap: wrap;
@@ -3211,11 +3219,6 @@
     overflow-x: hidden;
     overflow-y: auto;
     padding: 1px 2px 3px;
-  }
-  .presence-more-list {
-    right: auto;
-    left: 0;
-    width: calc(100vw - 32px);
   }
   .presence-group {
     flex: 1 1 100%;


### PR DESCRIPTION
承接已合并的 #57（presence 按人数计数）：顶部在线人数条人多时一排 chip 很挤，改为默认折叠。

## 改动（纯前端）
- `PresenceBar.tsx`：加 `expanded` state（默认折叠，localStorage `ap_presence_expanded` 记住偏好）+ `.presence-toggle` 按钮（aria-expanded + i18n aria-label + ▸/▾）；折叠时只显紧凑在线人数、不渲染 chip strip；展开时渲染**全部**参与者 chip（去掉旧的"前4+溢出"）；popover 折叠态不触发。
- 顺带修：折叠后 .conn 布局漂移（justify-self:end）；移动端 `.presence-meta` 原 display:none 会致折叠后整条消失且无法展开→改为可见。
- i18n `PresenceBar.expand`/`collapse`（en/zh）。

## 验证
- bun test 96 过、tsc 0、vite build 成功。
- chrome-use：默认折叠只显 "1/5 live ▸"；点开显全部 5 个 chip + ▾；刷新记住展开态。

（说明：此改动原先误推到已 merge 的 #57 分支上、成了游离提交；现从最新 main cherry-pick 到干净分支重开 PR。）