### PR TITLE
feat(channel): 支持频道元数据权限配置

### DIFF
--- a/cli/src/commands/channel.ts
+++ b/cli/src/commands/channel.ts
@@ -1,5 +1,5 @@
 // party channel create|list|archive|reset-guard
-import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
+import { isHelpArg, parseArgs, str, strArray, unknownFlagError, valueFlagError } from "../args";
 import { resolveChannel } from "../config";
 import { resolveAuth } from "../oidc-cli";
 import {
@@ -9,6 +9,7 @@ import {
   createChannel,
   handleRestError,
   inviteProjectAgent,
+  fetchChannelPerms,
   kickParticipant,
   listChannelMembers,
   listChannelRoles,
@@ -18,18 +19,45 @@ import {
   resetGuard,
   revokeJoinLink,
   setChannelRole,
+  setChannelPerms,
   setChannelVisibility,
   setCompletionGate,
   setLoopGuard,
   setWorkflowGuard,
+  type AgentChannelPermPolicy,
+  type ChannelPerms,
+  type ChannelPermsUpdate,
+  type HumanChannelListPolicy,
+  type HumanChannelPermPolicy,
 } from "../rest";
 import { isName, isSlug } from "../validation";
 
-const CHANNEL_FLAGS = ["title", "temp", "party", "public", "policy", "confirm", "expires", "max-uses", "remove", "responsibility"];
+const CHANNEL_FLAGS = [
+  "title",
+  "temp",
+  "party",
+  "public",
+  "policy",
+  "confirm",
+  "expires",
+  "max-uses",
+  "remove",
+  "responsibility",
+  "charter-write",
+  "charter-write-agents",
+  "agent",
+  "members-list",
+  "members-list-agents",
+  "members-agent",
+  "json",
+];
 const COLLAB_ROLES = ["host", "worker", "reviewer", "observer"] as const;
 const COMPLETION_GATES = ["reviewer", "off"] as const;
 const COMPLETION_REVIEW_POLICIES = ["sender", "owner"] as const;
 const VISIBILITIES = ["public", "private"] as const;
+const HUMAN_PERM_POLICIES = ["owner", "moderators", "members"] as const;
+const HUMAN_LIST_POLICIES = ["off", "owner", "moderators", "members"] as const;
+const AGENT_PERM_POLICIES = ["off", "moderators", "members", "allowlist"] as const;
 const HELP = `usage: party channel create <slug> [--title t] [--temp] [--party] [--public]
        party channel list
        party channel archive [slug]                 archive, kick live agents, keep history
@@ -42,6 +70,13 @@ const HELP = `usage: party channel create <slug> [--title t] [--temp] [--party] 
        party channel workflow-guard off|<limit> [slug]
        party channel visibility <slug> public|private [--confirm]
        party channel members <slug>
+       party channel perms <slug> [--json]
+       party channel perms <slug> [--charter-write owner|moderators|members]
+                                  [--charter-write-agents off|moderators|members|allowlist]
+                                  [--agent name ...]
+                                  [--members-list off|owner|moderators|members]
+                                  [--members-list-agents off|moderators|members|allowlist]
+                                  [--members-agent name ...]
        party channel join-link <slug> [--expires 7d] [--max-uses N]
        party channel join-link revoke <slug> <code>
        party channel leave <slug>
@@ -65,6 +100,18 @@ Options:
   --remove    revoke the channel-scoped token and remove membership when kicking
   --expires d join-link expiry like 7d, 12h, 30m, 60s
   --max-uses n join-link redemption limit
+  --json      output channel permission policy as JSON
+  --charter-write p
+              human charter writers: owner, moderators, or members
+  --charter-write-agents p
+              agent charter writers: off, moderators, members, or allowlist
+  --agent n   repeatable allowlist entry for --charter-write-agents allowlist
+  --members-list p
+              human member-list readers: off, owner, moderators, or members
+  --members-list-agents p
+              agent member-list readers: off, moderators, members, or allowlist
+  --members-agent n
+              repeatable allowlist entry for --members-list-agents allowlist
   --responsibility text, -m text
               structured responsibility shown in web division board and @ suggestions`;
 
@@ -94,13 +141,36 @@ function parseProfileRef(input: string | undefined): { owner: string; handle: st
   return { owner, handle };
 }
 
+function printPerms(slug: string, perms: ChannelPerms, json: boolean): void {
+  if (json) {
+    console.log(JSON.stringify({ channel_slug: slug, permissions: perms }, null, 2));
+    return;
+  }
+  console.log(`channel ${slug} permissions`);
+  console.log(`charter_write\t${perms.charter_write}`);
+  console.log(`charter_write_agents\t${perms.charter_write_agents}\t${perms.charter_write_agent_allowlist.join(",")}`);
+  console.log(`members_list\t${perms.members_list}`);
+  console.log(`members_list_agents\t${perms.members_list_agents}\t${perms.members_list_agent_allowlist.join(",")}`);
+}
+
+function repeatedNames(value: string[] | undefined, label: string): string[] | null | undefined {
+  if (value === undefined) return undefined;
+  const names = [...new Set(value.map((item) => item.trim()).filter(Boolean))].sort();
+  if (names.some((name) => !isName(name))) {
+    console.error(`${label} must match [a-zA-Z0-9][a-zA-Z0-9._-]{0,63}`);
+    return null;
+  }
+  return names;
+}
+
 export async function run(argv: string[]): Promise<number> {
   if (isHelpArg(argv, { allowHelpPositional: true })) {
     console.log(HELP);
     return 0;
   }
   const { positionals, flags } = parseArgs(argv, {
-    booleans: ["temp", "party", "public", "confirm", "remove"],
+    booleans: ["temp", "party", "public", "confirm", "remove", "json"],
+    repeatable: ["agent", "members-agent"],
     aliases: { m: "responsibility" },
   });
   const unknown = unknownFlagError(flags, CHANNEL_FLAGS);
@@ -108,7 +178,11 @@ export async function run(argv: string[]): Promise<number> {
     console.error(unknown);
     return 1;
   }
-  const flagError = valueFlagError(flags, ["title", "policy", "expires", "max-uses", "responsibility"]);
+  const flagError = valueFlagError(
+    flags,
+    ["title", "policy", "expires", "max-uses", "responsibility", "charter-write", "charter-write-agents", "members-list", "members-list-agents"],
+    ["agent", "members-agent"],
+  );
   if (flagError !== null) {
     console.error(flagError);
     return 1;
@@ -349,6 +423,55 @@ export async function run(argv: string[]): Promise<number> {
         }
         return 0;
       }
+      case "perms": {
+        const slug = resolveChannel(positionals[1]);
+        if (!slug) {
+          console.error("usage: party channel perms <slug> [--json] [--charter-write owner|moderators|members] [--charter-write-agents off|moderators|members|allowlist] [--agent name]");
+          return 1;
+        }
+        if (!isSlug(slug)) {
+          console.error("slug must match [a-z0-9][a-z0-9-]{0,63}");
+          return 1;
+        }
+        const charterWrite = str(flags["charter-write"]);
+        const charterWriteAgents = str(flags["charter-write-agents"]);
+        const membersList = str(flags["members-list"]);
+        const membersListAgents = str(flags["members-list-agents"]);
+        if (charterWrite !== undefined && !HUMAN_PERM_POLICIES.includes(charterWrite as HumanChannelPermPolicy)) {
+          console.error("--charter-write must be owner, moderators, or members");
+          return 1;
+        }
+        if (charterWriteAgents !== undefined && !AGENT_PERM_POLICIES.includes(charterWriteAgents as AgentChannelPermPolicy)) {
+          console.error("--charter-write-agents must be off, moderators, members, or allowlist");
+          return 1;
+        }
+        if (membersList !== undefined && !HUMAN_LIST_POLICIES.includes(membersList as HumanChannelListPolicy)) {
+          console.error("--members-list must be off, owner, moderators, or members");
+          return 1;
+        }
+        if (membersListAgents !== undefined && !AGENT_PERM_POLICIES.includes(membersListAgents as AgentChannelPermPolicy)) {
+          console.error("--members-list-agents must be off, moderators, members, or allowlist");
+          return 1;
+        }
+        const charterAgents = repeatedNames(strArray(flags.agent), "--agent");
+        if (charterAgents === null) return 1;
+        const membersAgents = repeatedNames(strArray(flags["members-agent"]), "--members-agent");
+        if (membersAgents === null) return 1;
+        const update: ChannelPermsUpdate = {
+          ...(charterWrite === undefined ? {} : { charter_write: charterWrite as HumanChannelPermPolicy }),
+          ...(charterWriteAgents === undefined ? {} : { charter_write_agents: charterWriteAgents as AgentChannelPermPolicy }),
+          ...(charterAgents === undefined ? {} : { charter_write_agent_allowlist: charterAgents }),
+          ...(membersList === undefined ? {} : { members_list: membersList as HumanChannelListPolicy }),
+          ...(membersListAgents === undefined ? {} : { members_list_agents: membersListAgents as AgentChannelPermPolicy }),
+          ...(membersAgents === undefined ? {} : { members_list_agent_allowlist: membersAgents }),
+        };
+        const changed = Object.keys(update).length > 0;
+        const perms = changed
+          ? await setChannelPerms(cfg.server, cfg.token, slug, update)
+          : await fetchChannelPerms(cfg.server, cfg.token, slug);
+        printPerms(slug, perms, flags.json === true);
+        return 0;
+      }
       case "join-link": {
         const actionOrSlug = positionals[1];
         if (actionOrSlug === "revoke") {
@@ -473,7 +596,7 @@ export async function run(argv: string[]): Promise<number> {
         return 1;
       }
       default:
-        console.error("usage: party channel create|list|archive|reset-guard|kick|invite-agent|gate|visibility|members|join-link|leave|role");
+        console.error("usage: party channel create|list|archive|reset-guard|kick|invite-agent|gate|visibility|members|perms|join-link|leave|role");
         return 1;
     }
   } catch (e) {

--- a/cli/src/rest.ts
+++ b/cli/src/rest.ts
@@ -62,7 +62,30 @@ export interface ChannelCharter {
   charter_rev: number;
   updated_at: number | null;
   updated_by: string | null;
+  permissions?: ChannelPerms;
 }
+
+export type HumanChannelPermPolicy = "owner" | "moderators" | "members";
+export type HumanChannelListPolicy = HumanChannelPermPolicy | "off";
+export type AgentChannelPermPolicy = "off" | "moderators" | "members" | "allowlist";
+
+export interface ChannelPerms {
+  charter_write: HumanChannelPermPolicy;
+  charter_write_agents: AgentChannelPermPolicy;
+  charter_write_agent_allowlist: string[];
+  members_list: HumanChannelListPolicy;
+  members_list_agents: AgentChannelPermPolicy;
+  members_list_agent_allowlist: string[];
+}
+
+export type ChannelPermsUpdate = Partial<{
+  charter_write: HumanChannelPermPolicy;
+  charter_write_agents: AgentChannelPermPolicy;
+  charter_write_agent_allowlist: string[];
+  members_list: HumanChannelListPolicy;
+  members_list_agents: AgentChannelPermPolicy;
+  members_list_agent_allowlist: string[];
+}>;
 
 export interface WebhookInfo {
   name: string;
@@ -424,6 +447,29 @@ export async function setChannelCharter(
     headers: bearerJson(token),
     body: JSON.stringify(body),
   })) as ChannelCharter;
+}
+
+export async function fetchChannelPerms(server: string, token: string, slug: string): Promise<ChannelPerms> {
+  const body = (await req(server, `/api/channels/${encodeURIComponent(slug)}/perms`, {
+    headers: bearerJson(token),
+  })) as { permissions?: ChannelPerms };
+  if (!body.permissions) throw new Error("server did not return channel permissions");
+  return body.permissions;
+}
+
+export async function setChannelPerms(
+  server: string,
+  token: string,
+  slug: string,
+  update: ChannelPermsUpdate,
+): Promise<ChannelPerms> {
+  const body = (await req(server, `/api/channels/${encodeURIComponent(slug)}/perms`, {
+    method: "PUT",
+    headers: bearerJson(token),
+    body: JSON.stringify(update),
+  })) as { permissions?: ChannelPerms };
+  if (!body.permissions) throw new Error("server did not return channel permissions");
+  return body.permissions;
 }
 
 export async function createChannel(

--- a/cli/test/m3.test.ts
+++ b/cli/test/m3.test.ts
@@ -2680,6 +2680,76 @@ describe("party channel guard config", () => {
   });
 });
 
+describe("party channel perms", () => {
+  test("prints current channel permissions as json", async () => {
+    mock = startRestMock();
+    writeCfg(mock.url);
+
+    const r = await runCli(["channel", "perms", "ops", "--json"]);
+    expect(r.code).toBe(0);
+    expect(JSON.parse(r.stdout)).toMatchObject({
+      channel_slug: "ops",
+      permissions: {
+        charter_write: "moderators",
+        charter_write_agents: "moderators",
+        members_list: "members",
+        members_list_agents: "members",
+      },
+    });
+    expect(reqsOf(mock, "GET", "/api/channels/ops/perms")).toHaveLength(1);
+  });
+
+  test("updates charter and member-list policies with separate agent allowlists", async () => {
+    mock = startRestMock();
+    writeCfg(mock.url);
+
+    const r = await runCli([
+      "channel",
+      "perms",
+      "ops",
+      "--charter-write",
+      "members",
+      "--charter-write-agents",
+      "allowlist",
+      "--agent",
+      "leo-codex",
+      "--agent",
+      "qa.bot",
+      "--members-list",
+      "moderators",
+      "--members-list-agents",
+      "allowlist",
+      "--members-agent",
+      "auditor",
+    ]);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain("charter_write\tmembers");
+    expect(reqsOf(mock, "PUT", "/api/channels/ops/perms")[0]!.body).toEqual({
+      charter_write: "members",
+      charter_write_agents: "allowlist",
+      charter_write_agent_allowlist: ["leo-codex", "qa.bot"],
+      members_list: "moderators",
+      members_list_agents: "allowlist",
+      members_list_agent_allowlist: ["auditor"],
+    });
+  });
+
+  test("validates policies and allowlist names locally", async () => {
+    mock = startRestMock();
+    writeCfg(mock.url);
+    for (const args of [
+      ["channel", "perms", "ops", "--charter-write", "off"],
+      ["channel", "perms", "ops", "--charter-write-agents", "owners"],
+      ["channel", "perms", "ops", "--members-list", "public"],
+      ["channel", "perms", "ops", "--agent", ":bad"],
+    ]) {
+      const r = await runCli(args);
+      expect(r.code).toBe(1);
+    }
+    expect(mock.requests.length).toBe(0);
+  });
+});
+
 
 describe("party channel role", () => {
   test("role set/list/unset 调用频道角色 API", async () => {

--- a/cli/test/rest-mock.ts
+++ b/cli/test/rest-mock.ts
@@ -21,6 +21,14 @@ export function startRestMock(handler?: RestHandler): RestMock {
   // 有状态 webhook 存储：add 后 list 能查到
   const webhooks = new Map<string, { name: string; url: string; filter: string }[]>();
   const roles = new Map<string, { name: string; role: string; responsibility: string | null; assigned_by: string; assigned_at: number }[]>();
+  const perms = new Map<string, {
+    charter_write: string;
+    charter_write_agents: string;
+    charter_write_agent_allowlist: string[];
+    members_list: string;
+    members_list_agents: string;
+    members_list_agent_allowlist: string[];
+  }>();
   const joinLinks = new Map<
     string,
     { code: string; channel_slug: string; created_by: string; created_at: number; expires_at: number | null; max_uses: number | null; uses: number; revoked_at: number | null }[]
@@ -209,6 +217,26 @@ export function startRestMock(handler?: RestHandler): RestMock {
         }
         if (r.method === "DELETE" && memberMatch[2]) {
           return Response.json({ ok: true });
+        }
+      }
+      const permsMatch = r.path.match(/^\/api\/channels\/([^/]+)\/perms$/);
+      if (permsMatch) {
+        const slug = decodeURIComponent(permsMatch[1]!);
+        const current = perms.get(slug) ?? {
+          charter_write: "moderators",
+          charter_write_agents: "moderators",
+          charter_write_agent_allowlist: [],
+          members_list: "members",
+          members_list_agents: "members",
+          members_list_agent_allowlist: [],
+        };
+        if (r.method === "GET") {
+          return Response.json({ permissions: current });
+        }
+        if (r.method === "PUT") {
+          const next = { ...current, ...(body as Record<string, unknown>) };
+          perms.set(slug, next as typeof current);
+          return Response.json({ permissions: next });
         }
       }
       if (r.method === "GET" && /^\/api\/channels\/[^/]+\/messages$/.test(r.path)) {

--- a/docs/superpowers/specs/2026-07-09-channel-permissions-design.html
+++ b/docs/superpowers/specs/2026-07-09-channel-permissions-design.html
@@ -1,0 +1,124 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>AgentParty Channel Permissions</title>
+  <style>
+    :root {
+      --fg: #17202a;
+      --muted: #667085;
+      --accent: #2563eb;
+      --border: #d0d5dd;
+      --bg: #ffffff;
+      --soft: #f8fafc;
+      --code: #eef2ff;
+    }
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--fg);
+      font: 15px/1.6 -apple-system, BlinkMacSystemFont, "PingFang SC", "Microsoft YaHei", sans-serif;
+    }
+    main {
+      max-width: 920px;
+      margin: 0 auto;
+      padding: 40px 24px 72px;
+    }
+    header { margin-bottom: 28px; }
+    h1, h2 { line-height: 1.2; margin: 0 0 12px; }
+    h1 { font-size: 30px; }
+    h2 { font-size: 20px; margin-top: 32px; }
+    p { margin: 0 0 14px; }
+    code {
+      background: var(--code);
+      border-radius: 4px;
+      padding: 1px 5px;
+      font-family: "SFMono-Regular", ui-monospace, Menlo, Consolas, monospace;
+      font-size: 0.92em;
+    }
+    pre {
+      margin: 12px 0 0;
+      padding: 14px 16px;
+      overflow-x: auto;
+      background: #101828;
+      color: #f9fafb;
+      border-radius: 6px;
+    }
+    pre code { background: transparent; color: inherit; padding: 0; }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 12px 0 20px;
+      font-size: 14px;
+    }
+    th, td {
+      border: 1px solid var(--border);
+      padding: 9px 10px;
+      text-align: left;
+      vertical-align: top;
+    }
+    th { background: var(--soft); }
+    aside {
+      border-left: 3px solid var(--accent);
+      background: var(--soft);
+      padding: 12px 14px;
+      margin: 18px 0;
+      color: var(--muted);
+    }
+  </style>
+</head>
+<body>
+<main>
+  <header>
+    <h1>AgentParty Channel Permissions</h1>
+    <p>Issue #71 introduces configurable channel metadata permissions for charter writes and member-list visibility. The model separates human and agent decisions so a channel can keep humans open while restricting autonomous agents.</p>
+  </header>
+
+  <section>
+    <h2>Policy Surface</h2>
+    <table>
+      <thead>
+        <tr><th>Operation</th><th>Human policy</th><th>Agent policy</th><th>Default</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Charter write</td>
+          <td><code>owner</code>, <code>moderators</code>, <code>members</code></td>
+          <td><code>off</code>, <code>moderators</code>, <code>members</code>, <code>allowlist</code></td>
+          <td><code>moderators</code> for both axes; agent host soft-role remains compatible under <code>moderators</code>.</td>
+        </tr>
+        <tr>
+          <td>Member list</td>
+          <td><code>off</code>, <code>owner</code>, <code>moderators</code>, <code>members</code></td>
+          <td><code>off</code>, <code>moderators</code>, <code>members</code>, <code>allowlist</code></td>
+          <td><code>members</code> for both axes, matching the old moderator-or-member behavior.</td>
+        </tr>
+      </tbody>
+    </table>
+    <aside>Only channel moderators can change permission policies. Host soft-role agents can keep editing the charter by default, but they cannot change the policy itself.</aside>
+  </section>
+
+  <section>
+    <h2>CLI</h2>
+    <pre><code>party channel perms seamail --json
+party channel perms seamail --charter-write members
+party channel perms seamail --charter-write-agents off
+party channel perms seamail --charter-write-agents allowlist --agent leo-codex
+party channel perms seamail --members-list moderators
+party channel perms seamail --members-list-agents allowlist --members-agent auditor</code></pre>
+  </section>
+
+  <section>
+    <h2>REST</h2>
+    <table>
+      <tbody>
+        <tr><th><code>GET /api/channels/:slug/perms</code></th><td>Returns <code>{ permissions }</code> for any identity that can read the channel.</td></tr>
+        <tr><th><code>PUT /api/channels/:slug/perms</code></th><td>Accepts partial policy updates and returns the normalized <code>{ permissions }</code>. Requires channel moderator rights.</td></tr>
+        <tr><th><code>GET /api/channels/:slug/charter</code></th><td>Also includes <code>permissions</code> so <code>party charter --json</code> can surface the current policy without an extra call.</td></tr>
+      </tbody>
+    </table>
+  </section>
+</main>
+</body>
+</html>

--- a/worker/migrations/0019_channel_perms.sql
+++ b/worker/migrations/0019_channel_perms.sql
@@ -1,0 +1,7 @@
+-- Configurable channel metadata permissions (#71).
+ALTER TABLE channels ADD COLUMN charter_write_policy TEXT NOT NULL DEFAULT 'moderators';
+ALTER TABLE channels ADD COLUMN charter_write_agents TEXT NOT NULL DEFAULT 'moderators';
+ALTER TABLE channels ADD COLUMN charter_write_agent_allowlist_json TEXT NOT NULL DEFAULT '[]';
+ALTER TABLE channels ADD COLUMN members_list_policy TEXT NOT NULL DEFAULT 'members';
+ALTER TABLE channels ADD COLUMN members_list_agents TEXT NOT NULL DEFAULT 'members';
+ALTER TABLE channels ADD COLUMN members_list_agent_allowlist_json TEXT NOT NULL DEFAULT '[]';

--- a/worker/scripts/verify-remote-schema.mjs
+++ b/worker/scripts/verify-remote-schema.mjs
@@ -4,7 +4,23 @@ const database = process.env.AGENTPARTY_D1_DATABASE ?? "agentparty";
 const wranglerConfig = process.env.AGENTPARTY_WRANGLER_CONFIG;
 
 const required = {
-  channels: ["id", "slug", "title", "topic", "kind", "mode", "created_by", "created_at", "archived_at"],
+  channels: [
+    "id",
+    "slug",
+    "title",
+    "topic",
+    "kind",
+    "mode",
+    "created_by",
+    "created_at",
+    "archived_at",
+    "charter_write_policy",
+    "charter_write_agents",
+    "charter_write_agent_allowlist_json",
+    "members_list_policy",
+    "members_list_agents",
+    "members_list_agent_allowlist_json",
+  ],
   tokens: ["id", "hash", "name", "role", "owner", "created_at", "revoked_at"],
   account_profiles: [
     "account",

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -71,6 +71,20 @@ const COMPLETION_REVIEW_POLICIES: readonly string[] = ["sender", "owner"] satisf
 const COLLAB_ROLES: readonly string[] = ["host", "worker", "reviewer", "observer"] satisfies CollaborationRole[];
 const TASK_STATES: readonly string[] = ["triage", "backlog", "assigned", "in_progress", "needs_review", "done", "blocked"] satisfies TaskState[];
 const TASK_ASSIGNEE_KINDS: readonly string[] = ["agent", "human", "squad"] satisfies TaskAssigneeKind[];
+const HUMAN_METADATA_POLICIES = ["owner", "moderators", "members"] as const;
+const AGENT_METADATA_POLICIES = ["off", "moderators", "members", "allowlist"] as const;
+
+type HumanMetadataPolicy = (typeof HUMAN_METADATA_POLICIES)[number];
+type AgentMetadataPolicy = (typeof AGENT_METADATA_POLICIES)[number];
+
+interface ChannelPerms {
+  charter_write: HumanMetadataPolicy;
+  charter_write_agents: AgentMetadataPolicy;
+  charter_write_agent_allowlist: string[];
+  members_list: HumanMetadataPolicy | "off";
+  members_list_agents: AgentMetadataPolicy;
+  members_list_agent_allowlist: string[];
+}
 
 function isDurableObjectReset(error: unknown): boolean {
   if (typeof error !== "object" || error === null) return false;
@@ -879,7 +893,9 @@ async function loadChannel(db: D1Database, slug: string) {
       `SELECT slug, kind, mode, archived_at, created_by, visibility, owner_account,
               completion_gate, completion_review_policy, loop_guard_enabled, loop_guard_limit,
               workflow_guard_enabled, workflow_guard_limit,
-              charter, charter_rev, charter_updated_at, charter_updated_by
+              charter, charter_rev, charter_updated_at, charter_updated_by,
+              charter_write_policy, charter_write_agents, charter_write_agent_allowlist_json,
+              members_list_policy, members_list_agents, members_list_agent_allowlist_json
          FROM channels WHERE slug = ?`,
     )
     .bind(slug)
@@ -901,6 +917,12 @@ async function loadChannel(db: D1Database, slug: string) {
       charter_rev: number;
       charter_updated_at: number | null;
       charter_updated_by: string | null;
+      charter_write_policy: string;
+      charter_write_agents: string;
+      charter_write_agent_allowlist_json: string;
+      members_list_policy: string;
+      members_list_agents: string;
+      members_list_agent_allowlist_json: string;
     }>();
 }
 
@@ -1010,10 +1032,126 @@ async function canConfigureChannel(db: D1Database, identity: TokenIdentity, chan
   return (await loadAssignedRole(db, channel.slug, identity.name)) === "host";
 }
 
+function parseNameListJson(value: string | null | undefined): string[] {
+  try {
+    const parsed = JSON.parse(value ?? "[]");
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((item): item is string => typeof item === "string" && NAME_RE.test(item));
+  } catch {
+    return [];
+  }
+}
+
+function channelPerms(channel: LoadedChannel): ChannelPerms {
+  const charterWrite = HUMAN_METADATA_POLICIES.includes(channel.charter_write_policy as HumanMetadataPolicy)
+    ? (channel.charter_write_policy as HumanMetadataPolicy)
+    : "moderators";
+  const charterWriteAgents = AGENT_METADATA_POLICIES.includes(channel.charter_write_agents as AgentMetadataPolicy)
+    ? (channel.charter_write_agents as AgentMetadataPolicy)
+    : "moderators";
+  const membersList = (["off", ...HUMAN_METADATA_POLICIES] as const).includes(channel.members_list_policy as ChannelPerms["members_list"])
+    ? (channel.members_list_policy as ChannelPerms["members_list"])
+    : "members";
+  const membersListAgents = AGENT_METADATA_POLICIES.includes(channel.members_list_agents as AgentMetadataPolicy)
+    ? (channel.members_list_agents as AgentMetadataPolicy)
+    : "members";
+  return {
+    charter_write: charterWrite,
+    charter_write_agents: charterWriteAgents,
+    charter_write_agent_allowlist: parseNameListJson(channel.charter_write_agent_allowlist_json),
+    members_list: membersList,
+    members_list_agents: membersListAgents,
+    members_list_agent_allowlist: parseNameListJson(channel.members_list_agent_allowlist_json),
+  };
+}
+
+function canByHumanPolicy(policy: HumanMetadataPolicy | "off", identity: TokenIdentity, channel: LoadedChannel, isMember: boolean): boolean {
+  if (policy === "off") return false;
+  if (policy === "owner") return identity.account != null && identity.account === channel.owner_account;
+  if (isChannelModerator(identity, channel)) return true;
+  return policy === "members" && isMember;
+}
+
+function canByAgentPolicy(
+  policy: AgentMetadataPolicy,
+  allowlist: string[],
+  identity: TokenIdentity,
+  channel: LoadedChannel,
+  isMember: boolean,
+  assignedRole: CollaborationRole | null,
+): boolean {
+  if (identity.role === "readonly" || policy === "off") return false;
+  if (policy === "allowlist") return allowlist.includes(identity.name);
+  if (isChannelModerator(identity, channel)) return true;
+  if (policy === "moderators") return assignedRole === "host";
+  return policy === "members" && isMember;
+}
+
+async function canListMembers(db: D1Database, identity: TokenIdentity, channel: LoadedChannel): Promise<boolean> {
+  const perms = channelPerms(channel);
+  const isMember = await isChannelMember(db, channel.slug, identity.account);
+  if (identity.kind === "agent") {
+    const role = await loadAssignedRole(db, channel.slug, identity.name);
+    return canByAgentPolicy(perms.members_list_agents, perms.members_list_agent_allowlist, identity, channel, isMember, role);
+  }
+  return canByHumanPolicy(perms.members_list, identity, channel, isMember);
+}
+
 async function canEditCharter(db: D1Database, identity: TokenIdentity, channel: LoadedChannel): Promise<boolean> {
   if (identity.role === "readonly") return false;
-  if (isChannelModerator(identity, channel)) return true;
-  return (await loadAssignedRole(db, channel.slug, identity.name)) === "host";
+  const perms = channelPerms(channel);
+  const isMember = await isChannelMember(db, channel.slug, identity.account);
+  if (identity.kind === "agent") {
+    const role = await loadAssignedRole(db, channel.slug, identity.name);
+    return canByAgentPolicy(perms.charter_write_agents, perms.charter_write_agent_allowlist, identity, channel, isMember, role);
+  }
+  return canByHumanPolicy(perms.charter_write, identity, channel, isMember);
+}
+
+function stringArrayBody(value: unknown): string[] | null {
+  if (!Array.isArray(value)) return null;
+  const items = value.map((item) => (typeof item === "string" ? item.trim() : "")).filter(Boolean);
+  if (items.some((item) => !NAME_RE.test(item))) return null;
+  return [...new Set(items)].sort();
+}
+
+function channelPermsPatch(body: Record<string, unknown>): { sets: string[]; values: string[] } | null {
+  const sets: string[] = [];
+  const values: string[] = [];
+  const setString = (column: string, value: string) => {
+    sets.push(`${column} = ?`);
+    values.push(value);
+  };
+  const maybeHumanPolicy = (key: string, column: string, allowOff = false) => {
+    if (!Object.prototype.hasOwnProperty.call(body, key)) return true;
+    const value = body[key];
+    if (typeof value !== "string") return false;
+    const allowed = allowOff ? (["off", ...HUMAN_METADATA_POLICIES] as readonly string[]) : HUMAN_METADATA_POLICIES;
+    if (!allowed.includes(value)) return false;
+    setString(column, value);
+    return true;
+  };
+  const maybeAgentPolicy = (key: string, column: string) => {
+    if (!Object.prototype.hasOwnProperty.call(body, key)) return true;
+    const value = body[key];
+    if (typeof value !== "string" || !AGENT_METADATA_POLICIES.includes(value as AgentMetadataPolicy)) return false;
+    setString(column, value);
+    return true;
+  };
+  const maybeAllowlist = (key: string, column: string) => {
+    if (!Object.prototype.hasOwnProperty.call(body, key)) return true;
+    const list = stringArrayBody(body[key]);
+    if (list === null) return false;
+    setString(column, JSON.stringify(list));
+    return true;
+  };
+  if (!maybeHumanPolicy("charter_write", "charter_write_policy")) return null;
+  if (!maybeAgentPolicy("charter_write_agents", "charter_write_agents")) return null;
+  if (!maybeAllowlist("charter_write_agent_allowlist", "charter_write_agent_allowlist_json")) return null;
+  if (!maybeHumanPolicy("members_list", "members_list_policy", true)) return null;
+  if (!maybeAgentPolicy("members_list_agents", "members_list_agents")) return null;
+  if (!maybeAllowlist("members_list_agent_allowlist", "members_list_agent_allowlist_json")) return null;
+  return { sets, values };
 }
 
 async function fetchJson(url: string, init: RequestInit): Promise<Record<string, unknown>> {
@@ -2413,9 +2551,8 @@ app.get("/api/channels/:slug/members", async (c) => {
   const channel = await loadChannel(c.env.DB, slug);
   if (!channel) return c.json(errorBody("not_found", "channel not found"), 404);
   const identity = c.get("identity");
-  const isMember = await isChannelMember(c.env.DB, slug, identity.account);
-  if (!isChannelModerator(identity, channel) && !isMember) {
-    return c.json(errorBody("forbidden", "only channel moderators or members can list members"), 403);
+  if (!(await canListMembers(c.env.DB, identity, channel))) {
+    return c.json(errorBody("forbidden", "not allowed to list channel members"), 403);
   }
   const { results } = await c.env.DB.prepare(
     "SELECT account, added_by, added_at FROM channel_members WHERE channel_slug = ? ORDER BY account",
@@ -2423,6 +2560,44 @@ app.get("/api/channels/:slug/members", async (c) => {
     .bind(slug)
     .all<{ account: string; added_by: string; added_at: number }>();
   return c.json({ members: results });
+});
+
+app.get("/api/channels/:slug/perms", async (c) => {
+  const slug = c.req.param("slug");
+  const channel = await loadChannel(c.env.DB, slug);
+  if (!channel) return c.json(errorBody("not_found", "channel not found"), 404);
+  if (!(await canAccessLoadedChannel(c.env.DB, c.get("identity"), channel))) {
+    return c.json(errorBody("forbidden", "not allowed in this channel"), 403);
+  }
+  return c.json({ permissions: channelPerms(channel) });
+});
+
+app.put("/api/channels/:slug/perms", async (c) => {
+  const slug = c.req.param("slug");
+  const channel = await loadChannel(c.env.DB, slug);
+  if (!channel) return c.json(errorBody("not_found", "channel not found"), 404);
+  const identity = c.get("identity");
+  if (!isChannelModerator(identity, channel)) {
+    return c.json(errorBody("forbidden", "only channel moderators can change channel permissions"), 403);
+  }
+  if (channel.archived_at !== null) {
+    return c.json(errorBody("archived", "channel is archived"), 410);
+  }
+  const body = (await c.req.json().catch(() => null)) as Record<string, unknown> | null;
+  if (body === null || Array.isArray(body)) {
+    return c.json(errorBody("bad_request", "permission policy object required"), 400);
+  }
+  const patch = channelPermsPatch(body);
+  if (patch === null) {
+    return c.json(errorBody("bad_request", "invalid permission policy"), 400);
+  }
+  if (patch.sets.length > 0) {
+    await c.env.DB.prepare(`UPDATE channels SET ${patch.sets.join(", ")} WHERE slug = ?`)
+      .bind(...patch.values, slug)
+      .run();
+  }
+  const updated = await loadChannel(c.env.DB, slug);
+  return c.json({ permissions: channelPerms(updated ?? channel) });
 });
 
 app.put("/api/channels/:slug/members/:account", async (c) => {
@@ -2654,6 +2829,7 @@ app.get("/api/channels/:slug/charter", async (c) => {
     charter_rev: channel.charter_rev,
     updated_at: channel.charter_updated_at,
     updated_by: channel.charter_updated_by,
+    permissions: channelPerms(channel),
   });
 });
 
@@ -2725,6 +2901,7 @@ app.put("/api/channels/:slug/charter", async (c) => {
     charter_rev: rev,
     updated_at: now,
     updated_by: updatedBy,
+    permissions: channelPerms(updated ?? channel),
   });
 });
 

--- a/worker/src/openapi.ts
+++ b/worker/src/openapi.ts
@@ -585,6 +585,48 @@ export const openapiDocument = {
         },
       },
     },
+    "/api/channels/{slug}/perms": {
+      get: {
+        summary: "read configurable channel metadata permissions",
+        security: [{ bearer: [] }],
+        parameters: [{ name: "slug", in: "path", required: true, schema: { type: "string" } }],
+        responses: {
+          "200": { description: "{permissions:{charter_write,charter_write_agents,charter_write_agent_allowlist,members_list,members_list_agents,members_list_agent_allowlist}}" },
+          "403": { description: "not allowed in this channel" },
+          "404": { description: "channel not found" },
+        },
+      },
+      put: {
+        summary: "configure charter and member-list permissions",
+        security: [{ bearer: [] }],
+        parameters: [{ name: "slug", in: "path", required: true, schema: { type: "string" } }],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  charter_write: { type: "string", enum: ["owner", "moderators", "members"] },
+                  charter_write_agents: { type: "string", enum: ["off", "moderators", "members", "allowlist"] },
+                  charter_write_agent_allowlist: { type: "array", items: { type: "string" } },
+                  members_list: { type: "string", enum: ["off", "owner", "moderators", "members"] },
+                  members_list_agents: { type: "string", enum: ["off", "moderators", "members", "allowlist"] },
+                  members_list_agent_allowlist: { type: "array", items: { type: "string" } },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          "200": { description: "{permissions:{...}}" },
+          "400": { description: "invalid permission policy" },
+          "403": { description: "only channel moderators can change channel permissions" },
+          "404": { description: "channel not found" },
+          "410": { description: "channel archived" },
+        },
+      },
+    },
     "/api/channels/{slug}/roles/{name}": {
       put: {
         summary: "assign a soft collaboration role for a channel participant",

--- a/worker/test/charter.spec.ts
+++ b/worker/test/charter.spec.ts
@@ -12,7 +12,18 @@ describe("channel charter", () => {
 
     const initial = await api(`/api/channels/${slug}/charter`, owner.token);
     expect(initial.status).toBe(200);
-    expect(await json(initial)).toMatchObject({ charter: null, charter_rev: 0, updated_at: null, updated_by: null });
+    expect(await json(initial)).toMatchObject({
+      charter: null,
+      charter_rev: 0,
+      updated_at: null,
+      updated_by: null,
+      permissions: {
+        charter_write: "moderators",
+        charter_write_agents: "moderators",
+        members_list: "members",
+        members_list_agents: "members",
+      },
+    });
 
     const updated = await api(`/api/channels/${slug}/charter`, owner.token, {
       method: "PUT",
@@ -78,6 +89,102 @@ describe("channel charter", () => {
     });
     expect(hostWrite.status).toBe(200);
     expect(await json(hostWrite)).toMatchObject({ charter: "host maintained charter", charter_rev: 1, updated_by: host.name });
+  });
+
+  it("configures charter write permissions separately for humans and agents", async () => {
+    const owner = await seedToken("agent", uniq("owner"), { owner: `${uniq("owner")}@example.com` });
+    const slug = await createChannel(owner.token);
+    const memberAccount = `${uniq("member")}@example.com`;
+    const member = await seedToken("human", uniq("human"), { owner: memberAccount });
+    const host = await seedToken("agent", uniq("host"), { owner: `${uniq("host")}@example.com`, channelScope: slug });
+
+    expect((await api(`/api/channels/${slug}/members/${encodeURIComponent(memberAccount)}`, owner.token, { method: "PUT" })).status).toBe(200);
+    expect((await api(`/api/channels/${slug}/roles/${host.name}`, owner.token, {
+      method: "PUT",
+      body: JSON.stringify({ role: "host" }),
+    })).status).toBe(200);
+
+    expect((await api(`/api/channels/${slug}/charter`, member.token, {
+      method: "PUT",
+      body: JSON.stringify({ charter: "member before policy" }),
+    })).status).toBe(403);
+    expect((await api(`/api/channels/${slug}/charter`, host.token, {
+      method: "PUT",
+      body: JSON.stringify({ charter: "host before policy" }),
+    })).status).toBe(200);
+
+    const configured = await api(`/api/channels/${slug}/perms`, owner.token, {
+      method: "PUT",
+      body: JSON.stringify({
+        charter_write: "members",
+        charter_write_agents: "off",
+      }),
+    });
+    expect(configured.status).toBe(200);
+    expect(await json(configured)).toMatchObject({
+      permissions: {
+        charter_write: "members",
+        charter_write_agents: "off",
+      },
+    });
+    expect((await api(`/api/channels/${slug}/charter`, member.token, {
+      method: "PUT",
+      body: JSON.stringify({ charter: "human member edit" }),
+    })).status).toBe(200);
+    expect((await api(`/api/channels/${slug}/charter`, host.token, {
+      method: "PUT",
+      body: JSON.stringify({ charter: "host after off" }),
+    })).status).toBe(403);
+
+    expect((await api(`/api/channels/${slug}/perms`, owner.token, {
+      method: "PUT",
+      body: JSON.stringify({
+        charter_write_agents: "allowlist",
+        charter_write_agent_allowlist: [host.name],
+      }),
+    })).status).toBe(200);
+    const allowlisted = await api(`/api/channels/${slug}/charter`, host.token, {
+      method: "PUT",
+      body: JSON.stringify({ charter: "allowlisted host edit" }),
+    });
+    expect(allowlisted.status).toBe(200);
+  });
+
+  it("configures member-list visibility separately for humans and agents", async () => {
+    const ownerAccount = `${uniq("owner")}@example.com`;
+    const owner = await seedToken("agent", uniq("owner"), { owner: ownerAccount });
+    const ownerHuman = await seedToken("human", uniq("owner-human"), { owner: ownerAccount });
+    const slug = await createChannel(owner.token);
+    const memberAccount = `${uniq("member")}@example.com`;
+    const member = await seedToken("human", uniq("human"), { owner: memberAccount });
+    const memberAgent = await seedToken("agent", uniq("agent"), { owner: memberAccount, channelScope: slug });
+    expect((await api(`/api/channels/${slug}/members/${encodeURIComponent(memberAccount)}`, owner.token, { method: "PUT" })).status).toBe(200);
+
+    expect((await api(`/api/channels/${slug}/members`, member.token)).status).toBe(200);
+    expect((await api(`/api/channels/${slug}/members`, memberAgent.token)).status).toBe(200);
+
+    const moderatorsOnly = await api(`/api/channels/${slug}/perms`, owner.token, {
+      method: "PUT",
+      body: JSON.stringify({
+        members_list: "moderators",
+        members_list_agents: "off",
+      }),
+    });
+    expect(moderatorsOnly.status).toBe(200);
+    expect((await api(`/api/channels/${slug}/members`, member.token)).status).toBe(403);
+    expect((await api(`/api/channels/${slug}/members`, memberAgent.token)).status).toBe(403);
+    expect((await api(`/api/channels/${slug}/members`, owner.token)).status).toBe(403);
+    expect((await api(`/api/channels/${slug}/members`, ownerHuman.token)).status).toBe(200);
+
+    const allowlisted = await api(`/api/channels/${slug}/perms`, owner.token, {
+      method: "PUT",
+      body: JSON.stringify({
+        members_list_agents: "allowlist",
+        members_list_agent_allowlist: [memberAgent.name],
+      }),
+    });
+    expect(allowlisted.status).toBe(200);
+    expect((await api(`/api/channels/${slug}/members`, memberAgent.token)).status).toBe(200);
   });
 
   it("rejects oversized charters and expected_rev conflicts", async () => {


### PR DESCRIPTION
## Summary
- add configurable channel metadata permissions for charter writes and member-list reads
- separate human and agent policy axes, with agent allowlists and current default behavior preserved
- expose GET/PUT /api/channels/:slug/perms, include permissions in charter JSON, and add party channel perms CLI
- add D1 migration/schema verification, OpenAPI entry, tests, and HTML design note

Closes #71

## Verification
- bun run check
- bunx vitest run test/webhooks.spec.ts (reran after the first full check hit a Cloudflare pool timeout in this unrelated file)
