### PR TITLE
chore(release): v0.2.78

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agentparty/cli",
   "license": "BUSL-1.1",
-  "version": "0.2.77",
+  "version": "0.2.78",
   "private": true,
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- bump CLI version to v0.2.78 for the channel permissions release

## Verification
- cd cli && bunx tsc --noEmit
- cd cli && bun run src/index.ts --version
