### PR TITLE
fix(web): 修复 @ 候选漏掉身份显示名

### DIFF
--- a/web/src/lib/mentions.test.ts
+++ b/web/src/lib/mentions.test.ts
@@ -103,6 +103,23 @@ describe("mentionCandidates", () => {
     expect(c.role).toBe("worker");
   });
 
+  test("identity-only agents stay mentionable even without live presence", () => {
+    const c = mentionCandidates([], {}, null, NOW, [
+      { name: "LEO-MAIN", display: "LEO-MAIN", kind: "agent", account: "lark:on_owner" },
+    ])[0]!;
+    expect(c.name).toBe("LEO-MAIN");
+    expect(c.display).toBe("LEO-MAIN");
+    expect(c.tier).toBe("recent");
+    expect(c.group).toBe("lark:on_owner");
+  });
+
+  test("identity-only agents can be found by readable display", () => {
+    const c = mentionCandidates([], {}, null, NOW, [
+      { name: "lark-14c1a0719d91", display: "AgentParty", kind: "agent", account: "lark:on_owner" },
+    ]);
+    expect(filterCandidates(c, "agent").map((candidate) => candidate.name)).toEqual(["lark-14c1a0719d91"]);
+  });
+
   test("assigned channel roles add offline agents and carry structured responsibility", () => {
     const c = mentionCandidates([], {}, null, NOW, [], [
       {

--- a/web/src/lib/mentions.ts
+++ b/web/src/lib/mentions.ts
@@ -52,7 +52,7 @@ function tierFor(
 
 // self 从候选里剔掉（@ 自己没意义）。档内按名字排序，档间 online > wakeable > recent。
 // 只把「有意义的 @ 目标」纳入：agent 各档都留；human 只在当前在线时才留（围观的人、尤其是
-// 只有 UUID 名的登录会话，不该冒进候选）；超过 1 天没露面的幽灵 presence 一律剔除。
+// 只有 UUID 名的登录会话，不该冒进候选）；超过 14 天没露面的幽灵 presence 一律剔除。
 export function mentionCandidates(
   participants: Sender[],
   presence: Record<string, PresenceEntry>,
@@ -80,7 +80,12 @@ export function mentionCandidates(
   const kindFor = (name: string): "agent" | "human" =>
     kindOf.get(name) ?? (SYSTEM_HUMAN_SESSION_RE.test(name) ? "human" : "agent");
 
-  const names = new Set<string>([...online, ...Object.keys(presence), ...roles.map((role) => role.name)]);
+  const names = new Set<string>([
+    ...online,
+    ...Object.keys(presence),
+    ...identities.map((identity) => identity.name),
+    ...roles.map((role) => role.name),
+  ]);
   const rank: Record<MentionTier, number> = { online: 0, wakeable: 1, recent: 2 };
   return [...names]
     .filter((name) => name !== self && name !== "system")
@@ -120,6 +125,7 @@ export function mentionCandidates(
       if (c.tier === "online") return true; // 当前连着的都留（含在线的人类）
       if (c.kind === "human") return false; // 不在线的人类围观者不作候选
       if (roleByName.has(c.name)) return true;
+      if (identityByName.has(c.name)) return true;
       const p = presence[c.name];
       const seen = p?.last_seen ?? p?.ts ?? 0;
       return now - seen <= DEAD_MS; // 幽灵清理：太久没露面的 agent 也剔除

--- a/web/src/pages/Channel.tsx
+++ b/web/src/pages/Channel.tsx
@@ -1919,8 +1919,10 @@ export function ChannelPage({
     for (const p of state.participants) kind.set(p.name, p.kind);
     for (const [name, p] of Object.entries(state.presence)) if (!kind.has(name) && p.kind) kind.set(name, p.kind);
     for (const m of state.messages) if (!kind.has(m.sender.name)) kind.set(m.sender.name, m.sender.kind);
+    for (const identity of channelIdentities) if (!kind.has(identity.name) && identity.kind) kind.set(identity.name, identity.kind);
+    for (const role of channelRoles) if (!kind.has(role.name) && role.kind) kind.set(role.name, role.kind);
     return (name: string): boolean => kind.get(name) === "agent";
-  }, [state.participants, state.presence, state.messages]);
+  }, [channelIdentities, channelRoles, state.participants, state.presence, state.messages]);
   // 发送后回执：seq → 每个被 @ 的 agent 目标的状态（已回复/已唤醒/唤醒失败/在线已送达/待唤醒/待重连）。
   const receiptsBySeq = useMemo(
     () =>
@@ -1937,14 +1939,19 @@ export function ChannelPage({
   // 发送前状态条：草稿里已 @ 的、且在频道里认得的目标 + 当前存活档位。
   const draftMentionStatuses = useMemo<DraftMentionStatus[]>(() => {
     const online = new Set(state.participants.map((p) => p.name));
-    const known = new Set<string>([...online, ...Object.keys(state.presence)]);
+    const known = new Set<string>([
+      ...online,
+      ...Object.keys(state.presence),
+      ...channelIdentities.map((identity) => identity.name),
+      ...channelRoles.map((role) => role.name),
+    ]);
     return parseDraftMentions(draft)
       .filter((name) => known.has(name) && name !== state.self)
       .map((name) => {
         const live = mentionLiveness(name, online, state.presence, teamNow);
         return { name, display: identityDisplay[name]?.display ?? name, tier: live.tier, wakeKind: live.wakeKind };
       });
-  }, [draft, state.participants, state.presence, state.self, teamNow, identityDisplay]);
+  }, [channelIdentities, channelRoles, draft, state.participants, state.presence, state.self, teamNow, identityDisplay]);
   // 轮询 @ 唤醒台账（仅 webhook 侧有行；serve/watch 靠 presence + 回复链接补齐）。用 ref 保持 7s 稳定
   // 间隔，不因每条新消息重挂定时器；标签页隐藏或频道无 agent @ 时跳过，端点失败也不影响其余回执渲染。
   const messagesRef = useRef(state.messages);

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -2942,15 +2942,16 @@ app.get("/api/channels/:slug/identities", async (c) => {
     return c.json(errorBody("forbidden", "not allowed in this channel"), 403);
   }
   const identities = new Map<string, { name: string; kind?: "agent" | "human"; account?: string; display: string }>();
-  const add = (identity: { name: string; kind?: "agent" | "human"; account?: string }) => {
+  const add = (identity: { name: string; kind?: "agent" | "human"; account?: string; display?: string }) => {
     const prev = identities.get(identity.name);
     const kind = identity.kind ?? prev?.kind;
     const account = identity.account ?? prev?.account;
+    const explicitDisplay = typeof identity.display === "string" && identity.display !== "" ? identity.display : undefined;
     identities.set(identity.name, {
       name: identity.name,
       ...(kind === undefined ? {} : { kind }),
       ...(account === undefined ? {} : { account }),
-      display: kind === "human" && account ? account : (prev?.display ?? identity.name),
+      display: explicitDisplay ?? (kind === "human" && account ? account : (prev?.display ?? identity.name)),
     });
   };
 
@@ -2963,6 +2964,26 @@ app.get("/api/channels/:slug/identities", async (c) => {
     const data = (await res.json()) as { identities?: { name: string; kind?: "agent" | "human"; account?: string }[] };
     for (const identity of data.identities ?? []) {
       if (typeof identity.name === "string" && identity.name !== "") add(identity);
+    }
+  }
+
+  const humanAccounts = new Set(
+    [...identities.values()]
+      .filter((identity) => identity.kind === "human" && identity.account !== undefined)
+      .map((identity) => identity.account!),
+  );
+  for (const account of humanAccounts) {
+    const profile = await c.env.DB.prepare(
+      `SELECT handle, display_name
+         FROM account_profiles
+        WHERE account = ?`,
+    )
+      .bind(account)
+      .first<{ handle: string | null; display_name: string | null }>();
+    const display = profile?.handle || profile?.display_name || null;
+    if (display === null) continue;
+    for (const identity of identities.values()) {
+      if (identity.kind === "human" && identity.account === account) add({ ...identity, display });
     }
   }
 

--- a/worker/test/channels.spec.ts
+++ b/worker/test/channels.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { SELF } from "cloudflare:test";
+import { SELF, env } from "cloudflare:test";
 import { api, createChannel, postMessage, seedToken, uniq, WsClient } from "./helpers";
 
 describe("channels", () => {
@@ -215,5 +215,31 @@ describe("channels", () => {
 
     const outsider = await seedToken("human", uniq("outsider"), { owner: "outsider@example.com" });
     expect((await api(`/api/channels/${slug}/identities`, outsider.token)).status).toBe(403);
+  });
+
+  it("identity map prefers human profile handles over opaque provider account ids", async () => {
+    const ownerName = "lark-ad72b3f9749e";
+    const ownerAccount = "lark:on_22608d74bd2d7f39f6dc67d0da248fa5";
+    const owner = await seedToken("human", ownerName, { owner: ownerAccount });
+    const handle = uniq("leo");
+    const now = Date.now();
+    await env.DB.prepare(
+      `INSERT INTO account_profiles (account, handle, display_name, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?)`,
+    )
+      .bind(ownerAccount, handle, "Leo", now, now)
+      .run();
+    const slug = await createChannel(owner.token);
+    expect((await postMessage(slug, owner.token, "hello from lark")).status).toBe(200);
+
+    const identitiesRes = await api(`/api/channels/${slug}/identities`, owner.token);
+    expect(identitiesRes.status).toBe(200);
+    const identities = ((await identitiesRes.json()) as {
+      identities: { name: string; display: string; kind?: string; account?: string }[];
+    }).identities;
+
+    expect(identities).toContainEqual(
+      expect.objectContaining({ name: ownerName, display: handle, kind: "human", account: ownerAccount }),
+    );
   });
 });


### PR DESCRIPTION
## Summary
- include channel identities in @ mention candidates and draft/receipt known-target logic
- enrich human identity labels from account profile handles instead of raw provider account ids
- add web and worker coverage for identity-only agents and readable human labels

## Verification
- bun test web/src/lib/mentions.test.ts web/src/lib/identityDisplay.test.ts
- cd web && bunx tsc --noEmit
- cd worker && bunx tsc --noEmit
- cd worker && bun run test -- --testNamePattern identity test/channels.spec.ts