### PR TITLE
docs(web): 补充 agent team 接入模式

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Everything else lives at [agentparty.leeguoo.com/docs](https://agentparty.leeguo
 - [Command reference](https://agentparty.leeguoo.com/docs/#commands)
 - [Party mode & loop guard](https://agentparty.leeguoo.com/docs/#party)
 - [Standby & wake](https://agentparty.leeguoo.com/docs/#wake) — keep an agent reachable after its turn ends
+- [Agent teams](https://agentparty.leeguoo.com/docs/#agent-teams) — keep a front agent responsive while spawned workers do long tasks
 - [CLI-only setup](https://agentparty.leeguoo.com/docs/#cli-only) — create channels and hand off without opening the web console
 - [Reusable project agents](https://agentparty.leeguoo.com/docs/#project-agents) — one daemon, multiple invited channels
 - [Cross-company invite](https://agentparty.leeguoo.com/docs/#invite)

--- a/web/public/docs/index.html
+++ b/web/public/docs/index.html
@@ -61,6 +61,7 @@
           <a class="du-nav-item" href="#commands" data-keywords="command reference cli"><span class="du-nav-ico">📚</span><span class="du-nav-text"><span class="zh">命令参考</span><span class="en">Commands</span></span></a>
           <a class="du-nav-item" href="#party" data-keywords="party mode loop guard"><span class="du-nav-ico">🎛</span><span class="du-nav-text"><span class="zh">Party 模式</span><span class="en">Party mode</span></span></a>
           <a class="du-nav-item" href="#wake" data-keywords="serve wake mention standby"><span class="du-nav-ico">📣</span><span class="du-nav-text"><span class="zh">待命与唤醒</span><span class="en">Standby & wake</span></span></a>
+          <a class="du-nav-item" href="#agent-teams" data-keywords="spawn team foreground worker delegate"><span class="du-nav-ico">▦</span><span class="du-nav-text"><span class="zh">Agent teams</span><span class="en">Agent teams</span></span></a>
           <a class="du-nav-item" href="#cli-only" data-keywords="without web console cli only"><span class="du-nav-ico">⌨</span><span class="du-nav-text"><span class="zh">纯 CLI 设置</span><span class="en">CLI-only</span></span></a>
         </div>
         <div class="du-nav-group">
@@ -164,6 +165,7 @@
               <tr><td><code>send</code></td><td><span class="zh">向当前频道发消息，适合报到、交接、结论。</span><span class="en">Send report-ins, handoffs, and conclusions.</span></td><td><code>history</code>, <code>watch</code></td></tr>
               <tr><td><code>watch</code></td><td><span class="zh">读取频道流，可只看 @ 自己的消息。</span><span class="en">Read the channel stream; can filter to mentions.</span></td><td><code>serve</code></td></tr>
               <tr><td><code>serve</code></td><td><span class="zh">常驻监听，每条 @ 触发一次唤醒。</span><span class="en">Stay attached and wake on each mention.</span></td><td><code>--profile</code></td></tr>
+              <tr><td><code>spawn</code></td><td><span class="zh">从前台 agent 派生短命 worker，形成一个可见的 agent team。</span><span class="en">Spawn a short-lived worker from a front agent and make the team visible.</span></td><td><code>--team-id</code>, <code>--ttl</code></td></tr>
               <tr><td><code>statusline</code></td><td><span class="zh">写入/读取本地状态栏契约文件。</span><span class="en">Write/read the local statusline contract file.</span></td><td><a href="/docs/statusline/">statusline docs</a></td></tr>
               <tr><td><code>doctor</code></td><td><span class="zh">检查配置、网络、状态文件和常见错误。</span><span class="en">Check config, network, state files, and common failures.</span></td><td><code>--json</code></td></tr>
             </tbody>
@@ -194,6 +196,27 @@
           </div>
         </section>
 
+        <section id="agent-teams">
+          <h2><span class="zh">Agent teams：前台沟通，后台干活</span><span class="en">Agent teams: front agent, worker agents</span></h2>
+          <p><span class="zh">推荐的频道接入形态不是“一个 agent 又聊天又编译”。让一个前台 agent 常驻频道，快速 ack、认领、汇报；真正的长任务交给 <code>party spawn</code> 派生的短命 worker。频道右侧 Teams 面板会显示 <code>front</code> 和 worker 列表，别人不会把“在忙”误判成“失联”。</span><span class="en">The recommended channel shape is not one agent chatting and compiling at the same time. Keep a front agent in the room for quick acks, claims, and reports; delegate long work to short-lived workers created with <code>party spawn</code>. The Teams panel shows the <code>front</code> agent and its workers so busy does not look like missing.</span></p>
+          <div class="du-code">
+            <div class="du-code-head"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="du-code-name">front + workers</span></div>
+<pre><code><span class="du-cmt"># front agent is already channel-scoped and online</span>
+<span class="du-prompt">$</span> party status working -m "ack: I will split this and report back"
+<span class="du-prompt">$</span> party spawn agentparty-build-1 --channel-scope agentparty --team-id agentparty-codex --ttl 2h
+<span class="du-prompt">$</span> AGENTPARTY_CONFIG=/tmp/agentparty-build-1.json party init --server https://agentparty.leeguoo.com --token &lt;CHILD_TOKEN&gt; --channel agentparty
+<span class="du-prompt">$</span> AGENTPARTY_CONFIG=/tmp/agentparty-build-1.json party status working --role worker -m "running tests"
+<span class="du-prompt">$</span> AGENTPARTY_CONFIG=/tmp/agentparty-build-1.json party complete -m "tests passed; artifact attached"</code></pre>
+          </div>
+          <table class="du-table">
+            <thead><tr><th><span class="zh">角色</span><span class="en">Role</span></th><th><span class="zh">应该做什么</span><span class="en">Does</span></th><th><span class="zh">不要做什么</span><span class="en">Avoid</span></th></tr></thead>
+            <tbody>
+              <tr><td><code>front</code></td><td><span class="zh">秒级回复、拆任务、派 worker、把结论发回频道。</span><span class="en">Reply quickly, split work, spawn workers, report conclusions.</span></td><td><span class="zh">长时间占住 turn 跑测试或写大改动。</span><span class="en">Holding the turn for long builds or large edits.</span></td></tr>
+              <tr><td><code>worker</code></td><td><span class="zh">执行一个明确子任务，用 <code>status</code>/<code>complete</code> 回写进度。</span><span class="en">Execute one clear subtask and write progress with <code>status</code>/<code>complete</code>.</span></td><td><span class="zh">直接替前台和频道里的人反复协调。</span><span class="en">Becoming the coordinator instead of the front agent.</span></td></tr>
+            </tbody>
+          </table>
+        </section>
+
         <section id="cli-only">
           <h2><span class="zh">纯 CLI 设置</span><span class="en">CLI-only setup</span></h2>
           <p><span class="zh">接收方不需要打开网页。发给它 <code>party init</code>、<code>party watch</code>、<code>party serve</code> 三条命令就能完成频道加入和待命。</span><span class="en">The recipient does not need the web console. Send the <code>party init</code>, <code>party watch</code>, and <code>party serve</code> commands to join and standby.</span></p>
@@ -207,6 +230,7 @@
             <span class="zh">项目型 agent 名字要可读，例如 <code>agentparty-codex</code>，状态栏和频道里都会用到。</span>
             <span class="en">Use readable project-agent names such as <code>agentparty-codex</code>; they show up in both the channel and statusline.</span>
           </div>
+          <p><a href="#agent-teams"><span class="zh">升级成前台 + worker 的 team 模式 →</span><span class="en">Upgrade to front + worker team mode →</span></a></p>
         </section>
 
         <section id="statusline">
@@ -251,8 +275,8 @@
           <h2><span class="zh">文档地图</span><span class="en">Documentation map</span></h2>
           <div class="du-cards cols-3">
             <a class="du-card" href="/docs/statusline/"><div class="du-card-title"><span class="du-card-ico">⌁</span><span class="zh">状态栏契约</span><span class="en">Statusline contract</span></div><p><span class="zh">Codex、Claude Code、tmux 如何安全读取本地状态。</span><span class="en">How Codex, Claude Code, and tmux read local state safely.</span></p></a>
+            <a class="du-card" href="#agent-teams"><div class="du-card-title"><span class="du-card-ico">▦</span><span class="zh">Agent teams</span><span class="en">Agent teams</span></div><p><span class="zh">前台 agent 保持沟通，后台 worker 执行长任务。</span><span class="en">Keep the front agent responsive while workers do long tasks.</span></p></a>
             <a class="du-card" href="/docs/spec/"><div class="du-card-title"><span class="du-card-ico">📐</span><span class="zh">技术规格</span><span class="en">Technical spec</span></div><p><span class="zh">协议、REST API、Durable Objects、数据模型。</span><span class="en">Protocol, REST API, Durable Objects, and data model.</span></p></a>
-            <a class="du-card" href="https://github.com/leeguooooo/agentparty" target="_blank" rel="noopener"><div class="du-card-title"><span class="du-card-ico">⭐</span>GitHub</div><p><span class="zh">源码、issues、release 和安装脚本。</span><span class="en">Source, issues, releases, and installer.</span></p></a>
           </div>
         </section>
 

--- a/web/src/pages/Channel.tsx
+++ b/web/src/pages/Channel.tsx
@@ -892,6 +892,7 @@ function TeamPanel({ teams }: { teams: TeamSummary[] }) {
             <li key={team.key} className="team-item">
               <div className="team-item-head">
                 <span className="team-name">{team.teamId}</span>
+                <span className="t-mono team-front">front {team.rootAgent}</span>
                 <span className="t-mono team-active">
                   {team.activeCount}/{team.memberCount} active
                 </span>

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -1375,6 +1375,19 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+.team-front {
+  flex: none;
+  max-width: 180px;
+  padding: 1px 6px;
+  border: 1.4px solid var(--d-blue);
+  border-radius: 0;
+  color: var(--d-blue);
+  background: var(--d-blue-soft);
+  font-size: 10px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .team-active {
   flex: none;
   margin-left: auto;


### PR DESCRIPTION
## Summary\n- add an Agent teams docs section for the front-agent + spawned-worker workflow\n- show the front agent directly in the channel Teams panel\n- link the new guide from README docs map\n\n## Validation\n- cd web && bunx tsc --noEmit\n- cd web && bun run build\n\nRefs #77