### PR TITLE
fix(web): 离线人类身份保留 @ 候选

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -134,6 +134,7 @@ export interface ChannelIdentity {
   display: string;
   kind?: "agent" | "human";
   account?: string;
+  handle?: string;
 }
 
 export type ChannelRoleInfo = ChannelRoleAssignment;

--- a/web/src/lib/mentions.test.ts
+++ b/web/src/lib/mentions.test.ts
@@ -120,6 +120,36 @@ describe("mentionCandidates", () => {
     expect(filterCandidates(c, "agent").map((candidate) => candidate.name)).toEqual(["lark-14c1a0719d91"]);
   });
 
+  test("offline human identity with handle stays mentionable by readable handle", () => {
+    const c = mentionCandidates([], {}, null, NOW, [
+      {
+        name: "lark-14c1a0719d91",
+        display: "Evan",
+        handle: "Evan",
+        kind: "human",
+        account: "lark:on_acda4d50062e089bf3b2401b907decde",
+      },
+    ]);
+    expect(c).toHaveLength(1);
+    expect(c[0]!.name).toBe("Evan");
+    expect(c[0]!.display).toBe("Evan");
+    expect(filterCandidates(c, "ev").map((candidate) => candidate.name)).toEqual(["Evan"]);
+  });
+
+  test("offline human identity without handle is still selectable by readable display", () => {
+    const c = mentionCandidates([], {}, null, NOW, [
+      {
+        name: "lark-14c1a0719d91",
+        display: "Evan",
+        kind: "human",
+        account: "lark:on_acda4d50062e089bf3b2401b907decde",
+      },
+    ]);
+    expect(c).toHaveLength(1);
+    expect(c[0]!.name).toBe("lark-14c1a0719d91");
+    expect(c[0]!.display).toBe("Evan");
+  });
+
   test("assigned channel roles add offline agents and carry structured responsibility", () => {
     const c = mentionCandidates([], {}, null, NOW, [], [
       {

--- a/web/src/lib/mentions.ts
+++ b/web/src/lib/mentions.ts
@@ -10,6 +10,7 @@ export interface MentionIdentity {
   display: string;
   kind?: "agent" | "human";
   account?: string;
+  handle?: string;
 }
 
 export interface MentionCandidate {
@@ -32,6 +33,7 @@ const DEAD_MS = 14 * 24 * 60 * 60 * 1000; // 14 天没露面才视为幽灵
 // OIDC 设备验证流 = login-verify-*。过渡期旧 presence 行没回填 kind 时靠名字把它们判为 human。
 const SYSTEM_HUMAN_SESSION_RE =
   /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|login-verify-.+)$/i;
+const NAME_TOKEN_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$/;
 
 // 档位：① 在线（当前有 WS 连接） ② 可唤醒（autoWakeReachable 统一口径 #47/#55：
 // serve/watch 需不 stale 且不能是 human_driven，webhook 服务端投递、离线也算） ③ 最近活跃（其余 presence）。
@@ -97,7 +99,11 @@ export function mentionCandidates(
       const account = identity?.account ?? assigned?.account ?? p?.account;
       // 人类全局唯一昵称（handle）：有则用它做 @ 插入 token 和显示名——UUID 会话名打不出来，
       // handle 才能被后端 R5 按 handle 识别为「被 @」。agent 不适用（其 name 本身就是可读 handle）。
-      const handle = kind === "human" ? (participantByName.get(name)?.handle ?? p?.handle) : undefined;
+      const identityHandle =
+        identity?.handle !== undefined && identity.handle !== "" && NAME_TOKEN_RE.test(identity.handle)
+          ? identity.handle
+          : undefined;
+      const handle = kind === "human" ? (participantByName.get(name)?.handle ?? p?.handle ?? identityHandle) : undefined;
       // 人类网页会话名是 UUID，显示账号 email 才认得出「是谁」；agent 名本身可读，用 name。
       const display = handle
         ? handle
@@ -123,7 +129,12 @@ export function mentionCandidates(
     })
     .filter((c) => {
       if (c.tier === "online") return true; // 当前连着的都留（含在线的人类）
-      if (c.kind === "human") return false; // 不在线的人类围观者不作候选
+      if (c.kind === "human") {
+        // 离线人类也可以是明确收件人：例如 Lark/OIDC 人类已经发过消息，identity API 能给出
+        // handle/display；但没有账号/显示名的围观 session 仍然隐藏，避免菜单里出现裸 UUID。
+        if (SYSTEM_HUMAN_SESSION_RE.test(c.name)) return c.account !== undefined && c.display !== c.name && c.display !== c.account;
+        return c.account !== undefined || (c.display !== c.name && c.display !== c.account);
+      }
       if (roleByName.has(c.name)) return true;
       if (identityByName.has(c.name)) return true;
       const p = presence[c.name];

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -2941,16 +2941,18 @@ app.get("/api/channels/:slug/identities", async (c) => {
   if (!(await canAccessLoadedChannel(c.env.DB, c.get("identity"), channel))) {
     return c.json(errorBody("forbidden", "not allowed in this channel"), 403);
   }
-  const identities = new Map<string, { name: string; kind?: "agent" | "human"; account?: string; display: string }>();
-  const add = (identity: { name: string; kind?: "agent" | "human"; account?: string; display?: string }) => {
+  const identities = new Map<string, { name: string; kind?: "agent" | "human"; account?: string; display: string; handle?: string }>();
+  const add = (identity: { name: string; kind?: "agent" | "human"; account?: string; display?: string; handle?: string | null }) => {
     const prev = identities.get(identity.name);
     const kind = identity.kind ?? prev?.kind;
     const account = identity.account ?? prev?.account;
+    const handle = typeof identity.handle === "string" && identity.handle !== "" ? identity.handle : prev?.handle;
     const explicitDisplay = typeof identity.display === "string" && identity.display !== "" ? identity.display : undefined;
     identities.set(identity.name, {
       name: identity.name,
       ...(kind === undefined ? {} : { kind }),
       ...(account === undefined ? {} : { account }),
+      ...(handle === undefined ? {} : { handle }),
       display: explicitDisplay ?? (kind === "human" && account ? account : (prev?.display ?? identity.name)),
     });
   };
@@ -2980,10 +2982,11 @@ app.get("/api/channels/:slug/identities", async (c) => {
     )
       .bind(account)
       .first<{ handle: string | null; display_name: string | null }>();
-    const display = profile?.handle || profile?.display_name || null;
+    const handle = profile?.handle || null;
+    const display = handle || profile?.display_name || null;
     if (display === null) continue;
     for (const identity of identities.values()) {
-      if (identity.kind === "human" && identity.account === account) add({ ...identity, display });
+      if (identity.kind === "human" && identity.account === account) add({ ...identity, display, handle });
     }
   }
 

--- a/worker/test/channels.spec.ts
+++ b/worker/test/channels.spec.ts
@@ -239,7 +239,7 @@ describe("channels", () => {
     }).identities;
 
     expect(identities).toContainEqual(
-      expect.objectContaining({ name: ownerName, display: handle, kind: "human", account: ownerAccount }),
+      expect.objectContaining({ name: ownerName, display: handle, handle, kind: "human", account: ownerAccount }),
     );
   });
 });


### PR DESCRIPTION
## Summary\n- expose human profile handles from the channel identities API\n- keep offline humans with readable identity/handle in the composer @ candidates\n- prefer a valid human handle as the inserted @ token while still hiding raw anonymous UUID sessions\n\n## Validation\n- bun test web/src/lib/mentions.test.ts web/src/lib/identityDisplay.test.ts\n- cd web && bunx tsc --noEmit\n- cd web && bun run build\n- cd worker && bun run test -- --testNamePattern identity test/channels.spec.ts\n- cd worker && bunx tsc --noEmit