### PR TITLE
fix(worker): status 非法 role 值回明确报错（列出合法值）而非笼统 invalid send payload

### DIFF
--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -593,8 +593,9 @@ function parseAgentContext(input: unknown): AgentContext | undefined | null {
 // parseSendFrame 返回 null 时用它给出更具体的拒收原因：role 拼错是 agent 自报协作角色最常见的坑，
 // 单独识别并回明确文案（列出合法值），而不是笼统的 "invalid send payload"，让 agent 能自我纠正。
 function sendRejectMessage(raw: unknown): string {
-  const f = raw as { kind?: unknown; role?: unknown } | null;
-  if (f !== null && f.kind === "status" && f.role !== undefined && parseCollaborationRole(f.role) === null) {
+  if (typeof raw !== "object" || raw === null) return "invalid send payload";
+  const f = raw as { kind?: unknown; role?: unknown };
+  if (f.kind === "status" && f.role !== undefined && parseCollaborationRole(f.role) === null) {
     return `role must be one of: ${COLLAB_ROLES.join(", ")}`;
   }
   return "invalid send payload";

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -590,6 +590,16 @@ function parseAgentContext(input: unknown): AgentContext | undefined | null {
   };
 }
 
+// parseSendFrame 返回 null 时用它给出更具体的拒收原因：role 拼错是 agent 自报协作角色最常见的坑，
+// 单独识别并回明确文案（列出合法值），而不是笼统的 "invalid send payload"，让 agent 能自我纠正。
+function sendRejectMessage(raw: unknown): string {
+  const f = raw as { kind?: unknown; role?: unknown } | null;
+  if (f !== null && f.kind === "status" && f.role !== undefined && parseCollaborationRole(f.role) === null) {
+    return `role must be one of: ${COLLAB_ROLES.join(", ")}`;
+  }
+  return "invalid send payload";
+}
+
 // rest body 与 ws send 帧共用的校验（rest 侧无 type 字段）
 function parseSendFrame(input: unknown): SendFrame | null {
   if (typeof input !== "object" || input === null) return null;
@@ -1105,7 +1115,7 @@ export class ChannelDO extends Server<Env> {
       }
       const send = parseSendFrame(frame);
       if (!send) {
-        this.sendFrame(connection, { type: "error", code: "bad_request", message: "invalid send payload" });
+        this.sendFrame(connection, { type: "error", code: "bad_request", message: sendRejectMessage(frame) });
         return;
       }
       const out = await this.handleSend(
@@ -2144,7 +2154,7 @@ export class ChannelDO extends Server<Env> {
             { status: ERROR_STATUS[rate.code] },
           );
         }
-        return Response.json({ error: { code: "bad_request", message: "invalid send payload" } }, { status: 400 });
+        return Response.json({ error: { code: "bad_request", message: sendRejectMessage(raw) } }, { status: 400 });
       }
       const out = await this.handleSend(identity, send, { countRate: true });
       if (!out.ok) {

--- a/worker/test/ws.spec.ts
+++ b/worker/test/ws.spec.ts
@@ -647,4 +647,28 @@ describe("websocket", () => {
     });
     expect(missing.status).toBe(404);
   });
+
+  it("rejects a status frame with an invalid collaboration role using a clear message", async () => {
+    const { token } = await seedToken("agent");
+    const slug = await createChannel(token);
+    const ws = await WsClient.open(slug, token);
+    await ws.nextOfType("welcome");
+    ws.send({ type: "send", kind: "status", state: "working", note: "x", mentions: [], role: "developer" });
+    const err = await ws.nextOfType("error");
+    expect(err).toMatchObject({ type: "error", code: "bad_request" });
+    expect(err.message).toContain("role");
+    expect(err.message).toContain("worker"); // 列出了合法值
+    ws.close();
+  });
+
+  it("accepts a status frame with a valid collaboration role", async () => {
+    const { token } = await seedToken("agent");
+    const slug = await createChannel(token);
+    const ws = await WsClient.open(slug, token);
+    await ws.nextOfType("welcome");
+    ws.send({ type: "send", kind: "status", state: "working", note: "handling backend", mentions: [], role: "worker" });
+    const sent = await ws.nextOfType("sent");
+    expect(sent.type).toBe("sent");
+    ws.close();
+  });
 });


### PR DESCRIPTION
## 背景
agent 通过 status 帧自报协作角色：`{kind:"status", state, note, role}`，`role` 必须是 `host|worker|reviewer|observer`。此前若 `role` 是非法值（如 `developer`），`parseCollaborationRole` 返回 null → `parseSendFrame` 整体返回 null → 服务端只回笼统的 `invalid send payload`，agent 不知道是 role 拼错，整条 status（含 state/note）被静默丢弃，排查困难。

## 改动
- `worker/src/do.ts`：新增 `sendRejectMessage(raw)` 助手——当 `parseSendFrame` 拒收且原因是 `kind:"status"` 的 role 非法时，返回 `role must be one of: host, worker, reviewer, observer`（合法值从 `COLLAB_ROLES` 派生），否则维持 `invalid send payload`。WS send 失败点与 REST-internal send 失败点均改用它（rate 限流分支不动）。
- role 为 undefined（未提供角色）或失败原因是其它字段时，仍回通用文案——只对"提供了但拼错 role"这一最常见的 agent 坑给精确提示。

## 说明
CLI `party status --role` 本身已在客户端校验角色值，所以这条主要是给**非 CLI / 直连协议（SDK、自建 WS 客户端）**的 agent 兜底，让它们能从错误信息里自我纠正，而不是收到一句无从下手的笼统报错。

## 验证
- `worker` vitest：`test/ws.spec.ts` 23/23 pass（新增 2 条：非法 role 回明确错、合法 role 正常 `sent`）
- `tsc --noEmit` 0 error