### PR TITLE
feat(cli): 标记 profile daemon 为前台 host

### DIFF
--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -907,7 +907,7 @@ export function projectAgentChildName(handle: string, channel: string): string {
 
 function profileReadyNote(profile: ProjectAgentProfile, channel: string, prepared: PreparedProfileWorkspace): string {
   const project = profile.repo_url ?? profile.workdir ?? "local";
-  return `project agent ready: ${profile.owner_account}/${profile.handle} channel=#${channel} project=${project} base=${profile.base_branch} worktree=${profile.worktree_strategy} cwd=${prepared.channelWorkdir}`;
+  return `front agent ready: ${profile.owner_account}/${profile.handle} channel=#${channel} team=${profile.handle} project=${project} base=${profile.base_branch} worktree=${profile.worktree_strategy} cwd=${prepared.channelWorkdir}`;
 }
 
 export async function runProfileServe(opts: ProfileServeOptions): Promise<number> {
@@ -955,6 +955,7 @@ export async function runProfileServe(opts: ProfileServeOptions): Promise<number
         await post(opts.server, child.token, channel, {
           kind: "status",
           state: "waiting",
+          role: "host",
           note,
           mentions: [],
           residency: "supervised",
@@ -966,7 +967,7 @@ export async function runProfileServe(opts: ProfileServeOptions): Promise<number
         });
         await post(opts.server, child.token, channel, {
           kind: "message",
-          body: `${profile.name || profile.handle} joined #${channel} as ${child.name}. ${note}`,
+          body: `${profile.name || profile.handle} joined #${channel} as front agent ${child.name}; workers should spawn under team ${profile.handle}. ${note}`,
           mentions: [],
           reply_to: null,
         });

--- a/cli/src/commands/spawn.ts
+++ b/cli/src/commands/spawn.ts
@@ -1,18 +1,18 @@
-// party spawn <child> — parent agent creates a short-lived channel-scoped child identity
+// party spawn <worker> — front agent creates a short-lived channel-scoped worker identity
 import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
 import { resolveAuthDetailed } from "../oidc-cli";
 import { handleRestError, RestError, spawnAgent } from "../rest";
 import { isName, isSlug } from "../validation";
 
 const SPAWN_FLAGS = ["channel-scope", "ttl", "team-id"];
-const HELP = `usage: party spawn <child> --channel-scope slug [--ttl 2h] [--team-id id]
+const HELP = `usage: party spawn <worker> --channel-scope slug [--ttl 2h] [--team-id id]
 
-Create a short-lived child agent token from the current runtime identity.
+Create a short-lived worker agent token from the current front/runtime identity.
 
 Options:
-  --channel-scope slug   required channel scope for the child
-  --ttl 2h               child lifetime: seconds, 30m, 2h, 1d (default server TTL)
-  --team-id id           lineage team id (defaults to parent agent)`;
+  --channel-scope slug   required channel scope for the worker
+  --ttl 2h               worker lifetime: seconds, 30m, 2h, 1d (default server TTL)
+  --team-id id           lineage team id for grouping with the front agent (defaults to parent agent)`;
 
 function parseTtl(input: string | undefined): number | string | undefined {
   if (input === undefined) return undefined;
@@ -42,7 +42,7 @@ export async function run(argv: string[]): Promise<number> {
   }
   const name = positionals[0];
   if (!name || positionals.length !== 1 || !isName(name)) {
-    console.error("usage: party spawn <child> --channel-scope slug [--ttl 2h] [--team-id id]");
+    console.error("usage: party spawn <worker> --channel-scope slug [--ttl 2h] [--team-id id]");
     return 1;
   }
   const channelScope = str(flags["channel-scope"]);
@@ -74,7 +74,7 @@ export async function run(argv: string[]): Promise<number> {
   try {
     const res = await spawnAgent(auth.server, auth.token, name, channelScope, { ttlSec: ttl, teamId });
     console.log(JSON.stringify(res));
-    console.error(`give it to the child: party init --server ${auth.server} --token ${res.token} --channel ${res.channel_scope}`);
+    console.error(`give it to the worker: party init --server ${auth.server} --token ${res.token} --channel ${res.channel_scope}`);
     return 0;
   } catch (e) {
     if (e instanceof RestError && (e.status === 401 || e.status === 403)) {

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -15,7 +15,7 @@ commands:
   logout                                             clear account session
   whoami    [--json] [--caps]                         print current identity + capabilities (hits /api/me)
   agent     add <name> [--channel-scope slug] | create <handle> --runner codex|claude|codex-sdk|shell [--invitable-by owner|org|anyone] | list
-  spawn     <child> --channel-scope slug [--ttl 2h]  create a short-lived child agent from current agent
+  spawn     <worker> --channel-scope slug [--ttl 2h] create a short-lived worker from the front agent
   init      --server URL --token T [--channel C]   write config, bind channel (create if missing)
   send      <text|-> [--channel C] [--mention name]... [--reply-to seq]
   complete  <text|-> --kickoff-seq seq [--channel C] [--replies n] [--timeout] [--issue n]... [--pr n]...

--- a/cli/test/account-commands.test.ts
+++ b/cli/test/account-commands.test.ts
@@ -309,6 +309,7 @@ describe("spawn", () => {
     expect(req?.auth).toBe("Bearer ap_parent");
     expect(req?.body).toEqual({ name: "child-bot", channel_scope: "ops", ttl_sec: 1800, team_id: "team.1" });
     expect(logs.join("\n")).toContain("ap_child-bot_secret");
+    expect(errs.join("\n")).toContain("give it to the worker");
     expect(errs.join("\n")).toContain("party init --server");
     expect(errs.join("\n")).toContain("--channel ops");
   });

--- a/cli/test/serve.test.ts
+++ b/cli/test/serve.test.ts
@@ -719,9 +719,16 @@ describe("project profile daemon", () => {
       { slug: "gamma", childName: projectAgentChildName("herness-dev", "gamma") },
     ]);
     expect(posts).toHaveLength(6);
-    expect(posts.filter((p) => (p.body as { kind: string }).kind === "status")).toHaveLength(3);
+    const statusPosts = posts.filter((p) => (p.body as { kind: string }).kind === "status");
+    const joinPosts = posts.filter((p) => (p.body as { kind: string }).kind === "message");
+    expect(statusPosts).toHaveLength(3);
+    expect(statusPosts.every((p) => (p.body as { role?: string }).role === "host")).toBe(true);
     expect(posts.every((p) => p.token.startsWith("ap_child_"))).toBe(true);
+    expect(String((posts[0]!.body as { note: string }).note)).toContain("front agent ready");
+    expect(String((posts[0]!.body as { note: string }).note)).toContain("team=herness-dev");
     expect(String((posts[0]!.body as { note: string }).note)).toContain("worktree=branch");
+    expect(joinPosts.every((p) => String((p.body as { body?: string }).body).includes("front agent"))).toBe(true);
+    expect(joinPosts.every((p) => String((p.body as { body?: string }).body).includes("workers should spawn under team herness-dev"))).toBe(true);
   });
 
   test("project-agent child names are stable and stay within the token name limit", () => {


### PR DESCRIPTION
## Summary
- make party serve --profile advertise its channel runtime as a front/host agent: role=host, residency=supervised, wake.kind=serve
- include team=<handle> in the profile ready note and announce that workers should spawn under that team
- align party spawn CLI help/output wording around worker agents instead of generic child agents

## Issue
Partial progress for #77: this lands the CLI/runtime semantics for the front-agent side of the agent-team model. It does not close the full issue yet; remaining pieces include richer team mention routing/presence UX and quota semantics.

## Verification
- cd cli && bun test test/serve.test.ts test/account-commands.test.ts
- cd cli && bun test test/cli.test.ts test/account-commands.test.ts test/serve.test.ts
- cd cli && bun test
- cd cli && bunx tsc --noEmit
- git diff --check
