### PR TITLE
feat(web): 区分 team front 与 workers

### DIFF
--- a/web/src/lib/teams.test.ts
+++ b/web/src/lib/teams.test.ts
@@ -114,6 +114,38 @@ describe("team summaries", () => {
 
     expect(teams[0]!.expiresAt).toBe(NOW + 30_000);
   });
+
+  test("identifies the host profile runtime as the front agent for its workers", () => {
+    const teams = summarizeTeams({
+      now: NOW,
+      participants: [sender("agentparty-agentparty-abc123", { lineage: lineage({ team_id: "codex-main" }) })],
+      presence: {
+        "agentparty-agentparty-abc123": presence("agentparty-agentparty-abc123", {
+          role: "host",
+          residency: "supervised",
+          lineage: lineage({ team_id: "codex-main" }),
+        }),
+        "agentparty-build-1": presence("agentparty-build-1", {
+          role: "worker",
+          residency: "bare",
+          lineage: lineage({ parent_agent: "agentparty-agentparty-abc123", team_id: "codex-main", depth: 1 }),
+        }),
+      },
+      messages: [],
+    });
+
+    expect(teams).toHaveLength(1);
+    expect(teams[0]!.teamId).toBe("codex-main");
+    expect(teams[0]!.frontAgent).toMatchObject({
+      name: "agentparty-agentparty-abc123",
+      role: "host",
+      active: true,
+    });
+    expect(teams[0]!.members.map((member) => [member.name, member.role])).toEqual([
+      ["agentparty-agentparty-abc123", "host"],
+      ["agentparty-build-1", "worker"],
+    ]);
+  });
 });
 
 describe("team message grouping", () => {

--- a/web/src/lib/teams.ts
+++ b/web/src/lib/teams.ts
@@ -1,4 +1,4 @@
-import { PRESENCE_TIMEOUT_MS, type MsgFrame, type PresenceEntry, type Residency, type Sender } from "@agentparty/shared";
+import { PRESENCE_TIMEOUT_MS, type CollaborationRole, type MsgFrame, type PresenceEntry, type Residency, type Sender } from "@agentparty/shared";
 
 export type TeamResidency = Residency | "mixed";
 
@@ -9,6 +9,7 @@ export interface TeamMemberSummary {
   teamId: string;
   depth: number;
   state: string;
+  role: CollaborationRole | null;
   residency: Residency | "unknown";
   active: boolean;
   connected: boolean;
@@ -28,6 +29,7 @@ export interface TeamSummary {
   residency: TeamResidency;
   expiresAt: number | null;
   lastSeen: number | null;
+  frontAgent: TeamMemberSummary | null;
   members: TeamMemberSummary[];
 }
 
@@ -59,6 +61,7 @@ interface MemberDraft {
   name: string;
   lineage: Sender["lineage"] | null;
   state: string;
+  role: CollaborationRole | null;
   residency: Residency | "unknown";
   connected: boolean;
   lastSeen: number | null;
@@ -104,6 +107,7 @@ function mergeMember(map: Map<string, MemberDraft>, name: string, patch: Partial
     name,
     lineage: null,
     state: "offline",
+    role: null,
     residency: "unknown",
     connected: false,
     lastSeen: null,
@@ -112,6 +116,7 @@ function mergeMember(map: Map<string, MemberDraft>, name: string, patch: Partial
     ...prev,
     ...patch,
     lineage: patch.lineage ?? prev.lineage,
+    role: patch.role ?? prev.role,
     residency: patch.residency ?? prev.residency,
     connected: prev.connected || patch.connected === true,
     lastSeen: newer(prev.lastSeen, patch.lastSeen ?? null),
@@ -143,6 +148,7 @@ export function summarizeTeams({ presence, participants, messages, now = Date.no
   for (const msg of messages) {
     mergeMember(members, msg.sender.name, {
       lineage: msg.sender.lineage ?? null,
+      role: msg.role ?? null,
       lastSeen: msg.ts,
     });
   }
@@ -152,6 +158,7 @@ export function summarizeTeams({ presence, participants, messages, now = Date.no
     mergeMember(members, entry.name, {
       lineage: entry.lineage ?? participantByName.get(entry.name)?.lineage ?? null,
       state: connected && entry.state === "offline" ? "online" : entry.state,
+      role: entry.role ?? null,
       residency: entry.residency ?? "unknown",
       connected,
       lastSeen: entry.last_seen ?? entry.ts,
@@ -169,6 +176,7 @@ export function summarizeTeams({ presence, participants, messages, now = Date.no
       teamId: member.lineage.team_id,
       depth: member.lineage.depth,
       state: member.state,
+      role: member.role,
       residency: member.residency,
       active,
       connected: member.connected,
@@ -189,6 +197,12 @@ export function summarizeTeams({ presence, participants, messages, now = Date.no
       const activeCount = sortedMembers.filter((member) => member.active).length;
       const parentAgents = [...new Set(sortedMembers.map((member) => member.parentAgent))].sort((a, b) => a.localeCompare(b));
       const residency = summarizeResidency(sortedMembers.map((member) => member.residency));
+      const frontAgent =
+        sortedMembers.find((member) => member.role === "host") ??
+        sortedMembers.find((member) =>
+          member.depth === 1 && member.parentAgent === member.rootAgent && member.teamId === member.rootAgent,
+        ) ??
+        null;
       return {
         key,
         rootAgent: sortedMembers[0]!.rootAgent,
@@ -201,6 +215,7 @@ export function summarizeTeams({ presence, participants, messages, now = Date.no
         residency,
         expiresAt: sortedMembers.reduce<number | null>((acc, member) => sooner(acc, member.expiresAt), null),
         lastSeen: sortedMembers.reduce<number | null>((acc, member) => newer(acc, member.lastSeen), null),
+        frontAgent,
         members: sortedMembers,
       };
     })

--- a/web/src/pages/Channel.tsx
+++ b/web/src/pages/Channel.tsx
@@ -881,6 +881,8 @@ function TeamPanel({ teams }: { teams: TeamSummary[] }) {
       </div>
       <ol className="team-list">
         {teams.map((team) => {
+          const front = team.frontAgent;
+          const workerMembers = front === null ? team.members : team.members.filter((member) => member.name !== front.name);
           const meta = [
             `root: ${team.rootAgent}`,
             team.parentAgents.length === 1 ? `parent: ${team.parentAgents[0]}` : `${team.parentAgents.length} parents`,
@@ -892,7 +894,13 @@ function TeamPanel({ teams }: { teams: TeamSummary[] }) {
             <li key={team.key} className="team-item">
               <div className="team-item-head">
                 <span className="team-name">{team.teamId}</span>
-                <span className="t-mono team-front">front {team.rootAgent}</span>
+                <span
+                  className={"t-mono team-front" + (front?.active ? " is-active" : "")}
+                  title={front === null ? `front: ${team.rootAgent}` : `front: ${front.name} · state: ${front.state} · residency: ${front.residency}`}
+                >
+                  <span className={`d-dot d-dot--${front?.active ? front.state : "offline"}`} />
+                  front {front?.name ?? team.rootAgent}
+                </span>
                 <span className="t-mono team-active">
                   {team.activeCount}/{team.memberCount} active
                 </span>
@@ -902,7 +910,8 @@ function TeamPanel({ teams }: { teams: TeamSummary[] }) {
               </div>
               <div className="t-mono team-meta">{meta.join(" · ")}</div>
               <div className="team-members">
-                {team.members.map((member) => (
+                {workerMembers.length === 0 && <span className="t-mono team-member team-member--empty">no workers</span>}
+                {workerMembers.map((member) => (
                   <span
                     key={member.name}
                     className={"t-mono team-member" + (member.active ? " is-active" : "")}

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -1400,6 +1400,9 @@
   white-space: nowrap;
 }
 .team-front {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
   flex: none;
   max-width: 180px;
   padding: 1px 6px;
@@ -1411,6 +1414,11 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+.team-front.is-active {
+  border-color: var(--d-green);
+  color: var(--d-green);
+  background: var(--d-green-soft);
 }
 .team-active {
   flex: none;
@@ -1467,6 +1475,10 @@
   border-color: var(--d-blue);
   color: var(--d-blue);
   background: var(--d-blue-soft);
+}
+.team-member--empty {
+  font-style: italic;
+  border-style: dashed;
 }
 .team-member span:last-child {
   min-width: 0;
@@ -2262,9 +2274,10 @@
 .ap-sprite {
   --ap-icon-x: 0%;
   --ap-icon-y: 0%;
+  --ap-icon-size: 20px;
   display: inline-block;
-  width: 17px;
-  height: 17px;
+  width: var(--ap-icon-size);
+  height: var(--ap-icon-size);
   flex: 0 0 auto;
   background-image: url("/assets/agentparty-ui-sprite-v2.png");
   background-repeat: no-repeat;
@@ -2285,6 +2298,10 @@
 .ap-sprite--success { --ap-icon-x: 66.667%; --ap-icon-y: 100%; }
 .ap-sprite--failed,
 .ap-sprite--waiting { --ap-icon-x: 100%; --ap-icon-y: 100%; }
+.chan-tool-btn .ap-sprite {
+  --ap-icon-size: 22px;
+  margin-left: -1px;
+}
 
 /* ---- 被@浏览器通知铃铛（Task C2） ---- */
 .notify-toggle { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
@@ -2295,6 +2312,7 @@
   padding: 3px 7px;
   justify-content: center;
 }
+.notify-toggle-btn .ap-sprite { --ap-icon-size: 21px; }
 .notify-toggle-btn.is-active { border-color: var(--d-yellow); background: var(--d-yellow); }
 .notify-toggle-hint { font-size: 12px; color: var(--t-dim); }
 .vis-confirm {


### PR DESCRIPTION
## Summary
- carry collaboration role into team summaries and identify role=host as the team's front agent
- render the front agent separately in the Teams panel, with workers listed below it
- enlarge sprite icons in dense app controls so the generated artwork remains readable

## Issue
Partial progress for #77 after #84. This makes the Teams panel match the front + workers model when profile daemons advertise role=host. Remaining pieces include richer team mention routing and full worker orchestration semantics.

## Verification
- cd web && bun test src/lib/teams.test.ts
- cd web && bun test
- cd web && bunx tsc --noEmit
- cd web && bunx vite build
- git diff --check