### PR TITLE
feat(tasks): 串联 completion 与 task 账本

### DIFF
--- a/cli/src/commands/complete.ts
+++ b/cli/src/commands/complete.ts
@@ -5,8 +5,8 @@ import { resolveAuth } from "../oidc-cli";
 import { handleRestError, postMessage } from "../rest";
 import { isName, isSlug, parseNonNegativeIntFlag, parsePositiveIntFlag } from "../validation";
 
-const COMPLETE_FLAGS = ["channel", "kickoff-seq", "replaces", "replies", "timeout", "issue", "pr", "mention"];
-const HELP = `usage: party complete <text|-> --kickoff-seq seq [--channel C] [--replaces seq] [--replies n] [--timeout] [--issue n]... [--pr n]... [--mention name]...
+const COMPLETE_FLAGS = ["channel", "kickoff-seq", "replaces", "replies", "timeout", "issue", "pr", "mention", "task"];
+const HELP = `usage: party complete <text|-> --kickoff-seq seq [--channel C] [--task id] [--replaces seq] [--replies n] [--timeout] [--issue n]... [--pr n]... [--mention name]...
 
 Publish a final synthesis completion artifact. The message replies to kickoff seq.
 If review gate is enabled, approve/reject it with: party review approve|reject <seq>
@@ -20,6 +20,7 @@ Options:
   --timeout         mark that collection ended by timeout
   --issue n         related GitHub issue number; repeatable
   --pr n            related GitHub PR number; repeatable
+  --task n          channel task this completion closes
   --mention name    mention a user or agent; repeatable`;
 
 function parsePositiveList(values: string[] | undefined, flag: string): number[] | string {
@@ -46,7 +47,7 @@ export async function run(argv: string[]): Promise<number> {
     console.error(unknown);
     return 1;
   }
-  const flagError = valueFlagError(parsed.flags, ["channel", "kickoff-seq", "replaces", "replies"], ["issue", "pr", "mention"]);
+  const flagError = valueFlagError(parsed.flags, ["channel", "kickoff-seq", "replaces", "replies", "task"], ["issue", "pr", "mention"]);
   if (flagError !== null) {
     console.error(flagError);
     return 1;
@@ -65,6 +66,11 @@ export async function run(argv: string[]): Promise<number> {
   const replaces = str(parsed.flags.replaces) === undefined ? undefined : parsePositiveIntFlag(str(parsed.flags.replaces), "replaces");
   if (typeof replaces === "string") {
     console.error(replaces);
+    return 1;
+  }
+  const taskId = str(parsed.flags.task) === undefined ? undefined : parsePositiveIntFlag(str(parsed.flags.task), "task");
+  if (typeof taskId === "string") {
+    console.error(taskId);
     return 1;
   }
   const relatedIssues = parsePositiveList(strArray(parsed.flags.issue), "issue");
@@ -121,6 +127,7 @@ export async function run(argv: string[]): Promise<number> {
         timeout: parsed.flags.timeout === true,
         related_issues: relatedIssues,
         related_prs: relatedPrs,
+        ...(taskId === undefined ? {} : { task_id: taskId }),
       },
       ...(replaces === undefined ? {} : { replaces }),
     });

--- a/cli/src/commands/status.ts
+++ b/cli/src/commands/status.ts
@@ -7,13 +7,14 @@ import type {
   SendHostDecision,
   SendStatusWorkflow,
   StatusState,
+  TaskState,
   WakeKind,
   WorkflowKind,
 } from "@agentparty/shared";
 import { isHelpArg, parseArgs, str, strArray, unknownFlagError, valueFlagError } from "../args";
 import { resolveChannel, saveCursor, workspaceId, workspaceLabel, worktreeLabel } from "../config";
 import { formatAuthDebugLine, resolveAuthDetailed } from "../oidc-cli";
-import { fetchMe, handleRestError, postMessage } from "../rest";
+import { fetchMe, handleRestError, postMessage, updateTask } from "../rest";
 import { isName, isSlug, parsePositiveIntFlag } from "../validation";
 
 const STATES: StatusState[] = ["working", "waiting", "blocked", "done"];
@@ -44,6 +45,7 @@ const STATUS_FLAGS = [
   "workflow-run",
   "workflow-step",
   "workflow-parent-summary-seq",
+  "task",
   "debug-auth",
 ];
 const HELP = `usage: party status [channel|--channel C] working|waiting|blocked|done [-m note] [--mention name]... [--debug-auth]
@@ -79,6 +81,7 @@ Options:
                    workflow step id
   --workflow-parent-summary-seq N
                    parent summary/status seq this workflow status refines
+  --task N         link this status to a channel task and update its task state
   --debug-auth     print resolved auth/config source to stderr`;
 
 export function buildContext(auth: Awaited<ReturnType<typeof resolveAuthDetailed>>): AgentContext {
@@ -139,6 +142,7 @@ export async function run(argv: string[]): Promise<number> {
       "workflow-run",
       "workflow-step",
       "workflow-parent-summary-seq",
+      "task",
     ],
     ["mention", "scope"],
   );
@@ -177,6 +181,11 @@ export async function run(argv: string[]): Promise<number> {
   const scope = strArray(flags.scope) ?? [];
   if (scope.some((item) => item.trim() === "")) {
     console.error("--scope must not be empty");
+    return 1;
+  }
+  const taskId = parsePositiveIntFlag(str(flags.task), "task");
+  if (typeof taskId === "string") {
+    console.error(taskId);
     return 1;
   }
   const summarySeq = parsePositiveIntFlag(str(flags["summary-seq"]), "summary-seq");
@@ -297,12 +306,14 @@ export async function run(argv: string[]): Promise<number> {
         console.error(`${formatAuthDebugLine(auth)} runtime-error=${message}`);
       }
     }
+    const taskScope = taskId === undefined ? [] : [`task:${taskId}`];
+    const effectiveScope = [...scope, ...taskScope];
     const { seq } = await postMessage(auth.server, auth.token, channel, {
       kind: "status",
       state: state as StatusState,
       note: str(flags.note) ?? "",
       mentions,
-      ...(scope.length > 0 ? { scope } : {}),
+      ...(effectiveScope.length > 0 ? { scope: effectiveScope } : {}),
       ...(summarySeq !== undefined ? { summary_seq: summarySeq } : {}),
       ...(blockedReason !== undefined ? { blocked_reason: blockedReason } : {}),
       ...(role !== undefined ? { role: role as CollaborationRole } : {}),
@@ -312,6 +323,13 @@ export async function run(argv: string[]): Promise<number> {
       ...(workflow !== undefined ? { workflow } : {}),
       context: buildContext(auth),
     });
+    if (taskId !== undefined) {
+      const taskState: TaskState =
+        state === "working" ? "in_progress" :
+        state === "waiting" ? "assigned" :
+        state as TaskState;
+      await updateTask(auth.server, auth.token, channel, taskId, { state: taskState });
+    }
     saveCursor(channel, seq);
     console.log(`status seq=${seq}`);
     return 0;

--- a/cli/test/m3.test.ts
+++ b/cli/test/m3.test.ts
@@ -704,6 +704,26 @@ describe("party status/history channel flag", () => {
     expect((req.body as { context: { worktree_label?: string } }).context.worktree_label).toContain(":");
   });
 
+  test("status --task scopes the status and updates the task ledger", async () => {
+    mock = startRestMock((req) => {
+      if (req.method === "PATCH" && req.path === "/api/channels/dev/tasks/12") {
+        return Response.json({ type: "task", id: 12, state: (req.body as { state: string }).state });
+      }
+      return undefined;
+    });
+    writeCfg(mock.url);
+    const r = await runCli(["status", "dev", "working", "-m", "started", "--scope", "web", "--task", "12"]);
+    expect(r.code).toBe(0);
+    const send = reqsOf(mock, "POST", "/api/channels/dev/messages")[0]!;
+    expect(send.body).toMatchObject({
+      kind: "status",
+      state: "working",
+      note: "started",
+      scope: ["web", "task:12"],
+    });
+    expect(reqsOf(mock, "PATCH", "/api/channels/dev/tasks/12")[0]!.body).toEqual({ state: "in_progress" });
+  });
+
   test("status debug-auth prints safe runtime/config source without raw token", async () => {
     mock = startRestMock();
     writeCfg(mock.url);
@@ -1324,6 +1344,8 @@ describe("party status/history channel flag", () => {
       "5",
       "--pr",
       "8",
+      "--task",
+      "12",
       "--mention",
       "alice",
     ]);
@@ -1342,6 +1364,7 @@ describe("party status/history channel flag", () => {
         timeout: true,
         related_issues: [5],
         related_prs: [8],
+        task_id: 12,
       },
     });
   });

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -427,6 +427,7 @@ export interface CompletionArtifact {
   timeout: boolean;
   related_issues: number[];
   related_prs: number[];
+  task_id?: number;
 }
 
 export interface CompletionReview {

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -205,6 +205,8 @@ function parseCompletionArtifact(input: unknown, replyTo: number | null): Comple
   const relatedIssues = parsePositiveIntArray(raw.related_issues);
   const relatedPrs = parsePositiveIntArray(raw.related_prs);
   if (relatedIssues === null || relatedPrs === null) return null;
+  const taskId = parseOptionalPositiveSeq(raw.task_id);
+  if (taskId === null) return null;
   const artifact: CompletionArtifact = {
     kind: "final_synthesis",
     kickoff_seq: kickoffSeq,
@@ -212,6 +214,7 @@ function parseCompletionArtifact(input: unknown, replyTo: number | null): Comple
     timeout: raw.timeout,
     related_issues: relatedIssues,
     related_prs: relatedPrs,
+    ...(taskId === undefined ? {} : { task_id: taskId }),
   };
   if (byteLength(JSON.stringify(artifact)) > COMPLETION_ARTIFACT_JSON_LIMIT) return null;
   return artifact;

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -672,6 +672,61 @@ async function loadTaskRow(db: D1Database, slug: string, id: number): Promise<Ta
     .first<TaskRow>();
 }
 
+function completionTaskIdFromPayload(input: unknown): number | null | undefined {
+  if (!isRecord(input) || input.kind !== "message") return undefined;
+  const artifact = input.completion_artifact;
+  if (!isRecord(artifact) || artifact.kind !== "final_synthesis" || artifact.task_id === undefined) return undefined;
+  return positiveInt(artifact.task_id);
+}
+
+function taskAnchorsWithCompletion(row: TaskRow, artifact: unknown, seq: number): number[] {
+  const anchors = taskRowToRecord(row).anchor_seqs;
+  if (isRecord(artifact)) {
+    const kickoff = positiveInt(artifact.kickoff_seq);
+    if (kickoff !== null && !anchors.includes(kickoff)) anchors.push(kickoff);
+  }
+  if (!anchors.includes(seq)) anchors.push(seq);
+  return anchors;
+}
+
+async function syncTaskCompletion(
+  env: AppEnv,
+  slug: string,
+  taskId: number,
+  artifact: unknown,
+  seq: number,
+  state: Extract<TaskState, "needs_review" | "done" | "in_progress">,
+): Promise<void> {
+  const row = await loadTaskRow(env.DB, slug, taskId);
+  if (!row) return;
+  const now = Date.now();
+  const anchors = taskAnchorsWithCompletion(row, artifact, seq);
+  await env.DB.prepare(
+    `UPDATE channel_tasks
+        SET state = ?,
+            completion_artifact_json = ?,
+            anchor_seqs_json = ?,
+            updated_at = ?,
+            completed_at = ?
+      WHERE channel_slug = ? AND id = ?`,
+  )
+    .bind(
+      state,
+      JSON.stringify(artifact),
+      JSON.stringify(anchors),
+      now,
+      state === "done" ? row.completed_at ?? now : null,
+      slug,
+      taskId,
+    )
+    .run();
+  const note =
+    state === "needs_review" ? `task #${taskId} needs_review via completion #${seq}` :
+    state === "done" ? `task #${taskId} done via completion #${seq}` :
+    `task #${taskId} back to in_progress after rejected completion #${seq}`;
+  await insertSystemStatus(env, slug, note).catch(() => false);
+}
+
 // 铸/重铸 token 的落库逻辑（/api/tokens 与 /api/agents 共用）：
 // 同名活 token 冲突返回 conflict；同名已吊销 token 复用行覆盖（owner/channel_scope 一并刷新），
 // 否则插新行。返回一次性明文 token。
@@ -3604,7 +3659,7 @@ app.post("/api/channels/:slug/messages/:seq/review", async (c) => {
   const seq = positiveInt(Number(c.req.param("seq")));
   if (seq === null) return c.json(errorBody("bad_request", "seq must be a positive integer"), 400);
   const assignedRole = await loadAssignedRole(c.env.DB, slug, identity.name);
-  return fetchChannelDO(
+  const res = await fetchChannelDO(
     c.env,
     slug,
     new Request(`https://do/internal/messages/${seq}/review`, {
@@ -3625,6 +3680,19 @@ app.post("/api/channels/:slug/messages/:seq/review", async (c) => {
       },
     }),
   );
+  if (!res.ok) return res;
+  const payload = (await res.clone().json().catch(() => null)) as { message?: MsgFrame } | null;
+  const message = payload?.message;
+  const taskId = message?.completion_artifact?.task_id;
+  const reviewState = message?.completion_review?.state;
+  if (message !== undefined && typeof taskId === "number" && Number.isInteger(taskId) && taskId > 0) {
+    if (reviewState === "approved") {
+      await syncTaskCompletion(c.env, slug, taskId, message.completion_artifact, message.seq, "done");
+    } else if (reviewState === "rejected") {
+      await syncTaskCompletion(c.env, slug, taskId, message.completion_artifact, message.seq, "in_progress");
+    }
+  }
+  return res;
 });
 
 app.post("/api/channels/:slug/messages/:seq/:action", async (c) => {
@@ -3699,13 +3767,26 @@ app.post("/api/channels/:slug/messages", async (c) => {
   if (channel.archived_at !== null) {
     return c.json(errorBody("archived", "channel is archived"), 410);
   }
+  const rawBody = await c.req.text();
+  const parsedBody = ((): unknown => {
+    try {
+      return JSON.parse(rawBody || "null");
+    } catch {
+      return null;
+    }
+  })();
+  const taskId = completionTaskIdFromPayload(parsedBody);
+  if (taskId === null) return c.json(errorBody("bad_request", "completion task_id must be a positive integer"), 400);
+  if (taskId !== undefined && !(await loadTaskRow(c.env.DB, slug, taskId))) {
+    return c.json(errorBody("not_found", "task not found in this channel"), 404);
+  }
   const assignedRole = await loadAssignedRole(c.env.DB, slug, identity.name);
-  return fetchChannelDO(
+  const res = await fetchChannelDO(
     c.env,
     slug,
     new Request("https://do/internal/messages", {
       method: "POST",
-      body: await c.req.text(),
+      body: rawBody,
       headers: {
         "content-type": "application/json",
         "x-partykit-room": slug,
@@ -3721,6 +3802,14 @@ app.post("/api/channels/:slug/messages", async (c) => {
       },
     }),
   );
+  if (!res.ok || taskId === undefined || !isRecord(parsedBody)) return res;
+  const payload = (await res.clone().json().catch(() => null)) as { seq?: unknown; completion_review?: { state?: unknown } } | null;
+  const seq = positiveInt(payload?.seq);
+  if (seq !== null) {
+    const state = payload?.completion_review?.state === "pending_review" ? "needs_review" : "done";
+    await syncTaskCompletion(c.env, slug, taskId, parsedBody.completion_artifact, seq, state);
+  }
+  return res;
 });
 
 // outbound webhook 注册 / 列表 / 删除（spec §7/§15），存储在频道 do 里

--- a/worker/test/completion-review.spec.ts
+++ b/worker/test/completion-review.spec.ts
@@ -6,7 +6,7 @@ interface MsgLike {
   body: string;
   mentions: string[];
   reply_to: number | null;
-  completion_artifact?: { kickoff_seq: number };
+  completion_artifact?: { kickoff_seq: number; task_id?: number };
   completion_review?: {
     state: "pending_review" | "approved" | "rejected";
     policy: "sender" | "owner";
@@ -36,7 +36,7 @@ async function fixture() {
   return { slug, owner, writer, reviewer, readonly, kickoffSeq };
 }
 
-async function postCompletion(slug: string, token: string, kickoffSeq: number, opts: { replaces?: number; body?: string } = {}) {
+async function postCompletion(slug: string, token: string, kickoffSeq: number, opts: { replaces?: number; body?: string; taskId?: number } = {}) {
   return api(`/api/channels/${slug}/messages`, token, {
     method: "POST",
     body: JSON.stringify({
@@ -51,10 +51,32 @@ async function postCompletion(slug: string, token: string, kickoffSeq: number, o
         timeout: false,
         related_issues: [],
         related_prs: [],
+        ...(opts.taskId === undefined ? {} : { task_id: opts.taskId }),
       },
       ...(opts.replaces === undefined ? {} : { replaces: opts.replaces }),
     }),
   });
+}
+
+async function createTask(slug: string, token: string, title = "Ship task-linked completion"): Promise<number> {
+  const res = await api(`/api/channels/${slug}/tasks`, token, {
+    method: "POST",
+    body: JSON.stringify({ title }),
+  });
+  expect(res.status).toBe(201);
+  return ((await res.json()) as { id: number }).id;
+}
+
+async function getTask(slug: string, token: string, id: number) {
+  const res = await api(`/api/channels/${slug}/tasks/${id}`, token);
+  expect(res.status).toBe(200);
+  return (await res.json()) as {
+    id: number;
+    state: string;
+    completion_artifact: { task_id?: number } | null;
+    anchor_seqs: number[];
+    completed_at: number | null;
+  };
 }
 
 async function history(slug: string, token: string): Promise<MsgLike[]> {
@@ -141,6 +163,46 @@ describe("review-gated completion (#34)", () => {
       mentions: [writer.name],
       body: `@${writer.name} review rejected #${seq}: missing test evidence`,
     });
+  });
+
+  it("syncs task state and artifact across completion review", async () => {
+    const { slug, writer, reviewer, kickoffSeq } = await fixture();
+    const taskId = await createTask(slug, writer.token);
+    const completion = await postCompletion(slug, writer.token, kickoffSeq, { taskId });
+    expect(completion.status).toBe(200);
+    const completionBody = (await completion.json()) as { seq: number; completion_review?: { state: string } };
+    expect(completionBody.completion_review?.state).toBe("pending_review");
+
+    const pendingTask = await getTask(slug, writer.token, taskId);
+    expect(pendingTask.state).toBe("needs_review");
+    expect(pendingTask.completion_artifact?.task_id).toBe(taskId);
+    expect(pendingTask.anchor_seqs).toEqual([kickoffSeq, completionBody.seq]);
+    expect(pendingTask.completed_at).toBeNull();
+
+    const rejected = await api(`/api/channels/${slug}/messages/${completionBody.seq}/review`, reviewer.token, {
+      method: "POST",
+      body: JSON.stringify({ action: "reject", reason: "needs more detail" }),
+    });
+    expect(rejected.status).toBe(200);
+    expect((await getTask(slug, writer.token, taskId)).state).toBe("in_progress");
+
+    const replacement = await postCompletion(slug, writer.token, kickoffSeq, {
+      taskId,
+      replaces: completionBody.seq,
+      body: "reworked final synthesis",
+    });
+    expect(replacement.status).toBe(200);
+    const replacementBody = (await replacement.json()) as { seq: number };
+    expect((await getTask(slug, writer.token, taskId)).state).toBe("needs_review");
+
+    const approved = await api(`/api/channels/${slug}/messages/${replacementBody.seq}/review`, reviewer.token, {
+      method: "POST",
+      body: JSON.stringify({ action: "approve" }),
+    });
+    expect(approved.status).toBe(200);
+    const doneTask = await getTask(slug, writer.token, taskId);
+    expect(doneTask.state).toBe("done");
+    expect(doneTask.completed_at).toBeTypeOf("number");
   });
 
   it("links a reworked completion to the rejected one and bumps the old row rev_seq", async () => {


### PR DESCRIPTION
## Summary
- add optional task_id to final synthesis completion artifacts
- add CLI support for party complete --task and party status --task
- sync linked task state through completion/review: pending review -> needs_review, approve -> done, reject -> in_progress
- persist completion artifact and anchor kickoff/completion seqs on the task ledger

## Issue
Partial progress for #68 M1. This connects the existing Task object with the existing status/complete/review flow so the board becomes a real ledger instead of a standalone list.

Remaining #68 slices: task from <seq>, richer block reason storage, board interactions/drag assign, digest/statusline task aggregation.

## Verification
- cd cli && bun test
- cd cli && bunx tsc --noEmit
- cd worker && bun run test
- cd worker && bunx tsc --noEmit
- cd web && bun test && bunx tsc --noEmit
- cd shared && bunx tsc --noEmit
- git diff --check