### PR TITLE
feat(cli): 支持从消息创建 task

### DIFF
--- a/cli/src/commands/task.ts
+++ b/cli/src/commands/task.ts
@@ -1,10 +1,10 @@
 // party task — channel-scoped task ledger.
-import type { TaskAssigneeKind, TaskRecord, TaskState } from "../rest";
+import type { MsgFrame, TaskAssigneeKind, TaskRecord, TaskState } from "@agentparty/shared";
 import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
 import { resolveChannel } from "../config";
 import { jsonFrame } from "../json";
 import { resolveAuth } from "../oidc-cli";
-import { createTask, handleRestError, listTasks, updateTask } from "../rest";
+import { createTask, fetchMessages, handleRestError, listTasks, updateTask } from "../rest";
 import { isName, isSlug, parsePositiveIntFlag } from "../validation";
 
 const TASK_STATES: readonly string[] = ["triage", "backlog", "assigned", "in_progress", "needs_review", "done", "blocked"] satisfies TaskState[];
@@ -26,6 +26,7 @@ const FLAGS = [
 ];
 
 const HELP = `usage: party task create <title|-> [--channel C] [--desc text] [--assignee @name] [--label bug]... [--priority N] [--parent ID] [--anchor seq]...
+  party task from <seq> [--channel C] [--title text] [--desc text] [--assignee @name] [--label bug]...
   party task list [--channel C] [--state S] [--assignee @name] [--limit N] [--json]
   party task assign <id> @name [--channel C] [--assignee-kind agent|human|squad]
   party task claim <id> [--channel C]
@@ -58,6 +59,12 @@ function readStdin(): Promise<string> {
 
 function compact(text: string): string {
   return text.replace(/\s+/g, " ").trim();
+}
+
+function titleFromMessage(msg: MsgFrame): string {
+  const raw = compact(msg.kind === "status" ? (msg.note ?? msg.body) : msg.body);
+  const label = raw === "" ? `${msg.sender.name} message #${msg.seq}` : raw;
+  return label.length > 120 ? `${label.slice(0, 117)}...` : label;
 }
 
 function formatTask(task: TaskRecord): string {
@@ -148,10 +155,27 @@ export async function run(argv: string[]): Promise<number> {
       return 0;
     }
 
-    if (sub === "create") {
-      const title = await titleArg(str(flags.title) ?? positionals[1]);
+    if (sub === "create" || sub === "from") {
+      const sourceSeq = sub === "from" ? parsePositiveIntFlag(positionals[1], "seq") : undefined;
+      if (typeof sourceSeq === "string") {
+        console.error(sourceSeq);
+        return 1;
+      }
+      if (sub === "from" && sourceSeq === undefined) {
+        console.error("usage: party task from <seq> [--channel C]");
+        return 1;
+      }
+      const source =
+        sourceSeq === undefined
+          ? undefined
+          : (await fetchMessages(cfg.server, cfg.token, slug, sourceSeq - 1, 1)).find((msg) => msg.seq === sourceSeq);
+      if (sourceSeq !== undefined && source === undefined) {
+        console.error(`message #${sourceSeq} not found`);
+        return 1;
+      }
+      const title = await titleArg(str(flags.title) ?? (sub === "create" ? positionals[1] : undefined)) ?? (source === undefined ? null : titleFromMessage(source));
       if (!title) {
-        console.error("usage: party task create <title|-> [--channel C]");
+        console.error(sub === "from" ? "usage: party task from <seq> [--channel C]" : "usage: party task create <title|-> [--channel C]");
         return 1;
       }
       const state = parseState(str(flags.state));
@@ -182,6 +206,7 @@ export async function run(argv: string[]): Promise<number> {
       }
       const anchorRaw = Array.isArray(flags.anchor) ? flags.anchor : flags.anchor === undefined ? [] : [flags.anchor];
       const anchors: number[] = [];
+      if (sourceSeq !== undefined) anchors.push(sourceSeq);
       for (const item of anchorRaw) {
         const anchor = parsePositiveIntFlag(typeof item === "string" ? item : undefined, "anchor");
         if (typeof anchor === "string" || anchor === undefined) {

--- a/cli/test/cli.test.ts
+++ b/cli/test/cli.test.ts
@@ -223,6 +223,80 @@ describe("cli subprocess", () => {
     });
   });
 
+  test("task from creates a task anchored to the source message", async () => {
+    const seen: { method: string; path: string; body: unknown }[] = [];
+    const task = {
+      type: "task",
+      id: 2,
+      channel: "dev",
+      title: "Investigate login timeout with traces",
+      desc: "needs owner",
+      state: "triage",
+      assignee: null,
+      created_by: "me",
+      created_by_kind: "agent",
+      priority: 0,
+      labels: ["bug"],
+      parent_id: null,
+      anchor_seqs: [7],
+      completion_artifact: null,
+      workflow_id: null,
+      created_at: 1,
+      updated_at: 1,
+    };
+    restServer = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      async fetch(req) {
+        const url = new URL(req.url);
+        const body = req.method === "GET" ? null : await req.json().catch(() => null);
+        seen.push({ method: req.method, path: `${url.pathname}${url.search}`, body });
+        if (url.pathname === "/api/channels/dev/messages" && req.method === "GET") {
+          return Response.json({
+            messages: [
+              {
+                type: "msg",
+                channel: "dev",
+                seq: 7,
+                ts: 1,
+                sender: { name: "evan", kind: "human" },
+                kind: "message",
+                body: "Investigate login timeout\nwith traces",
+                mentions: [],
+                reply_to: null,
+              },
+            ],
+          });
+        }
+        if (url.pathname === "/api/channels/dev/tasks" && req.method === "POST") {
+          return Response.json(task, { status: 201 });
+        }
+        return Response.json({ error: { code: "not_found", message: "not found" } }, { status: 404 });
+      },
+    });
+    mkdirSync(home, { recursive: true });
+    writeFileSync(
+      join(home, "config.json"),
+      JSON.stringify({ server: `http://127.0.0.1:${restServer.port}`, token: "ap_tok" }),
+    );
+
+    const result = await runCli(["task", "from", "7", "--channel", "dev", "--label", "bug", "--desc", "needs owner"]);
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("created #2");
+
+    expect(seen).toContainEqual({ method: "GET", path: "/api/channels/dev/messages?since=6&limit=1", body: null });
+    expect(seen).toContainEqual({
+      method: "POST",
+      path: "/api/channels/dev/tasks",
+      body: {
+        title: "Investigate login timeout with traces",
+        desc: "needs owner",
+        labels: ["bug"],
+        anchor_seqs: [7],
+      },
+    });
+  });
+
   test("charter template works without config", async () => {
     const r = await runCli(["charter", "template"]);
     expect(r.code).toBe(0);


### PR DESCRIPTION
## Summary
- add `party task from <seq>` to create a task from an existing channel message
- default the task title from compacted message/status text and anchor the source seq
- cover the subprocess REST flow in CLI tests

## Tests
- `cd cli && bun test test/cli.test.ts`
- `cd cli && bunx tsc --noEmit`
- `cd cli && bun test`
- `git diff --check`

Refs #68