### PR TITLE
feat(mcp): 暴露 task 账本工具

### DIFF
--- a/cli/src/commands/mcp.ts
+++ b/cli/src/commands/mcp.ts
@@ -1,6 +1,6 @@
 // party mcp — stdio MCP server exposing AgentParty as structured tools.
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import type { StatusState } from "@agentparty/shared";
+import type { MsgFrame, StatusState, TaskAssigneeKind, TaskState } from "@agentparty/shared";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
@@ -8,7 +8,18 @@ import pkg from "../../package.json" with { type: "json" };
 import { loadCursor, loadRevCursor, resolveChannel, saveCursor, saveRevCursor } from "../config";
 import { jsonFrame } from "../json";
 import { resolveAuth, resolveAuthDetailed } from "../oidc-cli";
-import { fetchMe, fetchMessages, fetchPresence, handleRestError, listChannels, postMessage, type Identity } from "../rest";
+import {
+  createTask,
+  fetchMe,
+  fetchMessages,
+  fetchPresence,
+  handleRestError,
+  listChannels,
+  listTasks,
+  postMessage,
+  updateTask,
+  type Identity,
+} from "../rest";
 import { isName, isSlug } from "../validation";
 import { buildContext } from "./status";
 import { runWatch } from "./watch";
@@ -28,10 +39,16 @@ Tools:
   party_who
   party_history
   party_digest
+  party_task_list
+  party_task_create
+  party_task_from_message
+  party_task_update
   party_watch_once
   party_wake_test`;
 
 const StateSchema = z.enum(["working", "waiting", "blocked", "done"]);
+const TaskStateSchema = z.enum(["triage", "backlog", "assigned", "in_progress", "needs_review", "done", "blocked"]);
+const TaskAssigneeKindSchema = z.enum(["agent", "human", "squad"]);
 
 function ok(data: Record<string, unknown>, text?: string): CallToolResult {
   return {
@@ -59,6 +76,30 @@ function normalizeMentions(mentions?: string[]): string[] {
   const bad = values.find((mention) => !isName(mention));
   if (bad !== undefined) throw new Error(`invalid mention: ${bad}`);
   return values;
+}
+
+function normalizeLabels(labels?: string[]): string[] | undefined {
+  if (labels === undefined) return undefined;
+  const trimmed = labels.map((label) => label.trim());
+  if (trimmed.some((label) => label === "")) throw new Error("labels must not be empty");
+  return [...new Set(trimmed)];
+}
+
+function normalizeAssignee(name?: string, kind?: TaskAssigneeKind): { name: string; kind: TaskAssigneeKind } | undefined {
+  if (name === undefined) return undefined;
+  const normalized = name.replace(/^@/, "");
+  if (!isName(normalized)) throw new Error("assignee_name must be a valid AgentParty name");
+  return { name: normalized, kind: kind ?? "agent" };
+}
+
+function compact(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+function titleFromMessage(msg: MsgFrame): string {
+  const raw = compact(msg.kind === "status" ? (msg.note ?? msg.body) : msg.body);
+  const label = raw === "" ? `${msg.sender.name} message #${msg.seq}` : raw;
+  return label.length > 120 ? `${label.slice(0, 117)}...` : label;
 }
 
 async function auth(): Promise<{ server: string; token: string; me?: Identity }> {
@@ -202,25 +243,36 @@ export function createMcpServer(defaultChannel?: string): McpServer {
         mentions: z.array(z.string()).optional(),
         scope: z.array(z.string()).optional(),
         summary_seq: z.number().int().positive().optional(),
+        task_id: z.number().int().positive().optional(),
       },
     },
-    async ({ channel, state, note, mentions, scope, summary_seq }) => {
+    async ({ channel, state, note, mentions, scope, summary_seq, task_id }) => {
       try {
         const authInfo = await resolveAuthDetailed();
         if (!authInfo.server || !authInfo.token) throw new Error("no config, run: party login or party init --server URL --token T");
         const resolved = normalizeChannel(channel, defaultChannel);
         const normalizedMentions = normalizeMentions(mentions);
+        const taskScope = task_id === undefined ? [] : [`task:${task_id}`];
+        const effectiveScope = [...(scope ?? []), ...taskScope];
         const { seq } = await postMessage(authInfo.server, authInfo.token, resolved, {
           kind: "status",
           state: state as StatusState,
           note: note ?? "",
           mentions: normalizedMentions,
-          ...(scope && scope.length > 0 ? { scope } : {}),
+          ...(effectiveScope.length > 0 ? { scope: effectiveScope } : {}),
           ...(summary_seq !== undefined ? { summary_seq } : {}),
           context: buildContext(authInfo),
         });
+        let task = undefined;
+        if (task_id !== undefined) {
+          const taskState: TaskState =
+            state === "working" ? "in_progress" :
+            state === "waiting" ? "assigned" :
+            state as TaskState;
+          task = await updateTask(authInfo.server, authInfo.token, resolved, task_id, { state: taskState });
+        }
         saveCursor(resolved, seq);
-        return ok({ type: "status", channel: resolved, seq, state });
+        return ok({ type: "status", channel: resolved, seq, state, ...(task !== undefined ? { task } : {}) });
       } catch (e) {
         const code = handleRestError(e);
         return fail(code === 1 && e instanceof Error ? e.message : `status failed with exit ${code}`);
@@ -295,6 +347,168 @@ export function createMcpServer(defaultChannel?: string): McpServer {
       ];
       const captured = await captureCommand(async () => (await import("./digest")).run(argv));
       return capturedResult("digest", captured);
+    },
+  );
+
+  server.registerTool(
+    "party_task_list",
+    {
+      title: "List channel tasks",
+      description: "List AgentParty channel tasks from the task ledger.",
+      inputSchema: {
+        channel: z.string().optional(),
+        state: TaskStateSchema.optional(),
+        assignee: z.string().optional().describe("Assignee name, with or without @ prefix."),
+        limit: z.number().int().positive().max(500).optional(),
+      },
+    },
+    async ({ channel, state, assignee, limit }) => {
+      try {
+        const cfg = await auth();
+        const resolved = normalizeChannel(channel, defaultChannel);
+        const normalizedAssignee = assignee?.replace(/^@/, "");
+        if (normalizedAssignee !== undefined && !isName(normalizedAssignee)) throw new Error("assignee must be a valid AgentParty name");
+        const tasks = await listTasks(cfg.server, cfg.token, resolved, {
+          ...(state !== undefined ? { state: state as TaskState } : {}),
+          ...(normalizedAssignee !== undefined ? { assignee: normalizedAssignee } : {}),
+          ...(limit !== undefined ? { limit } : {}),
+        });
+        return ok({ type: "task_list", channel: resolved, tasks });
+      } catch (e) {
+        return fail(e instanceof Error ? e.message : String(e));
+      }
+    },
+  );
+
+  server.registerTool(
+    "party_task_create",
+    {
+      title: "Create channel task",
+      description: "Create an AgentParty channel task.",
+      inputSchema: {
+        channel: z.string().optional(),
+        title: z.string().min(1),
+        desc: z.string().optional(),
+        state: TaskStateSchema.optional(),
+        assignee_name: z.string().optional().describe("Assignee name, with or without @ prefix."),
+        assignee_kind: TaskAssigneeKindSchema.optional(),
+        priority: z.number().int().min(-100).max(100).optional(),
+        labels: z.array(z.string()).optional(),
+        parent_id: z.number().int().positive().optional(),
+        anchor_seqs: z.array(z.number().int().positive()).optional(),
+        workflow_id: z.string().optional(),
+      },
+    },
+    async ({ channel, title, desc, state, assignee_name, assignee_kind, priority, labels, parent_id, anchor_seqs, workflow_id }) => {
+      try {
+        const cfg = await auth();
+        const resolved = normalizeChannel(channel, defaultChannel);
+        const normalizedLabels = normalizeLabels(labels);
+        const assignee = normalizeAssignee(assignee_name, assignee_kind as TaskAssigneeKind | undefined);
+        const task = await createTask(cfg.server, cfg.token, resolved, {
+          title,
+          ...(desc !== undefined ? { desc } : {}),
+          ...(state !== undefined ? { state: state as TaskState } : {}),
+          ...(assignee !== undefined ? { assignee } : {}),
+          ...(priority !== undefined ? { priority } : {}),
+          ...(normalizedLabels !== undefined && normalizedLabels.length > 0 ? { labels: normalizedLabels } : {}),
+          ...(parent_id !== undefined ? { parent_id } : {}),
+          ...(anchor_seqs !== undefined && anchor_seqs.length > 0 ? { anchor_seqs } : {}),
+          ...(workflow_id !== undefined ? { workflow_id } : {}),
+        });
+        return ok({ type: "task_create", channel: resolved, task });
+      } catch (e) {
+        return fail(e instanceof Error ? e.message : String(e));
+      }
+    },
+  );
+
+  server.registerTool(
+    "party_task_from_message",
+    {
+      title: "Create task from message",
+      description: "Create an AgentParty task from an existing message and anchor the source seq.",
+      inputSchema: {
+        channel: z.string().optional(),
+        source_seq: z.number().int().positive(),
+        title: z.string().min(1).optional(),
+        desc: z.string().optional(),
+        state: TaskStateSchema.optional(),
+        assignee_name: z.string().optional(),
+        assignee_kind: TaskAssigneeKindSchema.optional(),
+        priority: z.number().int().min(-100).max(100).optional(),
+        labels: z.array(z.string()).optional(),
+        parent_id: z.number().int().positive().optional(),
+        anchor_seqs: z.array(z.number().int().positive()).optional(),
+        workflow_id: z.string().optional(),
+      },
+    },
+    async ({ channel, source_seq, title, desc, state, assignee_name, assignee_kind, priority, labels, parent_id, anchor_seqs, workflow_id }) => {
+      try {
+        const cfg = await auth();
+        const resolved = normalizeChannel(channel, defaultChannel);
+        const source = (await fetchMessages(cfg.server, cfg.token, resolved, source_seq - 1, 1)).find((msg) => msg.seq === source_seq);
+        if (source === undefined) throw new Error(`message #${source_seq} not found`);
+        const normalizedLabels = normalizeLabels(labels);
+        const assignee = normalizeAssignee(assignee_name, assignee_kind as TaskAssigneeKind | undefined);
+        const anchors = [...new Set([source_seq, ...(anchor_seqs ?? [])])];
+        const task = await createTask(cfg.server, cfg.token, resolved, {
+          title: title ?? titleFromMessage(source),
+          ...(desc !== undefined ? { desc } : {}),
+          ...(state !== undefined ? { state: state as TaskState } : {}),
+          ...(assignee !== undefined ? { assignee } : {}),
+          ...(priority !== undefined ? { priority } : {}),
+          ...(normalizedLabels !== undefined && normalizedLabels.length > 0 ? { labels: normalizedLabels } : {}),
+          ...(parent_id !== undefined ? { parent_id } : {}),
+          anchor_seqs: anchors,
+          ...(workflow_id !== undefined ? { workflow_id } : {}),
+        });
+        return ok({ type: "task_from_message", channel: resolved, source_seq, task });
+      } catch (e) {
+        return fail(e instanceof Error ? e.message : String(e));
+      }
+    },
+  );
+
+  server.registerTool(
+    "party_task_update",
+    {
+      title: "Update channel task",
+      description: "Update title, state, assignee, priority, labels, or description for an AgentParty task.",
+      inputSchema: {
+        channel: z.string().optional(),
+        id: z.number().int().positive(),
+        title: z.string().min(1).optional(),
+        desc: z.string().nullable().optional(),
+        state: TaskStateSchema.optional(),
+        assignee_name: z.string().optional(),
+        assignee_kind: TaskAssigneeKindSchema.optional(),
+        clear_assignee: z.boolean().optional(),
+        priority: z.number().int().min(-100).max(100).optional(),
+        labels: z.array(z.string()).optional(),
+      },
+    },
+    async ({ channel, id, title, desc, state, assignee_name, assignee_kind, clear_assignee, priority, labels }) => {
+      try {
+        const cfg = await auth();
+        const resolved = normalizeChannel(channel, defaultChannel);
+        if (clear_assignee === true && assignee_name !== undefined) throw new Error("clear_assignee cannot be combined with assignee_name");
+        const normalizedLabels = normalizeLabels(labels);
+        const assignee = clear_assignee === true ? null : normalizeAssignee(assignee_name, assignee_kind as TaskAssigneeKind | undefined);
+        const body = {
+          ...(title !== undefined ? { title } : {}),
+          ...(desc !== undefined ? { desc } : {}),
+          ...(state !== undefined ? { state: state as TaskState } : {}),
+          ...(assignee !== undefined ? { assignee } : {}),
+          ...(priority !== undefined ? { priority } : {}),
+          ...(normalizedLabels !== undefined ? { labels: normalizedLabels } : {}),
+        };
+        if (Object.keys(body).length === 0) throw new Error("no task fields to update");
+        const task = await updateTask(cfg.server, cfg.token, resolved, id, body);
+        return ok({ type: "task_update", channel: resolved, task });
+      } catch (e) {
+        return fail(e instanceof Error ? e.message : String(e));
+      }
     },
   );
 

--- a/cli/test/cli.test.ts
+++ b/cli/test/cli.test.ts
@@ -95,7 +95,26 @@ describe("cli subprocess", () => {
   });
 
   test("mcp server lists tools and sends via REST（#66）", async () => {
-    const seen: { path: string; auth: string | null; body: unknown }[] = [];
+    const seen: { method: string; path: string; auth: string | null; body: unknown }[] = [];
+    const task = {
+      type: "task",
+      id: 1,
+      channel: "dev",
+      title: "Fix login",
+      desc: null,
+      state: "triage",
+      assignee: null,
+      created_by: "me",
+      created_by_kind: "agent",
+      priority: 2,
+      labels: ["bug"],
+      parent_id: null,
+      anchor_seqs: [7],
+      completion_artifact: null,
+      workflow_id: null,
+      created_at: 1,
+      updated_at: 1,
+    };
     restServer = Bun.serve({
       hostname: "127.0.0.1",
       port: 0,
@@ -105,9 +124,35 @@ describe("cli subprocess", () => {
         if (req.method !== "GET") {
           body = await req.json().catch(() => null);
         }
-        seen.push({ path: url.pathname, auth: req.headers.get("authorization"), body });
+        seen.push({ method: req.method, path: `${url.pathname}${url.search}`, auth: req.headers.get("authorization"), body });
         if (url.pathname === "/api/channels/dev/messages" && req.method === "POST") {
           return Response.json({ seq: 42 });
+        }
+        if (url.pathname === "/api/channels/dev/messages" && req.method === "GET") {
+          return Response.json({
+            messages: [
+              {
+                type: "msg",
+                channel: "dev",
+                seq: 7,
+                ts: 1,
+                sender: { name: "evan", kind: "human" },
+                kind: "message",
+                body: "Fix login from message",
+                mentions: [],
+                reply_to: null,
+              },
+            ],
+          });
+        }
+        if (url.pathname === "/api/channels/dev/tasks" && req.method === "GET") {
+          return Response.json({ tasks: [task] });
+        }
+        if (url.pathname === "/api/channels/dev/tasks" && req.method === "POST") {
+          return Response.json(task, { status: 201 });
+        }
+        if (url.pathname === "/api/channels/dev/tasks/1" && req.method === "PATCH") {
+          return Response.json({ ...task, ...(body && typeof body === "object" ? body : {}) });
         }
         if (url.pathname === "/api/me") {
           return Response.json({ name: "me", email: null, kind: "agent", role: "member", owner: null });
@@ -133,6 +178,10 @@ describe("cli subprocess", () => {
       const tools = await client.listTools();
       expect(tools.tools.map((tool) => tool.name)).toContain("party_send");
       expect(tools.tools.map((tool) => tool.name)).toContain("party_watch_once");
+      expect(tools.tools.map((tool) => tool.name)).toContain("party_task_create");
+      expect(tools.tools.map((tool) => tool.name)).toContain("party_task_from_message");
+      expect(tools.tools.map((tool) => tool.name)).toContain("party_task_list");
+      expect(tools.tools.map((tool) => tool.name)).toContain("party_task_update");
 
       const result = await client.callTool({
         name: "party_send",
@@ -140,11 +189,83 @@ describe("cli subprocess", () => {
       });
       expect(result.isError).not.toBe(true);
       expect(result.structuredContent).toMatchObject({ type: "send", channel: "dev", seq: 42 });
-      expect(seen).toContainEqual({
+      expect(seen).toContainEqual(expect.objectContaining({
+        method: "POST",
         path: "/api/channels/dev/messages",
         auth: "Bearer ap_tok",
         body: { kind: "message", body: "hello mcp", mentions: ["bob"], reply_to: null },
+      }));
+
+      const created = await client.callTool({
+        name: "party_task_create",
+        arguments: { title: "Fix login", labels: ["bug"], priority: 2, anchor_seqs: [7] },
       });
+      expect(created.isError).not.toBe(true);
+      expect(created.structuredContent).toMatchObject({ type: "task_create", channel: "dev", task: { id: 1 } });
+
+      const fromMessage = await client.callTool({
+        name: "party_task_from_message",
+        arguments: { source_seq: 7, labels: ["bug"] },
+      });
+      expect(fromMessage.isError).not.toBe(true);
+      expect(fromMessage.structuredContent).toMatchObject({ type: "task_from_message", source_seq: 7, task: { id: 1 } });
+
+      const listed = await client.callTool({
+        name: "party_task_list",
+        arguments: { state: "triage", assignee: "@alice" },
+      });
+      expect(listed.isError).not.toBe(true);
+      expect(listed.structuredContent).toMatchObject({ type: "task_list", channel: "dev", tasks: [{ id: 1 }] });
+
+      const updated = await client.callTool({
+        name: "party_task_update",
+        arguments: { id: 1, state: "assigned", assignee_name: "@alice" },
+      });
+      expect(updated.isError).not.toBe(true);
+      expect(updated.structuredContent).toMatchObject({ type: "task_update", task: { id: 1, state: "assigned" } });
+
+      const status = await client.callTool({
+        name: "party_status",
+        arguments: { state: "working", note: "started", task_id: 1 },
+      });
+      expect(status.isError).not.toBe(true);
+      expect(status.structuredContent).toMatchObject({ type: "status", task: { id: 1, state: "in_progress" } });
+
+      expect(seen).toContainEqual(expect.objectContaining({
+        method: "POST",
+        path: "/api/channels/dev/tasks",
+        body: { title: "Fix login", priority: 2, labels: ["bug"], anchor_seqs: [7] },
+      }));
+      expect(seen).toContainEqual(expect.objectContaining({
+        method: "GET",
+        path: "/api/channels/dev/messages?since=6&limit=1",
+        body: null,
+      }));
+      expect(seen).toContainEqual(expect.objectContaining({
+        method: "POST",
+        path: "/api/channels/dev/tasks",
+        body: { title: "Fix login from message", labels: ["bug"], anchor_seqs: [7] },
+      }));
+      expect(seen).toContainEqual(expect.objectContaining({
+        method: "GET",
+        path: "/api/channels/dev/tasks?state=triage&assignee=alice",
+        body: null,
+      }));
+      expect(seen).toContainEqual(expect.objectContaining({
+        method: "PATCH",
+        path: "/api/channels/dev/tasks/1",
+        body: { state: "assigned", assignee: { name: "alice", kind: "agent" } },
+      }));
+      expect(seen).toContainEqual(expect.objectContaining({
+        method: "POST",
+        path: "/api/channels/dev/messages",
+        body: { kind: "status", state: "working", note: "started", mentions: [], scope: ["task:1"], context: expect.any(Object) },
+      }));
+      expect(seen).toContainEqual(expect.objectContaining({
+        method: "PATCH",
+        path: "/api/channels/dev/tasks/1",
+        body: { state: "in_progress" },
+      }));
     } finally {
       await client.close();
     }


### PR DESCRIPTION
## Summary
- add MCP tools for task list/create/from-message/update
- let party_status accept task_id and sync the linked task state like the CLI status command
- cover the MCP stdio client flow and REST request shapes in CLI subprocess tests

## Tests
- `cd cli && bun test test/cli.test.ts`
- `cd cli && bunx tsc --noEmit`
- `cd cli && bun test`
- `git diff --check`

Refs #68