### PR TITLE
feat(mcp): 支持派生 worker agent

### DIFF
--- a/cli/src/commands/mcp.ts
+++ b/cli/src/commands/mcp.ts
@@ -17,6 +17,7 @@ import {
   listChannels,
   listTasks,
   postMessage,
+  spawnAgent,
   updateTask,
   type Identity,
 } from "../rest";
@@ -43,6 +44,7 @@ Tools:
   party_task_create
   party_task_from_message
   party_task_update
+  party_spawn_worker
   party_watch_once
   party_wake_test`;
 
@@ -506,6 +508,35 @@ export function createMcpServer(defaultChannel?: string): McpServer {
         if (Object.keys(body).length === 0) throw new Error("no task fields to update");
         const task = await updateTask(cfg.server, cfg.token, resolved, id, body);
         return ok({ type: "task_update", channel: resolved, task });
+      } catch (e) {
+        return fail(e instanceof Error ? e.message : String(e));
+      }
+    },
+  );
+
+  server.registerTool(
+    "party_spawn_worker",
+    {
+      title: "Spawn worker agent",
+      description: "Create a short-lived channel-scoped worker identity for a front agent to delegate work.",
+      inputSchema: {
+        name: z.string().describe("Worker agent name."),
+        channel: z.string().optional().describe("Channel slug for the worker scope. Defaults to the MCP server channel."),
+        ttl_sec: z.number().int().positive().optional().describe("Optional worker lifetime in seconds."),
+        team_id: z.string().optional().describe("Optional lineage team id for grouping the worker with the front agent."),
+      },
+    },
+    async ({ name, channel, ttl_sec, team_id }) => {
+      try {
+        if (!isName(name)) throw new Error("name must be a valid AgentParty name");
+        if (team_id !== undefined && !isName(team_id)) throw new Error("team_id must be a valid AgentParty name");
+        const cfg = await auth();
+        const resolved = normalizeChannel(channel, defaultChannel);
+        const worker = await spawnAgent(cfg.server, cfg.token, name, resolved, {
+          ...(ttl_sec !== undefined ? { ttlSec: ttl_sec } : {}),
+          ...(team_id !== undefined ? { teamId: team_id } : {}),
+        });
+        return ok({ type: "spawn_worker", channel: resolved, worker });
       } catch (e) {
         return fail(e instanceof Error ? e.message : String(e));
       }

--- a/cli/test/cli.test.ts
+++ b/cli/test/cli.test.ts
@@ -154,6 +154,17 @@ describe("cli subprocess", () => {
         if (url.pathname === "/api/channels/dev/tasks/1" && req.method === "PATCH") {
           return Response.json({ ...task, ...(body && typeof body === "object" ? body : {}) });
         }
+        if (url.pathname === "/api/spawn" && req.method === "POST") {
+          return Response.json({
+            token: "ap_child",
+            name: "worker-a",
+            role: "agent",
+            owner: "me",
+            channel_scope: "dev",
+            lineage: { parent_agent: "me", root_agent: "me", depth: 1, team_id: "team-a", expires_at: 1234 },
+            expires_at: 1234,
+          });
+        }
         if (url.pathname === "/api/me") {
           return Response.json({ name: "me", email: null, kind: "agent", role: "member", owner: null });
         }
@@ -182,6 +193,7 @@ describe("cli subprocess", () => {
       expect(tools.tools.map((tool) => tool.name)).toContain("party_task_from_message");
       expect(tools.tools.map((tool) => tool.name)).toContain("party_task_list");
       expect(tools.tools.map((tool) => tool.name)).toContain("party_task_update");
+      expect(tools.tools.map((tool) => tool.name)).toContain("party_spawn_worker");
 
       const result = await client.callTool({
         name: "party_send",
@@ -231,6 +243,13 @@ describe("cli subprocess", () => {
       expect(status.isError).not.toBe(true);
       expect(status.structuredContent).toMatchObject({ type: "status", task: { id: 1, state: "in_progress" } });
 
+      const spawned = await client.callTool({
+        name: "party_spawn_worker",
+        arguments: { name: "worker-a", ttl_sec: 3600, team_id: "team-a" },
+      });
+      expect(spawned.isError).not.toBe(true);
+      expect(spawned.structuredContent).toMatchObject({ type: "spawn_worker", channel: "dev", worker: { name: "worker-a", channel_scope: "dev" } });
+
       expect(seen).toContainEqual(expect.objectContaining({
         method: "POST",
         path: "/api/channels/dev/tasks",
@@ -265,6 +284,11 @@ describe("cli subprocess", () => {
         method: "PATCH",
         path: "/api/channels/dev/tasks/1",
         body: { state: "in_progress" },
+      }));
+      expect(seen).toContainEqual(expect.objectContaining({
+        method: "POST",
+        path: "/api/spawn",
+        body: { name: "worker-a", channel_scope: "dev", ttl_sec: 3600, team_id: "team-a" },
       }));
     } finally {
       await client.close();


### PR DESCRIPTION
## Summary
- add `party_spawn_worker` to the MCP server so front agents can create channel-scoped worker identities
- validate worker name/team id/channel locally and reuse the existing `/api/spawn` REST helper
- cover tool registration and request body shape in the MCP subprocess test

## Tests
- `cd cli && bunx tsc --noEmit`
- `cd cli && bun test test/cli.test.ts`
- `cd cli && bun test`
- `git diff --check`

Refs #77