### PR TITLE
fix(web): 发送/编辑路径 mention 前缀守卫，不再把 email 里的 @ 当显式 mention（#124）

### DIFF
--- a/web/src/lib/mentions.test.ts
+++ b/web/src/lib/mentions.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { PresenceEntry, Sender } from "@agentparty/shared";
-import { activeMentionQuery, filterCandidates, mentionCandidates } from "./mentions";
+import { activeMentionQuery, filterCandidates, mentionCandidates, parseDraftMentions } from "./mentions";
 
 const NOW = 1_000_000_000;
 
@@ -287,5 +287,27 @@ describe("filterCandidates", () => {
   });
   test("empty query returns all (capped)", () => {
     expect(filterCandidates(cands, "").length).toBe(3);
+  });
+});
+
+// 这个函数不只喂草稿状态条——发送/编辑路径也用它决定真正上报给服务端的 mentions 数组（issue #124），
+// 所以边界规则的回归必须被 CI 拦住，而不是靠人工在页面上试。
+describe("parseDraftMentions", () => {
+  test("不吃单词内部的 @（email / git 地址）", () => {
+    expect(parseDraftMentions("deploy@buildbot ping @alpha")).toEqual(["alpha"]);
+    expect(parseDraftMentions("mail me@x.com about @bob")).toEqual(["bob"]);
+  });
+  test("行首与空白后的 @ 都算", () => {
+    expect(parseDraftMentions("@alpha hi")).toEqual(["alpha"]);
+    expect(parseDraftMentions("hi\n@bob")).toEqual(["bob"]);
+  });
+  test("去重且保序", () => {
+    expect(parseDraftMentions("@bob @alice @bob")).toEqual(["bob", "alice"]);
+  });
+  test("过滤 system", () => {
+    expect(parseDraftMentions("@system hi @bob")).toEqual(["bob"]);
+  });
+  test("没有 mention 时返回空数组", () => {
+    expect(parseDraftMentions("just a plain message")).toEqual([]);
   });
 });

--- a/web/src/pages/Channel.tsx
+++ b/web/src/pages/Channel.tsx
@@ -94,8 +94,6 @@ interface Props {
   onAuthFailed(message: string): void;
 }
 
-const MENTION_RE = /@([a-zA-Z0-9][a-zA-Z0-9._-]*)/g;
-
 // IM 式加载：初始/上翻每页条数，与 DOM 消息窗口上限（贴底时超出即丢最老页，上翻可拉回）
 const PAGE_SIZE = 50;
 const MESSAGE_CAP = 300;
@@ -1947,7 +1945,8 @@ export function ChannelPage({
   const send = useCallback(() => {
     const body = draft.trim();
     if (body === "") return;
-    const mentions = [...new Set([...body.matchAll(MENTION_RE)].map((m) => m[1]!))];
+    // 与草稿 chips / 服务端 BODY_MENTION_RE 同一份语义：@ 前须行首或非标识符字符，不吃 email 里的 @
+    const mentions = parseDraftMentions(body);
     const ok =
       sockRef.current?.send({ type: "send", kind: "message", body, mentions, reply_to: replyTo }) ??
       false;
@@ -2185,7 +2184,7 @@ export function ChannelPage({
     setEditSaving(true);
     setMessageActionBusySeq(editingSeq);
     setMessageActionError(null);
-    const mentions = [...new Set([...editDraft.matchAll(MENTION_RE)].map((match) => match[1]!))];
+    const mentions = parseDraftMentions(editDraft);
     reviseMessage(slug, editingSeq, "edit", { body: editDraft, mentions })
       .then(({ message }) => {
         dispatch({ type: "frame", frame: message });


### PR DESCRIPTION
> **频道身份**：本 PR 由 `#agentparty` 频道的 agent **`Evan_Clauder`**（owner `lark:on_acda4d50062e089bf3b2401b907decde`）提交。依 seq 228 新规则标注。

---

来自 #139 深度评审。**本 PR 现在只修 #124**——原先并在一起的 #123（静默续期不清空 channels）已按评审意见从本分支撤下，另开 PR 处理（理由见下方评论）。

Fixes #124

## 问题
`Channel.tsx` 里有个本地的、**没有前缀守卫**的 `MENTION_RE`，被用在发送与编辑两条路径上，把 `deploy@buildbot`、`me@x.com` 里的 `@xxx` 当成显式 mention 上报给服务端（服务端信任显式数组）→ 真实触发一次 webhook 唤醒；而草稿下方的 chips 用的是**正确的** `parseDraftMentions`（带守卫，且早就 import 在同一个文件里），显示「没 @ 任何人」——两者语义分裂。

## 改动
- 删除本地 `MENTION_RE`（从源头消除 footgun），发送/编辑两处改用 `parseDraftMentions`
- 语义与草稿 chips、服务端 `BODY_MENTION_RE` 对齐；顺带过滤 `@system`、去重保序
- **补上 `parseDraftMentions` 的单测**：它已从「草稿状态条预览」升级为「决定实际上报 payload」的权威函数，此前**零测试覆盖**（`mentions.test.ts` 里那条 `ignores @ inside a word (email etc.)` 测的是 `activeMentionQuery`，不是它），改动 `DRAFT_MENTION_RE` 不会被 CI 拦住

## 验证
- `tsc --noEmit` 0 error / `bun test` 116 pass（新增 5 条）/ `vite build` 成功
- **端到端实测**（chrome-use + 本地 wrangler 栈）：在真实输入框发送 `deploy@buildbot ping @alpha`，服务端存下的 `mentions` 为 `["alpha"]`，`buildbot` 未被上报
