### PR TITLE
fix(worker): 信息类系统事件不再广播成 blocked

### DIFF
--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -439,6 +439,13 @@ function parseCollaborationRole(input: unknown): CollaborationRole | undefined |
   return input as CollaborationRole;
 }
 
+// undefined = 调用方没传（用默认值）；null = 传了但非法（400）。同 parseCollaborationRole 的三态约定。
+function statusStateFrom(input: unknown): StatusState | undefined | null {
+  if (input === undefined || input === null) return undefined;
+  if (typeof input !== "string" || !STATUS_STATES.includes(input)) return null;
+  return input as StatusState;
+}
+
 function parseRoleSource(input: unknown): CollaborationRoleSource | undefined | null {
   if (input === undefined) return undefined;
   if (typeof input !== "string" || !ROLE_SOURCES.includes(input)) return null;
@@ -1252,7 +1259,7 @@ export class ChannelDO extends Server<Env> {
       }
       if (attempt > WEBHOOK_MAX_RETRIES) {
         this.ctx.storage.sql.exec("DELETE FROM webhook_queue WHERE id = ?", id);
-        this.insertSystemStatus(`webhook ${webhookName} 连续投递失败已停用本条`, now);
+        this.insertSystemStatus(`webhook ${webhookName} 连续投递失败已停用本条`, now, false, { state: "blocked" });
         continue;
       }
       this.ctx.storage.sql.exec(
@@ -1416,7 +1423,7 @@ export class ChannelDO extends Server<Env> {
       if (delivery.ok) continue;
       const queued = Number(this.ctx.storage.sql.exec("SELECT COUNT(*) AS n FROM webhook_queue").one().n);
       if (queued >= MAX_WEBHOOK_QUEUE_ROWS) {
-        await this.insertSystemStatus("webhook retry queue is full; dropping failed delivery", now);
+        await this.insertSystemStatus("webhook retry queue is full; dropping failed delivery", now, false, { state: "blocked" });
         continue;
       }
       this.ctx.storage.sql.exec(
@@ -1572,7 +1579,9 @@ export class ChannelDO extends Server<Env> {
     options: { mentions?: string[]; workflow?: StatusWorkflow; broadcast?: boolean; state?: StatusState } = {},
   ): MsgFrame {
     const seq = this.lastSeq() + 1;
-    const state = options.state ?? "blocked";
+    // 默认 waiting 而非 blocked（#143）：信息类系统事件是常态、blocked 是例外，默认值失误的方向
+    // 必须是安全的。blocked 会让守 etiquette 的 agent 停手等人类，误报的代价远大于漏报。
+    const state = options.state ?? "waiting";
     const blockedReason = state === "blocked" ? note : null;
     const status: StatusEvent = {
       owner: "system",
@@ -1771,13 +1780,19 @@ export class ChannelDO extends Server<Env> {
       });
     }
     if (url.pathname === "/internal/system-status" && request.method === "POST") {
-      const body = (await request.json().catch(() => null)) as { note?: unknown; ts?: unknown } | null;
+      const body = (await request.json().catch(() => null)) as { note?: unknown; ts?: unknown; state?: unknown } | null;
       const note = typeof body?.note === "string" ? body.note : "";
       if (!note || note.length > 1000) {
         return Response.json({ error: { code: "bad_request", message: "valid note required" } }, { status: 400 });
       }
+      // state 由 worker 层显式指定（#143）：建 task / 改可见性 / squad 增删改这类信息事件是
+      // waiting，不能落成 blocked——etiquette 教 agent「blocked 就停手等人类」，打反了会瘫痪协作。
+      const state = statusStateFrom(body?.state);
+      if (state === null) {
+        return Response.json({ error: { code: "bad_request", message: "state must be working|waiting|blocked|done" } }, { status: 400 });
+      }
       const ts = typeof body?.ts === "number" && Number.isInteger(body.ts) ? body.ts : Date.now();
-      this.insertSystemStatus(note, ts);
+      this.insertSystemStatus(note, ts, false, state === undefined ? {} : { state });
       return Response.json({ ok: true });
     }
     if (url.pathname === "/internal/charter-rev" && request.method === "POST") {
@@ -2824,6 +2839,7 @@ export class ChannelDO extends Server<Env> {
         mentions,
         workflow: decision.workflow,
         broadcast: false,
+        state: "blocked",
       });
       this.pruneWorkflowGuardState();
       return guardFrame;
@@ -3084,7 +3100,7 @@ export class ChannelDO extends Server<Env> {
   private alertLoopGuard(message: string) {
     if (this.getMeta("loop_guard_alerted") !== null) return;
     this.setMeta("loop_guard_alerted", "1");
-    this.insertSystemStatus(`loop guard tripped: ${message}`, Date.now(), true);
+    this.insertSystemStatus(`loop guard tripped: ${message}`, Date.now(), true, { state: "blocked" });
   }
 
   private isArchived(): boolean {

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -16,6 +16,7 @@ import type {
   TaskAssigneeKind,
   TaskRecord,
   TaskSummary,
+  StatusState,
   TaskState,
   TokenRole,
   WebhookFilter,
@@ -75,6 +76,12 @@ const COMPLETION_REVIEW_POLICIES: readonly string[] = ["sender", "owner"] satisf
 const COLLAB_ROLES: readonly string[] = ["host", "worker", "reviewer", "observer"] satisfies CollaborationRole[];
 const TASK_STATES: readonly string[] = ["triage", "backlog", "assigned", "in_progress", "needs_review", "done", "blocked"] satisfies TaskState[];
 const TASK_ASSIGNEE_KINDS: readonly string[] = ["agent", "human", "squad"] satisfies TaskAssigneeKind[];
+
+// TASK_STATES.includes() 不做类型收窄，用守卫保住 TaskState
+function isTaskState(input: unknown): input is TaskState {
+  return typeof input === "string" && TASK_STATES.includes(input);
+}
+
 const HUMAN_METADATA_POLICIES = ["owner", "moderators", "members"] as const;
 const AGENT_METADATA_POLICIES = ["off", "moderators", "members", "allowlist"] as const;
 
@@ -828,7 +835,7 @@ async function syncTaskCompletion(
     state === "needs_review" ? `task #${taskId} needs_review via completion #${seq}` :
     state === "done" ? `task #${taskId} done via completion #${seq}` :
     `task #${taskId} back to in_progress after rejected completion #${seq}`;
-  await insertSystemStatus(env, slug, note).catch(() => false);
+  await insertSystemStatus(env, slug, note, statusStateForTask(state)).catch(() => false);
 }
 
 // 铸/重铸 token 的落库逻辑（/api/tokens 与 /api/agents 共用）：
@@ -1121,17 +1128,35 @@ async function channelMessageStats(env: AppEnv, slug: string): Promise<{ message
   return (await res.json()) as { message_count: number; earliest_ts: number | null };
 }
 
-async function insertSystemStatus(env: AppEnv, slug: string, note: string, ts = Date.now()): Promise<boolean> {
+// state 必传（#143）：worker 层发的都是信息类事件，落成 blocked 会让守 etiquette 的 agent
+// 停手等人类。唯一真 blocked 的来源在 DO 内部（webhook 死信 / 队列满 / guard 熔断）。
+async function insertSystemStatus(
+  env: AppEnv,
+  slug: string,
+  note: string,
+  state: StatusState = "waiting",
+  ts = Date.now(),
+): Promise<boolean> {
   const res = await fetchChannelDO(
     env,
     slug,
     new Request("https://do/internal/system-status", {
       method: "POST",
-      body: JSON.stringify({ note, ts }),
+      body: JSON.stringify({ note, ts, state }),
       headers: { "content-type": "application/json", "x-partykit-room": slug },
     }),
   );
   return res.ok;
+}
+
+// task 状态 → 系统状态帧的 state。task 自己 blocked 时确实该报 blocked；done 报 done；
+// 其余（triage/backlog/assigned/in_progress/needs_review）都是推进中的信息事件 → waiting。
+// 入参放宽到 string（DB 行的 state 列是裸 string）：未知值兜底 waiting，与 insertSystemStatus
+// 的默认值同向——误判成 blocked 会让 agent 停手，误判成 waiting 只是少一条告警。
+function statusStateForTask(state: string): StatusState {
+  if (state === "blocked") return "blocked";
+  if (state === "done") return "done";
+  return "waiting";
 }
 
 async function recentNonMemberSpeakers(db: D1Database, env: AppEnv, slug: string, ownerAccount: string | null): Promise<string[]> {
@@ -3002,7 +3027,7 @@ app.put("/api/channels/:slug/visibility", async (c) => {
   await c.env.DB.prepare("UPDATE channels SET visibility = ? WHERE slug = ?")
     .bind(visibility, slug)
     .run();
-  const ok = await insertSystemStatus(c.env, slug, `visibility changed to ${visibility} by ${identity.name}`, now);
+  const ok = await insertSystemStatus(c.env, slug, `visibility changed to ${visibility} by ${identity.name}`, "waiting", now);
   if (!ok) return c.json(errorBody("unavailable", "visibility changed but audit status failed"), 503);
   const recentSpeakers =
     visibility === "private" ? await recentNonMemberSpeakers(c.env.DB, c.env, slug, channel.owner_account) : [];
@@ -3323,7 +3348,7 @@ app.post("/api/channels/:slug/squads", async (c) => {
     throw error;
   }
   const row = await loadSquadRow(c.env.DB, slug, name);
-  await insertSystemStatus(c.env, slug, `squad @${name} created`).catch(() => false);
+  await insertSystemStatus(c.env, slug, `squad @${name} created`, "waiting").catch(() => false);
   return c.json(squadRowToRecord(row!), 201);
 });
 
@@ -3375,7 +3400,7 @@ app.patch("/api/channels/:slug/squads/:name", async (c) => {
     .bind(title, description, leader, JSON.stringify(members), now, slug, name)
     .run();
   const row = await loadSquadRow(c.env.DB, slug, name);
-  await insertSystemStatus(c.env, slug, `squad @${name} updated`).catch(() => false);
+  await insertSystemStatus(c.env, slug, `squad @${name} updated`, "waiting").catch(() => false);
   return c.json(squadRowToRecord(row!));
 });
 
@@ -3400,7 +3425,7 @@ app.delete("/api/channels/:slug/squads/:name", async (c) => {
   await c.env.DB.prepare("DELETE FROM channel_squads WHERE channel_slug = ? AND name = ?")
     .bind(slug, name)
     .run();
-  await insertSystemStatus(c.env, slug, `squad @${name} deleted`).catch(() => false);
+  await insertSystemStatus(c.env, slug, `squad @${name} deleted`, "waiting").catch(() => false);
   return c.json({ ok: true, squad: squadRowToRecord(existing) });
 });
 
@@ -3567,7 +3592,7 @@ app.post("/api/channels/:slug/tasks", async (c) => {
     .run();
   const id = Number(result.meta.last_row_id);
   const row = await loadTaskRow(c.env.DB, slug, id);
-  await insertSystemStatus(c.env, slug, `task #${id} created: ${title}`).catch(() => false);
+  await insertSystemStatus(c.env, slug, `task #${id} created: ${title}`, "waiting").catch(() => false);
   return c.json(taskRowToRecord(row!), 201);
 });
 
@@ -3592,7 +3617,7 @@ app.patch("/api/channels/:slug/tasks/:id", async (c) => {
   const body = (await c.req.json().catch(() => null)) as Record<string, unknown> | null;
   if (!body) return c.json(errorBody("bad_request", "json body required"), 400);
 
-  const state = body.state === undefined ? existing.state : typeof body.state === "string" && TASK_STATES.includes(body.state) ? body.state : null;
+  const state = body.state === undefined ? existing.state : isTaskState(body.state) ? body.state : null;
   if (state === null) {
     return c.json(errorBody("bad_request", "state must be triage|backlog|assigned|in_progress|needs_review|done|blocked"), 400);
   }
@@ -3643,7 +3668,7 @@ app.patch("/api/channels/:slug/tasks/:id", async (c) => {
     .bind(title, desc, state, nextAssigneeName, nextAssigneeKind, priority, JSON.stringify(labels), now, completedAt, slug, id)
     .run();
   const row = await loadTaskRow(c.env.DB, slug, id);
-  await insertSystemStatus(c.env, slug, `task #${id} ${state}`).catch(() => false);
+  await insertSystemStatus(c.env, slug, `task #${id} ${state}`, statusStateForTask(state)).catch(() => false);
   return c.json(taskRowToRecord(row!));
 });
 

--- a/worker/test/system-status-state.spec.ts
+++ b/worker/test/system-status-state.spec.ts
@@ -1,0 +1,126 @@
+// #143 回归：信息类系统事件不得落成 blocked。
+// blocked 在 party etiquette 里是「停手等人类」的信号；建 task / 改可见性 / 增删 squad
+// 这些是常态推进事件，误报成 blocked 会让守规矩的 agent 集体停摆。
+import { describe, expect, it } from "vitest";
+import { api, createChannel, postMessage, seedToken, uniq } from "./helpers";
+
+interface StatusMsg {
+  kind: string;
+  state: string | null;
+  body: string;
+  status?: { state: string; blocked_reason: string | null } | null;
+}
+
+async function statusMessages(slug: string, token: string): Promise<StatusMsg[]> {
+  const res = await api(`/api/channels/${slug}/messages?since=0&limit=100`, token);
+  const body = (await res.json()) as { messages: StatusMsg[] };
+  return body.messages.filter((m) => m.kind === "status");
+}
+
+function find(messages: StatusMsg[], bodyPrefix: string): StatusMsg | undefined {
+  return messages.find((m) => m.body.startsWith(bodyPrefix));
+}
+
+describe("system status state (#143)", () => {
+  it("task creation reports waiting, not blocked, and leaves blocked_reason null", async () => {
+    const owner = `owner-${uniq("sys")}@example.com`;
+    const human = await seedToken("human", uniq("human"), { owner });
+    const slug = await createChannel(human.token);
+
+    const created = await api(`/api/channels/${slug}/tasks`, human.token, {
+      method: "POST",
+      body: JSON.stringify({ title: "ship the thing" }),
+    });
+    expect(created.status).toBe(201);
+    const task = (await created.json()) as { id: number };
+
+    const msg = find(await statusMessages(slug, human.token), `task #${task.id} created:`);
+    expect(msg).toBeDefined();
+    expect(msg?.state).toBe("waiting");
+    // blocked_reason 曾被填成 task 标题——那是 blocked 语义泄漏的痕迹
+    expect(msg?.status?.blocked_reason ?? null).toBeNull();
+  });
+
+  it("task state changes map to waiting / blocked / done rather than always blocked", async () => {
+    const owner = `owner-${uniq("sys")}@example.com`;
+    const human = await seedToken("human", uniq("human"), { owner });
+    const slug = await createChannel(human.token);
+
+    const created = await api(`/api/channels/${slug}/tasks`, human.token, {
+      method: "POST",
+      body: JSON.stringify({ title: "map states" }),
+    });
+    const task = (await created.json()) as { id: number };
+
+    const move = async (state: string) => {
+      const res = await api(`/api/channels/${slug}/tasks/${task.id}`, human.token, {
+        method: "PATCH",
+        body: JSON.stringify({ state }),
+      });
+      expect(res.status).toBe(200);
+    };
+
+    await move("in_progress");
+    await move("blocked");
+    await move("done");
+
+    const statuses = await statusMessages(slug, human.token);
+    // 推进中 → waiting
+    expect(find(statuses, `task #${task.id} in_progress`)?.state).toBe("waiting");
+    // task 自己 blocked → 确实报 blocked（这条不该被"修掉"）
+    expect(find(statuses, `task #${task.id} blocked`)?.state).toBe("blocked");
+    // 完成 → done
+    expect(find(statuses, `task #${task.id} done`)?.state).toBe("done");
+  });
+
+  it("visibility change and squad lifecycle report waiting", async () => {
+    const owner = `owner-${uniq("sys")}@example.com`;
+    const human = await seedToken("human", uniq("human"), { owner });
+    const slug = await createChannel(human.token);
+
+    // private→public 需要二段确认（否则 409 needs_confirm），这里直接带上 confirm
+    const vis = await api(`/api/channels/${slug}/visibility`, human.token, {
+      method: "PUT",
+      body: JSON.stringify({ visibility: "public", confirm: true }),
+    });
+    expect(vis.status).toBe(200);
+
+    const member = await seedToken("agent", uniq("agent"), { owner });
+    const squadName = uniq("sq").toLowerCase();
+    const squad = await api(`/api/channels/${slug}/squads`, human.token, {
+      method: "POST",
+      body: JSON.stringify({ name: squadName, members: [member.name], leader: member.name }),
+    });
+    expect(squad.status).toBe(201);
+
+    const statuses = await statusMessages(slug, human.token);
+    expect(find(statuses, "visibility changed to public")?.state).toBe("waiting");
+    expect(find(statuses, `squad @${squadName} created`)?.state).toBe("waiting");
+    // 整个频道生命周期里不该出现任何 blocked——没有 webhook 死信、没有 guard 熔断
+    expect(statuses.filter((m) => m.state === "blocked")).toEqual([]);
+  });
+
+  // 反向兜底：真 blocked 的路径不能被"默认值翻转"顺手打反。
+  // 修复 #143 时 workflow guard tripped 原本依赖默认 blocked，翻转默认值会让它静默降级成
+  // waiting——当时靠人工审计才发现，没有任何测试会失败。这两条就是补上那道网。
+  it("loop guard tripped still reports blocked with a blocked_reason", async () => {
+    const agentA = await seedToken("agent", uniq("ga"));
+    const agentB = await seedToken("agent", uniq("gb"));
+    const slug = await createChannel(agentA.token);
+
+    const enable = await api(`/api/channels/${slug}/loop-guard`, agentA.token, {
+      method: "PUT",
+      body: JSON.stringify({ enabled: true, limit: 2 }),
+    });
+    expect(enable.status).toBe(200);
+
+    expect((await postMessage(slug, agentA.token, "one")).status).toBe(200);
+    expect((await postMessage(slug, agentB.token, "two")).status).toBe(200);
+    expect((await postMessage(slug, agentA.token, "tripped")).status).toBe(409);
+
+    const guard = find(await statusMessages(slug, agentA.token), "loop guard tripped:");
+    expect(guard).toBeDefined();
+    expect(guard?.state).toBe("blocked");
+    expect(guard?.status?.blocked_reason).toContain("loop guard tripped:");
+  });
+});

--- a/worker/test/workflow-guard.spec.ts
+++ b/worker/test/workflow-guard.spec.ts
@@ -84,4 +84,34 @@ describe("workflow no-progress guard", () => {
     expect(await disabled.json()).toEqual({ enabled: false, limit: null });
     expect((await postMessage(slug, workerA.token, "after workflow reset")).status).toBe(200);
   });
+
+  // #143 回归网：workflow guard tripped 的系统状态帧必须是 blocked。
+  // 修复 #143 时把 insertSystemStatus 的默认值从 blocked 翻成 waiting，这处原本依赖默认值，
+  // 差点被静默降级成 waiting——当时没有任何测试会失败。这条就是那道缺失的网。
+  it("tripping the workflow guard posts a system status with state=blocked", async () => {
+    const ownerAccount = `${uniq("acct")}@leeguoo.com`;
+    const workerA = await seedToken("agent", uniq("worker-a"), { owner: ownerAccount });
+    const host = await seedToken("human", uniq("host"), { owner: ownerAccount });
+    const slug = await createChannel(workerA.token);
+
+    expect((await postStatus(slug, host.token, { state: "working", note: "hosting", role: "host" })).status).toBe(200);
+    expect((await configureWorkflowGuard(slug, workerA.token, 2)).status).toBe(200);
+    expect((await postStatus(slug, workerA.token, {
+      state: "working",
+      note: "wf-x started",
+      workflow: workflow("wf-x"),
+    })).status).toBe(200);
+    expect((await postMessage(slug, workerA.token, "no progress 1")).status).toBe(200);
+    expect((await postMessage(slug, workerA.token, "no progress 2")).status).toBe(200);
+    expect((await postMessage(slug, workerA.token, "stale")).status).toBe(409);
+
+    const res = await api(`/api/channels/${slug}/messages?since=0&limit=100`, workerA.token);
+    const messages = (await res.json()) as {
+      messages: { kind: string; state: string | null; body: string; status?: { blocked_reason: string | null } | null }[];
+    };
+    const guard = messages.messages.find((m) => m.kind === "status" && m.body.startsWith("workflow guard tripped:"));
+    expect(guard).toBeDefined();
+    expect(guard?.state).toBe("blocked");
+    expect(guard?.status?.blocked_reason).toContain("wf-x");
+  });
 });


### PR DESCRIPTION
Closes #143

## 问题

`insertSystemStatus` 默认 `state = "blocked"`，而 worker 层的 REST 桥没有 `state` 参数，导致 **7 类信息事件**全被广播成「频道受阻」，`blocked_reason` 还被填成 task 标题：

```
[89] system(agent): [blocked] task #44 created: … · blocked=task #44 created: …
```

party etiquette 第 4 条教 agent「看到 blocked 就停手等人类」——建一个 task 就让全频道 agent 停摆，协作规则被打反。一次 46 条 task 同步灌了 46 条 blocked。

## 改动

- `do.ts`：默认值 `blocked` → `waiting`（信息事件是常态、blocked 是例外，默认值失误的方向必须安全）；`/internal/system-status` 新增 `state` 参数 + `statusStateFrom` 三态校验（非法值 400）
- `do.ts`：**四处**真 blocked 显式传 state —— webhook 死信、webhook 队列满、loop guard tripped、workflow guard tripped
- `index.ts`：REST 桥透传 `state`；新增 `statusStateForTask`（task `blocked`→blocked、`done`→done、其余→waiting）与 `isTaskState` 类型守卫；7 个调用点全部显式化

## 一个差点造成的静默回归

`workflow guard tripped`（`do.ts:2838`）原本**依赖默认值**表达 blocked。翻转默认值会让它静默降级成 `waiting`——熔断告警变成普通信息，**而且没有任何测试会失败**。审计调用点时才发现。

教训：「翻默认值」的风险不在被改的那一行，在所有依赖旧默认值的调用点。

## 测试

- 新增 `worker/test/system-status-state.spec.ts`（4 case）：task 创建报 waiting 且 `blocked_reason` 为 null、task 状态映射三态、可见性/squad 全程无 blocked、loop guard tripped 仍报 blocked
- `worker/test/workflow-guard.spec.ts` 补正面断言：tripped 时系统状态必须是 blocked —— **这道网原本缺失**，正是它让默认值翻转的静默降级无法被测试发现
- 两条 guard 断言均做过**变异测试**：移除显式 `state: "blocked"` 后立刻失败

`bun run check` 全过：32 spec / 235 tests / 全仓 typecheck + build。

https://claude.ai/code/session_01PgxkZeqJmDge3dYe9W2tPZ