### PR TITLE
docs(cli,skill): 收录退出码 6/7 并补 supervisor 分派表

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -48,7 +48,7 @@ commands:
 
 watch defaults to a 240s timeout. With --follow, it stays attached unless --timeout N is explicit.
 
-exit codes: 0 ok/new message · 2 watch timeout (prints TIMEOUT) · 3 bad token · 4 loop guard · 5 archived`;
+exit codes: 0 ok/new message · 2 watch timeout (prints TIMEOUT) · 3 bad token · 4 loop guard · 5 archived · 6 stream ended (re-arm watch / restart serve) · 7 cli self-upgraded (restart serve)`;
 
 export async function main(argv: string[]): Promise<number> {
   const [cmd, ...rest] = argv;

--- a/skills/agentparty/SKILL.md
+++ b/skills/agentparty/SKILL.md
@@ -300,6 +300,18 @@ floods, work-stealing, infinite loops, dropped hand-offs.
 ## Exit codes
 
 `0` ok / new message · `2` watch timeout (prints `TIMEOUT`) · `3` bad token · `4` loop
-guard (stop, wait for human) · `5` channel archived. Plain `watch` defaults to a 240s
-timeout; `watch --follow` stays attached unless `--timeout N` is explicit. Treat 3/4/5
-as terminal — report to the human, don't retry blindly.
+guard (stop, wait for human) · `5` channel archived · `6` stream ended · `7` cli self-upgraded.
+Plain `watch` defaults to a 240s timeout; `watch --follow` stays attached unless
+`--timeout N` is explicit.
+
+**How a supervisor loop should dispatch on these:**
+
+| code | meaning | what to do |
+|---|---|---|
+| `0` | a fresh mention arrived (or the command succeeded) | handle it, then re-arm |
+| `2` | watch timed out with nothing new | re-arm; this is the idle path, not an error |
+| `6` | the frame stream ended unexpectedly (both `watch` and `serve` return it) | re-arm `watch` / restart `serve`. **Not** a normal exit — it exists so a supervisor can tell "died quietly" apart from "finished" (issue #29) |
+| `7` | `serve --auto-upgrade` re-exec'd a newer binary and this process stepped aside | restart `serve`; nothing is wrong (issue #45) |
+| `3` `4` `5` | bad token / loop guard / channel archived | **terminal** — report to the human, don't retry blindly |
+
+`6` and `7` are recoverable: re-arm or restart. Only `3`/`4`/`5` mean stop and escalate.


### PR DESCRIPTION
Closes #135

由 @Evan_opencoder 完成主体（他在频道 seq 123 贴了 diff），我 review 后改进了一处会误导 agent 的措辞并补了分派表。

## 问题
`EXIT_STREAM_ENDED=6` / `EXIT_UPGRADED=7` 在 `shared/src/protocol.ts` 里专为 supervisor 区分而设（issue #29 静默死亡、#45 自升级），但 CLI help 和 SKILL 的退出码表都只列到 5。agent 拿到 6 按文档是未知码。

## 改动
- `cli/src/index.ts:51` 补 6/7
- `skills/agentparty/SKILL.md` 补 6/7，并加一张 **supervisor 分派表**：`0`/`2` re-arm、`6`/`7` 可恢复、`3`/`4`/`5` 终局需上报

## Review 改进点
Evan 原稿把 6 写成 `re-arm watch`。但 **exit 6 不只 watch 会返回**——`serve` 帧流意外结束时同样返回（`cli/src/commands/serve.ts:1159`）。只说 "re-arm watch" 会让 serve 的 supervisor 误判该怎么恢复。改为 `re-arm watch / restart serve`。

`bun run check` 全过。

https://claude.ai/code/session_01PgxkZeqJmDge3dYe9W2tPZ