### PR TITLE
feat(worker): 新建频道默认开启 loop guard

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -2584,10 +2584,13 @@ app.post("/api/channels", async (c) => {
   const creator = c.get("identity");
   try {
     await c.env.DB.prepare(
-      "INSERT INTO channels (slug, title, kind, mode, visibility, created_by, owner_account, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+      "INSERT INTO channels (slug, title, kind, mode, visibility, created_by, owner_account, created_at, loop_guard_enabled) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1)",
     )
       // created_by 记具体铸造者（审计）；owner_account = 创建者账号（ACL 依据）。
       // legacy token 无 account → owner_account = null（老频道，仅 legacy 过渡放行）。
+      // loop_guard_enabled=1（#96）：新频道开箱即有熔断，否则两个 agent 可在无人值守下
+      // 互相唤醒到天亮（唯一约束仅 30 msg/min）。limit 留空 → 回退 mode 默认 30/200。
+      // 存量频道保持关闭：强开会立刻熔断正在工作的频道。房主可随时 PUT loop-guard 关闭。
       .bind(slug, title, kind, mode, visibility, creator.name, creator.account ?? null, now)
       .run();
   } catch {

--- a/worker/test/guards.spec.ts
+++ b/worker/test/guards.spec.ts
@@ -1,7 +1,7 @@
 import { env, runInDurableObject } from "cloudflare:test";
 import { BODY_LIMIT, LOOP_GUARD_N, RATE_LIMIT_PER_MIN } from "@agentparty/shared";
 import { describe, expect, it } from "vitest";
-import { api, createChannel, postMessage, seedToken, WsClient } from "./helpers";
+import { api, createChannel, disableLoopGuard, postMessage, seedToken, WsClient } from "./helpers";
 
 async function errorCode(res: Response): Promise<string> {
   const body = (await res.json()) as { error: { code: string } };
@@ -22,6 +22,8 @@ describe("guards", () => {
     const agentB = await seedToken("agent");
     const human = await seedToken("human");
     const slug = await createChannel(agentA.token);
+    // #96 起新频道默认开 guard；本用例测的是关闭态，必须显式关闭
+    await disableLoopGuard(slug, agentA.token);
 
     for (let i = 0; i < LOOP_GUARD_N + 5; i++) {
       const token = i % 2 === 0 ? agentA.token : agentB.token;
@@ -41,6 +43,8 @@ describe("guards", () => {
     const agent = await seedToken("agent");
     const human = await seedToken("human");
     const slug = await createChannel(agent.token);
+    // #96 起新频道默认开 guard；本用例测的是关闭态，必须显式关闭
+    await disableLoopGuard(slug, agent.token);
     const init = await WsClient.open(slug, agent.token);
     await init.nextOfType("welcome");
     init.close();
@@ -62,6 +66,8 @@ describe("guards", () => {
     const agentA = await seedToken("agent");
     const agentB = await seedToken("agent");
     const slug = await createChannel(agentA.token);
+    // #96 起新频道默认开 guard；本用例测的是关闭态，必须显式关闭
+    await disableLoopGuard(slug, agentA.token);
 
     // 两个 agent token 交替，避开单 token 速率限制，streak 仍按 kind 累计
     for (let i = 0; i < LOOP_GUARD_N; i++) {

--- a/worker/test/helpers.ts
+++ b/worker/test/helpers.ts
@@ -173,3 +173,13 @@ export class WsClient {
     this.ws.close();
   }
 }
+
+// #96 起新频道默认开启 loop guard。测「关闭态」行为的用例必须显式关闭，
+// 不能再借用默认值——否则默认值一变，这些用例就在测别的东西。
+export async function disableLoopGuard(slug: string, token: string): Promise<void> {
+  const res = await api(`/api/channels/${slug}/loop-guard`, token, {
+    method: "PUT",
+    body: JSON.stringify({ enabled: false }),
+  });
+  if (!res.ok) throw new Error(`disableLoopGuard failed: ${res.status}`);
+}

--- a/worker/test/new-channel-guard-default.spec.ts
+++ b/worker/test/new-channel-guard-default.spec.ts
@@ -1,0 +1,50 @@
+// #96：新建频道默认开启 loop guard。
+// c3c4cdb 把 guard 改成 opt-in 后，新频道一律无熔断——两个 agent 在无人值守下可以
+// 互相唤醒到天亮，唯一约束是 30 msg/min。产品的核心承诺（agents talk, humans watch）
+// 要求新频道开箱就有这道刹车；存量频道不动（强开会立刻熔断正在工作的频道）。
+import { describe, expect, it } from "vitest";
+import { api, createChannel, postMessage, seedToken, uniq } from "./helpers";
+
+describe("new channels enable the loop guard by default (#96)", () => {
+  it("a freshly created channel reports loop_guard_enabled = 1", async () => {
+    const human = await seedToken("human", uniq("human"));
+    const slug = await createChannel(human.token);
+
+    const list = (await (await api("/api/channels", human.token)).json()) as {
+      channels: { slug: string; loop_guard_enabled?: number; loop_guard_limit?: number | null }[];
+    };
+    const ch = list.channels.find((c) => c.slug === slug);
+    expect(ch).toBeDefined();
+    expect(ch?.loop_guard_enabled).toBe(1);
+    // 不写死 limit：留空表示回退 mode 默认（normal 30 / party 200）
+    expect(ch?.loop_guard_limit ?? null).toBeNull();
+  });
+
+  it("the default guard actually trips at the normal-channel threshold", async () => {
+    const agentA = await seedToken("agent", uniq("ga"));
+    const agentB = await seedToken("agent", uniq("gb"));
+    const slug = await createChannel(agentA.token);
+
+    // LOOP_GUARD_N = 30：前 30 条连续 agent 消息放行，第 31 条熔断
+    for (let i = 0; i < 30; i++) {
+      const token = i % 2 === 0 ? agentA.token : agentB.token;
+      expect((await postMessage(slug, token, `msg-${i}`)).status).toBe(200);
+    }
+    const tripped = await postMessage(slug, agentA.token, "one too many");
+    expect(tripped.status).toBe(409);
+    const body = (await tripped.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("loop_guard");
+  });
+
+  it("owners can still turn the default guard off per channel", async () => {
+    const human = await seedToken("human", uniq("human"));
+    const slug = await createChannel(human.token);
+
+    const off = await api(`/api/channels/${slug}/loop-guard`, human.token, {
+      method: "PUT",
+      body: JSON.stringify({ enabled: false }),
+    });
+    expect(off.status).toBe(200);
+    expect(await off.json()).toEqual({ enabled: false, limit: null });
+  });
+});

--- a/worker/test/party.spec.ts
+++ b/worker/test/party.spec.ts
@@ -2,7 +2,7 @@ import { env, runInDurableObject } from "cloudflare:test";
 import { LOOP_GUARD_N, LOOP_GUARD_PARTY_N } from "@agentparty/shared";
 import { describe, expect, it } from "vitest";
 import type { ChannelDO } from "../src/do";
-import { api, postMessage, seedToken, uniq } from "./helpers";
+import { api, disableLoopGuard, postMessage, seedToken, uniq } from "./helpers";
 
 async function createModeChannel(token: string, mode?: string): Promise<string> {
   const slug = uniq("party");
@@ -56,6 +56,8 @@ describe("party mode", () => {
   it("party channel keeps accepting messages past the old loop guard thresholds", async () => {
     const { token } = await seedToken("agent");
     const slug = await createModeChannel(token, "party");
+    // #96 起新频道默认开 guard；本用例测的是关闭态，必须显式关闭
+    await disableLoopGuard(slug, token);
 
     // 首条消息让 do 缓存 mode=party
     expect((await postMessage(slug, token, "kickoff")).status).toBe(200);
@@ -72,6 +74,8 @@ describe("party mode", () => {
   it("normal channel keeps accepting messages past the old loop guard threshold", async () => {
     const { token } = await seedToken("agent");
     const slug = await createModeChannel(token);
+    // #96 起新频道默认开 guard；本用例测的是关闭态，必须显式关闭
+    await disableLoopGuard(slug, token);
     expect((await postMessage(slug, token, "kickoff")).status).toBe(200);
     await seedStreak(slug, LOOP_GUARD_N);
     const allowed = await postMessage(slug, token, "31st");

--- a/worker/test/webhooks.spec.ts
+++ b/worker/test/webhooks.spec.ts
@@ -2,7 +2,7 @@ import { env, fetchMock, runInDurableObject } from "cloudflare:test";
 import { LOOP_GUARD_N, MAX_WEBHOOKS_PER_CHANNEL, WEBHOOK_MAX_RETRIES } from "@agentparty/shared";
 import { afterEach, beforeAll, describe, expect, it } from "vitest";
 import type { ChannelDO } from "../src/do";
-import { api, createChannel, postMessage, seedToken, uniq } from "./helpers";
+import { api, createChannel, disableLoopGuard, postMessage, seedToken, uniq } from "./helpers";
 
 beforeAll(() => {
   fetchMock.activate();
@@ -393,6 +393,8 @@ describe("webhooks", () => {
     const agentA = await seedToken("agent");
     const agentB = await seedToken("agent");
     const slug = await createChannel(agentA.token);
+    // #96 起新频道默认开 guard；本用例测的是关闭态，必须显式关闭
+    await disableLoopGuard(slug, agentA.token);
     expect(
       (
         await addWebhook(slug, agentA.token, {


### PR DESCRIPTION
Closes #96 · 文档侧已由 #154 先行改口

## 问题

`c3c4cdb` 之后新频道一律无熔断。两个 `serve` agent 在无人值守下互相唤醒，唯一约束是 `RATE_LIMIT_PER_MIN = 30`（约 4.3 万条/夜）——正是 README 声称已解决的事故。

改前实测（本 PR 的失败测试就是证据）：新频道连发 31 条连续 agent 消息，全部 200。

## 产品决策

三个选项里选了最保守的：

| 选项 | 取舍 |
|---|---|
| 全局默认开（含存量频道） | ❌ 会立刻熔断正在工作的频道——包括本项目的开发频道，当前 streak 已 ≈7 |
| **新建频道默认开，存量不动** | ✅ 本 PR。新用户开箱有刹车，老频道零惊扰 |
| 只在 `serve` 挂载时警告 | ❌ 警告不是刹车；agent 不看 stderr |

- 新频道 `loop_guard_enabled = 1`，`limit` 留空 → 回退 mode 默认（normal 30 / party 200）
- 房主随时 `PUT /api/channels/:slug/loop-guard {"enabled": false}` 关闭，语义不变

## 六个既有测试为什么要改

`guards` / `party` / `webhooks` 里有 6 个用例在测**关闭态**行为，但它们是**借用默认值**实现的，不是显式关闭。默认值一变，这些用例就在测别的东西。

新增 `helpers.disableLoopGuard()`，让它们显式关闭。**测试要断言意图，不能依赖默认值**——这正是 #152 里 `workflow guard tripped` 静默降级的同类陷阱，那次没有任何测试会失败。

## 测试（TDD，先红后绿）

新增 `worker/test/new-channel-guard-default.spec.ts`：
- 新频道 `loop_guard_enabled = 1` 且 `limit` 为空
- 第 31 条连续 agent 消息真的 `409 loop_guard`（改前是 200）
- 房主仍可关闭

`bun run check` 全过：33 spec / 238 tests。

https://claude.ai/code/session_01PgxkZeqJmDge3dYe9W2tPZ