### PR TITLE
fix(cli): 修复游标持久化三连击，恢复「@ 恰好一次送达」

### DIFF
--- a/cli/src/commands/complete.ts
+++ b/cli/src/commands/complete.ts
@@ -1,6 +1,6 @@
 // party complete — publish a final synthesis as a first-class message artifact.
 import { isHelpArg, parseArgs, str, strArray, unknownFlagError, valueFlagError } from "../args";
-import { resolveChannel, saveCursor } from "../config";
+import { advanceCursorPastOwnMessage, resolveChannel } from "../config";
 import { resolveAuth } from "../oidc-cli";
 import { handleRestError, postMessage } from "../rest";
 import { isName, isSlug, parseNonNegativeIntFlag, parsePositiveIntFlag } from "../validation";
@@ -131,7 +131,7 @@ export async function run(argv: string[]): Promise<number> {
       },
       ...(replaces === undefined ? {} : { replaces }),
     });
-    saveCursor(channel, seq);
+    advanceCursorPastOwnMessage(channel, seq);
     if (completion_review?.state === "pending_review") {
       console.log(`completion seq=${seq} pending_review`);
       console.log(`next: party review approve ${seq} --channel ${channel}  # or: party review reject ${seq} -m "reason" --channel ${channel}`);

--- a/cli/src/commands/mcp.ts
+++ b/cli/src/commands/mcp.ts
@@ -5,7 +5,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
 import pkg from "../../package.json" with { type: "json" };
-import { loadCursor, loadRevCursor, resolveChannel, saveCursor, saveRevCursor } from "../config";
+import { advanceCursorPastOwnMessage, loadCursor, loadRevCursor, resolveChannel, saveCursor, saveRevCursor } from "../config";
 import { jsonFrame } from "../json";
 import { resolveAuth, resolveAuthDetailed } from "../oidc-cli";
 import {
@@ -235,7 +235,7 @@ export function createMcpServer(defaultChannel?: string): McpServer {
           mentions: normalizedMentions,
           reply_to: reply_to ?? null,
         });
-        saveCursor(resolved, seq);
+        advanceCursorPastOwnMessage(resolved, seq);
         return ok({ type: "send", channel: resolved, seq });
       } catch (e) {
         const code = handleRestError(e);
@@ -284,7 +284,7 @@ export function createMcpServer(defaultChannel?: string): McpServer {
             state as TaskState;
           task = await updateTask(authInfo.server, authInfo.token, resolved, task_id, { state: taskState });
         }
-        saveCursor(resolved, seq);
+        advanceCursorPastOwnMessage(resolved, seq);
         return ok({ type: "status", channel: resolved, seq, state, ...(task !== undefined ? { task } : {}) });
       } catch (e) {
         const code = handleRestError(e);

--- a/cli/src/commands/review.ts
+++ b/cli/src/commands/review.ts
@@ -1,6 +1,6 @@
 // party review approve/reject — settle a gated completion review.
 import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
-import { resolveChannel, saveCursor } from "../config";
+import { advanceCursorPastOwnMessage, resolveChannel } from "../config";
 import { formatMsg } from "../format";
 import { jsonFrame } from "../json";
 import { resolveAuth } from "../oidc-cli";
@@ -76,7 +76,7 @@ export async function run(argv: string[]): Promise<number> {
       action,
       ...(reason === undefined || reason === "" ? {} : { reason }),
     });
-    saveCursor(channel, result.reply.seq);
+    advanceCursorPastOwnMessage(channel, result.reply.seq);
     if (flags.json === true) {
       console.log(JSON.stringify(jsonFrame(result.message as unknown as Record<string, unknown>)));
     } else {

--- a/cli/src/commands/send.ts
+++ b/cli/src/commands/send.ts
@@ -1,6 +1,6 @@
 // party send — rest 一次性发消息，成功后推进游标
 import { isHelpArg, parseArgs, str, strArray, unknownFlagError, valueFlagError, type Parsed } from "../args";
-import { resolveChannel, saveCursor, type Config } from "../config";
+import { advanceCursorPastOwnMessage, resolveChannel, type Config } from "../config";
 import { formatAuthDebugLine, resolveAuthDetailed } from "../oidc-cli";
 import { fetchMe, fetchPresence, handleRestError, postMessage } from "../rest";
 import { formatReachLine, reachOf } from "../reach";
@@ -114,7 +114,7 @@ export async function doSend(cfg: Config, input: SendInput): Promise<number | { 
       mentions: input.mentions,
       reply_to: input.replyTo,
     });
-    saveCursor(input.channel, seq);
+    advanceCursorPastOwnMessage(input.channel, seq);
     writeStatuslineCache({
       ...localStatuslineBase(input.channel),
       unread: unreadFromCursor(seq, input.channel),

--- a/cli/src/commands/status.ts
+++ b/cli/src/commands/status.ts
@@ -12,7 +12,7 @@ import type {
   WorkflowKind,
 } from "@agentparty/shared";
 import { isHelpArg, parseArgs, str, strArray, unknownFlagError, valueFlagError } from "../args";
-import { resolveChannel, saveCursor, workspaceId, workspaceLabel, worktreeLabel } from "../config";
+import { advanceCursorPastOwnMessage, resolveChannel, workspaceId, workspaceLabel, worktreeLabel } from "../config";
 import { formatAuthDebugLine, resolveAuthDetailed } from "../oidc-cli";
 import { fetchMe, handleRestError, postMessage, updateTask } from "../rest";
 import { isName, isSlug, parsePositiveIntFlag } from "../validation";
@@ -330,7 +330,7 @@ export async function run(argv: string[]): Promise<number> {
         state as TaskState;
       await updateTask(auth.server, auth.token, channel, taskId, { state: taskState });
     }
-    saveCursor(channel, seq);
+    advanceCursorPastOwnMessage(channel, seq);
     console.log(`status seq=${seq}`);
     return 0;
   } catch (e) {

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -3,7 +3,7 @@ import { homedir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 
 export interface Config {
   server: string;
@@ -35,11 +35,22 @@ export interface ConfigWithSource {
   source: ConfigSourceInfo;
 }
 
+export interface ChannelCursor {
+  cursor: number;
+  rev_cursor?: number;
+}
+
 export interface WorkspaceState {
   channel: string;
   cursor: number;
   /** 修订游标：已见过的最大 rev_seq（hello.since_rev），与消息游标并列持久化 */
   rev_cursor?: number;
+  /**
+   * 分频道游标（#113）。旧版把游标只绑在 `channel` 上，于是 `serve --profile` 的所有
+   * 频道恒 since=0，每次重启把保留窗口里的历史 @ 逐条重放，反复拉起 runner。
+   * 顶层 channel/cursor/rev_cursor 保留作绑定频道的镜像，兼容旧读者与 statusline。
+   */
+  cursors?: Record<string, ChannelCursor>;
   /**
    * 面包屑：init 时若用了 AGENTPARTY_CONFIG，把该显式路径记进【cwd 基准】的 state（不受 env 影响）。
    * 回落用——Claude Code 的 Bash 不跨 turn 保留 export，被唤醒回复轮没了 env 就靠它找回绑定的 agent
@@ -230,10 +241,14 @@ export function readState(cwd: string = process.cwd()): WorkspaceState | null {
   }
 }
 
+// tmp + rename 原子替换（#113）：裸 writeFileSync 在崩溃/并发下会留下截断的 JSON，
+// readState 随即返回 null → 游标退回 0 → 整个保留窗口的 @ 被重放。范本同 statusline-cache.ts。
 export function writeState(st: WorkspaceState, cwd: string = process.cwd()): void {
   const p = statePath(cwd);
   mkdirSync(join(p, ".."), { recursive: true });
-  writeFileSync(p, JSON.stringify(st, null, 2) + "\n");
+  const tmp = `${p}.${process.pid}.${Date.now()}.tmp`;
+  writeFileSync(tmp, JSON.stringify(st, null, 2) + "\n");
+  renameSync(tmp, p);
 }
 
 export function resolveChannel(explicit?: string, cwd?: string): string | null {
@@ -241,27 +256,58 @@ export function resolveChannel(explicit?: string, cwd?: string): string | null {
   return readState(cwd)?.channel ?? null;
 }
 
-// 游标只在频道与 workspace 绑定频道一致时读写
+// 游标按频道键持久化（#113）。读旧格式时回落到顶层字段（绑定频道），保证升级不丢游标。
+function channelCursor(st: WorkspaceState | null, channel: string): ChannelCursor {
+  if (!st) return { cursor: 0 };
+  const scoped = st.cursors?.[channel];
+  if (scoped) return scoped;
+  if (st.channel === channel) return { cursor: st.cursor, ...(st.rev_cursor === undefined ? {} : { rev_cursor: st.rev_cursor }) };
+  return { cursor: 0 };
+}
+
+// 写回：分频道表是权威；绑定频道同步镜像到顶层，供 statusline 等旧读者使用。
+function putChannelCursor(channel: string, next: ChannelCursor, cwd?: string): void {
+  const st = readState(cwd) ?? { channel, cursor: 0 };
+  const merged: WorkspaceState = {
+    ...st,
+    cursors: { ...(st.cursors ?? {}), [channel]: next },
+  };
+  if (st.channel === channel) {
+    merged.cursor = next.cursor;
+    if (next.rev_cursor !== undefined) merged.rev_cursor = next.rev_cursor;
+  }
+  writeState(merged, cwd);
+}
+
 export function loadCursor(channel: string, cwd?: string): number {
-  const st = readState(cwd);
-  return st && st.channel === channel ? st.cursor : 0;
+  return channelCursor(readState(cwd), channel).cursor;
 }
 
 export function saveCursor(channel: string, cursor: number, cwd?: string): void {
-  const st = readState(cwd);
-  if (!st || st.channel !== channel) return;
-  if (cursor <= st.cursor) return;
-  writeState({ ...st, cursor }, cwd);
+  const cur = channelCursor(readState(cwd), channel);
+  if (cursor <= cur.cursor) return; // 单调，不回退
+  putChannelCursor(channel, { ...cur, cursor }, cwd);
+}
+
+/**
+ * 自己发消息后推进游标——**仅在没有空洞时**（#113）。
+ * 旧实现无条件 saveCursor(channel, mySeq)，把发送前所有未消费的消息（含正 @ 我的新 mention）
+ * 一起吞掉：不打印、不唤醒、不补拉。watch 侧本来就有 fromSelf 过滤（watch.ts），
+ * 所以「跳过自己的回声」根本不需要动游标。
+ * 这里只处理「我已经读到最新、紧接着自己发了一条」的情形，保住 statusline 的 unread=0。
+ */
+export function advanceCursorPastOwnMessage(channel: string, seq: number, cwd?: string): void {
+  const cur = channelCursor(readState(cwd), channel);
+  if (cur.cursor !== seq - 1) return; // 有空洞：那些是别人的消息，绝不跳过
+  putChannelCursor(channel, { ...cur, cursor: seq }, cwd);
 }
 
 export function loadRevCursor(channel: string, cwd?: string): number {
-  const st = readState(cwd);
-  return st && st.channel === channel ? (st.rev_cursor ?? 0) : 0;
+  return channelCursor(readState(cwd), channel).rev_cursor ?? 0;
 }
 
 export function saveRevCursor(channel: string, revCursor: number, cwd?: string): void {
-  const st = readState(cwd);
-  if (!st || st.channel !== channel) return;
-  if (revCursor <= (st.rev_cursor ?? 0)) return;
-  writeState({ ...st, rev_cursor: revCursor }, cwd);
+  const cur = channelCursor(readState(cwd), channel);
+  if (revCursor <= (cur.rev_cursor ?? 0)) return;
+  putChannelCursor(channel, { ...cur, rev_cursor: revCursor }, cwd);
 }

--- a/cli/src/statusline-cache.ts
+++ b/cli/src/statusline-cache.ts
@@ -1,7 +1,7 @@
 import type { MsgFrame } from "@agentparty/shared";
 import { mkdirSync, readFileSync, renameSync, writeFileSync, chmodSync } from "node:fs";
 import { dirname, join } from "node:path";
-import { agentpartyHome, readConfig, readState, workspaceId, type CachedIdentity } from "./config";
+import { agentpartyHome, loadCursor, readConfig, readState, type CachedIdentity, workspaceId } from "./config";
 import type { Identity } from "./rest";
 
 export interface StatuslineIdentity {
@@ -108,8 +108,8 @@ export function lastMessageFromFrame(frame: MsgFrame): StatuslineLastMessage {
 
 export function unreadFromCursor(latestSeq: number | undefined | null, channel?: string | null): number | undefined {
   if (typeof latestSeq !== "number" || latestSeq <= 0 || !channel) return undefined;
-  const state = readState();
-  const cursor = state?.channel === channel ? state.cursor : 0;
+  // #113：游标已按频道键持久化，不再只对绑定频道有效
+  const cursor = loadCursor(channel);
   return Math.max(0, latestSeq - cursor);
 }
 

--- a/cli/test/config.test.ts
+++ b/cli/test/config.test.ts
@@ -139,14 +139,20 @@ describe("workspace state", () => {
     expect(loadCursor("other", cwd)).toBe(0);
   });
 
-  test("saveCursor only advances bound channel monotonically", () => {
+  test("saveCursor advances monotonically and now keys by channel (#113)", () => {
     writeState({ channel: "dev", cursor: 5 }, cwd);
     saveCursor("dev", 9, cwd);
     expect(loadCursor("dev", cwd)).toBe(9);
     saveCursor("dev", 3, cwd);
-    expect(loadCursor("dev", cwd)).toBe(9);
+    expect(loadCursor("dev", cwd)).toBe(9); // 不回退
+
+    // #113 修复前：非绑定频道的游标被静默丢弃，serve --profile 的每个频道恒 since=0
     saveCursor("other", 42, cwd);
-    expect(readState(cwd)).toEqual({ channel: "dev", cursor: 9 });
+    expect(loadCursor("other", cwd)).toBe(42);
+    expect(loadCursor("dev", cwd)).toBe(9); // 互不干扰
+    // 绑定频道仍镜像到顶层，兼容旧读者
+    expect(readState(cwd)?.cursor).toBe(9);
+    expect(readState(cwd)?.channel).toBe("dev");
   });
 
   test("resolveChannel prefers explicit over bound", () => {

--- a/cli/test/cursor-persistence.test.ts
+++ b/cli/test/cursor-persistence.test.ts
@@ -1,0 +1,110 @@
+// #113：本地游标持久化三连击。三个独立缺陷共同击穿「@mention 恰好一次送达」。
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  advanceCursorPastOwnMessage,
+  loadCursor,
+  loadRevCursor,
+  readState,
+  saveCursor,
+  saveRevCursor,
+  statePath,
+  writeState,
+} from "../src/config";
+
+const cwd = () => mkdtempSync(join(tmpdir(), "ap-cursor-"));
+
+describe("cursor persistence (#113)", () => {
+  describe("① send 不得吞掉发送前未消费的消息", () => {
+    test("有空洞时，发自己的消息绝不推进游标", () => {
+      const d = cwd();
+      writeState({ channel: "dev", cursor: 10 }, d);
+      // 频道已经到 seq 14（11..14 是别人的消息，其中可能有 @我），我发的是 15
+      advanceCursorPastOwnMessage("dev", 15, d);
+      // 修复前：游标直接跳到 15，11..14 永久跳过——不打印、不唤醒、不补拉
+      expect(loadCursor("dev", d)).toBe(10);
+    });
+
+    test("无空洞时（我已读到最新），推进一格以保住 statusline 的 unread=0", () => {
+      const d = cwd();
+      writeState({ channel: "dev", cursor: 14 }, d);
+      advanceCursorPastOwnMessage("dev", 15, d);
+      expect(loadCursor("dev", d)).toBe(15);
+    });
+
+    test("乱序/重复调用不会让游标回退", () => {
+      const d = cwd();
+      writeState({ channel: "dev", cursor: 14 }, d);
+      advanceCursorPastOwnMessage("dev", 15, d);
+      advanceCursorPastOwnMessage("dev", 15, d); // 重复
+      advanceCursorPastOwnMessage("dev", 12, d); // 迟到的旧 seq
+      expect(loadCursor("dev", d)).toBe(15);
+    });
+  });
+
+  describe("② 游标必须按频道键，而不是只对绑定频道生效", () => {
+    test("serve --profile 的多个频道各自保有游标", () => {
+      const d = cwd();
+      writeState({ channel: "alpha", cursor: 0 }, d);
+      saveCursor("alpha", 100, d);
+      saveCursor("beta", 200, d);
+      saveCursor("gamma", 300, d);
+      // 修复前：beta/gamma 的 saveCursor 被静默丢弃 → 每次重启 since=0 → 重放全部历史 @
+      expect(loadCursor("alpha", d)).toBe(100);
+      expect(loadCursor("beta", d)).toBe(200);
+      expect(loadCursor("gamma", d)).toBe(300);
+    });
+
+    test("rev 游标同样按频道键", () => {
+      const d = cwd();
+      writeState({ channel: "alpha", cursor: 0 }, d);
+      saveRevCursor("alpha", 7, d);
+      saveRevCursor("beta", 9, d);
+      expect(loadRevCursor("alpha", d)).toBe(7);
+      expect(loadRevCursor("beta", d)).toBe(9);
+      expect(loadRevCursor("unknown", d)).toBe(0);
+    });
+
+    test("升级兼容：只有旧格式顶层字段时，绑定频道的游标不丢", () => {
+      const d = cwd();
+      // 模拟旧版写下的 state（无 cursors 表）
+      writeState({ channel: "dev", cursor: 42, rev_cursor: 8 }, d);
+      expect(loadCursor("dev", d)).toBe(42);
+      expect(loadRevCursor("dev", d)).toBe(8);
+      expect(loadCursor("other", d)).toBe(0);
+      // 写入后迁移到 cursors 表，且顶层仍镜像
+      saveCursor("dev", 43, d);
+      expect(readState(d)?.cursors?.dev?.cursor).toBe(43);
+      expect(readState(d)?.cursor).toBe(43);
+    });
+  });
+
+  describe("③ state.json 必须原子写", () => {
+    test("截断的 state 不会让游标退回 0 之外——写入本身不留半个文件", () => {
+      const d = cwd();
+      writeState({ channel: "dev", cursor: 5 }, d);
+      // 直接模拟一次崩溃留下的截断文件
+      writeFileSync(statePath(d), '{"channel":"dev","cur');
+      expect(readState(d)).toBeNull();
+      expect(loadCursor("dev", d)).toBe(0); // 损坏即重放，这正是要防的
+
+      // 修复后：writeState 走 tmp+rename，中途崩溃不会产生上面这种半截文件。
+      // 这里断言写完之后落盘的一定是完整可解析的 JSON。
+      writeState({ channel: "dev", cursor: 5 }, d);
+      saveCursor("dev", 6, d);
+      const raw = readState(d);
+      expect(raw).not.toBeNull();
+      expect(raw?.cursors?.dev?.cursor).toBe(6);
+    });
+
+    test("并发写不会互相截断（同一目录连续多次写，每次都可解析）", () => {
+      const d = cwd();
+      writeState({ channel: "dev", cursor: 0 }, d);
+      for (let i = 1; i <= 50; i++) saveCursor("dev", i, d);
+      expect(loadCursor("dev", d)).toBe(50);
+      expect(readState(d)).not.toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
Closes #113

评审报告里排在行动顺序第 2 位：**一个小模块，一次修掉两个 P1 一个 P2**，挽回产品命脉。

## 三个独立缺陷，同一后果

### ① `send` 成功后吞掉发送前未消费的消息

```ts
// cli/src/commands/send.ts:117（修复前）
saveCursor(input.channel, seq);   // ← 游标直接跳到自己新消息的 seq
```

发送前那些还没消费的消息——**包括正 @ 自己的新 mention**——被永久跳过：不打印、不唤醒、不补拉。

而 `watch.ts:154` 本来就有 `fromSelf` 过滤，「跳过自己的回声」根本不需要动游标。

**最短失败场景**：推荐的 `watch --once` 待命模式下，agent 回帖那一刻，期间第三方发的「@you 还要做 X」永久消失。

改：`advanceCursorPastOwnMessage()` 只在 `cursor === seq - 1`（无空洞）时前进一格，保住 statusline 的 `unread=0`；**有空洞一律不动**。6 处调用点（issue 说 5 处，实际 `mcp.ts` 有两处）。

### ② 游标只对绑定频道生效

`loadCursor`/`saveCursor` 都要求 `st.channel === channel`，于是 `serve --profile` 的所有频道恒 `since=0` —— 每次重启把保留窗口内的全部历史 @ 逐条重新拉起 runner。重复消费风暴，烧 token、刷屏、重放副作用。

改：`state.cursors: Record<channel, {cursor, rev_cursor}>`。旧格式读时回落、写时迁移，绑定频道仍镜像到顶层（兼容 statusline 等旧读者）。

### ③ `state.json` 非原子写

裸 `writeFileSync`，崩溃或并发即留下截断 JSON → `readState` 返回 `null` → 游标退回 0 → 同样重放。同仓 `statusline-cache.ts:136-139` 早有 tmp+rename 范本。

## 测试

`cli/test/cursor-persistence.test.ts`：三个缺陷各自的失败场景、升级兼容、单调性、并发写。

**变异测试**：还原缺陷 ① 和 ②，对应断言立刻变红（贴在 PR 讨论里）。

还修正了 `config.test.ts` 里一条**把缺陷 ② 当契约测死**的用例（`saveCursor("other", 42)` 被静默丢弃却断言 state 不变）。

`bun run check` 全过：cli 344 / web 155 / worker 238。

https://claude.ai/code/session_01PgxkZeqJmDge3dYe9W2tPZ