### PR TITLE
fix(web): 重连维护 revCursor，断线窗口内的 edit/retract 不再永久跳过

### DIFF
--- a/web/src/lib/ws.test.ts
+++ b/web/src/lib/ws.test.ts
@@ -1,0 +1,225 @@
+// issue #117 回归测试：重连时 hello.since_rev 必须是本地维护的 revCursor（已消费的最大 rev_seq），
+// 而不是新 welcome 的 last_rev_seq——否则断线窗口内的 edit/retract 会被服务端补拉永久跳过。
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { HelloFrame, ServerFrame } from "@agentparty/shared";
+import { ChannelSocket } from "./ws";
+
+// 最小 WebSocket 桩：记录 send 出去的帧，暴露 open/close/deliver 供测试驱动生命周期。
+class FakeSocket {
+  static instances: FakeSocket[] = [];
+  static OPEN = 1;
+  static reset() {
+    FakeSocket.instances = [];
+  }
+  readyState = 0; // CONNECTING
+  onopen: (() => void) | null = null;
+  onmessage: ((ev: { data: unknown }) => void) | null = null;
+  onclose: ((ev: { code: number; reason: string }) => void) | null = null;
+  sent: string[] = [];
+  constructor(
+    public url: string,
+    public protocols?: string[],
+  ) {
+    FakeSocket.instances.push(this);
+  }
+  send(data: string) {
+    this.sent.push(data);
+  }
+  close() {
+    this.readyState = 3; // CLOSED
+  }
+  // 测试驱动：进入 open 态并触发 onopen
+  open() {
+    this.readyState = FakeSocket.OPEN;
+    this.onopen?.();
+  }
+  // 测试驱动：投递一帧服务端消息
+  deliver(frame: ServerFrame) {
+    this.onmessage?.({ data: JSON.stringify(frame) });
+  }
+  // 测试驱动：触发一次传输层断线（非 1008，走重连）
+  drop(code = 1006, reason = "") {
+    this.readyState = 3;
+    this.onclose?.({ code, reason });
+  }
+  // 本连接发出的 hello 帧
+  hello(): HelloFrame {
+    const raw = this.sent.map((s) => JSON.parse(s) as { type: string });
+    const h = raw.find((f) => f.type === "hello");
+    if (!h) throw new Error("no hello frame sent on this socket");
+    return h as HelloFrame;
+  }
+}
+
+// 待触发的重连定时器回调（window.setTimeout 捕获），flushTimers 手动放行。
+let pendingTimers: Array<() => void>;
+function flushTimers() {
+  const due = pendingTimers.splice(0);
+  for (const fn of due) fn();
+}
+
+beforeEach(() => {
+  FakeSocket.reset();
+  pendingTimers = [];
+  (globalThis as unknown as { WebSocket: typeof FakeSocket }).WebSocket = FakeSocket;
+  (globalThis as unknown as { location: { protocol: string; host: string } }).location = {
+    protocol: "http:",
+    host: "localhost",
+  };
+  (globalThis as unknown as { window: unknown }).window = {
+    setInterval: () => 0,
+    clearInterval: () => {},
+    setTimeout: (fn: () => void) => {
+      pendingTimers.push(fn);
+      return pendingTimers.length;
+    },
+    clearTimeout: () => {},
+  };
+});
+
+afterEach(() => {
+  Reflect.deleteProperty(globalThis, "WebSocket");
+  Reflect.deleteProperty(globalThis, "window");
+  Reflect.deleteProperty(globalThis, "location");
+});
+
+function noopHandlers() {
+  return {
+    onFrame: () => {},
+    onStatus: () => {},
+    onFatal: () => {},
+  };
+}
+
+function welcome(lastRevSeq: number, lastSeq = 0): ServerFrame {
+  return {
+    type: "welcome",
+    channel: "demo",
+    self: "me",
+    participants: [],
+    last_seq: lastSeq,
+    last_rev_seq: lastRevSeq,
+    presence: [],
+  };
+}
+
+// rev_seq 携带者：一条修订快照（编辑后的消息）
+function msgWithRev(seq: number, revSeq: number): ServerFrame {
+  return {
+    type: "msg",
+    seq,
+    sender: { name: "a", kind: "agent" },
+    kind: "text",
+    body: "edited",
+    mentions: [],
+    reply_to: null,
+    state: null,
+    note: null,
+    status: null,
+    ts: 0,
+    edited: true,
+    edited_at: 1,
+    rev_seq: revSeq,
+  } as ServerFrame;
+}
+
+describe("ChannelSocket revCursor (issue #117)", () => {
+  test("首连：since_rev 播种为 welcome.last_rev_seq（REST 已带来当前正文，历史修订不重放）", () => {
+    const sock = new ChannelSocket("demo", "tok", noopHandlers(), { initialCursor: 42 });
+    sock.connect();
+    const s0 = FakeSocket.instances[0]!;
+    s0.open();
+    s0.deliver(welcome(100, 42));
+
+    expect(s0.hello().since).toBe(42);
+    expect(s0.hello().since_rev).toBe(100);
+    sock.dispose();
+  });
+
+  test("旧服务端无 last_rev_seq → since_rev 退回 0（旧全量重放语义）", () => {
+    const sock = new ChannelSocket("demo", "tok", noopHandlers(), { initialCursor: 5 });
+    sock.connect();
+    const s0 = FakeSocket.instances[0]!;
+    s0.open();
+    // last_rev_seq 缺省
+    s0.deliver({
+      type: "welcome",
+      channel: "demo",
+      self: "me",
+      participants: [],
+      last_seq: 5,
+      presence: [],
+    } as ServerFrame);
+
+    expect(s0.hello().since_rev).toBe(0);
+    sock.dispose();
+  });
+
+  test("收到带 rev_seq 的 update 帧后 revCursor 前进，重连时上报前进后的值", () => {
+    const sock = new ChannelSocket("demo", "tok", noopHandlers(), { initialCursor: 10 });
+    sock.connect();
+    const s0 = FakeSocket.instances[0]!;
+    s0.open();
+    s0.deliver(welcome(100, 10)); // 基线 revCursor=100
+    // live 修订：一条消息被编辑，rev_seq=105
+    s0.deliver(msgWithRev(7, 105));
+
+    // 断线 → 重连
+    s0.drop();
+    flushTimers();
+    const s1 = FakeSocket.instances[1]!;
+    expect(s1).toBeDefined();
+    s1.open();
+    s1.deliver(welcome(999, 10)); // 服务端水位已被别人推到 999
+
+    // 重连上报的是已消费的 revCursor(105)，不是新 welcome 的 last_rev_seq(999)
+    expect(s1.hello().since_rev).toBe(105);
+    sock.dispose();
+  });
+
+  test("重连的 since_rev 是已消费的 revCursor，而不是新 welcome.last_rev_seq（核心缺陷）", () => {
+    const sock = new ChannelSocket("demo", "tok", noopHandlers(), { initialCursor: 20 });
+    sock.connect();
+    const s0 = FakeSocket.instances[0]!;
+    s0.open();
+    s0.deliver(welcome(100, 20)); // 首连基线 revCursor=100
+    expect(s0.hello().since_rev).toBe(100);
+
+    // 断线窗口内没有任何帧到达本端（模拟：断线期间服务端发生了 edit/retract，water 涨到 200）
+    s0.drop();
+    flushTimers();
+    const s1 = FakeSocket.instances[1]!;
+    s1.open();
+    s1.deliver(welcome(200, 20)); // 断线期间修订把 last_rev_seq 推到 200
+
+    // 必须仍用 100 补拉，才能收到 (100,200] 区间的 edit/retract；用 200 会永久跳过（issue #117）
+    expect(s1.hello().since_rev).toBe(100);
+    expect(s1.hello().since_rev).not.toBe(200);
+    sock.dispose();
+  });
+
+  test("message_update 也推进 revCursor（live 编辑广播）", () => {
+    const sock = new ChannelSocket("demo", "tok", noopHandlers(), { initialCursor: 3 });
+    sock.connect();
+    const s0 = FakeSocket.instances[0]!;
+    s0.open();
+    s0.deliver(welcome(50, 3));
+    s0.deliver({
+      type: "message_update",
+      target_seq: 2,
+      action: "edit",
+      actor: { name: "a", kind: "agent" },
+      ts: 0,
+      message: msgWithRev(2, 77),
+    } as ServerFrame);
+
+    s0.drop();
+    flushTimers();
+    const s1 = FakeSocket.instances[1]!;
+    s1.open();
+    s1.deliver(welcome(500, 3));
+
+    expect(s1.hello().since_rev).toBe(77);
+    sock.dispose();
+  });
+});

--- a/web/src/lib/ws.ts
+++ b/web/src/lib/ws.ts
@@ -34,6 +34,8 @@ export interface ChannelSocketOptions {
 export class ChannelSocket {
   private ws: WebSocket | null = null;
   private cursor = 0; // 本地已见最大 seq，重连 hello 用
+  private revCursor = 0; // 本地已消费最大 rev_seq，重连 hello.since_rev 用（issue #117）
+  private revSeeded = false; // 首个 welcome 是否已用 last_rev_seq 播种 revCursor
   private backoff = BACKOFF_MIN_MS;
   private pingTimer: number | null = null;
   private reconnectTimer: number | null = null;
@@ -89,11 +91,22 @@ export class ChannelSocket {
       }
       if (frame.type === "welcome" && !helloSent) {
         helloSent = true;
-        // REST 初始页/上翻页携带的就是消息当前状态（含编辑后正文），历史修订无需重放；
-        // 窗口内消息的后续修订走 live message_update。旧服务端无 last_rev_seq → 0 = 旧语义。
-        this.send({ type: "hello", since: this.cursor, since_rev: frame.last_rev_seq ?? 0 });
+        // 首连：REST 初始页/上翻页携带的就是消息当前状态（含编辑后正文），历史修订无需重放，
+        //   直接以服务端当前修订水位 last_rev_seq 作 revCursor 基线。旧服务端无 last_rev_seq → 0 = 旧语义。
+        // 重连：必须用本地维护的 revCursor（已消费的最大 rev_seq）作 since_rev，绝不用新 welcome 的
+        //   last_rev_seq 覆盖——否则断线窗口内发生的 edit/retract（原地 UPDATE，只 bump rev_seq）
+        //   会落在 (旧 revCursor, 新 last_rev_seq] 区间被服务端补拉跳过，页面永久停留在原文（issue #117）。
+        if (!this.revSeeded) {
+          this.revCursor = frame.last_rev_seq ?? 0;
+          this.revSeeded = true;
+        }
+        this.send({ type: "hello", since: this.cursor, since_rev: this.revCursor });
       }
       if ((frame.type === "msg" || frame.type === "status") && frame.seq > this.cursor) this.cursor = frame.seq;
+      // 收到带 rev_seq 的修订快照（hello 补拉/live）或 live message_update 后推进 revCursor，
+      // 下次重连才不会把这次修订再补拉一遍，也保证重连补拉的下界正确（issue #117）。
+      if (frame.type === "msg" || frame.type === "status") this.advanceRev(frame.rev_seq);
+      if (frame.type === "message_update") this.advanceRev(frame.message.rev_seq);
       this.handlers.onFrame(frame);
     };
 
@@ -153,6 +166,11 @@ export class ChannelSocket {
     if (this.reconnectTimer !== null) clearTimeout(this.reconnectTimer);
     this.ws?.close(1000, "bye");
     this.ws = null;
+  }
+
+  // 修订游标只前移：修订快照是幂等展示事件，收到即视为已消费（不等 ack，与 CLI client.ts 对齐）。
+  private advanceRev(rev: number | undefined) {
+    if (typeof rev === "number" && rev > this.revCursor) this.revCursor = rev;
   }
 
   private clearPing() {


### PR DESCRIPTION
Closes #117

由后台 worker agent 完成，我 review 并独立复现了变异测试。

## 根因

`web/src/lib/ws.ts` **从未维护修订游标**。每次收到 `welcome`（首连和重连一视同仁）都执行 `since_rev: frame.last_rev_seq ?? 0`，无条件采用服务端**当前**修订水位。

服务端 hello 补拉是 `WHERE seq > since OR (rev_seq IS NOT NULL AND rev_seq > since_rev)`。而 edit/retract/supersede 是**原地 UPDATE 只 bump `rev_seq`**、`seq` 不变，只能走后一条分支。

断线窗口内的修订把 `last_rev_seq` 从 `R` 推到 `R'`，重连时 web 拿 `R'` 当 `since_rev` → `(R, R']` 区间的修订全部 `rev_seq <= since_rev` 被过滤 → **永久跳过**，页面无限期显示原文直到整页刷新。

**retract 的设计场景正是撤回误发的密钥。** 网络抖 30 秒，撤回对任何断线过的页面就失效了。

`cli/src/client.ts` 是正确的参照实现，web 缺这一层。

## 改动

- `revCursor` + `revSeeded`：首连用 `welcome.last_rev_seq` 播种（REST 初始页已含当前正文，历史修订无需重放——issue #33 既定行为），**重连一律上报本地 `revCursor`**
- 收到带 `rev_seq` 的 `msg`/`status` 与 `message_update` 时前移游标
- 特意用独立的 `revSeeded` 而非复用 `everConnected`：后者在 `onopen` 就置真，早于 `welcome` 到达，播种时机会错位

## 测试

`web/src/lib/ws.test.ts`（5 case，`FakeSocket` 桩 + 捕获式 `setTimeout` 驱动连接生命周期）：首连播种语义、旧服务端无 `last_rev_seq` 退回 0、`msg`/`message_update` 推进游标、**核心缺陷**（断线窗口内无帧到达时重连仍上报旧 `revCursor` 100 而非新 `last_rev_seq` 200）。

**变异测试（我独立复现过）**：把 `since_rev` 改回 `frame.last_rev_seq ?? 0` → 3 条重连断言立刻红；恢复后 5 条全绿。首连的 2 条始终绿——正确，因为首连行为两版本一致。

`bun run check` 全过。

https://claude.ai/code/session_01PgxkZeqJmDge3dYe9W2tPZ