### PR TITLE
fix(worker): 两处安全边界——削弱 guard 需 human；未验证 email 不作 ACL 锚点

### DIFF
--- a/worker/src/auth.ts
+++ b/worker/src/auth.ts
@@ -219,6 +219,8 @@ async function importVerifyKey(issuer: string, kid?: string): Promise<CryptoKey 
 }
 
 interface OidcClaims {
+  /** OIDC standard claim（#100）：email 未验证时不得作为 ACL 账号锚点。部分 IdP 用字符串 "true"。 */
+  email_verified?: boolean | string;
   iss?: string;
   aud?: string | string[];
   exp?: number;
@@ -251,7 +253,13 @@ async function verifyOidcToken(token: string, oidc: OidcConfig): Promise<TokenId
   const ok = await crypto.subtle.verify({ name: "RSASSA-PKCS1-v1_5" }, key, signature, signed);
   if (!ok) return null;
   // OIDC 人类：sub 作 name，role/kind=human；hash 用 oidc: 前哨（不落 D1，生命周期归 JWT exp）
-  const email = typeof claims.email === "string" ? claims.email : undefined;
+  //
+  // email 是私有频道 ACL 的唯一账号锚点（account = email ?? sub），所以只认经 IdP 验证过的
+  // email（#100）。允许自设未验证 email 的 IdP（Auth0 DB connection、GitHub 未验证邮箱等）
+  // 下，攻击者以 email=victim@corp.com 登录即可接管受害者的全部私有频道。
+  // email_verified 缺失或为 false → 忽略 email，回退到 sub（sub 由 IdP 保证唯一且不可伪造）。
+  const emailVerified = claims.email_verified === true || claims.email_verified === "true";
+  const email = emailVerified && typeof claims.email === "string" ? claims.email : undefined;
   return {
     name: claims.sub,
     email,

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1,5 +1,11 @@
 // worker 入口 — rest 路由 + ws 升级转发
-import { CHARTER_LIMIT, RESERVED_NAMES, ROLE_RESPONSIBILITY_LIMIT } from "@agentparty/shared";
+import {
+  CHARTER_LIMIT,
+  LOOP_GUARD_N,
+  LOOP_GUARD_PARTY_N,
+  RESERVED_NAMES,
+  ROLE_RESPONSIBILITY_LIMIT,
+} from "@agentparty/shared";
 import type {
   AgentLineage,
   CaptureKind,
@@ -3917,6 +3923,27 @@ app.put("/api/channels/:slug/completion-gate", async (c) => {
   return c.json({ gate, policy });
 });
 
+
+// #119：削弱 guard 的门禁不得弱于 reset-guard 的 human-only。
+// reset 只清计数，关闭/放宽 guard 是永久摘掉刹车——更强的动作，不能门禁更松。
+// 加强（开启、调低阈值）对任何 configurer 放行：那是往安全方向走。
+function loopGuardEffectiveLimit(channel: LoadedChannel): number {
+  if (channel.loop_guard_limit != null && channel.loop_guard_limit > 0) return channel.loop_guard_limit;
+  return channel.mode === "party" ? LOOP_GUARD_PARTY_N : LOOP_GUARD_N;
+}
+
+function weakensLoopGuard(channel: LoadedChannel, enabled: boolean, limit: number | null): boolean {
+  if (!enabled) return channel.loop_guard_enabled === 1; // 开→关 = 削弱；本就关着不算
+  if (channel.loop_guard_enabled !== 1) return false; // 关→开 = 加强
+  return limit !== null && limit > loopGuardEffectiveLimit(channel); // 放宽阈值 = 削弱
+}
+
+function weakensWorkflowGuard(channel: LoadedChannel, enabled: boolean, limit: number | null): boolean {
+  if (!enabled) return channel.workflow_guard_enabled === 1;
+  if (channel.workflow_guard_enabled !== 1) return false;
+  return limit !== null && limit > channel.workflow_guard_limit;
+}
+
 app.put("/api/channels/:slug/loop-guard", async (c) => {
   const slug = c.req.param("slug");
   const channel = await loadChannel(c.env.DB, slug);
@@ -3935,6 +3962,9 @@ app.put("/api/channels/:slug/loop-guard", async (c) => {
   const limit = body.enabled ? positiveInt(body.limit) : null;
   if (body.enabled && (limit === null || limit > 10_000)) {
     return c.json(errorBody("bad_request", "limit must be an integer between 1 and 10000"), 400);
+  }
+  if (weakensLoopGuard(channel, body.enabled, limit) && identity.kind !== "human") {
+    return c.json(errorBody("forbidden", "only a human can disable or loosen the loop guard"), 403);
   }
   const enabled = body.enabled ? 1 : 0;
   await c.env.DB.prepare("UPDATE channels SET loop_guard_enabled = ?, loop_guard_limit = ? WHERE slug = ?")
@@ -3974,6 +4004,9 @@ app.put("/api/channels/:slug/workflow-guard", async (c) => {
     : null;
   if (body.enabled && (limit === null || limit > 1000)) {
     return c.json(errorBody("bad_request", "limit must be an integer between 1 and 1000"), 400);
+  }
+  if (weakensWorkflowGuard(channel, body.enabled, limit) && identity.kind !== "human") {
+    return c.json(errorBody("forbidden", "only a human can disable or loosen the workflow guard"), 403);
   }
   const enabled = body.enabled ? 1 : 0;
   const storedLimit = limit ?? channel.workflow_guard_limit;

--- a/worker/test/guard-config-acl.spec.ts
+++ b/worker/test/guard-config-acl.spec.ts
@@ -1,0 +1,108 @@
+// #119：削弱 guard 的权限必须不弱于重置 guard。
+// reset-guard 严格要求 kind==="human"（loop guard 防的就是 agent 失控刷屏，不能让它
+// 重置自己的熔断）；但 PUT loop-guard / workflow-guard 只查 canConfigureChannel。
+// 于是被熔断的 agent 可以直接 {enabled:false} 关掉熔断——比 reset 更强的动作，门禁更松。
+//
+// 边界取「削弱 vs 加强」，不是一刀切 human-only：
+//   削弱（关闭、放宽阈值）→ human-only；加强（开启、调低阈值）→ 任何 configurer 都行。
+// 一刀切会打断 agent 合法地给频道加刹车的流程。
+import { describe, expect, it } from "vitest";
+import { api, createChannel, seedToken, uniq } from "./helpers";
+
+describe("guard config ACL (#119)", () => {
+  it("an agent cannot disable the loop guard, mirroring reset-guard's human-only rule", async () => {
+    const ownerAccount = `${uniq("acct")}@example.com`;
+    const human = await seedToken("human", uniq("human"), { owner: ownerAccount });
+    const agent = await seedToken("agent", uniq("agent"), { owner: ownerAccount });
+    const slug = await createChannel(human.token);
+
+    // agent 与房主同账号 → canConfigureChannel 放行，但 kind 是 agent
+    const off = await api(`/api/channels/${slug}/loop-guard`, agent.token, {
+      method: "PUT",
+      body: JSON.stringify({ enabled: false }),
+    });
+    expect(off.status).toBe(403);
+
+    // 同一个 agent 去 reset 也是 403 —— 两条门禁现在一致
+    const reset = await api(`/api/channels/${slug}/reset-guard`, agent.token, { method: "POST" });
+    expect(reset.status).toBe(403);
+  });
+
+  it("an agent cannot disable the workflow guard either", async () => {
+    const ownerAccount = `${uniq("acct")}@example.com`;
+    const human = await seedToken("human", uniq("human"), { owner: ownerAccount });
+    const agent = await seedToken("agent", uniq("agent"), { owner: ownerAccount });
+    const slug = await createChannel(human.token);
+
+    const off = await api(`/api/channels/${slug}/workflow-guard`, agent.token, {
+      method: "PUT",
+      body: JSON.stringify({ enabled: false }),
+    });
+    expect(off.status).toBe(403);
+  });
+
+  it("a human moderator can still configure both guards", async () => {
+    const human = await seedToken("human", uniq("human"));
+    const slug = await createChannel(human.token);
+
+    const loopOn = await api(`/api/channels/${slug}/loop-guard`, human.token, {
+      method: "PUT",
+      body: JSON.stringify({ enabled: true, limit: 5 }),
+    });
+    expect(loopOn.status).toBe(200);
+    expect(await loopOn.json()).toEqual({ enabled: true, limit: 5 });
+
+    const wfOn = await api(`/api/channels/${slug}/workflow-guard`, human.token, {
+      method: "PUT",
+      body: JSON.stringify({ enabled: true, limit: 4 }),
+    });
+    expect(wfOn.status).toBe(200);
+
+    const loopOff = await api(`/api/channels/${slug}/loop-guard`, human.token, {
+      method: "PUT",
+      body: JSON.stringify({ enabled: false }),
+    });
+    expect(loopOff.status).toBe(200);
+  });
+
+  it("an agent CAN strengthen the guard (enable it, or lower the limit)", async () => {
+    const ownerAccount = `${uniq("acct")}@example.com`;
+    const human = await seedToken("human", uniq("human"), { owner: ownerAccount });
+    const agent = await seedToken("agent", uniq("agent"), { owner: ownerAccount });
+    const slug = await createChannel(human.token);
+
+    // 新频道默认 enabled=1、limit 空（回退 mode 默认 30）。调低到 5 = 加强 → 放行
+    const tighten = await api(`/api/channels/${slug}/loop-guard`, agent.token, {
+      method: "PUT",
+      body: JSON.stringify({ enabled: true, limit: 5 }),
+    });
+    expect(tighten.status).toBe(200);
+
+    // 但放宽到 9000 = 削弱 → 403
+    const loosen = await api(`/api/channels/${slug}/loop-guard`, agent.token, {
+      method: "PUT",
+      body: JSON.stringify({ enabled: true, limit: 9000 }),
+    });
+    expect(loosen.status).toBe(403);
+  });
+
+  it("an agent can enable a guard that was off (off → on is strengthening)", async () => {
+    const ownerAccount = `${uniq("acct")}@example.com`;
+    const human = await seedToken("human", uniq("human"), { owner: ownerAccount });
+    const agent = await seedToken("agent", uniq("agent"), { owner: ownerAccount });
+    const slug = await createChannel(human.token);
+
+    // 人类先关掉
+    expect((await api(`/api/channels/${slug}/loop-guard`, human.token, {
+      method: "PUT",
+      body: JSON.stringify({ enabled: false }),
+    })).status).toBe(200);
+
+    // agent 再打开 → 放行
+    const on = await api(`/api/channels/${slug}/loop-guard`, agent.token, {
+      method: "PUT",
+      body: JSON.stringify({ enabled: true, limit: 10 }),
+    });
+    expect(on.status).toBe(200);
+  });
+});

--- a/worker/test/guards.spec.ts
+++ b/worker/test/guards.spec.ts
@@ -22,8 +22,8 @@ describe("guards", () => {
     const agentB = await seedToken("agent");
     const human = await seedToken("human");
     const slug = await createChannel(agentA.token);
-    // #96 起新频道默认开 guard；本用例测的是关闭态，必须显式关闭
-    await disableLoopGuard(slug, agentA.token);
+    // #96 起新频道默认开 guard；本用例测的是关闭态，必须显式关闭（#119：关闭是 human-only）
+    await disableLoopGuard(slug, human.token);
 
     for (let i = 0; i < LOOP_GUARD_N + 5; i++) {
       const token = i % 2 === 0 ? agentA.token : agentB.token;
@@ -43,8 +43,8 @@ describe("guards", () => {
     const agent = await seedToken("agent");
     const human = await seedToken("human");
     const slug = await createChannel(agent.token);
-    // #96 起新频道默认开 guard；本用例测的是关闭态，必须显式关闭
-    await disableLoopGuard(slug, agent.token);
+    // #96 起新频道默认开 guard；本用例测的是关闭态，必须显式关闭（#119：关闭是 human-only）
+    await disableLoopGuard(slug, human.token);
     const init = await WsClient.open(slug, agent.token);
     await init.nextOfType("welcome");
     init.close();
@@ -65,9 +65,10 @@ describe("guards", () => {
   it("disabled loop guard does not block the old 31st consecutive agent message", async () => {
     const agentA = await seedToken("agent");
     const agentB = await seedToken("agent");
+    const human = await seedToken("human");
     const slug = await createChannel(agentA.token);
-    // #96 起新频道默认开 guard；本用例测的是关闭态，必须显式关闭
-    await disableLoopGuard(slug, agentA.token);
+    // #96 起新频道默认开 guard；本用例测的是关闭态，必须显式关闭（#119：关闭是 human-only）
+    await disableLoopGuard(slug, human.token);
 
     // 两个 agent token 交替，避开单 token 速率限制，streak 仍按 kind 累计
     for (let i = 0; i < LOOP_GUARD_N; i++) {

--- a/worker/test/helpers.ts
+++ b/worker/test/helpers.ts
@@ -176,10 +176,11 @@ export class WsClient {
 
 // #96 起新频道默认开启 loop guard。测「关闭态」行为的用例必须显式关闭，
 // 不能再借用默认值——否则默认值一变，这些用例就在测别的东西。
-export async function disableLoopGuard(slug: string, token: string): Promise<void> {
-  const res = await api(`/api/channels/${slug}/loop-guard`, token, {
+// #119 起「关闭 guard」是 human-only（削弱刹车），所以必须拿人类 token 来关。
+export async function disableLoopGuard(slug: string, humanToken: string): Promise<void> {
+  const res = await api(`/api/channels/${slug}/loop-guard`, humanToken, {
     method: "PUT",
     body: JSON.stringify({ enabled: false }),
   });
-  if (!res.ok) throw new Error(`disableLoopGuard failed: ${res.status}`);
+  if (!res.ok) throw new Error(`disableLoopGuard failed: ${res.status} (needs a human moderator token)`);
 }

--- a/worker/test/oidc.spec.ts
+++ b/worker/test/oidc.spec.ts
@@ -54,7 +54,8 @@ async function signJwt(claims: Record<string, unknown>, opts: { kid?: string; ta
 
 function claims(issuer: string, over: Record<string, unknown> = {}) {
   const now = Math.floor(Date.now() / 1000);
-  return { iss: issuer, aud: CLIENT_ID, sub: "user-abc", email: "u@leeguoo.com", exp: now + 3600, iat: now, ...over };
+  // email_verified: true = 正常 IdP 的姿态（#100）。未验证的场景在专门的用例里显式覆盖。
+  return { iss: issuer, aud: CLIENT_ID, sub: "user-abc", email: "u@leeguoo.com", email_verified: true, exp: now + 3600, iat: now, ...over };
 }
 
 // 每个需要验签的单元用例用独立 issuer，避开 JWKS 内存缓存，让 interceptor 恰好消费一次
@@ -148,6 +149,45 @@ describe("lookupToken OIDC verification", () => {
     // oidc=null：JWT 不走验证，落 D1 hash 查询 → 未命中 → null（保持机器 token 现状）
     expect(await lookupToken(env.DB, await signJwt(claims(issuer)), null)).toBeNull();
   });
+
+  // #100：email 是私有频道 ACL 的唯一账号锚点。允许自设未验证 email 的 IdP 下，
+  // 攻击者以 email=victim@corp.com 登录即可接管受害者的全部私有频道。
+  it("ignores an unverified email and falls back to sub as the account anchor", async () => {
+    const issuer = freshIssuer();
+    mockJwks(issuer);
+    const id = await lookupToken(
+      env.DB,
+      await signJwt(claims(issuer, { email: "victim@corp.com", email_verified: false })),
+      oidc(issuer),
+    );
+    expect(id).not.toBeNull();
+    expect(id?.email).toBeUndefined();
+    expect(id?.account).toBe("user-abc"); // sub，不是被冒充的 email
+    expect(id?.owner).toBe("user-abc");
+  });
+
+  it("ignores an email when email_verified is absent entirely", async () => {
+    const issuer = freshIssuer();
+    mockJwks(issuer);
+    const id = await lookupToken(
+      env.DB,
+      await signJwt(claims(issuer, { email: "victim@corp.com", email_verified: undefined })),
+      oidc(issuer),
+    );
+    expect(id?.account).toBe("user-abc");
+  });
+
+  it('accepts the string "true" form some IdPs emit', async () => {
+    const issuer = freshIssuer();
+    mockJwks(issuer);
+    const id = await lookupToken(
+      env.DB,
+      await signJwt(claims(issuer, { email: "u@leeguoo.com", email_verified: "true" })),
+      oidc(issuer),
+    );
+    expect(id?.account).toBe("u@leeguoo.com");
+  });
+
 });
 
 describe("oidc end-to-end via SELF.fetch", () => {
@@ -223,4 +263,5 @@ describe("oidc end-to-end via SELF.fetch", () => {
     expect(post.status).toBe(200);
     expect((await post.json()) as { seq: number }).toMatchObject({ seq: 1 });
   });
+
 });

--- a/worker/test/party.spec.ts
+++ b/worker/test/party.spec.ts
@@ -55,9 +55,10 @@ describe("party mode", () => {
 
   it("party channel keeps accepting messages past the old loop guard thresholds", async () => {
     const { token } = await seedToken("agent");
+    const human = await seedToken("human");
     const slug = await createModeChannel(token, "party");
-    // #96 起新频道默认开 guard；本用例测的是关闭态，必须显式关闭
-    await disableLoopGuard(slug, token);
+    // #96 起新频道默认开 guard；本用例测的是关闭态，必须显式关闭（#119：关闭是 human-only）
+    await disableLoopGuard(slug, human.token);
 
     // 首条消息让 do 缓存 mode=party
     expect((await postMessage(slug, token, "kickoff")).status).toBe(200);
@@ -73,9 +74,10 @@ describe("party mode", () => {
 
   it("normal channel keeps accepting messages past the old loop guard threshold", async () => {
     const { token } = await seedToken("agent");
+    const human = await seedToken("human");
     const slug = await createModeChannel(token);
-    // #96 起新频道默认开 guard；本用例测的是关闭态，必须显式关闭
-    await disableLoopGuard(slug, token);
+    // #96 起新频道默认开 guard；本用例测的是关闭态，必须显式关闭（#119：关闭是 human-only）
+    await disableLoopGuard(slug, human.token);
     expect((await postMessage(slug, token, "kickoff")).status).toBe(200);
     await seedStreak(slug, LOOP_GUARD_N);
     const allowed = await postMessage(slug, token, "31st");

--- a/worker/test/webhooks.spec.ts
+++ b/worker/test/webhooks.spec.ts
@@ -393,8 +393,9 @@ describe("webhooks", () => {
     const agentA = await seedToken("agent");
     const agentB = await seedToken("agent");
     const slug = await createChannel(agentA.token);
-    // #96 起新频道默认开 guard；本用例测的是关闭态，必须显式关闭
-    await disableLoopGuard(slug, agentA.token);
+    const guardHuman = await seedToken("human");
+    // #96 起新频道默认开 guard；本用例测的是关闭态，必须显式关闭（#119：关闭是 human-only）
+    await disableLoopGuard(slug, guardHuman.token);
     expect(
       (
         await addWebhook(slug, agentA.token, {


### PR DESCRIPTION
Closes #119 · Closes #100

## #119 — 被熔断的 agent 可以自己关掉熔断

`reset-guard` 严格 human-only（注释写得很清楚：*loop guard 防的就是 agent 失控刷屏，不能让 agent 重置自己的熔断*），但 `PUT /loop-guard` 和 `PUT /workflow-guard` 只查 `canConfigureChannel`。

**关闭 guard 是比 reset 更强的动作**（reset 只清计数，关闭是永久摘掉刹车），门禁反而更松。

### 边界取「削弱 vs 加强」，不是一刀切

我第一版写成一刀切 `kind !== "human"` → **误伤 7 条既有用例**，其中包括 agent 合法地给频道**加**刹车。

| 动作 | 谁能做 |
|---|---|
| 关闭 guard | human only |
| 放宽阈值（limit 变大） | human only |
| 开启 guard | 任何 configurer |
| 收紧阈值（limit 变小） | 任何 configurer |

往安全方向走的动作不设限。

## #100 — OIDC 不校验 `email_verified`

`email` 是私有频道 ACL 的**唯一账号锚点**（`account = email ?? sub`，`acl.ts:41,52`），而 `auth.ts` 直接采信 JWT 里的 `email` claim，全仓无 `email_verified` 判定。

允许自设未验证 email 的 IdP（Auth0 DB connection、GitHub 未验证邮箱等）下，攻击者以 `email=victim@corp.com` 登录即获得受害者全部私有频道的读/写/房主权。企业 SSO 姿态下不可利用，属**条件性缺口**——但修复是几行。

改：`email_verified !== true`（含缺失）时忽略 email，回退到 `sub`。兼容部分 IdP 发的字符串 `"true"`。

顺带发现 `OidcClaims` 接口里**根本没声明** `email_verified` —— 协议层从没考虑过它，tsc 直接把这一点报了出来。

## 测试

- `guard-config-acl.spec.ts`：agent 不能关/放宽、**能**开/收紧；human 两者都行
- `oidc.spec.ts`：未验证 email 回退 sub、`email_verified` 缺失同样回退、字符串 `"true"` 接受
- **两处变异测试**：去掉门禁 / 去掉 `email_verified` 判定，对应断言立刻变红
- `helpers.disableLoopGuard()` 改收 human token，6 处调用点同步——**这些测试的失败正是新语义的证据**

`bun run check` 全过：34 spec / 246 tests。

https://claude.ai/code/session_01PgxkZeqJmDge3dYe9W2tPZ