### PR TITLE
fix(cli): party task list --json 输出单个自描述文档，空结果不再零字节

### DIFF
--- a/cli/src/commands/task.ts
+++ b/cli/src/commands/task.ts
@@ -36,7 +36,9 @@ const HELP = `usage: party task create <title|-> [--channel C] [--desc text] [--
   party task done <id> [--channel C]
 
 Create and move channel tasks. Agent-created tasks default to triage; human-created
-tasks default to backlog unless an assignee/state is provided.`;
+tasks default to backlog unless an assignee/state is provided.
+
+  --json   emit one JSON document: { schema, type: "task_list", channel, tasks, count }`;
 
 function parseState(value: string | undefined): TaskState | null | undefined {
   if (value === undefined) return undefined;
@@ -154,8 +156,14 @@ export async function run(argv: string[]): Promise<number> {
         ...(assignee !== undefined ? { assignee } : {}),
         ...(limit !== undefined ? { limit } : {}),
       });
-      for (const task of tasks) {
-        console.log(flags.json === true ? JSON.stringify(jsonFrame(task as unknown as Record<string, unknown>)) : formatTask(task));
+      if (flags.json === true) {
+        // Single JSON document (never zero bytes), mirroring the REST
+        // {tasks:[]} envelope so agents can JSON.parse stdout and read .tasks.
+        console.log(JSON.stringify(jsonFrame({ type: "task_list", channel: slug, tasks, count: tasks.length })));
+      } else if (tasks.length === 0) {
+        console.log(`no tasks in #${slug}`);
+      } else {
+        for (const task of tasks) console.log(formatTask(task));
       }
       return 0;
     }

--- a/cli/test/json-contract.test.ts
+++ b/cli/test/json-contract.test.ts
@@ -332,4 +332,68 @@ describe("json contract fixtures", () => {
     expect(result).toMatchObject({ code: 0, stderr: "" });
     expectContract(parseOneLine(result.stdout), fixture("whoami.logged-out.json"));
   });
+
+  test("task list --json emits a single task_list envelope (empty channel)", async () => {
+    restMock = startRestMock((req) => {
+      if (req.method === "GET" && /^\/api\/channels\/dev\/tasks$/.test(req.path)) {
+        return Response.json({ tasks: [] });
+      }
+      return undefined;
+    });
+    writeCfg(restMock.url);
+
+    const result = await runCli(["task", "list", "--channel", "dev", "--json"]);
+    expect(result).toMatchObject({ code: 0, stderr: "" });
+    // Must be a single parseable document, never zero bytes.
+    const parsed = parseOneLine(result.stdout) as Record<string, unknown>;
+    expect(parsed).toMatchObject({ type: "task_list", channel: "dev", count: 0 });
+    expect(parsed.schema).toBe("agentparty.v1");
+    expect(parsed.tasks).toEqual([]);
+  });
+
+  test("task list --json emits a single task_list envelope (with tasks)", async () => {
+    restMock = startRestMock((req) => {
+      if (req.method === "GET" && /^\/api\/channels\/dev\/tasks$/.test(req.path)) {
+        return Response.json({
+          tasks: [
+            {
+              type: "task",
+              id: 1,
+              state: "triage",
+              priority: 0,
+              title: "fix task list json",
+              labels: ["bug"],
+              assignee: null,
+              parent_id: null,
+              created_at: Date.now(),
+              updated_at: Date.now(),
+            },
+          ],
+        });
+      }
+      return undefined;
+    });
+    writeCfg(restMock.url);
+
+    const result = await runCli(["task", "list", "--channel", "dev", "--json"]);
+    expect(result).toMatchObject({ code: 0, stderr: "" });
+    const parsed = parseOneLine(result.stdout) as Record<string, unknown>;
+    expect(parsed).toMatchObject({ type: "task_list", channel: "dev", count: 1 });
+    expect(Array.isArray(parsed.tasks)).toBe(true);
+    expect((parsed.tasks as unknown[]).length).toBe(1);
+  });
+
+  test("task list (plain) prints a message instead of zero bytes for an empty channel", async () => {
+    restMock = startRestMock((req) => {
+      if (req.method === "GET" && /^\/api\/channels\/dev\/tasks$/.test(req.path)) {
+        return Response.json({ tasks: [] });
+      }
+      return undefined;
+    });
+    writeCfg(restMock.url);
+
+    const result = await runCli(["task", "list", "--channel", "dev"]);
+    expect(result).toMatchObject({ code: 0 });
+    expect(result.stdout.trim()).toBe("no tasks in #dev");
+  });
 });


### PR DESCRIPTION
Closes #142

主体由 @code-learning 完成（频道里带的新手 agent），方案 A 由 @LEO-MAIN 在 seq 107 拍板。我 review 并搬到隔离分支后合入。

## 问题

`cli/src/commands/task.ts` 逐行 `console.log` = 未文档化的 JSONL。空数组自然产出**零行零字节**：

```
$ party task list --channel agentparty --state needs_review --json
$ echo "rc=$? bytes=$(... | wc -c)"
rc=0 bytes=0
```

而 REST 返回的是自描述的 `{"tasks":[]}`。agent 照着 REST 的形状 `JSON.parse` 会直接崩（我 dogfooding 时第一条命令就踩了）；而且「没有 task」和「命令静默失败」在 `rc=0` + 零字节下**无法区分**。

## 改动

- `--json` 输出单个 `{ schema, type: "task_list", channel, tasks, count }` 文档，与 REST envelope 对齐
- `board --json` 本来就是单文档，两者现在一致
- 非 json 模式空结果打印 `no tasks in #<channel>`
- help 里写清 `--json` 的输出形状

## 测试

`json-contract.test.ts` 新增 3 条契约用例：空频道、非空频道、stdout 必须是单个可解析文档（never zero bytes）。

`bun run check` 全过：34 spec / 246 tests。

## 流程说明

这份改动原本落在主工作树的未提交区，卡住了 @LEO-MAIN 的 v0.2.85 发版（release 要求 clean worktree）。我把它转存到独立分支、还原主工作树后再走 PR——**代码是好的，流程要改**。

https://claude.ai/code/session_01PgxkZeqJmDge3dYe9W2tPZ