### PR TITLE
fix: presence 新鲜度不再对健康的 serve/watch 撒谎（不动 host 租约）

### DIFF
--- a/cli/src/commands/who.ts
+++ b/cli/src/commands/who.ts
@@ -58,7 +58,8 @@ export function classify(e: PresenceEntry, now: number): Row | null {
   if (e.name === "system") return null;
   const seen = e.last_seen ?? e.ts ?? 0;
   const age = now - seen;
-  const online = e.state !== "offline" && age < STALE_MS;
+  // online：与 web 一致以「当前有活 WS 连接」为准（#97 的 live）；无 live 信号时回退旧新鲜度启发式。
+  const online = e.state !== "offline" && (e.live === true || age < STALE_MS);
   const kind = kindOf(e);
   const wake = e.wake?.kind;
   let tier: Tier;

--- a/cli/src/reach.ts
+++ b/cli/src/reach.ts
@@ -23,7 +23,9 @@ export function reachOf(name: string, presence: PresenceEntry[], now: number): R
   const seen = e.last_seen ?? e.ts ?? 0;
   const age = now - seen;
   const wake = e.wake?.kind;
-  if (e.state !== "offline" && age < STALE_MS) return { name, reach: "online", ...(wake ? { wake } : {}) };
+  // online：与 web mentions 一致以「当前有活 WS 连接」为准（#97 的 live，DO 从 getConnections 权威判定）；
+  // 无 live 信号（旧 worker 响应）时回退到旧的新鲜度启发式，不回归。
+  if (e.state !== "offline" && (e.live === true || age < STALE_MS)) return { name, reach: "online", ...(wake ? { wake } : {}) };
   if (wake !== undefined && autoWakeReachable(e, now, STALE_MS) && age <= DEAD_MS) return { name, reach: "wakeable", wake };
   return { name, reach: "offline", ...(wake ? { wake } : {}) };
 }

--- a/cli/test/reach.test.ts
+++ b/cli/test/reach.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import type { PresenceEntry } from "@agentparty/shared";
+import { applyLiveConnection, type PresenceEntry } from "@agentparty/shared";
 import { formatReach, formatReachLine, reachOf } from "../src/reach";
 
 const NOW = 1_000_000_000;
@@ -48,6 +48,28 @@ describe("reachOf", () => {
 
   test("offline with no wake kind → offline", () => {
     expect(reachOf("x", [p({ name: "x", state: "offline", wake: { kind: "none" } })], NOW).reach).toBe("offline");
+  });
+});
+
+// issue #97：修复在服务端（DO presence 序列化给有活连接的 name 打 live=true，不改写 last_seen）。
+// reachOf 消费已带 live 的 presence：live 视同「在线」，与 web mentions（online.has＝participants＝活连接）
+// 同源同判。这里守住 CLI/web 一致性回归。applyLiveConnection 是那道服务端修正的纯函数形态。
+describe("consistency with server-side live-connection fix (#97)", () => {
+  test("有活连接的 serve agent：陈旧甚至 offline 的行经 applyLiveConnection 打 live 后 → reachOf 判 online", () => {
+    // 挂了 61s 没发帧的健康 serve：presence 陈旧、行内可能还是 offline（重连未自报）
+    const raw = p({ name: "bot", state: "offline", wake: { kind: "serve" }, residency: "supervised", last_seen: NOW - 61_000 });
+    // 未打 live（服务端不知道有活连接）时：CLI 会误判 offline —— 这正是 #97 里 CLI 与 web 打架的根源
+    expect(reachOf("bot", [raw], NOW).reach).toBe("offline");
+    // 打 live 后（服务端知道 bot 有活 WS 连接）：reachOf 判 online，与 web mentions（online.has）一致
+    const corrected = applyLiveConnection(raw, true);
+    expect(corrected.live).toBe(true);
+    expect(corrected.last_seen).toBe(NOW - 61_000); // 不改写 last_seen（host 租约不受污染）
+    expect(reachOf("bot", [corrected], NOW).reach).toBe("online");
+  });
+
+  test("无活连接：修正是恒等，陈旧 serve 仍判 offline（离线判定不被破坏）", () => {
+    const raw = p({ name: "bot", state: "offline", wake: { kind: "serve" }, residency: "supervised", last_seen: NOW - 61_000 });
+    expect(reachOf("bot", [applyLiveConnection(raw, false)], NOW).reach).toBe("offline");
   });
 });
 

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -274,6 +274,13 @@ export interface PresenceEntry {
   avatar_thumb?: string;
   /** 同一身份当前活跃连接数。仅 >1 时下发，用于提示 token/session 被重复使用。 */
   connection_count?: number;
+  /**
+   * 序列化时该 name 是否持有活 WS 连接（issue #97）。DO 从 getConnections 权威判定，仅 true 时下发；
+   * 旧客户端忽略。用途仅限「可达性/新鲜度」——live 视同新鲜（短路 wakeReachable 的 staleMs 判定）、
+   * 视同在线。**不参与 host 租约判定**：evaluateHostLease/summarizeHosts 仍只看 last_seen，failover 触发
+   * 条件保持「多久没干活」而非「TCP 有没有断」（一个卡在无超时 await 上的 serve socket 照样是活的）。
+   */
+  live?: boolean;
 }
 
 export interface ChannelRoleAssignment {
@@ -302,20 +309,44 @@ export function presenceLastSeen(entry: Pick<PresenceEntry, "last_seen" | "ts">)
 // 可唤醒判定的统一口径（issue #47），cli `party who` / `send --reach` 与 web mention 候选共用：
 // serve/watch 靠本地常驻 supervisor 持 WS，presence 不新鲜（supervisor 大概率已死）就叫不醒；
 // webhook 由服务端投递，agent 离线也真能被唤醒，不受新鲜度限制（幽灵清理由调用方另行处理）。
-export function wakeReachable(kind: WakeKind | undefined, ageMs: number, staleMs = PRESENCE_TIMEOUT_MS): boolean {
+// live（issue #97）：DO 权威判定「当前有活 WS 连接」时视同新鲜——WS 还连着本身就是 supervisor 存活的
+// 最强证据，短路 staleMs 判定，让健康但安静的 serve/watch 不被误判叫不醒。webhook 恒 true、不受影响。
+export function wakeReachable(
+  kind: WakeKind | undefined,
+  ageMs: number,
+  staleMs = PRESENCE_TIMEOUT_MS,
+  live = false,
+): boolean {
   if (kind === "webhook") return true;
-  return (kind === "serve" || kind === "watch") && ageMs < staleMs;
+  return (kind === "serve" || kind === "watch") && (live || ageMs < staleMs);
+}
+
+// issue #97：presence 的新鲜度不变量没人维护。presence.updated_at 只由 status 帧和 markOffline 写，
+// 活着但安静的 WS 连接不回写；于是一个健康的 serve/watch 挂着、频道静默 61s，就被 wakeReachable 误判
+// 「supervisor 已死、叫不醒」，断线重连后又钉死在 offline。但 DO 权威地知道谁有活连接（getConnections）。
+// 读侧修正：序列化 presence 时，若某 name 当前有活 WS 连接，就打上 live=true——可达性/新鲜度判定视同新鲜。
+// 关键：**不改写 ts/last_seen**（那会连带把 host 租约变成「socket 在就永不过期」，废掉 failover——见 live
+// 字段注释），只加一个独立信号让 wakeReachable/在线判定短路。同时把陈旧的 offline 提升为 waiting（连着但还
+// 没自报 = 待命可唤醒，不是在忙，所以不碰 working/waiting/blocked/done 这些已自报的工作态，只解 offline 死锁）。
+// 无活连接的行原样返回（引用不变），离线/租约判定完全不变。
+export function applyLiveConnection(entry: PresenceEntry, hasLiveConnection: boolean): PresenceEntry {
+  if (!hasLiveConnection) return entry;
+  const next: PresenceEntry = { ...entry, live: true };
+  if (next.state === "offline") next.state = "waiting";
+  return next;
 }
 
 export function autoWakeReachable(
-  entry: Pick<PresenceEntry, "wake" | "last_seen" | "ts" | "residency">,
+  entry: Pick<PresenceEntry, "wake" | "last_seen" | "ts" | "residency" | "live">,
   now: number,
   staleMs = PRESENCE_TIMEOUT_MS,
 ): boolean {
   if (entry.residency === "human_driven") return false;
+  const live = entry.live === true;
   const seen = presenceLastSeen(entry);
-  if (seen === null) return false;
-  return wakeReachable(entry.wake?.kind, now - seen, staleMs);
+  if (seen === null && !live) return false;
+  const ageMs = seen === null ? 0 : now - seen;
+  return wakeReachable(entry.wake?.kind, ageMs, staleMs, live);
 }
 
 export function evaluateHostLease(

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -1,5 +1,6 @@
 // channel durable object — seq 分配 / 广播 / presence / 补拉 / 各类熔断 / webhook 投递 / temp 归档
 import {
+  applyLiveConnection,
   BODY_LIMIT,
   LOOP_GUARD_N,
   LOOP_GUARD_PARTY_N,
@@ -3206,7 +3207,7 @@ export class ChannelDO extends Server<Env> {
          FROM presence ORDER BY name`,
       )
       .toArray()
-      .map((r) => this.withConnectionCount(this.presenceRowToEntry(r), liveCounts));
+      .map((r) => this.withLivePresence(this.presenceRowToEntry(r), liveCounts));
   }
 
   private presenceFor(name: string): PresenceEntry | null {
@@ -3221,12 +3222,16 @@ export class ChannelDO extends Server<Env> {
         name,
       )
       .toArray();
-    return rows.length > 0 ? this.withConnectionCount(this.presenceRowToEntry(rows[0]!), liveCounts) : null;
+    return rows.length > 0 ? this.withLivePresence(this.presenceRowToEntry(rows[0]!), liveCounts) : null;
   }
 
-  private withConnectionCount(entry: PresenceEntry, liveCounts: Map<string, number>): PresenceEntry {
+  // issue #97：presence 序列化时用「当前有无活 WS 连接」在读侧修正可达性/离线，再叠加重复连接计数。
+  // 有活连接 → applyLiveConnection 打 live=true、offline 提升为 waiting（不改写 ts/last_seen，故 host 租约
+  // 判定完全不受影响，详见 shared 注释）；无活连接 → 原样返回。connection_count 语义照旧（仅 >1 时下发）。
+  private withLivePresence(entry: PresenceEntry, liveCounts: Map<string, number>): PresenceEntry {
     const count = liveCounts.get(entry.name) ?? 0;
-    return count > 1 ? { ...entry, connection_count: count } : entry;
+    const live = applyLiveConnection(entry, count > 0);
+    return count > 1 ? { ...live, connection_count: count } : live;
   }
 
   private presenceRowToEntry(r: Record<string, unknown>): PresenceEntry {

--- a/worker/test/presence-liveness.spec.ts
+++ b/worker/test/presence-liveness.spec.ts
@@ -1,0 +1,164 @@
+// issue #97：活 WS 连接 = supervisor 存活的最强证据。presence.updated_at 只由 status 帧 / markOffline
+// 写，安静的健康连接不回写 → 被误判「叫不醒」；断线重连又钉死在 offline。修复用独立字段 `live`（DO 从
+// liveConnectionCounts 权威判定）短路可达性/新鲜度判定，**不改写 ts/last_seen**——所以 host 租约（只看
+// last_seen）语义完全不变，failover 不受影响。这里既覆盖纯函数，也走真实 WS 端到端。
+import {
+  applyLiveConnection,
+  autoWakeReachable,
+  evaluateHostLease,
+  PRESENCE_TIMEOUT_MS,
+  type PresenceEntry,
+} from "@agentparty/shared";
+import { describe, expect, it } from "vitest";
+import { WsClient, api, createChannel, seedToken } from "./helpers";
+
+const NOW = 1_000_000_000;
+const STALE_SEEN = NOW - (PRESENCE_TIMEOUT_MS + 60_000); // 早已陈旧的 last_seen（>60s）
+
+function entry(over: Partial<PresenceEntry> & { name: string }): PresenceEntry {
+  return { state: "waiting", note: null, ts: NOW, last_seen: NOW, ...over };
+}
+
+async function fetchPresence(slug: string, token: string): Promise<PresenceEntry[]> {
+  const res = await api(`/api/channels/${slug}/presence`, token);
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as { presence: PresenceEntry[] };
+  return body.presence;
+}
+
+describe("applyLiveConnection (issue #97 read-side reachability fix)", () => {
+  it("有活连接：打 live=true、offline 提升为 waiting，但**不改写 ts/last_seen**", () => {
+    const stale = entry({ name: "bot", state: "offline", wake: { kind: "serve" }, residency: "supervised", last_seen: STALE_SEEN, ts: STALE_SEEN });
+    const live = applyLiveConnection(stale, true);
+    expect(live.live).toBe(true);
+    expect(live.state).toBe("waiting"); // 解重连死锁
+    // 关键不变量：时间戳原封不动，host 租约据此判活不受污染
+    expect(live.last_seen).toBe(STALE_SEEN);
+    expect(live.ts).toBe(STALE_SEEN);
+  });
+
+  it("(b) 有活连接：autoWakeReachable 为 true —— live 短路了陈旧判定", () => {
+    const stale = entry({ name: "bot", state: "offline", wake: { kind: "serve" }, residency: "supervised", last_seen: STALE_SEEN, ts: STALE_SEEN });
+    // 没活连接时：陈旧 serve = supervisor 大概率已死 → 叫不醒
+    expect(autoWakeReachable(stale, NOW)).toBe(false);
+    // 有活连接：live 短路 staleMs → 可唤醒
+    expect(autoWakeReachable(applyLiveConnection(stale, true), NOW)).toBe(true);
+  });
+
+  it("(a) host 租约不吃 live：有活连接但 last_seen 陈旧的 host，evaluateHostLease 仍 stale/lease-expired", () => {
+    const host = entry({
+      name: "hostbot",
+      role: "host",
+      state: "working",
+      residency: "supervised",
+      wake: { kind: "serve", verified_at: 1 },
+      last_seen: STALE_SEEN,
+      ts: STALE_SEEN,
+    });
+    const withoutLive = evaluateHostLease(host, NOW);
+    const withLive = evaluateHostLease(applyLiveConnection(host, true), NOW);
+    // 与修复前完全一致：租约靠 last_seen 判活，live 不参与 → 仍然过期
+    expect(withLive.lease).toBe("stale");
+    expect(withLive.reason).toBe("lease-expired");
+    expect(withLive).toEqual(withoutLive);
+  });
+
+  it("没有活连接：陈旧的行原样返回（引用不变），仍判离线 / 不可达", () => {
+    const stale = entry({ name: "bot", state: "offline", wake: { kind: "serve" }, residency: "supervised", last_seen: STALE_SEEN, ts: STALE_SEEN });
+    const same = applyLiveConnection(stale, false);
+    expect(same).toBe(stale);
+    expect(same.live).toBeUndefined();
+    expect(autoWakeReachable(same, NOW)).toBe(false);
+  });
+
+  it("有活连接不谎称在忙：working/blocked/done 等已自报的工作态不被改写，只打 live", () => {
+    for (const state of ["working", "blocked", "done", "waiting"] as const) {
+      const e = entry({ name: "bot", state, note: "refactor", wake: { kind: "serve" }, residency: "supervised", last_seen: STALE_SEEN, ts: STALE_SEEN });
+      const live = applyLiveConnection(e, true);
+      expect(live.state).toBe(state); // 工作态原样
+      expect(live.note).toBe("refactor");
+      expect(live.live).toBe(true);
+      expect(live.last_seen).toBe(STALE_SEEN);
+    }
+  });
+
+  it("webhook 语义不受影响：无活连接、陈旧也恒可唤醒", () => {
+    const stale = entry({ name: "hookbot", state: "offline", wake: { kind: "webhook" }, last_seen: STALE_SEEN, ts: STALE_SEEN });
+    expect(autoWakeReachable(applyLiveConnection(stale, false), NOW)).toBe(true);
+    expect(autoWakeReachable(applyLiveConnection(stale, true), NOW)).toBe(true);
+  });
+});
+
+describe("DO presence wiring (issue #97 end-to-end)", () => {
+  it("活 WS 连接的 agent：/presence 标 live=true、报为非 offline、可自动唤醒", async () => {
+    const agent = await seedToken("agent");
+    const slug = await createChannel(agent.token);
+    const ws = await WsClient.open(slug, agent.token);
+    await ws.nextOfType("welcome");
+    ws.send({
+      type: "send",
+      kind: "status",
+      state: "working",
+      note: "on it",
+      mentions: [],
+      residency: "supervised",
+      wake: { kind: "serve", verified_at: 1 },
+    });
+    await ws.nextOfType("sent");
+
+    const list = await fetchPresence(slug, agent.token);
+    const me = list.find((p) => p.name === agent.name)!;
+    expect(me).toBeDefined();
+    expect(me.live).toBe(true);
+    expect(me.state).not.toBe("offline");
+    expect(autoWakeReachable(me, Date.now())).toBe(true);
+    ws.close();
+  });
+
+  it("断线重连后不再钉死在 offline：presence 行是 offline，活连接把它提升为可达", async () => {
+    const agent = await seedToken("agent");
+    const human = await seedToken("human");
+    const slug = await createChannel(agent.token);
+
+    // 人类观察者常驻，用它的 presence 帧同步 markOffline 时机，避免 onClose 竞态
+    const watcher = await WsClient.open(slug, human.token);
+    await watcher.nextOfType("welcome");
+
+    const first = await WsClient.open(slug, agent.token);
+    await first.nextOfType("welcome");
+    first.send({
+      type: "send",
+      kind: "status",
+      state: "working",
+      note: "first pass",
+      mentions: [],
+      residency: "supervised",
+      wake: { kind: "serve", verified_at: 1 },
+    });
+    await first.nextOfType("sent");
+
+    // 断线 → onClose → markOffline，等 watcher 收到 offline presence 帧才继续（消竞态）
+    first.close();
+    for (;;) {
+      const f = await watcher.nextOfType("presence");
+      if (f.name === agent.name && f.state === "offline") break;
+    }
+
+    // 此刻无活连接：/presence 权威地报 offline、无 live（离线判定不被破坏）
+    const offlineList = await fetchPresence(slug, agent.token);
+    const offlineMe = offlineList.find((p) => p.name === agent.name)!;
+    expect(offlineMe.state).toBe("offline");
+    expect(offlineMe.live).toBeUndefined();
+
+    // 重连：presence 行仍是 offline（下次自报前不变），但活连接立即让它重新可达
+    const second = await WsClient.open(slug, agent.token);
+    await second.nextOfType("welcome");
+
+    const reconnList = await fetchPresence(slug, agent.token);
+    const reconnMe = reconnList.find((p) => p.name === agent.name)!;
+    expect(reconnMe.live).toBe(true);
+    expect(reconnMe.state).not.toBe("offline"); // 不再钉死在 offline
+    expect(autoWakeReachable(reconnMe, Date.now())).toBe(true); // 可唤醒 / 可达，CLI 与 web 一致
+    second.close();
+  });
+});


### PR DESCRIPTION
Closes #97 —— 评审报告里最后一条未解决的 P1。

由后台 worker agent 完成，**经过一轮我打回的返工**；两条变异测试我独立复现过。

## 缺陷

`wakeReachable()` 把 presence 新鲜度当作「supervisor 还活着」的判据：

```ts
return (kind === "serve" || kind === "watch") && ageMs < staleMs;   // 60s
```

**但没有任何机制维持这个不变量。** `presence.updated_at` 只由 status 帧和 `markOffline` 写；活着但安静的 WS 连接不回写——字面 `{"type":"ping"}` 更是被 `setWebSocketAutoResponse` 直接应答，根本不进 handler。

后果（我今天真实踩到）：
- 健康的 `serve` 挂着、频道安静 61 秒 → `party wake test` 判 `not_auto_wakeable` 并**拒发 mention**。协作方以为对方死了，其实 @ 一下就秒醒。
- 断线重连后 presence 钉死在 `offline`，直到它主动自报 status。
- **CLI 与 web 对同一个 agent 给出相反结论** —— web 看 `participants`（活连接集合），是对的。

## 修复

DO 其实**权威地知道谁有活连接**（`getConnections()`）。读侧修正，不加定时器、不加写放大（`#128` 已经在说 DO 存储只增不减）。

- `PresenceEntry` 新增可选 `live?: boolean`，DO 序列化时对有活 WS 连接的 name 置 `true`
- `wakeReachable` / `autoWakeReachable`：`live === true` 短路陈旧判定（webhook 恒 true 不变）
- `offline → waiting` 提升，解开重连死锁；`working`/`waiting`/`blocked`/`done` 一律不改写
- CLI `reach`/`who` 的 online 分档改用 `live`，与 web 口径对齐；`live` 缺失（旧 worker）时回落旧启发式

## 第一版被我打回的原因

subagent 的初版把 `ts`/`last_seen` 改写成 `now`。但 `last_seen` 不只喂 `wakeReachable`——`evaluateHostLease` 和 `summarizeHosts` 也读它：

```ts
if (now - seen > leaseMs) return { lease: "stale", reason: "lease-expired", ... }
```

于是**任何持着 WS 的 host，租约永不过期**，failover 机制直接废掉。而活 socket 只证明进程还在、TCP 还开着——一个卡在无超时 `await` 上的 serve（正是 #116）socket 照样是活的，但它不处理任何 @。这正是 #27「送达 ≠ 醒来」的区别。

把 failover 的触发条件从「多久没干活」偷换成「TCP 有没有断」，不该顺手夹在一个修 presence 新鲜度的 PR 里。**返工后 `last_seen` 一行未动，host 租约逐字段不变。**

## 变异测试（我独立复现）

| 变异 | 结果 |
|---|---|
| 把 `last_seen` 改回写成 `now`（初版设计） | **3 条红**，含 host-lease 守卫 |
| 去掉 `live` 短路 | **1 条红**（`autoWakeReachable`） |

## 留给后续讨论

如果团队希望「活 WS 连接也持有/续期 host 租约」，那是一次**明确的 failover 策略变更**，值得独立 issue 和讨论。本 PR 刻意不做。

`bun run check` 全过：36 spec / 258 tests。

https://claude.ai/code/session_01PgxkZeqJmDge3dYe9W2tPZ