### PR TITLE
fix(web): OIDC 静默续期跨标签互斥，多标签不再互相作废并集体登出

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -9,6 +9,7 @@ import { TokenGate } from "./components/TokenGate";
 import { LanguageSwitcher } from "./components/LanguageSwitcher";
 import {
   AuthError,
+  type ChannelInfo,
   clearShareToken,
   clearToken,
   currentShareToken,
@@ -17,25 +18,26 @@ import {
   getToken,
   isShareMode,
   listChannels,
+  type MeInfo,
   readSession,
   redeemJoinLink,
   saveSession,
   saveToken,
   storedToken,
-  type ChannelInfo,
-  type MeInfo,
 } from "./lib/api";
 import {
-  type AuthProviderConfig,
-  type OidcConfig,
   authConfigForRuntime,
+  type AuthProviderConfig,
   beginLogin,
   completeLogin,
   decideJoinAuthAction,
   fetchAuthConfig,
   isCallbackPath,
+  type OidcConfig,
   refreshSession,
+  type WebSession,
 } from "./lib/oidc";
+import { sessionStillFresh, withRefreshLock } from "./lib/refreshLock";
 import { ChannelPage } from "./pages/Channel";
 import { Home } from "./pages/Home";
 import { matchChannel, matchJoin, useRoute } from "./router";
@@ -121,6 +123,16 @@ export function App() {
         return;
       }
     } else {
+      // 别的标签可能刚刚续期成功并写回了共享 localStorage（#126）：与其把所有标签一起
+      // 踢回登录页，不如接管那份新鲜会话。只有确实没有可用会话时才真正登出。
+      const adopted = readSession();
+      if (sessionStillFresh(adopted) && adopted !== null) {
+        setAuthError(null);
+        setChannels(null);
+        setListError(null);
+        setToken(adopted.accessToken);
+        return;
+      }
       clearToken();
     }
     setAuthError(message);
@@ -128,18 +140,33 @@ export function App() {
     setToken(null);
   }, []);
 
-  // 静默续期（去重）：refresh_token 会轮换，并发续期会互相作废，故全局只跑一枚在途 promise。
-  // 成功 → 落盘新会话 + setToken（触发下游用新 access_token 重连/重拉）；返回新 access_token。
+  // 静默续期（去重）：refresh_token 会轮换，并发续期会互相作废。
+  // 标签页内用 refreshInFlight 去重；**标签页之间**用 navigator.locks 互斥（#126）——
+  // 否则所有标签在 expiresAt-60s 这个绝对时刻同时拿同一个 refresh_token 去换，
+  // 先到的让后到的作废，后到者 hardLogout 清掉共享 localStorage 里的 session，
+  // 于是所有标签集体被踢回登录页。
+  // 拿到锁后先重读 session：很可能别的标签已经续好了，直接复用，一次请求都不发。
   const refreshInFlight = useRef<Promise<string> | null>(null);
   const doRefresh = useCallback((): Promise<string> => {
     if (refreshInFlight.current) return refreshInFlight.current;
-    const sess = readSession();
-    if (oidcRef.current === null || sess?.refreshToken == null) {
+    if (oidcRef.current === null || readSession()?.refreshToken == null) {
       return Promise.reject(new Error("no refreshable session"));
     }
-    const p = refreshSession(oidcRef.current, sess.refreshToken)
-      .then((next) => {
+    const p = withRefreshLock<WebSession>({
+      readFresh: () => {
+        const sess = readSession();
+        // 等锁期间别的标签很可能已经续好了：session 仍新鲜就直接复用，不再发请求
+        return sessionStillFresh(sess) ? sess : null;
+      },
+      refresh: async () => {
+        const sess = readSession();
+        if (oidcRef.current === null || sess?.refreshToken == null) throw new Error("no refreshable session");
+        const next = await refreshSession(oidcRef.current, sess.refreshToken);
         saveSession(next);
+        return next;
+      },
+    })
+      .then((next) => {
         setAuthError(null);
         setToken(next.accessToken);
         return next.accessToken;

--- a/web/src/lib/refreshLock.test.ts
+++ b/web/src/lib/refreshLock.test.ts
@@ -1,0 +1,118 @@
+// #126：OIDC 静默续期的跨标签互斥。
+import { describe, expect, test } from "bun:test";
+import { sessionStillFresh, withRefreshLock } from "./refreshLock";
+
+// 极简 LockManager：串行化同名锁，模拟浏览器跨标签行为
+function fakeLocks(): LockManager {
+  const queues = new Map<string, Promise<unknown>>();
+  return {
+    request: ((name: string, cb: () => Promise<unknown>) => {
+      const prev = queues.get(name) ?? Promise.resolve();
+      const next = prev.then(() => cb());
+      // 无论成败都让后来者继续排队
+      queues.set(name, next.catch(() => undefined));
+      return next;
+    }) as LockManager["request"],
+    query: async () => ({ held: [], pending: [] }),
+  } as LockManager;
+}
+
+interface Sess {
+  accessToken: string;
+  expiresAt: number;
+}
+
+const NOW = 1_000_000;
+
+describe("sessionStillFresh", () => {
+  test("fresh when more than the skew window remains", () => {
+    expect(sessionStillFresh({ accessToken: "a", expiresAt: NOW + 60 }, NOW)).toBe(true);
+  });
+  test("not fresh inside the skew window or past expiry", () => {
+    expect(sessionStillFresh({ accessToken: "a", expiresAt: NOW + 10 }, NOW)).toBe(false);
+    expect(sessionStillFresh({ accessToken: "a", expiresAt: NOW - 1 }, NOW)).toBe(false);
+  });
+  test("not fresh without a token or expiry", () => {
+    expect(sessionStillFresh(null, NOW)).toBe(false);
+    expect(sessionStillFresh({ accessToken: "a", expiresAt: null }, NOW)).toBe(false);
+    expect(sessionStillFresh({ accessToken: null, expiresAt: NOW + 60 }, NOW)).toBe(false);
+  });
+});
+
+describe("withRefreshLock (#126)", () => {
+  test("two tabs racing on expiry: only ONE hits the IdP, the other reuses the fresh session", async () => {
+    const locks = fakeLocks();
+    // 共享的「localStorage」
+    let stored: Sess | null = { accessToken: "old", expiresAt: NOW - 1 };
+    let idpCalls = 0;
+
+    const deps = () => ({
+      readFresh: () => (sessionStillFresh(stored, NOW) ? stored : null),
+      refresh: async () => {
+        idpCalls += 1;
+        // 真实 IdP：refresh_token 一次性，第二次调用会 invalid_grant
+        if (idpCalls > 1) throw new Error("invalid_grant");
+        await Promise.resolve();
+        stored = { accessToken: `new-${idpCalls}`, expiresAt: NOW + 600 };
+        return stored;
+      },
+    });
+
+    const [a, b] = await Promise.all([withRefreshLock(deps(), locks), withRefreshLock(deps(), locks)]);
+
+    // 关键：只发了一次 IdP 请求，第二个标签复用了新会话
+    expect(idpCalls).toBe(1);
+    expect(a.accessToken).toBe("new-1");
+    expect(b.accessToken).toBe("new-1");
+  });
+
+  test("without the lock the second tab burns the rotated refresh_token (this is the bug)", async () => {
+    let stored: Sess | null = { accessToken: "old", expiresAt: NOW - 1 };
+    let idpCalls = 0;
+    const refresh = async () => {
+      idpCalls += 1;
+      if (idpCalls > 1) throw new Error("invalid_grant");
+      await Promise.resolve();
+      stored = { accessToken: `new-${idpCalls}`, expiresAt: NOW + 600 };
+      return stored;
+    };
+    // 修复前的行为：两个标签各自直接 refresh，没有互斥
+    const results = await Promise.allSettled([refresh(), refresh()]);
+    expect(idpCalls).toBe(2);
+    expect(results[1]!.status).toBe("rejected"); // 后到的被 IdP 作废 → 该标签 hardLogout → 清共享 session
+  });
+
+  test("degrades gracefully when navigator.locks is unavailable", async () => {
+    let idpCalls = 0;
+    const got = await withRefreshLock<Sess>(
+      {
+        readFresh: () => null,
+        refresh: async () => {
+          idpCalls += 1;
+          return { accessToken: "x", expiresAt: NOW + 600 };
+        },
+      },
+      undefined,
+    );
+    expect(idpCalls).toBe(1);
+    expect(got.accessToken).toBe("x");
+  });
+
+  test("a caller that arrives after the winner never calls the IdP at all", async () => {
+    const locks = fakeLocks();
+    let idpCalls = 0;
+    const fresh: Sess = { accessToken: "already-fresh", expiresAt: NOW + 600 };
+    const got = await withRefreshLock<Sess>(
+      {
+        readFresh: () => (sessionStillFresh(fresh, NOW) ? fresh : null),
+        refresh: async () => {
+          idpCalls += 1;
+          return fresh;
+        },
+      },
+      locks,
+    );
+    expect(idpCalls).toBe(0);
+    expect(got.accessToken).toBe("already-fresh");
+  });
+});

--- a/web/src/lib/refreshLock.ts
+++ b/web/src/lib/refreshLock.ts
@@ -1,0 +1,49 @@
+// #126：OIDC 静默续期的跨标签互斥。
+//
+// refresh_token 是一次性的、会轮换：两个标签同时拿同一个 refresh_token 去换 token，
+// 先到的成功并让后到的那个作废（IdP 返回 invalid_grant），后到的标签 hardLogout →
+// 而 session 存在共享的 localStorage 里、clearToken 会连 SESSION_KEY 一起删 →
+// **所有标签集体被踢回登录页**。
+//
+// App.tsx 原本的 refreshInFlight 是 per-tab 的 useRef，注释写着「全局只跑一枚在途 promise」，
+// 但它只在单个标签页内去重。所有标签又按 expiresAt-60s 这个绝对时刻同时触发，必然撞上。
+//
+// 修法：navigator.locks 做跨标签互斥；拿到锁后**重读 session**——很可能别的标签已经续好了，
+// 此时直接复用新 token，一次网络请求都不发。
+
+const LOCK_NAME = "agentparty:oidc-refresh";
+
+/** 距过期还有 SKEW_SEC 以上就算「新鲜」——用于判断别的标签是否已经续过期。 */
+const SKEW_SEC = 30;
+
+export function sessionStillFresh(
+  sess: { accessToken?: string | null; expiresAt?: number | null } | null,
+  nowSec: number = Math.floor(Date.now() / 1000),
+): boolean {
+  if (sess?.accessToken == null || sess.expiresAt == null) return false;
+  return sess.expiresAt - SKEW_SEC > nowSec;
+}
+
+export interface RefreshLockDeps<T> {
+  /** 拿到锁之后重读一次会话；若它已经是新鲜的（别的标签续过了），返回它，不再发请求。 */
+  readFresh: () => T | null;
+  /** 真正去 IdP 换 token。只有拿到锁、且 readFresh 判定仍需续期时才会调用。 */
+  refresh: () => Promise<T>;
+}
+
+/**
+ * 在跨标签锁内执行续期。navigator.locks 不可用（老浏览器 / 非安全上下文）时降级为直接执行——
+ * 降级后的行为与修复前一致，不会更糟。
+ */
+export async function withRefreshLock<T>(deps: RefreshLockDeps<T>, locks: LockManager | undefined = navigator.locks): Promise<T> {
+  if (!locks) {
+    const fresh = deps.readFresh();
+    return fresh ?? (await deps.refresh());
+  }
+  return locks.request(LOCK_NAME, async () => {
+    // 关键：拿到锁之后才读。等锁期间别的标签很可能已经完成续期并写回 localStorage。
+    const fresh = deps.readFresh();
+    if (fresh !== null) return fresh;
+    return deps.refresh();
+  });
+}


### PR DESCRIPTION
Closes #126

⏸️ **等 @LEO-MAIN 的 v0.2.86 发布冻结解除后再合并。** 代码已就绪，`bun run check` 全过。

## 缺陷

`refresh_token` 是一次性的、会轮换。`App.tsx` 的 `refreshInFlight` 是 **per-tab `useRef`**——注释写着「全局只跑一枚在途 promise」，但它只在单个标签页内去重。而所有标签又按 `expiresAt - 60s` 这个**绝对时刻**同时触发续期。

于是：

1. 两个标签同时拿同一个 `refresh_token` 去换
2. 先到的成功，后到的被 IdP 判 `invalid_grant`
3. 后到者 `hardLogout()` → `clearToken()` 连 `SESSION_KEY` 一起删
4. session 存在**共享的 localStorage** 里 → **所有标签集体被踢回登录页**

笔记本唤醒（所有标签同时恢复）、双窗口工作时集中爆发。作者在 `App.tsx:125-127` 的注释里自己承认了这个风险。

## 修复（两道防线）

**① `web/src/lib/refreshLock.ts`** —— `navigator.locks` 跨标签互斥。
关键是**拿到锁之后才重读 session**：等锁期间别的标签很可能已经续好并写回 localStorage，此时直接复用，**一次网络请求都不发**。`navigator.locks` 不可用（老浏览器 / 非安全上下文）时降级为直接执行——不比修复前更糟。

**② `hardLogout` 接管分支** —— 真正登出前先看共享 localStorage 里有没有别的标签刚写入的新鲜 session，有就接管，而不是把所有标签一起踢掉。

## 测试

`web/src/lib/refreshLock.test.ts`（7 条），其中一条**显式复现修复前的 bug**：无锁时第二个标签烧掉轮换后的 `refresh_token` 并被 IdP 拒绝。

**变异测试**：去掉锁 → 「两个标签竞争时只发一次 IdP 请求」立刻红。

`bun run check` 全过：web 192 tests / 全仓 36 spec / worker 258 tests。

https://claude.ai/code/session_01PgxkZeqJmDge3dYe9W2tPZ