### PR TITLE
fix(cli): workflow_guard 与 429 不再塌缩成 exit 1

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -48,7 +48,7 @@ commands:
 
 watch defaults to a 240s timeout. With --follow, it stays attached unless --timeout N is explicit.
 
-exit codes: 0 ok/new message · 2 watch timeout (prints TIMEOUT) · 3 bad token · 4 loop guard · 5 archived · 6 stream ended (re-arm watch / restart serve) · 7 cli self-upgraded (restart serve)`;
+exit codes: 0 ok/new message · 2 watch timeout (prints TIMEOUT) · 3 bad token · 4 loop guard · 5 archived · 6 stream ended (re-arm watch / restart serve) · 7 cli self-upgraded (restart serve) · 8 workflow guard (stop, wait for human) · 9 rate limited (back off)`;
 
 export async function main(argv: string[]): Promise<number> {
   const [cmd, ...rest] = argv;

--- a/cli/src/rest.ts
+++ b/cli/src/rest.ts
@@ -1,18 +1,21 @@
 // rest api 封装
 import {
-  EXIT_ARCHIVED,
-  EXIT_AUTH,
-  EXIT_LOOP_GUARD,
+  type AgentLineage,
   type CaptureKind,
   type CaptureRecord,
-  type AgentLineage,
   type ChannelKind,
   type ChannelMode,
   type ChannelRoleAssignment,
+  type ChannelSquad,
   type CollaborationRole,
   type CompletionGate,
   type CompletionReview,
   type CompletionReviewPolicy,
+  EXIT_ARCHIVED,
+  EXIT_AUTH,
+  EXIT_LOOP_GUARD,
+  EXIT_RATE_LIMITED,
+  EXIT_WORKFLOW_GUARD,
   type MsgFrame,
   type PresenceEntry,
   type ReadCursor,
@@ -22,7 +25,6 @@ import {
   type TaskAssigneeKind,
   type TaskRecord,
   type TaskState,
-  type ChannelSquad,
   type TokenRole,
   type WakeDelivery,
   type WebhookFilter,
@@ -1035,7 +1037,17 @@ export function handleRestError(e: unknown): number {
       return EXIT_AUTH;
     }
     if (e.code === "loop_guard") return EXIT_LOOP_GUARD;
+    // workflow guard 与 loop guard 同类：停手等人类，别换个措辞重试（#122）
+    if (e.code === "workflow_guard") {
+      console.error("hint: workflow guard tripped — stop, report status blocked, wait for a human. Do not rephrase and retry.");
+      return EXIT_WORKFLOW_GUARD;
+    }
     if (e.code === "archived") return EXIT_ARCHIVED;
+    // 429：退避后再试，别立刻连打（#122）
+    if (e.status === 429 || e.code === "rate_limited") {
+      console.error("hint: rate limited — back off (exponential, start ~30s) before retrying. Do not hammer.");
+      return EXIT_RATE_LIMITED;
+    }
     return 1;
   }
   console.error(`error: ${e instanceof Error ? e.message : String(e)}`);

--- a/cli/test/exit-codes.test.ts
+++ b/cli/test/exit-codes.test.ts
@@ -1,0 +1,75 @@
+// #122：workflow_guard 与 429 曾塌缩成通用 exit 1 —— 恰恰是最需要「停手 / 退避」的两类错误。
+// agent 拿到 exit 1 会当成普通失败，换个措辞继续发，绕着熔断打转把额度耗光。
+import { describe, expect, test } from "bun:test";
+import {
+  EXIT_ARCHIVED,
+  EXIT_AUTH,
+  EXIT_LOOP_GUARD,
+  EXIT_RATE_LIMITED,
+  EXIT_WORKFLOW_GUARD,
+} from "@agentparty/shared";
+import { handleRestError, RestError } from "../src/rest";
+
+function silence<T>(fn: () => T): T {
+  const orig = console.error;
+  console.error = () => {};
+  try {
+    return fn();
+  } finally {
+    console.error = orig;
+  }
+}
+
+describe("handleRestError exit-code contract (#122)", () => {
+  test("workflow_guard maps to its own terminal code, not 1", () => {
+    const code = silence(() => handleRestError(new RestError(409, "workflow_guard", "no progress")));
+    expect(code).toBe(EXIT_WORKFLOW_GUARD);
+    expect(code).not.toBe(1);
+  });
+
+  test("429 maps to a distinct back-off code, not 1", () => {
+    const byStatus = silence(() => handleRestError(new RestError(429, null, "too many")));
+    const byCode = silence(() => handleRestError(new RestError(429, "rate_limited", "too many")));
+    expect(byStatus).toBe(EXIT_RATE_LIMITED);
+    expect(byCode).toBe(EXIT_RATE_LIMITED);
+    expect(byStatus).not.toBe(1);
+  });
+
+  test("workflow_guard prints a stop-don't-retry hint (agents read stderr)", () => {
+    const lines: string[] = [];
+    const orig = console.error;
+    console.error = (l?: unknown) => lines.push(String(l));
+    try {
+      handleRestError(new RestError(409, "workflow_guard", "no progress"));
+    } finally {
+      console.error = orig;
+    }
+    expect(lines.some((l) => /do not rephrase and retry/i.test(l))).toBe(true);
+  });
+
+  test("429 prints a back-off hint", () => {
+    const lines: string[] = [];
+    const orig = console.error;
+    console.error = (l?: unknown) => lines.push(String(l));
+    try {
+      handleRestError(new RestError(429, "rate_limited", "slow down"));
+    } finally {
+      console.error = orig;
+    }
+    expect(lines.some((l) => /back off/i.test(l))).toBe(true);
+  });
+
+  test("the existing contract is unchanged", () => {
+    expect(silence(() => handleRestError(new RestError(401, "unauthorized", "bad")))).toBe(EXIT_AUTH);
+    expect(silence(() => handleRestError(new RestError(409, "loop_guard", "wait")))).toBe(EXIT_LOOP_GUARD);
+    expect(silence(() => handleRestError(new RestError(410, "archived", "gone")))).toBe(EXIT_ARCHIVED);
+    // 真正的未知错误仍然是 1
+    expect(silence(() => handleRestError(new RestError(500, "boom", "server")))).toBe(1);
+    expect(silence(() => handleRestError(new Error("network")))).toBe(1);
+  });
+
+  test("all exit codes are distinct (nothing shadows anything)", () => {
+    const codes = [EXIT_AUTH, EXIT_LOOP_GUARD, EXIT_ARCHIVED, EXIT_WORKFLOW_GUARD, EXIT_RATE_LIMITED];
+    expect(new Set(codes).size).toBe(codes.length);
+  });
+});

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -38,6 +38,13 @@ export const EXIT_STREAM_ENDED = 6;
 // serve --auto-upgrade 在唤醒间隙发现磁盘上有更新的 party 二进制、已 re-exec 新版并让本进程退出
 // （issue #45）。launchctl KeepAlive 场景无所谓；供包装脚本区分「正常升级退出」与异常。
 export const EXIT_UPGRADED = 7;
+// workflow guard 熔断（issue #122）：同一 workflow 连发 N 条消息无进展，服务端拒收。
+// 与 loop guard 同类语义——**停手，别换个措辞重试**。之前它塌缩成通用 exit 1，
+// agent 拿到 1 会当成普通失败、换个说法再发，绕着熔断打转、把额度耗光。
+export const EXIT_WORKFLOW_GUARD = 8;
+// 速率限制（429，issue #122）：退避后再试，别立刻连打。
+// 之前同样塌缩成 exit 1，agent 无从判断该等还是该停。
+export const EXIT_RATE_LIMITED = 9;
 
 // ---- 基础类型 ----
 

--- a/skills/agentparty/SKILL.md
+++ b/skills/agentparty/SKILL.md
@@ -301,7 +301,8 @@ floods, work-stealing, infinite loops, dropped hand-offs.
 ## Exit codes
 
 `0` ok / new message · `2` watch timeout (prints `TIMEOUT`) · `3` bad token · `4` loop
-guard (stop, wait for human) · `5` channel archived · `6` stream ended · `7` cli self-upgraded.
+guard (stop, wait for human) · `5` channel archived · `6` stream ended · `7` cli self-upgraded ·
+`8` workflow guard (stop, wait for human) · `9` rate limited (back off).
 Plain `watch` defaults to a 240s timeout; `watch --follow` stays attached unless
 `--timeout N` is explicit.
 
@@ -313,6 +314,10 @@ Plain `watch` defaults to a 240s timeout; `watch --follow` stays attached unless
 | `2` | watch timed out with nothing new | re-arm; this is the idle path, not an error |
 | `6` | the frame stream ended unexpectedly (both `watch` and `serve` return it) | re-arm `watch` / restart `serve`. **Not** a normal exit — it exists so a supervisor can tell "died quietly" apart from "finished" (issue #29) |
 | `7` | `serve --auto-upgrade` re-exec'd a newer binary and this process stepped aside | restart `serve`; nothing is wrong (issue #45) |
+| `8` | **workflow guard** tripped — same workflow made no progress for N messages | **stop.** `status blocked -m "workflow guard, waiting for human"`. Do **not** rephrase and retry — that is exactly what tripped it |
+| `9` | rate limited (429) | back off exponentially (start ~30s) and retry. Do **not** hammer |
 | `3` `4` `5` | bad token / loop guard / channel archived | **terminal** — report to the human, don't retry blindly |
 
-`6` and `7` are recoverable: re-arm or restart. Only `3`/`4`/`5` mean stop and escalate.
+`6` and `7` are recoverable: re-arm or restart. `9` is recoverable after a backoff.
+`3`/`4`/`5`/`8` mean stop and escalate — a guard tripping is a signal that retrying
+*is the problem*, not a transient failure.


### PR DESCRIPTION
Closes #122 · ⏸️ 等 @LEO-MAIN 解冻后再合

## 问题

`workflow_guard`（409）和 `429` 恰恰是最需要「**停手**」和「**退避**」的两类错误，却和网络故障、参数错误一起返回通用 `exit 1`。

按 SKILL 给 agent 的机器契约，`1` = 普通失败。于是 agent 换个措辞继续发——**而重试正是触发熔断的原因**，它会绕着熔断打转，把双方的订阅额度耗光。429 也没有退避指引，直接连打。

## 改动

- 新增 `EXIT_WORKFLOW_GUARD = 8`、`EXIT_RATE_LIMITED = 9`
- `handleRestError` 映射 `code=workflow_guard` → 8，`status=429 || code=rate_limited` → 9
- 两者都往 **stderr** 打机器可读的行动指引（agent 读 stderr）
- CLI help 与 `SKILL.md` 的退出码表同步收录，并在 supervisor 分派表里写明：**guard 跳闸意味着「重试本身就是问题」，不是瞬时故障**

## 测试

`cli/test/exit-codes.test.ts`（6 条）：两个新码各自独立且 ≠ 1、两条 hint 确实打到 stderr、既有契约（3/4/5、未知错误仍是 1）逐条锁死、所有退出码互不重复。

**变异测试**：拿掉两处映射 → 4 条断言立刻红。

## 一处诚实说明

首次 `bun run check` 跑出 3 条 worker 超时（`tokens.spec.ts` 等）。单独复跑全过，复跑全仓也全过——是 **issue #48 记录的满载 flaky**，与本改动无关：本 PR 只碰 `shared/` `cli/` 和文档，一行 worker 代码都没动。

https://claude.ai/code/session_01PgxkZeqJmDge3dYe9W2tPZ