### PR TITLE
fix(worker): 协作角色锚定到账号，撤销的 name 被重铸后不再继承 host 权

### DIFF
--- a/worker/migrations/0021_channel_role_owner_account.sql
+++ b/worker/migrations/0021_channel_role_owner_account.sql
@@ -1,0 +1,26 @@
+-- Anchor collaboration roles to the ACCOUNT that owns the agent name, not the bare name (#101).
+--
+-- Before this, channel_roles was keyed purely by (channel_slug, agent_name). A `host` role
+-- outlived the token it was assigned to: revoke `deploy-bot` and let any other account re-mint a
+-- token of the same name, and the residual host role was inherited by the new (possibly hostile)
+-- token — granting charter writes, guard config, and speaking as the retired agent.
+--
+-- `owner_account` records the account the role is bound to:
+--   * NULL  = pre-allocation (role assigned before any token for this name existed). The first
+--             token minted for the name claims (binds) it — see persistToken. An UNBOUND role is
+--             NOT honoured at read time (loadAssignedRole denies NULL) — it only becomes usable
+--             once a mint binds it, so a stale NULL can never be inherited.
+--   * <acct>= the role is valid ONLY for an identity whose principal.account matches.
+--
+-- Backfill: bind existing rows to the CURRENT live token's owner. Rows whose token is revoked,
+-- absent, or owner-less (legacy) resolve to NULL and therefore stop granting power until
+-- reassigned — the deliberate fail-safe direction for accounts we cannot determine.
+ALTER TABLE channel_roles ADD COLUMN owner_account TEXT;
+
+UPDATE channel_roles
+   SET owner_account = (
+     SELECT t.owner
+       FROM tokens t
+      WHERE t.name = channel_roles.agent_name
+        AND t.revoked_at IS NULL
+   );

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -915,6 +915,13 @@ async function persistToken(
         now,
       )
       .run();
+    // 预分配认领（#101）：该 name 从无 token（existing 为 null）→ 这是它的【首次】铸造。
+    // 把此前预分配、尚未绑定的角色锚定到铸造账号。仅在首次铸造时绑定：重铸（existing 非 null，
+    // 见上面的 UPDATE 分支）绝不重绑，于是残留角色不会被易主的新账号继承。
+    await db
+      .prepare("UPDATE channel_roles SET owner_account = ? WHERE agent_name = ? AND owner_account IS NULL")
+      .bind(opts.owner ?? null, opts.name)
+      .run();
   }
   return { token };
 }
@@ -1219,7 +1226,7 @@ function channelHeaders(
 
 async function canConfigureChannel(db: D1Database, identity: TokenIdentity, channel: LoadedChannel): Promise<boolean> {
   if (isChannelModerator(identity, channel)) return true;
-  return (await loadAssignedRole(db, channel.slug, identity.name)) === "host";
+  return (await loadAssignedRole(db, channel.slug, identity)) === "host";
 }
 
 function parseNameListJson(value: string | null | undefined): string[] {
@@ -1281,7 +1288,7 @@ async function canListMembers(db: D1Database, identity: TokenIdentity, channel: 
   const perms = channelPerms(channel);
   const isMember = await isChannelMember(db, channel.slug, identity.account);
   if (identity.kind === "agent") {
-    const role = await loadAssignedRole(db, channel.slug, identity.name);
+    const role = await loadAssignedRole(db, channel.slug, identity);
     return canByAgentPolicy(perms.members_list_agents, perms.members_list_agent_allowlist, identity, channel, isMember, role);
   }
   return canByHumanPolicy(perms.members_list, identity, channel, isMember);
@@ -1292,7 +1299,7 @@ async function canEditCharter(db: D1Database, identity: TokenIdentity, channel: 
   const perms = channelPerms(channel);
   const isMember = await isChannelMember(db, channel.slug, identity.account);
   if (identity.kind === "agent") {
-    const role = await loadAssignedRole(db, channel.slug, identity.name);
+    const role = await loadAssignedRole(db, channel.slug, identity);
     return canByAgentPolicy(perms.charter_write_agents, perms.charter_write_agent_allowlist, identity, channel, isMember, role);
   }
   return canByHumanPolicy(perms.charter_write, identity, channel, isMember);
@@ -1437,12 +1444,19 @@ async function exchangeOAuthCode(
   return { ...user, provider: provider.id, expiresIn: token.expiresIn };
 }
 
-async function loadAssignedRole(db: D1Database, slug: string, name: string): Promise<CollaborationRole | null> {
+// 协作角色按【账号】锚定，不认裸 name（#101）。一个 host 角色只对绑定账号的身份生效：
+//   - owner_account 为 null（预分配未认领 / 迁移无法确定账号）→ 一律不生效（安全失败方向）。
+//     预分配角色由 persistToken 在该 name 首次铸 token 时绑定到铸造账号；未绑定前无 token 能读到它。
+//   - owner_account 非 null → 仅当 identity.account 严格相等才返回角色。
+// 于是「撤销旧 token → 他人重铸同名」拿不到残留角色（account 不符）；同账号重铸同名则保留（account 相等）。
+async function loadAssignedRole(db: D1Database, slug: string, identity: TokenIdentity): Promise<CollaborationRole | null> {
   const row = await db
-    .prepare("SELECT role FROM channel_roles WHERE channel_slug = ? AND agent_name = ?")
-    .bind(slug, name)
-    .first<{ role: string }>();
-  return row && COLLAB_ROLES.includes(row.role) ? (row.role as CollaborationRole) : null;
+    .prepare("SELECT role, owner_account FROM channel_roles WHERE channel_slug = ? AND agent_name = ?")
+    .bind(slug, identity.name)
+    .first<{ role: string; owner_account: string | null }>();
+  if (!row || !COLLAB_ROLES.includes(row.role)) return null;
+  if (row.owner_account === null) return null;
+  return row.owner_account === (identity.account ?? null) ? (row.role as CollaborationRole) : null;
 }
 
 function assignedRoleHeaders(role: CollaborationRole | null): Record<string, string> {
@@ -3830,16 +3844,25 @@ app.put("/api/channels/:slug/roles/:name", async (c) => {
     return c.json(errorBody("bad_request", `responsibility must be a string <= ${ROLE_RESPONSIBILITY_LIMIT} bytes`), 400);
   }
   const assignedAt = Date.now();
+  // 角色按账号锚定（#101）：绑定到该 name 当前【存活】token 的 owner。
+  // 若无存活 token（预分配「先分工再铸 token」）→ null，等 persistToken 在首次铸造时认领绑定。
+  const liveOwner = await c.env.DB.prepare(
+    "SELECT owner FROM tokens WHERE name = ? AND revoked_at IS NULL",
+  )
+    .bind(name)
+    .first<{ owner: string | null }>();
+  const ownerAccount = liveOwner?.owner ?? null;
   await c.env.DB.prepare(
-    `INSERT INTO channel_roles (channel_slug, agent_name, role, assigned_by, assigned_at, responsibility)
-     VALUES (?, ?, ?, ?, ?, ?)
+    `INSERT INTO channel_roles (channel_slug, agent_name, role, assigned_by, assigned_at, responsibility, owner_account)
+     VALUES (?, ?, ?, ?, ?, ?, ?)
      ON CONFLICT(channel_slug, agent_name) DO UPDATE SET
        role = excluded.role,
        assigned_by = excluded.assigned_by,
        assigned_at = excluded.assigned_at,
-       responsibility = ${responsibility.present ? "excluded.responsibility" : "channel_roles.responsibility"}`,
+       responsibility = ${responsibility.present ? "excluded.responsibility" : "channel_roles.responsibility"},
+       owner_account = COALESCE(excluded.owner_account, channel_roles.owner_account)`,
   )
-    .bind(slug, name, role, identity.name, assignedAt, responsibility.value)
+    .bind(slug, name, role, identity.name, assignedAt, responsibility.value, ownerAccount)
     .run();
   await fetchChannelDO(
     c.env,
@@ -4038,7 +4061,7 @@ app.post("/api/channels/:slug/messages/:seq/review", async (c) => {
   }
   const seq = positiveInt(Number(c.req.param("seq")));
   if (seq === null) return c.json(errorBody("bad_request", "seq must be a positive integer"), 400);
-  const assignedRole = await loadAssignedRole(c.env.DB, slug, identity.name);
+  const assignedRole = await loadAssignedRole(c.env.DB, slug, identity);
   const res = await fetchChannelDO(
     c.env,
     slug,
@@ -4092,7 +4115,7 @@ app.post("/api/channels/:slug/messages/:seq/:action", async (c) => {
   if (action !== "edit" && action !== "retract" && action !== "supersede") {
     return c.json(errorBody("bad_request", "action must be edit|retract|supersede"), 400);
   }
-  const assignedRole = await loadAssignedRole(c.env.DB, slug, identity.name);
+  const assignedRole = await loadAssignedRole(c.env.DB, slug, identity);
   return fetchChannelDO(
     c.env,
     slug,
@@ -4160,7 +4183,7 @@ app.post("/api/channels/:slug/messages", async (c) => {
   if (taskId !== undefined && !(await loadTaskRow(c.env.DB, slug, taskId))) {
     return c.json(errorBody("not_found", "task not found in this channel"), 404);
   }
-  const assignedRole = await loadAssignedRole(c.env.DB, slug, identity.name);
+  const assignedRole = await loadAssignedRole(c.env.DB, slug, identity);
   const res = await fetchChannelDO(
     c.env,
     slug,
@@ -4454,7 +4477,7 @@ app.get("/api/channels/:slug/ws", async (c) => {
   if (identity.owner) fwd.headers.set("x-ap-owner", identity.owner);
   fwd.headers.set("x-ap-token-hash", identity.hash);
   for (const [key, value] of Object.entries(lineageHeaders(identity))) fwd.headers.set(key, value);
-  const assignedRole = await loadAssignedRole(c.env.DB, slug, identity.name);
+  const assignedRole = await loadAssignedRole(c.env.DB, slug, identity);
   if (assignedRole !== null) {
     fwd.headers.set("x-ap-collab-role", assignedRole);
     fwd.headers.set("x-ap-role-source", "assigned");

--- a/worker/test/channel-role-account-binding.spec.ts
+++ b/worker/test/channel-role-account-binding.spec.ts
@@ -1,0 +1,135 @@
+// #101: channel_roles 曾按裸 name 绑定角色。deploy-bot 的 token 被撤销后，任何账号重铸同名 token
+// 就【继承】残留的 host 角色，从而拿到 canConfigureChannel（改 charter、配 guard）等配置权。
+//
+// 修复：角色锚定到账号（channel_roles.owner_account）。
+//   - 撤销后【他人】重铸同名 → 不继承（account 不符）。
+//   - 【同账号】重铸同名 → 保留（同一信任主体轮换自己的 token，不构成越权）。
+//   - 预分配（先给尚不存在的 name 分角色）仍可用：该 name 首次铸 token 时把角色绑定到铸造账号。
+//
+// 用例统一让「host agent」与「频道 owner」不同账号，使 canConfigureChannel 只能靠 host 角色放行
+// （isChannelModerator 走不通），从而精确验证 host 角色路径本身。
+import { describe, expect, it } from "vitest";
+import { ADMIN_HEADERS, api, createChannel, seedToken, uniq } from "./helpers";
+
+// 经真实铸造端点铸 token（走 persistToken，触发预分配绑定逻辑）。返回可用作 Bearer 的 token。
+async function mintToken(name: string, owner: string, role = "agent"): Promise<string> {
+  const res = await api("/api/tokens", "unused", {
+    method: "POST",
+    headers: ADMIN_HEADERS,
+    body: JSON.stringify({ name, role, owner }),
+  });
+  if (res.status !== 201) throw new Error(`mint failed: ${res.status} ${await res.text()}`);
+  return ((await res.json()) as { token: string }).token;
+}
+
+async function revokeToken(name: string): Promise<void> {
+  const res = await api(`/api/tokens/${name}`, "unused", { method: "DELETE", headers: ADMIN_HEADERS });
+  if (res.status !== 200) throw new Error(`revoke failed: ${res.status}`);
+}
+
+async function assignHost(slug: string, moderatorToken: string, name: string): Promise<void> {
+  const res = await api(`/api/channels/${slug}/roles/${name}`, moderatorToken, {
+    method: "PUT",
+    body: JSON.stringify({ role: "host" }),
+  });
+  if (res.status !== 200) throw new Error(`assign host failed: ${res.status} ${await res.text()}`);
+}
+
+// host 加强 loop guard（enabled:true, limit:5，纯加强动作，任何 configurer 都能做）。
+// 用它作为「能否行使 canConfigureChannel 配置权」的可观察探针：200 = 有配置权，403 = 无。
+function tightenGuard(slug: string, token: string): Promise<Response> {
+  return api(`/api/channels/${slug}/loop-guard`, token, {
+    method: "PUT",
+    body: JSON.stringify({ enabled: true, limit: 5 }),
+  });
+}
+
+describe("channel role account binding (#101)", () => {
+  it("a legitimate host (different account than owner) can configure the channel", async () => {
+    const ownerAcct = `${uniq("owner")}@example.com`;
+    const deployAcct = `${uniq("deploy")}@example.com`;
+    const human = await seedToken("human", uniq("human"), { owner: ownerAcct });
+    const slug = await createChannel(human.token);
+
+    const botName = uniq("deploy-bot");
+    const botToken = await mintToken(botName, deployAcct);
+    // 未分配角色 → 陌生账号无配置权
+    expect((await tightenGuard(slug, botToken)).status).toBe(403);
+
+    await assignHost(slug, human.token, botName);
+    // 分配 host 后 → 配置权放行（走 canConfigureChannel 的 host 路径）
+    expect((await tightenGuard(slug, botToken)).status).toBe(200);
+  });
+
+  it("after revoke, a DIFFERENT account re-minting the same name does NOT inherit the host role", async () => {
+    const ownerAcct = `${uniq("owner")}@example.com`;
+    const deployAcct = `${uniq("deploy")}@example.com`;
+    const attackerAcct = `${uniq("attacker")}@example.com`;
+    const human = await seedToken("human", uniq("human"), { owner: ownerAcct });
+    const slug = await createChannel(human.token);
+
+    const botName = uniq("deploy-bot");
+    const legit = await mintToken(botName, deployAcct);
+    await assignHost(slug, human.token, botName);
+    expect((await tightenGuard(slug, legit)).status).toBe(200); // legit host works
+
+    // token 轮换/撤销 → 攻击者账号重铸同名 agent
+    await revokeToken(botName);
+    const attacker = await mintToken(botName, attackerAcct);
+
+    // 残留 host 角色不被继承：攻击者拿不到配置权
+    const res = await tightenGuard(slug, attacker);
+    expect(res.status).toBe(403);
+  });
+
+  it("the SAME account re-minting the same name KEEPS the host role", async () => {
+    // 语义决定：角色锚定的是【账号】而非某一次铸造。同账号轮换自己的 token 是同一信任主体，
+    // 不是越权，故保留角色，避免每次轮换都要重分配的运维摩擦。
+    const ownerAcct = `${uniq("owner")}@example.com`;
+    const deployAcct = `${uniq("deploy")}@example.com`;
+    const human = await seedToken("human", uniq("human"), { owner: ownerAcct });
+    const slug = await createChannel(human.token);
+
+    const botName = uniq("deploy-bot");
+    await mintToken(botName, deployAcct);
+    await assignHost(slug, human.token, botName);
+
+    await revokeToken(botName);
+    const rotated = await mintToken(botName, deployAcct); // 同账号重铸
+
+    expect((await tightenGuard(slug, rotated)).status).toBe(200);
+  });
+
+  it("pre-allocation still works: assign a role before the token exists, first mint claims it", async () => {
+    const ownerAcct = `${uniq("owner")}@example.com`;
+    const futureAcct = `${uniq("future")}@example.com`;
+    const human = await seedToken("human", uniq("human"), { owner: ownerAcct });
+    const slug = await createChannel(human.token);
+
+    const botName = uniq("future-bot");
+    // 先分工：给尚不存在的 name 分 host（owner_account 记为 null，待认领）
+    await assignHost(slug, human.token, botName);
+    // 再铸 token：首次铸造把预分配角色绑定到铸造账号
+    const botToken = await mintToken(botName, futureAcct);
+
+    expect((await tightenGuard(slug, botToken)).status).toBe(200);
+  });
+
+  it("a pre-allocated role, once claimed, is NOT inherited by another account after revoke", async () => {
+    // 预分配 → 首次铸造绑定 → 撤销 → 他人重铸同名：仍然不继承（绑定已落到首铸账号）。
+    const ownerAcct = `${uniq("owner")}@example.com`;
+    const firstAcct = `${uniq("first")}@example.com`;
+    const attackerAcct = `${uniq("attacker")}@example.com`;
+    const human = await seedToken("human", uniq("human"), { owner: ownerAcct });
+    const slug = await createChannel(human.token);
+
+    const botName = uniq("future-bot");
+    await assignHost(slug, human.token, botName);
+    const first = await mintToken(botName, firstAcct);
+    expect((await tightenGuard(slug, first)).status).toBe(200); // claimed by firstAcct
+
+    await revokeToken(botName);
+    const attacker = await mintToken(botName, attackerAcct);
+    expect((await tightenGuard(slug, attacker)).status).toBe(403); // not inherited
+  });
+});


### PR DESCRIPTION
Closes #101 · 🔒 security · ⏸️ 等 @LEO-MAIN 解冻后再合

由后台 worker agent 完成，**两条变异测试我独立复现过**。

## 提权链

`channel_roles` 只按 `(channel_slug, agent_name)` 键，`loadAssignedRole` 按**裸 name** 查角色，完全不看是谁持有这个 name。而 `DELETE /api/tokens/:name` 只软删 token、**不动 `channel_roles`**，名字随即释放。

1. `deploy-bot` 的 host token 被例行轮换撤销
2. 任何能铸这个名字的账号（`/api/agents` 允许**任一注册人类账号**认领已释放的名字）重铸同名 token
3. 静默继承残留的 `host` 角色 → 拿到 `canConfigureChannel`（改 charter、配置 guard）

## 修法：读侧（授权边界）强制账号匹配

- `channel_roles` 新增 `owner_account` 列
- `loadAssignedRole` 改收 `identity`：`owner_account === null` **一律拒绝**；非 null 时必须与 `identity.account` 相等
- `PUT /roles` 写入当前活 token 的 owner；无活 token（预分配「先分工再铸 token」）时留 NULL
- `persistToken` **仅在该 name 首次铸造时**认领预分配的 NULL 行；重铸绝不重绑

**语义选择**：同账号重铸保留角色——轮换自己 agent 的 token 是同一信任主体，不是提权；每次轮换都掉角色是无谓的运维摩擦。已写死进测试。

## 迁移 0021 的失败方向

回填 `owner_account` = 该 name 当前活 token 的 owner。token 已撤销 / 不存在 / 无 owner（legacy）的行 → **NULL → 停止授权**，直到重新分配。

**不确定账号即拒绝。** legacy null-owner 部署会失去已分配的角色——这是刻意的安全失败方向，补救是重铸带账号的 token 并重新分配。

## 测试

`worker/test/channel-role-account-binding.spec.ts`（5 条）。探针用「收紧 loop guard」这一 host-only 动作，且 host agent 与频道 owner **刻意不同账号**——确保放行只可能来自 host 角色，而非 `isChannelModerator`。

**变异测试（我独立复现）**：

| 变异 | 变红的用例 |
|---|---|
| 去掉 `loadAssignedRole` 的账号检查 | 两条「不继承」用例（攻击成功，403 → 200） |
| 去掉 `persistToken` 的首次铸造绑定 | 两条预分配用例（NULL 被拒，200 → 403） |

两个变异各覆盖修复的一半，互不遮盖。

`bun run check` 全过：37 spec / 263 tests。

https://claude.ai/code/session_01PgxkZeqJmDge3dYe9W2tPZ