### PR TITLE
fix(worker): rev_seq 改用单调计数器，修剪后不再复用修订号

### DIFF
--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -3085,13 +3085,29 @@ export class ChannelDO extends Server<Env> {
   }
 
   // 修订游标（issue #33）：单调修订序号，编辑/撤回/超越各占一号；DO 单线程，MAX+1 足够
+  // rev_seq 计数器落 meta，绝不从 MAX(rev_seq) 派生（#125）。
+  //
+  // 修剪按 seq 删行（DELETE FROM messages WHERE seq <= cutoff），而一条【旧】消息若被
+  // 【近期】编辑/撤回过，它的 seq 很小、rev_seq 却很大。删掉这一行，MAX(rev_seq) 就回退，
+  // 下一个修订复用已经发过的号。此时一个离线客户端带着 since_rev=R 回来补拉，
+  // 服务端按 rev_seq > since_rev 过滤，新修订的号 <= R → 永久漏收。
+  // retract 的设计场景正是撤回误发的密钥——漏收就是撤不掉。
+  //
+  // 首次读取时从 MAX(rev_seq) 播种，存量 DO 无需迁移即可平滑升级。
   private lastRevSeq(): number {
+    const cached = this.getMeta("rev_seq");
+    if (cached !== null) return Number(cached);
     const row = this.ctx.storage.sql.exec("SELECT COALESCE(MAX(rev_seq), 0) AS last FROM messages").one();
-    return Number(row.last);
+    const seeded = Number(row.last);
+    this.setMeta("rev_seq", String(seeded));
+    return seeded;
   }
 
+  // 单调递增，且立即落盘——即便本次写入随后失败，号也不会被复用。
   private nextRevSeq(): number {
-    return this.lastRevSeq() + 1;
+    const next = this.lastRevSeq() + 1;
+    this.setMeta("rev_seq", String(next));
+    return next;
   }
 
   private agentStreak(): number {

--- a/worker/test/rev-seq-counter.spec.ts
+++ b/worker/test/rev-seq-counter.spec.ts
@@ -1,0 +1,112 @@
+// #125：rev_seq 必须来自单调计数器，绝不能从 MAX(rev_seq) 派生。
+//
+// 修剪按 seq 删行（DELETE FROM messages WHERE seq <= cutoff）。一条【旧】消息若被【近期】
+// 编辑/撤回过，它的 seq 很小、rev_seq 却很大。删掉这一行，MAX(rev_seq) 就回退，
+// 下一个修订复用一个已经广播过的号。
+//
+// 后果：离线客户端带着 since_rev = R 回来补拉，服务端按 rev_seq > since_rev 过滤，
+// 新修订的号 <= R → 永久漏收。retract 的设计场景正是撤回误发的密钥——漏收就是撤不掉。
+import { env, runInDurableObject } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import type { ChannelDO } from "../src/do";
+import { api, createChannel, postMessage, seedToken, uniq, WsClient } from "./helpers";
+
+/** 直接读 DO 里的 messages 表，拿当前最大 rev_seq（模拟修复前 lastRevSeq 的做法）。 */
+async function maxRevSeqInTable(slug: string): Promise<number> {
+  const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+  return runInDurableObject(stub, async (_i: ChannelDO, state) => {
+    const row = state.storage.sql.exec("SELECT COALESCE(MAX(rev_seq), 0) AS m FROM messages").one();
+    return Number(row.m);
+  });
+}
+
+/** 精确模拟修剪：删掉持有最大 rev_seq 的那一行（它的 seq 很小，会先被修剪掉）。 */
+async function deleteRowHoldingMaxRev(slug: string): Promise<void> {
+  const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+  await runInDurableObject(stub, async (_i: ChannelDO, state) => {
+    state.storage.sql.exec(
+      "DELETE FROM messages WHERE seq = (SELECT seq FROM messages WHERE rev_seq = (SELECT MAX(rev_seq) FROM messages))",
+    );
+  });
+}
+
+async function welcomeRevSeq(slug: string, token: string): Promise<number> {
+  const ws = await WsClient.open(slug, token);
+  const welcome = (await ws.nextOfType("welcome")) as { last_rev_seq?: number };
+  ws.close();
+  return welcome.last_rev_seq ?? 0;
+}
+
+describe("rev_seq monotonic counter (#125)", () => {
+  it("never reuses a revision number after the row holding MAX(rev_seq) is pruned away", async () => {
+    const author = await seedToken("human", uniq("a"));
+    const slug = await createChannel(author.token);
+
+    // 一条【旧】消息（低 seq），随后再发几条把它推成"旧"的
+    const oldMsg = (await (await postMessage(slug, author.token, "old message")).json()) as { seq: number };
+    for (let i = 0; i < 3; i++) expect((await postMessage(slug, author.token, `filler-${i}`)).status).toBe(200);
+
+    // 近期编辑这条旧消息 → 它拿到当前最大的 rev_seq，但 seq 仍然最小
+    const edited = await api(`/api/channels/${slug}/messages/${oldMsg.seq}/edit`, author.token, {
+      method: "POST",
+      body: JSON.stringify({ body: "edited late" }),
+    });
+    expect(edited.status).toBe(200);
+
+    const revBefore = await maxRevSeqInTable(slug);
+    expect(revBefore).toBeGreaterThan(0);
+    // 离线客户端此刻记下的水位
+    const clientSinceRev = await welcomeRevSeq(slug, author.token);
+    expect(clientSinceRev).toBe(revBefore);
+
+    // 修剪把这条低 seq 的行删掉 → 表里的 MAX(rev_seq) 回退
+    await deleteRowHoldingMaxRev(slug);
+    expect(await maxRevSeqInTable(slug)).toBeLessThan(revBefore);
+
+    // 现在做一次新的修订（撤回另一条消息）
+    const victim = (await (await postMessage(slug, author.token, "secret to retract")).json()) as { seq: number };
+    const retracted = await api(`/api/channels/${slug}/messages/${victim.seq}/retract`, author.token, {
+      method: "POST",
+    });
+    expect(retracted.status).toBe(200);
+
+    // 关键断言：新修订号必须严格大于离线客户端记下的水位，否则它补拉时会被
+    // rev_seq > since_rev 过滤掉——撤回永远送不到。
+    const newRev = await maxRevSeqInTable(slug);
+    expect(newRev).toBeGreaterThan(clientSinceRev);
+  }, 30_000);
+
+  it("welcome.last_rev_seq never goes backwards even after pruning", async () => {
+    const author = await seedToken("human", uniq("a"));
+    const slug = await createChannel(author.token);
+
+    const m = (await (await postMessage(slug, author.token, "m")).json()) as { seq: number };
+    expect((await api(`/api/channels/${slug}/messages/${m.seq}/edit`, author.token, {
+      method: "POST",
+      body: JSON.stringify({ body: "e1" }),
+    })).status).toBe(200);
+
+    const before = await welcomeRevSeq(slug, author.token);
+    await deleteRowHoldingMaxRev(slug);
+    const after = await welcomeRevSeq(slug, author.token);
+
+    // 修复前：welcome 报的水位会随 MAX 一起回退，客户端据此重连就会漏拉
+    expect(after).toBeGreaterThanOrEqual(before);
+  }, 30_000);
+
+  it("revision numbers stay strictly increasing across edit / retract", async () => {
+    const author = await seedToken("human", uniq("a"));
+    const slug = await createChannel(author.token);
+
+    const seen: number[] = [];
+    for (let i = 0; i < 3; i++) {
+      const msg = (await (await postMessage(slug, author.token, `m${i}`)).json()) as { seq: number };
+      await api(`/api/channels/${slug}/messages/${msg.seq}/edit`, author.token, {
+        method: "POST",
+        body: JSON.stringify({ body: `e${i}` }),
+      });
+      seen.push(await maxRevSeqInTable(slug));
+    }
+    for (let i = 1; i < seen.length; i++) expect(seen[i]!).toBeGreaterThan(seen[i - 1]!);
+  }, 30_000);
+});


### PR DESCRIPTION
Closes #125

## 缺陷

```ts
private lastRevSeq(): number {
  const row = this.ctx.storage.sql.exec("SELECT COALESCE(MAX(rev_seq), 0) AS last FROM messages").one();
  return Number(row.last);
}
```

修剪按 **seq** 删行：`DELETE FROM messages WHERE seq <= cutoff`。

而一条**旧**消息若被**近期**编辑/撤回过，它的 `seq` 很小、`rev_seq` 却很大。删掉这一行，`MAX(rev_seq)` 就回退，下一个修订**复用一个已经广播过的号**。

离线客户端带着 `since_rev = R` 回来补拉，服务端按 `rev_seq > since_rev` 过滤 → 新修订的号 `<= R` → **永久漏收**。

**retract 的设计场景正是撤回误发的密钥——漏收就是撤不掉。**

与 #33（revision 重放）同类的游标正确性问题，方向相反。

## 修复

`rev_seq` 计数器落 meta，单调递增且**立即落盘**（即便本次写入随后失败，号也不会被复用）。首次读取时从 `MAX(rev_seq)` 播种，**存量 DO 无需迁移**即可平滑升级。

## 测试

`worker/test/rev-seq-counter.spec.ts`（3 条）。用 `runInDurableObject` **精确删掉持有最大 `rev_seq` 的那一行**来模拟修剪——而不是灌 10000 条消息去触发 `RETAIN_N`。

**变异测试**：还原 `MAX(rev_seq)` 派生 → 前两条立刻红。

## 一处诚实说明

跑门禁时撞到 worker 满载 flaky，失败点在 `tokens` / `system-status-state` 之间**漂移**，单独跑 13/13 全过。已立 **#185** 追踪。本 PR 只碰 `rev_seq`，与那些用例无关。

https://claude.ai/code/session_01PgxkZeqJmDge3dYe9W2tPZ

## 频道身份

本 PR 由 AgentParty #agentparty 频道内的 **leo-claude** 开发。