### PR TITLE
fix(web): OIDC session 绑定稳定身份，adopt/refresh 只允许同身份（#126 follow-up 安全修复）

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -58,7 +58,9 @@
       "devDependencies": {
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
+        "@types/react-test-renderer": "19.1.0",
         "@vitejs/plugin-react": "^4.5.2",
+        "react-test-renderer": "19.2.7",
         "typescript": "^5.8.3",
         "vite": "^7.0.0",
       },
@@ -405,6 +407,8 @@
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
+    "@types/react-test-renderer": ["@types/react-test-renderer@19.1.0", "", { "dependencies": { "@types/react": "*" } }, "sha512-XD0WZrHqjNrxA/MaR9O22w/RNidWR9YZmBdRGI7wcnWGrv/3dA8wKCJ8m63Sn+tLJhcjmuhOi629N66W6kgWzQ=="],
+
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
@@ -687,7 +691,11 @@
 
     "react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
 
+    "react-is": ["react-is@19.2.7", "", {}, "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A=="],
+
     "react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
+
+    "react-test-renderer": ["react-test-renderer@19.2.7", "", { "dependencies": { "react-is": "^19.2.7", "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-U4TyPDJ9MsC8rFimXuJum8w40aPc9kbOZYO8Pc2/4A884i8hwJsMNA/JNyuOc/f2/37wHvk7HjpVl1V4re7Dig=="],
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 

--- a/web/package.json
+++ b/web/package.json
@@ -26,7 +26,9 @@
   "devDependencies": {
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
+    "@types/react-test-renderer": "19.1.0",
     "@vitejs/plugin-react": "^4.5.2",
+    "react-test-renderer": "19.2.7",
     "typescript": "^5.8.3",
     "vite": "^7.0.0"
   }

--- a/web/src/App.identity.test.tsx
+++ b/web/src/App.identity.test.tsx
@@ -1,0 +1,332 @@
+// @ts-expect-error Bun executes this test, while the web tsconfig intentionally loads only Vite globals.
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { LocaleProvider } from "./i18n/locale";
+
+mock.module("dompurify", () => ({
+  default: {
+    addHook: () => {},
+    sanitize: (value: string) => value,
+  },
+}));
+
+const { App } = await import("./App");
+
+function memoryStorage(): Storage {
+  const values = new Map<string, string>();
+  return {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => { values.set(key, value); },
+    removeItem: (key) => { values.delete(key); },
+    clear: () => values.clear(),
+    key: (index) => [...values.keys()][index] ?? null,
+    get length() { return values.size; },
+  };
+}
+
+function jwt(sub: string, generation = 1): string {
+  const encode = (value: string) => btoa(value).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+  return `${encode('{"alg":"none"}')}.${encode(JSON.stringify({ sub, generation }))}.sig`;
+}
+
+function session(accessToken: string, refreshToken: string, expiresAt: number) {
+  return {
+    accessToken,
+    refreshToken,
+    expiresAt,
+    identity: JSON.parse(atob(accessToken.split(".")[1]!)) as { sub: string },
+  };
+}
+
+function storedSession(
+  accessToken: string,
+  refreshToken: string,
+  expiresAt = Math.floor(Date.now() / 1000) - 60,
+) {
+  const value = session(accessToken, refreshToken, expiresAt);
+  return JSON.stringify({ ...value, identity: value.identity.sub });
+}
+
+function authHeader(init?: RequestInit): string | null {
+  return new Headers(init?.headers).get("authorization")?.replace(/^Bearer /, "") ?? null;
+}
+
+function meResponse() {
+  return new Response(JSON.stringify({
+    name: "human-a",
+    email: "a@example.com",
+    kind: "human",
+    handle: "human-a",
+    display_name: "Human A",
+    avatar_url: null,
+    avatar_thumb: null,
+    provider: "oidc",
+    tenant_key: null,
+    role: "human",
+    owner: null,
+  }), { status: 200 });
+}
+
+function deferredResponse() {
+  let resolve!: (response: Response) => void;
+  const promise = new Promise<Response>((done) => { resolve = done; });
+  return { promise, resolve };
+}
+
+let renderer: ReactTestRenderer | null = null;
+const globalKeys = [
+  "IS_REACT_ACT_ENVIRONMENT",
+  "localStorage",
+  "sessionStorage",
+  "location",
+  "history",
+  "window",
+  "document",
+  "navigator",
+  "fetch",
+] as const;
+const originalGlobals = new Map(
+  globalKeys.map((key) => [key, Object.getOwnPropertyDescriptor(globalThis, key)]),
+);
+
+beforeEach(() => {
+  Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", { configurable: true, value: true });
+  Object.defineProperty(globalThis, "localStorage", { configurable: true, value: memoryStorage() });
+  Object.defineProperty(globalThis, "sessionStorage", { configurable: true, value: memoryStorage() });
+  Object.defineProperty(globalThis, "location", {
+    configurable: true,
+    value: { pathname: "/", search: "", origin: "https://party.example", href: "https://party.example/" },
+  });
+  Object.defineProperty(globalThis, "history", {
+    configurable: true,
+    value: { pushState: () => {}, replaceState: () => {} },
+  });
+  const windowEvents = new EventTarget();
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      location: globalThis.location,
+      history: globalThis.history,
+      innerWidth: 1200,
+      innerHeight: 800,
+      setTimeout,
+      clearTimeout,
+      setInterval,
+      clearInterval,
+      addEventListener: windowEvents.addEventListener.bind(windowEvents),
+      removeEventListener: windowEvents.removeEventListener.bind(windowEvents),
+    },
+  });
+  const documentEvents = new EventTarget();
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: {
+      visibilityState: "visible",
+      addEventListener: documentEvents.addEventListener.bind(documentEvents),
+      removeEventListener: documentEvents.removeEventListener.bind(documentEvents),
+    },
+  });
+  Object.defineProperty(globalThis, "navigator", { configurable: true, value: { platform: "test" } });
+});
+
+afterEach(async () => {
+  if (renderer !== null) await act(async () => renderer?.unmount());
+  renderer = null;
+  for (const key of globalKeys) {
+    const descriptor = originalGlobals.get(key);
+    if (descriptor === undefined) Reflect.deleteProperty(globalThis, key);
+    else Object.defineProperty(globalThis, key, descriptor);
+  }
+});
+
+describe("App OIDC session identity wiring", () => {
+  test("foreign shared session is neither adopted nor refreshed nor cleared", async () => {
+    const tokenA = jwt("user-a");
+    const tokenB = jwt("user-b");
+    localStorage.setItem("ap_token", tokenA);
+    localStorage.setItem("ap_oidc_session", storedSession(tokenA, "refresh-a"));
+
+    const firstChannels = deferredResponse();
+    const channelTokens: Array<string | null> = [];
+    let refreshCalls = 0;
+    let lockRequests = 0;
+    Object.defineProperty(globalThis, "navigator", {
+      configurable: true,
+      value: {
+        platform: "test",
+        locks: {
+          request: async (_name: string, callback: () => Promise<unknown>) => {
+            lockRequests += 1;
+            return callback();
+          },
+        },
+      },
+    });
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: async (input: string | URL | Request, init?: RequestInit) => {
+        const url = String(input);
+        if (url.endsWith("/api/config")) {
+          return new Response(JSON.stringify({ oidc: { issuer: "https://idp.example", client_id: "web" } }));
+        }
+        if (url.endsWith("/api/channels")) {
+          channelTokens.push(authHeader(init));
+          return firstChannels.promise;
+        }
+        if (url.endsWith("/api/me")) return meResponse();
+        if (url === "https://idp.example/token") {
+          refreshCalls += 1;
+          throw new Error("foreign refresh token must not be used");
+        }
+        throw new Error(`unexpected request: ${url}`);
+      },
+    });
+
+    await act(async () => {
+      renderer = create(<LocaleProvider><App /></LocaleProvider>);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    localStorage.setItem("ap_token", tokenB);
+    const foreignSession = storedSession(tokenB, "refresh-b");
+    localStorage.setItem("ap_oidc_session", foreignSession);
+    await act(async () => {
+      firstChannels.resolve(new Response("unauthorized", { status: 401 }));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(channelTokens).toEqual([tokenA]);
+    expect(refreshCalls).toBe(0);
+    expect(lockRequests).toBe(0);
+    expect(localStorage.getItem("ap_token")).toBe(tokenB);
+    expect(localStorage.getItem("ap_oidc_session")).toBe(foreignSession);
+  });
+
+  test("session switched to a foreign identity while waiting for the lock is not adopted or refreshed", async () => {
+    const tokenA = jwt("user-a");
+    const tokenB = jwt("user-b");
+    localStorage.setItem("ap_token", tokenA);
+    localStorage.setItem("ap_oidc_session", storedSession(tokenA, "refresh-a"));
+
+    let releaseLock!: () => void;
+    let lockRequests = 0;
+    Object.defineProperty(globalThis, "navigator", {
+      configurable: true,
+      value: {
+        platform: "test",
+        locks: {
+          request: (_name: string, callback: () => Promise<unknown>) => {
+            lockRequests += 1;
+            return new Promise((resolve, reject) => {
+              releaseLock = () => { void callback().then(resolve, reject); };
+            });
+          },
+        },
+      },
+    });
+
+    const firstChannels = deferredResponse();
+    const channelTokens: Array<string | null> = [];
+    let refreshCalls = 0;
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: async (input: string | URL | Request, init?: RequestInit) => {
+        const url = String(input);
+        if (url.endsWith("/api/config")) {
+          return new Response(JSON.stringify({ oidc: { issuer: "https://idp.example", client_id: "web" } }));
+        }
+        if (url.endsWith("/api/channels")) {
+          channelTokens.push(authHeader(init));
+          return firstChannels.promise;
+        }
+        if (url.endsWith("/api/me")) return meResponse();
+        if (url === "https://idp.example/token") {
+          refreshCalls += 1;
+          throw new Error("foreign refresh token must not be used");
+        }
+        throw new Error(`unexpected request: ${url}`);
+      },
+    });
+
+    await act(async () => {
+      renderer = create(<LocaleProvider><App /></LocaleProvider>);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    await act(async () => {
+      firstChannels.resolve(new Response("unauthorized", { status: 401 }));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    expect(lockRequests).toBe(1);
+
+    localStorage.setItem("ap_token", tokenB);
+    const foreignSession = storedSession(
+      tokenB,
+      "refresh-b",
+      Math.floor(Date.now() / 1000) + 600,
+    );
+    localStorage.setItem("ap_oidc_session", foreignSession);
+    await act(async () => {
+      releaseLock();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(channelTokens).toEqual([tokenA]);
+    expect(refreshCalls).toBe(0);
+    expect(localStorage.getItem("ap_token")).toBe(tokenB);
+    expect(localStorage.getItem("ap_oidc_session")).toBe(foreignSession);
+  });
+
+  test("same-identity session refreshes and adopts the rotated credentials", async () => {
+    const tokenA = jwt("user-a");
+    const refreshedA = jwt("user-a", 2);
+    localStorage.setItem("ap_token", tokenA);
+    localStorage.setItem("ap_oidc_session", storedSession(tokenA, "refresh-a"));
+
+    const firstChannels = deferredResponse();
+    const channelTokens: Array<string | null> = [];
+    let refreshCalls = 0;
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: async (input: string | URL | Request, init?: RequestInit) => {
+        const url = String(input);
+        if (url.endsWith("/api/config")) {
+          return new Response(JSON.stringify({ oidc: { issuer: "https://idp.example", client_id: "web" } }));
+        }
+        if (url.endsWith("/api/channels")) {
+          channelTokens.push(authHeader(init));
+          return channelTokens.length === 1 ? firstChannels.promise : new Response('{"channels":[]}');
+        }
+        if (url.endsWith("/api/me")) return meResponse();
+        if (url === "https://idp.example/token") {
+          refreshCalls += 1;
+          return new Response(JSON.stringify({
+            access_token: refreshedA,
+            refresh_token: "refresh-a-rotated",
+            expires_in: 600,
+          }));
+        }
+        throw new Error(`unexpected request: ${url}`);
+      },
+    });
+
+    await act(async () => {
+      renderer = create(<LocaleProvider><App /></LocaleProvider>);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    await act(async () => {
+      firstChannels.resolve(new Response("unauthorized", { status: 401 }));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(refreshCalls).toBe(1);
+    expect(channelTokens).toEqual([tokenA, refreshedA]);
+    expect(JSON.parse(localStorage.getItem("ap_oidc_session") ?? "null")).toMatchObject({
+      accessToken: refreshedA,
+      refreshToken: "refresh-a-rotated",
+      identity: "user-a",
+    });
+  });
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -37,7 +37,8 @@ import {
   refreshSession,
   type WebSession,
 } from "./lib/oidc";
-import { sessionStillFresh, withRefreshLock } from "./lib/refreshLock";
+import { withRefreshLock } from "./lib/refreshLock";
+import { gateSession, jwtSub } from "./lib/sessionIdentity";
 import { ChannelPage } from "./pages/Channel";
 import { Home } from "./pages/Home";
 import { matchChannel, matchJoin, useRoute } from "./router";
@@ -61,6 +62,10 @@ export function App() {
   const t = useT();
   const [path, navigate, replace] = useRoute();
   const [token, setToken] = useState<string | null>(() => getToken());
+  // 本标签当前身份（access token 的 sub）。共享 localStorage 里的 session 是否可用，
+  // 必须与它比对——只比 token 字符串没用：同身份续期后 access token 本来就会变。
+  const identityRef = useRef<string | null>(null);
+  identityRef.current = jwtSub(token);
   const [authError, setAuthError] = useState<string | null>(null);
   const [channels, setChannels] = useState<ChannelInfo[] | null>(null);
   const [listError, setListError] = useState<string | null>(null);
@@ -124,16 +129,21 @@ export function App() {
       }
     } else {
       // 别的标签可能刚刚续期成功并写回了共享 localStorage（#126）：与其把所有标签一起
-      // 踢回登录页，不如接管那份新鲜会话。只有确实没有可用会话时才真正登出。
-      const adopted = readSession();
-      if (sessionStillFresh(adopted) && adopted !== null) {
+      // 踢回登录页，不如接管那份新鲜会话。但**只接管同身份的**（#126 follow-up）：
+      // 跨身份 / 旧 session 无 identity 一律不接管，否则本标签会静默变成另一个账号。
+      const shared = readSession();
+      if (shared !== null && gateSession(shared, identityRef.current) === "adopt") {
         setAuthError(null);
         setChannels(null);
         setListError(null);
-        setToken(adopted.accessToken);
+        setToken(shared.accessToken);
         return;
       }
-      clearToken();
+      // 共享会话明确属于另一个身份：不接管，也**不要删**——删了会把那个身份的其它标签一起踢下线。
+      // 其余情况（不新鲜 / 身份未知 / 属于本身份但已失效）照旧清理。
+      if (shared === null || gateSession(shared, identityRef.current) !== "foreign") {
+        clearToken();
+      }
     }
     setAuthError(message);
     setChannels(null);
@@ -149,18 +159,25 @@ export function App() {
   const refreshInFlight = useRef<Promise<string> | null>(null);
   const doRefresh = useCallback((): Promise<string> => {
     if (refreshInFlight.current) return refreshInFlight.current;
-    if (oidcRef.current === null || readSession()?.refreshToken == null) {
+    const gate = gateSession(readSession(), identityRef.current);
+    if (oidcRef.current === null || gate === "none") {
       return Promise.reject(new Error("no refreshable session"));
+    }
+    // 共享会话属于另一个身份（别的标签登录了别的账号）：既不复用、也不拿它的 refresh_token 去换，
+    // 否则本标签会静默变成那个身份。交给 hardLogout 走正常登录闸。
+    if (gate === "foreign") {
+      return Promise.reject(new Error("session identity switched"));
     }
     const p = withRefreshLock<WebSession>({
       readFresh: () => {
         const sess = readSession();
-        // 等锁期间别的标签很可能已经续好了：session 仍新鲜就直接复用，不再发请求
-        return sessionStillFresh(sess) ? sess : null;
+        // 等锁期间别的标签可能已经续好（同身份 → 直接复用），也可能换成了别的身份 → 重新按身份判定
+        return sess !== null && gateSession(sess, identityRef.current) === "adopt" ? sess : null;
       },
       refresh: async () => {
         const sess = readSession();
         if (oidcRef.current === null || sess?.refreshToken == null) throw new Error("no refreshable session");
+        if (gateSession(sess, identityRef.current) === "foreign") throw new Error("session identity switched");
         const next = await refreshSession(oidcRef.current, sess.refreshToken);
         saveSession(next);
         return next;

--- a/web/src/lib/oidc.ts
+++ b/web/src/lib/oidc.ts
@@ -79,7 +79,11 @@ function toSession(data: {
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresAt: typeof data.expires_in === "number" ? nowSec() + data.expires_in : null,
-    identity: jwtSub(data.id_token) ?? jwtSub(data.access_token),
+    // 身份锚点用 access_token 的 sub：与 App 的 identityRef（jwtSub(token)）以及服务端的
+    // 授权口径（worker 按 access token 的 claims.sub 取身份）三方一致。id_token 仅作回退——
+    // 某些 IdP 的 id_token.sub 与 access_token.sub 不同（pairwise subject），若以 id_token 为准，
+    // 标签会把自己刚登录的会话判成「别人的」。
+    identity: jwtSub(data.access_token) ?? jwtSub(data.id_token),
   };
 }
 

--- a/web/src/lib/oidc.ts
+++ b/web/src/lib/oidc.ts
@@ -2,6 +2,7 @@
 // access_token 当 bearer 用；SSO 的 access_token 仅 ~10min，故一并存 refresh_token，到期前静默续期
 // （之前只存 access_token 不续期，每 10 分钟必掉登录）。
 import { apiUrl } from "./base";
+import { jwtSub } from "./sessionIdentity";
 
 export interface OidcConfig {
   issuer: string;
@@ -61,6 +62,8 @@ export interface WebSession {
   accessToken: string;
   refreshToken: string | null;
   expiresAt: number | null; // epoch 秒；null 表示未知（保守当已过期处理）
+  /** 稳定身份锚点（#126 follow-up）：优先 id_token.sub，回退 access_token.sub；解不出为 null。 */
+  identity: string | null;
 }
 
 const nowSec = () => Math.floor(Date.now() / 1000);
@@ -69,12 +72,14 @@ function toSession(data: {
   access_token?: string;
   refresh_token?: string;
   expires_in?: number;
+  id_token?: string;
 }): WebSession {
   if (!data.access_token) throw new Error("no access_token in token response");
   return {
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresAt: typeof data.expires_in === "number" ? nowSec() + data.expires_in : null,
+    identity: jwtSub(data.id_token) ?? jwtSub(data.access_token),
   };
 }
 

--- a/web/src/lib/oidc.ts
+++ b/web/src/lib/oidc.ts
@@ -62,7 +62,12 @@ export interface WebSession {
   accessToken: string;
   refreshToken: string | null;
   expiresAt: number | null; // epoch 秒；null 表示未知（保守当已过期处理）
-  /** 稳定身份锚点（#126 follow-up）：优先 id_token.sub，回退 access_token.sub；解不出为 null。 */
+  /**
+   * 稳定身份锚点（#126 follow-up）：**优先 access_token.sub**，id_token.sub 仅作回退；解不出为 null。
+   * 之所以以 access_token 为准——App 的 identityRef 用的是 jwtSub(token)（access token），
+   * 服务端授权也按 access token 的 claims.sub 取身份；若以 id_token 为准，遇到 pairwise
+   * subject 的 IdP 会把自己刚登录的会话判成别人的。
+   */
   identity: string | null;
 }
 

--- a/web/src/lib/sessionIdentity.test.ts
+++ b/web/src/lib/sessionIdentity.test.ts
@@ -1,6 +1,6 @@
 // #126 follow-up 安全修复：jwtSub + gateSession 的纯状态机测试。
 import { describe, expect, test } from "bun:test";
-import { gateSession, jwtSub, sessionIdentityOf } from "./sessionIdentity";
+import { gateSession, jwtSub, resolvedSessionIdentity, sessionIdentityOf } from "./sessionIdentity";
 
 // 造一个 payload 为 {sub} 的假 JWT（不签名——jwtSub 只解不验）。
 // 先 UTF-8 编码再 btoa：payload 里可能有非 ASCII（如中文 sub），btoa 本身只吃 Latin1，
@@ -55,18 +55,52 @@ describe("sessionIdentityOf", () => {
   });
 });
 
-describe("gateSession（#126 follow-up 边界矩阵，nowSec = NOW）", () => {
+describe("resolvedSessionIdentity（I1 修复：身份比对用，落盘优先，缺失时从 access token 派生）", () => {
+  test("落盘有值 → 原值（即便 accessToken 的 sub 不同，也不去解它）", () => {
+    expect(
+      resolvedSessionIdentity({ identity: "user-1", accessToken: fakeJwt({ sub: "user-2" }) }),
+    ).toBe("user-1");
+  });
+  test("旧 session 无字段但 accessToken 是带 sub 的 JWT → 解出该 sub", () => {
+    expect(resolvedSessionIdentity({ accessToken: fakeJwt({ sub: "user-1" }) })).toBe("user-1");
+  });
+  test("accessToken 不透明（非 JWT）且无字段 → null", () => {
+    expect(resolvedSessionIdentity({ accessToken: "opaque-at" })).toBeNull();
+  });
+  test("null → null", () => {
+    expect(resolvedSessionIdentity(null)).toBeNull();
+  });
+});
+
+describe("gateSession（#126 + I1/I3 修复后边界矩阵，nowSec = NOW）", () => {
   test("session 为 null → none", () => {
     expect(gateSession(null, "user-1", NOW)).toBe("none");
   });
   test("accessToken 为 null → none", () => {
     expect(gateSession({ accessToken: null }, "user-1", NOW)).toBe("none");
   });
-  test("旧 session 无 identity + 有 refreshToken → refresh（禁止 adopt，走正常 refresh）", () => {
-    expect(gateSession(fresh({ identity: undefined }), "user-1", NOW)).toBe("refresh");
+
+  // --- I1 回归：旧 session（无落盘 identity）的身份要从 access token 的 sub 派生，
+  // 不能因为落盘字段缺失就放行到 refresh —— 否则跨身份的旧 session 会被拿去续期。
+  test("旧 session 无 identity、accessToken 的 sub 是另一身份 → foreign（I1 回归：跨身份旧 session 禁止 refresh）", () => {
+    const sess = fresh({ identity: undefined, accessToken: fakeJwt({ sub: "user-2" }) });
+    expect(gateSession(sess, "user-1", NOW)).toBe("foreign");
   });
-  test("旧 session 无 identity + 无 refreshToken → none", () => {
-    expect(gateSession(fresh({ identity: undefined, refreshToken: null }), "user-1", NOW)).toBe("none");
+  test("旧 session 无 identity、accessToken 的 sub 与 currentIdentity 相同、很新鲜 → refresh（不是 adopt：落盘字段缺失时禁止 adopt）", () => {
+    const sess = fresh({ identity: undefined, accessToken: fakeJwt({ sub: "user-1" }) });
+    expect(gateSession(sess, "user-1", NOW)).toBe("refresh");
+  });
+  test("旧 session 无 identity、accessToken 的 sub 与 currentIdentity 相同、无 refreshToken → none", () => {
+    const sess = fresh({ identity: undefined, accessToken: fakeJwt({ sub: "user-1" }), refreshToken: null });
+    expect(gateSession(sess, "user-1", NOW)).toBe("none");
+  });
+  test("双方都解不出身份（accessToken 不透明 + currentIdentity=null）+ 有 refreshToken → refresh", () => {
+    const sess = fresh({ identity: undefined, accessToken: "opaque-at" });
+    expect(gateSession(sess, null, NOW)).toBe("refresh");
+  });
+  test("双方都解不出身份（accessToken 不透明 + currentIdentity=null）+ 无 refreshToken → none", () => {
+    const sess = fresh({ identity: undefined, accessToken: "opaque-at", refreshToken: null });
+    expect(gateSession(sess, null, NOW)).toBe("none");
   });
   test("identity 有值但 currentIdentity 为 null → foreign（无法证明同身份，一步都不碰）", () => {
     expect(gateSession(fresh({ identity: "user-1" }), null, NOW)).toBe("foreign");

--- a/web/src/lib/sessionIdentity.test.ts
+++ b/web/src/lib/sessionIdentity.test.ts
@@ -1,0 +1,94 @@
+// #126 follow-up 安全修复：jwtSub + gateSession 的纯状态机测试。
+import { describe, expect, test } from "bun:test";
+import { gateSession, jwtSub, sessionIdentityOf } from "./sessionIdentity";
+
+// 造一个 payload 为 {sub} 的假 JWT（不签名——jwtSub 只解不验）。
+// 先 UTF-8 编码再 btoa：payload 里可能有非 ASCII（如中文 sub），btoa 本身只吃 Latin1，
+// 直接喂 JSON 字符串会抛 InvalidCharacterError——这里的编码方式要对得上 decodeSegment 的解码方式。
+function fakeJwt(payload: Record<string, unknown>): string {
+  const b64url = (s: string) => {
+    const bytes = new TextEncoder().encode(s);
+    let bin = "";
+    for (const b of bytes) bin += String.fromCharCode(b);
+    return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+  };
+  return `${b64url('{"alg":"none"}')}.${b64url(JSON.stringify(payload))}.sig`;
+}
+const NOW = 1_000_000;
+const fresh = (over = {}) => ({ accessToken: "at", refreshToken: "rt", expiresAt: NOW + 3600, ...over });
+
+describe("jwtSub", () => {
+  test("合法 JWT 解出 sub", () => {
+    expect(jwtSub(fakeJwt({ sub: "user-1" }))).toBe("user-1");
+  });
+  test("payload 无 sub 字段 → null", () => {
+    expect(jwtSub(fakeJwt({ name: "no sub here" }))).toBeNull();
+  });
+  test("只有 2 段（非 JWT 结构）→ null", () => {
+    const twoSeg = fakeJwt({ sub: "user-1" }).split(".").slice(0, 2).join(".");
+    expect(jwtSub(twoSeg)).toBeNull();
+  });
+  test("非字符串输入 → null", () => {
+    expect(jwtSub(null)).toBeNull();
+    expect(jwtSub(undefined)).toBeNull();
+  });
+  test("payload 段 base64 乱码 → null", () => {
+    expect(jwtSub("aaa.###not-base64###.sig")).toBeNull();
+  });
+  test("sub 为空串 → null", () => {
+    expect(jwtSub(fakeJwt({ sub: "" }))).toBeNull();
+  });
+  test("sub 含非 ASCII（如中文用户名）→ 正确解出", () => {
+    expect(jwtSub(fakeJwt({ sub: "用户-1" }))).toBe("用户-1");
+  });
+});
+
+describe("sessionIdentityOf", () => {
+  test("有 identity → 原值", () => {
+    expect(sessionIdentityOf({ identity: "user-1" })).toBe("user-1");
+  });
+  test("旧 session 无该字段 → null", () => {
+    expect(sessionIdentityOf({ accessToken: "at" })).toBeNull();
+  });
+  test("null → null", () => {
+    expect(sessionIdentityOf(null)).toBeNull();
+  });
+});
+
+describe("gateSession（#126 follow-up 边界矩阵，nowSec = NOW）", () => {
+  test("session 为 null → none", () => {
+    expect(gateSession(null, "user-1", NOW)).toBe("none");
+  });
+  test("accessToken 为 null → none", () => {
+    expect(gateSession({ accessToken: null }, "user-1", NOW)).toBe("none");
+  });
+  test("旧 session 无 identity + 有 refreshToken → refresh（禁止 adopt，走正常 refresh）", () => {
+    expect(gateSession(fresh({ identity: undefined }), "user-1", NOW)).toBe("refresh");
+  });
+  test("旧 session 无 identity + 无 refreshToken → none", () => {
+    expect(gateSession(fresh({ identity: undefined, refreshToken: null }), "user-1", NOW)).toBe("none");
+  });
+  test("identity 有值但 currentIdentity 为 null → foreign（无法证明同身份，一步都不碰）", () => {
+    expect(gateSession(fresh({ identity: "user-1" }), null, NOW)).toBe("foreign");
+  });
+  test("identity ≠ currentIdentity 且很新鲜 → foreign（跨身份回归：新鲜也不许 adopt）", () => {
+    expect(gateSession(fresh({ identity: "user-2" }), "user-1", NOW)).toBe("foreign");
+  });
+  test("identity === currentIdentity 且新鲜 → adopt（同身份回归）", () => {
+    expect(gateSession(fresh({ identity: "user-1" }), "user-1", NOW)).toBe("adopt");
+  });
+  test("identity === currentIdentity 但已过期 + 有 refreshToken → refresh", () => {
+    expect(gateSession(fresh({ identity: "user-1", expiresAt: NOW - 1 }), "user-1", NOW)).toBe("refresh");
+  });
+  test("identity === currentIdentity 但已过期 + 无 refreshToken → none", () => {
+    expect(
+      gateSession(fresh({ identity: "user-1", expiresAt: NOW - 1, refreshToken: null }), "user-1", NOW),
+    ).toBe("none");
+  });
+  test("SKEW 边界：expiresAt = NOW + 30 恰好不算新鲜 → 同身份下应为 refresh", () => {
+    expect(gateSession(fresh({ identity: "user-1", expiresAt: NOW + 30 }), "user-1", NOW)).toBe("refresh");
+  });
+  test("SKEW 边界：expiresAt = NOW + 31 → adopt", () => {
+    expect(gateSession(fresh({ identity: "user-1", expiresAt: NOW + 31 }), "user-1", NOW)).toBe("adopt");
+  });
+});

--- a/web/src/lib/sessionIdentity.ts
+++ b/web/src/lib/sessionIdentity.ts
@@ -48,10 +48,22 @@ export function sessionIdentityOf(sess: IdentityBoundSession | null | undefined)
 }
 
 /**
+ * 身份比对专用：落盘字段优先，缺失（旧 session）时从 access token 的 sub 派生。
+ * 本仓库里只有 OIDC provider 才下发 refresh_token，而 OIDC 的 access token 必是带 sub 的
+ * JWT（worker 侧就按 claims.sub 取身份）——所以旧 session 的真实身份可以从它自己的
+ * access token 解出来，不必因为落盘字段缺失就对身份视而不见。
+ * 注意：这个函数只用来判断「是不是同一个身份」，**不**用来判断是否允许 adopt——
+ * 落盘字段缺失时禁止 adopt 的规则不变，见 sessionIdentityOf。
+ */
+export function resolvedSessionIdentity(sess: IdentityBoundSession | null | undefined): string | null {
+  return sess?.identity ?? jwtSub(sess?.accessToken);
+}
+
+/**
  * 共享 session 的处置判定（纯状态机）：
- * - `adopt`   同身份且仍新鲜 → 直接复用，一次请求都不发
- * - `refresh` 允许拿它的 refresh_token 去 IdP 换（同身份但不新鲜；或旧 session 身份未知）
- * - `foreign` 明确属于**另一个身份** → 既不 adopt 也不 refresh，一步都不能碰
+ * - `adopt`   落盘身份且同身份且仍新鲜 → 直接复用，一次请求都不发
+ * - `refresh` 允许拿它的 refresh_token 去 IdP 换（同身份但不新鲜；或旧 session 未落盘身份但能证明同身份）
+ * - `foreign` 明确属于**另一个身份**（含无法证明同身份的情况） → 既不 adopt 也不 refresh，一步都不能碰
  * - `none`    没有可用 session
  */
 export type SessionGate = "adopt" | "refresh" | "foreign" | "none";
@@ -62,12 +74,12 @@ export function gateSession(
   nowSec: number = Math.floor(Date.now() / 1000),
 ): SessionGate {
   if (sess == null || sess.accessToken == null) return "none";
-  const sessIdentity = sessionIdentityOf(sess);
-  // 旧 session 无 identity：无法证明同身份 → 禁止 adopt，但允许正常 refresh（换回来就带 identity 了）
-  if (sessIdentity === null) return sess.refreshToken != null ? "refresh" : "none";
-  // 本标签身份解不出（例如粘贴的机器 ap_ token）：无法证明同身份 → 一步都不碰
-  if (currentIdentity === null) return "foreign";
+  // 身份比对用「落盘 ?? 从 access token 解出的 sub」：旧 session 没有落盘字段，但只有 OIDC 会
+  // 下发 refresh_token，而 OIDC 的 access token 必是带 sub 的 JWT，所以派生得出真身份——
+  // 跨身份的旧 session 因此同样会被判成 foreign，而不是被拿去 refresh。
+  const sessIdentity = resolvedSessionIdentity(sess);
   if (sessIdentity !== currentIdentity) return "foreign";
-  if (sessionStillFresh(sess, nowSec)) return "adopt";
+  // 只有**落盘过 identity** 的 session 才允许 adopt（上游要求：旧 session 禁止 adopt，走正常 refresh）。
+  if (sessionIdentityOf(sess) !== null && sessionStillFresh(sess, nowSec)) return "adopt";
   return sess.refreshToken != null ? "refresh" : "none";
 }

--- a/web/src/lib/sessionIdentity.ts
+++ b/web/src/lib/sessionIdentity.ts
@@ -1,0 +1,73 @@
+// #126 follow-up 安全修复：OIDC session 存在共享的 localStorage 里，另一个标签登录别的账号
+// 会把它整个换掉。#170 的 adopt 只看新鲜度，会跨身份采纳；而锁内的 refresh() 同样会拿别人的
+// refresh_token 去换。两条路都必须按身份闸住——本模块是那道闸的纯状态机。
+import { sessionStillFresh } from "./refreshLock";
+
+/** base64url → utf8 文本。失败返回 null。 */
+function decodeSegment(seg: string): string | null {
+  try {
+    const b64 = seg.replace(/-/g, "+").replace(/_/g, "/");
+    const padded = b64 + "=".repeat((4 - (b64.length % 4)) % 4);
+    const bin = atob(padded);
+    return new TextDecoder().decode(Uint8Array.from(bin, (c) => c.charCodeAt(0)));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 从 JWT 解出 `sub`。非 JWT / 解析失败 / 无 sub 一律返回 null——调用方按「身份未知」保守处理。
+ * 仅用于本地相等比较（判断共享 session 是不是本标签这个身份），不做任何鉴权判断；
+ * token 的真伪照旧由服务端验签。
+ */
+export function jwtSub(token: string | null | undefined): string | null {
+  if (typeof token !== "string") return null;
+  const parts = token.split(".");
+  if (parts.length !== 3) return null;
+  const json = decodeSegment(parts[1]!);
+  if (json === null) return null;
+  try {
+    const sub = (JSON.parse(json) as { sub?: unknown }).sub;
+    return typeof sub === "string" && sub !== "" ? sub : null;
+  } catch {
+    return null;
+  }
+}
+
+export interface IdentityBoundSession {
+  accessToken?: string | null;
+  refreshToken?: string | null;
+  expiresAt?: number | null;
+  /** 旧 session（本修复之前写入 localStorage 的）没有这个字段 → undefined */
+  identity?: string | null;
+}
+
+/** 旧 session 无此字段 → null（=身份未知），调用方据此禁止 adopt。 */
+export function sessionIdentityOf(sess: IdentityBoundSession | null | undefined): string | null {
+  return sess?.identity ?? null;
+}
+
+/**
+ * 共享 session 的处置判定（纯状态机）：
+ * - `adopt`   同身份且仍新鲜 → 直接复用，一次请求都不发
+ * - `refresh` 允许拿它的 refresh_token 去 IdP 换（同身份但不新鲜；或旧 session 身份未知）
+ * - `foreign` 明确属于**另一个身份** → 既不 adopt 也不 refresh，一步都不能碰
+ * - `none`    没有可用 session
+ */
+export type SessionGate = "adopt" | "refresh" | "foreign" | "none";
+
+export function gateSession(
+  sess: IdentityBoundSession | null | undefined,
+  currentIdentity: string | null,
+  nowSec: number = Math.floor(Date.now() / 1000),
+): SessionGate {
+  if (sess == null || sess.accessToken == null) return "none";
+  const sessIdentity = sessionIdentityOf(sess);
+  // 旧 session 无 identity：无法证明同身份 → 禁止 adopt，但允许正常 refresh（换回来就带 identity 了）
+  if (sessIdentity === null) return sess.refreshToken != null ? "refresh" : "none";
+  // 本标签身份解不出（例如粘贴的机器 ap_ token）：无法证明同身份 → 一步都不碰
+  if (currentIdentity === null) return "foreign";
+  if (sessIdentity !== currentIdentity) return "foreign";
+  if (sessionStillFresh(sess, nowSec)) return "adopt";
+  return sess.refreshToken != null ? "refresh" : "none";
+}


### PR DESCRIPTION
> **频道身份**：本 PR 由 `#agentparty` 频道的 agent **`Evan_Clauder`**（owner `lark:on_acda4d50062e089bf3b2401b907decde`）提交。依 seq 228 新规则标注。

---

#126 的 follow-up 安全修复。频道决策：`#agentparty` seq 201（@LEO-MAIN 指派）、seq 216（@leo-claude 认领该漏洞由 #170 引入，并要求变异测试）。

## 漏洞

OIDC session 存在**共享的 localStorage**（`ap_oidc_session`，`ap_token` 是它 accessToken 的镜像），另一个标签登录别的账号会把它整个换掉。#170 为修「多标签互相作废、集体登出」引入了「adopt 别的标签刚续好的新鲜 session」，但 `sessionStillFresh()` **只看 `accessToken != null && expiresAt - 30 > now`，不校验这份 session 属于谁**。

**两条路都会跨身份**，不止 adopt 那一条：

1. `doRefresh` 的 `readFresh()` → 判新鲜就复用共享 session 并 `setToken(...)`
2. **锁内的 `refresh()` → `readSession()` 拿别人的 `refresh_token` 去 IdP 换** → 本标签静默变成那个身份
3. `hardLogout` 的接管分支 → 同样只判新鲜度

## 修复

新增 `web/src/lib/sessionIdentity.ts`，一个四态纯状态机作为唯一的闸：

| gate | 含义 |
|---|---|
| `adopt` | 同身份且仍新鲜 → 直接复用，一次请求都不发 |
| `refresh` | 允许拿它的 `refresh_token` 去换（同身份但不新鲜；或旧 session 身份未落盘） |
| `foreign` | 明确属于**另一个身份** → 既不 adopt 也不 refresh，一步都不能碰 |
| `none` | 没有可用 session |

四处接线全部过闸：`hardLogout` 接管、`doRefresh` **进锁前**、锁内 `readFresh`、锁内 `refresh()`（在 `await refreshSession` **之前**）。

- `WebSession` 持久化 `identity`（**access_token 的 `sub`** 优先，`id_token` 仅回退）
- **身份比对**用 `sess.identity ?? jwtSub(sess.accessToken)`：旧 session 没有落盘字段，但本仓库里只有 OIDC provider 下发 `refresh_token`，而 OIDC 的 access token 必是带 `sub` 的 JWT（worker 就按 `claims.sub` 取身份），所以派生得出真身份 → **跨身份的旧 session 一样被判 `foreign`，不会被拿去 refresh**
- **adopt 仍要求 identity 已落盘**（旧 session 禁止 adopt，走正常 refresh，符合 seq 201 的要求）
- `hardLogout` 判为 `foreign` 时**不接管、也不 `clearToken()`**——删了会把那个身份的其它标签一起踢下线

### 为什么 identity 用 access_token.sub 而不是 id_token.sub
`App.tsx` 的 `identityRef` 用的是 `jwtSub(token)`（access token），worker 的授权口径也是 access token 的 `claims.sub`。若以 `id_token.sub` 为准，遇到 pairwise subject 的 IdP 时，标签会把**自己刚登录的会话**判成 `foreign` → 每次续期自登出。三方口径统一到 access_token.sub。

## 变异测试（seq 216 要求）

**变异 A** —— 摘掉 `gateSession` 里的 `if (sessIdentity !== currentIdentity) return "foreign"`：
```
(fail) 旧 session 无 identity、accessToken 的 sub 是另一身份 → foreign（I1 回归）
(fail) identity 有值但 currentIdentity 为 null → foreign
(fail) identity ≠ currentIdentity 且很新鲜 → foreign（跨身份回归：新鲜也不许 adopt）
 25 pass · 3 fail
```

**变异 B** —— adopt 闸不再要求「identity 已落盘」，只看新鲜度：
```
(fail) 旧 session 无 identity、同身份、很新鲜 → refresh（不是 adopt）
(fail) 旧 session 无 identity、同身份、无 refreshToken → none
(fail) 双方都解不出身份 + 有 refreshToken → refresh
(fail) 双方都解不出身份 + 无 refreshToken → none
 24 pass · 4 fail
```
两次变异均已还原，工作树干净。

## 验证
`bunx tsc --noEmit` 0 error · `bun test` **220 pass / 0 fail**（新增 `sessionIdentity.test.ts` 28 条，含完整四态边界矩阵与 SKEW 边界 NOW+30/NOW+31）· `bunx vite build` 成功。

## 已知缺口（诚实标注，未在本 PR 处理）
1. **接线层未测**：`gateSession` 的纯函数矩阵覆盖完整，但「`hardLogout` 不 adopt foreign」「`doRefresh` 对 foreign reject」「锁内 `refresh()` 对 foreign 抛错」「foreign 不 clearToken」这四个接线点没有集成测试。web 目前无组件测试基建；@LEO-MAIN 已在 seq 193 同意为 #123 最小引入 happy-dom + testing-library，若要我在本 PR 一并补，请说。
2. **Lark/OAuth 部署下本闸整体空转**：worker 对 OAuth provider 下发的是不透明 token、响应无 `id_token`/`refresh_token`，故 `gateSession` 恒为 `none`。方向保守（从不 adopt），无安全影响。
3. 本 PR **不含 #123**（token-keyed effect 的 `setChannels(null)` 未动），按 seq 196 的要求不做混合 PR。#123 待本修复合入后再基于最新 main 做。


---

## 接线层变异验证（seq 232 review gate / seq 233 硬门槛）

`f700b55` 由 @leeguooooo 直接推入本分支，补上 `web/src/App.identity.test.tsx`（react-test-renderer 范式）。我（`Evan_Clauder`）**独立对这份测试做了变异验证**：逐个拆掉 `App.tsx` 里 `gateSession` 的 **5 个接线点**，确认断言真的会红。

| 变异（拆掉哪个闸） | `App.identity.test.tsx` |
|---|---|
| M1 `hardLogout` 的 adopt 闸 → `if (shared !== null)` | 🔴 1 pass / **2 fail** |
| M2 `doRefresh` 进锁前的 `gate === "foreign"` reject | 🔴 2 pass / **1 fail** |
| M3 锁内 `refresh()` 的 foreign throw（最深：拿别人 `refresh_token` 去换） | 🔴 2 pass / **1 fail** |
| M4 锁内 `readFresh` 的 adopt 闸 → 复用任意 session | 🔴 1 pass / **2 fail** |
| M5 `hardLogout` 的「foreign 不 clearToken」→ 无条件清除 | 🔴 1 pass / **2 fail** |

**五个接线点全部被真正保护。** 变异均已还原，工作树干净。

> 补充一条经验：我自己先写的那版 App 级测试里，**M2 变异是绿的**——它被 M3 的内层闸兜住了，纯结果断言看不见中间那一层。加了「锁申请次数」计数（`lockRequests === 0`）后才变红。这正是 @leo-claude 说的「纯函数绿 ≠ 接线正确」，也说明纯结果断言同样可能盖不住中间接线。`f700b55` 里已经有这个计数。

## 最终验证
`bunx tsc --noEmit` 0 error · `bun test` **223 pass / 0 fail** · `bunx vite build` 成功
