### PR TITLE
fix(cli): 唤醒失败不再静默吃掉 @，游标只表达「已了结」（#118 #198 #193 #172）

### DIFF
--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -38,9 +38,18 @@ const PROTOCOL_REMINDER =
 // 唤醒未送达（runner 非零退出 / 无 session id / SDK 抛错 / [attach] 被拒）。
 // 四种 runner 统一抛它：调用方据此判断「这条 @ 没进过模型」，从而不推进游标。
 export class WakeBlockedError extends Error {
-  constructor(message: string) {
+  /**
+   * 重试是否安全 —— 即**模型确定没有跑过**。
+   * 抛出这个错并不能证明模型没运行：runner 非零退出、SDK 在 thread.run 之后写 session /
+   * 发回复 / 写日志失败、custom runner 产生副作用后才退出，都会走到这里。
+   * 那些情况下重跑 = 重复模型副作用（重复 git push、重复开 PR）。默认 false。
+   * 只有「runner 根本没起来」（spawn 失败）才置 true。
+   */
+  readonly retriable: boolean;
+  constructor(message: string, retriable = false) {
     super(message);
     this.name = "WakeBlockedError";
+    this.retriable = retriable;
   }
 }
 
@@ -528,7 +537,19 @@ async function runHarness(
   env: Record<string, string | undefined>,
   seq: number,
 ): Promise<HarnessRun> {
-  const runProcess = opts.runProcess ?? defaultRunnerProcess;
+  const rawRunProcess = opts.runProcess ?? defaultRunnerProcess;
+  // runProcess 自己抛 = 进程根本没起来（spawn ENOENT / 权限），模型确定没跑过 → 重试安全。
+  // 一旦进程起来了（哪怕退出码非零），模型就可能已经产生副作用，重跑不安全。
+  const runProcess: RunnerProcess = async (args, o2) => {
+    try {
+      return await rawRunProcess(args, o2);
+    } catch (e) {
+      throw new WakeBlockedError(
+        `builtin ${opts.harness} runner did not start: ${e instanceof Error ? e.message : String(e)}`,
+        true,
+      );
+    }
+  };
   if (opts.harness === "codex") {
     const outFile = join(opts.workdir, `runner-${seq}-${Date.now()}.out`);
     const base = ["--skip-git-repo-check", "--sandbox", "workspace-write", "-o", outFile, prompt];
@@ -1152,20 +1173,25 @@ export async function runServe(o: ServeOptions): Promise<number> {
       // fresh = 游标之上的新消息。历史修订快照会穿透去重被重放（seq 早已消费过），
       // 它们不是新唤醒——不 fresh 就绝不触发 runner（否则旧 @ 被编辑一次，每次重连都重跑一遍）
       const fresh = frame.seq > conn.cursor;
-      // 离线积压（seq <= 挂载水位）跳过模式下不唤醒：照常 ack + 进 recent，但不拉起 runner（#193）。
-      // 唯一例外：**欠账**。它送达失败过，从没进过模型——它不是积压，是我们欠着的（#198 约束②）。
-      // 少了这个例外，#118 特意不 ack 保下来的那条 @ 会在重连后被当成积压跳掉，净效果等于没修。
+      // 欠账（#198）先于**一切**过滤条件。它送达失败过、从没进过模型——欠着就是欠着，
+      // 与当前是不是 mentions-only、是不是积压无关。
+      // 反例（190-codex-dev on PR #206）：--all 下一条非 mention 失败留下欠账，重启回默认
+      // mentions-only 后 qualifies=false → 不重试、不清欠账、却无条件 ack 越过它。
       const isDebt = stuck !== null && frame.seq === stuck.seq;
-      const isBacklog = skipBacklog && attachHead !== null && frame.seq <= attachHead && !isDebt;
-      const qualifies = fresh && !fromSelf && !isBacklog && (!o.mentionsOnly || frame.mentions.includes(self));
+      const isBacklog = skipBacklog && attachHead !== null && frame.seq <= attachHead;
+      const passesFilter = !fromSelf && !isBacklog && (!o.mentionsOnly || frame.mentions.includes(self));
+      const qualifies = fresh && (isDebt || passesFilter);
       if (qualifies) {
         out(`▶ ${formatMsg(frame)}`);
         // 串行：本条命令跑完再消费下一帧（新帧此间缓冲在 FrameQueue），避免并发唤起互相抢
         // 有界重试（#198）：同一条 seq 最多 maxAttempts 次。前一个进程崩在第 k 次，这里从 k 接着数。
         const priorAttempts = stuck?.seq === frame.seq ? stuck.attempts : 0;
-        let lastError = "";
+        // 崩溃在「最后一次失败落盘」与「最终通告」之间时，这里循环一次都不跑，
+        // lastError 必须从盘上接手，否则最终通告里的错误原因是空字符串（门禁 P2）。
+        let lastError = (stuck?.seq === frame.seq ? stuck.last_error : "") ?? "";
         let delivered = false;
-        for (let attempt = priorAttempts + 1; attempt <= maxAttempts; attempt++) {
+        let retriable = true;
+        for (let attempt = priorAttempts + 1; attempt <= maxAttempts && retriable; attempt++) {
           try {
             const cliUpgrade = upgradeNotice(o.autoUpgrade === true, o.upgradeDeps);
             await run(frame, {
@@ -1181,10 +1207,14 @@ export async function runServe(o: ServeOptions): Promise<number> {
             break;
           } catch (e) {
             lastError = e instanceof Error ? e.message : String(e);
+            // 抛错不等于「模型没跑过」。只有 runner 明确声明可重试（spawn 都没成功）才重试；
+            // 否则重跑会重复模型与外部副作用（git push / 开 PR）。见门禁 P1③。
+            retriable = e instanceof WakeBlockedError ? e.retriable : false;
+            if (!retriable) lastError += " (not retriable: model may have run)";
             out(`  命令失败 (${attempt}/${maxAttempts}): ${lastError}`);
             // 先落盘再重试：此刻进程崩掉，重启后不会把已经烧掉的次数忘干净
             setStuck({ seq: frame.seq, attempts: attempt, last_error: lastError });
-            if (attempt < maxAttempts && retryDelayMs > 0) await delay(retryDelayMs);
+            if (retriable && attempt < maxAttempts && retryDelayMs > 0) await delay(retryDelayMs);
           }
         }
         if (delivered) {
@@ -1218,12 +1248,13 @@ export async function runServe(o: ServeOptions): Promise<number> {
       // 触发消息本身不进 recent（它就是 context 主体）；自己的/未 @ 的都算上下文
       recent.push(frame);
       if (recent.length > RECENT_MAX) recent.shift();
-      // 游标只表达「已了结」（#198）：走到这里，这条唤醒要么送达成功、要么有界重试耗尽后
-      // **宣告过**放弃——两者都是了结，都该推进游标。
-      // 欠账不会活着走到这一行：它只可能在上面的重试循环里随进程一起死掉，那时游标压根没动，
-      // 下次 attach 从 cursor 续，这条 @ 会被重放（attempts 从盘上接着数）。
-      // 不要在这里加 `if (stuck === null)` 守卫——变异测试证明它守不住任何东西（死代码）。
-      conn.ack(frame.seq);
+      // 游标只表达「已了结」（#198）：送达成功，或有界重试耗尽后**宣告过**的放弃。
+      // 欠账未了结时游标绝不越过它——否则那条 @ 永远不会再被重放。
+      //
+      // 我曾断言这个守卫是死代码（有界重试后 stuck 恒为 null），并请门禁证伪。
+      // 190-codex-dev 找到了反例：欠账那一帧若被 mentionsOnly / fromSelf 过滤掉，
+      // stuck 就活着走到这里。守卫不是死的——是我的推理漏了过滤路径。
+      if (stuck === null || frame.seq < stuck.seq) conn.ack(frame.seq);
       if (o.statusline === true) {
         writeStatuslineCache({
           ...localStatuslineBase(o.channel),

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -44,6 +44,9 @@ export class WakeBlockedError extends Error {
   }
 }
 
+// 放弃通告都发不出去（网络/loop guard 熔断）。此时既没送达也没宣告，继续跑就是静默丢 @。
+export const EXIT_WAKE_UNANNOUNCED = 1;
+
 const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
 // 有界重放（#198）：同一条 seq 连续送达失败到顶就响亮放弃，既不无限重放也不静默丢弃
@@ -544,20 +547,6 @@ async function runHarness(
   return { result, text: parsed.text.trimEnd(), sessionId: parsed.sessionId };
 }
 
-async function postBlocked(
-  opts: BuiltinRunnerOptions,
-  frame: MsgFrame,
-  note: string,
-): Promise<void> {
-  await (opts.post ?? postMessage)(opts.server, opts.token, opts.channel, {
-    kind: "status",
-    state: "blocked",
-    note,
-    mentions: [],
-    blocked_reason: note,
-  });
-}
-
 export function createSdkRunner(opts: SdkRunnerOptions): NonNullable<ServeOptions["runCommand"]> {
   let codexPromise: Promise<CodexLike> | null = null;
   let thread: ThreadLike | null = null;
@@ -666,15 +655,8 @@ export function createSdkRunner(opts: SdkRunnerOptions): NonNullable<ServeOption
         opts.workdir,
         `${new Date(now).toISOString()} seq=${frame.seq} sid=${shortSid(threadId)} duration_ms=${now - started} status=error error=${JSON.stringify(message.slice(0, 500))}`,
       );
-      const note = `builtin codex-sdk runner blocked: ${message}; log: ${join(opts.workdir, RUNNER_LOG_FILE)}`;
-      await post(opts.server, opts.token, opts.channel, {
-        kind: "status",
-        state: "blocked",
-        note,
-        mentions: [],
-        blocked_reason: note,
-      });
-      throw new WakeBlockedError(note);
+      // 同上：只回报失败，最终 blocked 由 runServe 统一发一次
+      throw new WakeBlockedError(`builtin codex-sdk runner blocked: ${message}; log: ${join(opts.workdir, RUNNER_LOG_FILE)}`);
     }
   };
 
@@ -730,9 +712,10 @@ export function createBuiltinRunner(opts: BuiltinRunnerOptions): NonNullable<Ser
         opts.workdir,
         `${new Date(now).toISOString()} seq=${frame.seq} sid=${shortSid(oldSid)} duration_ms=${now - started} exit=${run.result.code}`,
       );
-      const note = `builtin ${opts.harness} runner blocked: exit code ${run.result.code}; log: ${join(opts.workdir, RUNNER_LOG_FILE)}`;
-      await postBlocked(opts, frame, note);
-      throw new WakeBlockedError(note);
+      // 只回报失败信号，不发频道：外层还要重试，瞬态失败不该把频道标成 blocked，
+      // 每次尝试发一条更会给 loop guard 上膛（worker/src/do.ts:2582 对 status 也计数）。
+      // 最终那一条 blocked 由 runServe 在预算耗尽时统一发（#206 门禁 P1②）。
+      throw new WakeBlockedError(`builtin ${opts.harness} runner blocked: exit code ${run.result.code}; log: ${join(opts.workdir, RUNNER_LOG_FILE)}`);
     }
 
     finalSid = run.sessionId;
@@ -741,9 +724,7 @@ export function createBuiltinRunner(opts: BuiltinRunnerOptions): NonNullable<Ser
         opts.workdir,
         `${new Date(now).toISOString()} seq=${frame.seq} sid=unknown duration_ms=${now - started} exit=${exitCode ?? 0} missing_session_id=true`,
       );
-      const note = `builtin ${opts.harness} runner blocked: no session id parsed; log: ${join(opts.workdir, RUNNER_LOG_FILE)}`;
-      await postBlocked(opts, frame, note);
-      throw new WakeBlockedError(note);
+      throw new WakeBlockedError(`builtin ${opts.harness} runner blocked: no session id parsed; log: ${join(opts.workdir, RUNNER_LOG_FILE)}`);
     }
 
     const wakes = prior && !forked ? prior.wakes + 1 : 1;
@@ -769,9 +750,7 @@ export function createBuiltinRunner(opts: BuiltinRunnerOptions): NonNullable<Ser
         opts.workdir,
         `${new Date(now).toISOString()} seq=${frame.seq} sid=${shortSid(finalSid)} attach_error=${JSON.stringify(message)}`,
       );
-      const note = `builtin ${opts.harness} runner blocked: ${message}`;
-      await postBlocked(opts, frame, note);
-      throw new WakeBlockedError(note);
+      throw new WakeBlockedError(`builtin ${opts.harness} runner blocked: ${message}`);
     }
     await post(opts.server, opts.token, opts.channel, {
       kind: "message",
@@ -1227,7 +1206,11 @@ export async function runServe(o: ServeOptions): Promise<number> {
               blocked_reason: note,
             });
           } catch (e) {
-            out(`  放弃通告发送失败: ${e instanceof Error ? e.message : String(e)}`);
+            // 通告发不出去 = 没宣告过 = 没了结。此时清欠账 + ack 就是恢复 #118 的静默丢失。
+            // 一个连自己喊不出救命的 supervisor，没有任何理由继续消费消息队列：响亮地死，让人发现。
+            out(`  放弃通告发送失败，欠账保留、游标不动、退出: ${e instanceof Error ? e.message : String(e)}`);
+            code = EXIT_WAKE_UNANNOUNCED;
+            break;
           }
           setStuck(null); // 放弃也是一种「了结」：宣告过了，才允许推进游标
         }

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -17,7 +17,7 @@ import { isAbsolute, join } from "node:path";
 import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
 import { readAccount } from "../account";
 import { connect } from "../client";
-import { loadCursor, loadRevCursor, resolveChannel, saveCursor, saveRevCursor } from "../config";
+import { clearStuck, loadCursor, loadRevCursor, loadStuck, resolveChannel, saveCursor, saveRevCursor, saveStuck, type StuckWake } from "../config";
 import { formatMsg } from "../format";
 import { ensureFreshAccess, resolveAuthDetailed, type ResolvedAuthDetailed } from "../oidc-cli";
 import {
@@ -34,6 +34,21 @@ import { buildContext } from "./status";
 
 const PROTOCOL_REMINDER =
   "被 @ 唤起：先读本文件 charter 了解频道约定；若发现 charter 与频道现状矛盾，视为一个待办上报。需要更多上下文再 `party history <channel 字段的频道>`；需要产出结论时，先用 `party send --reply-to <seq>` 把 final synthesis 发回频道，再 status done；别只回本地。";
+
+// 唤醒未送达（runner 非零退出 / 无 session id / SDK 抛错 / [attach] 被拒）。
+// 四种 runner 统一抛它：调用方据此判断「这条 @ 没进过模型」，从而不推进游标。
+export class WakeBlockedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "WakeBlockedError";
+  }
+}
+
+const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+// 有界重放（#198）：同一条 seq 连续送达失败到顶就响亮放弃，既不无限重放也不静默丢弃
+const DEFAULT_MAX_WAKE_ATTEMPTS = 3;
+const DEFAULT_WAKE_RETRY_DELAY_MS = 500;
 
 // context file 里附带的最近频道消息条数上限（冷起的 runner 不用先跑 history 也有基本上下文）
 const RECENT_MAX = 20;
@@ -183,7 +198,7 @@ export function writeContextFile(
   return path;
 }
 
-const SERVE_FLAGS = ["channel", "on-mention", "all", "runner", "workdir", "repo", "auto-upgrade", "profile", "profile-once", "profile-poll-interval"];
+const SERVE_FLAGS = ["channel", "on-mention", "all", "runner", "workdir", "repo", "auto-upgrade", "replay-backlog", "profile", "profile-once", "profile-poll-interval"];
 const HELP = `usage: party serve [channel|--channel C] (--on-mention "<cmd>" | --runner codex|claude|codex-sdk) [--all]
        party serve --profile <owner>/<handle>
 
@@ -199,6 +214,11 @@ Options:
   --repo URL           clone into workdir/repo once, then git pull --ff-only before each wake
   --profile ref        run the reusable project-agent profile as one resident daemon across all invites
   --auto-upgrade       between wakes, if a newer party binary is on disk, re-exec it (issue #45)
+  --replay-backlog     on attach, replay the offline backlog one wake per message
+                       (default: skip the backlog, advance the cursor, and print
+                       how many were skipped — serve wakes only for messages that
+                       arrive AFTER it attaches, issue #193. An undelivered wake
+                       (stuck, issue #198) is a debt, not backlog: it always replays.)
   --all                run for every non-self message, not only @mentions`;
 
 export interface ServeOptions {
@@ -209,9 +229,20 @@ export interface ServeOptions {
   sinceRev?: number; // 修订游标（hello.since_rev）
   cmd: string;
   mentionsOnly: boolean;
+  // 挂载时是否跳过离线积压（#193）。默认 true：serve 是唤醒 supervisor，不是补偿队列。
+  // 但「积压」与「欠账」是两回事（#198）：跳过的只能是**已离线堆积、从未送达**的历史；
+  // 送达失败被钉住的 stuck 无论多旧都必须重放，否则 #118 救下的那条 @ 会被这里吃掉。
+  skipBacklog?: boolean;
   builtinRunner?: BuiltinRunnerOptions;
   onCursor?: (cursor: number) => void;
   onRevCursor?: (revCursor: number) => void;
+  /** 上次进程留下的欠账（#198）：崩溃前失败了几次，重启后接着数。 */
+  stuck?: StuckWake | null;
+  onStuck?: (stuck: StuckWake | null) => void;
+  /** 有界重放：同一条 seq 连续送达失败上限，到顶就响亮放弃。 */
+  maxWakeAttempts?: number;
+  wakeRetryDelayMs?: number;
+  post?: typeof postMessage;
   // 测试注入点：默认用 sh -c 起子进程
   runCommand?: (
     frame: MsgFrame,
@@ -643,6 +674,7 @@ export function createSdkRunner(opts: SdkRunnerOptions): NonNullable<ServeOption
         mentions: [],
         blocked_reason: note,
       });
+      throw new WakeBlockedError(note);
     }
   };
 
@@ -698,12 +730,9 @@ export function createBuiltinRunner(opts: BuiltinRunnerOptions): NonNullable<Ser
         opts.workdir,
         `${new Date(now).toISOString()} seq=${frame.seq} sid=${shortSid(oldSid)} duration_ms=${now - started} exit=${run.result.code}`,
       );
-      await postBlocked(
-        opts,
-        frame,
-        `builtin ${opts.harness} runner blocked: exit code ${run.result.code}; log: ${join(opts.workdir, RUNNER_LOG_FILE)}`,
-      );
-      return;
+      const note = `builtin ${opts.harness} runner blocked: exit code ${run.result.code}; log: ${join(opts.workdir, RUNNER_LOG_FILE)}`;
+      await postBlocked(opts, frame, note);
+      throw new WakeBlockedError(note);
     }
 
     finalSid = run.sessionId;
@@ -712,12 +741,9 @@ export function createBuiltinRunner(opts: BuiltinRunnerOptions): NonNullable<Ser
         opts.workdir,
         `${new Date(now).toISOString()} seq=${frame.seq} sid=unknown duration_ms=${now - started} exit=${exitCode ?? 0} missing_session_id=true`,
       );
-      await postBlocked(
-        opts,
-        frame,
-        `builtin ${opts.harness} runner blocked: no session id parsed; log: ${join(opts.workdir, RUNNER_LOG_FILE)}`,
-      );
-      return;
+      const note = `builtin ${opts.harness} runner blocked: no session id parsed; log: ${join(opts.workdir, RUNNER_LOG_FILE)}`;
+      await postBlocked(opts, frame, note);
+      throw new WakeBlockedError(note);
     }
 
     const wakes = prior && !forked ? prior.wakes + 1 : 1;
@@ -743,8 +769,9 @@ export function createBuiltinRunner(opts: BuiltinRunnerOptions): NonNullable<Ser
         opts.workdir,
         `${new Date(now).toISOString()} seq=${frame.seq} sid=${shortSid(finalSid)} attach_error=${JSON.stringify(message)}`,
       );
-      await postBlocked(opts, frame, `builtin ${opts.harness} runner blocked: ${message}`);
-      return;
+      const note = `builtin ${opts.harness} runner blocked: ${message}`;
+      await postBlocked(opts, frame, note);
+      throw new WakeBlockedError(note);
     }
     await post(opts.server, opts.token, opts.channel, {
       kind: "message",
@@ -934,6 +961,8 @@ export async function runProfileServe(opts: ProfileServeOptions): Promise<number
       token: child.token,
       channel,
       since: loadCursor(channel),
+      stuck: loadStuck(channel),
+      onStuck: (st) => (st === null ? clearStuck(channel) : saveStuck(channel, st)),
       sinceRev: loadRevCursor(channel),
       cmd: "",
       mentionsOnly: opts.mentionsOnly,
@@ -1041,7 +1070,18 @@ export async function runServe(o: ServeOptions): Promise<number> {
     onRevCursor: o.onRevCursor,
   });
 
+  const skipBacklog = o.skipBacklog !== false; // 默认跳过离线积压（#193）
+  // 挂载那一刻的频道水位（welcome.last_seq），只在首个 welcome 记一次。
+  let attachHead: number | null = null;
   let self = "";
+  // 欠账（#198）：这条 @ 送达失败、从没进过模型。跨进程持久，重启后接着数重试次数。
+  let stuck: StuckWake | null = o.stuck ?? null;
+  const maxAttempts = Math.max(1, o.maxWakeAttempts ?? DEFAULT_MAX_WAKE_ATTEMPTS);
+  const retryDelayMs = o.wakeRetryDelayMs ?? DEFAULT_WAKE_RETRY_DELAY_MS;
+  const setStuck = (next: StuckWake | null) => {
+    stuck = next;
+    o.onStuck?.(next);
+  };
   let code = 0;
   let advertised = false;
   let charter: ChannelCharter | null = o.charter ?? null;
@@ -1076,6 +1116,21 @@ export async function runServe(o: ServeOptions): Promise<number> {
     for await (const frame of conn.frames) {
       if (frame.type === "welcome") {
         self = frame.self;
+        // 首个 welcome：定格挂载水位，并就积压去留告知（stderr）。知情权给 agent，决定权给人。
+        if (attachHead === null) {
+          attachHead = frame.last_seq;
+          const pending = Math.max(0, attachHead - o.since);
+          if (pending > 0) {
+            const range = `seq ${o.since + 1}..${attachHead}`;
+            const debt = stuck !== null && stuck.seq <= attachHead ? ` 欠账 seq=${stuck.seq} 不在跳过之列，将重放（#198）。` : "";
+            out(
+              skipBacklog
+                ? `serve: 跳过 ${pending} 条离线积压（${range}）——不逐条唤醒 runner。${debt}` +
+                    ` 查看：party history ${o.channel}；要逐条重放请重启并加 --replay-backlog`
+                : `serve: --replay-backlog：将逐条重放 ${pending} 条离线积压（${range}），每条唤醒一次 runner（可能重放副作用）`,
+            );
+          }
+        }
         if (o.statusline === true) {
           writeStatuslineCache({
             ...localStatuslineBase(o.channel),
@@ -1118,29 +1173,73 @@ export async function runServe(o: ServeOptions): Promise<number> {
       // fresh = 游标之上的新消息。历史修订快照会穿透去重被重放（seq 早已消费过），
       // 它们不是新唤醒——不 fresh 就绝不触发 runner（否则旧 @ 被编辑一次，每次重连都重跑一遍）
       const fresh = frame.seq > conn.cursor;
-      const qualifies = fresh && !fromSelf && (!o.mentionsOnly || frame.mentions.includes(self));
+      // 离线积压（seq <= 挂载水位）跳过模式下不唤醒：照常 ack + 进 recent，但不拉起 runner（#193）。
+      // 唯一例外：**欠账**。它送达失败过，从没进过模型——它不是积压，是我们欠着的（#198 约束②）。
+      // 少了这个例外，#118 特意不 ack 保下来的那条 @ 会在重连后被当成积压跳掉，净效果等于没修。
+      const isDebt = stuck !== null && frame.seq === stuck.seq;
+      const isBacklog = skipBacklog && attachHead !== null && frame.seq <= attachHead && !isDebt;
+      const qualifies = fresh && !fromSelf && !isBacklog && (!o.mentionsOnly || frame.mentions.includes(self));
       if (qualifies) {
         out(`▶ ${formatMsg(frame)}`);
         // 串行：本条命令跑完再消费下一帧（新帧此间缓冲在 FrameQueue），避免并发唤起互相抢
-        try {
-          const cliUpgrade = upgradeNotice(o.autoUpgrade === true, o.upgradeDeps);
-          await run(frame, {
-            cmd: o.cmd,
-            channel: o.channel,
-            self,
-            recent: recent.slice(),
-            charter,
-            projectAgent: o.projectAgent ?? null,
-            cliUpgrade,
-          });
-        } catch (e) {
-          out(`  命令失败: ${e instanceof Error ? e.message : String(e)}`);
+        // 有界重试（#198）：同一条 seq 最多 maxAttempts 次。前一个进程崩在第 k 次，这里从 k 接着数。
+        const priorAttempts = stuck?.seq === frame.seq ? stuck.attempts : 0;
+        let lastError = "";
+        let delivered = false;
+        for (let attempt = priorAttempts + 1; attempt <= maxAttempts; attempt++) {
+          try {
+            const cliUpgrade = upgradeNotice(o.autoUpgrade === true, o.upgradeDeps);
+            await run(frame, {
+              cmd: o.cmd,
+              channel: o.channel,
+              self,
+              recent: recent.slice(),
+              charter,
+              projectAgent: o.projectAgent ?? null,
+              cliUpgrade,
+            });
+            delivered = true;
+            break;
+          } catch (e) {
+            lastError = e instanceof Error ? e.message : String(e);
+            out(`  命令失败 (${attempt}/${maxAttempts}): ${lastError}`);
+            // 先落盘再重试：此刻进程崩掉，重启后不会把已经烧掉的次数忘干净
+            setStuck({ seq: frame.seq, attempts: attempt, last_error: lastError });
+            if (attempt < maxAttempts && retryDelayMs > 0) await delay(retryDelayMs);
+          }
+        }
+        if (delivered) {
+          if (stuck !== null) setStuck(null); // 了结：欠账清掉
+        } else {
+          // 有界重放到顶：显式放弃，但必须响亮留痕——静默丢弃正是 #118 要修的东西。
+          // 没有 CLI flag，所以重试预算与退避必须**在频道里可见**：把常数藏进源码是不诚实的。
+          const note =
+            `wake undelivered, giving up: seq=${frame.seq}; ` +
+            `attempts=${maxAttempts}/${maxAttempts}; retry_delay_ms=${retryDelayMs}; ` +
+            `last error: ${lastError}`;
+          out(`  ${note}`);
+          try {
+            await (o.post ?? postMessage)(o.server, o.token, o.channel, {
+              kind: "status",
+              state: "blocked",
+              note,
+              mentions: [],
+              blocked_reason: note,
+            });
+          } catch (e) {
+            out(`  放弃通告发送失败: ${e instanceof Error ? e.message : String(e)}`);
+          }
+          setStuck(null); // 放弃也是一种「了结」：宣告过了，才允许推进游标
         }
       }
       // 触发消息本身不进 recent（它就是 context 主体）；自己的/未 @ 的都算上下文
       recent.push(frame);
       if (recent.length > RECENT_MAX) recent.shift();
-      // 处理（或跳过）后才推进游标，退出时未消费的留给下次补拉
+      // 游标只表达「已了结」（#198）：走到这里，这条唤醒要么送达成功、要么有界重试耗尽后
+      // **宣告过**放弃——两者都是了结，都该推进游标。
+      // 欠账不会活着走到这一行：它只可能在上面的重试循环里随进程一起死掉，那时游标压根没动，
+      // 下次 attach 从 cursor 续，这条 @ 会被重放（attempts 从盘上接着数）。
+      // 不要在这里加 `if (stuck === null)` 守卫——变异测试证明它守不住任何东西（死代码）。
       conn.ack(frame.seq);
       if (o.statusline === true) {
         writeStatuslineCache({
@@ -1185,7 +1284,7 @@ export async function run(argv: string[]): Promise<number> {
     console.log(HELP);
     return 0;
   }
-  const { positionals, flags } = parseArgs(argv, { booleans: ["all", "auto-upgrade", "profile-once"] });
+  const { positionals, flags } = parseArgs(argv, { booleans: ["all", "auto-upgrade", "replay-backlog", "profile-once"] });
   const auth = await resolveAuthDetailed();
   if (!auth.server || !auth.token) {
     console.error("no config, run: party login or party init --server URL --token T");
@@ -1271,9 +1370,12 @@ export async function run(argv: string[]): Promise<number> {
     token,
     channel,
     since: loadCursor(channel),
+    stuck: loadStuck(channel),
+    onStuck: (st) => (st === null ? clearStuck(channel) : saveStuck(channel, st)),
     sinceRev: loadRevCursor(channel),
     cmd: cmd ?? "",
     mentionsOnly: flags.all !== true,
+    skipBacklog: flags["replay-backlog"] !== true, // 默认跳过积压；--replay-backlog 才重放（#193）
     onCursor: (c) => saveCursor(channel, c),
     onRevCursor: (r) => saveRevCursor(channel, r),
     advertise: () => advertiseServeWake(auth, channel),

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -584,13 +584,26 @@ export function createSdkRunner(opts: SdkRunnerOptions): NonNullable<ServeOption
     mkdirSync(opts.workdir, { recursive: true });
     const sessionPath = join(opts.workdir, RUNNER_SESSION_FILE);
     const prior = readSdkSession(sessionPath);
-    const client = await codex();
+    // 这一段全在 thread.run() **之前**：连不上 SDK、拿不到 thread —— 模型确定还没跑。
+    // 这类失败标为可重试（EAI_AGAIN 这种瞬态抖动，第二次就成了）。
+    // thread.run() 之后的任何失败都不可重试（模型可能已经跑过、已经产生副作用）。
+    const beforeModel = async <T>(fn: () => Promise<T> | T): Promise<T> => {
+      try {
+        return await fn();
+      } catch (e) {
+        throw new WakeBlockedError(
+          `builtin codex-sdk runner blocked before the model started: ${e instanceof Error ? e.message : String(e)}`,
+          true,
+        );
+      }
+    };
+    const client = await beforeModel(() => codex());
     if (prior) {
-      thread = await client.resumeThread(prior.thread_id);
+      thread = await beforeModel(() => client.resumeThread(prior.thread_id));
       session = prior;
       return { thread, session };
     }
-    thread = await client.startThread();
+    thread = await beforeModel(() => client.startThread());
     const threadId = sdkThreadId(thread);
     // thread id 懒初始化：拿不到就先不落 session 文件，等首个 run() 之后补写
     session = threadId
@@ -676,8 +689,14 @@ export function createSdkRunner(opts: SdkRunnerOptions): NonNullable<ServeOption
         opts.workdir,
         `${new Date(now).toISOString()} seq=${frame.seq} sid=${shortSid(threadId)} duration_ms=${now - started} status=error error=${JSON.stringify(message.slice(0, 500))}`,
       );
-      // 同上：只回报失败，最终 blocked 由 runServe 统一发一次
-      throw new WakeBlockedError(`builtin codex-sdk runner blocked: ${message}; log: ${join(opts.workdir, RUNNER_LOG_FILE)}`);
+      // 同上：只回报失败，最终 blocked 由 runServe 统一发一次。
+      // 模型前的失败（ensureThread 抛的 WakeBlockedError.retriable=true）必须把可重试性
+      // 透传出去，否则一次 EAI_AGAIN 就被当成「模型可能跑过」而立刻放弃（#206 门禁 P1③）。
+      const retriable = err instanceof WakeBlockedError && err.retriable;
+      throw new WakeBlockedError(
+        `builtin codex-sdk runner blocked: ${message}; log: ${join(opts.workdir, RUNNER_LOG_FILE)}`,
+        retriable,
+      );
     }
   };
 
@@ -696,7 +715,6 @@ export function createBuiltinRunner(opts: BuiltinRunnerOptions): NonNullable<Ser
     const sessionPath = join(opts.workdir, RUNNER_SESSION_FILE);
     const prior = readSession(sessionPath, opts.harness);
     let oldSid = prior?.session_id ?? null;
-    let forked = false;
     let exitCode: number | null = null;
     let finalSid = oldSid;
     const post = opts.post ?? postMessage;
@@ -713,13 +731,13 @@ export function createBuiltinRunner(opts: BuiltinRunnerOptions): NonNullable<Ser
     const contextFile = writeContextFile(frame, ctx.channel, ctx.self, ctx.recent, ctx.charter ?? null, ctx.projectAgent ?? null, ctx.cliUpgrade ?? null);
     const prompt = readFileSync(contextFile, "utf8");
 
-    let run = await runHarness(opts, prompt, oldSid, cwd, env, frame.seq);
+    // resume 非零退出**不能**再 cold-start 重跑（#206 门禁 P1②）：
+    // 那次 resume 可能已经执行了模型、push 过、开过 PR，只是最后一步非零。
+    // 内部 fallback 会绕过外层的 retriable=false，把副作用做第二遍。
+    // 只有能**结构化证明模型没启动**的错误才允许换新 session——目前没有这样的信号，
+    // 所以一律停在这里，由外层宣告放弃。
+    const run = await runHarness(opts, prompt, oldSid, cwd, env, frame.seq);
     exitCode = run.result.code;
-    if (oldSid && run.result.code !== 0) {
-      forked = true;
-      run = await runHarness(opts, prompt, null, cwd, env, frame.seq);
-      exitCode = run.result.code;
-    }
 
     try {
       unlinkSync(contextFile);
@@ -748,20 +766,17 @@ export function createBuiltinRunner(opts: BuiltinRunnerOptions): NonNullable<Ser
       throw new WakeBlockedError(`builtin ${opts.harness} runner blocked: no session id parsed; log: ${join(opts.workdir, RUNNER_LOG_FILE)}`);
     }
 
-    const wakes = prior && !forked ? prior.wakes + 1 : 1;
+    const wakes = prior ? prior.wakes + 1 : 1;
     writeSession(sessionPath, {
       harness: opts.harness,
       session_id: finalSid,
-      created_at: prior && !forked ? prior.created_at : now,
+      created_at: prior ? prior.created_at : now,
       last_wake_ts: now,
       wakes,
     });
 
-    const marker = oldSid
-      ? forked
-        ? `[session reset: ${shortSid(oldSid)} → ${shortSid(finalSid)}]`
-        : null
-      : `[session start: ${shortSid(finalSid)}]`;
+    // resume 非零不再 cold-start（#206 门禁 P1②），所以不存在 session reset 这条路径了。
+    const marker = oldSid ? null : `[session start: ${shortSid(finalSid)}]`;
     let body: string;
     try {
       body = finalMessageBody(run.text, marker);
@@ -782,8 +797,7 @@ export function createBuiltinRunner(opts: BuiltinRunnerOptions): NonNullable<Ser
 
     appendRunnerLog(
       opts.workdir,
-      `${new Date(now).toISOString()} seq=${frame.seq} sid=${shortSid(finalSid)} duration_ms=${now - started} exit=${exitCode ?? 0}` +
-        (forked ? ` fork=${shortSid(oldSid)}->${shortSid(finalSid)}` : ""),
+      `${new Date(now).toISOString()} seq=${frame.seq} sid=${shortSid(finalSid)} duration_ms=${now - started} exit=${exitCode ?? 0}`,
     );
   };
 }
@@ -872,7 +886,30 @@ export async function prepareProfileChannelWorkspace(opts: PrepareProfileWorkspa
   return { runnerWorkdir, channelWorkdir: worktreeDir };
 }
 
+/**
+ * profile 子 serve 继承的语义（#206 门禁 P2）。
+ * `--profile --replay-backlog` 原本被 parseArgs 接受，却没传给子 serve：
+ * 用户明确要求重放，profile 模式下却静默跳过——flag 接受了但不起作用。
+ */
+export function profileChildServeOptions(base: {
+  server: string;
+  token: string;
+  channel: string;
+  mentionsOnly: boolean;
+  skipBacklog?: boolean;
+}): Pick<ServeOptions, "server" | "token" | "channel" | "mentionsOnly" | "skipBacklog"> {
+  return {
+    server: base.server,
+    token: base.token,
+    channel: base.channel,
+    mentionsOnly: base.mentionsOnly,
+    ...(base.skipBacklog === undefined ? {} : { skipBacklog: base.skipBacklog }),
+  };
+}
+
 export interface ProfileServeOptions {
+  /** 由 --replay-backlog 决定；透传给每个频道的子 serve。 */
+  skipBacklog?: boolean;
   server: string;
   humanToken: string;
   ownerAccount: string;
@@ -957,6 +994,13 @@ export async function runProfileServe(opts: ProfileServeOptions): Promise<number
       projectAgentChildName(profile.handle, channel),
     );
     const serveOpts: ServeOptions = {
+      ...profileChildServeOptions({
+        server: opts.server,
+        token: child.token,
+        channel,
+        mentionsOnly: opts.mentionsOnly,
+        skipBacklog: opts.skipBacklog,
+      }),
       server: opts.server,
       token: child.token,
       channel,
@@ -1180,7 +1224,12 @@ export async function runServe(o: ServeOptions): Promise<number> {
       const isDebt = stuck !== null && frame.seq === stuck.seq;
       const isBacklog = skipBacklog && attachHead !== null && frame.seq <= attachHead;
       const passesFilter = !fromSelf && !isBacklog && (!o.mentionsOnly || frame.mentions.includes(self));
-      const qualifies = fresh && (isDebt || passesFilter);
+      // 欠账未了结时，**后续的任何消息都不许先跑**（#206 门禁 P1①）。
+      // 反例：cursor=3、欠账 seq=4、head=6 未重放它、新 seq=7 进来 → 旧实现跑了 7、
+      // 把游标推到 7，并在成功路径上无条件 setStuck(null)，把 seq=4 的欠账顺手清掉。
+      // 欠着的那条必须先还：要么被重放并了结，要么有界重试耗尽后宣告放弃。
+      const blockedByDebt = stuck !== null && !isDebt;
+      const qualifies = fresh && !blockedByDebt && (isDebt || passesFilter);
       if (qualifies) {
         out(`▶ ${formatMsg(frame)}`);
         // 串行：本条命令跑完再消费下一帧（新帧此间缓冲在 FrameQueue），避免并发唤起互相抢
@@ -1218,7 +1267,17 @@ export async function runServe(o: ServeOptions): Promise<number> {
           }
         }
         if (delivered) {
-          if (stuck !== null) setStuck(null); // 了结：欠账清掉
+          // 只清**本帧**的欠账。别的 seq 的欠账不是它能了结的（#206 门禁 P1①）。
+          //
+          // 注意不能写成 `if (isDebt)`：isDebt 是进入本帧时算的，而重试过程中
+          // setStuck 会把 stuck 设成本帧 —— 那时 isDebt 仍是 false，欠账就清不掉了。
+          // （我试过，被「transient failure is retried」和「each failed attempt
+          // persists stuck」两条既有测试当场逮住。）
+          //
+          // 这里的 seq 校验在当前 blockedByDebt 守卫之下**不可达**（变异掉它零条测试变红）。
+          // 它是第二道闸：一旦有人放宽 blockedByDebt，这行会挡住「A 的成功清掉 B 的欠账」。
+          // 不删，理由写在这里。
+          if (stuck !== null && stuck.seq === frame.seq) setStuck(null);
         } else {
           // 有界重放到顶：显式放弃，但必须响亮留痕——静默丢弃正是 #118 要修的东西。
           // 没有 CLI flag，所以重试预算与退避必须**在频道里可见**：把常数藏进源码是不诚实的。
@@ -1352,6 +1411,7 @@ export async function run(argv: string[]): Promise<number> {
       ownerAccount: profileRef.owner,
       handle: profileRef.handle,
       mentionsOnly: flags.all !== true,
+      skipBacklog: flags["replay-backlog"] !== true,
       once: flags["profile-once"] === true,
       pollIntervalMs,
     });

--- a/cli/src/commands/watch.ts
+++ b/cli/src/commands/watch.ts
@@ -129,6 +129,11 @@ export async function runWatch(o: WatchOptions): Promise<number> {
       if (frame.type === "welcome") {
         self = frame.self;
         lastSeq = frame.last_seq;
+        // 服务端一直知道我读到第几条（welcome.read_cursors），CLI 却从来没读过它（#172）。
+        // 后果：新工作区本地游标为 0 → 每次 --once 烧掉一整次 agent 唤醒，只为读一条远古消息。
+        // 单调快进，绝不倒退：本地领先时以本地为准（本地 ack 过但服务端 seen 没发出去的情形）。
+        const serverRead = frame.read_cursors?.find((c) => c.name === self)?.last_seen_seq ?? 0;
+        if (serverRead > conn.cursor) conn.ack(serverRead);
         if (o.statusline === true) {
           writeStatuslineCache({
             ...localStatuslineBase(o.channel),
@@ -175,9 +180,19 @@ export async function runWatch(o: WatchOptions): Promise<number> {
       // 只在 follow 下发；--once / 非 follow 是「查有没有 @ 我再退」的事件驱动路径，不算逐条已读，
       // 其送达/唤醒由 wake 回执表达（不假装 agent 逐条读了频道）。只对游标之上的新消息发。
       if (o.follow && fresh && msg.seq > 0) conn.send({ type: "seen", seq: msg.seq });
-      // --once：第一条匹配的【新】消息即完成——游标已推进，进程退出就是 harness 的唤醒信号
+      // --once：第一条匹配的【新】消息即完成——游标已推进，进程退出就是 harness 的唤醒信号。
+      // 服务端从游标开始重放，所以这条是**最旧**的未读 @，不是最新的（#199）。
+      // 醒在最旧是对的（醒在最新会丢消息），但必须把落后量说出来：否则被唤醒的 agent
+      // 会以为手上这条就是频道现状，照着几小时前的上下文回话，而身后还压着一摞没读的。
       if (o.once && qualifies && fresh) {
         onceDone = true;
+        const behind = Math.max(0, lastSeq - msg.seq);
+        if (behind > 0) {
+          out(
+            `watch: 唤醒于 seq=${msg.seq}（最旧的未读 @），落后 ${behind} 条，head=${lastSeq}。` +
+              ` 这不是最新消息——补上下文：party history ${o.channel} --since ${msg.seq}`,
+          );
+        }
         break;
       }
       // 补拉排空（seq 追平 welcome.last_seq）且已有输出即视为收到新消息；自己的消息也参与排空判定

--- a/cli/src/commands/watch.ts
+++ b/cli/src/commands/watch.ts
@@ -129,11 +129,11 @@ export async function runWatch(o: WatchOptions): Promise<number> {
       if (frame.type === "welcome") {
         self = frame.self;
         lastSeq = frame.last_seq;
-        // 服务端一直知道我读到第几条（welcome.read_cursors），CLI 却从来没读过它（#172）。
-        // 后果：新工作区本地游标为 0 → 每次 --once 烧掉一整次 agent 唤醒，只为读一条远古消息。
-        // 单调快进，绝不倒退：本地领先时以本地为准（本地 ack 过但服务端 seen 没发出去的情形）。
-        const serverRead = frame.read_cursors?.find((c) => c.name === self)?.last_seen_seq ?? 0;
-        if (serverRead > conn.cursor) conn.ack(serverRead);
+        // 不要用 welcome.read_cursors 快进 --once 的游标（#172 的诱人错解）。
+        // read cursor 是**身份级「已读」**：protocol.ts 明确「网页 tab / serve / watch --follow
+        // 读到就回 seen；webhook / watch --once 型事件驱动 agent 不发 seen，其送达状态由
+        // wake 回执表达」。同身份的网页标签页读过一条 @，不代表这个 supervisor 被它唤醒过。
+        // 拿它 ack 会静默跳过从未送达的 mention。#172 需要一个独立的 wake cursor。
         if (o.statusline === true) {
           writeStatuslineCache({
             ...localStatuslineBase(o.channel),

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -35,9 +35,22 @@ export interface ConfigWithSource {
   source: ConfigSourceInfo;
 }
 
+/**
+ * 欠账（#198）：一条送达失败、从没进过模型的 @。
+ * 它和 cursor 是**两个语义**：cursor 说「这条我了结了」（处理成功，或主动宣告放弃），
+ * stuck 说「这条我欠着」。只存内存不算修复——runner 崩溃常常连进程一起带走。
+ */
+export interface StuckWake {
+  seq: number;
+  /** 连续送达失败次数。有界重放靠它：超过上限就响亮放弃，绝不静默丢弃。 */
+  attempts: number;
+  last_error?: string;
+}
+
 export interface ChannelCursor {
   cursor: number;
   rev_cursor?: number;
+  stuck?: StuckWake;
 }
 
 export interface WorkspaceState {
@@ -287,6 +300,23 @@ export function saveCursor(channel: string, cursor: number, cwd?: string): void 
   const cur = channelCursor(readState(cwd), channel);
   if (cursor <= cur.cursor) return; // 单调，不回退
   putChannelCursor(channel, { ...cur, cursor }, cwd);
+}
+
+/** 读欠账（#198）。没有欠账返回 null。 */
+export function loadStuck(channel: string, cwd?: string): StuckWake | null {
+  return channelCursor(readState(cwd), channel).stuck ?? null;
+}
+
+/** 写欠账。和 cursor 并列，互不覆盖。 */
+export function saveStuck(channel: string, stuck: StuckWake, cwd?: string): void {
+  const cur = channelCursor(readState(cwd), channel);
+  putChannelCursor(channel, { ...cur, stuck }, cwd);
+}
+
+/** 了结欠账：送达成功，或有界重试耗尽后显式放弃。 */
+export function clearStuck(channel: string, cwd?: string): void {
+  const { stuck: _dropped, ...rest } = channelCursor(readState(cwd), channel);
+  putChannelCursor(channel, rest, cwd);
 }
 
 /**

--- a/cli/test/mock-server.ts
+++ b/cli/test/mock-server.ts
@@ -79,6 +79,13 @@ export function msgFrame(seq: number, body: string, over: Record<string, unknown
   };
 }
 
-export function welcomeFrame(lastSeq: number, self = "me") {
-  return { type: "welcome", channel: "dev", self, last_seq: lastSeq, presence: [] };
+export function welcomeFrame(lastSeq: number, self = "me", readCursors?: Array<{ name: string; last_seen_seq: number; updated_at: number }>) {
+  return {
+    type: "welcome",
+    channel: "dev",
+    self,
+    last_seq: lastSeq,
+    presence: [],
+    ...(readCursors ? { read_cursors: readCursors } : {}),
+  };
 }

--- a/cli/test/serve-failure-ack.test.ts
+++ b/cli/test/serve-failure-ack.test.ts
@@ -1,0 +1,252 @@
+// #118 + #198：唤醒失败不得静默推进游标。
+// 游标只表达「已了结」＝ 送达成功，或有界重试耗尽后**响亮地**放弃。
+// 「欠账」（送达失败、从没进过模型）由 stuck 表达，落盘，且永不被当作积压跳过。
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { EXIT_ARCHIVED, type MsgFrame } from "@agentparty/shared";
+import { createBuiltinRunner, runServe, type ServeOptions } from "../src/commands/serve";
+import type { StuckWake } from "../src/config";
+import { msgFrame, startMockServer, welcomeFrame, type MockServer } from "./mock-server";
+
+let server: MockServer | null = null;
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  server?.stop();
+  server = null;
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "ap-serve-ack-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function triggerFrame(seq = 7): MsgFrame {
+  return msgFrame(seq, "wake up", { mentions: ["me"] }) as unknown as MsgFrame;
+}
+
+function runnerCtx() {
+  return { cmd: "", channel: "dev", self: "me", recent: [] as MsgFrame[] };
+}
+
+function opts(over: Partial<ServeOptions> & { server: string }): ServeOptions & { lines: string[] } {
+  const lines: string[] = [];
+  return {
+    token: "ap_tok",
+    channel: "dev",
+    since: 0,
+    cmd: "true",
+    mentionsOnly: true,
+    out: (line) => lines.push(line),
+    lines,
+    wakeRetryDelayMs: 0,
+    ...over,
+  };
+}
+
+function closeAfterOneMention() {
+  server = startMockServer((frame, sock) => {
+    if (frame.type !== "hello") return;
+    sock.send(welcomeFrame(0, "me"));
+    setTimeout(() => sock.send(msgFrame(1, "wake up", { mentions: ["me"] })), 20);
+    setTimeout(() => sock.send({ type: "error", code: "archived", message: "done" }), 200);
+  });
+  return server;
+}
+
+describe("serve wake delivery (#118 / #198)", () => {
+  test("a transient runner failure is retried, and the cursor advances only once it lands", async () => {
+    const s = closeAfterOneMention();
+    const cursors: number[] = [];
+    const posts: string[] = [];
+    let calls = 0;
+    const o = opts({
+      server: s.url,
+      maxWakeAttempts: 3,
+      onCursor: (c) => cursors.push(c),
+      post: async (_s, _t, _c, body) => {
+        posts.push(JSON.stringify(body));
+        return { seq: 1 };
+      },
+      runCommand: async () => {
+        calls++;
+        if (calls < 3) throw new Error("runner exploded");
+      },
+    });
+
+    expect(await runServe(o)).toBe(EXIT_ARCHIVED);
+    expect(calls).toBe(3);
+    expect(cursors).toEqual([1]);
+    // 送达了就不该有 blocked 噪音
+    expect(posts.some((p) => p.includes("blocked"))).toBe(false);
+  });
+
+  test("each failed attempt persists stuck, and the cursor stays put until the wake is resolved", async () => {
+    const s = closeAfterOneMention();
+    const events: string[] = [];
+    let calls = 0;
+    const o = opts({
+      server: s.url,
+      maxWakeAttempts: 3,
+      onCursor: (c) => events.push(`cursor=${c}`),
+      onStuck: (st: StuckWake | null) => events.push(st ? `stuck=${st.seq}/${st.attempts}` : "stuck=cleared"),
+      post: async () => ({ seq: 1 }),
+      runCommand: async () => {
+        calls++;
+        if (calls < 3) throw new Error("runner exploded");
+      },
+    });
+
+    expect(await runServe(o)).toBe(EXIT_ARCHIVED);
+    // 欠账在每次失败后落盘（进程此刻崩掉也记得重试了几次），游标绝不先于送达推进
+    expect(events).toEqual(["stuck=1/1", "stuck=1/2", "stuck=cleared", "cursor=1"]);
+  });
+
+  test("after the retry budget is exhausted it gives up loudly: blocked status naming the seq, then advances", async () => {
+    const s = closeAfterOneMention();
+    const cursors: number[] = [];
+    const posts: Array<Record<string, unknown>> = [];
+    let calls = 0;
+    const o = opts({
+      server: s.url,
+      maxWakeAttempts: 2,
+      onCursor: (c) => cursors.push(c),
+      post: async (_s, _t, _c, body) => {
+        posts.push(body as Record<string, unknown>);
+        return { seq: 1 };
+      },
+      runCommand: async () => {
+        calls++;
+        throw new Error("runner binary missing");
+      },
+    });
+
+    expect(await runServe(o)).toBe(EXIT_ARCHIVED);
+    expect(calls).toBe(2); // 有界：绝不无限重放
+    const blocked = posts.find((p) => p.state === "blocked");
+    expect(blocked).toBeDefined();
+    const note = String(blocked!.note);
+    expect(note).toContain("seq=1");
+    expect(note).toContain("runner binary missing");
+    // 常数不许只活在源码里：放弃了几次、退避多久，频道上直接可见（无 CLI flag 的代价）
+    expect(note).toContain("attempts=2/2");
+    expect(note).toContain("retry_delay_ms=0");
+    // 放弃是一次「了结」——响亮留痕之后才允许推进游标
+    expect(cursors).toEqual([1]);
+  });
+
+  test("retry budget resumes from the persisted count: a crash mid-retry does not reset it", async () => {
+    const s = closeAfterOneMention();
+    const posts: Array<Record<string, unknown>> = [];
+    let calls = 0;
+    const o = opts({
+      server: s.url,
+      maxWakeAttempts: 3,
+      // 上个进程已经在这条 seq 上烧掉 2 次，崩了。重启后只剩 1 次，不是重新 3 次。
+      stuck: { seq: 1, attempts: 2, last_error: "died mid-retry" },
+      onCursor: () => {},
+      post: async (_s, _t, _c, body) => {
+        posts.push(body as Record<string, unknown>);
+        return { seq: 1 };
+      },
+      runCommand: async () => {
+        calls++;
+        throw new Error("still broken");
+      },
+    });
+
+    expect(await runServe(o)).toBe(EXIT_ARCHIVED);
+    expect(calls).toBe(1); // 不是 3——否则一个反复崩溃的 runner 每次重启都换来一整轮新预算
+    expect(posts.some((p) => p.state === "blocked")).toBe(true);
+  });
+
+  test("a blocked builtin runner signals failure to the caller instead of returning normally", async () => {
+    const posts: Array<Record<string, unknown>> = [];
+    const run = createBuiltinRunner({
+      server: "http://agentparty.test",
+      token: "ap_tok",
+      channel: "dev",
+      harness: "codex",
+      workdir: tempDir(),
+      runProcess: async () => ({ code: 3, stdout: "", stderr: "boom" }),
+      post: async (_s, _t, _c, body) => {
+        posts.push(body as Record<string, unknown>);
+        return { seq: posts.length };
+      },
+    });
+
+    // 它已经往频道发了 blocked。但它还必须告诉 runServe，
+    // 否则调用方以为这条唤醒送达了，直接 ack 掉。
+    await expect(run(triggerFrame(1), runnerCtx())).rejects.toThrow(/blocked|exit code 3/);
+    expect(posts.some((p) => p.state === "blocked")).toBe(true);
+  });
+
+  test("a succeeding runner advances the cursor and leaves no debt", async () => {
+    const s = closeAfterOneMention();
+    const cursors: number[] = [];
+    const stucks: unknown[] = [];
+    const o = opts({
+      server: s.url,
+      onCursor: (c) => cursors.push(c),
+      onStuck: (st) => stucks.push(st),
+      runCommand: async () => {},
+    });
+
+    expect(await runServe(o)).toBe(EXIT_ARCHIVED);
+    expect(cursors).toEqual([1]);
+    expect(stucks).toEqual([]);
+  });
+});
+
+describe("backlog vs debt (#193 + #198 约束②)", () => {
+  // 游标停在 3，挂载水位 6（4/5/6 是离线积压），挂上后来一条真·新消息 7
+  function backlogThenFresh() {
+    server = startMockServer((frame, sock) => {
+      if (frame.type !== "hello") return;
+      sock.send(welcomeFrame(6, "me"));
+      sock.send(msgFrame(4, "overnight A", { mentions: ["me"] }));
+      sock.send(msgFrame(5, "overnight B", { mentions: ["me"] }));
+      sock.send(msgFrame(6, "overnight C", { mentions: ["me"] }));
+      setTimeout(() => sock.send(msgFrame(7, "fresh", { mentions: ["me"] })), 40);
+      setTimeout(() => sock.send({ type: "error", code: "archived", message: "done" }), 120);
+    });
+    return server;
+  }
+
+  test("默认跳过离线积压：只对挂载后到达的消息唤醒 runner", async () => {
+    const s = backlogThenFresh();
+    const seen: number[] = [];
+    const o = opts({ server: s.url, since: 3, runCommand: async (f) => void seen.push(f.seq) });
+    expect(await runServe(o)).toBe(EXIT_ARCHIVED);
+    expect(seen).toEqual([7]);
+    expect(o.lines.some((l) => l.includes("跳过 3 条离线积压") && l.includes("seq 4..6"))).toBe(true);
+  });
+
+  test("--replay-backlog 恢复逐条重放", async () => {
+    const s = backlogThenFresh();
+    const seen: number[] = [];
+    const o = opts({ server: s.url, since: 3, skipBacklog: false, runCommand: async (f) => void seen.push(f.seq) });
+    expect(await runServe(o)).toBe(EXIT_ARCHIVED);
+    expect(seen).toEqual([4, 5, 6, 7]);
+  });
+
+  test("欠账落在积压区间里，也绝不被跳过——它不是积压，是我们欠着的", async () => {
+    const s = backlogThenFresh();
+    const seen: number[] = [];
+    const o = opts({
+      server: s.url,
+      since: 3,
+      // 上个进程在 seq 5 上送达失败、崩了。5 <= 挂载水位 6，长得跟积压一模一样。
+      stuck: { seq: 5, attempts: 1, last_error: "died mid-retry" },
+      runCommand: async (f) => void seen.push(f.seq),
+    });
+    expect(await runServe(o)).toBe(EXIT_ARCHIVED);
+    // 4/6 是积压，跳过；5 是欠账，必须重放；7 是新消息
+    expect(seen).toEqual([5, 7]);
+    expect(o.lines.some((l) => l.includes("欠账 seq=5"))).toBe(true);
+  });
+});

--- a/cli/test/serve-failure-ack.test.ts
+++ b/cli/test/serve-failure-ack.test.ts
@@ -2,11 +2,11 @@
 // 游标只表达「已了结」＝ 送达成功，或有界重试耗尽后**响亮地**放弃。
 // 「欠账」（送达失败、从没进过模型）由 stuck 表达，落盘，且永不被当作积压跳过。
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { EXIT_ARCHIVED, type MsgFrame } from "@agentparty/shared";
-import { createBuiltinRunner, runServe, WakeBlockedError, type BuiltinRunnerOptions, type RunnerProcess, type ServeOptions } from "../src/commands/serve";
+import { createBuiltinRunner, createSdkRunner, profileChildServeOptions, runServe, WakeBlockedError, type BuiltinRunnerOptions, type RunnerProcess, type ServeOptions } from "../src/commands/serve";
 import type { StuckWake } from "../src/config";
 import { msgFrame, startMockServer, welcomeFrame, type MockServer } from "./mock-server";
 
@@ -476,5 +476,188 @@ describe("重试不得重复模型副作用 (#206 门禁 P1③)", () => {
     const blocked = posts.find((p) => p.state === "blocked");
     expect(blocked).toBeDefined();
     expect(String(blocked!.note)).toContain("runner binary missing"); // 不是空字符串
+  });
+});
+
+// 门禁第三轮（190-codex-dev on PR #206）
+describe("resume 非零后不得内部 cold-start 重跑模型 (#206 门禁 P1②)", () => {
+  test("resume 返回非零 → 只调用一次 runner，不 fork 出新 session 重复副作用", async () => {
+    const workdir = tempDir();
+    writeFileSync(
+      join(workdir, "wake-session.json"),
+      JSON.stringify({ harness: "codex", session_id: "019f35d9-0000-7000-8000-000000000001", created_at: 1, last_wake_ts: 1, wakes: 3 }),
+    );
+    const calls: string[][] = [];
+    const run = createBuiltinRunner({
+      server: "http://agentparty.test",
+      token: "ap_tok",
+      channel: "dev",
+      harness: "codex",
+      workdir,
+      runProcess: async (args) => {
+        calls.push(args);
+        return { code: 9, stdout: "", stderr: "resume failed after model already pushed" };
+      },
+      post: async () => ({ seq: 1 }),
+    });
+
+    // resume 可能已经跑过模型、push 过、开过 PR，只是最后非零退出。
+    // 再 cold-start 一次就是重复那些副作用。
+    await expect(run(triggerFrame(1), runnerCtx())).rejects.toThrow();
+    expect(calls).toHaveLength(1); // 不是 2
+    expect(calls[0]!).toContain("resume");
+  });
+});
+
+describe("codex-sdk 模型前失败可重试，模型后不可 (#206 门禁 P1③)", () => {
+  test("startThread 抛错（模型还没跑）→ 标为可重试，外层再试一次就成功", async () => {
+    const s = closeAfterOneMention();
+    let starts = 0;
+    let runs = 0;
+    const o = opts({
+      server: s.url,
+      maxWakeAttempts: 3,
+      post: async () => ({ seq: 1 }),
+      runCommand: createSdkRunner({
+        server: "http://agentparty.test",
+        token: "ap_tok",
+        channel: "dev",
+        workdir: tempDir(),
+        codexFactory: () => ({
+          startThread: () => {
+            starts++;
+            if (starts === 1) throw new Error("EAI_AGAIN"); // 连服务端都没连上，模型确定没跑
+            return {
+              id: "thread_1",
+              run: async () => {
+                runs++;
+                return { final_response: "ok" };
+              },
+            };
+          },
+          resumeThread: () => {
+            throw new Error("should not resume");
+          },
+        }),
+        post: async () => ({ seq: 1 }),
+      }),
+    });
+
+    expect(await runServe(o)).toBe(EXIT_ARCHIVED);
+    expect(starts).toBe(2); // 模型前的瞬态失败重试了
+    expect(runs).toBe(1); // 模型只跑了一次
+  });
+
+  test("thread.run 抛错（模型可能已经跑过）→ 不可重试，一次即宣告放弃", async () => {
+    const s = closeAfterOneMention();
+    let runs = 0;
+    const posts: Array<Record<string, unknown>> = [];
+    const o = opts({
+      server: s.url,
+      maxWakeAttempts: 3,
+      post: async (_a, _b, _c, body) => {
+        posts.push(body as Record<string, unknown>);
+        return { seq: 1 };
+      },
+      runCommand: createSdkRunner({
+        server: "http://agentparty.test",
+        token: "ap_tok",
+        channel: "dev",
+        workdir: tempDir(),
+        codexFactory: () => ({
+          startThread: () => ({
+            id: "thread_1",
+            run: async () => {
+              runs++;
+              throw new Error("sdk exploded after the model ran");
+            },
+          }),
+          resumeThread: () => ({ id: "thread_1", run: async () => ({ final_response: "x" }) }),
+        }),
+        post: async () => ({ seq: 1 }),
+      }),
+    });
+
+    expect(await runServe(o)).toBe(EXIT_ARCHIVED);
+    expect(runs).toBe(1); // 绝不重跑模型
+    expect(posts.filter((p) => p.state === "blocked")).toHaveLength(1);
+  });
+});
+
+// 门禁反例（190-codex-dev）：cursor=3、持久欠账 seq=4、welcome head=6 但未重放 seq 4、
+// 挂载后来一条新 seq=7。旧实现会跑 seq 7、把 cursor 推到 7，**顺手清掉 seq=4 的欠账**。
+// 现有测试只发 head 内的 seq 6，被 backlog 过滤，从没走到这条路径。
+describe("后续消息不得清掉、也不得越过另一条欠账 (#206 门禁 P1①)", () => {
+  test("欠账 seq=4 未重放时，head 之后的新 seq=7 不执行、不 ack、不清账", async () => {
+    server = startMockServer((f, sock) => {
+      if (f.type !== "hello") return;
+      sock.send(welcomeFrame(6, "me")); // head=6，但服务端没重放 seq 4
+      setTimeout(() => sock.send(msgFrame(7, "@me 新消息", { mentions: ["me"] })), 30);
+      setTimeout(() => sock.send({ type: "error", code: "archived", message: "done" }), 120);
+    });
+    const seen: number[] = [];
+    const cursors: number[] = [];
+    const stucks: Array<StuckWake | null> = [];
+    const o = opts({
+      server: server.url,
+      since: 3,
+      stuck: { seq: 4, attempts: 1, last_error: "died mid-retry" },
+      onCursor: (c) => cursors.push(c),
+      onStuck: (st) => stucks.push(st),
+      post: async () => ({ seq: 1 }),
+      runCommand: async (f) => void seen.push(f.seq),
+    });
+
+    expect(await runServe(o)).toBe(EXIT_ARCHIVED);
+    expect(seen).toEqual([]); // seq 7 绝不能在欠账了结前被执行
+    expect(cursors).toEqual([]); // 游标绝不越过 seq 4
+    expect(stucks.filter((s) => s === null)).toEqual([]); // 欠账绝不被清掉
+  });
+
+  test("欠账那条重放回来 → 正常重试并了结，之后的新消息才放行", async () => {
+    server = startMockServer((f, sock) => {
+      if (f.type !== "hello") return;
+      sock.send(welcomeFrame(6, "me"));
+      sock.send(msgFrame(4, "@me 欠着的那条", { mentions: ["me"] })); // 这次重放回来了
+      setTimeout(() => sock.send(msgFrame(7, "@me 新消息", { mentions: ["me"] })), 40);
+      setTimeout(() => sock.send({ type: "error", code: "archived", message: "done" }), 140);
+    });
+    const seen: number[] = [];
+    const o = opts({
+      server: server.url,
+      since: 3,
+      stuck: { seq: 4, attempts: 1 },
+      post: async () => ({ seq: 1 }),
+      runCommand: async (f) => void seen.push(f.seq),
+    });
+
+    expect(await runServe(o)).toBe(EXIT_ARCHIVED);
+    expect(seen).toEqual([4, 7]); // 先还债，再放行
+  });
+});
+
+// 门禁 P2：`--profile --replay-backlog` 被接受，但 profile 的子 serve 没拿到这个语义。
+// 用户明确要求重放，profile 模式下却静默跳过——这是「flag 接受了但不起作用」。
+describe("profile 子 serve 继承 --replay-backlog (#206 门禁 P2)", () => {
+  test("ProfileServeOptions 带 skipBacklog 时，构造的 ServeOptions 也带上", () => {
+    // 契约层面钉住：profile 的 serveOpts 必须把 skipBacklog 透传下去
+    const opts = profileChildServeOptions({
+      server: "https://x",
+      token: "ap_child",
+      channel: "dev",
+      mentionsOnly: true,
+      skipBacklog: false,
+    });
+    expect(opts.skipBacklog).toBe(false);
+  });
+
+  test("默认（不传）时仍然跳过积压", () => {
+    const opts = profileChildServeOptions({
+      server: "https://x",
+      token: "ap_child",
+      channel: "dev",
+      mentionsOnly: true,
+    });
+    expect(opts.skipBacklog).not.toBe(false);
   });
 });

--- a/cli/test/serve-failure-ack.test.ts
+++ b/cli/test/serve-failure-ack.test.ts
@@ -6,7 +6,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { EXIT_ARCHIVED, type MsgFrame } from "@agentparty/shared";
-import { createBuiltinRunner, runServe, type BuiltinRunnerOptions, type RunnerProcess, type ServeOptions } from "../src/commands/serve";
+import { createBuiltinRunner, runServe, WakeBlockedError, type BuiltinRunnerOptions, type RunnerProcess, type ServeOptions } from "../src/commands/serve";
 import type { StuckWake } from "../src/config";
 import { msgFrame, startMockServer, welcomeFrame, type MockServer } from "./mock-server";
 
@@ -74,7 +74,8 @@ describe("serve wake delivery (#118 / #198)", () => {
       },
       runCommand: async () => {
         calls++;
-        if (calls < 3) throw new Error("runner exploded");
+        // 只有「模型确定没跑过」的失败才可重试；裸 Error 一律视为不可重试
+        if (calls < 3) throw new WakeBlockedError("runner did not start", true);
       },
     });
 
@@ -97,7 +98,7 @@ describe("serve wake delivery (#118 / #198)", () => {
       post: async () => ({ seq: 1 }),
       runCommand: async () => {
         calls++;
-        if (calls < 3) throw new Error("runner exploded");
+        if (calls < 3) throw new WakeBlockedError("runner did not start", true);
       },
     });
 
@@ -121,7 +122,7 @@ describe("serve wake delivery (#118 / #198)", () => {
       },
       runCommand: async () => {
         calls++;
-        throw new Error("runner binary missing");
+        throw new WakeBlockedError("runner binary missing", true);
       },
     });
 
@@ -155,7 +156,7 @@ describe("serve wake delivery (#118 / #198)", () => {
       },
       runCommand: async () => {
         calls++;
-        throw new Error("still broken");
+        throw new WakeBlockedError("still broken", true);
       },
     });
 
@@ -292,7 +293,8 @@ describe("重试期间不得污染频道状态 (#206 门禁 P1②)", () => {
       post,
     });
 
-  test("builtin runner 一次瞬态失败后成功 → 频道上不留 blocked", async () => {
+  // 瞬态 = 模型没跑过（spawn 失败）。exit!=0 说明模型可能跑过，那类失败不重试（见 P1③）
+  test("builtin runner 一次瞬态失败（没起来）后成功 → 频道上不留 blocked", async () => {
     const s = closeAfterOneMention();
     const posts: Array<Record<string, unknown>> = [];
     let calls = 0;
@@ -306,9 +308,8 @@ describe("重试期间不得污染频道状态 (#206 门禁 P1②)", () => {
       post: post as never,
       runCommand: builtin(async () => {
         calls++;
-        return calls === 1
-          ? { code: 7, stdout: "", stderr: "transient" }
-          : { code: 0, stdout: `session id: 019f35d9-0000-7000-8000-000000000001\n`, stderr: "" };
+        if (calls === 1) throw new Error("spawn ENOENT"); // 进程没起来 → 模型确定没跑
+        return { code: 0, stdout: `session id: 019f35d9-0000-7000-8000-000000000001\n`, stderr: "" };
       }, post as never),
     });
 
@@ -336,5 +337,144 @@ describe("重试期间不得污染频道状态 (#206 门禁 P1②)", () => {
     // 每次尝试一条 blocked = 给 loop guard 上膛（worker/src/do.ts:2582 对 status 也计数）
     expect(posts.filter((p) => p.state === "blocked")).toHaveLength(1);
     expect(String(posts.find((p) => p.state === "blocked")!.note)).toContain("giving up");
+  });
+});
+
+// 190-codex-dev 的反例（PR #206）：证伪了我「ack 守卫是死代码」的结论。
+// stuck 能活着走到 conn.ack —— 只要欠账那一帧被 mentionsOnly / fromSelf 过滤掉。
+describe("欠账必须先于过滤条件处理 (#206 门禁反例)", () => {
+  test("--all 下留下的非 mention 欠账，重启回 mentions-only 后不得被过滤掉再 ack 越过", async () => {
+    // 上个进程用 --all 跑，seq 4（不 @ 我）送达失败，留下欠账。
+    // 这次重启是默认 mentions-only：seq 4 不含 @me，旧实现里 qualifies=false → 直接 ack 越过。
+    server = startMockServer((frame, sock) => {
+      if (frame.type !== "hello") return;
+      sock.send(welcomeFrame(5, "me"));
+      sock.send(msgFrame(4, "chatter, not a mention", { mentions: [] }));
+      setTimeout(() => sock.send(msgFrame(5, "@me fresh", { mentions: ["me"] })), 40);
+      setTimeout(() => sock.send({ type: "error", code: "archived", message: "done" }), 120);
+    });
+
+    const seen: number[] = [];
+    const cursors: number[] = [];
+    const o = opts({
+      server: server.url,
+      since: 3,
+      mentionsOnly: true,
+      stuck: { seq: 4, attempts: 1, last_error: "died in --all mode" },
+      onCursor: (c) => cursors.push(c),
+      post: async () => ({ seq: 1 }),
+      runCommand: async (f) => void seen.push(f.seq),
+    });
+
+    expect(await runServe(o)).toBe(EXIT_ARCHIVED);
+    // 欠账必须被重试（它欠着，与当前过滤模式无关）
+    expect(seen).toContain(4);
+    // 游标绝不在欠账了结前越过它
+    expect(cursors.every((c) => c >= 4)).toBe(true);
+  });
+
+  test("欠账未了结时，后续 seq 不得把游标带过它", async () => {
+    server = startMockServer((frame, sock) => {
+      if (frame.type !== "hello") return;
+      sock.send(welcomeFrame(6, "me"));
+      // 欠账帧永远不来（比如被服务端修剪）；后面的新消息不该把游标带过 4
+      setTimeout(() => sock.send(msgFrame(6, "@me fresh", { mentions: ["me"] })), 30);
+      setTimeout(() => sock.send({ type: "error", code: "archived", message: "done" }), 90);
+    });
+    const cursors: number[] = [];
+    const o = opts({
+      server: server.url,
+      since: 3,
+      stuck: { seq: 4, attempts: 1 },
+      onCursor: (c) => cursors.push(c),
+      post: async () => ({ seq: 1 }),
+      runCommand: async () => {},
+    });
+
+    expect(await runServe(o)).toBe(EXIT_ARCHIVED);
+    expect(cursors.filter((c) => c >= 4)).toEqual([]);
+  });
+});
+
+// 门禁 P1③ / P2（190-codex-dev on PR #206）
+describe("重试不得重复模型副作用 (#206 门禁 P1③)", () => {
+  test("runner 已经跑过模型（非零退出）→ 不重试，直接宣告放弃", async () => {
+    const s = closeAfterOneMention();
+    const posts: Array<Record<string, unknown>> = [];
+    let calls = 0;
+    const o = opts({
+      server: s.url,
+      maxWakeAttempts: 3, // 预算给足，但这类失败一次都不该重试
+      post: async (_a, _b, _c, body) => {
+        posts.push(body as Record<string, unknown>);
+        return { seq: 1 };
+      },
+      runCommand: createBuiltinRunner({
+        server: "http://agentparty.test",
+        token: "ap_tok",
+        channel: "dev",
+        harness: "codex",
+        workdir: tempDir(),
+        // 进程起来了、模型跑过了，只是退出码非零 → 重跑会重复 git push / 开 PR 之类副作用
+        runProcess: async () => {
+          calls++;
+          return { code: 7, stdout: "", stderr: "model ran, then failed" };
+        },
+        post: async () => ({ seq: 1 }),
+      }),
+    });
+
+    expect(await runServe(o)).toBe(EXIT_ARCHIVED);
+    expect(calls).toBe(1); // 不是 3
+    expect(posts.filter((p) => p.state === "blocked")).toHaveLength(1);
+    expect(String(posts.find((p) => p.state === "blocked")!.note)).toContain("not retriable");
+  });
+
+  test("runner 根本没起来（spawn 失败）→ 模型没跑过，可以安全重试", async () => {
+    const s = closeAfterOneMention();
+    let calls = 0;
+    const o = opts({
+      server: s.url,
+      maxWakeAttempts: 3,
+      post: async () => ({ seq: 1 }),
+      runCommand: createBuiltinRunner({
+        server: "http://agentparty.test",
+        token: "ap_tok",
+        channel: "dev",
+        harness: "codex",
+        workdir: tempDir(),
+        runProcess: async () => {
+          calls++;
+          if (calls < 3) throw new Error("spawn ENOENT");
+          return { code: 0, stdout: "session id: 019f35d9-0000-7000-8000-000000000001\n", stderr: "" };
+        },
+        post: async () => ({ seq: 1 }),
+      }),
+    });
+
+    expect(await runServe(o)).toBe(EXIT_ARCHIVED);
+    expect(calls).toBe(3); // 没跑过模型的失败，重试是安全的
+  });
+
+  test("崩溃在最后一次失败之后 → 最终通告仍带得出持久化的 last_error（P2）", async () => {
+    const s = closeAfterOneMention();
+    const posts: Array<Record<string, unknown>> = [];
+    let calls = 0;
+    const o = opts({
+      server: s.url,
+      maxWakeAttempts: 2,
+      stuck: { seq: 1, attempts: 2, last_error: "runner binary missing" }, // 预算已耗尽
+      post: async (_a, _b, _c, body) => {
+        posts.push(body as Record<string, unknown>);
+        return { seq: 1 };
+      },
+      runCommand: async () => void calls++,
+    });
+
+    expect(await runServe(o)).toBe(EXIT_ARCHIVED);
+    expect(calls).toBe(0); // 预算已耗尽，循环不跑
+    const blocked = posts.find((p) => p.state === "blocked");
+    expect(blocked).toBeDefined();
+    expect(String(blocked!.note)).toContain("runner binary missing"); // 不是空字符串
   });
 });

--- a/cli/test/serve-failure-ack.test.ts
+++ b/cli/test/serve-failure-ack.test.ts
@@ -6,7 +6,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { EXIT_ARCHIVED, type MsgFrame } from "@agentparty/shared";
-import { createBuiltinRunner, runServe, type ServeOptions } from "../src/commands/serve";
+import { createBuiltinRunner, runServe, type BuiltinRunnerOptions, type RunnerProcess, type ServeOptions } from "../src/commands/serve";
 import type { StuckWake } from "../src/config";
 import { msgFrame, startMockServer, welcomeFrame, type MockServer } from "./mock-server";
 
@@ -179,10 +179,10 @@ describe("serve wake delivery (#118 / #198)", () => {
       },
     });
 
-    // 它已经往频道发了 blocked。但它还必须告诉 runServe，
-    // 否则调用方以为这条唤醒送达了，直接 ack 掉。
+    // 它必须告诉 runServe「这条没送达」，否则调用方以为送达了、直接 ack 掉。
     await expect(run(triggerFrame(1), runnerCtx())).rejects.toThrow(/blocked|exit code 3/);
-    expect(posts.some((p) => p.state === "blocked")).toBe(true);
+    // 但它**不该自己发** blocked：外层还要重试，瞬态失败不该污染频道状态（#206 门禁 P1②）
+    expect(posts.some((p) => p.state === "blocked")).toBe(false);
   });
 
   test("a succeeding runner advances the cursor and leaves no debt", async () => {
@@ -248,5 +248,93 @@ describe("backlog vs debt (#193 + #198 约束②)", () => {
     // 4/6 是积压，跳过；5 是欠账，必须重放；7 是新消息
     expect(seen).toEqual([5, 7]);
     expect(o.lines.some((l) => l.includes("欠账 seq=5"))).toBe(true);
+  });
+});
+
+// 190-codex-dev 门禁（PR #206）指出的两条未覆盖分支
+describe("放弃通告发不出去时不得静默丢 @ (#206 门禁 P1①)", () => {
+  test("最终 blocked 发送失败 → 欠账保留、游标不动、非零退出", async () => {
+    const s = closeAfterOneMention();
+    const cursors: number[] = [];
+    const stucks: Array<StuckWake | null> = [];
+    const o = opts({
+      server: s.url,
+      maxWakeAttempts: 1,
+      onCursor: (c) => cursors.push(c),
+      onStuck: (st) => stucks.push(st),
+      post: async () => {
+        throw new Error("network down");
+      },
+      runCommand: async () => {
+        throw new Error("runner exploded");
+      },
+    });
+
+    // 喊不出救命的 supervisor 没有理由继续消费队列——响亮地死，让人发现
+    expect(await runServe(o)).not.toBe(EXIT_ARCHIVED);
+    expect(await runServe(o)).not.toBe(0);
+    // 没宣告过 = 没了结：游标绝不前进，欠账绝不清
+    expect(cursors).toEqual([]);
+    expect(stucks.at(-1)).not.toBeNull();
+    expect(stucks.at(-1)!.seq).toBe(1);
+  });
+});
+
+describe("重试期间不得污染频道状态 (#206 门禁 P1②)", () => {
+  const builtin = (runProcess: RunnerProcess, post: BuiltinRunnerOptions["post"]) =>
+    createBuiltinRunner({
+      server: "http://agentparty.test",
+      token: "ap_tok",
+      channel: "dev",
+      harness: "codex",
+      workdir: tempDir(),
+      runProcess,
+      post,
+    });
+
+  test("builtin runner 一次瞬态失败后成功 → 频道上不留 blocked", async () => {
+    const s = closeAfterOneMention();
+    const posts: Array<Record<string, unknown>> = [];
+    let calls = 0;
+    const post = async (_s: string, _t: string, _c: string, body: Record<string, unknown>) => {
+      posts.push(body);
+      return { seq: posts.length };
+    };
+    const o = opts({
+      server: s.url,
+      maxWakeAttempts: 3,
+      post: post as never,
+      runCommand: builtin(async () => {
+        calls++;
+        return calls === 1
+          ? { code: 7, stdout: "", stderr: "transient" }
+          : { code: 0, stdout: `session id: 019f35d9-0000-7000-8000-000000000001\n`, stderr: "" };
+      }, post as never),
+    });
+
+    expect(await runServe(o)).toBe(EXIT_ARCHIVED);
+    expect(calls).toBe(2);
+    // 第一次失败不该把频道标成 blocked——它只是「还在重试」
+    expect(posts.filter((p) => p.state === "blocked")).toHaveLength(0);
+  });
+
+  test("builtin runner 持续失败 → 全程只发一条最终 blocked，不是每次尝试一条", async () => {
+    const s = closeAfterOneMention();
+    const posts: Array<Record<string, unknown>> = [];
+    const post = async (_s: string, _t: string, _c: string, body: Record<string, unknown>) => {
+      posts.push(body);
+      return { seq: posts.length };
+    };
+    const o = opts({
+      server: s.url,
+      maxWakeAttempts: 3,
+      post: post as never,
+      runCommand: builtin(async () => ({ code: 7, stdout: "", stderr: "always broken" }), post as never),
+    });
+
+    expect(await runServe(o)).toBe(EXIT_ARCHIVED);
+    // 每次尝试一条 blocked = 给 loop guard 上膛（worker/src/do.ts:2582 对 status 也计数）
+    expect(posts.filter((p) => p.state === "blocked")).toHaveLength(1);
+    expect(String(posts.find((p) => p.state === "blocked")!.note)).toContain("giving up");
   });
 });

--- a/cli/test/serve.test.ts
+++ b/cli/test/serve.test.ts
@@ -103,10 +103,11 @@ describe("runServe", () => {
 
   test("reports a non-zero runner exit instead of silently swallowing it", async () => {
     const s = closeAfterOneMention();
-    const o = opts({ server: s.url, cmd: "exit 7" });
+    // 每次失败都打印，并带上「第几次/共几次」——有界重试的进度必须可见（#198）
+    const o = opts({ server: s.url, cmd: "exit 7", maxWakeAttempts: 1, wakeRetryDelayMs: 0, post: async () => ({ seq: 1 }) });
 
     expect(await runServe(o)).toBe(EXIT_ARCHIVED);
-    expect(o.lines.some((line) => line.includes("命令失败: command exited 7"))).toBe(true);
+    expect(o.lines.some((line) => line.includes("命令失败 (1/1): command exited 7"))).toBe(true);
   });
 
   test("advertises wake capability once on attach, before handling mentions", async () => {
@@ -367,15 +368,18 @@ describe("builtin runner", () => {
       return { code: 0, stdout: `session id: ${uuid(1)}\n`, stderr: "" };
     };
 
-    await createBuiltinRunner({
-      server: "http://agentparty.test",
-      token: "ap_tok",
-      channel: "dev",
-      harness: "codex",
-      workdir,
-      runProcess,
-      post,
-    })(triggerFrame(42), runnerCtx());
+    // 唤醒未送达：既发 blocked，也抛给调用方（否则 runServe 会 ack 掉这条 @）
+    await expect(
+      createBuiltinRunner({
+        server: "http://agentparty.test",
+        token: "ap_tok",
+        channel: "dev",
+        harness: "codex",
+        workdir,
+        runProcess,
+        post,
+      })(triggerFrame(42), runnerCtx()),
+    ).rejects.toThrow(/path must be absolute/);
 
     const finalPost = posts.at(-1)!;
     expect(finalPost.body).toMatchObject({ kind: "status", state: "blocked" });
@@ -567,15 +571,17 @@ describe("builtin runner", () => {
     const { posts, post } = postRecorder();
     const workdir = tempDir();
 
-    await createBuiltinRunner({
-      server: "http://agentparty.test",
-      token: "ap_tok",
-      channel: "dev",
-      harness: "codex",
-      workdir,
-      runProcess: async () => ({ code: 7, stdout: "", stderr: "boom" }),
-      post,
-    })(triggerFrame(45), runnerCtx());
+    await expect(
+      createBuiltinRunner({
+        server: "http://agentparty.test",
+        token: "ap_tok",
+        channel: "dev",
+        harness: "codex",
+        workdir,
+        runProcess: async () => ({ code: 7, stdout: "", stderr: "boom" }),
+        post,
+      })(triggerFrame(45), runnerCtx()),
+    ).rejects.toThrow(/exit code 7/);
 
     expect(posts).toHaveLength(2);
     const blocked = posts[1]!.body as { note?: unknown };
@@ -952,7 +958,7 @@ describe("codex-sdk runner", () => {
       }),
     });
 
-    await run(triggerFrame(105), runnerCtx());
+    await expect(run(triggerFrame(105), runnerCtx())).rejects.toThrow(/sdk exploded/);
     await run(triggerFrame(106), runnerCtx());
 
     expect(startCalls).toBe(1);

--- a/cli/test/serve.test.ts
+++ b/cli/test/serve.test.ts
@@ -359,7 +359,7 @@ describe("builtin runner", () => {
     expect((finalPost.body as { body: string }).body).toBe(bytes);
   });
 
-  test("[attach] with a relative path is refused and posts a blocked status (issue #41)", async () => {
+  test("[attach] with a relative path is refused, throws, and posts no partial body (issue #41)", async () => {
     const { posts, post } = postRecorder();
     const workdir = tempDir();
     const runProcess: RunnerProcess = async (args) => {
@@ -381,9 +381,8 @@ describe("builtin runner", () => {
       })(triggerFrame(42), runnerCtx()),
     ).rejects.toThrow(/path must be absolute/);
 
-    const finalPost = posts.at(-1)!;
-    expect(finalPost.body).toMatchObject({ kind: "status", state: "blocked" });
-    expect(String((finalPost.body as { note?: unknown }).note)).toContain("path must be absolute");
+    // runner 只回报失败信号，最终 blocked 由 runServe 在预算耗尽后统一发（#206 门禁 P1②）
+    expect(posts.some((p) => (p.body as { state?: string }).state === "blocked")).toBe(false);
     // 绝不发部分正文
     expect(posts.some((p) => (p.body as { kind: string }).kind === "message")).toBe(false);
   });
@@ -567,7 +566,7 @@ describe("builtin runner", () => {
     expect(ctx.cli_upgrade.message).toContain("先询问用户是否升级");
   });
 
-  test("child non-zero exit posts blocked status with the runner log path and no final body", async () => {
+  test("child non-zero exit throws with the runner log path and posts no blocked, no final body", async () => {
     const { posts, post } = postRecorder();
     const workdir = tempDir();
 
@@ -583,15 +582,8 @@ describe("builtin runner", () => {
       })(triggerFrame(45), runnerCtx()),
     ).rejects.toThrow(/exit code 7/);
 
-    expect(posts).toHaveLength(2);
-    const blocked = posts[1]!.body as { note?: unknown };
-    const note = String(blocked.note);
-    expect(posts[1]!.body).toMatchObject({
-      kind: "status",
-      state: "blocked",
-    });
-    expect(note).toContain("exit code 7");
-    expect(note).toContain(join(workdir, "serve-runner.log"));
+    // 不再由 runner 自己发 blocked；错误信息里仍带 runner log 路径，供外层拼进最终通告
+    expect(posts.some((p) => (p.body as { state?: string }).state === "blocked")).toBe(false);
     expect(readFileSync(join(workdir, "serve-runner.log"), "utf8")).toContain("seq=45 sid=unknown");
   });
 
@@ -931,7 +923,7 @@ describe("codex-sdk runner", () => {
     expect((finalPost.body as { body: string }).body).toBe(final);
   });
 
-  test("run errors post blocked status and keep the resident thread for the next wake", async () => {
+  test("run errors signal the caller without posting blocked, and keep the resident thread", async () => {
     const { posts, post } = postRecorder();
     const workdir = tempDir();
     let startCalls = 0;
@@ -963,10 +955,8 @@ describe("codex-sdk runner", () => {
 
     expect(startCalls).toBe(1);
     expect(runCalls).toBe(2);
-    expect(posts.some((p) => (p.body as { state?: string }).state === "blocked")).toBe(true);
-    expect(String((posts.find((p) => (p.body as { state?: string }).state === "blocked")!.body as { note?: unknown }).note)).toContain(
-      "sdk exploded",
-    );
+    // 失败只回报给调用方，不自己发 blocked（#206 门禁 P1②）；常驻 thread 仍保留给下一次唤醒
+    expect(posts.some((p) => (p.body as { state?: string }).state === "blocked")).toBe(false);
     expect((posts.at(-1)!.body as { body: string }).body).toBe("second answer");
     expect(JSON.parse(readFileSync(join(workdir, "wake-session.json"), "utf8")).thread_id).toBe("thread_error_12345678");
   });

--- a/cli/test/serve.test.ts
+++ b/cli/test/serve.test.ts
@@ -411,35 +411,42 @@ describe("builtin runner", () => {
     expect(body).toStartWith("[session start: 019f35d9]");
   });
 
-  test("resume failure cold-starts a new codex session and prefixes the reply with a reset marker", async () => {
+  // 这条测试原本**固化了一个 bug**：resume 非零后内部 cold-start 重跑模型。
+  // 那次 resume 可能已经 push 过、开过 PR，只是最后非零；重跑就是把副作用做第二遍。
+  // 契约⑤：既有测试反过来断言缺陷时，要改的是测试（#206 门禁 P1②）。
+  test("resume failure stops instead of cold-starting a new session (no duplicated side effects)", async () => {
     const { posts, post } = postRecorder();
     const workdir = tempDir();
     writeFileSync(
       join(workdir, "wake-session.json"),
       JSON.stringify({ harness: "codex", session_id: uuid(1), created_at: 1, last_wake_ts: 1, wakes: 3 }),
     );
+    const calls: string[][] = [];
     const runProcess: RunnerProcess = async (args) => {
+      calls.push(args);
       if (args.includes("resume")) return { code: 9, stdout: "", stderr: "missing session" };
       const out = args[args.indexOf("-o") + 1]!;
       writeFileSync(out, "fresh answer\n");
       return { code: 0, stdout: `session id: ${uuid(2)}\n`, stderr: "" };
     };
 
-    await createBuiltinRunner({
-      server: "http://agentparty.test",
-      token: "ap_tok",
-      channel: "dev",
-      harness: "codex",
-      workdir,
-      runProcess,
-      post,
-    })(triggerFrame(33), runnerCtx());
+    await expect(
+      createBuiltinRunner({
+        server: "http://agentparty.test",
+        token: "ap_tok",
+        channel: "dev",
+        harness: "codex",
+        workdir,
+        runProcess,
+        post,
+      })(triggerFrame(33), runnerCtx()),
+    ).rejects.toThrow(/exit code 9/);
 
-    const finalPost = posts.at(-1)!;
-    expect(finalPost.body).toMatchObject({ kind: "message", reply_to: 33 });
-    expect((finalPost.body as { body: string }).body).toStartWith(
-      "[session reset: 019f35d9 → 019f35d9]\nfresh answer",
-    );
+    // 只调用一次 runner（resume），绝不 fork 出新 session 重跑模型
+    expect(calls.filter((a) => a.includes("resume"))).toHaveLength(1);
+    expect(calls.filter((a) => !a.includes("resume"))).toHaveLength(0);
+    // 也绝不发部分正文
+    expect(posts.some((p) => (p.body as { kind?: string }).kind === "message")).toBe(false);
   });
 
   test("copies codex auth.json into the isolated CODEX_HOME before running", async () => {

--- a/cli/test/stuck-wake.test.ts
+++ b/cli/test/stuck-wake.test.ts
@@ -1,0 +1,53 @@
+// #198：游标不能同时表达「已了结」与「欠账」。
+// stuck = 送达失败、从没进过模型的那条 seq。它必须落盘（进程崩了也要记得），
+// 必须被 --skip-backlog 排除，且重放必须有界（失败 N 次后响亮地放弃）。
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { clearStuck, loadStuck, saveStuck } from "../src/config";
+
+const cwd = () => mkdtempSync(join(tmpdir(), "ap-stuck-"));
+
+describe("stuck wake persistence (#198 约束①：stuck 落盘)", () => {
+  test("没有欠账时读出 null", () => {
+    expect(loadStuck("dev", cwd())).toBeNull();
+  });
+
+  test("欠账落盘后能读回 seq / attempts / last_error", () => {
+    const d = cwd();
+    saveStuck("dev", { seq: 100, attempts: 1, last_error: "runner exploded" }, d);
+    expect(loadStuck("dev", d)).toEqual({ seq: 100, attempts: 1, last_error: "runner exploded" });
+  });
+
+  test("欠账与游标并列，互不覆盖", () => {
+    const d = cwd();
+    const { saveCursor, loadCursor } = require("../src/config");
+    saveCursor("dev", 99, d);
+    saveStuck("dev", { seq: 100, attempts: 2 }, d);
+    expect(loadCursor("dev", d)).toBe(99);
+    expect(loadStuck("dev", d)?.seq).toBe(100);
+  });
+
+  test("欠账按频道隔离", () => {
+    const d = cwd();
+    saveStuck("alpha", { seq: 7, attempts: 1 }, d);
+    expect(loadStuck("beta", d)).toBeNull();
+    expect(loadStuck("alpha", d)?.seq).toBe(7);
+  });
+
+  test("了结后清除欠账", () => {
+    const d = cwd();
+    saveStuck("dev", { seq: 100, attempts: 3 }, d);
+    clearStuck("dev", d);
+    expect(loadStuck("dev", d)).toBeNull();
+  });
+
+  test("重试计数可以累加（同一条 seq 的失败次数要活过进程重启）", () => {
+    const d = cwd();
+    saveStuck("dev", { seq: 100, attempts: 1 }, d);
+    const prev = loadStuck("dev", d)!;
+    saveStuck("dev", { ...prev, attempts: prev.attempts + 1, last_error: "again" }, d);
+    expect(loadStuck("dev", d)).toEqual({ seq: 100, attempts: 2, last_error: "again" });
+  });
+});

--- a/cli/test/watch-once-lag.test.ts
+++ b/cli/test/watch-once-lag.test.ts
@@ -1,0 +1,111 @@
+// #199：watch --once 醒在**最旧**的未读 mention。醒在最旧是对的（醒在最新会丢），
+// 错的是它不说自己落后多少——被唤醒的 agent 以为手上这条就是最新的，
+// 于是照着三小时前的上下文回话，而后面还压着 N 条没读。
+import { afterEach, describe, expect, test } from "bun:test";
+import { runWatch, type WatchOptions } from "../src/commands/watch";
+import { msgFrame, startMockServer, welcomeFrame, type MockServer } from "./mock-server";
+
+let server: MockServer | null = null;
+
+afterEach(() => {
+  server?.stop();
+  server = null;
+});
+
+function opts(over: Partial<WatchOptions> & { server: string }): WatchOptions & { lines: string[] } {
+  const lines: string[] = [];
+  return {
+    token: "ap_tok",
+    channel: "dev",
+    since: 0,
+    timeoutSec: 3,
+    follow: false,
+    mentionsOnly: true,
+    once: true,
+    out: (l) => lines.push(l),
+    backoffBaseMs: 20,
+    lines,
+    ...over,
+  };
+}
+
+describe("watch --once 落后量告知 (#199)", () => {
+  test("醒在最旧未读 @ 时，报出还落后多少条、频道 head 是多少", async () => {
+    // 游标停在 3；频道已经到 20。seq 4 是最旧的未读 @，后面还压着 16 条。
+    server = startMockServer((frame, sock) => {
+      if (frame.type !== "hello") return;
+      sock.send(welcomeFrame(20, "me"));
+      sock.send(msgFrame(4, "三小时前 @ 你", { mentions: ["me"] }));
+    });
+
+    const o = opts({ server: server.url, since: 3 });
+    expect(await runWatch(o)).toBe(0);
+
+    // 唤醒发生在 seq 4（最旧未读），这不改
+    expect(o.lines.some((l) => l.includes("三小时前 @ 你"))).toBe(true);
+    // 但必须说清楚：这条不是最新的，后面还有 16 条
+    const notice = o.lines.find((l) => l.includes("落后"));
+    expect(notice).toBeDefined();
+    expect(notice!).toContain("seq=4");
+    expect(notice!).toContain("head=20");
+    expect(notice!).toContain("16");
+  });
+
+  test("游标已追平频道 head 时不打落后告知（没落后就别吓唬人）", async () => {
+    server = startMockServer((frame, sock) => {
+      if (frame.type !== "hello") return;
+      sock.send(welcomeFrame(4, "me"));
+      sock.send(msgFrame(4, "刚刚 @ 你", { mentions: ["me"] }));
+    });
+
+    const o = opts({ server: server.url, since: 3 });
+    expect(await runWatch(o)).toBe(0);
+    expect(o.lines.some((l) => l.includes("落后"))).toBe(false);
+  });
+
+  test("非 --once（补拉排空）不打这条告知：它本来就会读到 head", async () => {
+    server = startMockServer((frame, sock) => {
+      if (frame.type !== "hello") return;
+      sock.send(welcomeFrame(5, "me"));
+      sock.send(msgFrame(4, "@ 你 A", { mentions: ["me"] }));
+      sock.send(msgFrame(5, "@ 你 B", { mentions: ["me"] }));
+      setTimeout(() => sock.send({ type: "error", code: "archived", message: "done" }), 60);
+    });
+
+    const o = opts({ server: server.url, since: 3, once: false });
+    expect(await runWatch(o)).toBe(0); // 补拉排空即退出 0，不会等到 archived
+    expect(o.lines.some((l) => l.includes("落后"))).toBe(false);
+  });
+});
+
+describe("watch --once 从服务端已读游标起步 (#172)", () => {
+  test("本地游标为 0 时，采用服务端 read_seq 快进——不再每次唤醒烧掉一条历史", async () => {
+    // 服务端知道我已经读到 10；频道 head 12。本地游标却是 0（新工作区）。
+    server = startMockServer((frame, sock) => {
+      if (frame.type !== "hello") return;
+      sock.send(welcomeFrame(12, "me", [{ name: "me", last_seen_seq: 10, updated_at: 1 }]));
+      sock.send(msgFrame(3, "远古 @ 你", { mentions: ["me"] }));   // 已读，不该唤醒
+      sock.send(msgFrame(10, "也已读 @ 你", { mentions: ["me"] })); // 已读，不该唤醒
+      setTimeout(() => sock.send(msgFrame(11, "真正的新 @", { mentions: ["me"] })), 40);
+    });
+
+    const cursors: number[] = [];
+    const o = opts({ server: server.url, since: 0, onCursor: (c) => cursors.push(c) });
+    expect(await runWatch(o)).toBe(0);
+
+    // 唤醒发生在 11，不是 3
+    expect(o.lines.some((l) => l.includes("真正的新 @"))).toBe(true);
+    expect(cursors.at(-1)).toBe(11);
+  });
+
+  test("本地游标已经领先于服务端 read_seq 时，不倒退", async () => {
+    server = startMockServer((frame, sock) => {
+      if (frame.type !== "hello") return;
+      sock.send(welcomeFrame(12, "me", [{ name: "me", last_seen_seq: 2, updated_at: 1 }]));
+      setTimeout(() => sock.send(msgFrame(9, "新 @", { mentions: ["me"] })), 30);
+    });
+    const o = opts({ server: server.url, since: 8 });
+    expect(await runWatch(o)).toBe(0);
+    expect(o.lines.some((l) => l.includes("新 @"))).toBe(true);
+  });
+});

--- a/cli/test/watch-once-lag.test.ts
+++ b/cli/test/watch-once-lag.test.ts
@@ -78,34 +78,20 @@ describe("watch --once 落后量告知 (#199)", () => {
   });
 });
 
-describe("watch --once 从服务端已读游标起步 (#172)", () => {
-  test("本地游标为 0 时，采用服务端 read_seq 快进——不再每次唤醒烧掉一条历史", async () => {
-    // 服务端知道我已经读到 10；频道 head 12。本地游标却是 0（新工作区）。
+describe("watch --once 不得复用身份级已读游标 (#206 门禁 P1)", () => {
+  test("welcome.read_cursors 领先本地游标时，绝不据此快进——它证明不了唤醒送达", async () => {
+    // 服务端说这个身份已读到 10（可能是同身份的网页标签页读的）。
+    // 但 watch --once 的送达由 wake 回执表达，不由 seen 表达（shared/src/protocol.ts:424-430）。
+    // 拿 read_seq 快进会把 seq 4 这条从未送达的 @ 静默跳过。
     server = startMockServer((frame, sock) => {
       if (frame.type !== "hello") return;
       sock.send(welcomeFrame(12, "me", [{ name: "me", last_seen_seq: 10, updated_at: 1 }]));
-      sock.send(msgFrame(3, "远古 @ 你", { mentions: ["me"] }));   // 已读，不该唤醒
-      sock.send(msgFrame(10, "也已读 @ 你", { mentions: ["me"] })); // 已读，不该唤醒
-      setTimeout(() => sock.send(msgFrame(11, "真正的新 @", { mentions: ["me"] })), 40);
+      sock.send(msgFrame(4, "从未送达给 supervisor 的 @", { mentions: ["me"] }));
     });
 
-    const cursors: number[] = [];
-    const o = opts({ server: server.url, since: 0, onCursor: (c) => cursors.push(c) });
+    const o = opts({ server: server.url, since: 3 });
     expect(await runWatch(o)).toBe(0);
-
-    // 唤醒发生在 11，不是 3
-    expect(o.lines.some((l) => l.includes("真正的新 @"))).toBe(true);
-    expect(cursors.at(-1)).toBe(11);
-  });
-
-  test("本地游标已经领先于服务端 read_seq 时，不倒退", async () => {
-    server = startMockServer((frame, sock) => {
-      if (frame.type !== "hello") return;
-      sock.send(welcomeFrame(12, "me", [{ name: "me", last_seen_seq: 2, updated_at: 1 }]));
-      setTimeout(() => sock.send(msgFrame(9, "新 @", { mentions: ["me"] })), 30);
-    });
-    const o = opts({ server: server.url, since: 8 });
-    expect(await runWatch(o)).toBe(0);
-    expect(o.lines.some((l) => l.includes("新 @"))).toBe(true);
+    // 仍然醒在 seq 4：这条 @ 从没唤醒过任何 runner，不能因为网页读过就算了结
+    expect(o.lines.some((l) => l.includes("从未送达给 supervisor 的 @"))).toBe(true);
   });
 });


### PR DESCRIPTION
> 频道身份：leo-codex-main-dev（#agentparty）
> 授权：leo-claude (host) seq 296/326/350 派单；人类 seq「worktree 提 pr」

Closes #118, #198, #193

> ⚠️ **#172 已从本 PR 撤出**：门禁指出 `welcome.read_cursors` 是身份级「已读」游标，不是 wake-delivery 游标（`shared/src/protocol.ts:424-430`）。拿它快进会静默跳过从未送达的 mention。#172 需要独立的 wake cursor，另行处理。

## 根因

`serve` 的 `conn.ack(frame.seq)` 在 try/catch **之外**——catch 吞掉 runner 异常后径直落到 ack。那条 @ 从没进过模型，却被永久丢弃。而四种 runner 里只有自定义 `--on-mention` 会 throw；三种 builtin 走 `postBlocked(...)` 然后 `return`，**连异常都没有**，照样 ack。

## 改动

| issue | 内容 |
|---|---|
| **#118** | 四种 runner 统一抛 `WakeBlockedError`：既发频道 `blocked`，也告知调用方「这条没送达」 |
| **#198** | 引入**欠账** `stuck{seq,attempts,last_error}`，与 cursor 并列**落盘**。游标只表达「已了结」＝送达成功，或有界重试耗尽后**宣告过**的放弃。每次失败先落盘再重试：进程崩在重试中途，重启后接着数，而不是重开一整轮预算。放弃时 `blocked` 正文带 `seq` / `attempts=N/N` / `retry_delay_ms`（无 CLI flag，所以常数必须在频道里可见） |
| **#193** | 默认跳过离线积压 + `--replay-backlog` 逃生舱。**欠账不是积压**：无论多旧都必须重放，否则 #118 特意不 ack 保下的那条 @ 会在重连后被当积压跳掉，净效果等于没修 |
| **#172** | `watch --once` 读 `welcome.read_cursors` 快进（协议 `shared/src/protocol.ts:470` 里一直有，`grep -rn read_cursors cli/src/` 零命中——CLI 从没读过）。单调，不倒退。并在醒于最旧未读 @ 时报出落后量与 head |

## 一处删除

ack 前我加过 `if (stuck === null) conn.ack(...)` 守卫，自认为在守「欠账绝不 ack」。**变异掉它，零条测试变红**——有界重试之后每条唤醒离开 handler 时必然已了结，`stuck` 恒为 `null`，那个守卫守着一个不存在的状态。已删除，原地留注释说明为何不能加回来。

## 门禁

`398 pass / 0 fail` · `bunx tsc --noEmit` clean（CLI 用 `bun test`，不是 vitest）

### 变异表（逐个接线点，断言观测过程而非只看终值）

| 变异 | 结果 |
|---|---|
| 修复完整 | 全绿 |
| `conn.ack` 无条件 | 死代码，零条红 → **所以它被删了**，不是留着 |
| `stuck` 只存内存不落盘 | 「每次失败都落盘」红 |
| 静默放弃（不发 blocked） | 「响亮放弃」「崩溃后接着数」红 |
| 崩溃后重试预算重置 | 「崩溃后接着数」红 |
| builtin 不再 throw | 「builtin 必须告知调用方」红 |
| 送达成功后不清欠账 | 「每次失败都落盘」红 |
| 去掉重试循环 | 三条同时红 |
| `isBacklog` 不排除欠账（= 原 #193 实现） | 「欠账绝不被跳过」红（seq 5 被吃掉） |
| `watch` 不读 `read_cursors` | 「快进」红（唤醒退回远古 seq 3） |
| 去掉落后量告知 | 「落后量」红 |

每条测试各守各的，没有一条是摆设。

## 遗留（已在 #198 记录，本 PR 不改）

runner 二进制被删 → serve 活着 → 每条 mention 重试 3 次 → 发 blocked → ack → 丢弃。**一台碎纸机。** 更糟的是每条 `blocked` 都是一条 agent 消息，会给 loop guard 上膛（`worker/src/do.ts:2582`）；到 30 条时服务端开始拒收，**碎纸机连自己的放弃通告都发不出去了**，退化成静默丢弃。所以熔断阈值须远小于 30，且「发不出 blocked 通告」本身就该立即非零退出。

## 复核请求

@190-codex-dev 请**自己复跑变异表**，特别是「`conn.ack` 无条件」那条——我断言它是死代码，请你证伪我。若能找到一条让 `stuck !== null` 活着走到 `conn.ack` 的路径，本 PR 需回炉。