### PR TITLE
fix(cli): serve 唤醒上下文路径带上身份，同机多 agent 不再互相覆盖（#197）

### DIFF
--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -58,9 +58,21 @@ export class WakeBlockedError extends Error {
 // 放弃通告都发不出去（网络/loop guard 熔断）。此时既没送达也没宣告，继续跑就是静默丢 @。
 export const EXIT_WAKE_UNANNOUNCED = 1;
 
+/** 传给 builtin runner 的提示：只给路径，不给正文（#120）。 */
+function wakePrompt(contextFile: string): string {
+  return (
+    `你在 AgentParty 频道里被 @ 了。唤醒上下文是一个 JSON 文件：${contextFile}\n` +
+    `先读它（含 channel / seq / sender / body / mentions / charter / recent），再动手。\n` +
+    `${PROTOCOL_REMINDER}`
+  );
+}
+
 const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
 // 有界重放（#198）：同一条 seq 连续送达失败到顶就响亮放弃，既不无限重放也不静默丢弃
+// env 里保留的正文上限。完整正文走 stdin 与 context file。
+const AP_BODY_MAX = 4_000;
+
 const DEFAULT_MAX_WAKE_ATTEMPTS = 3;
 const DEFAULT_WAKE_RETRY_DELAY_MS = 500;
 
@@ -346,7 +358,10 @@ async function defaultRun(
       AP_SEQ: String(frame.seq),
       AP_SENDER: frame.sender.name,
       AP_OWNER: frame.sender.owner ?? "",
-      AP_BODY: body,
+      // env 也会被同一 unix 用户下的兄弟 agent 读到（`ps -E`），而「一机多 agent」是推荐拓扑。
+      // 完整正文走 stdin（不进 ps）与 AP_CONTEXT_FILE（0700）；env 里只留一个可读的摘要。
+      AP_BODY: body.length > AP_BODY_MAX ? body.slice(0, AP_BODY_MAX) : body,
+      AP_BODY_TRUNCATED: body.length > AP_BODY_MAX ? "1" : "0",
       AP_MENTIONS: frame.mentions.join(","),
       AP_SELF: ctx.self,
       AP_REPLY_TO: String(frame.seq),
@@ -731,7 +746,14 @@ export function createBuiltinRunner(opts: BuiltinRunnerOptions): NonNullable<Ser
     const repoCwd = await ensureRepo(opts, env);
     const cwd = opts.cwd ?? repoCwd ?? opts.workdir;
     const contextFile = writeContextFile(ctx.contextDir, frame, ctx.channel, ctx.self, ctx.recent, ctx.charter ?? null, ctx.projectAgent ?? null, ctx.cliUpgrade ?? null);
-    const prompt = readFileSync(contextFile, "utf8");
+    // 绝不把 context JSON 当 argv 传（#120）：argv 对同机任意用户可见（`ps -axww`），
+    // 一条私有频道消息的正文、charter、最近 20 条上下文就全泄漏了。
+    // 只传 0700 私有目录里的文件路径——protocol_reminder 本来就叫模型「先读本文件」。
+    //
+    // 顺带证伪 issue 里「大消息 E2BIG」那半：macOS 上 argv 单条到 ~2MB 才 E2BIG，
+    // 而最坏 context ≈ 230KB（BODY_LIMIT 100KB + CHARTER_LIMIT 16KB + recent 20×400B）。
+    // 当前限额下炸不了；真正当下就成立的是上面这条泄漏。
+    const prompt = wakePrompt(contextFile);
 
     let run = await runHarness(opts, prompt, oldSid, cwd, env, frame.seq);
     exitCode = run.result.code;

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -8,7 +8,9 @@ import {
   copyFileSync,
   existsSync,
   mkdirSync,
+  mkdtempSync,
   readFileSync,
+  rmSync,
   unlinkSync,
   writeFileSync,
 } from "node:fs";
@@ -192,13 +194,20 @@ function buildWakeContext(
   };
 }
 
-// 文件名片段消毒：身份/频道来自服务端，但它们会进路径。`..` 和分隔符必须失去含义，
-// 否则一个叫 `../../etc/x` 的 name 能把上下文写出 tmpdir。正文里仍保留原始 self。
-function pathSafe(part: string): string {
-  return part.replace(/[^a-zA-Z0-9._-]/g, "_").replace(/\.{2,}/g, "_") || "_";
+/**
+ * 每个 serve 实例一个私有上下文目录（0700）。
+ *
+ * 不要把身份塞进文件名（PR #208 门禁）：那是**有损映射**——`tenant|alice` 与
+ * `tenant/alice` 消毒后同名，仍会互相覆盖；文件名也没有 server / profile 维度，
+ * 同时连 prod 与 test 私有部署时同频道同 seq 仍会串；长 IdP subject 还会 ENAMETOOLONG。
+ * 私有目录一次性解决碰撞、跨部署、长度三件事：路径里压根不出现身份。
+ */
+export function createWakeContextDir(): string {
+  return mkdtempSync(join(tmpdir(), "agentparty-serve-"), { encoding: "utf8" });
 }
 
 export function writeContextFile(
+  dir: string,
   frame: MsgFrame,
   channel: string,
   self: string,
@@ -207,10 +216,9 @@ export function writeContextFile(
   projectAgent: ProjectAgentRunContext | null = null,
   cliUpgrade: CliUpgradeNotice | null = null,
 ): string {
-  // 路径必须含身份（#197）。只用 channel+seq 时，同机多个 agent serve 同一频道会为同一条消息
-  // 写同一个文件、后写的赢——runner 读到别人的上下文，`self` 是别人的名字，而 --runner
-  // claude|codex 会把这个文件直接喂给模型。mode 0600 挡的是别的 unix 用户，挡不住兄弟 agent。
-  const path = join(tmpdir(), `agentparty-serve-${pathSafe(channel)}-${pathSafe(self)}-${frame.seq}.json`);
+  // dir 是本 serve 实例私有的（createWakeContextDir）。文件名只需 seq：同一次唤醒重复写得到
+  // 同一路径（幂等），而不同实例——不同身份 / 不同 server / 不同 profile——各在各的目录里。
+  const path = join(dir, `${frame.seq}.json`);
   writeFileSync(
     path,
     JSON.stringify(buildWakeContext(frame, channel, self, recent, charter, projectAgent, cliUpgrade), null, 2) + "\n",
@@ -271,6 +279,8 @@ export interface ServeOptions {
       cmd: string;
       channel: string;
       self: string;
+      /** 本 serve 实例私有的上下文目录（createWakeContextDir）。 */
+      contextDir: string;
       recent: MsgFrame[];
       charter?: ChannelCharter | null;
       projectAgent?: ProjectAgentRunContext | null;
@@ -315,6 +325,7 @@ async function defaultRun(
     cmd: string;
     channel: string;
     self: string;
+    contextDir: string;
     recent: MsgFrame[];
     charter?: ChannelCharter | null;
     projectAgent?: ProjectAgentRunContext | null;
@@ -322,7 +333,7 @@ async function defaultRun(
   },
 ): Promise<void> {
   const body = frame.kind === "message" ? frame.body : (frame.note ?? "");
-  const file = writeContextFile(frame, ctx.channel, ctx.self, ctx.recent, ctx.charter, ctx.projectAgent ?? null, ctx.cliUpgrade ?? null);
+  const file = writeContextFile(ctx.contextDir, frame, ctx.channel, ctx.self, ctx.recent, ctx.charter, ctx.projectAgent ?? null, ctx.cliUpgrade ?? null);
   const cmd = ctx.cmd.includes("{file}") ? ctx.cmd.replaceAll("{file}", file) : ctx.cmd;
   const proc = Bun.spawn(["sh", "-c", cmd], {
     stdin: new TextEncoder().encode(body),
@@ -719,7 +730,7 @@ export function createBuiltinRunner(opts: BuiltinRunnerOptions): NonNullable<Ser
 
     const repoCwd = await ensureRepo(opts, env);
     const cwd = opts.cwd ?? repoCwd ?? opts.workdir;
-    const contextFile = writeContextFile(frame, ctx.channel, ctx.self, ctx.recent, ctx.charter ?? null, ctx.projectAgent ?? null, ctx.cliUpgrade ?? null);
+    const contextFile = writeContextFile(ctx.contextDir, frame, ctx.channel, ctx.self, ctx.recent, ctx.charter ?? null, ctx.projectAgent ?? null, ctx.cliUpgrade ?? null);
     const prompt = readFileSync(contextFile, "utf8");
 
     let run = await runHarness(opts, prompt, oldSid, cwd, env, frame.seq);
@@ -1080,6 +1091,10 @@ export async function runServe(o: ServeOptions): Promise<number> {
   });
 
   const skipBacklog = o.skipBacklog !== false; // 默认跳过离线积压（#193）
+  // 本实例私有的上下文命名空间（#197 / #208 门禁）。退出时整目录删除：
+  // 失败的唤醒会把上下文留在盘上供本次排查，但它带着 charter / recent 正文，
+  // 不能在进程结束后继续躺在共享 tmpdir 里。
+  const contextDir = createWakeContextDir();
   // 挂载那一刻的频道水位（welcome.last_seq），只在首个 welcome 记一次。
   let attachHead: number | null = null;
   let self = "";
@@ -1207,6 +1222,7 @@ export async function runServe(o: ServeOptions): Promise<number> {
               cmd: o.cmd,
               channel: o.channel,
               self,
+              contextDir,
               recent: recent.slice(),
               charter,
               projectAgent: o.projectAgent ?? null,
@@ -1288,6 +1304,9 @@ export async function runServe(o: ServeOptions): Promise<number> {
       }
     }
   } finally {
+    // 私有目录里躺着 charter / recent 正文。失败的唤醒把它留到本次排查结束，
+    // 但绝不在进程退出后继续留在共享 tmpdir 里（#208 门禁 P2）。
+    rmSync(contextDir, { recursive: true, force: true });
     if (heartbeat) clearInterval(heartbeat);
     conn.close();
     if (o.statusline === true) clearStatuslineListener();

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -192,6 +192,12 @@ function buildWakeContext(
   };
 }
 
+// 文件名片段消毒：身份/频道来自服务端，但它们会进路径。`..` 和分隔符必须失去含义，
+// 否则一个叫 `../../etc/x` 的 name 能把上下文写出 tmpdir。正文里仍保留原始 self。
+function pathSafe(part: string): string {
+  return part.replace(/[^a-zA-Z0-9._-]/g, "_").replace(/\.{2,}/g, "_") || "_";
+}
+
 export function writeContextFile(
   frame: MsgFrame,
   channel: string,
@@ -201,7 +207,10 @@ export function writeContextFile(
   projectAgent: ProjectAgentRunContext | null = null,
   cliUpgrade: CliUpgradeNotice | null = null,
 ): string {
-  const path = join(tmpdir(), `agentparty-serve-${channel}-${frame.seq}.json`);
+  // 路径必须含身份（#197）。只用 channel+seq 时，同机多个 agent serve 同一频道会为同一条消息
+  // 写同一个文件、后写的赢——runner 读到别人的上下文，`self` 是别人的名字，而 --runner
+  // claude|codex 会把这个文件直接喂给模型。mode 0600 挡的是别的 unix 用户，挡不住兄弟 agent。
+  const path = join(tmpdir(), `agentparty-serve-${pathSafe(channel)}-${pathSafe(self)}-${frame.seq}.json`);
   writeFileSync(
     path,
     JSON.stringify(buildWakeContext(frame, channel, self, recent, charter, projectAgent, cliUpgrade), null, 2) + "\n",

--- a/cli/test/serve-argv-leak.test.ts
+++ b/cli/test/serve-argv-leak.test.ts
@@ -1,0 +1,148 @@
+// #120：serve 把未截断正文塞进 AP_BODY env，并把整个 context JSON 当成**单个 argv**
+// 传给 codex / claude。
+//
+// 我实测证伪了 issue 里「大消息 E2BIG」这半：
+//   - macOS 上 argv / env 单条到 ~2MB 才 E2BIG
+//   - 最坏 context JSON ≈ 230KB（BODY_LIMIT 100KB + CHARTER_LIMIT 16KB + recent 20×400B）
+//   差一个数量级，当前限额下炸不了。
+//
+// 但同一处代码有个更严重、且**当前就成立**的问题：argv 对同机任意用户可见（`ps -axww`）。
+// 一条私有频道消息的正文、频道 charter、最近 20 条上下文，全部躺在命令行里。
+// env 稍好（macOS 非特权用户读不到别人的 env），但同一 unix 用户下的兄弟 agent 照样能读——
+// 而「一台机器多个 agent」正是本项目推荐的拓扑。
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { EXIT_ARCHIVED, type MsgFrame } from "@agentparty/shared";
+import { createBuiltinRunner, runServe, type RunnerProcess } from "../src/commands/serve";
+import { msgFrame, startMockServer, welcomeFrame, type MockServer } from "./mock-server";
+
+const dirs: string[] = [];
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+function tmp(): string {
+  const d = mkdtempSync(join(tmpdir(), "ap-argv-"));
+  dirs.push(d);
+  return d;
+}
+
+const SECRET = "TOP_SECRET_MESSAGE_BODY";
+
+function frame(): MsgFrame {
+  return msgFrame(42, SECRET, { mentions: ["me"] }) as unknown as MsgFrame;
+}
+function ctx(contextDir: string) {
+  return { cmd: "", channel: "dev", self: "me", contextDir, recent: [] as MsgFrame[] };
+}
+
+describe("builtin runner 不得把消息正文放进 argv (#120)", () => {
+  test("codex 的 argv 里不出现正文 / charter，只出现 context 文件路径", async () => {
+    let captured: string[] = [];
+    const runProcess: RunnerProcess = async (args) => {
+      captured = args;
+      return { code: 0, stdout: "session id: 019f35d9-0000-7000-8000-000000000001\n", stderr: "" };
+    };
+    await createBuiltinRunner({
+      server: "http://agentparty.test",
+      token: "ap_tok",
+      channel: "dev",
+      harness: "codex",
+      workdir: tmp(),
+      runProcess,
+      post: async () => ({ seq: 1 }),
+    })(frame(), {
+      ...ctx(tmp()),
+      charter: { charter: "CHARTER_SECRET_TEXT", charter_rev: 1, updated_at: 0, updated_by: "x" },
+    });
+
+    const argv = captured.join(" ");
+    // ps -axww 对同机任意用户可见。正文和 charter 绝不能出现在这里。
+    expect(argv).not.toContain(SECRET);
+    expect(argv).not.toContain("CHARTER_SECRET_TEXT");
+    // 但模型必须拿得到——通过 0700 私有目录里的 context 文件路径
+    expect(argv.includes("agentparty-serve-") || argv.includes("ap-argv-")).toBe(true);
+    expect(argv).toContain(".json");
+  });
+
+  test("claude harness 同样不泄漏", async () => {
+    let captured: string[] = [];
+    const runProcess: RunnerProcess = async (args) => {
+      captured = args;
+      return { code: 0, stdout: JSON.stringify({ result: "ok", session_id: "abc" }), stderr: "" };
+    };
+    await createBuiltinRunner({
+      server: "http://agentparty.test",
+      token: "ap_tok",
+      channel: "dev",
+      harness: "claude",
+      workdir: tmp(),
+      runProcess,
+      post: async () => ({ seq: 1 }),
+    })(frame(), ctx(tmp()));
+
+    expect(captured.join(" ")).not.toContain(SECRET);
+  });
+});
+
+describe("AP_BODY 不得把未截断正文塞进 env (#120)", () => {
+  test("大正文：env 里被截断并打上 AP_BODY_TRUNCATED=1，完整正文仍走 stdin", async () => {
+    const outDir = tmp();
+    const big = "B".repeat(10_000);
+    let server: MockServer | null = null;
+    server = startMockServer((f, sock) => {
+      if (f.type !== "hello") return;
+      sock.send(welcomeFrame(0, "me"));
+      setTimeout(() => sock.send(msgFrame(1, big, { mentions: ["me"] })), 20);
+      setTimeout(() => sock.send({ type: "error", code: "archived", message: "done" }), 120);
+    });
+    try {
+      const code = await runServe({
+        server: server.url,
+        token: "ap_tok",
+        channel: "dev",
+        since: 0,
+        mentionsOnly: true,
+        out: () => {},
+        // env 长度、截断标志、stdin 长度各写一个文件
+        cmd: `printf '%s' "$AP_BODY" | wc -c > ${outDir}/envlen; printf '%s' "$AP_BODY_TRUNCATED" > ${outDir}/flag; wc -c > ${outDir}/stdinlen`,
+      });
+      expect(code).toBe(EXIT_ARCHIVED);
+
+      const envLen = Number(readFileSync(join(outDir, "envlen"), "utf8").trim());
+      const stdinLen = Number(readFileSync(join(outDir, "stdinlen"), "utf8").trim());
+      expect(readFileSync(join(outDir, "flag"), "utf8").trim()).toBe("1");
+      expect(envLen).toBeLessThan(big.length); // env 里被截断
+      expect(stdinLen).toBe(big.length); // stdin 拿到完整正文（stdin 不进 ps）
+    } finally {
+      server?.stop();
+    }
+  });
+
+  test("小正文：不截断，标志为 0", async () => {
+    const outDir = tmp();
+    let server: MockServer | null = null;
+    server = startMockServer((f, sock) => {
+      if (f.type !== "hello") return;
+      sock.send(welcomeFrame(0, "me"));
+      setTimeout(() => sock.send(msgFrame(1, "short", { mentions: ["me"] })), 20);
+      setTimeout(() => sock.send({ type: "error", code: "archived", message: "done" }), 120);
+    });
+    try {
+      await runServe({
+        server: server.url,
+        token: "ap_tok",
+        channel: "dev",
+        since: 0,
+        mentionsOnly: true,
+        out: () => {},
+        cmd: `printf '%s' "$AP_BODY" > ${outDir}/body; printf '%s' "$AP_BODY_TRUNCATED" > ${outDir}/flag`,
+      });
+      expect(readFileSync(join(outDir, "body"), "utf8")).toBe("short");
+      expect(readFileSync(join(outDir, "flag"), "utf8").trim()).toBe("0");
+    } finally {
+      server?.stop();
+    }
+  });
+});

--- a/cli/test/serve-context-identity.test.ts
+++ b/cli/test/serve-context-identity.test.ts
@@ -1,0 +1,50 @@
+// #197：serve 的唤醒上下文按 channel+seq 落盘，路径不含身份。
+// 同机多个 agent serve 同一频道时（README/SKILL 推荐的拓扑），同一条消息 → 同一个文件，
+// 后写的赢。runner 会读到**另一个 agent 的上下文**，其中 self 是别人的名字。
+// 而 --runner claude|codex 把这个文件直接喂给模型，protocol_reminder 还叫模型「先读本文件」。
+import { describe, expect, test } from "bun:test";
+import { readFileSync, unlinkSync } from "node:fs";
+import { EXIT_ARCHIVED, type MsgFrame } from "@agentparty/shared";
+import { writeContextFile } from "../src/commands/serve";
+import { msgFrame } from "./mock-server";
+
+function frame(seq: number): MsgFrame {
+  return msgFrame(seq, "@both of you", { mentions: ["alice", "bob"] }) as unknown as MsgFrame;
+}
+
+describe("serve 唤醒上下文按身份隔离 (#197)", () => {
+  test("同一频道、同一 seq、不同身份 → 不同文件，互不覆盖", () => {
+    const a = writeContextFile(frame(272), "dev", "alice", []);
+    const b = writeContextFile(frame(272), "dev", "bob", []);
+    try {
+      expect(a).not.toBe(b);
+      // 两份上下文各自说自己是谁——这是 #197 的核心：模型不能被告知自己是另一个 agent
+      expect(JSON.parse(readFileSync(a, "utf8")).self).toBe("alice");
+      expect(JSON.parse(readFileSync(b, "utf8")).self).toBe("bob");
+    } finally {
+      unlinkSync(a);
+      unlinkSync(b);
+    }
+  });
+
+  test("身份里的路径分隔符/点号不得逃逸出 tmpdir", () => {
+    const p = writeContextFile(frame(1), "dev", "../../etc/passwd", []);
+    try {
+      expect(p).not.toContain("..");
+      expect(p).not.toContain("/etc/passwd");
+      expect(JSON.parse(readFileSync(p, "utf8")).self).toBe("../../etc/passwd"); // 正文里仍是原名
+    } finally {
+      unlinkSync(p);
+    }
+  });
+
+  test("同一身份、同一 seq 重复写 → 同一路径（幂等，不堆垃圾）", () => {
+    const a = writeContextFile(frame(9), "dev", "alice", []);
+    const b = writeContextFile(frame(9), "dev", "alice", []);
+    try {
+      expect(a).toBe(b);
+    } finally {
+      unlinkSync(a);
+    }
+  });
+});

--- a/cli/test/serve-context-identity.test.ts
+++ b/cli/test/serve-context-identity.test.ts
@@ -1,50 +1,80 @@
-// #197：serve 的唤醒上下文按 channel+seq 落盘，路径不含身份。
-// 同机多个 agent serve 同一频道时（README/SKILL 推荐的拓扑），同一条消息 → 同一个文件，
-// 后写的赢。runner 会读到**另一个 agent 的上下文**，其中 self 是别人的名字。
-// 而 --runner claude|codex 把这个文件直接喂给模型，protocol_reminder 还叫模型「先读本文件」。
-import { describe, expect, test } from "bun:test";
-import { readFileSync, unlinkSync } from "node:fs";
-import { EXIT_ARCHIVED, type MsgFrame } from "@agentparty/shared";
-import { writeContextFile } from "../src/commands/serve";
+// #197：serve 的唤醒上下文按 channel+seq 落盘，路径不含身份 → 同机多个 agent serve
+// 同一频道时互相覆盖，runner 读到别人的上下文（self 是别人的名字），而 --runner claude|codex
+// 把这个文件直接喂给模型。
+//
+// 回炉（190-codex-dev / LEO-MAIN on PR #208）：把身份塞进文件名是**有损映射**——
+// `tenant|alice` 与 `tenant/alice` 消毒后同名；文件名也没有 server/profile 维度，
+// 一个用户同时连 prod / test 私有部署仍会串；长 IdP subject 还会 ENAMETOOLONG。
+// 正解是每个 serve 实例一个私有 mkdtemp 命名空间。
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { type MsgFrame } from "@agentparty/shared";
+import { createWakeContextDir, writeContextFile } from "../src/commands/serve";
 import { msgFrame } from "./mock-server";
+
+const dirs: string[] = [];
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+
+function ctxDir(): string {
+  const d = createWakeContextDir();
+  dirs.push(d);
+  return d;
+}
 
 function frame(seq: number): MsgFrame {
   return msgFrame(seq, "@both of you", { mentions: ["alice", "bob"] }) as unknown as MsgFrame;
 }
 
-describe("serve 唤醒上下文按身份隔离 (#197)", () => {
-  test("同一频道、同一 seq、不同身份 → 不同文件，互不覆盖", () => {
-    const a = writeContextFile(frame(272), "dev", "alice", []);
-    const b = writeContextFile(frame(272), "dev", "bob", []);
-    try {
-      expect(a).not.toBe(b);
-      // 两份上下文各自说自己是谁——这是 #197 的核心：模型不能被告知自己是另一个 agent
-      expect(JSON.parse(readFileSync(a, "utf8")).self).toBe("alice");
-      expect(JSON.parse(readFileSync(b, "utf8")).self).toBe("bob");
-    } finally {
-      unlinkSync(a);
-      unlinkSync(b);
-    }
+describe("serve 唤醒上下文按实例隔离 (#197 / #208 回炉)", () => {
+  test("两个 serve 实例（同频道同 seq，不同身份）→ 不同文件，互不覆盖", () => {
+    const a = writeContextFile(ctxDir(), frame(272), "dev", "alice", []);
+    const b = writeContextFile(ctxDir(), frame(272), "dev", "bob", []);
+    expect(a).not.toBe(b);
+    expect(JSON.parse(readFileSync(a, "utf8")).self).toBe("alice");
+    expect(JSON.parse(readFileSync(b, "utf8")).self).toBe("bob");
   });
 
-  test("身份里的路径分隔符/点号不得逃逸出 tmpdir", () => {
-    const p = writeContextFile(frame(1), "dev", "../../etc/passwd", []);
-    try {
-      expect(p).not.toContain("..");
-      expect(p).not.toContain("/etc/passwd");
-      expect(JSON.parse(readFileSync(p, "utf8")).self).toBe("../../etc/passwd"); // 正文里仍是原名
-    } finally {
-      unlinkSync(p);
-    }
+  test("有损碰撞不复存在：`tenant|alice` 与 `tenant/alice` 是不同实例，写不到一起", () => {
+    // 这两个身份任何「消毒成文件名」的方案都会映射成同名。私有目录方案里它们压根不进路径。
+    const a = writeContextFile(ctxDir(), frame(9), "dev", "tenant|alice", []);
+    const b = writeContextFile(ctxDir(), frame(9), "dev", "tenant/alice", []);
+    expect(a).not.toBe(b);
+    expect(existsSync(a)).toBe(true);
+    expect(existsSync(b)).toBe(true);
+    expect(JSON.parse(readFileSync(a, "utf8")).self).toBe("tenant|alice");
+    expect(JSON.parse(readFileSync(b, "utf8")).self).toBe("tenant/alice");
   });
 
-  test("同一身份、同一 seq 重复写 → 同一路径（幂等，不堆垃圾）", () => {
-    const a = writeContextFile(frame(9), "dev", "alice", []);
-    const b = writeContextFile(frame(9), "dev", "alice", []);
-    try {
-      expect(a).toBe(b);
-    } finally {
-      unlinkSync(a);
-    }
+  test("跨部署不串：同频道同身份同 seq，连 prod 与 test 的两个实例各写各的", () => {
+    const a = writeContextFile(ctxDir(), frame(5), "agentparty", "leo", []);
+    const b = writeContextFile(ctxDir(), frame(5), "agentparty", "leo", []);
+    expect(a).not.toBe(b);
+  });
+
+  test("超长 IdP subject 不撑爆文件名（ENAMETOOLONG）", () => {
+    const longSelf = "oidc|" + "x".repeat(4000);
+    const p = writeContextFile(ctxDir(), frame(1), "dev", longSelf, []);
+    expect(existsSync(p)).toBe(true);
+    // 路径长度由目录决定，与身份长度无关
+    expect(p.length).toBeLessThan(256);
+    expect(JSON.parse(readFileSync(p, "utf8")).self).toBe(longSelf); // 正文里仍是原名
+  });
+
+  test("同一实例、同一 seq 重复写 → 同一路径（幂等，不堆垃圾）", () => {
+    const d = ctxDir();
+    const a = writeContextFile(d, frame(9), "dev", "alice", []);
+    const b = writeContextFile(d, frame(9), "dev", "alice", []);
+    expect(a).toBe(b);
+    expect(readdirSync(d)).toHaveLength(1);
+  });
+
+  test("私有目录只有属主可进（0700）", () => {
+    const d = ctxDir();
+    const { statSync } = require("node:fs");
+    expect(statSync(d).mode & 0o777).toBe(0o700);
   });
 });

--- a/cli/test/serve-failure-ack.test.ts
+++ b/cli/test/serve-failure-ack.test.ts
@@ -30,7 +30,7 @@ function triggerFrame(seq = 7): MsgFrame {
 }
 
 function runnerCtx() {
-  return { cmd: "", channel: "dev", self: "me", recent: [] as MsgFrame[] };
+  return { cmd: "", channel: "dev", self: "me", contextDir: mkdtempSync(join(tmpdir(), "ap-ctx-")), recent: [] as MsgFrame[] };
 }
 
 function opts(over: Partial<ServeOptions> & { server: string }): ServeOptions & { lines: string[] } {

--- a/cli/test/serve.test.ts
+++ b/cli/test/serve.test.ts
@@ -63,7 +63,7 @@ function triggerFrame(seq = 7): MsgFrame {
 }
 
 function runnerCtx() {
-  return { cmd: "", channel: "dev", self: "me", recent: [] as MsgFrame[] };
+  return { cmd: "", channel: "dev", self: "me", contextDir: tempDir("ap-ctx-"), recent: [] as MsgFrame[] };
 }
 
 function uuid(n: number): string {
@@ -160,7 +160,7 @@ describe("runServe", () => {
       msgFrame(7, "context A") as unknown as MsgFrame,
       msgFrame(8, "x".repeat(500)) as unknown as MsgFrame, // 正文要截断
     ];
-    const path = writeContextFile(trigger, "dev", "me", prior);
+    const path = writeContextFile(tempDir("ap-ctx-"), trigger, "dev", "me", prior);
     try {
       const ctx = JSON.parse(readFileSync(path, "utf8"));
       expect(ctx).toMatchObject({ channel: "dev", seq: 9, self: "me", reply_to: 9 });
@@ -880,7 +880,7 @@ describe("codex-sdk runner", () => {
       }),
     })(
       msgFrame(103, "do it", { mentions: ["me"], sender: { name: "alice", kind: "human" } }) as unknown as MsgFrame,
-      { cmd: "", channel: "dev", self: "me", recent: [prior] },
+      { cmd: "", channel: "dev", self: "me", contextDir: tempDir("ap-ctx-"), recent: [prior] },
     );
 
     const ctx = JSON.parse(prompts[0]!);

--- a/cli/test/serve.test.ts
+++ b/cli/test/serve.test.ts
@@ -530,9 +530,14 @@ describe("builtin runner", () => {
   test("builtin runner prompt includes CLI upgrade notice and asks the user before continuing", async () => {
     const { post } = postRecorder();
     const workdir = tempDir();
+    // prompt 里只有 context 文件路径（#120：argv 对同机任意用户可见，不放正文/charter）。
+    // 升级提示随 context 文件送达模型，趁 runner 还在跑时读出来断言。
+    let ctxFromFile: Record<string, unknown> = {};
     let prompt = "";
     const runProcess: RunnerProcess = async (args) => {
       prompt = String(args.at(-1));
+      const m = prompt.match(/(\/[^\s]*\.json)/);
+      if (m) ctxFromFile = JSON.parse(readFileSync(m[0], "utf8"));
       const out = args[args.indexOf("-o") + 1]!;
       writeFileSync(out, "I will ask first.\n");
       return { code: 0, stdout: `session id: ${uuid(7)}\n`, stderr: "" };
@@ -558,7 +563,9 @@ describe("builtin runner", () => {
       },
     });
 
-    const ctx = JSON.parse(prompt);
+    // argv 里只有路径，没有正文
+    expect(prompt).not.toContain("wake up");
+    const ctx = ctxFromFile as { cli_upgrade: { message: string } };
     expect(ctx.cli_upgrade).toMatchObject({
       installed_version: "0.2.73",
       action_required: "ask_user",


### PR DESCRIPTION
> 频道身份：leo-codex-main-dev（#agentparty）
> **Stacked PR**：base 是 #206 的分支 `fix/serve-ack-on-failure`（同一文件 `serve.ts`，避免冲突）。#206 合并后本 PR 的 base 会自动变成 main。

Closes #197

## 根因

`cli/src/commands/serve.ts` 的 `writeContextFile`：路径只由 **channel + seq** 决定，**不含身份**。同机多个 agent serve 同一频道 → 同一条消息 → 同一个文件，后写的赢。

消费方把该路径交给 `--on-mention` 或直接喂给 `claude` / `codex`，而 `protocol_reminder` 明写「被 @ 唤起：先读本文件」。**模型会被告知自己是另一个 agent。**

`mode: 0o600` 挡的是别的 unix 用户，**挡不住同一用户下的兄弟 agent**——而「一台机器多个 agent」正是 README / SKILL 推荐的拓扑。

## 证据（实测，非推断）

身份 `leo-codex-main-dev` 的 runner 在 seq 272 收到的上下文里 `"self": "leo-claude"`。排除服务端：用该 token 直连 WS，`welcome.self` 正确返回 `leo-codex-main-dev`（`worker/src/index.ts:4474` 剥离客户端头后用 token 解析的 `identity.name`；`worker/src/do.ts:1031` 回 `self: state.name`）。发出的消息署名也正确。**是本地文件被同机另一个 serve 覆盖了。**

`$TMPDIR` 残留文件里同一命名空间存在两个不同的 `self`：`code-learning` 与 `leo-claude`。

## 改动

路径改为 `agentparty-serve-<channel>-<self>-<seq>.json`，并对进入路径的片段消毒（`..` 与分隔符失去含义）。**正文里的 `self` 仍是原始名字。**

## 门禁

`401 pass / 0 fail` · `bunx tsc --noEmit` clean（CLI 用 `bun test`，不是 vitest）

| 变异 | 结果 |
|---|---|
| 路径去掉身份（= 修复前） | 「不同身份 → 不同文件」**红** |
| 去掉路径消毒 | 「不得逃逸出 tmpdir」**红** |

## 遗留

- 仍未解决**同一身份**的两个 serve 进程互相覆盖（#99：同名 agent 多个 serve 无租约）。加 pid 会破坏幂等（同一次唤醒重复写应得同一路径），留给 #99 用租约解决。
- 成功的 `defaultRun` 会 `unlink` 该文件；同身份并发仍可能读到一半被删。同归 #99。
- 自建 runner 不应信任文件里的 `self`，应改用环境变量 `AP_SELF`（来自本连接 welcome 帧，可信）。
