### PR TITLE
fix(cli): whoami 打印生效 server，不再让 account session 的 server 冒充落点

### DIFF
--- a/cli/src/commands/whoami.ts
+++ b/cli/src/commands/whoami.ts
@@ -53,12 +53,18 @@ export async function run(argv: string[]): Promise<number> {
         ts: nowTs(),
         logged_in: false,
         server: null,
+        // issue #140：命令实际会打到哪台 server 是最要紧的字段，即便还没登录也不该缺失——
+        // effective_server 是解析出来的落点（可能来自 config，即便没有可用 token），
+        // account_server 单独给账号会话的 server，二者不该被合并成一个含糊的字段。
+        effective_server: auth.server,
+        account_server: auth.account.server ?? null,
         auth_source: auth.auth_source,
         account: auth.account,
         config: auth.config,
       })));
     } else {
       console.log("runtime: not logged in");
+      console.log(`server: ${auth.server ?? "none (no config server and no account session)"}`);
       console.log(`account: ${auth.account.present ? `${auth.account.email ?? auth.account.sub ?? "present"} present server=${auth.account.server}` : `absent path=${auth.account.path}`}`);
       console.log(`config: ${auth.config.path ? `${auth.config.kind} ${auth.config.path}` : "none"}`);
       console.log(`auth-source: ${auth.auth_source}`);
@@ -91,6 +97,11 @@ export async function run(argv: string[]): Promise<number> {
         ts: nowTs(),
         logged_in: true,
         server: auth.server,
+        // issue #140：agent 不该靠解析 `account:` 那行的人话来判断落点——effective_server 是
+        // /api/me 实际打的 server（与顶层 server 同值，换个不含糊的名字方便工具直接取），
+        // account_server 是账号会话自己的 server，二者可能不同，分开给才不会被混用。
+        effective_server: auth.server,
+        account_server: auth.account.server ?? null,
         ...me,
         auth_source: auth.auth_source,
         runtime: {
@@ -107,10 +118,24 @@ export async function run(argv: string[]): Promise<number> {
       })));
     } else {
       const who = me.email ?? me.name;
-      console.log(`runtime: logged in as ${who} (${me.kind}/${me.role})`);
+      // issue #140：这行是 agent 读 whoami 时最先看到的一行，生效 server 必须就在这里，
+      // 不能只靠底下的 account: 行（那行印的是账号会话的 server，可能是另一台机器）。
+      console.log(`runtime: logged in as ${who} (${me.kind}/${me.role}) server=${auth.server}`);
       if (me.owner) console.log(`  owner: ${me.owner}`);
       console.log(`  scope: ${me.channel_scope ?? "none (all channels)"}`);
-      console.log(`account: ${auth.account.present ? `${auth.account.email ?? auth.account.sub ?? "present"} present server=${auth.account.server}` : `absent path=${auth.account.path}`}`);
+      // account session 的 server 可能和生效 server 不是同一台（人类登录过另一台部署的常态），
+      // 不标注清楚，agent 会把这行的 URL 误当成命令实际打到的地方。
+      const accountServerMismatch =
+        auth.account.present && auth.account.server !== undefined && auth.account.server !== auth.server;
+      console.log(
+        `account: ${
+          auth.account.present
+            ? `${auth.account.email ?? auth.account.sub ?? "present"} present server=${auth.account.server}${
+                accountServerMismatch ? " (different server — not used for this command)" : ""
+              }`
+            : `absent path=${auth.account.path}`
+        }`,
+      );
       console.log(`config: ${auth.config.path ? `${auth.config.kind} ${auth.config.path} token=${auth.config.token_fingerprint ?? "none"}` : "none"}`);
       console.log(`auth-source: ${auth.auth_source}`);
       if (rejoin) {

--- a/cli/test/account-commands.test.ts
+++ b/cli/test/account-commands.test.ts
@@ -448,6 +448,99 @@ describe("whoami", () => {
     expect(code).toBe(1);
     expect(errs.join("\n")).toContain("unknown option --bogus");
   });
+
+  // issue #140：runtime config 指向 server A，account.json 是另一台 server B 的人类会话——
+  // /api/me 打的是 A，但旧输出只印 account 那行的 B，agent 会误判自己在 B 上。
+  describe("effective server disambiguation (issue #140)", () => {
+    test("text mode: runtime line shows the server /api/me was actually called against", async () => {
+      restMock = startRestMock();
+      writeConfig({ server: restMock.url, token: "ap_effective" });
+      writeAccount({
+        server: "https://agentparty.other-server.example",
+        refresh_token: "ref",
+        access_token: "acc-live",
+        email: "human@example.com",
+        expires_at: nowSec() + 3600,
+      });
+
+      const code = await whoamiRun([]);
+      expect(code).toBe(0);
+      const stdout = logs.join("\n");
+      // 生效 server（runtime_config 那个，也是 /api/me 实打的那个）必须出现在 runtime 行
+      expect(stdout).toContain(`runtime: logged in as agent (agent/agent) server=${restMock.url}`);
+      expect(restMock.requests.some((r) => r.path === "/api/me" && r.method === "GET")).toBe(true);
+    });
+
+    test("text mode: account line flags a server mismatch instead of silently implying it's in effect", async () => {
+      restMock = startRestMock();
+      writeConfig({ server: restMock.url, token: "ap_effective" });
+      writeAccount({
+        server: "https://agentparty.other-server.example",
+        refresh_token: "ref",
+        access_token: "acc-live",
+        email: "human@example.com",
+        expires_at: nowSec() + 3600,
+      });
+
+      const code = await whoamiRun([]);
+      expect(code).toBe(0);
+      const stdout = logs.join("\n");
+      expect(stdout).toContain("account: human@example.com present server=https://agentparty.other-server.example");
+      expect(stdout).toContain("different server");
+      expect(stdout).toContain("not used for this command");
+    });
+
+    test("text mode: no mismatch annotation when the account session is on the effective server", async () => {
+      mock = startOidcMock();
+      liveAccount(mock.url); // config 里没 token，回落 account_session，同一台 server
+      const code = await whoamiRun([]);
+      expect(code).toBe(0);
+      const stdout = logs.join("\n");
+      expect(stdout).toContain(`runtime: logged in as fan@example.com (human/human) server=${mock.url}`);
+      expect(stdout).not.toContain("different server");
+    });
+
+    test("json mode: effective_server and account_server are distinct, unambiguous fields", async () => {
+      restMock = startRestMock();
+      writeConfig({ server: restMock.url, token: "ap_effective" });
+      writeAccount({
+        server: "https://agentparty.other-server.example",
+        refresh_token: "ref",
+        access_token: "acc-live",
+        email: "human@example.com",
+        expires_at: nowSec() + 3600,
+      });
+
+      const code = await whoamiRun(["--json"]);
+      expect(code).toBe(0);
+      const frame = JSON.parse(logs[0]!);
+      expect(frame.effective_server).toBe(restMock!.url);
+      expect(frame.account_server).toBe("https://agentparty.other-server.example");
+      // 生效 server 不能和 account server 撞车，否则整个字段就是摆设
+      expect(frame.effective_server).not.toBe(frame.account_server);
+      // 既有的顶层 server 字段必须继续等于生效 server（合约不能破）
+      expect(frame.server).toBe(frame.effective_server);
+    });
+
+    test("text mode: not-logged-in path still prints the resolved config server", async () => {
+      writeConfig({ server: "https://agentparty.config-only.example", token: "" });
+      const code = await whoamiRun([]);
+      expect(code).toBe(0);
+      const stdout = logs.join("\n");
+      expect(stdout).toContain("not logged in");
+      expect(stdout).toContain("server: https://agentparty.config-only.example");
+    });
+
+    test("json mode: not-logged-in path still reports effective_server/account_server", async () => {
+      writeConfig({ server: "https://agentparty.config-only.example", token: "" });
+      const code = await whoamiRun(["--json"]);
+      expect(code).toBe(0);
+      const frame = JSON.parse(logs[0]!);
+      expect(frame.logged_in).toBe(false);
+      expect(frame.effective_server).toBe("https://agentparty.config-only.example");
+      expect(frame.account_server).toBe(null);
+    });
+  });
 });
 
 describe("statusline", () => {


### PR DESCRIPTION
> 频道身份：leo-codex-main-dev（#agentparty）

Closes #140

## 现象 → 根因（实测）

issue 描述属实（复现方式：config 走 `runtime_config`、account.json 是另一台 server 的人类登录会话）：`party whoami` 文本模式从不打印**生效 server**（`/api/me` 实际打的那台），只打印 `account:` 那行——即账号会话自己的 server，可能是另一台部署。

根因定位在 `cli/src/commands/whoami.ts`：

- `resolveAuthDetailed()`（`cli/src/oidc-cli.ts:346-389`）已经正确解析出生效 server（`auth.server`，`runtime_config` 优先，`account_session` 兜底），并且真实用它去 `fetchMe(auth.server, ...)`（`whoami.ts:75`）。
- 但文本模式渲染时，`auth.server` 从未被打印：
  - `whoami.ts:110`（旧）`runtime: logged in as ${who} (${me.kind}/${me.role})` — 没有 server
  - `whoami.ts:62/113`（旧）`account: ... server=${auth.account.server}` — 打印的是 account session 的 server，读者极易误当成生效 server
  - `whoami.ts:60-66`（旧，未登录分支）连 server 字段都完全没有
- `--json` 模式其实在顶层已经有 `server: auth.server`（`whoami.ts:93`，旧代码），所以 JSON 消费方本没有这个信息缺口；缺口只在**文本模式**——这一点比 issue 原文暗示的（JSON 也缺）略窄，一并澄清。

## 修复

`cli/src/commands/whoami.ts`：

1. 文本模式 `runtime:` 行追加 `server=<生效 server>`（登录与未登录分支都补，未登录分支原来完全没有 server 信息）。
2. 文本模式 `account:` 行：当 account session 的 server 与生效 server 不同，追加 `(different server — not used for this command)`。
3. `--json` 模式追加 `effective_server` / `account_server` 两个显式字段（登录、未登录分支都补），不再需要工具方去 diff 顶层 `server` 和 `account.server` 猜哪个在生效——这是 issue 建议 #3 的直接落地。

未改动 `cli/src/config.ts`（PR #206 在改，按要求只读不改）、`serve.ts`、`watch.ts`。

## 变异表（逐接线点拆解，`cd cli && bun test test/account-commands.test.ts`）

| # | 变异点（文件:行） | 操作 | 结果 |
|---|---|---|---|
| 1 | `whoami.ts:67` 未登录文本分支 `server:` 行 | 删除该行 | `text mode: not-logged-in path still prints the resolved config server` 精确变红，其余 38 条绿 |
| 2 | `whoami.ts:59-60` 未登录 JSON `effective_server`/`account_server` | 删除两行 | `json mode: not-logged-in path still reports effective_server/account_server` 精确变红 |
| 3 | `whoami.ts:103-104` 登录 JSON `effective_server`/`account_server` | 删除两行 | `json mode: effective_server and account_server are distinct, unambiguous fields` 精确变红 |
| 4 | `whoami.ts:123` `runtime:` 行 `server=${auth.server}` 后缀 | 去掉后缀 | 两条测试精确变红：`runtime line shows the server /api/me was actually called against`、`no mismatch annotation when the account session is on the effective server`（后者也断言了 runtime 行含 server=，是合理的双重覆盖，不是死代码） |
| 5 | `whoami.ts:128-129` `accountServerMismatch` 判定逻辑 | 硬编码为 `false` | `account line flags a server mismatch instead of silently implying it's in effect` 精确变红 |

5 处变异，5 处都有测试精确响应，无死代码。每次变异后单独跑过 `bun test test/account-commands.test.ts`，变红后立即用 `cp` 快照复原，复原后 `cmp` 确认与实现字节级一致。

## 门禁输出（实测）

```
$ cd cli && bunx tsc --noEmit
（无输出，exit 0）

$ cd cli && bun test test/account-commands.test.ts
 39 pass
 0 fail
 140 expect() calls

$ cd cli && bun test
 384 pass
 0 fail
 1 snapshots, 1393 expect() calls
```

（首轮全量曾出现 1 条 `cli.test.ts` 失败，是并发子进程压力下的偶发超时——单独重跑该文件、以及重跑整个套件两次都是 384/384 绿，与本次改动无关，判定为已知的 subprocess 冒烟测试抖动，不是本 PR 引入的。）

## 证据分级

- **实测**：上面变异表全部 5 条、tsc、bun test 全量，均为本地实际运行结果，非推断。
- **读代码推断**：`--json` 模式此前已含 `server: auth.server` 顶层字段的结论，来自读 `whoami.ts` 旧代码（未专门写 contract 测试验证旧版本行为，因为旧版本已被本 PR 替换，没有必要单独复现）；`resolveAuthDetailed()` 内部优先级注释（`oidc-cli.ts:340-345`）按已有注释转述，未逐行重新验证其历史正确性（不在本 issue 范围内）。

## 遗留问题 / 未做

- issue 建议 #2 用词是 "account 行加显式标注"，本 PR 用的文案是 `(different server — not used for this command)`；没有另做 `--caps` 或 `--rejoin` 场景下的专项断言，但这两个 flag 复用同一套 `runtime:`/`account:` 行，逻辑上已覆盖。
- 未触碰 `cli/src/config.ts`、`serve.ts`、`watch.ts`（按要求，PR #206 在改）。
- 未验证真实生产环境（`agentparty.leeguoo.com` vs `agentparty.pwtk-dev.work`）下的人工复现，只用本地 mock server 复现了同构场景（config token 指向 server A，account.json 指向不同的 server B 字符串）。
