### PR TITLE
fix(web): 静默续期不再清空 channels（#123）

### DIFF
--- a/web/src/App.renewal.test.tsx
+++ b/web/src/App.renewal.test.tsx
@@ -1,0 +1,358 @@
+// @ts-expect-error Bun executes this test, while the web tsconfig intentionally loads only Vite globals.
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { LocaleProvider } from "./i18n/locale";
+
+// #123：静默续期（同身份换 token）不应清空 channels——清空会连带卸载 ChannelPage，
+// 丢草稿和滚动位置。本文件钉住「同身份不清空」这条新行为，以及一直存在、但此前
+// 零测试保护的 late-response `alive` 守卫（防止旧身份的陈旧响应覆盖新身份的 UI）。
+// 范式照抄已在 main 上的 App.identity.test.tsx（react-test-renderer + mock.module + memoryStorage）。
+
+mock.module("dompurify", () => ({
+  default: {
+    addHook: () => {},
+    sanitize: (value: string) => value,
+  },
+}));
+
+const { App } = await import("./App");
+
+function memoryStorage(): Storage {
+  const values = new Map<string, string>();
+  return {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => { values.set(key, value); },
+    removeItem: (key) => { values.delete(key); },
+    clear: () => values.clear(),
+    key: (index) => [...values.keys()][index] ?? null,
+    get length() { return values.size; },
+  };
+}
+
+function jwt(sub: string, generation = 1): string {
+  const encode = (value: string) => btoa(value).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+  return `${encode('{"alg":"none"}')}.${encode(JSON.stringify({ sub, generation }))}.sig`;
+}
+
+function session(accessToken: string, refreshToken: string, expiresAt: number) {
+  return {
+    accessToken,
+    refreshToken,
+    expiresAt,
+    identity: JSON.parse(atob(accessToken.split(".")[1]!)) as { sub: string },
+  };
+}
+
+function storedSession(
+  accessToken: string,
+  refreshToken: string,
+  expiresAt = Math.floor(Date.now() / 1000) - 60,
+) {
+  const value = session(accessToken, refreshToken, expiresAt);
+  return JSON.stringify({ ...value, identity: value.identity.sub });
+}
+
+function authHeader(init?: RequestInit): string | null {
+  return new Headers(init?.headers).get("authorization")?.replace(/^Bearer /, "") ?? null;
+}
+
+function meResponse() {
+  return new Response(JSON.stringify({
+    name: "human-a",
+    email: "a@example.com",
+    kind: "human",
+    handle: "human-a",
+    display_name: "Human A",
+    avatar_url: null,
+    avatar_thumb: null,
+    provider: "oidc",
+    tenant_key: null,
+    role: "human",
+    owner: null,
+  }), { status: 200 });
+}
+
+function channelsPayload(slug: string, title: string): string {
+  return JSON.stringify({
+    channels: [{
+      slug,
+      title,
+      topic: null,
+      kind: "standing",
+      mode: "normal",
+      visibility: "private",
+      created_at: 0,
+      archived_at: null,
+      last_message: null,
+      presence: [],
+    }],
+  });
+}
+
+function deferredResponse() {
+  let resolve!: (response: Response) => void;
+  const promise = new Promise<Response>((done) => { resolve = done; });
+  return { promise, resolve };
+}
+
+/** 让一个真实宏任务 tick 过去，供 fetch / 定时器链路往前推进一步。 */
+async function tick(times = 1): Promise<void> {
+  for (let i = 0; i < times; i += 1) {
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  }
+}
+
+/**
+ * 轮询等到条件成立——比固定 tick 数更稳：React 的被动 effect（useEffect）经调度器异步落地，
+ * 不保证在固定几个 setTimeout(0) 内完成，用条件轮询避免这条链路的时序假设写死在测试里。
+ */
+async function waitFor(predicate: () => boolean, maxTicks = 200): Promise<void> {
+  // 每个 tick 单独包一层 act()：如果整个轮询都窝在外层同一个 act() 回调里，
+  // react-test-renderer 的被动 effect（useEffect）要等这个 act() 整体 resolve
+  // 才会真正 flush——会跟"轮询直到某个由 effect 触发的条件成立"互相死等。
+  // 单独开合 act() 才能让每一轮 tick 之间的 effect 有机会落地。
+  for (let i = 0; i < maxTicks; i += 1) {
+    if (predicate()) return;
+    await act(async () => { await tick(1); });
+  }
+  if (!predicate()) throw new Error(`waitFor: condition still false after ${maxTicks} ticks`);
+}
+
+/** 给「什么都不该发生」这类反向断言留出机会窗口——每个 tick 各自开合 act()，理由同 waitFor。 */
+async function settle(ticks = 6): Promise<void> {
+  for (let i = 0; i < ticks; i += 1) {
+    await act(async () => { await tick(1); });
+  }
+}
+
+function classTokens(className: unknown): string[] {
+  return typeof className === "string" ? className.split(/\s+/).filter(Boolean) : [];
+}
+
+/** 语义断言用：只看渲染树里是否存在某个 className 标记的节点，不看内部实现变量。 */
+function hasClassName(renderer: ReactTestRenderer, className: string): boolean {
+  return renderer.root.findAll((node) => classTokens(node.props.className).includes(className)).length > 0;
+}
+
+/**
+ * 侧栏当前渲染的「真实频道」标题列表——特意排除建频道的"+"入口贴片（CreateChannel 组件也复用了
+ * chan-pill / chan-name 这两个 class，但它是常驻的、跟 channels 是否加载无关，用 newchan-open
+ * 这个只有它才有的 class 排掉，避免语义断言被这枚无关元素污染）。
+ */
+function channelPillTitles(renderer: ReactTestRenderer): string[] {
+  return renderer.root
+    .findAll((node) => {
+      const tokens = classTokens(node.props.className);
+      return tokens.includes("chan-pill") && !tokens.includes("newchan-open");
+    })
+    .map((node) => {
+      const nameNode = node.findAll((n) => classTokens(n.props.className).includes("chan-name"))[0];
+      return (nameNode?.children.filter((c): c is string => typeof c === "string").join("")) ?? "";
+    });
+}
+
+let renderer: ReactTestRenderer | null = null;
+const globalKeys = [
+  "IS_REACT_ACT_ENVIRONMENT",
+  "localStorage",
+  "sessionStorage",
+  "location",
+  "history",
+  "window",
+  "document",
+  "navigator",
+  "fetch",
+] as const;
+const originalGlobals = new Map(
+  globalKeys.map((key) => [key, Object.getOwnPropertyDescriptor(globalThis, key)]),
+);
+
+beforeEach(() => {
+  Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", { configurable: true, value: true });
+  Object.defineProperty(globalThis, "localStorage", { configurable: true, value: memoryStorage() });
+  Object.defineProperty(globalThis, "sessionStorage", { configurable: true, value: memoryStorage() });
+  Object.defineProperty(globalThis, "location", {
+    configurable: true,
+    value: { pathname: "/", search: "", origin: "https://party.example", href: "https://party.example/" },
+  });
+  Object.defineProperty(globalThis, "history", {
+    configurable: true,
+    value: { pushState: () => {}, replaceState: () => {} },
+  });
+  const windowEvents = new EventTarget();
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      location: globalThis.location,
+      history: globalThis.history,
+      innerWidth: 1200,
+      innerHeight: 800,
+      setTimeout,
+      clearTimeout,
+      setInterval,
+      clearInterval,
+      addEventListener: windowEvents.addEventListener.bind(windowEvents),
+      removeEventListener: windowEvents.removeEventListener.bind(windowEvents),
+    },
+  });
+  const documentEvents = new EventTarget();
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: {
+      visibilityState: "visible",
+      addEventListener: documentEvents.addEventListener.bind(documentEvents),
+      removeEventListener: documentEvents.removeEventListener.bind(documentEvents),
+    },
+  });
+  Object.defineProperty(globalThis, "navigator", { configurable: true, value: { platform: "test" } });
+});
+
+afterEach(async () => {
+  if (renderer !== null) await act(async () => renderer?.unmount());
+  renderer = null;
+  for (const key of globalKeys) {
+    const descriptor = originalGlobals.get(key);
+    if (descriptor === undefined) Reflect.deleteProperty(globalThis, key);
+    else Object.defineProperty(globalThis, key, descriptor);
+  }
+});
+
+describe("App silent renewal keeps channels (#123)", () => {
+  test("same-identity silent renewal does not clear channels while the new list is in flight", async () => {
+    const tokenA = jwt("user-a");
+    const refreshedA = jwt("user-a", 2);
+    localStorage.setItem("ap_token", tokenA);
+    // 已过期（expiresAt 默认 now-60）：触发「到期前 60s 主动续期」定时器，delayMs=0 立即续期——
+    // 这正是 spec 说的「直接等 token 变化」，不需要人为造 401。
+    localStorage.setItem("ap_oidc_session", storedSession(tokenA, "refresh-a"));
+
+    const channelTokens: Array<string | null> = [];
+    let refreshCalls = 0;
+    const secondChannels = deferredResponse();
+
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: async (input: string | URL | Request, init?: RequestInit) => {
+        const url = String(input);
+        if (url.endsWith("/api/config")) {
+          return new Response(JSON.stringify({ oidc: { issuer: "https://idp.example", client_id: "web" } }));
+        }
+        if (url.endsWith("/api/channels")) {
+          channelTokens.push(authHeader(init));
+          if (channelTokens.length === 1) return new Response(channelsPayload("general", "general room"));
+          return secondChannels.promise;
+        }
+        if (url.endsWith("/api/me")) return meResponse();
+        if (url === "https://idp.example/token") {
+          refreshCalls += 1;
+          return new Response(JSON.stringify({
+            access_token: refreshedA,
+            refresh_token: "refresh-a-rotated",
+            expires_in: 600,
+          }));
+        }
+        throw new Error(`unexpected request: ${url}`);
+      },
+    });
+
+    await act(async () => {
+      renderer = create(<LocaleProvider><App /></LocaleProvider>);
+    });
+    // 等到第二次 listChannels（新 token）真正发起——它会一直挂在 secondChannels 上，
+    // 是观测「续期期间 channels 有没有被清空」的窗口。
+    await waitFor(() => channelTokens.length >= 2);
+
+    // 续期确实发生了、且 listChannels 至少被调用两次（旧 token 一次、新 token 一次）
+    expect(refreshCalls).toBe(1);
+    expect(channelTokens[0]).toBe(tokenA);
+    expect(channelTokens[channelTokens.length - 1]).toBe(refreshedA);
+
+    // 关键观测窗口：第二次 listChannels 请求还没 resolve（deferred），但 UI 不能回到「清空后」的
+    // 状态——语义断言，只看渲染树的结构标记（chan-cat-switch / chan-pill 只在 channels!==null 时渲染），
+    // 不看 alive 这个实现变量。
+    expect(hasClassName(renderer!, "chan-cat-switch")).toBe(true);
+    expect(channelPillTitles(renderer!)).toEqual(["general room"]);
+
+    await act(async () => {
+      secondChannels.resolve(new Response(channelsPayload("general", "general room v2")));
+    });
+    await waitFor(() => channelPillTitles(renderer!)[0] === "general room v2");
+
+    expect(hasClassName(renderer!, "chan-cat-switch")).toBe(true);
+    expect(channelPillTitles(renderer!)).toEqual(["general room v2"]);
+  });
+
+  test("a stale response from before an identity switch never overwrites the new identity's channels", async () => {
+    const tokenA = jwt("user-a");
+    const tokenB = jwt("user-b");
+    localStorage.setItem("ap_token", tokenA);
+    // 不落 ap_oidc_session：纯「粘贴 token」会话，没有静默续期路径搅局，专测 alive 竞态本身。
+
+    const channelTokens: Array<string | null> = [];
+    const firstChannels = deferredResponse();
+
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: async (input: string | URL | Request, init?: RequestInit) => {
+        const url = String(input);
+        if (url.endsWith("/api/config")) {
+          return new Response(JSON.stringify({ oidc: null }));
+        }
+        if (url.endsWith("/api/channels")) {
+          const tok = authHeader(init);
+          channelTokens.push(tok);
+          if (tok === tokenA) return firstChannels.promise;
+          return new Response(channelsPayload("b-room", "B's room"));
+        }
+        if (url.endsWith("/api/me")) return meResponse();
+        throw new Error(`unexpected request: ${url}`);
+      },
+    });
+
+    await act(async () => {
+      renderer = create(<LocaleProvider><App /></LocaleProvider>);
+    });
+    await waitFor(() => channelTokens.length >= 1);
+
+    // 身份 A 的 listChannels 请求已发出、还没 resolve（deferred）
+    expect(channelTokens).toEqual([tokenA]);
+
+    // 真实「登出」路径：点击退出登录按钮，token A → null，token-keyed effect 的旧闭包在
+    // cleanup 时把 alive 置 false（等价实现替换后则是 tokenRef.current 不再等于捕获的 tokenA）。
+    await act(async () => {
+      const signOutButton = renderer!.root.findByProps({ className: "app-signout t-mono" });
+      signOutButton.props.onClick();
+    });
+    await waitFor(() => {
+      try {
+        renderer!.root.findByProps({ id: "ap-token" });
+        return true;
+      } catch {
+        return false;
+      }
+    });
+
+    // 退出后回到 TokenGate；粘贴身份 B 的 token 登录——真实的「换身份」路径。
+    await act(async () => {
+      const tokenInput = renderer!.root.findByProps({ id: "ap-token" });
+      tokenInput.props.onChange({ target: { value: tokenB } });
+    });
+    await act(async () => {
+      const gateForm = renderer!.root.findByProps({ className: "gate-form" });
+      gateForm.props.onSubmit({ preventDefault: () => {} });
+    });
+    await waitFor(() => channelTokens.length >= 2);
+
+    expect(channelTokens).toEqual([tokenA, tokenB]);
+    await waitFor(() => channelPillTitles(renderer!)[0] === "B's room");
+    expect(channelPillTitles(renderer!)).toEqual(["B's room"]);
+
+    // 身份 A 那个迟迟没 resolve 的旧请求，这时才姗姗来迟——绝不能覆盖身份 B 的频道列表。
+    await act(async () => {
+      firstChannels.resolve(new Response(channelsPayload("a-room", "A's room")));
+    });
+    await settle();
+
+    expect(channelPillTitles(renderer!)).toEqual(["B's room"]);
+  });
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -262,8 +262,9 @@ export function App() {
       // 跨身份 / 旧 session 无 identity 一律不接管，否则本标签会静默变成另一个账号。
       const shared = readSession();
       if (shared !== null && gateSession(shared, identityRef.current) === "adopt") {
+        // #190 之后 adopt 分支已保证只接管同身份的共享会话（跨身份一律 foreign），
+        // 不清 channels——理由同 token-keyed effect 里的注释。
         setAuthError(null);
-        setChannels(null);
         setListError(null);
         setToken(shared.accessToken);
         return;
@@ -332,7 +333,8 @@ export function App() {
         restoreDesktop()
           .then((accessToken) => {
             if (accessToken === null) throw new Error("desktop session is unavailable");
-            setChannels(null);
+            // desktop 续期换回的是同一身份的新 token（同 server），不清 channels——理由同下面
+            // token-keyed effect 里的注释：清空只会连带卸载 ChannelPage、丢草稿。
             setListError(null);
           })
           .catch(() => hardLogout(message));
@@ -342,7 +344,7 @@ export function App() {
       if (!isShareMode() && sess?.refreshToken != null && oidcRef.current !== null) {
         doRefresh()
           .then(() => {
-            setChannels(null);
+            // 静默续期成功只是换了 access token 字符串，身份没变，不清 channels。
             setListError(null);
           })
           .catch(() => hardLogout(message));
@@ -493,7 +495,10 @@ export function App() {
   useEffect(() => {
     if (token === null || (!desktop && matchPair(path))) return;
     let alive = true;
-    setChannels(null);
+    // 同身份续期只换 token 字符串（sub 不变），这里不清 channels：清空会连带卸载
+    // ChannelPage、丢草稿和滚动位置。真正换身份 / 换 server 的路径都已在 setToken 前
+    // 显式清空过 channels，这里不清也不会残留旧身份的数据；陈旧响应由下面的 alive
+    // 闭包守卫挡住，不会覆盖新身份的 UI（见本文件其它 setChannels(null) 处的保留）。
     setListError(null);
     listChannels(token)
       .then((cs) => {


### PR DESCRIPTION
> **频道身份**：本 PR 由 `#agentparty` 频道的 agent **`Evan_Clauder`** 提交。

Fixes #123

## 缺陷

`App.tsx` 里 token-keyed 的 `listChannels` effect，每次 `token` 变化就先 `setChannels(null)`。**静默续期只换 access token 字符串、身份没变**，却也会把 `channels` 清空 → `channelPending` 为真 → `ChannelPage` 卸载 → 草稿（裸 `useState`）与滚动位置全丢。「无感续期」反而是最重的 UI 重置（例行 ~10 分钟一次）。

## 为什么不写状态机

`alive` 闭包守卫**早就存在**，不是本 PR 新加的东西。两个 `listChannels` effect（token-keyed 那个 + 下面的周期/可见性刷新那个）在 `.then` 与 `.catch` 里各有 `if (!alive) return`，cleanup 里 `alive = false`：

```ts
useEffect(() => {
  if (token === null || (!desktop && matchPair(path))) return;
  let alive = true;
  ...
  listChannels(token)
    .then((cs) => {
      if (!alive) return;   // 陈旧响应挡在这里
      setChannels(cs);
      setListError(null);
    })
    .catch((err) => {
      if (!alive) return;
      ...
    });
  return () => {
    alive = false;          // token 一变，旧闭包立即失效
  };
}, [activeOrigin, desktop, path, token, onAuthFailed]);
```

token 一变，旧闭包的 `alive` 立即被置 false，**陈旧响应覆盖不了新身份的 UI**。再加上：

- `onAuthFailed` 依赖 `[desktop, doRefresh, hardLogout, restoreDesktop]`，而这几个回调各自的依赖（`[desktop]` / `[activeOrigin]`）在同一 server + runtime 下引用稳定，不会在 token 没变时触发多余的重置；
- **#190** 之后，`doRefresh` 与 `hardLogout` 的 adopt 路径都有身份闸（`gateSession(...) === "adopt"` 才接管，跨身份一律 `foreign`）。

所以「同身份换 token」时保留 `channels` 是安全的，不需要引入 session generation 之类的新状态机——只是把清空这个动作从"每次 token 变化都做"改成"只在真正换身份 / 换 server / 登出时做"。

## 改动：删掉 4 处**同身份路径**的 `setChannels(null)`

1. **token-keyed effect**（`let alive = true; setChannels(null); setListError(null); listChannels(token)`）→ 删 `setChannels(null)`，保留 `setListError(null)`，补中文注释。
2. **`onAuthFailed` 里 `doRefresh().then(() => { setChannels(null); setListError(null); })`** → 删 `setChannels(null)`（浏览器静默续期）。
3. **`onAuthFailed` 里 `restoreDesktop().then((accessToken) => { ...; setChannels(null); setListError(null); })`** → 删 `setChannels(null)`（desktop 同身份恢复）。
4. **`hardLogout` 里 `gateSession(shared, identityRef.current) === "adopt"` 分支**内的 `setChannels(null)` → 删（#190 已保证只接管同身份）。

## 保留不动的 `setChannels(null)`（换身份 / 换后端 / 登出）

- `switchDesktopOrigin`（换服务器）
- `hardLogout` 的 desktop 分支、share fallback 分支、终局 `setToken(null)` 前那处
- `completeLogin` 成功（新登录）
- `signOut`（含 desktop 登出 / `clearToken()`）
- desktop server pairing 完成（换 origin）
- `TokenGate` 粘贴 token 登录

## 测试

新增 `web/src/App.renewal.test.tsx`（照 main 上已有的 `App.identity.test.tsx` 的 `react-test-renderer` + `mock.module` + `memoryStorage()` 范式）：

- **A. 同身份静默续期不清空 channels**：过期的 OIDC session 触发「到期前 60s 主动续期」定时器自动续期（不用人为造 401），断言 `listChannels` 至少调用两次，且在第二次请求还没 resolve 的窗口里，侧栏仍是"已加载"结构、真实频道标题持续渲染——语义断言，不看 `alive` 这个实现变量。
- **B. 钉住已有的 `alive` 守卫**（此前零测试保护）：第一个 `listChannels(tokenA)` 请求挂起不 resolve，期间走真实的「退出登录 → TokenGate 粘贴身份 B 的 token」换身份路径，随后才放行身份 A 的旧响应——断言 UI 上始终只有身份 B 的频道，旧响应没有覆盖。

## 变异表（逐个单独应用、验证后已还原，不在最终 diff 里）

| 变异 | 期望 | 实测 |
|---|---|---|
| M1：删掉 token-keyed effect `.then` 里的 `if (!alive) return;` | 测试 B 必须红 | ✅ 红——旧响应覆盖了身份 B 的频道列表 |
| M2：把 token-keyed effect 里的 `setChannels(null);` 加回来 | 测试 A 必须红 | ✅ 红——续期期间侧栏回到清空态 |
| M3：把 `hardLogout` adopt 分支的 `setChannels(null);` 加回来 | 如实报告覆盖情况 | ⚠️ **未被任何测试捕获**（新增 2 条 + 全仓库 296 条测试全绿）。如实说明：这一处目前没有测试保护，触发条件是"当前请求 401 → hardLogout → 发现共享 localStorage 里有别的标签刚续好的同身份新鲜 session → adopt"，需要模拟"另一个标签写入更新的共享 session"这个跨标签场景，属于比较边缘的时序，本次没有为它硬造测试。 |

## 等价实现替换（验收标准）

把 token-keyed effect 的 `alive` 布尔守卫换成语义等价的实现——用 `tokenRef`（渲染时同步写入，等价于 `identityRef` 那种手法）代替 `let alive`，`.then`/`.catch` 里比较 `tokenRef.current !== requestToken`（`requestToken` 是效果启动时闭包捕获的 token）而不是 `if (!alive) return`：

```ts
const tokenRef = useRef<string | null>(null);
tokenRef.current = token;
...
useEffect(() => {
  if (token === null || (!desktop && matchPair(path))) return;
  const requestToken = token;
  setListError(null);
  listChannels(token)
    .then((cs) => {
      if (tokenRef.current !== requestToken) return;
      setChannels(cs);
      setListError(null);
    })
    .catch((err) => {
      if (tokenRef.current !== requestToken) return;
      ...
    });
}, [activeOrigin, desktop, path, token, onAuthFailed]);
```

替换后跑全量测试：**296 pass / 0 fail**，与替换前完全一致——证明两条新测试断言的是"陈旧响应不能覆盖新身份 UI / 续期不清空 channels"这个语义，不是 `alive` 这个具体实现细节。验证完已还原为原来的 `alive` 写法（不在最终 diff 里）。

## 验证

```
$ bunx tsc --noEmit
（无输出，通过）

$ bun test
 296 pass
 0 fail
 789 expect() calls
Ran 296 tests across 35 files.

$ bunx vite build
✓ built in ~1s
（唯一警告是预置在案的 chunk size 提示，与本次改动无关）
```
