### PR TITLE
fix(cli): 保持认证凭据与生效服务成对

### DIFF
--- a/cli/src/commands/whoami.ts
+++ b/cli/src/commands/whoami.ts
@@ -6,6 +6,7 @@ import { resolveAuthDetailed } from "../oidc-cli";
 import { jsonFrame, nowTs } from "../json";
 import { readConfig, resolveChannel, writeConfig } from "../config";
 import { cachedIdentity, statuslineIdentity, writeStatuslineCache } from "../statusline-cache";
+import { healServerUrl } from "../validation";
 
 const WHOAMI_FLAGS = ["json", "caps", "rejoin"];
 const HELP = `usage: party whoami [--json] [--caps] [--rejoin]
@@ -91,8 +92,9 @@ export async function run(argv: string[]): Promise<number> {
           }
         : null;
     if (json) {
-      // 原样吐 /api/me（name/email/kind/role/owner…），供工具判身份/权限，免解析人类串
+      // 保留 /api/me 身份字段供工具判身份/权限；CLI 本地元数据在后，保持权威。
       console.log(JSON.stringify(jsonFrame({
+        ...me,
         type: "whoami",
         ts: nowTs(),
         logged_in: true,
@@ -102,7 +104,6 @@ export async function run(argv: string[]): Promise<number> {
         // account_server 是账号会话自己的 server，二者可能不同，分开给才不会被混用。
         effective_server: auth.server,
         account_server: auth.account.server ?? null,
-        ...me,
         auth_source: auth.auth_source,
         runtime: {
           name: me.name,
@@ -125,8 +126,11 @@ export async function run(argv: string[]): Promise<number> {
       console.log(`  scope: ${me.channel_scope ?? "none (all channels)"}`);
       // account session 的 server 可能和生效 server 不是同一台（人类登录过另一台部署的常态），
       // 不标注清楚，agent 会把这行的 URL 误当成命令实际打到的地方。
+      const accountServer = auth.account.server;
       const accountServerMismatch =
-        auth.account.present && auth.account.server !== undefined && auth.account.server !== auth.server;
+        auth.account.present &&
+        accountServer !== undefined &&
+        (healServerUrl(accountServer) ?? accountServer) !== (healServerUrl(auth.server) ?? auth.server);
       console.log(
         `account: ${
           auth.account.present

--- a/cli/src/oidc-cli.ts
+++ b/cli/src/oidc-cli.ts
@@ -342,11 +342,17 @@ function accountInfo(sess: AccountSession | null): AccountInfo {
 // 关键：agent 用 `party init --token <agent-token>` 接入后必须以「该 agent」的身份发言——
 // 若让残留的人类账号会话顶替，agent 就会以「人」的名义说话，且过期会话还会直接 401
 // （「让 agent 加入」踩过：init 写了 ap_ token，却被旧 account.json 顶掉导致 send 失败）。
-// server 优先 config（频道绑定所在），仅账号会话单独存在时用其 server。
+// server 必须与 credential source 成对选择，不能把 config server 和 account token 混用。
 export async function resolveAuthDetailed(): Promise<ResolvedAuthDetailed> {
   const { config: cfg, source } = readConfigWithSource();
   const sess = readAccount();
-  const rawServer = cfg?.server ?? sess?.server;
+  const useRuntimeConfig = !!cfg?.token;
+  const useAccountSession = !useRuntimeConfig && !!sess?.refresh_token;
+  const rawServer = useRuntimeConfig
+    ? cfg!.server
+    : useAccountSession
+      ? sess!.server
+      : cfg?.server ?? sess?.server;
   // 自愈缺协议头的 server（手改 config 的常见事故，生产实锤 #agentparty seq=725）：
   // 治不了就明确报出来，别让它流进 fetch 变成不可诊断的 "fetch() URL is invalid"
   const server = rawServer ? healServerUrl(rawServer) : undefined;
@@ -356,16 +362,16 @@ export async function resolveAuthDetailed(): Promise<ResolvedAuthDetailed> {
   if (!server) {
     return { server: null, token: null, auth_source: "none", config: source, account: accountInfo(sess) };
   }
-  if (cfg?.token) {
+  if (useRuntimeConfig) {
     return {
       server,
-      token: cfg.token,
+      token: cfg!.token,
       auth_source: "runtime_config",
       config: source,
       account: accountInfo(sess),
     };
   }
-  if (sess?.refresh_token) {
+  if (useAccountSession) {
     // 身份误用护栏（issue #42）：config 无 token、正回落到人类账号会话，但 cwd-state 有个指向
     // 已失效路径的 config_path 面包屑——说明这本该是个 agent，只是丢了它的 config。宁可显著告警，
     // 避免 agent 静默以人类身份发言（冒充是安全问题）。

--- a/cli/test/account-commands.test.ts
+++ b/cli/test/account-commands.test.ts
@@ -452,6 +452,52 @@ describe("whoami", () => {
   // issue #140：runtime config 指向 server A，account.json 是另一台 server B 的人类会话——
   // /api/me 打的是 A，但旧输出只印 account 那行的 B，agent 会误判自己在 B 上。
   describe("effective server disambiguation (issue #140)", () => {
+    test("account fallback keeps its token paired with the account server", async () => {
+      mock = startOidcMock();
+      restMock = startRestMock();
+      writeConfig({ server: mock.url, token: "" });
+      writeAccount({
+        server: restMock.url,
+        refresh_token: "ref",
+        access_token: "acc-live",
+        expires_at: nowSec() + 3600,
+      });
+
+      const code = await whoamiRun(["--json"]);
+      expect(code).toBe(0);
+      const frame = JSON.parse(logs[0]!);
+      expect(frame.server).toBe(restMock.url);
+      expect(frame.effective_server).toBe(restMock.url);
+      expect(frame.auth_source).toBe("account_session");
+      expect(restMock.requests.some((r) => r.path === "/api/me")).toBe(true);
+      expect(mock.requests.some((r) => r.path === "/api/me")).toBe(false);
+    });
+
+    test("json mode keeps local server fields authoritative over /api/me", async () => {
+      restMock = startRestMock((request) => {
+        if (request.method !== "GET" || request.path !== "/api/me") return undefined;
+        return Response.json({
+          name: "agent",
+          email: null,
+          kind: "agent",
+          role: "agent",
+          owner: null,
+          channel_scope: null,
+          server: "https://remote-payload.example",
+          effective_server: "https://remote-effective.example",
+          account_server: "https://remote-account.example",
+        });
+      });
+      writeConfig({ server: restMock.url, token: "ap_effective" });
+
+      const code = await whoamiRun(["--json"]);
+      expect(code).toBe(0);
+      const frame = JSON.parse(logs[0]!);
+      expect(frame.server).toBe(restMock.url);
+      expect(frame.effective_server).toBe(restMock.url);
+      expect(frame.account_server).toBe(null);
+    });
+
     test("text mode: runtime line shows the server /api/me was actually called against", async () => {
       restMock = startRestMock();
       writeConfig({ server: restMock.url, token: "ap_effective" });
@@ -498,6 +544,21 @@ describe("whoami", () => {
       const stdout = logs.join("\n");
       expect(stdout).toContain(`runtime: logged in as fan@example.com (human/human) server=${mock.url}`);
       expect(stdout).not.toContain("different server");
+    });
+
+    test("text mode: equivalent server URLs do not trigger a mismatch annotation", async () => {
+      restMock = startRestMock();
+      writeConfig({ server: restMock.url, token: "ap_effective" });
+      writeAccount({
+        server: `${restMock.url}/`,
+        refresh_token: "ref",
+        access_token: "acc-live",
+        expires_at: nowSec() + 3600,
+      });
+
+      const code = await whoamiRun([]);
+      expect(code).toBe(0);
+      expect(logs.join("\n")).not.toContain("different server");
     });
 
     test("json mode: effective_server and account_server are distinct, unambiguous fields", async () => {


### PR DESCRIPTION
## 问题

独立复审 PR #209 后发现两项 P2：

1. config 只有 server A、没有 token，而 account session B 有 token 时，resolver 会把 A 的 server 与 B 的 token 拼在一起。
2. 私有部署的 `/api/me` 若返回 `server/effective_server/account_server` 同名字段，会覆盖 CLI 本地权威字段。

同时修正仅尾斜杠不同导致的 server mismatch 假警告。

## 修复

- credential source 与 effective server 成对解析：runtime token 配 config server，account token 配 account server。
- JSON 先展开远端身份字段，再写本地权威 server 元数据。
- 比较前规范化 URL，仅用于 mismatch 告警，不改变输出和持久化值。

## 验证

- `bun test test/account.test.ts test/account-commands.test.ts`：58 pass / 0 fail
- `bun run typecheck`：通过
- `git diff --check`：通过

Follow-up to #209.
