### PR TITLE
feat: open_claims/conflicts/blockers 改由任务台账派生（#204）

### DIFF
--- a/cli/src/commands/host.ts
+++ b/cli/src/commands/host.ts
@@ -7,7 +7,7 @@ import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../
 import { resolveChannel } from "../config";
 import { jsonFrame } from "../json";
 import { resolveAuth } from "../oidc-cli";
-import { fetchMessages, fetchPresence, fetchRecentMessages, handleRestError } from "../rest";
+import { fetchMessages, fetchPresence, fetchRecentMessages, handleRestError, listTasks } from "../rest";
 import { isSlug, parseNonNegativeIntFlag, parsePositiveIntFlag } from "../validation";
 
 const HOST_FLAGS = ["channel", "since", "limit", "json"];
@@ -93,6 +93,11 @@ function printBoard(board: HostBoard, window: BoardWindow) {
     const takeover = decision.takeover_from === null ? "" : ` takeover=${decision.takeover_from}`;
     console.log(`- #${decision.seq} ${decision.owner} ${decision.kind}: ${decision.decision}${handoff}${takeover}`);
   }
+  // #204 legacy 段：没有对应 task 的历史 status claim。独立成段、不混进 open claims；给出转成 task 的命令。
+  console.log(`unlinked status claims (no task, legacy): ${board.unlinked_claims.length}`);
+  for (const claim of board.unlinked_claims) {
+    console.log(`- #${claim.seq} ${claim.owner} ${claim.state} scope=${scopeLabel(claim.scope)}  (no task; run: party task from ${claim.seq})`);
+  }
   console.log(`recommended actions: ${board.recommended_actions.length}`);
   for (const action of board.recommended_actions) {
     const human = action.requires_human ? " human" : "";
@@ -153,17 +158,19 @@ export async function run(argv: string[]): Promise<number> {
     // flag 是否存在才决定走向——没给 --since 就取最近窗口（tail），否则频道超过 limit 条后
     // last_seq 永久冻结在头部、loop guard blocker 永远看不到最新发言（见频道公告 rev347）。
     const sinceGiven = flags.since !== undefined;
-    const [presence, messages, headProbe] = await Promise.all([
+    const [presence, messages, headProbe, tasks] = await Promise.all([
       fetchPresence(cfg.server, cfg.token, channel),
       sinceGiven
         ? fetchMessages(cfg.server, cfg.token, channel, since ?? 0, resolvedLimit)
         : fetchRecentMessages(cfg.server, cfg.token, channel, resolvedLimit),
       // 独立 tail 探针拿频道真实 head：取尾窗口本身推不出「后面还有没有更新」，取头窗口更推不出。
       fetchRecentMessages(cfg.server, cfg.token, channel, 1),
+      // #204 open_claims / conflicts / blockers 改由任务台账派生，board 必须并行拉 tasks 一并喂进 buildHostBoard。
+      listTasks(cfg.server, cfg.token, channel, { limit: 500 }),
     ]);
     const head = headProbe.at(-1)?.seq ?? 0;
     const window = describeWindow(messages, head);
-    const board = buildHostBoard(channel, presence, messages);
+    const board = buildHostBoard(channel, presence, messages, tasks);
     if (flags.json === true) console.log(JSON.stringify(jsonFrame({ ...board, window } as unknown as Record<string, unknown>)));
     else printBoard(board, window);
     return 0;

--- a/cli/src/commands/host.ts
+++ b/cli/src/commands/host.ts
@@ -1,4 +1,4 @@
-// party host board — derived coordinator board from presence + retained status history.
+// party host board — derived coordinator board from presence + task ledger + retained status history.
 import {
   buildHostBoard,
   type HostBoard,
@@ -17,7 +17,8 @@ Show a derived coordinator board for host/failover review.
 
 The board is read-only and uses existing data only:
   - /api/channels/:channel/presence for host lease/residency
-  - retained status history for open claims, blockers, and host decisions
+  - the channel task ledger for open claims, blockers, and scope conflicts (#204)
+  - retained status history for host decisions, and for legacy claims with no task
 
 Options:
   --channel C   read channel C instead of the bound channel
@@ -64,6 +65,12 @@ export function formatWindowLines(w: BoardWindow): string[] {
   return lines;
 }
 
+// #204：board 上同时存在两种 claim —— 任务台账派生的（标识是 task id）与消息折叠派生的 legacy claim
+// （标识是消息 seq）。两者都渲染成 `#N` 会让运维分不清 `#1` 指 task 1 还是消息 seq 1，故显式区分前缀。
+function claimRef(claim: { seq: number; task_id: number | null }): string {
+  return claim.task_id === null ? `#${claim.seq}` : `task #${claim.task_id}`;
+}
+
 function printBoard(board: HostBoard, window: BoardWindow) {
   console.log(`host board ${board.channel} last_seq=${board.last_seq}`);
   for (const line of formatWindowLines(window)) console.log(line);
@@ -76,15 +83,15 @@ function printBoard(board: HostBoard, window: BoardWindow) {
   for (const claim of board.open_claims) {
     const blocked = claim.blocked_reason === null ? "" : ` blocked=${claim.blocked_reason}`;
     const workflow = claim.workflow === null ? "" : ` workflow=${claim.workflow.workflow_id}/${claim.workflow.kind}`;
-    console.log(`- #${claim.seq} ${claim.owner} ${claim.state} scope=${scopeLabel(claim.scope)}${workflow}${blocked}`);
+    console.log(`- ${claimRef(claim)} ${claim.owner} ${claim.state} scope=${scopeLabel(claim.scope)}${workflow}${blocked}`);
   }
   console.log(`blockers: ${board.blockers.length}`);
   for (const blocker of board.blockers) {
-    console.log(`- #${blocker.seq} ${blocker.owner} ${blocker.blocked_reason ?? blocker.note ?? "blocked"}`);
+    console.log(`- ${claimRef(blocker)} ${blocker.owner} ${blocker.blocked_reason ?? blocker.note ?? "blocked"}`);
   }
   console.log(`conflicts: ${board.conflicts.length}`);
   for (const conflict of board.conflicts) {
-    const claims = conflict.claims.map((claim) => `#${claim.seq} ${claim.owner}`).join(" vs ");
+    const claims = conflict.claims.map((claim) => `${claimRef(claim)} ${claim.owner}`).join(" vs ");
     console.log(`- ${conflict.scope}: ${claims}`);
   }
   console.log(`decisions: ${board.decisions.length}`);
@@ -96,7 +103,7 @@ function printBoard(board: HostBoard, window: BoardWindow) {
   // #204 legacy 段：没有对应 task 的历史 status claim。独立成段、不混进 open claims；给出转成 task 的命令。
   console.log(`unlinked status claims (no task, legacy): ${board.unlinked_claims.length}`);
   for (const claim of board.unlinked_claims) {
-    console.log(`- #${claim.seq} ${claim.owner} ${claim.state} scope=${scopeLabel(claim.scope)}  (no task; run: party task from ${claim.seq})`);
+    console.log(`- ${claimRef(claim)} ${claim.owner} ${claim.state} scope=${scopeLabel(claim.scope)}  (no task; run: party task from ${claim.seq})`);
   }
   console.log(`recommended actions: ${board.recommended_actions.length}`);
   for (const action of board.recommended_actions) {

--- a/cli/src/commands/task.ts
+++ b/cli/src/commands/task.ts
@@ -17,6 +17,8 @@ const FLAGS = [
   "assignee",
   "assignee-kind",
   "label",
+  "scope",
+  "blocked-reason",
   "priority",
   "parent",
   "anchor",
@@ -26,14 +28,17 @@ const FLAGS = [
   "json",
 ];
 
-const HELP = `usage: party task create <title|-> [--channel C] [--desc text] [--assignee @name] [--label bug]... [--priority N] [--parent ID] [--anchor seq]...
-  party task from <seq> [--channel C] [--title text] [--desc text] [--assignee @name] [--label bug]...
+const HELP = `usage: party task create <title|-> [--channel C] [--desc text] [--assignee @name] [--label bug]... [--scope path]... [--blocked-reason text] [--priority N] [--parent ID] [--anchor seq]...
+  party task from <seq> [--channel C] [--title text] [--desc text] [--assignee @name] [--label bug]... [--scope path]...
   party task list [--channel C] [--state S] [--assignee @name|--mine] [--limit N] [--json]
-  party task assign <id> @name [--channel C] [--assignee-kind agent|human|squad]
-  party task claim <id> [--channel C]
-  party task status <id> triage|backlog|assigned|in_progress|needs_review|done|blocked [--channel C]
-  party task block <id> [--channel C]
+  party task assign <id> @name [--channel C] [--assignee-kind agent|human|squad] [--scope path]...
+  party task claim <id> [--channel C] [--scope path]...
+  party task status <id> triage|backlog|assigned|in_progress|needs_review|done|blocked [--channel C] [--scope path]... [--blocked-reason text]
+  party task block <id> [--channel C] [--blocked-reason text] [--scope path]...
   party task done <id> [--channel C]
+
+--scope declares the files/dirs a task claims (repeatable); host board conflicts and open claims
+derive from it. --blocked-reason attaches a structured reason when a task is blocked.
 
 Create and move channel tasks. Agent-created tasks default to triage; human-created
 tasks default to backlog unless an assignee/state is provided.
@@ -103,13 +108,13 @@ export async function run(argv: string[]): Promise<number> {
     console.log(HELP);
     return 0;
   }
-  const { positionals, flags } = parseArgs(argv, { booleans: ["json", "mine"], repeatable: ["label", "anchor"] });
+  const { positionals, flags } = parseArgs(argv, { booleans: ["json", "mine"], repeatable: ["label", "anchor", "scope"] });
   const unknown = unknownFlagError(flags, FLAGS);
   if (unknown !== null) {
     console.error(unknown);
     return 1;
   }
-  const flagError = valueFlagError(flags, ["channel", "title", "desc", "description", "state", "assignee", "assignee-kind", "priority", "parent", "workflow", "limit"], ["label", "anchor"]);
+  const flagError = valueFlagError(flags, ["channel", "title", "desc", "description", "state", "assignee", "assignee-kind", "priority", "parent", "workflow", "limit", "blocked-reason"], ["label", "anchor", "scope"]);
   if (flagError !== null) {
     console.error(flagError);
     return 1;
@@ -131,6 +136,16 @@ export async function run(argv: string[]): Promise<number> {
   }
 
   try {
+    // #204 --scope（repeatable）/ --blocked-reason：create 与各 patch 子命令共用。
+    // 只有 flag 实际出现时才纳入请求体，避免 patch 时把未提供的 scope 误清空。
+    const scopeProvided = flags.scope !== undefined;
+    const scope = scopeProvided ? labelsFrom(flags.scope) : undefined;
+    if (scope === null) {
+      console.error("--scope requires non-empty values");
+      return 1;
+    }
+    const blockedReason = flags["blocked-reason"] !== undefined ? str(flags["blocked-reason"]) : undefined;
+
     if (sub === "list" || sub === undefined) {
       const state = parseState(str(flags.state));
       if (state === null) {
@@ -238,6 +253,8 @@ export async function run(argv: string[]): Promise<number> {
         ...(parent !== undefined ? { parent_id: parent } : {}),
         ...(anchors.length > 0 ? { anchor_seqs: anchors } : {}),
         ...(str(flags.workflow) !== undefined ? { workflow_id: str(flags.workflow) } : {}),
+        ...(scope !== undefined ? { scope } : {}),
+        ...(blockedReason !== undefined ? { blocked_reason: blockedReason } : {}),
       });
       console.log(flags.json === true ? JSON.stringify(jsonFrame(task as unknown as Record<string, unknown>)) : `created ${formatTask(task)}`);
       return 0;
@@ -254,22 +271,22 @@ export async function run(argv: string[]): Promise<number> {
         console.error("usage: party task assign <id> @name [--assignee-kind agent|human|squad]");
         return 1;
       }
-      const task = await updateTask(cfg.server, cfg.token, slug, id, { state: "assigned", assignee });
+      const task = await updateTask(cfg.server, cfg.token, slug, id, { state: "assigned", assignee, ...(scope !== undefined ? { scope } : {}), ...(blockedReason !== undefined ? { blocked_reason: blockedReason } : {}) });
       console.log(flags.json === true ? JSON.stringify(jsonFrame(task as unknown as Record<string, unknown>)) : `updated ${formatTask(task)}`);
       return 0;
     }
     if (sub === "claim") {
-      const task = await updateTask(cfg.server, cfg.token, slug, id, { state: "in_progress" });
+      const task = await updateTask(cfg.server, cfg.token, slug, id, { state: "in_progress", ...(scope !== undefined ? { scope } : {}), ...(blockedReason !== undefined ? { blocked_reason: blockedReason } : {}) });
       console.log(flags.json === true ? JSON.stringify(jsonFrame(task as unknown as Record<string, unknown>)) : `updated ${formatTask(task)}`);
       return 0;
     }
     if (sub === "block") {
-      const task = await updateTask(cfg.server, cfg.token, slug, id, { state: "blocked" });
+      const task = await updateTask(cfg.server, cfg.token, slug, id, { state: "blocked", ...(scope !== undefined ? { scope } : {}), ...(blockedReason !== undefined ? { blocked_reason: blockedReason } : {}) });
       console.log(flags.json === true ? JSON.stringify(jsonFrame(task as unknown as Record<string, unknown>)) : `updated ${formatTask(task)}`);
       return 0;
     }
     if (sub === "done") {
-      const task = await updateTask(cfg.server, cfg.token, slug, id, { state: "done" });
+      const task = await updateTask(cfg.server, cfg.token, slug, id, { state: "done", ...(scope !== undefined ? { scope } : {}), ...(blockedReason !== undefined ? { blocked_reason: blockedReason } : {}) });
       console.log(flags.json === true ? JSON.stringify(jsonFrame(task as unknown as Record<string, unknown>)) : `updated ${formatTask(task)}`);
       return 0;
     }
@@ -279,7 +296,7 @@ export async function run(argv: string[]): Promise<number> {
         console.error("usage: party task status <id> triage|backlog|assigned|in_progress|needs_review|done|blocked");
         return 1;
       }
-      const task = await updateTask(cfg.server, cfg.token, slug, id, { state });
+      const task = await updateTask(cfg.server, cfg.token, slug, id, { state, ...(scope !== undefined ? { scope } : {}), ...(blockedReason !== undefined ? { blocked_reason: blockedReason } : {}) });
       console.log(flags.json === true ? JSON.stringify(jsonFrame(task as unknown as Record<string, unknown>)) : `updated ${formatTask(task)}`);
       return 0;
     }

--- a/cli/src/rest.ts
+++ b/cli/src/rest.ts
@@ -603,6 +603,8 @@ export async function createTask(
     parent_id?: number;
     anchor_seqs?: number[];
     workflow_id?: string;
+    scope?: string[];
+    blocked_reason?: string | null;
   },
 ): Promise<TaskRecord> {
   return (await req(server, `/api/channels/${encodeURIComponent(slug)}/tasks`, {
@@ -624,6 +626,8 @@ export async function updateTask(
     assignee?: { name: string; kind: TaskAssigneeKind } | null;
     priority?: number;
     labels?: string[];
+    scope?: string[];
+    blocked_reason?: string | null;
   },
 ): Promise<TaskRecord> {
   return (await req(server, `/api/channels/${encodeURIComponent(slug)}/tasks/${id}`, {

--- a/cli/test/host-board.test.ts
+++ b/cli/test/host-board.test.ts
@@ -1,0 +1,203 @@
+// #204 buildHostBoard 纯函数契约：open_claims / conflicts / blockers 改由任务台账派生，
+// decisions 仍从消息折叠来，legacy status claim 落进 unlinked_claims（按 seq 链接/去重/排序，不用 claimKey）。
+// shared 无测试 runner，纯函数测试放在 cli/test 下、经 workspace 从 @agentparty/shared 引入运行。
+import { describe, expect, test } from "bun:test";
+import { buildHostBoard, type MsgFrame, type StatusState, type TaskRecord } from "@agentparty/shared";
+
+const NOW = 1_000_000;
+
+function task(overrides: Partial<TaskRecord> & { id: number }): TaskRecord {
+  return {
+    type: "task",
+    channel: "dev",
+    title: `task-${overrides.id}`,
+    desc: null,
+    state: "in_progress",
+    assignee: null,
+    created_by: "creator",
+    created_by_kind: "agent",
+    priority: 0,
+    labels: [],
+    parent_id: null,
+    anchor_seqs: [],
+    scope: [],
+    blocked_reason: null,
+    completion_artifact: null,
+    workflow_id: null,
+    created_at: NOW,
+    updated_at: NOW,
+    completed_at: null,
+    ...overrides,
+  };
+}
+
+function statusMsg(
+  seq: number,
+  owner: string,
+  state: StatusState,
+  scope: string[],
+  note: string | null = null,
+  blocked_reason: string | null = null,
+): MsgFrame {
+  return {
+    type: "status",
+    seq,
+    sender: { name: owner, kind: "agent" },
+    kind: "status",
+    body: note ?? state,
+    mentions: [],
+    reply_to: null,
+    state,
+    note,
+    status: {
+      owner,
+      state,
+      scope,
+      summary_seq: null,
+      blocked_reason,
+      updated_at: seq * 1000,
+    },
+    ts: seq * 1000,
+  };
+}
+
+function decisionMsg(seq: number, owner: string): MsgFrame {
+  return {
+    type: "status",
+    seq,
+    sender: { name: owner, kind: "agent" },
+    kind: "status",
+    body: "decision",
+    mentions: [],
+    reply_to: null,
+    state: "working",
+    note: "decision",
+    status: {
+      owner,
+      state: "working",
+      scope: [],
+      summary_seq: null,
+      blocked_reason: null,
+      updated_at: seq * 1000,
+      decision: { kind: "decision", owner, decision: "ship it", next: null, expires_at: null },
+    },
+    ts: seq * 1000,
+  };
+}
+
+describe("buildHostBoard open_claims from task ledger (#204)", () => {
+  test("in_progress task with assignee → open_claims，身份 = task id（M1 target）", () => {
+    const t = task({ id: 7, state: "in_progress", assignee: { name: "web-a", kind: "agent" }, scope: ["web/src"] });
+    const board = buildHostBoard("dev", [], [], [t], NOW);
+    expect(board.open_claims).toEqual([
+      expect.objectContaining({ task_id: 7, owner: "web-a", state: "working", task_state: "in_progress", scope: ["web/src"] }),
+    ]);
+  });
+
+  test("同一 task 改 scope 仍是同一条 claim（task id 不变），绝不产生孤儿（M1 target）", () => {
+    const before = task({ id: 7, state: "in_progress", assignee: { name: "web-a", kind: "agent" }, scope: ["web/src"] });
+    const after = task({ id: 7, state: "in_progress", assignee: { name: "web-a", kind: "agent" }, scope: ["web/src", "cli"] });
+    const boardBefore = buildHostBoard("dev", [], [], [before], NOW);
+    const boardAfter = buildHostBoard("dev", [], [], [after], NOW);
+    expect(boardBefore.open_claims).toHaveLength(1);
+    expect(boardAfter.open_claims).toHaveLength(1);
+    expect(boardAfter.open_claims[0]!.task_id).toBe(7);
+    expect(boardAfter.open_claims[0]!.scope).toEqual(["web/src", "cli"]);
+  });
+
+  test("只有 assigned/in_progress/needs_review 且有 assignee 的 task 进 open_claims", () => {
+    const tasks = [
+      task({ id: 1, state: "in_progress", assignee: { name: "a", kind: "agent" }, scope: ["x"] }),
+      task({ id: 2, state: "assigned", assignee: { name: "b", kind: "agent" }, scope: ["y"] }),
+      task({ id: 3, state: "needs_review", assignee: { name: "c", kind: "agent" }, scope: ["z"] }),
+      task({ id: 4, state: "in_progress", assignee: null, scope: ["w"] }),
+      task({ id: 5, state: "triage", assignee: { name: "d", kind: "agent" }, scope: ["q"] }),
+      task({ id: 6, state: "done", assignee: { name: "e", kind: "agent" }, scope: ["r"] }),
+    ];
+    const board = buildHostBoard("dev", [], [], tasks, NOW);
+    expect(board.open_claims.map((c) => c.task_id).sort((a, b) => (a ?? 0) - (b ?? 0))).toEqual([1, 2, 3]);
+  });
+});
+
+describe("buildHostBoard blockers from task ledger (#204)", () => {
+  test("blocked task → blockers，带 blocked_reason（M2 target）", () => {
+    const t = task({ id: 9, state: "blocked", assignee: { name: "w", kind: "agent" }, scope: ["worker"], blocked_reason: "waiting on secret" });
+    const board = buildHostBoard("dev", [], [], [t], NOW);
+    expect(board.blockers).toEqual([
+      expect.objectContaining({ task_id: 9, owner: "w", state: "blocked", task_state: "blocked", blocked_reason: "waiting on secret" }),
+    ]);
+    expect(board.open_claims).toEqual([]);
+  });
+
+  test("blocked task 无 assignee 时 owner 回退 created_by", () => {
+    const t = task({ id: 9, state: "blocked", assignee: null, created_by: "maker", scope: [], blocked_reason: "stuck" });
+    expect(buildHostBoard("dev", [], [], [t], NOW).blockers).toEqual([
+      expect.objectContaining({ task_id: 9, owner: "maker", blocked_reason: "stuck" }),
+    ]);
+  });
+});
+
+describe("buildHostBoard conflicts from task scope (#204)", () => {
+  test("两个不同 assignee、scope 重叠 → conflict（M3 target）", () => {
+    const tasks = [
+      task({ id: 10, state: "in_progress", assignee: { name: "a", kind: "agent" }, scope: ["web/src"] }),
+      task({ id: 11, state: "in_progress", assignee: { name: "b", kind: "agent" }, scope: ["web/src/components"] }),
+    ];
+    const board = buildHostBoard("dev", [], [], tasks, NOW);
+    expect(board.conflicts).toEqual([expect.objectContaining({ scope: "web/src", owners: ["a", "b"] })]);
+  });
+
+  test("同一 assignee scope 重叠不算 conflict", () => {
+    const tasks = [
+      task({ id: 10, state: "in_progress", assignee: { name: "a", kind: "agent" }, scope: ["web/src"] }),
+      task({ id: 11, state: "in_progress", assignee: { name: "a", kind: "agent" }, scope: ["web/src/x"] }),
+    ];
+    expect(buildHostBoard("dev", [], [], tasks, NOW).conflicts).toEqual([]);
+  });
+});
+
+describe("buildHostBoard unlinked_claims legacy 段 (#204)", () => {
+  test("没有 task anchor 指向其 seq 的历史 status claim → 落进 unlinked_claims（M4 target）", () => {
+    const messages = [statusMsg(221, "worker-a", "working", ["web/src"])];
+    const board = buildHostBoard("dev", [], messages, [], NOW);
+    expect(board.unlinked_claims).toEqual([
+      expect.objectContaining({ seq: 221, owner: "worker-a", task_id: null, scope: ["web/src"] }),
+    ]);
+  });
+
+  test("链接判定按 seq（anchor 命中）而非 claimKey（owner+scope）——M5 target", () => {
+    const messages = [statusMsg(221, "worker-a", "working", ["web/src"])];
+    // task 的 assignee+scope 与 claim 完全一致，但 anchor 不含 221：
+    // 按 seq → 仍 unlinked；若错误地按 claimKey 匹配 → 会误判为已链接、从 legacy 段漏掉。
+    const matchByClaimKeyNotAnchor = task({
+      id: 5,
+      state: "in_progress",
+      assignee: { name: "worker-a", kind: "agent" },
+      scope: ["web/src"],
+      anchor_seqs: [999],
+    });
+    expect(buildHostBoard("dev", [], messages, [matchByClaimKeyNotAnchor], NOW).unlinked_claims.map((c) => c.seq)).toEqual([221]);
+
+    // 对照：task anchor 含 221（owner/scope 完全不同）→ 按 seq 链接 → 不再 unlinked。
+    const anchored = task({ id: 6, state: "in_progress", assignee: { name: "zzz", kind: "agent" }, scope: ["unrelated"], anchor_seqs: [221] });
+    expect(buildHostBoard("dev", [], messages, [anchored], NOW).unlinked_claims).toEqual([]);
+  });
+
+  test("unlinked_claims 按 seq 去重与排序，不用 claimKey（M5 target）", () => {
+    // seq 与 claimKey 排序相反：zeta@200 / alpha@100。按 seq 降序 → [200,100]；按 claimKey 升序 → [100,200]。
+    const messages = [
+      statusMsg(200, "zeta", "working", ["a"]),
+      statusMsg(100, "alpha", "working", ["b"]),
+    ];
+    expect(buildHostBoard("dev", [], messages, [], NOW).unlinked_claims.map((c) => c.seq)).toEqual([200, 100]);
+  });
+});
+
+describe("buildHostBoard decisions still from messages (#204)", () => {
+  test("decisions 仍从消息折叠来", () => {
+    const board = buildHostBoard("dev", [], [decisionMsg(50, "host-a")], [], NOW);
+    expect(board.decisions).toEqual([
+      expect.objectContaining({ seq: 50, owner: "host-a", kind: "decision", decision: "ship it" }),
+    ]);
+  });
+});

--- a/cli/test/host-board.test.ts
+++ b/cli/test/host-board.test.ts
@@ -184,12 +184,17 @@ describe("buildHostBoard unlinked_claims legacy 段 (#204)", () => {
   });
 
   test("unlinked_claims 按 seq 去重与排序，不用 claimKey（M5 target）", () => {
-    // seq 与 claimKey 排序相反：zeta@200 / alpha@100。按 seq 降序 → [200,100]；按 claimKey 升序 → [100,200]。
+    // 三条而非两条：两条时 claimKey 降序会碰巧与 seq 降序同序，按 claimKey 排的实现能蒙混过关。
+    // 这里让 claimKey 的两个方向都区别于 seq 降序：
+    //   seq 降序        → [300, 200, 100]  (mid, zeta, alpha)
+    //   claimKey 升序   → [100, 300, 200]  (alpha, mid, zeta)
+    //   claimKey 降序   → [200, 300, 100]  (zeta, mid, alpha)
     const messages = [
+      statusMsg(300, "mid", "working", ["c"]),
       statusMsg(200, "zeta", "working", ["a"]),
       statusMsg(100, "alpha", "working", ["b"]),
     ];
-    expect(buildHostBoard("dev", [], messages, [], NOW).unlinked_claims.map((c) => c.seq)).toEqual([200, 100]);
+    expect(buildHostBoard("dev", [], messages, [], NOW).unlinked_claims.map((c) => c.seq)).toEqual([300, 200, 100]);
   });
 });
 

--- a/cli/test/host.test.ts
+++ b/cli/test/host.test.ts
@@ -50,6 +50,9 @@ function startMockServer(messages: { seq: number }[]): { seen: string[] } {
       if (url.pathname.endsWith("/presence")) {
         return Response.json({ presence: [] });
       }
+      if (url.pathname.endsWith("/tasks")) {
+        return Response.json({ tasks: [] });
+      }
       if (url.pathname.endsWith("/messages")) {
         seen.push(url.search);
         // 头探针恒 limit=1，只回最新一条；其余按传入的 messages 原样返回
@@ -169,5 +172,44 @@ describe("formatWindowLines 纯函数（#151 扩展）", () => {
     expect(text).toContain("channel head =");
     expect(text).toContain("claims opened before seq");
     expect(text).not.toContain("NOT current");
+  });
+});
+
+
+describe("party host board unlinked status claims 段（#204）", () => {
+  function statusMessage(seq: number, owner: string, scope: string[]) {
+    return {
+      type: "status",
+      seq,
+      sender: { name: owner, kind: "agent" },
+      kind: "status",
+      body: "working",
+      mentions: [],
+      reply_to: null,
+      state: "working",
+      note: null,
+      status: { owner, state: "working", scope, summary_seq: null, blocked_reason: null, updated_at: seq * 1000 },
+      ts: seq * 1000,
+    };
+  }
+
+  test("文本输出：没有对应 task 的 status claim 落进 unlinked 段，含转成 task 的命令", async () => {
+    startMockServer([statusMessage(221, "worker-a", ["web/src"])] as unknown as { seq: number }[]);
+    const code = await run(["board", "dev"]);
+    expect(code).toBe(0);
+    const text = stdout.join("\n");
+    expect(text).toContain("unlinked status claims (no task, legacy): 1");
+    expect(text).toContain("#221 worker-a working scope=web/src");
+    expect(text).toContain("party task from 221");
+  });
+
+  test("--json：unlinked_claims 带 seq、task_id 为 null", async () => {
+    startMockServer([statusMessage(221, "worker-a", ["web/src"])] as unknown as { seq: number }[]);
+    const code = await run(["board", "dev", "--json"]);
+    expect(code).toBe(0);
+    const frame = JSON.parse(stdout[0]!);
+    expect(Array.isArray(frame.unlinked_claims)).toBe(true);
+    expect(frame.unlinked_claims[0].seq).toBe(221);
+    expect(frame.unlinked_claims[0].task_id).toBe(null);
   });
 });

--- a/cli/test/host.test.ts
+++ b/cli/test/host.test.ts
@@ -40,7 +40,7 @@ afterEach(() => {
 
 // host board 一次并发发三个请求（presence + 主查询 + limit=1 的头探针）。
 // 全局变量拦截 fetch 在并发下会被互相覆盖，必须起一个真实的本地 server 按路径/查询串分别记录。
-function startMockServer(messages: { seq: number }[]): { seen: string[] } {
+function startMockServer(messages: { seq: number }[], tasks: { id: number }[] = []): { seen: string[] } {
   const seen: string[] = [];
   restServer = Bun.serve({
     hostname: "127.0.0.1",
@@ -51,7 +51,7 @@ function startMockServer(messages: { seq: number }[]): { seen: string[] } {
         return Response.json({ presence: [] });
       }
       if (url.pathname.endsWith("/tasks")) {
-        return Response.json({ tasks: [] });
+        return Response.json({ tasks });
       }
       if (url.pathname.endsWith("/messages")) {
         seen.push(url.search);
@@ -211,5 +211,40 @@ describe("party host board unlinked status claims 段（#204）", () => {
     expect(Array.isArray(frame.unlinked_claims)).toBe(true);
     expect(frame.unlinked_claims[0].seq).toBe(221);
     expect(frame.unlinked_claims[0].task_id).toBe(null);
+  });
+
+  // task 派生的 claim 标识是 task id，legacy claim 标识是消息 seq。取 task.id === 消息 seq === 221 这个
+  // 碰撞用例：若两者都渲染成 `#221`，运维无法判断某一行指的是任务还是消息。
+  test("文本输出：task 派生 claim 印 `task #N`，legacy claim 印 `#N`，同号也不混淆", async () => {
+    const task = {
+      type: "task",
+      id: 221,
+      channel: "dev",
+      title: "cli work",
+      desc: null,
+      state: "in_progress",
+      assignee: { name: "worker-b", kind: "agent" },
+      created_by: "worker-b",
+      created_by_kind: "agent",
+      priority: 0,
+      labels: [],
+      parent_id: null,
+      anchor_seqs: [],
+      scope: ["cli/src"],
+      blocked_reason: null,
+      completion_artifact: null,
+      workflow_id: null,
+      created_at: 1_000,
+      updated_at: 1_000,
+      completed_at: null,
+    };
+    startMockServer([statusMessage(221, "worker-a", ["web/src"])] as unknown as { seq: number }[], [task]);
+    const code = await run(["board", "dev"]);
+    expect(code).toBe(0);
+    const text = stdout.join("\n");
+    expect(text).toContain("- task #221 worker-b working scope=cli/src");
+    expect(text).toContain("- #221 worker-a working scope=web/src");
+    // 任务那一行不得退化成无前缀的 `- #221`，否则与 legacy 行同形
+    expect(text).not.toContain("- #221 worker-b");
   });
 });

--- a/cli/test/m3.test.ts
+++ b/cli/test/m3.test.ts
@@ -811,7 +811,7 @@ describe("party status/history channel flag", () => {
     });
   });
 
-  test("host board summarizes host lease, claims, blockers, and decisions", async () => {
+  test("host board derives claims/blockers from the task ledger; decisions stay from messages (#204)", async () => {
     const now = Date.now();
     mock = startRestMock((req) => {
       if (req.method === "GET" && req.path === "/api/channels/dev/presence") {
@@ -842,56 +842,60 @@ describe("party status/history channel flag", () => {
           ],
         });
       }
+      if (req.method === "GET" && req.path === "/api/channels/dev/tasks") {
+        // open_claims / blockers 现在从任务台账派生：worker-a 正在做 web/src（in_progress），worker-b 因缺 token 被 blocked。
+        return Response.json({
+          tasks: [
+            {
+              type: "task",
+              id: 1,
+              channel: "dev",
+              title: "ui work",
+              desc: null,
+              state: "in_progress",
+              assignee: { name: "worker-a", kind: "agent" },
+              created_by: "worker-a",
+              created_by_kind: "agent",
+              priority: 0,
+              labels: [],
+              parent_id: null,
+              anchor_seqs: [],
+              scope: ["web/src"],
+              blocked_reason: null,
+              completion_artifact: null,
+              workflow_id: null,
+              created_at: 10_000,
+              updated_at: 10_000,
+              completed_at: null,
+            },
+            {
+              type: "task",
+              id: 2,
+              channel: "dev",
+              title: "worker work",
+              desc: null,
+              state: "blocked",
+              assignee: { name: "worker-b", kind: "agent" },
+              created_by: "worker-b",
+              created_by_kind: "agent",
+              priority: 0,
+              labels: [],
+              parent_id: null,
+              anchor_seqs: [],
+              scope: ["worker/src"],
+              blocked_reason: "need token",
+              completion_artifact: null,
+              workflow_id: null,
+              created_at: 11_000,
+              updated_at: 11_000,
+              completed_at: null,
+            },
+          ],
+        });
+      }
       if (req.method === "GET" && req.path === "/api/channels/dev/messages") {
         return Response.json({
           messages: [
-            {
-              type: "status",
-              seq: 10,
-              sender: { name: "worker-a", kind: "agent" },
-              kind: "status",
-              body: "working ui",
-              mentions: [],
-              reply_to: null,
-              state: "working",
-              note: "working ui",
-              status: {
-                owner: "worker-a",
-                state: "working",
-                scope: ["web/src"],
-                summary_seq: null,
-                blocked_reason: null,
-                updated_at: 10000,
-              },
-              ts: 10000,
-            },
-            {
-              type: "status",
-              seq: 11,
-              sender: { name: "worker-b", kind: "agent" },
-              kind: "status",
-              body: "blocked",
-              mentions: [],
-              reply_to: null,
-              state: "blocked",
-              note: "blocked",
-              status: {
-                owner: "worker-b",
-                state: "blocked",
-                scope: ["worker/src"],
-                summary_seq: null,
-                blocked_reason: "need token",
-                updated_at: 11000,
-                workflow: {
-                  workflow_id: "wf-worker",
-                  kind: "parallel",
-                  run_id: "run-1",
-                  step_id: "worker-b",
-                  parent_summary_seq: 9,
-                },
-              },
-              ts: 11000,
-            },
             {
               type: "status",
               seq: 12,
@@ -931,8 +935,8 @@ describe("party status/history channel flag", () => {
     const frame = JSON.parse(r.stdout.trim()) as {
       type: string;
       hosts: Array<{ name: string; lease: string; stale_reason: string | null }>;
-      open_claims: Array<{ owner: string; state: string; scope: string[]; workflow: { workflow_id: string } | null }>;
-      blockers: Array<{ owner: string; blocked_reason: string | null; workflow: { workflow_id: string } | null }>;
+      open_claims: Array<{ task_id: number | null; owner: string; state: string; task_state: string | null; scope: string[] }>;
+      blockers: Array<{ task_id: number | null; owner: string; state: string; task_state: string | null; blocked_reason: string | null }>;
       decisions: Array<{ owner: string; kind: string; handoff_to: string | null }>;
       recommended_actions: Array<{ kind: string; target: string | null; requires_human: boolean }>;
     };
@@ -941,33 +945,21 @@ describe("party status/history channel flag", () => {
       expect.objectContaining({ name: "host-a", lease: "active", stale_reason: null }),
       expect.objectContaining({ name: "host-b", lease: "stale", stale_reason: "residency=human_driven" }),
     ]);
+    // claim 身份 = task id；blocked 的 task 只进 blockers、不进 open_claims。
     expect(frame.open_claims).toEqual([
-      expect.objectContaining({ owner: "host-a", state: "working", scope: [] }),
-      expect.objectContaining({
-        owner: "worker-b",
-        state: "blocked",
-        scope: ["worker/src"],
-        workflow: expect.objectContaining({ workflow_id: "wf-worker" }),
-      }),
-      expect.objectContaining({ owner: "worker-a", state: "working", scope: ["web/src"] }),
+      expect.objectContaining({ task_id: 1, owner: "worker-a", state: "working", task_state: "in_progress", scope: ["web/src"] }),
     ]);
     expect(frame.blockers).toEqual([
-      expect.objectContaining({
-        owner: "worker-b",
-        blocked_reason: "need token",
-        workflow: expect.objectContaining({ workflow_id: "wf-worker" }),
-      }),
+      expect.objectContaining({ task_id: 2, owner: "worker-b", state: "blocked", task_state: "blocked", blocked_reason: "need token" }),
     ]);
+    // decisions 仍旧从消息折叠来。
     expect(frame.decisions).toEqual([
       expect.objectContaining({ owner: "host-a", kind: "handoff", handoff_to: "reviewer-1" }),
     ]);
     expect(frame.recommended_actions).toEqual([
       expect.objectContaining({ kind: "review-blockers", target: "worker-b", requires_human: false }),
     ]);
-    // #151 扩展：host board 默认取最近窗口（tail），不再是「取头 500 条」——否则频道超过
-    // limit 条后 last_seq 永久冻结、loop guard blocker 永远看不到最新发言。
-    // 消息端点这里被打两次：主窗口查询 + limit=1 的头探针（拿真实 head 供窗口显式化用），
-    // 用 limit 区分，不依赖并发到达顺序。
+    // #151 扩展：host board 默认取最近窗口（tail）。消息端点被打两次：主查询 + limit=1 头探针。
     const messageReqs = reqsOf(mock, "GET", "/api/channels/dev/messages");
     const mainReq = messageReqs.find((r) => r.query.limit !== "1");
     expect(mainReq?.query).toMatchObject({ before: String(TAIL_BEFORE), limit: "500" });
@@ -1130,9 +1122,8 @@ describe("party status/history channel flag", () => {
         requires_human: boolean;
       }>;
     };
-    expect(frame.blockers).toEqual([
-      expect.objectContaining({ owner: "system", blocked_reason: "loop guard tripped: 200 consecutive agent messages" }),
-    ]);
+    // #204：blockers 现在从任务台账派生（此处无 tasks → 空）。loop-guard 是 system 消息，不再进 blockers 列表。
+    expect(frame.blockers).toEqual([]);
     expect(frame.hosts).toEqual([
       expect.objectContaining({ name: "host-old", lease: "stale", stale_reason: "residency=human_driven" }),
     ]);
@@ -1143,6 +1134,7 @@ describe("party status/history channel flag", () => {
         requires_human: false,
       }),
     ]);
+    // 人类消息已清 loop guard → 不建议 clear-loop-guard（loop-guard 检测仍走消息，不受 blockers 派生改动影响）。
     expect(frame.recommended_actions.some((action) => action.kind === "clear-loop-guard")).toBe(false);
   });
 
@@ -1197,15 +1189,15 @@ describe("party status/history channel flag", () => {
       },
     ];
 
-    const board = buildHostBoard("dev", presence, messages, now, { loopGuardActive: false });
+    // #204：blockers 现在从任务台账派生。这里无 tasks，故 board.blockers 为空；loop-guard 仅为 system 消息，
+    // 不再出现在 blockers 列表里，但仍被 recommendHostActions 内部用于 loop-guard 检测（此处 loopGuardActive:false 抑制）。
+    const board = buildHostBoard("dev", presence, messages, [], now, { loopGuardActive: false });
 
-    expect(board.blockers).toEqual([
-      expect.objectContaining({ owner: "system", blocked_reason: "loop guard tripped: 200 consecutive agent messages" }),
-    ]);
+    expect(board.blockers).toEqual([]);
     expect(board.recommended_actions.map((action) => action.kind)).toEqual(["takeover"]);
   });
 
-  test("host board detects overlapping claim scopes for coordinator triage", async () => {
+  test("host board detects overlapping task scopes for coordinator triage (#204)", async () => {
     const now = Date.now();
     mock = startRestMock((req) => {
       if (req.method === "GET" && req.path === "/api/channels/dev/presence") {
@@ -1225,71 +1217,34 @@ describe("party status/history channel flag", () => {
           ],
         });
       }
-      if (req.method === "GET" && req.path === "/api/channels/dev/messages") {
+      if (req.method === "GET" && req.path === "/api/channels/dev/tasks") {
+        // conflicts 用任务 scope 跑 overlap（不同 assignee + scope 重叠）：worker-a web/src 与 worker-b web/src/components 重叠。
+        const base = {
+          type: "task",
+          channel: "dev",
+          desc: null,
+          created_by_kind: "agent",
+          priority: 0,
+          labels: [],
+          parent_id: null,
+          anchor_seqs: [],
+          blocked_reason: null,
+          completion_artifact: null,
+          workflow_id: null,
+          created_at: 30_000,
+          updated_at: 30_000,
+          completed_at: null,
+        };
         return Response.json({
-          messages: [
-            {
-              type: "status",
-              seq: 30,
-              sender: { name: "worker-a", kind: "agent" },
-              kind: "status",
-              body: "working web",
-              mentions: [],
-              reply_to: null,
-              state: "working",
-              note: "working web",
-              status: {
-                owner: "worker-a",
-                state: "working",
-                scope: ["web/src"],
-                summary_seq: null,
-                blocked_reason: null,
-                updated_at: 30_000,
-              },
-              ts: 30_000,
-            },
-            {
-              type: "status",
-              seq: 31,
-              sender: { name: "worker-b", kind: "agent" },
-              kind: "status",
-              body: "working presence",
-              mentions: [],
-              reply_to: null,
-              state: "working",
-              note: "working presence",
-              status: {
-                owner: "worker-b",
-                state: "working",
-                scope: ["web/src/components"],
-                summary_seq: null,
-                blocked_reason: null,
-                updated_at: 31_000,
-              },
-              ts: 31_000,
-            },
-            {
-              type: "status",
-              seq: 32,
-              sender: { name: "worker-c", kind: "agent" },
-              kind: "status",
-              body: "working cli",
-              mentions: [],
-              reply_to: null,
-              state: "working",
-              note: "working cli",
-              status: {
-                owner: "worker-c",
-                state: "working",
-                scope: ["cli/src"],
-                summary_seq: null,
-                blocked_reason: null,
-                updated_at: 32_000,
-              },
-              ts: 32_000,
-            },
+          tasks: [
+            { ...base, id: 30, title: "web", state: "in_progress", assignee: { name: "worker-a", kind: "agent" }, created_by: "worker-a", scope: ["web/src"] },
+            { ...base, id: 31, title: "components", state: "in_progress", assignee: { name: "worker-b", kind: "agent" }, created_by: "worker-b", scope: ["web/src/components"] },
+            { ...base, id: 32, title: "cli", state: "in_progress", assignee: { name: "worker-c", kind: "agent" }, created_by: "worker-c", scope: ["cli/src"] },
           ],
         });
+      }
+      if (req.method === "GET" && req.path === "/api/channels/dev/messages") {
+        return Response.json({ messages: [] });
       }
       return undefined;
     });

--- a/cli/test/m3.test.ts
+++ b/cli/test/m3.test.ts
@@ -1255,17 +1255,18 @@ describe("party status/history channel flag", () => {
       conflicts: Array<{
         scope: string;
         owners: string[];
-        claims: Array<{ seq: number; owner: string; state: string; scope: string[] }>;
+        claims: Array<{ seq: number; task_id: number | null; owner: string; state: string; scope: string[] }>;
       }>;
       recommended_actions: Array<{ kind: string; target: string | null; reason: string }>;
     };
+    // #204：conflicts 由任务台账派生，每一侧都带 task_id，运维能直接看出冲突的是哪两个 task。
     expect(frame.conflicts).toEqual([
       {
         scope: "web/src",
         owners: ["worker-a", "worker-b"],
         claims: [
-          { seq: 31, owner: "worker-b", state: "working", scope: ["web/src/components"] },
-          { seq: 30, owner: "worker-a", state: "working", scope: ["web/src"] },
+          { seq: 31, task_id: 31, owner: "worker-b", state: "working", scope: ["web/src/components"] },
+          { seq: 30, task_id: 30, owner: "worker-a", state: "working", scope: ["web/src"] },
         ],
       },
     ]);

--- a/cli/test/rest-mock.ts
+++ b/cli/test/rest-mock.ts
@@ -242,6 +242,10 @@ export function startRestMock(handler?: RestHandler): RestMock {
       if (r.method === "GET" && /^\/api\/channels\/[^/]+\/messages$/.test(r.path)) {
         return Response.json({ messages: [] });
       }
+      // #204 host board 现在会并行拉 tasks；未显式处理的用例默认返回空台账，避免 404 让命令报错。
+      if (r.method === "GET" && /^\/api\/channels\/[^/]+\/tasks$/.test(r.path)) {
+        return Response.json({ tasks: [] });
+      }
       if (r.method === "GET" && /^\/api\/channels\/[^/]+\/search$/.test(r.path)) {
         return Response.json({ hits: [] });
       }

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -592,6 +592,8 @@ export interface DecisionSummary {
 
 export interface ConflictClaimSummary {
   seq: number;
+  /** 同 ClaimSummary.task_id：task 派生为对应 task 的 id，消息折叠派生为 null。渲染时据此区分 `task #N` 与 `#N`。 */
+  task_id: number | null;
   owner: string;
   state: StatusState;
   scope: string[];
@@ -777,12 +779,14 @@ export function summarizeConflicts(openClaims: ClaimSummary[]): ConflictSummary[
           const claims = groups.get(scope) ?? new Map<string, ConflictClaimSummary>();
           claims.set(`${left.owner}\0${left.seq}`, {
             seq: left.seq,
+            task_id: left.task_id,
             owner: left.owner,
             state: left.state,
             scope: left.scope,
           });
           claims.set(`${right.owner}\0${right.seq}`, {
             seq: right.seq,
+            task_id: right.task_id,
             owner: right.owner,
             state: right.state,
             scope: right.scope,

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -168,6 +168,10 @@ export interface TaskRecord {
   labels: string[];
   parent_id: number | null;
   anchor_seqs: number[];
+  /** 该任务声明占用的代码/文档作用域（#204）；conflicts 判定与派生 claim 的 scope 都来自这里 */
+  scope: string[];
+  /** state=blocked 时的结构化阻塞原因（#204）；其他状态为 null */
+  blocked_reason: string | null;
   completion_artifact: unknown | null;
   workflow_id: string | null;
   created_at: number;
@@ -557,8 +561,16 @@ export interface HostSummary {
 
 export interface ClaimSummary {
   seq: number;
+  /**
+   * claim 的新身份（#204）：任务台账派生的 claim = 对应 task 的 id；消息折叠派生的历史 claim（unlinked）无 task，为 null。
+   * owner+scope 拼出的 claimKey 不再是身份——同一 task 中途改 scope 仍是同一条 claim，不再裂成孤儿。
+   */
+  task_id: number | null;
   owner: string;
+  /** StatusState 口径的状态；task 派生时由 taskStateToStatusState(task.state) 映射得到 */
   state: StatusState;
+  /** 精确的任务台账状态（#204）；消息折叠派生的 claim 无对应 task 为 null，不丢失 assigned/in_progress/needs_review 的区分 */
+  task_state: TaskState | null;
   scope: string[];
   note: string | null;
   blocked_reason: string | null;
@@ -610,6 +622,8 @@ export interface HostBoard {
   blockers: ClaimSummary[];
   conflicts: ConflictSummary[];
   decisions: DecisionSummary[];
+  /** 历史消息里没有对应 task 的 status claim（#204 legacy 段）：按 seq 去重排序、附转换命令，不静默丢弃 */
+  unlinked_claims: ClaimSummary[];
   recommended_actions: RecommendedAction[];
 }
 
@@ -641,6 +655,25 @@ export function summarizeHosts(presence: PresenceEntry[], now: number): HostSumm
     });
 }
 
+// TaskState → StatusState 映射（#204）：host board 的 claim 用 StatusState 口径显示，而任务台账用 TaskState。
+// 活跃三态（assigned/in_progress/needs_review）视作 working，blocked/done 直通，triage/backlog 视作 waiting（待命/未开工）。
+// 精确 TaskState 另存于 claim.task_state，映射不丢信息。
+export function taskStateToStatusState(state: TaskState): StatusState {
+  switch (state) {
+    case "blocked":
+      return "blocked";
+    case "done":
+      return "done";
+    case "assigned":
+    case "in_progress":
+    case "needs_review":
+      return "working";
+    case "triage":
+    case "backlog":
+      return "waiting";
+  }
+}
+
 function claimKey(status: StatusEvent): string {
   return `${status.owner}\0${status.scope.join("\0")}`;
 }
@@ -648,8 +681,10 @@ function claimKey(status: StatusEvent): string {
 function claimFrom(seq: number, status: StatusEvent): ClaimSummary {
   return {
     seq,
+    task_id: null,
     owner: status.owner,
     state: status.state,
+    task_state: null,
     scope: status.scope,
     note: null,
     blocked_reason: status.blocked_reason,
@@ -849,16 +884,78 @@ export function recommendHostActions(
   return actions;
 }
 
+// #204：任务台账（channel_tasks）→ claim。claim 的身份 = task.id；owner = assignee（conflicts 按 assignee 判定），
+// 无 assignee 的任务（如无人认领的 blocked）回退 created_by 以保证 owner 非空。scope/blocked_reason 直接取自 task。
+function taskToClaim(task: TaskRecord): ClaimSummary {
+  return {
+    seq: task.id,
+    task_id: task.id,
+    owner: task.assignee?.name ?? task.created_by,
+    state: taskStateToStatusState(task.state),
+    task_state: task.state,
+    scope: task.scope,
+    note: task.blocked_reason,
+    blocked_reason: task.blocked_reason,
+    summary_seq: null,
+    updated_at: task.updated_at,
+    workflow: null,
+  };
+}
+
+// open_claims：活跃且有 assignee 的任务。claim 身份 = task id，故同一 task 改 scope 仍是同一条，不再裂成孤儿。
+const OPEN_CLAIM_STATES: readonly TaskState[] = ["assigned", "in_progress", "needs_review"];
+
+function openClaimsFromTasks(tasks: TaskRecord[]): ClaimSummary[] {
+  return tasks
+    .filter((task) => task.assignee !== null && OPEN_CLAIM_STATES.includes(task.state))
+    .map(taskToClaim)
+    .sort((a, b) => b.seq - a.seq);
+}
+
+function blockersFromTasks(tasks: TaskRecord[]): ClaimSummary[] {
+  return tasks
+    .filter((task) => task.state === "blocked")
+    .map(taskToClaim)
+    .sort((a, b) => b.seq - a.seq);
+}
+
+// unlinked（legacy）段（#204）：消息折叠出的 openClaims 里，没有任何 task 的 anchor_seqs 指向其 seq 的那些。
+// 「有对应 task」判定按 seq（anchor 命中），不用 owner+scope 拼 claimKey——这正是要修的影子台账根因：
+// 一个改过 scope 的 claim 用 claimKey 匹配会误判成「另一条」。去重与排序也按 seq（claim 的稳定标识），
+// 不用 claimKey：claimKey 会把同 owner+scope、不同 seq 的两条误并成一条、并按字符串序打乱顺序。
+function unlinkedClaimsFromMessages(messageOpenClaims: ClaimSummary[], tasks: TaskRecord[]): ClaimSummary[] {
+  const anchoredSeqs = new Set<number>();
+  for (const task of tasks) {
+    for (const seq of task.anchor_seqs) anchoredSeqs.add(seq);
+  }
+  const bySeq = new Map<number, ClaimSummary>();
+  for (const claim of messageOpenClaims) {
+    if (anchoredSeqs.has(claim.seq)) continue;
+    bySeq.set(claim.seq, claim);
+  }
+  return [...bySeq.values()].sort((a, b) => b.seq - a.seq);
+}
+
 export function buildHostBoard(
   channel: string,
   presence: PresenceEntry[],
   messages: MsgFrame[],
+  tasks: TaskRecord[] = [],
   now = Date.now(),
   options: HostBoardOptions = {},
 ): HostBoard {
-  const status = summarizeStatus(messages);
+  // decisions 仍从消息折叠来；open_claims / blockers / conflicts 改由任务台账派生（#204）。
+  const messageStatus = summarizeStatus(messages);
   const hosts = summarizeHosts(presence, now);
-  const conflicts = summarizeConflicts(status.openClaims);
+  const openClaims = openClaimsFromTasks(tasks);
+  const blockers = blockersFromTasks(tasks);
+  const conflicts = summarizeConflicts(openClaims);
+  const unlinkedClaims = unlinkedClaimsFromMessages(messageStatus.openClaims, tasks);
+  // recommendHostActions 的 loop-guard 检测靠 system status 消息里的 blocker（不是 task）；只喂 task blockers
+  // 会让 loop guard 永远看不到。故把消息里的 loop-guard system blocker 一并喂它；review-blockers 只对
+  // task blockers 生效（loop-guard blocker 的 owner=system 会被其 nonLoopBlockers 过滤掉）。
+  const loopGuardBlockers = messageStatus.blockers.filter(isLoopGuardBlocker);
+  const recommendBlockers = [...blockers, ...loopGuardBlockers];
   return {
     schema: "agentparty.v1",
     type: "host_board",
@@ -866,11 +963,12 @@ export function buildHostBoard(
     generated_at: now,
     last_seq: messages.at(-1)?.seq ?? 0,
     hosts,
-    open_claims: status.openClaims,
-    blockers: status.blockers,
+    open_claims: openClaims,
+    blockers,
     conflicts,
-    decisions: status.decisions,
-    recommended_actions: recommendHostActions(channel, hosts, status.blockers, conflicts, messages, options),
+    decisions: messageStatus.decisions,
+    unlinked_claims: unlinkedClaims,
+    recommended_actions: recommendHostActions(channel, hosts, recommendBlockers, conflicts, messages, options),
   };
 }
 

--- a/web/src/pages/Channel.tsx
+++ b/web/src/pages/Channel.tsx
@@ -2270,8 +2270,10 @@ export function ChannelPage({
     [state.messages, state.participants, state.presence, teamNow],
   );
   const hostBoard = useMemo(
-    () => buildHostBoard(slug, Object.values(state.presence), state.messages, teamNow, { loopGuardActive: state.loopGuard !== null }),
-    [slug, state.loopGuard, state.messages, state.presence, teamNow],
+    // #204 open_claims / conflicts / blockers 改由任务台账派生：把已加载的 tasks 一并喂进 buildHostBoard。
+    // 注：tasks 目前在打开任务面板时惰性加载，未打开时 board 的 task 派生段为空（详见 loadTaskLedger）。
+    () => buildHostBoard(slug, Object.values(state.presence), state.messages, tasks, teamNow, { loopGuardActive: state.loopGuard !== null }),
+    [slug, state.loopGuard, state.messages, state.presence, tasks, teamNow],
   );
   // @ 补全候选：participants ∪ presence，分档（在线/可唤醒/最近）。teamNow 30s 刷新驱动 stale 判定。
   const mentionOptions = useMemo(

--- a/web/src/pages/Channel.tsx
+++ b/web/src/pages/Channel.tsx
@@ -1585,9 +1585,13 @@ export function ChannelPage({
       .finally(() => setTaskActionBusyId(null));
   }, [loadTaskLedger, slug, taskActionBusyId, token]);
 
+  // #204：host board 的 conflicts 与 resolve-conflict / review-blockers 建议都从任务台账派生。
+  // HostBoardPanel 在进频道时就渲染，若这里只拉 summary，board 会一直显示「无冲突」直到用户碰巧
+  // 点开任务面板——空的 board 与「确实没有冲突」在界面上无法区分。故挂载时拉完整台账
+  // （loadTaskLedger 同时取 tasks 与 summary，替代原先单拉 summary 的调用）。
   useEffect(() => {
-    void loadTaskSummary();
-  }, [loadTaskSummary]);
+    void loadTaskLedger();
+  }, [loadTaskLedger]);
 
   const createTaskFromMessage = useCallback((seq: number) => {
     if (messageActionBusySeq !== null) return;

--- a/worker/migrations/0024_task_scope_and_blocked_reason.sql
+++ b/worker/migrations/0024_task_scope_and_blocked_reason.sql
@@ -1,0 +1,7 @@
+-- 任务台账（channel_tasks）首次拥有「作用域」与「阻塞原因」两个一等字段（#204）。
+-- 目的：让 open_claims / conflicts / blockers 改由任务台账派生，claim 的同一性变成 task id，
+-- scope 从「拼 claimKey 的同一性来源」降级为可变数据；conflicts 用任务 scope 跑 overlap 判定；
+-- blockers 直接带出结构化 blocked_reason，而不是从消息折叠里猜。
+-- 既有行按默认值补齐：scope_json 空数组、blocked_reason 为空。
+ALTER TABLE channel_tasks ADD COLUMN scope_json TEXT NOT NULL DEFAULT '[]';
+ALTER TABLE channel_tasks ADD COLUMN blocked_reason TEXT;

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -236,6 +236,10 @@ const TASK_TITLE_MAX = 200;
 const TASK_DESC_MAX = 8000;
 const TASK_LABEL_MAX = 40;
 const TASK_LABELS_MAX = 20;
+// #204 scope / blocked_reason 校验上限
+const TASK_SCOPE_ITEM_MAX = 256; // 每个 scope 条目的字节上限
+const TASK_SCOPE_MAX = 32; // scope 条目数量上限
+const TASK_BLOCKED_REASON_MAX = 2000; // blocked_reason 字节上限
 const SQUAD_MEMBERS_MAX = 50;
 const SQUAD_TITLE_MAX = 120;
 const SQUAD_DESCRIPTION_MAX = 4000;
@@ -617,6 +621,8 @@ function taskRowToRecord(row: {
   labels_json: string;
   parent_id: number | null;
   anchor_seqs_json: string;
+  scope_json: string;
+  blocked_reason: string | null;
   completion_artifact_json: string | null;
   workflow_id: string | null;
   created_at: number;
@@ -650,6 +656,8 @@ function taskRowToRecord(row: {
     labels: safeJsonArray<string>(row.labels_json).filter((label): label is string => typeof label === "string"),
     parent_id: row.parent_id,
     anchor_seqs: safeJsonArray<number>(row.anchor_seqs_json).filter((seq): seq is number => Number.isInteger(seq) && seq > 0),
+    scope: safeJsonArray<string>(row.scope_json).filter((entry): entry is string => typeof entry === "string" && entry.length > 0),
+    blocked_reason: row.blocked_reason,
     completion_artifact: completionArtifact,
     workflow_id: row.workflow_id,
     created_at: row.created_at,
@@ -683,6 +691,31 @@ function parseTaskAnchors(input: unknown): number[] | null {
     if (!anchors.includes(seq)) anchors.push(seq);
   }
   return anchors;
+}
+
+// #204 scope：每项非空字符串（去空白后非空）、字节上限、整体去重、数量上限。undefined/null → []。非法 → null。
+function parseTaskScope(input: unknown): string[] | null {
+  if (input === undefined || input === null) return [];
+  if (!Array.isArray(input)) return null;
+  const scope: string[] = [];
+  for (const item of input) {
+    if (typeof item !== "string") return null;
+    const entry = item.trim();
+    if (entry === "") return null;
+    if (textEncoder.encode(entry).byteLength > TASK_SCOPE_ITEM_MAX) return null;
+    if (!scope.includes(entry)) scope.push(entry);
+    if (scope.length > TASK_SCOPE_MAX) return null;
+  }
+  return scope;
+}
+
+// #204 blocked_reason：null 直通；字符串校验字节上限；非法类型/超长 → false（由调用方转 400）。
+// 注意：undefined 需由调用方先行处理（POST=默认 null，PATCH=保留原值），本函数不接收 undefined。
+function parseTaskBlockedReason(input: unknown): string | null | false {
+  if (input === null) return null;
+  if (typeof input !== "string") return false;
+  if (textEncoder.encode(input).byteLength > TASK_BLOCKED_REASON_MAX) return false;
+  return input;
 }
 
 function parseTaskAssignee(input: unknown): { name: string; kind: TaskAssigneeKind } | null | undefined {
@@ -3610,6 +3643,14 @@ app.post("/api/channels/:slug/tasks", async (c) => {
   }
   const anchorSeqs = parseTaskAnchors(body?.anchor_seqs);
   if (anchorSeqs === null) return c.json(errorBody("bad_request", "anchor_seqs must be positive integer array"), 400);
+  const scope = parseTaskScope(body?.scope);
+  if (scope === null) {
+    return c.json(errorBody("bad_request", `scope must be <= ${TASK_SCOPE_MAX} non-empty strings, each <= ${TASK_SCOPE_ITEM_MAX} bytes`), 400);
+  }
+  const blockedReason = body?.blocked_reason === undefined ? null : parseTaskBlockedReason(body.blocked_reason);
+  if (blockedReason === false) {
+    return c.json(errorBody("bad_request", `blocked_reason must be null or a string <= ${TASK_BLOCKED_REASON_MAX} bytes`), 400);
+  }
   const priority = body?.priority === undefined ? 0 : typeof body?.priority === "number" && Number.isInteger(body.priority) ? body.priority : null;
   if (priority === null || priority < -100 || priority > 100) {
     return c.json(errorBody("bad_request", "priority must be an integer between -100 and 100"), 400);
@@ -3631,8 +3672,8 @@ app.post("/api/channels/:slug/tasks", async (c) => {
     `INSERT INTO channel_tasks (
        channel_slug, title, description, state, assignee_name, assignee_kind,
        created_by, created_by_kind, created_by_owner, priority, labels_json,
-       parent_id, anchor_seqs_json, workflow_id, created_at, updated_at, completed_at
-     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+       parent_id, anchor_seqs_json, workflow_id, scope_json, blocked_reason, created_at, updated_at, completed_at
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   )
     .bind(
       slug,
@@ -3649,6 +3690,8 @@ app.post("/api/channels/:slug/tasks", async (c) => {
       parentId,
       JSON.stringify(anchorSeqs),
       workflowId,
+      JSON.stringify(scope),
+      blockedReason,
       now,
       now,
       state === "done" ? now : null,
@@ -3716,6 +3759,16 @@ app.patch("/api/channels/:slug/tasks/:id", async (c) => {
   if (priority === null || priority < -100 || priority > 100) {
     return c.json(errorBody("bad_request", "priority must be an integer between -100 and 100"), 400);
   }
+  const scope = body.scope === undefined
+    ? safeJsonArray<string>(existing.scope_json).filter((entry): entry is string => typeof entry === "string" && entry.length > 0)
+    : parseTaskScope(body.scope);
+  if (scope === null) {
+    return c.json(errorBody("bad_request", `scope must be <= ${TASK_SCOPE_MAX} non-empty strings, each <= ${TASK_SCOPE_ITEM_MAX} bytes`), 400);
+  }
+  const blockedReason = body.blocked_reason === undefined ? existing.blocked_reason : parseTaskBlockedReason(body.blocked_reason);
+  if (blockedReason === false) {
+    return c.json(errorBody("bad_request", `blocked_reason must be null or a string <= ${TASK_BLOCKED_REASON_MAX} bytes`), 400);
+  }
 
   const nextAssigneeName =
     assignee === undefined ? existing.assignee_name : assignee === null ? null : assignee.name;
@@ -3726,10 +3779,10 @@ app.patch("/api/channels/:slug/tasks/:id", async (c) => {
   await c.env.DB.prepare(
     `UPDATE channel_tasks
         SET title = ?, description = ?, state = ?, assignee_name = ?, assignee_kind = ?,
-            priority = ?, labels_json = ?, updated_at = ?, completed_at = ?
+            priority = ?, labels_json = ?, scope_json = ?, blocked_reason = ?, updated_at = ?, completed_at = ?
       WHERE channel_slug = ? AND id = ?`,
   )
-    .bind(title, desc, state, nextAssigneeName, nextAssigneeKind, priority, JSON.stringify(labels), now, completedAt, slug, id)
+    .bind(title, desc, state, nextAssigneeName, nextAssigneeKind, priority, JSON.stringify(labels), JSON.stringify(scope), blockedReason, now, completedAt, slug, id)
     .run();
   const row = await loadTaskRow(c.env.DB, slug, id);
   await insertSystemStatus(c.env, slug, `task #${id} ${state}`, statusStateForTask(state)).catch(() => false);

--- a/worker/test/tasks.spec.ts
+++ b/worker/test/tasks.spec.ts
@@ -94,4 +94,79 @@ describe("channel task ledger", () => {
 
     expect((await api(`/api/channels/${slug}/tasks`, otherHuman.token)).status).toBe(403);
   });
+
+  it("round-trips scope and blocked_reason; enforces scope/blocked_reason validation (#204)", async () => {
+    const owner = `owner-${uniq("scope")}@example.com`;
+    const human = await seedToken("human", uniq("human"), { owner });
+    const agent = await seedToken("agent", uniq("agent"), { owner });
+    const slug = await createChannel(human.token);
+
+    // create 带 scope（含重复项，服务端去重）+ blocked_reason
+    const created = await api(`/api/channels/${slug}/tasks`, human.token, {
+      method: "POST",
+      body: JSON.stringify({
+        title: "scoped task",
+        assignee: { name: agent.name, kind: "agent" },
+        scope: ["web/src", "cli/src", "web/src"],
+        blocked_reason: "waiting on token",
+      }),
+    });
+    expect(created.status).toBe(201);
+    const task = (await created.json()) as { id: number; scope: string[]; blocked_reason: string | null };
+    expect(task.scope).toEqual(["web/src", "cli/src"]);
+    expect(task.blocked_reason).toBe("waiting on token");
+
+    // GET 单条往返一致
+    const got = await api(`/api/channels/${slug}/tasks/${task.id}`, human.token);
+    expect(got.status).toBe(200);
+    expect(await got.json()).toMatchObject({ scope: ["web/src", "cli/src"], blocked_reason: "waiting on token" });
+
+    // 列表也带出 scope/blocked_reason
+    const listed = await api(`/api/channels/${slug}/tasks`, human.token);
+    const listedTask = ((await listed.json()) as { tasks: Array<{ id: number; scope: string[]; blocked_reason: string | null }> }).tasks.find((t) => t.id === task.id)!;
+    expect(listedTask.scope).toEqual(["web/src", "cli/src"]);
+    expect(listedTask.blocked_reason).toBe("waiting on token");
+
+    // PATCH 改 scope、清空 blocked_reason（null）
+    const patched = await api(`/api/channels/${slug}/tasks/${task.id}`, human.token, {
+      method: "PATCH",
+      body: JSON.stringify({ scope: ["worker/src"], blocked_reason: null }),
+    });
+    expect(patched.status).toBe(200);
+    expect(await patched.json()).toMatchObject({ scope: ["worker/src"], blocked_reason: null });
+
+    // PATCH 不带 scope → 保留原 scope（不被清空）
+    const patched2 = await api(`/api/channels/${slug}/tasks/${task.id}`, human.token, {
+      method: "PATCH",
+      body: JSON.stringify({ state: "in_progress" }),
+    });
+    expect(await patched2.json()).toMatchObject({ scope: ["worker/src"] });
+
+    // 非法 scope：含非字符串项 → 400
+    expect((await api(`/api/channels/${slug}/tasks`, human.token, {
+      method: "POST",
+      body: JSON.stringify({ title: "bad", scope: [123] }),
+    })).status).toBe(400);
+
+    // 非法 scope：空字符串项 → 400
+    expect((await api(`/api/channels/${slug}/tasks`, human.token, {
+      method: "POST",
+      body: JSON.stringify({ title: "bad", scope: [""] }),
+    })).status).toBe(400);
+
+    // 非法 blocked_reason：类型错误 → 400
+    expect((await api(`/api/channels/${slug}/tasks`, human.token, {
+      method: "POST",
+      body: JSON.stringify({ title: "bad", blocked_reason: 5 }),
+    })).status).toBe(400);
+
+    // 省略时默认 scope=[]、blocked_reason=null
+    const plain = await api(`/api/channels/${slug}/tasks`, human.token, {
+      method: "POST",
+      body: JSON.stringify({ title: "plain" }),
+    });
+    expect(plain.status).toBe(201);
+    expect(await plain.json()).toMatchObject({ scope: [], blocked_reason: null });
+  });
+
 });


### PR DESCRIPTION
> **频道身份**：本 PR 由 `#agentparty` 频道的 agent **`Evan_Clauder`** 提交。

Fixes #204

## 缺陷
`buildHostBoard` 的 `open_claims / conflicts / blockers` 原本由 `summarizeStatus(messages)` **折叠消息流**推断，这是一个影子台账：`claimKey = ${owner}\0${scope.join()}` 让 **scope 参与 claim 的同一性**。owner 中途改了 scope（`["web/src"]` → `["web/src","cli"]`）就变成另一条 claim，旧那条永远关不掉（后续 `done` 落到新 key 上），取全量也修不掉。根因是 **claim 从来没有稳定身份**。

## 裁决出处
- leo-claude 频道 seq **421 / 425**：选 (A) 加 `scope_json`——不是为 conflicts 加一列，而是让 claim 第一次拥有身份；换到任务台账后 claim 的同一性 = **task id**，scope 降级为可变数据。
- seq **359**：`open_claims / conflicts / blockers` 全来自任务台账，`decisions` 留消息折叠，加 `blocked_reason` 列。
- legacy 段按 **seq** 列，别复用 `claimKey`。

## 类型设计决定与理由
- `ClaimSummary` 新增 `task_id: number | null`（claim 的新身份；消息折叠派生的历史 claim 无 task 为 `null`）。这是本 PR 的核心：**身份从 owner+scope 拼的 claimKey 迁到 task id**。
- `state` 仍是 `StatusState`，**不硬塞 `TaskState`**：新增 `taskStateToStatusState` 映射（assigned/in_progress/needs_review→working，blocked/done 直通，triage/backlog→waiting）；同时新增 `task_state: TaskState | null` **保留精确任务状态不丢失**。这样 `printBoard`（用 StatusState 口径）、`summarizeConflicts`→`ConflictClaimSummary.state`、web 都无需改类型即可继续工作。
- `HostBoard` 新增 `unlinked_claims: ClaimSummary[]`；`TaskRecord` 新增 `scope: string[]` 与 `blocked_reason: string | null`。
- `summarizeStatus / claimKey / summarizeConflicts` 全部保留（decisions 与 unlinked 仍用），但 `claimKey` 不再用于 open_claims 的身份。
- loop-guard 是 **system status 消息**（不是 task）：为不切断熔断建议，仍把消息里的 loop-guard system blocker 单独并入 `recommendHostActions`，`review-blockers` 只对 task blockers 生效。

## legacy 段设计（不静默丢弃）
消息里没有对应 task 的历史 status claim 落进 `unlinked_claims`。「有对应 task」判定按 **seq**（task 的 `anchor_seqs` 命中该 claim 的 seq），不用 owner+scope 拼 claimKey；去重与排序也按 **seq**。`printBoard` 独立成段（不混进 open claims）并给出转换命令 `party task from <seq>`，`--json` 同步带 `unlinked_claims`。

## 变异表 + 等价实现替换（硬门槛，逐个单独应用后还原）
| 变异 | 期望 | 实测 |
|---|---|---|
| M1 `open_claims` 改回 `summarizeStatus(messages).openClaims` | 身份/孤儿断言红 | 4 fail（3 条 open_claims 契约 + host board 命令级）✓ |
| M2 `blockers` 改回消息折叠 | blocked_reason 断言红 | 5 fail（2 条 blocker 契约 + m3 814/1059/1149）✓ |
| M3 `conflicts` 用消息 scope | conflicts 断言红 | 2 fail（conflict 契约 + m3 1208）✓ |
| M4 `unlinked_claims` 恒 `[]` | legacy 段断言红 | 5 fail（2 host 命令级 + 3 契约）✓ |
| M5 `unlinked` 去重/排序键 seq→claimKey | 有断言红 | 1 fail（`unlinked 按 seq 去重与排序` 契约）✓ |
| **等价实现替换**（`unlinkedClaimsFromMessages` 换成 `some()` 内联 + `seen` Set 的语义等价写法） | 全绿 | **391 pass / 0 fail** ✓ |

M5 补充：因为 `summarizeStatus` 已按 claimKey 折叠出 openClaims（其中 seq 天然唯一），unlinked 步骤里 seq 与 claimKey 去重在「集合」上观测等价；seq 语义真正的区分点是「链接判定按 anchor seq」（`链接判定按 seq 而非 claimKey` 测试钉住）与「排序按 seq」（M5 命中的排序测试钉住），两处都有断言。

## 验证输出
```
shared: bunx tsc --noEmit → OK
cli:    bunx tsc --noEmit → OK；bun test → 391 pass / 0 fail（22 files）
worker: bunx tsc --noEmit → OK；bunx vitest run → 296 pass（40 files）
migration: ls worker/migrations | grep 0024 → 唯一
```

## 未做 / 未测到（如实列出）
- **web 加载时机未改**：host board 现在依赖 `tasks`，但 web 的 `tasks` 是打开任务面板时惰性加载（`loadTaskLedger`），未打开面板时 board 的 task 派生段为空。web `HostBoardPanel` 目前也只渲染 hosts/recommended_actions/conflicts（不渲染 open_claims/blockers/unlinked_claims），故可见影响仅为「未打开任务面板时 conflicts 段可能为空」。仅补了 `buildHostBoard` 的签名入参并加注释，未改 web 的加载策略（超出本次范围）。
- **web tsc 既有 2 处报错**（`web/src/lib/desktopRuntime.ts` 缺 `@tauri-apps/plugin-opener` / `plugin-deep-link` 类型声明）与本改动无关，未处理；本次改动的 `Channel.tsx` 自身类型通过。未跑 web 的 `bun test` / `vite build`（不在本任务验证范围）。
- **task 派生 claim 的 `workflow` 为 `null`**：`TaskRecord` 只有 `workflow_id`（字符串），无 `StatusWorkflow` 结构，故 task-derived claim/blocker 不再携带原消息折叠 blocker 的 `StatusWorkflow`。这是任务台账语义下的信息取舍。
- **conflicts 收窄到活跃 open_claims**（assigned/in_progress/needs_review）：blocked task 只进 blockers、不参与 conflict 判定。原消息折叠实现的 openClaims 含 blocked。
- **转换命令**用实际存在的 `party task from <seq>`（issue 示例里写的 `party task create --from-seq` 在 CLI 中不存在）。
