### PR TITLE
fix(cli): wake test 对无适配器的可达 agent 也发探针，自测目标秒失败 (#181, #194)

### DIFF
--- a/cli/src/commands/wake.ts
+++ b/cli/src/commands/wake.ts
@@ -1,7 +1,7 @@
 // party wake test — prove mention/wake/resume as separate phases.
 import { autoWakeReachable, EXIT_TIMEOUT, type MsgFrame, type PresenceEntry, type WakeDelivery } from "@agentparty/shared";
 import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
-import { resolveChannel } from "../config";
+import { readConfig, resolveChannel } from "../config";
 import { jsonFrame, nowTs } from "../json";
 import { resolveAuth } from "../oidc-cli";
 import { RestError, fetchMessages, fetchPresence, fetchWakeDeliveries, handleRestError, postMessage } from "../rest";
@@ -16,12 +16,17 @@ Run a wake contract test. This separates mention delivery, wake adapter delivery
 and linked agent resume. Only a fresh reply/status linked to the test mention
 counts as resumed.
 
+A target that advertises no wake adapter is still probed empirically (the mention is
+delivered and the reply/timeout is conclusive), because "no adapter" is not proof of
+"unreachable" — the harness may be polling. Targeting your own identity fails fast
+without sending a probe (serve/watch ignore self-messages).
+
 Options:
   --channel C    test in channel C instead of the bound channel
   --timeout N    seconds to wait for linked ack/status (default: 30)
   --json         emit one structured wake_test frame`;
 
-type WakeResult = "not_auto_wakeable" | "healthy" | "timeout";
+type WakeResult = "not_auto_wakeable" | "healthy" | "timeout" | "self_target";
 type AckEvidence = "reply_to" | "status.summary_seq";
 
 interface WakePresence {
@@ -63,26 +68,30 @@ function summarizePresence(p: PresenceEntry | null): WakePresence {
   };
 }
 
-function notWakeableReason(p: PresenceEntry | null, now: number): string | null {
-  if (p === null) return "no presence for target";
-  if (p.residency === "human_driven") return "target is human-driven; mention is inbox only";
-  // wake_kind is the real capability; residency is a soft hint. If a real adapter is
-  // advertised, send the mention and let the empirical resume/timeout be conclusive —
-  // even when residency=bare. A running `party serve` is a live supervisor whether the
-  // agent labeled itself bare or supervised, so refusing on residency alone would skip a
-  // wake that actually works (issue: serve+bare wrongly judged not_auto_wakeable). Only
-  // refuse when there is genuinely no adapter to invoke.
+// wake test 的探针闸门（issue #181）。把「送不送探针」和「heartbeat 怎么判」拆开：
+//  - block !== null  → 不发探针，直接结论 not_auto_wakeable（沿用旧语义 + 现有测试）。
+//    仅在「探针无处可去」时 block：没 presence（不在频道）、human_driven（只进收件箱）、
+//    声明了适配器却无心跳、或适配器陈旧（serve/watch 的常驻 supervisor 已死，#47/#97）。
+//  - advisory !== null → 仍发探针，但 heartbeat 视角是负面的（没声明任何适配器）。#181 的实锤：
+//    没声明适配器 ≠ 不可达——agent 可能在轮询或人盯着，是 wake 模型没表达的模式。此时从
+//    self-reported 元数据下「不可达」结论是不可证伪的，必须发探针、按「观测到的答复」定论。
+//  - 两者皆 null → 声明了新鲜适配器，正常发探针。
+function wakeProbeGate(p: PresenceEntry | null, now: number): { block: string | null; advisory: string | null } {
+  if (p === null) return { block: "no presence for target", advisory: null };
+  if (p.residency === "human_driven") return { block: "target is human-driven; mention is inbox only", advisory: null };
   if (p.wake === undefined || p.wake.kind === "none") {
-    return p.residency === "bare"
-      ? "target has bare residency and advertises no wake adapter"
-      : "target advertises no wake adapter";
+    const advisory =
+      p.residency === "bare"
+        ? "target has bare residency and advertises no wake adapter"
+        : "target advertises no wake adapter";
+    return { block: null, advisory };
   }
   const seen = p.last_seen ?? p.ts ?? null;
-  if (seen === null) return "target wake adapter has no last_seen heartbeat";
+  if (seen === null) return { block: "target wake adapter has no last_seen heartbeat", advisory: null };
   if (!autoWakeReachable(p, now, STALE_MS)) {
-    return `target ${p.wake.kind} wake adapter is stale; last seen ${Math.max(0, now - seen)}ms ago`;
+    return { block: `target ${p.wake.kind} wake adapter is stale; last seen ${Math.max(0, now - seen)}ms ago`, advisory: null };
   }
-  return null;
+  return { block: null, advisory: null };
 }
 
 function ackEvidence(mentionSeq: number, candidate: MsgFrame): AckEvidence | null {
@@ -224,13 +233,45 @@ export async function run(argv: string[]): Promise<number> {
     return 1;
   }
 
+  // #194: 目标解析为自己身份时立刻失败——serve/watch 按设计忽略发送者自己的消息，
+  // 自测必然 resumed:no。这个条件用本地缓存身份即可在发探针前判定，不必真往频道发一条
+  // mention（白烧 loop-guard 名额），更不必空等满 --timeout（把「误用」伪装成「agent 死了」）。
+  // 仅凭本地缓存身份判定（零网络请求）；身份未缓存时优雅降级到旧路径（发探针→timeout）。
+  const selfName = readConfig()?.identity?.name ?? null;
+  if (selfName !== null && selfName === target) {
+    const reason =
+      `wake test: @${target} is your own identity; serve/watch ignore self-messages. ` +
+      "Ask another identity to run this test.";
+    if (flags.json === true) {
+      const frame: WakeTestFrame = {
+        type: "wake_test",
+        channel,
+        target,
+        result: "self_target",
+        generated_at: nowTs(),
+        timeout_sec: timeoutSec,
+        presence: summarizePresence(null),
+        phases: {
+          mention_delivered: { ok: false, seq: null, evidence: "not sent because target is the caller's own identity" },
+          wake_invoked: { ok: false, adapter: null, evidence: reason },
+          agent_resumed: { ok: false, seq: null, evidence: null },
+        },
+        reason,
+      };
+      console.log(JSON.stringify(jsonFrame(frame)));
+    } else {
+      console.error(reason);
+    }
+    return 1;
+  }
+
   try {
     const presenceList = await fetchPresence(cfg.server, cfg.token, channel);
     const presence = presenceList.find((p) => p.name === target) ?? null;
     const generatedAt = nowTs();
-    const reason = notWakeableReason(presence, generatedAt);
+    const gate = wakeProbeGate(presence, generatedAt);
     const adapter = presence?.wake?.kind ?? null;
-    if (reason !== null) {
+    if (gate.block !== null) {
       const frame: WakeTestFrame = {
         type: "wake_test",
         channel,
@@ -241,10 +282,10 @@ export async function run(argv: string[]): Promise<number> {
         presence: summarizePresence(presence),
         phases: {
           mention_delivered: { ok: false, seq: null, evidence: "not sent because target is not auto-wakeable" },
-          wake_invoked: { ok: false, adapter, evidence: reason },
+          wake_invoked: { ok: false, adapter, evidence: gate.block },
           agent_resumed: { ok: false, seq: null, evidence: null },
         },
-        reason,
+        reason: gate.block,
       };
       if (flags.json === true) console.log(JSON.stringify(jsonFrame(frame)));
       else printHuman(frame);
@@ -284,20 +325,35 @@ export async function run(argv: string[]): Promise<number> {
         target +
         " is your own identity, retry from a different one)"
       : "timed out waiting for linked reply_to/status.summary_seq";
+    // #181: 探针已投递，按观测定论。收到 ack → healthy（哪怕它没声明任何 wake 适配器，
+    // 只要它真的答复了就是可达的）。没 ack 时，若 heartbeat 视角本就负面（没声明适配器），
+    // 结论仍是 not_auto_wakeable 但标注「探针已投递、未答复、未确认」——把 heartbeat 判定
+    // 和投递判定摊开，而不是当初那句不可证伪的 mention: not sent。
+    const result: WakeResult = ack !== null ? "healthy" : gate.advisory !== null ? "not_auto_wakeable" : "timeout";
+    const frameReason =
+      ack !== null
+        ? null
+        : gate.advisory !== null
+          ? `${gate.advisory} (unconfirmed — probe delivered #${seq}, no reply within ${timeoutSec}s)`
+          : timeoutReason;
+    const wakeInvoked =
+      gate.advisory !== null && wakeDelivery === null
+        ? { ok: false as const, adapter, evidence: gate.advisory }
+        : summarizeWakeDelivery(wakeDelivery, adapter);
     const frame: WakeTestFrame = {
       type: "wake_test",
       channel,
       target,
-      result: ack === null ? "timeout" : "healthy",
+      result,
       generated_at: nowTs(),
       timeout_sec: timeoutSec,
       presence: summarizePresence(presence),
       phases: {
         mention_delivered: { ok: true, seq, evidence: "message accepted by channel history" },
-        wake_invoked: summarizeWakeDelivery(wakeDelivery, adapter),
+        wake_invoked: wakeInvoked,
         agent_resumed: { ok: ack !== null, seq: ack?.seq ?? null, evidence: ack?.evidence ?? null },
       },
-      reason: ack === null ? timeoutReason : null,
+      reason: frameReason,
     };
     if (flags.json === true) console.log(JSON.stringify(jsonFrame(frame)));
     else printHuman(frame);

--- a/cli/test/wake.test.ts
+++ b/cli/test/wake.test.ts
@@ -1,0 +1,185 @@
+// party wake test — falsifiability (#181) 与 self-target 快速失败 (#194)
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { startRestMock, type RestMock, type RestRequest } from "./rest-mock";
+
+const indexPath = join(import.meta.dir, "..", "src", "index.ts");
+
+let home: string;
+let mock: RestMock | null = null;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "ap-wake-"));
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+  mock?.stop();
+  mock = null;
+});
+
+async function runCli(args: string[]): Promise<{ code: number; stdout: string; stderr: string }> {
+  const proc = Bun.spawn(["bun", "run", indexPath, ...args], {
+    env: { ...process.env, AGENTPARTY_HOME: home, ADMIN_SECRET: undefined },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, code] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { code, stdout, stderr };
+}
+
+function writeCfg(server: string, identityName?: string) {
+  mkdirSync(home, { recursive: true });
+  const cfg: Record<string, unknown> = { server, token: "ap_tok" };
+  if (identityName !== undefined) {
+    cfg.identity = {
+      name: identityName,
+      email: null,
+      kind: "agent",
+      role: "agent",
+      owner: null,
+      channel_scope: null,
+      verified_at: 0,
+    };
+  }
+  writeFileSync(join(home, "config.json"), JSON.stringify(cfg));
+}
+
+function reqsOf(m: RestMock, method: string, pathPrefix: string): RestRequest[] {
+  return m.requests.filter((r) => r.method === method && r.path.startsWith(pathPrefix));
+}
+
+// ── #181：advertises-no-adapter 的 agent 也要真发探针，让 not_auto_wakeable 可证伪 ──
+describe("wake test falsifiability (#181)", () => {
+  test("no advertised adapter but reachable: probe IS sent and reads healthy when it replies", async () => {
+    mock = startRestMock((req) => {
+      if (req.method === "GET" && req.path === "/api/channels/dev/presence") {
+        const now = Date.now();
+        // 声明了 residency 但没有 wake 适配器（tk-zego-im 场景：轮询/人驱动，模型没表达）
+        return Response.json({
+          presence: [{ name: "bot", state: "offline", note: null, ts: now, last_seen: now, residency: "supervised" }],
+        });
+      }
+      if (req.method === "POST" && req.path === "/api/channels/dev/messages") {
+        return Response.json({ seq: 5 });
+      }
+      if (req.method === "GET" && req.path === "/api/channels/dev/messages") {
+        return Response.json({
+          messages: [
+            { type: "message", seq: 6, sender: { name: "bot", kind: "agent" }, kind: "message", body: "on it", mentions: [], reply_to: 5, ts: 1 },
+          ],
+        });
+      }
+      return undefined;
+    });
+    writeCfg(mock.url, "me");
+
+    const r = await runCli(["wake", "test", "@bot", "dev", "--timeout", "1", "--json"]);
+    expect(r.code).toBe(0);
+    // 探针必须真发出去（旧行为是 mention: not sent）
+    expect(reqsOf(mock, "POST", "/api/channels/dev/messages")).toHaveLength(1);
+    const frame = JSON.parse(r.stdout.trim());
+    expect(frame).toMatchObject({
+      type: "wake_test",
+      result: "healthy",
+      phases: {
+        mention_delivered: { ok: true, seq: 5 },
+        agent_resumed: { ok: true, seq: 6, evidence: "reply_to" },
+      },
+    });
+  });
+
+  test("no advertised adapter and no reply: probe delivered, verdict is not_auto_wakeable (unconfirmed)", async () => {
+    mock = startRestMock((req) => {
+      if (req.method === "GET" && req.path === "/api/channels/dev/presence") {
+        const now = Date.now();
+        return Response.json({
+          presence: [{ name: "bot", state: "offline", note: null, ts: now, last_seen: now, residency: "supervised" }],
+        });
+      }
+      if (req.method === "POST" && req.path === "/api/channels/dev/messages") {
+        return Response.json({ seq: 7 });
+      }
+      if (req.method === "GET" && req.path === "/api/channels/dev/messages") {
+        return Response.json({ messages: [] });
+      }
+      return undefined;
+    });
+    writeCfg(mock.url, "me");
+
+    const r = await runCli(["wake", "test", "@bot", "dev", "--timeout", "1", "--json"]);
+    expect(r.code).toBe(2);
+    // 关键：探针发出了，mention 不再是 "not sent"
+    expect(reqsOf(mock, "POST", "/api/channels/dev/messages")).toHaveLength(1);
+    const frame = JSON.parse(r.stdout.trim());
+    expect(frame).toMatchObject({
+      type: "wake_test",
+      result: "not_auto_wakeable",
+      phases: {
+        mention_delivered: { ok: true, seq: 7 },
+        wake_invoked: { ok: false },
+        agent_resumed: { ok: false, seq: null },
+      },
+    });
+    // wake_invoked 摊出 heartbeat 视角（没声明适配器），而不是笼统的「未审计」
+    expect(frame.phases.wake_invoked.evidence).toContain("no wake adapter");
+    // 结论标注为「探针未答复，未确认」——把 heartbeat 判定与投递判定分开
+    expect(frame.reason).toContain("no wake adapter");
+    expect(frame.reason).toContain("unconfirmed");
+  });
+
+  test("human_driven stays inbox-only: no probe is sent (falsifiability scoped to no-adapter, not human)", async () => {
+    mock = startRestMock((req) => {
+      if (req.method === "GET" && req.path === "/api/channels/dev/presence") {
+        return Response.json({
+          presence: [{ name: "bot", state: "waiting", note: null, ts: 111, last_seen: 111, residency: "human_driven", wake: { kind: "none" } }],
+        });
+      }
+      return undefined;
+    });
+    writeCfg(mock.url, "me");
+
+    const r = await runCli(["wake", "test", "@bot", "dev", "--json"]);
+    expect(r.code).toBe(2);
+    expect(reqsOf(mock, "POST", "/api/channels/dev/messages")).toHaveLength(0);
+    const frame = JSON.parse(r.stdout.trim());
+    expect(frame).toMatchObject({
+      type: "wake_test",
+      result: "not_auto_wakeable",
+      phases: { mention_delivered: { ok: false, seq: null } },
+    });
+    expect(frame.reason).toContain("human-driven");
+  });
+});
+
+// ── #194：目标解析为自己身份时，别发真探针、别等满 timeout，立刻失败 ──
+describe("wake test self-target fast-fail (#194)", () => {
+  test("self-target (cached identity) fails immediately with no probe and no network call", async () => {
+    mock = startRestMock();
+    writeCfg(mock.url, "me");
+
+    const r = await runCli(["wake", "test", "@me", "dev"]);
+    // 与通用 timeout(exit 2) 区分开，供调度端识别「误用」而非「agent 真死了」
+    expect(r.code).toBe(1);
+    // 一条网络请求都不该发（presence 都没查，更别说探针）
+    expect(mock.requests).toHaveLength(0);
+    expect(r.stderr).toContain("your own identity");
+  });
+
+  test("self-target --json emits a structured self_target frame, still no probe", async () => {
+    mock = startRestMock();
+    writeCfg(mock.url, "me");
+
+    const r = await runCli(["wake", "test", "@me", "dev", "--json"]);
+    expect(r.code).toBe(1);
+    expect(reqsOf(mock, "POST", "/api/channels/dev/messages")).toHaveLength(0);
+    const frame = JSON.parse(r.stdout.trim());
+    expect(frame).toMatchObject({ type: "wake_test", target: "me", result: "self_target" });
+  });
+});


### PR DESCRIPTION
> 频道身份：leo-codex-main-dev（#agentparty）

Closes #181, #194

## 背景

`party wake test` 的核心承诺是「分离 mention 投递 / wake 适配器投递 / linked resume」，但两处塌缩了这个承诺：

- **#181**：对一个 `advertises no wake adapter` 但实际可达（轮询 / 人盯）的 agent，命令仅凭 self-reported 元数据就判 `not_auto_wakeable` 并 `mention: not sent`——**从不发探针**，于是这个结论**不可证伪**，`--timeout` 在唯一需要它的路径上形同虚设。这是「假阴性」：调度端读到 `not_auto_wakeable` 就把一个能干活的 agent 摘掉，且**无任何症状**。
- **#194**：`wake test` 打到**自己的身份**时，会真往频道发一条 mention，然后因为 serve/watch 按设计忽略自己的消息而**空等满 `--timeout`**——注定 `resumed: no`。既污染频道（白烧 loop-guard 名额），又把「误用」伪装成「agent 真死了」。

## 根因

- `cli/src/commands/wake.ts:66` `notWakeableReason()` 把「没适配器 / 适配器陈旧 / human_driven」**全部**折叠成一个短路返回；`wake.ts:233`（改前）`if (reason !== null)` 直接出帧 `mention_delivered.ok=false` 并 `return`，探针永不发出。→ #181
- `wake.ts` 改前**没有任何 self-target 检查**：run() 一路走到 `postMessage()` 才发探针，随后死等 `deadline`。→ #194

## 改动

`cli/src/commands/wake.ts`：

1. **#181 — 无适配器改为经验判定（发探针）。** 把 `notWakeableReason` 重构为 `wakeProbeGate()`，区分两类：
   - `block`（不发探针，沿用旧语义）：不在频道 / `human_driven`（只进收件箱）/ 声明了适配器却无心跳 / **陈旧 serve|watch**（常驻 supervisor 已死，属 #47/#97，且有现存测试锚定，本 PR 不动）。
   - `advisory`（**仍发探针**）：`wake` 未声明 / `kind==="none"`。发探针 + 等 `--timeout`，收到 linked reply/status → `healthy`（哪怕它没声明适配器）；没答复 → `not_auto_wakeable` 但结论标注 `... (unconfirmed — probe delivered #N, no reply within Ns)`，`mention_delivered.ok=true`、`wake_invoked.evidence` 摊出 heartbeat 视角。
   - 作用域说明：#181 的实锤是 `tk-zego-im` 的**无适配器**场景；issue 正文明确把陈旧适配器归给 #97，故本 PR 只修无适配器一支，陈旧/human_driven 维持拒绝。
2. **#194 — self-target 秒失败。** 在 `fetchPresence` 之前用**本地缓存身份**（`readConfig()?.identity?.name`，零网络请求）判定：目标 == 自身 → 立即 `exit 1`（与通用 timeout `exit 2` 区分），不发探针；`--json` 输出 `result:"self_target"` 帧，否则 stderr 打印引导语「@self is your own identity; ... Ask another identity to run this test.」。

## 变异表（逐个接线点拆掉 → 精确变红）

| # | 变异（拆掉的接线点） | 变红的测试 |
|---|---|---|
| M1 | self-target 比较 `selfName === target` 恒 false | #194 两条（cached fast-fail / --json self_target） |
| M2 | 缓存身份读取 `readConfig()?.identity?.name` → `null` | #194 两条 |
| M3 | 无适配器 `{block:null,advisory}` → 改回 `{block:advisory}`（重新拒绝） | #181 两条（healthy / probe-sent） |
| M4 | 结论折叠 `advisory!==null?"not_auto_wakeable":"timeout"` → 恒 `"timeout"` | #181「无答复」条（result 断言） |
| M5 | `frameReason` 的 `unconfirmed` 标注 → 退回 `timeoutReason` | #181「无答复」条（reason 断言） |
| M6 | `wake_invoked` 的 advisory 分支 → 恒用 `summarizeWakeDelivery` | #181「无答复」条（wake_invoked.evidence 断言） |
| M7 | `human_driven` 的 block 分支恒 false | #181 human_driven 守卫条（探针被误发） |

每处变异都**恰有**对应测试变红；无零覆盖的接线点。

## 门禁输出

- 新增 `cli/test/wake.test.ts`：**5 pass / 0 fail**（`cd cli && bun test test/wake.test.ts`）
- 全量 CLI：**383 pass / 0 fail**（`cd cli && bun test --timeout 30000`）
- 类型检查：`cd cli && bunx tsc --noEmit` clean
- 现存 wake 相关回归全绿：`m3.test.ts` 的 7 条 wake test（含陈旧拒绝 / human_driven / serve / webhook）+ `json-contract.test.ts` 12 条，均未受影响

> 注：默认 5s 逐测超时下，`m3.test.ts` 有两条**与本改动无关**的用例（`status role 本地校验` / `history 整数校验`，均 spawn 子进程）在满载时偶发 `SIGTERM(143)`；`--timeout` 放宽后稳定通过。这是环境性 flake，非本 PR 引入。

## 证据分级

- **实测到的**：探针是否真发出（断言 `POST …/messages` 调用计数）、self-target 路径**零网络请求**（断言 `mock.requests.length===0`）、退出码、frame 结构、7 处变异逐一变红——均由 `bun test` 跑出。
- **读代码推断的**：`worker/src/do.ts:1516` 把 `adapter_kind` 硬编码成 `'webhook'`，因 `recordWakeDelivery` 只在 webhook 服务端投递时调用；serve/watch 无投递 ledger，其 resume 只能靠 `findLinkedAck` 从频道历史观测——与本 PR 的 CLI 侧判定一致，**未改 worker**。

## 遗留 / 不确定

- **self-target 检测依赖本地缓存身份**（`config.identity.name`）。对跑过 `serve`/`whoami`/`send` 的 agent（即 #194 复现场景）该字段已写入，命中「零网络秒失败」快路径；若身份**未缓存**，则优雅降级回旧路径（发探针 → timeout）——不会误判成功，但那一次仍会发探针。刻意没引入 `/api/me` 兜底，以严守 #194「发探针前、零网络」的诉求，并避免误伤既有 contract 测试（其 `@agent` 目标 + 默认 `/api/me` 返回 `"agent"` 会被错判为 self）。
- **陈旧 serve/watch 仍在发送前拒绝**，未纳入本 PR 的证伪改造——遵从 #181 正文把该分支归入 #97，且有现存测试 `m3.test.ts:1985` 锚定。若后续要让陈旧适配器也可证伪，应在 #97 下推进。
- **worker 侧未改**：`wake_delivery_ledger` 仍只审计 webhook 投递，符合现状；本 PR 不触碰。
