### PR TITLE
fix(dist): 原子替换已安装的 party 二进制 (#205)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -154,7 +154,15 @@ main() {
   base="${MIRROR%/}/v${VERSION}"
   asset="${BIN_NAME}-${TARGET}.tar.gz"
   tmp="$(mktemp -d)"
-  trap 'rm -rf "$tmp"' EXIT
+  tmp_out=""
+  cleanup() {
+    [ -z "$tmp_out" ] || rm -f "$tmp_out" || true
+    rm -rf "$tmp" || true
+  }
+  trap cleanup EXIT
+  trap 'exit 129' HUP
+  trap 'exit 130' INT
+  trap 'exit 143' TERM
 
   fetch "${base}/${asset}"          "${tmp}/${asset}"
   fetch "${base}/${asset}.sha256"   "${tmp}/${asset}.sha256"
@@ -195,8 +203,11 @@ main() {
   [ -f "${tmp}/${BIN_NAME}" ] || die "archive missing ${BIN_NAME} binary"
 
   mkdir -p "$INSTALL_DIR"
-  install -m 0755 "${tmp}/${BIN_NAME}" "${INSTALL_DIR}/${BIN_NAME}" 2>/dev/null \
-    || { cp "${tmp}/${BIN_NAME}" "${INSTALL_DIR}/${BIN_NAME}" && chmod +x "${INSTALL_DIR}/${BIN_NAME}"; }
+  tmp_out="$(mktemp "${INSTALL_DIR}/.${BIN_NAME}.XXXXXX")"
+  install -m 0755 "${tmp}/${BIN_NAME}" "$tmp_out" 2>/dev/null \
+    || { cp "${tmp}/${BIN_NAME}" "$tmp_out" && chmod 0755 "$tmp_out"; }
+  mv -f "$tmp_out" "${INSTALL_DIR}/${BIN_NAME}"
+  tmp_out=""
 
   log "installed ${INSTALL_DIR}/${BIN_NAME} (v${VERSION})"
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "license": "BUSL-1.1",
   "private": true,
   "scripts": {
-    "check": "bun test scripts/release-version.test.ts scripts/desktop-update-manifest.test.ts scripts/desktop-release-workflow.test.ts scripts/desktop-pairing-smoke.test.ts && bunx tsc --project scripts/tsconfig.json && cd cli && bun test && bunx tsc --noEmit && cd ../shared && bunx tsc --noEmit && cd ../web && bun test && bunx tsc --noEmit && bunx vite build && cd ../worker && bun run verify:test-runtime && bunx vitest run && bunx tsc --noEmit",
+    "check": "sh -n install.sh && bun test scripts/release-version.test.ts scripts/desktop-update-manifest.test.ts scripts/desktop-release-workflow.test.ts scripts/desktop-pairing-smoke.test.ts scripts/install.test.ts && bunx tsc --project scripts/tsconfig.json && cd cli && bun test && bunx tsc --noEmit && cd ../shared && bunx tsc --noEmit && cd ../web && bun test && bunx tsc --noEmit && bunx vite build && cd ../worker && bun run verify:test-runtime && bunx vitest run && bunx tsc --noEmit",
     "desktop:dev": "cd desktop && bun run dev",
     "desktop:build": "cd desktop && bun run build",
     "desktop:build:prod": "cd desktop && bun run build:prod",

--- a/scripts/install.test.ts
+++ b/scripts/install.test.ts
@@ -1,0 +1,201 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, dirname, join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const repoRoot = resolve(import.meta.dir, "..");
+const installScript = join(repoRoot, "install.sh");
+const cleanup: string[] = [];
+
+type Fixture = ReturnType<typeof makeFixture>;
+
+function commandPath(name: string): string {
+  const result = spawnSync("/bin/sh", ["-c", `command -v ${name}`], {
+    encoding: "utf8",
+    env: process.env,
+  });
+  if (result.status !== 0) throw new Error(`missing test dependency: ${name}`);
+  return result.stdout.trim();
+}
+
+function writeShim(path: string, body: string): void {
+  writeFileSync(path, `#!/bin/sh\n${body}\n`);
+  chmodSync(path, 0o755);
+}
+
+function makeFixture() {
+  const root = mkdtempSync(join(tmpdir(), "agentparty-install-"));
+  cleanup.push(root);
+
+  const installDir = join(root, "bin");
+  const mirror = join(root, "mirror");
+  const payload = join(root, "payload");
+  const shims = join(root, "shims");
+  const releaseDir = join(mirror, "v0.2.87");
+  const trace = join(root, "trace.tsv");
+  mkdirSync(installDir, { recursive: true });
+  mkdirSync(payload, { recursive: true });
+  mkdirSync(shims, { recursive: true });
+  mkdirSync(releaseDir, { recursive: true });
+  writeFileSync(trace, "");
+
+  const target = join(installDir, "party");
+  writeFileSync(target, "old party\n");
+  chmodSync(target, 0o755);
+
+  const payloadBinary = join(payload, "party");
+  writeFileSync(payloadBinary, "#!/bin/sh\nprintf 'new party\\n'\n");
+  chmodSync(payloadBinary, 0o644);
+
+  const platform = process.platform === "darwin" ? "darwin" : "linux";
+  const architecture = process.arch === "arm64" ? "arm64" : "x64";
+  const asset = `party-${platform}-${architecture}.tar.gz`;
+  const archive = join(releaseDir, asset);
+  const tar = spawnSync(commandPath("tar"), ["-czf", archive, "-C", payload, "party"], {
+    encoding: "utf8",
+  });
+  if (tar.status !== 0) throw new Error(`failed to build installer fixture: ${tar.stderr}`);
+  const digest = createHash("sha256").update(readFileSync(archive)).digest("hex");
+  writeFileSync(`${archive}.sha256`, `${digest}  ${asset}\n`);
+
+  const realInstall = commandPath("install");
+  const realMv = commandPath("mv");
+  writeShim(
+    join(shims, "install"),
+    `printf 'install' >> "$INSTALLER_TRACE"
+for arg in "$@"; do printf '\\t%s' "$arg" >> "$INSTALLER_TRACE"; done
+printf '\\n' >> "$INSTALLER_TRACE"
+[ "\${INSTALLER_INSTALL_MODE:-pass}" = fail ] && exit 1
+exec ${realInstall} "$@"`,
+  );
+  writeShim(
+    join(shims, "mv"),
+    `printf 'mv' >> "$INSTALLER_TRACE"
+for arg in "$@"; do printf '\\t%s' "$arg" >> "$INSTALLER_TRACE"; done
+printf '\\n' >> "$INSTALLER_TRACE"
+case "\${INSTALLER_MV_MODE:-pass}" in
+  fail) exit 42 ;;
+  signal) kill -TERM "$PPID"; exit 0 ;;
+esac
+exec ${realMv} "$@"`,
+  );
+
+  return { root, installDir, mirror, shims, target, trace };
+}
+
+function runInstaller(fixture: Fixture, extraEnv: Record<string, string> = {}) {
+  return spawnSync("/bin/sh", [installScript], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${fixture.shims}:${process.env.PATH ?? ""}`,
+      AGENTPARTY_INSTALL_DIR: fixture.installDir,
+      AGENTPARTY_MIRROR: `file://${fixture.mirror}`,
+      AGENTPARTY_VERSION: "0.2.87",
+      INSTALLER_TRACE: fixture.trace,
+      ...extraEnv,
+    },
+  });
+}
+
+function traceEvents(fixture: Fixture): string[][] {
+  return readFileSync(fixture.trace, "utf8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => line.split("\t"));
+}
+
+function installedFiles(fixture: Fixture): string[] {
+  return readdirSync(fixture.installDir).sort();
+}
+
+afterEach(() => {
+  while (cleanup.length > 0) rmSync(cleanup.pop()!, { force: true, recursive: true });
+});
+
+describe("install.sh atomic replacement", () => {
+  test("stages each binary at a unique 0755 path beside the final target", () => {
+    const fixture = makeFixture();
+
+    const first = runInstaller(fixture);
+    const second = runInstaller(fixture);
+
+    expect(first.status).toBe(0);
+    expect(second.status).toBe(0);
+    const installEvents = traceEvents(fixture).filter(([command]) => command === "install");
+    const destinations = installEvents.map((event) => event.at(-1)!);
+    for (const event of installEvents) {
+      expect(event).toContain("-m");
+      expect(event).toContain("0755");
+    }
+    expect(destinations).toHaveLength(2);
+    expect(new Set(destinations).size).toBe(2);
+    for (const staged of destinations) {
+      expect(staged).not.toBe(fixture.target);
+      expect(dirname(staged)).toBe(fixture.installDir);
+      expect(basename(staged)).toMatch(/^\.party\.[A-Za-z0-9]+$/);
+    }
+    expect(statSync(fixture.target).mode & 0o777).toBe(0o755);
+  });
+
+  test("atomically renames the staged binary over the target and leaves no temporary file", () => {
+    const fixture = makeFixture();
+
+    const result = runInstaller(fixture);
+
+    expect(result.status).toBe(0);
+    const events = traceEvents(fixture);
+    const staged = events.find(([command]) => command === "install")!.at(-1)!;
+    expect(events.find(([command]) => command === "mv")).toEqual(["mv", "-f", staged, fixture.target]);
+    expect(readFileSync(fixture.target, "utf8")).toContain("new party");
+    expect(installedFiles(fixture)).toEqual(["party"]);
+  });
+
+  test("keeps the copy fallback while still replacing the target atomically", () => {
+    const fixture = makeFixture();
+
+    const result = runInstaller(fixture, { INSTALLER_INSTALL_MODE: "fail" });
+
+    expect(result.status).toBe(0);
+    const move = traceEvents(fixture).find(([command]) => command === "mv");
+    expect(move?.[1]).toBe("-f");
+    expect(dirname(move![2])).toBe(fixture.installDir);
+    expect(move?.[3]).toBe(fixture.target);
+    expect(readFileSync(fixture.target, "utf8")).toContain("new party");
+    expect(statSync(fixture.target).mode & 0o777).toBe(0o755);
+    expect(installedFiles(fixture)).toEqual(["party"]);
+  });
+
+  test("keeps the old target and cleans the staged file when the atomic rename fails", () => {
+    const fixture = makeFixture();
+
+    const result = runInstaller(fixture, { INSTALLER_MV_MODE: "fail" });
+
+    expect(result.status).toBe(42);
+    expect(readFileSync(fixture.target, "utf8")).toBe("old party\n");
+    expect(installedFiles(fixture)).toEqual(["party"]);
+  });
+
+  test("cleans the staged file when the installer receives TERM during replacement", () => {
+    const fixture = makeFixture();
+
+    const result = runInstaller(fixture, { INSTALLER_MV_MODE: "signal" });
+
+    expect(result.status).toBe(143);
+    expect(readFileSync(fixture.target, "utf8")).toBe("old party\n");
+    expect(installedFiles(fixture)).toEqual(["party"]);
+  });
+});


### PR DESCRIPTION
## 根因

`install.sh` 过去用 `install` / `cp` 直接覆盖正在运行的 Bun 单文件二进制。两者都会截断目标 inode；仍在 page-in 旧镜像的 `party serve` 可能因此 SIGBUS/SIGKILL。

## 修复

- 在安装目标同目录创建唯一 `.party.XXXXXX` 临时文件。
- 先把新二进制写入并设为 0755，再用同文件系统 `mv -f` 原子替换目录项。
- HUP/INT/TERM、复制失败和 rename 失败都清理 staging 文件。
- 旧目标在 rename 成功前保持不变。
- 新增 5 个真实 shell fixture 测试，并纳入根 `bun run check`。

## 验证

- TDD RED：旧实现 0 pass / 5 fail（直接写目标、没有 mv、故障/TERM 路径不成立）
- GREEN：`bun test scripts/install.test.ts`，5 pass / 0 fail
- `bunx tsc --project scripts/tsconfig.json`
- `sh -n install.sh`
- `shellcheck install.sh`
- `git diff --check`

本地完整 workspace check 的 scripts 45、CLI 384、Web tests/build 已通过；worker 阶段因共享工作区另一 agent 同时热改 `worker/src/index.ts`，workerd invalidation 后停止。PR 的隔离 CI 是最终全量门禁。

Addresses #205.
