### PR TITLE
fix(web): mention 改为 marked 解析后美化，避免代码块裸 HTML 与 URL 截断 (#131)

### DIFF
--- a/web/src/components/Markdown.tsx
+++ b/web/src/components/Markdown.tsx
@@ -1,8 +1,9 @@
 import { useMemo } from "react";
+import type { IdentityDisplayMap } from "../lib/identityDisplay";
 import { renderMarkdown } from "../lib/markdown";
 
-export function Markdown({ source }: { source: string }) {
-  // renderMarkdown 内部已过 DOMPurify 白名单
-  const html = useMemo(() => renderMarkdown(source), [source]);
+export function Markdown({ source, identities }: { source: string; identities?: IdentityDisplayMap }) {
+  // renderMarkdown 内部已过 DOMPurify 白名单；mention 在 marked 解析后美化（#131）
+  const html = useMemo(() => renderMarkdown(source, identities), [source, identities]);
   return <div className="msg-body" dangerouslySetInnerHTML={{ __html: html }} />;
 }

--- a/web/src/components/MessageCard.tsx
+++ b/web/src/components/MessageCard.tsx
@@ -5,7 +5,6 @@ import { useEffect, useRef, useState } from "react";
 import type { CSSProperties } from "react";
 import { agentHue } from "../lib/agentColor";
 import { displayForIdentity, resolveSenderLabel, type IdentityDisplayMap } from "../lib/identityDisplay";
-import { replaceMentionLabels } from "../lib/mentionMarkup";
 import { readStateFor } from "../lib/readList";
 import { summarizeReplyPreview } from "../lib/replyPreview";
 import { useT } from "../i18n/useT";
@@ -463,7 +462,7 @@ export function MessageCard({
       ) : msg.retracted ? (
         <p className="msg-retracted">{t("MessageCard.retracted")}</p>
       ) : (
-        <Markdown source={replaceMentionLabels(msg.body, identityDisplay)} />
+        <Markdown source={msg.body} identities={identityDisplay} />
       )}
       {!editing && actionError !== null && <p className="banner banner--red msg-action-error">{actionError}</p>}
     </article>

--- a/web/src/lib/markdown.ts
+++ b/web/src/lib/markdown.ts
@@ -21,7 +21,9 @@ import langSql from "highlight.js/lib/languages/sql";
 import langTypescript from "highlight.js/lib/languages/typescript";
 import langXml from "highlight.js/lib/languages/xml";
 import langYaml from "highlight.js/lib/languages/yaml";
-import { marked } from "marked";
+import { Marked } from "marked";
+import type { IdentityDisplayMap } from "./identityDisplay";
+import { mentionExtension } from "./mentionMarkup";
 
 hljs.registerLanguage("bash", langBash);
 hljs.registerLanguage("c", langC);
@@ -41,17 +43,27 @@ hljs.registerLanguage("typescript", langTypescript);
 hljs.registerLanguage("xml", langXml);
 hljs.registerLanguage("yaml", langYaml);
 
-marked.use({
-  renderer: {
-    code({ text, lang }) {
-      const language = lang && hljs.getLanguage(lang) ? lang : undefined;
-      const html = language
-        ? hljs.highlight(text, { language }).value
-        : hljs.highlightAuto(text).value;
-      return `<pre><code class="hljs">${html}</code></pre>`;
+// 每次渲染新建一个 Marked 实例：代码块高亮 renderer 恒定，mention 扩展按本条消息的
+// identities 闭包注入。mention 在解析后的 token 流上美化，代码块/行内代码/自动链接 URL
+// 天然被排除（见 mentionMarkup.ts 与 #131），不再往原文里塞裸 HTML。
+function createMarked(identities: IdentityDisplayMap | undefined): Marked {
+  const instance = new Marked();
+  instance.use({
+    renderer: {
+      code({ text, lang }) {
+        const language = lang && hljs.getLanguage(lang) ? lang : undefined;
+        const html = language
+          ? hljs.highlight(text, { language }).value
+          : hljs.highlightAuto(text).value;
+        return `<pre><code class="hljs">${html}</code></pre>`;
+      },
     },
-  },
-});
+  });
+  if (identities !== undefined) {
+    instance.use({ extensions: [mentionExtension(identities)] });
+  }
+  return instance;
+}
 
 // span/class 是 hljs 高亮产物的载体，必须放行。
 // img 不放行：远程 src 会让每个看频道的人自动请求第三方主机（IP/时段追踪 beacon），
@@ -69,24 +81,37 @@ const ALLOWED_ATTR = ["href", "title", "class", "start"];
 // class 只留 hljs 产物和受控 mention 产物，防止消息正文借用应用自身样式伪装系统 UI。
 const SAFE_CLASS_RE = /^(?:hljs(?:-[\w-]+)?|ap-mention)$/;
 
-DOMPurify.addHook("afterSanitizeAttributes", (node) => {
-  // 外链新窗口 + noopener（净化后统一补，用户写不进 target/rel）
-  if (node.tagName === "A" && node.hasAttribute("href")) {
-    node.setAttribute("target", "_blank");
-    node.setAttribute("rel", "noopener noreferrer");
-  }
-  if (node.hasAttribute("class")) {
-    const kept = (node.getAttribute("class") ?? "")
-      .split(/\s+/)
-      .filter((c) => SAFE_CLASS_RE.test(c))
-      .join(" ");
-    if (kept === "") node.removeAttribute("class");
-    else node.setAttribute("class", kept);
-  }
-});
+// addHook 只在有 DOM 时可用；无 DOM 环境（bun 测试、SSR）里 DOMPurify 是未绑定 window 的
+// 工厂，addHook/sanitize 均为 undefined。此处守卫让 markdown.ts 在无 DOM 下也能被 import，
+// 从而单测能覆盖 markdownToHtmlUnsafe 那一步——净化本身只在浏览器里真正执行，行为不变。
+if (typeof DOMPurify.addHook === "function") {
+  DOMPurify.addHook("afterSanitizeAttributes", (node) => {
+    // 外链新窗口 + noopener（净化后统一补，用户写不进 target/rel）
+    if (node.tagName === "A" && node.hasAttribute("href")) {
+      node.setAttribute("target", "_blank");
+      node.setAttribute("rel", "noopener noreferrer");
+    }
+    if (node.hasAttribute("class")) {
+      const kept = (node.getAttribute("class") ?? "")
+        .split(/\s+/)
+        .filter((c) => SAFE_CLASS_RE.test(c))
+        .join(" ");
+      if (kept === "") node.removeAttribute("class");
+      else node.setAttribute("class", kept);
+    }
+  });
+}
 
-export function renderMarkdown(md: string): string {
-  const raw = marked.parse(md, { async: false });
+// marked 解析 + mention 美化（DOMPurify 净化前的产物）。单独导出是因为 DOMPurify 依赖
+// DOM，在 bun 测试环境跑不起来（addHook 未定义）；这一步是纯 marked，可被单测覆盖，用来
+// 钉住「mention 在解析后美化、绝不在解析前注入」这条 #131 接线。DOMPurify 只做白名单，
+// 不改动 ap-mention span 的结构，所以这一步的输出即最终 HTML 的语义。
+export function markdownToHtmlUnsafe(md: string, identities?: IdentityDisplayMap): string {
+  return createMarked(identities).parse(md, { async: false });
+}
+
+export function renderMarkdown(md: string, identities?: IdentityDisplayMap): string {
+  const raw = markdownToHtmlUnsafe(md, identities);
   return DOMPurify.sanitize(raw, {
     ALLOWED_TAGS,
     ALLOWED_ATTR,

--- a/web/src/lib/mentionMarkup.test.ts
+++ b/web/src/lib/mentionMarkup.test.ts
@@ -1,23 +1,138 @@
 import { describe, expect, it } from "bun:test";
-import { replaceMentionLabels } from "./mentionMarkup";
+import { Marked } from "marked";
+import type { IdentityDisplayMap } from "./identityDisplay";
+import { markdownToHtmlUnsafe } from "./markdown";
+import { mentionExtension } from "./mentionMarkup";
 
-describe("replaceMentionLabels", () => {
-  it("renders readable email mentions as controlled spans instead of bare autolinks", () => {
-    const raw = "61ec302c-6c31-4bca-a1df-88152372f6d9";
-    expect(
-      replaceMentionLabels(`@${raw} hello`, {
-        [raw]: { display: "thejacks@163.com", kind: "human", account: "thejacks@163.com" },
-      }),
-    ).toBe(
-      '<span class="ap-mention" title="@61ec302c-6c31-4bca-a1df-88152372f6d9">@thejacks&#64;163.com</span> hello',
+const IDS: IdentityDisplayMap = {
+  alice: { display: "Alice", kind: "agent" },
+  "61ec302c-6c31-4bca-a1df-88152372f6d9": {
+    display: "thejacks@163.com",
+    kind: "human",
+    account: "thejacks@163.com",
+  },
+  weird: { display: 'a<&"b', kind: "human" },
+  self: { display: "self", kind: "agent" },
+};
+
+// 走真实生产管线（markdown.ts 的 marked + hljs + mention 扩展，DOMPurify 净化前的产物；
+// DOMPurify 只做白名单不改 ap-mention span 结构，且在 bun 无 DOM 跑不了）。用它做集成断言：
+// 若有人把 mention 改回「解析前注入」，代码块/URL 用例会立刻变红。
+const R = (md: string) => markdownToHtmlUnsafe(md, IDS).trim();
+
+// 直接驱动扩展本身、并监听 renderer——用于「断言过程」：mention 注入到底调用了没、拿到了什么。
+function spy(identities: IdentityDisplayMap) {
+  const calls: Array<{ name: string; display: string }> = [];
+  const ext = mentionExtension(identities);
+  const inner = (ext as { renderer: (tk: unknown) => string }).renderer;
+  const marked = new Marked();
+  marked.use({
+    extensions: [
+      {
+        ...ext,
+        renderer(token: unknown) {
+          const t = token as { name: string; display: string };
+          calls.push({ name: t.name, display: t.display });
+          return inner.call(this, token);
+        },
+      },
+    ],
+  });
+  return { calls, render: (md: string) => marked.parse(md, { async: false }).trim() };
+}
+
+describe("mention 美化：真实管线集成（#131）", () => {
+  it("prose 里的 @name 变成受控 span", () => {
+    expect(R("hi @alice there")).toBe(
+      '<p>hi <span class="ap-mention" title="@alice">@Alice</span> there</p>',
     );
   });
 
-  it("escapes mapped mention labels before injecting markdown html", () => {
-    expect(
-      replaceMentionLabels("@raw hello", {
-        raw: { display: 'a<&"b', kind: "human" },
-      }),
-    ).toBe('<span class="ap-mention" title="@raw">@a&lt;&amp;"b</span> hello');
+  it("代码块（fenced）里的 @name 保持字面，绝不出现 ap-mention span 或泄漏的裸 HTML", () => {
+    const out = R("```\n@alice inside code\n```");
+    expect(out).not.toContain("ap-mention"); // 既挡真 span，也挡旧 bug 里被转义的 span 文本
+    expect(out).toContain("@alice");
+    expect(out).toContain("inside code");
+  });
+
+  it("行内代码里的 @name 保持字面", () => {
+    expect(R("use `@alice` please")).toBe("<p>use <code>@alice</code> please</p>");
+  });
+
+  it("含 @ 的 URL 不被截断（issue 原例 a@b）", () => {
+    expect(R("see https://x.com/a@b/c done")).toBe(
+      '<p>see <a href="https://x.com/a@b/c">https://x.com/a@b/c</a> done</p>',
+    );
+  });
+
+  it("形如 /@alice/ 的 URL（旧代码在此截断）保持完整、href 内无 span", () => {
+    const out = R("repo https://github.com/@alice/repo end");
+    expect(out).toBe(
+      '<p>repo <a href="https://github.com/@alice/repo">https://github.com/@alice/repo</a> end</p>',
+    );
+    expect(out).toContain("https://github.com/@alice/repo");
+    expect(out).not.toContain("ap-mention");
+  });
+
+  it("词中间的 @（如邮箱片段 foo@alice）不当作 mention", () => {
+    // alice 是已知身份；靠「@ 前是词字符」这条边界规则挡住，而非靠 display===name
+    expect(R("email foo@alice please")).toBe("<p>email foo@alice please</p>");
+  });
+
+  it("可读邮箱 display 作为 span 渲染，@ 原样保留", () => {
+    const raw = "61ec302c-6c31-4bca-a1df-88152372f6d9";
+    expect(R(`@${raw} hello`)).toBe(
+      `<p><span class="ap-mention" title="@${raw}">@thejacks@163.com</span> hello</p>`,
+    );
+  });
+
+  it("注入前转义 display 里的 HTML 特殊字符", () => {
+    expect(R("@weird hi")).toBe(
+      '<p><span class="ap-mention" title="@weird">@a&lt;&amp;"b</span> hi</p>',
+    );
+  });
+
+  it("未知身份的 @name 保持字面", () => {
+    expect(R("hi @nobody there")).toBe("<p>hi @nobody there</p>");
+  });
+
+  it("display 与 name 相同时不注入", () => {
+    expect(R("hi @self there")).toBe("<p>hi @self there</p>");
+  });
+
+  it("句首、以及 /、* 等真实边界后的 @name 都识别为 mention", () => {
+    expect(R("@alice")).toBe('<p><span class="ap-mention" title="@alice">@Alice</span></p>');
+    expect(R("path /@alice/x")).toContain(
+      '/<span class="ap-mention" title="@alice">@Alice</span>/x',
+    );
+    expect(R("**b**@alice")).toBe(
+      '<p><strong>b</strong><span class="ap-mention" title="@alice">@Alice</span></p>',
+    );
+  });
+});
+
+describe("mention 美化：过程断言（renderer 是否被调用、入参是什么）", () => {
+  it("prose：mention renderer 恰好被调用一次，且拿到正确 name/display", () => {
+    const s = spy(IDS);
+    s.render("hi @alice there");
+    expect(s.calls).toEqual([{ name: "alice", display: "Alice" }]);
+  });
+
+  it("代码块：mention renderer 一次都不被调用（结构性排除，而非事后擦除）", () => {
+    const s = spy(IDS);
+    s.render("```\n@alice inside\n```");
+    expect(s.calls).toEqual([]);
+  });
+
+  it("行内代码：mention renderer 一次都不被调用", () => {
+    const s = spy(IDS);
+    s.render("use `@alice` here");
+    expect(s.calls).toEqual([]);
+  });
+
+  it("含 @ 的 URL：mention renderer 一次都不被调用", () => {
+    const s = spy(IDS);
+    s.render("go https://github.com/@alice/repo done");
+    expect(s.calls).toEqual([]);
   });
 });

--- a/web/src/lib/mentionMarkup.ts
+++ b/web/src/lib/mentionMarkup.ts
@@ -1,6 +1,11 @@
+import type { Tokens, TokenizerAndRendererExtension } from "marked";
 import type { IdentityDisplayMap } from "./identityDisplay";
 
-const BODY_MENTION_RE = /(^|[^a-zA-Z0-9._@-])@([a-zA-Z0-9][a-zA-Z0-9._-]*)/g;
+// mention 名字允许的字符：字母数字开头，后接 字母数字/._- 。
+const MENTION_RE = /^@([a-zA-Z0-9][a-zA-Z0-9._-]*)/;
+// mention 前必须是「边界」：非(字母数字/._@-)。用来排除 foo@bar 这类邮箱片段——
+// 只有像句首、空白、`/`、`*` 这种真实边界后的 @name 才算 mention。
+const NAME_CHAR_RE = /[a-zA-Z0-9._@-]/;
 
 function escapeHtmlAttr(value: string): string {
   return value
@@ -13,17 +18,59 @@ function escapeHtmlAttr(value: string): string {
 function escapeHtmlText(value: string): string {
   return value
     .replaceAll("&", "&amp;")
-    .replaceAll("@", "&#64;")
     .replaceAll("<", "&lt;")
     .replaceAll(">", "&gt;");
 }
 
-export function replaceMentionLabels(source: string, identities: IdentityDisplayMap | undefined): string {
-  if (identities === undefined) return source;
-  return source.replace(BODY_MENTION_RE, (full, prefix: string, name: string) => {
-    const display = identities[name]?.display;
-    return display === undefined || display === name
-      ? full
-      : `${prefix}<span class="ap-mention" title="@${escapeHtmlAttr(name)}">@${escapeHtmlText(display)}</span>`;
-  });
+interface MentionToken extends Tokens.Generic {
+  type: "apMention";
+  raw: string;
+  name: string;
+  display: string;
+}
+
+/**
+ * marked 内联扩展：在 marked **解析之后** 的 token 流上美化 @mention，而不是在解析前
+ * 往原文里塞裸 HTML。这样代码块（code）、行内代码（codespan）、以及被 marked 自动
+ * 链接的 URL 天然被排除在外——因为这些内容根本不会进入内联 tokenizer，或已被更早的
+ * tokenizer 整段吃掉。见 #131：旧的「解析前注入 span」会让代码块里的 @name 渲染成裸
+ * HTML，还会把含 @ 的 URL 截断。
+ *
+ * 渲染产物是 <span class="ap-mention">，class 已在 markdown.ts 的 DOMPurify 白名单里。
+ */
+export function mentionExtension(
+  identities: IdentityDisplayMap,
+): TokenizerAndRendererExtension {
+  return {
+    name: "apMention",
+    level: "inline",
+    start(src: string) {
+      const i = src.indexOf("@");
+      return i < 0 ? undefined : i;
+    },
+    tokenizer(src, tokens) {
+      // 边界校验：看紧挨在 @ 前面那个已产出 token 的最后一个字符。
+      // 若它是 name 允许字符（字母数字/._@-），说明这个 @ 处在词中间（如 foo@bar），
+      // 不当作 mention——与旧正则的前置字符类保持一致。
+      const prev = tokens[tokens.length - 1];
+      const prevRaw = typeof prev?.raw === "string" ? prev.raw : "";
+      const prevChar = prevRaw.slice(-1);
+      if (prevChar !== "" && NAME_CHAR_RE.test(prevChar)) return undefined;
+
+      const match = MENTION_RE.exec(src);
+      if (match === null) return undefined;
+      const name = match[1];
+      if (name === undefined) return undefined;
+      const display = identities[name]?.display;
+      // 没有映射、或映射回自身，就不接管这个 token：让 @name 以字面文本渲染。
+      if (display === undefined || display === name) return undefined;
+
+      const token: MentionToken = { type: "apMention", raw: match[0], name, display };
+      return token;
+    },
+    renderer(token) {
+      const { name, display } = token as MentionToken;
+      return `<span class="ap-mention" title="@${escapeHtmlAttr(name)}">@${escapeHtmlText(display)}</span>`;
+    },
+  };
 }


### PR DESCRIPTION
频道身份：leo-claude-worker-131

Closes #131

## 问题（已实测复现）

旧实现 `mentionMarkup.ts` 的 `replaceMentionLabels` 在 **marked 解析之前** 就把 `@name`
替换成裸 `<span>` 注入原文（`MessageCard.tsx` 先调它再交给 `renderMarkdown`）。实测把
同一条 body 过一遍「replaceMentionLabels → marked」管线，结果：

| 输入 | 旧输出（bug） |
|---|---|
| 代码块 ` ```\n@alice in code\n``` ` | `<pre><code>&lt;span class=&quot;ap-mention&quot; …&gt;@Alice&lt;/span&gt; in code</code></pre>`（裸 HTML 字面泄漏） |
| 行内代码 `` `@alice` `` | `<code>&lt;span …&gt;@Alice&lt;/span&gt;</code>` |
| URL `https://github.com/@alice/repo` | `<a href="https://github.com/">https://github.com/</a><span …>@Alice</span>/repo`（**href 在 @ 处截断**） |
| prose `@alice` | 正常 span（唯一对的情况） |

## 修法

按 issue 与设计指引，改为 **marked 内联扩展**（`mentionExtension`），在解析后的 token 流上
美化 mention。代码块（`code`）、行内代码（`codespan`）、被 marked 自动链接的 URL 天然被
**结构性排除**——它们根本不进内联 tokenizer，或已被更早的 tokenizer 整段吃掉，不再靠正则
去绕开。保留全部原语义：词边界规则（`foo@bar` 不算 mention，靠检查前一个 token 末字符）、
`display===name` 与未知身份不注入、HTML 转义。

- `mentionMarkup.ts`：`replaceMentionLabels`（解析前注入）→ `mentionExtension`（解析后 token）
- `markdown.ts`：`renderMarkdown(md, identities?)` 注册扩展；导出 `markdownToHtmlUnsafe`
  （净化前的纯 marked 步骤）供无 DOM 的 bun 单测覆盖真实管线；`DOMPurify.addHook` 加无 DOM
  守卫，让模块在无 DOM 下也能被 import
- `Markdown.tsx` / `MessageCard.tsx`：把 `identities` 透传给渲染，不再预注入 HTML

## 变异测试（硬门禁）

基线 15 例全绿。逐个植入变异后跑 `bun test src/lib/mentionMarkup.test.ts`：

| # | 变异（把修复/护栏破坏掉） | 结果 | 变红的用例 |
|---|---|---|---|
| M1 | 删除词边界护栏（`foo@bar` 判定） | 14 pass / **1 fail** | 「词中间的 @（foo@alice）不当作 mention」 |
| M2 | `escapeHtmlText` 改为原样返回（去转义） | 14 pass / **1 fail** | 「注入前转义 display 里的 HTML 特殊字符」 |
| M3 | 删除 `display===name` 护栏 | 14 pass / **1 fail** | 「display 与 name 相同时不注入」 |
| M4 | 删除 `display===undefined` 护栏（注入未知身份） | 14 pass / **1 fail** | 「未知身份的 @name 保持字面」 |
| M5 | tokenizer 恒返回 undefined（扩展整体失效） | 10 pass / **5 fail** | prose span、邮箱 display、转义、边界识别、**renderer 过程断言** |
| M6 | **复原 #131 本体**：改回「解析前注入 HTML」 | 10 pass / **5 fail** | **代码块**、**行内代码**、**URL `/@alice/` 不截断**、邮箱 display、转义 |

M6 是关键项：它把真正的 bug 装回去，恰好点红「代码块 / 行内代码 / URL」三条用例——
证明这些用例守的是真实回归，而不是「mention 关掉后碰巧变绿」（M5 那种平凡绿由 prose /
过程断言另行钉住）。代码块用例既 `not.toContain("ap-mention")`（挡真 span）又挡被转义的
`ap-mention` 文本（挡 M6 的裸 HTML 泄漏）；并用 renderer spy 断言「代码块里 mention renderer
一次都没被调用」——断言过程而非只断言最终字符串。

## 等价实现检查（断言语义而非形状）

把 `mentionExtension` 换成语义等价、结构不同的实现（正则 `[\w.-]`、`str.match`/`str.search`、
`tokens.at(-1)`、`==null`、扩频转义用 `[...v].map`）后跑同一套测试：**15 pass / 0 fail**。
测试钉的是语义，不是实现细节。

## 验证

- `web`：`bun test` 307 pass（含本次 15 例新测）；`bunx tsc --noEmit` 干净；`bunx vite build` 通过
- `cli`：378 pass；`tsc` 干净。`shared`：`tsc` 干净
- `scripts/release-version.test.ts`：默认 5000ms 下在本机（多 agent 并发、重负载）会因子进程
  spawn 超时误红；`--timeout 30000` 下 18 pass。该套件未被本 PR 改动，属环境 flake
- `worker`：本 PR **零改动** worker（仅 `web/`）；`verify:test-runtime` OK。worker vitest 全量
  跑出 7 failed / 288 passed，**全部是 `Test timed out in 20000ms` 超时**，且整轮耗时 824s
  （≈13 分钟，正常约 1–2 分钟）——因为同机另一 agent 的 worker vitest 在并发抢占
  miniflare/workerd。把其中确认失败的 `test/workflow-guard.spec.ts` 单独隔离重跑：**2 passed，
  139ms**。即这些失败是并发重负载下的超时 flake（已知 #185 signature），与本改动无关
