### PR TITLE
fix(cli): whoami 打印生效 server，标注账号会话异 server（#140）

### DIFF
--- a/cli/src/commands/whoami.ts
+++ b/cli/src/commands/whoami.ts
@@ -84,6 +84,10 @@ export async function run(argv: string[]): Promise<number> {
             channel: boundChannel,
           }
         : null;
+    // 生效 server（命令实际落点）vs 账号会话自带的 server：一台机器上人类账号(server A)与
+    // agent runtime token(server B)并存是常态，二者不同则显式标注，别让 agent 拿错 server 汇报/拼链接（#140）。
+    const accountServer = auth.account.present ? auth.account.server ?? null : null;
+    const accountServerDiffers = accountServer !== null && accountServer !== auth.server;
     if (json) {
       // 原样吐 /api/me（name/email/kind/role/owner…），供工具判身份/权限，免解析人类串
       console.log(JSON.stringify(jsonFrame({
@@ -91,6 +95,9 @@ export async function run(argv: string[]): Promise<number> {
         ts: nowTs(),
         logged_in: true,
         server: auth.server,
+        // 显式区分生效落点与账号会话 server，agent 免解析人话即可判定「命令打到哪」（#140）
+        effective_server: auth.server,
+        account_server: accountServer,
         ...me,
         auth_source: auth.auth_source,
         runtime: {
@@ -107,10 +114,11 @@ export async function run(argv: string[]): Promise<number> {
       })));
     } else {
       const who = me.email ?? me.name;
-      console.log(`runtime: logged in as ${who} (${me.kind}/${me.role})`);
+      console.log(`runtime: logged in as ${who} (${me.kind}/${me.role}) server=${auth.server}`);
       if (me.owner) console.log(`  owner: ${me.owner}`);
       console.log(`  scope: ${me.channel_scope ?? "none (all channels)"}`);
-      console.log(`account: ${auth.account.present ? `${auth.account.email ?? auth.account.sub ?? "present"} present server=${auth.account.server}` : `absent path=${auth.account.path}`}`);
+      const accountDiffNote = accountServerDiffers ? " (different server — not used for this command)" : "";
+      console.log(`account: ${auth.account.present ? `${auth.account.email ?? auth.account.sub ?? "present"} present server=${auth.account.server}${accountDiffNote}` : `absent path=${auth.account.path}`}`);
       console.log(`config: ${auth.config.path ? `${auth.config.kind} ${auth.config.path} token=${auth.config.token_fingerprint ?? "none"}` : "none"}`);
       console.log(`auth-source: ${auth.auth_source}`);
       if (rejoin) {

--- a/cli/test/whoami.test.ts
+++ b/cli/test/whoami.test.ts
@@ -1,0 +1,131 @@
+// #140：party whoami 必须打印「生效 server」（命令实际落点），别只显示账号会话的 server。
+// 子进程级冒烟：真实 argv 路由，验证 runtime_config 生效 server 与账号会话 server 不同的常态场景。
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const indexPath = join(import.meta.dir, "..", "src", "index.ts");
+
+// 账号会话所属 server（人类登录，server A）——本用例里它绝不该被当成生效落点。
+const ACCOUNT_SERVER = "https://agentparty.account-side.example";
+
+let home: string;
+let restServer: ReturnType<typeof Bun.serve> | null = null;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "ap-whoami-"));
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+  restServer?.stop(true);
+  restServer = null;
+});
+
+// server B：runtime config 指向的生效 server，命令真正打到这里。
+function startEffectiveServer(): string {
+  restServer = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch(req) {
+      const url = new URL(req.url);
+      if (url.pathname === "/api/me") {
+        return Response.json({ name: "leo-claude", email: null, kind: "agent", role: "agent", owner: "lark:on_x" });
+      }
+      return Response.json({ error: { code: "not_found", message: "not found" } }, { status: 404 });
+    },
+  });
+  return `http://127.0.0.1:${restServer.port}`;
+}
+
+function seedConfigAndAccount(effectiveServer: string, accountServer: string): void {
+  mkdirSync(home, { recursive: true });
+  // runtime_config：带 token，resolveAuth 里优先，auth_source=runtime_config
+  writeFileSync(join(home, "config.json"), JSON.stringify({ server: effectiveServer, token: "ap_runtime_tok" }));
+  // 并存的人类账号会话，指向另一个 server；access_token 未过期，即便被读到也不触发 refresh
+  writeFileSync(
+    join(home, "account.json"),
+    JSON.stringify({
+      server: accountServer,
+      refresh_token: "rt_human",
+      access_token: "at_human",
+      expires_at: Math.floor(Date.now() / 1000) + 3600,
+      email: "human@example.com",
+    }),
+  );
+}
+
+async function runCli(args: string[]): Promise<{ code: number; stdout: string; stderr: string }> {
+  const proc = Bun.spawn(["bun", "run", indexPath, ...args], {
+    env: { ...process.env, AGENTPARTY_HOME: home },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, code] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { code, stdout, stderr };
+}
+
+test("whoami 文本输出打印生效 server（命令实际落点），而不只是账号会话的 server（#140）", async () => {
+  const effective = startEffectiveServer();
+  seedConfigAndAccount(effective, ACCOUNT_SERVER);
+
+  const r = await runCli(["whoami"]);
+  expect(r.code).toBe(0);
+  // 核心断言：生效 server 必须可见——修复前它一次都不打印，只露账号会话的 server A。
+  expect(r.stdout).toContain(effective);
+  // runtime 段（第一行的落点身份）与生效 server 关联，而非把 server A 呈现成落点。
+  const runtimeLine = r.stdout.split("\n").find((l) => l.startsWith("runtime:")) ?? "";
+  expect(runtimeLine).toContain(effective);
+  expect(runtimeLine).not.toContain(ACCOUNT_SERVER);
+});
+
+test("account server 与生效 server 不同时，account 行显式标注「不是本次命令落点」（#140）", async () => {
+  const effective = startEffectiveServer();
+  seedConfigAndAccount(effective, ACCOUNT_SERVER);
+
+  const r = await runCli(["whoami"]);
+  expect(r.code).toBe(0);
+  const accountLine = r.stdout.split("\n").find((l) => l.startsWith("account:")) ?? "";
+  // account 行仍展示账号 server A，但必须带「不同 server / 未被本次命令使用」的显式提示。
+  expect(accountLine).toContain(ACCOUNT_SERVER);
+  expect(accountLine).toMatch(/different server|not used/i);
+});
+
+test("account server 与生效 server 相同时，不误报「不同 server」标注（#140）", async () => {
+  const effective = startEffectiveServer();
+  // 账号会话与 runtime 指向同一个 server
+  seedConfigAndAccount(effective, effective);
+
+  const r = await runCli(["whoami"]);
+  expect(r.code).toBe(0);
+  // 生效 server 依旧要打印
+  expect(r.stdout).toContain(effective);
+  const accountLine = r.stdout.split("\n").find((l) => l.startsWith("account:")) ?? "";
+  // 同 server 时不该出现差异提示（否则等于恒定误报，agent 会无谓怀疑落点）
+  expect(accountLine).not.toMatch(/different server|not used/i);
+});
+
+test("whoami --json 明确区分 effective_server 与 account_server（#140）", async () => {
+  const effective = startEffectiveServer();
+  seedConfigAndAccount(effective, ACCOUNT_SERVER);
+
+  const r = await runCli(["whoami", "--json"]);
+  expect(r.code).toBe(0);
+  const frame = JSON.parse(r.stdout) as {
+    type: string;
+    logged_in: boolean;
+    effective_server: string;
+    account_server: string | null;
+  };
+  expect(frame.type).toBe("whoami");
+  expect(frame.logged_in).toBe(true);
+  // 生效落点 = server B；账号会话 = server A；两者机器可读地区分开，agent 免解析人话。
+  expect(frame.effective_server).toBe(effective);
+  expect(frame.account_server).toBe(ACCOUNT_SERVER);
+  expect(frame.effective_server).not.toBe(frame.account_server);
+});


### PR DESCRIPTION
频道身份：leo-claude-worker-140

## 问题（#140）

`party whoami` 只显示账号会话（human login，server A）自带的 server，**从不打印 runtime config 实际生效的 server（server B）**。在「一台机器多 agent、多部署」的常态下——同时持有人类账号会话与 agent runtime token——agent 读 whoami 会得出「我在 server A」的错误结论，进而向人类汇报错误 server、拿错 URL 拼 permalink / join link、排障找错部署。`auth-source: runtime_config` 已说明生效的是 runtime，但它的 server 恰恰没被打印。

复现属实：runtime config 走 `cfg.token`（auth_source=runtime_config），`auth.server` = server B 却从不出现在输出里；account 行只露 server A。

## 改动（仅 `cli/src/commands/whoami.ts` + 测试）

1. `runtime:` 行追加 `server=<生效 server>`——第一行即可见命令落点。
2. account 行在其 server ≠ 生效 server 时追加 `(different server — not used for this command)`；同 server 时不误报。
3. `--json` 增加 `effective_server` / `account_server`，机器可读地区分落点与账号会话 server，agent 免解析人话。

## 质量门

### Mutation table（去掉修复，断言必须转红）

| # | Mutation | 转红的测试 |
|---|---|---|
| M1 | runtime 行去掉 `server=${auth.server}` | 文本输出打印生效 server（#140）✗ |
| M2 | account 标注固定为空串（去掉 diff note） | account 行显式标注「不是本次命令落点」（#140）✗ |
| M3 | JSON 去掉 `effective_server`/`account_server` | whoami --json 区分 effective/account server（#140）✗ |
| M4a | `accountServerDiffers = true`（恒真） | account server 相同时不误报（#140）✗ |
| M4b | `accountServerDiffers = false`（恒假） | account server 不同时标注（#140）✗ |

每个 mutation 恰好只毒死其对应测试（3 pass / 1 fail），无假绿。

### 等价实现检查（换结构等价实现，测试须保持全绿）

把实现换成**结构不同但语义相同**的写法后 `4 pass / 0 fail`：
- diff 判定 `accountServer !== null && accountServer !== auth.server` → `!([null, auth.server]).includes(accountServer)`
- runtime 行由模板串 → 数组 `[...].join(" ")` 拼接
- account 标注由三元 → `["", note][Number(accountServerDiffers)]` 索引

测试断言的是「生效 server 是否可见」「两个 server 是否被区分」等可观察行为与解析出的 URL 值，不锚定字符串拼接方式，故等价实现保持全绿。

## 验证

- `cd cli && bun test`：382 pass / 0 fail；`bunx tsc --noEmit` 干净。
- `bun run check`（整仓）：CLI/scripts/shared/web 全过；worker vitest 命中已知 #185 load flake——revocation/ws/scoped-token 规格在 40 文件并行满载下 `20001ms` 超时。已按规程**单独重跑这 4 个 spec 文件**（`ws.spec.ts` `broadcast-order.spec.ts` `acl.spec.ts` `new-channel-guard-default.spec.ts`）：`4 passed / 71 tests passed`。本 PR 仅动 `cli/`，与 worker Durable Object 代码无任何关系。

Closes #140

https://claude.ai/code/session_01PgxkZeqJmDge3dYe9W2tPZ