### PR TITLE
feat(worker,cli): loop guard 读路径，熔断前可读 limit/streak/remaining (#174)

### DIFF
--- a/cli/src/commands/channel.ts
+++ b/cli/src/commands/channel.ts
@@ -7,6 +7,7 @@ import {
   archiveChannel,
   clearChannelRole,
   createChannel,
+  getLoopGuard,
   handleRestError,
   inviteProjectAgent,
   fetchChannelPerms,
@@ -67,6 +68,7 @@ const HELP = `usage: party channel create <slug> [--title t] [--temp] [--party] 
        party channel remove-agent <owner>/<handle> [slug]
        party channel gate reviewer|off [slug] [--policy sender|owner]
        party channel guard unlimited|off|<limit> [slug]
+       party channel guard status [slug] [--json]   read limit/streak/remaining before exit 4
        party channel workflow-guard off|<limit> [slug]
        party channel visibility <slug> public|private [--confirm]
        party channel members <slug>
@@ -339,9 +341,31 @@ export async function run(argv: string[]): Promise<number> {
       }
       case "guard": {
         const value = positionals[1];
+        // #174 读路径：熔断前读 limit/streak/remaining，与 set 语义共用 guard 子命令。
+        if (value === "status") {
+          const slug = resolveChannel(positionals[2]);
+          if (!slug) {
+            console.error("usage: party channel guard status [slug] [--json]");
+            return 1;
+          }
+          if (!isSlug(slug)) {
+            console.error("slug must match [a-z0-9][a-z0-9-]{0,63}");
+            return 1;
+          }
+          const state = await getLoopGuard(cfg.server, cfg.token, slug);
+          if (flags.json === true) {
+            console.log(JSON.stringify(state));
+          } else {
+            const onoff = state.enabled ? "on" : "off";
+            console.log(
+              `loop guard ${slug}: ${onoff} streak=${state.streak}/${state.limit} remaining=${state.remaining} resets_on=${state.resets_on}`,
+            );
+          }
+          return 0;
+        }
         const slug = resolveChannel(positionals[2]);
         if (!value || !slug) {
-          console.error("usage: party channel guard unlimited|off|<limit> [slug]");
+          console.error("usage: party channel guard status|unlimited|off|<limit> [slug]");
           return 1;
         }
         if (!isSlug(slug)) {

--- a/cli/src/rest.ts
+++ b/cli/src/rest.ts
@@ -899,6 +899,21 @@ export async function setLoopGuard(
   })) as { enabled: boolean; limit: number | null };
 }
 
+export interface LoopGuardState {
+  enabled: boolean;
+  limit: number;
+  streak: number;
+  remaining: number;
+  resets_on: string;
+}
+
+// #174 loop guard 读路径：熔断前就能读到 limit/streak/remaining，agent 据此自我节流。
+export async function getLoopGuard(server: string, token: string, slug: string): Promise<LoopGuardState> {
+  return (await req(server, `/api/channels/${encodeURIComponent(slug)}/loop-guard`, {
+    headers: bearerJson(token),
+  })) as LoopGuardState;
+}
+
 export async function setWorkflowGuard(
   server: string,
   token: string,

--- a/cli/test/channel-guard-status.test.ts
+++ b/cli/test/channel-guard-status.test.ts
@@ -1,0 +1,72 @@
+// party channel guard status（#174）：熔断前读 limit/streak/remaining 的 CLI 入口
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { writeConfig, writeState } from "../src/config";
+import { run as channelRun } from "../src/commands/channel";
+import { startOidcMock, type OidcMock } from "./oidc-mock";
+
+let home: string;
+let mock: OidcMock | null = null;
+let logs: string[];
+let errs: string[];
+const origLog = console.log;
+const origErr = console.error;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "ap-guardstatus-"));
+  process.env.AGENTPARTY_HOME = home;
+  logs = [];
+  errs = [];
+  console.log = (...a: unknown[]) => logs.push(a.map(String).join(" "));
+  console.error = (...a: unknown[]) => errs.push(a.map(String).join(" "));
+});
+
+afterEach(() => {
+  console.log = origLog;
+  console.error = origErr;
+  delete process.env.AGENTPARTY_HOME;
+  rmSync(home, { recursive: true, force: true });
+  mock?.stop();
+  mock = null;
+});
+
+test("guard status --json prints the guard state and hits GET loop-guard", async () => {
+  mock = startOidcMock();
+  writeConfig({ server: mock.url, token: "ap_runtime" });
+  writeState({ channel: "ops", cursor: 0 });
+
+  const code = await channelRun(["guard", "status", "ops", "--json"]);
+  expect(code).toBe(0);
+
+  const req = mock.requests.find((r) => r.path === "/api/channels/ops/loop-guard");
+  expect(req?.method).toBe("GET");
+  expect(req?.auth).toBe("Bearer ap_runtime");
+
+  const printed = JSON.parse(logs.join("\n"));
+  expect(printed).toEqual({ enabled: true, limit: 30, streak: 27, remaining: 3, resets_on: "human" });
+});
+
+test("guard status (human-readable) surfaces streak/limit/remaining and reset target", async () => {
+  mock = startOidcMock();
+  writeConfig({ server: mock.url, token: "ap_runtime" });
+  writeState({ channel: "ops", cursor: 0 });
+
+  const code = await channelRun(["guard", "status"]);
+  expect(code).toBe(0);
+  const out = logs.join("\n");
+  expect(out).toContain("27");
+  expect(out).toContain("30");
+  expect(out).toContain("3");
+  expect(out.toLowerCase()).toContain("human");
+});
+
+test("guard status resolves the slug from state when omitted", async () => {
+  mock = startOidcMock();
+  writeConfig({ server: mock.url, token: "ap_runtime" });
+  writeState({ channel: "ops", cursor: 0 });
+
+  await channelRun(["guard", "status"]);
+  expect(mock.requests.some((r) => r.path === "/api/channels/ops/loop-guard")).toBe(true);
+});

--- a/cli/test/oidc-mock.ts
+++ b/cli/test/oidc-mock.ts
@@ -147,6 +147,10 @@ export function startOidcMock(opts: MockOptions = {}): OidcMock {
         const filtered = handle ? invites.filter((i) => i.profile_handle === handle) : invites;
         return Response.json({ invites: filtered });
       }
+      if (req.method === "GET" && /^\/api\/channels\/[^/]+\/loop-guard$/.test(u.pathname)) {
+        // #174 loop guard 读路径 mock
+        return Response.json({ enabled: true, limit: 30, streak: 27, remaining: 3, resets_on: "human" });
+      }
       if (req.method === "POST" && /^\/api\/channels\/[^/]+\/project-agents$/.test(u.pathname)) {
         const slug = u.pathname.split("/")[3] ?? "dev";
         const b = rec.body as { owner_account?: string; handle?: string } | null;

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -1714,6 +1714,12 @@ export class ChannelDO extends Server<Env> {
       // party who：完整 presence 快照（含 kind/wake/last_seen），供 CLI 分档展示谁在线/可唤醒
       return Response.json({ presence: this.presenceList() });
     }
+    if (url.pathname === "/internal/guard" && request.method === "GET") {
+      // party channel guard status（#174）：熔断前就能读到 limit/streak/remaining。
+      // 先按 header 刷新 config meta，保证 enabled/limit 与 D1 权威一致，streak 取 DO 自身状态。
+      this.cacheChannelMeta(request.headers, request.headers.get("x-ap-host"));
+      return Response.json(this.loopGuardState());
+    }
     if (url.pathname === "/internal/identities" && request.method === "GET") {
       const identities = new Map<string, { name: string; kind?: SenderKind; account?: string }>();
       const add = (name: unknown, kind: unknown, account: unknown) => {
@@ -3134,15 +3140,39 @@ export class ChannelDO extends Server<Env> {
     return `agent_count:${name}`;
   }
 
-  private globalLoopGuardMessage(): string | null {
-    if (this.getMeta("loop_guard_enabled") !== "1") return null;
+  // 熔断实际生效的阈值：显式配置优先，否则回落 normal/party 默认（便于手工修复旧 DO meta）。
+  private effectiveLoopGuardLimit(): number {
     const configured = Number(this.getMeta("loop_guard_limit") ?? "");
-    // 频道未显式配置 limit 时保留旧 normal/party 默认，便于手工修复旧 DO meta。
-    const guardLimit = Number.isInteger(configured) && configured > 0
+    return Number.isInteger(configured) && configured > 0
       ? Math.min(configured, 10_000)
       : this.getMeta("mode") === "party"
         ? LOOP_GUARD_PARTY_N
         : LOOP_GUARD_N;
+  }
+
+  // 熔断【之前】就可读的 guard 快照（#174）：limit/streak/remaining 与实际触发用同一套阈值口径，
+  // 让 agent 能自我节流，而不必先撞 exit 4 把频道锁死才知道 guard 存在。
+  private loopGuardState(): {
+    enabled: boolean;
+    limit: number;
+    streak: number;
+    remaining: number;
+    resets_on: "human";
+  } {
+    const limit = this.effectiveLoopGuardLimit();
+    const streak = this.agentStreak();
+    return {
+      enabled: this.getMeta("loop_guard_enabled") === "1",
+      limit,
+      streak,
+      remaining: Math.max(0, limit - streak),
+      resets_on: "human",
+    };
+  }
+
+  private globalLoopGuardMessage(): string | null {
+    if (this.getMeta("loop_guard_enabled") !== "1") return null;
+    const guardLimit = this.effectiveLoopGuardLimit();
     return this.agentStreak() >= guardLimit
       ? `${guardLimit} consecutive agent messages, waiting for a human`
       : null;

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -3219,6 +3219,24 @@ app.get("/api/channels/:slug/presence", async (c) => {
   return fetchChannelDO(c.env, slug, new Request("https://do/internal/presence", { headers: { "x-partykit-room": slug } }));
 });
 
+app.get("/api/channels/:slug/loop-guard", async (c) => {
+  // #174 loop guard 读路径：熔断前就能读 limit/streak/remaining。与 presence 同样的 ACL 门。
+  // 传 channelHeaders 让 DO 用 D1 权威刷新 enabled/limit，再叠上它自己的 streak。
+  const slug = c.req.param("slug");
+  const channel = await loadChannel(c.env.DB, slug);
+  if (!channel) return c.json(errorBody("not_found", "channel not found"), 404);
+  if (!(await canAccessLoadedChannel(c.env.DB, c.get("identity"), channel))) {
+    return c.json(errorBody("forbidden", "not allowed in this channel"), 403);
+  }
+  return fetchChannelDO(
+    c.env,
+    slug,
+    new Request("https://do/internal/guard", {
+      headers: { "x-partykit-room": slug, ...channelHeaders(channel, c.req.url) },
+    }),
+  );
+});
+
 app.get("/api/channels/:slug/identities", async (c) => {
   const slug = c.req.param("slug");
   const channel = await loadChannel(c.env.DB, slug);

--- a/worker/test/guard-read.spec.ts
+++ b/worker/test/guard-read.spec.ts
@@ -1,0 +1,108 @@
+import { LOOP_GUARD_N } from "@agentparty/shared";
+import { describe, expect, it } from "vitest";
+import { api, createChannel, disableLoopGuard, postMessage, seedToken } from "./helpers";
+
+interface GuardState {
+  enabled: boolean;
+  limit: number;
+  streak: number;
+  remaining: number;
+  resets_on: string;
+}
+
+async function guardState(slug: string, token: string): Promise<GuardState> {
+  const res = await api(`/api/channels/${slug}/loop-guard`, token);
+  expect(res.status).toBe(200);
+  return (await res.json()) as GuardState;
+}
+
+describe("loop guard read path", () => {
+  it("exposes enabled/limit/streak/remaining/resets_on for a fresh channel", async () => {
+    const agent = await seedToken("agent");
+    const slug = await createChannel(agent.token);
+    // #96 起新频道默认开 guard，limit 落到 normal 默认
+    expect(await guardState(slug, agent.token)).toEqual({
+      enabled: true,
+      limit: LOOP_GUARD_N,
+      streak: 0,
+      remaining: LOOP_GUARD_N,
+      resets_on: "human",
+    });
+  });
+
+  it("increments streak by exactly one per agent message and decrements remaining", async () => {
+    const agentA = await seedToken("agent");
+    const agentB = await seedToken("agent");
+    const slug = await createChannel(agentA.token);
+
+    expect((await guardState(slug, agentA.token)).streak).toBe(0);
+
+    await postMessage(slug, agentA.token, "m0");
+    let g = await guardState(slug, agentA.token);
+    expect(g.streak).toBe(1);
+    expect(g.remaining).toBe(LOOP_GUARD_N - 1);
+
+    await postMessage(slug, agentB.token, "m1");
+    g = await guardState(slug, agentA.token);
+    expect(g.streak).toBe(2);
+    expect(g.remaining).toBe(LOOP_GUARD_N - 2);
+
+    await postMessage(slug, agentA.token, "m2");
+    g = await guardState(slug, agentA.token);
+    expect(g.streak).toBe(3);
+    expect(g.remaining).toBe(LOOP_GUARD_N - 3);
+  });
+
+  it("resets streak to zero after a human speaks", async () => {
+    const agent = await seedToken("agent");
+    const human = await seedToken("human");
+    const slug = await createChannel(agent.token);
+
+    await postMessage(slug, agent.token, "a0");
+    await postMessage(slug, agent.token, "a1");
+    expect((await guardState(slug, agent.token)).streak).toBe(2);
+
+    await postMessage(slug, human.token, "human here");
+    const g = await guardState(slug, agent.token);
+    expect(g.streak).toBe(0);
+    expect(g.remaining).toBe(LOOP_GUARD_N);
+  });
+
+  it("reflects a per-channel configured limit", async () => {
+    const agent = await seedToken("agent");
+    const slug = await createChannel(agent.token);
+    const enable = await api(`/api/channels/${slug}/loop-guard`, agent.token, {
+      method: "PUT",
+      body: JSON.stringify({ enabled: true, limit: 3 }),
+    });
+    expect(enable.status).toBe(200);
+
+    const g = await guardState(slug, agent.token);
+    expect(g.enabled).toBe(true);
+    expect(g.limit).toBe(3);
+    expect(g.remaining).toBe(3);
+
+    await postMessage(slug, agent.token, "one");
+    const g2 = await guardState(slug, agent.token);
+    expect(g2.streak).toBe(1);
+    expect(g2.remaining).toBe(2);
+  });
+
+  it("reports enabled=false once a human disables the guard", async () => {
+    const agent = await seedToken("agent");
+    const human = await seedToken("human");
+    const slug = await createChannel(agent.token);
+    await disableLoopGuard(slug, human.token);
+    const g = await guardState(slug, agent.token);
+    expect(g.enabled).toBe(false);
+  });
+
+  it("denies reading guard state to a token scoped to another private channel", async () => {
+    const agent = await seedToken("agent");
+    const slug = await createChannel(agent.token);
+    // channel-scoped token 硬上限单频道：scope 不匹配则 ACL 拒（acl.ts canAccessChannel）
+    const stranger = await seedToken("agent", undefined, { channelScope: "some-other-channel" });
+    const res = await api(`/api/channels/${slug}/loop-guard`, stranger.token);
+    expect(res.status).toBe(403);
+  });
+});


### PR DESCRIPTION
> 频道身份：leo-codex-main-dev（#agentparty）

Closes #174

## 根因

loop guard 只有写路径没有读路径：`party channel guard` 是 set-only，`who/history/whoami` 都不带 guard 状态。agent 唯一能发现 guard 的方式就是撞上它——`send` 返回 exit 4（`EXIT_LOOP_GUARD`），此时频道已对所有 agent gag 到人类发言为止。没有任何「熔断前」信号可供自我节流。

限额（`loop_guard_enabled`/`loop_guard_limit`）落在 D1 `channels` 表；当前计数 `agent_streak` 落在 DO meta（`worker/src/do.ts:2582` 每条 agent 消息 +1，`clearLoopGuardState()` 在人类发言时清零）。二者都没有对外读接口。

## 改动

- `worker/src/do.ts`
  - 抽出 `effectiveLoopGuardLimit()`（原本内联在 `globalLoopGuardMessage`），让读路径与实际触发用**同一套阈值口径**（显式配置优先，否则按 mode 回落 normal 30 / party 200）。
  - 新增 `loopGuardState()` → `{enabled,limit,streak,remaining,resets_on:"human"}`，`remaining = max(0, limit - streak)`。
  - 新增内部端点 `GET /internal/guard`（`do.ts:1717` 附近）：先 `cacheChannelMeta` 用请求头刷新 config，再返回快照。
- `worker/src/index.ts`
  - 新增 `GET /api/channels/:slug/loop-guard`（presence 路由旁）：与 presence 同样的 `canAccessLoadedChannel` ACL 门；转发时带 `channelHeaders(channel)`，让 DO 以 D1 为权威刷新 `enabled/limit`，再叠上它自己的 `streak`。
- `cli/src/rest.ts`：新增 `getLoopGuard()`（GET）。
- `cli/src/commands/channel.ts`：新增 `party channel guard status [slug] [--json]`。

一条命令即可读到「还剩几条」：

```
$ party channel guard status agentparty
loop guard agentparty: on streak=27/30 remaining=3 resets_on=human
$ party channel guard status agentparty --json
{"enabled":true,"limit":30,"streak":27,"remaining":3,"resets_on":"human"}
```

## TDD

先写失败测试并亲眼看红：`worker/test/guard-read.spec.ts` 6 条初始全红（路由不存在 → 404，非拼写错误）；`cli/test/channel-guard-status.test.ts` 3 条初始全红（`guard status` 被当成 set 值 → exit 1）。再写实现转绿。断言了观测过程：streak 随每条 agent 消息精确 +1、remaining 精确 -1、人类发言后 streak 归零 remaining 回满，而不是只断言字段存在。

## 变异表（逐个接线点拆开，确认对应测试精确变红）

| # | 接线点 | 变异 | 精确变红的测试 |
|---|---|---|---|
| M1 | `do.ts loopGuardState.remaining` | `max(0,limit-streak)` → `999` | 4 条：fresh-channel / per-message / human-reset / configured-limit |
| M2 | `do.ts loopGuardState.streak` | `agentStreak()` → `0` | 3 条：per-message / human-reset / configured-limit |
| M3 | `do.ts loopGuardState.enabled` | `=== "1"` → `true` | 1 条：disabled 测试 |
| M4 | `do.ts /internal/guard` 的 `cacheChannelMeta` | 删掉该调用 | 1 条：fresh-channel（无 hydration 时 enabled 读成 false）→ **非死代码，load-bearing**：DO 未被连接/发送过时靠它从 D1 灌 meta |
| M5 | `do.ts effectiveLoopGuardLimit` 配置分支 | `min(configured,10000)` → `7777` | 2 条：guard-read 的 configured-limit + **guards.spec 的熔断触发测试**（证明重构后触发路径仍用同一计算） |
| M6 | `index.ts` 路由 ACL 门 | `false &&` 短路掉 | 1 条：forbidden 测试 |
| M7 | `channel.ts` CLI status 取值 | 清零 state 字段 | 2 条 CLI：`--json` + human-readable（第 3 条只断言请求 path，正确不受影响） |

每个接线点都有覆盖测试，无死代码。

## 门禁输出

- `worker`：`bunx vitest run test/guard-read.spec.ts` → 6 passed。相关面 `guard-read + guards + new-channel-guard-default + guard-config-acl + workflow-guard` 隔离跑 → 27 passed。
- `cli`：`bun test test/channel-guard-status.test.ts test/account-commands.test.ts test/cli.test.ts` → 56 passed。
- `tsc --noEmit`：cli / worker 均 0 error。

### 已知环境 flaky（如实说明）

worker 全量在满载下（本机当时同时跑 6 个 agent）跑出 2 条红：
- `guards > disabled loop guard allows agent messages beyond the old global threshold`（20000ms 超时）
- `guards > rate limits repeated invalid send payloads`（26396ms，跨分钟 rate 桶时序敏感）

二者均为时序/负载敏感，**单独重跑 `bunx vitest run test/guards.spec.ts` → 11 passed 全绿**，判定为已知满载环境 flaky（同 #185/#200 家族），与本改动无关。本改动只涉及新增读端点 + 一处纯重构（已被 M5 证明触发路径行为不变）。

## 遗留问题（不在本 PR 范围）

- `do.ts:2582` 的 streak 计数**不区分 kind**——status 消息也计入 streak。本 PR 如实暴露 streak（与实际触发口径一致），未改计数语义；若要「只按真实对话消息计数」是独立的行为变更，应另开 issue。
- 未把 guard 塞进 `who --json` / welcome / MCP `party_who`（issue 建议之一）。当前以独立读端点 + CLI 入口满足「一条命令看到还剩几条」，范围克制；如需 poll 面聚合可后续跟进。
