### PR TITLE
fix(worker): who 与 history 不再对同一身份的 kind 各说各话 (#173)

### DIFF
--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -3224,16 +3224,22 @@ export class ChannelDO extends Server<Env> {
     this.ctx.storage.sql.exec("DELETE FROM meta WHERE key = ?", key);
   }
 
+  // issue #173：presence.kind 只有 status 帧写路径会盖，markOffline 新建的行、kind 列迁移前的旧行都是 NULL。
+  // 而 messages.sender_kind 每条消息落库时都从权威 token（identity.kind）盖，永远有真值。presence.kind 缺失时
+  // 回填该 name 最近一条消息的 sender_kind，让 `who`（读 presence）与 `history`（读 messages）对同一身份返回同一个
+  // kind——否则 CLI who.ts kindOf() 会按名字猜（非 UUID → "agent"），把只发过普通消息的人类谎报成 agent。
+  // presence.kind 非 NULL 时（即刚发过 status 帧、最新一手 token 快照）优先用它，不被历史消息覆盖。
+  private static readonly PRESENCE_COLUMNS = `name,
+                COALESCE(kind, (SELECT sender_kind FROM messages WHERE sender_name = presence.name ORDER BY seq DESC LIMIT 1)) AS kind,
+                account, handle, display_name, avatar_url, avatar_thumb,
+                state, note, updated_at, status_scope_json, status_summary_seq, status_blocked_reason,
+                status_context_json, status_decision_json, status_workflow_json, role, role_source, residency, wake_kind, wake_verified_at,
+                context_json, lineage_json`;
+
   private presenceList(): PresenceEntry[] {
     const liveCounts = this.liveConnectionCounts();
     return this.ctx.storage.sql
-      .exec(
-        `SELECT name, kind, account, handle, display_name, avatar_url, avatar_thumb,
-                state, note, updated_at, status_scope_json, status_summary_seq, status_blocked_reason,
-                status_context_json, status_decision_json, status_workflow_json, role, role_source, residency, wake_kind, wake_verified_at,
-                context_json, lineage_json
-         FROM presence ORDER BY name`,
-      )
+      .exec(`SELECT ${ChannelDO.PRESENCE_COLUMNS} FROM presence ORDER BY name`)
       .toArray()
       .map((r) => this.withLivePresence(this.presenceRowToEntry(r), liveCounts));
   }
@@ -3241,14 +3247,7 @@ export class ChannelDO extends Server<Env> {
   private presenceFor(name: string): PresenceEntry | null {
     const liveCounts = this.liveConnectionCounts();
     const rows = this.ctx.storage.sql
-      .exec(
-        `SELECT name, kind, account, handle, display_name, avatar_url, avatar_thumb,
-                state, note, updated_at, status_scope_json, status_summary_seq, status_blocked_reason,
-                status_context_json, status_decision_json, status_workflow_json, role, role_source, residency, wake_kind, wake_verified_at,
-                context_json, lineage_json
-         FROM presence WHERE name = ?`,
-        name,
-      )
+      .exec(`SELECT ${ChannelDO.PRESENCE_COLUMNS} FROM presence WHERE name = ?`, name)
       .toArray();
     return rows.length > 0 ? this.withLivePresence(this.presenceRowToEntry(rows[0]!), liveCounts) : null;
   }

--- a/worker/test/kind-consistency.spec.ts
+++ b/worker/test/kind-consistency.spec.ts
@@ -1,0 +1,82 @@
+// issue #173：`party who`（presence）与 `party history`（messages）对同一身份的 kind 说法不一致。
+//
+// 根因：两侧 kind 都是「写入时」从权威 token（tokens.role → identity.kind）盖的快照——
+//   - messages.sender_kind：每条消息落库时盖，永远有真值（history 读这个，可靠）。
+//   - presence.kind：只有 status 帧写路径会盖；markOffline / kind 列迁移前的旧行 = NULL。
+// presence.kind 为 NULL 时，presenceRowToEntry 省略 kind，CLI who.ts kindOf() 便按名字猜
+// （非 UUID → "agent"）。于是「只发过普通消息、没发过 status 帧就离线」的人类，被 who 谎报成 agent，
+// 而 history 如实报 human。二者对同一身份给出不同的 kind。
+//
+// 权威来源 = messages.sender_kind（token 盖的、不臆造）。修复让 presence 读侧在自身 kind 为 NULL 时，
+// 回填该 name 最近一条消息的 sender_kind，从而 who 与 history 对同一身份返回**同一个** kind 值。
+import type { MsgFrame, PresenceEntry } from "@agentparty/shared";
+import { describe, expect, it } from "vitest";
+import { WsClient, api, createChannel, postMessage, seedToken } from "./helpers";
+
+async function fetchPresence(slug: string, token: string): Promise<PresenceEntry[]> {
+  const res = await api(`/api/channels/${slug}/presence`, token);
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as { presence: PresenceEntry[] };
+  return body.presence;
+}
+
+async function fetchMessages(slug: string, token: string): Promise<MsgFrame[]> {
+  const res = await api(`/api/channels/${slug}/messages?since=0&limit=1000`, token);
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as { messages: MsgFrame[] };
+  return body.messages;
+}
+
+describe("issue #173: who 与 history 对同一身份的 kind 必须一致", () => {
+  it("只发过普通消息、离线后 presence.kind=NULL 的人类：/presence 报 human，与 history 同值（不再被猜成 agent）", async () => {
+    const creator = await seedToken("agent");
+    const human = await seedToken("human");
+    const slug = await createChannel(creator.token);
+
+    // 人类只发一条普通消息（非 status 帧）→ 进 history（sender_kind=human），但**不写 presence**。
+    const posted = await postMessage(slug, human.token, "human speaking, can reset loop guard");
+    expect(posted.status).toBe(200);
+
+    // watcher 常驻，用它收到的 offline presence 帧同步 markOffline 时机（消 onClose 竞态）。
+    const watcher = await WsClient.open(slug, creator.token);
+    await watcher.nextOfType("welcome");
+
+    // 人类连一次 WS 再断开 → onClose → markOffline 新建 presence 行，kind 列为 NULL。
+    const humanWs = await WsClient.open(slug, human.token);
+    await humanWs.nextOfType("welcome");
+    humanWs.close();
+
+    // 等 markOffline 广播出该 name 的 offline presence 帧。
+    let offlineFrame: PresenceEntry | undefined;
+    for (;;) {
+      const f = await watcher.nextOfType("presence");
+      if (f.name === human.name && f.state === "offline") {
+        offlineFrame = f as unknown as PresenceEntry;
+        break;
+      }
+    }
+
+    // history 侧：权威 sender_kind = human。
+    const messages = await fetchMessages(slug, human.token);
+    const mine = messages.find((m) => m.sender.name === human.name);
+    expect(mine).toBeDefined();
+    const historyKind = mine!.sender.kind;
+    expect(historyKind).toBe("human");
+
+    // presence 侧（who 数据源）：修复前 presence.kind=NULL → 省略 → who 猜成 agent；
+    // 修复后回填 messages.sender_kind → human。
+    const presence = await fetchPresence(slug, human.token);
+    const entry = presence.find((p) => p.name === human.name);
+    expect(entry).toBeDefined();
+    const presenceKind = entry!.kind;
+
+    // 核心断言：两条路径对同一身份返回**同一个** kind 值（而非只断言字段存在）。
+    expect(presenceKind).toBe("human");
+    expect(presenceKind).toBe(historyKind);
+
+    // markOffline 走 presenceFor：其广播帧也必须带回填后的 human（覆盖 presenceFor 接线点）。
+    expect(offlineFrame!.kind).toBe("human");
+
+    watcher.close();
+  });
+});


### PR DESCRIPTION
> 频道身份：leo-codex-main-dev（#agentparty）

Closes #173

## 根因（哪一侧权威、为什么）

两侧的 `kind` 都是**写入时**从权威 token（`tokens.role` → `identity.kind`，`worker/src/auth.ts:156`）盖下的快照，读侧都不回查 token：

- `history` 读 `messages.sender_kind`（`worker/src/do.ts:3322`，`rowToFrame`）。每条消息落库时都盖一次（`do.ts:2534`），**永远有真值** → 可靠。
- `who` 读 `presence.kind`（`do.ts:3280`，`presenceRowToEntry`）。只有 **status 帧**写路径会盖（`do.ts:2600` 的 upsert）。`markOffline`（`do.ts:1331`，只发过普通消息就离线的身份）新建的行、以及 `kind` 列迁移（`do.ts:891` `ALTER TABLE presence ADD COLUMN kind`）之前的旧行，`kind` 都是 **NULL**。

`presence.kind` 为 NULL 时 `presenceRowToEntry` 省略该字段，CLI `who.ts` 的 `kindOf()`（`cli/src/commands/who.ts:51-54`）便**按名字猜**：非 UUID 名 → `"agent"`。于是「只发过普通消息、没发过 status 帧就离线」的人类被 `who` 谎报成 `agent`，而 `history` 如实报 `human`。issue 里 `leo-claude-host` 正是这种：`history` 有它的 human 消息，`presence` 行 `kind=NULL`。

**权威来源 = `messages.sender_kind`**（token 盖的、从不臆造）。`history` 是可靠侧，`who` 是臆造侧。issue 方向成立（who 把 human 说成 agent），但更精确的定位是：不是 presence「存了 agent」，而是 presence **没存**、CLI 猜成了 agent。

## 修复

让 presence 读侧（`presenceList()` / `presenceFor()`）在自身 `kind` 为 NULL 时，`COALESCE` 回填该 name 最近一条消息的 `sender_kind`。于是 `who` 与 `history` 都源自同一个 `messages.sender_kind`，对同一身份返回**同一个** kind 值。`presence.kind` 非 NULL 时（刚发过 status 帧 = 最新一手 token 快照）优先用它，不被历史消息覆盖——所以「token 改角色/名字重铸」这类 presence 比历史更新的正当场景不受影响（who=当前、history=历史，本就该不同，非本 bug）。

## 变异表

| # | 接线点 (file:line) | 变异 | 期望变红的断言 | 结果 |
|---|---|---|---|---|
| A | `do.ts` `PRESENCE_COLUMNS` 的 `COALESCE(...)` → 裸 `kind`（presenceList 路径） | 去掉回填 | `presenceKind === "human"`（spec:74，走 `/presence` = presenceList） | 精确变红：`expected undefined to be 'human'` @ `:74` |
| A' | 同上（presenceFor 路径） | 去掉回填 + 临时停用 presenceList 断言 | `offlineFrame.kind === "human"`（markOffline 广播帧走 presenceFor） | 精确变红 @ `:79` |

两个读函数共用同一 SQL 片段 `PRESENCE_COLUMNS`，测试分别断言了两条消费路径（`/presence` 端点走 `presenceList`；`markOffline` 广播帧走 `presenceFor`），去掉 `COALESCE` 各自都精确变红。无零覆盖接线点。

## 门禁输出

- worker `bunx vitest run kind-consistency`：先红（`presenceKind=undefined` vs `history=human`）→ 实现后绿。
- worker 全量 vitest：全过（见下）。
- CLI `bun test`：384 pass / 0 fail。
- worker + CLI `bunx tsc --noEmit`：exit 0。

## 证据分级

- **实测输出**：上述先红后绿、变异 A/A' 精确变红、全量套件与类型检查全过。
- **读代码推断**：token 是最终权威（auth.ts）；`tokens.name UNIQUE`（`migrations/0001_init.sql:16`）故 name→role 1:1，历史/presence 分歧源于 name 复用或 status 帧未回写，而非同一时刻两个 role。

## 遗留问题

- CLI `who.ts kindOf()` 的「非 UUID 名 → agent」猜测仍在：只在某 name **presence.kind=NULL 且一条消息都没发过**时才触发（本 bug 的 `leo-claude-host` 有消息，已被服务端回填覆盖，不再触发）。issue 建议此时 `who` 应「省略而非猜 agent」；改动会牵动 `Row.kind` 变可选、文本/JSON 渲染契约，属独立收尾，本 PR 未动，如实标注。
- issue 另建议 `who --json` 带 `owner` 供交叉核对；本 PR 聚焦「kind 一致」这一核心分歧，未扩包。
