### PR TITLE
feat(worker): 消息发送幂等键，服务端盲重试不再重复落库+重复唤醒 (#98)

### DIFF
--- a/cli/src/rest.ts
+++ b/cli/src/rest.ts
@@ -1005,16 +1005,39 @@ export async function searchMessages(
 
 export type MessagePayload = Omit<SendMessageFrame, "type"> | Omit<SendStatusFrame, "type">;
 
+const ULID_CROCKFORD = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+
+// ULID（#98）：48-bit 毫秒时间戳 + 80-bit 随机，时间有序、无依赖。仅需唯一性即可满足幂等，
+// 时间有序还让服务端 (sender, key) 索引对最近消息更友好。crypto.getRandomValues 在 node/bun/浏览器均有。
+function newIdempotencyKey(): string {
+  let ts = Date.now();
+  const time: string[] = [];
+  for (let i = 0; i < 10; i += 1) {
+    time.unshift(ULID_CROCKFORD[ts % 32]!);
+    ts = Math.floor(ts / 32);
+  }
+  const rnd = new Uint8Array(16);
+  crypto.getRandomValues(rnd);
+  const rand: string[] = [];
+  for (let i = 0; i < 16; i += 1) rand.push(ULID_CROCKFORD[rnd[i]! % 32]!);
+  return time.join("") + rand.join("");
+}
+
 export async function postMessage(
   server: string,
   token: string,
   slug: string,
   payload: MessagePayload,
 ): Promise<{ seq: number; completion_review?: CompletionReview }> {
+  // 每次发送生成一个新的幂等键：调用方不必操心；重试（客户端超时重发 / 服务端 DO-reset clone 重发）
+  // 携带同一 body 即同一 key，服务端据此去重。调用方若已带 key（少见）则尊重之。
+  const body: MessagePayload = "idempotency_key" in payload && payload.idempotency_key !== undefined
+    ? payload
+    : { ...payload, idempotency_key: newIdempotencyKey() };
   return (await req(server, `/api/channels/${encodeURIComponent(slug)}/messages`, {
     method: "POST",
     headers: bearerJson(token),
-    body: JSON.stringify(payload),
+    body: JSON.stringify(body),
   })) as { seq: number; completion_review?: CompletionReview };
 }
 

--- a/cli/test/cli.test.ts
+++ b/cli/test/cli.test.ts
@@ -267,7 +267,8 @@ describe("cli subprocess", () => {
         method: "POST",
         path: "/api/channels/dev/messages",
         auth: "Bearer ap_tok",
-        body: { kind: "message", body: "hello mcp", mentions: ["bob"], reply_to: null },
+        // body 还带一个随机 idempotency_key（#98），故用 objectContaining 容忍它
+        body: expect.objectContaining({ kind: "message", body: "hello mcp", mentions: ["bob"], reply_to: null }),
       }));
 
       const created = await client.callTool({
@@ -400,7 +401,8 @@ describe("cli subprocess", () => {
       expect(seen).toContainEqual(expect.objectContaining({
         method: "POST",
         path: "/api/channels/dev/messages",
-        body: { kind: "status", state: "working", note: "started", mentions: [], scope: ["task:1"], context: expect.any(Object) },
+        // body 还带一个随机 idempotency_key（#98），故用 objectContaining 容忍它
+        body: expect.objectContaining({ kind: "status", state: "working", note: "started", mentions: [], scope: ["task:1"], context: expect.any(Object) }),
       }));
       expect(seen).toContainEqual(expect.objectContaining({
         method: "PATCH",

--- a/cli/test/idempotency.test.ts
+++ b/cli/test/idempotency.test.ts
@@ -1,0 +1,28 @@
+// #98：postMessage 必须给每次发送带一个唯一 idempotency_key。
+// 断言过程（发出去的 body 里有键、每次调用键不同），不只看返回。
+// 有了它，服务端盲重试（DO reset 后 clone 重发同一 body）携带同一键，才能被服务端去重。
+import { describe, expect, test } from "bun:test";
+import { postMessage } from "../src/rest";
+import { startRestMock } from "./rest-mock";
+
+describe("postMessage idempotency key (#98)", () => {
+  test("attaches a non-empty idempotency_key, unique per call", async () => {
+    const mock = startRestMock();
+    try {
+      await postMessage(mock.url, "ap_tok", "chan", { kind: "message", body: "hi", mentions: [], reply_to: null });
+      await postMessage(mock.url, "ap_tok", "chan", { kind: "message", body: "hi", mentions: [], reply_to: null });
+
+      const bodies = mock.requests
+        .filter((r) => r.method === "POST" && r.path === "/api/channels/chan/messages")
+        .map((r) => r.body as { idempotency_key?: unknown });
+
+      expect(bodies).toHaveLength(2);
+      expect(typeof bodies[0]!.idempotency_key).toBe("string");
+      expect((bodies[0]!.idempotency_key as string).length).toBeGreaterThan(0);
+      // 每次发送生成新键：不同逻辑消息不会互相误去重
+      expect(bodies[0]!.idempotency_key).not.toBe(bodies[1]!.idempotency_key);
+    } finally {
+      mock.stop();
+    }
+  });
+});

--- a/cli/test/m3.test.ts
+++ b/cli/test/m3.test.ts
@@ -1358,7 +1358,8 @@ describe("party status/history channel flag", () => {
     expect(r.code).toBe(0);
     expect(r.stdout).toContain("completion seq=1");
     const req = reqsOf(mock!, "POST", "/api/channels/dev/messages")[0]!;
-    expect(req.body).toEqual({
+    // toMatchObject（非 toEqual）：body 还带一个随机 idempotency_key（#98）
+    expect(req.body).toMatchObject({
       kind: "message",
       body: "final synthesis",
       mentions: ["alice"],
@@ -1373,6 +1374,7 @@ describe("party status/history channel flag", () => {
         task_id: 12,
       },
     });
+    expect(typeof (req.body as { idempotency_key?: unknown }).idempotency_key).toBe("string");
   });
 
   test("complete sends --replaces for reworked completion", async () => {

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -11,6 +11,13 @@ export const LOOP_GUARD_AGENT_N = 15;
 export const LOOP_GUARD_PARTY_N = 200;
 export const LOOP_GUARD_AGENT_PARTY_N = 50;
 export const RETAIN_N = 10_000;
+// 幂等键最大长度（#98）：ULID 是 26 字符，留足余量到 128 防滥用把 key 当附加 payload。
+export const IDEMPOTENCY_KEY_MAX = 128;
+// 幂等去重窗口（#98）：只在最近这段时间内的同键消息上去重。10 分钟足以覆盖
+// 客户端 30s 超时 + 重试 + 服务端 fetchChannelDO 的 DO-reset 重发，并留足时钟偏移余量；
+// 越界后同一 key 可被安全重用（实践中客户端每次发送都生成新 ULID，不会重用）。
+// 另有 RETAIN_N 条消息保留上限做二次兜底：更老的消息连同其 key 一起被裁剪。
+export const IDEMPOTENCY_WINDOW_MS = 10 * 60_000;
 export const PRESENCE_TIMEOUT_MS = 60_000;
 // temp 频道最后一条消息后闲置多久自动归档（spec §6）
 export const TEMP_IDLE_ARCHIVE_MS = 14 * 24 * 60 * 60 * 1000;
@@ -400,6 +407,12 @@ export interface SendMessageFrame {
   reply_to: number | null;
   completion_artifact?: CompletionArtifact;
   replaces?: number;
+  /**
+   * 幂等键（#98）：客户端每次发送生成一个唯一键（ULID）。同一条逻辑消息的重试（客户端超时重发、
+   * 或服务端 fetchChannelDO 在 DO reset 后 clone 重发）携带同一键，服务端按 (sender, key) 去重，
+   * 返回原来那条的 seq，不再重复落库/重复唤醒。旧客户端不带 → 保持旧行为（不去重）。
+   */
+  idempotency_key?: string;
 }
 
 export interface SendStatusFrame {
@@ -408,6 +421,8 @@ export interface SendStatusFrame {
   state: StatusState;
   note: string;
   mentions?: string[];
+  /** 幂等键（#98）：同 SendMessageFrame，status 帧同样会重复落库 + 重复唤醒，故也支持去重。 */
+  idempotency_key?: string;
   scope?: string[];
   summary_seq?: number | null;
   blocked_reason?: string | null;

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -2,6 +2,8 @@
 import {
   applyLiveConnection,
   BODY_LIMIT,
+  IDEMPOTENCY_KEY_MAX,
+  IDEMPOTENCY_WINDOW_MS,
   LOOP_GUARD_N,
   LOOP_GUARD_PARTY_N,
   MAX_WEBHOOKS_PER_CHANNEL,
@@ -88,7 +90,8 @@ interface WebhookDeliveryResult {
 }
 
 type SendOutcome =
-  | { ok: true; seq: number; frames: ServerFrame[] }
+  // deduped：命中幂等去重（#98）——seq/frames 来自原来那条已落库消息，调用方须跳过广播/唤醒等副作用
+  | { ok: true; seq: number; frames: ServerFrame[]; deduped?: boolean }
   | { ok: false; code: ErrorCode; message: string };
 type SendErrorOutcome = Extract<SendOutcome, { ok: false }>;
 
@@ -618,10 +621,18 @@ function sendRejectMessage(raw: unknown): string {
   return "invalid send payload";
 }
 
+// 幂等键（#98）：仅接受非空、长度受限的字符串；异常值静默丢弃（不因它拒收整条 send，向后兼容）。
+function parseIdempotencyKey(raw: unknown): string | undefined {
+  if (typeof raw !== "string") return undefined;
+  if (raw.length === 0 || raw.length > IDEMPOTENCY_KEY_MAX) return undefined;
+  return raw;
+}
+
 // rest body 与 ws send 帧共用的校验（rest 侧无 type 字段）
 function parseSendFrame(input: unknown): SendFrame | null {
   if (typeof input !== "object" || input === null) return null;
   const f = input as Record<string, unknown>;
+  const idempotencyKey = parseIdempotencyKey(f.idempotency_key);
   if (f.kind === "message") {
     if (typeof f.body !== "string") return null;
     const explicit = parseMentions(f.mentions);
@@ -650,6 +661,7 @@ function parseSendFrame(input: unknown): SendFrame | null {
       reply_to,
       ...(completionArtifact !== undefined ? { completion_artifact: completionArtifact } : {}),
       ...(completionArtifact !== undefined && replaces !== undefined ? { replaces } : {}),
+      ...(idempotencyKey !== undefined ? { idempotency_key: idempotencyKey } : {}),
     };
   }
   if (f.kind === "status") {
@@ -698,6 +710,7 @@ function parseSendFrame(input: unknown): SendFrame | null {
       ...(context !== undefined ? { context } : {}),
       ...(decision !== undefined ? { decision } : {}),
       ...(workflow !== undefined ? { workflow } : {}),
+      ...(idempotencyKey !== undefined ? { idempotency_key: idempotencyKey } : {}),
     };
   }
   return null;
@@ -859,6 +872,9 @@ export class ChannelDO extends Server<Env> {
       "ALTER TABLE messages ADD COLUMN sender_display_name TEXT",
       "ALTER TABLE messages ADD COLUMN sender_avatar_url TEXT",
       "ALTER TABLE messages ADD COLUMN sender_avatar_thumb TEXT",
+      // 幂等键（#98）：客户端每次发送带一个 ULID，服务端按 (sender_name, idempotency_key) 去重。
+      // 注：messages 表是 DO 内建 SQLite（ctx.storage.sql），不是 D1，故无需 worker/migrations 迁移文件。
+      "ALTER TABLE messages ADD COLUMN idempotency_key TEXT",
     ]) {
       try {
         sql.exec(ddl);
@@ -866,6 +882,8 @@ export class ChannelDO extends Server<Env> {
         // 列已存在
       }
     }
+    // 幂等去重查询走 (sender_name, idempotency_key)；NULL 键（老客户端/非幂等发送）不进有效查询路径。
+    sql.exec("CREATE INDEX IF NOT EXISTS idx_messages_idempotency ON messages(sender_name, idempotency_key)");
     sql.exec(`CREATE TABLE IF NOT EXISTS presence (
       name TEXT PRIMARY KEY,
       state TEXT NOT NULL,
@@ -1157,6 +1175,8 @@ export class ChannelDO extends Server<Env> {
       }
       // sent 先于广播到达发送方，客户端先推进游标再看到自己的回声
       this.sendFrame(connection, { type: "sent", seq: out.seq });
+      // 幂等去重命中（#98）：只回 sent（原 seq），不重复广播/唤醒。ws 发送目前不带 key，故常态为 false。
+      if (out.deduped) return;
       // 广播必须紧跟 INSERT，中间不能有任何 await（#114）：
       // 并发发送时 A 落库 seq=N 后若在这里等 D1，B 落库 N+1 先广播，watcher ack 了 N+1，
       // 后到的 N 就被客户端当作「已消费」永久丢弃（client.ts: seq <= cursor 静默丢），
@@ -2193,10 +2213,13 @@ export class ChannelDO extends Server<Env> {
           { status: ERROR_STATUS[out.code] },
         );
       }
-      // 同 ws 路径（#114）：先广播，再做与本条消息无关的连接清理
-      for (const f of out.frames) this.broadcastFrame(f);
-      await this.closeInactiveConnections();
-      await this.afterSend(out.frames[0] as MsgFrame);
+      // 幂等去重命中（#98）：首发时已广播/唤醒过，重发只回原 seq，绝不重复副作用
+      if (!out.deduped) {
+        // 同 ws 路径（#114）：先广播，再做与本条消息无关的连接清理
+        for (const f of out.frames) this.broadcastFrame(f);
+        await this.closeInactiveConnections();
+        await this.afterSend(out.frames[0] as MsgFrame);
+      }
       const sent = out.frames[0] as MsgFrame;
       return Response.json({
         seq: out.seq,
@@ -2388,6 +2411,23 @@ export class ChannelDO extends Server<Env> {
     if (!(await this.isTokenActive(identity.tokenHash))) {
       return { ok: false, code: "unauthorized", message: "invalid or revoked token" };
     }
+    // 幂等去重（#98）：必须在 rate/loop/workflow guard 与 INSERT 之前——重试是网络产物而非第二条消息，
+    // 不能重复消耗配额、不能重复触发熔断，更不能重复落库/重复唤醒。命中就原样返回首发那条的 seq。
+    // 窗口 IDEMPOTENCY_WINDOW_MS 内、同一 sender_name 的同一 key 才去重；DO 单线程 + 重试串行发生，
+    // SELECT→INSERT 之间无并发同键写入之虞。
+    if (frame.idempotency_key !== undefined) {
+      const priorRow = this.ctx.storage.sql
+        .exec(
+          "SELECT * FROM messages WHERE sender_name = ? AND idempotency_key = ? AND ts >= ? ORDER BY seq DESC LIMIT 1",
+          identity.name,
+          frame.idempotency_key,
+          Date.now() - IDEMPOTENCY_WINDOW_MS,
+        )
+        .toArray()[0];
+      if (priorRow !== undefined) {
+        return { ok: true, seq: Number(priorRow.seq), frames: [this.rowToFrame(priorRow)], deduped: true };
+      }
+    }
     const payload = frame.kind === "message" ? frame.body : frame.note;
     if (byteLength(payload) > BODY_LIMIT) {
       return { ok: false, code: "too_large", message: `body exceeds ${BODY_LIMIT} bytes` };
@@ -2527,9 +2567,9 @@ export class ChannelDO extends Server<Env> {
          state, note, status_scope_json, status_summary_seq, status_blocked_reason, status_context_json,
          status_decision_json, status_workflow_json, message_workflow_json,
          sender_role, sender_role_source, completion_artifact_json, completion_review_state, completion_review_policy,
-         completion_review_replaces_seq, ts
+         completion_review_replaces_seq, idempotency_key, ts
        )
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       seq,
       identity.name,
       identity.kind,
@@ -2560,6 +2600,7 @@ export class ChannelDO extends Server<Env> {
       msg.completion_review?.state ?? null,
       msg.completion_review?.policy ?? null,
       replacesSeq ?? null,
+      frame.idempotency_key ?? null,
       now,
     );
     let replacedUpdate: MessageUpdateFrame | undefined;

--- a/worker/test/idempotency.spec.ts
+++ b/worker/test/idempotency.spec.ts
@@ -1,0 +1,133 @@
+// 消息幂等键（#98）：客户端带 idempotency_key，服务端按 (sender_name, key) 去重。
+// 核心防线针对「服务端盲重试」——POST /messages 走 fetchChannelDO(retries=1)，
+// DO reset 后 clone 重发同一 body，命中已落库窗口即重复消息 + 重复唤醒。
+// 断言观测过程：重发后 messages 表只多一行、返回的 seq 与首发相同——不是只断言「没报错」。
+import { describe, expect, it } from "vitest";
+import { WsClient, api, createChannel, seedToken } from "./helpers";
+
+interface MsgLike {
+  seq: number;
+  kind: string;
+  body: string;
+  sender: { name: string; kind: string };
+}
+
+function send(slug: string, token: string, body: string, key?: string): Promise<Response> {
+  const payload = {
+    kind: "message",
+    body,
+    mentions: [] as string[],
+    reply_to: null,
+    ...(key === undefined ? {} : { idempotency_key: key }),
+  };
+  return api(`/api/channels/${slug}/messages`, token, {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}
+
+async function messages(slug: string, token: string): Promise<MsgLike[]> {
+  const res = await api(`/api/channels/${slug}/messages?since=0&limit=1000`, token);
+  const { messages } = (await res.json()) as { messages: MsgLike[] };
+  return messages.filter((m) => m.kind === "message");
+}
+
+describe("message idempotency (#98)", () => {
+  it("dedups a resend with the same key: same seq, exactly one row", async () => {
+    const { token } = await seedToken("agent");
+    const slug = await createChannel(token);
+    const key = crypto.randomUUID();
+
+    const first = await send(slug, token, "hello", key);
+    expect(first.status).toBe(200);
+    const seq1 = ((await first.json()) as { seq: number }).seq;
+
+    const second = await send(slug, token, "hello", key);
+    expect(second.status).toBe(200);
+    const seq2 = ((await second.json()) as { seq: number }).seq;
+
+    // 返回的是原来那条的 seq，不是新插入
+    expect(seq2).toBe(seq1);
+    // messages 表只多一行
+    const rows = await messages(slug, token);
+    expect(rows.filter((m) => m.body === "hello")).toHaveLength(1);
+  });
+
+  it("control: without a key, two identical sends both insert", async () => {
+    const { token } = await seedToken("agent");
+    const slug = await createChannel(token);
+
+    const first = await send(slug, token, "dup");
+    const seq1 = ((await first.json()) as { seq: number }).seq;
+    const second = await send(slug, token, "dup");
+    const seq2 = ((await second.json()) as { seq: number }).seq;
+
+    expect(seq2).toBe(seq1 + 1);
+    const rows = await messages(slug, token);
+    expect(rows.filter((m) => m.body === "dup")).toHaveLength(2);
+  });
+
+  it("different keys are not deduped", async () => {
+    const { token } = await seedToken("agent");
+    const slug = await createChannel(token);
+
+    const seq1 = ((await (await send(slug, token, "x", crypto.randomUUID())).json()) as { seq: number }).seq;
+    const seq2 = ((await (await send(slug, token, "x", crypto.randomUUID())).json()) as { seq: number }).seq;
+
+    expect(seq2).toBe(seq1 + 1);
+    expect((await messages(slug, token)).filter((m) => m.body === "x")).toHaveLength(2);
+  });
+
+  it("dedup is scoped per sender: same key from two senders both insert", async () => {
+    const { token: tokenA } = await seedToken("agent");
+    const { token: tokenB } = await seedToken("agent");
+    const slug = await createChannel(tokenA);
+    const key = crypto.randomUUID();
+
+    const resA = await send(slug, tokenA, "shared-key", key);
+    expect(resA.status).toBe(200);
+    const resB = await send(slug, tokenB, "shared-key", key);
+    expect(resB.status).toBe(200);
+
+    const seqA = ((await resA.json()) as { seq: number }).seq;
+    const seqB = ((await resB.json()) as { seq: number }).seq;
+    expect(seqB).not.toBe(seqA);
+    expect((await messages(slug, tokenA)).filter((m) => m.body === "shared-key")).toHaveLength(2);
+  });
+
+  it("deduped resend does not re-broadcast (no double delivery / no double wake)", async () => {
+    const { token } = await seedToken("agent");
+    const slug = await createChannel(token);
+    // 房主自己订阅：绕开私有频道 ACL；观测广播是否重复。
+    const ws = await WsClient.open(slug, token);
+    const key = crypto.randomUUID();
+
+    const first = await send(slug, token, "once", key);
+    expect(first.status).toBe(200);
+    const echoed = await ws.nextOfType("msg");
+    expect(echoed.body).toBe("once");
+
+    // 同键重发命中去重：不得再广播第二条（afterSend 唤醒同在此 if 块内，一并跳过）
+    const second = await send(slug, token, "once", key);
+    expect(second.status).toBe(200);
+    await expect(ws.nextOfType("msg", 500)).rejects.toThrow();
+    ws.close();
+  });
+
+  it("dedups status sends too (status frame also carries a key)", async () => {
+    const { token } = await seedToken("agent");
+    const slug = await createChannel(token);
+    const key = crypto.randomUUID();
+    const statusBody = { kind: "status", state: "working", note: "on it", idempotency_key: key };
+    const sendStatus = () =>
+      api(`/api/channels/${slug}/messages`, token, { method: "POST", body: JSON.stringify(statusBody) });
+
+    const seq1 = ((await (await sendStatus()).json()) as { seq: number }).seq;
+    const seq2 = ((await (await sendStatus()).json()) as { seq: number }).seq;
+    expect(seq2).toBe(seq1);
+
+    const res = await api(`/api/channels/${slug}/messages?since=0&limit=1000`, token);
+    const { messages } = (await res.json()) as { messages: { kind: string; note: string | null }[] };
+    expect(messages.filter((m) => m.kind === "status" && m.note === "on it")).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
> 频道身份：leo-codex-main-dev（#agentparty）

Closes #98

## 根因（实测确认「服务端盲重试」前提成立）

写路径确实在盲重试非幂等写：

- `worker/src/index.ts:129` `fetchChannelDO(..., retries = 1)`：`stub.fetch` 抛 `isDurableObjectReset`（`index.ts:117`，匹配 "invalidating this Durable Object … Please retry"）时，`request.clone()` **重发同一请求**。
- `worker/src/index.ts:4228` POST `/api/channels/:slug/messages` 正是用它转发到 DO。
- `worker/src/do.ts:2423` `const seq = this.lastSeq() + 1;` → `do.ts:2523` `INSERT INTO messages`：**无任何去重**。
- 失败场景：DO 处理完 POST、`INSERT` 已落库，随后 DO 在响应途中被 reset → runtime 向 worker 抛 reset → `fetchChannelDO` clone 重发 → `handleSend` 再跑一遍 → 第二行 seq=lastSeq+1。结果：**频道两条一模一样的消息、目标 agent 被 `afterSend` 唤醒两次、webhook/mention 副作用×2**，而客户端拿到的是超时。
- 客户端侧 `cli/src/rest.ts` 的 `req()` 目前只有 30s 超时（#116），本身不重试；但只要 body 带稳定幂等键，任何层的重发（含未来的客户端重试）都能被去重。

证据分级：`fetchChannelDO` 重试路径、INSERT 无去重 = **读代码确认**；去重生效、重发只多一行/同 seq/不重复广播 = **实测**（vitest，见下）。

## 方案

- **客户端**（`cli/src/rest.ts`）：`postMessage` 每次发送生成一个 ULID 幂等键（48-bit 毫秒时间戳 + 80-bit 随机，无依赖，`crypto.getRandomValues`），随 body 发送。重试携带同一 body 即同一键。
- **协议**（`shared/src/protocol.ts`）：`SendMessageFrame` / `SendStatusFrame` 增 `idempotency_key?: string`（status 帧同样会重复落库+重复唤醒，故也支持）。
- **服务端**（`worker/src/do.ts`）：`handleSend` 在 **rate / loop guard / workflow guard / INSERT 之前** 按 `(sender_name, idempotency_key)` 查最近窗口内是否已有该键的消息；命中就返回**原来那条的 seq**，`deduped: true`。调用方（POST + WS 两处）据此**跳过广播与 `afterSend`（唤醒）**。重试因此不重复消耗配额、不重复触发熔断、不重复副作用。

### 去重窗口 = 10 分钟（`IDEMPOTENCY_WINDOW_MS`，写进 `shared/src/protocol.ts`）

只在最近 10 分钟内、同一 sender 的同一键上去重。为什么是 10 分钟：足以覆盖「客户端 30s 超时 + 重试 + 服务端 `fetchChannelDO` 的 DO-reset 重发」，并留足时钟偏移余量；越界后同一键可被安全重用（实践中客户端每次发送都生成新 ULID，不会重用）。另有 `RETAIN_N`（10,000 条）保留上限做二次兜底：更老的消息连同其键一起被裁剪。

### 无需 D1 migration

`messages` 表是 **DO 内建 SQLite**（`ctx.storage.sql`），不是 D1。列通过 `do.ts` 里既有的 `ALTER TABLE messages ADD COLUMN` 幂等模式添加（同旁边一堆 ADD COLUMN），并建 `idx_messages_idempotency(sender_name, idempotency_key)`。因此**不碰 `worker/migrations/`**，天然避开 #112 的编号重复坑。

## TDD

先写 4 条 worker + 1 条 CLI 测试并**亲眼看红**：
- worker：同键重发 `expected 2 to be 1`（第二次仍插新行，seq2=seq1+1，非缺失键拼写错误）——而 control（无键两发=两行）、异键、跨 sender 三条同时**绿**，证明红点精确隔离到「同键去重」这一缺失行为。
- CLI：`idempotency_key` 为 `undefined`。

断言观测过程：「重发后 `messages` 表只多一行」「返回 seq 与首发相同」「订阅 ws 不再收到第二次广播」，不是只断言「没报错」。

## 变异表（逐个接线点拆掉，确认精确变红）

| # | 接线点 (file) | 变异 | 精确变红的测试 |
|---|---|---|---|
| M1 | `cli/src/rest.ts` postMessage 挂键 | 不挂 key | CLI `attaches a non-empty idempotency_key` ✗ |
| M2 | `do.ts` parseSendFrame **message** 分支提键 | 删该分支 spread | msg 去重 ✗ + 广播跳过 ✗；**status 去重仍绿**（分支隔离） |
| M3 | `do.ts` parseSendFrame **status** 分支提键 | 删该分支 spread | 仅 status 去重 ✗；三条 msg 测试全绿 |
| M6 | `do.ts` handleSend 去重查+早返 | 关掉该块 | msg 去重 ✗ + 广播跳过 ✗ + status 去重 ✗；control/异键/跨 sender 绿 |
| M7 | `do.ts` INSERT 绑 `idempotency_key` | 改绑 null | 三条去重全 ✗（SELECT 永不命中） |
| M8 | `do.ts` POST 处理器 `if (!out.deduped)` | 改 `if(true)`（照旧广播） | 仅「广播跳过」✗；seq/行数测试仍绿（去重逻辑仍拦住第二次 INSERT） |

**零测试变红（如实说明）：**
- M9 `do.ts` WS onMessage `if (out.deduped) return;`：删掉→**0 条变红**。WS send 目前不带幂等键，此路不可达——**保留作防御**（未来 WS 携带键时兜底），已在注释标注。
- `CREATE INDEX idx_messages_idempotency`：**性能行**，删掉不改变正确性、0 条变红。保留以避免去重 SELECT 全表扫。

## 门禁

- 新测试：worker `test/idempotency.spec.ts` 6/6 ✓；CLI `test/idempotency.test.ts` 1/1 ✓
- CLI 全量：`bun test` **379 pass / 0 fail**（改了两处历史用例：`cli.test.ts` 两条、`m3.test.ts` 一条——它们对发出 body 做精确匹配，现放宽为 `objectContaining` / `toMatchObject` 以容忍随机键；`m3` 补断言键为 string）
- worker 全量：`bunx vitest run` → 300 pass，唯一失败是 `tokens.spec.ts > revocation …`（满载 29896ms 超时），**单独重跑 9/9 绿 37ms**——即 #185/#200 已知 flaky，与本改动无关
- 类型：`cd cli && bunx tsc --noEmit`、`cd worker && bunx tsc --noEmit` 均 EXIT=0

## 遗留问题

- 幂等只对**携带同一键的重发**生效：服务端盲重试（本 issue 主因）、进程内客户端重试均已覆盖；但**人类/agent 另起一次 `party send`** 会生成新键，不去重（属新意图，符合预期）。
- WS send 路径尚未生成幂等键（长连接，重试语义不同）；已留 `deduped` 防御位，接入成本低但本 PR 未做。
- status 去重同样生效，但 presence 的 upsert 是 `ON CONFLICT DO UPDATE`（本就幂等），去重主要价值在避免重复 status 行 + 重复唤醒。
