### PR TITLE
fix(web): ws 心跳校验 pong，静默死连接不再误显 open

### DIFF
--- a/web/src/lib/ws.heartbeat.test.ts
+++ b/web/src/lib/ws.heartbeat.test.ts
@@ -1,0 +1,218 @@
+// issue #130 回归测试：ws 心跳发了 ping 必须在有界时间内收到 pong（或任何回帧），否则判定
+// TCP 半开死连接——主动 close + 触发重连。绝不能把"沉默"当成健康、继续显示 open。
+//
+// 观测的是"过程"而非终值：
+//   - 死连接下断言 socket 真的被 close 了、状态真的翻成 reconnecting、退避定时器真的排到并拉起新连接；
+//   - 健康连接（每个 interval 都回 pong）下断言 socket 从不被 close、状态一直是 open。
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { ServerFrame } from "@agentparty/shared";
+import { ChannelSocket } from "./ws";
+
+// 受控时钟：ws.ts 的看门狗用 Date.now() 算 lastFrameAt 新鲜度，测试用它推进"时间"。
+let clock = 0;
+const realDateNow = Date.now;
+
+// 捕获 window.setInterval 的心跳回调，fireHeartbeat() 手动放行一次 tick。
+let intervalCbs: Map<number, () => void>;
+let intervalSeq: number;
+function fireHeartbeat() {
+  for (const cb of [...intervalCbs.values()]) cb();
+}
+
+// 捕获 window.setTimeout 的重连回调，flushTimers() 手动放行。
+let pendingTimers: Array<() => void>;
+function flushTimers() {
+  const due = pendingTimers.splice(0);
+  for (const fn of due) fn();
+}
+
+class FakeSocket {
+  static instances: FakeSocket[] = [];
+  static OPEN = 1;
+  static reset() {
+    FakeSocket.instances = [];
+  }
+  readyState = 0; // CONNECTING
+  onopen: (() => void) | null = null;
+  onmessage: ((ev: { data: unknown }) => void) | null = null;
+  onclose: ((ev: { code: number; reason: string }) => void) | null = null;
+  sent: string[] = [];
+  closeCalls: Array<{ code?: number; reason?: string }> = [];
+  constructor(
+    public url: string,
+    public protocols?: string[],
+  ) {
+    FakeSocket.instances.push(this);
+  }
+  send(data: string) {
+    this.sent.push(data);
+  }
+  // 真实浏览器 close() 不会同步触发 onclose；看门狗那条路径会先摘掉 onclose 再 close，
+  // 所以这里只记录 close 被调用（不回调 onclose）。
+  close(code?: number, reason?: string) {
+    this.readyState = 3; // CLOSED
+    this.closeCalls.push({ code, reason });
+  }
+  get closed() {
+    return this.closeCalls.length > 0;
+  }
+  open() {
+    this.readyState = FakeSocket.OPEN;
+    this.onopen?.();
+  }
+  deliver(frame: ServerFrame | { type: string }) {
+    this.onmessage?.({ data: JSON.stringify(frame) });
+  }
+  pings() {
+    return this.sent.filter((s) => s === '{"type":"ping"}');
+  }
+}
+
+function welcome(): ServerFrame {
+  return {
+    type: "welcome",
+    channel: "demo",
+    self: "me",
+    participants: [],
+    last_seq: 0,
+    last_rev_seq: 0,
+    presence: [],
+  } as ServerFrame;
+}
+
+// 记录 onStatus 全过程，断言"翻成 reconnecting"，而不是只看最后一帧
+function statusRecorder() {
+  const statuses: string[] = [];
+  return {
+    statuses,
+    handlers: {
+      onFrame: () => {},
+      onStatus: (s: string) => statuses.push(s),
+      onFatal: () => {},
+    },
+  };
+}
+
+beforeEach(() => {
+  clock = 1_000_000;
+  Date.now = () => clock;
+  FakeSocket.reset();
+  intervalCbs = new Map();
+  intervalSeq = 0;
+  pendingTimers = [];
+  (globalThis as unknown as { WebSocket: typeof FakeSocket }).WebSocket = FakeSocket;
+  (globalThis as unknown as { location: { protocol: string; host: string } }).location = {
+    protocol: "http:",
+    host: "localhost",
+  };
+  (globalThis as unknown as { window: unknown }).window = {
+    setInterval: (fn: () => void) => {
+      const id = ++intervalSeq;
+      intervalCbs.set(id, fn);
+      return id;
+    },
+    clearInterval: (id: number) => {
+      intervalCbs.delete(id);
+    },
+    setTimeout: (fn: () => void) => {
+      pendingTimers.push(fn);
+      return pendingTimers.length;
+    },
+    clearTimeout: () => {},
+  };
+});
+
+afterEach(() => {
+  Date.now = realDateNow;
+  Reflect.deleteProperty(globalThis, "WebSocket");
+  Reflect.deleteProperty(globalThis, "window");
+  Reflect.deleteProperty(globalThis, "location");
+});
+
+const PING_INTERVAL = 25_000;
+
+describe("ChannelSocket 心跳 pong 看门狗 (issue #130)", () => {
+  test("静默死连接：ping 发出去但收不到 pong → 主动 close + 翻 reconnecting + 拉起新连接", () => {
+    const { statuses, handlers } = statusRecorder();
+    const sock = new ChannelSocket("demo", "tok", handlers);
+    sock.connect();
+    const s0 = FakeSocket.instances[0]!;
+    s0.open();
+    s0.deliver(welcome()); // 最后一次收到帧就停在这里（模拟随后 TCP 半开、彻底沉默）
+
+    // 一路推进时间、逐个 tick 放行心跳，但从不投递 pong。
+    // 看门狗阈值 = 2×interval：直到 now - lastFrameAt 超过它才判死。
+    for (let i = 1; i <= 4 && !s0.closed; i++) {
+      clock += PING_INTERVAL;
+      fireHeartbeat();
+    }
+
+    // 过程断言 1：死连接真的被 close 了（不是只改了个状态字段）
+    expect(s0.closed).toBe(true);
+    // 过程断言 2：至少发过 ping（证明确实在心跳，只是没人应答）
+    expect(s0.pings().length).toBeGreaterThan(0);
+    // 过程断言 3：状态真的从 open 翻成了 reconnecting（不再对用户谎报 open）
+    expect(statuses).toContain("open");
+    expect(statuses[statuses.length - 1]).toBe("reconnecting");
+
+    // 过程断言 4：重连真的发起——退避定时器排到后拉起了一条新连接
+    expect(FakeSocket.instances.length).toBe(1);
+    flushTimers();
+    expect(FakeSocket.instances.length).toBe(2);
+    expect(FakeSocket.instances[1]).toBeDefined();
+
+    sock.dispose();
+  });
+
+  test("健康连接：每个 interval 都回 pong → socket 从不被 close，状态始终 open", () => {
+    const { statuses, handlers } = statusRecorder();
+    const sock = new ChannelSocket("demo", "tok", handlers);
+    sock.connect();
+    const s0 = FakeSocket.instances[0]!;
+    s0.open();
+    s0.deliver(welcome());
+
+    // 6 个心跳周期，每次 tick 后服务端如常回 pong
+    for (let i = 0; i < 6; i++) {
+      clock += PING_INTERVAL;
+      fireHeartbeat();
+      s0.deliver({ type: "pong" }); // do 的 auto-response
+    }
+
+    expect(s0.closed).toBe(false);
+    // 全程只有一个 socket，没有误触发重连
+    expect(FakeSocket.instances.length).toBe(1);
+    // 状态从没翻成 reconnecting
+    expect(statuses).not.toContain("reconnecting");
+    expect(statuses[statuses.length - 1]).toBe("open");
+    // 确实一直在发 ping（心跳没被误停）
+    expect(s0.pings().length).toBe(6);
+
+    sock.dispose();
+  });
+
+  test("连上后迟迟没有 welcome/任何帧：看门狗以 open 时刻为基线，首个周期内不误杀、超阈值后照样判死", () => {
+    const { handlers } = statusRecorder();
+    const sock = new ChannelSocket("demo", "tok", handlers);
+    sock.connect();
+    const s0 = FakeSocket.instances[0]!;
+    s0.open(); // 握手成功，但服务端此后再没发过任何帧（含 welcome）
+
+    // 第 1 个周期（25s < 2×interval）：open 时刻是新鲜基线，给足宽限，不能误杀。
+    // 若 onopen 没把 lastFrameAt 初始化成 open 时刻（退回字段默认 0），这里会在首个 tick 立刻判死。
+    clock += PING_INTERVAL;
+    fireHeartbeat();
+    expect(s0.closed).toBe(false);
+
+    // 继续沉默越过阈值：看门狗完全不依赖"收到过帧"，照样判死 + 重连（沉默 ≠ 健康）。
+    for (let i = 0; i < 3 && !s0.closed; i++) {
+      clock += PING_INTERVAL;
+      fireHeartbeat();
+    }
+    expect(s0.closed).toBe(true);
+    flushTimers();
+    expect(FakeSocket.instances.length).toBe(2);
+
+    sock.dispose();
+  });
+});

--- a/web/src/lib/ws.ts
+++ b/web/src/lib/ws.ts
@@ -7,6 +7,11 @@ export type SocketStatus = "connecting" | "open" | "reconnecting" | "closed";
 export type FatalReason = "revoked" | "archived" | "forbidden";
 
 const PING_INTERVAL_MS = 25_000;
+// 静默死连接看门狗阈值（issue #130）。健康连接下 do 的 setWebSocketAutoResponse 会对每个 ping 即时
+// 回 pong，所以每个 interval 都会刷新 lastFrameAt。取 2×interval：容忍一整个心跳周期的抖动/单帧丢失，
+// 但连续两个周期（含至少一个完整 ping→pong 往返）一帧不回，就判定链路已死。取值直接采纳 issue #130
+// 的建议（"lastFrameAt 超 2×interval 主动 close"），也与 do 判 offline 的 60s 无帧同数量级、略更灵敏。
+const PONG_TIMEOUT_MS = 2 * PING_INTERVAL_MS;
 const BACKOFF_MIN_MS = 1_000;
 const BACKOFF_MAX_MS = 30_000;
 
@@ -38,6 +43,7 @@ export class ChannelSocket {
   private revSeeded = false; // 首个 welcome 是否已用 last_rev_seq 播种 revCursor
   private backoff = BACKOFF_MIN_MS;
   private pingTimer: number | null = null;
+  private lastFrameAt = 0; // 最近一次收到任何入站帧（含 pong）的时刻，心跳看门狗判活用（issue #130）
   private reconnectTimer: number | null = null;
   private everConnected = false;
   private handshakeFails = 0; // 连续「从未 open 就被关」的次数
@@ -71,18 +77,30 @@ export class ChannelSocket {
       this.everConnected = true;
       this.handshakeFails = 0;
       this.backoff = BACKOFF_MIN_MS;
+      this.lastFrameAt = Date.now(); // 看门狗基线：刚连上视为"此刻收到过帧"，避免首个周期误判死连接
       this.handlers.onStatus("open");
       // hello 等 welcome 到了再发（见 onmessage）：welcome.last_rev_seq 作 since_rev，
       // 服务端就不会把全部历史修订快照无条件重放进来——IM 窗口模式下，一条被编辑的
       // 远古消息会被插到窗口最前，导致上翻分页从它往下、中段历史永久跳过（review P1）。
       // 字面量须与 do 的 setWebSocketAutoResponse 配对，不唤醒 do
       this.pingTimer = window.setInterval(() => {
-        if (ws.readyState === WebSocket.OPEN) ws.send('{"type":"ping"}');
+        if (ws.readyState !== WebSocket.OPEN) return;
+        // 静默死连接（TCP 半开）看门狗：健康连接下每个 ping 都会被 do 即时 pong 回来刷新 lastFrameAt。
+        // 若连续 PONG_TIMEOUT_MS 一帧未回（含 pong），说明发出去的 ping 全部石沉大海——链路已死但
+        // readyState 仍是 OPEN、onclose 迟迟不来。此时必须主动 close + 重连，绝不能把"沉默"当成健康
+        // 继续对用户显示 open（issue #130：一个 supervisor 挂着却收不到消息，presence 还显示在线）。
+        if (Date.now() - this.lastFrameAt > PONG_TIMEOUT_MS) {
+          this.handleStaleConnection(ws);
+          return;
+        }
+        ws.send('{"type":"ping"}');
       }, PING_INTERVAL_MS);
     };
 
     ws.onmessage = (ev) => {
       if (typeof ev.data !== "string") return;
+      // 任何入站帧（含 pong）都证明链路还活着 → 刷新看门狗时钟（issue #130）
+      this.lastFrameAt = Date.now();
       let frame: ServerFrame;
       try {
         frame = JSON.parse(ev.data) as ServerFrame;
@@ -171,6 +189,26 @@ export class ChannelSocket {
   // 修订游标只前移：修订快照是幂等展示事件，收到即视为已消费（不等 ack，与 CLI client.ts 对齐）。
   private advanceRev(rev: number | undefined) {
     if (typeof rev === "number" && rev > this.revCursor) this.revCursor = rev;
+  }
+
+  // 看门狗判定连接已死（发了 ping 但 PONG_TIMEOUT_MS 内无任何回帧）：主动收尾并自驱重连。
+  // 先摘掉 handler 再 close——半开死连接的 onclose 可能迟迟不触发，摘掉后既不依赖它，也防止 close()
+  // 迟到的 onclose 又走一遍 scheduleReconnect 造成双连接。收尾等价于 onclose 的 transient 分支
+  // （opened=true 时的非 1008 断线）：翻 reconnecting + 退避重连（issue #130）。
+  private handleStaleConnection(ws: WebSocket) {
+    this.clearPing();
+    ws.onopen = null;
+    ws.onmessage = null;
+    ws.onclose = null;
+    try {
+      ws.close(4000, "stale");
+    } catch {
+      // 已处于 CLOSING/CLOSED，忽略
+    }
+    if (this.ws === ws) this.ws = null;
+    if (this.disposed) return;
+    this.handlers.onStatus("reconnecting");
+    this.scheduleReconnect();
   }
 
   private clearPing() {


### PR DESCRIPTION
> 频道身份：leo-codex-main-dev（#agentparty）

Closes #130

## 根因

`web/src/lib/ws.ts`（改前 79-81 行）的心跳只发 ping、从不校验 pong：

```ts
this.pingTimer = window.setInterval(() => {
  if (ws.readyState === WebSocket.OPEN) ws.send('{"type":"ping"}');
}, PING_INTERVAL_MS);
```

服务端其实**会**回 pong——`worker/src/do.ts:996-997` 用 `setWebSocketAutoResponse('{"type":"ping"}','{"type":"pong"}')` 即时应答，`do.ts:1071-1073` 兜底其余序列化。问题是客户端收到 pong 后什么都不做，也从不检查"该来的 pong 没来"。

TCP 半开（silent dead connection）下，`readyState` 仍是 `OPEN`、`onclose` 迟迟不触发，前端窗口期内继续显示 `open`。这正是本仓库反复踩的坑：supervisor 挂着但收不到消息，presence 还显示在线。**把"沉默"当成了健康。**

## 修法

心跳看门狗（观测"有没有回帧"，而不是"socket 还 open 吗"）：

- 新增 `lastFrameAt`：`onmessage` 里任何入站帧（含 pong）都刷新它；`onopen` 里以连上时刻做基线。
- 每个心跳 tick **先检查**：`Date.now() - lastFrameAt > PONG_TIMEOUT_MS` → 判定链路已死 → `handleStaleConnection()`：先摘掉 `onopen/onmessage/onclose` 再 `ws.close(4000,"stale")`，然后 `onStatus("reconnecting")` + `scheduleReconnect()`。
- 先摘 handler 再 close：半开死连接的 `onclose` 可能迟迟不来，摘掉后既不依赖它，也避免 `close()` 迟到的 `onclose` 再走一遍 `scheduleReconnect` 造成双连接。

## 阈值取值理由

`PONG_TIMEOUT_MS = 2 * PING_INTERVAL_MS = 50s`（`PING_INTERVAL_MS` 沿用现有 25s）。

- 健康连接下 do 对每个 ping 即时回 pong，`lastFrameAt` 每个 interval 都刷新，稳态新鲜度永远 ≤ 一个 interval。
- 取 2×：容忍一整个心跳周期的调度抖动 / 单帧丢失，但**连续两个周期**（其间至少一个完整 ping→pong 往返）一帧不回，就判死。
- 直接采纳 issue #130 作者建议（"lastFrameAt 超 2×interval 主动 close"）；与 `do.ts:1198` 判 offline 的"60s 无帧"同数量级、略更灵敏（前端更早自愈，避免用户干等）。
- 写成具名常量 + 注释，不是隐形魔法数。

## 变异表（逐接线点）

每处接线点单独拆掉，跑 `bun test src/lib/ws.heartbeat.test.ts`，确认对应测试**精确变红**。全部实测，非推断。

| # | 接线点 | 变异 | 变红的测试 | 结论 |
|---|--------|------|-----------|------|
| M1 | ping tick 里的 staleness 检查 | `if (…> PONG_TIMEOUT_MS)` → `if (false)` | 静默死连接 | 精确捕获（检测逻辑） |
| M2 | `onmessage` 刷新 `lastFrameAt` | 删掉该行 | 健康连接 | 精确捕获（删了会误杀健康连接） |
| M3 | `onopen` 基线初始化 `lastFrameAt` | 删掉该行 | welcome-less 连接 | 精确捕获**（首轮：0 条变红——见下）** |
| M4 | `ws.close(4000,"stale")` | 删掉 | 静默死连接 + welcome-less | 精确捕获 |
| M5 | `scheduleReconnect()` | 删掉 | 静默死连接 + welcome-less | 精确捕获 |
| M6 | `onStatus("reconnecting")` | 删掉 | 静默死连接 | 精确捕获 |
| M7 | 阈值 `2×` | 改成 `10×`（几乎不触发） | 静默死连接 + welcome-less | 精确捕获（钉住取值） |

**M3 首轮零变红 → 补测，不是删代码。** 第一版只有 2 个测试时，删掉 `onopen` 的基线初始化**零条测试变红**——因为两个测试里 `welcome` 都在 `open` 之后立刻到达、顺手把 `lastFrameAt` 刷成了当前时刻，基线初始化被兜住了。按团队纪律排查后判定这不是死代码：它守的是"握手成功但服务端迟迟不发 welcome/任何帧"的边界——没有它，`lastFrameAt` 停在字段默认值 `0`，首个 tick 就会 `Date.now()-0` 巨大 > 阈值、把刚连上的连接**立刻误杀**。于是补了第 3 个测试（连上后不投递任何帧：断言首个周期内不误杀、越过阈值后照样判死），M3 随即被精确捕获。

## 门禁输出（实测）

```
# web 全量测试
$ cd web && bun test
 299 pass  0 fail  (35 files)

# 心跳新测试单独
$ bun test src/lib/ws.heartbeat.test.ts
 3 pass  0 fail

# 类型检查
$ bunx tsc --noEmit
 (exit 0)
```

改动仅 `web/src/lib/ws.ts`（+39 -1）+ 新测试文件 `web/src/lib/ws.heartbeat.test.ts`。未碰 `Channel.tsx`（PR #217 在改）、未碰 `serve.ts/watch.ts/config.ts/do.ts`。

## 遗留问题 / 发现

- **CLI 侧 `cli/src/client.ts` 有同一个 bug（读代码推断，非实测）。** 它的心跳（`client.ts:195-197`）同样只 `sock.send({type:"ping"})`、`onmessage` 从不追踪 pong/lastFrame、`onclose` 也没有看门狗。同样的 TCP 半开场景下，`watch --follow` 会静默挂起不重连。**本 PR 不动 `cli/src/client.ts`**（它在别人未合并的 PR 影响面里），建议**单独开 issue** 用同一套 `lastFrameAt` 看门狗修 CLI。证据分级：web 侧全部实测；CLI 侧是读 `client.ts` + `do.ts` 推断，未跑真实半开连接复现。
- 本修复无法覆盖"onopen 后 `close(4000)` 在极端浏览器上不触发任何清理"的假想场景——但已通过"先摘 handler 再 close + 自驱 `scheduleReconnect`"绕开对 `onclose` 的依赖，不再把命交回给那条不可靠的传输通道。
