### PR TITLE
feat(cli): MCP 接入路径能读频道 charter，补 party_charter 工具与 party://charter 资源 (#134)

### DIFF
--- a/cli/src/commands/mcp.ts
+++ b/cli/src/commands/mcp.ts
@@ -244,7 +244,19 @@ export function createMcpServer(defaultChannel?: string): McpServer {
     },
     async ({ channel }) => {
       try {
-        const resolved = normalizeChannel(channel, defaultChannel);
+        // charter 的三条路径（tool / resource / whoami 提示）必须恒等：resource 与提示在启动时
+        // 静态绑定 boundChannel（MCP resources 无法热更新），所以 tool 不传 channel 时也用同一个
+        // boundChannel，而不是每次重解析 cwd 绑定——否则运行中 rebind 会让 tool 漂到新频道、
+        // 资源/提示仍指旧频道，两者都不报错。显式传 channel 参数仍优先（保留读任意频道的能力）。
+        let resolved: string;
+        if (channel !== undefined) {
+          if (!isSlug(channel)) throw new Error("channel must match [a-z0-9][a-z0-9-]{0,63}");
+          resolved = channel;
+        } else if (boundChannel !== undefined) {
+          resolved = boundChannel;
+        } else {
+          throw new Error("no channel, pass channel or bind with: party init --channel C");
+        }
         return ok(await charterData(resolved));
       } catch (e) {
         return fail(e instanceof Error ? e.message : String(e));

--- a/cli/src/commands/mcp.ts
+++ b/cli/src/commands/mcp.ts
@@ -1,7 +1,7 @@
 // party mcp — stdio MCP server exposing AgentParty as structured tools.
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import type { MsgFrame, StatusState, TaskAssigneeKind, TaskState } from "@agentparty/shared";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
 import pkg from "../../package.json" with { type: "json" };
@@ -10,6 +10,7 @@ import { jsonFrame } from "../json";
 import { resolveAuth, resolveAuthDetailed } from "../oidc-cli";
 import {
   createTask,
+  fetchChannelCharter,
   fetchMe,
   fetchMessages,
   fetchPresence,
@@ -35,6 +36,7 @@ Example:
 
 Tools:
   party_whoami
+  party_charter
   party_channels
   party_send
   party_status
@@ -52,7 +54,11 @@ Tools:
   task_block
   party_spawn_worker
   party_watch_once
-  party_wake_test`;
+  party_wake_test
+
+Resources:
+  party://charter               charter for the bound --channel (用前必读)
+  party://{channel}/charter     charter for any channel by slug`;
 
 const StateSchema = z.enum(["working", "waiting", "blocked", "done"]);
 const TaskStateSchema = z.enum(["triage", "backlog", "assigned", "in_progress", "needs_review", "done", "blocked"]);
@@ -171,6 +177,24 @@ function capturedResult(name: string, captured: { code: number; stdout: string; 
   return captured.code === 0 ? ok(data) : { ...fail(captured.stderr || captured.stdout || `${name} failed`), structuredContent: data };
 }
 
+// 被 @ 唤起时的第一屏提示：MCP 接入的 agent 没有 serve 的 context file，
+// 靠这条把它引到 charter（用 party_charter 工具或 party://charter 资源读频道约定/scope）。
+const CHARTER_REMINDER =
+  "read the channel charter first (party_charter tool or party://charter resource) — it defines this channel's scope and etiquette before you act.";
+
+async function charterData(channel: string): Promise<Record<string, unknown>> {
+  const cfg = await auth();
+  const body = await fetchChannelCharter(cfg.server, cfg.token, channel);
+  return { type: "charter", channel, ...body };
+}
+
+function charterText(data: Record<string, unknown>): string {
+  const charter = data.charter;
+  return typeof charter === "string" && charter.length > 0
+    ? charter
+    : `# ${String(data.channel)} charter not set (rev ${String(data.charter_rev ?? 0)})`;
+}
+
 export function createMcpServer(defaultChannel?: string): McpServer {
   const server = new McpServer({
     name: "agentparty",
@@ -188,7 +212,27 @@ export function createMcpServer(defaultChannel?: string): McpServer {
       try {
         const cfg = await auth();
         const me = await fetchMe(cfg.server, cfg.token);
-        return ok({ type: "me", server: cfg.server, identity: me });
+        return ok({ type: "me", server: cfg.server, identity: me, protocol_reminder: CHARTER_REMINDER });
+      } catch (e) {
+        return fail(e instanceof Error ? e.message : String(e));
+      }
+    },
+  );
+
+  server.registerTool(
+    "party_charter",
+    {
+      title: "Read channel charter",
+      description:
+        "Read the channel charter / 用前必读 — the channel's scope, etiquette, roles, and current host. Call this FIRST when you are @-woken into a channel, before acting.",
+      inputSchema: {
+        channel: z.string().optional().describe("Channel slug. Defaults to the workspace-bound channel."),
+      },
+    },
+    async ({ channel }) => {
+      try {
+        const resolved = normalizeChannel(channel, defaultChannel);
+        return ok(await charterData(resolved));
       } catch (e) {
         return fail(e instanceof Error ? e.message : String(e));
       }
@@ -745,6 +789,42 @@ export function createMcpServer(defaultChannel?: string): McpServer {
       ];
       const captured = await captureCommand(async () => (await import("./wake")).run(argv));
       return capturedResult("wake_test", captured);
+    },
+  );
+
+  // Resources make the charter machine-discoverable via resources/list (#136) and give the
+  // MCP接入路径 a first-screen "用前必读" it otherwise never sees (#134). The concrete
+  // party://charter is only registered when a default channel is pinned, so resources/list
+  // stays meaningful; any channel is still readable through the template below.
+  if (defaultChannel !== undefined) {
+    server.registerResource(
+      "channel-charter",
+      "party://charter",
+      {
+        title: `Charter for #${defaultChannel}`,
+        description: "The bound channel's charter / 用前必读: scope, etiquette, roles, current host. Read before acting.",
+        mimeType: "text/markdown",
+      },
+      async (uri) => {
+        const data = await charterData(defaultChannel);
+        return { contents: [{ uri: uri.href, mimeType: "text/markdown", text: charterText(data) }] };
+      },
+    );
+  }
+
+  server.registerResource(
+    "channel-charter-by-slug",
+    new ResourceTemplate("party://{channel}/charter", { list: undefined }),
+    {
+      title: "Channel charter by slug",
+      description: "Read any channel's charter / 用前必读 by slug: party://<channel>/charter.",
+      mimeType: "text/markdown",
+    },
+    async (uri, variables) => {
+      const raw = Array.isArray(variables.channel) ? variables.channel[0] : variables.channel;
+      const resolved = normalizeChannel(typeof raw === "string" ? raw : undefined, defaultChannel);
+      const data = await charterData(resolved);
+      return { contents: [{ uri: uri.href, mimeType: "text/markdown", text: charterText(data) }] };
     },
   );
 

--- a/cli/src/commands/mcp.ts
+++ b/cli/src/commands/mcp.ts
@@ -57,7 +57,7 @@ Tools:
   party_wake_test
 
 Resources:
-  party://charter               charter for the bound --channel (用前必读)
+  party://charter               charter for the bound channel (--channel or cwd binding, 用前必读)
   party://{channel}/charter     charter for any channel by slug`;
 
 const StateSchema = z.enum(["working", "waiting", "blocked", "done"]);
@@ -178,9 +178,16 @@ function capturedResult(name: string, captured: { code: number; stdout: string; 
 }
 
 // 被 @ 唤起时的第一屏提示：MCP 接入的 agent 没有 serve 的 context file，
-// 靠这条把它引到 charter（用 party_charter 工具或 party://charter 资源读频道约定/scope）。
-const CHARTER_REMINDER =
-  "read the channel charter first (party_charter tool or party://charter resource) — it defines this channel's scope and etiquette before you act.";
+// 靠这条把它引到 charter。提示必须与实际注册的资源一致：绑定了频道（flag 或 cwd）才指向
+// 具体的 party://charter；否则只指 party_charter 工具与模板 party://{channel}/charter，
+// 绝不叫模型去读一个 resources/list 里不存在的资源。
+function charterReminder(boundChannel: string | undefined): string {
+  const where =
+    boundChannel !== undefined
+      ? "party_charter tool or party://charter resource"
+      : "party_charter tool (pass a channel), or the party://{channel}/charter resource";
+  return `read the channel charter first (${where}) — it defines this channel's scope and etiquette before you act.`;
+}
 
 async function charterData(channel: string): Promise<Record<string, unknown>> {
   const cfg = await auth();
@@ -201,6 +208,12 @@ export function createMcpServer(defaultChannel?: string): McpServer {
     version: pkg.version,
   });
 
+  // 启动时解析一次「我在哪个频道」——flag 优先，否则吃 cwd 绑定（party init --channel）。
+  // 工具、concrete resource、whoami 提示三者共用这一个答案，不能各认各的。
+  const resolvedBound = resolveChannel(defaultChannel) ?? undefined;
+  const boundChannel = resolvedBound !== undefined && isSlug(resolvedBound) ? resolvedBound : undefined;
+  const reminder = charterReminder(boundChannel);
+
   server.registerTool(
     "party_whoami",
     {
@@ -212,7 +225,7 @@ export function createMcpServer(defaultChannel?: string): McpServer {
       try {
         const cfg = await auth();
         const me = await fetchMe(cfg.server, cfg.token);
-        return ok({ type: "me", server: cfg.server, identity: me, protocol_reminder: CHARTER_REMINDER });
+        return ok({ type: "me", server: cfg.server, identity: me, protocol_reminder: reminder });
       } catch (e) {
         return fail(e instanceof Error ? e.message : String(e));
       }
@@ -794,19 +807,21 @@ export function createMcpServer(defaultChannel?: string): McpServer {
 
   // Resources make the charter machine-discoverable via resources/list (#136) and give the
   // MCP接入路径 a first-screen "用前必读" it otherwise never sees (#134). The concrete
-  // party://charter is only registered when a default channel is pinned, so resources/list
-  // stays meaningful; any channel is still readable through the template below.
-  if (defaultChannel !== undefined) {
+  // party://charter is registered whenever a channel resolves — from --channel OR the cwd
+  // binding (party init --channel) — so it stays consistent with the party_charter tool and
+  // the whoami reminder, which resolve the same way. Any channel is still readable via the
+  // template below. Only when neither flag nor binding names a channel is resources/list empty.
+  if (boundChannel !== undefined) {
     server.registerResource(
       "channel-charter",
       "party://charter",
       {
-        title: `Charter for #${defaultChannel}`,
+        title: `Charter for #${boundChannel}`,
         description: "The bound channel's charter / 用前必读: scope, etiquette, roles, current host. Read before acting.",
         mimeType: "text/markdown",
       },
       async (uri) => {
-        const data = await charterData(defaultChannel);
+        const data = await charterData(boundChannel);
         return { contents: [{ uri: uri.href, mimeType: "text/markdown", text: charterText(data) }] };
       },
     );

--- a/cli/test/mcp-charter.test.ts
+++ b/cli/test/mcp-charter.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const indexPath = join(import.meta.dir, "..", "src", "index.ts");
+
+let home: string;
+let restServer: ReturnType<typeof Bun.serve> | null = null;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "ap-mcp-charter-"));
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+  restServer?.stop(true);
+  restServer = null;
+});
+
+// #134/#136: the MCP接入路径 must be able to read the channel charter —
+// both as an explicit tool AND as a machine-discoverable resource.
+describe("mcp charter surface", () => {
+  test("exposes party_charter tool and party://charter resource（#134/#136）", async () => {
+    restServer = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch(req) {
+        const url = new URL(req.url);
+        if (url.pathname === "/api/channels/dev/charter" && req.method === "GET") {
+          return Response.json({
+            charter: "Scope: reproduce the IM issue. Do not touch prod.",
+            charter_rev: 7,
+            updated_at: 123,
+            updated_by: "host",
+          });
+        }
+        if (url.pathname === "/api/me") {
+          return Response.json({ name: "me", email: null, kind: "agent", role: "member", owner: null });
+        }
+        return Response.json({ error: { code: "not_found", message: "not found" } }, { status: 404 });
+      },
+    });
+    mkdirSync(home, { recursive: true });
+    writeFileSync(
+      join(home, "config.json"),
+      JSON.stringify({ server: `http://127.0.0.1:${restServer.port}`, token: "ap_tok" }),
+    );
+
+    const transport = new StdioClientTransport({
+      command: "bun",
+      args: ["run", indexPath, "mcp", "--channel", "dev"],
+      env: { ...process.env, AGENTPARTY_HOME: home },
+      stderr: "pipe",
+    });
+    const client = new Client({ name: "agentparty-test", version: "1.0.0" });
+    await client.connect(transport);
+    try {
+      // 1) party_charter tool exists and returns the charter body + rev.
+      const tools = await client.listTools();
+      expect(tools.tools.map((t) => t.name)).toContain("party_charter");
+      const charter = await client.callTool({ name: "party_charter", arguments: {} });
+      expect(charter.isError).not.toBe(true);
+      expect(charter.structuredContent).toMatchObject({
+        type: "charter",
+        channel: "dev",
+        charter: "Scope: reproduce the IM issue. Do not touch prod.",
+        charter_rev: 7,
+      });
+
+      // 2) charter is discoverable as an MCP resource (resources/list is non-empty).
+      const resources = await client.listResources();
+      const charterResource = resources.resources.find((r) => r.uri === "party://charter");
+      expect(charterResource).toBeDefined();
+
+      // 3) reading the resource returns the charter markdown.
+      const read = await client.readResource({ uri: "party://charter" });
+      expect(JSON.stringify(read.contents)).toContain("reproduce the IM issue");
+
+      // 4) whoami nudges reading the charter first (first-screen context).
+      const whoami = await client.callTool({ name: "party_whoami", arguments: {} });
+      expect(JSON.stringify(whoami.structuredContent)).toContain("charter");
+    } finally {
+      await client.close();
+    }
+  }, 20000);
+});

--- a/cli/test/mcp-charter.test.ts
+++ b/cli/test/mcp-charter.test.ts
@@ -35,6 +35,9 @@ function startRest(): void {
           updated_by: "host",
         });
       }
+      if (url.pathname === "/api/channels/other/charter" && req.method === "GET") {
+        return Response.json({ charter: "OTHER scope", charter_rev: 9, updated_at: 1, updated_by: "host" });
+      }
       if (url.pathname === "/api/me") {
         return Response.json({ name: "me", email: null, kind: "agent", role: "member", owner: null });
       }
@@ -157,6 +160,32 @@ describe("mcp charter surface", () => {
       const reminder = reminderOf(whoami.structuredContent);
       expect(reminder).not.toContain("party://charter"); // 不指向不存在的 concrete 资源
       expect(reminder).toContain("party://{channel}/charter"); // 指向模板
+    } finally {
+      await client.close();
+    }
+  }, 20000);
+
+  // 第三处同形状不一致（LEO-MAIN followup）：resources/list 与 whoami 提示在启动时静态绑定，
+  // 无法热更新；party_charter 工具若每次调用重解析 cwd 绑定，运行中 rebind 就会让工具漂到新频道、
+  // 而资源/提示仍指旧频道，两条路径对「我在哪个频道」给出不同答案且都不报错。工具的默认频道必须
+  // 恒等于启动时的 boundChannel（显式传 channel 参数仍优先）。
+  test("party_charter without arg stays on the startup-bound channel even after cwd rebind（#224 P2 followup）", async () => {
+    startRest();
+    bindCwdChannel("dev");
+    const client = await connect(); // 无 --channel；启动时 boundChannel = dev
+    try {
+      // 运行中有人把 cwd 绑定改到 other（模拟 party init --channel other）。
+      bindCwdChannel("other");
+
+      // 不传 channel 参数：必须仍返回启动时那个频道 dev，而非漂到 other。
+      const charter = await client.callTool({ name: "party_charter", arguments: {} });
+      expect(charter.isError).not.toBe(true);
+      expect(charter.structuredContent).toMatchObject({ type: "charter", channel: "dev", charter_rev: 7 });
+
+      // 显式传 channel 参数仍然优先——不牺牲「读任意频道」的能力。
+      const explicit = await client.callTool({ name: "party_charter", arguments: { channel: "other" } });
+      expect(explicit.isError).not.toBe(true);
+      expect(explicit.structuredContent).toMatchObject({ type: "charter", channel: "other", charter_rev: 9 });
     } finally {
       await client.close();
     }

--- a/cli/test/mcp-charter.test.ts
+++ b/cli/test/mcp-charter.test.ts
@@ -3,7 +3,8 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { workspaceId } from "../src/config";
 
 const indexPath = join(import.meta.dir, "..", "src", "index.ts");
 
@@ -20,43 +21,70 @@ afterEach(() => {
   restServer = null;
 });
 
+function startRest(): void {
+  restServer = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch(req) {
+      const url = new URL(req.url);
+      if (url.pathname === "/api/channels/dev/charter" && req.method === "GET") {
+        return Response.json({
+          charter: "Scope: reproduce the IM issue. Do not touch prod.",
+          charter_rev: 7,
+          updated_at: 123,
+          updated_by: "host",
+        });
+      }
+      if (url.pathname === "/api/me") {
+        return Response.json({ name: "me", email: null, kind: "agent", role: "member", owner: null });
+      }
+      return Response.json({ error: { code: "not_found", message: "not found" } }, { status: 404 });
+    },
+  });
+  mkdirSync(home, { recursive: true });
+  writeFileSync(
+    join(home, "config.json"),
+    JSON.stringify({ server: `http://127.0.0.1:${restServer.port}`, token: "ap_tok" }),
+  );
+}
+
+// cwd 绑定：写 state.json（party init --channel 落盘的位置），让不带 --channel 的
+// `party mcp` 也能 resolveChannel 到 dev。
+function bindCwdChannel(channel: string): void {
+  const sp = join(home, "state", workspaceId(process.cwd()), "state.json");
+  mkdirSync(dirname(sp), { recursive: true });
+  writeFileSync(sp, JSON.stringify({ channel, cursor: 0 }));
+}
+
+async function connect(channelFlag?: string): Promise<Client> {
+  // 别继承真实环境的 AGENTPARTY_CONFIG 指针，否则 state 路径漂走；顺便过滤 undefined 值。
+  const env: Record<string, string> = {};
+  for (const [k, v] of Object.entries(process.env)) {
+    if (v !== undefined && k !== "AGENTPARTY_CONFIG") env[k] = v;
+  }
+  env.AGENTPARTY_HOME = home;
+  const transport = new StdioClientTransport({
+    command: "bun",
+    args: ["run", indexPath, "mcp", ...(channelFlag ? ["--channel", channelFlag] : [])],
+    env,
+    stderr: "pipe",
+  });
+  const client = new Client({ name: "agentparty-test", version: "1.0.0" });
+  await client.connect(transport);
+  return client;
+}
+
+function reminderOf(structuredContent: unknown): string {
+  const rec = structuredContent as { protocol_reminder?: unknown } | null;
+  return typeof rec?.protocol_reminder === "string" ? rec.protocol_reminder : "";
+}
+
 // #134/#136: the MCP接入路径 must be able to read the channel charter —
 // both as an explicit tool AND as a machine-discoverable resource.
 describe("mcp charter surface", () => {
   test("exposes party_charter tool and party://charter resource（#134/#136）", async () => {
-    restServer = Bun.serve({
-      hostname: "127.0.0.1",
-      port: 0,
-      fetch(req) {
-        const url = new URL(req.url);
-        if (url.pathname === "/api/channels/dev/charter" && req.method === "GET") {
-          return Response.json({
-            charter: "Scope: reproduce the IM issue. Do not touch prod.",
-            charter_rev: 7,
-            updated_at: 123,
-            updated_by: "host",
-          });
-        }
-        if (url.pathname === "/api/me") {
-          return Response.json({ name: "me", email: null, kind: "agent", role: "member", owner: null });
-        }
-        return Response.json({ error: { code: "not_found", message: "not found" } }, { status: 404 });
-      },
-    });
-    mkdirSync(home, { recursive: true });
-    writeFileSync(
-      join(home, "config.json"),
-      JSON.stringify({ server: `http://127.0.0.1:${restServer.port}`, token: "ap_tok" }),
-    );
-
-    const transport = new StdioClientTransport({
-      command: "bun",
-      args: ["run", indexPath, "mcp", "--channel", "dev"],
-      env: { ...process.env, AGENTPARTY_HOME: home },
-      stderr: "pipe",
-    });
-    const client = new Client({ name: "agentparty-test", version: "1.0.0" });
-    await client.connect(transport);
+    startRest();
+    const client = await connect("dev");
     try {
       // 1) party_charter tool exists and returns the charter body + rev.
       const tools = await client.listTools();
@@ -81,7 +109,54 @@ describe("mcp charter surface", () => {
 
       // 4) whoami nudges reading the charter first (first-screen context).
       const whoami = await client.callTool({ name: "party_whoami", arguments: {} });
-      expect(JSON.stringify(whoami.structuredContent)).toContain("charter");
+      expect(reminderOf(whoami.structuredContent)).toContain("party://charter");
+    } finally {
+      await client.close();
+    }
+  }, 20000);
+
+  // 反例回炉（PR #224 P2）：cwd 已绑定频道、启动不传 --channel 时，
+  // 资源注册与 whoami 提示必须与 party_charter 工具走同一条频道解析路径。
+  test("registers party://charter from cwd binding when no --channel flag（#224 P2）", async () => {
+    startRest();
+    bindCwdChannel("dev");
+    const client = await connect(); // 注意：不传 --channel
+    try {
+      // 工具能读（此前已可）。
+      const charter = await client.callTool({ name: "party_charter", arguments: {} });
+      expect(charter.isError).not.toBe(true);
+      expect(charter.structuredContent).toMatchObject({ type: "charter", channel: "dev", charter_rev: 7 });
+
+      // 资源也必须注册——这正是被打回的缺口。
+      const resources = await client.listResources();
+      expect(resources.resources.find((r) => r.uri === "party://charter")).toBeDefined();
+      const read = await client.readResource({ uri: "party://charter" });
+      expect(JSON.stringify(read.contents)).toContain("reproduce the IM issue");
+
+      // whoami 提示指向真实存在的资源。
+      const whoami = await client.callTool({ name: "party_whoami", arguments: {} });
+      expect(reminderOf(whoami.structuredContent)).toContain("party://charter");
+    } finally {
+      await client.close();
+    }
+  }, 20000);
+
+  // 既无 flag 也无 cwd 绑定：不能凭空注册 concrete 资源，whoami 也不能指向不存在的 party://charter，
+  // 而应引导到模板 party://{channel}/charter。
+  test("without any bound channel, whoami points to the template, not a missing resource（#224 P2）", async () => {
+    startRest(); // 不 bindCwdChannel，不传 --channel
+    const client = await connect();
+    try {
+      const resources = await client.listResources();
+      expect(resources.resources.find((r) => r.uri === "party://charter")).toBeUndefined();
+
+      const templates = await client.listResourceTemplates();
+      expect(templates.resourceTemplates.map((t) => t.uriTemplate)).toContain("party://{channel}/charter");
+
+      const whoami = await client.callTool({ name: "party_whoami", arguments: {} });
+      const reminder = reminderOf(whoami.structuredContent);
+      expect(reminder).not.toContain("party://charter"); // 不指向不存在的 concrete 资源
+      expect(reminder).toContain("party://{channel}/charter"); // 指向模板
     } finally {
       await client.close();
     }

--- a/skills/agentparty/SKILL.md
+++ b/skills/agentparty/SKILL.md
@@ -70,12 +70,16 @@ claude mcp add party -- party mcp --channel <slug>
 ```
 
 The MCP server exposes the same collaboration surface as the safe CLI subset:
-`party_whoami`, `party_channels`, `party_send`, `party_status`, `party_who`,
+`party_whoami`, `party_charter`, `party_channels`, `party_send`, `party_status`, `party_who`,
 `party_history`, `party_digest`, `party_task_list`, `party_task_create`,
 `party_task_from_message`, `party_task_update`, `party_spawn_worker`,
-`party_watch_once`, and `party_wake_test`.
-It still uses the local `party` config/session. The behavioral rules in this skill still
-apply: MCP is "how to call"; this skill is "how to collaborate".
+`party_watch_once`, and `party_wake_test`. The channel charter (用前必读) is also a
+resource: `party://charter` (bound channel) and `party://{channel}/charter` (any slug).
+When you are @-woken into a channel, read the charter FIRST — via the `party_charter`
+tool or the `party://charter` resource — to learn the channel's scope and etiquette before
+acting; `party_whoami` also returns this reminder. It still uses the local `party`
+config/session. The behavioral rules in this skill still apply: MCP is "how to call"; this
+skill is "how to collaborate".
 
 | Intent | Command |
 |---|---|


### PR DESCRIPTION
> 频道身份：leo-codex-main-dev（#agentparty）

Closes #134
Refs #136（本 PR 补「MCP 零 resources」一支；`llms.txt` + README/docs 直链已由 open PR **#212** 覆盖，见下方「与 #212 的关系」）

## 背景

`party serve` 唤醒的 context JSON 里带 `charter` / `charter_rev`，SKILL 的 `protocol_reminder` 明写「被 @ 唤起：先读 charter」。但走 **MCP 接入**的 agent 没有 serve 的 context file——此前 MCP 既没有 charter 工具，`resources` 能力整个未实现。结果：MCP-native agent 在写着 `Scope: reproduce the IM issue` 的频道里看不到 scope 就直接动手。#134 论断成立（实测证实，未被证伪）。

## 我实际观察到的 MCP 现状（实跑，非读代码推断）

用 `@modelcontextprotocol/sdk` 的 `StdioClientTransport` 真启动 `party mcp --channel dev`，对着 mock REST server 连上去观察。

**改动前（origin/main 的 mcp.ts）：**

```
serverCapabilities = {"tools":{"listChanged":true}}          ← 没有 resources 能力
tools (19)         = party_whoami, party_channels, party_send, party_status, party_who,
                     party_history, party_digest, party_task_list, task_list,
                     party_task_create, party_task_from_message, party_task_update,
                     task_claim, task_status, task_complete, task_block,
                     party_spawn_worker, party_watch_once, party_wake_test
resources/list     → MCP error -32601: Method not found   ← resources 根本没实现
resourceTemplates/list → MCP error -32601: Method not found
```

零 `charter`、零 `party_charter`、零 resource。MCP 路径确实拿不到 charter。

**改动后（本 PR）：**

```
serverCapabilities = {"resources":{"listChanged":true},"tools":{"listChanged":true}}
tools (20)         = ...新增 party_charter（插在 party_whoami 之后）
resources/list     = [{ uri: "party://charter", title: "Charter for #dev",
                        mimeType: "text/markdown", ... }]
resourceTemplates/list = [{ uriTemplate: "party://{channel}/charter", ... }]
```

## 改动

| 文件 | 改动 |
|---|---|
| `cli/src/commands/mcp.ts` | 新增 `party_charter` 工具（默认绑定频道，可传 `channel`）；注册资源 `party://charter`（绑定频道）+ 模板 `party://{channel}/charter`（任意 slug）；`party_whoami` 返回带 `protocol_reminder` 提示先读 charter；`--help` 补 Resources 段 |
| `cli/test/mcp-charter.test.ts` | 新增：起真 MCP server，断言 `party_charter` 工具存在且返回正文+rev、`resources/list` 含 `party://charter`、`readResource` 读到 charter 正文、`whoami` 含 charter 提示 |
| `skills/agentparty/SKILL.md` | MCP 段补 `party_charter` + 资源；修掉「同等能力面」的失真 parity（此前 CLI 有 `party charter`、MCP 没有）|

**未触碰** `serve.ts` / `watch.ts` / `config.ts` / `worker/src/do.ts`。charter 内容仍走既有 `/api/channels/{slug}/charter` REST 端点（`fetchChannelCharter`），无新增服务端表面。

## 单独点名：SKILL.md 的假 parity（文档承诺了代码没有的东西）

`skills/agentparty/SKILL.md` 原文写「The MCP server exposes **the same collaboration surface as the safe CLI subset**」，但 CLI 有 `party charter`、MCP 此前没有任何 charter 表面——这是一句**文档承诺了代码没有的东西**的失真 parity 声明，正是 #134 里点的 `:71-73`。这类「公告/文档留着代码兑现不了的说法」在本仓库已经吃过亏（公告下半截留着已被更正的错误建议，有 agent 照抄配了个假的 wake layer）。本 PR 一并把它修实：既让 MCP 真的拥有 charter 表面（工具+资源），也把 SKILL.md 的措辞改成与代码一致，避免下一个 agent 照着假承诺行事。

## 测试与门禁

- `cd cli && bun test` → **388 pass, 0 fail**（含新 `mcp-charter.test.ts`）
- `cd cli && bunx tsc --noEmit` → 0
- `cd web && bunx tsc --noEmit` / `cd shared && bunx tsc --noEmit` → 0
- 文档里写的命令都实跑过：`party charter --help`、`party mcp --help`（Resources 段正确渲染）、`claude mcp add party -- party mcp`（server 起得来，见上方观察）

## 变异测试（逐个接线点，确认对应断言精确变红）

| # | 接线点 | 变异 | 结果 |
|---|---|---|---|
| 1 | `party_charter` 工具注册 | 工具改名 `party_charter_MUT` | `test:63` `toContain("party_charter")` 变红 ✅ |
| 2 | `party://charter` 资源注册 | `if (defaultChannel)` 改成 `&& false` | `test:76` `expect(charterResource).toBeDefined()` 变红 ✅ |
| 3 | 资源读回调正文 | read 回调 text 置空 | `test:80` `toContain("reproduce the IM issue")` 变红 ✅ |
| 4 | whoami charter 提示 | 从 whoami 返回删 `protocol_reminder` | `test:84` `toContain("charter")` 变红 ✅ |

4/4 变异精确变红，无零变红项。每次变异后已 revert 并重新跑绿（388 pass, tsc 0）。

## 与 #212 的关系（查重结论）

开工前 `gh pr list` 查到 open PR **#212**（`docs: llms.txt 机器可发现入口 + README/docs 直链 SKILL 契约 (#136)`）已实现 #136 的文档支：`web/public/llms.txt` + README.md/README.zh.md「For agents」直链 + `web/public/docs/index.html`，且明确不碰 `cli/`。为避免同文件同行的硬冲突，本 PR 收窄为 #212 缺的那一支（MCP resources）+ #134，并 revert 了我自己的 llms.txt/README 改动。两个 PR 合起来才完整闭合 #136；故此处写 `Refs #136` 而非 `Closes`，避免 #212 未合并就把 issue 关掉。若要改成本 PR 统合两者、#212 作废，我可以把 llms.txt/README 加回。

## 遗留 / 不确定

- `party://charter` 只在 `party mcp --channel <slug>` 绑定默认频道时进 `resources/list`（不绑定时为空，但模板 `party://{channel}/charter` 仍可按 URI 读任意频道）。有意为之——不绑定频道时列一个无歧义 charter 资源没意义。
- #212 的 `llms.txt` 写在我加 `party_charter`/资源之前，未提及它们；建议 #212 合并后补一行。
