### PR TITLE
fix(cli): 补 workflow guard 的 human 重置入口，熔断文案指向能用的命令 (#127)

### DIFF
--- a/cli/src/commands/channel.ts
+++ b/cli/src/commands/channel.ts
@@ -17,6 +17,7 @@ import {
   removeChannelMember,
   removeProjectAgentInvite,
   resetGuard,
+  resetWorkflowGuard,
   revokeJoinLink,
   setChannelRole,
   setChannelPerms,
@@ -51,6 +52,8 @@ const CHANNEL_FLAGS = [
   "members-agent",
   "json",
 ];
+// 与 worker/src/do.ts WORKFLOW_ID_RE 及 status --workflow-id 校验保持一致
+const WORKFLOW_ID_RE = /^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,127}$/;
 const COLLAB_ROLES = ["host", "worker", "reviewer", "observer"] as const;
 const COMPLETION_GATES = ["reviewer", "off"] as const;
 const COMPLETION_REVIEW_POLICIES = ["sender", "owner"] as const;
@@ -61,7 +64,9 @@ const AGENT_PERM_POLICIES = ["off", "moderators", "members", "allowlist"] as con
 const HELP = `usage: party channel create <slug> [--title t] [--temp] [--party] [--public]
        party channel list
        party channel archive [slug]                 archive, kick live agents, keep history
-       party channel reset-guard [slug]
+       party channel reset-guard [slug]                 clear the loop guard (agent-flood breaker)
+       party channel reset-workflow-guard <workflow_id> [slug]
+                                                        clear a stuck workflow no-progress guard
        party channel kick <name> [slug] [--remove]
        party channel invite-agent <owner>/<handle> [slug]
        party channel remove-agent <owner>/<handle> [slug]
@@ -257,6 +262,25 @@ export async function run(argv: string[]): Promise<number> {
         }
         await resetGuard(cfg.server, cfg.token, slug);
         console.log(`guard reset ${slug}`);
+        return 0;
+      }
+      case "reset-workflow-guard": {
+        const workflowId = positionals[1];
+        const slug = resolveChannel(positionals[2]);
+        if (!workflowId || !slug) {
+          console.error("usage: party channel reset-workflow-guard <workflow_id> [slug]");
+          return 1;
+        }
+        if (!WORKFLOW_ID_RE.test(workflowId)) {
+          console.error("workflow_id must match [a-zA-Z0-9][a-zA-Z0-9._:-]{0,127}");
+          return 1;
+        }
+        if (!isSlug(slug)) {
+          console.error("slug must match [a-z0-9][a-z0-9-]{0,63}");
+          return 1;
+        }
+        await resetWorkflowGuard(cfg.server, cfg.token, slug, workflowId);
+        console.log(`workflow guard reset ${slug}: ${workflowId}`);
         return 0;
       }
       case "kick": {
@@ -596,7 +620,7 @@ export async function run(argv: string[]): Promise<number> {
         return 1;
       }
       default:
-        console.error("usage: party channel create|list|archive|reset-guard|kick|invite-agent|gate|visibility|members|perms|join-link|leave|role");
+        console.error("usage: party channel create|list|archive|reset-guard|reset-workflow-guard|kick|invite-agent|gate|visibility|members|perms|join-link|leave|role");
         return 1;
     }
   } catch (e) {

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -41,7 +41,7 @@ commands:
   host      board [channel|--channel C] [--since seq] [--limit n] [--json]
   capture   <seq>|list [channel|--channel C] --as decision|requirement|bug|action-item [-m note] [--json] [--issue-body]
   wake      test @agent [channel|--channel C] [--timeout N] [--json]
-  channel   create <slug> [--title t] [--temp] [--party] [--public] | list | archive [slug] | guard unlimited|off|<limit> [slug] | workflow-guard off|<limit> [slug] | reset-guard [slug] | kick <name> [slug] | invite-agent <owner>/<handle> [slug] | remove-agent <owner>/<handle> [slug] | join-link <slug> | role list|set|unset
+  channel   create <slug> [--title t] [--temp] [--party] [--public] | list | archive [slug] | guard unlimited|off|<limit> [slug] | workflow-guard off|<limit> [slug] | reset-guard [slug] | reset-workflow-guard <workflow_id> [slug] | kick <name> [slug] | invite-agent <owner>/<handle> [slug] | remove-agent <owner>/<handle> [slug] | join-link <slug> | role list|set|unset
   invite    "<title>" [--slug s] [--temp] [--party] [--public] [--guest-name bob] [--owner label]   (ADMIN_SECRET env)
   webhook   add <channel> --name n --url URL --secret S [--filter mentions|status|needs-human|all] | remove <channel> --name n | list <channel>
   token     create --name n --role agent|human|readonly --owner label [--channel-scope slug] | revoke <name>   (ADMIN_SECRET env)

--- a/cli/src/rest.ts
+++ b/cli/src/rest.ts
@@ -1032,6 +1032,20 @@ export async function resetGuard(server: string, token: string, slug: string): P
   });
 }
 
+// 重置某个 workflow 的 no-progress 熔断（与 loop guard 的 reset-guard 分属两套熔断器）。
+// human-only + moderator/host，服务端 /api/channels/:slug/workflows/:workflow_id/reset-guard 强制。
+export async function resetWorkflowGuard(
+  server: string,
+  token: string,
+  slug: string,
+  workflowId: string,
+): Promise<void> {
+  await req(server, `/api/channels/${encodeURIComponent(slug)}/workflows/${encodeURIComponent(workflowId)}/reset-guard`, {
+    method: "POST",
+    headers: bearerJson(token),
+  });
+}
+
 // 房主踢人：按参与者/token 名字踢出频道（防滥用 MVP，spec §5）
 export async function kickParticipant(
   server: string,
@@ -1063,7 +1077,11 @@ export function handleRestError(e: unknown): number {
     if (e.code === "loop_guard") return EXIT_LOOP_GUARD;
     // workflow guard 与 loop guard 同类：停手等人类，别换个措辞重试（#122）
     if (e.code === "workflow_guard") {
-      console.error("hint: workflow guard tripped — stop, report status blocked, wait for a human. Do not rephrase and retry.");
+      console.error(
+        "hint: workflow guard tripped — stop, report status blocked, wait for a human. Do not rephrase and retry.\n" +
+          "      a human clears it with: party channel reset-workflow-guard <workflow_id> [slug]\n" +
+          "      (the blocked workflow_id is named in the error above; plain `reset-guard` only clears the loop guard, not this)",
+      );
       return EXIT_WORKFLOW_GUARD;
     }
     if (e.code === "archived") return EXIT_ARCHIVED;

--- a/cli/test/exit-codes.test.ts
+++ b/cli/test/exit-codes.test.ts
@@ -47,6 +47,20 @@ describe("handleRestError exit-code contract (#122)", () => {
     expect(lines.some((l) => /do not rephrase and retry/i.test(l))).toBe(true);
   });
 
+  // #127：熔断解除文案必须指向真正能用的命令。工作流熔断只能用 reset-workflow-guard 清，
+  // 不是 loop guard 的 reset-guard —— 照着旧文案（只说「等人类」）做的人无从下手。
+  test("workflow_guard hint names the reset-workflow-guard command", () => {
+    const lines: string[] = [];
+    const orig = console.error;
+    console.error = (l?: unknown) => lines.push(String(l));
+    try {
+      handleRestError(new RestError(409, "workflow_guard", "workflow wf-b is blocked by workflow guard"));
+    } finally {
+      console.error = orig;
+    }
+    expect(lines.some((l) => /party channel reset-workflow-guard/.test(l))).toBe(true);
+  });
+
   test("429 prints a back-off hint", () => {
     const lines: string[] = [];
     const orig = console.error;

--- a/cli/test/m3.test.ts
+++ b/cli/test/m3.test.ts
@@ -2626,6 +2626,48 @@ describe("party channel reset-guard", () => {
   });
 });
 
+describe("party channel reset-workflow-guard", () => {
+  test("reset-workflow-guard <wid> <slug> 调 POST /workflows/<wid>/reset-guard", async () => {
+    mock = startRestMock();
+    writeCfg(mock.url);
+    const r = await runCli(["channel", "reset-workflow-guard", "wf-b", "town-square"]);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain("workflow guard reset town-square: wf-b");
+    const reqs = reqsOf(mock, "POST", "/api/channels/town-square/workflows/wf-b/reset-guard");
+    expect(reqs.length).toBe(1);
+    expect(reqs[0]!.headers.authorization).toBe("Bearer ap_tok");
+    // 没打到 loop guard 的 reset-guard 端点（两者是不同的熔断器）
+    expect(reqsOf(mock, "POST", "/api/channels/town-square/reset-guard").length).toBe(0);
+  });
+
+  test("省略 slug 时用绑定频道", async () => {
+    mock = startRestMock();
+    writeCfg(mock.url);
+    writeWorkspaceState("ops");
+    const r = await runCli(["channel", "reset-workflow-guard", "wf-x"]);
+    expect(r.code).toBe(0);
+    expect(reqsOf(mock, "POST", "/api/channels/ops/workflows/wf-x/reset-guard").length).toBe(1);
+  });
+
+  test("缺 workflow_id 报用法且不发请求", async () => {
+    mock = startRestMock();
+    writeCfg(mock.url);
+    writeWorkspaceState("ops");
+    const r = await runCli(["channel", "reset-workflow-guard"]);
+    expect(r.code).toBe(1);
+    expect(r.stderr).toContain("usage: party channel reset-workflow-guard <workflow_id> [slug]");
+    expect(mock.requests.length).toBe(0);
+  });
+
+  test("非法 workflow_id 本地拒绝，不发请求", async () => {
+    mock = startRestMock();
+    writeCfg(mock.url);
+    const r = await runCli(["channel", "reset-workflow-guard", "bad id", "ops"]);
+    expect(r.code).toBe(1);
+    expect(mock.requests.length).toBe(0);
+  });
+});
+
 describe("party channel gate", () => {
   test("gate reviewer 调 PUT /completion-gate，可带 policy", async () => {
     mock = startRestMock();

--- a/cli/test/rest-mock.ts
+++ b/cli/test/rest-mock.ts
@@ -94,6 +94,10 @@ export function startRestMock(handler?: RestHandler): RestMock {
       if (r.method === "POST" && /^\/api\/channels\/[^/]+\/reset-guard$/.test(r.path)) {
         return Response.json({ ok: true });
       }
+      const wfReset = r.path.match(/^\/api\/channels\/[^/]+\/workflows\/([^/]+)\/reset-guard$/);
+      if (r.method === "POST" && wfReset) {
+        return Response.json({ ok: true, workflow_id: decodeURIComponent(wfReset[1]!) });
+      }
       if (r.method === "PUT" && /^\/api\/channels\/[^/]+\/completion-gate$/.test(r.path)) {
         const b = body as { gate: "off" | "reviewer"; policy?: "sender" | "owner" };
         return Response.json({ gate: b.gate, policy: b.policy ?? "sender" });


### PR DESCRIPTION
> 频道身份：leo-codex-main-dev（#agentparty）

Closes #127

## 复现：409 文案实际指向哪里（不照 issue 描述，自己查）

issue 说「409 文案指错路」。自己顺代码走了一遍，实际情况比这句更具体：

1. workflow guard 熔断的 409 消息由 `worker/src/do.ts:2779` `workflowGuardBlockedMessage()` 生成：
   `workflow <id> is blocked by workflow guard at seq N; send a progress status or ask a human to reset it`。
   它只说「ask a human to reset it」，**不点名任何命令**。`worker/src/index.ts:4249` 对 DO 的 4xx 是 `return res` 原样透传，index.ts 不重写这段文案。
2. 而现存唯一的 human 重置 CLI 命令 `party channel reset-guard`（`cli/src/rest.ts` → `POST /api/channels/:slug/reset-guard` → `do.ts:2292` `clearLoopGuardState()`）**只清 loop guard**。照着「ask a human to reset it」去跑 `reset-guard` 的人，workflow 仍然卡死——这就是「照着文案做的人发现它不管用」。
3. workflow 的真正重置端点 `POST /api/channels/:slug/workflows/:workflow_id/reset-guard`（`worker/src/index.ts:4461` → `do.ts:2301` `resetWorkflowGuard()`）**已经存在且工作正常**（`worker/test/workflow-guard.spec.ts:76` 已覆盖，human host 打它得 200），但在 CLI 与 web 里**零调用**——没有任何显式入口。
4. 另有隐藏行为：human 随便发一条消息会同时清两套熔断（`do.ts:2585-2586` `clearLoopGuardState()` + `clearWorkflowGuards()`），未见于文档。

结论：worker 端点无需改（human-only ACL 已就位）；缺口在 **CLI 入口 + 文案**。`do.ts` 那段 409 正文在别人未合并的 PR 里，只读，未动。

## 改动

- 新增 `party channel reset-workflow-guard <workflow_id> [slug]`，直接命中已有的 workflow reset 端点（`cli/src/commands/channel.ts`）。workflow_id 本地按 `/^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,127}$/` 校验（与 worker `WORKFLOW_ID_RE` 一致）。
- `cli/src/rest.ts` 暴露 `resetWorkflowGuard()`。
- `handleRestError` 的 `workflow_guard` 提示改为指向 `reset-workflow-guard`，并点明它与只清 loop guard 的 `reset-guard` 是两套熔断器——**这是 CLI 用户实际读到的、我能改的那段「文案」**。
- help / 命令总览同步。

### 文案：改前 / 改后

改前（`cli/src/rest.ts` workflow_guard 分支）：
```
hint: workflow guard tripped — stop, report status blocked, wait for a human. Do not rephrase and retry.
```
改后：
```
hint: workflow guard tripped — stop, report status blocked, wait for a human. Do not rephrase and retry.
      a human clears it with: party channel reset-workflow-guard <workflow_id> [slug]
      (the blocked workflow_id is named in the error above; plain `reset-guard` only clears the loop guard, not this)
```

## 命令实测（自己跑一遍）

- `cli/test/m3.test.ts` 子进程实跑 `bun run index.ts channel reset-workflow-guard wf-b town-square`（真实 argv → 真实 bun.serve mock），断言**精确打到** `POST /api/channels/town-square/workflows/wf-b/reset-guard`，且**没有**误打 loop guard 的 `reset-guard`。exit 0，stdout `workflow guard reset town-square: wf-b`。
- 端点侧 `worker/test/workflow-guard.spec.ts` 实测：human host 打该端点得 `200 {ok:true, workflow_id}`，之后 agent 可继续发消息。命令 → 端点全链路成立。

## 变异表（逐接线点拆，确认精确变红）

| # | 拆掉的接线点 | 期望变红 | 实测 |
|---|---|---|---|
| 1 | `resetWorkflowGuard` 的端点路径 → 改成 loop `reset-guard` | 两个正路径 endpoint 断言 | ✅ 恰好 2 条红（`reset-workflow-guard <wid> <slug>` + `省略 slug`） |
| 2 | 去掉 `WORKFLOW_ID_RE` 校验（`if(false)`） | 非法 id 测试 | ✅ 恰好 1 条红（`非法 workflow_id 本地拒绝`） |
| 3 | 改坏缺参 usage 文案 | 缺参用法测试 | ✅ 恰好 1 条红（`缺 workflow_id 报用法`） |
| 4 | 提示回退到旧文案（不点名命令） | 新提示测试红、旧「do not rephrase」测试仍绿 | ✅ 恰好 1 条红（`hint names the reset-workflow-guard command`），旧断言绿 |

零变异未覆盖的接线点。

## 门禁

- `cd cli && bun test` → 392 pass / 0 fail（含新增 5 条）
- `cd cli && bunx tsc --noEmit` → clean
- `cd web && bun run build` → ok；`cd worker && bunx vitest run test/workflow-guard.spec.ts` → 2 pass（未改 worker，仅复核命令目标端点）

## 遗留 / 不确定

- 未动 `worker/src/do.ts`（只读，在别人 PR 里）。所以 409 正文里的「ask a human to reset it」措辞仍不点名命令；能修的「文案」是 CLI 侧提示。若日后要在 409 正文里直接给命令，需在那个 PR 落地后跟进。
- 未加 host board 的 `clear-workflow-guard` 推荐动作（`shared/src/protocol.ts` 目前 workflow blocker 归到 `review-blockers`、command 为 null）——避免扩面，留作后续。
- ACL 差异（既有、未改）：loop `reset-guard` 要 `isChannelModerator && human`；workflow reset 要 `canConfigureChannel(= moderator 或指派 host) && human`。human-only 一致，moderator/host 范围 workflow 侧略宽，是既有设计。
- **PR #219 也在动 `cli/src/commands/channel.ts`（加 `channel guard status`）**，rebase 时 switch 分支与 help 文案可能有小冲突面。
