### PR TITLE
ci(worker): 迁移编号查重守卫，重号在 CI 拦截而非落到目录枚举顺序

### DIFF
--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -1,0 +1,59 @@
+# D1 migrations — numbering contract
+
+`worker/migrations/` holds the Cloudflare D1 schema migrations. They are applied
+with `wrangler d1 migrations apply` (see `worker/package.json` → `migrate:remote`,
+run automatically by `deploy`).
+
+## The rule
+
+**Every migration filename must have a unique `NNNN_` number.** Add a new
+migration as the next free number (`0024_…`, `0025_…`, …). Never reuse a number.
+
+A CI guard enforces this: `scripts/check-migration-numbering.ts` fails the build
+(`bun run check`) if two files share a number.
+
+## Why numbers must be unique
+
+wrangler applies migrations in the order it **enumerates the directory**. In the
+version this repo pins (`wrangler ^4.22.0`, currently resolving to `4.35.0`),
+`getMigrationNames` reads the folder with `opendirSync().readSync()` and applies
+**no sort at all** — so files run in raw filesystem enumeration order, which can
+differ across machines and platforms. Newer wrangler (`4.107.0`) *does* sort, so
+the ordering guarantee is version-dependent under a `^` range. Two files sharing a
+number is therefore a latent, environment-dependent hazard even when it happens to
+work today.
+
+## The grandfathered collisions (do not "fix" them)
+
+Two numbers already collide:
+
+| number | files |
+| --- | --- |
+| `0015` | `0015_agent_profiles.sql`, `0015_guard_config.sql` |
+| `0016` | `0016_account_profile_metadata.sql`, `0016_account_profiles_handle_nocase.sql` |
+
+These are **already applied to production** (both prod and xdream). They are
+currently benign only because, within each pair, the two files touch disjoint
+schema objects (e.g. `agent_profiles` vs. `channels`), so their relative order does
+not matter.
+
+**They must not be renumbered.** wrangler records each applied migration by its
+*exact filename* in the `d1_migrations` table; `getUnappliedMigrations` computes
+"unapplied = files on disk whose name is not in that table". Renaming an
+already-applied file makes wrangler treat it as a brand-new migration and **run it
+again** against production — re-executing `CREATE TABLE` / `ALTER TABLE` and
+failing or corrupting the live schema.
+
+So the collisions are frozen: tolerated by the guard via a grandfather list, but no
+new file may join them. The guard rejects a third file on `0015`/`0016` and rejects
+renaming any grandfathered file. **Do not extend the grandfather list to silence a
+new collision — renumber the new migration instead.**
+
+## Running the guard locally
+
+```bash
+bun scripts/check-migration-numbering.ts        # checks worker/migrations/
+bun test scripts/check-migration-numbering.test.ts
+```
+
+Reference: issue #112.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "license": "BUSL-1.1",
   "private": true,
   "scripts": {
-    "check:scripts": "sh -n install.sh && bun test scripts/release-version.test.ts scripts/desktop-update-manifest.test.ts scripts/desktop-release-workflow.test.ts scripts/desktop-pairing-smoke.test.ts scripts/install.test.ts scripts/check-aggregate.test.ts scripts/ci-paths-filter.test.ts && bunx tsc --project scripts/tsconfig.json",
+    "check:scripts": "sh -n install.sh && bun scripts/check-migration-numbering.ts && bun test scripts/release-version.test.ts scripts/desktop-update-manifest.test.ts scripts/desktop-release-workflow.test.ts scripts/desktop-pairing-smoke.test.ts scripts/install.test.ts scripts/check-aggregate.test.ts scripts/ci-paths-filter.test.ts scripts/check-migration-numbering.test.ts && bunx tsc --project scripts/tsconfig.json",
     "check:cli": "cd cli && bun test && bunx tsc --noEmit",
     "check:shared": "cd shared && bunx tsc --noEmit",
     "check:web": "cd web && bun test && bunx tsc --noEmit && bunx vite build",

--- a/scripts/check-migration-numbering.test.ts
+++ b/scripts/check-migration-numbering.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+import {
+  analyzeMigrations,
+  GRANDFATHERED_DUPLICATES,
+} from "./check-migration-numbering";
+
+const repoRoot = resolve(import.meta.dir, "..");
+const script = join(repoRoot, "scripts", "check-migration-numbering.ts");
+const realMigrationsDir = join(repoRoot, "worker", "migrations");
+
+const cleanup: string[] = [];
+afterEach(() => {
+  while (cleanup.length) {
+    const dir = cleanup.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function makeDir(files: string[]): string {
+  const dir = mkdtempSync(join(tmpdir(), "agentparty-migrations-"));
+  cleanup.push(dir);
+  for (const f of files) writeFileSync(join(dir, f), "-- fixture\n");
+  return dir;
+}
+
+function run(args: string[]): { status: number; out: string } {
+  const r = spawnSync("bun", [script, ...args], {
+    encoding: "utf8",
+    env: process.env,
+  });
+  return { status: r.status ?? -1, out: `${r.stdout}${r.stderr}` };
+}
+
+describe("analyzeMigrations (pure)", () => {
+  test("flags a fresh duplicate number as forbidden", () => {
+    const res = analyzeMigrations(
+      ["0001_a.sql", "0002_b.sql", "0002_c.sql"],
+      [],
+    );
+    expect(res.forbidden.map((g) => g.number)).toEqual([2]);
+    expect(res.forbidden[0].files).toEqual(["0002_b.sql", "0002_c.sql"]);
+  });
+
+  test("grandfathered duplicates are tolerated, not forbidden", () => {
+    const res = analyzeMigrations(
+      [...GRANDFATHERED_DUPLICATES],
+      GRANDFATHERED_DUPLICATES,
+    );
+    // both 0015 and 0016 collide, but all files are grandfathered
+    expect(res.duplicates.map((g) => g.number)).toEqual([15, 16]);
+    expect(res.forbidden).toEqual([]);
+  });
+
+  test("adding a THIRD file to a grandfathered number is forbidden (frozen)", () => {
+    const res = analyzeMigrations(
+      [...GRANDFATHERED_DUPLICATES, "0015_new_thing.sql"],
+      GRANDFATHERED_DUPLICATES,
+    );
+    expect(res.forbidden.map((g) => g.number)).toEqual([15]);
+  });
+
+  test("renaming a grandfathered file is forbidden (would re-run in prod)", () => {
+    const renamed = GRANDFATHERED_DUPLICATES.map((f) =>
+      f === "0015_guard_config.sql" ? "0015_guardcfg.sql" : f,
+    );
+    const res = analyzeMigrations(renamed, GRANDFATHERED_DUPLICATES);
+    expect(res.forbidden.map((g) => g.number)).toEqual([15]);
+  });
+
+  test("unique numbering yields no duplicates", () => {
+    const res = analyzeMigrations(
+      ["0001_a.sql", "0002_b.sql", "0003_c.sql"],
+      [],
+    );
+    expect(res.duplicates).toEqual([]);
+    expect(res.forbidden).toEqual([]);
+  });
+
+  test("a .sql without a numeric prefix is reported as unnumbered", () => {
+    const res = analyzeMigrations(["init.sql", "0001_a.sql"], []);
+    expect(res.unnumbered).toEqual(["init.sql"]);
+  });
+});
+
+describe("check-migration-numbering CLI", () => {
+  test("real worker/migrations passes (grandfathered dups tolerated)", () => {
+    const r = run(["--dir", realMigrationsDir]);
+    expect(r.status).toBe(0);
+  });
+
+  test("exits non-zero on a NEW duplicate number", () => {
+    const dir = makeDir(["0001_a.sql", "0007_b.sql", "0007_c.sql"]);
+    const r = run(["--dir", dir, "--allow", ""]);
+    expect(r.status).not.toBe(0);
+    expect(r.out).toContain("0007");
+  });
+
+  test("exits zero on a clean, uniquely-numbered dir", () => {
+    const dir = makeDir(["0001_a.sql", "0002_b.sql", "0003_c.sql"]);
+    const r = run(["--dir", dir, "--allow", ""]);
+    expect(r.status).toBe(0);
+  });
+
+  test("grandfather is frozen: a third file on a known dup fails", () => {
+    const dir = makeDir([...GRANDFATHERED_DUPLICATES, "0015_new_thing.sql"]);
+    // no --allow → CLI uses the built-in grandfather list
+    const r = run(["--dir", dir]);
+    expect(r.status).not.toBe(0);
+    expect(r.out).toContain("0015");
+  });
+});

--- a/scripts/check-migration-numbering.test.ts
+++ b/scripts/check-migration-numbering.test.ts
@@ -85,6 +85,30 @@ describe("analyzeMigrations (pure)", () => {
     const res = analyzeMigrations(["init.sql", "0001_a.sql"], []);
     expect(res.unnumbered).toEqual(["init.sql"]);
   });
+
+  test("a non-4-digit prefix is unnumbered (NNNN_ contract, not just any digits)", () => {
+    // #230 P2: `\d+` let 2- or 5-digit widths through; the contract is exactly NNNN_.
+    const res = analyzeMigrations(["25_bad_width.sql", "00250_too_wide.sql", "0026_ok.sql"], []);
+    expect(res.unnumbered).toEqual(["00250_too_wide.sql", "25_bad_width.sql"]);
+  });
+
+  test("renaming a grandfathered (applied) file across numbers is caught even with no new dup", () => {
+    // #230 P1: rename 0015_agent_profiles.sql -> 0099_agent_profiles.sql. Now no number
+    // collides (0015 keeps only guard_config, 0099 is unique), so the duplicate check is
+    // blind — but wrangler would re-run the renamed applied migration. missingGrandfathered
+    // catches it.
+    const renamed = GRANDFATHERED_DUPLICATES.filter((f) => f !== "0015_agent_profiles.sql").concat(
+      "0099_agent_profiles.sql",
+    );
+    const res = analyzeMigrations(renamed);
+    expect(res.forbidden).toEqual([]); // no NEW duplicate number
+    expect(res.missingGrandfathered).toEqual(["0015_agent_profiles.sql"]);
+  });
+
+  test("all grandfathered files present => missingGrandfathered empty", () => {
+    const res = analyzeMigrations([...GRANDFATHERED_DUPLICATES]);
+    expect(res.missingGrandfathered).toEqual([]);
+  });
 });
 
 describe("check-migration-numbering CLI", () => {
@@ -112,5 +136,24 @@ describe("check-migration-numbering CLI", () => {
     const r = run(["--dir", dir]);
     expect(r.status).not.toBe(0);
     expect(r.out).toContain("0015");
+  });
+
+  test("renaming an applied migration across numbers fails (no new dup, but re-run hazard)", () => {
+    // #230 P1 via CLI: the grandfather list is intact except 0015_agent_profiles.sql
+    // was renamed to a fresh unique number → no collision, but the guard must still fail.
+    const dir = makeDir(
+      GRANDFATHERED_DUPLICATES.filter((f) => f !== "0015_agent_profiles.sql").concat("0099_agent_profiles.sql"),
+    );
+    const r = run(["--dir", dir]);
+    expect(r.status).not.toBe(0);
+    expect(r.out).toContain("0015_agent_profiles.sql");
+  });
+
+  test("a 2-digit-width prefix fails the CLI (NNNN_ contract)", () => {
+    // #230 P2 via CLI
+    const dir = makeDir(["0001_a.sql", "25_bad_width.sql"]);
+    const r = run(["--dir", dir, "--allow", ""]);
+    expect(r.status).not.toBe(0);
+    expect(r.out).toContain("25_bad_width.sql");
   });
 });

--- a/scripts/check-migration-numbering.ts
+++ b/scripts/check-migration-numbering.ts
@@ -31,7 +31,10 @@ export const GRANDFATHERED_DUPLICATES: readonly string[] = [
   "0016_account_profiles_handle_nocase.sql",
 ];
 
-export const MIGRATION_RE = /^(\d+)_.*\.sql$/;
+// Exactly four digits: the documented contract is `NNNN_`. `\d+` would let
+// `25_bad_width.sql` or `00250_x.sql` slip through with a width that sorts
+// differently from the 4-digit files around it.
+export const MIGRATION_RE = /^(\d{4})_.*\.sql$/;
 
 export interface DuplicateGroup {
   number: number;
@@ -45,6 +48,15 @@ export interface AnalysisResult {
   forbidden: DuplicateGroup[];
   /** `.sql` files without a leading `NNNN_` migration prefix. */
   unnumbered: string[];
+  /**
+   * Grandfathered (already-applied) filenames that are no longer present in the
+   * directory. Renaming/removing an applied migration makes wrangler treat it as
+   * new and re-run it against production — so a missing grandfathered file fails
+   * the guard even though it produces no NEW duplicate number. This is the
+   * "rename an applied migration across numbers" bypass the duplicate check alone
+   * cannot see.
+   */
+  missingGrandfathered: string[];
 }
 
 export function analyzeMigrations(
@@ -52,6 +64,7 @@ export function analyzeMigrations(
   allowed: Iterable<string> = GRANDFATHERED_DUPLICATES,
 ): AnalysisResult {
   const allowSet = new Set(allowed);
+  const fileSet = new Set(filenames);
   const byNumber = new Map<number, string[]>();
   const unnumbered: string[] = [];
 
@@ -79,7 +92,9 @@ export function analyzeMigrations(
     if (!group.files.every((f) => allowSet.has(f))) forbidden.push(group);
   }
 
-  return { duplicates, forbidden, unnumbered: unnumbered.sort() };
+  const missingGrandfathered = [...allowSet].filter((f) => !fileSet.has(f)).sort();
+
+  return { duplicates, forbidden, unnumbered: unnumbered.sort(), missingGrandfathered };
 }
 
 interface CliOptions {
@@ -121,12 +136,12 @@ function main(): void {
     process.exit(2);
   }
 
-  const { duplicates, forbidden, unnumbered } = analyzeMigrations(
+  const { duplicates, forbidden, unnumbered, missingGrandfathered } = analyzeMigrations(
     entries,
     allowed,
   );
 
-  if (forbidden.length === 0 && unnumbered.length === 0) {
+  if (forbidden.length === 0 && unnumbered.length === 0 && missingGrandfathered.length === 0) {
     const note =
       duplicates.length > 0
         ? ` (${duplicates.length} grandfathered duplicate number(s) tolerated)`
@@ -146,6 +161,11 @@ function main(): void {
   }
   for (const name of unnumbered) {
     console.error(`  .sql without NNNN_ prefix: ${name}`);
+  }
+  for (const name of missingGrandfathered) {
+    console.error(
+      `  already-applied migration renamed/removed: ${name} — wrangler would re-run it against production`,
+    );
   }
   console.error(
     "\nEach migration number must be unique. Renumber the new migration to the " +

--- a/scripts/check-migration-numbering.ts
+++ b/scripts/check-migration-numbering.ts
@@ -1,0 +1,158 @@
+#!/usr/bin/env bun
+// Guard against duplicate D1 migration numbers in worker/migrations/.
+//
+// Why this exists (issue #112): wrangler applies migrations in the order it
+// enumerates the directory. In the version this repo pins (wrangler ^4.22.0,
+// resolved 4.35.0) `getMigrationNames` reads the folder with
+// `opendirSync().readSync()` and applies NO sort — so same-numbered files run in
+// raw filesystem enumeration order, which differs across machines/platforms.
+// Newer wrangler (4.107.0) does sort, so the guarantee is version-dependent under
+// a `^` range. Either way, two files sharing a number is a latent hazard.
+//
+// We CANNOT simply renumber the existing collisions: they are already applied to
+// production (prod + xdream). wrangler records applied migrations by exact
+// filename in the `d1_migrations` table; renaming an applied file makes wrangler
+// treat it as new and re-run it. So the existing pairs are grandfathered (frozen),
+// and this guard blocks any NEW collision — including a third file on a known
+// number or a rename of a grandfathered file.
+//
+// See docs/migrations.md.
+
+import { readdirSync } from "node:fs";
+import { resolve } from "node:path";
+
+// Duplicate migration filenames that already collide AND are already applied to
+// production. Tolerated but FROZEN — do not add to this list to "fix" a new
+// collision; renumber the new migration instead.
+export const GRANDFATHERED_DUPLICATES: readonly string[] = [
+  "0015_agent_profiles.sql",
+  "0015_guard_config.sql",
+  "0016_account_profile_metadata.sql",
+  "0016_account_profiles_handle_nocase.sql",
+];
+
+export const MIGRATION_RE = /^(\d+)_.*\.sql$/;
+
+export interface DuplicateGroup {
+  number: number;
+  files: string[];
+}
+
+export interface AnalysisResult {
+  /** Every number owned by more than one file (grandfathered or not). */
+  duplicates: DuplicateGroup[];
+  /** Duplicate groups that are NOT fully grandfathered — these fail the guard. */
+  forbidden: DuplicateGroup[];
+  /** `.sql` files without a leading `NNNN_` migration prefix. */
+  unnumbered: string[];
+}
+
+export function analyzeMigrations(
+  filenames: readonly string[],
+  allowed: Iterable<string> = GRANDFATHERED_DUPLICATES,
+): AnalysisResult {
+  const allowSet = new Set(allowed);
+  const byNumber = new Map<number, string[]>();
+  const unnumbered: string[] = [];
+
+  for (const name of filenames) {
+    if (!name.endsWith(".sql")) continue;
+    const match = MIGRATION_RE.exec(name);
+    if (!match) {
+      unnumbered.push(name);
+      continue;
+    }
+    const number = Number.parseInt(match[1], 10);
+    const files = byNumber.get(number) ?? [];
+    files.push(name);
+    byNumber.set(number, files);
+  }
+
+  const duplicates: DuplicateGroup[] = [];
+  const forbidden: DuplicateGroup[] = [];
+
+  for (const [number, files] of [...byNumber].sort((a, b) => a[0] - b[0])) {
+    if (files.length < 2) continue;
+    const group: DuplicateGroup = { number, files: [...files].sort() };
+    duplicates.push(group);
+    // A collision is only tolerated when EVERY file in it is grandfathered.
+    if (!group.files.every((f) => allowSet.has(f))) forbidden.push(group);
+  }
+
+  return { duplicates, forbidden, unnumbered: unnumbered.sort() };
+}
+
+interface CliOptions {
+  dir: string;
+  allowed: string[];
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  const defaultDir = resolve(import.meta.dir, "..", "worker", "migrations");
+  let dir = defaultDir;
+  let allowed: string[] = [...GRANDFATHERED_DUPLICATES];
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--dir") {
+      dir = resolve(argv[++i] ?? "");
+    } else if (arg === "--allow") {
+      // `--allow ""` means "nothing is grandfathered".
+      const raw = argv[++i] ?? "";
+      allowed = raw
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean);
+    } else {
+      throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+  return { dir, allowed };
+}
+
+function main(): void {
+  const { dir, allowed } = parseArgs(process.argv.slice(2));
+
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch (err) {
+    console.error(`check-migration-numbering: cannot read ${dir}: ${err}`);
+    process.exit(2);
+  }
+
+  const { duplicates, forbidden, unnumbered } = analyzeMigrations(
+    entries,
+    allowed,
+  );
+
+  if (forbidden.length === 0 && unnumbered.length === 0) {
+    const note =
+      duplicates.length > 0
+        ? ` (${duplicates.length} grandfathered duplicate number(s) tolerated)`
+        : "";
+    console.log(
+      `check-migration-numbering: ok — ${dir}${note}`,
+    );
+    process.exit(0);
+  }
+
+  console.error(`check-migration-numbering: FAILED for ${dir}`);
+  for (const group of forbidden) {
+    const num = String(group.number).padStart(4, "0");
+    console.error(
+      `  duplicate migration number ${num}: ${group.files.join(", ")}`,
+    );
+  }
+  for (const name of unnumbered) {
+    console.error(`  .sql without NNNN_ prefix: ${name}`);
+  }
+  console.error(
+    "\nEach migration number must be unique. Renumber the new migration to the " +
+      "next free number. Do NOT rename an already-applied migration and do NOT " +
+      "extend the grandfather list — see docs/migrations.md and issue #112.",
+  );
+  process.exit(1);
+}
+
+if (import.meta.main) main();


### PR DESCRIPTION
> 频道身份：leo-codex-main-dev（#agentparty）

Closes #112

## 现状事实

| 事实 | 值 | 证据分级 |
| --- | --- | --- |
| 重号对数量 | **2 对**：`0015_agent_profiles.sql`+`0015_guard_config.sql`；`0016_account_profile_metadata.sql`+`0016_account_profiles_handle_nocase.sql` | 实际查到（`ls` + `git ls-tree origin/main worker/migrations/`） |
| wrangler 如何排序（pin 版本） | `wrangler ^4.22.0` → 本机装到 **4.35.0**：`getMigrationNames` 用 `opendirSync().readSync()` 循环，**完全不排序**，返回原始目录枚举顺序 | 读源码（`node_modules/.bun/wrangler@4.35.0/.../wrangler-dist/cli.js`，`getMigrationNames` / `getUnappliedMigrations`，约 86337–86379 行） |
| wrangler 如何排序（新版本） | **4.107.0**：`listFilesRelative(...).sort(compareMigrationPaths)`，按前导数字排序、同号再按整串字典序兜底。所以 `^` 范围下排序保证**随解析到的版本漂移** | 读源码（4.107.0 `cli.js`，`listFilesRelative` / `compareMigrationPaths` / `compareSegments`） |
| wrangler 如何记录已应用 | 记在 `d1_migrations` 表（`DEFAULT_MIGRATION_TABLE="d1_migrations"`），按**精确文件名**匹配：`unapplied = 磁盘文件名 − 表里的 name`。→ 重命名已应用文件会被当成新迁移**重跑** | 读源码（`getUnappliedMigrations` / `listAppliedMigrations`，`.map(m => m.name)`） |
| 是否已应用到生产（prod + xdream） | **无法直接验证**（禁止我跑 `wrangler d1 ... --remote`）。保守假设：**已应用**。支撑推断：`deploy` 脚本每次先跑 `migrate:remote`（`d1 migrations apply --remote`）再跑 `verify:remote-schema`，后者 `verify-remote-schema.mjs:172` 跑 `d1 migrations list --remote` 且未全部应用就抛错，并断言 `agent_profiles` 表 / `account_profiles` 列存在于远端——正是 0015/0016 创建的对象；两个环境都已跑到 0023 之后 | 推断（读源码 + 部署管线），非直接查询 |
| 当前为何良性 | 每对内部两文件触及**互不相交**的 schema 对象（`agent_profiles` vs `channels`、`account_profiles` 列 vs 索引），相对顺序不影响结果 | 读迁移 SQL |

## 修法：加守卫 + 冻结历史 + 文档（不重排）

**不重排历史。** 理由如上：这两对已应用到生产，wrangler 按精确文件名记录，重命名 = 对生产重跑 `CREATE TABLE`/`ALTER TABLE`，会失败或污染线上 schema。这是不可接受的数据风险。

改为：
- `scripts/check-migration-numbering.ts`：纯函数 `analyzeMigrations` + CLI 守卫。把 0015/0016 两对列为 **grandfather（冻结、容忍）**，拦截未来任何新重号——包括给 0015/0016 再加第三个文件、或重命名任一 grandfather 文件。
- `scripts/check-migration-numbering.test.ts`：TDD。
- `docs/migrations.md`：编号契约 + 「为何不能重排历史」。
- 根 `package.json` 的 `check`：直接跑守卫脚本 + 把测试纳入 `bun test` 列表，故 CI（`release.yml` 每次 PR/push 跑 `bun run check`）会拦。

**为什么不选重排历史**：唯一能「修干净」的方式是重命名 0015/0016 使编号唯一，但那恰好触发 wrangler 的重跑逻辑，对已上线的两个环境是高风险写操作。守卫 + 文档以零数据风险达成「未来不再出现重号」，而现状的重号本就良性。

## 变异表（拆守卫，测试精确变红 → 恢复变绿）

| # | 变异 | 结果 |
| --- | --- | --- |
| M1 | 删掉 `forbidden.push(group)`（守卫永不判违规） | 5 fail（含 fresh dup / 第三文件 / 重命名 / CLI 两条） |
| M2 | 失败路径 `process.exit(1)` → `exit(0)` | 2 fail（两条 CLI `status != 0`） |
| M3 | `allowSet.has(f)` → `true`（忽略 grandfather 白名单） | 5 fail |
| M4 | 重号阈值 `length < 2` → `length < 3`（漏检成对重号） | 4 fail |
| — | 恢复原文件 | 10 pass / 0 fail |

零变红项：无。四个变异均精确变红。

## 门禁输出

```
$ bun scripts/check-migration-numbering.ts
check-migration-numbering: ok — .../worker/migrations (2 grandfathered duplicate number(s) tolerated)   # exit 0

$ bun test scripts/check-migration-numbering.test.ts
10 pass / 0 fail / 15 expect() calls

$ bunx tsc --project scripts/tsconfig.json   # OK
```

## 遗留问题 / 不确定

- **「已应用到生产」是推断，非直接验证**（我被禁止跑 remote 查询）。结论建立在保守假设「已应用」之上——即便实际未应用，守卫 + 文档也无害；只有「确已未应用」时才存在「本可安全重排」的更优解，但没有证据支持，也不值得为此冒险。
- 未跑 worker vitest 全量 / 根 `bun run check` 全量（本机满载、已知 flaky #185/#200，且本改动不触碰 worker 运行时）。改动仅新增根 `scripts/` 下的独立脚本 + 测试 + 文档 + 一行 `check` 编排，已单测通过并 tsc 干净。
- `wrangler-accounts` 包装器最终 `spawnSync("wrangler", ...)` 走 PATH 上的 wrangler，部署时实际版本取决于环境全局安装，进一步佐证「排序行为不可依赖」。
