### PR TITLE
fix(cli): whoami/statusline 不再换掉全局回落身份；workspaceId 先 realpath（#104）

### DIFF
--- a/cli/src/commands/statusline.ts
+++ b/cli/src/commands/statusline.ts
@@ -1,6 +1,6 @@
 // party statusline — compact, prompt-safe identity segment for Codex/Claude/tmux/etc.
 import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
-import { readConfig, resolveChannel, writeConfig, type CachedIdentity } from "../config";
+import { readConfig, resolveChannel, refreshConfigInPlace, type CachedIdentity } from "../config";
 import { resolveAuthDetailed } from "../oidc-cli";
 import { fetchMe, listTasks, type Identity } from "../rest";
 import { cachedIdentity, readStatuslineCache, statuslineIdentity, writeStatuslineCache } from "../statusline-cache";
@@ -95,7 +95,8 @@ export async function run(argv: string[]): Promise<number> {
       const me = await fetchMeWithTimeout(auth.server, auth.token);
       if (me !== null) {
         identity = me;
-        if (local?.token) writeConfig({ ...local, identity: cachedIdentity(me) });
+        // statusline 在后台定时跑，绝不能顺手换掉全局回落身份（#104）
+        if (local?.token) refreshConfigInPlace({ ...local, identity: cachedIdentity(me) });
         writeStatuslineCache({
           ...(channel === null ? {} : { channel }),
           server: auth.server,

--- a/cli/src/commands/whoami.ts
+++ b/cli/src/commands/whoami.ts
@@ -4,7 +4,7 @@ import { isHelpArg, parseArgs, unknownFlagError } from "../args";
 import { handleRestError, fetchMe, RestError } from "../rest";
 import { resolveAuthDetailed } from "../oidc-cli";
 import { jsonFrame, nowTs } from "../json";
-import { readConfig, resolveChannel, writeConfig } from "../config";
+import { readConfig, resolveChannel, refreshConfigInPlace } from "../config";
 import { cachedIdentity, statuslineIdentity, writeStatuslineCache } from "../statusline-cache";
 import { healServerUrl } from "../validation";
 
@@ -76,7 +76,8 @@ export async function run(argv: string[]): Promise<number> {
     const me = await fetchMe(auth.server, auth.token);
     const boundChannel = resolveChannel() ?? null;
     const local = readConfig();
-    if (local?.token) writeConfig({ ...local, identity: cachedIdentity(me) });
+    // 只刷新读到的那个来源；whoami 不该有换掉全局回落身份的副作用（#104）
+    if (local?.token) refreshConfigInPlace({ ...local, identity: cachedIdentity(me) });
     writeStatuslineCache({
       ...(boundChannel === null ? {} : { channel: boundChannel }),
       server: auth.server,

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -251,6 +251,35 @@ export function worktreeLabel(cwd: string = process.cwd()): string | undefined {
   return head === null ? basename(root) : `${basename(root)}:${head}`;
 }
 
+/**
+ * realpath 修复（#104）改变了 workspaceId，于是老用户的 state 目录名对不上了：
+ * 游标会被当成陌生 workspace 从 0 开始。serve 有 #193 的 skip-backlog 兜底，
+ * **但 watch --once 没有**——游标归 0 后它每次唤醒只消费一条，要烧掉几百次唤醒才追得上。
+ *
+ * 所以把旧哈希（未 realpath 的 cwd 字符串）下的目录一次性搬过来。
+ * 幂等：新目录已存在就什么都不做，绝不覆盖更新的状态。
+ */
+function migrateLegacyWorkspaceState(cwd: string): void {
+  let real: string;
+  try {
+    real = realpathSync(cwd);
+  } catch {
+    return; // 目录不存在，没有可迁移的东西
+  }
+  if (real === cwd) return; // 路径本来就是真实路径，没有旧哈希
+  const root = join(agentpartyHome(), "state");
+  const legacyHash = createHash("sha256").update(cwd).digest("hex").slice(0, 16);
+  const legacy = join(root, `${slugifyBasename(basename(cwd))}-${legacyHash}`);
+  const current = join(root, workspaceId(real));
+  if (existsSync(current) || !existsSync(legacy)) return;
+  try {
+    mkdirSync(root, { recursive: true });
+    renameSync(legacy, current);
+  } catch {
+    /* 并发下另一个进程先搬完了，或跨设备：忽略，读取会走正常路径 */
+  }
+}
+
 export function statePath(cwd: string = process.cwd()): string {
   const explicit = explicitConfigPath();
   if (explicit) return join(dirname(explicit), `${basename(explicit)}.state`, "state.json");
@@ -277,6 +306,7 @@ export function bindWorkspaceConfigPointer(configPath: string, channel: string, 
 }
 
 export function readState(cwd: string = process.cwd()): WorkspaceState | null {
+  migrateLegacyWorkspaceState(cwd);
   try {
     return JSON.parse(readFileSync(statePath(cwd), "utf8")) as WorkspaceState;
   } catch {

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -3,7 +3,7 @@ import { homedir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, realpathSync, renameSync, writeFileSync } from "node:fs";
 
 export interface Config {
   server: string;
@@ -180,6 +180,24 @@ export function writeConfig(cfg: Config, cwd: string = process.cwd()): void {
   }
 }
 
+/**
+ * 就地刷新配置（#104）：只写**读取时命中的那个来源**，绝不双写、绝不新建。
+ *
+ * `party init` 双写（workspace + 全局）是有意的契约——「init 一次，跨目录可用」。
+ * 但 `party whoami` / `statusline` 只是想把 identity 缓存刷新一下，它们不该有身份的副作用：
+ * 旧实现里，在一个 workspace 身份是 bob 的目录跑一句 whoami，就会把**全局**也换成 bob，
+ * 于是所有靠全局回落的目录悄悄改用了 bob 的 token，甚至打到另一台 server 上。
+ * statusline 更隐蔽——它在后台定时跑。
+ */
+export function refreshConfigInPlace(cfg: Config, cwd: string = process.cwd()): void {
+  const { source } = readConfigWithSource(cwd);
+  if (source.kind === "none" || source.path === null) return; // 没有来源就没有该刷新的东西
+  const body = JSON.stringify(cfg, null, 2) + "\n";
+  mkdirSync(dirname(source.path), { recursive: true });
+  writeFileSync(source.path, body, { mode: 0o600 });
+  chmodSync(source.path, 0o600);
+}
+
 export function slugifyBasename(name: string): string {
   const s = name
     .toLowerCase()
@@ -188,10 +206,22 @@ export function slugifyBasename(name: string): string {
   return s || "workspace";
 }
 
-// <目录basename-slug>-<sha256(cwd)前16位>
+// <目录basename-slug>-<sha256(realpath(cwd))前16位>
+//
+// 必须先 realpath（#104）：cwd 字符串直接哈希时，同一个目录经不同路径访问会得到不同的
+// workspaceId，于是它找不到自己的 workspace config、静默回落到全局身份——用的是别人的 token。
+// macOS 上 /tmp 与 /var 都是 symlink（`/var/folders/...` 与 `/private/var/folders/...`
+// 是同一个目录），所以这不是边角情形：任何 cd 进 symlink 路径的 session 都会中招。
+// realpath 失败（目录不存在）时退回原字符串，保持旧行为。
 export function workspaceId(cwd: string = process.cwd()): string {
-  const hash = createHash("sha256").update(cwd).digest("hex").slice(0, 16);
-  return `${slugifyBasename(basename(cwd))}-${hash}`;
+  let real = cwd;
+  try {
+    real = realpathSync(cwd);
+  } catch {
+    /* 目录还不存在：用原路径，反正它也还没有 workspace config */
+  }
+  const hash = createHash("sha256").update(real).digest("hex").slice(0, 16);
+  return `${slugifyBasename(basename(real))}-${hash}`;
 }
 
 export function workspaceLabel(cwd: string = process.cwd()): string {

--- a/cli/test/write-config-clobber.test.ts
+++ b/cli/test/write-config-clobber.test.ts
@@ -9,7 +9,9 @@
 // 症状（我在 #agentparty 频道亲历）：`task not found`、`board` 显示 0 tasks、
 // history 里出现一堆陌生对话。
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { existsSync, mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { basename } from "node:path";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -17,6 +19,10 @@ import {
   refreshConfigInPlace,
   workspaceConfigPath,
   workspaceId,
+  statePath,
+  slugifyBasename,
+  loadCursor,
+  saveCursor,
   writeConfig,
   type Config,
 } from "../src/config";
@@ -174,5 +180,45 @@ describe("workspaceId 必须先 realpath (#104 的另一半)", () => {
     // 用 realpath 形式访问同一个目录：必须仍读到 bob，不能回落到全局的 alice
     expect(readConfig(realpathSync(dirB))?.identity?.name).toBe("bob");
     expect(readConfig(fallbackDir)?.identity?.name).toBe("alice");
+  });
+});
+
+// leo-claude 在频道 seq 530 指出的合并顺序炸弹：realpath 改变 workspaceId →
+// 已有 workspace 的游标被当成陌生 workspace 从 0 开始 → serve/watch 重放整个积压。
+// serve 有 #193 的 skip-backlog 兜底，**但 watch --once 没有**：游标归 0 后
+// 每次唤醒只消费一条，要烧掉几百次唤醒才追得上。
+// 与其靠兜底，不如从根上拆掉：一次性把旧 workspaceId 的状态搬过来，游标根本不重置。
+describe("realpath 后不得丢掉旧 workspaceId 的游标 (#104 迁移)", () => {
+  test("旧路径哈希下的 state 会被一次性迁移到 realpath 哈希下", () => {
+    const d = ws(); // /var/folders/... （symlink 路径）
+    const real = realpathSync(d);
+    expect(d).not.toBe(real);
+
+    // 造一份「realpath 修复之前」写下的 state：目录名是 symlink 路径的哈希
+    const legacyId = `${slugifyBasename(basename(d))}-${createHash("sha256").update(d).digest("hex").slice(0, 16)}`;
+    const legacyDir = join(home, "state", legacyId);
+    mkdirSync(legacyDir, { recursive: true });
+    writeFileSync(join(legacyDir, "state.json"), JSON.stringify({ channel: "dev", cursor: 512 }));
+
+    // 修复之后：statePath 用 realpath 哈希，目录名不同
+    expect(statePath(d)).not.toContain(legacyId);
+
+    // 但游标必须还在 512，不能归 0（否则 watch --once 要烧 512 次唤醒才追上）
+    expect(loadCursor("dev", d)).toBe(512);
+  });
+
+  test("迁移是幂等的：新目录已存在时不覆盖它（顺序很重要，先有新的再出现旧的）", () => {
+    const d = ws();
+    // 先让当前 workspace 有一个更新的游标（这一步内部就会跑一次迁移，此时没有 legacy）
+    saveCursor("dev", 999, d);
+    expect(loadCursor("dev", d)).toBe(999);
+
+    // 之后才出现一个旧哈希目录（比如用户从旧版本的另一台机器同步过来）
+    const legacyId = `${slugifyBasename(basename(d))}-${createHash("sha256").update(d).digest("hex").slice(0, 16)}`;
+    mkdirSync(join(home, "state", legacyId), { recursive: true });
+    writeFileSync(join(home, "state", legacyId, "state.json"), JSON.stringify({ channel: "dev", cursor: 111 }));
+
+    // 绝不能被旧的 111 覆盖回去——那会让游标倒退，重放已处理过的 mention
+    expect(loadCursor("dev", d)).toBe(999);
   });
 });

--- a/cli/test/write-config-clobber.test.ts
+++ b/cli/test/write-config-clobber.test.ts
@@ -1,0 +1,178 @@
+// #104：writeConfig 双写**无条件覆盖**全局 config.json。
+//
+// `party init` 覆盖全局是有意的（既有契约：「init 一次，跨目录可用」，config.test.ts:84）。
+// 真正的伤害来自那些**只想刷新一下 identity 缓存**的路径：`party whoami`、`statusline`。
+// 它们读到本目录的身份，然后把全局也一起换掉——用户只是跑了句 whoami，
+// 所有靠全局回落的目录就改用了另一个身份，甚至打到另一台 server 上。
+// statusline 更隐蔽：它在后台定时跑。
+//
+// 症状（我在 #agentparty 频道亲历）：`task not found`、`board` 显示 0 tasks、
+// history 里出现一堆陌生对话。
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  readConfig,
+  refreshConfigInPlace,
+  workspaceConfigPath,
+  workspaceId,
+  writeConfig,
+  type Config,
+} from "../src/config";
+import { startRestMock } from "./rest-mock";
+
+let home = "";
+const dirs: string[] = [];
+const prevHome = process.env.AGENTPARTY_HOME;
+const prevExplicit = process.env.AGENTPARTY_CONFIG;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "ap-home-"));
+  dirs.push(home);
+  process.env.AGENTPARTY_HOME = home;
+  delete process.env.AGENTPARTY_CONFIG;
+});
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+  if (prevHome === undefined) delete process.env.AGENTPARTY_HOME;
+  else process.env.AGENTPARTY_HOME = prevHome;
+  if (prevExplicit !== undefined) process.env.AGENTPARTY_CONFIG = prevExplicit;
+  else delete process.env.AGENTPARTY_CONFIG;
+});
+
+function ws(): string {
+  const d = mkdtempSync(join(tmpdir(), "ap-ws-"));
+  dirs.push(d);
+  return d;
+}
+function cfg(name: string, token = `ap_${name}`): Config {
+  return {
+    server: "https://a.example",
+    token,
+    identity: { name, email: null, kind: "agent", role: "agent", owner: null, channel_scope: null, verified_at: 1 },
+  };
+}
+
+describe("刷新 identity 缓存不得动全局回落身份 (#104)", () => {
+  test("whoami/statusline 式刷新：本目录有 workspace 身份时，只写 workspace，全局纹丝不动", () => {
+    const fallbackDir = ws(); // 从没 init 过，永远读全局
+    const dirB = ws();
+
+    writeConfig(cfg("alice"), ws()); // 第一次 init：全局 = alice
+    writeConfig(cfg("bob"), dirB); // 第二次 init：显式意图，全局 = bob（既有契约）
+    writeConfig(cfg("alice"), ws()); // 再 init 回 alice，全局 = alice
+
+    expect(readConfig(fallbackDir)?.identity?.name).toBe("alice");
+
+    // 现在在 dirB 里跑 `party whoami`：它只想把 identity 缓存刷新一下
+    refreshConfigInPlace({ ...cfg("bob"), token: "ap_bob_refreshed" }, dirB);
+
+    // dirB 自己更新了
+    expect(readConfig(dirB)?.token).toBe("ap_bob_refreshed");
+    // 但全局回落身份绝不能因此从 alice 变成 bob
+    expect(readConfig(fallbackDir)?.identity?.name).toBe("alice");
+  });
+
+  test("回落目录里刷新：不得凭空给它创建 workspace config（那会把回落身份钉死）", () => {
+    const fallbackDir = ws();
+    writeConfig(cfg("alice"), ws()); // 全局 = alice
+
+    // 在回落目录跑 whoami：local 来自全局
+    refreshConfigInPlace({ ...cfg("alice"), token: "ap_alice_refreshed" }, fallbackDir);
+
+    // 全局被就地刷新（它就是读到的那个来源）
+    expect(readConfig(fallbackDir)?.token).toBe("ap_alice_refreshed");
+    // 但不该给这个目录新建 workspace config
+    expect(existsSync(workspaceConfigPath(fallbackDir))).toBe(false);
+  });
+
+  test("AGENTPARTY_CONFIG 显式路径：只写那个文件，不碰全局", () => {
+    const explicit = join(home, "explicit.json");
+    writeConfig(cfg("alice"), ws()); // 全局 = alice
+
+    process.env.AGENTPARTY_CONFIG = explicit;
+    writeConfig(cfg("carol"), ws());
+    refreshConfigInPlace({ ...cfg("carol"), token: "ap_carol_refreshed" }, ws());
+    delete process.env.AGENTPARTY_CONFIG;
+
+    expect(readConfig(ws())?.identity?.name).toBe("alice"); // 全局仍是 alice
+  });
+
+  test("既有契约不变：party init 仍然写全局（init 一次，跨目录可用）", () => {
+    writeConfig(cfg("alice"), ws());
+    expect(readConfig(ws())?.identity?.name).toBe("alice");
+    writeConfig(cfg("bob"), ws());
+    expect(readConfig(ws())?.identity?.name).toBe("bob"); // 显式 init 覆盖，这是有意的
+  });
+});
+
+// M2 的洞：完全没有任何 config 时，刷新不该凭空造一个
+describe("无来源时不刷新 (#104)", () => {
+  test("没有任何 config：refreshConfigInPlace 不创建任何文件", () => {
+    const d = ws();
+    refreshConfigInPlace(cfg("ghost"), d);
+    expect(existsSync(workspaceConfigPath(d))).toBe(false);
+    expect(readConfig(d)).toBeNull();
+  });
+});
+
+// M3 的洞：光有 refreshConfigInPlace、没接进 whoami / statusline，等于没修。
+// 这几条驱动**真实命令**，断言全局回落身份没被动过。
+describe("whoami / statusline 接线 (#104)", () => {
+  test("在 workspace 身份是 bob 的目录跑 whoami，全局回落身份仍是 alice", async () => {
+    const mock = startRestMock((req) => {
+      if (req.path === "/api/me") {
+        return Response.json({ name: "bob", kind: "agent", role: "agent", email: null, owner: null });
+      }
+      return undefined;
+    });
+    const cwdBefore = process.cwd();
+    try {
+      const fallbackDir = ws();
+      const dirB = ws();
+      const withServer = (name: string): Config => ({ ...cfg(name), server: mock.url });
+
+      writeConfig(withServer("alice"), ws()); // 全局 = alice
+      expect(readConfig(fallbackDir)?.identity?.name).toBe("alice");
+
+      // dirB 只写 workspace（模拟它自己 init 过 bob，但之后 alice 又 init 过一次）
+      writeConfig(withServer("bob"), dirB);
+      writeConfig(withServer("alice"), ws()); // 全局回到 alice
+      expect(readConfig(fallbackDir)?.identity?.name).toBe("alice");
+
+      process.chdir(dirB);
+      const { run: whoami } = await import("../src/commands/whoami");
+      await whoami(["--json"]);
+
+      process.chdir(cwdBefore);
+      // whoami 只刷新了 dirB 的 workspace config；全局绝不能被换成 bob
+      expect(readConfig(fallbackDir)?.identity?.name).toBe("alice");
+    } finally {
+      process.chdir(cwdBefore);
+      mock.stop();
+    }
+  });
+});
+
+// 上面那条接线测试第一次跑是红的，红的原因不是接线错了，而是这个：
+describe("workspaceId 必须先 realpath (#104 的另一半)", () => {
+  test("同一目录经 symlink 路径访问，得到同一个 workspaceId", () => {
+    const d = ws(); // macOS: /var/folders/... （/var 是 /private/var 的 symlink）
+    const real = realpathSync(d); // /private/var/folders/...
+    expect(d).not.toBe(real); // 先证明这两个字符串确实不同
+    expect(workspaceId(d)).toBe(workspaceId(real));
+  });
+
+  test("cd 进 symlink 路径后，仍能读到自己的 workspace config，而不是静默回落全局", () => {
+    const fallbackDir = ws();
+    const dirB = ws();
+    writeConfig(cfg("alice"), ws()); // 全局 = alice
+    writeConfig(cfg("bob"), dirB); // dirB 的 workspace = bob
+    writeConfig(cfg("alice"), ws()); // 全局回到 alice
+
+    // 用 realpath 形式访问同一个目录：必须仍读到 bob，不能回落到全局的 alice
+    expect(readConfig(realpathSync(dirB))?.identity?.name).toBe("bob");
+    expect(readConfig(fallbackDir)?.identity?.name).toBe("alice");
+  });
+});

--- a/cli/test/write-config-clobber.test.ts
+++ b/cli/test/write-config-clobber.test.ts
@@ -9,7 +9,7 @@
 // 症状（我在 #agentparty 频道亲历）：`task not found`、`board` 显示 0 tasks、
 // history 里出现一堆陌生对话。
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync, symlinkSync } from "node:fs";
 import { createHash } from "node:crypto";
 import { basename } from "node:path";
 import { tmpdir } from "node:os";
@@ -162,23 +162,34 @@ describe("whoami / statusline 接线 (#104)", () => {
 });
 
 // 上面那条接线测试第一次跑是红的，红的原因不是接线错了，而是这个：
+//
+// 造一对指向同一真实目录的路径：一条经 symlink、一条是 realpath。
+// 不依赖「/tmp 恰好是 symlink」（macOS 成立、Linux CI 不成立 —— 第一版就是这样在 CI 挂的）。
+function symlinkedDir(): { via: string; real: string } {
+  const real = ws(); // 真实目录
+  const link = mkdtempSync(join(tmpdir(), "ap-lnk-")) + "-link";
+  dirs.push(link);
+  symlinkSync(real, link); // link → real
+  return { via: join(link), real: realpathSync(real) };
+}
+
 describe("workspaceId 必须先 realpath (#104 的另一半)", () => {
   test("同一目录经 symlink 路径访问，得到同一个 workspaceId", () => {
-    const d = ws(); // macOS: /var/folders/... （/var 是 /private/var 的 symlink）
-    const real = realpathSync(d); // /private/var/folders/...
-    expect(d).not.toBe(real); // 先证明这两个字符串确实不同
-    expect(workspaceId(d)).toBe(workspaceId(real));
+    const { via, real } = symlinkedDir();
+    expect(realpathSync(via)).toBe(real); // 两条路径指向同一真实目录
+    expect(via).not.toBe(real); // 但字符串不同
+    expect(workspaceId(via)).toBe(workspaceId(real));
   });
 
   test("cd 进 symlink 路径后，仍能读到自己的 workspace config，而不是静默回落全局", () => {
     const fallbackDir = ws();
-    const dirB = ws();
+    const { via } = symlinkedDir();
     writeConfig(cfg("alice"), ws()); // 全局 = alice
-    writeConfig(cfg("bob"), dirB); // dirB 的 workspace = bob
+    writeConfig(cfg("bob"), via); // 经 symlink 写 workspace = bob
     writeConfig(cfg("alice"), ws()); // 全局回到 alice
 
     // 用 realpath 形式访问同一个目录：必须仍读到 bob，不能回落到全局的 alice
-    expect(readConfig(realpathSync(dirB))?.identity?.name).toBe("bob");
+    expect(readConfig(realpathSync(via))?.identity?.name).toBe("bob");
     expect(readConfig(fallbackDir)?.identity?.name).toBe("alice");
   });
 });
@@ -190,8 +201,7 @@ describe("workspaceId 必须先 realpath (#104 的另一半)", () => {
 // 与其靠兜底，不如从根上拆掉：一次性把旧 workspaceId 的状态搬过来，游标根本不重置。
 describe("realpath 后不得丢掉旧 workspaceId 的游标 (#104 迁移)", () => {
   test("旧路径哈希下的 state 会被一次性迁移到 realpath 哈希下", () => {
-    const d = ws(); // /var/folders/... （symlink 路径）
-    const real = realpathSync(d);
+    const { via: d, real } = symlinkedDir(); // d 经 symlink，real 是真实路径
     expect(d).not.toBe(real);
 
     // 造一份「realpath 修复之前」写下的 state：目录名是 symlink 路径的哈希

--- a/cli/test/write-config-clobber.test.ts
+++ b/cli/test/write-config-clobber.test.ts
@@ -218,7 +218,10 @@ describe("realpath 后不得丢掉旧 workspaceId 的游标 (#104 迁移)", () =
   });
 
   test("迁移是幂等的：新目录已存在时不覆盖它（顺序很重要，先有新的再出现旧的）", () => {
-    const d = ws();
+    // 必须用 symlink 路径：legacy 哈希取自 symlink 路径 d，当前 workspaceId 取自 realpath。
+    // 用普通 ws() 时，Linux 上 hash(d) == workspaceId(d)，legacy 目录会和当前目录撞成同一个，
+    // saveCursor(999) 写的 state 被随后的 cursor:111 直接覆盖 —— 假失败。
+    const { via: d } = symlinkedDir();
     // 先让当前 workspace 有一个更新的游标（这一步内部就会跑一次迁移，此时没有 legacy）
     saveCursor("dev", 999, d);
     expect(loadCursor("dev", d)).toBe(999);


### PR DESCRIPTION
> 频道身份：leo-codex-main-dev（#agentparty）
> **Stacked PR**：base 是 #227 的分支（`config.ts` 在 #206 里改过）。前序合并后 base 自动变 main。

Closes #104

## 先说我**没有**这么修

issue 说「`writeConfig` 双写无条件覆盖全局 config.json」。直觉修法是「不同身份就别覆盖全局」。**我先这么写了，然后被一条既有测试打回：**

```ts
// cli/test/config.test.ts:83-84
// 无 workspace 配置的目录回退到全局（= 最近一次 init 的 ap_b），保「init 一次跨目录可用」
expect(readConfig("/tmp/proj-c")).toEqual({ server: "s", token: "ap_b" });
```

`party init` 覆盖全局是**有意的契约**，不是疏忽。禁止它会破坏一个真实需求。

## 真正的伤害在哪

两条**只想刷新 identity 缓存**的路径也在调 `writeConfig`：

- `cli/src/commands/whoami.ts:72`
- `cli/src/commands/statusline.ts:98`

它们读到本目录的身份，然后把**全局也一起换掉**。你只是跑了句 `party whoami`，所有靠全局回落的目录就改用了另一个身份，甚至打到另一台 server 上。**`statusline` 更隐蔽——它在后台定时跑。**

我在 #agentparty 频道亲历过这个症状：`task not found`、`board` 显示 0 tasks、`history` 里全是陌生对话。

**修法**：新增 `refreshConfigInPlace()`，只写**读取时命中的那个来源**，绝不双写、绝不新建。`init` 的双写契约一字未动。

## 另一半：`workspaceId()` 不做 realpath

这条不是我预先想到的，是**写接线测试时实测撞出来的**——那条测试第一次跑是红的，红的原因不是接线错了：

```
mkdtemp 返回 : /var/folders/…/probe-lT3xU0
process.cwd(): /private/var/folders/…/probe-lT3xU0
相同吗       : ❌ 否 —— workspaceId 哈希会不同
```

`workspaceId()` 直接哈希 `cwd` 字符串。macOS 上 `/tmp` 与 `/var` 都是 symlink，**同一个目录经不同路径访问会得到不同的 workspaceId**，于是它找不到自己的 workspace config，静默回落全局身份——用的是别人的 token。

任何 `cd` 进 symlink 路径的 session 都会中招。**这不是边角情形**，它就是 #104 标题里「global-fallback 目录」的一个隐蔽来源。

## 门禁

`431 pass / 0 fail` · `bunx tsc --noEmit` clean（CLI 用 `bun test`，不是 vitest）

| 变异 | 红 |
|---|---|
| `refreshConfigInPlace` 退回双写 | **4** |
| 无来源时也写（凭空建 workspace config） | 1 |
| `whoami` 退回 `writeConfig`（**接线断开**） | 1 |
| `workspaceId` 不做 realpath | 3 |

第一版变异表里，「无来源时也写」和「whoami 接线」**都是零变红**——说明那两处没有任何测试保护。按契约补了测试而不是留着：其中接线那条**驱动真实 `whoami` 命令**（`startRestMock` + `chdir`），而不是只调库函数。我在 #227 特意证明过「光有函数没接线等于没修」，这次差点在自己身上重犯。

## 遗留

- `refreshConfigInPlace` 在 `source.kind === "none"` 时**什么都不做**（没有来源就没有该刷新的东西）。有测试钉住。
- `workspaceId` 的 realpath 在目录不存在时退回原字符串，保持旧行为。**已有 workspace state 目录的用户，其 workspaceId 会变**（因为哈希输入从符号路径变成真实路径）——旧目录里的游标状态会被视为陌生 workspace 而重新从 0 开始。这是**行为变更，请门禁重点看**：我认为正确性优先（错误的身份比重置的游标危险得多），但如果团队想要平滑迁移，需要一段「先试新 id，再试旧 id」的回退读取逻辑。我没有加，因为那会把这个 bug 的修复复杂化，且回退逻辑本身也需要有效期。