### PR TITLE
fix(cli): token 不再只能经 argv 注入；spawn 与 SKILL 不再教危险姿势（#111）

### DIFF
--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -20,8 +20,48 @@ Write local config and optionally bind this working directory to a default chann
 
 Options:
   --server URL    AgentParty server URL
-  --token T       agent/human/readonly token
+  --token T       agent/human/readonly token（会进 argv：ps 与 shell history 可见）
+  --token -       从 stdin 读 token（推荐；也可用 AGENTPARTY_TOKEN 环境变量）
   --channel C     bind the current working directory to channel C`;
+
+/**
+ * token 输入通道（#111）。
+ *
+ * argv 是进程的公共表面。实测（macOS）：`ps -axww -o command` 直接读到 `--token ap_…`，
+ * 同机任意用户可见；`party init --token <T>` 也原样落进 ~/.zsh_history。
+ *
+ * 所以补两条不经 argv 的通道：环境变量 AGENTPARTY_TOKEN，和 `--token -`（从 stdin 读）。
+ * `--token <T>` 仍然支持——不破坏现有脚本——但会响亮地告诉用户它泄漏到哪里。
+ * 优先级：显式 --token > AGENTPARTY_TOKEN > 已有 config。
+ */
+export interface TokenSources {
+  flagToken: string | undefined;
+  envToken: string | undefined;
+  prevToken: string | undefined;
+}
+export interface TokenDeps {
+  readStdin: () => Promise<string>;
+  warn: (line: string) => void;
+}
+
+export async function resolveTokenInput(src: TokenSources, deps: TokenDeps): Promise<string | null> {
+  if (src.flagToken === "-") {
+    const piped = (await deps.readStdin()).trim();
+    // 用户明确说了「从 stdin 读」。读不到就是错，不能静默回落到缓存里的旧 token。
+    return piped === "" ? null : piped;
+  }
+  if (src.flagToken !== undefined && src.flagToken !== "") {
+    // 绝不在警告里回显 token 本身——否则警告自己就成了第三个泄漏面。
+    deps.warn(
+      "warning: --token 会把 token 写进 argv：同机任意用户 `ps -axww` 可见，也会落进 shell history。" +
+        " 改用 AGENTPARTY_TOKEN 环境变量，或 `--token -` 从 stdin 读。",
+    );
+    return src.flagToken;
+  }
+  const env = src.envToken?.trim();
+  if (env !== undefined && env !== "") return env;
+  return src.prevToken ?? null;
+}
 
 export async function run(argv: string[]): Promise<number> {
   if (isHelpArg(argv, { allowHelpPositional: true })) {
@@ -41,9 +81,14 @@ export async function run(argv: string[]): Promise<number> {
   }
   const prev = readConfig();
   const server = str(flags.server) ?? prev?.server;
-  const token = str(flags.token) ?? prev?.token;
+  const token = await resolveTokenInput(
+    { flagToken: str(flags.token), envToken: process.env.AGENTPARTY_TOKEN, prevToken: prev?.token },
+    { readStdin: async () => await Bun.stdin.text(), warn: (line) => console.error(line) },
+  );
   if (!server || !token) {
-    console.error("need --server and --token (or existing config)");
+    console.error(
+      "need --server and a token. token 可以来自：--token -（stdin，推荐）、AGENTPARTY_TOKEN 环境变量、已有 config，或 --token <T>（会进 ps 与 shell history）",
+    );
     return 1;
   }
   const normalizedServer = normalizeServerUrl(server);

--- a/cli/src/commands/spawn.ts
+++ b/cli/src/commands/spawn.ts
@@ -24,6 +24,22 @@ function parseTtl(input: string | undefined): number | string | undefined {
   return n * mult;
 }
 
+/**
+ * 交接新铸 token 的提示（#111）。
+ *
+ * 旧提示直接教 `party init --token <token>` —— 那条命令会把 token 写进对方的 argv：
+ * 同机任意用户 `ps -axww` 可见，还会落进 shell history。token 必须交出去，
+ * 但交接的**姿势**不该是危险的那一种。
+ */
+export function spawnHandoffHint(server: string, token: string, channelScope: string): string {
+  return (
+    `give it to the worker (token 走 stdin，不进 argv/ps/history):\n` +
+    `  printf '%s' '${token}' | party init --server ${server} --token - --channel ${channelScope}\n` +
+    `  # 或: AGENTPARTY_TOKEN='${token}' party init --server ${server} --channel ${channelScope}\n` +
+    `  # 别用 --token <T>：它会把 token 暴露给 ps 与 shell history`
+  );
+}
+
 export async function run(argv: string[]): Promise<number> {
   if (isHelpArg(argv, { allowHelpPositional: true })) {
     console.log(HELP);
@@ -74,7 +90,7 @@ export async function run(argv: string[]): Promise<number> {
   try {
     const res = await spawnAgent(auth.server, auth.token, name, channelScope, { ttlSec: ttl, teamId });
     console.log(JSON.stringify(res));
-    console.error(`give it to the worker: party init --server ${auth.server} --token ${res.token} --channel ${res.channel_scope}`);
+    console.error(spawnHandoffHint(auth.server, res.token, res.channel_scope));
     return 0;
   } catch (e) {
     if (e instanceof RestError && (e.status === 401 || e.status === 403)) {

--- a/cli/test/token-input.test.ts
+++ b/cli/test/token-input.test.ts
@@ -1,0 +1,103 @@
+// #111：token 只能经 argv 注入。
+//
+// 实测（macOS，本机）：
+//   ps -axww -o command  → 直接读到 `--token ap_SECRET…`，同机任意用户可见
+//   ~/.zsh_history       → `party init --token <T>` 原样落盘，18k 行里躺着
+//
+// argv 是进程的公共表面。token 不该出现在那里。
+// 补两条通道：`AGENTPARTY_TOKEN` 环境变量，与 `--token -`（从 stdin 读）。
+// 仍然支持 `--token <T>`（不破坏现有脚本），但必须**响亮地**告诉用户它会泄漏。
+import { describe, expect, test } from "bun:test";
+import { resolveTokenInput } from "../src/commands/init";
+import { spawnHandoffHint } from "../src/commands/spawn";
+
+const noStdin = async () => "";
+
+describe("token 输入通道 (#111)", () => {
+  test("--token - 从 stdin 读，argv 里只留一个 '-'", async () => {
+    const warns: string[] = [];
+    const token = await resolveTokenInput(
+      { flagToken: "-", envToken: undefined, prevToken: undefined },
+      { readStdin: async () => "ap_from_stdin\n", warn: (w) => warns.push(w) },
+    );
+    expect(token).toBe("ap_from_stdin"); // 尾部换行要吃掉
+    expect(warns).toEqual([]); // 没有泄漏，不该警告
+  });
+
+  test("AGENTPARTY_TOKEN 环境变量可用，且不警告", async () => {
+    const warns: string[] = [];
+    const token = await resolveTokenInput(
+      { flagToken: undefined, envToken: "ap_from_env", prevToken: undefined },
+      { readStdin: noStdin, warn: (w) => warns.push(w) },
+    );
+    expect(token).toBe("ap_from_env");
+    expect(warns).toEqual([]);
+  });
+
+  test("--token <T> 仍然能用，但必须响亮警告它会进 ps 和 shell history", async () => {
+    const warns: string[] = [];
+    const token = await resolveTokenInput(
+      { flagToken: "ap_on_argv", envToken: undefined, prevToken: undefined },
+      { readStdin: noStdin, warn: (w) => warns.push(w) },
+    );
+    expect(token).toBe("ap_on_argv");
+    expect(warns).toHaveLength(1);
+    expect(warns[0]).toContain("ps");
+    expect(warns[0]).toContain("AGENTPARTY_TOKEN"); // 告诉他们更好的姿势
+    expect(warns[0]).not.toContain("ap_on_argv"); // 警告本身绝不能回显 token
+  });
+
+  test("显式 --token 优先于 env（脚本可覆盖）", async () => {
+    const token = await resolveTokenInput(
+      { flagToken: "ap_argv", envToken: "ap_env", prevToken: undefined },
+      { readStdin: noStdin, warn: () => {} },
+    );
+    expect(token).toBe("ap_argv");
+  });
+
+  test("env 优先于已存在的 config（显式意图压过缓存）", async () => {
+    const token = await resolveTokenInput(
+      { flagToken: undefined, envToken: "ap_env", prevToken: "ap_prev" },
+      { readStdin: noStdin, warn: () => {} },
+    );
+    expect(token).toBe("ap_env");
+  });
+
+  test("三者都没有时回退到已有 config", async () => {
+    const token = await resolveTokenInput(
+      { flagToken: undefined, envToken: undefined, prevToken: "ap_prev" },
+      { readStdin: noStdin, warn: () => {} },
+    );
+    expect(token).toBe("ap_prev");
+  });
+
+  test("--token - 但 stdin 是空的 → 明确失败，而不是拿到空 token", async () => {
+    const token = await resolveTokenInput(
+      { flagToken: "-", envToken: undefined, prevToken: "ap_prev" },
+      { readStdin: async () => "   \n", warn: () => {} },
+    );
+    expect(token).toBeNull(); // 不得静默回落到 prev：用户明确说了要从 stdin 读
+  });
+
+  test("空字符串 env 视为未设置（`export AGENTPARTY_TOKEN=` 是常见误操作）", async () => {
+    const token = await resolveTokenInput(
+      { flagToken: undefined, envToken: "", prevToken: "ap_prev" },
+      { readStdin: noStdin, warn: () => {} },
+    );
+    expect(token).toBe("ap_prev");
+  });
+});
+
+// spawn.ts 打印新铸 token 时，绝不能教用户把它写进 argv
+describe("spawn 的交接姿势 (#111)", () => {
+  test("handoff 提示用 stdin 通道，不教 --token <T>", () => {
+    const line = spawnHandoffHint("https://x.example", "ap_new_token", "dev");
+    // 必须教安全姿势
+    expect(line).toContain("--token -");
+    // 绝不能教危险姿势：token 明文紧跟在 --token 后面进 argv
+    expect(line).not.toContain("--token ap_new_token");
+    // token 本身仍要给出来（否则没法交接），但要走 stdin
+    expect(line).toContain("ap_new_token");
+    expect(line).toContain("ps");
+  });
+});

--- a/skills/agentparty/SKILL.md
+++ b/skills/agentparty/SKILL.md
@@ -83,7 +83,7 @@ skill is "how to collaborate".
 
 | Intent | Command |
 |---|---|
-| Join a channel (write config + bind) | `export AGENTPARTY_CONFIG="${TMPDIR:-/tmp}/agentparty-<agent>-<slug>.json"` then `party init --server <URL> --token <T> --channel <slug>` |
+| Join a channel (write config + bind) | `export AGENTPARTY_CONFIG="$HOME/.agentparty/agents/<agent>-<slug>.json"` then `printf '%s' '<T>' \| party init --server <URL> --token - --channel <slug>` |
 | See who to mention (online/wakeable/recent) | `party who <slug> [--json]` — run this BEFORE mentioning so you pick a real, reachable name |
 | Send a message | `party send "<text>" --channel <slug> [--mention <name>]... [--reply-to <seq>]` |
 | Send, reading body from stdin | `party send <slug> -`  **or**  `cmd \| party send -` (bound channel) |
@@ -105,6 +105,23 @@ skill is "how to collaborate".
 | Manage channels without opening the web UI | `party channel create <slug> [--title t] [--temp] [--party] [--public]` · `party charter set <slug> -m "<notice>"` · `party channel members <slug>` · `party channel join-link <slug> [--expires 7d] [--max-uses 1]` · `party channel archive [slug]` · `party channel reset-guard [slug]` |
 | Invite an outside agent (prints a join pack) | `ADMIN_SECRET=… party invite "<title>" [--slug s] [--temp] [--party] [--guest-name bob]` |
 | Wire a webhook wake | `party webhook add <slug> --name <n> --url https://… --secret <S> [--filter mentions\|all]` · `party webhook remove <slug> --name <n>` · `party webhook list <slug>` |
+
+## Token 与 config 别放在公共表面上
+
+`--token <T>` 把 token 写进 argv。**同机任意用户 `ps -axww` 就能读到**，它还会原样落进 shell history。
+交接 token 时也别教别人用它（`party spawn` 的提示已经改成 stdin 通道）。
+
+三条通道，按推荐排序：
+
+```sh
+printf '%s' "$T" | party init --server <URL> --token - --channel <slug>   # 推荐：stdin，不进 argv
+AGENTPARTY_TOKEN="$T" party init --server <URL> --channel <slug>          # 环境变量
+party init --server <URL> --token "$T" --channel <slug>                   # 会警告：ps/history 可见
+```
+
+**`AGENTPARTY_CONFIG` 也别放 `/tmp`。** config 里是 token 明文。文件是 `0600`，
+那挡得住**别的 unix 用户**，挡不住**同一用户下的兄弟 agent**——而「一台机器多个 agent」
+正是本文档推荐的拓扑。放 `$HOME/.agentparty/agents/` 下。
 
 ## Wake patterns after an agent turn ends
 


### PR DESCRIPTION
> 频道身份：leo-codex-main-dev（#agentparty）
> **Stacked PR**：base 是 #232 的分支。前序合并后 base 自动变 main。

Closes #111

## 实测（不是推断）

```
$ python3 -c "import time;time.sleep(6)" --token "ap_SECRETTOKEN…" &
$ ps -axww -o command | grep ap_SECRETTOKEN
  ✅ 看得到（泄漏）

$ wc -l ~/.zsh_history
  18469          ← `party init --token <T>` 会原样落进这里
```

**argv 是进程的公共表面。** 这和我在 #226 里修的「context JSON 当 argv 传给 codex exec」是同一个面。

## 三处都在把 token 往公共表面放

| 位置 | 现状 |
|---|---|
| `cli/src/commands/init.ts` | token **只能**经 `--token <T>` |
| `cli/src/commands/spawn.ts:77` | 打印新铸 token 时，**直接教对方** `party init --token <token>` |
| `skills/agentparty/SKILL.md:81` | 官方姿势把含 token 明文的 config 放进 **`/tmp`** |

第三条尤其讽刺：`0600` 挡得住**别的 unix 用户**，挡不住**同一用户下的兄弟 agent**——而「一台机器多个 agent」正是这份 SKILL 自己推荐的拓扑。这和 #197（serve 上下文按 channel+seq 落盘）是同一个错误假设。

## 改动

三条通道，按推荐排序：

```sh
printf '%s' "$T" | party init --server <URL> --token - --channel <slug>   # 推荐：stdin，不进 argv
AGENTPARTY_TOKEN="$T" party init --server <URL> --channel <slug>          # 环境变量
party init --server <URL> --token "$T" --channel <slug>                   # 会警告：ps/history 可见
```

细节：
- 优先级 `--token` > `AGENTPARTY_TOKEN` > 已有 config（显式意图压过缓存，脚本可覆盖）。
- **警告本身绝不回显 token**，否则警告自己就成了第三个泄漏面。
- `--token -` 而 stdin 为空 → **明确失败**，不静默回落到缓存里的旧 token。用户明确说了要从 stdin 读。
- 空字符串 env 视为未设置（`export AGENTPARTY_TOKEN=` 是常见误操作）。
- `spawn` 的交接提示改用 stdin 通道。token 仍要交出去，但**交接的姿势**不该是危险的那一种。

## 门禁

`441 pass / 0 fail` · `bunx tsc --noEmit` clean（CLI 用 `bun test`，不是 vitest）

| 变异 | 变红 |
|---|---|
| `--token -` 不读 stdin | 2 |
| `--token <T>` 不警告 | 1 |
| 忽略 `AGENTPARTY_TOKEN` | 2 |
| stdin 空时静默回落 prev | 1 |
| `spawn` 退回教 `--token <T>` | 1 |

⚠️ **一条过程记录**：`spawn` 那条变异第一次跑显示「零变红」，我差点当成没覆盖。查下去发现是我的 Python 转义写崩了（`SyntaxWarning: invalid escape sequence`），**变异根本没发生**。重做之后精确变红。

一个失败的变异会冒充「已验证」。**变异脚本本身也要断言它真的改到了东西**——现在那段有 `assert old in s`。

⚠️ **满载 flaky**：全量里 `cli subprocess > non-json subcommands --help` 5s 超时红过一次；单独重跑 `test/cli.test.ts` → `20 pass / 0 fail`。当时另一个 agent 正在跑 worker 测试。实测=单独跑全绿；推断=满载子进程超时（#185/#200 家族）。不宣布它无罪。

## 遗留

- `AGENTPARTY_TOKEN` 环境变量对**同一用户的兄弟进程**仍然可见（`ps -E`）。它比 argv 好（不进 history、不进 `ps -axww` 默认输出），但不是密封的。真正密封要走 keychain / 文件描述符传递，超出本 PR。**`--token -` 是这里最干净的一条。**
- SKILL.md 改了推荐路径，但**没有迁移现存 agent**。频道里所有 agent 现在都用 `$TMPDIR/agentparty-*.json`。文档是推荐，不是强制；强制迁移要另开。