### PR TITLE
fix(cli): who --json 补出 account/handle/display_name，不再让人类 @ 送不到 (#110)

### DIFF
--- a/cli/src/commands/who.ts
+++ b/cli/src/commands/who.ts
@@ -110,11 +110,25 @@ function readNote(readSeq: number | undefined, lastSeq: number): string {
 
 // 身份分层（#110）：终端行里补出 @handle / account / 展示名，让人看得见「该 @ 哪个别名」。
 // handle 是人类被 @ 通知的真正投递键（web notify 按 handle 命中），name 可能只是 UUID 会话名。
+export function terminalIdentityText(value: string): string {
+  return value.replace(/[\u0000-\u001F\u007F-\u009F]+/g, " ").replace(/\s+/g, " ").trim();
+}
+
 export function identityNote(r: Row): string {
   const parts: string[] = [];
-  if (r.handle !== undefined && r.handle !== r.name) parts.push(`@${r.handle}`);
-  if (r.display_name !== undefined) parts.push(r.display_name);
-  if (r.account !== undefined) parts.push(r.account);
+  const name = terminalIdentityText(r.name);
+  if (r.handle !== undefined) {
+    const handle = terminalIdentityText(r.handle);
+    if (handle !== "" && handle !== name) parts.push(`@${handle}`);
+  }
+  if (r.display_name !== undefined) {
+    const displayName = terminalIdentityText(r.display_name);
+    if (displayName !== "") parts.push(displayName);
+  }
+  if (r.account !== undefined) {
+    const account = terminalIdentityText(r.account);
+    if (account !== "") parts.push(account);
+  }
   return parts.length > 0 ? ` (${parts.join(" · ")})` : "";
 }
 

--- a/cli/src/commands/who.ts
+++ b/cli/src/commands/who.ts
@@ -21,10 +21,13 @@ shown as "watch (unverified)" until proven — check with: party wake test @name
 A "read #N / read ✓ / N behind" note shows how far a streaming reader (web, or an
 agent on serve / watch --follow) has read. No note = not a line-by-line reader.
 Then bring one in: party send "@name …" --mention name
+A human is @-notified by their handle (their web client matches on handle, not the
+session name), so mention the "@handle" shown here — not a UUID session name.
 
 Options:
   --channel C   read channel C instead of the bound channel
-  --json        emit one JSON object per line (name/kind/tier/wake/wake_unverified/age_ms/read_seq)`;
+  --json        emit one JSON object per line
+                (name/kind/tier/wake/wake_unverified/account/handle/display_name/age_ms/read_seq)`;
 
 const STALE_MS = 60_000; // 与 DO presence 扫描一致
 const DEAD_MS = 14 * 24 * 60 * 60 * 1000; // 14 天没露面视为幽灵，不再列
@@ -45,6 +48,12 @@ interface Row {
   age_ms: number;
   connection_count?: number;
   read_seq?: number; // 读到的最大 seq（Phase 2）；无游标 = 不逐帧流式读，不标注
+  // 身份分层（#110）：presence 已带 account/handle/display_name，who 之前只吐 name，
+  // 想 @ 一个人类的 agent 从 who 里看不到 handle——而 web 通知按 handle 命中，@ 名字送不到。
+  // 这里原样带出（仅在 presence 给了非空值时），让 who 不再对已有身份信息保持沉默。
+  account?: string; // 会话背后的账号（人类 = OIDC email；agent = owner）
+  handle?: string; // 人类全局唯一 @别名；@ 通知的真正投递键（web notify 按 handle 命中）
+  display_name?: string; // OAuth/SSO 展示名
 }
 
 // kind 已知取 kind；旧 presence 行没回填时 UUID 名判 human（网页登录会话），其余判 agent。
@@ -77,6 +86,10 @@ export function classify(e: PresenceEntry, now: number): Row | null {
     tier,
     ...(wake === undefined ? {} : { wake }),
     ...(wake === "watch" && e.wake?.verified_at === undefined ? { wake_unverified: true as const } : {}),
+    // 身份分层（#110）：只在 presence 给了非空值时带出，缺失就省略（诚实留白，不无中生有）。
+    ...(typeof e.account === "string" && e.account !== "" ? { account: e.account } : {}),
+    ...(typeof e.handle === "string" && e.handle !== "" ? { handle: e.handle } : {}),
+    ...(typeof e.display_name === "string" && e.display_name !== "" ? { display_name: e.display_name } : {}),
     age_ms: age,
     ...(typeof e.connection_count === "number" && e.connection_count > 1
       ? { connection_count: e.connection_count }
@@ -93,6 +106,16 @@ function readNote(readSeq: number | undefined, lastSeq: number): string {
   if (lastSeq > 0 && readSeq >= lastSeq) return " · read ✓";
   const behind = lastSeq - readSeq;
   return behind > 0 ? ` · read #${readSeq} (${behind} behind)` : ` · read #${readSeq}`;
+}
+
+// 身份分层（#110）：终端行里补出 @handle / account / 展示名，让人看得见「该 @ 哪个别名」。
+// handle 是人类被 @ 通知的真正投递键（web notify 按 handle 命中），name 可能只是 UUID 会话名。
+export function identityNote(r: Row): string {
+  const parts: string[] = [];
+  if (r.handle !== undefined && r.handle !== r.name) parts.push(`@${r.handle}`);
+  if (r.display_name !== undefined) parts.push(r.display_name);
+  if (r.account !== undefined) parts.push(r.account);
+  return parts.length > 0 ? ` (${parts.join(" · ")})` : "";
 }
 
 function humanAge(ms: number): string {
@@ -172,7 +195,7 @@ export async function run(argv: string[]): Promise<number> {
       const age = r.tier === "online" ? "" : ` (${humanAge(r.age_ms)})`;
       const duplicate = r.connection_count !== undefined ? ` x${r.connection_count} sessions` : "";
       const read = readNote(r.read_seq, lastSeq);
-      console.log(`${DOT[r.tier]} ${r.tier.padEnd(8)} ${r.name}  [${r.kind}]${wake}${read}${duplicate}${age}`);
+      console.log(`${DOT[r.tier]} ${r.tier.padEnd(8)} ${r.name}  [${r.kind}]${identityNote(r)}${wake}${read}${duplicate}${age}`);
     }
     return 0;
   } catch (e) {

--- a/cli/test/who.test.ts
+++ b/cli/test/who.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { PresenceEntry } from "@agentparty/shared";
-import { classify } from "../src/commands/who";
+import { classify, identityNote } from "../src/commands/who";
 
 const NOW = 1_000_000_000;
 
@@ -49,6 +49,83 @@ describe("who classify（#47：可唤醒判定按 wake.kind 分口径）", () =>
 
   test("不在线的人类不列", () => {
     expect(classify(p({ name: "leo", kind: "human", state: "offline", last_seen: NOW - 120_000 }), NOW)).toBeNull();
+  });
+});
+
+describe("who 身份分层（#110：who --json 不再对 presence 已有的身份信息保持沉默）", () => {
+  // presence 里 name / kind / account / handle / display_name 是五层身份；who 只吐 name 时，
+  // 想 @ 一个人类的 agent 从 who 里看不到 handle，@ 名字送不到（web 通知按 handle 命中）。
+  test("在线人类：handle / account / display_name 原样带出，与 presence 一致", () => {
+    const e = p({
+      name: "web-login-uuid",
+      kind: "human",
+      state: "working",
+      account: "davianpearson1@gmail.com",
+      handle: "leo",
+      display_name: "Davian Pearson",
+    });
+    const r = classify(e, NOW);
+    expect(r).not.toBeNull();
+    expect(r?.handle).toBe("leo");
+    expect(r?.account).toBe("davianpearson1@gmail.com");
+    expect(r?.display_name).toBe("Davian Pearson");
+  });
+
+  test("agent 也带出 account（owner/账号），供归属展示", () => {
+    const r = classify(p({ name: "leeguooooo-agentparty-mini2", account: "leeguooooo@gmail.com" }), NOW);
+    expect(r?.account).toBe("leeguooooo@gmail.com");
+  });
+
+  test("缺字段就省略（不无中生有 null/空串），诚实留白", () => {
+    const r = classify(p({ name: "bob" }), NOW);
+    expect(r).not.toBeNull();
+    expect("handle" in (r as object)).toBe(false);
+    expect("account" in (r as object)).toBe(false);
+    expect("display_name" in (r as object)).toBe(false);
+  });
+
+  test("空串等同缺失：不下发（presence 层不会给空串，但防御性对齐）", () => {
+    const r = classify(p({ name: "bob", handle: "", account: "", display_name: "" }), NOW);
+    expect("handle" in (r as object)).toBe(false);
+    expect("account" in (r as object)).toBe(false);
+    expect("display_name" in (r as object)).toBe(false);
+  });
+
+  // 绑定真实观测路径：who --json 打印的是 JSON.stringify(classify(...))，断言序列化后 key 真的在。
+  test("JSON.stringify（who --json 的真实输出）含 handle/account/display_name 且值一致", () => {
+    const e = p({
+      name: "web-login-uuid",
+      kind: "human",
+      state: "working",
+      account: "davianpearson1@gmail.com",
+      handle: "leo",
+      display_name: "Davian Pearson",
+    });
+    const line = JSON.stringify(classify(e, NOW));
+    const parsed = JSON.parse(line) as Record<string, unknown>;
+    expect(parsed.handle).toBe("leo");
+    expect(parsed.account).toBe("davianpearson1@gmail.com");
+    expect(parsed.display_name).toBe("Davian Pearson");
+    // 与 presence 输入的值逐字一致（不是只断言 key 存在）
+    expect(parsed.handle).toBe(e.handle);
+    expect(parsed.account).toBe(e.account);
+    expect(parsed.display_name).toBe(e.display_name);
+  });
+
+  // 终端行（非 --json）也要能看见 @handle，否则人类读 who 仍不知道该 @ 谁。
+  test("identityNote：@handle 出现在人类可读行里；handle==name 时不重复", () => {
+    const withHandle = classify(
+      p({ name: "web-login-uuid", kind: "human", state: "working", handle: "leo", account: "a@b.com" }),
+      NOW,
+    );
+    const note = identityNote(withHandle!);
+    expect(note).toContain("@leo");
+    expect(note).toContain("a@b.com");
+    // handle 与 name 相同 → 不重复贴 @name
+    const same = classify(p({ name: "leo", kind: "human", state: "working", handle: "leo" }), NOW);
+    expect(identityNote(same!)).not.toContain("@leo");
+    // 什么身份信息都没有 → 空串，不污染输出
+    expect(identityNote(classify(p({ name: "bob" }), NOW)!)).toBe("");
   });
 });
 

--- a/cli/test/who.test.ts
+++ b/cli/test/who.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { PresenceEntry } from "@agentparty/shared";
-import { classify, identityNote } from "../src/commands/who";
+import { classify, identityNote, terminalIdentityText } from "../src/commands/who";
 
 const NOW = 1_000_000_000;
 
@@ -126,6 +126,34 @@ describe("who 身份分层（#110：who --json 不再对 presence 已有的身�
     expect(identityNote(same!)).not.toContain("@leo");
     // 什么身份信息都没有 → 空串，不污染输出
     expect(identityNote(classify(p({ name: "bob" }), NOW)!)).toBe("");
+  });
+
+  test("who --json 保留 raw 身份字段；终端 identityNote 归一化控制字符", () => {
+    const e = p({
+      name: "web-login-uuid",
+      kind: "human",
+      state: "working",
+      handle: "leo\n\u001b[31m\u009badmin",
+      account: "team\r\nroot@example.com",
+      display_name: "Davian\tPearson\u007f\u0085Ops",
+    });
+    const r = classify(e, NOW)!;
+
+    // JSON 路径必须保持 presence 的真实 raw 值，不能为了终端展示污染机器可读输出。
+    const parsed = JSON.parse(JSON.stringify(r)) as Record<string, unknown>;
+    expect(parsed.handle).toBe(e.handle);
+    expect(parsed.account).toBe(e.account);
+    expect(parsed.display_name).toBe(e.display_name);
+
+    const note = identityNote(r);
+    expect(note).toContain("@leo [31m admin");
+    expect(note).toContain("team root@example.com");
+    expect(note).toContain("Davian Pearson Ops");
+    expect(note).not.toMatch(/[\u0000-\u001F\u007F-\u009F]/);
+  });
+
+  test("terminalIdentityText：控制字符变空格，并折叠多余空白", () => {
+    expect(terminalIdentityText(" a\n\tb\u001b[31m\u009bc\u007f\u0085 ")).toBe("a b [31m c");
   });
 });
 


### PR DESCRIPTION
> 频道身份：leo-codex-main-dev（#agentparty）

Closes #110

## 结论：issue 论断成立（未证伪）

`presence` 有五层身份 `name / kind / account / handle / display_name`，`party who --json` 只吐 `name`。核心不是"缺个字段"，是 **who 对 presence 已有的身份信息保持沉默**——本仓库已经因"把工具的沉默当数据"酿过一次全频道误报离线事故。

## 实跑证据：`who --json` vs presence REST（同一时刻，#agentparty，21 条 presence）

**改前 `party who agentparty --json`（v0.2.88 安装版）** 每行 key 只有：
```
name, kind, tier, wake, age_ms, read_seq, wake_unverified   (+ connection_count 当 >1)
```

**同一时刻 `GET /api/channels/agentparty/presence`** 每条 presence 的 key 并集：
```
name, kind, account, state, note, ts, last_seen, status,
role, role_source, residency, wake, context, lineage, live
```
其中 `account`（agent=owner、人类=OIDC email）被 who 整个丢掉；协议里的 `handle / display_name` 同一序列化路径（`do.ts presenceRowToEntry`）也照丢——当时无带 handle 的人类在线，故快照里未出现，但机制一致。

**改后 patched who 实跑（bun run src/index.ts who agentparty --json）**，同一 agent 现在带出 account：
```
改前: {"name":"leeguooooo-agentparty-mini2","kind":"agent","tier":"recent","wake":"serve","age_ms":...}
改后: {"name":"leeguooooo-agentparty-mini2","kind":"agent","tier":"recent","wake":"serve","account":"leeguooooo@gmail.com","age_ms":...}
```
终端行同步补出：`○ recent leeguooooo-agentparty-mini2 [agent] (leeguooooo@gmail.com) (1h)`

> 证据分级：`account` 补出为**实跑观测**（上方 live 输出）；`handle / display_name` 为**单测验证**（当前无带 handle 的人类在线，无法 live 复现，但 do.ts 对三者用同一条 `COALESCE ... string && !==""` 序列化，classify 用同一守卫透传，行为同构）。

## "无 handle 的人类收不到 @" —— 成立

送达按 **handle**，不是 name：`web/src/lib/notify.ts` `isOwnMention` → `myHandle===null` 直接返回 false，且命中判据是 `msg.mentions.includes(myHandle)`；`Channel.tsx` 传入的 `selfHandle` = 人类账号的 @handle。服务端 `do.ts` 不做 name↔handle 改写（`expandSquadMentions` 只展开 squad）。于是：

- 人类**无 handle** → `myHandle` 为 null → 任何 @ 永不触发通知（web 侧硬事实）。
- 人类**有 handle 但 name≠handle**（web 登录 name 常是 UUID）→ 只有 @handle 能命中；而 who 只给 name，agent 无从得知 handle，@ 名字静默失败。

who 补出 handle 修的是后者：让 agent 从 who 就能看到该 @ 的 @handle（终端行 `@handle`，json 里 `handle`）。前者（人类根本没设 handle）是账号侧问题，who 无法凭空造 handle，本 PR 不声称修它。

## 变异表（逐接线点拆除，`cd cli && bun test test/who.test.ts`）

| # | 变异 | 精确变红的测试 |
|---|---|---|
| M1 | classify 去掉 `account` 透传 | 原样带出 / agent 带 account / JSON.stringify 一致 / identityNote（4 红）|
| M2 | classify 去掉 `handle` 透传 | 原样带出 / JSON.stringify 一致 / identityNote（3 红）|
| M3 | classify 去掉 `display_name` 透传 | 原样带出 / JSON.stringify 一致（2 红）|
| M4 | 去掉 handle 空串守卫（`!==""`）| 空串等同缺失（1 红）|
| M5 | identityNote 去掉 `handle!==name` 守卫 | identityNote（1 红）|
| M6 | identityNote 从不 push handle | identityNote（1 红）|

零漏网：每个接线点都有测试精确变红。

## 门禁

- `cd cli && bun test` → **407 pass / 0 fail**（who.test.ts 17 pass）
- `cd cli && bunx tsc --noEmit` → 干净（exit 0）
- 先写测试 → 亲眼见红（`Received: undefined`，功能缺失非拼写）→ 再实现 → 转绿

## 纪律与边界

- 只改 `cli/src/commands/who.ts`；`shared/src/protocol.ts` 未改（字段本就在 `PresenceEntry`，无需扩）。`do.ts / index.ts / rest.ts` 只读未动。
- 环境：CLI 用 `bun test`（非 vitest）；根目录 `bun install` 后测试全绿，无 flaky。

## 遗留

- 人类"根本没设 handle → 收不到任何 @"是账号侧缺口，who 无法修（无 handle 可显示）；可另开 issue 引导人类设 handle 或让 web 在无 handle 时回退按 name 命中。
- 未改终端列宽/对齐逻辑，identity note 直接尾接，长 account 会让行变长——纯展示，不影响 json 契约。
