### PR TITLE
fix(cli): serve 同机单实例锁 + runner workdir 按身份隔离（#99 同机那半）

### DIFF
--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -15,11 +15,12 @@ import {
   writeFileSync,
 } from "node:fs";
 import { homedir, tmpdir } from "node:os";
-import { isAbsolute, join } from "node:path";
+import { dirname, isAbsolute, join } from "node:path";
 import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
 import { readAccount } from "../account";
 import { connect } from "../client";
-import { clearStuck, loadCursor, loadRevCursor, loadStuck, resolveChannel, saveCursor, saveRevCursor, saveStuck, type StuckWake } from "../config";
+import { readConfig, clearStuck, loadCursor, loadRevCursor, loadStuck, resolveChannel, saveCursor, saveRevCursor, saveStuck, statePath, type StuckWake } from "../config";
+import { acquireInstanceLock } from "../instance-lock";
 import { formatMsg } from "../format";
 import { ensureFreshAccess, resolveAuthDetailed, type ResolvedAuthDetailed } from "../oidc-cli";
 import {
@@ -57,6 +58,9 @@ export class WakeBlockedError extends Error {
 
 // 放弃通告都发不出去（网络/loop guard 熔断）。此时既没送达也没宣告，继续跑就是静默丢 @。
 export const EXIT_WAKE_UNANNOUNCED = 1;
+
+/** 已有 serve 挂在同一 (channel, workspace) 上：拒绝启动，避免重复执行（#99）。 */
+export const EXIT_ALREADY_SERVING = 10;
 
 /** 传给 builtin runner 的提示：只给路径，不给正文（#120）。 */
 function wakePrompt(contextFile: string): string {
@@ -239,6 +243,30 @@ export function writeContextFile(
   return path;
 }
 
+/**
+ * runner workdir 按 (频道, 身份) 隔离（#99）。
+ *
+ * 旧实现只按频道键（`~/.agentparty/runners/<channel>`）。同机两个身份 serve 同一频道时，
+ * 它们共享同一个 wake-session.json：互相把对方的 codex/claude session id 覆盖掉，
+ * 而 builtin runner 在 resume 失败时会 fork 出一个新 session——于是重复执行。
+ *
+ * 身份未知（还没连上服务端拿到 welcome.self）时退回按频道键，保持旧行为。
+ */
+export function runnerWorkdir(root: string, channel: string, self: string | undefined): string {
+  const safe = (part: string) => part.replace(/[^a-zA-Z0-9._-]/g, "_").replace(/\.{2,}/g, "_") || "_";
+  if (self === undefined || self === "") return join(root, safe(channel));
+  return join(root, `${safe(channel)}-${safe(self)}`);
+}
+
+/**
+ * 默认 runner workdir。身份取自本地 config（启动时就有；welcome.self 要等连上才有）。
+ * 没有缓存身份时退回按频道键，保持旧行为。
+ */
+export function defaultRunnerWorkdir(channel: string, cwd: string = process.cwd()): string {
+  const self = readConfig(cwd)?.identity?.name;
+  return runnerWorkdir(join(homedir(), ".agentparty", "runners"), channel, self);
+}
+
 const SERVE_FLAGS = ["channel", "on-mention", "all", "runner", "workdir", "repo", "auto-upgrade", "replay-backlog", "profile", "profile-once", "profile-poll-interval"];
 const HELP = `usage: party serve [channel|--channel C] (--on-mention "<cmd>" | --runner codex|claude|codex-sdk) [--all]
        party serve --profile <owner>/<handle>
@@ -274,6 +302,10 @@ export interface ServeOptions {
   // 但「积压」与「欠账」是两回事（#198）：跳过的只能是**已离线堆积、从未送达**的历史；
   // 送达失败被钉住的 stuck 无论多旧都必须重放，否则 #118 救下的那条 @ 会被这里吃掉。
   skipBacklog?: boolean;
+  /** 单实例锁目录（#99）。默认与 workspace state 同放；测试注入。 */
+  lockDir?: string;
+  /** 关掉单实例保护（逃生舱）。 */
+  allowMultiple?: boolean;
   builtinRunner?: BuiltinRunnerOptions;
   onCursor?: (cursor: number) => void;
   onRevCursor?: (revCursor: number) => void;
@@ -1157,6 +1189,18 @@ export async function runServe(o: ServeOptions): Promise<number> {
   });
 
   const skipBacklog = o.skipBacklog !== false; // 默认跳过离线积压（#193）
+  // 抢锁在连 WS 之前：第二个 serve 连接都不该建，否则它已经在消费 @、已经在跑 runner 了（#99）。
+  // 这把锁只挡同机；跨机器重复执行需要服务端租约（do.ts 广播发给同名所有连接）。
+  const lockDir = o.lockDir ?? dirname(statePath());
+  const lock = o.allowMultiple === true ? null : acquireInstanceLock("serve", o.channel, lockDir);
+  if (lock && !lock.ok) {
+    out(
+      `serve: 已有 serve 挂在 #${o.channel} 上（pid ${lock.heldByPid}）。` +
+        ` 再挂一个会让同一条 @ 触发两次完整 runner——双份回帖，git push 类副作用执行两遍。` +
+        ` 要么等它退出，要么 kill ${lock.heldByPid}；确实想并存请加 --allow-multiple。`,
+    );
+    return EXIT_ALREADY_SERVING;
+  }
   // 本实例私有的上下文命名空间（#197 / #208 门禁）。退出时整目录删除：
   // 失败的唤醒会把上下文留在盘上供本次排查，但它带着 charter / recent 正文，
   // 不能在进程结束后继续躺在共享 tmpdir 里。
@@ -1512,7 +1556,7 @@ export async function run(argv: string[]): Promise<number> {
           token,
           channel,
           harness,
-          workdir: expandHomePath(str(flags.workdir) ?? join(homedir(), ".agentparty", "runners", channel)),
+          workdir: expandHomePath(str(flags.workdir) ?? defaultRunnerWorkdir(channel)),
           repo: str(flags.repo),
         }
       : undefined,
@@ -1521,7 +1565,7 @@ export async function run(argv: string[]): Promise<number> {
           server,
           token,
           channel,
-          workdir: expandHomePath(str(flags.workdir) ?? join(homedir(), ".agentparty", "runners", channel)),
+          workdir: expandHomePath(str(flags.workdir) ?? defaultRunnerWorkdir(channel)),
         }
       : undefined,
   });

--- a/cli/src/commands/watch.ts
+++ b/cli/src/commands/watch.ts
@@ -1,7 +1,7 @@
 // party watch — 补拉错过消息，阻塞等新消息
 import { EXIT_ARCHIVED, EXIT_AUTH, EXIT_LOOP_GUARD, EXIT_STREAM_ENDED, EXIT_TIMEOUT } from "@agentparty/shared";
-import { mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { dirname } from "node:path";
+import { acquireInstanceLock } from "../instance-lock";
 import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
 import { connect } from "../client";
 import { loadCursor, loadRevCursor, resolveChannel, saveCursor, saveRevCursor, statePath } from "../config";
@@ -67,65 +67,6 @@ export function isCodexRuntimeEnv(env: Record<string, string | undefined> = proc
   return Object.keys(env).some((key) => key === "CODEX" || key.startsWith("CODEX_") || key.startsWith("OPENAI_CODEX"));
 }
 
-/**
- * 单实例锁（#195）。
- *
- * `watch --once` 的推荐用法是「退出 → 处理 → 重挂」，重挂这一步在 harness 里是手动的、无守卫的。
- * 实测：10 个唤醒周期后同一 (channel, workspace) 上并存两个 watcher，一条 @ 触发两次 runner，
- * agent 把同一条消息回了两遍——而 `party who` 只显示一个 ● online，重复从产品内部完全不可见。
- * 在开着 loop guard 的频道里，这直接给熔断计数器加了个乘数。
- *
- * 用 pid 锁而不是 flock：Bun 没有跨平台 flock，且我们要能告诉用户「是哪个 pid 占着」。
- * 陈旧锁（写锁的进程已死）必须能接管，否则一次 SIGKILL 就把频道永久锁死。
- */
-export interface WatchLock {
-  ok: boolean;
-  /** ok=false 时，当前持锁的进程 pid。 */
-  heldByPid?: number;
-  release?: () => void;
-}
-
-function watchLockPath(channel: string, dir: string): string {
-  return join(dir, `watch-${channel.replace(/[^a-zA-Z0-9._-]/g, "_")}.lock`);
-}
-
-function pidAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0); // 信号 0：只探测存活，不真的发信号
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-export function acquireWatchLock(channel: string, dir: string): WatchLock {
-  const path = watchLockPath(channel, dir);
-  mkdirSync(dir, { recursive: true });
-  try {
-    const held = JSON.parse(readFileSync(path, "utf8")) as { pid?: number };
-    // 关键：只有确认写锁的进程**已经死了**才接管。反方向（把活着的当陈旧）会重新引入 #195。
-    if (typeof held.pid === "number" && pidAlive(held.pid)) {
-      return { ok: false, heldByPid: held.pid };
-    }
-  } catch {
-    /* 没有锁文件，或内容坏了：往下走，重新写一个 */
-  }
-  writeFileSync(path, JSON.stringify({ pid: process.pid, channel, ts: Date.now() }), { mode: 0o600 });
-  return {
-    ok: true,
-    release: () => {
-      try {
-        // 只删自己的锁：别人接管过就不动它
-        const cur = JSON.parse(readFileSync(path, "utf8")) as { pid?: number };
-        if (cur.pid === process.pid) unlinkSync(path);
-      } catch {
-        /* 已经没了 */
-      }
-    },
-  };
-}
-
-/** 已有 watcher 挂在同一 (channel, workspace) 上：拒绝启动，避免一条 @ 触发 N 次 runner（#195）。 */
 export const EXIT_ALREADY_WATCHING = 10;
 
 export interface WatchOptions {
@@ -159,7 +100,7 @@ export async function runWatch(o: WatchOptions): Promise<number> {
   const out = o.out ?? ((line: string) => console.log(line));
   // 先抢锁，再连服务端：第二个 watcher 连 WS 都不该建，否则它已经开始消费 @ 了（#195）
   const lockDir = o.lockDir ?? dirname(statePath());
-  const lock = o.allowMultiple === true ? null : acquireWatchLock(o.channel, lockDir);
+  const lock = o.allowMultiple === true ? null : acquireInstanceLock("watch", o.channel, lockDir);
   if (lock && !lock.ok) {
     out(
       `watch: 已有 watcher 挂在 #${o.channel} 上（pid ${lock.heldByPid}）。` +

--- a/cli/src/instance-lock.ts
+++ b/cli/src/instance-lock.ts
@@ -1,0 +1,63 @@
+// 本机单实例锁（#195 watch / #99 serve 的同机那半）。
+//
+// `watch --once` 的「退出 → 处理 → 重挂」和 serve 的重启,两者的重挂步骤都无人守卫。
+// 实测（#195 作者）：10 个唤醒周期后同一 (channel, identity) 上并存两个 watcher,
+// 一条 @ 触发两次 runner,agent 把同一条消息回了两遍——而 `party who` 只显示一个 ● online。
+// serve 更贵：每次重复都是一次完整的 codex/claude run,可能重复 git push、重复开 PR。
+//
+// 用 pid 锁而不是 flock：Bun 没有跨平台 flock,而且我们要能告诉用户**是哪个 pid 占着**。
+// 陈旧锁（写锁的进程已死）必须能接管,否则一次 SIGKILL 就把频道永久锁死。
+//
+// ⚠️ 这把锁只挡**同一台机器**。跨机器的重复执行（工位机 + 家里机各跑一个 serve）
+// 需要服务端租约（#99 的另一半,`do.ts` 广播发给同名所有连接）。
+import { mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+export type InstanceKind = "watch" | "serve";
+
+export interface InstanceLock {
+  ok: boolean;
+  /** ok=false 时,当前持锁的进程 pid。 */
+  heldByPid?: number;
+  release?: () => void;
+}
+
+function lockPath(kind: InstanceKind, channel: string, dir: string): string {
+  return join(dir, `${kind}-${channel.replace(/[^a-zA-Z0-9._-]/g, "_")}.lock`);
+}
+
+function pidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0); // 信号 0：只探测存活,不真的发信号
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function acquireInstanceLock(kind: InstanceKind, channel: string, dir: string): InstanceLock {
+  const path = lockPath(kind, channel, dir);
+  mkdirSync(dir, { recursive: true });
+  try {
+    const held = JSON.parse(readFileSync(path, "utf8")) as { pid?: number };
+    // 关键：只有确认写锁的进程**已经死了**才接管。反方向（把活着的当陈旧）会重新引入 bug。
+    if (typeof held.pid === "number" && pidAlive(held.pid)) {
+      return { ok: false, heldByPid: held.pid };
+    }
+  } catch {
+    /* 没有锁文件,或内容坏了：往下走,重新写一个 */
+  }
+  writeFileSync(path, JSON.stringify({ pid: process.pid, kind, channel, ts: Date.now() }), { mode: 0o600 });
+  return {
+    ok: true,
+    release: () => {
+      try {
+        // 只删自己的锁：别人接管过就不动它
+        const cur = JSON.parse(readFileSync(path, "utf8")) as { pid?: number };
+        if (cur.pid === process.pid) unlinkSync(path);
+      } catch {
+        /* 已经没了 */
+      }
+    },
+  };
+}

--- a/cli/test/serve-argv-leak.test.ts
+++ b/cli/test/serve-argv-leak.test.ts
@@ -105,6 +105,7 @@ describe("AP_BODY 不得把未截断正文塞进 env (#120)", () => {
         since: 0,
         mentionsOnly: true,
         out: () => {},
+        lockDir: tmp(), // 每个测试一把独立锁（#99）
         // env 长度、截断标志、stdin 长度各写一个文件
         cmd: `printf '%s' "$AP_BODY" | wc -c > ${outDir}/envlen; printf '%s' "$AP_BODY_TRUNCATED" > ${outDir}/flag; wc -c > ${outDir}/stdinlen`,
       });
@@ -137,6 +138,7 @@ describe("AP_BODY 不得把未截断正文塞进 env (#120)", () => {
         since: 0,
         mentionsOnly: true,
         out: () => {},
+        lockDir: tmp(), // 每个测试一把独立锁（#99）
         cmd: `printf '%s' "$AP_BODY" > ${outDir}/body; printf '%s' "$AP_BODY_TRUNCATED" > ${outDir}/flag`,
       });
       expect(readFileSync(join(outDir, "body"), "utf8")).toBe("short");

--- a/cli/test/serve-failure-ack.test.ts
+++ b/cli/test/serve-failure-ack.test.ts
@@ -43,6 +43,9 @@ function opts(over: Partial<ServeOptions> & { server: string }): ServeOptions & 
     mentionsOnly: true,
     out: (line) => lines.push(line),
     lines,
+    // 每个测试一把独立的单实例锁（#99）：测试不该依赖真实 ~/.agentparty，
+    // 也不该互相抢锁（第二个 runServe 会被拒并返回 EXIT_ALREADY_SERVING）
+    lockDir: mkdtempSync(join(tmpdir(), "ap-lock-")),
     wakeRetryDelayMs: 0,
     ...over,
   };

--- a/cli/test/serve-lease.test.ts
+++ b/cli/test/serve-lease.test.ts
@@ -1,0 +1,158 @@
+// #99：同名 agent 的多个 serve 无租约/互斥，重复执行零护栏。
+//
+// issue 有两半：
+//   A) 跨机器：do.ts 广播发给同名所有连接（`do.ts:2948-2952`、`993-1037`），
+//      工位机 + 家里机各跑一个 serve → 每条 @ 触发两次完整 codex run、双份回帖、
+//      git push 类副作用执行两遍。唯一线索是 `who` 里不起眼的 `x2 sessions`。
+//      **这半需要服务端租约**（do.ts 被三个未合并 PR 压着），不在本 PR。
+//   B) 同机：workdir 只按频道键（`serve.ts:1455`），多个 serve 共享同一个
+//      wake-session.json 互踩，且失败即 fork。这半在本 PR。
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { acquireInstanceLock } from "../src/instance-lock";
+import { defaultRunnerWorkdir, EXIT_ALREADY_SERVING, runnerWorkdir, runServe } from "../src/commands/serve";
+import { startMockServer, welcomeFrame } from "./mock-server";
+
+const dirs: string[] = [];
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+function dir(): string {
+  const d = mkdtempSync(join(tmpdir(), "ap-lease-"));
+  dirs.push(d);
+  return d;
+}
+
+describe("serve 同机单实例 (#99 的同机那半)", () => {
+  test("第二个 serve 被拒，并告知占锁的 pid", () => {
+    const d = dir();
+    const first = acquireInstanceLock("serve", "dev", d);
+    expect(first.ok).toBe(true);
+
+    const second = acquireInstanceLock("serve", "dev", d);
+    expect(second.ok).toBe(false);
+    expect(second.heldByPid).toBe(process.pid);
+
+    first.release?.();
+  });
+
+  test("serve 与 watch 互不阻塞（不同 kind，各自一把锁）", () => {
+    const d = dir();
+    const s = acquireInstanceLock("serve", "dev", d);
+    const w = acquireInstanceLock("watch", "dev", d);
+    expect(s.ok).toBe(true);
+    expect(w.ok).toBe(true);
+    s.release?.();
+    w.release?.();
+  });
+
+  test("陈旧锁（写锁的进程已死）会被接管，一次 SIGKILL 不该把频道永久锁死", () => {
+    const d = dir();
+    const dead = 999_999;
+    expect(() => process.kill(dead, 0)).toThrow();
+    writeFileSync(join(d, "serve-dev.lock"), JSON.stringify({ pid: dead }));
+    const lock = acquireInstanceLock("serve", "dev", d);
+    expect(lock.ok).toBe(true);
+    lock.release?.();
+  });
+
+  test("活着的锁不会被误判成陈旧（错的方向最危险）", () => {
+    const d = dir();
+    writeFileSync(join(d, "serve-dev.lock"), JSON.stringify({ pid: process.pid }));
+    const lock = acquireInstanceLock("serve", "dev", d);
+    expect(lock.ok).toBe(false);
+  });
+});
+
+describe("runner workdir 按身份隔离 (#99)", () => {
+  test("同频道、不同身份 → 不同 workdir（wake-session.json 不再互踩）", () => {
+    const a = runnerWorkdir("/home/x/.agentparty/runners", "dev", "alice");
+    const b = runnerWorkdir("/home/x/.agentparty/runners", "dev", "bob");
+    expect(a).not.toBe(b);
+    expect(a).toContain("dev");
+    expect(a).toContain("alice");
+  });
+
+  test("身份未知（还没连上服务端）时退回按频道键，保持旧行为", () => {
+    const w = runnerWorkdir("/home/x/.agentparty/runners", "dev", undefined);
+    expect(w).toBe("/home/x/.agentparty/runners/dev");
+  });
+
+  test("身份里的路径分隔符不得逃逸出 runners 根目录", () => {
+    const w = runnerWorkdir("/home/x/.agentparty/runners", "dev", "../../etc/passwd");
+    expect(w).not.toContain("..");
+    expect(w).not.toContain("/etc/passwd");
+    expect(w.startsWith("/home/x/.agentparty/runners/")).toBe(true);
+  });
+});
+
+// 光有 runnerWorkdir、没接进默认值计算，等于没修。
+describe("defaultRunnerWorkdir 接线 (#99)", () => {
+  test("config 里有身份时，默认 workdir 带上身份", () => {
+    const d = dir();
+    const cfgPath = join(d, "cfg.json");
+    writeFileSync(
+      cfgPath,
+      JSON.stringify({
+        server: "https://x",
+        token: "ap_t",
+        identity: { name: "alice", email: null, kind: "agent", role: "agent", owner: null, channel_scope: null, verified_at: 1 },
+      }),
+    );
+    const prev = process.env.AGENTPARTY_CONFIG;
+    process.env.AGENTPARTY_CONFIG = cfgPath;
+    try {
+      expect(defaultRunnerWorkdir("dev")).toContain("dev-alice");
+    } finally {
+      if (prev === undefined) delete process.env.AGENTPARTY_CONFIG;
+      else process.env.AGENTPARTY_CONFIG = prev;
+    }
+  });
+
+  test("没有缓存身份时退回按频道键（旧行为）", () => {
+    const d = dir();
+    const cfgPath = join(d, "cfg.json");
+    writeFileSync(cfgPath, JSON.stringify({ server: "https://x", token: "ap_t" }));
+    const prev = process.env.AGENTPARTY_CONFIG;
+    process.env.AGENTPARTY_CONFIG = cfgPath;
+    try {
+      expect(defaultRunnerWorkdir("dev").endsWith("/runners/dev")).toBe(true);
+    } finally {
+      if (prev === undefined) delete process.env.AGENTPARTY_CONFIG;
+      else process.env.AGENTPARTY_CONFIG = prev;
+    }
+  });
+});
+
+describe("runServe 接线 (#99)", () => {
+  test("第二个 serve 直接被拒，且连 WS 都不建（否则它已经在跑 runner 了）", async () => {
+    const d = dir();
+    let connections = 0;
+    const server = startMockServer((f, sock) => {
+      if (f.type !== "hello") return;
+      connections++;
+      sock.send(welcomeFrame(0, "me"));
+    });
+    try {
+      writeFileSync(join(d, "serve-dev.lock"), JSON.stringify({ pid: process.pid }));
+      const lines: string[] = [];
+      const code = await runServe({
+        server: server.url,
+        token: "ap_tok",
+        channel: "dev",
+        since: 0,
+        cmd: "true",
+        mentionsOnly: true,
+        lockDir: d,
+        out: (l) => lines.push(l),
+      });
+      expect(code).toBe(EXIT_ALREADY_SERVING);
+      expect(connections).toBe(0); // 关键：没有建立连接，没有消费任何 @
+      expect(lines.some((l) => l.includes(String(process.pid)))).toBe(true);
+    } finally {
+      server.stop();
+    }
+  });
+});

--- a/cli/test/serve.test.ts
+++ b/cli/test/serve.test.ts
@@ -38,6 +38,9 @@ function opts(over: Partial<ServeOptions> & { server: string }): ServeOptions & 
     mentionsOnly: true,
     out: (line) => lines.push(line),
     lines,
+    // 每个测试一把独立的单实例锁（#99）：测试不该依赖真实 ~/.agentparty，
+    // 也不该互相抢锁（第二个 runServe 会被拒并返回 EXIT_ALREADY_SERVING）
+    lockDir: mkdtempSync(join(tmpdir(), "ap-lock-")),
     ...over,
   };
 }

--- a/cli/test/watch-single-instance.test.ts
+++ b/cli/test/watch-single-instance.test.ts
@@ -8,7 +8,8 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { acquireWatchLock, EXIT_ALREADY_WATCHING, runWatch } from "../src/commands/watch";
+import { EXIT_ALREADY_WATCHING, runWatch } from "../src/commands/watch";
+import { acquireInstanceLock } from "../src/instance-lock";
 import { startMockServer, welcomeFrame } from "./mock-server";
 
 const dirs: string[] = [];
@@ -23,17 +24,17 @@ function dir(): string {
 
 describe("watch 单实例保护 (#195)", () => {
   test("第一个 watcher 拿到锁", () => {
-    const lock = acquireWatchLock("dev", dir());
+    const lock = acquireInstanceLock("watch", "dev", dir());
     expect(lock.ok).toBe(true);
     lock.release?.();
   });
 
   test("同一 (channel, workspace) 的第二个 watcher 被拒，并告知已有 watcher 的 pid", () => {
     const d = dir();
-    const first = acquireWatchLock("dev", d);
+    const first = acquireInstanceLock("watch", "dev", d);
     expect(first.ok).toBe(true);
 
-    const second = acquireWatchLock("dev", d);
+    const second = acquireInstanceLock("watch", "dev", d);
     expect(second.ok).toBe(false);
     expect(second.heldByPid).toBe(process.pid);
 
@@ -42,8 +43,8 @@ describe("watch 单实例保护 (#195)", () => {
 
   test("不同频道互不阻塞", () => {
     const d = dir();
-    const a = acquireWatchLock("alpha", d);
-    const b = acquireWatchLock("beta", d);
+    const a = acquireInstanceLock("watch", "alpha", d);
+    const b = acquireInstanceLock("watch", "beta", d);
     expect(a.ok).toBe(true);
     expect(b.ok).toBe(true);
     a.release?.();
@@ -52,9 +53,9 @@ describe("watch 单实例保护 (#195)", () => {
 
   test("释放之后可以重挂（正常的 exit → 处理 → 重挂 循环）", () => {
     const d = dir();
-    const first = acquireWatchLock("dev", d);
+    const first = acquireInstanceLock("watch", "dev", d);
     first.release?.();
-    const second = acquireWatchLock("dev", d);
+    const second = acquireInstanceLock("watch", "dev", d);
     expect(second.ok).toBe(true);
     second.release?.();
   });
@@ -66,7 +67,7 @@ describe("watch 单实例保护 (#195)", () => {
     expect(() => process.kill(dead, 0)).toThrow(); // 先确认这个 pid 真的不存在
     writeFileSync(join(d, "watch-dev.lock"), JSON.stringify({ pid: dead, channel: "dev" }));
 
-    const lock = acquireWatchLock("dev", d);
+    const lock = acquireInstanceLock("watch", "dev", d);
     expect(lock.ok).toBe(true);
     expect(JSON.parse(readFileSync(join(d, "watch-dev.lock"), "utf8")).pid).toBe(process.pid);
     lock.release?.();
@@ -75,7 +76,7 @@ describe("watch 单实例保护 (#195)", () => {
   test("活着的锁不会被误判成陈旧（这是最危险的错误方向）", () => {
     const d = dir();
     writeFileSync(join(d, "watch-dev.lock"), JSON.stringify({ pid: process.pid, channel: "dev" }));
-    const lock = acquireWatchLock("dev", d);
+    const lock = acquireInstanceLock("watch", "dev", d);
     expect(lock.ok).toBe(false);
     expect(lock.heldByPid).toBe(process.pid);
   });


### PR DESCRIPTION
> 频道身份：leo-codex-main-dev（#agentparty）
> **Stacked PR**：base 是 #235 的分支。前序合并后 base 自动变 main。

Refs #99（只修同机那半，**不 Closes**）

## 我只修了一半，另一半我修不了

issue 合并了两个根因：

| | 根因 | 本 PR |
|---|---|---|
| **A** 跨机器 | `do.ts:2948-2952` 广播发给同名**所有**连接；`do.ts:993-1037` 同名连接无限接受 | ❌ **需要服务端租约**。`do.ts` 被 #219/#220/#222 三个未合并 PR 压着，而且本地 pid 锁**本来就挡不住另一台机器** |
| **B** 同机 | `serve.ts` 的 workdir 只按频道键；多个 serve 共享 `wake-session.json` 互踩，失败即 fork | ✅ 本 PR |

失败场景（issue 原文）：工位机 + 家里机各跑一个 serve，每条 @ 触发两次完整 codex run、双份回帖，**git push 类副作用执行两遍**，唯一线索是 `who` 里不起眼的 `x2 sessions`。

**A 那半我没碰，也没假装碰了。** 所以是 `Refs` 不是 `Closes`。

## B 做了什么

**① serve 抢单实例锁。** 复用 #195 给 `watch` 做的那把，抽成 `cli/src/instance-lock.ts`（不是复制粘贴）。

- **抢锁在连 WS 之前**。第二个 serve 连接都不该建——建了它就已经在消费 @、已经在跑 runner 了。
- 拒绝时**告知占锁的 pid**，人能 kill 掉它。
- **陈旧锁可接管**（`kill -0` 探测）。否则一次 SIGKILL 就把频道永久锁死。
- `serve` 与 `watch` 各一把锁（不同 kind），互不阻塞。
- `--allow-multiple` 逃生舱。新退出码 `EXIT_ALREADY_SERVING`。

**② runner workdir 按 (频道, 身份) 隔离。** 旧实现只按频道键，同机两个身份 serve 同一频道会共享同一个 `wake-session.json`：互相覆盖对方的 codex/claude session id，而 builtin runner 在 resume 失败时会 **fork 出一个新 session**——于是重复执行。身份取自本地 config（启动时就有；`welcome.self` 要等连上才有），没有缓存身份时退回旧行为。

## 门禁

`452 pass / 0 fail` · `bunx tsc --noEmit` clean

| 变异 | 变红 |
|---|---|
| serve 不抢锁（**接线断开**） | 1 |
| `pidAlive` 恒 `false`（**活锁误判陈旧**） | 3 |
| `pidAlive` 恒 `true`（**陈旧锁永久锁死**） | 1 |
| workdir 不带身份 | 2 |
| `defaultRunnerWorkdir` 不读 config 身份（**接线断开**） | 1 |
| 锁不区分 kind（serve 挡住 watch） | 3 |

两个**相反**的错误方向各有测试守着。两条「接线断开」变异专门证明「光有函数没接进命令等于没修」——`runnerWorkdir` 写完之后我查了一下，CLI 里的默认值**果然还是老写法**，等于没修。

变异脚本这次都带 `assert old in s`：昨天我在 #235 遇到过转义写崩、变异根本没执行却显示「零变红」，**一个失败的变异会冒充「已验证」**。

## 副作用：既有 serve 测试改了 lockDir

加锁之后，`serve-failure-ack` / `serve.test` / `serve-argv-leak` 里的多个 `runServe` 在同一进程里抢同一把默认锁（`~/.agentparty` 下），第二个开始返回 `EXIT_ALREADY_SERVING`。给它们各自的临时锁目录——**测试本来就不该依赖真实 `~/.agentparty`**。

## 遗留

- **A 那半（跨机器重复执行）没解决。** 需要服务端在 `do.ts` 里按 (channel, name) 发租约：同名只允许一个 serve 连接进入「执行者」角色，其余降级为只读。建议 `do.ts` 空出来后单开一条，别塞进本 PR。
- serve 与 watch 各一把锁，所以**同机同身份同频道同时跑 serve 和 watch 仍会互踩游标**（两者共享 cursor，都会 ack）。我没有把它们互斥掉，因为有人可能有意同时跑。这条要不要收紧，请门禁定。