### PR TITLE
fix(desktop): 点击系统通知定位到对应消息

### DIFF
--- a/desktop/src-tauri/capabilities/default.json
+++ b/desktop/src-tauri/capabilities/default.json
@@ -12,6 +12,7 @@
     "notification:allow-is-permission-granted",
     "notification:allow-request-permission",
     "notification:allow-notify",
+    "notification:allow-register-listener",
     "autostart:allow-enable",
     "autostart:allow-disable",
     "autostart:allow-is-enabled",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -21,7 +21,7 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data: blob: https: http://127.0.0.1:* http://localhost:* http://[::1]:*; connect-src 'self' ipc: http://ipc.localhost https: wss: http://127.0.0.1:* http://localhost:* http://[::1]:* ws://127.0.0.1:* ws://localhost:* ws://[::1]:*"
     }
   },
   "bundle": {

--- a/scripts/desktop-release-workflow.test.ts
+++ b/scripts/desktop-release-workflow.test.ts
@@ -10,6 +10,9 @@ const desktopDocs = readFileSync(
 const tauriConfig = JSON.parse(
   readFileSync(resolve(import.meta.dir, "../desktop/src-tauri/tauri.conf.json"), "utf8"),
 );
+const desktopCapability = JSON.parse(
+  readFileSync(resolve(import.meta.dir, "../desktop/src-tauri/capabilities/default.json"), "utf8"),
+);
 
 describe("desktop release workflow", () => {
   test("hands every signed updater artifact to the release job", () => {
@@ -25,6 +28,19 @@ describe("desktop release workflow", () => {
     expect(workflow).toContain("bun scripts/desktop-update-manifest.ts");
     expect(workflow).toContain("--output dist/latest.json");
     expect(workflow).toContain("dist/latest.json");
+  });
+
+  test("allows the desktop shell to receive notification click actions", () => {
+    expect(desktopCapability.permissions).toContain("notification:allow-register-listener");
+  });
+
+  test("ships the desktop webview with a restrictive content security policy", () => {
+    const csp = tauriConfig.app.security.csp;
+    expect(typeof csp).toBe("string");
+    expect(csp).toContain("default-src 'self'");
+    expect(csp).toContain("script-src 'self'");
+    expect(csp).toContain("connect-src 'self'");
+    expect(csp).not.toContain("script-src 'self' 'unsafe-eval'");
   });
 
   test("gates desktop distribution and falls back to an honest unnotarized preview", () => {

--- a/web/public/docs/desktop/index.html
+++ b/web/public/docs/desktop/index.html
@@ -103,7 +103,7 @@
             <tr><td><span class="zh">点击托盘图标</span><span class="en">Click the tray icon</span></td><td><span class="zh">重新显示并聚焦主窗口。</span><span class="en">Shows and focuses the main window.</span></td></tr>
             <tr><td><span class="zh">托盘 → 退出</span><span class="en">Tray → Quit</span></td><td><span class="zh">真正结束应用；仅关闭窗口不会退出。</span><span class="en">Actually quits the app; closing the window does not.</span></td></tr>
             <tr><td><span class="zh">登录时启动</span><span class="en">Launch at login</span></td><td><span class="zh">可从桌面设置开关；系统启动时应用在后台运行，不抢焦点。</span><span class="en">Controlled from desktop settings; the app starts in the background without taking focus.</span></td></tr>
-            <tr><td><span class="zh">当前频道的 @</span><span class="en">@mentions in the current channel</span></td><td><span class="zh">频道铃铛开启并授予 macOS 通知权限后，后台 @ 会发系统通知并增加 Dock 角标。</span><span class="en">With the channel bell enabled and macOS notification permission granted, background @mentions send a system notification and increment the Dock badge.</span></td></tr>
+            <tr><td><span class="zh">当前频道的 @</span><span class="en">@mentions in the current channel</span></td><td><span class="zh">频道铃铛开启并授予 macOS 通知权限后，后台 @ 会发系统通知并增加 Dock 角标；点击通知会唤醒窗口并定位到对应消息。</span><span class="en">With the channel bell enabled and macOS notification permission granted, background @mentions send a system notification and increment the Dock badge. Clicking the notification opens the app at that message.</span></td></tr>
           </tbody>
         </table>
 

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -45,6 +45,9 @@ const unpairedOrigin = "https://agentparty.pwtk-dev.work";
 let renderer: ReactTestRenderer | null = null;
 let credentialDeletes = 0;
 let storedCredential: string | null = null;
+let notificationActionHandler: ((notification: { extra?: Record<string, unknown> }) => void) | null = null;
+let desktopFocusCalls: string[] = [];
+let pushedPaths: string[] = [];
 
 beforeEach(() => {
   Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", { configurable: true, value: true });
@@ -56,7 +59,12 @@ beforeEach(() => {
   });
   Object.defineProperty(globalThis, "history", {
     configurable: true,
-    value: { pushState: () => {}, replaceState: () => {} },
+    value: {
+      pushState: (_state: unknown, _unused: string, url?: string | URL | null) => {
+        pushedPaths.push(String(url ?? ""));
+      },
+      replaceState: () => {},
+    },
   });
 
   const windowEvents = new EventTarget();
@@ -74,6 +82,7 @@ beforeEach(() => {
       clearInterval,
       addEventListener: windowEvents.addEventListener.bind(windowEvents),
       removeEventListener: windowEvents.removeEventListener.bind(windowEvents),
+      focus: () => { desktopFocusCalls.push("browser-focus"); },
     },
   });
   const documentEvents = new EventTarget();
@@ -93,6 +102,9 @@ beforeEach(() => {
   addCustomServerProfile(localStorage, { label: "Private", origin: "https://private.example.com" });
   saveActiveServerOrigin(localStorage, activeOrigin);
   credentialDeletes = 0;
+  notificationActionHandler = null;
+  desktopFocusCalls = [];
+  pushedPaths = [];
   storedCredential = JSON.stringify({
     refreshToken: "old-refresh",
     deviceSecret: "old-device-secret",
@@ -121,6 +133,23 @@ beforeEach(() => {
     loadDeepLink: async () => ({
       getCurrent: async () => null,
       onOpenUrl: async () => () => {},
+    }),
+    loadNotification: async () => ({
+      isPermissionGranted: async () => true,
+      requestPermission: async () => "granted",
+      sendNotification: () => {},
+      onAction: async (handler) => {
+        notificationActionHandler = handler;
+        return { unregister: async () => {} };
+      },
+    }),
+    loadWindow: async () => ({
+      getCurrentWindow: () => ({
+        setBadgeCount: async () => {},
+        show: async () => { desktopFocusCalls.push("show"); },
+        unminimize: async () => { desktopFocusCalls.push("unminimize"); },
+        setFocus: async () => { desktopFocusCalls.push("focus"); },
+      }),
     }),
   });
   Object.defineProperty(globalThis, "fetch", {
@@ -176,6 +205,24 @@ afterEach(async () => {
 });
 
 describe("App desktop server pairing behavior", () => {
+  test("opens a clicked desktop mention notification at the target message", async () => {
+    await act(async () => {
+      renderer = create(<LocaleProvider><App /></LocaleProvider>);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(notificationActionHandler).not.toBeNull();
+    await act(async () => {
+      notificationActionHandler?.({ extra: { slug: "general", seq: 42 } });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(desktopFocusCalls).toEqual(["show", "unminimize", "focus"]);
+    expect(pushedPaths).toContain("/c/general");
+    expect(location.hash).toBe("#msg-42");
+  });
+
   test("successful server switch leaves a channel route from the previous server", async () => {
     const privateOrigin = "https://private.example.com";
     const replacements: string[] = [];

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -48,7 +48,11 @@ import {
   logoutDesktopSession,
   migrateLegacyDesktopCredential,
 } from "./lib/desktopCredentials";
-import { isDesktopRuntime } from "./lib/desktopRuntime";
+import {
+  isDesktopRuntime,
+  listenForDesktopNotificationActions,
+  showAndFocusDesktopWindow,
+} from "./lib/desktopRuntime";
 import { setApiBase } from "./lib/base";
 import {
   addCustomServerProfile,
@@ -134,6 +138,24 @@ export function App() {
     }
     return stored;
   });
+
+  useEffect(() => {
+    if (!desktop) return;
+    let alive = true;
+    let stop = () => {};
+    void listenForDesktopNotificationActions(({ slug, seq }) => {
+      void showAndFocusDesktopWindow();
+      navigate(`/c/${slug}`);
+      window.location.hash = `#msg-${seq}`;
+    }).then((unlisten) => {
+      if (alive) stop = unlisten;
+      else unlisten();
+    });
+    return () => {
+      alive = false;
+      stop();
+    };
+  }, [desktop, navigate]);
 
   const restoreDesktop = useCallback(() => {
     setDesktopBoot("loading");

--- a/web/src/lib/desktopRuntime.test.ts
+++ b/web/src/lib/desktopRuntime.test.ts
@@ -5,6 +5,7 @@ import {
   isAutostartEnabled,
   isDesktopNotificationPermissionGranted,
   isDesktopNotificationSupported,
+  listenForDesktopNotificationActions,
   listenForDesktopPairLinks,
   openDesktopVerificationUrl,
   requestDesktopNotificationPermission,
@@ -25,6 +26,7 @@ function notificationModule(overrides: Partial<NotificationModule> = {}): Notifi
     isPermissionGranted: async () => true,
     requestPermission: async () => "granted",
     sendNotification: () => {},
+    onAction: async () => ({ unregister: async () => {} }),
     ...overrides,
   };
 }
@@ -77,6 +79,8 @@ describe("browser fallback", () => {
     expect(await isDesktopNotificationPermissionGranted()).toBe(false);
     expect(await requestDesktopNotificationPermission()).toBe("unsupported");
     expect(await sendMentionNotification({ title: "Mention", body: "hello", slug: "general", seq: 7 })).toBe(false);
+    const stopNotificationActions = await listenForDesktopNotificationActions(() => {});
+    stopNotificationActions();
     expect(await setDesktopBadge(4)).toBe(false);
     expect(await showAndFocusDesktopWindow()).toBe(false);
     const unlisten = await listenForDesktopUpdateChecks(() => {});
@@ -167,6 +171,34 @@ describe("desktop notifications", () => {
 
     expect(await sendMentionNotification({ title: "Mention", body: "hello", slug: "general", seq: 8 })).toBe(false);
     expect(sends).toBe(0);
+  });
+
+  test("delivers validated notification actions and unregisters the native listener", async () => {
+    let actionHandler: ((notification: { extra?: Record<string, unknown> }) => void) | null = null;
+    let unregistered = false;
+    const actions: Array<{ slug: string; seq: number }> = [];
+    __setDesktopRuntimeDependenciesForTests({
+      isTauri: () => true,
+      loadNotification: async () => notificationModule({
+        onAction: async (handler) => {
+          actionHandler = handler;
+          return { unregister: async () => { unregistered = true; } };
+        },
+      }),
+    });
+
+    const stop = await listenForDesktopNotificationActions((action) => actions.push(action));
+    actionHandler?.({ extra: { slug: "general", seq: 42 } });
+    actionHandler?.({ extra: { slug: "../admin", seq: 43 } });
+    actionHandler?.({ extra: { slug: "general", seq: 0 } });
+    actionHandler?.({ extra: { slug: "general", seq: 1.5 } });
+    actionHandler?.({ extra: { slug: "general", seq: "44" } });
+    actionHandler?.({});
+    stop();
+    await Promise.resolve();
+
+    expect(actions).toEqual([{ slug: "general", seq: 42 }]);
+    expect(unregistered).toBe(true);
   });
 });
 
@@ -334,6 +366,8 @@ describe("native plugin failures", () => {
     expect(await isDesktopNotificationPermissionGranted()).toBe(false);
     expect(await requestDesktopNotificationPermission()).toBe("unsupported");
     expect(await sendMentionNotification({ title: "Mention", body: "hello", slug: "general", seq: 9 })).toBe(false);
+    const stopNotificationActions = await listenForDesktopNotificationActions(() => {});
+    stopNotificationActions();
     expect(await setDesktopBadge(2)).toBe(false);
     expect(await showAndFocusDesktopWindow()).toBe(false);
     expect(await isAutostartEnabled()).toBe(false);

--- a/web/src/lib/desktopRuntime.ts
+++ b/web/src/lib/desktopRuntime.ts
@@ -16,6 +16,15 @@ export interface MentionNotification {
   seq: number;
 }
 
+export interface DesktopNotificationAction {
+  slug: string;
+  seq: number;
+}
+
+interface NotificationListener {
+  unregister(): Promise<void>;
+}
+
 interface NotificationModule {
   isPermissionGranted(): Promise<boolean>;
   requestPermission(): Promise<Exclude<DesktopNotificationPermission, "unsupported">>;
@@ -24,6 +33,7 @@ interface NotificationModule {
     body: string;
     extra: { slug: string; seq: number };
   }): void;
+  onAction(handler: (notification: { extra?: Record<string, unknown> }) => void): Promise<NotificationListener>;
 }
 
 interface AutostartModule {
@@ -136,6 +146,30 @@ export async function sendMentionNotification(input: MentionNotification): Promi
     return true;
   } catch {
     return false;
+  }
+}
+
+export async function listenForDesktopNotificationActions(
+  onAction: (action: DesktopNotificationAction) => void,
+): Promise<() => void> {
+  if (!isDesktopRuntime()) return () => {};
+  try {
+    const notification = await dependencies.loadNotification();
+    const listener = await notification.onAction(({ extra }) => {
+      const slug = extra?.slug;
+      const seq = extra?.seq;
+      if (
+        typeof slug !== "string" ||
+        !/^[a-z0-9][a-z0-9-]{0,63}$/.test(slug) ||
+        typeof seq !== "number" ||
+        !Number.isSafeInteger(seq) ||
+        seq <= 0
+      ) return;
+      onAction({ slug, seq });
+    });
+    return () => { void listener.unregister(); };
+  } catch {
+    return () => {};
   }
 }
 


### PR DESCRIPTION
## 变更
- 注册 Tauri 通知 action listener，校验 slug/seq 后聚焦窗口、切换频道并定位消息
- 补齐 `notification:allow-register-listener` capability，避免 mock 通过但安装包失效
- 为桌面 WebView 增加 CSP，同时保留 HTTPS 私有部署与 loopback HTTP/WS 联调
- 桌面文档补充通知点击行为

## 验证
- `bun run check`
- `cargo test --manifest-path desktop/src-tauri/Cargo.toml`
- `bunx tauri build --debug --no-bundle`

桌面 v0.2.88 仍是未公证 preview；Apple Developer 签名/公证与 updater key 桥接在 #221 继续收口。