### PR TITLE
fix(desktop): 完善设置弹层键盘焦点

### DIFF
--- a/web/src/components/DesktopSettings.test.tsx
+++ b/web/src/components/DesktopSettings.test.tsx
@@ -11,6 +11,7 @@ import {
   loadAutostartSetting,
   shouldDismissDesktopSettings,
   type DesktopSettingsRuntime,
+  updateDesktopSettingsFocus,
 } from "./DesktopSettings";
 
 const translations: Record<string, string> = {
@@ -152,5 +153,17 @@ describe("desktop settings dismissal", () => {
     expect(isDesktopSettingsOutsideClick(root, outside)).toBe(true);
     expect(isDesktopSettingsOutsideClick(root, inside)).toBe(false);
     expect(isDesktopSettingsOutsideClick(null, outside)).toBe(false);
+  });
+
+  test("moves focus into the popover and restores it for keyboard dismissal", () => {
+    const calls: string[] = [];
+    const control = { focus: () => calls.push("control") };
+    const trigger = { focus: () => calls.push("trigger") };
+
+    updateDesktopSettingsFocus(true, false, false, control, trigger);
+    updateDesktopSettingsFocus(false, true, true, control, trigger);
+    updateDesktopSettingsFocus(false, true, false, control, trigger);
+
+    expect(calls).toEqual(["control", "trigger"]);
   });
 });

--- a/web/src/components/DesktopSettings.tsx
+++ b/web/src/components/DesktopSettings.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState, type RefObject } from "react";
 import {
   isAutostartEnabled,
   isDesktopRuntime,
@@ -47,15 +47,31 @@ export function isDesktopSettingsOutsideClick(
   return root !== null && !root.contains(target);
 }
 
+interface FocusTarget {
+  focus(): void;
+}
+
+export function updateDesktopSettingsFocus(
+  open: boolean,
+  wasOpen: boolean,
+  restoreFocus: boolean,
+  control: FocusTarget | null,
+  trigger: FocusTarget | null,
+): void {
+  if (open && !wasOpen) control?.focus();
+  else if (!open && wasOpen && restoreFocus) trigger?.focus();
+}
+
 interface PanelProps {
   enabled: boolean;
   pending: boolean;
   error: boolean;
   t: TFunc;
   onToggle(): void;
+  switchRef?: RefObject<HTMLButtonElement | null>;
 }
 
-export function DesktopSettingsPanel({ enabled, pending, error, t, onToggle }: PanelProps) {
+export function DesktopSettingsPanel({ enabled, pending, error, t, onToggle, switchRef }: PanelProps) {
   return (
     <section
       id="desktop-settings-panel"
@@ -70,6 +86,7 @@ export function DesktopSettingsPanel({ enabled, pending, error, t, onToggle }: P
           <small>{t("DesktopSettings.autostart.description")}</small>
         </span>
         <button
+          ref={switchRef}
           type="button"
           className={`desktop-settings-switch${enabled ? " is-on" : ""}`}
           role="switch"
@@ -99,6 +116,10 @@ export function DesktopSettings({ runtime = defaultRuntime }: Props) {
   const [pending, setPending] = useState(desktop);
   const [error, setError] = useState(false);
   const rootRef = useRef<HTMLDivElement | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const switchRef = useRef<HTMLButtonElement | null>(null);
+  const wasOpenRef = useRef(false);
+  const restoreFocusRef = useRef(false);
 
   useEffect(() => {
     if (!desktop) return;
@@ -115,10 +136,14 @@ export function DesktopSettings({ runtime = defaultRuntime }: Props) {
   useEffect(() => {
     if (!open) return;
     const onKeyDown = (event: KeyboardEvent) => {
-      if (shouldDismissDesktopSettings(event)) setOpen(false);
+      if (shouldDismissDesktopSettings(event)) {
+        restoreFocusRef.current = true;
+        setOpen(false);
+      }
     };
     const onPointerDown = (event: PointerEvent) => {
       if (event.target instanceof Node && isDesktopSettingsOutsideClick(rootRef.current, event.target)) {
+        restoreFocusRef.current = false;
         setOpen(false);
       }
     };
@@ -128,6 +153,18 @@ export function DesktopSettings({ runtime = defaultRuntime }: Props) {
       document.removeEventListener("keydown", onKeyDown);
       document.removeEventListener("pointerdown", onPointerDown);
     };
+  }, [open]);
+
+  useLayoutEffect(() => {
+    updateDesktopSettingsFocus(
+      open,
+      wasOpenRef.current,
+      restoreFocusRef.current,
+      switchRef.current,
+      triggerRef.current,
+    );
+    wasOpenRef.current = open;
+    if (!open) restoreFocusRef.current = false;
   }, [open]);
 
   if (!desktop) return null;
@@ -147,13 +184,18 @@ export function DesktopSettings({ runtime = defaultRuntime }: Props) {
   return (
     <div className="desktop-settings" ref={rootRef}>
       <button
+        ref={triggerRef}
         type="button"
         className="desktop-settings-trigger"
         aria-label={t("DesktopSettings.control.label")}
         title={t("DesktopSettings.control.label")}
         aria-expanded={open}
+        aria-haspopup="dialog"
         aria-controls="desktop-settings-panel"
-        onClick={() => setOpen((current) => !current)}
+        onClick={() => setOpen((current) => {
+          restoreFocusRef.current = current;
+          return !current;
+        })}
       >
         <span className="ap-sprite ap-sprite--settings" aria-hidden="true" />
       </button>
@@ -164,6 +206,7 @@ export function DesktopSettings({ runtime = defaultRuntime }: Props) {
           error={error}
           t={t}
           onToggle={toggleAutostart}
+          switchRef={switchRef}
         />
       )}
     </div>


### PR DESCRIPTION
## 变更
- 打开桌面设置时把焦点移入“开机启动”开关
- Escape 或再次点击触发器关闭时恢复焦点；点击外部关闭不抢走用户的新焦点
- 补 `aria-haspopup=dialog` 与焦点策略单测

## 验证
- `bun test web/src/components/DesktopSettings.test.tsx`
- `bun run --cwd web typecheck`