### PR TITLE
feat(release): 支持 updater key 双通道桥接

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,7 +194,33 @@ jobs:
       - name: install deps
         run: bun install --frozen-lockfile
 
-      - name: require updater signing key
+      - name: resolve updater key mode
+        id: updater-key-mode
+        env:
+          DESKTOP_UPDATER_KEY_MODE: ${{ vars.DESKTOP_UPDATER_KEY_MODE }}
+          DESKTOP_UPDATER_BRIDGE_TAG: ${{ vars.DESKTOP_UPDATER_BRIDGE_TAG }}
+        run: |
+          set -euo pipefail
+          mode="${DESKTOP_UPDATER_KEY_MODE:-}"
+          case "$mode" in
+            legacy|bridge|v2) ;;
+            *)
+              echo "::error::invalid DESKTOP_UPDATER_KEY_MODE: $mode"
+              exit 1
+              ;;
+          esac
+          if [ "$mode" != "legacy" ] && [ -z "${DESKTOP_UPDATER_BRIDGE_TAG:-}" ]; then
+            echo "::error::DESKTOP_UPDATER_BRIDGE_TAG is required for $mode updater key mode"
+            exit 1
+          fi
+          if [ "$mode" = "bridge" ] && [ "$DESKTOP_UPDATER_BRIDGE_TAG" != "$GITHUB_REF_NAME" ]; then
+            echo "::error::bridge mode requires DESKTOP_UPDATER_BRIDGE_TAG to equal the release tag"
+            exit 1
+          fi
+          echo "mode=$mode" >> "$GITHUB_OUTPUT"
+
+      - name: require legacy updater signing key
+        if: steps.updater-key-mode.outputs.mode != 'v2'
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
@@ -204,9 +230,26 @@ jobs:
             exit 1
           fi
 
+      - name: require v2 updater signing key
+        if: steps.updater-key-mode.outputs.mode == 'bridge' || steps.updater-key-mode.outputs.mode == 'v2'
+        env:
+          TAURI_SIGNING_PRIVATE_KEY_V2: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_V2 }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD_V2: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD_V2 }}
+        run: |
+          set -euo pipefail
+          if [ -z "${TAURI_SIGNING_PRIVATE_KEY_V2:-}" ]; then
+            echo "::error::TAURI_SIGNING_PRIVATE_KEY_V2 is required for ${{ steps.updater-key-mode.outputs.mode }} updater key mode"
+            exit 1
+          fi
+          if [ -z "${TAURI_SIGNING_PRIVATE_KEY_PASSWORD_V2:-}" ]; then
+            echo "::error::TAURI_SIGNING_PRIVATE_KEY_PASSWORD_V2 is required for ${{ steps.updater-key-mode.outputs.mode }} updater key mode"
+            exit 1
+          fi
+
       - name: detect Apple Developer ID and notarization credentials
         id: apple-signing
         env:
+          DESKTOP_REQUIRE_NOTARIZATION: ${{ vars.DESKTOP_REQUIRE_NOTARIZATION }}
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
@@ -215,6 +258,11 @@ jobs:
           KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
         run: |
           set -euo pipefail
+          require_notarization="${DESKTOP_REQUIRE_NOTARIZATION:-false}"
+          if [ "$require_notarization" != "true" ] && [ "$require_notarization" != "false" ]; then
+            echo "::error::DESKTOP_REQUIRE_NOTARIZATION must be true or false"
+            exit 1
+          fi
           missing=()
           for name in APPLE_CERTIFICATE APPLE_CERTIFICATE_PASSWORD APPLE_ID APPLE_PASSWORD APPLE_TEAM_ID KEYCHAIN_PASSWORD; do
             if [ -z "${!name:-}" ]; then
@@ -222,6 +270,10 @@ jobs:
             fi
           done
           if [ "${#missing[@]}" -gt 0 ]; then
+            if [ "$require_notarization" = "true" ]; then
+              printf '::error::Apple signing is required; missing: %s\n' "$(IFS=', '; echo "${missing[*]}")"
+              exit 1
+            fi
             echo "enabled=false" >> "$GITHUB_OUTPUT"
             printf '::warning::Apple signing is unavailable; publishing an unnotarized desktop preview. Missing: %s\n' "$(IFS=', '; echo "${missing[*]}")"
           else
@@ -254,8 +306,8 @@ jobs:
           fi
           echo "APPLE_SIGNING_IDENTITY=$signing_identity" >> "$GITHUB_ENV"
 
-      - name: build notarized desktop app
-        if: steps.apple-signing.outputs.enabled == 'true'
+      - name: build notarized desktop app with legacy updater key
+        if: steps.apple-signing.outputs.enabled == 'true' && steps.updater-key-mode.outputs.mode != 'v2'
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
@@ -264,11 +316,28 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: bun run desktop:build:prod
 
-      - name: build unnotarized desktop preview
-        if: steps.apple-signing.outputs.enabled == 'false'
+      - name: build notarized desktop app with v2 updater key
+        if: steps.apple-signing.outputs.enabled == 'true' && steps.updater-key-mode.outputs.mode == 'v2'
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_V2 }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD_V2 }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: bun run desktop:build:prod
+
+      - name: build unnotarized desktop preview with legacy updater key
+        if: steps.apple-signing.outputs.enabled == 'false' && steps.updater-key-mode.outputs.mode != 'v2'
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: bun run desktop:build:prod
+
+      - name: build unnotarized desktop preview with v2 updater key
+        if: steps.apple-signing.outputs.enabled == 'false' && steps.updater-key-mode.outputs.mode == 'v2'
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_V2 }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD_V2 }}
         run: bun run desktop:build:prod
 
       - name: verify Developer ID signature and notarization ticket
@@ -287,10 +356,34 @@ jobs:
           xcrun stapler validate "$dmg"
           spctl --assess --type open --context context:primary-signature --verbose=4 "$dmg"
 
+      - name: sign bridge updater with v2 key
+        if: steps.updater-key-mode.outputs.mode == 'bridge'
+        working-directory: desktop
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_V2 }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD_V2 }}
+        run: |
+          set -euo pipefail
+          updater="$(find src-tauri/target/release/bundle/macos -name '*.app.tar.gz' -type f | head -n 1)"
+          if [ -z "$updater" ] || [ ! -s "${updater}.sig" ]; then
+            echo "::error::legacy updater signature is missing before bridge dual-signing"
+            exit 1
+          fi
+          cp "${updater}.sig" "${updater}.sig.legacy"
+          rm "${updater}.sig"
+          bunx tauri signer sign "$updater"
+          if [ ! -s "${updater}.sig" ]; then
+            echo "::error::v2 updater signature was not generated"
+            exit 1
+          fi
+          mv "${updater}.sig" "${updater}.sig.v2"
+          mv "${updater}.sig.legacy" "${updater}.sig"
+
       - name: package desktop artifacts
         env:
           ASSET: ${{ matrix.asset }}
           NOTARIZED: ${{ steps.apple-signing.outputs.enabled }}
+          UPDATER_KEY_MODE: ${{ steps.updater-key-mode.outputs.mode }}
         run: |
           set -euo pipefail
           dmg="$(find desktop/src-tauri/target/release/bundle/dmg -name '*.dmg' -type f 2>/dev/null | head -n 1 || true)"
@@ -300,18 +393,25 @@ jobs:
             find desktop/src-tauri/target/release/bundle -type f || true
             exit 1
           fi
+          if [ "$UPDATER_KEY_MODE" = "bridge" ] && [ ! -s "${updater}.sig.v2" ]; then
+            echo "::error::bridge updater v2 signature is missing"
+            exit 1
+          fi
           dmg_out="agentparty-desktop-${ASSET}.dmg"
           updater_out="agentparty-desktop-${ASSET}.app.tar.gz"
           cp "$dmg" "$dmg_out"
           cp "$updater" "$updater_out"
           cp "${updater}.sig" "${updater_out}.sig"
+          if [ "$UPDATER_KEY_MODE" = "bridge" ]; then
+            cp "${updater}.sig.v2" "${updater_out}.sig.v2"
+          fi
           shasum -a 256 "$dmg_out" > "${dmg_out}.sha256"
           distribution="preview"
           if [ "$NOTARIZED" = "true" ]; then
             distribution="production"
           fi
-          printf '{"notarized":%s,"distribution":"%s"}\n' \
-            "$NOTARIZED" "$distribution" > "agentparty-desktop-${ASSET}.signing-status.json"
+          printf '{"notarized":%s,"distribution":"%s","updater_key_mode":"%s"}\n' \
+            "$NOTARIZED" "$distribution" "$UPDATER_KEY_MODE" > "agentparty-desktop-${ASSET}.signing-status.json"
 
       - name: upload desktop artifact
         uses: actions/upload-artifact@v4
@@ -337,6 +437,31 @@ jobs:
         with:
           bun-version: "1.3.14"
 
+      - name: resolve updater key mode
+        id: updater-key-mode
+        env:
+          DESKTOP_UPDATER_KEY_MODE: ${{ vars.DESKTOP_UPDATER_KEY_MODE }}
+          DESKTOP_UPDATER_BRIDGE_TAG: ${{ vars.DESKTOP_UPDATER_BRIDGE_TAG }}
+        run: |
+          set -euo pipefail
+          mode="${DESKTOP_UPDATER_KEY_MODE:-}"
+          case "$mode" in
+            legacy|bridge|v2) ;;
+            *)
+              echo "::error::invalid DESKTOP_UPDATER_KEY_MODE: $mode"
+              exit 1
+              ;;
+          esac
+          if [ "$mode" != "legacy" ] && [ -z "${DESKTOP_UPDATER_BRIDGE_TAG:-}" ]; then
+            echo "::error::DESKTOP_UPDATER_BRIDGE_TAG is required for $mode updater key mode"
+            exit 1
+          fi
+          if [ "$mode" = "bridge" ] && [ "$DESKTOP_UPDATER_BRIDGE_TAG" != "$GITHUB_REF_NAME" ]; then
+            echo "::error::bridge mode requires DESKTOP_UPDATER_BRIDGE_TAG to equal the release tag"
+            exit 1
+          fi
+          echo "mode=$mode" >> "$GITHUB_OUTPUT"
+
       - name: collect artifacts
         uses: actions/download-artifact@v4
         with:
@@ -344,6 +469,8 @@ jobs:
           merge-multiple: true
 
       - name: classify desktop distribution
+        env:
+          EXPECTED_UPDATER_KEY_MODE: ${{ steps.updater-key-mode.outputs.mode }}
         run: |
           set -euo pipefail
           shopt -s nullglob
@@ -353,15 +480,20 @@ jobs:
             exit 1
           fi
 
-          status_count="$(jq -s 'map({notarized, distribution}) | unique | length' "${status_files[@]}")"
+          status_count="$(jq -s 'map({notarized, distribution, updater_key_mode}) | unique | length' "${status_files[@]}")"
           if [ "$status_count" -ne 1 ]; then
-            echo "::error::desktop architectures disagree on signing status"
+            echo "::error::desktop architectures disagree on signing status or updater key mode"
             jq -s '.' "${status_files[@]}"
             exit 1
           fi
 
           notarized="$(jq -r '.notarized' "${status_files[0]}")"
           distribution="$(jq -r '.distribution' "${status_files[0]}")"
+          updater_key_mode="$(jq -r '.updater_key_mode' "${status_files[0]}")"
+          if [ "$updater_key_mode" != "$EXPECTED_UPDATER_KEY_MODE" ]; then
+            echo "::error::desktop updater key mode does not match release configuration"
+            exit 1
+          fi
           if [ "$notarized" = "true" ] && [ "$distribution" = "production" ]; then
             DESKTOP_RELEASE_NOTES="AgentParty $GITHUB_REF_NAME desktop update; Developer ID signed and Apple notarized."
             cat > dist/release-body.md <<EOF
@@ -387,14 +519,55 @@ jobs:
           echo "DESKTOP_RELEASE_NOTES=$DESKTOP_RELEASE_NOTES" >> "$GITHUB_ENV"
 
       - name: generate desktop updater manifest
+        env:
+          GH_TOKEN: ${{ github.token }}
+          UPDATER_KEY_MODE: ${{ steps.updater-key-mode.outputs.mode }}
+          DESKTOP_UPDATER_BRIDGE_TAG: ${{ vars.DESKTOP_UPDATER_BRIDGE_TAG }}
         run: |
-          bun scripts/desktop-update-manifest.ts \
-            --version "${GITHUB_REF_NAME#v}" \
-            --tag "$GITHUB_REF_NAME" \
-            --repo "$GITHUB_REPOSITORY" \
-            --dir dist \
-            --output dist/latest.json \
-            --notes "$DESKTOP_RELEASE_NOTES"
+          set -euo pipefail
+          generate_manifest() {
+            local output="$1"
+            local signature_suffix="$2"
+            bun scripts/desktop-update-manifest.ts \
+              --version "${GITHUB_REF_NAME#v}" \
+              --tag "$GITHUB_REF_NAME" \
+              --repo "$GITHUB_REPOSITORY" \
+              --dir dist \
+              --output "$output" \
+              --notes "$DESKTOP_RELEASE_NOTES" \
+              --signature-suffix "$signature_suffix"
+          }
+
+          case "$UPDATER_KEY_MODE" in
+            legacy)
+              generate_manifest dist/latest.json ".sig"
+              ;;
+            bridge)
+              generate_manifest dist/latest.json ".sig"
+              generate_manifest dist/latest-v2.json ".sig.v2"
+              ;;
+            v2)
+              gh release download "$DESKTOP_UPDATER_BRIDGE_TAG" \
+                --repo "$GITHUB_REPOSITORY" \
+                --pattern latest.json \
+                --output dist/latest.json
+              bridge_version="${DESKTOP_UPDATER_BRIDGE_TAG#v}"
+              encoded_bridge_tag="$(jq -rn --arg tag "$DESKTOP_UPDATER_BRIDGE_TAG" '$tag | @uri')"
+              bridge_path="/releases/download/${encoded_bridge_tag}/"
+              if ! jq -e --arg version "$bridge_version" --arg bridge_path "$bridge_path" '
+                .version == $version and
+                (.platforms | type == "object" and length > 0) and
+                all(.platforms[];
+                  (.url | type == "string" and contains($bridge_path)) and
+                  (.signature | type == "string" and length > 0)
+                )
+              ' dist/latest.json >/dev/null; then
+                echo "::error::legacy updater manifest does not point to the configured bridge tag"
+                exit 1
+              fi
+              generate_manifest dist/latest-v2.json ".sig"
+              ;;
+          esac
 
       - name: classify release channel
         id: release-channel
@@ -423,7 +596,9 @@ jobs:
             dist/*.tar.gz
             dist/*.tar.gz.sha256
             dist/*.tar.gz.sig
+            dist/*.tar.gz.sig.v2
             dist/*.dmg
             dist/*.dmg.sha256
             dist/*.signing-status.json
             dist/latest.json
+            dist/latest-v2.json

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -44,8 +44,8 @@
       }
     },
     "updater": {
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDZCNEQ4QjAzMUFFMENCOTgKUldTWXkrQWFBNHROYStyOEdvNTJsWkFxYTlLcVZ0OVRiMEtVSDZ1OGxneXdOUEVua2EzUk5scGcK",
-      "endpoints": ["https://github.com/leeguooooo/agentparty/releases/latest/download/latest.json"]
+      "pubkey": "ZFc1MGNuVnpkR1ZrSUdOdmJXMWxiblE2SUcxcGJtbHphV2R1SUhCMVlteHBZeUJyWlhrNklFUTBNakF6UVRFeU5URXdORFZEUVRFS1VsZFRhRmhCVWxKRmFtOW5NVXRUUWtVNWExTmpLek5xVUhONWVUaFFSR1pTY0dSdk5ucHNka3dyUmpOQmFVcEdaR0ZyYzIxdlNtRUs=",
+      "endpoints": ["https://github.com/leeguooooo/agentparty/releases/latest/download/latest-v2.json"]
     }
   }
 }

--- a/scripts/desktop-release-workflow.test.ts
+++ b/scripts/desktop-release-workflow.test.ts
@@ -13,6 +13,12 @@ const tauriConfig = JSON.parse(
 const desktopCapability = JSON.parse(
   readFileSync(resolve(import.meta.dir, "../desktop/src-tauri/capabilities/default.json"), "utf8"),
 );
+const desktopJob = workflow.slice(workflow.indexOf("  desktop:"), workflow.indexOf("  release:"));
+const releaseJob = workflow.slice(workflow.indexOf("  release:"));
+
+function namedStep(job: string, name: string, nextName: string): string {
+  return job.slice(job.indexOf(`      - name: ${name}`), job.indexOf(`      - name: ${nextName}`));
+}
 
 describe("desktop release workflow", () => {
   test("hands every signed updater artifact to the release job", () => {
@@ -43,10 +49,83 @@ describe("desktop release workflow", () => {
     expect(csp).not.toContain("script-src 'self' 'unsafe-eval'");
   });
 
+  test("fails closed unless updater key mode is legacy, bridge, or v2", () => {
+    expect(desktopJob).toContain('mode="${DESKTOP_UPDATER_KEY_MODE:-}"');
+    expect(desktopJob).toContain("legacy|bridge|v2)");
+    expect(desktopJob).toContain("invalid DESKTOP_UPDATER_KEY_MODE");
+    expect(releaseJob).toContain('mode="${DESKTOP_UPDATER_KEY_MODE:-}"');
+    expect(releaseJob).toContain("legacy|bridge|v2)");
+  });
+
+  test("keeps the old key out of v2 builds and requires both key generations for bridge", () => {
+    expect(desktopJob).toContain("id: updater-key-mode");
+    expect(desktopJob).toContain("require legacy updater signing key");
+    expect(desktopJob).toContain("steps.updater-key-mode.outputs.mode != 'v2'");
+    expect(desktopJob).toContain("require v2 updater signing key");
+    expect(desktopJob).toContain("TAURI_SIGNING_PRIVATE_KEY_V2: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_V2 }}");
+    expect(desktopJob).toContain("TAURI_SIGNING_PRIVATE_KEY_PASSWORD_V2: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD_V2 }}");
+    expect(desktopJob).toContain("build notarized desktop app with v2 updater key");
+    expect(desktopJob).toContain("build unnotarized desktop preview with v2 updater key");
+    expect(desktopJob).toContain("if: steps.apple-signing.outputs.enabled == 'true' && steps.updater-key-mode.outputs.mode == 'v2'");
+    expect(desktopJob).toContain("if: steps.apple-signing.outputs.enabled == 'false' && steps.updater-key-mode.outputs.mode == 'v2'");
+
+    const notarizedV2 = namedStep(
+      desktopJob,
+      "build notarized desktop app with v2 updater key",
+      "build unnotarized desktop preview with legacy updater key",
+    );
+    const previewV2 = namedStep(
+      desktopJob,
+      "build unnotarized desktop preview with v2 updater key",
+      "verify Developer ID signature and notarization ticket",
+    );
+    for (const v2Build of [notarizedV2, previewV2]) {
+      expect(v2Build).toContain("secrets.TAURI_SIGNING_PRIVATE_KEY_V2");
+      expect(v2Build).not.toContain("secrets.TAURI_SIGNING_PRIVATE_KEY }}");
+      expect(v2Build).not.toContain("secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}");
+    }
+  });
+
+  test("dual-signs bridge archives and publishes both updater channels", () => {
+    expect(tauriConfig.plugins.updater.endpoints).toEqual([
+      "https://github.com/leeguooooo/agentparty/releases/latest/download/latest-v2.json",
+    ]);
+    expect(desktopJob).toContain("name: sign bridge updater with v2 key");
+    expect(desktopJob).toContain('mv "${updater}.sig" "${updater}.sig.v2"');
+    expect(desktopJob).toContain('cp "${updater}.sig.v2" "${updater_out}.sig.v2"');
+    expect(releaseJob).toContain('generate_manifest dist/latest.json ".sig"');
+    expect(releaseJob).toContain('generate_manifest dist/latest-v2.json ".sig.v2"');
+    expect(releaseJob).toContain('--signature-suffix "$signature_suffix"');
+    expect(releaseJob).toContain("dist/latest-v2.json");
+    expect(releaseJob).toContain("dist/*.tar.gz.sig.v2");
+    expect(releaseJob).not.toMatch(/environment:\s*\n\s+name: release/);
+  });
+
+  test("pins the legacy channel to the configured bridge release in v2 mode", () => {
+    expect(desktopJob).toContain("DESKTOP_UPDATER_BRIDGE_TAG: ${{ vars.DESKTOP_UPDATER_BRIDGE_TAG }}");
+    expect(desktopJob).toContain("DESKTOP_UPDATER_BRIDGE_TAG is required");
+    expect(desktopJob).toContain("bridge mode requires DESKTOP_UPDATER_BRIDGE_TAG to equal the release tag");
+    expect(releaseJob).toContain('gh release download "$DESKTOP_UPDATER_BRIDGE_TAG"');
+    expect(releaseJob).toContain("--pattern latest.json");
+    expect(releaseJob).toContain("--output dist/latest.json");
+    expect(releaseJob).toContain("encoded_bridge_tag=");
+    expect(releaseJob).toContain("legacy updater manifest does not point to the configured bridge tag");
+  });
+
+  test("records updater key mode and rejects architecture or configuration drift", () => {
+    expect(desktopJob).toContain('"updater_key_mode":"%s"');
+    expect(releaseJob).toContain("map({notarized, distribution, updater_key_mode})");
+    expect(releaseJob).toContain("desktop architectures disagree on signing status or updater key mode");
+    expect(releaseJob).toContain("desktop updater key mode does not match release configuration");
+  });
+
   test("gates desktop distribution and falls back to an honest unnotarized preview", () => {
     expect(tauriConfig.bundle.macOS.signingIdentity).not.toBe("-");
     expect(workflow).toMatch(/desktop:\n(?:[\s\S]*?)environment:\n\s+name: release/);
     expect(workflow).toContain("id: apple-signing");
+    expect(workflow).toContain("vars.DESKTOP_REQUIRE_NOTARIZATION");
+    expect(workflow).toContain("DESKTOP_REQUIRE_NOTARIZATION must be true or false");
+    expect(workflow).toContain("Apple signing is required; missing:");
     expect(workflow).toContain('echo "enabled=false" >> "$GITHUB_OUTPUT"');
     expect(workflow).toContain("if: steps.apple-signing.outputs.enabled == 'true'");
     expect(workflow).toContain("if: steps.apple-signing.outputs.enabled == 'false'");

--- a/scripts/desktop-update-manifest.test.ts
+++ b/scripts/desktop-update-manifest.test.ts
@@ -17,6 +17,7 @@ function makeReleaseDirectory(): string {
   for (const [architecture, bundleName] of Object.entries(bundleNames)) {
     writeFileSync(join(directory, bundleName), `${architecture} bundle`);
     writeFileSync(join(directory, `${bundleName}.sig`), `${architecture} signature\n`);
+    writeFileSync(join(directory, `${bundleName}.sig.v2`), `${architecture} v2 signature\n`);
   }
   return directory;
 }
@@ -57,6 +58,23 @@ describe("buildDesktopUpdateManifest", () => {
         },
       },
     });
+  });
+
+  test("selects an alternate signature suffix for the v2 updater channel", () => {
+    const manifest = buildDesktopUpdateManifest({
+      ...manifestInput(),
+      signatureSuffix: ".sig.v2",
+    });
+
+    expect(manifest.platforms["darwin-aarch64"].signature).toBe("arm64 v2 signature\n");
+    expect(manifest.platforms["darwin-x86_64"].signature).toBe("x64 v2 signature\n");
+  });
+
+  test("rejects unsafe signature suffixes", () => {
+    expect(() => buildDesktopUpdateManifest({
+      ...manifestInput(),
+      signatureSuffix: "../../private-key",
+    })).toThrow("Invalid updater signature suffix: ../../private-key");
   });
 
   test("uses an injected clock when no publication date is supplied", () => {
@@ -121,6 +139,16 @@ describe("buildDesktopUpdateManifest", () => {
     );
   });
 
+  test("rejects a missing signature for the selected updater channel", () => {
+    const directory = makeReleaseDirectory();
+    unlinkSync(join(directory, `${bundleNames.arm64}.sig.v2`));
+
+    expect(() => buildDesktopUpdateManifest({
+      ...manifestInput(directory),
+      signatureSuffix: ".sig.v2",
+    })).toThrow(`Missing updater signature: ${bundleNames.arm64}.sig.v2`);
+  });
+
   test("rejects an empty updater signature", () => {
     const directory = makeReleaseDirectory();
     writeFileSync(join(directory, `${bundleNames.arm64}.sig`), " \n\t");
@@ -172,9 +200,29 @@ describe("desktop update manifest CLI", () => {
     expect(readdirSync(join(directory, "updates"))).toEqual(["latest.json"]);
   });
 
+  test("writes a v2 manifest from the requested signature suffix", () => {
+    const directory = makeReleaseDirectory();
+    const output = join(directory, "updates", "latest-v2.json");
+
+    runDesktopUpdateManifestCli([
+      "--version", "0.2.83",
+      "--tag", "v0.2.83",
+      "--repo", "leeguooooo/agentparty",
+      "--dir", directory,
+      "--output", output,
+      "--notes", "Desktop maturity release",
+      "--signature-suffix", ".sig.v2",
+      "--pub-date", "2026-07-10T12:30:45Z",
+    ]);
+
+    const manifest = JSON.parse(readFileSync(output, "utf8"));
+    expect(manifest.platforms["darwin-aarch64"].signature).toBe("arm64 v2 signature\n");
+    expect(manifest.platforms["darwin-x86_64"].signature).toBe("x64 v2 signature\n");
+  });
+
   test("requires every named CLI flag and prints usage", () => {
     expect(() => runDesktopUpdateManifestCli(["--version", "0.2.83"])).toThrow(
-      "Usage: bun scripts/desktop-update-manifest.ts --version <semver> --tag <tag> --repo <owner/repo> --dir <bundle-directory> --output <latest.json> --notes <notes> [--pub-date <RFC3339>]",
+      "Usage: bun scripts/desktop-update-manifest.ts --version <semver> --tag <tag> --repo <owner/repo> --dir <bundle-directory> --output <latest.json> --notes <notes> [--signature-suffix <.sig>] [--pub-date <RFC3339>]",
     );
   });
 
@@ -189,7 +237,7 @@ describe("desktop update manifest CLI", () => {
       "--output", join(directory, "latest.json"),
       "--pub-date", "2026-07-10T12:30:45Z",
     ])).toThrow(
-      "Usage: bun scripts/desktop-update-manifest.ts --version <semver> --tag <tag> --repo <owner/repo> --dir <bundle-directory> --output <latest.json> --notes <notes> [--pub-date <RFC3339>]",
+      "Usage: bun scripts/desktop-update-manifest.ts --version <semver> --tag <tag> --repo <owner/repo> --dir <bundle-directory> --output <latest.json> --notes <notes> [--signature-suffix <.sig>] [--pub-date <RFC3339>]",
     );
   });
 

--- a/scripts/desktop-update-manifest.ts
+++ b/scripts/desktop-update-manifest.ts
@@ -4,7 +4,8 @@ import { basename, dirname, join } from "node:path";
 
 const SEMVER = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/;
 const RFC_3339 = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(Z|[+-](\d{2}):(\d{2}))$/;
-const usage = "Usage: bun scripts/desktop-update-manifest.ts --version <semver> --tag <tag> --repo <owner/repo> --dir <bundle-directory> --output <latest.json> --notes <notes> [--pub-date <RFC3339>]";
+const SIGNATURE_SUFFIX = /^\.sig(?:\.[A-Za-z0-9_-]+)?$/;
+const usage = "Usage: bun scripts/desktop-update-manifest.ts --version <semver> --tag <tag> --repo <owner/repo> --dir <bundle-directory> --output <latest.json> --notes <notes> [--signature-suffix <.sig>] [--pub-date <RFC3339>]";
 
 const updaterBundles = {
   "darwin-aarch64": "agentparty-desktop-darwin-arm64.app.tar.gz",
@@ -17,6 +18,7 @@ export interface DesktopUpdateManifestInput {
   repo: string;
   dir: string;
   notes: string;
+  signatureSuffix?: string;
   pubDate?: string;
 }
 
@@ -84,14 +86,21 @@ function releaseUrl(repo: string, tag: string, bundleName: string): string {
   return `https://github.com/${repositoryParts.map(encodeURIComponent).join("/")}/releases/download/${encodeURIComponent(tag)}/${encodeURIComponent(bundleName)}`;
 }
 
-function readSignature(dir: string, bundleName: string): string {
+function validateSignatureSuffix(signatureSuffix: string): string {
+  if (!SIGNATURE_SUFFIX.test(signatureSuffix)) {
+    throw new Error(`Invalid updater signature suffix: ${signatureSuffix}`);
+  }
+  return signatureSuffix;
+}
+
+function readSignature(dir: string, bundleName: string, signatureSuffix: string): string {
   const bundlePath = join(dir, bundleName);
   if (!existsSync(bundlePath)) throw new Error(`Missing updater bundle: ${bundleName}`);
   const bundleStat = statSync(bundlePath);
   if (!bundleStat.isFile()) throw new Error(`Invalid updater bundle: ${bundleName}`);
   if (bundleStat.size === 0) throw new Error(`Empty updater bundle: ${bundleName}`);
 
-  const signatureName = `${bundleName}.sig`;
+  const signatureName = `${bundleName}${signatureSuffix}`;
   const signaturePath = join(dir, signatureName);
   if (!existsSync(signaturePath)) throw new Error(`Missing updater signature: ${signatureName}`);
   if (!statSync(signaturePath).isFile()) throw new Error(`Invalid updater signature: ${signatureName}`);
@@ -108,12 +117,13 @@ export function buildDesktopUpdateManifest(
   if (input.tag.length === 0) throw new Error("Release tag is required");
   const pubDate = input.pubDate ?? now().toISOString();
   validateRfc3339Date(pubDate);
+  const signatureSuffix = validateSignatureSuffix(input.signatureSuffix ?? ".sig");
 
   const platforms: DesktopUpdateManifest["platforms"] = {};
   for (const [platform, bundleName] of Object.entries(updaterBundles)) {
     platforms[platform] = {
       url: releaseUrl(input.repo, input.tag, bundleName),
-      signature: readSignature(input.dir, bundleName),
+      signature: readSignature(input.dir, bundleName, signatureSuffix),
     };
   }
 
@@ -134,6 +144,7 @@ function parseCliArguments(arguments_: string[]): DesktopUpdateManifestInput & {
     ["--dir", "dir"],
     ["--output", "output"],
     ["--notes", "notes"],
+    ["--signature-suffix", "signatureSuffix"],
     ["--pub-date", "pubDate"],
   ]);
 
@@ -155,6 +166,7 @@ function parseCliArguments(arguments_: string[]): DesktopUpdateManifestInput & {
     dir: values.get("dir")!,
     output: values.get("output")!,
     notes: values.get("notes")!,
+    signatureSuffix: values.get("signatureSuffix"),
     pubDate: values.get("pubDate"),
   };
 }

--- a/scripts/release-version.test.ts
+++ b/scripts/release-version.test.ts
@@ -499,6 +499,12 @@ describe("release asset verification", () => {
     "agentparty-desktop-darwin-x64.signing-status.json",
     "latest.json",
   ];
+  const bridgeAssets = [
+    ...requiredAssets,
+    "agentparty-desktop-darwin-arm64.app.tar.gz.sig.v2",
+    "agentparty-desktop-darwin-x64.app.tar.gz.sig.v2",
+    "latest-v2.json",
+  ];
 
   function releaseAssetsJson(assets: string[], emptyAsset?: string) {
     return JSON.stringify({ assets: assets.map((name) => ({ name, size: name === emptyAsset ? 0 : 1 })) });
@@ -511,6 +517,34 @@ describe("release asset verification", () => {
 
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain("21 required release assets ok");
+  });
+
+  test("requires both updater channels and v2 signatures for a bridge release", () => {
+    const result = runReleaseShell("verify_release_assets", {
+      DESKTOP_UPDATER_KEY_MODE: "bridge",
+      RELEASE_ASSETS_JSON: releaseAssetsJson(bridgeAssets),
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("24 required release assets ok");
+
+    const missing = "latest-v2.json";
+    const incomplete = runReleaseShell("verify_release_assets", {
+      DESKTOP_UPDATER_KEY_MODE: "bridge",
+      RELEASE_ASSETS_JSON: releaseAssetsJson(bridgeAssets.filter((asset) => asset !== missing)),
+    });
+    expect(incomplete.exitCode).not.toBe(0);
+    expect(incomplete.stderr).toContain(`missing release assets: ${missing}`);
+  });
+
+  test("requires the v2 manifest but not bridge-only signatures after rotation", () => {
+    const result = runReleaseShell("verify_release_assets", {
+      DESKTOP_UPDATER_KEY_MODE: "v2",
+      RELEASE_ASSETS_JSON: releaseAssetsJson([...requiredAssets, "latest-v2.json"]),
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("22 required release assets ok");
   });
 
   test("rejects a release missing a signed desktop updater asset", () => {

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -134,6 +134,14 @@ required = {
     "agentparty-desktop-darwin-x64.signing-status.json",
     "latest.json",
 }
+mode = os.environ.get("DESKTOP_UPDATER_KEY_MODE", "legacy")
+if mode in {"bridge", "v2"}:
+    required.add("latest-v2.json")
+if mode == "bridge":
+    required.update({
+        "agentparty-desktop-darwin-arm64.app.tar.gz.sig.v2",
+        "agentparty-desktop-darwin-x64.app.tar.gz.sig.v2",
+    })
 
 try:
     payload = json.loads(os.environ["RELEASE_ASSETS_JSON"])
@@ -280,6 +288,9 @@ main() {
   local RELEASE_ASSETS_JSON
   RELEASE_ASSETS_JSON=$(gh release view "$TAG" --json assets)
   export RELEASE_ASSETS_JSON
+  local DESKTOP_UPDATER_KEY_MODE
+  DESKTOP_UPDATER_KEY_MODE=$(gh variable get DESKTOP_UPDATER_KEY_MODE --repo leeguooooo/AgentParty 2>/dev/null || printf 'legacy')
+  export DESKTOP_UPDATER_KEY_MODE
   verify_release_assets
   echo "== 装机 =="
   curl -fsSL https://raw.githubusercontent.com/leeguooooo/agentparty/main/install.sh | sh


### PR DESCRIPTION
## 背景
旧 updater 私钥只存在 repository secret，GitHub 无法读取并原位迁移。直接换公钥会让 v0.2.88 客户端无法验证后续更新。

## 方案
- 显式 `legacy | bridge | v2` 模式，缺模式/key/bridge tag 均 fail closed
- bridge 版本的 archive 同时由旧 key 和 v2 key 签名
- 旧客户端继续读 `latest.json`，bridge 应用内嵌 v2 公钥并改读 `latest-v2.json`
- v2 后续版本滚动 `latest-v2.json`，每个最新 Release 都复制 bridge 的旧 `latest.json`，旧通道永久钉在 bridge 版本
- status metadata 跨架构校验 updater key mode，v2 build 不注入旧 key

## 已配置
- `release` Environment: `TAURI_SIGNING_PRIVATE_KEY_V2` / `...PASSWORD_V2`
- Repository variables: `DESKTOP_UPDATER_KEY_MODE=bridge` / `DESKTOP_UPDATER_BRIDGE_TAG=v0.2.89`
- v2 私钥恢复副本在本机 Keychain；仓库只提交公钥

## 验证
- 29 个 manifest/workflow 定向测试通过
- release.yml YAML 解析通过
- `gh release download --pattern latest.json --output ...` 实际命令通过
- v2 私钥对真实 `.app.tar.gz` 的本地 signer 集成通过
- `bunx tauri build --debug --no-bundle` 通过
- `bun run check` 正在本地执行，CI 也会复核

关联 #221。