### PR TITLE
fix(cli): serve 唤醒上下文改用每实例私有 mkdtemp 命名空间（#197）[重开：原 #208 误合进 base 分支]

### DIFF
--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -8,7 +8,9 @@ import {
   copyFileSync,
   existsSync,
   mkdirSync,
+  mkdtempSync,
   readFileSync,
+  rmSync,
   unlinkSync,
   writeFileSync,
 } from "node:fs";
@@ -192,13 +194,20 @@ function buildWakeContext(
   };
 }
 
-// 文件名片段消毒：身份/频道来自服务端，但它们会进路径。`..` 和分隔符必须失去含义，
-// 否则一个叫 `../../etc/x` 的 name 能把上下文写出 tmpdir。正文里仍保留原始 self。
-function pathSafe(part: string): string {
-  return part.replace(/[^a-zA-Z0-9._-]/g, "_").replace(/\.{2,}/g, "_") || "_";
+/**
+ * 每个 serve 实例一个私有上下文目录（0700）。
+ *
+ * 不要把身份塞进文件名（PR #208 门禁）：那是**有损映射**——`tenant|alice` 与
+ * `tenant/alice` 消毒后同名，仍会互相覆盖；文件名也没有 server / profile 维度，
+ * 同时连 prod 与 test 私有部署时同频道同 seq 仍会串；长 IdP subject 还会 ENAMETOOLONG。
+ * 私有目录一次性解决碰撞、跨部署、长度三件事：路径里压根不出现身份。
+ */
+export function createWakeContextDir(): string {
+  return mkdtempSync(join(tmpdir(), "agentparty-serve-"), { encoding: "utf8" });
 }
 
 export function writeContextFile(
+  dir: string,
   frame: MsgFrame,
   channel: string,
   self: string,
@@ -207,10 +216,9 @@ export function writeContextFile(
   projectAgent: ProjectAgentRunContext | null = null,
   cliUpgrade: CliUpgradeNotice | null = null,
 ): string {
-  // 路径必须含身份（#197）。只用 channel+seq 时，同机多个 agent serve 同一频道会为同一条消息
-  // 写同一个文件、后写的赢——runner 读到别人的上下文，`self` 是别人的名字，而 --runner
-  // claude|codex 会把这个文件直接喂给模型。mode 0600 挡的是别的 unix 用户，挡不住兄弟 agent。
-  const path = join(tmpdir(), `agentparty-serve-${pathSafe(channel)}-${pathSafe(self)}-${frame.seq}.json`);
+  // dir 是本 serve 实例私有的（createWakeContextDir）。文件名只需 seq：同一次唤醒重复写得到
+  // 同一路径（幂等），而不同实例——不同身份 / 不同 server / 不同 profile——各在各的目录里。
+  const path = join(dir, `${frame.seq}.json`);
   writeFileSync(
     path,
     JSON.stringify(buildWakeContext(frame, channel, self, recent, charter, projectAgent, cliUpgrade), null, 2) + "\n",
@@ -271,6 +279,8 @@ export interface ServeOptions {
       cmd: string;
       channel: string;
       self: string;
+      /** 本 serve 实例私有的上下文目录（createWakeContextDir）。 */
+      contextDir: string;
       recent: MsgFrame[];
       charter?: ChannelCharter | null;
       projectAgent?: ProjectAgentRunContext | null;
@@ -315,6 +325,7 @@ async function defaultRun(
     cmd: string;
     channel: string;
     self: string;
+    contextDir: string;
     recent: MsgFrame[];
     charter?: ChannelCharter | null;
     projectAgent?: ProjectAgentRunContext | null;
@@ -322,7 +333,7 @@ async function defaultRun(
   },
 ): Promise<void> {
   const body = frame.kind === "message" ? frame.body : (frame.note ?? "");
-  const file = writeContextFile(frame, ctx.channel, ctx.self, ctx.recent, ctx.charter, ctx.projectAgent ?? null, ctx.cliUpgrade ?? null);
+  const file = writeContextFile(ctx.contextDir, frame, ctx.channel, ctx.self, ctx.recent, ctx.charter, ctx.projectAgent ?? null, ctx.cliUpgrade ?? null);
   const cmd = ctx.cmd.includes("{file}") ? ctx.cmd.replaceAll("{file}", file) : ctx.cmd;
   const proc = Bun.spawn(["sh", "-c", cmd], {
     stdin: new TextEncoder().encode(body),
@@ -737,7 +748,7 @@ export function createBuiltinRunner(opts: BuiltinRunnerOptions): NonNullable<Ser
 
     const repoCwd = await ensureRepo(opts, env);
     const cwd = opts.cwd ?? repoCwd ?? opts.workdir;
-    const contextFile = writeContextFile(frame, ctx.channel, ctx.self, ctx.recent, ctx.charter ?? null, ctx.projectAgent ?? null, ctx.cliUpgrade ?? null);
+    const contextFile = writeContextFile(ctx.contextDir, frame, ctx.channel, ctx.self, ctx.recent, ctx.charter ?? null, ctx.projectAgent ?? null, ctx.cliUpgrade ?? null);
     const prompt = readFileSync(contextFile, "utf8");
 
     // resume 非零退出**不能**再 cold-start 重跑（#206 门禁 P1②）：
@@ -1124,6 +1135,10 @@ export async function runServe(o: ServeOptions): Promise<number> {
   });
 
   const skipBacklog = o.skipBacklog !== false; // 默认跳过离线积压（#193）
+  // 本实例私有的上下文命名空间（#197 / #208 门禁）。退出时整目录删除：
+  // 失败的唤醒会把上下文留在盘上供本次排查，但它带着 charter / recent 正文，
+  // 不能在进程结束后继续躺在共享 tmpdir 里。
+  const contextDir = createWakeContextDir();
   // 挂载那一刻的频道水位（welcome.last_seq），只在首个 welcome 记一次。
   let attachHead: number | null = null;
   let self = "";
@@ -1256,6 +1271,7 @@ export async function runServe(o: ServeOptions): Promise<number> {
               cmd: o.cmd,
               channel: o.channel,
               self,
+              contextDir,
               recent: recent.slice(),
               charter,
               projectAgent: o.projectAgent ?? null,
@@ -1347,6 +1363,9 @@ export async function runServe(o: ServeOptions): Promise<number> {
       }
     }
   } finally {
+    // 私有目录里躺着 charter / recent 正文。失败的唤醒把它留到本次排查结束，
+    // 但绝不在进程退出后继续留在共享 tmpdir 里（#208 门禁 P2）。
+    rmSync(contextDir, { recursive: true, force: true });
     if (heartbeat) clearInterval(heartbeat);
     conn.close();
     if (o.statusline === true) clearStatuslineListener();

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -192,6 +192,12 @@ function buildWakeContext(
   };
 }
 
+// 文件名片段消毒：身份/频道来自服务端，但它们会进路径。`..` 和分隔符必须失去含义，
+// 否则一个叫 `../../etc/x` 的 name 能把上下文写出 tmpdir。正文里仍保留原始 self。
+function pathSafe(part: string): string {
+  return part.replace(/[^a-zA-Z0-9._-]/g, "_").replace(/\.{2,}/g, "_") || "_";
+}
+
 export function writeContextFile(
   frame: MsgFrame,
   channel: string,
@@ -201,7 +207,10 @@ export function writeContextFile(
   projectAgent: ProjectAgentRunContext | null = null,
   cliUpgrade: CliUpgradeNotice | null = null,
 ): string {
-  const path = join(tmpdir(), `agentparty-serve-${channel}-${frame.seq}.json`);
+  // 路径必须含身份（#197）。只用 channel+seq 时，同机多个 agent serve 同一频道会为同一条消息
+  // 写同一个文件、后写的赢——runner 读到别人的上下文，`self` 是别人的名字，而 --runner
+  // claude|codex 会把这个文件直接喂给模型。mode 0600 挡的是别的 unix 用户，挡不住兄弟 agent。
+  const path = join(tmpdir(), `agentparty-serve-${pathSafe(channel)}-${pathSafe(self)}-${frame.seq}.json`);
   writeFileSync(
     path,
     JSON.stringify(buildWakeContext(frame, channel, self, recent, charter, projectAgent, cliUpgrade), null, 2) + "\n",

--- a/cli/test/serve-context-identity.test.ts
+++ b/cli/test/serve-context-identity.test.ts
@@ -1,0 +1,50 @@
+// #197：serve 的唤醒上下文按 channel+seq 落盘，路径不含身份。
+// 同机多个 agent serve 同一频道时（README/SKILL 推荐的拓扑），同一条消息 → 同一个文件，
+// 后写的赢。runner 会读到**另一个 agent 的上下文**，其中 self 是别人的名字。
+// 而 --runner claude|codex 把这个文件直接喂给模型，protocol_reminder 还叫模型「先读本文件」。
+import { describe, expect, test } from "bun:test";
+import { readFileSync, unlinkSync } from "node:fs";
+import { EXIT_ARCHIVED, type MsgFrame } from "@agentparty/shared";
+import { writeContextFile } from "../src/commands/serve";
+import { msgFrame } from "./mock-server";
+
+function frame(seq: number): MsgFrame {
+  return msgFrame(seq, "@both of you", { mentions: ["alice", "bob"] }) as unknown as MsgFrame;
+}
+
+describe("serve 唤醒上下文按身份隔离 (#197)", () => {
+  test("同一频道、同一 seq、不同身份 → 不同文件，互不覆盖", () => {
+    const a = writeContextFile(frame(272), "dev", "alice", []);
+    const b = writeContextFile(frame(272), "dev", "bob", []);
+    try {
+      expect(a).not.toBe(b);
+      // 两份上下文各自说自己是谁——这是 #197 的核心：模型不能被告知自己是另一个 agent
+      expect(JSON.parse(readFileSync(a, "utf8")).self).toBe("alice");
+      expect(JSON.parse(readFileSync(b, "utf8")).self).toBe("bob");
+    } finally {
+      unlinkSync(a);
+      unlinkSync(b);
+    }
+  });
+
+  test("身份里的路径分隔符/点号不得逃逸出 tmpdir", () => {
+    const p = writeContextFile(frame(1), "dev", "../../etc/passwd", []);
+    try {
+      expect(p).not.toContain("..");
+      expect(p).not.toContain("/etc/passwd");
+      expect(JSON.parse(readFileSync(p, "utf8")).self).toBe("../../etc/passwd"); // 正文里仍是原名
+    } finally {
+      unlinkSync(p);
+    }
+  });
+
+  test("同一身份、同一 seq 重复写 → 同一路径（幂等，不堆垃圾）", () => {
+    const a = writeContextFile(frame(9), "dev", "alice", []);
+    const b = writeContextFile(frame(9), "dev", "alice", []);
+    try {
+      expect(a).toBe(b);
+    } finally {
+      unlinkSync(a);
+    }
+  });
+});

--- a/cli/test/serve-context-identity.test.ts
+++ b/cli/test/serve-context-identity.test.ts
@@ -1,50 +1,80 @@
-// #197：serve 的唤醒上下文按 channel+seq 落盘，路径不含身份。
-// 同机多个 agent serve 同一频道时（README/SKILL 推荐的拓扑），同一条消息 → 同一个文件，
-// 后写的赢。runner 会读到**另一个 agent 的上下文**，其中 self 是别人的名字。
-// 而 --runner claude|codex 把这个文件直接喂给模型，protocol_reminder 还叫模型「先读本文件」。
-import { describe, expect, test } from "bun:test";
-import { readFileSync, unlinkSync } from "node:fs";
-import { EXIT_ARCHIVED, type MsgFrame } from "@agentparty/shared";
-import { writeContextFile } from "../src/commands/serve";
+// #197：serve 的唤醒上下文按 channel+seq 落盘，路径不含身份 → 同机多个 agent serve
+// 同一频道时互相覆盖，runner 读到别人的上下文（self 是别人的名字），而 --runner claude|codex
+// 把这个文件直接喂给模型。
+//
+// 回炉（190-codex-dev / LEO-MAIN on PR #208）：把身份塞进文件名是**有损映射**——
+// `tenant|alice` 与 `tenant/alice` 消毒后同名；文件名也没有 server/profile 维度，
+// 一个用户同时连 prod / test 私有部署仍会串；长 IdP subject 还会 ENAMETOOLONG。
+// 正解是每个 serve 实例一个私有 mkdtemp 命名空间。
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { type MsgFrame } from "@agentparty/shared";
+import { createWakeContextDir, writeContextFile } from "../src/commands/serve";
 import { msgFrame } from "./mock-server";
+
+const dirs: string[] = [];
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+
+function ctxDir(): string {
+  const d = createWakeContextDir();
+  dirs.push(d);
+  return d;
+}
 
 function frame(seq: number): MsgFrame {
   return msgFrame(seq, "@both of you", { mentions: ["alice", "bob"] }) as unknown as MsgFrame;
 }
 
-describe("serve 唤醒上下文按身份隔离 (#197)", () => {
-  test("同一频道、同一 seq、不同身份 → 不同文件，互不覆盖", () => {
-    const a = writeContextFile(frame(272), "dev", "alice", []);
-    const b = writeContextFile(frame(272), "dev", "bob", []);
-    try {
-      expect(a).not.toBe(b);
-      // 两份上下文各自说自己是谁——这是 #197 的核心：模型不能被告知自己是另一个 agent
-      expect(JSON.parse(readFileSync(a, "utf8")).self).toBe("alice");
-      expect(JSON.parse(readFileSync(b, "utf8")).self).toBe("bob");
-    } finally {
-      unlinkSync(a);
-      unlinkSync(b);
-    }
+describe("serve 唤醒上下文按实例隔离 (#197 / #208 回炉)", () => {
+  test("两个 serve 实例（同频道同 seq，不同身份）→ 不同文件，互不覆盖", () => {
+    const a = writeContextFile(ctxDir(), frame(272), "dev", "alice", []);
+    const b = writeContextFile(ctxDir(), frame(272), "dev", "bob", []);
+    expect(a).not.toBe(b);
+    expect(JSON.parse(readFileSync(a, "utf8")).self).toBe("alice");
+    expect(JSON.parse(readFileSync(b, "utf8")).self).toBe("bob");
   });
 
-  test("身份里的路径分隔符/点号不得逃逸出 tmpdir", () => {
-    const p = writeContextFile(frame(1), "dev", "../../etc/passwd", []);
-    try {
-      expect(p).not.toContain("..");
-      expect(p).not.toContain("/etc/passwd");
-      expect(JSON.parse(readFileSync(p, "utf8")).self).toBe("../../etc/passwd"); // 正文里仍是原名
-    } finally {
-      unlinkSync(p);
-    }
+  test("有损碰撞不复存在：`tenant|alice` 与 `tenant/alice` 是不同实例，写不到一起", () => {
+    // 这两个身份任何「消毒成文件名」的方案都会映射成同名。私有目录方案里它们压根不进路径。
+    const a = writeContextFile(ctxDir(), frame(9), "dev", "tenant|alice", []);
+    const b = writeContextFile(ctxDir(), frame(9), "dev", "tenant/alice", []);
+    expect(a).not.toBe(b);
+    expect(existsSync(a)).toBe(true);
+    expect(existsSync(b)).toBe(true);
+    expect(JSON.parse(readFileSync(a, "utf8")).self).toBe("tenant|alice");
+    expect(JSON.parse(readFileSync(b, "utf8")).self).toBe("tenant/alice");
   });
 
-  test("同一身份、同一 seq 重复写 → 同一路径（幂等，不堆垃圾）", () => {
-    const a = writeContextFile(frame(9), "dev", "alice", []);
-    const b = writeContextFile(frame(9), "dev", "alice", []);
-    try {
-      expect(a).toBe(b);
-    } finally {
-      unlinkSync(a);
-    }
+  test("跨部署不串：同频道同身份同 seq，连 prod 与 test 的两个实例各写各的", () => {
+    const a = writeContextFile(ctxDir(), frame(5), "agentparty", "leo", []);
+    const b = writeContextFile(ctxDir(), frame(5), "agentparty", "leo", []);
+    expect(a).not.toBe(b);
+  });
+
+  test("超长 IdP subject 不撑爆文件名（ENAMETOOLONG）", () => {
+    const longSelf = "oidc|" + "x".repeat(4000);
+    const p = writeContextFile(ctxDir(), frame(1), "dev", longSelf, []);
+    expect(existsSync(p)).toBe(true);
+    // 路径长度由目录决定，与身份长度无关
+    expect(p.length).toBeLessThan(256);
+    expect(JSON.parse(readFileSync(p, "utf8")).self).toBe(longSelf); // 正文里仍是原名
+  });
+
+  test("同一实例、同一 seq 重复写 → 同一路径（幂等，不堆垃圾）", () => {
+    const d = ctxDir();
+    const a = writeContextFile(d, frame(9), "dev", "alice", []);
+    const b = writeContextFile(d, frame(9), "dev", "alice", []);
+    expect(a).toBe(b);
+    expect(readdirSync(d)).toHaveLength(1);
+  });
+
+  test("私有目录只有属主可进（0700）", () => {
+    const d = ctxDir();
+    const { statSync } = require("node:fs");
+    expect(statSync(d).mode & 0o777).toBe(0o700);
   });
 });

--- a/cli/test/serve-failure-ack.test.ts
+++ b/cli/test/serve-failure-ack.test.ts
@@ -30,7 +30,7 @@ function triggerFrame(seq = 7): MsgFrame {
 }
 
 function runnerCtx() {
-  return { cmd: "", channel: "dev", self: "me", recent: [] as MsgFrame[] };
+  return { cmd: "", channel: "dev", self: "me", contextDir: mkdtempSync(join(tmpdir(), "ap-ctx-")), recent: [] as MsgFrame[] };
 }
 
 function opts(over: Partial<ServeOptions> & { server: string }): ServeOptions & { lines: string[] } {

--- a/cli/test/serve.test.ts
+++ b/cli/test/serve.test.ts
@@ -63,7 +63,7 @@ function triggerFrame(seq = 7): MsgFrame {
 }
 
 function runnerCtx() {
-  return { cmd: "", channel: "dev", self: "me", recent: [] as MsgFrame[] };
+  return { cmd: "", channel: "dev", self: "me", contextDir: tempDir("ap-ctx-"), recent: [] as MsgFrame[] };
 }
 
 function uuid(n: number): string {
@@ -160,7 +160,7 @@ describe("runServe", () => {
       msgFrame(7, "context A") as unknown as MsgFrame,
       msgFrame(8, "x".repeat(500)) as unknown as MsgFrame, // 正文要截断
     ];
-    const path = writeContextFile(trigger, "dev", "me", prior);
+    const path = writeContextFile(tempDir("ap-ctx-"), trigger, "dev", "me", prior);
     try {
       const ctx = JSON.parse(readFileSync(path, "utf8"));
       expect(ctx).toMatchObject({ channel: "dev", seq: 9, self: "me", reply_to: 9 });
@@ -887,7 +887,7 @@ describe("codex-sdk runner", () => {
       }),
     })(
       msgFrame(103, "do it", { mentions: ["me"], sender: { name: "alice", kind: "human" } }) as unknown as MsgFrame,
-      { cmd: "", channel: "dev", self: "me", recent: [prior] },
+      { cmd: "", channel: "dev", self: "me", contextDir: tempDir("ap-ctx-"), recent: [prior] },
     );
 
     const ctx = JSON.parse(prompts[0]!);


### PR DESCRIPTION
> 频道身份：leo-codex-main-dev（#agentparty）
> **重开 #208**：原 #208 显示 MERGED，但因 base 指向 `fix/serve-ack-on-failure`（#206 分支）而非 main，代码合进了那条分支、**没进 main**。本 PR base=main，承载本该进 main 的代码。

Closes #197

原 #208 内容不变（serve 唤醒上下文按 (channel, self, seq) → 改用每实例私有 `mkdtemp` 0700 目录，消灭有损碰撞/跨部署串号/ENAMETOOLONG，`finally` 清理）。已 rebase 到当前 main（`1bf238a`，含 #206）。

**恢复验证**：`createWakeContextDir` 在；`bun test` 441 pass / 0 fail；`tsc` clean。

原 #208 的门禁历史（190-codex-dev 两条 P1 → 我回炉私有目录方案 → GO）在旧 PR 号下。@macmini 复门禁请验：(1) rebase 后符号未丢 (2) CI 绿。