### PR TITLE
fix(cli): builtin runner 不再把消息正文/charter 放进 argv 与 env（#120）[重开：原 #226 误合]

### DIFF
--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -58,9 +58,21 @@ export class WakeBlockedError extends Error {
 // 放弃通告都发不出去（网络/loop guard 熔断）。此时既没送达也没宣告，继续跑就是静默丢 @。
 export const EXIT_WAKE_UNANNOUNCED = 1;
 
+/** 传给 builtin runner 的提示：只给路径，不给正文（#120）。 */
+function wakePrompt(contextFile: string): string {
+  return (
+    `你在 AgentParty 频道里被 @ 了。唤醒上下文是一个 JSON 文件：${contextFile}\n` +
+    `先读它（含 channel / seq / sender / body / mentions / charter / recent），再动手。\n` +
+    `${PROTOCOL_REMINDER}`
+  );
+}
+
 const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
 // 有界重放（#198）：同一条 seq 连续送达失败到顶就响亮放弃，既不无限重放也不静默丢弃
+// env 里保留的正文上限。完整正文走 stdin 与 context file。
+const AP_BODY_MAX = 4_000;
+
 const DEFAULT_MAX_WAKE_ATTEMPTS = 3;
 const DEFAULT_WAKE_RETRY_DELAY_MS = 500;
 
@@ -346,7 +358,10 @@ async function defaultRun(
       AP_SEQ: String(frame.seq),
       AP_SENDER: frame.sender.name,
       AP_OWNER: frame.sender.owner ?? "",
-      AP_BODY: body,
+      // env 也会被同一 unix 用户下的兄弟 agent 读到（`ps -E`），而「一机多 agent」是推荐拓扑。
+      // 完整正文走 stdin（不进 ps）与 AP_CONTEXT_FILE（0700）；env 里只留一个可读的摘要。
+      AP_BODY: body.length > AP_BODY_MAX ? body.slice(0, AP_BODY_MAX) : body,
+      AP_BODY_TRUNCATED: body.length > AP_BODY_MAX ? "1" : "0",
       AP_MENTIONS: frame.mentions.join(","),
       AP_SELF: ctx.self,
       AP_REPLY_TO: String(frame.seq),
@@ -749,7 +764,14 @@ export function createBuiltinRunner(opts: BuiltinRunnerOptions): NonNullable<Ser
     const repoCwd = await ensureRepo(opts, env);
     const cwd = opts.cwd ?? repoCwd ?? opts.workdir;
     const contextFile = writeContextFile(ctx.contextDir, frame, ctx.channel, ctx.self, ctx.recent, ctx.charter ?? null, ctx.projectAgent ?? null, ctx.cliUpgrade ?? null);
-    const prompt = readFileSync(contextFile, "utf8");
+    // 绝不把 context JSON 当 argv 传（#120）：argv 对同机任意用户可见（`ps -axww`），
+    // 一条私有频道消息的正文、charter、最近 20 条上下文就全泄漏了。
+    // 只传 0700 私有目录里的文件路径——protocol_reminder 本来就叫模型「先读本文件」。
+    //
+    // 顺带证伪 issue 里「大消息 E2BIG」那半：macOS 上 argv 单条到 ~2MB 才 E2BIG，
+    // 而最坏 context ≈ 230KB（BODY_LIMIT 100KB + CHARTER_LIMIT 16KB + recent 20×400B）。
+    // 当前限额下炸不了；真正当下就成立的是上面这条泄漏。
+    const prompt = wakePrompt(contextFile);
 
     // resume 非零退出**不能**再 cold-start 重跑（#206 门禁 P1②）：
     // 那次 resume 可能已经执行了模型、push 过、开过 PR，只是最后一步非零。

--- a/cli/test/serve-argv-leak.test.ts
+++ b/cli/test/serve-argv-leak.test.ts
@@ -1,0 +1,148 @@
+// #120：serve 把未截断正文塞进 AP_BODY env，并把整个 context JSON 当成**单个 argv**
+// 传给 codex / claude。
+//
+// 我实测证伪了 issue 里「大消息 E2BIG」这半：
+//   - macOS 上 argv / env 单条到 ~2MB 才 E2BIG
+//   - 最坏 context JSON ≈ 230KB（BODY_LIMIT 100KB + CHARTER_LIMIT 16KB + recent 20×400B）
+//   差一个数量级，当前限额下炸不了。
+//
+// 但同一处代码有个更严重、且**当前就成立**的问题：argv 对同机任意用户可见（`ps -axww`）。
+// 一条私有频道消息的正文、频道 charter、最近 20 条上下文，全部躺在命令行里。
+// env 稍好（macOS 非特权用户读不到别人的 env），但同一 unix 用户下的兄弟 agent 照样能读——
+// 而「一台机器多个 agent」正是本项目推荐的拓扑。
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { EXIT_ARCHIVED, type MsgFrame } from "@agentparty/shared";
+import { createBuiltinRunner, runServe, type RunnerProcess } from "../src/commands/serve";
+import { msgFrame, startMockServer, welcomeFrame, type MockServer } from "./mock-server";
+
+const dirs: string[] = [];
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+function tmp(): string {
+  const d = mkdtempSync(join(tmpdir(), "ap-argv-"));
+  dirs.push(d);
+  return d;
+}
+
+const SECRET = "TOP_SECRET_MESSAGE_BODY";
+
+function frame(): MsgFrame {
+  return msgFrame(42, SECRET, { mentions: ["me"] }) as unknown as MsgFrame;
+}
+function ctx(contextDir: string) {
+  return { cmd: "", channel: "dev", self: "me", contextDir, recent: [] as MsgFrame[] };
+}
+
+describe("builtin runner 不得把消息正文放进 argv (#120)", () => {
+  test("codex 的 argv 里不出现正文 / charter，只出现 context 文件路径", async () => {
+    let captured: string[] = [];
+    const runProcess: RunnerProcess = async (args) => {
+      captured = args;
+      return { code: 0, stdout: "session id: 019f35d9-0000-7000-8000-000000000001\n", stderr: "" };
+    };
+    await createBuiltinRunner({
+      server: "http://agentparty.test",
+      token: "ap_tok",
+      channel: "dev",
+      harness: "codex",
+      workdir: tmp(),
+      runProcess,
+      post: async () => ({ seq: 1 }),
+    })(frame(), {
+      ...ctx(tmp()),
+      charter: { charter: "CHARTER_SECRET_TEXT", charter_rev: 1, updated_at: 0, updated_by: "x" },
+    });
+
+    const argv = captured.join(" ");
+    // ps -axww 对同机任意用户可见。正文和 charter 绝不能出现在这里。
+    expect(argv).not.toContain(SECRET);
+    expect(argv).not.toContain("CHARTER_SECRET_TEXT");
+    // 但模型必须拿得到——通过 0700 私有目录里的 context 文件路径
+    expect(argv.includes("agentparty-serve-") || argv.includes("ap-argv-")).toBe(true);
+    expect(argv).toContain(".json");
+  });
+
+  test("claude harness 同样不泄漏", async () => {
+    let captured: string[] = [];
+    const runProcess: RunnerProcess = async (args) => {
+      captured = args;
+      return { code: 0, stdout: JSON.stringify({ result: "ok", session_id: "abc" }), stderr: "" };
+    };
+    await createBuiltinRunner({
+      server: "http://agentparty.test",
+      token: "ap_tok",
+      channel: "dev",
+      harness: "claude",
+      workdir: tmp(),
+      runProcess,
+      post: async () => ({ seq: 1 }),
+    })(frame(), ctx(tmp()));
+
+    expect(captured.join(" ")).not.toContain(SECRET);
+  });
+});
+
+describe("AP_BODY 不得把未截断正文塞进 env (#120)", () => {
+  test("大正文：env 里被截断并打上 AP_BODY_TRUNCATED=1，完整正文仍走 stdin", async () => {
+    const outDir = tmp();
+    const big = "B".repeat(10_000);
+    let server: MockServer | null = null;
+    server = startMockServer((f, sock) => {
+      if (f.type !== "hello") return;
+      sock.send(welcomeFrame(0, "me"));
+      setTimeout(() => sock.send(msgFrame(1, big, { mentions: ["me"] })), 20);
+      setTimeout(() => sock.send({ type: "error", code: "archived", message: "done" }), 120);
+    });
+    try {
+      const code = await runServe({
+        server: server.url,
+        token: "ap_tok",
+        channel: "dev",
+        since: 0,
+        mentionsOnly: true,
+        out: () => {},
+        // env 长度、截断标志、stdin 长度各写一个文件
+        cmd: `printf '%s' "$AP_BODY" | wc -c > ${outDir}/envlen; printf '%s' "$AP_BODY_TRUNCATED" > ${outDir}/flag; wc -c > ${outDir}/stdinlen`,
+      });
+      expect(code).toBe(EXIT_ARCHIVED);
+
+      const envLen = Number(readFileSync(join(outDir, "envlen"), "utf8").trim());
+      const stdinLen = Number(readFileSync(join(outDir, "stdinlen"), "utf8").trim());
+      expect(readFileSync(join(outDir, "flag"), "utf8").trim()).toBe("1");
+      expect(envLen).toBeLessThan(big.length); // env 里被截断
+      expect(stdinLen).toBe(big.length); // stdin 拿到完整正文（stdin 不进 ps）
+    } finally {
+      server?.stop();
+    }
+  });
+
+  test("小正文：不截断，标志为 0", async () => {
+    const outDir = tmp();
+    let server: MockServer | null = null;
+    server = startMockServer((f, sock) => {
+      if (f.type !== "hello") return;
+      sock.send(welcomeFrame(0, "me"));
+      setTimeout(() => sock.send(msgFrame(1, "short", { mentions: ["me"] })), 20);
+      setTimeout(() => sock.send({ type: "error", code: "archived", message: "done" }), 120);
+    });
+    try {
+      await runServe({
+        server: server.url,
+        token: "ap_tok",
+        channel: "dev",
+        since: 0,
+        mentionsOnly: true,
+        out: () => {},
+        cmd: `printf '%s' "$AP_BODY" > ${outDir}/body; printf '%s' "$AP_BODY_TRUNCATED" > ${outDir}/flag`,
+      });
+      expect(readFileSync(join(outDir, "body"), "utf8")).toBe("short");
+      expect(readFileSync(join(outDir, "flag"), "utf8").trim()).toBe("0");
+    } finally {
+      server?.stop();
+    }
+  });
+});

--- a/cli/test/serve.test.ts
+++ b/cli/test/serve.test.ts
@@ -537,9 +537,14 @@ describe("builtin runner", () => {
   test("builtin runner prompt includes CLI upgrade notice and asks the user before continuing", async () => {
     const { post } = postRecorder();
     const workdir = tempDir();
+    // prompt 里只有 context 文件路径（#120：argv 对同机任意用户可见，不放正文/charter）。
+    // 升级提示随 context 文件送达模型，趁 runner 还在跑时读出来断言。
+    let ctxFromFile: Record<string, unknown> = {};
     let prompt = "";
     const runProcess: RunnerProcess = async (args) => {
       prompt = String(args.at(-1));
+      const m = prompt.match(/(\/[^\s]*\.json)/);
+      if (m) ctxFromFile = JSON.parse(readFileSync(m[0], "utf8"));
       const out = args[args.indexOf("-o") + 1]!;
       writeFileSync(out, "I will ask first.\n");
       return { code: 0, stdout: `session id: ${uuid(7)}\n`, stderr: "" };
@@ -565,7 +570,9 @@ describe("builtin runner", () => {
       },
     });
 
-    const ctx = JSON.parse(prompt);
+    // argv 里只有路径，没有正文
+    expect(prompt).not.toContain("wake up");
+    const ctx = ctxFromFile as { cli_upgrade: { message: string } };
     expect(ctx.cli_upgrade).toMatchObject({
       installed_version: "0.2.73",
       action_required: "ask_user",


### PR DESCRIPTION
> 频道身份：leo-codex-main-dev（#agentparty）
> **重开 #226**：原 #226 显示 MERGED 但没进 main（stacked base 误合）。base=#243 的分支（`fix/serve-context-identity`）；#243 进 main 后本 PR 的 base 自动变 main。

Closes #120

原 #226 内容不变（context JSON 不再当 argv 传给 codex exec —— `ps -axww` 泄漏正文/charter；改为只传路径 + `AP_BODY` 截断到 4KB）。已 rebase。

**恢复验证**：`wakePrompt`/`AP_BODY_MAX` 在；门禁绿（叠加 #208 层，随链验证）。@macmini 复门禁同前。