### PR TITLE
fix(cli): watch 单实例保护，一条 @ 不再触发 N 次唤醒（#195）[重开：原 #227 误合]

### DIFF
--- a/cli/src/commands/watch.ts
+++ b/cli/src/commands/watch.ts
@@ -1,8 +1,10 @@
 // party watch — 补拉错过消息，阻塞等新消息
 import { EXIT_ARCHIVED, EXIT_AUTH, EXIT_LOOP_GUARD, EXIT_STREAM_ENDED, EXIT_TIMEOUT } from "@agentparty/shared";
+import { mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
 import { connect } from "../client";
-import { loadCursor, loadRevCursor, resolveChannel, saveCursor, saveRevCursor } from "../config";
+import { loadCursor, loadRevCursor, resolveChannel, saveCursor, saveRevCursor, statePath } from "../config";
 import { resolveAuth } from "../oidc-cli";
 import { formatMsg } from "../format";
 import { MAX_TIMEOUT_SEC, isSlug, parsePositiveIntFlag } from "../validation";
@@ -16,8 +18,8 @@ import {
   writeStatuslineCache,
 } from "../statusline-cache";
 
-const WATCH_FLAGS = ["channel", "timeout", "follow", "once", "mentions-only", "exclude-self", "json"];
-const HELP = `usage: party watch [channel|--channel C] [--timeout N] [--mentions-only] [--exclude-self] [--follow|--once] [--json]
+const WATCH_FLAGS = ["channel", "timeout", "follow", "once", "mentions-only", "exclude-self", "json", "allow-multiple"];
+const HELP = `usage: party watch [channel|--channel C] [--timeout N] [--mentions-only] [--exclude-self] [--follow|--once] [--json] [--allow-multiple]
 
 Watch a channel for new messages. By default this waits up to 240 seconds.
 With --follow, it stays attached unless --timeout N is explicit.
@@ -65,6 +67,67 @@ export function isCodexRuntimeEnv(env: Record<string, string | undefined> = proc
   return Object.keys(env).some((key) => key === "CODEX" || key.startsWith("CODEX_") || key.startsWith("OPENAI_CODEX"));
 }
 
+/**
+ * 单实例锁（#195）。
+ *
+ * `watch --once` 的推荐用法是「退出 → 处理 → 重挂」，重挂这一步在 harness 里是手动的、无守卫的。
+ * 实测：10 个唤醒周期后同一 (channel, workspace) 上并存两个 watcher，一条 @ 触发两次 runner，
+ * agent 把同一条消息回了两遍——而 `party who` 只显示一个 ● online，重复从产品内部完全不可见。
+ * 在开着 loop guard 的频道里，这直接给熔断计数器加了个乘数。
+ *
+ * 用 pid 锁而不是 flock：Bun 没有跨平台 flock，且我们要能告诉用户「是哪个 pid 占着」。
+ * 陈旧锁（写锁的进程已死）必须能接管，否则一次 SIGKILL 就把频道永久锁死。
+ */
+export interface WatchLock {
+  ok: boolean;
+  /** ok=false 时，当前持锁的进程 pid。 */
+  heldByPid?: number;
+  release?: () => void;
+}
+
+function watchLockPath(channel: string, dir: string): string {
+  return join(dir, `watch-${channel.replace(/[^a-zA-Z0-9._-]/g, "_")}.lock`);
+}
+
+function pidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0); // 信号 0：只探测存活，不真的发信号
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function acquireWatchLock(channel: string, dir: string): WatchLock {
+  const path = watchLockPath(channel, dir);
+  mkdirSync(dir, { recursive: true });
+  try {
+    const held = JSON.parse(readFileSync(path, "utf8")) as { pid?: number };
+    // 关键：只有确认写锁的进程**已经死了**才接管。反方向（把活着的当陈旧）会重新引入 #195。
+    if (typeof held.pid === "number" && pidAlive(held.pid)) {
+      return { ok: false, heldByPid: held.pid };
+    }
+  } catch {
+    /* 没有锁文件，或内容坏了：往下走，重新写一个 */
+  }
+  writeFileSync(path, JSON.stringify({ pid: process.pid, channel, ts: Date.now() }), { mode: 0o600 });
+  return {
+    ok: true,
+    release: () => {
+      try {
+        // 只删自己的锁：别人接管过就不动它
+        const cur = JSON.parse(readFileSync(path, "utf8")) as { pid?: number };
+        if (cur.pid === process.pid) unlinkSync(path);
+      } catch {
+        /* 已经没了 */
+      }
+    },
+  };
+}
+
+/** 已有 watcher 挂在同一 (channel, workspace) 上：拒绝启动，避免一条 @ 触发 N 次 runner（#195）。 */
+export const EXIT_ALREADY_WATCHING = 10;
+
 export interface WatchOptions {
   server: string;
   token: string;
@@ -81,6 +144,10 @@ export interface WatchOptions {
   out?: (line: string) => void;
   backoffBaseMs?: number;
   statusline?: boolean;
+  /** 单实例锁目录（#195）。默认与 workspace state 同放；测试注入。 */
+  lockDir?: string;
+  /** 关掉单实例保护（逃生舱）。 */
+  allowMultiple?: boolean;
 }
 
 export function resolveWatchTimeoutSec(timeout: number | undefined, indefinite: boolean): number {
@@ -90,6 +157,17 @@ export function resolveWatchTimeoutSec(timeout: number | undefined, indefinite: 
 
 export async function runWatch(o: WatchOptions): Promise<number> {
   const out = o.out ?? ((line: string) => console.log(line));
+  // 先抢锁，再连服务端：第二个 watcher 连 WS 都不该建，否则它已经开始消费 @ 了（#195）
+  const lockDir = o.lockDir ?? dirname(statePath());
+  const lock = o.allowMultiple === true ? null : acquireWatchLock(o.channel, lockDir);
+  if (lock && !lock.ok) {
+    out(
+      `watch: 已有 watcher 挂在 #${o.channel} 上（pid ${lock.heldByPid}）。` +
+        ` 再挂一个会让同一条 @ 触发 N 次唤醒——agent 会把同一条消息回 N 遍，并给 loop guard 上膛。` +
+        ` 要么等它退出，要么 kill ${lock.heldByPid}；确实想并存请加 --allow-multiple。`,
+    );
+    return EXIT_ALREADY_WATCHING;
+  }
   const conn = connect(o.server, o.token, o.channel, o.since, {
     onCursor: o.onCursor,
     sinceRev: o.sinceRev,
@@ -199,6 +277,7 @@ export async function runWatch(o: WatchOptions): Promise<number> {
       if (!o.follow && !o.once && printed > 0 && msg.seq >= lastSeq) break;
     }
   } finally {
+    lock?.release?.();
     if (timer) clearTimeout(timer);
     if (heartbeat) clearInterval(heartbeat);
     conn.close();
@@ -231,7 +310,7 @@ export async function run(argv: string[]): Promise<number> {
     console.log(HELP);
     return 0;
   }
-  const { positionals, flags } = parseArgs(argv, { booleans: ["follow", "once", "mentions-only", "exclude-self", "json"] });
+  const { positionals, flags } = parseArgs(argv, { booleans: ["follow", "once", "mentions-only", "exclude-self", "json", "allow-multiple"] });
   if (flags.follow === true && flags.once === true) {
     console.error("--follow and --once are mutually exclusive: follow keeps watching, once exits after the first match");
     return 1;
@@ -281,6 +360,7 @@ export async function run(argv: string[]): Promise<number> {
     onCursor: (c) => saveCursor(channel, c),
     onRevCursor: (r) => saveRevCursor(channel, r),
     statusline: true,
+    allowMultiple: flags["allow-multiple"] === true,
   });
   if (flags.once === true && flags.json !== true && code === 0) console.error(ONCE_REARM_ADVISORY);
   return code;

--- a/cli/test/watch-single-instance.test.ts
+++ b/cli/test/watch-single-instance.test.ts
@@ -1,0 +1,146 @@
+// #195：`watch --once` 的推荐用法是「退出 → 处理 → 重挂」，但重挂这一步无人守卫。
+// 实测（issue 作者）：10 个唤醒周期后同一 (channel, identity) 上挂了**两个** watcher，
+// 一条 @ 触发两次 runner，agent 把同一条消息回了两遍。而 `party who` 只显示一个 ● online——
+// 重复从产品内部完全不可见。
+//
+// 在有 loop guard 的频道里，这是直接给熔断计数器加了个乘数（每条重复回复都是一条 agent 消息）。
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { acquireWatchLock, EXIT_ALREADY_WATCHING, runWatch } from "../src/commands/watch";
+import { startMockServer, welcomeFrame } from "./mock-server";
+
+const dirs: string[] = [];
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+function dir(): string {
+  const d = mkdtempSync(join(tmpdir(), "ap-lock-"));
+  dirs.push(d);
+  return d;
+}
+
+describe("watch 单实例保护 (#195)", () => {
+  test("第一个 watcher 拿到锁", () => {
+    const lock = acquireWatchLock("dev", dir());
+    expect(lock.ok).toBe(true);
+    lock.release?.();
+  });
+
+  test("同一 (channel, workspace) 的第二个 watcher 被拒，并告知已有 watcher 的 pid", () => {
+    const d = dir();
+    const first = acquireWatchLock("dev", d);
+    expect(first.ok).toBe(true);
+
+    const second = acquireWatchLock("dev", d);
+    expect(second.ok).toBe(false);
+    expect(second.heldByPid).toBe(process.pid);
+
+    first.release?.();
+  });
+
+  test("不同频道互不阻塞", () => {
+    const d = dir();
+    const a = acquireWatchLock("alpha", d);
+    const b = acquireWatchLock("beta", d);
+    expect(a.ok).toBe(true);
+    expect(b.ok).toBe(true);
+    a.release?.();
+    b.release?.();
+  });
+
+  test("释放之后可以重挂（正常的 exit → 处理 → 重挂 循环）", () => {
+    const d = dir();
+    const first = acquireWatchLock("dev", d);
+    first.release?.();
+    const second = acquireWatchLock("dev", d);
+    expect(second.ok).toBe(true);
+    second.release?.();
+  });
+
+  test("陈旧锁（写锁的进程已经死了）会被接管，不会把频道永久锁死", () => {
+    const d = dir();
+    // 手写一个指向不存在进程的锁：kill -0 会失败 → 判定陈旧 → 接管
+    const dead = 999_999;
+    expect(() => process.kill(dead, 0)).toThrow(); // 先确认这个 pid 真的不存在
+    writeFileSync(join(d, "watch-dev.lock"), JSON.stringify({ pid: dead, channel: "dev" }));
+
+    const lock = acquireWatchLock("dev", d);
+    expect(lock.ok).toBe(true);
+    expect(JSON.parse(readFileSync(join(d, "watch-dev.lock"), "utf8")).pid).toBe(process.pid);
+    lock.release?.();
+  });
+
+  test("活着的锁不会被误判成陈旧（这是最危险的错误方向）", () => {
+    const d = dir();
+    writeFileSync(join(d, "watch-dev.lock"), JSON.stringify({ pid: process.pid, channel: "dev" }));
+    const lock = acquireWatchLock("dev", d);
+    expect(lock.ok).toBe(false);
+    expect(lock.heldByPid).toBe(process.pid);
+  });
+});
+
+// 光有锁函数没接进 runWatch 等于没修。这几条断言观测的是**过程**：
+// 第二个 watcher 有没有真的去连服务端、有没有消费掉那条 @。
+describe("runWatch 接线 (#195)", () => {
+  test("第二个 watcher 直接被拒，且连 WS 都不建（否则它已经在消费 @ 了）", async () => {
+    const d = dir();
+    let connections = 0;
+    const server = startMockServer((f, sock) => {
+      if (f.type !== "hello") return;
+      connections++;
+      sock.send(welcomeFrame(0, "me"));
+    });
+    try {
+      writeFileSync(join(d, "watch-dev.lock"), JSON.stringify({ pid: process.pid, channel: "dev" }));
+      const lines: string[] = [];
+      const code = await runWatch({
+        server: server.url,
+        token: "ap_tok",
+        channel: "dev",
+        since: 0,
+        timeoutSec: 2,
+        follow: false,
+        mentionsOnly: true,
+        once: true,
+        lockDir: d,
+        out: (l) => lines.push(l),
+        backoffBaseMs: 20,
+      });
+      expect(code).toBe(EXIT_ALREADY_WATCHING);
+      expect(connections).toBe(0); // 关键：没有建立连接
+      expect(lines.some((l) => l.includes(String(process.pid)))).toBe(true); // 告知占锁的 pid
+    } finally {
+      server.stop();
+    }
+  });
+
+  test("--allow-multiple 是逃生舱：明知故犯时放行", async () => {
+    const d = dir();
+    writeFileSync(join(d, "watch-dev.lock"), JSON.stringify({ pid: process.pid, channel: "dev" }));
+    const server = startMockServer((f, sock) => {
+      if (f.type !== "hello") return;
+      sock.send(welcomeFrame(0, "me"));
+      setTimeout(() => sock.send({ type: "error", code: "archived", message: "done" }), 30);
+    });
+    try {
+      const code = await runWatch({
+        server: server.url,
+        token: "ap_tok",
+        channel: "dev",
+        since: 0,
+        timeoutSec: 2,
+        follow: false,
+        mentionsOnly: true,
+        lockDir: d,
+        allowMultiple: true,
+        out: () => {},
+        backoffBaseMs: 20,
+      });
+      expect(code).not.toBe(EXIT_ALREADY_WATCHING);
+    } finally {
+      server.stop();
+    }
+  });
+});


### PR DESCRIPTION
> 频道身份：leo-codex-main-dev（#agentparty）
> **重开 #227**：原 #227 显示 MERGED 但没进 main（stacked base 误合进 `fix/serve-e2big`）。base=#226 的分支；前序进 main 后自动变 main。

Closes #195

原 #227 内容不变（按 (channel, workspace) pid 锁；抢锁在连 WS 之前；陈旧锁可接管；`--allow-multiple` 逃生舱；`EXIT_ALREADY_WATCHING`）。已 rebase。

**恢复验证**：watch 锁（`acquireWatchLock`/`EXIT_ALREADY_WATCHING`）在；`bun test` 453 pass / 0 fail；`tsc` clean。@macmini 复门禁同前。