### PR TITLE
ci: 拆分 full check 为 check:scripts/:cli/:shared/:web/:worker（#247 phase 1）

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,12 @@
   "license": "BUSL-1.1",
   "private": true,
   "scripts": {
-    "check": "sh -n install.sh && bun test scripts/release-version.test.ts scripts/desktop-update-manifest.test.ts scripts/desktop-release-workflow.test.ts scripts/desktop-pairing-smoke.test.ts scripts/install.test.ts && bunx tsc --project scripts/tsconfig.json && cd cli && bun test && bunx tsc --noEmit && cd ../shared && bunx tsc --noEmit && cd ../web && bun test && bunx tsc --noEmit && bunx vite build && cd ../worker && bun run verify:test-runtime && bunx vitest run && bunx tsc --noEmit",
+    "check:scripts": "sh -n install.sh && bun test scripts/release-version.test.ts scripts/desktop-update-manifest.test.ts scripts/desktop-release-workflow.test.ts scripts/desktop-pairing-smoke.test.ts scripts/install.test.ts scripts/check-aggregate.test.ts && bunx tsc --project scripts/tsconfig.json",
+    "check:cli": "cd cli && bun test && bunx tsc --noEmit",
+    "check:shared": "cd shared && bunx tsc --noEmit",
+    "check:web": "cd web && bun test && bunx tsc --noEmit && bunx vite build",
+    "check:worker": "cd worker && bun run verify:test-runtime && bunx vitest run && bunx tsc --noEmit",
+    "check": "bun run check:scripts && bun run check:cli && bun run check:shared && bun run check:web && bun run check:worker",
     "desktop:dev": "cd desktop && bun run dev",
     "desktop:build": "cd desktop && bun run build",
     "desktop:build:prod": "cd desktop && bun run build:prod",

--- a/scripts/check-aggregate.test.ts
+++ b/scripts/check-aggregate.test.ts
@@ -1,0 +1,44 @@
+// #247：`check` 被拆成 check:scripts / :cli / :shared / :web / :worker，
+// 好让 CI 按变更 area 只跑对应的一段（CLI 改动不再等全套 worker vitest）。
+//
+// 这里守一个不变量：聚合的 `check` 必须跑**每一个** check:* 子脚本。
+// 最危险的失败模式是「加了 check:foo 却忘了接进 check」——CI 全套会漏掉那段，
+// 显示绿、实际没测。这个守卫让那种漂移在 CI 里直接红。
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const pkg = JSON.parse(readFileSync(join(import.meta.dir, "..", "package.json"), "utf8")) as {
+  scripts: Record<string, string>;
+};
+
+describe("check 聚合完整性 (#247)", () => {
+  const subChecks = Object.keys(pkg.scripts).filter((k) => k.startsWith("check:"));
+
+  test("至少拆出了各 workspace 的 check（不是空拆）", () => {
+    for (const area of ["check:scripts", "check:cli", "check:shared", "check:web", "check:worker"]) {
+      expect(subChecks).toContain(area);
+    }
+  });
+
+  test("聚合的 `check` 跑了每一个 check:*（没有孤儿子检查）", () => {
+    const check = pkg.scripts.check ?? "";
+    for (const sub of subChecks) {
+      // `bun run check:cli` —— 聚合必须按名字引用每个子检查
+      expect(check).toContain(`run ${sub}`);
+    }
+  });
+
+  test("`check` 不引用任何不存在的 check:*（防止改名后留悬空引用）", () => {
+    const check = pkg.scripts.check ?? "";
+    const referenced = [...check.matchAll(/run (check:[a-z]+)/g)].map((m) => m[1]);
+    for (const ref of referenced) {
+      expect(subChecks).toContain(ref);
+    }
+  });
+
+  test("`release:verify` / `release:deploy` 仍走全量 `check`（拆分不能弱化发布门禁）", () => {
+    expect(pkg.scripts["release:verify"]).toContain("run check");
+    expect(pkg.scripts["release:deploy"]).toContain("run check");
+  });
+});


### PR DESCRIPTION
> 频道身份：leo-codex-main-dev（#agentparty）
> **#247 phase 1（只动 package.json，零风险，先合）**。phase 2（workflow paths-filter）另开一个 PR，由 macmini 门禁 YAML。

Refs #247

## 为什么

CLI 改动的 CI 现在要等全套 worker vitest（分钟级），是节奏瓶颈。拆分后 workflow 能按变更 area 只跑对应 check —— CLI-only 的 PR 秒级。

## phase 1 做了什么（零风险）

- `check` 拆成 5 个 `check:<area>`（scripts / cli / shared / web / worker），各自 `cd` 进对应 workspace，可独立跑。
- 顶层 `check` 变成 `bun run check:scripts && … && bun run check:worker` —— **语义完全不变**，仍是全量 fallback。
- `release:verify` / `release:deploy` 仍走全量 `check`，**发布门禁不弱化**。

**没有改 workflow**。paths-filter 的 job 拆分留 phase 2，且会保留 full-check 作 fallback（配错也不漏测）。

## 守卫（这是拆分最危险的地方）

`scripts/check-aggregate.test.ts`（接进 `check:scripts`，自己也进 CI）锚定：**`check` 必须引用每一个 `check:*`**。

最危险的失败模式：有人加了 `check:foo` 却忘了接进 `check` —— 全量会**漏测那段、显示绿**。这正是我们今天一整天在修的「显示完成、实际没有」。

变异（`check` 去掉一个子引用）→ 守卫精确变红。还守了：release 脚本仍走全量 `check`、`check` 不引用不存在的子检查（防改名留悬空）。

## 门禁

`check:scripts` 63 pass（含守卫）、`check:cli` 453 pass，各自独立跑通，tsc clean。

## 一条如实交代

调查 `check:scripts` 的一个 tsc 报错（`Cannot find type definition file for 'bun'`）时，我误跑了一次 `git stash`，把自己的改动 stash 了 —— 这是我自己的隔离 worktree（`agentparty-wt-247`，非共享主树），已 `stash pop` 全部取回，改动完整。那个 tsc 报错的真因是新 worktree 没跑 `bun install`，装完就消失，不是代码问题。记一条：新 worktree 先 `bun install`。