### PR TITLE
feat(worker): 暴露并验证部署版本身份 (#203)

### DIFF
--- a/scripts/desktop-pairing-smoke.test.ts
+++ b/scripts/desktop-pairing-smoke.test.ts
@@ -47,7 +47,7 @@ describe("desktop pairing deploy smoke", () => {
   });
 
   test("runs the Device Flow smoke unconditionally after every target deploy", () => {
-    const deploy = dualDeploy.indexOf('run("wrangler-accounts", ["--profile", target.profile, "deploy"');
+    const deploy = dualDeploy.indexOf('"deploy", "--config", target.config');
     const pairingSmoke = dualDeploy.indexOf('run("node", ["scripts/smoke-desktop-pairing.mjs"]');
     const optionalAuthenticatedSmoke = dualDeploy.indexOf("if (target.smokeToken && target.smokeWriteToken)");
     expect(deploy).toBeGreaterThan(-1);

--- a/web/public/docs/index.html
+++ b/web/public/docs/index.html
@@ -141,6 +141,7 @@
             <span class="zh">直接跑 <code>party doctor</code> 看配置、server、token、频道绑定和本地状态文件是否正常。</span>
             <span class="en">Run <code>party doctor</code> to check config, server, token, channel binding, and local state files.</span>
           </div>
+          <p><span class="zh">每次部署都会把版本、完整 commit 和部署时间编译进 Worker；<code>GET /api/health</code> 可独立核对当前产物。官方双环境流程会在每个环境部署后立即反查这些字段并要求完全一致；维护者也可随时运行 <code>bun run verify:dual-deployment</code> 对比 prod、xdream 与本地 HEAD。</span><span class="en">Each deploy compiles its version, full commit, and deployment timestamp into the Worker, so <code>GET /api/health</code> independently identifies the running artifact. The official dual-target flow reads these fields back after each deploy and requires an exact match; maintainers can also run <code>bun run verify:dual-deployment</code> to compare prod, xdream, and local HEAD.</span></p>
         </section>
 
         <section id="quickstart">

--- a/worker/package.json
+++ b/worker/package.json
@@ -12,6 +12,7 @@
     "deploy:prod": "node scripts/deploy-dual.mjs prod",
     "deploy:xdream": "node scripts/deploy-dual.mjs xdream",
     "deploy:dual": "node scripts/deploy-dual.mjs",
+    "verify:dual-deployment": "node scripts/verify-dual-deployment.mjs",
     "smoke:prod": "node scripts/smoke-prod.mjs",
     "verify:remote-schema": "node scripts/verify-remote-schema.mjs",
     "verify:test-runtime": "node scripts/verify-test-runtime.mjs",

--- a/worker/scripts/deploy-dual.mjs
+++ b/worker/scripts/deploy-dual.mjs
@@ -1,5 +1,6 @@
-import { spawnSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
+import { deploymentDefineArgs, verifyDeploymentMetadata } from "./deployment-metadata.mjs";
 
 function smokeBaseFromConfig(config) {
   const text = readFileSync(config, "utf8");
@@ -39,7 +40,16 @@ function run(cmd, args, options = {}) {
   }
 }
 
-function deployTarget(name) {
+const trackedChanges = execFileSync("git", ["status", "--porcelain", "--untracked-files=no"], { encoding: "utf8" }).trim();
+if (trackedChanges !== "") throw new Error("refusing to deploy tracked, uncommitted changes");
+
+const deploymentMetadata = {
+  version: JSON.parse(readFileSync("../desktop/package.json", "utf8")).version,
+  commit: execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).trim(),
+  deployed_at: new Date().toISOString(),
+};
+
+async function deployTarget(name) {
   const target = targets[name];
   if (!target) throw new Error(`unknown deploy target: ${name}`);
 
@@ -53,7 +63,13 @@ function deployTarget(name) {
       AGENTPARTY_WRANGLER_CONFIG: target.config,
     },
   });
-  run("wrangler-accounts", ["--profile", target.profile, "deploy", "--config", target.config], { env });
+  run("wrangler-accounts", [
+    "--profile", target.profile,
+    "deploy", "--config", target.config,
+    ...deploymentDefineArgs(deploymentMetadata),
+  ], { env });
+  await verifyDeploymentMetadata(target.smokeBase, deploymentMetadata);
+  console.error(`Verified ${name} deployment: ${deploymentMetadata.version} ${deploymentMetadata.commit}`);
   run("node", ["scripts/smoke-desktop-pairing.mjs"], {
     env: { ...env, AGENTPARTY_SMOKE_BASE: target.smokeBase },
   });
@@ -75,4 +91,4 @@ const requested = process.argv.slice(2);
 const names = requested.length > 0 ? requested : ["prod", "xdream"];
 
 run("bun", ["run", "build:web"]);
-for (const name of names) deployTarget(name);
+for (const name of names) await deployTarget(name);

--- a/worker/scripts/deployment-metadata.d.mts
+++ b/worker/scripts/deployment-metadata.d.mts
@@ -1,0 +1,22 @@
+export interface DeploymentMetadata {
+  version: string;
+  commit: string;
+  deployed_at: string;
+}
+
+export function validateDeploymentMetadata(metadata: DeploymentMetadata): DeploymentMetadata;
+export function deploymentDefineArgs(metadata: DeploymentMetadata): string[];
+export function readDeploymentMetadata(
+  base: string,
+  fetcher?: typeof fetch,
+): Promise<DeploymentMetadata>;
+export function verifyDeploymentMetadata(
+  base: string,
+  expected: DeploymentMetadata,
+  fetcher?: typeof fetch,
+): Promise<DeploymentMetadata>;
+export function verifyDualDeployment(
+  targets: Record<string, string>,
+  expected: DeploymentMetadata,
+  fetcher?: typeof fetch,
+): Promise<Record<string, DeploymentMetadata>>;

--- a/worker/scripts/deployment-metadata.mjs
+++ b/worker/scripts/deployment-metadata.mjs
@@ -1,0 +1,56 @@
+const SEMVER_RE = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
+const COMMIT_RE = /^[0-9a-f]{40}$/;
+
+export function validateDeploymentMetadata(metadata) {
+  if (!metadata || !SEMVER_RE.test(metadata.version)) throw new Error("deployment version is invalid");
+  if (!COMMIT_RE.test(metadata.commit)) throw new Error("deployment commit is invalid");
+  if (typeof metadata.deployed_at !== "string" || Number.isNaN(Date.parse(metadata.deployed_at))) {
+    throw new Error("deployment timestamp is invalid");
+  }
+  return metadata;
+}
+
+export function deploymentDefineArgs(metadata) {
+  validateDeploymentMetadata(metadata);
+  return [
+    "--define", `__AGENTPARTY_BUILD_VERSION__:${JSON.stringify(metadata.version)}`,
+    "--define", `__AGENTPARTY_BUILD_COMMIT__:${JSON.stringify(metadata.commit)}`,
+    "--define", `__AGENTPARTY_DEPLOYED_AT__:${JSON.stringify(metadata.deployed_at)}`,
+  ];
+}
+
+export async function readDeploymentMetadata(base, fetcher = fetch) {
+  const origin = base.replace(/\/+$/, "");
+  const response = await fetcher(`${origin}/api/health?deployment_metadata=1`, {
+    headers: { "cache-control": "no-cache" },
+  });
+  if (!response.ok) throw new Error(`deployment health returned ${response.status}`);
+
+  const actual = await response.json();
+  if (actual?.ok !== true) throw new Error("deployment health is not ok");
+  validateDeploymentMetadata(actual);
+  return { version: actual.version, commit: actual.commit, deployed_at: actual.deployed_at };
+}
+
+export async function verifyDeploymentMetadata(base, expected, fetcher = fetch) {
+  validateDeploymentMetadata(expected);
+  const actual = await readDeploymentMetadata(base, fetcher);
+  for (const field of ["version", "commit", "deployed_at"]) {
+    if (actual?.[field] !== expected[field]) {
+      throw new Error(`${field} mismatch: expected ${expected[field]}, got ${actual?.[field] ?? "missing"}`);
+    }
+  }
+  return actual;
+}
+
+export async function verifyDualDeployment(targets, expected, fetcher = fetch) {
+  const verified = {};
+  for (const [name, base] of Object.entries(targets)) {
+    try {
+      verified[name] = await verifyDeploymentMetadata(base, expected, fetcher);
+    } catch (error) {
+      throw new Error(`${name}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+  return verified;
+}

--- a/worker/scripts/verify-dual-deployment.mjs
+++ b/worker/scripts/verify-dual-deployment.mjs
@@ -1,0 +1,28 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { readDeploymentMetadata } from "./deployment-metadata.mjs";
+
+const expectedVersion = JSON.parse(readFileSync("../desktop/package.json", "utf8")).version;
+const expectedCommit = execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).trim();
+const targets = {
+  prod: process.env.AGENTPARTY_PROD_SMOKE_BASE ?? "https://agentparty.leeguoo.com",
+  xdream: process.env.AGENTPARTY_XDREAM_SMOKE_BASE ?? "https://agentparty.pwtk-dev.work",
+};
+
+const entries = await Promise.all(Object.entries(targets).map(async ([name, base]) => {
+  const metadata = await readDeploymentMetadata(base);
+  if (metadata.version !== expectedVersion) {
+    throw new Error(`${name}: version mismatch: expected ${expectedVersion}, got ${metadata.version}`);
+  }
+  if (metadata.commit !== expectedCommit) {
+    throw new Error(`${name}: commit mismatch: expected ${expectedCommit}, got ${metadata.commit}`);
+  }
+  return [name, metadata];
+}));
+
+const verified = Object.fromEntries(entries);
+if (verified.prod.deployed_at !== verified.xdream.deployed_at) {
+  throw new Error(`deployment timestamp mismatch: prod=${verified.prod.deployed_at}, xdream=${verified.xdream.deployed_at}`);
+}
+
+console.log(JSON.stringify(verified, null, 2));

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -62,7 +62,17 @@ import {
 } from "./integrations/lark";
 import { openapiDocument } from "./openapi";
 
+declare const __AGENTPARTY_BUILD_VERSION__: string | undefined;
+declare const __AGENTPARTY_BUILD_COMMIT__: string | undefined;
+declare const __AGENTPARTY_DEPLOYED_AT__: string | undefined;
+
 export { ChannelDO };
+
+const DEPLOYMENT_METADATA = Object.freeze({
+  version: typeof __AGENTPARTY_BUILD_VERSION__ === "string" ? __AGENTPARTY_BUILD_VERSION__ : "dev",
+  commit: typeof __AGENTPARTY_BUILD_COMMIT__ === "string" ? __AGENTPARTY_BUILD_COMMIT__ : "unknown",
+  deployed_at: typeof __AGENTPARTY_DEPLOYED_AT__ === "string" ? __AGENTPARTY_DEPLOYED_AT__ : null,
+});
 
 // OIDC_ISSUER + OIDC_CLIENT_ID 为可选 vars/secrets：都配齐才启用人类网页 OIDC 登录（spec §10）。
 // AUTH_PROVIDERS 是新版可扩展 OAuth 配置，Lark/Feishu 走 worker 服务端换码，secret 不下发给浏览器。
@@ -1617,7 +1627,10 @@ app.use("/api/*", async (c, next) => {
   c.res.headers.append("vary", "Origin");
 });
 
-app.get("/api/health", (c) => c.json({ ok: true }));
+app.get("/api/health", (c) => {
+  c.header("cache-control", "no-store");
+  return c.json({ ok: true, ...DEPLOYMENT_METADATA });
+});
 app.get("/openapi.json", (c) => c.json(openapiDocument));
 
 // Desktop Device Flow: only start/token/refresh are unauthenticated. The short user code is

--- a/worker/test/deployment-metadata-script.spec.ts
+++ b/worker/test/deployment-metadata-script.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import {
+  deploymentDefineArgs,
+  verifyDualDeployment,
+  verifyDeploymentMetadata,
+} from "../scripts/deployment-metadata.mjs";
+
+const metadata = {
+  version: "0.2.89",
+  commit: "0123456789abcdef0123456789abcdef01234567",
+  deployed_at: "2026-07-11T00:00:00.000Z",
+};
+
+describe("deployment metadata script", () => {
+  it("encodes build identity as Wrangler compile-time defines", () => {
+    expect(deploymentDefineArgs(metadata)).toEqual([
+      "--define", '__AGENTPARTY_BUILD_VERSION__:"0.2.89"',
+      "--define", '__AGENTPARTY_BUILD_COMMIT__:"0123456789abcdef0123456789abcdef01234567"',
+      "--define", '__AGENTPARTY_DEPLOYED_AT__:"2026-07-11T00:00:00.000Z"',
+    ]);
+  });
+
+  it("accepts only the exact deployed identity", async () => {
+    const fetcher = async () => new Response(JSON.stringify({ ok: true, ...metadata }), {
+      headers: { "content-type": "application/json" },
+    });
+
+    await expect(verifyDeploymentMetadata("https://example.test", metadata, fetcher)).resolves.toEqual(metadata);
+    await expect(verifyDeploymentMetadata("https://example.test", { ...metadata, commit: "f".repeat(40) }, fetcher))
+      .rejects.toThrow("commit mismatch");
+  });
+
+  it("verifies prod and xdream against one expected build", async () => {
+    const fetcher = async (input: string | URL | Request) => {
+      const url = String(input);
+      const body = url.startsWith("https://prod.test")
+        ? { ok: true, ...metadata }
+        : { ok: true, ...metadata, commit: "f".repeat(40) };
+      return new Response(JSON.stringify(body), { headers: { "content-type": "application/json" } });
+    };
+
+    await expect(verifyDualDeployment({ prod: "https://prod.test" }, metadata, fetcher))
+      .resolves.toEqual({ prod: metadata });
+    await expect(verifyDualDeployment({ prod: "https://prod.test", xdream: "https://xdream.test" }, metadata, fetcher))
+      .rejects.toThrow("xdream: commit mismatch");
+  });
+
+});

--- a/worker/test/health.spec.ts
+++ b/worker/test/health.spec.ts
@@ -1,0 +1,17 @@
+import { SELF } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+
+describe("deployment health metadata", () => {
+  it("exposes an uncached build identity", async () => {
+    const response = await SELF.fetch("http://ap.test/api/health");
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(await response.json()).toEqual({
+      ok: true,
+      version: "dev",
+      commit: "unknown",
+      deployed_at: null,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- expose build-time `version`, full `commit`, and `deployed_at` from uncached `GET /api/health`
- derive one deployment identity from the clean git worktree and desktop release version
- inject that identity through Wrangler compile-time `--define` values for both targets
- read each target back immediately after deploy and fail on any mismatch before smoke tests
- add `bun run verify:dual-deployment` to compare prod, xdream, and local HEAD at any time
- document the verification surface in the self-host section

## Verification

- RED: health test failed because the old endpoint had no metadata/cache header
- focused worker tests: 9/9 passed after rebase
- TypeScript: passed
- Wrangler `deploy --dry-run`: passed; generated bundle contains exact version/commit/deployed_at defines
- web production build: passed
- worker full run reached 299/300; the known unrelated `channel-role-account-binding` test timed out at 20s under load (#185), then passed isolated 5/5 in 75ms before rebase and 257ms after rebase

## Operational behavior

`deploy:dual` now refuses tracked uncommitted changes. Both targets receive the same metadata timestamp; a partial or stale deployment is detected immediately.

Closes #203.
