### PR TITLE
fix(worker): 等待部署元数据完成边缘传播 (#203)

### DIFF
--- a/worker/scripts/deployment-metadata.d.mts
+++ b/worker/scripts/deployment-metadata.d.mts
@@ -4,6 +4,12 @@ export interface DeploymentMetadata {
   deployed_at: string;
 }
 
+export interface DeploymentVerificationOptions {
+  attempts?: number;
+  delayMs?: number;
+  sleep?: (delayMs: number) => Promise<void>;
+}
+
 export function validateDeploymentMetadata(metadata: DeploymentMetadata): DeploymentMetadata;
 export function deploymentDefineArgs(metadata: DeploymentMetadata): string[];
 export function readDeploymentMetadata(
@@ -14,9 +20,11 @@ export function verifyDeploymentMetadata(
   base: string,
   expected: DeploymentMetadata,
   fetcher?: typeof fetch,
+  options?: DeploymentVerificationOptions,
 ): Promise<DeploymentMetadata>;
 export function verifyDualDeployment(
   targets: Record<string, string>,
   expected: DeploymentMetadata,
   fetcher?: typeof fetch,
+  options?: DeploymentVerificationOptions,
 ): Promise<Record<string, DeploymentMetadata>>;

--- a/worker/scripts/deployment-metadata.mjs
+++ b/worker/scripts/deployment-metadata.mjs
@@ -1,5 +1,9 @@
 const SEMVER_RE = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
 const COMMIT_RE = /^[0-9a-f]{40}$/;
+const DEFAULT_VERIFY_ATTEMPTS = 12;
+const DEFAULT_VERIFY_DELAY_MS = 1_000;
+
+const defaultSleep = (delayMs) => new Promise((resolve) => setTimeout(resolve, delayMs));
 
 export function validateDeploymentMetadata(metadata) {
   if (!metadata || !SEMVER_RE.test(metadata.version)) throw new Error("deployment version is invalid");
@@ -32,22 +36,37 @@ export async function readDeploymentMetadata(base, fetcher = fetch) {
   return { version: actual.version, commit: actual.commit, deployed_at: actual.deployed_at };
 }
 
-export async function verifyDeploymentMetadata(base, expected, fetcher = fetch) {
+export async function verifyDeploymentMetadata(base, expected, fetcher = fetch, options = {}) {
   validateDeploymentMetadata(expected);
-  const actual = await readDeploymentMetadata(base, fetcher);
-  for (const field of ["version", "commit", "deployed_at"]) {
-    if (actual?.[field] !== expected[field]) {
-      throw new Error(`${field} mismatch: expected ${expected[field]}, got ${actual?.[field] ?? "missing"}`);
+  const attempts = options.attempts ?? DEFAULT_VERIFY_ATTEMPTS;
+  const delayMs = options.delayMs ?? DEFAULT_VERIFY_DELAY_MS;
+  const sleep = options.sleep ?? defaultSleep;
+  if (!Number.isInteger(attempts) || attempts < 1) throw new Error("deployment verification attempts are invalid");
+  if (!Number.isFinite(delayMs) || delayMs < 0) throw new Error("deployment verification delay is invalid");
+
+  let lastError;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      const actual = await readDeploymentMetadata(base, fetcher);
+      for (const field of ["version", "commit", "deployed_at"]) {
+        if (actual?.[field] !== expected[field]) {
+          throw new Error(`${field} mismatch: expected ${expected[field]}, got ${actual?.[field] ?? "missing"}`);
+        }
+      }
+      return actual;
+    } catch (error) {
+      lastError = error;
+      if (attempt < attempts) await sleep(delayMs);
     }
   }
-  return actual;
+  throw lastError;
 }
 
-export async function verifyDualDeployment(targets, expected, fetcher = fetch) {
+export async function verifyDualDeployment(targets, expected, fetcher = fetch, options = {}) {
   const verified = {};
   for (const [name, base] of Object.entries(targets)) {
     try {
-      verified[name] = await verifyDeploymentMetadata(base, expected, fetcher);
+      verified[name] = await verifyDeploymentMetadata(base, expected, fetcher, options);
     } catch (error) {
       throw new Error(`${name}: ${error instanceof Error ? error.message : String(error)}`);
     }

--- a/worker/test/deployment-metadata-script.spec.ts
+++ b/worker/test/deployment-metadata-script.spec.ts
@@ -26,8 +26,30 @@ describe("deployment metadata script", () => {
     });
 
     await expect(verifyDeploymentMetadata("https://example.test", metadata, fetcher)).resolves.toEqual(metadata);
-    await expect(verifyDeploymentMetadata("https://example.test", { ...metadata, commit: "f".repeat(40) }, fetcher))
+    await expect(verifyDeploymentMetadata(
+      "https://example.test",
+      { ...metadata, commit: "f".repeat(40) },
+      fetcher,
+      { attempts: 1, delayMs: 0, sleep: async () => {} },
+    ))
       .rejects.toThrow("commit mismatch");
+  });
+
+  it("retries a stale edge response until the deployed identity propagates", async () => {
+    let calls = 0;
+    const waits: number[] = [];
+    const fetcher = async () => {
+      calls += 1;
+      const body = calls === 1 ? { ok: true } : { ok: true, ...metadata };
+      return new Response(JSON.stringify(body), { headers: { "content-type": "application/json" } });
+    };
+
+    await expect(verifyDeploymentMetadata("https://example.test", metadata, fetcher, {
+      attempts: 2,
+      delayMs: 25,
+      sleep: async (delayMs) => { waits.push(delayMs); },
+    })).resolves.toEqual(metadata);
+    expect({ calls, waits }).toEqual({ calls: 2, waits: [25] });
   });
 
   it("verifies prod and xdream against one expected build", async () => {
@@ -41,7 +63,12 @@ describe("deployment metadata script", () => {
 
     await expect(verifyDualDeployment({ prod: "https://prod.test" }, metadata, fetcher))
       .resolves.toEqual({ prod: metadata });
-    await expect(verifyDualDeployment({ prod: "https://prod.test", xdream: "https://xdream.test" }, metadata, fetcher))
+    await expect(verifyDualDeployment(
+      { prod: "https://prod.test", xdream: "https://xdream.test" },
+      metadata,
+      fetcher,
+      { attempts: 1, delayMs: 0, sleep: async () => {} },
+    ))
       .rejects.toThrow("xdream: commit mismatch");
   });
 


### PR DESCRIPTION
## Summary

- retry deployment metadata verification during the bounded Cloudflare edge propagation window
- keep the final check exact for version, full commit, and deployment timestamp
- make attempts, delay, and sleep injectable for deterministic tests
- preserve one-attempt mode for mismatch unit tests

## Production evidence

The first production deployment with #251 uploaded Worker version `2868c3f4-dd47-4ffd-9400-a32204b9fb74`. The immediate health read still returned the previous `{ "ok": true }` response and the new gate stopped before xdream. Seconds later prod returned the exact injected identity:

- version: `0.2.89`
- commit: `a2b23ce91256b6e5e98c332f53b2c46e4c5f5a9d`
- deployed_at: `2026-07-10T23:17:17.095Z`

This proves a propagation race rather than a missing define.

## Verification

- regression test: stale first response, exact second response
- focused suite: 5/5 passed
- worker TypeScript passed
- Node syntax check passed

Follow-up to #251 / #203.
