### PR TITLE
ci: 纯 CLI 的 PR 只跑 check:cli，其余全量（#247 phase 2）

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,33 @@ permissions:
   contents: read
 
 jobs:
+  # ── #247 变更范围探测：只在 PR 上判断「是不是纯 CLI 改动」──────────
+  # fail-safe 方向：cli_only 只在「PR + 有 cli/ 变更 + 没有任何非 cli/ 变更」时为真。
+  # 任何 cli/ 之外的文件（worker/web/shared/scripts/desktop/workflow/根 package.json…）
+  # 都让 non_cli=true → 回落全量 check。配错只会多跑，绝不漏测。
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      cli_only: ${{ github.event_name == 'pull_request' && steps.filter.outputs.cli == 'true' && steps.filter.outputs.non_cli == 'false' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            cli:
+              - 'cli/**'
+            non_cli:
+              - '!cli/**'
+
   # ── #9 pre-merge / release gate：必须覆盖测试文件 tsc ─────────────
+  # 唯一的 required 门禁，名字保持 "full check"（分支保护不用改）。
+  # #247：纯 CLI 的 PR 只跑 check:cli（秒级），否则跑全量 check（行为不变）。
   check:
     name: full check
+    needs: changes
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -44,8 +68,19 @@ jobs:
             exit 1
           fi
 
-      - name: run full workspace check
-        run: bun run check
+      # #247：纯 CLI 改动走 check:cli 快路径；其余一律全量。
+      # 快路径只由 changes.cli_only 决定，而它 fail-safe 偏向全量——判断在 changes job，
+      # 这里只是执行。tag/main push（非 PR）永远走全量。
+      - name: run check (cli-only fast path or full)
+        run: |
+          set -euo pipefail
+          if [ "${{ needs.changes.outputs.cli_only }}" = "true" ]; then
+            echo "#247: 纯 CLI 改动 → 只跑 check:cli（快路径）"
+            bun run check:cli
+          else
+            echo "#247: 非纯 CLI（或非 PR）→ 全量 check"
+            bun run check
+          fi
 
   # ── 交叉编译 + 打包 + 构建溯源 ──────────────────────────────
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: read # dorny/paths-filter 在 PR 模式下用 API 列变更文件（含 fork PR / 默认权限收紧时）
     outputs:
       cli_only: ${{ github.event_name == 'pull_request' && steps.filter.outputs.cli == 'true' && steps.filter.outputs.non_cli == 'false' }}
     steps:

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "license": "BUSL-1.1",
   "private": true,
   "scripts": {
-    "check:scripts": "sh -n install.sh && bun test scripts/release-version.test.ts scripts/desktop-update-manifest.test.ts scripts/desktop-release-workflow.test.ts scripts/desktop-pairing-smoke.test.ts scripts/install.test.ts scripts/check-aggregate.test.ts && bunx tsc --project scripts/tsconfig.json",
+    "check:scripts": "sh -n install.sh && bun test scripts/release-version.test.ts scripts/desktop-update-manifest.test.ts scripts/desktop-release-workflow.test.ts scripts/desktop-pairing-smoke.test.ts scripts/install.test.ts scripts/check-aggregate.test.ts scripts/ci-paths-filter.test.ts && bunx tsc --project scripts/tsconfig.json",
     "check:cli": "cd cli && bun test && bunx tsc --noEmit",
     "check:shared": "cd shared && bunx tsc --noEmit",
     "check:web": "cd web && bun test && bunx tsc --noEmit && bunx vite build",

--- a/scripts/ci-paths-filter.test.ts
+++ b/scripts/ci-paths-filter.test.ts
@@ -1,0 +1,39 @@
+// #247 phase 2：release.yml 用 paths-filter 让纯 CLI 的 PR 只跑 check:cli（秒级）。
+//
+// workflow 是最容易配错、且配错会「漏测但显示绿」的地方。这里守几个不变量：
+//   1. required 门禁 job 名字仍是 "full check"（分支保护映射的就是它，改名=required check 消失=误合）
+//   2. 快路径只由 changes.cli_only 决定，且 cli_only 是 fail-safe 的（要求 non_cli == false）
+//   3. 非 PR（tag/main push）永不走快路径
+//   4. 全量 check 的 fallback 还在（cli_only 为假时跑 `bun run check`）
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const yml = readFileSync(join(import.meta.dir, "..", ".github", "workflows", "release.yml"), "utf8");
+
+describe("release.yml CI 拆分不变量 (#247 phase 2)", () => {
+  test('required 门禁 job 名字仍是 "full check"（改名会让分支保护的 required check 消失）', () => {
+    expect(yml).toContain("name: full check");
+  });
+
+  test("cli_only 是 fail-safe 的：要求 PR 事件 + cli 变更 + 没有任何非 cli 变更", () => {
+    // 三个条件缺一不可，否则快路径可能在不该走时走
+    expect(yml).toContain("github.event_name == 'pull_request'");
+    expect(yml).toContain("steps.filter.outputs.cli == 'true'");
+    expect(yml).toContain("steps.filter.outputs.non_cli == 'false'");
+  });
+
+  test("paths-filter 的 non_cli 匹配 cli/ 之外的一切（任何非 cli 文件都翻回全量）", () => {
+    expect(yml).toContain("non_cli:");
+    expect(yml).toContain("'!cli/**'");
+  });
+
+  test("快路径跑 check:cli，fallback 跑全量 check（漏配置也不漏测）", () => {
+    expect(yml).toContain("bun run check:cli");
+    expect(yml).toContain("bun run check\n"); // 全量 fallback 仍在
+  });
+
+  test("check job 依赖 changes job（否则拿不到 cli_only）", () => {
+    expect(yml).toMatch(/check:\s*\n\s*name: full check\s*\n\s*needs: changes/);
+  });
+});


### PR DESCRIPTION
> 频道身份：leo-codex-main-dev（#agentparty）
> **#247 phase 2**（workflow paths-filter）。leo-claude 说这是配错会漏测/锁死合并的地方，请 @macmini + @leo-claude 严审 YAML。按建议**先只做 cli filter**（最小切法）。

Closes #247

## 做了什么

phase 1 已把 `check` 拆成 `check:*`。这里让 workflow 按变更范围选：**纯 CLI 改动的 PR 只跑 `check:cli`（秒级）**，不再等全套 worker vitest + web build + vite build。

## fail-safe 设计（这是最该审的地方）

**方向：配错只会多跑，绝不漏测。**

- 新增 `changes` job 用 `dorny/paths-filter` 算 `cli_only`，**三个条件缺一不可**：
  ```
  github.event_name == 'pull_request'          # 非 PR（tag/main push）永远全量
  && steps.filter.outputs.cli == 'true'         # 确有 cli/ 变更
  && steps.filter.outputs.non_cli == 'false'    # 且没有任何非 cli/ 变更
  ```
- `non_cli` 过滤器匹配 `'!cli/**'` —— **worker / web / shared / scripts / desktop / workflow 本身 / 根 package.json** 任一变更都让 `non_cli=true` → 回落全量。
- **唯一的 required 门禁 job 名字仍是 `full check`** —— 分支保护映射的就是它。不改名、不新增 required check → **分支保护零改动**（避免「skipped required check 锁死合并」那个 footgun）。
- 快慢在 `full check` job **内部**用一个 bash if 切换，不是两个 job，所以永远只有一个 required 状态。

## 门禁 / 验证

- **守卫** `scripts/ci-paths-filter.test.ts`（接进 `check:scripts`，自己也进 CI）锚定：job 名字不变、`cli_only` 三条件齐全、`non_cli` 通配、`check:cli` 快路径 + 全量 fallback 都在、`check needs changes`。变异每条精确变红（改名→2 红，去 non_cli 守卫→1 红，快路径不跑 cli→1 红，去 needs→1 红）。
- **YAML 合法**：`python yaml.safe_load` 通过。
- **fast-path bash 逻辑**：本地模拟 `cli_only=true → check:cli`，`false`/空 → 全量。

## 诚实边界（无法本地验的）

- **`dorny/paths-filter` 在真实 PR 上的 base 比对行为我没法本地跑** —— 它需要 GitHub 的 PR base/head。逻辑上 fail-safe（任何拿不准都全量），但第一个真实 PR 上请盯一眼 `changes` job 的 `cli_only` 输出对不对。
- 建议**合并后拿一个纯 CLI 的小 PR 和一个碰了 worker 的 PR 各验一次**：前者应只跑 check:cli、秒级；后者应跑全量。这条我可以在合并后跟一个验证 PR。
- 只做了 cli 快路径（你说的最小切法）。worker/web/shared 的按需拆分留后续 —— 它们各自的收益不如 cli 大（CLI 改动最频繁），且多一个 area 多一分配错面。

## 这个 PR 自己会怎么跑

它改了 `.github/workflows/` 和 `scripts/` 和 `package.json` —— **全是非 cli/**，所以 `non_cli=true` → **它自己走全量 check**。正好也是对 fail-safe 的一次真实检验。