### PR TITLE
fix(release): 在发布正文附上实际变更记录 (#183)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -554,6 +554,22 @@ jobs:
           fi
           echo "DESKTOP_RELEASE_NOTES=$DESKTOP_RELEASE_NOTES" >> "$GITHUB_ENV"
 
+      - name: generate release changelog
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          jq -n --arg tag_name "$GITHUB_REF_NAME" '{tag_name: $tag_name}' > dist/generate-notes-request.json
+          gh api --method POST "repos/$GITHUB_REPOSITORY/releases/generate-notes" \
+            --input dist/generate-notes-request.json \
+            --jq .body > dist/generated-release-notes.md
+          if [ ! -s dist/generated-release-notes.md ]; then
+            echo "::error::GitHub generated an empty release changelog"
+            exit 1
+          fi
+          printf '\n' >> dist/release-body.md
+          cat dist/generated-release-notes.md >> dist/release-body.md
+
       - name: generate desktop updater manifest
         env:
           GH_TOKEN: ${{ github.token }}

--- a/scripts/desktop-release-workflow.test.ts
+++ b/scripts/desktop-release-workflow.test.ts
@@ -174,4 +174,13 @@ describe("desktop release workflow", () => {
     expect(workflow).toContain("prerelease: ${{ steps.release-channel.outputs.prerelease }}");
     expect(workflow).toContain("make_latest: ${{ steps.release-channel.outputs.make_latest }}");
   });
+
+  test("appends GitHub generated changelog entries to the release distribution notice", () => {
+    expect(releaseJob).toContain("name: generate release changelog");
+    expect(releaseJob).toContain("GH_TOKEN: ${{ github.token }}");
+    expect(releaseJob).toContain("repos/$GITHUB_REPOSITORY/releases/generate-notes");
+    expect(releaseJob).toContain('--arg tag_name "$GITHUB_REF_NAME"');
+    expect(releaseJob).toContain("dist/generated-release-notes.md");
+    expect(releaseJob).toContain('cat dist/generated-release-notes.md >> dist/release-body.md');
+  });
 });


### PR DESCRIPTION
## 变更

- 发布时调用 GitHub `releases/generate-notes`，以当前 tag 生成真实 PR/commit changelog
- 将 changelog 追加到现有 production/preview 分发声明之后
- 生成结果为空或 API 失败时阻断发布，避免再次产生只有模板文字的 Release
- 增加 workflow contract test，锁定 token、tag、输出文件和正文拼接

## 验证

- `bun test scripts/desktop-release-workflow.test.ts`（14 pass）
- `bun -e 'import { parse } from "yaml"; parse(await Bun.file(".github/workflows/release.yml").text())'`
- 对 `v0.2.89` 实跑 GitHub generate-notes：返回 8 个 PR 条目和 `v0.2.88...v0.2.89` compare 链接
