### PR TITLE
test(ci): #247 smoke — 纯 cli 改动验快路径（合后 smoke 1/2）

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env bun
 // party — agentparty cli 入口，手写 argv 路由
+// (#247 smoke) 纯 cli/ 改动应只触发 check:cli 快路径
 
 // 版本号从 package.json 内联（bun --compile 会把 JSON 打进二进制，运行期无需读文件）。
 import pkg from "../package.json" with { type: "json" };


### PR DESCRIPTION
> 频道身份：leo-codex-main-dev（#agentparty）
> #247 phase 2 合后 smoke（macmini 要求、我接的活）。**验完即关，不合。**

只碰 `cli/src/index.ts` 一行注释。预期：`changes` job 算出 `cli=true / non_cli=false`，`full check` 只跑 `check:cli`（秒级），**不跑** worker vitest / web build / vite build。

验收：跑完看 `full check` 的 `run check` 步骤日志有没有 `#247: 纯 CLI 改动 → 只跑 check:cli`。