### PR TITLE
feat(desktop): 在设置中显示应用与服务器版本 (#192)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -864,7 +864,7 @@ export function App() {
             />
           </div>
         )}
-        <DesktopSettings />
+        <DesktopSettings serverOrigin={activeOrigin} />
         {desktop && (
           <ServerSwitcher
             profiles={serverProfiles}

--- a/web/src/components/DesktopSettings.test.tsx
+++ b/web/src/components/DesktopSettings.test.tsx
@@ -9,6 +9,7 @@ import {
   DesktopSettingsPanel,
   isDesktopSettingsOutsideClick,
   loadAutostartSetting,
+  loadDesktopVersionInfo,
   shouldDismissDesktopSettings,
   type DesktopSettingsRuntime,
   updateDesktopSettingsFocus,
@@ -21,6 +22,10 @@ const translations: Record<string, string> = {
   "DesktopSettings.autostart.description": "Open AgentParty when you sign in.",
   "DesktopSettings.autostart.loading": "Reading system setting",
   "DesktopSettings.autostart.error": "Couldn't update this setting.",
+  "DesktopSettings.version.desktop": "Desktop",
+  "DesktopSettings.version.server": "Server",
+  "DesktopSettings.version.build": "Build",
+  "DesktopSettings.version.unavailable": "Unavailable",
 };
 const t = (key: string) => translations[key] ?? key;
 
@@ -29,6 +34,7 @@ function runtime(overrides: Partial<DesktopSettingsRuntime> = {}): DesktopSettin
     isDesktopRuntime: () => true,
     isAutostartEnabled: async () => false,
     setAutostartEnabled: async () => true,
+    getAppVersion: async () => "0.2.89",
     ...overrides,
   };
 }
@@ -45,6 +51,8 @@ describe("DesktopSettings", () => {
       expect(DesktopSettingsStrings[locale]["DesktopSettings.control.label"]).toBeTruthy();
       expect(DesktopSettingsStrings[locale]["DesktopSettings.autostart.label"]).toBeTruthy();
       expect(DesktopSettingsStrings[locale]["DesktopSettings.autostart.error"]).toBeTruthy();
+      expect(DesktopSettingsStrings[locale]["DesktopSettings.version.desktop"]).toBeTruthy();
+      expect(DesktopSettingsStrings[locale]["DesktopSettings.version.server"]).toBeTruthy();
     }
   });
 
@@ -68,7 +76,14 @@ describe("DesktopSettings", () => {
 describe("DesktopSettingsPanel", () => {
   test("exposes the launch-at-login toggle as a keyboard-operable switch", () => {
     const html = renderToStaticMarkup(
-      <DesktopSettingsPanel enabled={true} pending={false} error={false} t={t} onToggle={() => {}} />,
+      <DesktopSettingsPanel
+        enabled={true}
+        pending={false}
+        error={false}
+        versions={{ desktop: "0.2.88", server: "0.2.89", commit: "048e06e5d1b5" }}
+        t={t}
+        onToggle={() => {}}
+      />,
     );
 
     expect(html).toContain('id="desktop-settings-panel"');
@@ -76,15 +91,63 @@ describe("DesktopSettingsPanel", () => {
     expect(html).toContain('role="switch"');
     expect(html).toContain('aria-checked="true"');
     expect(html).toContain("Launch at login");
+    expect(html).toContain("Desktop");
+    expect(html).toContain("0.2.88");
+    expect(html).toContain("Server");
+    expect(html).toContain("0.2.89");
+    expect(html).toContain("048e06e");
   });
 
   test("disables the switch while reading or writing and renders a short error", () => {
     const html = renderToStaticMarkup(
-      <DesktopSettingsPanel enabled={false} pending={true} error={true} t={t} onToggle={() => {}} />,
+      <DesktopSettingsPanel
+        enabled={false}
+        pending={true}
+        error={true}
+        versions={{ desktop: null, server: null, commit: null }}
+        t={t}
+        onToggle={() => {}}
+      />,
     );
 
     expect(html).toContain("disabled");
     expect(html).toContain("update this setting.");
+  });
+});
+
+describe("desktop version information", () => {
+  test("combines the native app version with the active server build identity", async () => {
+    const requests: string[] = [];
+    const info = await loadDesktopVersionInfo(
+      runtime({ getAppVersion: async () => "0.2.88" }),
+      "https://party.example.com/",
+      async (input) => {
+        requests.push(String(input));
+        return new Response(JSON.stringify({
+          ok: true,
+          version: "0.2.89",
+          commit: "048e06e5d1b5f70eee5bbca0eb854d3aa710f473",
+          deployed_at: "2026-07-10T23:27:24.905Z",
+        }), { status: 200 });
+      },
+    );
+
+    expect(requests).toEqual(["https://party.example.com/api/health"]);
+    expect(info).toEqual({
+      desktop: "0.2.88",
+      server: "0.2.89",
+      commit: "048e06e5d1b5f70eee5bbca0eb854d3aa710f473",
+    });
+  });
+
+  test("keeps native and server failures independent", async () => {
+    const info = await loadDesktopVersionInfo(
+      runtime({ getAppVersion: async () => { throw new Error("native unavailable"); } }),
+      "https://party.example.com",
+      async () => new Response("not json", { status: 502 }),
+    );
+
+    expect(info).toEqual({ desktop: null, server: null, commit: null });
   });
 });
 

--- a/web/src/components/DesktopSettings.tsx
+++ b/web/src/components/DesktopSettings.tsx
@@ -11,12 +11,56 @@ export interface DesktopSettingsRuntime {
   isDesktopRuntime(): boolean;
   isAutostartEnabled(): Promise<boolean>;
   setAutostartEnabled(enabled: boolean): Promise<boolean>;
+  getAppVersion(): Promise<string>;
+}
+
+export interface DesktopVersionInfo {
+  desktop: string | null;
+  server: string | null;
+  commit: string | null;
+}
+
+type DesktopVersionFetcher = (input: string) => Promise<Response>;
+
+function displayVersion(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim();
+  return normalized.length > 0 && normalized.length <= 64 && !/[\u0000-\u001f\u007f-\u009f]/.test(normalized)
+    ? normalized
+    : null;
+}
+
+function displayCommit(value: unknown): string | null {
+  return typeof value === "string" && /^[0-9a-f]{40}$/i.test(value) ? value.toLowerCase() : null;
+}
+
+export async function loadDesktopVersionInfo(
+  runtime: DesktopSettingsRuntime,
+  serverOrigin: string,
+  fetcher: DesktopVersionFetcher = fetch,
+): Promise<DesktopVersionInfo> {
+  const desktop = runtime.getAppVersion().then(displayVersion).catch(() => null);
+  const server = (async (): Promise<Pick<DesktopVersionInfo, "server" | "commit">> => {
+    const origin = serverOrigin.trim().replace(/\/+$/, "");
+    if (origin === "") return { server: null, commit: null };
+    try {
+      const response = await fetcher(`${origin}/api/health`);
+      if (!response.ok) return { server: null, commit: null };
+      const payload = await response.json() as { version?: unknown; commit?: unknown };
+      return { server: displayVersion(payload.version), commit: displayCommit(payload.commit) };
+    } catch {
+      return { server: null, commit: null };
+    }
+  })();
+  const [desktopVersion, serverVersion] = await Promise.all([desktop, server]);
+  return { desktop: desktopVersion, ...serverVersion };
 }
 
 const defaultRuntime: DesktopSettingsRuntime = {
   isDesktopRuntime,
   isAutostartEnabled,
   setAutostartEnabled,
+  getAppVersion: async () => (await import("@tauri-apps/api/app")).getVersion(),
 };
 
 export async function loadAutostartSetting(runtime: DesktopSettingsRuntime): Promise<boolean> {
@@ -66,12 +110,14 @@ interface PanelProps {
   enabled: boolean;
   pending: boolean;
   error: boolean;
+  versions: DesktopVersionInfo;
   t: TFunc;
   onToggle(): void;
   switchRef?: RefObject<HTMLButtonElement | null>;
 }
 
-export function DesktopSettingsPanel({ enabled, pending, error, t, onToggle, switchRef }: PanelProps) {
+export function DesktopSettingsPanel({ enabled, pending, error, versions, t, onToggle, switchRef }: PanelProps) {
+  const unavailable = t("DesktopSettings.version.unavailable");
   return (
     <section
       id="desktop-settings-panel"
@@ -100,21 +146,31 @@ export function DesktopSettingsPanel({ enabled, pending, error, t, onToggle, swi
       </div>
       {pending && <p className="desktop-settings-status">{t("DesktopSettings.autostart.loading")}</p>}
       {error && <p className="desktop-settings-error" role="alert">{t("DesktopSettings.autostart.error")}</p>}
+      <dl className="desktop-settings-versions">
+        <div><dt>{t("DesktopSettings.version.desktop")}</dt><dd>{versions.desktop ?? unavailable}</dd></div>
+        <div><dt>{t("DesktopSettings.version.server")}</dt><dd>{versions.server ?? unavailable}</dd></div>
+        <div>
+          <dt>{t("DesktopSettings.version.build")}</dt>
+          <dd title={versions.commit ?? undefined}>{versions.commit?.slice(0, 8) ?? unavailable}</dd>
+        </div>
+      </dl>
     </section>
   );
 }
 
 interface Props {
   runtime?: DesktopSettingsRuntime;
+  serverOrigin?: string;
 }
 
-export function DesktopSettings({ runtime = defaultRuntime }: Props) {
+export function DesktopSettings({ runtime = defaultRuntime, serverOrigin = "" }: Props) {
   const t = useT();
   const desktop = runtime.isDesktopRuntime();
   const [open, setOpen] = useState(false);
   const [enabled, setEnabled] = useState(false);
   const [pending, setPending] = useState(desktop);
   const [error, setError] = useState(false);
+  const [versions, setVersions] = useState<DesktopVersionInfo>({ desktop: null, server: null, commit: null });
   const rootRef = useRef<HTMLDivElement | null>(null);
   const triggerRef = useRef<HTMLButtonElement | null>(null);
   const switchRef = useRef<HTMLButtonElement | null>(null);
@@ -132,6 +188,15 @@ export function DesktopSettings({ runtime = defaultRuntime }: Props) {
     });
     return () => { alive = false; };
   }, [desktop, runtime]);
+
+  useEffect(() => {
+    if (!desktop) return;
+    let alive = true;
+    void loadDesktopVersionInfo(runtime, serverOrigin).then((next) => {
+      if (alive) setVersions(next);
+    });
+    return () => { alive = false; };
+  }, [desktop, runtime, serverOrigin]);
 
   useEffect(() => {
     if (!open) return;
@@ -204,6 +269,7 @@ export function DesktopSettings({ runtime = defaultRuntime }: Props) {
           enabled={enabled}
           pending={pending}
           error={error}
+          versions={versions}
           t={t}
           onToggle={toggleAutostart}
           switchRef={switchRef}

--- a/web/src/i18n/strings/DesktopSettings.ts
+++ b/web/src/i18n/strings/DesktopSettings.ts
@@ -8,6 +8,10 @@ export const DesktopSettingsStrings: LocaleDict = {
     "DesktopSettings.autostart.description": "Start AgentParty in the background when you sign in.",
     "DesktopSettings.autostart.loading": "Reading system setting",
     "DesktopSettings.autostart.error": "Couldn't update this setting.",
+    "DesktopSettings.version.desktop": "Desktop",
+    "DesktopSettings.version.server": "Server",
+    "DesktopSettings.version.build": "Build",
+    "DesktopSettings.version.unavailable": "Unavailable",
   },
   zh: {
     "DesktopSettings.control.label": "应用设置",
@@ -16,6 +20,10 @@ export const DesktopSettingsStrings: LocaleDict = {
     "DesktopSettings.autostart.description": "登录系统后在后台启动 AgentParty。",
     "DesktopSettings.autostart.loading": "正在读取系统设置",
     "DesktopSettings.autostart.error": "无法更新此设置。",
+    "DesktopSettings.version.desktop": "桌面版",
+    "DesktopSettings.version.server": "服务器",
+    "DesktopSettings.version.build": "构建",
+    "DesktopSettings.version.unavailable": "不可用",
   },
 };
 

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -222,6 +222,10 @@
 .desktop-settings-error { margin: 8px 0 0; font-size: 10px; }
 .desktop-settings-status { color: var(--t-dim); }
 .desktop-settings-error { color: var(--d-red); }
+.desktop-settings-versions { display: grid; gap: 4px; margin: 10px 0 0; padding-top: 8px; border-top: 1px solid var(--t-faint); }
+.desktop-settings-versions div { display: flex; justify-content: space-between; gap: 14px; }
+.desktop-settings-versions dt { color: var(--t-dim); }
+.desktop-settings-versions dd { margin: 0; color: var(--t-text); font-weight: 700; }
 .app-me {
   margin-left: auto;
   flex: 1 1 240px;


### PR DESCRIPTION
## 变更

- 桌面设置面板显示 Desktop、当前 Server 和 server commit
- native app version 与 `/api/health` 独立加载、独立容错
- 切换 production/private server 后自动刷新对应 build identity
- commit 仅显示前 8 位，完整值放在 title；无 raw error 展示
- 增加中英文文案和解析/渲染回归

## 验证

- `bun test web/src/App.test.tsx web/src/components/DesktopSettings.test.tsx`（18 pass）
- web TypeScript check 通过

## 待补

- Mac 当前锁屏，CI 绿后在解锁环境补桌面截图和 prod/private 切换视觉验收
