### PR TITLE
ci: full check 拆成并行 per-workspace job（6min→取最慢单个）

### DIFF
--- a/.github/actions/bun-install/action.yml
+++ b/.github/actions/bun-install/action.yml
@@ -1,0 +1,21 @@
+# 复用的 workspace setup：pin bun + 缓存 bun 全局 install cache + frozen install。
+# 每个并行 check job 都装全 workspace（根 lockfile 保证 workspace:* 依赖可解析），
+# 缓存命中时 install 只需秒级。
+name: bun install
+description: Set up bun and install all workspace dependencies with a warm cache.
+runs:
+  using: composite
+  steps:
+    - uses: oven-sh/setup-bun@v2
+      with:
+        bun-version: "1.3.14"
+    - name: cache bun install
+      uses: actions/cache@v4
+      with:
+        path: ~/.bun/install/cache
+        key: bun-install-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+        restore-keys: |
+          bun-install-${{ runner.os }}-
+    - name: install deps
+      shell: bash
+      run: bun install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,27 +38,57 @@ jobs:
             non_cli:
               - '!cli/**'
 
-  # ── #9 pre-merge / release gate：必须覆盖测试文件 tsc ─────────────
-  # 唯一的 required 门禁，名字保持 "full check"（分支保护不用改）。
-  # #247：纯 CLI 的 PR 只跑 check:cli（秒级），否则跑全量 check（行为不变）。
-  check:
-    name: full check
+  # ── #9 pre-merge / release gate：每个 workspace 独立并行跑，墙上时间=最慢单个 ──
+  # 5 个 workspace（cli/worker/web/shared/scripts）互不依赖（worker vitest 用隔离的
+  # 空 assets 目录，不再需要 web/dist），原来一个 job 串行跑 `bun run check` 要 ~6min，
+  # 拆并行后 ≈ 最慢那个 job。
+  # 复用的 setup 步骤（checkout+bun+install cache+install）由 composite action 提供。
+  #
+  # 快路径（#247）：纯 CLI 的 PR 只有 check-cli 真跑；worker/web/shared/scripts 靠
+  # `if: cli_only != 'true'` 跳过。fail-safe 方向不变——cli_only 只在 changes job 里
+  # 按「PR + cli 变更 + 无任何非 cli 变更」判定，配错只多跑绝不漏测；tag/main push
+  # 非 PR，cli_only 恒 false，5 个 workspace 全跑。
+
+  # cli 在两条路径下都要跑，所以无条件执行。
+  check-cli:
     needs: changes
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/bun-install
+      - run: bun run check:cli
 
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.3.14"
+  # worker/web/shared/scripts：非纯 CLI（或非 PR）才跑，纯 CLI 快路径下 skip。
+  check-rest:
+    name: check ${{ matrix.ws }}
+    needs: changes
+    if: needs.changes.outputs.cli_only != 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        ws: [worker, web, shared, scripts]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/bun-install
+      - run: bun run check:${{ matrix.ws }}
 
-      - name: install deps
-        run: bun install --frozen-lockfile
-
+  # 发布版本契约：只在 tag 上校验 tag == cli/desktop package.json 版本。
+  # 非 tag 时 skip（聚合门禁把 skipped 当通过）。
+  version-contract:
+    needs: changes
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/bun-install
       - name: verify release version contract
-        if: startsWith(github.ref, 'refs/tags/v')
         run: |
           set -euo pipefail
           TAG_VERSION="${GITHUB_REF_NAME#v}"
@@ -69,19 +99,37 @@ jobs:
             exit 1
           fi
 
-      # #247：纯 CLI 改动走 check:cli 快路径；其余一律全量。
-      # 快路径只由 changes.cli_only 决定，而它 fail-safe 偏向全量——判断在 changes job，
-      # 这里只是执行。tag/main push（非 PR）永远走全量。
-      - name: run check (cli-only fast path or full)
+  # 唯一的 required 门禁，名字保持 "full check"（分支保护映射的就是它，不用改设置）。
+  # if: always() → 无论上游成功/跳过/失败都跑；任一 workspace job 结论为 failure/cancelled
+  # 则本 job 失败，skipped（快路径跳过的）与 success 都算通过。build/desktop 仍 needs: check。
+  check:
+    name: full check
+    needs:
+      - check-cli
+      - check-rest
+      - version-contract
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: aggregate workspace check results
+        env:
+          R_CLI: ${{ needs.check-cli.result }}
+          R_REST: ${{ needs.check-rest.result }}
+          R_VERSION: ${{ needs.version-contract.result }}
         run: |
           set -euo pipefail
-          if [ "${{ needs.changes.outputs.cli_only }}" = "true" ]; then
-            echo "#247: 纯 CLI 改动 → 只跑 check:cli（快路径）"
-            bun run check:cli
-          else
-            echo "#247: 非纯 CLI（或非 PR）→ 全量 check"
-            bun run check
-          fi
+          echo "cli=$R_CLI rest=$R_REST version=$R_VERSION"
+          fail=0
+          for r in "$R_CLI" "$R_REST" "$R_VERSION"; do
+            case "$r" in
+              success|skipped) ;;
+              *) echo "::error::required check job did not pass: result=$r"; fail=1 ;;
+            esac
+          done
+          [ "$fail" = "0" ] || exit 1
+          echo "full check ✅"
 
   # ── 交叉编译 + 打包 + 构建溯源 ──────────────────────────────
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,8 @@ jobs:
       - uses: ./.github/actions/bun-install
       - run: bun run check:cli
 
-  # worker/web/shared/scripts：非纯 CLI（或非 PR）才跑，纯 CLI 快路径下 skip。
+  # web/shared/scripts：非纯 CLI（或非 PR）才跑，纯 CLI 快路径下 skip。
+  # worker 因为一个 workerd 串行跑 43 个 spec 太慢（~6min），单独拆分片 job，见下。
   check-rest:
     name: check ${{ matrix.ws }}
     needs: changes
@@ -71,11 +72,50 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ws: [worker, web, shared, scripts]
+        ws: [web, shared, scripts]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/bun-install
       - run: bun run check:${{ matrix.ws }}
+
+  # worker 测试：43 个 spec 在单 workerd 里串行要 ~6min，是唯一长杆。
+  # 用 vitest --shard 按文件切成 6 片并行——每片是独立 runner 上的全新 workerd，
+  # 跨片没有同一 job 内的 DO thrash（fileParallelism:false/singleWorker 只约束单 job 内）。
+  # 墙上时间 ≈ 最重那一片，而非全部串行之和。
+  check-worker:
+    name: check worker (shard ${{ matrix.shard }}/6)
+    needs: changes
+    if: needs.changes.outputs.cli_only != 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4, 5, 6]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/bun-install
+      - name: verify test runtime
+        working-directory: worker
+        run: bun run verify:test-runtime
+      - name: vitest shard ${{ matrix.shard }}/6
+        working-directory: worker
+        run: bunx vitest run --shard=${{ matrix.shard }}/6
+
+  # worker tsc 只跑一次，放并行独立 job（不放进分片，避免每片重复 typecheck）。
+  check-worker-types:
+    name: check worker (types)
+    needs: changes
+    if: needs.changes.outputs.cli_only != 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/bun-install
+      - working-directory: worker
+        run: bunx tsc --noEmit
 
   # 发布版本契约：只在 tag 上校验 tag == cli/desktop package.json 版本。
   # 非 tag 时 skip（聚合门禁把 skipped 当通过）。
@@ -107,6 +147,8 @@ jobs:
     needs:
       - check-cli
       - check-rest
+      - check-worker
+      - check-worker-types
       - version-contract
     if: always()
     runs-on: ubuntu-latest
@@ -117,12 +159,14 @@ jobs:
         env:
           R_CLI: ${{ needs.check-cli.result }}
           R_REST: ${{ needs.check-rest.result }}
+          R_WORKER: ${{ needs.check-worker.result }}
+          R_WORKER_TYPES: ${{ needs.check-worker-types.result }}
           R_VERSION: ${{ needs.version-contract.result }}
         run: |
           set -euo pipefail
-          echo "cli=$R_CLI rest=$R_REST version=$R_VERSION"
+          echo "cli=$R_CLI rest=$R_REST worker=$R_WORKER worker-types=$R_WORKER_TYPES version=$R_VERSION"
           fail=0
-          for r in "$R_CLI" "$R_REST" "$R_VERSION"; do
+          for r in "$R_CLI" "$R_REST" "$R_WORKER" "$R_WORKER_TYPES" "$R_VERSION"; do
             case "$r" in
               success|skipped) ;;
               *) echo "::error::required check job did not pass: result=$r"; fail=1 ;;

--- a/scripts/ci-paths-filter.test.ts
+++ b/scripts/ci-paths-filter.test.ts
@@ -30,13 +30,21 @@ describe("release.yml 并行门禁 + CI 拆分不变量 (#247 phase 2)", () => {
     expect(yml).toContain("'!cli/**'");
   });
 
-  test("5 个 workspace 各自 check:* 都在 workflow 里（漏配某个 = 漏测该 workspace）", () => {
+  test("cli + web/shared/scripts 各自 check:* 都在 workflow 里（漏配某个 = 漏测该 workspace）", () => {
     expect(yml).toContain("bun run check:cli");
-    // worker/web/shared/scripts 走 matrix：bun run check:${{ matrix.ws }}
+    // web/shared/scripts 走 matrix：bun run check:${{ matrix.ws }}
     expect(yml).toContain("bun run check:${{ matrix.ws }}");
-    for (const ws of ["worker", "web", "shared", "scripts"]) {
-      expect(yml).toContain(ws);
-    }
+    expect(yml).toContain("ws: [web, shared, scripts]");
+  });
+
+  test("worker 测试按文件分片并行（vitest --shard），且 typecheck 单跑不漏", () => {
+    // worker 是唯一长杆，拆 6 片；每片跑 vitest 的一个分片，tsc 单独一 job。
+    expect(yml).toContain("bunx vitest run --shard=${{ matrix.shard }}/6");
+    expect(yml).toContain("shard: [1, 2, 3, 4, 5, 6]");
+    // worker 的 tsc 仍在（放独立 check-worker-types job，不进分片）
+    expect(yml).toMatch(/check-worker-types:[\s\S]*?bunx tsc --noEmit/);
+    // worker vitest 前的 runtime 预检仍在
+    expect(yml).toContain("bun run verify:test-runtime");
   });
 
   test("非 cli 的 workspace 靠 cli_only 跳过（快路径下只有 check-cli 真跑）", () => {
@@ -47,9 +55,9 @@ describe("release.yml 并行门禁 + CI 拆分不变量 (#247 phase 2)", () => {
     expect(yml).toMatch(/check-cli:\s*\n\s*needs: changes\s*\n\s*runs-on:/);
   });
 
-  test('聚合 "full check" needs 全部 workspace job，且 if: always()（上游跳过/失败都要能裁决）', () => {
+  test('聚合 "full check" needs 全部 workspace job（含 worker 分片与 types），且 if: always()', () => {
     expect(yml).toMatch(/check:\s*\n\s*name: full check/);
-    for (const dep of ["check-cli", "check-rest", "version-contract"]) {
+    for (const dep of ["check-cli", "check-rest", "check-worker", "check-worker-types", "version-contract"]) {
       expect(yml).toContain(`- ${dep}`);
     }
     expect(yml).toContain("if: always()");

--- a/scripts/ci-paths-filter.test.ts
+++ b/scripts/ci-paths-filter.test.ts
@@ -1,17 +1,19 @@
-// #247 phase 2：release.yml 用 paths-filter 让纯 CLI 的 PR 只跑 check:cli（秒级）。
+// #247 phase 2 + 并行门禁：release.yml 把 full check 拆成并行 per-workspace job，
+// 并保留 paths-filter 让纯 CLI 的 PR 只跑 check:cli（秒级）。
 //
 // workflow 是最容易配错、且配错会「漏测但显示绿」的地方。这里守几个不变量：
 //   1. required 门禁 job 名字仍是 "full check"（分支保护映射的就是它，改名=required check 消失=误合）
 //   2. 快路径只由 changes.cli_only 决定，且 cli_only 是 fail-safe 的（要求 non_cli == false）
 //   3. 非 PR（tag/main push）永不走快路径
-//   4. 全量 check 的 fallback 还在（cli_only 为假时跑 `bun run check`）
+//   4. 5 个 workspace（cli/worker/web/shared/scripts）都有人跑，且非 cli 的靠 cli_only 跳过
+//   5. 聚合门禁把 workspace job 的 failure 变成自己失败，skipped 才算通过（漏配不漏测）
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
 const yml = readFileSync(join(import.meta.dir, "..", ".github", "workflows", "release.yml"), "utf8");
 
-describe("release.yml CI 拆分不变量 (#247 phase 2)", () => {
+describe("release.yml 并行门禁 + CI 拆分不变量 (#247 phase 2)", () => {
   test('required 门禁 job 名字仍是 "full check"（改名会让分支保护的 required check 消失）', () => {
     expect(yml).toContain("name: full check");
   });
@@ -28,12 +30,37 @@ describe("release.yml CI 拆分不变量 (#247 phase 2)", () => {
     expect(yml).toContain("'!cli/**'");
   });
 
-  test("快路径跑 check:cli，fallback 跑全量 check（漏配置也不漏测）", () => {
+  test("5 个 workspace 各自 check:* 都在 workflow 里（漏配某个 = 漏测该 workspace）", () => {
     expect(yml).toContain("bun run check:cli");
-    expect(yml).toContain("bun run check\n"); // 全量 fallback 仍在
+    // worker/web/shared/scripts 走 matrix：bun run check:${{ matrix.ws }}
+    expect(yml).toContain("bun run check:${{ matrix.ws }}");
+    for (const ws of ["worker", "web", "shared", "scripts"]) {
+      expect(yml).toContain(ws);
+    }
   });
 
-  test("check job 依赖 changes job（否则拿不到 cli_only）", () => {
-    expect(yml).toMatch(/check:\s*\n\s*name: full check\s*\n\s*needs: changes/);
+  test("非 cli 的 workspace 靠 cli_only 跳过（快路径下只有 check-cli 真跑）", () => {
+    expect(yml).toContain("if: needs.changes.outputs.cli_only != 'true'");
+  });
+
+  test("check-cli 无条件跑（cli 在快路径与全量下都要测）", () => {
+    expect(yml).toMatch(/check-cli:\s*\n\s*needs: changes\s*\n\s*runs-on:/);
+  });
+
+  test('聚合 "full check" needs 全部 workspace job，且 if: always()（上游跳过/失败都要能裁决）', () => {
+    expect(yml).toMatch(/check:\s*\n\s*name: full check/);
+    for (const dep of ["check-cli", "check-rest", "version-contract"]) {
+      expect(yml).toContain(`- ${dep}`);
+    }
+    expect(yml).toContain("if: always()");
+  });
+
+  test("聚合门禁把 failure/cancelled 变成自己失败，只有 success|skipped 通过（漏配不漏测）", () => {
+    expect(yml).toContain("success|skipped");
+    expect(yml).toContain("required check job did not pass");
+  });
+
+  test("build/desktop 仍 needs: check（聚合门禁是发布前置）", () => {
+    expect(yml).toMatch(/needs: check\b/);
   });
 });


### PR DESCRIPTION
频道身份：网页 leo（owner）——owner 指名亲自做、弄完直接合 main（提速 CI 是本轮明确 P0）。

## 问题
`full check` 现在是**单 job 串行**跑 `bun run check`（check:cli→worker→web→shared→scripts），PR/发布门禁 ~6min，是节奏主要瓶颈。#253 的路径过滤只救了纯 CLI PR，full check 本身还是 6min。

## 改法
5 个 workspace 互不依赖（worker vitest 用 vitest.config 里隔离的空 assets 目录，**不再需要 web/dist**），拆成**并行 job**，墙上时间 = 最慢单个而非求和：

- `check-cli` 无条件跑；`check-rest` matrix(worker/web/shared/scripts) `if: cli_only != 'true'` 跳过 → #247 纯 CLI 快路径不变
- `version-contract` 独立 job，仅 tag 上校验 tag==cli/desktop 版本
- 聚合 job 名保持 **"full check"**（分支保护零改动）：`needs` 全部 workspace job + `if: always()`，任一 failure/cancelled 则失败，**skipped/success 通过**（快路径跳过的 workspace 不误判成 fail）
- 复用 composite action `.github/actions/bun-install`：pin bun + 缓存 bun install cache + frozen install
- `ci-paths-filter.test.ts` 按新结构扩断言（required 名不丢、skipped≠fail、非 cli 靠 cli_only 跳过、build/desktop 仍 needs check）

## fail-safe
配错只多跑、绝不漏测：cli_only 仍在 changes job 按「PR+cli 变更+无任何非 cli 变更」判定；tag/main push 非 PR，5 个 workspace 全跑。

本 PR 改了 `.github/**`+`scripts/**` → 非纯 CLI → 跑全并行套件，正好验证全路径。合前会贴每-workspace 实测耗时。

https://claude.ai/code/session_01PgxkZeqJmDge3dYe9W2tPZ