### PR TITLE
feat(agentparty): 展示每个 agent 的 CLI 版本 (#192)

### DIFF
--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -1,5 +1,6 @@
 // ws 客户端：帧异步迭代 + 指数退避重连 + seq 去重 + ack 驱动的游标推进
 import type { ClientFrame, ServerFrame } from "@agentparty/shared";
+import pkg from "../package.json" with { type: "json" };
 
 class FrameQueue {
   private items: ServerFrame[] = [];
@@ -190,7 +191,7 @@ export function connect(
       opened = true;
       attempt = 0;
       helloSince = cursor;
-      sock.send(JSON.stringify({ type: "hello", since: cursor, since_rev: revCursor }));
+      sock.send(JSON.stringify({ type: "hello", since: cursor, since_rev: revCursor, client_version: pkg.version }));
       stopPing();
       pingTimer = setInterval(() => {
         if (sock.readyState === WebSocket.OPEN) sock.send(JSON.stringify({ type: "ping" }));

--- a/cli/test/client.test.ts
+++ b/cli/test/client.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import type { ServerFrame } from "@agentparty/shared";
+import pkg from "../package.json" with { type: "json" };
 import { connect, type Connection } from "../src/client";
 import { msgFrame, startMockServer, welcomeFrame, type MockServer } from "./mock-server";
 
@@ -92,7 +93,7 @@ describe("ws client", () => {
     const revs: number[] = [];
     conn = connect(server.url, "ap_tok", "dev", 6, { sinceRev: 2, onRevCursor: (r) => revs.push(r) });
     await collect(conn, 2, 800, false);
-    expect(hellos[0]).toMatchObject({ since: 6, since_rev: 2 });
+    expect(hellos[0]).toMatchObject({ since: 6, since_rev: 2, client_version: pkg.version });
     expect(revs).toEqual([5]);
     expect(conn.revCursor).toBe(5);
   });
@@ -221,8 +222,10 @@ describe("ws client", () => {
   });
 
   test("reconnects with backoff and latest cursor", async () => {
+    const hellos: Record<string, unknown>[] = [];
     server = startMockServer((frame, sock, connIndex) => {
       if (frame.type !== "hello") return;
+      hellos.push(frame as unknown as Record<string, unknown>);
       if (connIndex === 0) {
         sock.send(welcomeFrame(4));
         sock.send(msgFrame(4, "before drop"));
@@ -235,6 +238,10 @@ describe("ws client", () => {
     conn = connect(server.url, "ap_tok", "dev", 0, { backoffBaseMs: 20 });
     const frames = await collect(conn, 4, 5000);
     expect(server.hellos).toEqual([0, 4]);
+    expect(hellos).toEqual([
+      expect.objectContaining({ since: 0, client_version: pkg.version }),
+      expect.objectContaining({ since: 4, client_version: pkg.version }),
+    ]);
     const bodies = frames.filter((f) => f.type === "msg").map((f) => (f as { body: string }).body);
     expect(bodies).toEqual(["before drop", "after reconnect"]);
     expect(conn.cursor).toBe(5);

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -255,6 +255,8 @@ export interface Sender {
 
 export interface PresenceEntry {
   name: string;
+  /** 最近一次有效 CLI hello 上报的 package version；旧客户端或非 CLI 客户端缺失时省略。 */
+  client_version?: string;
   // agent / human。@ 补全等需要区分「可 @ 的 agent」和「只是围观的人类会话」。
   // 旧 worker 响应缺此字段 → undefined，消费方按未知处理（不当人类排除）。
   kind?: SenderKind;
@@ -384,6 +386,8 @@ export function evaluateHostLease(
 export interface HelloFrame {
   type: "hello";
   since: number;
+  /** CLI package version。可选以兼容旧客户端；服务端会忽略非法值。 */
+  client_version?: string;
   /**
    * 修订游标：客户端已见过的最大 rev_seq。带上它，服务端补拉只重放 rev_seq 更大的
    * 修订快照（编辑/撤回/超越），而不是把全部历史修订对每次连接无条件重放（issue #33）。
@@ -891,6 +895,7 @@ export interface SentFrame {
 export interface PresenceFrame {
   type: "presence";
   name: string;
+  client_version?: string;
   kind?: SenderKind;
   account?: string;
   state: PresenceState;

--- a/web/src/components/PresenceBar.test.ts
+++ b/web/src/components/PresenceBar.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, test } from "bun:test";
-import { buildGroups, countLiveGroups, ownerKey, type Item } from "./PresenceBar";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { PresenceEntry, Sender } from "@agentparty/shared";
+import { createElement } from "react";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { LocaleProvider } from "../i18n/locale";
+import { buildGroups, countLiveGroups, ownerKey, PresenceBar, type Item } from "./PresenceBar";
 
 function item(over: Partial<Item> = {}): Item {
   return {
@@ -20,9 +24,13 @@ function item(over: Partial<Item> = {}): Item {
     owner: null,
     account: null,
     handle: null,
+    displayName: null,
+    avatarUrl: null,
+    avatarThumb: null,
     display: "agent-a",
     responsibility: null,
     connectionCount: 1,
+    clientVersion: null,
     ...over,
   };
 }
@@ -90,5 +98,102 @@ describe("presence grouping by account", () => {
     const { live, total } = countLiveGroups(groups);
     expect(total).toBe(1);
     expect(live).toBe(0);
+  });
+});
+
+function memoryStorage(seed: Record<string, string> = {}): Storage {
+  const values = new Map(Object.entries(seed));
+  return {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => { values.set(key, value); },
+    removeItem: (key) => { values.delete(key); },
+    clear: () => values.clear(),
+    key: (index) => [...values.keys()][index] ?? null,
+    get length() { return values.size; },
+  };
+}
+
+function presenceEntry(clientVersion?: string): PresenceEntry {
+  return {
+    name: "agent-a",
+    kind: "agent",
+    state: "working",
+    note: null,
+    ts: Date.now(),
+    ...(clientVersion === undefined ? {} : { client_version: clientVersion }),
+  };
+}
+
+const participants: Sender[] = [{ name: "agent-a", kind: "agent" }];
+let renderer: ReactTestRenderer | null = null;
+
+beforeEach(() => {
+  Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", { configurable: true, value: true });
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: memoryStorage({ ap_locale: "en", ap_presence_expanded: "1" }),
+  });
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      setInterval: globalThis.setInterval.bind(globalThis),
+      clearInterval: globalThis.clearInterval.bind(globalThis),
+      innerWidth: 1280,
+      innerHeight: 800,
+    },
+  });
+});
+
+afterEach(async () => {
+  if (renderer !== null) await act(async () => renderer?.unmount());
+  renderer = null;
+  Reflect.deleteProperty(globalThis, "localStorage");
+  Reflect.deleteProperty(globalThis, "window");
+});
+
+function renderPresence(entry: PresenceEntry): ReactTestRenderer {
+  let next!: ReactTestRenderer;
+  void act(() => {
+    next = create(
+      createElement(
+        LocaleProvider,
+        null,
+        createElement(PresenceBar, {
+          presence: { "agent-a": entry },
+          participants,
+          status: "open",
+        }),
+      ),
+    );
+  });
+  renderer = next;
+  return next;
+}
+
+function nodesWithClass(r: ReactTestRenderer, className: string) {
+  return r.root.findAll((node) => String(node.props.className ?? "").split(" ").includes(className));
+}
+
+describe("presence client version", () => {
+  test("shows an agent CLI version in expanded details and the group tooltip, then removes it when collapsed", async () => {
+    const r = renderPresence(presenceEntry("0.2.89"));
+
+    const versions = nodesWithClass(r, "presence-client-version");
+    expect(versions).toHaveLength(1);
+    expect(versions[0]?.children).toEqual(["cli v", "0.2.89"]);
+    const group = nodesWithClass(r, "presence-group")[0];
+    expect(group?.props.title).toContain("agent-a: cli v0.2.89");
+
+    await act(async () => {
+      r.root.findByProps({ "aria-label": "collapse" }).props.onClick();
+    });
+
+    expect(nodesWithClass(r, "presence-client-version")).toHaveLength(0);
+  });
+
+  test("does not render a version label for legacy presence entries", () => {
+    const r = renderPresence(presenceEntry());
+
+    expect(nodesWithClass(r, "presence-client-version")).toHaveLength(0);
   });
 });

--- a/web/src/components/PresenceBar.tsx
+++ b/web/src/components/PresenceBar.tsx
@@ -44,6 +44,7 @@ export interface Item {
   display: string;
   responsibility: string | null;
   connectionCount: number;
+  clientVersion: string | null;
 }
 
 export interface PresenceGroup {
@@ -210,6 +211,7 @@ export function PresenceBar({
   const names = [...new Set([...participants.map((p) => p.name), ...Object.keys(presence), ...roles.map((role) => role.name)])].sort();
   const items: Item[] = names.map((name) => {
     const entry = presence[name];
+    const clientVersion = entry?.client_version ?? null;
     const sender = byName.get(name);
     const assigned = roleByName.get(name);
     const owner = sender?.owner ?? entry?.account ?? assigned?.account ?? null;
@@ -234,6 +236,7 @@ export function PresenceBar({
       avatarThumb: sender?.avatar_thumb ?? entry?.avatar_thumb ?? null,
       responsibility: assigned?.responsibility ?? null,
       connectionCount: sender?.connection_count ?? entry?.connection_count ?? (connected ? 1 : 0),
+      clientVersion,
     };
     if (!connected) {
       // owner 本就仅连接中的参与者可知（见上方字段注释）；handle 依赖同一份可信度，一并置空，
@@ -320,6 +323,7 @@ export function PresenceBar({
       it.workflow?.step_id ? `workflow step: ${it.workflow.step_id}` : null,
       it.workflow?.parent_summary_seq ? `parent summary: #${it.workflow.parent_summary_seq}` : null,
       it.connectionCount > 1 ? `${it.connectionCount} live sessions using this identity` : null,
+      it.kind === "agent" && it.clientVersion !== null ? `cli v${it.clientVersion}` : null,
       it.note !== null && it.note !== "" ? `note: ${it.note}` : null,
       it.lastSeen !== null ? `last seen: ${fmtRel(it.lastSeen)}` : null,
     ].filter((part): part is string => part !== null);
@@ -362,6 +366,9 @@ export function PresenceBar({
         {it.connectionCount > 1 && (
           <span className="t-mono presence-duplicate">x{it.connectionCount} sessions</span>
         )}
+        {full && it.kind === "agent" && it.clientVersion !== null && (
+          <span className="t-mono presence-client-version">cli v{it.clientVersion}</span>
+        )}
         {full && it.workflow !== null && <span className="t-mono presence-context">wf:{it.workflow.workflow_id}</span>}
         {full && it.note !== null && it.note !== "" && <span className="t-mono presence-note">{it.note}</span>}
         {full && it.responsibility !== null && it.responsibility !== "" && (
@@ -402,6 +409,9 @@ export function PresenceBar({
       duplicateSessions > 0 ? `${duplicateSessions} extra live session${duplicateSessions === 1 ? "" : "s"}` : null,
       group.human !== null ? `human: ${group.human.name}` : null,
       group.agents.length > 0 ? `agents: ${group.agents.map((item) => item.name).join(", ")}` : null,
+      ...group.agents
+        .filter((item) => item.clientVersion !== null)
+        .map((item) => `${item.name}: cli v${item.clientVersion}`),
     ].filter((part): part is string => part !== null).join(" · ");
     return (
       <section
@@ -446,6 +456,9 @@ export function PresenceBar({
                 <span className={`d-dot d-dot--${agent.state}`} />
                 <span>{agent.display}</span>
                 <span className={`t-mono presence-agent-kind presence-kind--${agent.kind}`}>{agent.kind}</span>
+                {agent.clientVersion !== null && (
+                  <span className="t-mono presence-client-version">cli v{agent.clientVersion}</span>
+                )}
                 {agent.connectionCount > 1 && <span className="t-mono presence-agent-duplicate">x{agent.connectionCount}</span>}
                 {roleBadge(agent, now) !== null && <span className="t-mono presence-agent-role">{roleBadge(agent, now)}</span>}
               </span>

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -976,6 +976,16 @@
   flex: none;
   color: var(--t-dim);
 }
+.presence-client-version {
+  flex: 0 1 auto;
+  min-width: 0;
+  max-width: 90px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--t-dim);
+  font-size: 9.5px;
+  white-space: nowrap;
+}
 .presence-agent-kind,
 .presence-kind {
   flex: none;
@@ -4117,6 +4127,7 @@
   .presence-group-label {
     max-width: 52vw;
   }
+  .presence-agent-chip .presence-client-version { display: none; }
   .presence-name { max-width: 42vw; }
   .presence-note { max-width: 120px; }
   .presence-popover {

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -115,6 +115,7 @@ const HOST_DECISION_KINDS: readonly string[] = ["decision", "handoff", "takeover
 const WORKFLOW_KINDS: readonly string[] = ["pipeline", "parallel", "orchestrator-workers", "evaluator-optimizer"];
 const MENTION_NAME_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$/;
 const WORKFLOW_ID_RE = /^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,127}$/;
+const CLIENT_VERSION_RE = /^[0-9A-Za-z][0-9A-Za-z.+-]{0,63}$/;
 const MAX_MENTIONS = 50;
 const MENTIONS_JSON_LIMIT = 4096;
 const MAX_STATUS_SCOPE = 50;
@@ -127,6 +128,10 @@ const REVIEW_REASON_LIMIT = 4000;
 
 function byteLength(s: string): number {
   return new TextEncoder().encode(s).byteLength;
+}
+
+function parseClientVersion(input: unknown): string | null {
+  return typeof input === "string" && CLIENT_VERSION_RE.test(input) ? input : null;
 }
 
 function parseMentions(input: unknown): string[] | null {
@@ -885,7 +890,8 @@ export class ChannelDO extends Server<Env> {
       context_json TEXT,
       lineage_json TEXT,
       kind TEXT,
-      account TEXT
+      account TEXT,
+      client_version TEXT
     )`);
     for (const ddl of [
       "ALTER TABLE presence ADD COLUMN kind TEXT",
@@ -908,6 +914,7 @@ export class ChannelDO extends Server<Env> {
       "ALTER TABLE presence ADD COLUMN display_name TEXT",
       "ALTER TABLE presence ADD COLUMN avatar_url TEXT",
       "ALTER TABLE presence ADD COLUMN avatar_thumb TEXT",
+      "ALTER TABLE presence ADD COLUMN client_version TEXT",
     ]) {
       try {
         sql.exec(ddl);
@@ -1078,6 +1085,8 @@ export class ChannelDO extends Server<Env> {
       return;
     }
     if (frame.type === "hello") {
+      const clientVersion = parseClientVersion(frame.client_version);
+      if (clientVersion !== null) this.recordClientVersion(st.name, clientVersion, Date.now());
       const since = typeof frame.since === "number" && frame.since > 0 ? Math.floor(frame.since) : 0;
       const sinceRev =
         typeof frame.since_rev === "number" && frame.since_rev >= 0 ? Math.floor(frame.since_rev) : null;
@@ -1338,6 +1347,18 @@ export class ChannelDO extends Server<Env> {
     const frame: PresenceFrame = { type: "presence", name, state: "offline", note: null, ts };
     const entry = this.presenceFor(name);
     this.broadcastFrame(entry ? { type: "presence", ...entry } : frame);
+  }
+
+  private recordClientVersion(name: string, clientVersion: string, ts: number) {
+    this.ctx.storage.sql.exec(
+      `INSERT INTO presence (name, state, note, updated_at, client_version) VALUES (?, 'waiting', NULL, ?, ?)
+       ON CONFLICT(name) DO UPDATE SET client_version = excluded.client_version`,
+      name,
+      ts,
+      clientVersion,
+    );
+    const entry = this.presenceFor(name);
+    if (entry) this.broadcastFrame({ type: "presence", ...entry });
   }
 
   // worker 每次转发都会带上频道快照头，do 写 meta 缓存（同 archived 的手法）
@@ -3231,7 +3252,7 @@ export class ChannelDO extends Server<Env> {
   // presence.kind 非 NULL 时（即刚发过 status 帧、最新一手 token 快照）优先用它，不被历史消息覆盖。
   private static readonly PRESENCE_COLUMNS = `name,
                 COALESCE(kind, (SELECT sender_kind FROM messages WHERE sender_name = presence.name ORDER BY seq DESC LIMIT 1)) AS kind,
-                account, handle, display_name, avatar_url, avatar_thumb,
+                account, handle, display_name, avatar_url, avatar_thumb, client_version,
                 state, note, updated_at, status_scope_json, status_summary_seq, status_blocked_reason,
                 status_context_json, status_decision_json, status_workflow_json, role, role_source, residency, wake_kind, wake_verified_at,
                 context_json, lineage_json`;
@@ -3276,6 +3297,9 @@ export class ChannelDO extends Server<Env> {
         : statusEventFromRow(r, String(r.name), state as StatusState, ts);
     return {
       name: String(r.name),
+      ...(typeof r.client_version === "string" && r.client_version !== ""
+        ? { client_version: r.client_version }
+        : {}),
       ...(r.kind === "agent" || r.kind === "human" ? { kind: r.kind as SenderKind } : {}),
       ...(typeof r.account === "string" && r.account !== "" ? { account: r.account } : {}),
       ...(typeof r.handle === "string" && r.handle !== "" ? { handle: r.handle } : {}),

--- a/worker/test/client-version.spec.ts
+++ b/worker/test/client-version.spec.ts
@@ -1,0 +1,98 @@
+import type { PresenceEntry } from "@agentparty/shared";
+import { describe, expect, it } from "vitest";
+import { WsClient, api, createChannel, seedToken } from "./helpers";
+
+async function fetchPresence(slug: string, token: string): Promise<PresenceEntry[]> {
+  const res = await api(`/api/channels/${slug}/presence`, token);
+  expect(res.status).toBe(200);
+  return ((await res.json()) as { presence: PresenceEntry[] }).presence;
+}
+
+async function sendStatus(ws: WsClient, note: string): Promise<void> {
+  ws.send({ type: "send", kind: "status", state: "working", note });
+  await ws.nextOfType("sent");
+  await ws.nextOfType("status");
+}
+
+describe("CLI client version presence (issue #192)", () => {
+  it("keeps legacy hello without a version backward compatible", async () => {
+    const agent = await seedToken("agent");
+    const slug = await createChannel(agent.token);
+    const ws = await WsClient.open(slug, agent.token);
+    await ws.nextOfType("welcome");
+
+    ws.send({ type: "hello", since: 0 });
+    await sendStatus(ws, "legacy client");
+
+    const entry = (await fetchPresence(slug, agent.token)).find((item) => item.name === agent.name);
+    expect(entry).toBeDefined();
+    expect(entry).not.toHaveProperty("client_version");
+    ws.close();
+  });
+
+  it("accepts the 64-character boundary and ignores malformed or overlong versions", async () => {
+    const agent = await seedToken("agent");
+    const slug = await createChannel(agent.token);
+    const ws = await WsClient.open(slug, agent.token);
+    await ws.nextOfType("welcome");
+    const maxVersion = `1.0.0-${"a".repeat(58)}`;
+    expect(maxVersion).toHaveLength(64);
+
+    ws.send({ type: "hello", since: 0, client_version: maxVersion });
+    await sendStatus(ws, "version boundary");
+    expect((await fetchPresence(slug, agent.token)).find((item) => item.name === agent.name)).toMatchObject({
+      client_version: maxVersion,
+    });
+
+    for (const client_version of ["", " 1.2.3", "1.2.3\n", "1/2/3", "x".repeat(65), 123]) {
+      ws.send({ type: "hello", since: 0, client_version });
+      await sendStatus(ws, `invalid ${String(client_version).slice(0, 8)}`);
+    }
+    expect((await fetchPresence(slug, agent.token)).find((item) => item.name === agent.name)).toMatchObject({
+      client_version: maxVersion,
+    });
+    ws.close();
+  });
+
+  it("broadcasts, serializes, and updates the version when the same identity reconnects", async () => {
+    const agent = await seedToken("agent");
+    const observer = await seedToken("human");
+    const slug = await createChannel(agent.token);
+    const watcher = await WsClient.open(slug, observer.token);
+    await watcher.nextOfType("welcome");
+
+    const first = await WsClient.open(slug, agent.token);
+    await first.nextOfType("welcome");
+    first.send({ type: "hello", since: 0, client_version: "0.2.89" });
+    expect(await watcher.nextOfType("presence")).toMatchObject({
+      name: agent.name,
+      client_version: "0.2.89",
+    });
+    first.close();
+    for (;;) {
+      const frame = await watcher.nextOfType("presence");
+      if (frame.name === agent.name && frame.state === "offline") break;
+    }
+
+    const second = await WsClient.open(slug, agent.token);
+    await second.nextOfType("welcome");
+    second.send({ type: "hello", since: 0, client_version: "0.2.90-beta.1" });
+    expect(await watcher.nextOfType("presence")).toMatchObject({
+      name: agent.name,
+      client_version: "0.2.90-beta.1",
+    });
+
+    const restEntry = (await fetchPresence(slug, agent.token)).find((item) => item.name === agent.name);
+    expect(restEntry).toMatchObject({ client_version: "0.2.90-beta.1" });
+
+    const reader = await WsClient.open(slug, observer.token);
+    const welcome = await reader.nextOfType("welcome");
+    expect(welcome.presence).toContainEqual(
+      expect.objectContaining({ name: agent.name, client_version: "0.2.90-beta.1" }),
+    );
+
+    reader.close();
+    second.close();
+    watcher.close();
+  });
+});


### PR DESCRIPTION
## 变更

- CLI 每次连接/重连在 hello 上报自身 package version
- shared protocol 增加可选 `client_version`，兼容旧客户端
- ChannelDO 持久化并广播有效版本；非法/超长值忽略且不覆盖最后有效值
- 只更新版本字段，不刷新 presence `updated_at`、状态或 note
- Web expanded presence 和 tooltip 显示 `cli v<version>`；旧客户端不占位，窄屏隐藏 compact 标签

## 验证

- CLI client + PresenceBar：18 pass
- worker `client-version` + `presence-liveness`：11 pass
- worker TypeScript：通过
- subagent `check:shared`、`check:cli`、`check:web` 均通过（web 338 pass）
- worker 全量在并行热重载期间为 300 pass / 4 unrelated timeout；本 PR 定向 spec 同次 3/3 通过，交由 CI clean runner 再做全量门禁

## 兼容性

- 旧 CLI 不带字段时行为不变
- 同一身份同时运行多个 CLI 版本时，presence 显示最后收到的有效 hello 版本
