### PR TITLE
fix(#196): retract 真正抹掉正文——不再残留于 original_body / audit（security P1）

### DIFF
--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -1963,20 +1963,22 @@ export class ChannelDO extends Server<Env> {
         return Response.json({ message: frame });
       }
       if (action === "retract") {
+        // #196 安全：retract 的设计场景是撤回误发的密钥，正文必须真正抹掉，不能残留在任何地方。
+        // 故审计不留 old_body（只记「谁在何时 retract 了 seq」），也不把正文搬进 original_body
+        // （否则 rowToFrame 的 revision.original_body 会把密钥重新广播 + hello 补拉回来）。
+        // edit 不同：它不是密钥撤回，仍保留 old_body / original_body 供「编辑自何处」展示。
         this.ctx.storage.sql.exec(
           `INSERT INTO message_audit (target_seq, action, actor_name, actor_kind, old_body, new_body, created_at)
-           VALUES (?, 'retract', ?, ?, ?, NULL, ?)`,
+           VALUES (?, 'retract', ?, ?, NULL, NULL, ?)`,
           seq,
           identity.name,
           identity.kind,
-          String(row.body),
           now,
         );
         this.ctx.storage.sql.exec(
           `UPDATE messages
-              SET body = '', mentions_json = '[]', original_body = COALESCE(original_body, ?), retracted_at = ?, retracted_by = ?, rev_seq = ?
+              SET body = '', mentions_json = '[]', original_body = NULL, retracted_at = ?, retracted_by = ?, rev_seq = ?
             WHERE seq = ?`,
-          originalBody,
           now,
           identity.name,
           this.nextRevSeq(),

--- a/worker/test/message-mutations.spec.ts
+++ b/worker/test/message-mutations.spec.ts
@@ -56,23 +56,35 @@ describe("message edit/retract/supersede", () => {
     });
   });
 
-  it("lets a moderator retract another sender and removes it from search", async () => {
+  it("retract scrubs the body everywhere — not readable via revision, audit, or search (#196)", async () => {
     const { slug, owner, writer } = await scopedFixture();
     const sent = await postMessage(slug, writer.token, "needle secret");
     const seq = ((await sent.json()) as { seq: number }).seq;
 
     const retracted = await api(`/api/channels/${slug}/messages/${seq}/retract`, owner.token, { method: "POST" });
     expect(retracted.status).toBe(200);
-    expect(((await retracted.json()) as { message: MsgLike }).message).toMatchObject({
-      seq,
-      body: "",
-      retracted: true,
-      revision: { original_body: "needle secret" },
-    });
+    const message = ((await retracted.json()) as { message: MsgLike }).message;
+    // 正文清空；revision.original_body 不得带回密钥——否则 retract 响应帧 / hello 补拉 / history 会重发它
+    expect(message).toMatchObject({ seq, body: "", retracted: true });
+    expect(message.revision?.original_body ?? null).toBe(null);
 
+    // search 命不中
     const search = await api(`/api/channels/${slug}/search?q=needle`, writer.token);
     expect(search.status).toBe(200);
     expect(((await search.json()) as { hits: unknown[] }).hits).toEqual([]);
+
+    // 审计端点也读不回密钥：retract 只记「谁在何时撤回了 seq」，old_body 必须为 null
+    const audit = await api(`/api/channels/${slug}/messages/${seq}/audit`, owner.token);
+    expect(audit.status).toBe(200);
+    const auditRows = ((await audit.json()) as { audit: Array<{ action: string; old_body: string | null }> }).audit;
+    const retractRow = auditRows.find((r) => r.action === "retract");
+    expect(retractRow).toBeDefined();
+    expect(retractRow!.old_body).toBe(null);
+    expect(JSON.stringify(auditRows)).not.toContain("needle secret");
+
+    // 补拉 history（模拟 hello 补拉）同样不含密钥
+    const history = await api(`/api/channels/${slug}/messages?since=0&limit=1000`, owner.token);
+    expect(JSON.stringify(await history.json())).not.toContain("needle secret");
   });
 
   it("supersedes with a new linked message", async () => {


### PR DESCRIPTION
频道身份：网页 leo（owner），下场实现 P1。

## 问题（security P1）
retract 的设计场景是撤回误发的密钥，但撤回后正文活在三处，其中一处还被主动广播：
- **original_body**：retract 前 `COALESCE(original_body, 全文)` 保留正文，`rowToFrame` 对任何非空 original_body 都带出 `revision.original_body` → retract 响应帧 / hello 补拉 / history **把密钥重新广播回所有客户端**。
- **message_audit.old_body**：retract 存 `old_body = String(row.body)` 全文，经 `/audit` 端点原样读回。

## 修复（retract 专属；edit 不变——edit 非密钥场景，仍保留 old_body/original_body 供「编辑自何处」）
- retract 审计 `old_body` 落 NULL，只记「谁在何时撤回了 seq」。
- retract 时 `original_body` 落 NULL（不再 COALESCE 保留正文）。

## 契约④（血例）
原测试 `revision: { original_body: "needle secret" }` 是**把泄漏钉死的断言**——任何想修的人先看到这条绿灯会以为自己改坏了。改写成抹净回归：断言 retract 后密钥不出现在 revision / audit(old_body=null) / history / search **任何一处**。变异方向：恢复 COALESCE / old_body=全文，测试转红。

验证：message-mutations.spec 4/4，worker tsc 干净。

注：已存在的历史 retract 数据（original_body 已残留）需单独数据清理，本 PR 只堵未来泄漏。

Closes #196.

https://claude.ai/code/session_01PgxkZeqJmDge3dYe9W2tPZ