### PR TITLE
fix(worker): 吊销扇出按 channel_presence 注册表收窄，不再唤醒全部频道 DO（#200）

### DIFF
--- a/worker/migrations/0026_channel_presence.sql
+++ b/worker/migrations/0026_channel_presence.sql
@@ -1,0 +1,13 @@
+-- 活连接注册表（#200）：DO 在 ws connect/disconnect 时写入，让吊销扇出从 O(全部频道)
+-- 收窄到「确有该 name 活连接的频道」（通常 0-1 个）。也是 #191/#107 缺的服务端可查询活连接
+-- 视图的基座——列刻意留宽（kind/owner/token_hash），供后续复用。
+CREATE TABLE IF NOT EXISTS channel_presence (
+  channel_slug TEXT NOT NULL,
+  name         TEXT NOT NULL,
+  kind         TEXT,
+  owner        TEXT,
+  token_hash   TEXT,
+  connected_at INTEGER NOT NULL,
+  PRIMARY KEY (channel_slug, name)
+);
+CREATE INDEX IF NOT EXISTS idx_channel_presence_name ON channel_presence(name);

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -1093,6 +1093,9 @@ export class ChannelDO extends Server<Env> {
       connection.close(1008, "archived");
       return;
     }
+    // #200：非归档连接落活连接注册表，且在 welcome 之前 await——保证吊销扇出看得见这条连接，
+    // 也保证测试拿到 welcome 时行已落库。归档分支已在上面 close，不写。
+    await this.d1PresenceUpsert(state);
     const loopGuard = state.kind === "agent" ? this.loopGuardMessage(state.name) : this.globalLoopGuardMessage();
     this.sendFrame(connection, {
       type: "welcome",
@@ -1240,15 +1243,18 @@ export class ChannelDO extends Server<Env> {
     }
   }
 
-  onClose(connection: Connection<ConnState>) {
+  async onClose(connection: Connection<ConnState>) {
     const st = connection.state;
     if (!st || !st.name || st.archived) return;
     for (const other of this.getConnections<ConnState>()) {
       if (other.id !== connection.id && other.state?.name === st.name) {
+        // 该 name 在本 DO 还有其它活连接：名仍在线，不删注册表行。
         this.broadcastFrame({ type: "participants", participants: this.participants() });
         return;
       }
     }
+    // 走到这里 = 本 DO 该 name 的最后一条连接正在关闭 → 尽力删掉活连接注册表行（#200）。
+    await this.d1PresenceDelete(st.name);
     const removedAt = Number(this.getMeta(this.removedPresenceKey(st.name)) ?? "");
     if (Number.isInteger(removedAt) && Date.now() - removedAt < PRESENCE_SCAN_MS) {
       this.ctx.storage.sql.exec("DELETE FROM presence WHERE name = ?", st.name);
@@ -1263,6 +1269,9 @@ export class ChannelDO extends Server<Env> {
   async onAlarm() {
     const now = Date.now();
     const live = this.scanPresence(now);
+    // #200：60s presence 扫描顺带把本频道注册表与当前连接对齐——DO 醒着、ws 已恢复，
+    // reconcile 安全，被吊销驱逐/删失败留下的残留行由此有界清理。
+    await this.d1PresenceReconcile();
     await this.retryWebhooks(now);
     await this.checkTempArchive(now);
     await this.scheduleNextAlarm(now, live);
@@ -1411,6 +1420,65 @@ export class ChannelDO extends Server<Env> {
     const frame: PresenceFrame = { type: "presence", name, state: "offline", note: null, ts };
     const entry = this.presenceFor(name);
     this.broadcastFrame(entry ? { type: "presence", ...entry } : frame);
+  }
+
+  // #200 活连接注册表（D1 表 channel_presence）：让吊销扇出从 O(全部频道) 收窄到
+  // 「确有该 name 活连接的频道」。写入(connect)可靠且在 welcome 之前 await——漏一行 =
+  // 被吊销 token 踢不掉 = 安全漏洞（假阴性）；删除(close)尽力而为，残留由 onAlarm reconcile
+  // 有界清理（假阳性 = 冷启动 no-op，无害）。D1 抖动不能炸生命周期，故整体 try/catch 吞错。
+  private async d1PresenceUpsert(state: ConnState) {
+    if (!state.name) return;
+    try {
+      await this.env.DB.prepare(
+        `INSERT OR REPLACE INTO channel_presence
+           (channel_slug, name, kind, owner, token_hash, connected_at)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+      )
+        .bind(this.name, state.name, state.kind, state.owner ?? null, state.tokenHash ?? null, Date.now())
+        .run();
+    } catch {
+      // D1 抖动：宁可残留旧行也不炸 onConnect；下一次 connect/reconcile 会纠正
+    }
+  }
+
+  private async d1PresenceDelete(name: string) {
+    if (!name) return;
+    try {
+      await this.env.DB.prepare("DELETE FROM channel_presence WHERE channel_slug = ? AND name = ?")
+        .bind(this.name, name)
+        .run();
+    } catch {
+      // 删失败 = 残留行（假阳性），onAlarm reconcile 兜底
+    }
+  }
+
+  // 把本频道注册表与当前 getConnections() 对齐：给每个存活 name upsert，删掉不再在线的残留行。
+  // 只在连接确定已恢复时调用（onAlarm，DO 醒着且 ws 已恢复），否则会误删活连接行造成假阴性。
+  private async d1PresenceReconcile() {
+    try {
+      const live = new Set<string>();
+      for (const connection of this.getConnections<ConnState>()) {
+        const st = connection.state;
+        if (!st || !st.name || st.archived) continue;
+        if (!live.has(st.name)) await this.d1PresenceUpsert(st);
+        live.add(st.name);
+      }
+      const names = [...live];
+      if (names.length === 0) {
+        await this.env.DB.prepare("DELETE FROM channel_presence WHERE channel_slug = ?")
+          .bind(this.name)
+          .run();
+      } else {
+        const placeholders = names.map(() => "?").join(", ");
+        await this.env.DB.prepare(
+          `DELETE FROM channel_presence WHERE channel_slug = ? AND name NOT IN (${placeholders})`,
+        )
+          .bind(this.name, ...names)
+          .run();
+      }
+    } catch {
+      // reconcile 是补偿性清理，抖动就下个 alarm 再来
+    }
   }
 
   private recordClientVersion(name: string, clientVersion: string, ts: number) {

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -2460,8 +2460,12 @@ app.delete("/api/tokens/:name", requireAdmin, async (c) => {
     resource: `token/${name}`,
     channel: revoked.channel_scope,
   });
-  // 吊销即时生效：踢掉所有未归档频道里该 name 的存活 ws（spec §12）
-  const { results } = await c.env.DB.prepare("SELECT slug FROM channels").all<{ slug: string }>();
+  // 吊销即时生效：踢掉该 name 的存活 ws（spec §12）。
+  // #200：只踢确有该 name 活连接的频道（注册表由 DO 维护），不再唤醒全部频道 DO。
+  const { results } = await c.env.DB
+    .prepare("SELECT DISTINCT channel_slug AS slug FROM channel_presence WHERE name = ?")
+    .bind(name)
+    .all<{ slug: string }>();
   await Promise.all(
     results.map(async ({ slug }) => {
       try {

--- a/worker/test/revocation-fanout.spec.ts
+++ b/worker/test/revocation-fanout.spec.ts
@@ -1,0 +1,134 @@
+// #200：吊销扇出按 channel_presence 活连接注册表收窄。
+//
+// 背景：DELETE /api/tokens/:name 原来 `SELECT slug FROM channels`（无过滤）唤醒每一个
+// 频道 DO 去踢线——O(全部频道)，149 频道时扇出 8.3s，是 #185 flaky 的主因。
+// 修法：DO 在 ws connect/disconnect 维护 D1 表 channel_presence；DELETE 只对注册表里
+// 确有该 name 活连接的频道发 /internal/kick（通常 0-1 个）。
+//
+// 正确性红线：假阴性（漏一个活连接 → 被吊销 token 继续在线）= 安全漏洞，必须避免；
+// 假阳性（残留过期行 → 多踢一个无匹配连接的频道）= 冷启动 no-op，无害。
+import { describe, expect, it } from "vitest";
+import { ADMIN_HEADERS, createChannel, postMessage, seedToken, uniq, WsClient } from "./helpers";
+import { SELF, env } from "cloudflare:test";
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+async function presenceChannels(name: string): Promise<string[]> {
+  const { results } = await env.DB.prepare(
+    "SELECT channel_slug FROM channel_presence WHERE name = ? ORDER BY channel_slug",
+  )
+    .bind(name)
+    .all<{ channel_slug: string }>();
+  return results.map((r) => r.channel_slug);
+}
+
+function revoke(name: string): Promise<Response> {
+  return SELF.fetch(`http://ap.test/api/tokens/${name}`, { method: "DELETE", headers: ADMIN_HEADERS });
+}
+
+describe("revocation fanout narrowed by channel_presence (#200)", () => {
+  // 测试1：onConnect 在 welcome 之前 await 写入注册表行。victim 只连 A（另建 B 不连），
+  // 注册表必须只出现 A，不含 B。变异（注释掉 onConnect 的 upsert）→ 此断言红。
+  it("records a live-connection row for the channel the victim actually joined, not others", async () => {
+    const victim = await seedToken("agent", uniq("victim"));
+    const host = await seedToken("human", uniq("host"));
+    const chanA = await createChannel(host.token);
+    const chanB = await createChannel(host.token); // 建了但 victim 不连
+
+    const ws = await WsClient.open(chanA, victim.token);
+    await ws.nextOfType("welcome"); // welcome 到达时行已落库（upsert 在 welcome 之前 await）
+
+    expect(await presenceChannels(victim.name)).toEqual([chanA]);
+    expect(await presenceChannels(victim.name)).not.toContain(chanB);
+    ws.close();
+  }, 30_000);
+
+  // 测试2：onClose 走到 markOffline 分支（该 name 在本 DO 最后一条连接）时 await 删行。
+  // 断开后轮询直到行消失。变异（注释掉 onClose 的 delete）→ 行永不消失 → 超时红。
+  it("removes the registry row after the victim's last connection closes", async () => {
+    const victim = await seedToken("agent", uniq("victim"));
+    const host = await seedToken("human", uniq("host"));
+    const chanA = await createChannel(host.token);
+
+    const ws = await WsClient.open(chanA, victim.token);
+    await ws.nextOfType("welcome");
+    expect(await presenceChannels(victim.name)).toEqual([chanA]);
+
+    ws.close();
+    // onClose 是异步删；给它落库时间，最多轮询 ~2s。
+    let rows = await presenceChannels(victim.name);
+    for (let i = 0; i < 40 && rows.length > 0; i++) {
+      await sleep(50);
+      rows = await presenceChannels(victim.name);
+    }
+    expect(rows).toEqual([]);
+  }, 30_000);
+
+  // 测试3：安全不回归——收窄后仍踢得掉被吊销 token 的活连接。照抄 broadcast-order.spec.ts:75 的模式。
+  it("still kicks a revoked token's live ws after narrowing (no false negative)", async () => {
+    const victim = await seedToken("agent", uniq("victim"));
+    const other = await seedToken("human", uniq("other"));
+    const chanA = await createChannel(other.token);
+
+    const ws = await WsClient.open(chanA, victim.token);
+    await ws.nextOfType("welcome");
+
+    const del = await revoke(victim.name);
+    expect(del.status).toBe(200);
+
+    // 任一条消息都会触发连接扫描；被吊销的连接必须收到 unauthorized（DELETE 扇出本身也会踢）。
+    expect((await postMessage(chanA, other.token, "trigger the scan")).status).toBe(200);
+    const err = (await ws.nextOfType("error")) as { code: string };
+    expect(err.code).toBe("unauthorized");
+    ws.close();
+  }, 30_000);
+
+  // 测试4：收窄语义（间接）——victim 在 A 有活连接、B 无。吊销时注册表只解析出 A，
+  // 证明扇出面 = 1（不再是 O(全部频道)）。B 的 DO 是否被冷启动无直接 API 可测——
+  // 只能靠注册表行数间接保证扇出集合 = {A}。
+  it("resolves the revocation fanout set to exactly the channels holding a live row", async () => {
+    const victim = await seedToken("agent", uniq("victim"));
+    const host = await seedToken("human", uniq("host"));
+    const chanA = await createChannel(host.token);
+    await createChannel(host.token); // B：在 channels 表里，但 victim 无活连接 → 不该进扇出集
+
+    const ws = await WsClient.open(chanA, victim.token);
+    await ws.nextOfType("welcome");
+
+    // 吊销前：注册表对 victim 只有 A 一行 → 扇出面 = {A}，而不是全部频道。
+    expect(await presenceChannels(victim.name)).toEqual([chanA]);
+
+    const del = await revoke(victim.name);
+    expect(del.status).toBe(200);
+    const err = (await ws.nextOfType("error")) as { code: string };
+    expect(err.code).toBe("unauthorized");
+    ws.close();
+  }, 30_000);
+
+  // 测试5：收窄的「源」是注册表而非 channels 全表——这条精确咬住 DELETE 的查询。
+  // 构造：victim 连 A，但手动清掉它的注册表行（模拟「扇出源 = 注册表」下无匹配行）。
+  // 收窄查询（正确）→ 扇出集为空 → 不发 kick → victim 不被吊销扇出踢（窗口内无 error 帧）。
+  // 变异（DELETE 改回 `SELECT slug FROM channels`）→ A 在 channels 表 → 踢 A → victim 收到
+  // unauthorized → 本条红。这也从反面说明：onConnect 的 upsert 必须可靠 await（否则真实
+  // 场景下漏行 = 活连接踢不掉 = 安全漏洞）。
+  it("drives the fanout from channel_presence, not the full channels table", async () => {
+    const victim = await seedToken("agent", uniq("victim"));
+    const host = await seedToken("human", uniq("host"));
+    const chanA = await createChannel(host.token);
+
+    const ws = await WsClient.open(chanA, victim.token);
+    await ws.nextOfType("welcome");
+    expect(await presenceChannels(victim.name)).toEqual([chanA]);
+
+    // 手动清掉注册表行——扇出源里再无该 name 的活连接。
+    await env.DB.prepare("DELETE FROM channel_presence WHERE name = ?").bind(victim.name).run();
+
+    const del = await revoke(victim.name);
+    expect(del.status).toBe(200);
+
+    // 收窄查询扇出集为空 → 不发 kick → 窗口内 victim 收不到 error 帧（无其它扫描触发）。
+    // 用 nextOfType 跳过 connect 时的 participants 广播，只等 error——超时即证明没被踢。
+    await expect(ws.nextOfType("error", 600)).rejects.toThrow(/timeout/);
+    ws.close();
+  }, 30_000);
+});


### PR DESCRIPTION
## 修什么（#200，P1）

`DELETE /api/tokens/:name` 原本 `SELECT slug FROM channels`（无过滤）唤醒**每一个**频道 DO 去踢线——O(全部频道)，149 频道时光扇出 8.3s，是 #185 CI flaky 的主因。根因：Worker 看不见「谁在哪个频道有活连接」。

## 怎么修

新增 D1 可查活连接注册表 `channel_presence`（迁移 `0026`），由 `ChannelDO` 维护：
- `onConnect`：非归档连接在 **welcome 之前 await** `d1PresenceUpsert`（`INSERT OR REPLACE`，bound param）。
- `onClose`（改 async）：本 DO 该 name **最后一条**连接关闭时 `d1PresenceDelete`（覆盖 kick-remove 与正常 offline 两条终结路径）。
- `onAlarm`：60s presence 扫描后 `d1PresenceReconcile`，把本频道注册表与当前 `getConnections()` 对齐，清理残留行（有界）。
- `onStart` **不删行**（可能早于 ws 恢复，删了会开假阴性窗口）。

`DELETE` 改为 `SELECT DISTINCT channel_slug FROM channel_presence WHERE name = ?`——只对确有活连接的频道（通常 0–1 个）发 `/internal/kick`。

## 正确性 / 安全权衡（评审重点）

- **假阳性无害**：残留行 → 多踢一个无匹配连接的频道 → 冷启动 no-op。
- **假阴性 = 安全漏洞**（漏一行 → 被吊销 token 踢不掉）。因此 upsert 在 welcome 前 await。
- **残留的小窗口**：若 onConnect 的 upsert 因 D1 抖动失败、且下次 reconcile（≤60s）前发生吊销，该连接不会被**即时**踢。但既有的**逐消息 activity 扫描**（do.ts:3058，被吊销 token 的 send/收帧触发 `closeRevokedConnection`）是兜底——该连接顶多空握 socket、无法动作，下次交互即被关。相对旧「踢全部频道」是新增的一个低危窗口，请安全侧确认可接受。

## 门禁
- 新 spec `revocation-fanout.spec.ts`：5/5（TDD，先红后绿）。
- worker `tsc --noEmit` = 0；`scripts` tsc = 0；迁移守卫 = 0（0026，四位，无新重号）。
- 全量 vitest：单 workerd 满载下偶发 1 条**无关**测试超时（#43/#48 已知 flaky，隔离单跑全过；CI retry:1 掩盖）。我的 spec 与 #185 revocation 两轮全绿。
- 变异：注释 onConnect upsert→测1红；注释 onClose delete→测2红；DELETE 查询改回全表→测5红；均还原后复绿。

## 顺带
`channel_presence` 是 **#191/#107** 缺的服务端可查询活连接视图的基座，列刻意留宽（kind/owner/token_hash），schema 落 #191/#107 时可评审微调。

🤖 实现经审阅后提交；走 PR 由 @leeguooooo / LEO-MAIN 做 security 终审，未自合。
