### PR TITLE
fix(#200): token 撤销只踢可达频道，不再唤醒全部署每个 DO（worker P1）

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -2447,10 +2447,10 @@ app.delete("/api/tokens/:name", requireAdmin, async (c) => {
     `UPDATE tokens
         SET revoked_at = ?
       WHERE name = ? AND revoked_at IS NULL
-      RETURNING channel_scope`,
+      RETURNING channel_scope, owner`,
   )
     .bind(Date.now(), name)
-    .first<{ channel_scope: string | null }>();
+    .first<{ channel_scope: string | null; owner: string | null }>();
   if (revoked === null) {
     return c.json(errorBody("not_found", "no active token with that name"), 404);
   }
@@ -2460,8 +2460,25 @@ app.delete("/api/tokens/:name", requireAdmin, async (c) => {
     resource: `token/${name}`,
     channel: revoked.channel_scope,
   });
-  // 吊销即时生效：踢掉所有未归档频道里该 name 的存活 ws（spec §12）
-  const { results } = await c.env.DB.prepare("SELECT slug FROM channels").all<{ slug: string }>();
+  // 吊销即时生效：踢掉该 name 的存活 ws（spec §12）。#200：只踢该 token **可能持连接**的频道，
+  // 而不是唤醒整个部署的每一个 DO（O(全部频道)、冷启动、149 频道时光扇出 8.3s、还是 #185 CI flaky 主因）。
+  // 收窄按 token 类型（严格是「该 token 能访问的频道」的超集，即实际连接的超集，绝不漏踢）：
+  //   - channel_scope 有值：scoped/guest token 只在那一个频道有效（acl.ts canAccessChannel）→ 只踢它。
+  //   - 账号级 token：覆盖 canAccessChannel/canAccessLoadedChannel 的全部访问路径：
+  //       public（对任何 token 开放，不能只看 channel_members）∪ 自己创建的（created_by=name，
+  //       兜住 owner 为空的 token）∪ 账号房主（owner_account=account）∪ 成员（channel_members）
+  //       ∪ 被邀请的 project-agent（channel_agent_invites，按 name=profile_handle）。
+  const scopedSlugs = revoked.channel_scope
+    ? await c.env.DB.prepare("SELECT slug FROM channels WHERE slug = ?").bind(revoked.channel_scope).all<{ slug: string }>()
+    : await c.env.DB.prepare(
+        `SELECT slug FROM channels
+          WHERE visibility = 'public'
+             OR created_by = ?2
+             OR (?1 IS NOT NULL AND owner_account = ?1)
+             OR (?1 IS NOT NULL AND slug IN (SELECT channel_slug FROM channel_members WHERE account = ?1))
+             OR slug IN (SELECT channel_slug FROM channel_agent_invites WHERE profile_handle = ?2 AND revoked_at IS NULL)`,
+      ).bind(revoked.owner, name).all<{ slug: string }>();
+  const { results } = scopedSlugs;
   await Promise.all(
     results.map(async ({ slug }) => {
       try {

--- a/worker/test/lifecycle.spec.ts
+++ b/worker/test/lifecycle.spec.ts
@@ -1,7 +1,7 @@
 import { SELF, env, runInDurableObject } from "cloudflare:test";
 import { describe, expect, it } from "vitest";
 import type { ChannelDO } from "../src/do";
-import { ADMIN_HEADERS, api, createChannel, postMessage, seedToken, WsClient } from "./helpers";
+import { ADMIN_HEADERS, api, createChannel, postMessage, seedToken, uniq, WsClient } from "./helpers";
 
 async function errorCode(res: Response): Promise<string> {
   const body = (await res.json()) as { error: { code: string } };
@@ -125,6 +125,33 @@ describe("channel lifecycle endpoints", () => {
       .run();
 
     const revoked = await SELF.fetch(`http://ap.test/api/tokens/${name}`, {
+      method: "DELETE",
+      headers: ADMIN_HEADERS,
+    });
+    expect(revoked.status).toBe(200);
+    const err = await ws.nextOfType("error");
+    expect(err.code).toBe("unauthorized");
+    ws.close();
+  });
+
+  it("revocation still kicks a socket in a public channel the token neither owns nor is a member of (#200)", async () => {
+    // #200 收窄的安全关键路径：public 频道对任何 token 开放（acl.ts），一个既非房主也非成员的
+    // token 也能连进来。收窄若只看 owner_account/channel_members 会漏踢它 → 撤销的 token 还连着。
+    const ownerTok = await seedToken("agent", uniq("pubowner"), { owner: "pubowner@x.com" });
+    const slug = uniq("pubch");
+    const created = await SELF.fetch("http://ap.test/api/channels", {
+      method: "POST",
+      headers: { authorization: `Bearer ${ownerTok.token}`, "content-type": "application/json" },
+      body: JSON.stringify({ slug, kind: "standing", visibility: "public" }),
+    });
+    expect(created.status).toBe(201);
+
+    // 另一个账号的 token，不是房主、不是成员，靠 public 连进来
+    const intruder = await seedToken("agent", uniq("intruder"), { owner: "intruder@x.com" });
+    const ws = await WsClient.open(slug, intruder.token);
+    await ws.nextOfType("welcome");
+
+    const revoked = await SELF.fetch(`http://ap.test/api/tokens/${intruder.name}`, {
       method: "DELETE",
       headers: ADMIN_HEADERS,
     });


### PR DESCRIPTION
频道身份：网页 leo（owner），下场实现 P1。

## 问题（worker P1）
`DELETE /api/tokens/:name` 原来 `SELECT slug FROM channels`（无过滤）**唤醒整个部署的每一个频道 DO** 并 `await`——每个都冷启动跑 schema init。量化：149 频道时光扇出 **8.3s、超线性**；也是 **#185 CI flaky 的主因**（5 次失败 4 次走这条 revoke→kick 路）。

## 修复：收窄到「该 token 能访问的频道」（严格是实际连接的超集，绝不漏踢）
- **channel_scope 有值**：scoped/guest token 只在那一个频道有效 → 只踢它（最常见的跨公司 guest 撤销从 O(全部) 降到 O(1)）。
- **账号级 token**：覆盖 `acl.ts` canAccessChannel/canAccessLoadedChannel 的全部访问路径——`public`（对任何 token 开放，不能只看成员）∪ `created_by=name`（兜住 owner 为空的 token）∪ `owner_account=account` ∪ `channel_members` ∪ `channel_agent_invites`。

## 安全（血例）
public 频道对任何 token 开放，收窄若只看 owner/member 会**漏踢 → 撤销的 token 还连着**。这是收窄的安全关键路径。新增回归：一个**既非房主也非成员**的 token 靠 public 连入，撤销**仍被踢线**。变异方向：从收窄里去掉 `visibility='public'` 分支，该测试转红。已保留「归档频道也踢」（不加 archived 过滤，原 `revocation kicks live sockets even when archived` 测试仍绿）。

验证：lifecycle/tokens/channel-role-account-binding/acl 62/62，worker tsc 干净。CI 全量校验。

Closes #200. 附带缓解 #185（分片 + 扇出收窄双管）。

https://claude.ai/code/session_01PgxkZeqJmDge3dYe9W2tPZ