### PR TITLE
fix(worker): workflow guard 进展判定不再被状态交替愚弄（#106）

### DIFF
--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -130,6 +130,10 @@ const STATUS_WORKFLOW_JSON_LIMIT = 4096;
 const MAX_COMPLETION_RELATED = 20;
 const COMPLETION_ARTIFACT_JSON_LIMIT = 4096;
 const REVIEW_REASON_LIMIT = 4000;
+// #106：workflow guard 近期 (step,state) 窗口大小。8 足以罩住多 agent 在若干状态间的环形 ping-pong
+// （长度 ≤8 的循环里，重访的 tuple 仍在窗口内 → 被判非进展 → 计数累加直到 trip）；又足够小，
+// 让真正线性推进的工作流（每帧都是新 step）永远命中「窗口内没见过」→ 判进展 → 永不误伤。
+const WORKFLOW_GUARD_WINDOW = 8;
 
 function byteLength(s: string): number {
   return new TextEncoder().encode(s).byteLength;
@@ -411,6 +415,22 @@ function statusWorkflowFromSend(input: SendStatusWorkflow | undefined): StatusWo
     step_id: input.step_id ?? null,
     parent_summary_seq: input.parent_summary_seq ?? null,
   };
+}
+
+// #106：workflow guard 近期窗口的 tuple 键。step_id / state 均不含 \u0000，用它当分隔符杜绝歧义拼接。
+function workflowTupleKey(stepId: string | null, state: StatusState | null): string {
+  return `${stepId ?? ""}\u0000${state ?? ""}`;
+}
+
+// 存量行 recent_tuples 为 NULL / 脏数据时安全退回 []（等价于「窗口里什么都没见过」）。
+function parseWorkflowGuardTuples(input: unknown): string[] {
+  if (typeof input !== "string" || input === "") return [];
+  try {
+    const parsed = JSON.parse(input) as unknown;
+    return Array.isArray(parsed) ? parsed.filter((v): v is string => typeof v === "string").slice(-WORKFLOW_GUARD_WINDOW) : [];
+  } catch {
+    return [];
+  }
 }
 
 function parseStoredStatusWorkflow(input: unknown): StatusWorkflow | undefined {
@@ -751,6 +771,9 @@ interface WorkflowGuardRow {
   state: StatusState | null;
   count_since_progress: number;
   no_progress: number;
+  // #106：本 run 内近期见过的 (step_id,state) tuple 环形窗口（最多 WORKFLOW_GUARD_WINDOW 个）。
+  // 进展判定不再只比对紧邻上一帧——回到窗口里见过的 tuple = 非进展（振荡），只有从未见过的新 tuple 才算进展。
+  recent_tuples: string[];
   blocked_seq: number | null;
   last_progress_seq: number | null;
   last_counted_seq: number | null;
@@ -1040,6 +1063,7 @@ export class ChannelDO extends Server<Env> {
       state TEXT,
       count_since_progress INTEGER NOT NULL DEFAULT 0,
       no_progress INTEGER NOT NULL DEFAULT 0,
+      recent_tuples TEXT,
       blocked_seq INTEGER,
       last_progress_seq INTEGER,
       last_counted_seq INTEGER,
@@ -1050,6 +1074,13 @@ export class ChannelDO extends Server<Env> {
       terminal_seq INTEGER,
       updated_at INTEGER NOT NULL
     )`);
+    // #106：给早于本次的 DO 表补 recent_tuples 列（DO 内建 SQLite，非 D1，无需 worker/migrations 迁移文件）。
+    // 与 messages 表补列同手法：幂等 ALTER，列已存在则吞掉；缺列的存量行 recent_tuples 为 NULL → 解析成 []。
+    try {
+      sql.exec("ALTER TABLE workflow_guard_state ADD COLUMN recent_tuples TEXT");
+    } catch {
+      // 列已存在
+    }
     sql.exec("CREATE INDEX IF NOT EXISTS workflow_guard_state_updated_idx ON workflow_guard_state(updated_at)");
     sql.exec(
       "CREATE INDEX IF NOT EXISTS workflow_guard_state_no_progress_idx ON workflow_guard_state(no_progress, updated_at)",
@@ -2845,6 +2876,7 @@ export class ChannelDO extends Server<Env> {
       state: r.state === null || r.state === undefined ? null : (String(r.state) as StatusState),
       count_since_progress: Number(r.count_since_progress),
       no_progress: Number(r.no_progress),
+      recent_tuples: parseWorkflowGuardTuples(r.recent_tuples),
       blocked_seq: r.blocked_seq === null || r.blocked_seq === undefined ? null : Number(r.blocked_seq),
       last_progress_seq: r.last_progress_seq === null || r.last_progress_seq === undefined ? null : Number(r.last_progress_seq),
       last_counted_seq: r.last_counted_seq === null || r.last_counted_seq === undefined ? null : Number(r.last_counted_seq),
@@ -2856,13 +2888,26 @@ export class ChannelDO extends Server<Env> {
     };
   }
 
+  // #106：进展 = 一个在本 run 近期窗口里从未见过的 (step_id,state) tuple。
+  // 旧实现只比对紧邻上一行，任何翻转都算进展——双 agent 在 A/B 之间来回，每帧都「≠上一帧」→ 永远进展 →
+  // 计数永不累加 → guard 永不 trip。现在用窗口判定：回到窗口里见过的 tuple = 非进展（振荡），计数继续爬；
+  // run_id 变化 = 新 run = 全新进展且窗口重置。真正线性推进（每帧都是新 step）永远命中「窗口内没见过」→ 判进展。
   private workflowProgressed(workflow: StatusWorkflow, state: StatusState, row: WorkflowGuardRow | null): boolean {
-    return (
-      row === null ||
-      row.run_id !== workflow.run_id ||
-      row.step_id !== workflow.step_id ||
-      row.state !== state
-    );
+    if (row === null) return true;
+    if (row.run_id !== workflow.run_id) return true;
+    return !row.recent_tuples.includes(workflowTupleKey(workflow.step_id, state));
+  }
+
+  // 计算本次落库要写回的近期窗口：run 内沿用旧窗口并追加当前 tuple（换 run 则清空重开），环形截断到窗口大小。
+  // tuple 为 null（message 帧无 step/state 转移）时不追加，只保留 run 内旧窗口。
+  private nextWorkflowGuardWindow(
+    row: WorkflowGuardRow | null,
+    workflow: StatusWorkflow,
+    tuple: string | null,
+  ): string[] {
+    const base = row !== null && row.run_id === workflow.run_id ? row.recent_tuples : [];
+    const next = tuple === null ? base : [...base, tuple];
+    return next.slice(-WORKFLOW_GUARD_WINDOW);
   }
 
   private workflowFromReply(replyTo: number | null): StatusWorkflow | undefined {
@@ -2928,12 +2973,15 @@ export class ChannelDO extends Server<Env> {
     const row = this.workflowGuardRow(decision.workflow.workflow_id);
     const hostName = this.activeHostName() ?? row?.host_name ?? null;
     if (msg.kind === "status" && msg.state === "done") {
-      this.upsertWorkflowGuardProgress(decision.workflow, msg.state, msg.seq, identity.name, hostName, now, true);
+      const window = this.nextWorkflowGuardWindow(row, decision.workflow, workflowTupleKey(decision.workflow.step_id, msg.state));
+      this.upsertWorkflowGuardProgress(decision.workflow, msg.state, msg.seq, identity.name, hostName, now, true, window);
       this.pruneWorkflowGuardState();
       return undefined;
     }
     if (msg.kind === "status" && decision.progressed) {
-      this.upsertWorkflowGuardProgress(decision.workflow, msg.state ?? "working", msg.seq, identity.name, hostName, now, false);
+      const state = msg.state ?? "working";
+      const window = this.nextWorkflowGuardWindow(row, decision.workflow, workflowTupleKey(decision.workflow.step_id, state));
+      this.upsertWorkflowGuardProgress(decision.workflow, state, msg.seq, identity.name, hostName, now, false, window);
       this.pruneWorkflowGuardState();
       return undefined;
     }
@@ -2942,13 +2990,17 @@ export class ChannelDO extends Server<Env> {
     const shouldTrip = (row?.no_progress ?? 0) === 0 && nextCount >= this.workflowGuardLimit();
     const blockedSeq = shouldTrip ? msg.seq : row?.blocked_seq ?? null;
     const trackedState = msg.kind === "status" ? msg.state : row?.state ?? null;
+    // #106：只有 status 帧承载 (step,state) 转移；message 帧（reply/presence 关联的工作流）没有 tuple，
+    // 传 null → 窗口原样保留，不污染振荡判定。非进展的重访 tuple 照样进窗口，让后续判定持续认得它。
+    const countedTuple = msg.kind === "status" ? workflowTupleKey(decision.workflow.step_id, msg.state) : null;
+    const nextWindow = this.nextWorkflowGuardWindow(row, decision.workflow, countedTuple);
     this.ctx.storage.sql.exec(
       `INSERT INTO workflow_guard_state (
-         workflow_id, kind, run_id, step_id, state, count_since_progress, no_progress,
+         workflow_id, kind, run_id, step_id, state, count_since_progress, no_progress, recent_tuples,
          blocked_seq, last_progress_seq, last_counted_seq, initiator_name, host_name,
          terminal, terminal_seq, updated_at
        )
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, NULL, ?)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, NULL, ?)
        ON CONFLICT(workflow_id) DO UPDATE SET
          kind = excluded.kind,
          run_id = excluded.run_id,
@@ -2956,6 +3008,7 @@ export class ChannelDO extends Server<Env> {
          state = excluded.state,
          count_since_progress = excluded.count_since_progress,
          no_progress = excluded.no_progress,
+         recent_tuples = excluded.recent_tuples,
          blocked_seq = COALESCE(workflow_guard_state.blocked_seq, excluded.blocked_seq),
          last_counted_seq = excluded.last_counted_seq,
          initiator_name = COALESCE(workflow_guard_state.initiator_name, excluded.initiator_name),
@@ -2970,6 +3023,7 @@ export class ChannelDO extends Server<Env> {
       trackedState,
       nextCount,
       shouldTrip ? 1 : row?.no_progress ?? 0,
+      JSON.stringify(nextWindow),
       blockedSeq,
       row?.last_progress_seq ?? null,
       msg.seq,
@@ -3001,14 +3055,15 @@ export class ChannelDO extends Server<Env> {
     hostName: string | null,
     now: number,
     terminal: boolean,
+    recentTuples: string[],
   ) {
     this.ctx.storage.sql.exec(
       `INSERT INTO workflow_guard_state (
-         workflow_id, kind, run_id, step_id, state, count_since_progress, no_progress,
+         workflow_id, kind, run_id, step_id, state, count_since_progress, no_progress, recent_tuples,
          blocked_seq, last_progress_seq, last_counted_seq, initiator_name, host_name,
          terminal, terminal_seq, updated_at
        )
-       VALUES (?, ?, ?, ?, ?, 0, 0, NULL, ?, NULL, ?, ?, ?, ?, ?)
+       VALUES (?, ?, ?, ?, ?, 0, 0, ?, NULL, ?, NULL, ?, ?, ?, ?, ?)
        ON CONFLICT(workflow_id) DO UPDATE SET
          kind = excluded.kind,
          run_id = excluded.run_id,
@@ -3016,6 +3071,7 @@ export class ChannelDO extends Server<Env> {
          state = excluded.state,
          count_since_progress = 0,
          no_progress = 0,
+         recent_tuples = excluded.recent_tuples,
          blocked_seq = NULL,
          last_progress_seq = excluded.last_progress_seq,
          initiator_name = COALESCE(workflow_guard_state.initiator_name, excluded.initiator_name),
@@ -3028,6 +3084,7 @@ export class ChannelDO extends Server<Env> {
       workflow.run_id,
       workflow.step_id,
       state,
+      JSON.stringify(recentTuples),
       seq,
       initiatorName,
       hostName,

--- a/worker/test/workflow-guard-progress.spec.ts
+++ b/worker/test/workflow-guard-progress.spec.ts
@@ -1,0 +1,126 @@
+// #106：workflow guard 的「进展」判定不能被状态交替愚弄。
+// 旧盲区：workflowProgressed 只比对「紧邻上一行」——两个 agent 各在不同 (step,state) 之间
+// 来回上报，每一帧都「不同于上一帧」→ 永远判为进展 → no-progress 计数永远归零 → guard 永不 trip，
+// 双 agent A↔B ping-pong 可以无人值守地跑到天亮。修复后用「近期 (step,state) 窗口」判定：
+// 回到窗口里见过的 tuple = 非进展，计数继续累加，最终 trip。
+import { describe, expect, it } from "vitest";
+import { api, createChannel, seedToken, uniq } from "./helpers";
+
+const workflow = (step_id: string, state = "working", workflow_id = "wf-loop", run_id = "run-1") => ({
+  workflow_id,
+  kind: "pipeline" as const,
+  run_id,
+  step_id,
+  state,
+});
+
+function postStatus(
+  slug: string,
+  token: string,
+  body: {
+    state: "working" | "waiting" | "blocked" | "done";
+    note: string;
+    workflow: ReturnType<typeof workflow>;
+  },
+) {
+  const { state: _wfState, ...wf } = body.workflow;
+  return api(`/api/channels/${slug}/messages`, token, {
+    method: "POST",
+    body: JSON.stringify({
+      kind: "status",
+      state: body.state,
+      note: body.note,
+      mentions: [],
+      workflow: wf,
+    }),
+  });
+}
+
+async function configureWorkflowGuard(slug: string, token: string, limit: number, enabled = true) {
+  return api(`/api/channels/${slug}/workflow-guard`, token, {
+    method: "PUT",
+    body: JSON.stringify({ enabled, limit }),
+  });
+}
+
+describe("workflow guard progress detection resists state oscillation (#106)", () => {
+  it("two agents alternating between two (step,state) tuples on one run eventually trip the guard", async () => {
+    const owner = `${uniq("acct")}@leeguoo.com`;
+    const agentA = await seedToken("agent", uniq("wf-a"), { owner });
+    const agentB = await seedToken("agent", uniq("wf-b"), { owner });
+    const slug = await createChannel(agentA.token);
+
+    expect((await configureWorkflowGuard(slug, agentA.token, 2)).status).toBe(200);
+
+    // 播种两个 tuple：第一次见到 step-a 与 step-b 都是真进展 → 计数保持 0。
+    expect(
+      (await postStatus(slug, agentA.token, { state: "working", note: "A step-a", workflow: workflow("step-a") })).status,
+    ).toBe(200);
+    expect(
+      (await postStatus(slug, agentB.token, { state: "working", note: "B step-b", workflow: workflow("step-b") })).status,
+    ).toBe(200);
+
+    // 之后就是纯振荡：两 agent 在同一 run 的 step-a / step-b 之间来回，没有任何新状态。
+    // 旧代码把每一次翻转都当进展 → 永不 trip；新代码把「回到窗口里见过的 tuple」判为非进展 → 计数累加。
+    const oscillation = [
+      await postStatus(slug, agentA.token, { state: "working", note: "A step-a again", workflow: workflow("step-a") }),
+      await postStatus(slug, agentB.token, { state: "working", note: "B step-b again", workflow: workflow("step-b") }),
+      await postStatus(slug, agentA.token, { state: "working", note: "A step-a yet again", workflow: workflow("step-a") }),
+    ];
+
+    // 前两次振荡累加计数（limit=2），第三次因 no_progress 已置位而被 pre-insert 拦截为 409。
+    expect(oscillation[0]!.status).toBe(200);
+    expect(oscillation[1]!.status).toBe(200);
+    expect(oscillation[2]!.status).toBe(409);
+    expect(((await oscillation[2]!.json()) as { error: { code: string } }).error.code).toBe("workflow_guard");
+  });
+
+  it("a genuinely forward-advancing workflow (new step each turn) does NOT trip within the limit", async () => {
+    const owner = `${uniq("acct")}@leeguoo.com`;
+    const agent = await seedToken("agent", uniq("wf-fwd"), { owner });
+    const slug = await createChannel(agent.token);
+
+    // limit=2 是最激进的设置；即便如此，只要每一帧都是没见过的新 (step,state)，就永远是进展、永不 trip。
+    expect((await configureWorkflowGuard(slug, agent.token, 2)).status).toBe(200);
+
+    for (let i = 0; i < 8; i++) {
+      const res = await postStatus(slug, agent.token, {
+        state: "working",
+        note: `forward step ${i}`,
+        workflow: workflow(`step-${i}`, "working", "wf-fwd"),
+      });
+      expect(res.status).toBe(200);
+    }
+  });
+
+  it("returning to a state seen earlier in the run but different from the immediately-previous frame is NOT progress", async () => {
+    // 精确咬住盲区：A→B→A。旧代码里第二个 A「不同于上一帧 B」→ 判进展；新代码里 A 在窗口内 → 非进展。
+    const owner = `${uniq("acct")}@leeguoo.com`;
+    const agent = await seedToken("agent", uniq("wf-rev"), { owner });
+    const slug = await createChannel(agent.token);
+
+    expect((await configureWorkflowGuard(slug, agent.token, 1)).status).toBe(200);
+
+    expect(
+      (await postStatus(slug, agent.token, { state: "working", note: "A", workflow: workflow("step-a", "working", "wf-rev") }))
+        .status,
+    ).toBe(200);
+    expect(
+      (await postStatus(slug, agent.token, { state: "working", note: "B", workflow: workflow("step-b", "working", "wf-rev") }))
+        .status,
+    ).toBe(200);
+    // 回到 step-a：窗口内已有 → 非进展 → 计数 1，limit=1 → 置位 no_progress（本帧仍 200）。
+    expect(
+      (await postStatus(slug, agent.token, { state: "working", note: "A again", workflow: workflow("step-a", "working", "wf-rev") }))
+        .status,
+    ).toBe(200);
+    // 再翻回 step-b：no_progress 已置位且仍非进展 → 409。
+    const blocked = await postStatus(slug, agent.token, {
+      state: "working",
+      note: "B again",
+      workflow: workflow("step-b", "working", "wf-rev"),
+    });
+    expect(blocked.status).toBe(409);
+    expect(((await blocked.json()) as { error: { code: string } }).error.code).toBe("workflow_guard");
+  });
+});


### PR DESCRIPTION
## 修什么（#106，[P3][design]，opt-in 窄加固）

workflow guard 的「进展」判定可被状态交替愚弄。`workflowProgressed` 原来只比对**紧邻上一行**——`run_id/step_id/state` 任一不同即判进展、`no_progress` 计数归零。两个 agent 在不同 `(step,state)` 间来回上报时每帧都「≠上一帧」→ 永远判进展 → **guard 永不 trip**，无人锚点的 A↔B ping-pong 可跑到天亮。

## 怎么修

改用「本 run 近期 `(step,state)` 窗口」（`WORKFLOW_GUARD_WINDOW=8`）：
- 进展 = 一个在本 run 近期窗口里**从未见过**的 tuple。
- 回到窗口内见过的 tuple = **非进展（振荡）**，`no_progress` 计数继续爬直到 trip。
- `run_id` 变化 = 新 run，窗口重置。
- 真正线性推进（每帧都是新 step）永远命中「窗口内没见过」→ 判进展 → **永不误伤**。

窗口存在 DO 内建 SQLite 的 `workflow_guard_state.recent_tuples`（`onStart` 幂等 `ALTER ADD COLUMN`，与 messages 表补列同手法；**DO-local sqlite 非 D1，无需 worker/migrations 迁移文件**；存量行 `NULL` → 解析成 `[]`）。`message` 帧无 tuple 传 null、不污染窗口。opt-in 门（`workflowGuardEnabled`）与非 agent 短路不变。

## 门禁（我逐行审 + 亲跑，agent 报告被截断故全部复验）
- 新 spec `workflow-guard-progress.spec.ts`：3/3（TDD，先红后绿）。
- 既有 `workflow-guard.spec.ts`：无回归（2 文件 5 测试全绿）。
- worker `tsc --noEmit` = 0。
- 变异：把 `workflowProgressed` 改回旧松判定 → 振荡 trip + A→B→A 两条测试红；还原后复绿。

## 评审请确认
- **残留限制**：>8 个**不同** `(step,state)` 的长环仍可绕过（重访 tuple 已滑出窗口 → 判新进展）。属窄加固可接受，但请确认窗口=8 够用，或是否要更大/按时间窗。
- 语义：把「回到近期见过的状态」判为非进展，是否与你们对 workflow「合法回退/重试」的预期一致（合法重试若在 8 步内重复同一 tuple 会被计入 no-progress——但仍需累计到 limit 且无真进展才 trip）。

🤖 实现由 agent 完成、经我逐行审 + 复验；走 PR 由 @leeguooooo / LEO-MAIN 确认 guard 语义后合，未自合（loop-breaker 安全代码）。
