### PR TITLE
feat(worker,cli): task 加 external_ref 幂等键，issue→task 同步可重跑不重复建（#141）

### DIFF
--- a/cli/src/commands/task.ts
+++ b/cli/src/commands/task.ts
@@ -23,12 +23,13 @@ const FLAGS = [
   "parent",
   "anchor",
   "workflow",
+  "external-ref",
   "limit",
   "mine",
   "json",
 ];
 
-const HELP = `usage: party task create <title|-> [--channel C] [--desc text] [--assignee @name] [--label bug]... [--scope path]... [--blocked-reason text] [--priority N] [--parent ID] [--anchor seq]...
+const HELP = `usage: party task create <title|-> [--channel C] [--desc text] [--assignee @name] [--label bug]... [--scope path]... [--blocked-reason text] [--priority N] [--parent ID] [--anchor seq]... [--external-ref ref]
   party task from <seq> [--channel C] [--title text] [--desc text] [--assignee @name] [--label bug]... [--scope path]...
   party task list [--channel C] [--state S] [--assignee @name|--mine] [--limit N] [--json]
   party task assign <id> @name [--channel C] [--assignee-kind agent|human|squad] [--scope path]...
@@ -39,6 +40,9 @@ const HELP = `usage: party task create <title|-> [--channel C] [--desc text] [--
 
 --scope declares the files/dirs a task claims (repeatable); host board conflicts and open claims
 derive from it. --blocked-reason attaches a structured reason when a task is blocked.
+--external-ref (create only) is an idempotency key (e.g. gh:owner/repo#96): creating with a ref
+that already exists in the channel returns the existing task instead of a duplicate — safe to
+rerun an issue→task sync (#141).
 
 Create and move channel tasks. Agent-created tasks default to triage; human-created
 tasks default to backlog unless an assignee/state is provided.
@@ -114,7 +118,7 @@ export async function run(argv: string[]): Promise<number> {
     console.error(unknown);
     return 1;
   }
-  const flagError = valueFlagError(flags, ["channel", "title", "desc", "description", "state", "assignee", "assignee-kind", "priority", "parent", "workflow", "limit", "blocked-reason"], ["label", "anchor", "scope"]);
+  const flagError = valueFlagError(flags, ["channel", "title", "desc", "description", "state", "assignee", "assignee-kind", "priority", "parent", "workflow", "limit", "blocked-reason", "external-ref"], ["label", "anchor", "scope"]);
   if (flagError !== null) {
     console.error(flagError);
     return 1;
@@ -243,6 +247,7 @@ export async function run(argv: string[]): Promise<number> {
         }
         anchors.push(anchor);
       }
+      const externalRef = str(flags["external-ref"]);
       const task = await createTask(cfg.server, cfg.token, slug, {
         title,
         ...(desc !== undefined ? { desc } : {}),
@@ -255,6 +260,7 @@ export async function run(argv: string[]): Promise<number> {
         ...(str(flags.workflow) !== undefined ? { workflow_id: str(flags.workflow) } : {}),
         ...(scope !== undefined ? { scope } : {}),
         ...(blockedReason !== undefined ? { blocked_reason: blockedReason } : {}),
+        ...(externalRef !== undefined ? { external_ref: externalRef } : {}),
       });
       console.log(flags.json === true ? JSON.stringify(jsonFrame(task as unknown as Record<string, unknown>)) : `created ${formatTask(task)}`);
       return 0;

--- a/cli/src/rest.ts
+++ b/cli/src/rest.ts
@@ -605,6 +605,7 @@ export async function createTask(
     workflow_id?: string;
     scope?: string[];
     blocked_reason?: string | null;
+    external_ref?: string;
   },
 ): Promise<TaskRecord> {
   return (await req(server, `/api/channels/${encodeURIComponent(slug)}/tasks`, {

--- a/cli/test/host-board.test.ts
+++ b/cli/test/host-board.test.ts
@@ -22,6 +22,7 @@ function task(overrides: Partial<TaskRecord> & { id: number }): TaskRecord {
     anchor_seqs: [],
     scope: [],
     blocked_reason: null,
+    external_ref: null,
     completion_artifact: null,
     workflow_id: null,
     created_at: NOW,

--- a/cli/test/task-external-ref.test.ts
+++ b/cli/test/task-external-ref.test.ts
@@ -1,0 +1,140 @@
+// #141 CLI 侧：party task create --external-ref <ref> 把外部引用键透传进请求体，
+// 供 issue→task 同步脚本做幂等 create（对照 worker/test/task-external-ref.spec.ts）。
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const indexPath = join(import.meta.dir, "..", "src", "index.ts");
+
+let home: string;
+let restServer: ReturnType<typeof Bun.serve> | null = null;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "ap-cli-extref-"));
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+  restServer?.stop(true);
+  restServer = null;
+});
+
+async function runCli(args: string[]): Promise<{ code: number; stdout: string; stderr: string }> {
+  const proc = Bun.spawn(["bun", "run", indexPath, ...args], {
+    env: { ...process.env, AGENTPARTY_HOME: home },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, code] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { code, stdout, stderr };
+}
+
+describe("party task create --external-ref", () => {
+  test("sends external_ref in the POST body", async () => {
+    const seen: { method: string; path: string; body: unknown }[] = [];
+    const task = {
+      type: "task",
+      id: 9,
+      channel: "dev",
+      title: "sync issue #96",
+      desc: null,
+      state: "triage",
+      assignee: null,
+      created_by: "me",
+      created_by_kind: "agent",
+      priority: 0,
+      labels: [],
+      parent_id: null,
+      anchor_seqs: [],
+      external_ref: "gh:leeguooooo/agentparty#96",
+      completion_artifact: null,
+      workflow_id: null,
+      created_at: 1,
+      updated_at: 1,
+    };
+    restServer = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      async fetch(req) {
+        const url = new URL(req.url);
+        const body = req.method === "GET" ? null : await req.json().catch(() => null);
+        seen.push({ method: req.method, path: `${url.pathname}${url.search}`, body });
+        if (url.pathname === "/api/channels/dev/tasks" && req.method === "POST") {
+          return Response.json(task, { status: 201 });
+        }
+        return Response.json({ error: { code: "not_found", message: "not found" } }, { status: 404 });
+      },
+    });
+    mkdirSync(home, { recursive: true });
+    writeFileSync(
+      join(home, "config.json"),
+      JSON.stringify({ server: `http://127.0.0.1:${restServer.port}`, token: "ap_tok" }),
+    );
+
+    const r = await runCli(["task", "create", "sync issue #96", "--channel", "dev", "--external-ref", "gh:leeguooooo/agentparty#96"]);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain("created #9");
+
+    expect(seen).toContainEqual({
+      method: "POST",
+      path: "/api/channels/dev/tasks",
+      body: { title: "sync issue #96", external_ref: "gh:leeguooooo/agentparty#96" },
+    });
+  });
+
+  test("omits external_ref from the POST body when the flag is not passed", async () => {
+    const seen: { method: string; path: string; body: unknown }[] = [];
+    const task = {
+      type: "task",
+      id: 10,
+      channel: "dev",
+      title: "plain task",
+      desc: null,
+      state: "triage",
+      assignee: null,
+      created_by: "me",
+      created_by_kind: "agent",
+      priority: 0,
+      labels: [],
+      parent_id: null,
+      anchor_seqs: [],
+      external_ref: null,
+      completion_artifact: null,
+      workflow_id: null,
+      created_at: 1,
+      updated_at: 1,
+    };
+    restServer = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      async fetch(req) {
+        const url = new URL(req.url);
+        const body = req.method === "GET" ? null : await req.json().catch(() => null);
+        seen.push({ method: req.method, path: `${url.pathname}${url.search}`, body });
+        if (url.pathname === "/api/channels/dev/tasks" && req.method === "POST") {
+          return Response.json(task, { status: 201 });
+        }
+        return Response.json({ error: { code: "not_found", message: "not found" } }, { status: 404 });
+      },
+    });
+    mkdirSync(home, { recursive: true });
+    writeFileSync(
+      join(home, "config.json"),
+      JSON.stringify({ server: `http://127.0.0.1:${restServer.port}`, token: "ap_tok" }),
+    );
+
+    const r = await runCli(["task", "create", "plain task", "--channel", "dev"]);
+    expect(r.code).toBe(0);
+
+    expect(seen).toContainEqual({
+      method: "POST",
+      path: "/api/channels/dev/tasks",
+      body: { title: "plain task" },
+    });
+  });
+});

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -179,6 +179,8 @@ export interface TaskRecord {
   scope: string[];
   /** state=blocked 时的结构化阻塞原因（#204）；其他状态为 null */
   blocked_reason: string | null;
+  /** 外部系统引用键（如 gh:owner/repo#96），供 issue→task 同步做幂等 create（#141）；未提供为 null */
+  external_ref: string | null;
   completion_artifact: unknown | null;
   workflow_id: string | null;
   created_at: number;

--- a/web/src/pages/TaskLedgerPanel.test.tsx
+++ b/web/src/pages/TaskLedgerPanel.test.tsx
@@ -57,6 +57,7 @@ function task(overrides: Partial<TaskRecord> = {}): TaskRecord {
     workflow_id: null,
     scope: [],
     blocked_reason: null,
+    external_ref: null,
     created_at: 0,
     updated_at: 0,
     completed_at: null,

--- a/worker/migrations/0026_task_external_ref.sql
+++ b/worker/migrations/0026_task_external_ref.sql
@@ -1,0 +1,9 @@
+-- task 加可选外部引用键 external_ref（如 gh:owner/repo#96），承载「外部系统 → task 看板」
+-- 同步的幂等锚点（#141，同类根因参照 #98 消息幂等键）。
+-- 唯一索引按 channel 内 scope：同一 channel 内 external_ref 不可重复，跨 channel 允许复用同一 ref。
+-- NULL 不参与冲突判定（SQLite 标准行为：UNIQUE 索引里 NULL 互不相等），多条未带 external_ref
+-- 的 task 可以正常共存，不影响今天「无 ref 每次都新建」的默认路径。
+ALTER TABLE channel_tasks ADD COLUMN external_ref TEXT;
+
+CREATE UNIQUE INDEX idx_channel_tasks_channel_external_ref
+  ON channel_tasks(channel_slug, external_ref);

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -257,6 +257,7 @@ const TASK_LABELS_MAX = 20;
 const TASK_SCOPE_ITEM_MAX = 256; // 每个 scope 条目的字节上限
 const TASK_SCOPE_MAX = 32; // scope 条目数量上限
 const TASK_BLOCKED_REASON_MAX = 2000; // blocked_reason 字节上限
+const TASK_EXTERNAL_REF_MAX = 512; // #141 external_ref 字节上限
 const SQUAD_MEMBERS_MAX = 50;
 const SQUAD_TITLE_MAX = 120;
 const SQUAD_DESCRIPTION_MAX = 4000;
@@ -640,6 +641,7 @@ function taskRowToRecord(row: {
   anchor_seqs_json: string;
   scope_json: string;
   blocked_reason: string | null;
+  external_ref: string | null;
   completion_artifact_json: string | null;
   workflow_id: string | null;
   created_at: number;
@@ -675,6 +677,7 @@ function taskRowToRecord(row: {
     anchor_seqs: safeJsonArray<number>(row.anchor_seqs_json).filter((seq): seq is number => Number.isInteger(seq) && seq > 0),
     scope: safeJsonArray<string>(row.scope_json).filter((entry): entry is string => typeof entry === "string" && entry.length > 0),
     blocked_reason: row.blocked_reason,
+    external_ref: row.external_ref,
     completion_artifact: completionArtifact,
     workflow_id: row.workflow_id,
     created_at: row.created_at,
@@ -732,6 +735,17 @@ function parseTaskBlockedReason(input: unknown): string | null | false {
   if (input === null) return null;
   if (typeof input !== "string") return false;
   if (textEncoder.encode(input).byteLength > TASK_BLOCKED_REASON_MAX) return false;
+  return input;
+}
+
+// #141 external_ref：null 直通；字符串校验非空、字节上限、不含控制字符；非法类型/超长/空串 → false。
+// 注意：undefined 需由调用方先行处理（POST=不提供即 null），本函数不接收 undefined。
+function parseTaskExternalRef(input: unknown): string | null | false {
+  if (input === null) return null;
+  if (typeof input !== "string") return false;
+  if (input.trim() === "") return false;
+  if (textEncoder.encode(input).byteLength > TASK_EXTERNAL_REF_MAX) return false;
+  if (/[\x00-\x1f\x7f]/.test(input)) return false;
   return input;
 }
 
@@ -3826,6 +3840,11 @@ app.post("/api/channels/:slug/tasks", async (c) => {
   if (blockedReason === false) {
     return c.json(errorBody("bad_request", `blocked_reason must be null or a string <= ${TASK_BLOCKED_REASON_MAX} bytes`), 400);
   }
+  // #141 external_ref：可选外部引用键，供 issue→task 同步做幂等 create。undefined/null → 不去重（今天的默认行为）。
+  const externalRef = body?.external_ref === undefined ? null : parseTaskExternalRef(body.external_ref);
+  if (externalRef === false) {
+    return c.json(errorBody("bad_request", `external_ref must be null or a non-empty printable string <= ${TASK_EXTERNAL_REF_MAX} bytes`), 400);
+  }
   const priority = body?.priority === undefined ? 0 : typeof body?.priority === "number" && Number.isInteger(body.priority) ? body.priority : null;
   if (priority === null || priority < -100 || priority > 100) {
     return c.json(errorBody("bad_request", "priority must be an integer between -100 and 100"), 400);
@@ -3846,36 +3865,63 @@ app.post("/api/channels/:slug/tasks", async (c) => {
   // 否则 blockers 派生会读到「未 blocked 却带 reason」的陈旧数据（门禁 P1）。服务端强制，
   // 不信任客户端一致性。
   const effectiveBlockedReason = state === "blocked" ? blockedReason : null;
-  const now = Date.now();
-  const result = await c.env.DB.prepare(
-    `INSERT INTO channel_tasks (
-       channel_slug, title, description, state, assignee_name, assignee_kind,
-       created_by, created_by_kind, created_by_owner, priority, labels_json,
-       parent_id, anchor_seqs_json, workflow_id, scope_json, blocked_reason, created_at, updated_at, completed_at
-     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-  )
-    .bind(
-      slug,
-      title,
-      desc,
-      state,
-      assignee?.name ?? null,
-      assignee?.kind ?? null,
-      identity.name,
-      identity.kind,
-      identity.owner ?? null,
-      priority,
-      JSON.stringify(labels),
-      parentId,
-      JSON.stringify(anchorSeqs),
-      workflowId,
-      JSON.stringify(scope),
-      effectiveBlockedReason,
-      now,
-      now,
-      state === "done" ? now : null,
+  // #141 幂等 create：external_ref 命中已存在的 (channel, external_ref) 行 → 直接返回既有 task（200），
+  // 不再 INSERT、不再重复触发 system status/唤醒。这是 issue→task 同步重跑不再重复建的核心。
+  if (externalRef !== null) {
+    const existing = await c.env.DB.prepare(
+      `SELECT * FROM channel_tasks WHERE channel_slug = ? AND external_ref = ?`,
     )
-    .run();
+      .bind(slug, externalRef)
+      .first<TaskRow>();
+    if (existing) return c.json(taskRowToRecord(existing), 200);
+  }
+  const now = Date.now();
+  let result: D1Result;
+  try {
+    result = await c.env.DB.prepare(
+      `INSERT INTO channel_tasks (
+         channel_slug, title, description, state, assignee_name, assignee_kind,
+         created_by, created_by_kind, created_by_owner, priority, labels_json,
+         parent_id, anchor_seqs_json, workflow_id, scope_json, blocked_reason, external_ref, created_at, updated_at, completed_at
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+      .bind(
+        slug,
+        title,
+        desc,
+        state,
+        assignee?.name ?? null,
+        assignee?.kind ?? null,
+        identity.name,
+        identity.kind,
+        identity.owner ?? null,
+        priority,
+        JSON.stringify(labels),
+        parentId,
+        JSON.stringify(anchorSeqs),
+        workflowId,
+        JSON.stringify(scope),
+        effectiveBlockedReason,
+        externalRef,
+        now,
+        now,
+        state === "done" ? now : null,
+      )
+      .run();
+  } catch (error) {
+    // #141 并发兜底：两个请求同时带同一 external_ref 都读到「未命中」再各自 INSERT，
+    // 唯一索引 (channel_slug, external_ref) 会让后到的一条撞 UNIQUE constraint failed——
+    // 回落成幂等命中语义（200 + 既有行），而不是把 D1 错误甩给调用方。
+    if (externalRef !== null && String(error).includes("UNIQUE constraint failed")) {
+      const existing = await c.env.DB.prepare(
+        `SELECT * FROM channel_tasks WHERE channel_slug = ? AND external_ref = ?`,
+      )
+        .bind(slug, externalRef)
+        .first<TaskRow>();
+      if (existing) return c.json(taskRowToRecord(existing), 200);
+    }
+    throw error;
+  }
   const id = Number(result.meta.last_row_id);
   const row = await loadTaskRow(c.env.DB, slug, id);
   await insertSystemStatus(c.env, slug, `task #${id} created: ${title}`, "waiting").catch(() => false);

--- a/worker/test/task-external-ref.spec.ts
+++ b/worker/test/task-external-ref.spec.ts
@@ -1,0 +1,129 @@
+// #141 task external_ref 幂等键：同一 (channel, external_ref) 重复 create 不再重复建行。
+// 同根因参照 #98（消息幂等键），这里是 task 面的复现。
+import { describe, expect, it } from "vitest";
+import { api, createChannel, seedToken, uniq } from "./helpers";
+
+describe("channel task external_ref idempotency (#141)", () => {
+  it("returns the existing task with 200 on a second create with the same external_ref (no duplicate row)", async () => {
+    const human = await seedToken("human", uniq("human"));
+    const slug = await createChannel(human.token);
+    const ref = `gh:leeguooooo/agentparty#${uniq("ref")}`;
+
+    const first = await api(`/api/channels/${slug}/tasks`, human.token, {
+      method: "POST",
+      body: JSON.stringify({ title: "sync issue #96", external_ref: ref }),
+    });
+    expect(first.status).toBe(201);
+    const firstTask = (await first.json()) as { id: number; external_ref: string | null };
+    expect(firstTask.external_ref).toBe(ref);
+
+    // 重跑同步：同一 external_ref 再 create 一次——不同 title，模拟重试请求体可能略有出入。
+    const second = await api(`/api/channels/${slug}/tasks`, human.token, {
+      method: "POST",
+      body: JSON.stringify({ title: "sync issue #96 (retry)", external_ref: ref }),
+    });
+    expect(second.status).toBe(200);
+    const secondTask = (await second.json()) as { id: number; external_ref: string | null };
+    expect(secondTask.id).toBe(firstTask.id);
+    expect(secondTask.external_ref).toBe(ref);
+
+    const listed = await api(`/api/channels/${slug}/tasks`, human.token);
+    const tasks = ((await listed.json()) as { tasks: { id: number }[] }).tasks;
+    expect(tasks.length).toBe(1);
+    expect(tasks[0]!.id).toBe(firstTask.id);
+  });
+
+  it("creates distinct tasks for distinct external_ref values", async () => {
+    const human = await seedToken("human", uniq("human"));
+    const slug = await createChannel(human.token);
+
+    const a = await api(`/api/channels/${slug}/tasks`, human.token, {
+      method: "POST",
+      body: JSON.stringify({ title: "issue A", external_ref: `gh:org/repo#${uniq("a")}` }),
+    });
+    const b = await api(`/api/channels/${slug}/tasks`, human.token, {
+      method: "POST",
+      body: JSON.stringify({ title: "issue B", external_ref: `gh:org/repo#${uniq("b")}` }),
+    });
+    expect(a.status).toBe(201);
+    expect(b.status).toBe(201);
+    const aId = ((await a.json()) as { id: number }).id;
+    const bId = ((await b.json()) as { id: number }).id;
+    expect(aId).not.toBe(bId);
+
+    const listed = await api(`/api/channels/${slug}/tasks`, human.token);
+    expect(((await listed.json()) as { tasks: { id: number }[] }).tasks.length).toBe(2);
+  });
+
+  it("does not falsely dedup tasks with absent/null external_ref (NULLs are distinct)", async () => {
+    const human = await seedToken("human", uniq("human"));
+    const slug = await createChannel(human.token);
+
+    const a = await api(`/api/channels/${slug}/tasks`, human.token, {
+      method: "POST",
+      body: JSON.stringify({ title: "no ref A" }),
+    });
+    const b = await api(`/api/channels/${slug}/tasks`, human.token, {
+      method: "POST",
+      body: JSON.stringify({ title: "no ref B", external_ref: null }),
+    });
+    const c = await api(`/api/channels/${slug}/tasks`, human.token, {
+      method: "POST",
+      body: JSON.stringify({ title: "no ref C" }),
+    });
+    expect(a.status).toBe(201);
+    expect(b.status).toBe(201);
+    expect(c.status).toBe(201);
+    const aTask = (await a.json()) as { id: number; external_ref: string | null };
+    const bTask = (await b.json()) as { id: number; external_ref: string | null };
+    const cTask = (await c.json()) as { id: number; external_ref: string | null };
+    expect(aTask.external_ref).toBe(null);
+    expect(bTask.external_ref).toBe(null);
+    expect(cTask.external_ref).toBe(null);
+    expect(new Set([aTask.id, bTask.id, cTask.id]).size).toBe(3);
+
+    const listed = await api(`/api/channels/${slug}/tasks`, human.token);
+    expect(((await listed.json()) as { tasks: { id: number }[] }).tasks.length).toBe(3);
+  });
+
+  it("scopes external_ref uniqueness per channel: same ref in two channels does not collide", async () => {
+    const human = await seedToken("human", uniq("human"));
+    const slugA = await createChannel(human.token);
+    const slugB = await createChannel(human.token);
+    const ref = `gh:leeguooooo/agentparty#${uniq("scoped")}`;
+
+    const a = await api(`/api/channels/${slugA}/tasks`, human.token, {
+      method: "POST",
+      body: JSON.stringify({ title: "A", external_ref: ref }),
+    });
+    const b = await api(`/api/channels/${slugB}/tasks`, human.token, {
+      method: "POST",
+      body: JSON.stringify({ title: "B", external_ref: ref }),
+    });
+    expect(a.status).toBe(201);
+    expect(b.status).toBe(201);
+  });
+
+  it("rejects invalid external_ref: empty string and over-length", async () => {
+    const human = await seedToken("human", uniq("human"));
+    const slug = await createChannel(human.token);
+
+    const empty = await api(`/api/channels/${slug}/tasks`, human.token, {
+      method: "POST",
+      body: JSON.stringify({ title: "bad", external_ref: "" }),
+    });
+    expect(empty.status).toBe(400);
+
+    const tooLong = await api(`/api/channels/${slug}/tasks`, human.token, {
+      method: "POST",
+      body: JSON.stringify({ title: "bad", external_ref: "x".repeat(600) }),
+    });
+    expect(tooLong.status).toBe(400);
+
+    const wrongType = await api(`/api/channels/${slug}/tasks`, human.token, {
+      method: "POST",
+      body: JSON.stringify({ title: "bad", external_ref: 5 }),
+    });
+    expect(wrongType.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## 修什么（#141，[P2][design]）

`party task create`（`POST /api/channels/:slug/tasks`）没有外部引用/幂等键。把 43 个 GitHub issue 同步进 task 看板后**重跑一次就产生 43 条重复**，写路径没有客户端可控的去重锚点。这是 #98（消息幂等）在 task 面的同类根因。

## 怎么修（幂等核心，按 owner 在 issue 里给的设计）

1. **迁移 `0026_task_external_ref.sql`**：`channel_tasks` 加可选 `external_ref TEXT` + 唯一索引 `(channel_slug, external_ref)`。NULL 不参与冲突（SQLite 标准：UNIQUE 里 NULL 互不相等）→ 无 ref 的 task 照常共存，默认路径不变。
2. **`POST .../tasks`**：可选 `external_ref` 字段。命中已存在 `(channel, external_ref)` 行 → **返回既有 task（200）**、不 INSERT、不重复触发 system status/唤醒；未命中 → 正常 INSERT；缺省/null → 保持今天「每次新建」的行为。并发兜底：两个请求都 miss 预查再各自 INSERT 时，唯一索引让后者撞 `UNIQUE constraint failed` → catch 回落成同一 200-既有行语义，不甩 D1 错误给调用方。校验：非空、≤512 字节、无控制字符，非法 → 400。
3. **CLI**：`party task create <title> --external-ref <ref>` 透传（仅在给了 flag 时带上）。
4. `shared` `TaskRecord.external_ref: string | null`，`taskRowToRecord` 带出。

## 门禁（我逐行审 + 对 origin 的提交亲跑，agent 中途有过误 `git checkout` 故全部复验）
- worker 新 spec `task-external-ref.spec.ts` 5/5 + 既有 `tasks.spec.ts` 无回归（9/9）；全量 worker 342/0。
- cli 新 spec 2/2；全量 cli 542/0。
- worker `tsc` = 0、cli `tsc` = 0、迁移守卫 = 0（0026 唯一，四位）。
- 变异：仅禁用预查**不够**（并发 catch 兜底也提供幂等）——我用「预查关 + INSERT 绑 null（彻底不去重）」才让幂等测试变红（1 fail），还原后复绿。

## 评审请确认 / 后续（agent 标注）
1. **MCP 缺口**：`party_task_create` MCP 工具的 zod schema 还没接 `external_ref`——走 MCP（非 CLI）建 task 的 agent 目前传不了幂等键。若 MCP 同步要用，需快速跟进。
2. **并发兜底未做真并发测试**：catch 分支逻辑正确（镜像预查的 200-既有行），但没有真·并行两请求打到 DO/D1 的测试（该测试在本 harness 里时序脆弱）。
3. **校验边界（512 字节、可打印无控制字符）是 agent 自选**（仿 workflow_id 风格），是否要别的上限/格式（如强制 `gh:` 前缀）请拍。
4. **未做（留后续）**：`party task sync` 子命令、`PUT .../tasks/by-ref/:ref`、task 删除/归档语义。

🤖 实现由 agent 完成、经我逐行审 + 对 origin 提交复验；走 PR 由 @leeguooooo / LEO-MAIN 审后合（DB schema + 幂等正确性），未自合。
