### PR TITLE
feat(worker,web): 频道发图片/文件走 R2，消息带附件引用（#176）

### DIFF
--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -409,6 +409,20 @@ export interface HelloFrame {
   since_rev?: number;
 }
 
+/**
+ * 频道消息附件引用（#176）：仅是指向 R2 对象的元数据，blob 本体不进消息帧/DO sqlite。
+ * 客户端先 POST /api/channels/:slug/attachments 上传拿到本结构，再随消息带上 N 个引用。
+ */
+export interface Attachment {
+  /** R2 对象键：<slug>/<uuid>/<filename>，前缀锚定到频道 slug 以隔离跨频道读取 */
+  key: string;
+  filename: string;
+  content_type: string;
+  size: number;
+  /** 回 worker 的鉴权下载路径 /api/channels/<slug>/attachments/<uuid>/<filename>；不是裸 R2 公链 */
+  url: string;
+}
+
 export interface SendMessageFrame {
   type: "send";
   kind: "message";
@@ -416,6 +430,8 @@ export interface SendMessageFrame {
   mentions: string[];
   reply_to: number | null;
   completion_artifact?: CompletionArtifact;
+  /** 附件引用（#176）；空/缺省视为无附件。上限见 do 侧 MAX_ATTACHMENTS_PER_MESSAGE。 */
+  attachments?: Attachment[];
   replaces?: number;
   /**
    * 幂等键（#98）：客户端每次发送生成一个唯一键（ULID）。同一条逻辑消息的重试（客户端超时重发、
@@ -551,6 +567,8 @@ export interface MsgFrame {
   role_source?: CollaborationRoleSource;
   completion_artifact?: CompletionArtifact;
   completion_review?: CompletionReview;
+  /** 附件引用（#176）；仅 kind:"message" 携带，无附件时省略。 */
+  attachments?: Attachment[];
   ts: number;
   edited?: true;
   edited_at?: number;

--- a/web/src/components/AttachmentList.tsx
+++ b/web/src/components/AttachmentList.tsx
@@ -1,0 +1,87 @@
+// 消息附件渲染（#176）：图片内联缩略图，其它文件给下载按钮。
+// 下载端点要 Bearer 鉴权，<img src>/<a href> 带不了头，所以先 fetch 成 blob 再造 objectURL。
+import { useEffect, useState } from "react";
+import type { Attachment } from "@agentparty/shared";
+import { fetchAttachmentBlob, getToken } from "../lib/api";
+
+function isImage(contentType: string): boolean {
+  return contentType.startsWith("image/");
+}
+
+export function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function ImageThumb({ att }: { att: Attachment }) {
+  const [src, setSrc] = useState<string | null>(null);
+  const [failed, setFailed] = useState(false);
+  useEffect(() => {
+    let alive = true;
+    let objectUrl: string | null = null;
+    fetchAttachmentBlob(getToken(), att.url)
+      .then((blob) => {
+        if (!alive) return;
+        objectUrl = URL.createObjectURL(blob);
+        setSrc(objectUrl);
+      })
+      .catch(() => {
+        if (alive) setFailed(true);
+      });
+    return () => {
+      alive = false;
+      if (objectUrl !== null) URL.revokeObjectURL(objectUrl);
+    };
+  }, [att.url]);
+  if (failed) return <FileLink att={att} />;
+  if (src === null) {
+    return <span className="msg-attachment-loading t-mono">{att.filename}…</span>;
+  }
+  return (
+    <a href={src} target="_blank" rel="noreferrer" className="msg-attachment-img" title={att.filename}>
+      <img src={src} alt={att.filename} loading="lazy" />
+    </a>
+  );
+}
+
+function FileLink({ att }: { att: Attachment }) {
+  const onDownload = async () => {
+    try {
+      const blob = await fetchAttachmentBlob(getToken(), att.url);
+      const objectUrl = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = objectUrl;
+      a.download = att.filename;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      setTimeout(() => URL.revokeObjectURL(objectUrl), 10_000);
+    } catch {
+      // 静默失败：下载权限/网络问题在 UI 无 toast 约定下不打断阅读
+    }
+  };
+  return (
+    <button
+      type="button"
+      className="d-btn msg-attachment-file t-mono"
+      onClick={() => void onDownload()}
+      title={att.filename}
+    >
+      ⬇ {att.filename} <span className="msg-attachment-size">{formatSize(att.size)}</span>
+    </button>
+  );
+}
+
+export function AttachmentList({ attachments }: { attachments: Attachment[] }) {
+  if (attachments.length === 0) return null;
+  return (
+    <div className="msg-attachments">
+      {attachments.map((att) => (
+        <div key={att.key} className="msg-attachment">
+          {isImage(att.content_type) ? <ImageThumb att={att} /> : <FileLink att={att} />}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/web/src/components/Composer.attachments.test.tsx
+++ b/web/src/components/Composer.attachments.test.tsx
@@ -1,0 +1,104 @@
+// 附件 composer 交互（#176）：附件按钮、待发 chip、纯附件可发、移除回调。
+// @ts-expect-error Bun executes this test, while the web tsconfig intentionally loads only Vite globals.
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import type { Attachment } from "@agentparty/shared";
+import { LocaleProvider } from "../i18n/locale";
+import { Composer } from "./Composer";
+
+function memoryStorage(): Storage {
+  const values = new Map<string, string>();
+  return {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => { values.set(key, value); },
+    removeItem: (key) => { values.delete(key); },
+    clear: () => values.clear(),
+    key: (index) => [...values.keys()][index] ?? null,
+    get length() { return values.size; },
+  };
+}
+
+let renderer: ReactTestRenderer | null = null;
+
+beforeEach(() => {
+  Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", { configurable: true, value: true });
+  Object.defineProperty(globalThis, "localStorage", { configurable: true, value: memoryStorage() });
+});
+
+afterEach(() => {
+  act(() => renderer?.unmount());
+  renderer = null;
+});
+
+const att: Attachment = {
+  key: "slug/uuid/pic.png",
+  filename: "pic.png",
+  content_type: "image/png",
+  size: 2048,
+  url: "/api/channels/slug/attachments/uuid/pic.png",
+};
+
+function render(props: Partial<Parameters<typeof Composer>[0]>) {
+  localStorage.setItem("ap_locale", "en");
+  const base = {
+    draft: "",
+    setDraft: () => {},
+    onSend: () => {},
+    ready: true,
+    candidates: [],
+    mentionStatuses: [],
+  };
+  act(() => {
+    renderer = create(
+      <LocaleProvider>
+        <Composer {...base} {...props} />
+      </LocaleProvider>,
+    );
+  });
+  return renderer!.root;
+}
+
+function byClass(root: ReturnType<typeof render>, cls: string) {
+  return root.findAll(
+    (n) => typeof n.props.className === "string" && n.props.className.split(" ").includes(cls),
+  );
+}
+
+describe("Composer attachments (#176)", () => {
+  test("attach button appears only when onPickFiles is wired", () => {
+    expect(byClass(render({}), "composer-attach")).toHaveLength(0);
+    expect(byClass(render({ onPickFiles: () => {} }), "composer-attach")).toHaveLength(1);
+  });
+
+  test("pending attachment renders a chip with the filename", () => {
+    const root = render({ onPickFiles: () => {}, attachments: [att] });
+    const names = byClass(root, "composer-attachment-name");
+    expect(names).toHaveLength(1);
+    expect(names[0]!.props.children).toBe("pic.png");
+  });
+
+  test("send is enabled with an attachment even when the draft is empty", () => {
+    const root = render({ onPickFiles: () => {}, attachments: [att], draft: "" });
+    const send = byClass(root, "composer-send")[0]!;
+    expect(send.props.disabled).toBe(false);
+  });
+
+  test("with no draft and no attachments, send stays disabled", () => {
+    const root = render({ onPickFiles: () => {}, attachments: [], draft: "" });
+    expect(byClass(root, "composer-send")[0]!.props.disabled).toBe(true);
+  });
+
+  test("remove button invokes onRemoveAttachment with the key", () => {
+    let removed: string | null = null;
+    const root = render({
+      onPickFiles: () => {},
+      attachments: [att],
+      onRemoveAttachment: (k: string) => {
+        removed = k;
+      },
+    });
+    const removeBtn = byClass(root, "composer-attachment-remove")[0]!;
+    act(() => removeBtn.props.onClick());
+    expect(removed).toBe("slug/uuid/pic.png");
+  });
+});

--- a/web/src/components/Composer.tsx
+++ b/web/src/components/Composer.tsx
@@ -2,6 +2,8 @@
 // readonly / archived 时由页面层直接不渲染本组件（错误内联为条幅）。
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { ChangeEvent, CSSProperties, KeyboardEvent } from "react";
+import type { Attachment } from "@agentparty/shared";
+import { formatSize } from "./AttachmentList";
 import { agentHue } from "../lib/agentColor";
 import {
   activeMentionQuery,
@@ -22,6 +24,12 @@ interface Props {
   ready: boolean; // ws open 才能发
   candidates: MentionCandidate[]; // @ 补全候选（participants ∪ presence，已分档排序）
   mentionStatuses: DraftMentionStatus[]; // 草稿里已 @ 的目标 + 当前存活档位（发送前提醒会不会白发）
+  // 附件（#176）：已上传待发的引用 + 选文件/移除回调 + 上传中/错误态。缺省即无附件能力。
+  attachments?: Attachment[];
+  onPickFiles?: (files: FileList) => void;
+  onRemoveAttachment?: (key: string) => void;
+  uploading?: boolean;
+  uploadError?: string | null;
 }
 
 const TIER_DOT: Record<MentionTier, string> = { online: "●", wakeable: "◐", recent: "○" };
@@ -51,8 +59,24 @@ function groupLabel(group: string, t: TFunc): string {
   return group;
 }
 
-export function Composer({ draft, setDraft, onSend, ready, candidates, mentionStatuses }: Props) {
+export function Composer({
+  draft,
+  setDraft,
+  onSend,
+  ready,
+  candidates,
+  mentionStatuses,
+  attachments = [],
+  onPickFiles,
+  onRemoveAttachment,
+  uploading = false,
+  uploadError = null,
+}: Props) {
   const t = useT();
+  const fileRef = useRef<HTMLInputElement | null>(null);
+  const canAttach = onPickFiles !== undefined;
+  // 有附件时允许空正文发送（纯图片消息）
+  const sendDisabled = !ready || uploading || (draft.trim() === "" && attachments.length === 0);
   const TIER_LABEL: Record<MentionTier, string> = {
     online: t("Composer.tier.online"),
     wakeable: t("Composer.tier.wakeable"),
@@ -235,16 +259,63 @@ export function Composer({ draft, setDraft, onSend, ready, candidates, mentionSt
         onKeyDown={onKeyDown}
         onBlur={() => setTimeout(() => setMenu(null), 120)}
       />
+      {attachments.length > 0 && (
+        <ul className="composer-attachments" aria-label="pending attachments">
+          {attachments.map((att) => (
+            <li key={att.key} className="composer-attachment t-mono">
+              <span className="composer-attachment-name">{att.filename}</span>
+              <span className="composer-attachment-size">{formatSize(att.size)}</span>
+              {onRemoveAttachment !== undefined && (
+                <button
+                  type="button"
+                  className="composer-attachment-remove"
+                  aria-label={`remove ${att.filename}`}
+                  onClick={() => onRemoveAttachment(att.key)}
+                >
+                  ×
+                </button>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+      {uploadError !== null && <p className="banner banner--red composer-upload-error">{uploadError}</p>}
       <FeatureTip tip="Tips.wake" className="composer-wake-tip" />
-      <button
-        type="button"
-        className="d-btn d-btn--primary composer-send"
-        onClick={onSend}
-        disabled={!ready || draft.trim() === ""}
-        title={ready ? t("Composer.send.readyTitle") : t("Composer.send.connectingTitle")}
-      >
-        {t("Composer.send.label")}
-      </button>
+      <div className="composer-actions">
+        {canAttach && (
+          <>
+            <input
+              ref={fileRef}
+              type="file"
+              multiple
+              className="composer-file-input"
+              style={{ display: "none" }}
+              onChange={(e) => {
+                if (e.target.files !== null && e.target.files.length > 0) onPickFiles?.(e.target.files);
+                e.target.value = "";
+              }}
+            />
+            <button
+              type="button"
+              className="d-btn composer-attach"
+              onClick={() => fileRef.current?.click()}
+              disabled={uploading}
+              title={t("Composer.attach.title")}
+            >
+              {uploading ? t("Composer.attach.uploading") : t("Composer.attach.label")}
+            </button>
+          </>
+        )}
+        <button
+          type="button"
+          className="d-btn d-btn--primary composer-send"
+          onClick={onSend}
+          disabled={sendDisabled}
+          title={ready ? t("Composer.send.readyTitle") : t("Composer.send.connectingTitle")}
+        >
+          {t("Composer.send.label")}
+        </button>
+      </div>
     </div>
   );
 }

--- a/web/src/components/MessageCard.tsx
+++ b/web/src/components/MessageCard.tsx
@@ -11,6 +11,7 @@ import { useT } from "../i18n/useT";
 import "../i18n/strings/MessageCard";
 import { fmtTime } from "../lib/time";
 import type { MentionReceipt } from "../lib/wakeReceipt";
+import { AttachmentList } from "./AttachmentList";
 import { Markdown } from "./Markdown";
 import { MessageStatus } from "./MessageStatus";
 
@@ -482,6 +483,9 @@ export function MessageCard({
         <p className="msg-retracted">{t("MessageCard.retracted")}</p>
       ) : (
         <Markdown source={msg.body} identities={identityDisplay} />
+      )}
+      {!editing && !msg.retracted && msg.attachments !== undefined && msg.attachments.length > 0 && (
+        <AttachmentList attachments={msg.attachments} />
       )}
       {!editing && actionError !== null && <p className="banner banner--red msg-action-error">{actionError}</p>}
     </article>

--- a/web/src/i18n/strings/Composer.ts
+++ b/web/src/i18n/strings/Composer.ts
@@ -19,6 +19,9 @@ export const ComposerStrings: LocaleDict = {
     "Composer.send.label": "send",
     "Composer.send.readyTitle": "send (⏎ / ⌘⏎)",
     "Composer.send.connectingTitle": "connecting…",
+    "Composer.attach.label": "attach",
+    "Composer.attach.uploading": "uploading…",
+    "Composer.attach.title": "attach images or files",
   },
   zh: {
     "Composer.tier.online": "在线",
@@ -38,6 +41,9 @@ export const ComposerStrings: LocaleDict = {
     "Composer.send.label": "发送",
     "Composer.send.readyTitle": "发送（⏎ / ⌘⏎）",
     "Composer.send.connectingTitle": "连接中…",
+    "Composer.attach.label": "附件",
+    "Composer.attach.uploading": "上传中…",
+    "Composer.attach.title": "上传图片或文件",
   },
 };
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,7 +1,7 @@
 // rest 封装 + token 存取。
 // 规则（spec §10 / M2 契约）：URL 带 ?t= 时优先用它，并立即从地址栏移除；
 // share token 只放 sessionStorage，本次标签页可刷新，避免长期落 localStorage。
-import type { ChannelRoleAssignment, ChannelSquad, CollaborationRole, MsgFrame, PresenceEntry, SearchHit, TaskAssigneeKind, TaskRecord, TaskState, TaskSummary, WakeDelivery } from "@agentparty/shared";
+import type { Attachment, ChannelRoleAssignment, ChannelSquad, CollaborationRole, MsgFrame, PresenceEntry, SearchHit, TaskAssigneeKind, TaskRecord, TaskState, TaskSummary, WakeDelivery } from "@agentparty/shared";
 import { apiUrl } from "./base";
 import type { WebSession } from "./oidc";
 
@@ -173,6 +173,40 @@ export async function fetchMe(token: string): Promise<MeInfo> {
   if (res.status === 401) throw new AuthError("invalid or revoked token");
   if (!res.ok) throw new Error(`GET /api/me failed (${res.status})`);
   return (await res.json()) as MeInfo;
+}
+
+// 附件上传（#176）：把文件本体 POST 到频道，拿回 R2 引用元数据；随后发消息时带在 attachments 里。
+// 体积上限 25MB 在服务端强制（超限 413）。TooLarge 单列以便前端给出明确文案。
+export class TooLargeError extends Error {}
+
+export async function uploadAttachment(token: string, slug: string, file: File): Promise<Attachment> {
+  const res = await fetchApi(
+    `/api/channels/${slug}/attachments?filename=${encodeURIComponent(file.name)}`,
+    {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": file.type || "application/octet-stream",
+      },
+      body: file,
+    },
+  );
+  if (res.status === 401) throw new AuthError("invalid or revoked token");
+  if (res.status === 403) throw new ForbiddenError("not allowed to upload here");
+  if (res.status === 413) throw new TooLargeError("file too large (max 25MB)");
+  if (!res.ok) throw new Error(`upload failed (${res.status})`);
+  return (await res.json()) as Attachment;
+}
+
+// 附件下载（#176）：下载端点要 Bearer 鉴权，<img src>/<a href> 带不了头，所以取回 blob 再造 objectURL。
+export async function fetchAttachmentBlob(token: string | null, url: string): Promise<Blob> {
+  const res = await fetchApi(url, {
+    headers: token ? { authorization: `Bearer ${token}` } : {},
+  });
+  if (res.status === 401) throw new AuthError("invalid or revoked token");
+  if (res.status === 403) throw new ForbiddenError("not allowed to read this attachment");
+  if (!res.ok) throw new Error(`download failed (${res.status})`);
+  return res.blob();
 }
 
 export async function listChannels(token: string): Promise<ChannelInfo[]> {

--- a/web/src/pages/Channel.tsx
+++ b/web/src/pages/Channel.tsx
@@ -2,7 +2,7 @@
 // App 用 key={slug} 挂载本组件，切频道即整体重建（socket/状态零残留）。
 import { useCallback, useEffect, useLayoutEffect, useMemo, useReducer, useRef, useState } from "react";
 import type { CSSProperties, ReactNode } from "react";
-import { buildHostBoard, type ChannelSquad, type CollaborationRole, type HostBoard, type MsgFrame, type PresenceEntry, type ReadCursor, type SearchHit, type Sender, type TaskAssigneeKind, type TaskRecord, type TaskState, type TaskSummary, type WakeDelivery } from "@agentparty/shared";
+import { buildHostBoard, type Attachment, type ChannelSquad, type CollaborationRole, type HostBoard, type MsgFrame, type PresenceEntry, type ReadCursor, type SearchHit, type Sender, type TaskAssigneeKind, type TaskRecord, type TaskState, type TaskSummary, type WakeDelivery } from "@agentparty/shared";
 import { AgentJoin } from "../components/AgentJoin";
 import { AgentTokens } from "../components/AgentTokens";
 import { VisibilityToggle } from "../components/VisibilityToggle";
@@ -39,7 +39,9 @@ import {
   setLoopGuard,
   setWorkflowGuard,
   setChannelRole,
+  TooLargeError,
   updateTask,
+  uploadAttachment,
   ValidationError,
 } from "../lib/api";
 import { agentHue } from "../lib/agentColor";
@@ -1661,6 +1663,10 @@ export function ChannelPage({
   const [state, dispatch] = useReducer(channelReducer, initialChannelState);
   const [channelIdentities, setChannelIdentities] = useState<ChannelIdentity[]>([]);
   const [draft, setDraft] = useState("");
+  // 附件（#176）：已上传待随下一条消息发出的引用 + 上传中/错误态
+  const [attachments, setAttachments] = useState<Attachment[]>([]);
+  const [uploading, setUploading] = useState(false);
+  const [uploadError, setUploadError] = useState<string | null>(null);
   const [search, setSearch] = useState("");
   const [searchFrom, setSearchFrom] = useState("");
   const [searchSince, setSearchSince] = useState("");
@@ -2287,16 +2293,57 @@ export function ChannelPage({
 
   const send = useCallback(() => {
     const body = draft.trim();
-    if (body === "") return;
+    // 有附件时允许空正文（纯图片/文件消息）
+    if (body === "" && attachments.length === 0) return;
     // 与草稿 chips / 服务端 BODY_MENTION_RE 同一份语义：@ 前须行首或非标识符字符，不吃 email 里的 @
     const mentions = parseDraftMentions(body);
     const ok =
-      sockRef.current?.send({ type: "send", kind: "message", body, mentions, reply_to: replyTo }) ??
-      false;
+      sockRef.current?.send({
+        type: "send",
+        kind: "message",
+        body,
+        mentions,
+        reply_to: replyTo,
+        ...(attachments.length > 0 ? { attachments } : {}),
+      }) ?? false;
     // ⌘⏎ 不受按钮 disabled 门控，断线窗口内发送失败要内联提示（草稿保留）
-    if (ok) pendingSendsRef.current.push({ draft, replyTo });
-    else dispatch({ type: "send_failed", message: "not connected — message not sent, draft kept" });
-  }, [draft, replyTo]);
+    if (ok) {
+      pendingSendsRef.current.push({ draft, replyTo });
+      // 附件已落 R2，ws 已接收帧 → 乐观清空待发引用（失败时保留草稿由 ack 逻辑处理）
+      setAttachments([]);
+      setUploadError(null);
+    } else {
+      dispatch({ type: "send_failed", message: "not connected — message not sent, draft kept" });
+    }
+  }, [draft, replyTo, attachments]);
+
+  // 选文件 → 逐个上传到 R2 → 追加引用；上限 25MB / 20 个由服务端强制，前端只报错不拦
+  const onPickFiles = useCallback(
+    (files: FileList) => {
+      setUploading(true);
+      setUploadError(null);
+      const list = Array.from(files);
+      void (async () => {
+        for (const file of list) {
+          try {
+            const meta = await uploadAttachment(token, slug, file);
+            setAttachments((prev) => (prev.some((a) => a.key === meta.key) ? prev : [...prev, meta]));
+          } catch (err) {
+            if (err instanceof AuthError) authFailedRef.current("token revoked — paste a new one");
+            else if (err instanceof TooLargeError) setUploadError(`${file.name}: file too large (max 25MB)`);
+            else if (err instanceof ForbiddenError) setUploadError(`${file.name}: not allowed to upload here`);
+            else setUploadError(`${file.name}: upload failed`);
+          }
+        }
+        setUploading(false);
+      })();
+    },
+    [token, slug],
+  );
+
+  const onRemoveAttachment = useCallback((key: string) => {
+    setAttachments((prev) => prev.filter((a) => a.key !== key));
+  }, []);
 
   const canWrite = state.self !== null && !state.archived && !state.readonly;
   const charterUpdated = charter !== null && charter.charter_rev > seenCharterRev;
@@ -3356,6 +3403,11 @@ export function ChannelPage({
           ready={state.status === "open"}
           candidates={mentionOptions}
           mentionStatuses={draftMentionStatuses}
+          attachments={attachments}
+          onPickFiles={onPickFiles}
+          onRemoveAttachment={onRemoveAttachment}
+          uploading={uploading}
+          uploadError={uploadError}
         />
       )}
     </div>

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -3779,6 +3779,66 @@
 .composer-input::placeholder { color: var(--t-dim); }
 .composer-send { align-self: flex-end; }
 
+/* ---- 附件 composer（#176） ---- */
+.composer-actions {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  justify-content: flex-end;
+}
+.composer-attachments {
+  list-style: none;
+  margin: 0;
+  padding: 0.25rem 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+.composer-attachment {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.15rem 0.5rem;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-size: 0.8rem;
+}
+.composer-attachment-size { color: var(--t-dim); }
+.composer-attachment-remove {
+  border: none;
+  background: none;
+  cursor: pointer;
+  color: var(--t-dim);
+  font-size: 1rem;
+  line-height: 1;
+  padding: 0;
+}
+.composer-attachment-remove:hover { color: var(--fg, inherit); }
+.composer-upload-error { margin: 0.25rem 0; }
+
+/* ---- 消息附件渲染（#176） ---- */
+.msg-attachments {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.4rem;
+}
+.msg-attachment-img img {
+  max-width: 320px;
+  max-height: 240px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  display: block;
+}
+.msg-attachment-file {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+}
+.msg-attachment-size { color: var(--t-dim); }
+.msg-attachment-loading { color: var(--t-dim); font-size: 0.85rem; }
+
 .d-btn:disabled {
   opacity: 0.45;
   cursor: not-allowed;

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -19,6 +19,7 @@ import {
   WEBHOOK_RETRY_DELAYS_MS,
   WEBHOOK_TIMEOUT_MS,
   type AgentLineage,
+  type Attachment,
   type ErrorCode,
   type AgentContext,
   type CollaborationRole,
@@ -247,6 +248,17 @@ function parseStoredCompletionArtifact(input: unknown): CompletionArtifact | und
     const parsed = JSON.parse(input) as unknown;
     const artifact = parseCompletionArtifact(parsed, (parsed as { kickoff_seq?: unknown } | null)?.kickoff_seq as number | null);
     return artifact ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+// 反序列化落库的附件引用（#176）；复用 parseAttachments 做结构校验，脏数据静默丢弃。
+function parseStoredAttachments(input: unknown): Attachment[] | undefined {
+  if (typeof input !== "string" || input === "") return undefined;
+  try {
+    const parsed = parseAttachments(JSON.parse(input) as unknown);
+    return parsed === null ? undefined : parsed;
   } catch {
     return undefined;
   }
@@ -655,6 +667,32 @@ function parseIdempotencyKey(raw: unknown): string | undefined {
   return raw;
 }
 
+// 附件引用（#176）：一条消息可带 N 个引用，只是元数据不是 blob。缺省/空数组 → undefined（不落列）。
+// 校验失败（类型不对、超上限）返回 null，由 parseSendFrame 上抛整条拒收——附件是主动带上的，宁可明确报错。
+const MAX_ATTACHMENTS_PER_MESSAGE = 20;
+const ATTACHMENT_KEY_MAX = 1024;
+const ATTACHMENT_FILENAME_MAX = 512;
+const ATTACHMENT_CONTENT_TYPE_MAX = 256;
+const ATTACHMENT_URL_MAX = 2048;
+function parseAttachments(raw: unknown): Attachment[] | null | undefined {
+  if (raw === undefined || raw === null) return undefined;
+  if (!Array.isArray(raw)) return null;
+  if (raw.length === 0) return undefined;
+  if (raw.length > MAX_ATTACHMENTS_PER_MESSAGE) return null;
+  const out: Attachment[] = [];
+  for (const item of raw) {
+    if (typeof item !== "object" || item === null) return null;
+    const a = item as Record<string, unknown>;
+    if (typeof a.key !== "string" || a.key.length === 0 || a.key.length > ATTACHMENT_KEY_MAX) return null;
+    if (typeof a.filename !== "string" || a.filename.length === 0 || a.filename.length > ATTACHMENT_FILENAME_MAX) return null;
+    if (typeof a.content_type !== "string" || a.content_type.length === 0 || a.content_type.length > ATTACHMENT_CONTENT_TYPE_MAX) return null;
+    if (typeof a.size !== "number" || !Number.isInteger(a.size) || a.size < 0) return null;
+    if (typeof a.url !== "string" || a.url.length === 0 || a.url.length > ATTACHMENT_URL_MAX) return null;
+    out.push({ key: a.key, filename: a.filename, content_type: a.content_type, size: a.size, url: a.url });
+  }
+  return out;
+}
+
 // rest body 与 ws send 帧共用的校验（rest 侧无 type 字段）
 function parseSendFrame(input: unknown): SendFrame | null {
   if (typeof input !== "object" || input === null) return null;
@@ -675,6 +713,8 @@ function parseSendFrame(input: unknown): SendFrame | null {
     if (reply_to === undefined) return null;
     const completionArtifact = parseCompletionArtifact(f.completion_artifact, reply_to);
     if (completionArtifact === null) return null;
+    const attachments = parseAttachments(f.attachments);
+    if (attachments === null) return null;
     let replaces: number | undefined;
     if (f.replaces !== undefined) {
       if (typeof f.replaces !== "number" || !Number.isInteger(f.replaces) || f.replaces <= 0) return null;
@@ -687,6 +727,7 @@ function parseSendFrame(input: unknown): SendFrame | null {
       mentions,
       reply_to,
       ...(completionArtifact !== undefined ? { completion_artifact: completionArtifact } : {}),
+      ...(attachments !== undefined ? { attachments } : {}),
       ...(completionArtifact !== undefined && replaces !== undefined ? { replaces } : {}),
       ...(idempotencyKey !== undefined ? { idempotency_key: idempotencyKey } : {}),
     };
@@ -905,6 +946,8 @@ export class ChannelDO extends Server<Env> {
       // 幂等键（#98）：客户端每次发送带一个 ULID，服务端按 (sender_name, idempotency_key) 去重。
       // 注：messages 表是 DO 内建 SQLite（ctx.storage.sql），不是 D1，故无需 worker/migrations 迁移文件。
       "ALTER TABLE messages ADD COLUMN idempotency_key TEXT",
+      // 附件引用（#176）：存 Attachment[] 的 JSON，仅元数据（key/filename/type/size/url），blob 在 R2。
+      "ALTER TABLE messages ADD COLUMN attachments_json TEXT",
     ]) {
       try {
         sql.exec(ddl);
@@ -2618,6 +2661,7 @@ export class ChannelDO extends Server<Env> {
     const completionGate = this.getMeta("completion_gate");
     const completionReviewPolicy = (this.getMeta("completion_review_policy") ?? "sender") as CompletionReviewPolicy;
     const completionArtifact = frame.kind === "message" ? frame.completion_artifact : undefined;
+    const attachments = frame.kind === "message" ? frame.attachments : undefined;
     const replacesSeq =
       frame.kind === "message" && completionArtifact !== undefined && completionGate === "reviewer"
         ? frame.replaces
@@ -2662,6 +2706,7 @@ export class ChannelDO extends Server<Env> {
             ...(effectiveRole === undefined ? {} : { role: effectiveRole }),
             ...(roleSource === undefined ? {} : { role_source: roleSource }),
             ...(completionArtifact !== undefined ? { completion_artifact: completionArtifact } : {}),
+            ...(attachments !== undefined ? { attachments } : {}),
             ...(completionArtifact !== undefined && completionGate === "reviewer"
               ? {
                   completion_review: {
@@ -2696,9 +2741,9 @@ export class ChannelDO extends Server<Env> {
          state, note, status_scope_json, status_summary_seq, status_blocked_reason, status_context_json,
          status_decision_json, status_workflow_json, message_workflow_json,
          sender_role, sender_role_source, completion_artifact_json, completion_review_state, completion_review_policy,
-         completion_review_replaces_seq, idempotency_key, ts
+         completion_review_replaces_seq, idempotency_key, attachments_json, ts
        )
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       seq,
       identity.name,
       identity.kind,
@@ -2730,6 +2775,7 @@ export class ChannelDO extends Server<Env> {
       msg.completion_review?.policy ?? null,
       replacesSeq ?? null,
       frame.idempotency_key ?? null,
+      attachments === undefined ? null : JSON.stringify(attachments),
       now,
     );
     let replacedUpdate: MessageUpdateFrame | undefined;
@@ -3580,6 +3626,8 @@ export class ChannelDO extends Server<Env> {
       if (completionReview !== undefined) frame.completion_review = completionReview;
       const workflowRef = parseStoredStatusWorkflow(r.message_workflow_json);
       if (workflowRef !== undefined) frame.workflow_ref = workflowRef;
+      const attachments = parseStoredAttachments(r.attachments_json);
+      if (attachments !== undefined) frame.attachments = attachments;
     }
     if (r.edited_at !== null && r.edited_at !== undefined) {
       frame.edited = true;

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -8,6 +8,7 @@ import {
 } from "@agentparty/shared";
 import type {
   AgentLineage,
+  Attachment,
   CaptureKind,
   ChannelRoleAssignment,
   ChannelSquad,
@@ -210,6 +211,10 @@ async function loadChannelRoleAssignment(db: D1Database, slug: string, name: str
 const WEBHOOK_FILTERS: readonly string[] = ["mentions", "status", "needs-human", "all"] satisfies WebhookFilter[];
 const CAPTURE_KINDS: readonly string[] = ["decision", "requirement", "bug", "action-item"] satisfies CaptureKind[];
 const WEBHOOK_URL_MAX = 2048;
+// 附件上传体积上限（#176）：25 MiB。R2 免费额度 10GB 存储 + 无出站费，够撑；超限返回 413。
+const ATTACHMENT_SIZE_LIMIT = 25 * 1024 * 1024;
+// 附件文件名：单段、禁路径分隔符与控制符，用作 R2 key 末段和下载文件名
+const ATTACHMENT_FILENAME_RE = /^[^/\\\x00-\x1f\x7f]{1,255}$/;
 const WEBHOOK_SECRET_MAX = 4096;
 const HEADER_VALUE_RE = /^[\x21-\x7e]+$/;
 // do 无条件信任的内部头清单：ws 升级转发前必须逐个剥离客户端注入值，只认 worker 权威版本
@@ -4478,6 +4483,80 @@ app.get("/api/channels/:slug/messages/:seq/audit", async (c) => {
       headers: { "x-partykit-room": slug },
     }),
   );
+});
+
+// 附件上传（#176）：blob 进 R2，返回引用元数据；发消息时把引用带在 attachments 字段里。
+// 鉴权同频道写：必须是可访问该频道的非 readonly token（私有频道即房主/成员/被邀 agent）。
+app.post("/api/channels/:slug/attachments", async (c) => {
+  const slug = c.req.param("slug");
+  const channel = await loadChannel(c.env.DB, slug);
+  if (!channel) return c.json(errorBody("not_found", "channel not found"), 404);
+  const identity = c.get("identity");
+  if (!(await canAccessLoadedChannel(c.env.DB, identity, channel))) {
+    return c.json(errorBody("forbidden", "not allowed in this channel"), 403);
+  }
+  if (identity.role === "readonly") {
+    return c.json(errorBody("forbidden", "readonly token cannot upload attachments"), 403);
+  }
+  if (channel.archived_at !== null) {
+    return c.json(errorBody("archived", "channel is archived"), 410);
+  }
+  const filename = (c.req.query("filename") ?? "").trim();
+  if (!ATTACHMENT_FILENAME_RE.test(filename)) {
+    return c.json(errorBody("bad_request", "filename query param required (single path segment, <=255 chars)"), 400);
+  }
+  // Content-Length 先挡一刀，避免把超大体读进内存
+  const declaredLength = Number(c.req.header("content-length"));
+  if (Number.isFinite(declaredLength) && declaredLength > ATTACHMENT_SIZE_LIMIT) {
+    return c.json(errorBody("too_large", `attachment exceeds ${ATTACHMENT_SIZE_LIMIT} bytes`), 413);
+  }
+  const bytes = new Uint8Array(await c.req.arrayBuffer());
+  if (bytes.byteLength === 0) {
+    return c.json(errorBody("bad_request", "attachment body is empty"), 400);
+  }
+  if (bytes.byteLength > ATTACHMENT_SIZE_LIMIT) {
+    return c.json(errorBody("too_large", `attachment exceeds ${ATTACHMENT_SIZE_LIMIT} bytes`), 413);
+  }
+  const contentType = c.req.header("content-type")?.split(";")[0]?.trim() || "application/octet-stream";
+  // key 前缀锚定 slug：下载时 worker 用权威 slug 重新拼 key，跨频道的伪造引用读不到别人的 blob
+  const objectPath = `${crypto.randomUUID()}/${filename}`;
+  const key = `${slug}/${objectPath}`;
+  await c.env.ATTACHMENTS.put(key, bytes, {
+    httpMetadata: { contentType },
+    customMetadata: { filename, uploaded_by: identity.name, channel: slug },
+  });
+  const meta: Attachment = {
+    key,
+    filename,
+    content_type: contentType,
+    size: bytes.byteLength,
+    url: `/api/channels/${slug}/attachments/${objectPath}`,
+  };
+  return c.json(meta, 201);
+});
+
+// 附件下载（#176）：同频道读鉴权，从 R2 流式回传。绝不暴露裸 R2 公链——频道内容是受控的。
+app.get("/api/channels/:slug/attachments/:path{.+}", async (c) => {
+  const slug = c.req.param("slug");
+  const channel = await loadChannel(c.env.DB, slug);
+  if (!channel) return c.json(errorBody("not_found", "channel not found"), 404);
+  if (!(await canAccessLoadedChannel(c.env.DB, c.get("identity"), channel))) {
+    return c.json(errorBody("forbidden", "not allowed in this channel"), 403);
+  }
+  const objectPath = c.req.param("path");
+  // 只认 worker 权威 slug 前缀拼出的 key，客户端传的完整 key 一律不信任，防目录穿越
+  if (!objectPath || objectPath.includes("..") || objectPath.startsWith("/")) {
+    return c.json(errorBody("bad_request", "invalid attachment path"), 400);
+  }
+  const object = await c.env.ATTACHMENTS.get(`${slug}/${objectPath}`);
+  if (!object) return c.json(errorBody("not_found", "attachment not found"), 404);
+  const headers = new Headers();
+  object.writeHttpMetadata(headers);
+  headers.set("etag", object.httpEtag);
+  if (!headers.has("content-type")) headers.set("content-type", "application/octet-stream");
+  // nosniff：即便 content-type 被伪造也不让浏览器嗅探成可执行类型，缓解存储型 XSS
+  headers.set("x-content-type-options", "nosniff");
+  return new Response(object.body, { headers });
 });
 
 app.post("/api/channels/:slug/messages", async (c) => {

--- a/worker/test/attachments.spec.ts
+++ b/worker/test/attachments.spec.ts
@@ -1,0 +1,134 @@
+import type { MsgFrame } from "@agentparty/shared";
+import { SELF } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import { api, createChannel, seedToken, uniq } from "./helpers";
+
+// 直接用 SELF.fetch 上传二进制，绕开 api() 的默认 application/json content-type
+function upload(
+  slug: string,
+  token: string | null,
+  filename: string,
+  bytes: Uint8Array,
+  contentType = "application/octet-stream",
+): Promise<Response> {
+  return SELF.fetch(`http://ap.test/api/channels/${slug}/attachments?filename=${encodeURIComponent(filename)}`, {
+    method: "POST",
+    headers: {
+      ...(token ? { authorization: `Bearer ${token}` } : {}),
+      "content-type": contentType,
+    },
+    body: bytes,
+  });
+}
+
+function download(slug: string, token: string | null, path: string): Promise<Response> {
+  return SELF.fetch(`http://ap.test/api/channels/${slug}/attachments/${path}`, {
+    headers: token ? { authorization: `Bearer ${token}` } : {},
+  });
+}
+
+describe("channel attachments (R2)", () => {
+  it("uploads a blob to R2 and returns metadata", async () => {
+    const { token } = await seedToken("agent", uniq("owner"), { owner: "owner@ap.test" });
+    const slug = await createChannel(token);
+    const bytes = new TextEncoder().encode("hello attachment world");
+    const res = await upload(slug, token, "note.txt", bytes, "text/plain");
+    expect(res.status).toBe(201);
+    const meta = (await res.json()) as {
+      key: string;
+      filename: string;
+      content_type: string;
+      size: number;
+      url: string;
+    };
+    expect(meta.filename).toBe("note.txt");
+    expect(meta.content_type).toBe("text/plain");
+    expect(meta.size).toBe(bytes.byteLength);
+    // key 锚定到频道 slug 前缀，隔离跨频道读取
+    expect(meta.key.startsWith(`${slug}/`)).toBe(true);
+    expect(meta.key.endsWith("/note.txt")).toBe(true);
+    // url 是回 worker 的鉴权下载路径，不是裸 R2 公链
+    expect(meta.url.startsWith(`/api/channels/${slug}/attachments/`)).toBe(true);
+    expect(meta.url).not.toContain("r2.cloudflarestorage");
+  });
+
+  it("streams the stored blob back with auth and correct content-type", async () => {
+    const { token } = await seedToken("agent", uniq("owner"), { owner: "owner@ap.test" });
+    const slug = await createChannel(token);
+    const bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1, 2, 3]);
+    const meta = (await (await upload(slug, token, "pic.png", bytes, "image/png")).json()) as { url: string };
+    const res = await download(slug, token, meta.url.split("/attachments/")[1]!);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("image/png");
+    const got = new Uint8Array(await res.arrayBuffer());
+    expect([...got]).toEqual([...bytes]);
+  });
+
+  it("rejects upload without a valid token (401)", async () => {
+    const { token } = await seedToken("agent", uniq("owner"), { owner: "owner@ap.test" });
+    const slug = await createChannel(token);
+    const res = await upload(slug, null, "x.txt", new TextEncoder().encode("x"), "text/plain");
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects download from a non-member of a private channel (403)", async () => {
+    const { token } = await seedToken("agent", uniq("owner"), { owner: "owner@ap.test" });
+    const slug = await createChannel(token); // private by default
+    const bytes = new TextEncoder().encode("secret");
+    const meta = (await (await upload(slug, token, "s.txt", bytes, "text/plain")).json()) as { url: string };
+    const objectPath = meta.url.split("/attachments/")[1]!;
+    // 陌生账号 token：非房主、非成员 → 私有频道禁读
+    const { token: intruder } = await seedToken("agent", uniq("intruder"), { owner: "intruder@ap.test" });
+    const res = await download(slug, intruder, objectPath);
+    expect(res.status).toBe(403);
+    // 无 token → 401
+    expect((await download(slug, null, objectPath)).status).toBe(401);
+  });
+
+  it("rejects an oversize upload (413)", async () => {
+    const { token } = await seedToken("agent", uniq("owner"), { owner: "owner@ap.test" });
+    const slug = await createChannel(token);
+    // 26MB > 25MB cap
+    const big = new Uint8Array(26 * 1024 * 1024);
+    const res = await upload(slug, token, "big.bin", big, "application/octet-stream");
+    expect(res.status).toBe(413);
+  });
+
+  it("round-trips attachment refs on a message", async () => {
+    const { token } = await seedToken("agent", uniq("owner"), { owner: "owner@ap.test" });
+    const slug = await createChannel(token);
+    const bytes = new TextEncoder().encode("attach me");
+    const meta = (await (await upload(slug, token, "doc.pdf", bytes, "application/pdf")).json()) as {
+      key: string;
+      filename: string;
+      content_type: string;
+      size: number;
+      url: string;
+    };
+    const send = await api(`/api/channels/${slug}/messages`, token, {
+      method: "POST",
+      body: JSON.stringify({
+        kind: "message",
+        body: "see attached",
+        mentions: [],
+        reply_to: null,
+        attachments: [meta],
+      }),
+    });
+    expect(send.status).toBe(200);
+
+    const list = await api(`/api/channels/${slug}/messages`, token);
+    expect(list.status).toBe(200);
+    const { messages } = (await list.json()) as { messages: MsgFrame[] };
+    const msg = messages.find((m) => m.body === "see attached");
+    expect(msg).toBeDefined();
+    expect(msg?.attachments).toHaveLength(1);
+    expect(msg?.attachments?.[0]).toMatchObject({
+      key: meta.key,
+      filename: "doc.pdf",
+      content_type: "application/pdf",
+      size: bytes.byteLength,
+      url: meta.url,
+    });
+  });
+});

--- a/worker/vitest.config.ts
+++ b/worker/vitest.config.ts
@@ -23,6 +23,8 @@ export default defineWorkersConfig(async () => {
       durable_objects: { bindings: [{ name: "CHANNELS", class_name: "ChannelDO" }] },
       migrations: [{ tag: "v1", new_sqlite_classes: ["ChannelDO"] }],
       assets: { directory: assetsDir, binding: "ASSETS", run_worker_first: ["/api/*", "/openapi.json"] },
+      // vitest-pool-workers 下 miniflare 会为每个声明的 r2 bucket 自动起一个内存 R2，无需真实账号
+      r2_buckets: [{ binding: "ATTACHMENTS", bucket_name: "agentparty-attachments-test" }],
       d1_databases: [
         {
           binding: "DB",

--- a/worker/worker-configuration.d.ts
+++ b/worker/worker-configuration.d.ts
@@ -4,6 +4,7 @@
 interface __BaseEnv_Env {
 	DB: D1Database;
 	CHANNELS: DurableObjectNamespace<import("./src/index").ChannelDO>;
+	ATTACHMENTS: R2Bucket;
 }
 declare namespace Cloudflare {
 	interface GlobalProps {

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -33,6 +33,14 @@
       "migrations_dir": "migrations"
     }
   ],
+  // 频道附件（#176）：图片/文件走 R2。部署前运营需先建桶：
+  //   wrangler r2 bucket create agentparty-attachments
+  "r2_buckets": [
+    {
+      "binding": "ATTACHMENTS",
+      "bucket_name": "agentparty-attachments"
+    }
+  ],
   "routes": [
     {
       "pattern": "agentparty.leeguoo.com",

--- a/worker/wrangler.xdream.jsonc
+++ b/worker/wrangler.xdream.jsonc
@@ -35,6 +35,14 @@
       "migrations_dir": "migrations"
     }
   ],
+  // 频道附件（#176）：图片/文件走 R2。部署前运营需先建桶（xdream 账号）：
+  //   wrangler r2 bucket create agentparty-attachments-xdream
+  "r2_buckets": [
+    {
+      "binding": "ATTACHMENTS",
+      "bucket_name": "agentparty-attachments-xdream"
+    }
+  ],
   "routes": [
     {
       "pattern": "agentparty.pwtk-dev.work",


### PR DESCRIPTION
## 做什么（#176，owner 2026-07-11 拍板「R2 存，消息带附件引用」）

频道支持发**图片 + 任意文件**：blob 进 Cloudflare R2，消息只带附件引用（key/filename/type/size/url），前端渲染（图片内联缩略图、其它文件下载链接）。

## ⚠️ 部署前必做（否则 worker 绑不上 ATTACHMENTS，起不来）
两套账号各建桶（binding `ATTACHMENTS` 已加进两份 wrangler）：
```
wrangler r2 bucket create agentparty-attachments            # prod（wrangler.jsonc）
wrangler r2 bucket create agentparty-attachments-xdream     # xdream 账号（wrangler.xdream.jsonc）
```
测试无需真桶：vitest-pool-workers 从 r2_buckets 配置自动起内存 R2。

## 端点 + 鉴权
- `POST /api/channels/:slug/attachments?filename=<name>`：body=raw blob。鉴权=可访问该频道的**非 readonly** token + 非归档。`filename` 单路径段校验（`^[^/\\控制字符]{1,255}$`）。size 双挡（Content-Length 预挡 + 实际字节）→ 413，上限 25 MiB。key=`<slug>/<uuid>/<filename>`。返回元数据 201。
- `GET /api/channels/:slug/attachments/:path{.+}`：同频道读鉴权，从 R2 流式回传，`nosniff`。**key 用权威 slug 前缀重拼、拒 `..`/前导 `/`**——伪造跨频道引用读不到别人的 blob；绝不暴露裸 R2 公链。

## 持久化
`shared` 加 `Attachment` 类型 + `SendMessageFrame.attachments?`/`MsgFrame.attachments?`。DO-sqlite `messages.attachments_json`（onStart 幂等 ALTER 补列，非 D1 迁移）。`parseAttachments` 结构校验（≤20/条，字段长度上限），撤回消息时丢弃附件。WS + REST 两条 send 路径都过。

## 门禁（我逐行审 + 对 origin 提交复验）
- worker attachments spec 6/6；全量 worker 342（1 条无关 flaky #43/#48，隔离单跑过）。
- web 全量 429/0、`tsc` 0、`vite build` 0；worker/shared `tsc` 0。
- 变异 5 条各自咬红，含**安全项**：下载端点鉴权守卫短路 → 非成员 403 测试红（我亲跑确认）。

## 评审/运营请确认
1. **建桶是部署阻塞**（上面两条命令，prod + xdream 都要）。
2. 下载端点**从不信任存储的 key/url**，永远用 token 授权的 slug 重拼 R2 key——伪造跨频道引用泄不了别人 blob。请复核这条边界。
3. 发消息时附件元数据只做结构校验、不校验 R2 是否真存在；安全边界在下载端点。确认可接受，还是要 send 时校验 key 属于本频道。
4. `worker-configuration.d.ts` 手加了 `ATTACHMENTS: R2Bucket`，部署时若偏好机器生成可 `wrangler types` 重生。

## 未做（后续）
CLI `party send --attach`、composer 拖拽/进度条、openapi.ts 文档两个新端点。

🤖 实现由 opus agent 完成、经我逐行审（重点鉴权/路径/size）+ 对 origin 提交复验；走 PR 由 @leeguooooo / LEO-MAIN 审 + 运营建桶后合，未自合。
