### PR TITLE
feat(#280): 系统公告与通知悬停看全文

### DIFF
--- a/web/src/components/MentionToast.test.tsx
+++ b/web/src/components/MentionToast.test.tsx
@@ -1,0 +1,81 @@
+// @ts-expect-error Bun executes this test, while the web tsconfig intentionally loads only Vite globals.
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { LocaleProvider } from "../i18n/locale";
+import { MentionToast, type MentionToastItem } from "./MentionToast";
+
+function memoryStorage(seed: Record<string, string> = {}): Storage {
+  const values = new Map<string, string>(Object.entries(seed));
+  return {
+    getItem: (k) => values.get(k) ?? null,
+    setItem: (k, v) => { values.set(k, v); },
+    removeItem: (k) => { values.delete(k); },
+    clear: () => values.clear(),
+    key: (i) => [...values.keys()][i] ?? null,
+    get length() { return values.size; },
+  };
+}
+
+let renderer: ReactTestRenderer | null = null;
+beforeEach(() => {
+  Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", { configurable: true, value: true });
+  Object.defineProperty(globalThis, "localStorage", { configurable: true, value: memoryStorage({ ap_locale: "en" }) });
+  // ToastCard 的 useEffect 用 window.setTimeout；bun test 无 DOM window，指向 globalThis 的定时器。
+  Object.defineProperty(globalThis, "window", { configurable: true, value: globalThis });
+});
+afterEach(async () => {
+  if (renderer !== null) await act(async () => renderer?.unmount());
+  renderer = null;
+  Reflect.deleteProperty(globalThis, "localStorage");
+  Reflect.deleteProperty(globalThis, "window");
+});
+
+// 找到 className 含 target 的第一个节点，返回其 props
+function findByClass(node: unknown, target: string): Record<string, unknown> | null {
+  if (node === null || typeof node !== "object") return null;
+  const n = node as { props?: Record<string, unknown>; children?: unknown };
+  const cls = n.props?.className;
+  if (typeof cls === "string" && cls.split(" ").includes(target)) return n.props!;
+  const kids = n.children;
+  if (Array.isArray(kids)) {
+    for (const k of kids) { const hit = findByClass(k, target); if (hit) return hit; }
+  } else if (kids) {
+    const hit = findByClass(kids, target); if (hit) return hit;
+  }
+  return null;
+}
+
+describe("MentionToast 悬停看全文 (#280)", () => {
+  test("toast body 把完整正文挂到 title 上（body 只显截断预览）", () => {
+    const item: MentionToastItem = {
+      seq: 1,
+      sender: { name: "alice", kind: "agent" },
+      body: "这是截断的预览…",
+      fullBody: "这是完整的很长很长的正文，悬停时应该能看到全部内容而不是被截断的预览。",
+    };
+    void act(() => {
+      renderer = create(
+        <LocaleProvider>
+          <MentionToast items={[item]} channel="dev" identityDisplay={{}} onJump={() => {}} onDismiss={() => {}} />
+        </LocaleProvider>,
+      );
+    });
+    const bodyProps = findByClass(renderer!.toJSON(), "mention-toast-body");
+    expect(bodyProps).not.toBeNull();
+    // #280 核心：完整正文挂在 title 上（悬停可见），可见文本仍是截断预览
+    expect(bodyProps!.title).toBe(item.fullBody);
+  });
+
+  test("缺 fullBody 时 title 回退到 body（向后兼容）", () => {
+    const item: MentionToastItem = { seq: 2, sender: { name: "bob", kind: "agent" }, body: "short" };
+    void act(() => {
+      renderer = create(
+        <LocaleProvider>
+          <MentionToast items={[item]} channel="dev" identityDisplay={{}} onJump={() => {}} onDismiss={() => {}} />
+        </LocaleProvider>,
+      );
+    });
+    const bodyProps = findByClass(renderer!.toJSON(), "mention-toast-body");
+    expect(bodyProps!.title).toBe("short");
+  });
+});

--- a/web/src/components/MentionToast.tsx
+++ b/web/src/components/MentionToast.tsx
@@ -10,6 +10,7 @@ export interface MentionToastItem {
   seq: number;
   sender: Sender; // 原始发送者，渲染时经 resolveSenderLabel 解析显示名，保证与消息卡一致
   body: string;   // 已截断的正文预览
+  fullBody?: string; // #280：完整正文，挂到 title 上供悬停看全文（缺省回退到 body）
 }
 
 interface Props {
@@ -60,7 +61,7 @@ function ToastCard({
           onKeyDown={(e) => e.stopPropagation()}
         >×</button>
       </div>
-      <div className="mention-toast-body">{item.body}</div>
+      <div className="mention-toast-body" title={(item.fullBody ?? item.body) || undefined}>{item.body}</div>
     </div>
   );
 }

--- a/web/src/components/MessageCard.tsx
+++ b/web/src/components/MessageCard.tsx
@@ -252,9 +252,12 @@ export function MessageCard({
       blockedReason !== null && !blockedIsDupOfNote ? `blocked ${blockedReason}` : null,
       msg.status?.summary_seq !== null && msg.status?.summary_seq !== undefined ? `summary #${msg.status.summary_seq}` : null,
     ].filter((part): part is string => typeof part === "string" && part !== "");
+    // #280：系统公告/状态在时间线里只显示紧凑摘要，长内容会被 CSS 截断。把完整内容
+    // （note/scope/blocked/summary + workflow 详情）挂到原生 title 上，鼠标悬停即可看全文。
+    const statusFullDetail = [statusBits.join(" · "), statusTitle].filter((part) => part !== "").join("\n");
     return (
       <div id={`msg-${msg.seq}`} className="msg-status" data-state={msg.state ?? undefined} style={hueStyle}>
-        <span>
+        <span title={statusFullDetail !== "" ? statusFullDetail : undefined}>
           <span className="msg-sender" title={senderTitle}>{senderLabel}</span>
           {owner !== null && (
             <span className="t-mono msg-owner" title={`owner: ${owner}`}>

--- a/web/src/pages/Channel.tsx
+++ b/web/src/pages/Channel.tsx
@@ -2119,6 +2119,7 @@ export function ChannelPage({
                   seq: frame.seq,
                   sender: frame.sender, // 存原始 sender，渲染时用 resolveSenderLabel 解析，与消息卡显示保持一致
                   body: summarizeReplyPreview(frame.body),
+                  fullBody: frame.body, // #280：完整正文，供 toast 悬停看全文
                 },
               ].slice(-3),
             );


### PR DESCRIPTION
频道身份：网页 leo（owner）。#280：系统公告和通知只显摘要/截断，悬停应能看完整内容。

给两处挂原生 title，鼠标悬停即见全文：
- **系统公告**（MessageCard `.msg-status`）：title = note/scope/blocked/summary + workflow 详情全文。
- **被@ toast**（MentionToast）：新增 `fullBody`（Channel 传 `frame.body`），可见处仍显截断预览，title 显全文；缺省回退到 body（向后兼容）。

纯 web、声明式属性，不碰后端。测试：MentionToast fullBody→title + 回退 2/2；check:web 426/426，vite build 通过。

Closes #280.

https://claude.ai/code/session_01PgxkZeqJmDge3dYe9W2tPZ