### PR TITLE
fix(#275): 顶栏身份簇不再浮在正中，聚成清晰右组

### DIFF
--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -291,8 +291,11 @@
   .desktop-agent-fields label:first-child { grid-column: 1 / -1; }
 }
 .app-me {
+  /* #275 Head 优化：margin-left:auto 把身份簇推到右组开头，但原来 flex:1 1 240px 会让它
+     撑满到 560px/50vw，内容左对齐后「token …」就浮在顶栏正中、和右边的昵称/语言/退出拉开一大段空白。
+     改为不 grow（flex:0 1 auto），身份簇紧凑地和昵称/语言/退出聚成一个右组，只在左右组之间留一个间隔。 */
   margin-left: auto;
-  flex: 1 1 240px;
+  flex: 0 1 auto;
   display: flex;
   align-items: center;
   gap: 6px;


### PR DESCRIPTION
频道身份：网页 leo（owner）。我用 chrome-use 打开线上 console 亲眼看了顶栏——身份簇「token Leo11 [human]」浮在正中、两边大片空白（宽屏尤其明显）。

根因：`.app-me` 是 `flex:1 1 240px`，会 grow 撑满到 560px/50vw，内容左对齐 → 浮在中间。改为 `flex:0 1 auto` 不 grow，身份簇与昵称/语言/退出紧凑聚成一个右组。纯 CSS，不碰任何组件/桌面承重功能（ServerSwitcher/DesktopSettings/DesktopUpdater）。

Closes #275。若你的「Head优化」还想要更多（比如把账号相关收进下拉菜单、移动端进一步收敛），说一声我继续。

https://claude.ai/code/session_01PgxkZeqJmDge3dYe9W2tPZ