### PR TITLE
feat(worker,web,cli): agent 全局唯一昵称 + @中文昵称服务端解析唤醒（#165）

### DIFF
--- a/cli/src/commands/nickname.ts
+++ b/cli/src/commands/nickname.ts
@@ -1,0 +1,76 @@
+// party nickname <名字> — agent 设自己的全局唯一昵称（#165），设完别人就能 @中文昵称 唤醒你。
+// 走 PUT /api/me/nickname；仅 agent token 可用（human 用网页设 @handle，readonly 不能设）。
+import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
+import { RestError, setNickname } from "../rest";
+import { resolveAuth } from "../oidc-cli";
+
+// 与后端 NICKNAME_RE 对齐：任意 unicode 字母/数字开头，后随 ._- ，总长 1–64。
+const NICKNAME_RE = /^[\p{L}\p{N}][\p{L}\p{N}._-]{0,63}$/u;
+const NICKNAME_FLAGS = ["server"];
+const HELP = `usage: party nickname <name>
+
+Set your agent's globally-unique nickname (可中文). Others @mention it to wake you.
+
+Example:
+  party nickname 小助手
+
+Notes:
+  - agent session only (humans set an @handle on the web; readonly can't set one)
+  - unicode ok (中文); starts with a letter/digit, then . _ - ; up to 64 chars
+  - must be globally unique across handles, token names, and other nicknames`;
+
+export async function run(argv: string[]): Promise<number> {
+  if (isHelpArg(argv, { allowHelpPositional: true })) {
+    console.log(HELP);
+    return 0;
+  }
+  const { positionals, flags } = parseArgs(argv);
+  const unknown = unknownFlagError(flags, NICKNAME_FLAGS);
+  if (unknown !== null) {
+    console.error(unknown);
+    return 1;
+  }
+  const flagError = valueFlagError(flags, ["server"]);
+  if (flagError !== null) {
+    console.error(flagError);
+    return 1;
+  }
+  const nickname = (positionals[0] ?? "").trim();
+  if (nickname === "") {
+    console.error("usage: party nickname <name>  (e.g. party nickname 小助手)");
+    return 1;
+  }
+  if (!NICKNAME_RE.test(nickname)) {
+    console.error("invalid nickname: no spaces or @, start with a letter/digit, then . _ - , up to 64 chars");
+    return 1;
+  }
+  const auth = await resolveAuth();
+  if (!auth) {
+    console.error("no config, run: party login or party init --server URL --token T");
+    return 1;
+  }
+  try {
+    const res = await setNickname(auth.server, auth.token, nickname);
+    console.log(`nickname set: ${res.nickname}  — others can now wake you with @${res.nickname}`);
+    return 0;
+  } catch (e) {
+    if (e instanceof RestError) {
+      if (e.status === 409) {
+        console.error(`nickname "${nickname}" is already taken (${e.code ?? "conflict"}) — pick another`);
+        return 1;
+      }
+      if (e.status === 403) {
+        console.error("only an agent session can set a nickname (humans set an @handle on the web)");
+        return 1;
+      }
+      if (e.status === 400) {
+        console.error(`invalid nickname: ${e.message}`);
+        return 1;
+      }
+      console.error(`error: ${e.code ?? e.status} ${e.message}`);
+      return 1;
+    }
+    console.error(`nickname failed: ${e instanceof Error ? e.message : String(e)}`);
+    return 1;
+  }
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -14,6 +14,7 @@ commands:
   login     [--server URL]                          browser sign-in, store account session (human)
   logout                                             clear account session
   whoami    [--json] [--caps]                         print current identity + capabilities (hits /api/me)
+  nickname  <name>                                    set your agent's globally-unique nickname (可中文); others @it to wake you
   agent     add <name> [--channel-scope slug] | create <handle> --runner codex|claude|codex-sdk|shell [--invitable-by owner|org|anyone] | list
   spawn     <worker> --channel-scope slug [--ttl 2h] create a short-lived worker from the front agent
   init      --server URL --token T [--channel C]   write config, bind channel (create if missing)
@@ -68,6 +69,8 @@ export async function main(argv: string[]): Promise<number> {
       return (await import("./commands/logout")).run(rest);
     case "whoami":
       return (await import("./commands/whoami")).run(rest);
+    case "nickname":
+      return (await import("./commands/nickname")).run(rest);
     case "agent":
       return (await import("./commands/agent")).run(rest);
     case "spawn":

--- a/cli/src/rest.ts
+++ b/cli/src/rest.ts
@@ -250,6 +250,15 @@ export async function fetchMe(server: string, token: string): Promise<Identity> 
   return (await req(server, "/api/me", { headers: bearerJson(token) })) as Identity;
 }
 
+// #165：agent 设自己的全局唯一昵称（可被 @中文昵称 唤醒）。须 agent token 作 bearer。
+export async function setNickname(server: string, token: string, nickname: string): Promise<{ nickname: string }> {
+  return (await req(server, "/api/me/nickname", {
+    method: "PUT",
+    headers: bearerJson(token),
+    body: JSON.stringify({ nickname }),
+  })) as { nickname: string };
+}
+
 // 账号自助铸 agent token（spec P3）：须账号会话作 bearer，owner 由 worker 从会话推导
 export async function createAgent(
   server: string,

--- a/cli/test/nickname.test.ts
+++ b/cli/test/nickname.test.ts
@@ -1,0 +1,48 @@
+// #165：party nickname <name> —— agent 设全局唯一昵称。这里只覆盖联网前的纯参数校验路径
+// （help / 空 / 格式非法），不打网络；set 成功/冲突走 worker 集成测试（nickname.spec.ts）。
+import { describe, expect, test } from "bun:test";
+import { run } from "../src/commands/nickname";
+
+function capture(fn: () => Promise<number>): Promise<{ code: number; out: string[]; err: string[] }> {
+  const out: string[] = [];
+  const err: string[] = [];
+  const origLog = console.log;
+  const origErr = console.error;
+  console.log = (...a: unknown[]) => out.push(a.join(" "));
+  console.error = (...a: unknown[]) => err.push(a.join(" "));
+  return fn()
+    .then((code) => ({ code, out, err }))
+    .finally(() => {
+      console.log = origLog;
+      console.error = origErr;
+    });
+}
+
+describe("party nickname 参数校验（#165）", () => {
+  test("--help 打印用法并 exit 0", async () => {
+    const { code, out } = await capture(() => run(["--help"]));
+    expect(code).toBe(0);
+    expect(out.join("\n")).toContain("party nickname <name>");
+  });
+
+  test("缺名字 → exit 1", async () => {
+    const { code, err } = await capture(() => run([]));
+    expect(code).toBe(1);
+    expect(err.join("\n")).toContain("usage: party nickname");
+  });
+
+  test("含空格/@ 的非法昵称在联网前就被挡下 → exit 1", async () => {
+    const spaced = await capture(() => run(["中 文"]));
+    expect(spaced.code).toBe(1);
+    expect(spaced.err.join("\n")).toContain("invalid nickname");
+    const atSign = await capture(() => run(["foo@bar"]));
+    expect(atSign.code).toBe(1);
+    expect(atSign.err.join("\n")).toContain("invalid nickname");
+  });
+
+  test("超长（>64）昵称被挡下 → exit 1", async () => {
+    const { code, err } = await capture(() => run(["字".repeat(65)]));
+    expect(code).toBe(1);
+    expect(err.join("\n")).toContain("invalid nickname");
+  });
+});

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -255,7 +255,7 @@ export interface Sender {
   /** 所属人：机器 ap_ token 铸造时写入的标签，人类 OIDC token 为其 email。无则省略（旧客户端忽略） */
   owner?: string;
   lineage?: AgentLineage;
-  /** 人类全局唯一昵称（可@别名）。仅人类且已设置时下发；agent/未设置省略。旧客户端忽略。 */
+  /** 全局唯一昵称（可@别名）。人类=account handle，agent=自设 nickname（#165）；已设置才下发，未设置省略。旧客户端忽略。 */
   handle?: string;
   /** OAuth/SSO profile display name. Optional; clients fall back to handle/owner/name. */
   display_name?: string;
@@ -287,7 +287,7 @@ export interface PresenceEntry {
   wake?: WakeInfo;
   context?: AgentContext;
   lineage?: AgentLineage;
-  /** 人类全局唯一昵称（可@别名）。仅人类且已设置时下发；旧客户端忽略。 */
+  /** 全局唯一昵称（可@别名）。人类=account handle，agent=自设 nickname（#165）；已设置才下发，未设置省略。旧客户端忽略。 */
   handle?: string;
   /** OAuth/SSO profile display name. Optional; clients fall back to handle/account/name. */
   display_name?: string;
@@ -1046,7 +1046,7 @@ export interface PresenceFrame {
   wake?: WakeInfo;
   context?: AgentContext;
   lineage?: AgentLineage;
-  /** 人类全局唯一昵称（可@别名）。仅人类且已设置时下发；旧客户端忽略。 */
+  /** 全局唯一昵称（可@别名）。人类=account handle，agent=自设 nickname（#165）；已设置才下发，未设置省略。旧客户端忽略。 */
   handle?: string;
   display_name?: string;
   avatar_url?: string;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -791,7 +791,8 @@ export function App() {
   // 建频道入口只给能建的人（登录人类、非分享只读）；scoped agent token 铸不了频道
   const canCreate = !isShareMode() && me?.role === "human";
   // 设置/修改 @handle 只给登录人类账号（agent token 会话、分享只读链接都不显示，Task B2）
-  const canSetHandle = !isShareMode() && me?.role === "human";
+  // #165：人类设 @handle，agent 会话设昵称——都走同一入口/浮层，只是 mode 不同。readonly/分享态不给设。
+  const canSetHandle = !isShareMode() && (me?.role === "human" || me?.role === "agent");
   const channelPending = slug !== null && channels === null && listError === null;
   const unknownChannel =
     slug !== null && channels !== null && !channels.some((c) => c.slug === slug);
@@ -856,6 +857,7 @@ export function App() {
           <div className="handlesetup-panel" style={handlePanelStyle}>
             <HandleSetup
               current={me.handle}
+              mode={me.kind === "agent" ? "nickname" : "handle"}
               onSaved={(handle) => {
                 setMe((prev) => (prev ? { ...prev, handle } : prev));
                 setHandleSetupOpen(false);

--- a/web/src/components/HandleSetup.tsx
+++ b/web/src/components/HandleSetup.tsx
@@ -1,61 +1,78 @@
-// 人类账号设置/修改 @handle（Task B2）。纯表单：输入 + 保存 + 内联错误行，不含自己的开关按钮/
+// 自助设置/修改可@别名（Task B2 + #165）。纯表单：输入 + 保存 + 内联错误行，不含自己的开关按钮/
 // 定位逻辑——由调用方（App.tsx 的 me chip 入口）决定何时挂载、挂在哪。
+// mode="handle"：人类账号 @handle（ASCII，2–32）；mode="nickname"：agent 昵称（可中文，1–64，#165）。
 import { useCallback, useState } from "react";
-import { AuthError, ConflictError, ForbiddenError, setHandle, ValidationError } from "../lib/api";
+import {
+  AuthError,
+  ConflictError,
+  ForbiddenError,
+  setHandle,
+  setNickname,
+  ValidationError,
+} from "../lib/api";
 import { useT } from "../i18n/useT";
 import "../i18n/strings/HandleSetup";
 
-// spec：字母/数字开头，后随字母/数字/._- ，总长 2–32；大小写原样保留显示，唯一性由后端按不分大小写判定
+// handle：字母/数字开头，后随字母/数字/._- ，总长 2–32（唯一性后端不分大小写）。
 const HANDLE_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]{1,31}$/;
+// nickname：首字为任意 unicode 字母/数字（含中文），后随 ._- ，总长 1–64（与后端 NICKNAME_RE 对齐）。
+const NICKNAME_RE = /^[\p{L}\p{N}][\p{L}\p{N}._-]{0,63}$/u;
 
 interface Props {
   current: string | null;
-  onSaved(handle: string): void;
+  mode?: "handle" | "nickname";
+  onSaved(value: string): void;
   onClose?(): void;
 }
 
-export function HandleSetup({ current, onSaved, onClose }: Props) {
+export function HandleSetup({ current, mode = "handle", onSaved, onClose }: Props) {
   const t = useT();
+  const nick = mode === "nickname";
   const [value, setValue] = useState(current ?? "");
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
 
   const trimmed = value.trim();
-  const formatOk = HANDLE_RE.test(trimmed);
+  const formatOk = (nick ? NICKNAME_RE : HANDLE_RE).test(trimmed);
+  // 键前缀：nickname 模式用 HandleSetup.nick.*，缺省回退到通用键（save/saving/cancel 等共用）。
+  const s = (key: string) => t(nick ? `HandleSetup.nick.${key}` : `HandleSetup.${key}`);
 
   const submit = useCallback(async () => {
     if (!formatOk || busy) return;
     setErr(null);
     setBusy(true);
     try {
-      const res = await setHandle(trimmed);
+      const saved = nick ? (await setNickname(trimmed)).nickname : (await setHandle(trimmed)).handle;
       setBusy(false);
-      onSaved(res.handle);
+      onSaved(saved);
     } catch (e) {
       setBusy(false);
       setErr(
         e instanceof ConflictError
-          ? t("HandleSetup.errConflict")
+          ? s("errConflict")
           : e instanceof ValidationError
-            ? t("HandleSetup.errValidation")
+            ? s("errValidation")
             : e instanceof ForbiddenError
-              ? t("HandleSetup.errForbidden")
+              ? s("errForbidden")
               : e instanceof AuthError
                 ? t("HandleSetup.errGeneric")
                 : t("HandleSetup.errGeneric"),
       );
     }
-  }, [formatOk, busy, trimmed, onSaved, t]);
+  }, [formatOk, busy, nick, trimmed, onSaved, t]);
 
   return (
     <div className="handlesetup">
-      <p className="handlesetup-title">{t("HandleSetup.title")}</p>
+      <p className="handlesetup-title">{nick ? t("HandleSetup.nick.title") : t("HandleSetup.title")}</p>
+      {nick && current === null && trimmed.length === 0 && (
+        <p className="handlesetup-empty">{t("HandleSetup.nick.empty")}</p>
+      )}
       <input
         className="t-mono handlesetup-input"
         value={value}
         autoFocus
         spellCheck={false}
-        placeholder={t("HandleSetup.placeholder")}
+        placeholder={nick ? t("HandleSetup.nick.placeholder") : t("HandleSetup.placeholder")}
         onChange={(e) => setValue(e.target.value)}
         onKeyDown={(e) => {
           if (e.key === "Enter") void submit();
@@ -64,7 +81,7 @@ export function HandleSetup({ current, onSaved, onClose }: Props) {
         disabled={busy}
       />
       {value.trim().length > 0 && !formatOk && (
-        <p className="handlesetup-hint">{t("HandleSetup.formatHint")}</p>
+        <p className="handlesetup-hint">{nick ? t("HandleSetup.nick.formatHint") : t("HandleSetup.formatHint")}</p>
       )}
       {err !== null && (
         <p className="banner banner--red handlesetup-err" role="alert">

--- a/web/src/i18n/strings/HandleSetup.ts
+++ b/web/src/i18n/strings/HandleSetup.ts
@@ -12,6 +12,13 @@ export const HandleSetupStrings: LocaleDict = {
     "HandleSetup.errValidation": "Invalid handle format",
     "HandleSetup.errForbidden": "Only human accounts can set a handle",
     "HandleSetup.errGeneric": "Couldn't save, try again shortly",
+    "HandleSetup.nick.title": "Nickname",
+    "HandleSetup.nick.placeholder": "nickname (中文 ok, e.g. 小助手)",
+    "HandleSetup.nick.formatHint": "letters/digits (any language, incl. 中文) then ._- , up to 64 chars — others @mention you by this",
+    "HandleSetup.nick.errConflict": "That nickname is already taken — try another",
+    "HandleSetup.nick.errValidation": "Invalid nickname: no spaces or @, must start with a letter or digit",
+    "HandleSetup.nick.errForbidden": "Only an agent session can set a nickname",
+    "HandleSetup.nick.empty": "No nickname yet — set one so others can @you.",
   },
   zh: {
     "HandleSetup.title": "显示名",
@@ -24,6 +31,13 @@ export const HandleSetupStrings: LocaleDict = {
     "HandleSetup.errValidation": "显示名格式不合法",
     "HandleSetup.errForbidden": "只有人类账号能设置显示名",
     "HandleSetup.errGeneric": "保存失败，请稍后重试",
+    "HandleSetup.nick.title": "昵称",
+    "HandleSetup.nick.placeholder": "昵称（可中文，如 小助手）",
+    "HandleSetup.nick.formatHint": "字母/数字（含中文）开头，后随 ._- ，最长 64 位——别人靠它 @ 你",
+    "HandleSetup.nick.errConflict": "该昵称已被占用，换一个试试",
+    "HandleSetup.nick.errValidation": "昵称不合法：不能含空格或 @，须以字母或数字开头",
+    "HandleSetup.nick.errForbidden": "只有 agent 会话能设置昵称",
+    "HandleSetup.nick.empty": "还没设昵称——设一个，别人就能 @ 你了。",
   },
 };
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -622,6 +622,24 @@ export async function setHandle(handle: string): Promise<{ handle: string }> {
   return (await res.json()) as { handle: string };
 }
 
+// #165：agent 会话设置昵称（PUT /api/me/nickname）：400 格式非法 / 403 非 agent / 409 冲突。
+// 与 setHandle 同形，只是别名可含 unicode（中文），后端 nicknameConflict 判全局唯一。
+export async function setNickname(nickname: string): Promise<{ nickname: string }> {
+  const token = getToken();
+  if (token === null) throw new AuthError("missing token");
+  const res = await fetchApi("/api/me/nickname", {
+    method: "PUT",
+    headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+    body: JSON.stringify({ nickname }),
+  });
+  if (res.status === 401) throw new AuthError("invalid or revoked token");
+  if (res.status === 403) throw new ForbiddenError("forbidden");
+  if (res.status === 400) throw new ValidationError("invalid nickname");
+  if (res.status === 409) throw new ConflictError("nickname unavailable");
+  if (!res.ok) throw new Error(`PUT /api/me/nickname failed (${res.status})`);
+  return (await res.json()) as { nickname: string };
+}
+
 export async function fetchChannelCharter(token: string, slug: string): Promise<ChannelCharter> {
   const res = await fetchApi(`/api/channels/${encodeURIComponent(slug)}/charter`, {
     headers: { authorization: `Bearer ${token}` },

--- a/web/src/lib/identityDisplay.ts
+++ b/web/src/lib/identityDisplay.ts
@@ -65,20 +65,20 @@ export function buildIdentityDisplay(input: {
 }): IdentityDisplayMap {
   const map: IdentityDisplayMap = {};
 
-  // 显示优先级：人类 handle > SSO display name > owner/account（email）> 原始 name。
-  // agent 恒无 handle，天然回退 name，不受影响。map 的 key 仍是原始 name/UUID，不受此优先级影响。
+  // 显示优先级：handle（人类=account handle，agent=自设昵称 #165）> SSO display name > owner/account（email）> 原始 name。
+  // agent 有昵称就显示昵称，没有则天然回退 name。map 的 key 仍是原始 name/UUID，不受此优先级影响。
   for (const sender of input.participants) {
     addIdentity(map, sender.name, {
       kind: sender.kind,
       account: sender.owner,
-      display: sender.kind === "human" ? sender.handle || sender.display_name || sender.owner || sender.name : sender.name,
+      display: sender.handle || (sender.kind === "human" ? sender.display_name || sender.owner : undefined) || sender.name,
     });
   }
   for (const entry of Object.values(input.presence)) {
     addIdentity(map, entry.name, {
       kind: entry.kind,
       account: entry.account,
-      display: entry.kind === "human" ? entry.handle || entry.display_name || entry.account || entry.name : entry.name,
+      display: entry.handle || (entry.kind === "human" ? entry.display_name || entry.account : undefined) || entry.name,
     });
   }
   for (const message of input.messages) {
@@ -86,9 +86,9 @@ export function buildIdentityDisplay(input: {
       kind: message.sender.kind,
       account: message.sender.owner,
       display:
-        message.sender.kind === "human"
-          ? message.sender.handle || message.sender.display_name || message.sender.owner || message.sender.name
-          : message.sender.name,
+        message.sender.handle ||
+        (message.sender.kind === "human" ? message.sender.display_name || message.sender.owner : undefined) ||
+        message.sender.name,
     });
   }
   for (const option of input.mentionOptions) {

--- a/web/src/lib/mentions.test.ts
+++ b/web/src/lib/mentions.test.ts
@@ -310,4 +310,18 @@ describe("parseDraftMentions", () => {
   test("没有 mention 时返回空数组", () => {
     expect(parseDraftMentions("just a plain message")).toEqual([]);
   });
+  // #165：中文昵称
+  test("解析 @中文昵称，且 email 里的 @ 仍不算", () => {
+    expect(parseDraftMentions("@小助手 帮我看下")).toEqual(["小助手"]);
+    expect(parseDraftMentions("hi @程序员小明 and @bob")).toEqual(["程序员小明", "bob"]);
+    expect(parseDraftMentions("mail me@bar.com thanks")).toEqual([]);
+    expect(parseDraftMentions("路人甲@小明")).toEqual([]); // @ 前是中文标识符 → 不当 mention
+  });
+});
+
+describe("activeMentionQuery — 中文昵称补全（#165）", () => {
+  test("打 @中 触发补全下拉", () => {
+    expect(activeMentionQuery("@中", 2)).toEqual({ start: 0, query: "中" });
+    expect(activeMentionQuery("hi @小助", 6)).toEqual({ start: 3, query: "小助" });
+  });
 });

--- a/web/src/lib/mentions.ts
+++ b/web/src/lib/mentions.ts
@@ -33,7 +33,8 @@ const DEAD_MS = 14 * 24 * 60 * 60 * 1000; // 14 天没露面才视为幽灵
 // OIDC 设备验证流 = login-verify-*。过渡期旧 presence 行没回填 kind 时靠名字把它们判为 human。
 const SYSTEM_HUMAN_SESSION_RE =
   /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|login-verify-.+)$/i;
-const NAME_TOKEN_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$/;
+// #165：昵称可含 unicode（中文），故放开首字为任意字母/数字（与后端 NICKNAME_RE 对齐）。
+const NAME_TOKEN_RE = /^[\p{L}\p{N}][\p{L}\p{N}._-]{0,63}$/u;
 
 // 档位：① 在线（当前有 WS 连接） ② 可唤醒（autoWakeReachable 统一口径 #47/#55：
 // serve/watch 需不 stale 且不能是 human_driven，webhook 服务端投递、离线也算） ③ 最近活跃（其余 presence）。
@@ -98,13 +99,13 @@ export function mentionCandidates(
       const identity = identityByName.get(name);
       const assigned = roleByName.get(name);
       const account = identity?.account ?? assigned?.account ?? p?.account;
-      // 人类全局唯一昵称（handle）：有则用它做 @ 插入 token 和显示名——UUID 会话名打不出来，
-      // handle 才能被后端 R5 按 handle 识别为「被 @」。agent 不适用（其 name 本身就是可读 handle）。
+      // 全局唯一昵称（handle）：有则用它做 @ 插入 token 和显示名。人类=account handle（UUID 会话名打不出来，
+      // 只有 handle 能被后端识别为「被 @」）；agent=自设昵称（#165，可中文，其 ASCII name 由后端解析回填）。
       const identityHandle =
         identity?.handle !== undefined && identity.handle !== "" && NAME_TOKEN_RE.test(identity.handle)
           ? identity.handle
           : undefined;
-      const handle = kind === "human" ? (participantByName.get(name)?.handle ?? p?.handle ?? identityHandle) : undefined;
+      const handle = participantByName.get(name)?.handle ?? p?.handle ?? identityHandle;
       // 人类网页会话名是 UUID，显示账号 email 才认得出「是谁」；agent 名本身可读，用 name。
       const display = handle
         ? handle
@@ -168,7 +169,7 @@ export function mentionCandidates(
 // prefix 允许 [a-zA-Z0-9._-]（与 name 字符集一致），@ 前须是行首或空白（不匹配 email 里的 @）。
 export function activeMentionQuery(text: string, caret: number): { start: number; query: string } | null {
   let i = caret - 1;
-  while (i >= 0 && /[a-zA-Z0-9._-]/.test(text[i]!)) i--;
+  while (i >= 0 && /[\p{L}\p{N}._-]/u.test(text[i]!)) i--;
   if (i < 0 || text[i] !== "@") return null;
   if (i > 0 && !/\s/.test(text[i - 1]!)) return null; // @ 前不是空白/行首 → 是 email 之类，不触发
   return { start: i, query: text.slice(i + 1, caret) };
@@ -203,7 +204,9 @@ export function mentionLiveness(
 
 // 从草稿正文里提取 @name（与服务端 BODY_MENTION_RE 一致：@ 前须行首/空白，不吃 email 里的 @）。
 // 去重、保序，供发送前状态条渲染。
-const DRAFT_MENTION_RE = /(^|[^a-zA-Z0-9._@-])@([a-zA-Z0-9][a-zA-Z0-9._-]*)/g;
+// #165：放开为 unicode（含中文昵称）。@ 前的边界字符类同样排除 unicode 字母/数字，@ 前是标识符
+// （含中文）就不当 mention（email/句中 @ 安全）；捕获 token 上界 64（{0,63}）。
+const DRAFT_MENTION_RE = /(^|[^\p{L}\p{N}._@-])@([\p{L}\p{N}][\p{L}\p{N}._-]{0,63})/gu;
 export function parseDraftMentions(text: string): string[] {
   const out: string[] = [];
   const seen = new Set<string>();

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -444,6 +444,8 @@
 }
 .handlesetup-input:focus { outline: none; border-color: var(--t-accent); }
 .handlesetup-hint { margin: 0; font-size: 11px; color: var(--t-dim); }
+/* #165：agent 昵称未设时的空状态提示（比错误行更柔和，引导而非报错） */
+.handlesetup-empty { margin: 0; font-size: 11px; color: var(--t-dim); font-style: italic; }
 .handlesetup-err { margin: 0; }
 .handlesetup-actions { display: flex; justify-content: flex-end; gap: 8px; }
 

--- a/worker/migrations/0027_agent_nicknames.sql
+++ b/worker/migrations/0027_agent_nicknames.sql
@@ -1,0 +1,10 @@
+-- #165：agent 全局唯一昵称（可 @中文昵称 唤醒）。与人类 handle（0014 account_profiles）共用 @ 命名空间。
+-- 按 token name 存（per-identity）——agent 与 human 共享 account，不能像 handle 那样 per-account。
+-- nickname 是显示 + 被@检测别名，不授予任何权限。唯一性大小写不敏感（COLLATE NOCASE，与 handle 一致）。
+CREATE TABLE agent_nicknames (
+  name       TEXT PRIMARY KEY,
+  nickname   TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+CREATE UNIQUE INDEX idx_agent_nicknames_nickname ON agent_nicknames(nickname COLLATE NOCASE);

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -120,6 +120,9 @@ const WAKE_KINDS: readonly string[] = ["none", "watch", "serve", "webhook"];
 const HOST_DECISION_KINDS: readonly string[] = ["decision", "handoff", "takeover"];
 const WORKFLOW_KINDS: readonly string[] = ["pipeline", "parallel", "orchestrator-workers", "evaluator-optimizer"];
 const MENTION_NAME_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$/;
+// #165：mentions 数组现在也能装 unicode @昵称（中文），故用放开首字的 unicode 版校验它；
+// MENTION_NAME_RE 仍保 ASCII，用于 squad / lineage / handoff 这些结构性标识符。
+const MENTION_TOKEN_RE = /^[\p{L}\p{N}][\p{L}\p{N}._-]{0,63}$/u;
 const WORKFLOW_ID_RE = /^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,127}$/;
 const CLIENT_VERSION_RE = /^[0-9A-Za-z][0-9A-Za-z.+-]{0,63}$/;
 const MAX_MENTIONS = 50;
@@ -149,7 +152,7 @@ function parseMentions(input: unknown): string[] | null {
   if (!Array.isArray(input)) return null;
   if (
     input.length > MAX_MENTIONS ||
-    input.some((m) => typeof m !== "string" || !MENTION_NAME_RE.test(m)) ||
+    input.some((m) => typeof m !== "string" || !MENTION_TOKEN_RE.test(m)) ||
     byteLength(JSON.stringify(input)) > MENTIONS_JSON_LIMIT
   ) {
     return null;
@@ -161,7 +164,9 @@ function parseMentions(input: unknown): string[] | null {
 // 数组——若发送方只在正文打 @ 没进数组（裸 party send "@name"），目标永不被唤醒。故服务端
 // 从 body/note 兜底提取并 union 进 mentions，去重、剔除 system、总量截到 MAX_MENTIONS。
 // 误报无害：wake ledger 只投给真实可唤醒目标，无对应者的 @ 不会触发任何投递。
-const BODY_MENTION_RE = /(?:^|\s)@([a-zA-Z0-9][a-zA-Z0-9._-]{0,63})/g;
+// #165：放开首字为 unicode 字母/数字，能捕获 @中文昵称。@ 前仍须行首/空白（不吃 email 的 @），
+// 长度仍上界 64（[\p{L}\p{N}._-]{0,63}）。捕获到的 @昵称 由 resolveNicknameMentions 解析成真实 name。
+const BODY_MENTION_RE = /(?:^|\s)@([\p{L}\p{N}][\p{L}\p{N}._-]{0,63})/gu;
 function mergeBodyMentions(explicit: string[], text: string): string[] {
   const seen = new Set(explicit);
   const out = [...explicit];
@@ -1148,7 +1153,7 @@ export class ChannelDO extends Server<Env> {
       kind: h.get("x-ap-kind") === "agent" ? "agent" : "human",
       role: (h.get("x-ap-role") ?? "readonly") as TokenRole,
       owner: h.get("x-ap-owner") ?? undefined,
-      handle: h.get("x-ap-handle") ?? undefined,
+      handle: decodedHeaderText(h, "x-ap-handle"),
       ...profileFromHeaders(h),
       lineage: lineageFromHeaders(h),
       tokenHash: h.get("x-ap-token-hash") ?? "",
@@ -2024,7 +2029,7 @@ export class ChannelDO extends Server<Env> {
         kind: request.headers.get("x-ap-kind") === "agent" ? "agent" : "human",
         role: (request.headers.get("x-ap-role") ?? "readonly") as TokenRole,
         owner: request.headers.get("x-ap-owner") ?? undefined,
-        handle: request.headers.get("x-ap-handle") ?? undefined,
+        handle: decodedHeaderText(request.headers, "x-ap-handle"),
         ...profileFromHeaders(request.headers),
         lineage: lineageFromHeaders(request.headers),
         tokenHash: request.headers.get("x-ap-token-hash") ?? "",
@@ -2174,7 +2179,7 @@ export class ChannelDO extends Server<Env> {
         kind: request.headers.get("x-ap-kind") === "agent" ? "agent" : "human",
         role: (request.headers.get("x-ap-role") ?? "readonly") as TokenRole,
         owner: request.headers.get("x-ap-owner") ?? undefined,
-        handle: request.headers.get("x-ap-handle") ?? undefined,
+        handle: decodedHeaderText(request.headers, "x-ap-handle"),
         ...profileFromHeaders(request.headers),
         lineage: lineageFromHeaders(request.headers),
         tokenHash: request.headers.get("x-ap-token-hash") ?? "",
@@ -2354,7 +2359,7 @@ export class ChannelDO extends Server<Env> {
         kind: request.headers.get("x-ap-kind") === "agent" ? "agent" : "human",
         role: (request.headers.get("x-ap-role") ?? "readonly") as TokenRole,
         owner: request.headers.get("x-ap-owner") ?? undefined,
-        handle: request.headers.get("x-ap-handle") ?? undefined,
+        handle: decodedHeaderText(request.headers, "x-ap-handle"),
         ...profileFromHeaders(request.headers),
         lineage: lineageFromHeaders(request.headers),
         tokenHash: request.headers.get("x-ap-token-hash") ?? "",
@@ -2568,6 +2573,32 @@ export class ChannelDO extends Server<Env> {
     return withExpandedMentions(frame, [...routed]);
   }
 
+  // #165：把正文/显式 mentions 里的 @昵称（含中文）解析成目标 agent 的真实 ASCII name，union 进 mentions。
+  // 手法镜像 expandSquadMentions（读 D1、大小写不敏感匹配、再重写 mentions），且同样跑在 INSERT 之前——
+  // 这样 serve/watch（msg.mentions.includes(name)）与 webhook（shouldDeliverWebhook 按 hookName=name）
+  // 都能凭真实 name 命中被 @ 的 agent。昵称是全局唯一的，故一个 token 匹配即定位到唯一 agent。
+  private async resolveNicknameMentions(frame: SendFrame): Promise<SendFrame> {
+    const mentions = frame.mentions ?? [];
+    if (mentions.length === 0) return frame;
+    const candidates = mentions.filter((t) => t !== "system" && t.length <= 64);
+    if (candidates.length === 0) return frame;
+    const placeholders = candidates.map(() => "?").join(", ");
+    const rows = await this.env.DB.prepare(
+      `SELECT name, nickname FROM agent_nicknames WHERE nickname COLLATE NOCASE IN (${placeholders})`,
+    )
+      .bind(...candidates)
+      .all<{ name: string; nickname: string }>()
+      .catch(() => ({ results: [] as { name: string; nickname: string }[] }));
+    if (rows.results.length === 0) return frame;
+    const routed = new Set(mentions);
+    for (const row of rows.results) {
+      if (typeof row.name !== "string" || !MENTION_NAME_RE.test(row.name)) continue;
+      routed.add(row.name);
+      if (routed.size >= MAX_MENTIONS) break;
+    }
+    return withExpandedMentions(frame, [...routed]);
+  }
+
   // 校验 → 分配 seq → 落库 → 修剪/presence，返回待广播帧
   private async handleSend(
     identity: Identity,
@@ -2605,6 +2636,7 @@ export class ChannelDO extends Server<Env> {
       return { ok: false, code: "too_large", message: `body exceeds ${BODY_LIMIT} bytes` };
     }
     frame = await this.expandSquadMentions(frame);
+    frame = await this.resolveNicknameMentions(frame);
     const workflowGuard = this.workflowGuardDecision(identity, frame);
     if (workflowGuard !== null) {
       const row = this.workflowGuardRow(workflowGuard.workflow.workflow_id);

--- a/worker/src/handle.ts
+++ b/worker/src/handle.ts
@@ -8,15 +8,21 @@ export function validateHandleFormat(input: unknown): string | null {
   return HANDLE_RE.test(h) ? h : null;
 }
 
-// 冲突检查：撞保留名 / 撞任意 token 名 / 已被别的账号占用。无冲突返回 null。
+// 冲突检查：撞保留名 / 撞任意 token 名 / 撞 agent 昵称 / 已被别的账号占用。无冲突返回 null。
+// #165：handle 与 agent 昵称共用同一套 @ 命名空间，故反向也要挡住撞已存在 agent 昵称。
 export async function handleConflict(
   db: D1Database,
   handle: string,
   forAccount: string | null,
-): Promise<"reserved" | "token_name" | "taken" | null> {
+): Promise<"reserved" | "token_name" | "nickname" | "taken" | null> {
   if (RESERVED_NAMES.includes(handle)) return "reserved";
   const tok = await db.prepare("SELECT 1 FROM tokens WHERE name = ? COLLATE NOCASE").bind(handle).first();
   if (tok) return "token_name";
+  const nick = await db
+    .prepare("SELECT 1 FROM agent_nicknames WHERE nickname = ? COLLATE NOCASE")
+    .bind(handle)
+    .first();
+  if (nick) return "nickname";
   const owner = await db
     .prepare("SELECT account FROM account_profiles WHERE handle = ?")
     .bind(handle)

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -52,6 +52,7 @@ import {
   startDesktopPairing,
 } from "./desktop-pairing";
 import { handleConflict, validateHandleFormat } from "./handle";
+import { nicknameConflict, validateNicknameFormat } from "./nickname";
 import {
   bestEffortRecordManagementAudit,
   listManagementAudit,
@@ -942,10 +943,13 @@ async function persistToken(
     .bind(opts.name)
     .first<{ id: number; revoked_at: number | null }>();
   if (existing && existing.revoked_at === null) return { conflict: true };
-  // 反向唯一性：token 名不得撞已存在的人类 handle（二者共用 @ 命名空间）
+  // 反向唯一性：token 名不得撞已存在的人类 handle 或 agent 昵称（三者共用 @ 命名空间，#165）
   const handleOwner = await db.prepare("SELECT 1 FROM account_profiles WHERE handle = ? COLLATE NOCASE")
     .bind(opts.name).first();
   if (handleOwner) return { conflict: true };
+  const nickOwner = await db.prepare("SELECT 1 FROM agent_nicknames WHERE nickname = ? COLLATE NOCASE")
+    .bind(opts.name).first();
+  if (nickOwner) return { conflict: true };
   const token = randomToken();
   const hash = await sha256Hex(token);
   const now = Date.now();
@@ -1546,9 +1550,18 @@ function assignedRoleHeaders(role: CollaborationRole | null): Record<string, str
 }
 
 // 人类 handle 头：仅当身份是人类且已设 handle 才带（权威值，供 do 盖 presence + stamp 消息，Task A6/A7）。
-// agent 即使与 human 共享 account 也不继承其 handle——handle 是按 account 存的，但只对人类身份生效。
-// export 仅供 test 直接单测（do 尚不消费这个头，spec 里现有的"观察 do 副作用"手法在这没有可观察点）。
+// #165：agent 身份则带自己的 nickname（同样走 x-ap-handle，复用 do 的 presence/sender 展示管线）。
+// x-ap-handle 一律 encodeURIComponent——人类 handle 是 ASCII 编码后原样不变，agent 中文昵称则需编码
+// 才能塞进 latin1 的 HTTP 头（do 侧 decodedHeaderText 解回）。
 export async function handleHeader(db: D1Database, identity: TokenIdentity): Promise<Record<string, string>> {
+  // agent：昵称按 token name 存，与是否有 account 无关。
+  if (identity.kind === "agent") {
+    const row = await db
+      .prepare("SELECT nickname FROM agent_nicknames WHERE name = ?")
+      .bind(identity.name)
+      .first<{ nickname: string | null }>();
+    return row?.nickname ? { "x-ap-handle": encodeURIComponent(row.nickname) } : {};
+  }
   if (identity.kind !== "human" || identity.account == null) return {};
   const row = await db.prepare(
     `SELECT handle, display_name, avatar_url, avatar_thumb
@@ -1559,7 +1572,7 @@ export async function handleHeader(db: D1Database, identity: TokenIdentity): Pro
     .first<{ handle: string | null; display_name: string | null; avatar_url: string | null; avatar_thumb: string | null }>();
   if (!row) return {};
   return {
-    ...(row.handle ? { "x-ap-handle": row.handle } : {}),
+    ...(row.handle ? { "x-ap-handle": encodeURIComponent(row.handle) } : {}),
     ...(row.display_name ? { "x-ap-display-name": encodeURIComponent(row.display_name) } : {}),
     ...(row.avatar_url ? { "x-ap-avatar-url": row.avatar_url } : {}),
     ...(row.avatar_thumb ? { "x-ap-avatar-thumb": row.avatar_thumb } : {}),
@@ -1848,6 +1861,12 @@ app.get("/api/me", requireBearer, async (c) => {
           provider: string | null;
           tenant_key: string | null;
         }>();
+  // #165：agent 的昵称按 token name 存（非 per-account），单独取，作为 handle 回给网页 me chip。
+  const agentNickname = id.kind !== "agent"
+    ? null
+    : (await c.env.DB.prepare("SELECT nickname FROM agent_nicknames WHERE name = ?")
+        .bind(id.name)
+        .first<{ nickname: string | null }>())?.nickname ?? null;
   return c.json({
     name: id.name,
     email: id.email ?? null,
@@ -1856,7 +1875,7 @@ app.get("/api/me", requireBearer, async (c) => {
     owner: id.owner ?? null,
     channel_scope: id.channel_scope ?? null,
     lineage: id.lineage ?? null,
-    handle: profile?.handle ?? null,
+    handle: profile?.handle ?? agentNickname,
     display_name: profile?.display_name ?? null,
     avatar_url: profile?.avatar_url ?? null,
     avatar_thumb: profile?.avatar_thumb ?? null,
@@ -1910,6 +1929,43 @@ app.put("/api/me/handle", requireBearer, async (c) => {
     throw e; // 其它未预期错误保持原样（让它 500，不掩盖真问题）
   }
   return c.json({ handle });
+});
+
+// #165：设置/更新本 agent 的全局唯一昵称（可被 @中文昵称 唤醒）。昵称按 token name 存（per-identity，
+// 因 agent 与 human 共享 account，不能像 handle 那样 per-account）。仅 agent 身份可用；
+// readonly/human 一律 403（human 用 /api/me/handle）。撞保留名/token 名/人类 handle/别的 agent 昵称 → 409。
+app.put("/api/me/nickname", requireBearer, async (c) => {
+  const id = c.get("identity");
+  if (id.role !== "agent") {
+    return c.json(errorBody("forbidden", "setting a nickname requires an agent session"), 403);
+  }
+  const body = (await c.req.json().catch(() => null)) as { nickname?: unknown } | null;
+  const nickname = validateNicknameFormat(body?.nickname);
+  if (nickname === null) {
+    return c.json(errorBody("bad_request", "nickname must be 1-64 unicode letters/digits (start alnum, then . _ -)"), 400);
+  }
+  const conflict = await nicknameConflict(c.env.DB, nickname, id.name);
+  if (conflict !== null) {
+    return c.json(errorBody("conflict", `nickname unavailable (${conflict})`), 409);
+  }
+  const now = Date.now();
+  try {
+    await c.env.DB.prepare(
+      `INSERT INTO agent_nicknames (name, nickname, created_at, updated_at)
+       VALUES (?, ?, ?, ?)
+       ON CONFLICT(name) DO UPDATE SET nickname = excluded.nickname, updated_at = excluded.updated_at`,
+    )
+      .bind(id.name, nickname, now, now)
+      .run();
+  } catch (e) {
+    // 竞态：nicknameConflict 通过后、另一 agent 抢先占了同名 → UNIQUE(nickname) 冲突。转 409（非 500）。
+    const msg = e instanceof Error ? e.message : String(e);
+    if (msg.includes("UNIQUE")) {
+      return c.json(errorBody("conflict", "nickname unavailable (taken)"), 409);
+    }
+    throw e;
+  }
+  return c.json({ nickname });
 });
 
 app.post("/api/tokens", requireAdmin, async (c) => {

--- a/worker/src/nickname.ts
+++ b/worker/src/nickname.ts
@@ -1,0 +1,36 @@
+import { RESERVED_NAMES } from "@agentparty/shared";
+
+// #165：agent 全局唯一昵称（可 @中文昵称 唤醒）。与人类 handle 共用一套 @ 命名空间，
+// 但存法不同：handle 按 account（人类一账号一昵称），nickname 按 token name（agent 与 human
+// 共享 account，故必须 per-identity）。允许 unicode 首字（中文），后续字符再放开 . _ -。
+// 长度上界 64（与 do.ts BODY_MENTION_RE 的 {0,63} 捕获上界对齐——设了就一定能被 @ 到）。
+export const NICKNAME_RE = /^[\p{L}\p{N}][\p{L}\p{N}._-]{0,63}$/u;
+
+export function validateNicknameFormat(input: unknown): string | null {
+  if (typeof input !== "string") return null;
+  const n = input.trim();
+  return NICKNAME_RE.test(n) ? n : null;
+}
+
+// 冲突检查（共用 @ 命名空间）：撞保留名 / 撞任意 token 名 / 撞人类 handle / 已被别的 agent 占用。
+// forName = 设置者自己的 token name（同名覆盖自己那条不算冲突）。无冲突返回 null。
+export async function nicknameConflict(
+  db: D1Database,
+  nickname: string,
+  forName: string,
+): Promise<"reserved" | "token_name" | "handle" | "taken" | null> {
+  if (RESERVED_NAMES.includes(nickname)) return "reserved";
+  const tok = await db.prepare("SELECT 1 FROM tokens WHERE name = ? COLLATE NOCASE").bind(nickname).first();
+  if (tok) return "token_name";
+  const handle = await db
+    .prepare("SELECT 1 FROM account_profiles WHERE handle = ? COLLATE NOCASE")
+    .bind(nickname)
+    .first();
+  if (handle) return "handle";
+  const owner = await db
+    .prepare("SELECT name FROM agent_nicknames WHERE nickname = ? COLLATE NOCASE")
+    .bind(nickname)
+    .first<{ name: string }>();
+  if (owner && owner.name !== forName) return "taken";
+  return null;
+}

--- a/worker/test/nickname.spec.ts
+++ b/worker/test/nickname.spec.ts
@@ -1,0 +1,113 @@
+// #165：agent 也能设「全局唯一昵称」（复用 #59 的 @别名命名空间），且可被 @中文昵称 唤醒。
+// 昵称存 D1 agent_nicknames（按 token name，per-identity，非 per-account——agent 与 human 共享 account）。
+// 唤醒的关键：DO 发送路径把正文里的 @昵称 解析成目标真实 name 写进 mentions_json，
+// serve/watch/webhook 全按真实 ASCII name 命中，昵称是不可 @ 到的（除非被解析）。
+import { SELF } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import { validateNicknameFormat } from "../src/nickname";
+import { api, createChannel, seedToken, uniq, WsClient } from "./helpers";
+
+async function setNickname(token: string, nickname: string): Promise<Response> {
+  return api("/api/me/nickname", token, { method: "PUT", body: JSON.stringify({ nickname }) });
+}
+async function setHandle(token: string, handle: string): Promise<Response> {
+  return api("/api/me/handle", token, { method: "PUT", body: JSON.stringify({ handle }) });
+}
+
+describe("validateNicknameFormat（#165）", () => {
+  it("接受中文/unicode 昵称，原样保留", () => {
+    expect(validateNicknameFormat("中文昵称")).toBe("中文昵称");
+    expect(validateNicknameFormat("小助手")).toBe("小助手");
+    expect(validateNicknameFormat("bot中文")).toBe("bot中文");
+    expect(validateNicknameFormat("Evan")).toBe("Evan");
+  });
+  it("拒绝非法：含空白 / @ / 首字为 . / 超长 / 非串", () => {
+    expect(validateNicknameFormat("中 文")).toBeNull();
+    expect(validateNicknameFormat("foo@bar")).toBeNull();
+    expect(validateNicknameFormat(".中文")).toBeNull();
+    expect(validateNicknameFormat("字".repeat(65))).toBeNull();
+    expect(validateNicknameFormat(123)).toBeNull();
+  });
+});
+
+describe("agent 设昵称 + 全局唯一（#165）", () => {
+  it("agent 设中文昵称成功，stamp 到 sender.handle", async () => {
+    const agent = await seedToken("agent", uniq("a"));
+    const setRes = await setNickname(agent.token, "小助手");
+    expect(setRes.status).toBe(200);
+
+    const slug = await createChannel(agent.token);
+    const ws = await WsClient.open(slug, agent.token);
+    await ws.nextOfType("welcome");
+    ws.send({ type: "send", kind: "message", body: "hi", mentions: [], reply_to: null });
+    await ws.nextOfType("sent");
+    const msg = await ws.nextOfType("msg");
+    expect(msg.sender.handle).toBe("小助手");
+    ws.close();
+  });
+
+  it("同一昵称不能被第二个 agent 占用（全局唯一）", async () => {
+    const a1 = await seedToken("agent", uniq("a"));
+    const a2 = await seedToken("agent", uniq("a"));
+    expect((await setNickname(a1.token, "唯一名")).status).toBe(200);
+    expect((await setNickname(a2.token, "唯一名")).status).toBe(409);
+  });
+
+  it("昵称不能撞人类 handle（共用 @ 命名空间）", async () => {
+    const owner = uniq("acct");
+    const human = await seedToken("human", uniq("h"), { owner });
+    const agent = await seedToken("agent", uniq("a"));
+    expect((await setHandle(human.token, "sharedname")).status).toBe(200);
+    expect((await setNickname(agent.token, "sharedname")).status).toBe(409);
+  });
+
+  it("人类 handle 反向也不能撞已存在的 agent 昵称", async () => {
+    const owner = uniq("acct");
+    const human = await seedToken("human", uniq("h"), { owner });
+    const agent = await seedToken("agent", uniq("a"));
+    expect((await setNickname(agent.token, "reverse")).status).toBe(200);
+    expect((await setHandle(human.token, "reverse")).status).toBe(409);
+  });
+
+  it("昵称不能撞已存在的 token 名", async () => {
+    const victim = await seedToken("agent", uniq("takenname"));
+    const agent = await seedToken("agent", uniq("a"));
+    expect((await setNickname(agent.token, victim.name)).status).toBe(409);
+  });
+
+  it("非 agent（readonly）不能设昵称", async () => {
+    const ro = await seedToken("readonly", uniq("ro"));
+    expect((await setNickname(ro.token, "nope")).status).toBe(403);
+  });
+});
+
+describe("@中文昵称 解析成真实 name 并唤醒（#165）", () => {
+  it("正文 @昵称 → mentions_json 含目标真实 name", async () => {
+    const target = await seedToken("agent", uniq("target"));
+    expect((await setNickname(target.token, "程序员小明")).status).toBe(200);
+
+    const sender = await seedToken("agent", uniq("sender"));
+    const slug = await createChannel(sender.token);
+    const ws = await WsClient.open(slug, sender.token);
+    await ws.nextOfType("welcome");
+    ws.send({ type: "send", kind: "message", body: "@程序员小明 帮我看下", mentions: [], reply_to: null });
+    await ws.nextOfType("sent");
+    const msg = await ws.nextOfType("msg");
+    expect(msg.mentions).toContain(target.name);
+    ws.close();
+  });
+
+  it("email 里的 @ 不产生 mention", async () => {
+    const target = await seedToken("agent", uniq("target"));
+    expect((await setNickname(target.token, "小红")).status).toBe(200);
+    const sender = await seedToken("agent", uniq("sender"));
+    const slug = await createChannel(sender.token);
+    const ws = await WsClient.open(slug, sender.token);
+    await ws.nextOfType("welcome");
+    ws.send({ type: "send", kind: "message", body: "mail me at foo@bar.com thanks", mentions: [], reply_to: null });
+    await ws.nextOfType("sent");
+    const msg = await ws.nextOfType("msg");
+    expect(msg.mentions).toEqual([]);
+    ws.close();
+  });
+});


### PR DESCRIPTION
## 做什么（#165，owner 2026-07-11 拍板「agent 也全局唯一、复用现有 @ 命名空间」）

agent 可设自定义（**中文**）昵称，别人 `@中文昵称` 能**真正唤醒**它。

## 为什么是新活（调研推翻了「掀个门复用 display_name」的前提）
- @别名靠人类 **handle**（`account_profiles`，**按账号**、humans-only 是数据模型决定的），`display_name` 根本不参与 @ 解析。
- @→name 解析在**客户端**；agent 靠 `mentions.includes(真实name)` 被 serve/watch/webhook 唤醒。
- 所以 @中文昵称要唤醒 agent，必须**服务端**把昵称解析进 mentions；且 @ 正则只认 ASCII，中文根本 parse 不了。

## 怎么做
- **迁移 0027** `agent_nicknames(name PK, nickname NOCASE UNIQUE, ...)`：按 token name 存（agent/human 共享 account，不能像 handle 那样 per-account）；全局唯一大小写不敏感。
- **共用一套 @ 命名空间、双向闭合**：`nicknameConflict` 查 保留名∪token名∪人类handle∪已占用；`handleConflict` 反向也查 agent_nicknames（设 handle 不能撞已存在的昵称）。
- **服务端解析** `resolveNicknameMentions`（DO 发送路径，紧接 `expandSquadMentions`）：读 D1 把 @昵称改写进 `mentions_json` 的真实 name → serve/watch/webhook 唤醒逻辑不变即可被中文昵称叫醒。加进 routed 前 `MENTION_NAME_RE` 校验、遵守 `MAX_MENTIONS`。
- **正则扩 unicode**：`BODY_MENTION_RE = /(?:^|\s)@([\p{L}\p{N}][\p{L}\p{N}._-]{0,63})/gu`——保留前导空白/行首（`foo@bar.com` 不误判为 mention）、长度上界 64；web `DRAFT_MENTION_RE` 同步。
- **web**：昵称设置/编辑（含内联校验反馈：taken/太长/非法字符）+ chip 渲染中文昵称。**CLI** `party nickname` 命令。

## 门禁（agent 收尾两次被截断，我接管提交 + 亲跑全套）
- worker nickname spec 10/10；cli nickname 4/4；web 433/0；worker/cli/web `tsc` 0；web `vite build` 0；迁移守卫 0（0027）。
- 变异：resolver 不把真实 name 加进 mentions → @昵称唤醒测试红（亲跑确认）；还原复绿。

## 评审请确认
- 中文昵称 chip / @ 输入体验（web）——正则与 handle 校验对齐，`u` flag 下 `\p{L}` 含 CJK。
- 解析在每条带 mention 的 send 上查一次 D1（IN 占位符、NOCASE、失败 catch→空）；量级与 expandSquadMentions 同级。

🤖 opus agent 实现、经我逐行审（迁移/解析器/正则/命名空间）+ 接管收尾 + 全门禁复验；走 PR 由 @leeguooooo / LEO-MAIN 审后合，未自合。
