### PR TITLE
feat(worker,cli,web): presence 表达 busy + 队列深度，长任务不再假装可达（#103）

### DIFF
--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -30,6 +30,12 @@ class FrameQueue {
   [Symbol.asyncIterator](): AsyncIterator<ServerFrame> {
     return this;
   }
+
+  // 已缓冲、尚未被消费的帧快照（#103）：serve 串行处理一条 wake 时，其后到达的帧堆在这里。
+  // 用于估算「排在身后的 wake 深度」。返回副本，调用方遍历不影响队列。
+  snapshot(): ServerFrame[] {
+    return [...this.items];
+  }
 }
 
 export interface ConnectOptions {
@@ -55,6 +61,8 @@ export interface Connection {
   /** 消费方处理完一条 msg 后调用，此时才推进并持久化游标 */
   ack(seq: number): void;
   close(): void;
+  /** 已缓冲、尚未消费的帧快照（#103）：估算 serve 排队深度用。 */
+  pendingFrames(): ServerFrame[];
   readonly cursor: number;
   readonly revCursor: number;
 }
@@ -301,6 +309,9 @@ export function connect(
         ws.close();
       }
       queue.end();
+    },
+    pendingFrames() {
+      return queue.snapshot();
     },
     get cursor() {
       return cursor;

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -1,7 +1,7 @@
 // party serve — 常驻监听频道，每条 @你 的消息触发一次本地命令，把「跑完就停的 session agent」
 // 用外部 supervisor 唤醒（wake GOAL 的 session 型那半；有入站 URL 的 runtime 走 webhook）。
 // 复用 client.connect 的自动重连帧流，真正常驻；命令串行执行（一条处理完再下一条，不并发抢跑）。
-import { EXIT_ARCHIVED, EXIT_AUTH, EXIT_STREAM_ENDED, EXIT_UPGRADED, type MsgFrame } from "@agentparty/shared";
+import { EXIT_ARCHIVED, EXIT_AUTH, EXIT_STREAM_ENDED, EXIT_UPGRADED, type MsgFrame, type ServerFrame } from "@agentparty/shared";
 import { maybeReexecUpgrade, upgradeNotice, type CliUpgradeNotice, type UpgradeDeps } from "../upgrade";
 import {
   appendFileSync,
@@ -373,6 +373,8 @@ export interface ServeOptions {
       charter?: ChannelCharter | null;
       projectAgent?: ProjectAgentRunContext | null;
       cliUpgrade?: CliUpgradeNotice | null;
+      /** 排在当前 wake 身后、尚未处理的 wake 数（#103）；runner 随 working 帧上报 busy+此值。 */
+      queueDepth?: number;
     },
   ) => Promise<void>;
   sdkRunner?: SdkRunnerOptions;
@@ -418,6 +420,8 @@ async function defaultRun(
     charter?: ChannelCharter | null;
     projectAgent?: ProjectAgentRunContext | null;
     cliUpgrade?: CliUpgradeNotice | null;
+    /** 排在当前 wake 身后、尚未处理的 wake 数（#103）。 */
+    queueDepth?: number;
   },
 ): Promise<void> {
   const body = frame.kind === "message" ? frame.body : (frame.note ?? "");
@@ -780,6 +784,8 @@ export function createSdkRunner(opts: SdkRunnerOptions): NonNullable<ServeOption
       charter?: ChannelCharter | null;
       projectAgent?: ProjectAgentRunContext | null;
       cliUpgrade?: CliUpgradeNotice | null;
+      /** 排在当前 wake 身后、尚未处理的 wake 数（#103）。 */
+      queueDepth?: number;
     },
   ): Promise<void> => {
     const started = opts.now?.() ?? Date.now();
@@ -792,6 +798,9 @@ export function createSdkRunner(opts: SdkRunnerOptions): NonNullable<ServeOption
       state: "working",
       note: `wake ack: ${ctx.self} builtin codex-sdk runner handling seq=${frame.seq}`,
       mentions: [],
+      // busy（#103）：串行处理这条 wake 期间自报「忙 + 身后队列深度」，让 who/reach/web 别谎报可即时响应。
+      busy: true,
+      queue_depth: ctx.queueDepth ?? 0,
     });
 
     let threadId = session?.thread_id ?? null;
@@ -875,6 +884,9 @@ export function createBuiltinRunner(opts: BuiltinRunnerOptions): NonNullable<Ser
       state: "working",
       note: `wake ack: ${ctx.self} builtin ${opts.harness} runner handling seq=${frame.seq}`,
       mentions: [],
+      // busy（#103）：串行处理这条 wake 期间自报「忙 + 身后队列深度」，让 who/reach/web 别谎报可即时响应。
+      busy: true,
+      queue_depth: ctx.queueDepth ?? 0,
     });
 
     const repoCwd = await ensureRepo(opts, env);
@@ -1261,9 +1273,35 @@ function errText(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
+// 排队深度估算（#103）：serve 串行处理一条 wake 时，其后到达并已缓冲的帧里，有多少条是「够格触发
+// 一次唤醒」的新消息——即排在身后、迟早要挨个处理的 wake 数。只数已缓冲快照，不含正在处理的这条。
+// afterSeq = 当前正在处理/已了结到的 seq；只数它之后、非自己发的、（mentions-only 时）@ 到自己的消息。
+export function pendingWakeDepth(
+  pending: ServerFrame[],
+  self: string,
+  mentionsOnly: boolean,
+  afterSeq: number,
+): number {
+  let depth = 0;
+  for (const f of pending) {
+    if (f.type !== "msg") continue;
+    if (f.seq <= afterSeq) continue;
+    if (f.sender.name === self) continue;
+    if (mentionsOnly && !f.mentions.includes(self)) continue;
+    depth += 1;
+  }
+  return depth;
+}
+
 export async function runServe(o: ServeOptions): Promise<number> {
   const out = o.out ?? ((line: string) => console.error(line));
   const run = o.runCommand ?? (o.sdkRunner ? createSdkRunner(o.sdkRunner) : o.builtinRunner ? createBuiltinRunner(o.builtinRunner) : defaultRun);
+  // busy 生命周期（#103）：只有内建 serve runner（builtin/sdk）在 working 帧里自报 busy=true，
+  // 因此也只有它们需要 runServe 在收尾时补一条「busy=false 空闲」把 busy 清干净。注入 runCommand
+  // 的测试、以及 --cmd 裸执行器（自管 presence）不参与，避免覆盖它们自己的收尾状态。
+  const reportsBusy = o.runCommand === undefined && (o.builtinRunner !== undefined || o.sdkRunner !== undefined);
+  // 已自报 busy、尚未补发空闲清除。一次 busy→idle 转场只补一条，不逐 tick 刷。
+  let busyReported = false;
   let upgraded = false;
   let nudgedUpgrade = false;
   // 本地连接健康探针（#254）：WS 生命周期转场（不是 presence 自报、不是 PID 推断）落 health.json，
@@ -1468,6 +1506,10 @@ export async function runServe(o: ServeOptions): Promise<number> {
         let lastError = (stuck?.seq === frame.seq ? stuck.last_error : "") ?? "";
         let delivered = false;
         let retriable = true;
+        // 身后已缓冲的 wake 深度（#103）：内建 runner 随 working 帧上报，presence 显示「忙 + N 待处理」。
+        // 本帧正在处理，故只数它 seq 之后、够格触发唤醒的缓冲帧。
+        const queueDepth = pendingWakeDepth(conn.pendingFrames(), self, o.mentionsOnly === true, frame.seq);
+        if (reportsBusy) busyReported = true;
         for (let attempt = priorAttempts + 1; attempt <= maxAttempts && retriable; attempt++) {
           try {
             const cliUpgrade = upgradeNotice(o.autoUpgrade === true, o.upgradeDeps);
@@ -1480,6 +1522,7 @@ export async function runServe(o: ServeOptions): Promise<number> {
               charter,
               projectAgent: o.projectAgent ?? null,
               cliUpgrade,
+              queueDepth,
             });
             delivered = true;
             break;
@@ -1509,6 +1552,29 @@ export async function runServe(o: ServeOptions): Promise<number> {
           // 它是第二道闸：一旦有人放宽 blockedByDebt，这行会挡住「A 的成功清掉 B 的欠账」。
           // 不删，理由写在这里。
           if (stuck !== null && stuck.seq === frame.seq) setStuck(null);
+          // busy 清除（#103）：这条 wake 处理完了。若身后已无待处理 wake（队列排空），补一条「空闲」把
+          // 之前 working 帧上的 busy 清回 false——否则任务结束后 presence 会永远卡在「忙」（假忙）。
+          // 只在真排空时补：还有 @ 排队就保持 busy=true，等下一条 wake 的 working 帧继续覆盖 queue_depth。
+          if (busyReported) {
+            const remaining = pendingWakeDepth(conn.pendingFrames(), self, o.mentionsOnly === true, conn.cursor);
+            if (remaining === 0) {
+              busyReported = false;
+              try {
+                await (o.post ?? postMessage)(o.server, o.token, o.channel, {
+                  kind: "status",
+                  state: "waiting",
+                  note: `idle: ${self} finished wake seq=${frame.seq}, waiting for next @`,
+                  mentions: [],
+                  busy: false,
+                  queue_depth: 0,
+                });
+              } catch (e) {
+                // 清 busy 只是锦上添花：发不出去就下条 wake 的 working 帧会重置 queue_depth，
+                // 或下次排空再补。留痕但不影响主流程（wake 已成功送达）。
+                out(`  busy 清除通告发送失败（不影响送达）: ${errText(e)}`);
+              }
+            }
+          }
         } else {
           // 有界重放到顶：显式放弃，但必须响亮留痕——静默丢弃正是 #118 要修的东西。
           // 没有 CLI flag，所以重试预算与退避必须**在频道里可见**：把常数藏进源码是不诚实的。

--- a/cli/src/commands/who.ts
+++ b/cli/src/commands/who.ts
@@ -15,6 +15,9 @@ List who is in a channel, tiered by how you can reach them:
   ● online    connected right now
   ◐ wakeable  not connected, but @-mention will wake them (serve/watch/webhook)
   ○ recent    seen lately; mention delivers, wake not guaranteed
+A "⏳ busy" tag means the target is serially handling a wake (e.g. a long run): it
+is reachable but a reply will be slow — an ask that times out means "busy", not
+"offline", so do not re-@ it. "N queued" shows how many wakes are already waiting.
 wake=serve runs a live supervisor and webhook is server-delivered; wake=watch is
 self-declared and depends on the harness actually resuming the agent, so it is
 shown as "watch (unverified)" until proven — check with: party wake test @name
@@ -27,7 +30,7 @@ session name), so mention the "@handle" shown here — not a UUID session name.
 Options:
   --channel C   read channel C instead of the bound channel
   --json        emit one JSON object per line
-                (name/kind/tier/wake/wake_unverified/account/handle/display_name/age_ms/read_seq)`;
+                (name/kind/tier/wake/wake_unverified/busy/queue_depth/account/handle/display_name/age_ms/read_seq)`;
 
 const STALE_MS = 60_000; // 与 DO presence 扫描一致
 const DEAD_MS = 14 * 24 * 60 * 60 * 1000; // 14 天没露面视为幽灵，不再列
@@ -58,6 +61,9 @@ interface Row {
   account?: string; // 会话背后的账号（人类 = OIDC email；agent = owner）
   handle?: string; // 人类全局唯一 @别名；@ 通知的真正投递键（web notify 按 handle 命中）
   display_name?: string; // OAuth/SSO 展示名
+  // busy（#103）：serve 正串行处理一条 wake，回复会慢。让人别把「@ 了没立刻回」误判成失联、反复 @。
+  busy?: true;
+  queue_depth?: number; // 忙时排在身后、尚未处理的 wake 数；>0 才带出
 }
 
 // kind 已知取 kind；旧 presence 行没回填时 UUID 名判 human（网页登录会话），其余判 agent。
@@ -97,6 +103,9 @@ export function classify(e: PresenceEntry, now: number): Row | null {
     ...(typeof e.account === "string" && e.account !== "" ? { account: e.account } : {}),
     ...(typeof e.handle === "string" && e.handle !== "" ? { handle: e.handle } : {}),
     ...(typeof e.display_name === "string" && e.display_name !== "" ? { display_name: e.display_name } : {}),
+    // busy/queue_depth（#103）：仅在服务端标了 busy（目标可达且自报忙）时带出；离线态服务端本就不下发 busy。
+    ...(e.busy === true ? { busy: true as const } : {}),
+    ...(e.busy === true && typeof e.queue_depth === "number" && e.queue_depth > 0 ? { queue_depth: e.queue_depth } : {}),
     age_ms: age,
     ...(typeof e.connection_count === "number" && e.connection_count > 1
       ? { connection_count: e.connection_count }
@@ -137,6 +146,14 @@ export function identityNote(r: Row): string {
     if (account !== "") parts.push(account);
   }
   return parts.length > 0 ? ` (${parts.join(" · ")})` : "";
+}
+
+// busy 标注（#103）：目标可达但正串行处理一条 wake——「⏳ busy」或「⏳ busy · N queued」。
+// 让人看懂「@ 了没立刻回」是忙、不是失联，别反复 @ 堆重复唤醒。
+export function busyNote(r: Row): string {
+  if (r.busy !== true) return "";
+  const queued = r.queue_depth !== undefined && r.queue_depth > 0 ? ` · ${r.queue_depth} queued` : "";
+  return ` · ⏳ busy${queued}`;
 }
 
 function humanAge(ms: number): string {
@@ -225,7 +242,7 @@ export async function run(argv: string[]): Promise<number> {
       }
       const wake = r.tier === "wakeable" && r.wake ? ` ${r.wake}${r.wake_unverified === true ? " (unverified)" : ""}` : "";
       const age = r.tier === "online" ? "" : ` (${humanAge(r.age_ms)})`;
-      console.log(`${DOT[r.tier]} ${r.tier.padEnd(8)} ${r.name}  [${r.kind}]${identityNote(r)}${wake}${read}${duplicate}${age}`);
+      console.log(`${DOT[r.tier]} ${r.tier.padEnd(8)} ${r.name}  [${r.kind}]${identityNote(r)}${busyNote(r)}${wake}${read}${duplicate}${age}`);
     }
     return 0;
   } catch (e) {

--- a/cli/src/reach.ts
+++ b/cli/src/reach.ts
@@ -15,6 +15,18 @@ export interface Reachability {
   name: string;
   reach: Reach;
   wake?: WakeKind;
+  // busy（#103）：目标可达但正串行处理一条 wake，回复会慢。让调用方把 ask 超时当「忙」而非「失联」，
+  // 别反复 @ 堆重复唤醒。仅在服务端标了 busy（即目标在线且自报忙）时带出。
+  busy?: true;
+  // 忙时排在身后、尚未处理的 wake 数（#103）；>0 才带出。
+  queueDepth?: number;
+}
+
+// busy/queue_depth 只在目标「可达」（online/wakeable）时有意义——offline 谈不上忙。
+function busyBits(e: PresenceEntry | undefined): Pick<Reachability, "busy" | "queueDepth"> {
+  if (e?.busy !== true) return {};
+  const depth = typeof e.queue_depth === "number" && e.queue_depth > 0 ? e.queue_depth : undefined;
+  return { busy: true, ...(depth !== undefined ? { queueDepth: depth } : {}) };
 }
 
 export function reachOf(name: string, presence: PresenceEntry[], now: number): Reachability {
@@ -25,16 +37,24 @@ export function reachOf(name: string, presence: PresenceEntry[], now: number): R
   const wake = e.wake?.kind;
   // online：与 web mentions 一致以「当前有活 WS 连接」为准（#97 的 live，DO 从 getConnections 权威判定）；
   // 无 live 信号（旧 worker 响应）时回退到旧的新鲜度启发式，不回归。
-  if (e.state !== "offline" && (e.live === true || age < STALE_MS)) return { name, reach: "online", ...(wake ? { wake } : {}) };
-  if (wake !== undefined && autoWakeReachable(e, now, STALE_MS) && age <= DEAD_MS) return { name, reach: "wakeable", wake };
+  if (e.state !== "offline" && (e.live === true || age < STALE_MS))
+    return { name, reach: "online", ...(wake ? { wake } : {}), ...busyBits(e) };
+  if (wake !== undefined && autoWakeReachable(e, now, STALE_MS) && age <= DEAD_MS)
+    return { name, reach: "wakeable", wake, ...busyBits(e) };
   return { name, reach: "offline", ...(wake ? { wake } : {}) };
 }
 
 const DOT: Record<Reach, string> = { online: "●", wakeable: "◐", offline: "○" };
 
+// 忙态后缀：「· busy」或「· busy, N queued」。目标可达但正忙——回复会慢，别当失联。
+function busyNote(r: Reachability): string {
+  if (r.busy !== true) return "";
+  return r.queueDepth !== undefined ? ` · busy, ${r.queueDepth} queued` : " · busy";
+}
+
 export function formatReach(r: Reachability): string {
-  if (r.reach === "online") return `@${r.name} ${DOT.online} online`;
-  if (r.reach === "wakeable") return `@${r.name} ${DOT.wakeable} wakeable${r.wake ? `(${r.wake})` : ""}`;
+  if (r.reach === "online") return `@${r.name} ${DOT.online} online${busyNote(r)}`;
+  if (r.reach === "wakeable") return `@${r.name} ${DOT.wakeable} wakeable${r.wake ? `(${r.wake})` : ""}${busyNote(r)}`;
   return `@${r.name} ${DOT.offline} offline — reconnect to reach`;
 }
 

--- a/cli/test/reach.test.ts
+++ b/cli/test/reach.test.ts
@@ -73,6 +73,46 @@ describe("consistency with server-side live-connection fix (#97)", () => {
   });
 });
 
+// busy + 队列深度（#103）：目标可达但正串行处理一条 wake——回复会慢，不是失联。
+describe("busy surfacing (#103)", () => {
+  test("online + busy with no queue → carries busy, no queueDepth", () => {
+    const r = reachOf("bot", [p({ name: "bot", busy: true })], NOW);
+    expect(r.reach).toBe("online");
+    expect(r.busy).toBe(true);
+    expect(r).not.toHaveProperty("queueDepth");
+  });
+
+  test("online + busy with a backlog → carries queue depth", () => {
+    const r = reachOf("bot", [p({ name: "bot", busy: true, queue_depth: 4 })], NOW);
+    expect(r).toMatchObject({ reach: "online", busy: true, queueDepth: 4 });
+  });
+
+  test("wakeable serve + busy → busy rides on wakeable too", () => {
+    const r = reachOf("bot", [p({ name: "bot", state: "offline", wake: { kind: "serve" }, busy: true, queue_depth: 2 })], NOW);
+    expect(r).toMatchObject({ reach: "wakeable", wake: "serve", busy: true, queueDepth: 2 });
+  });
+
+  test("not busy → no busy/queueDepth fields", () => {
+    const r = reachOf("bot", [p({ name: "bot" })], NOW);
+    expect(r).not.toHaveProperty("busy");
+    expect(r).not.toHaveProperty("queueDepth");
+  });
+
+  test("queue_depth of 0 while busy → busy but no queued count", () => {
+    const r = reachOf("bot", [p({ name: "bot", busy: true, queue_depth: 0 })], NOW);
+    expect(r.busy).toBe(true);
+    expect(r).not.toHaveProperty("queueDepth");
+  });
+
+  test("format shows busy and queued count legibly", () => {
+    expect(formatReach({ name: "a", reach: "online", busy: true })).toBe("@a ● online · busy");
+    expect(formatReach({ name: "a", reach: "online", busy: true, queueDepth: 3 })).toBe("@a ● online · busy, 3 queued");
+    expect(formatReach({ name: "b", reach: "wakeable", wake: "serve", busy: true, queueDepth: 1 })).toBe(
+      "@b ◐ wakeable(serve) · busy, 1 queued",
+    );
+  });
+});
+
 describe("formatting", () => {
   test("per-target labels are honest and compact", () => {
     expect(formatReach({ name: "a", reach: "online" })).toBe("@a ● online");

--- a/cli/test/serve.test.ts
+++ b/cli/test/serve.test.ts
@@ -7,6 +7,7 @@ import {
   createBuiltinRunner,
   createSdkRunner,
   projectAgentChildName,
+  pendingWakeDepth,
   run as runServeCommand,
   runProfileServe,
   runServe,
@@ -102,6 +103,38 @@ describe("runServe", () => {
     expect(seen[0]!.frame.seq).toBe(1);
     expect(seen[0]!.self).toBe("me");
     expect(cursors).toEqual([1]);
+  });
+
+  // busy + 队列深度（#103）：serve 串行处理长任务时不再假装可即时响应。
+  test("busy lifecycle: builtin runner marks busy on the working frame, then serve clears it when idle", async () => {
+    const s = closeAfterOneMention();
+    const { posts, post } = postRecorder();
+    const workdir = tempDir();
+    const runProcess: RunnerProcess = async (args) => {
+      const out = args[args.indexOf("-o") + 1]!;
+      writeFileSync(out, "answer\n");
+      return { code: 0, stdout: `session id: ${uuid(1)}\n`, stderr: "" };
+    };
+    const o = opts({
+      server: s.url,
+      post,
+      builtinRunner: { server: s.url, token: "ap_tok", channel: "dev", harness: "codex", workdir, runProcess, post },
+    });
+
+    expect(await runServe(o)).toBe(EXIT_ARCHIVED);
+
+    // 处理这条 wake 时自报「忙」（无积压 → queue_depth 0）
+    const working = posts.find((p) => (p.body as { state?: string }).state === "working");
+    expect(working, "runner must post a working frame").toBeDefined();
+    expect(working!.body).toMatchObject({ kind: "status", state: "working", busy: true, queue_depth: 0 });
+
+    // 收尾补一条「空闲」把 busy 清回 false——任务结束就不再假忙
+    const idle = posts.find((p) => (p.body as { state?: string; busy?: boolean }).state === "waiting" && (p.body as { busy?: boolean }).busy === false);
+    expect(idle, "serve must post a busy=false idle-clear once the queue drains").toBeDefined();
+    expect(idle!.body).toMatchObject({ kind: "status", state: "waiting", busy: false, queue_depth: 0 });
+
+    // 顺序：先忙后清
+    expect(posts.indexOf(working!)).toBeLessThan(posts.indexOf(idle!));
   });
 
   test("reports a non-zero runner exit instead of silently swallowing it", async () => {
@@ -1050,5 +1083,33 @@ describe("codex-sdk runner", () => {
     await second;
     expect(JSON.parse(prompts[0]!).seq).toBe(107);
     expect(JSON.parse(prompts[1]!).seq).toBe(108);
+  });
+});
+
+// 排队深度估算（#103）：只数「排在当前 wake 身后、够格触发唤醒」的已缓冲帧。
+describe("pendingWakeDepth (#103)", () => {
+  const msg = (seq: number, sender: string, mentions: string[]) =>
+    msgFrame(seq, "x", { sender: { name: sender, kind: "agent" }, mentions }) as never;
+
+  test("counts buffered mentions after the current seq, excluding self and older frames", () => {
+    const pending = [
+      msg(2, "alice", ["me"]),
+      msg(3, "bob", ["me"]),
+      msg(4, "me", ["me"]), // 自己发的不算
+      { type: "status", seq: 5 } as never, // 非 msg 帧不算
+      msg(1, "alice", ["me"]), // 早于/等于当前 seq 不算
+    ];
+    expect(pendingWakeDepth(pending, "me", true, 1)).toBe(2);
+  });
+
+  test("mentions-only=false counts every fresh message from others, mentioned or not", () => {
+    const pending = [msg(2, "alice", []), msg(3, "bob", ["someone-else"])];
+    expect(pendingWakeDepth(pending, "me", false, 1)).toBe(2);
+    // mentions-only=true 时，没 @ 我的不算
+    expect(pendingWakeDepth(pending, "me", true, 1)).toBe(0);
+  });
+
+  test("empty queue → depth 0", () => {
+    expect(pendingWakeDepth([], "me", true, 0)).toBe(0);
   });
 });

--- a/cli/test/who.test.ts
+++ b/cli/test/who.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { PresenceEntry } from "@agentparty/shared";
-import { classify, identityNote, terminalIdentityText } from "../src/commands/who";
+import { busyNote, classify, identityNote, terminalIdentityText } from "../src/commands/who";
 
 const NOW = 1_000_000_000;
 
@@ -202,5 +202,42 @@ describe("who wake_unverified（#55/#60：自报 watch wake 如实标注未验�
     expect(serve?.wake_unverified).toBeUndefined();
     const hook = classify(p({ name: "bot", state: "offline", wake: { kind: "webhook" } }), NOW);
     expect(hook?.wake_unverified).toBeUndefined();
+  });
+});
+
+// busy + 队列深度（#103）：serve 串行处理长任务时，who 要能看出「忙、N 待处理」，
+// 而不是显示 working/可达、让人以为 @ 了会立刻回。
+describe("who busy + queue depth (#103)", () => {
+  test("busy 在线 agent：classify 带出 busy，无队列时不带 queue_depth", () => {
+    const r = classify(p({ name: "bot", state: "working", busy: true }), NOW);
+    expect(r?.tier).toBe("online");
+    expect(r?.busy).toBe(true);
+    expect(r).not.toHaveProperty("queue_depth");
+  });
+
+  test("busy 且有积压：带出 queue_depth", () => {
+    const r = classify(p({ name: "bot", state: "working", busy: true, queue_depth: 3 }), NOW);
+    expect(r?.busy).toBe(true);
+    expect(r?.queue_depth).toBe(3);
+  });
+
+  test("不 busy：不带 busy/queue_depth（诚实留白）", () => {
+    const r = classify(p({ name: "bot", state: "working", queue_depth: 5 }), NOW);
+    expect(r).not.toHaveProperty("busy");
+    expect(r).not.toHaveProperty("queue_depth");
+  });
+
+  test("busy 但 queue_depth=0：只带 busy，不显示 0 queued", () => {
+    const r = classify(p({ name: "bot", state: "working", busy: true, queue_depth: 0 }), NOW);
+    expect(r?.busy).toBe(true);
+    expect(r).not.toHaveProperty("queue_depth");
+  });
+
+  test("busyNote 渲染：忙、忙+队列、空闲三态", () => {
+    expect(busyNote({ name: "a", kind: "agent", tier: "online", age_ms: 0, busy: true })).toBe(" · ⏳ busy");
+    expect(busyNote({ name: "a", kind: "agent", tier: "online", age_ms: 0, busy: true, queue_depth: 4 })).toBe(
+      " · ⏳ busy · 4 queued",
+    );
+    expect(busyNote({ name: "a", kind: "agent", tier: "online", age_ms: 0 })).toBe("");
   });
 });

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -310,6 +310,14 @@ export interface PresenceEntry {
    * 条件保持「多久没干活」而非「TCP 有没有断」（一个卡在无超时 await 上的 serve socket 照样是活的）。
    */
   live?: boolean;
+  /**
+   * serve 正串行处理一条 wake、无法即时响应新 @（issue #103）。DO 从最近一条 status 帧的 busy 写入，
+   * 仅 state != offline 且 busy 时下发；旧客户端忽略。用途：who/reach/web 显示「忙」，让同事把 ask 超时
+   * 当作「忙、稍后回」而非「失联」，别反复 @ 堆重复唤醒。**不参与可达性/租约判定**——忙 ≠ 不可达。
+   */
+  busy?: boolean;
+  /** 排在当前 wake 身后、尚未处理的 wake 数（issue #103）。仅 state != offline 且 >0 时下发。 */
+  queue_depth?: number;
 }
 
 export interface ChannelRoleAssignment {
@@ -465,6 +473,13 @@ export interface SendStatusFrame {
   context?: AgentContext;
   decision?: SendHostDecision;
   workflow?: SendStatusWorkflow;
+  /**
+   * serve 串行处理一条 wake 时置 true：正忙、无法即时响应新 @（issue #103）。空/false = 空闲。
+   * 服务端据此在 presence 上表达「忙」，让同事把 ask 超时当作「忙」而非「失联」，别反复 @ 堆重复唤醒。
+   */
+  busy?: boolean;
+  /** 当前排在身后、尚未处理的 wake 数（issue #103）。0/缺省 = 无积压。非负整数。 */
+  queue_depth?: number;
 }
 
 export type SendFrame = SendMessageFrame | SendStatusFrame;

--- a/web/src/components/PresenceBar.test.ts
+++ b/web/src/components/PresenceBar.test.ts
@@ -3,7 +3,7 @@ import type { PresenceEntry, Sender } from "@agentparty/shared";
 import { createElement } from "react";
 import { act, create, type ReactTestRenderer } from "react-test-renderer";
 import { LocaleProvider } from "../i18n/locale";
-import { buildGroups, countLiveGroups, ownerKey, pauseResumeAt, PresenceBar, type Item } from "./PresenceBar";
+import { buildGroups, busyLabel, countLiveGroups, ownerKey, pauseResumeAt, PresenceBar, type Item } from "./PresenceBar";
 
 function item(over: Partial<Item> = {}): Item {
   return {
@@ -126,6 +126,10 @@ function presenceEntry(clientVersion?: string): PresenceEntry {
   };
 }
 
+function busyEntry(over: Partial<PresenceEntry> = {}): PresenceEntry {
+  return { name: "agent-a", kind: "agent", state: "working", note: null, ts: Date.now(), busy: true, ...over };
+}
+
 const participants: Sender[] = [{ name: "agent-a", kind: "agent" }];
 let renderer: ReactTestRenderer | null = null;
 
@@ -197,6 +201,41 @@ describe("presence client version", () => {
     const r = renderPresence(presenceEntry());
 
     expect(nodesWithClass(r, "presence-client-version")).toHaveLength(0);
+  });
+});
+
+// busy + 队列深度（#103）：serve 串行处理长任务时，presence 要显式表达「忙 + N 待处理」，
+// 与 working 蜡笔点区分，让人别把「@ 了没立刻回」当失联。
+describe("busy indicator + queue depth (#103)", () => {
+  test("busyLabel: 忙无队列 / 忙有队列 / 不忙三态", () => {
+    const it = (over: Partial<Item>) =>
+      ({ name: "a", busy: false, queueDepth: null, ...over }) as Item;
+    expect(busyLabel(it({ busy: true, queueDepth: null }))).toBe("⏳ busy");
+    expect(busyLabel(it({ busy: true, queueDepth: 4 }))).toBe("⏳ busy · 4 queued");
+    expect(busyLabel(it({ busy: false }))).toBeNull();
+  });
+
+  test("busy 项渲染琥珀徽章 + 顶部「N busy」汇总", () => {
+    const r = renderPresence(busyEntry({ queue_depth: 3 }));
+    const badges = nodesWithClass(r, "presence-busy");
+    expect(badges.length).toBeGreaterThan(0);
+    expect(badges.some((n) => n.children.join("").includes("⏳ busy · 3 queued"))).toBe(true);
+    const summary = nodesWithClass(r, "presence-alert--busy");
+    expect(summary).toHaveLength(1);
+    expect(summary[0]?.children.join("")).toContain("1 busy");
+  });
+
+  test("busy 但无队列：徽章只显示「busy」，不显示 queued", () => {
+    const r = renderPresence(busyEntry({ queue_depth: 0 }));
+    const badges = nodesWithClass(r, "presence-busy");
+    expect(badges.some((n) => n.children.join("") === "⏳ busy")).toBe(true);
+    expect(badges.some((n) => n.children.join("").includes("queued"))).toBe(false);
+  });
+
+  test("不忙的 working 项：不渲染 busy 徽章或汇总", () => {
+    const r = renderPresence(presenceEntry());
+    expect(nodesWithClass(r, "presence-busy")).toHaveLength(0);
+    expect(nodesWithClass(r, "presence-alert--busy")).toHaveLength(0);
   });
 });
 

--- a/web/src/components/PresenceBar.tsx
+++ b/web/src/components/PresenceBar.tsx
@@ -71,9 +71,11 @@ export interface Item {
   connectionCount: number;
   clientVersion: string | null;
   // 人为暂停接待（#180）：被 @ 也不唤醒（webhook 不投、serve/watch 自我抑制），消息仍进历史。
-  // 与 offline 语义/视觉都不同——不是掉线丢了，是人主动按下暂停。
   paused: boolean;
   resumeAt: number | null; // 定时恢复时刻（epoch ms）；null = 需手动恢复
+  // busy（#103）：serve 正串行处理一条 wake，可达但回复会慢。working = 在干活，busy = 正忙无法即时响应新 @。
+  busy: boolean;
+  queueDepth: number | null; // 忙时身后排队、尚未处理的 wake 数；>0 才有值
 }
 
 export interface PresenceGroup {
@@ -116,6 +118,12 @@ function residencyBadge(item: Item): string | null {
   if (item.residency === null) return null;
   if (item.residency === "human_driven") return "manual";
   return item.residency;
+}
+
+// busy 标签（#103）：「⏳ busy」或「⏳ busy · N queued」。null = 不忙，不渲染。
+export function busyLabel(item: Item): string | null {
+  if (!item.busy) return null;
+  return item.queueDepth !== null ? `⏳ busy · ${item.queueDepth} queued` : "⏳ busy";
 }
 
 function wakeabilityBadge(item: Item): { text: string; tone: "off" | "pending" | "on" } | null {
@@ -272,6 +280,9 @@ export function PresenceBar({
       // 暂停接待（#180）：即使 agent 离线也保留 paused（人主动设的状态，不随连接消失）。
       paused: entry?.paused === true,
       resumeAt: entry?.resume_at ?? null,
+      // busy/queueDepth（#103）：服务端只在 state != offline 且真忙时下发 busy，故离线项天然为 false。
+      busy: entry?.busy === true,
+      queueDepth: entry?.busy === true && typeof entry.queue_depth === "number" && entry.queue_depth > 0 ? entry.queue_depth : null,
     };
     if (!connected) {
       // owner 本就仅连接中的参与者可知（见上方字段注释）；handle 依赖同一份可信度，一并置空，
@@ -314,6 +325,7 @@ export function PresenceBar({
   // 顶部计数按账号折叠后的人数（非会话行数）——离线会话已在 buildGroups 里按 account 归并。
   const { live: liveGroups, total: totalGroups } = countLiveGroups(sortedGroups);
   const blockedCount = items.filter((it) => it.state === "blocked").length;
+  const busyCount = items.filter((it) => it.busy).length;
   const duplicateCount = items.filter((it) => it.connectionCount > 1).length;
   // 折叠态下 chip 不在 DOM 里，popover 也不该跟着冒出来。
   const activePopoverGroup =
@@ -331,10 +343,12 @@ export function PresenceBar({
     const badge = roleBadge(it, now);
     const residency = residencyBadge(it);
     const wakeability = wakeabilityBadge(it);
+    const busy = busyLabel(it);
     const activeHost = hasActiveHostLease(it, now);
     const full = mode === "full";
     const titleParts = [
       it.owner !== null && it.owner !== it.name ? `${it.name} · ${it.owner}` : it.name,
+      it.busy ? `busy${it.queueDepth !== null ? ` · ${it.queueDepth} queued` : ""} (reachable, reply may be slow — do not re-@)` : null,
       it.handle !== null && it.handle !== "" ? `handle: ${it.handle}` : null,
       it.role !== null ? `role: ${it.role}` : null,
       it.responsibility !== null && it.responsibility !== "" ? `responsibility: ${it.responsibility}` : null,
@@ -401,6 +415,7 @@ export function PresenceBar({
             {badge}
           </span>
         )}
+        {busy !== null && <span className="t-mono presence-busy">{busy}</span>}
         {full && it.lineage !== null && (
           <span className="t-mono presence-lineage">child:{it.lineage.parent_agent}</span>
         )}
@@ -565,6 +580,7 @@ export function PresenceBar({
                 )}
                 {agent.connectionCount > 1 && <span className="t-mono presence-agent-duplicate">x{agent.connectionCount}</span>}
                 {roleBadge(agent, now) !== null && <span className="t-mono presence-agent-role">{roleBadge(agent, now)}</span>}
+                {busyLabel(agent) !== null && <span className="t-mono presence-busy presence-busy--chip">{busyLabel(agent)}</span>}
               </span>
             ))}
             {hiddenAgents > 0 && <span className="t-mono presence-agent-more">+{hiddenAgents}</span>}
@@ -594,6 +610,11 @@ export function PresenceBar({
             <span className="presence-toggle-arrow" aria-hidden="true">{expanded ? "▾" : "▸"}</span>
           </button>
           {blockedCount > 0 && <span className="t-mono presence-alert">{blockedCount} blocked</span>}
+          {busyCount > 0 && (
+            <span className="t-mono presence-alert presence-alert--busy" title="serially handling a wake — reachable, reply may be slow">
+              ⏳ {busyCount} busy
+            </span>
+          )}
           {duplicateCount > 0 && <span className="t-mono presence-alert presence-alert--duplicate">{duplicateCount} duplicate</span>}
           {items.length === 0 && (
             <span className="t-mono presence-empty" role="status" aria-live="polite">

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -1205,6 +1205,12 @@
 .presence-alert--duplicate {
   background: var(--t-panel);
 }
+/* busy 汇总徽章（#103）：琥珀调，区别于红色 blocked 告警。 */
+.presence-alert--busy {
+  border-color: var(--d-amber);
+  color: var(--d-amber);
+  background: var(--d-amber-soft);
+}
 .presence-popover {
   position: fixed;
   z-index: 70;
@@ -1374,6 +1380,23 @@
 .presence-role--active {
   background: var(--d-green);
   color: #fff;
+}
+/* busy（#103）：琥珀蜡笔徽章，与 role/residency 同形，色调独立——一眼看出「忙、可达但回复慢」。 */
+.presence-busy {
+  flex: none;
+  padding: 1px 5px;
+  border: 1.4px solid var(--d-amber);
+  border-radius: 0;
+  background: var(--d-amber-soft);
+  color: var(--d-amber);
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+.presence-busy--chip {
+  font-size: 9px;
+  padding: 0 4px;
 }
 .presence-wake--off {
   border-color: var(--t-faint);

--- a/web/src/styles/tokens.css
+++ b/web/src/styles/tokens.css
@@ -60,6 +60,9 @@
   --d-red-soft: #3a1f1c;
   --d-blue-soft: #1a2436;
   --d-green-soft: #16301f;
+  /* busy（#103）：琥珀色，暗底提亮免糊背景 */
+  --d-amber: #e8a24a;
+  --d-amber-soft: #3a2a12;
   --code-bg: #0a0c10;
   --code-border: #3a4250;
   --scroll-track: #161a20;
@@ -76,6 +79,9 @@
   --d-blue-soft: #dde7ff;
   --d-green: #34b36b;
   --d-green-soft: #d8f0df;
+  /* busy（#103）：琥珀色，与 working 绿点、blocked 红明确区分 */
+  --d-amber: #c9720b;
+  --d-amber-soft: #ffeccb;
   /* 硬偏移阴影：淡墨而非重墨，阴影只提"纸片感"不抢戏 */
   --d-shadow: rgba(0, 0, 0, 0.16);
   /* 代码块 / 滚动条配色（midnight 有对应暗色覆盖） */
@@ -87,6 +93,7 @@
   --p-working: var(--d-green);
   --p-waiting: var(--d-blue);
   --p-blocked: var(--d-red);
+  --p-busy: var(--d-amber);
   --p-done: #8a857a;
   --p-offline: #cfcabb;
 

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -768,6 +768,17 @@ function parseSendFrame(input: unknown): SendFrame | null {
     if (decision === null) return null;
     const workflow = parseSendStatusWorkflow(f.workflow);
     if (workflow === null) return null;
+    // busy（#103）：serve 串行处理时自报「忙」。只认 boolean；false 也保留（用于把 busy 显式清回空闲）。
+    if (f.busy !== undefined && typeof f.busy !== "boolean") return null;
+    const busy = f.busy as boolean | undefined;
+    // queue_depth（#103）：非负整数，封顶防脏值撑爆展示。非法/负数 → 拒收（parseSendFrame 返 null）。
+    const queueDepth =
+      f.queue_depth === undefined
+        ? undefined
+        : typeof f.queue_depth === "number" && Number.isInteger(f.queue_depth) && f.queue_depth >= 0
+          ? Math.min(f.queue_depth, 100_000)
+          : null;
+    if (queueDepth === null) return null;
     return {
       type: "send",
       kind: "status",
@@ -783,6 +794,8 @@ function parseSendFrame(input: unknown): SendFrame | null {
       ...(context !== undefined ? { context } : {}),
       ...(decision !== undefined ? { decision } : {}),
       ...(workflow !== undefined ? { workflow } : {}),
+      ...(busy !== undefined ? { busy } : {}),
+      ...(queueDepth !== undefined ? { queue_depth: queueDepth } : {}),
       ...(idempotencyKey !== undefined ? { idempotency_key: idempotencyKey } : {}),
     };
   }
@@ -1009,6 +1022,9 @@ export class ChannelDO extends Server<Env> {
       // 人为「暂停接待」（issue #180）：paused_at 非 NULL 即暂停；paused_resume_at 为定时恢复时刻（epoch ms）。
       "ALTER TABLE presence ADD COLUMN paused_at INTEGER",
       "ALTER TABLE presence ADD COLUMN paused_resume_at INTEGER",
+      // busy + 队列深度（#103）：serve 串行处理长任务时自报「忙 + N 待处理」，供 who/reach/web 展示。
+      "ALTER TABLE presence ADD COLUMN busy INTEGER",
+      "ALTER TABLE presence ADD COLUMN queue_depth INTEGER",
     ]) {
       try {
         sql.exec(ddl);
@@ -2961,9 +2977,9 @@ export class ChannelDO extends Server<Env> {
            name, kind, account, handle, display_name, avatar_url, avatar_thumb,
            state, note, updated_at, status_scope_json, status_summary_seq, status_blocked_reason,
            status_context_json, status_decision_json, status_workflow_json, role, role_source, residency, wake_kind, wake_verified_at, context_json,
-           lineage_json
+           lineage_json, busy, queue_depth
          )
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
          ON CONFLICT(name) DO UPDATE SET
            kind = excluded.kind,
            account = COALESCE(excluded.account, presence.account),
@@ -2986,7 +3002,9 @@ export class ChannelDO extends Server<Env> {
            wake_kind = CASE WHEN ? THEN excluded.wake_kind ELSE presence.wake_kind END,
            wake_verified_at = CASE WHEN ? THEN excluded.wake_verified_at ELSE presence.wake_verified_at END,
            context_json = COALESCE(excluded.context_json, presence.context_json),
-           lineage_json = excluded.lineage_json`,
+           lineage_json = excluded.lineage_json,
+           busy = excluded.busy,
+           queue_depth = excluded.queue_depth`,
         identity.name,
         identity.kind,
         identity.owner ?? null, // 人类会话 = email，agent = 所属账号；presence.account 存它供前端显示「是谁」
@@ -3010,6 +3028,10 @@ export class ChannelDO extends Server<Env> {
         frame.wake?.verified_at ?? null,
         frame.context === undefined ? null : JSON.stringify(frame.context),
         identity.lineage === undefined ? null : JSON.stringify(identity.lineage),
+        // busy/queue_depth（#103）：每条 status 覆盖写（非 COALESCE）——不显式自报 busy 的 status
+        // （waiting/done/blocked 等）自然把 busy 清回 0，这就是「任务结束即清 busy」的落点。
+        frame.busy === true ? 1 : 0,
+        frame.queue_depth ?? 0,
         wakeProvided,
         wakeProvided,
       );
@@ -3649,7 +3671,7 @@ export class ChannelDO extends Server<Env> {
                 account, handle, display_name, avatar_url, avatar_thumb, client_version,
                 state, note, updated_at, status_scope_json, status_summary_seq, status_blocked_reason,
                 status_context_json, status_decision_json, status_workflow_json, role, role_source, residency, wake_kind, wake_verified_at,
-                context_json, lineage_json, paused_at, paused_resume_at`;
+                context_json, lineage_json, paused_at, paused_resume_at, busy, queue_depth`;
 
   private presenceList(): PresenceEntry[] {
     const liveCounts = this.liveConnectionCounts();
@@ -3728,6 +3750,10 @@ export class ChannelDO extends Server<Env> {
         const lineage = parseStoredLineage(r.lineage_json);
         return lineage === undefined ? {} : { lineage };
       })(),
+      // busy/queue_depth（#103）：仅在真的 busy / 有积压时下发，且 offline 一律不带（离线谈不上「忙」）。
+      // 缺省即「不忙、无积压」，旧客户端与旧行没这两列时 Number(undefined/null)=0/NaN，天然回退。
+      ...(state !== "offline" && Number(r.busy) === 1 ? { busy: true } : {}),
+      ...(state !== "offline" && Number(r.queue_depth) > 0 ? { queue_depth: Number(r.queue_depth) } : {}),
     };
   }
 

--- a/worker/test/presence-busy.spec.ts
+++ b/worker/test/presence-busy.spec.ts
@@ -1,0 +1,100 @@
+import type { PresenceEntry } from "@agentparty/shared";
+import { describe, expect, it } from "vitest";
+import { WsClient, api, createChannel, seedToken } from "./helpers";
+
+async function fetchPresence(slug: string, token: string): Promise<PresenceEntry[]> {
+  const res = await api(`/api/channels/${slug}/presence`, token);
+  expect(res.status).toBe(200);
+  return ((await res.json()) as { presence: PresenceEntry[] }).presence;
+}
+
+async function sendStatus(ws: WsClient, frame: Record<string, unknown>): Promise<void> {
+  ws.send({ type: "send", kind: "status", state: "working", note: "n", mentions: [], ...frame });
+  await ws.nextOfType("sent");
+  await ws.nextOfType("status");
+}
+
+describe("presence busy + queue depth (issue #103)", () => {
+  it("reflects busy=true and queue_depth from a status frame in the presence snapshot", async () => {
+    const agent = await seedToken("agent");
+    const slug = await createChannel(agent.token);
+    const ws = await WsClient.open(slug, agent.token);
+    await ws.nextOfType("welcome");
+    ws.send({ type: "hello", since: 0 });
+
+    await sendStatus(ws, { state: "working", busy: true, queue_depth: 3 });
+
+    const entry = (await fetchPresence(slug, agent.token)).find((e) => e.name === agent.name);
+    expect(entry).toMatchObject({ busy: true, queue_depth: 3 });
+    ws.close();
+  });
+
+  it("clears busy when a later status omits it (serve goes idle)", async () => {
+    const agent = await seedToken("agent");
+    const slug = await createChannel(agent.token);
+    const ws = await WsClient.open(slug, agent.token);
+    await ws.nextOfType("welcome");
+    ws.send({ type: "hello", since: 0 });
+
+    await sendStatus(ws, { state: "working", busy: true, queue_depth: 2 });
+    await sendStatus(ws, { state: "waiting", busy: false });
+
+    const entry = (await fetchPresence(slug, agent.token)).find((e) => e.name === agent.name);
+    expect(entry).toBeDefined();
+    expect(entry).not.toHaveProperty("busy");
+    expect(entry).not.toHaveProperty("queue_depth");
+    ws.close();
+  });
+
+  it("omits busy/queue_depth entirely for a plain status (backward compatible)", async () => {
+    const agent = await seedToken("agent");
+    const slug = await createChannel(agent.token);
+    const ws = await WsClient.open(slug, agent.token);
+    await ws.nextOfType("welcome");
+    ws.send({ type: "hello", since: 0 });
+
+    await sendStatus(ws, { state: "working" });
+
+    const entry = (await fetchPresence(slug, agent.token)).find((e) => e.name === agent.name);
+    expect(entry).toBeDefined();
+    expect(entry).not.toHaveProperty("busy");
+    expect(entry).not.toHaveProperty("queue_depth");
+    ws.close();
+  });
+
+  it("broadcasts busy on the presence frame to other readers", async () => {
+    const agent = await seedToken("agent");
+    const observer = await seedToken("human");
+    const slug = await createChannel(agent.token);
+    const watcher = await WsClient.open(slug, observer.token);
+    await watcher.nextOfType("welcome");
+
+    const ws = await WsClient.open(slug, agent.token);
+    await ws.nextOfType("welcome");
+    ws.send({ type: "hello", since: 0 });
+    ws.send({ type: "send", kind: "status", state: "working", note: "busy", mentions: [], busy: true, queue_depth: 5 });
+
+    for (;;) {
+      const frame = await watcher.nextOfType("presence");
+      if (frame.name === agent.name && frame.state === "working") {
+        expect(frame).toMatchObject({ busy: true, queue_depth: 5 });
+        break;
+      }
+    }
+    ws.close();
+    watcher.close();
+  });
+
+  it("rejects a malformed queue_depth (negative / non-integer)", async () => {
+    const agent = await seedToken("agent");
+    const slug = await createChannel(agent.token);
+    const ws = await WsClient.open(slug, agent.token);
+    await ws.nextOfType("welcome");
+    ws.send({ type: "hello", since: 0 });
+
+    ws.send({ type: "send", kind: "status", state: "working", note: "bad", mentions: [], queue_depth: -1 });
+    const err = await ws.nextOfType("error");
+    expect(err.code).toBe("bad_request");
+    ws.close();
+  });
+});


### PR DESCRIPTION
## 做什么（#103，owner 2026-07-11 拍板「加 busy + 队列深度」）

serve 串行跑长任务（如 40 分钟 codex run）时，presence 仍显 working/可达，同事 `party ask` 超时 → 判失联 → 反复 @ → 队列塞进更多重复唤醒。现在 presence 能表达 **busy** + **队列深度**，who/ask/reach 显示「在忙·N 排队·别再 @」。

## 设计
- `busy` 是**与状态机正交的布尔**（不是新 state），`queue_depth` 非负整数——不动任何 branch on `state` 的逻辑（wakeReachable/host-lease/summarizeHosts），把对 #165/#180 并行 presence 改动的 churn 降到最小。
- 落 DO presence 表（幂等 onStart ALTER，非 D1 迁移），**overwrite 非 COALESCE**：任何不声明 busy 的 status（waiting/done/blocked）都把它清零——**这就是「任务完成→busy 清除」机制**。
- `queue_depth` 由 serve 采集：builtin/sdk runner 把 `busy:true`+`queue_depth` 盖在既有 working ack 帧上；depth = 当前唤醒身后会触发唤醒的缓冲帧数。队列排空后 serve 发一条 `waiting busy:false` idle-clear（去重、仅真 runner）。
- **surfacing**：`party who`（+json）`⏳ busy · N queued` + 图例「可达但回复慢，别再 @」；`send --reach` 显示 `busy, N queued`（ask 超时读作 busy 非 offline）；web amber busy 徽章（区别绿色 working 点）+ 每 agent 队列数 + 顶部「⏳ N busy」汇总。

## 门禁（我对 origin HEAD rebase 到最新 main 后亲验）
- worker presence-busy spec 5/5；cli 560/0；web 430/0；tsc worker/shared/cli/web 全 0；web build 0。rebase 无冲突。
- worker 全量 51 spec/350 test 分批全过（一次性全跑撞 miniflare exit 144 环境 flake，与本改动无关，分批全绿）。
- 变异：worker INSERT busy 绑死 0 → presence-busy 测试红（亲跑确认）；共 7 条（worker 绑定/读闸/校验、serve idle-clear、reach、who、web label）各自咬。

## 评审请确认（agent 标注）
1. busy+0 只显「busy」、busy+N 显数；长跑中 depth 是 dispatch 时快照（串行 loop 卡在 run() 内物理上无法中途重发），同事跑中 @ 看到 `busy:true`（关键修复），计数下次转移才更新——符合 issue「on transitions, not per-tick」。
2. `--cmd` 裸模式不显 busy（用户命令自己管 presence）；如需可作后续。
3. idle-clear 每次排空多发一条 `waiting`——顺带修了个潜在陈旧（serve 唤醒后从不发 waiting、presence 卡在 working）；loop-guard 计一条 agent 消息但默认关、限于 idle 转移。
4. do.ts churn 仅 busy/queue_depth 两列，应对 #165/#180 rebase 干净。

🤖 opus agent 实现（含完整 who/ask/reach/web 打磨 + 边界测试）、经我对 origin HEAD 亲验（rebase+全门禁+busy 绑定变异）；走 PR 由 @leeguooooo / LEO-MAIN 审后合，未自合。
