### PR TITLE
fix(worker): DO meta 配置缓存加单调/权威守卫，在途旧快照不再回滚（#102）

### DIFF
--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -1563,7 +1563,16 @@ export class ChannelDO extends Server<Env> {
   }
 
   // worker 每次转发都会带上频道快照头，do 写 meta 缓存（同 archived 的手法）
-  private cacheChannelMeta(h: Headers, host: string | null) {
+  // 每个请求都带着自己那一刻的 D1 快照头进来。无脑 last-writer-wins 会让在途旧快照回滚
+  // 刚改的配置（#102）——正如 archived 早就防住的同一竞态：archived 只由权威路径写、且是单向
+  // 闩，旧快照掀不回去。这里对 charter_rev / guard config 补上同款防线：
+  //   - charter_rev 天生是单调计数器（D1 里只 +1），只接受 rev ≥ 已缓存值；旧快照的小 rev 丢弃。
+  //   - guard config（loop/workflow 的 enabled/limit）没有自带版本号，无法比较新旧。于是照搬
+  //     archived 的手法「DO 自己写下的值即权威」：只有权威配置推送（/internal/init，由 guard PUT
+  //     触发）能改动已缓存的 guard 值；在途请求的顺带快照只能在 DO 从未缓存过时做首次播种，绝不
+  //     覆盖已有值——这样管理员刚关掉的 guard 不会被旧快照又打开。
+  private cacheChannelMeta(h: Headers, host: string | null, opts?: { authoritative?: boolean }) {
+    const authoritative = opts?.authoritative === true;
     const mode = h.get("x-ap-mode");
     if (mode === "normal" || mode === "party") this.setMeta("mode", mode);
     const ckind = h.get("x-ap-channel-kind");
@@ -1574,27 +1583,38 @@ export class ChannelDO extends Server<Env> {
     if (completionReviewPolicy === "sender" || completionReviewPolicy === "owner") {
       this.setMeta("completion_review_policy", completionReviewPolicy);
     }
-    const loopGuardEnabled = h.get("x-ap-loop-guard-enabled");
-    if (loopGuardEnabled === "0" || loopGuardEnabled === "1") {
-      this.setMeta("loop_guard_enabled", loopGuardEnabled);
-      if (loopGuardEnabled === "0") this.deleteMeta("loop_guard_limit");
+    // loop guard：权威推送随意改；顺带快照只在从未缓存 enabled 时播种，不回滚
+    if (authoritative || this.getMeta("loop_guard_enabled") === null) {
+      const loopGuardEnabled = h.get("x-ap-loop-guard-enabled");
+      if (loopGuardEnabled === "0" || loopGuardEnabled === "1") {
+        this.setMeta("loop_guard_enabled", loopGuardEnabled);
+        if (loopGuardEnabled === "0") this.deleteMeta("loop_guard_limit");
+      }
+      const rawLoopGuardLimit = h.get("x-ap-loop-guard-limit");
+      if (rawLoopGuardLimit === "") this.deleteMeta("loop_guard_limit");
+      const loopGuardLimit = Number(rawLoopGuardLimit ?? "");
+      if (Number.isInteger(loopGuardLimit) && loopGuardLimit > 0) {
+        this.setMeta("loop_guard_limit", String(Math.min(loopGuardLimit, 10_000)));
+      }
     }
-    const rawLoopGuardLimit = h.get("x-ap-loop-guard-limit");
-    if (rawLoopGuardLimit === "") this.deleteMeta("loop_guard_limit");
-    const loopGuardLimit = Number(rawLoopGuardLimit ?? "");
-    if (Number.isInteger(loopGuardLimit) && loopGuardLimit > 0) {
-      this.setMeta("loop_guard_limit", String(Math.min(loopGuardLimit, 10_000)));
+    // workflow guard：同上
+    if (authoritative || this.getMeta("workflow_guard_enabled") === null) {
+      const workflowGuardEnabled = h.get("x-ap-workflow-guard-enabled");
+      if (workflowGuardEnabled === "0" || workflowGuardEnabled === "1") {
+        this.setMeta("workflow_guard_enabled", workflowGuardEnabled);
+      }
+      const workflowGuardLimit = Number(h.get("x-ap-workflow-guard-limit") ?? "");
+      if (Number.isInteger(workflowGuardLimit) && workflowGuardLimit > 0) {
+        this.setMeta("workflow_guard_limit", String(Math.min(workflowGuardLimit, 1000)));
+      }
     }
-    const workflowGuardEnabled = h.get("x-ap-workflow-guard-enabled");
-    if (workflowGuardEnabled === "0" || workflowGuardEnabled === "1") {
-      this.setMeta("workflow_guard_enabled", workflowGuardEnabled);
-    }
-    const workflowGuardLimit = Number(h.get("x-ap-workflow-guard-limit") ?? "");
-    if (Number.isInteger(workflowGuardLimit) && workflowGuardLimit > 0) {
-      this.setMeta("workflow_guard_limit", String(Math.min(workflowGuardLimit, 1000)));
-    }
+    // charter_rev：单调守卫，只前进不后退（旧快照的小 rev 丢弃）
     const charterRev = Number(h.get("x-ap-charter-rev") ?? "");
-    if (Number.isInteger(charterRev) && charterRev >= 0) this.setMeta("charter_rev", String(charterRev));
+    if (Number.isInteger(charterRev) && charterRev >= 0) {
+      const cachedRaw = Number(this.getMeta("charter_rev") ?? "");
+      const cached = Number.isInteger(cachedRaw) ? cachedRaw : -1;
+      if (charterRev >= cached) this.setMeta("charter_rev", String(charterRev));
+    }
     if (host) this.setMeta("host", host);
   }
 
@@ -1968,7 +1988,9 @@ export class ChannelDO extends Server<Env> {
       return Response.json({ identities: [...identities.values()].sort((a, b) => a.name.localeCompare(b.name)) });
     }
     if (url.pathname === "/internal/init" && request.method === "POST") {
-      this.cacheChannelMeta(request.headers, request.headers.get("x-ap-host"));
+      // /internal/init 是权威配置推送（channel 创建 + 每次 guard PUT 都打这条），
+      // 承载当下 D1 的真值，故允许改动已缓存的 guard config（#102）。
+      this.cacheChannelMeta(request.headers, request.headers.get("x-ap-host"), { authoritative: true });
       if (this.getMeta("ckind") === "temp") {
         const born = Date.now();
         this.setMeta("born", String(born));

--- a/worker/test/do-meta-version.spec.ts
+++ b/worker/test/do-meta-version.spec.ts
@@ -1,0 +1,134 @@
+import { env, runInDurableObject } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import type { ChannelDO } from "../src/do";
+import { createChannel, seedToken } from "./helpers";
+
+// #102: cacheChannelMeta 无条件写入每个请求携带的 D1 快照头，charter_rev/guard 无版本守卫。
+// 在途旧快照可静默回滚刚改的配置（作者已对 archived 防了同一竞态）。这里在 DO 层直接复现：
+//   - authoritative 配置推送 == worker 的 /internal/init（guard PUT 触发）
+//   - incidental 快照 == 任何在途请求按自带 D1 快照重新缓存（onConnect / send / guard 读）
+type MetaHeaders = {
+  loopEnabled?: string;
+  loopLimit?: string;
+  workflowEnabled?: string;
+  workflowLimit?: string;
+  charterRev?: string;
+};
+
+function headers(h: MetaHeaders): Record<string, string> {
+  return {
+    "x-ap-mode": "normal",
+    "x-ap-channel-kind": "standing",
+    "x-ap-completion-gate": "off",
+    "x-ap-completion-review-policy": "sender",
+    "x-ap-loop-guard-enabled": h.loopEnabled ?? "1",
+    "x-ap-loop-guard-limit": h.loopLimit ?? "",
+    "x-ap-workflow-guard-enabled": h.workflowEnabled ?? "0",
+    "x-ap-workflow-guard-limit": h.workflowLimit ?? "30",
+    "x-ap-charter-rev": h.charterRev ?? "0",
+    "x-ap-host": "ap.test",
+  };
+}
+
+// 直接调 onRequest 会绕过 partyserver 的 onStart（建表），显式跑一次（幂等）。
+function ensureSchema(instance: ChannelDO) {
+  instance.onStart();
+}
+
+// 权威配置推送：guard PUT 关闭/开启守卫时 worker 打给 DO 的 /internal/init。
+async function authoritativePush(slug: string, h: MetaHeaders) {
+  const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+  await runInDurableObject(stub, async (instance: ChannelDO) => {
+    ensureSchema(instance);
+    const res = await instance.onRequest(
+      new Request("https://do/internal/init", { method: "POST", headers: headers(h) }),
+    );
+    expect(res.status).toBe(200);
+  });
+}
+
+// 在途请求：携带（可能过期的）D1 快照，走一条会顺带重新缓存 config 的读路径（/internal/guard）。
+async function incidentalSnapshot(slug: string, h: MetaHeaders) {
+  const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+  await runInDurableObject(stub, async (instance: ChannelDO) => {
+    ensureSchema(instance);
+    const res = await instance.onRequest(
+      new Request("https://do/internal/guard", { method: "GET", headers: headers(h) }),
+    );
+    expect(res.status).toBe(200);
+  });
+}
+
+async function meta(slug: string, key: string): Promise<string | null> {
+  const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+  return runInDurableObject(stub, async (_instance: ChannelDO, state) => {
+    const rows = state.storage.sql.exec("SELECT value FROM meta WHERE key = ?", key).toArray();
+    return rows.length > 0 ? String(rows[0]!.value) : null;
+  });
+}
+
+describe("DO meta config cache — 在途旧快照不得回滚 guard/charter_rev (#102)", () => {
+  it("stale snapshot re-enabling the loop guard does NOT roll back an admin disable", async () => {
+    const agent = await seedToken("agent");
+    const slug = await createChannel(agent.token);
+
+    // 频道默认开着：权威地写入 enabled=1, limit=5
+    await authoritativePush(slug, { loopEnabled: "1", loopLimit: "5" });
+    expect(await meta(slug, "loop_guard_enabled")).toBe("1");
+
+    // 管理员关闭 loop guard（权威配置推送）
+    await authoritativePush(slug, { loopEnabled: "0" });
+    expect(await meta(slug, "loop_guard_enabled")).toBe("0");
+    expect(await meta(slug, "loop_guard_limit")).toBeNull();
+
+    // 一个仍携带旧快照（enabled=1）的在途请求落地
+    await incidentalSnapshot(slug, { loopEnabled: "1", loopLimit: "5" });
+
+    // 绝不能把刚关掉的 guard 又打开
+    expect(await meta(slug, "loop_guard_enabled")).toBe("0");
+    expect(await meta(slug, "loop_guard_limit")).toBeNull();
+  });
+
+  it("a genuinely newer authoritative change still applies (re-enable after disable)", async () => {
+    const agent = await seedToken("agent");
+    const slug = await createChannel(agent.token);
+
+    await authoritativePush(slug, { loopEnabled: "0" });
+    expect(await meta(slug, "loop_guard_enabled")).toBe("0");
+
+    // 管理员重新开启并放宽阈值：权威推送必须生效
+    await authoritativePush(slug, { loopEnabled: "1", loopLimit: "7" });
+    expect(await meta(slug, "loop_guard_enabled")).toBe("1");
+    expect(await meta(slug, "loop_guard_limit")).toBe("7");
+  });
+
+  it("stale snapshot must not roll back a workflow-guard disable", async () => {
+    const agent = await seedToken("agent");
+    const slug = await createChannel(agent.token);
+
+    await authoritativePush(slug, { workflowEnabled: "1", workflowLimit: "30" });
+    expect(await meta(slug, "workflow_guard_enabled")).toBe("1");
+
+    await authoritativePush(slug, { workflowEnabled: "0" });
+    expect(await meta(slug, "workflow_guard_enabled")).toBe("0");
+
+    await incidentalSnapshot(slug, { workflowEnabled: "1", workflowLimit: "30" });
+    expect(await meta(slug, "workflow_guard_enabled")).toBe("0");
+  });
+
+  it("charter_rev only moves forward — a stale snapshot never rolls it back", async () => {
+    const agent = await seedToken("agent");
+    const slug = await createChannel(agent.token);
+
+    await authoritativePush(slug, { charterRev: "5" });
+    expect(await meta(slug, "charter_rev")).toBe("5");
+
+    // 在途旧快照携带更小的 rev
+    await incidentalSnapshot(slug, { charterRev: "3" });
+    expect(await meta(slug, "charter_rev")).toBe("5");
+
+    // 真正更新的 rev 仍然生效
+    await incidentalSnapshot(slug, { charterRev: "7" });
+    expect(await meta(slug, "charter_rev")).toBe("7");
+  });
+});


### PR DESCRIPTION
## 修什么（#102，[P2][design]，并发正确性 bug）

`cacheChannelMeta` 无条件用**每个请求携带的 D1 快照头**写 meta 缓存，`charter_rev` / guard config 无版本守卫。在途旧快照可静默回滚刚改的配置。

**失败场景**：管理员 PUT 关闭 loop guard 后，一个携带旧快照的在途请求把 meta 写回**开启**；全 WS 参与者无自愈 HTTP 路径，被熔断的 agent「明明关了还 409」。作者早已对 `archived` 防住同一竞态（`do.ts:1012`），guard/charter_rev 是遗漏。

## 怎么修（照搬 archived 的防线）
- **charter_rev**：天生单调计数器 → 只接受 `rev ≥ 已缓存`，旧快照的小 rev 丢弃。
- **guard config**（loop/workflow 的 enabled/limit）：无自带版本 → 照搬 archived「DO 自己写下的值即权威」。`cacheChannelMeta` 加 `opts.authoritative`；只有 **`/internal/init`** 传 `authoritative:true` 能改动已缓存 guard——而 `/internal/init` 正是 channel 创建 + **每次 guard PUT**（`index.ts:4327` loop-guard PUT、`4370` workflow-guard PUT）触发的权威推送，承载当下 D1 真值。在途请求的顺带快照只在 DO **从未缓存**该值时首次播种，绝不覆盖已有值。

**无回归**：合法改配置走 guard PUT → /internal/init → 权威写入正常生效；只有在途旧快照被挡。

## 门禁（agent 收尾截断，我接管提交 + 亲验）
- 新 spec `do-meta-version.spec.ts` 4/4（TDD，DO 层直接复现：authoritativePush=/internal/init vs incidentalSnapshot=/internal/guard）；worker tsc 0；rebase 到最新 main 无冲突。
- 变异：把 guard 权威守卫还原成 `if (true)`（last-writer-wins） → 回滚测试红；还原复绿。

## 评审请确认
- guard config 用「首次播种 + 仅权威改动」而非版本比较（因为 guard 快照头无版本号）——与 archived 一致。若日后给 guard 加 updated_at/版本，可升级成 charter_rev 那样的单调比较。
- diff 集中在 `cacheChannelMeta`(~1503) + `/internal/init` handler(~1921)，远离 presence 区，对 #103/#165/#180 rebase 干净。

🤖 opus agent 实现、经我逐行审（权威链：guard PUT→/internal/init 确认无回归）+ 接管收尾 + 复验；走 PR 由 @leeguooooo / LEO-MAIN 审后合，未自合。
