### PR TITLE
fix(cli): serve 交付物 [attach]/超限正文改走 R2 附件，不再静默 413 丢失（#109）

### DIFF
--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -1,7 +1,7 @@
 // party serve — 常驻监听频道，每条 @你 的消息触发一次本地命令，把「跑完就停的 session agent」
 // 用外部 supervisor 唤醒（wake GOAL 的 session 型那半；有入站 URL 的 runtime 走 webhook）。
 // 复用 client.connect 的自动重连帧流，真正常驻；命令串行执行（一条处理完再下一条，不并发抢跑）。
-import { EXIT_ARCHIVED, EXIT_AUTH, EXIT_STREAM_ENDED, EXIT_UPGRADED, type MsgFrame, type ServerFrame } from "@agentparty/shared";
+import { BODY_LIMIT, EXIT_ARCHIVED, EXIT_AUTH, EXIT_STREAM_ENDED, EXIT_UPGRADED, type MsgFrame, type ServerFrame } from "@agentparty/shared";
 import { maybeReexecUpgrade, upgradeNotice, type CliUpgradeNotice, type UpgradeDeps } from "../upgrade";
 import {
   appendFileSync,
@@ -16,7 +16,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { homedir, tmpdir } from "node:os";
-import { dirname, isAbsolute, join } from "node:path";
+import { basename, dirname, isAbsolute, join } from "node:path";
 import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
 import { readAccount } from "../account";
 import { connect } from "../client";
@@ -33,7 +33,7 @@ import {
   unreadFromCursor,
   writeStatuslineCache,
 } from "../statusline-cache";
-import { ensureProjectAgentChannelRuntime, fetchChannelCharter, listProjectAgentInvites, mintProjectAgentRuntimeToken, postMessage, RestError, type ChannelCharter, type ChannelProjectAgentInvite, type ProjectAgentChannelRuntime, type ProjectAgentProfile } from "../rest";
+import { ensureProjectAgentChannelRuntime, fetchChannelCharter, listProjectAgentInvites, mintProjectAgentRuntimeToken, postMessage, RestError, uploadAttachment, type ChannelCharter, type ChannelProjectAgentInvite, type ProjectAgentChannelRuntime, type ProjectAgentProfile } from "../rest";
 import { isName, isSlug } from "../validation";
 import { buildContext } from "./status";
 
@@ -174,6 +174,8 @@ export interface BuiltinRunnerOptions {
   authSourceFile?: string;
   now?: () => number;
   post?: typeof postMessage;
+  /** 交付物上传（#109）；默认真 REST。测试注入 mock。 */
+  uploadAttachment?: typeof uploadAttachment;
 }
 
 export interface ThreadLike {
@@ -196,6 +198,8 @@ export interface SdkRunnerOptions {
   codexFactory?: () => CodexLike | Promise<CodexLike>;
   now?: () => number;
   post?: typeof postMessage;
+  /** 交付物上传（#109）；默认真 REST。测试注入 mock。 */
+  uploadAttachment?: typeof uploadAttachment;
 }
 
 export interface ProjectAgentRunContext {
@@ -478,10 +482,123 @@ function attachmentPathFromRunnerText(text: string): string | null {
   return null;
 }
 
-function finalMessageBody(text: string, marker: string | null): string {
-  const attach = attachmentPathFromRunnerText(text);
-  if (attach) return readFileSync(attach, "utf8");
-  return marker ? `${marker}\n${text}` : text;
+const ATTACH_LINE_RE = /^\[attach:[^\]\r\n]+\]$/;
+
+// worker 存什么 content-type 就回什么（它 split(";")[0] 归一化）。给常见交付物一个像样的类型，
+// 让 web 的 AttachmentList 能正确渲染（图片走 <img>、文本可预览）；认不出就 octet-stream。
+const ATTACHMENT_CONTENT_TYPE_BY_EXT: Record<string, string> = {
+  diff: "text/x-diff; charset=utf-8",
+  patch: "text/x-diff; charset=utf-8",
+  md: "text/markdown; charset=utf-8",
+  markdown: "text/markdown; charset=utf-8",
+  txt: "text/plain; charset=utf-8",
+  log: "text/plain; charset=utf-8",
+  json: "application/json; charset=utf-8",
+  csv: "text/csv; charset=utf-8",
+  html: "text/html; charset=utf-8",
+  xml: "application/xml; charset=utf-8",
+  yaml: "text/yaml; charset=utf-8",
+  yml: "text/yaml; charset=utf-8",
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  webp: "image/webp",
+  svg: "image/svg+xml",
+  pdf: "application/pdf",
+  zip: "application/zip",
+};
+
+function guessAttachmentContentType(filename: string): string {
+  const dot = filename.lastIndexOf(".");
+  const ext = dot >= 0 ? filename.slice(dot + 1).toLowerCase() : "";
+  return ATTACHMENT_CONTENT_TYPE_BY_EXT[ext] ?? "application/octet-stream";
+}
+
+// worker 端 filename 校验：/^[^/\\\x00-\x1f\x7f]{1,255}$/（单段、无控制符）。消毒到合法单段。
+function safeAttachmentFilename(name: string): string {
+  const cleaned = name.replace(/[/\\\x00-\x1f\x7f]/g, "_").slice(0, 255);
+  return cleaned.length > 0 ? cleaned : "attachment";
+}
+
+function stripAttachLines(text: string): string {
+  return text
+    .split(/\r?\n/)
+    .filter((line) => !ATTACH_LINE_RE.test(line.trim()))
+    .join("\n")
+    .trim();
+}
+
+// 正文兜底裁剪：极少见——[attach] 周围的叙述文本本身超过 BODY_LIMIT。裁到安全字节数，附件仍完整。
+function clampInlineBody(body: string): string {
+  if (Buffer.byteLength(body, "utf8") <= BODY_LIMIT) return body;
+  return Buffer.from(body, "utf8").subarray(0, BODY_LIMIT - 1024).toString("utf8");
+}
+
+/**
+ * 交付一条 runner 结果（#109）。
+ *
+ * 旧实现把 [attach] 文件内容 / 长正文直接 inline 进消息 body：一撞 BODY_LIMIT(100KB) worker 就 413，
+ * 而那次 post 在 try/catch 之外，连 blocked 都发不出——交付物静默丢失。
+ *
+ * 现在：有 [attach] 交付物、或 inline 正文会超限，就先把 blob 传到 R2（复用 #176 的附件端点），
+ * 消息只带轻量正文 + 附件引用，走既有 AttachmentList 渲染。上传/交付失败由调用方兜进 WakeBlockedError，
+ * 最终 runServe 发 blocked（带原因），绝不静默丢。
+ */
+async function deliverRunnerMessage(opts: {
+  post: typeof postMessage;
+  upload: typeof uploadAttachment;
+  server: string;
+  token: string;
+  channel: string;
+  replyTo: number;
+  text: string;
+  marker: string | null;
+}): Promise<void> {
+  const { post, upload, server, token, channel, replyTo, text, marker } = opts;
+  // [attach:/abs/path]：交付物永远走 R2 附件（相对路径在此抛错，与旧行为一致）。
+  const attachPath = attachmentPathFromRunnerText(text);
+  if (attachPath !== null) {
+    const bytes = readFileSync(attachPath); // Buffer：逐字节，不做 utf8 往返，保住 #41 的完整性
+    const filename = safeAttachmentFilename(basename(attachPath));
+    const ref = await upload(server, token, channel, filename, bytes, guessAttachmentContentType(filename));
+    const rest = stripAttachLines(text);
+    const parts: string[] = [];
+    if (marker) parts.push(marker);
+    if (rest) parts.push(rest);
+    if (parts.length === 0) parts.push(`[attached ${filename}]`);
+    await post(server, token, channel, {
+      kind: "message",
+      body: clampInlineBody(parts.join("\n")),
+      mentions: [],
+      reply_to: replyTo,
+      attachments: [ref],
+    });
+    return;
+  }
+
+  const inline = marker ? `${marker}\n${text}` : text;
+  const inlineBytes = Buffer.byteLength(inline, "utf8");
+  if (inlineBytes > BODY_LIMIT) {
+    // 正文超 inline 上限：整段传成 R2 附件，正文只留一行指引（#109），不再撞 413。
+    const filename = `delivery-seq${replyTo}.md`;
+    const ref = await upload(server, token, channel, filename, Buffer.from(inline, "utf8"), "text/markdown; charset=utf-8");
+    await post(server, token, channel, {
+      kind: "message",
+      body: `[reply body ${inlineBytes} bytes exceeded the ${BODY_LIMIT}-byte inline limit; delivered as attachment ${filename}]`,
+      mentions: [],
+      reply_to: replyTo,
+      attachments: [ref],
+    });
+    return;
+  }
+
+  await post(server, token, channel, {
+    kind: "message",
+    body: inline,
+    mentions: [],
+    reply_to: replyTo,
+  });
 }
 
 async function defaultRunnerProcess(
@@ -827,11 +944,16 @@ export function createSdkRunner(opts: SdkRunnerOptions): NonNullable<ServeOption
         wakes: baseSession.wakes + 1,
       };
       writeSdkSession(sessionPath, session);
-      await post(opts.server, opts.token, opts.channel, {
-        kind: "message",
-        body,
-        mentions: [],
-        reply_to: frame.seq,
+      // 交付走统一路径：超限正文改走 R2 附件（#109），不再 inline 撞 413。上传失败落进下面的 catch。
+      await deliverRunnerMessage({
+        post,
+        upload: opts.uploadAttachment ?? uploadAttachment,
+        server: opts.server,
+        token: opts.token,
+        channel: opts.channel,
+        replyTo: frame.seq,
+        text: body,
+        marker: null,
       });
       appendRunnerLog(
         opts.workdir,
@@ -947,9 +1069,20 @@ export function createBuiltinRunner(opts: BuiltinRunnerOptions): NonNullable<Ser
 
     // resume 非零不再 cold-start（#206 门禁 P1②），所以不存在 session reset 这条路径了。
     const marker = oldSid ? null : `[session start: ${shortSid(finalSid)}]`;
-    let body: string;
+    // 交付：[attach] 交付物 / 超限正文改走 R2 附件（#109）。上传+发送整体包进 try —— 旧代码里
+    // 那次 post（含 413）在 try 外逃逸，交付物静默丢失；现在失败一律转 WakeBlockedError，
+    // 由 runServe 统一发 blocked（带原因）。
     try {
-      body = finalMessageBody(run.text, marker);
+      await deliverRunnerMessage({
+        post,
+        upload: opts.uploadAttachment ?? uploadAttachment,
+        server: opts.server,
+        token: opts.token,
+        channel: opts.channel,
+        replyTo: frame.seq,
+        text: run.text,
+        marker,
+      });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       appendRunnerLog(
@@ -958,12 +1091,6 @@ export function createBuiltinRunner(opts: BuiltinRunnerOptions): NonNullable<Ser
       );
       throw new WakeBlockedError(`builtin ${opts.harness} runner blocked: ${message}`);
     }
-    await post(opts.server, opts.token, opts.channel, {
-      kind: "message",
-      body,
-      mentions: [],
-      reply_to: frame.seq,
-    });
 
     appendRunnerLog(
       opts.workdir,

--- a/cli/src/rest.ts
+++ b/cli/src/rest.ts
@@ -1,6 +1,7 @@
 // rest api 封装
 import {
   type AgentLineage,
+  type Attachment,
   type CaptureKind,
   type CaptureRecord,
   type ChannelKind,
@@ -1068,6 +1069,28 @@ export async function postMessage(
     headers: bearerJson(token),
     body: JSON.stringify(body),
   })) as { seq: number; completion_review?: CompletionReview };
+}
+
+// 附件上传（#176/#109）：blob 进 R2，返回引用元数据；随消息带在 attachments 字段里。
+// serve 交付物（[attach] 文件 / 超过 BODY_LIMIT 的正文）走这里，绝不再 inline 进消息正文撞 413。
+// content-type 直接透传给 worker（它会 split(";")[0] 归一化）；content-length 由 fetch 依 body 自动补。
+export async function uploadAttachment(
+  server: string,
+  token: string,
+  slug: string,
+  filename: string,
+  bytes: Uint8Array,
+  contentType: string,
+): Promise<Attachment> {
+  return (await req(server, `/api/channels/${encodeURIComponent(slug)}/attachments?filename=${encodeURIComponent(filename)}`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": contentType,
+    },
+    // typed array 是合法 BodyInit；不能走 bearerJson（它会把 content-type 钉成 application/json）
+    body: bytes,
+  })) as Attachment;
 }
 
 export async function archiveChannel(server: string, token: string, slug: string): Promise<void> {

--- a/cli/test/serve.test.ts
+++ b/cli/test/serve.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, readlinkSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
-import { EXIT_ARCHIVED, type MsgFrame } from "@agentparty/shared";
+import { EXIT_ARCHIVED, type Attachment, type MsgFrame } from "@agentparty/shared";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -81,6 +81,23 @@ function postRecorder() {
     post: async (server: string, token: string, channel: string, body: MessagePayload) => {
       posts.push({ server, token, channel, body });
       return { seq: posts.length };
+    },
+  };
+}
+
+function uploadRecorder() {
+  const uploads: Array<{ server: string; token: string; channel: string; filename: string; bytes: Uint8Array; contentType: string }> = [];
+  return {
+    uploads,
+    upload: async (server: string, token: string, channel: string, filename: string, bytes: Uint8Array, contentType: string): Promise<Attachment> => {
+      uploads.push({ server, token, channel, filename, bytes: Uint8Array.from(bytes), contentType });
+      return {
+        key: `${channel}/00000000-0000-4000-8000-000000000000/${filename}`,
+        filename,
+        content_type: contentType,
+        size: bytes.byteLength,
+        url: `/api/channels/${channel}/attachments/00000000-0000-4000-8000-000000000000/${filename}`,
+      };
     },
   };
 }
@@ -365,8 +382,9 @@ describe("builtin runner", () => {
     expect(log).toContain("exit=0");
   });
 
-  test("[attach:path] passthrough sends the file bytes verbatim as the reply body (issue #41)", async () => {
+  test("[attach:path] uploads the file to R2 and references it as an attachment, not inlined (#41/#109)", async () => {
     const { posts, post } = postRecorder();
+    const { uploads, upload } = uploadRecorder();
     const workdir = tempDir();
     const payload = tempDir();
     const attachFile = join(payload, "delivery.diff");
@@ -387,12 +405,117 @@ describe("builtin runner", () => {
       workdir,
       runProcess,
       post,
+      uploadAttachment: upload,
     })(triggerFrame(41), runnerCtx());
+
+    // 交付物逐字节上传到 R2（不做 utf8 往返、不经模型转述），保住 #41 的完整性
+    expect(uploads).toHaveLength(1);
+    expect(uploads[0]!.filename).toBe("delivery.diff");
+    expect(Buffer.from(uploads[0]!.bytes).toString("utf8")).toBe(bytes);
 
     const finalPost = posts.at(-1)!;
     expect(finalPost.body).toMatchObject({ kind: "message", reply_to: 41 });
-    // 正文 = 文件逐字节,不是模型输出、不加 session marker、不含摘要行
-    expect((finalPost.body as { body: string }).body).toBe(bytes);
+    const msg = finalPost.body as { body: string; attachments?: Array<{ filename: string }> };
+    // 正文不再是文件内容（不再 inline → 不再撞 BODY_LIMIT / 413）；文件以附件引用随消息带上
+    expect(msg.body).not.toBe(bytes);
+    expect(msg.attachments).toHaveLength(1);
+    expect(msg.attachments![0]!.filename).toBe("delivery.diff");
+  });
+
+  test("oversize reply body is uploaded to R2 and referenced as an attachment, never a 413 (#109)", async () => {
+    const { posts, post } = postRecorder();
+    const { uploads, upload } = uploadRecorder();
+    const workdir = tempDir();
+    // 超过 BODY_LIMIT(100_000) 的正文：旧路径会 inline → worker 413 → 交付物静默丢失
+    const huge = "x".repeat(100_001);
+    const runProcess: RunnerProcess = async (args) => {
+      const out = args[args.indexOf("-o") + 1]!;
+      writeFileSync(out, huge);
+      return { code: 0, stdout: `session id: ${uuid(1)}\n`, stderr: "" };
+    };
+
+    await createBuiltinRunner({
+      server: "http://agentparty.test",
+      token: "ap_tok",
+      channel: "dev",
+      harness: "codex",
+      workdir,
+      runProcess,
+      post,
+      uploadAttachment: upload,
+    })(triggerFrame(50), runnerCtx());
+
+    expect(uploads).toHaveLength(1);
+    expect(uploads[0]!.bytes.byteLength).toBeGreaterThan(100_000);
+    const finalPost = posts.at(-1)!;
+    const msg = finalPost.body as { kind: string; body: string; attachments?: unknown[] };
+    expect(msg.kind).toBe("message");
+    expect(msg.attachments).toHaveLength(1);
+    // 送出的正文本身不再超限（否则 worker 仍会 413）
+    expect(Buffer.byteLength(msg.body, "utf8")).toBeLessThanOrEqual(100_000);
+  });
+
+  test("[attach] upload failure blocks the wake and posts no partial message (#109)", async () => {
+    const { posts, post } = postRecorder();
+    const workdir = tempDir();
+    const payload = tempDir();
+    const attachFile = join(payload, "delivery.diff");
+    writeFileSync(attachFile, "some artifact bytes");
+    const runProcess: RunnerProcess = async (args) => {
+      const out = args[args.indexOf("-o") + 1]!;
+      writeFileSync(out, `[attach:${attachFile}]\n`);
+      return { code: 0, stdout: `session id: ${uuid(1)}\n`, stderr: "" };
+    };
+    const upload = async (): Promise<Attachment> => {
+      throw new Error("attachment endpoint rejected: 413 too_large");
+    };
+
+    // 唤醒未送达：抛给调用方（否则 runServe 会 ack 掉这条 @），最终 blocked 由 runServe 统一发
+    await expect(
+      createBuiltinRunner({
+        server: "http://agentparty.test",
+        token: "ap_tok",
+        channel: "dev",
+        harness: "codex",
+        workdir,
+        runProcess,
+        post,
+        uploadAttachment: upload,
+      })(triggerFrame(51), runnerCtx()),
+    ).rejects.toThrow(/413 too_large/);
+
+    // 绝不发部分正文（附件上传失败就整条不发）
+    expect(posts.some((p) => (p.body as { kind?: string }).kind === "message")).toBe(false);
+  });
+
+  test("upload failure surfaces as a blocked status carrying the reason (runServe end to end, #109)", async () => {
+    const s = closeAfterOneMention();
+    const { posts, post } = postRecorder();
+    const workdir = tempDir();
+    const huge = "x".repeat(100_001);
+    const runProcess: RunnerProcess = async (args) => {
+      const out = args[args.indexOf("-o") + 1]!;
+      writeFileSync(out, huge);
+      return { code: 0, stdout: `session id: ${uuid(1)}\n`, stderr: "" };
+    };
+    const upload = async (): Promise<Attachment> => {
+      throw new Error("attachment endpoint rejected: 413 too_large");
+    };
+    const o = opts({
+      server: s.url,
+      post,
+      maxWakeAttempts: 1,
+      builtinRunner: { server: s.url, token: "ap_tok", channel: "dev", harness: "codex", workdir, runProcess, post, uploadAttachment: upload },
+    });
+
+    expect(await runServe(o)).toBe(EXIT_ARCHIVED);
+
+    const blocked = posts.find((p) => (p.body as { state?: string }).state === "blocked");
+    expect(blocked).toBeDefined();
+    // 不是静默 413：原因透传到 blocked_reason，人能看见交付为什么没送达
+    expect((blocked!.body as { blocked_reason?: string }).blocked_reason).toContain("413 too_large");
+    // 既然上传失败，绝不发出（半截）消息
+    expect(posts.some((p) => (p.body as { kind?: string }).kind === "message")).toBe(false);
   });
 
   test("[attach] with a relative path is refused, throws, and posts no partial body (issue #41)", async () => {


### PR DESCRIPTION
## 修什么（#109，[P3][design]）

serve runner 的交付物（`[attach]` 输出 + 超限回复正文）被内联进消息正文，撞 100KB `BODY_LIMIT` → worker `413`；而那条 post 在交付 try/catch **之外**，连 blocked 都发不出——交付物**静默丢失**。

## 怎么修（复用 #176 R2 附件基建）
- `cli/src/rest.ts` 新增 `uploadAttachment`：raw bytes POST 到 #176 的 `POST /api/channels/:slug/attachments`，返回 Attachment 引用。
- `cli/src/commands/serve.ts` 新 `deliverRunnerMessage` 统一 builtin(codex/claude) 与 codex-sdk 两条交付：
  - **`[attach:/abs/path]`** → 一律走 R2。文件按 Buffer 读（字节精确、不 utf8 round-trip，保住 #41 保证），basename 消毒成合法单段文件名、按扩展名猜 content-type（图片/文本在 web AttachmentList 正确渲染）；消息带 `attachments:[ref]` + 轻正文。
  - **无 attach 但内联正文 > BODY_LIMIT** → 整段上传成 `delivery-seq<seq>.md`，正文只留一行指针 + 引用，绝不 413。
  - **错误/超限路径**：整个 upload+post 在交付 try 内 → 任何失败抛 `WakeBlockedError` → `runServe` 发 **blocked 状态 + blocked_reason**。无静默丢、无半条消息。

## 门禁（我对 origin HEAD rebase 到最新 main 后亲验）
- cli 全量 584/0；serve.test.ts 39/0；cli/shared/worker tsc 0。rebase 无冲突。
- 变异：oversize 阈值 `> BODY_LIMIT` 抬高 100 万 → oversize R2 + e2e blocked 测试红（2 fail）；丢 `attachments:[ref]` → attach 测试红；吞交付失败不抛 → 3 测试红。均还原复绿。

## 评审注意
- **发现 main 上没有 #176 的 CLI `--attach` helper**（`a65af25` 只是 feat(worker,web)）——#282 的 cli/web 打磨 commit 合并时疑似丢了。我在 `rest.ts` 按 worker 实际契约新建了 `uploadAttachment`。这个 #282 打磨丢失我另查/另补。
- 扩到 codex-sdk runner（其 finalText 同样有 413 暴露），走同一 helper。
- 更新了 #41 那条「[attach] 逐字内联」测试断言成 R2 交付（那正是 #109 描述的 bug）。

🤖 opus agent 实现、经我逐行审 + 对 origin HEAD 亲验；走 PR。
