### PR TITLE
fix: 找回 #176 合并丢失的打磨（CLI --attach + web 拖拽/进度 + openapi）

### DIFF
--- a/cli/src/commands/send.ts
+++ b/cli/src/commands/send.ts
@@ -1,17 +1,22 @@
 // party send — rest 一次性发消息，成功后推进游标
+import { basename } from "node:path";
+import type { Attachment } from "@agentparty/shared";
 import { isHelpArg, parseArgs, str, strArray, unknownFlagError, valueFlagError, type Parsed } from "../args";
 import { advanceCursorPastOwnMessage, resolveChannel, type Config } from "../config";
 import { formatAuthDebugLine, resolveAuthDetailed } from "../oidc-cli";
-import { fetchMe, fetchPresence, handleRestError, postMessage } from "../rest";
+import { fetchMe, fetchPresence, handleRestError, postMessage, RestError, uploadAttachment } from "../rest";
 import { formatReachLine, reachOf } from "../reach";
 import { localStatuslineBase, statuslinePreview, unreadFromCursor, writeStatuslineCache } from "../statusline-cache";
 import { isName, isSlug, parsePositiveIntFlag } from "../validation";
 
-export const sendSpec = { repeatable: ["mention"], booleans: ["debug-auth", "reach", "no-reach"] };
-const SEND_FLAGS = ["channel", "reply-to", "mention", "debug-auth", "reach", "no-reach"];
-const HELP = `usage: party send <text|-> [--channel C] [--mention name]... [--reply-to seq] [--debug-auth]
+export const sendSpec = { repeatable: ["mention", "attach"], booleans: ["debug-auth", "reach", "no-reach"] };
+const SEND_FLAGS = ["channel", "reply-to", "mention", "attach", "debug-auth", "reach", "no-reach"];
+const HELP = `usage: party send <text|-> [--channel C] [--mention name]... [--attach path]... [--reply-to seq] [--debug-auth]
 
 Send one message to a channel. Use "-" as the body to read stdin.
+
+With --attach, each file is uploaded to the channel first, then the message is sent
+carrying the attachment refs. Body may be empty when at least one --attach is present.
 
 After a send with --mention, a reachability line prints to stderr — whether each
 target is ● online / ◐ wakeable / ○ offline (won't reach until it reconnects).
@@ -20,16 +25,85 @@ On by default in an interactive terminal; --reach forces it, --no-reach silences
 Options:
   --channel C      send to channel C instead of the bound channel
   --mention name   mention a user or agent; repeatable
+  --attach path    upload a local file and attach it; repeatable (max 25MB each)
   --reply-to seq   attach this message as a reply to seq
   --reach          show mention reachability even when not a TTY (agent loops)
   --no-reach       never show mention reachability
   --debug-auth     print resolved auth/config source to stderr`;
+
+// 附件上限与文件名规则与 worker 侧保持一致（#176）：本地先挡一刀，给出比服务端 413 更贴切的文案。
+const ATTACH_SIZE_LIMIT = 25 * 1024 * 1024;
+const ATTACH_FILENAME_RE = /^[^/\\\x00-\x1f\x7f]{1,255}$/;
+
+// 常见类型的扩展名 → MIME 映射；命中不了回退 application/octet-stream，让服务端按 nosniff 处理。
+const CONTENT_TYPE_BY_EXT: Record<string, string> = {
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  webp: "image/webp",
+  svg: "image/svg+xml",
+  pdf: "application/pdf",
+  txt: "text/plain",
+  md: "text/markdown",
+  json: "application/json",
+  csv: "text/csv",
+  zip: "application/zip",
+  log: "text/plain",
+};
+
+function guessContentType(filename: string): string {
+  const ext = filename.includes(".") ? filename.slice(filename.lastIndexOf(".") + 1).toLowerCase() : "";
+  return CONTENT_TYPE_BY_EXT[ext] ?? "application/octet-stream";
+}
+
+export interface AttachSource {
+  path: string;
+  filename: string;
+  size: number;
+  contentType: string;
+  bytes: Uint8Array;
+}
 
 export interface SendInput {
   channel: string;
   body: string;
   mentions: string[];
   replyTo: number | null;
+  attachPaths: string[];
+}
+
+// 本地路径 → 上传源：不存在/空文件/超限一律抛带路径的可读错误，绝不静默上传半个包。
+export async function resolveAttachments(paths: string[]): Promise<AttachSource[]> {
+  const sources: AttachSource[] = [];
+  for (const path of paths) {
+    const file = Bun.file(path);
+    if (!(await file.exists())) throw new Error(`attach: file not found: ${path}`);
+    const filename = basename(path);
+    if (!ATTACH_FILENAME_RE.test(filename)) {
+      throw new Error(`attach: illegal filename (single path segment, <=255 chars, no control chars): ${filename}`);
+    }
+    const bytes = new Uint8Array(await file.arrayBuffer());
+    if (bytes.byteLength === 0) throw new Error(`attach: file is empty: ${path}`);
+    if (bytes.byteLength > ATTACH_SIZE_LIMIT) throw new Error(`attach: ${filename}: file too large (max 25MB)`);
+    sources.push({ path, filename, size: bytes.byteLength, contentType: guessContentType(filename), bytes });
+  }
+  return sources;
+}
+
+// 逐个上传，保序返回引用。upload 可注入以便测试；默认走 rest.uploadAttachment。
+export async function collectAttachments(
+  server: string,
+  token: string,
+  slug: string,
+  sources: AttachSource[],
+  upload: typeof uploadAttachment = uploadAttachment,
+): Promise<Attachment[]> {
+  const refs: Attachment[] = [];
+  for (const src of sources) {
+    refs.push(await upload(server, token, slug, { name: src.filename, type: src.contentType, bytes: src.bytes }));
+  }
+  return refs;
 }
 
 export async function resolveSendInput(parsed: Parsed): Promise<SendInput | null> {
@@ -39,11 +113,12 @@ export async function resolveSendInput(parsed: Parsed): Promise<SendInput | null
     console.error(unknown);
     return null;
   }
-  const flagError = valueFlagError(flags, ["channel", "reply-to"], ["mention"]);
+  const flagError = valueFlagError(flags, ["channel", "reply-to"], ["mention", "attach"]);
   if (flagError !== null) {
     console.error(flagError);
     return null;
   }
+  const attachPaths = strArray(flags.attach) ?? [];
   const replyTo = parsePositiveIntFlag(str(flags["reply-to"]), "reply-to");
   if (typeof replyTo === "string") {
     console.error(replyTo);
@@ -82,8 +157,13 @@ export async function resolveSendInput(parsed: Parsed): Promise<SendInput | null
   if (readStdin) {
     text = await Bun.stdin.text();
   } else if (text === undefined) {
-    console.error("missing message body (use - to read stdin)");
-    return null;
+    // 纯附件消息（#176）：有 --attach 就允许空正文，与网页端「纯图片消息」一致。
+    if (attachPaths.length > 0) {
+      text = "";
+    } else {
+      console.error("missing message body (use - to read stdin, or --attach a file)");
+      return null;
+    }
   }
   // send footgun 软提示（#6）：无 --channel、≥2 个裸 positional、首个像 slug 且 ≠ 目标频道 →
   // 很可能误把「send <频道> <正文>」当成了子命令用法（首个词其实被并进了正文，发到了绑定频道）。
@@ -103,16 +183,46 @@ export async function resolveSendInput(parsed: Parsed): Promise<SendInput | null
     body: text,
     mentions,
     replyTo: replyTo ?? null,
+    attachPaths,
   };
 }
 
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
 export async function doSend(cfg: Config, input: SendInput): Promise<number | { seq: number }> {
+  // 先把 --attach 的文件上传到 R2，拿到引用；解析/上传任一失败就直接退，不发一条空引用的消息。
+  let attachments: Attachment[] | undefined;
+  if (input.attachPaths.length > 0) {
+    let sources: AttachSource[];
+    try {
+      sources = await resolveAttachments(input.attachPaths);
+    } catch (e) {
+      console.error(`error: ${e instanceof Error ? e.message : String(e)}`);
+      return 1;
+    }
+    try {
+      attachments = await collectAttachments(cfg.server, cfg.token, input.channel, sources);
+    } catch (e) {
+      // 上传阶段 413 给「max 25MB」贴切文案（服务端消息是字节数，可读性差）；其余走契约退出码。
+      if (e instanceof RestError && (e.code === "too_large" || e.status === 413)) {
+        console.error("error: attachment too large (max 25MB)");
+        return 1;
+      }
+      return handleRestError(e);
+    }
+    for (const ref of attachments) console.error(`uploaded ${ref.filename} (${formatSize(ref.size)})`);
+  }
   try {
     const { seq } = await postMessage(cfg.server, cfg.token, input.channel, {
       kind: "message",
       body: input.body,
       mentions: input.mentions,
       reply_to: input.replyTo,
+      ...(attachments !== undefined && attachments.length > 0 ? { attachments } : {}),
     });
     advanceCursorPastOwnMessage(input.channel, seq);
     writeStatuslineCache({
@@ -157,7 +267,8 @@ export async function run(argv: string[]): Promise<number> {
   }
   const result = await doSend({ server: auth.server, token: auth.token }, input);
   if (typeof result === "number") return result;
-  console.log(`sent seq=${result.seq}`);
+  const attachNote = input.attachPaths.length > 0 ? ` (+${input.attachPaths.length} attachment${input.attachPaths.length > 1 ? "s" : ""})` : "";
+  console.log(`sent seq=${result.seq}${attachNote}`);
   await showReach(auth.server, auth.token, parsed, input);
   return 0;
 }

--- a/cli/src/rest.ts
+++ b/cli/src/rest.ts
@@ -1,6 +1,7 @@
 // rest api 封装
 import {
   type AgentLineage,
+  type Attachment,
   type CaptureKind,
   type CaptureRecord,
   type ChannelKind,
@@ -1050,6 +1051,27 @@ function newIdempotencyKey(): string {
   const rand: string[] = [];
   for (let i = 0; i < 16; i += 1) rand.push(ULID_CROCKFORD[rnd[i]! % 32]!);
   return time.join("") + rand.join("");
+}
+
+export type { Attachment };
+
+// 附件上传（#176）：把文件本体 POST 到频道附件端点，拿回 R2 引用元数据；随后 postMessage 时带在
+// attachments 字段里。413 too_large / 403 forbidden 由 req() 抛成带 code 的 RestError，调用方据此给文案。
+export async function uploadAttachment(
+  server: string,
+  token: string,
+  slug: string,
+  file: { name: string; type: string; bytes: Uint8Array },
+): Promise<Attachment> {
+  return (await req(
+    server,
+    `/api/channels/${encodeURIComponent(slug)}/attachments?filename=${encodeURIComponent(file.name)}`,
+    {
+      method: "POST",
+      headers: { authorization: `Bearer ${token}`, "content-type": file.type || "application/octet-stream" },
+      body: file.bytes,
+    },
+  )) as Attachment;
 }
 
 export async function postMessage(

--- a/cli/test/send-attach.test.ts
+++ b/cli/test/send-attach.test.ts
@@ -1,0 +1,97 @@
+// party send --attach（#176）：解析 --attach 路径、本地文件 → 上传源、上传并附加到消息。
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Attachment } from "@agentparty/shared";
+import { parseArgs } from "../src/args";
+import { collectAttachments, resolveAttachments, resolveSendInput, sendSpec } from "../src/commands/send";
+
+let dir = "";
+let png = "";
+let big = "";
+let empty = "";
+
+beforeAll(async () => {
+  dir = await mkdtemp(join(tmpdir(), "ap-attach-"));
+  png = join(dir, "pic.png");
+  big = join(dir, "huge.bin");
+  empty = join(dir, "empty.txt");
+  await writeFile(png, new Uint8Array([0x89, 0x50, 0x4e, 0x47, 1, 2, 3, 4]));
+  await writeFile(big, new Uint8Array(25 * 1024 * 1024 + 1));
+  await writeFile(empty, new Uint8Array(0));
+});
+
+afterAll(async () => {
+  if (dir) await rm(dir, { recursive: true, force: true });
+});
+
+describe("send --attach parsing", () => {
+  test("--attach is repeatable and collected into attachPaths", async () => {
+    const parsed = parseArgs(["hello", "--channel", "c", "--attach", "a.png", "--attach", "b.pdf"], sendSpec);
+    const input = await resolveSendInput(parsed);
+    expect(input).not.toBeNull();
+    expect(input!.attachPaths).toEqual(["a.png", "b.pdf"]);
+  });
+
+  test("empty body is allowed when --attach is present", async () => {
+    const parsed = parseArgs(["--channel", "c", "--attach", "a.png"], sendSpec);
+    const input = await resolveSendInput(parsed);
+    expect(input).not.toBeNull();
+    expect(input!.body).toBe("");
+    expect(input!.attachPaths).toEqual(["a.png"]);
+  });
+
+  test("without body or attachments it still errors", async () => {
+    const parsed = parseArgs(["--channel", "c"], sendSpec);
+    expect(await resolveSendInput(parsed)).toBeNull();
+  });
+});
+
+describe("resolveAttachments", () => {
+  test("reads a real file into an upload source with basename + size + type", async () => {
+    const [src] = await resolveAttachments([png]);
+    expect(src!.filename).toBe("pic.png");
+    expect(src!.size).toBe(8);
+    expect(src!.contentType).toBe("image/png");
+    expect(src!.bytes.byteLength).toBe(8);
+  });
+
+  test("missing file throws a legible not-found error naming the path", async () => {
+    await expect(resolveAttachments([join(dir, "nope.png")])).rejects.toThrow(/file not found/i);
+  });
+
+  test("oversize file throws max-25MB error", async () => {
+    await expect(resolveAttachments([big])).rejects.toThrow(/too large \(max 25MB\)/i);
+  });
+
+  test("empty file is rejected", async () => {
+    await expect(resolveAttachments([empty])).rejects.toThrow(/empty/i);
+  });
+});
+
+describe("collectAttachments", () => {
+  test("uploads each source and returns the refs in order", async () => {
+    const seen: string[] = [];
+    const upload = async (
+      _server: string,
+      _token: string,
+      slug: string,
+      file: { name: string },
+    ): Promise<Attachment> => {
+      seen.push(file.name);
+      return {
+        key: `${slug}/uuid/${file.name}`,
+        filename: file.name,
+        content_type: "image/png",
+        size: 8,
+        url: `/api/channels/${slug}/attachments/uuid/${file.name}`,
+      };
+    };
+    const sources = await resolveAttachments([png]);
+    const refs = await collectAttachments("https://s", "tok", "chan", sources, upload);
+    expect(seen).toEqual(["pic.png"]);
+    expect(refs).toHaveLength(1);
+    expect(refs[0]!.url).toBe("/api/channels/chan/attachments/uuid/pic.png");
+  });
+});

--- a/web/src/components/AttachmentList.tsx
+++ b/web/src/components/AttachmentList.tsx
@@ -66,9 +66,11 @@ function FileLink({ att }: { att: Attachment }) {
       type="button"
       className="d-btn msg-attachment-file t-mono"
       onClick={() => void onDownload()}
-      title={att.filename}
+      title={`${att.filename} · ${formatSize(att.size)} · download`}
     >
-      ⬇ {att.filename} <span className="msg-attachment-size">{formatSize(att.size)}</span>
+      <span aria-hidden="true">⬇</span>
+      <span className="msg-attachment-fname">{att.filename}</span>
+      <span className="msg-attachment-size">{formatSize(att.size)}</span>
     </button>
   );
 }

--- a/web/src/components/Composer.attachments.test.tsx
+++ b/web/src/components/Composer.attachments.test.tsx
@@ -38,6 +38,10 @@ const att: Attachment = {
   url: "/api/channels/slug/attachments/uuid/pic.png",
 };
 
+function fileList(...files: File[]): FileList {
+  return files as unknown as FileList;
+}
+
 function render(props: Partial<Parameters<typeof Composer>[0]>) {
   localStorage.setItem("ap_locale", "en");
   const base = {
@@ -100,5 +104,66 @@ describe("Composer attachments (#176)", () => {
     const removeBtn = byClass(root, "composer-attachment-remove")[0]!;
     act(() => removeBtn.props.onClick());
     expect(removed).toBe("slug/uuid/pic.png");
+  });
+
+  test("dropping files onto the composer forwards them to onPickFiles", () => {
+    let dropped: FileList | null = null;
+    const root = render({ onPickFiles: (f: FileList) => { dropped = f; } });
+    const composer = byClass(root, "composer")[0]!;
+    const file = new File([new Uint8Array([1, 2, 3])], "drop.png", { type: "image/png" });
+    act(() =>
+      composer.props.onDrop({ preventDefault() {}, stopPropagation() {}, dataTransfer: { files: fileList(file) } }),
+    );
+    expect(dropped).not.toBeNull();
+    expect(dropped![0]!.name).toBe("drop.png");
+  });
+
+  test("pasting an image forwards it to onPickFiles", () => {
+    let pasted: FileList | null = null;
+    const root = render({ onPickFiles: (f: FileList) => { pasted = f; } });
+    const textarea = byClass(root, "composer-input")[0]!;
+    const file = new File([new Uint8Array([1, 2, 3])], "clip.png", { type: "image/png" });
+    act(() => textarea.props.onPaste({ preventDefault() {}, clipboardData: { files: fileList(file) } }));
+    expect(pasted).not.toBeNull();
+    expect(pasted![0]!.name).toBe("clip.png");
+  });
+
+  test("pasting plain text (no files) does not call onPickFiles", () => {
+    let called = false;
+    const root = render({ onPickFiles: () => { called = true; } });
+    const textarea = byClass(root, "composer-input")[0]!;
+    act(() => textarea.props.onPaste({ preventDefault() {}, clipboardData: { files: fileList() } }));
+    expect(called).toBe(false);
+  });
+
+  test("an in-flight upload renders a chip with its filename", () => {
+    const root = render({
+      onPickFiles: () => {},
+      uploads: [{ id: "u1", filename: "up.png", size: 1234, status: "uploading" }],
+    });
+    const names = byClass(root, "composer-upload-name");
+    expect(names).toHaveLength(1);
+    expect(names[0]!.props.children).toBe("up.png");
+  });
+
+  test("a failed upload shows a retry button that calls onRetryUpload with the id", () => {
+    let retried: string | null = null;
+    const root = render({
+      onPickFiles: () => {},
+      uploads: [{ id: "u2", filename: "bad.png", size: 10, status: "error", error: "file too large (max 25MB)" }],
+      onRetryUpload: (id: string) => { retried = id; },
+    });
+    const retry = byClass(root, "composer-upload-retry")[0]!;
+    act(() => retry.props.onClick());
+    expect(retried).toBe("u2");
+  });
+
+  test("send is disabled while an upload is in flight, even with draft text", () => {
+    const root = render({
+      onPickFiles: () => {},
+      draft: "hi",
+      uploads: [{ id: "u3", filename: "wip.png", size: 10, status: "uploading" }],
+    });
+    expect(byClass(root, "composer-send")[0]!.props.disabled).toBe(true);
   });
 });

--- a/web/src/components/Composer.tsx
+++ b/web/src/components/Composer.tsx
@@ -1,7 +1,7 @@
 // 底部插话框：Markdown、@name mention（动态在线列表补全，issue #39）、Cmd/Ctrl+Enter 发送（spec §9 第 4 块）。
 // readonly / archived 时由页面层直接不渲染本组件（错误内联为条幅）。
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { ChangeEvent, CSSProperties, KeyboardEvent } from "react";
+import type { ChangeEvent, ClipboardEvent, CSSProperties, DragEvent, KeyboardEvent } from "react";
 import type { Attachment } from "@agentparty/shared";
 import { formatSize } from "./AttachmentList";
 import { agentHue } from "../lib/agentColor";
@@ -24,12 +24,25 @@ interface Props {
   ready: boolean; // ws open 才能发
   candidates: MentionCandidate[]; // @ 补全候选（participants ∪ presence，已分档排序）
   mentionStatuses: DraftMentionStatus[]; // 草稿里已 @ 的目标 + 当前存活档位（发送前提醒会不会白发）
-  // 附件（#176）：已上传待发的引用 + 选文件/移除回调 + 上传中/错误态。缺省即无附件能力。
+  // 附件（#176）：已上传待发的引用 + 选文件/移除回调 + 每文件上传中/错误态。缺省即无附件能力。
   attachments?: Attachment[];
   onPickFiles?: (files: FileList) => void;
   onRemoveAttachment?: (key: string) => void;
+  // 在途/失败的上传（每文件一条）；uploading 时禁发，error 时给重试/撤下。
+  uploads?: UploadItem[];
+  onRetryUpload?: (id: string) => void;
+  onCancelUpload?: (id: string) => void;
   uploading?: boolean;
   uploadError?: string | null;
+}
+
+// 上传中/失败的附件（#176）：已完成的进 attachments，在途/失败的进 uploads，各自成 chip。
+export interface UploadItem {
+  id: string;
+  filename: string;
+  size: number;
+  status: "uploading" | "error";
+  error?: string;
 }
 
 const TIER_DOT: Record<MentionTier, string> = { online: "●", wakeable: "◐", recent: "○" };
@@ -69,14 +82,19 @@ export function Composer({
   attachments = [],
   onPickFiles,
   onRemoveAttachment,
+  uploads = [],
+  onRetryUpload,
+  onCancelUpload,
   uploading = false,
   uploadError = null,
 }: Props) {
   const t = useT();
   const fileRef = useRef<HTMLInputElement | null>(null);
+  const [dragging, setDragging] = useState(false);
   const canAttach = onPickFiles !== undefined;
-  // 有附件时允许空正文发送（纯图片消息）
-  const sendDisabled = !ready || uploading || (draft.trim() === "" && attachments.length === 0);
+  const anyUploading = uploading || uploads.some((u) => u.status === "uploading");
+  // 有附件时允许空正文发送（纯图片消息）；任一上传在途时禁发，避免发出漏引用的半成品。
+  const sendDisabled = !ready || anyUploading || (draft.trim() === "" && attachments.length === 0);
   const TIER_LABEL: Record<MentionTier, string> = {
     online: t("Composer.tier.online"),
     wakeable: t("Composer.tier.wakeable"),
@@ -183,8 +201,47 @@ export function Composer({
     recompute(e.currentTarget.value, e.currentTarget.selectionStart ?? 0);
   };
 
+  // 拖拽到插话框任意处即上传（#176）。dragover 必须 preventDefault，否则浏览器不触发 drop。
+  const onDragOver = (e: DragEvent<HTMLDivElement>) => {
+    if (!canAttach) return;
+    e.preventDefault();
+    if (!dragging) setDragging(true);
+  };
+  const onDragLeave = (e: DragEvent<HTMLDivElement>) => {
+    // 只有真正离开 composer（而非移到子元素）才收起高亮
+    if (e.currentTarget.contains(e.relatedTarget as Node | null)) return;
+    setDragging(false);
+  };
+  const onDrop = (e: DragEvent<HTMLDivElement>) => {
+    if (!canAttach) return;
+    e.preventDefault();
+    e.stopPropagation();
+    setDragging(false);
+    const files = e.dataTransfer?.files;
+    if (files !== undefined && files.length > 0) onPickFiles?.(files);
+  };
+  // 剪贴板里带文件（截图/复制的图片或文件）即上传；纯文本粘贴不拦截，走默认插入。
+  const onPaste = (e: ClipboardEvent<HTMLTextAreaElement>) => {
+    if (!canAttach) return;
+    const files = e.clipboardData?.files;
+    if (files !== undefined && files.length > 0) {
+      e.preventDefault();
+      onPickFiles?.(files);
+    }
+  };
+
   return (
-    <div className="composer">
+    <div
+      className={"composer" + (dragging ? " composer--dragging" : "")}
+      onDragOver={onDragOver}
+      onDragLeave={onDragLeave}
+      onDrop={onDrop}
+    >
+      {dragging && (
+        <div className="composer-dropzone" aria-hidden="true">
+          {t("Composer.attach.dropHere")}
+        </div>
+      )}
       {menu !== null && (
         <ul className="mention-menu" role="listbox" aria-label="mention suggestions">
           {menu.items.map((c, i) => {
@@ -257,6 +314,7 @@ export function Composer({
         onKeyUp={onKeyUp}
         onClick={(e) => recompute(e.currentTarget.value, e.currentTarget.selectionStart ?? 0)}
         onKeyDown={onKeyDown}
+        onPaste={onPaste}
         onBlur={() => setTimeout(() => setMenu(null), 120)}
       />
       {attachments.length > 0 && (
@@ -271,6 +329,46 @@ export function Composer({
                   className="composer-attachment-remove"
                   aria-label={`remove ${att.filename}`}
                   onClick={() => onRemoveAttachment(att.key)}
+                >
+                  ×
+                </button>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+      {uploads.length > 0 && (
+        <ul className="composer-uploads" aria-label="uploads in progress">
+          {uploads.map((u) => (
+            <li key={u.id} className={`composer-upload composer-upload--${u.status} t-mono`}>
+              {u.status === "uploading" ? (
+                <span className="composer-upload-spinner" aria-hidden="true" />
+              ) : (
+                <span className="composer-upload-icon composer-upload-icon--error" aria-hidden="true">!</span>
+              )}
+              <span className="composer-upload-name">{u.filename}</span>
+              {u.status === "uploading" ? (
+                <span className="composer-upload-status">{t("Composer.upload.uploading")}</span>
+              ) : (
+                <span className="composer-upload-status composer-upload-error-text">
+                  {u.error ?? t("Composer.upload.failed")}
+                </span>
+              )}
+              {u.status === "error" && onRetryUpload !== undefined && (
+                <button
+                  type="button"
+                  className="composer-upload-retry"
+                  onClick={() => onRetryUpload(u.id)}
+                >
+                  {t("Composer.upload.retry")}
+                </button>
+              )}
+              {onCancelUpload !== undefined && (
+                <button
+                  type="button"
+                  className="composer-upload-cancel"
+                  aria-label={`dismiss ${u.filename}`}
+                  onClick={() => onCancelUpload(u.id)}
                 >
                   ×
                 </button>

--- a/web/src/i18n/strings/Composer.ts
+++ b/web/src/i18n/strings/Composer.ts
@@ -22,6 +22,10 @@ export const ComposerStrings: LocaleDict = {
     "Composer.attach.label": "attach",
     "Composer.attach.uploading": "uploading…",
     "Composer.attach.title": "attach images or files",
+    "Composer.attach.dropHere": "drop files to attach",
+    "Composer.upload.uploading": "uploading…",
+    "Composer.upload.failed": "upload failed",
+    "Composer.upload.retry": "retry",
   },
   zh: {
     "Composer.tier.online": "在线",
@@ -44,6 +48,10 @@ export const ComposerStrings: LocaleDict = {
     "Composer.attach.label": "附件",
     "Composer.attach.uploading": "上传中…",
     "Composer.attach.title": "上传图片或文件",
+    "Composer.attach.dropHere": "拖放文件以上传",
+    "Composer.upload.uploading": "上传中…",
+    "Composer.upload.failed": "上传失败",
+    "Composer.upload.retry": "重试",
   },
 };
 

--- a/web/src/pages/Channel.tsx
+++ b/web/src/pages/Channel.tsx
@@ -7,7 +7,7 @@ import { AgentJoin } from "../components/AgentJoin";
 import { AgentTokens } from "../components/AgentTokens";
 import { VisibilityToggle } from "../components/VisibilityToggle";
 import { JoinLink } from "../components/JoinLink";
-import { Composer } from "../components/Composer";
+import { Composer, type UploadItem } from "../components/Composer";
 import { Markdown } from "../components/Markdown";
 import { MessageCard } from "../components/MessageCard";
 import { MentionToast, type MentionToastItem } from "../components/MentionToast";
@@ -1665,10 +1665,11 @@ export function ChannelPage({
   const [state, dispatch] = useReducer(channelReducer, initialChannelState);
   const [channelIdentities, setChannelIdentities] = useState<ChannelIdentity[]>([]);
   const [draft, setDraft] = useState("");
-  // 附件（#176）：已上传待随下一条消息发出的引用 + 上传中/错误态
+  // 附件（#176）：已上传待随下一条消息发出的引用（attachments）+ 在途/失败的每文件上传态（uploads）。
   const [attachments, setAttachments] = useState<Attachment[]>([]);
-  const [uploading, setUploading] = useState(false);
-  const [uploadError, setUploadError] = useState<string | null>(null);
+  const [uploads, setUploads] = useState<UploadItem[]>([]);
+  // 失败重试要拿回原始 File；uploads 里只存元数据，File 本体放这个 ref（不进 render）。
+  const uploadFilesRef = useRef<Map<string, File>>(new Map());
   const [search, setSearch] = useState("");
   const [searchFrom, setSearchFrom] = useState("");
   const [searchSince, setSearchSince] = useState("");
@@ -2325,6 +2326,8 @@ export function ChannelPage({
 
   const send = useCallback(() => {
     const body = draft.trim();
+    // 上传在途时按下 ⌘⏎ 不发（按钮已 disabled，但快捷键绕过它）——否则会漏掉还没落 R2 的引用。
+    if (uploads.some((u) => u.status === "uploading")) return;
     // 有附件时允许空正文（纯图片/文件消息）
     if (body === "" && attachments.length === 0) return;
     // 与草稿 chips / 服务端 BODY_MENTION_RE 同一份语义：@ 前须行首或非标识符字符，不吃 email 里的 @
@@ -2341,37 +2344,66 @@ export function ChannelPage({
     // ⌘⏎ 不受按钮 disabled 门控，断线窗口内发送失败要内联提示（草稿保留）
     if (ok) {
       pendingSendsRef.current.push({ draft, replyTo });
-      // 附件已落 R2，ws 已接收帧 → 乐观清空待发引用（失败时保留草稿由 ack 逻辑处理）
+      // 附件已落 R2，ws 已接收帧 → 乐观清空待发引用（失败上传一并丢弃，失败时保留草稿由 ack 逻辑处理）
       setAttachments([]);
-      setUploadError(null);
+      setUploads([]);
+      uploadFilesRef.current.clear();
     } else {
       dispatch({ type: "send_failed", message: "not connected — message not sent, draft kept" });
     }
-  }, [draft, replyTo, attachments]);
+  }, [draft, replyTo, attachments, uploads]);
 
-  // 选文件 → 逐个上传到 R2 → 追加引用；上限 25MB / 20 个由服务端强制，前端只报错不拦
-  const onPickFiles = useCallback(
-    (files: FileList) => {
-      setUploading(true);
-      setUploadError(null);
-      const list = Array.from(files);
-      void (async () => {
-        for (const file of list) {
-          try {
-            const meta = await uploadAttachment(token, slug, file);
-            setAttachments((prev) => (prev.some((a) => a.key === meta.key) ? prev : [...prev, meta]));
-          } catch (err) {
-            if (err instanceof AuthError) authFailedRef.current("token revoked — paste a new one");
-            else if (err instanceof TooLargeError) setUploadError(`${file.name}: file too large (max 25MB)`);
-            else if (err instanceof ForbiddenError) setUploadError(`${file.name}: not allowed to upload here`);
-            else setUploadError(`${file.name}: upload failed`);
-          }
+  // 单文件上传：先落一条 uploading 态，成功转入 attachments、失败转 error 态（可重试）。
+  const runUpload = useCallback(
+    async (id: string, file: File) => {
+      setUploads((prev) => prev.map((u) => (u.id === id ? { ...u, status: "uploading", error: undefined } : u)));
+      try {
+        const meta = await uploadAttachment(token, slug, file);
+        uploadFilesRef.current.delete(id);
+        setUploads((prev) => prev.filter((u) => u.id !== id));
+        setAttachments((prev) => (prev.some((a) => a.key === meta.key) ? prev : [...prev, meta]));
+      } catch (err) {
+        if (err instanceof AuthError) {
+          authFailedRef.current("token revoked — paste a new one");
+          return;
         }
-        setUploading(false);
-      })();
+        const error =
+          err instanceof TooLargeError
+            ? "file too large (max 25MB)"
+            : err instanceof ForbiddenError
+              ? "not allowed to upload here"
+              : "upload failed";
+        setUploads((prev) => prev.map((u) => (u.id === id ? { ...u, status: "error", error } : u)));
+      }
     },
     [token, slug],
   );
+
+  // 选/拖/粘贴文件 → 每文件一条上传态并行上传；上限 25MB / 20 个由服务端强制，前端只报错不拦。
+  const onPickFiles = useCallback(
+    (files: FileList) => {
+      for (const file of Array.from(files)) {
+        const id = crypto.randomUUID();
+        uploadFilesRef.current.set(id, file);
+        setUploads((prev) => [...prev, { id, filename: file.name, size: file.size, status: "uploading" }]);
+        void runUpload(id, file);
+      }
+    },
+    [runUpload],
+  );
+
+  const onRetryUpload = useCallback(
+    (id: string) => {
+      const file = uploadFilesRef.current.get(id);
+      if (file !== undefined) void runUpload(id, file);
+    },
+    [runUpload],
+  );
+
+  const onCancelUpload = useCallback((id: string) => {
+    uploadFilesRef.current.delete(id);
+    setUploads((prev) => prev.filter((u) => u.id !== id));
+  }, []);
 
   const onRemoveAttachment = useCallback((key: string) => {
     setAttachments((prev) => prev.filter((a) => a.key !== key));
@@ -3442,8 +3474,9 @@ export function ChannelPage({
           attachments={attachments}
           onPickFiles={onPickFiles}
           onRemoveAttachment={onRemoveAttachment}
-          uploading={uploading}
-          uploadError={uploadError}
+          uploads={uploads}
+          onRetryUpload={onRetryUpload}
+          onCancelUpload={onCancelUpload}
         />
       )}
     </div>

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -3894,25 +3894,128 @@
 .composer-attachment-remove:hover { color: var(--fg, inherit); }
 .composer-upload-error { margin: 0.25rem 0; }
 
+/* 拖拽上传高亮（#176）：composer 相对定位，dropzone 覆盖其上 */
+.composer { position: relative; }
+.composer--dragging { outline: 2px dashed var(--accent, var(--fg)); outline-offset: 2px; }
+.composer-dropzone {
+  position: absolute;
+  inset: 0;
+  z-index: 3;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--bg, #000) 78%, transparent);
+  color: var(--fg, inherit);
+  font-size: 0.9rem;
+  pointer-events: none;
+}
+
+/* 每文件上传态 chip（#176） */
+.composer-uploads {
+  list-style: none;
+  margin: 0;
+  padding: 0.25rem 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+.composer-upload {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.15rem 0.5rem;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-size: 0.8rem;
+  max-width: 100%;
+}
+.composer-upload-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 12rem;
+}
+.composer-upload-status { color: var(--t-dim); }
+.composer-upload--error { border-color: var(--red, #c0392b); }
+.composer-upload-error-text { color: var(--red, #c0392b); }
+.composer-upload-icon--error {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1rem;
+  height: 1rem;
+  border-radius: 50%;
+  border: 1px solid var(--red, #c0392b);
+  color: var(--red, #c0392b);
+  font-weight: bold;
+  line-height: 1;
+}
+.composer-upload-spinner {
+  width: 0.85rem;
+  height: 0.85rem;
+  border: 2px solid var(--border);
+  border-top-color: var(--fg, inherit);
+  border-radius: 50%;
+  animation: composer-upload-spin 0.7s linear infinite;
+}
+@keyframes composer-upload-spin { to { transform: rotate(360deg); } }
+@media (prefers-reduced-motion: reduce) {
+  .composer-upload-spinner { animation-duration: 2s; }
+}
+.composer-upload-retry {
+  border: 1px solid var(--border);
+  background: none;
+  cursor: pointer;
+  color: var(--fg, inherit);
+  font: inherit;
+  border-radius: 3px;
+  padding: 0 0.35rem;
+}
+.composer-upload-retry:hover { border-color: var(--fg, inherit); }
+.composer-upload-cancel {
+  border: none;
+  background: none;
+  cursor: pointer;
+  color: var(--t-dim);
+  font-size: 1rem;
+  line-height: 1;
+  padding: 0;
+}
+.composer-upload-cancel:hover { color: var(--fg, inherit); }
+
 /* ---- 消息附件渲染（#176） ---- */
 .msg-attachments {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
   margin-top: 0.4rem;
+  max-width: 100%;
 }
+.msg-attachment { max-width: 100%; }
+.msg-attachment-img { display: inline-block; max-width: 100%; }
 .msg-attachment-img img {
-  max-width: 320px;
+  /* 缩略图受限于 320px 与容器宽度的较小者，移动端不撑破消息卡 */
+  max-width: min(320px, 100%);
   max-height: 240px;
+  width: auto;
+  height: auto;
   border-radius: 6px;
   border: 1px solid var(--border);
   display: block;
+  cursor: zoom-in;
 }
 .msg-attachment-file {
   display: inline-flex;
   align-items: center;
   gap: 0.35rem;
   font-size: 0.85rem;
+  max-width: 100%;
+}
+.msg-attachment-file .msg-attachment-fname {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .msg-attachment-size { color: var(--t-dim); }
 .msg-attachment-loading { color: var(--t-dim); font-size: 0.85rem; }

--- a/worker/src/openapi.ts
+++ b/worker/src/openapi.ts
@@ -428,6 +428,26 @@ export const openapiDocument = {
                           related_prs: { type: "array", items: { type: "integer", minimum: 1 } },
                         },
                       },
+                      attachments: {
+                        type: "array",
+                        maxItems: 20,
+                        description:
+                          "R2 attachment refs from POST /api/channels/{slug}/attachments; body may be empty when >=1 attachment is present",
+                        items: {
+                          type: "object",
+                          required: ["key", "filename", "content_type", "size", "url"],
+                          properties: {
+                            key: { type: "string", description: "<slug>/<uuid>/<filename> R2 object key" },
+                            filename: { type: "string", maxLength: 255 },
+                            content_type: { type: "string" },
+                            size: { type: "integer", minimum: 0 },
+                            url: {
+                              type: "string",
+                              description: "authenticated download path /api/channels/{slug}/attachments/{uuid}/{filename}",
+                            },
+                          },
+                        },
+                      },
                     },
                   },
                   {
@@ -515,6 +535,61 @@ export const openapiDocument = {
           "410": { description: "channel archived" },
           "413": { description: "body too large" },
           "429": { description: "rate limited" },
+        },
+      },
+    },
+    "/api/channels/{slug}/attachments": {
+      post: {
+        summary: "upload one attachment blob to R2 and get a ref",
+        description:
+          "uploads the raw request body to R2 under <slug>/<uuid>/<filename>; returns the ref to carry in a message's attachments field. non-readonly token with channel access required. max 25MB.",
+        security: [{ bearer: [] }],
+        parameters: [
+          { name: "slug", in: "path", required: true, schema: { type: "string" } },
+          {
+            name: "filename",
+            in: "query",
+            required: true,
+            schema: { type: "string", maxLength: 255, pattern: "^[^/\\\\\\x00-\\x1f\\x7f]{1,255}$" },
+            description: "single path segment; becomes the R2 key suffix and download filename",
+          },
+        ],
+        requestBody: {
+          required: true,
+          description: "raw file bytes; Content-Type is stored and echoed on download",
+          content: { "application/octet-stream": { schema: { type: "string", format: "binary" } } },
+        },
+        responses: {
+          "201": { description: "{key, filename, content_type, size, url}" },
+          "400": { description: "missing/illegal filename or empty body" },
+          "403": { description: "readonly token or no channel access" },
+          "404": { description: "channel not found" },
+          "410": { description: "channel archived" },
+          "413": { description: "attachment exceeds 25MB" },
+        },
+      },
+    },
+    "/api/channels/{slug}/attachments/{path}": {
+      get: {
+        summary: "download an attachment blob from R2 (authenticated)",
+        description:
+          "streams the R2 object back with its stored content-type and X-Content-Type-Options: nosniff. same read access as the channel; never a public R2 link. path is <uuid>/<filename>.",
+        security: [{ bearer: [] }],
+        parameters: [
+          { name: "slug", in: "path", required: true, schema: { type: "string" } },
+          {
+            name: "path",
+            in: "path",
+            required: true,
+            schema: { type: "string" },
+            description: "<uuid>/<filename> object path (no .. or leading /)",
+          },
+        ],
+        responses: {
+          "200": { description: "attachment bytes" },
+          "400": { description: "invalid attachment path" },
+          "403": { description: "no channel access" },
+          "404": { description: "channel or attachment not found" },
         },
       },
     },


### PR DESCRIPTION
## 找回 #176/#282 合并时丢失的打磨 commit

**回归**：#282（R2 附件）合并进 main 时只落了 base commit `a65af25`（feat worker,web），**3 个打磨 commit 全丢了**——我审过、验过、CI 绿过的活没进 main。缺失的：
- **CLI `party send --attach <path>`**（可重复）：上传文件到 R2 再随消息发，空正文允许（与网页端一致）。`send-attach.test.ts` 8 用例也丢了。
- **web 附件拖拽/粘贴上传 + 每文件进度/错误态/重试 + 图片渲染打磨**（`Composer` onDrop/onPaste、mobile 不破版）。`Composer.attachments.test.tsx` 的打磨用例丢了。
- **openapi 文档化**两个附件端点 + 消息 attachments 字段。

三个 commit 在对象库里都可达，**cherry-pick 干净应用到最新 main**（原 SHA 6170944/597012a/40803be → 3136c47/a65988f/8975912），无冲突。

## 门禁（cherry-pick 后我亲跑）
- cli send-attach 8/8；web Composer.attachments 11/11；cli/web/worker tsc 0；web build 0。

## ⚠️ 与 #292(#109) 的重叠——合并时去重
`3136c47`（原 cli --attach）带回 `rest.uploadAttachment`；#292(#109 serve→R2) 因为发现它丢了、也新建了一个同名 helper。**两者都进 main 时 rest.ts 会有重复定义**——第二个合并的 PR 我负责去重（保留一份、两个调用方共用）。建议先合本 PR（恢复原件），#292 合时我把它的重复 uploadAttachment 换成引用本 PR 的。

🤖 纯 cherry-pick 找回既有已验证工作 + 我复跑门禁。
