### PR TITLE
feat(worker): webhook 死信持久化 + moderator 可重投 + 可见性，不再静默永久丢弃（#105）

### DIFF
--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -32,6 +32,11 @@ export const ROLE_RESPONSIBILITY_LIMIT = 500;
 export const RESERVED_NAMES: readonly string[] = ["system"];
 export const MAX_WEBHOOK_QUEUE_ROWS = 200;
 export const WEBHOOK_RETRY_BATCH_SIZE = 25;
+// 死信保留上限（#105）：重试耗尽 / 队列满而被永久放弃的投递不再静默丢弃，落死信表待人重投。
+// 有界裁剪（只留最新 N 条）避免坏端点把 DO 存储写爆。
+export const MAX_WEBHOOK_DEAD_LETTERS = 200;
+// 单次 redeliver 最多重投多少条死信，避免一个端点的巨量积压一次性打满 subrequest 配额。
+export const WEBHOOK_REDELIVER_BATCH_SIZE = 50;
 
 // ---- 会员分层（#277 骨架）----
 // 账号维度的 free/member 层：托管部署每月要成本，会员用于回收；自部署始终免费。

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -9,12 +9,14 @@ import {
   LOOP_GUARD_N,
   LOOP_GUARD_PARTY_N,
   MAX_WEBHOOKS_PER_CHANNEL,
+  MAX_WEBHOOK_DEAD_LETTERS,
   MAX_WEBHOOK_QUEUE_ROWS,
   PRESENCE_TIMEOUT_MS,
   RATE_LIMIT_PER_MIN,
   RETAIN_N,
   TEMP_IDLE_ARCHIVE_MS,
   WEBHOOK_MAX_RETRIES,
+  WEBHOOK_REDELIVER_BATCH_SIZE,
   WEBHOOK_RETRY_BATCH_SIZE,
   WEBHOOK_RETRY_DELAYS_MS,
   WEBHOOK_TIMEOUT_MS,
@@ -1056,6 +1058,18 @@ export class ChannelDO extends Server<Env> {
       attempts INTEGER NOT NULL DEFAULT 0,
       next_retry_at INTEGER NOT NULL
     )`);
+    // 死信表（#105）：重试耗尽 / 队列满而被永久放弃的投递落在这里，不再静默丢弃。
+    // 保留原始 payload 以便 moderator 原样重投；有界裁剪（见 recordDeadLetter）防止写爆。
+    sql.exec(`CREATE TABLE IF NOT EXISTS webhook_dead_letters (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      webhook_name TEXT NOT NULL,
+      mention_seq INTEGER NOT NULL,
+      payload TEXT NOT NULL,
+      attempts INTEGER NOT NULL,
+      last_status INTEGER,
+      last_error TEXT,
+      dead_lettered_at INTEGER NOT NULL
+    )`);
     sql.exec(`CREATE TABLE IF NOT EXISTS wake_delivery_ledger (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       mention_seq INTEGER NOT NULL,
@@ -1436,7 +1450,10 @@ export class ChannelDO extends Server<Env> {
       }
       if (attempt > WEBHOOK_MAX_RETRIES) {
         this.ctx.storage.sql.exec("DELETE FROM webhook_queue WHERE id = ?", id);
-        this.insertSystemStatus(`webhook ${webhookName} 连续投递失败已停用本条`, now, false, { state: "blocked" });
+        // #105：不再静默永久丢弃——落死信表待 moderator 重投，
+        // 并向频道插一条 system status（in-channel，不经 webhook 自身，见 dispatchWebhooks 对 system 帧的默认跳过）。
+        this.recordDeadLetter(webhookName, payload, attempt, delivery, now);
+        this.insertSystemStatus(`webhook ${webhookName} 连续投递失败已转入死信，可 redeliver 重投`, now, false, { state: "blocked" });
         continue;
       }
       this.ctx.storage.sql.exec(
@@ -1452,6 +1469,137 @@ export class ChannelDO extends Server<Env> {
     return WEBHOOK_RETRY_DELAYS_MS[
       Math.min(Math.max(attempts, 1), WEBHOOK_RETRY_DELAYS_MS.length) - 1
     ] as number;
+  }
+
+  // #105：把一条被永久放弃的投递落死信表。保留 payload 供 redeliver 原样重投；
+  // 有界裁剪——超过上限只留最新 MAX_WEBHOOK_DEAD_LETTERS 条，坏端点写不爆 DO 存储。
+  private recordDeadLetter(
+    webhookName: string,
+    payload: string,
+    attempts: number,
+    delivery: WebhookDeliveryResult,
+    now: number,
+  ) {
+    this.ctx.storage.sql.exec(
+      `INSERT INTO webhook_dead_letters (
+         webhook_name, mention_seq, payload, attempts, last_status, last_error, dead_lettered_at
+       ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      webhookName,
+      this.seqFromWebhookPayload(payload),
+      payload,
+      attempts,
+      delivery.status,
+      delivery.error,
+      now,
+    );
+    this.ctx.storage.sql.exec(
+      `DELETE FROM webhook_dead_letters
+        WHERE id NOT IN (SELECT id FROM webhook_dead_letters ORDER BY id DESC LIMIT ?)`,
+      MAX_WEBHOOK_DEAD_LETTERS,
+    );
+  }
+
+  // 测试专用薄封装：单测直接造死信验证裁剪，不必真跑一整轮重试耗尽。
+  recordDeadLetterForTest(
+    webhookName: string,
+    payload: string,
+    attempts: number,
+    delivery: WebhookDeliveryResult,
+  ) {
+    this.recordDeadLetter(webhookName, payload, attempts, delivery, Date.now());
+  }
+
+  // #105：重投死信。成功即从死信表清除并记 wake ledger；失败则原地留存、attempts 递增，
+  // 绝不静默消失——「重投还是不通」仍是死信，operator 可再试或删 webhook。
+  // 不重新入 webhook_queue：redeliver 是一次显式尝试，不重启自动退避循环（least-surprising）。
+  private async redeliverDeadLetters(name: string | null): Promise<{ redelivered: number; failed: number; remaining: number }> {
+    const where = name === null ? "" : " WHERE dl.webhook_name = ?";
+    const args: (string | number)[] = name === null ? [WEBHOOK_REDELIVER_BATCH_SIZE] : [name, WEBHOOK_REDELIVER_BATCH_SIZE];
+    const rows = this.ctx.storage.sql
+      .exec(
+        `SELECT dl.id, dl.webhook_name, dl.payload, dl.attempts, w.url, w.secret
+           FROM webhook_dead_letters dl LEFT JOIN webhooks w ON w.name = dl.webhook_name${where}
+          ORDER BY dl.id
+          LIMIT ?`,
+        ...args,
+      )
+      .toArray();
+    let redelivered = 0;
+    let failed = 0;
+    const now = Date.now();
+    for (const row of rows) {
+      const id = Number(row.id);
+      const webhookName = String(row.webhook_name);
+      const payload = String(row.payload);
+      const attempt = Number(row.attempts) + 1;
+      // webhook 已被删除 → 无从投递，视为失败但留存，operator 需先重建同名 webhook 或清死信。
+      if (row.url === null) {
+        failed++;
+        this.ctx.storage.sql.exec(
+          "UPDATE webhook_dead_letters SET attempts = ?, last_status = NULL, last_error = ?, dead_lettered_at = ? WHERE id = ?",
+          attempt,
+          "webhook no longer registered",
+          now,
+          id,
+        );
+        continue;
+      }
+      const delivery = await this.deliverWebhook(String(row.url), String(row.secret), payload);
+      this.recordWakeDelivery({
+        mentionSeq: this.seqFromWebhookPayload(payload),
+        targetName: webhookName,
+        webhookName,
+        attempt,
+        delivery,
+      });
+      if (delivery.ok) {
+        redelivered++;
+        this.ctx.storage.sql.exec("DELETE FROM webhook_dead_letters WHERE id = ?", id);
+        continue;
+      }
+      failed++;
+      this.ctx.storage.sql.exec(
+        "UPDATE webhook_dead_letters SET attempts = ?, last_status = ?, last_error = ?, dead_lettered_at = ? WHERE id = ?",
+        attempt,
+        delivery.status,
+        delivery.error,
+        now,
+        id,
+      );
+    }
+    const remaining = Number(
+      name === null
+        ? this.ctx.storage.sql.exec("SELECT COUNT(*) AS n FROM webhook_dead_letters").one().n
+        : this.ctx.storage.sql.exec("SELECT COUNT(*) AS n FROM webhook_dead_letters WHERE webhook_name = ?", name).one().n,
+    );
+    return { redelivered, failed, remaining };
+  }
+
+  private listDeadLetters(): {
+    id: number;
+    webhook_name: string;
+    mention_seq: number;
+    attempts: number;
+    last_status: number | null;
+    last_error: string | null;
+    dead_lettered_at: number;
+  }[] {
+    return this.ctx.storage.sql
+      .exec(
+        `SELECT id, webhook_name, mention_seq, attempts, last_status, last_error, dead_lettered_at
+           FROM webhook_dead_letters
+          ORDER BY id`,
+      )
+      .toArray()
+      .map((r) => ({
+        id: Number(r.id),
+        webhook_name: String(r.webhook_name),
+        mention_seq: Number(r.mention_seq),
+        attempts: Number(r.attempts),
+        last_status: r.last_status === null ? null : Number(r.last_status),
+        last_error: r.last_error === null ? null : String(r.last_error),
+        dead_lettered_at: Number(r.dead_lettered_at),
+      }));
   }
 
   // temp 频道最后一条消息后闲置超时 → 归档：写 do meta + 回写 d1 archived_at + 踢连接
@@ -1690,7 +1838,9 @@ export class ChannelDO extends Server<Env> {
       if (delivery.ok) continue;
       const queued = Number(this.ctx.storage.sql.exec("SELECT COUNT(*) AS n FROM webhook_queue").one().n);
       if (queued >= MAX_WEBHOOK_QUEUE_ROWS) {
-        await this.insertSystemStatus("webhook retry queue is full; dropping failed delivery", now, false, { state: "blocked" });
+        // #105：队列满不再直接丢——落死信表，operator 事后可查可重投。
+        this.recordDeadLetter(hook.name, payload, 1, delivery, now);
+        await this.insertSystemStatus("webhook retry queue is full; delivery moved to dead-letters", now, false, { state: "blocked" });
         continue;
       }
       this.ctx.storage.sql.exec(
@@ -2448,6 +2598,16 @@ export class ChannelDO extends Server<Env> {
         }));
       return Response.json({ deliveries });
     }
+    if (url.pathname === "/internal/dead-letters" && request.method === "GET") {
+      // #105：列出被永久放弃、待重投的死信（不回 payload 明文，正文在频道历史里已可读）
+      return Response.json({ dead_letters: this.listDeadLetters() });
+    }
+    if (url.pathname === "/internal/dead-letters/redeliver" && request.method === "POST") {
+      // #105：重投死信。?name= 限定单个 webhook；缺省重投全部（受批次上限约束）。
+      const name = url.searchParams.get("name");
+      const result = await this.redeliverDeadLetters(name);
+      return Response.json(result);
+    }
     if (url.pathname === "/internal/read-cursors" && request.method === "GET") {
       // 已读游标快照 + 频道最新 seq，供 `party who` 标注每个身份读到第几条 / 落后多少（Phase 2 · CLI）。
       return Response.json({ cursors: this.readCursors(), last_seq: this.lastSeq() });
@@ -2586,6 +2746,8 @@ export class ChannelDO extends Server<Env> {
       }
       this.ctx.storage.sql.exec("DELETE FROM webhooks WHERE name = ?", name);
       this.ctx.storage.sql.exec("DELETE FROM webhook_queue WHERE webhook_name = ?", name);
+      // #105：webhook 删除后其死信已无从重投，一并清掉避免留下不可投递的孤儿。
+      this.ctx.storage.sql.exec("DELETE FROM webhook_dead_letters WHERE webhook_name = ?", name);
       return Response.json({ ok: true });
     }
     if (url.pathname === "/internal/reset-guard" && request.method === "POST") {

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -4843,6 +4843,52 @@ app.delete("/api/channels/:slug/webhooks/:name", async (c) => {
   return response;
 });
 
+// #105：列出死信（重试耗尽 / 队列满被永久放弃的投递）。与 webhook 管理同权限：仅房主 / ap_ token。
+app.get("/api/channels/:slug/webhooks/dead-letters", async (c) => {
+  const slug = c.req.param("slug");
+  const channel = await loadChannel(c.env.DB, slug);
+  if (!channel) return c.json(errorBody("not_found", "channel not found"), 404);
+  if (!isChannelModerator(c.get("identity"), channel)) {
+    return c.json(errorBody("forbidden", "only the channel owner or an ap_ token can manage webhooks"), 403);
+  }
+  return fetchChannelDO(
+    c.env,
+    slug,
+    new Request("https://do/internal/dead-letters", { headers: { "x-partykit-room": slug } }),
+  );
+});
+
+// #105：重投某 webhook 的死信。成功即出表，仍失败留表待再试——不再永久静默丢弃。管理权同上。
+app.post("/api/channels/:slug/webhooks/:name/redeliver", async (c) => {
+  const slug = c.req.param("slug");
+  const channel = await loadChannel(c.env.DB, slug);
+  if (!channel) return c.json(errorBody("not_found", "channel not found"), 404);
+  if (!isChannelModerator(c.get("identity"), channel)) {
+    return c.json(errorBody("forbidden", "only the channel owner or an ap_ token can manage webhooks"), 403);
+  }
+  if (channel.archived_at !== null) {
+    return c.json(errorBody("archived", "channel is archived"), 410);
+  }
+  const name = c.req.param("name");
+  const response = await fetchChannelDO(
+    c.env,
+    slug,
+    new Request(`https://do/internal/dead-letters/redeliver?name=${encodeURIComponent(name)}`, {
+      method: "POST",
+      headers: { "x-partykit-room": slug },
+    }),
+  );
+  if (response.ok) {
+    await bestEffortRecordManagementAudit(c.env.DB, {
+      actor: managementAuditActor(c.get("identity")),
+      action: "channel.webhook.redeliver",
+      resource: `channel/${slug}/webhooks/${name}`,
+      channel: slug,
+    });
+  }
+  return response;
+});
+
 app.post("/api/channels/:slug/archive", async (c) => {
   const slug = c.req.param("slug");
   const channel = await loadChannel(c.env.DB, slug);

--- a/worker/src/management-audit.ts
+++ b/worker/src/management-audit.ts
@@ -13,6 +13,7 @@ export type ManagementAuditAction =
   | "channel.member.remove"
   | "channel.webhook.add"
   | "channel.webhook.remove"
+  | "channel.webhook.redeliver"
   | "channel.archive";
 
 export interface ManagementAuditActor {

--- a/worker/test/webhook-redeliver.spec.ts
+++ b/worker/test/webhook-redeliver.spec.ts
@@ -1,0 +1,211 @@
+import { MAX_WEBHOOK_DEAD_LETTERS, WEBHOOK_MAX_RETRIES } from "@agentparty/shared";
+import { env, fetchMock, runInDurableObject } from "cloudflare:test";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import type { ChannelDO } from "../src/do";
+import { api, createChannel, seedToken, uniq } from "./helpers";
+
+beforeAll(() => {
+  fetchMock.activate();
+  fetchMock.disableNetConnect();
+});
+afterEach(() => fetchMock.assertNoPendingInterceptors());
+
+function sendMessage(slug: string, token: string, body: string, mentions: string[] = []) {
+  return api(`/api/channels/${slug}/messages`, token, {
+    method: "POST",
+    body: JSON.stringify({ kind: "message", body, mentions, reply_to: null }),
+  });
+}
+
+function addWebhook(slug: string, token: string, name: string, url: string, filter = "all") {
+  return api(`/api/channels/${slug}/webhooks`, token, {
+    method: "POST",
+    body: JSON.stringify({ name, url, secret: "s", filter }),
+  });
+}
+
+async function deadLetterRows(slug: string) {
+  const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+  return runInDurableObject(stub, async (_instance: ChannelDO, state) =>
+    state.storage.sql
+      .exec(
+        `SELECT webhook_name, mention_seq, payload, attempts, last_status, last_error, dead_lettered_at
+           FROM webhook_dead_letters
+          ORDER BY id`,
+      )
+      .toArray()
+      .map((r) => ({
+        webhook_name: String(r.webhook_name),
+        mention_seq: Number(r.mention_seq),
+        payload: String(r.payload),
+        attempts: Number(r.attempts),
+        last_status: r.last_status === null ? null : Number(r.last_status),
+        last_error: r.last_error === null ? null : String(r.last_error),
+        dead_lettered_at: Number(r.dead_lettered_at),
+      })),
+  );
+}
+
+// 把队列里的这条拨到「下一次失败即达上限」再触发 alarm，得到一条确定的死信
+async function exhaustToDeadLetter(slug: string) {
+  const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+  await runInDurableObject(stub, async (instance: ChannelDO, state) => {
+    state.storage.sql.exec(
+      "UPDATE webhook_queue SET attempts = ?, next_retry_at = ?",
+      WEBHOOK_MAX_RETRIES,
+      Date.now() - 1,
+    );
+    await instance.onAlarm();
+  });
+}
+
+describe("webhook dead-letter persistence + redeliver", () => {
+  it("persists a dead-letter instead of silently dropping when retries are exhausted", async () => {
+    const { token } = await seedToken("agent");
+    const slug = await createChannel(token);
+    const hook = uniq("dl");
+    expect((await addWebhook(slug, token, hook, "https://dead.test/wake")).status).toBe(201);
+
+    // 立即首投失败 → 入队 attempts=1（无 interceptor + disableNetConnect）
+    expect((await sendMessage(slug, token, `@${hook} ping`, [hook])).status).toBe(200);
+    await exhaustToDeadLetter(slug);
+
+    const dead = await deadLetterRows(slug);
+    expect(dead).toHaveLength(1);
+    expect(dead[0]).toMatchObject({
+      webhook_name: hook,
+      mention_seq: 1,
+      attempts: WEBHOOK_MAX_RETRIES + 1,
+    });
+    expect(dead[0]?.last_error).toEqual(expect.any(String));
+    // payload 里带着原始消息体，redeliver 时要原样重投
+    expect(JSON.parse(dead[0]?.payload ?? "{}")).toMatchObject({ seq: 1, channel: slug });
+  });
+
+  it("lists dead-letters over a moderator-only endpoint", async () => {
+    const { token } = await seedToken("agent");
+    const slug = await createChannel(token);
+    const hook = uniq("dl");
+    expect((await addWebhook(slug, token, hook, "https://dead.test/wake")).status).toBe(201);
+    expect((await sendMessage(slug, token, `@${hook} ping`, [hook])).status).toBe(200);
+    await exhaustToDeadLetter(slug);
+
+    const res = await api(`/api/channels/${slug}/webhooks/dead-letters`, token);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { dead_letters: { webhook_name: string; mention_seq: number; attempts: number }[] };
+    expect(body.dead_letters).toHaveLength(1);
+    expect(body.dead_letters[0]).toMatchObject({ webhook_name: hook, mention_seq: 1 });
+
+    // readonly（非 moderator）看不到死信
+    const { token: ro } = await seedToken("readonly");
+    expect((await api(`/api/channels/${slug}/webhooks/dead-letters`, ro)).status).toBe(403);
+  });
+
+  it("redeliver re-attempts a dead-letter and clears it on success", async () => {
+    const { token } = await seedToken("agent");
+    const slug = await createChannel(token);
+    const hook = uniq("dl");
+    expect((await addWebhook(slug, token, hook, "https://revive.test/wake")).status).toBe(201);
+    expect((await sendMessage(slug, token, `@${hook} ping`, [hook])).status).toBe(200);
+    await exhaustToDeadLetter(slug);
+    expect(await deadLetterRows(slug)).toHaveLength(1);
+
+    fetchMock.get("https://revive.test").intercept({ path: "/wake", method: "POST" }).reply(200, "ok");
+    const res = await api(`/api/channels/${slug}/webhooks/${hook}/redeliver`, token, { method: "POST" });
+    expect(res.status).toBe(200);
+    expect((await res.json()) as { redelivered: number; failed: number }).toMatchObject({
+      redelivered: 1,
+      failed: 0,
+    });
+    // 投递成功 → 死信清空
+    expect(await deadLetterRows(slug)).toHaveLength(0);
+  });
+
+  it("redeliver that still fails leaves the delivery dead-lettered", async () => {
+    const { token } = await seedToken("agent");
+    const slug = await createChannel(token);
+    const hook = uniq("dl");
+    expect((await addWebhook(slug, token, hook, "https://stilldown.test/wake")).status).toBe(201);
+    expect((await sendMessage(slug, token, `@${hook} ping`, [hook])).status).toBe(200);
+    await exhaustToDeadLetter(slug);
+    expect(await deadLetterRows(slug)).toHaveLength(1);
+
+    // 无 interceptor → redeliver 再次失败
+    const res = await api(`/api/channels/${slug}/webhooks/${hook}/redeliver`, token, { method: "POST" });
+    expect(res.status).toBe(200);
+    expect((await res.json()) as { redelivered: number; failed: number }).toMatchObject({
+      redelivered: 0,
+      failed: 1,
+    });
+    // 仍然是死信，attempts 递增，不再静默消失
+    const dead = await deadLetterRows(slug);
+    expect(dead).toHaveLength(1);
+    expect(dead[0]?.attempts).toBe(WEBHOOK_MAX_RETRIES + 2);
+  });
+
+  it("non-moderator cannot redeliver", async () => {
+    const { token } = await seedToken("agent");
+    const slug = await createChannel(token);
+    const hook = uniq("dl");
+    expect((await addWebhook(slug, token, hook, "https://dead.test/wake")).status).toBe(201);
+    expect((await sendMessage(slug, token, `@${hook} ping`, [hook])).status).toBe(200);
+    await exhaustToDeadLetter(slug);
+
+    const { token: ro } = await seedToken("readonly");
+    const res = await api(`/api/channels/${slug}/webhooks/${hook}/redeliver`, ro, { method: "POST" });
+    expect(res.status).toBe(403);
+    // 死信没被非授权者动过
+    expect(await deadLetterRows(slug)).toHaveLength(1);
+  });
+
+  it("persists a dead-letter when the retry queue is full (drop is no longer silent)", async () => {
+    const { token } = await seedToken("agent");
+    const slug = await createChannel(token);
+    const hook = uniq("dl");
+    expect((await addWebhook(slug, token, hook, "https://dead.test/wake")).status).toBe(201);
+
+    // 先把队列填满，再让下一条失败投递撞上「队列满」丢弃点
+    const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+    await runInDurableObject(stub, async (_instance: ChannelDO, state) => {
+      for (let i = 0; i < 200; i++) {
+        state.storage.sql.exec(
+          "INSERT INTO webhook_queue (webhook_name, payload, attempts, next_retry_at) VALUES (?, ?, 1, ?)",
+          hook,
+          JSON.stringify({ seq: 900 + i, channel: slug }),
+          Date.now() + 3_600_000,
+        );
+      }
+    });
+
+    expect((await sendMessage(slug, token, `@${hook} overflow`, [hook])).status).toBe(200);
+    await new Promise((r) => setTimeout(r, 50));
+
+    const dead = await deadLetterRows(slug);
+    expect(dead).toHaveLength(1);
+    expect(dead[0]).toMatchObject({ webhook_name: hook });
+    expect(JSON.parse(dead[0]?.payload ?? "{}")).toMatchObject({ body: expect.stringContaining("overflow") });
+  });
+
+  it("prunes dead-letters so the table stays bounded", async () => {
+    const { token } = await seedToken("agent");
+    const slug = await createChannel(token);
+    const hook = uniq("dl");
+    // 走一次真实请求，确保 onStart 已建表（与生产路径一致），再直接造死信验证裁剪
+    expect((await api(`/api/channels/${slug}/webhooks/dead-letters`, token)).status).toBe(200);
+    const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+    await runInDurableObject(stub, async (instance: ChannelDO, state) => {
+      for (let i = 0; i < MAX_WEBHOOK_DEAD_LETTERS + 25; i++) {
+        instance.recordDeadLetterForTest(hook, JSON.stringify({ seq: i + 1, channel: slug }), 4, {
+          ok: false,
+          status: 500,
+          error: "boom",
+        });
+      }
+      const n = Number(state.storage.sql.exec("SELECT COUNT(*) AS n FROM webhook_dead_letters").one().n);
+      expect(n).toBe(MAX_WEBHOOK_DEAD_LETTERS);
+      // 保留的是最新的一批（旧的被裁掉）
+      const min = Number(state.storage.sql.exec("SELECT MIN(mention_seq) AS m FROM webhook_dead_letters").one().m);
+      expect(min).toBe(25 + 1);
+    });
+  });
+});


### PR DESCRIPTION
## 修什么（#105，[P3][design]）

webhook 重试 ~21 分钟耗尽后**永久丢弃、无 redeliver**，且死信告警本身不走 webhook（运营可能永远不知道）。两处丢弃点（`retryWebhooks` 重试耗尽 + `dispatchWebhooks` 队列满 200）都 DELETE/silent-continue、零痕迹。

## 怎么修（完整：持久化 + 重投 + 可见性）
- **持久化**：新 DO-sqlite 表 `webhook_dead_letters`（onStart 幂等建表，同 webhook_queue 手法），存 `webhook_name/mention_seq/payload/attempts/last_status/last_error/dead_lettered_at`——**留原 payload 供精确重放**。有界：每次插入后修剪到最新 `MAX_WEBHOOK_DEAD_LETTERS`(200)。两处丢弃点改为 `recordDeadLetter` 而非消失。
- **重投**：`POST /api/channels/:slug/webhooks/:name/redeliver`，每条死信一次显式尝试（批 50）：成功删行 + 记 wake-ledger；失败保留死信、attempts+1（**不重启自动退避队列**，最少惊讶）。返回 `{redelivered,failed,remaining}`，记 management-audit。
- **可见性**：`GET .../webhooks/dead-letters` 列出（响应不含 payload——正文在频道历史里可读）。告警走 in-channel system status，且 dispatchWebhooks 跳过 system 帧，**不路由经刚死的那个 webhook**。
- **鉴权**：两端点 `isChannelModerator`（同 webhook add/list/delete）。删 webhook 时连带清其死信、避免孤儿。

## 门禁（对 origin HEAD rebase 后亲验）
- 新 spec `webhook-redeliver.spec.ts` 7/7；webhooks+webhook-dispatch+management-audit 27/27 无回归；worker tsc 0；rebase 无冲突。
- 变异：去掉重试耗尽处的 recordDeadLetter → 死信持久化测试红；去掉重投成功的删行 → 清除测试红；非 moderator 重投放行 → 鉴权测试红。均复绿。
- 全量 3 条超时是满载 flake（隔离单跑过），只碰 webhook 代码。

🤖 opus agent 实现 + 我逐行审 + 亲验。
