### PR TITLE
feat(#284): 频道内交互式提问——agent 抛选项，人类点选回答

### DIFF
--- a/cli/src/commands/send.ts
+++ b/cli/src/commands/send.ts
@@ -9,9 +9,9 @@ import { formatReachLine, reachOf } from "../reach";
 import { localStatuslineBase, statuslinePreview, unreadFromCursor, writeStatuslineCache } from "../statusline-cache";
 import { isName, isSlug, parsePositiveIntFlag } from "../validation";
 
-export const sendSpec = { repeatable: ["mention", "attach"], booleans: ["debug-auth", "reach", "no-reach"] };
-const SEND_FLAGS = ["channel", "reply-to", "mention", "attach", "debug-auth", "reach", "no-reach"];
-const HELP = `usage: party send <text|-> [--channel C] [--mention name]... [--attach path]... [--reply-to seq] [--debug-auth]
+export const sendSpec = { repeatable: ["mention", "attach", "option"], booleans: ["debug-auth", "reach", "no-reach"] };
+const SEND_FLAGS = ["channel", "reply-to", "mention", "attach", "option", "debug-auth", "reach", "no-reach"];
+const HELP = `usage: party send <text|-> [--channel C] [--mention name]... [--attach path]... [--option label]... [--reply-to seq] [--debug-auth]
 
 Send one message to a channel. Use "-" as the body to read stdin.
 
@@ -26,6 +26,8 @@ Options:
   --channel C      send to channel C instead of the bound channel
   --mention name   mention a user or agent; repeatable
   --attach path    upload a local file and attach it; repeatable (max 25MB each)
+  --option label   turn this message into an in-channel prompt with a clickable option; repeatable (#284).
+                   body becomes the question; humans click an option to answer (approve/reject = --option 通过 --option 拒绝)
   --reply-to seq   attach this message as a reply to seq
   --reach          show mention reachability even when not a TTY (agent loops)
   --no-reach       never show mention reachability
@@ -71,6 +73,7 @@ export interface SendInput {
   mentions: string[];
   replyTo: number | null;
   attachPaths: string[];
+  options: string[]; // #284：非空则把消息变成带这些选项的交互式提问
 }
 
 // 本地路径 → 上传源：不存在/空文件/超限一律抛带路径的可读错误，绝不静默上传半个包。
@@ -119,6 +122,7 @@ export async function resolveSendInput(parsed: Parsed): Promise<SendInput | null
     return null;
   }
   const attachPaths = strArray(flags.attach) ?? [];
+  const options = (strArray(flags.option) ?? []).map((o) => o.trim()).filter((o) => o !== "");
   const replyTo = parsePositiveIntFlag(str(flags["reply-to"]), "reply-to");
   if (typeof replyTo === "string") {
     console.error(replyTo);
@@ -184,6 +188,7 @@ export async function resolveSendInput(parsed: Parsed): Promise<SendInput | null
     mentions,
     replyTo: replyTo ?? null,
     attachPaths,
+    options,
   };
 }
 
@@ -223,6 +228,7 @@ export async function doSend(cfg: Config, input: SendInput): Promise<number | { 
       mentions: input.mentions,
       reply_to: input.replyTo,
       ...(attachments !== undefined && attachments.length > 0 ? { attachments } : {}),
+      ...(input.options.length > 0 ? { prompt: { question: input.body, options: input.options } } : {}),
     });
     advanceCursorPastOwnMessage(input.channel, seq);
     writeStatuslineCache({

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -473,6 +473,19 @@ export interface Attachment {
   url: string;
 }
 
+/**
+ * 频道内交互式提问（#284）：agent 抛一个问题 + 若干选项，人类（或别的 agent）在频道 UI 里点选回答。
+ * 回答走普通回复消息（reply_to 指向本条），body 形如「选择：<选项>」。把 CLI 里 agent↔人的选择/审批
+ * 交互搬进频道。approve/reject 只是 options 为 ["通过","拒绝"] 的特例。
+ */
+export interface MessagePrompt {
+  question: string;
+  options: string[];
+}
+export const PROMPT_QUESTION_MAX = 500;
+export const PROMPT_OPTION_MAX = 100; // 每个选项字节上限
+export const PROMPT_OPTIONS_MAX = 12; // 选项数量上限
+
 export interface SendMessageFrame {
   type: "send";
   kind: "message";
@@ -482,6 +495,8 @@ export interface SendMessageFrame {
   completion_artifact?: CompletionArtifact;
   /** 附件引用（#176）；空/缺省视为无附件。上限见 do 侧 MAX_ATTACHMENTS_PER_MESSAGE。 */
   attachments?: Attachment[];
+  /** 交互式提问（#284）；带上则该消息在频道里渲染成可点选按钮。 */
+  prompt?: MessagePrompt;
   replaces?: number;
   /**
    * 幂等键（#98）：客户端每次发送生成一个唯一键（ULID）。同一条逻辑消息的重试（客户端超时重发、
@@ -626,6 +641,8 @@ export interface MsgFrame {
   completion_review?: CompletionReview;
   /** 附件引用（#176）；仅 kind:"message" 携带，无附件时省略。 */
   attachments?: Attachment[];
+  /** 交互式提问（#284）；带上则前端渲染为可点选按钮，点选发一条回复本条的消息。 */
+  prompt?: MessagePrompt;
   ts: number;
   edited?: true;
   edited_at?: number;

--- a/web/src/components/MessageCard.tsx
+++ b/web/src/components/MessageCard.tsx
@@ -29,6 +29,8 @@ interface Props {
   // 消息右键菜单（PR #49）：引用/编辑/撤回/复制
   canModerate: boolean;
   onReply(seq: number): void;
+  /** #284 交互式提问：点选项时一键发一条回复本条的答案（并 @问的人）。缺省则选项只读展示。 */
+  onAnswerPrompt?: (seq: number, senderName: string, option: string) => void;
   onEdit(seq: number): void;
   onRetract(seq: number): void;
   canCreateTask: boolean;
@@ -111,6 +113,7 @@ export function MessageCard({
   quotedMessage,
   canModerate,
   onReply,
+  onAnswerPrompt,
   onEdit,
   onRetract,
   canCreateTask,
@@ -489,6 +492,29 @@ export function MessageCard({
       )}
       {!editing && !msg.retracted && msg.attachments !== undefined && msg.attachments.length > 0 && (
         <AttachmentList attachments={msg.attachments} />
+      )}
+      {!editing && !msg.retracted && msg.prompt !== undefined && (
+        <div className="msg-prompt" role="group" aria-label={msg.prompt.question}>
+          <div className="msg-prompt-q">{msg.prompt.question}</div>
+          <div className="msg-prompt-opts">
+            {msg.prompt.options.map((opt) =>
+              onAnswerPrompt !== undefined ? (
+                <button
+                  key={opt}
+                  type="button"
+                  className="msg-prompt-opt"
+                  onClick={() => onAnswerPrompt(msg.seq, msg.sender.name, opt)}
+                >
+                  {opt}
+                </button>
+              ) : (
+                <span key={opt} className="msg-prompt-opt msg-prompt-opt--readonly">
+                  {opt}
+                </span>
+              ),
+            )}
+          </div>
+        </div>
       )}
       {!editing && actionError !== null && <p className="banner banner--red msg-action-error">{actionError}</p>}
     </article>

--- a/web/src/i18n/strings/MessageCard.ts
+++ b/web/src/i18n/strings/MessageCard.ts
@@ -16,6 +16,7 @@ export const MessageCardStrings: LocaleDict = {
     "MessageCard.edit.saving": "saving…",
     "MessageCard.edit.cancel": "cancel",
     "MessageCard.reply.retracted": "original message retracted",
+    "MessageCard.prompt.answer": "Chose: {option}",
     "MessageCard.reply.jump": "jump to original message #{seq}",
   },
   zh: {
@@ -33,6 +34,7 @@ export const MessageCardStrings: LocaleDict = {
     "MessageCard.edit.saving": "保存中…",
     "MessageCard.edit.cancel": "取消",
     "MessageCard.reply.retracted": "原消息已撤回",
+    "MessageCard.prompt.answer": "选择：{option}",
     "MessageCard.reply.jump": "跳转到原消息 #{seq}",
   },
 };

--- a/web/src/pages/Channel.tsx
+++ b/web/src/pages/Channel.tsx
@@ -2325,6 +2325,17 @@ export function ChannelPage({
     setReplyTo((current) => (current === submitted.replyTo ? null : current));
   }, [state.lastSentSeq]);
 
+  // #284：点选交互式提问的一个选项 → 一键发一条回复该问题的答案，并 @ 问的人（把它叫醒看答案）。
+  const answerPrompt = useCallback((seq: number, senderName: string, option: string) => {
+    sockRef.current?.send({
+      type: "send",
+      kind: "message",
+      body: t("MessageCard.prompt.answer", { option }),
+      mentions: senderName !== "" ? [senderName] : [],
+      reply_to: seq,
+    });
+  }, [t]);
+
   const send = useCallback(() => {
     const body = draft.trim();
     // 上传在途时按下 ⌘⏎ 不发（按钮已 disabled，但快捷键绕过它）——否则会漏掉还没落 R2 的引用。
@@ -3346,6 +3357,7 @@ export function ChannelPage({
                   canModerate={canModerate}
                   quotedMessage={item.message.reply_to !== null ? messageBySeq.get(item.message.reply_to) ?? null : null}
                   onReply={startReply}
+                  onAnswerPrompt={answerPrompt}
                   onEdit={startEdit}
                   onRetract={retractMessage}
                   canCreateTask={canWrite}

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -5210,3 +5210,12 @@
 .settings-facts dd { margin: 0; color: var(--t-body, #2a2820); font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 /* 面板内的 @别名编辑（复用 HandleSetup）与账号区留出间距 */
 .settings-handle { margin-top: 12px; }
+
+/* #284 频道内交互式提问 */
+.msg-prompt { margin-top: 8px; padding: 8px 10px; border: 1px solid var(--border, #ddd); border-left: 3px solid var(--accent, #4a9eff); border-radius: 6px; background: var(--t-faint, rgba(74,158,255,0.05)); }
+.msg-prompt-q { font-size: 13px; font-weight: 600; margin-bottom: 8px; }
+.msg-prompt-opts { display: flex; flex-wrap: wrap; gap: 6px; }
+.msg-prompt-opt { font-size: 12px; padding: 4px 12px; border: 1px solid var(--border, #ccc); border-radius: 16px; background: var(--t-bg, #fff); cursor: pointer; color: var(--fg, inherit); }
+.msg-prompt-opt:hover { border-color: var(--accent, #4a9eff); background: var(--accent, #4a9eff); color: #fff; }
+.msg-prompt-opt--readonly { cursor: default; opacity: 0.7; }
+.msg-prompt-opt--readonly:hover { border-color: var(--border, #ccc); background: var(--t-bg, #fff); color: var(--fg, inherit); }

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -22,6 +22,10 @@ import {
   WEBHOOK_TIMEOUT_MS,
   type AgentLineage,
   type Attachment,
+  type MessagePrompt,
+  PROMPT_QUESTION_MAX,
+  PROMPT_OPTION_MAX,
+  PROMPT_OPTIONS_MAX,
   type ErrorCode,
   type AgentContext,
   type CollaborationRole,
@@ -700,6 +704,38 @@ function parseAttachments(raw: unknown): Attachment[] | null | undefined {
   return out;
 }
 
+// #284 交互式提问校验：question 非空且不超上限，options 为 1..PROMPT_OPTIONS_MAX 个非空字符串
+// （去空白、各不超上限、去重）。undefined/null → 无 prompt；非法 → null（调用方拒收）。
+function parseMessagePrompt(raw: unknown): MessagePrompt | null | undefined {
+  if (raw === undefined || raw === null) return undefined;
+  if (typeof raw !== "object") return null;
+  const p = raw as Record<string, unknown>;
+  if (typeof p.question !== "string") return null;
+  const question = p.question.trim();
+  if (question === "" || byteLength(question) > PROMPT_QUESTION_MAX) return null;
+  if (!Array.isArray(p.options)) return null;
+  const options: string[] = [];
+  for (const item of p.options) {
+    if (typeof item !== "string") return null;
+    const opt = item.trim();
+    if (opt === "" || byteLength(opt) > PROMPT_OPTION_MAX) return null;
+    if (!options.includes(opt)) options.push(opt);
+  }
+  if (options.length === 0 || options.length > PROMPT_OPTIONS_MAX) return null;
+  return { question, options };
+}
+
+// 反序列化落库的 prompt（#284）；复用同一校验，脏数据静默丢弃。
+function parseStoredMessagePrompt(input: unknown): MessagePrompt | undefined {
+  if (typeof input !== "string" || input === "") return undefined;
+  try {
+    const parsed = parseMessagePrompt(JSON.parse(input) as unknown);
+    return parsed === null ? undefined : parsed;
+  } catch {
+    return undefined;
+  }
+}
+
 // rest body 与 ws send 帧共用的校验（rest 侧无 type 字段）
 function parseSendFrame(input: unknown): SendFrame | null {
   if (typeof input !== "object" || input === null) return null;
@@ -722,6 +758,8 @@ function parseSendFrame(input: unknown): SendFrame | null {
     if (completionArtifact === null) return null;
     const attachments = parseAttachments(f.attachments);
     if (attachments === null) return null;
+    const prompt = parseMessagePrompt(f.prompt);
+    if (prompt === null) return null;
     let replaces: number | undefined;
     if (f.replaces !== undefined) {
       if (typeof f.replaces !== "number" || !Number.isInteger(f.replaces) || f.replaces <= 0) return null;
@@ -735,6 +773,7 @@ function parseSendFrame(input: unknown): SendFrame | null {
       reply_to,
       ...(completionArtifact !== undefined ? { completion_artifact: completionArtifact } : {}),
       ...(attachments !== undefined ? { attachments } : {}),
+      ...(prompt !== undefined ? { prompt } : {}),
       ...(completionArtifact !== undefined && replaces !== undefined ? { replaces } : {}),
       ...(idempotencyKey !== undefined ? { idempotency_key: idempotencyKey } : {}),
     };
@@ -968,6 +1007,8 @@ export class ChannelDO extends Server<Env> {
       "ALTER TABLE messages ADD COLUMN idempotency_key TEXT",
       // 附件引用（#176）：存 Attachment[] 的 JSON，仅元数据（key/filename/type/size/url），blob 在 R2。
       "ALTER TABLE messages ADD COLUMN attachments_json TEXT",
+      // #284 交互式提问：{question, options[]} JSON；DO 内建 SQLite 幂等 ALTER，非 D1 迁移。
+      "ALTER TABLE messages ADD COLUMN prompt_json TEXT",
     ]) {
       try {
         sql.exec(ddl);
@@ -2984,6 +3025,7 @@ export class ChannelDO extends Server<Env> {
     const completionReviewPolicy = (this.getMeta("completion_review_policy") ?? "sender") as CompletionReviewPolicy;
     const completionArtifact = frame.kind === "message" ? frame.completion_artifact : undefined;
     const attachments = frame.kind === "message" ? frame.attachments : undefined;
+    const prompt = frame.kind === "message" ? frame.prompt : undefined;
     const replacesSeq =
       frame.kind === "message" && completionArtifact !== undefined && completionGate === "reviewer"
         ? frame.replaces
@@ -3063,9 +3105,9 @@ export class ChannelDO extends Server<Env> {
          state, note, status_scope_json, status_summary_seq, status_blocked_reason, status_context_json,
          status_decision_json, status_workflow_json, message_workflow_json,
          sender_role, sender_role_source, completion_artifact_json, completion_review_state, completion_review_policy,
-         completion_review_replaces_seq, idempotency_key, attachments_json, ts
+         completion_review_replaces_seq, idempotency_key, attachments_json, prompt_json, ts
        )
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       seq,
       identity.name,
       identity.kind,
@@ -3098,6 +3140,7 @@ export class ChannelDO extends Server<Env> {
       replacesSeq ?? null,
       frame.idempotency_key ?? null,
       attachments === undefined ? null : JSON.stringify(attachments),
+      prompt === undefined ? null : JSON.stringify(prompt),
       now,
     );
     let replacedUpdate: MessageUpdateFrame | undefined;
@@ -3969,6 +4012,9 @@ export class ChannelDO extends Server<Env> {
       if (workflowRef !== undefined) frame.workflow_ref = workflowRef;
       const attachments = parseStoredAttachments(r.attachments_json);
       if (attachments !== undefined) frame.attachments = attachments;
+      // #284 交互式提问：已撤回的消息不再渲染可点按钮。
+      const prompt = parseStoredMessagePrompt(r.prompt_json);
+      if (prompt !== undefined && !retracted) frame.prompt = prompt;
     }
     if (r.edited_at !== null && r.edited_at !== undefined) {
       frame.edited = true;

--- a/worker/test/prompt.spec.ts
+++ b/worker/test/prompt.spec.ts
@@ -1,0 +1,59 @@
+// #284 频道内交互式提问：消息带 prompt {question, options[]}，服务端校验 + 落库 + 回帧带出。
+import { describe, expect, it } from "vitest";
+import { api, createChannel, seedToken } from "./helpers";
+
+interface MsgLike {
+  seq: number;
+  body: string;
+  kind: string;
+  prompt?: { question: string; options: string[] };
+}
+
+async function messages(slug: string, token: string): Promise<MsgLike[]> {
+  const res = await api(`/api/channels/${slug}/messages?since=0&limit=1000`, token);
+  return ((await res.json()) as { messages: MsgLike[] }).messages;
+}
+
+function send(slug: string, token: string, body: string, prompt?: unknown): Promise<Response> {
+  return api(`/api/channels/${slug}/messages`, token, {
+    method: "POST",
+    body: JSON.stringify({ kind: "message", body, mentions: [], reply_to: null, ...(prompt === undefined ? {} : { prompt }) }),
+  });
+}
+
+describe("message prompt (#284)", () => {
+  it("round-trips a prompt: question + options come back on the frame", async () => {
+    const { token } = await seedToken("agent");
+    const slug = await createChannel(token);
+    const res = await send(slug, token, "选择执行方案", { question: "选择执行方案", options: ["方案A", "方案B", "方案A"] });
+    expect(res.status).toBe(200);
+    const msg = (await messages(slug, token)).find((m) => m.body === "选择执行方案")!;
+    expect(msg.prompt).toBeDefined();
+    expect(msg.prompt!.question).toBe("选择执行方案");
+    // 重复选项去重
+    expect(msg.prompt!.options).toEqual(["方案A", "方案B"]);
+  });
+
+  it("a normal message has no prompt", async () => {
+    const { token } = await seedToken("agent");
+    const slug = await createChannel(token);
+    await send(slug, token, "hi");
+    const msg = (await messages(slug, token)).find((m) => m.body === "hi")!;
+    expect(msg.prompt).toBeUndefined();
+  });
+
+  it("rejects an invalid prompt (empty options) with 400, does not persist", async () => {
+    const { token } = await seedToken("agent");
+    const slug = await createChannel(token);
+    const bad = await send(slug, token, "bad prompt", { question: "q", options: [] });
+    expect(bad.status).toBe(400);
+    expect((await messages(slug, token)).some((m) => m.body === "bad prompt")).toBe(false);
+  });
+
+  it("rejects a prompt whose question is missing", async () => {
+    const { token } = await seedToken("agent");
+    const slug = await createChannel(token);
+    const bad = await send(slug, token, "no q", { options: ["A"] });
+    expect(bad.status).toBe(400);
+  });
+});


### PR DESCRIPTION
频道身份：网页 leo（owner）。#284 Part2：把 CLI 里 agent↔人的选择/审批交互搬进频道。

**流程**：agent 发带 prompt 的消息（`party send "选择方案" --option 方案A --option 方案B`）→ 频道渲染问题+可点按钮 → 人类点一个 → 一键发「选择：X」回复（reply_to 指向问题、@ 问的人叫醒它）。approve/reject = `--option 通过 --option 拒绝`。

- **shared**：MessagePrompt 类型 + 两个 frame 的 prompt 字段 + 上限。
- **worker**：校验（question 非空≤500B，options 1..12 个≤100B、去重）+ prompt_json 落库（DO 幂等 ALTER）+ rowToFrame（撤回不渲染）。
- **web**：MessageCard 渲染 prompt，onAnswerPrompt 一键直发答案 + @问的人；i18n en/zh + CSS。
- **cli**：`party send --option`（可重复）。

Part1（方案上传+预览）已由 #176 附件覆盖。测试：worker prompt.spec 4/4、check:web 472/472、cli 22/22，全 tsc 干净。

Closes #284.