### PR TITLE
feat(worker,cli): per-agent wake 预算/配额硬上限，超额 @ 不再无界烧订阅（#108）

### DIFF
--- a/cli/src/commands/wake-budget.ts
+++ b/cli/src/commands/wake-budget.ts
@@ -1,0 +1,128 @@
+// party wake-budget（issue #108）——查看/设置某 agent 在频道里的 wake 预算（窗口内唤醒硬上限）。
+// 背景：每个 @ 触发一次完整 runner run，会烧目标 agent 的 LLM 订阅/tokens；协议此前无任何总量上限。
+// 设了预算后，窗口内已投 wake 达到 limit 的目标，再被 @ 也不投 webhook（不烧订阅），落 ledger 的
+// budget 行 + 频道内 system status 可观测。缺省不设 = 不限（正常流）。
+// 授权：agent 可给自己设（自我节流），moderator（房主 / ap_）可给任意 agent 设/清。
+import { isHelpArg, num, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
+import { resolveChannel } from "../config";
+import { resolveAuth } from "../oidc-cli";
+import { getWakeBudget, handleRestError, setWakeBudget } from "../rest";
+import { isSlug } from "../validation";
+import { parseDurationMs } from "./pause";
+
+const FLAGS = ["channel", "limit", "window", "off"];
+const HELP = `usage: party wake-budget <name> [channel|--channel C]
+       party wake-budget <name> --limit N [--window <dur>] [channel|--channel C]
+       party wake-budget <name> --off [channel|--channel C]
+
+Inspect or set an agent's per-channel wake budget (issue #108). Every @-mention
+triggers a full runner run that burns the target's LLM subscription. A wake budget
+caps how many wakes an agent takes per rolling window; @-mentions beyond the cap are
+withheld (webhook not fired, no tokens burned) and surfaced in-channel + the ledger.
+
+Run with no flags to inspect. An agent may set its own budget; a channel moderator
+may set/clear any agent's budget.
+
+Options:
+  --channel C    act on channel C instead of the bound channel
+  --limit N      max wakes per window (positive integer). Sets the budget.
+  --window D     rolling window: 30m / 2h / 1d / 90s (default 1h when omitted)
+  --off          clear the budget (back to unlimited / normal flow)`;
+
+function fmtWindow(ms: number | null): string {
+  if (ms === null) return "-";
+  if (ms % 86_400_000 === 0) return `${ms / 86_400_000}d`;
+  if (ms % 3_600_000 === 0) return `${ms / 3_600_000}h`;
+  if (ms % 60_000 === 0) return `${ms / 60_000}m`;
+  return `${Math.round(ms / 1000)}s`;
+}
+
+export async function run(argv: string[]): Promise<number> {
+  if (isHelpArg(argv, { allowHelpPositional: true })) {
+    console.log(HELP);
+    return 0;
+  }
+  const { positionals, flags } = parseArgs(argv, { booleans: ["off"] });
+  const unknown = unknownFlagError(flags, FLAGS);
+  if (unknown !== null) {
+    console.error(unknown);
+    return 1;
+  }
+  const flagError = valueFlagError(flags, ["channel", "limit", "window"]);
+  if (flagError !== null) {
+    console.error(flagError);
+    return 1;
+  }
+  const name = positionals[0];
+  if (!name) {
+    console.error("usage: party wake-budget <name> [--limit N [--window D] | --off]");
+    return 1;
+  }
+  const channel = resolveChannel(str(flags.channel) ?? positionals[1]);
+  if (!channel) {
+    console.error("no channel, pass one or bind with: party init --channel C");
+    return 1;
+  }
+  if (!isSlug(channel)) {
+    console.error("channel must match [a-z0-9][a-z0-9-]{0,63}");
+    return 1;
+  }
+  const cfg = await resolveAuth();
+  if (!cfg) {
+    console.error("no config, run: party login or party init --server URL --token T");
+    return 1;
+  }
+
+  const off = flags.off === true;
+  const limitRaw = num(flags.limit);
+  const windowStr = str(flags.window);
+  const isSet = off || limitRaw !== undefined || windowStr !== undefined;
+
+  try {
+    // 无任何写入 flag → inspect
+    if (!isSet) {
+      const state = await getWakeBudget(cfg.server, cfg.token, channel, name);
+      if (!state.enabled) {
+        console.log(`${name}: no wake budget (unlimited)`);
+        return 0;
+      }
+      const resets =
+        state.window_resets_at === null ? "" : ` (window rolls at ${new Date(state.window_resets_at).toISOString()})`;
+      console.log(
+        `${name}: ${state.used}/${state.limit} wakes used per ${fmtWindow(state.window_ms)}, ${state.remaining} remaining${resets}`,
+      );
+      return 0;
+    }
+
+    if (off) {
+      await setWakeBudget(cfg.server, cfg.token, channel, name, { enabled: false });
+      console.log(`cleared wake budget for ${name} in ${channel} — back to unlimited`);
+      return 0;
+    }
+
+    if (limitRaw === undefined || !Number.isInteger(limitRaw) || limitRaw <= 0) {
+      console.error("invalid --limit: pass a positive integer, e.g. --limit 20");
+      return 1;
+    }
+    let windowMs: number | undefined;
+    if (windowStr !== undefined) {
+      const parsed = parseDurationMs(windowStr);
+      if (parsed === null || parsed <= 0) {
+        console.error("invalid --window: use 30m / 2h / 1d / 90s");
+        return 1;
+      }
+      windowMs = parsed;
+    }
+    const state = await setWakeBudget(cfg.server, cfg.token, channel, name, {
+      enabled: true,
+      limit: limitRaw,
+      ...(windowMs === undefined ? {} : { window_ms: windowMs }),
+    });
+    console.log(
+      `set wake budget for ${name} in ${channel}: ${state.limit} wakes per ${fmtWindow(state.window_ms)} — over-budget @-mentions are withheld`,
+    );
+    return 0;
+  } catch (e) {
+    return handleRestError(e);
+  }
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -38,6 +38,7 @@ commands:
   who       [channel|--channel C] [--json]                who is online/wakeable/recent — pick who to --mention
   pause     <name> [--channel C] [--resume-at T|--for D]   stop waking an agent (moderator); auto-resume at T / after D
   resume    <name> [--channel C]                           resume a paused agent's reception (moderator)
+  wake-budget <name> [--limit N [--window D]|--off]        cap an agent's wakes per window; over-budget @ withheld (#108)
   health    [--json] [--channel C] [--stale-after ms]      local serve WS health probe (pid alive != ws alive, #254)
   charter   [slug] [--json] | set [slug] -f file.md|-m text|- | template
   history   [channel|--channel C] [--since seq] [--limit n] [--json] [--completion]
@@ -118,6 +119,8 @@ export async function main(argv: string[]): Promise<number> {
     case "pause":
     case "resume":
       return (await import("./commands/pause")).run(cmd, rest);
+    case "wake-budget":
+      return (await import("./commands/wake-budget")).run(rest);
     case "charter":
       return (await import("./commands/charter")).run(rest);
     case "history":

--- a/cli/src/rest.ts
+++ b/cli/src/rest.ts
@@ -977,6 +977,42 @@ export async function getLoopGuard(server: string, token: string, slug: string):
   })) as LoopGuardState;
 }
 
+// #108 per-agent wake 预算：窗口内 wake 硬上限，超额 @ 不再投 webhook（不烧订阅）。
+export interface WakeBudgetState {
+  name: string;
+  enabled: boolean;
+  limit: number | null;
+  window_ms: number | null;
+  used: number;
+  remaining: number | null;
+  window_resets_at: number | null;
+}
+
+export async function getWakeBudget(
+  server: string,
+  token: string,
+  slug: string,
+  name: string,
+): Promise<WakeBudgetState> {
+  return (await req(server, `/api/channels/${encodeURIComponent(slug)}/wake-budget/${encodeURIComponent(name)}`, {
+    headers: bearerJson(token),
+  })) as WakeBudgetState;
+}
+
+export async function setWakeBudget(
+  server: string,
+  token: string,
+  slug: string,
+  name: string,
+  body: { enabled: boolean; limit?: number; window_ms?: number },
+): Promise<WakeBudgetState> {
+  return (await req(server, `/api/channels/${encodeURIComponent(slug)}/wake-budget/${encodeURIComponent(name)}`, {
+    method: "PUT",
+    headers: bearerJson(token),
+    body: JSON.stringify(body),
+  })) as WakeBudgetState;
+}
+
 export async function setWorkflowGuard(
   server: string,
   token: string,

--- a/cli/test/oidc-mock.ts
+++ b/cli/test/oidc-mock.ts
@@ -30,6 +30,7 @@ export function startOidcMock(opts: MockOptions = {}): OidcMock {
   const tokenCalls: Record<string, string>[] = [];
   const profiles: Record<string, unknown>[] = [];
   const invites: Record<string, unknown>[] = [];
+  const wakeBudgets = new Map<string, { limit: number; window_ms: number }>();
   let base = "";
 
   const server = Bun.serve({
@@ -150,6 +151,32 @@ export function startOidcMock(opts: MockOptions = {}): OidcMock {
       if (req.method === "GET" && /^\/api\/channels\/[^/]+\/loop-guard$/.test(u.pathname)) {
         // #174 loop guard 读路径 mock
         return Response.json({ enabled: true, limit: 30, streak: 27, remaining: 3, resets_on: "human" });
+      }
+      // #108 per-agent wake 预算 set/inspect mock（内存态）
+      const wbMatch = u.pathname.match(/^\/api\/channels\/[^/]+\/wake-budget\/([^/]+)$/);
+      if (wbMatch) {
+        const name = decodeURIComponent(wbMatch[1] ?? "");
+        if (req.method === "PUT") {
+          const b = rec.body as { enabled?: boolean; limit?: number; window_ms?: number } | null;
+          if (b?.enabled === false) {
+            wakeBudgets.delete(name);
+          } else {
+            wakeBudgets.set(name, { limit: b?.limit ?? 0, window_ms: b?.window_ms ?? 3_600_000 });
+          }
+        }
+        const cfg = wakeBudgets.get(name);
+        if (!cfg) {
+          return Response.json({ name, enabled: false, limit: null, window_ms: null, used: 0, remaining: null, window_resets_at: null });
+        }
+        return Response.json({
+          name,
+          enabled: true,
+          limit: cfg.limit,
+          window_ms: cfg.window_ms,
+          used: 0,
+          remaining: cfg.limit,
+          window_resets_at: null,
+        });
       }
       if (req.method === "POST" && /^\/api\/channels\/[^/]+\/project-agents$/.test(u.pathname)) {
         const slug = u.pathname.split("/")[3] ?? "dev";

--- a/cli/test/wake-budget.test.ts
+++ b/cli/test/wake-budget.test.ts
@@ -1,0 +1,100 @@
+// party wake-budget（issue #108）：inspect（GET）/ set（PUT --limit --window）/ clear（--off），
+// 以及 fmtWindow 展示与 --limit 校验。窗口内 wake 硬上限，超额 @ 由 worker 侧抑制（不烧订阅）。
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { run as wakeBudgetRun } from "../src/commands/wake-budget";
+import { writeConfig, writeState } from "../src/config";
+import { startOidcMock, type OidcMock } from "./oidc-mock";
+
+let home: string;
+let mock: OidcMock | null = null;
+let logs: string[];
+let errs: string[];
+const origLog = console.log;
+const origErr = console.error;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "ap-wakebudget-"));
+  process.env.AGENTPARTY_HOME = home;
+  logs = [];
+  errs = [];
+  console.log = (...a: unknown[]) => logs.push(a.map(String).join(" "));
+  console.error = (...a: unknown[]) => errs.push(a.map(String).join(" "));
+});
+
+afterEach(() => {
+  console.log = origLog;
+  console.error = origErr;
+  delete process.env.AGENTPARTY_HOME;
+  rmSync(home, { recursive: true, force: true });
+  mock?.stop();
+  mock = null;
+});
+
+test("no flags → inspect via GET, prints 'no wake budget' when unset", async () => {
+  mock = startOidcMock();
+  writeConfig({ server: mock.url, token: "ap_runtime" });
+  writeState({ channel: "ops", cursor: 0 });
+
+  const code = await wakeBudgetRun(["alice"]);
+  expect(code).toBe(0);
+  const req = mock.requests.find((r) => r.path === "/api/channels/ops/wake-budget/alice");
+  expect(req?.method).toBe("GET");
+  expect(logs.join("\n").toLowerCase()).toContain("no wake budget");
+});
+
+test("--limit N --window D → PUT sets budget and echoes the cap", async () => {
+  mock = startOidcMock();
+  writeConfig({ server: mock.url, token: "ap_runtime" });
+  writeState({ channel: "ops", cursor: 0 });
+
+  const code = await wakeBudgetRun(["bob", "--limit", "20", "--window", "2h"]);
+  expect(code).toBe(0);
+  const put = mock.requests.find((r) => r.path === "/api/channels/ops/wake-budget/bob" && r.method === "PUT");
+  expect(put).toBeDefined();
+  expect(put?.body).toMatchObject({ enabled: true, limit: 20, window_ms: 7_200_000 });
+  const out = logs.join("\n");
+  expect(out).toContain("20 wakes");
+  expect(out).toContain("2h");
+
+  // 设完再 inspect 应看到已生效
+  logs.length = 0;
+  await wakeBudgetRun(["bob"]);
+  expect(logs.join("\n")).toContain("20");
+});
+
+test("--off → PUT enabled:false clears the budget", async () => {
+  mock = startOidcMock();
+  writeConfig({ server: mock.url, token: "ap_runtime" });
+  writeState({ channel: "ops", cursor: 0 });
+
+  await wakeBudgetRun(["carol", "--limit", "5"]);
+  logs.length = 0;
+  const code = await wakeBudgetRun(["carol", "--off"]);
+  expect(code).toBe(0);
+  const puts = mock.requests.filter((r) => r.path === "/api/channels/ops/wake-budget/carol" && r.method === "PUT");
+  expect(puts.at(-1)?.body).toMatchObject({ enabled: false });
+  expect(logs.join("\n").toLowerCase()).toContain("unlimited");
+});
+
+test("--limit 0 → local validation error, no request", async () => {
+  mock = startOidcMock();
+  writeConfig({ server: mock.url, token: "ap_runtime" });
+  writeState({ channel: "ops", cursor: 0 });
+
+  const code = await wakeBudgetRun(["dave", "--limit", "0"]);
+  expect(code).toBe(1);
+  expect(errs.join("\n")).toContain("--limit");
+  expect(mock.requests.some((r) => r.path.includes("/wake-budget/dave"))).toBe(false);
+});
+
+test("missing name → usage error", async () => {
+  mock = startOidcMock();
+  writeConfig({ server: mock.url, token: "ap_runtime" });
+  writeState({ channel: "ops", cursor: 0 });
+  const code = await wakeBudgetRun([]);
+  expect(code).toBe(1);
+  expect(errs.join("\n").toLowerCase()).toContain("usage");
+});

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -38,6 +38,16 @@ export const MAX_WEBHOOK_DEAD_LETTERS = 200;
 // 单次 redeliver 最多重投多少条死信，避免一个端点的巨量积压一次性打满 subrequest 配额。
 export const WEBHOOK_REDELIVER_BATCH_SIZE = 50;
 
+// ---- per-agent wake 预算/配额（#108）----
+// 每个 @ 触发一次完整 runner run，会烧目标 agent 的 LLM 订阅/tokens；协议此前无任何总量上限
+// （README 宣称的「capacity routing」无落地）。这里给每个 agent 一个滚动窗口内的 wake 硬上限：
+// 窗口内已投 wake 数达到 limit 后，再来的 @ 不再投 webhook（不烧订阅），落 wake_delivery_ledger
+// 的 budget 行 + 频道内 system status 可观测。缺省不设 = 不限（正常流，零影响）。
+export const WAKE_BUDGET_DEFAULT_WINDOW_MS = 60 * 60_000; // 未显式指定窗口时默认 1 小时
+export const WAKE_BUDGET_MIN_WINDOW_MS = 1_000; // 窗口下限 1s，防除零/病态极短窗口
+export const WAKE_BUDGET_MAX_WINDOW_MS = 30 * 24 * 60 * 60 * 1000; // 窗口上限 30 天
+export const WAKE_BUDGET_MAX_LIMIT = 100_000; // limit 硬上限，防把预算当计数器滥用
+
 // ---- 会员分层（#277 骨架）----
 // 账号维度的 free/member 层：托管部署每月要成本，会员用于回收；自部署始终免费。
 // 本次只搭骨架——建库、开通路径、isMember 钩子；不定价、不接支付、不 gate 任何功能。

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -24,6 +24,10 @@ import {
   WEBHOOK_RETRY_BATCH_SIZE,
   WEBHOOK_RETRY_DELAYS_MS,
   WEBHOOK_TIMEOUT_MS,
+  WAKE_BUDGET_DEFAULT_WINDOW_MS,
+  WAKE_BUDGET_MAX_LIMIT,
+  WAKE_BUDGET_MAX_WINDOW_MS,
+  WAKE_BUDGET_MIN_WINDOW_MS,
   type AgentLineage,
   type Attachment,
   type ErrorCode,
@@ -1925,9 +1929,22 @@ export class ChannelDO extends Server<Env> {
       (h) => this.shouldDeliverWebhook(h.filter, h.name, msg) && !this.isPresencePaused(h.name),
     );
     if (targets.length === 0) return;
+    // #108 per-agent wake 预算：在真正投递（烧订阅）之前判每个目标是否已超窗口内 wake 硬上限。
+    // 超额者不投 webhook（这是「webhook not fired」的强制点），落 wake_delivery_ledger 的 budget
+    // 行做归属审计（哪条 mention_seq、谁被 @），并按窗口去重地在频道内 system status 通告一次可观测。
+    const firing: WebhookRow[] = [];
+    for (const hook of targets) {
+      if (this.isOverWakeBudget(hook.name, now)) {
+        this.recordWakeWithheld(msg.seq, hook.name, now);
+        this.alertWakeBudget(hook.name, now);
+      } else {
+        firing.push(hook);
+      }
+    }
+    if (firing.length === 0) return;
     // 并行投递：一个慢/坏端点不再拖累其余 hook（首投已由 afterSend 的 waitUntil 移出发送关键路径）
     const results = await Promise.all(
-      targets.map(async (hook) => ({
+      firing.map(async (hook) => ({
         hook,
         delivery: await this.deliverWebhook(hook.url, hook.secret, payload),
       })),
@@ -2043,6 +2060,118 @@ export class ChannelDO extends Server<Env> {
       resume.ackSeq,
       resume.resumeSeq,
     );
+  }
+
+  // #108 per-agent wake 预算配置：未设 = null = 不限（正常流）。limit 存 meta，window 缺省 1 小时。
+  private wakeBudgetConfig(name: string): { limit: number; windowMs: number } | null {
+    const raw = this.getMeta(`wake_budget_limit:${name}`);
+    if (raw === null) return null;
+    const limit = Number(raw);
+    if (!Number.isInteger(limit) || limit <= 0) return null;
+    const rawWindow = Number(this.getMeta(`wake_budget_window:${name}`) ?? "");
+    const windowMs =
+      Number.isInteger(rawWindow) && rawWindow >= WAKE_BUDGET_MIN_WINDOW_MS ? rawWindow : WAKE_BUDGET_DEFAULT_WINDOW_MS;
+    return { limit, windowMs };
+  }
+
+  // 滚动窗口内已消耗的 wake 数：ledger 里该 target 的首投行（attempt=1，排除 budget 抑制标记与重试行）。
+  // 一条首投 = 一次「唤醒该 agent 的 runner」，正是要计的烧订阅事件；重试（attempt>1）是同一 wake 的
+  // 再投，不重复计；budget 行是被抑制的、从未真投，不消耗预算。
+  private wakeCountInWindow(name: string, windowStart: number): number {
+    return Number(
+      this.ctx.storage.sql
+        .exec(
+          `SELECT COUNT(*) AS n FROM wake_delivery_ledger
+            WHERE target_name = ? AND attempt = 1 AND result != 'budget' AND attempted_at >= ?`,
+          name,
+          windowStart,
+        )
+        .one().n,
+    );
+  }
+
+  // 该目标此刻是否已超 wake 预算（true = 应抑制，不投 webhook）。未设预算 = 永不超。
+  private isOverWakeBudget(name: string, now: number): boolean {
+    const cfg = this.wakeBudgetConfig(name);
+    if (cfg === null) return false;
+    return this.wakeCountInWindow(name, now - cfg.windowMs) >= cfg.limit;
+  }
+
+  // 超预算而被抑制的 wake：落一条 result='budget' 的 ledger 行做审计——归属到具体 mention_seq / 目标，
+  // http_status=null（从未真投），error 记下预算参数。计数查询用 result!='budget' 把它排除在消耗之外。
+  private recordWakeWithheld(mentionSeq: number, name: string, now: number) {
+    const cfg = this.wakeBudgetConfig(name);
+    const resume = this.findExistingWakeResume(name, mentionSeq);
+    this.ctx.storage.sql.exec(
+      `INSERT INTO wake_delivery_ledger (
+         mention_seq, target_name, webhook_name, adapter_kind, attempt,
+         result, http_status, error, attempted_at, ack_seq, resume_seq
+       )
+       VALUES (?, ?, ?, 'webhook', 1, 'budget', NULL, ?, ?, ?, ?)`,
+      mentionSeq,
+      name,
+      name,
+      cfg === null
+        ? "wake budget exceeded"
+        : `wake budget exceeded: ${cfg.limit} wakes / ${cfg.windowMs}ms`,
+      now,
+      resume.ackSeq,
+      resume.resumeSeq,
+    );
+  }
+
+  // 频道内可观测：预算用尽时通告一条 system status。按窗口去重（一个窗口内只播一次），避免
+  // 高频 @ 把频道刷屏。用 waiting 而非 blocked——这是节流不是熔断，blocked 会让守 etiquette 的 agent 停手。
+  private alertWakeBudget(name: string, now: number) {
+    const cfg = this.wakeBudgetConfig(name);
+    if (cfg === null) return;
+    const key = `wake_budget_alerted:${name}`;
+    const last = Number(this.getMeta(key) ?? "");
+    if (Number.isInteger(last) && now - last < cfg.windowMs) return;
+    this.setMeta(key, String(now));
+    const windowMin = Math.max(1, Math.round(cfg.windowMs / 60_000));
+    this.insertSystemStatus(
+      `wake budget for ${name} exhausted: ${cfg.limit} wakes per ${windowMin}m — further @-mentions are withheld until the window rolls`,
+      now,
+      false,
+      { state: "waiting" },
+    );
+  }
+
+  // 预算快照（inspect 用）：含窗口内已用 used / remaining / 最早那次 wake 老化出窗后的恢复时刻。
+  private wakeBudgetState(name: string): {
+    name: string;
+    enabled: boolean;
+    limit: number | null;
+    window_ms: number | null;
+    used: number;
+    remaining: number | null;
+    window_resets_at: number | null;
+  } {
+    const cfg = this.wakeBudgetConfig(name);
+    if (cfg === null) {
+      return { name, enabled: false, limit: null, window_ms: null, used: 0, remaining: null, window_resets_at: null };
+    }
+    const now = Date.now();
+    const windowStart = now - cfg.windowMs;
+    const used = this.wakeCountInWindow(name, windowStart);
+    const oldest = this.ctx.storage.sql
+      .exec(
+        `SELECT MIN(attempted_at) AS t FROM wake_delivery_ledger
+          WHERE target_name = ? AND attempt = 1 AND result != 'budget' AND attempted_at >= ?`,
+        name,
+        windowStart,
+      )
+      .one().t;
+    return {
+      name,
+      enabled: true,
+      limit: cfg.limit,
+      window_ms: cfg.windowMs,
+      used,
+      remaining: Math.max(0, cfg.limit - used),
+      window_resets_at: oldest === null || oldest === undefined ? null : Number(oldest) + cfg.windowMs,
+    };
   }
 
   private findExistingWakeResume(targetName: string, mentionSeq: number): { ackSeq: number | null; resumeSeq: number | null } {
@@ -3076,6 +3205,50 @@ export class ChannelDO extends Server<Env> {
       }
       this.resumePresence(name, now);
       return Response.json({ ok: true, paused: false });
+    }
+    // #108 per-agent wake 预算 set/inspect。授权在 worker 侧已判（agent-for-self / moderator），do 只落状态。
+    const wakeBudgetMatch = url.pathname.match(/^\/internal\/wake-budget\/([^/]+)$/);
+    if (wakeBudgetMatch) {
+      const name = decodeURIComponent(wakeBudgetMatch[1] ?? "");
+      if (!name) {
+        return Response.json({ error: { code: "bad_request", message: "name required" } }, { status: 400 });
+      }
+      if (request.method === "GET") {
+        return Response.json(this.wakeBudgetState(name));
+      }
+      if (request.method === "PUT") {
+        const body = (await request.json().catch(() => null)) as
+          | { enabled?: unknown; limit?: unknown; window_ms?: unknown }
+          | null;
+        // enabled 显式 false = 清除预算（回到不限）；缺省视为设置。
+        if (body?.enabled === false) {
+          this.deleteMeta(`wake_budget_limit:${name}`);
+          this.deleteMeta(`wake_budget_window:${name}`);
+          this.deleteMeta(`wake_budget_alerted:${name}`);
+          return Response.json(this.wakeBudgetState(name));
+        }
+        const limit = Number(body?.limit);
+        if (!Number.isInteger(limit) || limit <= 0) {
+          return Response.json(
+            { error: { code: "bad_request", message: "limit must be a positive integer" } },
+            { status: 400 },
+          );
+        }
+        const rawWindow =
+          body?.window_ms === undefined || body?.window_ms === null
+            ? WAKE_BUDGET_DEFAULT_WINDOW_MS
+            : Number(body.window_ms);
+        if (!Number.isInteger(rawWindow) || rawWindow < WAKE_BUDGET_MIN_WINDOW_MS) {
+          return Response.json(
+            { error: { code: "bad_request", message: `window_ms must be an integer >= ${WAKE_BUDGET_MIN_WINDOW_MS}` } },
+            { status: 400 },
+          );
+        }
+        this.setMeta(`wake_budget_limit:${name}`, String(Math.min(limit, WAKE_BUDGET_MAX_LIMIT)));
+        this.setMeta(`wake_budget_window:${name}`, String(Math.min(rawWindow, WAKE_BUDGET_MAX_WINDOW_MS)));
+        this.deleteMeta(`wake_budget_alerted:${name}`); // 改配置即清抑制标记，新配置下可重新告警
+        return Response.json(this.wakeBudgetState(name));
+      }
     }
     return new Response("not found", { status: 404 });
   }

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -3659,6 +3659,50 @@ app.get("/api/channels/:slug/wake-deliveries", async (c) => {
   );
 });
 
+// #108 per-agent wake 预算 inspect：任何能访问频道的成员可读某 agent 的窗口内 used/remaining。
+app.get("/api/channels/:slug/wake-budget/:name", async (c) => {
+  const slug = c.req.param("slug");
+  const channel = await loadChannel(c.env.DB, slug);
+  if (!channel) return c.json(errorBody("not_found", "channel not found"), 404);
+  if (!(await canAccessLoadedChannel(c.env.DB, c.get("identity"), channel))) {
+    return c.json(errorBody("forbidden", "not allowed in this channel"), 403);
+  }
+  const name = c.req.param("name");
+  if (!name || name.length > 256) return c.json(errorBody("bad_request", "valid name required"), 400);
+  return fetchChannelDO(
+    c.env,
+    slug,
+    new Request(`https://do/internal/wake-budget/${encodeURIComponent(name)}`, {
+      headers: { "x-partykit-room": slug },
+    }),
+  );
+});
+
+// #108 set：agent 给自己设（自我节流 wake），或 moderator 给任意 agent 设/清（硬上限，超额 @ 不再烧订阅）。
+app.put("/api/channels/:slug/wake-budget/:name", async (c) => {
+  const slug = c.req.param("slug");
+  const channel = await loadChannel(c.env.DB, slug);
+  if (!channel) return c.json(errorBody("not_found", "channel not found"), 404);
+  const name = c.req.param("name");
+  if (!name || name.length > 256) return c.json(errorBody("bad_request", "valid name required"), 400);
+  const identity = c.get("identity");
+  const isSelf =
+    identity.kind === "agent" && identity.name === name && (await canAccessLoadedChannel(c.env.DB, identity, channel));
+  if (!isSelf && !isChannelModerator(identity, channel)) {
+    return c.json(errorBody("forbidden", "only the agent itself or a channel moderator can set a wake budget"), 403);
+  }
+  const body = await c.req.json().catch(() => null);
+  return fetchChannelDO(
+    c.env,
+    slug,
+    new Request(`https://do/internal/wake-budget/${encodeURIComponent(name)}`, {
+      method: "PUT",
+      body: JSON.stringify(body ?? {}),
+      headers: { "content-type": "application/json", "x-partykit-room": slug },
+    }),
+  );
+});
+
 app.get("/api/channels/:slug/read-cursors", async (c) => {
   const slug = c.req.param("slug");
   const channel = await loadChannel(c.env.DB, slug);

--- a/worker/test/wake-budget.spec.ts
+++ b/worker/test/wake-budget.spec.ts
@@ -1,0 +1,249 @@
+// issue #108：per-agent wake 预算/配额硬上限。每个 @ 触发一次完整 runner run，会烧目标的
+// LLM 订阅；协议此前无任何总量上限。这里给每个 agent 一个滚动窗口内的 wake 硬上限：窗口内
+// 已投 wake 达到 limit 后，再来的 @ 不再投 webhook（不烧订阅），落 wake_delivery_ledger 的
+// budget 行 + 频道内 system status 可观测；窗口滚动后自动恢复；不设预算 = 正常流（不限）。
+import { env, fetchMock, runInDurableObject } from "cloudflare:test";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import type { ChannelDO } from "../src/do";
+import { api, createChannel, seedToken, uniq } from "./helpers";
+
+beforeAll(() => {
+  fetchMock.activate();
+  fetchMock.disableNetConnect();
+});
+afterEach(() => fetchMock.assertNoPendingInterceptors());
+
+function sendMention(slug: string, token: string, target: string) {
+  return api(`/api/channels/${slug}/messages`, token, {
+    method: "POST",
+    body: JSON.stringify({ kind: "message", body: `@${target} ping`, mentions: [target], reply_to: null }),
+  });
+}
+
+function addWebhook(slug: string, token: string, name: string, url: string, filter = "mentions") {
+  return api(`/api/channels/${slug}/webhooks`, token, {
+    method: "POST",
+    body: JSON.stringify({ name, url, secret: "s", filter }),
+  });
+}
+
+function setBudget(
+  slug: string,
+  token: string,
+  name: string,
+  body: { enabled: boolean; limit?: number; window_ms?: number },
+) {
+  return api(`/api/channels/${slug}/wake-budget/${encodeURIComponent(name)}`, token, {
+    method: "PUT",
+    body: JSON.stringify(body),
+  });
+}
+
+function getBudget(slug: string, token: string, name: string) {
+  return api(`/api/channels/${slug}/wake-budget/${encodeURIComponent(name)}`, token);
+}
+
+interface LedgerRow {
+  mention_seq: number;
+  target_name: string;
+  attempt: number;
+  result: string;
+  http_status: number | null;
+  error: string | null;
+}
+
+async function ledgerRows(slug: string, target: string): Promise<LedgerRow[]> {
+  const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+  return runInDurableObject(stub, async (_i: ChannelDO, state) =>
+    state.storage.sql
+      .exec(
+        `SELECT mention_seq, target_name, attempt, result, http_status, error
+           FROM wake_delivery_ledger WHERE target_name = ? ORDER BY id`,
+        target,
+      )
+      .toArray()
+      .map((r) => ({
+        mention_seq: Number(r.mention_seq),
+        target_name: String(r.target_name),
+        attempt: Number(r.attempt),
+        result: String(r.result),
+        http_status: r.http_status === null ? null : Number(r.http_status),
+        error: r.error === null ? null : String(r.error),
+      })),
+  );
+}
+
+async function systemNotes(slug: string, token: string): Promise<string[]> {
+  const res = await api(`/api/channels/${slug}/messages?since=0`, token);
+  const body = (await res.json()) as { messages: { sender: { name: string }; body: string }[] };
+  return body.messages.filter((m) => m.sender.name === "system").map((m) => m.body);
+}
+
+describe("per-agent wake 预算（issue #108）", () => {
+  it("budget=N：窗口内前 N 个 @ 正常投递，第 N+1 个被抑制（webhook 不投），落 budget 行可观测", async () => {
+    const { token } = await seedToken("agent");
+    const target = uniq("budget-agent");
+    await seedToken("agent", target);
+    const slug = await createChannel(token);
+    expect((await addWebhook(slug, token, target, "https://budget-wake.test/hook")).status).toBe(201);
+
+    // 预算：窗口内最多 2 次 wake（大窗口，实测不会自然滚动）
+    expect((await setBudget(slug, token, target, { enabled: true, limit: 2, window_ms: 3_600_000 })).status).toBe(200);
+
+    // 前两个 @ 应真的投递（各注册一次 interceptor）
+    for (let i = 0; i < 2; i++) {
+      fetchMock.get("https://budget-wake.test").intercept({ path: "/hook", method: "POST" }).reply(200, "ok");
+      expect((await sendMention(slug, token, target)).status).toBe(200);
+      await new Promise((r) => setTimeout(r, 60));
+    }
+
+    // 第 3 个 @ 超预算：不注册 interceptor——若真投递会因 disableNetConnect 抛错并落 failed 行
+    expect((await sendMention(slug, token, target)).status).toBe(200);
+    await new Promise((r) => setTimeout(r, 60));
+
+    const rows = await ledgerRows(slug, target);
+    // 两次成功首投 + 一次 budget 抑制标记；没有 failed（证明第 3 个从未真的 fetch）
+    expect(rows.filter((r) => r.result === "ok" && r.attempt === 1)).toHaveLength(2);
+    const budgetRows = rows.filter((r) => r.result === "budget");
+    expect(budgetRows).toHaveLength(1);
+    expect(rows.some((r) => r.result === "failed")).toBe(false);
+
+    // 归属：budget 行带上是哪条 mention（第 3 条消息）以及被 @ 的目标
+    expect(budgetRows[0]).toMatchObject({ mention_seq: 3, target_name: target, attempt: 1, http_status: null });
+    expect(budgetRows[0]?.error).toEqual(expect.stringContaining("wake budget"));
+
+    // 频道内可观测：一条 system status 通告预算已用尽
+    const notes = await systemNotes(slug, token);
+    expect(notes.some((n) => n.includes(target) && n.toLowerCase().includes("wake budget"))).toBe(true);
+  });
+
+  it("不设预算 = 正常流：不限次数投递，无 budget 行", async () => {
+    const { token } = await seedToken("agent");
+    const target = uniq("nobudget-agent");
+    await seedToken("agent", target);
+    const slug = await createChannel(token);
+    expect((await addWebhook(slug, token, target, "https://nobudget-wake.test/hook")).status).toBe(201);
+
+    for (let i = 0; i < 4; i++) {
+      fetchMock.get("https://nobudget-wake.test").intercept({ path: "/hook", method: "POST" }).reply(200, "ok");
+      expect((await sendMention(slug, token, target)).status).toBe(200);
+      await new Promise((r) => setTimeout(r, 60));
+    }
+
+    const rows = await ledgerRows(slug, target);
+    expect(rows.filter((r) => r.result === "ok" && r.attempt === 1)).toHaveLength(4);
+    expect(rows.some((r) => r.result === "budget")).toBe(false);
+  });
+
+  it("窗口滚动后恢复投递：把窗口内旧 wake 的 attempted_at 挪到窗口外，下一个 @ 又能投", async () => {
+    const { token } = await seedToken("agent");
+    const target = uniq("roll-agent");
+    await seedToken("agent", target);
+    const slug = await createChannel(token);
+    expect((await addWebhook(slug, token, target, "https://roll-wake.test/hook")).status).toBe(201);
+    expect((await setBudget(slug, token, target, { enabled: true, limit: 1, window_ms: 3_600_000 })).status).toBe(200);
+
+    // 第 1 个投递用满预算
+    fetchMock.get("https://roll-wake.test").intercept({ path: "/hook", method: "POST" }).reply(200, "ok");
+    expect((await sendMention(slug, token, target)).status).toBe(200);
+    await new Promise((r) => setTimeout(r, 60));
+
+    // 第 2 个被抑制（budget 行，无 fetch）
+    expect((await sendMention(slug, token, target)).status).toBe(200);
+    await new Promise((r) => setTimeout(r, 60));
+    expect((await ledgerRows(slug, target)).filter((r) => r.result === "budget")).toHaveLength(1);
+
+    // 把已消耗的那次 wake 挪到窗口之外（模拟时间前进 / 窗口滚动）
+    const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+    await runInDurableObject(stub, async (_i: ChannelDO, state) => {
+      state.storage.sql.exec(
+        "UPDATE wake_delivery_ledger SET attempted_at = ? WHERE target_name = ? AND result = 'ok'",
+        Date.now() - 7_200_000,
+        target,
+      );
+    });
+
+    // 现在窗口内已消耗为 0，下一个 @ 又能投
+    fetchMock.get("https://roll-wake.test").intercept({ path: "/hook", method: "POST" }).reply(200, "ok");
+    expect((await sendMention(slug, token, target)).status).toBe(200);
+    await new Promise((r) => setTimeout(r, 60));
+    const okRows = (await ledgerRows(slug, target)).filter((r) => r.result === "ok" && r.attempt === 1);
+    expect(okRows).toHaveLength(2);
+  });
+
+  it("inspect：GET 返回 enabled/limit/window/used/remaining", async () => {
+    const { token } = await seedToken("agent");
+    const target = uniq("inspect-agent");
+    await seedToken("agent", target);
+    const slug = await createChannel(token);
+    expect((await addWebhook(slug, token, target, "https://inspect-wake.test/hook")).status).toBe(201);
+    expect((await setBudget(slug, token, target, { enabled: true, limit: 3, window_ms: 3_600_000 })).status).toBe(200);
+
+    fetchMock.get("https://inspect-wake.test").intercept({ path: "/hook", method: "POST" }).reply(200, "ok");
+    expect((await sendMention(slug, token, target)).status).toBe(200);
+    await new Promise((r) => setTimeout(r, 60));
+
+    const res = await getBudget(slug, token, target);
+    expect(res.status).toBe(200);
+    expect((await res.json()) as Record<string, unknown>).toMatchObject({
+      name: target,
+      enabled: true,
+      limit: 3,
+      window_ms: 3_600_000,
+      used: 1,
+      remaining: 2,
+    });
+  });
+
+  it("agent 可给自己设预算；持不同名字的 scoped token 不能替别人设（403）", async () => {
+    const { token } = await seedToken("agent");
+    const target = uniq("self-agent");
+    const slug = await createChannel(token);
+    // 目标自己的 channel-scoped token（能访问频道，但不是 moderator）
+    const { token: selfToken } = await seedToken("agent", target, { channelScope: slug });
+    // 自设应放行
+    expect((await setBudget(slug, selfToken, target, { enabled: true, limit: 5 })).status).toBe(200);
+
+    // 另一个 agent 的 scoped token 想替 target 设 → 403
+    const { token: otherToken } = await seedToken("agent", uniq("other"), { channelScope: slug });
+    expect((await setBudget(slug, otherToken, target, { enabled: true, limit: 1 })).status).toBe(403);
+  });
+
+  it("--off/清除预算后回到不限：清掉后超额 @ 恢复投递", async () => {
+    const { token } = await seedToken("agent");
+    const target = uniq("clear-agent");
+    await seedToken("agent", target);
+    const slug = await createChannel(token);
+    expect((await addWebhook(slug, token, target, "https://clear-wake.test/hook")).status).toBe(201);
+    expect((await setBudget(slug, token, target, { enabled: true, limit: 1, window_ms: 3_600_000 })).status).toBe(200);
+
+    fetchMock.get("https://clear-wake.test").intercept({ path: "/hook", method: "POST" }).reply(200, "ok");
+    expect((await sendMention(slug, token, target)).status).toBe(200);
+    await new Promise((r) => setTimeout(r, 60));
+
+    // 超预算，被抑制
+    expect((await sendMention(slug, token, target)).status).toBe(200);
+    await new Promise((r) => setTimeout(r, 60));
+    expect((await ledgerRows(slug, target)).filter((r) => r.result === "budget")).toHaveLength(1);
+
+    // 清除预算
+    expect((await setBudget(slug, token, target, { enabled: false })).status).toBe(200);
+    const cleared = await getBudget(slug, token, target);
+    expect((await cleared.json()) as Record<string, unknown>).toMatchObject({ enabled: false, limit: null });
+
+    // 现在又能投
+    fetchMock.get("https://clear-wake.test").intercept({ path: "/hook", method: "POST" }).reply(200, "ok");
+    expect((await sendMention(slug, token, target)).status).toBe(200);
+    await new Promise((r) => setTimeout(r, 60));
+    expect((await ledgerRows(slug, target)).filter((r) => r.result === "ok" && r.attempt === 1)).toHaveLength(2);
+  });
+
+  it("limit 必须为正整数，否则 400", async () => {
+    const { token } = await seedToken("agent");
+    const target = uniq("badlimit-agent");
+    await seedToken("agent", target);
+    const slug = await createChannel(token);
+    expect((await setBudget(slug, token, target, { enabled: true, limit: 0 })).status).toBe(400);
+    expect((await setBudget(slug, token, target, { enabled: true, limit: -3 })).status).toBe(400);
+  });
+});


### PR DESCRIPTION
## 做什么（#108，owner 2026-07-11 拍板「加 per-agent wake 预算/配额 + 硬上限」）

每 @ 一次跑一次完整 run、烧对方订阅，无总量上限。加 **per-agent（按频道）wake 预算硬上限**：agent 可设滚动窗口内最大唤醒数，超额的 @ **在 webhook 发出前被扣住**（真熔断，非仅计量）。

## 实现
- **预算模型**：`wake_budget_limit:<name>` / `wake_budget_window:<name>` 存 DO meta；默认窗口 1h；window∈[1s,30d]、limit≤10万；**未设=无限（零影响，同 loop-guard 未配即放行）**。
- **熔断点**：`dispatchWebhooks` 发每个 webhook **前**用 `isOverWakeBudget` 分流 firing/withheld——这就是 issue 说的「webhook not fired」点。计数复用 `wake_delivery_ledger`：窗口内 `attempt=1 且 result!='budget'` 的 COUNT（重试/扣住行不自耗）。
- **可见性/归属**：扣住的 wake 写 `result='budget'` ledger 行，带 **mention_seq(哪个@)+target_name(@谁)**+预算参数，经 wake-deliveries API 可查；每窗口一条去重的 in-channel system 提示（waiting 态节流，非 blocked 熔断）。
- **设/查**：`GET/PUT /api/channels/:slug/wake-budget/:name`（读=任意成员；写=agent 本人 或 moderator）；CLI `party wake-budget <name> [--limit N --window D | --off]`。

## 门禁（对 origin HEAD rebase 后亲验）
- worker wake-budget 7/7；回归 49/49；cli 609/609；worker/cli/shared tsc 0；rebase 无冲突。
- 变异：`isOverWakeBudget` 恒 false（去掉上限）→ 3 条熔断测试红（超额 wake 发出、budget ledger 行缺失）。复绿。

## 评审注意
- 熔断收在 **webhook wake 路径**（服务端发起、真烧 token 的那条）；serve/watch 是 agent 自己的 pull 循环、看得到 in-channel 提示但硬熔断在 webhook——刻意收窄 scope，避开并行的 #191/#228 do.ts 改动。配置在 DO meta（非 D1）。

🤖 opus agent 实现 + 我亲验。
