### PR TITLE
feat(cli,worker,web): serve 长任务每-任务进度/心跳可见性（扩 #103 busy）（#228）

### DIFF
--- a/cli/src/commands/health.ts
+++ b/cli/src/commands/health.ts
@@ -35,6 +35,9 @@ export interface HealthReport {
   last_frame_at?: number | null;
   last_error?: string | null;
   connected_since?: number | null;
+  current_task?: number | null;
+  task_started_at?: number | null;
+  heartbeat_at?: number | null;
   updated_at?: number;
 }
 
@@ -87,6 +90,7 @@ export async function run(argv: string[]): Promise<number> {
     return 1;
   }
 
+  const now = Date.now();
   const ageS = report.age_ms === null || report.age_ms === undefined ? null : Math.round(report.age_ms / 1000);
   console.log(`pid:             ${report.pid}`);
   console.log(`channel:         ${report.channel}`);
@@ -95,6 +99,21 @@ export async function run(argv: string[]): Promise<number> {
   console.log(`reconnect_count: ${report.reconnect_count}`);
   console.log(`last_frame_at:   ${report.last_frame_at === null ? "(never)" : `${new Date(report.last_frame_at!).toISOString()} (${ageS}s ago)`}`);
   console.log(`last_error:      ${report.last_error ?? "(none)"}`);
+  // 每任务进度/心跳（#228）：本机操作者一眼看到「正在跑 seq=X 的任务、心跳 Ns 前」，
+  // 不必去 launchd/tmux 后台文件里翻 ▶ 和 runner log。空闲则不打印这行。
+  if (report.current_task !== null && report.current_task !== undefined) {
+    const hbAgeS =
+      report.heartbeat_at === null || report.heartbeat_at === undefined
+        ? null
+        : Math.round((now - report.heartbeat_at) / 1000);
+    const runS =
+      report.task_started_at === null || report.task_started_at === undefined
+        ? null
+        : Math.round((now - report.task_started_at) / 1000);
+    const hb = hbAgeS === null ? "(no heartbeat)" : `heartbeat ${hbAgeS}s ago`;
+    const ran = runS === null ? "" : `, running ${runS}s`;
+    console.log(`current_task:    seq=${report.current_task} (${hb}${ran})`);
+  }
 
   if (channel !== undefined && report.channel !== channel) {
     console.log(`→ health stale for #${channel}: record belongs to #${report.channel}`);

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -84,6 +84,9 @@ const AP_BODY_MAX = 4_000;
 
 const DEFAULT_MAX_WAKE_ATTEMPTS = 3;
 const DEFAULT_WAKE_RETRY_DELAY_MS = 500;
+// 每任务心跳节奏（#228）：任务运行期间每隔这么久刷一次「还活着、正在处理 seq=X」。
+// 15s 足够让频道/本机在几分钟的长任务里持续看到新鲜度，又远比逐 tick 便宜（presence-only，不落 history）。
+const DEFAULT_TASK_HEARTBEAT_MS = 15_000;
 // 普通频道 loop guard 是 30；必须远低于它，避免放弃通告先把频道熔断、随后静默丢消息。
 const MAX_CONSECUTIVE_WAKE_ABANDONS = 3;
 const BLOCKED_ERROR_MAX = 300;
@@ -392,6 +395,10 @@ export interface ServeOptions {
   upgradeDeps?: UpgradeDeps; // 测试注入版本读取/re-exec
   out?: (line: string) => void;
   statusline?: boolean;
+  /** 每任务心跳间隔（#228）。默认 DEFAULT_TASK_HEARTBEAT_MS；测试注入更短值。 */
+  heartbeatIntervalMs?: number;
+  /** 时钟注入（#228）：任务开始时刻与每次心跳时刻走它，便于测试断言心跳在推进。默认 Date.now。 */
+  now?: () => number;
 }
 
 // serve 一挂上就把 presence 标成可唤醒：residency=supervised + wake.kind=serve。
@@ -1637,33 +1644,67 @@ export async function runServe(o: ServeOptions): Promise<number> {
         // 本帧正在处理，故只数它 seq 之后、够格触发唤醒的缓冲帧。
         const queueDepth = pendingWakeDepth(conn.pendingFrames(), self, o.mentionsOnly === true, frame.seq);
         if (reportsBusy) busyReported = true;
-        for (let attempt = priorAttempts + 1; attempt <= maxAttempts && retriable; attempt++) {
+        // 每任务进度/心跳（#228，扩 #103 busy）：run() 会把这条串行循环阻塞数分钟——期间频道与本机都看不到
+        // 「具体这条任务在跑、活着」。用一个 setInterval 侧信道在 run() 执行期间周期性刷新（阻塞的循环靠定时器
+        // 心跳），每拍做两件事：① 本机 health.json 盖上 current_task/heartbeat_at（供 party health/watchdog）；
+        // ② 一条 presence-only 的 heartbeat 帧发给 DO（供 who/web），**不落 history、不刷屏**。任务结束（成功或
+        // 放弃）在 finally 里清定时器 + 发一条 current_task=null 的清除帧——绝不留「假在跑」的僵状态。
+        const nowFn = o.now ?? (() => Date.now());
+        const taskStartedAt = nowFn();
+        const heartbeatIntervalMs = o.heartbeatIntervalMs ?? DEFAULT_TASK_HEARTBEAT_MS;
+        const emitTaskBeat = (active: boolean, at: number) => {
+          const fields = active
+            ? { current_task: frame.seq, task_started_at: taskStartedAt, heartbeat_at: at }
+            : { current_task: null, task_started_at: null, heartbeat_at: null };
           try {
-            const cliUpgrade = upgradeNotice(o.autoUpgrade === true, o.upgradeDeps);
-            await run(frame, {
-              cmd: o.cmd,
-              channel: o.channel,
-              self,
-              contextDir,
-              recent: recent.slice(),
-              charter,
-              projectAgent: o.projectAgent ?? null,
-              cliUpgrade,
-              queueDepth,
-            });
-            delivered = true;
-            break;
-          } catch (e) {
-            lastError = e instanceof Error ? e.message : String(e);
-            // 抛错不等于「模型没跑过」。只有 runner 明确声明可重试（spawn 都没成功）才重试；
-            // 否则重跑会重复模型与外部副作用（git push / 开 PR）。见门禁 P1③。
-            retriable = e instanceof WakeBlockedError ? e.retriable : false;
-            if (!retriable) lastError += " (not retriable: model may have run)";
-            out(`  命令失败 (${attempt}/${maxAttempts}): ${lastError}`);
-            // 先落盘再重试：此刻进程崩掉，重启后不会把已经烧掉的次数忘干净
-            setStuck({ seq: frame.seq, attempts: attempt, last_error: lastError });
-            if (retriable && attempt < maxAttempts && retryDelayMs > 0) await delay(retryDelayMs);
+            writeHealthCache({ channel: o.channel, ...fields });
+          } catch {
+            /* 本机 health 落盘失败不影响唤醒 */
           }
+          try {
+            conn.send({ type: "heartbeat", ...fields });
+          } catch {
+            /* WS 未就绪就漏一拍：本机 health 仍新鲜，且下一拍/清除会补 */
+          }
+        };
+        // t=0 立刻发一拍「started」：不必等第一个间隔，频道/本机马上就能看到「已开始处理 seq=X」。
+        emitTaskBeat(true, taskStartedAt);
+        const taskBeat: ReturnType<typeof setInterval> = setInterval(() => emitTaskBeat(true, nowFn()), heartbeatIntervalMs);
+        if (typeof taskBeat.unref === "function") taskBeat.unref();
+        try {
+          for (let attempt = priorAttempts + 1; attempt <= maxAttempts && retriable; attempt++) {
+            try {
+              const cliUpgrade = upgradeNotice(o.autoUpgrade === true, o.upgradeDeps);
+              await run(frame, {
+                cmd: o.cmd,
+                channel: o.channel,
+                self,
+                contextDir,
+                recent: recent.slice(),
+                charter,
+                projectAgent: o.projectAgent ?? null,
+                cliUpgrade,
+                queueDepth,
+              });
+              delivered = true;
+              break;
+            } catch (e) {
+              lastError = e instanceof Error ? e.message : String(e);
+              // 抛错不等于「模型没跑过」。只有 runner 明确声明可重试（spawn 都没成功）才重试；
+              // 否则重跑会重复模型与外部副作用（git push / 开 PR）。见门禁 P1③。
+              retriable = e instanceof WakeBlockedError ? e.retriable : false;
+              if (!retriable) lastError += " (not retriable: model may have run)";
+              out(`  命令失败 (${attempt}/${maxAttempts}): ${lastError}`);
+              // 先落盘再重试：此刻进程崩掉，重启后不会把已经烧掉的次数忘干净
+              setStuck({ seq: frame.seq, attempts: attempt, last_error: lastError });
+              if (retriable && attempt < maxAttempts && retryDelayMs > 0) await delay(retryDelayMs);
+            }
+          }
+        } finally {
+          // 任务收尾：无论送达、放弃还是抛异常穿透，都停心跳并清除本机+频道的「正在处理」状态。
+          // 若身后还有排队的 wake，下一条自己的 started 拍会把 current_task 覆盖成新 seq。
+          clearInterval(taskBeat);
+          emitTaskBeat(false, nowFn());
         }
         if (delivered) {
           // 一条真正送达的 wake 证明 runner 恢复了；此前连续失败不再代表当前健康状态。

--- a/cli/src/commands/who.ts
+++ b/cli/src/commands/who.ts
@@ -30,7 +30,7 @@ session name), so mention the "@handle" shown here — not a UUID session name.
 Options:
   --channel C   read channel C instead of the bound channel
   --json        emit one JSON object per line
-                (name/kind/tier/wake/wake_unverified/busy/queue_depth/account/handle/display_name/age_ms/read_seq)`;
+                (name/kind/tier/wake/wake_unverified/busy/queue_depth/current_task/task_started_at/heartbeat_at/account/handle/display_name/age_ms/read_seq)`;
 
 const STALE_MS = 60_000; // 与 DO presence 扫描一致
 const DEAD_MS = 14 * 24 * 60 * 60 * 1000; // 14 天没露面视为幽灵，不再列
@@ -64,6 +64,11 @@ interface Row {
   // busy（#103）：serve 正串行处理一条 wake，回复会慢。让人别把「@ 了没立刻回」误判成失联、反复 @。
   busy?: true;
   queue_depth?: number; // 忙时排在身后、尚未处理的 wake 数；>0 才带出
+  // 每任务进度/心跳（#228）：正在处理哪条 wake（触发 seq）、何时开始、最近心跳。让频道区分
+  // 「还在干、活到 T」与「卡死」——比裸 busy 更细。仅在有活跃任务时带出。
+  current_task?: number;
+  task_started_at?: number;
+  heartbeat_at?: number;
 }
 
 // kind 已知取 kind；旧 presence 行没回填时 UUID 名判 human（网页登录会话），其余判 agent。
@@ -106,6 +111,14 @@ export function classify(e: PresenceEntry, now: number): Row | null {
     // busy/queue_depth（#103）：仅在服务端标了 busy（目标可达且自报忙）时带出；离线态服务端本就不下发 busy。
     ...(e.busy === true ? { busy: true as const } : {}),
     ...(e.busy === true && typeof e.queue_depth === "number" && e.queue_depth > 0 ? { queue_depth: e.queue_depth } : {}),
+    // 每任务进度/心跳（#228）：服务端只在 state != offline 且有活跃任务时下发 current_task，原样带出。
+    ...(typeof e.current_task === "number"
+      ? {
+          current_task: e.current_task,
+          ...(typeof e.task_started_at === "number" ? { task_started_at: e.task_started_at } : {}),
+          ...(typeof e.heartbeat_at === "number" ? { heartbeat_at: e.heartbeat_at } : {}),
+        }
+      : {}),
     age_ms: age,
     ...(typeof e.connection_count === "number" && e.connection_count > 1
       ? { connection_count: e.connection_count }
@@ -154,6 +167,15 @@ export function busyNote(r: Row): string {
   if (r.busy !== true) return "";
   const queued = r.queue_depth !== undefined && r.queue_depth > 0 ? ` · ${r.queue_depth} queued` : "";
   return ` · ⏳ busy${queued}`;
+}
+
+// 每任务进度/心跳标注（#228）：比 busy 更细——「▶ seq X」是正在处理哪条 wake，「♥ Ns」是心跳新鲜度。
+// 心跳还在推进 = 活着；心跳很旧 = 大概率卡死（配合 live 一起看）。仅在有活跃任务时渲染。
+export function taskNote(r: Row, now: number): string {
+  if (typeof r.current_task !== "number") return "";
+  const beat =
+    typeof r.heartbeat_at === "number" ? ` · ♥ ${humanAge(Math.max(0, now - r.heartbeat_at))}` : " · ♥ (none)";
+  return ` · ▶ seq ${r.current_task}${beat}`;
 }
 
 function humanAge(ms: number): string {
@@ -242,7 +264,7 @@ export async function run(argv: string[]): Promise<number> {
       }
       const wake = r.tier === "wakeable" && r.wake ? ` ${r.wake}${r.wake_unverified === true ? " (unverified)" : ""}` : "";
       const age = r.tier === "online" ? "" : ` (${humanAge(r.age_ms)})`;
-      console.log(`${DOT[r.tier]} ${r.tier.padEnd(8)} ${r.name}  [${r.kind}]${identityNote(r)}${busyNote(r)}${wake}${read}${duplicate}${age}`);
+      console.log(`${DOT[r.tier]} ${r.tier.padEnd(8)} ${r.name}  [${r.kind}]${identityNote(r)}${busyNote(r)}${taskNote(r, now)}${wake}${read}${duplicate}${age}`);
     }
     return 0;
   } catch (e) {

--- a/cli/src/health-cache.ts
+++ b/cli/src/health-cache.ts
@@ -23,6 +23,15 @@ export interface HealthCache {
   last_error: string | null;
   /** 当前这次连上是从什么时候开始的；重连后刷新，断开时清空。 */
   connected_since: number | null;
+  /**
+   * 每任务进度/心跳（#228）：serve 正在处理哪条 wake（触发 seq）。空闲时 null。
+   * 本机操作者用它（配合 party health）看到「正在跑 seq=X 的任务」，不必去后台文件里翻 runner log。
+   */
+  current_task: number | null;
+  /** 当前任务的 run() 开始时刻（epoch ms）（#228）。与 current_task 同生共死。 */
+  task_started_at: number | null;
+  /** 最近一次任务心跳时刻（epoch ms）（#228）。周期性推进；与 last_frame_at（连接新鲜度）正交——它是「任务还在跑」。 */
+  heartbeat_at: number | null;
   updated_at: number;
 }
 
@@ -59,6 +68,9 @@ export function writeHealthCache(patch: HealthPatch, cwd: string = process.cwd()
     reconnect_count: pick(patch, "reconnect_count", prev?.reconnect_count ?? 0),
     last_error: pick(patch, "last_error", prev?.last_error ?? null),
     connected_since: pick(patch, "connected_since", prev?.connected_since ?? null),
+    current_task: pick(patch, "current_task", prev?.current_task ?? null),
+    task_started_at: pick(patch, "task_started_at", prev?.task_started_at ?? null),
+    heartbeat_at: pick(patch, "heartbeat_at", prev?.heartbeat_at ?? null),
     updated_at: now,
   };
 

--- a/cli/test/health-cache.test.ts
+++ b/cli/test/health-cache.test.ts
@@ -36,6 +36,9 @@ describe("health cache contract", () => {
       reconnect_count: 0,
       last_error: null,
       connected_since: null,
+      current_task: null,
+      task_started_at: null,
+      heartbeat_at: null,
       updated_at: 1234,
     });
     expect(statSync(healthCachePath(cwd)).mode & 0o777).toBe(0o600);

--- a/cli/test/serve.test.ts
+++ b/cli/test/serve.test.ts
@@ -154,6 +154,80 @@ describe("runServe", () => {
     expect(posts.indexOf(working!)).toBeLessThan(posts.indexOf(idle!));
   });
 
+  // 每任务进度/心跳（#228，扩 #103 busy）：run() 阻塞串行循环数分钟时，靠 setInterval 侧信道
+  // 周期性发 presence-only 的 heartbeat 帧（不落 history），频道/本机都能看到「正在处理 seq=X、活到 T」。
+  test("task heartbeat: while a wake runs, serve emits advancing heartbeats with current_task, then clears on completion", async () => {
+    const beats: Array<{ current_task: number | null; task_started_at: number | null; heartbeat_at: number | null }> = [];
+    server = startMockServer((frame, sock) => {
+      if (frame.type === "heartbeat") {
+        beats.push(frame as unknown as (typeof beats)[number]);
+        return;
+      }
+      if (frame.type !== "hello") return;
+      sock.send(welcomeFrame(0, "me"));
+      setTimeout(() => sock.send(msgFrame(1, "long task", { mentions: ["me"] })), 10);
+      setTimeout(() => sock.send({ type: "error", code: "archived", message: "done" }), 250);
+    });
+    let tick = 0;
+    const o = opts({
+      server: server.url,
+      heartbeatIntervalMs: 8,
+      now: () => (tick += 1000),
+      // 自定义（注入）runner：阻塞 ~70ms 模拟长任务；#228 的重点就是让自定义 runner 也被看见。
+      runCommand: async () => {
+        await new Promise((r) => setTimeout(r, 70));
+      },
+    });
+
+    expect(await runServe(o)).toBe(EXIT_ARCHIVED);
+
+    const active = beats.filter((b) => b.current_task === 1);
+    // 立刻一拍 started + 至少一拍间隔心跳
+    expect(active.length, "must emit a started beat plus periodic heartbeats while the task runs").toBeGreaterThanOrEqual(2);
+    // heartbeat_at 严格递增 —— 证明心跳真的在推进（不是发同一个时间戳）
+    for (let i = 1; i < active.length; i++) {
+      expect(active[i]!.heartbeat_at!).toBeGreaterThan(active[i - 1]!.heartbeat_at!);
+      expect(active[i]!.task_started_at).toBe(active[0]!.task_started_at);
+    }
+    // 收尾清除：一条 current_task=null，且在所有活跃心跳之后
+    const clears = beats.filter((b) => b.current_task === null);
+    expect(clears.length, "must clear the running task once it finishes").toBeGreaterThanOrEqual(1);
+    expect(beats.lastIndexOf(active[active.length - 1]!)).toBeLessThan(beats.indexOf(clears[0]!));
+  });
+
+  // 本机操作者可见性（#228）：health.json 盖上正在处理的 seq，任务结束清回 null。
+  test("task heartbeat: stamps current_task into the local health file and clears it on completion", async () => {
+    const { readHealthCache } = await import("../src/health-cache");
+    const prevHome = process.env.AGENTPARTY_HOME;
+    process.env.AGENTPARTY_HOME = tempDir("ap-hb-home-");
+    try {
+      let seenDuringRun: number | null = null;
+      server = startMockServer((frame, sock) => {
+        if (frame.type === "hello") {
+          sock.send(welcomeFrame(0, "me"));
+          setTimeout(() => sock.send(msgFrame(1, "long task", { mentions: ["me"] })), 10);
+          setTimeout(() => sock.send({ type: "error", code: "archived", message: "done" }), 200);
+        }
+      });
+      const o = opts({
+        server: server.url,
+        heartbeatIntervalMs: 8,
+        runCommand: async () => {
+          await new Promise((r) => setTimeout(r, 60));
+          // 任务执行到一半时，health.json 应该已经写上 current_task=1
+          seenDuringRun = readHealthCache()?.current_task ?? null;
+        },
+      });
+
+      expect(await runServe(o)).toBe(EXIT_ARCHIVED);
+      expect(seenDuringRun as number | null, "health.json must show the running task while it executes").toBe(1);
+      expect(readHealthCache()?.current_task, "health.json must clear the task once it finishes").toBeNull();
+    } finally {
+      if (prevHome === undefined) delete process.env.AGENTPARTY_HOME;
+      else process.env.AGENTPARTY_HOME = prevHome;
+    }
+  });
+
   test("reports a non-zero runner exit instead of silently swallowing it", async () => {
     const s = closeAfterOneMention();
     // 每次失败都打印，并带上「第几次/共几次」——有界重试的进度必须可见（#198）

--- a/cli/test/who.test.ts
+++ b/cli/test/who.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { PresenceEntry } from "@agentparty/shared";
-import { busyNote, classify, identityNote, terminalIdentityText } from "../src/commands/who";
+import { busyNote, classify, identityNote, taskNote, terminalIdentityText } from "../src/commands/who";
 
 const NOW = 1_000_000_000;
 
@@ -239,5 +239,25 @@ describe("who busy + queue depth (#103)", () => {
       " · ⏳ busy · 4 queued",
     );
     expect(busyNote({ name: "a", kind: "agent", tier: "online", age_ms: 0 })).toBe("");
+  });
+
+  test("taskNote 渲染：正在处理的 seq + 心跳新鲜度（#228）", () => {
+    const now = 100_000;
+    // 有 current_task + 心跳：显示 ▶ seq 与心跳年龄
+    expect(taskNote({ name: "a", kind: "agent", tier: "online", age_ms: 0, current_task: 510, heartbeat_at: now - 8_000 }, now)).toBe(
+      " · ▶ seq 510 · ♥ 8s",
+    );
+    // 无心跳时间戳：如实标 (none)，不伪造新鲜
+    expect(taskNote({ name: "a", kind: "agent", tier: "online", age_ms: 0, current_task: 7 }, now)).toBe(" · ▶ seq 7 · ♥ (none)");
+    // 无活跃任务：空
+    expect(taskNote({ name: "a", kind: "agent", tier: "online", age_ms: 0 }, now)).toBe("");
+  });
+
+  test("classify 带出 current_task/task_started_at/heartbeat_at；离线不带（#228）", () => {
+    const online = classify(p({ name: "bot", current_task: 42, task_started_at: 1000, heartbeat_at: 2000 }), NOW);
+    expect(online).toMatchObject({ current_task: 42, task_started_at: 1000, heartbeat_at: 2000 });
+    // 离线 presence 服务端本就不下发这些字段；即便脏数据混进来，classify 也不该把它当成「正在处理」。
+    const offline = classify(p({ name: "bot", state: "offline", wake: { kind: "serve" } }), NOW);
+    expect(offline?.current_task).toBeUndefined();
   });
 });

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -365,6 +365,20 @@ export interface PresenceEntry {
   busy?: boolean;
   /** 排在当前 wake 身后、尚未处理的 wake 数（issue #103）。仅 state != offline 且 >0 时下发。 */
   queue_depth?: number;
+  /**
+   * 当前正在处理的那条 wake 的触发 seq（reply_to / @ 的 seq）（issue #228，扩 #103 busy）。
+   * serve 处理一条长任务期间用轻量、presence-only 的 heartbeat 帧刷这三个字段：正在处理哪条、何时开始、
+   * 最近一次心跳。用途：who/web 区分「还在干、活到 T」与「卡死」——busy 只说「在忙」，这里说「在忙哪一条、活没活」。
+   * 仅 state != offline 且有活跃任务时下发；任务结束由 heartbeat(current_task=null) 清除。旧客户端忽略。
+   */
+  current_task?: number;
+  /** 当前任务的 run() 开始时刻（epoch ms）（issue #228）。与 current_task 同生共死。 */
+  task_started_at?: number;
+  /**
+   * 最近一次心跳时刻（epoch ms）（issue #228）。serve 周期性推进它；消费方据 now-heartbeat_at 判新鲜度：
+   * 心跳还在推进 = 活着，长时间不动 = 卡死。不参与可达性/租约判定。
+   */
+  heartbeat_at?: number;
 }
 
 export interface ChannelRoleAssignment {
@@ -545,7 +559,23 @@ export interface SeenFrame {
   seq: number;
 }
 
-export type ClientFrame = HelloFrame | SendFrame | PingFrame | SeenFrame;
+/**
+ * 每任务进度/心跳（issue #228，扩 #103 busy）。serve 处理一条长 wake 期间，周期性发这条**轻量、
+ * presence-only** 的帧：只更新发送者 presence 上的 current_task/task_started_at/heartbeat_at，
+ * **不落 history**（不刷屏，是 ledger 而非聊天）。任务结束发一条 current_task=null 的清除帧。
+ * 三个字段要么全是非负整数（正在处理），要么全是 null（清除）。脏值被服务端静默丢弃、不断流。
+ */
+export interface HeartbeatFrame {
+  type: "heartbeat";
+  /** 正在处理的 wake 的触发 seq；null = 任务结束、清除。 */
+  current_task: number | null;
+  /** 当前任务 run() 的开始时刻（epoch ms）；随 current_task 一起清空。 */
+  task_started_at: number | null;
+  /** 本次心跳时刻（epoch ms），周期性推进；随 current_task 一起清空。 */
+  heartbeat_at: number | null;
+}
+
+export type ClientFrame = HelloFrame | SendFrame | PingFrame | SeenFrame | HeartbeatFrame;
 
 // ---- 服务端 → 客户端帧 ----
 

--- a/web/src/components/PresenceBar.test.ts
+++ b/web/src/components/PresenceBar.test.ts
@@ -3,7 +3,7 @@ import type { PresenceEntry, Sender } from "@agentparty/shared";
 import { createElement } from "react";
 import { act, create, type ReactTestRenderer } from "react-test-renderer";
 import { LocaleProvider } from "../i18n/locale";
-import { buildGroups, busyLabel, countLiveGroups, ownerKey, pauseResumeAt, PresenceBar, type Item } from "./PresenceBar";
+import { buildGroups, busyLabel, countLiveGroups, ownerKey, pauseResumeAt, PresenceBar, taskLabel, type Item } from "./PresenceBar";
 
 function item(over: Partial<Item> = {}): Item {
   return {
@@ -213,6 +213,18 @@ describe("busy indicator + queue depth (#103)", () => {
     expect(busyLabel(it({ busy: true, queueDepth: null }))).toBe("⏳ busy");
     expect(busyLabel(it({ busy: true, queueDepth: 4 }))).toBe("⏳ busy · 4 queued");
     expect(busyLabel(it({ busy: false }))).toBeNull();
+  });
+
+  // 每任务进度/心跳（#228）：比 busy 更细——标明正在处理哪条 wake + 心跳新鲜度。
+  test("taskLabel: 有任务+心跳 / 有任务无心跳 / 无任务三态", () => {
+    const now = 100_000;
+    const it = (over: Partial<Item>) =>
+      ({ name: "a", busy: false, queueDepth: null, currentTask: null, heartbeatAt: null, ...over }) as Item;
+    // 新鲜心跳（<45s）显示 "now" = 还活着；很旧则显示 "2m"/"1h" = 大概率卡死。
+    expect(taskLabel(it({ currentTask: 510, heartbeatAt: now - 5_000 }), now)).toBe("▶ #510 · ♥ now");
+    expect(taskLabel(it({ currentTask: 510, heartbeatAt: now - 120_000 }), now)).toBe("▶ #510 · ♥ 2m");
+    expect(taskLabel(it({ currentTask: 7 }), now)).toBe("▶ #7");
+    expect(taskLabel(it({ currentTask: null }), now)).toBeNull();
   });
 
   test("busy 项渲染琥珀徽章 + 顶部「N busy」汇总", () => {

--- a/web/src/components/PresenceBar.tsx
+++ b/web/src/components/PresenceBar.tsx
@@ -76,6 +76,10 @@ export interface Item {
   // busy（#103）：serve 正串行处理一条 wake，可达但回复会慢。working = 在干活，busy = 正忙无法即时响应新 @。
   busy: boolean;
   queueDepth: number | null; // 忙时身后排队、尚未处理的 wake 数；>0 才有值
+  // 每任务进度/心跳（#228）：正在处理哪条 wake（触发 seq）、最近心跳时刻。比 busy 更细——能区分
+  // 「还在干、活到 T」与「卡死」。null = 无活跃任务。
+  currentTask: number | null;
+  heartbeatAt: number | null; // 最近心跳（epoch ms）；据 now-heartbeatAt 算新鲜度
 }
 
 export interface PresenceGroup {
@@ -124,6 +128,14 @@ function residencyBadge(item: Item): string | null {
 export function busyLabel(item: Item): string | null {
   if (!item.busy) return null;
   return item.queueDepth !== null ? `⏳ busy · ${item.queueDepth} queued` : "⏳ busy";
+}
+
+// 每任务进度/心跳 chip（#228）：「▶ #510」或「▶ #510 · ♥ 8s」。比 busy 更细——不仅「在忙」，还标明
+// 正在处理哪条 wake（触发 seq）和心跳新鲜度。心跳还在推进 = 活着；很旧 = 大概率卡死。null = 无活跃任务。
+export function taskLabel(item: Item, now: number): string | null {
+  if (item.currentTask === null) return null;
+  const beat = item.heartbeatAt !== null ? ` · ♥ ${fmtRel(item.heartbeatAt, now)}` : "";
+  return `▶ #${item.currentTask}${beat}`;
 }
 
 function wakeabilityBadge(item: Item): { text: string; tone: "off" | "pending" | "on" } | null {
@@ -283,6 +295,9 @@ export function PresenceBar({
       // busy/queueDepth（#103）：服务端只在 state != offline 且真忙时下发 busy，故离线项天然为 false。
       busy: entry?.busy === true,
       queueDepth: entry?.busy === true && typeof entry.queue_depth === "number" && entry.queue_depth > 0 ? entry.queue_depth : null,
+      // 每任务进度/心跳（#228）：服务端只在 state != offline 且有活跃任务时下发 current_task，故离线项天然为 null。
+      currentTask: typeof entry?.current_task === "number" ? entry.current_task : null,
+      heartbeatAt: typeof entry?.current_task === "number" && typeof entry?.heartbeat_at === "number" ? entry.heartbeat_at : null,
     };
     if (!connected) {
       // owner 本就仅连接中的参与者可知（见上方字段注释）；handle 依赖同一份可信度，一并置空，
@@ -344,11 +359,19 @@ export function PresenceBar({
     const residency = residencyBadge(it);
     const wakeability = wakeabilityBadge(it);
     const busy = busyLabel(it);
+    const task = taskLabel(it, now);
+    const taskTitle =
+      it.currentTask === null
+        ? null
+        : it.heartbeatAt !== null
+          ? t("PresenceBar.taskTitleBeat", { seq: it.currentTask, age: fmtRel(it.heartbeatAt, now) })
+          : t("PresenceBar.taskTitle", { seq: it.currentTask });
     const activeHost = hasActiveHostLease(it, now);
     const full = mode === "full";
     const titleParts = [
       it.owner !== null && it.owner !== it.name ? `${it.name} · ${it.owner}` : it.name,
       it.busy ? `busy${it.queueDepth !== null ? ` · ${it.queueDepth} queued` : ""} (reachable, reply may be slow — do not re-@)` : null,
+      taskTitle,
       it.handle !== null && it.handle !== "" ? `handle: ${it.handle}` : null,
       it.role !== null ? `role: ${it.role}` : null,
       it.responsibility !== null && it.responsibility !== "" ? `responsibility: ${it.responsibility}` : null,
@@ -416,6 +439,11 @@ export function PresenceBar({
           </span>
         )}
         {busy !== null && <span className="t-mono presence-busy">{busy}</span>}
+        {task !== null && (
+          <span className="t-mono presence-busy presence-task" title={taskTitle ?? undefined}>
+            {task}
+          </span>
+        )}
         {full && it.lineage !== null && (
           <span className="t-mono presence-lineage">child:{it.lineage.parent_agent}</span>
         )}
@@ -581,6 +609,9 @@ export function PresenceBar({
                 {agent.connectionCount > 1 && <span className="t-mono presence-agent-duplicate">x{agent.connectionCount}</span>}
                 {roleBadge(agent, now) !== null && <span className="t-mono presence-agent-role">{roleBadge(agent, now)}</span>}
                 {busyLabel(agent) !== null && <span className="t-mono presence-busy presence-busy--chip">{busyLabel(agent)}</span>}
+                {taskLabel(agent, now) !== null && (
+                  <span className="t-mono presence-busy presence-busy--chip presence-task">{taskLabel(agent, now)}</span>
+                )}
               </span>
             ))}
             {hiddenAgents > 0 && <span className="t-mono presence-agent-more">+{hiddenAgents}</span>}

--- a/web/src/i18n/strings/PresenceBar.ts
+++ b/web/src/i18n/strings/PresenceBar.ts
@@ -19,6 +19,11 @@ export const PresenceBarStrings: LocaleDict = {
     "PresenceBar.pausedChipUntil": "⏸ paused · resumes {time}",
     "PresenceBar.pausedManual": "Paused — won't be woken by @-mentions until resumed manually",
     "PresenceBar.pausedUntil": "Paused — won't be woken by @-mentions; auto-resumes {time}",
+    // 每任务进度/心跳（#228）
+    "PresenceBar.taskChip": "▶ #{seq}",
+    "PresenceBar.taskChipBeat": "▶ #{seq} · ♥ {age}",
+    "PresenceBar.taskTitle": "running the wake from #{seq}",
+    "PresenceBar.taskTitleBeat": "running the wake from #{seq} — last heartbeat {age} (still alive; a stale heartbeat means stuck)",
   },
   zh: {
     "PresenceBar.kickTitle": "踢出 {name}",
@@ -38,6 +43,11 @@ export const PresenceBarStrings: LocaleDict = {
     "PresenceBar.pausedChipUntil": "⏸ 已暂停 · {time} 恢复",
     "PresenceBar.pausedManual": "已暂停接待——被 @ 也不唤醒，需手动恢复",
     "PresenceBar.pausedUntil": "已暂停接待——被 @ 也不唤醒；将于 {time} 自动恢复",
+    // 每任务进度/心跳（#228）
+    "PresenceBar.taskChip": "▶ #{seq}",
+    "PresenceBar.taskChipBeat": "▶ #{seq} · ♥ {age}",
+    "PresenceBar.taskTitle": "正在处理 #{seq} 的唤醒",
+    "PresenceBar.taskTitleBeat": "正在处理 #{seq} 的唤醒——最近心跳 {age}（还活着；心跳很旧多半卡死了）",
   },
 };
 

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -1523,6 +1523,12 @@
   font-size: 9px;
   padding: 0 4px;
 }
+/* 每任务进度/心跳（#228）：与 busy 的琥珀区分——蓝色表达「正在处理具体这条 wake、心跳新鲜」。 */
+.presence-task {
+  border-color: var(--d-blue);
+  background: var(--d-blue-soft);
+  color: var(--d-blue);
+}
 .presence-wake--off {
   border-color: var(--t-faint);
   color: var(--t-dim);

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -898,6 +898,29 @@ function parseSendFrame(input: unknown): SendFrame | null {
   return null;
 }
 
+export interface ParsedTaskHeartbeat {
+  current_task: number | null;
+  task_started_at: number | null;
+  heartbeat_at: number | null;
+}
+
+// 每任务心跳帧校验（#228）：三字段要么全是非负整数（活跃任务），要么各自 null（清除）。
+// 混入负数/浮点/非数字 → 返回 null（整帧丢弃）。缺字段按 undefined→拒收，避免半截状态写脏 presence。
+function parseHeartbeatFrame(input: unknown): ParsedTaskHeartbeat | null {
+  if (typeof input !== "object" || input === null) return null;
+  const f = input as Record<string, unknown>;
+  const field = (v: unknown): number | null | undefined => {
+    if (v === null) return null;
+    if (typeof v === "number" && Number.isInteger(v) && v >= 0) return Math.min(v, Number.MAX_SAFE_INTEGER);
+    return undefined; // 非法
+  };
+  const current = field(f.current_task);
+  const started = field(f.task_started_at);
+  const heartbeat = field(f.heartbeat_at);
+  if (current === undefined || started === undefined || heartbeat === undefined) return null;
+  return { current_task: current, task_started_at: started, heartbeat_at: heartbeat };
+}
+
 async function hmacSha256Hex(secret: string, body: string): Promise<string> {
   const enc = new TextEncoder();
   const key = await crypto.subtle.importKey(
@@ -1131,6 +1154,11 @@ export class ChannelDO extends Server<Env> {
       // busy + 队列深度（#103）：serve 串行处理长任务时自报「忙 + N 待处理」，供 who/reach/web 展示。
       "ALTER TABLE presence ADD COLUMN busy INTEGER",
       "ALTER TABLE presence ADD COLUMN queue_depth INTEGER",
+      // 每任务进度/心跳（#228，扩 #103）：正在处理哪条 wake（触发 seq）、何时开始、最近心跳。
+      // 由 presence-only 的 heartbeat 帧刷（不落 history）；任务结束/离线时清空。供 who/web 判「活着 vs 卡死」。
+      "ALTER TABLE presence ADD COLUMN current_task INTEGER",
+      "ALTER TABLE presence ADD COLUMN task_started_at INTEGER",
+      "ALTER TABLE presence ADD COLUMN heartbeat_at INTEGER",
     ]) {
       try {
         sql.exec(ddl);
@@ -1406,6 +1434,13 @@ export class ChannelDO extends Server<Env> {
         const cursor = this.recordSeen(st.name, st.kind, seq);
         if (cursor !== null) this.broadcastFrame({ type: "read_cursor", ...cursor });
       }
+      return;
+    }
+    if (frame.type === "heartbeat") {
+      // 每任务进度/心跳（#228）：presence-only，不落 history、不占发送速率、不炸连接。
+      // 脏值（负数/非整数/字段不齐）静默丢弃——心跳是自动流量，宁可漏一拍也别断流。
+      const hb = parseHeartbeatFrame(frame);
+      if (hb !== null) this.applyTaskHeartbeat(st.name, hb);
       return;
     }
     if (frame.type === "send") {
@@ -1759,8 +1794,11 @@ export class ChannelDO extends Server<Env> {
 
   private markOffline(name: string, ts: number) {
     this.ctx.storage.sql.exec(
+      // 离线时清掉每任务心跳（#228）：否则一次硬崩后再上线（发个 status 但不带心跳），旧的 current_task
+      // 会借尸还魂显示成「还在处理」。心跳字段与「活着」正交，离线即无任务，直接清空最干净。
       `INSERT INTO presence (name, state, note, updated_at) VALUES (?, 'offline', NULL, ?)
-       ON CONFLICT(name) DO UPDATE SET state = 'offline', updated_at = excluded.updated_at`,
+       ON CONFLICT(name) DO UPDATE SET state = 'offline', updated_at = excluded.updated_at,
+         current_task = NULL, task_started_at = NULL, heartbeat_at = NULL`,
       name,
       ts,
     );
@@ -1776,6 +1814,23 @@ export class ChannelDO extends Server<Env> {
       name,
       ts,
       clientVersion,
+    );
+    const entry = this.presenceFor(name);
+    if (entry) this.broadcastFrame({ type: "presence", ...entry });
+  }
+
+  // 每任务进度/心跳（#228）：只更新 presence 上的 current_task/task_started_at/heartbeat_at 三列，
+  // 不碰 state/note/busy、不落 history（presence-only，不刷屏）。仅当已有这行 presence 时才更新+广播；
+  // 从没发过 presence（连 status 都没发）就无从附着，直接忽略。current_task=null 即清除（任务结束）。
+  private applyTaskHeartbeat(name: string, hb: ParsedTaskHeartbeat) {
+    const exists = this.ctx.storage.sql.exec("SELECT 1 FROM presence WHERE name = ? LIMIT 1", name).toArray().length > 0;
+    if (!exists) return;
+    this.ctx.storage.sql.exec(
+      `UPDATE presence SET current_task = ?, task_started_at = ?, heartbeat_at = ? WHERE name = ?`,
+      hb.current_task,
+      hb.task_started_at,
+      hb.heartbeat_at,
+      name,
     );
     const entry = this.presenceFor(name);
     if (entry) this.broadcastFrame({ type: "presence", ...entry });
@@ -4106,7 +4161,8 @@ export class ChannelDO extends Server<Env> {
                 account, handle, display_name, avatar_url, avatar_thumb, client_version,
                 state, note, updated_at, status_scope_json, status_summary_seq, status_blocked_reason,
                 status_context_json, status_decision_json, status_workflow_json, role, role_source, residency, wake_kind, wake_verified_at,
-                context_json, lineage_json, paused_at, paused_resume_at, busy, queue_depth`;
+                context_json, lineage_json, paused_at, paused_resume_at, busy, queue_depth,
+                current_task, task_started_at, heartbeat_at`;
 
   private presenceList(): PresenceEntry[] {
     const liveCounts = this.liveConnectionCounts();
@@ -4189,6 +4245,15 @@ export class ChannelDO extends Server<Env> {
       // 缺省即「不忙、无积压」，旧客户端与旧行没这两列时 Number(undefined/null)=0/NaN，天然回退。
       ...(state !== "offline" && Number(r.busy) === 1 ? { busy: true } : {}),
       ...(state !== "offline" && Number(r.queue_depth) > 0 ? { queue_depth: Number(r.queue_depth) } : {}),
+      // 每任务进度/心跳（#228）：仅在有活跃任务（current_task 非空）且 state != offline 时下发这一组。
+      // 三者同生共死：只要 current_task 在，就一并带出 started/heartbeat，供消费方算新鲜度。
+      ...(state !== "offline" && r.current_task !== null && r.current_task !== undefined
+        ? {
+            current_task: Number(r.current_task),
+            ...(r.task_started_at === null || r.task_started_at === undefined ? {} : { task_started_at: Number(r.task_started_at) }),
+            ...(r.heartbeat_at === null || r.heartbeat_at === undefined ? {} : { heartbeat_at: Number(r.heartbeat_at) }),
+          }
+        : {}),
     };
   }
 

--- a/worker/test/presence-task-heartbeat.spec.ts
+++ b/worker/test/presence-task-heartbeat.spec.ts
@@ -1,0 +1,126 @@
+import type { PresenceEntry } from "@agentparty/shared";
+import { describe, expect, it } from "vitest";
+import { WsClient, api, createChannel, seedToken } from "./helpers";
+
+// 每任务进度/心跳（issue #228，扩 #103 busy）：serve 处理一条长 wake 期间，用轻量、presence-only 的
+// heartbeat 帧把「正在处理的触发 seq、开始时间、最近心跳」刷进 presence，让 who/web 能区分
+// 「还在干、活到 T」与「卡死」。心跳不落 history（不刷屏），任务结束由 current_task=null 清除。
+
+async function fetchPresence(slug: string, token: string): Promise<PresenceEntry[]> {
+  const res = await api(`/api/channels/${slug}/presence`, token);
+  expect(res.status).toBe(200);
+  return ((await res.json()) as { presence: PresenceEntry[] }).presence;
+}
+
+// heartbeat 前得先有一行 presence（serve 挂上先发一条 status）。
+async function seedPresence(ws: WsClient): Promise<void> {
+  ws.send({ type: "send", kind: "status", state: "waiting", note: "attached", mentions: [] });
+  await ws.nextOfType("sent");
+  await ws.nextOfType("status");
+}
+
+describe("presence per-task heartbeat (issue #228)", () => {
+  it("stamps current_task / task_started_at / heartbeat_at from a heartbeat frame", async () => {
+    const agent = await seedToken("agent");
+    const slug = await createChannel(agent.token);
+    const ws = await WsClient.open(slug, agent.token);
+    await ws.nextOfType("welcome");
+    ws.send({ type: "hello", since: 0 });
+    await seedPresence(ws);
+
+    ws.send({ type: "heartbeat", current_task: 510, task_started_at: 1000, heartbeat_at: 1000 });
+    // presence-only：广播一条 presence 帧，但不产生新的 msg/status 历史帧
+    await ws.nextOfType("presence");
+
+    const entry = (await fetchPresence(slug, agent.token)).find((e) => e.name === agent.name);
+    expect(entry).toMatchObject({ current_task: 510, task_started_at: 1000, heartbeat_at: 1000 });
+    ws.close();
+  });
+
+  it("advances heartbeat_at on subsequent heartbeats without appending history", async () => {
+    const agent = await seedToken("agent");
+    const slug = await createChannel(agent.token);
+    const ws = await WsClient.open(slug, agent.token);
+    const welcome = await ws.nextOfType("welcome");
+    const headSeq = (welcome as { last_seq: number }).last_seq;
+    ws.send({ type: "hello", since: 0 });
+    await seedPresence(ws);
+
+    ws.send({ type: "heartbeat", current_task: 7, task_started_at: 1000, heartbeat_at: 1000 });
+    await ws.nextOfType("presence");
+    ws.send({ type: "heartbeat", current_task: 7, task_started_at: 1000, heartbeat_at: 5000 });
+    await ws.nextOfType("presence");
+
+    const entry = (await fetchPresence(slug, agent.token)).find((e) => e.name === agent.name);
+    expect(entry).toMatchObject({ current_task: 7, task_started_at: 1000, heartbeat_at: 5000 });
+
+    // 心跳不刷屏：history 里只有 seedPresence 那条 status；心跳没有再加任何一条。
+    const hist = await api(`/api/channels/${slug}/messages?since=${headSeq}`, agent.token);
+    const msgs = ((await hist.json()) as { messages: { seq: number }[] }).messages;
+    expect(msgs.filter((m) => m.seq > headSeq).length).toBe(1);
+    ws.close();
+  });
+
+  it("clears the task fields when a heartbeat carries current_task=null (task done)", async () => {
+    const agent = await seedToken("agent");
+    const slug = await createChannel(agent.token);
+    const ws = await WsClient.open(slug, agent.token);
+    await ws.nextOfType("welcome");
+    ws.send({ type: "hello", since: 0 });
+    await seedPresence(ws);
+
+    ws.send({ type: "heartbeat", current_task: 7, task_started_at: 1000, heartbeat_at: 1000 });
+    await ws.nextOfType("presence");
+    ws.send({ type: "heartbeat", current_task: null, task_started_at: null, heartbeat_at: null });
+    await ws.nextOfType("presence");
+
+    const entry = (await fetchPresence(slug, agent.token)).find((e) => e.name === agent.name);
+    expect(entry).toBeDefined();
+    expect(entry).not.toHaveProperty("current_task");
+    expect(entry).not.toHaveProperty("task_started_at");
+    expect(entry).not.toHaveProperty("heartbeat_at");
+    ws.close();
+  });
+
+  it("broadcasts the running task to other readers", async () => {
+    const agent = await seedToken("agent");
+    const observer = await seedToken("human");
+    const slug = await createChannel(agent.token);
+    const watcher = await WsClient.open(slug, observer.token);
+    await watcher.nextOfType("welcome");
+
+    const ws = await WsClient.open(slug, agent.token);
+    await ws.nextOfType("welcome");
+    ws.send({ type: "hello", since: 0 });
+    await seedPresence(ws);
+    ws.send({ type: "heartbeat", current_task: 42, task_started_at: 2000, heartbeat_at: 2000 });
+
+    for (;;) {
+      const frame = await watcher.nextOfType("presence");
+      if (frame.name === agent.name && (frame as { current_task?: number }).current_task === 42) {
+        expect(frame).toMatchObject({ current_task: 42, task_started_at: 2000, heartbeat_at: 2000 });
+        break;
+      }
+    }
+    ws.close();
+    watcher.close();
+  });
+
+  it("ignores a malformed heartbeat (negative / non-integer) without erroring the socket", async () => {
+    const agent = await seedToken("agent");
+    const slug = await createChannel(agent.token);
+    const ws = await WsClient.open(slug, agent.token);
+    await ws.nextOfType("welcome");
+    ws.send({ type: "hello", since: 0 });
+    await seedPresence(ws);
+
+    // 脏值被丢弃：不落 presence、不炸连接（心跳是自动流量，宁可静默忽略也别断流）。
+    ws.send({ type: "heartbeat", current_task: -1, task_started_at: 1000, heartbeat_at: 1000 });
+    ws.send({ type: "heartbeat", current_task: 9, task_started_at: 1000, heartbeat_at: 1000 });
+    await ws.nextOfType("presence");
+
+    const entry = (await fetchPresence(slug, agent.token)).find((e) => e.name === agent.name);
+    expect(entry).toMatchObject({ current_task: 9 });
+    ws.close();
+  });
+});


### PR DESCRIPTION
## 做什么（#228，owner 2026-07-11 拍板「要更细：每任务进度/心跳」）

serve custom runner 跑数分钟长任务时，频道与本机操作者都不知道有具体任务在跑。在我刚落的 **#103(busy+队列)** 基础上，加**每任务进度/心跳**：频道能看到「某具体 wake(trigger seq) 正在跑 + 上次心跳 T」、本机也看得到。

## 实现
- **3 个正交 presence 字段**（与 #103 的 busy/queue_depth 并列）：`current_task`（运行中 wake 的 trigger seq）、`task_started_at`、`heartbeat_at`。busy 机制不动。
- **阻塞的串行循环如何还能心跳**：`run()` 阻塞 for-await 数分钟——心跳走 `runServe` 里 `setInterval` 侧信道，`try/finally` 包住 run。t=0 立即「started」，之后每 15s（可配）：① 盖进本机 `health.json`（#254）→ `party health` 显示「seq=X（心跳 Ns 前、已跑 Ms）」；② 发一个**presence-only** `heartbeat` WS 帧 → DO 只更新那 3 列并广播 presence delta，**不落 history 行**（是 ledger 不是刷屏）。
- **完成即清**：`finally` 清 interval + 发 `current_task=null`（投递/放弃/异常都清，无卡死「运行中」）。覆盖**所有** runner 类型（含 `--on-mention` 自定义，正是 #228 核心缺口）。`markOffline` 也清列，硬崩重连不残留。
- **频道**：`party who`(+json) 显 `▶ seq X · ♥ Ns`；web PresenceBar 蓝色任务 chip（区别 amber busy）+ i18n hover 带心跳新鲜度。

## 门禁（对 origin HEAD rebase 到含 #108 的 main 后亲验）
- worker presence-task-heartbeat 5/5 + presence-busy 无回归；cli 608；web 487；tsc worker/cli/web/shared 0；web build 0；rebase 无冲突；无 D1 迁移（DO-sqlite 幂等列）。
- 变异：serve interval 不 fire→CLI 心跳测试红；去掉 finally 清→清除/health 测试红；do.ts 心跳 UPDATE 空转→worker 4 红。均复绿。

## 评审注意
- 本机走 health file（owner 点名的面），未动 statusline cache（issue 也提了，避免加宽 statusline 形状，后续可加）。
- 与 #191(可唤醒)、#108(wake 预算) 并行开发，scope 收在 #103 busy 的心跳扩展。

🤖 opus agent 实现 + 我亲验。
