### PR TITLE
fix(worker): hello 首连同步分块，不再单次序列化上万行（保完整性）（#129）

### DIFF
--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -148,6 +148,10 @@ const STATUS_SCOPE_JSON_LIMIT = 4096;
 const STATUS_DECISION_JSON_LIMIT = 4096;
 const STATUS_WORKFLOW_JSON_LIMIT = 4096;
 const MAX_COMPLETION_RELATED = 20;
+// #129：hello 首连补拉的分页大小。REST /internal/messages 早有 limit=1000；hello 曾无 LIMIT，
+// 单次把最多 1 万行一并 toArray 序列化。改为按 seq 分页多批下发（每批 ≤ 此值）——单条查询恒有界，
+// 又不砍完整性：循环直到某页短于一页即判排空，跨批次仍下发全部消息（客户端逐帧消费，与不分页无差别）。
+const HELLO_BACKFILL_PAGE_SIZE = 1000;
 const COMPLETION_ARTIFACT_JSON_LIMIT = 4096;
 const REVIEW_REASON_LIMIT = 4000;
 // #106：workflow guard 近期 (step,state) 窗口大小。8 足以罩住多 agent 在若干状态间的环形 ping-pong
@@ -1401,34 +1405,47 @@ export class ChannelDO extends Server<Env> {
       const sinceRev =
         typeof frame.since_rev === "number" && frame.since_rev >= 0 ? Math.floor(frame.since_rev) : null;
       // 带 since_rev 的新客户端：修订快照只重放 rev_seq 更大的那些（issue #33）；
-      // 不带的旧客户端：保持旧行为（全部历史修订每次连接都重放，由客户端自行去重）
-      const rows =
+      // 不带的旧客户端：保持旧行为（全部历史修订每次连接都重放，由客户端自行去重）。
+      //
+      // #129：分页而非无 LIMIT。曾用单条查询把全部匹配行（最多 1 万）一并 toArray——单次序列化上万行。
+      // 现按 seq 游标分页（seq 是主键、唯一、单调），每页 ≤ HELLO_BACKFILL_PAGE_SIZE 有界下发，循环到
+      // 某页短于一页即排空。分页游标从 0 起（不是 since）：since_rev 命中的行 seq 可能 ≤ since，
+      // 必须纳入遍历，否则会漏掉「seq 小但被修订」的行。跨批次逐帧下发，客户端消费与不分页时完全一致，
+      // 首连即完整的契约不破。
+      //
+      // 注：补拉期间不 await——DO 单线程处理这条 hello，其间新 send 无法穿插改表，快照一致；分页边界
+      // 只会漏「本次 hello 开始后」的新消息，那些由 send 的 live 广播补上（seq 更大，客户端照收）。
+      const backfillQuery =
         sinceRev !== null
-          ? this.ctx.storage.sql
-              .exec(
-                `SELECT * FROM messages
-                  WHERE seq > ?
-                     OR (rev_seq IS NOT NULL AND rev_seq > ?)
-                  ORDER BY seq`,
-                since,
-                sinceRev,
-              )
-              .toArray()
-          : this.ctx.storage.sql
-              .exec(
-                `SELECT * FROM messages
-                  WHERE seq > ?
-                     OR edited_at IS NOT NULL
-                     OR retracted_at IS NOT NULL
-                     OR supersedes IS NOT NULL
-                     OR superseded_by IS NOT NULL
-                     OR completion_review_state IS NOT NULL
-                     OR completion_review_replaced_by_seq IS NOT NULL
-                  ORDER BY seq`,
-                since,
-              )
-              .toArray();
-      for (const row of rows) this.sendFrame(connection, this.rowToFrame(row));
+          ? `SELECT * FROM messages
+              WHERE (seq > ? OR (rev_seq IS NOT NULL AND rev_seq > ?))
+                AND seq > ?
+              ORDER BY seq LIMIT ?`
+          : `SELECT * FROM messages
+              WHERE (seq > ?
+                 OR edited_at IS NOT NULL
+                 OR retracted_at IS NOT NULL
+                 OR supersedes IS NOT NULL
+                 OR superseded_by IS NOT NULL
+                 OR completion_review_state IS NOT NULL
+                 OR completion_review_replaced_by_seq IS NOT NULL)
+                AND seq > ?
+              ORDER BY seq LIMIT ?`;
+      let pageCursor = 0;
+      for (;;) {
+        const rows =
+          sinceRev !== null
+            ? this.ctx.storage.sql
+                .exec(backfillQuery, since, sinceRev, pageCursor, HELLO_BACKFILL_PAGE_SIZE)
+                .toArray()
+            : this.ctx.storage.sql
+                .exec(backfillQuery, since, pageCursor, HELLO_BACKFILL_PAGE_SIZE)
+                .toArray();
+        for (const row of rows) this.sendFrame(connection, this.rowToFrame(row));
+        if (rows.length < HELLO_BACKFILL_PAGE_SIZE) break;
+        // 游标推进到本页最后一行的 seq；seq 唯一且升序，下一页严格取更大的 seq，保证前进、不重不漏。
+        pageCursor = Number(rows[rows.length - 1]!.seq);
+      }
       return;
     }
     if (frame.type === "seen") {

--- a/worker/test/hello-backfill.spec.ts
+++ b/worker/test/hello-backfill.spec.ts
@@ -1,0 +1,108 @@
+import { env, runInDurableObject } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import type { ChannelDO } from "../src/do";
+import { WsClient, createChannel, seedToken } from "./helpers";
+
+// #129: hello 首连补拉曾用单条无 LIMIT 查询把最多 1 万行一次性 toArray 序列化。
+// 正确修法是分块（每页有界）而非砍 LIMIT——砍 LIMIT 会静默丢尾、破坏「首连即完整」契约。
+// 这些用例把「> 一页」的频道喂给 since=0 的全新客户端，验证：
+//   (1) 完整性：所有消息都补拉到，不在一页处被截断；
+//   (2) 有界性：任何单条补拉查询返回的行数都 <= 一页，不再单次序列化上万行。
+
+// 直接往 DO 的内建 SQLite 批量塞消息，绕开逐条 send 的往返（造 > 1000 行才够快）。
+async function seedMessages(slug: string, count: number): Promise<void> {
+  const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+  await runInDurableObject(stub, async (instance: ChannelDO) => {
+    const sql = (instance as unknown as { ctx: { storage: { sql: SqlLike } } }).ctx.storage.sql;
+    const now = Date.now();
+    for (let seq = 1; seq <= count; seq++) {
+      sql.exec(
+        `INSERT INTO messages (seq, sender_name, sender_kind, kind, body, mentions_json, reply_to, ts)
+         VALUES (?, ?, ?, 'message', ?, '[]', NULL, ?)`,
+        seq,
+        "seeder",
+        "agent",
+        `m${seq}`,
+        now + seq,
+      );
+    }
+  });
+}
+
+interface SqlLike {
+  exec(query: string, ...args: unknown[]): { toArray(): Record<string, unknown>[] };
+}
+
+// 收集 since=0 补拉到的所有 msg 的 seq（收满 expected 条即停）。
+async function collectBackfillSeqs(ws: WsClient, expected: number): Promise<number[]> {
+  const seqs: number[] = [];
+  while (seqs.length < expected) {
+    const msg = await ws.nextOfType("msg", 8000);
+    seqs.push(msg.seq);
+  }
+  return seqs;
+}
+
+describe("hello backfill chunking (#129)", () => {
+  it("delivers ALL messages to a fresh since=0 client when the channel exceeds one page", async () => {
+    const { token } = await seedToken("agent");
+    const slug = await createChannel(token);
+    const total = 1500; // > 1000 一页，迫使至少两页续拉
+
+    const reader = await WsClient.open(slug, token); // 先连一次让 onStart 建表
+    await reader.nextOfType("welcome");
+    await seedMessages(slug, total);
+    reader.send({ type: "hello", since: 0 });
+
+    const seqs = await collectBackfillSeqs(reader, total);
+    reader.close();
+
+    // 全量、无缺口、无重复：首连即完整
+    expect(seqs.length).toBe(total);
+    expect(new Set(seqs).size).toBe(total);
+    expect(Math.min(...seqs)).toBe(1);
+    expect(Math.max(...seqs)).toBe(total);
+  });
+
+  it("bounds each backfill query to at most one page (no single 10k-row serialization)", async () => {
+    const { token } = await seedToken("agent");
+    const slug = await createChannel(token);
+    const total = 1500;
+
+    const reader = await WsClient.open(slug, token); // 先连一次让 onStart 建表
+    await reader.nextOfType("welcome");
+    await seedMessages(slug, total);
+
+    const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+    // 给 DO 实例的 sql.exec 挂一个探针，记录任一「补拉查询」单次返回的最大行数。
+    // 探针在同一 isolate 内持久存活，随后 WS hello 触发的查询都会经过它。
+    await runInDurableObject(stub, async (instance: ChannelDO) => {
+      const holder = instance as unknown as {
+        ctx: { storage: { sql: SqlLike } };
+        __maxBackfillBatch: number;
+      };
+      holder.__maxBackfillBatch = 0;
+      const sql = holder.ctx.storage.sql;
+      const realExec = sql.exec.bind(sql);
+      sql.exec = ((query: string, ...args: unknown[]) => {
+        if (/SELECT \* FROM messages/i.test(query) && /ORDER BY seq/i.test(query)) {
+          const rows = realExec(query, ...args).toArray();
+          if (rows.length > holder.__maxBackfillBatch) holder.__maxBackfillBatch = rows.length;
+          return { toArray: () => rows };
+        }
+        return realExec(query, ...args);
+      }) as SqlLike["exec"];
+    });
+
+    reader.send({ type: "hello", since: 0 });
+    await collectBackfillSeqs(reader, total);
+    reader.close();
+
+    const maxBatch = await runInDurableObject(stub, async (instance: ChannelDO) => {
+      return (instance as unknown as { __maxBackfillBatch: number }).__maxBackfillBatch;
+    });
+    // 每页有界：单次查询绝不返回超过一页（1000）行。
+    expect(maxBatch).toBeGreaterThan(0);
+    expect(maxBatch).toBeLessThanOrEqual(1000);
+  });
+});


### PR DESCRIPTION
## 修什么（#129，[P3][impl]）

hello 首连补拉曾**无 LIMIT**：`since=0` 单条查询把最多 1 万行一并 `toArray` 序列化（REST `/internal/messages` 早有 `limit=1000`）。首连同步语义被依赖，正确修法是**分块而非砍 LIMIT**。

## 怎么修（分页，保完整性）
- 按 seq 游标分页（`HELLO_BACKFILL_PAGE_SIZE=1000`）：`WHERE (原条件) AND seq > ? ORDER BY seq LIMIT ?`，循环到某页短于一页即排空，游标推进到本页末 seq。seq 唯一升序 → 严格前进、不重不漏。**跨批次逐帧下发全部消息**，客户端消费与不分页完全一致，首连即完整的契约不破。
- 游标**从 0 起（非 since）**：`since_rev` 命中的修订行 seq 可能 ≤ since，必须纳入遍历，否则漏「seq 小但被修订」的行。
- 补拉期**不 await**：DO 单线程处理这条 hello、其间无 send 穿插改表、快照一致；分页边界只漏「hello 开始后」的新消息，由 send 的 live 广播补上（seq 更大、客户端照收）。

## 门禁（对 origin HEAD rebase 后亲验）
- worker hello-backfill spec 2/2；worker tsc 0；rebase 无冲突。
- spec 塞 1500 条（>1 页强制多页），断言 **全 1500 到齐（完整性：length/unique/min=1/max=1500）** 且 **每查询 `__maxBackfillBatch ≤ 1000`（有界性）**。
- ⚠️ **变异 caveat（诚实）**：两次变异（break 提前 / PAGE_SIZE 调大回无界）都触发了已知的 vitest-pool-workers DO-reload flake（改 do.ts → workerd 「index.ts changed」重载 → Failed Suites / no tests），未拿到干净的单断言红。完整性+有界性由 spec 断言覆盖、正确代码上 2/2 通过、分页逻辑经人工复核（游标单调不重不漏）。CI 环境跑该 spec 更稳，请复核。

🤖 opus agent 实现、收尾截断我接管（审+提交+复验）。
