### PR TITLE
fix(web): 主面板不再整体滚动，仅内容区滚（固定 shell 高度 + 单一滚动区）（#301）

### DIFF
--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -8,6 +8,10 @@
   height: 100dvh;
   display: flex;
   flex-direction: column;
+  /* #301：外壳锁死在视口高度，永不整体滚动。任何内容都由内部指定的滚动区
+     （.stream / .home / .app-side / 面板体 / 设置浮层）自己滚，溢出的兜底裁在
+     视口边缘，而不是让整块主面板跟着 body 一起滚。 */
+  overflow: hidden;
 }
 
 /* ---- 骨架 ---- */
@@ -490,6 +494,9 @@
   min-height: 0;
   display: flex;
   flex-direction: column;
+  /* #301：主面板本身不滚——内容（.chan 里的 .stream / 落地页 .home）各自内部滚，
+     主面板只作固定高度的容器，绝不因内容变高而整体滚动。 */
+  overflow: hidden;
 }
 
 /* ---- 频道列表 ---- */
@@ -4249,12 +4256,17 @@
 /* ---- 登录闸 ---- */
 .gate {
   flex: 1;
+  min-height: 0;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   gap: 6px;
   padding: 24px;
+  /* #301：登录/错误态是 #root 直属的另一「主面板」。#root 现在裁在视口高度，
+     所以矮屏下 gate 的内容必须自己滚（min-height:0 让居中的 flex 内容可收缩），
+     否则会被视口裁掉顶部。 */
+  overflow-y: auto;
 }
 .gate-title { font-size: 40px; margin: 0; }
 .gate-sub { color: var(--t-muted); font-size: 15px; margin: 0 0 22px; }

--- a/web/src/styles/app.scroll.test.ts
+++ b/web/src/styles/app.scroll.test.ts
@@ -1,0 +1,64 @@
+// @ts-expect-error Bun executes this test, while the web tsconfig intentionally loads only Vite globals.
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+// issue #301：「主面板不能滚动，只有内容区域才能滚动」——外壳（#root / .app-main /
+// 登录 gate）必须锁死在视口高度、绝不整体滚动，滚动只发生在指定的内容区
+// （.stream 消息流 / .home 落地页网格 / gate 自身）。react-test-renderer 不跑布局/CSS，
+// 测不出滚动行为，所以这里直接读 app.css 源码断言约束链，防止回归。
+//
+// 机理（已用真实浏览器量过）：#root 固定 100dvh，链上每层 min-height:0 让 flex 子项
+// 可收缩，末端内容区用 overflow auto 自己滚；#root / .app-main 再补 overflow:hidden
+// 作兜底，任何未来内容都不会把整块主面板拖着 body 一起滚。
+
+const cssPath = fileURLToPath(new URL("./app.css", import.meta.url));
+const css = readFileSync(cssPath, "utf8");
+
+function ruleBody(selector: string): string {
+  const needle = `${selector} {`;
+  const start = css.indexOf(needle);
+  if (start === -1) throw new Error(`selector not found in app.css: ${selector}`);
+  const end = css.indexOf("}", start);
+  if (end === -1) throw new Error(`unterminated rule for selector: ${selector}`);
+  return css.slice(start, end);
+}
+
+describe("app shell scroll containment (#301)", () => {
+  test("#root is locked to the viewport height and clips — the shell never scrolls as a whole", () => {
+    const body = ruleBody("#root");
+    expect(body).toContain("100dvh");
+    expect(body).toContain("overflow: hidden");
+  });
+
+  test(".app-main (the main panel) does not scroll itself — it clips, content scrolls inside", () => {
+    const body = ruleBody(".app-main");
+    expect(body).toContain("min-height: 0");
+    expect(body).toContain("overflow: hidden");
+  });
+
+  test(".chan constrains its own height and clips so only .stream scrolls", () => {
+    const body = ruleBody(".chan");
+    expect(body).toContain("min-height: 0");
+    expect(body).toContain("overflow: hidden");
+  });
+
+  test(".stream (the message content region) is the scroll region", () => {
+    const body = ruleBody(".stream");
+    expect(body).toContain("min-height: 0");
+    expect(body).toContain("overflow-y: auto");
+  });
+
+  test(".home (landing content region) scrolls internally, not the shell", () => {
+    const body = ruleBody(".home");
+    expect(body).toContain("overflow-y: auto");
+  });
+
+  test(".gate (login/error panel, a #root-direct surface) scrolls its own content on short viewports", () => {
+    const body = ruleBody(".gate");
+    // min-height:0 lets the centered flex content shrink so overflow-y:auto can engage
+    // instead of spilling out and scrolling the (now clipped) shell / body.
+    expect(body).toContain("min-height: 0");
+    expect(body).toContain("overflow-y: auto");
+  });
+});


### PR DESCRIPTION
## 修什么（#301）

「主面板不能滚动，只有内容区域才能滚动。」——整个主面板会整体滚动，应该只有内容区（消息流）滚，chrome（头/输入/侧栏）固定。

## 根因 + 修法
shell 链（`#root` 100dvh → `.app` → `.app-shell` → `.app-main` → `.chan`/`.home` → `.stream`）靠 flex `min-height:0` 界定内容区，但**缺 clipping 安全网**：没有任何层强制 shell 停在视口高度，于是被撑高的层会一路溢到 body、整壳滚动（尤其 `.gate` 登录/错误面在矮屏）。
- `#root`：加 `overflow: hidden`——shell 锁死 100dvh、绝不整体滚，溢出在视口边界被截。
- `.app-main`：加 `overflow: hidden`——「主面板」固定高，滚动委派给内部 `.stream`/`.home`（它们已各自内滚）。
- `.gate`：加 `min-height:0 + overflow-y:auto`——矮屏时登录面自己内滚，不再整壳溢出/顶部被切。

## 验证（真浏览器 chrome-use，桌面/移动/矮屏）
Channel/Home 视图：仅 `.stream`/`.home` 滚，body/#root/.app-main 不滚（修前修后一致=健康态 no-op）。Gate 在 500px 矮屏：**修前** body 整体滚（scrollHeight 1011>500）复现 bug；**修后** 仅 `.gate` 内滚、body/#root 固定。

## 门禁（rebase 后亲验）
web 500/0（含 6 新 scroll 测试）；tsc 0；vite build 0；rebase 无冲突。overlay/dropdown 都是 position:fixed，逃出 clip、无回归。

🤖 opus agent 实现（含真浏览器测量）+ 我复验。
