### PR TITLE
feat(desktop): 桌面版贴网页邀请链接进入频道，与网页共用邀请机制（#297）

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,6 +6,7 @@ import { ChannelList } from "./components/ChannelList";
 import { CreateChannel } from "./components/CreateChannel";
 import { DesktopSettings } from "./components/DesktopSettings";
 import { DesktopDownloadLink } from "./components/DesktopDownloadLink";
+import { DesktopInvitePaste } from "./components/DesktopInvitePaste";
 import { DesktopPairingGate } from "./components/DesktopPairingGate";
 import { DesktopUpdater } from "./components/DesktopUpdater";
 import { TokenGate } from "./components/TokenGate";
@@ -13,6 +14,7 @@ import { SettingsPanel } from "./components/SettingsPanel";
 import { OnboardingGuide } from "./components/OnboardingGuide";
 import { ServerProfileAddGate, ServerSwitcher } from "./components/ServerProfiles";
 import {
+  applyShareToken,
   AuthError,
   type ChannelInfo,
   clearShareToken,
@@ -174,6 +176,21 @@ export function App() {
         throw cause;
       });
   }, [activeOrigin]);
+
+  // 桌面版贴观看邀请链接（#297）：/c/<slug>?t=<token> 的观看 token 直接落进分享态（复用 #186），
+  // 换成只读会话打开频道——与网页命中 ?t= 等价，只是桌面没有地址栏，token 从粘贴框进来。
+  const enterWatchInvite = useCallback(
+    (slug: string, watchToken: string) => {
+      applyShareToken(watchToken);
+      setAuthError(null);
+      setChannels(null);
+      setListError(null);
+      setMe(null);
+      setToken(watchToken);
+      navigate(`/c/${slug}`);
+    },
+    [navigate],
+  );
 
   const switchDesktopOrigin = useCallback(async (origin: string) => {
     const result = await switchActiveDesktopServer(origin);
@@ -909,6 +926,16 @@ export function App() {
         <aside className="app-side">
           {canCreate && token !== null && (
             <CreateChannel token={token} onCreated={onChannelCreated} />
+          )}
+          {/* 桌面版：贴网页邀请链接进入频道（#297）。桌面壳没地址栏，粘贴框把 /join 或 /c 链接
+              解析后走网页同款兑换——participate 走 /join/<code> 兑换 effect，watch 落分享态。 */}
+          {desktop && !isShareMode() && (
+            <DesktopInvitePaste
+              activeOrigin={activeOrigin}
+              onParticipate={(code) => navigate(`/join/${code}`)}
+              onOpen={(s) => navigate(`/c/${s}`)}
+              onWatch={enterWatchInvite}
+            />
           )}
           <ChannelList channels={channels} active={slug} error={listError} onOpen={openChannel} />
         </aside>

--- a/web/src/components/DesktopInvitePaste.test.tsx
+++ b/web/src/components/DesktopInvitePaste.test.tsx
@@ -1,0 +1,141 @@
+// @ts-expect-error Bun executes this test, while the web tsconfig intentionally loads only Vite globals.
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { LocaleProvider } from "../i18n/locale";
+import { DesktopInvitePaste } from "./DesktopInvitePaste";
+
+// 桌面粘贴入口必须真把解析结果接到对应回调（#297 wiring 门禁）：
+//   /join/<code> → onParticipate(code)；/c/<slug>?t= → onWatch(slug, token)；/c/<slug> → onOpen(slug)。
+// 换错回调这些断言就红——这是「组件真被 wire 进去且分流正确」的护栏。
+const SERVER = "https://agentparty.leeguoo.com";
+
+let renderer: ReactTestRenderer | null = null;
+
+interface Calls {
+  participate: string[];
+  watch: Array<{ slug: string; token: string }>;
+  open: string[];
+}
+
+function render(calls: Calls, opts?: { readClipboard?: () => Promise<string>; origin?: string }) {
+  act(() => {
+    renderer = create(
+      <LocaleProvider>
+        <DesktopInvitePaste
+          activeOrigin={opts?.origin ?? SERVER}
+          onParticipate={(code) => calls.participate.push(code)}
+          onWatch={(slug, token) => calls.watch.push({ slug, token })}
+          onOpen={(slug) => calls.open.push(slug)}
+          readClipboard={opts?.readClipboard}
+        />
+      </LocaleProvider>,
+    );
+  });
+  return renderer as ReactTestRenderer;
+}
+
+function expand(r: ReactTestRenderer) {
+  const toggle = r.root.findAll((n) => n.type === "button" && String(n.props.className ?? "").includes("invite-paste-btn"))[0]!;
+  act(() => (toggle.props.onClick as () => void)());
+}
+
+function typeUrl(r: ReactTestRenderer, url: string) {
+  const input = r.root.findAll((n) => n.type === "input")[0]!;
+  act(() => (input.props.onChange as (e: { target: { value: string } }) => void)({ target: { value: url } }));
+}
+
+function clickJoin(r: ReactTestRenderer) {
+  const btn = r.root.findAll((n) => n.type === "button" && String(n.props.className ?? "").includes("d-btn--primary"))[0]!;
+  act(() => (btn.props.onClick as () => void)());
+}
+
+function clickDetect(r: ReactTestRenderer) {
+  const btn = r.root.findAll((n) => n.type === "button" && String(n.props.className ?? "").includes("invite-paste-detect"))[0]!;
+  act(() => (btn.props.onClick as () => void)());
+}
+
+function text(r: ReactTestRenderer, className: string): string | null {
+  const nodes = r.root.findAll((n) => String(n.props.className ?? "").includes(className));
+  return nodes.length === 0 ? null : nodes.map((n) => n.children.join("")).join("");
+}
+
+afterEach(() => {
+  act(() => renderer?.unmount());
+  renderer = null;
+});
+
+describe("DesktopInvitePaste wiring", () => {
+  let calls: Calls;
+  beforeEach(() => {
+    calls = { participate: [], watch: [], open: [] };
+  });
+
+  test("participate link routes to onParticipate with the code", () => {
+    const r = render(calls);
+    expand(r);
+    typeUrl(r, `${SERVER}/join/abc123`);
+    clickJoin(r);
+    expect(calls.participate).toEqual(["abc123"]);
+    expect(calls.watch).toEqual([]);
+    expect(calls.open).toEqual([]);
+  });
+
+  test("watch link routes to onWatch with slug + token", () => {
+    const r = render(calls);
+    expand(r);
+    typeUrl(r, `${SERVER}/c/devchan?t=ap_watchtoken`);
+    clickJoin(r);
+    expect(calls.watch).toEqual([{ slug: "devchan", token: "ap_watchtoken" }]);
+    expect(calls.participate).toEqual([]);
+  });
+
+  test("plain channel link routes to onOpen with slug", () => {
+    const r = render(calls);
+    expand(r);
+    typeUrl(r, `${SERVER}/c/devchan`);
+    clickJoin(r);
+    expect(calls.open).toEqual(["devchan"]);
+    expect(calls.watch).toEqual([]);
+  });
+
+  test("wrong-host invite shows an error naming both hosts and fires no callback", () => {
+    const r = render(calls);
+    expand(r);
+    typeUrl(r, "https://evil.example.com/join/abc");
+    clickJoin(r);
+    expect(calls.participate).toEqual([]);
+    const err = text(r, "invite-paste-error");
+    expect(err).not.toBeNull();
+    expect(err).toContain("evil.example.com");
+    expect(err).toContain("agentparty.leeguoo.com");
+  });
+
+  test("malformed invite shows an error and fires no callback", () => {
+    const r = render(calls);
+    expand(r);
+    typeUrl(r, "not a link");
+    clickJoin(r);
+    expect(calls.participate).toEqual([]);
+    expect(text(r, "invite-paste-error")).not.toBeNull();
+  });
+
+  test("detect from clipboard prefills + prompts but does NOT auto-join (user still confirms)", async () => {
+    const r = render(calls, { readClipboard: () => Promise.resolve(`${SERVER}/join/frompaste`) });
+    expand(r);
+    await act(async () => clickDetect(r));
+    // 检测阶段不触发加入——只回填 + 提示
+    expect(calls.participate).toEqual([]);
+    expect(text(r, "invite-paste-detected")).not.toBeNull();
+    // 用户确认后才加入，用的是剪贴板检测回填进来的链接
+    clickJoin(r);
+    expect(calls.participate).toEqual(["frompaste"]);
+  });
+
+  test("clipboard read failure surfaces the clipboard error", async () => {
+    const r = render(calls, { readClipboard: () => Promise.reject(new Error("blocked")) });
+    expand(r);
+    await act(async () => clickDetect(r));
+    expect(text(r, "invite-paste-error")).not.toBeNull();
+    expect(calls.participate).toEqual([]);
+  });
+});

--- a/web/src/components/DesktopInvitePaste.tsx
+++ b/web/src/components/DesktopInvitePaste.tsx
@@ -1,0 +1,146 @@
+// 桌面版贴网页邀请链接进入频道（#297）。桌面壳没有地址栏，用户拿到的是网页版的 /join 或
+// /c 链接——这里给一个粘贴入口：解析 + 校验宿主 + 按 #186 模式分流回 App 走网页同款兑换。
+// 「从剪贴板检测」是 issue 里「识别到剪贴板就问是否加入」的许可友好版：读剪贴板需用户手势，
+// 故做成显式按钮（点一下即读，webview 里合法），检测到就回填并提示，真正加入仍由用户点「加入」确认。
+import { useCallback, useState } from "react";
+import { resolveInviteForServer, type InviteResolution } from "../lib/inviteLink";
+import { useT, type TFunc } from "../i18n/useT";
+import "../i18n/strings/DesktopInvite";
+
+interface Props {
+  activeOrigin: string;
+  onParticipate(code: string): void;
+  onWatch(slug: string, token: string): void;
+  onOpen(slug: string): void;
+  // DI：默认读系统剪贴板（webview 内 user-gesture 触发合法）；测试注入桩。
+  readClipboard?: () => Promise<string>;
+}
+
+const defaultReadClipboard = (): Promise<string> =>
+  navigator.clipboard?.readText?.() ?? Promise.reject(new Error("clipboard unavailable"));
+
+function errorMessage(t: TFunc, r: Extract<InviteResolution, { ok: false }>, activeOrigin: string): string {
+  switch (r.reason) {
+    case "empty":
+      return t("DesktopInvite.error.empty");
+    case "malformed":
+      return t("DesktopInvite.error.malformed");
+    case "unsupported":
+      return t("DesktopInvite.error.unsupported");
+    case "wrong-host":
+      return t("DesktopInvite.error.wrongHost", {
+        expected: r.expectedHost ?? activeOrigin,
+        actual: r.actualHost ?? "?",
+      });
+  }
+}
+
+function detectedMessage(t: TFunc, action: Extract<InviteResolution, { ok: true }>["action"]): string {
+  if (action.kind === "participate") return t("DesktopInvite.detected.participate");
+  if (action.kind === "watch") return t("DesktopInvite.detected.watch", { slug: action.slug });
+  return t("DesktopInvite.detected.open", { slug: action.slug });
+}
+
+export function DesktopInvitePaste({
+  activeOrigin,
+  onParticipate,
+  onWatch,
+  onOpen,
+  readClipboard = defaultReadClipboard,
+}: Props) {
+  const t = useT();
+  const [open, setOpen] = useState(false);
+  const [value, setValue] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [detected, setDetected] = useState<string | null>(null);
+
+  const run = useCallback(
+    (raw: string) => {
+      const r = resolveInviteForServer(raw, activeOrigin);
+      if (!r.ok) {
+        setError(errorMessage(t, r, activeOrigin));
+        return;
+      }
+      setError(null);
+      setDetected(null);
+      if (r.action.kind === "participate") onParticipate(r.action.code);
+      else if (r.action.kind === "watch") onWatch(r.action.slug, r.action.token);
+      else onOpen(r.action.slug);
+    },
+    [activeOrigin, t, onParticipate, onWatch, onOpen],
+  );
+
+  const detectFromClipboard = useCallback(async () => {
+    setError(null);
+    setDetected(null);
+    let text: string;
+    try {
+      text = await readClipboard();
+    } catch {
+      setError(t("DesktopInvite.error.clipboard"));
+      return;
+    }
+    const r = resolveInviteForServer(text, activeOrigin);
+    if (!r.ok) {
+      setError(errorMessage(t, r, activeOrigin));
+      return;
+    }
+    setValue(text.trim());
+    setDetected(detectedMessage(t, r.action));
+  }, [readClipboard, activeOrigin, t]);
+
+  return (
+    <div className="invite-paste joinlink">
+      <button
+        type="button"
+        className="d-btn joinlink-btn invite-paste-btn"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+      >
+        {t("DesktopInvite.button")}
+      </button>
+      {open && (
+        <div className="joinlink-panel invite-paste-panel">
+          <span className="joinlink-hint">{t("DesktopInvite.hint")}</span>
+          <input
+            className="invite-paste-input"
+            type="text"
+            value={value}
+            placeholder={t("DesktopInvite.placeholder")}
+            onChange={(e) => {
+              setValue(e.target.value);
+              setError(null);
+              setDetected(null);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") run(value);
+            }}
+          />
+          <div className="joinlink-gen-row invite-paste-actions">
+            <button
+              type="button"
+              className="d-btn d-btn--primary"
+              disabled={value.trim() === ""}
+              onClick={() => run(value)}
+            >
+              {t("DesktopInvite.join")}
+            </button>
+            <button type="button" className="d-btn invite-paste-detect" onClick={() => void detectFromClipboard()}>
+              {t("DesktopInvite.detect")}
+            </button>
+          </div>
+          {detected !== null && (
+            <p className="banner invite-paste-detected" role="status" aria-live="polite">
+              {detected}
+            </p>
+          )}
+          {error !== null && (
+            <p className="joinlink-error invite-paste-error" role="alert">
+              {error}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/i18n/strings/DesktopInvite.ts
+++ b/web/src/i18n/strings/DesktopInvite.ts
@@ -1,0 +1,36 @@
+import { registerDict, type LocaleDict } from "../dict";
+
+export const DesktopInviteStrings: LocaleDict = {
+  en: {
+    "DesktopInvite.button": "paste invite link",
+    "DesktopInvite.hint": "Paste a web invite link to enter a channel — the same link works in the browser and here.",
+    "DesktopInvite.placeholder": "https://…/join/… or https://…/c/…?t=…",
+    "DesktopInvite.join": "join",
+    "DesktopInvite.detect": "detect from clipboard",
+    "DesktopInvite.detected.participate": "Invite link detected — click join to enter.",
+    "DesktopInvite.detected.watch": "Watch link for #{slug} detected — click join to open read-only.",
+    "DesktopInvite.detected.open": "Channel link for #{slug} detected — click join to open.",
+    "DesktopInvite.error.empty": "Paste an invite link first.",
+    "DesktopInvite.error.malformed": "That doesn't look like a link — copy the full invite URL.",
+    "DesktopInvite.error.unsupported": "Unrecognized link — use a /join/… or /c/… invite link.",
+    "DesktopInvite.error.wrongHost": "This invite is for {actual}, but you're connected to {expected}. Switch servers first.",
+    "DesktopInvite.error.clipboard": "Couldn't read the clipboard — paste the link manually.",
+  },
+  zh: {
+    "DesktopInvite.button": "粘贴邀请链接",
+    "DesktopInvite.hint": "粘贴网页版的邀请链接进入频道——同一条链接在浏览器和这里都能用。",
+    "DesktopInvite.placeholder": "https://…/join/… 或 https://…/c/…?t=…",
+    "DesktopInvite.join": "加入",
+    "DesktopInvite.detect": "从剪贴板检测",
+    "DesktopInvite.detected.participate": "检测到邀请链接——点「加入」进入。",
+    "DesktopInvite.detected.watch": "检测到 #{slug} 的观看链接——点「加入」以只读方式打开。",
+    "DesktopInvite.detected.open": "检测到 #{slug} 的频道链接——点「加入」打开。",
+    "DesktopInvite.error.empty": "先粘贴一条邀请链接。",
+    "DesktopInvite.error.malformed": "这不像一条链接——请复制完整的邀请 URL。",
+    "DesktopInvite.error.unsupported": "无法识别的链接——请使用 /join/… 或 /c/… 邀请链接。",
+    "DesktopInvite.error.wrongHost": "这条邀请属于 {actual}，而你当前连接的是 {expected}。请先切换服务器。",
+    "DesktopInvite.error.clipboard": "读取剪贴板失败——请手动粘贴链接。",
+  },
+};
+
+registerDict(DesktopInviteStrings);

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -85,6 +85,18 @@ export function clearShareToken() {
   sessionStorage.removeItem(SHARE_TOKEN_KEY);
 }
 
+// 桌面版贴观看邀请链接（#297）：链接里的 ?t= 观看 token 不经地址栏，直接落进分享态。
+// 与网页 getToken() 命中 ?t= 的分支等价（都设 activeShareToken + sessionStorage），
+// 于是 isShareMode() 为真、ChannelPage 走只读——复用同一套 #186 观看机制。
+export function applyShareToken(token: string) {
+  activeShareToken = token;
+  try {
+    sessionStorage.setItem(SHARE_TOKEN_KEY, token);
+  } catch {
+    // 非浏览器测试环境无 sessionStorage；activeShareToken 已够驱动本次会话。
+  }
+}
+
 // 分享 token 失效时退回粘贴登录：把 ?t= 从地址栏摘掉，避免 getToken 继续命中坏 token
 export function dropUrlToken() {
   const url = new URL(window.location.href);

--- a/web/src/lib/inviteLink.test.ts
+++ b/web/src/lib/inviteLink.test.ts
@@ -1,0 +1,109 @@
+// @ts-expect-error Bun executes this test, while the web tsconfig intentionally loads only Vite globals.
+import { describe, expect, test } from "bun:test";
+import { parseInviteUrl, resolveInviteForServer } from "./inviteLink";
+
+// 桌面版「贴网页邀请链接进入频道」（#297）的纯解析层。桌面壳没有地址栏，用户只能粘贴
+// 网页版铸出来的同一条链接（#186/#38）。这里把 URL 拆成 {server, slug/code, token} 并按
+// 邀请模式分流：/join/<code>=参与，/c/<slug>?t=<token>=观看，/c/<slug>=直接打开。
+const SERVER = "https://agentparty.leeguoo.com";
+
+describe("parseInviteUrl", () => {
+  test("participate link /join/<code> → participate action carrying server + code", () => {
+    const r = parseInviteUrl(`${SERVER}/join/AbC_1-23xyz`);
+    expect(r).toEqual({ ok: true, action: { kind: "participate", server: SERVER, code: "AbC_1-23xyz" } });
+  });
+
+  test("watch link /c/<slug>?t=<token> → watch action carrying slug + token", () => {
+    const r = parseInviteUrl(`${SERVER}/c/devchan?t=ap_watchtoken`);
+    expect(r).toEqual({ ok: true, action: { kind: "watch", server: SERVER, slug: "devchan", token: "ap_watchtoken" } });
+  });
+
+  test("plain channel link /c/<slug> (no token) → open action", () => {
+    const r = parseInviteUrl(`${SERVER}/c/devchan`);
+    expect(r).toEqual({ ok: true, action: { kind: "open", server: SERVER, slug: "devchan" } });
+  });
+
+  test("trailing slash on join and channel paths still parses", () => {
+    expect(parseInviteUrl(`${SERVER}/join/abc/`)).toEqual({ ok: true, action: { kind: "participate", server: SERVER, code: "abc" } });
+    expect(parseInviteUrl(`${SERVER}/c/devchan/`)).toEqual({ ok: true, action: { kind: "open", server: SERVER, slug: "devchan" } });
+  });
+
+  test("watch token is read even when other query params precede it", () => {
+    const r = parseInviteUrl(`${SERVER}/c/devchan?foo=1&t=tok2`);
+    expect(r).toEqual({ ok: true, action: { kind: "watch", server: SERVER, slug: "devchan", token: "tok2" } });
+  });
+
+  test("empty ?t= degrades to open (not a broken watch)", () => {
+    expect(parseInviteUrl(`${SERVER}/c/devchan?t=`)).toEqual({ ok: true, action: { kind: "open", server: SERVER, slug: "devchan" } });
+  });
+
+  test("surrounding whitespace is trimmed", () => {
+    const r = parseInviteUrl(`   ${SERVER}/join/abc   `);
+    expect(r).toEqual({ ok: true, action: { kind: "participate", server: SERVER, code: "abc" } });
+  });
+
+  test("host case is normalized by URL parsing (server origin lowercased)", () => {
+    const r = parseInviteUrl("HTTPS://AgentParty.LeeGuoo.COM/c/devchan?t=tok");
+    expect(r).toEqual({ ok: true, action: { kind: "watch", server: SERVER, slug: "devchan", token: "tok" } });
+  });
+
+  test("empty / whitespace-only input → empty", () => {
+    expect(parseInviteUrl("")).toEqual({ ok: false, reason: "empty" });
+    expect(parseInviteUrl("   ")).toEqual({ ok: false, reason: "empty" });
+  });
+
+  test("non-URL garbage → malformed", () => {
+    expect(parseInviteUrl("not a url")).toEqual({ ok: false, reason: "malformed" });
+  });
+
+  test("non-http(s) schemes are rejected as unsupported (no separate desktop scheme)", () => {
+    expect(parseInviteUrl("agentparty://pair/ABCDE-12345")).toEqual({ ok: false, reason: "unsupported" });
+    expect(parseInviteUrl("javascript:alert(1)")).toEqual({ ok: false, reason: "unsupported" });
+    expect(parseInviteUrl("ftp://agentparty.leeguoo.com/c/devchan")).toEqual({ ok: false, reason: "unsupported" });
+  });
+
+  test("known-host but unrecognized path → unsupported", () => {
+    expect(parseInviteUrl(`${SERVER}/settings`)).toEqual({ ok: false, reason: "unsupported" });
+    expect(parseInviteUrl(`${SERVER}/`)).toEqual({ ok: false, reason: "unsupported" });
+  });
+
+  test("invalid channel slug (uppercase) is not accepted as a channel", () => {
+    expect(parseInviteUrl(`${SERVER}/c/DevChan`)).toEqual({ ok: false, reason: "unsupported" });
+  });
+});
+
+describe("resolveInviteForServer (host validation against the paired desktop server)", () => {
+  test("invite whose origin equals the active server resolves to its action", () => {
+    expect(resolveInviteForServer(`${SERVER}/join/abc`, SERVER)).toEqual({
+      ok: true,
+      action: { kind: "participate", server: SERVER, code: "abc" },
+    });
+  });
+
+  test("different host → wrong-host with both hosts for a clear error", () => {
+    const r = resolveInviteForServer("https://evil.example.com/join/abc", SERVER);
+    expect(r).toEqual({ ok: false, reason: "wrong-host", expectedHost: "agentparty.leeguoo.com", actualHost: "evil.example.com" });
+  });
+
+  test("same host but different port → wrong-host", () => {
+    const r = resolveInviteForServer("https://agentparty.leeguoo.com:8443/join/abc", SERVER);
+    expect(r.ok).toBe(false);
+    expect(r).toMatchObject({ reason: "wrong-host" });
+  });
+
+  test("scheme mismatch (http vs https) → wrong-host", () => {
+    const r = resolveInviteForServer("http://agentparty.leeguoo.com/join/abc", SERVER);
+    expect(r).toMatchObject({ ok: false, reason: "wrong-host" });
+  });
+
+  test("parse failures pass through unchanged (not reported as wrong-host)", () => {
+    expect(resolveInviteForServer("", SERVER)).toEqual({ ok: false, reason: "empty" });
+    expect(resolveInviteForServer("not a url", SERVER)).toEqual({ ok: false, reason: "malformed" });
+    expect(resolveInviteForServer("agentparty://pair/ABCDE-12345", SERVER)).toEqual({ ok: false, reason: "unsupported" });
+  });
+
+  test("unparseable active origin never yields a false match", () => {
+    const r = resolveInviteForServer(`${SERVER}/join/abc`, "not-an-origin");
+    expect(r).toMatchObject({ ok: false, reason: "wrong-host" });
+  });
+});

--- a/web/src/lib/inviteLink.ts
+++ b/web/src/lib/inviteLink.ts
@@ -1,0 +1,92 @@
+// 桌面版「贴网页邀请链接进入频道」（#297）。桌面壳（Tauri）是网页版的 vite 产物套壳，
+// 没有地址栏——用户无法像浏览器那样直接打开一条 /join 或 /c 链接。这里把网页版铸出来的
+// **同一条**邀请链接（#186/#38，不另造 desktop scheme）解析成结构化动作，交给桌面 UI 兑换：
+//   · /join/<code>        → participate：登录态下 POST /api/join/<code> 加入为成员
+//   · /c/<slug>?t=<token> → watch：只读围观 token（复用 ?t= 分享机制）
+//   · /c/<slug>           → open：直接打开频道（已是成员时）
+// server 一并解析出来供宿主校验：桌面当前会话只对应一台已配对服务器，跨服邀请必须先切服。
+import { matchChannel, matchJoin } from "../router";
+
+export type InviteAction =
+  | { kind: "participate"; server: string; code: string }
+  | { kind: "watch"; server: string; slug: string; token: string }
+  | { kind: "open"; server: string; slug: string };
+
+export type InviteParseReason = "empty" | "malformed" | "unsupported";
+
+export type ParsedInvite =
+  | { ok: true; action: InviteAction }
+  | { ok: false; reason: InviteParseReason };
+
+export function parseInviteUrl(raw: string): ParsedInvite {
+  const trimmed = raw.trim();
+  if (trimmed === "") return { ok: false, reason: "empty" };
+
+  let url: URL;
+  try {
+    url = new URL(trimmed);
+  } catch {
+    return { ok: false, reason: "malformed" };
+  }
+  // 只认网页版真正用的 http(s)。agentparty://（配对 deep-link）、javascript: 等一律拒——
+  // 邀请入口不做 scheme 分流，避免把桌面私有协议和网页链接搅在一起。
+  if (url.protocol !== "https:" && url.protocol !== "http:") {
+    return { ok: false, reason: "unsupported" };
+  }
+  const server = url.origin;
+
+  const code = matchJoin(url.pathname);
+  if (code !== null) return { ok: true, action: { kind: "participate", server, code } };
+
+  const slug = matchChannel(url.pathname);
+  if (slug !== null) {
+    const token = url.searchParams.get("t");
+    if (token !== null && token !== "") {
+      return { ok: true, action: { kind: "watch", server, slug, token } };
+    }
+    return { ok: true, action: { kind: "open", server, slug } };
+  }
+
+  return { ok: false, reason: "unsupported" };
+}
+
+export type InviteResolution =
+  | { ok: true; action: InviteAction }
+  | {
+      ok: false;
+      reason: InviteParseReason | "wrong-host";
+      expectedHost?: string;
+      actualHost?: string;
+    };
+
+// 桌面宿主校验：邀请链接的 origin 必须与当前配对的服务器一致。桌面每个会话只持有一台
+// 服务器的凭据/分享 token，跨服链接直接兑换只会 401 或落到错误的 API base——与其静默出错，
+// 不如在这里明确回 wrong-host，并带上两边 host 供 UI 提示「先切到 <host> 再粘贴」。
+export function resolveInviteForServer(raw: string, activeOrigin: string): InviteResolution {
+  const parsed = parseInviteUrl(raw);
+  if (!parsed.ok) return parsed;
+
+  const actualHost = hostOf(parsed.action.server);
+  let expectedOrigin: string;
+  let expectedHost: string;
+  try {
+    const active = new URL(activeOrigin);
+    expectedOrigin = active.origin;
+    expectedHost = active.host;
+  } catch {
+    return { ok: false, reason: "wrong-host", actualHost };
+  }
+
+  if (parsed.action.server !== expectedOrigin) {
+    return { ok: false, reason: "wrong-host", expectedHost, actualHost };
+  }
+  return { ok: true, action: parsed.action };
+}
+
+function hostOf(origin: string): string {
+  try {
+    return new URL(origin).host;
+  } catch {
+    return origin;
+  }
+}

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -3001,6 +3001,21 @@
 .joinlink-revoke { color: var(--d-red, #c0392b); }
 .joinlink-empty { font-size: 12px; color: var(--t-dim); margin: 0; }
 .joinlink-error { font-size: 12px; color: var(--d-red, #c0392b); margin: 0; }
+/* 桌面版贴邀请链接（#297）：入口在左侧栏，浮层左对齐（joinlink 默认右对齐是给顶栏用的）。 */
+.invite-paste { margin-bottom: 8px; }
+.invite-paste-btn { width: 100%; }
+.invite-paste-panel { left: 0; right: auto; }
+.invite-paste-input {
+  width: 100%;
+  box-sizing: border-box;
+  font-size: 12.5px;
+  padding: 5px 8px;
+  border: 1.6px solid var(--d-ink);
+  border-radius: 0;
+  background: var(--t-panel);
+  color: var(--fg, inherit);
+}
+.invite-paste-detected { font-size: 12px; margin: 0; }
 .agenttokens { position: relative; }
 .agenttokens-btn { font-size: 13px; }
 .agenttokens-panel {


### PR DESCRIPTION
## 做什么（#297，owner「设计桌面版频道邀请进入方式，最好贴网页邀请链接共用」）

桌面 app 是 web 套 Tauri、无地址栏——收到 **web** 邀请链接（`/join/<code>` 参与 / `/c/<slug>?t=<token>` 观看，均来自 #186/#38）没法打开。加**贴网页邀请链接进入**，与网页**共用同一套链接**、不造新桌面方案。

## 实现（纯 web，复用同一链接）
- **`web/src/lib/inviteLink.ts`**（纯函数 TDD）：`parseInviteUrl(url)` → `{server, code|slug, token}`，按 #186 模式路由：`/join/<code>`→participate、`/c/<slug>?t=`→watch、`/c/<slug>`→open；拒非 http(s)/畸形/未知路径。`resolveInviteForServer(url, activeOrigin)` 加 host 校验——邀请 origin 必须等于已配对的桌面 server，否则 `wrong-host`（token 模型只对当前 server 有效）。
- **`DesktopInvitePaste.tsx`**：可折叠粘贴框 + join + 「从剪贴板检测」（用户手势读剪贴板、预填 + 「是否加入」确认，不自动 join）。剪贴板读注入以便测试。
- **接入**：`App.tsx` 侧栏 `{desktop && !isShareMode()}` 渲染——participate→`navigate('/join/<code>')` 走既有 redeem effect；watch→`applyShareToken`+open（只读，同 web `?t=`）；open→`navigate('/c/<slug>')`。**已接进 UI、非孤立组件。**

## 门禁（rebase 到最新 main 后亲验）
- web inviteLink 19 + DesktopInvitePaste 7 = 26/26；全量 520/0；tsc 0；vite build 0；rebase 无冲突。
- 变异：parser watch 丢 token（退化成 open）→ 解析测试红；resolver 关 host 校验 → 3 红；component participate 误路由 onWatch → 2 红。均复绿。

## 说明 / 未做
- 仅 **background「剪贴板变化自动弹出」**（静默轮询）需 `tauri-plugin-clipboard-manager`（Cargo dep + capability），环境跑不了 cargo check、怕弄红 CI，故未加——手势式「从剪贴板检测」在 Tauri webview 今天就能用，无原生依赖，未动任何 Rust 文件。
- 桌面 watch 邀请是临时的（share token 存 sessionStorage、桌面启动忽略浏览器 token 回配对门）——与网页观看链接是短暂只读围观一致。

🤖 opus agent 实现（前一次被我误清 worktree 困死、重派；这次组件真接进 UI）+ 我复验。
