### PR TITLE
feat(worker): serve/watch 唤醒也进服务端 ledger（广播 vs 已消费分明），补齐唤醒审计（#107）

### DIFF
--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -1964,8 +1964,10 @@ export class ChannelDO extends Server<Env> {
     if (host) this.setMeta("host", host);
   }
 
-  // 消息落库广播之后的副作用：webhook 投递 + temp 归档计时续排
+  // 消息落库广播之后的副作用：serve/watch 唤醒审计 + webhook 投递 + temp 归档计时续排
   private async afterSend(msg: MsgFrame) {
+    // #107：serve/watch 目标的 @ 广播即落 ledger（同步 SQL，不烧订阅、不发网络）——补齐它们缺失的服务端唤醒审计。
+    this.recordServeWatchWakes(msg);
     // 首投移出发送关键路径：坏/慢端点不再让每条消息阻塞 N×10s 才返回 seq（DoS 频道）
     this.ctx.waitUntil(this.dispatchWebhooks(msg));
     if (this.getMeta("ckind") === "temp" && !this.isArchived()) {
@@ -2134,6 +2136,52 @@ export class ChannelDO extends Server<Env> {
     );
   }
 
+  // #107：某 name 当前登记的 wake 层（presence.wake_kind）。无 presence / 未登记 = null。
+  private wakeKindFor(name: string): WakeKind | null {
+    const row = this.ctx.storage.sql.exec("SELECT wake_kind FROM presence WHERE name = ?", name).toArray()[0];
+    const raw = row?.wake_kind;
+    return typeof raw === "string" ? (raw as WakeKind) : null;
+  }
+
+  // #107：serve/watch 的唤醒也进服务端 ledger。webhook 由服务端主动 POST、天然可审计；serve/watch 是
+  // 拉模型——agent 自己的 loop 读广播、匹配 mentions.includes(self)，服务端从不"投递"给它们。故服务端能
+  // 诚实记录的唯一事实是：这条 @ 被广播了，且被 @ 的目标是一个已登记 serve/watch 的可唤醒 agent。记为
+  // result='broadcast'（已广播给拉客户端，**不是**"已确认消费"）。之后该 agent resume 且引用了这条 @
+  // （复用 #191 的 @->resume 观测，见 linkWakeResume）才升级为 result='consumed'。绝不因为"广播了"就声称
+  // 唤醒成功——broadcast 与 consumed 泾渭分明。adapter_kind 记 'serve'/'watch'，webhook 唤醒仍是 'webhook'。
+  private recordServeWatchWakes(msg: MsgFrame) {
+    if (msg.mentions.length === 0) return;
+    const now = Date.now();
+    const seen = new Set<string>();
+    for (const name of msg.mentions) {
+      if (seen.has(name)) continue;
+      seen.add(name);
+      const kind = this.wakeKindFor(name);
+      if (kind !== "serve" && kind !== "watch") continue;
+      // #180：被人为暂停接待的目标，webhook 一律不投；serve/watch 同理不落"已广播唤醒"行，
+      // 让"存在一条 broadcast 行" == "服务端确实把这条 @ 推给了未被抑制的可唤醒拉客户端"。
+      if (this.isPresencePaused(name)) continue;
+      // 极端情形（resume 竟先于本行落库）下也别把已闭环的唤醒错记成未消费。
+      const resume = this.findExistingWakeResume(name, msg.seq);
+      const consumed = resume.ackSeq !== null || resume.resumeSeq !== null;
+      this.ctx.storage.sql.exec(
+        `INSERT INTO wake_delivery_ledger (
+           mention_seq, target_name, webhook_name, adapter_kind, attempt,
+           result, http_status, error, attempted_at, ack_seq, resume_seq
+         )
+         VALUES (?, ?, ?, ?, 1, ?, NULL, NULL, ?, ?, ?)`,
+        msg.seq,
+        name,
+        name, // webhook_name NOT NULL：serve/watch 无 webhook，回填 target 名，审计读列时 adapter_kind 已足够区分
+        kind,
+        consumed ? "consumed" : "broadcast",
+        now,
+        resume.ackSeq,
+        resume.resumeSeq,
+      );
+    }
+  }
+
   // #108 per-agent wake 预算配置：未设 = null = 不限（正常流）。limit 存 meta，window 缺省 1 小时。
   private wakeBudgetConfig(name: string): { limit: number; windowMs: number } | null {
     const raw = this.getMeta(`wake_budget_limit:${name}`);
@@ -2153,8 +2201,10 @@ export class ChannelDO extends Server<Env> {
     return Number(
       this.ctx.storage.sql
         .exec(
+          // #107：wake 预算只计 webhook 唤醒（"烧订阅"的那一类）；serve/watch 的 broadcast/consumed 行是拉模型
+          // 的审计记录、不消耗 webhook 预算，故用 adapter_kind='webhook' 把它们排除在预算之外。
           `SELECT COUNT(*) AS n FROM wake_delivery_ledger
-            WHERE target_name = ? AND attempt = 1 AND result != 'budget' AND attempted_at >= ?`,
+            WHERE target_name = ? AND adapter_kind = 'webhook' AND attempt = 1 AND result != 'budget' AND attempted_at >= ?`,
           name,
           windowStart,
         )
@@ -2230,7 +2280,7 @@ export class ChannelDO extends Server<Env> {
     const oldest = this.ctx.storage.sql
       .exec(
         `SELECT MIN(attempted_at) AS t FROM wake_delivery_ledger
-          WHERE target_name = ? AND attempt = 1 AND result != 'budget' AND attempted_at >= ?`,
+          WHERE target_name = ? AND adapter_kind = 'webhook' AND attempt = 1 AND result != 'budget' AND attempted_at >= ?`,
         name,
         windowStart,
       )
@@ -3730,8 +3780,11 @@ export class ChannelDO extends Server<Env> {
   private linkWakeResume(targetName: string, msg: MsgFrame, now: number) {
     if (msg.reply_to !== null) {
       this.ctx.storage.sql.exec(
+        // #107：serve/watch 的 broadcast 行在观测到 @->resume 时升级为 consumed（webhook 行 result 不动，
+        // 仍是 ok/failed/budget）——"已广播"与"已确认消费"至此分明。
         `UPDATE wake_delivery_ledger
-            SET ack_seq = COALESCE(ack_seq, ?)
+            SET ack_seq = COALESCE(ack_seq, ?),
+                result = CASE WHEN adapter_kind IN ('serve', 'watch') THEN 'consumed' ELSE result END
           WHERE mention_seq = ? AND target_name = ?`,
         msg.seq,
         msg.reply_to,
@@ -3743,8 +3796,10 @@ export class ChannelDO extends Server<Env> {
     const summarySeq = msg.status?.summary_seq ?? null;
     if (summarySeq !== null) {
       this.ctx.storage.sql.exec(
+        // #107：同上，status 帧的 summary_seq 指向的 @ 若命中 serve/watch broadcast 行，同样升级为 consumed。
         `UPDATE wake_delivery_ledger
-            SET resume_seq = COALESCE(resume_seq, ?)
+            SET resume_seq = COALESCE(resume_seq, ?),
+                result = CASE WHEN adapter_kind IN ('serve', 'watch') THEN 'consumed' ELSE result END
           WHERE mention_seq = ? AND target_name = ?`,
         msg.seq,
         summarySeq,

--- a/worker/test/serve-watch-wake-ledger.spec.ts
+++ b/worker/test/serve-watch-wake-ledger.spec.ts
@@ -1,0 +1,218 @@
+// #107：serve/watch 的唤醒也要进服务端 ledger。webhook 由服务端主动投递、天然可审计；serve/watch 是
+// 拉模型（agent 自己的 loop 读广播、匹配 mentions.includes(self)），服务端不"投递"给它们。故服务端能诚实
+// 记录的事实是：一条 @ 被广播到某频道，且被 @ 的目标是已登记 serve/watch 的可唤醒 agent —— 记为
+// result='broadcast'（已广播给拉模型客户端，非"已确认消费"）。之后若该 agent resume 且引用了这条 @
+// （复用 #191 的 @→resume 观测），才升级为 result='consumed'。"已广播"与"已确认消费"泾渭分明，绝不越权声称。
+import { env, runInDurableObject } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import type { ChannelDO } from "../src/do";
+import { WsClient, api, createChannel, seedToken, uniq } from "./helpers";
+
+function sendMessage(slug: string, token: string, body: string, mentions: string[] = []) {
+  return api(`/api/channels/${slug}/messages`, token, {
+    method: "POST",
+    body: JSON.stringify({ kind: "message", body, mentions, reply_to: null }),
+  });
+}
+
+function reply(slug: string, token: string, body: string, replyTo: number, mentions: string[] = []) {
+  return api(`/api/channels/${slug}/messages`, token, {
+    method: "POST",
+    body: JSON.stringify({ kind: "message", body, mentions, reply_to: replyTo }),
+  });
+}
+
+async function ledgerRows(slug: string) {
+  const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+  return runInDurableObject(stub, async (_instance: ChannelDO, state) =>
+    state.storage.sql
+      .exec(
+        `SELECT mention_seq, target_name, webhook_name, adapter_kind, attempt,
+                result, http_status, error, ack_seq, resume_seq
+         FROM wake_delivery_ledger
+         ORDER BY id`,
+      )
+      .toArray()
+      .map((r) => ({
+        mention_seq: Number(r.mention_seq),
+        target_name: String(r.target_name),
+        webhook_name: String(r.webhook_name),
+        adapter_kind: String(r.adapter_kind),
+        attempt: Number(r.attempt),
+        result: String(r.result),
+        http_status: r.http_status === null ? null : Number(r.http_status),
+        error: r.error === null ? null : String(r.error),
+        ack_seq: r.ack_seq === null ? null : Number(r.ack_seq),
+        resume_seq: r.resume_seq === null ? null : Number(r.resume_seq),
+      })),
+  );
+}
+
+async function wakeVerifiedAt(slug: string, name: string): Promise<number | null> {
+  const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+  return runInDurableObject(stub, async (_instance: ChannelDO, state) => {
+    const row = state.storage.sql.exec("SELECT wake_verified_at FROM presence WHERE name = ?", name).toArray()[0];
+    return row === undefined || row.wake_verified_at === null || row.wake_verified_at === undefined
+      ? null
+      : Number(row.wake_verified_at);
+  });
+}
+
+// 用真实 WS status 帧把某 agent 登记成 serve/watch（服务端据此盖 presence.wake_kind）。
+async function registerWakeAgent(slug: string, token: string, kind: "serve" | "watch"): Promise<WsClient> {
+  const ws = await WsClient.open(slug, token);
+  await ws.nextOfType("welcome");
+  ws.send({ type: "send", kind: "status", state: "waiting", note: "standby", mentions: [], residency: "supervised", wake: { kind } });
+  await ws.nextOfType("sent");
+  return ws;
+}
+
+describe("#107 serve/watch wakes land in the server-side wake ledger", () => {
+  it("records a broadcast ledger row when an @ targets a registered serve agent", async () => {
+    const sender = await seedToken("agent");
+    const bot = await seedToken("agent", uniq("serve-bot"));
+    const slug = await createChannel(sender.token);
+    const botWs = await registerWakeAgent(slug, bot.token, "serve");
+
+    expect((await sendMessage(slug, sender.token, `@${bot.name} ping`, [bot.name])).status).toBe(200);
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(await ledgerRows(slug)).toEqual([
+      {
+        mention_seq: 2, // seq 1 = the serve agent's registering status frame
+        target_name: bot.name,
+        webhook_name: bot.name,
+        adapter_kind: "serve",
+        attempt: 1,
+        result: "broadcast",
+        http_status: null,
+        error: null,
+        ack_seq: null,
+        resume_seq: null,
+      },
+    ]);
+
+    // 审计 API 与 webhook 唤醒同口径可查
+    const apiRes = await api(`/api/channels/${slug}/wake-deliveries?since=1&target=${bot.name}`, sender.token);
+    expect(apiRes.status).toBe(200);
+    expect((await apiRes.json()) as { deliveries: unknown[] }).toMatchObject({
+      deliveries: [{ mention_seq: 2, target_name: bot.name, adapter_kind: "serve", result: "broadcast", ack_seq: null, resume_seq: null }],
+    });
+    botWs.close();
+  });
+
+  it("records adapter_kind='watch' for a registered watch agent", async () => {
+    const sender = await seedToken("agent");
+    const bot = await seedToken("agent", uniq("watch-bot"));
+    const slug = await createChannel(sender.token);
+    const botWs = await registerWakeAgent(slug, bot.token, "watch");
+
+    expect((await sendMessage(slug, sender.token, `@${bot.name} hey`, [bot.name])).status).toBe(200);
+    await new Promise((r) => setTimeout(r, 50));
+
+    const rows = await ledgerRows(slug);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ target_name: bot.name, adapter_kind: "watch", result: "broadcast" });
+    botWs.close();
+  });
+
+  it("does NOT record a serve/watch row for a mention with no wakeable presence", async () => {
+    const sender = await seedToken("agent");
+    const ghost = uniq("ghost"); // never registered any presence
+    const slug = await createChannel(sender.token);
+
+    expect((await sendMessage(slug, sender.token, `@${ghost} anybody?`, [ghost])).status).toBe(200);
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(await ledgerRows(slug)).toEqual([]);
+  });
+
+  it("does NOT record a serve/watch row for a wake=none agent (mutation guard: only serve/watch)", async () => {
+    const sender = await seedToken("agent");
+    const bot = await seedToken("agent", uniq("none-bot"));
+    const slug = await createChannel(sender.token);
+    const botWs = await WsClient.open(slug, bot.token);
+    await botWs.nextOfType("welcome");
+    botWs.send({ type: "send", kind: "status", state: "waiting", note: "no wake", mentions: [], wake: { kind: "none" } });
+    await botWs.nextOfType("sent");
+
+    expect((await sendMessage(slug, sender.token, `@${bot.name} ping`, [bot.name])).status).toBe(200);
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(await ledgerRows(slug)).toEqual([]);
+    botWs.close();
+  });
+
+  it("keeps result='broadcast' when the agent never resumes (broadcast != confirmed consumed)", async () => {
+    const sender = await seedToken("agent");
+    const bot = await seedToken("agent", uniq("silent-bot"));
+    const slug = await createChannel(sender.token);
+    const botWs = await registerWakeAgent(slug, bot.token, "serve");
+
+    expect((await sendMessage(slug, sender.token, `@${bot.name} ping`, [bot.name])).status).toBe(200);
+    await new Promise((r) => setTimeout(r, 50));
+
+    const rows = await ledgerRows(slug);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.result).toBe("broadcast"); // 广播了，但没有确认消费——绝不擅自升级
+    expect(rows[0]?.ack_seq).toBeNull();
+    expect(rows[0]?.resume_seq).toBeNull();
+    botWs.close();
+  });
+
+  it("marks the row consumed when the serve agent replies to the @ (reuses #191 @->resume signal)", async () => {
+    const sender = await seedToken("agent");
+    const bot = await seedToken("agent", uniq("resume-bot"));
+    const slug = await createChannel(sender.token);
+    const botWs = await registerWakeAgent(slug, bot.token, "serve");
+
+    // seq 1 = register status; seq 2 = @-mention
+    expect((await sendMessage(slug, sender.token, `@${bot.name} ping`, [bot.name])).status).toBe(200);
+    await new Promise((r) => setTimeout(r, 50));
+    // 服务端此刻只观测到广播，尚未消费
+    expect(await wakeVerifiedAt(slug, bot.name)).toBeNull();
+
+    // seq 3 = the serve agent replies to the @ -> server-observed @->resume closes the loop
+    expect((await reply(slug, bot.token, "on it", 2)).status).toBe(200);
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(await ledgerRows(slug)).toEqual([
+      {
+        mention_seq: 2,
+        target_name: bot.name,
+        webhook_name: bot.name,
+        adapter_kind: "serve",
+        attempt: 1,
+        result: "consumed",
+        http_status: null,
+        error: null,
+        ack_seq: 3,
+        resume_seq: null,
+      },
+    ]);
+    // #191：同一 @->resume 闭环也盖了 wake_verified_at —— ledger 的 consumed 与 presence 的 verified 是同源信号
+    expect(await wakeVerifiedAt(slug, bot.name)).not.toBeNull();
+    botWs.close();
+  });
+
+  it("marks the row consumed on a status resume whose summary_seq points at the @", async () => {
+    const sender = await seedToken("agent");
+    const bot = await seedToken("agent", uniq("status-bot"));
+    const slug = await createChannel(sender.token);
+    const botWs = await registerWakeAgent(slug, bot.token, "serve");
+
+    // seq 1 = register; seq 2 = @-mention
+    expect((await sendMessage(slug, sender.token, `@${bot.name} status?`, [bot.name])).status).toBe(200);
+    await new Promise((r) => setTimeout(r, 50));
+
+    // seq 3 = status frame summarizing seq 2
+    botWs.send({ type: "send", kind: "status", state: "done", note: "resumed", mentions: [], summary_seq: 2 });
+    await botWs.nextOfType("sent");
+    await new Promise((r) => setTimeout(r, 50));
+
+    const rows = await ledgerRows(slug);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ mention_seq: 2, target_name: bot.name, adapter_kind: "serve", result: "consumed", resume_seq: 3 });
+    botWs.close();
+  });
+});


### PR DESCRIPTION
## 做什么（#107，[P3][design]）

`wake_delivery_ledger` 原只覆盖 webhook 唤醒；serve/watch 的唤醒无服务端 ledger——无法审计它们是否被唤醒（#191 也标了这缺口阻塞了 serve/watch 探针失败的可观测性）。

## 怎么修（诚实的 ledger，不 overclaim）
- `recordServeWatchWakes(msg)`（afterSend、消息已落库广播后）：对每个被 @ 的、已登记 serve/watch 的可唤醒目标，写一行 ledger `adapter_kind='serve'/'watch'`、`result='broadcast'`——**诚实**：serve/watch 是拉模型，服务端能确证的只是「这条 @ 被广播了、目标是可唤醒 agent」，**不是**「已消费」。
- 该 agent 之后 **resume 且引用了这条 @**（复用 #191 的 @→resume 观测 `linkWakeResume`）→ 升为 `result='consumed'`。broadcast 与 consumed 泾渭分明，绝不因「广播了」就声称唤醒成功。
- 尊重 **#180 暂停**：被暂停目标不落 broadcast 行（同 webhook 抑制）——「有 broadcast 行」==「服务端确实把这条 @ 推给了未被抑制的可唤醒拉客户端」。
- 协调 **#108 wake 预算**：预算只计 `adapter_kind='webhook'`（烧订阅那类），serve/watch 的 broadcast/consumed 行不入预算（拉模型不烧对方订阅）。
- 经既有 wake-deliveries 审计 API 可查，serve/watch 唤醒与 webhook 一样可审计。

## 门禁（对 origin HEAD rebase 到含 #108 的 main 后亲验）
- worker serve-watch-wake-ledger 8/8 + wake-budget 6/6（**#108 无回归**，adapter_kind='webhook' 限定生效）；worker tsc 0；rebase 无冲突。
- 变异：`recordServeWatchWakes` 空转 → #107 spec 红。复绿。

🤖 opus agent 实现（诚实区分 broadcast/consumed、复用 #191、协调 #108/#180）、收尾截断我接管（审+提交+复验）。
