### PR TITLE
feat(worker,cli): 同名 serve 跨机租约/互斥，重复执行不再零护栏（#99 跨机那半）

### DIFF
--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -1498,6 +1498,12 @@ export async function runServe(o: ServeOptions): Promise<number> {
   // 人为暂停接待（#180）：服务端对 webhook 已抑制，但 serve 是本地 supervisor、消息照样广播给它。
   // 收到自己的 paused presence 帧就自我抑制唤醒——被 @ 也不触发 runner，直到收到恢复帧。消息仍进历史。
   let selfPaused = false;
+  // 同名 serve 跨机租约（#99）：同机单实例锁（上文）只挡本机；跨机器两台 serve 各连一条 WS，服务端广播
+  // 把每条 @ 发给同名所有连接 → 两台都跑完整 runner。修复：挂上后向服务端 claim 租约，只有持租的那台跑
+  // runner。hasLease 默认 true（老服务端不认租约、从不下发 serve_lease → 保持旧行为不回归）；收到
+  // held=false 转 standby（被 @ 也不跑，消息仍进历史、游标照推进），held=true（持租/顶替）恢复响应。
+  let hasLease = true;
+  let leaseKnown = false; // 是否至少收到过一次 serve_lease（用于只在真 standby 时打印提示）
   let charter: ChannelCharter | null = o.charter ?? null;
   const refreshCharter = async (reason: string, expectedRev?: number) => {
     if (!o.fetchCharter) return;
@@ -1533,6 +1539,10 @@ export async function runServe(o: ServeOptions): Promise<number> {
       writeHealthCache({ channel: o.channel, last_frame_at: Date.now() });
       if (frame.type === "welcome") {
         self = frame.self;
+        // 挂上/重连即向服务端 claim serve 租约（#99）。best-effort：ws 此刻是 OPEN，claim 会送出；
+        // 服务端在同名多条 serve 里选唯一持租者并回 serve_lease。老服务端不认识它、直接忽略（hasLease
+        // 默认 true → 旧行为）。重连每次 welcome 都重新 claim（连接换了，租约候选身份也换了）。
+        conn.send({ type: "serve_lease", op: "claim" });
         // 连上时若自己已被暂停接待（#180），从 welcome 的 presence 快照里认出来——重连也不误唤醒。
         const mine = frame.presence?.find((p) => p.name === self);
         selfPaused = mine?.paused === true;
@@ -1605,6 +1615,24 @@ export async function runServe(o: ServeOptions): Promise<number> {
           );
         }
       }
+      // 同名 serve 跨机租约（#99）：服务端在同名多条 serve 连接里选唯一持租者，用这帧告诉本连接是否持租。
+      // 只有持租的那台跑 runner；held=false 转 standby（下方 qualifies 拦住 runner），持租者掉线后服务端
+      // 补发 held=true 让 standby 顶上。跨进程互斥点在服务端——本地只是遵从它的裁决。
+      if (frame.type === "serve_lease" && frame.name === self) {
+        const next = frame.held === true;
+        if (!leaseKnown || next !== hasLease) {
+          hasLease = next;
+          out(
+            hasLease
+              ? leaseKnown
+                ? "serve: 取得 serve 租约——本台顶替，开始响应 @（同名另一台已让出/掉线）。"
+                : "serve: 持有 serve 租约——本台负责跑 runner。"
+              : "serve: 未持有 serve 租约（同名另一台 serve 在跑）——本台转 standby：被 @ 也不跑 runner，消息仍进历史；持租者掉线后自动顶替。",
+          );
+        }
+        leaseKnown = true;
+        continue;
+      }
       if (frame.type !== "msg") continue;
       const fromSelf = frame.sender.name === self;
       // fresh = 游标之上的新消息。历史修订快照会穿透去重被重放（seq 早已消费过），
@@ -1629,7 +1657,12 @@ export async function runServe(o: ServeOptions): Promise<number> {
       if (wouldWake && selfPaused) {
         out(`⏸ 暂停中，跳过唤醒（消息仍在历史）: ${formatMsg(frame)}`);
       }
-      const qualifies = wouldWake && !selfPaused;
+      // 未持租（#99）：同名另一台 serve 在跑，本台是 standby——被 @ 也不跑 runner，但消息照进 recent/历史、
+      // 游标照推进（下方 ack），与暂停接待同路径。持租者掉线后收到 held=true 再从新消息开始响应。
+      if (wouldWake && !selfPaused && !hasLease) {
+        out(`▷ standby（未持有 serve 租约），跳过唤醒（消息仍在历史）: ${formatMsg(frame)}`);
+      }
+      const qualifies = wouldWake && !selfPaused && hasLease;
       if (qualifies) {
         out(`▶ ${formatMsg(frame)}`);
         // 串行：本条命令跑完再消费下一帧（新帧此间缓冲在 FrameQueue），避免并发唤起互相抢

--- a/cli/test/serve-cross-machine-lease.test.ts
+++ b/cli/test/serve-cross-machine-lease.test.ts
@@ -1,0 +1,118 @@
+// issue #99 跨机那半（客户端侧）：serve 挂上后向服务端 claim serve 租约；只有服务端回 held=true 的那台
+// 才跑 runner。收到 held=false（另一台在跑）就转 standby：被 @ 也不触发 runner，消息仍进历史、游标照推进
+// （与 #180 暂停接待同路径）。持租者掉线后服务端补发 held=true，standby 顶上开始跑。老服务端不认租约、
+// 从不下发 serve_lease → 客户端默认持租（held 未知即照跑），不回归。
+import { afterEach, describe, expect, test } from "bun:test";
+import type { ClientFrame } from "@agentparty/shared";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runServe, type ServeOptions } from "../src/commands/serve";
+import { msgFrame, startMockServer, welcomeFrame, type MockServer } from "./mock-server";
+
+let server: MockServer | null = null;
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  server?.stop();
+  server = null;
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function opts(over: Partial<ServeOptions> & { server: string }): ServeOptions & { lines: string[] } {
+  const lines: string[] = [];
+  const lockDir = mkdtempSync(join(tmpdir(), "ap-lock-"));
+  tempDirs.push(lockDir);
+  return {
+    token: "ap_tok",
+    channel: "dev",
+    since: 0,
+    cmd: "true",
+    mentionsOnly: true,
+    out: (line) => lines.push(line),
+    lines,
+    lockDir,
+    ...over,
+  };
+}
+
+function leaseFrame(held: boolean, name = "me") {
+  return { type: "serve_lease", name, held };
+}
+
+describe("serve 跨机租约客户端互斥（#99）", () => {
+  test("held=false（另一台持租）：@我 不跑 runner，但游标仍推进（standby）", async () => {
+    let ran = 0;
+    const cursors: number[] = [];
+    server = startMockServer((frame, sock) => {
+      if (frame.type !== "hello") return;
+      sock.send(welcomeFrame(0, "me"));
+      setTimeout(() => sock.send(leaseFrame(false)), 20);
+      setTimeout(() => sock.send(msgFrame(1, "@me wake up", { mentions: ["me"] })), 40);
+      setTimeout(() => sock.send({ type: "error", code: "archived", message: "done" }), 80);
+    });
+    const o = opts({ server: server.url, onCursor: (c) => cursors.push(c), runCommand: async () => { ran++; } });
+    await runServe(o);
+    expect(ran).toBe(0); // 不持租：runner 一次都没跑
+    expect(cursors).toContain(1); // 消息仍被消费、游标推进（不留欠账）
+    expect(o.lines.some((l) => l.includes("standby") || l.includes("租约"))).toBe(true);
+  });
+
+  test("held=true（本台持租）：@我 正常唤醒 runner", async () => {
+    let ran = 0;
+    server = startMockServer((frame, sock) => {
+      if (frame.type !== "hello") return;
+      sock.send(welcomeFrame(0, "me"));
+      setTimeout(() => sock.send(leaseFrame(true)), 20);
+      setTimeout(() => sock.send(msgFrame(1, "@me wake up", { mentions: ["me"] })), 40);
+      setTimeout(() => sock.send({ type: "error", code: "archived", message: "done" }), 80);
+    });
+    const o = opts({ server: server.url, runCommand: async () => { ran++; } });
+    await runServe(o);
+    expect(ran).toBe(1);
+  });
+
+  test("takeover：先 held=false 跳过，收到 held=true 后的 @ 才跑", async () => {
+    let ran = 0;
+    server = startMockServer((frame, sock) => {
+      if (frame.type !== "hello") return;
+      sock.send(welcomeFrame(0, "me"));
+      setTimeout(() => sock.send(leaseFrame(false)), 15);
+      setTimeout(() => sock.send(msgFrame(1, "@me while standby", { mentions: ["me"] })), 30);
+      setTimeout(() => sock.send(leaseFrame(true)), 45);
+      setTimeout(() => sock.send(msgFrame(2, "@me after takeover", { mentions: ["me"] })), 60);
+      setTimeout(() => sock.send({ type: "error", code: "archived", message: "done" }), 100);
+    });
+    const o = opts({ server: server.url, runCommand: async () => { ran++; } });
+    await runServe(o);
+    expect(ran).toBe(1); // 只跑了 takeover 之后的那条
+  });
+
+  test("老服务端从不下发 serve_lease：客户端默认持租，照常唤醒（不回归）", async () => {
+    let ran = 0;
+    server = startMockServer((frame, sock) => {
+      if (frame.type !== "hello") return;
+      sock.send(welcomeFrame(0, "me"));
+      setTimeout(() => sock.send(msgFrame(1, "@me wake up", { mentions: ["me"] })), 30);
+      setTimeout(() => sock.send({ type: "error", code: "archived", message: "done" }), 70);
+    });
+    const o = opts({ server: server.url, runCommand: async () => { ran++; } });
+    await runServe(o);
+    expect(ran).toBe(1);
+  });
+
+  test("serve 挂上后向服务端 claim 租约（welcome 后发 serve_lease op=claim）", async () => {
+    const clientFrames: ClientFrame[] = [];
+    server = startMockServer((frame, sock) => {
+      clientFrames.push(frame);
+      if (frame.type !== "hello") return;
+      sock.send(welcomeFrame(0, "me"));
+      setTimeout(() => sock.send({ type: "error", code: "archived", message: "done" }), 40);
+    });
+    const o = opts({ server: server.url, runCommand: async () => {} });
+    await runServe(o);
+    const claim = clientFrames.find((f) => (f as { type: string }).type === "serve_lease");
+    expect(claim).toBeDefined();
+    expect((claim as { op?: string }).op).toBe("claim");
+  });
+});

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -376,6 +376,13 @@ export interface PresenceEntry {
   /** 排在当前 wake 身后、尚未处理的 wake 数（issue #103）。仅 state != offline 且 >0 时下发。 */
   queue_depth?: number;
   /**
+   * 同名多机 serve 里，除持租者外仍挂着、处于 standby 的 serve 连接数（issue #99）。DO 从活连接里的
+   * serve 租约候选权威判定：候选数 N ≥ 2 时下发 N-1（有几台在待命顶替），否则省略。用途：who / web
+   * 一眼看出「这个 name 有重复 serve，但只有 1 台在真正跑 runner」——把过去只能靠 connection_count x2
+   * 猜测的重复执行风险，明确成「已被租约互斥、其余在 standby」。旧客户端忽略。
+   */
+  serve_standbys?: number;
+  /**
    * 当前正在处理的那条 wake 的触发 seq（reply_to / @ 的 seq）（issue #228，扩 #103 busy）。
    * serve 处理一条长任务期间用轻量、presence-only 的 heartbeat 帧刷这三个字段：正在处理哪条、何时开始、
    * 最近一次心跳。用途：who/web 区分「还在干、活到 T」与「卡死」——busy 只说「在忙」，这里说「在忙哪一条、活没活」。
@@ -621,7 +628,15 @@ export interface HeartbeatFrame {
   heartbeat_at: number | null;
 }
 
-export type ClientFrame = HelloFrame | SendFrame | PingFrame | SeenFrame | HeartbeatFrame;
+// 同名 serve 跨机租约（#99）：一个 serve 连接声明「我是这个 name 的 serve runner，想当唯一在跑的那个」。
+// 服务端据此在同名的多条 serve 连接里选出唯一持租者，并回 ServeLeaseFrame 告知各连接是否持租。
+// 只有 serve 型 supervisor 发它；watch / webhook / 人类连接都不发。op 目前恒为 "claim"（断连即隐式释放）。
+export interface ServeLeaseClaimFrame {
+  type: "serve_lease";
+  op: "claim";
+}
+
+export type ClientFrame = HelloFrame | SendFrame | PingFrame | SeenFrame | HeartbeatFrame | ServeLeaseClaimFrame;
 
 // ---- 服务端 → 客户端帧 ----
 
@@ -1258,6 +1273,17 @@ export interface PongFrame {
   type: "pong";
 }
 
+// 同名 serve 跨机租约（#99）：服务端告诉某条 serve 连接它此刻是否持租。
+// held=true 的那条才跑 runner；held=false 的转入 standby（被 @ 也不跑，消息仍进历史、游标照推进）。
+// 持租者断连 / 心跳超时（presence 60s 扫描）后，服务端把租约转给下一条 standby 并补发 held=true。
+export interface ServeLeaseFrame {
+  type: "serve_lease";
+  /** 本连接所属身份 name。 */
+  name: string;
+  /** 本连接此刻是否持有该 name 的 serve 租约（唯一在跑的那个）。 */
+  held: boolean;
+}
+
 export type ServerFrame =
   | WelcomeFrame
   | ParticipantsFrame
@@ -1267,4 +1293,5 @@ export type ServerFrame =
   | PresenceFrame
   | ReadCursorFrame
   | ErrorFrame
-  | PongFrame;
+  | PongFrame
+  | ServeLeaseFrame;

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -85,6 +85,13 @@ interface ConnState {
   collabRoleSource?: CollaborationRoleSource;
   archived: boolean;
   lastSeen: number;
+  // 同名 serve 跨机租约（#99）：本连接是否 claim 过 serve 租约（是一条 serve runner）。
+  serveCandidate?: boolean;
+  // claim 时分配的单调序号（meta 计数器）。同名多条候选里最小序号者持租——序号在首次 claim 定死、
+  // 重连/重复 claim 不变，故持租者掉线后由"次早"顶上，重连的原持租者拿到更大序号、不抢回（软租约）。
+  serveClaimSeq?: number;
+  // 上次已通告给本连接的持租状态，用于去重：只在 held 变化时才补发 serve_lease 帧。
+  serveLeaseHeld?: boolean;
 }
 
 interface Identity {
@@ -1464,6 +1471,16 @@ export class ChannelDO extends Server<Env> {
       if (hb !== null) this.applyTaskHeartbeat(st.name, hb);
       return;
     }
+    if (frame.type === "serve_lease" && frame.op === "claim") {
+      // 同名 serve 跨机租约（#99）：本连接声明它是一条 serve runner，想当唯一在跑的那个。
+      // 首次 claim 定死一个单调序号（重复 claim 不改，避免重连者用更小序号抢回租约）；随后在同名候选里
+      // 选最小序号者持租，回 serve_lease 告知各连接是否持租。断连/心跳超时由 onClose/scanPresence 触发改选。
+      if (!st.serveCandidate) {
+        st = connection.setState({ ...st, serveCandidate: true, serveClaimSeq: this.nextServeClaimSeq() }) ?? st;
+      }
+      this.reconcileServeLease(st.name);
+      return;
+    }
     if (frame.type === "send") {
       if (st.archived || this.isArchived()) {
         this.sendFrame(connection, { type: "error", code: "archived", message: "channel is archived" });
@@ -1515,6 +1532,9 @@ export class ChannelDO extends Server<Env> {
   onClose(connection: Connection<ConnState>) {
     const st = connection.state;
     if (!st || !st.name || st.archived) return;
+    // 同名 serve 跨机租约（#99）：持租者/候选断连 → 重选，让下一条 standby 顶上（补发 held=true）。
+    // 排除正在关闭的这条（getConnections 可能仍返回它）。非 serve 连接不触发。
+    if (st.serveCandidate) this.reconcileServeLease(st.name, connection.id);
     for (const other of this.getConnections<ConnState>()) {
       if (other.id !== connection.id && other.state?.name === st.name) {
         this.broadcastFrame({ type: "participants", participants: this.participants() });
@@ -1552,8 +1572,11 @@ export class ChannelDO extends Server<Env> {
       if (now - last >= PRESENCE_TIMEOUT_MS) stale.push(connection);
       else live++;
     }
+    // 同名 serve 跨机租约（#99）：心跳超时的持租者，其连接在这里被关；关掉后要重选租约让 standby 顶上。
+    const staleServeNames = new Set<string>();
     for (const connection of stale) {
       const name = connection.state?.name;
+      if (connection.state?.serveCandidate && name) staleServeNames.add(name);
       connection.close(1001, "heartbeat timeout");
       if (!name) continue;
       // getConnections 只回 open 的连接，刚 close 的不算
@@ -1566,6 +1589,8 @@ export class ChannelDO extends Server<Env> {
       }
       if (gone) this.markOffline(name, now);
     }
+    // 已 close 的陈旧连接不在 getConnections 里，直接重选：存活的候选里最早的顶上、补发 held=true。
+    for (const name of staleServeNames) this.reconcileServeLease(name);
     if (stale.length > 0) {
       this.broadcastFrame({ type: "participants", participants: this.participants() });
     }
@@ -4405,6 +4430,60 @@ export class ChannelDO extends Server<Env> {
     return counts;
   }
 
+  // ---- 同名 serve 跨机租约（issue #99）----
+  // 同机单实例锁（CLI src/instance-lock.ts，#237）只挡本机；跨机器两台 serve 各连一条 WS，广播把每条 @
+  // 发给同名所有连接 → 都跑完整 runner、双份副作用。这里在服务端做互斥：同名 serve 连接各自 claim，只有
+  // claim 最早（序号最小）的那条持租、跑 runner；其余转 standby。持租者断连/心跳超时后自动让下一条顶上。
+
+  // claim 时从单调计数器取一个序号：越早 claim 越小。序号首次 claim 后定死，故持租者掉线由"次早"顶替、
+  // 重连的原持租者拿到更大序号不抢回（软租约）。计数器落 meta，DO hibernate 也不丢。
+  private nextServeClaimSeq(): number {
+    const next = (Number(this.getMeta("serve_claim_seq") ?? "0") || 0) + 1;
+    this.setMeta("serve_claim_seq", String(next));
+    return next;
+  }
+
+  // 同名的活 serve 候选连接，按 claim 序号升序（并列用 connection.id 兜底稳定）。excludeId 供 onClose 用：
+  // 正在关闭的连接 getConnections 可能仍返回，但它已不该参与选举。
+  private serveLeaseCandidates(name: string, excludeId?: string): Connection<ConnState>[] {
+    const list: Connection<ConnState>[] = [];
+    for (const c of this.getConnections<ConnState>()) {
+      if (c.id === excludeId) continue;
+      const st = c.state;
+      if (st?.serveCandidate && st.name === name) list.push(c);
+    }
+    list.sort((a, b) => {
+      const sa = a.state?.serveClaimSeq ?? Number.MAX_SAFE_INTEGER;
+      const sb = b.state?.serveClaimSeq ?? Number.MAX_SAFE_INTEGER;
+      return sa !== sb ? sa - sb : a.id.localeCompare(b.id);
+    });
+    return list;
+  }
+
+  // 选出唯一持租者（序号最小），给每条候选连接补发它此刻是否持租——只在 held 相对上次变化时才发（去重）。
+  private reconcileServeLease(name: string, excludeId?: string) {
+    const candidates = this.serveLeaseCandidates(name, excludeId);
+    const holderId = candidates[0]?.id;
+    for (const c of candidates) {
+      const st = c.state;
+      if (!st) continue;
+      const held = c.id === holderId;
+      if (st.serveLeaseHeld === held) continue;
+      c.setState({ ...st, serveLeaseHeld: held });
+      this.sendFrame(c, { type: "serve_lease", name, held });
+    }
+  }
+
+  // 每个 name 的 serve 候选连接数（含持租者）。用于 presence 暴露 standby 数（候选数 - 1）。
+  private serveCandidateCounts(): Map<string, number> {
+    const counts = new Map<string, number>();
+    for (const c of this.getConnections<ConnState>()) {
+      const st = c.state;
+      if (st?.serveCandidate && st.name) counts.set(st.name, (counts.get(st.name) ?? 0) + 1);
+    }
+    return counts;
+  }
+
   private getMeta(key: string): string | null {
     const rows = this.ctx.storage.sql.exec("SELECT value FROM meta WHERE key = ?", key).toArray();
     return rows.length > 0 ? String(rows[0]!.value) : null;
@@ -4446,27 +4525,37 @@ export class ChannelDO extends Server<Env> {
 
   private presenceList(): PresenceEntry[] {
     const liveCounts = this.liveConnectionCounts();
+    const serveCounts = this.serveCandidateCounts();
     return this.ctx.storage.sql
       .exec(`SELECT ${ChannelDO.PRESENCE_COLUMNS} FROM presence ORDER BY name`)
       .toArray()
-      .map((r) => this.withLivePresence(this.presenceRowToEntry(r), liveCounts));
+      .map((r) => this.withLivePresence(this.presenceRowToEntry(r), liveCounts, serveCounts));
   }
 
   private presenceFor(name: string): PresenceEntry | null {
     const liveCounts = this.liveConnectionCounts();
+    const serveCounts = this.serveCandidateCounts();
     const rows = this.ctx.storage.sql
       .exec(`SELECT ${ChannelDO.PRESENCE_COLUMNS} FROM presence WHERE name = ?`, name)
       .toArray();
-    return rows.length > 0 ? this.withLivePresence(this.presenceRowToEntry(rows[0]!), liveCounts) : null;
+    return rows.length > 0 ? this.withLivePresence(this.presenceRowToEntry(rows[0]!), liveCounts, serveCounts) : null;
   }
 
   // issue #97：presence 序列化时用「当前有无活 WS 连接」在读侧修正可达性/离线，再叠加重复连接计数。
   // 有活连接 → applyLiveConnection 打 live=true、offline 提升为 waiting（不改写 ts/last_seen，故 host 租约
   // 判定完全不受影响，详见 shared 注释）；无活连接 → 原样返回。connection_count 语义照旧（仅 >1 时下发）。
-  private withLivePresence(entry: PresenceEntry, liveCounts: Map<string, number>): PresenceEntry {
+  private withLivePresence(
+    entry: PresenceEntry,
+    liveCounts: Map<string, number>,
+    serveCounts?: Map<string, number>,
+  ): PresenceEntry {
     const count = liveCounts.get(entry.name) ?? 0;
     const live = applyLiveConnection(entry, count > 0);
-    return count > 1 ? { ...live, connection_count: count } : live;
+    const withCount = count > 1 ? { ...live, connection_count: count } : live;
+    // 同名 serve standby 数（#99）：serve 候选连接数 - 1 持租者。>0 才下发（有几台在待命顶替），让 who/web
+    // 一眼看出"重复 serve 但已被租约互斥、只有 1 台在跑"，而不是只能靠 connection_count x2 猜。
+    const standbys = (serveCounts?.get(entry.name) ?? 0) - 1;
+    return standbys > 0 ? { ...withCount, serve_standbys: standbys } : withCount;
   }
 
   private presenceRowToEntry(r: Record<string, unknown>): PresenceEntry {

--- a/worker/test/serve-lease-cross-machine.spec.ts
+++ b/worker/test/serve-lease-cross-machine.spec.ts
@@ -1,0 +1,138 @@
+// issue #99 跨机那半：同名多个 serve（工位机 + 家里机各一）都连着同一频道，服务端广播把每条 @ 发给
+// 所有同名连接 → 旧行为下两台都跑完整 runner、双份回帖、git push 类副作用执行两遍。同机单实例锁（#237，
+// 本地 pid 锁）挡不住跨机器。这里补服务端 serve 租约：同名 serve 连接各自 claim，服务端只让最早 claim 的
+// 那条持租（held=true）、其余转 standby（held=false）；持租者断连后租约转给下一条 standby（held=true）。
+// 只有持租的那条才跑 runner —— 重复执行被服务端互斥掉，而不只是事后在 who 里看见 x2。
+import type { PresenceEntry, ServeLeaseFrame } from "@agentparty/shared";
+import { describe, expect, it } from "vitest";
+import { WsClient, api, createChannel, seedToken } from "./helpers";
+
+async function claimServeLease(ws: WsClient): Promise<ServeLeaseFrame> {
+  ws.send({ type: "serve_lease", op: "claim" });
+  return ws.nextOfType("serve_lease");
+}
+
+async function fetchPresence(slug: string, token: string): Promise<PresenceEntry[]> {
+  const res = await api(`/api/channels/${slug}/presence`, token);
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as { presence: PresenceEntry[] };
+  return body.presence;
+}
+
+describe("同名 serve 跨机租约（issue #99）", () => {
+  it("两条同名 serve 都 claim：最早 claim 的持租，第二条转 standby（held=false）", async () => {
+    const agent = await seedToken("agent");
+    const slug = await createChannel(agent.token);
+
+    const first = await WsClient.open(slug, agent.token);
+    await first.nextOfType("welcome");
+    const firstLease = await claimServeLease(first);
+    expect(firstLease.held).toBe(true);
+    expect(firstLease.name).toBe(agent.name);
+
+    const second = await WsClient.open(slug, agent.token);
+    await second.nextOfType("welcome");
+    const secondLease = await claimServeLease(second);
+    // 关键互斥：第二条同名 serve 不持租 → 它不会跑 runner，跨机重复执行被挡住
+    expect(secondLease.held).toBe(false);
+    expect(secondLease.name).toBe(agent.name);
+
+    first.close();
+    second.close();
+  });
+
+  it("持租者断连：租约转给 standby，补发 held=true（takeover）", async () => {
+    const agent = await seedToken("agent");
+    const human = await seedToken("human");
+    const slug = await createChannel(agent.token);
+
+    // 人类观察者常驻，用它的 presence 帧同步 onClose 时机，避免竞态
+    const watcher = await WsClient.open(slug, human.token);
+    await watcher.nextOfType("welcome");
+
+    const holder = await WsClient.open(slug, agent.token);
+    await holder.nextOfType("welcome");
+    expect((await claimServeLease(holder)).held).toBe(true);
+
+    const standby = await WsClient.open(slug, agent.token);
+    await standby.nextOfType("welcome");
+    expect((await claimServeLease(standby)).held).toBe(false);
+
+    // 持租者掉线（进程被 kill / 网络断） → 服务端把租约让给 standby
+    holder.close();
+    const takeover = await standby.nextOfType("serve_lease");
+    expect(takeover.held).toBe(true);
+
+    standby.close();
+    watcher.close();
+  });
+
+  it("standby 顶替后原持租者重连：baton 不被抢回，新连接进 standby（软租约）", async () => {
+    const agent = await seedToken("agent");
+    const human = await seedToken("human");
+    const slug = await createChannel(agent.token);
+    const watcher = await WsClient.open(slug, human.token);
+    await watcher.nextOfType("welcome");
+
+    const holder = await WsClient.open(slug, agent.token);
+    await holder.nextOfType("welcome");
+    expect((await claimServeLease(holder)).held).toBe(true);
+    const standby = await WsClient.open(slug, agent.token);
+    await standby.nextOfType("welcome");
+    expect((await claimServeLease(standby)).held).toBe(false);
+
+    holder.close();
+    expect((await standby.nextOfType("serve_lease")).held).toBe(true); // standby 顶上
+
+    // 原持租者重连并重新 claim：当前 standby 正持租且在跑，重连者不该抢回租约（否则两台抢跑）
+    const rejoin = await WsClient.open(slug, agent.token);
+    await rejoin.nextOfType("welcome");
+    expect((await claimServeLease(rejoin)).held).toBe(false);
+
+    standby.close();
+    rejoin.close();
+    watcher.close();
+  });
+
+  it("/presence 暴露 serve standby 数：同名 2 台 serve → serve_standbys=1", async () => {
+    const agent = await seedToken("agent");
+    const human = await seedToken("human");
+    const slug = await createChannel(agent.token);
+    // 人类观察者常驻，用它的 participants 帧同步第二台断连的 onClose 时机，避免竞态。
+    const watcher = await WsClient.open(slug, human.token);
+    await watcher.nextOfType("welcome");
+
+    const first = await WsClient.open(slug, agent.token);
+    await first.nextOfType("welcome");
+    expect((await claimServeLease(first)).held).toBe(true);
+    // 真实 serve 挂上即 advertise 一条 status（residency=supervised、wake=serve）→ 建 presence 行。
+    first.send({
+      type: "send",
+      kind: "status",
+      state: "waiting",
+      note: "serving",
+      mentions: [],
+      residency: "supervised",
+      wake: { kind: "serve", verified_at: 1 },
+    });
+    await first.nextOfType("sent");
+    const second = await WsClient.open(slug, agent.token);
+    await second.nextOfType("welcome");
+    expect((await claimServeLease(second)).held).toBe(false);
+
+    const list = await fetchPresence(slug, agent.token);
+    const me = list.find((p) => p.name === agent.name)!;
+    expect(me).toBeDefined();
+    expect(me.serve_standbys).toBe(1);
+
+    // 只剩一台 serve：standby 数归零（省略）。等 watcher 收到断连引发的 participants 帧，确保 onClose 已结算。
+    second.close();
+    await watcher.nextOfType("participants");
+    const soloList = await fetchPresence(slug, agent.token);
+    const solo = soloList.find((p) => p.name === agent.name)!;
+    expect(solo.serve_standbys).toBeUndefined();
+
+    first.close();
+    watcher.close();
+  });
+});


### PR DESCRIPTION
## 做什么（#99，[P2][design]，跨机那半）

同名 serve 多进程无租约/互斥 → 重复执行。**同机那半已由 11b08c4 解决**（本地单实例锁）；本 PR 补**跨机**：不同机器上两个 serve 同名，原本都唤醒、都跑同一 @、重复劳动。

## 实现（服务端租约）
- **服务端租约**：serve 挂载时 `serve_lease claim`，DO 的 `reconcileServeLease` 选**最小连接序号**者持租，回 `serve_lease{held}` 帧告知各连接是否持租。心跳/断连（onClose / scanPresence 陈旧连接）触发**改选**——持租者/候选断连，下一条 standby 顶上（补发 held=true）。
- **serve 端**：非持租者**不跑 runner**（standby 待命），只有持租者响应 @；持租者死（连接断/心跳停）→ standby 自动顶上；原持租者回来重新竞选。去重：只在 held 变化时补发帧。
- 保留同机锁（11b08c4）不变，这是其上的跨机层。

## 门禁（对 origin HEAD rebase 到最新 main 后亲验）
- worker serve-lease-cross-machine 4/4；cli 5/5；shared/worker/cli tsc 0；rebase 无冲突（lease 逻辑与并行的 #107 ledger 区不重叠）。
- 变异：`reconcileServeLease` 让所有候选都 held（互斥失效）→ 唯一持租测试红。复绿。

🤖 opus agent 实现（服务端租约+standby 顶替+改选）、收尾截断我接管（审+rebase+复验）。
