### PR TITLE
chore(ci): 加 Dependabot + CI bun audit，依赖树自动更新与漏洞告警（#137 供应链）

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,63 @@
+# #137 供应链输入侧：产物侧（release.yml 的 cosign + provenance）已经不错，
+# 输入侧（依赖树自动更新 + 漏洞告警）在此之前完全空白——.github/ 下只有
+# workflows/，没有任何 dependabot/renovate 配置。这个文件补上。
+#
+# 覆盖三个生态：
+#   - bun：单一 workspace 根 lockfile（bun.lock）管住 worker/cli/shared/web/desktop
+#     五个 workspace 成员，Dependabot 从根 "/" 一个入口就能解析全部 package.json。
+#   - cargo：desktop/src-tauri 是唯一的 Rust crate（Tauri 桌面壳）。
+#   - github-actions：.github/workflows/*.yml + .github/actions/*/action.yml 里
+#     引用的 actions（actions/checkout、sigstore/cosign-installer 等）。
+#
+# 分组 minor/patch 减噪音——一周最多几个 PR 而不是逐包轰炸；major 版本不分组，
+# 单独出 PR 走人工审（避免自动合入破坏性升级）。
+version: 2
+updates:
+  - package-ecosystem: "bun"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "cargo"
+    directory: "/desktop/src-tauri"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore(ci)"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,6 +117,37 @@ jobs:
       - working-directory: worker
         run: bunx tsc --noEmit
 
+  # ── #137 供应链输入侧：bun audit 扫 bun.lock 依赖树已知漏洞 ──────────
+  # 只在 PR 上跑，且不进 "full check" 的 needs——bun audit 命中的公开漏洞库
+  # 会随时间变化，把它塞进 required 门禁等于让历史 PR 因为无关的第三方新
+  # CVE 突然变红。先让结果在 job 日志/summary 里可见，观察一段时间稳定后
+  # 再考虑收紧成阻断项。
+  dependency-audit:
+    name: dependency audit (bun audit)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/bun-install
+      - name: bun audit
+        run: |
+          set +e
+          bun audit 2>&1 | tee bun-audit.log
+          status="${PIPESTATUS[0]}"
+          set -e
+          {
+            echo "## bun audit (#137，非阻断)"
+            echo '```'
+            cat bun-audit.log
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ "$status" -ne 0 ]; then
+            echo "::warning::bun audit reported findings (exit $status) — non-blocking, see job summary"
+          fi
+          exit 0
+
   # 发布版本契约：只在 tag 上校验 tag == CLI / desktop JS / desktop Rust 版本。
   # 非 tag 时 skip（聚合门禁把 skipped 当通过）。
   version-contract:

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "license": "BUSL-1.1",
   "private": true,
   "scripts": {
-    "check:scripts": "sh -n install.sh && sh -n install-desktop.sh && bun scripts/check-migration-numbering.ts && bun test scripts/release-version.test.ts scripts/desktop-update-manifest.test.ts scripts/desktop-release-workflow.test.ts scripts/apple-signing-mode.test.ts scripts/configure-apple-release.test.ts scripts/prepare-desktop-sidecar.test.ts scripts/desktop-production-acceptance.test.ts scripts/desktop-pairing-smoke.test.ts scripts/install.test.ts scripts/install-desktop.test.ts scripts/check-aggregate.test.ts scripts/ci-paths-filter.test.ts scripts/check-migration-numbering.test.ts && bunx tsc --project scripts/tsconfig.json",
+    "check:scripts": "sh -n install.sh && sh -n install-desktop.sh && bun scripts/check-migration-numbering.ts && bun test scripts/release-version.test.ts scripts/desktop-update-manifest.test.ts scripts/desktop-release-workflow.test.ts scripts/apple-signing-mode.test.ts scripts/configure-apple-release.test.ts scripts/prepare-desktop-sidecar.test.ts scripts/desktop-production-acceptance.test.ts scripts/desktop-pairing-smoke.test.ts scripts/install.test.ts scripts/install-desktop.test.ts scripts/check-aggregate.test.ts scripts/ci-paths-filter.test.ts scripts/check-migration-numbering.test.ts scripts/supply-chain-deps.test.ts && bunx tsc --project scripts/tsconfig.json",
     "check:cli": "cd cli && bun test && bunx tsc --noEmit",
     "check:shared": "cd shared && bunx tsc --noEmit",
     "check:web": "cd web && bun test && bunx tsc --noEmit && bunx vite build",

--- a/scripts/supply-chain-deps.test.ts
+++ b/scripts/supply-chain-deps.test.ts
@@ -1,0 +1,105 @@
+// #137 供应链输入侧：产物侧（release.yml 的 cosign sign-blob + attest-build-provenance）
+// 之前就做得不错，输入侧（依赖树自动更新 + 漏洞告警）是空白——.github/ 下只有
+// workflows/，没有 dependabot/renovate 配置，"full check" 也没有 bun audit/lockfile
+// 审计步骤。这里补两件事并守住不变量：
+//   1. .github/dependabot.yml 存在、是合法 YAML、覆盖 bun/cargo/github-actions 三个生态。
+//   2. release.yml 有一个 bun audit 步骤，且它不进 "full check" 的 needs（非阻断，
+//      不能因为第三方新披露的 CVE 让历史 PR 突然变红）。
+//
+// YAML 解析用 Bun 内置的 Bun.YAML.parse（bun runtime 自带，无需额外依赖），
+// 不是字符串猜测——真解析出对象后再断言字段。
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+type DependabotUpdate = {
+  "package-ecosystem": string;
+  directory: string;
+  schedule?: { interval?: string };
+  groups?: Record<string, { "update-types"?: string[] }>;
+};
+
+type DependabotConfig = {
+  version: number;
+  updates: DependabotUpdate[];
+};
+
+const repoRoot = join(import.meta.dir, "..");
+const dependabotPath = join(repoRoot, ".github", "dependabot.yml");
+const dependabotYaml = readFileSync(dependabotPath, "utf8");
+const releaseYml = readFileSync(join(repoRoot, ".github", "workflows", "release.yml"), "utf8");
+
+describe(".github/dependabot.yml (#137 供应链输入侧)", () => {
+  test("是合法 YAML（真解析，不是字符串猜测）", () => {
+    expect(() => Bun.YAML.parse(dependabotYaml)).not.toThrow();
+  });
+
+  const config = Bun.YAML.parse(dependabotYaml) as DependabotConfig;
+
+  test("顶层 version: 2", () => {
+    expect(config.version).toBe(2);
+  });
+
+  test("覆盖 bun / cargo / github-actions 三个生态", () => {
+    const ecosystems = config.updates.map((u) => u["package-ecosystem"]);
+    for (const eco of ["bun", "cargo", "github-actions"]) {
+      expect(ecosystems).toContain(eco);
+    }
+  });
+
+  test("bun 生态指向 workspace 根目录（单一 bun.lock 管住 5 个 workspace 成员）", () => {
+    const bunEntry = config.updates.find((u) => u["package-ecosystem"] === "bun");
+    expect(bunEntry?.directory).toBe("/");
+  });
+
+  test("cargo 生态指向 desktop/src-tauri（唯一的 Rust crate）", () => {
+    const cargoEntry = config.updates.find((u) => u["package-ecosystem"] === "cargo");
+    expect(cargoEntry?.directory).toBe("/desktop/src-tauri");
+  });
+
+  test("每个生态都配了 schedule.interval，且不是 daily（daily 太吵）", () => {
+    for (const update of config.updates) {
+      expect(update.schedule?.interval).toBeTruthy();
+      expect(update.schedule?.interval).not.toBe("daily");
+    }
+  });
+
+  test("每个生态都把 minor/patch 分组，避免逐包刷屏；major 不分组，单独出 PR 走人工审", () => {
+    for (const update of config.updates) {
+      const groupNames = Object.keys(update.groups ?? {});
+      expect(groupNames.length).toBeGreaterThan(0);
+      for (const group of Object.values(update.groups ?? {})) {
+        const types = group["update-types"] ?? [];
+        expect(types).toContain("minor");
+        expect(types).toContain("patch");
+        expect(types).not.toContain("major");
+      }
+    }
+  });
+});
+
+describe("release.yml bun audit 步骤 (#137 供应链输入侧)", () => {
+  test("release.yml 本身仍是合法 YAML（改动没有打断缩进/结构）", () => {
+    expect(() => Bun.YAML.parse(releaseYml)).not.toThrow();
+  });
+
+  test("有 dependency-audit job 跑 bun audit", () => {
+    expect(releaseYml).toContain("dependency-audit:");
+    expect(releaseYml).toContain("bun audit");
+  });
+
+  test("dependency-audit 只在 PR 上跑（不在 main push / tag 上重复扫）", () => {
+    expect(releaseYml).toMatch(/dependency-audit:[\s\S]*?if: github\.event_name == 'pull_request'/);
+  });
+
+  test("dependency-audit 非阻断：不进 required 门禁 \"full check\" 的 needs 列表", () => {
+    const checkJobMatch = releaseYml.match(/\n  check:\n    name: full check\n    needs:\n([\s\S]*?)\n {4}if: always\(\)/);
+    expect(checkJobMatch).not.toBeNull();
+    const needsBlock = checkJobMatch?.[1] ?? "";
+    expect(needsBlock).not.toContain("dependency-audit");
+  });
+
+  test('required 门禁 job 名字仍是 "full check"（改名会让分支保护的 required check 消失）', () => {
+    expect(releaseYml).toContain("name: full check");
+  });
+});


### PR DESCRIPTION
## 补什么（#137 供应链，dimension 6）

产物侧已好（release.yml 有 cosign + provenance），输入侧无依赖自动更新/漏洞告警：`.github/` 只有 workflows/，无 dependabot/renovate；CI 无 `bun audit`。

## 做了
- **`.github/dependabot.yml`**（新）：三个生态、周一 weekly、minor/patch 分组减噪、major 单列人工审——`bun`(根 `/`，单 bun.lock 覆盖 5 个 workspace)、`cargo`(`/desktop/src-tauri`)、`github-actions`(`/`)。
- **`release.yml` 新 `dependency-audit` job**（`version-contract` 前）：仅 PR 触发、复用既有 `bun-install` 复合 action、跑 `bun audit` 写 job summary、非零出 `::warning::` 后**恒 exit 0**、**不入 `check` 的 needs**——新披露的第三方 CVE 不会翻红 required `full check`。实测 bun audit 当前查出 3 个真漏洞（ws/wrangler 开发依赖），确认走真路径非 stub。
- **`scripts/supply-chain-deps.test.ts`**（新，接进 check:scripts）：用 `Bun.YAML.parse` 验 dependabot.yml 有效+三生态+weekly+分组；验 release.yml 仍有效；验 audit job 存在/PR-gated/不在 check.needs；验 `full check` 名不变。

## 门禁
- scripts 测试 12/12；`full check` 名不变（分支保护映射）；rebase 无冲突。config-only、低风险。
- 说明：`package-ecosystem: "bun"` 是文档化生态值，沙箱内无法打 GitHub 服务端校验 API，仅做本地 schema 形状校验。

🤖 agent 实现 + 我复验。
