### PR TITLE
feat(desktop): 生产↔私有部署切换不丢会话 + 桌面绝不持久化粘贴的 party token（#248 可编码部分）

### DIFF
--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -1,0 +1,40 @@
+// @ts-expect-error Bun executes this test, while the web tsconfig intentionally loads only Vite globals.
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { saveToken, storedToken } from "./api";
+
+let values: Map<string, string>;
+
+beforeEach(() => {
+  values = new Map();
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    writable: true,
+    value: {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => { values.set(key, value); },
+      removeItem: (key: string) => { values.delete(key); },
+    },
+  });
+});
+
+afterEach(() => {
+  Reflect.deleteProperty(globalThis, "__TAURI_INTERNALS__");
+  Reflect.deleteProperty(globalThis, "localStorage");
+});
+
+describe("desktop never persists a pasted party token (#248)", () => {
+  test("the browser still persists a pasted token so refresh keeps the session", () => {
+    saveToken("ap_pasted_in_browser");
+    expect(storedToken()).toBe("ap_pasted_in_browser");
+  });
+
+  test("the desktop runtime refuses to write a pasted party token to any persistent store", () => {
+    Object.defineProperty(globalThis, "__TAURI_INTERNALS__", { configurable: true, value: {} });
+
+    saveToken("ap_pasted_in_desktop_must_not_persist");
+
+    // 桌面自身的持久化存储里绝不能出现粘贴的 party token（只允许设备码/OIDC 会话）。
+    expect(storedToken()).toBeNull();
+    expect([...values.values()].join("|")).not.toContain("ap_pasted_in_desktop_must_not_persist");
+  });
+});

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -3,6 +3,7 @@
 // share token 只放 sessionStorage，本次标签页可刷新，避免长期落 localStorage。
 import type { Attachment, ChannelRoleAssignment, ChannelSquad, CollaborationRole, MsgFrame, PresenceEntry, SearchHit, TaskAssigneeKind, TaskRecord, TaskState, TaskSummary, WakeDelivery } from "@agentparty/shared";
 import { apiUrl } from "./base";
+import { isTauriEnvironment } from "./desktopUpdater";
 import type { WebSession } from "./oidc";
 
 const TOKEN_KEY = "ap_token";
@@ -56,6 +57,11 @@ export function getToken(): string | null {
 }
 
 export function saveToken(token: string) {
+  // 桌面端绝不把「粘贴的 party token」落进持久化存储（#248）：桌面登录只经设备码配对
+  // （refresh 存系统钥匙串）或 OIDC 浏览器登录换来的会话，粘贴的 token 至多驱动本次内存会话。
+  // 这与 App 渲染层（桌面永不渲染粘贴登录闸）互为兜底——即便渲染层回归误挂粘贴闸，
+  // 持久化边界仍拒绝写盘，保证桌面自身存储里不会留下粘贴的 party token。
+  if (isTauriEnvironment()) return;
   localStorage.setItem(TOKEN_KEY, token);
 }
 

--- a/web/src/lib/serverSwitch.test.ts
+++ b/web/src/lib/serverSwitch.test.ts
@@ -1,7 +1,12 @@
 // @ts-expect-error Bun executes this test, while the web tsconfig intentionally loads only Vite globals.
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { apiBase, apiUrl, clearApiBase, setApiBase, wsUrl } from "./base";
-import type { DesktopCredentialVault } from "./desktopCredentials";
+import {
+  createInvokeCredentialVault,
+  refreshDesktopSession,
+  type DesktopCredentialVault,
+  type DesktopInvoker,
+} from "./desktopCredentials";
 import {
   addCustomServerProfile,
   loadActiveServerOrigin,
@@ -116,6 +121,58 @@ describe("atomic desktop server switching", () => {
     });
     expect(restores).toBe(1);
     expect(commits).toBe(1);
+  });
+
+  test("switching to a private deployment and back preserves the original server session", async () => {
+    const prod = "https://agentparty.leeguoo.com";
+    const priv = "https://party.example.com";
+
+    // 真实的按 origin 分槽的凭据金库（复用 desktop_credential_* 命令的语义），
+    // 配上真实的 refreshDesktopSession，端到端验证往返切换不丢原会话。
+    const slots = new Map<string, string>();
+    const invoke: DesktopInvoker = async <T>(command: string, args?: Record<string, unknown>) => {
+      const origin = String(args?.origin);
+      if (command === "desktop_credential_write") slots.set(origin, String(args?.credential));
+      if (command === "desktop_credential_delete") slots.delete(origin);
+      return (command === "desktop_credential_read" ? slots.get(origin) ?? null : null) as T;
+    };
+    const vaultForOrigin = (origin: string) => createInvokeCredentialVault(origin, invoke);
+    await vaultForOrigin(prod).write({ refreshToken: "prod-r0", deviceSecret: "prod-secret", serverOrigin: prod, sessionId: "prod-session" });
+    await vaultForOrigin(priv).write({ refreshToken: "priv-r0", deviceSecret: "priv-secret", serverOrigin: priv, sessionId: "priv-session" });
+
+    const rotations: Record<string, string[]> = { [prod]: ["prod-r1"], [priv]: ["priv-r1"] };
+    const refreshed: string[] = [];
+    const fetcher = async (url: string | URL | Request) => {
+      const origin = new URL(String(url)).origin;
+      refreshed.push(origin);
+      const next = rotations[origin]!.shift()!;
+      return new Response(
+        JSON.stringify({ access_token: `${origin}#access`, refresh_token: next, expires_in: 600, session_id: `${origin}#session` }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    };
+    const dependencies = {
+      vaultForOrigin,
+      restore: (vault: DesktopCredentialVault, origin: string) => refreshDesktopSession(vault, [origin], fetcher),
+      setRuntimeBase: setApiBase,
+    };
+
+    // 起始在生产（beforeEach 已设为活跃），切到私有部署。
+    const toPrivate = await switchActiveDesktopServer(priv, storage, dependencies);
+    expect(toPrivate.origin).toBe(priv);
+    expect(apiBase()).toBe(priv);
+    // 只轮换了目标（私有）槽；生产会话原封未动，没有被清或被覆盖。
+    expect(refreshed).toEqual([priv]);
+    expect(JSON.parse(slots.get(prod)!)).toMatchObject({ refreshToken: "prod-r0", serverOrigin: prod });
+
+    // 再切回生产：生产会话仍在（本次轮换到 prod-r1），私有会话也没在往返里丢。
+    const toProduction = await switchActiveDesktopServer(prod, storage, dependencies);
+    expect(toProduction.origin).toBe(prod);
+    expect(toProduction.accessToken).toBe(`${prod}#access`);
+    expect(apiBase()).toBe(prod);
+    expect(refreshed).toEqual([priv, prod]);
+    expect(JSON.parse(slots.get(prod)!)).toMatchObject({ refreshToken: "prod-r1", serverOrigin: prod });
+    expect(JSON.parse(slots.get(priv)!)).toMatchObject({ refreshToken: "priv-r1", serverOrigin: priv });
   });
 });
 


### PR DESCRIPTION
## #248 的可编码验收项（Apple/真机那半不在此，见下方 runbook）

#248 是桌面生产发布验收清单，大半卡在 Apple 账号/真机 E2E。本 PR 做**可编码的两项** + 文档核对。

### 1. 生产↔私有部署切换不丢会话（验证 + 补测试）
机制本已正确：会话按 server origin 隔离（keychain 槽=`sha256(origin)`，TS vault 与 Rust 都拒绝 origin 与槽不符的凭据）；`switchActiveDesktopServer` 先恢复目标会话再切 API/WS base、从不碰另一 origin 的槽、恢复失败回滚。**缺口是没测试**——补了 prod→私有→prod 真往返 E2E，断言两 origin 会话都完好、各自只轮换自己的 refresh token。变异：注入删另一 origin 槽 → 测试红。

### 2. 桌面绝不持久化粘贴的 party token（加固 + 测试）
native keychain 本就存不下粘贴 token（`StoredDesktopCredential` deny_unknown_fields，Rust 测试已证）。唯一未设防的持久边界是 `saveToken`→`localStorage("ap_token")`——它唯一调用者（粘贴 token 的 `TokenGate.onSubmit`）在桌面不可达（`desktop && token===null` 时渲染 device-code 配对门）。**加防御纵深**：`saveToken` 在 `isTauriEnvironment()` 下直接 return——即便渲染层日后回归误露粘贴门，也不会落持久存储。测试断言桌面运行时不写；变异去掉守卫 → 红。浏览器行为不变。

### 3. 文档对齐分发状态（核对，无需改）
README/install-desktop.sh/最新 plan 都已明确标当前是**未公证 preview**（production 需 Developer ID+公证、卡 Apple 账号）。无误述。

## 门禁
web tsc 0；全量 529/0；vite build 0；api+serverSwitch 10/10；变异两条各自咬；rebase 无冲突。未动 Rust/Tauri 原生发布配置/签名/CI/release.yml。

## ⚠️ #248 仍卡在 Apple 账号/真机 E2E 的项（留给运营，需 Apple 开发者账号）
- Developer ID Application 签名配进 release Environment；两架构公证+装订过；status preview→production、Gatekeeper 过。
- 真机：旧版发现→下载→验签→安装→重启→报新版本（解锁 Mac 上 GUI updater E2E）。
- prod+xdream 真 token 对的完整鉴权部署 smoke。(#203) 独立可查的部署版本/commit。
- （更新失败诊断项已由 ef6b4d2 完成，无需动作。）

🤖 agent 实现（会话隔离/防 token 持久化/文档核对 + 运营 runbook）+ 我复验。
