### PR TITLE
feat(worker): 每账号频道配额+创建限速 + 每频道 WS 连接上限，堵账单攻击面（#137 成本滥用）

### DIFF
--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -38,6 +38,18 @@ export const MAX_WEBHOOK_DEAD_LETTERS = 200;
 // 单次 redeliver 最多重投多少条死信，避免一个端点的巨量积压一次性打满 subrequest 配额。
 export const WEBHOOK_REDELIVER_BATCH_SIZE = 50;
 
+// ---- 每账号频道配额 + 创建限速 + 每频道连接上限（#137 成本模型与滥用防护）----
+// 每个频道背后是一个 Durable Object + 一行 D1；此前 POST /api/channels 无任何配额，
+// 任一带账号的 ap_ token 持有者可无限造 DO/D1 行（面向跨公司外部 agent 发 token 的产品，
+// 这是真实账单攻击面）。下面给「拥有该频道的账号」两道闸：owned 总量硬上限 + 滚动窗口创建限速。
+// 缺省对单团队足够宽松（正常协作不可能撞上），只挡量级异常的滥用。legacy 无账号 token 不受限（fail-open）。
+export const MAX_CHANNELS_PER_ACCOUNT = 100; // 单账号可拥有（owner_account）的频道总数上限（含归档，堵 create→archive→create 绕过）
+export const CHANNEL_CREATE_WINDOW_MS = 60 * 60_000; // 创建限速滚动窗口：1 小时
+export const MAX_CHANNEL_CREATES_PER_WINDOW = 20; // 单账号每窗口最多新建频道数
+// 每频道并发 WS 连接上限：DO 无上限时单频道可被灌爆连接（每连接吃内存 + presence 扇出）。
+// 缺省 200 远超任何真实多公司 party 的在场规模；worker env 可覆盖以便运维调参 / 测试用小值。
+export const MAX_CONNECTIONS_PER_CHANNEL = 200;
+
 // ---- per-agent wake 预算/配额（#108）----
 // 每个 @ 触发一次完整 runner run，会烧目标 agent 的 LLM 订阅/tokens；协议此前无任何总量上限
 // （README 宣称的「capacity routing」无落地）。这里给每个 agent 一个滚动窗口内的 wake 硬上限：
@@ -320,6 +332,8 @@ export type ErrorCode =
   | "loop_guard"
   | "workflow_guard"
   | "archived"
+  | "quota_exceeded"
+  | "channel_full"
   | "not_found";
 
 export type RestErrorCode = ErrorCode | "conflict" | "unavailable" | "forbidden";

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -18,6 +18,7 @@ import {
   DECISION_OPTIONS_MAX,
   DECISION_OPTION_LIMIT,
   DECISION_REASON_LIMIT,
+  MAX_CONNECTIONS_PER_CHANNEL,
   PRESENCE_TIMEOUT_MS,
   RATE_LIMIT_PER_MIN,
   RETAIN_N,
@@ -132,6 +133,8 @@ export const ERROR_STATUS: Record<ErrorCode, number> = {
   loop_guard: 409,
   workflow_guard: 409,
   archived: 410,
+  quota_exceeded: 403,
+  channel_full: 429,
   not_found: 404,
 };
 
@@ -1329,6 +1332,14 @@ export class ChannelDO extends Server<Env> {
     );
   }
 
+  // #137：每频道连接上限缺省取 MAX_CONNECTIONS_PER_CHANNEL；worker env 可覆盖以便运维调参
+  // 或测试用小值（避免为验证上限真开 200 条 WS）。非法/缺省值回退到常量。
+  private maxConnectionsPerChannel(): number {
+    const raw = (this.env as { MAX_CONNECTIONS_PER_CHANNEL?: unknown }).MAX_CONNECTIONS_PER_CHANNEL;
+    const n = typeof raw === "string" ? Number(raw) : typeof raw === "number" ? raw : NaN;
+    return Number.isInteger(n) && n > 0 ? n : MAX_CONNECTIONS_PER_CHANNEL;
+  }
+
   async onConnect(connection: Connection<ConnState>, ctx: ConnectionContext) {
     const h = ctx.request.headers;
     const state: ConnState = {
@@ -1353,6 +1364,23 @@ export class ChannelDO extends Server<Env> {
     if (state.archived || this.isArchived()) {
       this.sendFrame(connection, { type: "error", code: "archived", message: "channel is archived" });
       connection.close(1008, "archived");
+      return;
+    }
+    // #137 每频道 WS 连接上限：DO 无上限时单频道可被灌爆连接（每连接吃内存 + presence 扇出）。
+    // getConnections 在 onConnect 时已含刚接入的这条，按 id 排除自己后计数「其它存活连接」，
+    // 达上限即拒绝这条（第 N+1 条），前 N 条照常。镜像 archived 的 error 帧 + 1008 关闭。
+    const connCap = this.maxConnectionsPerChannel();
+    let otherConns = 0;
+    for (const other of this.getConnections<ConnState>()) {
+      if (other.id !== connection.id) otherConns++;
+    }
+    if (otherConns >= connCap) {
+      this.sendFrame(connection, {
+        type: "error",
+        code: "channel_full",
+        message: `channel connection limit reached (max ${connCap})`,
+      });
+      connection.close(1008, "channel_full");
       return;
     }
     const loopGuard = state.kind === "agent" ? this.loopGuardMessage(state.name) : this.globalLoopGuardMessage();

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1,9 +1,12 @@
 // worker 入口 — rest 路由 + ws 升级转发
 import {
+  CHANNEL_CREATE_WINDOW_MS,
   CHARTER_LIMIT,
   DEFAULT_MEMBERSHIP,
   LOOP_GUARD_N,
   LOOP_GUARD_PARTY_N,
+  MAX_CHANNELS_PER_ACCOUNT,
+  MAX_CHANNEL_CREATES_PER_WINDOW,
   normalizeTier,
   RESERVED_NAMES,
   ROLE_RESPONSIBILITY_LIMIT,
@@ -2925,6 +2928,38 @@ app.post("/api/channels", async (c) => {
   }
   const now = Date.now();
   const creator = c.get("identity");
+  // #137 成本滥用：每频道 = 一个 DO + 一行 D1。带账号的 token 受两道闸约束——
+  //   owned 总量硬上限（quota_exceeded/403）+ 滚动窗口创建限速（rate_limited/429）。
+  // owned 计数含归档频道（archived_at 不为 null 也占 DO/D1），堵 create→archive→create 绕过。
+  // legacy 无账号 token（account == null）不计入、不受限（fail-open，与建表处 owner_account=null 的过渡口径一致）。
+  if (creator.account != null) {
+    const windowStart = now - CHANNEL_CREATE_WINDOW_MS;
+    const counts = await c.env.DB.prepare(
+      `SELECT COUNT(*) AS total,
+              COALESCE(SUM(CASE WHEN created_at >= ?1 THEN 1 ELSE 0 END), 0) AS recent
+         FROM channels
+        WHERE owner_account = ?2`,
+    )
+      .bind(windowStart, creator.account)
+      .first<{ total: number; recent: number }>();
+    const total = Number(counts?.total ?? 0);
+    const recent = Number(counts?.recent ?? 0);
+    if (total >= MAX_CHANNELS_PER_ACCOUNT) {
+      return c.json(
+        errorBody("quota_exceeded", `account channel quota reached (max ${MAX_CHANNELS_PER_ACCOUNT} channels per account)`),
+        403,
+      );
+    }
+    if (recent >= MAX_CHANNEL_CREATES_PER_WINDOW) {
+      return c.json(
+        errorBody(
+          "rate_limited",
+          `too many channels created recently (max ${MAX_CHANNEL_CREATES_PER_WINDOW} per hour)`,
+        ),
+        429,
+      );
+    }
+  }
   try {
     await c.env.DB.prepare(
       "INSERT INTO channels (slug, title, kind, mode, visibility, created_by, owner_account, created_at, loop_guard_enabled) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1)",

--- a/worker/test/account-channel-quota.spec.ts
+++ b/worker/test/account-channel-quota.spec.ts
@@ -1,0 +1,123 @@
+import {
+  MAX_CHANNELS_PER_ACCOUNT,
+  MAX_CHANNEL_CREATES_PER_WINDOW,
+} from "@agentparty/shared";
+import { describe, expect, it } from "vitest";
+import { env } from "cloudflare:test";
+import { api, seedToken, uniq, WsClient } from "./helpers";
+
+// #137 成本滥用：每频道一个 Durable Object，无配额时任一带账号的 ap_ token 可无限造 DO + D1 行。
+// 下面直接向 D1 播种 channels 行来把某账号推到配额/限速边界，避免真跑上百次建频道 API。
+
+async function seedChannels(
+  ownerAccount: string,
+  count: number,
+  createdAt: number,
+): Promise<void> {
+  const now = createdAt;
+  for (let i = 0; i < count; i++) {
+    await env.DB.prepare(
+      "INSERT INTO channels (slug, kind, created_by, owner_account, created_at) VALUES (?, 'standing', ?, ?, ?)",
+    )
+      .bind(uniq("seed"), "seed-creator", ownerAccount, now)
+      .run();
+  }
+}
+
+function createChannelReq(token: string) {
+  return api("/api/channels", token, {
+    method: "POST",
+    body: JSON.stringify({ slug: uniq("ch"), kind: "standing" }),
+  });
+}
+
+describe("per-account channel quota (#137)", () => {
+  it("rejects channel creation once the account is at its owned-channel quota", async () => {
+    const account = uniq("acct");
+    const { token } = await seedToken("agent", uniq("tok"), { owner: account });
+    // 播种到「配额 - 1」，用一个 window 之外的时间戳避免撞上创建限速
+    const old = Date.now() - 2 * 60 * 60 * 1000;
+    await seedChannels(account, MAX_CHANNELS_PER_ACCOUNT - 1, old);
+
+    // 第 N 个（刚好到配额）仍放行
+    expect((await createChannelReq(token)).status).toBe(201);
+
+    // 第 N+1 个：超配额，403 quota_exceeded
+    const over = await createChannelReq(token);
+    expect(over.status).toBe(403);
+    expect(((await over.json()) as { error: { code: string } }).error.code).toBe("quota_exceeded");
+  });
+
+  it("lets an under-quota account create channels", async () => {
+    const account = uniq("acct");
+    const { token } = await seedToken("agent", uniq("tok"), { owner: account });
+    expect((await createChannelReq(token)).status).toBe(201);
+  });
+
+  it("does not quota-limit legacy tokens without an account (fail-open)", async () => {
+    // 一堆无归属账号（owner_account = NULL）的历史频道不该把 legacy token 也卡死
+    const old = Date.now() - 2 * 60 * 60 * 1000;
+    for (let i = 0; i < MAX_CHANNELS_PER_ACCOUNT + 5; i++) {
+      await env.DB.prepare(
+        "INSERT INTO channels (slug, kind, created_by, owner_account, created_at) VALUES (?, 'standing', ?, NULL, ?)",
+      )
+        .bind(uniq("legacy"), "legacy", old)
+        .run();
+    }
+    const { token } = await seedToken("agent"); // 无 owner → account null
+    expect((await createChannelReq(token)).status).toBe(201);
+  });
+
+  it("rate-limits bursty channel creation within the window (429 rate_limited)", async () => {
+    const account = uniq("acct");
+    const { token } = await seedToken("agent", uniq("tok"), { owner: account });
+    // 窗口内已有「限速 - 1」个刚创建的频道；总数远低于配额，只应触发限速
+    await seedChannels(account, MAX_CHANNEL_CREATES_PER_WINDOW - 1, Date.now());
+
+    // 第 N 个（刚好到限速上限）仍放行
+    expect((await createChannelReq(token)).status).toBe(201);
+
+    // 第 N+1 个：窗口内创建过多，429 rate_limited
+    const over = await createChannelReq(token);
+    expect(over.status).toBe(429);
+    expect(((await over.json()) as { error: { code: string } }).error.code).toBe("rate_limited");
+  });
+});
+
+// 测试环境把每频道连接上限降到 TEST_CONN_CAP（vitest.config.ts 的 miniflare binding
+// MAX_CONNECTIONS_PER_CHANNEL 与此值保持一致），避免真开 200 条 WS。
+const TEST_CONN_CAP = 10;
+
+describe("per-channel WS connection cap (#137)", () => {
+  it("accepts up to the cap and rejects the next connection with channel_full", async () => {
+    const account = uniq("acct");
+    const { token } = await seedToken("agent", uniq("tok"), { owner: account });
+    const slug = uniq("ch");
+    expect(
+      (
+        await api("/api/channels", token, {
+          method: "POST",
+          body: JSON.stringify({ slug, kind: "standing" }),
+        })
+      ).status,
+    ).toBe(201);
+
+    const open: WsClient[] = [];
+    try {
+      // cap 条连接全部拿到 welcome
+      for (let i = 0; i < TEST_CONN_CAP; i++) {
+        const ws = await WsClient.open(slug, token);
+        expect((await ws.nextOfType("welcome")).type).toBe("welcome");
+        open.push(ws);
+      }
+
+      // 第 cap+1 条：被拒，先收到 error:channel_full
+      const overflow = await WsClient.open(slug, token);
+      const err = await overflow.nextOfType("error");
+      expect(err.code).toBe("channel_full");
+      overflow.close();
+    } finally {
+      for (const ws of open) ws.close();
+    }
+  });
+});

--- a/worker/vitest.config.ts
+++ b/worker/vitest.config.ts
@@ -69,6 +69,10 @@ export default defineWorkersConfig(async () => {
               ]),
               LARK_CLIENT_SECRET: "test-lark-secret",
               DESKTOP_PAIRING_SECRET: "test-desktop-pairing-secret-at-least-32-bytes",
+              // #137：把每频道 WS 连接上限降到小值，测试才不用真开 200 条连接验证上限。
+              // 值必须 > 任何单个 it 对同一频道的并发连接数（现存最多 <6），并与
+              // account-channel-quota.spec.ts 的 TEST_CONN_CAP 保持一致。
+              MAX_CONNECTIONS_PER_CHANNEL: "10",
             },
           },
         },


### PR DESCRIPTION
## 补什么（#137 成本滥用，dimension 3）

`POST /api/channels` 无每账号配额/创建限速——每频道一个 Durable Object，任一 ap_ token 可无限造 DO + D1 行（面向跨公司外部 agent 发 token 的产品，真实账单攻击面）。DO 内也无每频道 WS 连接上限。

## 做了（真熔断，仿既有限速/队列上限手法）
- **每账号频道配额**：owned 频道数硬上限 `MAX_CHANNELS_PER_ACCOUNT`（超 → `quota_exceeded`/403），按 `owner_account` 从 D1 计数。
- **创建限速**：滚动窗 `MAX_CHANNEL_CREATES_PER_WINDOW`/小时（超 → `rate_limited`/429）。
- **legacy fail-open**：无账号 token（account==null）不计入、不受限（与建表处 owner_account=null 过渡口径一致）。
- **每频道 WS 连接上限**：do.ts `onConnect` 排除刚接入的自己后计存活连接，`>= maxConnectionsPerChannel()`（缺省 `MAX_CONNECTIONS_PER_CHANNEL`、worker env 可覆盖调参）则拒新连接。
- 默认宽松，单团队正常用不会撞；文档在常量注释。

## 门禁（对 origin HEAD rebase 后亲验）
- worker account-channel-quota 5/5；worker tsc 0；rebase 无冲突。
- 变异：配额检查短路（`false &&`）→ 超额建频道测试红。复绿。

🤖 opus agent 实现、收尾截断我接管（审+提交+复验）。
