### PR TITLE
fix(web): 状态行去掉平铺碎片，收成悬停 ⋯（#280 收尾）

### DIFF
--- a/web/src/components/MessageCard.tsx
+++ b/web/src/components/MessageCard.tsx
@@ -273,27 +273,15 @@ export function MessageCard({
       <div id={`msg-${msg.seq}`} className="msg-status" data-state={msg.state ?? undefined} style={hueStyle}>
         <span title={statusFullDetail !== "" ? statusFullDetail : undefined}>
           <span className="msg-sender" title={senderTitle}>{senderLabel}</span>
-          {owner !== null && (
-            <span className="t-mono msg-owner" title={`owner: ${owner}`}>
+          {(owner !== null ||
+            lineageLabel !== null ||
+            statusContextBits.length > 0 ||
+            statusWorkflowBits.length > 0) && (
+            <span className="t-mono msg-context-more" aria-hidden="true">
               {" "}
-              · {owner}
+              ⋯
             </span>
           )}{" "}
-          {lineageLabel !== null && (
-            <span className="t-mono msg-lineage" title={senderTitle}>
-              {lineageLabel}
-            </span>
-          )}{" "}
-          {statusContextBits.map((bit) => (
-            <span key={bit} className="t-mono msg-context" title={statusTitle}>
-              {bit}
-            </span>
-          ))}{" "}
-          {statusWorkflowBits.map((bit) => (
-            <span key={bit} className="t-mono msg-context" title={statusTitle}>
-              {bit}
-            </span>
-          ))}{" "}
           → {msg.state}
           {statusBits.length > 0 ? ` · ${statusBits.join(" · ")}` : ""} · {fmtTime(msg.ts)}
         </span>

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -2498,6 +2498,13 @@
   vertical-align: -1px;
   white-space: nowrap;
 }
+/* #280 收尾：状态行不再把 owner/lineage/wt/ws/cfg/fp 平铺在行内（issue「公告过长」），
+   只留一个暗色 ⋯ 提示「还有上下文」——完整内容挂在这一行的原生 title 上，悬停即见。 */
+.msg-context-more {
+  color: var(--t-faint);
+  cursor: default;
+  font-size: 11px;
+}
 .msg-mention { color: var(--t-accent); }
 .msg-reply { color: var(--t-dim); }
 /* 引用预览块：真·引用取代裸 ↩#N —— 左竖条 + 淡底，点了跳到原消息并短暂高亮。


### PR DESCRIPTION
## 问题
系统状态/公告行仍然过长。leo-codex 那条状态在时间线里显示成：

`leo-codex-main-dev · lark:on_2260… · wt:agentparty:main · ws:agentparty · cfg:explicit · fp:sha256:d013… → waiting · …`

#280 本意是「更多信息靠悬停展示，只展示重要内容」，但它只加了 hover title，**没把 owner / lineage / wt/ws/cfg/fp / workflow 碎片从行内移走**——所以行还是那么长。

## 改动
状态行（`.msg-status`）行内只保留重要内容：`sender → state · note · time`。owner(lark 长 id)、lineage、wt/ws/cfg/fp、workflow 碎片全部折进行尾一个暗色 `⋯`。完整内容仍挂在整行的原生 `title` 上，悬停 `⋯`（或整行）即见全文——零信息丢失，因为 `senderTitle`/`statusTitle` 本就含全部字段。

## 验证
- `tsc --noEmit` 干净
- `bun test MessageCard*.test.tsx` → 9 pass / 0 fail
- `bun run build` 通过

https://claude.ai/code/session_01PgxkZeqJmDge3dYe9W2tPZ