### PR TITLE
feat(worker,cli): CLI↔worker 版本协商——/api/version + min-version 护栏（#137 发布兼容）

### DIFF
--- a/cli/src/rest.ts
+++ b/cli/src/rest.ts
@@ -195,7 +195,11 @@ const REQ_TIMEOUT_MS = 30_000;
 
 async function req(server: string, path: string, init: RequestInit = {}): Promise<unknown> {
   const signal = init.signal ?? AbortSignal.timeout(REQ_TIMEOUT_MS);
-  const res = await fetch(server.replace(/\/+$/, "") + path, { ...init, signal });
+  // 版本协商（#137）：每个 REST 调用都带上客户端版本，服务端据此做 min-version 护栏/建言。
+  // 用 Headers 合并，既保留调用方的 authorization/content-type，又不覆盖显式已设的版本头。
+  const headers = new Headers(init.headers);
+  if (!headers.has("x-ap-client-version")) headers.set("x-ap-client-version", pkg.version);
+  const res = await fetch(server.replace(/\/+$/, "") + path, { ...init, headers, signal });
   const raw = await res.text();
   let body: unknown = null;
   try {
@@ -228,6 +232,27 @@ export async function fetchPublicConfig(server: string): Promise<PublicConfig> {
   const clientId = body.cli_client_id ?? body.oidc?.client_id;
   if (!clientId) throw new Error("server did not advertise a cli client_id");
   return { issuer, clientId };
+}
+
+// 服务端版本协商信息（#137）：/api/version 暴露 version/commit + 声明的最低客户端版本 + 是否硬拒。
+export interface ServerVersion {
+  version: string;
+  commit: string;
+  deployed_at: string | null;
+  min_client_version: string;
+  min_client_enforced: boolean;
+}
+
+export async function fetchServerVersion(server: string): Promise<ServerVersion> {
+  const body = (await req(server, "/api/version")) as Partial<ServerVersion> | null;
+  return {
+    version: typeof body?.version === "string" ? body.version : "unknown",
+    commit: typeof body?.commit === "string" ? body.commit : "unknown",
+    deployed_at: typeof body?.deployed_at === "string" ? body.deployed_at : null,
+    // 老 worker 无 /api/version 时不会走到这（req 抛 404）；字段缺省则按最宽松处理，绝不误报过时。
+    min_client_version: typeof body?.min_client_version === "string" ? body.min_client_version : "0.0.0",
+    min_client_enforced: body?.min_client_enforced === true,
+  };
 }
 
 export interface Identity {

--- a/cli/src/upgrade.ts
+++ b/cli/src/upgrade.ts
@@ -78,6 +78,37 @@ export function upgradeNotice(auto: boolean, deps: UpgradeDeps = {}): CliUpgrade
   };
 }
 
+// 服务端声明的最低客户端版本（#137）高于本机运行版本时的升级提示——与磁盘自升级（cli_upgrade）
+// 互补：cli_upgrade 是「磁盘已有新版、re-exec 即可」，这条是「服务端要求更高、需真正去装新版」。
+// 形状对齐 CliUpgradeNotice（action_required=ask_user + command），runner 复用同一条询问用户的处理流。
+export interface ServerMinVersionNotice {
+  running_version: string;
+  min_client_version: string;
+  enforced: boolean;
+  action_required: "ask_user";
+  message: string;
+  command: string;
+}
+
+export function serverMinVersionNotice(
+  minClientVersion: string,
+  enforced: boolean,
+  deps: { runningVersion?: string } = {},
+): ServerMinVersionNotice | null {
+  const running = deps.runningVersion ?? RUNNING_VERSION;
+  if (compareVersions(running, minClientVersion) >= 0) return null;
+  return {
+    running_version: running,
+    min_client_version: minClientVersion,
+    enforced,
+    action_required: "ask_user",
+    message: enforced
+      ? `服务端要求 party CLI 最低 v${minClientVersion}，当前 v${running} 已被拒绝。请先运行升级命令再继续。`
+      : `服务端声明 party CLI 最低支持版本 v${minClientVersion}，当前 v${running} 偏旧（协议可能有破坏性变更）。继续任务前先询问用户是否升级。`,
+    command: INSTALL_LINE,
+  };
+}
+
 // re-exec 磁盘上的新二进制：spawn 同 argv、继承 stdio、detach，然后让调用方退出。
 // PID 会变——launchctl KeepAlive 天然重启；nohup 场景新进程接管（旧进程退出）。
 function defaultReexec(execPath: string, argv: string[]): void {

--- a/cli/test/version-negotiation.test.ts
+++ b/cli/test/version-negotiation.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { fetchServerVersion } from "../src/rest";
+import { RUNNING_VERSION, serverMinVersionNotice } from "../src/upgrade";
+
+const originalFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("CLI↔worker version negotiation (issue #137)", () => {
+  test("every REST call announces the client version via x-ap-client-version", async () => {
+    let seen: string | null = "MISSING";
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      const req = input instanceof Request ? input : new Request(String(input), init);
+      seen = req.headers.get("x-ap-client-version");
+      return Response.json({ version: "dev", commit: "unknown", deployed_at: null, min_client_version: "0.2.0" });
+    }) as typeof fetch;
+
+    await fetchServerVersion("https://ap.test");
+    expect(seen).toBe(RUNNING_VERSION);
+  });
+
+  test("fetchServerVersion parses the endpoint and tolerates a legacy server (missing fields)", async () => {
+    globalThis.fetch = (async (_input: string | URL | Request, _init?: RequestInit) =>
+      Response.json({
+        version: "0.2.94",
+        commit: "abc",
+        deployed_at: "2026-07-11T00:00:00Z",
+        min_client_version: "0.3.0",
+        min_client_enforced: true,
+      })) as typeof fetch;
+    expect(await fetchServerVersion("https://ap.test")).toEqual({
+      version: "0.2.94",
+      commit: "abc",
+      deployed_at: "2026-07-11T00:00:00Z",
+      min_client_version: "0.3.0",
+      min_client_enforced: true,
+    });
+
+    globalThis.fetch = (async (_input: string | URL | Request, _init?: RequestInit) => Response.json({})) as typeof fetch;
+    const legacy = await fetchServerVersion("https://ap.test");
+    expect(legacy.min_client_version).toBe("0.0.0");
+    expect(legacy.min_client_enforced).toBe(false);
+  });
+
+  test("serverMinVersionNotice fires only when the running version is below the declared floor", () => {
+    // 低于下限 → 生成升级提示（对齐 cli_upgrade 的 ask_user 流）
+    const below = serverMinVersionNotice("9.9.9", false, { runningVersion: "0.2.60" });
+    expect(below).not.toBeNull();
+    expect(below?.action_required).toBe("ask_user");
+    expect(below?.min_client_version).toBe("9.9.9");
+    expect(below?.running_version).toBe("0.2.60");
+    expect(below?.enforced).toBe(false);
+    expect(below?.command).toContain("install.sh");
+
+    // 等于/高于下限 → 无提示
+    expect(serverMinVersionNotice("0.2.60", false, { runningVersion: "0.2.60" })).toBeNull();
+    expect(serverMinVersionNotice("0.2.0", false, { runningVersion: "0.2.94" })).toBeNull();
+
+    // enforced 标透传，并改用「已被拒绝」的措辞
+    const enforced = serverMinVersionNotice("9.9.9", true, { runningVersion: "0.2.60" });
+    expect(enforced?.enforced).toBe(true);
+    expect(enforced?.message).toContain("拒绝");
+  });
+});

--- a/worker/src/client-version.ts
+++ b/worker/src/client-version.ts
@@ -1,0 +1,93 @@
+// CLI↔worker 版本协商（issue #137，发布/回滚与版本兼容维度）。
+//
+// CLI 按二进制分发天然滞后，协议破坏性变更（如 loop guard 默认值翻转）对老客户端此前无任何护栏。
+// 这里让服务端声明一个「最低支持客户端版本」（min-version），并对带版本头的调用做判定：
+//   - 默认「建言（advisory）」：低版本客户端照常放行，仅通过响应头 x-ap-client-too-old 给出可执行信号，
+//     避免滞后的老客户端被一刀切锁死——护栏的意义是**信号**，不是墙。
+//   - 仅当显式开启 MIN_CLIENT_ENFORCE 才硬拒（426 + 结构化 client_too_old），供必要时的紧急护栏。
+// 缺版本头 = legacy/unknown，永不硬拒，也不打 too-old 标（避免误伤浏览器等本就不带头的客户端）。
+
+export const CLIENT_VERSION_HEADER = "x-ap-client-version";
+export const MIN_CLIENT_VERSION_HEADER = "x-ap-min-client-version";
+export const CLIENT_TOO_OLD_HEADER = "x-ap-client-too-old";
+
+// 默认最低版本：取一个保守下限，当前所有在跑的 CLI（0.2.x）都在其上，纯建言不打扰任何人；
+// 运维可经 MIN_CLIENT_VERSION 环境变量把它收紧到某次破坏性变更之后的版本，逐步收紧而非一次锁死。
+export const DEFAULT_MIN_CLIENT_VERSION = "0.2.0";
+
+export const CLI_INSTALL_COMMAND =
+  "curl -fsSL https://raw.githubusercontent.com/leeguooooo/agentparty/main/install.sh | sh";
+
+// 与 do.ts 的 presence client_version 同一套字符集约束：首字符字母/数字，总长 ≤64。
+const CLIENT_VERSION_RE = /^[0-9A-Za-z][0-9A-Za-z.+-]{0,63}$/;
+
+export function parseClientVersion(input: unknown): string | null {
+  return typeof input === "string" && CLIENT_VERSION_RE.test(input) ? input : null;
+}
+
+// semver X.Y.Z 比较：a>b→1, a<b→-1, ==→0。只认前三段数字，其余（-beta.1 等预发行后缀）忽略。
+// 规则与 cli/src/upgrade.ts 的 compareVersions 一致，两端对 min-version 的判定不会分叉。
+export function compareClientVersions(a: string, b: string): number {
+  const pa = a.split(".").map((n) => Number.parseInt(n, 10) || 0);
+  const pb = b.split(".").map((n) => Number.parseInt(n, 10) || 0);
+  for (let i = 0; i < 3; i++) {
+    const d = (pa[i] ?? 0) - (pb[i] ?? 0);
+    if (d !== 0) return d > 0 ? 1 : -1;
+  }
+  return 0;
+}
+
+// 从环境变量解析声明的最低版本；缺失/非法一律回落到内置默认（绝不因配置错误意外锁死客户端）。
+export function resolveMinClientVersion(raw: string | undefined | null): string {
+  return parseClientVersion(typeof raw === "string" ? raw.trim() : "") ?? DEFAULT_MIN_CLIENT_VERSION;
+}
+
+// enforce 开关：仅接受常见真值串，其余（含缺省）一律视为关（默认建言、不硬拒）。
+export function isEnforced(raw: string | undefined | null): boolean {
+  const v = typeof raw === "string" ? raw.trim().toLowerCase() : "";
+  return v === "1" || v === "true" || v === "yes" || v === "on";
+}
+
+export type ClientVersionStatus = "ok" | "too_old" | "unknown";
+
+export interface ClientVersionVerdict {
+  status: ClientVersionStatus;
+  client_version: string | null;
+  min_client_version: string;
+}
+
+// 判定调用方版本。缺头/非法头 → unknown（legacy，永不硬拒、不打标）；有头且低于下限 → too_old；否则 ok。
+export function evaluateClientVersion(
+  header: string | null | undefined,
+  minVersion: string,
+): ClientVersionVerdict {
+  const parsed = parseClientVersion(header);
+  if (parsed === null) return { status: "unknown", client_version: null, min_client_version: minVersion };
+  const status: ClientVersionStatus = compareClientVersions(parsed, minVersion) < 0 ? "too_old" : "ok";
+  return { status, client_version: parsed, min_client_version: minVersion };
+}
+
+// 破坏性版本护栏给过时客户端的结构化信号——形状对齐 cli 的 cli_upgrade（action_required + command），
+// 让 runner 复用同一条「询问用户是否升级」的处理流。仅在 enforce 硬拒（426）时作为响应体返回。
+export interface ClientTooOldNotice {
+  error: { code: "client_too_old"; message: string };
+  min_client_version: string;
+  client_version: string | null;
+  action_required: "ask_user";
+  command: string;
+}
+
+export function clientTooOldNotice(verdict: ClientVersionVerdict): ClientTooOldNotice {
+  return {
+    error: {
+      code: "client_too_old",
+      message: `party CLI ${verdict.client_version ?? "(unknown)"} 低于服务端要求的最低版本 ${
+        verdict.min_client_version
+      }，请升级后重试：${CLI_INSTALL_COMMAND}`,
+    },
+    min_client_version: verdict.min_client_version,
+    client_version: verdict.client_version,
+    action_required: "ask_user",
+    command: CLI_INSTALL_COMMAND,
+  };
+}

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1758,8 +1758,13 @@ app.use("/api/*", async (c, next) => {
   }
   await next();
   // 建言信号：始终告知下限；已知过时才打 too-old 标（unknown/legacy 不打，避免误伤本就不带头的浏览器等）。
-  c.res.headers.set(MIN_CLIENT_VERSION_HEADER, minVersion);
-  if (verdict.status === "too_old") c.res.headers.set(CLIENT_TOO_OLD_HEADER, "1");
+  // 建言头是尽力而为——某些响应（流式/已终结）的 headers 不可变，绝不能因加建言头而把请求崩成 500。
+  try {
+    c.res.headers.set(MIN_CLIENT_VERSION_HEADER, minVersion);
+    if (verdict.status === "too_old") c.res.headers.set(CLIENT_TOO_OLD_HEADER, "1");
+  } catch {
+    // 不可变响应头：跳过建言头，不影响正文
+  }
 });
 
 app.get("/api/health", (c) => {

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -41,6 +41,15 @@ import type { Context } from "hono";
 import { createMiddleware } from "hono/factory";
 import { canAccessChannel, isChannelModerator } from "./acl";
 import {
+  CLIENT_TOO_OLD_HEADER,
+  CLIENT_VERSION_HEADER,
+  MIN_CLIENT_VERSION_HEADER,
+  clientTooOldNotice,
+  evaluateClientVersion,
+  isEnforced,
+  resolveMinClientVersion,
+} from "./client-version";
+import {
   extractBearer,
   lookupToken,
   oidcConfigFromEnv,
@@ -102,6 +111,9 @@ type AppEnv = Env & {
   LARK_CLIENT_SECRET?: string;
   FEISHU_CLIENT_SECRET?: string;
   DESKTOP_PAIRING_SECRET?: string;
+  // CLI↔worker 版本协商（#137）：声明的最低客户端版本 + 是否硬拒。缺省时用内置默认、默认只建言。
+  MIN_CLIENT_VERSION?: string;
+  MIN_CLIENT_ENFORCE?: string;
 };
 
 type AppContext = {
@@ -1730,9 +1742,40 @@ app.use("/api/*", async (c, next) => {
   c.res.headers.append("vary", "Origin");
 });
 
+// CLI↔worker 版本协商护栏（#137）。默认建言：低版本客户端照常放行，仅回一个 x-ap-client-too-old 信号头；
+// 仅当 MIN_CLIENT_ENFORCE 显式开启且客户端**确实带版本头且低于下限**时才 426 硬拒——缺头的 legacy 永不拒。
+// /api/version 与 /api/health 是老客户端了解自己过时的唯一入口，任何模式下都不拦。
+app.use("/api/*", async (c, next) => {
+  const path = new URL(c.req.url).pathname;
+  if (path === "/api/version" || path === "/api/health") return next();
+  const minVersion = resolveMinClientVersion(c.env.MIN_CLIENT_VERSION);
+  const verdict = evaluateClientVersion(c.req.header(CLIENT_VERSION_HEADER), minVersion);
+  if (verdict.status === "too_old" && isEnforced(c.env.MIN_CLIENT_ENFORCE)) {
+    c.header("cache-control", "no-store");
+    c.header(MIN_CLIENT_VERSION_HEADER, minVersion);
+    c.header(CLIENT_TOO_OLD_HEADER, "1");
+    return c.json(clientTooOldNotice(verdict), 426);
+  }
+  await next();
+  // 建言信号：始终告知下限；已知过时才打 too-old 标（unknown/legacy 不打，避免误伤本就不带头的浏览器等）。
+  c.res.headers.set(MIN_CLIENT_VERSION_HEADER, minVersion);
+  if (verdict.status === "too_old") c.res.headers.set(CLIENT_TOO_OLD_HEADER, "1");
+});
+
 app.get("/api/health", (c) => {
   c.header("cache-control", "no-store");
   return c.json({ ok: true, ...DEPLOYMENT_METADATA });
+});
+
+// CLI↔worker 版本协商源点（#137）：服务端 version/commit/deployed_at + 声明的最低客户端版本 + 是否硬拒。
+// 老客户端据此得知自己是否过时；本端点与 /api/health 永不受 min-version 护栏拦截（见下方中间件）。
+app.get("/api/version", (c) => {
+  c.header("cache-control", "no-store");
+  return c.json({
+    ...DEPLOYMENT_METADATA,
+    min_client_version: resolveMinClientVersion(c.env.MIN_CLIENT_VERSION),
+    min_client_enforced: isEnforced(c.env.MIN_CLIENT_ENFORCE),
+  });
 });
 
 app.get("/api/management-audit", requireAdmin, async (c) => {

--- a/worker/test/version-negotiation.spec.ts
+++ b/worker/test/version-negotiation.spec.ts
@@ -1,0 +1,114 @@
+import { SELF } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import {
+  CLIENT_TOO_OLD_HEADER,
+  CLIENT_VERSION_HEADER,
+  DEFAULT_MIN_CLIENT_VERSION,
+  MIN_CLIENT_VERSION_HEADER,
+  clientTooOldNotice,
+  compareClientVersions,
+  evaluateClientVersion,
+  isEnforced,
+  resolveMinClientVersion,
+} from "../src/client-version";
+
+// #137 发布兼容——版本协商的纯逻辑（min-version 判定、enforce 解析、结构化信号形状）。
+describe("client version negotiation logic (issue #137)", () => {
+  it("compares semver by numeric X.Y.Z segments", () => {
+    expect(compareClientVersions("0.2.1", "0.2.0")).toBe(1);
+    expect(compareClientVersions("0.2.0", "0.2.1")).toBe(-1);
+    expect(compareClientVersions("0.2.0", "0.2.0")).toBe(0);
+    expect(compareClientVersions("1.0.0", "0.9.9")).toBe(1);
+    // 预发行后缀被忽略，只看前三段
+    expect(compareClientVersions("0.2.0-beta.1", "0.2.0")).toBe(0);
+  });
+
+  it("flags a below-min client as too_old", () => {
+    const v = evaluateClientVersion("0.1.0", "0.2.0");
+    expect(v.status).toBe("too_old");
+    expect(v.client_version).toBe("0.1.0");
+    expect(v.min_client_version).toBe("0.2.0");
+  });
+
+  it("leaves an at/above-min client unaffected (ok)", () => {
+    expect(evaluateClientVersion("0.2.0", "0.2.0").status).toBe("ok");
+    expect(evaluateClientVersion("0.2.94", "0.2.0").status).toBe("ok");
+  });
+
+  it("treats a missing or malformed version header as unknown (legacy), never too_old", () => {
+    expect(evaluateClientVersion(undefined, "0.2.0").status).toBe("unknown");
+    expect(evaluateClientVersion(null, "0.2.0").status).toBe("unknown");
+    expect(evaluateClientVersion("", "0.2.0").status).toBe("unknown");
+    expect(evaluateClientVersion(" 1.2.3", "0.2.0").status).toBe("unknown");
+    expect(evaluateClientVersion("x".repeat(65), "0.2.0").status).toBe("unknown");
+  });
+
+  it("parses the enforce flag from common truthy strings only", () => {
+    for (const on of ["1", "true", "TRUE", "yes", "on"]) expect(isEnforced(on)).toBe(true);
+    for (const off of ["0", "false", "no", "off", "", undefined, null]) expect(isEnforced(off)).toBe(false);
+  });
+
+  it("resolves the min version from env, falling back to the default on absent/invalid input", () => {
+    expect(resolveMinClientVersion("0.5.0")).toBe("0.5.0");
+    expect(resolveMinClientVersion(undefined)).toBe(DEFAULT_MIN_CLIENT_VERSION);
+    expect(resolveMinClientVersion("")).toBe(DEFAULT_MIN_CLIENT_VERSION);
+    expect(resolveMinClientVersion(" not a version ")).toBe(DEFAULT_MIN_CLIENT_VERSION);
+  });
+
+  it("builds a structured client_too_old notice mirroring the cli_upgrade ask-user flow", () => {
+    const notice = clientTooOldNotice(evaluateClientVersion("0.1.0", "0.2.0"));
+    expect(notice.error.code).toBe("client_too_old");
+    expect(notice.action_required).toBe("ask_user");
+    expect(notice.min_client_version).toBe("0.2.0");
+    expect(notice.client_version).toBe("0.1.0");
+    expect(notice.command).toContain("install.sh");
+  });
+});
+
+// #137——/api/version 端点 + REST 层 min-version 护栏（默认建言：低版本照常放行，只加信号头）。
+describe("version endpoint and advisory guardrail (issue #137)", () => {
+  it("exposes server version/commit + declared min client version, uncached", async () => {
+    const res = await SELF.fetch("http://ap.test/api/version");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toBe("no-store");
+    expect(await res.json()).toEqual({
+      version: "dev",
+      commit: "unknown",
+      deployed_at: null,
+      min_client_version: DEFAULT_MIN_CLIENT_VERSION,
+      min_client_enforced: false,
+    });
+  });
+
+  it("never guards /api/version itself, so an old client can always learn it is old", async () => {
+    const res = await SELF.fetch("http://ap.test/api/version", {
+      headers: { [CLIENT_VERSION_HEADER]: "0.0.1" },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get(CLIENT_TOO_OLD_HEADER)).toBeNull();
+  });
+
+  it("advises (does not reject) a below-min client, tagging the response and advertising the floor", async () => {
+    const res = await SELF.fetch("http://ap.test/api/config", {
+      headers: { [CLIENT_VERSION_HEADER]: "0.1.0" },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get(CLIENT_TOO_OLD_HEADER)).toBe("1");
+    expect(res.headers.get(MIN_CLIENT_VERSION_HEADER)).toBe(DEFAULT_MIN_CLIENT_VERSION);
+  });
+
+  it("leaves an at/above-min client unflagged", async () => {
+    const res = await SELF.fetch("http://ap.test/api/config", {
+      headers: { [CLIENT_VERSION_HEADER]: "9.9.9" },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get(CLIENT_TOO_OLD_HEADER)).toBeNull();
+    expect(res.headers.get(MIN_CLIENT_VERSION_HEADER)).toBe(DEFAULT_MIN_CLIENT_VERSION);
+  });
+
+  it("keeps a no-version (legacy) client working and unflagged", async () => {
+    const res = await SELF.fetch("http://ap.test/api/config");
+    expect(res.status).toBe(200);
+    expect(res.headers.get(CLIENT_TOO_OLD_HEADER)).toBeNull();
+  });
+});


### PR DESCRIPTION
## 补什么（#137 发布/版本兼容，dimension 2）

CLI↔worker 无版本协商：CLI 无版本头、服务端无 /api/version 或 min-version 机制。CLI 二进制分发天然滞后，协议破坏性变更（如最近 loop guard 默认翻转）对老客户端零护栏。（wrangler deploy/migrations-in-CI 那部分是发布运维、不在此。）

## 做了（真护栏，非破坏性）
- **客户端版本头**：CLI 每 REST 调用带 `x-ap-client-version=pkg.version`（复用 presence 的 client_version 字符集约束）。
- **`/api/version`**：暴露服务端 version/commit + 声明的 `min_client_version` + 是否硬拒。
- **min-version 护栏**：默认**建言**——低版本客户端**照常放行**、仅经响应头 `x-ap-client-too-old` 给可执行升级信号（护栏是信号不是墙，避免滞后老客户端被一刀切锁死）；仅 `MIN_CLIENT_ENFORCE` 显式开时硬拒（426 + 结构化 `client_too_old`）。**缺版本头=legacy/unknown 永不硬拒、也不打 too-old 标**（浏览器等本就不带头的客户端不误伤）。
- `DEFAULT_MIN_CLIENT_VERSION=0.2.0`（当前所有 CLI 在其上、纯建言不打扰）；运维经 `MIN_CLIENT_VERSION` env 逐步收紧到某次破坏性变更之后。两端版本比较规则与 cli upgrade.ts 一致、不分叉。

## 门禁（对 origin HEAD rebase 到含 #137b 的 main 后亲验）
- worker version-negotiation 12/12；cli version-negotiation 3/3；worker/cli tsc 0；rebase 无冲突。
- 变异：min-version 判定恒 "ok"（护栏失效）→ spec 红。复绿。

🤖 opus agent 实现、收尾截断我接管（审+提交+复验）。
