### PR TITLE
feat(worker): 补齐敏感管理操作审计落库 + 修 redeliver 审计潜伏丢失（#137 可观测性）

### DIFF
--- a/worker/migrations/0030_management_audit_actions.sql
+++ b/worker/migrations/0030_management_audit_actions.sql
@@ -1,0 +1,52 @@
+-- #137 可观测性：补齐敏感管理操作的审计动作枚举。
+-- 0025 的 action CHECK 只列了 9 个动作，连代码里早已记录的 channel.webhook.redeliver 都不在内
+-- （越界值被 CHECK 拒绝，bestEffortRecordManagementAudit 静默吞掉——审计悄悄丢行）。
+-- 本次把频道创建 / 角色增删 / join-link 增删 / project-agent 邀请撤销 / guard 配置与重置 /
+-- 会员开通等敏感管理动作纳入枚举。SQLite 无法 ALTER 一个 CHECK，只能重建表、搬数据、换名。
+CREATE TABLE management_audit_new (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  cursor_token TEXT NOT NULL,
+  actor_account TEXT,
+  actor_kind TEXT NOT NULL CHECK (actor_kind IN ('admin', 'human', 'agent')),
+  action TEXT NOT NULL CHECK (action IN (
+    'token.issue',
+    'token.revoke',
+    'channel.create',
+    'channel.permissions.update',
+    'channel.visibility.update',
+    'channel.member.add',
+    'channel.member.remove',
+    'channel.role.assign',
+    'channel.role.remove',
+    'channel.join_link.create',
+    'channel.join_link.revoke',
+    'channel.project_agent.invite',
+    'channel.project_agent.remove',
+    'channel.guard.update',
+    'channel.guard.reset',
+    'channel.webhook.add',
+    'channel.webhook.remove',
+    'channel.webhook.redeliver',
+    'channel.archive',
+    'membership.set'
+  )),
+  resource TEXT NOT NULL,
+  channel TEXT,
+  result TEXT NOT NULL CHECK (result = 'success'),
+  timestamp INTEGER NOT NULL,
+  metadata_json TEXT NOT NULL DEFAULT '{}'
+    CHECK (json_valid(metadata_json) AND length(metadata_json) <= 4096)
+);
+
+INSERT INTO management_audit_new (
+  id, cursor_token, actor_account, actor_kind, action, resource, channel, result, timestamp, metadata_json
+)
+SELECT id, cursor_token, actor_account, actor_kind, action, resource, channel, result, timestamp, metadata_json
+  FROM management_audit;
+
+DROP TABLE management_audit;
+ALTER TABLE management_audit_new RENAME TO management_audit;
+
+CREATE UNIQUE INDEX idx_management_audit_cursor_token ON management_audit(cursor_token);
+CREATE INDEX idx_management_audit_timestamp ON management_audit(id DESC);
+CREATE INDEX idx_management_audit_channel ON management_audit(channel, id DESC);

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -2082,6 +2082,14 @@ app.post("/api/admin/membership", requireAdmin, async (c) => {
   )
     .bind(account, tier, memberSince, now)
     .run();
+  await bestEffortRecordManagementAudit(c.env.DB, {
+    actor: managementAuditAdminActor,
+    action: "membership.set",
+    resource: `account/${account}`,
+    channel: null,
+    timestamp: now,
+    metadata: { tier },
+  });
   return c.json({ account, tier, member_since: memberSince });
 });
 
@@ -3049,6 +3057,14 @@ app.post("/api/channels", async (c) => {
       return c.json(errorBody("unavailable", "temp channel initialization failed"), 503);
     }
   }
+  await bestEffortRecordManagementAudit(c.env.DB, {
+    actor: managementAuditActor(creator),
+    action: "channel.create",
+    resource: `channel/${slug}`,
+    channel: slug,
+    timestamp: now,
+    metadata: { kind, mode, visibility },
+  });
   return c.json({ slug, title, kind, mode, visibility }, 201);
 });
 
@@ -3114,6 +3130,13 @@ app.post("/api/channels/:slug/project-agents", async (c) => {
   )
     .bind(slug, ownerAccount, handle, invitedBy, invitedAt)
     .run();
+  await bestEffortRecordManagementAudit(c.env.DB, {
+    actor: managementAuditActor(identity),
+    action: "channel.project_agent.invite",
+    resource: `channel/${slug}/project-agents/${ownerAccount}/${handle}`,
+    channel: slug,
+    timestamp: invitedAt,
+  });
   return c.json(
     {
       id: result.meta.last_row_id,
@@ -3160,6 +3183,13 @@ app.delete("/api/channels/:slug/project-agents", async (c) => {
   if (result.meta.changes === 0) {
     return c.json(errorBody("not_found", "active project agent invite not found"), 404);
   }
+  await bestEffortRecordManagementAudit(c.env.DB, {
+    actor: managementAuditActor(identity),
+    action: "channel.project_agent.remove",
+    resource: `channel/${slug}/project-agents/${ownerAccount}/${handle}`,
+    channel: slug,
+    timestamp: revokedAt,
+  });
   const childRows = await c.env.DB.prepare(
     `SELECT name
        FROM tokens
@@ -3368,6 +3398,13 @@ app.post("/api/channels/:slug/join-links", async (c) => {
       )
         .bind(code, slug, createdBy, now, expiresAt, maxUses)
         .run();
+      await bestEffortRecordManagementAudit(c.env.DB, {
+        actor: managementAuditActor(identity),
+        action: "channel.join_link.create",
+        resource: `channel/${slug}/join-links/${code}`,
+        channel: slug,
+        timestamp: now,
+      });
       const url = new URL(c.req.url);
       return c.json(
         { code, url: `${url.origin}/join/${code}`, channel_slug: slug, created_by: createdBy, created_at: now, expires_at: expiresAt, max_uses: maxUses, uses: 0, revoked_at: null },
@@ -3403,15 +3440,24 @@ app.delete("/api/channels/:slug/join-links/:code", async (c) => {
   const code = c.req.param("code");
   const channel = await loadChannel(c.env.DB, slug);
   if (!channel) return c.json(errorBody("not_found", "channel not found"), 404);
-  if (!isChannelModerator(c.get("identity"), channel)) {
+  const identity = c.get("identity");
+  if (!isChannelModerator(identity, channel)) {
     return c.json(errorBody("forbidden", "only the channel owner or an ap_ token can manage join links"), 403);
   }
+  const revokedAt = Date.now();
   const result = await c.env.DB.prepare(
     "UPDATE channel_join_links SET revoked_at = COALESCE(revoked_at, ?) WHERE code = ? AND channel_slug = ?",
   )
-    .bind(Date.now(), code, slug)
+    .bind(revokedAt, code, slug)
     .run();
   if (result.meta.changes === 0) return c.json(errorBody("not_found", "join link not found"), 404);
+  await bestEffortRecordManagementAudit(c.env.DB, {
+    actor: managementAuditActor(identity),
+    action: "channel.join_link.revoke",
+    resource: `channel/${slug}/join-links/${code}`,
+    channel: slug,
+    timestamp: revokedAt,
+  });
   return c.json({ ok: true });
 });
 
@@ -3545,6 +3591,13 @@ app.post("/api/join/:code", async (c) => {
       .run();
     return c.json(errorBody("not_found", "join link has reached its max uses"), 410);
   }
+  await bestEffortRecordManagementAudit(c.env.DB, {
+    actor: managementAuditActor(identity),
+    action: "channel.member.add",
+    resource: `channel/${link.channel_slug}/members/${identity.account}`,
+    channel: link.channel_slug,
+    timestamp: now,
+  });
   return c.json({ channel_slug: link.channel_slug, joined: true });
 });
 
@@ -4527,6 +4580,14 @@ app.put("/api/channels/:slug/roles/:name", async (c) => {
       headers: { "content-type": "application/json", "x-partykit-room": slug },
     }),
   );
+  await bestEffortRecordManagementAudit(c.env.DB, {
+    actor: managementAuditActor(identity),
+    action: "channel.role.assign",
+    resource: `channel/${slug}/roles/${name}`,
+    channel: slug,
+    timestamp: assignedAt,
+    metadata: { role },
+  });
   const saved = await loadChannelRoleAssignment(c.env.DB, slug, name);
   return c.json(saved ?? { name, role, responsibility: responsibility.value, assigned_by: identity.name, assigned_at: assignedAt });
 });
@@ -4543,7 +4604,8 @@ app.delete("/api/channels/:slug/roles/:name", async (c) => {
   if (!NAME_RE.test(name)) {
     return c.json(errorBody("bad_request", "valid name required"), 400);
   }
-  await c.env.DB.prepare("DELETE FROM channel_roles WHERE channel_slug = ? AND agent_name = ?")
+  const removedAt = Date.now();
+  const removed = await c.env.DB.prepare("DELETE FROM channel_roles WHERE channel_slug = ? AND agent_name = ?")
     .bind(slug, name)
     .run();
   await fetchChannelDO(
@@ -4555,6 +4617,15 @@ app.delete("/api/channels/:slug/roles/:name", async (c) => {
       headers: { "content-type": "application/json", "x-partykit-room": slug },
     }),
   );
+  if (removed.meta.changes > 0) {
+    await bestEffortRecordManagementAudit(c.env.DB, {
+      actor: managementAuditActor(identity),
+      action: "channel.role.remove",
+      resource: `channel/${slug}/roles/${name}`,
+      channel: slug,
+      timestamp: removedAt,
+    });
+  }
   return c.json({ ok: true });
 });
 
@@ -4597,6 +4668,13 @@ app.put("/api/channels/:slug/completion-gate", async (c) => {
       headers: { "x-partykit-room": slug, ...channelHeaders(updated, c.req.url) },
     }),
   );
+  await bestEffortRecordManagementAudit(c.env.DB, {
+    actor: managementAuditActor(identity),
+    action: "channel.guard.update",
+    resource: `channel/${slug}/guards/completion_gate`,
+    channel: slug,
+    metadata: { guard: "completion_gate" },
+  });
   return c.json({ gate, policy });
 });
 
@@ -4628,6 +4706,13 @@ app.put("/api/channels/:slug/decision-mode", async (c) => {
       headers: { "x-partykit-room": slug, ...channelHeaders(updated, c.req.url) },
     }),
   );
+  await bestEffortRecordManagementAudit(c.env.DB, {
+    actor: managementAuditActor(identity),
+    action: "channel.guard.update",
+    resource: `channel/${slug}/guards/decision_mode`,
+    channel: slug,
+    metadata: { guard: "decision_mode" },
+  });
   return c.json({ mode });
 });
 
@@ -4687,6 +4772,13 @@ app.put("/api/channels/:slug/loop-guard", async (c) => {
       headers: { "x-partykit-room": slug, ...channelHeaders(updated, c.req.url) },
     }),
   );
+  await bestEffortRecordManagementAudit(c.env.DB, {
+    actor: managementAuditActor(identity),
+    action: "channel.guard.update",
+    resource: `channel/${slug}/guards/loop_guard`,
+    channel: slug,
+    metadata: { guard: "loop_guard" },
+  });
   return c.json({ enabled: body.enabled, limit });
 });
 
@@ -4730,6 +4822,13 @@ app.put("/api/channels/:slug/workflow-guard", async (c) => {
       headers: { "x-partykit-room": slug, ...channelHeaders(updated, c.req.url) },
     }),
   );
+  await bestEffortRecordManagementAudit(c.env.DB, {
+    actor: managementAuditActor(identity),
+    action: "channel.guard.update",
+    resource: `channel/${slug}/guards/workflow_guard`,
+    channel: slug,
+    metadata: { guard: "workflow_guard" },
+  });
   return c.json({ enabled: body.enabled, limit });
 });
 
@@ -5334,10 +5433,11 @@ app.post("/api/channels/:slug/reset-guard", async (c) => {
   if (!channel) return c.json(errorBody("not_found", "channel not found"), 404);
   // 重置 loop guard 要同时满足两条：① 是房主/ap_ token（挡粉丝越权重置别人频道）
   // ② 是 human（loop guard 防的就是 agent 失控刷屏，不能让 agent 重置自己的熔断）
-  if (!isChannelModerator(c.get("identity"), channel) || c.get("identity").kind !== "human") {
+  const identity = c.get("identity");
+  if (!isChannelModerator(identity, channel) || identity.kind !== "human") {
     return c.json(errorBody("forbidden", "only a human owner or human ap_ token can reset guard"), 403);
   }
-  return fetchChannelDO(
+  const res = await fetchChannelDO(
     c.env,
     slug,
     new Request("https://do/internal/reset-guard", {
@@ -5345,6 +5445,16 @@ app.post("/api/channels/:slug/reset-guard", async (c) => {
       headers: { "x-partykit-room": slug },
     }),
   );
+  if (res.ok) {
+    await bestEffortRecordManagementAudit(c.env.DB, {
+      actor: managementAuditActor(identity),
+      action: "channel.guard.reset",
+      resource: `channel/${slug}/guards/loop`,
+      channel: slug,
+      metadata: { guard: "loop" },
+    });
+  }
+  return res;
 });
 
 app.post("/api/channels/:slug/workflows/:workflow_id/reset-guard", async (c) => {
@@ -5368,6 +5478,13 @@ app.post("/api/channels/:slug/workflows/:workflow_id/reset-guard", async (c) => 
     }),
   );
   if (!res.ok) return c.json(errorBody("unavailable", "workflow guard reset failed"), 503);
+  await bestEffortRecordManagementAudit(c.env.DB, {
+    actor: managementAuditActor(identity),
+    action: "channel.guard.reset",
+    resource: `channel/${slug}/guards/workflow/${workflowId}`,
+    channel: slug,
+    metadata: { guard: "workflow" },
+  });
   return c.json({ ok: true, workflow_id: workflowId });
 });
 

--- a/worker/src/management-audit.ts
+++ b/worker/src/management-audit.ts
@@ -7,14 +7,24 @@ export type ManagementAuditActorKind = "admin" | "human" | "agent";
 export type ManagementAuditAction =
   | "token.issue"
   | "token.revoke"
+  | "channel.create"
   | "channel.permissions.update"
   | "channel.visibility.update"
   | "channel.member.add"
   | "channel.member.remove"
+  | "channel.role.assign"
+  | "channel.role.remove"
+  | "channel.join_link.create"
+  | "channel.join_link.revoke"
+  | "channel.project_agent.invite"
+  | "channel.project_agent.remove"
+  | "channel.guard.update"
+  | "channel.guard.reset"
   | "channel.webhook.add"
   | "channel.webhook.remove"
   | "channel.webhook.redeliver"
-  | "channel.archive";
+  | "channel.archive"
+  | "membership.set";
 
 export interface ManagementAuditActor {
   account: string | null;
@@ -84,6 +94,35 @@ function safeMetadata(action: ManagementAuditAction, input: unknown): Record<str
       metadata.webhook_filter === "all"
       ? { webhook_filter: metadata.webhook_filter }
       : {};
+  }
+  if (action === "channel.create") {
+    const result: Record<string, unknown> = {};
+    if (metadata.kind === "standing" || metadata.kind === "temp") result.kind = metadata.kind;
+    if (metadata.mode === "normal" || metadata.mode === "party") result.mode = metadata.mode;
+    if (metadata.visibility === "public" || metadata.visibility === "private") result.visibility = metadata.visibility;
+    return result;
+  }
+  if (action === "channel.role.assign") {
+    return metadata.role === "host" ||
+      metadata.role === "worker" ||
+      metadata.role === "reviewer" ||
+      metadata.role === "observer"
+      ? { role: metadata.role }
+      : {};
+  }
+  if (action === "channel.guard.update") {
+    return metadata.guard === "completion_gate" ||
+      metadata.guard === "decision_mode" ||
+      metadata.guard === "loop_guard" ||
+      metadata.guard === "workflow_guard"
+      ? { guard: metadata.guard }
+      : {};
+  }
+  if (action === "channel.guard.reset") {
+    return metadata.guard === "loop" || metadata.guard === "workflow" ? { guard: metadata.guard } : {};
+  }
+  if (action === "membership.set") {
+    return metadata.tier === "free" || metadata.tier === "member" ? { tier: metadata.tier } : {};
   }
   return {};
 }

--- a/worker/test/management-audit-coverage.spec.ts
+++ b/worker/test/management-audit-coverage.spec.ts
@@ -1,0 +1,219 @@
+import { SELF, env } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import { ADMIN_HEADERS, api, createChannel, seedToken, uniq } from "./helpers";
+
+interface AuditEntry {
+  actor_account: string | null;
+  actor_kind: "admin" | "human" | "agent";
+  action: string;
+  resource: string;
+  channel: string | null;
+  result: "success";
+  timestamp: number;
+  metadata: Record<string, unknown>;
+}
+
+interface AuditPage {
+  audit: AuditEntry[];
+  next_cursor: string | null;
+}
+
+async function channelAudit(slug: string, token: string): Promise<AuditEntry[]> {
+  const res = await api(`/api/channels/${slug}/management-audit?limit=100`, token);
+  expect(res.status).toBe(200);
+  return ((await res.json()) as AuditPage).audit;
+}
+
+async function globalAudit(): Promise<AuditEntry[]> {
+  const res = await SELF.fetch("http://ap.test/api/management-audit?limit=100", { headers: ADMIN_HEADERS });
+  expect(res.status).toBe(200);
+  return ((await res.json()) as AuditPage).audit;
+}
+
+describe("management audit coverage (#137)", () => {
+  it("records channel creation channel-scoped with sanitized metadata", async () => {
+    const ownerAccount = `${uniq("owner")}@example.com`;
+    const owner = await seedToken("human", uniq("owner-token"), { owner: ownerAccount });
+    const slug = uniq("ch");
+    expect(
+      (
+        await api("/api/channels", owner.token, {
+          method: "POST",
+          body: JSON.stringify({ slug, kind: "standing", mode: "party", visibility: "public" }),
+        })
+      ).status,
+    ).toBe(201);
+
+    const entry = (await channelAudit(slug, owner.token)).find((e) => e.action === "channel.create");
+    expect(entry).toBeDefined();
+    expect(entry?.resource).toBe(`channel/${slug}`);
+    expect(entry?.channel).toBe(slug);
+    expect(entry?.actor_account).toBe(ownerAccount);
+    expect(entry?.actor_kind).toBe("human");
+    expect(entry?.metadata).toEqual({ kind: "standing", mode: "party", visibility: "public" });
+  });
+
+  it("records paid membership changes globally with only the tier in metadata", async () => {
+    const account = `${uniq("member")}@example.com`;
+    expect(
+      (
+        await SELF.fetch("http://ap.test/api/admin/membership", {
+          method: "POST",
+          headers: { ...ADMIN_HEADERS, "content-type": "application/json" },
+          body: JSON.stringify({ account, tier: "member" }),
+        })
+      ).status,
+    ).toBe(200);
+
+    const entry = (await globalAudit()).find(
+      (e) => e.action === "membership.set" && e.resource === `account/${account}`,
+    );
+    expect(entry).toBeDefined();
+    expect(entry?.actor_kind).toBe("admin");
+    expect(entry?.actor_account).toBeNull();
+    expect(entry?.channel).toBeNull();
+    expect(entry?.metadata).toEqual({ tier: "member" });
+  });
+
+  it("records role assignment and removal with the collaboration role", async () => {
+    const ownerAccount = `${uniq("owner")}@example.com`;
+    const owner = await seedToken("human", uniq("owner-token"), { owner: ownerAccount });
+    const slug = await createChannel(owner.token);
+    const name = uniq("worker-agent");
+
+    expect(
+      (
+        await api(`/api/channels/${slug}/roles/${name}`, owner.token, {
+          method: "PUT",
+          body: JSON.stringify({ role: "reviewer" }),
+        })
+      ).status,
+    ).toBe(200);
+    expect((await api(`/api/channels/${slug}/roles/${name}`, owner.token, { method: "DELETE" })).status).toBe(200);
+
+    const audit = await channelAudit(slug, owner.token);
+    const assign = audit.find((e) => e.action === "channel.role.assign" && e.resource === `channel/${slug}/roles/${name}`);
+    const remove = audit.find((e) => e.action === "channel.role.remove" && e.resource === `channel/${slug}/roles/${name}`);
+    expect(assign).toBeDefined();
+    expect(assign?.metadata).toEqual({ role: "reviewer" });
+    expect(assign?.channel).toBe(slug);
+    expect(remove).toBeDefined();
+    expect(remove?.channel).toBe(slug);
+  });
+
+  it("records join-link creation and revocation", async () => {
+    const owner = await seedToken("human", uniq("owner-token"), { owner: `${uniq("owner")}@example.com` });
+    const slug = await createChannel(owner.token);
+
+    const created = await api(`/api/channels/${slug}/join-links`, owner.token, {
+      method: "POST",
+      body: JSON.stringify({ max_uses: 5 }),
+    });
+    expect(created.status).toBe(201);
+    const { code } = (await created.json()) as { code: string };
+
+    expect((await api(`/api/channels/${slug}/join-links/${code}`, owner.token, { method: "DELETE" })).status).toBe(200);
+
+    const audit = await channelAudit(slug, owner.token);
+    expect(audit.some((e) => e.action === "channel.join_link.create" && e.resource === `channel/${slug}/join-links/${code}`)).toBe(true);
+    expect(audit.some((e) => e.action === "channel.join_link.revoke" && e.resource === `channel/${slug}/join-links/${code}`)).toBe(true);
+    // The revoke of a code that does not exist must not be audited.
+    expect((await api(`/api/channels/${slug}/join-links/NOPE1234`, owner.token, { method: "DELETE" })).status).toBe(404);
+    expect((await channelAudit(slug, owner.token)).some((e) => e.resource === `channel/${slug}/join-links/NOPE1234`)).toBe(false);
+  });
+
+  it("records a human accepting a join link as a member add", async () => {
+    const owner = await seedToken("human", uniq("owner-token"), { owner: `${uniq("owner")}@example.com` });
+    const slug = await createChannel(owner.token);
+    const created = await api(`/api/channels/${slug}/join-links`, owner.token, {
+      method: "POST",
+      body: JSON.stringify({}),
+    });
+    expect(created.status).toBe(201);
+    const { code } = (await created.json()) as { code: string };
+
+    const joinerAccount = `${uniq("joiner")}@example.com`;
+    const joiner = await seedToken("human", uniq("joiner-token"), { owner: joinerAccount });
+    const joined = await api(`/api/join/${code}`, joiner.token, { method: "POST" });
+    expect(joined.status).toBe(200);
+    expect((await joined.json()) as { joined: boolean }).toEqual(expect.objectContaining({ joined: true }));
+
+    const entry = (await channelAudit(slug, owner.token)).find(
+      (e) => e.action === "channel.member.add" && e.resource === `channel/${slug}/members/${joinerAccount}`,
+    );
+    expect(entry).toBeDefined();
+    expect(entry?.actor_account).toBe(joinerAccount);
+    expect(entry?.actor_kind).toBe("human");
+    expect(entry?.channel).toBe(slug);
+  });
+
+  it("records project-agent invitation and revocation", async () => {
+    const ownerAccount = `${uniq("owner")}@example.com`;
+    const owner = await seedToken("human", uniq("owner-token"), { owner: ownerAccount });
+    const slug = await createChannel(owner.token);
+    const handle = uniq("proj");
+    const now = Date.now();
+    await env.DB.prepare(
+      `INSERT INTO agent_profiles (
+         owner_account, handle, name, runner, base_branch, worktree_strategy, invitable_by, created_at, updated_at
+       ) VALUES (?, ?, ?, 'codex', 'main', 'branch', 'owner', ?, ?)`,
+    )
+      .bind(ownerAccount, handle, handle, now, now)
+      .run();
+
+    expect(
+      (
+        await api(`/api/channels/${slug}/project-agents`, owner.token, {
+          method: "POST",
+          body: JSON.stringify({ owner_account: ownerAccount, handle }),
+        })
+      ).status,
+    ).toBe(201);
+    expect(
+      (
+        await api(`/api/channels/${slug}/project-agents`, owner.token, {
+          method: "DELETE",
+          body: JSON.stringify({ owner_account: ownerAccount, handle }),
+        })
+      ).status,
+    ).toBe(200);
+
+    const audit = await channelAudit(slug, owner.token);
+    const resource = `channel/${slug}/project-agents/${ownerAccount}/${handle}`;
+    expect(audit.some((e) => e.action === "channel.project_agent.invite" && e.resource === resource)).toBe(true);
+    expect(audit.some((e) => e.action === "channel.project_agent.remove" && e.resource === resource)).toBe(true);
+  });
+
+  it("records every guard configuration change with the guard name", async () => {
+    const owner = await seedToken("human", uniq("owner-token"), { owner: `${uniq("owner")}@example.com` });
+    const slug = await createChannel(owner.token);
+
+    expect((await api(`/api/channels/${slug}/completion-gate`, owner.token, { method: "PUT", body: JSON.stringify({ gate: "reviewer" }) })).status).toBe(200);
+    expect((await api(`/api/channels/${slug}/decision-mode`, owner.token, { method: "PUT", body: JSON.stringify({ mode: "unattended" }) })).status).toBe(200);
+    expect((await api(`/api/channels/${slug}/loop-guard`, owner.token, { method: "PUT", body: JSON.stringify({ enabled: false }) })).status).toBe(200);
+    expect((await api(`/api/channels/${slug}/workflow-guard`, owner.token, { method: "PUT", body: JSON.stringify({ enabled: true, limit: 5 }) })).status).toBe(200);
+
+    const audit = await channelAudit(slug, owner.token);
+    const updates = audit.filter((e) => e.action === "channel.guard.update");
+    const guards = updates.map((e) => (e.metadata as { guard?: string }).guard).sort();
+    expect(guards).toEqual(["completion_gate", "decision_mode", "loop_guard", "workflow_guard"]);
+    for (const e of updates) {
+      expect(e.resource).toBe(`channel/${slug}/guards/${(e.metadata as { guard: string }).guard}`);
+      expect(e.channel).toBe(slug);
+    }
+  });
+
+  it("records loop and workflow guard resets", async () => {
+    const owner = await seedToken("human", uniq("owner-token"), { owner: `${uniq("owner")}@example.com` });
+    const slug = await createChannel(owner.token);
+
+    expect((await api(`/api/channels/${slug}/reset-guard`, owner.token, { method: "POST" })).status).toBe(200);
+    expect(
+      (await api(`/api/channels/${slug}/workflows/wf-1/reset-guard`, owner.token, { method: "POST" })).status,
+    ).toBe(200);
+
+    const audit = await channelAudit(slug, owner.token);
+    expect(audit.some((e) => e.action === "channel.guard.reset" && (e.metadata as { guard?: string }).guard === "loop" && e.resource === `channel/${slug}/guards/loop`)).toBe(true);
+    expect(audit.some((e) => e.action === "channel.guard.reset" && (e.metadata as { guard?: string }).guard === "workflow" && e.resource === `channel/${slug}/guards/workflow/wf-1`)).toBe(true);
+  });
+});

--- a/worker/test/management-audit.spec.ts
+++ b/worker/test/management-audit.spec.ts
@@ -238,6 +238,7 @@ describe("management audit", () => {
       "channel.member.add",
       "channel.visibility.update",
       "channel.permissions.update",
+      "channel.create",
     ]);
     expect(page.audit.every((entry) => entry.channel === slug)).toBe(true);
     expect(page.audit.every((entry) => entry.actor_account === ownerAccount && entry.actor_kind === "human")).toBe(true);
@@ -273,15 +274,16 @@ describe("management audit", () => {
       expect((await api(`/api/channels/${slug}/members/${encodeURIComponent(account)}`, owner.token, { method: "PUT" })).status).toBe(200);
     }
 
+    // 4 rows total: channel.create (from createChannel) + 3 member adds.
     const first = await readPage(await api(`/api/channels/${slug}/management-audit?limit=2`, owner.token));
     expect(first.audit).toHaveLength(2);
     expect(first.next_cursor).toBeTypeOf("string");
     const second = await readPage(
       await api(`/api/channels/${slug}/management-audit?limit=2&cursor=${encodeURIComponent(first.next_cursor ?? "")}`, owner.token),
     );
-    expect(second.audit).toHaveLength(1);
+    expect(second.audit).toHaveLength(2);
     expect(second.next_cursor).toBeNull();
-    expect(new Set([...first.audit, ...second.audit].map((entry) => entry.resource)).size).toBe(3);
+    expect(new Set([...first.audit, ...second.audit].map((entry) => entry.resource)).size).toBe(4);
 
     expect((await api(`/api/channels/${slug}/management-audit?limit=0`, owner.token)).status).toBe(400);
     expect((await api(`/api/channels/${slug}/management-audit?limit=101`, owner.token)).status).toBe(400);

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -46,5 +46,11 @@
       "pattern": "agentparty.leeguoo.com",
       "custom_domain": true
     }
-  ]
+  ],
+  // #137 可观测性：开启 Cloudflare Workers Logs（内建，无需外部服务 / 密钥）。
+  // 线上出安全事件或故障时可在 dashboard 查 console.error（如审计落库失败标记）与请求日志。
+  "observability": {
+    "enabled": true,
+    "head_sampling_rate": 1
+  }
 }

--- a/worker/wrangler.xdream.jsonc
+++ b/worker/wrangler.xdream.jsonc
@@ -48,5 +48,11 @@
       "pattern": "agentparty.pwtk-dev.work",
       "custom_domain": true
     }
-  ]
+  ],
+  // #137 可观测性：开启 Cloudflare Workers Logs（内建，无需外部服务 / 密钥）。
+  // 线上出安全事件或故障时可在 dashboard 查 console.error（如审计落库失败标记）与请求日志。
+  "observability": {
+    "enabled": true,
+    "head_sampling_rate": 1
+  }
 }


### PR DESCRIPTION
## 补什么（#137 可观测性/运维审计，dimension 1）

`management_audit` + `bestEffortRecordManagementAudit` 早已存在，但许多**改状态的敏感管理端点从不落审计**——出安全事件/线上故障时既无法追责也无法定位。

## 做了（同 helper、同形状、不记密钥/token）
补审计到 11 个未覆盖端点：`channel.create`、`membership.set`、`channel.role.assign/remove`、`channel.join_link.create/revoke`、`channel.member.add`(link 自助入)、`channel.project_agent.invite/remove`、`channel.guard.update`(completion-gate/decision-mode/loop/workflow)、`channel.guard.reset`。（token 签发/撤销、权限/可见性变更、成员增删、webhook 增删/重投、archive 本已覆盖。）

- **迁移 0030**：扩 `management_audit.action` CHECK enum 收纳新 action。**并修一个潜伏 bug**：0025 的 CHECK 从没列 `channel.webhook.redeliver`（代码却已记录）→ 越界 insert 被 CHECK 拒、又被 best-effort helper 静默吞 → redeliver 审计一直在丢。现纳入。（SQLite 不能 ALTER CHECK，重建表→拷行→改名。）
- `management-audit.ts`：扩 action union + `safeMetadata` 白名单分支（kind/mode/visibility、tier、role、guard）——只有枚举字段进 metadata，绝不落 URL/密钥/正文。
- 两套 wrangler 加 Cloudflare Workers `observability` 块（enabled、head_sampling_rate:1）——内置 Workers Logs，无外部服务/密钥。

## 门禁（对 origin HEAD rebase 后亲验，与已合的 #137b/#137d 无冲突）
- 新 spec management-audit-coverage 8/8 + management-audit 更新 = 19/19；worker tsc 0；迁移守卫 ok（0030）；rebase 无冲突。
- 变异：role.assign 审计 action 记错 → 覆盖 spec 红；guard.reset 审计去掉 → 红。复绿。

## scope
lark-notify / 桌面配对 token 签发（需 Lark 配置/真配对，测不了）标 follow-up；squads/charter/昵称是内容非权限边界、刻意不记。

🤖 opus agent 实现（含修 redeliver 审计潜伏 bug）、收尾截断我接管（审+提交+复验）。
