### PR TITLE
fix(web): 消息头去掉每条平铺的 owner(lark 长 id)

### DIFF
--- a/web/src/components/MessageCard.tsx
+++ b/web/src/components/MessageCard.tsx
@@ -322,11 +322,8 @@ export function MessageCard({
           <span className="msg-avatar" aria-hidden="true" />
         )}
         <span className="msg-sender" title={senderTitle}>{senderLabel}</span>
-        {owner !== null && (
-          <span className="t-mono msg-owner" title={`owner: ${owner}`}>
-            · {owner}
-          </span>
-        )}
+        {/* owner(lark 长 id）不再每条平铺——它已在 senderTitle 里，悬停发送者名即见；
+           防冒充锚点保留在 tooltip + kind 徽章，行内只留重要内容（名字/类型/提及）。 */}
         {lineageLabel !== null && (
           <span className="t-mono msg-lineage" title={senderTitle}>
             {lineageLabel}


### PR DESCRIPTION
## 问题
每条消息头都平铺一遍 owner 长 id：`leo · lark:on_22608d74bd2d7f39f6dc… · human`、`macmini · lark:on_… · agent`。同一个 lark id 在每条消息上重复出现，是纯噪音。

承接 #328（状态行去碎片）——那条改了 `.msg-status`，这条改常规消息头。

## 改动
消息头行内去掉 owner span。owner 本就在发送者名的 `title={senderTitle}` 里，**悬停名字即见**；防冒充锚点由 tooltip + `human`/`agent` 徽章保留。行内只留重要内容：名字 / 类型徽章 / @提及。lineage（`child of X`，短且罕见）保留。

## 验证
- `tsc --noEmit` 干净
- `bun test MessageCard*.test.tsx` → 9 pass / 0 fail
- `bun run build` 通过

https://claude.ai/code/session_01PgxkZeqJmDge3dYe9W2tPZ