### PR TITLE
fix(cli): join pack 的 agent config 改放持久目录，不再被 macOS 临时清理抹掉身份

### DIFF
--- a/cli/src/commands/invite.ts
+++ b/cli/src/commands/invite.ts
@@ -207,7 +207,7 @@ curl -fsSL https://raw.githubusercontent.com/leeguooooo/agentparty/main/install.
 export PATH="\$HOME/.local/bin:\$PATH"
 
 # 2) 隔离本地配置（同机多身份不串号）
-export AGENTPARTY_CONFIG="\${TMPDIR:-/tmp}/agentparty-${shareName}-${slug}.json"
+export AGENTPARTY_CONFIG="$HOME/.agentparty/agents/agentparty-${shareName}-${slug}.json"
 
 # 3) 绑定频道（readonly token，只出现这一次）
 ${initLine}
@@ -242,11 +242,11 @@ export PATH="\$HOME/.local/bin:\$PATH"
 command -v party >/dev/null || { echo "party 仍不在 PATH，用绝对路径：\$HOME/.local/bin/party"; alias party="\$HOME/.local/bin/party"; }
 
 # 2) 隔离本地配置（同机多 agent 不串号）——记住这个路径，之后【每条 party 命令都要带上它】
-export AGENTPARTY_CONFIG="\${TMPDIR:-/tmp}/agentparty-${guestName}-${slug}.json"
+export AGENTPARTY_CONFIG="$HOME/.agentparty/agents/agentparty-${guestName}-${slug}.json"
 # ⚠ Claude Code 等按轮执行的 harness：不同 turn 是不同 shell，export 不保留！被 @ 唤醒后回复那轮
 #   若不带 AGENTPARTY_CONFIG，party send 会丢掉你的身份（回落到人类账号=冒充，或串到别的 agent）。
 #   所以：① init 已把路径记进本目录，party v0.2.60+ 能自动找回；② 保险起见，回复命令写成
-#   AGENTPARTY_CONFIG="\${TMPDIR:-/tmp}/agentparty-${guestName}-${slug}.json" party send ... 前缀内联。
+#   AGENTPARTY_CONFIG="$HOME/.agentparty/agents/agentparty-${guestName}-${slug}.json" party send ... 前缀内联。
 
 # 3) 绑定频道 + 报到（token 只出现这一次；报到不能省，否则网页看不到你）
 party init --server ${server} --token ${guest.token} --channel ${slug}

--- a/cli/test/__snapshots__/m3.test.ts.snap
+++ b/cli/test/__snapshots__/m3.test.ts.snap
@@ -20,11 +20,11 @@ export PATH="$HOME/.local/bin:$PATH"
 command -v party >/dev/null || { echo "party 仍不在 PATH，用绝对路径：$HOME/.local/bin/party"; alias party="$HOME/.local/bin/party"; }
 
 # 2) 隔离本地配置（同机多 agent 不串号）——记住这个路径，之后【每条 party 命令都要带上它】
-export AGENTPARTY_CONFIG="\${TMPDIR:-/tmp}/agentparty-fix-login-bug-guest-fix-login-bug.json"
+export AGENTPARTY_CONFIG="$HOME/.agentparty/agents/agentparty-fix-login-bug-guest-fix-login-bug.json"
 # ⚠ Claude Code 等按轮执行的 harness：不同 turn 是不同 shell，export 不保留！被 @ 唤醒后回复那轮
 #   若不带 AGENTPARTY_CONFIG，party send 会丢掉你的身份（回落到人类账号=冒充，或串到别的 agent）。
 #   所以：① init 已把路径记进本目录，party v0.2.60+ 能自动找回；② 保险起见，回复命令写成
-#   AGENTPARTY_CONFIG="\${TMPDIR:-/tmp}/agentparty-fix-login-bug-guest-fix-login-bug.json" party send ... 前缀内联。
+#   AGENTPARTY_CONFIG="$HOME/.agentparty/agents/agentparty-fix-login-bug-guest-fix-login-bug.json" party send ... 前缀内联。
 
 # 3) 绑定频道 + 报到（token 只出现这一次；报到不能省，否则网页看不到你）
 party init --server https://party.example --token ap_fix-login-bug-guest_secret --channel fix-login-bug


### PR DESCRIPTION
## 修什么（生产事故直接根因）

本机**全部 agent 的 config（含 token）被 macOS 定期临时清理批量删除**——join pack（`party invite` 打印的接入包）让 agent 把长期凭据放 `${TMPDIR:-/tmp}`，这是易失目录。后果链：serve 掉线 → @ 无人接 → 人类看到「唤醒失败」→ 发送 forbidden（回落人类账号）。

## 修法
join pack 三处路径 `${TMPDIR:-/tmp}/agentparty-<name>-<slug>.json` → **`$HOME/.agentparty/agents/agentparty-<name>-<slug>.json`**（持久；`writeConfig` 对 explicit 路径已自动 `mkdirSync(dirname)`，无需另建目录逻辑）。m3 join-pack 快照同步（diff 仅路径变化）。

## 门禁
cli 全量 635/0；tsc 0。

## 运营注意
存量 agent 的 config 已被清、需从工作身份重发 join pack / 重新 init 到新路径。本机 leo-codex-main-dev 等身份都需重铸 token（见频道协调）。

🤖 事故定位 + 修复。
