### PR TITLE
fix(security): 终端转义注入 + legacy token 跨频道 moderator（#372）

### DIFF
--- a/cli/src/format.ts
+++ b/cli/src/format.ts
@@ -1,6 +1,16 @@
 // 消息打印格式："[seq] name(kind): body 首行"，多行缩进跟随
 import type { AgentContext, MsgFrame } from "@agentparty/shared";
 
+// #372 安全：远端可控字段（body/name/owner/context/attachment 文件名/note 等）会被原样打进终端。
+// 攻击者发一条含终端转义序列的消息，就能在每个 watch/history 该频道的 agent 终端上注入 OSC52
+// 剪贴板写入、用光标/清屏序列伪造或隐藏输出。剥离 C0（保留 \t\n，去掉含 ESC/BEL/CR 在内的其余）、
+// DEL、C1，把注入序列降级为可见文本。换行是 formatMsg 自己的结构，逐行清洗后再拼接。
+// eslint-disable-next-line no-control-regex
+const TERMINAL_CONTROL = /[\x00-\x08\x0B-\x1F\x7F-\x9F]/g;
+export function stripTerminalControls(text: string): string {
+  return text.replace(TERMINAL_CONTROL, "");
+}
+
 function formatSender(m: MsgFrame): string {
   const owner = m.sender.owner && m.sender.owner !== m.sender.name ? ` owner=${m.sender.owner}` : "";
   const lineage = m.sender.lineage ? ` parent=${m.sender.lineage.parent_agent} team=${m.sender.lineage.team_id}` : "";
@@ -36,7 +46,12 @@ function formatAttachments(m: MsgFrame): string[] {
   );
 }
 
+// 唯一出口：任何远端字段拼进来后，整串统一剥离终端控制字符（#372）。逐行结构用的 \n/\t 保留。
 export function formatMsg(m: MsgFrame): string {
+  return stripTerminalControls(formatMsgRaw(m));
+}
+
+function formatMsgRaw(m: MsgFrame): string {
   const badges = [
     m.completion_artifact !== undefined ? "completion" : null,
     m.edited ? "edited" : null,

--- a/cli/test/format.test.ts
+++ b/cli/test/format.test.ts
@@ -147,3 +147,36 @@ describe("formatMsg", () => {
     );
   });
 });
+
+describe("formatMsg strips terminal control chars (#372 security)", () => {
+  const ESC = String.fromCharCode(0x1b);
+  const BEL = String.fromCharCode(0x07);
+  const CR = String.fromCharCode(0x0d);
+
+  test("neutralizes an OSC52 clipboard-write sequence in the body", () => {
+    const out = formatMsg(msgFrame({ body: `hi${ESC}]52;c;ZXZpbA==${BEL}there` }));
+    expect(out).not.toContain(ESC);
+    expect(out).not.toContain(BEL);
+    // 序列被降级为可见文本，内容不丢
+    expect(out).toContain("]52;c;ZXZpbA==");
+    expect(out).toBe("[7] agent-a(agent owner=team-a): hi]52;c;ZXZpbA==there");
+  });
+
+  test("strips CR (line-overwrite spoofing) and CSI cursor sequences", () => {
+    const out = formatMsg(msgFrame({ body: `real${CR}${ESC}[2Kfake` }));
+    expect(out).not.toContain(CR);
+    expect(out).not.toContain(ESC);
+    expect(out).toBe("[7] agent-a(agent owner=team-a): real[2Kfake");
+  });
+
+  test("preserves legitimate newlines (multi-line body) and tabs", () => {
+    const out = formatMsg(msgFrame({ body: "line1\nline2\tcol" }));
+    expect(out).toBe("[7] agent-a(agent owner=team-a): line1\n    line2\tcol");
+  });
+
+  test("sanitizes control chars injected via sender name / owner too", () => {
+    const out = formatMsg(msgFrame({ sender: { name: `a${ESC}[31m`, kind: "agent", owner: `t${BEL}` } }));
+    expect(out).not.toContain(ESC);
+    expect(out).not.toContain(BEL);
+  });
+});

--- a/worker/src/acl.ts
+++ b/worker/src/acl.ts
@@ -24,6 +24,15 @@ function isLegacyAdminToken(identity: AclIdentity): boolean {
   return !isOidcIdentity(identity) && identity.account == null;
 }
 
+// #372 安全修复：legacy 放行只对**无归属账号的老频道**（owner_account 为 null）生效。
+// 修复前，owner=null 的存量 ap_ token 对**任意**频道（含账号拥有的私有频道）恒判 moderator——
+// 迁移 0003 只 ADD COLUMN 不回填、`undefined == null` 为真，导致全局跨频道 god-mode。
+// 收紧后：老频道仍由 legacy token 过渡管理，但账号拥有的频道（owner_account 非空）不再放行，
+// legacy token 落到账号/成员规则（其 account 为 null，不匹配 owner_account）→ 私有频道被拒。
+function legacyAdminAppliesTo(identity: AclIdentity, channel: ChannelAcl): boolean {
+  return isLegacyAdminToken(identity) && channel.owner_account == null;
+}
+
 // 是否允许「进入/读」该频道（spec §5.4/§5.5 访问矩阵），判定顺序：
 //   ① public → 任何通过鉴权的身份放行（public 先于 scope，scoped token 也能进公开频道）
 //   ② channel_scope 非空 → 仅 slug 命中才放行，否则一律 forbidden（对所有 role 含 readonly 硬上限，
@@ -36,7 +45,7 @@ function isLegacyAdminToken(identity: AclIdentity): boolean {
 export function canAccessChannel(identity: AclIdentity, channel: ChannelAcl, isMember: boolean): boolean {
   if (channel.visibility === "public") return true;
   if (identity.channel_scope != null) return channel.slug === identity.channel_scope;
-  if (isLegacyAdminToken(identity)) return true;
+  if (legacyAdminAppliesTo(identity, channel)) return true;
   if (identity.role === "readonly") return false;
   if (identity.account != null && identity.account === channel.owner_account) return true;
   return isMember;
@@ -48,6 +57,6 @@ export function canAccessChannel(identity: AclIdentity, channel: ChannelAcl, isM
 export function isChannelModerator(identity: AclIdentity, channel: ChannelAcl): boolean {
   if (identity.role === "readonly") return false;
   if (identity.channel_scope != null) return false;
-  if (isLegacyAdminToken(identity)) return true;
+  if (legacyAdminAppliesTo(identity, channel)) return true;
   return identity.account != null && identity.account === channel.owner_account;
 }

--- a/worker/test/acl.spec.ts
+++ b/worker/test/acl.spec.ts
@@ -78,11 +78,13 @@ describe("canAccessChannel v2 matrix (spec §5.4/§5.5)", () => {
     expect(canAccessChannel(roNoScope, collabCh, false)).toBe(false);
   });
 
-  it("legacy ap_ token (owner=null) transitional passthrough on private (agent & readonly)", () => {
+  // #372 安全：legacy 放行只对无归属账号的老频道（owner_account=null）生效。
+  // 修复前 legacy token 对任意账号拥有的私有频道也 true（全局跨频道 god-mode）——现已收紧。
+  it("legacy ap_ token (owner=null) passes ONLY on owner_account=null legacy channels, denied on account-owned", () => {
     for (const id of [legacyAgent, legacyReadonly]) {
-      expect(canAccessChannel(id, privateOwned, false)).toBe(true);
-      expect(canAccessChannel(id, otherOwned, false)).toBe(true);
-      expect(canAccessChannel(id, legacyCh, false)).toBe(true);
+      expect(canAccessChannel(id, legacyCh, false)).toBe(true); // 老频道过渡放行
+      expect(canAccessChannel(id, privateOwned, false)).toBe(false); // #372：账号拥有的私有频道不再放行
+      expect(canAccessChannel(id, otherOwned, false)).toBe(false); // 别账号频道更不该进
     }
   });
 
@@ -102,8 +104,11 @@ describe("isChannelModerator v2 (spec §5)", () => {
     expect(isChannelModerator(apAgent, legacyCh)).toBe(false); // owner_account=null 不命中
   });
 
-  it("legacy ap_ token moderates (transitional); OIDC fan does not", () => {
-    expect(isChannelModerator(legacyAgent, privateOwned)).toBe(true);
+  // #372 安全：legacy token 只 moderate owner_account=null 的老频道，不再对账号拥有的频道恒判 moderator。
+  it("legacy ap_ token moderates ONLY owner_account=null channels; OIDC fan does not", () => {
+    expect(isChannelModerator(legacyAgent, legacyCh)).toBe(true); // 老频道过渡放行
+    expect(isChannelModerator(legacyAgent, privateOwned)).toBe(false); // #372：账号拥有的频道不再放行
+    expect(isChannelModerator(legacyAgent, otherOwned)).toBe(false); // 别账号频道不能管
     expect(isChannelModerator(oidcFan, publicCh)).toBe(false);
     expect(isChannelModerator(oidcFan, privateOwned)).toBe(false);
   });


### PR DESCRIPTION
两条经对抗性验证的安全问题（#372），leo-claude 接管（原 assignee leo-codex-main-dev 的 serve 已死，wake test 证实 offline）。

## 1. 终端转义注入 — cli/src/format.ts
`formatMsg` 把远端可控字段原样打进终端。攻击者发一条含终端转义序列的消息，就能在**每个 watch/history 该频道的 agent 终端**上注入 OSC52 剪贴板写入、用 CSI/CR 伪造或隐藏输出。跨公司频道下是真实横向攻击面。

**修复**：新增 `stripTerminalControls()`，在 formatMsg **唯一出口**剥离 C0（保留 `\t`/`\n`，去掉含 ESC/BEL/CR 的其余）、DEL、C1，一个 choke point 覆盖 body/name/owner/context/attachment 所有远端字段，把注入序列降级为可见文本（内容不丢）。

## 2. legacy ap_ token 跨频道恒判 moderator — worker/src/acl.ts
`owner=null` 的存量 `ap_` token（迁移 0003 只 ADD COLUMN 不回填 + JS `undefined==null`）对**任意频道**（含账号拥有的私有频道）恒判 moderator，可编辑 charter/踢人/归档/reset-guard，作用域全局跨频道。

**修复**：`legacyAdminAppliesTo(identity, channel)` = legacy token **且** `channel.owner_account == null`。放行只对无归属账号的老频道生效；账号拥有的频道落到账号/成员规则（legacy token 的 account 为 null，不匹配 owner_account）→ 被拒。channel-scoped token 不受影响（先被 scope 拦）。`acl.spec.ts` 里原本编码漏洞行为的断言已更新为安全行为。

## 验证
- worker：73 文件 / 484 用例全过（含更新后的 acl 对抗断言）、tsc 干净
- cli：659 用例全过（含 4 个新增控制字符剥离测试）、tsc 干净

Closes #372
https://claude.ai/code/session_01PgxkZeqJmDge3dYe9W2tPZ