### PR TITLE
feat: 角色 reports_to 管理层级(可跨 owner) — #370 组织树后端①

### DIFF
--- a/cli/src/commands/channel.ts
+++ b/cli/src/commands/channel.ts
@@ -45,6 +45,7 @@ const CHANNEL_FLAGS = [
   "max-uses",
   "remove",
   "responsibility",
+  "reports-to",
   "charter-write",
   "charter-write-agents",
   "agent",
@@ -601,7 +602,7 @@ export async function run(argv: string[]): Promise<number> {
           const role = positionals[3];
           const slug = resolveChannel(positionals[4]);
           if (!name || !role || !slug) {
-            console.error("usage: party channel role set <name> host|worker|reviewer|observer [slug] [--responsibility text]");
+            console.error("usage: party channel role set <name> host|worker|reviewer|observer [slug] [--responsibility text] [--reports-to <manager>|--reports-to \"\"]");
             return 1;
           }
           if (!isName(name)) {
@@ -617,8 +618,9 @@ export async function run(argv: string[]): Promise<number> {
             return 1;
           }
           const responsibility = str(flags.responsibility);
-          await setChannelRole(cfg.server, cfg.token, slug, name, role as (typeof COLLAB_ROLES)[number], responsibility);
-          console.log(`assigned ${name} as ${role} in ${slug}`);
+          const reportsTo = flags["reports-to"] === undefined ? undefined : str(flags["reports-to"]) ?? "";
+          await setChannelRole(cfg.server, cfg.token, slug, name, role as (typeof COLLAB_ROLES)[number], responsibility, reportsTo);
+          console.log(`assigned ${name} as ${role} in ${slug}${reportsTo ? `, reporting to ${reportsTo}` : ""}`);
           return 0;
         }
         if (action === "unset") {

--- a/cli/src/rest.ts
+++ b/cli/src/rest.ts
@@ -941,11 +941,16 @@ export async function setChannelRole(
   name: string,
   role: CollaborationRole,
   responsibility?: string,
+  // #370：向谁汇报（可跨 owner）。undefined=不改；空串=清空（顶层）；否则 agent 名。
+  reportsTo?: string,
 ): Promise<ChannelRoleInfo> {
+  const payload: Record<string, unknown> = { role };
+  if (responsibility !== undefined) payload.responsibility = responsibility;
+  if (reportsTo !== undefined) payload.reports_to = reportsTo === "" ? null : reportsTo;
   return (await req(server, `/api/channels/${encodeURIComponent(slug)}/roles/${encodeURIComponent(name)}`, {
     method: "PUT",
     headers: bearerJson(token),
-    body: JSON.stringify(responsibility === undefined ? { role } : { role, responsibility }),
+    body: JSON.stringify(payload),
   })) as ChannelRoleInfo;
 }
 

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -451,6 +451,8 @@ export interface ChannelRoleAssignment {
   kind?: SenderKind;
   account?: string;
   display?: string;
+  /** 管理层级（#370）：本 agent 向哪个 agent 汇报，构成组织树。可跨 owner；null/缺省=顶层。 */
+  reports_to?: string | null;
 }
 
 export interface HostLeaseEvaluation {

--- a/worker/migrations/0033_channel_role_reports_to.sql
+++ b/worker/migrations/0033_channel_role_reports_to.sql
@@ -1,0 +1,5 @@
+-- 组织架构管理层级（#370，方案A 团队面板）：agent 可向另一个 agent 汇报，构成 reports_to 树。
+-- 不加 owner 约束——允许**跨 owner 挂靠**（owner X 的 agent 挂到 owner Y 的 agent 下，由其领导）。
+-- 可空 = 顶层（不向谁汇报）。环路防护、自引用拒绝、目标须为本频道在场 agent，都在应用层校验
+-- （见 index.ts PUT /roles/:name）。归属账号仍由 owner_account 表达，reports_to 只表达管理层级。
+ALTER TABLE channel_roles ADD COLUMN reports_to TEXT;

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -214,6 +214,7 @@ interface ChannelRoleRow {
   assigned_at: number;
   token_role: TokenRole | null;
   account: string | null;
+  reports_to: string | null;
 }
 
 function channelRoleAssignmentFromRow(row: ChannelRoleRow): ChannelRoleAssignment {
@@ -227,13 +228,14 @@ function channelRoleAssignmentFromRow(row: ChannelRoleRow): ChannelRoleAssignmen
     ...(kind === undefined ? {} : { kind }),
     ...(row.account === null ? {} : { account: row.account }),
     ...(kind === "human" && row.account !== null ? { display: row.account } : { display: row.name }),
+    ...(row.reports_to == null ? {} : { reports_to: row.reports_to }),
   };
 }
 
 async function loadChannelRoleAssignment(db: D1Database, slug: string, name: string): Promise<ChannelRoleAssignment | null> {
   const row = await db.prepare(
     `SELECT cr.agent_name AS name, cr.role, cr.responsibility, cr.assigned_by, cr.assigned_at,
-            t.role AS token_role, t.owner AS account
+            t.role AS token_role, t.owner AS account, cr.reports_to
        FROM channel_roles cr
        LEFT JOIN tokens t ON t.name = cr.agent_name AND t.revoked_at IS NULL
       WHERE cr.channel_slug = ? AND cr.agent_name = ?`,
@@ -5003,7 +5005,7 @@ app.get("/api/channels/:slug/roles", async (c) => {
   }
   const { results } = await c.env.DB.prepare(
     `SELECT cr.agent_name AS name, cr.role, cr.responsibility, cr.assigned_by, cr.assigned_at,
-            t.role AS token_role, t.owner AS account
+            t.role AS token_role, t.owner AS account, cr.reports_to
        FROM channel_roles cr
        LEFT JOIN tokens t ON t.name = cr.agent_name AND t.revoked_at IS NULL
       WHERE cr.channel_slug = ?
@@ -5036,6 +5038,44 @@ app.put("/api/channels/:slug/roles/:name", async (c) => {
   if (responsibility === null) {
     return c.json(errorBody("bad_request", `responsibility must be a string <= ${ROLE_RESPONSIBILITY_LIMIT} bytes`), 400);
   }
+  // #370 reports_to：管理层级（可跨 owner）。undefined=不改；null/""=清空（顶层）；否则须是本频道在场
+  // 角色、非自己、且不成环。归属账号不参与此校验——正是为了允许 owner X 的 agent 挂到 owner Y 的 agent 下。
+  const reportsToRaw = body?.reports_to;
+  const reportsToProvided = reportsToRaw !== undefined;
+  let reportsTo: string | null = null;
+  if (reportsToProvided) {
+    if (reportsToRaw === null || reportsToRaw === "") {
+      reportsTo = null;
+    } else if (typeof reportsToRaw !== "string" || !NAME_RE.test(reportsToRaw)) {
+      return c.json(errorBody("bad_request", "reports_to must be a valid agent name or null"), 400);
+    } else if (reportsToRaw === name) {
+      return c.json(errorBody("bad_request", "an agent cannot report to itself"), 400);
+    } else {
+      reportsTo = reportsToRaw;
+    }
+    if (reportsTo !== null) {
+      const edgeRows = await c.env.DB.prepare(
+        "SELECT agent_name, reports_to FROM channel_roles WHERE channel_slug = ?",
+      )
+        .bind(slug)
+        .all<{ agent_name: string; reports_to: string | null }>();
+      const managerOf = new Map(edgeRows.results.map((r) => [r.agent_name, r.reports_to]));
+      if (!managerOf.has(reportsTo)) {
+        return c.json(errorBody("bad_request", "reports_to must reference an agent that already has a role in this channel"), 400);
+      }
+      // 从 reportsTo 沿 reports_to 链上溯：碰到被指派者 name → 会成环，拒绝。
+      let cursor: string | null = reportsTo;
+      const seen = new Set<string>();
+      while (cursor !== null) {
+        if (cursor === name) {
+          return c.json(errorBody("bad_request", "reports_to would create a reporting cycle"), 400);
+        }
+        if (seen.has(cursor)) break;
+        seen.add(cursor);
+        cursor = managerOf.get(cursor) ?? null;
+      }
+    }
+  }
   const assignedAt = Date.now();
   // 角色按账号锚定（#101）：绑定到该 name 当前【存活】token 的 owner。
   // 若无存活 token（预分配「先分工再铸 token」）→ null，等 persistToken 在首次铸造时认领绑定。
@@ -5046,16 +5086,17 @@ app.put("/api/channels/:slug/roles/:name", async (c) => {
     .first<{ owner: string | null }>();
   const ownerAccount = liveOwner?.owner ?? null;
   await c.env.DB.prepare(
-    `INSERT INTO channel_roles (channel_slug, agent_name, role, assigned_by, assigned_at, responsibility, owner_account)
-     VALUES (?, ?, ?, ?, ?, ?, ?)
+    `INSERT INTO channel_roles (channel_slug, agent_name, role, assigned_by, assigned_at, responsibility, owner_account, reports_to)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)
      ON CONFLICT(channel_slug, agent_name) DO UPDATE SET
        role = excluded.role,
        assigned_by = excluded.assigned_by,
        assigned_at = excluded.assigned_at,
        responsibility = ${responsibility.present ? "excluded.responsibility" : "channel_roles.responsibility"},
-       owner_account = COALESCE(excluded.owner_account, channel_roles.owner_account)`,
+       owner_account = COALESCE(excluded.owner_account, channel_roles.owner_account),
+       reports_to = ${reportsToProvided ? "excluded.reports_to" : "channel_roles.reports_to"}`,
   )
-    .bind(slug, name, role, identity.name, assignedAt, responsibility.value, ownerAccount)
+    .bind(slug, name, role, identity.name, assignedAt, responsibility.value, ownerAccount, reportsTo)
     .run();
   await fetchChannelDO(
     c.env,

--- a/worker/test/reports-to.spec.ts
+++ b/worker/test/reports-to.spec.ts
@@ -1,0 +1,66 @@
+// #370 组织架构管理层级：channel_roles.reports_to 构成组织树，允许跨 owner 挂靠。
+// 关键不变量：跨 owner 允许、自引用拒绝、环路拒绝、目标须为本频道已有角色。
+import { describe, expect, it } from "vitest";
+import { api, createChannel, seedToken, uniq } from "./helpers";
+
+async function setRole(
+  slug: string,
+  moderator: string,
+  name: string,
+  body: Record<string, unknown>,
+): Promise<Response> {
+  return api(`/api/channels/${slug}/roles/${name}`, moderator, {
+    method: "PUT",
+    body: JSON.stringify(body),
+  });
+}
+
+async function rolesOf(slug: string, token: string, name: string) {
+  const res = await api(`/api/channels/${slug}/roles`, token);
+  const { roles } = (await res.json()) as { roles: Array<{ name: string; reports_to?: string | null }> };
+  return roles.find((r) => r.name === name);
+}
+
+describe("channel role reports_to (org hierarchy #370)", () => {
+  it("round-trips reports_to and allows cross-owner reporting", async () => {
+    const ownerA = `a-${uniq("acct")}@example.com`;
+    const ownerB = `b-${uniq("acct")}@example.com`;
+    const human = await seedToken("human", uniq("human"), { owner: ownerA });
+    const lead = await seedToken("agent", uniq("lead"), { owner: ownerA });
+    const worker = await seedToken("agent", uniq("worker"), { owner: ownerB }); // 不同 owner
+    const slug = await createChannel(human.token);
+
+    // 先给两个 agent 角色（reports_to 目标须为本频道已有角色）
+    expect((await setRole(slug, human.token, lead.name, { role: "host" })).status).toBe(200);
+    expect((await setRole(slug, human.token, worker.name, { role: "worker" })).status).toBe(200);
+
+    // 跨 owner 挂靠：ownerB 的 worker 向 ownerA 的 lead 汇报 → 允许
+    const set = await setRole(slug, human.token, worker.name, { role: "worker", reports_to: lead.name });
+    expect(set.status).toBe(200);
+    expect((await rolesOf(slug, human.token, worker.name))?.reports_to).toBe(lead.name);
+
+    // 清空 → 顶层（reports_to 省略）
+    expect((await setRole(slug, human.token, worker.name, { role: "worker", reports_to: null })).status).toBe(200);
+    expect((await rolesOf(slug, human.token, worker.name))?.reports_to).toBeUndefined();
+  });
+
+  it("rejects self-reference, cycles, and unknown targets", async () => {
+    const owner = `${uniq("acct")}@example.com`;
+    const human = await seedToken("human", uniq("human"), { owner });
+    const a = await seedToken("agent", uniq("a"), { owner });
+    const b = await seedToken("agent", uniq("b"), { owner });
+    const slug = await createChannel(human.token);
+    await setRole(slug, human.token, a.name, { role: "worker" });
+    await setRole(slug, human.token, b.name, { role: "worker" });
+
+    // 自引用 → 400
+    expect((await setRole(slug, human.token, a.name, { role: "worker", reports_to: a.name })).status).toBe(400);
+
+    // 目标不是本频道角色 → 400
+    expect((await setRole(slug, human.token, a.name, { role: "worker", reports_to: "ghost-agent" })).status).toBe(400);
+
+    // 环路：a→b 后再 b→a 应被拒
+    expect((await setRole(slug, human.token, a.name, { role: "worker", reports_to: b.name })).status).toBe(200);
+    expect((await setRole(slug, human.token, b.name, { role: "worker", reports_to: a.name })).status).toBe(400);
+  });
+});


### PR DESCRIPTION
owner 定 #370 走方案A、组织架构走**办公软件式管理层级组织树**，且 agent 可**跨 owner 挂靠**（owner X 的 agent 挂到 owner Y 的 agent 下、由其领导）。这是后端①（web 组织树 UI 后续落）。

## 改动
- **迁移 0033**：`channel_roles` 加可空 `reports_to`（**不加 owner 约束＝允许跨 owner**）
- **shared**：`ChannelRoleAssignment.reports_to?: string \| null`
- **worker `PUT /roles/:name`**：收 `reports_to`，校验：
  - `null`/`""` → 清空（顶层）
  - 须是本频道已有角色（否则 400）
  - 不能是自己（400）
  - **环路防护**：从目标沿 reports_to 链上溯，碰到被指派者 → 400 `would create a reporting cycle`
  - 归属账号**不参与**校验 → 放行跨 owner
  - 序列化 + 两处 SELECT 带出 `reports_to`
- **cli**：`party channel role set <name> <role> [--reports-to <manager>|--reports-to ""]`

## 不变量（测试钉死）
跨 owner 允许 / round-trip / 清空 / 自引用→400 / 环路→400 / 目标不存在→400

## 验证
worker 74 文件 489 用例全过（+2 reports-to.spec）、cli 662 过、shared/worker/cli tsc 干净。

Refs #370
https://claude.ai/code/session_01PgxkZeqJmDge3dYe9W2tPZ