### PR TITLE
feat(web): composer 图片附件缩略图预览(#377)

### DIFF
--- a/web/src/components/AttachmentList.tsx
+++ b/web/src/components/AttachmentList.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import type { Attachment } from "@agentparty/shared";
 import { fetchAttachmentBlob, getToken } from "../lib/api";
 
-function isImage(contentType: string): boolean {
+export function isImageAttachment(contentType: string): boolean {
   return contentType.startsWith("image/");
 }
 
@@ -14,13 +14,17 @@ export function formatSize(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
-function ImageThumb({ att }: { att: Attachment }) {
+// 鉴权下载端点带不了 <img> 头，先 fetch 成 blob 再造 objectURL。消息缩略图与 composer 待发预览共用。
+export function useAttachmentBlobUrl(url: string): { src: string | null; failed: boolean } {
   const [src, setSrc] = useState<string | null>(null);
   const [failed, setFailed] = useState(false);
   useEffect(() => {
     let alive = true;
     let objectUrl: string | null = null;
-    fetchAttachmentBlob(getToken(), att.url)
+    setSrc(null);
+    setFailed(false);
+    if (url === "") return; // 非图片附件传空串 → 不发请求（hook 不能条件调用，用空串跳过）
+    fetchAttachmentBlob(getToken(), url)
       .then((blob) => {
         if (!alive) return;
         objectUrl = URL.createObjectURL(blob);
@@ -33,7 +37,12 @@ function ImageThumb({ att }: { att: Attachment }) {
       alive = false;
       if (objectUrl !== null) URL.revokeObjectURL(objectUrl);
     };
-  }, [att.url]);
+  }, [url]);
+  return { src, failed };
+}
+
+function ImageThumb({ att }: { att: Attachment }) {
+  const { src, failed } = useAttachmentBlobUrl(att.url);
   if (failed) return <FileLink att={att} />;
   if (src === null) {
     return <span className="msg-attachment-loading t-mono">{att.filename}…</span>;
@@ -81,7 +90,7 @@ export function AttachmentList({ attachments }: { attachments: Attachment[] }) {
     <div className="msg-attachments">
       {attachments.map((att) => (
         <div key={att.key} className="msg-attachment">
-          {isImage(att.content_type) ? <ImageThumb att={att} /> : <FileLink att={att} />}
+          {isImageAttachment(att.content_type) ? <ImageThumb att={att} /> : <FileLink att={att} />}
         </div>
       ))}
     </div>

--- a/web/src/components/Composer.attachments.test.tsx
+++ b/web/src/components/Composer.attachments.test.tsx
@@ -23,6 +23,8 @@ let renderer: ReactTestRenderer | null = null;
 beforeEach(() => {
   Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", { configurable: true, value: true });
   Object.defineProperty(globalThis, "localStorage", { configurable: true, value: memoryStorage() });
+  // #377 图片缩略图路径会走 getToken()（读 session/local storage）；单测无 DOM，补桩避免 ReferenceError。
+  Object.defineProperty(globalThis, "sessionStorage", { configurable: true, value: memoryStorage() });
 });
 
 afterEach(() => {
@@ -74,11 +76,20 @@ describe("Composer attachments (#176)", () => {
     expect(byClass(render({ onPickFiles: () => {} }), "composer-attach")).toHaveLength(1);
   });
 
-  test("pending attachment renders a chip with the filename", () => {
-    const root = render({ onPickFiles: () => {}, attachments: [att] });
+  test("non-image pending attachment renders a chip with the filename", () => {
+    const docAtt: Attachment = { ...att, key: "slug/uuid/spec.pdf", filename: "spec.pdf", content_type: "application/pdf" };
+    const root = render({ onPickFiles: () => {}, attachments: [docAtt] });
     const names = byClass(root, "composer-attachment-name");
     expect(names).toHaveLength(1);
-    expect(names[0]!.props.children).toBe("pic.png");
+    expect(names[0]!.props.children).toBe("spec.pdf");
+  });
+
+  test("image pending attachment renders a thumbnail preview with a remove button (#377)", () => {
+    const root = render({ onPickFiles: () => {}, attachments: [att], onRemoveAttachment: () => {} });
+    // 图片走缩略图路径（composer-attachment--img），不再是文件名 chip
+    expect(byClass(root, "composer-attachment--img")).toHaveLength(1);
+    expect(byClass(root, "composer-attachment-name")).toHaveLength(0);
+    expect(byClass(root, "composer-attachment-remove")).toHaveLength(1);
   });
 
   test("send is enabled with an attachment even when the draft is empty", () => {

--- a/web/src/components/Composer.tsx
+++ b/web/src/components/Composer.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import type { ChangeEvent, ClipboardEvent, CSSProperties, DragEvent, KeyboardEvent } from "react";
 import type { Attachment } from "@agentparty/shared";
-import { formatSize } from "./AttachmentList";
+import { formatSize, isImageAttachment, useAttachmentBlobUrl } from "./AttachmentList";
 import { agentHue } from "../lib/agentColor";
 import {
   activeMentionQuery,
@@ -44,6 +44,50 @@ export interface UploadItem {
   size: number;
   status: "uploading" | "error";
   error?: string;
+}
+
+// #377 待发附件预览（参考 Codex）：图片显缩略图 + 角标 ×；非图片显文件名 chip + ×。
+function PendingAttachment({
+  att,
+  onRemove,
+  removeLabel,
+}: {
+  att: Attachment;
+  onRemove?: (key: string) => void;
+  removeLabel: string;
+}) {
+  const isImage = isImageAttachment(att.content_type);
+  const { src, failed } = useAttachmentBlobUrl(isImage ? att.url : "");
+  const removeBtn =
+    onRemove === undefined ? null : (
+      <button
+        type="button"
+        className="composer-attachment-remove"
+        aria-label={removeLabel}
+        onClick={() => onRemove(att.key)}
+      >
+        ×
+      </button>
+    );
+  if (isImage && !failed) {
+    return (
+      <li className="composer-attachment composer-attachment--img" title={`${att.filename} · ${formatSize(att.size)}`}>
+        {src === null ? (
+          <span className="composer-attachment-thumb composer-attachment-thumb--loading" aria-hidden="true" />
+        ) : (
+          <img className="composer-attachment-thumb" src={src} alt={att.filename} />
+        )}
+        {removeBtn}
+      </li>
+    );
+  }
+  return (
+    <li className="composer-attachment t-mono">
+      <span className="composer-attachment-name">{att.filename}</span>
+      <span className="composer-attachment-size">{formatSize(att.size)}</span>
+      {removeBtn}
+    </li>
+  );
 }
 
 const TIER_DOT: Record<MentionTier, string> = { online: "●", wakeable: "◐", recent: "○" };
@@ -336,20 +380,12 @@ export function Composer({
       {attachments.length > 0 && (
         <ul className="composer-attachments" aria-label="pending attachments">
           {attachments.map((att) => (
-            <li key={att.key} className="composer-attachment t-mono">
-              <span className="composer-attachment-name">{att.filename}</span>
-              <span className="composer-attachment-size">{formatSize(att.size)}</span>
-              {onRemoveAttachment !== undefined && (
-                <button
-                  type="button"
-                  className="composer-attachment-remove"
-                  aria-label={`remove ${att.filename}`}
-                  onClick={() => onRemoveAttachment(att.key)}
-                >
-                  ×
-                </button>
-              )}
-            </li>
+            <PendingAttachment
+              key={att.key}
+              att={att}
+              onRemove={onRemoveAttachment}
+              removeLabel={`remove ${att.filename}`}
+            />
           ))}
         </ul>
       )}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -90,6 +90,7 @@ export async function inviteLarkMember(
 }
 
 export function urlToken(): string | null {
+  if (typeof window === "undefined") return null; // SSR/单测无 window 时不崩（无 URL token）
   return new URLSearchParams(window.location.search).get("t");
 }
 

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -4488,6 +4488,41 @@
   padding: 0;
 }
 .composer-attachment-remove:hover { color: var(--fg, inherit); }
+/* #377 图片待发预览（参考 Codex）：方形缩略图 + 右上角 × 浮层 */
+.composer-attachment--img {
+  position: relative;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+  width: 56px;
+  height: 56px;
+}
+.composer-attachment-thumb {
+  width: 56px;
+  height: 56px;
+  object-fit: cover;
+  display: block;
+}
+.composer-attachment-thumb--loading {
+  background: var(--t-panel2);
+  animation: kick-confirm-pulse 1.2s ease-in-out infinite;
+}
+.composer-attachment--img .composer-attachment-remove {
+  position: absolute;
+  top: 1px;
+  right: 1px;
+  width: 18px;
+  height: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  background: rgba(0, 0, 0, 0.55);
+  border-radius: 50%;
+  font-size: 13px;
+}
+.composer-attachment--img .composer-attachment-remove:hover { background: rgba(0, 0, 0, 0.8); color: #fff; }
 .composer-upload-error { margin: 0.25rem 0; }
 
 /* 拖拽上传高亮（#176）：composer 相对定位，dropzone 覆盖其上 */


### PR DESCRIPTION
owner 反馈参考 Codex：composer 里待发的**图片附件应显缩略图预览**（+ 角标 ×），而非纯文件名 chip。

## 改动
- 抽 `useAttachmentBlobUrl` hook + `isImageAttachment` 到 `AttachmentList`——消息缩略图与 composer 待发预览**共用**鉴权 blob 加载（不重复）
- `Composer` 新增 `PendingAttachment`：图片 → 方形缩略图 + 右上角 × 浮层（Codex 式）；非图片 → 文件名 chip + ×；filename/size 落 `title`
- `urlToken()` 加 `typeof window` guard（SSR/单测健壮性）

## 验证
web 650 全过（Composer 附件测试改为「缩略图 / 文件 chip」两路径 + 新增 #377 缩略图断言）、tsc 干净、build 通过。

Closes #377
https://claude.ai/code/session_01PgxkZeqJmDge3dYe9W2tPZ