### PR TITLE
feat(web): 组织架构树(办公软件式,按 reports_to,可跨 owner) — #370 前端①

### DIFF
--- a/web/src/components/OrgTree.test.ts
+++ b/web/src/components/OrgTree.test.ts
@@ -1,0 +1,44 @@
+// @ts-expect-error Bun executes this test, while the web tsconfig intentionally loads only Vite globals.
+import { describe, expect, test } from "bun:test";
+import type { ChannelRoleAssignment } from "@agentparty/shared";
+import { buildOrgForest } from "./OrgTree";
+
+function role(name: string, over: Partial<ChannelRoleAssignment> = {}): ChannelRoleAssignment {
+  return { name, role: "worker", responsibility: null, assigned_by: "x", assigned_at: 0, ...over };
+}
+
+describe("buildOrgForest (#370)", () => {
+  test("nests children under their reports_to manager (incl. cross-owner)", () => {
+    const roles = [
+      role("lead", { role: "host", account: "a@x.com" }),
+      role("w1", { account: "a@x.com", reports_to: "lead" }),
+      role("w2", { account: "b@y.com", reports_to: "lead" }), // 跨 owner 挂在 lead 下
+    ];
+    const forest = buildOrgForest(roles);
+    expect(forest.map((n) => n.role.name)).toEqual(["lead"]);
+    expect(forest[0]!.children.map((n) => n.role.name)).toEqual(["w1", "w2"]);
+  });
+
+  test("no-reports_to nodes are roots", () => {
+    const forest = buildOrgForest([role("a"), role("b")]);
+    expect(forest.map((n) => n.role.name).sort()).toEqual(["a", "b"]);
+    expect(forest.every((n) => n.children.length === 0)).toBe(true);
+  });
+
+  test("reports_to pointing to a non-member falls back to root (orphan)", () => {
+    const forest = buildOrgForest([role("a", { reports_to: "ghost" })]);
+    expect(forest.map((n) => n.role.name)).toEqual(["a"]);
+  });
+
+  test("cyclic reports_to does not infinite-loop and still renders all nodes as roots", () => {
+    const roles = [role("a", { reports_to: "b" }), role("b", { reports_to: "a" })];
+    const forest = buildOrgForest(roles);
+    // 两者互指成环 → 都当 root，节点不丢、不无限递归
+    expect(forest.map((n) => n.role.name).sort()).toEqual(["a", "b"]);
+  });
+
+  test("self-reference is treated as root", () => {
+    const forest = buildOrgForest([role("a", { reports_to: "a" })]);
+    expect(forest.map((n) => n.role.name)).toEqual(["a"]);
+  });
+});

--- a/web/src/components/OrgTree.tsx
+++ b/web/src/components/OrgTree.tsx
@@ -1,0 +1,182 @@
+// #370 组织架构树：按 channel_roles.reports_to 画办公软件式管理层级。
+// 支持跨 owner 挂靠——节点归属账号与其上级不同则显归属徽章。moderator 可就地设「向谁汇报」。
+import type { ChannelRoleAssignment, PresenceEntry } from "@agentparty/shared";
+import { useT } from "../i18n/useT";
+import "../i18n/strings/OrgTree";
+
+export interface OrgNode {
+  role: ChannelRoleAssignment;
+  children: OrgNode[];
+}
+
+// 从 roles 建森林：root = 无 reports_to 或指向不存在成员的节点。防环（沿链遇到已访问即断），
+// 保证任何数据下都能渲染出树（不会无限递归 / 丢节点）。
+export function buildOrgForest(roles: ChannelRoleAssignment[]): OrgNode[] {
+  const byName = new Map(roles.map((r) => [r.name, r]));
+  const nodes = new Map<string, OrgNode>(roles.map((r) => [r.name, { role: r, children: [] }]));
+  const roots: OrgNode[] = [];
+  for (const r of roles) {
+    const manager = r.reports_to != null && r.reports_to !== r.name ? byName.get(r.reports_to) : undefined;
+    // 防环：从 r 沿 reports_to 上溯，若能回到自己则视为无效上级 → 当 root
+    let cyclic = false;
+    if (manager) {
+      const seen = new Set<string>([r.name]);
+      let cur: string | null | undefined = r.reports_to;
+      while (cur != null) {
+        if (seen.has(cur)) { cyclic = true; break; }
+        seen.add(cur);
+        cur = byName.get(cur)?.reports_to ?? null;
+      }
+    }
+    if (manager && !cyclic) nodes.get(manager.name)!.children.push(nodes.get(r.name)!);
+    else roots.push(nodes.get(r.name)!);
+  }
+  const sortRec = (list: OrgNode[]) => {
+    list.sort((a, b) => a.role.name.localeCompare(b.role.name));
+    for (const n of list) sortRec(n.children);
+  };
+  sortRec(roots);
+  return roots;
+}
+
+type NodeStatus = "online" | "wakeable" | "offline";
+function statusOf(p: PresenceEntry | undefined): NodeStatus {
+  if (p?.live === true) return "online";
+  const kind = p?.wake?.kind;
+  if (kind === "watch" || kind === "serve" || kind === "webhook") return "wakeable";
+  return "offline";
+}
+
+function OrgRow({
+  node,
+  depth,
+  presenceByName,
+  parentAccount,
+  allNames,
+  canModerate,
+  onSetReportsTo,
+  busyName,
+  onOpenDetail,
+}: {
+  node: OrgNode;
+  depth: number;
+  presenceByName: Map<string, PresenceEntry>;
+  parentAccount: string | null;
+  allNames: string[];
+  canModerate: boolean;
+  onSetReportsTo?: (name: string, reportsTo: string | null) => void;
+  busyName: string | null;
+  onOpenDetail?: (name: string) => void;
+}) {
+  const t = useT();
+  const { role } = node;
+  const p = presenceByName.get(role.name);
+  const status = statusOf(p);
+  const account = role.account ?? null;
+  // 跨 owner：本节点归属账号与其上级不同 → 显归属徽章（办公软件里「外部/借调」的意味）
+  const crossOwner = account !== null && parentAccount !== null && account !== parentAccount;
+  return (
+    <li className="org-node">
+      <div className="org-row" style={{ paddingLeft: `${depth * 16}px` }}>
+        <span className={`org-status org-status--${status}`} aria-hidden="true" />
+        <button
+          type="button"
+          className="org-name"
+          onClick={() => onOpenDetail?.(role.name)}
+          title={account ?? role.name}
+        >
+          {role.display ?? role.name}
+        </button>
+        <span className={`org-role org-role--${role.role}`}>{role.role}</span>
+        {crossOwner && (
+          <span className="org-owner-badge" title={t("OrgTree.ownerBadge.title", { account: account ?? "" })}>
+            {t("OrgTree.ownerBadge.label", { account: shortAccount(account) })}
+          </span>
+        )}
+        <span className={`org-status-text org-status-text--${status}`}>{t(`OrgTree.status.${status}`)}</span>
+        {canModerate && onSetReportsTo !== undefined && (
+          <select
+            className="org-reports-select"
+            value={role.reports_to ?? ""}
+            disabled={busyName === role.name}
+            aria-label={t("OrgTree.reportsTo.label", { name: role.name })}
+            onChange={(e) => onSetReportsTo(role.name, e.target.value === "" ? null : e.target.value)}
+          >
+            <option value="">{t("OrgTree.reportsTo.top")}</option>
+            {allNames
+              .filter((n) => n !== role.name)
+              .map((n) => (
+                <option key={n} value={n}>
+                  {t("OrgTree.reportsTo.option", { name: n })}
+                </option>
+              ))}
+          </select>
+        )}
+      </div>
+      {node.children.length > 0 && (
+        <ul className="org-children">
+          {node.children.map((child) => (
+            <OrgRow
+              key={child.role.name}
+              node={child}
+              depth={depth + 1}
+              presenceByName={presenceByName}
+              parentAccount={account}
+              allNames={allNames}
+              canModerate={canModerate}
+              onSetReportsTo={onSetReportsTo}
+              busyName={busyName}
+              onOpenDetail={onOpenDetail}
+            />
+          ))}
+        </ul>
+      )}
+    </li>
+  );
+}
+
+function shortAccount(account: string | null): string {
+  if (account === null) return "";
+  const at = account.indexOf("@");
+  return at > 0 ? account.slice(0, at) : account;
+}
+
+export function OrgTree({
+  roles,
+  presence,
+  canModerate = false,
+  onSetReportsTo,
+  busyName = null,
+  onOpenDetail,
+}: {
+  roles: ChannelRoleAssignment[];
+  presence: PresenceEntry[];
+  canModerate?: boolean;
+  onSetReportsTo?: (name: string, reportsTo: string | null) => void;
+  busyName?: string | null;
+  onOpenDetail?: (name: string) => void;
+}) {
+  const t = useT();
+  const forest = buildOrgForest(roles);
+  const presenceByName = new Map(presence.map((p) => [p.name, p]));
+  const allNames = roles.map((r) => r.name);
+  if (forest.length === 0) return <p className="org-empty">{t("OrgTree.empty")}</p>;
+  return (
+    <ul className="org-tree" aria-label={t("OrgTree.aria")}>
+      {forest.map((node) => (
+        <OrgRow
+          key={node.role.name}
+          node={node}
+          depth={0}
+          presenceByName={presenceByName}
+          parentAccount={null}
+          allNames={allNames}
+          canModerate={canModerate}
+          onSetReportsTo={onSetReportsTo}
+          busyName={busyName}
+          onOpenDetail={onOpenDetail}
+        />
+      ))}
+    </ul>
+  );
+}

--- a/web/src/i18n/strings/OrgTree.ts
+++ b/web/src/i18n/strings/OrgTree.ts
@@ -1,0 +1,32 @@
+import { registerDict, type LocaleDict } from "../dict";
+
+export const OrgTreeStrings: LocaleDict = {
+  en: {
+    "OrgTree.heading": "Org chart · reporting lines",
+    "OrgTree.aria": "org chart by reporting line",
+    "OrgTree.empty": "No roles assigned yet — assign roles to build the org chart.",
+    "OrgTree.status.online": "online",
+    "OrgTree.status.wakeable": "wakeable",
+    "OrgTree.status.offline": "offline",
+    "OrgTree.ownerBadge.label": "owner: {account}",
+    "OrgTree.ownerBadge.title": "belongs to a different account ({account}) than its manager (cross-org delegation)",
+    "OrgTree.reportsTo.label": "set who {name} reports to",
+    "OrgTree.reportsTo.top": "— top level —",
+    "OrgTree.reportsTo.option": "reports to {name}",
+  },
+  zh: {
+    "OrgTree.heading": "组织架构 · 汇报线",
+    "OrgTree.aria": "按汇报线的组织架构图",
+    "OrgTree.empty": "还没有分工——先给成员分配角色来生成组织架构图。",
+    "OrgTree.status.online": "在线",
+    "OrgTree.status.wakeable": "可唤醒",
+    "OrgTree.status.offline": "离线",
+    "OrgTree.ownerBadge.label": "归属：{account}",
+    "OrgTree.ownerBadge.title": "归属账号（{account}）与其上级不同——跨组织挂靠",
+    "OrgTree.reportsTo.label": "设置 {name} 向谁汇报",
+    "OrgTree.reportsTo.top": "— 顶层 —",
+    "OrgTree.reportsTo.option": "向 {name} 汇报",
+  },
+};
+
+registerDict(OrgTreeStrings);

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -607,11 +607,15 @@ export async function setChannelRole(
   name: string,
   role: CollaborationRole,
   responsibility: string,
+  // #370：向谁汇报（可跨 owner）。undefined=不改；null=清空（顶层）；否则 agent 名。
+  reportsTo?: string | null,
 ): Promise<ChannelRoleInfo> {
+  const body: Record<string, unknown> = { role, responsibility };
+  if (reportsTo !== undefined) body.reports_to = reportsTo;
   const res = await fetchApi(`/api/channels/${encodeURIComponent(slug)}/roles/${encodeURIComponent(name)}`, {
     method: "PUT",
     headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
-    body: JSON.stringify({ role, responsibility }),
+    body: JSON.stringify(body),
   });
   if (res.status === 401) throw new AuthError("invalid or revoked token");
   if (res.status === 403) throw new ForbiddenError("forbidden");

--- a/web/src/pages/Channel.tsx
+++ b/web/src/pages/Channel.tsx
@@ -15,6 +15,7 @@ import { MessageCard } from "../components/MessageCard";
 import { MentionToast, type MentionToastItem } from "../components/MentionToast";
 import { NotifyToggle, readNotifyOptin } from "../components/NotifyToggle";
 import { PresenceBar } from "../components/PresenceBar";
+import { OrgTree } from "../components/OrgTree";
 import { OrgTreePreview } from "../components/OrgTreePreview";
 import {
   archiveChannel,
@@ -3092,6 +3093,26 @@ export function ChannelPage({
       .finally(() => setRoleSaving(null));
   }, [channelRoles, roleSaving, slug, token, t]);
 
+  // #370 组织树：就地设置某成员向谁汇报（reportsTo=null 清空）。沿用现有角色/职责，只改 reports_to。
+  const setReportsTo = useCallback((name: string, reportsTo: string | null) => {
+    if (roleSaving !== null) return;
+    const current = channelRoles.find((role) => role.name === name);
+    if (current === undefined) return;
+    setRoleSaving(name);
+    setRoleError(null);
+    setChannelRole(token, slug, name, current.role, current.responsibility ?? "", reportsTo)
+      .then((saved) => {
+        setChannelRoles((roles) => [...roles.filter((role) => role.name !== saved.name), { ...current, ...saved }]);
+      })
+      .catch((err: unknown) => {
+        if (err instanceof AuthError) authFailedRef.current(tRef.current("Channel.error.tokenRevoked"));
+        else if (err instanceof ForbiddenError) setRoleError(t("Channel.roles.forbidden"));
+        else if (err instanceof ValidationError) setRoleError(t("Channel.roles.invalid"));
+        else setRoleError(t("Channel.roles.saveFailed"));
+      })
+      .finally(() => setRoleSaving(null));
+  }, [channelRoles, roleSaving, slug, token, t]);
+
   const clearRole = useCallback((name: string) => {
     if (roleSaving !== null) return;
     const ok = window.confirm(t("Channel.roles.clearConfirm", { name }));
@@ -3711,6 +3732,19 @@ export function ChannelPage({
               onSave={saveCharter}
               onRetry={() => void loadCharter()}
             />
+          )}
+          {activePanel === "roles" && (
+            <div className="org-tree-section">
+              <div className="org-tree-head">{t("OrgTree.heading")}</div>
+              <OrgTree
+                roles={channelRoles}
+                presence={Object.values(state.presence)}
+                canModerate={canModerate}
+                onSetReportsTo={setReportsTo}
+                busyName={roleSaving}
+                onOpenDetail={setOpenAgentDetail}
+              />
+            </div>
           )}
           {activePanel === "roles" && (
             <DivisionBoard

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -5898,3 +5898,41 @@
     min-height: 36px;
   }
 }
+
+/* #370 组织架构树（办公软件式管理层级，按 reports_to） */
+.org-tree-section { margin: 0 4px 8px; }
+.org-tree-head { font-size: 12px; font-weight: 700; color: var(--t-muted); padding: 4px 2px; }
+.org-tree, .org-children { list-style: none; margin: 0; padding: 0; }
+.org-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 4px;
+  border-radius: 4px;
+}
+.org-row:hover { background: var(--t-panel2); }
+.org-status { width: 8px; height: 8px; border-radius: 50%; flex: none; }
+.org-status--online { background: #2ecc71; }
+.org-status--wakeable { background: #f4c430; }
+.org-status--offline { background: var(--t-faint); }
+.org-name {
+  border: none; background: none; cursor: pointer; padding: 0;
+  color: var(--fg, inherit); font-weight: 600; font-size: 13px;
+}
+.org-name:hover { text-decoration: underline; }
+.org-role {
+  font-size: 10px; padding: 0 5px; border-radius: 0; border: 1px solid var(--t-faint);
+  color: var(--t-dim); text-transform: uppercase; letter-spacing: 0.03em;
+}
+.org-role--host { color: var(--t-accent); border-color: var(--t-accent); }
+.org-owner-badge {
+  font-size: 10px; padding: 0 5px; border-radius: 8px;
+  background: var(--d-yellow, #f4e5b8); color: var(--fg, #6b5900);
+}
+.org-status-text { font-size: 10px; color: var(--t-dim); }
+.org-status-text--online { color: #2ecc71; }
+.org-reports-select {
+  margin-left: auto; font-size: 11px; max-width: 160px;
+  background: var(--t-panel2); color: var(--fg, inherit); border: 1px solid var(--t-faint);
+}
+.org-empty { color: var(--t-dim); font-size: 12px; padding: 6px 4px; }


### PR DESCRIPTION
owner 定 #370 方案A + 组织架构走**办公软件式管理层级组织树**。这是前端①：组织树落地（后端 reports_to 已在 #378 合入）。

## 改动
- **OrgTree 组件**：从 `channel_roles.reports_to` 建管理层级森林（`buildOrgForest`）；**防环/自引用/孤儿**都兜底当 root（不无限递归、不丢节点）
- 每节点：状态点（在线/可唤醒/离线）+ 名字（点开 AgentDetailModal）+ 角色徽章 + **跨 owner 归属徽章**（归属账号 ≠ 上级账号时显示）+ moderator 就地设「向谁汇报」下拉
- 接入分工面板顶部；`setChannelRole` web 端加 `reportsTo` 透传 + `setReportsTo` handler
- i18n en+zh + CSS

## 验证
`buildOrgForest` 单测：跨 owner 挂靠 / 无 reports_to 为 root / 孤儿兜底 / 环路不无限递归 / 自引用当 root。web 655 全过（+5）、tsc/build 干净。

## 剩余（后续 PR）
分工/协调面板完整合并、任务详情/检索、#369 上传 UI。本 PR 落地 owner 最看重的**组织树 + 跨 owner 汇报**核心能力。

Refs #370
https://claude.ai/code/session_01PgxkZeqJmDge3dYe9W2tPZ