### PR TITLE
perf(worker): 附件内容 hash 去重(#387)

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -5549,13 +5549,23 @@ app.post("/api/channels/:slug/attachments", async (c) => {
     return c.json(errorBody("too_large", `attachment exceeds ${sizeLimit} bytes${sizeHint}`), 413);
   }
   const contentType = c.req.header("content-type")?.split(";")[0]?.trim() || "application/octet-stream";
-  // key 前缀锚定 slug：下载时 worker 用权威 slug 重新拼 key，跨频道的伪造引用读不到别人的 blob
-  const objectPath = `${crypto.randomUUID()}/${filename}`;
+  // #387 内容 hash 去重：object 按内容 sha256 命名（不再随机 uuid）——同频道内同内容+同名
+  // 重复上传落到同一个 key，R2 里只存一份，省存储/带宽。key 前缀仍锚定 slug 做跨频道隔离
+  // （下载时 worker 用权威 slug 重拼 key，伪造引用读不到别人的 blob）。hash 即完整性锚。
+  const digest = await crypto.subtle.digest("SHA-256", bytes.buffer as ArrayBuffer);
+  const hash = Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+  const objectPath = `${hash}/${filename}`;
   const key = `${slug}/${objectPath}`;
-  await c.env.ATTACHMENTS.put(key, bytes, {
-    httpMetadata: { contentType },
-    customMetadata: { filename, uploaded_by: identity.name, channel: slug },
-  });
+  // 已存在同内容同名对象 → 跳过 put（去重命中），省一次写 + 上行带宽。
+  const existing = await c.env.ATTACHMENTS.head(key);
+  if (existing === null) {
+    await c.env.ATTACHMENTS.put(key, bytes, {
+      httpMetadata: { contentType },
+      customMetadata: { filename, uploaded_by: identity.name, channel: slug },
+    });
+  }
   const meta: Attachment = {
     key,
     filename,

--- a/worker/test/attachments.spec.ts
+++ b/worker/test/attachments.spec.ts
@@ -131,4 +131,27 @@ describe("channel attachments (R2)", () => {
       url: meta.url,
     });
   });
+
+  it("dedupes by content hash: same bytes+filename → same key; different bytes → different key (#387)", async () => {
+    const { token } = await seedToken("agent", uniq("owner"), { owner: "owner@ap.test" });
+    const slug = await createChannel(token);
+    const bytes = new TextEncoder().encode("identical payload for dedup");
+
+    const first = (await (await upload(slug, token, "dup.bin", bytes)).json()) as { key: string; url: string };
+    const second = (await (await upload(slug, token, "dup.bin", bytes)).json()) as { key: string; url: string };
+    // 内容 hash 命名 → 同内容同名两次上传落同一个 key（R2 里只一份）
+    expect(second.key).toBe(first.key);
+    expect(second.url).toBe(first.url);
+    // key 是 slug/<64hex>/filename
+    expect(first.key).toMatch(new RegExp(`^${slug}/[0-9a-f]{64}/dup\\.bin$`));
+
+    // 内容不同 → key 不同
+    const other = (await (await upload(slug, token, "dup.bin", new TextEncoder().encode("different"))).json()) as { key: string };
+    expect(other.key).not.toBe(first.key);
+
+    // 去重命中后仍可正常下载（对象确实在）
+    const dl = await download(slug, token, second.url.split("/attachments/")[1]!);
+    expect(dl.status).toBe(200);
+    expect(new TextEncoder().encode(await dl.text())).toEqual(bytes);
+  });
 });


### PR DESCRIPTION
附件 object 之前用随机 uuid 命名，同文件重复上传在 R2 存多份。改成按内容 **sha256 命名**：key = `<slug>/<sha256>/<filename>`。同频道同内容+同名重复上传落同一 key，head 命中就跳过 put——省存储+带宽，hash 即完整性锚。

key 前缀仍锚定 slug（跨频道隔离不动）；旧 uuid-key 存量附件照常解析，向后兼容。

worker 全量 + 附件 round-trip 全过（新增去重断言）、tsc 干净。

Closes #387