### PR TITLE
ci(pr-agent): cancel-in-progress 改 false（取消的 required check 会卡合并）

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -18,7 +18,9 @@ permissions:
 
 concurrency:
   group: pr-agent-${{ github.event.pull_request.number || github.event.issue.number }}
-  cancel-in-progress: true
+  # 不取消在途 run：pr_agent 是 required check，被取消的 run 会报红卡住合并，且取消绕过
+  # continue-on-error/exit 0。宁可多跑一次也不能让取消把 required check 变红。
+  cancel-in-progress: false
 
 jobs:
   pr_agent:


### PR DESCRIPTION
软阻断实测踩到的坑：pr_agent 是 required check，但 cancel-in-progress:true 时并发把在途 run 取消 → 取消的 job 报红（且绕过 continue-on-error），把 PR 卡死（#397 实测中招）。改 cancel-in-progress:false，宁可多跑一次也不让取消变红。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化自动检查流程，避免新运行取消进行中的检查，减少合并状态异常或检查变红的情况。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->