### PR TITLE
ci: review-ack 强制闸——合并前必须留 review 结论（不靠记忆，对所有人生效）

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## 改动说明
+<!-- 这个 PR 做了什么、为什么 -->
+
+## 合并前检查（review-ack 强制闸——不留结论合不了）
+> main 分支保护要求：合并前必须**读过 review 并留下结论**。做法二选一，否则 `review-ack` check 红、无法合并：
+> - 在本 PR 提交一次 review（Files → Review changes → Approve/Comment），或
+> - 评论一条以 `review-ack:` 开头的结论，说清 pr-agent(qwen) / CodeRabbit 的 review 有无**真问题**、哪些是**误报**、哪些**采纳**。
+
+- [ ] 我已读 pr-agent / CodeRabbit 的 review，真问题已处理、误报已判明
+- [ ] 本地门禁通过（tsc / 测试 / build）
+- [ ] 涉及安全/鉴权/数据的改动已做对抗性验证（变异测试或等价手段）

--- a/.github/workflows/review-ack.yml
+++ b/.github/workflows/review-ack.yml
@@ -1,0 +1,54 @@
+# 合并前必须「读了 review」的强制闸——对所有人生效，不靠任何人记忆。
+# 机制：这是 required check，只有当 PR 上出现一条 review 结论（ack）时才变绿、才允许合并。
+# ack = 任意非机器人身份 提交了 PR review（approve/comment/request-changes），
+#   或 留了一条以 `review-ack:` / `合并前已读` 开头的评论。
+# 不依赖任何 LLM 端点：即便 pr-agent 端点挂了、无自动 review，人也必须自己看过并写下结论才能合。
+# 空 ack 也拦不住恶意糊弄，但把「留结论」变成仓库强制的可核查动作，而非记忆里的自觉。
+name: Review Ack Gate
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  pull_request_review:
+    types: [submitted, dismissed]
+  issue_comment:
+    types: [created, edited, deleted]
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+
+concurrency:
+  group: review-ack-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: false   # required check 不能被取消（取消=红=卡合并）
+
+jobs:
+  review-ack:
+    if: >-
+      github.event_name != 'issue_comment' ||
+      github.event.issue.pull_request
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: 检查 PR 是否已有「读过 review」的结论（ack）
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number || github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          BOTS='github-actions|github-actions\[bot\]|qodo|pr-agent|coderabbit|dependabot'
+          # ① 正式 PR review（approve / comment / changes_requested），非机器人
+          REVIEWS=$(gh api "repos/$REPO/pulls/$PR/reviews" --paginate \
+            --jq "[.[] | select((.user.login | test(\"$BOTS\"; \"i\")) | not) | select(.state != \"PENDING\")] | length")
+          # ② 评论里的显式 ack（review-ack: / 合并前已读 / 合并者 review 结论），非机器人
+          ACK_COMMENTS=$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
+            --jq "[.[] | select((.user.login | test(\"$BOTS\"; \"i\")) | not) | select(.body | test(\"review-ack:|合并前已读|合并者 review 结论\"; \"i\"))] | length")
+          echo "非机器人 PR reviews: $REVIEWS · ack 评论: $ACK_COMMENTS"
+          if [ "$REVIEWS" -gt 0 ] || [ "$ACK_COMMENTS" -gt 0 ]; then
+            echo "✅ 已有 review 结论——合并者看过了。"
+            exit 0
+          fi
+          echo "::error::合并前必须先读 review 并留结论：在 PR 上提交一次 review，或评论一条以 'review-ack:' 开头的合并结论（说清 pr-agent/CodeRabbit 的 review 有无真问题、误报、是否采纳）。这是对所有人生效的强制闸，不是自觉。"
+          exit 1

--- a/.github/workflows/review-ack.yml
+++ b/.github/workflows/review-ack.yml
@@ -41,7 +41,7 @@ jobs:
           BOTS='github-actions|github-actions\[bot\]|qodo|pr-agent|coderabbit|dependabot'
           # ① 正式 PR review（approve / comment / changes_requested），非机器人
           REVIEWS=$(gh api "repos/$REPO/pulls/$PR/reviews" --paginate \
-            --jq "[.[] | select((.user.login | test(\"$BOTS\"; \"i\")) | not) | select(.state != \"PENDING\")] | length")
+            --jq "[.[] | select((.user.login | test(\"$BOTS\"; \"i\")) | not) | select(.state != \"PENDING\" and .state != \"DISMISSED\")] | length")
           # ② 评论里的显式 ack（review-ack: / 合并前已读 / 合并者 review 结论），非机器人
           ACK_COMMENTS=$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
             --jq "[.[] | select((.user.login | test(\"$BOTS\"; \"i\")) | not) | select(.body | test(\"review-ack:|合并前已读|合并者 review 结论\"; \"i\"))] | length")

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+# 贡献指南
+
+## 合并纪律：review 必须被「读到」，不靠记忆
+
+自动 review（pr-agent 用 qwen-max、CodeRabbit）会在每个 PR 上贴评论。但**非阻塞的 review 若没人读就是摆设**。为此 main 分支有两道对所有人生效的强制闸（required status checks），不依赖任何人的自觉：
+
+1. **`pr_agent`（软阻断）**：合并前必须等自动 review 跑完——端点通时评论已贴在 PR 上；端点挂时无评论但 check 照样绿（不卡死 PR）。
+2. **`review-ack`（读了才能合）**：合并前必须有人留下 **review 结论**，否则 check 红、无法合并。做法二选一：
+   - 在 PR 提交一次 review（Approve / Comment / Request changes），或
+   - 评论一条以 `review-ack:` 开头（或含「合并前已读」「合并者 review 结论」）的结论，说清 review 有无**真问题**、哪些是**误报**、哪些**采纳**。
+
+> 为什么这样设计：`pr_agent` 保证 review 被**产出**，`review-ack` 保证 review 被**读到并判断**。两道都不依赖 LLM 端点存活；端点挂时 `pr_agent` 自动放行，但 `review-ack` 仍要求人看过——因为「有没有真问题」终究要人判。
+
+## 其它约定
+
+- 开自己的分支 + worktree 提 PR；动代码前先 `git fetch` 查重（多 agent 并行开发）。
+- 迁移文件用 `worker/migrations/` 下一个空号（四位），过 `scripts/check-migration-numbering.test.ts`。
+- Secret 绝不硬编码进代码/工作流——用 GitHub Secret 引用。


### PR DESCRIPTION
review-ack: owner 指出『合并前读 review』不能靠 agent 记忆——别人进来提代码看不到。本 PR 把纪律固化进仓库：

- **新 required check `review-ack`**：合并前必须有人留下 review 结论（正式 PR review，或以 `review-ack:` 开头的评论）才变绿、才允许合并。不依赖 LLM 端点。
- **PR 模板** + **CONTRIBUTING.md**：新贡献者一眼看到两道闸的规则。

配合已有的 `pr_agent`（软阻断，保证 review 被产出），`review-ack` 保证 review 被读到并判断。本 PR 自己就要过这道闸——我会留 review 结论。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增“合并前 Review 确认”检查：仅当 PR 存在非机器人用户的正式 Review（approve/comment/request-changes）或包含指定确认关键词的讨论评论时，才允许合并。
* **改进**
  * 未检测到符合条件的有效确认时，检查将失败并阻止合并。
  * 在 PR/评论相关触发场景下自动更新必读检查状态。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->