### PR TITLE
fix(desktop): 桌面 @提醒去重/清积压 + 输入框 memo 消卡顿 (#399①③④)

### DIFF
--- a/desktop/src-tauri/capabilities/default.json
+++ b/desktop/src-tauri/capabilities/default.json
@@ -13,6 +13,7 @@
     "notification:allow-request-permission",
     "notification:allow-notify",
     "notification:allow-register-listener",
+    "notification:allow-get-active",
     "notification:allow-remove-active",
     "autostart:allow-enable",
     "autostart:allow-disable",

--- a/desktop/src-tauri/capabilities/default.json
+++ b/desktop/src-tauri/capabilities/default.json
@@ -13,6 +13,7 @@
     "notification:allow-request-permission",
     "notification:allow-notify",
     "notification:allow-register-listener",
+    "notification:allow-remove-active",
     "autostart:allow-enable",
     "autostart:allow-disable",
     "autostart:allow-is-enabled",

--- a/web/src/components/MessageCard.tsx
+++ b/web/src/components/MessageCard.tsx
@@ -1,7 +1,7 @@
 // 消息渲染：message → doodle 卡片外壳 + mono 元信息 + markdown 正文；
 // status → 时间线分隔条（spec §9 第 2 块）。
 import type { AgentContext, MsgFrame, PresenceEntry, ReadCursor, Sender } from "@agentparty/shared";
-import { useEffect, useRef, useState } from "react";
+import { memo, useEffect, useRef, useState } from "react";
 import type { CSSProperties } from "react";
 import { agentHue } from "../lib/agentColor";
 import { displayForIdentity, resolveSenderLabel, type IdentityDisplayMap } from "../lib/identityDisplay";
@@ -122,7 +122,11 @@ export function presenceTitleBits(entry: PresenceEntry | undefined): string[] {
   ].filter((part): part is string => part !== null);
 }
 
-export function MessageCard({
+// memo 化：主输入框每次按键都会重渲染 Channel（draft 是顶层 state），中文 IME 尤其密集。
+// 卡片的所有 props（msg / 各 useCallback 回调 / useMemo 出来的 identityDisplay·receipts /
+// 逐条标量）在 draft-only 重渲染时引用稳定，浅比较即可跳过整窗口卡片的重渲染，消除输入卡顿
+// （issue #399④）。真正变动的那条卡片（新消息 / 编辑中 / 回执变化）props 会变，照常更新。
+function MessageCardImpl({
   msg,
   self,
   identityDisplay,
@@ -669,3 +673,5 @@ export function MessageCard({
     </article>
   );
 }
+
+export const MessageCard = memo(MessageCardImpl);

--- a/web/src/lib/desktopRuntime.test.ts
+++ b/web/src/lib/desktopRuntime.test.ts
@@ -2,6 +2,8 @@ import { afterEach, describe, expect, test } from "bun:test";
 import {
   __resetDesktopRuntimeForTests,
   __setDesktopRuntimeDependenciesForTests,
+  clearDeliveredNotifications,
+  mentionNotificationId,
   isAutostartEnabled,
   isDesktopNotificationPermissionGranted,
   isDesktopNotificationSupported,
@@ -152,10 +154,51 @@ describe("desktop notifications", () => {
       seq: 42,
     })).toBe(true);
     expect(payloads).toEqual([{
+      id: mentionNotificationId("general", 42),
       title: "Mention in #general",
       body: "Ada: hello @leo",
       extra: { slug: "general", seq: 42 },
     }]);
+  });
+
+  test("derives a stable, positive notification id per (channel, seq)", () => {
+    // 同一 (频道, seq) → 同一 id：多窗口 / 重连 / 重开都覆盖同一条通知，去掉通知中心重复。
+    const a = mentionNotificationId("general", 42);
+    expect(mentionNotificationId("general", 42)).toBe(a);
+    expect(a).toBeGreaterThan(0);
+    expect(Number.isSafeInteger(a)).toBe(true);
+    // 不同 seq / 频道给出不同 id，避免误覆盖别的通知。
+    expect(mentionNotificationId("general", 43)).not.toBe(a);
+    expect(mentionNotificationId("other", 42)).not.toBe(a);
+  });
+
+  test("clearDeliveredNotifications removes all active notifications when supported", async () => {
+    let cleared = 0;
+    __setDesktopRuntimeDependenciesForTests({
+      isTauri: () => true,
+      loadNotification: async () => notificationModule({
+        removeAllActive: async () => {
+          cleared += 1;
+        },
+      }),
+    });
+
+    expect(await clearDeliveredNotifications()).toBe(true);
+    expect(cleared).toBe(1);
+  });
+
+  test("clearDeliveredNotifications is a safe no-op on shells without removeAllActive", async () => {
+    __setDesktopRuntimeDependenciesForTests({
+      isTauri: () => true,
+      loadNotification: async () => {
+        const base = notificationModule();
+        // 旧壳：JS 里没有 removeAllActive。
+        delete (base as { removeAllActive?: unknown }).removeAllActive;
+        return base;
+      },
+    });
+
+    expect(await clearDeliveredNotifications()).toBe(false);
   });
 
   test("does not send when notification permission is not granted", async () => {

--- a/web/src/lib/desktopRuntime.test.ts
+++ b/web/src/lib/desktopRuntime.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import {
   __resetDesktopRuntimeForTests,
   __setDesktopRuntimeDependenciesForTests,
-  clearDeliveredNotifications,
+  clearDeliveredMentionNotifications,
   mentionNotificationId,
   isAutostartEnabled,
   isDesktopNotificationPermissionGranted,
@@ -172,33 +172,76 @@ describe("desktop notifications", () => {
     expect(mentionNotificationId("other", 42)).not.toBe(a);
   });
 
-  test("clearDeliveredNotifications removes all active notifications when supported", async () => {
-    let cleared = 0;
+  test("clearDeliveredMentionNotifications removes only the focused channel's notifications", async () => {
+    // 通知中心里混着两个频道 + 一条无关通知；只应删掉当前频道（general）的两条：
+    // 一条按确定性 id 命中（已加载窗口内的 @），一条按 extra.slug 命中（窗口外但 extra 回传）。
+    const delivered = [
+      { id: mentionNotificationId("general", 42), extra: { slug: "general", seq: 42 } },
+      { id: 999999, extra: { slug: "general", seq: 7 } },
+      { id: mentionNotificationId("other", 5), extra: { slug: "other", seq: 5 } },
+      { id: 111, extra: {} },
+    ];
+    let removed: Array<{ id: number }> = [];
     __setDesktopRuntimeDependenciesForTests({
       isTauri: () => true,
       loadNotification: async () => notificationModule({
-        removeAllActive: async () => {
-          cleared += 1;
+        active: async () => delivered,
+        removeActive: async (notifications) => {
+          removed = notifications;
         },
       }),
     });
 
-    expect(await clearDeliveredNotifications()).toBe(true);
-    expect(cleared).toBe(1);
+    expect(await clearDeliveredMentionNotifications("general", [mentionNotificationId("general", 42)])).toBe(true);
+    expect(removed.map((n) => n.id).sort((a, b) => a - b)).toEqual(
+      [mentionNotificationId("general", 42), 999999].sort((a, b) => a - b),
+    );
   });
 
-  test("clearDeliveredNotifications is a safe no-op on shells without removeAllActive", async () => {
+  test("clearDeliveredMentionNotifications skips removeActive when nothing matches", async () => {
+    let removeCalls = 0;
+    __setDesktopRuntimeDependenciesForTests({
+      isTauri: () => true,
+      loadNotification: async () => notificationModule({
+        active: async () => [{ id: mentionNotificationId("other", 5), extra: { slug: "other", seq: 5 } }],
+        removeActive: async () => {
+          removeCalls += 1;
+        },
+      }),
+    });
+
+    expect(await clearDeliveredMentionNotifications("general", [])).toBe(true);
+    expect(removeCalls).toBe(0);
+  });
+
+  test("clearDeliveredMentionNotifications is a safe no-op on shells without active/removeActive", async () => {
     __setDesktopRuntimeDependenciesForTests({
       isTauri: () => true,
       loadNotification: async () => {
         const base = notificationModule();
-        // 旧壳：JS 里没有 removeAllActive。
-        delete (base as { removeAllActive?: unknown }).removeAllActive;
+        // 旧壳：JS 里没有 active / removeActive。
+        delete (base as { active?: unknown }).active;
+        delete (base as { removeActive?: unknown }).removeActive;
         return base;
       },
     });
 
-    expect(await clearDeliveredNotifications()).toBe(false);
+    expect(await clearDeliveredMentionNotifications("general", [1, 2, 3])).toBe(false);
+  });
+
+  test("clearDeliveredMentionNotifications returns false when the native command rejects", async () => {
+    // 旧壳保留了 JS 方法但底层命令不支持：应进入 catch 返回 false（CodeRabbit #401）。
+    __setDesktopRuntimeDependenciesForTests({
+      isTauri: () => true,
+      loadNotification: async () => notificationModule({
+        active: async () => [{ id: mentionNotificationId("general", 42), extra: { slug: "general", seq: 42 } }],
+        removeActive: async () => {
+          throw new Error("plugin:notification|remove_active not implemented");
+        },
+      }),
+    });
+
+    expect(await clearDeliveredMentionNotifications("general", [mentionNotificationId("general", 42)])).toBe(false);
   });
 
   test("does not send when notification permission is not granted", async () => {

--- a/web/src/lib/desktopRuntime.ts
+++ b/web/src/lib/desktopRuntime.ts
@@ -40,8 +40,9 @@ interface NotificationModule {
     extra?: Record<string, unknown>;
   }): void;
   onAction(handler: (notification: { extra?: Record<string, unknown> }) => void): Promise<NotificationListener>;
-  // 清掉通知中心里所有已投递的通知（issue #399）。旧壳可能没有此命令，标可选，调用侧兜底。
-  removeAllActive?(): Promise<void>;
+  // 枚举已投递的通知 / 按 id 精确删除（issue #399）。旧壳可能没有这两条命令，标可选、调用侧兜底。
+  active?(): Promise<Array<{ id: number; extra?: Record<string, unknown> }>>;
+  removeActive?(notifications: Array<{ id: number }>): Promise<void>;
 }
 
 interface AutostartModule {
@@ -168,14 +169,25 @@ export async function sendMentionNotification(input: MentionNotification): Promi
   }
 }
 
-// 清掉通知中心里所有已投递的 @提醒。用户聚焦窗口即视为读到，堆积的旧通知应随之消失
-// （issue #399：「每次登录进来都显示 @我，但我都看过了」）。旧壳无 removeAllActive → 兜底返回 false。
-export async function clearDeliveredNotifications(): Promise<boolean> {
+// 清掉通知中心里「当前频道」已投递的 @提醒。用户聚焦窗口即视为读到，堆积的旧通知应随之消失
+// （issue #399：「每次登录进来都显示 @我，但我都看过了」）。
+//
+// 只删当前频道，绝不用 removeAllActive——那会把其他频道仍未读的 @提醒一并误删（CodeRabbit #401）。
+// 匹配用双保险：① 确定性 id（hash(频道:seq)，调用方按已加载的本频道 @消息算好传入，不依赖平台回传
+// extra）；② 发送时写入的 extra.slug（覆盖已加载窗口外、但 extra 能回传的旧通知）。任一命中即删。
+// 旧壳缺 active / removeActive → 兜底返回 false。
+export async function clearDeliveredMentionNotifications(
+  slug: string,
+  mentionIds: readonly number[],
+): Promise<boolean> {
   if (!isDesktopRuntime()) return false;
   try {
     const notification = await dependencies.loadNotification();
-    if (typeof notification.removeAllActive !== "function") return false;
-    await notification.removeAllActive();
+    if (typeof notification.active !== "function" || typeof notification.removeActive !== "function") return false;
+    const idSet = new Set(mentionIds);
+    const delivered = await notification.active();
+    const mine = delivered.filter((n) => idSet.has(n.id) || n.extra?.slug === slug);
+    if (mine.length > 0) await notification.removeActive(mine.map((n) => ({ id: n.id })));
     return true;
   } catch {
     return false;

--- a/web/src/lib/desktopRuntime.ts
+++ b/web/src/lib/desktopRuntime.ts
@@ -34,11 +34,14 @@ interface NotificationModule {
   isPermissionGranted(): Promise<boolean>;
   requestPermission(): Promise<Exclude<DesktopNotificationPermission, "unsupported">>;
   sendNotification(options: {
+    id?: number;
     title: string;
     body: string;
     extra?: Record<string, unknown>;
   }): void;
   onAction(handler: (notification: { extra?: Record<string, unknown> }) => void): Promise<NotificationListener>;
+  // 清掉通知中心里所有已投递的通知（issue #399）。旧壳可能没有此命令，标可选，调用侧兜底。
+  removeAllActive?(): Promise<void>;
 }
 
 interface AutostartModule {
@@ -138,16 +141,41 @@ export async function requestDesktopNotificationPermission(): Promise<DesktopNot
   }
 }
 
+// 稳定通知 id：同一 (频道, seq) 的 @提醒在多窗口 / 重连 / 重开时都映射到同一 id，
+// macOS 用相同 identifier 覆盖旧通知而非再堆一条——消除通知中心里的重复（issue #399：
+// 两个 session 各弹一次、或重触发导致同一条 @ 出现多遍）。djb2 → 正 i32、非 0。
+export function mentionNotificationId(slug: string, seq: number): number {
+  const s = `${slug}:${seq}`;
+  let h = 5381;
+  for (let i = 0; i < s.length; i += 1) h = ((h << 5) + h + s.charCodeAt(i)) | 0;
+  return (h & 0x7fffffff) || 1;
+}
+
 export async function sendMentionNotification(input: MentionNotification): Promise<boolean> {
   if (!isDesktopRuntime()) return false;
   try {
     const notification = await dependencies.loadNotification();
     if (!(await notification.isPermissionGranted())) return false;
     await notification.sendNotification({
+      id: mentionNotificationId(input.slug, input.seq),
       title: input.title,
       body: input.body,
       extra: { slug: input.slug, seq: input.seq },
     });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// 清掉通知中心里所有已投递的 @提醒。用户聚焦窗口即视为读到，堆积的旧通知应随之消失
+// （issue #399：「每次登录进来都显示 @我，但我都看过了」）。旧壳无 removeAllActive → 兜底返回 false。
+export async function clearDeliveredNotifications(): Promise<boolean> {
+  if (!isDesktopRuntime()) return false;
+  try {
+    const notification = await dependencies.loadNotification();
+    if (typeof notification.removeAllActive !== "function") return false;
+    await notification.removeAllActive();
     return true;
   } catch {
     return false;

--- a/web/src/lib/notify.ts
+++ b/web/src/lib/notify.ts
@@ -1,6 +1,6 @@
 import type { MsgFrame } from "@agentparty/shared";
 
-function isOwnMention(msg: MsgFrame, myHandle: string | null): boolean {
+export function isOwnMention(msg: MsgFrame, myHandle: string | null): boolean {
   if (myHandle === null || msg.kind !== "message" || msg.retracted) return false;
   if (msg.sender.handle === myHandle) return false;
   return msg.mentions.includes(myHandle);

--- a/web/src/pages/Channel.tsx
+++ b/web/src/pages/Channel.tsx
@@ -64,6 +64,7 @@ import { catchupKey, summarizeCatchup, type CatchupDigest } from "../lib/digest"
 import { buildOrgTree, type OrgMemberInput } from "../lib/orgTree";
 import { formatDivisionSection, mergeDivisionIntoCharter, type DivisionCharterRole } from "../lib/divisionCharter";
 import {
+  clearDeliveredNotifications,
   isDesktopRuntime,
   sendMentionNotification,
   setDesktopBadge,
@@ -2759,6 +2760,8 @@ export function ChannelPage({
       if (document.hidden) return;
       desktopMentionBadgeRef.current = 0;
       void setDesktopBadge(0);
+      // 聚焦即视为读到：清掉通知中心堆积的旧 @提醒，否则每次打开桌面版仍会看到已读的 @（issue #399）。
+      void clearDeliveredNotifications();
       if (stickBottom.current) sendSeen(lastSeqRef.current);
     };
     document.addEventListener("visibilitychange", markVisible);

--- a/web/src/pages/Channel.tsx
+++ b/web/src/pages/Channel.tsx
@@ -64,8 +64,9 @@ import { catchupKey, summarizeCatchup, type CatchupDigest } from "../lib/digest"
 import { buildOrgTree, type OrgMemberInput } from "../lib/orgTree";
 import { formatDivisionSection, mergeDivisionIntoCharter, type DivisionCharterRole } from "../lib/divisionCharter";
 import {
-  clearDeliveredNotifications,
+  clearDeliveredMentionNotifications,
   isDesktopRuntime,
+  mentionNotificationId,
   sendMentionNotification,
   setDesktopBadge,
 } from "../lib/desktopRuntime";
@@ -79,7 +80,7 @@ import {
   type AgentFilterKind,
   type AgentFilterMode,
 } from "../lib/filters";
-import { nextMentionBadgeCount, shouldMarkSeen, shouldNotify, shouldToast } from "../lib/notify";
+import { isOwnMention, nextMentionBadgeCount, shouldMarkSeen, shouldNotify, shouldToast } from "../lib/notify";
 import { historyFallbackRecovered } from "../lib/historyRecovery";
 import { summarizeReplyPreview } from "../lib/replyPreview";
 import { fmtTime } from "../lib/time";
@@ -2755,13 +2756,22 @@ export function ChannelPage({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [lastSeq]);
 
+  // 当前频道已加载窗口里所有 @我的确定性通知 id：聚焦时据此精确清掉本频道在通知中心的
+  // 旧 @提醒，绝不误删其他频道的（issue #399 / CodeRabbit #401）。用 ref 供 markVisible 读最新值。
+  const mentionNotificationIds = useMemo(
+    () => state.messages.filter((m) => isOwnMention(m, selfHandle)).map((m) => mentionNotificationId(slug, m.seq)),
+    [state.messages, selfHandle, slug],
+  );
+  const mentionNotificationIdsRef = useRef<number[]>(mentionNotificationIds);
+  mentionNotificationIdsRef.current = mentionNotificationIds;
+
   useEffect(() => {
     const markVisible = () => {
       if (document.hidden) return;
       desktopMentionBadgeRef.current = 0;
       void setDesktopBadge(0);
-      // 聚焦即视为读到：清掉通知中心堆积的旧 @提醒，否则每次打开桌面版仍会看到已读的 @（issue #399）。
-      void clearDeliveredNotifications();
+      // 聚焦即视为读到：清掉通知中心里本频道堆积的旧 @提醒，否则每次打开桌面版仍会看到已读的 @（issue #399）。
+      void clearDeliveredMentionNotifications(slug, mentionNotificationIdsRef.current);
       if (stickBottom.current) sendSeen(lastSeqRef.current);
     };
     document.addEventListener("visibilitychange", markVisible);


### PR DESCRIPTION
## 背景
issue #399 桌面版 bug 批的第 ①③ 项（见 issue 两张截图）：
1. 每次打开桌面版都重复弹「有人在 #agentparty @了你」——即使早已读过、点过 x。
3. 通知中心里同一条 @ 堆叠多份（截图可见同一条「Lark M1 线上验收」出现两遍）。

## 根因
- **重复**：`sendNotification` 未设稳定 `id`，macOS 把每次调用当作全新通知另起一条。用户开了两个桌面会话（presence 显示 `x2 sessions`），每条 @ 被两个会话各弹一次 → 通知中心堆两份。
- **已读不消失**：通知投递后从不清除。用户在应用内把消息读完（聚焦窗口 / 贴底回执已读），通知中心里的旧 @ 仍原封不动堆着。socket 层重连游标（`since=this.cursor`）本身是稳的，不重放旧帧，所以问题不在重放，而在"发出去的通知没人收走"。

## 修复
- `sendMentionNotification` 传稳定 `id = djb2(频道:seq)` → 同一 (频道, seq) 的 @ 在多窗口 / 重连 / 重开都映射到同一 id，macOS 覆盖而非堆叠。
- 新增 `clearDeliveredNotifications()`：窗口聚焦（`markVisible`）时调 `removeAllActive`，把通知中心里已读的 @ 清掉（对齐 Slack/Discord「打开即清」的直觉）。
- 授权补 `notification:allow-remove-active`；`removeAllActive` 在旧壳缺失时安全兜底为 no-op（可选方法 + typeof 守卫）。

## 测试
- `web/src/lib/desktopRuntime.test.ts`：20 pass。新增
  - id 稳定性（同 (频道,seq) 同 id、正 i32、不同 seq/频道不同）；
  - `clearDeliveredNotifications` 在支持时调用 `removeAllActive`、旧壳缺失时安全返回 false；
  - 更新既有断言以包含新的 `id` 字段。
- `tsc --noEmit` 通过。

## 影响面
纯桌面（`isDesktopRuntime()` 守卫）：浏览器/只读分享无变化。desktop 打包 web/dist，随下次 UI 热更新或版本发布生效。

涉及 #399（本 PR 只修 ①③；②滚动贴底、④⑤输入框一致性另开 PR，故不自动 Closes 整个 issue）

Claude-Session: https://claude.ai/code/session_01PgxkZeqJmDge3dYe9W2tPZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 新功能
- 桌面通知现支持为“提及通知（@）”生成稳定标识，便于精确区分同一频道的提醒。
- 通知中心新增能力：可按标识移除已投递的相关提及通知，并兼容不支持清理的运行环境。

## Bug 修复
- 修复桌面端切换回可见/重新聚焦后仍残留已读“提及通知（@）”的问题，自动清理旧提醒，减少堆积。

## 性能优化
- 对消息卡片进行记忆化处理，降低草稿高频更新时的无谓重渲染。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## 追加：#399④ 输入框卡顿（commit 24e2e1e）
**根因**：`draft` 是 Channel 顶层 state，每次按键 `setDraft` 重渲染整个 Channel，连带把可视窗口内几百张 MessageCard 全部重渲染（markdown/附件），中文 IME 高频 change 把开销放大成卡顿。
**修复**：给 MessageCard 加 `React.memo`。其 props 在 draft-only 重渲染时全部引用稳定（回调均 useCallback、identityDisplay/receipts 是 useMemo、其余逐条标量），浅比较跳过整窗口重渲染；真正变动的那条照常更新。TeamThread 内的卡片同样受益。
**测试**：MessageCard 5 个测试文件 24 用例全过。

（本 PR 现覆盖 #399 ①③④；②滚动贴底另议）