### PR TITLE
ci(review-ack): 改用 commit status 发到 PR head SHA（修 issue_comment 更新不到闸）

### DIFF
--- a/.github/workflows/review-ack.yml
+++ b/.github/workflows/review-ack.yml
@@ -1,16 +1,18 @@
 # 合并前必须「读了 review」的强制闸——对所有人生效，不靠任何人记忆。
-# 机制：这是 required check，只有当 PR 上出现一条 review 结论（ack）时才变绿、才允许合并。
-# ack = 任意非机器人身份 提交了 PR review（approve/comment/request-changes），
-#   或 留了一条以 `review-ack:` / `合并前已读` 开头的评论。
-# 不依赖任何 LLM 端点：即便 pr-agent 端点挂了、无自动 review，人也必须自己看过并写下结论才能合。
-# 空 ack 也拦不住恶意糊弄，但把「留结论」变成仓库强制的可核查动作，而非记忆里的自觉。
+# 机制：job 显式给 PR head SHA 发一个 commit status（context=review-ack）。
+#   - 有 ack（非机器人的正式 PR review，或以 review-ack:/合并前已读/合并者 review 结论 开头的评论）→ status=success（绿、可合）
+#   - 无 ack → status=failure（红、拦合并）
+# 用 commit status 而非 job 自身的 check-run，是因为 issue_comment 事件的 run 跑在 main ref 上、
+#   其自动 check-run 挂不到 PR head SHA；显式发 status 到 head SHA 才能让「留 ack 后」正确转绿。
+# job 名 review_ack_runner ≠ required 的 context(review-ack)，避免两个同名 check 冲突。
+# 不依赖任何 LLM 端点：端点挂时 pr_agent 自动放行，但本闸仍要求人看过并留结论。
 name: Review Ack Gate
 
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
   pull_request_review:
-    types: [submitted, dismissed]
+    types: [submitted, dismissed, edited]
   issue_comment:
     types: [created, edited, deleted]
 
@@ -18,37 +20,44 @@ permissions:
   contents: read
   pull-requests: read
   issues: read
+  statuses: write   # 给 head SHA 发 commit status
 
 concurrency:
   group: review-ack-${{ github.event.pull_request.number || github.event.issue.number }}
-  cancel-in-progress: false   # required check 不能被取消（取消=红=卡合并）
+  cancel-in-progress: false
 
 jobs:
-  review-ack:
+  review_ack_runner:
     if: >-
       github.event_name != 'issue_comment' ||
       github.event.issue.pull_request
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: 检查 PR 是否已有「读过 review」的结论（ack）
+      - name: 评估 ack 并给 PR head SHA 发 review-ack commit status
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           PR: ${{ github.event.pull_request.number || github.event.issue.number }}
         run: |
           set -euo pipefail
+          # PR head SHA：pull_request 事件直接给；其它事件（issue_comment/review）查 PR 拿
+          SHA="${{ github.event.pull_request.head.sha }}"
+          if [ -z "$SHA" ]; then
+            SHA=$(gh pr view "$PR" --repo "$REPO" --json headRefOid --jq .headRefOid)
+          fi
+          echo "PR #$PR head SHA=$SHA"
           BOTS='github-actions|github-actions\[bot\]|qodo|pr-agent|coderabbit|dependabot'
-          # ① 正式 PR review（approve / comment / changes_requested），非机器人
           REVIEWS=$(gh api "repos/$REPO/pulls/$PR/reviews" --paginate \
             --jq "[.[] | select((.user.login | test(\"$BOTS\"; \"i\")) | not) | select(.state != \"PENDING\" and .state != \"DISMISSED\")] | length")
-          # ② 评论里的显式 ack（review-ack: / 合并前已读 / 合并者 review 结论），非机器人
           ACK_COMMENTS=$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
             --jq "[.[] | select((.user.login | test(\"$BOTS\"; \"i\")) | not) | select(.body | test(\"review-ack:|合并前已读|合并者 review 结论\"; \"i\"))] | length")
-          echo "非机器人 PR reviews: $REVIEWS · ack 评论: $ACK_COMMENTS"
+          echo "非机器人 PR reviews=$REVIEWS · ack 评论=$ACK_COMMENTS"
           if [ "$REVIEWS" -gt 0 ] || [ "$ACK_COMMENTS" -gt 0 ]; then
-            echo "✅ 已有 review 结论——合并者看过了。"
-            exit 0
+            STATE=success; DESC="已有 review 结论——合并者看过了"
+          else
+            STATE=failure; DESC="合并前必须先读 review 并留结论：提交一次 PR review，或评论 review-ack: 开头的合并结论"
           fi
-          echo "::error::合并前必须先读 review 并留结论：在 PR 上提交一次 review，或评论一条以 'review-ack:' 开头的合并结论（说清 pr-agent/CodeRabbit 的 review 有无真问题、误报、是否采纳）。这是对所有人生效的强制闸，不是自觉。"
-          exit 1
+          gh api -X POST "repos/$REPO/statuses/$SHA" \
+            -f state="$STATE" -f context="review-ack" -f description="$DESC" >/dev/null
+          echo "已发 commit status: review-ack=$STATE @ $SHA"

--- a/.github/workflows/review-ack.yml
+++ b/.github/workflows/review-ack.yml
@@ -44,14 +44,21 @@ jobs:
           # PR head SHA：pull_request 事件直接给；其它事件（issue_comment/review）查 PR 拿
           SHA="${{ github.event.pull_request.head.sha }}"
           if [ -z "$SHA" ]; then
-            SHA=$(gh pr view "$PR" --repo "$REPO" --json headRefOid --jq .headRefOid)
+            # 采纳 pr-agent 建议：查 head SHA 加错误处理，拿不到就报错退出（而非静默用空 SHA 发错状态）
+            SHA=$(gh pr view "$PR" --repo "$REPO" --json headRefOid --jq .headRefOid 2>/dev/null || true)
+          fi
+          if [ -z "$SHA" ] || [ "$SHA" = "null" ]; then
+            echo "::error::拿不到 PR #$PR 的 head SHA，无法发 review-ack 状态"
+            exit 1
           fi
           echo "PR #$PR head SHA=$SHA"
           BOTS='github-actions|github-actions\[bot\]|qodo|pr-agent|coderabbit|dependabot'
+          # 采纳 pr-agent 建议：API 失败时按 0 计（fail-safe——查不到就当无 ack、保持红，绝不误放行）
           REVIEWS=$(gh api "repos/$REPO/pulls/$PR/reviews" --paginate \
-            --jq "[.[] | select((.user.login | test(\"$BOTS\"; \"i\")) | not) | select(.state != \"PENDING\" and .state != \"DISMISSED\")] | length")
+            --jq "[.[] | select((.user.login | test(\"$BOTS\"; \"i\")) | not) | select(.state != \"PENDING\" and .state != \"DISMISSED\")] | length" 2>/dev/null || echo 0)
           ACK_COMMENTS=$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
-            --jq "[.[] | select((.user.login | test(\"$BOTS\"; \"i\")) | not) | select(.body | test(\"review-ack:|合并前已读|合并者 review 结论\"; \"i\"))] | length")
+            --jq "[.[] | select((.user.login | test(\"$BOTS\"; \"i\")) | not) | select(.body | test(\"review-ack:|合并前已读|合并者 review 结论\"; \"i\"))] | length" 2>/dev/null || echo 0)
+          REVIEWS=${REVIEWS:-0}; ACK_COMMENTS=${ACK_COMMENTS:-0}
           echo "非机器人 PR reviews=$REVIEWS · ack 评论=$ACK_COMMENTS"
           if [ "$REVIEWS" -gt 0 ] || [ "$ACK_COMMENTS" -gt 0 ]; then
             STATE=success; DESC="已有 review 结论——合并者看过了"


### PR DESCRIPTION
review-ack: 修 review-ack 闸的机制坑——上一版用 job 自身 check-run 做 required，issue_comment 事件的 run 跑在 main ref、check-run 挂不到 PR head SHA，导致『留 ack 评论后 review-ack 不转绿』(#402 实测)。改成 job 显式给 head SHA 发 commit status(context=review-ack)，job 名 review_ack_runner ≠ 该 context 避免撞车。这样任一事件都能正确更新 PR 上的闸。

本 PR 因鸡生蛋（修闸本身、新机制还没上 main）review-ack 会红，用 admin 应急合（正是 admin 逃生口的用途）。我已读 pr-agent review（无安全问题）并留本结论。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 修复评审确认检查结果不稳定的问题，现可更可靠地反映到拉取请求的状态中。
  * 会基于最新的评审/确认信息，及时将状态标记为成功或失败。

* **改进**
  * 支持在评审或确认评论被编辑、撤销等情况下自动重新评估。
  * 扩展对更多事件类型的触发与状态同步表现。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->