### PR TITLE
fix(ci): 修复 review-ack 机器人过滤

### DIFF
--- a/.github/workflows/review-ack.yml
+++ b/.github/workflows/review-ack.yml
@@ -52,12 +52,11 @@ jobs:
             exit 1
           fi
           echo "PR #$PR head SHA=$SHA"
-          BOTS='github-actions|github-actions\[bot\]|qodo|pr-agent|coderabbit|dependabot'
           # 采纳 pr-agent 建议：API 失败时按 0 计（fail-safe——查不到就当无 ack、保持红，绝不误放行）
           REVIEWS=$(gh api "repos/$REPO/pulls/$PR/reviews" --paginate \
-            --jq "[.[] | select((.user.login | test(\"$BOTS\"; \"i\")) | not) | select(.state != \"PENDING\" and .state != \"DISMISSED\")] | length" 2>/dev/null || echo 0)
+            --jq '[.[] | select(.user.type != "Bot") | select(.state != "PENDING" and .state != "DISMISSED")] | length' 2>/dev/null || echo 0)
           ACK_COMMENTS=$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
-            --jq "[.[] | select((.user.login | test(\"$BOTS\"; \"i\")) | not) | select(.body | test(\"review-ack:|合并前已读|合并者 review 结论\"; \"i\"))] | length" 2>/dev/null || echo 0)
+            --jq '[.[] | select(.user.type != "Bot") | select(.body | test("review-ack:|合并前已读|合并者 review 结论"; "i"))] | length' 2>/dev/null || echo 0)
           REVIEWS=${REVIEWS:-0}; ACK_COMMENTS=${ACK_COMMENTS:-0}
           echo "非机器人 PR reviews=$REVIEWS · ack 评论=$ACK_COMMENTS"
           if [ "$REVIEWS" -gt 0 ] || [ "$ACK_COMMENTS" -gt 0 ]; then


### PR DESCRIPTION
## 问题

`BOTS` 正则被插入 jq 双引号字符串后，`\[` 成为 jq 非法转义。两个 `gh api --jq` 都失败并被 `|| echo 0` 吞掉，导致任何真实 review/ack 都无法让 required status 转绿。

## 修复

直接使用 GitHub API 的结构化字段 `.user.type != "Bot"`，不再维护机器人用户名正则。

## 验证

在 #404 的真实 API 数据上运行同一 jq：`REVIEWS=1 ACK_COMMENTS=1`；`git diff --check` 与 `actionlint` 通过。

关联阻塞：#401、#404。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化审查确认状态的判断逻辑，更准确地区分人工审查与自动化机器人操作。
  * 改进对确认评论的识别，减少有效确认未被识别或无效评论误触发的情况。
  * 持续根据最新审查确认状态更新提交状态，确保合并检查结果更可靠。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->