### PR TITLE
fix(web): 稳定频道初始贴底滚动 (#399②⑤)

### DIFF
--- a/web/src/lib/scrollPin.test.ts
+++ b/web/src/lib/scrollPin.test.ts
@@ -11,7 +11,7 @@ describe("channel stream bottom pinning", () => {
   test("pins after layout growth only while the user remains in sticky-bottom mode", () => {
     const pinned = { scrollTop: 800, scrollHeight: 1200, clientHeight: 200 };
     expect(pinToBottom(pinned, true)).toBe(true);
-    expect(pinned.scrollTop).toBe(1200);
+    expect(pinned.scrollTop).toBe(1000);
 
     const readingHistory = { scrollTop: 300, scrollHeight: 1200, clientHeight: 200 };
     expect(pinToBottom(readingHistory, false)).toBe(false);

--- a/web/src/lib/scrollPin.test.ts
+++ b/web/src/lib/scrollPin.test.ts
@@ -6,6 +6,8 @@ describe("channel stream bottom pinning", () => {
   test("treats the final 160px as sticky-bottom territory", () => {
     expect(isNearBottom({ scrollTop: 740, scrollHeight: 1000, clientHeight: 200 })).toBe(true);
     expect(isNearBottom({ scrollTop: 500, scrollHeight: 1000, clientHeight: 200 })).toBe(false);
+    expect(isNearBottom({ scrollTop: 2000, scrollHeight: 1000, clientHeight: 200 })).toBe(true);
+    expect(isNearBottom({ scrollTop: -40, scrollHeight: 1000, clientHeight: 200 })).toBe(false);
   });
 
   test("pins after layout growth only while the user remains in sticky-bottom mode", () => {

--- a/web/src/lib/scrollPin.test.ts
+++ b/web/src/lib/scrollPin.test.ts
@@ -1,0 +1,20 @@
+// @ts-expect-error Bun executes this test, while the web tsconfig intentionally loads only Vite globals.
+import { describe, expect, test } from "bun:test";
+import { isNearBottom, pinToBottom } from "./scrollPin";
+
+describe("channel stream bottom pinning", () => {
+  test("treats the final 160px as sticky-bottom territory", () => {
+    expect(isNearBottom({ scrollTop: 740, scrollHeight: 1000, clientHeight: 200 })).toBe(true);
+    expect(isNearBottom({ scrollTop: 500, scrollHeight: 1000, clientHeight: 200 })).toBe(false);
+  });
+
+  test("pins after layout growth only while the user remains in sticky-bottom mode", () => {
+    const pinned = { scrollTop: 800, scrollHeight: 1200, clientHeight: 200 };
+    expect(pinToBottom(pinned, true)).toBe(true);
+    expect(pinned.scrollTop).toBe(1200);
+
+    const readingHistory = { scrollTop: 300, scrollHeight: 1200, clientHeight: 200 };
+    expect(pinToBottom(readingHistory, false)).toBe(false);
+    expect(readingHistory.scrollTop).toBe(300);
+  });
+});

--- a/web/src/lib/scrollPin.ts
+++ b/web/src/lib/scrollPin.ts
@@ -10,6 +10,6 @@ export function isNearBottom(viewport: ScrollViewport, threshold = 160): boolean
 
 export function pinToBottom(viewport: ScrollViewport, enabled: boolean): boolean {
   if (!enabled) return false;
-  viewport.scrollTop = viewport.scrollHeight;
+  viewport.scrollTop = Math.max(0, viewport.scrollHeight - viewport.clientHeight);
   return true;
 }

--- a/web/src/lib/scrollPin.ts
+++ b/web/src/lib/scrollPin.ts
@@ -1,0 +1,15 @@
+export interface ScrollViewport {
+  scrollTop: number;
+  scrollHeight: number;
+  clientHeight: number;
+}
+
+export function isNearBottom(viewport: ScrollViewport, threshold = 160): boolean {
+  return viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight < threshold;
+}
+
+export function pinToBottom(viewport: ScrollViewport, enabled: boolean): boolean {
+  if (!enabled) return false;
+  viewport.scrollTop = viewport.scrollHeight;
+  return true;
+}

--- a/web/src/lib/scrollPin.ts
+++ b/web/src/lib/scrollPin.ts
@@ -5,7 +5,9 @@ export interface ScrollViewport {
 }
 
 export function isNearBottom(viewport: ScrollViewport, threshold = 160): boolean {
-  return viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight < threshold;
+  const maxScrollTop = Math.max(0, viewport.scrollHeight - viewport.clientHeight);
+  const scrollTop = Math.max(0, Math.min(viewport.scrollTop, maxScrollTop));
+  return maxScrollTop - scrollTop < threshold;
 }
 
 export function pinToBottom(viewport: ScrollViewport, enabled: boolean): boolean {

--- a/web/src/pages/Channel.scroll.source.test.ts
+++ b/web/src/pages/Channel.scroll.source.test.ts
@@ -1,0 +1,14 @@
+// @ts-expect-error Bun executes this test, while the web tsconfig intentionally loads only Vite globals.
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(import.meta.dir + "/Channel.tsx", "utf8");
+
+test("channel stream re-pins after initial paint and late desktop layout changes", () => {
+  expect(source).toContain("useLayoutEffect(() => {");
+  expect(source).toContain("window.requestAnimationFrame");
+  expect(source).toContain("new ResizeObserver(repin)");
+  expect(source).toContain('el.addEventListener("load", repin, true)');
+  expect(source).toContain("pinToBottom(el, stickBottom.current)");
+  expect(source).toContain("}, [sendSeen, slug]);");
+});

--- a/web/src/pages/Channel.tsx
+++ b/web/src/pages/Channel.tsx
@@ -82,6 +82,7 @@ import {
 } from "../lib/filters";
 import { isOwnMention, nextMentionBadgeCount, shouldMarkSeen, shouldNotify, shouldToast } from "../lib/notify";
 import { historyFallbackRecovered } from "../lib/historyRecovery";
+import { isNearBottom, pinToBottom } from "../lib/scrollPin";
 import { summarizeReplyPreview } from "../lib/replyPreview";
 import { fmtTime } from "../lib/time";
 import { groupTeamMessages, summarizeTeams, type TeamMessageThread, type TeamSummary } from "../lib/teams";
@@ -2743,9 +2744,17 @@ export function ChannelPage({
     },
     [shareMode],
   );
-  useEffect(() => {
+  useLayoutEffect(() => {
     const el = streamRef.current;
-    if (el !== null && stickBottom.current) el.scrollTop = el.scrollHeight;
+    if (el !== null) pinToBottom(el, stickBottom.current);
+    const frame = window.requestAnimationFrame(() => {
+      const current = streamRef.current;
+      if (current !== null) pinToBottom(current, stickBottom.current);
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [lastSeq]);
+
+  useEffect(() => {
     if (shouldMarkSeen(document.hidden, stickBottom.current)) sendSeen(lastSeq);
     // 贴底时收窄消息窗口：DOM 不挂几千条；被丢弃的最老页上翻会重新拉回
     if (stickBottom.current && state.messages.length > MESSAGE_CAP + PAGE_SIZE) {
@@ -2755,6 +2764,19 @@ export function ChannelPage({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [lastSeq]);
+
+  useEffect(() => {
+    const el = streamRef.current;
+    if (el === null) return;
+    const repin = () => pinToBottom(el, stickBottom.current);
+    const observer = typeof ResizeObserver === "undefined" ? null : new ResizeObserver(repin);
+    observer?.observe(el);
+    el.addEventListener("load", repin, true);
+    return () => {
+      observer?.disconnect();
+      el.removeEventListener("load", repin, true);
+    };
+  }, []);
 
   // 当前频道已加载窗口里所有 @我的确定性通知 id：聚焦时据此精确清掉本频道在通知中心的
   // 旧 @提醒，绝不误删其他频道的（issue #399 / CodeRabbit #401）。用 ref 供 markVisible 读最新值。
@@ -2783,7 +2805,7 @@ export function ChannelPage({
       desktopMentionBadgeRef.current = 0;
       void setDesktopBadge(0);
     };
-  }, [sendSeen]);
+  }, [sendSeen, slug]);
 
   // prepend 老页后的 scroll anchoring：绘制前把 scrollTop 平移新增高度，视口纹丝不动
   const firstSeq = state.messages.length > 0 ? state.messages[0]!.seq : 0;
@@ -2848,7 +2870,7 @@ export function ChannelPage({
   const onScroll = useCallback(() => {
     const el = streamRef.current;
     if (el === null) return;
-    stickBottom.current = el.scrollHeight - el.scrollTop - el.clientHeight < 160;
+    stickBottom.current = isNearBottom(el);
     if (stickBottom.current) sendSeen(lastSeqRef.current); // 滚到底＝看到了最新，回执已读
     if (el.scrollTop < TOP_LOAD_PX) loadOlder();
   }, [loadOlder, sendSeen]);


### PR DESCRIPTION
## 改动说明

修复 #399 ②，并关闭 ⑤ 的实现差异：桌面与浏览器共用同一 Composer/Channel 代码和同一签名 UI 热更新，本次让首屏与晚到布局变化保持一致。

- 初始历史和新消息改用 `useLayoutEffect` 在绘制前贴底，并在下一帧复核 WebView 晚到布局。
- 仍处于贴底模式时，容器 resize 或图片/资源 load 后重新贴底。
- 用户主动上翻后 `stickBottom=false`，上述机制不会把用户拉回。
- 提取可测试的 near-bottom/pin helper。
- 补上 #401 review 遗漏的 `slug` effect 依赖，避免通知清理闭包陈旧。

## 合并前检查

- [x] focused 9 pass
- [x] `bun run check:web`: 687 pass，TypeScript + Vite production build
- [x] `git diff --check`
- [ ] review-ack：等待 reviewer/CodeRabbit 结论

实机截图验收待 Mac 解锁后在同一 Desktop UI 热更新上完成。

关联 #399。