### PR TITLE
fix(desktop): 聚焦时只清当前频道的已读提醒 (#399)

### DIFF
--- a/web/src/pages/Channel.tsx
+++ b/web/src/pages/Channel.tsx
@@ -2807,6 +2807,15 @@ export function ChannelPage({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [lastSeq]);
 
+  // 当前频道已加载窗口里所有 @我的确定性通知 id：聚焦时据此精确清掉本频道在通知中心的
+  // 旧 @提醒，绝不误删其他频道的（issue #399 / CodeRabbit #401）。用 ref 供 markVisible 读最新值。
+  const mentionNotificationIds = useMemo(
+    () => state.messages.filter((m) => isOwnMention(m, selfHandle)).map((m) => mentionNotificationId(slug, m.seq)),
+    [state.messages, selfHandle, slug],
+  );
+  const mentionNotificationIdsRef = useRef<number[]>(mentionNotificationIds);
+  mentionNotificationIdsRef.current = mentionNotificationIds;
+
   useEffect(() => {
     const el = streamRef.current;
     if (el === null) return;


### PR DESCRIPTION
## 改动说明

- 在已合入的桌面提醒清理基础上，只删除当前频道的已读 @提醒，避免误删其他频道仍未读通知。
- 分支已重放到最新 main，仅保留这一条增量修复，消除重复声明导致的 Web CI 失败。

## 合并前检查（review-ack 强制闸）

- [x] 已读 pr-agent / CodeRabbit review：`slug` 依赖已纳入 effect；空 ID 数组仍需调用以便按 `extra.slug` 清理窗口外通知。
- [x] `git diff --check` 通过。
- [x] 远端 release workflow 将重新验证 Web/desktop 全套门禁。

关联 #399（主修复已由 #401 合入，本 PR 是不误删其他频道的跟进）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复频道中“提及我的”通知状态更新不及时的问题。
  * 当相关消息进入可见区域或页面重新获得焦点时，系统现在能够更准确地识别并清理已查看的提及通知。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->