### PR TITLE
fix(cli): MCP party_task_create 接入 external_ref 幂等键 (#141)

### DIFF
--- a/cli/src/commands/mcp.ts
+++ b/cli/src/commands/mcp.ts
@@ -518,9 +518,15 @@ export function createMcpServer(defaultChannel?: string): McpServer {
         parent_id: z.number().int().positive().optional(),
         anchor_seqs: z.array(z.number().int().positive()).optional(),
         workflow_id: z.string().optional(),
+        external_ref: z
+          .string()
+          .optional()
+          .describe(
+            "Idempotency key (e.g. gh:owner/repo#96). Creating with a ref that already exists in the channel returns the existing task instead of a duplicate — safe to rerun an issue→task sync (#141).",
+          ),
       },
     },
-    async ({ channel, title, desc, state, assignee_name, assignee_kind, priority, labels, parent_id, anchor_seqs, workflow_id }) => {
+    async ({ channel, title, desc, state, assignee_name, assignee_kind, priority, labels, parent_id, anchor_seqs, workflow_id, external_ref }) => {
       try {
         const cfg = await auth();
         const resolved = normalizeChannel(channel, defaultChannel);
@@ -536,6 +542,7 @@ export function createMcpServer(defaultChannel?: string): McpServer {
           ...(parent_id !== undefined ? { parent_id } : {}),
           ...(anchor_seqs !== undefined && anchor_seqs.length > 0 ? { anchor_seqs } : {}),
           ...(workflow_id !== undefined ? { workflow_id } : {}),
+          ...(external_ref !== undefined ? { external_ref } : {}),
         });
         return ok({ type: "task_create", channel: resolved, task });
       } catch (e) {

--- a/cli/test/mcp-task-external-ref.test.ts
+++ b/cli/test/mcp-task-external-ref.test.ts
@@ -1,0 +1,162 @@
+// #141 MCP 侧：party_task_create 工具把 external_ref 幂等键透传进请求体，
+// 让 agent 走 MCP（主路径）重跑 issue→task 同步时命中既有 task 而不产生重复
+// （对照 cli/test/task-external-ref.test.ts 的裸 CLI 路径 + worker 后端幂等）。
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const indexPath = join(import.meta.dir, "..", "src", "index.ts");
+
+let home: string;
+let restServer: ReturnType<typeof Bun.serve> | null = null;
+const seen: { method: string; path: string; body: unknown }[] = [];
+
+const EXT_REF = "gh:leeguooooo/agentparty#96";
+
+// 幂等后端：命中已存在的 external_ref 时 worker 返回既有 task（同一个 id），
+// 不新建。这里恒定返回 id=9 的 task 来模拟这一契约。
+function existingTask(): Record<string, unknown> {
+  return {
+    type: "task",
+    id: 9,
+    channel: "dev",
+    title: "sync issue #96",
+    desc: null,
+    state: "triage",
+    assignee: null,
+    created_by: "me",
+    created_by_kind: "agent",
+    priority: 0,
+    labels: [],
+    parent_id: null,
+    anchor_seqs: [],
+    external_ref: EXT_REF,
+    completion_artifact: null,
+    workflow_id: null,
+    created_at: 1,
+    updated_at: 1,
+  };
+}
+
+function startRest(): void {
+  restServer = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+      const body = req.method === "GET" ? null : await req.json().catch(() => null);
+      seen.push({ method: req.method, path: `${url.pathname}${url.search}`, body });
+      if (url.pathname === "/api/me") {
+        return Response.json({ name: "me", email: null, kind: "agent", role: "member", owner: null });
+      }
+      if (url.pathname === "/api/channels/dev/tasks" && req.method === "POST") {
+        return Response.json(existingTask(), { status: 201 });
+      }
+      return Response.json({ error: { code: "not_found", message: "not found" } }, { status: 404 });
+    },
+  });
+  mkdirSync(home, { recursive: true });
+  writeFileSync(
+    join(home, "config.json"),
+    JSON.stringify({ server: `http://127.0.0.1:${restServer.port}`, token: "ap_tok" }),
+  );
+}
+
+async function connect(channelFlag: string): Promise<Client> {
+  const env: Record<string, string> = {};
+  for (const [k, v] of Object.entries(process.env)) {
+    if (v !== undefined && k !== "AGENTPARTY_CONFIG") env[k] = v;
+  }
+  env.AGENTPARTY_HOME = home;
+  const transport = new StdioClientTransport({
+    command: "bun",
+    args: ["run", indexPath, "mcp", "--channel", channelFlag],
+    env,
+    stderr: "pipe",
+  });
+  const client = new Client({ name: "agentparty-test", version: "1.0.0" });
+  await client.connect(transport);
+  return client;
+}
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "ap-mcp-extref-"));
+  seen.length = 0;
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+  restServer?.stop(true);
+  restServer = null;
+});
+
+describe("mcp party_task_create external_ref（#141）", () => {
+  // 工具 schema 必须声明 external_ref，否则 MCP client 传进来的键会被丢弃。
+  test("party_task_create advertises external_ref in its input schema", async () => {
+    startRest();
+    const client = await connect("dev");
+    try {
+      const tools = await client.listTools();
+      const tool = tools.tools.find((t) => t.name === "party_task_create");
+      expect(tool).toBeDefined();
+      const props = (tool?.inputSchema as { properties?: Record<string, unknown> } | undefined)?.properties ?? {};
+      expect(Object.keys(props)).toContain("external_ref");
+    } finally {
+      await client.close();
+    }
+  }, 20000);
+
+  // 主路径回归：agent 走 MCP 建 task 时，external_ref 必须进 POST body，
+  // 后端命中既有 task 返回同一 id——重跑同步不产生重复。
+  test("forwards external_ref in the POST body and returns the existing task", async () => {
+    startRest();
+    const client = await connect("dev");
+    try {
+      const first = await client.callTool({
+        name: "party_task_create",
+        arguments: { title: "sync issue #96", external_ref: EXT_REF },
+      });
+      expect(first.isError).not.toBe(true);
+      expect(first.structuredContent).toMatchObject({
+        type: "task_create",
+        channel: "dev",
+        task: { id: 9, external_ref: EXT_REF },
+      });
+
+      // 重跑同步：同一 external_ref 再建一次，后端仍返回 id=9（幂等），不产生新 task。
+      const second = await client.callTool({
+        name: "party_task_create",
+        arguments: { title: "sync issue #96", external_ref: EXT_REF },
+      });
+      expect(second.structuredContent).toMatchObject({ task: { id: 9 } });
+
+      const posts = seen.filter((s) => s.method === "POST" && s.path === "/api/channels/dev/tasks");
+      expect(posts.length).toBe(2);
+      for (const p of posts) {
+        expect(p.body).toMatchObject({ title: "sync issue #96", external_ref: EXT_REF });
+      }
+    } finally {
+      await client.close();
+    }
+  }, 20000);
+
+  // 未传 external_ref 时不得把该键塞进请求体（保持后端 body 干净）。
+  test("omits external_ref from the body when the argument is absent", async () => {
+    startRest();
+    const client = await connect("dev");
+    try {
+      const r = await client.callTool({
+        name: "party_task_create",
+        arguments: { title: "plain task" },
+      });
+      expect(r.isError).not.toBe(true);
+      const post = seen.find((s) => s.method === "POST" && s.path === "/api/channels/dev/tasks");
+      expect(post?.body).toEqual({ title: "plain task" });
+    } finally {
+      await client.close();
+    }
+  }, 20000);
+});


### PR DESCRIPTION
## 缺口
task external_ref 幂等键的后端 + 裸 CLI 已做（#270：migration 0026、worker POST /tasks 命中 external_ref 返回既有 task、`party task create --external-ref`）。但 **agent 走 MCP 建 task 是主路径**，而 `cli/src/commands/mcp.ts` 的 `party_task_create` 工具的 zod inputSchema 不含 `external_ref`、也不透传给 `createTask`——MCP client 传进来的键被丢弃，agent 重跑 issue→task 同步仍产生全量重复 task。正是 #141 要根治的。

## 改法
- `mcp.ts`：`party_task_create` inputSchema 增加可选 `external_ref`（带幂等语义 describe），并在调用 `createTask` 时透传，与 CLI `--external-ref` 走同一后端幂等路径。`createTask` 签名早已支持 `external_ref`（rest.ts:661），本次仅补 MCP 接线。
- 不改后端、不改 CLI、不碰其它工具。

## 测试
新增 `cli/test/mcp-task-external-ref.test.ts`（真实起 MCP stdio client + mock REST）：
1. `party_task_create` 的 input schema 暴露 `external_ref`；
2. 带 `external_ref` 重跑两次，`external_ref` 都进 POST body，后端命中返回同一 task id（幂等，不产生重复）；
3. 未传 `external_ref` 时不塞进请求体（body 保持干净）。

本地 `bun test`：新测 3 pass；`mcp-charter` + `task-external-ref` 回归 6 pass；`tsc --noEmit` 干净。

涉及 #141，待 host 验收。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 创建任务时支持传入可选的外部引用标识。
  * 重复使用相同外部引用时，可复用已有任务，避免重复创建。
  * 未提供外部引用时，创建请求保持原有行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->