### PR TITLE
fix(cli): ask 超时提示目标 busy 而非裸 TIMEOUT (#103)

### DIFF
--- a/cli/src/commands/ask.ts
+++ b/cli/src/commands/ask.ts
@@ -1,7 +1,10 @@
 // party ask — send + watch 语法糖，agent 主循环用
+import { EXIT_TIMEOUT } from "@agentparty/shared";
 import { parseArgs, str, unknownFlagError, valueFlagError } from "../args";
 import { loadCursor, loadRevCursor, saveCursor, saveRevCursor } from "../config";
 import { resolveAuth } from "../oidc-cli";
+import { busyTimeoutHint } from "../reach";
+import { fetchPresence } from "../rest";
 import { MAX_TIMEOUT_SEC, parsePositiveIntFlag } from "../validation";
 import { doSend, resolveSendInput, sendSpec } from "./send";
 import { runWatch } from "./watch";
@@ -40,7 +43,7 @@ export async function run(argv: string[]): Promise<number> {
 
   // 游标从自己刚发的 seq 起，自己的消息不会被当成回复
   const since = Math.max(result.seq, loadCursor(input.channel));
-  return runWatch({
+  const code = await runWatch({
     server: cfg.server,
     token: cfg.token,
     channel: input.channel,
@@ -53,4 +56,17 @@ export async function run(argv: string[]): Promise<number> {
     onRevCursor: (r) => saveRevCursor(input.channel, r),
     statusline: true,
   });
+  // 超时富提示（#103）：runWatch 已吐裸 TIMEOUT 到 stdout，看不出对方是「忙」还是「失联」。
+  // 若被 @ 的目标此刻仍标 busy（serve 正串行处理），在 stderr 补一行——别把超时误判成掉线反复 @。
+  // 锦上添花：presence 拉取失败不改变退出码，保持原 TIMEOUT 行为。
+  if (code === EXIT_TIMEOUT && input.mentions.length > 0) {
+    try {
+      const presence = await fetchPresence(cfg.server, cfg.token, input.channel);
+      const hint = busyTimeoutHint(input.mentions, presence, Date.now());
+      if (hint !== null) console.error(hint);
+    } catch {
+      /* presence 不可达：静默，裸 TIMEOUT 已足够 */
+    }
+  }
+  return code;
 }

--- a/cli/src/reach.ts
+++ b/cli/src/reach.ts
@@ -62,3 +62,14 @@ export function formatReach(r: Reachability): string {
 export function formatReachLine(rs: Reachability[]): string {
   return "→ " + rs.map(formatReach).join("  ·  ");
 }
+
+// ask 超时提示（#103）：party ask 委托 watch，超时只吐裸 TIMEOUT，看不出对方是「忙」还是「失联」。
+// 用 reachOf 查被 @ 的目标此刻是否仍标 busy（serve 正串行处理一条 wake）：若有，返回一行富提示，
+// 让调用方把超时当「忙、回复慢」而非「离线」，别反复 @ 堆重复唤醒。无 busy 目标返回 null，
+// 调用方保持原裸 TIMEOUT 行为（查不到就不无中生有）。
+export function busyTimeoutHint(mentions: string[], presence: PresenceEntry[], now: number): string | null {
+  const busy = mentions.map((m) => reachOf(m, presence, now)).filter((r) => r.busy === true);
+  if (busy.length === 0) return null;
+  const parts = busy.map((r) => `@${r.name} 忙碌中${r.queueDepth !== undefined ? `, ${r.queueDepth} 排队` : ""}`);
+  return `TIMEOUT — ${parts.join("; ")}; 稍后再试, 勿重复 @（对方在忙, 不是失联）`;
+}

--- a/cli/test/reach.test.ts
+++ b/cli/test/reach.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { applyLiveConnection, type PresenceEntry } from "@agentparty/shared";
-import { formatReach, formatReachLine, reachOf } from "../src/reach";
+import { busyTimeoutHint, formatReach, formatReachLine, reachOf } from "../src/reach";
 
 const NOW = 1_000_000_000;
 
@@ -110,6 +110,56 @@ describe("busy surfacing (#103)", () => {
     expect(formatReach({ name: "b", reach: "wakeable", wake: "serve", busy: true, queueDepth: 1 })).toBe(
       "@b ◐ wakeable(serve) · busy, 1 queued",
     );
+  });
+});
+
+// ask 超时富提示（#103）：ask 委托 watch，超时只吐裸 TIMEOUT，看不出对方是「忙」还是「失联」。
+// 若被 @ 的目标此刻仍标 busy，busyTimeoutHint 返回一行忙碌提示；否则 null（保持裸 TIMEOUT）。
+describe("busyTimeoutHint (#103)", () => {
+  test("目标 busy 带队列 → 富提示含忙碌 + 排队数", () => {
+    const presence = [p({ name: "bot", busy: true, queue_depth: 3 })];
+    expect(busyTimeoutHint(["bot"], presence, NOW)).toBe(
+      "TIMEOUT — @bot 忙碌中, 3 排队; 稍后再试, 勿重复 @（对方在忙, 不是失联）",
+    );
+  });
+
+  test("目标 busy 无队列 → 只报忙碌，不带排队数", () => {
+    const presence = [p({ name: "bot", busy: true })];
+    expect(busyTimeoutHint(["bot"], presence, NOW)).toBe(
+      "TIMEOUT — @bot 忙碌中; 稍后再试, 勿重复 @（对方在忙, 不是失联）",
+    );
+  });
+
+  test("wakeable serve + busy 同样出提示（可达即有意义）", () => {
+    const presence = [p({ name: "bot", state: "offline", wake: { kind: "serve" }, busy: true, queue_depth: 1 })];
+    expect(busyTimeoutHint(["bot"], presence, NOW)).toBe(
+      "TIMEOUT — @bot 忙碌中, 1 排队; 稍后再试, 勿重复 @（对方在忙, 不是失联）",
+    );
+  });
+
+  test("多个目标只列出 busy 的那些", () => {
+    const presence = [
+      p({ name: "a", busy: true, queue_depth: 2 }),
+      p({ name: "b" }), // 在线不忙
+    ];
+    expect(busyTimeoutHint(["a", "b"], presence, NOW)).toBe(
+      "TIMEOUT — @a 忙碌中, 2 排队; 稍后再试, 勿重复 @（对方在忙, 不是失联）",
+    );
+  });
+
+  test("多个目标都 busy → 分号连接", () => {
+    const presence = [p({ name: "a", busy: true, queue_depth: 2 }), p({ name: "b", busy: true })];
+    expect(busyTimeoutHint(["a", "b"], presence, NOW)).toBe(
+      "TIMEOUT — @a 忙碌中, 2 排队; @b 忙碌中; 稍后再试, 勿重复 @（对方在忙, 不是失联）",
+    );
+  });
+
+  test("无 busy 目标 → null（保持裸 TIMEOUT）", () => {
+    expect(busyTimeoutHint(["a"], [p({ name: "a" })], NOW)).toBeNull();
+  });
+
+  test("目标离线（查不到）→ null，不无中生有", () => {
+    expect(busyTimeoutHint(["ghost"], [], NOW)).toBeNull();
   });
 });
 


### PR DESCRIPTION
## 缺口（#103 残留）

presence busy/queue_depth 四层已做（5139fe2），`party who` / `send --reach` 已显示 busy。但 **`party ask` 超时时不显示 busy 提示**：`ask.ts` 委托 `runWatch`，超时时 `watch.ts` 只打裸 `TIMEOUT`（`{type:"timeout"}`），无 busy 线索、也不提示去看 who/reach。用 `party ask` 的人拿到无修饰的超时，容易把「对方只是忙」误判成「offline」，反复 @ 堆重复唤醒。

## 改法

- 新增 `busyTimeoutHint(mentions, presence, now)`（`cli/src/reach.ts`）：复用已有的 `reachOf`，只挑出此刻仍标 `busy` 的被 @ 目标，格式化成一行 `TIMEOUT — @x 忙碌中, N 排队; 稍后再试, 勿重复 @（对方在忙, 不是失联）`。无 busy 目标返回 `null`。
- `ask.ts`：捕获 `runWatch` 返回码，仅当 `code === EXIT_TIMEOUT` 且本次有 @ 目标时，拉一次 `fetchPresence` 并打印 hint 到 **stderr**（与 send 的 reach 行、watch 的 advisory 一致，不污染 stdout 的 `TIMEOUT` 机器信号）。
- 只在能查到目标 busy 时附加；查不到 busy 或 presence 拉取失败则静默，**保持原裸 TIMEOUT 行为与退出码**。未改 240s 默认超时（设计如此）。

## 测试

- `cli/test/reach.test.ts` 新增 `busyTimeoutHint` 用例：带队列 / 无队列 / wakeable+busy / 多目标只列 busy / 多 busy 分号连接 / 无 busy → null / 离线查不到 → null。
- 全量 `cd cli && bun test` → 672 pass 0 fail；`bunx tsc --noEmit` → clean。

涉及 #103，待 host 验收。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **功能优化**
  * 当提及的对象因忙碌或排队导致请求超时时，命令行会提供更明确的提示。
  * 提示可显示对象当前忙碌状态及排队数量，帮助区分“回复较慢”和“暂时无法联系”。

* **问题修复**
  * 无法获取状态信息时将保持原有超时行为，避免显示不准确的离线提示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->