### PR TITLE
fix(cli): party wake test 审计 serve/watch 唤醒 (#107)

### DIFF
--- a/cli/src/commands/wake.ts
+++ b/cli/src/commands/wake.ts
@@ -1,5 +1,5 @@
 // party wake test — prove mention/wake/resume as separate phases.
-import { autoWakeReachable, EXIT_TIMEOUT, type MsgFrame, type PresenceEntry, type WakeDelivery } from "@agentparty/shared";
+import { autoWakeReachable, EXIT_TIMEOUT, type MsgFrame, type PresenceEntry, type WakeDelivery, type WakeKind } from "@agentparty/shared";
 import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
 import { readConfig, resolveChannel } from "../config";
 import { jsonFrame, nowTs } from "../json";
@@ -141,17 +141,56 @@ function summarizeWakeDelivery(delivery: WakeDelivery | null, adapter: string | 
   };
 }
 
-async function fetchLatestWebhookDelivery(
+// #107：serve/watch 是拉模型——服务端从不主动投递，只能记「这条 @ 已广播给已登记 serve/watch 的可唤醒
+// 目标」(result='broadcast')；该 agent resume 引用这条 @ 后升级为 'consumed'。故 wake_invoked 相位映射为：
+//  - null delivery         → ok:null，标注「尚未审计」（沿用旧语义，仅在 ledger 缺行/端点不支持时）。
+//  - result='broadcast'    → ok:null，但给出真实审计证据（已广播、待 resume 确认消费），而不是笼统的「未审计」。
+//  - result='consumed'     → ok:true，唤醒闭环（resume 已引用这条 @）。
+function summarizeServeWatchDelivery(delivery: WakeDelivery | null, adapter: string | null): { ok: boolean | null; adapter: string | null; evidence: string } {
+  if (delivery === null) {
+    return {
+      ok: null,
+      adapter,
+      evidence: "serve/watch broadcast is not audited by the worker yet; only linked resume is conclusive",
+    };
+  }
+  const kind = delivery.adapter_kind;
+  if (delivery.result === "consumed") {
+    const via = delivery.ack_seq !== null ? `reply #${delivery.ack_seq}` : delivery.resume_seq !== null ? `status #${delivery.resume_seq}` : "linked resume";
+    return {
+      ok: true,
+      adapter,
+      evidence: `${kind} client consumed the broadcast for mention #${delivery.mention_seq} (${via})`,
+    };
+  }
+  // result='broadcast'：服务端已把这条 @ 广播给可唤醒的拉客户端，但尚未观测到引用它的 resume。
+  return {
+    ok: null,
+    adapter,
+    evidence: `${kind} broadcast delivered for mention #${delivery.mention_seq}; awaiting linked resume to confirm consumption`,
+  };
+}
+
+// #107：webhook 由服务端主动投递、天然可审计；serve/watch 的广播同样落 ledger（adapter_kind='serve'|'watch'）。
+// 按目标当前登记的 wake 层挑对应的 adapter_kind 读最新一行——webhook 只认 'webhook'，serve/watch 认两者。
+function ledgerKindsFor(adapter: string | null): readonly WakeKind[] | null {
+  if (adapter === "webhook") return ["webhook"];
+  if (adapter === "serve" || adapter === "watch") return ["serve", "watch"];
+  return null;
+}
+
+async function fetchLatestLedgerDelivery(
   server: string,
   token: string,
   channel: string,
   target: string,
   mentionSeq: number,
+  kinds: readonly WakeKind[],
 ): Promise<WakeDelivery | null> {
   try {
     const deliveries = await fetchWakeDeliveries(server, token, channel, { since: mentionSeq, target, limit: 20 });
     return deliveries
-      .filter((d) => d.mention_seq === mentionSeq && d.adapter_kind === "webhook")
+      .filter((d) => d.mention_seq === mentionSeq && kinds.includes(d.adapter_kind))
       .at(-1) ?? null;
   } catch (e) {
     if (e instanceof RestError && (e.status === 404 || e.status === 501)) return null;
@@ -171,7 +210,17 @@ function printHuman(frame: WakeTestFrame) {
   console.log(
     `mention: ${frame.phases.mention_delivered.ok ? `delivered #${frame.phases.mention_delivered.seq}` : "not sent"}`,
   );
-  console.log(`wake invoked: ${frame.phases.wake_invoked.ok === null ? "not audited" : frame.phases.wake_invoked.ok ? "yes" : "no"}`);
+  // #107：ok===null 时别一律印死板的「not audited」——serve/watch 的 broadcast 行已是真实审计结果，
+  // 直接摊出 evidence（broadcast 已投递/待 resume 确认），只有 ledger 真无行时 evidence 才是「未审计」。
+  console.log(
+    `wake invoked: ${
+      frame.phases.wake_invoked.ok === null
+        ? frame.phases.wake_invoked.evidence
+        : frame.phases.wake_invoked.ok
+          ? "yes"
+          : "no"
+    }`,
+  );
   console.log(
     `resumed: ${
       frame.phases.agent_resumed.ok
@@ -299,11 +348,12 @@ export async function run(argv: string[]): Promise<number> {
       reply_to: null,
     });
     const deadline = Date.now() + timeoutSec * 1000;
+    const ledgerKinds = ledgerKindsFor(adapter);
     let ack: { seq: number; evidence: AckEvidence } | null = null;
     let wakeDelivery: WakeDelivery | null = null;
     do {
-      if (adapter === "webhook") {
-        wakeDelivery = await fetchLatestWebhookDelivery(cfg.server, cfg.token, channel, target, seq);
+      if (ledgerKinds !== null) {
+        wakeDelivery = await fetchLatestLedgerDelivery(cfg.server, cfg.token, channel, target, seq, ledgerKinds);
         ack = ackFromWakeDelivery(wakeDelivery);
         if (ack !== null) break;
       }
@@ -311,8 +361,8 @@ export async function run(argv: string[]): Promise<number> {
       if (ack !== null) break;
       await sleep(Math.min(1000, Math.max(100, deadline - Date.now())));
     } while (Date.now() < deadline);
-    if (adapter === "webhook" && wakeDelivery === null) {
-      wakeDelivery = await fetchLatestWebhookDelivery(cfg.server, cfg.token, channel, target, seq);
+    if (ledgerKinds !== null && wakeDelivery === null) {
+      wakeDelivery = await fetchLatestLedgerDelivery(cfg.server, cfg.token, channel, target, seq, ledgerKinds);
     }
 
     // serve/watch are local supervisors reading the channel stream; they filter out the
@@ -339,7 +389,9 @@ export async function run(argv: string[]): Promise<number> {
     const wakeInvoked =
       gate.advisory !== null && wakeDelivery === null
         ? { ok: false as const, adapter, evidence: gate.advisory }
-        : summarizeWakeDelivery(wakeDelivery, adapter);
+        : adapter === "serve" || adapter === "watch"
+          ? summarizeServeWatchDelivery(wakeDelivery, adapter)
+          : summarizeWakeDelivery(wakeDelivery, adapter);
     const frame: WakeTestFrame = {
       type: "wake_test",
       channel,

--- a/cli/test/wake.test.ts
+++ b/cli/test/wake.test.ts
@@ -183,3 +183,231 @@ describe("wake test self-target fast-fail (#194)", () => {
     expect(frame).toMatchObject({ type: "wake_test", target: "me", result: "self_target" });
   });
 });
+
+// ── #107：serve/watch 的唤醒也进服务端 ledger，CLI 要读它、把 wake_invoked 从「not audited」升级为真实审计 ──
+function freshServeWatchPresence(kind: "serve" | "watch") {
+  const now = Date.now();
+  return {
+    name: "agent",
+    state: "waiting",
+    note: null,
+    ts: now,
+    last_seen: now,
+    residency: "supervised",
+    wake: { kind, verified_at: 100 },
+  };
+}
+
+describe("wake test audits serve/watch ledger (#107)", () => {
+  test("serve broadcast (not yet consumed): wake_invoked reads the ledger, not 'not audited'", async () => {
+    mock = startRestMock((req) => {
+      if (req.method === "GET" && req.path === "/api/channels/dev/presence") {
+        return Response.json({ presence: [freshServeWatchPresence("serve")] });
+      }
+      if (req.method === "POST" && req.path === "/api/channels/dev/messages") {
+        return Response.json({ seq: 50 });
+      }
+      if (req.method === "GET" && req.path === "/api/channels/dev/wake-deliveries") {
+        return Response.json({
+          deliveries: [
+            {
+              mention_seq: 50,
+              target_name: "agent",
+              webhook_name: "agent",
+              adapter_kind: "serve",
+              attempt: 1,
+              result: "broadcast",
+              http_status: null,
+              error: null,
+              attempted_at: 112,
+              ack_seq: null,
+              resume_seq: null,
+            },
+          ],
+        });
+      }
+      if (req.method === "GET" && req.path === "/api/channels/dev/messages") {
+        return Response.json({ messages: [] });
+      }
+      return undefined;
+    });
+    writeCfg(mock.url);
+
+    const r = await runCli(["wake", "test", "@agent", "dev", "--timeout", "1", "--json"]);
+    // broadcast ≠ consumed：还没观测到 resume，仍是 timeout（exit 2），但不再是「未审计」
+    expect(r.code).toBe(2);
+    const frame = JSON.parse(r.stdout.trim());
+    expect(frame).toMatchObject({
+      type: "wake_test",
+      result: "timeout",
+      phases: {
+        mention_delivered: { ok: true, seq: 50 },
+        wake_invoked: { ok: null, adapter: "serve" },
+        agent_resumed: { ok: false, seq: null },
+      },
+    });
+    // 关键：wake_invoked 摊出真实审计事实（已广播、待 resume 确认），不再是笼统的「未审计」占位
+    expect(frame.phases.wake_invoked.evidence).toContain("broadcast delivered");
+    expect(frame.phases.wake_invoked.evidence).toContain("awaiting linked resume");
+    expect(frame.phases.wake_invoked.evidence).not.toContain("not audited");
+    // CLI 确实读了 ledger（serve 目标此前根本不查）
+    expect(reqsOf(mock, "GET", "/api/channels/dev/wake-deliveries")[0]!.query).toMatchObject({
+      since: "50",
+      target: "agent",
+    });
+  });
+
+  test("serve consumed: ledger resume evidence lifts wake_invoked to yes and resolves resumed", async () => {
+    mock = startRestMock((req) => {
+      if (req.method === "GET" && req.path === "/api/channels/dev/presence") {
+        return Response.json({ presence: [freshServeWatchPresence("serve")] });
+      }
+      if (req.method === "POST" && req.path === "/api/channels/dev/messages") {
+        return Response.json({ seq: 60 });
+      }
+      if (req.method === "GET" && req.path === "/api/channels/dev/wake-deliveries") {
+        return Response.json({
+          deliveries: [
+            {
+              mention_seq: 60,
+              target_name: "agent",
+              webhook_name: "agent",
+              adapter_kind: "serve",
+              attempt: 1,
+              result: "consumed",
+              http_status: null,
+              error: null,
+              attempted_at: 112,
+              ack_seq: 61,
+              resume_seq: null,
+            },
+          ],
+        });
+      }
+      // ledger 已闭环，无需靠频道历史里的 reply 佐证
+      if (req.method === "GET" && req.path === "/api/channels/dev/messages") {
+        return Response.json({ messages: [] });
+      }
+      return undefined;
+    });
+    writeCfg(mock.url);
+
+    const r = await runCli(["wake", "test", "@agent", "dev", "--timeout", "1", "--json"]);
+    expect(r.code).toBe(0);
+    const frame = JSON.parse(r.stdout.trim());
+    expect(frame).toMatchObject({
+      type: "wake_test",
+      result: "healthy",
+      phases: {
+        mention_delivered: { ok: true, seq: 60 },
+        wake_invoked: { ok: true, adapter: "serve" },
+        agent_resumed: { ok: true, seq: 61, evidence: "reply_to" },
+      },
+    });
+    expect(frame.phases.wake_invoked.evidence).toContain("consumed");
+  });
+
+  test("watch broadcast: ledger filter keeps serve/watch rows and ignores unrelated webhook rows", async () => {
+    mock = startRestMock((req) => {
+      if (req.method === "GET" && req.path === "/api/channels/dev/presence") {
+        return Response.json({ presence: [freshServeWatchPresence("watch")] });
+      }
+      if (req.method === "POST" && req.path === "/api/channels/dev/messages") {
+        return Response.json({ seq: 70 });
+      }
+      if (req.method === "GET" && req.path === "/api/channels/dev/wake-deliveries") {
+        return Response.json({
+          deliveries: [
+            // 无关的 webhook 行（同一 mention_seq）：watch 目标必须过滤掉它，否则会误判成 consumed
+            {
+              mention_seq: 70,
+              target_name: "agent",
+              webhook_name: "hook",
+              adapter_kind: "webhook",
+              attempt: 1,
+              result: "ok",
+              http_status: 202,
+              error: null,
+              attempted_at: 111,
+              ack_seq: 999,
+              resume_seq: null,
+            },
+            {
+              mention_seq: 70,
+              target_name: "agent",
+              webhook_name: "agent",
+              adapter_kind: "watch",
+              attempt: 1,
+              result: "broadcast",
+              http_status: null,
+              error: null,
+              attempted_at: 112,
+              ack_seq: null,
+              resume_seq: null,
+            },
+          ],
+        });
+      }
+      if (req.method === "GET" && req.path === "/api/channels/dev/messages") {
+        return Response.json({ messages: [] });
+      }
+      return undefined;
+    });
+    writeCfg(mock.url);
+
+    const r = await runCli(["wake", "test", "@agent", "dev", "--timeout", "1", "--json"]);
+    expect(r.code).toBe(2);
+    const frame = JSON.parse(r.stdout.trim());
+    // 只认 watch 那行（broadcast → 待确认），绝不把 webhook 行的 ack_seq=999 当成 watch 的 resume
+    expect(frame).toMatchObject({
+      type: "wake_test",
+      result: "timeout",
+      phases: {
+        wake_invoked: { ok: null, adapter: "watch" },
+        agent_resumed: { ok: false, seq: null },
+      },
+    });
+    expect(frame.phases.wake_invoked.evidence).toContain("watch broadcast delivered");
+  });
+
+  test("human output surfaces the broadcast audit instead of printing 'not audited'", async () => {
+    mock = startRestMock((req) => {
+      if (req.method === "GET" && req.path === "/api/channels/dev/presence") {
+        return Response.json({ presence: [freshServeWatchPresence("serve")] });
+      }
+      if (req.method === "POST" && req.path === "/api/channels/dev/messages") {
+        return Response.json({ seq: 80 });
+      }
+      if (req.method === "GET" && req.path === "/api/channels/dev/wake-deliveries") {
+        return Response.json({
+          deliveries: [
+            {
+              mention_seq: 80,
+              target_name: "agent",
+              webhook_name: "agent",
+              adapter_kind: "serve",
+              attempt: 1,
+              result: "broadcast",
+              http_status: null,
+              error: null,
+              attempted_at: 112,
+              ack_seq: null,
+              resume_seq: null,
+            },
+          ],
+        });
+      }
+      if (req.method === "GET" && req.path === "/api/channels/dev/messages") {
+        return Response.json({ messages: [] });
+      }
+      return undefined;
+    });
+    writeCfg(mock.url);
+
+    const r = await runCli(["wake", "test", "@agent", "dev", "--timeout", "1"]);
+    expect(r.code).toBe(2);
+    // 人读输出的 wake invoked 行不再是死板的「not audited」，而是真实广播审计
+    expect(r.stdout).toContain("wake invoked: serve broadcast delivered");
+    expect(r.stdout).not.toContain("wake invoked: not audited");
+  });
+});


### PR DESCRIPTION
## 缺口（#107）

服务端已把 serve/watch 唤醒落 `wake_delivery_ledger`（`worker/src/do.ts` `recordServeWatchWakes`，`adapter_kind='serve'|'watch'`，广播即 `result='broadcast'`，agent resume 引用后经 `linkWakeResume` 升级为 `'consumed'`），REST 读路径 `/api/channels/:slug/wake-deliveries` 也返回 `adapter_kind`。

但 CLI `cli/src/commands/wake.ts` 仍**只对 webhook 读 ledger**：轮询循环 `if (adapter === "webhook")` 才 fetch，且 fetch 又硬过滤 `d.adapter_kind === "webhook"`。结果 `party wake test @<serve/watch-agent>` 的 `wake_invoked` 相位恒显示 **"not audited"**，明明服务端已有 broadcast/consumed 审计事实。

## 改法

- 把 `fetchLatestWebhookDelivery` 泛化为 `fetchLatestLedgerDelivery(..., kinds)`，并按目标登记的 wake 层挑 `adapter_kind`（`ledgerKindsFor`：webhook 只认 `'webhook'`，serve/watch 认 `('serve','watch')`）。
- 新增 `summarizeServeWatchDelivery`：`broadcast` → `ok:null` 但给出**真实审计证据**（已广播、待 resume 确认消费），`consumed` → `ok:true`（唤醒闭环）。复用已有 `ackFromWakeDelivery` 从 `ack_seq/resume_seq` 取 resume 证据。
- 轮询循环对 serve/watch 也读 ledger（此前根本不查）。
- 人读输出的 `wake invoked` 行在 `ok===null` 时摊出 evidence，不再一律印死板的 "not audited"。

## 测试

`cli/test/wake.test.ts` 新增 4 例：serve broadcast（未消费→`ok:null` 且真实审计证据、验证 CLI 确实读了 ledger）、serve consumed（→`ok:true` + resumed）、watch broadcast（ledger 过滤无关 webhook 行，不误判 consumed）、人读输出不再印 "not audited"。

```
wake / m3 / stuck-wake / wake-budget / wakeable-presence 五套：155 pass, 0 fail
```

只改这个缺口，未动服务端与其他命令。

涉及 #107，待 host 验收。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 改进 `party wake test` 对 serve/watch 唤醒流程的审计与状态判断。
  * 新增广播、消费及恢复确认等更具体的证据展示。
* **问题修复**
  * 修复不同唤醒通道之间可能误用交付确认信息的问题。
  * 优化等待恢复确认的逻辑，减少错误的超时或未审计提示。
* **体验改进**
  * 人类可读输出现在会清晰区分“已广播等待恢复”和“已成功恢复”。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->