### PR TITLE
fix(cli): watch 尊重 paused，暂停期不被 @ 唤醒 (#180)

### DIFF
--- a/cli/src/commands/watch.ts
+++ b/cli/src/commands/watch.ts
@@ -194,6 +194,10 @@ export async function runWatch(o: WatchOptions): Promise<number> {
   let timedOut = false;
   let onceDone = false;
   let code = 0;
+  // 人为暂停接待（#180）：镜像 serve 的 self-paused 跟踪。被 @ 时不把 --once 退出当唤醒信号，
+  // 但消息照常打印进历史、游标照推进。从 welcome 的 presence 快照认出初始状态（重连也不误唤醒），
+  // 之后靠 presence 帧增量翻转。恢复后不重放暂停期的 @（在历史里，agent 自行补看），与 serve 一致。
+  let selfPaused = false;
   let timer: ReturnType<typeof setTimeout> | null = null;
   if (o.timeoutSec > 0) {
     timer = setTimeout(() => {
@@ -220,6 +224,15 @@ export async function runWatch(o: WatchOptions): Promise<number> {
       if (frame.type === "welcome") {
         self = frame.self;
         lastSeq = frame.last_seq;
+        // 连上/重连时若自己已被暂停接待（#180），从 welcome 的 presence 快照里认出来——
+        // 重连也不会把暂停期的 @ 误当成 --once 唤醒。提示走 stderr，不污染被消费的 stdout 流。
+        const mine = frame.presence?.find((p) => p.name === self);
+        selfPaused = mine?.paused === true;
+        if (selfPaused) {
+          console.error(
+            `watch: 当前处于暂停接待状态——被 @ 也不作为 --once 唤醒信号${typeof mine?.resume_at === "number" ? `，将于 ${new Date(mine.resume_at).toISOString()} 恢复` : "（等人工恢复）"}。消息仍进历史。`,
+          );
+        }
         // 不要用 welcome.read_cursors 快进 --once 的游标（#172 的诱人错解）。
         // read cursor 是**身份级「已读」**：protocol.ts 明确「网页 tab / serve / watch --follow
         // 读到就回 seen；webhook / watch --once 型事件驱动 agent 不发 seen，其送达状态由
@@ -245,6 +258,20 @@ export async function runWatch(o: WatchOptions): Promise<number> {
         else code = 1;
         break;
       }
+      // 人为暂停/恢复（#180）：跟踪自己的 paused 状态（镜像 serve）。moderator 一按暂停/恢复，
+      // DO 就广播这帧过来。提示走 stderr，不污染被消费的 stdout 流。
+      if (frame.type === "presence" && frame.name === self) {
+        const nextPaused = frame.paused === true;
+        if (nextPaused !== selfPaused) {
+          selfPaused = nextPaused;
+          console.error(
+            selfPaused
+              ? `watch: 已被暂停接待——被 @ 也不再作为 --once 唤醒信号${typeof frame.resume_at === "number" ? `，将于 ${new Date(frame.resume_at).toISOString()} 恢复` : "（等人工恢复）"}。消息仍进历史。`
+              : "watch: 已恢复接待——@ 重新作为唤醒信号。",
+          );
+        }
+        continue;
+      }
       const msg = frame.type === "message_update" ? frame.message : frame;
       if (msg.type !== "msg" && msg.type !== "status") continue;
       lastSeq = Math.max(lastSeq, msg.seq);
@@ -253,8 +280,11 @@ export async function runWatch(o: WatchOptions): Promise<number> {
       // fresh = 游标之上的新消息。重放的历史修订快照（seq 早已消费过）会穿透去重进来
       // ——它们可以照常打印（展示编辑是 feature），但绝不能算「唤醒」（曾把 --once 假唤醒）
       const fresh = msg.seq > conn.cursor;
+      // 暂停接待（#180）：qualifies 的新消息本该把 --once 退出当唤醒信号，但人按了暂停 →
+      // 不退出、不发 once-wake 帧。消息仍照常打印进历史、游标照推进（下方 ack），与 serve 一致。
+      const wakes = fresh && !selfPaused;
       if (qualifies) {
-        if (o.json && o.once && fresh) {
+        if (o.json && o.once && wakes) {
           out(
             JSON.stringify(
               jsonFrame({
@@ -289,7 +319,14 @@ export async function runWatch(o: WatchOptions): Promise<number> {
       // 服务端从游标开始重放，所以这条是**最旧**的未读 @，不是最新的（#199）。
       // 醒在最旧是对的（醒在最新会丢消息），但必须把落后量说出来：否则被唤醒的 agent
       // 会以为手上这条就是频道现状，照着几小时前的上下文回话，而身后还压着一摞没读的。
-      if (o.once && qualifies && fresh) {
+      // 暂停接待中被 @：不退出、不唤醒；发一条 stderr 提示交代这条 @ 已在历史里，恢复后自行补看。
+      if (o.once && qualifies && fresh && selfPaused) {
+        console.error(
+          `watch: ⏸ 暂停接待中，seq=${msg.seq} 的 @ 不作为 --once 唤醒信号（消息已在历史）。` +
+            ` 恢复后补看：party history ${o.channel} --since ${msg.seq}`,
+        );
+      }
+      if (o.once && qualifies && wakes) {
         onceDone = true;
         const behind = Math.max(0, lastSeq - msg.seq);
         if (!o.json && behind > 0) {

--- a/cli/test/watch-pause.test.ts
+++ b/cli/test/watch-pause.test.ts
@@ -1,0 +1,124 @@
+// #180：watch --once 必须尊重「暂停接待」。被暂停的 agent 用 `party watch --once`（给 Claude Code
+// 的旗舰唤醒姿势）被 @ 时不能退出——进程退出就是唤醒信号，退出=被唤醒=暂停形同虚设。
+// 镜像 serve 的 self-paused 跟踪：从 welcome 的 presence 快照认出初始暂停态、靠 presence 帧增量翻转；
+// 暂停期被 @ 不作为 --once 唤醒退出，但消息照常打印进历史、游标照推进；恢复后 @ 重新唤醒。
+import { afterEach, describe, expect, test } from "bun:test";
+import { EXIT_TIMEOUT } from "@agentparty/shared";
+import { runWatch, type WatchOptions } from "../src/commands/watch";
+import { msgFrame, startMockServer, type MockServer } from "./mock-server";
+
+let server: MockServer | null = null;
+
+function pausedWelcome(lastSeq: number, self = "me", over: Record<string, unknown> = {}) {
+  return {
+    type: "welcome",
+    channel: "dev",
+    self,
+    last_seq: lastSeq,
+    presence: [
+      { name: self, state: "online", note: null, ts: Date.now(), paused: true, resume_at: Date.now() + 3_600_000 },
+    ],
+    ...over,
+  };
+}
+
+function plainWelcome(lastSeq: number, self = "me") {
+  return { type: "welcome", channel: "dev", self, last_seq: lastSeq, presence: [] };
+}
+
+function presenceFrame(name: string, over: Record<string, unknown> = {}) {
+  return { type: "presence", name, state: "online", note: null, ts: Date.now(), ...over };
+}
+
+function opts(over: Partial<WatchOptions> & { server: string }): WatchOptions & { lines: string[]; cursors: number[] } {
+  const lines: string[] = [];
+  const cursors: number[] = [];
+  return {
+    token: "ap_tok",
+    channel: "dev",
+    since: 3,
+    timeoutSec: 1,
+    follow: false,
+    mentionsOnly: true,
+    once: true,
+    allowMultiple: true,
+    out: (l) => lines.push(l),
+    onCursor: (c) => cursors.push(c),
+    backoffBaseMs: 20,
+    lines,
+    cursors,
+    ...over,
+  };
+}
+
+afterEach(() => {
+  server?.stop();
+  server = null;
+});
+
+describe("watch --once 尊重暂停接待 (#180)", () => {
+  test("welcome 快照里已暂停：被 @ 不退出（超时而非唤醒），但消息照进历史、游标照推进", async () => {
+    server = startMockServer((frame, sock) => {
+      if (frame.type !== "hello") return;
+      sock.send(pausedWelcome(3, "me"));
+      sock.send(msgFrame(4, "暂停期 @ 你", { mentions: ["me"] }));
+    });
+
+    const o = opts({ server: server.url });
+    // 没被唤醒——一直等到超时（若尊重失败会 return 0 提前退出=假唤醒）
+    expect(await runWatch(o)).toBe(EXIT_TIMEOUT);
+    expect(o.lines).toContain("TIMEOUT");
+    // 消息照常入历史：打印出来 + 游标推进到该 seq（服务端据此标记已读）
+    expect(o.lines.some((l) => l.includes("暂停期 @ 你"))).toBe(true);
+    expect(o.cursors).toContain(4);
+    // 但绝不发 --once 唤醒摘要（channel_last_seq=... lag=... 是唤醒回执）
+    expect(o.lines.some((l) => l.includes("channel_last_seq"))).toBe(false);
+  });
+
+  test("运行中收到 presence 暂停帧：随后被 @ 也不退出", async () => {
+    server = startMockServer((frame, sock) => {
+      if (frame.type !== "hello") return;
+      sock.send(plainWelcome(3, "me"));
+      sock.send(presenceFrame("me", { paused: true, resume_at: Date.now() + 60_000 }));
+      sock.send(msgFrame(4, "刚被暂停后 @ 你", { mentions: ["me"] }));
+    });
+
+    const o = opts({ server: server.url });
+    expect(await runWatch(o)).toBe(EXIT_TIMEOUT);
+    expect(o.lines.some((l) => l.includes("刚被暂停后 @ 你"))).toBe(true);
+    expect(o.cursors).toContain(4);
+    expect(o.lines.some((l) => l.includes("channel_last_seq"))).toBe(false);
+  });
+
+  test("恢复接待后：@ 重新作为唤醒信号，正常退出 0", async () => {
+    server = startMockServer((frame, sock) => {
+      if (frame.type !== "hello") return;
+      // 起始已暂停 → seq 4 的 @ 不唤醒；收到恢复 presence 帧后，seq 5 的 @ 才唤醒退出。
+      sock.send(pausedWelcome(3, "me"));
+      sock.send(msgFrame(4, "暂停期 @ 你（不该醒）", { mentions: ["me"] }));
+      sock.send(presenceFrame("me")); // paused 省略 = 恢复接待
+      sock.send(msgFrame(5, "恢复后 @ 你（该醒）", { mentions: ["me"] }));
+    });
+
+    const o = opts({ server: server.url });
+    // 醒在 seq 5，正常退出 0（若停在 seq 4 唤醒，就读不到 seq 5 了）
+    expect(await runWatch(o)).toBe(0);
+    expect(o.lines.some((l) => l.includes("恢复后 @ 你"))).toBe(true);
+    expect(o.lines).toContain("watch: channel_last_seq=5 lag=0 skipped_mention_seqs=[]");
+    expect(o.cursors).toContain(5);
+  });
+
+  test("别人被暂停不影响我：presence 帧 name 不是自己时照常唤醒", async () => {
+    server = startMockServer((frame, sock) => {
+      if (frame.type !== "hello") return;
+      sock.send(plainWelcome(3, "me"));
+      sock.send(presenceFrame("bob", { paused: true })); // 是 bob 被暂停，不是我
+      sock.send(msgFrame(4, "@ 你", { mentions: ["me"] }));
+    });
+
+    const o = opts({ server: server.url });
+    expect(await runWatch(o)).toBe(0);
+    expect(o.lines.some((l) => l.includes("@ 你"))).toBe(true);
+    expect(o.cursors).toContain(4);
+  });
+});


### PR DESCRIPTION
## 缺口

#180 的 pause/resume/定时恢复/webhook 抑制/serve 自抑制都已落地（a668e02），但 `cli/src/commands/watch.ts` **0 处引用 paused**。唤醒判定纯粹是：

```ts
const qualifies = !fromSelf && (!o.mentionsOnly || msg.mentions.includes(self));
```

于是被暂停接待的 agent 用 `party watch --once`（给 Claude Code 的旗舰唤醒姿势）被 @ 时，`--once` 照样退出——进程退出就是唤醒信号，退出＝被唤醒，**暂停对 watch 形同虚设**。serve.ts 已有正确做法（self-paused 跟踪，serve.ts:1560/1607/1667），watch 没镜像过去。

## 改法

镜像 serve.ts 的 self-paused 跟踪到 watch.ts：

- **welcome 快照**：`frame.presence?.find(p => p.name === self)?.paused` 认出连上/重连时的初始暂停态，重连也不会把暂停期的 @ 误当唤醒。
- **presence 帧**：`frame.type === "presence" && frame.name === self` 时增量翻转 `selfPaused`（moderator 一按暂停/恢复 DO 就广播这帧）。
- **唤醒收窄**：`const wakes = fresh && !selfPaused`。暂停期 qualifies 的新消息不再触发 `--once` 退出、也不发 once-wake JSON 帧；但消息**照常打印进历史、游标照推进**（`ack` 不变），恢复后不重放（在历史里 agent 自行补看）——与 serve 完全一致。
- 所有提示走 stderr，不污染被消费的 stdout 流。

watch 无 `--on-mention`（那是 serve 的旗标）；watch 侧的等价唤醒面就是 `--once` 退出与 once-wake 帧，均已受 paused 抑制。

## 测试

新增 `cli/test/watch-pause.test.ts`（4 例，全绿）：

1. welcome 快照里已暂停：被 @ 不退出（超时 `EXIT_TIMEOUT` 而非唤醒），但消息照打印、游标推进到该 seq，且不发 `channel_last_seq` 唤醒摘要。
2. 运行中收到 presence 暂停帧：随后被 @ 也不退出。
3. 恢复接待后：@ 重新作为唤醒信号，正常退出 0（醒在恢复后的 seq）。
4. 别人（bob）被暂停不影响自己：presence.name 非 self 时照常唤醒。

`bun test test/watch-pause.test.ts` → 4 pass；既有 `watch*.test.ts` 48 pass 无回归；`tsc --noEmit` 干净。

涉及 #180，待 host 验收。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能改进**
  - `watch --once` 现在会识别当前账号是否处于暂停接待状态。
  - 暂停期间，消息仍会正常输出并推进游标，但被提及不会触发唤醒或退出。
  - 恢复接待后，后续符合条件的提及可正常唤醒并退出。
  - 暂停其他账号不会影响当前账号的唤醒行为。
  - 暂停期间收到的提及会显示提示，便于恢复后按序查看历史消息。

- **测试**
  - 新增暂停、恢复及重连场景的行为验证。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->