### PR TITLE
feat(web): 分工变化自动同步到公告 (#150)

### DIFF
--- a/web/src/lib/divisionCharter.ts
+++ b/web/src/lib/divisionCharter.ts
@@ -39,6 +39,13 @@ export function formatDivisionSection(roles: DivisionCharterRole[], labels: Divi
   return `${START_MARKER}\n### ${labels.heading}\n${body}\n${END_MARKER}`;
 }
 
+// #150 自动同步：判断公告里是否已经有「自动分工区块」（marker 存在）。用来区分
+// 「本来就没有分工、也不该无中生有写空区块」和「区块曾经写过、现在分工清零需要更新」
+// 两种情况——前者自动同步应静默跳过，后者应把区块刷新为空。
+export function charterHasDivisionSection(charterText: string): boolean {
+  return charterText.includes(START_MARKER);
+}
+
 export function mergeDivisionIntoCharter(charterText: string, section: string): string {
   const markerRe = new RegExp(`${escapeForRegExp(START_MARKER)}[\\s\\S]*?${escapeForRegExp(END_MARKER)}`);
   if (markerRe.test(charterText)) {

--- a/web/src/pages/Channel.tsx
+++ b/web/src/pages/Channel.tsx
@@ -62,7 +62,7 @@ import { buildReceipts, type MentionReceipt } from "../lib/wakeReceipt";
 import { completionMessages } from "../lib/completions";
 import { catchupKey, summarizeCatchup, type CatchupDigest } from "../lib/digest";
 import { buildOrgTree, type OrgMemberInput } from "../lib/orgTree";
-import { formatDivisionSection, mergeDivisionIntoCharter, type DivisionCharterRole } from "../lib/divisionCharter";
+import { charterHasDivisionSection, formatDivisionSection, mergeDivisionIntoCharter, type DivisionCharterRole } from "../lib/divisionCharter";
 import {
   clearDeliveredMentionNotifications,
   isDesktopRuntime,
@@ -641,22 +641,56 @@ export function DivisionBoard({
     .filter((item) => item.count > 0);
 
   // issue #150\uff1a\u62ff\u5f53\u524d\u5df2\u58f0\u660e\u5206\u5de5\uff08assigned + self\uff0c\u4e0d\u542b\u672a\u5206\u5de5\u5360\u4f4d\uff09\u62fc\u6210 markdown
-  // \u5c0f\u8282\uff0c\u5408\u5e76\u8fdb\u73b0\u6709\u516c\u544a\u6587\u672c\uff0c\u4ea4\u7ed9\u4e0a\u5c42\u843d\u76d8\u3002
-  const syncDivisionToCharter = () => {
-    const declared: DivisionCharterRole[] = roleViews
-      .filter((view): view is typeof view & { role: NonNullable<typeof view.role> } => view.role !== null)
-      .map((view) => ({
-        display: view.display,
-        accountLabel: view.accountLabel,
-        role: view.role.role,
-        responsibility: view.role.responsibility,
-      }));
-    const section = formatDivisionSection(declared, {
+  // \u5c0f\u8282\uff0c\u5408\u5e76\u8fdb\u73b0\u6709\u516c\u544a\u6587\u672c\u3002\u7eaf\u8ba1\u7b97\u653e\u5728\u6e32\u67d3\u671f\uff0c\u624b\u52a8\u6309\u94ae\u548c\u4e0b\u9762\u7684\u81ea\u52a8\u540c\u6b65 effect
+  // \u5171\u7528\u540c\u4e00\u4efd\u5408\u5e76\u7ed3\u679c nextCharterText\u2014\u2014\u4fdd\u8bc1\u300c\u624b\u70b9\u300d\u548c\u300c\u81ea\u52a8\u300d\u5199\u8fdb\u53bb\u7684\u6587\u672c\u4e00\u6a21\u4e00\u6837\u3002
+  const declared: DivisionCharterRole[] = roleViews
+    .filter((view): view is typeof view & { role: NonNullable<typeof view.role> } => view.role !== null)
+    .map((view) => ({
+      display: view.display,
+      accountLabel: view.accountLabel,
+      role: view.role.role,
+      responsibility: view.role.responsibility,
+    }));
+  const currentCharterText = charterText ?? "";
+  const nextCharterText = mergeDivisionIntoCharter(
+    currentCharterText,
+    formatDivisionSection(declared, {
       heading: t("Channel.roles.syncHeading"),
       empty: t("Channel.roles.syncEmpty"),
-    });
-    onSyncToCharter(mergeDivisionIntoCharter(charterText ?? "", section));
+    }),
+  );
+  const syncDivisionToCharter = () => {
+    onSyncToCharter(nextCharterText);
   };
+
+  // issue #150\uff1a\u5934\u53f7\u8bc9\u6c42\u662f\u300c\u5206\u5de5\u53d8\u5316\u5373\u81ea\u52a8\u540c\u6b65\u5230\u516c\u544a\u300d\uff0c\u624b\u52a8\u6309\u94ae\u53ea\u505a\u515c\u5e95\u3002\u8fd9\u91cc\u76d1\u542c
+  // \u5408\u5e76\u7ed3\u679c\u7684\u53d8\u5316\uff0c\u53bb\u6296\u540e\u81ea\u52a8\u843d\u76d8\u3002\u5e42\u7b49/\u65ad\u73af\u9760 mergeDivisionIntoCharter\u2014\u2014\u5199\u8fdb\u53bb\u540e
+  // charterText \u4f1a\u53d8\u5f97\u4e0e\u5408\u5e76\u7ed3\u679c\u4e00\u81f4\uff0ceffect \u518d\u8dd1\u5c31 no-op\uff0c\u4e0d\u4f1a\u81ea\u6211\u5faa\u73af\u3002\u5b88\u536b\uff1a
+  //   - \u975e moderator \u9759\u9ed8\u8df3\u8fc7\uff08\u81ea\u52a8\u5199\u8def\u5f84\u4ecd\u8d70 moderator-only \u7684 setChannelCharter\uff0c
+  //     \u666e\u901a agent \u89e6\u53d1\u53ea\u4f1a 403\uff0c\u4e0d\u5982\u4e0d\u5199\u2014\u2014\u670d\u52a1\u7aef\u81ea\u52a8\u5199\u8005\u662f\u66f4\u5927\u6539\u52a8\uff0c\u7559 follow-up\uff09\uff1b
+  //   - \u5199\u5165\u5728\u9014\uff08syncingCharter\uff0c\u5373\u4e0a\u5c42 charterSaving\uff09\u65f6\u4e0d\u53e0\u5199\uff0c\u590d\u7528\u73b0\u6709\u5e76\u53d1\u5b88\u536b\uff1b
+  //   - \u53ea\u5728\u5408\u5e76\u7ed3\u679c\u4e0e\u5f53\u524d\u516c\u544a\u5b9e\u9645\u4e0d\u540c\u624d\u5199\uff08\u5e42\u7b49\uff0c\u9632\u91cd\u590d\u5806\u53e0\uff09\uff1b
+  //   - \u672c\u6765\u6ca1\u6709\u5206\u5de5\u3001\u516c\u544a\u91cc\u4e5f\u6ca1\u6709\u65e2\u5b58\u5206\u5de5\u533a\u5757\u65f6\u4e0d\u65e0\u4e2d\u751f\u6709\u5199\u7a7a\u533a\u5757\u2014\u2014\u90a3\u79cd\u300c\u663e\u5f0f\u7269\u5316
+  //     \u7a7a\u533a\u5757\u300d\u7684\u52a8\u4f5c\u7559\u7ed9\u624b\u52a8\u6309\u94ae\uff1b\u533a\u5757\u66fe\u5199\u8fc7\u3001\u5206\u5de5\u6e05\u96f6\u65f6\u4ecd\u4f1a\u81ea\u52a8\u5237\u65b0\u4e3a\u7a7a\uff1b
+  //   - lastAutoSyncedRef \u8bb0\u4f4f\u4e0a\u4e00\u6b21\u81ea\u52a8\u5199\u8fc7\u7684\u6587\u672c\uff0c\u4e07\u4e00\u670d\u52a1\u7aef\u56de\u5b58\u65f6\u505a\u4e86\u89c4\u8303\u5316
+  //     \uff08charterText \u4e0e\u6211\u4eec\u53d1\u51fa\u7684\u7565\u6709\u51fa\u5165\uff09\u4e5f\u4e0d\u4f1a\u6bcf\u4e2a\u53bb\u6296\u5468\u671f\u91cd\u590d\u5199\u3001\u6296\u6210\u6b7b\u5faa\u73af\u3002
+  const onSyncRef = useRef(onSyncToCharter);
+  onSyncRef.current = onSyncToCharter;
+  const lastAutoSyncedRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!canModerate) return;
+    if (syncingCharter) return;
+    if (declared.length === 0 && !charterHasDivisionSection(currentCharterText)) return;
+    if (nextCharterText === currentCharterText) return;
+    if (nextCharterText === lastAutoSyncedRef.current) return;
+    const timer = setTimeout(() => {
+      lastAutoSyncedRef.current = nextCharterText;
+      onSyncRef.current(nextCharterText);
+    }, 800);
+    return () => clearTimeout(timer);
+    // declared.length \u8986\u76d6\u300c\u5206\u5de5\u6570\u91cf\u53d8\u5316\u300d\uff1bnextCharterText \u8986\u76d6\u300c\u5206\u5de5\u5185\u5bb9/\u516c\u544a\u5e95\u7a3f\u53d8\u5316\u300d\u3002
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [nextCharterText, currentCharterText, canModerate, syncingCharter, declared.length]);
 
   return (
     <details className="role-board" aria-label={t("Channel.roles.label")} open={forceOpen ? true : undefined}>

--- a/web/src/pages/DivisionBoard.test.tsx
+++ b/web/src/pages/DivisionBoard.test.tsx
@@ -26,6 +26,11 @@ let renderer: ReactTestRenderer | null = null;
 
 const noop = () => {};
 
+// #150 自动同步用 800ms 去抖的 setTimeout；测试等它触发。留足余量避免 CI 抖动。
+const AUTO_SYNC_DEBOUNCE_MS = 800;
+const wait = (ms: number) => new Promise<void>((resolve) => { setTimeout(resolve, ms); });
+const flushAutoSync = () => wait(AUTO_SYNC_DEBOUNCE_MS + 250);
+
 function presenceEntry(overrides: Partial<PresenceEntry> & { name: string }): PresenceEntry {
   return {
     state: "working",
@@ -287,6 +292,98 @@ describe("DivisionBoard sync-to-charter (#150)", () => {
     render(baseProps({ canModerate: false }));
     const btn = renderer!.root.findAll((n) => n.props.className === "d-btn role-sync-charter-btn");
     expect(btn.length).toBe(0);
+  });
+});
+
+// issue #150（缺口）：头号诉求是「分工/角色变化即自动同步到公告」，此前只有手动按钮。
+// 这里测自动同步 effect：分工变化去抖后自动落盘、非 moderator 静默跳过、内容一致时
+// 幂等不重复写。手动按钮保留为兜底（上一组已覆盖），默认自动。
+describe("DivisionBoard auto-sync-to-charter (#150)", () => {
+  const hostRole = {
+    name: "leo-claude", role: "host" as const, responsibility: "统筹", assigned_by: "leo",
+    assigned_at: 1, kind: "agent" as const, account: "leo", display: "leo-claude",
+  };
+
+  test("moderator auto-syncs declared roles into the charter with no button click", async () => {
+    let synced: string | null = null;
+    render(
+      baseProps({
+        canModerate: true,
+        charterText: "# Team charter\n\nBe kind to each other.",
+        roles: [hostRole],
+        presence: { "leo-claude": presenceEntry({ name: "leo-claude", account: "leo" }) },
+        onSyncToCharter: (text: string) => { synced = text; },
+      }),
+    );
+    // 没有任何点击——纯靠 effect + 去抖触发。
+    await flushAutoSync();
+    expect(synced).not.toBeNull();
+    expect(synced as unknown as string).toContain("leo-claude");
+    expect(synced as unknown as string).toContain("Be kind to each other.");
+  });
+
+  test("non-moderators never auto-write the charter (silent skip, no failing 403 write)", async () => {
+    let synced: string | null = null;
+    render(
+      baseProps({
+        canModerate: false,
+        charterText: "# Team charter",
+        roles: [hostRole],
+        presence: { "leo-claude": presenceEntry({ name: "leo-claude", account: "leo" }) },
+        onSyncToCharter: (text: string) => { synced = text; },
+      }),
+    );
+    await flushAutoSync();
+    expect(synced).toBeNull();
+  });
+
+  test("does not auto-write out of nothing when there is no division and no existing section", async () => {
+    let synced: string | null = null;
+    render(
+      baseProps({
+        canModerate: true,
+        charterText: "# Team charter\n\nBe kind.",
+        roles: [],
+        presence: {},
+        onSyncToCharter: (text: string) => { synced = text; },
+      }),
+    );
+    await flushAutoSync();
+    expect(synced).toBeNull();
+  });
+
+  test("idempotent: no second auto-write once the charter already holds the up-to-date section", async () => {
+    // 第一阶段：空底稿 + 分工，自动写出合并结果。
+    let synced: string | null = null;
+    render(
+      baseProps({
+        canModerate: true,
+        charterText: "# Team charter\n\nBe kind.",
+        roles: [hostRole],
+        presence: { "leo-claude": presenceEntry({ name: "leo-claude", account: "leo" }) },
+        onSyncToCharter: (text: string) => { synced = text; },
+      }),
+    );
+    await flushAutoSync();
+    const firstWrite = synced;
+    expect(firstWrite).not.toBeNull();
+    act(() => renderer!.unmount());
+    renderer = null;
+
+    // 第二阶段：把「已同步好的公告」作为底稿重新渲染，同一份分工——合并结果与现状一致，
+    // 不应再触发任何写入（幂等，防重复堆叠 / 防自我循环）。
+    let secondWrite: string | null = null;
+    render(
+      baseProps({
+        canModerate: true,
+        charterText: firstWrite as unknown as string,
+        roles: [hostRole],
+        presence: { "leo-claude": presenceEntry({ name: "leo-claude", account: "leo" }) },
+        onSyncToCharter: (text: string) => { secondWrite = text; },
+      }),
+    );
+    await flushAutoSync();
+    expect(secondWrite).toBeNull();
   });
 });
 


### PR DESCRIPTION
## 缺口（#150）
#150 头号诉求是「分工内容**自动**同步到公告」。此前只落地了手动「同步到公告」按钮（`web/src/pages/Channel.tsx` DivisionBoard，`canModerate` + `onClick` 唯一触发），"自动"未 honor——分工/角色变化后公告不会跟着更新，仍要人去点。

## 产品口径（host 已定，照做）
1. **角色/分工变化即自动同步**：分工数据变化时自动调用现有的 `syncDivisionToCharter` 逻辑（`mergeDivisionIntoCharter` 幂等 marker 合并已存在），不用点按钮。
2. **保留手动按钮**作为兜底，默认自动。
3. **权限**：自动写仍走现有 moderator-only 的 `setChannelCharter`；非 moderator 静默跳过（不报错、不触发 403）。服务端自动写者是更大改动，留 follow-up。
4. charter 里 auto 区块用稳定 marker（`formatDivisionSection`）分隔，auto 段与手写段可区分。

## 改法
- **`DivisionBoard` 新增 `useEffect`**：监听已声明分工（`roleViews` → `declared`）与公告底稿合并后的 `nextCharterText`，去抖 800ms 后自动落盘。手动按钮与自动 effect 共用同一份合并结果，保证「手点」和「自动」写入文本一致。
- **幂等/断环**：靠既有 `mergeDivisionIntoCharter`（marker 区块整体替换）——写入后 `charterText` 与合并结果一致，effect 再跑即 no-op，不自我循环；另加 `lastAutoSyncedRef` 防服务端回存规范化导致的抖动环。
- **并发守卫**：写入在途（`syncingCharter`／上层 `charterSaving`）时不叠写，复用现有守卫。
- **不无中生有**：无分工且公告无既存分工区块时不自动写空区块（留给手动按钮）；区块写过、分工清零时仍自动刷新为空。新增导出 `charterHasDivisionSection` 做判定。

## 测试
`web/src/pages/DivisionBoard.test.tsx` 新增自动同步一组（4 例）：
- 分工变化去抖后**自动 merge** 进公告（无点击）
- **非 moderator 不写**（静默跳过）
- **幂等不重复**（已同步好的底稿重渲染不再写）
- 无分工且无既存区块**不无中生有**

`cd web && bun test --max-concurrency 1` 全量 **696 pass / 0 fail**；`bunx tsc --noEmit` 通过。

涉及 #150，待 host 验收。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 分工信息在满足条件时会自动同步到频道公告，无需手动点击。
  * 公告已有分工内容时，相关变更会自动更新；没有分工内容时不会产生空白区块。
  * 自动同步具备防重复机制，避免重复写入相同内容。

* **错误修复**
  * 优化分工与公告的同步逻辑，减少不必要的公告更新并提升同步稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->