### PR TITLE
feat(cli): serve runner 启动落可审计 status (#228)

### DIFF
--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -1494,6 +1494,13 @@ export async function runServe(o: ServeOptions): Promise<number> {
   // 因此也只有它们需要 runServe 在收尾时补一条「busy=false 空闲」把 busy 清干净。注入 runCommand
   // 的测试、以及 --cmd 裸执行器（自管 presence）不参与，避免覆盖它们自己的收尾状态。
   const reportsBusy = o.runCommand === undefined && (o.builtinRunner !== undefined || o.sdkRunner !== undefined);
+  // runner_started 审计标签（#228）：标明是哪种 runner 启动，写进落 history 的审计 status。
+  // sdk / builtin / custom(o.cmd 或注入的 runCommand) 三类统一在下方 wrap 点用它发一条启动证据。
+  const runnerKind = o.sdkRunner
+    ? "codex-sdk"
+    : o.builtinRunner
+      ? `builtin-${o.builtinRunner.harness}`
+      : "custom";
   // 已自报 busy、尚未补发空闲清除。一次 busy→idle 转场只补一条，不逐 tick 刷。
   let busyReported = false;
   let upgraded = false;
@@ -1772,6 +1779,24 @@ export async function runServe(o: ServeOptions): Promise<number> {
         };
         // t=0 立刻发一拍「started」：不必等第一个间隔，频道/本机马上就能看到「已开始处理 seq=X」。
         emitTaskBeat(true, taskStartedAt);
+        // runner_started 审计（#228）：上面那拍是 presence-only 的 heartbeat——**不落 history、任务结束即清**，
+        // 任务跑完后频道历史里没有任何「这个 runner 曾为 seq=X 启动过」的证据。这里在 run() 之前补发一条
+        // **落 history** 的 working status，作为可审计的启动记录。三种 runner（builtin / sdk / custom o.cmd）
+        // 统一在此 wrap 点覆盖——尤其 custom o.cmd 此前只有 presence 心跳、零 history 证据。
+        // 与「结束」（runner 自己的回帖 / 排空后的 idle waiting 帧）和「失败」（blocked 帧）区分：note 以
+        // 「runner started for seq X」起头，带 trigger_seq 与 runner 类型。不置 busy——busy 生命周期仍由
+        // builtin/sdk 的 wake-ack 帧与下方 idle 清除各管各的，这条纯审计不掺和（custom 不参与 busy）。
+        // best-effort：审计发不出去不阻塞唤醒（主职是把 @ 送进模型），留痕即可。
+        try {
+          await (o.post ?? postMessage)(o.server, o.token, o.channel, {
+            kind: "status",
+            state: "working",
+            note: `runner started for seq ${frame.seq}: ${self} runner=${runnerKind}`,
+            mentions: [],
+          });
+        } catch (e) {
+          out(`  runner_started 审计发送失败（不影响送达）: ${errText(e)}`);
+        }
         const taskBeat: ReturnType<typeof setInterval> = setInterval(() => emitTaskBeat(true, nowFn()), heartbeatIntervalMs);
         if (typeof taskBeat.unref === "function") taskBeat.unref();
         try {

--- a/cli/test/serve.test.ts
+++ b/cli/test/serve.test.ts
@@ -205,9 +205,11 @@ describe("runServe", () => {
 
     expect(await runServe(o)).toBe(EXIT_ARCHIVED);
 
-    // 处理这条 wake 时自报「忙」（无积压 → queue_depth 0）
-    const working = posts.find((p) => (p.body as { state?: string }).state === "working");
-    expect(working, "runner must post a working frame").toBeDefined();
+    // 处理这条 wake 时自报「忙」（无积压 → queue_depth 0）。
+    // 注意：#228 起 wrap 点会先落一条 busy 无关的 runner_started 审计 working 帧，故这里精确挑
+    // busy=true 的那条 wake-ack，而不是第一条 working。
+    const working = posts.find((p) => (p.body as { state?: string; busy?: boolean }).state === "working" && (p.body as { busy?: boolean }).busy === true);
+    expect(working, "runner must post a busy working frame").toBeDefined();
     expect(working!.body).toMatchObject({ kind: "status", state: "working", busy: true, queue_depth: 0 });
 
     // 收尾补一条「空闲」把 busy 清回 false——任务结束就不再假忙
@@ -258,6 +260,64 @@ describe("runServe", () => {
     const clears = beats.filter((b) => b.current_task === null);
     expect(clears.length, "must clear the running task once it finishes").toBeGreaterThanOrEqual(1);
     expect(beats.lastIndexOf(active[active.length - 1]!)).toBeLessThan(beats.indexOf(clears[0]!));
+  });
+
+  // runner_started 审计（#228）：presence 心跳不落 history、任务结束即清 —— custom runner 跑完后频道
+  // 历史里此前零证据它曾启动。现在 wrap 点补发一条落 history 的 working status「runner started for seq X」。
+  test("runner_started audit: custom runner posts an auditable working status to history on start", async () => {
+    const s = closeAfterOneMention();
+    const { posts, post } = postRecorder();
+    const o = opts({
+      server: s.url,
+      post,
+      // 注入的自定义 runner（runnerKind=custom）：成功返回，不自报 busy、不发结束/失败 status。
+      runCommand: async () => {},
+    });
+
+    expect(await runServe(o)).toBe(EXIT_ARCHIVED);
+
+    // 启动即落一条可审计的 working status —— 这正是此前 custom runner 缺失的那条历史证据。
+    const started = posts.find(
+      (p) =>
+        (p.body as { state?: string }).state === "working" &&
+        typeof (p.body as { note?: string }).note === "string" &&
+        (p.body as { note: string }).note.startsWith("runner started for seq 1"),
+    );
+    expect(started, "custom runner must post an auditable runner_started status").toBeDefined();
+    expect(started!.body).toMatchObject({ kind: "status", state: "working" });
+    // 带 trigger_seq 与 runner 信息，方便审计时定位是哪种 runner 为哪条 wake 启动。
+    expect((started!.body as { note: string }).note).toContain("runner=custom");
+    // 纯审计记录：不掺 busy（custom 不参与 busy 生命周期，置 busy 会让 presence 卡「假忙」）。
+    expect((started!.body as { busy?: boolean }).busy).toBeUndefined();
+    // 与「失败」区分：成功路径不产生 blocked 帧。
+    expect(posts.some((p) => (p.body as { state?: string }).state === "blocked")).toBe(false);
+  });
+
+  // 与结束/失败区分（#228）：失败时 runner_started 仍先落，随后才是 blocked —— 两条各司其职、可分辨。
+  test("runner_started audit: distinct from the failure status, and posted before it", async () => {
+    const s = closeAfterOneMention();
+    const { posts, post } = postRecorder();
+    const o = opts({
+      server: s.url,
+      post,
+      // 抛普通 Error（非 WakeBlockedError）→ 不可重试 → 走放弃路径发一条 blocked。
+      runCommand: async () => {
+        throw new Error("custom runner boom");
+      },
+    });
+
+    expect(await runServe(o)).toBe(EXIT_ARCHIVED);
+
+    const startedIdx = posts.findIndex(
+      (p) =>
+        (p.body as { state?: string }).state === "working" &&
+        (p.body as { note?: string }).note?.startsWith("runner started for seq 1"),
+    );
+    const blockedIdx = posts.findIndex((p) => (p.body as { state?: string }).state === "blocked");
+    expect(startedIdx, "runner_started must be posted even when the runner fails").toBeGreaterThanOrEqual(0);
+    expect(blockedIdx, "failure must post a blocked status").toBeGreaterThanOrEqual(0);
+    // 启动证据先落、失败通告后落 —— 顺序即「先启动，后失败」的可审计时间线。
+    expect(startedIdx).toBeLessThan(blockedIdx);
   });
 
   // 本机操作者可见性（#228）：health.json 盖上正在处理的 seq，任务结束清回 null。


### PR DESCRIPTION
## 缺口（#228）

serve 处理长 wake 时有每任务 presence 心跳（15c4da1，who/PresenceBar 可见），但它 **presence-only、不落 history、任务结束即清**——任务跑完后频道历史里**零证据**它曾为某条 wake 启动过。`git grep runner_started` 无命中，事后无从审计。尤其 custom `o.cmd` runner，此前**只有** presence 心跳、零 history 记录。

## host 口径

在 serve 的 custom runner **启动时**发一条**落 history**、可审计、与 completed/failed **区分**的 status，任务结束后频道历史里仍有它启动过的证据。保留现有心跳（presence）。范围：`runServe` 里 wrap `run()` 的启动点，builtin + sdk + custom `o.cmd` 三种 runner 统一覆盖。

## 改法

- 在 `runServe` 的 run() wrap 点（`emitTaskBeat` 启动拍之后、run 循环之前）补发一条 **落 history** 的 `kind:"status" state:"working"`，note 以 `runner started for seq X` 起头，带 `trigger_seq`（seq）与 `runner` 类型（`runnerKind`：`codex-sdk` / `builtin-<harness>` / `custom`）。
- 三种 runner 统一在此 wrap 点覆盖——`custom o.cmd` 从此也有 history 证据。
- 与「结束」（runner 回帖 / 排空后 idle `waiting`）和「失败」（`blocked`）区分。
- **不置 busy**：busy 生命周期仍由 builtin/sdk 的 wake-ack 帧与 idle 清除各管各的，这条纯审计不掺和（custom 不参与 busy，置 busy 会让 presence 卡「假忙」）。
- **best-effort**：审计发不出去只留痕、不阻塞唤醒（主职是把 @ 送进模型）。
- 现有 presence 心跳完全不动。

## 测试（`cli/test/serve.test.ts`）

- `runner_started audit: custom runner posts an auditable working status to history on start`——custom runner 启动即落一条 `working` 且 note 为 `runner started for seq 1`、含 `runner=custom`、无 `busy`；成功路径无 `blocked`。
- `runner_started audit: distinct from the failure status, and posted before it`——runner 抛错时 runner_started 仍先落、`blocked` 后落，两条可分辨。
- 既有 busy-lifecycle 测试改挑 `busy=true` 的 wake-ack 帧（wrap 点新增的审计 `working` 帧排在它前面）。
- `cd cli && bun test` 全量 **667 pass / 0 fail**，`tsc --noEmit` 通过。

涉及 #228，待 host 验收（不 Closes）。未接 party wake test（#191 边界）、queued 归 #103，均不在本轮范围。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增执行器启动审计状态，记录触发序列号及执行器类型。
  * 审计状态在任务开始前发布，即使执行器随后失败也会保留。

* **可靠性改进**
  * 审计消息发送失败不会阻断任务唤醒流程。
  * 优化工作中与空闲状态的识别，确保忙碌状态清除逻辑准确。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->