### PR TITLE
feat(worker,cli): 按身份数据硬擦除+导出(GDPR最小闭环) (#421)

### DIFF
--- a/cli/src/commands/gdpr.ts
+++ b/cli/src/commands/gdpr.ts
@@ -28,6 +28,10 @@ Options:
   --yes         confirm the (irreversible) erase without prompting
   --json        (export) print the raw JSON dump`;
 
+function terminalSafe(value: string): string {
+  return value.replace(/[\u0000-\u001f\u007f-\u009f]/g, "?");
+}
+
 export async function run(argv: string[]): Promise<number> {
   if (isHelpArg(argv, { allowHelpPositional: true })) {
     console.log(HELP);
@@ -70,25 +74,19 @@ export async function run(argv: string[]): Promise<number> {
   }
 
   try {
+    const shownName = terminalSafe(name);
     if (sub === "export") {
       const data = await exportIdentityData(cfg.server, cfg.token, channel, name);
       if (flags.json === true) {
         console.log(JSON.stringify(data, null, 2));
         return 0;
       }
-      const d = data as {
-        messages?: unknown[];
-        audit?: unknown[];
-        wake_deliveries?: unknown[];
-        read_cursor?: unknown;
-        presence?: unknown[];
-      };
-      console.log(`data for ${name} in ${channel}:`);
-      console.log(`  messages:        ${(d.messages ?? []).length}`);
-      console.log(`  audit rows:      ${(d.audit ?? []).length}`);
-      console.log(`  wake deliveries: ${(d.wake_deliveries ?? []).length}`);
-      console.log(`  read cursor:     ${d.read_cursor ? "yes" : "none"}`);
-      console.log(`  presence rows:   ${(d.presence ?? []).length}`);
+      console.log(`data for ${shownName} in ${channel}:`);
+      console.log(`  messages:        ${data.messages.length}`);
+      console.log(`  audit rows:      ${data.audit.length}`);
+      console.log(`  wake deliveries: ${data.wake_deliveries.length}`);
+      console.log(`  read cursor:     ${data.read_cursor ? "yes" : "none"}`);
+      console.log(`  presence rows:   ${data.presence.length}`);
       console.log("re-run with --json for the full dump");
       return 0;
     }
@@ -96,13 +94,13 @@ export async function run(argv: string[]): Promise<number> {
     if (flags.yes !== true) {
       console.error(
         `refusing to erase without confirmation.\n` +
-          `  this PHYSICALLY deletes ${name}'s identifiable data in ${channel} and scrubs its message bodies to [erased].\n` +
-          `  re-run with --yes to proceed: party gdpr erase ${name} ${channel} --yes`,
+          `  this PHYSICALLY deletes ${shownName}'s identifiable data in ${channel} and scrubs its message bodies to [erased].\n` +
+          `  re-run with --yes to proceed: party gdpr erase -- ${shownName} ${channel} --yes`,
       );
       return 1;
     }
     const summary = await eraseIdentityData(cfg.server, cfg.token, channel, name);
-    console.log(`erased ${name} from ${channel}:`);
+    console.log(`erased ${shownName} from ${channel}:`);
     console.log(`  messages scrubbed:    ${summary.messages_scrubbed}`);
     console.log(`  audit rows deleted:   ${summary.audit_deleted}`);
     console.log(`  wake ledger deleted:  ${summary.wake_ledger_deleted}`);

--- a/cli/src/commands/gdpr.ts
+++ b/cli/src/commands/gdpr.ts
@@ -1,0 +1,115 @@
+// party gdpr erase|export（issue #421）——按身份的数据保留/合规入口。
+// 跨公司频道里，A 公司的 agent 可能误贴密钥 / 客户 PII。撤回（#196）只清单条消息正文，清不掉审计/账本的
+// 身份维度，也没有「彻底抹除某身份可归因内容」的口子。这里补上：
+//   erase   物理删除该身份在频道 message_audit/wake 账本/读游标/presence 的可识别行 + 抹掉其消息正文/归属 PII。
+//   export  只读导出该身份在频道可归因的全部数据（数据可携 / 出境审查）。
+// 授权同 kick/pause：仅频道 moderator（房主 / ap_ token）。erase 不可逆，默认要 --yes 确认。
+import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
+import { resolveChannel } from "../config";
+import { resolveAuth } from "../oidc-cli";
+import { eraseIdentityData, exportIdentityData, handleRestError } from "../rest";
+import { isSlug } from "../validation";
+
+const GDPR_FLAGS = ["channel", "yes", "json"];
+const HELP = `usage: party gdpr erase <name> [channel|--channel C] [--yes]
+       party gdpr export <name> [channel|--channel C] [--json]
+
+Per-identity data retention / compliance entry point (moderator only, issue #421).
+
+  erase   Physically delete an identity's identifiable rows in this channel
+          (message_audit / wake ledger / read cursors / presence) AND scrub the
+          bodies + attribution PII of messages it authored to [erased].
+          Irreversible — requires --yes.
+  export  Read-only dump of everything attributable to the identity in this
+          channel (messages + audit + wake deliveries + read cursor + presence).
+
+Options:
+  --channel C   act on channel C instead of the bound channel
+  --yes         confirm the (irreversible) erase without prompting
+  --json        (export) print the raw JSON dump`;
+
+export async function run(argv: string[]): Promise<number> {
+  if (isHelpArg(argv, { allowHelpPositional: true })) {
+    console.log(HELP);
+    return 0;
+  }
+  const sub = argv[0];
+  if (sub !== "erase" && sub !== "export") {
+    console.error("usage: party gdpr erase|export <name> [channel] [--yes|--json]");
+    return 1;
+  }
+  const { positionals, flags } = parseArgs(argv.slice(1), { booleans: ["yes", "json"] });
+  const unknown = unknownFlagError(flags, GDPR_FLAGS);
+  if (unknown !== null) {
+    console.error(unknown);
+    return 1;
+  }
+  const flagError = valueFlagError(flags, ["channel"]);
+  if (flagError !== null) {
+    console.error(flagError);
+    return 1;
+  }
+  const name = positionals[0];
+  if (!name) {
+    console.error(`usage: party gdpr ${sub} <name> [channel]`);
+    return 1;
+  }
+  const channel = resolveChannel(str(flags.channel) ?? positionals[1]);
+  if (!channel) {
+    console.error("no channel, pass one or bind with: party init --channel C");
+    return 1;
+  }
+  if (!isSlug(channel)) {
+    console.error("channel must match [a-z0-9][a-z0-9-]{0,63}");
+    return 1;
+  }
+  const cfg = await resolveAuth();
+  if (!cfg) {
+    console.error("no config, run: party login or party init --server URL --token T");
+    return 1;
+  }
+
+  try {
+    if (sub === "export") {
+      const data = await exportIdentityData(cfg.server, cfg.token, channel, name);
+      if (flags.json === true) {
+        console.log(JSON.stringify(data, null, 2));
+        return 0;
+      }
+      const d = data as {
+        messages?: unknown[];
+        audit?: unknown[];
+        wake_deliveries?: unknown[];
+        read_cursor?: unknown;
+        presence?: unknown[];
+      };
+      console.log(`data for ${name} in ${channel}:`);
+      console.log(`  messages:        ${(d.messages ?? []).length}`);
+      console.log(`  audit rows:      ${(d.audit ?? []).length}`);
+      console.log(`  wake deliveries: ${(d.wake_deliveries ?? []).length}`);
+      console.log(`  read cursor:     ${d.read_cursor ? "yes" : "none"}`);
+      console.log(`  presence rows:   ${(d.presence ?? []).length}`);
+      console.log("re-run with --json for the full dump");
+      return 0;
+    }
+    // erase：不可逆，要 --yes
+    if (flags.yes !== true) {
+      console.error(
+        `refusing to erase without confirmation.\n` +
+          `  this PHYSICALLY deletes ${name}'s identifiable data in ${channel} and scrubs its message bodies to [erased].\n` +
+          `  re-run with --yes to proceed: party gdpr erase ${name} ${channel} --yes`,
+      );
+      return 1;
+    }
+    const summary = await eraseIdentityData(cfg.server, cfg.token, channel, name);
+    console.log(`erased ${name} from ${channel}:`);
+    console.log(`  messages scrubbed:    ${summary.messages_scrubbed}`);
+    console.log(`  audit rows deleted:   ${summary.audit_deleted}`);
+    console.log(`  wake ledger deleted:  ${summary.wake_ledger_deleted}`);
+    console.log(`  read cursors deleted: ${summary.read_cursors_deleted}`);
+    console.log(`  presence deleted:     ${summary.presence_deleted}`);
+    return 0;
+  } catch (e) {
+    return handleRestError(e);
+  }
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -52,6 +52,7 @@ commands:
   webhook   add <channel> --name n --url URL --secret S [--filter mentions|status|needs-human|all] | remove <channel> --name n | list <channel>
   token     create --name n --role agent|human|readonly --owner label [--channel-scope slug] | revoke <name>   (ADMIN_SECRET env)
   membership activate --account a | deactivate --account a   owner-only: mark an account member/free (#277)   (ADMIN_SECRET env)
+  gdpr      erase <name> [channel] --yes | export <name> [channel] [--json]   per-identity hard-erase / export (moderator, #421)
 
 watch defaults to a 240s timeout. With --follow, it stays attached unless --timeout N is explicit.
 
@@ -145,6 +146,8 @@ export async function main(argv: string[]): Promise<number> {
       return (await import("./commands/token")).run(rest);
     case "membership":
       return (await import("./commands/membership")).run(rest);
+    case "gdpr":
+      return (await import("./commands/gdpr")).run(rest);
     case "doctor":
       return (await import("./commands/doctor")).run(rest);
     case "health":

--- a/cli/src/rest.ts
+++ b/cli/src/rest.ts
@@ -13,6 +13,8 @@ import {
   type CompletionReview,
   type CompletionReviewPolicy,
   type DecisionMode,
+  type IdentityEraseSummary,
+  type IdentityExportData,
   EXIT_ARCHIVED,
   EXIT_AUTH,
   EXIT_LOOP_GUARD,
@@ -1308,16 +1310,6 @@ export async function resumeAgent(server: string, token: string, slug: string, n
 
 // GDPR 按身份数据擦除（#421）。物理删除该身份在频道 message_audit/wake 账本/读游标/presence 的可识别行，
 // 并把其消息正文 + 归属 PII 抹成 [erased]。返回各表命中数。仅频道 moderator（房主 / ap_ token）可调。
-export interface IdentityEraseSummary {
-  name: string;
-  erased_at: number;
-  messages_scrubbed: number;
-  audit_deleted: number;
-  wake_ledger_deleted: number;
-  read_cursors_deleted: number;
-  presence_deleted: number;
-}
-
 export async function eraseIdentityData(
   server: string,
   token: string,
@@ -1336,10 +1328,29 @@ export async function exportIdentityData(
   token: string,
   slug: string,
   name: string,
-): Promise<unknown> {
-  return await req(server, `/api/channels/${encodeURIComponent(slug)}/identity/${encodeURIComponent(name)}/data`, {
-    headers: bearerJson(token),
-  });
+): Promise<IdentityExportData> {
+  const merged: IdentityExportData = {
+    name, exported_at: Date.now(), messages: [], audit: [], wake_deliveries: [],
+    read_cursor: null, presence: [], next: { messages: 0, audit: 0, wake_deliveries: 0 },
+  };
+  while (merged.next.messages !== null || merged.next.audit !== null || merged.next.wake_deliveries !== null) {
+    const query = new URLSearchParams({
+      message_after: String(merged.next.messages ?? -1),
+      audit_after: String(merged.next.audit ?? -1),
+      wake_after: String(merged.next.wake_deliveries ?? -1),
+    });
+    const page = (await req(server,
+      `/api/channels/${encodeURIComponent(slug)}/identity/${encodeURIComponent(name)}/data?${query}`,
+      { headers: bearerJson(token) })) as IdentityExportData;
+    merged.exported_at = page.exported_at;
+    merged.messages.push(...page.messages);
+    merged.audit.push(...page.audit);
+    merged.wake_deliveries.push(...page.wake_deliveries);
+    merged.read_cursor ??= page.read_cursor;
+    if (merged.presence.length === 0) merged.presence = page.presence;
+    merged.next = page.next;
+  }
+  return merged;
 }
 
 // rest 错误 → 契约退出码

--- a/cli/src/rest.ts
+++ b/cli/src/rest.ts
@@ -1306,6 +1306,42 @@ export async function resumeAgent(server: string, token: string, slug: string, n
   });
 }
 
+// GDPR 按身份数据擦除（#421）。物理删除该身份在频道 message_audit/wake 账本/读游标/presence 的可识别行，
+// 并把其消息正文 + 归属 PII 抹成 [erased]。返回各表命中数。仅频道 moderator（房主 / ap_ token）可调。
+export interface IdentityEraseSummary {
+  name: string;
+  erased_at: number;
+  messages_scrubbed: number;
+  audit_deleted: number;
+  wake_ledger_deleted: number;
+  read_cursors_deleted: number;
+  presence_deleted: number;
+}
+
+export async function eraseIdentityData(
+  server: string,
+  token: string,
+  slug: string,
+  name: string,
+): Promise<IdentityEraseSummary> {
+  return (await req(server, `/api/channels/${encodeURIComponent(slug)}/identity/${encodeURIComponent(name)}/data`, {
+    method: "DELETE",
+    headers: bearerJson(token),
+  })) as IdentityEraseSummary;
+}
+
+// GDPR 按身份数据导出（#421，只读）。返回该身份在频道可归因的全部数据，供数据可携 / 出境审查。
+export async function exportIdentityData(
+  server: string,
+  token: string,
+  slug: string,
+  name: string,
+): Promise<unknown> {
+  return await req(server, `/api/channels/${encodeURIComponent(slug)}/identity/${encodeURIComponent(name)}/data`, {
+    headers: bearerJson(token),
+  });
+}
+
 // rest 错误 → 契约退出码
 export function handleRestError(e: unknown): number {
   if (e instanceof RestError) {

--- a/cli/test/gdpr.test.ts
+++ b/cli/test/gdpr.test.ts
@@ -14,7 +14,7 @@ let errs: string[];
 const origLog = console.log;
 const origErr = console.error;
 
-const IDENTITY_RE = /^\/api\/channels\/([^/]+)\/identity\/([^/]+)\/data$/;
+const IDENTITY_RE = /^\/api\/channels\/([^/]+)\/identity\/([^/?]+)\/data(?:\?.*)?$/;
 
 beforeEach(() => {
   home = mkdtempSync(join(tmpdir(), "ap-gdpr-"));
@@ -45,6 +45,7 @@ beforeEach(() => {
       wake_deliveries: [{ target_name: "bot" }],
       read_cursor: { name: "bot" },
       presence: [{ name: "bot" }],
+      next: { messages: null, audit: null, wake_deliveries: null },
     });
   });
   writeConfig({ server: restMock.url, token: "ap_mod" });
@@ -95,6 +96,18 @@ describe("party gdpr", () => {
     const parsed = JSON.parse(logs.join("\n")) as { name: string; messages: unknown[] };
     expect(parsed.name).toBe("bot");
     expect(parsed.messages.length).toBe(2);
+  });
+
+  test("sanitizes control characters in terminal output", async () => {
+    const code = await gdprRun(["erase", "bot\u001b[31m", "--yes"]);
+    expect(code).toBe(0);
+    expect(logs.join("\n")).not.toContain("\u001b");
+  });
+
+  test("accepts a dash-prefixed identity after the option terminator", async () => {
+    const code = await gdprRun(["erase", "--yes", "--", "-bot"]);
+    expect(code).toBe(0);
+    expect(restMock!.requests.some((r) => r.path.includes("identity/-bot/data"))).toBe(true);
   });
 
   test("rejects an unknown subcommand", async () => {

--- a/cli/test/gdpr.test.ts
+++ b/cli/test/gdpr.test.ts
@@ -1,0 +1,106 @@
+// party gdpr erase|export（#421）：确认闸（erase 需 --yes）、命令层路由 + 回显。
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { writeConfig, writeState } from "../src/config";
+import { run as gdprRun } from "../src/commands/gdpr";
+import { startRestMock, type RestMock } from "./rest-mock";
+
+let home: string;
+let restMock: RestMock | null = null;
+let logs: string[];
+let errs: string[];
+const origLog = console.log;
+const origErr = console.error;
+
+const IDENTITY_RE = /^\/api\/channels\/([^/]+)\/identity\/([^/]+)\/data$/;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "ap-gdpr-"));
+  process.env.AGENTPARTY_HOME = home;
+  logs = [];
+  errs = [];
+  console.log = (...a: unknown[]) => logs.push(a.map(String).join(" "));
+  console.error = (...a: unknown[]) => errs.push(a.map(String).join(" "));
+  restMock = startRestMock((r) => {
+    const m = r.path.match(IDENTITY_RE);
+    if (!m) return undefined;
+    if (r.method === "DELETE") {
+      return Response.json({
+        name: decodeURIComponent(m[2]!),
+        erased_at: 1,
+        messages_scrubbed: 3,
+        audit_deleted: 2,
+        wake_ledger_deleted: 1,
+        read_cursors_deleted: 1,
+        presence_deleted: 1,
+      });
+    }
+    return Response.json({
+      name: decodeURIComponent(m[2]!),
+      exported_at: 1,
+      messages: [{ seq: 1, body: "a" }, { seq: 2, body: "b" }],
+      audit: [{ target_seq: 1, action: "edit", actor: { name: "bot", kind: "agent" } }],
+      wake_deliveries: [{ target_name: "bot" }],
+      read_cursor: { name: "bot" },
+      presence: [{ name: "bot" }],
+    });
+  });
+  writeConfig({ server: restMock.url, token: "ap_mod" });
+  writeState({ channel: "ops", cursor: 0 });
+});
+
+afterEach(() => {
+  console.log = origLog;
+  console.error = origErr;
+  delete process.env.AGENTPARTY_HOME;
+  rmSync(home, { recursive: true, force: true });
+  restMock?.stop();
+  restMock = null;
+});
+
+describe("party gdpr", () => {
+  test("erase without --yes refuses before any request", async () => {
+    const code = await gdprRun(["erase", "bot"]);
+    expect(code).toBe(1);
+    expect(errs.join("\n")).toContain("refusing to erase without confirmation");
+    expect(restMock!.requests.some((r) => IDENTITY_RE.test(r.path))).toBe(false);
+  });
+
+  test("erase --yes hits DELETE and prints the counts", async () => {
+    const code = await gdprRun(["erase", "bot", "--yes"]);
+    expect(code).toBe(0);
+    const req = restMock!.requests.find((r) => IDENTITY_RE.test(r.path));
+    expect(req?.method).toBe("DELETE");
+    expect(req?.path).toBe("/api/channels/ops/identity/bot/data");
+    expect(req?.headers.authorization).toBe("Bearer ap_mod");
+    const out = logs.join("\n");
+    expect(out).toContain("messages scrubbed:    3");
+    expect(out).toContain("audit rows deleted:   2");
+  });
+
+  test("export hits GET and prints a summary", async () => {
+    const code = await gdprRun(["export", "bot"]);
+    expect(code).toBe(0);
+    const req = restMock!.requests.find((r) => IDENTITY_RE.test(r.path));
+    expect(req?.method).toBe("GET");
+    expect(logs.join("\n")).toContain("messages:        2");
+    expect(logs.join("\n")).toContain("audit rows:      1");
+  });
+
+  test("export --json prints the raw dump", async () => {
+    const code = await gdprRun(["export", "bot", "--json"]);
+    expect(code).toBe(0);
+    const parsed = JSON.parse(logs.join("\n")) as { name: string; messages: unknown[] };
+    expect(parsed.name).toBe("bot");
+    expect(parsed.messages.length).toBe(2);
+  });
+
+  test("rejects an unknown subcommand", async () => {
+    const code = await gdprRun(["nuke", "bot"]);
+    expect(code).toBe(1);
+    expect(errs.join("\n")).toContain("usage: party gdpr");
+    expect(restMock!.requests.some((r) => IDENTITY_RE.test(r.path))).toBe(false);
+  });
+});

--- a/docs/data-retention.md
+++ b/docs/data-retention.md
@@ -1,0 +1,73 @@
+# Data retention, deletion & GDPR (issue #421)
+
+AgentParty is a **cross-company** channel system: an agent from company A may paste a
+secret, customer PII, or otherwise sensitive content into a channel shared with company B.
+This doc states what data is kept, for how long, and how to erase or export it — the
+compliance answer for external tenants.
+
+## What is stored, and where
+
+Each channel is a Durable Object with its own SQLite (`worker/src/do.ts`); global data
+(tokens, channel membership, management audit) lives in D1 (`worker/src/index.ts`).
+
+| Table (per-channel DO) | Holds | Identifiable data |
+|---|---|---|
+| `messages` | every message, incl. edit/retract markers | `sender_name`, `sender_owner`, handle/avatar, body |
+| `message_audit` | edit/retract history per message | `actor_name`, old/new body (edits) |
+| `wake_delivery_ledger` | wake/webhook delivery attempts | `target_name` |
+| `read_cursor` | per-identity read position | `name` |
+| `presence` | who is/was connected | `name`, handle/avatar |
+
+## Retention windows (bounded pruning, #128)
+
+`onAlarm` prunes the DO tables on the ~60s presence cycle
+(`ChannelDO.pruneStorage`); constants in `shared/src/protocol.ts`:
+
+| Table | Policy | Constant |
+|---|---|---|
+| `wake_delivery_ledger` | time window | `WAKE_LEDGER_RETENTION_MS` (35 days) |
+| `message_audit` | newest N rows | `MAX_MESSAGE_AUDIT_ROWS` (20 000) |
+| `read_cursor` | aged + disconnected | `READ_CURSOR_RETENTION_MS` (30 days) |
+| `messages` | newest N kept for replay | `RETAIN_N` (10 000) |
+
+Retract (#196) scrubs a **retracted** message's body to `[retracted]` and nulls its
+audit bodies. There is **no per-identity** retention window — retention is table-wide, so
+an identity's data persists until pruned by the windows above or explicitly erased.
+
+## Per-identity hard erase (#421)
+
+`DELETE /api/channels/:slug/identity/:name/data` — **moderator only** (channel owner or
+`ap_` token). CLI: `party gdpr erase <name> [channel] --yes` (irreversible; `--yes` required).
+
+In one atomic transaction it, for `<name>` in that channel:
+
+- **`messages`**: scrubs the body to `[erased]`, nulls attribution PII
+  (`sender_owner`, handle, display name, avatar, lineage) and every JSON payload column;
+  keeps `sender_name` + `seq` as a tombstone so reply chains don't dangle.
+- **`message_audit`**: deletes rows where the identity is the actor or the target message
+  was authored by it.
+- **`wake_delivery_ledger` / `read_cursor` / `presence`**: deletes all rows for the identity.
+
+Returns per-table hit counts, and records a `channel.identity.erase` entry in the D1
+management audit (counts only, no content).
+
+## Per-identity export (#421)
+
+`GET /api/channels/:slug/identity/:name/data` — **moderator only**, read-only. CLI:
+`party gdpr export <name> [channel] [--json]`. Returns the identity's messages, audit rows,
+wake deliveries, read cursor and presence in that channel (data portability / egress review).
+
+## Known gaps / follow-up
+
+This is a **minimal viable compliance closure** (hard erase + export), scoped to one
+channel's DO. Not yet covered:
+
+- **Cross-channel / system-wide erase** — erase is per-channel; a system-wide "forget this
+  identity everywhere" pass (fan-out over every channel) is follow-up.
+- **D1-side identity data** — revoking the identity's `tokens` row and removing
+  `channel_members` is still done via `party channel kick <name> --remove`, not by erase.
+- **`sender_name` anonymization** — kept as a tombstone; it is a channel-scoped nickname,
+  not raw PII (account-level `owner`/email is already scrubbed), but full name rewriting is
+  follow-up.
+- **Configurable per-channel/global retention windows with scheduled physical delete** and
+  **temp-channel archive → timed hard delete** remain follow-up (see issue #421 items 2).

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -837,6 +837,50 @@ export interface MsgFrame {
   };
 }
 
+/** One bounded page of data attributable to an identity in a channel. */
+export interface IdentityExportData {
+  name: string;
+  exported_at: number;
+  messages: MsgFrame[];
+  audit: {
+    target_seq: number;
+    action: string;
+    actor: { name: string; kind: string };
+    old_body: string | null;
+    new_body: string | null;
+    original_byte_length: number | null;
+    created_at: number;
+  }[];
+  wake_deliveries: {
+    mention_seq: number;
+    target_name: string;
+    webhook_name: string;
+    adapter_kind: string;
+    attempt: number;
+    result: string;
+    http_status: number | null;
+    error: string | null;
+    attempted_at: number;
+    ack_seq: number | null;
+    resume_seq: number | null;
+  }[];
+  read_cursor: ReadCursor | null;
+  presence: PresenceEntry[];
+  next: { messages: number | null; audit: number | null; wake_deliveries: number | null };
+}
+
+export interface IdentityEraseSummary {
+  name: string;
+  erased_at: number;
+  messages_scrubbed: number;
+  audit_deleted: number;
+  wake_ledger_deleted: number;
+  webhook_payloads_deleted: number;
+  read_cursors_deleted: number;
+  presence_deleted: number;
+  attachment_keys: string[];
+}
+
 export interface HostSummary {
   name: string;
   lease: HostLeaseState;

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -50,6 +50,8 @@ import {
   type DecisionState,
   type HostDecision,
   type HostDecisionKind,
+  type IdentityEraseSummary,
+  type IdentityExportData,
   type MsgFrame,
   type MessageUpdateFrame,
   type PresenceEntry,
@@ -3334,12 +3336,24 @@ export class ChannelDO extends Server<Env> {
     if (identityDataMatch && request.method === "GET") {
       // 只读导出：该身份在本频道可归因的全部数据（消息 + 审计 + wake 账本 + 读游标 + presence）。
       const name = decodeURIComponent(identityDataMatch[1]!);
-      return Response.json(this.exportIdentityData(name));
+      const cursor = (key: string): number => {
+        const value = Number(url.searchParams.get(key) ?? "0");
+        return Number.isSafeInteger(value) && value >= 0 ? value : 0;
+      };
+      return Response.json(this.exportIdentityData(name, {
+        messages: cursor("message_after"), audit: cursor("audit_after"), wake_deliveries: cursor("wake_after"),
+      }));
     }
     if (identityDataMatch && request.method === "DELETE") {
       // 硬擦除：物理删除该身份在本频道的可识别数据，并把其发过的消息正文/归属 PII 抹成 [erased]。
       const name = decodeURIComponent(identityDataMatch[1]!);
-      return Response.json(this.eraseIdentityData(name));
+      const actor: Identity = {
+        name: request.headers.get("x-ap-name") ?? "system",
+        kind: request.headers.get("x-ap-kind") === "agent" ? "agent" : "human",
+        role: (request.headers.get("x-ap-role") ?? "host") as TokenRole,
+        tokenHash: request.headers.get("x-ap-token-hash") ?? "",
+      };
+      return Response.json(this.eraseIdentityData(name, actor));
     }
     if (url.pathname === "/internal/messages" && request.method === "POST") {
       this.cacheChannelMeta(request.headers, request.headers.get("x-ap-host"));
@@ -4490,51 +4504,31 @@ export class ChannelDO extends Server<Env> {
 
   // GDPR 只读导出（#421）：该身份在本频道可归因的全部数据，供数据可携 / 出境审查。不改任何状态。
   // 复用 rowToFrame / presenceFor / readCursors，与现有观测端点同口径，不另造字段。
-  private exportIdentityData(name: string): {
-    name: string;
-    exported_at: number;
-    messages: MsgFrame[];
-    audit: {
-      target_seq: number;
-      action: string;
-      actor: { name: string; kind: string };
-      old_body: string | null;
-      new_body: string | null;
-      original_byte_length: number | null;
-      created_at: number;
-    }[];
-    wake_deliveries: {
-      mention_seq: number;
-      target_name: string;
-      webhook_name: string;
-      adapter_kind: string;
-      attempt: number;
-      result: string;
-      http_status: number | null;
-      error: string | null;
-      attempted_at: number;
-      ack_seq: number | null;
-      resume_seq: number | null;
-    }[];
-    read_cursor: ReadCursor | null;
-    presence: PresenceEntry[];
-  } {
+  private exportIdentityData(
+    name: string,
+    after: { messages: number; audit: number; wake_deliveries: number },
+  ): IdentityExportData {
     const sql = this.ctx.storage.sql;
-    const messages = sql
-      .exec("SELECT * FROM messages WHERE sender_name = ? ORDER BY seq", name)
-      .toArray()
+    const pageSize = 200;
+    const messageRows = sql
+      .exec("SELECT * FROM messages WHERE sender_name = ? AND seq > ? ORDER BY seq LIMIT ?", name, after.messages, pageSize + 1)
+      .toArray();
+    const messages = messageRows.slice(0, pageSize)
       .map((r) => this.rowToFrame(r));
     // 审计：该身份作为 actor 的行 + 其发的消息被审计过的行（target_seq 命中）。撤回后正文已 NULL。
-    const audit = sql
+    const auditRows = sql
       .exec(
-        `SELECT target_seq, action, actor_name, actor_kind, old_body, new_body, original_byte_length, created_at
+        `SELECT id, target_seq, action, actor_name, actor_kind, old_body, new_body, original_byte_length, created_at
            FROM message_audit
-          WHERE actor_name = ? OR target_seq IN (SELECT seq FROM messages WHERE sender_name = ?)
-          ORDER BY id`,
+          WHERE id > ? AND (actor_name = ? OR target_seq IN (SELECT seq FROM messages WHERE sender_name = ?))
+          ORDER BY id LIMIT ?`,
+        after.audit,
         name,
         name,
+        pageSize + 1,
       )
-      .toArray()
+      .toArray();
+    const audit = auditRows.slice(0, pageSize)
       .map((r) => ({
         target_seq: Number(r.target_seq),
         action: String(r.action),
@@ -4545,14 +4539,17 @@ export class ChannelDO extends Server<Env> {
           r.original_byte_length === null || r.original_byte_length === undefined ? null : Number(r.original_byte_length),
         created_at: Number(r.created_at),
       }));
-    const wake_deliveries = sql
+    const wakeRows = sql
       .exec(
-        `SELECT mention_seq, target_name, webhook_name, adapter_kind, attempt,
+        `SELECT id, mention_seq, target_name, webhook_name, adapter_kind, attempt,
                 result, http_status, error, attempted_at, ack_seq, resume_seq
-           FROM wake_delivery_ledger WHERE target_name = ? ORDER BY id`,
+           FROM wake_delivery_ledger WHERE target_name = ? AND id > ? ORDER BY id LIMIT ?`,
         name,
+        after.wake_deliveries,
+        pageSize + 1,
       )
-      .toArray()
+      .toArray();
+    const wake_deliveries = wakeRows.slice(0, pageSize)
       .map((r) => ({
         mention_seq: Number(r.mention_seq),
         target_name: String(r.target_name),
@@ -4576,6 +4573,11 @@ export class ChannelDO extends Server<Env> {
       wake_deliveries,
       read_cursor: cursor,
       presence: presenceEntry === null ? [] : [presenceEntry],
+      next: {
+        messages: messageRows.length > pageSize ? Number(messageRows[pageSize - 1]!.seq) : null,
+        audit: auditRows.length > pageSize ? Number(auditRows[pageSize - 1]!.id) : null,
+        wake_deliveries: wakeRows.length > pageSize ? Number(wakeRows[pageSize - 1]!.id) : null,
+      },
     };
   }
 
@@ -4584,30 +4586,35 @@ export class ChannelDO extends Server<Env> {
   // JSON payload）抹成 [erased]——#196 撤回清洗只覆盖已撤回的消息，这里补齐「按身份彻底擦除」的口子。
   // 单事务原子提交；返回各表命中数供 worker 落审计 + CLI 回显。sender_name 作为墓碑保留（频道内昵称，
   // 非原始 PII；账号级 owner 已抹），线程/回复链不悬空；跨频道 / D1 token 维度擦除留 follow-up。
-  private eraseIdentityData(name: string): {
-    name: string;
-    erased_at: number;
-    messages_scrubbed: number;
-    audit_deleted: number;
-    wake_ledger_deleted: number;
-    read_cursors_deleted: number;
-    presence_deleted: number;
-  } {
+  private eraseIdentityData(name: string, actor: Identity): IdentityEraseSummary {
     const sql = this.ctx.storage.sql;
     const countOne = (query: string, ...args: (string | number)[]): number =>
       Number(sql.exec(query, ...args).one().n ?? 0);
     let messages_scrubbed = 0;
     let audit_deleted = 0;
     let wake_ledger_deleted = 0;
+    let webhook_payloads_deleted = 0;
     let read_cursors_deleted = 0;
     let presence_deleted = 0;
+    const attachmentKeys: string[] = [];
+    const updatedSeqs: number[] = [];
     this.ctx.storage.transactionSync(() => {
+      const affected = sql.exec(
+        "SELECT seq, attachments_json FROM messages WHERE sender_name = ? AND body != '[erased]' ORDER BY seq",
+        name,
+      ).toArray();
+      for (const row of affected) {
+        updatedSeqs.push(Number(row.seq));
+        for (const attachment of parseStoredAttachments(row.attachments_json) ?? []) attachmentKeys.push(attachment.key);
+      }
       messages_scrubbed = countOne(
         "SELECT COUNT(*) AS n FROM messages WHERE sender_name = ? AND body != '[erased]'",
         name,
       );
       // 正文 + 归属 PII 一并抹除。列集对齐 #196 撤回清洗，另加 sender_owner/handle/头像/血缘/decision。
-      sql.exec(
+      for (const seq of updatedSeqs) {
+        const revSeq = this.nextRevSeq();
+        sql.exec(
         `UPDATE messages
             SET body = '[erased]', mentions_json = '[]', original_body = NULL,
                 state = NULL, note = NULL,
@@ -4619,10 +4626,13 @@ export class ChannelDO extends Server<Env> {
                 decision_request_json = NULL, decision_resolution_json = NULL, decision_response_json = NULL,
                 sender_owner = NULL, sender_lineage_json = NULL, sender_role = NULL, sender_role_source = NULL,
                 sender_handle = NULL, sender_display_name = NULL, sender_avatar_url = NULL, sender_avatar_thumb = NULL,
-                attachments_json = NULL, edited_by = NULL, retracted_by = NULL, idempotency_key = NULL
-          WHERE sender_name = ? AND body != '[erased]'`,
-        name,
+                attachments_json = NULL, edited_by = NULL, retracted_by = NULL, idempotency_key = NULL,
+                rev_seq = ?
+          WHERE seq = ?`,
+        revSeq,
+        seq,
       );
+      }
       audit_deleted = countOne(
         `SELECT COUNT(*) AS n FROM message_audit
           WHERE actor_name = ? OR target_seq IN (SELECT seq FROM messages WHERE sender_name = ?)`,
@@ -4637,12 +4647,29 @@ export class ChannelDO extends Server<Env> {
       );
       wake_ledger_deleted = countOne("SELECT COUNT(*) AS n FROM wake_delivery_ledger WHERE target_name = ?", name);
       sql.exec("DELETE FROM wake_delivery_ledger WHERE target_name = ?", name);
+      webhook_payloads_deleted = countOne(
+        `SELECT (SELECT COUNT(*) FROM webhook_queue WHERE json_extract(payload, '$.sender.name') = ?) +
+                (SELECT COUNT(*) FROM webhook_dead_letters WHERE json_extract(payload, '$.sender.name') = ?) AS n`,
+        name,
+        name,
+      );
+      sql.exec("DELETE FROM webhook_queue WHERE json_extract(payload, '$.sender.name') = ?", name);
+      sql.exec("DELETE FROM webhook_dead_letters WHERE json_extract(payload, '$.sender.name') = ?", name);
       read_cursors_deleted = countOne("SELECT COUNT(*) AS n FROM read_cursor WHERE name = ?", name);
       sql.exec("DELETE FROM read_cursor WHERE name = ?", name);
       presence_deleted = countOne("SELECT COUNT(*) AS n FROM presence WHERE name = ?", name);
       sql.exec("DELETE FROM presence WHERE name = ?", name);
     });
-    return { name, erased_at: Date.now(), messages_scrubbed, audit_deleted, wake_ledger_deleted, read_cursors_deleted, presence_deleted };
+    const erasedAt = Date.now();
+    for (const seq of updatedSeqs) {
+      const row = sql.exec("SELECT * FROM messages WHERE seq = ?", seq).toArray()[0];
+      if (row) this.broadcastFrame(this.messageUpdate("edit", actor, this.rowToFrame(row), erasedAt));
+    }
+    return {
+      name, erased_at: erasedAt, messages_scrubbed, audit_deleted, wake_ledger_deleted,
+      webhook_payloads_deleted, read_cursors_deleted, presence_deleted,
+      attachment_keys: [...new Set(attachmentKeys)],
+    };
   }
 
   // seen 帧：把某身份的已读游标前移到 seq（只前移；旧 seq 幂等忽略）。前移了返回新游标（供广播），

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -3329,6 +3329,18 @@ export class ChannelDO extends Server<Env> {
       // 已读游标快照 + 频道最新 seq，供 `party who` 标注每个身份读到第几条 / 落后多少（Phase 2 · CLI）。
       return Response.json({ cursors: this.readCursors(), last_seq: this.lastSeq() });
     }
+    // GDPR 按身份数据出口/擦除（#421）。授权在 worker 层做（moderator 门），DO 只按 name 读/删本频道数据。
+    const identityDataMatch = url.pathname.match(/^\/internal\/identity\/([^/]+)\/data$/);
+    if (identityDataMatch && request.method === "GET") {
+      // 只读导出：该身份在本频道可归因的全部数据（消息 + 审计 + wake 账本 + 读游标 + presence）。
+      const name = decodeURIComponent(identityDataMatch[1]!);
+      return Response.json(this.exportIdentityData(name));
+    }
+    if (identityDataMatch && request.method === "DELETE") {
+      // 硬擦除：物理删除该身份在本频道的可识别数据，并把其发过的消息正文/归属 PII 抹成 [erased]。
+      const name = decodeURIComponent(identityDataMatch[1]!);
+      return Response.json(this.eraseIdentityData(name));
+    }
     if (url.pathname === "/internal/messages" && request.method === "POST") {
       this.cacheChannelMeta(request.headers, request.headers.get("x-ap-host"));
       const identity: Identity = {
@@ -4474,6 +4486,163 @@ export class ChannelDO extends Server<Env> {
         last_seen_seq: Number(r.last_seen_seq),
         updated_at: Number(r.updated_at),
       }));
+  }
+
+  // GDPR 只读导出（#421）：该身份在本频道可归因的全部数据，供数据可携 / 出境审查。不改任何状态。
+  // 复用 rowToFrame / presenceFor / readCursors，与现有观测端点同口径，不另造字段。
+  private exportIdentityData(name: string): {
+    name: string;
+    exported_at: number;
+    messages: MsgFrame[];
+    audit: {
+      target_seq: number;
+      action: string;
+      actor: { name: string; kind: string };
+      old_body: string | null;
+      new_body: string | null;
+      original_byte_length: number | null;
+      created_at: number;
+    }[];
+    wake_deliveries: {
+      mention_seq: number;
+      target_name: string;
+      webhook_name: string;
+      adapter_kind: string;
+      attempt: number;
+      result: string;
+      http_status: number | null;
+      error: string | null;
+      attempted_at: number;
+      ack_seq: number | null;
+      resume_seq: number | null;
+    }[];
+    read_cursor: ReadCursor | null;
+    presence: PresenceEntry[];
+  } {
+    const sql = this.ctx.storage.sql;
+    const messages = sql
+      .exec("SELECT * FROM messages WHERE sender_name = ? ORDER BY seq", name)
+      .toArray()
+      .map((r) => this.rowToFrame(r));
+    // 审计：该身份作为 actor 的行 + 其发的消息被审计过的行（target_seq 命中）。撤回后正文已 NULL。
+    const audit = sql
+      .exec(
+        `SELECT target_seq, action, actor_name, actor_kind, old_body, new_body, original_byte_length, created_at
+           FROM message_audit
+          WHERE actor_name = ? OR target_seq IN (SELECT seq FROM messages WHERE sender_name = ?)
+          ORDER BY id`,
+        name,
+        name,
+      )
+      .toArray()
+      .map((r) => ({
+        target_seq: Number(r.target_seq),
+        action: String(r.action),
+        actor: { name: String(r.actor_name), kind: String(r.actor_kind) },
+        old_body: r.old_body === null || r.old_body === undefined ? null : String(r.old_body),
+        new_body: r.new_body === null || r.new_body === undefined ? null : String(r.new_body),
+        original_byte_length:
+          r.original_byte_length === null || r.original_byte_length === undefined ? null : Number(r.original_byte_length),
+        created_at: Number(r.created_at),
+      }));
+    const wake_deliveries = sql
+      .exec(
+        `SELECT mention_seq, target_name, webhook_name, adapter_kind, attempt,
+                result, http_status, error, attempted_at, ack_seq, resume_seq
+           FROM wake_delivery_ledger WHERE target_name = ? ORDER BY id`,
+        name,
+      )
+      .toArray()
+      .map((r) => ({
+        mention_seq: Number(r.mention_seq),
+        target_name: String(r.target_name),
+        webhook_name: String(r.webhook_name),
+        adapter_kind: String(r.adapter_kind),
+        attempt: Number(r.attempt),
+        result: String(r.result),
+        http_status: r.http_status === null || r.http_status === undefined ? null : Number(r.http_status),
+        error: r.error === null || r.error === undefined ? null : String(r.error),
+        attempted_at: Number(r.attempted_at),
+        ack_seq: r.ack_seq === null || r.ack_seq === undefined ? null : Number(r.ack_seq),
+        resume_seq: r.resume_seq === null || r.resume_seq === undefined ? null : Number(r.resume_seq),
+      }));
+    const cursor = this.readCursors().find((c) => c.name === name) ?? null;
+    const presenceEntry = this.presenceFor(name);
+    return {
+      name,
+      exported_at: Date.now(),
+      messages,
+      audit,
+      wake_deliveries,
+      read_cursor: cursor,
+      presence: presenceEntry === null ? [] : [presenceEntry],
+    };
+  }
+
+  // GDPR 按身份硬擦除（#421）：物理删除该身份在本频道 message_audit / wake_delivery_ledger /
+  // read_cursor / presence 的可识别行，并把其发过的消息正文 + 归属 PII（owner/handle/头像/血缘/各类
+  // JSON payload）抹成 [erased]——#196 撤回清洗只覆盖已撤回的消息，这里补齐「按身份彻底擦除」的口子。
+  // 单事务原子提交；返回各表命中数供 worker 落审计 + CLI 回显。sender_name 作为墓碑保留（频道内昵称，
+  // 非原始 PII；账号级 owner 已抹），线程/回复链不悬空；跨频道 / D1 token 维度擦除留 follow-up。
+  private eraseIdentityData(name: string): {
+    name: string;
+    erased_at: number;
+    messages_scrubbed: number;
+    audit_deleted: number;
+    wake_ledger_deleted: number;
+    read_cursors_deleted: number;
+    presence_deleted: number;
+  } {
+    const sql = this.ctx.storage.sql;
+    const countOne = (query: string, ...args: (string | number)[]): number =>
+      Number(sql.exec(query, ...args).one().n ?? 0);
+    let messages_scrubbed = 0;
+    let audit_deleted = 0;
+    let wake_ledger_deleted = 0;
+    let read_cursors_deleted = 0;
+    let presence_deleted = 0;
+    this.ctx.storage.transactionSync(() => {
+      messages_scrubbed = countOne(
+        "SELECT COUNT(*) AS n FROM messages WHERE sender_name = ? AND body != '[erased]'",
+        name,
+      );
+      // 正文 + 归属 PII 一并抹除。列集对齐 #196 撤回清洗，另加 sender_owner/handle/头像/血缘/decision。
+      sql.exec(
+        `UPDATE messages
+            SET body = '[erased]', mentions_json = '[]', original_body = NULL,
+                state = NULL, note = NULL,
+                status_scope_json = NULL, status_blocked_reason = NULL, status_context_json = NULL,
+                status_decision_json = NULL, status_workflow_json = NULL, message_workflow_json = NULL,
+                completion_artifact_json = NULL, completion_review_state = NULL, completion_review_policy = NULL,
+                completion_reviewed_by = NULL, completion_reviewed_by_kind = NULL, completion_reviewed_by_owner = NULL,
+                completion_reviewed_at = NULL, completion_review_reason = NULL,
+                decision_request_json = NULL, decision_resolution_json = NULL, decision_response_json = NULL,
+                sender_owner = NULL, sender_lineage_json = NULL, sender_role = NULL, sender_role_source = NULL,
+                sender_handle = NULL, sender_display_name = NULL, sender_avatar_url = NULL, sender_avatar_thumb = NULL,
+                attachments_json = NULL, edited_by = NULL, retracted_by = NULL, idempotency_key = NULL
+          WHERE sender_name = ? AND body != '[erased]'`,
+        name,
+      );
+      audit_deleted = countOne(
+        `SELECT COUNT(*) AS n FROM message_audit
+          WHERE actor_name = ? OR target_seq IN (SELECT seq FROM messages WHERE sender_name = ?)`,
+        name,
+        name,
+      );
+      sql.exec(
+        `DELETE FROM message_audit
+          WHERE actor_name = ? OR target_seq IN (SELECT seq FROM messages WHERE sender_name = ?)`,
+        name,
+        name,
+      );
+      wake_ledger_deleted = countOne("SELECT COUNT(*) AS n FROM wake_delivery_ledger WHERE target_name = ?", name);
+      sql.exec("DELETE FROM wake_delivery_ledger WHERE target_name = ?", name);
+      read_cursors_deleted = countOne("SELECT COUNT(*) AS n FROM read_cursor WHERE name = ?", name);
+      sql.exec("DELETE FROM read_cursor WHERE name = ?", name);
+      presence_deleted = countOne("SELECT COUNT(*) AS n FROM presence WHERE name = ?", name);
+      sql.exec("DELETE FROM presence WHERE name = ?", name);
+    });
+    return { name, erased_at: Date.now(), messages_scrubbed, audit_deleted, wake_ledger_deleted, read_cursors_deleted, presence_deleted };
   }
 
   // seen 帧：把某身份的已读游标前移到 seq（只前移；旧 seq 幂等忽略）。前移了返回新游标（供广播），

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -5562,7 +5562,7 @@ app.get("/api/channels/:slug/identity/:name/data", async (c) => {
   return fetchChannelDO(
     c.env,
     slug,
-    new Request(`https://do/internal/identity/${encodeURIComponent(name)}/data`, {
+    new Request(`https://do/internal/identity/${encodeURIComponent(name)}/data${new URL(c.req.url).search}`, {
       headers: { "x-partykit-room": slug },
     }),
   );
@@ -5588,11 +5588,21 @@ app.delete("/api/channels/:slug/identity/:name/data", async (c) => {
     slug,
     new Request(`https://do/internal/identity/${encodeURIComponent(name)}/data`, {
       method: "DELETE",
-      headers: { "x-partykit-room": slug },
+      headers: {
+        "x-partykit-room": slug,
+        "x-ap-name": identity.name,
+        "x-ap-kind": identity.kind,
+        "x-ap-role": identity.role,
+        "x-ap-token-hash": identity.hash,
+      },
     }),
   );
   if (res.ok) {
-    const summary = (await res.clone().json().catch(() => null)) as Record<string, unknown> | null;
+    const summary = (await res.clone().json().catch(() => null)) as (Record<string, unknown> & { attachment_keys?: unknown }) | null;
+    const attachmentKeys = Array.isArray(summary?.attachment_keys)
+      ? summary.attachment_keys.filter((key): key is string => typeof key === "string" && key.startsWith(`${slug}/`))
+      : [];
+    await Promise.all(attachmentKeys.map((key) => c.env.ATTACHMENTS.delete(key)));
     await bestEffortRecordManagementAudit(c.env.DB, {
       actor: managementAuditActor(identity),
       action: "channel.identity.erase",

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -5545,6 +5545,65 @@ app.get("/api/channels/:slug/messages/:seq/audit", async (c) => {
   );
 });
 
+// GDPR 按身份数据出口（#421）。只读，导出某身份在本频道的全部可归因数据（消息 + 审计 + wake 账本 +
+// 读游标 + presence），满足「数据可携」/ 出境审查。授权同 kick/pause：仅频道 moderator（房主 / ap_）——
+// 导出包含 PII，不能让普通成员随手拉别人的数据。
+app.get("/api/channels/:slug/identity/:name/data", async (c) => {
+  const slug = c.req.param("slug");
+  const channel = await loadChannel(c.env.DB, slug);
+  if (!channel) return c.json(errorBody("not_found", "channel not found"), 404);
+  if (!isChannelModerator(c.get("identity"), channel)) {
+    return c.json(errorBody("forbidden", "only the channel owner or an ap_ token can export identity data"), 403);
+  }
+  const name = c.req.param("name");
+  if (!name || name.length > 256) {
+    return c.json(errorBody("bad_request", "valid name required"), 400);
+  }
+  return fetchChannelDO(
+    c.env,
+    slug,
+    new Request(`https://do/internal/identity/${encodeURIComponent(name)}/data`, {
+      headers: { "x-partykit-room": slug },
+    }),
+  );
+});
+
+// GDPR 按身份硬擦除（#421）。物理删除该身份在本频道 message_audit / wake_delivery_ledger / read_cursor /
+// presence 的可识别行，并把其发过的消息正文 + 归属 PII 抹成 [erased]——补齐撤回（#196）只覆盖单条消息、
+// 覆盖不到审计/账本身份维度的合规缺口。授权同 kick：仅频道 moderator（房主 / ap_）；操作落 management_audit。
+app.delete("/api/channels/:slug/identity/:name/data", async (c) => {
+  const slug = c.req.param("slug");
+  const channel = await loadChannel(c.env.DB, slug);
+  if (!channel) return c.json(errorBody("not_found", "channel not found"), 404);
+  const identity = c.get("identity");
+  if (!isChannelModerator(identity, channel)) {
+    return c.json(errorBody("forbidden", "only the channel owner or an ap_ token can erase identity data"), 403);
+  }
+  const name = c.req.param("name");
+  if (!name || name.length > 256) {
+    return c.json(errorBody("bad_request", "valid name required"), 400);
+  }
+  const res = await fetchChannelDO(
+    c.env,
+    slug,
+    new Request(`https://do/internal/identity/${encodeURIComponent(name)}/data`, {
+      method: "DELETE",
+      headers: { "x-partykit-room": slug },
+    }),
+  );
+  if (res.ok) {
+    const summary = (await res.clone().json().catch(() => null)) as Record<string, unknown> | null;
+    await bestEffortRecordManagementAudit(c.env.DB, {
+      actor: managementAuditActor(identity),
+      action: "channel.identity.erase",
+      resource: `channel/${slug}/identity/${name}`,
+      channel: slug,
+      metadata: summary ?? {},
+    });
+  }
+  return res;
+});
+
 // 附件上传（#176）：blob 进 R2，返回引用元数据；发消息时把引用带在 attachments 字段里。
 // 鉴权同频道写：必须是可访问该频道的非 readonly token（私有频道即房主/成员/被邀 agent）。
 app.post("/api/channels/:slug/attachments", async (c) => {

--- a/worker/src/management-audit.ts
+++ b/worker/src/management-audit.ts
@@ -26,6 +26,7 @@ export type ManagementAuditAction =
   | "channel.webhook.remove"
   | "channel.webhook.redeliver"
   | "channel.archive"
+  | "channel.identity.erase"
   | "membership.set";
 
 export interface ManagementAuditActor {
@@ -122,6 +123,21 @@ function safeMetadata(action: ManagementAuditAction, input: unknown): Record<str
   }
   if (action === "channel.guard.reset") {
     return metadata.guard === "loop" || metadata.guard === "workflow" ? { guard: metadata.guard } : {};
+  }
+  if (action === "channel.identity.erase") {
+    // GDPR 硬擦除（#421）：只留各表命中数（纯数字，无内容），供合规追溯「删了多少行」。
+    const result: Record<string, unknown> = {};
+    for (const field of [
+      "messages_scrubbed",
+      "audit_deleted",
+      "wake_ledger_deleted",
+      "read_cursors_deleted",
+      "presence_deleted",
+    ]) {
+      const value = metadata[field];
+      if (typeof value === "number" && Number.isInteger(value) && value >= 0) result[field] = value;
+    }
+    return result;
   }
   if (action === "membership.set") {
     return metadata.tier === "free" || metadata.tier === "member" ? { tier: metadata.tier } : {};

--- a/worker/test/identity-erasure.spec.ts
+++ b/worker/test/identity-erasure.spec.ts
@@ -8,7 +8,13 @@ import { api, createChannel, postMessage, seedToken, uniq } from "./helpers";
 
 interface ExportShape {
   name: string;
-  messages: { seq: number; body: string }[];
+  messages: {
+    seq: number;
+    body: string;
+    sender: { name: string; owner?: string; handle?: string; display_name?: string; avatar_url?: string };
+    attachments?: unknown[];
+    rev_seq?: number;
+  }[];
   audit: { target_seq: number; action: string; actor: { name: string } }[];
   wake_deliveries: { target_name: string }[];
   read_cursor: { name: string } | null;
@@ -55,18 +61,20 @@ async function seedIdentityRows(slug: string, name: string): Promise<void> {
 
 describe("gdpr identity erasure + export (#421)", () => {
   it("exports an identity's data and then hard-erases it (moderator only)", async () => {
-    const { slug, owner, writer } = await fixture();
+    const { slug, owner, writer, other } = await fixture();
 
     // 造可归因数据：两条消息 + 一次编辑（产生 message_audit 行，actor = writer）。
     const first = await postMessage(slug, writer.token, "first body");
     const firstSeq = ((await first.json()) as { seq: number }).seq;
     await postMessage(slug, writer.token, "second body");
+    await postMessage(slug, other.token, "other body");
     const edited = await api(`/api/channels/${slug}/messages/${firstSeq}/edit`, writer.token, {
       method: "POST",
       body: JSON.stringify({ body: "edited body" }),
     });
     expect(edited.status).toBe(200);
     await seedIdentityRows(slug, writer.name);
+    await seedIdentityRows(slug, other.name);
 
     // 导出（moderator）：能看到全部维度。
     const exportRes = await api(`/api/channels/${slug}/identity/${encodeURIComponent(writer.name)}/data`, owner.token);
@@ -102,11 +110,23 @@ describe("gdpr identity erasure + export (#421)", () => {
     const after = (await (
       await api(`/api/channels/${slug}/identity/${encodeURIComponent(writer.name)}/data`, owner.token)
     ).json()) as ExportShape;
+    expect(after.messages.length).toBe(2);
     expect(after.messages.every((m) => m.body === "[erased]")).toBe(true);
+    expect(after.messages.every((m) => m.sender.name === writer.name)).toBe(true);
+    expect(after.messages.every((m) => m.sender.owner === undefined && m.sender.handle === undefined)).toBe(true);
+    expect(after.messages.every((m) => m.sender.display_name === undefined && m.sender.avatar_url === undefined)).toBe(true);
+    expect(after.messages.every((m) => m.attachments === undefined)).toBe(true);
+    expect(after.messages.every((m) => typeof m.rev_seq === "number")).toBe(true);
     expect(after.audit.length).toBe(0);
     expect(after.wake_deliveries.length).toBe(0);
     expect(after.read_cursor).toBeNull();
     expect(after.presence.length).toBe(0);
+
+    const otherAfter = (await (
+      await api(`/api/channels/${slug}/identity/${encodeURIComponent(other.name)}/data`, owner.token)
+    ).json()) as ExportShape;
+    expect(otherAfter.messages.some((m) => m.body === "other body")).toBe(true);
+    expect(otherAfter.presence.length).toBe(1);
 
     // 频道历史里也不再有原文。
     const history = await api(`/api/channels/${slug}/messages?since=0`, owner.token);
@@ -117,7 +137,7 @@ describe("gdpr identity erasure + export (#421)", () => {
   });
 
   it("rejects export and erase from a non-moderator", async () => {
-    const { slug, writer, other } = await fixture();
+    const { slug, owner, writer, other } = await fixture();
     await postMessage(slug, writer.token, "sensitive");
 
     const exportDenied = await api(
@@ -134,8 +154,9 @@ describe("gdpr identity erasure + export (#421)", () => {
     expect(eraseDenied.status).toBe(403);
 
     // 拒绝后原文仍在，未被误删。
-    const stillThere = await api(`/api/channels/${slug}/identity/${encodeURIComponent(writer.name)}/data`, writer.token);
-    // writer 自己也不是 moderator，同样 403（导出含 PII，只给房主/ap_）。
-    expect(stillThere.status).toBe(403);
+    const stillThere = await api(`/api/channels/${slug}/identity/${encodeURIComponent(writer.name)}/data`, owner.token);
+    expect(stillThere.status).toBe(200);
+    const stillThereData = (await stillThere.json()) as ExportShape;
+    expect(stillThereData.messages.some((m) => m.body === "sensitive")).toBe(true);
   });
 });

--- a/worker/test/identity-erasure.spec.ts
+++ b/worker/test/identity-erasure.spec.ts
@@ -1,0 +1,141 @@
+// GDPR 按身份硬擦除 + 导出（#421）。验证：
+//  - moderator 能导出某身份在频道的全部可归因数据；擦除后这些数据不可查、消息正文被抹成 [erased]。
+//  - 非 moderator 无论导出还是擦除都被 403 拒。
+import { env, runInDurableObject } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import type { ChannelDO } from "../src/do";
+import { api, createChannel, postMessage, seedToken, uniq } from "./helpers";
+
+interface ExportShape {
+  name: string;
+  messages: { seq: number; body: string }[];
+  audit: { target_seq: number; action: string; actor: { name: string } }[];
+  wake_deliveries: { target_name: string }[];
+  read_cursor: { name: string } | null;
+  presence: { name: string }[];
+}
+
+async function fixture() {
+  const acct = `${uniq("acct")}@leeguoo.com`;
+  const owner = await seedToken("agent", uniq("owner"), { owner: acct });
+  const slug = await createChannel(owner.token);
+  const writer = await seedToken("agent", uniq("writer"), { owner: acct, channelScope: slug });
+  const other = await seedToken("agent", uniq("other"), { owner: acct, channelScope: slug });
+  return { slug, owner, writer, other };
+}
+
+// 直接往 DO 塞 presence / wake 账本 / 读游标行，绕开 WS 时序，做确定性的擦除断言。
+async function seedIdentityRows(slug: string, name: string): Promise<void> {
+  const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+  await runInDurableObject(stub, async (_do: ChannelDO, state) => {
+    const now = Date.now();
+    state.storage.sql.exec(
+      "INSERT INTO presence (name, session_id, state, updated_at) VALUES (?, ?, 'online', ?)",
+      name,
+      "sess-1",
+      now,
+    );
+    state.storage.sql.exec(
+      `INSERT INTO wake_delivery_ledger (mention_seq, target_name, webhook_name, adapter_kind, attempt, result, attempted_at)
+       VALUES (?, ?, ?, 'webhook', 1, 'ok', ?)`,
+      1,
+      name,
+      name,
+      now,
+    );
+    state.storage.sql.exec(
+      "INSERT INTO read_cursor (name, session_id, kind, last_seen_seq, updated_at) VALUES (?, ?, 'agent', ?, ?)",
+      name,
+      "sess-1",
+      2,
+      now,
+    );
+  });
+}
+
+describe("gdpr identity erasure + export (#421)", () => {
+  it("exports an identity's data and then hard-erases it (moderator only)", async () => {
+    const { slug, owner, writer } = await fixture();
+
+    // 造可归因数据：两条消息 + 一次编辑（产生 message_audit 行，actor = writer）。
+    const first = await postMessage(slug, writer.token, "first body");
+    const firstSeq = ((await first.json()) as { seq: number }).seq;
+    await postMessage(slug, writer.token, "second body");
+    const edited = await api(`/api/channels/${slug}/messages/${firstSeq}/edit`, writer.token, {
+      method: "POST",
+      body: JSON.stringify({ body: "edited body" }),
+    });
+    expect(edited.status).toBe(200);
+    await seedIdentityRows(slug, writer.name);
+
+    // 导出（moderator）：能看到全部维度。
+    const exportRes = await api(`/api/channels/${slug}/identity/${encodeURIComponent(writer.name)}/data`, owner.token);
+    expect(exportRes.status).toBe(200);
+    const dump = (await exportRes.json()) as ExportShape;
+    expect(dump.name).toBe(writer.name);
+    expect(dump.messages.length).toBe(2);
+    expect(dump.audit.length).toBeGreaterThanOrEqual(1);
+    expect(dump.audit.every((a) => a.actor.name === writer.name || a.target_seq === firstSeq)).toBe(true);
+    expect(dump.wake_deliveries.length).toBe(1);
+    expect(dump.read_cursor?.name).toBe(writer.name);
+    expect(dump.presence.length).toBe(1);
+
+    // 擦除（moderator）：返回各表命中数。
+    const eraseRes = await api(`/api/channels/${slug}/identity/${encodeURIComponent(writer.name)}/data`, owner.token, {
+      method: "DELETE",
+    });
+    expect(eraseRes.status).toBe(200);
+    const summary = (await eraseRes.json()) as {
+      messages_scrubbed: number;
+      audit_deleted: number;
+      wake_ledger_deleted: number;
+      read_cursors_deleted: number;
+      presence_deleted: number;
+    };
+    expect(summary.messages_scrubbed).toBe(2);
+    expect(summary.audit_deleted).toBeGreaterThanOrEqual(1);
+    expect(summary.wake_ledger_deleted).toBe(1);
+    expect(summary.read_cursors_deleted).toBe(1);
+    expect(summary.presence_deleted).toBe(1);
+
+    // 擦除后：该身份数据不可查——消息正文被抹成 [erased]，审计/账本/游标/presence 清零。
+    const after = (await (
+      await api(`/api/channels/${slug}/identity/${encodeURIComponent(writer.name)}/data`, owner.token)
+    ).json()) as ExportShape;
+    expect(after.messages.every((m) => m.body === "[erased]")).toBe(true);
+    expect(after.audit.length).toBe(0);
+    expect(after.wake_deliveries.length).toBe(0);
+    expect(after.read_cursor).toBeNull();
+    expect(after.presence.length).toBe(0);
+
+    // 频道历史里也不再有原文。
+    const history = await api(`/api/channels/${slug}/messages?since=0`, owner.token);
+    const messages = ((await history.json()) as { messages: { body: string }[] }).messages;
+    expect(messages.some((m) => m.body === "first body" || m.body === "second body" || m.body === "edited body")).toBe(
+      false,
+    );
+  });
+
+  it("rejects export and erase from a non-moderator", async () => {
+    const { slug, writer, other } = await fixture();
+    await postMessage(slug, writer.token, "sensitive");
+
+    const exportDenied = await api(
+      `/api/channels/${slug}/identity/${encodeURIComponent(writer.name)}/data`,
+      other.token,
+    );
+    expect(exportDenied.status).toBe(403);
+
+    const eraseDenied = await api(
+      `/api/channels/${slug}/identity/${encodeURIComponent(writer.name)}/data`,
+      other.token,
+      { method: "DELETE" },
+    );
+    expect(eraseDenied.status).toBe(403);
+
+    // 拒绝后原文仍在，未被误删。
+    const stillThere = await api(`/api/channels/${slug}/identity/${encodeURIComponent(writer.name)}/data`, writer.token);
+    // writer 自己也不是 moderator，同样 403（导出含 PII，只给房主/ap_）。
+    expect(stillThere.status).toBe(403);
+  });
+});


### PR DESCRIPTION
涉及 #421,待 host 验收(不 Closes)。

## 需求
#421 从 #137 面4(数据保留/合规)拆出:撤回(#196)只 scrub 单条消息正文,清不掉 `message_audit` / 账本里的身份维度;无 GDPR/hard-delete/按身份擦除/导出入口。跨公司频道里 A 公司 agent 误贴的密钥/PII 撤回后仍可归因、可查。

## 范围(务实的最小可验收闭环:硬擦除 + 导出)
本轮做**按身份的硬擦除 + 只读导出**,其余(可配置保留期物理删、temp 归档到期真删、跨频道/D1 维度、system-wide forget)留 follow-up,见 `docs/data-retention.md`。

## 改法
- **worker/src/do.ts**:新增 DO 内部路由 `GET|DELETE /internal/identity/:name/data`。
  - `eraseIdentityData`:单事务原子擦除该身份在本频道 `message_audit`(actor 或其消息 target)/ `wake_delivery_ledger`(target_name)/ `read_cursor`(name)/ `presence`(name)的可识别行;把其发过的 `messages` 正文 + 归属 PII(owner/handle/头像/血缘/各 JSON payload)抹成 `[erased]`,`sender_name` 留墓碑防回复链悬空。返回各表命中数。
  - `exportIdentityData`:只读导出该身份在本频道的 messages / audit / wake_deliveries / read_cursor / presence。
- **worker/src/index.ts**:新增 moderator 门控(同 kick/pause:房主 / `ap_`)的 `DELETE|GET /api/channels/:slug/identity/:name/data`;擦除成功落 `channel.identity.erase` 管理审计(仅命中数,无内容)。
- **worker/src/management-audit.ts**:加 `channel.identity.erase` action + 其 metadata 白名单(纯数字命中数)。
- **cli**:新增 `party gdpr erase|export <name> [channel]`;`erase` 不可逆需 `--yes`;`export` 支持 `--json`。rest.ts 加 `eraseIdentityData`/`exportIdentityData`。
- **docs/data-retention.md**:数据保留/删除/GDPR 合规说明(现有 #128 表级修剪现状 + 新擦除/导出 + 已知 gap),满足验收「有文档说明」。

## 保留期现状(范围点2)
`#128` 已有表级有界修剪(`WAKE_LEDGER_RETENTION_MS` 35d / `MAX_MESSAGE_AUDIT_ROWS` 20k / `READ_CURSOR_RETENTION_MS` 30d / `RETAIN_N` 10k),常量在 `shared/src/protocol.ts`。**无按身份保留窗口**——已在文档写明现状,不重造。

## 测试(先 `web build` 后 worker vitest,均绿 + tsc 0)
- `worker/test/identity-erasure.spec.ts`:moderator 导出返回数据;擦除后消息正文=`[erased]`、审计/账本/游标/presence 清零、历史无原文;非 moderator 导出+擦除均 403。
- `cli/test/gdpr.test.ts`:`erase` 无 `--yes` 前置拒绝(不发请求);`--yes` 命中 DELETE + 回显命中数;`export` 命中 GET + summary;`--json` 原样 dump;未知子命令拒绝。
- worker 全量相关 spec(management-audit / message-mutations / do-storage-pruning)+ cli 全量 670 tests 通过。

## 留的 follow-up
- 跨频道 / system-wide「forget everywhere」fan-out。
- D1 侧 token 撤销 + channel_members 清理并入擦除(当前走 `channel kick --remove`)。
- `sender_name` 完全匿名化(现留墓碑,account 级 owner 已抹)。
- 可配置的按频道/全局保留窗口 + 到期物理删;temp 归档 → 定时硬删。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增 CLI 子命令 `party gdpr`：支持 `export|erase <name>`，可选 `--channel`、`--yes`（仅擦除确认）、`--json`（导出输出原始 JSON），并提供消息/审计/投递/游标/presence 的汇总或全量结果查看。
  - 新增频道级“按身份”导出与硬擦除能力（仅版主权限），擦除会清理相关数据并附带管理审计记录。
- **测试**
  - 增加 GDPR 导出/擦除端到端测试，覆盖权限校验、确认流程、JSON 解析、输出清理与分页导出一致性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->