### PR TITLE
feat(worker,cli): 频道导出备份 + DO/D1 对账 (#422)

### DIFF
--- a/cli/src/commands/channel.ts
+++ b/cli/src/commands/channel.ts
@@ -7,8 +7,10 @@ import {
   archiveChannel,
   clearChannelRole,
   createChannel,
+  exportChannel,
   getLoopGuard,
   handleRestError,
+  reconcileChannel,
   inviteProjectAgent,
   fetchChannelPerms,
   kickParticipant,
@@ -32,6 +34,7 @@ import {
   type HumanChannelListPolicy,
   type HumanChannelPermPolicy,
 } from "../rest";
+import { writeFileSync } from "node:fs";
 import { isName, isSlug } from "../validation";
 
 const CHANNEL_FLAGS = [
@@ -53,6 +56,7 @@ const CHANNEL_FLAGS = [
   "members-list-agents",
   "members-agent",
   "json",
+  "out",
 ];
 // 与 worker/src/do.ts WORKFLOW_ID_RE 及 status --workflow-id 校验保持一致
 const WORKFLOW_ID_RE = /^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,127}$/;
@@ -91,6 +95,8 @@ const HELP = `usage: party channel create <slug> [--title t] [--temp] [--party] 
        party channel role list [slug]
        party channel role set <name> host|worker|reviewer|observer [slug] [--responsibility text]
        party channel role unset <name> [slug]
+       party channel export <slug> [--out file.json]   dump channel backup (D1 + DO) as JSON
+       party channel reconcile <slug> [--json]          report DO/D1 double-write divergence (exit 1 on drift)
 
 Manage channels.
 
@@ -108,7 +114,8 @@ Options:
   --remove    revoke the channel-scoped token and remove membership when kicking
   --expires d join-link expiry like 7d, 12h, 30m, 60s
   --max-uses n join-link redemption limit
-  --json      output channel permission policy as JSON
+  --json      output channel permission/reconcile result as JSON
+  --out f     write channel export backup to file f (default: stdout)
   --charter-write p
               human charter writers: owner, moderators, or members
   --charter-write-agents p
@@ -188,7 +195,7 @@ export async function run(argv: string[]): Promise<number> {
   }
   const flagError = valueFlagError(
     flags,
-    ["title", "policy", "expires", "max-uses", "responsibility", "charter-write", "charter-write-agents", "members-list", "members-list-agents"],
+    ["title", "policy", "expires", "max-uses", "responsibility", "charter-write", "charter-write-agents", "members-list", "members-list-agents", "out"],
     ["agent", "members-agent"],
   );
   if (flagError !== null) {
@@ -645,8 +652,54 @@ export async function run(argv: string[]): Promise<number> {
         console.error("usage: party channel role list|set|unset");
         return 1;
       }
+      case "export": {
+        // #422 频道级备份：把 D1（channels 行 + roles/tasks/members）+ DO 持久表 dump 成一份 JSON 存档。
+        const slug = resolveChannel(positionals[1]);
+        if (!slug) {
+          console.error("usage: party channel export <slug> [--out file.json]");
+          return 1;
+        }
+        if (!isSlug(slug)) {
+          console.error("slug must match [a-z0-9][a-z0-9-]{0,63}");
+          return 1;
+        }
+        const backup = await exportChannel(cfg.server, cfg.token, slug);
+        const json = JSON.stringify(backup, null, 2);
+        const out = str(flags.out);
+        if (out) {
+          writeFileSync(out, json + "\n");
+          console.error(`exported ${slug} backup to ${out}`);
+        } else {
+          console.log(json);
+        }
+        return 0;
+      }
+      case "reconcile": {
+        // #422 DO↔D1 对账：只读比对双写字段，报告分裂项。有分裂时退出码 1（便于 CI 门禁）。
+        const slug = resolveChannel(positionals[1]);
+        if (!slug) {
+          console.error("usage: party channel reconcile <slug> [--json]");
+          return 1;
+        }
+        if (!isSlug(slug)) {
+          console.error("slug must match [a-z0-9][a-z0-9-]{0,63}");
+          return 1;
+        }
+        const report = await reconcileChannel(cfg.server, cfg.token, slug);
+        if (flags.json === true) {
+          console.log(JSON.stringify(report, null, 2));
+        } else if (report.ok) {
+          console.log(`in sync\t${slug}\tno DO/D1 divergence detected`);
+        } else {
+          console.log(`DRIFT DETECTED\t${slug}\t${report.divergences.length} field(s)`);
+          for (const d of report.divergences) {
+            console.log(`  ${d.field}\td1=${JSON.stringify(d.d1)}\tdo=${JSON.stringify(d.durable_object)}`);
+          }
+        }
+        return report.ok ? 0 : 1;
+      }
       default:
-        console.error("usage: party channel create|list|archive|reset-guard|reset-workflow-guard|kick|invite-agent|gate|visibility|members|perms|join-link|leave|role");
+        console.error("usage: party channel create|list|archive|reset-guard|reset-workflow-guard|kick|invite-agent|gate|visibility|members|perms|join-link|leave|role|export|reconcile");
         return 1;
     }
   } catch (e) {

--- a/cli/src/commands/channel.ts
+++ b/cli/src/commands/channel.ts
@@ -667,7 +667,12 @@ export async function run(argv: string[]): Promise<number> {
         const json = JSON.stringify(backup, null, 2);
         const out = str(flags.out);
         if (out) {
-          writeFileSync(out, json + "\n");
+          try {
+            writeFileSync(out, json + "\n");
+          } catch (error) {
+            console.error(`failed to write backup to ${out}: ${error instanceof Error ? error.message : String(error)}`);
+            return 1;
+          }
           console.error(`exported ${slug} backup to ${out}`);
         } else {
           console.log(json);

--- a/cli/src/rest.ts
+++ b/cli/src/rest.ts
@@ -1255,6 +1255,27 @@ export async function resetGuard(server: string, token: string, slug: string): P
   });
 }
 
+// #422 频道级备份：拉取合并后的频道存档 JSON（D1 channels 行 + roles/tasks/members + DO 持久表）。
+// moderator-only；原样返回服务端 JSON 交由 CLI 写盘/打印，作为离线备份物。
+export async function exportChannel(server: string, token: string, slug: string): Promise<unknown> {
+  return req(server, `/api/channels/${encodeURIComponent(slug)}/export`, { headers: bearerJson(token) });
+}
+
+// #422 DO↔D1 对账报告：只读比对双写字段，返回 { ok, divergences[], durable_object }。
+export interface ReconcileReport {
+  ok: boolean;
+  checked_at: number;
+  channel: string;
+  divergences: { field: string; d1: unknown; durable_object: unknown }[];
+  durable_object: Record<string, unknown>;
+}
+
+export async function reconcileChannel(server: string, token: string, slug: string): Promise<ReconcileReport> {
+  return (await req(server, `/api/channels/${encodeURIComponent(slug)}/reconcile`, {
+    headers: bearerJson(token),
+  })) as ReconcileReport;
+}
+
 // 重置某个 workflow 的 no-progress 熔断（与 loop guard 的 reset-guard 分属两套熔断器）。
 // human-only + moderator/host，服务端 /api/channels/:slug/workflows/:workflow_id/reset-guard 强制。
 export async function resetWorkflowGuard(

--- a/docs/channel-backup-recovery.html
+++ b/docs/channel-backup-recovery.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>AgentParty 频道备份与恢复 Runbook</title>
+  <style>
+    :root { --fg:#172033; --muted:#667085; --accent:#2563eb; --border:#d0d5dd; --bg:#f8fafc; }
+    * { box-sizing:border-box; }
+    body { margin:0; color:var(--fg); background:var(--bg); font:15px/1.6 -apple-system,BlinkMacSystemFont,"PingFang SC","Microsoft YaHei",sans-serif; }
+    main { max-width:960px; margin:40px auto; padding:0 24px 56px; }
+    header,section,aside { background:#fff; border:1px solid var(--border); border-radius:10px; padding:22px; margin:16px 0; }
+    h1,h2 { margin:0 0 10px; line-height:1.25; } h2 { font-size:20px; }
+    p { margin:8px 0; } code { background:#eef2f6; padding:2px 5px; border-radius:4px; }
+    pre { overflow:auto; background:#111827; color:#f8fafc; padding:14px; border-radius:7px; }
+    table { width:100%; border-collapse:collapse; } th,td { padding:9px; border:1px solid var(--border); text-align:left; vertical-align:top; }
+    th { background:#f2f4f7; } .warn { border-left:4px solid var(--accent); }
+  </style>
+</head>
+<body><main>
+  <header><h1>频道备份与恢复 Runbook</h1><p>适用于单频道 DO SQLite 与 D1 元数据分裂、误部署或存储恢复。备份格式版本为 <code>backup_version: 1</code>。</p></header>
+  <section><h2>1. 先冻结写入并采集证据</h2><pre><code>party channel reconcile &lt;slug&gt; --json
+party channel export &lt;slug&gt; --out &lt;slug&gt;-$(date +%Y%m%d-%H%M%S).json</code></pre><p>保存当前部署 commit、D1 time-travel 时间点、对账输出和导出文件校验和。不要在证据保存前覆盖 DO。</p></section>
+  <section><h2>2. 判断权威数据源</h2><table><thead><tr><th>故障</th><th>权威源</th><th>动作</th></tr></thead><tbody>
+    <tr><td>仅 D1 元数据误改</td><td>导出物中的 <code>channel</code> / D1 表</td><td>用 D1 time-travel 恢复到确认时间点，再重新对账。</td></tr>
+    <tr><td>DO SQLite 丢失或损坏</td><td>最近一次频道导出物</td><td>新建/清空目标 DO 后，按导出表的主键顺序恢复持久表；跳过 rate、webhook queue/dead letters、wake ledger 等瞬时表。</td></tr>
+    <tr><td>DO 与 D1 分裂</td><td>D1 配置字段；DO 消息历史</td><td>先恢复 D1，再通过正常频道初始化请求重推配置；消息只从导出物恢复，禁止双向盲合并。</td></tr>
+  </tbody></table></section>
+  <section><h2>3. D1 time-travel</h2><p>使用 Cloudflare D1 time-travel 在独立恢复库验证目标时间点；确认 schema 与行数后再替换生产库。迁移不可逆时，先回退 Worker 到与目标 schema 兼容的版本。</p><pre><code>wrangler d1 time-travel info &lt;database&gt;
+wrangler d1 time-travel restore &lt;database&gt; --timestamp=&lt;ISO-8601&gt;</code></pre></section>
+  <section><h2>4. DO 状态重建</h2><p>导出 JSON 的 <code>durable_object.tables</code> 是恢复输入。恢复工具必须逐表事务写入、校验行数，并保持 <code>messages.seq</code>、修订游标和 meta 计数器单调。恢复期间禁止客户端连接；完成后再解除写入冻结。</p></section>
+  <section><h2>5. 验收</h2><pre><code>party channel reconcile &lt;slug&gt;
+party history --channel &lt;slug&gt; --limit 20
+party who --channel &lt;slug&gt;</code></pre><p>要求 reconcile 为 <code>ok:true</code>、最近消息可读、成员/角色/任务数量与备份一致，并记录恢复操作者、时间点、源文件 SHA-256 和部署 commit。</p></section>
+  <aside class="warn"><strong>边界：</strong>当前 CLI 提供导出与对账，不提供自动覆盖生产 DO 的 <code>restore</code> 命令。恢复写入必须在隔离环境演练并经 owner 审批；不得把 D1 time-travel 当作 DO SQLite 的备份。</aside>
+</main></body></html>

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -2812,6 +2812,47 @@ export class ChannelDO extends Server<Env> {
         earliest_ts: row.earliest_ts === null || row.earliest_ts === undefined ? null : Number(row.earliest_ts),
       });
     }
+    if (url.pathname === "/internal/export" && request.method === "GET") {
+      // #422 频道级备份：把 DO 内建 SQLite 的持久表整表 dump 成 JSON，作为离线存档 = DO 的备份物
+      //（D1 有 time-travel 兜底，DO 侧此前无等价备份）。跳过纯运行期表（速率窗口、webhook 重试队列/死信、
+      // 唤醒投递账本）——它们是瞬时状态，不属于需要归档的频道数据，且会让备份无谓膨胀。
+      const ephemeral = new Set(["rate", "webhook_queue", "webhook_dead_letters", "wake_delivery_ledger"]);
+      const tableRows = this.ctx.storage.sql
+        .exec("SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' AND name NOT LIKE '_cf_%'")
+        .toArray();
+      const tables: Record<string, unknown[]> = {};
+      const rowCounts: Record<string, number> = {};
+      for (const t of tableRows) {
+        const name = String(t.name);
+        if (ephemeral.has(name)) continue;
+        // 表名来自 sqlite_master（无外部输入），拼接安全；无法参数化标识符故直接内插。
+        const rows = this.ctx.storage.sql.exec(`SELECT * FROM "${name}"`).toArray();
+        tables[name] = rows;
+        rowCounts[name] = rows.length;
+      }
+      return Response.json({ exported_at: Date.now(), row_counts: rowCounts, tables });
+    }
+    if (url.pathname === "/internal/reconcile-state" && request.method === "GET") {
+      // #422 对账：暴露 DO 侧对「与 D1 双写字段」的当前缓存值，供 worker 与 D1 channels 行逐字段比对。
+      // meta 是懒缓存（standing 频道创建时不 push /internal/init，首条消息/guard/可见性变更才落）——
+      // 故未落的字段返回 null，由 worker 侧解释为「DO 尚未物化」而非分裂。archived 恒有真值（缺省 false）。
+      const msgCount = this.ctx.storage.sql.exec("SELECT COUNT(*) AS n FROM messages").one();
+      return Response.json({
+        archived: this.isArchived(),
+        mode: this.getMeta("mode"),
+        ckind: this.getMeta("ckind"),
+        visibility: this.getMeta("visibility"),
+        completion_gate: this.getMeta("completion_gate"),
+        completion_review_policy: this.getMeta("completion_review_policy"),
+        decision_mode: this.getMeta("decision_mode"),
+        loop_guard_enabled: this.getMeta("loop_guard_enabled"),
+        loop_guard_limit: this.getMeta("loop_guard_limit"),
+        workflow_guard_enabled: this.getMeta("workflow_guard_enabled"),
+        workflow_guard_limit: this.getMeta("workflow_guard_limit"),
+        charter_rev: this.charterRev(),
+        message_count: Number(msgCount.n ?? 0),
+      });
+    }
     if (url.pathname === "/internal/system-status" && request.method === "POST") {
       const body = (await request.json().catch(() => null)) as { note?: unknown; ts?: unknown; state?: unknown } | null;
       const note = typeof body?.note === "string" ? body.note : "";

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -3869,6 +3869,97 @@ app.delete("/api/channels/:slug/share-links/:name", async (c) => {
   return c.json({ ok: true });
 });
 
+// #422 频道级导出/备份：把某频道分散在 D1（channels 行 + roles/tasks/members）与 DO（messages/presence/meta
+// 等内建 SQLite 持久表）的关键状态合并成一份可离线存档的 JSON。moderator-only（同 share-links/members 的 ap_ 门）。
+// 与 #421 的按身份 GDPR 导出正交：本端点按频道全量、面向容灾备份，不做 per-identity 脱敏。
+app.get("/api/channels/:slug/export", async (c) => {
+  const slug = c.req.param("slug");
+  const channel = await loadChannel(c.env.DB, slug);
+  if (!channel) return c.json(errorBody("not_found", "channel not found"), 404);
+  const identity = c.get("identity");
+  if (!isChannelModerator(identity, channel)) {
+    return c.json(errorBody("forbidden", "only channel moderators can export a channel backup"), 403);
+  }
+  const doRes = await fetchChannelDO(
+    c.env,
+    slug,
+    new Request("https://do/internal/export", { headers: { "x-partykit-room": slug } }),
+  );
+  if (!doRes.ok) return c.json(errorBody("unavailable", "channel state export failed"), 503);
+  const doDump = (await doRes.json()) as { exported_at: number; row_counts: Record<string, number>; tables: Record<string, unknown[]> };
+  const [roles, tasks, members] = await Promise.all([
+    c.env.DB.prepare("SELECT * FROM channel_roles WHERE channel_slug = ? ORDER BY agent_name").bind(slug).all(),
+    c.env.DB.prepare("SELECT * FROM channel_tasks WHERE channel_slug = ? ORDER BY id").bind(slug).all(),
+    c.env.DB.prepare("SELECT * FROM channel_members WHERE channel_slug = ? ORDER BY account").bind(slug).all(),
+  ]);
+  await bestEffortRecordManagementAudit(c.env.DB, {
+    actor: managementAuditActor(identity),
+    action: "channel.export",
+    resource: `channel/${slug}`,
+    channel: slug,
+  });
+  return c.json({
+    backup_version: 1,
+    exported_at: Date.now(),
+    channel,
+    d1: {
+      channel_roles: roles.results ?? [],
+      channel_tasks: tasks.results ?? [],
+      channel_members: members.results ?? [],
+    },
+    durable_object: doDump,
+  });
+});
+
+// #422 DO↔D1 对账：只读校验双写字段是否一致，报告分裂项，不做修复（先给对账手段，修复留 follow-up）。
+// 逐字段比对 D1 channels 行与 DO 缓存的 meta 快照。DO meta 为懒缓存：未物化的配置字段（null）跳过，
+// 不误报为分裂；archived 恒有真值故始终比对——D1 写成功但 DO 归档 alarm 未跑的分裂即从此处显形。
+app.get("/api/channels/:slug/reconcile", async (c) => {
+  const slug = c.req.param("slug");
+  const channel = await loadChannel(c.env.DB, slug);
+  if (!channel) return c.json(errorBody("not_found", "channel not found"), 404);
+  const identity = c.get("identity");
+  if (!isChannelModerator(identity, channel)) {
+    return c.json(errorBody("forbidden", "only channel moderators can reconcile a channel"), 403);
+  }
+  const doRes = await fetchChannelDO(
+    c.env,
+    slug,
+    new Request("https://do/internal/reconcile-state", { headers: { "x-partykit-room": slug } }),
+  );
+  if (!doRes.ok) return c.json(errorBody("unavailable", "channel reconcile-state fetch failed"), 503);
+  const state = (await doRes.json()) as Record<string, unknown>;
+  const divergences: { field: string; d1: unknown; durable_object: unknown }[] = [];
+  const flag = (field: string, d1: unknown, dobj: unknown) => divergences.push({ field, d1, durable_object: dobj });
+  // archived：D1 有 archived_at ⇔ DO isArchived。恒比对（DO 缺省 false 与 D1 null 一致，健康频道不误报）。
+  const d1Archived = channel.archived_at != null;
+  if (d1Archived !== (state.archived === true)) flag("archived", d1Archived, state.archived === true);
+  // 配置字段：DO 懒缓存，未物化（null）则跳过；两侧都有具体值且不同才判分裂。
+  const cmp = (field: string, d1: unknown, dobj: unknown) => {
+    if (dobj === null || dobj === undefined) return; // DO 尚未物化，非分裂
+    if (String(d1) !== String(dobj)) flag(field, d1, dobj);
+  };
+  cmp("mode", channel.mode, state.mode);
+  cmp("kind", channel.kind, state.ckind);
+  cmp("visibility", channel.visibility, state.visibility);
+  cmp("completion_gate", channel.completion_gate, state.completion_gate);
+  cmp("completion_review_policy", channel.completion_review_policy, state.completion_review_policy);
+  cmp("decision_mode", channel.decision_mode, state.decision_mode);
+  cmp("loop_guard_enabled", channel.loop_guard_enabled, state.loop_guard_enabled);
+  cmp("loop_guard_limit", channel.loop_guard_limit, state.loop_guard_limit);
+  cmp("workflow_guard_enabled", channel.workflow_guard_enabled, state.workflow_guard_enabled);
+  cmp("workflow_guard_limit", channel.workflow_guard_limit, state.workflow_guard_limit);
+  // charter_rev：单调，DO 只前进不后退；DO 落后即分裂（D1 权威更新未随 channelHeaders 抵达 DO）。
+  cmp("charter_rev", channel.charter_rev, state.charter_rev);
+  return c.json({
+    ok: divergences.length === 0,
+    checked_at: Date.now(),
+    channel: slug,
+    divergences,
+    durable_object: state,
+  });
+});
+
 app.post("/api/channels/:slug/join-requests", async (c) => {
   const identity = c.get("identity");
   if (identity.role !== "human" || identity.account == null) {

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -3886,7 +3886,10 @@ app.get("/api/channels/:slug/export", async (c) => {
     new Request("https://do/internal/export", { headers: { "x-partykit-room": slug } }),
   );
   if (!doRes.ok) return c.json(errorBody("unavailable", "channel state export failed"), 503);
-  const doDump = (await doRes.json()) as { exported_at: number; row_counts: Record<string, number>; tables: Record<string, unknown[]> };
+  const doDump = (await doRes.json().catch(() => null)) as {
+    exported_at: number; row_counts: Record<string, number>; tables: Record<string, unknown[]>;
+  } | null;
+  if (doDump === null) return c.json(errorBody("unavailable", "channel state export returned invalid JSON"), 503);
   const [roles, tasks, members] = await Promise.all([
     c.env.DB.prepare("SELECT * FROM channel_roles WHERE channel_slug = ? ORDER BY agent_name").bind(slug).all(),
     c.env.DB.prepare("SELECT * FROM channel_tasks WHERE channel_slug = ? ORDER BY id").bind(slug).all(),

--- a/worker/src/management-audit.ts
+++ b/worker/src/management-audit.ts
@@ -27,6 +27,7 @@ export type ManagementAuditAction =
   | "channel.webhook.redeliver"
   | "channel.archive"
   | "channel.identity.erase"
+  | "channel.export"
   | "membership.set";
 
 export interface ManagementAuditActor {

--- a/worker/test/backup-reconcile.spec.ts
+++ b/worker/test/backup-reconcile.spec.ts
@@ -1,0 +1,100 @@
+// #422 频道级导出备份 + DO↔D1 对账。
+// 导出：moderator-only，合并 D1（channels 行 + roles/tasks/members）与 DO 持久表为一份存档 JSON。
+// 对账：只读比对双写字段，人造分裂（直接改 D1 archived_at）时检出「archived」divergence。
+import { env } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import { api, postMessage, seedToken, uniq } from "./helpers";
+
+async function makeChannel(token: string): Promise<string> {
+  const slug = uniq("bk");
+  const res = await api("/api/channels", token, {
+    method: "POST",
+    body: JSON.stringify({ slug, kind: "standing", visibility: "private" }),
+  });
+  expect(res.status).toBe(201);
+  return slug;
+}
+
+describe("channel export backup (#422)", () => {
+  it("moderator exports a full channel backup with D1 rows and DO messages", async () => {
+    const ownerAcct = `${uniq("owner")}@example.com`;
+    const owner = await seedToken("human", uniq("owner"), { owner: ownerAcct });
+    const slug = await makeChannel(owner.token);
+    expect((await postMessage(slug, owner.token, "backup me")).status).toBe(200);
+
+    const res = await api(`/api/channels/${slug}/export`, owner.token);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      backup_version: number;
+      channel: { slug: string; visibility: string };
+      d1: { channel_roles: unknown[]; channel_tasks: unknown[]; channel_members: unknown[] };
+      durable_object: { tables: Record<string, { body: string }[]>; row_counts: Record<string, number> };
+    };
+    expect(body.backup_version).toBe(1);
+    expect(body.channel.slug).toBe(slug);
+    expect(body.channel.visibility).toBe("private");
+    // D1 面存在（数组即可，roles/tasks/members 可空）
+    expect(Array.isArray(body.d1.channel_roles)).toBe(true);
+    expect(Array.isArray(body.d1.channel_tasks)).toBe(true);
+    expect(Array.isArray(body.d1.channel_members)).toBe(true);
+    // DO 面：messages 表含刚发的那条，且导出的是完整行（带 body），不是截断摘要
+    const messages = body.durable_object.tables.messages;
+    expect(Array.isArray(messages)).toBe(true);
+    expect(messages.some((m) => m.body === "backup me")).toBe(true);
+    expect(body.durable_object.row_counts.messages).toBeGreaterThanOrEqual(1);
+    // 瞬时运行期表被排除，不进备份
+    expect(body.durable_object.tables.webhook_queue).toBeUndefined();
+    expect(body.durable_object.tables.rate).toBeUndefined();
+  });
+
+  it("rejects non-moderators from exporting or reconciling", async () => {
+    const ownerAcct = `${uniq("owner")}@example.com`;
+    const owner = await seedToken("human", uniq("owner"), { owner: ownerAcct });
+    const slug = await makeChannel(owner.token);
+
+    const outsider = await seedToken("human", uniq("out"), { owner: `${uniq("out")}@example.com` });
+    expect((await api(`/api/channels/${slug}/export`, outsider.token)).status).toBe(403);
+    expect((await api(`/api/channels/${slug}/reconcile`, outsider.token)).status).toBe(403);
+
+    // readonly watch token 亦非 moderator
+    const ro = await seedToken("readonly", uniq("ro"), { owner: ownerAcct, channelScope: slug });
+    expect((await api(`/api/channels/${slug}/export`, ro.token)).status).toBe(403);
+    expect((await api(`/api/channels/${slug}/reconcile`, ro.token)).status).toBe(403);
+  });
+});
+
+describe("channel reconcile DO/D1 (#422)", () => {
+  it("reports a healthy channel as in sync", async () => {
+    const ownerAcct = `${uniq("owner")}@example.com`;
+    const owner = await seedToken("human", uniq("owner"), { owner: ownerAcct });
+    const slug = await makeChannel(owner.token);
+    await postMessage(slug, owner.token, "hi");
+
+    const res = await api(`/api/channels/${slug}/reconcile`, owner.token);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; divergences: { field: string }[] };
+    expect(body.ok).toBe(true);
+    expect(body.divergences).toEqual([]);
+  });
+
+  it("detects a manufactured DO↔D1 split (D1 archived, DO not)", async () => {
+    const ownerAcct = `${uniq("owner")}@example.com`;
+    const owner = await seedToken("human", uniq("owner"), { owner: ownerAcct });
+    const slug = await makeChannel(owner.token);
+
+    // 直接改 D1 让它归档，但不走 archive 端点 → DO 侧 meta 仍非归档：制造双写分裂
+    await env.DB.prepare("UPDATE channels SET archived_at = ? WHERE slug = ?").bind(Date.now(), slug).run();
+
+    const res = await api(`/api/channels/${slug}/reconcile`, owner.token);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      ok: boolean;
+      divergences: { field: string; d1: unknown; durable_object: unknown }[];
+    };
+    expect(body.ok).toBe(false);
+    const drift = body.divergences.find((d) => d.field === "archived");
+    expect(drift).toBeDefined();
+    expect(drift?.d1).toBe(true);
+    expect(drift?.durable_object).toBe(false);
+  });
+});


### PR DESCRIPTION
## 需求（#422，从 #137 面5 备份/容灾拆出）

- 状态双写在 D1 单库 + 每频道 DO SQLite，二者互为缓存，一旦分裂无对账手段。
- `scripts/` / `cli/src/commands/` 无 export/backup/reconcile 入口。
- D1 有 time-travel 兜底，DO SQLite 无等价备份物。

验收标准：存在 reconcile 工具报告 DO↔D1 不一致；存在 export/backup 命令导出频道级数据；恢复流程文档。

## 范围（务实最小闭环：导出备份 + 基础对账）

按 issue「若完整容灾太大，做导出备份 + 基础对账最小闭环」执行。复用 #176 attachments / #186 share-links 的 moderator 鉴权模式，不重造权限。与 #421（按身份 GDPR 导出）正交——本 PR 按频道全量、面向容灾备份。

## 改法

**worker**
- `do.ts` 新增 `GET /internal/export`：从 `sqlite_master` 枚举并整表 dump DO 内建 SQLite 的持久表为 JSON，跳过瞬时运行期表（`rate`/`webhook_queue`/`webhook_dead_letters`/`wake_delivery_ledger`）——这是此前缺失的 DO SQLite 备份物。
- `do.ts` 新增 `GET /internal/reconcile-state`：暴露 DO 对「与 D1 双写字段」的当前缓存值 + message_count。
- `index.ts` 新增 `GET /api/channels/:slug/export`（moderator-only）：合并 D1 `channels` 行 + `channel_roles`/`channel_tasks`/`channel_members` 与 DO 持久表为一份 `backup_version:1` 的存档 JSON，并记 `channel.export` 审计。
- `index.ts` 新增 `GET /api/channels/:slug/reconcile`（moderator-only）：逐字段比对 D1 与 DO 缓存（archived / mode / kind / visibility / gates / guards / charter_rev），报告分裂项。DO meta 为懒缓存，未物化的 `null` 字段跳过不误报；`archived` 恒比对——D1 写成功但 DO 归档 alarm 未跑的分裂即从此显形。
- `management-audit.ts` 增加 `channel.export` 动作。

**cli**
- `party channel export <slug> [--out file.json]`：拉取备份 JSON，写盘或打印（离线存档）。
- `party channel reconcile <slug> [--json]`：打印对账报告，有分裂退出码 1（便于 CI 门禁）。

## 测试

`worker/test/backup-reconcile.spec.ts`（4 项，全绿）：
- 导出返回完整数据：D1 三表 + DO `messages` 完整行（带 body，非摘要），且排除瞬时表；
- 鉴权拒非 moderator：outsider 与 readonly watch token 对 export/reconcile 均 403；
- 健康频道对账 `ok:true` 无 divergence；
- 人造 D1↔DO 分裂（直接 UPDATE D1 `archived_at`，DO 仍非归档）→ 检出 `archived` divergence。

先 `cd web && bun run build`，再 `cd worker && bunx vitest run test/backup-reconcile.spec.ts` 4 pass；worker + cli `tsc --noEmit` 均通过；management-audit-coverage/channels/share-links 回归 22 pass。

## Follow-up（本 PR 未做）

- reconcile 仅报告不修复：可选 `--fix` 从 D1 权威重推 DO（走 channelHeaders /internal/init）留后续。
- 文档化恢复 runbook：从导出物或 D1 time-travel 重建 DO 状态（DO SQLite 无原生 time-travel）。
- export/reconcile 端点补 OpenAPI 注册（现 share-links 等亦未注册，保持一致）。
- 全量/多频道批量导出脚本（当前按频道，`party channel list` 可循环）。

涉及 #422，待 host 验收。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增 `party channel export`：按指定频道导出格式化备份 JSON，支持输出到终端或指定文件，并包含导出版本与导出时间。
  - 新增 `party channel reconcile`：执行频道状态对账，支持文本/JSON 输出；一致显示 `in sync`，不一致列出漂移字段并以 0/1 作为退出码。
  - 新增频道级备份导出与对账能力：仅频道版主可用，并记录导出审计信息。
- **文档**
  - 新增频道备份与恢复 Runbook，覆盖核验、故障场景与安全边界。
- **测试**
  - 增加频道导出/对账端到端测试（校验结构与权限、以及 DO↔D1 分裂对账结果）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->