### PR TITLE
fix(cli): health --channel 读取对应频道槽位 (#428)

### DIFF
--- a/cli/src/commands/health.ts
+++ b/cli/src/commands/health.ts
@@ -78,7 +78,7 @@ export async function run(argv: string[]): Promise<number> {
   const staleAfterMs = staleAfterFlag ?? DEFAULT_STALE_AFTER_MS;
   const channel = str(flags.channel);
 
-  const report = buildHealthReport(readHealthCache(), { channel, staleAfterMs });
+  const report = buildHealthReport(readHealthCache(process.cwd(), channel), { channel, staleAfterMs });
 
   if (flags.json === true) {
     console.log(JSON.stringify(report, null, 2));

--- a/cli/test/health-command.test.ts
+++ b/cli/test/health-command.test.ts
@@ -76,6 +76,18 @@ describe("party health", () => {
     expect(code).toBe(2);
   });
 
+  test("--channel reads its canonical slot instead of the last-written workspace mirror", async () => {
+    const now = Date.now();
+    writeHealthCache({ channel: "dev", ws_connected: true, reconnecting: false, last_frame_at: now }, cwd);
+    writeHealthCache({ channel: "ops", ws_connected: true, reconnecting: false, last_frame_at: now }, cwd);
+
+    const code = await run(["--channel", "dev", "--json"]);
+    expect(code).toBe(0);
+    const report = JSON.parse(logs.join(""));
+    expect(report.channel).toBe("dev");
+    expect(report.healthy).toBe(true);
+  });
+
   test("text output includes a one-line operator hint", async () => {
     writeHealthCache({ channel: "dev", ws_connected: false, reconnecting: true, reconnect_count: 3 }, cwd);
     const code = await run([]);


### PR DESCRIPTION
## 改动说明

- `party health --channel` 读取规范 per-channel slot，不再误读最后写入的 workspace 兼容镜像。
- 新增双频道回归测试，确保后写入的另一个频道不会污染查询。

## 合并前检查（review-ack 强制闸）

- [x] `bun test ./cli/test/health-command.test.ts`：8/8。
- [x] CLI `tsc --noEmit`。
- [x] `git diff --check`。

Closes #428

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复健康检查在指定 `--channel` 时读取错误缓存来源的问题。
  * 健康报告现可正确反映对应工作目录与频道的健康状态、过期情况及频道匹配结果。

* **Tests**
  * 新增针对频道缓存读取和健康状态判断的验证。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->