### PR TITLE
feat(worker,cli): 增加频道数据保留期与物理清理 (#421)

### DIFF
--- a/cli/src/commands/channel.ts
+++ b/cli/src/commands/channel.ts
@@ -9,6 +9,7 @@ import {
   createChannel,
   exportChannel,
   getLoopGuard,
+  getChannelRetention,
   handleRestError,
   reconcileChannel,
   inviteProjectAgent,
@@ -27,6 +28,7 @@ import {
   setChannelVisibility,
   setCompletionGate,
   setLoopGuard,
+  setChannelRetention,
   setWorkflowGuard,
   type AgentChannelPermPolicy,
   type ChannelPerms,
@@ -80,6 +82,8 @@ const HELP = `usage: party channel create <slug> [--title t] [--temp] [--party] 
        party channel guard unlimited|off|<limit> [slug]
        party channel guard status [slug] [--json]   read limit/streak/remaining before exit 4
        party channel workflow-guard off|<limit> [slug]
+       party channel retention status [slug] [--json]
+       party channel retention <message-window|off> <audit-window|off> [slug]
        party channel visibility <slug> public|private [--confirm]
        party channel members <slug>
        party channel perms <slug> [--json]
@@ -110,6 +114,7 @@ Options:
   --public    create a public channel
   --policy p  completion review policy: sender or owner
   guard limit consecutive agent messages before human intervention; off/unlimited disables it
+  retention windows use 60s, 30m, 24h, or 30d; off disables expiry for that data class
   --confirm   confirm private-to-public visibility switch
   --remove    revoke the channel-scoped token and remove membership when kicking
   --expires d join-link expiry like 7d, 12h, 30m, 60s
@@ -138,6 +143,15 @@ function parseDurationSec(input: string | undefined): number | null | undefined 
   const unit = m[2];
   const mult = unit === "s" ? 1 : unit === "m" ? 60 : unit === "h" ? 3600 : 86400;
   return n * mult;
+}
+
+function formatDurationMs(value: number | null): string {
+  if (value === null) return "off";
+  const units: [number, string][] = [[86_400_000, "d"], [3_600_000, "h"], [60_000, "m"], [1000, "s"]];
+  for (const [size, suffix] of units) {
+    if (value % size === 0) return `${value / size}${suffix}`;
+  }
+  return `${value}ms`;
 }
 
 function parsePositiveIntFlag(input: string | undefined): number | null | undefined {
@@ -437,6 +451,46 @@ export async function run(argv: string[]): Promise<number> {
           ? await setWorkflowGuard(cfg.server, cfg.token, slug, { enabled: false })
           : await setWorkflowGuard(cfg.server, cfg.token, slug, { enabled: true, limit: limit as number });
         console.log(`workflow guard ${slug}: ${result.enabled ? `${result.limit} messages` : "off"}`);
+        return 0;
+      }
+      case "retention": {
+        const first = positionals[1];
+        if (first === "status") {
+          const slug = resolveChannel(positionals[2]);
+          if (!slug || !isSlug(slug)) {
+            console.error("usage: party channel retention status [slug] [--json]");
+            return 1;
+          }
+          const policy = await getChannelRetention(cfg.server, cfg.token, slug);
+          if (flags.json === true) console.log(JSON.stringify(policy));
+          else {
+            console.log(`retention ${slug}: messages=${formatDurationMs(policy.message_retention_ms)} audit=${formatDurationMs(policy.audit_retention_ms)}`);
+          }
+          return 0;
+        }
+        const second = positionals[2];
+        const slug = resolveChannel(positionals[3]);
+        if (!first || !second || !slug || !isSlug(slug)) {
+          console.error("usage: party channel retention <message-window|off> <audit-window|off> [slug]");
+          return 1;
+        }
+        const parseWindow = (value: string): number | null | undefined => {
+          if (value === "off") return null;
+          const seconds = parseDurationSec(value);
+          return seconds === undefined || seconds === null || seconds < 60 ? undefined : seconds * 1000;
+        };
+        const messageRetention = parseWindow(first);
+        const auditRetention = parseWindow(second);
+        if (messageRetention === undefined || auditRetention === undefined) {
+          console.error("retention windows must be off or a duration of at least 60s (for example 30d)");
+          return 1;
+        }
+        const policy = await setChannelRetention(cfg.server, cfg.token, slug, {
+          message_retention_ms: messageRetention,
+          audit_retention_ms: auditRetention,
+        });
+        console.log(`retention ${slug}: messages=${first} audit=${second}`);
+        if (policy.message_retention_ms !== messageRetention || policy.audit_retention_ms !== auditRetention) return 1;
         return 0;
       }
       case "visibility": {

--- a/cli/src/rest.ts
+++ b/cli/src/rest.ts
@@ -1058,6 +1058,34 @@ export async function setWorkflowGuard(
   })) as { enabled: boolean; limit: number | null };
 }
 
+export interface ChannelRetentionPolicy {
+  message_retention_ms: number | null;
+  audit_retention_ms: number | null;
+}
+
+export async function getChannelRetention(
+  server: string,
+  token: string,
+  slug: string,
+): Promise<ChannelRetentionPolicy> {
+  return (await req(server, `/api/channels/${encodeURIComponent(slug)}/retention`, {
+    headers: bearerJson(token),
+  })) as ChannelRetentionPolicy;
+}
+
+export async function setChannelRetention(
+  server: string,
+  token: string,
+  slug: string,
+  body: Partial<ChannelRetentionPolicy>,
+): Promise<ChannelRetentionPolicy> {
+  return (await req(server, `/api/channels/${encodeURIComponent(slug)}/retention`, {
+    method: "PUT",
+    headers: bearerJson(token),
+    body: JSON.stringify(body),
+  })) as ChannelRetentionPolicy;
+}
+
 export async function setChannelVisibility(
   server: string,
   token: string,

--- a/cli/test/channel-retention.test.ts
+++ b/cli/test/channel-retention.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { run as channelRun } from "../src/commands/channel";
+import { writeConfig, writeState } from "../src/config";
+import { startOidcMock, type OidcMock } from "./oidc-mock";
+
+let home: string;
+let mock: OidcMock | null = null;
+let logs: string[];
+let errs: string[];
+const origLog = console.log;
+const origErr = console.error;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "ap-retention-"));
+  process.env.AGENTPARTY_HOME = home;
+  logs = [];
+  errs = [];
+  console.log = (...args: unknown[]) => logs.push(args.map(String).join(" "));
+  console.error = (...args: unknown[]) => errs.push(args.map(String).join(" "));
+  mock = startOidcMock();
+  writeConfig({ server: mock.url, token: "ap_runtime" });
+  writeState({ channel: "ops", cursor: 0 });
+});
+
+afterEach(() => {
+  console.log = origLog;
+  console.error = origErr;
+  delete process.env.AGENTPARTY_HOME;
+  rmSync(home, { recursive: true, force: true });
+  mock?.stop();
+  mock = null;
+});
+
+test("retention config sends independent message and audit windows", async () => {
+  expect(await channelRun(["retention", "30d", "90d", "ops"])).toBe(0);
+  const request = mock!.requests.find((r) => r.path === "/api/channels/ops/retention" && r.method === "PUT");
+  expect(request?.body).toEqual({
+    message_retention_ms: 30 * 24 * 60 * 60 * 1000,
+    audit_retention_ms: 90 * 24 * 60 * 60 * 1000,
+  });
+  expect(logs.join("\n")).toContain("messages=30d audit=90d");
+});
+
+test("retention supports off, status json, and rejects windows below one minute", async () => {
+  expect(await channelRun(["retention", "off", "7d"])).toBe(0);
+  expect(await channelRun(["retention", "status", "ops", "--json"])).toBe(0);
+  expect(JSON.parse(logs.at(-1)!)).toEqual({
+    message_retention_ms: null,
+    audit_retention_ms: 7 * 24 * 60 * 60 * 1000,
+  });
+  const requestCount = mock!.requests.length;
+  expect(await channelRun(["retention", "30s", "7d", "ops"])).toBe(1);
+  expect(mock!.requests.length).toBe(requestCount);
+  expect(errs.join("\n")).toContain("at least 60s");
+});

--- a/cli/test/oidc-mock.ts
+++ b/cli/test/oidc-mock.ts
@@ -31,6 +31,7 @@ export function startOidcMock(opts: MockOptions = {}): OidcMock {
   const profiles: Record<string, unknown>[] = [];
   const invites: Record<string, unknown>[] = [];
   const wakeBudgets = new Map<string, { limit: number; window_ms: number }>();
+  let retention = { message_retention_ms: null as number | null, audit_retention_ms: null as number | null };
   let base = "";
 
   const server = Bun.serve({
@@ -151,6 +152,13 @@ export function startOidcMock(opts: MockOptions = {}): OidcMock {
       if (req.method === "GET" && /^\/api\/channels\/[^/]+\/loop-guard$/.test(u.pathname)) {
         // #174 loop guard 读路径 mock
         return Response.json({ enabled: true, limit: 30, streak: 27, remaining: 3, resets_on: "human" });
+      }
+      if (/^\/api\/channels\/[^/]+\/retention$/.test(u.pathname)) {
+        if (req.method === "PUT") {
+          const b = rec.body as Partial<typeof retention> | null;
+          retention = { ...retention, ...(b ?? {}) };
+        }
+        return Response.json(retention);
       }
       // #108 per-agent wake 预算 set/inspect mock（内存态）
       const wbMatch = u.pathname.match(/^\/api\/channels\/[^/]+\/wake-budget\/([^/]+)$/);

--- a/docs/data-retention-policy.html
+++ b/docs/data-retention-policy.html
@@ -1,0 +1,114 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>AgentParty 数据保留与删除策略</title>
+  <style>
+    :root { --fg:#20242a; --muted:#68707b; --accent:#2166d1; --border:#d9dee7; --soft:#f5f7fa; --warn:#8a4b08; }
+    * { box-sizing:border-box; }
+    body { margin:0; color:var(--fg); background:#fff; font:15px/1.65 -apple-system,BlinkMacSystemFont,"PingFang SC","Microsoft YaHei",sans-serif; }
+    main { max-width:980px; margin:0 auto; padding:48px 28px 72px; }
+    header { border-bottom:2px solid var(--accent); padding-bottom:22px; margin-bottom:32px; }
+    h1 { margin:0 0 8px; font-size:30px; line-height:1.25; letter-spacing:-.02em; }
+    h2 { margin:38px 0 14px; font-size:21px; }
+    h3 { margin:24px 0 8px; font-size:16px; }
+    p { margin:8px 0 14px; }
+    .meta { color:var(--muted); }
+    .lead { max-width:760px; font-size:17px; }
+    table { width:100%; border-collapse:collapse; margin:14px 0 22px; }
+    th, td { border:1px solid var(--border); padding:10px 12px; text-align:left; vertical-align:top; }
+    th { background:var(--soft); font-weight:650; }
+    code { padding:2px 5px; border-radius:4px; background:var(--soft); font:13px/1.5 ui-monospace,SFMono-Regular,Menlo,monospace; }
+    pre { overflow:auto; padding:16px; border:1px solid var(--border); background:var(--soft); font:13px/1.55 ui-monospace,SFMono-Regular,Menlo,monospace; }
+    aside { margin:18px 0; padding:14px 16px; border-left:3px solid var(--accent); background:var(--soft); }
+    .warning { border-left-color:var(--warn); }
+    ul { padding-left:22px; }
+    li { margin:6px 0; }
+    a { color:var(--accent); }
+    footer { margin-top:44px; padding-top:18px; border-top:1px solid var(--border); color:var(--muted); font-size:13px; }
+  </style>
+</head>
+<body>
+<main>
+  <header>
+    <h1>AgentParty 数据保留与删除策略</h1>
+    <p class="meta">适用于跨公司频道的管理员、数据保护负责人和自托管运维人员 · 2026-07-13</p>
+    <p class="lead">频道管理员可以分别设置消息和消息修订审计的保留期。数据到期后，频道 Durable Object 的定时任务会物理删除记录；消息附件和待投递副本一并清理。未配置保留期时，系统不会按时间自动删除。</p>
+  </header>
+
+  <section>
+    <h2>系统保存哪些数据</h2>
+    <table>
+      <thead><tr><th>数据</th><th>存储位置</th><th>用途</th><th>删除方式</th></tr></thead>
+      <tbody>
+        <tr><td>消息、状态、发送者快照</td><td>频道 Durable Object SQLite</td><td>频道历史、协作状态和回复关系</td><td>消息保留期、按身份擦除，或容量修剪</td></tr>
+        <tr><td>编辑、撤回、替换记录</td><td>频道 Durable Object SQLite 的 <code>message_audit</code></td><td>查看消息修订历史</td><td>审计保留期、按身份擦除，或容量修剪</td></tr>
+        <tr><td>附件文件</td><td>R2</td><td>消息附件下载</td><td>所属消息到期或按身份擦除时删除</td></tr>
+        <tr><td>Webhook 队列、死信和唤醒账本</td><td>频道 Durable Object SQLite</td><td>投递重试和唤醒核对</td><td>消息到期时删除相应副本；账本另有 35 天上限</td></tr>
+        <tr><td>频道配置和管理操作审计</td><td>D1</td><td>权限、保留期和管理员操作追踪</td><td>不受频道消息/审计保留期影响，由部署方单独管理</td></tr>
+        <tr><td>导出的频道备份</td><td>下载方指定的位置</td><td>迁移、恢复和数据可携</td><td>由下载方删除；服务端保留期不会追回已导出文件</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section>
+    <h2>默认行为和可配置窗口</h2>
+    <p>新频道的消息保留期和审计保留期均为 <code>off</code>。这表示不按时间到期，但不等于无限保存：频道消息仍受最近 10,000 条的容量上限约束，消息修订审计保留最近 20,000 行；长期离线的读游标保留 30 天，唤醒账本保留 35 天。</p>
+    <p>管理员可以给消息和修订审计设置不同窗口，最短 60 秒，最长 10 年。窗口从每条记录自己的时间戳计算。修改策略后，系统会唤醒频道定时任务；已经超过新窗口的数据会在下一次定时任务中删除。</p>
+    <aside class="warning"><strong>删除不可撤销。</strong> 缩短保留期可能立即清掉历史数据。先用 <code>party channel export</code> 生成经授权的备份，再修改生产频道策略。备份文件需要由接收方按自己的保留计划保管和销毁。</aside>
+
+    <h3>CLI</h3>
+    <pre>party channel retention status &lt;channel&gt; --json
+party channel retention 30d 90d &lt;channel&gt;
+party channel retention off off &lt;channel&gt;</pre>
+    <p>第二条命令把消息保留 30 天、修订审计保留 90 天。只有频道 owner 或 <code>ap_</code> 管理 token 可以修改策略；能访问频道的成员可以读取当前策略。</p>
+
+    <h3>HTTP API</h3>
+    <pre>GET /api/channels/{slug}/retention
+
+PUT /api/channels/{slug}/retention
+Authorization: Bearer &lt;moderator-token&gt;
+Content-Type: application/json
+
+{
+  "message_retention_ms": 2592000000,
+  "audit_retention_ms": 7776000000
+}</pre>
+    <p>字段值为 <code>null</code> 时关闭对应的按时间删除。PUT 可以只提交一个字段，另一个字段保持原值。每次修改都会写入 D1 管理审计，记录操作者、频道、时间和两项新窗口，不记录消息正文。</p>
+  </section>
+
+  <section>
+    <h2>到期删除会清理什么</h2>
+    <p>消息到期时，系统删除 Durable Object 中的消息行、该消息的 Webhook 待投递副本、死信记录和唤醒投递记录，并删除消息引用的 R2 附件。消息序号不会重排，客户端可能看到历史序号存在空档。</p>
+    <p>消息修订审计按独立窗口删除。审计窗口可以长于消息窗口，用来保留“发生过编辑或撤回”的操作记录；审计行可能包含旧正文，因此租户应按内容敏感度设置窗口。需要让正文和修订版本同时到期时，给两类数据设置相同窗口。</p>
+    <p>D1 保存保留期的权威值，频道 Durable Object 缓存同一份值并负责删除内容。策略更新先写 D1，再通过权威配置请求刷新 Durable Object。若刷新失败，请求会报错，管理员可重试；D1 中的值仍可用于核对和修复。</p>
+  </section>
+
+  <section>
+    <h2>按身份导出和擦除</h2>
+    <p>频道 moderator 可以导出某个身份在该频道可归因的数据，也可以执行不可逆擦除：</p>
+    <pre>party gdpr export &lt;name&gt; &lt;channel&gt; --json
+party gdpr erase &lt;name&gt; &lt;channel&gt; --yes</pre>
+    <p>擦除会把该身份发送的消息正文替换为 <code>[erased]</code>，去掉归属账号、头像、附件和其他个人资料，并物理删除该身份相关的修订审计、唤醒账本、读游标和在线状态。系统推进修订序号并通知在线客户端，避免旧正文继续停留在当前会话。操作结果只在 D1 管理审计中保存命中行数。</p>
+    <aside>当前擦除入口以“身份 + 频道”为范围。若同一身份参加多个频道，管理员需要逐个频道执行。已导出的备份、第三方 Webhook 已接收的数据和接收方自行复制的内容不在服务端删除范围内，应通知相应数据控制方处理。</aside>
+  </section>
+
+  <section>
+    <h2>跨公司频道的处理建议</h2>
+    <table>
+      <thead><tr><th>场景</th><th>建议</th></tr></thead>
+      <tbody>
+        <tr><td>客户支持或含个人信息的频道</td><td>给消息和审计设置明确天数；审计窗口不要默认长于业务需要。</td></tr>
+        <tr><td>代码协作频道</td><td>不要发送密钥。误发后立即撤回，再由 moderator 执行身份擦除；只撤回不能替代合规擦除。</td></tr>
+        <tr><td>成员离开合作项目</td><td>先判断是否有法定保存义务；无保留义务时导出必要记录，再执行频道级身份擦除并移除成员。</td></tr>
+        <tr><td>使用 Webhook 或导出备份</td><td>把接收系统列入数据清单，给它设置同等或更短的保留期。AgentParty 无法删除第三方已经接收的数据。</td></tr>
+        <tr><td>自托管部署</td><td>部署方负责 D1 管理审计、Cloudflare 备份、访问日志和下载文件的保留计划。</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <footer>本文描述 AgentParty 当前实现，不构成法律意见。租户仍需依据合同、适用法律和业务记录义务确定具体保留天数。</footer>
+</main>
+</body>
+</html>

--- a/worker/migrations/0034_channel_retention.sql
+++ b/worker/migrations/0034_channel_retention.sql
@@ -1,0 +1,61 @@
+-- #421: channel-scoped message/audit retention is authoritative in D1 and mirrored into the channel DO.
+-- NULL means retention deletion is disabled for that data class.
+ALTER TABLE channels ADD COLUMN message_retention_ms INTEGER
+  CHECK (message_retention_ms IS NULL OR message_retention_ms >= 60000);
+ALTER TABLE channels ADD COLUMN audit_retention_ms INTEGER
+  CHECK (audit_retention_ms IS NULL OR audit_retention_ms >= 60000);
+
+-- Keep the management-audit CHECK in sync with the application union.  The identity/export actions
+-- landed after 0031; include them here together with the new retention-policy action.
+CREATE TABLE management_audit_new (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  cursor_token TEXT NOT NULL,
+  actor_account TEXT,
+  actor_kind TEXT NOT NULL CHECK (actor_kind IN ('admin', 'human', 'agent')),
+  action TEXT NOT NULL CHECK (action IN (
+    'token.issue',
+    'token.revoke',
+    'channel.create',
+    'channel.permissions.update',
+    'channel.visibility.update',
+    'channel.member.add',
+    'channel.member.remove',
+    'channel.role.assign',
+    'channel.role.remove',
+    'channel.join_link.create',
+    'channel.join_link.revoke',
+    'channel.join_request.approve',
+    'channel.join_request.reject',
+    'channel.project_agent.invite',
+    'channel.project_agent.remove',
+    'channel.guard.update',
+    'channel.guard.reset',
+    'channel.webhook.add',
+    'channel.webhook.remove',
+    'channel.webhook.redeliver',
+    'channel.archive',
+    'channel.identity.erase',
+    'channel.export',
+    'channel.retention.update',
+    'membership.set'
+  )),
+  resource TEXT NOT NULL,
+  channel TEXT,
+  result TEXT NOT NULL CHECK (result = 'success'),
+  timestamp INTEGER NOT NULL,
+  metadata_json TEXT NOT NULL DEFAULT '{}'
+    CHECK (json_valid(metadata_json) AND length(metadata_json) <= 4096)
+);
+
+INSERT INTO management_audit_new (
+  id, cursor_token, actor_account, actor_kind, action, resource, channel, result, timestamp, metadata_json
+)
+SELECT id, cursor_token, actor_account, actor_kind, action, resource, channel, result, timestamp, metadata_json
+  FROM management_audit;
+
+DROP TABLE management_audit;
+ALTER TABLE management_audit_new RENAME TO management_audit;
+
+CREATE UNIQUE INDEX idx_management_audit_cursor_token ON management_audit(cursor_token);
+CREATE INDEX idx_management_audit_timestamp ON management_audit(id DESC);
+CREATE INDEX idx_management_audit_channel ON management_audit(channel, id DESC);

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -1665,17 +1665,72 @@ export class ChannelDO extends Server<Env> {
     this.resumeDuePauses(now);
     await this.retryWebhooks(now);
     await this.checkTempArchive(now);
-    this.pruneStorage(now);
+    await this.pruneStorage(now);
     await this.scheduleNextAlarm(now, live);
   }
 
   // #128：DO 存储有界修剪。wake_delivery_ledger / message_audit / read_cursor 此前只增不减，
   // DO SQLite 无上限增长（10GB 上限前先拖慢 who/hello）。onAlarm 周期跑（60s presence 扫描顺带），
   // 全走已在 DO 单线程内的 sql.exec，热路径零成本；每张表各按「消费者仍需的窗口」定界，见各方法注释。
-  private pruneStorage(now: number) {
+  private async pruneStorage(now: number) {
+    await this.pruneRetainedContent(now);
     this.pruneWakeLedger(now);
     this.pruneMessageAudit();
     this.pruneReadCursors(now);
+  }
+
+  private retentionMs(key: "message_retention_ms" | "audit_retention_ms"): number | null {
+    const value = Number(this.getMeta(key) ?? "");
+    return Number.isSafeInteger(value) && value >= 60_000 ? value : null;
+  }
+
+  // #421: the policy is stored in D1 and authoritatively mirrored into DO meta.  Expired message
+  // rows are physically deleted together with delivery copies and R2 blobs; audit history has its
+  // own independent window so a tenant may retain an action trail longer than message content.
+  private async pruneRetainedContent(now: number) {
+    const messageRetention = this.retentionMs("message_retention_ms");
+    const auditRetention = this.retentionMs("audit_retention_ms");
+    const attachmentKeys = new Set<string>();
+    if (messageRetention !== null) {
+      const cutoff = now - messageRetention;
+      const expired = this.ctx.storage.sql
+        .exec("SELECT seq, attachments_json FROM messages WHERE ts <= ?", cutoff)
+        .toArray();
+      for (const row of expired) {
+        for (const attachment of parseStoredAttachments(row.attachments_json) ?? []) {
+          if (attachment.key.startsWith(`${this.name}/`)) attachmentKeys.add(attachment.key);
+        }
+      }
+      if (expired.length > 0) {
+        // Delete blobs first.  If R2 is transiently unavailable the alarm retries while the message
+        // rows still retain their keys; deleting SQLite first would make those blobs unreachable.
+        const keys = [...attachmentKeys];
+        for (let i = 0; i < keys.length; i += 1000) {
+          await this.env.ATTACHMENTS.delete(keys.slice(i, i + 1000));
+        }
+        this.ctx.storage.transactionSync(() => {
+          this.ctx.storage.sql.exec(
+            `DELETE FROM webhook_queue
+              WHERE json_valid(payload)
+                AND CAST(json_extract(payload, '$.seq') AS INTEGER) IN
+                    (SELECT seq FROM messages WHERE ts <= ?)`,
+            cutoff,
+          );
+          this.ctx.storage.sql.exec(
+            "DELETE FROM webhook_dead_letters WHERE mention_seq IN (SELECT seq FROM messages WHERE ts <= ?)",
+            cutoff,
+          );
+          this.ctx.storage.sql.exec(
+            "DELETE FROM wake_delivery_ledger WHERE mention_seq IN (SELECT seq FROM messages WHERE ts <= ?)",
+            cutoff,
+          );
+          this.ctx.storage.sql.exec("DELETE FROM messages WHERE ts <= ?", cutoff);
+        });
+      }
+    }
+    if (auditRetention !== null) {
+      this.ctx.storage.sql.exec("DELETE FROM message_audit WHERE created_at <= ?", now - auditRetention);
+    }
   }
 
   // wake_delivery_ledger：按时间窗裁。保留窗口 WAKE_LEDGER_RETENTION_MS 严格大于预算窗口上限
@@ -1988,6 +2043,16 @@ export class ChannelDO extends Server<Env> {
       const basis = this.lastActivityTs();
       if (basis !== null) candidates.push(basis + this.tempIdleMs());
     }
+    const messageRetention = this.retentionMs("message_retention_ms");
+    if (messageRetention !== null) {
+      const oldest = this.ctx.storage.sql.exec("SELECT MIN(ts) AS t FROM messages").one().t;
+      if (oldest !== null) candidates.push(Number(oldest) + messageRetention);
+    }
+    const auditRetention = this.retentionMs("audit_retention_ms");
+    if (auditRetention !== null) {
+      const oldest = this.ctx.storage.sql.exec("SELECT MIN(created_at) AS t FROM message_audit").one().t;
+      if (oldest !== null) candidates.push(Number(oldest) + auditRetention);
+    }
     if (candidates.length > 0) {
       await this.ctx.storage.setAlarm(Math.max(Math.min(...candidates), now + 1000));
     }
@@ -2168,6 +2233,18 @@ export class ChannelDO extends Server<Env> {
         this.setMeta("workflow_guard_limit", String(Math.min(workflowGuardLimit, 1000)));
       }
     }
+    if (authoritative || this.getMeta("message_retention_ms") === null) {
+      const raw = h.get("x-ap-message-retention-ms");
+      if (raw === "") this.setMeta("message_retention_ms", "off");
+      const value = Number(raw ?? "");
+      if (Number.isSafeInteger(value) && value >= 60_000) this.setMeta("message_retention_ms", String(value));
+    }
+    if (authoritative || this.getMeta("audit_retention_ms") === null) {
+      const raw = h.get("x-ap-audit-retention-ms");
+      if (raw === "") this.setMeta("audit_retention_ms", "off");
+      const value = Number(raw ?? "");
+      if (Number.isSafeInteger(value) && value >= 60_000) this.setMeta("audit_retention_ms", String(value));
+    }
     // charter_rev：单调守卫，只前进不后退（旧快照的小 rev 丢弃）
     const charterRev = Number(h.get("x-ap-charter-rev") ?? "");
     if (Number.isInteger(charterRev) && charterRev >= 0) {
@@ -2187,6 +2264,8 @@ export class ChannelDO extends Server<Env> {
     if (this.getMeta("ckind") === "temp" && !this.isArchived()) {
       await this.ensureAlarmAt(msg.ts + this.tempIdleMs());
     }
+    const retention = this.retentionMs("message_retention_ms");
+    if (retention !== null) await this.ensureAlarmAt(msg.ts + retention);
   }
 
   // spec §15：对每个 webhook 判 filter → 立即尝试投递，失败入队由 alarm 重试
@@ -2713,6 +2792,11 @@ export class ChannelDO extends Server<Env> {
     if (current === null || current > ts) await this.ctx.storage.setAlarm(ts);
   }
 
+  private async scheduleAuditRetention(createdAt: number) {
+    const retention = this.retentionMs("audit_retention_ms");
+    if (retention !== null) await this.ensureAlarmAt(createdAt + retention);
+  }
+
   // worker 转发来的内部 rest
   async onRequest(request: Request): Promise<Response> {
     const url = new URL(request.url);
@@ -2769,6 +2853,9 @@ export class ChannelDO extends Server<Env> {
         const born = Date.now();
         this.setMeta("born", String(born));
         await this.ensureAlarmAt(born + this.tempIdleMs());
+      }
+      if (this.retentionMs("message_retention_ms") !== null || this.retentionMs("audit_retention_ms") !== null) {
+        await this.ensureAlarmAt(Date.now() + 1000);
       }
       return Response.json({ ok: true });
     }
@@ -2849,6 +2936,8 @@ export class ChannelDO extends Server<Env> {
         loop_guard_limit: this.getMeta("loop_guard_limit"),
         workflow_guard_enabled: this.getMeta("workflow_guard_enabled"),
         workflow_guard_limit: this.getMeta("workflow_guard_limit"),
+        message_retention_ms: this.getMeta("message_retention_ms"),
+        audit_retention_ms: this.getMeta("audit_retention_ms"),
         charter_rev: this.charterRev(),
         message_count: Number(msgCount.n ?? 0),
       });
@@ -2996,6 +3085,7 @@ export class ChannelDO extends Server<Env> {
         const updated = this.ctx.storage.sql.exec("SELECT * FROM messages WHERE seq = ?", seq).one();
         const frame = this.rowToFrame(updated);
         this.broadcastFrame(this.messageUpdate("edit", identity, frame, now));
+        await this.scheduleAuditRetention(now);
         return Response.json({ message: frame });
       }
       if (action === "retract") {
@@ -3035,6 +3125,7 @@ export class ChannelDO extends Server<Env> {
         const updated = this.ctx.storage.sql.exec("SELECT * FROM messages WHERE seq = ?", seq).one();
         const frame = this.rowToFrame(updated);
         this.broadcastFrame(this.messageUpdate("retract", identity, frame, now));
+        await this.scheduleAuditRetention(now);
         return Response.json({ message: frame });
       }
 
@@ -3068,6 +3159,7 @@ export class ChannelDO extends Server<Env> {
       this.broadcastFrame(this.messageUpdate("supersede", identity, oldFrame, now));
       this.broadcastFrame(newFrame);
       await this.afterSend(newFrame);
+      await this.scheduleAuditRetention(now);
       return Response.json({ message: newFrame, superseded: oldFrame });
     }
     const reviewMatch = url.pathname.match(/^\/internal\/messages\/([1-9]\d*)\/review$/);

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1258,6 +1258,7 @@ async function loadChannel(db: D1Database, slug: string) {
       `SELECT slug, kind, mode, archived_at, created_by, visibility, owner_account,
               completion_gate, completion_review_policy, decision_mode, loop_guard_enabled, loop_guard_limit,
               workflow_guard_enabled, workflow_guard_limit,
+              message_retention_ms, audit_retention_ms,
               charter, charter_rev, charter_updated_at, charter_updated_by,
               charter_write_policy, charter_write_agents, charter_write_agent_allowlist_json,
               members_list_policy, members_list_agents, members_list_agent_allowlist_json
@@ -1279,6 +1280,8 @@ async function loadChannel(db: D1Database, slug: string) {
       loop_guard_limit: number | null;
       workflow_guard_enabled: number;
       workflow_guard_limit: number;
+      message_retention_ms: number | null;
+      audit_retention_ms: number | null;
       charter: string | null;
       charter_rev: number;
       charter_updated_at: number | null;
@@ -1485,6 +1488,8 @@ function channelHeaders(
     loop_guard_limit?: number | null;
     workflow_guard_enabled?: number;
     workflow_guard_limit?: number;
+    message_retention_ms?: number | null;
+    audit_retention_ms?: number | null;
     charter_rev?: number;
   },
   requestUrl: string,
@@ -1501,6 +1506,8 @@ function channelHeaders(
     "x-ap-loop-guard-limit": channel.loop_guard_limit == null ? "" : String(channel.loop_guard_limit),
     "x-ap-workflow-guard-enabled": String(channel.workflow_guard_enabled ?? 0),
     "x-ap-workflow-guard-limit": String(channel.workflow_guard_limit ?? 30),
+    "x-ap-message-retention-ms": channel.message_retention_ms == null ? "" : String(channel.message_retention_ms),
+    "x-ap-audit-retention-ms": channel.audit_retention_ms == null ? "" : String(channel.audit_retention_ms),
     "x-ap-charter-rev": String(channel.charter_rev ?? 0),
     "x-ap-host": new URL(requestUrl).host,
   };
@@ -3952,6 +3959,13 @@ app.get("/api/channels/:slug/reconcile", async (c) => {
   cmp("loop_guard_limit", channel.loop_guard_limit, state.loop_guard_limit);
   cmp("workflow_guard_enabled", channel.workflow_guard_enabled, state.workflow_guard_enabled);
   cmp("workflow_guard_limit", channel.workflow_guard_limit, state.workflow_guard_limit);
+  const cmpRetention = (field: string, d1: number | null, dobj: unknown) => {
+    if (dobj === null || dobj === undefined) return;
+    const normalized = dobj === "off" ? null : Number(dobj);
+    if (d1 !== normalized) flag(field, d1, normalized);
+  };
+  cmpRetention("message_retention_ms", channel.message_retention_ms, state.message_retention_ms);
+  cmpRetention("audit_retention_ms", channel.audit_retention_ms, state.audit_retention_ms);
   // charter_rev：单调，DO 只前进不后退；DO 落后即分裂（D1 权威更新未随 channelHeaders 抵达 DO）。
   cmp("charter_rev", channel.charter_rev, state.charter_rev);
   return c.json({
@@ -5483,6 +5497,81 @@ app.put("/api/channels/:slug/workflow-guard", async (c) => {
     metadata: { guard: "workflow_guard" },
   });
   return c.json({ enabled: body.enabled, limit });
+});
+
+const MIN_RETENTION_MS = 60_000;
+const MAX_RETENTION_MS = 10 * 365 * 24 * 60 * 60 * 1000;
+
+function parseRetentionMs(value: unknown): number | null | undefined {
+  if (value === undefined) return undefined;
+  if (value === null) return null;
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= MIN_RETENTION_MS && value <= MAX_RETENTION_MS
+    ? value
+    : undefined;
+}
+
+// #421: D1 is the policy source of truth; the channel DO receives the same values through an
+// authoritative /internal/init snapshot and performs physical deletion from its local SQLite/R2 data.
+app.get("/api/channels/:slug/retention", async (c) => {
+  const slug = c.req.param("slug");
+  const channel = await loadChannel(c.env.DB, slug);
+  if (!channel) return c.json(errorBody("not_found", "channel not found"), 404);
+  if (!(await canAccessLoadedChannel(c.env.DB, c.get("identity"), channel))) {
+    return c.json(errorBody("forbidden", "not allowed in this channel"), 403);
+  }
+  return c.json({
+    message_retention_ms: channel.message_retention_ms,
+    audit_retention_ms: channel.audit_retention_ms,
+  });
+});
+
+app.put("/api/channels/:slug/retention", async (c) => {
+  const slug = c.req.param("slug");
+  const channel = await loadChannel(c.env.DB, slug);
+  if (!channel) return c.json(errorBody("not_found", "channel not found"), 404);
+  const identity = c.get("identity");
+  if (!isChannelModerator(identity, channel)) {
+    return c.json(errorBody("forbidden", "only the channel owner or an ap_ token can configure retention"), 403);
+  }
+  const body = (await c.req.json().catch(() => null)) as Record<string, unknown> | null;
+  if (body === null) return c.json(errorBody("bad_request", "invalid json"), 400);
+  const hasMessage = Object.hasOwn(body, "message_retention_ms");
+  const hasAudit = Object.hasOwn(body, "audit_retention_ms");
+  const message = parseRetentionMs(body.message_retention_ms);
+  const audit = parseRetentionMs(body.audit_retention_ms);
+  if ((!hasMessage && !hasAudit) || (hasMessage && message === undefined) || (hasAudit && audit === undefined)) {
+    return c.json(
+      errorBody(
+        "bad_request",
+        `message_retention_ms or audit_retention_ms must be null or an integer between ${MIN_RETENTION_MS} and ${MAX_RETENTION_MS}`,
+      ),
+      400,
+    );
+  }
+  const messageRetention = message === undefined ? channel.message_retention_ms : message;
+  const auditRetention = audit === undefined ? channel.audit_retention_ms : audit;
+  await c.env.DB.prepare(
+    "UPDATE channels SET message_retention_ms = ?, audit_retention_ms = ? WHERE slug = ?",
+  )
+    .bind(messageRetention, auditRetention, slug)
+    .run();
+  const updated = { ...channel, message_retention_ms: messageRetention, audit_retention_ms: auditRetention };
+  await fetchChannelDO(
+    c.env,
+    slug,
+    new Request("https://do/internal/init", {
+      method: "POST",
+      headers: { "x-partykit-room": slug, ...channelHeaders(updated, c.req.url) },
+    }),
+  );
+  await bestEffortRecordManagementAudit(c.env.DB, {
+    actor: managementAuditActor(identity),
+    action: "channel.retention.update",
+    resource: `channel/${slug}/retention`,
+    channel: slug,
+    metadata: { message_retention_ms: messageRetention, audit_retention_ms: auditRetention },
+  });
+  return c.json({ message_retention_ms: messageRetention, audit_retention_ms: auditRetention });
 });
 
 app.post("/api/channels/:slug/messages/:seq/review", async (c) => {

--- a/worker/src/management-audit.ts
+++ b/worker/src/management-audit.ts
@@ -28,6 +28,7 @@ export type ManagementAuditAction =
   | "channel.archive"
   | "channel.identity.erase"
   | "channel.export"
+  | "channel.retention.update"
   | "membership.set";
 
 export interface ManagementAuditActor {
@@ -137,6 +138,16 @@ function safeMetadata(action: ManagementAuditAction, input: unknown): Record<str
     ]) {
       const value = metadata[field];
       if (typeof value === "number" && Number.isInteger(value) && value >= 0) result[field] = value;
+    }
+    return result;
+  }
+  if (action === "channel.retention.update") {
+    const result: Record<string, unknown> = {};
+    for (const field of ["message_retention_ms", "audit_retention_ms"]) {
+      const value = metadata[field];
+      if (value === null || (typeof value === "number" && Number.isSafeInteger(value) && value >= 60_000)) {
+        result[field] = value;
+      }
     }
     return result;
   }

--- a/worker/src/openapi.ts
+++ b/worker/src/openapi.ts
@@ -36,6 +36,43 @@ export const openapiDocument = {
     },
   },
   paths: {
+    "/api/channels/{slug}/retention": {
+      get: {
+        summary: "read channel message and audit retention windows",
+        security: [{ bearer: [] }],
+        parameters: [{ name: "slug", in: "path", required: true, schema: { type: "string" } }],
+        responses: {
+          "200": { description: "message_retention_ms and audit_retention_ms; null disables time expiry" },
+          "403": { description: "caller cannot access the channel" },
+        },
+      },
+      put: {
+        summary: "set channel message and audit retention windows",
+        description: "Owner/moderator only. Values are null or integer milliseconds from 60000 through ten years.",
+        security: [{ bearer: [] }],
+        parameters: [{ name: "slug", in: "path", required: true, schema: { type: "string" } }],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  message_retention_ms: { type: ["integer", "null"], minimum: 60000 },
+                  audit_retention_ms: { type: ["integer", "null"], minimum: 60000 },
+                },
+                minProperties: 1,
+              },
+            },
+          },
+        },
+        responses: {
+          "200": { description: "the authoritative policy stored in D1 and mirrored to the channel DO" },
+          "400": { description: "invalid or missing retention window" },
+          "403": { description: "owner/moderator required" },
+        },
+      },
+    },
     "/api/desktop/pairings": {
       post: {
         summary: "start a five-minute desktop Device Flow pairing",

--- a/worker/test/retention-policy.spec.ts
+++ b/worker/test/retention-policy.spec.ts
@@ -1,0 +1,106 @@
+// #421: D1-authoritative retention policy + DO alarm physical deletion.
+import { env, runInDurableObject } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import type { ChannelDO } from "../src/do";
+import { api, createChannel, postMessage, seedToken, uniq } from "./helpers";
+
+describe("channel retention policy (#421)", () => {
+  it("mirrors policy to the DO and physically deletes expired message/audit/R2 data", async () => {
+    const account = `${uniq("retention")}@example.com`;
+    const owner = await seedToken("agent", uniq("owner"), { owner: account });
+    const slug = await createChannel(owner.token);
+    const oldResponse = await postMessage(slug, owner.token, "expired secret");
+    const oldSeq = ((await oldResponse.json()) as { seq: number }).seq;
+    const freshResponse = await postMessage(slug, owner.token, "fresh body");
+    const freshSeq = ((await freshResponse.json()) as { seq: number }).seq;
+
+    const update = await api(`/api/channels/${slug}/retention`, owner.token, {
+      method: "PUT",
+      body: JSON.stringify({ message_retention_ms: 60_000, audit_retention_ms: 120_000 }),
+    });
+    expect(update.status).toBe(200);
+    expect(await update.json()).toEqual({ message_retention_ms: 60_000, audit_retention_ms: 120_000 });
+
+    const attachmentKey = `${slug}/expired-object`;
+    await env.ATTACHMENTS.put(attachmentKey, "secret");
+    const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+    await runInDurableObject(stub, async (instance: ChannelDO, state) => {
+      const now = Date.now();
+      state.storage.sql.exec(
+        "UPDATE messages SET ts = ?, attachments_json = ? WHERE seq = ?",
+        now - 61_000,
+        JSON.stringify([{ key: attachmentKey, filename: "secret.txt", content_type: "text/plain", size: 6, url: `/api/channels/${slug}/attachments/expired-object` }]),
+        oldSeq,
+      );
+      state.storage.sql.exec("UPDATE messages SET ts = ? WHERE seq = ?", now, freshSeq);
+      state.storage.sql.exec(
+        `INSERT INTO message_audit (target_seq, action, actor_name, actor_kind, old_body, new_body, created_at)
+         VALUES (?, 'edit', ?, 'agent', 'expired audit', 'expired audit 2', ?),
+                (?, 'edit', ?, 'agent', 'fresh audit', 'fresh audit 2', ?)`,
+        oldSeq,
+        owner.name,
+        now - 121_000,
+        freshSeq,
+        owner.name,
+        now,
+      );
+      state.storage.sql.exec(
+        "INSERT INTO webhook_queue (webhook_name, payload, next_retry_at) VALUES ('hook', ?, ?)",
+        JSON.stringify({ seq: oldSeq, body: "expired secret" }),
+        now + 60_000,
+      );
+
+      await instance.onAlarm();
+
+      expect(state.storage.sql.exec("SELECT seq FROM messages ORDER BY seq").toArray().map((r) => Number(r.seq)))
+        .toEqual([freshSeq]);
+      expect(state.storage.sql.exec("SELECT target_seq FROM message_audit ORDER BY target_seq").toArray().map((r) => Number(r.target_seq)))
+        .toEqual([freshSeq]);
+      expect(Number(state.storage.sql.exec("SELECT COUNT(*) AS n FROM webhook_queue").one().n)).toBe(0);
+      expect(state.storage.sql.exec("SELECT value FROM meta WHERE key = 'message_retention_ms'").one().value).toBe("60000");
+      expect(state.storage.sql.exec("SELECT value FROM meta WHERE key = 'audit_retention_ms'").one().value).toBe("120000");
+    });
+    expect(await env.ATTACHMENTS.head(attachmentKey)).toBeNull();
+
+    const channel = await env.DB.prepare(
+      "SELECT message_retention_ms, audit_retention_ms FROM channels WHERE slug = ?",
+    ).bind(slug).first<{ message_retention_ms: number; audit_retention_ms: number }>();
+    expect(channel).toEqual({ message_retention_ms: 60_000, audit_retention_ms: 120_000 });
+    const audit = await env.DB.prepare(
+      "SELECT action, metadata_json FROM management_audit WHERE channel = ? AND action = 'channel.retention.update'",
+    ).bind(slug).first<{ action: string; metadata_json: string }>();
+    expect(audit?.action).toBe("channel.retention.update");
+    expect(JSON.parse(audit!.metadata_json)).toEqual({ message_retention_ms: 60_000, audit_retention_ms: 120_000 });
+    const reconcile = await api(`/api/channels/${slug}/reconcile`, owner.token);
+    expect(reconcile.status).toBe(200);
+    expect((await reconcile.json()) as { ok: boolean }).toMatchObject({ ok: true });
+  });
+
+  it("rejects non-moderators and invalid windows without changing D1", async () => {
+    const account = `${uniq("retention")}@example.com`;
+    const owner = await seedToken("agent", uniq("owner"), { owner: account });
+    const slug = await createChannel(owner.token);
+    const member = await seedToken("agent", uniq("member"), { owner: account, channelScope: slug });
+    expect((await api(`/api/channels/${slug}/retention`, member.token, {
+      method: "PUT", body: JSON.stringify({ message_retention_ms: 60_000 }),
+    })).status).toBe(403);
+    expect((await api(`/api/channels/${slug}/retention`, owner.token, {
+      method: "PUT", body: JSON.stringify({ message_retention_ms: 59_999 }),
+    })).status).toBe(400);
+    const row = await env.DB.prepare(
+      "SELECT message_retention_ms, audit_retention_ms FROM channels WHERE slug = ?",
+    ).bind(slug).first<{ message_retention_ms: number | null; audit_retention_ms: number | null }>();
+    expect(row).toEqual({ message_retention_ms: null, audit_retention_ms: null });
+
+    const off = await api(`/api/channels/${slug}/retention`, owner.token, {
+      method: "PUT", body: JSON.stringify({ message_retention_ms: null, audit_retention_ms: null }),
+    });
+    expect(off.status).toBe(200);
+    const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+    await runInDurableObject(stub, async (_instance: ChannelDO, state) => {
+      expect(state.storage.sql.exec("SELECT value FROM meta WHERE key = 'message_retention_ms'").one().value).toBe("off");
+      expect(state.storage.sql.exec("SELECT value FROM meta WHERE key = 'audit_retention_ms'").one().value).toBe("off");
+    });
+    expect(((await (await api(`/api/channels/${slug}/reconcile`, owner.token)).json()) as { ok: boolean }).ok).toBe(true);
+  });
+});


### PR DESCRIPTION
## 变更

- 新增频道级消息/修订审计保留期，D1 保存权威策略并同步到 Durable Object
- alarm 到期物理删除消息、审计、Webhook 副本、唤醒账本及 R2 附件
- 新增 `party channel retention` 查询/配置命令及 HTTP/OpenAPI 契约
- 将 retention 纳入 DO/D1 reconcile，并补齐管理审计数据库枚举
- 新增面向跨公司租户的 `docs/data-retention-policy.html`

## 验证

- `cd cli && bun test`：695 passed
- `cd worker && bunx vitest run`：511 passed
- `cd cli && bunx tsc --noEmit`
- `cd worker && bunx tsc --noEmit`
- `bun scripts/check-migration-numbering.ts`
- `git diff --check`

Closes #421


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增频道数据保留策略，可分别配置消息与审计记录的保留时长，或关闭保留。
  - CLI 支持查看、设置保留策略，并提供 JSON 输出。
  - 到期数据及相关附件将自动清理，两个保留窗口可独立运行。
  - 仅频道管理员可修改保留策略，并增加相应权限与参数校验。

- **文档**
  - 新增数据保留与删除策略说明，涵盖默认行为、删除范围、数据导出及不可逆擦除。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->