### PR TITLE
feat: 消息展示发送方 CLI 版本 + 落后提示 (#434)

### DIFF
--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -363,6 +363,9 @@ export interface Sender {
   /** OAuth/SSO profile avatar URL. Optional; clients may render initials when absent. */
   avatar_url?: string;
   avatar_thumb?: string;
+  /** 发送这条消息时 sender 的 CLI package version（发送即快照，随消息帧下发；#434）。
+   *  仅带 x-ap-client-version 的 CLI 发送才有；网页/旧客户端/无头请求缺失时省略。旧消费方忽略。 */
+  client_version?: string;
   /** 同一身份当前活跃连接数。仅 >1 时下发，用于提示 token/session 被重复使用。 */
   connection_count?: number;
 }

--- a/web/src/components/MessageCard.clientVersion.test.tsx
+++ b/web/src/components/MessageCard.clientVersion.test.tsx
@@ -1,0 +1,64 @@
+// #434：消息头展示发送方 CLI 版本徽标（cli vX）。落后判定依赖服务端 /api/version 的 min_client_version，
+// bun 单测（react-test-renderer，无 window）下 useMinClientVersion 恒为 null，故这里只验证「版本文本渲染 /
+// 无版本时不渲染」；落后转琥珀 + ⚠ 的比较逻辑由 lib/clientVersion.test.ts 单测覆盖。
+// @ts-expect-error Bun executes this test, while the web tsconfig intentionally loads only Vite globals.
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { act, create, type ReactTestInstance, type ReactTestRenderer } from "react-test-renderer";
+import type { MsgFrame } from "@agentparty/shared";
+import { LocaleProvider } from "../i18n/locale";
+
+mock.module("../lib/markdown", () => ({ renderMarkdown: (s: string) => s }));
+const { MessageCard } = await import("./MessageCard");
+
+let renderer: ReactTestRenderer | null = null;
+const noop = () => undefined;
+
+beforeEach(() => {
+  Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", { configurable: true, value: true });
+  Object.defineProperty(globalThis, "localStorage", { configurable: true, value: {
+    getItem: () => "en", setItem() {}, removeItem() {}, clear() {}, key: () => null, length: 0,
+  } });
+});
+
+afterEach(() => {
+  act(() => renderer?.unmount());
+  renderer = null;
+});
+
+function render(msg: MsgFrame): ReactTestInstance {
+  act(() => {
+    renderer = create(<LocaleProvider><MessageCard
+      msg={msg} self={null} quotedMessage={null} canModerate={false} onReply={noop} onEdit={noop}
+      onRetract={noop} canCreateTask={false} onCreateTask={noop} editing={false} editDraft=""
+      editSaving={false} actionError={null} busy={false} onEditDraftChange={noop} onEditCancel={noop} onEditSave={noop}
+    /></LocaleProvider>);
+  });
+  return renderer!.root;
+}
+
+function versionBadges(root: ReactTestInstance): ReactTestInstance[] {
+  return root.findAll((n) => n.type === "span" && String(n.props.className ?? "").includes("msg-client-version"));
+}
+
+const base = {
+  type: "msg", seq: 7, kind: "message", body: "hi", mentions: [], reply_to: null,
+  state: null, note: null, status: null, ts: 1_700_000_000_000,
+} as const;
+
+describe("MessageCard sender CLI version (#434)", () => {
+  test("sender.client_version 有值 → 渲染 cli vX 徽标", () => {
+    const msg = { ...base, sender: { name: "planner", kind: "agent", client_version: "0.3.1" } } as unknown as MsgFrame;
+    const badges = versionBadges(render(msg));
+    expect(badges.length).toBeGreaterThan(0);
+    const text = badges[0]!.children.filter((c) => typeof c === "string").join("");
+    expect(text).toContain("cli v");
+    expect(text).toContain("0.3.1");
+    // min 未知（测试环境无 window）→ 不标落后。
+    expect(badges.some((b) => String(b.props.className ?? "").includes("--outdated"))).toBe(false);
+  });
+
+  test("sender 无 client_version → 不渲染徽标", () => {
+    const msg = { ...base, sender: { name: "planner", kind: "agent" } } as unknown as MsgFrame;
+    expect(versionBadges(render(msg))).toHaveLength(0);
+  });
+});

--- a/web/src/components/MessageCard.tsx
+++ b/web/src/components/MessageCard.tsx
@@ -4,6 +4,7 @@ import type { AgentContext, MsgFrame, PresenceEntry, ReadCursor, Sender } from "
 import { memo, useEffect, useRef, useState } from "react";
 import type { CSSProperties } from "react";
 import { agentHue } from "../lib/agentColor";
+import { isClientVersionOutdated, useMinClientVersion } from "../lib/clientVersion";
 import { displayForIdentity, resolveSenderLabel, type IdentityDisplayMap } from "../lib/identityDisplay";
 import { readStateFor } from "../lib/readList";
 import { summarizeReplyPreview } from "../lib/replyPreview";
@@ -154,6 +155,7 @@ function MessageCardImpl({
   onDecisionRespond,
 }: Props) {
   const t = useT();
+  const minClientVersion = useMinClientVersion();
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
   const [copied, setCopied] = useState(false);
   const [statusExpanded, setStatusExpanded] = useState(false);
@@ -171,6 +173,9 @@ function MessageCardImpl({
       : { readers: [], unread: [] };
   // owner/email 无论是否被 handle 取代，都作为防冒充锚点保留在下方副标签 + tooltip 中（见 senderTitle）。
   const senderLabel = resolveSenderLabel(msg.sender, identityDisplay);
+  // #434：发送方 CLI 版本（发送时快照）。落后于服务端最低版本时标警告；未知版本/未拉到下限时不标。
+  const clientVersion = msg.sender.client_version ?? null;
+  const clientOutdated = isClientVersionOutdated(clientVersion, minClientVersion);
   const owner = msg.sender.owner && msg.sender.owner !== senderLabel ? msg.sender.owner : null;
   const lineage = msg.sender.lineage ?? null;
   const lineageLabel = lineage === null ? null : `child of ${lineage.parent_agent}`;
@@ -390,6 +395,23 @@ function MessageCardImpl({
         <span className={"msg-kind" + (msg.sender.kind === "human" ? " msg-kind--human" : "")}>
           {msg.sender.kind}
         </span>
+        {clientVersion !== null && (
+          <span
+            className={"t-mono msg-client-version" + (clientOutdated ? " msg-client-version--outdated" : "")}
+            title={
+              clientOutdated
+                ? t("MessageCard.clientVersion.outdated", { version: clientVersion, min: minClientVersion ?? "" })
+                : t("MessageCard.clientVersion.title", { version: clientVersion })
+            }
+          >
+            cli v{clientVersion}
+            {clientOutdated && (
+              <span className="msg-client-version-warn" aria-hidden="true">
+                {" "}⚠
+              </span>
+            )}
+          </span>
+        )}
         {msg.mentions.map((m) => {
           // #274：@提及悬停也能看到该名字的实时状态；原始名与显示名不同时保留 @原名防冒充锚点。
           const mentionTitle = [

--- a/web/src/i18n/strings/MessageCard.ts
+++ b/web/src/i18n/strings/MessageCard.ts
@@ -26,6 +26,8 @@ export const MessageCardStrings: LocaleDict = {
     "MessageCard.decision.awaiting": "awaiting a human decision",
     "MessageCard.decision.resolved": "resolved → {option}",
     "MessageCard.decision.autoResolved": "auto-resolved (unattended) → {option}",
+    "MessageCard.clientVersion.title": "sender CLI version v{version}",
+    "MessageCard.clientVersion.outdated": "sender CLI v{version} is behind the recommended v{min} — upgrade suggested",
   },
   zh: {
     "MessageCard.badge.edited": "已编辑",
@@ -52,6 +54,8 @@ export const MessageCardStrings: LocaleDict = {
     "MessageCard.decision.awaiting": "等待人类决策",
     "MessageCard.decision.resolved": "已决 → {option}",
     "MessageCard.decision.autoResolved": "自动放行（无人值守）→ {option}",
+    "MessageCard.clientVersion.title": "发送方 CLI 版本 v{version}",
+    "MessageCard.clientVersion.outdated": "发送方 CLI v{version} 落后于推荐版本 v{min}，建议升级",
   },
 };
 

--- a/web/src/lib/clientVersion.test.ts
+++ b/web/src/lib/clientVersion.test.ts
@@ -1,0 +1,39 @@
+// #434：发送方 CLI 版本比较 + 落后判定。规则须与 worker/src/client-version.ts 一致（只认前三段数字）。
+// @ts-expect-error Bun executes this test, while the web tsconfig intentionally loads only Vite globals.
+import { describe, expect, test } from "bun:test";
+import { compareClientVersions, isClientVersionOutdated } from "./clientVersion";
+
+describe("compareClientVersions (#434)", () => {
+  test("按前三段数字比较", () => {
+    expect(compareClientVersions("0.3.1", "0.3.0")).toBe(1);
+    expect(compareClientVersions("0.2.9", "0.3.0")).toBe(-1);
+    expect(compareClientVersions("1.0.0", "1.0.0")).toBe(0);
+  });
+
+  test("忽略预发行后缀（第四段及 -beta 等）", () => {
+    expect(compareClientVersions("0.3.1-beta.2", "0.3.1")).toBe(0);
+    expect(compareClientVersions("0.3.1", "0.3.1-rc.1")).toBe(0);
+  });
+
+  test("缺段按 0 补齐", () => {
+    expect(compareClientVersions("1", "1.0.0")).toBe(0);
+    expect(compareClientVersions("1.2", "1.2.0")).toBe(0);
+  });
+});
+
+describe("isClientVersionOutdated (#434)", () => {
+  test("严格低于最低版本 → 落后", () => {
+    expect(isClientVersionOutdated("0.2.0", "0.3.0")).toBe(true);
+  });
+
+  test("等于或高于最低版本 → 不落后", () => {
+    expect(isClientVersionOutdated("0.3.0", "0.3.0")).toBe(false);
+    expect(isClientVersionOutdated("0.4.0", "0.3.0")).toBe(false);
+  });
+
+  test("版本或下限未知 → 一律不判落后（不误伤）", () => {
+    expect(isClientVersionOutdated(null, "0.3.0")).toBe(false);
+    expect(isClientVersionOutdated("0.2.0", null)).toBe(false);
+    expect(isClientVersionOutdated(undefined, undefined)).toBe(false);
+  });
+});

--- a/web/src/lib/clientVersion.ts
+++ b/web/src/lib/clientVersion.ts
@@ -1,0 +1,70 @@
+// 发送方 CLI 版本展示 + 落后判定（#434）。
+// 消息帧的 sender.client_version 是「发送时快照」；服务端 /api/version 声明当前 min_client_version。
+// 低于该下限即视为落后，网页在该条消息旁标警告符号，提示升级。
+//
+// 版本比较规则与 worker/src/client-version.ts 的 compareClientVersions、cli/src/upgrade.ts 完全一致：
+// 只认前三段数字（X.Y.Z），忽略 -beta.1 等预发行后缀，三端对 min-version 的判定不分叉。
+import { useEffect, useState } from "react";
+import { apiUrl } from "./base";
+
+// a>b→1, a<b→-1, ==→0。
+export function compareClientVersions(a: string, b: string): number {
+  const pa = a.split(".").map((n) => Number.parseInt(n, 10) || 0);
+  const pb = b.split(".").map((n) => Number.parseInt(n, 10) || 0);
+  for (let i = 0; i < 3; i++) {
+    const d = (pa[i] ?? 0) - (pb[i] ?? 0);
+    if (d !== 0) return d > 0 ? 1 : -1;
+  }
+  return 0;
+}
+
+// 发送方版本严格低于服务端最低版本 → 落后。任一为空则「未知」，一律不判落后（不误伤）。
+export function isClientVersionOutdated(version: string | null | undefined, min: string | null | undefined): boolean {
+  if (!version || !min) return false;
+  return compareClientVersions(version, min) < 0;
+}
+
+// 服务端声明的最低客户端版本，全站只拉一次并缓存；解析失败/离线一律回落 null（=未知，不标落后）。
+let cachedMin: string | null = null;
+let inflight: Promise<void> | null = null;
+const listeners = new Set<() => void>();
+
+function fetchMinClientVersion(): Promise<void> {
+  if (inflight !== null) return inflight;
+  inflight = fetch(apiUrl("/api/version"), { headers: { accept: "application/json" } })
+    .then((res) => (res.ok ? res.json() : null))
+    .then((data: unknown) => {
+      const min =
+        data !== null && typeof data === "object" && typeof (data as { min_client_version?: unknown }).min_client_version === "string"
+          ? (data as { min_client_version: string }).min_client_version
+          : null;
+      if (min !== null && min !== cachedMin) {
+        cachedMin = min;
+        for (const notify of listeners) notify();
+      }
+    })
+    .catch(() => {
+      // 版本端点拿不到就当未知——宁可不标落后，也不误报。
+    })
+    .finally(() => {
+      inflight = null;
+    });
+  return inflight;
+}
+
+// 读取服务端最低客户端版本。首个消费方触发一次拉取，拉到后所有订阅者一并重渲染。
+// 非浏览器环境（如 bun 单测的 react-test-renderer）无 window，直接返回 null，不发网络请求。
+export function useMinClientVersion(): string | null {
+  const [min, setMin] = useState<string | null>(cachedMin);
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const update = () => setMin(cachedMin);
+    listeners.add(update);
+    if (cachedMin === null) void fetchMinClientVersion();
+    else update();
+    return () => {
+      listeners.delete(update);
+    };
+  }, []);
+  return min;
+}

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -2641,6 +2641,17 @@
   background: var(--d-blue-soft);
   white-space: nowrap;
 }
+/* #434：发送方 CLI 版本徽标；落后于服务端最低版本时转琥珀色 + ⚠。 */
+.msg-client-version {
+  font-size: 10px;
+  color: var(--t-dim);
+  white-space: nowrap;
+}
+.msg-client-version--outdated {
+  color: var(--d-amber);
+  font-weight: 600;
+}
+.msg-client-version-warn { color: var(--d-amber); }
 .msg-context {
   display: inline-block;
   max-width: min(180px, 34vw);

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -102,6 +102,8 @@ interface ConnState {
   serveClaimSeq?: number;
   // 上次已通告给本连接的持租状态，用于去重：只在 held 变化时才补发 serve_lease 帧。
   serveLeaseHeld?: boolean;
+  // #434：本连接最近一次 hello 上报的 CLI package version，供 WS send 快照进消息 sender_client_version。
+  clientVersion?: string;
 }
 
 const LEGACY_SESSION_ID = "__legacy__";
@@ -121,6 +123,9 @@ interface Identity {
   collabRoleSource?: CollaborationRoleSource;
   // #381：public_watch 写门信号（worker 权威）。缺省/false 且频道为 public_watch → handleSend 拒发。
   canWrite?: boolean;
+  // #434：发送方 CLI 版本（x-ap-client-version）。WS 取自 hello 快照进连接态，REST 取自请求头。
+  // 落库快照到消息 sender_client_version 列并随帧下发；缺头/网页请求为 undefined。
+  clientVersion?: string;
 }
 
 interface WebhookDeliveryResult {
@@ -697,7 +702,7 @@ function lineageFromHeaders(headers: Headers): AgentLineage | undefined {
   return lineage ?? undefined;
 }
 
-function senderFromIdentity(identity: Pick<Identity, "name" | "kind" | "owner" | "handle" | "displayName" | "avatarUrl" | "avatarThumb" | "lineage">): Sender {
+function senderFromIdentity(identity: Pick<Identity, "name" | "kind" | "owner" | "handle" | "displayName" | "avatarUrl" | "avatarThumb" | "lineage" | "clientVersion">): Sender {
   return {
     name: identity.name,
     kind: identity.kind,
@@ -707,6 +712,7 @@ function senderFromIdentity(identity: Pick<Identity, "name" | "kind" | "owner" |
     ...(identity.displayName === undefined ? {} : { display_name: identity.displayName }),
     ...(identity.avatarUrl === undefined ? {} : { avatar_url: identity.avatarUrl }),
     ...(identity.avatarThumb === undefined ? {} : { avatar_thumb: identity.avatarThumb }),
+    ...(identity.clientVersion === undefined ? {} : { client_version: identity.clientVersion }),
   };
 }
 
@@ -1093,6 +1099,10 @@ export class ChannelDO extends Server<Env> {
       "ALTER TABLE messages ADD COLUMN idempotency_key TEXT",
       // 附件引用（#176）：存 Attachment[] 的 JSON，仅元数据（key/filename/type/size/url），blob 在 R2。
       "ALTER TABLE messages ADD COLUMN attachments_json TEXT",
+      // 发送方 CLI 版本快照（#434）：发送即定格 sender 的 x-ap-client-version，随消息帧/历史下发，
+      // 网页据此显示「该条来自哪个 CLI 版本」，落后于服务端最低版本时标警告。同 messages 其余列走 DO 内建
+      // SQLite 幂等补列（非 D1 迁移）。缺头/网页/旧客户端为 NULL，消费方省略展示。
+      "ALTER TABLE messages ADD COLUMN sender_client_version TEXT",
     ]) {
       try {
         sql.exec(ddl);
@@ -1519,7 +1529,11 @@ export class ChannelDO extends Server<Env> {
     }
     if (frame.type === "hello") {
       const clientVersion = parseClientVersion(frame.client_version);
-      if (clientVersion !== null) this.recordClientVersion(st.name, connection.id, clientVersion, Date.now());
+      if (clientVersion !== null) {
+        this.recordClientVersion(st.name, connection.id, clientVersion, Date.now());
+        // #434：把版本快照进连接态，供本连接后续 send 落库到消息 sender_client_version（无需每条再解析头）。
+        st = connection.setState({ ...st, clientVersion }) ?? st;
+      }
       const since = typeof frame.since === "number" && frame.since > 0 ? Math.floor(frame.since) : 0;
       const sinceRev =
         typeof frame.since_rev === "number" && frame.since_rev >= 0 ? Math.floor(frame.since_rev) : null;
@@ -1620,6 +1634,7 @@ export class ChannelDO extends Server<Env> {
           collabRole: st.collabRole,
           collabRoleSource: st.collabRoleSource,
           canWrite: st.canWrite,
+          clientVersion: st.clientVersion,
         },
         send,
         { countRate: false, sessionId: connection.id },
@@ -3024,6 +3039,8 @@ export class ChannelDO extends Server<Env> {
         collabRole: parseCollaborationRole(request.headers.get("x-ap-collab-role") ?? undefined) ?? undefined,
         collabRoleSource: parseRoleSource(request.headers.get("x-ap-role-source") ?? undefined) ?? undefined,
         canWrite: request.headers.get("x-ap-can-write") === "1",
+        // #434：REST 发送方 CLI 版本（index.ts 已把 x-ap-client-version 转发进来），快照进消息 sender_client_version。
+        clientVersion: parseClientVersion(request.headers.get("x-ap-client-version")) ?? undefined,
       };
       if (this.isArchived()) {
         return Response.json({ error: { code: "archived", message: "channel is archived" } }, { status: 410 });
@@ -3178,6 +3195,8 @@ export class ChannelDO extends Server<Env> {
         collabRole: parseCollaborationRole(request.headers.get("x-ap-collab-role") ?? undefined) ?? undefined,
         collabRoleSource: parseRoleSource(request.headers.get("x-ap-role-source") ?? undefined) ?? undefined,
         canWrite: request.headers.get("x-ap-can-write") === "1",
+        // #434：REST 发送方 CLI 版本（index.ts 已把 x-ap-client-version 转发进来），快照进消息 sender_client_version。
+        clientVersion: parseClientVersion(request.headers.get("x-ap-client-version")) ?? undefined,
       };
       if (this.isArchived()) {
         return Response.json({ error: { code: "archived", message: "channel is archived" } }, { status: 410 });
@@ -3281,6 +3300,8 @@ export class ChannelDO extends Server<Env> {
         collabRole: parseCollaborationRole(request.headers.get("x-ap-collab-role") ?? undefined) ?? undefined,
         collabRoleSource: parseRoleSource(request.headers.get("x-ap-role-source") ?? undefined) ?? undefined,
         canWrite: request.headers.get("x-ap-can-write") === "1",
+        // #434：REST 发送方 CLI 版本（index.ts 已把 x-ap-client-version 转发进来），快照进消息 sender_client_version。
+        clientVersion: parseClientVersion(request.headers.get("x-ap-client-version")) ?? undefined,
       };
       // moderator 由 worker 层（isChannelModerator）算好后转发；DO 只信这一位。
       const isModerator = request.headers.get("x-ap-moderator") === "1";
@@ -3502,6 +3523,8 @@ export class ChannelDO extends Server<Env> {
         collabRole: parseCollaborationRole(request.headers.get("x-ap-collab-role") ?? undefined) ?? undefined,
         collabRoleSource: parseRoleSource(request.headers.get("x-ap-role-source") ?? undefined) ?? undefined,
         canWrite: request.headers.get("x-ap-can-write") === "1",
+        // #434：REST 发送方 CLI 版本（index.ts 已把 x-ap-client-version 转发进来），快照进消息 sender_client_version。
+        clientVersion: parseClientVersion(request.headers.get("x-ap-client-version")) ?? undefined,
       };
       let raw: unknown;
       try {
@@ -4009,9 +4032,9 @@ export class ChannelDO extends Server<Env> {
          status_decision_json, status_workflow_json, message_workflow_json,
          sender_role, sender_role_source, completion_artifact_json, completion_review_state, completion_review_policy,
          completion_review_replaces_seq, decision_request_json, decision_state, decision_resolution_json,
-         idempotency_key, attachments_json, ts
+         idempotency_key, attachments_json, sender_client_version, ts
        )
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       seq,
       identity.name,
       identity.kind,
@@ -4049,6 +4072,7 @@ export class ChannelDO extends Server<Env> {
         : JSON.stringify(decisionResolution),
       frame.idempotency_key ?? null,
       attachments === undefined ? null : JSON.stringify(attachments),
+      identity.clientVersion ?? null,
       now,
     );
     let replacedUpdate: MessageUpdateFrame | undefined;
@@ -5242,6 +5266,8 @@ export class ChannelDO extends Server<Env> {
         ...(r.sender_display_name === null || r.sender_display_name === undefined ? {} : { display_name: String(r.sender_display_name) }),
         ...(r.sender_avatar_url === null || r.sender_avatar_url === undefined ? {} : { avatar_url: String(r.sender_avatar_url) }),
         ...(r.sender_avatar_thumb === null || r.sender_avatar_thumb === undefined ? {} : { avatar_thumb: String(r.sender_avatar_thumb) }),
+        // #434：历史回放/修订帧也带上发送时快照的 CLI 版本，网页展示与 live 帧一致。
+        ...(r.sender_client_version === null || r.sender_client_version === undefined ? {} : { client_version: String(r.sender_client_version) }),
       },
       kind,
       body: retracted ? "[retracted]" : String(r.body),

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1782,6 +1782,13 @@ function assignedRoleHeaders(role: CollaborationRole | null): Record<string, str
   return role === null ? {} : { "x-ap-collab-role": role, "x-ap-role-source": "assigned" };
 }
 
+// #434：把发送方 CLI 的 x-ap-client-version 透传给 DO，供 handleSend 快照进消息 sender_client_version。
+// 仅带且合法时透传（非法/缺失一律不带，DO 侧 parseClientVersion 再校验一次）。网页/无头请求天然无此头。
+function clientVersionForwardHeaders(c: Context<AppContext>): Record<string, string> {
+  const raw = c.req.header(CLIENT_VERSION_HEADER);
+  return raw ? { [CLIENT_VERSION_HEADER]: raw } : {};
+}
+
 // 人类 handle 头：仅当身份是人类且已设 handle 才带（权威值，供 do 盖 presence + stamp 消息，Task A6/A7）。
 // #165：agent 身份则带自己的 nickname（同样走 x-ap-handle，复用 do 的 presence/sender 展示管线）。
 // x-ap-handle 一律 encodeURIComponent——人类 handle 是 ASCII 编码后原样不变，agent 中文昵称则需编码
@@ -5705,6 +5712,8 @@ app.post("/api/channels/:slug/messages/:seq/:action", async (c) => {
         // 超越会被 fail-closed 拦下。edit/retract 不经 handleSend，多带此位无害。
         ...(await writeGateHeaders(c.env.DB, identity, channel)),
         ...(await handleHeader(c.env.DB, identity)),
+        // #434：supersede 走 handleSend 落新消息，透传 CLI 版本，与直接发送一致。
+        ...clientVersionForwardHeaders(c),
       },
     }),
   );
@@ -5933,6 +5942,7 @@ app.post("/api/channels/:slug/messages", async (c) => {
         // #381：public_watch 写门信号——非成员/未被邀者在 public_watch 频道会被 DO handleSend 拒发
         ...(await writeGateHeaders(c.env.DB, identity, channel)),
         ...(await handleHeader(c.env.DB, identity)),
+        ...clientVersionForwardHeaders(c),
       },
     }),
   );

--- a/worker/test/message-client-version.spec.ts
+++ b/worker/test/message-client-version.spec.ts
@@ -1,0 +1,57 @@
+// #434：发送方 CLI 版本随消息落库 + 随消息帧/历史返回。
+// CLI 每次 REST 调用带 x-ap-client-version，服务端在 handleSend 时把它快照进消息 sender.client_version，
+// 供网页展示「该条来自哪个 CLI 版本」并对落后版本标警告。
+import { describe, expect, it } from "vitest";
+import { api, createChannel, seedToken } from "./helpers";
+
+interface MsgLike {
+  seq: number;
+  sender: { name: string; kind: string; client_version?: string };
+  body: string;
+}
+
+function sendWithClientVersion(slug: string, token: string, body: string, clientVersion?: string): Promise<Response> {
+  return api(`/api/channels/${slug}/messages`, token, {
+    method: "POST",
+    body: JSON.stringify({ kind: "message", body, mentions: [], reply_to: null }),
+    headers: clientVersion === undefined ? {} : { "x-ap-client-version": clientVersion },
+  });
+}
+
+describe("message sender client version (#434)", () => {
+  it("snapshots x-ap-client-version onto the message and returns it via history", async () => {
+    const { token } = await seedToken("agent");
+    const slug = await createChannel(token);
+
+    const res = await sendWithClientVersion(slug, token, "hello", "0.3.1");
+    expect(res.status).toBe(200);
+
+    const hist = await api(`/api/channels/${slug}/messages?since=0`, token);
+    const { messages } = (await hist.json()) as { messages: MsgLike[] };
+    expect(messages).toHaveLength(1);
+    expect(messages[0]!.sender.client_version).toBe("0.3.1");
+  });
+
+  it("omits client_version when the sender sends no version header (web/legacy)", async () => {
+    const { token } = await seedToken("agent");
+    const slug = await createChannel(token);
+
+    expect((await sendWithClientVersion(slug, token, "no version")).status).toBe(200);
+
+    const hist = await api(`/api/channels/${slug}/messages?since=0`, token);
+    const { messages } = (await hist.json()) as { messages: MsgLike[] };
+    expect(messages[0]!.sender.client_version).toBeUndefined();
+  });
+
+  it("rejects a malformed version header (falls back to omitted, never crashes send)", async () => {
+    const { token } = await seedToken("agent");
+    const slug = await createChannel(token);
+
+    // 空格/非法字符不满足 CLIENT_VERSION_RE → parseClientVersion 返回 null → 不落库。
+    expect((await sendWithClientVersion(slug, token, "bad ver", "not a version!!")).status).toBe(200);
+
+    const hist = await api(`/api/channels/${slug}/messages?since=0`, token);
+    const { messages } = (await hist.json()) as { messages: MsgLike[] };
+    expect(messages[0]!.sender.client_version).toBeUndefined();
+  });
+});


### PR DESCRIPTION
涉及 #434，待 host 验收（不 Closes）。

## 调研结论：后端原本做了多少
- CLI 每次 REST 调用都带 `x-ap-client-version` 头（`cli/src/rest.ts`），WS 则在 `hello` 帧带 `client_version`。
- worker 已有版本协商设施：`worker/src/client-version.ts`（`compareClientVersions` / `evaluateClientVersion` / `resolveMinClientVersion`）+ `/api/version` 暴露 `min_client_version` + MIN_CLIENT_VERSION 中间件。
- **但**：发送方版本此前只被记进 `presence` 表（`recordClientVersion`），**没有随消息持久化**——消息表无版本列，消息帧/历史里也查不到「该条来自哪个 CLI 版本」。所以网页无从展示。本 PR 补齐这一段。

## 改法
### 后端
- `messages` 表新增 `sender_client_version` 列（DO 内建 SQLite 幂等 `ALTER`，非 D1 迁移，与该表其余列同手法）。
- `Identity` / `ConnState` 增加 `clientVersion`：
  - WS：`hello` 时把版本快照进连接态，后续该连接的 send 直接取用。
  - REST：从转发头 `x-ap-client-version` 读取（`index.ts` 在发送 + supersede 两条会经 `handleSend` 的转发上透传该头给 DO）。
- `handleSend` 落库时快照该版本；`senderFromIdentity` + `rowToFrame` 把 `client_version` 挂到 `Sender`，live 帧与历史回放一致下发。
- `shared` 的 `Sender` 协议类型新增 `client_version?`。

### 前端
- 新增 `web/src/lib/clientVersion.ts`：`compareClientVersions` / `isClientVersionOutdated`（规则与 worker/cli 完全一致，只认前三段数字，忽略预发行后缀）+ `useMinClientVersion`（全站拉一次 `/api/version` 缓存；无 `window` 的单测环境恒返回 `null`，不误标落后）。
- `MessageCard` 头部展示 `cli vX` 徽标；落后于 `min_client_version` 时转琥珀 + `⚠`，悬停「发送方 CLI vX 落后于推荐版本 vY，建议升级」。i18n 走 `strings/MessageCard.ts`，样式加在 `app.css`。
- **未触碰 `App.tsx` / `Channel.tsx`**（MessageCard 经 hook 自足，避免与 #433 撞车）。

## 测试
- worker `test/message-client-version.spec.ts`：带头快照 / 缺头省略 / 非法头兜底不崩。
- web `lib/clientVersion.test.ts`（比较 + 落后判定）、`components/MessageCard.clientVersion.test.tsx`（徽标渲染 / 无版本不渲染）。
- 全量绿：worker `514 passed`、web `712 passed`；shared/worker/web `tsc --noEmit` 干净；`vite build` 通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 消息卡片现会显示发送方 CLI 版本。
  - 当版本低于最低支持版本时，会显示升级提示和警告标识。
  - 消息历史记录会保留发送时的 CLI 版本信息。
  - 未提供版本信息的网页、旧客户端或请求不会显示徽标。
- **测试**
  - 新增版本比较、过期判断及消息展示场景的测试覆盖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->