### PR TITLE
fix(web): 收紧加入申请备注校验

### DIFF
--- a/web/src/components/JoinRequestBanner.tsx
+++ b/web/src/components/JoinRequestBanner.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useT } from "../i18n/useT";
+import { JOIN_REQUEST_NOTE_MAX_LENGTH } from "../lib/joinRequestPending";
 import type { AuthProviderConfig } from "../lib/oidc";
 import "../i18n/strings/Channel";
 
@@ -40,7 +41,7 @@ export function JoinRequestBanner({ state, idleText, reason, errorMessage, provi
         <textarea
           className="joinrequest-note-input"
           value={note}
-          maxLength={2000}
+          maxLength={JOIN_REQUEST_NOTE_MAX_LENGTH}
           rows={2}
           placeholder={t("Channel.joinRequest.notePlaceholder")}
           onChange={(event) => setNote(event.target.value)}

--- a/web/src/lib/joinRequestPending.test.ts
+++ b/web/src/lib/joinRequestPending.test.ts
@@ -46,6 +46,12 @@ describe("pending watch-token join request storage", () => {
     expect(readPendingJoinRequest(1_001)).toEqual({ slug: "private-room", note: "", expiresAt: 901_000 });
   });
 
+  test("rejects an explicit null note instead of treating it as a legacy missing field", () => {
+    session.setItem("ap_pending_join_request", '{"slug":"private-room","note":null,"expiresAt":901000}');
+    expect(readPendingJoinRequest(1_001)).toBeNull();
+    expect(session.getItem("ap_pending_join_request")).toBeNull();
+  });
+
   test("drops malformed and expired pending values", () => {
     session.setItem("ap_pending_join_request", '{"slug":"../bad","expiresAt":2000}');
     expect(readPendingJoinRequest()).toBeNull();

--- a/web/src/lib/joinRequestPending.ts
+++ b/web/src/lib/joinRequestPending.ts
@@ -2,7 +2,7 @@ const PENDING_KEY = "ap_pending_join_request";
 const TARGET_KEY = "ap_join_request_target";
 const PENDING_TTL_MS = 15 * 60 * 1000;
 const SLUG_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$/;
-const NOTE_MAX_LENGTH = 2000;
+export const JOIN_REQUEST_NOTE_MAX_LENGTH = 2000;
 
 export interface PendingJoinRequest {
   slug: string;
@@ -15,12 +15,14 @@ function validSlug(value: unknown): value is string {
 }
 
 function validNote(value: unknown): value is string {
-  return typeof value === "string" && value.length <= NOTE_MAX_LENGTH;
+  return typeof value === "string" && value.length <= JOIN_REQUEST_NOTE_MAX_LENGTH;
 }
 
 export function savePendingJoinRequest(value: { slug: string; note?: string }, now = Date.now()): void {
   if (!validSlug(value.slug)) throw new Error("invalid pending join request");
-  const note = value.note?.trim() ?? "";
+  const rawNote: unknown = value.note;
+  if (rawNote !== undefined && typeof rawNote !== "string") throw new Error("invalid pending join request");
+  const note = (rawNote ?? "").trim();
   if (!validNote(note)) throw new Error("invalid pending join request");
   sessionStorage.setItem(PENDING_KEY, JSON.stringify({ slug: value.slug, note, expiresAt: now + PENDING_TTL_MS }));
 }
@@ -28,7 +30,7 @@ export function savePendingJoinRequest(value: { slug: string; note?: string }, n
 export function readPendingJoinRequest(now = Date.now()): PendingJoinRequest | null {
   try {
     const parsed = JSON.parse(sessionStorage.getItem(PENDING_KEY) ?? "null") as Partial<PendingJoinRequest> | null;
-    const note = parsed?.note ?? "";
+    const note = parsed?.note === undefined ? "" : parsed.note;
     if (parsed === null || !validSlug(parsed.slug) || !validNote(note) || typeof parsed.expiresAt !== "number" || parsed.expiresAt <= now) {
       throw new Error("invalid pending join request");
     }


### PR DESCRIPTION
## 改动说明
- 仅将旧 marker 中缺失的 `note` 兼容为空字符串
- 显式 `note:null` 或其他非字符串值会被拒绝并清理
- 导出并复用统一的 `JOIN_REQUEST_NOTE_MAX_LENGTH`，消除 UI/校验重复常量

## 合并前检查
- `bun run check:web`：714 tests passed，TypeScript 与 Vite production build 通过
- 变异：恢复 `parsed?.note ?? ""` 后，`note:null` 回归测试稳定变红
- review-ack：处理 PR #438 的两条 CodeRabbit actionable comments
- 安全：pending marker 仍不包含 watch token；非法 marker fail closed

## Coordination
- 频道身份：codex-002
- AgentParty task #103
- host seq=986 授权 #433 lane 与 PR review；本 PR 是 #438 合并后 review follow-up

Follow-up to #438

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能改进**
  - 加入请求备注统一支持最多 2,000 个字符，并在输入框中应用该限制。
  - 提交前会规范化备注内容，自动去除首尾空格。

- **问题修复**
  - 改进异常或无效的待处理加入请求数据处理；检测到无效备注后将自动清理，避免影响后续操作。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->