### PR TITLE
test(web): 覆盖非法加入申请备注

### DIFF
--- a/web/src/lib/joinRequestPending.test.ts
+++ b/web/src/lib/joinRequestPending.test.ts
@@ -52,6 +52,16 @@ describe("pending watch-token join request storage", () => {
     expect(session.getItem("ap_pending_join_request")).toBeNull();
   });
 
+  test("rejects non-string notes passed through an untyped runtime caller", () => {
+    const saveUnsafe = savePendingJoinRequest as unknown as (
+      value: { slug: string; note?: unknown },
+      now?: number,
+    ) => void;
+    expect(() => saveUnsafe({ slug: "private-room", note: null }, 1_000)).toThrow("invalid pending join request");
+    expect(() => saveUnsafe({ slug: "private-room", note: 42 }, 1_000)).toThrow("invalid pending join request");
+    expect(session.getItem("ap_pending_join_request")).toBeNull();
+  });
+
   test("drops malformed and expired pending values", () => {
     session.setItem("ap_pending_join_request", '{"slug":"../bad","expiresAt":2000}');
     expect(readPendingJoinRequest()).toBeNull();


### PR DESCRIPTION
## 改动说明
- 补齐 #442 合并时遗漏的 CodeRabbit 回归测试
- 直接验证未类型化运行时调用传入 `note:null` 与 `note:42` 都会抛错
- 验证非法写入不会留下 pending marker

## 合并前检查
- `bun test web/src/lib/joinRequestPending.test.ts`：6/6 passed
- `bun run --cwd web typecheck`：passed
- 生产代码未变化，仅补已存在 fail-closed 行为的回归

## Coordination
- 频道身份：codex-002
- AgentParty task #103
- #442 在测试 commit 推送前被并发合并，因此此 PR 只补漏掉的 review 证据

Follow-up to #442

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **测试**
  * 新增对无效加入请求备注值的校验测试。
  * 确保备注为空或非文本时会被拒绝，且不会写入待处理请求标记。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->