### PR TITLE
fix(cli): 避免 watch 上报阻塞监听

### DIFF
--- a/cli/src/commands/watch.ts
+++ b/cli/src/commands/watch.ts
@@ -270,7 +270,9 @@ export async function runWatch(o: WatchOptions): Promise<number> {
         if (!advertised) {
           advertised = true;
           try {
-            await o.advertise?.();
+            // 上报不能反过来阻塞监听：REST 请求若卡住，welcome 后的 @ 仍必须立刻进入主循环。
+            // 同步抛错和异步拒绝都按 best-effort 静默处理。
+            void o.advertise?.().catch(() => {});
           } catch {
             /* best-effort presence：失败静默，不碰 stdout/stderr（保 --json 帧契约与 stderr 洁净） */
           }

--- a/cli/test/watch-advertise.test.ts
+++ b/cli/test/watch-advertise.test.ts
@@ -104,6 +104,22 @@ describe("watch attach 上报 wake_kind=watch (#440)", () => {
     expect(o.lines.some((l) => l.includes("wake up"))).toBe(true);
   });
 
+  test("advertise 永不返回也不阻塞后续 @", async () => {
+    server = startMockServer((frame, sock) => {
+      if (frame.type !== "hello") return;
+      sock.send(welcomeFrame(0, "me"));
+      sock.send(msgFrame(1, "wake through stalled advertise", { mentions: ["me"] }));
+    });
+
+    const o = opts({
+      server: server.url,
+      advertise: () => new Promise<void>(() => {}),
+    });
+
+    expect(await runWatch(o)).toBe(0);
+    expect(o.lines.some((l) => l.includes("wake through stalled advertise"))).toBe(true);
+  });
+
   test("advertiseWatchWake 发 wake.kind=watch + residency=supervised，且不谎称已验证", async () => {
     let captured: Record<string, unknown> | null = null;
     api = Bun.serve({


### PR DESCRIPTION
## 问题

#441 合并后，`runWatch` 会在 welcome 分支 `await advertise()`。如果 presence REST 请求永不返回，watch 即使已经连上 WebSocket，也不会继续消费后续 @。

## 修复

- 将 wake capability 上报改为真正的 best-effort 非阻塞调用
- 同步抛错与异步 reject 继续静默处理，保持 stdout/stderr 契约
- 新增永不 resolve 的 advertise 回归测试，证明后续 @ 仍能唤醒

## 验证

- `bun test cli/test/watch-advertise.test.ts`：6 passed
- `bun test cli/test/cursor-persistence.test.ts --timeout 10000`：9 passed（全量 CLI 首轮该既有并发用例 5s 超时，隔离重跑通过）
- `bunx tsc --noEmit`（cli）：通过
- mutation：恢复 `await advertise()` 后，新测试在 1000ms 明确 timeout

Follow-up to #440.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **问题修复**
  * 优化监听唤醒流程：唤醒通知不会再因后台上报操作迟迟未完成而阻塞后续消息处理。
  * 即使上报操作失败或一直未响应，监听输出和消息接收仍可保持正常。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->