### PR TITLE
fix(web): 让可见性说明保持同行

### DIFF
--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -3081,7 +3081,13 @@
 .vis-seg-btn:last-child { border-right: 0; }
 .vis-seg-btn.is-on { background: var(--d-ink); color: var(--t-panel); }
 .vis-seg-btn:disabled:not(.is-on) { opacity: 0.55; cursor: default; }
-.vis-help { font-size: 11.5px; color: var(--t-dim); flex-basis: 100%; margin: 2px 0 0; }
+.vis-help {
+  flex: none;
+  margin: 0;
+  color: var(--t-dim);
+  font-size: 11.5px;
+  white-space: nowrap;
+}
 
 /* ---- 小图雪碧图（app 运行界面，替代散落 emoji/符号） ---- */
 .ap-sprite {

--- a/web/src/styles/app.visibilityToggle.test.ts
+++ b/web/src/styles/app.visibilityToggle.test.ts
@@ -1,0 +1,24 @@
+// @ts-expect-error Bun executes this test, while the web tsconfig intentionally loads only Vite globals.
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const css = readFileSync(fileURLToPath(new URL("./app.css", import.meta.url)), "utf8");
+
+function ruleBody(selector: string): string {
+  const start = css.indexOf(`${selector} {`);
+  if (start === -1) throw new Error(`selector not found in app.css: ${selector}`);
+  const end = css.indexOf("}", start);
+  if (end === -1) throw new Error(`unterminated rule for selector: ${selector}`);
+  return css.slice(start, end);
+}
+
+describe("issue #443 visibility controls layout", () => {
+  test("the current visibility description stays inline with its controls", () => {
+    const body = ruleBody(".vis-help");
+    expect(body).not.toContain("flex-basis: 100%");
+    expect(body).toContain("flex: none");
+    expect(body).toContain("white-space: nowrap");
+    expect(body).toContain("margin: 0");
+  });
+});

--- a/web/src/styles/app.visibilityToggle.test.ts
+++ b/web/src/styles/app.visibilityToggle.test.ts
@@ -17,6 +17,7 @@ describe("issue #443 visibility controls layout", () => {
   test("the current visibility description stays inline with its controls", () => {
     const body = ruleBody(".vis-help");
     expect(body).not.toContain("flex-basis: 100%");
+    expect(body).not.toContain("margin: 2px 0 0");
     expect(body).toContain("flex: none");
     expect(body).toContain("white-space: nowrap");
     expect(body).toContain("margin: 0");


### PR DESCRIPTION
## 修复

- 去掉 `.vis-help` 强制占满一行的 `flex-basis: 100%`
- 让当前可见性说明与徽章、三档选择器、帮助按钮保持同行
- 窄屏继续由现有工具条横向滚动承载，不压缩说明文本

## 验证

- `bun run check:web`：715 passed，TypeScript 与 Vite build 通过
- mutation：恢复 `flex-basis: 100%` 后，新增 CSS 契约测试明确失败

Closes #443.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **问题修复**
  - 优化可见性切换控件旁帮助提示的样式：调整布局与间距规则，固定单行呈现，避免与控件错位或产生不期望的换行/间距偏移。

- **测试**
  - 新增基于样式回归的测试：读取编译后的 CSS 并校验帮助提示相关规则，确保保持单行布局与预期的间距/属性设置。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->