### PR TITLE
perf(cli): 限制唤醒辅助上下文预算

### DIFF
--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -106,6 +106,10 @@ function sanitizeBlockedError(error: string): string {
 // context file 里附带的最近频道消息条数上限（冷起的 runner 不用先跑 history 也有基本上下文）
 const RECENT_MAX = 20;
 const RECENT_BODY_MAX = 400;
+// 自动塞给模型的辅助正文预算（不含本次触发消息）。触发正文始终保留全文；charter/recent
+// 超出预算时显式标记，runner 可按需 `party charter/history` 补取，避免每次 wake 固定烧掉大段上下文（#436）。
+const WAKE_AUX_BODY_MAX = 8_000;
+const WAKE_CHARTER_BODY_MAX = 4_000;
 const RUNNER_SESSION_FILE = "wake-session.json";
 const RUNNER_LOG_FILE = "serve-runner.log";
 
@@ -249,6 +253,43 @@ function buildWakeContext(
   attachments?: WakeContextAttachment[],
 ) {
   const body = frame.kind === "message" ? frame.body : (frame.note ?? "");
+  const rawCharter = charter?.charter ?? null;
+  const charterNotice = `\n… [charter truncated; run \`party charter ${channel}\`]`;
+  const boundedCharter = rawCharter === null
+    ? null
+    : rawCharter.length <= WAKE_CHARTER_BODY_MAX
+      ? rawCharter
+      : rawCharter.slice(0, WAKE_CHARTER_BODY_MAX - charterNotice.length) + charterNotice;
+  let recentBudget = WAKE_AUX_BODY_MAX - (boundedCharter?.length ?? 0);
+  let recentBodyChars = 0;
+  let recentBodyTruncated = false;
+  const boundedRecent: Array<{
+    seq: number;
+    sender: string;
+    kind: MsgFrame["kind"];
+    body: string;
+    attachments: ReturnType<typeof attachmentContextMetadata>[];
+    ts: number;
+  }> = [];
+  // 最近的消息最有用：从尾部向前装预算，最后再恢复时间顺序。
+  for (let i = recent.length - 1; i >= 0 && recentBudget > 0; i--) {
+    const message = recent[i]!;
+    const rawBody = message.kind === "message" ? message.body : (message.note ?? "");
+    const boundedBody = rawBody.slice(0, Math.min(RECENT_BODY_MAX, recentBudget));
+    recentBodyTruncated ||= boundedBody.length < rawBody.length;
+    recentBodyChars += boundedBody.length;
+    recentBudget -= boundedBody.length;
+    boundedRecent.push({
+      seq: message.seq,
+      sender: message.sender.name,
+      kind: message.kind,
+      body: boundedBody,
+      attachments: message.attachments?.map(attachmentContextMetadata) ?? [],
+      ts: message.ts,
+    });
+  }
+  boundedRecent.reverse();
+  recentBodyTruncated ||= boundedRecent.length < recent.length;
   return {
     channel,
     seq: frame.seq,
@@ -260,18 +301,24 @@ function buildWakeContext(
     mentions: frame.mentions,
     reply_to: frame.seq, // 回这条就 --reply-to 它
     self,
-    charter: charter?.charter ?? null,
+    charter: boundedCharter,
     charter_rev: charter?.charter_rev ?? 0,
     project_agent: projectAgent,
     cli_upgrade: cliUpgrade,
-    recent: recent.map((m) => ({
-      seq: m.seq,
-      sender: m.sender.name,
-      kind: m.kind,
-      body: (m.kind === "message" ? m.body : (m.note ?? "")).slice(0, RECENT_BODY_MAX),
-      attachments: m.attachments?.map(attachmentContextMetadata) ?? [],
-      ts: m.ts,
-    })),
+    recent: boundedRecent,
+    context_budget: {
+      policy: "auxiliary-body-chars-v1",
+      max_auxiliary_body_chars: WAKE_AUX_BODY_MAX,
+      auxiliary_body_chars: (boundedCharter?.length ?? 0) + recentBodyChars,
+      trigger_body_chars: body.length,
+      trigger_body_truncated: false,
+      charter_chars: boundedCharter?.length ?? 0,
+      charter_truncated: rawCharter !== null && boundedCharter !== rawCharter,
+      recent_body_chars: recentBodyChars,
+      recent_messages_included: boundedRecent.length,
+      recent_messages_available: recent.length,
+      recent_truncated: recentBodyTruncated,
+    },
     protocol_reminder: PROTOCOL_REMINDER,
   };
 }

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -238,6 +238,16 @@ function attachmentContextMetadata(attachment: Attachment): WakeContextAttachmen
   return { ...attachment, auth: "Bearer token required", local_path: null };
 }
 
+function codePointLength(value: string): number {
+  return Array.from(value).length;
+}
+
+function truncateCodePoints(value: string, maxLength: number): string {
+  if (maxLength <= 0) return "";
+  const points = Array.from(value);
+  return points.length <= maxLength ? value : points.slice(0, maxLength).join("");
+}
+
 // 把一条 @mention 的完整上下文落成 JSON 文件，命令拿路径读——避开 env/stdin 的 shell quoting/注入，
 // 也让 runner 能一次拿全 channel/seq/sender/body/reply_to/recent/protocol_reminder（评审建议）。
 // recent = 触发消息之前、serve 在线期间看到的最近频道消息（含自己/未 @ 的闲聊，正文截断），
@@ -255,12 +265,16 @@ function buildWakeContext(
   const body = frame.kind === "message" ? frame.body : (frame.note ?? "");
   const rawCharter = charter?.charter ?? null;
   const charterNotice = `\n… [charter truncated; run \`party charter ${channel}\`]`;
+  const charterNoticeLength = codePointLength(charterNotice);
   const boundedCharter = rawCharter === null
     ? null
-    : rawCharter.length <= WAKE_CHARTER_BODY_MAX
+    : codePointLength(rawCharter) <= WAKE_CHARTER_BODY_MAX
       ? rawCharter
-      : rawCharter.slice(0, WAKE_CHARTER_BODY_MAX - charterNotice.length) + charterNotice;
-  let recentBudget = WAKE_AUX_BODY_MAX - (boundedCharter?.length ?? 0);
+      : charterNoticeLength >= WAKE_CHARTER_BODY_MAX
+        ? truncateCodePoints(charterNotice, WAKE_CHARTER_BODY_MAX)
+        : truncateCodePoints(rawCharter, WAKE_CHARTER_BODY_MAX - charterNoticeLength) + charterNotice;
+  const boundedCharterLength = boundedCharter === null ? 0 : codePointLength(boundedCharter);
+  let recentBudget = WAKE_AUX_BODY_MAX - boundedCharterLength;
   let recentBodyChars = 0;
   let recentBodyTruncated = false;
   const boundedRecent: Array<{
@@ -275,10 +289,12 @@ function buildWakeContext(
   for (let i = recent.length - 1; i >= 0 && recentBudget > 0; i--) {
     const message = recent[i]!;
     const rawBody = message.kind === "message" ? message.body : (message.note ?? "");
-    const boundedBody = rawBody.slice(0, Math.min(RECENT_BODY_MAX, recentBudget));
-    recentBodyTruncated ||= boundedBody.length < rawBody.length;
-    recentBodyChars += boundedBody.length;
-    recentBudget -= boundedBody.length;
+    const rawBodyLength = codePointLength(rawBody);
+    const boundedBody = truncateCodePoints(rawBody, Math.min(RECENT_BODY_MAX, recentBudget));
+    const boundedBodyLength = codePointLength(boundedBody);
+    recentBodyTruncated ||= boundedBodyLength < rawBodyLength;
+    recentBodyChars += boundedBodyLength;
+    recentBudget -= boundedBodyLength;
     boundedRecent.push({
       seq: message.seq,
       sender: message.sender.name,
@@ -309,10 +325,10 @@ function buildWakeContext(
     context_budget: {
       policy: "auxiliary-body-chars-v1",
       max_auxiliary_body_chars: WAKE_AUX_BODY_MAX,
-      auxiliary_body_chars: (boundedCharter?.length ?? 0) + recentBodyChars,
-      trigger_body_chars: body.length,
+      auxiliary_body_chars: boundedCharterLength + recentBodyChars,
+      trigger_body_chars: codePointLength(body),
       trigger_body_truncated: false,
-      charter_chars: boundedCharter?.length ?? 0,
+      charter_chars: boundedCharterLength,
       charter_truncated: rawCharter !== null && boundedCharter !== rawCharter,
       recent_body_chars: recentBodyChars,
       recent_messages_included: boundedRecent.length,

--- a/cli/test/serve.test.ts
+++ b/cli/test/serve.test.ts
@@ -473,6 +473,65 @@ describe("runServe", () => {
     }
   });
 
+  test("wake context uses the final partial recent-message budget", () => {
+    const trigger = msgFrame(50, "full trigger", { mentions: ["me"] }) as unknown as MsgFrame;
+    const prior = Array.from({ length: 12 }, (_, index) =>
+      msgFrame(index + 1, `m${String(index + 1).padStart(2, "0")}` + "x".repeat(397)) as unknown as MsgFrame,
+    );
+    const path = writeContextFile(
+      tempDir("ap-budget-partial-"),
+      trigger,
+      "dev",
+      "me",
+      prior,
+      { charter: "C".repeat(3_999), charter_rev: 8, updated_at: null, updated_by: null },
+    );
+    try {
+      const ctx = JSON.parse(readFileSync(path, "utf8"));
+      expect(ctx.body).toBe("full trigger");
+      expect(ctx.recent.map((m: { seq: number }) => m.seq)).toEqual([2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+      expect(ctx.recent[0].body).toBe("m");
+      expect(ctx.context_budget).toMatchObject({
+        auxiliary_body_chars: 8_000,
+        charter_chars: 3_999,
+        recent_body_chars: 4_001,
+        recent_messages_included: 11,
+        recent_messages_available: 12,
+        recent_truncated: true,
+      });
+    } finally {
+      unlinkSync(path);
+    }
+  });
+
+  test("wake context truncates on Unicode code-point boundaries", () => {
+    const triggerBody = "🧭".repeat(10);
+    const trigger = msgFrame(50, triggerBody, { mentions: ["me"] }) as unknown as MsgFrame;
+    const path = writeContextFile(
+      tempDir("ap-budget-unicode-"),
+      trigger,
+      "dev",
+      "me",
+      [msgFrame(49, "😀".repeat(500)) as unknown as MsgFrame],
+      { charter: "🚀".repeat(5_000), charter_rev: 9, updated_at: null, updated_by: null },
+    );
+    try {
+      const ctx = JSON.parse(readFileSync(path, "utf8"));
+      expect(ctx.body).toBe(triggerBody);
+      expect(Array.from(ctx.charter)).toHaveLength(4_000);
+      expect(ctx.charter).toEndWith("[charter truncated; run `party charter dev`]");
+      expect(Array.from(ctx.recent[0].body)).toHaveLength(400);
+      expect(ctx.recent[0].body).toBe("😀".repeat(400));
+      expect(ctx.context_budget).toMatchObject({
+        trigger_body_chars: 10,
+        charter_chars: 4_000,
+        recent_body_chars: 400,
+      });
+    } finally {
+      unlinkSync(path);
+    }
+  });
+
   test("replayed revision snapshot of an old mention does not re-trigger the runner", async () => {
     // 旧 @ 被编辑过 → 服务端每次连接都重放它；runner 只能被真正未消费的新消息触发
     server = startMockServer((frame, sock) => {

--- a/cli/test/serve.test.ts
+++ b/cli/test/serve.test.ts
@@ -418,9 +418,56 @@ describe("runServe", () => {
       expect(ctx).toMatchObject({ channel: "dev", seq: 9, self: "me", reply_to: 9 });
       expect(ctx.recent.map((m: { seq: number }) => m.seq)).toEqual([7, 8]);
       expect(ctx.recent[1].body).toHaveLength(400);
+      expect(ctx.context_budget).toMatchObject({
+        max_auxiliary_body_chars: 8000,
+        trigger_body_chars: 12,
+        trigger_body_truncated: false,
+        recent_messages_included: 2,
+        recent_messages_available: 2,
+        recent_truncated: true,
+      });
       expect(ctx.protocol_reminder).toContain("party history");
       expect(ctx.protocol_reminder).toContain("trellis");
       expect(ctx.protocol_reminder).toContain("不要触发项目自带的其它频道/工作流机制");
+    } finally {
+      unlinkSync(path);
+    }
+  });
+
+  test("wake context caps charter + recent bodies while preserving the full trigger", () => {
+    const triggerBody = "T".repeat(12_000);
+    const trigger = msgFrame(50, triggerBody, { mentions: ["me"] }) as unknown as MsgFrame;
+    const prior = Array.from({ length: 20 }, (_, index) =>
+      msgFrame(index + 1, String(index + 1).padStart(2, "0") + "x".repeat(498)) as unknown as MsgFrame,
+    );
+    const path = writeContextFile(
+      tempDir("ap-budget-"),
+      trigger,
+      "dev",
+      "me",
+      prior,
+      { charter: "C".repeat(8_000), charter_rev: 7, updated_at: null, updated_by: null },
+    );
+    try {
+      const ctx = JSON.parse(readFileSync(path, "utf8"));
+      expect(ctx.body).toBe(triggerBody); // 用户本次指令绝不为省 token 被裁掉
+      expect(ctx.charter).toHaveLength(4_000);
+      expect(ctx.charter).toEndWith("[charter truncated; run `party charter dev`]");
+      expect(ctx.recent.map((m: { seq: number }) => m.seq)).toEqual([11, 12, 13, 14, 15, 16, 17, 18, 19, 20]);
+      expect(ctx.recent.reduce((sum: number, m: { body: string }) => sum + m.body.length, 0)).toBe(4_000);
+      expect(ctx.context_budget).toEqual({
+        policy: "auxiliary-body-chars-v1",
+        max_auxiliary_body_chars: 8_000,
+        auxiliary_body_chars: 8_000,
+        trigger_body_chars: 12_000,
+        trigger_body_truncated: false,
+        charter_chars: 4_000,
+        charter_truncated: true,
+        recent_body_chars: 4_000,
+        recent_messages_included: 10,
+        recent_messages_available: 20,
+        recent_truncated: true,
+      });
     } finally {
       unlinkSync(path);
     }


### PR DESCRIPTION
## 优化

- 本次触发消息始终保留全文，不为省 token 裁掉用户指令
- charter 上限 4,000 字符，并附按需读取命令
- charter + recent 正文合计最多 8,000 字符；charter 未用预算自动让给 recent
- recent 从最新消息向前装入，输出仍保持时间顺序
- wake context 新增 `context_budget`，显式报告字符预算、截断状态和纳入消息数

按 #436 的线上样本（13,860 字符自动辅助正文），上限降到 8,000，至少减少约 42%。

## 验证

- `bun test cli/test/serve.test.ts --timeout 10000`：45 passed
- `bunx tsc --noEmit`（cli）：通过
- mutation：把 charter 上限恢复到 8,000 后，预算测试明确失败（expected 4,000 / got 8,000）
- 全量 CLI：699 passed；2 个既有时序用例在机器高负载下失败（heartbeat clear、cursor 5s timeout），两者隔离/聚焦运行通过，且不在本 PR 修改路径

Closes #436.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 调整唤醒上下文裁剪：触发正文完整保留；charter 与近期消息按统一字符预算共同裁剪，并优先保留最新的近期内容。
  * charter 截断时附带补全提示；裁剪在 Unicode 码点边界进行，避免字符被截断。
  * 新增上下文预算与截断状态信息（context_budget），便于查看实际保留与占用情况。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->