### PR TITLE
feat(web): 悬停展示 agent 公开职责

### DIFF
--- a/web/src/components/MessageCard.presence.test.tsx
+++ b/web/src/components/MessageCard.presence.test.tsx
@@ -8,7 +8,7 @@ import { LocaleProvider } from "../i18n/locale";
 
 // Markdown 正文经 DOMPurify（需真实 DOM）；本用例只关心悬停 title，桩掉渲染避免拉起 DOM。
 mock.module("../lib/markdown", () => ({ renderMarkdown: (s: string) => s }));
-const { MessageCard, presenceTitleBits } = await import("./MessageCard");
+const { MessageCard, agentInfoTitleBits, presenceTitleBits } = await import("./MessageCard");
 
 let renderer: ReactTestRenderer | null = null;
 
@@ -122,6 +122,33 @@ describe("presenceTitleBits (#274)", () => {
   });
 });
 
+describe("agentInfoTitleBits (#448)", () => {
+  test("优先展示频道公开分工，并附 agent 当前 note 与状态", () => {
+    expect(agentInfoTitleBits(
+      presenceEntry({ role: "worker", note: "正在核对迁移" }),
+      {
+        name: "planner",
+        role: "reviewer",
+        responsibility: "检查发布风险与回归范围",
+        assigned_by: "host",
+        assigned_at: 1,
+      },
+    )).toEqual([
+      "role: reviewer",
+      "responsibility: 检查发布风险与回归范围",
+      "note: 正在核对迁移",
+      "status: working",
+    ]);
+  });
+
+  test("没有公开分工时回退到 agent 自报 role，空 note 不占行", () => {
+    expect(agentInfoTitleBits(presenceEntry({ role: "worker", note: "  " }), undefined)).toEqual([
+      "role: worker",
+      "status: working",
+    ]);
+  });
+});
+
 describe("发送者名/@提及悬停展示实时状态 (#274)", () => {
   test("传入 presence map 时 senderTitle 追加 status/task 行", () => {
     const root = render(baseMsg({}), {
@@ -131,6 +158,23 @@ describe("发送者名/@提及悬停展示实时状态 (#274)", () => {
     expect(title).toContain("status: busy");
     expect(title).toContain("task: #510");
     expect(title).toContain("queued: 2");
+  });
+
+  test("sender 与 @ 悬停都能看到频道公开职责", () => {
+    const role = {
+      name: "planner",
+      role: "worker",
+      responsibility: "先读 issue，再实现和验证",
+      assigned_by: "host",
+      assigned_at: 1,
+    };
+    const root = render(baseMsg({ mentions: ["planner"] }), {
+      presence: { planner: presenceEntry({ note: "实现中" }) },
+      agentRoles: { planner: role },
+    });
+    expect(senderTitle(root)).toContain("responsibility: 先读 issue，再实现和验证");
+    expect(senderTitle(root)).toContain("note: 实现中");
+    expect(mentionTitle(root)).toContain("responsibility: 先读 issue，再实现和验证");
   });
 
   test("不传 presence（或查不到该名字）时 senderTitle 不含 status/task 行", () => {

--- a/web/src/components/MessageCard.tsx
+++ b/web/src/components/MessageCard.tsx
@@ -1,6 +1,6 @@
 // 消息渲染：message → doodle 卡片外壳 + mono 元信息 + markdown 正文；
 // status → 时间线分隔条（spec §9 第 2 块）。
-import type { AgentContext, MsgFrame, PresenceEntry, ReadCursor, Sender } from "@agentparty/shared";
+import type { AgentContext, ChannelRoleAssignment, MsgFrame, PresenceEntry, ReadCursor, Sender } from "@agentparty/shared";
 import { memo, useEffect, useRef, useState } from "react";
 import type { CSSProperties } from "react";
 import { agentHue } from "../lib/agentColor";
@@ -45,6 +45,8 @@ interface Props {
   onEditSave(): void;
   // #274：name → presence 条目（Channel 的 state.presence 原样传下来），悬停发送者名/@提及展示实时状态。
   presence?: Record<string, PresenceEntry>;
+  // #448：频道公开分工（role/responsibility）。只展示频道内已公开的信息，不把账号私有 profile prompt 塞进消息。
+  agentRoles?: Record<string, ChannelRoleAssignment>;
   // 频道决策协议（#284）：人类/moderator 是否可对本条 decision_request 拍板 + 回调。
   canRespondDecision?: boolean;
   decisionBusy?: boolean;
@@ -123,6 +125,21 @@ export function presenceTitleBits(entry: PresenceEntry | undefined): string[] {
   ].filter((part): part is string => part !== null);
 }
 
+/** #448：发送者/@ 的悬停信息补齐频道公开职责，以及 agent 当前主动上报的 note。 */
+export function agentInfoTitleBits(
+  entry: PresenceEntry | undefined,
+  assignment: ChannelRoleAssignment | undefined,
+): string[] {
+  const responsibility = assignment?.responsibility?.trim() ?? "";
+  const note = entry?.note?.trim() ?? "";
+  return [
+    assignment !== undefined ? `role: ${assignment.role}` : entry?.role ? `role: ${entry.role}` : null,
+    responsibility !== "" ? `responsibility: ${responsibility}` : null,
+    note !== "" ? `note: ${note}` : null,
+    ...presenceTitleBits(entry),
+  ].filter((part): part is string => part !== null);
+}
+
 // memo 化：主输入框每次按键都会重渲染 Channel（draft 是顶层 state），中文 IME 尤其密集。
 // 卡片的所有 props（msg / 各 useCallback 回调 / useMemo 出来的 identityDisplay·receipts /
 // 逐条标量）在 draft-only 重渲染时引用稳定，浅比较即可跳过整窗口卡片的重渲染，消除输入卡顿
@@ -150,6 +167,7 @@ function MessageCardImpl({
   onEditCancel,
   onEditSave,
   presence,
+  agentRoles,
   canRespondDecision,
   decisionBusy,
   onDecisionRespond,
@@ -189,7 +207,7 @@ function MessageCardImpl({
     lineage ? `team: ${lineage.team_id}` : null,
     lineage ? `depth: ${lineage.depth}` : null,
     lineage?.expires_at ? `expires: ${fmtTime(lineage.expires_at)}` : null,
-    ...presenceTitleBits(presence?.[msg.sender.name]),
+    ...agentInfoTitleBits(presence?.[msg.sender.name], agentRoles?.[msg.sender.name]),
   ]
     .filter((part): part is string => part !== null)
     .join("\n");
@@ -416,7 +434,7 @@ function MessageCardImpl({
           // #274：@提及悬停也能看到该名字的实时状态；原始名与显示名不同时保留 @原名防冒充锚点。
           const mentionTitle = [
             m === displayForIdentity(m, identityDisplay) ? null : `@${m}`,
-            ...presenceTitleBits(presence?.[m]),
+            ...agentInfoTitleBits(presence?.[m], agentRoles?.[m]),
           ]
             .filter((part): part is string => part !== null)
             .join("\n");

--- a/web/src/pages/Channel.tsx
+++ b/web/src/pages/Channel.tsx
@@ -2050,6 +2050,7 @@ function TeamThread({
   busySeq,
   messageBySeq,
   presence,
+  agentRoles,
   onReply,
   onEdit,
   onRetract,
@@ -2075,6 +2076,7 @@ function TeamThread({
   messageBySeq: Map<number, MsgFrame>;
   // #274：name → presence 条目，MessageCard 悬停发送者名/@提及展示实时状态
   presence: Record<string, PresenceEntry>;
+  agentRoles: Record<string, ChannelRoleInfo>;
   onReply: (seq: number) => void;
   onEdit: (seq: number) => void;
   onRetract: (seq: number) => void;
@@ -2124,6 +2126,7 @@ function TeamThread({
             participants={participants}
             canModerate={canModerate}
             presence={presence}
+            agentRoles={agentRoles}
             quotedMessage={message.reply_to !== null ? messageBySeq.get(message.reply_to) ?? null : null}
             onReply={onReply}
             onEdit={onEdit}
@@ -3525,6 +3528,10 @@ export function ChannelPage({
   const totalInView = q === "" ? timelineMessages.length : searchHits.length;
   const visibleInView = q === "" ? visibleMessages.length : visibleSearchHits.length;
   const structuredRoleCount = channelRoles.length + selfReportedRoles(channelRoles, state.presence, channelIdentities).length;
+  const channelRolesByName = useMemo(
+    () => Object.fromEntries(channelRoles.map((role) => [role.name, role])),
+    [channelRoles],
+  );
   // #370 点1：公告面板单列一块「分工摘要」——host + 各角色计数，只读，点开跳团队面板看全貌。
   const charterDivisionSummary = ((): string => {
     if (channelRoles.length === 0) return "";
@@ -4025,6 +4032,7 @@ export function ChannelPage({
                   participants={state.participants}
                   canModerate={canModerate}
                   presence={state.presence}
+                  agentRoles={channelRolesByName}
                   quotedMessage={item.message.reply_to !== null ? messageBySeq.get(item.message.reply_to) ?? null : null}
                   onReply={startReply}
                   onEdit={startEdit}
@@ -4060,6 +4068,7 @@ export function ChannelPage({
                   busySeq={messageActionBusySeq}
                   messageBySeq={messageBySeq}
                   presence={state.presence}
+                  agentRoles={channelRolesByName}
                   onReply={startReply}
                   onEdit={startEdit}
                   onRetract={retractMessage}


### PR DESCRIPTION
## 优化

- 消息发送者名悬停新增频道公开 `role` / `responsibility`
- 同时展示 agent 当前主动上报的 `note` 与既有 status/task/queued
- 正文里的 @提及复用同一套悬停信息
- 分组折叠的 team thread 与普通消息流行为一致

隐私边界：这里只展示频道成员本来就能在“团队/分工”面板看到的公开职责，以及 presence 公开 note；不会把账号私有 project-agent profile prompt 写进历史或暴露给其他成员。

## 验证

- `bun run check:web`：717 passed，TypeScript 与 Vite build 通过
- mutation：移除 responsibility 输出后，新增测试明确失败

Closes #448.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 消息卡片中，悬停发送者或提及时可查看频道内公开的职责、责任说明及备注。
  * 当职责信息不完整时，系统会自动显示可用的状态信息，并避免展示空白备注。
* **改进**
  * 统一发送者名称与提及名称的悬停信息，提供一致的频道角色说明。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->