### PR TITLE
feat(web): 升级 Agent 工作看板

### DIFF
--- a/web/src/pages/AgentBoardPanel.test.tsx
+++ b/web/src/pages/AgentBoardPanel.test.tsx
@@ -22,10 +22,15 @@ function presence(name: string, over: Partial<PresenceEntry> = {}): PresenceEntr
   return { name, kind: "agent", state: "waiting", note: null, ts: 0, ...over } as PresenceEntry;
 }
 
-function task(id: number, assignee: string | null, state: TaskRecord["state"]): TaskRecord {
+function task(
+  id: number,
+  assignee: string | null,
+  state: TaskRecord["state"],
+  assigneeKind: "agent" | "human" | "squad" = "agent",
+): TaskRecord {
   return {
     type: "task", id, channel: "c", title: `t${id}`, desc: null, state,
-    assignee: assignee === null ? null : { name: assignee, kind: "agent" },
+    assignee: assignee === null ? null : { name: assignee, kind: assigneeKind },
     created_by: "h", created_by_kind: "human", priority: 0, labels: [], parent_id: null,
     anchor_seqs: [], completion_artifact: null, workflow_id: null, scope: [], blocked_reason: null,
     external_ref: null, created_at: 0, updated_at: 0, completed_at: null,
@@ -67,12 +72,21 @@ function allText(r: ReactTestRenderer): string {
 
 describe("AgentBoardPanel (#187)", () => {
   test("groups tasks by assignee and derives busy/offline status from presence", () => {
-    const p = [presence("alice", { state: "working", live: true }), presence("bob", { live: false })];
+    const p = [
+      presence("alice", { state: "working", live: true }),
+      presence("bob", { live: false }),
+      presence("carol", { state: "waiting", live: true }),
+      presence("dave", { state: "blocked", live: true }),
+    ];
     const tasks = [
       task(1, "alice", "in_progress"), task(2, "alice", "in_progress"), task(3, "alice", "assigned"),
       task(4, "bob", "needs_review"),
       task(5, null, "in_progress"), // 无 assignee 不计入任何 agent
       task(6, "alice", "done"), // done 不计入在手
+      task(7, "dave", "blocked"),
+      task(8, "carol", "assigned"),
+      task(9, "human-owner", "assigned", "human"),
+      task(10, "review-squad", "in_progress", "squad"),
     ];
     const r = render("en", p, tasks);
     const txt = allText(r);
@@ -85,17 +99,26 @@ describe("AgentBoardPanel (#187)", () => {
     expect(txt).toContain("offline");
     // 每个状态是一列，agent 卡片落在对应列，并直接展示真实任务进度。
     const busyLane = r.root.findByProps({ "data-status": "busy" });
+    const blockedLane = r.root.findByProps({ "data-status": "blocked" });
+    const idleLane = r.root.findByProps({ "data-status": "idle" });
     const offlineLane = r.root.findByProps({ "data-status": "offline" });
     expect(treeText(busyLane)).toContain("alice");
     expect(treeText(busyLane)).toContain("t1");
+    expect(treeText(blockedLane)).toContain("dave");
+    expect(treeText(blockedLane)).toContain("t7");
+    expect(treeText(idleLane)).toContain("carol");
+    expect(treeText(idleLane)).toContain("t8");
     expect(treeText(offlineLane)).toContain("bob");
     expect(treeText(offlineLane)).toContain("t4");
-    expect(r.root.findAllByProps({ "data-status": "idle" })).toHaveLength(1);
-    expect(r.root.findAllByProps({ "data-status": "blocked" })).toHaveLength(1);
     // 无 assignee 的 task5 不产生「未命名」agent 行
     expect(txt).not.toContain("t5");
     // 已完成任务不再属于在手工作。
     expect(txt).not.toContain("t6");
+    // human/squad 任务不能凭空生成 Agent 卡片。
+    expect(txt).not.toContain("human-owner");
+    expect(txt).not.toContain("review-squad");
+    expect(txt).not.toContain("t9");
+    expect(txt).not.toContain("t10");
   });
 
   test("empty when no agents and no assigned tasks", () => {

--- a/web/src/pages/AgentBoardPanel.test.tsx
+++ b/web/src/pages/AgentBoardPanel.test.tsx
@@ -51,15 +51,18 @@ function render(locale: "en" | "zh", presenceList: PresenceEntry[], tasks: TaskR
   renderer = r;
   return r;
 }
-function allText(r: ReactTestRenderer): string {
+function treeText(node: unknown): string {
   const out: string[] = [];
   const walk = (node: unknown) => {
     if (typeof node === "string") out.push(node);
     else if (Array.isArray(node)) node.forEach(walk);
     else if (node !== null && typeof node === "object" && "children" in (node as Record<string, unknown>)) walk((node as { children: unknown }).children);
   };
-  walk(r.toJSON());
+  walk(node);
   return out.join(" ");
+}
+function allText(r: ReactTestRenderer): string {
+  return treeText(r.toJSON());
 }
 
 describe("AgentBoardPanel (#187)", () => {
@@ -71,7 +74,8 @@ describe("AgentBoardPanel (#187)", () => {
       task(5, null, "in_progress"), // 无 assignee 不计入任何 agent
       task(6, "alice", "done"), // done 不计入在手
     ];
-    const txt = allText(render("en", p, tasks));
+    const r = render("en", p, tasks);
+    const txt = allText(r);
     // alice：busy + 2 in progress + 1 queued
     expect(txt).toContain("alice");
     expect(txt).toContain("busy");
@@ -79,8 +83,19 @@ describe("AgentBoardPanel (#187)", () => {
     // bob：live=false → offline，且有 1 待审
     expect(txt).toContain("bob");
     expect(txt).toContain("offline");
+    // 每个状态是一列，agent 卡片落在对应列，并直接展示真实任务进度。
+    const busyLane = r.root.findByProps({ "data-status": "busy" });
+    const offlineLane = r.root.findByProps({ "data-status": "offline" });
+    expect(treeText(busyLane)).toContain("alice");
+    expect(treeText(busyLane)).toContain("t1");
+    expect(treeText(offlineLane)).toContain("bob");
+    expect(treeText(offlineLane)).toContain("t4");
+    expect(r.root.findAllByProps({ "data-status": "idle" })).toHaveLength(1);
+    expect(r.root.findAllByProps({ "data-status": "blocked" })).toHaveLength(1);
     // 无 assignee 的 task5 不产生「未命名」agent 行
     expect(txt).not.toContain("t5");
+    // 已完成任务不再属于在手工作。
+    expect(txt).not.toContain("t6");
   });
 
   test("empty when no agents and no assigned tasks", () => {

--- a/web/src/pages/Channel.tsx
+++ b/web/src/pages/Channel.tsx
@@ -1450,7 +1450,7 @@ export function AgentBoardPanel({ presence, tasks }: { presence: PresenceEntry[]
   const tasksByName = new Map<string, TaskRecord[]>();
   for (const task of tasks) {
     const name = task.assignee?.name;
-    if (!name) continue;
+    if (!name || task.assignee?.kind !== "agent") continue;
     if (task.state !== "in_progress" && task.state !== "assigned" && task.state !== "needs_review" && task.state !== "blocked") continue;
     const assigned = tasksByName.get(name) ?? [];
     assigned.push(task);

--- a/web/src/pages/Channel.tsx
+++ b/web/src/pages/Channel.tsx
@@ -1447,24 +1447,33 @@ const AGENT_STATUS_ORDER: Record<AgentBoardStatus, number> = { busy: 0, blocked:
 
 export function AgentBoardPanel({ presence, tasks }: { presence: PresenceEntry[]; tasks: TaskRecord[] }) {
   const t = useT();
-  const counts = new Map<string, { inProgress: number; queued: number; review: number; blocked: number }>();
-  const bump = (name: string, key: "inProgress" | "queued" | "review" | "blocked") => {
-    const cur = counts.get(name) ?? { inProgress: 0, queued: 0, review: 0, blocked: 0 };
-    cur[key] += 1;
-    counts.set(name, cur);
-  };
+  const tasksByName = new Map<string, TaskRecord[]>();
   for (const task of tasks) {
     const name = task.assignee?.name;
     if (!name) continue;
-    if (task.state === "in_progress") bump(name, "inProgress");
-    else if (task.state === "assigned") bump(name, "queued");
-    else if (task.state === "needs_review") bump(name, "review");
-    else if (task.state === "blocked") bump(name, "blocked");
+    if (task.state !== "in_progress" && task.state !== "assigned" && task.state !== "needs_review" && task.state !== "blocked") continue;
+    const assigned = tasksByName.get(name) ?? [];
+    assigned.push(task);
+    tasksByName.set(name, assigned);
+  }
+  const taskStateOrder: Partial<Record<TaskRecord["state"], number>> = {
+    in_progress: 0,
+    blocked: 1,
+    needs_review: 2,
+    assigned: 3,
+  };
+  for (const assigned of tasksByName.values()) {
+    assigned.sort((a, b) =>
+      (taskStateOrder[a.state] ?? 99) - (taskStateOrder[b.state] ?? 99)
+      || b.priority - a.priority
+      || b.updated_at - a.updated_at
+      || a.id - b.id,
+    );
   }
   const presenceByName = new Map(presence.map((p) => [p.name, p]));
   const names = new Set<string>();
   for (const p of presence) if (p.kind !== "human") names.add(p.name);
-  for (const name of counts.keys()) names.add(name);
+  for (const name of tasksByName.keys()) names.add(name);
   const statusOf = (p: PresenceEntry | undefined): AgentBoardStatus => {
     if (!p || p.live !== true) return "offline";
     if (p.state === "blocked") return "blocked";
@@ -1474,11 +1483,23 @@ export function AgentBoardPanel({ presence, tasks }: { presence: PresenceEntry[]
   const rows = [...names]
     .map((name) => {
       const p = presenceByName.get(name);
-      const c = counts.get(name) ?? { inProgress: 0, queued: 0, review: 0, blocked: 0 };
+      const assigned = tasksByName.get(name) ?? [];
       // #187 第4项「排期」：surface presence 里的暂停/定时恢复（resume_at），看板本行直接可见。
-      return { name, status: statusOf(p), note: p?.note ?? null, paused: p?.paused === true, resumeAt: p?.resume_at ?? null, ...c };
+      return {
+        name,
+        status: statusOf(p),
+        note: p?.note ?? null,
+        paused: p?.paused === true,
+        resumeAt: p?.resume_at ?? null,
+        tasks: assigned,
+        inProgress: assigned.filter((task) => task.state === "in_progress").length,
+        queued: assigned.filter((task) => task.state === "assigned").length,
+        review: assigned.filter((task) => task.state === "needs_review").length,
+        blocked: assigned.filter((task) => task.state === "blocked").length,
+      };
     })
     .sort((a, b) => AGENT_STATUS_ORDER[a.status] - AGENT_STATUS_ORDER[b.status] || b.inProgress - a.inProgress || a.name.localeCompare(b.name));
+  const laneStatuses: AgentBoardStatus[] = ["busy", "blocked", "idle", "offline"];
 
   if (rows.length === 0) {
     return (
@@ -1489,28 +1510,59 @@ export function AgentBoardPanel({ presence, tasks }: { presence: PresenceEntry[]
   }
   return (
     <section className="agent-board-panel" aria-label={t("Channel.agentBoard.aria")}>
-      {rows.map((row) => (
-        <div key={row.name} className={`agent-board-row agent-board-row--${row.status}`}>
-          <div className="agent-board-row-head">
-            <span className="agent-board-name">{row.name}</span>
-            <span className={`t-mono agent-board-status agent-board-status--${row.status}`}>{t(`Channel.agents.status.${row.status}`)}</span>
-          </div>
-          {row.note !== null && row.note.trim() !== "" && <p className="agent-board-note">{row.note}</p>}
-          {row.paused && (
-            <p className="t-mono agent-board-schedule">
-              {row.resumeAt !== null
-                ? t("Channel.agents.pausedUntil", { time: fmtTime(row.resumeAt) })
-                : t("Channel.agents.pausedManual")}
-            </p>
-          )}
-          <div className="agent-board-counts t-mono">
-            <span title={t("Channel.agents.count.inProgress")}>▶ {row.inProgress}</span>
-            <span title={t("Channel.agents.count.queued")}>⏳ {row.queued}</span>
-            <span title={t("Channel.agents.count.review")}>👁 {row.review}</span>
-            {row.blocked > 0 && <span className="agent-board-count-blocked" title={t("Channel.agents.count.blocked")}>⛔ {row.blocked}</span>}
-          </div>
-        </div>
-      ))}
+      {laneStatuses.map((status) => {
+        const laneRows = rows.filter((row) => row.status === status);
+        const statusLabel = t(`Channel.agents.status.${status}`);
+        return (
+          <section
+            key={status}
+            className={`agent-board-lane agent-board-lane--${status}`}
+            data-status={status}
+            aria-label={t("Channel.tasks.columnAria", { state: statusLabel })}
+          >
+            <header className="agent-board-lane-head">
+              <h3 className={`agent-board-lane-title agent-board-status--${status}`}>{statusLabel}</h3>
+              <span className="t-mono agent-board-lane-count">{laneRows.length}</span>
+            </header>
+            <div className="agent-board-lane-cards">
+              {laneRows.length === 0 && <p className="agent-board-lane-empty">{t("Channel.tasks.columnEmpty")}</p>}
+              {laneRows.map((row) => (
+                <article key={row.name} className={`agent-board-row agent-board-row--${row.status}`} data-agent={row.name}>
+                  <div className="agent-board-row-head">
+                    <span className="agent-board-name">{row.name}</span>
+                    <span className={`t-mono agent-board-status agent-board-status--${row.status}`}>{statusLabel}</span>
+                  </div>
+                  {row.note !== null && row.note.trim() !== "" && <p className="agent-board-note">{row.note}</p>}
+                  {row.paused && (
+                    <p className="t-mono agent-board-schedule">
+                      {row.resumeAt !== null
+                        ? t("Channel.agents.pausedUntil", { time: fmtTime(row.resumeAt) })
+                        : t("Channel.agents.pausedManual")}
+                    </p>
+                  )}
+                  <div className="agent-board-counts t-mono">
+                    <span title={t("Channel.agents.count.inProgress")}>▶ {row.inProgress}</span>
+                    <span title={t("Channel.agents.count.queued")}>⏳ {row.queued}</span>
+                    <span title={t("Channel.agents.count.review")}>👁 {row.review}</span>
+                    {row.blocked > 0 && <span className="agent-board-count-blocked" title={t("Channel.agents.count.blocked")}>⛔ {row.blocked}</span>}
+                  </div>
+                  {row.tasks.length > 0 && (
+                    <ol className="agent-board-task-list">
+                      {row.tasks.map((task) => (
+                        <li key={task.id} className={`agent-board-task agent-board-task--${task.state}`}>
+                          <span className="t-mono agent-board-task-id">#{task.id}</span>
+                          <span className="agent-board-task-title" title={task.title}>{task.title}</span>
+                          <span className="t-mono agent-board-task-state">{t(`Channel.tasks.state.${task.state}`)}</span>
+                        </li>
+                      ))}
+                    </ol>
+                  )}
+                </article>
+              ))}
+            </div>
+          </section>
+        );
+      })}
     </section>
   );
 }

--- a/web/src/styles/app.agentBoard.test.ts
+++ b/web/src/styles/app.agentBoard.test.ts
@@ -1,0 +1,30 @@
+// @ts-expect-error Bun executes this test, while the web tsconfig intentionally loads only Vite globals.
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const css = readFileSync(fileURLToPath(new URL("./app.css", import.meta.url)), "utf8");
+
+function ruleBody(selector: string): string {
+  const start = css.indexOf(`${selector} {`);
+  if (start === -1) throw new Error(`selector not found in app.css: ${selector}`);
+  const end = css.indexOf("}", start);
+  if (end === -1) throw new Error(`unterminated rule for selector: ${selector}`);
+  return css.slice(start, end);
+}
+
+describe("issue #435 agent work board layout", () => {
+  test("lays out the four status lanes as a horizontally scrollable grid", () => {
+    const body = ruleBody(".agent-board-panel");
+    expect(body).toContain("display: grid");
+    expect(body).toContain("grid-template-columns: repeat(4, minmax(220px, 1fr))");
+    expect(body).toContain("overflow-x: auto");
+  });
+
+  test("keeps task title and state readable inside each agent card", () => {
+    const task = ruleBody(".agent-board-task");
+    const title = ruleBody(".agent-board-task-title");
+    expect(task).toContain("grid-template-columns: auto minmax(0, 1fr) auto");
+    expect(title).toContain("text-overflow: ellipsis");
+  });
+});

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -5804,8 +5804,42 @@
 .composer-wake-tip .feature-tip-bubble { left: auto; right: 0; transform: none; }
 
 /* #187 agent 维度看板 */
-.agent-board-panel { display: flex; flex-direction: column; gap: 8px; }
+.agent-board-panel {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(220px, 1fr));
+  align-items: start;
+  gap: 10px;
+  overflow-x: auto;
+  padding-bottom: 4px;
+}
 .agent-board-empty { color: var(--muted, #888); font-size: 13px; }
+.agent-board-lane {
+  min-width: 220px;
+  border: 1px solid var(--border, #2a2a2a);
+  border-radius: 8px;
+  background: var(--t-faint, rgba(127, 127, 127, 0.06));
+  overflow: hidden;
+}
+.agent-board-lane-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border, #2a2a2a);
+}
+.agent-board-lane-title { margin: 0; font-size: 12px; text-transform: uppercase; letter-spacing: 0.04em; }
+.agent-board-lane-count {
+  min-width: 20px;
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: var(--t-panel, #fff);
+  color: var(--muted, #888);
+  font-size: 11px;
+  text-align: center;
+}
+.agent-board-lane-cards { display: flex; flex-direction: column; gap: 8px; padding: 8px; }
+.agent-board-lane-empty { margin: 8px 2px; color: var(--muted, #888); font-size: 12px; text-align: center; }
 .agent-board-row {
   border: 1px solid var(--border, #2a2a2a);
   border-left: 3px solid var(--border, #2a2a2a);
@@ -5827,6 +5861,27 @@
 .agent-board-note { margin: 0; font-size: 12px; color: var(--muted, #999); }
 .agent-board-counts { display: flex; gap: 12px; font-size: 12px; color: var(--muted, #999); }
 .agent-board-count-blocked { color: var(--danger, #e5534b); }
+.agent-board-task-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 3px 0 0;
+  padding: 7px 0 0;
+  border-top: 1px solid var(--border, #2a2a2a);
+  list-style: none;
+}
+.agent-board-task {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: baseline;
+  gap: 6px;
+  font-size: 11px;
+  line-height: 1.35;
+}
+.agent-board-task-id { color: var(--muted, #999); }
+.agent-board-task-title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.agent-board-task-state { color: var(--muted, #999); font-size: 10px; white-space: nowrap; }
+.agent-board-task--blocked .agent-board-task-state { color: var(--danger, #e5534b); }
 
 /* #273 全局设置面板 */
 .app-settings-btn {


### PR DESCRIPTION
## 变更
- 将 Agent 面板改为忙碌、阻塞、空闲、离线四条横向泳道
- 每张 Agent 卡片继续展示公开状态、备注、排期和各阶段计数
- 直接展示在手任务的编号、标题与当前阶段，并按阶段、优先级和更新时间排序
- 增加布局与任务可见性的回归测试

## 验证
- `bun run check:web`（完整 Web 测试、TypeScript、Vite build）
- `bun test web/src/pages/AgentBoardPanel.test.tsx web/src/styles/app.agentBoard.test.ts`（8/8）
- 变异验证：删除任务标题渲染后目标测试失败，恢复后通过

Closes #435

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * Agent 看板按忙碌/阻塞/空闲/离线分栏展示，并为每位 Agent 汇总任务列表与分状态数量。
  * 支持在卡片中展示暂停信息及预计恢复时间。
* **界面优化**
  * 看板改为四列横向可滚动网格布局；新增分栏与任务列表样式。
  * 任务标题超出自动省略显示，阻塞状态强调为对应颜色。
* **测试**
  * 增强渲染断言：按分栏定位并验证任务/Agent 卡片的显示与不应出现的情况。
  * 新增对关键 CSS 布局规则的验证用例。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->