### PR TITLE
feat(acl): 允许 host 暂停频道 Agent

### DIFF
--- a/worker/migrations/0036_management_audit_agent_reception.sql
+++ b/worker/migrations/0036_management_audit_agent_reception.sql
@@ -1,0 +1,57 @@
+-- #439: host-agent pause/resume is a security-relevant, channel-scoped control action.
+-- SQLite cannot extend a CHECK list in place, so rebuild while preserving every existing row/index.
+CREATE TABLE management_audit_new (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  cursor_token TEXT NOT NULL,
+  actor_account TEXT,
+  actor_kind TEXT NOT NULL CHECK (actor_kind IN ('admin', 'human', 'agent')),
+  action TEXT NOT NULL CHECK (action IN (
+    'token.issue',
+    'token.revoke',
+    'agent.nickname.update',
+    'agent.reception.pause',
+    'agent.reception.resume',
+    'channel.create',
+    'channel.permissions.update',
+    'channel.visibility.update',
+    'channel.member.add',
+    'channel.member.remove',
+    'channel.role.assign',
+    'channel.role.remove',
+    'channel.join_link.create',
+    'channel.join_link.revoke',
+    'channel.join_request.approve',
+    'channel.join_request.reject',
+    'channel.project_agent.invite',
+    'channel.project_agent.remove',
+    'channel.guard.update',
+    'channel.guard.reset',
+    'channel.webhook.add',
+    'channel.webhook.remove',
+    'channel.webhook.redeliver',
+    'channel.archive',
+    'channel.identity.erase',
+    'channel.export',
+    'channel.retention.update',
+    'membership.set'
+  )),
+  resource TEXT NOT NULL,
+  channel TEXT,
+  result TEXT NOT NULL CHECK (result = 'success'),
+  timestamp INTEGER NOT NULL,
+  metadata_json TEXT NOT NULL DEFAULT '{}'
+    CHECK (json_valid(metadata_json) AND length(metadata_json) <= 4096)
+);
+
+INSERT INTO management_audit_new (
+  id, cursor_token, actor_account, actor_kind, action, resource, channel, result, timestamp, metadata_json
+)
+SELECT id, cursor_token, actor_account, actor_kind, action, resource, channel, result, timestamp, metadata_json
+  FROM management_audit;
+
+DROP TABLE management_audit;
+ALTER TABLE management_audit_new RENAME TO management_audit;
+
+CREATE UNIQUE INDEX idx_management_audit_cursor_token ON management_audit(cursor_token);
+CREATE INDEX idx_management_audit_timestamp ON management_audit(id DESC);
+CREATE INDEX idx_management_audit_channel ON management_audit(channel, id DESC);

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -6249,18 +6249,52 @@ app.post("/api/channels/:slug/kick", async (c) => {
   return c.json({ ok: true });
 });
 
-// 人为暂停/恢复某 agent 的接待（issue #180）。授权口径同 kick：仅频道 moderator（房主 / legacy ap_）。
+type AgentReceptionController = "moderator" | "host";
+
+async function agentReceptionController(
+  db: D1Database,
+  slug: string,
+  identity: TokenIdentity,
+  channel: LoadedChannel,
+): Promise<AgentReceptionController | null> {
+  if (isChannelModerator(identity, channel)) return "moderator";
+  if (identity.kind !== "agent" || identity.role !== "agent") return null;
+  return (await loadAssignedRole(db, slug, identity)) === "host" ? "host" : null;
+}
+
+async function isActiveAgentReceptionTarget(db: D1Database, slug: string, name: string): Promise<boolean> {
+  const row = await db.prepare(
+    `SELECT 1 AS found
+       FROM tokens
+      WHERE name = ?
+        AND role = 'agent'
+        AND revoked_at IS NULL
+        AND (child_expires_at IS NULL OR child_expires_at > ?)
+        AND (channel_scope IS NULL OR channel_scope = ?)`,
+  )
+    .bind(name, Date.now(), slug)
+    .first<{ found: number }>();
+  return row !== null;
+}
+
+// 人为暂停/恢复某 agent 的接待（issue #180/#439）。房主 / legacy ap_ 保持原权限；频道 host agent
+// 也可在本频道止损，但只能控制有效且未被 scope 到其他频道的 agent token，不能借此管理人类。
 // 暂停后该 agent 被 @ 也不唤醒（webhook 不投、serve/watch 自我抑制），消息仍进历史；可带 resume_at 定时恢复。
 app.post("/api/channels/:slug/presence/:name/pause", async (c) => {
   const slug = c.req.param("slug");
   const channel = await loadChannel(c.env.DB, slug);
   if (!channel) return c.json(errorBody("not_found", "channel not found"), 404);
-  if (!isChannelModerator(c.get("identity"), channel)) {
-    return c.json(errorBody("forbidden", "only the channel owner or an ap_ token can pause an agent"), 403);
+  const identity = c.get("identity");
+  const controller = await agentReceptionController(c.env.DB, slug, identity, channel);
+  if (controller === null) {
+    return c.json(errorBody("forbidden", "only the channel owner, an ap_ moderator, or a host agent can pause an agent"), 403);
   }
   const name = c.req.param("name");
   if (!name || name.length > 256) {
     return c.json(errorBody("bad_request", "valid name required"), 400);
+  }
+  if (controller === "host" && !(await isActiveAgentReceptionTarget(c.env.DB, slug, name))) {
+    return c.json(errorBody("forbidden", "host agents can only pause an active agent in this channel"), 403);
   }
   const body = (await c.req.json().catch(() => null)) as { resume_at?: unknown } | null;
   const res = await fetchChannelDO(
@@ -6272,6 +6306,15 @@ app.post("/api/channels/:slug/presence/:name/pause", async (c) => {
       headers: { "content-type": "application/json", "x-partykit-room": slug },
     }),
   );
+  if (res.ok) {
+    await bestEffortRecordManagementAudit(c.env.DB, {
+      actor: managementAuditActor(identity),
+      action: "agent.reception.pause",
+      resource: `channel/${slug}/agents/${name}/reception`,
+      channel: slug,
+      metadata: { resume_at: body?.resume_at ?? null },
+    });
+  }
   return res;
 });
 
@@ -6279,12 +6322,17 @@ app.post("/api/channels/:slug/presence/:name/resume", async (c) => {
   const slug = c.req.param("slug");
   const channel = await loadChannel(c.env.DB, slug);
   if (!channel) return c.json(errorBody("not_found", "channel not found"), 404);
-  if (!isChannelModerator(c.get("identity"), channel)) {
-    return c.json(errorBody("forbidden", "only the channel owner or an ap_ token can resume an agent"), 403);
+  const identity = c.get("identity");
+  const controller = await agentReceptionController(c.env.DB, slug, identity, channel);
+  if (controller === null) {
+    return c.json(errorBody("forbidden", "only the channel owner, an ap_ moderator, or a host agent can resume an agent"), 403);
   }
   const name = c.req.param("name");
   if (!name || name.length > 256) {
     return c.json(errorBody("bad_request", "valid name required"), 400);
+  }
+  if (controller === "host" && !(await isActiveAgentReceptionTarget(c.env.DB, slug, name))) {
+    return c.json(errorBody("forbidden", "host agents can only resume an active agent in this channel"), 403);
   }
   const res = await fetchChannelDO(
     c.env,
@@ -6294,6 +6342,14 @@ app.post("/api/channels/:slug/presence/:name/resume", async (c) => {
       headers: { "content-type": "application/json", "x-partykit-room": slug },
     }),
   );
+  if (res.ok) {
+    await bestEffortRecordManagementAudit(c.env.DB, {
+      actor: managementAuditActor(identity),
+      action: "agent.reception.resume",
+      resource: `channel/${slug}/agents/${name}/reception`,
+      channel: slug,
+    });
+  }
   return res;
 });
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -6259,6 +6259,7 @@ async function agentReceptionController(
 ): Promise<AgentReceptionController | null> {
   if (isChannelModerator(identity, channel)) return "moderator";
   if (identity.kind !== "agent" || identity.role !== "agent") return null;
+  if (identity.channel_scope != null && identity.channel_scope !== slug) return null;
   return (await loadAssignedRole(db, slug, identity)) === "host" ? "host" : null;
 }
 

--- a/worker/src/management-audit.ts
+++ b/worker/src/management-audit.ts
@@ -8,6 +8,8 @@ export type ManagementAuditAction =
   | "token.issue"
   | "token.revoke"
   | "agent.nickname.update"
+  | "agent.reception.pause"
+  | "agent.reception.resume"
   | "channel.create"
   | "channel.permissions.update"
   | "channel.visibility.update"
@@ -126,6 +128,12 @@ function safeMetadata(action: ManagementAuditAction, input: unknown): Record<str
   }
   if (action === "channel.guard.reset") {
     return metadata.guard === "loop" || metadata.guard === "workflow" ? { guard: metadata.guard } : {};
+  }
+  if (action === "agent.reception.pause") {
+    const resumeAt = metadata.resume_at;
+    return resumeAt === null || (typeof resumeAt === "number" && Number.isSafeInteger(resumeAt) && resumeAt > 0)
+      ? { resume_at: resumeAt }
+      : {};
   }
   if (action === "channel.identity.erase") {
     // GDPR 硬擦除（#421）：只留各表命中数（纯数字，无内容），供合规追溯「删了多少行」。

--- a/worker/test/pause-reception.spec.ts
+++ b/worker/test/pause-reception.spec.ts
@@ -205,27 +205,29 @@ describe("暂停接待（issue #180）", () => {
     }));
   });
 
-  it("host agent 只能控制有效 agent，不能暂停 human 或其他频道 scope 的 agent", async () => {
+  it("host agent 只能控制有效 agent，不能暂停 human、过期或其他频道 scope 的 agent", async () => {
     const owner = await seedToken("agent");
     const slug = await createChannel(owner.token);
     const host = await seedToken("agent", uniq("host-agent"), { owner: `${uniq("host")}@example.com`, channelScope: slug });
     await assignHost(slug, owner.token, host.name);
     const human = await seedToken("human", uniq("human-target"), { channelScope: slug });
+    const expired = await seedToken("agent", uniq("expired-agent"), { channelScope: slug, childExpiresAt: Date.now() - 1_000 });
     const otherScoped = await seedToken("agent", uniq("other-agent"), { channelScope: uniq("other-channel") });
 
     expect((await pause(slug, host.token, human.name)).status).toBe(403);
+    expect((await pause(slug, host.token, expired.name)).status).toBe(403);
     expect((await pause(slug, host.token, otherScoped.name)).status).toBe(403);
     expect((await resume(slug, host.token, human.name)).status).toBe(403);
     expect((await managementAudit(slug, owner.token)).filter((entry) => entry.action.startsWith("agent.reception."))).toHaveLength(0);
   });
 
-  it("另一个频道的 host 角色不能跨频道暂停 agent", async () => {
+  it("scope 在另一个频道的 token 即使被分配当前频道 host，也不能跨频道暂停 agent", async () => {
     const owner = await seedToken("agent");
     const slug = await createChannel(owner.token);
     const otherSlug = await createChannel(owner.token);
     const hostAccount = `${uniq("host")}@example.com`;
-    const host = await seedToken("agent", uniq("host-agent"), { owner: hostAccount });
-    await assignHost(otherSlug, owner.token, host.name);
+    const host = await seedToken("agent", uniq("host-agent"), { owner: hostAccount, channelScope: otherSlug });
+    await assignHost(slug, owner.token, host.name);
     const target = await seedToken("agent", uniq("target"), { channelScope: slug });
 
     expect((await pause(slug, host.token, target.name)).status).toBe(403);

--- a/worker/test/pause-reception.spec.ts
+++ b/worker/test/pause-reception.spec.ts
@@ -233,6 +233,7 @@ describe("暂停接待（issue #180）", () => {
     const target = await seedToken("agent", uniq("target"), { channelScope: slug });
 
     expect((await pause(slug, host.token, target.name)).status).toBe(403);
+    expect((await resume(slug, host.token, target.name)).status).toBe(403);
     expect((await presenceOf(slug, owner.token, target.name))?.paused).toBeUndefined();
   });
 

--- a/worker/test/pause-reception.spec.ts
+++ b/worker/test/pause-reception.spec.ts
@@ -59,6 +59,34 @@ async function bodiesInHistory(slug: string, token: string): Promise<string[]> {
   return body.messages.map((m) => m.body);
 }
 
+async function assignHost(slug: string, moderatorToken: string, name: string): Promise<void> {
+  const res = await api(`/api/channels/${slug}/roles/${encodeURIComponent(name)}`, moderatorToken, {
+    method: "PUT",
+    body: JSON.stringify({ role: "host" }),
+  });
+  if (!res.ok) throw new Error(`assign host failed: ${res.status} ${await res.text()}`);
+}
+
+async function managementAudit(slug: string, token: string): Promise<Array<{
+  actor_account: string | null;
+  actor_kind: string;
+  action: string;
+  resource: string;
+  channel: string | null;
+  metadata: Record<string, unknown>;
+}>> {
+  const res = await api(`/api/channels/${slug}/management-audit?limit=100`, token);
+  if (!res.ok) throw new Error(`management audit failed: ${res.status}`);
+  return ((await res.json()) as { audit: Array<{
+    actor_account: string | null;
+    actor_kind: string;
+    action: string;
+    resource: string;
+    channel: string | null;
+    metadata: Record<string, unknown>;
+  }> }).audit;
+}
+
 describe("暂停接待（issue #180）", () => {
   it("被暂停的 agent 被 @ 时不投 webhook（唤醒被抑制），但消息仍进历史", async () => {
     const { token } = await seedToken("agent");
@@ -141,6 +169,67 @@ describe("暂停接待（issue #180）", () => {
     expect(res.status).toBe(403);
     // 未真的暂停
     expect((await presenceOf(slug, token, target))?.paused).toBeUndefined();
+  });
+
+  it("频道 host agent 可暂停并恢复 agent，且两次止损操作都可审计（#439）", async () => {
+    const owner = await seedToken("agent");
+    const slug = await createChannel(owner.token);
+    const target = await seedToken("agent", uniq("runaway"), { channelScope: slug });
+    const hostAccount = `${uniq("host")}@example.com`;
+    const host = await seedToken("agent", uniq("host-agent"), { owner: hostAccount, channelScope: slug });
+    await assignHost(slug, owner.token, host.name);
+
+    const resumeAt = Date.now() + 60_000;
+    expect((await pause(slug, host.token, target.name, resumeAt)).status).toBe(200);
+    expect((await presenceOf(slug, owner.token, target.name))?.paused).toBe(true);
+    expect((await resume(slug, host.token, target.name)).status).toBe(200);
+    expect((await presenceOf(slug, owner.token, target.name))?.paused).toBeUndefined();
+
+    const audit = await managementAudit(slug, owner.token);
+    const resource = `channel/${slug}/agents/${target.name}/reception`;
+    expect(audit).toContainEqual(expect.objectContaining({
+      actor_account: hostAccount,
+      actor_kind: "agent",
+      action: "agent.reception.pause",
+      resource,
+      channel: slug,
+      metadata: { resume_at: resumeAt },
+    }));
+    expect(audit).toContainEqual(expect.objectContaining({
+      actor_account: hostAccount,
+      actor_kind: "agent",
+      action: "agent.reception.resume",
+      resource,
+      channel: slug,
+      metadata: {},
+    }));
+  });
+
+  it("host agent 只能控制有效 agent，不能暂停 human 或其他频道 scope 的 agent", async () => {
+    const owner = await seedToken("agent");
+    const slug = await createChannel(owner.token);
+    const host = await seedToken("agent", uniq("host-agent"), { owner: `${uniq("host")}@example.com`, channelScope: slug });
+    await assignHost(slug, owner.token, host.name);
+    const human = await seedToken("human", uniq("human-target"), { channelScope: slug });
+    const otherScoped = await seedToken("agent", uniq("other-agent"), { channelScope: uniq("other-channel") });
+
+    expect((await pause(slug, host.token, human.name)).status).toBe(403);
+    expect((await pause(slug, host.token, otherScoped.name)).status).toBe(403);
+    expect((await resume(slug, host.token, human.name)).status).toBe(403);
+    expect((await managementAudit(slug, owner.token)).filter((entry) => entry.action.startsWith("agent.reception."))).toHaveLength(0);
+  });
+
+  it("另一个频道的 host 角色不能跨频道暂停 agent", async () => {
+    const owner = await seedToken("agent");
+    const slug = await createChannel(owner.token);
+    const otherSlug = await createChannel(owner.token);
+    const hostAccount = `${uniq("host")}@example.com`;
+    const host = await seedToken("agent", uniq("host-agent"), { owner: hostAccount });
+    await assignHost(otherSlug, owner.token, host.name);
+    const target = await seedToken("agent", uniq("target"), { channelScope: slug });
+
+    expect((await pause(slug, host.token, target.name)).status).toBe(403);
+    expect((await presenceOf(slug, owner.token, target.name))?.paused).toBeUndefined();
   });
 
   it("resume_at 必须是未来的整数 epoch-ms，否则 400", async () => {

--- a/worker/test/pause-reception.spec.ts
+++ b/worker/test/pause-reception.spec.ts
@@ -205,19 +205,21 @@ describe("暂停接待（issue #180）", () => {
     }));
   });
 
-  it("host agent 只能控制有效 agent，不能暂停 human、过期或其他频道 scope 的 agent", async () => {
+  it("host agent 只能控制有效 agent，不能暂停或恢复 human、已撤销、过期或其他频道 scope 的 agent", async () => {
     const owner = await seedToken("agent");
     const slug = await createChannel(owner.token);
     const host = await seedToken("agent", uniq("host-agent"), { owner: `${uniq("host")}@example.com`, channelScope: slug });
     await assignHost(slug, owner.token, host.name);
     const human = await seedToken("human", uniq("human-target"), { channelScope: slug });
+    const revoked = await seedToken("agent", uniq("revoked-agent"), { channelScope: slug });
+    await env.DB.prepare("UPDATE tokens SET revoked_at = ? WHERE name = ?").bind(Date.now(), revoked.name).run();
     const expired = await seedToken("agent", uniq("expired-agent"), { channelScope: slug, childExpiresAt: Date.now() - 1_000 });
     const otherScoped = await seedToken("agent", uniq("other-agent"), { channelScope: uniq("other-channel") });
 
-    expect((await pause(slug, host.token, human.name)).status).toBe(403);
-    expect((await pause(slug, host.token, expired.name)).status).toBe(403);
-    expect((await pause(slug, host.token, otherScoped.name)).status).toBe(403);
-    expect((await resume(slug, host.token, human.name)).status).toBe(403);
+    for (const target of [human, revoked, expired, otherScoped]) {
+      expect((await pause(slug, host.token, target.name)).status).toBe(403);
+      expect((await resume(slug, host.token, target.name)).status).toBe(403);
+    }
     expect((await managementAudit(slug, owner.token)).filter((entry) => entry.action.startsWith("agent.reception."))).toHaveLength(0);
   });
 


### PR DESCRIPTION
## 依赖

暂时堆叠在 #445 上，因为本 PR 的管理审计迁移必须接续其 `0035`。#445 合并后会把 base 切回 `main` 再合并。

## 变更
- 房主/legacy ap_ 的暂停恢复权限保持不变
- 频道内账号绑定的 `host` agent 可暂停/恢复本频道 agent，普通 worker/reviewer/observer 仍为 403
- host 只能控制有效 agent token；human、撤销/过期、被 scope 到其他频道的目标均拒绝
- host 角色按既有 owner_account 绑定校验，其他频道的 host 不能跨频道操作
- pause/resume 写入独立管理审计动作，并新增 0036 迁移

## 验证
- `vitest run test/pause-reception.spec.ts`：12/12
- `tsc --noEmit`：通过
- `check-migration-numbering`：通过
- 变异验证：将 host 角色判定改为 worker 后，正向权限用例失败

Closes #439

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增更细粒度的接待暂停/恢复控制：仅频道 Host Agent 可对其频道内“仍处于有效接待目标”的 Agent 执行操作；暂停支持可选 `resume_at`，恢复后自动清除暂停状态。
  * 管理审计新增 `agent.reception.pause` / `agent.reception.resume` 记录：暂停会写入 `resume_at`（若未提供则为空），恢复记录元数据为空对象。
* **错误修复**
  * 加强权限与目标有效性校验：跨频道、已撤销、已过期或非 Agent 等场景将被拒绝，且不会产生对应审计记录。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->