### PR TITLE
feat(cli): party worktree list/prune——安全清理 worktree（patch-equiv 检测 + dirty 保全，#455）

### DIFF
--- a/cli/src/commands/worktree.ts
+++ b/cli/src/commands/worktree.ts
@@ -171,6 +171,13 @@ export async function classifyWorktrees(
 
     // dirty 检测：在该 worktree 内跑 status --porcelain。
     const status = await git(["-C", w.path, "status", "--porcelain"], root);
+    if (status.code !== 0) {
+      // status 拿不到（磁盘/权限/索引损坏）——状态未知。空 stdout 绝不能被读成
+      // dirty=0 → merged-clean → 删。保守当未合，留给人处理，别误删。
+      row.status = "unmerged";
+      rows.push(row);
+      continue;
+    }
     row.dirty = status.stdout.split("\n").filter((l) => l.trim() !== "").length;
 
     if (row.ahead === 0) {

--- a/cli/src/commands/worktree.ts
+++ b/cli/src/commands/worktree.ts
@@ -1,0 +1,363 @@
+// party worktree list|prune — 安全清理 agentparty 并行开发留下的 worktree（issue #455）。
+//
+// 判『能否安全删』不能靠 ahead 计数——squash/rebase-merge 会把 patch 揉进 main 却留下不同 SHA，
+// 单看 ahead 会把已合工作误判成未合。#450 手动考古验证过的正确三步（本命令原样产品化）：
+//   1. patch-equivalent 检测：`git cherry <base> <branch>` 数 '+' 提交——0 个 = 内容已在 base。
+//   2. dirty 保全：worktree 有未提交改动时【绝不 --force 丢活】——先 commit+push 到 preserve/*，再删。
+//   3. 未合价值：有 '+' 提交 → skip + 报告，交作者追 main 开 PR。
+import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
+
+const HELP = `usage: party worktree list [--base <ref>] [--json]
+       party worktree prune [--base <ref>] [--dry-run] [--remote] [--yes]
+
+Safely tear down git worktrees left by parallel agent development (#455).
+
+Status is decided by patch-equivalence, NOT ahead-count (squash/rebase-merge
+would otherwise mis-flag merged work as unmerged):
+  merged-clean  git cherry <base> <branch> has 0 '+' commits AND worktree is clean
+  merged-dirty  patch-equivalent merged BUT has uncommitted changes
+  unmerged      has '+' commits not in base (real unmerged work)
+
+list   print every worktree with its status + (commits-ahead / dirty-file-count).
+
+prune  DEFAULT IS --dry-run: print the plan, do nothing. Pass --yes to execute.
+  merged-clean -> git worktree remove + git branch -D  (+ push --delete if --remote)
+  merged-dirty -> commit + push origin HEAD:preserve/<branch>, THEN remove (never
+                  --force-loses work; if preserve fails the worktree is SKIPPED)
+  unmerged     -> SKIP + report so you can open a PR
+  Never touches the main working tree, the current worktree, or a locked worktree.
+
+Options:
+  --base <ref>   base to compare against (default: origin/main)
+  --json         (list) machine-readable output
+  --dry-run      (prune) print plan only — this is the default
+  --remote       (prune) also delete the remote branch for merged-clean
+  --yes          (prune) actually execute the plan`;
+
+const FLAGS = ["base"];
+const BOOLEANS = ["json", "dry-run", "remote", "yes"];
+
+export interface GitResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+export type GitRunner = (args: string[], cwd: string) => Promise<GitResult>;
+
+const defaultGit: GitRunner = async (args, cwd) => {
+  const proc = Bun.spawn(["git", ...args], {
+    cwd,
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, code] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { code, stdout, stderr };
+};
+
+export type WorktreeStatus =
+  | "merged-clean"
+  | "merged-dirty"
+  | "unmerged"
+  | "main"
+  | "current"
+  | "locked"
+  | "detached";
+
+export interface WorktreeRow {
+  path: string;
+  branch: string | null;
+  status: WorktreeStatus;
+  ahead: number; // '+' commits not patch-equivalent in base
+  dirty: number; // uncommitted file count
+}
+
+interface RawWorktree {
+  path: string;
+  branch: string | null; // short branch name, null if detached
+  detached: boolean;
+  locked: boolean;
+  bare: boolean;
+}
+
+// 解析 `git worktree list --porcelain`：block 之间空行分隔，主工作树是第一个 block。
+export function parseWorktreePorcelain(out: string): RawWorktree[] {
+  const blocks: RawWorktree[] = [];
+  let cur: RawWorktree | null = null;
+  for (const line of out.split("\n")) {
+    if (line === "") {
+      if (cur) blocks.push(cur);
+      cur = null;
+      continue;
+    }
+    if (line.startsWith("worktree ")) {
+      if (cur) blocks.push(cur);
+      cur = { path: line.slice("worktree ".length), branch: null, detached: false, locked: false, bare: false };
+      continue;
+    }
+    if (!cur) continue;
+    if (line.startsWith("branch ")) {
+      const ref = line.slice("branch ".length);
+      cur.branch = ref.startsWith("refs/heads/") ? ref.slice("refs/heads/".length) : ref;
+    } else if (line === "detached") {
+      cur.detached = true;
+    } else if (line === "bare") {
+      cur.bare = true;
+    } else if (line === "locked" || line.startsWith("locked ")) {
+      cur.locked = true;
+    }
+  }
+  if (cur) blocks.push(cur);
+  return blocks;
+}
+
+// 枚举 + 判定每个 worktree 的状态。root 是任一属于该仓的目录（通常 process.cwd()）。
+export async function classifyWorktrees(
+  root: string,
+  base: string,
+  git: GitRunner = defaultGit,
+): Promise<WorktreeRow[]> {
+  const list = await git(["worktree", "list", "--porcelain"], root);
+  if (list.code !== 0) {
+    throw new Error(`git worktree list failed: ${list.stderr.trim() || list.stdout.trim()}`);
+  }
+  const raws = parseWorktreePorcelain(list.stdout);
+
+  // 当前工作树（cwd 所在的顶层）——绝不删自己脚下的。
+  const top = await git(["rev-parse", "--show-toplevel"], root);
+  const currentPath = top.code === 0 ? top.stdout.trim() : "";
+
+  const rows: WorktreeRow[] = [];
+  for (let i = 0; i < raws.length; i++) {
+    const w = raws[i]!;
+    const row: WorktreeRow = { path: w.path, branch: w.branch, status: "unmerged", ahead: 0, dirty: 0 };
+
+    // 不可动的三类：主工作树（列表首项 / bare）、当前工作树、被锁的。
+    if (i === 0 || w.bare) {
+      row.status = "main";
+      rows.push(row);
+      continue;
+    }
+    if (w.path === currentPath) {
+      row.status = "current";
+      rows.push(row);
+      continue;
+    }
+    if (w.locked) {
+      row.status = "locked";
+      rows.push(row);
+      continue;
+    }
+    if (w.detached || !w.branch) {
+      row.status = "detached";
+      rows.push(row);
+      continue;
+    }
+
+    // patch-equivalent 检测：cherry 的 '+' 行 = 未在 base 里的提交。
+    const cherry = await git(["cherry", base, w.branch], root);
+    if (cherry.code !== 0) {
+      // base 解析不了或分支异常——保守起见当未合，别误删。
+      row.status = "unmerged";
+      rows.push(row);
+      continue;
+    }
+    row.ahead = cherry.stdout.split("\n").filter((l) => l.startsWith("+")).length;
+
+    // dirty 检测：在该 worktree 内跑 status --porcelain。
+    const status = await git(["-C", w.path, "status", "--porcelain"], root);
+    row.dirty = status.stdout.split("\n").filter((l) => l.trim() !== "").length;
+
+    if (row.ahead === 0) {
+      row.status = row.dirty > 0 ? "merged-dirty" : "merged-clean";
+    } else {
+      row.status = "unmerged";
+    }
+    rows.push(row);
+  }
+  return rows;
+}
+
+function detail(r: WorktreeRow): string {
+  if (r.status === "unmerged") return `${r.ahead} commit${r.ahead === 1 ? "" : "s"} ahead`;
+  if (r.status === "merged-dirty") return `${r.dirty} dirty file${r.dirty === 1 ? "" : "s"}`;
+  return "";
+}
+
+async function runList(root: string, base: string, json: boolean, git: GitRunner): Promise<number> {
+  const rows = await classifyWorktrees(root, base, git);
+  if (json) {
+    console.log(JSON.stringify(rows));
+    return 0;
+  }
+  console.log(`base: ${base}`);
+  for (const r of rows) {
+    const d = detail(r);
+    console.log(`${r.status.padEnd(13)} ${(r.branch ?? "(detached)").padEnd(28)} ${d.padEnd(16)} ${r.path}`);
+  }
+  return 0;
+}
+
+interface PruneAction {
+  row: WorktreeRow;
+  kind: "remove" | "preserve" | "skip";
+  reason: string;
+}
+
+function planPrune(rows: WorktreeRow[], remote: boolean): PruneAction[] {
+  return rows.map((row): PruneAction => {
+    switch (row.status) {
+      case "merged-clean":
+        return {
+          row,
+          kind: "remove",
+          reason: `remove worktree + branch ${row.branch}${remote ? " (+ remote)" : ""}`,
+        };
+      case "merged-dirty":
+        return {
+          row,
+          kind: "preserve",
+          reason: `commit + push -> preserve/${row.branch}, then remove worktree + branch`,
+        };
+      case "unmerged":
+        return { row, kind: "skip", reason: `unmerged (${row.ahead} ahead) — open a PR to main` };
+      default:
+        return { row, kind: "skip", reason: row.status };
+    }
+  });
+}
+
+async function removeMergedClean(
+  root: string,
+  action: PruneAction,
+  remote: boolean,
+  git: GitRunner,
+): Promise<boolean> {
+  const branch = action.row.branch!;
+  const rm = await git(["worktree", "remove", action.row.path], root);
+  if (rm.code !== 0) {
+    console.error(`  ! ${branch}: worktree remove failed, skipped — ${rm.stderr.trim()}`);
+    return false;
+  }
+  const del = await git(["branch", "-D", branch], root);
+  if (del.code !== 0) {
+    console.error(`  ! ${branch}: worktree removed but branch delete failed — ${del.stderr.trim()}`);
+  }
+  if (remote) {
+    const pushDel = await git(["push", "origin", "--delete", branch], root);
+    if (pushDel.code !== 0) {
+      console.error(`  ! ${branch}: remote branch delete failed — ${pushDel.stderr.trim()}`);
+    }
+  }
+  console.log(`  removed ${branch} (merged-clean)`);
+  return true;
+}
+
+// merged-dirty：绝不 --force 丢活。先把未提交改动 commit + push 到 preserve/*，全部成功才删。
+// 任一步失败 → 保留 worktree，跳过并告警，宁可留着让人处理也不丢工作。
+async function preserveAndRemove(root: string, action: PruneAction, git: GitRunner): Promise<boolean> {
+  const branch = action.row.branch!;
+  const path = action.row.path;
+  const add = await git(["-C", path, "add", "-A"], root);
+  if (add.code !== 0) {
+    console.error(`  ! ${branch}: git add failed, worktree preserved as-is — ${add.stderr.trim()}`);
+    return false;
+  }
+  const commit = await git(["-C", path, "commit", "-m", `wip: preserve ${branch} (#455)`], root);
+  if (commit.code !== 0) {
+    console.error(`  ! ${branch}: commit failed, worktree preserved as-is — ${commit.stderr.trim()}`);
+    return false;
+  }
+  const push = await git(["-C", path, "push", "origin", `HEAD:preserve/${branch}`], root);
+  if (push.code !== 0) {
+    console.error(`  ! ${branch}: push to preserve/${branch} failed, worktree preserved as-is — ${push.stderr.trim()}`);
+    return false;
+  }
+  // 改动已安全落到 origin/preserve/*，现在删本地 worktree+分支才不丢活。
+  const rm = await git(["worktree", "remove", "--force", path], root);
+  if (rm.code !== 0) {
+    console.error(`  ! ${branch}: preserved to preserve/${branch} but worktree remove failed — ${rm.stderr.trim()}`);
+    return false;
+  }
+  const del = await git(["branch", "-D", branch], root);
+  if (del.code !== 0) {
+    console.error(`  ! ${branch}: preserved + worktree removed but branch delete failed — ${del.stderr.trim()}`);
+  }
+  console.log(`  preserved ${branch} -> origin/preserve/${branch}, then removed (merged-dirty)`);
+  return true;
+}
+
+async function runPrune(
+  root: string,
+  base: string,
+  opts: { dryRun: boolean; remote: boolean; yes: boolean },
+  git: GitRunner,
+): Promise<number> {
+  const rows = await classifyWorktrees(root, base, git);
+  const actions = planPrune(rows, opts.remote);
+  const act = opts.yes && !opts.dryRun;
+
+  if (!act) {
+    console.log(`plan (dry-run — pass --yes to execute), base ${base}:`);
+    for (const a of actions) {
+      const b = a.row.branch ?? "(detached)";
+      console.log(`  ${a.kind.padEnd(8)} ${b.padEnd(28)} ${a.reason}  [${a.row.path}]`);
+    }
+    const removable = actions.filter((a) => a.kind !== "skip").length;
+    console.log(`\n${removable} worktree(s) would be cleaned, ${actions.length - removable} skipped. Re-run with --yes.`);
+    return 0;
+  }
+
+  console.log(`executing prune, base ${base}:`);
+  for (const a of actions) {
+    if (a.kind === "skip") {
+      const b = a.row.branch ?? "(detached)";
+      console.log(`  skip    ${b} — ${a.reason}`);
+      continue;
+    }
+    if (a.kind === "remove") await removeMergedClean(root, a, opts.remote, git);
+    else await preserveAndRemove(root, a, git);
+  }
+  return 0;
+}
+
+export async function run(argv: string[], git: GitRunner = defaultGit): Promise<number> {
+  if (isHelpArg(argv, { allowHelpPositional: true })) {
+    console.log(HELP);
+    return 0;
+  }
+  const { positionals, flags } = parseArgs(argv, { booleans: BOOLEANS });
+  const unknown = unknownFlagError(flags, [...FLAGS, ...BOOLEANS]);
+  if (unknown !== null) {
+    console.error(unknown);
+    return 1;
+  }
+  const flagError = valueFlagError(flags, FLAGS);
+  if (flagError !== null) {
+    console.error(flagError);
+    return 1;
+  }
+  const sub = positionals[0];
+  const base = str(flags.base) ?? "origin/main";
+  const root = process.cwd();
+
+  switch (sub) {
+    case "list":
+      return runList(root, base, flags.json === true, git);
+    case "prune":
+      return runPrune(
+        root,
+        base,
+        { dryRun: flags["dry-run"] === true, remote: flags.remote === true, yes: flags.yes === true },
+        git,
+      );
+    default:
+      console.error("usage: party worktree list|prune [--base <ref>]");
+      return 1;
+  }
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -53,6 +53,7 @@ commands:
   token     create --name n --role agent|human|readonly --owner label [--channel-scope slug] | revoke <name>   (ADMIN_SECRET env)
   membership activate --account a | deactivate --account a   owner-only: mark an account member/free (#277)   (ADMIN_SECRET env)
   gdpr      erase <name> [channel] --yes | export <name> [channel] [--json]   per-identity hard-erase / export (moderator, #421)
+  worktree  list [--base ref] [--json] | prune [--base ref] [--dry-run] [--remote] [--yes]   safely tear down stale dev worktrees (#455)
 
 watch defaults to a 240s timeout. With --follow, it stays attached unless --timeout N is explicit.
 
@@ -152,6 +153,8 @@ export async function main(argv: string[]): Promise<number> {
       return (await import("./commands/doctor")).run(rest);
     case "health":
       return (await import("./commands/health")).run(rest);
+    case "worktree":
+      return (await import("./commands/worktree")).run(rest);
     default:
       console.error(`unknown command: ${cmd}`);
       console.log(HELP);

--- a/cli/test/worktree.test.ts
+++ b/cli/test/worktree.test.ts
@@ -3,7 +3,7 @@ import { execFileSync } from "node:child_process";
 import { existsSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { classifyWorktrees, run } from "../src/commands/worktree";
+import { classifyWorktrees, type GitRunner, run } from "../src/commands/worktree";
 
 // 用真 git：临时仓库 + 真 worktree，覆盖 merged-clean / merged-dirty / unmerged 三态。
 // 不 mock git——命令的价值就在于对真 porcelain 输出的解析与真 cherry/status 判定。
@@ -87,6 +87,22 @@ describe("classifyWorktrees", () => {
     const realMain = realpathSync(main);
     const mainRow = rows.find((r) => r.path === realMain);
     expect(mainRow?.status).toBe("main");
+  });
+
+  test("git status 失败时绝不判 merged-clean（否则 prune 会删掉状态未知的 worktree）", async () => {
+    // 注入一个 runner：wt-mc 的 status --porcelain 失败（磁盘/权限/索引损坏等）。
+    // 空 stdout 绝不能被读成 dirty=0 → merged-clean → 删。status 拿不到 = 状态未知 = 保守保留。
+    // 命令形如 git(["-C", <wt路径>, "status", "--porcelain"], root)——按 args 内容匹配。
+    const failingGit: GitRunner = async (args, cwd) => {
+      if (args.includes("status") && args.some((a) => a.includes("wt-mc"))) {
+        return { code: 1, stdout: "", stderr: "fatal: simulated status failure" };
+      }
+      const out = execFileSync("git", args, { cwd, encoding: "utf8" });
+      return { code: 0, stdout: out, stderr: "" };
+    };
+    const rows = await classifyWorktrees(main, "main", failingGit);
+    const mc = rows.find((r) => r.branch === "mc");
+    expect(mc?.status).not.toBe("merged-clean");
   });
 });
 

--- a/cli/test/worktree.test.ts
+++ b/cli/test/worktree.test.ts
@@ -136,6 +136,18 @@ describe("party worktree prune", () => {
     expect(files).toContain("dirty.txt");
   });
 
+  test("--yes: preserve push 失败时 worktree 保留、脏活不丢（安全关键路径）", async () => {
+    // 把 origin 指到不存在的地址，preserve push 必失败
+    git(main, "remote", "set-url", "origin", join(root, "nonexistent-origin.git"));
+    const code = await run(["prune", "--base", "main", "--yes"]);
+    expect(code).toBe(0);
+    // push 失败 → 绝不删 worktree（脏活还在原地）
+    expect(existsSync(join(root, "wt-md"))).toBe(true);
+    expect(existsSync(join(root, "wt-md", "dirty.txt"))).toBe(true);
+    // 明确报了跳过/失败
+    expect(errs.join("\n").toLowerCase()).toContain("md");
+  });
+
   test("--yes skips unmerged: worktree + branch survive", async () => {
     const code = await run(["prune", "--base", "main", "--yes"]);
     expect(code).toBe(0);

--- a/cli/test/worktree.test.ts
+++ b/cli/test/worktree.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { classifyWorktrees, run } from "../src/commands/worktree";
+
+// 用真 git：临时仓库 + 真 worktree，覆盖 merged-clean / merged-dirty / unmerged 三态。
+// 不 mock git——命令的价值就在于对真 porcelain 输出的解析与真 cherry/status 判定。
+
+let root: string;
+let main: string; // 主工作树
+let origin: string; // 裸远端，供 preserve/* push
+let oldCwd: string;
+let logs: string[];
+let errs: string[];
+let oldLog: typeof console.log;
+let oldError: typeof console.error;
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+}
+
+function commitFile(cwd: string, name: string, content: string, msg: string): void {
+  writeFileSync(join(cwd, name), content);
+  git(cwd, "add", "-A");
+  git(cwd, "commit", "-m", msg);
+}
+
+beforeEach(() => {
+  oldCwd = process.cwd();
+  root = mkdtempSync(join(tmpdir(), "ap-worktree-"));
+  origin = join(root, "origin.git");
+  main = join(root, "main");
+
+  git(root, "init", "--bare", "origin.git");
+  git(root, "init", "-b", "main", "main");
+  git(main, "config", "user.email", "t@t.io");
+  git(main, "config", "user.name", "t");
+  git(main, "remote", "add", "origin", origin);
+  commitFile(main, "base.txt", "base\n", "init");
+  git(main, "push", "-u", "origin", "main");
+
+  // merged-clean: 分支提交了改动，同一 patch 也进了 main（cherry -> '-'），工作树干净。
+  git(main, "worktree", "add", "-b", "mc", join(root, "wt-mc"), "main");
+  commitFile(join(root, "wt-mc"), "mc.txt", "mc-change\n", "mc: add file");
+  const mcSha = git(join(root, "wt-mc"), "rev-parse", "HEAD");
+  git(main, "cherry-pick", mcSha); // main 现在 patch-equivalent 含 mc 的改动
+
+  // merged-dirty: 同上 patch-equivalent，但工作树留未提交改动。
+  git(main, "worktree", "add", "-b", "md", join(root, "wt-md"), "main");
+  commitFile(join(root, "wt-md"), "md.txt", "md-change\n", "md: add file");
+  const mdSha = git(join(root, "wt-md"), "rev-parse", "HEAD");
+  git(main, "cherry-pick", mdSha);
+  writeFileSync(join(root, "wt-md", "dirty.txt"), "uncommitted work\n"); // 脏
+
+  // unmerged: 分支有真未合提交（cherry -> '+'）。
+  git(main, "worktree", "add", "-b", "un", join(root, "wt-un"), "main");
+  commitFile(join(root, "wt-un"), "un.txt", "un-change\n", "un: real unmerged work");
+
+  process.chdir(main);
+  logs = [];
+  errs = [];
+  oldLog = console.log;
+  oldError = console.error;
+  console.log = (line?: unknown) => logs.push(String(line));
+  console.error = (line?: unknown) => errs.push(String(line));
+});
+
+afterEach(() => {
+  process.chdir(oldCwd);
+  console.log = oldLog;
+  console.error = oldError;
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("classifyWorktrees", () => {
+  test("classifies merged-clean / merged-dirty / unmerged, skips main", async () => {
+    const rows = await classifyWorktrees(main, "main");
+    const by = (b: string) => rows.find((r) => r.branch === b);
+    expect(by("mc")?.status).toBe("merged-clean");
+    expect(by("md")?.status).toBe("merged-dirty");
+    expect(by("md")?.dirty).toBeGreaterThan(0);
+    expect(by("un")?.status).toBe("unmerged");
+    expect(by("un")?.ahead).toBeGreaterThan(0);
+    // 主工作树永远是 skip（不能删）。git 会 realpath（macOS /var -> /private/var）。
+    const realMain = realpathSync(main);
+    const mainRow = rows.find((r) => r.path === realMain);
+    expect(mainRow?.status).toBe("main");
+  });
+});
+
+describe("party worktree list", () => {
+  test("--json emits the three states", async () => {
+    const code = await run(["list", "--base", "main", "--json"]);
+    expect(code).toBe(0);
+    const out = JSON.parse(logs.join(""));
+    const statuses = Object.fromEntries(out.map((r: any) => [r.branch, r.status]));
+    expect(statuses.mc).toBe("merged-clean");
+    expect(statuses.md).toBe("merged-dirty");
+    expect(statuses.un).toBe("unmerged");
+  });
+});
+
+describe("party worktree prune", () => {
+  test("default is dry-run: touches nothing", async () => {
+    const code = await run(["prune", "--base", "main"]);
+    expect(code).toBe(0);
+    expect(existsSync(join(root, "wt-mc"))).toBe(true);
+    expect(existsSync(join(root, "wt-md"))).toBe(true);
+    expect(existsSync(join(root, "wt-un"))).toBe(true);
+    // 分支都还在
+    const branches = git(main, "branch", "--format=%(refname:short)");
+    expect(branches).toContain("mc");
+    expect(logs.join("\n").toLowerCase()).toContain("dry-run");
+  });
+
+  test("--yes removes merged-clean worktree + branch", async () => {
+    const code = await run(["prune", "--base", "main", "--yes"]);
+    expect(code).toBe(0);
+    expect(existsSync(join(root, "wt-mc"))).toBe(false);
+    const branches = git(main, "branch", "--format=%(refname:short)").split("\n");
+    expect(branches).not.toContain("mc");
+  });
+
+  test("--yes preserves merged-dirty to preserve/* BEFORE removing (never loses work)", async () => {
+    const code = await run(["prune", "--base", "main", "--yes"]);
+    expect(code).toBe(0);
+    // 工作树删了
+    expect(existsSync(join(root, "wt-md"))).toBe(false);
+    // 但脏改动被 push 到 origin 的 preserve/md，内容没丢
+    const remoteRefs = git(main, "ls-remote", "--heads", "origin");
+    expect(remoteRefs).toContain("refs/heads/preserve/md");
+    // preserve 分支里确实含那份未提交的文件
+    const files = git(main, "ls-tree", "-r", "--name-only", "origin/preserve/md");
+    expect(files).toContain("dirty.txt");
+  });
+
+  test("--yes skips unmerged: worktree + branch survive", async () => {
+    const code = await run(["prune", "--base", "main", "--yes"]);
+    expect(code).toBe(0);
+    expect(existsSync(join(root, "wt-un"))).toBe(true);
+    const branches = git(main, "branch", "--format=%(refname:short)").split("\n");
+    expect(branches).toContain("un");
+    expect(logs.join("\n")).toContain("un");
+  });
+});


### PR DESCRIPTION
review-ack: 把 #450 的一次性人肉 worktree 考古产品化成 `party worktree` 命令（owner 指出的『鼓励 worktree 却没善后』弊端）。

## 命令
- `party worktree list [--base] [--json]`：列 worktree + 自动分类 merged-clean / merged-dirty / unmerged。
- `party worktree prune [--base] [--dry-run] [--remote] [--yes]`（默认 dry-run）：merged-clean 删；**merged-dirty 先 commit+push 到 preserve/* 再删（绝不 --force 丢活，push 失败则跳过保留）**；unmerged skip+报告。
- 保护：主工作树/当前 worktree/locked/detached 一律不碰。

## 判定
用 `git cherry` patch-equivalent（不靠 ahead 计数——squash/rebase-merge 会误判），正是 #450 手动验证过的算法。

## 门禁 + 集成审查逮到的缺口
- cli worktree 7/7、tsc 0、rebase 无冲突。
- 变异：跳过 preserve → 丢活测试红；无 --yes/dry-run 守卫 → dry-run 测试红。
- **我审查时发现原测试没覆盖『preserve push 失败→绝不删』这条安全关键路径**（变异不咬），已补测试（remote 打坏使 push 必败、断言 worktree 保留、dirty 留原地），现变异该守卫会红。这正是软阻断+review-ack 要的价值——读+验证逮到覆盖缺口。

## 后续（#455 scoped out）
PR 合并时 webhook/hook 自动删对应 worktree——从源头不积压。

🤖 opus agent 实现 + 我逐行审 + 补安全测试 + 变异亲验。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增 `party worktree list`：展示各 worktree 的合并/清理状态、领先提交数及未提交变更数。
  - 新增 `party worktree prune`：默认预览清理计划（dry-run），仅在确认后执行安全清理；可选删除对应远程分支。
  - 对已合并但有改动的工作树会先保存并推送到 `preserve/*`，失败则保留并提示，避免数据丢失。
- **文档**
  - 更新 CLI 帮助信息，补充 `worktree` 命令用法与选项。
- **测试**
  - 新增 worktree 端到端集成测试，覆盖 list/prune 多场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->