### PR TITLE
fix(watch): 避免监听器退出后假在线

### DIFF
--- a/cli/src/commands/invite.ts
+++ b/cli/src/commands/invite.ts
@@ -257,14 +257,16 @@ ${checkinLines}
 #   维护任务台账（别和实际漂移）：认领 party task claim <id>（或 party task create）→ 开工 party status working --task <id> → 完成 party status done --task <id>
 # 保持能被叫醒（先选对 runtime；选错会“看起来在线但没人处理 @”）：
 #   Codex CLI / Codex tool-call shell：不要用 watch 当 wake 层；用 party serve + codex exec resume。
-#   Claude Code / 已证明“后台进程退出会唤醒同一会话”的 harness：可以用 watch --once，每次唤醒后要重挂。
+#   Claude Code 的 run_in_background 可能在回合边界被回收：watch --once 只算当前回合临时等待，绝不算耐久在线。
+#   耐久 Claude 项目 agent：从持久 terminal 跑 party serve ${slug} --runner claude。
+#   其它已证明会保留后台任务并在退出时唤醒同一会话的 harness：可用 watch --once，每次唤醒后重挂。
 #   未知 harness：用 party serve，并让别人从另一个身份 party wake test @你 验证。
 #   watch --follow：只适合 tail/debug；它只是打印，不会自动唤醒 agent。
 #
 # 核心原则：保住你自己会话的上下文，别每次失忆冷起。
-#   ◆ Claude Code：后台任务待命——唤醒发生在你当前会话里，session 上下文 100% 保留：
+#   ◆ Claude Code 回合内临时等待（非耐久 presence；回合切换可能被 kill）：
 #     用 run_in_background 跑：party watch ${slug} --mentions-only --once
-#     被 @ 时它退出 → harness 自动把结果作为新一轮唤醒你 → 处理完再跑它一次继续待命。
+#     每个 turn 都要重挂；无人值守请改用：party serve ${slug} --runner claude
 #   ★ Codex / 其它 harness / 通用：party serve ${slug} --on-mention '<唤醒命令，见下>'
 #     常驻 supervisor 替你等、被 @ 才拉起你一次，等待零 token；挂上即自动声明「可被唤醒」
 #     （别人可用 party wake test @你 验证）。唤醒命令务必「续会话」而非冷起，session 上下文才不丢：

--- a/cli/src/commands/watch.ts
+++ b/cli/src/commands/watch.ts
@@ -28,19 +28,19 @@ const HELP = `usage: party watch [channel|--channel C] [--timeout N] [--mentions
 Watch a channel for new messages. By default this waits up to 240 seconds.
 With --follow, it stays attached unless --timeout N is explicit.
 With --once, it stays attached until the FIRST matching message, prints it, and
-exits 0 — made for harness background tasks (e.g. Claude Code run_in_background):
-the process exit is the wake signal, so the mention lands in your EXISTING
-session with its context intact.
+exits 0. It is only a wake signal while the harness keeps that background task
+alive. Claude Code may kill run_in_background tasks at turn boundaries, so this
+is turn-scoped best effort, not durable unattended presence.
 For --mentions-only --once, an uninitialized cursor (0) attaches at the current
 channel head to avoid replaying old mentions. Use --since 0 to request backlog.
 Self messages are skipped by default; --exclude-self is accepted as an explicit
 automation hint for scripts that want to document that behavior.
 NOTE: --follow only PRINTS messages. Most harnesses (Codex included) never turn
 background output into a new agent turn, so a mention can sit unread while you
-look online. --once is only a wake layer when your harness proves that process
-exit resumes the same agent session. Codex CLI does not; for Codex/unknown
-harnesses keep a durable supervisor with:
-  party serve <channel> --on-mention '<cmd>'
+look online. --once is only a wake layer while your harness preserves the task
+and proves that process exit resumes the same agent session. For durable Claude
+Code/Codex presence, run a project agent from a persistent terminal with:
+  party serve <channel> --runner claude|codex
 Verify the whole chain from another identity with: party wake test @<you>
 
 Options:
@@ -60,7 +60,8 @@ Options:
 export const FOLLOW_WAKE_ADVISORY =
   "note: --follow only prints; unless your harness turns background output into a new agent turn " +
   "(Codex does not), mentions will sit here unread while you look online. " +
-  "Prefer --once (exit = wake signal) or: party serve <channel> --on-mention '<cmd>'. " +
+  "Use --once only for a turn-scoped wait, or a durable project agent with: " +
+  "party serve <channel> --runner claude|codex. " +
   "Verify from another identity: party wake test @<you>";
 
 export const ONCE_CODEX_ADVISORY =
@@ -68,17 +69,22 @@ export const ONCE_CODEX_ADVISORY =
   "Use `party serve <channel> --on-mention '<codex exec resume ...; party send ...>'` " +
   "from a durable supervisor (tmux/launchctl/daemon), then verify with `party wake test @<you>`.";
 
-export const ONCE_REARM_ADVISORY =
-  "note: --once is single-shot. Re-arm it after handling this wake, or use `party serve` for Codex/unknown harnesses.";
+export const ONCE_CLAUDE_ADVISORY =
+  "warning: Claude Code may kill `run_in_background` watchers at a turn boundary. " +
+  "This --once listener is only a turn-scoped wait; re-arm it every turn and do not claim durable presence. " +
+  "For unattended wake, run `party serve <channel> --runner claude` from a persistent terminal/project agent.";
 
-/** Claude Code：后台任务退出即唤醒同一会话，watch --once 在它上面正常工作。 */
+export const ONCE_REARM_ADVISORY =
+  "note: --once is single-shot and harness-scoped. Re-arm it every turn, or use `party serve --runner claude|codex` for durable presence.";
+
+/** Claude Code 环境：可做回合内 --once，但 run_in_background 可能在回合边界被回收（#454）。 */
 export function isClaudeCodeEnv(env: Record<string, string | undefined> = process.env): boolean {
   return env.CLAUDECODE !== undefined || Object.keys(env).some((key) => key.startsWith("CLAUDE_CODE_"));
 }
 
 export function isCodexRuntimeEnv(env: Record<string, string | undefined> = process.env): boolean {
-  // Claude Code 优先短路（#175）：它装 codex 插件/companion 时 env 里也会有 CODEX_* 变量，
-  // 但它的后台退出会唤醒——那条「Codex 不会唤醒你、改用 serve」的警告对它是反的。
+  // Claude Code 优先短路（#175）：它装 codex 插件/companion 时 env 里也会有 CODEX_* 变量；
+  // 它需要 #454 的 turn-scoped 警告，而不是 Codex 的「退出不会唤醒」警告。
   if (isClaudeCodeEnv(env)) return false;
   return Object.keys(env).some((key) => key === "CODEX" || key.startsWith("CODEX_") || key.startsWith("OPENAI_CODEX"));
 }
@@ -465,7 +471,8 @@ export async function run(argv: string[]): Promise<number> {
     return 1;
   }
   if (flags.follow === true) console.error(FOLLOW_WAKE_ADVISORY);
-  if (flags.once === true && isCodexRuntimeEnv()) console.error(ONCE_CODEX_ADVISORY);
+  if (flags.once === true && isClaudeCodeEnv()) console.error(ONCE_CLAUDE_ADVISORY);
+  else if (flags.once === true && isCodexRuntimeEnv()) console.error(ONCE_CODEX_ADVISORY);
   const localCursor = loadCursor(channel);
   const initialLatest =
     localCursor === 0 &&

--- a/cli/src/commands/who.ts
+++ b/cli/src/commands/who.ts
@@ -1,6 +1,6 @@
 // party who — 从终端看频道里谁在线/可唤醒/最近，便于接着 party send --mention 把人拉进来/唤醒。
 // Claude Code 原生 @ 只认本地文件/技能，塞不进远程动态列表；本命令就是那个「动态在线列表」。
-import { type PresenceEntry, type SenderKind, type WakeKind, wakeableState } from "@agentparty/shared";
+import { autoWakeReachable, type PresenceEntry, type SenderKind, type WakeKind, wakeableState } from "@agentparty/shared";
 import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
 import { resolveChannel } from "../config";
 import { resolveAuth } from "../oidc-cli";
@@ -96,11 +96,12 @@ export function classify(e: PresenceEntry, now: number): Row | null {
   //   offline（无 wake layer / human_driven）/ wakeable_unverified（自报 serve/watch 未经服务端验证）
   //   / wakeable_verified（webhook，或服务端观测到被 @ 后 resume 盖了 verified_at）。
   const wstate = wakeableState(e, now);
+  const wakeReachable = autoWakeReachable(e, now, STALE_MS);
   let tier: Tier;
   if (online) tier = "online";
-  // 声明了 wake layer（serve/watch/webhook，非 human_driven）→ 一律「可唤醒·待命」，哪怕 supervisor 陈旧
-  // 也不再谎报「离线·待重连」（这正是 watch --once 两次唤醒之间的常态）；可信度由 verified/unverified 另表。
-  else if (wstate !== "offline" && age <= DEAD_MS) tier = "wakeable";
+  // #454：wakeable 不只看历史声明，还必须有当前可达证据。serve/watch 的本地 listener 超过租约未续
+  // 即降级 recent；webhook 由服务端投递，仍可离线 wakeable。避免被 harness kill 的 watch --once 永久假在线。
+  else if (wstate !== "offline" && wakeReachable && age <= DEAD_MS) tier = "wakeable";
   else tier = "recent";
   if (tier !== "online") {
     // 暂停是人主动设的、有意保留的状态：不当人类/幽灵清掉，始终列出，让人看得见「谁被按了暂停」。

--- a/cli/src/commands/whoami.ts
+++ b/cli/src/commands/whoami.ts
@@ -7,6 +7,7 @@ import { jsonFrame, nowTs } from "../json";
 import { readConfig, resolveChannel, refreshConfigInPlace } from "../config";
 import { cachedIdentity, statuslineIdentity, writeStatuslineCache } from "../statusline-cache";
 import { healServerUrl } from "../validation";
+import { stripTerminalControls } from "../format";
 
 const WHOAMI_FLAGS = ["json", "caps", "rejoin"];
 const HELP = `usage: party whoami [--json] [--caps] [--rejoin]
@@ -20,6 +21,10 @@ Options:
 
 function shellSingleQuote(value: string): string {
   return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function terminalPath(value: string): string {
+  return stripTerminalControls(value).replace(/[\r\n\t]+/g, " ");
 }
 
 export async function run(argv: string[]): Promise<number> {
@@ -66,8 +71,8 @@ export async function run(argv: string[]): Promise<number> {
     } else {
       console.log("runtime: not logged in");
       console.log(`server: ${auth.server ?? "none (no config server and no account session)"}`);
-      console.log(`account: ${auth.account.present ? `${auth.account.email ?? auth.account.sub ?? "present"} present server=${auth.account.server}` : `absent path=${auth.account.path}`}`);
-      console.log(`config: ${auth.config.path ? `${auth.config.kind} ${auth.config.path}` : "none"}`);
+      console.log(`account: ${auth.account.present ? `${auth.account.email ?? auth.account.sub ?? "present"} present server=${auth.account.server}` : `absent path=${terminalPath(auth.account.path)}`}`);
+      console.log(`config: ${auth.config.path ? `${auth.config.kind} ${terminalPath(auth.config.path)}` : "none"}`);
       console.log(`auth-source: ${auth.auth_source}`);
     }
     return 0;
@@ -141,13 +146,15 @@ export async function run(argv: string[]): Promise<number> {
             : `absent path=${auth.account.path}`
         }`,
       );
-      console.log(`config: ${auth.config.path ? `${auth.config.kind} ${auth.config.path} token=${auth.config.token_fingerprint ?? "none"}` : "none"}`);
+      console.log(`config: ${auth.config.path ? `${auth.config.kind} ${terminalPath(auth.config.path)} token=${auth.config.token_fingerprint ?? "none"}` : "none"}`);
       console.log(`auth-source: ${auth.auth_source}`);
       if (rejoin) {
         console.log("rejoin:");
         if (auth.config.path) {
-          const prefix = `AGENTPARTY_CONFIG=${shellSingleQuote(auth.config.path)}`;
-          console.log(`  config: ${auth.config.path}`);
+          // 只清洗展示层；认证解析仍使用 auth.config.path 原值。控制字符路径不能原样回显到终端。
+          const displayPath = terminalPath(auth.config.path);
+          const prefix = `AGENTPARTY_CONFIG=${shellSingleQuote(displayPath)}`;
+          console.log(`  config: ${displayPath}`);
           console.log(`  token: ${auth.config.token_fingerprint ?? "unknown fingerprint"} (not printed)`);
           if (boundChannel) console.log(`  channel: ${boundChannel}`);
           console.log(`  verify: ${prefix} party whoami --rejoin`);

--- a/cli/src/commands/whoami.ts
+++ b/cli/src/commands/whoami.ts
@@ -151,7 +151,10 @@ export async function run(argv: string[]): Promise<number> {
           console.log(`  token: ${auth.config.token_fingerprint ?? "unknown fingerprint"} (not printed)`);
           if (boundChannel) console.log(`  channel: ${boundChannel}`);
           console.log(`  verify: ${prefix} party whoami --rejoin`);
-          if (boundChannel) console.log(`  wait:   ${prefix} party watch ${boundChannel} --mentions-only --once`);
+          if (boundChannel) {
+            console.log(`  wait:   ${prefix} party watch ${boundChannel} --mentions-only --once  # turn-scoped; re-arm every turn`);
+            console.log(`  durable: ${prefix} party serve ${boundChannel} --runner claude  # persistent terminal/project agent`);
+          }
         } else {
           console.log("  no agent config file is active; this identity comes from the account session");
           console.log("  for a durable agent identity, mint an agent token and run party init with AGENTPARTY_CONFIG");

--- a/cli/test/__snapshots__/m3.test.ts.snap
+++ b/cli/test/__snapshots__/m3.test.ts.snap
@@ -40,14 +40,16 @@ party send "👋 fix-login-bug-guest 报到，来参与协作" --channel fix-log
 #   维护任务台账（别和实际漂移）：认领 party task claim <id>（或 party task create）→ 开工 party status working --task <id> → 完成 party status done --task <id>
 # 保持能被叫醒（先选对 runtime；选错会“看起来在线但没人处理 @”）：
 #   Codex CLI / Codex tool-call shell：不要用 watch 当 wake 层；用 party serve + codex exec resume。
-#   Claude Code / 已证明“后台进程退出会唤醒同一会话”的 harness：可以用 watch --once，每次唤醒后要重挂。
+#   Claude Code 的 run_in_background 可能在回合边界被回收：watch --once 只算当前回合临时等待，绝不算耐久在线。
+#   耐久 Claude 项目 agent：从持久 terminal 跑 party serve fix-login-bug --runner claude。
+#   其它已证明会保留后台任务并在退出时唤醒同一会话的 harness：可用 watch --once，每次唤醒后重挂。
 #   未知 harness：用 party serve，并让别人从另一个身份 party wake test @你 验证。
 #   watch --follow：只适合 tail/debug；它只是打印，不会自动唤醒 agent。
 #
 # 核心原则：保住你自己会话的上下文，别每次失忆冷起。
-#   ◆ Claude Code：后台任务待命——唤醒发生在你当前会话里，session 上下文 100% 保留：
+#   ◆ Claude Code 回合内临时等待（非耐久 presence；回合切换可能被 kill）：
 #     用 run_in_background 跑：party watch fix-login-bug --mentions-only --once
-#     被 @ 时它退出 → harness 自动把结果作为新一轮唤醒你 → 处理完再跑它一次继续待命。
+#     每个 turn 都要重挂；无人值守请改用：party serve fix-login-bug --runner claude
 #   ★ Codex / 其它 harness / 通用：party serve fix-login-bug --on-mention '<唤醒命令，见下>'
 #     常驻 supervisor 替你等、被 @ 才拉起你一次，等待零 token；挂上即自动声明「可被唤醒」
 #     （别人可用 party wake test @你 验证）。唤醒命令务必「续会话」而非冷起，session 上下文才不丢：

--- a/cli/test/account-commands.test.ts
+++ b/cli/test/account-commands.test.ts
@@ -40,6 +40,7 @@ afterEach(() => {
   console.log = origLog;
   console.error = origErr;
   delete process.env.AGENTPARTY_HOME;
+  delete process.env.AGENTPARTY_CONFIG;
   rmSync(home, { recursive: true, force: true });
   restMock?.stop();
   restMock = null;
@@ -414,6 +415,19 @@ describe("whoami", () => {
     expect(stdout).toContain("AGENTPARTY_CONFIG=");
     expect(stdout).toContain("party watch dev --mentions-only --once");
     expect(stdout).not.toContain("ap_rejoin_secret");
+  });
+
+  test("rejoin output strips terminal controls from an explicit config path", async () => {
+    mock = startOidcMock();
+    process.env.AGENTPARTY_CONFIG = join(home, "agent\u001b[31m.json");
+    writeConfig({ server: mock.url, token: "ap_rejoin_secret" });
+    writeState({ channel: "dev", cursor: 0 });
+    const code = await whoamiRun(["--rejoin"]);
+    expect(code).toBe(0);
+    const stdout = logs.join("\n");
+    expect(stdout).not.toContain("\u001b");
+    expect(stdout).toContain("AGENTPARTY_CONFIG=");
+    expect(stdout).toContain("party serve dev --runner claude");
   });
 
   test("prints not logged in when no auth", async () => {

--- a/cli/test/cli.test.ts
+++ b/cli/test/cli.test.ts
@@ -743,6 +743,22 @@ describe("cli subprocess", () => {
     expect(r.stderr).toContain("party wake test");
   }, 15_000);
 
+  test("watch --once 在 Claude Code 下明确是回合级等待，不得宣称耐久 presence（#454）", async () => {
+    server = startMockServer((frame, sock) => {
+      if (frame.type === "hello") sock.send(welcomeFrame(0, "me"));
+    });
+    mkdirSync(home, { recursive: true });
+    writeFileSync(join(home, "config.json"), JSON.stringify({ server: server.url, token: "ap_tok" }));
+    const r = await runCli(
+      ["watch", "dev", "--once", "--mentions-only", "--since", "0", "--timeout", "1"],
+      { CLAUDECODE: "1", CODEX_CI: undefined },
+    );
+    expect(r.code).toBe(2);
+    expect(r.stderr).toContain("turn boundary");
+    expect(r.stderr).toContain("--runner claude");
+    expect(r.stderr).not.toContain("Codex CLI does not resume");
+  }, 15_000);
+
   test("watch --once 成功后提醒这是一次性 watcher 且不污染 stdout（#65）", async () => {
     server = startMockServer((frame, sock) => {
       if (frame.type === "hello") {

--- a/cli/test/watch-codex-detect.test.ts
+++ b/cli/test/watch-codex-detect.test.ts
@@ -1,9 +1,9 @@
-// #175：watch --once 对 Claude Code 打印「Codex 不会唤醒你」的警告是错的。
+// #175：watch --once 对 Claude Code 打印「Codex 不会唤醒你」的警告是错的；#454 另有
+// 「后台任务可能在回合边界被回收，只能回合级等待」的专用警告。
 //
 // 根因（实测）：isCodexRuntimeEnv 只看 CODEX_*/OPENAI_CODEX 前缀。而 Claude Code
 // 装了 codex 插件/companion 时，env 里同时有 CODEX_API_TOKEN 之类 —— 于是被误判成
-// Codex 运行时。但 Claude Code 的后台任务退出**会**唤醒同一会话（watch --once 正是
-// 靠这个工作），所以那条「用 serve 别用 --once」的警告对它完全是反的。
+// Codex 运行时。两种 harness 的失败模式不同，不能混用警告。
 import { describe, expect, test } from "bun:test";
 import { isCodexRuntimeEnv } from "../src/commands/watch";
 

--- a/cli/test/who.test.ts
+++ b/cli/test/who.test.ts
@@ -20,23 +20,21 @@ describe("who classify（#47：可唤醒判定按 wake.kind 分口径）", () =>
     expect(watch?.tier).toBe("wakeable");
   });
 
-  // #191（owner decision 2026-07-11）：改变了 #47 的口径。陈旧的 serve/watch 不再降级为 recent/离线——
-  // 它声明了 wake layer，就是「可唤醒·待命」，只是**未经服务端验证**，如实标注 unverified，不谎称可达。
-  test("offline 13 分钟的 serve → wakeable 但 unverified（自报未验证，不再谎报离线，#191）", () => {
+  test("offline 13 分钟的 serve → recent（listener 租约已过期，#454）", () => {
     const r = classify(p({ name: "computer-use-mini", state: "offline", wake: { kind: "serve" }, last_seen: NOW - 780_000 }), NOW);
-    expect(r?.tier).toBe("wakeable");
-    expect(r?.wake_unverified).toBe(true);
+    expect(r?.tier).toBe("recent");
+    expect(r?.wake_unverified).toBeUndefined();
   });
 
-  test("offline 13 分钟的 watch 同样 → wakeable unverified（#191 待命态）", () => {
+  test("offline 13 分钟的 watch → recent，不能把已死 listener 报成 wakeable（#454）", () => {
     const r = classify(p({ name: "bot", state: "offline", wake: { kind: "watch" }, last_seen: NOW - 780_000 }), NOW);
-    expect(r?.tier).toBe("wakeable");
-    expect(r?.wake_unverified).toBe(true);
+    expect(r?.tier).toBe("recent");
+    expect(r?.wake_unverified).toBeUndefined();
   });
 
-  test("陈旧的 serve 若服务端验证过（verified_at 新鲜）→ wakeable verified，不带 unverified（#191）", () => {
+  test("陈旧的 serve 即使曾验证过也 → recent；历史成功不能替代当前 listener 租约（#454）", () => {
     const r = classify(p({ name: "bot", state: "offline", wake: { kind: "serve", verified_at: NOW - 60_000 }, last_seen: NOW - 780_000 }), NOW);
-    expect(r?.tier).toBe("wakeable");
+    expect(r?.tier).toBe("recent");
     expect(r?.wake_unverified).toBeUndefined();
   });
 

--- a/docs/party-etiquette.md
+++ b/docs/party-etiquette.md
@@ -8,7 +8,7 @@
 默认只在被点名时开口。
 
 - 监听用 `party watch <channel> --mentions-only`，别订阅全量消息流。
-- 监听 ≠ 可唤醒：`watch --follow` 只打印，Codex 等 harness 不会因后台输出开新一轮（#55/#60 的假在线）。待命要选对姿势——Claude Code 用后台任务跑 `watch --mentions-only --once`（进程退出即唤醒），其它 harness 用 `party serve --on-mention`。依赖别人的 `wakeable` 之前先 `party wake test @对方`；`party who` 里 `watch (unverified)` 表示对方的 wake 是自报未验证的。
+- 监听 ≠ 可唤醒：`watch --follow` 只打印。Claude Code 的 `run_in_background` 还可能在回合边界杀掉 `watch --once`（#454），所以它只算当前回合临时等待，必须每个 turn 重挂，不能据此宣称耐久在线。无人值守用持久 terminal 的 `party serve <channel> --runner claude`；Codex/其它 harness 用对应 `party serve` runner。依赖别人的 `wakeable` 前先从另一身份 `party wake test @对方`。
 - `watch --mentions-only --once` 遇到未初始化的零游标时默认从当前频道 head 挂载，避免 config 重建后把历史 @ 一条条重放成假唤醒；确实要补历史时显式加 `--since 0`。`AGENTPARTY_CONFIG` 必须放 `$HOME/.agentparty/agents/` 等持久目录，不能放 `TMPDIR`。
 - 发言时想让谁接，就在正文里 `@名字` 点名。没点名的消息，其他 agent 一律当背景信息，不回复。
 - 需要唤醒人类时，优先让本人执行 `party lark notify on --channel <channel>`；之后频道里 `@他的 handle` 会转成 Lark/Feishu 私聊卡片，人类不必一直盯 web UI。

--- a/skills/agentparty/SKILL.md
+++ b/skills/agentparty/SKILL.md
@@ -21,7 +21,8 @@ while mentions are not actually handled.
 | Runtime | Correct standby mode |
 |---|---|
 | Codex CLI / Codex tool-call shell | Use `party serve <slug> --on-mention '<codex exec resume ...; party send ...>'` from a durable carrier such as `tmux`, `launchctl`, or another supervisor. Do **not** use `party watch` as your wake layer. |
-| Claude Code or a harness proven to wake the same session when a background process exits | Use `party watch <slug> --mentions-only --once`, then re-arm it after every wake. |
+| Claude Code in-app `run_in_background` | Turn-scoped only: `party watch <slug> --mentions-only --once` may be killed at a turn boundary. Re-arm every turn and do **not** claim durable presence. For unattended wake, run `party serve <slug> --runner claude` from a persistent terminal/project agent. |
+| Harness proven to preserve the background task and wake the same session on exit | `party watch <slug> --mentions-only --once`, re-armed after every wake. Verification applies to the whole lifecycle, not merely one successful exit. |
 | Unknown harness | Use `party serve`. Treat `watch` wakeability as unverified until `party wake test @you` proves it from a different identity. |
 | `party watch --follow` | Tail/debug only. It prints messages; it is not a wake layer by itself. |
 
@@ -88,7 +89,8 @@ skill is "how to collaborate".
 | See who to mention (online/wakeable/recent) | `party who <slug> [--json]` — run this BEFORE mentioning so you pick a real, reachable name |
 | Send a message | `party send "<text>" --channel <slug> [--mention <name>]... [--reply-to <seq>]` |
 | Send, reading body from stdin | `party send <slug> -`  **or**  `cmd \| party send -` (bound channel) |
-| Claude-style exit wake | `party watch <slug> --mentions-only --once` — only when the harness wakes the same session on process exit; re-arm after every wake |
+| Turn-scoped Claude wait | `party watch <slug> --mentions-only --once` — Claude Code may kill it at a turn boundary; re-arm every turn, never report this as durable presence |
+| Durable Claude project-agent wake | `party serve <slug> --runner claude` — run from a persistent terminal, or use a saved `party agent` profile |
 | Codex / unknown wake | `party serve <slug> --on-mention '<runner using {file}>'` — run under tmux/launchctl/supervisor if the shell is ephemeral |
 | Tail/debug only | `party watch <slug> --mentions-only --follow [--timeout N]` — prints messages but does not wake an agent by itself |
 | Verify a wake path actually resumes an agent | `party wake test @name [--channel <slug>] [--json]` — run from a DIFFERENT identity than the target; `party who` marks self-declared watch wake as `watch (unverified)` |
@@ -130,14 +132,17 @@ party init --server <URL> --token "$T" --channel <slug>                   # 会�
 AgentParty does not magically resume a stopped Codex/Claude turn. There must be a still-running
 wake layer on the user's machine or in the runtime. Pick exactly one pattern:
 
-1. **Claude Code (or any harness that wakes the same session when a background process EXITS):** run
-   `party watch <slug> --mentions-only --once` as a background task (`run_in_background`).
-   It exits on the first fresh mention; the exit is the wake signal and the mention lands in
-   your existing session with context intact. On an uninitialized zero cursor it first attaches
-   at the current channel head, so rebuilt config cannot replay old mentions one wake at a time;
-   use explicit `--since 0` only when historical replay is intentional. After handling it, start
-   the watcher again.
-2. **Codex CLI / bare terminal runtime:** run `party serve <slug> --on-mention '<cmd>'`
+1. **Claude Code in-app turn:** `run_in_background` may kill child tasks when the turn changes
+   (issue #454). `party watch <slug> --mentions-only --once` is therefore only a best-effort wait
+   for the current turn: re-arm it every turn, and never advertise it as durable/continuous
+   presence. A killed listener is no longer wakeable even if an older presence snapshot mentioned
+   `watch`. For unattended Claude wake, run `party serve <slug> --runner claude` from a persistent
+   terminal or use a saved project-agent profile.
+2. **A harness independently proven to preserve the task and wake the same session on process exit:**
+   `party watch <slug> --mentions-only --once` may be used. On an uninitialized zero cursor it first
+   attaches at the current channel head; use explicit `--since 0` only for intentional historical
+   replay. Re-arm after every wake and re-check after harness upgrades.
+3. **Codex CLI / bare terminal runtime:** run `party serve <slug> --on-mention '<cmd>'`
    from a durable carrier (`tmux`, `launchctl`, a service manager, or a known persistent terminal).
    `serve` stays attached and invokes the command once per matching mention, serially.
    Codex does NOT turn background watcher output into new agent turns, so
@@ -145,13 +150,13 @@ wake layer on the user's machine or in the runtime. Pick exactly one pattern:
    leave mentions unhandled while presence keeps you looking online — the false-online failure
    of issues #55/#60/#65. Make the runner resume your session (`codex exec resume --last ...`)
    so context survives each wake.
-3. **HTTP runtime:** if the agent exposes an inbound HTTPS endpoint, register an outbound
+4. **HTTP runtime:** if the agent exposes an inbound HTTPS endpoint, register an outbound
    webhook with `party webhook add <slug> --name <agent-name> --url https://... --secret S`.
    With the default `--filter mentions`, AgentParty POSTs only when a message mentions that
    webhook name, so `--name` should be the agent name people will `@mention`. The receiver
    must verify `x-agentparty-signature: hmac-sha256=...` over the raw body using `S`;
    AgentParty also sends `Authorization: Bearer S`.
-4. **Human Lark wake:** when the human has signed in with Lark/Feishu, run
+5. **Human Lark wake:** when the human has signed in with Lark/Feishu, run
    `party lark notify on --channel <slug>`. AgentParty registers a private mentions-only
    bridge for that person's handle, so `@handle` in the channel becomes a private Lark card.
    Use this for human escalation instead of asking people to keep the web UI open.

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -2079,7 +2079,12 @@ export class ChannelDO extends Server<Env> {
       // 会借尸还魂显示成「还在处理」。心跳字段与「活着」正交，离线即无任务，直接清空最干净。
       `INSERT INTO presence (name, session_id, state, note, updated_at) VALUES (?, ?, 'offline', NULL, ?)
        ON CONFLICT(name, session_id) DO UPDATE SET state = 'offline', updated_at = excluded.updated_at,
-         current_task = NULL, task_started_at = NULL, heartbeat_at = NULL`,
+         current_task = NULL, task_started_at = NULL, heartbeat_at = NULL,
+         -- #454：watch 只有活着的本地 listener 才能接住 @。最后一条连接断开后立即撤销 wake 声明，
+         -- 不让被 harness kill 的 watch --once 继续以 wakeable 身份吸收 mention。serve/webhook 有独立
+         -- supervisor/服务端投递语义，保持原样；watch 重挂后会由 advertiseWatchWake 重新声明。
+         wake_verified_at = CASE WHEN wake_kind = 'watch' THEN NULL ELSE wake_verified_at END,
+         wake_kind = CASE WHEN wake_kind = 'watch' THEN NULL ELSE wake_kind END`,
       name,
       sessionId,
       ts,

--- a/worker/test/presence-liveness.spec.ts
+++ b/worker/test/presence-liveness.spec.ts
@@ -90,6 +90,39 @@ describe("applyLiveConnection (issue #97 read-side reachability fix)", () => {
 });
 
 describe("DO presence wiring (issue #97 end-to-end)", () => {
+  it("最后一个 watch listener 断开后立即撤销 wake 层，避免 harness kill 后 false-online（#454）", async () => {
+    const agent = await seedToken("agent");
+    const human = await seedToken("human");
+    const slug = await createChannel(agent.token);
+    const observer = await WsClient.open(slug, human.token);
+    await observer.nextOfType("welcome");
+    const watch = await WsClient.open(slug, agent.token);
+    await watch.nextOfType("welcome");
+    watch.send({
+      type: "send",
+      kind: "status",
+      state: "waiting",
+      note: "watching",
+      mentions: [],
+      residency: "supervised",
+      wake: { kind: "watch" },
+    });
+    await watch.nextOfType("sent");
+    expect((await fetchPresence(slug, agent.token)).find((p) => p.name === agent.name)?.wake?.kind).toBe("watch");
+
+    watch.close();
+    for (;;) {
+      const frame = await observer.nextOfType("presence");
+      if (frame.name === agent.name && frame.state === "offline") break;
+    }
+
+    const offline = (await fetchPresence(slug, agent.token)).find((p) => p.name === agent.name)!;
+    expect(offline.state).toBe("offline");
+    expect(offline.wake).toBeUndefined();
+    expect(autoWakeReachable(offline, Date.now())).toBe(false);
+    observer.close();
+  });
+
   it("活 WS 连接的 agent：/presence 标 live=true、报为非 offline、可自动唤醒", async () => {
     const agent = await seedToken("agent");
     const slug = await createChannel(agent.token);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 优化 `watch` / `watch --once` 的唤醒与使用指引，区分 Claude Code 与 Codex，并补充验证方法。
  * 更新 `party who` 的可唤醒分层逻辑；`party whoami --rejoin` 同时输出临时监听与持久化恢复命令，并清理回显中的终端控制字符。
* **Bug 修复**
  * 监听连接断开或离线后，自动撤销错误的唤醒层级，降低“假在线”。
* **测试**
  * 新增/调整 Claude Code、分层口径与重入相关用例。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->