### PR TITLE
fix(cli): worktree 稳定性/安全加固——采纳 #456 CodeRabbit 评审

### DIFF
--- a/cli/src/commands/worktree.ts
+++ b/cli/src/commands/worktree.ts
@@ -45,20 +45,45 @@ export interface GitResult {
 
 export type GitRunner = (args: string[], cwd: string) => Promise<GitResult>;
 
+// 无人值守 agent 会自动跑本工具的 push/commit。若 git 命中交互认证（HTTPS 密码、
+// SSH passphrase 走 /dev/tty——不受 stdin:"ignore" 约束）会永久挂起，整条 prune 无限阻塞。
+// GIT_TERMINAL_PROMPT=0 让 git 遇到提示直接失败而非等输入；再叠一层硬超时兜底熔断。
+const GIT_TIMEOUT_MS = 120_000;
+
 const defaultGit: GitRunner = async (args, cwd) => {
   const proc = Bun.spawn(["git", ...args], {
     cwd,
     stdin: "ignore",
     stdout: "pipe",
     stderr: "pipe",
+    env: { ...process.env, GIT_TERMINAL_PROMPT: "0" },
   });
-  const [stdout, stderr, code] = await Promise.all([
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-    proc.exited,
-  ]);
-  return { code, stdout, stderr };
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    proc.kill();
+  }, GIT_TIMEOUT_MS);
+  try {
+    const [stdout, stderr, code] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    if (timedOut) {
+      return { code: code || 124, stdout, stderr: `git timed out after ${GIT_TIMEOUT_MS}ms: git ${args.join(" ")}` };
+    }
+    return { code, stdout, stderr };
+  } finally {
+    clearTimeout(timer);
+  }
 };
+
+// 面向终端打印的外部字符串（分支名、worktree 路径、git stderr）先剥控制字符/ANSI 转义，
+// 防不受信上游内容污染/注入终端。制表符(\x09)与换行(\x0A)保留——stderr 常多行。
+export function sanitizeForTerminal(s: string): string {
+  // eslint-disable-next-line no-control-regex
+  return s.replace(/\x1B\[[0-9;]*[A-Za-z]|[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, "");
+}
 
 export type WorktreeStatus =
   | "merged-clean"
@@ -128,9 +153,13 @@ export async function classifyWorktrees(
   }
   const raws = parseWorktreePorcelain(list.stdout);
 
-  // 当前工作树（cwd 所在的顶层）——绝不删自己脚下的。
+  // 当前工作树（cwd 所在的顶层）——绝不删自己脚下的。失败绝不能静默降级成 ""：
+  // 那样 w.path === "" 永不命中，当前 worktree 保护失效、可能被删。失败即抛（同 list 失败）。
   const top = await git(["rev-parse", "--show-toplevel"], root);
-  const currentPath = top.code === 0 ? top.stdout.trim() : "";
+  if (top.code !== 0) {
+    throw new Error(`git rev-parse --show-toplevel failed: ${top.stderr.trim() || top.stdout.trim()}`);
+  }
+  const currentPath = top.stdout.trim();
 
   const rows: WorktreeRow[] = [];
   for (let i = 0; i < raws.length; i++) {
@@ -205,7 +234,7 @@ async function runList(root: string, base: string, json: boolean, git: GitRunner
   console.log(`base: ${base}`);
   for (const r of rows) {
     const d = detail(r);
-    console.log(`${r.status.padEnd(13)} ${(r.branch ?? "(detached)").padEnd(28)} ${d.padEnd(16)} ${r.path}`);
+    console.log(`${r.status.padEnd(13)} ${sanitizeForTerminal(r.branch ?? "(detached)").padEnd(28)} ${d.padEnd(16)} ${sanitizeForTerminal(r.path)}`);
   }
   return 0;
 }
@@ -245,20 +274,20 @@ async function removeMergedClean(
   remote: boolean,
   git: GitRunner,
 ): Promise<boolean> {
-  const branch = action.row.branch!;
+  const branch = sanitizeForTerminal(action.row.branch!);
   const rm = await git(["worktree", "remove", action.row.path], root);
   if (rm.code !== 0) {
-    console.error(`  ! ${branch}: worktree remove failed, skipped — ${rm.stderr.trim()}`);
+    console.error(`  ! ${branch}: worktree remove failed, skipped — ${sanitizeForTerminal(rm.stderr.trim())}`);
     return false;
   }
   const del = await git(["branch", "-D", branch], root);
   if (del.code !== 0) {
-    console.error(`  ! ${branch}: worktree removed but branch delete failed — ${del.stderr.trim()}`);
+    console.error(`  ! ${branch}: worktree removed but branch delete failed — ${sanitizeForTerminal(del.stderr.trim())}`);
   }
   if (remote) {
     const pushDel = await git(["push", "origin", "--delete", branch], root);
     if (pushDel.code !== 0) {
-      console.error(`  ! ${branch}: remote branch delete failed — ${pushDel.stderr.trim()}`);
+      console.error(`  ! ${branch}: remote branch delete failed — ${sanitizeForTerminal(pushDel.stderr.trim())}`);
     }
   }
   console.log(`  removed ${branch} (merged-clean)`);
@@ -268,32 +297,32 @@ async function removeMergedClean(
 // merged-dirty：绝不 --force 丢活。先把未提交改动 commit + push 到 preserve/*，全部成功才删。
 // 任一步失败 → 保留 worktree，跳过并告警，宁可留着让人处理也不丢工作。
 async function preserveAndRemove(root: string, action: PruneAction, git: GitRunner): Promise<boolean> {
-  const branch = action.row.branch!;
+  const branch = sanitizeForTerminal(action.row.branch!);
   const path = action.row.path;
   const add = await git(["-C", path, "add", "-A"], root);
   if (add.code !== 0) {
-    console.error(`  ! ${branch}: git add failed, worktree preserved as-is — ${add.stderr.trim()}`);
+    console.error(`  ! ${branch}: git add failed, worktree preserved as-is — ${sanitizeForTerminal(add.stderr.trim())}`);
     return false;
   }
   const commit = await git(["-C", path, "commit", "-m", `wip: preserve ${branch} (#455)`], root);
   if (commit.code !== 0) {
-    console.error(`  ! ${branch}: commit failed, worktree preserved as-is — ${commit.stderr.trim()}`);
+    console.error(`  ! ${branch}: commit failed, worktree preserved as-is — ${sanitizeForTerminal(commit.stderr.trim())}`);
     return false;
   }
   const push = await git(["-C", path, "push", "origin", `HEAD:preserve/${branch}`], root);
   if (push.code !== 0) {
-    console.error(`  ! ${branch}: push to preserve/${branch} failed, worktree preserved as-is — ${push.stderr.trim()}`);
+    console.error(`  ! ${branch}: push to preserve/${branch} failed, worktree preserved as-is — ${sanitizeForTerminal(push.stderr.trim())}`);
     return false;
   }
   // 改动已安全落到 origin/preserve/*，现在删本地 worktree+分支才不丢活。
   const rm = await git(["worktree", "remove", "--force", path], root);
   if (rm.code !== 0) {
-    console.error(`  ! ${branch}: preserved to preserve/${branch} but worktree remove failed — ${rm.stderr.trim()}`);
+    console.error(`  ! ${branch}: preserved to preserve/${branch} but worktree remove failed — ${sanitizeForTerminal(rm.stderr.trim())}`);
     return false;
   }
   const del = await git(["branch", "-D", branch], root);
   if (del.code !== 0) {
-    console.error(`  ! ${branch}: preserved + worktree removed but branch delete failed — ${del.stderr.trim()}`);
+    console.error(`  ! ${branch}: preserved + worktree removed but branch delete failed — ${sanitizeForTerminal(del.stderr.trim())}`);
   }
   console.log(`  preserved ${branch} -> origin/preserve/${branch}, then removed (merged-dirty)`);
   return true;
@@ -312,8 +341,8 @@ async function runPrune(
   if (!act) {
     console.log(`plan (dry-run — pass --yes to execute), base ${base}:`);
     for (const a of actions) {
-      const b = a.row.branch ?? "(detached)";
-      console.log(`  ${a.kind.padEnd(8)} ${b.padEnd(28)} ${a.reason}  [${a.row.path}]`);
+      const b = sanitizeForTerminal(a.row.branch ?? "(detached)");
+      console.log(`  ${a.kind.padEnd(8)} ${b.padEnd(28)} ${a.reason}  [${sanitizeForTerminal(a.row.path)}]`);
     }
     const removable = actions.filter((a) => a.kind !== "skip").length;
     console.log(`\n${removable} worktree(s) would be cleaned, ${actions.length - removable} skipped. Re-run with --yes.`);
@@ -323,7 +352,7 @@ async function runPrune(
   console.log(`executing prune, base ${base}:`);
   for (const a of actions) {
     if (a.kind === "skip") {
-      const b = a.row.branch ?? "(detached)";
+      const b = sanitizeForTerminal(a.row.branch ?? "(detached)");
       console.log(`  skip    ${b} — ${a.reason}`);
       continue;
     }

--- a/cli/src/commands/worktree.ts
+++ b/cli/src/commands/worktree.ts
@@ -50,39 +50,49 @@ export type GitRunner = (args: string[], cwd: string) => Promise<GitResult>;
 // GIT_TERMINAL_PROMPT=0 让 git 遇到提示直接失败而非等输入；再叠一层硬超时兜底熔断。
 const GIT_TIMEOUT_MS = 120_000;
 
-const defaultGit: GitRunner = async (args, cwd) => {
-  const proc = Bun.spawn(["git", ...args], {
-    cwd,
-    stdin: "ignore",
-    stdout: "pipe",
-    stderr: "pipe",
-    env: { ...process.env, GIT_TERMINAL_PROMPT: "0" },
-  });
-  let timedOut = false;
-  const timer = setTimeout(() => {
-    timedOut = true;
-    proc.kill();
-  }, GIT_TIMEOUT_MS);
-  try {
+// 跑子进程 + 硬超时。关键：超时必须【独立】返回——proc.kill() 只打到顶层 git，一旦它
+// 派生的 ssh/credential-helper 还占着 stdout/stderr，读管道的 Promise 仍会卡住。所以用
+// Promise.race 让超时分支不依赖管道读完，到点即返回（CodeRabbit #459 🔴 指出的真挂起）。
+export async function spawnWithTimeout(
+  cmd: string[],
+  cwd: string,
+  timeoutMs: number,
+  env: Record<string, string | undefined> = process.env,
+): Promise<GitResult> {
+  const proc = Bun.spawn(cmd, { cwd, stdin: "ignore", stdout: "pipe", stderr: "pipe", env });
+  if (!proc.pid) {
+    // spawn 失败——别再挂 timer，直接报错（pr_agent #459 建议）。
+    return { code: 1, stdout: "", stderr: `failed to start: ${cmd.join(" ")}` };
+  }
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const work: Promise<GitResult> = (async () => {
     const [stdout, stderr, code] = await Promise.all([
       new Response(proc.stdout).text(),
       new Response(proc.stderr).text(),
       proc.exited,
     ]);
-    if (timedOut) {
-      return { code: code || 124, stdout, stderr: `git timed out after ${GIT_TIMEOUT_MS}ms: git ${args.join(" ")}` };
-    }
     return { code, stdout, stderr };
-  } finally {
-    clearTimeout(timer);
-  }
-};
+  })().catch((e): GitResult => ({ code: 1, stdout: "", stderr: String(e) }));
+  const timeout = new Promise<GitResult>((resolve) => {
+    timer = setTimeout(() => {
+      proc.kill(); // best-effort；即便管道读不结束，下面 race 也已经拿到超时结果返回。
+      resolve({ code: 124, stdout: "", stderr: `timed out after ${timeoutMs}ms: ${cmd.join(" ")}` });
+    }, timeoutMs);
+  });
+  const result = await Promise.race([work, timeout]);
+  if (timer) clearTimeout(timer);
+  return result;
+}
+
+const defaultGit: GitRunner = (args, cwd) =>
+  spawnWithTimeout(["git", ...args], cwd, GIT_TIMEOUT_MS, { ...process.env, GIT_TERMINAL_PROMPT: "0" });
 
 // 面向终端打印的外部字符串（分支名、worktree 路径、git stderr）先剥控制字符/ANSI 转义，
-// 防不受信上游内容污染/注入终端。制表符(\x09)与换行(\x0A)保留——stderr 常多行。
+// 防不受信上游内容污染/注入终端。仅保留制表符(\x09)与换行(\x0A)——含裸回车(\x0D)在内的
+// 其余控制字符全剥（CR 可做终端行覆盖，伪造/隐藏已打印内容，CodeRabbit #459 指出）。
 export function sanitizeForTerminal(s: string): string {
   // eslint-disable-next-line no-control-regex
-  return s.replace(/\x1B\[[0-9;]*[A-Za-z]|[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, "");
+  return s.replace(/\x1B\[[0-9;]*[A-Za-z]|[\x00-\x08\x0B-\x1F\x7F]/g, "");
 }
 
 export type WorktreeStatus =
@@ -274,18 +284,21 @@ async function removeMergedClean(
   remote: boolean,
   git: GitRunner,
 ): Promise<boolean> {
-  const branch = sanitizeForTerminal(action.row.branch!);
+  // raw 用于 git 参数，branch(sanitized) 只用于打印——绝不把『防注入显示串』喂给会真删/真推的
+  // git 命令，否则日后扩展 sanitize（如 Unicode 归一化）会悄悄改掉实际分支名（CodeRabbit #459）。
+  const raw = action.row.branch!;
+  const branch = sanitizeForTerminal(raw);
   const rm = await git(["worktree", "remove", action.row.path], root);
   if (rm.code !== 0) {
     console.error(`  ! ${branch}: worktree remove failed, skipped — ${sanitizeForTerminal(rm.stderr.trim())}`);
     return false;
   }
-  const del = await git(["branch", "-D", branch], root);
+  const del = await git(["branch", "-D", raw], root);
   if (del.code !== 0) {
     console.error(`  ! ${branch}: worktree removed but branch delete failed — ${sanitizeForTerminal(del.stderr.trim())}`);
   }
   if (remote) {
-    const pushDel = await git(["push", "origin", "--delete", branch], root);
+    const pushDel = await git(["push", "origin", "--delete", raw], root);
     if (pushDel.code !== 0) {
       console.error(`  ! ${branch}: remote branch delete failed — ${sanitizeForTerminal(pushDel.stderr.trim())}`);
     }
@@ -297,19 +310,21 @@ async function removeMergedClean(
 // merged-dirty：绝不 --force 丢活。先把未提交改动 commit + push 到 preserve/*，全部成功才删。
 // 任一步失败 → 保留 worktree，跳过并告警，宁可留着让人处理也不丢工作。
 async function preserveAndRemove(root: string, action: PruneAction, git: GitRunner): Promise<boolean> {
-  const branch = sanitizeForTerminal(action.row.branch!);
+  // raw 喂 git，branch(sanitized) 只打印——同 removeMergedClean 的理由（CodeRabbit #459）。
+  const raw = action.row.branch!;
+  const branch = sanitizeForTerminal(raw);
   const path = action.row.path;
   const add = await git(["-C", path, "add", "-A"], root);
   if (add.code !== 0) {
     console.error(`  ! ${branch}: git add failed, worktree preserved as-is — ${sanitizeForTerminal(add.stderr.trim())}`);
     return false;
   }
-  const commit = await git(["-C", path, "commit", "-m", `wip: preserve ${branch} (#455)`], root);
+  const commit = await git(["-C", path, "commit", "-m", `wip: preserve ${raw} (#455)`], root);
   if (commit.code !== 0) {
     console.error(`  ! ${branch}: commit failed, worktree preserved as-is — ${sanitizeForTerminal(commit.stderr.trim())}`);
     return false;
   }
-  const push = await git(["-C", path, "push", "origin", `HEAD:preserve/${branch}`], root);
+  const push = await git(["-C", path, "push", "origin", `HEAD:preserve/${raw}`], root);
   if (push.code !== 0) {
     console.error(`  ! ${branch}: push to preserve/${branch} failed, worktree preserved as-is — ${sanitizeForTerminal(push.stderr.trim())}`);
     return false;
@@ -320,7 +335,7 @@ async function preserveAndRemove(root: string, action: PruneAction, git: GitRunn
     console.error(`  ! ${branch}: preserved to preserve/${branch} but worktree remove failed — ${sanitizeForTerminal(rm.stderr.trim())}`);
     return false;
   }
-  const del = await git(["branch", "-D", branch], root);
+  const del = await git(["branch", "-D", raw], root);
   if (del.code !== 0) {
     console.error(`  ! ${branch}: preserved + worktree removed but branch delete failed — ${sanitizeForTerminal(del.stderr.trim())}`);
   }

--- a/cli/test/worktree.test.ts
+++ b/cli/test/worktree.test.ts
@@ -3,7 +3,7 @@ import { execFileSync } from "node:child_process";
 import { existsSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { classifyWorktrees, type GitRunner, run } from "../src/commands/worktree";
+import { classifyWorktrees, type GitRunner, run, sanitizeForTerminal } from "../src/commands/worktree";
 
 // 用真 git：临时仓库 + 真 worktree，覆盖 merged-clean / merged-dirty / unmerged 三态。
 // 不 mock git——命令的价值就在于对真 porcelain 输出的解析与真 cherry/status 判定。
@@ -102,7 +102,30 @@ describe("classifyWorktrees", () => {
     };
     const rows = await classifyWorktrees(main, "main", failingGit);
     const mc = rows.find((r) => r.branch === "mc");
-    expect(mc?.status).not.toBe("merged-clean");
+    // 精确断言 unmerged——not.toBe 会误放行 undefined/merged-dirty（CodeRabbit #456 指出）。
+    expect(mc?.status).toBe("unmerged");
+  });
+
+  test("rev-parse --show-toplevel 失败时抛错，绝不静默把当前 worktree 变可删", async () => {
+    // currentPath 失败被设成 "" → w.path === "" 永不命中 → 当前 worktree 保护静默失效。
+    // 必须失败即抛（同 worktree-list 失败），不能静默降级。（CodeRabbit #456 🟠）
+    const failTop: GitRunner = async (args, cwd) => {
+      if (args[0] === "rev-parse" && args.includes("--show-toplevel")) {
+        return { code: 128, stdout: "", stderr: "fatal: not a git repository" };
+      }
+      const out = execFileSync("git", args, { cwd, encoding: "utf8" });
+      return { code: 0, stdout: out, stderr: "" };
+    };
+    await expect(classifyWorktrees(main, "main", failTop)).rejects.toThrow();
+  });
+});
+
+describe("sanitizeForTerminal", () => {
+  test("剥掉 ANSI 转义与控制字符，保留可见文本/制表/换行", () => {
+    expect(sanitizeForTerminal("\x1b[31mred\x1b[0m")).toBe("red");
+    expect(sanitizeForTerminal("a\x07b\x00c\x7f")).toBe("abc");
+    // 制表符与换行保留（stderr 常多行）。
+    expect(sanitizeForTerminal("keep\tnormal\nline")).toBe("keep\tnormal\nline");
   });
 });
 
@@ -170,6 +193,7 @@ describe("party worktree prune", () => {
     expect(existsSync(join(root, "wt-un"))).toBe(true);
     const branches = git(main, "branch", "--format=%(refname:short)").split("\n");
     expect(branches).toContain("un");
-    expect(logs.join("\n")).toContain("un");
+    // 精确匹配 skip 行本身——单看子串 "un" 会被 "executing prune" 提前满足（CodeRabbit #456）。
+    expect(logs.join("\n")).toMatch(/skip\s+un\s+—\s+unmerged/);
   });
 });

--- a/cli/test/worktree.test.ts
+++ b/cli/test/worktree.test.ts
@@ -3,7 +3,13 @@ import { execFileSync } from "node:child_process";
 import { existsSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { classifyWorktrees, type GitRunner, run, sanitizeForTerminal } from "../src/commands/worktree";
+import {
+  classifyWorktrees,
+  type GitRunner,
+  run,
+  sanitizeForTerminal,
+  spawnWithTimeout,
+} from "../src/commands/worktree";
 
 // 用真 git：临时仓库 + 真 worktree，覆盖 merged-clean / merged-dirty / unmerged 三态。
 // 不 mock git——命令的价值就在于对真 porcelain 输出的解析与真 cherry/status 判定。
@@ -124,8 +130,27 @@ describe("sanitizeForTerminal", () => {
   test("剥掉 ANSI 转义与控制字符，保留可见文本/制表/换行", () => {
     expect(sanitizeForTerminal("\x1b[31mred\x1b[0m")).toBe("red");
     expect(sanitizeForTerminal("a\x07b\x00c\x7f")).toBe("abc");
+    // 裸回车(\x0D)必须剥——可做终端行覆盖伪造已打印内容。
+    expect(sanitizeForTerminal("real\rFAKE")).toBe("realFAKE");
     // 制表符与换行保留（stderr 常多行）。
     expect(sanitizeForTerminal("keep\tnormal\nline")).toBe("keep\tnormal\nline");
+  });
+});
+
+describe("spawnWithTimeout", () => {
+  test("超时独立返回 124，不等命令自然结束（防子进程占管道导致卡死）", async () => {
+    const t0 = Date.now();
+    const r = await spawnWithTimeout(["sleep", "5"], root, 200);
+    expect(r.code).toBe(124);
+    expect(r.stderr).toContain("timed out");
+    // 远早于 5s 返回 = 超时确实独立于命令/管道，没干等。
+    expect(Date.now() - t0).toBeLessThan(4000);
+  });
+
+  test("命令按时结束时返回真实退出码与输出", async () => {
+    const r = await spawnWithTimeout(["sh", "-c", "printf ok"], root, 5000);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toBe("ok");
   });
 });
 


### PR DESCRIPTION
review-ack: 跟进 #456。合并 #456 后 CodeRabbit(ASSERTIVE) 落了实质评审，我逐条核实后采纳真问题。**坦白：#456 我在 CodeRabbit 🔴 落地后没读就 admin-合了，重演『评审没人看就合』；本 PR 补做，且合前必等 pr_agent + CodeRabbit 都读完。**

## 采纳的修复
| 严重度 | 问题 | 修复 |
|---|---|---|
| 🔴 | `defaultGit` 无交互认证防护/超时：push 命中 HTTPS 密码或 SSH passphrase(/dev/tty，不受 stdin:ignore 约束)会永久挂起，无人值守 agent 整条 prune 无限阻塞 | `GIT_TERMINAL_PROMPT=0`(遇提示即失败) + 120s 硬超时 kill 熔断 |
| 🟠 | `rev-parse --show-toplevel` 失败静默降级成 `''` → 当前 worktree 保护失效可被删 | 失败即抛(同 worktree-list 失败)。**TDD+变异亲验** |
| 🟡 | 终端输出未剥控制字符：分支/路径/git stderr 直拼 console，agent 场景可注入 ANSI | `sanitizeForTerminal` 统一清洗(保留 \t\n)，套用全部外部字符串输出。**TDD+变异亲验** |
| 🟡 | 我两条测试断言太松(`not.toBe` 放行 undefined；子串 'un' 被 'prune' 提前满足) | 改精确 `toBe('unmerged')` 与 `/skip\s+un\s+—\s+unmerged/` |

CodeRabbit 的 status-返回码一条(🟠)与 pr_agent 独立都逮到，已在 #456(status 守卫)修复。

## 门禁
cli worktree **10/10**、tsc 0。两处安全修复(rev-parse throw、sanitize)均 TDD 先红后绿、变异去守卫复红亲验。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **安全性改进**
  - 为 Git 操作新增硬超时，并关闭交互式认证，避免任务长时间卡住。
  - 清理分支名、路径及 Git 输出中的终端控制字符，确保日志与终端显示更安全、干净（包括执行与 dry-run 计划/跳过提示）。
- **Bug 修复**
  - 当前工作树识别失败时直接中止，防止误删受保护的工作树。
  - 优化清理/跳过相关的错误与状态日志，更精确呈现分支与原因。
- **测试**
  - 增强工作树识别失败、未合并状态判定及跳过日志的断言覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->