### PR TITLE
fix(cli): 加固 worktree 清理安全边界

### DIFF
--- a/cli/src/commands/worktree.ts
+++ b/cli/src/commands/worktree.ts
@@ -54,27 +54,31 @@ interface KillableGitProcess {
   kill(signal?: NodeJS.Signals | number): void;
 }
 
-type WindowsTreeKiller = (pid: number) => void;
+type WindowsTreeKiller = (pid: number) => Promise<boolean>;
 
-function taskkillProcessTree(pid: number): void {
-  const killer = Bun.spawn(["taskkill", "/PID", String(pid), "/T", "/F"], {
-    stdin: "ignore",
-    stdout: "ignore",
-    stderr: "ignore",
-  });
-  killer.unref();
+async function taskkillProcessTree(pid: number): Promise<boolean> {
+  try {
+    const killer = Bun.spawn(["taskkill", "/PID", String(pid), "/T", "/F"], {
+      stdin: "ignore",
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+    killer.unref();
+    return (await killer.exited) === 0;
+  } catch {
+    return false;
+  }
 }
 
-export function terminateGitProcessTree(
+export async function terminateGitProcessTree(
   proc: KillableGitProcess,
   platform: NodeJS.Platform = process.platform,
   killGroup: typeof process.kill = process.kill,
   killWindowsTree: WindowsTreeKiller = taskkillProcessTree,
-): "group" | "tree" | "child" {
+): Promise<"group" | "tree" | "child"> {
   if (platform === "win32") {
     try {
-      killWindowsTree(proc.pid);
-      return "tree";
+      if (await killWindowsTree(proc.pid)) return "tree";
     } catch {
       // taskkill 启动失败时仍要至少终止直接子进程。
     }
@@ -119,23 +123,56 @@ export async function spawnWithTimeout(
     ]);
     return { code, stdout, stderr };
   })().catch((error): GitResult => ({ code: 1, stdout: "", stderr: String(error) }));
+
+  const stopChild = () => {
+    void terminateGitProcessTree(proc).catch(() => {
+      try {
+        proc.kill("SIGKILL");
+      } catch {
+        /* 已退出或终止失败；下面仍会断开父进程引用。 */
+      }
+    });
+    try {
+      void proc.stdout.cancel().catch(() => undefined);
+      void proc.stderr.cancel().catch(() => undefined);
+    } catch {
+      // Response reader 可能已经锁住流；unref 仍确保残留 pipe 不把 CLI 挂住。
+    }
+    try {
+      proc.unref();
+    } catch {
+      /* Bun 旧版本兜底：timeout/signal race 仍会立即返回。 */
+    }
+  };
+
+  let resolveSignal: ((result: GitResult) => void) | undefined;
+  const signal = new Promise<GitResult>((resolve) => {
+    resolveSignal = resolve;
+  });
+  const onSigint = () => {
+    stopChild();
+    resolveSignal?.({ code: 130, stdout: "", stderr: "interrupted by SIGINT" });
+  };
+  const onSigterm = () => {
+    stopChild();
+    resolveSignal?.({ code: 143, stdout: "", stderr: "terminated by SIGTERM" });
+  };
+  process.once("SIGINT", onSigint);
+  process.once("SIGTERM", onSigterm);
+
   const timeout = new Promise<GitResult>((resolve) => {
     timer = setTimeout(() => {
-      try {
-        terminateGitProcessTree(proc);
-      } catch {
-        try {
-          proc.kill("SIGKILL");
-        } catch {
-          /* 已退出或终止失败：race 仍会立即返回，绝不依赖管道收尾。 */
-        }
-      }
+      stopChild();
       resolve({ code: 124, stdout: "", stderr: `timed out after ${timeoutMs}ms: ${cmd.join(" ")}` });
     }, timeoutMs);
   });
-  const result = await Promise.race([work, timeout]);
-  if (timer) clearTimeout(timer);
-  return result;
+  try {
+    return await Promise.race([work, timeout, signal]);
+  } finally {
+    if (timer) clearTimeout(timer);
+    process.removeListener("SIGINT", onSigint);
+    process.removeListener("SIGTERM", onSigterm);
+  }
 }
 
 export async function runGitCommand(
@@ -143,13 +180,19 @@ export async function runGitCommand(
   cwd: string,
   opts: { timeoutMs?: number; env?: Record<string, string | undefined> } = {},
 ): Promise<GitResult> {
-  return spawnWithTimeout(["git", ...args], cwd, opts.timeoutMs ?? DEFAULT_GIT_TIMEOUT_MS, {
+  const env: Record<string, string | undefined> = {
     ...process.env,
     ...opts.env,
     GIT_TERMINAL_PROMPT: "0",
     GCM_INTERACTIVE: "Never",
-    GIT_SSH_COMMAND: opts.env?.GIT_SSH_COMMAND ?? process.env.GIT_SSH_COMMAND ?? "ssh -o BatchMode=yes",
-  });
+    GIT_SSH_COMMAND: opts.env?.GIT_SSH_COMMAND ?? "ssh -o BatchMode=yes",
+    GIT_CONFIG_COUNT: "1",
+    GIT_CONFIG_KEY_0: "core.askPass",
+    GIT_CONFIG_VALUE_0: "",
+  };
+  delete env.GIT_ASKPASS;
+  delete env.SSH_ASKPASS;
+  return spawnWithTimeout(["git", ...args], cwd, opts.timeoutMs ?? DEFAULT_GIT_TIMEOUT_MS, env);
 }
 
 const defaultGit: GitRunner = (args, cwd) => runGitCommand(args, cwd);

--- a/cli/src/commands/worktree.ts
+++ b/cli/src/commands/worktree.ts
@@ -229,8 +229,7 @@ export function isAgentPartyWorktree(path: string, branch: string | null): boole
   return (
     branch?.startsWith("agentparty/") === true ||
     /(?:^|\/)agentparty-wt-[^/]+(?:\/|$)/i.test(normalized) ||
-    /(?:^|\/)\.claude\/worktrees\/agent-[^/]+(?:\/|$)/.test(normalized) ||
-    /(?:^|\/)worktrees\/[^/]+(?:\/|$)/.test(normalized)
+    /(?:^|\/)\.claude\/worktrees\/agent-[^/]+(?:\/|$)/.test(normalized)
   );
 }
 

--- a/cli/src/commands/worktree.ts
+++ b/cli/src/commands/worktree.ts
@@ -181,9 +181,15 @@ export async function runGitCommand(
   opts: { timeoutMs?: number; env?: Record<string, string | undefined> } = {},
 ): Promise<GitResult> {
   const inheritedSshCommand = opts.env?.GIT_SSH_COMMAND ?? process.env.GIT_SSH_COMMAND ?? "ssh";
-  const sshCommand = /(?:^|\s)-o\s*BatchMode(?:=|\s+)/iu.test(inheritedSshCommand)
-    ? inheritedSshCommand
-    : `${inheritedSshCommand} -o BatchMode=yes`;
+  let foundBatchMode = false;
+  const normalizedSshCommand = inheritedSshCommand.replace(
+    /(^|\s)-o\s*BatchMode\s*(?:=\s*|\s+)(?:yes|no|ask)\b/giu,
+    (_match, leading: string) => {
+      foundBatchMode = true;
+      return `${leading}-o BatchMode=yes`;
+    },
+  );
+  const sshCommand = foundBatchMode ? normalizedSshCommand : `${inheritedSshCommand} -o BatchMode=yes`;
   const env: Record<string, string | undefined> = {
     ...process.env,
     ...opts.env,

--- a/cli/src/commands/worktree.ts
+++ b/cli/src/commands/worktree.ts
@@ -180,15 +180,16 @@ export async function runGitCommand(
   cwd: string,
   opts: { timeoutMs?: number; env?: Record<string, string | undefined> } = {},
 ): Promise<GitResult> {
+  const inheritedSshCommand = opts.env?.GIT_SSH_COMMAND ?? process.env.GIT_SSH_COMMAND ?? "ssh";
+  const sshCommand = /(?:^|\s)-o\s*BatchMode(?:=|\s+)/iu.test(inheritedSshCommand)
+    ? inheritedSshCommand
+    : `${inheritedSshCommand} -o BatchMode=yes`;
   const env: Record<string, string | undefined> = {
     ...process.env,
     ...opts.env,
     GIT_TERMINAL_PROMPT: "0",
     GCM_INTERACTIVE: "Never",
-    GIT_SSH_COMMAND: opts.env?.GIT_SSH_COMMAND ?? "ssh -o BatchMode=yes",
-    GIT_CONFIG_COUNT: "1",
-    GIT_CONFIG_KEY_0: "core.askPass",
-    GIT_CONFIG_VALUE_0: "",
+    GIT_SSH_COMMAND: sshCommand,
   };
   delete env.GIT_ASKPASS;
   delete env.SSH_ASKPASS;
@@ -412,7 +413,7 @@ async function removeMergedClean(
   action: PruneAction,
   remote: boolean,
   git: GitRunner,
-): Promise<boolean> {
+): Promise<number> {
   // raw 用于 git 参数，branch(sanitized) 只用于打印——绝不把『防注入显示串』喂给会真删/真推的
   // git 命令，否则日后扩展 sanitize（如 Unicode 归一化）会悄悄改掉实际分支名（CodeRabbit #459）。
   const raw = action.row.branch!;
@@ -420,27 +421,27 @@ async function removeMergedClean(
   const rm = await git(["worktree", "remove", action.row.path], root);
   if (rm.code !== 0) {
     console.error(`  ! ${branch}: worktree remove failed, skipped — ${terminal(rm.stderr.trim())}`);
-    return false;
+    return rm.code;
   }
   const del = await git(["branch", "-D", raw], root);
   if (del.code !== 0) {
     console.error(`  ! ${branch}: worktree removed but branch delete failed — ${terminal(del.stderr.trim())}`);
-    return false;
+    return del.code;
   }
   if (remote) {
     const pushDel = await git(["push", "origin", "--delete", raw], root);
     if (pushDel.code !== 0) {
       console.error(`  ! ${branch}: remote branch delete failed — ${terminal(pushDel.stderr.trim())}`);
-      return false;
+      return pushDel.code;
     }
   }
   console.log(`  removed ${branch} (merged-clean)`);
-  return true;
+  return 0;
 }
 
 // merged-dirty：绝不 --force 丢活。先把未提交改动 commit + push 到 preserve/*，全部成功才删。
 // 任一步失败 → 保留 worktree，跳过并告警，宁可留着让人处理也不丢工作。
-async function preserveAndRemove(root: string, action: PruneAction, git: GitRunner): Promise<boolean> {
+async function preserveAndRemove(root: string, action: PruneAction, git: GitRunner): Promise<number> {
   // raw 喂 git，branch(sanitized) 只打印——同 removeMergedClean 的理由（CodeRabbit #459）。
   const raw = action.row.branch!;
   const branch = terminal(raw);
@@ -448,19 +449,19 @@ async function preserveAndRemove(root: string, action: PruneAction, git: GitRunn
   const add = await git(["-C", path, "add", "-A"], root);
   if (add.code !== 0) {
     console.error(`  ! ${branch}: git add failed, worktree preserved as-is — ${terminal(add.stderr.trim())}`);
-    return false;
+    return add.code;
   }
   const commit = await git(["-C", path, "commit", "-m", `wip: preserve ${raw} (#455)`], root);
   if (commit.code !== 0) {
     console.error(`  ! ${branch}: commit failed, worktree preserved as-is — ${terminal(commit.stderr.trim())}`);
-    return false;
+    return commit.code;
   }
   const push = await git(["-C", path, "push", "origin", `HEAD:preserve/${raw}`], root);
   if (push.code !== 0) {
     console.error(
       `  ! ${branch}: push to preserve/${branch} failed, worktree preserved as-is — ${terminal(push.stderr.trim())}`,
     );
-    return false;
+    return push.code;
   }
   // 改动已安全落到 origin/preserve/*，现在删本地 worktree+分支才不丢活。
   const rm = await git(["worktree", "remove", "--force", path], root);
@@ -468,17 +469,17 @@ async function preserveAndRemove(root: string, action: PruneAction, git: GitRunn
     console.error(
       `  ! ${branch}: preserved to preserve/${branch} but worktree remove failed — ${terminal(rm.stderr.trim())}`,
     );
-    return false;
+    return rm.code;
   }
   const del = await git(["branch", "-D", raw], root);
   if (del.code !== 0) {
     console.error(
       `  ! ${branch}: preserved + worktree removed but branch delete failed — ${terminal(del.stderr.trim())}`,
     );
-    return false;
+    return del.code;
   }
   console.log(`  preserved ${branch} -> origin/preserve/${branch}, then removed (merged-dirty)`);
-  return true;
+  return 0;
 }
 
 async function runPrune(
@@ -512,11 +513,12 @@ async function runPrune(
       console.log(`  skip    ${terminal(b)} — ${terminal(a.reason)}`);
       continue;
     }
-    const ok =
+    const code =
       a.kind === "remove"
         ? await removeMergedClean(root, a, opts.remote, git)
         : await preserveAndRemove(root, a, git);
-    if (!ok) failed = true;
+    if (code === 130 || code === 143) return code;
+    if (code !== 0) failed = true;
   }
   return failed ? 1 : 0;
 }

--- a/cli/src/commands/worktree.ts
+++ b/cli/src/commands/worktree.ts
@@ -6,6 +6,7 @@
 //   2. dirty 保全：worktree 有未提交改动时【绝不 --force 丢活】——先 commit+push 到 preserve/*，再删。
 //   3. 未合价值：有 '+' 提交 → skip + 报告，交作者追 main 开 PR。
 import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
+import { stripTerminalControls } from "../format";
 
 const HELP = `usage: party worktree list [--base <ref>] [--json]
        party worktree prune [--base <ref>] [--dry-run] [--remote] [--yes]
@@ -19,13 +20,14 @@ would otherwise mis-flag merged work as unmerged):
   unmerged      has '+' commits not in base (real unmerged work)
 
 list   print every worktree with its status + (commits-ahead / dirty-file-count).
+       Only AgentParty patterns are eligible for cleanup; unrelated worktrees are reported and skipped.
 
 prune  DEFAULT IS --dry-run: print the plan, do nothing. Pass --yes to execute.
   merged-clean -> git worktree remove + git branch -D  (+ push --delete if --remote)
   merged-dirty -> commit + push origin HEAD:preserve/<branch>, THEN remove (never
                   --force-loses work; if preserve fails the worktree is SKIPPED)
   unmerged     -> SKIP + report so you can open a PR
-  Never touches the main working tree, the current worktree, or a locked worktree.
+  Never touches the main/current/locked/detached worktree, or an unrelated worktree.
 
 Options:
   --base <ref>   base to compare against (default: origin/main)
@@ -45,20 +47,54 @@ export interface GitResult {
 
 export type GitRunner = (args: string[], cwd: string) => Promise<GitResult>;
 
-const defaultGit: GitRunner = async (args, cwd) => {
+const DEFAULT_GIT_TIMEOUT_MS = 30_000;
+
+export async function runGitCommand(
+  args: string[],
+  cwd: string,
+  opts: { timeoutMs?: number; env?: Record<string, string | undefined> } = {},
+): Promise<GitResult> {
   const proc = Bun.spawn(["git", ...args], {
     cwd,
     stdin: "ignore",
     stdout: "pipe",
     stderr: "pipe",
+    detached: true,
+    env: {
+      ...process.env,
+      ...opts.env,
+      GIT_TERMINAL_PROMPT: "0",
+      GCM_INTERACTIVE: "Never",
+      GIT_SSH_COMMAND: opts.env?.GIT_SSH_COMMAND ?? process.env.GIT_SSH_COMMAND ?? "ssh -o BatchMode=yes",
+    },
   });
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    try {
+      // detached 让 Git 及其 ssh/credential helper 处在独立进程组；超时要杀整组，
+      // 否则只杀 git 时子进程仍可能握着 stdout/stderr pipe，Promise 会继续永久等待。
+      process.kill(-proc.pid, "SIGKILL");
+    } catch {
+      try {
+        proc.kill("SIGKILL");
+      } catch {
+        /* 已退出：流读取会正常收尾 */
+      }
+    }
+  }, opts.timeoutMs ?? DEFAULT_GIT_TIMEOUT_MS);
   const [stdout, stderr, code] = await Promise.all([
     new Response(proc.stdout).text(),
     new Response(proc.stderr).text(),
     proc.exited,
   ]);
-  return { code, stdout, stderr };
-};
+  clearTimeout(timer);
+  return timedOut
+    ? { code: 124, stdout, stderr: `${stderr}${stderr.endsWith("\n") || stderr === "" ? "" : "\n"}git command timed out` }
+    : { code, stdout, stderr };
+}
+
+const defaultGit: GitRunner = (args, cwd) => runGitCommand(args, cwd);
 
 export type WorktreeStatus =
   | "merged-clean"
@@ -67,7 +103,8 @@ export type WorktreeStatus =
   | "main"
   | "current"
   | "locked"
-  | "detached";
+  | "detached"
+  | "unrelated";
 
 export interface WorktreeRow {
   path: string;
@@ -83,6 +120,16 @@ interface RawWorktree {
   detached: boolean;
   locked: boolean;
   bare: boolean;
+}
+
+export function isAgentPartyWorktree(path: string, branch: string | null): boolean {
+  const normalized = path.replaceAll("\\", "/");
+  return (
+    branch?.startsWith("agentparty/") === true ||
+    /(?:^|\/)agentparty-wt-[^/]+(?:\/|$)/i.test(normalized) ||
+    /(?:^|\/)\.claude\/worktrees\/agent-[^/]+(?:\/|$)/.test(normalized) ||
+    /(?:^|\/)worktrees\/[^/]+(?:\/|$)/.test(normalized)
+  );
 }
 
 // 解析 `git worktree list --porcelain`：block 之间空行分隔，主工作树是第一个 block。
@@ -124,13 +171,16 @@ export async function classifyWorktrees(
 ): Promise<WorktreeRow[]> {
   const list = await git(["worktree", "list", "--porcelain"], root);
   if (list.code !== 0) {
-    throw new Error(`git worktree list failed: ${list.stderr.trim() || list.stdout.trim()}`);
+    throw new Error(`git worktree list failed: ${terminal(list.stderr.trim() || list.stdout.trim())}`);
   }
   const raws = parseWorktreePorcelain(list.stdout);
 
   // 当前工作树（cwd 所在的顶层）——绝不删自己脚下的。
   const top = await git(["rev-parse", "--show-toplevel"], root);
-  const currentPath = top.code === 0 ? top.stdout.trim() : "";
+  if (top.code !== 0 || top.stdout.trim() === "") {
+    throw new Error(`cannot protect current worktree: ${terminal(top.stderr.trim() || "git rev-parse failed")}`);
+  }
+  const currentPath = top.stdout.trim();
 
   const rows: WorktreeRow[] = [];
   for (let i = 0; i < raws.length; i++) {
@@ -155,6 +205,11 @@ export async function classifyWorktrees(
     }
     if (w.detached || !w.branch) {
       row.status = "detached";
+      rows.push(row);
+      continue;
+    }
+    if (!isAgentPartyWorktree(w.path, w.branch)) {
+      row.status = "unrelated";
       rows.push(row);
       continue;
     }
@@ -196,16 +251,22 @@ function detail(r: WorktreeRow): string {
   return "";
 }
 
+function terminal(input: string): string {
+  return stripTerminalControls(input).replace(/[\r\n\t]+/g, " ");
+}
+
 async function runList(root: string, base: string, json: boolean, git: GitRunner): Promise<number> {
   const rows = await classifyWorktrees(root, base, git);
   if (json) {
     console.log(JSON.stringify(rows));
     return 0;
   }
-  console.log(`base: ${base}`);
+  console.log(`base: ${terminal(base)}`);
   for (const r of rows) {
     const d = detail(r);
-    console.log(`${r.status.padEnd(13)} ${(r.branch ?? "(detached)").padEnd(28)} ${d.padEnd(16)} ${r.path}`);
+    console.log(
+      `${r.status.padEnd(13)} ${terminal(r.branch ?? "(detached)").padEnd(28)} ${d.padEnd(16)} ${terminal(r.path)}`,
+    );
   }
   return 0;
 }
@@ -248,20 +309,22 @@ async function removeMergedClean(
   const branch = action.row.branch!;
   const rm = await git(["worktree", "remove", action.row.path], root);
   if (rm.code !== 0) {
-    console.error(`  ! ${branch}: worktree remove failed, skipped — ${rm.stderr.trim()}`);
+    console.error(`  ! ${terminal(branch)}: worktree remove failed, skipped — ${terminal(rm.stderr.trim())}`);
     return false;
   }
   const del = await git(["branch", "-D", branch], root);
   if (del.code !== 0) {
-    console.error(`  ! ${branch}: worktree removed but branch delete failed — ${del.stderr.trim()}`);
+    console.error(`  ! ${terminal(branch)}: worktree removed but branch delete failed — ${terminal(del.stderr.trim())}`);
+    return false;
   }
   if (remote) {
     const pushDel = await git(["push", "origin", "--delete", branch], root);
     if (pushDel.code !== 0) {
-      console.error(`  ! ${branch}: remote branch delete failed — ${pushDel.stderr.trim()}`);
+      console.error(`  ! ${terminal(branch)}: remote branch delete failed — ${terminal(pushDel.stderr.trim())}`);
+      return false;
     }
   }
-  console.log(`  removed ${branch} (merged-clean)`);
+  console.log(`  removed ${terminal(branch)} (merged-clean)`);
   return true;
 }
 
@@ -272,30 +335,37 @@ async function preserveAndRemove(root: string, action: PruneAction, git: GitRunn
   const path = action.row.path;
   const add = await git(["-C", path, "add", "-A"], root);
   if (add.code !== 0) {
-    console.error(`  ! ${branch}: git add failed, worktree preserved as-is — ${add.stderr.trim()}`);
+    console.error(`  ! ${terminal(branch)}: git add failed, worktree preserved as-is — ${terminal(add.stderr.trim())}`);
     return false;
   }
   const commit = await git(["-C", path, "commit", "-m", `wip: preserve ${branch} (#455)`], root);
   if (commit.code !== 0) {
-    console.error(`  ! ${branch}: commit failed, worktree preserved as-is — ${commit.stderr.trim()}`);
+    console.error(`  ! ${terminal(branch)}: commit failed, worktree preserved as-is — ${terminal(commit.stderr.trim())}`);
     return false;
   }
   const push = await git(["-C", path, "push", "origin", `HEAD:preserve/${branch}`], root);
   if (push.code !== 0) {
-    console.error(`  ! ${branch}: push to preserve/${branch} failed, worktree preserved as-is — ${push.stderr.trim()}`);
+    console.error(
+      `  ! ${terminal(branch)}: push to preserve/${terminal(branch)} failed, worktree preserved as-is — ${terminal(push.stderr.trim())}`,
+    );
     return false;
   }
   // 改动已安全落到 origin/preserve/*，现在删本地 worktree+分支才不丢活。
   const rm = await git(["worktree", "remove", "--force", path], root);
   if (rm.code !== 0) {
-    console.error(`  ! ${branch}: preserved to preserve/${branch} but worktree remove failed — ${rm.stderr.trim()}`);
+    console.error(
+      `  ! ${terminal(branch)}: preserved to preserve/${terminal(branch)} but worktree remove failed — ${terminal(rm.stderr.trim())}`,
+    );
     return false;
   }
   const del = await git(["branch", "-D", branch], root);
   if (del.code !== 0) {
-    console.error(`  ! ${branch}: preserved + worktree removed but branch delete failed — ${del.stderr.trim()}`);
+    console.error(
+      `  ! ${terminal(branch)}: preserved + worktree removed but branch delete failed — ${terminal(del.stderr.trim())}`,
+    );
+    return false;
   }
-  console.log(`  preserved ${branch} -> origin/preserve/${branch}, then removed (merged-dirty)`);
+  console.log(`  preserved ${terminal(branch)} -> origin/preserve/${terminal(branch)}, then removed (merged-dirty)`);
   return true;
 }
 
@@ -310,27 +380,33 @@ async function runPrune(
   const act = opts.yes && !opts.dryRun;
 
   if (!act) {
-    console.log(`plan (dry-run — pass --yes to execute), base ${base}:`);
+    console.log(`plan (dry-run — pass --yes to execute), base ${terminal(base)}:`);
     for (const a of actions) {
       const b = a.row.branch ?? "(detached)";
-      console.log(`  ${a.kind.padEnd(8)} ${b.padEnd(28)} ${a.reason}  [${a.row.path}]`);
+      console.log(
+        `  ${a.kind.padEnd(8)} ${terminal(b).padEnd(28)} ${terminal(a.reason)}  [${terminal(a.row.path)}]`,
+      );
     }
     const removable = actions.filter((a) => a.kind !== "skip").length;
     console.log(`\n${removable} worktree(s) would be cleaned, ${actions.length - removable} skipped. Re-run with --yes.`);
     return 0;
   }
 
-  console.log(`executing prune, base ${base}:`);
+  console.log(`executing prune, base ${terminal(base)}:`);
+  let failed = false;
   for (const a of actions) {
     if (a.kind === "skip") {
       const b = a.row.branch ?? "(detached)";
-      console.log(`  skip    ${b} — ${a.reason}`);
+      console.log(`  skip    ${terminal(b)} — ${terminal(a.reason)}`);
       continue;
     }
-    if (a.kind === "remove") await removeMergedClean(root, a, opts.remote, git);
-    else await preserveAndRemove(root, a, git);
+    const ok =
+      a.kind === "remove"
+        ? await removeMergedClean(root, a, opts.remote, git)
+        : await preserveAndRemove(root, a, git);
+    if (!ok) failed = true;
   }
-  return 0;
+  return failed ? 1 : 0;
 }
 
 export async function run(argv: string[], git: GitRunner = defaultGit): Promise<number> {

--- a/cli/src/commands/worktree.ts
+++ b/cli/src/commands/worktree.ts
@@ -189,6 +189,13 @@ export async function runGitCommand(
       return `${leading}-o BatchMode=yes`;
     },
   );
+  if (/BatchMode/iu.test(normalizedSshCommand.replaceAll(/BatchMode=yes/giu, ""))) {
+    return {
+      code: 1,
+      stdout: "",
+      stderr: "unsafe GIT_SSH_COMMAND BatchMode syntax; refusing an interactive Git command",
+    };
+  }
   const sshCommand = foundBatchMode ? normalizedSshCommand : `${inheritedSshCommand} -o BatchMode=yes`;
   const env: Record<string, string | undefined> = {
     ...process.env,

--- a/cli/src/commands/worktree.ts
+++ b/cli/src/commands/worktree.ts
@@ -49,6 +49,47 @@ export type GitRunner = (args: string[], cwd: string) => Promise<GitResult>;
 
 const DEFAULT_GIT_TIMEOUT_MS = 30_000;
 
+interface KillableGitProcess {
+  pid: number;
+  kill(signal?: NodeJS.Signals | number): void;
+}
+
+type WindowsTreeKiller = (pid: number) => void;
+
+function taskkillProcessTree(pid: number): void {
+  const killer = Bun.spawn(["taskkill", "/PID", String(pid), "/T", "/F"], {
+    stdin: "ignore",
+    stdout: "ignore",
+    stderr: "ignore",
+  });
+  killer.unref();
+}
+
+export function terminateGitProcessTree(
+  proc: KillableGitProcess,
+  platform: NodeJS.Platform = process.platform,
+  killGroup: typeof process.kill = process.kill,
+  killWindowsTree: WindowsTreeKiller = taskkillProcessTree,
+): "group" | "tree" | "child" {
+  if (platform === "win32") {
+    try {
+      killWindowsTree(proc.pid);
+      return "tree";
+    } catch {
+      // taskkill 启动失败时仍要至少终止直接子进程。
+    }
+  } else {
+    try {
+      killGroup(-proc.pid, "SIGKILL");
+      return "group";
+    } catch {
+      // Git 可能恰好已退出；回退到直接子进程。
+    }
+  }
+  proc.kill("SIGKILL");
+  return "child";
+}
+
 export async function runGitCommand(
   args: string[],
   cwd: string,
@@ -59,7 +100,9 @@ export async function runGitCommand(
     stdin: "ignore",
     stdout: "pipe",
     stderr: "pipe",
-    detached: true,
+    // POSIX 上独立进程组可一次终止 git + ssh/credential helper；
+    // Windows 保留父子关系，超时时交给 taskkill /T /F 清整棵进程树。
+    detached: process.platform !== "win32",
     env: {
       ...process.env,
       ...opts.env,
@@ -72,9 +115,7 @@ export async function runGitCommand(
   const timer = setTimeout(() => {
     timedOut = true;
     try {
-      // detached 让 Git 及其 ssh/credential helper 处在独立进程组；超时要杀整组，
-      // 否则只杀 git 时子进程仍可能握着 stdout/stderr pipe，Promise 会继续永久等待。
-      process.kill(-proc.pid, "SIGKILL");
+      terminateGitProcessTree(proc);
     } catch {
       try {
         proc.kill("SIGKILL");

--- a/cli/src/commands/worktree.ts
+++ b/cli/src/commands/worktree.ts
@@ -183,7 +183,7 @@ export async function runGitCommand(
   const inheritedSshCommand = opts.env?.GIT_SSH_COMMAND ?? process.env.GIT_SSH_COMMAND ?? "ssh";
   let foundBatchMode = false;
   const normalizedSshCommand = inheritedSshCommand.replace(
-    /(^|\s)-o\s*BatchMode\s*(?:=\s*|\s+)(?:yes|no|ask)\b/giu,
+    /(^|\s)["']?-o\s*["']?BatchMode["']?\s*(?:=\s*|\s+)["']?(?:yes|no|ask)["']?/giu,
     (_match, leading: string) => {
       foundBatchMode = true;
       return `${leading}-o BatchMode=yes`;

--- a/cli/test/cli.test.ts
+++ b/cli/test/cli.test.ts
@@ -72,6 +72,7 @@ describe("cli subprocess", () => {
       "squad",
       "charter",
       "statusline",
+      "worktree",
     ];
     for (const cmd of commands) {
       const r = await runCli([cmd, "--help"]);

--- a/cli/test/worktree.test.ts
+++ b/cli/test/worktree.test.ts
@@ -128,14 +128,17 @@ describe("classifyWorktrees", () => {
 });
 
 describe("git runner safety", () => {
-  test("uses taskkill semantics for the full process tree on Windows", () => {
+  test("uses taskkill semantics for the full process tree on Windows", async () => {
     const treePids: number[] = [];
     const childSignals: Array<NodeJS.Signals | number | undefined> = [];
-    const result = terminateGitProcessTree(
+    const result = await terminateGitProcessTree(
       { pid: 42, kill: (signal) => childSignals.push(signal) },
       "win32",
       process.kill,
-      (pid) => treePids.push(pid),
+      async (pid) => {
+        treePids.push(pid);
+        return true;
+      },
     );
 
     expect(result).toBe("tree");
@@ -143,24 +146,55 @@ describe("git runner safety", () => {
     expect(childSignals).toEqual([]);
   });
 
+  test("falls back to the direct child when taskkill fails", async () => {
+    const childSignals: Array<NodeJS.Signals | number | undefined> = [];
+    const result = await terminateGitProcessTree(
+      { pid: 42, kill: (signal) => childSignals.push(signal) },
+      "win32",
+      process.kill,
+      async () => false,
+    );
+    expect(result).toBe("child");
+    expect(childSignals).toEqual(["SIGKILL"]);
+  });
+
   test("disables interactive Git and credential prompts", async () => {
     const bin = join(root, "bin");
     git(root, "init", "--quiet", bin);
     const fakeGit = join(bin, "git");
-    writeFileSync(fakeGit, "#!/bin/sh\nprintf '%s|%s' \"$GIT_TERMINAL_PROMPT\" \"$GCM_INTERACTIVE\"\n");
+    writeFileSync(
+      fakeGit,
+      "#!/bin/sh\nprintf '%s|%s|%s|%s|%s|%s' \"$GIT_TERMINAL_PROMPT\" \"$GCM_INTERACTIVE\" \"${GIT_ASKPASS-unset}\" \"${SSH_ASKPASS-unset}\" \"$GIT_SSH_COMMAND\" \"$GIT_CONFIG_KEY_0\"\n",
+    );
     chmodSync(fakeGit, 0o755);
     const result = await runGitCommand(["status"], main, {
-      env: { PATH: `${bin}:${process.env.PATH ?? ""}` },
+      env: {
+        PATH: `${bin}:${process.env.PATH ?? ""}`,
+        GIT_ASKPASS: "/tmp/should-not-run",
+        SSH_ASKPASS: "/tmp/should-not-run",
+      },
     });
     expect(result.code).toBe(0);
-    expect(result.stdout).toBe("0|Never");
+    expect(result.stdout).toBe("0|Never|unset|unset|ssh -o BatchMode=yes|core.askPass");
   });
 });
 
 describe("spawnWithTimeout", () => {
+  test("SIGINT 级联终止子进程并清理信号监听器", async () => {
+    const before = process.listenerCount("SIGINT");
+    const pending = spawnWithTimeout([process.execPath, "-e", "setTimeout(() => {}, 5000)"], root, 5000);
+    await Bun.sleep(50);
+    process.emit("SIGINT");
+
+    const r = await pending;
+    expect(r.code).toBe(130);
+    expect(r.stderr).toContain("SIGINT");
+    expect(process.listenerCount("SIGINT")).toBe(before);
+  });
+
   test("超时独立返回 124，不等命令自然结束（防子进程占管道导致卡死）", async () => {
     const t0 = Date.now();
-    const r = await spawnWithTimeout(["sleep", "5"], root, 200);
+    const r = await spawnWithTimeout([process.execPath, "-e", "setTimeout(() => {}, 5000)"], root, 200);
     expect(r.code).toBe(124);
     expect(r.stderr).toContain("timed out");
     // 远早于 5s 返回 = 超时确实独立于命令/管道，没干等。
@@ -168,7 +202,7 @@ describe("spawnWithTimeout", () => {
   });
 
   test("命令按时结束时返回真实退出码与输出", async () => {
-    const r = await spawnWithTimeout(["sh", "-c", "printf ok"], root, 5000);
+    const r = await spawnWithTimeout([process.execPath, "-e", "process.stdout.write('ok')"], root, 5000);
     expect(r.code).toBe(0);
     expect(r.stdout).toBe("ok");
   });

--- a/cli/test/worktree.test.ts
+++ b/cli/test/worktree.test.ts
@@ -67,7 +67,8 @@ beforeEach(() => {
   commitFile(join(root, "agentparty-wt-un"), "un.txt", "un-change\n", "un: real unmerged work");
 
   // 普通手工 worktree：即使 patch 已在 main，也不属于 AgentParty teardown 范围，绝不能清。
-  git(main, "worktree", "add", "-b", "manual", join(root, "manual-wt"), "main");
+  // 路径故意叫 worktrees/manual：通用 worktrees/* 不是 AgentParty 身份证据，仍必须跳过。
+  git(main, "worktree", "add", "-b", "manual", join(root, "worktrees", "manual"), "main");
 
   process.chdir(main);
   logs = [];
@@ -314,7 +315,7 @@ describe("party worktree prune", () => {
   test("--yes skips unrelated manual worktree", async () => {
     const code = await run(["prune", "--base", "main", "--yes"]);
     expect(code).toBe(0);
-    expect(existsSync(join(root, "manual-wt"))).toBe(true);
+    expect(existsSync(join(root, "worktrees", "manual"))).toBe(true);
     const branches = git(main, "branch", "--format=%(refname:short)").split("\n");
     expect(branches).toContain("manual");
     expect(logs.join("\n")).toMatch(/skip\s+manual\s+— unrelated/);

--- a/cli/test/worktree.test.ts
+++ b/cli/test/worktree.test.ts
@@ -1,9 +1,9 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { classifyWorktrees, type GitRunner, run } from "../src/commands/worktree";
+import { classifyWorktrees, type GitRunner, run, runGitCommand } from "../src/commands/worktree";
 
 // 用真 git：临时仓库 + 真 worktree，覆盖 merged-clean / merged-dirty / unmerged 三态。
 // 不 mock git——命令的价值就在于对真 porcelain 输出的解析与真 cherry/status 判定。
@@ -42,21 +42,24 @@ beforeEach(() => {
   git(main, "push", "-u", "origin", "main");
 
   // merged-clean: 分支提交了改动，同一 patch 也进了 main（cherry -> '-'），工作树干净。
-  git(main, "worktree", "add", "-b", "mc", join(root, "wt-mc"), "main");
-  commitFile(join(root, "wt-mc"), "mc.txt", "mc-change\n", "mc: add file");
-  const mcSha = git(join(root, "wt-mc"), "rev-parse", "HEAD");
+  git(main, "worktree", "add", "-b", "mc", join(root, "agentparty-wt-mc"), "main");
+  commitFile(join(root, "agentparty-wt-mc"), "mc.txt", "mc-change\n", "mc: add file");
+  const mcSha = git(join(root, "agentparty-wt-mc"), "rev-parse", "HEAD");
   git(main, "cherry-pick", mcSha); // main 现在 patch-equivalent 含 mc 的改动
 
   // merged-dirty: 同上 patch-equivalent，但工作树留未提交改动。
-  git(main, "worktree", "add", "-b", "md", join(root, "wt-md"), "main");
-  commitFile(join(root, "wt-md"), "md.txt", "md-change\n", "md: add file");
-  const mdSha = git(join(root, "wt-md"), "rev-parse", "HEAD");
+  git(main, "worktree", "add", "-b", "md", join(root, "agentparty-wt-md"), "main");
+  commitFile(join(root, "agentparty-wt-md"), "md.txt", "md-change\n", "md: add file");
+  const mdSha = git(join(root, "agentparty-wt-md"), "rev-parse", "HEAD");
   git(main, "cherry-pick", mdSha);
-  writeFileSync(join(root, "wt-md", "dirty.txt"), "uncommitted work\n"); // 脏
+  writeFileSync(join(root, "agentparty-wt-md", "dirty.txt"), "uncommitted work\n"); // 脏
 
   // unmerged: 分支有真未合提交（cherry -> '+'）。
-  git(main, "worktree", "add", "-b", "un", join(root, "wt-un"), "main");
-  commitFile(join(root, "wt-un"), "un.txt", "un-change\n", "un: real unmerged work");
+  git(main, "worktree", "add", "-b", "un", join(root, "agentparty-wt-un"), "main");
+  commitFile(join(root, "agentparty-wt-un"), "un.txt", "un-change\n", "un: real unmerged work");
+
+  // 普通手工 worktree：即使 patch 已在 main，也不属于 AgentParty teardown 范围，绝不能清。
+  git(main, "worktree", "add", "-b", "manual", join(root, "manual-wt"), "main");
 
   process.chdir(main);
   logs = [];
@@ -94,7 +97,7 @@ describe("classifyWorktrees", () => {
     // 空 stdout 绝不能被读成 dirty=0 → merged-clean → 删。status 拿不到 = 状态未知 = 保守保留。
     // 命令形如 git(["-C", <wt路径>, "status", "--porcelain"], root)——按 args 内容匹配。
     const failingGit: GitRunner = async (args, cwd) => {
-      if (args.includes("status") && args.some((a) => a.includes("wt-mc"))) {
+      if (args.includes("status") && args.some((a) => a.includes("agentparty-wt-mc"))) {
         return { code: 1, stdout: "", stderr: "fatal: simulated status failure" };
       }
       const out = execFileSync("git", args, { cwd, encoding: "utf8" });
@@ -102,7 +105,33 @@ describe("classifyWorktrees", () => {
     };
     const rows = await classifyWorktrees(main, "main", failingGit);
     const mc = rows.find((r) => r.branch === "mc");
-    expect(mc?.status).not.toBe("merged-clean");
+    expect(mc?.status).toBe("unmerged");
+  });
+
+  test("rev-parse 当前 worktree 失败时直接中止，不能绕过 current 保护", async () => {
+    const failingGit: GitRunner = async (args, cwd) => {
+      if (args[0] === "rev-parse") return { code: 1, stdout: "", stderr: "simulated rev-parse failure" };
+      const out = execFileSync("git", args, { cwd, encoding: "utf8" });
+      return { code: 0, stdout: out, stderr: "" };
+    };
+    await expect(classifyWorktrees(main, "main", failingGit)).rejects.toThrow("cannot protect current worktree");
+  });
+});
+
+describe("git runner safety", () => {
+  test("disables interactive prompts and kills a hung git command on timeout", async () => {
+    const bin = join(root, "bin");
+    git(root, "init", "--quiet", bin);
+    const fakeGit = join(bin, "git");
+    writeFileSync(fakeGit, "#!/bin/sh\nprintf '%s|%s' \"$GIT_TERMINAL_PROMPT\" \"$GCM_INTERACTIVE\"\nexec sleep 0.2\n");
+    chmodSync(fakeGit, 0o755);
+    const result = await runGitCommand(["status"], main, {
+      timeoutMs: 30,
+      env: { PATH: `${bin}:${process.env.PATH ?? ""}` },
+    });
+    expect(result.code).toBe(124);
+    expect(result.stdout).toBe("0|Never");
+    expect(result.stderr).toContain("timed out");
   });
 });
 
@@ -122,9 +151,9 @@ describe("party worktree prune", () => {
   test("default is dry-run: touches nothing", async () => {
     const code = await run(["prune", "--base", "main"]);
     expect(code).toBe(0);
-    expect(existsSync(join(root, "wt-mc"))).toBe(true);
-    expect(existsSync(join(root, "wt-md"))).toBe(true);
-    expect(existsSync(join(root, "wt-un"))).toBe(true);
+    expect(existsSync(join(root, "agentparty-wt-mc"))).toBe(true);
+    expect(existsSync(join(root, "agentparty-wt-md"))).toBe(true);
+    expect(existsSync(join(root, "agentparty-wt-un"))).toBe(true);
     // 分支都还在
     const branches = git(main, "branch", "--format=%(refname:short)");
     expect(branches).toContain("mc");
@@ -134,7 +163,7 @@ describe("party worktree prune", () => {
   test("--yes removes merged-clean worktree + branch", async () => {
     const code = await run(["prune", "--base", "main", "--yes"]);
     expect(code).toBe(0);
-    expect(existsSync(join(root, "wt-mc"))).toBe(false);
+    expect(existsSync(join(root, "agentparty-wt-mc"))).toBe(false);
     const branches = git(main, "branch", "--format=%(refname:short)").split("\n");
     expect(branches).not.toContain("mc");
   });
@@ -143,7 +172,7 @@ describe("party worktree prune", () => {
     const code = await run(["prune", "--base", "main", "--yes"]);
     expect(code).toBe(0);
     // 工作树删了
-    expect(existsSync(join(root, "wt-md"))).toBe(false);
+    expect(existsSync(join(root, "agentparty-wt-md"))).toBe(false);
     // 但脏改动被 push 到 origin 的 preserve/md，内容没丢
     const remoteRefs = git(main, "ls-remote", "--heads", "origin");
     expect(remoteRefs).toContain("refs/heads/preserve/md");
@@ -156,10 +185,10 @@ describe("party worktree prune", () => {
     // 把 origin 指到不存在的地址，preserve push 必失败
     git(main, "remote", "set-url", "origin", join(root, "nonexistent-origin.git"));
     const code = await run(["prune", "--base", "main", "--yes"]);
-    expect(code).toBe(0);
+    expect(code).toBe(1);
     // push 失败 → 绝不删 worktree（脏活还在原地）
-    expect(existsSync(join(root, "wt-md"))).toBe(true);
-    expect(existsSync(join(root, "wt-md", "dirty.txt"))).toBe(true);
+    expect(existsSync(join(root, "agentparty-wt-md"))).toBe(true);
+    expect(existsSync(join(root, "agentparty-wt-md", "dirty.txt"))).toBe(true);
     // 明确报了跳过/失败
     expect(errs.join("\n").toLowerCase()).toContain("md");
   });
@@ -167,9 +196,18 @@ describe("party worktree prune", () => {
   test("--yes skips unmerged: worktree + branch survive", async () => {
     const code = await run(["prune", "--base", "main", "--yes"]);
     expect(code).toBe(0);
-    expect(existsSync(join(root, "wt-un"))).toBe(true);
+    expect(existsSync(join(root, "agentparty-wt-un"))).toBe(true);
     const branches = git(main, "branch", "--format=%(refname:short)").split("\n");
     expect(branches).toContain("un");
-    expect(logs.join("\n")).toContain("un");
+    expect(logs.join("\n")).toMatch(/skip\s+un\s+—/);
+  });
+
+  test("--yes skips unrelated manual worktree", async () => {
+    const code = await run(["prune", "--base", "main", "--yes"]);
+    expect(code).toBe(0);
+    expect(existsSync(join(root, "manual-wt"))).toBe(true);
+    const branches = git(main, "branch", "--format=%(refname:short)").split("\n");
+    expect(branches).toContain("manual");
+    expect(logs.join("\n")).toMatch(/skip\s+manual\s+— unrelated/);
   });
 });

--- a/cli/test/worktree.test.ts
+++ b/cli/test/worktree.test.ts
@@ -185,6 +185,12 @@ describe("git runner safety", () => {
       env: { PATH: `${bin}:${process.env.PATH ?? ""}`, GIT_SSH_COMMAND: "ssh -o BatchMode=yes -i key" },
     });
     expect(existingBatchMode.stdout.match(/BatchMode=yes/gu)?.length).toBe(1);
+
+    const interactiveBatchMode = await runGitCommand(["status"], main, {
+      env: { PATH: `${bin}:${process.env.PATH ?? ""}`, GIT_SSH_COMMAND: "ssh -i key -oBatchMode=no" },
+    });
+    expect(interactiveBatchMode.stdout).toContain("ssh -i key -o BatchMode=yes");
+    expect(interactiveBatchMode.stdout).not.toContain("BatchMode=no");
   });
 });
 

--- a/cli/test/worktree.test.ts
+++ b/cli/test/worktree.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { execFileSync } from "node:child_process";
 import { chmodSync, existsSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { delimiter, join } from "node:path";
 import {
   classifyWorktrees,
   type GitRunner,
@@ -170,7 +170,7 @@ describe("git runner safety", () => {
     chmodSync(fakeGit, 0o755);
     const result = await runGitCommand(["status"], main, {
       env: {
-        PATH: `${bin}:${process.env.PATH ?? ""}`,
+        PATH: `${bin}${delimiter}${process.env.PATH ?? ""}`,
         GIT_ASKPASS: "/tmp/should-not-run",
         SSH_ASKPASS: "/tmp/should-not-run",
         GIT_SSH_COMMAND: "ssh -i '/tmp/key path'",
@@ -182,25 +182,35 @@ describe("git runner safety", () => {
     expect(result.stdout).toBe("0|Never|unset|unset|ssh -i '/tmp/key path' -o BatchMode=yes|2|http.sslVerify");
 
     const existingBatchMode = await runGitCommand(["status"], main, {
-      env: { PATH: `${bin}:${process.env.PATH ?? ""}`, GIT_SSH_COMMAND: "ssh -o BatchMode=yes -i key" },
+      env: { PATH: `${bin}${delimiter}${process.env.PATH ?? ""}`, GIT_SSH_COMMAND: "ssh -o BatchMode=yes -i key" },
     });
     expect(existingBatchMode.stdout.match(/BatchMode=yes/gu)?.length).toBe(1);
 
     const interactiveBatchMode = await runGitCommand(["status"], main, {
-      env: { PATH: `${bin}:${process.env.PATH ?? ""}`, GIT_SSH_COMMAND: "ssh -i key -oBatchMode=no" },
+      env: { PATH: `${bin}${delimiter}${process.env.PATH ?? ""}`, GIT_SSH_COMMAND: "ssh -i key -oBatchMode=no" },
     });
     expect(interactiveBatchMode.stdout).toContain("ssh -i key -o BatchMode=yes");
     expect(interactiveBatchMode.stdout).not.toContain("BatchMode=no");
 
     const quotedBatchModes = await runGitCommand(["status"], main, {
       env: {
-        PATH: `${bin}:${process.env.PATH ?? ""}`,
+        PATH: `${bin}${delimiter}${process.env.PATH ?? ""}`,
         GIT_SSH_COMMAND: `ssh -i 'key path' -o 'BatchMode=no' "-oBatchMode=ask" -o BatchMode='no'`,
       },
     });
     expect(quotedBatchModes.stdout).toContain("ssh -i 'key path'");
     expect(quotedBatchModes.stdout.match(/BatchMode=yes/gu)?.length).toBe(3);
     expect(quotedBatchModes.stdout).not.toMatch(/BatchMode=(?:no|ask)/u);
+
+    const unsafeSeparatedTokens = await runGitCommand(["status"], main, {
+      env: {
+        PATH: `${bin}${delimiter}${process.env.PATH ?? ""}`,
+        GIT_SSH_COMMAND: `ssh '-o' 'BatchMode=no'`,
+      },
+    });
+    expect(unsafeSeparatedTokens.code).toBe(1);
+    expect(unsafeSeparatedTokens.stdout).toBe("");
+    expect(unsafeSeparatedTokens.stderr).toContain("unsafe GIT_SSH_COMMAND BatchMode syntax");
   });
 });
 

--- a/cli/test/worktree.test.ts
+++ b/cli/test/worktree.test.ts
@@ -191,6 +191,16 @@ describe("git runner safety", () => {
     });
     expect(interactiveBatchMode.stdout).toContain("ssh -i key -o BatchMode=yes");
     expect(interactiveBatchMode.stdout).not.toContain("BatchMode=no");
+
+    const quotedBatchModes = await runGitCommand(["status"], main, {
+      env: {
+        PATH: `${bin}:${process.env.PATH ?? ""}`,
+        GIT_SSH_COMMAND: `ssh -i 'key path' -o 'BatchMode=no' "-oBatchMode=ask" -o BatchMode='no'`,
+      },
+    });
+    expect(quotedBatchModes.stdout).toContain("ssh -i 'key path'");
+    expect(quotedBatchModes.stdout.match(/BatchMode=yes/gu)?.length).toBe(3);
+    expect(quotedBatchModes.stdout).not.toMatch(/BatchMode=(?:no|ask)/u);
   });
 });
 

--- a/cli/test/worktree.test.ts
+++ b/cli/test/worktree.test.ts
@@ -164,7 +164,7 @@ describe("git runner safety", () => {
     const fakeGit = join(bin, "git");
     writeFileSync(
       fakeGit,
-      "#!/bin/sh\nprintf '%s|%s|%s|%s|%s|%s' \"$GIT_TERMINAL_PROMPT\" \"$GCM_INTERACTIVE\" \"${GIT_ASKPASS-unset}\" \"${SSH_ASKPASS-unset}\" \"$GIT_SSH_COMMAND\" \"$GIT_CONFIG_KEY_0\"\n",
+      "#!/bin/sh\nprintf '%s|%s|%s|%s|%s|%s|%s' \"$GIT_TERMINAL_PROMPT\" \"$GCM_INTERACTIVE\" \"${GIT_ASKPASS-unset}\" \"${SSH_ASKPASS-unset}\" \"$GIT_SSH_COMMAND\" \"$GIT_CONFIG_COUNT\" \"$GIT_CONFIG_KEY_0\"\n",
     );
     chmodSync(fakeGit, 0o755);
     const result = await runGitCommand(["status"], main, {
@@ -172,10 +172,18 @@ describe("git runner safety", () => {
         PATH: `${bin}:${process.env.PATH ?? ""}`,
         GIT_ASKPASS: "/tmp/should-not-run",
         SSH_ASKPASS: "/tmp/should-not-run",
+        GIT_SSH_COMMAND: "ssh -i '/tmp/key path'",
+        GIT_CONFIG_COUNT: "2",
+        GIT_CONFIG_KEY_0: "http.sslVerify",
       },
     });
     expect(result.code).toBe(0);
-    expect(result.stdout).toBe("0|Never|unset|unset|ssh -o BatchMode=yes|core.askPass");
+    expect(result.stdout).toBe("0|Never|unset|unset|ssh -i '/tmp/key path' -o BatchMode=yes|2|http.sslVerify");
+
+    const existingBatchMode = await runGitCommand(["status"], main, {
+      env: { PATH: `${bin}:${process.env.PATH ?? ""}`, GIT_SSH_COMMAND: "ssh -o BatchMode=yes -i key" },
+    });
+    expect(existingBatchMode.stdout.match(/BatchMode=yes/gu)?.length).toBe(1);
   });
 });
 
@@ -248,6 +256,24 @@ describe("party worktree prune", () => {
     expect(existsSync(join(root, "agentparty-wt-mc"))).toBe(false);
     const branches = git(main, "branch", "--format=%(refname:short)").split("\n");
     expect(branches).not.toContain("mc");
+  });
+
+  test("SIGINT/SIGTERM exit code stops prune before the next destructive command", async () => {
+    const destructive: string[][] = [];
+    const interruptedGit: GitRunner = async (args, cwd) => {
+      if (args[0] === "worktree" && args[1] === "remove") {
+        destructive.push(args);
+        return { code: 130, stdout: "", stderr: "interrupted by SIGINT" };
+      }
+      if (args[0] === "branch" && args[1] === "-D") destructive.push(args);
+      const out = execFileSync("git", args, { cwd, encoding: "utf8" });
+      return { code: 0, stdout: out, stderr: "" };
+    };
+
+    const code = await run(["prune", "--base", "main", "--yes"], interruptedGit);
+    expect(code).toBe(130);
+    expect(destructive).toHaveLength(1);
+    expect(existsSync(join(root, "agentparty-wt-md"))).toBe(true);
   });
 
   test("--yes preserves merged-dirty to preserve/* BEFORE removing (never loses work)", async () => {

--- a/cli/test/worktree.test.ts
+++ b/cli/test/worktree.test.ts
@@ -3,7 +3,13 @@ import { execFileSync } from "node:child_process";
 import { chmodSync, existsSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { classifyWorktrees, type GitRunner, run, runGitCommand } from "../src/commands/worktree";
+import {
+  classifyWorktrees,
+  type GitRunner,
+  run,
+  runGitCommand,
+  terminateGitProcessTree,
+} from "../src/commands/worktree";
 
 // 用真 git：临时仓库 + 真 worktree，覆盖 merged-clean / merged-dirty / unmerged 三态。
 // 不 mock git——命令的价值就在于对真 porcelain 输出的解析与真 cherry/status 判定。
@@ -119,6 +125,21 @@ describe("classifyWorktrees", () => {
 });
 
 describe("git runner safety", () => {
+  test("uses taskkill semantics for the full process tree on Windows", () => {
+    const treePids: number[] = [];
+    const childSignals: Array<NodeJS.Signals | number | undefined> = [];
+    const result = terminateGitProcessTree(
+      { pid: 42, kill: (signal) => childSignals.push(signal) },
+      "win32",
+      process.kill,
+      (pid) => treePids.push(pid),
+    );
+
+    expect(result).toBe("tree");
+    expect(treePids).toEqual([42]);
+    expect(childSignals).toEqual([]);
+  });
+
   test("disables interactive prompts and kills a hung git command on timeout", async () => {
     const bin = join(root, "bin");
     git(root, "init", "--quiet", bin);


### PR DESCRIPTION
## 变更

跟进已合并的 #456，补齐评审中仍有效的安全边界：

- Git 子进程禁用交互凭据提示，并用 30 秒超时杀整个进程组，避免 git/ssh helper 永久挂起
- 当前 worktree 的 `rev-parse` 失败时直接中止，不能静默绕过“绝不删自己”保护
- 只允许 AgentParty worktree 路径/分支模式进入清理，其余标记 `unrelated` 并跳过
- 文本输出统一清洗路径、分支与 Git stderr 的终端控制字符
- preserve/remove 任一步失败返回非零，不再让自动化误判为成功
- 收紧 status 失败与 unmerged 报告断言，并补真实 CLI 路由覆盖

## 验证

- `bun test test/worktree.test.ts test/cli.test.ts`：33 pass
- `bunx tsc --noEmit`
- `git diff --check`
- 四组变异验证均按预期红灯：移除 current 保护、移除 unrelated 跳过、忽略超时参数、吞掉 preserve 失败退出码

Closes #455


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 工作树增加“unrelated”状态；`party worktree prune/list` 会自动跳过不匹配项，并同步帮助与跳过日志说明。
* **问题修复**
  * 收紧 `party worktree prune` 的超时与中止语义：默认 30s，超时返回 124；SIGINT/SIGTERM 返回 130/143；增强终端输出清洗与 dry-run 计划格式对齐。
  * 统一 Git 子命令的非交互执行策略；破坏性步骤任一步失败即停止并返回对应退出码。
* **测试**
  * 补强 Windows 进程树终止回退、交互/凭据相关环境禁用、SIGINT 中止行为，以及保留/删除与 push 失败的安全路径断言。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->