### PR TITLE
fix(web): 允许鼠标进入在线成员浮层

### DIFF
--- a/web/src/components/PresenceBar.test.ts
+++ b/web/src/components/PresenceBar.test.ts
@@ -383,6 +383,36 @@ describe("presence group popover overflow (#357)", () => {
 
     expect(nodesWithClass(r, "presence-popover-more")[0]?.children.join("")).toBe("+1 · 展开参与者");
   });
+
+  test("mouse can cross the trigger gap into the popover without closing it (#457)", async () => {
+    const r = renderPresenceRoster(3);
+    const group = nodesWithClass(r, "presence-group")[0];
+    await act(async () => {
+      group?.props.onMouseEnter({
+        currentTarget: { getBoundingClientRect: () => ({ left: 10, right: 310, top: 10, bottom: 44, width: 300, height: 34 }) },
+      });
+    });
+    const popover = nodesWithClass(r, "presence-popover")[0];
+    expect(popover).toBeDefined();
+
+    await act(async () => {
+      group?.props.onMouseLeave();
+      popover?.props.onMouseEnter();
+      await new Promise((resolve) => setTimeout(resolve, 200));
+    });
+    expect(nodesWithClass(r, "presence-popover")).toHaveLength(1);
+
+    await act(async () => {
+      nodesWithClass(r, "presence-popover")[0]?.props.onMouseLeave();
+      await new Promise((resolve) => setTimeout(resolve, 200));
+    });
+    expect(nodesWithClass(r, "presence-popover")).toHaveLength(0);
+  });
+
+  test("popover accepts pointer events so its enter handler can keep it open (#457)", async () => {
+    const css = await Bun.file(new URL("../styles/app.css", import.meta.url)).text();
+    expect(css).toMatch(/\.presence-popover\s*\{[^}]*pointer-events:\s*auto;/s);
+  });
 });
 
 function renderWith(entry: PresenceEntry, extra: Record<string, unknown>): ReactTestRenderer {

--- a/web/src/components/PresenceBar.tsx
+++ b/web/src/components/PresenceBar.tsx
@@ -364,7 +364,14 @@ export function PresenceBar({
     }, 160);
   }
 
-  useEffect(() => () => cancelPopoverClose(), []);
+  useEffect(
+    () => () => {
+      if (popoverCloseTimer.current === null) return;
+      clearTimeout(popoverCloseTimer.current);
+      popoverCloseTimer.current = null;
+    },
+    [],
+  );
   function toggleExpanded() {
     setHoveredGroup(null); // 折叠会把 chip 移出 DOM，先关掉可能悬着的 popover
     setExpandedGroupKey(null);

--- a/web/src/components/PresenceBar.tsx
+++ b/web/src/components/PresenceBar.tsx
@@ -1,7 +1,7 @@
 // 顶部 presence 条：每参与者一个手绘胶囊（名字 + 蜡笔状态点 + note + 相对时间），
 // 右端挂连接状态。"对方卡在哪"一眼可见（spec §9 第 3 块）。
 import { evaluateHostLease, wakeableState, type ChannelRoleAssignment, type PresenceEntry, type PresenceState, type Sender } from "@agentparty/shared";
-import { useEffect, useState, type CSSProperties } from "react";
+import { useEffect, useRef, useState, type CSSProperties } from "react";
 import { agentHue } from "../lib/agentColor";
 import { fmtRel } from "../lib/time";
 import type { SocketStatus } from "../lib/ws";
@@ -346,6 +346,25 @@ export function PresenceBar({
   });
   const [hoveredGroup, setHoveredGroup] = useState<{ key: string; left: number; top: number; width: number } | null>(null);
   const [expandedGroupKey, setExpandedGroupKey] = useState<string | null>(null);
+  const popoverCloseTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  function cancelPopoverClose() {
+    if (popoverCloseTimer.current === null) return;
+    clearTimeout(popoverCloseTimer.current);
+    popoverCloseTimer.current = null;
+  }
+
+  function schedulePopoverClose() {
+    cancelPopoverClose();
+    // #457：chip 与 fixed popover 之间有 8px 间隙。立即关闭会让鼠标永远跨不过去；
+    // 留一个短 grace period，进入 popover 后取消，既可操作又不会把浮层粘在页面上。
+    popoverCloseTimer.current = setTimeout(() => {
+      popoverCloseTimer.current = null;
+      setHoveredGroup(null);
+    }, 160);
+  }
+
+  useEffect(() => () => cancelPopoverClose(), []);
   function toggleExpanded() {
     setHoveredGroup(null); // 折叠会把 chip 移出 DOM，先关掉可能悬着的 popover
     setExpandedGroupKey(null);
@@ -365,6 +384,7 @@ export function PresenceBar({
     !expanded || hoveredGroup === null ? null : sortedGroups.find((group) => group.key === hoveredGroup.key) ?? null;
 
   function showGroupPopover(group: PresenceGroup, rect: DOMRect) {
+    cancelPopoverClose();
     const margin = 10;
     const width = Math.min(520, window.innerWidth - margin * 2);
     const left = Math.min(Math.max(margin, rect.left), Math.max(margin, window.innerWidth - width - margin));
@@ -592,7 +612,7 @@ export function PresenceBar({
           if (!full) showGroupPopover(group, e.currentTarget.getBoundingClientRect());
         }}
         onMouseLeave={() => {
-          if (!full) setHoveredGroup(null);
+          if (!full) schedulePopoverClose();
         }}
         onFocus={(e) => {
           if (!full) showGroupPopover(group, e.currentTarget.getBoundingClientRect());
@@ -734,6 +754,8 @@ export function PresenceBar({
         <div
           className="presence-popover"
           role="tooltip"
+          onMouseEnter={cancelPopoverClose}
+          onMouseLeave={schedulePopoverClose}
           style={{
             left: hoveredGroup.left,
             top: hoveredGroup.top,

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -1406,7 +1406,7 @@
 .presence-popover {
   position: fixed;
   z-index: 70;
-  pointer-events: none;
+  pointer-events: auto;
   max-height: min(70vh, 520px);
   overflow: hidden;
   display: flex;


### PR DESCRIPTION
## 变更

- presence 分组触发区离开时不再立即卸载浮层，增加 160ms 跨越间隙的 grace period
- 鼠标进入浮层会取消关闭计时，离开浮层后再关闭
- 将浮层从 `pointer-events: none` 改为可接收鼠标事件
- 组件卸载时清理计时器

## 验证

- PresenceBar 测试：29 pass
- Web TypeScript 检查通过
- Vite 生产构建通过
- 变异验证：移除浮层 `onMouseEnter` 时跨越测试红；恢复 `pointer-events:none` 时 CSS 契约测试红

Closes #457


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复鼠标从在线状态分组移动到详情浮层时浮层意外关闭或闪烁的问题。
  * 优化浮层悬停与离开行为：在触发器与浮层之间跨越时保持显示，离开后按延迟规则正常关闭。
  * 浮层现在可接收鼠标与触控交互（不再作为不可交互层）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->