### PR TITLE
fix(cli): 防止监听器交接静默丢失唤醒

### DIFF
--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -56,9 +56,12 @@ class FrameQueue {
   // prepend 而不是 push：它们的 seq 早于当前缓冲区，必须先还旧账再处理新帧。
   prepend(frames: ServerFrame[]): void {
     if (this.done || frames.length === 0) return;
-    this.items.unshift(...frames);
+    // 禁止 unshift(...frames)：参数展开到数万帧会触发 Maximum call stack size exceeded。
+    this.items = frames.concat(this.items);
   }
 }
+
+export const DEFAULT_MAX_UNACKED_FRAMES = 4096;
 
 const RETRYABLE_NETWORK_CODES = new Set([
   "EAI_AGAIN",
@@ -105,6 +108,8 @@ export interface ConnectOptions {
   backoffBaseMs?: number;
   backoffMaxMs?: number;
   pingIntervalMs?: number;
+  /** 未确认消息缓存上限；超限时 fail-fast 且不推进 cursor，交给 supervisor 重启后安全补拉。 */
+  maxUnackedFrames?: number;
   /**
    * 连接健康探针（issue #254）：WS 生命周期转场通知，供上层（serve）落本地 health.json。
    * "open" = 握手成功（socket 已连上，尚未必然收到 welcome）；"reconnecting" = 断线后进入退避等待；
@@ -170,6 +175,7 @@ export function connect(
   const base = opts.backoffBaseMs ?? 1000;
   const max = opts.backoffMaxMs ?? 30_000;
   const pingEvery = opts.pingIntervalMs ?? 25_000;
+  const maxUnackedFrames = Math.max(1, Math.floor(opts.maxUnackedFrames ?? DEFAULT_MAX_UNACKED_FRAMES));
   const httpBase = server.replace(/\/+$/, "");
   const wsUrl = httpBase.replace(/^http/, "ws") + `/api/channels/${encodeURIComponent(slug)}/ws`;
 
@@ -324,6 +330,17 @@ export function connect(
             deliveredRevisions.set(frame.seq, fp);
           } else {
             if (frame.seq <= cursor || delivered.has(frame.seq)) continue;
+            if (unacked.size >= maxUnackedFrames) {
+              const error = new Error(
+                `unacked replay buffer exceeded ${maxUnackedFrames} frames; terminating without advancing cursor`,
+              );
+              closed = true;
+              stopPing();
+              opts.onStatus?.("closed", { error: error.message });
+              queue.fail(error);
+              sock.close(1011, "unacked replay buffer exceeded");
+              return;
+            }
             delivered.add(frame.seq);
             unacked.set(frame.seq, frame);
           }

--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -56,8 +56,15 @@ class FrameQueue {
   // prepend 而不是 push：它们的 seq 早于当前缓冲区，必须先还旧账再处理新帧。
   prepend(frames: ServerFrame[]): boolean {
     if (this.done || frames.length === 0) return false;
+    let index = 0;
+    while (index < frames.length) {
+      const waiter = this.waiters.shift();
+      if (!waiter) break;
+      waiter.resolve({ value: frames[index]!, done: false });
+      index += 1;
+    }
     // 禁止 unshift(...frames)：参数展开到数万帧会触发 Maximum call stack size exceeded。
-    this.items = frames.concat(this.items);
+    if (index < frames.length) this.items = frames.slice(index).concat(this.items);
     return true;
   }
 }
@@ -176,7 +183,10 @@ export function connect(
   const base = opts.backoffBaseMs ?? 1000;
   const max = opts.backoffMaxMs ?? 30_000;
   const pingEvery = opts.pingIntervalMs ?? 25_000;
-  const maxUnackedFrames = Math.max(1, Math.floor(opts.maxUnackedFrames ?? DEFAULT_MAX_UNACKED_FRAMES));
+  const requestedMaxUnackedFrames = opts.maxUnackedFrames ?? DEFAULT_MAX_UNACKED_FRAMES;
+  const maxUnackedFrames = Number.isFinite(requestedMaxUnackedFrames)
+    ? Math.max(1, Math.floor(requestedMaxUnackedFrames))
+    : DEFAULT_MAX_UNACKED_FRAMES;
   const httpBase = server.replace(/\/+$/, "");
   const wsUrl = httpBase.replace(/^http/, "ws") + `/api/channels/${encodeURIComponent(slug)}/ws`;
 

--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -51,6 +51,13 @@ class FrameQueue {
   snapshot(): ServerFrame[] {
     return [...this.items];
   }
+
+  // 租约 standby 已经取走、但没有 ack 的帧需要在接管时重新排到队首。
+  // prepend 而不是 push：它们的 seq 早于当前缓冲区，必须先还旧账再处理新帧。
+  prepend(frames: ServerFrame[]): void {
+    if (this.done || frames.length === 0) return;
+    this.items.unshift(...frames);
+  }
 }
 
 const RETRYABLE_NETWORK_CODES = new Set([
@@ -115,6 +122,11 @@ export interface Connection {
   close(): void;
   /** 已缓冲、尚未消费的帧快照（#103）：估算 serve 排队深度用。 */
   pendingFrames(): ServerFrame[];
+  /**
+   * 把已经交给消费方、但尚未 ack 的普通消息重新排到队首。
+   * serve standby 在租约接管时用它重放未送达 wake；返回实际重排数量。
+   */
+  replayUnacked(): number;
   readonly cursor: number;
   readonly revCursor: number;
 }
@@ -173,6 +185,8 @@ export function connect(
   };
   // 已入队未 ack 的 seq，broadcast 与 hello 补拉重叠时去重
   const delivered = new Set<number>();
+  // 非修订消息的原始帧保留到 ack；serve standby 接管租约时可把已消费但未确认的帧重新排队。
+  const unacked = new Map<number, ServerFrame>();
   // 已递过的修订快照 seq → 指纹：跨重连去重（服务端每次 hello 都重放全部历史修订）
   const deliveredRevisions = new Map<number, string>();
   let closed = false;
@@ -187,7 +201,10 @@ export function connect(
       opts.onCursor?.(cursor);
     }
     for (const s of delivered) {
-      if (s <= cursor) delivered.delete(s);
+      if (s <= cursor) {
+        delivered.delete(s);
+        unacked.delete(s);
+      }
     }
   };
 
@@ -308,6 +325,7 @@ export function connect(
           } else {
             if (frame.seq <= cursor || delivered.has(frame.seq)) continue;
             delivered.add(frame.seq);
+            unacked.set(frame.seq, frame);
           }
         }
         // 自回声：sent 立即推进游标，自己的消息不会被当成新消息
@@ -383,6 +401,20 @@ export function connect(
     },
     pendingFrames() {
       return queue.snapshot();
+    },
+    replayUnacked() {
+      const pendingSeqs = new Set(
+        queue
+          .snapshot()
+          .filter((frame): frame is Extract<ServerFrame, { type: "msg" | "status" }> => frame.type === "msg" || frame.type === "status")
+          .map((frame) => frame.seq),
+      );
+      const frames = [...unacked.entries()]
+        .filter(([seq]) => seq > cursor && !pendingSeqs.has(seq))
+        .sort(([a], [b]) => a - b)
+        .map(([, frame]) => frame);
+      queue.prepend(frames);
+      return frames.length;
     },
     get cursor() {
       return cursor;

--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -186,7 +186,7 @@ export function connect(
   // 已入队未 ack 的 seq，broadcast 与 hello 补拉重叠时去重
   const delivered = new Set<number>();
   // 非修订消息的原始帧保留到 ack；serve standby 接管租约时可把已消费但未确认的帧重新排队。
-  const unacked = new Map<number, ServerFrame>();
+  const unacked = new Map<number, Extract<ServerFrame, { type: "msg" | "status" }>>();
   // 已递过的修订快照 seq → 指纹：跨重连去重（服务端每次 hello 都重放全部历史修订）
   const deliveredRevisions = new Map<number, string>();
   let closed = false;

--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -54,10 +54,11 @@ class FrameQueue {
 
   // 租约 standby 已经取走、但没有 ack 的帧需要在接管时重新排到队首。
   // prepend 而不是 push：它们的 seq 早于当前缓冲区，必须先还旧账再处理新帧。
-  prepend(frames: ServerFrame[]): void {
-    if (this.done || frames.length === 0) return;
+  prepend(frames: ServerFrame[]): boolean {
+    if (this.done || frames.length === 0) return false;
     // 禁止 unshift(...frames)：参数展开到数万帧会触发 Maximum call stack size exceeded。
     this.items = frames.concat(this.items);
+    return true;
   }
 }
 
@@ -430,8 +431,7 @@ export function connect(
         .filter(([seq]) => seq > cursor && !pendingSeqs.has(seq))
         .sort(([a], [b]) => a - b)
         .map(([, frame]) => frame);
-      queue.prepend(frames);
-      return frames.length;
+      return queue.prepend(frames) ? frames.length : 0;
     },
     get cursor() {
       return cursor;

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -1806,6 +1806,8 @@ export async function runServe(o: ServeOptions): Promise<number> {
         deferredLeaseSeq = Math.min(deferredLeaseSeq ?? frame.seq, frame.seq);
         out(`▷ standby（未持有 serve 租约），保留未确认 wake seq=${frame.seq}，接管后重放: ${formatMsg(frame)}`);
       }
+      // deferredLeaseSeq 只会在 !hasLease 时设置，held=true 分支会先清空再 replay；因此持租处理
+      // 与 standby 冻结区互斥。不要在这里额外跳过，否则一旦状态漂移反而会把欠账永久冻住。
       const qualifies = wouldWake && !selfPaused && hasLease;
       if (qualifies) {
         out(`▶ ${formatMsg(frame)}`);

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -16,12 +16,12 @@ import {
   writeFileSync,
 } from "node:fs";
 import { homedir, tmpdir } from "node:os";
-import { basename, dirname, isAbsolute, join } from "node:path";
+import { basename, isAbsolute, join } from "node:path";
 import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
 import { readAccount } from "../account";
 import { connect } from "../client";
-import { readConfig, clearStuck, loadCursor, loadRevCursor, loadStuck, resolveChannel, saveCursor, saveRevCursor, saveStuck, statePath, type StuckWake } from "../config";
-import { acquireInstanceLock } from "../instance-lock";
+import { readConfig, clearStuck, loadCursor, loadRevCursor, loadStuck, resolveChannel, saveCursor, saveRevCursor, saveStuck, type StuckWake } from "../config";
+import { acquireInstanceLock, defaultInstanceLockDir, instanceLockTarget } from "../instance-lock";
 import { formatMsg } from "../format";
 import { clearHealthCache, writeHealthCache } from "../health-cache";
 import { ensureFreshAccess, resolveAuthDetailed, type ResolvedAuthDetailed } from "../oidc-cli";
@@ -66,7 +66,7 @@ export const EXIT_WAKE_UNANNOUNCED = 1;
 /** 连续放弃熔断：supervisor 已经无法履行唤醒职责，停止排空后续 @。 */
 export const EXIT_WAKE_ABANDON_CIRCUIT = 11;
 
-/** 已有 serve 挂在同一 (channel, workspace) 上：拒绝启动，避免重复执行（#99）。 */
+/** 已有 serve 挂在同一 (server identity, channel, machine) 上：拒绝启动，避免重复执行（#99/#465）。 */
 export const EXIT_ALREADY_SERVING = 10;
 
 /** 传给 builtin runner 的提示：只给路径，不给正文（#120）。 */
@@ -435,7 +435,7 @@ export interface ServeOptions {
   // 但「积压」与「欠账」是两回事（#198）：跳过的只能是**已离线堆积、从未送达**的历史；
   // 送达失败被钉住的 stuck 无论多旧都必须重放，否则 #118 救下的那条 @ 会被这里吃掉。
   skipBacklog?: boolean;
-  /** 单实例锁目录（#99）。默认与 workspace state 同放；测试注入。 */
+  /** 单实例锁目录（#99/#465）。默认全机共享、再按 server/token 身份隔离；测试注入。 */
   lockDir?: string;
   /** 关掉单实例保护（逃生舱）。 */
   allowMultiple?: boolean;
@@ -1582,26 +1582,31 @@ export async function runServe(o: ServeOptions): Promise<number> {
       writeHealthCache({ channel: o.channel, ws_connected: false, reconnecting: false, connected_since: null, last_error: detail?.error ?? null });
     }
   };
-  const conn = connect(o.server, o.token, o.channel, o.since, {
-    onCursor: o.onCursor,
-    sinceRev: o.sinceRev,
-    onRevCursor: o.onRevCursor,
-    onStatus: onWsStatus,
-  });
-
   const skipBacklog = o.skipBacklog !== false; // 默认跳过离线积压（#193）
   // 抢锁在连 WS 之前：第二个 serve 连接都不该建，否则它已经在消费 @、已经在跑 runner 了（#99）。
   // 这把锁只挡同机；跨机器重复执行需要服务端租约（do.ts 广播发给同名所有连接）。
-  const lockDir = o.lockDir ?? dirname(statePath());
-  const lock = o.allowMultiple === true ? null : acquireInstanceLock("serve", o.channel, lockDir);
+  const lockDir = o.lockDir ?? defaultInstanceLockDir();
+  const lockTarget = o.lockDir === undefined ? instanceLockTarget(o.server, o.token, o.channel) : o.channel;
+  const lock = o.allowMultiple === true ? null : acquireInstanceLock("serve", lockTarget, lockDir);
   if (lock && !lock.ok) {
     out(
       `serve: 已有 serve 挂在 #${o.channel} 上（pid ${lock.heldByPid}）。` +
         ` 再挂一个会让同一条 @ 触发两次完整 runner——双份回帖，git push 类副作用执行两遍。` +
         ` 要么等它退出，要么 kill ${lock.heldByPid}；确实想并存请加 --allow-multiple。`,
     );
-    conn.close();
     return EXIT_ALREADY_SERVING;
+  }
+  let conn: ReturnType<typeof connect>;
+  try {
+    conn = connect(o.server, o.token, o.channel, o.since, {
+      onCursor: o.onCursor,
+      sinceRev: o.sinceRev,
+      onRevCursor: o.onRevCursor,
+      onStatus: onWsStatus,
+    });
+  } catch (error) {
+    lock?.release?.();
+    throw error;
   }
   // 挂载之初就落一份 health 基线：即便还没收到第一帧，watchdog 也能看到「这个 pid 认领了这个频道」，
   // 而不是文件缺失时无法区分「serve 没起来」和「serve 起来了但还没写过健康数据」。
@@ -1631,9 +1636,12 @@ export async function runServe(o: ServeOptions): Promise<number> {
   // 同名 serve 跨机租约（#99）：同机单实例锁（上文）只挡本机；跨机器两台 serve 各连一条 WS，服务端广播
   // 把每条 @ 发给同名所有连接 → 两台都跑完整 runner。修复：挂上后向服务端 claim 租约，只有持租的那台跑
   // runner。hasLease 默认 true（老服务端不认租约、从不下发 serve_lease → 保持旧行为不回归）；收到
-  // held=false 转 standby（被 @ 也不跑，消息仍进历史、游标照推进），held=true（持租/顶替）恢复响应。
+  // held=false 转 standby（不跑 runner，且保留未确认 wake），held=true（持租/顶替）恢复并重放。
   let hasLease = true;
   let leaseKnown = false; // 是否至少收到过一次 serve_lease（用于只在真 standby 时打印提示）
+  // standby 收到的最早可唤醒消息。它以及后续帧都不推进 cursor；接管租约时由 Connection
+  // 把已消费但未 ack 的帧按 seq 重排到队首，避免持租者中途退出时静默吞掉在飞 wake（#465）。
+  let deferredLeaseSeq: number | null = null;
   let charter: ChannelCharter | null = o.charter ?? null;
   const refreshCharter = async (reason: string, expectedRev?: number) => {
     if (!o.fetchCharter) return;
@@ -1750,14 +1758,17 @@ export async function runServe(o: ServeOptions): Promise<number> {
       // 补发 held=true 让 standby 顶上。跨进程互斥点在服务端——本地只是遵从它的裁决。
       if (frame.type === "serve_lease" && frame.name === self) {
         const next = frame.held === true;
+        const takingOver = leaseKnown && !hasLease && next;
         if (!leaseKnown || next !== hasLease) {
           hasLease = next;
+          const replayed = takingOver ? conn.replayUnacked() : 0;
+          if (takingOver) deferredLeaseSeq = null;
           out(
             hasLease
               ? leaseKnown
-                ? "serve: 取得 serve 租约——本台顶替，开始响应 @（同名另一台已让出/掉线）。"
+                ? `serve: 取得 serve 租约——本台顶替，开始响应 @；重放 ${replayed} 条未确认帧（同名另一台已让出/掉线）。`
                 : "serve: 持有 serve 租约——本台负责跑 runner。"
-              : "serve: 未持有 serve 租约（同名另一台 serve 在跑）——本台转 standby：被 @ 也不跑 runner，消息仍进历史；持租者掉线后自动顶替。",
+              : "serve: 未持有 serve 租约（同名另一台 serve 在跑）——本台转 standby：@ 会保留为未确认欠账；持租者掉线后自动顶替并重放。",
           );
         }
         leaseKnown = true;
@@ -1787,10 +1798,13 @@ export async function runServe(o: ServeOptions): Promise<number> {
       if (wouldWake && selfPaused) {
         out(`⏸ 暂停中，跳过唤醒（消息仍在历史）: ${formatMsg(frame)}`);
       }
-      // 未持租（#99）：同名另一台 serve 在跑，本台是 standby——被 @ 也不跑 runner，但消息照进 recent/历史、
-      // 游标照推进（下方 ack），与暂停接待同路径。持租者掉线后收到 held=true 再从新消息开始响应。
-      if (wouldWake && !selfPaused && !hasLease) {
-        out(`▷ standby（未持有 serve 租约），跳过唤醒（消息仍在历史）: ${formatMsg(frame)}`);
+      // 未持租（#465）：standby 不跑 runner，也绝不能 ack 越过这条 @。记住最早 seq，并冻结后续
+      // cursor；租约顶替时 replayUnacked() 把这些帧按序放回队首。这样持租者被 kill 时至少重投，
+      // 不再出现 runner started 之后无人回复、standby 却已把同一条消息消费掉的静默丢失。
+      const deferredForLease = wouldWake && !selfPaused && !hasLease;
+      if (deferredForLease) {
+        deferredLeaseSeq = Math.min(deferredLeaseSeq ?? frame.seq, frame.seq);
+        out(`▷ standby（未持有 serve 租约），保留未确认 wake seq=${frame.seq}，接管后重放: ${formatMsg(frame)}`);
       }
       const qualifies = wouldWake && !selfPaused && hasLease;
       if (qualifies) {
@@ -1982,16 +1996,19 @@ export async function runServe(o: ServeOptions): Promise<number> {
           }
         }
       }
-      // 触发消息本身不进 recent（它就是 context 主体）；自己的/未 @ 的都算上下文
-      recent.push(frame);
-      if (recent.length > RECENT_MAX) recent.shift();
+      const heldForLease = deferredLeaseSeq !== null && frame.seq >= deferredLeaseSeq;
+      // standby 冻结区会在接管时完整重放；首次经过时不提前塞进 recent，避免重放后上下文重复。
+      if (!heldForLease) {
+        recent.push(frame);
+        if (recent.length > RECENT_MAX) recent.shift();
+      }
       // 游标只表达「已了结」（#198）：送达成功，或有界重试耗尽后**宣告过**的放弃。
       // 欠账未了结时游标绝不越过它——否则那条 @ 永远不会再被重放。
       //
       // 我曾断言这个守卫是死代码（有界重试后 stuck 恒为 null），并请门禁证伪。
       // 190-codex-dev 找到了反例：欠账那一帧若被 mentionsOnly / fromSelf 过滤掉，
       // stuck 就活着走到这里。守卫不是死的——是我的推理漏了过滤路径。
-      if (stuck === null || frame.seq < stuck.seq) conn.ack(frame.seq);
+      if ((stuck === null || frame.seq < stuck.seq) && !heldForLease) conn.ack(frame.seq);
       if (o.statusline === true) {
         writeStatuslineCache({
           ...localStatuslineBase(o.channel),
@@ -2021,6 +2038,7 @@ export async function runServe(o: ServeOptions): Promise<number> {
     // 私有目录里躺着 charter / recent 正文。失败的唤醒把它留到本次排查结束，
     // 但绝不在进程退出后继续留在共享 tmpdir 里（#208 门禁 P2）。
     rmSync(contextDir, { recursive: true, force: true });
+    lock?.release?.();
     if (heartbeat) clearInterval(heartbeat);
     conn.close();
     if (o.statusline === true) clearStatuslineListener();

--- a/cli/src/commands/watch.ts
+++ b/cli/src/commands/watch.ts
@@ -1,10 +1,9 @@
 // party watch — 补拉错过消息，阻塞等新消息
 import { EXIT_ARCHIVED, EXIT_AUTH, EXIT_LOOP_GUARD, EXIT_STREAM_ENDED, EXIT_TIMEOUT, type MsgFrame } from "@agentparty/shared";
-import { dirname } from "node:path";
-import { acquireInstanceLock } from "../instance-lock";
+import { acquireInstanceLock, defaultInstanceLockDir, instanceLockTarget } from "../instance-lock";
 import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
 import { connect } from "../client";
-import { loadCursor, loadRevCursor, resolveChannel, saveCursor, saveRevCursor, statePath } from "../config";
+import { loadCursor, loadRevCursor, resolveChannel, saveCursor, saveRevCursor } from "../config";
 import { resolveAuthDetailed, type ResolvedAuthDetailed } from "../oidc-cli";
 import { formatMsg } from "../format";
 import { fetchMe, fetchMessages, fetchRecentMessages, handleRestError, postMessage } from "../rest";
@@ -108,7 +107,7 @@ export interface WatchOptions {
   out?: (line: string) => void;
   backoffBaseMs?: number;
   statusline?: boolean;
-  /** 单实例锁目录（#195）。默认与 workspace state 同放；测试注入。 */
+  /** 单实例锁目录（#195/#465）。默认全机共享、再按 server/token 身份隔离；测试注入。 */
   lockDir?: string;
   /** 关掉单实例保护（逃生舱）。 */
   allowMultiple?: boolean;
@@ -200,8 +199,9 @@ async function resolveExplicitWatchCursor(
 export async function runWatch(o: WatchOptions): Promise<number> {
   const out = o.out ?? ((line: string) => console.log(line));
   // 先抢锁，再连服务端：第二个 watcher 连 WS 都不该建，否则它已经开始消费 @ 了（#195）
-  const lockDir = o.lockDir ?? dirname(statePath());
-  const lock = o.allowMultiple === true ? null : acquireInstanceLock("watch", o.channel, lockDir);
+  const lockDir = o.lockDir ?? defaultInstanceLockDir();
+  const lockTarget = o.lockDir === undefined ? instanceLockTarget(o.server, o.token, o.channel) : o.channel;
+  const lock = o.allowMultiple === true ? null : acquireInstanceLock("watch", lockTarget, lockDir);
   if (lock && !lock.ok) {
     out(
       `watch: 已有 watcher 挂在 #${o.channel} 上（pid ${lock.heldByPid}）。` +
@@ -210,12 +210,18 @@ export async function runWatch(o: WatchOptions): Promise<number> {
     );
     return EXIT_ALREADY_WATCHING;
   }
-  const conn = connect(o.server, o.token, o.channel, o.since, {
-    onCursor: o.onCursor,
-    sinceRev: o.sinceRev,
-    onRevCursor: o.onRevCursor,
-    backoffBaseMs: o.backoffBaseMs,
-  });
+  let conn: ReturnType<typeof connect>;
+  try {
+    conn = connect(o.server, o.token, o.channel, o.since, {
+      onCursor: o.onCursor,
+      sinceRev: o.sinceRev,
+      onRevCursor: o.onRevCursor,
+      backoffBaseMs: o.backoffBaseMs,
+    });
+  } catch (error) {
+    lock?.release?.();
+    throw error;
+  }
 
   let self = "";
   let lastSeq = 0;

--- a/cli/src/instance-lock.ts
+++ b/cli/src/instance-lock.ts
@@ -58,6 +58,7 @@ function inspectProcess(pid: number): ProcessIdentity {
   const probe = spawnSync("ps", ["-o", "lstart=", "-o", "stat=", "-p", String(pid)], {
     encoding: "utf8",
     timeout: 1000,
+    env: { ...process.env, LC_ALL: "C", LC_TIME: "C" },
   });
   if (probe.error || probe.status !== 0) return { alive: true };
   const line = probe.stdout.trim();

--- a/cli/src/instance-lock.ts
+++ b/cli/src/instance-lock.ts
@@ -11,8 +11,10 @@
 // ⚠️ 这把锁只挡**同一台机器**。跨机器的重复执行（工位机 + 家里机各跑一个 serve）
 // 需要服务端租约（#99 的另一半,`do.ts` 广播发给同名所有连接）。
 import { mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
+import { spawnSync } from "node:child_process";
 import { join } from "node:path";
+import { agentpartyHome } from "./config";
 
 export type InstanceKind = "watch" | "serve";
 
@@ -27,18 +29,64 @@ function lockPath(kind: InstanceKind, channel: string, dir: string): string {
   return join(dir, `${kind}-${channel.replace(/[^a-zA-Z0-9._-]/g, "_")}.lock`);
 }
 
-function pidAlive(pid: number): boolean {
+/** 默认锁目录不再跟 cwd/workspace 走：同一身份从另一个 repo 启动也必须互斥。 */
+export function defaultInstanceLockDir(): string {
+  return join(agentpartyHome(), "instances");
+}
+
+/** token 只参与不可逆摘要，不落盘；不同 server/身份在同一频道互不阻塞。 */
+export function instanceLockTarget(server: string, token: string, channel: string): string {
+  const identity = createHash("sha256").update(server).update("\0").update(token).digest("hex").slice(0, 24);
+  return `${identity}-${channel}`;
+}
+
+interface ProcessIdentity {
+  alive: boolean;
+  startedAt?: number;
+}
+
+function inspectProcess(pid: number): ProcessIdentity {
   try {
     process.kill(pid, 0); // 信号 0：只探测存活,不真的发信号
-    return true;
   } catch {
-    return false;
+    return { alive: false };
   }
+  if (process.platform === "win32") return { alive: true };
+
+  // kill(pid, 0) 对 zombie 仍返回成功，而且 PID 可能已被系统复用。用 ps 同时核验状态与出生时间；
+  // ps 不可用时保守回落到 kill(0)，绝不误杀一个无法确认的活进程。
+  const probe = spawnSync("ps", ["-o", "lstart=", "-o", "stat=", "-p", String(pid)], {
+    encoding: "utf8",
+    timeout: 1000,
+  });
+  if (probe.error || probe.status !== 0) return { alive: true };
+  const line = probe.stdout.trim();
+  const match = line.match(/^(\S+\s+\S+\s+\d+\s+\d{2}:\d{2}:\d{2}\s+\d{4})\s+(\S+)/);
+  if (!match) return line === "" ? { alive: false } : { alive: true };
+  if (match[2]!.startsWith("Z")) return { alive: false };
+  const startedAt = Date.parse(match[1]!);
+  return Number.isFinite(startedAt) ? { alive: true, startedAt } : { alive: true };
+}
+
+const PROCESS_STARTED_AT =
+  inspectProcess(process.pid).startedAt ?? Math.floor((Date.now() - process.uptime() * 1000) / 1000) * 1000;
+
+function holderAlive(holder: LockHolder | null): holder is LockHolder & { pid: number } {
+  if (typeof holder?.pid !== "number") return false;
+  const processIdentity = inspectProcess(holder.pid);
+  if (!processIdentity.alive) return false;
+  if (holder.started_at === undefined || processIdentity.startedAt === undefined) return true;
+  return Math.abs(holder.started_at - processIdentity.startedAt) <= 2000;
+}
+
+export function currentProcessStartedAt(): number {
+  return PROCESS_STARTED_AT;
 }
 
 interface LockHolder {
   pid?: number;
   id?: string;
+  started_at?: number;
 }
 
 function readHolder(path: string): LockHolder | null {
@@ -57,7 +105,7 @@ export function acquireInstanceLock(kind: InstanceKind, channel: string, dir: st
   const path = lockPath(kind, channel, dir);
   const reclaimPath = `${path}.reclaim`;
   const lockId = randomUUID();
-  const body = JSON.stringify({ pid: process.pid, id: lockId, kind, channel, ts: Date.now() });
+  const body = JSON.stringify({ pid: process.pid, id: lockId, started_at: PROCESS_STARTED_AT, kind, channel, ts: Date.now() });
   let staleGeneration: string | null = null;
   mkdirSync(dir, { recursive: true });
 
@@ -70,7 +118,7 @@ export function acquireInstanceLock(kind: InstanceKind, channel: string, dir: st
     }
 
     const held = readHolder(path);
-    if (typeof held?.pid === "number" && pidAlive(held.pid)) {
+    if (holderAlive(held)) {
       return { ok: false, heldByPid: held.pid };
     }
     const generation = held?.id ?? `legacy:${held?.pid ?? "invalid"}`;
@@ -89,7 +137,7 @@ export function acquireInstanceLock(kind: InstanceKind, channel: string, dir: st
     } catch (error) {
       if (!isAlreadyExists(error)) throw error;
       const reclaimer = readHolder(reclaimPath);
-      if (typeof reclaimer?.pid === "number" && !pidAlive(reclaimer.pid)) {
+      if (typeof reclaimer?.pid === "number" && !holderAlive(reclaimer)) {
         try {
           unlinkSync(reclaimPath);
         } catch {
@@ -103,7 +151,7 @@ export function acquireInstanceLock(kind: InstanceKind, channel: string, dir: st
 
     try {
       const current = readHolder(path);
-      if (typeof current?.pid === "number" && pidAlive(current.pid)) {
+      if (holderAlive(current)) {
         return { ok: false, heldByPid: current.pid };
       }
       const currentGeneration = current?.id ?? `legacy:${current?.pid ?? "invalid"}`;
@@ -133,8 +181,8 @@ export function acquireInstanceLock(kind: InstanceKind, channel: string, dir: st
     release: () => {
       try {
         // 只删自己的锁：别人接管过就不动它
-        const cur = JSON.parse(readFileSync(path, "utf8")) as { pid?: number };
-        if (cur.pid === process.pid) unlinkSync(path);
+        const cur = JSON.parse(readFileSync(path, "utf8")) as { id?: string };
+        if (cur.id === lockId) unlinkSync(path);
       } catch {
         /* 已经没了 */
       }

--- a/cli/test/client.test.ts
+++ b/cli/test/client.test.ts
@@ -116,6 +116,29 @@ describe("ws client", () => {
     expect(conn.replayUnacked()).toBe(0);
   });
 
+  test("fails safely at the unacked replay cap without advancing the cursor", async () => {
+    server = startMockServer((frame, sock) => {
+      if (frame.type !== "hello") return;
+      sock.send(welcomeFrame(3));
+      sock.send(msgFrame(1, "one"));
+      sock.send(msgFrame(2, "two"));
+      sock.send(msgFrame(3, "overflow"));
+    });
+    conn = connect(server.url, "ap_tok", "dev", 0, { maxUnackedFrames: 2 });
+
+    let failure: unknown;
+    try {
+      for await (const _frame of conn.frames) {
+        // 故意不 ack：模拟 standby 冻结 cursor。
+      }
+    } catch (error) {
+      failure = error;
+    }
+    expect(failure).toBeInstanceOf(Error);
+    expect((failure as Error).message).toContain("terminating without advancing cursor");
+    expect(conn.cursor).toBe(0);
+  });
+
   test("dedups frames delivered by both broadcast and backfill", async () => {
     server = startMockServer((frame, sock) => {
       if (frame.type === "hello") {

--- a/cli/test/client.test.ts
+++ b/cli/test/client.test.ts
@@ -91,6 +91,31 @@ describe("ws client", () => {
     expect(conn.cursor).toBe(1);
   });
 
+  test("replayUnacked puts consumed standby frames back before newer queued frames", async () => {
+    server = startMockServer((frame, sock) => {
+      if (frame.type !== "hello") return;
+      sock.send(welcomeFrame(3));
+      sock.send(msgFrame(1, "standby wake"));
+      sock.send(msgFrame(2, "queued context"));
+      sock.send(msgFrame(3, "queued latest"));
+    });
+    conn = connect(server.url, "ap_tok", "dev", 0);
+    const it = conn.frames[Symbol.asyncIterator]();
+    await it.next(); // welcome
+    const consumed = (await it.next()).value as { type: "msg"; seq: number; body: string };
+    expect(consumed.body).toBe("standby wake");
+
+    // seq=2/3 还在 FrameQueue，只有已取走但未 ack 的 seq=1 应被重排；不得复制仍在队里的帧。
+    expect(conn.replayUnacked()).toBe(1);
+    const replay = (await it.next()).value as { type: "msg"; seq: number; body: string };
+    const second = (await it.next()).value as { type: "msg"; seq: number; body: string };
+    const third = (await it.next()).value as { type: "msg"; seq: number; body: string };
+    expect([replay.body, second.body, third.body]).toEqual(["standby wake", "queued context", "queued latest"]);
+
+    conn.ack(3);
+    expect(conn.replayUnacked()).toBe(0);
+  });
+
   test("dedups frames delivered by both broadcast and backfill", async () => {
     server = startMockServer((frame, sock) => {
       if (frame.type === "hello") {

--- a/cli/test/client.test.ts
+++ b/cli/test/client.test.ts
@@ -155,6 +155,24 @@ describe("ws client", () => {
     expect(conn.replayUnacked()).toBe(0);
   });
 
+  test("replay resolves a consumer already waiting for the next frame", async () => {
+    server = startMockServer((frame, sock) => {
+      if (frame.type !== "hello") return;
+      sock.send(welcomeFrame(1));
+      sock.send(msgFrame(1, "standby wake"));
+    });
+    conn = connect(server.url, "ap_tok", "dev", 0);
+    const it = conn.frames[Symbol.asyncIterator]();
+    await it.next(); // welcome
+    await it.next(); // msg remains unacked
+
+    const pendingNext = it.next();
+    expect(conn.replayUnacked()).toBe(1);
+
+    const replay = (await pendingNext).value as { type: "msg"; body: string };
+    expect(replay.body).toBe("standby wake");
+  });
+
   test("dedups frames delivered by both broadcast and backfill", async () => {
     server = startMockServer((frame, sock) => {
       if (frame.type === "hello") {

--- a/cli/test/client.test.ts
+++ b/cli/test/client.test.ts
@@ -139,6 +139,22 @@ describe("ws client", () => {
     expect(conn.cursor).toBe(0);
   });
 
+  test("reports no replay after the connection queue is closed", async () => {
+    server = startMockServer((frame, sock) => {
+      if (frame.type !== "hello") return;
+      sock.send(welcomeFrame(1));
+      sock.send(msgFrame(1, "standby wake"));
+    });
+    conn = connect(server.url, "ap_tok", "dev", 0);
+    const it = conn.frames[Symbol.asyncIterator]();
+    await it.next(); // welcome
+    await it.next(); // msg remains unacked
+
+    conn.close();
+
+    expect(conn.replayUnacked()).toBe(0);
+  });
+
   test("dedups frames delivered by both broadcast and backfill", async () => {
     server = startMockServer((frame, sock) => {
       if (frame.type === "hello") {

--- a/cli/test/serve-cross-machine-lease.test.ts
+++ b/cli/test/serve-cross-machine-lease.test.ts
@@ -1,6 +1,6 @@
 // issue #99 跨机那半（客户端侧）：serve 挂上后向服务端 claim serve 租约；只有服务端回 held=true 的那台
-// 才跑 runner。收到 held=false（另一台在跑）就转 standby：被 @ 也不触发 runner，消息仍进历史、游标照推进
-// （与 #180 暂停接待同路径）。持租者掉线后服务端补发 held=true，standby 顶上开始跑。老服务端不认租约、
+// 才跑 runner。收到 held=false（另一台在跑）就转 standby：被 @ 不触发 runner，但保留为未确认帧；
+// 持租者掉线后服务端补发 held=true，standby 顶上并按序重放。老服务端不认租约、
 // 从不下发 serve_lease → 客户端默认持租（held 未知即照跑），不回归。
 import { afterEach, describe, expect, test } from "bun:test";
 import type { ClientFrame } from "@agentparty/shared";
@@ -41,7 +41,7 @@ function leaseFrame(held: boolean, name = "me") {
 }
 
 describe("serve 跨机租约客户端互斥（#99）", () => {
-  test("held=false（另一台持租）：@我 不跑 runner，但游标仍推进（standby）", async () => {
+  test("held=false（另一台持租）：@我 不跑 runner，也不推进游标吞掉 wake", async () => {
     let ran = 0;
     const cursors: number[] = [];
     server = startMockServer((frame, sock) => {
@@ -54,7 +54,7 @@ describe("serve 跨机租约客户端互斥（#99）", () => {
     const o = opts({ server: server.url, onCursor: (c) => cursors.push(c), runCommand: async () => { ran++; } });
     await runServe(o);
     expect(ran).toBe(0); // 不持租：runner 一次都没跑
-    expect(cursors).toContain(1); // 消息仍被消费、游标推进（不留欠账）
+    expect(cursors).not.toContain(1); // standby 保留未确认，租约接管后才能重放
     expect(o.lines.some((l) => l.includes("standby") || l.includes("租约"))).toBe(true);
   });
 
@@ -72,8 +72,8 @@ describe("serve 跨机租约客户端互斥（#99）", () => {
     expect(ran).toBe(1);
   });
 
-  test("takeover：先 held=false 跳过，收到 held=true 后的 @ 才跑", async () => {
-    let ran = 0;
+  test("takeover：held=false 期间的 @ 与接管后的 @ 都按序送达", async () => {
+    const ran: number[] = [];
     server = startMockServer((frame, sock) => {
       if (frame.type !== "hello") return;
       sock.send(welcomeFrame(0, "me"));
@@ -83,9 +83,32 @@ describe("serve 跨机租约客户端互斥（#99）", () => {
       setTimeout(() => sock.send(msgFrame(2, "@me after takeover", { mentions: ["me"] })), 60);
       setTimeout(() => sock.send({ type: "error", code: "archived", message: "done" }), 100);
     });
-    const o = opts({ server: server.url, runCommand: async () => { ran++; } });
+    const o = opts({ server: server.url, runCommand: async (frame) => { ran.push(frame.seq); } });
     await runServe(o);
-    expect(ran).toBe(1); // 只跑了 takeover 之后的那条
+    expect(ran).toEqual([1, 2]);
+    expect(o.lines.some((line) => line.includes("重放 1 条未确认帧"))).toBe(true);
+  });
+
+  test("runner 在租约变更到 standby 前已经启动时允许 drain 完成", async () => {
+    const events: string[] = [];
+    server = startMockServer((frame, sock) => {
+      if (frame.type !== "hello") return;
+      sock.send(welcomeFrame(0, "me"));
+      setTimeout(() => sock.send(leaseFrame(true)), 10);
+      setTimeout(() => sock.send(msgFrame(1, "@me long wake", { mentions: ["me"] })), 20);
+      setTimeout(() => sock.send(leaseFrame(false)), 30);
+      setTimeout(() => sock.send({ type: "error", code: "archived", message: "done" }), 100);
+    });
+    const o = opts({
+      server: server.url,
+      runCommand: async () => {
+        events.push("started");
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        events.push("finished");
+      },
+    });
+    await runServe(o);
+    expect(events).toEqual(["started", "finished"]);
   });
 
   test("老服务端从不下发 serve_lease：客户端默认持租，照常唤醒（不回归）", async () => {

--- a/cli/test/serve-lease.test.ts
+++ b/cli/test/serve-lease.test.ts
@@ -11,7 +11,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { acquireInstanceLock } from "../src/instance-lock";
+import { acquireInstanceLock, defaultInstanceLockDir, instanceLockTarget } from "../src/instance-lock";
 import { defaultRunnerWorkdir, EXIT_ALREADY_SERVING, runnerWorkdir, runServe } from "../src/commands/serve";
 import { startMockServer, welcomeFrame } from "./mock-server";
 
@@ -127,6 +127,41 @@ describe("defaultRunnerWorkdir 接线 (#99)", () => {
 });
 
 describe("runServe 接线 (#99)", () => {
+  test("默认锁跨 cwd 使用全局身份作用域，重复 serve 在连 WS 前被拒", async () => {
+    const home = dir();
+    const previousHome = process.env.AGENTPARTY_HOME;
+    process.env.AGENTPARTY_HOME = home;
+    let connections = 0;
+    const server = startMockServer((f, sock) => {
+      if (f.type !== "hello") return;
+      connections++;
+      sock.send(welcomeFrame(0, "me"));
+    });
+    const held = acquireInstanceLock(
+      "serve",
+      instanceLockTarget(server.url, "ap_tok", "dev"),
+      defaultInstanceLockDir(),
+    );
+    try {
+      const code = await runServe({
+        server: server.url,
+        token: "ap_tok",
+        channel: "dev",
+        since: 0,
+        cmd: "true",
+        mentionsOnly: true,
+        out: () => {},
+      });
+      expect(code).toBe(EXIT_ALREADY_SERVING);
+      expect(connections).toBe(0);
+    } finally {
+      held.release?.();
+      server.stop();
+      if (previousHome === undefined) delete process.env.AGENTPARTY_HOME;
+      else process.env.AGENTPARTY_HOME = previousHome;
+    }
+  });
+
   test("第二个 serve 直接被拒，且连 WS 都不建（否则它已经在跑 runner 了）", async () => {
     const d = dir();
     let connections = 0;

--- a/cli/test/watch-single-instance.test.ts
+++ b/cli/test/watch-single-instance.test.ts
@@ -9,7 +9,7 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "nod
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { EXIT_ALREADY_WATCHING, runWatch } from "../src/commands/watch";
-import { acquireInstanceLock } from "../src/instance-lock";
+import { acquireInstanceLock, currentProcessStartedAt, defaultInstanceLockDir, instanceLockTarget } from "../src/instance-lock";
 import { startMockServer, welcomeFrame } from "./mock-server";
 
 const dirs: string[] = [];
@@ -29,7 +29,7 @@ describe("watch 单实例保护 (#195)", () => {
     lock.release?.();
   });
 
-  test("同一 (channel, workspace) 的第二个 watcher 被拒，并告知已有 watcher 的 pid", () => {
+  test("同一锁作用域内的第二个 watcher 被拒，并告知已有 watcher 的 pid", () => {
     const d = dir();
     const first = acquireInstanceLock("watch", "dev", d);
     expect(first.ok).toBe(true);
@@ -81,6 +81,27 @@ describe("watch 单实例保护 (#195)", () => {
     expect(lock.heldByPid).toBe(process.pid);
   });
 
+  test("PID 已复用给另一个出生时间的进程时自动回收陈旧锁", () => {
+    if (process.platform === "win32") return;
+    const d = dir();
+    writeFileSync(
+      join(d, "watch-dev.lock"),
+      JSON.stringify({ pid: process.pid, started_at: currentProcessStartedAt() - 60_000, channel: "dev" }),
+    );
+    const lock = acquireInstanceLock("watch", "dev", d);
+    expect(lock.ok).toBe(true);
+    lock.release?.();
+  });
+
+  test("生产锁目标跨 cwd 稳定，并按 server/token 身份隔离", () => {
+    expect(instanceLockTarget("https://party.test", "tok-a", "dev")).toBe(
+      instanceLockTarget("https://party.test", "tok-a", "dev"),
+    );
+    expect(instanceLockTarget("https://party.test", "tok-a", "dev")).not.toBe(
+      instanceLockTarget("https://party.test", "tok-b", "dev"),
+    );
+  });
+
   test("8 个进程并发接管同一陈旧锁时只有一个成功", async () => {
     const d = dir();
     const start = join(d, "start");
@@ -110,6 +131,43 @@ describe("watch 单实例保护 (#195)", () => {
 // 光有锁函数没接进 runWatch 等于没修。这几条断言观测的是**过程**：
 // 第二个 watcher 有没有真的去连服务端、有没有消费掉那条 @。
 describe("runWatch 接线 (#195)", () => {
+  test("默认锁跨 cwd 使用全局身份作用域，另一工作目录启动也被拒", async () => {
+    const home = dir();
+    const previousHome = process.env.AGENTPARTY_HOME;
+    process.env.AGENTPARTY_HOME = home;
+    let connections = 0;
+    const server = startMockServer((f, sock) => {
+      if (f.type !== "hello") return;
+      connections++;
+      sock.send(welcomeFrame(0, "me"));
+    });
+    const held = acquireInstanceLock(
+      "watch",
+      instanceLockTarget(server.url, "ap_tok", "dev"),
+      defaultInstanceLockDir(),
+    );
+    try {
+      const code = await runWatch({
+        server: server.url,
+        token: "ap_tok",
+        channel: "dev",
+        since: 0,
+        timeoutSec: 1,
+        follow: false,
+        mentionsOnly: true,
+        once: true,
+        out: () => {},
+      });
+      expect(code).toBe(EXIT_ALREADY_WATCHING);
+      expect(connections).toBe(0);
+    } finally {
+      held.release?.();
+      server.stop();
+      if (previousHome === undefined) delete process.env.AGENTPARTY_HOME;
+      else process.env.AGENTPARTY_HOME = previousHome;
+    }
+  });
+
   test("第二个 watcher 直接被拒，且连 WS 都不建（否则它已经在消费 @ 了）", async () => {
     const d = dir();
     let connections = 0;

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -3899,7 +3899,9 @@ export class ChannelDO extends Server<Env> {
         };
       }
     }
-    const loopGuard = identity.kind === "agent" ? this.loopGuardMessage(identity.name) : null;
+    // status 是 presence/协调状态，不是对话消息：agent 已触发 fair-share guard 后仍必须能声明
+    // blocked/waiting，让频道知道它为什么停下。它也不消耗/重置消息 streak（#466）。
+    const loopGuard = identity.kind === "agent" && frame.kind === "message" ? this.loopGuardMessage(identity.name) : null;
     if (loopGuard !== null) {
       this.alertLoopGuard(loopGuard);
       return {
@@ -4096,12 +4098,14 @@ export class ChannelDO extends Server<Env> {
     }
     this.linkWakeResume(identity.name, msg, now);
     const workflowGuardFrame = this.applyWorkflowGuardAfterSend(identity, msg, workflowGuard, now);
-    if (identity.kind === "agent") {
-      this.setMeta("agent_streak", String(this.agentStreak() + 1));
-      this.setMeta(this.agentCountKey(identity.name), String(this.agentCount(identity.name) + 1));
-    } else {
-      this.clearLoopGuardState();
-      this.clearWorkflowGuards();
+    if (frame.kind === "message") {
+      if (identity.kind === "agent") {
+        this.setMeta("agent_streak", String(this.agentStreak() + 1));
+        this.setMeta(this.agentCountKey(identity.name), String(this.agentCount(identity.name) + 1));
+      } else {
+        this.clearLoopGuardState();
+        this.clearWorkflowGuards();
+      }
     }
     if (seq % 100 === 0) {
       sql.exec(

--- a/worker/test/agent-loop-guard.spec.ts
+++ b/worker/test/agent-loop-guard.spec.ts
@@ -36,6 +36,13 @@ async function expectLoopGuard(res: Response) {
   await expect(res.json()).resolves.toMatchObject({ error: { code: "loop_guard" } });
 }
 
+function postStatus(slug: string, token: string, state: "waiting" | "blocked", note: string): Promise<Response> {
+  return api(`/api/channels/${slug}/messages`, token, {
+    method: "POST",
+    body: JSON.stringify({ kind: "status", state, note, mentions: [] }),
+  });
+}
+
 describe("per-agent loop guard fairness", () => {
   it("blocks only the normal-mode agent that has already sent 15 messages", async () => {
     const agentA = await seedToken("agent");
@@ -78,5 +85,30 @@ describe("per-agent loop guard fairness", () => {
     await seedLoopGuardCounts(slug, agent.name, LOOP_GUARD_AGENT_N, LOOP_GUARD_N);
 
     expect((await postMessage(slug, agent.token, "guard disabled")).status).toBe(200);
+  });
+
+  it("lets a blocked agent publish status without consuming or clearing its message quota", async () => {
+    const agent = await seedToken("agent");
+    const slug = await createChannel(agent.token);
+    expect((await postMessage(slug, agent.token, "warm up")).status).toBe(200);
+    await seedLoopGuardCounts(slug, agent.name, LOOP_GUARD_AGENT_N);
+
+    const status = await postStatus(slug, agent.token, "blocked", "loop guard，待人类 reset");
+    expect(status.status).toBe(200);
+    await expect(status.json()).resolves.toMatchObject({ seq: 2 });
+    await expectLoopGuard(await postMessage(slug, agent.token, "still blocked until a human message"));
+  });
+
+  it("a human status does not masquerade as the human message that resets loop guard", async () => {
+    const agent = await seedToken("agent");
+    const human = await seedToken("human");
+    const slug = await createChannel(agent.token);
+    expect((await postMessage(slug, agent.token, "warm up")).status).toBe(200);
+    await seedLoopGuardCounts(slug, agent.name, LOOP_GUARD_AGENT_N);
+
+    expect((await postStatus(slug, human.token, "waiting", "presence only")).status).toBe(200);
+    await expectLoopGuard(await postMessage(slug, agent.token, "status must not reset guard"));
+    expect((await postMessage(slug, human.token, "real human reset")).status).toBe(200);
+    expect((await postMessage(slug, agent.token, "allowed now")).status).toBe(200);
   });
 });

--- a/worker/test/new-channel-guard-default.spec.ts
+++ b/worker/test/new-channel-guard-default.spec.ts
@@ -36,14 +36,12 @@ describe("new channels enable the loop guard by default (#96)", () => {
     expect(body.error.code).toBe("loop_guard");
   });
 
-  it("status frames count toward the loop-guard streak, not just message sends (#133)", async () => {
-    // 文档反复只说「连续 agent 消息」，读者会以为 status（含 blocked）不算。
-    // do.ts:2582 对每条 agent 帧无差别 +1，不区分 message / status。
+  it("status frames do not consume the message loop-guard quota (#466)", async () => {
     const agentA = await seedToken("agent", uniq("sa"));
     const agentB = await seedToken("agent", uniq("sb"));
     const slug = await createChannel(agentA.token);
 
-    // 30 条全是 status 帧（两 agent 轮流，各 15 条 → 不触 30/min 单身份限流）。
+    // status 是 presence 协调信息：即使达到消息阈值数量，也不应消耗熔断额度。
     for (let i = 0; i < 30; i++) {
       const token = i % 2 === 0 ? agentA.token : agentB.token;
       const res = await api(`/api/channels/${slug}/messages`, token, {
@@ -52,7 +50,13 @@ describe("new channels enable the loop guard by default (#96)", () => {
       });
       expect(res.status).toBe(200);
     }
-    // 第 31 条 agent 帧应被 loop guard 拒绝，证明 30 条 status 已把 streak 填满。
+    expect((await postMessage(slug, agentA.token, "first real message")).status).toBe(200);
+
+    // 只有真实 agent message 会累计：再发送 29 条后，第 31 条 message 才熔断。
+    for (let i = 1; i < 30; i++) {
+      const token = i % 2 === 0 ? agentA.token : agentB.token;
+      expect((await postMessage(slug, token, `msg-${i}`)).status).toBe(200);
+    }
     const tripped = await postMessage(slug, agentA.token, "one message too many");
     expect(tripped.status).toBe(409);
     expect(((await tripped.json()) as { error: { code: string } }).error.code).toBe("loop_guard");


### PR DESCRIPTION
## 修复

- standby 不再确认尚未处理的 wake，取得租约后按 seq 重放未确认帧
- 同机监听器锁改为跨 cwd、按 server/token/channel 身份隔离，并识别 zombie/PID 复用
- status 帧不再消耗或重置消息 loop guard，已熔断的 agent 仍能报告 blocked/waiting
- 先抢锁再建 WebSocket，退出及同步建连失败都会释放自己的锁

## 验证

- bun run check:cli（729 passed）
- bun run check:worker（522 passed）
- bun run check:shared
- 两项反向验证：移除 standby ack 保护会复现 wake 丢失；让 status 重新进入 guard 会触发测试失败

Closes #465
Closes #466

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 接管/顶替时按更早 seq 顺序重放未确认消息，提升接管时序一致性。
  * 新增连接未确认积压上限配置，默认更稳健；接管后可补放欠账。
  * 单实例锁升级：默认锁目录固定，并支持按服务身份隔离作用域，降低误拒绝/误接管。
* **问题修复**
  * 跨机租约：`held=false` 不再提前推进进度或触发执行；`held=true` 后才接管重放。
  * 连接未确认过多会更快失败，队列关闭后不再重放。
  * `status` 类消息不再错误触发/重置 loop/workflow 保护，也不再消耗熔断配额。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->