### PR TITLE
fix(lark): 迁移通讯录搜索到 v3 API

### DIFF
--- a/web/src/components/LarkMemberInvite.test.tsx
+++ b/web/src/components/LarkMemberInvite.test.tsx
@@ -120,6 +120,41 @@ test("clears results and pagination when contact permission is revoked during lo
   expect(renderer!.root.findByProps({ role: "status" })).toBeTruthy();
 });
 
+test("deduplicates users returned through multiple department pages", async () => {
+  let searches = 0;
+  act(() => {
+    renderer = create(
+      <LocaleProvider>
+        <LarkMemberInvite
+          slug="room"
+          token="token"
+          search={async () => {
+            searches += 1;
+            return searches === 1
+              ? {
+                  users: [{ id: "on_alice", name: "Alice", avatar_url: null, already_member: false }],
+                  next_cursor: "next",
+                }
+              : {
+                  users: [
+                    { id: "on_alice", name: "Alice", avatar_url: null, already_member: false },
+                    { id: "on_bob", name: "Bob", avatar_url: null, already_member: false },
+                  ],
+                  next_cursor: null,
+                };
+          }}
+        />
+      </LocaleProvider>,
+    );
+  });
+  const input = renderer!.root.findByType("input");
+  act(() => input.props.onChange({ target: { value: "a" } }));
+  await act(async () => renderer!.root.findByType("form").props.onSubmit({ preventDefault() {} }));
+  await act(async () => renderer!.root.findByProps({ className: "d-btn lark-invite-more" }).props.onClick());
+  expect(renderer!.root.findAllByProps({ "data-lark-user-id": "on_alice" })).toHaveLength(1);
+  expect(renderer!.root.findAllByProps({ "data-lark-user-id": "on_bob" })).toHaveLength(1);
+});
+
 test("disables stale invite actions when contact permission is revoked during invite", async () => {
   act(() => {
     renderer = create(

--- a/web/src/components/LarkMemberInvite.test.tsx
+++ b/web/src/components/LarkMemberInvite.test.tsx
@@ -122,14 +122,16 @@ test("clears results and pagination when contact permission is revoked during lo
 
 test("deduplicates users returned through multiple department pages", async () => {
   let searches = 0;
+  const cursors: Array<string | null> = [];
   act(() => {
     renderer = create(
       <LocaleProvider>
         <LarkMemberInvite
           slug="room"
           token="token"
-          search={async () => {
+          search={async (_token, _slug, _query, _limit, cursor) => {
             searches += 1;
+            cursors.push(cursor ?? null);
             return searches === 1
               ? {
                   users: [
@@ -157,6 +159,7 @@ test("deduplicates users returned through multiple department pages", async () =
   await act(async () => renderer!.root.findByProps({ className: "d-btn lark-invite-more" }).props.onClick());
   expect(renderer!.root.findAllByProps({ "data-lark-user-id": "on_alice" })).toHaveLength(1);
   expect(renderer!.root.findAllByProps({ "data-lark-user-id": "on_bob" })).toHaveLength(1);
+  expect(cursors).toEqual([null, "next"]);
 });
 
 test("disables stale invite actions when contact permission is revoked during invite", async () => {

--- a/web/src/components/LarkMemberInvite.test.tsx
+++ b/web/src/components/LarkMemberInvite.test.tsx
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, expect, test } from "bun:test";
 import { act, create, type ReactTestRenderer } from "react-test-renderer";
 import { LocaleProvider } from "../i18n/locale";
-import { LarkDirectoryApiError } from "../lib/api";
+import { LarkDirectoryApiError, type LarkDirectoryPage } from "../lib/api";
 import { LarkMemberInvite } from "./LarkMemberInvite";
 
 function memoryStorage(): Storage {
@@ -160,6 +160,74 @@ test("deduplicates users returned through multiple department pages", async () =
   expect(renderer!.root.findAllByProps({ "data-lark-user-id": "on_alice" })).toHaveLength(1);
   expect(renderer!.root.findAllByProps({ "data-lark-user-id": "on_bob" })).toHaveLength(1);
   expect(cursors).toEqual([null, "next"]);
+});
+
+test("clears old results and pagination when the query changes", async () => {
+  act(() => {
+    renderer = create(
+      <LocaleProvider>
+        <LarkMemberInvite
+          slug="room"
+          token="token"
+          search={async (_token, _slug, query) => query === "Alice"
+            ? {
+                users: [{ id: "on_alice", name: "Alice", avatar_url: null, already_member: false }],
+                next_cursor: "alice-next",
+              }
+            : {
+                users: [{ id: "on_bob", name: "Bob", avatar_url: null, already_member: false }],
+                next_cursor: null,
+              }}
+        />
+      </LocaleProvider>,
+    );
+  });
+  const input = renderer!.root.findByType("input");
+  act(() => input.props.onChange({ target: { value: "Alice" } }));
+  await act(async () => renderer!.root.findByType("form").props.onSubmit({ preventDefault() {} }));
+  expect(renderer!.root.findByProps({ "data-lark-user-id": "on_alice" })).toBeTruthy();
+  expect(renderer!.root.findByProps({ className: "d-btn lark-invite-more" })).toBeTruthy();
+
+  act(() => input.props.onChange({ target: { value: "Bob" } }));
+  expect(renderer!.root.findAllByProps({ "data-lark-user-id": "on_alice" })).toHaveLength(0);
+  expect(renderer!.root.findAllByProps({ className: "d-btn lark-invite-more" })).toHaveLength(0);
+  await act(async () => renderer!.root.findByType("form").props.onSubmit({ preventDefault() {} }));
+  expect(renderer!.root.findByProps({ "data-lark-user-id": "on_bob" })).toBeTruthy();
+});
+
+test("ignores a stale response after the query changes", async () => {
+  let resolveAlice!: (page: LarkDirectoryPage) => void;
+  const alicePage = new Promise<LarkDirectoryPage>((resolve) => { resolveAlice = resolve; });
+  act(() => {
+    renderer = create(
+      <LocaleProvider>
+        <LarkMemberInvite
+          slug="room"
+          token="token"
+          search={async (_token, _slug, query) => query === "Alice"
+            ? alicePage
+            : {
+                users: [{ id: "on_bob", name: "Bob", avatar_url: null, already_member: false }],
+                next_cursor: null,
+              }}
+        />
+      </LocaleProvider>,
+    );
+  });
+  const input = renderer!.root.findByType("input");
+  act(() => input.props.onChange({ target: { value: "Alice" } }));
+  let firstRequest!: Promise<void>;
+  act(() => { firstRequest = renderer!.root.findByType("form").props.onSubmit({ preventDefault() {} }); });
+  act(() => input.props.onChange({ target: { value: "Bob" } }));
+  await act(async () => renderer!.root.findByType("form").props.onSubmit({ preventDefault() {} }));
+  resolveAlice({
+    users: [{ id: "on_alice", name: "Alice", avatar_url: null, already_member: false }],
+    next_cursor: "stale-next",
+  });
+  await act(async () => { await firstRequest; });
+  expect(renderer!.root.findAllByProps({ "data-lark-user-id": "on_alice" })).toHaveLength(0);
+  expect(renderer!.root.findAllByProps({ "data-lark-user-id": "on_bob" })).toHaveLength(1);
+  expect(renderer!.root.findAllByProps({ className: "d-btn lark-invite-more" })).toHaveLength(0);
 });
 
 test("disables stale invite actions when contact permission is revoked during invite", async () => {

--- a/web/src/components/LarkMemberInvite.test.tsx
+++ b/web/src/components/LarkMemberInvite.test.tsx
@@ -132,13 +132,17 @@ test("deduplicates users returned through multiple department pages", async () =
             searches += 1;
             return searches === 1
               ? {
-                  users: [{ id: "on_alice", name: "Alice", avatar_url: null, already_member: false }],
+                  users: [
+                    { id: "on_alice", name: "Alice", avatar_url: null, already_member: false },
+                    { id: "on_alice", name: "Alice duplicate", avatar_url: null, already_member: false },
+                  ],
                   next_cursor: "next",
                 }
               : {
                   users: [
                     { id: "on_alice", name: "Alice", avatar_url: null, already_member: false },
                     { id: "on_bob", name: "Bob", avatar_url: null, already_member: false },
+                    { id: "on_bob", name: "Bob duplicate", avatar_url: null, already_member: false },
                   ],
                   next_cursor: null,
                 };

--- a/web/src/components/LarkMemberInvite.tsx
+++ b/web/src/components/LarkMemberInvite.tsx
@@ -68,7 +68,11 @@ export function LarkMemberInvite({
     setError(null);
     try {
       const page: LarkDirectoryPage = await search(token, slug, normalized, 20, nextCursor);
-      setUsers((current) => nextCursor === null ? page.users : [...current, ...page.users]);
+      setUsers((current) => {
+        if (nextCursor === null) return page.users;
+        const known = new Set(current.map((user) => user.id));
+        return [...current, ...page.users.filter((user) => !known.has(user.id))];
+      });
       setCursor(page.next_cursor);
       setSearched(true);
     } catch (cause) {

--- a/web/src/components/LarkMemberInvite.tsx
+++ b/web/src/components/LarkMemberInvite.tsx
@@ -69,9 +69,14 @@ export function LarkMemberInvite({
     try {
       const page: LarkDirectoryPage = await search(token, slug, normalized, 20, nextCursor);
       setUsers((current) => {
-        if (nextCursor === null) return page.users;
-        const known = new Set(current.map((user) => user.id));
-        return [...current, ...page.users.filter((user) => !known.has(user.id))];
+        const merged = nextCursor === null ? [] : [...current];
+        const known = new Set(merged.map((user) => user.id));
+        for (const user of page.users) {
+          if (known.has(user.id)) continue;
+          known.add(user.id);
+          merged.push(user);
+        }
+        return merged;
       });
       setCursor(page.next_cursor);
       setSearched(true);

--- a/web/src/components/LarkMemberInvite.tsx
+++ b/web/src/components/LarkMemberInvite.tsx
@@ -1,4 +1,4 @@
-import { useState, type FormEvent } from "react";
+import { useRef, useState, type FormEvent } from "react";
 import {
   inviteLarkMember,
   LarkDirectoryApiError,
@@ -33,6 +33,8 @@ export function LarkMemberInvite({
   const [busy, setBusy] = useState(false);
   const [inviting, setInviting] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const activeQuery = useRef("");
+  const queryVersion = useRef(0);
   // #382：部署未开通 Lark 通讯录权限时，撞一次就记住——之后禁用搜索并持久提示，
   // 不让用户反复搜了才报错。权限是 owner 在 Lark 后台配置项，前端只能优雅降级。
   const [directoryUnavailable, setDirectoryUnavailable] = useState(false);
@@ -64,10 +66,12 @@ export function LarkMemberInvite({
   async function runSearch(nextCursor: string | null) {
     const normalized = query.trim();
     if (!normalized) return;
+    const version = queryVersion.current;
     setBusy(true);
     setError(null);
     try {
       const page: LarkDirectoryPage = await search(token, slug, normalized, 20, nextCursor);
+      if (version !== queryVersion.current || normalized !== activeQuery.current) return;
       setUsers((current) => {
         const merged = nextCursor === null ? [] : [...current];
         const known = new Set(merged.map((user) => user.id));
@@ -81,11 +85,25 @@ export function LarkMemberInvite({
       setCursor(page.next_cursor);
       setSearched(true);
     } catch (cause) {
+      if (version !== queryVersion.current || normalized !== activeQuery.current) return;
       if (isDirectoryPermissionError(cause)) disableDirectoryActions();
       else setError(errorLabel(cause, "LarkInvite.error.search"));
     } finally {
-      setBusy(false);
+      if (version === queryVersion.current && normalized === activeQuery.current) setBusy(false);
     }
+  }
+
+  function changeQuery(value: string) {
+    setQuery(value);
+    const normalized = value.trim();
+    if (normalized === activeQuery.current) return;
+    activeQuery.current = normalized;
+    queryVersion.current += 1;
+    setUsers([]);
+    setCursor(null);
+    setSearched(false);
+    setError(null);
+    setBusy(false);
   }
 
   async function submit(event: FormEvent) {
@@ -123,7 +141,7 @@ export function LarkMemberInvite({
               maxLength={64}
               aria-label={t("LarkInvite.searchLabel")}
               placeholder={t("LarkInvite.placeholder")}
-              onChange={(event) => setQuery(event.target.value)}
+              onChange={(event) => changeQuery(event.target.value)}
             />
             <button type="submit" className="d-btn d-btn--primary" disabled={busy || !query.trim()}>
               {busy ? t("LarkInvite.searching") : t("LarkInvite.search")}

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -3561,7 +3561,8 @@ app.get("/api/channels/:slug/lark-directory", async (c) => {
     ).bind(slug).all<{ account: string }>()).results.map((row) => row.account));
     return c.json({
       users: page.users.map((user) => {
-        const account = knownAccounts.get(user.id) ?? directoryAccount(provider.id, user.id);
+        const account = user.identifiers.map((identifier) => knownAccounts.get(identifier)).find((known) => known !== undefined)
+          ?? directoryAccount(provider.id, user.id);
         return { id: user.id, name: user.name, avatar_url: user.avatarUrl, already_member: account !== null && members.has(account) };
       }),
       next_cursor: page.nextCursor,
@@ -3600,11 +3601,12 @@ app.post("/api/channels/:slug/lark-members", async (c) => {
   }
   try {
     const user = await getLarkDirectoryUser(c.env, provider, userId);
+    const identifiers = [...user.identifiers, "", ""].slice(0, 3);
     const known = await c.env.DB.prepare(
       `SELECT account FROM account_profiles
-        WHERE provider = ? AND provider_user_id = ? AND tenant_key = ?
+        WHERE provider = ? AND tenant_key = ? AND provider_user_id IN (?, ?, ?)
         LIMIT 1`,
-    ).bind(provider.id, user.id, profile.tenant_key).first<{ account: string }>();
+    ).bind(provider.id, profile.tenant_key, ...identifiers).first<{ account: string }>();
     const account = known?.account ?? directoryAccount(provider.id, user.id);
     if (account === null) return c.json(errorBody("bad_request", "unsupported Lark user id"), 400);
     await ensureDefaultHandle(c.env.DB, {

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -3601,13 +3601,20 @@ app.post("/api/channels/:slug/lark-members", async (c) => {
   }
   try {
     const user = await getLarkDirectoryUser(c.env, provider, userId);
-    const identifiers = [...user.identifiers, "", ""].slice(0, 3);
-    const known = await c.env.DB.prepare(
-      `SELECT account FROM account_profiles
-        WHERE provider = ? AND tenant_key = ? AND provider_user_id IN (?, ?, ?)
-        LIMIT 1`,
-    ).bind(provider.id, profile.tenant_key, ...identifiers).first<{ account: string }>();
-    const account = known?.account ?? directoryAccount(provider.id, user.id);
+    const directoryIdentifiers = user.identifiers.slice(0, 3);
+    const identifiers = [...directoryIdentifiers, "", ""].slice(0, 3);
+    const knownProfiles = await c.env.DB.prepare(
+      `SELECT account, provider_user_id FROM account_profiles
+        WHERE provider = ? AND tenant_key = ? AND provider_user_id IN (?, ?, ?)`,
+    ).bind(provider.id, profile.tenant_key, ...identifiers)
+      .all<{ account: string; provider_user_id: string }>();
+    const accountsByIdentifier = new Map(
+      knownProfiles.results.map((knownProfile) => [knownProfile.provider_user_id, knownProfile.account]),
+    );
+    const knownAccount = directoryIdentifiers
+      .map((identifier) => accountsByIdentifier.get(identifier))
+      .find((candidate) => candidate !== undefined);
+    const account = knownAccount ?? directoryAccount(provider.id, user.id);
     if (account === null) return c.json(errorBody("bad_request", "unsupported Lark user id"), 400);
     await ensureDefaultHandle(c.env.DB, {
       account,

--- a/worker/src/integrations/lark.ts
+++ b/worker/src/integrations/lark.ts
@@ -13,6 +13,7 @@ export interface LarkProviderConfig {
 
 export interface LarkDirectoryUser {
   id: string;
+  identifiers: string[];
   name: string;
   avatarUrl: string | null;
 }
@@ -219,7 +220,11 @@ function directoryUsers(data: Record<string, unknown>): LarkDirectoryUser[] {
   const users: LarkDirectoryUser[] = [];
   for (const value of rows) {
     if (!isRecord(value)) continue;
-    const id = typeof value.union_id === "string" ? value.union_id.trim() : "";
+    const identifiers = [value.union_id, value.open_id, value.user_id]
+      .filter((identifier): identifier is string => typeof identifier === "string" && identifier.trim().length > 0)
+      .map((identifier) => identifier.trim())
+      .filter((identifier, index, all) => all.indexOf(identifier) === index);
+    const id = identifiers[0] ?? "";
     const name = typeof value.name === "string" ? value.name.trim() : "";
     if (!id || !name) continue;
     const avatar = isRecord(value.avatar) ? value.avatar : {};
@@ -228,7 +233,7 @@ function directoryUsers(data: Record<string, unknown>): LarkDirectoryUser[] {
       : typeof value.avatar_url === "string"
         ? value.avatar_url
         : null;
-    users.push({ id, name, avatarUrl });
+    users.push({ id, identifiers, name, avatarUrl });
   }
   return users;
 }

--- a/worker/src/integrations/lark.ts
+++ b/worker/src/integrations/lark.ts
@@ -42,11 +42,108 @@ const DEFAULT_SECRET_ENV: Record<LarkProviderKind, string> = {
   feishu: "FEISHU_CLIENT_SECRET",
 };
 const TOKEN_SKEW_MS = 60_000;
+const DIRECTORY_CURSOR_VERSION = 1;
+const DIRECTORY_CURSOR_MAX = 1_024;
+const DIRECTORY_PAGE_TOKEN_MAX = 512;
+const DEPARTMENT_ID_RE = /^[a-zA-Z0-9][a-zA-Z0-9_\-@.]{0,63}$/;
 const tokenCache = new Map<string, { token: string; expiresAt: number }>();
 const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+interface DirectoryCursorState {
+  v: 1;
+  q: string;
+  p: string;
+  d: string;
+  u: string | null;
+  n: string | null;
+  s: boolean;
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
+}
+
+function providerSecret(env: EnvLike, provider: LarkProviderConfig): string {
+  const secret = (env as Record<string, string | undefined>)[provider.clientSecretEnv]?.trim();
+  if (!secret) throw new Error("lark provider secret is not configured");
+  return secret;
+}
+
+function base64url(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function base64urlBytes(value: string): Uint8Array | null {
+  if (!/^[A-Za-z0-9_-]+$/.test(value)) return null;
+  try {
+    const padded = value.replace(/-/g, "+").replace(/_/g, "/").padEnd(Math.ceil(value.length / 4) * 4, "=");
+    const binary = atob(padded);
+    return Uint8Array.from(binary, (char) => char.charCodeAt(0));
+  } catch {
+    return null;
+  }
+}
+
+async function directoryCursorSignature(secret: string, payload: string): Promise<Uint8Array> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    textEncoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  return new Uint8Array(await crypto.subtle.sign("HMAC", key, textEncoder.encode(payload))).slice(0, 16);
+}
+
+function sameBytes(left: Uint8Array, right: Uint8Array): boolean {
+  if (left.length !== right.length) return false;
+  let difference = 0;
+  for (let index = 0; index < left.length; index += 1) difference |= left[index] ^ right[index];
+  return difference === 0;
+}
+
+function validPageToken(value: unknown): value is string | null {
+  return value === null || (typeof value === "string" && value.length > 0 && value.length <= DIRECTORY_PAGE_TOKEN_MAX);
+}
+
+async function encodeDirectoryCursor(secret: string, state: DirectoryCursorState): Promise<string> {
+  const payload = base64url(textEncoder.encode(JSON.stringify(state)));
+  const encoded = `${payload}.${base64url(await directoryCursorSignature(secret, payload))}`;
+  if (encoded.length > DIRECTORY_CURSOR_MAX) throw new LarkDirectoryError("upstream", "Lark directory cursor is too large");
+  return encoded;
+}
+
+async function decodeDirectoryCursor(
+  secret: string,
+  cursor: string,
+  query: string,
+  providerId: string,
+): Promise<DirectoryCursorState> {
+  const invalid = () => new LarkDirectoryError("invalid_cursor", "Lark directory cursor is invalid");
+  if (cursor.length === 0 || cursor.length > DIRECTORY_CURSOR_MAX) throw invalid();
+  const [payload, signature, extra] = cursor.split(".");
+  const payloadBytes = payload === undefined ? null : base64urlBytes(payload);
+  const signatureBytes = signature === undefined ? null : base64urlBytes(signature);
+  if (payloadBytes === null || signatureBytes === null || extra !== undefined) throw invalid();
+  const expected = await directoryCursorSignature(secret, payload);
+  if (!sameBytes(signatureBytes, expected)) throw invalid();
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(textDecoder.decode(payloadBytes));
+  } catch {
+    throw invalid();
+  }
+  if (
+    !isRecord(decoded) || decoded.v !== DIRECTORY_CURSOR_VERSION || decoded.q !== query || decoded.p !== providerId ||
+    typeof decoded.d !== "string" || !DEPARTMENT_ID_RE.test(decoded.d) || !validPageToken(decoded.u) ||
+    !validPageToken(decoded.n) || typeof decoded.s !== "boolean" || (!decoded.s && (decoded.d !== "0" || decoded.n !== null))
+  ) {
+    throw invalid();
+  }
+  return decoded as unknown as DirectoryCursorState;
 }
 
 function authProviderConfigs(env: EnvLike): LarkProviderConfig[] {
@@ -89,7 +186,7 @@ function larkError(data: Record<string, unknown>, status: number): LarkDirectory
   if (code === 41012 || code === 99992352 || code === 99992363 || code === 99992364 || code === 99992381) {
     return new LarkDirectoryError("not_found", message);
   }
-  if (code === 41050 || code === 40004 || /(?:permission|authority|scope)/i.test(message)) {
+  if (code === 41050 || code === 40004 || code === 40014 || /(?:permission|authority|scope)/i.test(message)) {
     return new LarkDirectoryError("permission", message);
   }
   return new LarkDirectoryError("upstream", message);
@@ -131,6 +228,42 @@ function directoryUsers(data: Record<string, unknown>): LarkDirectoryUser[] {
   return users;
 }
 
+async function nextLarkDepartment(
+  env: EnvLike,
+  provider: LarkProviderConfig,
+  pageToken: string | null,
+): Promise<{ departmentId: string; nextPageToken: string | null } | null> {
+  const params = new URLSearchParams({
+    department_id_type: "open_department_id",
+    fetch_child: "true",
+    page_size: "1",
+  });
+  if (pageToken !== null) params.set("page_token", pageToken);
+  const data = await larkDirectoryRequest(
+    env,
+    provider,
+    `/open-apis/contact/v3/departments/0/children?${params.toString()}`,
+  );
+  const payload = isRecord(data.data) ? data.data : {};
+  const items = Array.isArray(payload.items) ? payload.items : [];
+  if (items.length === 0) {
+    if (payload.has_more === true) throw new LarkDirectoryError("upstream", "Lark returned an empty department page");
+    return null;
+  }
+  const item = items[0];
+  const departmentId = isRecord(item) && typeof item.open_department_id === "string"
+    ? item.open_department_id.trim()
+    : "";
+  if (!DEPARTMENT_ID_RE.test(departmentId)) throw new LarkDirectoryError("upstream", "Lark returned an invalid department id");
+  const nextPageToken = payload.has_more === true && typeof payload.page_token === "string" && payload.page_token
+    ? payload.page_token
+    : null;
+  if (payload.has_more === true && nextPageToken === null) {
+    throw new LarkDirectoryError("upstream", "Lark omitted the next department cursor");
+  }
+  return { departmentId, nextPageToken };
+}
+
 export async function searchLarkDirectory(
   env: EnvLike,
   provider: LarkProviderConfig,
@@ -138,19 +271,48 @@ export async function searchLarkDirectory(
   cursor: string | null,
   pageSize: number,
 ): Promise<{ users: LarkDirectoryUser[]; nextCursor: string | null }> {
-  const params = new URLSearchParams({ open_department_id: "0", fetch_child: "true", page_size: String(pageSize) });
-  if (cursor !== null) params.set("page_token", cursor);
+  const normalizedQuery = query.toLocaleLowerCase();
+  const secret = providerSecret(env, provider);
+  const state = cursor === null
+    ? { v: DIRECTORY_CURSOR_VERSION, q: normalizedQuery, p: provider.id, d: "0", u: null, n: null, s: false } as DirectoryCursorState
+    : await decodeDirectoryCursor(secret, cursor, normalizedQuery, provider.id);
+  const params = new URLSearchParams({
+    user_id_type: "union_id",
+    department_id_type: "open_department_id",
+    department_id: state.d,
+    page_size: String(pageSize),
+  });
+  if (state.u !== null) params.set("page_token", state.u);
   const data = await larkDirectoryRequest(
     env,
     provider,
-    `/open-apis/contact/v1/department/user/detail/list?${params.toString()}`,
+    `/open-apis/contact/v3/users/find_by_department?${params.toString()}`,
   );
-  const normalizedQuery = query.toLocaleLowerCase();
   const users = directoryUsers(data).filter((user) => user.name.toLocaleLowerCase().includes(normalizedQuery));
   const payload = isRecord(data.data) ? data.data : {};
   const hasMore = payload.has_more === true;
   const pageToken = typeof payload.page_token === "string" && payload.page_token ? payload.page_token : null;
-  return { users, nextCursor: hasMore ? pageToken : null };
+  if (hasMore && pageToken === null) throw new LarkDirectoryError("upstream", "Lark omitted the next user cursor");
+  let nextState: DirectoryCursorState | null = hasMore
+    ? { ...state, u: pageToken }
+    : null;
+  if (!hasMore) {
+    const nextDepartment = state.s
+      ? state.n === null ? null : await nextLarkDepartment(env, provider, state.n)
+      : await nextLarkDepartment(env, provider, null);
+    if (nextDepartment !== null) {
+      nextState = {
+        v: DIRECTORY_CURSOR_VERSION,
+        q: normalizedQuery,
+        p: provider.id,
+        d: nextDepartment.departmentId,
+        u: null,
+        n: nextDepartment.nextPageToken,
+        s: true,
+      };
+    }
+  }
+  return { users, nextCursor: nextState === null ? null : await encodeDirectoryCursor(secret, nextState) };
 }
 
 export async function getLarkDirectoryUser(
@@ -195,8 +357,7 @@ export function inferReceiveIdType(providerUserId: string, email: string | null 
 }
 
 export async function getTenantAccessToken(env: EnvLike, provider: LarkProviderConfig): Promise<string> {
-  const secret = (env as Record<string, string | undefined>)[provider.clientSecretEnv]?.trim();
-  if (!secret) throw new Error("lark provider secret is not configured");
+  const secret = providerSecret(env, provider);
   const cacheKey = `${provider.id}:${provider.kind}:${provider.clientId}:${secret}`;
   const cached = tokenCache.get(cacheKey);
   const now = Date.now();

--- a/worker/src/integrations/lark.ts
+++ b/worker/src/integrations/lark.ts
@@ -45,6 +45,7 @@ const TOKEN_SKEW_MS = 60_000;
 const DIRECTORY_CURSOR_VERSION = 1;
 const DIRECTORY_CURSOR_MAX = 1_024;
 const DIRECTORY_PAGE_TOKEN_MAX = 512;
+const DIRECTORY_DEPARTMENT_BATCH = 4;
 const DEPARTMENT_ID_RE = /^[a-zA-Z0-9][a-zA-Z0-9_\-@.]{0,63}$/;
 const tokenCache = new Map<string, { token: string; expiresAt: number }>();
 const textEncoder = new TextEncoder();
@@ -55,6 +56,7 @@ interface DirectoryCursorState {
   q: string;
   p: string;
   d: string;
+  a: string[];
   u: string | null;
   n: string | null;
   s: boolean;
@@ -139,7 +141,10 @@ async function decodeDirectoryCursor(
   if (
     !isRecord(decoded) || decoded.v !== DIRECTORY_CURSOR_VERSION || decoded.q !== query || decoded.p !== providerId ||
     typeof decoded.d !== "string" || !DEPARTMENT_ID_RE.test(decoded.d) || !validPageToken(decoded.u) ||
-    !validPageToken(decoded.n) || typeof decoded.s !== "boolean" || (!decoded.s && (decoded.d !== "0" || decoded.n !== null))
+    !Array.isArray(decoded.a) || decoded.a.length >= DIRECTORY_DEPARTMENT_BATCH ||
+    !decoded.a.every((departmentId) => typeof departmentId === "string" && DEPARTMENT_ID_RE.test(departmentId)) ||
+    !validPageToken(decoded.n) || typeof decoded.s !== "boolean" ||
+    (!decoded.s && (decoded.d !== "0" || decoded.a.length !== 0 || decoded.n !== null))
   ) {
     throw invalid();
   }
@@ -228,15 +233,15 @@ function directoryUsers(data: Record<string, unknown>): LarkDirectoryUser[] {
   return users;
 }
 
-async function nextLarkDepartment(
+async function nextLarkDepartments(
   env: EnvLike,
   provider: LarkProviderConfig,
   pageToken: string | null,
-): Promise<{ departmentId: string; nextPageToken: string | null } | null> {
+): Promise<{ departmentIds: string[]; nextPageToken: string | null } | null> {
   const params = new URLSearchParams({
     department_id_type: "open_department_id",
     fetch_child: "true",
-    page_size: "1",
+    page_size: String(DIRECTORY_DEPARTMENT_BATCH),
   });
   if (pageToken !== null) params.set("page_token", pageToken);
   const data = await larkDirectoryRequest(
@@ -250,18 +255,43 @@ async function nextLarkDepartment(
     if (payload.has_more === true) throw new LarkDirectoryError("upstream", "Lark returned an empty department page");
     return null;
   }
-  const item = items[0];
-  const departmentId = isRecord(item) && typeof item.open_department_id === "string"
+  const departmentIds = items.map((item) => isRecord(item) && typeof item.open_department_id === "string"
     ? item.open_department_id.trim()
-    : "";
-  if (!DEPARTMENT_ID_RE.test(departmentId)) throw new LarkDirectoryError("upstream", "Lark returned an invalid department id");
+    : "");
+  if (departmentIds.some((departmentId) => !DEPARTMENT_ID_RE.test(departmentId))) {
+    throw new LarkDirectoryError("upstream", "Lark returned an invalid department id");
+  }
   const nextPageToken = payload.has_more === true && typeof payload.page_token === "string" && payload.page_token
     ? payload.page_token
     : null;
   if (payload.has_more === true && nextPageToken === null) {
     throw new LarkDirectoryError("upstream", "Lark omitted the next department cursor");
   }
-  return { departmentId, nextPageToken };
+  return { departmentIds, nextPageToken };
+}
+
+async function advanceLarkDepartment(
+  env: EnvLike,
+  provider: LarkProviderConfig,
+  state: DirectoryCursorState,
+): Promise<DirectoryCursorState | null> {
+  if (state.a.length > 0) {
+    return { ...state, d: state.a[0], a: state.a.slice(1), u: null, s: true };
+  }
+  const batch = state.s
+    ? state.n === null ? null : await nextLarkDepartments(env, provider, state.n)
+    : await nextLarkDepartments(env, provider, null);
+  if (batch === null) return null;
+  return {
+    v: DIRECTORY_CURSOR_VERSION,
+    q: state.q,
+    p: state.p,
+    d: batch.departmentIds[0],
+    a: batch.departmentIds.slice(1),
+    u: null,
+    n: batch.nextPageToken,
+    s: true,
+  };
 }
 
 export async function searchLarkDirectory(
@@ -274,7 +304,7 @@ export async function searchLarkDirectory(
   const normalizedQuery = query.toLocaleLowerCase();
   const secret = providerSecret(env, provider);
   const state = cursor === null
-    ? { v: DIRECTORY_CURSOR_VERSION, q: normalizedQuery, p: provider.id, d: "0", u: null, n: null, s: false } as DirectoryCursorState
+    ? { v: DIRECTORY_CURSOR_VERSION, q: normalizedQuery, p: provider.id, d: "0", a: [], u: null, n: null, s: false } as DirectoryCursorState
     : await decodeDirectoryCursor(secret, cursor, normalizedQuery, provider.id);
   const params = new URLSearchParams({
     user_id_type: "union_id",
@@ -297,20 +327,7 @@ export async function searchLarkDirectory(
     ? { ...state, u: pageToken }
     : null;
   if (!hasMore) {
-    const nextDepartment = state.s
-      ? state.n === null ? null : await nextLarkDepartment(env, provider, state.n)
-      : await nextLarkDepartment(env, provider, null);
-    if (nextDepartment !== null) {
-      nextState = {
-        v: DIRECTORY_CURSOR_VERSION,
-        q: normalizedQuery,
-        p: provider.id,
-        d: nextDepartment.departmentId,
-        u: null,
-        n: nextDepartment.nextPageToken,
-        s: true,
-      };
-    }
+    nextState = await advanceLarkDepartment(env, provider, state);
   }
   return { users, nextCursor: nextState === null ? null : await encodeDirectoryCursor(secret, nextState) };
 }

--- a/worker/test/lark-directory.spec.ts
+++ b/worker/test/lark-directory.spec.ts
@@ -176,6 +176,44 @@ describe("Lark organization member invitations (#358)", () => {
     expect(await third.json()).toEqual({ users: [], next_cursor: null });
   });
 
+  it("matches an existing member whose profile still stores an open_id", async () => {
+    const owner = await larkHuman();
+    const slug = await createChannel(owner.token);
+    const legacyAccount = `lark-main:${uniq("legacy_alice")}`;
+    const unionId = uniq("on_alice");
+    const openId = uniq("ou_alice");
+    const userId = uniq("alice_user");
+    const now = Date.now();
+    await env.DB.prepare(
+      `INSERT INTO account_profiles (
+         account, handle, display_name, provider, provider_user_id, tenant_key, created_at, updated_at
+       ) VALUES (?, ?, 'Alice', 'lark-main', ?, 'tenant-test', ?, ?)`,
+    ).bind(legacyAccount, uniq("alice"), openId, now, now).run();
+    await env.DB.prepare(
+      "INSERT INTO channel_members (channel_slug, account, added_by, added_at) VALUES (?, ?, ?, ?)",
+    ).bind(slug, legacyAccount, owner.account, now).run();
+    mockTenantToken();
+    fetchMock.get(LARK_ORIGIN)
+      .intercept({
+        path: "/open-apis/contact/v3/users/find_by_department?user_id_type=union_id&department_id_type=open_department_id&department_id=0&page_size=20",
+        method: "GET",
+      })
+      .reply(200, {
+        code: 0,
+        data: {
+          has_more: true,
+          page_token: "next-page",
+          items: [{ union_id: unionId, open_id: openId, user_id: userId, name: "Alice" }],
+        },
+      });
+
+    const response = await api(`/api/channels/${slug}/lark-directory?q=alice&limit=20`, owner.token);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      users: [{ id: unionId, name: "Alice", already_member: true }],
+    });
+  });
+
   it("maps missing v3 department visibility to the stable contact-permission error", async () => {
     const owner = await larkHuman();
     const slug = await createChannel(owner.token);
@@ -227,6 +265,40 @@ describe("Lark organization member invitations (#358)", () => {
     const audit = await api(`/api/channels/${slug}/management-audit?limit=100`, owner.token);
     const entries = ((await audit.json()) as { audit: Array<{ action: string; resource: string }> }).audit;
     expect(entries.filter((entry) => entry.action === "channel.member.add" && entry.resource === `channel/${slug}/members/lark-main:on_alice`)).toHaveLength(1);
+  });
+
+  it("reuses an open_id profile during a union_id invite and migrates it to the stable id", async () => {
+    const owner = await larkHuman();
+    const slug = await createChannel(owner.token);
+    const legacyAccount = `lark-main:${uniq("legacy_alice")}`;
+    const unionId = uniq("on_alice");
+    const openId = uniq("ou_alice");
+    const userId = uniq("alice_user");
+    const now = Date.now();
+    await env.DB.prepare(
+      `INSERT INTO account_profiles (
+         account, handle, display_name, provider, provider_user_id, tenant_key, created_at, updated_at
+       ) VALUES (?, ?, 'Alice', 'lark-main', ?, 'tenant-test', ?, ?)`,
+    ).bind(legacyAccount, uniq("alice"), openId, now, now).run();
+    mockTenantToken();
+    fetchMock.get(LARK_ORIGIN)
+      .intercept({ path: `/open-apis/contact/v3/users/${unionId}?user_id_type=union_id`, method: "GET" })
+      .reply(200, {
+        code: 0,
+        data: { user: { union_id: unionId, open_id: openId, user_id: userId, name: "Alice" } },
+      });
+
+    const response = await api(`/api/channels/${slug}/lark-members`, owner.token, {
+      method: "POST",
+      body: JSON.stringify({ user_id: unionId }),
+    });
+    expect(response.status).toBe(201);
+    expect(await env.DB.prepare(
+      "SELECT account FROM channel_members WHERE channel_slug = ? AND account = ?",
+    ).bind(slug, legacyAccount).first()).not.toBeNull();
+    expect(await env.DB.prepare(
+      "SELECT provider_user_id FROM account_profiles WHERE account = ?",
+    ).bind(legacyAccount).first<{ provider_user_id: string }>()).toEqual({ provider_user_id: unionId });
   });
 
   it("uses the stable contact-permission code for direct invite failures", async () => {

--- a/worker/test/lark-directory.spec.ts
+++ b/worker/test/lark-directory.spec.ts
@@ -40,7 +40,7 @@ function mockTenantToken() {
 function mockDirectoryPage(options: { permissionDenied?: boolean; persist?: boolean } = {}) {
   const interceptor = fetchMock.get(LARK_ORIGIN)
     .intercept({
-      path: "/open-apis/contact/v1/department/user/detail/list?open_department_id=0&fetch_child=true&page_size=20",
+      path: "/open-apis/contact/v3/users/find_by_department?user_id_type=union_id&department_id_type=open_department_id&department_id=0&page_size=20",
       method: "GET",
     })
     .reply(200, options.permissionDenied
@@ -50,7 +50,7 @@ function mockDirectoryPage(options: { permissionDenied?: boolean; persist?: bool
           data: {
             has_more: true,
             page_token: "next-page",
-            user_list: [
+            items: [
               {
                 union_id: "on_alice",
                 name: "Alice Zhang",
@@ -89,9 +89,89 @@ describe("Lark organization member invitations (#358)", () => {
     const body = (await response.json()) as Record<string, unknown>;
     expect(body).toEqual({
       users: [{ id: "on_alice", name: "Alice Zhang", avatar_url: "https://cdn.example/alice.png", already_member: false }],
-      next_cursor: "next-page",
+      next_cursor: expect.stringMatching(/^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/),
     });
+    expect(String(body.next_cursor)).not.toContain("next-page");
     expect(JSON.stringify(body)).not.toMatch(/tenant-secret-token|must-not-leak|81000000000|access.?token/i);
+  });
+
+  it("walks recursive v3 departments with a query-bound signed cursor", async () => {
+    const owner = await larkHuman();
+    const slug = await createChannel(owner.token);
+    mockTenantToken();
+    fetchMock.get(LARK_ORIGIN)
+      .intercept({
+        path: "/open-apis/contact/v3/users/find_by_department?user_id_type=union_id&department_id_type=open_department_id&department_id=0&page_size=20",
+        method: "GET",
+      })
+      .reply(200, { code: 0, data: { has_more: false, items: [{ union_id: "on_owner", name: "Owner" }] } });
+    fetchMock.get(LARK_ORIGIN)
+      .intercept({
+        path: "/open-apis/contact/v3/departments/0/children?department_id_type=open_department_id&fetch_child=true&page_size=1",
+        method: "GET",
+      })
+      .reply(200, {
+        code: 0,
+        data: { has_more: false, items: [{ open_department_id: "od-engineering" }] },
+      });
+
+    const first = await api(`/api/channels/${slug}/lark-directory?q=alice&limit=20`, owner.token);
+    expect(first.status).toBe(200);
+    const firstPage = (await first.json()) as { users: unknown[]; next_cursor: string };
+    expect(firstPage.users).toEqual([]);
+    expect(firstPage.next_cursor).toMatch(/^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/);
+
+    const tampered = `${firstPage.next_cursor.slice(0, -1)}${firstPage.next_cursor.endsWith("A") ? "B" : "A"}`;
+    const rejected = await api(
+      `/api/channels/${slug}/lark-directory?q=alice&limit=20&cursor=${encodeURIComponent(tampered)}`,
+      owner.token,
+    );
+    expect(rejected.status).toBe(400);
+    expect(await rejected.json()).toMatchObject({ error: { code: "bad_request" } });
+
+    fetchMock.get(LARK_ORIGIN)
+      .intercept({
+        path: "/open-apis/contact/v3/users/find_by_department?user_id_type=union_id&department_id_type=open_department_id&department_id=od-engineering&page_size=20",
+        method: "GET",
+      })
+      .reply(200, {
+        code: 0,
+        data: {
+          has_more: false,
+          items: [{ union_id: "on_alice", name: "Alice Zhang", avatar: { avatar_72: "https://cdn.example/alice.png" } }],
+        },
+      });
+    const second = await api(
+      `/api/channels/${slug}/lark-directory?q=alice&limit=20&cursor=${encodeURIComponent(firstPage.next_cursor)}`,
+      owner.token,
+    );
+    expect(second.status).toBe(200);
+    expect(await second.json()).toMatchObject({
+      users: [{ id: "on_alice", name: "Alice Zhang", avatar_url: "https://cdn.example/alice.png" }],
+      next_cursor: null,
+    });
+  });
+
+  it("maps missing v3 department visibility to the stable contact-permission error", async () => {
+    const owner = await larkHuman();
+    const slug = await createChannel(owner.token);
+    mockTenantToken();
+    fetchMock.get(LARK_ORIGIN)
+      .intercept({
+        path: "/open-apis/contact/v3/users/find_by_department?user_id_type=union_id&department_id_type=open_department_id&department_id=0&page_size=20",
+        method: "GET",
+      })
+      .reply(200, { code: 0, data: { has_more: false, items: [] } });
+    fetchMock.get(LARK_ORIGIN)
+      .intercept({
+        path: "/open-apis/contact/v3/departments/0/children?department_id_type=open_department_id&fetch_child=true&page_size=1",
+        method: "GET",
+      })
+      .reply(403, { code: 40014, msg: "no parent dept authority" });
+
+    const response = await api(`/api/channels/${slug}/lark-directory?q=alice&limit=20`, owner.token);
+    expect(response.status).toBe(503);
+    expect(await response.json()).toMatchObject({ error: { code: "lark_contact_permission_required" } });
   });
 
   it("directly adds the selected same-tenant Lark user idempotently and records management audit", async () => {

--- a/worker/test/lark-directory.spec.ts
+++ b/worker/test/lark-directory.spec.ts
@@ -107,12 +107,15 @@ describe("Lark organization member invitations (#358)", () => {
       .reply(200, { code: 0, data: { has_more: false, items: [{ union_id: "on_owner", name: "Owner" }] } });
     fetchMock.get(LARK_ORIGIN)
       .intercept({
-        path: "/open-apis/contact/v3/departments/0/children?department_id_type=open_department_id&fetch_child=true&page_size=1",
+        path: "/open-apis/contact/v3/departments/0/children?department_id_type=open_department_id&fetch_child=true&page_size=4",
         method: "GET",
       })
       .reply(200, {
         code: 0,
-        data: { has_more: false, items: [{ open_department_id: "od-engineering" }] },
+        data: {
+          has_more: false,
+          items: [{ open_department_id: "od-engineering" }, { open_department_id: "od-sales" }],
+        },
       });
 
     const first = await api(`/api/channels/${slug}/lark-directory?q=alice&limit=20`, owner.token);
@@ -153,10 +156,24 @@ describe("Lark organization member invitations (#358)", () => {
       owner.token,
     );
     expect(second.status).toBe(200);
-    expect(await second.json()).toMatchObject({
+    const secondPage = (await second.json()) as { users: unknown[]; next_cursor: string };
+    expect(secondPage).toMatchObject({
       users: [{ id: "on_alice", name: "Alice Zhang", avatar_url: "https://cdn.example/alice.png" }],
-      next_cursor: null,
     });
+    expect(secondPage.next_cursor).toMatch(/^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/);
+
+    fetchMock.get(LARK_ORIGIN)
+      .intercept({
+        path: "/open-apis/contact/v3/users/find_by_department?user_id_type=union_id&department_id_type=open_department_id&department_id=od-sales&page_size=20",
+        method: "GET",
+      })
+      .reply(200, { code: 0, data: { has_more: false, items: [{ union_id: "on_bob", name: "Bob" }] } });
+    const third = await api(
+      `/api/channels/${slug}/lark-directory?q=alice&limit=20&cursor=${encodeURIComponent(secondPage.next_cursor)}`,
+      owner.token,
+    );
+    expect(third.status).toBe(200);
+    expect(await third.json()).toEqual({ users: [], next_cursor: null });
   });
 
   it("maps missing v3 department visibility to the stable contact-permission error", async () => {
@@ -171,7 +188,7 @@ describe("Lark organization member invitations (#358)", () => {
       .reply(200, { code: 0, data: { has_more: false, items: [] } });
     fetchMock.get(LARK_ORIGIN)
       .intercept({
-        path: "/open-apis/contact/v3/departments/0/children?department_id_type=open_department_id&fetch_child=true&page_size=1",
+        path: "/open-apis/contact/v3/departments/0/children?department_id_type=open_department_id&fetch_child=true&page_size=4",
         method: "GET",
       })
       .reply(403, { code: 40014, msg: "no parent dept authority" });

--- a/worker/test/lark-directory.spec.ts
+++ b/worker/test/lark-directory.spec.ts
@@ -37,6 +37,11 @@ function mockTenantToken() {
     .reply(200, { code: 0, tenant_access_token: "tenant-secret-token", expire: 3600 });
 }
 
+function decodeDirectoryCursor(cursor: string): Record<string, unknown> {
+  const payload = cursor.split(".", 1)[0].replace(/-/g, "+").replace(/_/g, "/");
+  return JSON.parse(atob(payload.padEnd(Math.ceil(payload.length / 4) * 4, "="))) as Record<string, unknown>;
+}
+
 function mockDirectoryPage(options: { permissionDenied?: boolean; persist?: boolean } = {}) {
   const interceptor = fetchMock.get(LARK_ORIGIN)
     .intercept({
@@ -209,9 +214,11 @@ describe("Lark organization member invitations (#358)", () => {
 
     const response = await api(`/api/channels/${slug}/lark-directory?q=alice&limit=20`, owner.token);
     expect(response.status).toBe(200);
-    expect(await response.json()).toMatchObject({
+    const body = (await response.json()) as { users: unknown[]; next_cursor: string };
+    expect(body).toMatchObject({
       users: [{ id: unionId, name: "Alice", already_member: true }],
     });
+    expect(decodeDirectoryCursor(body.next_cursor)).toMatchObject({ d: "0", u: "next-page" });
   });
 
   it("maps missing v3 department visibility to the stable contact-permission error", async () => {
@@ -299,6 +306,45 @@ describe("Lark organization member invitations (#358)", () => {
     expect(await env.DB.prepare(
       "SELECT provider_user_id FROM account_profiles WHERE account = ?",
     ).bind(legacyAccount).first<{ provider_user_id: string }>()).toEqual({ provider_user_id: unionId });
+  });
+
+  it("prefers the stable union_id account when multiple historical identifiers already exist", async () => {
+    const owner = await larkHuman();
+    const slug = await createChannel(owner.token);
+    const unionAccount = `lark-main:${uniq("union_alice")}`;
+    const openAccount = `lark-main:${uniq("open_alice")}`;
+    const unionId = uniq("on_alice");
+    const openId = uniq("ou_alice");
+    const userId = uniq("alice_user");
+    const now = Date.now();
+    await env.DB.batch([
+      env.DB.prepare(
+        `INSERT INTO account_profiles (
+           account, handle, display_name, provider, provider_user_id, tenant_key, created_at, updated_at
+         ) VALUES (?, ?, 'Union Alice', 'lark-main', ?, 'tenant-test', ?, ?)`,
+      ).bind(unionAccount, uniq("union_alice"), unionId, now, now),
+      env.DB.prepare(
+        `INSERT INTO account_profiles (
+           account, handle, display_name, provider, provider_user_id, tenant_key, created_at, updated_at
+         ) VALUES (?, ?, 'Open Alice', 'lark-main', ?, 'tenant-test', ?, ?)`,
+      ).bind(openAccount, uniq("open_alice"), openId, now, now),
+    ]);
+    mockTenantToken();
+    fetchMock.get(LARK_ORIGIN)
+      .intercept({ path: `/open-apis/contact/v3/users/${unionId}?user_id_type=union_id`, method: "GET" })
+      .reply(200, {
+        code: 0,
+        data: { user: { union_id: unionId, open_id: openId, user_id: userId, name: "Alice" } },
+      });
+
+    const response = await api(`/api/channels/${slug}/lark-members`, owner.token, {
+      method: "POST",
+      body: JSON.stringify({ user_id: unionId }),
+    });
+    expect(response.status).toBe(201);
+    expect((await env.DB.prepare(
+      "SELECT account FROM channel_members WHERE channel_slug = ? AND account IN (?, ?) ORDER BY account",
+    ).bind(slug, unionAccount, openAccount).all<{ account: string }>()).results).toEqual([{ account: unionAccount }]);
   });
 
   it("uses the stable contact-permission code for direct invite failures", async () => {

--- a/worker/test/lark-directory.spec.ts
+++ b/worker/test/lark-directory.spec.ts
@@ -129,6 +129,13 @@ describe("Lark organization member invitations (#358)", () => {
     expect(rejected.status).toBe(400);
     expect(await rejected.json()).toMatchObject({ error: { code: "bad_request" } });
 
+    const rebound = await api(
+      `/api/channels/${slug}/lark-directory?q=bob&limit=20&cursor=${encodeURIComponent(firstPage.next_cursor)}`,
+      owner.token,
+    );
+    expect(rebound.status).toBe(400);
+    expect(await rebound.json()).toMatchObject({ error: { code: "bad_request" } });
+
     fetchMock.get(LARK_ORIGIN)
       .intercept({
         path: "/open-apis/contact/v3/users/find_by_department?user_id_type=union_id&department_id_type=open_department_id&department_id=od-engineering&page_size=20",


### PR DESCRIPTION
## 改动说明

- 将 legacy `/contact/v1/department/user/detail/list` 迁移到当前 v3 API。
- 先查询根部门直属用户，再通过 `departments/0/children?fetch_child=true` 递归分页所有子部门，并逐部门查询直属用户，保持全组织覆盖。
- 用 Provider secret 对跨部门游标做 HMAC 签名，并绑定查询词与 Provider；篡改或跨查询复用返回稳定 `bad_request`。
- 覆盖 v3 `40014` 部门可见范围错误，并保持现有 `lark_contact_permission_required` 契约。
- 前端跨部门分页按 Lark user id 去重，避免多部门用户产生重复条目。

Refs #382

## 合并前检查（review-ack 强制闸——不留结论合不了）

- [ ] 我已读 pr-agent / CodeRabbit 的 review，真问题已处理、误报已判明
- [x] 本地门禁通过：Worker 79 files / 524 tests、Worker tsc；Web 99 files / 725 tests、Web tsc、Vite production build
- [x] 涉及安全/鉴权/数据的改动已做对抗性验证：签名游标篡改返回 400；游标绑定查询词和 Provider；敏感字段仍不下发


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能 / 增强**
  - Lark/Feishu 目录搜索升级为 v3：支持跨部门递归加载，游标携带状态并进行签名校验；目录返回标识字段用于更准确的账号关联。
- **问题修复**
  - 修复多部门/多页结果导致的同一用户重复展示；翻页与输入查询切换时的状态更一致，过期请求结果不会污染当前界面。
  - 邀请组织成员到频道时改进账号匹配策略；权限类错误映射更清晰稳定。
- **测试**
  - 更新并补充 v3 分页递归、游标格式/篡改校验、去重渲染与竞态防护用例；新增标识复用/迁移场景覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->