### PR TITLE
fix(cli): keep builtin runner wake context inside workdir

### DIFF
--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -362,8 +362,8 @@ export function writeContextFile(
   cliUpgrade: CliUpgradeNotice | null = null,
   attachments?: WakeContextAttachment[],
 ): string {
-  // dir 是本 serve 实例私有的（createWakeContextDir）。文件名只需 seq：同一次唤醒重复写得到
-  // 同一路径（幂等），而不同实例——不同身份 / 不同 server / 不同 profile——各在各的目录里。
+  // dir 必须由调用方按运行实例隔离。文件名只需 seq：同一次唤醒重复写得到同一路径（幂等），
+  // 而不同实例——不同身份 / 不同 server / 不同 profile——各在各的目录里。
   const path = join(dir, `${frame.seq}.json`);
   writeFileSync(
     path,
@@ -371,6 +371,12 @@ export function writeContextFile(
     { mode: 0o600 },
   );
   return path;
+}
+
+function builtinRunnerContextDir(workdir: string): string {
+  const dir = join(workdir, "wake-context");
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
+  return dir;
 }
 
 /**
@@ -1143,7 +1149,9 @@ export function createBuiltinRunner(opts: BuiltinRunnerOptions): NonNullable<Ser
 
     const repoCwd = await ensureRepo(opts, env);
     const cwd = opts.cwd ?? repoCwd ?? opts.workdir;
-    const contextFile = writeContextFile(ctx.contextDir, frame, ctx.channel, ctx.self, ctx.recent, ctx.charter ?? null, ctx.projectAgent ?? null, ctx.cliUpgrade ?? null, ctx.attachments);
+    // #479：builtin Claude/Codex 子进程在 runner workdir 内运行；把 context JSON 写到 workdir
+    // 内，避免 Claude Code 默认权限模式因读取系统 tmpdir 文件而卡无人批准的权限弹窗。
+    const contextFile = writeContextFile(builtinRunnerContextDir(opts.workdir), frame, ctx.channel, ctx.self, ctx.recent, ctx.charter ?? null, ctx.projectAgent ?? null, ctx.cliUpgrade ?? null, ctx.attachments);
     // 绝不把 context JSON 当 argv 传（#120）：argv 对同机任意用户可见（`ps -axww`），
     // 一条私有频道消息的正文、charter、最近 20 条上下文就全泄漏了。
     // 只传 0700 私有目录里的文件路径——protocol_reminder 本来就叫模型「先读本文件」。

--- a/cli/test/serve.test.ts
+++ b/cli/test/serve.test.ts
@@ -1009,14 +1009,11 @@ describe("builtin runner", () => {
   test("builtin claude runner writes wake context inside the runner workdir (#479)", async () => {
     const { post } = postRecorder();
     const workdir = tempDir();
+    const expectedContextPath = join(workdir, "wake-context", "6.json");
     let prompt = "";
-    let contextPath = "";
     const runProcess: RunnerProcess = async (args) => {
       prompt = String(args.at(-1));
-      const m = prompt.match(/(\/[^\s]*\.json)/);
-      contextPath = m?.[0] ?? "";
-      expect(contextPath).toStartWith(join(workdir, "wake-context") + sep);
-      expect(JSON.parse(readFileSync(contextPath, "utf8"))).toMatchObject({ channel: "dev", seq: 6 });
+      expect(JSON.parse(readFileSync(expectedContextPath, "utf8"))).toMatchObject({ channel: "dev", seq: 6 });
       return { code: 0, stdout: JSON.stringify({ session_id: uuid(6), result: "ok" }), stderr: "" };
     };
 
@@ -1030,9 +1027,10 @@ describe("builtin runner", () => {
       post,
     })(triggerFrame(6), runnerCtx());
 
-    expect(prompt).toContain(contextPath);
-    expect(existsSync(contextPath)).toBe(false);
-    expect(existsSync(join(workdir, "wake-context"))).toBe(true);
+    expect(prompt).toContain(expectedContextPath);
+    expect(expectedContextPath).toStartWith(join(workdir, "wake-context") + sep);
+    expect(existsSync(expectedContextPath)).toBe(false);
+    expect(lstatSync(join(workdir, "wake-context")).isDirectory()).toBe(true);
   });
 
   test("outer serve process posts ack and final message with reply_to and session start marker", async () => {

--- a/cli/test/serve.test.ts
+++ b/cli/test/serve.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, readlinkSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
 import { EXIT_ARCHIVED, type Attachment, type MsgFrame } from "@agentparty/shared";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, sep } from "node:path";
 import {
   createBuiltinRunner,
   createSdkRunner,
@@ -1004,6 +1004,35 @@ describe("builtin runner", () => {
     expect(JSON.parse(readFileSync(join(workdir, "wake-session.json"), "utf8")).session_id).toBe(uuid(4));
     expect(calls[0]).toContain("--output-format");
     expect(calls[1]).toEqual(["claude", "-p", "--resume", uuid(4), expect.any(String)]);
+  });
+
+  test("builtin claude runner writes wake context inside the runner workdir (#479)", async () => {
+    const { post } = postRecorder();
+    const workdir = tempDir();
+    let prompt = "";
+    let contextPath = "";
+    const runProcess: RunnerProcess = async (args) => {
+      prompt = String(args.at(-1));
+      const m = prompt.match(/(\/[^\s]*\.json)/);
+      contextPath = m?.[0] ?? "";
+      expect(contextPath).toStartWith(join(workdir, "wake-context") + sep);
+      expect(JSON.parse(readFileSync(contextPath, "utf8"))).toMatchObject({ channel: "dev", seq: 6 });
+      return { code: 0, stdout: JSON.stringify({ session_id: uuid(6), result: "ok" }), stderr: "" };
+    };
+
+    await createBuiltinRunner({
+      server: "http://agentparty.test",
+      token: "ap_tok",
+      channel: "dev",
+      harness: "claude",
+      workdir,
+      runProcess,
+      post,
+    })(triggerFrame(6), runnerCtx());
+
+    expect(prompt).toContain(contextPath);
+    expect(existsSync(contextPath)).toBe(false);
+    expect(existsSync(join(workdir, "wake-context"))).toBe(true);
   });
 
   test("outer serve process posts ack and final message with reply_to and session start marker", async () => {


### PR DESCRIPTION
## 改动说明

- builtin `party serve --runner claude|codex` 的 wake context JSON 改为写入 runner workdir 下的 `wake-context/`。
- 避免 Claude Code 默认权限模式读取系统临时目录 `/var/folders/...` 文件时卡住无人批准。
- 不默认添加 `--dangerously-skip-permissions`，保持权限边界更小。
- 增加 #479 回归测试，断言 Claude runner prompt 中的 context 文件位于 runner workdir 内，且运行后会被清理。

## 验证

- bun test cli/test/serve.test.ts -t "builtin claude runner writes wake context"
- bun test cli/test/serve.test.ts
- bunx tsc --project cli/tsconfig.json --noEmit

Fixes #479

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复内置 Codex/Claude Runner 的唤醒上下文文件写入与读取位置：现在会在各运行实例隔离的工作目录下创建对应的 `wake-context` 目录并生成上下文文件，避免不同实例互相覆盖及权限异常。
  * 改进唤醒上下文的清理策略：运行结束后会清理生成的临时上下文内容，但保留 `wake-context` 目录以保证后续流程稳定。
* **Tests**
  * 新增内置 Claude Runner 的测试用例，验证上下文内容包含 `channel: "dev"` 与正确序号，并检查清理与目录保留效果。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->