### PR TITLE
perf(worker): presence 扫描 alarm 自适应降低 DO compute 成本 (#487)

### DIFF
--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -153,8 +153,19 @@ export const ERROR_STATUS: Record<ErrorCode, number> = {
   not_found: 404,
 };
 
-// presence 扫描周期（spec §5：60s 无帧判 offline）
-export const PRESENCE_SCAN_MS = PRESENCE_TIMEOUT_MS;
+// presence 扫描 / 半开连接回收窗口（#487 降本）。
+// 背景：Durable Objects Compute 是账单最大头（$37.50/68%），根因是每个有连接的频道 DO 被这个 alarm
+// 24/7 每分钟唤醒一次。WS Hibernation 已开，健康连接的 ping 由 auto-response 处理、不唤醒 DO；alarm 唯一
+// 的活是「醒来看看有没有连接超时静默（半开）需要回收」。把回收窗口与 alarm 重挂间隔从 60s 拉到 2× =
+// 120s，并改成按连接实际到期时刻自适应重挂（见 scheduleNextAlarm），把每频道唤醒频率砍半。
+//
+// 与 PRESENCE_TIMEOUT_MS 的分工：
+//   • PRESENCE_TIMEOUT_MS(60s) —— **面向客户端的时间戳新鲜度口径**（host 租约 / wakeReachable，只看
+//     presence.last_seen / ts）。本次不动，host failover / 可唤醒判定语义完全不变。
+//   • PRESENCE_SCAN_MS(120s)   —— **服务端回收半开 WS 连接的静默阈值 + alarm 重挂间隔**。客户端每 25s
+//     ping（cli/web 一致），健康连接永远够不到 120s 静默，不会误回收；真半开的连接在其最后一次 ping 后
+//     ≤PRESENCE_SCAN_MS + 一个 ping 间隔内被标 offline（#487 验收：≤2× 新间隔，自适应下实测≈1×）。
+export const PRESENCE_SCAN_MS = 2 * PRESENCE_TIMEOUT_MS;
 
 const STATUS_STATES: readonly string[] = ["working", "waiting", "blocked", "done"];
 const COLLAB_ROLES: readonly string[] = ["host", "worker", "reviewer", "observer"];
@@ -1490,7 +1501,8 @@ export class ChannelDO extends Server<Env> {
       read_cursors: this.readCursors(),
     });
     this.broadcastFrame({ type: "participants", participants: this.participants() });
-    // 只前移不后移：即便已有远期 alarm（temp 归档 +14 天 / webhook 重试）也保证 60s presence 扫描
+    // 只前移不后移：即便已有远期 alarm（temp 归档 +14 天 / webhook 重试）也保证 presence 扫描按期到来。
+    // 新连接此刻刚握手（lastSeen=now），最早也要 PRESENCE_SCAN_MS 静默才可能被判半开，故排到 now+窗口即可。
     await this.ensureAlarmAt(Date.now() + PRESENCE_SCAN_MS);
   }
 
@@ -1663,8 +1675,10 @@ export class ChannelDO extends Server<Env> {
     // 同名 serve 跨机租约（#99）：持租者/候选断连 → 重选，让下一条 standby 顶上（补发 held=true）。
     // 排除正在关闭的这条（getConnections 可能仍返回它）。非 serve 连接不触发。
     if (st.serveCandidate) this.reconcileServeLease(st.name, connection.id);
+    // 被移除成员的残连关闭去抖：窗口口径按 presence 新鲜度基准（60s），与 #487 拉长的扫描间隔无关，
+    // 保持既有语义不变——避免把回收 alarm 的间隔耦合进「移除后多久内的残连关闭要抹掉 presence」。
     const removedAt = Number(this.getMeta(this.removedPresenceKey(st.name)) ?? "");
-    if (Number.isInteger(removedAt) && Date.now() - removedAt < PRESENCE_SCAN_MS) {
+    if (Number.isInteger(removedAt) && Date.now() - removedAt < PRESENCE_TIMEOUT_MS) {
       this.ctx.storage.sql.exec("DELETE FROM presence WHERE name = ?", st.name);
       this.broadcastFrame({ type: "participants", participants: this.participants() });
       return;
@@ -1676,12 +1690,12 @@ export class ChannelDO extends Server<Env> {
   // alarm 三件套（spec §6/§13）：presence 扫描 → webhook 重试 → temp 归档检查，最后按最近到期时间续排
   async onAlarm() {
     const now = Date.now();
-    const live = this.scanPresence(now);
+    const scan = this.scanPresence(now);
     this.resumeDuePauses(now);
     await this.retryWebhooks(now);
     await this.checkTempArchive(now);
     await this.pruneStorage(now);
-    await this.scheduleNextAlarm(now, live);
+    await this.scheduleNextAlarm(now, scan);
   }
 
   // #128：DO 存储有界修剪。wake_delivery_ledger / message_audit / read_cursor 此前只增不减，
@@ -1794,16 +1808,23 @@ export class ChannelDO extends Server<Env> {
     }
   }
 
-  // spec §5：60s 无帧（ping 由 auto-response 记时间戳）判 offline，返回存活连接数
-  private scanPresence(now: number): number {
+  // #487：静默超过 PRESENCE_SCAN_MS（120s）的半开连接判 offline 并回收；ping 由 auto-response 盖时间戳、
+  // 不唤醒 DO。返回存活连接数 + 最早一条存活连接的 last 活动时刻（earliestSeen），供 scheduleNextAlarm 按
+  // 「最早到期」自适应重挂 alarm——只在真有连接可能超时的那一刻醒来，而非固定每分钟空转。
+  private scanPresence(now: number): { live: number; earliestSeen: number | null } {
     const stale: Connection<ConnState>[] = [];
     let live = 0;
+    let earliestSeen: number | null = null;
     for (const connection of this.getConnections<ConnState>()) {
       const st = connection.state;
       const pinged = this.ctx.getWebSocketAutoResponseTimestamp(connection)?.getTime() ?? 0;
       const last = Math.max(pinged, st?.lastSeen ?? 0);
-      if (now - last >= PRESENCE_TIMEOUT_MS) stale.push(connection);
-      else live++;
+      if (now - last >= PRESENCE_SCAN_MS) {
+        stale.push(connection);
+      } else {
+        live++;
+        if (earliestSeen === null || last < earliestSeen) earliestSeen = last;
+      }
     }
     // 同名 serve 跨机租约（#99）：心跳超时的持租者，其连接在这里被关；关掉后要重选租约让 standby 顶上。
     const staleServeNames = new Set<string>();
@@ -1819,7 +1840,7 @@ export class ChannelDO extends Server<Env> {
     if (stale.length > 0) {
       this.broadcastFrame({ type: "participants", participants: this.participants() });
     }
-    return live;
+    return { live, earliestSeen };
   }
 
   // 队列里到期的重投一轮：成功删行，失败退避 1/4/16 分钟，超过 3 次丢弃并向频道记一条 status
@@ -2040,10 +2061,16 @@ export class ChannelDO extends Server<Env> {
     }
   }
 
-  // 三个来源里最近的下一个到期时间：presence 扫描 / webhook 重试 / temp 归档
-  private async scheduleNextAlarm(now: number, live: number) {
+  // 各来源里最近的下一个到期时间：presence 扫描 / webhook 重试 / paused 恢复 / temp 归档 / retention 修剪。
+  // #487：presence 候选从固定 `now + PRESENCE_SCAN_MS` 改为 `earliestSeen + PRESENCE_SCAN_MS`——即最早一条
+  // 存活连接真正可能跨过静默阈值的时刻。健康连接每 25s ping、last 紧贴当下，到期约在 now+95~120s，等于把
+  // 空转的每分钟唤醒拉到近两分钟一次（无连接则彻底不排，让 DO 睡到别的 candidate）。webhook/paused/temp/
+  // retention 候选一律照旧，各自的 alarm 用途不受影响（#180 / #128 / temp 归档仍按点触发）。
+  private async scheduleNextAlarm(now: number, scan: { live: number; earliestSeen: number | null }) {
     const candidates: number[] = [];
-    if (live > 0) candidates.push(now + PRESENCE_SCAN_MS);
+    if (scan.live > 0 && scan.earliestSeen !== null) {
+      candidates.push(scan.earliestSeen + PRESENCE_SCAN_MS);
+    }
     const next = this.ctx.storage.sql
       .exec("SELECT MIN(next_retry_at) AS t FROM webhook_queue")
       .one();

--- a/worker/test/alarm-schedule.spec.ts
+++ b/worker/test/alarm-schedule.spec.ts
@@ -1,12 +1,12 @@
-import { PRESENCE_TIMEOUT_MS } from "@agentparty/shared";
 import { env, runInDurableObject } from "cloudflare:test";
 import { describe, expect, it } from "vitest";
-import type { ChannelDO } from "../src/do";
+import { type ChannelDO, PRESENCE_SCAN_MS } from "../src/do";
 import { WsClient, createChannel, seedToken } from "./helpers";
 
 describe("alarm scheduling", () => {
-  // 修复 1：已存在远期 alarm（temp 归档 +14 天 / webhook 重试）时，新连接仍要排 60s presence 扫描，
+  // 修复 1：已存在远期 alarm（temp 归档 +14 天 / webhook 重试）时，新连接仍要排 presence 扫描，
   // 否则 kill -9（无 close 帧）的连接最长要等远期 alarm 才被标 offline，网页假在线可达 14 天。
+  // #487：扫描窗口从 60s 拉到 PRESENCE_SCAN_MS(120s) 降 DO compute，断言随之改用该常量。
   it("moves the alarm forward to the presence scan window on connect despite a far-future alarm", async () => {
     const { token } = await seedToken("agent");
     // temp 频道的 /internal/init 会排一个 +14 天的归档 alarm
@@ -18,7 +18,7 @@ describe("alarm scheduling", () => {
     );
     // 前置断言：连接前确实是远期 alarm
     expect(before).not.toBeNull();
-    expect(before!).toBeGreaterThan(Date.now() + PRESENCE_TIMEOUT_MS + 60_000);
+    expect(before!).toBeGreaterThan(Date.now() + PRESENCE_SCAN_MS + 60_000);
 
     const ws = await WsClient.open(slug, token);
     await ws.nextOfType("welcome");
@@ -27,7 +27,7 @@ describe("alarm scheduling", () => {
       state.storage.getAlarm(),
     );
     expect(after).not.toBeNull();
-    expect(after!).toBeLessThanOrEqual(Date.now() + PRESENCE_TIMEOUT_MS + 5_000);
+    expect(after!).toBeLessThanOrEqual(Date.now() + PRESENCE_SCAN_MS + 5_000);
     ws.close();
   });
 });

--- a/worker/test/presence-alarm-adaptive.spec.ts
+++ b/worker/test/presence-alarm-adaptive.spec.ts
@@ -1,0 +1,143 @@
+// #487（降本）：Durable Objects Compute 是 Cloudflare 账单最大头（$37.50/68%），根因是每个有连接的
+// 频道 DO 被 60s presence 扫描 alarm 24/7 每分钟唤醒一次。本 spec 证明改造后：
+//   ① 唤醒频率下降——健康连接的下一次扫描排到 ~PRESENCE_SCAN_MS(120s) 而非旧的 60s；且按连接真实到期
+//      时刻自适应（earliestSeen + 窗口），无连接时干脆不排 presence alarm。
+//   ② presence 超时仍能检出——静默超过 PRESENCE_SCAN_MS 的半开连接照样被标 offline 回收。
+//   ③ paused/retention/temp 等其它 alarm 用途不受影响——它们走 scheduleNextAlarm 的独立 candidates，
+//      即便一个连接都没有也照常排点（这里以 #180 定时恢复为代表）。
+import { PRESENCE_TIMEOUT_MS } from "@agentparty/shared";
+import { env, runInDurableObject } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import { type ChannelDO, PRESENCE_SCAN_MS } from "../src/do";
+import { WsClient, createChannel, seedToken } from "./helpers";
+
+type ConnPeek = { name: string; lastSeen: number };
+
+describe("#487 presence 扫描 alarm 自适应降本", () => {
+  it("① 健康连接：下一次扫描排到 ~PRESENCE_SCAN_MS 之外，而非旧的每 60s 唤醒", async () => {
+    const agent = await seedToken("agent");
+    const slug = await createChannel(agent.token);
+    const ws = await WsClient.open(slug, agent.token);
+    await ws.nextOfType("welcome");
+
+    const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+    const res = await runInDurableObject(stub, async (instance: ChannelDO, state) => {
+      const now = Date.now();
+      // 刚 ping 过的健康连接（lastSeen=now，auto-response 未介入）
+      for (const c of instance.getConnections<ConnPeek>()) {
+        const st = c.state;
+        if (st?.name === agent.name) c.setState({ ...st, lastSeen: now });
+      }
+      await instance.onAlarm();
+      return { alarm: await state.storage.getAlarm(), now };
+    });
+
+    expect(res.alarm).not.toBeNull();
+    // 旧实现固定 now+60s；新实现 earliestSeen(=now)+120s。断言明显越过旧的 60s cadence。
+    expect(res.alarm!).toBeGreaterThan(res.now + PRESENCE_TIMEOUT_MS + 10_000);
+    expect(res.alarm!).toBeLessThanOrEqual(res.now + PRESENCE_SCAN_MS + 2_000);
+    ws.close();
+  });
+
+  it("① 自适应：下一次扫描 = 最早连接的 last + 窗口，不是固定 now+窗口", async () => {
+    const agent = await seedToken("agent");
+    const slug = await createChannel(agent.token);
+    const ws = await WsClient.open(slug, agent.token);
+    await ws.nextOfType("welcome");
+
+    const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+    const res = await runInDurableObject(stub, async (instance: ChannelDO, state) => {
+      const now = Date.now();
+      // 40s 前 ping 过：到期应在 now + (窗口 - 40s)，证明是 earliestSeen 驱动而非固定 now+窗口
+      for (const c of instance.getConnections<ConnPeek>()) {
+        const st = c.state;
+        if (st?.name === agent.name) c.setState({ ...st, lastSeen: now - 40_000 });
+      }
+      await instance.onAlarm();
+      return { alarm: await state.storage.getAlarm(), now };
+    });
+
+    const expected = res.now + (PRESENCE_SCAN_MS - 40_000);
+    expect(res.alarm!).toBeGreaterThan(expected - 3_000);
+    expect(res.alarm!).toBeLessThanOrEqual(expected + 3_000);
+    ws.close();
+  });
+
+  it("① 无存活连接：不再挂 presence 扫描 alarm（DO 可睡到别的 candidate）", async () => {
+    const { token } = await seedToken("agent");
+    const slug = await createChannel(token); // standing 频道，init 不排 alarm
+
+    const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+    const alarm = await runInDurableObject(stub, async (instance: ChannelDO, state) => {
+      instance.onStart(); // 未经连接的 standing DO 尚未建表，先物化 schema（幂等 CREATE IF NOT EXISTS）
+      await instance.onAlarm();
+      return state.storage.getAlarm();
+    });
+    expect(alarm).toBeNull();
+  });
+
+  it("② 静默 > PRESENCE_SCAN_MS 的半开连接仍被标 offline；60~120s 之间的连接不被误回收", async () => {
+    const agent = await seedToken("agent");
+    const human = await seedToken("human");
+    const slug = await createChannel(agent.token);
+    const silent = await WsClient.open(slug, agent.token);
+    await silent.nextOfType("welcome");
+    const watcher = await WsClient.open(slug, human.token);
+    await watcher.nextOfType("welcome");
+
+    const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+
+    // (a) 90s 静默（旧 60s 窗口会误杀）：新窗口下仍存活，连接不被关。健康端每 25s ping，永远够不到 120s。
+    const survived = await runInDurableObject(stub, async (instance: ChannelDO) => {
+      const now = Date.now();
+      for (const c of instance.getConnections<ConnPeek>()) {
+        const st = c.state;
+        if (st?.name === agent.name) c.setState({ ...st, lastSeen: now - 90_000 });
+      }
+      await instance.onAlarm();
+      let found = false;
+      for (const c of instance.getConnections<ConnPeek>()) if (c.state?.name === agent.name) found = true;
+      return found;
+    });
+    expect(survived).toBe(true);
+
+    // (b) 越过 PRESENCE_SCAN_MS 的静默：判 offline 并回收，watcher 收到 offline presence。
+    await runInDurableObject(stub, async (instance: ChannelDO) => {
+      const now = Date.now();
+      for (const c of instance.getConnections<ConnPeek>()) {
+        const st = c.state;
+        if (st?.name === agent.name) c.setState({ ...st, lastSeen: now - (PRESENCE_SCAN_MS + 1_000) });
+      }
+      await instance.onAlarm();
+    });
+    const presence = await watcher.nextOfType("presence");
+    expect(presence).toMatchObject({ name: agent.name, state: "offline" });
+    watcher.close();
+  });
+
+  it("③ 其它 alarm 用途不受影响：无连接时 paused 定时恢复（#180）仍照常排点", async () => {
+    const { token } = await seedToken("agent");
+    const slug = await createChannel(token);
+
+    const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+    const res = await runInDurableObject(stub, async (instance: ChannelDO, state) => {
+      instance.onStart(); // 物化 schema（standing DO 未经连接尚未建表）
+      const now = Date.now();
+      const resumeAt = now + 300_000;
+      // 一条未来才恢复的 paused presence，没有任何活连接
+      state.storage.sql.exec(
+        "INSERT INTO presence (name, session_id, state, note, updated_at, paused_resume_at) VALUES (?, ?, 'offline', NULL, ?, ?)",
+        "pausedbot",
+        "s1",
+        now,
+        resumeAt,
+      );
+      await instance.onAlarm();
+      return { alarm: await state.storage.getAlarm(), resumeAt };
+    });
+    // presence 扫描贡献为空（无连接），但 paused 恢复 candidate 照样把 alarm 排到恢复时刻。
+    expect(res.alarm).not.toBeNull();
+    expect(res.alarm!).toBeGreaterThan(res.resumeAt - 3_000);
+    expect(res.alarm!).toBeLessThanOrEqual(res.resumeAt + 3_000);
+  });
+});


### PR DESCRIPTION
## 根因
> ⚠️ **成本定性更正(2026-07-14 GraphQL 实测)**:$37.50 DO Compute 是**整个共享账号**(5+ 项目)的数字,**不是 AgentParty 的**。逐 worker 拆分后 `agentparty-xdream` 只占 DO Compute **6.9%**(≈$2.6/月);账号大头是无关的 `discord-gateway-worker-test`(76.7%)。本 PR 是**白省我们自己那 6.9% 的一部分**,不是砍账单大头——见 #487 顶部更正。技术优化本身仍成立:

WS Hibernation 已开（`do.ts` `static options = { hibernate: true }`），健康连接的 ping 由 auto-response 处理、**不唤醒 DO**——所以贵的不是连接数，而是 **60s presence 扫描 alarm**：每个有连接的频道 DO 被 `ensureAlarmAt(now + PRESENCE_SCAN_MS)` / `scheduleNextAlarm` 24/7 每分钟叫醒一次，累计成这笔 compute。

## 改法（不动客户端时间戳口径）
- `PRESENCE_SCAN_MS`：`= PRESENCE_TIMEOUT_MS(60s)` → `2 × = 120s`。它现在只当**服务端回收半开 WS 连接的静默阈值 + alarm 重挂间隔**；`PRESENCE_TIMEOUT_MS` 保持 60s 不变，故 **host 租约 / `wakeReachable` / `wakeReceipt` 的时间戳新鲜度判定语义完全不变**，host 租约 / `wakeReachable` / `wakeReceipt` 的 60s 时间戳新鲜度判定不变；但同名 serve runner 崩溃后的 `reconcileServeLease` 由 stale 扫描触发，故最坏顶替延迟会随扫描窗口从 60s 增至 120s。这是降低 24/7 alarm 唤醒频率的明确取舍。
- `scheduleNextAlarm` 的 presence candidate 从固定 `now + 窗口` 改为 **`earliestSeen + 窗口`**（最早一条存活连接真正可能跨过静默阈值的时刻），**无存活连接时干脆不排** presence alarm。
- `scanPresence` 回收阈值随之用 `PRESENCE_SCAN_MS`，并返回 `earliestSeen` 供自适应重挂。
- `onClose` 的「被移除成员残连去抖」窗口显式钉在 `PRESENCE_TIMEOUT_MS(60s)`，与扫描间隔解耦，语义不变。
- **webhook 重试 / paused 定时恢复(#180) / temp 归档 / retention 修剪(#128) 的 candidate 一律照旧**，各自的 alarm 用途不受影响。

## 改动前后每频道唤醒频率
客户端每 25s ping（cli/web 一致）：

| | 下一次扫描排点 | 唤醒频率 |
|---|---|---|
| 改前 | 固定 `now + 60s` | **60 次/小时** |
| 改后 | `earliestSeen + 120s`（健康连接 last 紧贴当下）≈ `now + 95~120s` | **~30–36 次/小时（约砍半）** |

## presence 正确性保证
- 半开（无 close 帧）连接在其**最后一次 ping 后 ≤ 窗口 + 一个 ping 间隔**内被标 offline 回收；自适应重挂让实测检出窗口 ≈ 1× `PRESENCE_SCAN_MS`（满足验收「≤2× 新间隔」）。
- 健康连接每 25s ping，永远够不到 120s 静默 → **不会误回收**。
- 不改写 `ts / last_seen`，`applyLiveConnection` 的 `live` 短路、`evaluateHostLease`、`wakeReceipt` 序列化判定均不受影响（`PRESENCE_TIMEOUT_MS` 未动）。

## 测试
- 新增 `worker/test/presence-alarm-adaptive.spec.ts`：① 健康连接下一次扫描排到 ~120s 而非 60s + 自适应到期(`last+窗口`) + 无连接不重挂；② 静默 > 120s 仍检出 offline，且 60–120s 之间不误杀；③ 无连接时 paused 恢复(#180) candidate 照常排点。
- `worker/test/alarm-schedule.spec.ts` 断言随窗口常量更新。
- `cd web && bun run build` 通过；`bunx vitest run`（presence/alarm/webhook/pause/retention/temp/pruning/lease/wake 等 18 个相关 spec）全绿；`bunx tsc --noEmit` 干净。

涉及 #487，待 host 验收。

https://claude.ai/code/session_01PgxkZeqJmDge3dYe9W2tPZ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **性能优化**
  * 优化半开连接的 presence 扫描与回收时序，减少不必要的唤醒。
  * 扫描时间将根据连接活跃状态自适应安排，更接近可能超时的时刻。

* **Bug 修复**
  * 改进静默连接的离线标记与回收，确保连接能够及时清理。
  * 无活跃连接时避免保留无意义的 presence 扫描，同时不影响其他定时任务。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->