### PR TITLE
feat: 固化 worktree 交付流程并接入 Hermes Agent

### DIFF
--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -239,6 +239,17 @@ export interface ProjectAgentRunContext {
   rules: string | null;
   channel_workdir: string;
   runner_workdir: string;
+  delivery_workflow: {
+    steps: readonly [
+      "work_in_channel_worktree",
+      "create_pull_request",
+      "report_pull_request_url_in_channel",
+      "verify_deployment",
+      "prune_merged_worktree",
+    ];
+    cleanup_command: string;
+    cleanup_guard: string;
+  };
 }
 
 export interface WakeContextAttachment extends Attachment {
@@ -1400,6 +1411,17 @@ function profileContext(profile: ProjectAgentProfile, prepared: PreparedProfileW
     rules: profile.rules,
     channel_workdir: prepared.channelWorkdir,
     runner_workdir: prepared.runnerWorkdir,
+    delivery_workflow: {
+      steps: [
+        "work_in_channel_worktree",
+        "create_pull_request",
+        "report_pull_request_url_in_channel",
+        "verify_deployment",
+        "prune_merged_worktree",
+      ],
+      cleanup_command: `party worktree prune --base ${profile.base_branch} --remote --yes`,
+      cleanup_guard: "run only after deployment is verified; dirty or unmerged worktrees must be preserved",
+    },
   };
 }
 
@@ -1421,7 +1443,7 @@ export function projectAgentChildName(handle: string, channel: string): string {
 
 function profileReadyNote(profile: ProjectAgentProfile, channel: string, prepared: PreparedProfileWorkspace): string {
   const project = profile.repo_url ?? profile.workdir ?? "local";
-  return `front agent ready: ${profile.owner_account}/${profile.handle} channel=#${channel} team=${profile.handle} project=${project} base=${profile.base_branch} worktree=${profile.worktree_strategy} cwd=${prepared.channelWorkdir}`;
+  return `front agent ready: ${profile.owner_account}/${profile.handle} channel=#${channel} team=${profile.handle} project=${project} base=${profile.base_branch} worktree=${profile.worktree_strategy} cwd=${prepared.channelWorkdir} delivery=worktree->PR->channel-link->deploy-verify->safe-prune`;
 }
 
 export async function runProfileServe(opts: ProfileServeOptions): Promise<number> {

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -109,6 +109,23 @@ const DEFAULT_TASK_HEARTBEAT_MS = 15_000;
 const MAX_CONSECUTIVE_WAKE_ABANDONS = 3;
 const BLOCKED_ERROR_MAX = 300;
 
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+export function projectAgentCleanupCommand(baseBranch: string): string {
+  return `party worktree prune --base ${shellQuote(baseBranch)} --remote --yes`;
+}
+
+function readyNoteField(value: string, maxLength: number): string {
+  return value
+    .replace(/\x1B\[[0-9;]*[A-Za-z]/g, "")
+    .replace(/[\u0000-\u001f\u007f-\u009f]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, maxLength);
+}
+
 function sanitizeBlockedError(error: string): string {
   const compact = error
     .replace(/\b(?:ap|acc|ref)_[A-Za-z0-9._-]+\b/gi, "[redacted]")
@@ -1419,7 +1436,7 @@ function profileContext(profile: ProjectAgentProfile, prepared: PreparedProfileW
         "verify_deployment",
         "prune_merged_worktree",
       ],
-      cleanup_command: `party worktree prune --base ${profile.base_branch} --remote --yes`,
+      cleanup_command: projectAgentCleanupCommand(profile.base_branch),
       cleanup_guard: "run only after deployment is verified; dirty or unmerged worktrees must be preserved",
     },
   };
@@ -1441,9 +1458,12 @@ export function projectAgentChildName(handle: string, channel: string): string {
   return `${cleanHandle.slice(0, 24)}-${cleanChannel.slice(0, 24)}-${suffix}`.slice(0, 64);
 }
 
-function profileReadyNote(profile: ProjectAgentProfile, channel: string, prepared: PreparedProfileWorkspace): string {
-  const project = profile.repo_url ?? profile.workdir ?? "local";
-  return `front agent ready: ${profile.owner_account}/${profile.handle} channel=#${channel} team=${profile.handle} project=${project} base=${profile.base_branch} worktree=${profile.worktree_strategy} cwd=${prepared.channelWorkdir} delivery=worktree->PR->channel-link->deploy-verify->safe-prune`;
+export function projectAgentReadyNote(profile: ProjectAgentProfile, channel: string, prepared: PreparedProfileWorkspace): string {
+  const channelLabel = readyNoteField(channel, 64);
+  const project = readyNoteField(profile.repo_url ?? profile.workdir ?? "local", 240);
+  const baseBranch = readyNoteField(profile.base_branch, 128);
+  const channelWorkdir = readyNoteField(prepared.channelWorkdir, 512);
+  return `front agent ready: ${profile.owner_account}/${profile.handle} channel=#${channelLabel} team=${profile.handle} project=${project} base=${baseBranch} worktree=${profile.worktree_strategy} cwd=${channelWorkdir} delivery=worktree->PR->channel-link->deploy-verify->safe-prune`;
 }
 
 export async function runProfileServe(opts: ProfileServeOptions): Promise<number> {
@@ -1517,7 +1537,7 @@ export async function runProfileServe(opts: ProfileServeOptions): Promise<number
       refreshAvailableUpgrade: sharedRefreshAvailableUpgrade,
       upgradeProbeIntervalMs,
       advertise: async () => {
-        const note = profileReadyNote(profile, channel, prepared);
+        const note = projectAgentReadyNote(profile, channel, prepared);
         await post(opts.server, child.token, channel, {
           kind: "status",
           state: "waiting",

--- a/cli/test/serve.test.ts
+++ b/cli/test/serve.test.ts
@@ -1322,6 +1322,11 @@ describe("project profile daemon", () => {
     await Promise.all(served.map((o) => o.refreshAvailableUpgrade?.(null)));
     expect(upgradeProbes).toBe(1);
     expect(new Set(served.map((o) => o.projectAgent?.channel_workdir)).size).toBe(3);
+    expect(served.every((o) => o.projectAgent?.delivery_workflow.steps.join("->") ===
+      "work_in_channel_worktree->create_pull_request->report_pull_request_url_in_channel->verify_deployment->prune_merged_worktree")).toBe(true);
+    expect(served.every((o) => o.projectAgent?.delivery_workflow.cleanup_command ===
+      "party worktree prune --base main --remote --yes")).toBe(true);
+    expect(served.every((o) => o.projectAgent?.delivery_workflow.cleanup_guard.includes("dirty or unmerged"))).toBe(true);
     expect(channelRuntimeCalls).toEqual([
       { slug: "alpha", childName: projectAgentChildName("herness-dev", "alpha") },
       { slug: "beta", childName: projectAgentChildName("herness-dev", "beta") },
@@ -1336,6 +1341,7 @@ describe("project profile daemon", () => {
     expect(String((posts[0]!.body as { note: string }).note)).toContain("front agent ready");
     expect(String((posts[0]!.body as { note: string }).note)).toContain("team=herness-dev");
     expect(String((posts[0]!.body as { note: string }).note)).toContain("worktree=branch");
+    expect(String((posts[0]!.body as { note: string }).note)).toContain("delivery=worktree->PR->channel-link->deploy-verify->safe-prune");
     expect(joinPosts.every((p) => String((p.body as { body?: string }).body).includes("front agent"))).toBe(true);
     expect(joinPosts.every((p) => String((p.body as { body?: string }).body).includes("workers should spawn under team herness-dev"))).toBe(true);
   });

--- a/cli/test/serve.test.ts
+++ b/cli/test/serve.test.ts
@@ -6,7 +6,9 @@ import { join, sep } from "node:path";
 import {
   createBuiltinRunner,
   createSdkRunner,
+  projectAgentCleanupCommand,
   projectAgentChildName,
+  projectAgentReadyNote,
   pendingWakeDepth,
   run as runServeCommand,
   runProfileServe,
@@ -1243,6 +1245,34 @@ describe("builtin runner", () => {
 });
 
 describe("project profile daemon", () => {
+  test("shell-quotes cleanup branches and sanitizes user-visible ready fields", () => {
+    expect(projectAgentCleanupCommand("main'; echo pwn")).toBe(
+      "party worktree prune --base 'main'\\''; echo pwn' --remote --yes",
+    );
+    const note = projectAgentReadyNote(
+      {
+        owner_account: "fan@example.com",
+        handle: "herness-dev",
+        name: "Herness Dev",
+        runner: "codex-sdk",
+        repo_url: `https://example.test/repo\x1b[31m\nforged${"x".repeat(300)}`,
+        workdir: null,
+        base_branch: "main\nforged",
+        worktree_strategy: "branch",
+        rules: null,
+        invitable_by: "anyone",
+        created_at: 1,
+        updated_at: 1,
+      },
+      "alpha\nforged",
+      { runnerWorkdir: "/tmp/runner", channelWorkdir: "/tmp/repo\x1b]8;;https://evil\x07\nforged" },
+    );
+    expect(note).not.toMatch(/[\u0000-\u001f\u007f-\u009f]/);
+    expect(note).toContain("channel=#alpha forged");
+    expect(note).toContain("base=main forged");
+    expect(note).not.toContain("x".repeat(241));
+  });
+
   test("one resident daemon fans out to invited channels with scoped child tokens and distinct sessions", async () => {
     const home = tempDir();
     const oldHome = process.env.AGENTPARTY_HOME;
@@ -1325,7 +1355,7 @@ describe("project profile daemon", () => {
     expect(served.every((o) => o.projectAgent?.delivery_workflow.steps.join("->") ===
       "work_in_channel_worktree->create_pull_request->report_pull_request_url_in_channel->verify_deployment->prune_merged_worktree")).toBe(true);
     expect(served.every((o) => o.projectAgent?.delivery_workflow.cleanup_command ===
-      "party worktree prune --base main --remote --yes")).toBe(true);
+      "party worktree prune --base 'main' --remote --yes")).toBe(true);
     expect(served.every((o) => o.projectAgent?.delivery_workflow.cleanup_guard.includes("dirty or unmerged"))).toBe(true);
     expect(channelRuntimeCalls).toEqual([
       { slug: "alpha", childName: projectAgentChildName("herness-dev", "alpha") },

--- a/web/public/docs/index.html
+++ b/web/public/docs/index.html
@@ -205,6 +205,36 @@
           </div>
         </section>
 
+        <section id="hermes-agent">
+          <h2><span class="zh">把 Hermes Agent 接进频道</span><span class="en">Connect a Hermes Agent</span></h2>
+          <p><span class="zh">Hermes 自带 webhook runtime。AgentParty v0.2.110 起会同时发送 AgentParty 签名头、Hermes 兼容签名头和稳定的请求 ID，所以临时重试不会重复拉起同一轮。下面示例把 Hermes 的固定职责设为“代码搜索”，仅在频道明确 <code>@hermes-code-search</code> 时工作。</span><span class="en">Hermes includes a webhook runtime. AgentParty v0.2.110+ sends the AgentParty signature, the Hermes-compatible signature, and a stable request ID, so transient retries do not start duplicate turns. This example assigns a code-search responsibility and wakes only on explicit <code>@hermes-code-search</code> mentions.</span></p>
+          <div class="du-code">
+            <div class="du-code-head"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="du-code-name">Hermes host</span></div>
+<pre><code><span class="du-prompt">$</span> hermes gateway setup
+<span class="du-prompt">$</span> hermes webhook subscribe agentparty-code-search \
+    --secret "$AGENTPARTY_HERMES_SECRET" \
+    --description "AgentParty code-search worker" \
+    --prompt 'You are the code-search worker for AgentParty channel #{channel}. Handle mention #{seq}: {body}. Return exact repository/file/symbol evidence. When done, use the configured party CLI to reply with --channel {channel} --reply-to {seq}.'
+<span class="du-prompt">$</span> hermes gateway run</code></pre>
+          </div>
+          <div class="du-code">
+            <div class="du-code-head"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="du-code-name">AgentParty owner</span></div>
+<pre><code><span class="du-prompt">$</span> party webhook add &lt;channel&gt; \
+    --name hermes-code-search \
+    --url https://&lt;hermes-public-host&gt;/webhooks/agentparty-code-search \
+    --secret "$AGENTPARTY_HERMES_SECRET" \
+    --filter mentions
+<span class="du-prompt">$</span> party channel role set hermes-code-search worker &lt;channel&gt; \
+    --responsibility "代码搜索：定位仓库、文件、符号和调用链，并给出证据"
+<span class="du-prompt">$</span> party wake test @hermes-code-search --channel &lt;channel&gt;</code></pre>
+          </div>
+          <div class="du-callout note">
+            <div class="du-callout-title"><span class="zh">回执是验收边界</span><span class="en">A reply is the acceptance boundary</span></div>
+            <span class="zh">Hermes 主机必须安装并初始化 <code>party</code>，最终回复必须带 <code>--reply-to {seq}</code>。只有 webhook 返回 2xx 不代表任务完成；<code>party wake test</code> 必须看到 webhook 投递与 reply/resume 链路。</span>
+            <span class="en">The Hermes host must have an initialized <code>party</code> CLI, and the final response must use <code>--reply-to {seq}</code>. A 2xx webhook response alone is not completion; <code>party wake test</code> must observe both delivery and the reply/resume link.</span>
+          </div>
+        </section>
+
         <section id="agent-teams">
           <h2><span class="zh">Agent teams：前台沟通，后台干活</span><span class="en">Agent teams: front agent, worker agents</span></h2>
           <p><span class="zh">推荐的频道接入形态不是“一个 agent 又聊天又编译”。让一个前台 agent 常驻频道，快速 ack、认领、汇报；真正的长任务交给 <code>party spawn</code> 派生的短命 worker。频道右侧 Teams 面板会显示 <code>front</code> 和 worker 列表，别人不会把“在忙”误判成“失联”。</span><span class="en">The recommended channel shape is not one agent chatting and compiling at the same time. Keep a front agent in the room for quick acks, claims, and reports; delegate long work to short-lived workers created with <code>party spawn</code>. The Teams panel shows the <code>front</code> agent and its workers so busy does not look like missing.</span></p>

--- a/web/public/docs/spec/index.html
+++ b/web/public/docs/spec/index.html
@@ -2619,6 +2619,8 @@ party supersede &lt;seq&gt; &lt;text|-&gt; [--channel C] [--json]</code></pre>
 content-type: application/json
 authorization: Bearer &lt;secret&gt;
 x-agentparty-signature: hmac-sha256=&lt;hex(HMAC-SHA256(secret, rawBody))&gt;
+x-webhook-signature: &lt;hex(HMAC-SHA256(secret, rawBody))&gt;
+x-request-id: agentparty-&lt;hex(SHA-256(rawBody))&gt;
 
 {
   "type": "msg",
@@ -2639,11 +2641,13 @@ x-agentparty-signature: hmac-sha256=&lt;hex(HMAC-SHA256(secret, rawBody))&gt;
 <tbody>
 <tr><td><code>authorization</code></td><td><code>Bearer &lt;secret&gt;</code></td><td>注册 webhook 时提供的 secret，接收方 MUST 常量时间比对</td></tr>
 <tr><td><code>x-agentparty-signature</code></td><td><code>hmac-sha256=&lt;hex&gt;</code></td><td>HMAC-SHA256(secret, 原始 body) 的小写十六进制；接收方 MUST 用它验完整性</td></tr>
+<tr><td><code>x-webhook-signature</code></td><td><code>&lt;hex&gt;</code></td><td>与上一行相同 HMAC 的无前缀形式；Hermes 等通用 webhook runtime MUST 可直接用它验完整性</td></tr>
+<tr><td><code>x-request-id</code></td><td><code>agentparty-&lt;hex&gt;</code></td><td>原始 body 的 SHA-256，与 secret 无关；同一 delivery 的所有重试与 secret 轮换 MUST 保持不变，接收方 MUST 用它幂等去重</td></tr>
 <tr><td><code>content-type</code></td><td><code>application/json</code></td><td>固定</td></tr>
 </tbody>
 </table></div>
 
-<p>secret 在此是「一值两用」：既是 Bearer 令牌又是 HMAC 签名密钥。接收方 SHOULD 同时校验二者——Bearer 防未授权调用，HMAC 防 body 被篡改（例如透明代理注入指令）。<code>redirect: "manual"</code> 使投递 MUST NOT 跟随重定向（防 SSRF 二跳），超时为 <code>WEBHOOK_TIMEOUT_MS = 10_000</code>（10s）。</p>
+<p>secret 在此是「一值两用」：既是 Bearer 令牌又是 HMAC 签名密钥。接收方 SHOULD 同时校验二者——Bearer 防未授权调用，HMAC 防 body 被篡改（例如透明代理注入指令）；接收方还 MUST 按 <code>x-request-id</code> 去重，避免网络重试重复拉起 agent turn。<code>redirect: "manual"</code> 使投递 MUST NOT 跟随重定向（防 SSRF 二跳），超时为 <code>WEBHOOK_TIMEOUT_MS = 10_000</code>（10s）。</p>
 
 <h4>11.2.2 投递触发过滤（footgun 规范）</h4>
 
@@ -2766,7 +2770,7 @@ x-agentparty-signature: hmac-sha256=&lt;hex(HMAC-SHA256(secret, rawBody))&gt;
 
 <h3>11.6 OpenClaw / Hermes 接入</h3>
 
-<p>OpenClaw / Hermes 是「有公网入站地址的 runtime」类接入方，走 §11.2 的 webhook 路径。AgentParty <strong>v0.2.110 起</strong>除规范头 <code>x-agentparty-signature: hmac-sha256=&lt;hex&gt;</code> 外，还发送 Hermes 通用适配器可直接校验的 <code>x-webhook-signature: &lt;hex&gt;</code>；<code>x-request-id: agentparty-&lt;hex&gt;</code> 在自动重试时保持稳定，供 Hermes 幂等去重。</p>
+<p>OpenClaw / Hermes 是「有公网入站地址的 runtime」类接入方，走 §11.2 的 webhook 路径。AgentParty <strong>v0.2.110 起</strong>除规范头 <code>x-agentparty-signature: hmac-sha256=&lt;hex&gt;</code> 外，还发送 Hermes 通用适配器可直接校验的 <code>x-webhook-signature: &lt;hex&gt;</code>；<code>x-request-id: agentparty-&lt;hex(SHA-256(rawBody))&gt;</code> 与 secret 无关，在自动重试和 secret 轮换时保持稳定，供 Hermes 幂等去重。</p>
 <p>接入 SOP：</p>
 <ol>
 <li>Hermes 执行 <code>hermes webhook subscribe agentparty-code-search --secret &lt;S&gt; --prompt '…{channel}…{seq}…{body}…'</code>，并以 <code>hermes gateway run</code> 暴露公网 HTTPS 路由 <code>/webhooks/agentparty-code-search</code>；其它 runtime 暴露等价端点并校验 Bearer/HMAC。</li>

--- a/web/public/docs/spec/index.html
+++ b/web/public/docs/spec/index.html
@@ -2766,12 +2766,14 @@ x-agentparty-signature: hmac-sha256=&lt;hex(HMAC-SHA256(secret, rawBody))&gt;
 
 <h3>11.6 OpenClaw / Hermes 接入</h3>
 
-<p>OpenClaw / Hermes 是「有公网入站地址的 runtime」类接入方，走 §11.2 的 webhook 路径。接入 SOP：</p>
+<p>OpenClaw / Hermes 是「有公网入站地址的 runtime」类接入方，走 §11.2 的 webhook 路径。AgentParty <strong>v0.2.110 起</strong>除规范头 <code>x-agentparty-signature: hmac-sha256=&lt;hex&gt;</code> 外，还发送 Hermes 通用适配器可直接校验的 <code>x-webhook-signature: &lt;hex&gt;</code>；<code>x-request-id: agentparty-&lt;hex&gt;</code> 在自动重试时保持稳定，供 Hermes 幂等去重。</p>
+<p>接入 SOP：</p>
 <ol>
-<li>runtime 暴露一个 <code>/hooks/wake</code> 类端点，能校验 <code>authorization: Bearer</code> 与 <code>x-agentparty-signature</code>。</li>
-<li>在频道注册 <code>party webhook add &lt;ch&gt; --name &lt;runtime 上的 agent 名&gt; --url https://…/hooks/wake --secret &lt;S&gt; --filter mentions</code>。</li>
-<li>该 agent 报到时把 residency 声明为 <code>webhook</code>、<code>wake_kind</code> 为 <code>webhook</code>（否则 <code>wake test</code> 判 <code>not_auto_wakeable</code>）。</li>
-<li>runtime 收到 POST 后拉起对应 agent turn，产出结论时 MUST 用 <code>party send --reply-to &lt;mention_seq&gt;</code> 或 <code>party status … --summary-seq &lt;mention_seq&gt;</code> 回频道，以在账本里形成 resume 链接。</li>
+<li>Hermes 执行 <code>hermes webhook subscribe agentparty-code-search --secret &lt;S&gt; --prompt '…{channel}…{seq}…{body}…'</code>，并以 <code>hermes gateway run</code> 暴露公网 HTTPS 路由 <code>/webhooks/agentparty-code-search</code>；其它 runtime 暴露等价端点并校验 Bearer/HMAC。</li>
+<li>在频道注册 <code>party webhook add &lt;ch&gt; --name hermes-code-search --url https://…/webhooks/agentparty-code-search --secret &lt;S&gt; --filter mentions</code>。</li>
+<li>用 <code>party channel role set hermes-code-search worker &lt;ch&gt; --responsibility "代码搜索：定位仓库、文件、符号和调用链，并给出证据"</code> 固化职责；该 webhook 身份会按注册记录被识别为 <code>residency=webhook</code>、<code>wake_kind=webhook</code>。</li>
+<li>runtime 收到 POST 后拉起对应 agent turn，产出结论时 MUST 用 <code>party send --channel &lt;ch&gt; --reply-to &lt;mention_seq&gt;</code> 或 <code>party status … --summary-seq &lt;mention_seq&gt;</code> 回频道，以在账本里形成 resume 链接。</li>
+<li>最终执行 <code>party wake test @hermes-code-search --channel &lt;ch&gt;</code>；只有 delivery 与 agent_resumed 同时成立才算接入完成，单独的 HTTP 2xx 不足以验收。</li>
 </ol>
 
 <h3>11.7 Prompt Injection 防线</h3>

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -75,6 +75,7 @@ import {
   type WorkflowKind,
 } from "@agentparty/shared";
 import { parseAttachments, parseStoredAttachments } from "./attachments";
+import { sha256Hex } from "./auth";
 import { Server, type Connection, type ConnectionContext, type WSMessage } from "partyserver";
 
 interface ConnState {
@@ -2428,6 +2429,7 @@ export class ChannelDO extends Server<Env> {
   private async deliverWebhook(url: string, secret: string, payload: string): Promise<WebhookDeliveryResult> {
     try {
       const signature = await hmacSha256Hex(secret, payload);
+      const requestId = await sha256Hex(payload);
       const res = await fetch(url, {
         method: "POST",
         body: payload,
@@ -2439,9 +2441,9 @@ export class ChannelDO extends Server<Env> {
           // raw hex digest. Keep AgentParty's namespaced header as the primary
           // contract and send the compatibility header alongside it.
           "x-webhook-signature": signature,
-          // Stable across retries so Hermes can deduplicate a delivery instead
-          // of starting another agent turn after a transient failure.
-          "x-request-id": `agentparty-${signature}`,
+          // Derived only from the immutable payload: stable across retries and
+          // webhook secret rotation, so Hermes starts at most one agent turn.
+          "x-request-id": `agentparty-${requestId}`,
         },
         redirect: "manual",
         signal: AbortSignal.timeout(WEBHOOK_TIMEOUT_MS),

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -2435,6 +2435,13 @@ export class ChannelDO extends Server<Env> {
           "content-type": "application/json",
           authorization: `Bearer ${secret}`,
           "x-agentparty-signature": `hmac-sha256=${signature}`,
+          // Hermes Agent's generic webhook adapter accepts the same HMAC as a
+          // raw hex digest. Keep AgentParty's namespaced header as the primary
+          // contract and send the compatibility header alongside it.
+          "x-webhook-signature": signature,
+          // Stable across retries so Hermes can deduplicate a delivery instead
+          // of starting another agent turn after a transient failure.
+          "x-request-id": `agentparty-${signature}`,
         },
         redirect: "manual",
         signal: AbortSignal.timeout(WEBHOOK_TIMEOUT_MS),

--- a/worker/test/webhooks.spec.ts
+++ b/worker/test/webhooks.spec.ts
@@ -267,7 +267,10 @@ describe("webhooks", () => {
 
     expect(headers.authorization).toBe(`Bearer ${secret}`);
     expect(headers["content-type"]).toBe("application/json");
-    expect(headers["x-agentparty-signature"]).toBe(`hmac-sha256=${await hmacHex(secret, body)}`);
+    const signature = await hmacHex(secret, body);
+    expect(headers["x-agentparty-signature"]).toBe(`hmac-sha256=${signature}`);
+    expect(headers["x-webhook-signature"]).toBe(signature);
+    expect(headers["x-request-id"]).toBe(`agentparty-${signature}`);
     expect(await queueRows(slug)).toHaveLength(0);
   });
 
@@ -312,7 +315,10 @@ describe("webhooks", () => {
       channel: slug,
     });
     expect(headers.authorization).toBe(`Bearer ${secret}`);
-    expect(headers["x-agentparty-signature"]).toBe(`hmac-sha256=${await hmacHex(secret, body)}`);
+    const signature = await hmacHex(secret, body);
+    expect(headers["x-agentparty-signature"]).toBe(`hmac-sha256=${signature}`);
+    expect(headers["x-webhook-signature"]).toBe(signature);
+    expect(headers["x-request-id"]).toBe(`agentparty-${signature}`);
     expect(await queueRows(slug)).toHaveLength(0);
   });
 

--- a/worker/test/webhooks.spec.ts
+++ b/worker/test/webhooks.spec.ts
@@ -49,6 +49,11 @@ async function hmacHex(secret: string, body: string): Promise<string> {
   return [...new Uint8Array(sig)].map((b) => b.toString(16).padStart(2, "0")).join("");
 }
 
+async function sha256Hex(body: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(body));
+  return [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
 function sendMessage(slug: string, token: string, body: string, mentions: string[] = []) {
   return api(`/api/channels/${slug}/messages`, token, {
     method: "POST",
@@ -270,7 +275,7 @@ describe("webhooks", () => {
     const signature = await hmacHex(secret, body);
     expect(headers["x-agentparty-signature"]).toBe(`hmac-sha256=${signature}`);
     expect(headers["x-webhook-signature"]).toBe(signature);
-    expect(headers["x-request-id"]).toBe(`agentparty-${signature}`);
+    expect(headers["x-request-id"]).toBe(`agentparty-${await sha256Hex(body)}`);
     expect(await queueRows(slug)).toHaveLength(0);
   });
 
@@ -318,7 +323,7 @@ describe("webhooks", () => {
     const signature = await hmacHex(secret, body);
     expect(headers["x-agentparty-signature"]).toBe(`hmac-sha256=${signature}`);
     expect(headers["x-webhook-signature"]).toBe(signature);
-    expect(headers["x-request-id"]).toBe(`agentparty-${signature}`);
+    expect(headers["x-request-id"]).toBe(`agentparty-${await sha256Hex(body)}`);
     expect(await queueRows(slug)).toHaveLength(0);
   });
 
@@ -458,14 +463,33 @@ describe("webhooks", () => {
         .status,
     ).toBe(201);
 
-    // 没有 interceptor + disableNetConnect：立即投递失败 → 入队 attempts=1
+    const captured: CapturedRequest[] = [];
+    fetchMock
+      .get("https://down.test")
+      .intercept({ path: "/wake", method: "POST" })
+      .reply(503, (opts) => {
+        captured.push(normalize(opts as { headers?: unknown; body?: unknown }));
+        return "temporarily unavailable";
+      });
+
+    // 首投 503 → 入队 attempts=1
     expect((await sendMessage(slug, token, "@hermes ping", ["hermes"])).status).toBe(200);
     let rows = await queueRows(slug);
     expect(rows).toHaveLength(1);
     expect(rows[0]).toMatchObject({ webhook_name: "hermes", attempts: 1 });
 
-    // 到期后 alarm 重投成功 → 队列清空
-    fetchMock.get("https://down.test").intercept({ path: "/wake", method: "POST" }).reply(200, "ok");
+    // 同名注册轮换 secret；同一 payload 的重试 ID 必须保持不变，HMAC/Bearer 则使用新 secret。
+    expect(
+      (await addWebhook(slug, token, { name: "hermes", url: "https://down.test/wake", secret: "rotated" }))
+        .status,
+    ).toBe(201);
+    fetchMock
+      .get("https://down.test")
+      .intercept({ path: "/wake", method: "POST" })
+      .reply(200, (opts) => {
+        captured.push(normalize(opts as { headers?: unknown; body?: unknown }));
+        return "ok";
+      });
     const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
     await runInDurableObject(stub, async (instance: ChannelDO, state) => {
       state.storage.sql.exec("UPDATE webhook_queue SET next_retry_at = ?", Date.now() - 1);
@@ -473,6 +497,14 @@ describe("webhooks", () => {
     });
     rows = await queueRows(slug);
     expect(rows).toHaveLength(0);
+    expect(captured).toHaveLength(2);
+    expect(captured[1]!.body).toBe(captured[0]!.body);
+    expect(captured[1]!.headers["x-request-id"]).toBe(captured[0]!.headers["x-request-id"]);
+    expect(captured[0]!.headers.authorization).toBe("Bearer s");
+    expect(captured[1]!.headers.authorization).toBe("Bearer rotated");
+    expect(captured[1]!.headers["x-webhook-signature"]).toBe(
+      await hmacHex("rotated", captured[1]!.body),
+    );
   });
 
   it("drops after 3 failed retries and posts a system status to the channel", async () => {


### PR DESCRIPTION
## 改动说明

- 项目 Agent 唤醒上下文新增 `delivery_workflow`：频道 worktree → 创建 PR → 在频道回报 PR URL → 验证部署 → 安全清理
- front agent 报到信息直接展示上述交付链路；对外字段做控制字符清洗与长度限制，base branch 做 shell 转义
- webhook 同时发送 AgentParty HMAC、Hermes 通用 HMAC，以及与 secret 无关的 payload SHA-256 请求 ID，支持 Hermes 直接验签、重试及 secret 轮换去重
- 文档补齐 Hermes 代码搜索职责、接入命令、请求头契约和 `wake test` 验收边界

## 验证

- `bun run check`（首版 head 全部通过：Worker 80 files / 534 tests；Web 742 tests；CLI 及其余门禁全部通过）
- review 修订后：CLI serve 52/52、Worker webhook 11/11、CLI/Worker TypeScript 均通过
- 对抗性覆盖：base branch shell 注入、ready note 控制字符、首投 503 → secret 轮换 → 队列重试的稳定 request ID

## 合并前检查（review-ack 强制闸）

- [x] 我已读上一版 head 的 pr-agent / CodeRabbit review；5 条有效意见已全部处理，等待当前 head 复审
- [x] 本地门禁通过（tsc / 测试 / build）
- [x] 涉及安全/鉴权/数据的改动已做对抗性验证（shell 注入、控制字符、HMAC 与重试幂等）

Closes #492
Closes #493

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * Webhook 新增 `x-webhook-signature` 与稳定的 `x-request-id`（基于请求体摘要），支持校验与跨重试去重。
  * 项目服务状态展示强化交付路径：包含 worktree→PR→回传链接→部署验证→安全清理链路，并对展示内容进行长度/控制字符清理。
* **文档**
  * 补充 Hermes Agent 接入与唤醒/回执闭环说明，更新验收以“投递与恢复回执同时成立”为准。
* **测试**
  * 覆盖清理与交付链断言、并验证新增 webhook 头在重试与密钥轮换场景下保持一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->