### PR TITLE
fix(worker): 修复 webhook 成功后错误返回 500

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -196,6 +196,17 @@ async function fetchChannelDO(env: AppEnv, slug: string, request: Request | (() 
   throw lastError;
 }
 
+// Responses returned by Durable Object fetches have immutable headers in the
+// production Workers runtime. Hono's response middleware appends headers after
+// the handler returns, so copy the response into a fresh, mutable wrapper first.
+export function mutableFetchResponse(response: Response): Response {
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+}
+
 function parseRoleResponsibility(body: Record<string, unknown> | null): { present: boolean; value: string | null } | null {
   if (body === null || !Object.prototype.hasOwnProperty.call(body, "responsibility")) {
     return { present: false, value: null };
@@ -6093,7 +6104,7 @@ app.post("/api/channels/:slug/webhooks", async (c) => {
       metadata: { webhook_filter: filter },
     });
   }
-  return response;
+  return mutableFetchResponse(response);
 });
 
 app.get("/api/channels/:slug/webhooks", async (c) => {
@@ -6144,7 +6155,7 @@ app.delete("/api/channels/:slug/webhooks/:name", async (c) => {
       channel: slug,
     });
   }
-  return response;
+  return mutableFetchResponse(response);
 });
 
 // #105：列出死信（重试耗尽 / 队列满被永久放弃的投递）。与 webhook 管理同权限：仅房主 / ap_ token。
@@ -6190,7 +6201,7 @@ app.post("/api/channels/:slug/webhooks/:name/redeliver", async (c) => {
       channel: slug,
     });
   }
-  return response;
+  return mutableFetchResponse(response);
 });
 
 app.post("/api/channels/:slug/archive", async (c) => {

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -203,7 +203,7 @@ export function mutableFetchResponse(response: Response): Response {
   return new Response(response.body, {
     status: response.status,
     statusText: response.statusText,
-    headers: response.headers,
+    headers: new Headers(response.headers),
   });
 }
 

--- a/worker/test/webhook-redeliver.spec.ts
+++ b/worker/test/webhook-redeliver.spec.ts
@@ -112,8 +112,12 @@ describe("webhook dead-letter persistence + redeliver", () => {
     expect(await deadLetterRows(slug)).toHaveLength(1);
 
     fetchMock.get("https://revive.test").intercept({ path: "/wake", method: "POST" }).reply(200, "ok");
-    const res = await api(`/api/channels/${slug}/webhooks/${hook}/redeliver`, token, { method: "POST" });
+    const res = await api(`/api/channels/${slug}/webhooks/${hook}/redeliver`, token, {
+      method: "POST",
+      headers: { origin: "http://agentparty-ui.localhost" },
+    });
     expect(res.status).toBe(200);
+    expect(res.headers.get("access-control-allow-origin")).toBe("http://agentparty-ui.localhost");
     expect((await res.json()) as { redelivered: number; failed: number }).toMatchObject({
       redelivered: 1,
       failed: 0,

--- a/worker/test/webhooks.spec.ts
+++ b/worker/test/webhooks.spec.ts
@@ -163,13 +163,18 @@ describe("webhooks", () => {
       expect(unsafe.status).toBe(400);
     }
 
-    const created = await addWebhook(slug, agent.token, {
-      name: "hermes",
-      url: "https://hooks.test/wake",
-      secret: "super-secret",
-      filter: "mentions",
+    const created = await api(`/api/channels/${slug}/webhooks`, agent.token, {
+      method: "POST",
+      headers: { origin: "http://agentparty-ui.localhost" },
+      body: JSON.stringify({
+        name: "hermes",
+        url: "https://hooks.test/wake",
+        secret: "super-secret",
+        filter: "mentions",
+      }),
     });
     expect(created.status).toBe(201);
+    expect(created.headers.get("access-control-allow-origin")).toBe("http://agentparty-ui.localhost");
 
     const list = await api(`/api/channels/${slug}/webhooks`, agent.token);
     expect(list.status).toBe(200);
@@ -185,8 +190,12 @@ describe("webhooks", () => {
 
     const roDelete = await api(`/api/channels/${slug}/webhooks/hermes`, ro.token, { method: "DELETE" });
     expect(roDelete.status).toBe(403);
-    const del = await api(`/api/channels/${slug}/webhooks/hermes`, agent.token, { method: "DELETE" });
+    const del = await api(`/api/channels/${slug}/webhooks/hermes`, agent.token, {
+      method: "DELETE",
+      headers: { origin: "http://agentparty-ui.localhost" },
+    });
     expect(del.status).toBe(200);
+    expect(del.headers.get("access-control-allow-origin")).toBe("http://agentparty-ui.localhost");
     const again = await api(`/api/channels/${slug}/webhooks/hermes`, agent.token, { method: "DELETE" });
     expect(again.status).toBe(404);
     const empty = (await (await api(`/api/channels/${slug}/webhooks`, agent.token)).json()) as {

--- a/worker/test/webhooks.spec.ts
+++ b/worker/test/webhooks.spec.ts
@@ -3,6 +3,7 @@ import { fetchMock } from "./fetch-mock";
 import { LOOP_GUARD_N, MAX_WEBHOOKS_PER_CHANNEL, WEBHOOK_MAX_RETRIES } from "@agentparty/shared";
 import { afterEach, beforeAll, describe, expect, it } from "vitest";
 import type { ChannelDO } from "../src/do";
+import { mutableFetchResponse } from "../src/index";
 import { api, createChannel, disableLoopGuard, postMessage, seedToken, uniq } from "./helpers";
 
 beforeAll(() => {
@@ -90,6 +91,17 @@ async function queueRows(slug: string) {
 }
 
 describe("webhooks", () => {
+  it("copies immutable Durable Object responses before Hono appends headers (#495)", () => {
+    const upstream = Response.redirect("https://do/internal/webhooks", 302);
+    expect(() => upstream.headers.set("x-regression", "broken")).toThrow();
+
+    const response = mutableFetchResponse(upstream);
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe("https://do/internal/webhooks");
+    expect(() => response.headers.set("x-regression", "fixed")).not.toThrow();
+    expect(response.headers.get("x-regression")).toBe("fixed");
+  });
+
   it("registers, lists without leaking secret, deletes; readonly is rejected", async () => {
     const agent = await seedToken("agent");
     const ro = await seedToken("readonly");


### PR DESCRIPTION
Closes #495

## 改动

- 把 Durable Object 返回的 Response 复制到 headers 可修改的新 Response
- 覆盖 webhook 注册、删除和 dead-letter redeliver 三个直接返回 DO Response 的端点
- 新增 immutable headers 回归测试，证明 Hono 可继续追加响应头

## 验证

- `bunx vitest run test/webhooks.spec.ts`：12/12
- `bunx tsc --noEmit`
- `git diff --check`
- 线上复现：DO 已返回 201，但外层因 `TypeError: Can't modify immutable headers.` 错回 500

## 合并前检查（review-ack 强制闸）

- [x] 已读取当前 head 的 PR Agent review
- [ ] 等待并读取当前 head 的 CodeRabbit review
- [x] 本地针对性测试、类型检查、diff 检查通过
- [x] 变更范围只覆盖 #495


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复 Webhook 管理及死信重新投递成功路径中，后续追加响应头失败导致请求不可用的问题。
  * 保持原有响应状态（含 302 重定向）与关键响应头不变，并允许在成功路径中继续添加新的响应头。
  * Webhook 相关请求补齐并验证响应的 `access-control-allow-origin` 与预期 origin 一致。
* **Tests**
  * 新增回归测试：验证在上游返回不可变响应头的情况下，仍可成功写入并读取新增的响应头。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->