### PR TITLE
fix(web): 补齐提及信息卡与触屏交互

### DIFF
--- a/web/src/components/MessageCard.presence.test.tsx
+++ b/web/src/components/MessageCard.presence.test.tsx
@@ -94,13 +94,16 @@ function textContent(node: ReactTestInstance): string {
 }
 
 function senderCardText(root: ReactTestInstance): string {
-  const card = root.find((n) => n.type === "aside" && String(n.props.className ?? "").includes("msg-agent-card"));
+  const card = root.find((n) => n.type === "aside" && String(n.props.id ?? "").startsWith("agent-info-") && !String(n.props.id).includes("-mention-"));
   return textContent(card);
 }
 
-function mentionTitle(root: ReactTestInstance): string | undefined {
-  const span = root.find((n) => n.type === "span" && String(n.props.className ?? "").includes("msg-mention"));
-  return span.props.title as string | undefined;
+function mentionCard(root: ReactTestInstance): ReactTestInstance {
+  return root.find((n) => n.type === "aside" && String(n.props.id ?? "").includes("-mention-"));
+}
+
+function mentionTrigger(root: ReactTestInstance): ReactTestInstance {
+  return root.find((n) => n.type === "button" && String(n.props.className ?? "").includes("msg-mention"));
 }
 
 afterEach(() => {
@@ -162,7 +165,7 @@ describe("发送者即时信息卡/@提及悬停展示实时状态 (#274/#490)",
     expect(card).toContain("Current work#510 · working");
   });
 
-  test("sender 与 @ 悬停都能看到频道公开职责", () => {
+  test("sender 与 @ 都使用完整信息卡展示公开职责", () => {
     const role = {
       name: "planner",
       role: "worker",
@@ -176,7 +179,24 @@ describe("发送者即时信息卡/@提及悬停展示实时状态 (#274/#490)",
     });
     expect(senderCardText(root)).toContain("Role & divisionworker · 先读 issue，再实现和验证");
     expect(senderCardText(root)).toContain("Current work实现中 · working");
-    expect(mentionTitle(root)).toContain("responsibility: 先读 issue，再实现和验证");
+    expect(textContent(mentionCard(root))).toContain("Role & divisionworker · 先读 issue，再实现和验证");
+    expect(textContent(mentionCard(root))).toContain("Current work实现中 · working");
+  });
+
+  test("移动端点击 @提及会显式打开信息卡，再次点击关闭", () => {
+    const root = render(baseMsg({ mentions: ["planner"] }), {
+      presence: { planner: presenceEntry({ note: "实现中" }) },
+    });
+    const trigger = mentionTrigger(root);
+    let blurred = false;
+    const clickEvent = { currentTarget: { blur: () => { blurred = true; } } };
+    expect(trigger.props["aria-expanded"]).toBe(false);
+    act(() => trigger.props.onClick(clickEvent));
+    expect(mentionTrigger(root).props["aria-expanded"]).toBe(true);
+    expect(mentionCard(root).parent?.props.className).toContain("msg-agent-popover--open");
+    act(() => mentionTrigger(root).props.onClick(clickEvent));
+    expect(mentionTrigger(root).props["aria-expanded"]).toBe(false);
+    expect(blurred).toBe(true);
   });
 
   test("不传 presence（或查不到该名字）时 sender 信息卡明确显示未上报", () => {
@@ -225,14 +245,14 @@ describe("发送者即时信息卡/@提及悬停展示实时状态 (#274/#490)",
     expect(blurred).toBe(true);
   });
 
-  test("@提及悬停也能看到该名字的状态；presence 查不到时 title 保持缺省", () => {
+  test("@提及信息卡展示该名字的状态；presence 查不到时明确显示未上报", () => {
     const withPresence = render(baseMsg({ mentions: ["reviewer"] }), {
       presence: { reviewer: presenceEntry({ name: "reviewer", state: "waiting", current_task: 42 }) },
     });
-    expect(mentionTitle(withPresence)).toBe("status: waiting\ntask: #42");
+    expect(textContent(mentionCard(withPresence))).toContain("Current work#42 · waiting");
     act(() => renderer?.unmount());
 
     const withoutPresence = render(baseMsg({ mentions: ["reviewer"] }));
-    expect(mentionTitle(withoutPresence)).toBeUndefined();
+    expect(textContent(mentionCard(withoutPresence))).toContain("Current workNot reported");
   });
 });

--- a/web/src/components/MessageCard.presence.test.tsx
+++ b/web/src/components/MessageCard.presence.test.tsx
@@ -11,8 +11,33 @@ mock.module("../lib/markdown", () => ({ renderMarkdown: (s: string) => s }));
 const { MessageCard, agentInfoTitleBits, presenceTitleBits } = await import("./MessageCard");
 
 let renderer: ReactTestRenderer | null = null;
+let windowEvents: TestEventTarget;
+let documentEvents: TestEventTarget;
+const insidePopoverTarget = {};
 
 const noop = () => undefined;
+
+class TestEventTarget {
+  private listeners = new Map<string, Set<(event: unknown) => void>>();
+
+  addEventListener(type: string, listener: (event: unknown) => void) {
+    const listeners = this.listeners.get(type) ?? new Set();
+    listeners.add(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  removeEventListener(type: string, listener: (event: unknown) => void) {
+    this.listeners.get(type)?.delete(listener);
+  }
+
+  emit(type: string, event: unknown) {
+    for (const listener of this.listeners.get(type) ?? []) listener(event);
+  }
+
+  count(type: string) {
+    return this.listeners.get(type)?.size ?? 0;
+  }
+}
 
 function memoryStorage(): Storage {
   const values = new Map<string, string>();
@@ -27,8 +52,12 @@ function memoryStorage(): Storage {
 }
 
 beforeEach(() => {
+  windowEvents = new TestEventTarget();
+  documentEvents = new TestEventTarget();
   Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", { configurable: true, value: true });
   Object.defineProperty(globalThis, "localStorage", { configurable: true, value: memoryStorage() });
+  Object.defineProperty(globalThis, "window", { configurable: true, value: windowEvents });
+  Object.defineProperty(globalThis, "document", { configurable: true, value: documentEvents });
 });
 
 function baseMsg(overrides: Partial<MsgFrame>): MsgFrame {
@@ -84,6 +113,16 @@ function render(msg: MsgFrame, extra: Record<string, unknown> = {}, locale: "en"
           {...extra}
         />
       </LocaleProvider>,
+      {
+        createNodeMock(element) {
+          const className = String((element.props as { className?: string }).className ?? "");
+          if (className.includes("msg-agent-popover")) {
+            return { contains: (target: unknown) => target === insidePopoverTarget };
+          }
+          if (className.includes("msg-agent-trigger")) return { blur: noop };
+          return {};
+        },
+      },
     );
   });
   return renderer!.root;
@@ -109,6 +148,8 @@ function mentionTrigger(root: ReactTestInstance): ReactTestInstance {
 afterEach(() => {
   act(() => renderer?.unmount());
   renderer = null;
+  Reflect.deleteProperty(globalThis, "window");
+  Reflect.deleteProperty(globalThis, "document");
 });
 
 describe("presenceTitleBits (#274)", () => {
@@ -196,7 +237,31 @@ describe("发送者即时信息卡/@提及悬停展示实时状态 (#274/#490)",
     expect(mentionCard(root).parent?.props.className).toContain("msg-agent-popover--open");
     act(() => mentionTrigger(root).props.onClick(clickEvent));
     expect(mentionTrigger(root).props["aria-expanded"]).toBe(false);
+    expect(mentionCard(root).parent?.props.className).toContain("msg-agent-popover--closed");
     expect(blurred).toBe(true);
+  });
+
+  test("打开 @提及信息卡后，站内点击保留，站外点击与 Escape 都会收起", () => {
+    const root = render(baseMsg({ mentions: ["planner"] }));
+    const clickEvent = { currentTarget: { blur: noop } };
+
+    act(() => mentionTrigger(root).props.onClick(clickEvent));
+    expect(documentEvents.count("pointerdown")).toBe(1);
+    expect(windowEvents.count("keydown")).toBe(1);
+
+    act(() => documentEvents.emit("pointerdown", { target: insidePopoverTarget }));
+    expect(mentionTrigger(root).props["aria-expanded"]).toBe(true);
+
+    act(() => documentEvents.emit("pointerdown", { target: {} }));
+    expect(mentionTrigger(root).props["aria-expanded"]).toBe(false);
+    expect(mentionCard(root).parent?.props.className).toContain("msg-agent-popover--closed");
+    expect(documentEvents.count("pointerdown")).toBe(0);
+
+    act(() => mentionTrigger(root).props.onClick(clickEvent));
+    act(() => windowEvents.emit("keydown", { key: "Escape" }));
+    expect(mentionTrigger(root).props["aria-expanded"]).toBe(false);
+    expect(mentionCard(root).parent?.props.className).toContain("msg-agent-popover--closed");
+    expect(windowEvents.count("keydown")).toBe(0);
   });
 
   test("不传 presence（或查不到该名字）时 sender 信息卡明确显示未上报", () => {
@@ -210,6 +275,7 @@ describe("发送者即时信息卡/@提及悬停展示实时状态 (#274/#490)",
     const root = render(baseMsg({ mentions: ["reviewer"] }), {}, "zh");
     expect(senderCardText(root)).toContain("身份agent");
     expect(senderCardText(root)).toContain("进行中的工作未上报");
+    expect(textContent(mentionCard(root))).toContain("身份未上报");
     expect(textContent(mentionCard(root))).toContain("角色与分工未上报");
   });
 
@@ -245,9 +311,11 @@ describe("发送者即时信息卡/@提及悬停展示实时状态 (#274/#490)",
     const root = render(baseMsg({}));
     const trigger = root.find((n) => n.type === "button" && String(n.props.className ?? "").includes("msg-agent-trigger"));
     let blurred = false;
-    trigger.props.onKeyDown({
-      key: "Escape",
-      currentTarget: { blur: () => { blurred = true; } },
+    act(() => {
+      trigger.props.onKeyDown({
+        key: "Escape",
+        currentTarget: { blur: () => { blurred = true; } },
+      });
     });
     expect(blurred).toBe(true);
   });
@@ -261,5 +329,23 @@ describe("发送者即时信息卡/@提及悬停展示实时状态 (#274/#490)",
 
     const withoutPresence = render(baseMsg({ mentions: ["reviewer"] }));
     expect(textContent(mentionCard(withoutPresence))).toContain("Current workNot reported");
+  });
+
+  test("离线 @agent 从 presence 快照恢复身份和 owner，不伪装成在线参与者", () => {
+    const root = render(baseMsg({ mentions: ["reviewer"] }), {
+      presence: {
+        reviewer: presenceEntry({ name: "reviewer", kind: "agent", account: "owner-a" }),
+      },
+    });
+    expect(textContent(mentionCard(root))).toContain("Identityagent · owner-a");
+  });
+
+  test("离线 @human 从 identity map 恢复人类身份和账号", () => {
+    const root = render(baseMsg({ mentions: ["reviewer"] }), {
+      identityDisplay: {
+        reviewer: { display: "Alice", kind: "human", account: "alice@example.com" },
+      },
+    });
+    expect(textContent(mentionCard(root))).toContain("Identityhuman · alice@example.com");
   });
 });

--- a/web/src/components/MessageCard.presence.test.tsx
+++ b/web/src/components/MessageCard.presence.test.tsx
@@ -58,8 +58,8 @@ function presenceEntry(overrides: Partial<PresenceEntry>): PresenceEntry {
   } as PresenceEntry;
 }
 
-function render(msg: MsgFrame, extra: Record<string, unknown> = {}) {
-  localStorage.setItem("ap_locale", "en");
+function render(msg: MsgFrame, extra: Record<string, unknown> = {}, locale: "en" | "zh" = "en") {
+  localStorage.setItem("ap_locale", locale);
   act(() => {
     renderer = create(
       <LocaleProvider>
@@ -204,6 +204,13 @@ describe("发送者即时信息卡/@提及悬停展示实时状态 (#274/#490)",
     const card = senderCardText(root);
     expect(card).toContain("@planner");
     expect(card).toContain("Current workNot reported");
+  });
+
+  test("中文 locale 使用同步的信息卡文案", () => {
+    const root = render(baseMsg({ mentions: ["reviewer"] }), {}, "zh");
+    expect(senderCardText(root)).toContain("身份agent");
+    expect(senderCardText(root)).toContain("进行中的工作未上报");
+    expect(textContent(mentionCard(root))).toContain("角色与分工未上报");
   });
 
   test("信息卡展示 leader、分工和最近三项工作", () => {

--- a/web/src/components/MessageCard.tsx
+++ b/web/src/components/MessageCard.tsx
@@ -49,6 +49,8 @@ interface Props {
   agentRoles?: Record<string, ChannelRoleAssignment>;
   // #490：发送者信息卡展示最近工作；Channel 已按 agent 截成最多三条，避免卡片自己反复扫整段历史。
   recentMessages?: MsgFrame[];
+  // #490 follow-up：@提及也复用同一张完整信息卡，因此需要按被提及 agent 取最近工作。
+  recentMessagesByAgent?: ReadonlyMap<string, MsgFrame[]>;
   // 频道决策协议（#284）：人类/moderator 是否可对本条 decision_request 拍板 + 回调。
   canRespondDecision?: boolean;
   decisionBusy?: boolean;
@@ -158,6 +160,7 @@ function AgentInfoPopover({
   entry,
   assignment,
   recentMessages,
+  triggerClassName,
 }: {
   id: string;
   label: string;
@@ -167,8 +170,12 @@ function AgentInfoPopover({
   entry: PresenceEntry | undefined;
   assignment: ChannelRoleAssignment | undefined;
   recentMessages: MsgFrame[];
+  triggerClassName: string;
 }) {
   const t = useT();
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
   const leader = assignment?.reports_to ?? entry?.lineage?.parent_agent ?? null;
   const role = assignment?.role ?? entry?.role ?? null;
   const responsibility = assignment?.responsibility?.trim() || null;
@@ -179,14 +186,41 @@ function AgentInfoPopover({
     .map((message) => ({ message, text: activityLine(message) }))
     .filter((item) => item.text !== "")
     .slice(0, 3);
+  useEffect(() => {
+    if (!open || typeof document === "undefined" || typeof window === "undefined") return;
+    const onPointerDown = (event: PointerEvent) => {
+      if (!rootRef.current?.contains(event.target as Node | null)) {
+        triggerRef.current?.blur();
+        setOpen(false);
+      }
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("pointerdown", onPointerDown);
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown);
+      window.removeEventListener("keydown", onKeyDown);
+    };
+  }, [open]);
   return (
-    <div className="msg-agent-popover">
+    <div ref={rootRef} className={`msg-agent-popover${open ? " msg-agent-popover--open" : ""}`}>
       <button
+        ref={triggerRef}
         type="button"
-        className="msg-sender msg-agent-trigger"
+        className={`${triggerClassName} msg-agent-trigger`}
         aria-describedby={id}
+        aria-expanded={open}
+        onClick={(event) => {
+          if (open) event.currentTarget.blur();
+          setOpen((value) => !value);
+        }}
         onKeyDown={(event) => {
-          if (event.key === "Escape") event.currentTarget.blur();
+          if (event.key === "Escape") {
+            setOpen(false);
+            event.currentTarget.blur();
+          }
         }}
       >
         {label}
@@ -263,6 +297,7 @@ function MessageCardImpl({
   presence,
   agentRoles,
   recentMessages = [],
+  recentMessagesByAgent,
   canRespondDecision,
   decisionBusy,
   onDecisionRespond,
@@ -506,6 +541,7 @@ function MessageCardImpl({
           entry={presence?.[msg.sender.name]}
           assignment={agentRoles?.[msg.sender.name]}
           recentMessages={recentMessages}
+          triggerClassName="msg-sender"
         />
         {/* owner(lark 长 id）不再每条平铺——它已在 senderTitle 里，悬停发送者名即见；
            防冒充锚点保留在 tooltip + kind 徽章，行内只留重要内容（名字/类型/提及）。 */}
@@ -535,17 +571,20 @@ function MessageCardImpl({
           </span>
         )}
         {msg.mentions.map((m) => {
-          // #274：@提及悬停也能看到该名字的实时状态；原始名与显示名不同时保留 @原名防冒充锚点。
-          const mentionTitle = [
-            m === displayForIdentity(m, identityDisplay) ? null : `@${m}`,
-            ...agentInfoTitleBits(presence?.[m], agentRoles?.[m]),
-          ]
-            .filter((part): part is string => part !== null)
-            .join("\n");
+          const mentionedSender = participants?.find((participant) => participant.name === m);
           return (
-            <span key={m} className="msg-mention" title={mentionTitle !== "" ? mentionTitle : undefined}>
-              @{displayForIdentity(m, identityDisplay)}
-            </span>
+            <AgentInfoPopover
+              key={m}
+              id={`agent-info-${msg.seq}-mention-${m}`}
+              label={`@${displayForIdentity(m, identityDisplay)}`}
+              name={m}
+              kind={mentionedSender?.kind ?? "agent"}
+              owner={mentionedSender?.owner ?? null}
+              entry={presence?.[m]}
+              assignment={agentRoles?.[m]}
+              recentMessages={recentMessagesByAgent?.get(m) ?? (m === msg.sender.name ? recentMessages : [])}
+              triggerClassName="msg-mention"
+            />
           );
         })}
         {msg.reply_to !== null && quotedMessage === null && <span className="msg-reply">↩ #{msg.reply_to}</span>}

--- a/web/src/components/MessageCard.tsx
+++ b/web/src/components/MessageCard.tsx
@@ -1,7 +1,7 @@
 // 消息渲染：message → doodle 卡片外壳 + mono 元信息 + markdown 正文；
 // status → 时间线分隔条（spec §9 第 2 块）。
 import type { AgentContext, ChannelRoleAssignment, MsgFrame, PresenceEntry, ReadCursor, Sender } from "@agentparty/shared";
-import { memo, useEffect, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useRef, useState } from "react";
 import type { CSSProperties } from "react";
 import { agentHue } from "../lib/agentColor";
 import { isClientVersionOutdated, useMinClientVersion } from "../lib/clientVersion";
@@ -16,6 +16,7 @@ import type { MentionReceipt } from "../lib/wakeReceipt";
 import { AttachmentList } from "./AttachmentList";
 import { Markdown } from "./Markdown";
 import { MessageStatus } from "./MessageStatus";
+import { useDismissableLayer } from "./useDismissableLayer";
 
 interface Props {
   msg: MsgFrame;
@@ -176,6 +177,10 @@ function AgentInfoPopover({
   const [open, setOpen] = useState(false);
   const rootRef = useRef<HTMLDivElement | null>(null);
   const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const dismiss = useCallback(() => {
+    triggerRef.current?.blur();
+    setOpen(false);
+  }, []);
   const leader = assignment?.reports_to ?? entry?.lineage?.parent_agent ?? null;
   const role = assignment?.role ?? entry?.role ?? null;
   const responsibility = assignment?.responsibility?.trim() || null;
@@ -186,24 +191,11 @@ function AgentInfoPopover({
     .map((message) => ({ message, text: activityLine(message) }))
     .filter((item) => item.text !== "")
     .slice(0, 3);
-  useEffect(() => {
-    if (!open || typeof document === "undefined" || typeof window === "undefined") return;
-    const onPointerDown = (event: PointerEvent) => {
-      if (!rootRef.current?.contains(event.target as Node | null)) {
-        triggerRef.current?.blur();
-        setOpen(false);
-      }
-    };
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") setOpen(false);
-    };
-    document.addEventListener("pointerdown", onPointerDown);
-    window.addEventListener("keydown", onKeyDown);
-    return () => {
-      document.removeEventListener("pointerdown", onPointerDown);
-      window.removeEventListener("keydown", onKeyDown);
-    };
-  }, [open]);
+  useDismissableLayer({
+    active: open && typeof document !== "undefined" && typeof window !== "undefined",
+    onDismiss: dismiss,
+    outsideRef: rootRef,
+  });
   return (
     <div ref={rootRef} className={`msg-agent-popover${open ? " msg-agent-popover--open" : ""}`}>
       <button
@@ -218,8 +210,8 @@ function AgentInfoPopover({
         }}
         onKeyDown={(event) => {
           if (event.key === "Escape") {
-            setOpen(false);
             event.currentTarget.blur();
+            dismiss();
           }
         }}
       >

--- a/web/src/components/MessageCard.tsx
+++ b/web/src/components/MessageCard.tsx
@@ -166,7 +166,7 @@ function AgentInfoPopover({
   id: string;
   label: string;
   name: string;
-  kind: Sender["kind"];
+  kind: Sender["kind"] | null;
   owner: string | null;
   entry: PresenceEntry | undefined;
   assignment: ChannelRoleAssignment | undefined;
@@ -175,11 +175,13 @@ function AgentInfoPopover({
 }) {
   const t = useT();
   const [open, setOpen] = useState(false);
+  const [suppressed, setSuppressed] = useState(false);
   const rootRef = useRef<HTMLDivElement | null>(null);
   const triggerRef = useRef<HTMLButtonElement | null>(null);
   const dismiss = useCallback(() => {
     triggerRef.current?.blur();
     setOpen(false);
+    setSuppressed(true);
   }, []);
   const leader = assignment?.reports_to ?? entry?.lineage?.parent_agent ?? null;
   const role = assignment?.role ?? entry?.role ?? null;
@@ -197,7 +199,16 @@ function AgentInfoPopover({
     outsideRef: rootRef,
   });
   return (
-    <div ref={rootRef} className={`msg-agent-popover${open ? " msg-agent-popover--open" : ""}`}>
+    <div
+      ref={rootRef}
+      className={`msg-agent-popover${open ? " msg-agent-popover--open" : ""}${suppressed ? " msg-agent-popover--closed" : ""}`}
+      onMouseEnter={() => {
+        if (!open) setSuppressed(false);
+      }}
+      onMouseLeave={() => {
+        if (!open) setSuppressed(false);
+      }}
+    >
       <button
         ref={triggerRef}
         type="button"
@@ -205,9 +216,16 @@ function AgentInfoPopover({
         aria-describedby={id}
         aria-expanded={open}
         onClick={(event) => {
-          if (open) event.currentTarget.blur();
-          setOpen((value) => !value);
+          if (open) {
+            event.currentTarget.blur();
+            setOpen(false);
+            setSuppressed(true);
+          } else {
+            setSuppressed(false);
+            setOpen(true);
+          }
         }}
+        onFocus={() => setSuppressed(false)}
         onKeyDown={(event) => {
           if (event.key === "Escape") {
             event.currentTarget.blur();
@@ -225,7 +243,7 @@ function AgentInfoPopover({
         <dl className="msg-agent-card-facts">
           <div>
             <dt>{t("MessageCard.agentCard.identity")}</dt>
-            <dd>{[kind, owner].filter(Boolean).join(" · ")}</dd>
+            <dd>{[kind, owner].filter(Boolean).join(" · ") || t("MessageCard.agentCard.none")}</dd>
           </div>
           <div>
             <dt>{t("MessageCard.agentCard.leader")}</dt>
@@ -564,15 +582,17 @@ function MessageCardImpl({
         )}
         {msg.mentions.map((m) => {
           const mentionedSender = participants?.find((participant) => participant.name === m);
+          const mentionedPresence = presence?.[m];
+          const mentionedIdentity = identityDisplay?.[m];
           return (
             <AgentInfoPopover
               key={m}
               id={`agent-info-${msg.seq}-mention-${m}`}
               label={`@${displayForIdentity(m, identityDisplay)}`}
               name={m}
-              kind={mentionedSender?.kind ?? "agent"}
-              owner={mentionedSender?.owner ?? null}
-              entry={presence?.[m]}
+              kind={mentionedSender?.kind ?? mentionedPresence?.kind ?? mentionedIdentity?.kind ?? null}
+              owner={mentionedSender?.owner ?? mentionedPresence?.account ?? mentionedIdentity?.account ?? null}
+              entry={mentionedPresence}
               assignment={agentRoles?.[m]}
               recentMessages={recentMessagesByAgent?.get(m) ?? (m === msg.sender.name ? recentMessages : [])}
               triggerClassName="msg-mention"

--- a/web/src/pages/Channel.tsx
+++ b/web/src/pages/Channel.tsx
@@ -2196,6 +2196,7 @@ function TeamThread({
             presence={presence}
             agentRoles={agentRoles}
             recentMessages={recentMessagesByAgent.get(message.sender.name) ?? EMPTY_RECENT_MESSAGES}
+            recentMessagesByAgent={recentMessagesByAgent}
             quotedMessage={message.reply_to !== null ? messageBySeq.get(message.reply_to) ?? null : null}
             onReply={onReply}
             onEdit={onEdit}
@@ -4118,6 +4119,7 @@ export function ChannelPage({
                   presence={state.presence}
                   agentRoles={channelRolesByName}
                   recentMessages={recentMessagesByAgent.get(item.message.sender.name) ?? EMPTY_RECENT_MESSAGES}
+                  recentMessagesByAgent={recentMessagesByAgent}
                   quotedMessage={item.message.reply_to !== null ? messageBySeq.get(item.message.reply_to) ?? null : null}
                   onReply={startReply}
                   onEdit={startEdit}

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -2658,8 +2658,8 @@
   transform: translateY(-2px);
   transition: opacity 60ms linear, transform 60ms linear, visibility 0s linear 60ms;
 }
-.msg-agent-popover:hover .msg-agent-card,
-.msg-agent-popover:focus-within .msg-agent-card,
+.msg-agent-popover:not(.msg-agent-popover--closed):hover .msg-agent-card,
+.msg-agent-popover:not(.msg-agent-popover--closed):focus-within .msg-agent-card,
 .msg-agent-popover--open .msg-agent-card {
   opacity: 1;
   visibility: visible;

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -2659,7 +2659,8 @@
   transition: opacity 60ms linear, transform 60ms linear, visibility 0s linear 60ms;
 }
 .msg-agent-popover:hover .msg-agent-card,
-.msg-agent-popover:focus-within .msg-agent-card {
+.msg-agent-popover:focus-within .msg-agent-card,
+.msg-agent-popover--open .msg-agent-card {
   opacity: 1;
   visibility: visible;
   pointer-events: auto;
@@ -5444,6 +5445,14 @@
     left: 8px !important;
     width: calc(100vw - 16px) !important;
     max-height: 58vh;
+  }
+  /* 触屏没有可靠 hover，信息卡按底部 sheet 展示，避免靠近右侧的 @ 名字把卡片推出视口。 */
+  .msg-agent-card {
+    position: fixed;
+    inset: auto 10px max(10px, env(safe-area-inset-bottom));
+    width: auto;
+    max-height: min(70dvh, 560px);
+    overflow: auto;
   }
   /* 工具条：窄屏收成单行横向滚动带（与 .side 频道条同样的处理），把纵向空间还给消息流。
      原先三组按钮各占满整行、内部再换行，会堆成 5-6 行（实测约 232px），把消息流挤到只剩一条缝。

--- a/web/src/styles/app.taskAndAgentCard.test.ts
+++ b/web/src/styles/app.taskAndAgentCard.test.ts
@@ -15,7 +15,7 @@ describe("task title containment (#489)", () => {
 describe("agent hover/touch card (#490)", () => {
   test("opens immediately on hover, keyboard focus, or explicit touch click", () => {
     expect(css).toMatch(/\.msg-agent-card\s*\{[^}]*transition:\s*opacity 60ms linear/s);
-    expect(css).toMatch(/\.msg-agent-popover:hover \.msg-agent-card,[\s\S]*\.msg-agent-popover:focus-within \.msg-agent-card,[\s\S]*\.msg-agent-popover--open \.msg-agent-card\s*\{[^}]*visibility:\s*visible;/s);
+    expect(css).toMatch(/\.msg-agent-popover:not\(\.msg-agent-popover--closed\):hover \.msg-agent-card,[\s\S]*\.msg-agent-popover:not\(\.msg-agent-popover--closed\):focus-within \.msg-agent-card,[\s\S]*\.msg-agent-popover--open \.msg-agent-card\s*\{[^}]*visibility:\s*visible;/s);
     expect(css).toMatch(/@media \(max-width:\s*760px\)[\s\S]*\.msg-agent-card\s*\{[^}]*position:\s*fixed;[^}]*inset:\s*auto 10px[^}]*max-height:\s*min\(70dvh, 560px\);/s);
   });
 });

--- a/web/src/styles/app.taskAndAgentCard.test.ts
+++ b/web/src/styles/app.taskAndAgentCard.test.ts
@@ -12,9 +12,10 @@ describe("task title containment (#489)", () => {
   });
 });
 
-describe("agent hover card (#490)", () => {
-  test("opens immediately on hover or keyboard focus without a native tooltip delay", () => {
+describe("agent hover/touch card (#490)", () => {
+  test("opens immediately on hover, keyboard focus, or explicit touch click", () => {
     expect(css).toMatch(/\.msg-agent-card\s*\{[^}]*transition:\s*opacity 60ms linear/s);
-    expect(css).toMatch(/\.msg-agent-popover:hover \.msg-agent-card,[\s\S]*\.msg-agent-popover:focus-within \.msg-agent-card\s*\{[^}]*visibility:\s*visible;/s);
+    expect(css).toMatch(/\.msg-agent-popover:hover \.msg-agent-card,[\s\S]*\.msg-agent-popover:focus-within \.msg-agent-card,[\s\S]*\.msg-agent-popover--open \.msg-agent-card\s*\{[^}]*visibility:\s*visible;/s);
+    expect(css).toMatch(/@media \(max-width:\s*760px\)[\s\S]*\.msg-agent-card\s*\{[^}]*position:\s*fixed;[^}]*inset:\s*auto 10px[^}]*max-height:\s*min\(70dvh, 560px\);/s);
   });
 });


### PR DESCRIPTION
## 修复

- 消息头里的 @Agent 不再只有原生单行 tooltip，改为与发送者一致的完整信息卡
- 信息卡展示身份、Leader、分工、当前状态和该 Agent 最近三项工作
- 发送者和 @Agent 都支持点击显式开关，移动端无需 hover
- 点击外部或 Escape 收起，保留桌面立即 hover / focus 行为

## 验证

- bun test web/src/components/MessageCard.presence.test.tsx：12/12
- bun run check:web：743/743、TypeScript、生产构建全部通过
- git diff --check

Closes #490

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * `@提及` 信息卡支持展示“当前工作与状态”，并基于被提及对象的近期消息呈现“近期工作”内容；缺少状态信息时明确显示“未上报”。
  * 移动端支持点击 `@提及` 打开/关闭信息卡。
  * 信息卡可通过外部点击或按 Esc 关闭（状态切换并在关闭时触发失焦表现）。
* **问题修复**
  * 统一发送者与 `@提及` 的信息卡悬停/聚焦/触摸打开交互与展示效果，优化移动端弹层显示与布局。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->