### PR TITLE
fix(web): 补齐跨组织提及候选

### DIFF
--- a/web/src/lib/mentions.test.ts
+++ b/web/src/lib/mentions.test.ts
@@ -142,6 +142,26 @@ describe("mentionCandidates", () => {
     expect(filterCandidates(candidates, "evan").map((candidate) => candidate.name)).toEqual(["Evan_Clauder"]);
   });
 
+  test("同名 sender 的稀疏新帧不会擦掉完整 owner/handle/display (#499)", () => {
+    const complete = message({
+      name: "cross-owner-session",
+      kind: "human",
+      owner: "lark:on_cross_company",
+      handle: "Evan_Clauder",
+      display_name: "Evan",
+    }, NOW - 1);
+    const sparse = message({ name: "cross-owner-session", kind: "human" }, NOW);
+    const candidates = mentionCandidates([], {}, null, NOW, [], [], [], [complete, sparse]);
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]).toMatchObject({
+      name: "Evan_Clauder",
+      display: "Evan_Clauder",
+      account: "lark:on_cross_company",
+      group: "lark:on_cross_company",
+    });
+  });
+
   test("超过 14 天的消息 sender 不会绕过幽灵清理重新进入候选 (#499)", () => {
     const DAY = 24 * 60 * 60 * 1000;
     const messages = [message({ name: "old-cross-owner", kind: "agent", owner: "lark:on_old" }, NOW - 15 * DAY)];

--- a/web/src/lib/mentions.test.ts
+++ b/web/src/lib/mentions.test.ts
@@ -1,11 +1,27 @@
 import { describe, expect, test } from "bun:test";
-import type { PresenceEntry, Sender } from "@agentparty/shared";
+import type { MsgFrame, PresenceEntry, Sender } from "@agentparty/shared";
 import { activeMentionQuery, filterCandidates, mentionCandidates, parseDraftMentions } from "./mentions";
 
 const NOW = 1_000_000_000;
 
 function presence(over: Partial<PresenceEntry> & { name: string }): PresenceEntry {
   return { state: "waiting", note: null, ts: NOW, last_seen: NOW, ...over };
+}
+
+function message(sender: Sender, ts = NOW): MsgFrame {
+  return {
+    type: "msg",
+    seq: 1,
+    sender,
+    kind: "message",
+    body: "hello",
+    mentions: [],
+    reply_to: null,
+    state: null,
+    note: null,
+    status: null,
+    ts,
+  } as MsgFrame;
 }
 
 describe("mentionCandidates", () => {
@@ -111,6 +127,25 @@ describe("mentionCandidates", () => {
     expect(c.display).toBe("LEO-MAIN");
     expect(c.tier).toBe("recent");
     expect(c.group).toBe("lark:on_owner");
+  });
+
+  test("页面打开后发言的跨 owner agent 无需新的 presence 帧也会进入空查询和名字过滤候选 (#499)", () => {
+    const messages = [message({
+      name: "Evan_Clauder",
+      kind: "agent",
+      owner: "lark:on_cross_company",
+    })];
+    const candidates = mentionCandidates([], {}, "leo", NOW, [], [], [], messages);
+
+    expect(candidates.map((candidate) => candidate.name)).toEqual(["Evan_Clauder"]);
+    expect(candidates[0]?.group).toBe("lark:on_cross_company");
+    expect(filterCandidates(candidates, "evan").map((candidate) => candidate.name)).toEqual(["Evan_Clauder"]);
+  });
+
+  test("超过 14 天的消息 sender 不会绕过幽灵清理重新进入候选 (#499)", () => {
+    const DAY = 24 * 60 * 60 * 1000;
+    const messages = [message({ name: "old-cross-owner", kind: "agent", owner: "lark:on_old" }, NOW - 15 * DAY)];
+    expect(mentionCandidates([], {}, null, NOW, [], [], [], messages)).toEqual([]);
   });
 
   test("identity-only agents can be found by readable display", () => {

--- a/web/src/lib/mentions.test.ts
+++ b/web/src/lib/mentions.test.ts
@@ -142,6 +142,49 @@ describe("mentionCandidates", () => {
     expect(filterCandidates(candidates, "evan").map((candidate) => candidate.name)).toEqual(["Evan_Clauder"]);
   });
 
+  test("participants-only agent uses its owner instead of falling into unowned agents (#499)", () => {
+    const candidates = mentionCandidates([
+      { name: "external-live", kind: "agent", owner: "lark:on_cross_company" },
+    ], {}, null, NOW);
+
+    expect(candidates[0]).toMatchObject({
+      name: "external-live",
+      account: "lark:on_cross_company",
+      group: "lark:on_cross_company",
+    });
+  });
+
+  test("participants-only human UUID remains readable through its owner (#499)", () => {
+    const uuid = "61ec302c-6c31-4bca-a1df-88152372f6d9";
+    const candidates = mentionCandidates([
+      { name: uuid, kind: "human", owner: "cross-owner@example.com" },
+    ], {}, null, NOW);
+
+    expect(candidates[0]).toMatchObject({
+      name: uuid,
+      display: "cross-owner@example.com",
+      account: "cross-owner@example.com",
+    });
+  });
+
+  test("recent raw sender stays retained when stale presence supplies a different current handle (#499)", () => {
+    const DAY = 24 * 60 * 60 * 1000;
+    const messages = [message({ name: "external-session", kind: "agent", handle: "old-handle" })];
+    const pres = {
+      "external-session": presence({
+        name: "external-session",
+        kind: "agent",
+        handle: "new-handle",
+        last_seen: NOW - 15 * DAY,
+        ts: NOW - 15 * DAY,
+      }),
+    };
+
+    expect(mentionCandidates([], pres, null, NOW, [], [], [], messages)).toMatchObject([
+      { name: "new-handle", tier: "recent" },
+    ]);
+  });
+
   test("同名 sender 的稀疏新帧不会擦掉完整 owner/handle/display (#499)", () => {
     const complete = message({
       name: "cross-owner-session",

--- a/web/src/lib/mentions.ts
+++ b/web/src/lib/mentions.ts
@@ -23,6 +23,7 @@ export interface MentionCandidate {
   role?: string; // 协作角色/职责（host/worker/reviewer/observer），hover 显示
   responsibility?: string; // 结构化职责说明（频道分工字段）
   note?: string; // 当前 status note
+  wakeKind?: WakeKind | null; // 当前唤醒层；发送前状态条直接复用最终候选，避免身份集合漂移
 }
 
 const STALE_MS = 60_000; // 与 PRESENCE_TIMEOUT_MS 一致：serve/watch 超过即算 recent 而非可唤醒
@@ -76,7 +77,19 @@ export function mentionCandidates(
   const recentMentionNames = new Set<string>();
   for (const message of messages) {
     if (now - message.ts > DEAD_MS) continue;
-    recentSenderByName.set(message.sender.name, message.sender);
+    const previous = recentSenderByName.get(message.sender.name);
+    // 同一身份的历史帧可能新旧协议混杂：较新的稀疏 sender 不能擦掉较早帧里已有的 owner/handle/display。
+    recentSenderByName.set(message.sender.name, {
+      ...message.sender,
+      owner: message.sender.owner || previous?.owner,
+      lineage: message.sender.lineage ?? previous?.lineage,
+      handle: message.sender.handle || previous?.handle,
+      display_name: message.sender.display_name || previous?.display_name,
+      avatar_url: message.sender.avatar_url || previous?.avatar_url,
+      avatar_thumb: message.sender.avatar_thumb || previous?.avatar_thumb,
+      client_version: message.sender.client_version || previous?.client_version,
+      connection_count: message.sender.connection_count ?? previous?.connection_count,
+    });
     recentMentionNames.add(message.sender.name);
     if (message.sender.handle) recentMentionNames.add(message.sender.handle);
   }
@@ -141,6 +154,7 @@ export function mentionCandidates(
         role: assigned?.role ?? p?.role,
         responsibility: assigned?.responsibility ?? undefined,
         note: p?.note ?? undefined,
+        wakeKind: p?.wake?.kind ?? null,
       };
     })
     .filter((c) => {
@@ -176,6 +190,7 @@ export function mentionCandidates(
       role: squad.leader === null ? undefined : `leader:${squad.leader}`,
       responsibility: `${squad.members.length} members`,
       note: squad.description ?? undefined,
+      wakeKind: "webhook" as const,
     }));
   return [...squadCandidates, ...base];
 }

--- a/web/src/lib/mentions.ts
+++ b/web/src/lib/mentions.ts
@@ -2,6 +2,7 @@
 // 分档的候选列表，供 Composer 的 @ 补全下拉用。"可 @" ≠ "在线连接"——本产品最特别的一档是
 // 「可唤醒」：人不在但 @ 了会被 serve/watch/webhook 拉起来。
 import { autoWakeReachable, type ChannelRoleAssignment, type ChannelSquad, type MsgFrame, type PresenceEntry, type Sender, type WakeKind } from "@agentparty/shared";
+import { mergeSenderIdentity } from "./senderIdentity";
 
 export type MentionTier = "online" | "wakeable" | "recent";
 
@@ -79,17 +80,7 @@ export function mentionCandidates(
     if (now - message.ts > DEAD_MS) continue;
     const previous = recentSenderByName.get(message.sender.name);
     // 同一身份的历史帧可能新旧协议混杂：较新的稀疏 sender 不能擦掉较早帧里已有的 owner/handle/display。
-    recentSenderByName.set(message.sender.name, {
-      ...message.sender,
-      owner: message.sender.owner || previous?.owner,
-      lineage: message.sender.lineage ?? previous?.lineage,
-      handle: message.sender.handle || previous?.handle,
-      display_name: message.sender.display_name || previous?.display_name,
-      avatar_url: message.sender.avatar_url || previous?.avatar_url,
-      avatar_thumb: message.sender.avatar_thumb || previous?.avatar_thumb,
-      client_version: message.sender.client_version || previous?.client_version,
-      connection_count: message.sender.connection_count ?? previous?.connection_count,
-    });
+    recentSenderByName.set(message.sender.name, mergeSenderIdentity(previous, message.sender));
     recentMentionNames.add(message.sender.name);
     if (message.sender.handle) recentMentionNames.add(message.sender.handle);
   }

--- a/web/src/lib/mentions.ts
+++ b/web/src/lib/mentions.ts
@@ -1,7 +1,7 @@
 // @ 提及候选（issue #39）：把 participants（WS 连着）∪ presence（含 wake 信息）合成一个
 // 分档的候选列表，供 Composer 的 @ 补全下拉用。"可 @" ≠ "在线连接"——本产品最特别的一档是
 // 「可唤醒」：人不在但 @ 了会被 serve/watch/webhook 拉起来。
-import { autoWakeReachable, type ChannelRoleAssignment, type ChannelSquad, type PresenceEntry, type Sender, type WakeKind } from "@agentparty/shared";
+import { autoWakeReachable, type ChannelRoleAssignment, type ChannelSquad, type MsgFrame, type PresenceEntry, type Sender, type WakeKind } from "@agentparty/shared";
 
 export type MentionTier = "online" | "wakeable" | "recent";
 
@@ -64,13 +64,25 @@ export function mentionCandidates(
   identities: MentionIdentity[] = [],
   roles: ChannelRoleAssignment[] = [],
   squads: ChannelSquad[] = [],
+  messages: MsgFrame[] = [],
 ): MentionCandidate[] {
   const online = new Set(participants.map((p) => p.name));
   const participantByName = new Map(participants.map((p) => [p.name, p]));
   const identityByName = new Map(identities.map((identity) => [identity.name, identity]));
   const roleByName = new Map(roles.map((role) => [role.name, role]));
+  // identities REST 只在频道 mount 时抓一次。页面打开后才发言、又没有补 status/presence 帧的成员
+  // 仍应立即可 @；消息 sender 是服务端已鉴权的频道身份，按同一 14 天窗口补进候选即可。
+  const recentSenderByName = new Map<string, Sender>();
+  const recentMentionNames = new Set<string>();
+  for (const message of messages) {
+    if (now - message.ts > DEAD_MS) continue;
+    recentSenderByName.set(message.sender.name, message.sender);
+    recentMentionNames.add(message.sender.name);
+    if (message.sender.handle) recentMentionNames.add(message.sender.handle);
+  }
   const kindOf = new Map<string, "agent" | "human">();
   for (const p of participants) kindOf.set(p.name, p.kind);
+  for (const sender of recentSenderByName.values()) kindOf.set(sender.name, sender.kind);
   for (const identity of identities) {
     if (identity.kind === "agent" || identity.kind === "human") kindOf.set(identity.name, identity.kind);
   }
@@ -89,6 +101,7 @@ export function mentionCandidates(
     ...Object.keys(presence),
     ...identities.map((identity) => identity.name),
     ...roles.map((role) => role.name),
+    ...recentSenderByName.keys(),
   ]);
   const rank: Record<MentionTier, number> = { online: 0, wakeable: 1, recent: 2 };
   const base = [...names]
@@ -98,14 +111,15 @@ export function mentionCandidates(
       const p = presence[name];
       const identity = identityByName.get(name);
       const assigned = roleByName.get(name);
-      const account = identity?.account ?? assigned?.account ?? p?.account;
+      const recentSender = recentSenderByName.get(name);
+      const account = identity?.account ?? assigned?.account ?? p?.account ?? recentSender?.owner;
       // 全局唯一昵称（handle）：有则用它做 @ 插入 token 和显示名。人类=account handle（UUID 会话名打不出来，
       // 只有 handle 能被后端识别为「被 @」）；agent=自设昵称（#165，可中文，其 ASCII name 由后端解析回填）。
       const identityHandle =
         identity?.handle !== undefined && identity.handle !== "" && NAME_TOKEN_RE.test(identity.handle)
           ? identity.handle
           : undefined;
-      const handle = participantByName.get(name)?.handle ?? p?.handle ?? identityHandle;
+      const handle = participantByName.get(name)?.handle ?? p?.handle ?? identityHandle ?? recentSender?.handle;
       // 人类网页会话名是 UUID，显示账号 email 才认得出「是谁」；agent 名本身可读，用 name。
       const display = handle
         ? handle
@@ -114,7 +128,7 @@ export function mentionCandidates(
           : assigned?.display && assigned.display !== ""
             ? assigned.display
             : kind === "human" && account
-              ? account
+              ? recentSender?.display_name || account
               : name;
       const group = account ?? (kind === "human" ? "human sessions" : "unowned agents");
       return {
@@ -139,6 +153,7 @@ export function mentionCandidates(
       }
       if (roleByName.has(c.name)) return true;
       if (identityByName.has(c.name)) return true;
+      if (recentMentionNames.has(c.name)) return true;
       const p = presence[c.name];
       const seen = p?.last_seen ?? p?.ts ?? 0;
       return now - seen <= DEAD_MS; // 幽灵清理：太久没露面的 agent 也剔除

--- a/web/src/lib/mentions.ts
+++ b/web/src/lib/mentions.ts
@@ -2,7 +2,7 @@
 // 分档的候选列表，供 Composer 的 @ 补全下拉用。"可 @" ≠ "在线连接"——本产品最特别的一档是
 // 「可唤醒」：人不在但 @ 了会被 serve/watch/webhook 拉起来。
 import { autoWakeReachable, type ChannelRoleAssignment, type ChannelSquad, type PresenceEntry, type Sender, type WakeKind } from "@agentparty/shared";
-import { mergeSenderIdentity, type SenderIdentitySnapshot } from "./senderIdentity";
+import { MENTION_SENDER_RETENTION_MS, mergeSenderIdentity, type SenderIdentitySnapshot } from "./senderIdentity";
 
 export type MentionTier = "online" | "wakeable" | "recent";
 
@@ -30,7 +30,7 @@ export interface MentionCandidate {
 const STALE_MS = 60_000; // 与 PRESENCE_TIMEOUT_MS 一致：serve/watch 超过即算 recent 而非可唤醒
 // 幽灵清理：只为防止频道长期累积几个月前的一次性 agent。设得宽松——几天前聊过的 agent
 // 仍是合理的 @/唤醒目标，不该被剔。真正的噪声（围观的人类会话）已由 kind/UUID 规则处理。
-const DEAD_MS = 14 * 24 * 60 * 60 * 1000; // 14 天没露面才视为幽灵
+const DEAD_MS = MENTION_SENDER_RETENTION_MS; // 14 天没露面才视为幽灵
 // 系统生成的人类会话名，永远不是有意义的 @ 目标：网页登录 token 默认名 = 纯 UUID；
 // OIDC 设备验证流 = login-verify-*。过渡期旧 presence 行没回填 kind 时靠名字把它们判为 human。
 const SYSTEM_HUMAN_SESSION_RE =
@@ -116,7 +116,12 @@ export function mentionCandidates(
       const identity = identityByName.get(name);
       const assigned = roleByName.get(name);
       const recentSender = recentSenderByName.get(name);
-      const account = identity?.account ?? assigned?.account ?? p?.account ?? recentSender?.owner;
+      const account =
+        identity?.account ??
+        assigned?.account ??
+        p?.account ??
+        participantByName.get(name)?.owner ??
+        recentSender?.owner;
       // 全局唯一昵称（handle）：有则用它做 @ 插入 token 和显示名。人类=account handle（UUID 会话名打不出来，
       // 只有 handle 能被后端识别为「被 @」）；agent=自设昵称（#165，可中文，其 ASCII name 由后端解析回填）。
       const identityHandle =
@@ -136,6 +141,7 @@ export function mentionCandidates(
               : name;
       const group = account ?? (kind === "human" ? "human sessions" : "unowned agents");
       return {
+        sourceName: name,
         name: handle ?? name,
         display,
         kind,
@@ -156,10 +162,10 @@ export function mentionCandidates(
         if (SYSTEM_HUMAN_SESSION_RE.test(c.name)) return c.account !== undefined && c.display !== c.name && c.display !== c.account;
         return c.account !== undefined || (c.display !== c.name && c.display !== c.account);
       }
-      if (roleByName.has(c.name)) return true;
-      if (identityByName.has(c.name)) return true;
-      if (recentMentionNames.has(c.name)) return true;
-      const p = presence[c.name];
+      if (roleByName.has(c.sourceName)) return true;
+      if (identityByName.has(c.sourceName)) return true;
+      if (recentMentionNames.has(c.sourceName) || recentMentionNames.has(c.name)) return true;
+      const p = presence[c.sourceName];
       const seen = p?.last_seen ?? p?.ts ?? 0;
       return now - seen <= DEAD_MS; // 幽灵清理：太久没露面的 agent 也剔除
     })
@@ -169,7 +175,8 @@ export function mentionCandidates(
       if (!SYSTEM_HUMAN_SESSION_RE.test(c.name)) return true;
       return c.account !== undefined && c.display !== c.name;
     })
-    .sort((a, b) => a.group.localeCompare(b.group) || rank[a.tier] - rank[b.tier] || a.display.localeCompare(b.display));
+    .sort((a, b) => a.group.localeCompare(b.group) || rank[a.tier] - rank[b.tier] || a.display.localeCompare(b.display))
+    .map(({ sourceName: _sourceName, ...candidate }) => candidate);
   const squadCandidates: MentionCandidate[] = squads
     .filter((squad) => squad.name !== self && squad.name !== "system")
     .map((squad) => ({

--- a/web/src/lib/mentions.ts
+++ b/web/src/lib/mentions.ts
@@ -1,8 +1,8 @@
 // @ 提及候选（issue #39）：把 participants（WS 连着）∪ presence（含 wake 信息）合成一个
 // 分档的候选列表，供 Composer 的 @ 补全下拉用。"可 @" ≠ "在线连接"——本产品最特别的一档是
 // 「可唤醒」：人不在但 @ 了会被 serve/watch/webhook 拉起来。
-import { autoWakeReachable, type ChannelRoleAssignment, type ChannelSquad, type MsgFrame, type PresenceEntry, type Sender, type WakeKind } from "@agentparty/shared";
-import { mergeSenderIdentity } from "./senderIdentity";
+import { autoWakeReachable, type ChannelRoleAssignment, type ChannelSquad, type PresenceEntry, type Sender, type WakeKind } from "@agentparty/shared";
+import { mergeSenderIdentity, type SenderIdentitySnapshot } from "./senderIdentity";
 
 export type MentionTier = "online" | "wakeable" | "recent";
 
@@ -66,7 +66,7 @@ export function mentionCandidates(
   identities: MentionIdentity[] = [],
   roles: ChannelRoleAssignment[] = [],
   squads: ChannelSquad[] = [],
-  messages: MsgFrame[] = [],
+  messages: SenderIdentitySnapshot[] = [],
 ): MentionCandidate[] {
   const online = new Set(participants.map((p) => p.name));
   const participantByName = new Map(participants.map((p) => [p.name, p]));

--- a/web/src/lib/senderIdentity.ts
+++ b/web/src/lib/senderIdentity.ts
@@ -1,5 +1,10 @@
 import type { Sender } from "@agentparty/shared";
 
+export interface SenderIdentitySnapshot {
+  ts: number;
+  sender: Sender;
+}
+
 /** 合并新旧协议混杂的 sender 快照：新身份字段优先，缺失/空串时保留旧值。 */
 export function mergeSenderIdentity(previous: Sender | undefined, next: Sender): Sender {
   return {

--- a/web/src/lib/senderIdentity.ts
+++ b/web/src/lib/senderIdentity.ts
@@ -5,6 +5,8 @@ export interface SenderIdentitySnapshot {
   sender: Sender;
 }
 
+export const MENTION_SENDER_RETENTION_MS = 14 * 24 * 60 * 60 * 1000;
+
 /** 合并新旧协议混杂的 sender 快照：新身份字段优先，缺失/空串时保留旧值。 */
 export function mergeSenderIdentity(previous: Sender | undefined, next: Sender): Sender {
   return {

--- a/web/src/lib/senderIdentity.ts
+++ b/web/src/lib/senderIdentity.ts
@@ -1,0 +1,16 @@
+import type { Sender } from "@agentparty/shared";
+
+/** 合并新旧协议混杂的 sender 快照：新身份字段优先，缺失/空串时保留旧值。 */
+export function mergeSenderIdentity(previous: Sender | undefined, next: Sender): Sender {
+  return {
+    ...next,
+    owner: next.owner || previous?.owner,
+    lineage: next.lineage ?? previous?.lineage,
+    handle: next.handle || previous?.handle,
+    display_name: next.display_name || previous?.display_name,
+    avatar_url: next.avatar_url || previous?.avatar_url,
+    avatar_thumb: next.avatar_thumb || previous?.avatar_thumb,
+    client_version: next.client_version || previous?.client_version,
+    connection_count: next.connection_count ?? previous?.connection_count,
+  };
+}

--- a/web/src/pages/Channel.tsx
+++ b/web/src/pages/Channel.tsx
@@ -3521,8 +3521,8 @@ export function ChannelPage({
   );
   // @ 补全候选：participants ∪ presence，分档（在线/可唤醒/最近）。teamNow 30s 刷新驱动 stale 判定。
   const mentionOptions = useMemo(
-    () => mentionCandidates(state.participants, state.presence, state.self, teamNow, channelIdentities, channelRoles, channelSquads),
-    [channelIdentities, channelRoles, channelSquads, state.participants, state.presence, state.self, teamNow],
+    () => mentionCandidates(state.participants, state.presence, state.self, teamNow, channelIdentities, channelRoles, channelSquads, state.messages),
+    [channelIdentities, channelRoles, channelSquads, state.messages, state.participants, state.presence, state.self, teamNow],
   );
   const identityDisplay = useMemo(
     () =>

--- a/web/src/pages/Channel.tsx
+++ b/web/src/pages/Channel.tsx
@@ -57,7 +57,7 @@ import {
 import type { AuthProviderConfig } from "../lib/oidc";
 import { agentHue } from "../lib/agentColor";
 import { buildIdentityDisplay, type IdentityDisplayMap } from "../lib/identityDisplay";
-import { mentionCandidates, mentionLiveness, parseDraftMentions, type DraftMentionStatus } from "../lib/mentions";
+import { mentionCandidates, parseDraftMentions, type DraftMentionStatus } from "../lib/mentions";
 import { buildReceipts, type MentionReceipt } from "../lib/wakeReceipt";
 import { completionMessages } from "../lib/completions";
 import { catchupKey, summarizeCatchup, type CatchupDigest } from "../lib/digest";
@@ -3521,8 +3521,8 @@ export function ChannelPage({
   );
   // @ 补全候选：participants ∪ presence，分档（在线/可唤醒/最近）。teamNow 30s 刷新驱动 stale 判定。
   const mentionOptions = useMemo(
-    () => mentionCandidates(state.participants, state.presence, state.self, teamNow, channelIdentities, channelRoles, channelSquads, state.messages),
-    [channelIdentities, channelRoles, channelSquads, state.messages, state.participants, state.presence, state.self, teamNow],
+    () => mentionCandidates(state.participants, state.presence, state.self, teamNow, channelIdentities, channelRoles, channelSquads, Object.values(state.mentionSenders)),
+    [channelIdentities, channelRoles, channelSquads, state.mentionSenders, state.participants, state.presence, state.self, teamNow],
   );
   const identityDisplay = useMemo(
     () =>
@@ -3560,23 +3560,15 @@ export function ChannelPage({
   );
   // 发送前状态条：草稿里已 @ 的、且在频道里认得的目标 + 当前存活档位。
   const draftMentionStatuses = useMemo<DraftMentionStatus[]>(() => {
-    const online = new Set(state.participants.map((p) => p.name));
-    const known = new Set<string>([
-      ...online,
-      ...Object.keys(state.presence),
-      ...channelIdentities.map((identity) => identity.name),
-      ...channelRoles.map((role) => role.name),
-      ...channelSquads.map((squad) => squad.name),
-    ]);
+    // 以补全菜单的最终结果为唯一身份集合：消息 sender、handle 与 squad 都不会再和状态条各算一套。
+    const known = new Map(mentionOptions.map((candidate) => [candidate.name, candidate]));
     return parseDraftMentions(draft)
       .filter((name) => known.has(name) && name !== state.self)
       .map((name) => {
-        const squad = channelSquads.find((item) => item.name === name);
-        if (squad) return { name, display: squad.title ?? squad.name, tier: "wakeable", wakeKind: "webhook" };
-        const live = mentionLiveness(name, online, state.presence, teamNow);
-        return { name, display: identityDisplay[name]?.display ?? name, tier: live.tier, wakeKind: live.wakeKind };
+        const candidate = known.get(name)!;
+        return { name, display: candidate.display, tier: candidate.tier, wakeKind: candidate.wakeKind ?? null };
       });
-  }, [channelIdentities, channelRoles, channelSquads, draft, state.participants, state.presence, state.self, teamNow, identityDisplay]);
+  }, [draft, mentionOptions, state.self]);
   // 轮询 @ 唤醒台账（仅 webhook 侧有行；serve/watch 靠 presence + 回复链接补齐）。用 ref 保持 7s 稳定
   // 间隔，不因每条新消息重挂定时器；标签页隐藏或频道无 agent @ 时跳过，端点失败也不影响其余回执渲染。
   const messagesRef = useRef(state.messages);

--- a/web/src/state.test.ts
+++ b/web/src/state.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from "bun:test";
 import type { MsgFrame, PresenceFrame } from "@agentparty/shared";
 import { channelReducer, initialChannelState } from "./state";
 
+const NOW_FOR_RETENTION = 1_725_000_000_000;
+
 function msgFrame(seq: number, body: string, over: Partial<MsgFrame> = {}): MsgFrame {
   return {
     type: "msg",
@@ -130,6 +132,20 @@ describe("channel state", () => {
       },
     });
     expect(s.mentionSenders.external).not.toHaveProperty("body");
+  });
+
+  test("mention sender snapshots older than 14 days are evicted on the next write", () => {
+    const DAY = 24 * 60 * 60 * 1000;
+    let s = channelReducer(initialChannelState, {
+      type: "frame",
+      frame: msgFrame(1, "old", { ts: NOW_FOR_RETENTION, sender: { name: "old-agent", kind: "agent" } }),
+    });
+    s = channelReducer(s, {
+      type: "frame",
+      frame: msgFrame(2, "new", { ts: NOW_FOR_RETENTION + 15 * DAY, sender: { name: "new-agent", kind: "agent" } }),
+    });
+
+    expect(Object.keys(s.mentionSenders)).toEqual(["new-agent"]);
   });
 
   test("read_cursor frame upserts monotonically; welcome snapshot seeds cursors", () => {

--- a/web/src/state.test.ts
+++ b/web/src/state.test.ts
@@ -38,6 +38,36 @@ describe("channel state", () => {
     expect(revised.messages[0]).toMatchObject({ seq: 6, body: "edited", edited: true });
   });
 
+  test("message_update replaces the message and refreshes the stable mention sender snapshot", () => {
+    const original = msgFrame(6, "original", {
+      sender: { name: "external", kind: "agent", owner: "lark:on_cross" },
+    });
+    const first = channelReducer(initialChannelState, { type: "frame", frame: original });
+    const edited = msgFrame(6, "edited", {
+      sender: { name: "external", kind: "agent", handle: "external-handle" },
+      edited: true,
+      edited_at: original.ts + 1,
+      edited_by: "external",
+    });
+    const revised = channelReducer(first, {
+      type: "frame",
+      frame: {
+        type: "message_update",
+        target_seq: 6,
+        action: "edit",
+        actor: { name: "external", kind: "agent" },
+        ts: edited.ts,
+        message: edited,
+      },
+    });
+
+    expect(revised.messages[0]).toMatchObject({ seq: 6, body: "edited", edited: true });
+    expect(revised.mentionSenders.external).toMatchObject({
+      seq: 6,
+      sender: { name: "external", owner: "lark:on_cross", handle: "external-handle" },
+    });
+  });
+
   test("prepending an older page keeps messages sorted and deduped (IM scroll-up)", () => {
     let s = initialChannelState;
     for (const seq of [51, 52, 53]) s = channelReducer(s, { type: "frame", frame: msgFrame(seq, `m${seq}`) });

--- a/web/src/state.test.ts
+++ b/web/src/state.test.ts
@@ -51,8 +51,29 @@ describe("channel state", () => {
     for (let seq = 1; seq <= 10; seq++) s = channelReducer(s, { type: "frame", frame: msgFrame(seq, `m${seq}`) });
     const trimmed = channelReducer(s, { type: "trim", keep: 4 });
     expect(trimmed.messages.map((m) => m.seq)).toEqual([7, 8, 9, 10]);
+    expect(trimmed.mentionSenders.bob?.seq).toBe(10); // @ 身份窗口不随 DOM 消息窗口一起裁掉
     // 低于上限时不动原状态（引用相等，避免无谓重渲染）
     expect(channelReducer(trimmed, { type: "trim", keep: 4 })).toBe(trimmed);
+  });
+
+  test("mention sender snapshot survives trim and merges complete identity fields", () => {
+    let s = channelReducer(initialChannelState, {
+      type: "frame",
+      frame: msgFrame(1, "complete", {
+        sender: { name: "external", kind: "agent", owner: "lark:on_cross", handle: "external-handle" },
+      }),
+    });
+    s = channelReducer(s, {
+      type: "frame",
+      frame: msgFrame(2, "sparse", { sender: { name: "external", kind: "agent" } }),
+    });
+    s = channelReducer(s, { type: "trim", keep: 1 });
+
+    expect(s.messages.map((m) => m.seq)).toEqual([2]);
+    expect(s.mentionSenders.external).toMatchObject({
+      seq: 2,
+      sender: { name: "external", owner: "lark:on_cross", handle: "external-handle" },
+    });
   });
 
   test("read_cursor frame upserts monotonically; welcome snapshot seeds cursors", () => {

--- a/web/src/state.test.ts
+++ b/web/src/state.test.ts
@@ -63,7 +63,7 @@ describe("channel state", () => {
 
     expect(revised.messages[0]).toMatchObject({ seq: 6, body: "edited", edited: true });
     expect(revised.mentionSenders.external).toMatchObject({
-      seq: 6,
+      ts: edited.ts,
       sender: { name: "external", owner: "lark:on_cross", handle: "external-handle" },
     });
   });
@@ -81,7 +81,7 @@ describe("channel state", () => {
     for (let seq = 1; seq <= 10; seq++) s = channelReducer(s, { type: "frame", frame: msgFrame(seq, `m${seq}`) });
     const trimmed = channelReducer(s, { type: "trim", keep: 4 });
     expect(trimmed.messages.map((m) => m.seq)).toEqual([7, 8, 9, 10]);
-    expect(trimmed.mentionSenders.bob?.seq).toBe(10); // @ 身份窗口不随 DOM 消息窗口一起裁掉
+    expect(trimmed.mentionSenders.bob?.ts).toBe(msgFrame(10, "").ts); // @ 身份窗口不随 DOM 消息窗口一起裁掉
     // 低于上限时不动原状态（引用相等，避免无谓重渲染）
     expect(channelReducer(trimmed, { type: "trim", keep: 4 })).toBe(trimmed);
   });
@@ -101,9 +101,35 @@ describe("channel state", () => {
 
     expect(s.messages.map((m) => m.seq)).toEqual([2]);
     expect(s.mentionSenders.external).toMatchObject({
-      seq: 2,
+      ts: msgFrame(2, "").ts,
       sender: { name: "external", owner: "lark:on_cross", handle: "external-handle" },
     });
+  });
+
+  test("an older loaded frame only fills gaps and never overwrites a newer sender identity", () => {
+    let s = channelReducer(initialChannelState, {
+      type: "frame",
+      frame: msgFrame(20, "new", {
+        sender: { name: "external", kind: "agent", owner: "new-owner", handle: "new-handle" },
+      }),
+    });
+    s = channelReducer(s, {
+      type: "frame",
+      frame: msgFrame(10, "old", {
+        sender: { name: "external", kind: "agent", owner: "old-owner", display_name: "Old display" },
+      }),
+    });
+
+    expect(s.mentionSenders.external).toMatchObject({
+      ts: msgFrame(20, "").ts,
+      sender: {
+        name: "external",
+        owner: "new-owner",
+        handle: "new-handle",
+        display_name: "Old display",
+      },
+    });
+    expect(s.mentionSenders.external).not.toHaveProperty("body");
   });
 
   test("read_cursor frame upserts monotonically; welcome snapshot seeds cursors", () => {

--- a/web/src/state.ts
+++ b/web/src/state.ts
@@ -9,6 +9,8 @@ export interface ChannelState {
   mode: ChannelMode;
   presence: Record<string, PresenceEntry>;
   messages: MsgFrame[]; // 按 seq 升序、已去重
+  /** 每个近期发信人的最新身份快照；独立于 messages 窗口，trim 后仍可用于 @ 候选。 */
+  mentionSenders: Record<string, MsgFrame>;
   readCursors: Record<string, ReadCursor>; // 每身份读到第几条（Phase 2）；人类 + 流式 agent 同表
   status: SocketStatus;
   readonly: boolean; // welcome.role=readonly（或 send 被拒 unauthorized 兜底）→ 隐藏输入框
@@ -26,6 +28,7 @@ export const initialChannelState: ChannelState = {
   mode: "normal",
   presence: {},
   messages: [],
+  mentionSenders: {},
   readCursors: {},
   status: "connecting",
   readonly: false,
@@ -112,6 +115,24 @@ function replaceMessage(messages: MsgFrame[], msg: MsgFrame): MsgFrame[] {
   return replaced ? next : insertMessage(messages, msg);
 }
 
+function rememberMentionSender(senders: Record<string, MsgFrame>, frame: MsgFrame): Record<string, MsgFrame> {
+  const previous = senders[frame.sender.name];
+  const sender: Sender = {
+    ...frame.sender,
+    owner: frame.sender.owner || previous?.sender.owner,
+    lineage: frame.sender.lineage ?? previous?.sender.lineage,
+    handle: frame.sender.handle || previous?.sender.handle,
+    display_name: frame.sender.display_name || previous?.sender.display_name,
+    avatar_url: frame.sender.avatar_url || previous?.sender.avatar_url,
+    avatar_thumb: frame.sender.avatar_thumb || previous?.sender.avatar_thumb,
+    client_version: frame.sender.client_version || previous?.sender.client_version,
+    connection_count: frame.sender.connection_count ?? previous?.sender.connection_count,
+  };
+  // 上翻加载老页时不把 last-seen 时间倒退，但可用老帧补齐稀疏身份字段。
+  const latest = previous !== undefined && previous.ts > frame.ts ? previous : frame;
+  return { ...senders, [frame.sender.name]: { ...latest, sender } };
+}
+
 function applyFrame(state: ChannelState, frame: ServerFrame): ChannelState {
   switch (frame.type) {
     case "welcome": {
@@ -155,7 +176,11 @@ function applyFrame(state: ChannelState, frame: ServerFrame): ChannelState {
       return { ...state, participants: frame.participants };
     case "msg":
     case "status": {
-      const next: ChannelState = { ...state, messages: insertMessage(state.messages, frame) };
+      const next: ChannelState = {
+        ...state,
+        messages: insertMessage(state.messages, frame),
+        mentionSenders: rememberMentionSender(state.mentionSenders, frame),
+      };
       // 人类发言重置服务端 loop guard 计数，黄条同步撤下
       if (
         frame.sender.kind === "human" &&
@@ -168,7 +193,11 @@ function applyFrame(state: ChannelState, frame: ServerFrame): ChannelState {
       return next;
     }
     case "message_update":
-      return { ...state, messages: replaceMessage(state.messages, frame.message) };
+      return {
+        ...state,
+        messages: replaceMessage(state.messages, frame.message),
+        mentionSenders: rememberMentionSender(state.mentionSenders, frame.message),
+      };
     case "presence":
       return {
         ...state,

--- a/web/src/state.ts
+++ b/web/src/state.ts
@@ -2,7 +2,7 @@
 // 消息按 seq 去重排序；status 帧同时进时间线和 presence 快照；error 帧内联展示不做 toast。
 import type { ChannelMode, MsgFrame, PresenceEntry, ReadCursor, Sender, ServerFrame } from "@agentparty/shared";
 import type { FatalReason, SocketStatus } from "./lib/ws";
-import { mergeSenderIdentity, type SenderIdentitySnapshot } from "./lib/senderIdentity";
+import { MENTION_SENDER_RETENTION_MS, mergeSenderIdentity, type SenderIdentitySnapshot } from "./lib/senderIdentity";
 
 export interface ChannelState {
   self: string | null;
@@ -126,10 +126,15 @@ function rememberMentionSender(
   const sender = previousIsNewer
     ? mergeSenderIdentity(frame.sender, previous.sender)
     : mergeSenderIdentity(previous?.sender, frame.sender);
-  return {
+  const updated = {
     ...senders,
     [frame.sender.name]: { ts: previousIsNewer ? previous.ts : frame.ts, sender },
   };
+  let watermark = frame.ts;
+  for (const snapshot of Object.values(updated)) watermark = Math.max(watermark, snapshot.ts);
+  return Object.fromEntries(
+    Object.entries(updated).filter(([, snapshot]) => watermark - snapshot.ts <= MENTION_SENDER_RETENTION_MS),
+  );
 }
 
 function applyFrame(state: ChannelState, frame: ServerFrame): ChannelState {

--- a/web/src/state.ts
+++ b/web/src/state.ts
@@ -2,7 +2,7 @@
 // 消息按 seq 去重排序；status 帧同时进时间线和 presence 快照；error 帧内联展示不做 toast。
 import type { ChannelMode, MsgFrame, PresenceEntry, ReadCursor, Sender, ServerFrame } from "@agentparty/shared";
 import type { FatalReason, SocketStatus } from "./lib/ws";
-import { mergeSenderIdentity } from "./lib/senderIdentity";
+import { mergeSenderIdentity, type SenderIdentitySnapshot } from "./lib/senderIdentity";
 
 export interface ChannelState {
   self: string | null;
@@ -11,7 +11,7 @@ export interface ChannelState {
   presence: Record<string, PresenceEntry>;
   messages: MsgFrame[]; // 按 seq 升序、已去重
   /** 每个近期发信人的最新身份快照；独立于 messages 窗口，trim 后仍可用于 @ 候选。 */
-  mentionSenders: Record<string, MsgFrame>;
+  mentionSenders: Record<string, SenderIdentitySnapshot>;
   readCursors: Record<string, ReadCursor>; // 每身份读到第几条（Phase 2）；人类 + 流式 agent 同表
   status: SocketStatus;
   readonly: boolean; // welcome.role=readonly（或 send 被拒 unauthorized 兜底）→ 隐藏输入框
@@ -116,12 +116,20 @@ function replaceMessage(messages: MsgFrame[], msg: MsgFrame): MsgFrame[] {
   return replaced ? next : insertMessage(messages, msg);
 }
 
-function rememberMentionSender(senders: Record<string, MsgFrame>, frame: MsgFrame): Record<string, MsgFrame> {
+function rememberMentionSender(
+  senders: Record<string, SenderIdentitySnapshot>,
+  frame: MsgFrame,
+): Record<string, SenderIdentitySnapshot> {
   const previous = senders[frame.sender.name];
-  const sender = mergeSenderIdentity(previous?.sender, frame.sender);
-  // 上翻加载老页时不把 last-seen 时间倒退，但可用老帧补齐稀疏身份字段。
-  const latest = previous !== undefined && previous.ts > frame.ts ? previous : frame;
-  return { ...senders, [frame.sender.name]: { ...latest, sender } };
+  // 上翻加载老页时不把 last-seen 时间或身份倒退：旧帧只能补新快照缺失的字段，不能覆盖新值。
+  const previousIsNewer = previous !== undefined && previous.ts > frame.ts;
+  const sender = previousIsNewer
+    ? mergeSenderIdentity(frame.sender, previous.sender)
+    : mergeSenderIdentity(previous?.sender, frame.sender);
+  return {
+    ...senders,
+    [frame.sender.name]: { ts: previousIsNewer ? previous.ts : frame.ts, sender },
+  };
 }
 
 function applyFrame(state: ChannelState, frame: ServerFrame): ChannelState {

--- a/web/src/state.ts
+++ b/web/src/state.ts
@@ -2,6 +2,7 @@
 // 消息按 seq 去重排序；status 帧同时进时间线和 presence 快照；error 帧内联展示不做 toast。
 import type { ChannelMode, MsgFrame, PresenceEntry, ReadCursor, Sender, ServerFrame } from "@agentparty/shared";
 import type { FatalReason, SocketStatus } from "./lib/ws";
+import { mergeSenderIdentity } from "./lib/senderIdentity";
 
 export interface ChannelState {
   self: string | null;
@@ -117,17 +118,7 @@ function replaceMessage(messages: MsgFrame[], msg: MsgFrame): MsgFrame[] {
 
 function rememberMentionSender(senders: Record<string, MsgFrame>, frame: MsgFrame): Record<string, MsgFrame> {
   const previous = senders[frame.sender.name];
-  const sender: Sender = {
-    ...frame.sender,
-    owner: frame.sender.owner || previous?.sender.owner,
-    lineage: frame.sender.lineage ?? previous?.sender.lineage,
-    handle: frame.sender.handle || previous?.sender.handle,
-    display_name: frame.sender.display_name || previous?.sender.display_name,
-    avatar_url: frame.sender.avatar_url || previous?.sender.avatar_url,
-    avatar_thumb: frame.sender.avatar_thumb || previous?.sender.avatar_thumb,
-    client_version: frame.sender.client_version || previous?.sender.client_version,
-    connection_count: frame.sender.connection_count ?? previous?.sender.connection_count,
-  };
+  const sender = mergeSenderIdentity(previous?.sender, frame.sender);
   // 上翻加载老页时不把 last-seen 时间倒退，但可用老帧补齐稀疏身份字段。
   const latest = previous !== undefined && previous.ts > frame.ts ? previous : frame;
   return { ...senders, [frame.sender.name]: { ...latest, sender } };


### PR DESCRIPTION
## 改动说明

- @候选除 participants / presence / mount 时 identities 外，也纳入页面打开后实时收到的最近消息 sender
- 直接复用服务端已鉴权 sender 的 kind、owner、handle；不按当前用户 owner 过滤
- 只纳入 14 天窗口内的消息，保持幽灵成员清理语义

## 合并前检查

- [x] 定向 mentions 测试 37/37
- [x] bun run check:web：749/749、TypeScript、生产构建
- [x] git diff --check
- [ ] review-ack：等待当前 head 双路 bot review 后回填

Closes #499

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 频道 @ 补全引入“近期发信人身份快照”并保留唤醒来源信息：即使缺少最新存在信息或跨所有者，也能更稳定、准确地生成候选。
  * 频道维度变更（身份/分工/分队）会触发 @ 候选与草稿 @ 状态同步刷新。
  * 消息编辑后会刷新相关发送者身份合并结果；草稿 @ 目标解析与当前候选保持一致更新。
* **测试**
  * 新增回归与快照/裁剪场景：覆盖跨所有者、稀疏身份帧合并不丢字段、编辑替换逻辑，以及超过保留时长的清理规则。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->