### PR TITLE
fix(cli): 如实报告 custom runner SIGTERM

### DIFF
--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -603,7 +603,10 @@ async function defaultRun(
   const code = await proc.exited;
   if (code !== 0) {
     // 保留 context file 供排查，抛错让 runServe 打印（不发频道）
-    throw new Error(`command exited ${code} (context: ${file})`);
+    // POSIX shell 用 128 + signal 表示被信号终止；143 = 128 + SIGTERM(15)。
+    // 明说 SIGTERM，避免 owner 只能看到一个难以辨认的数字、误以为 serve 静默吞掉了 wake。
+    const signal = code === 143 ? " (SIGTERM)" : "";
+    throw new Error(`command exited ${code}${signal} (context: ${file})`);
   }
   try {
     unlinkSync(file);
@@ -1917,6 +1920,9 @@ export async function runServe(o: ServeOptions): Promise<number> {
         let lastError = (stuck?.seq === frame.seq ? stuck.last_error : "") ?? "";
         let delivered = false;
         let retriable = true;
+        // custom/builtin runner 一旦可能已经执行过模型就不会重试；最终通告必须报告真实执行次数，
+        // 不能把配置预算 maxAttempts 伪装成实际已跑次数（例如一次 SIGTERM 不能写成 3/3）。
+        let attemptsUsed = priorAttempts;
         // 身后已缓冲的 wake 深度（#103）：内建 runner 随 working 帧上报，presence 显示「忙 + N 待处理」。
         // 本帧正在处理，故只数它 seq 之后、够格触发唤醒的缓冲帧。
         const queueDepth = pendingWakeDepth(conn.pendingFrames(), self, o.mentionsOnly === true, frame.seq);
@@ -1978,6 +1984,7 @@ export async function runServe(o: ServeOptions): Promise<number> {
         if (typeof taskBeat.unref === "function") taskBeat.unref();
         try {
           for (let attempt = priorAttempts + 1; attempt <= maxAttempts && retriable; attempt++) {
+            attemptsUsed = attempt;
             try {
               // 磁盘已经装好的新版优先（可直接 re-exec）；否则把服务器发布版提示交给 runner，
               // 让 agent 在频道里主动请 owner 升级。旧客户端不知道新协议时最需要这条提醒（#485）。
@@ -2064,7 +2071,7 @@ export async function runServe(o: ServeOptions): Promise<number> {
           // 没有 CLI flag，所以重试预算与退避必须**在频道里可见**：把常数藏进源码是不诚实的。
           const note =
             `wake undelivered, giving up: seq=${frame.seq}; ` +
-            `attempts=${maxAttempts}/${maxAttempts}; retry_delay_ms=${retryDelayMs}; ` +
+            `attempts=${attemptsUsed}/${maxAttempts}; retry_delay_ms=${retryDelayMs}; ` +
             `last error: ${lastError}`;
           out(`  ${note}`);
           try {

--- a/cli/test/serve-failure-ack.test.ts
+++ b/cli/test/serve-failure-ack.test.ts
@@ -514,7 +514,9 @@ describe("重试不得重复模型副作用 (#206 门禁 P1③)", () => {
     expect(await runServe(o)).toBe(EXIT_ARCHIVED);
     expect(calls).toBe(1); // 不是 3
     expect(posts.filter((p) => p.state === "blocked")).toHaveLength(1);
-    expect(String(posts.find((p) => p.state === "blocked")!.note)).toContain("not retriable");
+    const note = String(posts.find((p) => p.state === "blocked")!.note);
+    expect(note).toContain("attempts=1/3");
+    expect(note).toContain("not retriable");
   });
 
   test("runner 根本没起来（spawn 失败）→ 模型没跑过，可以安全重试", async () => {

--- a/cli/test/serve.test.ts
+++ b/cli/test/serve.test.ts
@@ -365,6 +365,30 @@ describe("runServe", () => {
     expect(o.lines.some((line) => line.includes("命令失败 (1/1): command exited 7"))).toBe(true);
   });
 
+  test("reports custom runner SIGTERM immediately with the truthful attempt count", async () => {
+    const s = closeAfterOneMention();
+    const posts: MessagePayload[] = [];
+    const o = opts({
+      server: s.url,
+      cmd: "exit 143",
+      maxWakeAttempts: 3,
+      wakeRetryDelayMs: 0,
+      post: async (_server, _token, _channel, body) => {
+        posts.push(body);
+        return { seq: posts.length };
+      },
+    });
+
+    expect(await runServe(o)).toBe(EXIT_ARCHIVED);
+    expect(o.lines.filter((line) => line.includes("命令失败"))).toHaveLength(1);
+    expect(o.lines.some((line) => line.includes("command exited 143 (SIGTERM)"))).toBe(true);
+    const blocked = posts.find((post) => post.kind === "status" && post.state === "blocked");
+    expect(blocked).toBeDefined();
+    const blockedNote = blocked && "note" in blocked ? blocked.note : undefined;
+    expect(blockedNote).toContain("attempts=1/3");
+    expect(blockedNote).toContain("command exited 143 (SIGTERM)");
+  });
+
   test("advertises wake capability once on attach, before handling mentions", async () => {
     const s = closeAfterOneMention();
     let advertiseCalls = 0;

--- a/cli/test/serve.test.ts
+++ b/cli/test/serve.test.ts
@@ -387,6 +387,7 @@ describe("runServe", () => {
     const blockedNote = blocked && "note" in blocked ? blocked.note : undefined;
     expect(blockedNote).toContain("attempts=1/3");
     expect(blockedNote).toContain("command exited 143 (SIGTERM)");
+    expect(blockedNote).toContain("(context: ");
   });
 
   test("advertises wake capability once on attach, before handling mentions", async () => {


### PR DESCRIPTION
Closes #500

## 改动说明
- custom runner 返回 143 时明确标注 SIGTERM，保留 context 路径供排查
- 不可重试失败按真实执行次数通告，例如一次失败显示 attempts=1/3，不再误报 3/3
- 增加真实 `sh -c "exit 143"` 回归用例，并加强不可重试失败断言

## 合并前检查
- `bun test cli/test/serve.test.ts cli/test/serve-failure-ack.test.ts`：80 pass
- `bun run check:cli`：740 pass；随后修正测试联合类型收窄
- `cd cli && bunx tsc --noEmit`：通过
- `git diff --check`：通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **错误处理**
  * 自定义命令因 SIGTERM（退出码 143）终止时，错误信息会明确标注信号原因，便于定位“被信号终止”的场景。
  * 服务唤醒失败状态现在会展示更准确的尝试次数（例如以已用/上限形式呈现），避免把“真实尝试次数”误报为“已达到最大重试次数”。  
* **测试**
  * 更新并新增服务失败与重试相关用例，校验失败输出与 blocked 状态说明（含尝试次数与失败原因）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->