### PR TITLE
fix(desktop): 补齐更新回执边界处理

### DIFF
--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -250,12 +250,13 @@ fn write_updater_diagnostic(path: &Path, diagnostic: &UpdaterDiagnostic) -> Resu
     Ok(())
 }
 
+const MAX_DIAGNOSTIC_BYTES: u64 = 64 * 1024;
+
 fn finalize_pending_updater_relaunch(
     path: &Path,
     current_version: &str,
     timestamp: u64,
 ) -> Result<bool, String> {
-    const MAX_DIAGNOSTIC_BYTES: u64 = 64 * 1024;
     let file = match fs::File::open(path) {
         Ok(file) => file,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
@@ -1496,7 +1497,11 @@ mod tests {
     fn native_startup_rejects_an_oversized_updater_receipt() {
         let temp = TempDir::new().unwrap();
         let path = temp.path().join("updater-diagnostic.json");
-        std::fs::write(&path, vec![b'x'; 64 * 1024 + 1]).unwrap();
+        std::fs::write(
+            &path,
+            vec![b'x'; (super::MAX_DIAGNOSTIC_BYTES + 1) as usize],
+        )
+        .unwrap();
 
         assert_eq!(
             finalize_pending_updater_relaunch(&path, "0.2.91", 654_321).unwrap_err(),

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -1,6 +1,6 @@
 use std::{
     fs::{self, OpenOptions},
-    io::Write,
+    io::{Read, Write},
     path::Path,
     sync::{
         atomic::{AtomicBool, AtomicU64, Ordering},
@@ -255,10 +255,19 @@ fn finalize_pending_updater_relaunch(
     current_version: &str,
     timestamp: u64,
 ) -> Result<bool, String> {
-    if !path.exists() {
-        return Ok(false);
+    const MAX_DIAGNOSTIC_BYTES: u64 = 64 * 1024;
+    let file = match fs::File::open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(_) => return Err("updater diagnostic is unavailable".to_string()),
+    };
+    let mut raw = Vec::new();
+    file.take(MAX_DIAGNOSTIC_BYTES + 1)
+        .read_to_end(&mut raw)
+        .map_err(|_| "updater diagnostic is unavailable".to_string())?;
+    if raw.len() as u64 > MAX_DIAGNOSTIC_BYTES {
+        return Err("updater diagnostic is too large".to_string());
     }
-    let raw = fs::read(path).map_err(|_| "updater diagnostic is unavailable".to_string())?;
     let pending: UpdaterDiagnostic =
         serde_json::from_slice(&raw).map_err(|_| "updater diagnostic is invalid".to_string())?;
     validate_updater_diagnostic(&pending)?;
@@ -286,11 +295,7 @@ fn finalize_pending_updater_relaunch(
 
 #[cfg(desktop)]
 fn finalize_pending_updater_relaunch_for_app(app: &tauri::App) -> Result<bool, String> {
-    let path = app
-        .path()
-        .app_data_dir()
-        .map_err(|_| "desktop app data directory is unavailable".to_string())?
-        .join(UPDATER_DIAGNOSTIC_FILE);
+    let path = app_data_dir(app.handle())?.join(UPDATER_DIAGNOSTIC_FILE);
     let timestamp = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map_err(|_| "system clock is unavailable".to_string())?
@@ -1247,8 +1252,8 @@ mod tests {
         migrate_legacy_credential, parse_stored_credential, refresh_enabled_autostart,
         release_info_from_build, tray_action, validate_updater_diagnostic,
         write_updater_diagnostic, AutostartBackend, CredentialBackend, ExitGuard, MainWindowGate,
-        TrayAction, UpdaterDiagnostic, UpdaterDiagnosticCategory, UpdaterDiagnosticStage,
-        UpdaterDiagnosticStatus, CREDENTIAL_ACCOUNT,
+        TrayAction, UpdaterDiagnostic, UpdaterDiagnosticCategory, UpdaterDiagnosticSource,
+        UpdaterDiagnosticStage, UpdaterDiagnosticStatus, CREDENTIAL_ACCOUNT,
     };
 
     #[test]
@@ -1446,6 +1451,57 @@ mod tests {
         let stored: UpdaterDiagnostic =
             serde_json::from_slice(&std::fs::read(path).unwrap()).unwrap();
         assert_eq!(stored, pending);
+    }
+
+    #[test]
+    fn native_startup_ignores_missing_and_non_pending_updater_receipts() {
+        let temp = TempDir::new().unwrap();
+        let missing = temp.path().join("missing.json");
+        assert!(!finalize_pending_updater_relaunch(&missing, "0.2.91", 654_321).unwrap());
+
+        let completed_path = temp.path().join("completed.json");
+        let completed = UpdaterDiagnostic {
+            status: UpdaterDiagnosticStatus::Success,
+            source: None,
+            stage: UpdaterDiagnosticStage::Relaunch,
+            category: None,
+            timestamp: 123_456,
+            app_version: Some("0.2.91".to_string()),
+            target_version: Some("0.2.91".to_string()),
+        };
+        write_updater_diagnostic(&completed_path, &completed).unwrap();
+        assert!(!finalize_pending_updater_relaunch(&completed_path, "0.2.91", 654_321).unwrap());
+        let stored: UpdaterDiagnostic =
+            serde_json::from_slice(&std::fs::read(completed_path).unwrap()).unwrap();
+        assert_eq!(stored, completed);
+
+        let check_path = temp.path().join("check.json");
+        let check = UpdaterDiagnostic {
+            status: UpdaterDiagnosticStatus::Success,
+            source: Some(UpdaterDiagnosticSource::Manual),
+            stage: UpdaterDiagnosticStage::Check,
+            category: None,
+            timestamp: 123_456,
+            app_version: Some("0.2.91".to_string()),
+            target_version: None,
+        };
+        write_updater_diagnostic(&check_path, &check).unwrap();
+        assert!(!finalize_pending_updater_relaunch(&check_path, "0.2.91", 654_321).unwrap());
+        let stored: UpdaterDiagnostic =
+            serde_json::from_slice(&std::fs::read(check_path).unwrap()).unwrap();
+        assert_eq!(stored, check);
+    }
+
+    #[test]
+    fn native_startup_rejects_an_oversized_updater_receipt() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("updater-diagnostic.json");
+        std::fs::write(&path, vec![b'x'; 64 * 1024 + 1]).unwrap();
+
+        assert_eq!(
+            finalize_pending_updater_relaunch(&path, "0.2.91", 654_321).unwrap_err(),
+            "updater diagnostic is too large"
+        );
     }
 
     #[derive(Default)]


### PR DESCRIPTION
## 改动说明\n\nPR #505 合并后补齐 bot review 中确认有效的边界：\n\n- 直接打开 updater receipt，并将 NotFound 映射为 Ok(false)，消除 exists/read 竞态\n- 复用仓库 app_data_dir helper\n- 将诊断文件读取限制为 64 KiB\n- 新增文件缺失、非 pending、非 relaunch、超限文件测试\n\n## 合并前检查（review-ack 强制闸——不留结论合不了）\n\n- [x] 我已读 PR #505 的 pr-agent / CodeRabbit review，真问题已处理、误报已判明\n- [x] 本地门禁通过（cargo fmt / Rust 全量单测）\n- [x] 涉及数据的改动已做对抗性验证（目标版本不匹配、非 pending、非 relaunch、文件缺失和超限文件均已覆盖）\n\n## 验证\n\n- cargo fmt --manifest-path desktop/src-tauri/Cargo.toml -- --check\n- cargo test --manifest-path desktop/src-tauri/Cargo.toml --lib\n- 结果：76 passed, 0 failed, 1 ignored

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 优化启动后待重启更新状态处理：诊断文件读取改为有上限的受控读取，避免超大文件导致异常。
  * 当诊断文件过大时将返回明确错误（如 “too large”），并保持更新状态不被错误落盘。
  * 调整诊断文件路径获取方式，提升启动阶段一致性与稳定性。

* **Tests**
  * 补全并更新单元测试：覆盖缺失/不符合条件的收据不落盘，以及超大诊断文件触发对应错误信息的场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->