### PR TITLE
fix(cli): 重放未确认的 watch 唤醒 (#508)

### DIFF
--- a/cli/src/commands/watch.ts
+++ b/cli/src/commands/watch.ts
@@ -3,7 +3,17 @@ import { EXIT_ARCHIVED, EXIT_AUTH, EXIT_LOOP_GUARD, EXIT_STREAM_ENDED, EXIT_TIME
 import { acquireInstanceLock, defaultInstanceLockDir, instanceLockTarget } from "../instance-lock";
 import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
 import { connect } from "../client";
-import { loadCursor, loadRevCursor, resolveChannel, saveCursor, saveRevCursor } from "../config";
+import {
+  clearStuck,
+  loadCursor,
+  loadRevCursor,
+  loadStuck,
+  resolveChannel,
+  saveCursor,
+  saveRevCursor,
+  saveStuck,
+  type StuckWake,
+} from "../config";
 import { resolveAuthDetailed, type ResolvedAuthDetailed } from "../oidc-cli";
 import { formatMsg } from "../format";
 import { fetchMe, fetchMessages, fetchRecentMessages, handleRestError, postMessage } from "../rest";
@@ -30,6 +40,8 @@ With --once, it stays attached until the FIRST matching message, prints it, and
 exits 0. It is only a wake signal while the harness keeps that background task
 alive. Claude Code may kill run_in_background tasks at turn boundaries, so this
 is turn-scoped best effort, not durable unattended presence.
+Re-arm --once with the persisted cursor (omit --latest). If the previous result
+was lost before the agent replied, the pending wake is replayed first.
 For --mentions-only --once, an uninitialized cursor (0) attaches at the current
 channel head to avoid replaying old mentions. Use --since 0 to request backlog.
 Self messages are skipped by default; --exclude-self is accepted as an explicit
@@ -75,7 +87,12 @@ export const ONCE_CLAUDE_ADVISORY =
   "For unattended wake, run `party serve <channel> --runner claude --replay-backlog` from a persistent terminal/project agent.";
 
 export const ONCE_REARM_ADVISORY =
-  "note: --once is single-shot and harness-scoped. Re-arm it every turn, or use `party serve --runner claude|codex --replay-backlog` for durable presence and process-loss recovery.";
+  "note: --once is single-shot and harness-scoped. Re-arm it every turn without --latest; pending wakes are replayed until this identity sends a message/status. " +
+  "For unattended presence, use `party serve --runner claude|codex --replay-backlog`.";
+
+export const ONCE_LATEST_ADVISORY =
+  "warning: re-arming `party watch --once` with --latest explicitly discards backlog. " +
+  "Use the persisted cursor (omit --latest); any pending unacknowledged wake will be replayed first.";
 
 /** Claude Code 环境：可做回合内 --once，但 run_in_background 可能在回合边界被回收（#454）。 */
 export function isClaudeCodeEnv(env: Record<string, string | undefined> = process.env): boolean {
@@ -103,6 +120,8 @@ export interface WatchOptions {
   once?: boolean; // 第一条匹配消息后立即退出 0（harness 后台任务的唤醒信号）
   json?: boolean; // 输出 NDJSON 帧而非人类格式，供 supervisor/工具消费
   skippedMentionSeqs?: number[]; // 显式 --latest/--since 快进时跳过的 @，随 once wake 交给 agent
+  /** --once 打印前先持久化「尚未被模型确认」的唤醒；后续自己发消息/状态才清账（#508）。 */
+  onStuck?: (stuck: StuckWake | null) => void;
   onCursor?: (cursor: number) => void;
   onRevCursor?: (revCursor: number) => void;
   out?: (line: string) => void;
@@ -333,6 +352,18 @@ export async function runWatch(o: WatchOptions): Promise<number> {
       // 暂停接待（#180）：qualifies 的新消息本该把 --once 退出当唤醒信号，但人按了暂停 →
       // 不退出、不发 once-wake 帧。消息仍照常打印进历史、游标照推进（下方 ack），与 serve 一致。
       const wakes = fresh && !selfPaused;
+      // Claude Code 会在 turn boundary 回收 run_in_background watcher（#508）。旧逻辑先打印、
+      // 再 ack 游标：后台结果若被 harness 吞掉，下一次 watch 已从更高游标开始，这条 @ 永久消失。
+      // 因此先落一笔 durable debt，再打印、再推进 transport cursor。agent 后续发出任何消息/状态，
+      // advanceCursorPastOwnMessage 才把 debt 清掉；如果模型没真正恢复，下次 --once 会先重放同一 seq。
+      if (o.once && qualifies && wakes) {
+        o.onStuck?.({
+          seq: msg.seq,
+          attempts: 0,
+          last_error: "watch wake awaiting agent acknowledgement",
+          source: "watch",
+        });
+      }
       if (qualifies) {
         if (o.json && o.once && wakes) {
           out(
@@ -480,7 +511,55 @@ export async function run(argv: string[]): Promise<number> {
   if (flags.follow === true) console.error(FOLLOW_WAKE_ADVISORY);
   if (flags.once === true && isClaudeCodeEnv()) console.error(ONCE_CLAUDE_ADVISORY);
   else if (flags.once === true && isCodexRuntimeEnv()) console.error(ONCE_CODEX_ADVISORY);
+  if (flags.once === true && flags.latest === true) console.error(ONCE_LATEST_ADVISORY);
   const localCursor = loadCursor(channel);
+  const stuck = loadStuck(channel);
+  // pending wake 比任何显式快进选择都优先。即使调用者误用 --latest，也不能先把仍未被模型
+  // 确认的 @ 丢掉。REST 精确补拉后立即退出，避免重新挂起一个可能又被 harness 回收的后台任务。
+  if (flags.once === true && stuck !== null) {
+    if (stuck.source !== "watch") {
+      console.error(
+        `error: #${channel} has a pending serve wake at seq=${stuck.seq}; ` +
+          "watch will not overwrite that delivery debt. Resume the existing party serve supervisor first.",
+      );
+      return 1;
+    }
+    try {
+      const pending = (await fetchMessages(cfg.server, cfg.token, channel, Math.max(0, stuck.seq - 1), 1))
+        .find((msg) => msg.seq === stuck.seq);
+      if (pending === undefined) {
+        console.error(
+          `error: pending watch wake seq=${stuck.seq} is no longer retained; debt was preserved. ` +
+            `Inspect channel history before clearing or advancing this workspace state.`,
+        );
+        return 1;
+      }
+      const replay = { ...stuck, attempts: stuck.attempts + 1 };
+      saveStuck(channel, replay);
+      if (flags.json === true) {
+        console.log(
+          JSON.stringify(
+            jsonFrame({
+              ...(pending as unknown as Record<string, unknown>),
+              watch_replay: true,
+              pending_ack: true,
+              replay_attempt: replay.attempts,
+            }),
+          ),
+        );
+      } else {
+        console.log(
+          `watch: replaying pending unacknowledged wake seq=${stuck.seq} attempt=${replay.attempts}; ` +
+            `send a reply/status after handling it to clear this debt.`,
+        );
+        console.log(formatMsg(pending));
+      }
+      if (flags.json !== true) console.error(ONCE_REARM_ADVISORY);
+      return 0;
+    } catch (e) {
+      return handleRestError(e);
+    }
+  }
   const initialLatest =
     localCursor === 0 &&
     explicitSince === undefined &&
@@ -535,6 +614,7 @@ export async function run(argv: string[]): Promise<number> {
     mentionsOnly: flags["mentions-only"] === true,
     json: flags.json === true,
     skippedMentionSeqs,
+    onStuck: (st) => (st === null ? clearStuck(channel) : saveStuck(channel, st)),
     onCursor: (c) => saveCursor(channel, c),
     onRevCursor: (r) => saveRevCursor(channel, r),
     statusline: true,

--- a/cli/src/commands/watch.ts
+++ b/cli/src/commands/watch.ts
@@ -4,14 +4,13 @@ import { acquireInstanceLock, defaultInstanceLockDir, instanceLockTarget } from 
 import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
 import { connect } from "../client";
 import {
-  clearStuck,
   loadCursor,
   loadRevCursor,
   loadStuck,
   resolveChannel,
   saveCursor,
   saveRevCursor,
-  saveStuck,
+  saveWatchStuck,
   type StuckWake,
 } from "../config";
 import { resolveAuthDetailed, type ResolvedAuthDetailed } from "../oidc-cli";
@@ -121,7 +120,7 @@ export interface WatchOptions {
   json?: boolean; // 输出 NDJSON 帧而非人类格式，供 supervisor/工具消费
   skippedMentionSeqs?: number[]; // 显式 --latest/--since 快进时跳过的 @，随 once wake 交给 agent
   /** --once 打印前先持久化「尚未被模型确认」的唤醒；后续自己发消息/状态才清账（#508）。 */
-  onStuck?: (stuck: StuckWake | null) => void;
+  onStuck?: (stuck: StuckWake) => void;
   onCursor?: (cursor: number) => void;
   onRevCursor?: (revCursor: number) => void;
   out?: (line: string) => void;
@@ -362,6 +361,8 @@ export async function runWatch(o: WatchOptions): Promise<number> {
           attempts: 0,
           last_error: "watch wake awaiting agent acknowledgement",
           source: "watch",
+          channel_last_seq: lastSeq,
+          skipped_mention_seqs: o.skippedMentionSeqs ?? [],
         });
       }
       if (qualifies) {
@@ -525,8 +526,11 @@ export async function run(argv: string[]): Promise<number> {
       return 1;
     }
     try {
-      const pending = (await fetchMessages(cfg.server, cfg.token, channel, Math.max(0, stuck.seq - 1), 1))
-        .find((msg) => msg.seq === stuck.seq);
+      const [pendingPage, tail] = await Promise.all([
+        fetchMessages(cfg.server, cfg.token, channel, Math.max(0, stuck.seq - 1), 1),
+        fetchRecentMessages(cfg.server, cfg.token, channel, 1),
+      ]);
+      const pending = pendingPage.find((msg) => msg.seq === stuck.seq);
       if (pending === undefined) {
         console.error(
           `error: pending watch wake seq=${stuck.seq} is no longer retained; debt was preserved. ` +
@@ -535,7 +539,16 @@ export async function run(argv: string[]): Promise<number> {
         return 1;
       }
       const replay = { ...stuck, attempts: stuck.attempts + 1 };
-      saveStuck(channel, replay);
+      if (!saveWatchStuck(channel, replay)) {
+        console.error(
+          `error: #${channel} acquired a pending serve wake while replaying seq=${stuck.seq}; ` +
+            "watch preserved that delivery debt and did not acknowledge this wake.",
+        );
+        return 1;
+      }
+      const channelLastSeq = Math.max(stuck.channel_last_seq ?? 0, tail.at(-1)?.seq ?? 0, pending.seq);
+      const lag = Math.max(0, channelLastSeq - pending.seq);
+      const skippedMentionSeqs = stuck.skipped_mention_seqs ?? [];
       if (flags.json === true) {
         console.log(
           JSON.stringify(
@@ -544,13 +557,19 @@ export async function run(argv: string[]): Promise<number> {
               watch_replay: true,
               pending_ack: true,
               replay_attempt: replay.attempts,
+              channel_last_seq: channelLastSeq,
+              lag,
+              skipped_mention_seqs: skippedMentionSeqs,
             }),
           ),
         );
       } else {
         console.log(
           `watch: replaying pending unacknowledged wake seq=${stuck.seq} attempt=${replay.attempts}; ` +
-            `send a reply/status after handling it to clear this debt.`,
+            `channel_last_seq=${channelLastSeq} lag=${lag} ` +
+            `skipped_mention_seqs=${JSON.stringify(skippedMentionSeqs)}; ` +
+            `send a reply/status after handling it to clear this debt.` +
+            (lag > 0 ? ` 补上下文：party history ${channel} --since ${stuck.seq}` : ""),
         );
         console.log(formatMsg(pending));
       }
@@ -614,7 +633,13 @@ export async function run(argv: string[]): Promise<number> {
     mentionsOnly: flags["mentions-only"] === true,
     json: flags.json === true,
     skippedMentionSeqs,
-    onStuck: (st) => (st === null ? clearStuck(channel) : saveStuck(channel, st)),
+    onStuck: (st) => {
+      if (!saveWatchStuck(channel, st)) {
+        throw new Error(
+          `#${channel} has a pending serve wake; watch preserved that delivery debt and did not acknowledge this wake`,
+        );
+      }
+    },
     onCursor: (c) => saveCursor(channel, c),
     onRevCursor: (r) => saveRevCursor(channel, r),
     statusline: true,

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -57,6 +57,8 @@ export interface StuckWake {
   /** 连续送达失败次数。有界重放靠它：超过上限就响亮放弃，绝不静默丢弃。 */
   attempts: number;
   last_error?: string;
+  /** 旧状态/serve 欠账没有该字段；watch 用它隔离两阶段确认语义，不能误清 serve delivery debt。 */
+  source?: "serve" | "watch";
 }
 
 export interface ChannelCursor {
@@ -473,7 +475,14 @@ export function clearStuck(channel: string, cwd?: string): void {
  * 这里只处理「我已经读到最新、紧接着自己发了一条」的情形，保住 statusline 的 unread=0。
  */
 export function advanceCursorPastOwnMessage(channel: string, seq: number, cwd?: string): void {
-  updateChannelCursor(channel, (cur) => cur.cursor === seq - 1 ? { ...cur, cursor: seq } : null, cwd);
+  updateChannelCursor(channel, (cur) => {
+    const advancesCursor = cur.cursor === seq - 1;
+    const acknowledgesWake = cur.stuck?.source === "watch" && seq > cur.stuck.seq;
+    if (!advancesCursor && !acknowledgesWake) return null;
+    const next: ChannelCursor = advancesCursor ? { ...cur, cursor: seq } : { ...cur };
+    if (acknowledgesWake) delete next.stuck;
+    return next;
+  }, cwd);
 }
 
 export function loadRevCursor(channel: string, cwd?: string): number {

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -59,6 +59,10 @@ export interface StuckWake {
   last_error?: string;
   /** 旧状态/serve 欠账没有该字段；watch 用它隔离两阶段确认语义，不能误清 serve delivery debt。 */
   source?: "serve" | "watch";
+  /** watch 首次输出时看到的频道 head；重放时会再探测并取较新者。 */
+  channel_last_seq?: number;
+  /** 首次显式快进时跳过的 mentions，随 pending wake 一起保留。 */
+  skipped_mention_seqs?: number[];
 }
 
 export interface ChannelCursor {
@@ -457,6 +461,20 @@ export function loadStuck(channel: string, cwd?: string): StuckWake | null {
 /** 写欠账。和 cursor 并列，互不覆盖。 */
 export function saveStuck(channel: string, stuck: StuckWake, cwd?: string): void {
   updateChannelCursor(channel, (cur) => ({ ...cur, stuck }), cwd);
+}
+
+/**
+ * 原子写 watch 欠账：watch/serve 用不同实例锁，可以并发；不能先 load 再 save（TOCTOU 会覆盖 serve debt）。
+ * 返回 false 表示已有非 watch 欠账，调用方必须停止且不得 ack 当前消息。
+ */
+export function saveWatchStuck(channel: string, stuck: StuckWake, cwd?: string): boolean {
+  let saved = false;
+  updateChannelCursor(channel, (cur) => {
+    if (cur.stuck !== undefined && cur.stuck.source !== "watch") return null;
+    saved = true;
+    return { ...cur, stuck: { ...stuck, source: "watch" } };
+  }, cwd);
+  return saved;
 }
 
 /** 了结欠账：送达成功，或有界重试耗尽后显式放弃。 */

--- a/cli/test/cursor-persistence.test.ts
+++ b/cli/test/cursor-persistence.test.ts
@@ -5,11 +5,13 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   advanceCursorPastOwnMessage,
+  loadStuck,
   loadCursor,
   loadRevCursor,
   readState,
   saveCursor,
   saveRevCursor,
+  saveStuck,
   statePath,
   workspaceId,
   writeState,
@@ -42,6 +44,39 @@ describe("cursor persistence (#113)", () => {
       advanceCursorPastOwnMessage("dev", 15, d); // 重复
       advanceCursorPastOwnMessage("dev", 12, d); // 迟到的旧 seq
       expect(loadCursor("dev", d)).toBe(15);
+    });
+
+    test("后续自己发言会确认 pending wake，即使 cursor 前仍有空洞也只清 debt、不吞消息 (#508)", () => {
+      const d = cwd();
+      writeState({ channel: "dev", cursor: 10 }, d);
+      saveStuck("dev", { seq: 12, attempts: 2, source: "watch" }, d);
+
+      advanceCursorPastOwnMessage("dev", 15, d);
+
+      expect(loadCursor("dev", d)).toBe(10);
+      expect(loadStuck("dev", d)).toBeNull();
+    });
+
+    test("早于 pending wake 的乱序自发消息不能误清 debt (#508)", () => {
+      const d = cwd();
+      writeState({ channel: "dev", cursor: 10 }, d);
+      saveStuck("dev", { seq: 12, attempts: 1, source: "watch" }, d);
+
+      advanceCursorPastOwnMessage("dev", 11, d);
+
+      expect(loadCursor("dev", d)).toBe(11);
+      expect(loadStuck("dev", d)).toEqual({ seq: 12, attempts: 1, source: "watch" });
+    });
+
+    test("自己发言不能误清 serve 的 runner delivery debt (#508)", () => {
+      const d = cwd();
+      writeState({ channel: "dev", cursor: 10 }, d);
+      saveStuck("dev", { seq: 12, attempts: 1 }, d);
+
+      advanceCursorPastOwnMessage("dev", 15, d);
+
+      expect(loadCursor("dev", d)).toBe(10);
+      expect(loadStuck("dev", d)).toEqual({ seq: 12, attempts: 1 });
     });
   });
 

--- a/cli/test/stuck-wake.test.ts
+++ b/cli/test/stuck-wake.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, test } from "bun:test";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { clearStuck, loadStuck, saveStuck } from "../src/config";
+import { clearStuck, loadStuck, saveStuck, saveWatchStuck } from "../src/config";
 
 const cwd = () => mkdtempSync(join(tmpdir(), "ap-stuck-"));
 
@@ -49,5 +49,18 @@ describe("stuck wake persistence (#198 约束①：stuck 落盘)", () => {
     const prev = loadStuck("dev", d)!;
     saveStuck("dev", { ...prev, attempts: prev.attempts + 1, last_error: "again" }, d);
     expect(loadStuck("dev", d)).toEqual({ seq: 100, attempts: 2, last_error: "again" });
+  });
+
+  test("watch 原子写不能覆盖 serve 欠账，但可以创建或更新自己的欠账 (#508)", () => {
+    const d = cwd();
+    saveStuck("dev", { seq: 100, attempts: 1 }, d);
+
+    expect(saveWatchStuck("dev", { seq: 101, attempts: 0, source: "watch" }, d)).toBe(false);
+    expect(loadStuck("dev", d)).toEqual({ seq: 100, attempts: 1 });
+
+    clearStuck("dev", d);
+    expect(saveWatchStuck("dev", { seq: 101, attempts: 0, source: "watch" }, d)).toBe(true);
+    expect(saveWatchStuck("dev", { seq: 101, attempts: 1, source: "watch" }, d)).toBe(true);
+    expect(loadStuck("dev", d)).toEqual({ seq: 101, attempts: 1, source: "watch" });
   });
 });

--- a/cli/test/watch-once-lag.test.ts
+++ b/cli/test/watch-once-lag.test.ts
@@ -56,6 +56,28 @@ function opts(over: Partial<WatchOptions> & { server: string }): WatchOptions & 
 }
 
 describe("watch --once 落后量告知 (#199)", () => {
+  test("持久化 pending wake 发生在输出与 cursor ack 之前 (#508)", async () => {
+    const events: string[] = [];
+    server = startMockServer((frame, sock) => {
+      if (frame.type !== "hello") return;
+      sock.send(welcomeFrame(4, "me"));
+      sock.send(msgFrame(4, "wake", { mentions: ["me"] }));
+    });
+
+    const o = opts({
+      server: server.url,
+      since: 3,
+      out: (line) => events.push(`out:${line}`),
+      onStuck: (stuck) => events.push(`stuck:${stuck?.seq ?? "clear"}`),
+      onCursor: (cursor) => events.push(`cursor:${cursor}`),
+    });
+    expect(await runWatch(o)).toBe(0);
+
+    expect(events[0]).toBe("stuck:4");
+    expect(events.findIndex((event) => event.startsWith("out:"))).toBeGreaterThan(0);
+    expect(events.indexOf("stuck:4")).toBeLessThan(events.indexOf("cursor:4"));
+  });
+
   test("醒在最旧未读 @ 时，报出还落后多少条、频道 head 是多少", async () => {
     // 游标停在 3；频道已经到 20。seq 4 是最旧的未读 @，后面还压着 16 条。
     server = startMockServer((frame, sock) => {
@@ -126,6 +148,95 @@ describe("watch --once 落后量告知 (#199)", () => {
     expect(await runWatch(o)).toBe(0); // 补拉排空即退出 0，不会等到 archived
     expect(o.lines.some((l) => l.includes("落后"))).toBe(false);
   });
+});
+
+describe("watch --once pending wake replay (#508)", () => {
+  test("重挂先从 REST 重放欠账，--latest 也不能越过，且不再建立 WS", async () => {
+    home = mkdtempSync(join(tmpdir(), "ap-watch-pending-replay-"));
+    const pending = msgFrame(10, "@me must survive reaper", { mentions: ["me"] });
+    let upgrades = 0;
+    apiServer = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch(req, srv) {
+        const url = new URL(req.url);
+        if (url.pathname === "/api/channels/dev/messages") {
+          const since = Number(url.searchParams.get("since") ?? 0);
+          return Response.json({ messages: pending.seq > since ? [pending] : [] });
+        }
+        if (url.pathname === "/api/me") {
+          return Response.json({ name: "me", kind: "agent", role: "agent", email: null, owner: null });
+        }
+        upgrades++;
+        if (srv.upgrade(req, { data: undefined })) return;
+        return new Response("not found", { status: 404 });
+      },
+      websocket: { message() {} },
+    });
+    writeFileSync(
+      join(home, "config.json"),
+      JSON.stringify({ server: `http://127.0.0.1:${apiServer.port}`, token: "ap_tok" }),
+    );
+    const dir = join(home, "state", workspaceId(process.cwd()));
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "state.json"),
+      JSON.stringify({
+        channel: "dev",
+        cursor: 10,
+        cursors: {
+          dev: {
+            cursor: 10,
+            stuck: { seq: 10, attempts: 0, last_error: "watch wake awaiting agent acknowledgement", source: "watch" },
+          },
+        },
+      }),
+    );
+
+    const first = await runCli(["watch", "dev", "--once", "--mentions-only", "--latest", "--json"]);
+    expect(first.code).toBe(0);
+    expect(upgrades).toBe(0);
+    expect(JSON.parse(first.stdout)).toMatchObject({
+      type: "msg",
+      seq: 10,
+      watch_replay: true,
+      pending_ack: true,
+      replay_attempt: 1,
+    });
+    expect(first.stderr).toContain("--latest explicitly discards backlog");
+    expect(JSON.parse(readFileSync(join(dir, "state.json"), "utf8")).cursors.dev.stuck.attempts).toBe(1);
+
+    const second = await runCli(["watch", "dev", "--once", "--mentions-only", "--json"]);
+    expect(second.code).toBe(0);
+    expect(JSON.parse(second.stdout)).toMatchObject({ seq: 10, watch_replay: true, replay_attempt: 2 });
+    expect(JSON.parse(readFileSync(join(dir, "state.json"), "utf8")).cursors.dev.stuck.attempts).toBe(2);
+  }, 15_000);
+
+  test("欠账消息已退出保留窗口时响亮失败并保留 debt", async () => {
+    home = mkdtempSync(join(tmpdir(), "ap-watch-pending-missing-"));
+    apiServer = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch() {
+        return Response.json({ messages: [] });
+      },
+    });
+    writeFileSync(
+      join(home, "config.json"),
+      JSON.stringify({ server: `http://127.0.0.1:${apiServer.port}`, token: "ap_tok" }),
+    );
+    const dir = join(home, "state", workspaceId(process.cwd()));
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "state.json"),
+      JSON.stringify({ channel: "dev", cursor: 10, cursors: { dev: { cursor: 10, stuck: { seq: 10, attempts: 3, source: "watch" } } } }),
+    );
+
+    const result = await runCli(["watch", "dev", "--once", "--mentions-only", "--json"]);
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain("no longer retained");
+    expect(JSON.parse(readFileSync(join(dir, "state.json"), "utf8")).cursors.dev.stuck).toEqual({ seq: 10, attempts: 3, source: "watch" });
+  }, 15_000);
 });
 
 describe("watch --once 不得复用身份级已读游标 (#206 门禁 P1)", () => {

--- a/cli/test/watch-once-lag.test.ts
+++ b/cli/test/watch-once-lag.test.ts
@@ -264,6 +264,11 @@ describe("watch --once pending wake replay (#508)", () => {
       lag: 4,
       skipped_mention_seqs: [3, 7],
     });
+
+    const human = await runCli(["watch", "dev", "--once", "--mentions-only"]);
+    expect(human.code).toBe(0);
+    expect(human.stdout).toContain("channel_last_seq=14 lag=4 skipped_mention_seqs=[3,7]");
+    expect(human.stdout).toContain("party history dev --since 10");
   }, 15_000);
 
   test("欠账消息已退出保留窗口时响亮失败并保留 debt", async () => {

--- a/cli/test/watch-once-lag.test.ts
+++ b/cli/test/watch-once-lag.test.ts
@@ -68,7 +68,7 @@ describe("watch --once 落后量告知 (#199)", () => {
       server: server.url,
       since: 3,
       out: (line) => events.push(`out:${line}`),
-      onStuck: (stuck) => events.push(`stuck:${stuck?.seq ?? "clear"}`),
+      onStuck: (stuck) => events.push(`stuck:${stuck.seq}`),
       onCursor: (cursor) => events.push(`cursor:${cursor}`),
     });
     expect(await runWatch(o)).toBe(0);
@@ -202,6 +202,9 @@ describe("watch --once pending wake replay (#508)", () => {
       watch_replay: true,
       pending_ack: true,
       replay_attempt: 1,
+      channel_last_seq: 10,
+      lag: 0,
+      skipped_mention_seqs: [],
     });
     expect(first.stderr).toContain("--latest explicitly discards backlog");
     expect(JSON.parse(readFileSync(join(dir, "state.json"), "utf8")).cursors.dev.stuck.attempts).toBe(1);
@@ -210,6 +213,57 @@ describe("watch --once pending wake replay (#508)", () => {
     expect(second.code).toBe(0);
     expect(JSON.parse(second.stdout)).toMatchObject({ seq: 10, watch_replay: true, replay_attempt: 2 });
     expect(JSON.parse(readFileSync(join(dir, "state.json"), "utf8")).cursors.dev.stuck.attempts).toBe(2);
+  }, 15_000);
+
+  test("重放帧重新探测频道 head，并保留首次快进的 mention 元数据 (#508)", async () => {
+    home = mkdtempSync(join(tmpdir(), "ap-watch-pending-head-"));
+    const pending = msgFrame(10, "oldest pending wake", { mentions: ["me"] });
+    const head = msgFrame(14, "newer context");
+    apiServer = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch(req) {
+        const url = new URL(req.url);
+        if (url.pathname !== "/api/channels/dev/messages") return new Response("not found", { status: 404 });
+        return Response.json({ messages: url.searchParams.has("before") ? [head] : [pending] });
+      },
+    });
+    writeFileSync(
+      join(home, "config.json"),
+      JSON.stringify({ server: `http://127.0.0.1:${apiServer.port}`, token: "ap_tok" }),
+    );
+    const dir = join(home, "state", workspaceId(process.cwd()));
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "state.json"),
+      JSON.stringify({
+        channel: "dev",
+        cursor: 10,
+        cursors: {
+          dev: {
+            cursor: 10,
+            stuck: {
+              seq: 10,
+              attempts: 0,
+              source: "watch",
+              channel_last_seq: 12,
+              skipped_mention_seqs: [3, 7],
+            },
+          },
+        },
+      }),
+    );
+
+    const result = await runCli(["watch", "dev", "--once", "--mentions-only", "--json"]);
+    expect(result.code).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      seq: 10,
+      watch_replay: true,
+      pending_ack: true,
+      channel_last_seq: 14,
+      lag: 4,
+      skipped_mention_seqs: [3, 7],
+    });
   }, 15_000);
 
   test("欠账消息已退出保留窗口时响亮失败并保留 debt", async () => {

--- a/docs/party-etiquette.md
+++ b/docs/party-etiquette.md
@@ -8,7 +8,7 @@
 默认只在被点名时开口。
 
 - 监听用 `party watch <channel> --mentions-only`，别订阅全量消息流。
-- 监听 ≠ 可唤醒：`watch --follow` 只打印。Claude Code 的 `run_in_background` 还可能在回合边界或后台 reaper 下杀掉 `watch --once`（#454/#474），所以它只算当前回合临时等待，必须每个 turn 重挂，不能据此宣称耐久在线。无人值守用持久 terminal 的 `party serve <channel> --runner claude` 或 webhook 唤醒；Codex/其它 harness 用对应 `party serve` runner。依赖别人的 `wakeable` 前先从另一身份 `party wake test @对方`。
+- 监听 ≠ 可唤醒：`watch --follow` 只打印。Claude Code 的 `run_in_background` 还可能在回合边界或后台 reaper 下杀掉 `watch --once`（#454/#474/#508），所以它只算当前回合临时等待，必须每个 turn 重挂，不能据此宣称耐久在线。重挂时**不要加 `--latest`**：直接复用持久游标；上一轮若在模型确认前被回收，CLI 会先重放 `pending_ack` 的同一条 @，直到该身份发送回复或状态才清账。无人值守仍用持久 terminal 的 `party serve <channel> --runner claude --replay-backlog` 或 webhook 唤醒；Codex/其它 harness 用对应 `party serve` runner。依赖别人的 `wakeable` 前先从另一身份 `party wake test @对方`。
 - `watch --mentions-only --once` 遇到未初始化的零游标时默认从当前频道 head 挂载，避免 config 重建后把历史 @ 一条条重放成假唤醒；确实要补历史时显式加 `--since 0`。`AGENTPARTY_CONFIG` 必须放 `$HOME/.agentparty/agents/` 等持久目录，不能放 `TMPDIR`。
 - 发言时想让谁接，就在正文里 `@名字` 点名。没点名的消息，其他 agent 一律当背景信息，不回复。
 - 需要唤醒人类时，优先让本人执行 `party lark notify on --channel <channel>`；之后频道里 `@他的 handle` 会转成 Lark/Feishu 私聊卡片，人类不必一直盯 web UI。


### PR DESCRIPTION
Closes #508

## 变更
- `watch --once` 输出前先持久化 pending wake，再推进 transport cursor
- 重挂时先精确重放未确认 wake；`--latest` 不能越过欠账
- 该身份后续发送消息/状态后清除 watch 欠账
- watch/serve 欠账分源隔离，避免误清 runner delivery debt
- 更新 Claude Code 安全重挂说明

## 验证
- `bun test cli/test/watch-once-lag.test.ts cli/test/cursor-persistence.test.ts cli/test/serve-failure-ack.test.ts`（52 pass）
- `bun run check:cli`（pass）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * `watch --once` 新增“stuck wake（未确认唤醒债务）”的持久化与重放，记录并递增重放尝试次数，确保 stuck 事件先于输出/确认发生。
  * `--once --latest` 明确弃置 backlog，并在 REST-only 场景输出重放提示后直接退出 0。
* **错误修复**
  * 保护来源为 `serve` 的欠账不被 `watch` 覆盖；保存失败会中止流程，过期欠账不回写。
  * 游标推进与欠账清理逻辑更精确，避免乱序/空洞误清。
* **测试**
  * 扩展 cursor/stuck 持久化、重放时序、成功/失败边界用例。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->