### PR TITLE
fix(ci): 避免 review-ack 状态竞态 (#509)

### DIFF
--- a/scripts/review-ack-gate.mjs
+++ b/scripts/review-ack-gate.mjs
@@ -80,10 +80,19 @@ export function evaluateReviewAck({
       PR_AGENT_RE.test(comment.body ?? "") &&
       commentTime(comment) >= runTime(prAgentRun),
   );
+  // CodeRabbit 的 success status 只证明「当前 head 的审查流程已完成」，不代表那一刻产生了
+  // 新的 review 内容。人工 issue comment 会触发 CodeRabbit 摘要刷新 / 状态重发；若把该 status
+  // 的 updated_at 当最新 review 时间，ack 自己会制造一个更晚的 bot 时间戳，形成恒红竞态（#509）。
+  // 有正式 review 时一律以 submitted_at 为内容时间；只有 CodeRabbit 未产出正式 review 的
+  // soft-success 路径，才拿 success status 作为最小 bot artifact 兜底。
+  const codeRabbitArtifactTimes = codeRabbitReviews.length > 0
+    ? codeRabbitReviews.map(reviewTime)
+    : codeRabbitStatus?.state === "success"
+      ? [statusTime(codeRabbitStatus)]
+      : [];
   const botArtifactTimes = [
     ...prAgentArtifacts.map(commentTime),
-    ...codeRabbitReviews.map(reviewTime),
-    ...(codeRabbitStatus?.state === "success" ? [statusTime(codeRabbitStatus)] : []),
+    ...codeRabbitArtifactTimes,
   ].filter((time) => time > 0);
   if (botArtifactTimes.length === 0) {
     return {

--- a/scripts/review-ack-gate.test.ts
+++ b/scripts/review-ack-gate.test.ts
@@ -194,6 +194,26 @@ describe("review-ack ordering gate (#460)", () => {
     expect(result.code).toBe("ack_after_reviews");
   });
 
+  test("CodeRabbit status/summary refresh caused by an issue-comment ack cannot make that ack stale (#509)", () => {
+    const result = evaluate({
+      statuses: [{ ...codeRabbitStatus[0], updated_at: "2026-07-13T10:04:00Z" }],
+      comments: [
+        prAgentGuide,
+        {
+          user: user("coderabbitai[bot]", "Bot"),
+          body: "<!-- This is an auto-generated comment: summarize by coderabbit.ai -->",
+          created_at: "2026-07-13T10:00:00Z",
+          updated_at: "2026-07-13T10:05:00Z",
+        },
+        { user: user("maintainer"), body: "review-ack: valid findings fixed", created_at: "2026-07-13T10:03:00Z" },
+      ],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.code).toBe("ack_after_reviews");
+    expect(result.latestBotReviewAt).toBe(Date.parse(codeRabbitReview.submitted_at));
+  });
+
   test("pr_agent endpoint failure does not block when its workflow completed without a comment", () => {
     const result = evaluate({
       comments: [
@@ -228,6 +248,17 @@ describe("review-ack ordering gate (#460)", () => {
   test("current-head CodeRabbit success status is a bot artifact even without a formal review", () => {
     const result = evaluate({ reviews: [], comments: [] });
     expect(result.code).toBe("missing_ack");
+  });
+
+  test("without a formal CodeRabbit review, the success status remains the fallback ordering artifact", () => {
+    const result = evaluate({
+      reviews: [],
+      comments: [
+        { user: user("maintainer"), body: "review-ack: after soft success", created_at: "2026-07-13T10:03:00Z" },
+      ],
+    });
+    expect(result.ok).toBe(true);
+    expect(result.latestBotReviewAt).toBe(Date.parse(codeRabbitStatus[0].updated_at));
   });
 
   test("never accepts an ack when no bot review artifact exists", () => {


### PR DESCRIPTION
Closes #509

## 变更
- CodeRabbit 有正式 review 时，仅用 `submitted_at` 参与 ack 先后判断
- CodeRabbit success status 只负责完成态门禁，不再覆盖正式 review 的内容时间
- 无正式 review 的 soft-success 路径继续以 status 作为兜底 artifact
- 增加 #507 实际竞态回归测试：ack 后摘要/status 刷新不得把 ack 判旧

## 验证
- `bun run check:scripts`（208 tests + TypeScript 全通过）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复 CodeRabbit 审查状态时间判定逻辑，避免自动生成的状态更新错误地将确认标记为过期。
  * 在缺少正式 CodeRabbit 审查时，支持使用成功状态时间作为备用依据，确保确认结果准确。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->