### PR TITLE
fix(web): 固定 live 参与者入口在状态末尾

### DIFF
--- a/web/src/components/PresenceBar.test.ts
+++ b/web/src/components/PresenceBar.test.ts
@@ -319,6 +319,21 @@ describe("busy indicator + queue depth (#103)", () => {
 });
 
 describe("presence live roster dialog (#484)", () => {
+  test("keeps the live roster button last after every status badge (#179)", () => {
+    const r = renderWith(busyEntry({ connection_count: 2 }), { party: true });
+    const meta = r.root.findByProps({ "aria-label": "channel presence summary" });
+    const directClasses = meta.children.map((child) =>
+      typeof child === "string" ? "" : String(child.props.className ?? ""),
+    );
+
+    expect(directClasses).toEqual([
+      "d-hl party-badge",
+      "t-mono presence-alert presence-alert--busy",
+      "t-mono presence-alert presence-alert--duplicate",
+      "presence-toggle",
+    ]);
+  });
+
   // #179 的可点击计数保留；#484 把姓名列表从顶部条移进独立 modal。
   test("the live count is a real button that toggles an accessible participant dialog", async () => {
     const r = renderPresence(presenceEntry());

--- a/web/src/components/PresenceBar.tsx
+++ b/web/src/components/PresenceBar.tsx
@@ -724,6 +724,18 @@ export function PresenceBar({
         <div className="presence-meta" aria-label="channel presence summary">
           {isPublic && <span className="d-hl public-badge">{publicWatch ? "WATCH" : "PUBLIC"}</span>}
           {party && <span className="d-hl party-badge">PARTY</span>}
+          {blockedCount > 0 && <span className="t-mono presence-alert">{blockedCount} blocked</span>}
+          {busyCount > 0 && (
+            <span className="t-mono presence-alert presence-alert--busy" title="serially handling a wake — reachable, reply may be slow">
+              ⏳ {busyCount} busy
+            </span>
+          )}
+          {duplicateCount > 0 && <span className="t-mono presence-alert presence-alert--duplicate">{duplicateCount} duplicate</span>}
+          {items.length === 0 && (
+            <span className="t-mono presence-empty" role="status" aria-live="polite">
+              nobody here yet
+            </span>
+          )}
           <button
             ref={rosterToggleRef}
             type="button"
@@ -738,18 +750,6 @@ export function PresenceBar({
             </span>
             <span className="presence-toggle-arrow" aria-hidden="true">{rosterOpen ? "▾" : "▸"}</span>
           </button>
-          {blockedCount > 0 && <span className="t-mono presence-alert">{blockedCount} blocked</span>}
-          {busyCount > 0 && (
-            <span className="t-mono presence-alert presence-alert--busy" title="serially handling a wake — reachable, reply may be slow">
-              ⏳ {busyCount} busy
-            </span>
-          )}
-          {duplicateCount > 0 && <span className="t-mono presence-alert presence-alert--duplicate">{duplicateCount} duplicate</span>}
-          {items.length === 0 && (
-            <span className="t-mono presence-empty" role="status" aria-live="polite">
-              nobody here yet
-            </span>
-          )}
         </div>
         <span className="conn t-mono" data-s={status} role="status" aria-live="polite">
           {status === "open" ? "● live" : `◌ ${status}…`}


### PR DESCRIPTION
Closes #179

- 将 live 参与者入口移动到 blocked / busy / duplicate 等状态徽章之后，保证任何状态组合下都是 presence-meta 最后一个子项
- 保留现有大尺寸参与者 dialog、键盘可达与关闭行为
- 新增 busy + duplicate 组合的直接子项顺序回归测试

验证：
- bun test web/src/components/PresenceBar.test.ts web/src/components/ChannelToolstrip.test.tsx（35 pass）
- bun run check:web（767 pass，tsc 与 vite build 通过）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化频道顶部在线状态栏的展示顺序。
  * 忙碌、重复等状态提示徽章将始终显示在“在线成员”按钮之前，界面布局更加清晰一致。
  * 修复状态提示与在线成员按钮排列不稳定的问题。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->