### PR TITLE
fix(web): 团队面板去掉重复 header (#504)

### DIFF
--- a/web/src/components/TeamTabs.tsx
+++ b/web/src/components/TeamTabs.tsx
@@ -21,9 +21,11 @@ export interface TeamTabsProps {
   board: ReactNode;
   coordination: ReactNode;
   initialTab?: TeamTab;
+  // #504：博客风头自带关闭按钮（设计里 关闭 在头右上）。传入后 modal 隐藏它自己的头，避免双 header。
+  onClose?: () => void;
 }
 
-export function TeamTabs({ stats, mentionCount, division, board, coordination, initialTab = "division" }: TeamTabsProps) {
+export function TeamTabs({ stats, mentionCount, division, board, coordination, initialTab = "division", onClose }: TeamTabsProps) {
   const t = useT();
   const [tab, setTab] = useState<TeamTab>(initialTab);
   const idPrefix = useId();
@@ -62,6 +64,11 @@ export function TeamTabs({ stats, mentionCount, division, board, coordination, i
             {t("Channel.team.badge.unclaimed", { count: String(stats.unclaimed) })}
           </span>
         </div>
+        {onClose !== undefined && (
+          <button type="button" className="d-btn team-blog-close" onClick={onClose}>
+            {t("Channel.tools.close")} ✕
+          </button>
+        )}
       </header>
 
       <nav className="team-blog-tabs" role="tablist" aria-label={t("Channel.tools.team")}>

--- a/web/src/pages/Channel.tsx
+++ b/web/src/pages/Channel.tsx
@@ -983,11 +983,14 @@ export function ChannelPanelModal({
   subtitle,
   onClose,
   children,
+  hideHeader = false,
 }: {
   title: string;
   subtitle?: string;
   onClose: () => void;
   children: ReactNode;
+  // #504：内容自带头部（如团队面板博客风头）时隐藏 modal 默认头，避免双 header。
+  hideHeader?: boolean;
 }) {
   const t = useT();
   useEffect(() => {
@@ -1002,15 +1005,17 @@ export function ChannelPanelModal({
     <div className="channel-panel-overlay" role="dialog" aria-modal="true" aria-label={title}>
       <button className="channel-panel-scrim" type="button" aria-label={t("Channel.tools.close")} onClick={onClose} />
       <section className="channel-panel-card">
-        <header className="channel-panel-head">
-          <div className="channel-panel-titlebox">
-            <h2>{title}</h2>
-            {subtitle !== undefined && subtitle !== "" && <p className="t-mono">{subtitle}</p>}
-          </div>
-          <button className="d-btn channel-panel-close" type="button" onClick={onClose}>
-            {t("Channel.tools.close")}
-          </button>
-        </header>
+        {!hideHeader && (
+          <header className="channel-panel-head">
+            <div className="channel-panel-titlebox">
+              <h2>{title}</h2>
+              {subtitle !== undefined && subtitle !== "" && <p className="t-mono">{subtitle}</p>}
+            </div>
+            <button className="d-btn channel-panel-close" type="button" onClick={onClose}>
+              {t("Channel.tools.close")}
+            </button>
+          </header>
+        )}
         <div className="channel-panel-body">{children}</div>
       </section>
     </div>
@@ -4057,6 +4062,7 @@ export function ChannelPage({
             undefined
           }
           onClose={() => setActivePanel(null)}
+          hideHeader={activePanel === "team"}
         >
           {activePanel === "charter" && (
             <CharterBanner
@@ -4092,6 +4098,7 @@ export function ChannelPage({
             // 结构一目了然、页签带角标。各段数据逻辑不动（DivisionBoard 等原样），TeamTabs 只管外壳。
             // 组织架构树仍在 DivisionBoard 顶部（OrgTreePreview）。
             <TeamTabs
+              onClose={() => setActivePanel(null)}
               stats={{
                 roles: structuredRoleCount,
                 online: onlineAgentCount,

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -6274,9 +6274,10 @@
 /* #504 团队面板「博客风」页签外壳 —— 头部 + 三页签导航，复用 neo-brutalist terminal token。 */
 .team-blog { display: flex; flex-direction: column; gap: 0; }
 .team-blog-head {
-  display: flex; align-items: flex-start; justify-content: space-between; gap: 12px;
+  display: flex; align-items: flex-start; justify-content: flex-start; gap: 14px;
   flex-wrap: wrap; padding-bottom: 10px; border-bottom: 2px solid var(--t-border);
 }
+.team-blog-close { margin-left: auto; align-self: flex-start; flex: none; }
 .team-blog-title { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
 .team-blog-name { margin: 0; font: 700 20px/1.1 var(--t-mono); color: var(--t-text); letter-spacing: -0.5px; }
 .team-blog-prompt { font-size: 12px; color: var(--t-muted); }


### PR DESCRIPTION
review-ack: 跟进 #504。owner 截图指出团队面板叠了**两个「团队」header**——ChannelPanelModal 自带标题头 + TeamTabs 博客风头。设计只有一个头。

## 修复
- `ChannelPanelModal` 加 `hideHeader` prop；团队面板传 `hideHeader={activePanel==="team"}` 隐藏 modal 默认头。
- `关闭` 按钮移进 `TeamTabs` 博客头右上（`关闭 ✕`，对齐设计），传 `onClose`。

## 验证（这次先视觉核对再交付）
- tsc 0 · build · DivisionBoard/TeamTabs 25 测试绿
- **部署 xdream 截图核对**：团队面板现在只有一个头（团队 + 徽标 + 关闭✕ + $cat 提示符），冗余 modal 头已消失。

关联 #504。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 团队面板支持在博客风格头部显示关闭按钮，便于快速退出当前面板。
  * 团队面板弹层支持隐藏默认标题栏，避免与内容自带头部重复显示。

* **样式优化**
  * 调整团队面板头部布局与间距，提升博客风格页签的视觉一致性。
  * 其他面板继续保留原有标题栏和关闭操作。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->