### PR TITLE
fix(web): 修正团队面板在线 Agent 漏计 (#514)

### DIFF
--- a/web/src/pages/AgentBoardPanel.test.tsx
+++ b/web/src/pages/AgentBoardPanel.test.tsx
@@ -4,7 +4,7 @@ import { act, create, type ReactTestRenderer } from "react-test-renderer";
 import type { PresenceEntry, Sender, TaskRecord } from "@agentparty/shared";
 import { LocaleProvider } from "../i18n/locale";
 
-const { AgentBoardPanel } = await import("./Channel");
+const { AgentBoardPanel, agentPresenceSummary } = await import("./Channel");
 
 function memoryStorage(seed: Record<string, string> = {}): Storage {
   const values = new Map<string, string>(Object.entries(seed));
@@ -172,6 +172,12 @@ describe("AgentBoardPanel (#187)", () => {
     expect(treeText(r.root.findByProps({ "data-status": "offline" }))).not.toContain("reconnected");
   });
 
+  test("human-only participant is excluded from every Agent lane (#514)", () => {
+    const txt = allText(render("en", [], [], [{ name: "human-owner", kind: "human" }]));
+    expect(txt).not.toContain("human-owner");
+    expect(txt).toContain("No agents yet");
+  });
+
   test("surfaces scheduling: paused agent with resume_at shows resume time (#187 排期)", () => {
     // 定时恢复：paused + resume_at → 本行展示「暂停至 HH:MM」，时间来自 presence.resume_at
     const at = new Date();
@@ -196,5 +202,28 @@ describe("AgentBoardPanel (#187)", () => {
     const txt = allText(render("en", p, [task(1, "carol", "in_progress")]));
     expect(txt).toContain("carol");
     expect(txt).not.toContain("paused");
+  });
+});
+
+describe("agentPresenceSummary (#514)", () => {
+  test("unions live agents, excludes humans, and keeps unmatched presence offline", () => {
+    const summary = agentPresenceSummary(
+      [
+        presence("reconnected", { state: "offline", live: false }),
+        presence("offline-agent", { state: "waiting", live: false }),
+        presence("human-presence", { kind: "human", live: true }),
+      ],
+      [
+        { name: "reconnected", kind: "agent" },
+        { name: "participant-only", kind: "agent" },
+        { name: "human-only", kind: "human" },
+        { name: "human-presence", kind: "human" },
+      ],
+    );
+
+    expect([...summary.agentNames].sort()).toEqual(["offline-agent", "participant-only", "reconnected"]);
+    expect([...summary.onlineNames].sort()).toEqual(["participant-only", "reconnected"]);
+    expect(summary.online).toBe(2);
+    expect(summary.offline).toBe(1);
   });
 });

--- a/web/src/pages/AgentBoardPanel.test.tsx
+++ b/web/src/pages/AgentBoardPanel.test.tsx
@@ -1,7 +1,7 @@
 // @ts-expect-error Bun executes this test, while the web tsconfig intentionally loads only Vite globals.
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { act, create, type ReactTestRenderer } from "react-test-renderer";
-import type { PresenceEntry, TaskRecord } from "@agentparty/shared";
+import type { PresenceEntry, Sender, TaskRecord } from "@agentparty/shared";
 import { LocaleProvider } from "../i18n/locale";
 
 const { AgentBoardPanel } = await import("./Channel");
@@ -47,11 +47,16 @@ afterEach(async () => {
   Reflect.deleteProperty(globalThis, "localStorage");
 });
 
-function render(locale: "en" | "zh", presenceList: PresenceEntry[], tasks: TaskRecord[]): ReactTestRenderer {
+function render(
+  locale: "en" | "zh",
+  presenceList: PresenceEntry[],
+  tasks: TaskRecord[],
+  participants: Sender[] = [],
+): ReactTestRenderer {
   Object.defineProperty(globalThis, "localStorage", { configurable: true, value: memoryStorage({ ap_locale: locale }) });
   let r!: ReactTestRenderer;
   void act(() => {
-    r = create(<LocaleProvider><AgentBoardPanel presence={presenceList} tasks={tasks} /></LocaleProvider>);
+    r = create(<LocaleProvider><AgentBoardPanel presence={presenceList} participants={participants} tasks={tasks} /></LocaleProvider>);
   });
   renderer = r;
   return r;
@@ -146,6 +151,25 @@ describe("AgentBoardPanel (#187)", () => {
     const txt = allText(render("en", [], [task(1, "ghost", "assigned")]));
     expect(txt).toContain("ghost");
     expect(txt).toContain("offline");
+  });
+
+  test("participant-only agent is visible and online before its first presence row (#514)", () => {
+    const r = render("en", [], [], [{ name: "fresh-agent", kind: "agent" }]);
+    const idleLane = r.root.findByProps({ "data-status": "idle" });
+    const offlineLane = r.root.findByProps({ "data-status": "offline" });
+    expect(treeText(idleLane)).toContain("fresh-agent");
+    expect(treeText(offlineLane)).not.toContain("fresh-agent");
+  });
+
+  test("live participants override a stale persisted offline row (#514)", () => {
+    const r = render(
+      "en",
+      [presence("reconnected", { state: "offline", live: false })],
+      [],
+      [{ name: "reconnected", kind: "agent" }],
+    );
+    expect(treeText(r.root.findByProps({ "data-status": "idle" }))).toContain("reconnected");
+    expect(treeText(r.root.findByProps({ "data-status": "offline" }))).not.toContain("reconnected");
   });
 
   test("surfaces scheduling: paused agent with resume_at shows resume time (#187 排期)", () => {

--- a/web/src/pages/AgentBoardPanel.test.tsx
+++ b/web/src/pages/AgentBoardPanel.test.tsx
@@ -206,7 +206,7 @@ describe("AgentBoardPanel (#187)", () => {
 });
 
 describe("agentPresenceSummary (#514)", () => {
-  test("unions live agents, excludes humans, and keeps unmatched presence offline", () => {
+  test("unions live and tasked agents, excludes humans, and keeps unmatched entries offline", () => {
     const summary = agentPresenceSummary(
       [
         presence("reconnected", { state: "offline", live: false }),
@@ -219,11 +219,12 @@ describe("agentPresenceSummary (#514)", () => {
         { name: "human-only", kind: "human" },
         { name: "human-presence", kind: "human" },
       ],
+      ["task-only"],
     );
 
-    expect([...summary.agentNames].sort()).toEqual(["offline-agent", "participant-only", "reconnected"]);
+    expect([...summary.agentNames].sort()).toEqual(["offline-agent", "participant-only", "reconnected", "task-only"]);
     expect([...summary.onlineNames].sort()).toEqual(["participant-only", "reconnected"]);
     expect(summary.online).toBe(2);
-    expect(summary.offline).toBe(1);
+    expect(summary.offline).toBe(2);
   });
 });

--- a/web/src/pages/Channel.tsx
+++ b/web/src/pages/Channel.tsx
@@ -3770,7 +3770,10 @@ export function ChannelPage({
   const taskReviewCount = taskSummary?.needs_review ?? tasks.filter((task) => task.state === "needs_review").length;
   const taskBlockedCount = taskSummary?.blocked ?? tasks.filter((task) => task.state === "blocked").length;
   const taskMineCount = taskSummary?.mine ?? 0;
-  const agentPresence = agentPresenceSummary(Object.values(state.presence), state.participants);
+  const agentPresence = useMemo(
+    () => agentPresenceSummary(Object.values(state.presence), state.participants),
+    [state.participants, state.presence],
+  );
   const onlineAgentCount = agentPresence.online;
   // #504 团队面板博客风页签的角标：离线 agent 数 / 未认领分工数 / @我未读数。
   // 未认领复用 DivisionBoard 同款 unassignedMembers（assigned+self 之外的已连接成员），语义一致。

--- a/web/src/pages/Channel.tsx
+++ b/web/src/pages/Channel.tsx
@@ -1515,7 +1515,42 @@ export function TeamPanel({ teams }: { teams: TeamSummary[] }) {
 type AgentBoardStatus = "busy" | "blocked" | "idle" | "offline";
 const AGENT_STATUS_ORDER: Record<AgentBoardStatus, number> = { busy: 0, blocked: 1, idle: 2, offline: 3 };
 
-export function AgentBoardPanel({ presence, tasks }: { presence: PresenceEntry[]; tasks: TaskRecord[] }) {
+export function agentPresenceSummary(presence: PresenceEntry[], participants: Sender[]) {
+  const participantKinds = new Map(participants.map((participant) => [participant.name, participant.kind]));
+  const agentNames = new Set<string>();
+  for (const entry of presence) {
+    if ((participantKinds.get(entry.name) ?? entry.kind) !== "human") agentNames.add(entry.name);
+  }
+  for (const participant of participants) {
+    if (participant.kind === "agent") agentNames.add(participant.name);
+    else agentNames.delete(participant.name);
+  }
+
+  // participants is the Durable Object's authoritative list of currently open
+  // connections. A freshly connected agent does not necessarily have a
+  // persisted presence row yet, so presence.live alone under-counts the board.
+  const onlineNames = new Set(
+    participants
+      .filter((participant) => participant.kind === "agent")
+      .map((participant) => participant.name),
+  );
+  for (const entry of presence) {
+    if (entry.live === true && (participantKinds.get(entry.name) ?? entry.kind) !== "human") {
+      onlineNames.add(entry.name);
+    }
+  }
+  return { agentNames, onlineNames, online: onlineNames.size, offline: agentNames.size - onlineNames.size };
+}
+
+export function AgentBoardPanel({
+  presence,
+  participants = [],
+  tasks,
+}: {
+  presence: PresenceEntry[];
+  participants?: Sender[];
+  tasks: TaskRecord[];
+}) {
   const t = useT();
   const tasksByName = new Map<string, TaskRecord[]>();
   for (const task of tasks) {
@@ -1541,13 +1576,13 @@ export function AgentBoardPanel({ presence, tasks }: { presence: PresenceEntry[]
     );
   }
   const presenceByName = new Map(presence.map((p) => [p.name, p]));
-  const names = new Set<string>();
-  for (const p of presence) if (p.kind !== "human") names.add(p.name);
+  const presenceSummary = agentPresenceSummary(presence, participants);
+  const names = new Set(presenceSummary.agentNames);
   for (const name of tasksByName.keys()) names.add(name);
-  const statusOf = (p: PresenceEntry | undefined): AgentBoardStatus => {
-    if (!p || p.live !== true) return "offline";
-    if (p.state === "blocked") return "blocked";
-    if (p.state === "working") return "busy";
+  const statusOf = (name: string, p: PresenceEntry | undefined): AgentBoardStatus => {
+    if (!presenceSummary.onlineNames.has(name)) return "offline";
+    if (p?.state === "blocked") return "blocked";
+    if (p?.state === "working") return "busy";
     return "idle";
   };
   const rows = [...names]
@@ -1557,7 +1592,7 @@ export function AgentBoardPanel({ presence, tasks }: { presence: PresenceEntry[]
       // #187 第4项「排期」：surface presence 里的暂停/定时恢复（resume_at），看板本行直接可见。
       return {
         name,
-        status: statusOf(p),
+        status: statusOf(name, p),
         note: p?.note ?? null,
         paused: p?.paused === true,
         resumeAt: p?.resume_at ?? null,
@@ -3730,10 +3765,11 @@ export function ChannelPage({
   const taskReviewCount = taskSummary?.needs_review ?? tasks.filter((task) => task.state === "needs_review").length;
   const taskBlockedCount = taskSummary?.blocked ?? tasks.filter((task) => task.state === "blocked").length;
   const taskMineCount = taskSummary?.mine ?? 0;
-  const onlineAgentCount = Object.values(state.presence).filter((entry) => entry.kind !== "human" && entry.live === true).length;
+  const agentPresence = agentPresenceSummary(Object.values(state.presence), state.participants);
+  const onlineAgentCount = agentPresence.online;
   // #504 团队面板博客风页签的角标：离线 agent 数 / 未认领分工数 / @我未读数。
   // 未认领复用 DivisionBoard 同款 unassignedMembers（assigned+self 之外的已连接成员），语义一致。
-  const offlineAgentCount = Object.values(state.presence).filter((entry) => entry.kind !== "human" && entry.live !== true).length;
+  const offlineAgentCount = agentPresence.offline;
   const unclaimedTeamCount = unassignedMembers(
     channelRoles,
     selfReportedRoles(channelRoles, state.presence, channelIdentities),
@@ -4126,7 +4162,7 @@ export function ChannelPage({
                   onOpenAgentDetail={setOpenAgentDetail}
                 />
               }
-              board={<AgentBoardPanel presence={Object.values(state.presence)} tasks={tasks} />}
+              board={<AgentBoardPanel presence={Object.values(state.presence)} participants={state.participants} tasks={tasks} />}
               coordination={coordinationContent}
             />
           )}

--- a/web/src/pages/Channel.tsx
+++ b/web/src/pages/Channel.tsx
@@ -1520,7 +1520,11 @@ export function TeamPanel({ teams }: { teams: TeamSummary[] }) {
 type AgentBoardStatus = "busy" | "blocked" | "idle" | "offline";
 const AGENT_STATUS_ORDER: Record<AgentBoardStatus, number> = { busy: 0, blocked: 1, idle: 2, offline: 3 };
 
-export function agentPresenceSummary(presence: PresenceEntry[], participants: Sender[]) {
+export function agentPresenceSummary(
+  presence: PresenceEntry[],
+  participants: Sender[],
+  taskAgentNames: Iterable<string> = [],
+) {
   const participantKinds = new Map(participants.map((participant) => [participant.name, participant.kind]));
   const agentNames = new Set<string>();
   for (const entry of presence) {
@@ -1530,6 +1534,7 @@ export function agentPresenceSummary(presence: PresenceEntry[], participants: Se
     if (participant.kind === "agent") agentNames.add(participant.name);
     else agentNames.delete(participant.name);
   }
+  for (const name of taskAgentNames) agentNames.add(name);
 
   // participants is the Durable Object's authoritative list of currently open
   // connections. A freshly connected agent does not necessarily have a
@@ -1547,6 +1552,14 @@ export function agentPresenceSummary(presence: PresenceEntry[], participants: Se
   return { agentNames, onlineNames, online: onlineNames.size, offline: agentNames.size - onlineNames.size };
 }
 
+export function agentBoardTaskAssignee(task: TaskRecord): string | null {
+  const name = task.assignee?.name;
+  if (!name || task.assignee?.kind !== "agent") return null;
+  return task.state === "in_progress" || task.state === "assigned" || task.state === "needs_review" || task.state === "blocked"
+    ? name
+    : null;
+}
+
 export function AgentBoardPanel({
   presence,
   participants = [],
@@ -1559,9 +1572,8 @@ export function AgentBoardPanel({
   const t = useT();
   const tasksByName = new Map<string, TaskRecord[]>();
   for (const task of tasks) {
-    const name = task.assignee?.name;
-    if (!name || task.assignee?.kind !== "agent") continue;
-    if (task.state !== "in_progress" && task.state !== "assigned" && task.state !== "needs_review" && task.state !== "blocked") continue;
+    const name = agentBoardTaskAssignee(task);
+    if (name === null) continue;
     const assigned = tasksByName.get(name) ?? [];
     assigned.push(task);
     tasksByName.set(name, assigned);
@@ -1581,9 +1593,8 @@ export function AgentBoardPanel({
     );
   }
   const presenceByName = new Map(presence.map((p) => [p.name, p]));
-  const presenceSummary = agentPresenceSummary(presence, participants);
+  const presenceSummary = agentPresenceSummary(presence, participants, tasksByName.keys());
   const names = new Set(presenceSummary.agentNames);
-  for (const name of tasksByName.keys()) names.add(name);
   const statusOf = (name: string, p: PresenceEntry | undefined): AgentBoardStatus => {
     if (!presenceSummary.onlineNames.has(name)) return "offline";
     if (p?.state === "blocked") return "blocked";
@@ -3771,8 +3782,12 @@ export function ChannelPage({
   const taskBlockedCount = taskSummary?.blocked ?? tasks.filter((task) => task.state === "blocked").length;
   const taskMineCount = taskSummary?.mine ?? 0;
   const agentPresence = useMemo(
-    () => agentPresenceSummary(Object.values(state.presence), state.participants),
-    [state.participants, state.presence],
+    () => agentPresenceSummary(
+      Object.values(state.presence),
+      state.participants,
+      tasks.map(agentBoardTaskAssignee).filter((name): name is string => name !== null),
+    ),
+    [state.participants, state.presence, tasks],
   );
   const onlineAgentCount = agentPresence.online;
   // #504 团队面板博客风页签的角标：离线 agent 数 / 未认领分工数 / @我未读数。


### PR DESCRIPTION
Closes #514

## 问题
团队角标和 Agent 看板只消费持久化 `presence`。Agent 已经建立实时连接、但尚未写入第一条 presence/status 时会完全消失；重连后旧的离线行也可能覆盖当前在线事实。

## 修复
- 将 Durable Object 下发的实时 `participants` 与 `presence` 按 name 合并
- 当前连接中的 agent 作为在线权威信号
- 团队角标与 Agent 看板复用同一汇总口径
- human 不进入 Agent 统计

## 验证
- 新增 participant-only agent 首次连接回归测试
- 新增实时 participant 覆盖旧离线 presence 回归测试
- `bun test web/src/pages/AgentBoardPanel.test.tsx`：9 pass
- `bun run check:web`：772 pass，tsc 与 Vite build 通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 优化团队面板 Agent 状态口径：已连接但尚未落盘 presence 的 Agent 会正确计入在线；陈旧离线记录会被同名在线参与者覆盖，避免误入离线或停留在错误状态。
  * 统一页签角标与 Agent 分栏的在线/离线人数统计，并补齐“有任务但尚未落盘”的显示缺口。
  * blocked/working 等状态映射到对应看板状态；human 类型参与者不会出现在任何 Agent 分栏，空态文案保持一致。
* **Tests**
  * 新增/更新用例覆盖上述场景与汇总逻辑校验。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->