### PR TITLE
fix(cli): 持久化临时 Agent 身份配置 (#518)

### DIFF
--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -2,6 +2,7 @@
 import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
 import {
   bindWorkspaceConfigPointer,
+  durableConfigPointerPath,
   explicitConfigPath,
   readConfig,
   readConfigWithSource,
@@ -124,7 +125,7 @@ export async function run(argv: string[]): Promise<number> {
     // 用了 AGENTPARTY_CONFIG 隔离时，往 cwd-state 记面包屑：被唤醒回复轮丢了 env 也能找回本 agent
     // 的 config，不回落到人类账号会话（issue #42）。同 cwd 多 agent 仍会撞指针——那种要用不同 cwd。
     const explicit = explicitConfigPath();
-    if (explicit) bindWorkspaceConfigPointer(explicit, channel);
+    if (explicit) bindWorkspaceConfigPointer(durableConfigPointerPath(explicit), channel);
     console.log(`bound channel ${channel}`);
   } else {
     writeConfig(cfg);

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -1,6 +1,6 @@
 // 全局配置与 workspace 游标状态
-import { homedir } from "node:os";
-import { basename, dirname, join } from "node:path";
+import { homedir, tmpdir } from "node:os";
+import { basename, dirname, join, resolve, sep } from "node:path";
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
@@ -104,6 +104,10 @@ export function explicitConfigPath(): string | null {
 export function globalConfigPath(): string {
   const explicit = explicitConfigPath();
   if (explicit) return explicit;
+  return defaultGlobalConfigPath();
+}
+
+function defaultGlobalConfigPath(): string {
   return join(agentpartyHome(), "config.json");
 }
 
@@ -114,7 +118,65 @@ export function globalConfigPath(): string {
 export function workspaceConfigPath(cwd: string = process.cwd()): string {
   const explicit = explicitConfigPath();
   if (explicit) return explicit;
+  return defaultWorkspaceConfigPath(cwd);
+}
+
+function defaultWorkspaceConfigPath(cwd: string): string {
   return join(agentpartyHome(), "state", workspaceId(cwd), "config.json");
+}
+
+function canonicalPath(path: string): string {
+  try {
+    return realpathSync(path);
+  } catch {
+    // TMPDIR 被整目录清掉后，直接 realpath(dirname(path)) 也会失败。向上找到最近仍存在的
+    // 祖先（macOS 通常是 /var/folders/.../T），先消解 /var → /private/var，再接回尾段。
+    let current = resolve(path);
+    const tail: string[] = [];
+    while (!existsSync(current)) {
+      const parent = dirname(current);
+      if (parent === current) return resolve(path);
+      tail.unshift(basename(current));
+      current = parent;
+    }
+    try {
+      return join(realpathSync(current), ...tail);
+    } catch {
+      return resolve(path);
+    }
+  }
+}
+
+function isWithin(path: string, root: string): boolean {
+  const candidate = canonicalPath(path);
+  const base = canonicalPath(root);
+  return candidate === base || candidate.startsWith(base.endsWith(sep) ? base : `${base}${sep}`);
+}
+
+/**
+ * 临时目录不能成为 agent token 的唯一存储（#518）。
+ *
+ * 保留调用方给出的文件名（spawn / invite 已含 agent+channel），但把副本放进
+ * ~/.agentparty/agents。AGENTPARTY_HOME 本身视为显式持久根，即使测试或高级用户把它
+ * 指到了系统临时目录，也不对它递归再镜像。
+ */
+export function durableConfigPointerPath(path: string): string {
+  if (isWithin(path, agentpartyHome())) return path;
+  const ephemeral = [tmpdir(), "/tmp", "/private/tmp"].some((root) => isWithin(path, root));
+  if (!ephemeral) return path;
+
+  const rawStem = basename(path).replace(/\.json$/i, "");
+  const stem = slugifyBasename(rawStem);
+  const stableStem = stem.startsWith("agentparty-")
+    ? stem
+    : `${stem}-${createHash("sha256").update(canonicalPath(path)).digest("hex").slice(0, 8)}`;
+  return join(agentpartyHome(), "agents", `${stableStem}.json`);
+}
+
+function writeConfigFile(path: string, cfg: Config): void {
+  atomicWriteJson(path, cfg);
+  const durable = durableConfigPointerPath(path);
+  if (durable !== path) atomicWriteJson(durable, cfg);
 }
 
 // 兼容旧调用：优先返回存在的 workspace 级路径，否则全局路径。
@@ -136,18 +198,56 @@ function sourceInfo(kind: ConfigSourceKind, path: string | null, cfg: Config | n
   };
 }
 
+function readBreadcrumbConfig(cwd: string): ConfigWithSource | null {
+  try {
+    const st = JSON.parse(readFileSync(cwdStatePath(cwd), "utf8")) as WorkspaceState;
+    const breadcrumb = st.bindings?.[st.channel] ?? st.config_path;
+    if (!breadcrumb) return null;
+    try {
+      const cfg = JSON.parse(readFileSync(breadcrumb, "utf8")) as Config;
+      return { config: cfg, source: sourceInfo("explicit", breadcrumb, cfg, cwd) };
+    } catch {
+      console.error(`warning: workspace config breadcrumb is unreadable: ${breadcrumb}; falling back to global config`);
+    }
+  } catch {
+    /* 无 cwd state */
+  }
+  return null;
+}
+
 export function readConfigWithSource(cwd: string = process.cwd()): ConfigWithSource {
   const explicit = explicitConfigPath();
+  let missingExplicit: ConfigSourceInfo | null = null;
   if (explicit) {
     try {
       const cfg = JSON.parse(readFileSync(explicit, "utf8")) as Config;
       return { config: cfg, source: sourceInfo("explicit", explicit, cfg, cwd) };
     } catch {
-      return { config: null, source: sourceInfo("explicit", explicit, null, cwd) };
+      // 显式路径若被 TMPDIR 清理，只尝试 workspace breadcrumb 的同身份持久镜像（#518）。
+      // 若镜像也失败，保留 explicit source 并失败关闭，诊断仍能指出真正丢失的路径。
+      missingExplicit = sourceInfo("explicit", explicit, null, cwd);
     }
   }
 
-  const ws = workspaceConfigPath(cwd);
+  // 显式路径丢失时，只接受由该路径确定性推导出的持久镜像；不能盲信 cwd 中可能属于
+  // 另一并发 agent 的 breadcrumb，否则会从“丢身份”变成更危险的静默串号。
+  if (missingExplicit) {
+    const durable = durableConfigPointerPath(explicit!);
+    if (durable !== explicit) {
+      try {
+        const cfg = JSON.parse(readFileSync(durable, "utf8")) as Config;
+        return { config: cfg, source: sourceInfo("explicit", durable, cfg, cwd) };
+      } catch {
+        /* 持久镜像同样不可读：下面失败关闭 */
+      }
+    }
+    // AGENTPARTY_CONFIG 是明确的身份选择；其本体和持久 breadcrumb 都不可读时必须失败关闭，
+    // 不能继续拿 workspace/global 的另一枚 token 冒充当前 agent。
+    return { config: null, source: missingExplicit };
+  }
+
+  // 走到这里说明没有 AGENTPARTY_CONFIG，按正常 workspace → breadcrumb → global 顺序读取。
+  const ws = defaultWorkspaceConfigPath(cwd);
   try {
     const cfg = JSON.parse(readFileSync(ws, "utf8")) as Config;
     return { config: cfg, source: sourceInfo("workspace", ws, cfg, cwd) };
@@ -156,22 +256,10 @@ export function readConfigWithSource(cwd: string = process.cwd()): ConfigWithSou
   }
 
   // cwd 绑定优先于全局兜底（#359）。bindings 是新格式；config_path 是旧状态兼容镜像。
-  try {
-    const st = JSON.parse(readFileSync(cwdStatePath(cwd), "utf8")) as WorkspaceState;
-    const breadcrumb = st.bindings?.[st.channel] ?? st.config_path;
-    if (breadcrumb) {
-      try {
-        const cfg = JSON.parse(readFileSync(breadcrumb, "utf8")) as Config;
-        return { config: cfg, source: sourceInfo("explicit", breadcrumb, cfg, cwd) };
-      } catch {
-        console.error(`warning: workspace config breadcrumb is unreadable: ${breadcrumb}; falling back to global config`);
-      }
-    }
-  } catch {
-    /* 无 cwd state */
-  }
+  const breadcrumb = readBreadcrumbConfig(cwd);
+  if (breadcrumb) return breadcrumb;
 
-  const global = globalConfigPath();
+  const global = defaultGlobalConfigPath();
   try {
     const cfg = JSON.parse(readFileSync(global, "utf8")) as Config;
     return { config: cfg, source: sourceInfo("global", global, cfg, cwd) };
@@ -188,7 +276,7 @@ export function readConfig(cwd: string = process.cwd()): Config | null {
 export function writeConfig(cfg: Config, cwd: string = process.cwd()): void {
   const explicit = explicitConfigPath();
   if (explicit) {
-    atomicWriteJson(explicit, cfg);
+    writeConfigFile(explicit, cfg);
     return;
   }
   // 配置里有 token 明文，收紧到仅属主可读写；对已存在的文件补 chmod
@@ -211,7 +299,7 @@ export function writeConfig(cfg: Config, cwd: string = process.cwd()): void {
 export function refreshConfigInPlace(cfg: Config, cwd: string = process.cwd()): void {
   const { source } = readConfigWithSource(cwd);
   if (source.kind === "none" || source.path === null) return; // 没有来源就没有该刷新的东西
-  atomicWriteJson(source.path, cfg);
+  writeConfigFile(source.path, cfg);
 }
 
 export function slugifyBasename(name: string): string {
@@ -298,8 +386,19 @@ function migrateLegacyWorkspaceState(cwd: string): void {
 
 export function statePath(cwd: string = process.cwd()): string {
   const explicit = explicitConfigPath();
-  if (explicit) return join(dirname(explicit), `${basename(explicit)}.state`, "state.json");
+  if (explicit) return configScopedStatePath(explicit);
   return join(agentpartyHome(), "state", workspaceId(cwd), "state.json");
+}
+
+function configScopedStatePath(configPath: string): string {
+  return join(dirname(configPath), `${basename(configPath)}.state`, "state.json");
+}
+
+function durableStatePath(): string | null {
+  const explicit = explicitConfigPath();
+  if (!explicit) return null;
+  const durable = durableConfigPointerPath(explicit);
+  return durable === explicit ? null : configScopedStatePath(durable);
 }
 
 // cwd 基准的 state 路径，永远无视 AGENTPARTY_CONFIG——面包屑指针写这里，回复轮（无 env）才找得到。
@@ -392,18 +491,28 @@ export function bindWorkspaceConfigPointer(configPath: string, channel: string, 
 
 export function readState(cwd: string = process.cwd()): WorkspaceState | null {
   migrateLegacyWorkspaceState(cwd);
-  try {
-    return JSON.parse(readFileSync(statePath(cwd), "utf8")) as WorkspaceState;
-  } catch {
-    return null;
+  const durable = durableStatePath();
+  const paths = [statePath(cwd), durable, explicitConfigPath() && !durable ? null : cwdStatePath(cwd)].filter(
+    (path, index, all): path is string => path !== null && all.indexOf(path) === index,
+  );
+  for (const path of paths) {
+    const state = readStateFile(path);
+    if (state) return state;
   }
+  return null;
+}
+
+function writeStateCopies(primary: string, st: WorkspaceState): void {
+  atomicWriteJson(primary, st);
+  const durable = durableStatePath();
+  if (durable && durable !== primary) atomicWriteJson(durable, st);
 }
 
 // tmp + rename 原子替换（#113）：裸 writeFileSync 在崩溃/并发下会留下截断的 JSON，
 // readState 随即返回 null → 游标退回 0 → 整个保留窗口的 @ 被重放。范本同 statusline-cache.ts。
 export function writeState(st: WorkspaceState, cwd: string = process.cwd()): void {
   const p = statePath(cwd);
-  withStateLock(p, () => atomicWriteJson(p, st));
+  withStateLock(p, () => writeStateCopies(p, st));
 }
 
 export function resolveChannel(explicit?: string, cwd?: string): string | null {
@@ -429,7 +538,7 @@ function updateChannelCursor(
   migrateLegacyWorkspaceState(cwd);
   const p = statePath(cwd);
   withStateLock(p, () => {
-    const st = readStateFile(p) ?? { channel, cursor: 0 };
+    const st = readStateFile(p) ?? readState(cwd) ?? { channel, cursor: 0 };
     const next = update(channelCursor(st, channel));
     if (next === null) return;
     const merged: WorkspaceState = {
@@ -441,7 +550,7 @@ function updateChannelCursor(
       if (next.rev_cursor === undefined) delete merged.rev_cursor;
       else merged.rev_cursor = next.rev_cursor;
     }
-    atomicWriteJson(p, merged);
+    writeStateCopies(p, merged);
   });
 }
 

--- a/cli/src/oidc-cli.ts
+++ b/cli/src/oidc-cli.ts
@@ -10,12 +10,13 @@ import { readFileSync } from "node:fs";
 function orphanedAgentPointer(): string | null {
   try {
     const st = JSON.parse(readFileSync(cwdStatePath(), "utf8")) as WorkspaceState;
-    if (!st.config_path) return null;
+    const pointer = st.bindings?.[st.channel] ?? st.config_path;
+    if (!pointer) return null;
     try {
-      readFileSync(st.config_path, "utf8");
+      readFileSync(pointer, "utf8");
       return null; // 文件还在，readConfigWithSource 的面包屑回落已经用它了，不是孤儿
     } catch {
-      return st.config_path;
+      return pointer;
     }
   } catch {
     return null;
@@ -379,8 +380,15 @@ export async function resolveAuthDetailed(): Promise<ResolvedAuthDetailed> {
     if (orphan) {
       console.error(
         `⚠ identity would resolve to human account (${sess.email ?? "logged-in user"}), but this workspace was bound to an agent config at ${orphan} which is now missing. ` +
-          `if you are the agent, restore that file or run every command with AGENTPARTY_CONFIG=<path> (issue #42).`,
+          `refusing human-account fallback; restore that file or run every command with AGENTPARTY_CONFIG=<path> (issues #42/#518).`,
       );
+      return {
+        server,
+        token: null,
+        auth_source: "none",
+        config: source,
+        account: accountInfo(sess),
+      };
     }
     const { token } = await ensureFreshAccess(sess);
     return {

--- a/cli/test/account.test.ts
+++ b/cli/test/account.test.ts
@@ -4,7 +4,7 @@ import { mkdtempSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { accountPath, readAccount, writeAccount, clearAccount } from "../src/account";
-import { writeConfig } from "../src/config";
+import { writeConfig, writeState } from "../src/config";
 import {
   challengeFor,
   decodeJwtPayload,
@@ -30,6 +30,7 @@ beforeEach(() => {
 
 afterEach(() => {
   delete process.env.AGENTPARTY_HOME;
+  delete process.env.AGENTPARTY_CONFIG;
   rmSync(home, { recursive: true, force: true });
   mock?.stop();
   mock = null;
@@ -188,6 +189,29 @@ describe("resolveAuth precedence", () => {
     });
     const auth = await resolveAuth();
     expect(auth).toEqual({ server: "https://issuer.example.com", token: "acc-live" });
+  });
+
+  test("missing bound agent config fails closed instead of falling back to a human account (#518)", async () => {
+    const missing = join(home, "agents", "missing-agent.json");
+    writeState({ channel: "dev", cursor: 0, config_path: missing, bindings: { dev: missing } });
+    writeAccount({
+      server: "https://issuer.example.com",
+      refresh_token: "ref",
+      access_token: "acc-live",
+      expires_at: nowSec() + 3600,
+      email: "human@example.com",
+    });
+    const errors: string[] = [];
+    const originalError = console.error;
+    console.error = (...args: unknown[]) => errors.push(args.join(" "));
+    try {
+      const auth = await resolveAuthDetailed();
+      expect(auth).toMatchObject({ server: "https://issuer.example.com", token: null, auth_source: "none" });
+    } finally {
+      console.error = originalError;
+    }
+    expect(errors.join("\n")).toContain("refusing human-account fallback");
+    expect(errors.join("\n")).toContain(missing);
   });
 
   test("null when neither present", async () => {

--- a/cli/test/config.test.ts
+++ b/cli/test/config.test.ts
@@ -1,11 +1,12 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync, statSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createHash } from "node:crypto";
 import {
   bindWorkspaceConfigPointer,
   cwdStatePath,
+  durableConfigPointerPath,
   globalConfigPath,
   loadCursor,
   readConfig,
@@ -24,15 +25,18 @@ import {
 } from "../src/config";
 
 let home: string;
+let volatileDirs: string[];
 
 beforeEach(() => {
   home = mkdtempSync(join(tmpdir(), "ap-test-"));
+  volatileDirs = [];
   process.env.AGENTPARTY_HOME = home;
 });
 
 afterEach(() => {
   delete process.env.AGENTPARTY_HOME;
   delete process.env.AGENTPARTY_CONFIG;
+  for (const dir of volatileDirs) rmSync(dir, { recursive: true, force: true });
   rmSync(home, { recursive: true, force: true });
 });
 
@@ -234,6 +238,49 @@ describe("workspace state", () => {
     expect(r.config?.token).toBe("ap_AGENT");
     expect(r.source.kind).toBe("explicit");
     expect(r.source.path).toBe(cfgPath);
+  });
+
+  test("TMPDIR config is mirrored persistently and recovers even while the explicit path stays missing (#518)", () => {
+    const volatile = mkdtempSync(join(tmpdir(), "ap-volatile-config-"));
+    volatileDirs.push(volatile);
+    const tempConfig = join(volatile, "agentparty-worker-dev.json");
+    const durable = join(home, "agents", "agentparty-worker-dev.json");
+
+    process.env.AGENTPARTY_CONFIG = tempConfig;
+    writeConfig({ server: "https://agentparty.example.com", token: "ap_DURABLE" }, cwd);
+    writeState({ channel: "dev", cursor: 9 }, cwd);
+    expect(durableConfigPointerPath(tempConfig)).toBe(durable);
+    expect(statSync(durable).mode & 0o777).toBe(0o600);
+    bindWorkspaceConfigPointer(durableConfigPointerPath(tempConfig), "dev", cwd);
+
+    rmSync(volatile, { recursive: true, force: true });
+    const recovered = readConfigWithSource(cwd);
+    expect(recovered).toMatchObject({
+      config: { server: "https://agentparty.example.com", token: "ap_DURABLE" },
+      source: { kind: "explicit", path: durable },
+    });
+    expect(readState(cwd)).toMatchObject({ channel: "dev", cursor: 9 });
+    const breadcrumbState = JSON.parse(readFileSync(cwdStatePath(cwd), "utf8"));
+    expect(breadcrumbState).toMatchObject({
+      config_path: durable,
+      bindings: { dev: durable },
+    });
+  });
+
+  test("a missing persistent explicit config fails closed instead of borrowing another workspace identity (#518)", () => {
+    writeConfig({ server: "s", token: "ap_global" }, "/tmp/global-identity");
+    const other = join(home, "agents", "other-agent.json");
+    process.env.AGENTPARTY_CONFIG = other;
+    writeConfig({ server: "s", token: "ap_OTHER" }, cwd);
+    bindWorkspaceConfigPointer(other, "dev", cwd);
+
+    const missing = join(home, "agents", "missing-agent.json");
+    process.env.AGENTPARTY_CONFIG = missing;
+    expect(readConfigWithSource(cwd)).toMatchObject({
+      config: null,
+      source: { kind: "explicit", path: missing },
+    });
+    expect(readState(cwd)).toBeNull();
   });
 
   test("channel bindings survive later init and channel follows the latest init (#360)", () => {

--- a/cli/test/history.test.ts
+++ b/cli/test/history.test.ts
@@ -7,6 +7,8 @@ import { join } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { run } from "../src/commands/history";
+import { writeAccount } from "../src/account";
+import { writeState } from "../src/config";
 import { messagesQuery, TAIL_BEFORE } from "../src/rest";
 
 let home: string;
@@ -94,6 +96,26 @@ function captureSearch(): { get: () => string } {
 }
 
 describe("party history 参数解析（#151）", () => {
+  test("missing bound agent config is loud and exits non-zero instead of using a human account (#518)", async () => {
+    rmSync(join(home, "config.json"), { force: true });
+    const missing = join(home, "agents", "missing-agent.json");
+    writeState({ channel: "dev", cursor: 0, config_path: missing, bindings: { dev: missing } });
+    writeAccount({
+      server: "https://issuer.example.com",
+      refresh_token: "ref",
+      access_token: "acc-live",
+      expires_at: Math.floor(Date.now() / 1000) + 3600,
+      email: "human@example.com",
+    });
+    globalThis.fetch = (async () => {
+      throw new Error("history must fail before making a request with the human token");
+    }) as unknown as typeof fetch;
+
+    expect(await run(["dev"])).toBe(1);
+    expect(stderr.join("\n")).toContain("refusing human-account fallback");
+    expect(stderr.join("\n")).toContain("no config");
+  });
+
   test("attachment-only history output contains actionable metadata (#362)", async () => {
     globalThis.fetch = (async () => Response.json({
       messages: [{


### PR DESCRIPTION
## Summary
- 临时目录中的显式 Agent config 自动镜像到 `~/.agentparty/agents/`，state/cursor 同步持久化
- `$TMPDIR` 被整目录清理后，即使 `AGENTPARTY_CONFIG` 仍指向失效路径，也能从同身份持久镜像恢复
- config 与镜像都不可读时失败关闭，禁止回落到其他 workspace/global token 或人类账号
- `party history` 在 orphan identity 下响亮报错并非零退出

## Verification
- `bun test cli/test/config.test.ts cli/test/account.test.ts cli/test/history.test.ts`（52 pass）
- `bunx tsc --noEmit -p cli/tsconfig.json`
- `bun run check:cli`

Closes #518

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 配置与工作区状态现在支持持久化镜像，临时目录中的配置也能更可靠地恢复。
  * 优化配置读取顺序，优先使用当前工作区绑定的配置，减少身份或配置错配。
  * 配置文件缺失或不可读时将明确报错并停止操作，不再错误回退到其他账号会话。
  * 完善相关错误提示，帮助快速定位丢失的配置路径。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->