### PR TITLE
fix: 修复 Lark 搜索、附件分享与 Agent 会话恢复

### DIFF
--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -599,7 +599,7 @@ export interface Attachment {
   filename: string;
   content_type: string;
   size: number;
-  /** 回 worker 的鉴权下载路径 /api/channels/<slug>/attachments/<uuid>/<filename>；不是裸 R2 公链 */
+  /** 回 worker 的私有下载路径；授权客户端可为它换取短时签名 URL，不暴露裸 R2 公链。 */
   url: string;
 }
 

--- a/web/src/components/AttachmentList.tsx
+++ b/web/src/components/AttachmentList.tsx
@@ -1,8 +1,7 @@
 // 消息附件渲染（#176）：图片内联缩略图，其它文件给下载按钮。
-// 下载端点要 Bearer 鉴权，<img src>/<a href> 带不了头，所以先 fetch 成 blob 再造 objectURL。
 import { useEffect, useState } from "react";
 import type { Attachment } from "@agentparty/shared";
-import { fetchAttachmentBlob, getToken } from "../lib/api";
+import { fetchAttachmentBlob, fetchAttachmentSignedUrl, getToken } from "../lib/api";
 
 export function isImageAttachment(contentType: string): boolean {
   return contentType.startsWith("image/");
@@ -14,7 +13,8 @@ export function formatSize(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
-// 鉴权下载端点带不了 <img> 头，先 fetch 成 blob 再造 objectURL。消息缩略图与 composer 待发预览共用。
+// 先换短时签名 URL，让 <img src>、新标签页和 Lark 等不能带 Authorization 的消费端都能读取。
+// 老 worker 没有签名接口时回退 blob，保持滚动发布期间兼容。
 export function useAttachmentBlobUrl(url: string): { src: string | null; failed: boolean } {
   const [src, setSrc] = useState<string | null>(null);
   const [failed, setFailed] = useState(false);
@@ -24,12 +24,22 @@ export function useAttachmentBlobUrl(url: string): { src: string | null; failed:
     setSrc(null);
     setFailed(false);
     if (url === "") return; // 非图片附件传空串 → 不发请求（hook 不能条件调用，用空串跳过）
-    fetchAttachmentBlob(getToken(), url)
-      .then((blob) => {
-        if (!alive) return;
-        objectUrl = URL.createObjectURL(blob);
-        setSrc(objectUrl);
-      })
+    const token = getToken();
+    void (async () => {
+      if (token) {
+        try {
+          const signedUrl = await fetchAttachmentSignedUrl(token, url);
+          if (alive) setSrc(signedUrl);
+          return;
+        } catch {
+          // Rolling deploy / self-hosted old worker: fall back to the authenticated blob path.
+        }
+      }
+      const blob = await fetchAttachmentBlob(token, url);
+      if (!alive) return;
+      objectUrl = URL.createObjectURL(blob);
+      setSrc(objectUrl);
+    })()
       .catch(() => {
         if (alive) setFailed(true);
       });
@@ -57,7 +67,19 @@ function ImageThumb({ att }: { att: Attachment }) {
 function FileLink({ att }: { att: Attachment }) {
   const onDownload = async () => {
     try {
-      const blob = await fetchAttachmentBlob(getToken(), att.url);
+      const token = getToken();
+      if (token) {
+        const signedUrl = await fetchAttachmentSignedUrl(token, att.url);
+        const a = document.createElement("a");
+        a.href = signedUrl;
+        a.download = att.filename;
+        a.rel = "noreferrer";
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        return;
+      }
+      const blob = await fetchAttachmentBlob(null, att.url);
       const objectUrl = URL.createObjectURL(blob);
       const a = document.createElement("a");
       a.href = objectUrl;

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -295,7 +295,22 @@ export async function uploadAttachment(token: string, slug: string, file: File):
   return (await res.json()) as Attachment;
 }
 
-// 附件下载（#176）：下载端点要 Bearer 鉴权，<img src>/<a href> 带不了头，所以取回 blob 再造 objectURL。
+// 为不能带 Authorization 的消费端换一个 15 分钟签名 URL（#521）。原始附件路径仍保持私有，
+// 签名只授予单个 pathname 的短时 GET 权限，不把 bearer 放进 query string。
+export async function fetchAttachmentSignedUrl(token: string, url: string): Promise<string> {
+  const separator = url.includes("?") ? "&" : "?";
+  const res = await fetchApi(`${url}${separator}signed-url=1`, {
+    headers: { authorization: `Bearer ${token}` },
+  });
+  if (res.status === 401) throw new AuthError("invalid or revoked token");
+  if (res.status === 403) throw new ForbiddenError("not allowed to read this attachment");
+  if (!res.ok) throw new Error(`sign attachment failed (${res.status})`);
+  const body = (await res.json()) as { url?: unknown };
+  if (typeof body.url !== "string" || body.url.length === 0) throw new Error("signed attachment URL missing");
+  return body.url;
+}
+
+// 兼容旧 worker / 非浏览器下载路径：仍可用 bearer 直接取 blob。
 export async function fetchAttachmentBlob(token: string | null, url: string): Promise<Blob> {
   const res = await fetchApi(url, {
     headers: token ? { authorization: `Bearer ${token}` } : {},

--- a/worker/src/attachment-signatures.ts
+++ b/worker/src/attachment-signatures.ts
@@ -1,0 +1,94 @@
+const SIGNATURE_VERSION = "v1";
+export const ATTACHMENT_SIGNED_URL_TTL_SECONDS = 15 * 60;
+const ATTACHMENT_SIGNED_URL_MAX_FUTURE_SECONDS = ATTACHMENT_SIGNED_URL_TTL_SECONDS + 60;
+
+export type AttachmentSigningEnv = {
+  ATTACHMENT_SIGNING_SECRET?: string;
+  DESKTOP_PAIRING_SECRET?: string;
+  ADMIN_SECRET?: string;
+};
+
+function signingSecret(env: AttachmentSigningEnv): string | null {
+  return env.ATTACHMENT_SIGNING_SECRET?.trim() || env.DESKTOP_PAIRING_SECRET?.trim() || env.ADMIN_SECRET?.trim() || null;
+}
+
+function attachmentPath(pathname: string): boolean {
+  return /^\/api\/channels\/[a-z0-9][a-z0-9-]{0,63}\/attachments\/.+$/u.test(pathname);
+}
+
+function base64url(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/u, "");
+}
+
+function decodeBase64url(value: string): Uint8Array | null {
+  if (!/^[A-Za-z0-9_-]+$/u.test(value)) return null;
+  try {
+    const base64 = value.replace(/-/g, "+").replace(/_/g, "/").padEnd(Math.ceil(value.length / 4) * 4, "=");
+    const binary = atob(base64);
+    return Uint8Array.from(binary, (char) => char.charCodeAt(0));
+  } catch {
+    return null;
+  }
+}
+
+function sameBytes(left: Uint8Array, right: Uint8Array): boolean {
+  if (left.length !== right.length) return false;
+  let diff = 0;
+  for (let i = 0; i < left.length; i += 1) diff |= left[i]! ^ right[i]!;
+  return diff === 0;
+}
+
+async function signature(secret: string, pathname: string, expiresAt: number): Promise<Uint8Array> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  return new Uint8Array(
+    await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(`${SIGNATURE_VERSION}\n${expiresAt}\n${pathname}`)),
+  );
+}
+
+export async function createSignedAttachmentUrl(
+  requestUrl: string,
+  env: AttachmentSigningEnv,
+  nowMs = Date.now(),
+): Promise<{ url: string; expiresAt: number } | null> {
+  const secret = signingSecret(env);
+  const url = new URL(requestUrl);
+  if (secret === null || !attachmentPath(url.pathname)) return null;
+  const expiresAt = Math.floor(nowMs / 1000) + ATTACHMENT_SIGNED_URL_TTL_SECONDS;
+  const signed = await signature(secret, url.pathname, expiresAt);
+  url.search = "";
+  url.searchParams.set("exp", String(expiresAt));
+  url.searchParams.set("sig", base64url(signed));
+  return { url: url.toString(), expiresAt };
+}
+
+export async function verifySignedAttachmentRequest(
+  requestUrl: string,
+  env: AttachmentSigningEnv,
+  nowMs = Date.now(),
+): Promise<boolean> {
+  const secret = signingSecret(env);
+  const url = new URL(requestUrl);
+  if (secret === null || !attachmentPath(url.pathname)) return false;
+  const keys = [...url.searchParams.keys()];
+  if (keys.length !== 2 || !keys.includes("exp") || !keys.includes("sig")) return false;
+  const expiresAt = Number(url.searchParams.get("exp"));
+  const supplied = decodeBase64url(url.searchParams.get("sig") ?? "");
+  const now = Math.floor(nowMs / 1000);
+  if (
+    !Number.isSafeInteger(expiresAt) ||
+    expiresAt < now ||
+    expiresAt > now + ATTACHMENT_SIGNED_URL_MAX_FUTURE_SECONDS ||
+    supplied === null
+  ) {
+    return false;
+  }
+  return sameBytes(supplied, await signature(secret, url.pathname, expiresAt));
+}

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -41,6 +41,7 @@ import type {
   WebhookFilter,
 } from "@agentparty/shared";
 import { MAX_ATTACHMENTS, parseAttachment, parseAttachments, parseStoredAttachment, parseStoredAttachments } from "./attachments";
+import { createSignedAttachmentUrl, verifySignedAttachmentRequest } from "./attachment-signatures";
 import { Hono } from "hono";
 import type { Context } from "hono";
 import { createMiddleware } from "hono/factory";
@@ -119,6 +120,7 @@ type AppEnv = Env & {
   LARK_CLIENT_SECRET?: string;
   FEISHU_CLIENT_SECRET?: string;
   DESKTOP_PAIRING_SECRET?: string;
+  ATTACHMENT_SIGNING_SECRET?: string;
   // CLI↔worker 版本协商（#137）：声明的最低客户端版本 + 是否硬拒。缺省时用内置默认、默认只建言。
   MIN_CLIENT_VERSION?: string;
   MIN_CLIENT_ENFORCE?: string;
@@ -130,7 +132,7 @@ type AppEnv = Env & {
 
 type AppContext = {
   Bindings: AppEnv;
-  Variables: { identity: TokenIdentity };
+  Variables: { identity: TokenIdentity; attachmentSignatureVerified: boolean };
 };
 
 const NAME_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$/;
@@ -1254,6 +1256,17 @@ async function loadMembership(db: D1Database, account: string | null | undefined
 
 const requireBearer = createMiddleware<AppContext>(async (c, next) => {
   if (!c.get("identity")) {
+    if (c.req.method === "GET" && await verifySignedAttachmentRequest(c.req.url, c.env)) {
+      c.set("attachmentSignatureVerified", true);
+      c.set("identity", {
+        name: "signed-attachment",
+        role: "readonly",
+        kind: "agent",
+        hash: "signed-attachment",
+      });
+      await next();
+      return;
+    }
     const bearer = extractBearer(c.req.raw, {
       allowQueryToken:
         c.req.method === "GET" &&
@@ -2145,7 +2158,22 @@ app.post("/api/integrations/lark/relay", async (c) => {
     return c.json(errorBody("unavailable", "lark provider is not configured"), 503);
   }
   try {
-    await sendLarkCard(c.env, provider, sub.receive_id, sub.receive_id_type, buildMentionCard(payload));
+    const origin = new URL(c.req.url).origin;
+    const signedAttachments = payload.attachments === undefined
+      ? undefined
+      : (await Promise.all(payload.attachments.map(async (attachment) => {
+          const channelPath = `/api/channels/${payload.channel}/attachments/`;
+          if (!attachment.key.startsWith(`${payload.channel}/`) || !attachment.url.startsWith(channelPath)) return null;
+          const signed = await createSignedAttachmentUrl(`${origin}${attachment.url}`, c.env);
+          return signed === null ? null : { ...attachment, url: signed.url };
+        }))).filter((attachment): attachment is NonNullable<typeof attachment> => attachment !== null);
+    await sendLarkCard(
+      c.env,
+      provider,
+      sub.receive_id,
+      sub.receive_id_type,
+      buildMentionCard({ ...payload, ...(signedAttachments === undefined ? {} : { attachments: signedAttachments }) }),
+    );
   } catch (e) {
     const message = e instanceof Error ? e.message : "lark delivery failed";
     return c.json(errorBody("unavailable", message), 502);
@@ -5962,13 +5990,20 @@ app.get("/api/channels/:slug/attachments/:path{.+}", async (c) => {
   const slug = c.req.param("slug");
   const channel = await loadChannel(c.env.DB, slug);
   if (!channel) return c.json(errorBody("not_found", "channel not found"), 404);
-  if (!(await canAccessLoadedChannel(c.env.DB, c.get("identity"), channel))) {
+  const signedRequest = c.get("attachmentSignatureVerified") === true;
+  if (!signedRequest && !(await canAccessLoadedChannel(c.env.DB, c.get("identity"), channel))) {
     return c.json(errorBody("forbidden", "not allowed in this channel"), 403);
   }
   const objectPath = c.req.param("path");
   // 只认 worker 权威 slug 前缀拼出的 key，客户端传的完整 key 一律不信任，防目录穿越
   if (!objectPath || objectPath.includes("..") || objectPath.startsWith("/")) {
     return c.json(errorBody("bad_request", "invalid attachment path"), 400);
+  }
+  if (c.req.query("signed-url") === "1") {
+    if (signedRequest) return c.json(errorBody("forbidden", "signed URLs cannot mint another signed URL"), 403);
+    const signed = await createSignedAttachmentUrl(c.req.url, c.env);
+    if (signed === null) return c.json(errorBody("unavailable", "attachment signing is not configured"), 503);
+    return c.json({ url: signed.url, expires_at: signed.expiresAt });
   }
   const object = await c.env.ATTACHMENTS.get(`${slug}/${objectPath}`);
   if (!object) return c.json(errorBody("not_found", "attachment not found"), 404);
@@ -5978,6 +6013,8 @@ app.get("/api/channels/:slug/attachments/:path{.+}", async (c) => {
   if (!headers.has("content-type")) headers.set("content-type", "application/octet-stream");
   // nosniff：即便 content-type 被伪造也不让浏览器嗅探成可执行类型，缓解存储型 XSS
   headers.set("x-content-type-options", "nosniff");
+  headers.set("referrer-policy", "no-referrer");
+  if (signedRequest) headers.set("cache-control", "private, max-age=900");
   return new Response(object.body, { headers });
 });
 

--- a/worker/src/integrations/lark.ts
+++ b/worker/src/integrations/lark.ts
@@ -49,6 +49,7 @@ const DIRECTORY_PAGE_TOKEN_MAX = 512;
 const DIRECTORY_DEPARTMENT_BATCH = 4;
 const DIRECTORY_SCOPE_PAGE_SIZE = 100;
 const DIRECTORY_SCOPE_SCAN_LIMIT = 400;
+const DIRECTORY_EMPTY_PAGE_SCAN_LIMIT = 24;
 const DEPARTMENT_ID_RE = /^[a-zA-Z0-9][a-zA-Z0-9_\-@.]{0,63}$/;
 const tokenCache = new Map<string, { token: string; expiresAt: number }>();
 const textEncoder = new TextEncoder();
@@ -459,38 +460,43 @@ export async function searchLarkDirectory(
     ? { v: DIRECTORY_CURSOR_VERSION, q: normalizedQuery, p: provider.id, d: "0", a: [], u: null, n: null, s: false } as DirectoryCursorState
     : await decodeDirectoryCursor(secret, cursor, normalizedQuery, provider.id);
   if (state.m === "scope") return scopedLarkDirectorySearch(env, provider, normalizedQuery, pageSize, state);
-  const params = new URLSearchParams({
-    user_id_type: "union_id",
-    department_id_type: "open_department_id",
-    department_id: state.d,
-    page_size: String(pageSize),
-  });
-  if (state.u !== null) params.set("page_token", state.u);
-  let data: Record<string, unknown>;
-  try {
-    data = await larkDirectoryRequest(
-      env,
-      provider,
-      `/open-apis/contact/v3/users/find_by_department?${params.toString()}`,
-    );
-  } catch (error) {
-    if (cursor === null && error instanceof LarkDirectoryError && error.kind === "permission") {
-      return scopedLarkDirectorySearch(env, provider, normalizedQuery, pageSize);
+  let currentState: DirectoryCursorState | null = state;
+  let emptyPagesScanned = 0;
+  while (currentState !== null && emptyPagesScanned < DIRECTORY_EMPTY_PAGE_SCAN_LIMIT) {
+    const params = new URLSearchParams({
+      user_id_type: "union_id",
+      department_id_type: "open_department_id",
+      department_id: currentState.d,
+      page_size: String(pageSize),
+    });
+    if (currentState.u !== null) params.set("page_token", currentState.u);
+    let data: Record<string, unknown>;
+    try {
+      data = await larkDirectoryRequest(
+        env,
+        provider,
+        `/open-apis/contact/v3/users/find_by_department?${params.toString()}`,
+      );
+    } catch (error) {
+      if (cursor === null && error instanceof LarkDirectoryError && error.kind === "permission") {
+        return scopedLarkDirectorySearch(env, provider, normalizedQuery, pageSize);
+      }
+      throw error;
     }
-    throw error;
+    const users = directoryUsers(data).filter((user) => user.name.toLocaleLowerCase().includes(normalizedQuery));
+    const payload = isRecord(data.data) ? data.data : {};
+    const hasMore = payload.has_more === true;
+    const pageToken = typeof payload.page_token === "string" && payload.page_token ? payload.page_token : null;
+    if (hasMore && pageToken === null) throw new LarkDirectoryError("upstream", "Lark omitted the next user cursor");
+    currentState = hasMore
+      ? { ...currentState, u: pageToken }
+      : await advanceLarkDepartment(env, provider, currentState);
+    if (users.length > 0) {
+      return { users, nextCursor: currentState === null ? null : await encodeDirectoryCursor(secret, currentState) };
+    }
+    emptyPagesScanned += 1;
   }
-  const users = directoryUsers(data).filter((user) => user.name.toLocaleLowerCase().includes(normalizedQuery));
-  const payload = isRecord(data.data) ? data.data : {};
-  const hasMore = payload.has_more === true;
-  const pageToken = typeof payload.page_token === "string" && payload.page_token ? payload.page_token : null;
-  if (hasMore && pageToken === null) throw new LarkDirectoryError("upstream", "Lark omitted the next user cursor");
-  let nextState: DirectoryCursorState | null = hasMore
-    ? { ...state, u: pageToken }
-    : null;
-  if (!hasMore) {
-    nextState = await advanceLarkDepartment(env, provider, state);
-  }
-  return { users, nextCursor: nextState === null ? null : await encodeDirectoryCursor(secret, nextState) };
+  return { users: [], nextCursor: currentState === null ? null : await encodeDirectoryCursor(secret, currentState) };
 }
 
 export async function getLarkDirectoryUser(
@@ -589,6 +595,9 @@ export function buildMentionCard(payload: LarkWebhookPayload): Record<string, un
   const title = `AgentParty @${payload.mentions.join(", @")}`;
   const sender = payload.sender.display_name || payload.sender.handle || payload.sender.owner || payload.sender.name;
   const body = payload.kind === "status" ? payload.note || payload.body : payload.body;
+  const attachmentLinks = payload.attachments?.map((attachment) =>
+    `[${attachment.filename.replace(/[\\[\]]/g, "\\$&")}](${attachment.url})`).join(" · ");
+  const content = attachmentLinks ? `${body}\n\n📎 ${attachmentLinks}` : body;
   return {
     config: { wide_screen_mode: true },
     header: {
@@ -598,7 +607,7 @@ export function buildMentionCard(payload: LarkWebhookPayload): Record<string, un
     elements: [
       {
         tag: "markdown",
-        content: `**${sender}** mentioned you in **#${payload.channel}**\n\n${body}`,
+        content: `**${sender}** mentioned you in **#${payload.channel}**\n\n${content}`,
       },
       {
         tag: "action",

--- a/worker/src/openapi.ts
+++ b/worker/src/openapi.ts
@@ -643,13 +643,13 @@ export const openapiDocument = {
                           type: "object",
                           required: ["key", "filename", "content_type", "size", "url"],
                           properties: {
-                            key: { type: "string", description: "<slug>/<uuid>/<filename> R2 object key" },
+                            key: { type: "string", description: "<slug>/<sha256>/<filename> R2 object key" },
                             filename: { type: "string", maxLength: 255 },
                             content_type: { type: "string" },
                             size: { type: "integer", minimum: 0 },
                             url: {
                               type: "string",
-                              description: "authenticated download path /api/channels/{slug}/attachments/{uuid}/{filename}",
+                              description: "private download path; authorized clients can exchange it for a short-lived signed URL",
                             },
                           },
                         },
@@ -777,10 +777,10 @@ export const openapiDocument = {
     },
     "/api/channels/{slug}/attachments/{path}": {
       get: {
-        summary: "download an attachment blob from R2 (authenticated)",
+        summary: "download an attachment blob or mint a short-lived signed URL",
         description:
-          "streams the R2 object back with its stored content-type and X-Content-Type-Options: nosniff. same read access as the channel; never a public R2 link. path is <uuid>/<filename>.",
-        security: [{ bearer: [] }],
+          "Bearer-authenticated callers may add signed-url=1 to receive a 15-minute path-bound URL. That URL can be fetched without Authorization and streams the R2 object with nosniff; the R2 bucket itself remains private.",
+        security: [{ bearer: [] }, {}],
         parameters: [
           { name: "slug", in: "path", required: true, schema: { type: "string" } },
           {
@@ -788,7 +788,14 @@ export const openapiDocument = {
             in: "path",
             required: true,
             schema: { type: "string" },
-            description: "<uuid>/<filename> object path (no .. or leading /)",
+            description: "<sha256>/<filename> object path (no .. or leading /)",
+          },
+          {
+            name: "signed-url",
+            in: "query",
+            required: false,
+            schema: { type: "string", enum: ["1"] },
+            description: "with Bearer auth, return {url,expires_at} instead of the object bytes",
           },
         ],
         responses: {

--- a/worker/test/attachment-signatures.spec.ts
+++ b/worker/test/attachment-signatures.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import {
+  ATTACHMENT_SIGNED_URL_TTL_SECONDS,
+  createSignedAttachmentUrl,
+  verifySignedAttachmentRequest,
+} from "../src/attachment-signatures";
+
+const env = { ATTACHMENT_SIGNING_SECRET: "test-attachment-signing-secret" };
+const source = "https://agentparty.example/api/channels/private-room/attachments/abc123/proof.png?signed-url=1";
+
+describe("attachment signed URLs (#521)", () => {
+  it("binds the signature to the exact path and rejects extra query capabilities", async () => {
+    const now = 1_700_000_000_000;
+    const signed = await createSignedAttachmentUrl(source, env, now);
+    expect(signed).not.toBeNull();
+    expect(signed?.expiresAt).toBe(Math.floor(now / 1000) + ATTACHMENT_SIGNED_URL_TTL_SECONDS);
+    expect(await verifySignedAttachmentRequest(signed!.url, env, now)).toBe(true);
+
+    const changedPath = new URL(signed!.url);
+    changedPath.pathname = changedPath.pathname.replace("proof.png", "secret.png");
+    expect(await verifySignedAttachmentRequest(changedPath.toString(), env, now)).toBe(false);
+
+    const extraQuery = new URL(signed!.url);
+    extraQuery.searchParams.set("signed-url", "1");
+    expect(await verifySignedAttachmentRequest(extraQuery.toString(), env, now)).toBe(false);
+  });
+
+  it("expires fail-closed and cannot sign when no deployment secret exists", async () => {
+    const now = 1_700_000_000_000;
+    const signed = await createSignedAttachmentUrl(source, env, now);
+    expect(await verifySignedAttachmentRequest(signed!.url, env, (signed!.expiresAt + 1) * 1000)).toBe(false);
+    expect(await createSignedAttachmentUrl(source, {}, now)).toBeNull();
+    expect(await verifySignedAttachmentRequest(signed!.url, {}, now)).toBe(false);
+  });
+});

--- a/worker/test/attachments.spec.ts
+++ b/worker/test/attachments.spec.ts
@@ -85,6 +85,34 @@ describe("channel attachments (R2)", () => {
     expect((await download(slug, null, objectPath)).status).toBe(401);
   });
 
+  it("mints a short-lived path-bound URL that an img request can read without Bearer (#521)", async () => {
+    const { token } = await seedToken("agent", uniq("owner"), { owner: "owner@ap.test" });
+    const slug = await createChannel(token);
+    const bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 1, 2, 3]);
+    const meta = (await (await upload(slug, token, "signed.png", bytes, "image/png")).json()) as { url: string };
+
+    const minted = await SELF.fetch(`http://ap.test${meta.url}?signed-url=1`, {
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(minted.status).toBe(200);
+    const body = (await minted.json()) as { url: string; expires_at: number };
+    expect(body.url).toMatch(new RegExp(`^http://ap\\.test${meta.url.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\?exp=\\d+&sig=[A-Za-z0-9_-]+$`));
+    expect(body.expires_at).toBeGreaterThan(Math.floor(Date.now() / 1000));
+
+    const image = await SELF.fetch(body.url);
+    expect(image.status).toBe(200);
+    expect(image.headers.get("content-type")).toBe("image/png");
+    expect(image.headers.get("referrer-policy")).toBe("no-referrer");
+    expect([...new Uint8Array(await image.arrayBuffer())]).toEqual([...bytes]);
+
+    const tampered = new URL(body.url);
+    tampered.pathname = tampered.pathname.replace("signed.png", "other.png");
+    expect((await SELF.fetch(tampered)).status).toBe(401);
+    const extraQuery = new URL(body.url);
+    extraQuery.searchParams.set("signed-url", "1");
+    expect((await SELF.fetch(extraQuery)).status).toBe(401);
+  });
+
   it("rejects an oversize upload (413)", async () => {
     const { token } = await seedToken("agent", uniq("owner"), { owner: "owner@ap.test" });
     const slug = await createChannel(token);

--- a/worker/test/lark-directory.spec.ts
+++ b/worker/test/lark-directory.spec.ts
@@ -100,7 +100,7 @@ describe("Lark organization member invitations (#358)", () => {
     expect(JSON.stringify(body)).not.toMatch(/tenant-secret-token|must-not-leak|81000000000|access.?token/i);
   });
 
-  it("walks recursive v3 departments with a query-bound signed cursor", async () => {
+  it("skips empty directory pages until it finds a match and keeps a query-bound signed cursor (#520)", async () => {
     const owner = await larkHuman();
     const slug = await createChannel(owner.token);
     mockTenantToken();
@@ -122,14 +122,31 @@ describe("Lark organization member invitations (#358)", () => {
           items: [{ open_department_id: "od-engineering" }, { open_department_id: "od-sales" }],
         },
       });
+    fetchMock.get(LARK_ORIGIN)
+      .intercept({
+        path: "/open-apis/contact/v3/users/find_by_department?user_id_type=union_id&department_id_type=open_department_id&department_id=od-engineering&page_size=20",
+        method: "GET",
+      })
+      .reply(200, {
+        code: 0,
+        data: {
+          has_more: false,
+          items: [{ union_id: "on_alice", name: "Alice Zhang", avatar: { avatar_72: "https://cdn.example/alice.png" } }],
+        },
+      });
 
     const first = await api(`/api/channels/${slug}/lark-directory?q=alice&limit=20`, owner.token);
     expect(first.status).toBe(200);
     const firstPage = (await first.json()) as { users: unknown[]; next_cursor: string };
-    expect(firstPage.users).toEqual([]);
+    expect(firstPage.users).toEqual([
+      { id: "on_alice", name: "Alice Zhang", avatar_url: "https://cdn.example/alice.png", already_member: false },
+    ]);
     expect(firstPage.next_cursor).toMatch(/^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/);
 
-    const tampered = `${firstPage.next_cursor.slice(0, -1)}${firstPage.next_cursor.endsWith("A") ? "B" : "A"}`;
+    const signatureIndex = firstPage.next_cursor.indexOf(".") + 1;
+    const tampered = `${firstPage.next_cursor.slice(0, signatureIndex)}${
+      firstPage.next_cursor[signatureIndex] === "A" ? "B" : "A"
+    }${firstPage.next_cursor.slice(signatureIndex + 1)}`;
     const rejected = await api(
       `/api/channels/${slug}/lark-directory?q=alice&limit=20&cursor=${encodeURIComponent(tampered)}`,
       owner.token,
@@ -146,39 +163,16 @@ describe("Lark organization member invitations (#358)", () => {
 
     fetchMock.get(LARK_ORIGIN)
       .intercept({
-        path: "/open-apis/contact/v3/users/find_by_department?user_id_type=union_id&department_id_type=open_department_id&department_id=od-engineering&page_size=20",
+        path: "/open-apis/contact/v3/users/find_by_department?user_id_type=union_id&department_id_type=open_department_id&department_id=od-sales&page_size=20",
         method: "GET",
       })
-      .reply(200, {
-        code: 0,
-        data: {
-          has_more: false,
-          items: [{ union_id: "on_alice", name: "Alice Zhang", avatar: { avatar_72: "https://cdn.example/alice.png" } }],
-        },
-      });
+      .reply(200, { code: 0, data: { has_more: false, items: [{ union_id: "on_bob", name: "Bob" }] } });
     const second = await api(
       `/api/channels/${slug}/lark-directory?q=alice&limit=20&cursor=${encodeURIComponent(firstPage.next_cursor)}`,
       owner.token,
     );
     expect(second.status).toBe(200);
-    const secondPage = (await second.json()) as { users: unknown[]; next_cursor: string };
-    expect(secondPage).toMatchObject({
-      users: [{ id: "on_alice", name: "Alice Zhang", avatar_url: "https://cdn.example/alice.png" }],
-    });
-    expect(secondPage.next_cursor).toMatch(/^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/);
-
-    fetchMock.get(LARK_ORIGIN)
-      .intercept({
-        path: "/open-apis/contact/v3/users/find_by_department?user_id_type=union_id&department_id_type=open_department_id&department_id=od-sales&page_size=20",
-        method: "GET",
-      })
-      .reply(200, { code: 0, data: { has_more: false, items: [{ union_id: "on_bob", name: "Bob" }] } });
-    const third = await api(
-      `/api/channels/${slug}/lark-directory?q=alice&limit=20&cursor=${encodeURIComponent(secondPage.next_cursor)}`,
-      owner.token,
-    );
-    expect(third.status).toBe(200);
-    expect(await third.json()).toEqual({ users: [], next_cursor: null });
+    expect(await second.json()).toEqual({ users: [], next_cursor: null });
   });
 
   it("matches an existing member whose profile still stores an open_id", async () => {

--- a/worker/test/lark.spec.ts
+++ b/worker/test/lark.spec.ts
@@ -73,7 +73,6 @@ describe("lark notification integration", () => {
     const profile = await seedLarkProfile(account, "larkalice");
     const human = await seedToken("human", uniq("human"), { owner: account });
     const slug = await createChannel(human.token);
-
     const agent = await seedToken("agent", uniq("agent"), { owner: account });
     expect((await api(`/api/channels/${slug}/lark-notify`, agent.token, { method: "POST" })).status).toBe(403);
 
@@ -104,6 +103,10 @@ describe("lark notification integration", () => {
     const profile = await seedLarkProfile(account, "larkrelay");
     const human = await seedToken("human", uniq("human"), { owner: account });
     const slug = await createChannel(human.token);
+    const attachmentPath = `hash-${uniq("image")}/proof.png`;
+    await env.ATTACHMENTS.put(`${slug}/${attachmentPath}`, new Uint8Array([1, 2, 3]), {
+      httpMetadata: { contentType: "image/png" },
+    });
     expect((await api(`/api/channels/${slug}/lark-notify`, human.token, { method: "POST" })).status).toBe(201);
     const sub = await env.DB.prepare("SELECT secret FROM lark_notify_subscriptions WHERE channel_slug = ? AND account = ?")
       .bind(slug, account)
@@ -121,6 +124,19 @@ describe("lark notification integration", () => {
       channel: slug,
       permalink: `https://ap.test/c/${slug}`,
       sender: { name: "codex", kind: "agent", role: "agent", display: "Codex" },
+      attachments: [{
+        key: `${slug}/${attachmentPath}`,
+        filename: "proof.png",
+        content_type: "image/png",
+        size: 3,
+        url: `/api/channels/${slug}/attachments/${attachmentPath}`,
+      }, {
+        key: `other-private-channel/${attachmentPath}`,
+        filename: "must-not-sign.png",
+        content_type: "image/png",
+        size: 3,
+        url: `/api/channels/other-private-channel/attachments/${attachmentPath}`,
+      }],
     });
 
     let larkMessage: Record<string, unknown> | null = null;
@@ -153,7 +169,14 @@ describe("lark notification integration", () => {
       msg_type: "interactive",
     });
     const content = JSON.parse(String(sent.content)) as Record<string, unknown>;
-    expect(content).toMatchObject(buildMentionCard(JSON.parse(payload)));
+    const markdown = String((content.elements as Array<Record<string, unknown>>)[0]?.content);
+    const signedUrl = markdown.match(/\((http:\/\/ap\.test\/api\/channels\/[^)]+\?exp=\d+&sig=[A-Za-z0-9_-]+)\)/)?.[1];
+    expect(signedUrl).toBeTypeOf("string");
+    expect(markdown).toContain("proof.png");
+    expect(markdown).not.toContain("must-not-sign.png");
+    const image = await SELF.fetch(signedUrl!);
+    expect(image.status).toBe(200);
+    expect(image.headers.get("content-type")).toBe("image/png");
   });
 
   it("rejects bad relay auth/signature and turns Lark nonzero code into retryable 502", async () => {


### PR DESCRIPTION
## 变更

- #520：Lark 通讯录搜索在当前页无匹配时继续扫描后续页/部门，避免实际联系人被误报为“没有匹配的成员”
- #521：私有附件支持 15 分钟、路径绑定的 HMAC 签名 URL，供 img、下载链接及 Lark 通知使用
- #521：原始 R2 保持私有；签名 URL 不携带 Bearer，且禁止跨频道签名、篡改路径和附加查询参数；Web 保留旧 worker blob 回退
- #522：builtin Codex/Claude runner 自动上报 wake session；重启连接后从 wake-session.json 再上报
- #522：交互式 agent 可通过 party status 的 session flags 主动上报；DO 持久化到 presence，party who/JSON 与网页 Agent 详情均展示

## 验证

- `bun run check`（scripts + CLI + shared + Web 774 tests/build + worker）
- `bun run check:cli`（755 tests + tsc）
- `bun run check:worker`（81 files / 540 tests + tsc）
- `git diff --check`

Closes #520
Closes #521
Closes #522