### PR TITLE
fix(web): 打磨频道工具栏与窄屏输入布局

### DIFF
--- a/web/src/components/ChannelToolstrip.test.tsx
+++ b/web/src/components/ChannelToolstrip.test.tsx
@@ -101,7 +101,9 @@ describe("ChannelToolstrip discoverability (#355)", () => {
     const css = readFileSync(new URL("../styles/app.css", import.meta.url), "utf8");
     expect(css).toContain(".chan-toolstrip-toggle {\n  display: none;");
     expect(css).toMatch(/@media \(max-width: 760px\)[\s\S]*\.chan-toolstrip-toggle \{[\s\S]*display: inline-flex;/);
+    expect(css).toMatch(/@media \(max-width: 760px\)[\s\S]*\.chan-toolstrip-toggle-label \{[\s\S]*display: none;/);
     expect(css).toMatch(/@media \(max-width: 760px\)[\s\S]*\.chan-toolstrip--collapsed \.chan-toolstrip-content \{\s*display: none;/);
     expect(css).toMatch(/@media \(max-width: 760px\)[\s\S]*\.chan-toolstrip-content \{[\s\S]*overflow-x: auto;/);
+    expect(css).toMatch(/\.chan-tool-btn \.ap-sprite\s*{[^}]*--ap-icon-size:\s*28px;[^}]*background-size:\s*440% 330%;/s);
   });
 });

--- a/web/src/components/VisibilityToggle.tsx
+++ b/web/src/components/VisibilityToggle.tsx
@@ -67,7 +67,9 @@ export function VisibilityToggle({ slug, token, visibility, onChanged, onAuthFai
         ))}
       </div>
       <FeatureTip tip="Tips.visibility" />
-      <p className="vis-help t-mono">{t(`Visibility.opt.${visibility}.help`)}</p>
+      <p className="vis-help t-mono" title={t(`Visibility.opt.${visibility}.help`)}>
+        {t(`Visibility.opt.${visibility}.help`)}
+      </p>
       {confirm !== null && (
         <div className="vis-confirm" role="alertdialog" aria-label={t("Visibility.confirmDialogLabel")}>
           <span className="vis-confirm-text">

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -38,6 +38,7 @@
   font-size: 27px;
   /* marker 草书字体上伸很高，必须给足行高，否则标题顶部被容器上边缘裁掉 */
   line-height: 1.35;
+  white-space: nowrap;
   text-decoration: none;
   color: var(--d-ink);
 }
@@ -3263,10 +3264,53 @@
 .vis-seg-btn:disabled:not(.is-on) { opacity: 0.55; cursor: default; }
 .vis-help {
   flex: none;
+  max-width: min(300px, 15vw);
   margin: 0;
+  overflow: hidden;
   color: var(--t-dim);
   font-size: 11.5px;
+  text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+/* 常规桌面宽度固定成“功能 / 管理”两行。视觉皮不变，只阻止嵌套 flex
+   因说明文字的固有宽度额外折出第三行。 */
+@media (min-width: 1360px) {
+  .chan-toolstrip {
+    display: block;
+  }
+  .chan-toolstrip-content {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .chan-tool-buttons,
+  .chan-tool-actions {
+    width: 100%;
+  }
+  .chan-tool-actions {
+    flex-wrap: nowrap;
+    justify-content: flex-start;
+    margin-left: 0;
+  }
+  .chan-admin-actions,
+  .vis-toggle {
+    flex-wrap: nowrap;
+  }
+  .chan-admin-actions {
+    flex: 1 1 auto;
+  }
+  .vis-toggle {
+    min-width: 0;
+    margin-left: 0;
+  }
+}
+
+/* 中等桌面保留可见性帮助按钮，省去与其 tooltip 重复的长句，防止管理行折行。 */
+@media (min-width: 761px) and (max-width: 1359px) {
+  .vis-help {
+    display: none;
+  }
 }
 
 /* ---- 小图雪碧图（app 运行界面，替代散落 emoji/符号） ---- */
@@ -3299,7 +3343,10 @@
 .ap-sprite--failed,
 .ap-sprite--waiting { --ap-icon-x: 100%; --ap-icon-y: 100%; }
 .chan-tool-btn .ap-sprite {
-  --ap-icon-size: 26px;
+  --ap-icon-size: 28px;
+  /* The source artwork intentionally has breathing room inside each tile.
+     Zoom the tile slightly so the drawing remains legible at toolbar scale. */
+  background-size: 440% 330%;
   margin-left: -1px;
 }
 
@@ -5472,8 +5519,9 @@
   }
   .chan-toolstrip-toggle .ap-sprite { --ap-icon-size: 22px; }
   .chan-toolstrip-toggle-label {
-    font-size: 11px;
-    white-space: nowrap;
+    /* The button already has an accessible label and title. On a 390px viewport
+       this text used a third of the toolbar, leaving the actual tools clipped. */
+    display: none;
   }
   .chan-toolstrip-toggle-arrow {
     width: 7px;
@@ -6195,6 +6243,21 @@
   .desktop-agent-fields input,
   .desktop-agent-fields select {
     font-size: 16px;
+  }
+}
+
+/* 极窄屏把编辑区与命令分两行，避免附件、提示和发送按钮挤掉正文输入宽度。 */
+@media (max-width: 400px) {
+  .composer {
+    gap: 8px;
+  }
+  .composer-input {
+    flex: 0 0 100%;
+    width: 100%;
+    min-width: 0;
+  }
+  .composer-actions {
+    margin-left: auto;
   }
 }
 

--- a/web/src/styles/app.layoutTouch.test.ts
+++ b/web/src/styles/app.layoutTouch.test.ts
@@ -16,6 +16,12 @@ function ruleBody(selector: string): string {
 }
 
 describe("issue #357 layout and touch CSS", () => {
+  test("the brand stays intact and the narrow composer keeps a full-width editor", () => {
+    expect(ruleBody(".app-logo")).toContain("white-space: nowrap");
+    expect(css).toMatch(/@media \(max-width: 400px\)[\s\S]*\.composer-input\s*{[^}]*flex:\s*0 0 100%;[^}]*width:\s*100%;/s);
+    expect(css).toMatch(/@media \(max-width: 400px\)[\s\S]*\.composer-actions\s*{[^}]*margin-left:\s*auto;/s);
+  });
+
   test("the charter modal delegates scrolling to the panel body", () => {
     const body = ruleBody(".channel-panel-body .charter-body .msg-body");
     expect(body).toContain("max-height: none");

--- a/web/src/styles/app.visibilityToggle.test.ts
+++ b/web/src/styles/app.visibilityToggle.test.ts
@@ -19,7 +19,15 @@ describe("issue #443 visibility controls layout", () => {
     expect(body).not.toContain("flex-basis: 100%");
     expect(body).not.toContain("margin: 2px 0 0");
     expect(body).toContain("flex: none");
+    expect(body).toContain("max-width: min(300px, 15vw)");
+    expect(body).toContain("text-overflow: ellipsis");
     expect(body).toContain("white-space: nowrap");
     expect(body).toContain("margin: 0");
+  });
+
+  test("wide desktop tool controls use two fixed rows", () => {
+    expect(css).toMatch(/@media \(min-width: 1360px\)[\s\S]*\.chan-toolstrip-content\s*{[^}]*flex-direction:\s*column;[^}]*gap:\s*6px;/s);
+    expect(css).toMatch(/@media \(min-width: 1360px\)[\s\S]*\.chan-tool-actions\s*{[^}]*flex-wrap:\s*nowrap;[^}]*margin-left:\s*0;/s);
+    expect(css).toMatch(/@media \(min-width: 761px\) and \(max-width: 1359px\)[\s\S]*\.vis-help\s*{[^}]*display:\s*none;/s);
   });
 });


### PR DESCRIPTION
## 变更
- 保留现有暖纸底、硬边框、珊瑚红印章和等宽字体，不做全局换肤
- 1360px 以上频道工具区固定为两行；1200px 隐藏重复说明但保留帮助 tooltip
- 390px 工具入口改为图标按钮，把可见工具宽度从 210px 提高到 300px
- 320px Logo 不换行，composer 输入框独占整行
- 雪碧图主体约放大 20%，按钮整体高度基本不变

## 实测
- 1440/1360/1200：工具区 78px，无页面横向溢出
- 390/320：顶栏 57.5px、工具区 47px，输入框分别 354px/284px
- 设置面板在 1440/390 下完整可滚动且无重叠

## 验证
- `bun run check:web`
- 776 tests passed
- TypeScript passed
- Vite production build passed

## 合并前检查
- [x] 已读 CodeRabbit：无 actionable comment
- [x] 已读 Qwen：移动端隐藏文字为预期，按钮保留 aria-label/title；ellipsis 已在 CSS 实现
- [x] CI 全绿，本地 Web 全量门禁通过
- [x] 无安全边界变更