### PR TITLE
feat(agent): 持久化可恢复会话信息

### DIFF
--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -1,7 +1,7 @@
 // party serve — 常驻监听频道，每条 @你 的消息触发一次本地命令，把「跑完就停的 session agent」
 // 用外部 supervisor 唤醒（wake GOAL 的 session 型那半；有入站 URL 的 runtime 走 webhook）。
 // 复用 client.connect 的自动重连帧流，真正常驻；命令串行执行（一条处理完再下一条，不并发抢跑）。
-import { BODY_LIMIT, EXIT_ARCHIVED, EXIT_AUTH, EXIT_STREAM_ENDED, EXIT_UPGRADED, type Attachment, type MsgFrame, type ServerFrame } from "@agentparty/shared";
+import { BODY_LIMIT, EXIT_ARCHIVED, EXIT_AUTH, EXIT_STREAM_ENDED, EXIT_UPGRADED, type AgentSessionInfo, type Attachment, type MsgFrame, type ServerFrame } from "@agentparty/shared";
 import { maybeReexecUpgrade, serverVersionUpgradeNotice, upgradeNotice, type CliUpgradeNotice, type UpgradeDeps } from "../upgrade";
 import {
   appendFileSync,
@@ -193,6 +193,8 @@ interface WakeSessionState {
   created_at: number;
   last_wake_ts: number;
   wakes: number;
+  cwd?: string;
+  workdir?: string;
 }
 
 interface SdkWakeSessionState {
@@ -201,6 +203,8 @@ interface SdkWakeSessionState {
   created_at: number;
   last_wake_ts: number;
   wakes: number;
+  cwd?: string;
+  workdir?: string;
 }
 
 export interface BuiltinRunnerOptions {
@@ -218,6 +222,8 @@ export interface BuiltinRunnerOptions {
   post?: typeof postMessage;
   /** 交付物上传（#109）；默认真 REST。测试注入 mock。 */
   uploadAttachment?: typeof uploadAttachment;
+  /** 模型 session 落盘后自报给频道 presence（issue #522）。 */
+  onSession?: (session: AgentSessionInfo) => void;
 }
 
 export interface ThreadLike {
@@ -242,6 +248,8 @@ export interface SdkRunnerOptions {
   post?: typeof postMessage;
   /** 交付物上传（#109）；默认真 REST。测试注入 mock。 */
   uploadAttachment?: typeof uploadAttachment;
+  /** 模型 session 落盘后自报给频道 presence（issue #522）。 */
+  onSession?: (session: AgentSessionInfo) => void;
 }
 
 export interface ProjectAgentRunContext {
@@ -857,6 +865,32 @@ function writeSdkSession(path: string, state: SdkWakeSessionState): void {
   writeFileSync(path, JSON.stringify(state, null, 2) + "\n", { mode: 0o600 });
 }
 
+function persistedAgentSession(o: Pick<ServeOptions, "builtinRunner" | "sdkRunner">): AgentSessionInfo | null {
+  if (o.builtinRunner !== undefined) {
+    const state = readSession(join(o.builtinRunner.workdir, RUNNER_SESSION_FILE), o.builtinRunner.harness);
+    if (state === null) return null;
+    return {
+      harness: state.harness,
+      session_id: state.session_id,
+      updated_at: state.last_wake_ts,
+      cwd: state.cwd ?? o.builtinRunner.cwd ?? o.builtinRunner.workdir,
+      workdir: state.workdir ?? o.builtinRunner.workdir,
+    };
+  }
+  if (o.sdkRunner !== undefined) {
+    const state = readSdkSession(join(o.sdkRunner.workdir, RUNNER_SESSION_FILE));
+    if (state === null) return null;
+    return {
+      harness: "codex-sdk",
+      session_id: state.thread_id,
+      updated_at: state.last_wake_ts,
+      cwd: state.cwd ?? o.sdkRunner.workdir,
+      workdir: state.workdir ?? o.sdkRunner.workdir,
+    };
+  }
+  return null;
+}
+
 function shortSid(sid: string | null | undefined): string {
   return sid ? sid.slice(0, 8) : "unknown";
 }
@@ -1131,8 +1165,16 @@ export function createSdkRunner(opts: SdkRunnerOptions): NonNullable<ServeOption
         ...baseSession,
         last_wake_ts: now,
         wakes: baseSession.wakes + 1,
+        workdir: opts.workdir,
       };
       writeSdkSession(sessionPath, session);
+      opts.onSession?.({
+        harness: "codex-sdk",
+        session_id: session.thread_id,
+        updated_at: now,
+        ...(session.cwd === undefined ? {} : { cwd: session.cwd }),
+        workdir: opts.workdir,
+      });
       // 交付走统一路径：超限正文改走 R2 附件（#109），不再 inline 撞 413。上传失败落进下面的 catch。
       await deliverRunnerMessage({
         post,
@@ -1152,9 +1194,16 @@ export function createSdkRunner(opts: SdkRunnerOptions): NonNullable<ServeOption
       const now = opts.now?.() ?? Date.now();
       const message = err instanceof Error ? err.message : String(err);
       if (session) {
-        session = { ...session, last_wake_ts: now, wakes: session.wakes + 1 };
+        session = { ...session, last_wake_ts: now, wakes: session.wakes + 1, workdir: opts.workdir };
         writeSdkSession(sessionPath, session);
         threadId = session.thread_id;
+        opts.onSession?.({
+          harness: "codex-sdk",
+          session_id: session.thread_id,
+          updated_at: now,
+          ...(session.cwd === undefined ? {} : { cwd: session.cwd }),
+          workdir: opts.workdir,
+        });
       }
       appendRunnerLog(
         opts.workdir,
@@ -1256,6 +1305,15 @@ export function createBuiltinRunner(opts: BuiltinRunnerOptions): NonNullable<Ser
       created_at: prior ? prior.created_at : now,
       last_wake_ts: now,
       wakes,
+      cwd,
+      workdir: opts.workdir,
+    });
+    opts.onSession?.({
+      harness: opts.harness,
+      session_id: finalSid,
+      updated_at: now,
+      cwd,
+      workdir: opts.workdir,
     });
 
     // resume 非零不再 cold-start（#206 门禁 P1②），所以不存在 session reset 这条路径了。
@@ -1651,7 +1709,6 @@ export function pendingWakeDepth(
 
 export async function runServe(o: ServeOptions): Promise<number> {
   const out = o.out ?? ((line: string) => console.error(line));
-  const run = o.runCommand ?? (o.sdkRunner ? createSdkRunner(o.sdkRunner) : o.builtinRunner ? createBuiltinRunner(o.builtinRunner) : defaultRun);
   // busy 生命周期（#103）：只有内建 serve runner（builtin/sdk）在 working 帧里自报 busy=true，
   // 因此也只有它们需要 runServe 在收尾时补一条「busy=false 空闲」把 busy 清干净。注入 runCommand
   // 的测试、以及 --cmd 裸执行器（自管 presence）不参与，避免覆盖它们自己的收尾状态。
@@ -1709,6 +1766,38 @@ export async function runServe(o: ServeOptions): Promise<number> {
     lock?.release?.();
     throw error;
   }
+  // issue #522：runner 的模型 session 是可恢复句柄，不是 websocket session。连接建立后把它作为
+  // presence-only 元数据自报；每次 runner 冷起/续会并刷新本地 wake-session.json 后再覆盖一次。
+  const reportAgentSession = (session: AgentSessionInfo) => {
+    try {
+      conn.send({
+        type: "heartbeat",
+        current_task: null,
+        task_started_at: null,
+        heartbeat_at: null,
+        agent_session: session,
+      });
+    } catch {
+      // 重连 welcome 会从本地 wake-session.json 再报；一次 WS 窗口失败不阻断 runner。
+    }
+  };
+  const run = o.runCommand ?? (o.sdkRunner
+    ? createSdkRunner({
+        ...o.sdkRunner,
+        onSession: (session) => {
+          o.sdkRunner?.onSession?.(session);
+          reportAgentSession(session);
+        },
+      })
+    : o.builtinRunner
+      ? createBuiltinRunner({
+          ...o.builtinRunner,
+          onSession: (session) => {
+            o.builtinRunner?.onSession?.(session);
+            reportAgentSession(session);
+          },
+        })
+      : defaultRun);
   // 挂载之初就落一份 health 基线：即便还没收到第一帧，watchdog 也能看到「这个 pid 认领了这个频道」，
   // 而不是文件缺失时无法区分「serve 没起来」和「serve 起来了但还没写过健康数据」。
   writeHealthCache({ channel: o.channel, ws_connected: false, reconnecting: false, reconnect_count: 0, last_frame_at: null, last_error: null, connected_since: null });
@@ -1782,6 +1871,8 @@ export async function runServe(o: ServeOptions): Promise<number> {
         // 服务端在同名多条 serve 里选唯一持租者并回 serve_lease。老服务端不认识它、直接忽略（hasLease
         // 默认 true → 旧行为）。重连每次 welcome 都重新 claim（连接换了，租约候选身份也换了）。
         conn.send({ type: "serve_lease", op: "claim" });
+        const persistedSession = persistedAgentSession(o);
+        if (persistedSession !== null) reportAgentSession(persistedSession);
         // 连上时若自己已被暂停接待（#180），从 welcome 的 presence 快照里认出来——重连也不误唤醒。
         const mine = frame.presence?.find((p) => p.name === self);
         selfPaused = mine?.paused === true;

--- a/cli/src/commands/status.ts
+++ b/cli/src/commands/status.ts
@@ -1,6 +1,7 @@
 // party status — 发 status 消息（rest）
 import type {
   AgentContext,
+  AgentSessionInfo,
   CollaborationRole,
   HostDecisionKind,
   Residency,
@@ -21,6 +22,7 @@ const STATES: StatusState[] = ["working", "waiting", "blocked", "done"];
 const COLLAB_ROLES: CollaborationRole[] = ["host", "worker", "reviewer", "observer"];
 const RESIDENCIES: Residency[] = ["supervised", "webhook", "bare", "human_driven", "unknown"];
 const WAKE_KINDS: WakeKind[] = ["none", "watch", "serve", "webhook"];
+const SESSION_HARNESSES: AgentSessionInfo["harness"][] = ["codex", "claude", "codex-sdk"];
 const DECISION_KINDS: HostDecisionKind[] = ["decision", "handoff", "takeover"];
 const WORKFLOW_KINDS: WorkflowKind[] = ["pipeline", "parallel", "orchestrator-workers", "evaluator-optimizer"];
 const WORKFLOW_ID_RE = /^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,127}$/;
@@ -34,6 +36,10 @@ const STATUS_FLAGS = [
   "role",
   "residency",
   "wake-kind",
+  "session-id",
+  "session-harness",
+  "session-cwd",
+  "session-workdir",
   "decision-kind",
   "decision",
   "next",
@@ -63,6 +69,12 @@ Options:
   --role role      collaboration role: host|worker|reviewer|observer
   --residency r    wake residency: supervised|webhook|bare|human_driven|unknown
   --wake-kind k    wake layer kind: none|watch|serve|webhook
+  --session-id id  report the model session id used for restart resume (#522)
+  --session-harness h
+                   model harness: codex|claude|codex-sdk (required with --session-id)
+  --session-cwd dir model working directory; defaults to the current directory
+  --session-workdir dir
+                   runner state directory containing wake-session.json (optional)
   --decision text  structured host decision/handoff note
   --decision-kind k
                    decision type: decision|handoff|takeover
@@ -131,6 +143,10 @@ export async function run(argv: string[]): Promise<number> {
       "role",
       "residency",
       "wake-kind",
+      "session-id",
+      "session-harness",
+      "session-cwd",
+      "session-workdir",
       "decision-kind",
       "decision",
       "next",
@@ -209,6 +225,36 @@ export async function run(argv: string[]): Promise<number> {
     console.error(`--wake-kind must be one of: ${WAKE_KINDS.join("|")}`);
     return 1;
   }
+  const sessionId = str(flags["session-id"]);
+  const sessionHarness = str(flags["session-harness"]);
+  const sessionCwd = str(flags["session-cwd"]);
+  const sessionWorkdir = str(flags["session-workdir"]);
+  const sessionFlagUsed = sessionId !== undefined || sessionHarness !== undefined || sessionCwd !== undefined || sessionWorkdir !== undefined;
+  if (sessionFlagUsed && (sessionId === undefined || sessionHarness === undefined)) {
+    console.error("--session-id and --session-harness are required when reporting a resume session");
+    return 1;
+  }
+  if (sessionId !== undefined && !/^[A-Za-z0-9._:-]{1,256}$/u.test(sessionId)) {
+    console.error("--session-id must be 1-256 safe identifier characters");
+    return 1;
+  }
+  if (sessionHarness !== undefined && !SESSION_HARNESSES.includes(sessionHarness as AgentSessionInfo["harness"])) {
+    console.error(`--session-harness must be one of: ${SESSION_HARNESSES.join("|")}`);
+    return 1;
+  }
+  if ([sessionCwd, sessionWorkdir].some((value) => value !== undefined && (value.length === 0 || value.length > 2048))) {
+    console.error("--session-cwd/--session-workdir must be non-empty and at most 2048 characters");
+    return 1;
+  }
+  const agentSession: AgentSessionInfo | undefined = sessionId === undefined || sessionHarness === undefined
+    ? undefined
+    : {
+        harness: sessionHarness as AgentSessionInfo["harness"],
+        session_id: sessionId,
+        updated_at: Date.now(),
+        cwd: sessionCwd ?? process.cwd(),
+        ...(sessionWorkdir === undefined ? {} : { workdir: sessionWorkdir }),
+      };
   const decisionKind = str(flags["decision-kind"]);
   if (decisionKind !== undefined && !DECISION_KINDS.includes(decisionKind as HostDecisionKind)) {
     console.error(`--decision-kind must be one of: ${DECISION_KINDS.join("|")}`);
@@ -319,6 +365,7 @@ export async function run(argv: string[]): Promise<number> {
       ...(role !== undefined ? { role: role as CollaborationRole } : {}),
       ...(residency !== undefined ? { residency: residency as Residency } : {}),
       ...(wakeKind !== undefined ? { wake: { kind: wakeKind as WakeKind } } : {}),
+      ...(agentSession === undefined ? {} : { agent_session: agentSession }),
       ...(decision !== undefined ? { decision } : {}),
       ...(workflow !== undefined ? { workflow } : {}),
       context: buildContext(auth),

--- a/cli/src/commands/who.ts
+++ b/cli/src/commands/who.ts
@@ -35,7 +35,7 @@ session name), so mention the "@handle" shown here — not a UUID session name.
 Options:
   --channel C   read channel C instead of the bound channel
   --json        emit one JSON object per line
-                (name/kind/tier/wake/wake_unverified/busy/queue_depth/current_task/task_started_at/heartbeat_at/account/handle/display_name/age_ms/read_seq)`;
+                (name/kind/tier/wake/wake_unverified/busy/queue_depth/current_task/task_started_at/heartbeat_at/agent_session/account/handle/display_name/age_ms/read_seq)`;
 
 const STALE_MS = 60_000; // 与 DO presence 扫描一致
 const DEAD_MS = 14 * 24 * 60 * 60 * 1000; // 14 天没露面视为幽灵，不再列
@@ -74,6 +74,8 @@ interface Row {
   current_task?: number;
   task_started_at?: number;
   heartbeat_at?: number;
+  // runner 自报、worker 持久化的模型会话句柄（#522）；不是 websocket session。
+  agent_session?: PresenceEntry["agent_session"];
 }
 
 // kind 已知取 kind；旧 presence 行没回填时 UUID 名判 human（网页登录会话），其余判 agent。
@@ -132,6 +134,7 @@ export function classify(e: PresenceEntry, now: number): Row | null {
           ...(typeof e.heartbeat_at === "number" ? { heartbeat_at: e.heartbeat_at } : {}),
         }
       : {}),
+    ...(e.agent_session === undefined ? {} : { agent_session: e.agent_session }),
     age_ms: age,
     ...(typeof e.connection_count === "number" && e.connection_count > 1
       ? { connection_count: e.connection_count }
@@ -189,6 +192,14 @@ export function taskNote(r: Row, now: number): string {
   const beat =
     typeof r.heartbeat_at === "number" ? ` · ♥ ${humanAge(Math.max(0, now - r.heartbeat_at))}` : " · ♥ (none)";
   return ` · ▶ seq ${r.current_task}${beat}`;
+}
+
+export function sessionNote(r: Row): string {
+  const session = r.agent_session;
+  if (session === undefined) return "";
+  const harness = terminalIdentityText(session.harness);
+  const id = terminalIdentityText(session.session_id);
+  return harness === "" || id === "" ? "" : ` · session ${harness}:${id}`;
 }
 
 function humanAge(ms: number): string {
@@ -282,7 +293,7 @@ export async function run(argv: string[]): Promise<number> {
           ? ` · ${r.wake_unverified === true ? "unverified" : "verified"}${r.wake ? ` (${r.wake})` : ""}`
           : "";
       const age = r.tier === "online" ? "" : ` (${humanAge(r.age_ms)})`;
-      console.log(`${DOT[r.tier]} ${r.tier.padEnd(8)} ${r.name}  [${r.kind}]${identityNote(r)}${busyNote(r)}${taskNote(r, now)}${wake}${read}${duplicate}${age}`);
+      console.log(`${DOT[r.tier]} ${r.tier.padEnd(8)} ${r.name}  [${r.kind}]${identityNote(r)}${busyNote(r)}${taskNote(r, now)}${sessionNote(r)}${wake}${read}${duplicate}${age}`);
     }
     return 0;
   } catch (e) {

--- a/cli/test/m3.test.ts
+++ b/cli/test/m3.test.ts
@@ -732,6 +732,27 @@ describe("party status/history channel flag", () => {
     expect((req.body as { context: { worktree_label?: string } }).context.worktree_label).toContain(":");
   });
 
+  test("status lets an interactive agent self-report its restart-resume session (#522)", async () => {
+    mock = startRestMock();
+    writeCfg(mock.url);
+    const r = await runCli([
+      "status", "dev", "working",
+      "--session-harness", "claude",
+      "--session-id", "019f35d9-0000-7000-8000-000000000522",
+      "--session-cwd", "/workspace/agentparty",
+    ]);
+    expect(r.code).toBe(0);
+    const req = reqsOf(mock, "POST", "/api/channels/dev/messages")[0]!;
+    expect(req.body).toMatchObject({
+      agent_session: {
+        harness: "claude",
+        session_id: "019f35d9-0000-7000-8000-000000000522",
+        cwd: "/workspace/agentparty",
+        updated_at: expect.any(Number),
+      },
+    });
+  });
+
   test("status --task scopes the status and updates the task ledger", async () => {
     mock = startRestMock((req) => {
       if (req.method === "PATCH" && req.path === "/api/channels/dev/tasks/12") {

--- a/cli/test/serve.test.ts
+++ b/cli/test/serve.test.ts
@@ -265,6 +265,41 @@ describe("runServe", () => {
     expect(beats.lastIndexOf(active[active.length - 1]!)).toBeLessThan(beats.indexOf(clears[0]!));
   });
 
+  test("restart resume: serve reports the persisted runner session on welcome (#522)", async () => {
+    const workdir = tempDir();
+    writeFileSync(join(workdir, "wake-session.json"), JSON.stringify({
+      harness: "codex",
+      session_id: uuid(22),
+      created_at: 1000,
+      last_wake_ts: 2000,
+      wakes: 3,
+      cwd: "/workspace/project",
+      workdir,
+    }));
+    const clientFrames: Array<Record<string, unknown>> = [];
+    server = startMockServer((frame, sock) => {
+      clientFrames.push(frame as unknown as Record<string, unknown>);
+      if (frame.type !== "hello") return;
+      sock.send(welcomeFrame(0, "me"));
+      setTimeout(() => sock.send({ type: "error", code: "archived", message: "done" }), 40);
+    });
+    const o = opts({
+      server: server.url,
+      builtinRunner: { server: server.url, token: "ap_tok", channel: "dev", harness: "codex", workdir },
+    });
+
+    expect(await runServe(o)).toBe(EXIT_ARCHIVED);
+    expect(clientFrames).toContainEqual(expect.objectContaining({
+      type: "heartbeat",
+      current_task: null,
+      agent_session: expect.objectContaining({
+        harness: "codex",
+        session_id: uuid(22),
+        cwd: "/workspace/project",
+      }),
+    }));
+  });
+
   // runner_started 审计（#228）：presence 心跳不落 history、任务结束即清 —— custom runner 跑完后频道
   // 历史里此前零证据它曾启动。现在 wrap 点补发一条落 history 的 working status「runner started for seq X」。
   test("runner_started audit: custom runner posts an auditable working status to history on start", async () => {
@@ -741,6 +776,7 @@ describe("builtin runner", () => {
     const { post } = postRecorder();
     const workdir = tempDir();
     const calls: string[][] = [];
+    const reported: Array<{ session_id: string; harness: string }> = [];
     const runProcess: RunnerProcess = async (args) => {
       calls.push(args);
       const out = args[args.indexOf("-o") + 1]!;
@@ -759,6 +795,7 @@ describe("builtin runner", () => {
       workdir,
       runProcess,
       post,
+      onSession: (session) => reported.push(session),
     });
 
     await run(triggerFrame(1), runnerCtx());
@@ -766,6 +803,10 @@ describe("builtin runner", () => {
 
     const state = JSON.parse(readFileSync(join(workdir, "wake-session.json"), "utf8"));
     expect(state).toMatchObject({ harness: "codex", session_id: uuid(1), wakes: 2 });
+    expect(reported).toEqual([
+      expect.objectContaining({ harness: "codex", session_id: uuid(1) }),
+      expect.objectContaining({ harness: "codex", session_id: uuid(1) }),
+    ]);
     expect(calls[0]!.slice(0, 2)).toEqual(["codex", "exec"]);
     expect(calls[1]!.slice(0, 4)).toEqual(["codex", "exec", "resume", uuid(1)]);
     const log = readFileSync(join(workdir, "serve-runner.log"), "utf8");

--- a/cli/test/who.test.ts
+++ b/cli/test/who.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { PresenceEntry } from "@agentparty/shared";
-import { busyNote, classify, identityNote, taskNote, terminalIdentityText } from "../src/commands/who";
+import { busyNote, classify, identityNote, sessionNote, taskNote, terminalIdentityText } from "../src/commands/who";
 
 const NOW = 1_000_000_000;
 
@@ -189,6 +189,27 @@ describe("who 身份分层（#110：who --json 不再对 presence 已有的身�
 
   test("terminalIdentityText：控制字符变空格，并折叠多余空白", () => {
     expect(terminalIdentityText(" a\n\tb\u001b[31m\u009bc\u007f\u0085 ")).toBe("a b [31m c");
+  });
+});
+
+describe("who agent session（#522）", () => {
+  test("JSON 保留完整 resume 信息，终端行显示可直接复用的 harness + session id", () => {
+    const r = classify(p({
+      name: "resume-agent",
+      agent_session: {
+        harness: "codex",
+        session_id: "019f35d9-0000-7000-8000-000000000522",
+        updated_at: NOW,
+        cwd: "/workspace/agentparty",
+      },
+    }), NOW)!;
+    expect(JSON.parse(JSON.stringify(r)).agent_session).toEqual({
+      harness: "codex",
+      session_id: "019f35d9-0000-7000-8000-000000000522",
+      updated_at: NOW,
+      cwd: "/workspace/agentparty",
+    });
+    expect(sessionNote(r)).toBe(" · session codex:019f35d9-0000-7000-8000-000000000522");
   });
 });
 

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -372,6 +372,20 @@ export interface Sender {
   connection_count?: number;
 }
 
+/**
+ * Agent 自报的可恢复模型会话（issue #522）。它是 runner 的 Codex/Claude 会话句柄，
+ * 不是 AgentParty websocket/登录 session。频道 ACL 保护 presence；旧客户端忽略该字段。
+ */
+export interface AgentSessionInfo {
+  harness: "codex" | "claude" | "codex-sdk";
+  session_id: string;
+  updated_at: number;
+  /** 模型进程实际运行目录；恢复时应回到同一目录，避免 resume 到错误项目。 */
+  cwd?: string;
+  /** 持久化 wake-session.json / 隔离 CODEX_HOME 的 runner 目录。 */
+  workdir?: string;
+}
+
 export interface PresenceEntry {
   name: string;
   /** 最近一次有效 CLI hello 上报的 package version；旧客户端或非 CLI 客户端缺失时省略。 */
@@ -445,6 +459,8 @@ export interface PresenceEntry {
    * 心跳还在推进 = 活着，长时间不动 = 卡死。不参与可达性/租约判定。
    */
   heartbeat_at?: number;
+  /** Agent 自报并由频道持久化的模型会话句柄；供重启后精确 resume（issue #522）。 */
+  agent_session?: AgentSessionInfo;
 }
 
 export interface ChannelRoleAssignment {
@@ -647,6 +663,8 @@ export interface SendStatusFrame {
   busy?: boolean;
   /** 当前排在身后、尚未处理的 wake 数（issue #103）。0/缺省 = 无积压。非负整数。 */
   queue_depth?: number;
+  /** Agent 主动上报的可恢复模型会话；适用于非 builtin runner 的交互式 agent（issue #522）。 */
+  agent_session?: AgentSessionInfo;
 }
 
 export type SendFrame = SendMessageFrame | SendStatusFrame;
@@ -677,6 +695,11 @@ export interface HeartbeatFrame {
   task_started_at: number | null;
   /** 本次心跳时刻（epoch ms），周期性推进；随 current_task 一起清空。 */
   heartbeat_at: number | null;
+  /**
+   * 可选的模型会话自报。可与任务心跳同帧，也可在三个任务字段均为 null 时单独上报；
+   * 服务端持久化但不落聊天 history。缺省表示不更新已有会话。
+   */
+  agent_session?: AgentSessionInfo;
 }
 
 // 同名 serve 跨机租约（#99）：一个 serve 连接声明「我是这个 name 的 serve runner，想当唯一在跑的那个」。
@@ -1370,6 +1393,8 @@ export interface PresenceFrame {
   task_started_at?: number;
   /** 当前任务最近心跳；与 current_task 同生共死。 */
   heartbeat_at?: number;
+  /** Agent 自报并由频道持久化的模型会话句柄；供重启后精确 resume（issue #522）。 */
+  agent_session?: AgentSessionInfo;
   /** 同一身份当前活跃连接数。 */
   connection_count?: number;
 }

--- a/web/src/components/AgentDetailModal.test.tsx
+++ b/web/src/components/AgentDetailModal.test.tsx
@@ -99,7 +99,7 @@ describe("AgentDetailModal (#272)", () => {
     return { name: "worker-a", state: "working", note: null, ts: 1, kind: "agent", ...overrides };
   }
 
-  test("renders the agent's presence fields: state, busy/queue, current task, paused, wake", () => {
+  test("renders the agent's presence fields: state, busy/queue, current task, paused, wake, resume session", () => {
     const root = render({
       name: "worker-a",
       display: "worker-a",
@@ -114,6 +114,12 @@ describe("AgentDetailModal (#272)", () => {
         paused: true,
         wake: { kind: "serve" },
         residency: "supervised",
+        agent_session: {
+          harness: "codex",
+          session_id: "019f35d9-0000-7000-8000-000000000522",
+          updated_at: Date.now(),
+          cwd: "/workspace/agentparty",
+        },
       }),
       messages: [],
       onClose: () => {},
@@ -122,6 +128,9 @@ describe("AgentDetailModal (#272)", () => {
     expect(text).toContain("忙碌 · 排队 3 条");
     expect(text).toContain("510");
     expect(text).toContain("已暂停");
+    expect(text).toContain("codex");
+    expect(text).toContain("019f35d9-0000-7000-8000-000000000522");
+    expect(text).toContain("/workspace/agentparty");
   });
 
   test("history section lists only that agent's messages", () => {

--- a/web/src/components/AgentDetailModal.tsx
+++ b/web/src/components/AgentDetailModal.tsx
@@ -60,6 +60,7 @@ export function AgentDetailModal({ name, display, kind, owner, online, presence,
   const role = presence?.role ?? null;
   const reportsTo = presence?.lineage?.parent_agent ?? null;
   const clientVersion = presence?.client_version ?? null;
+  const agentSession = presence?.agent_session ?? null;
 
   return (
     <div className="channel-panel-overlay agent-detail-overlay" role="dialog" aria-modal="true" aria-label={t("AgentDetailModal.title", { name: display })}>
@@ -169,6 +170,20 @@ export function AgentDetailModal({ name, display, kind, owner, online, presence,
                   <dt>{t("AgentDetailModal.clientVersion")}</dt>
                   <dd className="t-mono">v{clientVersion}</dd>
                 </div>
+              )}
+              {agentSession !== null && (
+                <>
+                  <div className="agent-detail-fact">
+                    <dt>{t("AgentDetailModal.session")}</dt>
+                    <dd className="t-mono">{agentSession.harness}:{agentSession.session_id}</dd>
+                  </div>
+                  {agentSession.cwd !== undefined && (
+                    <div className="agent-detail-fact">
+                      <dt>{t("AgentDetailModal.sessionCwd")}</dt>
+                      <dd className="t-mono">{agentSession.cwd}</dd>
+                    </div>
+                  )}
+                </>
               )}
             </dl>
           </section>

--- a/web/src/i18n/strings/AgentDetailModal.ts
+++ b/web/src/i18n/strings/AgentDetailModal.ts
@@ -29,6 +29,8 @@ export const AgentDetailModalStrings: LocaleDict = {
     "AgentDetailModal.roleNone": "no declared role",
     "AgentDetailModal.reportsTo": "reports to",
     "AgentDetailModal.clientVersion": "client version",
+    "AgentDetailModal.session": "resume session",
+    "AgentDetailModal.sessionCwd": "resume cwd",
   },
   zh: {
     "AgentDetailModal.title": "{name} — Agent 详情",
@@ -57,6 +59,8 @@ export const AgentDetailModalStrings: LocaleDict = {
     "AgentDetailModal.roleNone": "尚未声明角色",
     "AgentDetailModal.reportsTo": "汇报给",
     "AgentDetailModal.clientVersion": "客户端版本",
+    "AgentDetailModal.session": "可恢复会话",
+    "AgentDetailModal.sessionCwd": "恢复目录",
   },
 };
 

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -33,6 +33,7 @@ import {
   WAKE_BUDGET_MAX_WINDOW_MS,
   WAKE_BUDGET_MIN_WINDOW_MS,
   type AgentLineage,
+  type AgentSessionInfo,
   type Attachment,
   type ErrorCode,
   type AgentContext,
@@ -891,6 +892,8 @@ function parseSendFrame(input: unknown): SendFrame | null {
           ? Math.min(f.queue_depth, 100_000)
           : null;
     if (queueDepth === null) return null;
+    const agentSession = f.agent_session === undefined ? undefined : parseAgentSessionInfo(f.agent_session);
+    if (f.agent_session !== undefined && agentSession === undefined) return null;
     return {
       type: "send",
       kind: "status",
@@ -908,6 +911,7 @@ function parseSendFrame(input: unknown): SendFrame | null {
       ...(workflow !== undefined ? { workflow } : {}),
       ...(busy !== undefined ? { busy } : {}),
       ...(queueDepth !== undefined ? { queue_depth: queueDepth } : {}),
+      ...(agentSession === undefined ? {} : { agent_session: agentSession }),
       ...(idempotencyKey !== undefined ? { idempotency_key: idempotencyKey } : {}),
     };
   }
@@ -918,6 +922,29 @@ export interface ParsedTaskHeartbeat {
   current_task: number | null;
   task_started_at: number | null;
   heartbeat_at: number | null;
+  agent_session?: AgentSessionInfo;
+}
+
+function parseAgentSessionInfo(input: unknown): AgentSessionInfo | undefined {
+  if (typeof input !== "object" || input === null) return undefined;
+  const value = input as Record<string, unknown>;
+  if (value.harness !== "codex" && value.harness !== "claude" && value.harness !== "codex-sdk") return undefined;
+  if (typeof value.session_id !== "string" || !/^[A-Za-z0-9._:-]{1,256}$/u.test(value.session_id)) return undefined;
+  if (typeof value.updated_at !== "number" || !Number.isSafeInteger(value.updated_at) || value.updated_at < 0) return undefined;
+  const optionalPath = (field: unknown): string | undefined | false => {
+    if (field === undefined) return undefined;
+    return typeof field === "string" && field.length > 0 && field.length <= 2048 ? field : false;
+  };
+  const cwd = optionalPath(value.cwd);
+  const workdir = optionalPath(value.workdir);
+  if (cwd === false || workdir === false) return undefined;
+  return {
+    harness: value.harness,
+    session_id: value.session_id,
+    updated_at: value.updated_at,
+    ...(cwd === undefined ? {} : { cwd }),
+    ...(workdir === undefined ? {} : { workdir }),
+  };
 }
 
 // 每任务心跳帧校验（#228）：三字段要么全是非负整数（活跃任务），要么各自 null（清除）。
@@ -934,7 +961,14 @@ function parseHeartbeatFrame(input: unknown): ParsedTaskHeartbeat | null {
   const started = field(f.task_started_at);
   const heartbeat = field(f.heartbeat_at);
   if (current === undefined || started === undefined || heartbeat === undefined) return null;
-  return { current_task: current, task_started_at: started, heartbeat_at: heartbeat };
+  const agentSession = f.agent_session === undefined ? undefined : parseAgentSessionInfo(f.agent_session);
+  if (f.agent_session !== undefined && agentSession === undefined) return null;
+  return {
+    current_task: current,
+    task_started_at: started,
+    heartbeat_at: heartbeat,
+    ...(agentSession === undefined ? {} : { agent_session: agentSession }),
+  };
 }
 
 async function hmacSha256Hex(secret: string, body: string): Promise<string> {
@@ -1146,6 +1180,7 @@ export class ChannelDO extends Server<Env> {
       kind TEXT,
       account TEXT,
       client_version TEXT,
+      agent_session_json TEXT,
       PRIMARY KEY (name, session_id)
     )`);
     for (const ddl of [
@@ -1171,6 +1206,8 @@ export class ChannelDO extends Server<Env> {
       "ALTER TABLE presence ADD COLUMN avatar_url TEXT",
       "ALTER TABLE presence ADD COLUMN avatar_thumb TEXT",
       "ALTER TABLE presence ADD COLUMN client_version TEXT",
+      // issue #522：runner 自报的 Codex/Claude 模型会话句柄；与 websocket session_id 不同。
+      "ALTER TABLE presence ADD COLUMN agent_session_json TEXT",
       // 人为「暂停接待」（issue #180）：paused_at 非 NULL 即暂停；paused_resume_at 为定时恢复时刻（epoch ms）。
       "ALTER TABLE presence ADD COLUMN paused_at INTEGER",
       "ALTER TABLE presence ADD COLUMN paused_resume_at INTEGER",
@@ -1391,6 +1428,7 @@ export class ChannelDO extends Server<Env> {
         current_task INTEGER,
         task_started_at INTEGER,
         heartbeat_at INTEGER,
+        agent_session_json TEXT,
         PRIMARY KEY (name, session_id)
       )`);
       sql.exec(`INSERT INTO presence_session_v2 (
@@ -1399,14 +1437,14 @@ export class ChannelDO extends Server<Env> {
         status_decision_json, status_workflow_json, role, role_source, residency, wake_kind,
         wake_verified_at, context_json, lineage_json, kind, account, client_version, handle,
         display_name, avatar_url, avatar_thumb, paused_at, paused_resume_at, busy, queue_depth,
-        current_task, task_started_at, heartbeat_at
+        current_task, task_started_at, heartbeat_at, agent_session_json
       ) SELECT
         name, COALESCE(NULLIF(session_id, ''), '${LEGACY_SESSION_ID}'), state, note, updated_at,
         status_scope_json, status_summary_seq, status_blocked_reason, status_context_json,
         status_decision_json, status_workflow_json, role, role_source, residency, wake_kind,
         wake_verified_at, context_json, lineage_json, kind, account, client_version, handle,
         display_name, avatar_url, avatar_thumb, paused_at, paused_resume_at, busy, queue_depth,
-        current_task, task_started_at, heartbeat_at
+        current_task, task_started_at, heartbeat_at, agent_session_json
       FROM presence`);
       sql.exec("DROP TABLE presence");
       sql.exec("ALTER TABLE presence_session_v2 RENAME TO presence");
@@ -2150,7 +2188,7 @@ export class ChannelDO extends Server<Env> {
     if (entry) this.broadcastFrame({ type: "presence", ...entry });
   }
 
-  // 每任务进度/心跳（#228）：只更新 presence 上的 current_task/task_started_at/heartbeat_at 三列，
+  // 每任务进度/心跳（#228）+ runner session 自报（#522）：只更新 presence，不落 history。
   // 不碰 state/note/busy、不落 history（presence-only，不刷屏）。仅当已有这行 presence 时才更新+广播；
   // 从没发过 presence（连 status 都没发）就无从附着，直接忽略。current_task=null 即清除（任务结束）。
   private applyTaskHeartbeat(name: string, sessionId: string, hb: ParsedTaskHeartbeat) {
@@ -2160,10 +2198,13 @@ export class ChannelDO extends Server<Env> {
         .toArray().length > 0;
     if (!exists) return;
     this.ctx.storage.sql.exec(
-      `UPDATE presence SET current_task = ?, task_started_at = ?, heartbeat_at = ? WHERE name = ? AND session_id = ?`,
+      `UPDATE presence SET current_task = ?, task_started_at = ?, heartbeat_at = ?,
+         agent_session_json = COALESCE(?, agent_session_json)
+       WHERE name = ? AND session_id = ?`,
       hb.current_task,
       hb.task_started_at,
       hb.heartbeat_at,
+      hb.agent_session === undefined ? null : JSON.stringify(hb.agent_session),
       name,
       sessionId,
     );
@@ -4159,9 +4200,9 @@ export class ChannelDO extends Server<Env> {
            name, session_id, kind, account, handle, display_name, avatar_url, avatar_thumb,
            state, note, updated_at, status_scope_json, status_summary_seq, status_blocked_reason,
            status_context_json, status_decision_json, status_workflow_json, role, role_source, residency, wake_kind, wake_verified_at, context_json,
-           lineage_json, busy, queue_depth
+           lineage_json, busy, queue_depth, agent_session_json
          )
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
          ON CONFLICT(name, session_id) DO UPDATE SET
            kind = excluded.kind,
            account = COALESCE(excluded.account, presence.account),
@@ -4192,7 +4233,8 @@ export class ChannelDO extends Server<Env> {
            context_json = COALESCE(excluded.context_json, presence.context_json),
            lineage_json = excluded.lineage_json,
            busy = excluded.busy,
-           queue_depth = excluded.queue_depth`,
+           queue_depth = excluded.queue_depth,
+           agent_session_json = COALESCE(excluded.agent_session_json, presence.agent_session_json)`,
         identity.name,
         options.sessionId ?? LEGACY_SESSION_ID,
         identity.kind,
@@ -4221,6 +4263,7 @@ export class ChannelDO extends Server<Env> {
         // （waiting/done/blocked 等）自然把 busy 清回 0，这就是「任务结束即清 busy」的落点。
         frame.busy === true ? 1 : 0,
         frame.queue_depth ?? 0,
+        frame.agent_session === undefined ? null : JSON.stringify(frame.agent_session),
         wakeProvided,
         wakeProvided,
       );
@@ -5123,7 +5166,7 @@ export class ChannelDO extends Server<Env> {
                 state, note, updated_at, status_scope_json, status_summary_seq, status_blocked_reason,
                 status_context_json, status_decision_json, status_workflow_json, role, role_source, residency, wake_kind, wake_verified_at,
                 context_json, lineage_json, paused_at, paused_resume_at, busy, queue_depth,
-                current_task, task_started_at, heartbeat_at`;
+                current_task, task_started_at, heartbeat_at, agent_session_json`;
 
   private presenceList(): PresenceEntry[] {
     const liveCounts = this.liveConnectionCounts();
@@ -5283,6 +5326,15 @@ export class ChannelDO extends Server<Env> {
             ...(r.heartbeat_at === null || r.heartbeat_at === undefined ? {} : { heartbeat_at: Number(r.heartbeat_at) }),
           }
         : {}),
+      ...(() => {
+        if (typeof r.agent_session_json !== "string" || r.agent_session_json === "") return {};
+        try {
+          const session = parseAgentSessionInfo(JSON.parse(r.agent_session_json) as unknown);
+          return session === undefined ? {} : { agent_session: session };
+        } catch {
+          return {};
+        }
+      })(),
     };
   }
 

--- a/worker/test/session-presence-isolation.spec.ts
+++ b/worker/test/session-presence-isolation.spec.ts
@@ -23,6 +23,73 @@ async function presence(slug: string, token: string, name: string): Promise<Pres
 }
 
 describe("same-name websocket session isolation (#363)", () => {
+  it("persists an agent-reported model session in presence for restart resume (#522)", async () => {
+    const agent = await seedToken("agent");
+    const slug = await createChannel(agent.token);
+    const ws = await WsClient.open(slug, agent.token);
+    await ws.nextOfType("welcome");
+    await sendStatus(ws, "waiting", "ready");
+
+    ws.send({
+      type: "heartbeat",
+      current_task: null,
+      task_started_at: null,
+      heartbeat_at: null,
+      agent_session: {
+        harness: "codex",
+        session_id: "019f35d9-0000-7000-8000-000000000522",
+        updated_at: 1_700_000_000_000,
+        cwd: "/workspace/agentparty",
+        workdir: "/home/agent/.agentparty/runners/test",
+      },
+    });
+    await ws.nextOfType("presence");
+
+    expect(await presence(slug, agent.token, agent.name)).toMatchObject({
+      agent_session: {
+        harness: "codex",
+        session_id: "019f35d9-0000-7000-8000-000000000522",
+        updated_at: 1_700_000_000_000,
+        cwd: "/workspace/agentparty",
+        workdir: "/home/agent/.agentparty/runners/test",
+      },
+    });
+
+    const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+    await runInDurableObject(stub, async (_instance: ChannelDO, state) => {
+      const row = state.storage.sql
+        .exec("SELECT agent_session_json FROM presence WHERE name = ?", agent.name)
+        .one();
+      expect(JSON.parse(String(row.agent_session_json))).toMatchObject({ harness: "codex" });
+    });
+    ws.close();
+  });
+
+  it("accepts an interactive agent session on a normal status frame (#522)", async () => {
+    const agent = await seedToken("agent");
+    const slug = await createChannel(agent.token);
+    const ws = await WsClient.open(slug, agent.token);
+    await ws.nextOfType("welcome");
+    await sendStatus(ws, "working", "interactive session", {
+      agent_session: {
+        harness: "claude",
+        session_id: "019f35d9-0000-7000-8000-000000000523",
+        updated_at: 1_700_000_000_001,
+        cwd: "/workspace/manual",
+      },
+    });
+
+    expect(await presence(slug, agent.token, agent.name)).toMatchObject({
+      state: "working",
+      agent_session: {
+        harness: "claude",
+        session_id: "019f35d9-0000-7000-8000-000000000523",
+        cwd: "/workspace/manual",
+      },
+    });
+    ws.close();
+  });
+
   it("keeps status, busy, and task state per connection while aggregating the active session", async () => {
     const agent = await seedToken("agent");
     const slug = await createChannel(agent.token);


### PR DESCRIPTION
## 变更
- 在 presence/heartbeat/status 协议中持久化 agent 的 harness、session id、时间与工作目录
- 内置 Codex、Claude、Codex SDK runner 启动和 session 变化时自动上报，重启后从 wake-session.json 恢复上报
- `party status` 支持交互式 agent 主动上报，`party who` 与 Web Agent 详情展示 resume 信息
- Worker 持久化并校验 session 信息，heartbeat 上报不污染频道历史

## 验证
- CLI 全量：755 passed
- Worker 全量：540 passed
- Web 定向：7 passed
- shared/worker/cli/web TypeScript 通过
- `git diff --check` 通过

Closes #522

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增可恢复会话信息展示，包括会话类型、会话 ID 和恢复目录。
  - `party status` 支持上报会话恢复参数，便于重启后继续使用原会话。
  - `party serve` 可自动报告已保存的会话状态。
  - `party who` 及代理详情面板显示可恢复会话标识。

- **改进**
  - 会话状态可在重连、重启及持续运行期间保持并恢复。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->