### PR TITLE
fix(attachments): 收紧签名密钥与下载回退

### DIFF
--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -594,7 +594,7 @@ export interface HelloFrame {
  * 客户端先 POST /api/channels/:slug/attachments 上传拿到本结构，再随消息带上 N 个引用。
  */
 export interface Attachment {
-  /** R2 对象键：<slug>/<uuid>/<filename>，前缀锚定到频道 slug 以隔离跨频道读取 */
+  /** R2 对象键：<slug>/<sha256>/<filename>，前缀锚定到频道 slug 以隔离跨频道读取 */
   key: string;
   filename: string;
   content_type: string;

--- a/web/src/components/AttachmentList.test.ts
+++ b/web/src/components/AttachmentList.test.ts
@@ -1,0 +1,48 @@
+// @ts-expect-error Bun executes this test, while the web tsconfig intentionally loads only Vite globals.
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const signedCalls: Array<{ token: string; url: string }> = [];
+const blobCalls: Array<{ token: string | null; url: string }> = [];
+let signedFailure = false;
+
+mock.module("../lib/api", () => ({
+  getToken: () => null,
+  fetchAttachmentSignedUrl: async (token: string, url: string) => {
+    signedCalls.push({ token, url });
+    if (signedFailure) throw new Error("old worker");
+    return "https://ap.test/signed";
+  },
+  fetchAttachmentBlob: async (token: string | null, url: string) => {
+    blobCalls.push({ token, url });
+    return new Blob(["proof"]);
+  },
+}));
+
+const { resolveAttachmentDownloadUrl } = await import("./AttachmentList");
+
+beforeEach(() => {
+  signedCalls.length = 0;
+  blobCalls.length = 0;
+  signedFailure = false;
+  URL.createObjectURL = mock(() => "blob:authenticated-fallback");
+});
+
+describe("attachment downloads (#521)", () => {
+  test("uses a signed URL when the worker supports it", async () => {
+    expect(await resolveAttachmentDownloadUrl("token", "/attachment")).toEqual({
+      href: "https://ap.test/signed",
+      revoke: false,
+    });
+    expect(signedCalls).toEqual([{ token: "token", url: "/attachment" }]);
+    expect(blobCalls).toEqual([]);
+  });
+
+  test("falls back to an authenticated blob when signed URL exchange fails", async () => {
+    signedFailure = true;
+    expect(await resolveAttachmentDownloadUrl("token", "/attachment")).toEqual({
+      href: "blob:authenticated-fallback",
+      revoke: true,
+    });
+    expect(blobCalls).toEqual([{ token: "token", url: "/attachment" }]);
+  });
+});

--- a/web/src/components/AttachmentList.tsx
+++ b/web/src/components/AttachmentList.tsx
@@ -64,30 +64,34 @@ function ImageThumb({ att }: { att: Attachment }) {
   );
 }
 
+export async function resolveAttachmentDownloadUrl(
+  token: string | null,
+  url: string,
+): Promise<{ href: string; revoke: boolean }> {
+  if (token) {
+    try {
+      return { href: await fetchAttachmentSignedUrl(token, url), revoke: false };
+    } catch {
+      // Rolling deploy / self-hosted old worker: use the authenticated blob path.
+    }
+  }
+  const blob = await fetchAttachmentBlob(token, url);
+  return { href: URL.createObjectURL(blob), revoke: true };
+}
+
 function FileLink({ att }: { att: Attachment }) {
   const onDownload = async () => {
     try {
       const token = getToken();
-      if (token) {
-        const signedUrl = await fetchAttachmentSignedUrl(token, att.url);
-        const a = document.createElement("a");
-        a.href = signedUrl;
-        a.download = att.filename;
-        a.rel = "noreferrer";
-        document.body.appendChild(a);
-        a.click();
-        a.remove();
-        return;
-      }
-      const blob = await fetchAttachmentBlob(null, att.url);
-      const objectUrl = URL.createObjectURL(blob);
+      const resolved = await resolveAttachmentDownloadUrl(token, att.url);
       const a = document.createElement("a");
-      a.href = objectUrl;
+      a.href = resolved.href;
       a.download = att.filename;
+      a.rel = "noreferrer";
       document.body.appendChild(a);
       a.click();
       a.remove();
-      setTimeout(() => URL.revokeObjectURL(objectUrl), 10_000);
+      if (resolved.revoke) setTimeout(() => URL.revokeObjectURL(resolved.href), 10_000);
     } catch {
       // 静默失败：下载权限/网络问题在 UI 无 toast 约定下不打断阅读
     }

--- a/worker/src/attachment-signatures.ts
+++ b/worker/src/attachment-signatures.ts
@@ -4,12 +4,10 @@ const ATTACHMENT_SIGNED_URL_MAX_FUTURE_SECONDS = ATTACHMENT_SIGNED_URL_TTL_SECON
 
 export type AttachmentSigningEnv = {
   ATTACHMENT_SIGNING_SECRET?: string;
-  DESKTOP_PAIRING_SECRET?: string;
-  ADMIN_SECRET?: string;
 };
 
 function signingSecret(env: AttachmentSigningEnv): string | null {
-  return env.ATTACHMENT_SIGNING_SECRET?.trim() || env.DESKTOP_PAIRING_SECRET?.trim() || env.ADMIN_SECRET?.trim() || null;
+  return env.ATTACHMENT_SIGNING_SECRET?.trim() || null;
 }
 
 function attachmentPath(pathname: string): boolean {

--- a/worker/src/integrations/lark.ts
+++ b/worker/src/integrations/lark.ts
@@ -595,8 +595,10 @@ export function buildMentionCard(payload: LarkWebhookPayload): Record<string, un
   const title = `AgentParty @${payload.mentions.join(", @")}`;
   const sender = payload.sender.display_name || payload.sender.handle || payload.sender.owner || payload.sender.name;
   const body = payload.kind === "status" ? payload.note || payload.body : payload.body;
-  const attachmentLinks = payload.attachments?.map((attachment) =>
-    `[${attachment.filename.replace(/[\\[\]]/g, "\\$&")}](${attachment.url})`).join(" · ");
+  const attachmentLinks = payload.attachments?.map((attachment) => {
+    const markdownSafeUrl = attachment.url.replace(/\(/g, "%28").replace(/\)/g, "%29");
+    return `[${attachment.filename.replace(/[\\[\]]/g, "\\$&")}](${markdownSafeUrl})`;
+  }).join(" · ");
   const content = attachmentLinks ? `${body}\n\n📎 ${attachmentLinks}` : body;
   return {
     config: { wide_screen_mode: true },

--- a/worker/src/openapi.ts
+++ b/worker/src/openapi.ts
@@ -748,7 +748,7 @@ export const openapiDocument = {
       post: {
         summary: "upload one attachment blob to R2 and get a ref",
         description:
-          "uploads the raw request body to R2 under <slug>/<uuid>/<filename>; returns the ref to carry in a message's attachments field. non-readonly token with channel access required. max 25MB.",
+          "uploads the raw request body to R2 under <slug>/<sha256>/<filename>; returns the ref to carry in a message's attachments field. non-readonly token with channel access required. max 25MB.",
         security: [{ bearer: [] }],
         parameters: [
           { name: "slug", in: "path", required: true, schema: { type: "string" } },

--- a/worker/test/attachment-signatures.spec.ts
+++ b/worker/test/attachment-signatures.spec.ts
@@ -31,5 +31,9 @@ describe("attachment signed URLs (#521)", () => {
     expect(await verifySignedAttachmentRequest(signed!.url, env, (signed!.expiresAt + 1) * 1000)).toBe(false);
     expect(await createSignedAttachmentUrl(source, {}, now)).toBeNull();
     expect(await verifySignedAttachmentRequest(signed!.url, {}, now)).toBe(false);
+    expect(await createSignedAttachmentUrl(source, {
+      DESKTOP_PAIRING_SECRET: "must-not-cross-sign",
+      ADMIN_SECRET: "must-not-cross-sign",
+    } as Record<string, string>, now)).toBeNull();
   });
 });

--- a/worker/test/lark.spec.ts
+++ b/worker/test/lark.spec.ts
@@ -68,6 +68,34 @@ describe("lark notification integration", () => {
     expect(await verifyWebhookSignature("secret", body, `hmac-sha256=${sig.slice(0, -1)}0`)).toBe(false);
   });
 
+  it("escapes parentheses in attachment URLs before embedding them in Lark markdown", () => {
+    const card = buildMentionCard({
+      type: "msg",
+      seq: 1,
+      kind: "message",
+      body: "proof",
+      mentions: ["reviewer"],
+      reply_to: null,
+      state: null,
+      note: null,
+      status: null,
+      ts: 1_700_000_000_000,
+      channel: "qa",
+      permalink: "https://ap.test/c/qa",
+      sender: { name: "codex", kind: "agent" },
+      attachments: [{
+        key: "qa/hash/proof(1).png",
+        filename: "proof(1).png",
+        content_type: "image/png",
+        size: 3,
+        url: "https://ap.test/api/channels/qa/attachments/hash/proof(1).png?exp=1&sig=test",
+      }],
+    });
+    const markdown = String((card.elements as Array<Record<string, unknown>>)[0]?.content);
+    expect(markdown).toContain("proof%281%29.png?exp=1&sig=test");
+    expect(markdown).not.toContain("proof(1).png?exp=1&sig=test");
+  });
+
   it("enables a human subscription by registering a mentions webhook in the channel DO", async () => {
     const account = `lark-email:${uniq("owner")}@example.com`;
     const profile = await seedLarkProfile(account, "larkalice");

--- a/worker/vitest.config.ts
+++ b/worker/vitest.config.ts
@@ -56,6 +56,7 @@ export default defineConfig(async () => {
             ]),
             LARK_CLIENT_SECRET: "test-lark-secret",
             DESKTOP_PAIRING_SECRET: "test-desktop-pairing-secret-at-least-32-bytes",
+            ATTACHMENT_SIGNING_SECRET: "test-attachment-signing-secret-at-least-32-bytes",
             // #137：把每频道 WS 连接上限降到小值，测试才不用真开 200 条连接验证上限。
             // 值必须 > 任何单个 it 对同一频道的并发连接数（现存最多 <6），并与
             // account-channel-quota.spec.ts 的 TEST_CONN_CAP 保持一致。


### PR DESCRIPTION
## 变更
- 非图片下载在 signed URL 交换失败时回退到带 bearer 的 blob 下载，兼容滚动发布和旧 worker
- 附件签名只接受专用 `ATTACHMENT_SIGNING_SECRET`，不再复用管理或桌面配对密钥
- Lark Markdown 附件链接转义路径中的括号
- OpenAPI 与共享协议统一使用真实的 `<sha256>` object key 说明
- production 与 pwtk/xdream 已配置同一个专用签名 secret（值未进入仓库或日志）

## 验证
- `bun run check` 全量通过
- CLI 752 passed
- Web 776 passed，TypeScript 与 Vite build 通过
- Worker 81 files / 539 passed，TypeScript 通过
- 新增 signed URL 下载回退、密钥域隔离与 Lark Markdown 括号测试

Follow-up to #523 review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 附件下载优先使用签名链接；签名获取失败时自动回退至安全的临时 Blob 下载。
- **问题修复**
  - 修复包含括号的附件文件名在 Markdown 链接中解析异常的问题。
  - 优化临时下载地址的释放策略，避免影响远程签名链接。
- **安全性**
  - 附件签名统一使用专用签名密钥，提升访问隔离性。
  - 更新附件存储路径约定，增强不同频道间的读取隔离。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->