### PR TITLE
fix(web): 打磨消息卡与回复交互

### DIFF
--- a/web/src/components/AttachmentList.test.tsx
+++ b/web/src/components/AttachmentList.test.tsx
@@ -1,0 +1,47 @@
+// @ts-expect-error Bun executes this test, while the web tsconfig intentionally loads only Vite globals.
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import type { Attachment } from "@agentparty/shared";
+
+const signedUrl = "https://files.example.test/image.png?signature=test";
+
+mock.module("../lib/api", () => ({
+  fetchAttachmentBlob: mock(async () => new Blob()),
+  fetchAttachmentSignedUrl: mock(async () => signedUrl),
+  getToken: () => "test-token",
+}));
+
+const { AttachmentList } = await import("./AttachmentList");
+
+let renderer: ReactTestRenderer | null = null;
+
+const image: Attachment = {
+  key: "channel/id/image.png",
+  url: "/api/channels/channel/attachments/id/image.png",
+  filename: "image.png",
+  content_type: "image/png",
+  size: 2048,
+};
+
+afterEach(() => {
+  act(() => renderer?.unmount());
+  renderer = null;
+});
+
+describe("AttachmentList image fallback", () => {
+  test("falls back to the file download button when the signed image cannot render", async () => {
+    await act(async () => {
+      renderer = create(<AttachmentList attachments={[image]} />);
+      await Promise.resolve();
+    });
+
+    const img = renderer!.root.findByType("img");
+    expect(img.props.src).toBe(signedUrl);
+
+    act(() => img.props.onError());
+
+    const fallback = renderer!.root.findByProps({ className: "d-btn msg-attachment-file t-mono" });
+    expect(fallback.props.title).toBe("image.png · 2.0 KB · download");
+    expect(renderer!.root.findAllByType("img")).toHaveLength(0);
+  });
+});

--- a/web/src/components/AttachmentList.tsx
+++ b/web/src/components/AttachmentList.tsx
@@ -53,13 +53,15 @@ export function useAttachmentBlobUrl(url: string): { src: string | null; failed:
 
 function ImageThumb({ att }: { att: Attachment }) {
   const { src, failed } = useAttachmentBlobUrl(att.url);
-  if (failed) return <FileLink att={att} />;
+  const [imageFailed, setImageFailed] = useState(false);
+  useEffect(() => setImageFailed(false), [att.url]);
+  if (failed || imageFailed) return <FileLink att={att} />;
   if (src === null) {
     return <span className="msg-attachment-loading t-mono">{att.filename}…</span>;
   }
   return (
     <a href={src} target="_blank" rel="noreferrer" className="msg-attachment-img" title={att.filename}>
-      <img src={src} alt={att.filename} loading="lazy" />
+      <img src={src} alt={att.filename} loading="lazy" onError={() => setImageFailed(true)} />
     </a>
   );
 }
@@ -99,7 +101,7 @@ function FileLink({ att }: { att: Attachment }) {
       onClick={() => void onDownload()}
       title={`${att.filename} · ${formatSize(att.size)} · download`}
     >
-      <span aria-hidden="true">⬇</span>
+      <span className="msg-attachment-download-icon" aria-hidden="true">↓</span>
       <span className="msg-attachment-fname">{att.filename}</span>
       <span className="msg-attachment-size">{formatSize(att.size)}</span>
     </button>

--- a/web/src/components/Composer.escape.test.tsx
+++ b/web/src/components/Composer.escape.test.tsx
@@ -1,5 +1,5 @@
 // @ts-expect-error Bun executes this test, while the web tsconfig intentionally loads only Vite globals.
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { act, create, type ReactTestRenderer } from "react-test-renderer";
 import { LocaleProvider } from "../i18n/locale";
 import { Composer } from "./Composer";
@@ -21,6 +21,7 @@ function memoryStorage(): Storage {
 beforeEach(() => {
   Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", { configurable: true, value: true });
   Object.defineProperty(globalThis, "localStorage", { configurable: true, value: memoryStorage() });
+  Object.defineProperty(globalThis, "window", { configurable: true, value: { innerHeight: 844 } });
 });
 
 afterEach(() => {
@@ -53,6 +54,37 @@ function keyEvent(key: string, isComposing = false) {
 }
 
 describe("Composer Escape handling (#357)", () => {
+  test("focuses and reveals the composer when reply mode starts", () => {
+    const focus = mock(() => undefined);
+    const scrollIntoView = mock(() => undefined);
+
+    act(() => {
+      renderer = create(
+        <LocaleProvider>
+          <Composer
+            draft=""
+            setDraft={() => undefined}
+            onSend={() => undefined}
+            focusRequest={3}
+            ready
+            candidates={[]}
+            mentionStatuses={[]}
+          />
+        </LocaleProvider>,
+        {
+          createNodeMock: (element) =>
+            element.type === "textarea"
+              && (element.props as { className?: string }).className?.includes("composer-input") === true
+              ? { focus, scrollIntoView, style: {}, scrollHeight: 80 }
+              : {},
+        },
+      );
+    });
+
+    expect(focus).toHaveBeenCalledWith({ preventScroll: true });
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest", inline: "nearest" });
+  });
+
   test("mention menu consumes the first Escape before reply cancellation", () => {
     let cancelled = 0;
     const { root, textarea } = render(() => { cancelled += 1; });

--- a/web/src/components/Composer.tsx
+++ b/web/src/components/Composer.tsx
@@ -22,6 +22,7 @@ interface Props {
   setDraft(value: string): void;
   onSend(): void;
   onEscape?: () => void;
+  focusRequest?: number | null;
   ready: boolean; // ws open 才能发
   candidates: MentionCandidate[]; // @ 补全候选（participants ∪ presence，已分档排序）
   mentionStatuses: DraftMentionStatus[]; // 草稿里已 @ 的目标 + 当前存活档位（发送前提醒会不会白发）
@@ -122,6 +123,7 @@ export function Composer({
   setDraft,
   onSend,
   onEscape,
+  focusRequest = null,
   ready,
   candidates,
   mentionStatuses,
@@ -163,6 +165,14 @@ export function Composer({
     ta.style.height = "auto";
     ta.style.height = Math.min(ta.scrollHeight, Math.round(window.innerHeight * 0.4)) + "px";
   }, [draft]);
+
+  useLayoutEffect(() => {
+    if (focusRequest === null) return;
+    const ta = taRef.current;
+    if (ta === null) return;
+    ta.focus({ preventScroll: true });
+    ta.scrollIntoView({ block: "nearest", inline: "nearest" });
+  }, [focusRequest]);
 
   useEffect(() => {
     if (menu === null) return;

--- a/web/src/components/MessageCard.details.test.tsx
+++ b/web/src/components/MessageCard.details.test.tsx
@@ -40,7 +40,34 @@ function renderStatus(): ReturnType<ReactTestRenderer["root"]["findByProps"]> {
   return renderer!.root;
 }
 
+function renderMessage(): ReturnType<ReactTestRenderer["root"]["findByProps"]> {
+  const msg = {
+    type: "msg", seq: 10, sender: { name: "builder", kind: "agent", owner: "team@example.com" }, kind: "message",
+    body: "finished", mentions: [], reply_to: null, state: null, note: null, status: null,
+    ts: 1_700_000_000_000,
+  } as unknown as MsgFrame;
+  act(() => {
+    renderer = create(<LocaleProvider><MessageCard
+      msg={msg} self={null} quotedMessage={null} canModerate={false} onReply={noop} onEdit={noop}
+      onRetract={noop} canCreateTask={false} onCreateTask={noop} editing={false} editDraft=""
+      editSaving={false} actionError={null} busy={false} onEditDraftChange={noop} onEditCancel={noop} onEditSave={noop}
+    /></LocaleProvider>);
+  });
+  return renderer!.root;
+}
+
 describe("MessageCard touch and keyboard details (#357)", () => {
+  test("identity and stable action metadata render in separate header groups", () => {
+    const root = renderMessage();
+    const main = root.findByProps({ className: "msg-head-main" });
+    const meta = root.findByProps({ className: "msg-head-meta" });
+
+    expect(main.findByProps({ className: "msg-sender msg-agent-trigger" })).toBeDefined();
+    expect(meta.findByProps({ className: "d-btn msg-menu-trigger" })).toBeDefined();
+    expect(meta.findByProps({ className: "msg-seq" }).children).toEqual(["#", "10"]);
+    expect(meta.findByProps({ className: "msg-time" })).toBeDefined();
+  });
+
   test("status full detail expands by click and keyboard", () => {
     const root = renderStatus();
     const summary = root.findByProps({ className: "msg-status-summary" });

--- a/web/src/components/MessageCard.editing.test.tsx
+++ b/web/src/components/MessageCard.editing.test.tsx
@@ -96,6 +96,48 @@ afterEach(() => {
 });
 
 describe("message edit keyboard shortcuts (#343)", () => {
+  test("focuses and reveals the editor when editing starts", () => {
+    const focus = mock(() => undefined);
+    const scrollIntoView = mock(() => undefined);
+
+    localStorage.setItem("ap_locale", "en");
+    act(() => {
+      renderer = create(
+        <LocaleProvider>
+          <MessageCard
+            msg={baseMsg()}
+            self="planner"
+            quotedMessage={null}
+            canModerate={false}
+            onReply={noop}
+            onEdit={noop}
+            onRetract={noop}
+            canCreateTask={false}
+            onCreateTask={noop}
+            editing={true}
+            editDraft="changed"
+            editSaving={false}
+            actionError={null}
+            busy={false}
+            onEditDraftChange={noop}
+            onEditCancel={noop}
+            onEditSave={noop}
+          />
+        </LocaleProvider>,
+        {
+          createNodeMock: (element) =>
+            element.type === "textarea"
+              && (element.props as { className?: string }).className?.includes("msg-edit-input") === true
+              ? { focus, scrollIntoView }
+              : {},
+        },
+      );
+    });
+
+    expect(focus).toHaveBeenCalledWith({ preventScroll: true });
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest", inline: "nearest" });
+  });
+
   test("Escape cancels editing", () => {
     let cancelCalls = 0;
     const textarea = renderEditor({ onEditCancel: () => { cancelCalls += 1; } });

--- a/web/src/components/MessageCard.tsx
+++ b/web/src/components/MessageCard.tsx
@@ -1,7 +1,7 @@
 // 消息渲染：message → doodle 卡片外壳 + mono 元信息 + markdown 正文；
 // status → 时间线分隔条（spec §9 第 2 块）。
 import type { AgentContext, ChannelRoleAssignment, MsgFrame, PresenceEntry, ReadCursor, Sender } from "@agentparty/shared";
-import { memo, useCallback, useEffect, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import type { CSSProperties } from "react";
 import { agentHue } from "../lib/agentColor";
 import { isClientVersionOutdated, useMinClientVersion } from "../lib/clientVersion";
@@ -322,6 +322,7 @@ function MessageCardImpl({
   const [decisionRejectDraft, setDecisionRejectDraft] = useState("");
   const menuRef = useRef<HTMLDivElement | null>(null);
   const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const editInputRef = useRef<HTMLTextAreaElement | null>(null);
   // 每个 agent 一个确定性色相：CSS 用 --ah 套 hsl() 给头像点/名字/卡片左条上色
   const hueStyle = { "--ah": agentHue(msg.sender.name) } as CSSProperties;
   // 已读/未读名单（Phase 2）：只在有游标数据时算；status 分隔条不显示。
@@ -416,6 +417,14 @@ function MessageCardImpl({
     const timer = window.setTimeout(() => setCopied(false), 1400);
     return () => window.clearTimeout(timer);
   }, [copied]);
+
+  useLayoutEffect(() => {
+    if (!editing) return;
+    const input = editInputRef.current;
+    if (input === null) return;
+    input.focus({ preventScroll: true });
+    input.scrollIntoView({ block: "nearest", inline: "nearest" });
+  }, [editing]);
 
   const openMenuAt = (x: number, y: number) => {
     const clampedX = Math.max(8, Math.min(x, window.innerWidth - 188));
@@ -537,110 +546,113 @@ function MessageCardImpl({
       }
     >
       <header className="d-meta msg-head">
-        {msg.sender.avatar_thumb || msg.sender.avatar_url ? (
-          <img className="msg-avatar msg-avatar--img" src={msg.sender.avatar_thumb ?? msg.sender.avatar_url} alt="" />
-        ) : (
-          <span className="msg-avatar" aria-hidden="true" />
-        )}
-        <AgentInfoPopover
-          id={`agent-info-${msg.seq}-${msg.sender.name}`}
-          label={senderLabel}
-          name={msg.sender.name}
-          kind={msg.sender.kind}
-          owner={msg.sender.owner ?? null}
-          entry={presence?.[msg.sender.name]}
-          assignment={agentRoles?.[msg.sender.name]}
-          recentMessages={recentMessages}
-          triggerClassName="msg-sender"
-        />
-        {/* owner(lark 长 id）不再每条平铺——它已在 senderTitle 里，悬停发送者名即见；
-           防冒充锚点保留在 tooltip + kind 徽章，行内只留重要内容（名字/类型/提及）。 */}
-        {lineageLabel !== null && (
-          <span className="t-mono msg-lineage" title={senderTitle}>
-            {lineageLabel}
+        <div className="msg-head-main">
+          {msg.sender.avatar_thumb || msg.sender.avatar_url ? (
+            <img className="msg-avatar msg-avatar--img" src={msg.sender.avatar_thumb ?? msg.sender.avatar_url} alt="" />
+          ) : (
+            <span className="msg-avatar" aria-hidden="true" />
+          )}
+          <AgentInfoPopover
+            id={`agent-info-${msg.seq}-${msg.sender.name}`}
+            label={senderLabel}
+            name={msg.sender.name}
+            kind={msg.sender.kind}
+            owner={msg.sender.owner ?? null}
+            entry={presence?.[msg.sender.name]}
+            assignment={agentRoles?.[msg.sender.name]}
+            recentMessages={recentMessages}
+            triggerClassName="msg-sender"
+          />
+          {/* owner(lark 长 id）不再每条平铺——它已在 senderTitle 里，悬停发送者名即见；
+             防冒充锚点保留在 tooltip + kind 徽章，行内只留重要内容（名字/类型/提及）。 */}
+          {lineageLabel !== null && (
+            <span className="t-mono msg-lineage" title={senderTitle}>
+              {lineageLabel}
+            </span>
+          )}
+          <span className={"msg-kind" + (msg.sender.kind === "human" ? " msg-kind--human" : "")}>
+            {msg.sender.kind}
           </span>
-        )}
-        <span className={"msg-kind" + (msg.sender.kind === "human" ? " msg-kind--human" : "")}>
-          {msg.sender.kind}
-        </span>
-        {clientVersion !== null && (
-          <span
-            className={"t-mono msg-client-version" + (clientOutdated ? " msg-client-version--outdated" : "")}
-            title={
-              clientOutdated
-                ? t("MessageCard.clientVersion.outdated", { version: clientVersion, min: minClientVersion ?? "" })
-                : t("MessageCard.clientVersion.title", { version: clientVersion })
-            }
-          >
-            cli v{clientVersion}
-            {clientOutdated && (
-              <span className="msg-client-version-warn" aria-hidden="true">
-                {" "}⚠
-              </span>
-            )}
-          </span>
-        )}
-        {msg.mentions.map((m) => {
-          const mentionedSender = participants?.find((participant) => participant.name === m);
-          const mentionedPresence = presence?.[m];
-          const mentionedIdentity = identityDisplay?.[m];
-          return (
-            <AgentInfoPopover
-              key={m}
-              id={`agent-info-${msg.seq}-mention-${m}`}
-              label={`@${displayForIdentity(m, identityDisplay)}`}
-              name={m}
-              kind={mentionedSender?.kind ?? mentionedPresence?.kind ?? mentionedIdentity?.kind ?? null}
-              owner={mentionedSender?.owner ?? mentionedPresence?.account ?? mentionedIdentity?.account ?? null}
-              entry={mentionedPresence}
-              assignment={agentRoles?.[m]}
-              recentMessages={recentMessagesByAgent?.get(m) ?? (m === msg.sender.name ? recentMessages : [])}
-              triggerClassName="msg-mention"
-            />
-          );
-        })}
-        {msg.reply_to !== null && quotedMessage === null && <span className="msg-reply">↩ #{msg.reply_to}</span>}
-        {revisionBadges.map((badge) => (
-          <span key={badge} className="msg-revision">
-            {badge}
-          </span>
-        ))}
-        {review !== undefined && reviewBadge !== null && (
-          <span className={`msg-review msg-review--${review.state}`} title={reviewTitleText}>
-            {reviewBadge}
-          </span>
-        )}
-        {decisionState !== undefined && (
-          <span className={`msg-decision-badge msg-decision-badge--${decisionState}`}>
-            {t(`MessageCard.decision.state.${decisionState}`)}
-          </span>
-        )}
-        {decisionResponse !== undefined && (
-          <span className="msg-decision-badge msg-decision-badge--response">
-            {t("MessageCard.decision.responseBadge")}
-          </span>
-        )}
-        <span className="msg-fill" />
-        {copied && <span className="msg-copy-feedback">{t("MessageCard.copied")}</span>}
-        {canShowActions && (
-          <button
-            ref={triggerRef}
-            type="button"
-            className="d-btn msg-menu-trigger"
-            aria-label={t("MessageCard.menu.more")}
-            aria-expanded={menu !== null}
-            title={t("MessageCard.menu.more")}
-            disabled={busy}
-            onClick={(event) => {
-              const rect = event.currentTarget.getBoundingClientRect();
-              openMenuAt(rect.right - 12, rect.bottom + 6);
-            }}
-          >
-            ⋯
-          </button>
-        )}
-        <span>#{msg.seq}</span>
-        <time>{fmtTime(msg.ts)}</time>
+          {clientVersion !== null && (
+            <span
+              className={"t-mono msg-client-version" + (clientOutdated ? " msg-client-version--outdated" : "")}
+              title={
+                clientOutdated
+                  ? t("MessageCard.clientVersion.outdated", { version: clientVersion, min: minClientVersion ?? "" })
+                  : t("MessageCard.clientVersion.title", { version: clientVersion })
+              }
+            >
+              cli v{clientVersion}
+              {clientOutdated && (
+                <span className="msg-client-version-warn" aria-hidden="true">
+                  {" "}⚠
+                </span>
+              )}
+            </span>
+          )}
+          {msg.mentions.map((m) => {
+            const mentionedSender = participants?.find((participant) => participant.name === m);
+            const mentionedPresence = presence?.[m];
+            const mentionedIdentity = identityDisplay?.[m];
+            return (
+              <AgentInfoPopover
+                key={m}
+                id={`agent-info-${msg.seq}-mention-${m}`}
+                label={`@${displayForIdentity(m, identityDisplay)}`}
+                name={m}
+                kind={mentionedSender?.kind ?? mentionedPresence?.kind ?? mentionedIdentity?.kind ?? null}
+                owner={mentionedSender?.owner ?? mentionedPresence?.account ?? mentionedIdentity?.account ?? null}
+                entry={mentionedPresence}
+                assignment={agentRoles?.[m]}
+                recentMessages={recentMessagesByAgent?.get(m) ?? (m === msg.sender.name ? recentMessages : [])}
+                triggerClassName="msg-mention"
+              />
+            );
+          })}
+          {msg.reply_to !== null && quotedMessage === null && <span className="msg-reply">↩ #{msg.reply_to}</span>}
+          {revisionBadges.map((badge) => (
+            <span key={badge} className="msg-revision">
+              {badge}
+            </span>
+          ))}
+          {review !== undefined && reviewBadge !== null && (
+            <span className={`msg-review msg-review--${review.state}`} title={reviewTitleText}>
+              {reviewBadge}
+            </span>
+          )}
+          {decisionState !== undefined && (
+            <span className={`msg-decision-badge msg-decision-badge--${decisionState}`}>
+              {t(`MessageCard.decision.state.${decisionState}`)}
+            </span>
+          )}
+          {decisionResponse !== undefined && (
+            <span className="msg-decision-badge msg-decision-badge--response">
+              {t("MessageCard.decision.responseBadge")}
+            </span>
+          )}
+        </div>
+        <div className="msg-head-meta">
+          {copied && <span className="msg-copy-feedback">{t("MessageCard.copied")}</span>}
+          {canShowActions && (
+            <button
+              ref={triggerRef}
+              type="button"
+              className="d-btn msg-menu-trigger"
+              aria-label={t("MessageCard.menu.more")}
+              aria-expanded={menu !== null}
+              title={t("MessageCard.menu.more")}
+              disabled={busy}
+              onClick={(event) => {
+                const rect = event.currentTarget.getBoundingClientRect();
+                openMenuAt(rect.right - 12, rect.bottom + 6);
+              }}
+            >
+              ⋯
+            </button>
+          )}
+          <span className="msg-seq">#{msg.seq}</span>
+          <time className="msg-time">{fmtTime(msg.ts)}</time>
+        </div>
       </header>
       {msg.reply_to !== null && quotedMessage !== null && (
         <button
@@ -829,6 +841,7 @@ function MessageCardImpl({
       {editing ? (
         <div className="msg-edit">
           <textarea
+            ref={editInputRef}
             className="msg-edit-input t-mono"
             rows={4}
             value={editDraft}

--- a/web/src/pages/Channel.tsx
+++ b/web/src/pages/Channel.tsx
@@ -4541,6 +4541,7 @@ export function ChannelPage({
           setDraft={setDraft}
           onSend={send}
           onEscape={replyTo !== null ? cancelReply : undefined}
+          focusRequest={replyTo}
           ready={state.status === "open"}
           candidates={mentionOptions}
           mentionStatuses={draftMentionStatuses}

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -2596,7 +2596,26 @@
   position: relative;
   box-shadow: inset 4px 0 0 hsl(var(--ah, 220) 58% var(--agent-l-soft)), 4px 4px 0 var(--d-shadow);
 }
-.msg-head { flex-wrap: wrap; margin-bottom: 2px; }
+.msg-head {
+  align-items: flex-start;
+  flex-wrap: nowrap;
+  margin-bottom: 2px;
+}
+.msg-head-main,
+.msg-head-meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+.msg-head-main {
+  flex: 1 1 auto;
+  flex-wrap: wrap;
+}
+.msg-head-meta {
+  flex: none;
+  margin-left: auto;
+}
 .msg-avatar {
   flex: none;
   align-self: center;
@@ -3001,7 +3020,6 @@
   color: inherit;
   font-weight: 600;
 }
-.msg-fill { flex: 1; }
 .msg-copy-feedback {
   font-size: 11px;
   color: var(--t-dim);
@@ -4963,12 +4981,24 @@
   font-size: 0.85rem;
   max-width: 100%;
 }
+.msg-attachment-download-icon {
+  flex: none;
+  font-family: var(--d-mono);
+  font-size: 1rem;
+  line-height: 1;
+}
 .msg-attachment-file .msg-attachment-fname {
+  flex: 1;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.msg-attachment-size { color: var(--t-dim); }
+.msg-attachment-size {
+  flex: none;
+  color: var(--t-dim);
+  white-space: nowrap;
+}
 .msg-attachment-loading { color: var(--t-dim); font-size: 0.85rem; }
 
 .d-btn:disabled {
@@ -6280,6 +6310,18 @@
   .msg-menu-trigger {
     min-width: 36px;
     min-height: 36px;
+  }
+  .msg-head {
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+  .msg-head-main,
+  .msg-head-meta {
+    width: 100%;
+  }
+  .msg-head-meta {
+    justify-content: flex-end;
+    margin-left: 0;
   }
   .lang-switch-btn {
     min-height: 36px;


### PR DESCRIPTION
## 变更
- 将消息身份信息与操作元信息拆成稳定分组，窄屏下菜单、序号和时间不再随发送者长度漂移
- 进入消息编辑态时自动聚焦并滚入可视区，保存/取消不再被固定输入区遮挡
- 进入回复态时直接聚焦 composer，并保持 Escape 取消语义
- 图片加载失败时降级为文件下载按钮；长文件名省略、文件大小保持单行
- 下载符号改为稳定文本图标，避免系统 emoji 风格漂移

## 视觉约束
保留现有 AgentParty 纸张底色、硬黑边、硬阴影、红色印章和等宽字体；本 PR 不做全局换皮。

## 验证
- `bun run check:web`：778 tests、TypeScript、Vite production build 通过
- Chrome 390x844：无页面横向溢出；消息头统一 60.6px；编辑按钮完整可见；回复后 composer 自动聚焦；附件按钮 33px
- Chrome 1440x900：消息头保持 25px 单行；无横向溢出；消息菜单未越界


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 回复消息时，输入框会自动聚焦并滚动到可见区域。
  - 进入消息编辑状态时，编辑框会自动聚焦并定位。
  - 优化消息头部信息布局，调整发送者、时间、序号及操作入口的展示。

- **问题修复**
  - 图片附件加载失败时，自动提供文件下载入口，并显示文件名与大小提示。

- **样式优化**
  - 改进消息头部和附件下载区域在桌面端及移动端的排版与触控体验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->