### PR TITLE
fix(cli): 支持消息参数中的换行转义

### DIFF
--- a/cli/src/commands/send.ts
+++ b/cli/src/commands/send.ts
@@ -14,6 +14,7 @@ const SEND_FLAGS = ["channel", "reply-to", "mention", "attach", "debug-auth", "r
 const HELP = `usage: party send <text|-> [--channel C] [--mention name]... [--attach path]... [--reply-to seq] [--debug-auth]
 
 Send one message to a channel. Use "-" as the body to read stdin.
+Positional text decodes \\n as a line break; use \\\\n for a literal \\n, or stdin for exact bytes.
 
 With --attach, each file is uploaded to the channel first, then the message is sent
 carrying the attachment refs. Body may be empty when at least one --attach is present.
@@ -72,6 +73,15 @@ export interface SendInput {
   mentions: string[];
   replyTo: number | null;
   attachPaths: string[];
+}
+
+// Agent-generated shell commands commonly pass multiline replies as one quoted argument containing `\n`.
+// Decode only positional text; stdin remains byte-for-byte so code and other literal content always have an exact path.
+export function decodePositionalNewlines(input: string): string {
+  return input.replace(/(\\+)n/g, (_match, slashes: string) => {
+    const prefix = "\\".repeat(Math.floor(slashes.length / 2));
+    return prefix + (slashes.length % 2 === 1 ? "\n" : "n");
+  });
 }
 
 // 本地路径 → 上传源：不存在/空文件/超限一律抛带路径的可读错误，绝不静默上传半个包。
@@ -143,7 +153,7 @@ export async function resolveSendInput(parsed: Parsed): Promise<SendInput | null
   } else if (trailingStdin && positionals.length === 1) {
     readStdin = true; // send -、send --channel C -、send - --
   } else {
-    text = positionals.length > 0 ? positionals.join(" ") : undefined;
+    text = positionals.length > 0 ? decodePositionalNewlines(positionals.join(" ")) : undefined;
   }
 
   const channel = resolveChannel(channelArg);

--- a/cli/test/send-attach.test.ts
+++ b/cli/test/send-attach.test.ts
@@ -5,7 +5,13 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Attachment } from "@agentparty/shared";
 import { parseArgs } from "../src/args";
-import { collectAttachments, resolveAttachments, resolveSendInput, sendSpec } from "../src/commands/send";
+import {
+  collectAttachments,
+  decodePositionalNewlines,
+  resolveAttachments,
+  resolveSendInput,
+  sendSpec,
+} from "../src/commands/send";
 
 let dir = "";
 let png = "";
@@ -27,6 +33,20 @@ afterAll(async () => {
 });
 
 describe("send --attach parsing", () => {
+  test("quoted positional text decodes escaped newlines", async () => {
+    const parsed = parseArgs(["first\\nsecond", "--channel", "c"], sendSpec);
+    const input = await resolveSendInput(parsed);
+    expect(input?.body).toBe("first\nsecond");
+  });
+
+  test("an escaped backslash keeps a literal \\n sequence", () => {
+    expect(decodePositionalNewlines(String.raw`first\\nsecond`)).toBe(String.raw`first\nsecond`);
+  });
+
+  test("mixed escaped and literal newline sequences preserve intent", () => {
+    expect(decodePositionalNewlines(String.raw`one\ntwo\\nthree\\\nfour`)).toBe("one\ntwo\\nthree\\\nfour");
+  });
+
   test("--attach is repeatable and collected into attachPaths", async () => {
     const parsed = parseArgs(["hello", "--channel", "c", "--attach", "a.png", "--attach", "b.pdf"], sendSpec);
     const input = await resolveSendInput(parsed);


### PR DESCRIPTION
Closes #529

## 根因

`party send "第一行\\n第二行"` 的 positional 参数会把 `\\n` 原样发进消息正文。Web/Markdown 收到的不是换行，所以只能如实显示反斜杠和 `n`。

## 修复

- 仅对 positional 正文解码未转义的 `\\n`
- `\\\\n` 保留为字面量 `\\n`
- stdin (`party send -`) 继续逐字节保留，不做任何猜测
- help 明确三种输入方式

## 验证

- 新增单个、转义、混合奇偶反斜杠三组回归测试
- `bun run check:cli` 通过

旧消息保持不可变；升级 CLI 后新发送的命令行正文生效。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - `party send` 的位置文本参数现支持将 `\n` 转换为换行。
  - 可正确区分转义反斜杠与实际换行，保留用户输入意图。
  - 通过标准输入发送时仍保留原始字节内容，不进行转换。
- **文档**
  - 更新命令帮助信息，说明位置文本与标准输入的换行处理方式。
- **测试**
  - 新增多项用例，覆盖换行、反斜杠及混合转义场景。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->