### PR TITLE
test(web): 覆盖编辑与回复态切换

### DIFF
--- a/web/src/components/Composer.escape.test.tsx
+++ b/web/src/components/Composer.escape.test.tsx
@@ -57,20 +57,23 @@ describe("Composer Escape handling (#357)", () => {
   test("focuses and reveals the composer when reply mode starts", () => {
     const focus = mock(() => undefined);
     const scrollIntoView = mock(() => undefined);
+    const composer = (focusRequest: number | null) => (
+      <LocaleProvider>
+        <Composer
+          draft=""
+          setDraft={() => undefined}
+          onSend={() => undefined}
+          focusRequest={focusRequest}
+          ready
+          candidates={[]}
+          mentionStatuses={[]}
+        />
+      </LocaleProvider>
+    );
 
     act(() => {
       renderer = create(
-        <LocaleProvider>
-          <Composer
-            draft=""
-            setDraft={() => undefined}
-            onSend={() => undefined}
-            focusRequest={3}
-            ready
-            candidates={[]}
-            mentionStatuses={[]}
-          />
-        </LocaleProvider>,
+        composer(null),
         {
           createNodeMock: (element) =>
             element.type === "textarea"
@@ -80,6 +83,11 @@ describe("Composer Escape handling (#357)", () => {
         },
       );
     });
+
+    expect(focus).not.toHaveBeenCalled();
+    expect(scrollIntoView).not.toHaveBeenCalled();
+
+    act(() => renderer!.update(composer(3)));
 
     expect(focus).toHaveBeenCalledWith({ preventScroll: true });
     expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest", inline: "nearest" });

--- a/web/src/components/MessageCard.editing.test.tsx
+++ b/web/src/components/MessageCard.editing.test.tsx
@@ -99,31 +99,34 @@ describe("message edit keyboard shortcuts (#343)", () => {
   test("focuses and reveals the editor when editing starts", () => {
     const focus = mock(() => undefined);
     const scrollIntoView = mock(() => undefined);
+    const card = (editing: boolean) => (
+      <LocaleProvider>
+        <MessageCard
+          msg={baseMsg()}
+          self="planner"
+          quotedMessage={null}
+          canModerate={false}
+          onReply={noop}
+          onEdit={noop}
+          onRetract={noop}
+          canCreateTask={false}
+          onCreateTask={noop}
+          editing={editing}
+          editDraft="changed"
+          editSaving={false}
+          actionError={null}
+          busy={false}
+          onEditDraftChange={noop}
+          onEditCancel={noop}
+          onEditSave={noop}
+        />
+      </LocaleProvider>
+    );
 
     localStorage.setItem("ap_locale", "en");
     act(() => {
       renderer = create(
-        <LocaleProvider>
-          <MessageCard
-            msg={baseMsg()}
-            self="planner"
-            quotedMessage={null}
-            canModerate={false}
-            onReply={noop}
-            onEdit={noop}
-            onRetract={noop}
-            canCreateTask={false}
-            onCreateTask={noop}
-            editing={true}
-            editDraft="changed"
-            editSaving={false}
-            actionError={null}
-            busy={false}
-            onEditDraftChange={noop}
-            onEditCancel={noop}
-            onEditSave={noop}
-          />
-        </LocaleProvider>,
+        card(false),
         {
           createNodeMock: (element) =>
             element.type === "textarea"
@@ -133,6 +136,11 @@ describe("message edit keyboard shortcuts (#343)", () => {
         },
       );
     });
+
+    expect(focus).not.toHaveBeenCalled();
+    expect(scrollIntoView).not.toHaveBeenCalled();
+
+    act(() => renderer!.update(card(true)));
 
     expect(focus).toHaveBeenCalledWith({ preventScroll: true });
     expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest", inline: "nearest" });


### PR DESCRIPTION
## 摘要

补齐 #531 合并后 CodeRabbit 指出的两个有效测试缺口：

- 回复态从 `focusRequest=null` 切换到具体请求时才断言聚焦与滚动
- 编辑态从 `editing=false` 切换到 `true` 时才断言聚焦与滚动

不修改产品代码与视觉样式。

## 验证

- `bun test web/src/components/Composer.escape.test.tsx web/src/components/MessageCard.editing.test.tsx`（10 pass）
- `bun run --cwd web typecheck`
- `git diff --check origin/main...HEAD`

Follow-up to #531.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **测试**
  - 优化回复模式和消息编辑模式的交互测试，分别验证组件在进入对应状态前不会触发聚焦或滚动。
  - 增加状态切换后的验证，确保进入回复或编辑状态时，编辑区域能够正确获得焦点并自动滚动展示。
  - 保留现有键盘快捷操作测试，提升相关交互行为的覆盖准确性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->