### PR TITLE
fix(lark): 保留人类账号资料与身份

### DIFF
--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -1486,6 +1486,10 @@ export class ChannelDO extends Server<Env> {
       connection.close(1008, "channel_full");
       return;
     }
+    // #527：浏览器人类通常不会主动发 status。连接建立时就把 worker 从账号资料解析出的
+    // 权威 identity 落到本 session 的 presence，避免只在断线时由 markOffline 造出一个
+    // 没有 kind/profile 的占位行，进而让 who 把 lark-* 人类猜成 agent。
+    if (state.kind === "human") this.materializeConnectionPresence(state, connection.id, Date.now());
     const loopGuard = state.kind === "agent" ? this.loopGuardMessage(state.name) : this.globalLoopGuardMessage();
     this.sendFrame(connection, {
       type: "welcome",
@@ -1642,6 +1646,9 @@ export class ChannelDO extends Server<Env> {
           role: st.role,
           owner: st.owner,
           handle: st.handle,
+          displayName: st.displayName,
+          avatarUrl: st.avatarUrl,
+          avatarThumb: st.avatarThumb,
           lineage: st.lineage,
           tokenHash: st.tokenHash,
           collabRole: st.collabRole,
@@ -2120,6 +2127,64 @@ export class ChannelDO extends Server<Env> {
     const frame: PresenceFrame = { type: "presence", name, state: "offline", note: null, ts };
     const entry = this.presenceFor(name);
     this.broadcastFrame(entry ? { type: "presence", ...entry } : frame);
+  }
+
+  private materializeConnectionPresence(identity: ConnState, sessionId: string, ts: number) {
+    const previous = this.ctx.storage.sql
+      .exec(
+        `SELECT status_scope_json, status_summary_seq, status_blocked_reason, status_context_json,
+                status_decision_json, status_workflow_json, role, role_source, residency,
+                wake_kind, wake_verified_at, context_json, lineage_json, client_version,
+                paused_at, paused_resume_at
+           FROM presence WHERE name = ? AND session_id != ?
+          ORDER BY updated_at DESC LIMIT 1`,
+        identity.name,
+        sessionId,
+      )
+      .toArray()[0];
+    this.ctx.storage.sql.exec(
+      `INSERT INTO presence (
+         name, session_id, kind, account, handle, display_name, avatar_url, avatar_thumb,
+         state, note, updated_at,
+         status_scope_json, status_summary_seq, status_blocked_reason, status_context_json,
+         status_decision_json, status_workflow_json, role, role_source, residency,
+         wake_kind, wake_verified_at, context_json, lineage_json, client_version,
+         paused_at, paused_resume_at
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'waiting', NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(name, session_id) DO UPDATE SET
+         kind = excluded.kind,
+         account = COALESCE(excluded.account, presence.account),
+         handle = COALESCE(excluded.handle, presence.handle),
+         display_name = COALESCE(excluded.display_name, presence.display_name),
+         avatar_url = COALESCE(excluded.avatar_url, presence.avatar_url),
+         avatar_thumb = COALESCE(excluded.avatar_thumb, presence.avatar_thumb),
+         lineage_json = COALESCE(excluded.lineage_json, presence.lineage_json)`,
+      identity.name,
+      sessionId,
+      identity.kind,
+      identity.owner ?? null,
+      identity.handle ?? null,
+      identity.displayName ?? null,
+      identity.avatarUrl ?? null,
+      identity.avatarThumb ?? null,
+      ts,
+      previous?.status_scope_json ?? null,
+      previous?.status_summary_seq ?? null,
+      previous?.status_blocked_reason ?? null,
+      previous?.status_context_json ?? null,
+      previous?.status_decision_json ?? null,
+      previous?.status_workflow_json ?? null,
+      previous?.role ?? null,
+      previous?.role_source ?? null,
+      previous?.residency ?? null,
+      previous?.wake_kind ?? null,
+      previous?.wake_verified_at ?? null,
+      previous?.context_json ?? null,
+      identity.lineage === undefined ? (previous?.lineage_json ?? null) : JSON.stringify(identity.lineage),
+      previous?.client_version ?? null,
+      previous?.paused_at ?? null,
+      previous?.paused_resume_at ?? null,
+    );
   }
 
   private cleanupPresenceSession(name: string, sessionId: string, ts: number) {

--- a/worker/test/lark-oauth-presence.spec.ts
+++ b/worker/test/lark-oauth-presence.spec.ts
@@ -1,0 +1,113 @@
+import { env, SELF } from "cloudflare:test";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { api, createChannel, seedToken, uniq, WsClient } from "./helpers";
+import { fetchMock } from "./fetch-mock";
+
+const LARK_ORIGIN = "https://open.larksuite.com";
+
+beforeAll(() => {
+  fetchMock.activate();
+  fetchMock.disableNetConnect();
+});
+
+afterEach(() => fetchMock.assertNoPendingInterceptors());
+afterAll(() => fetchMock.deactivate());
+
+describe("Lark OAuth human presence (#527)", () => {
+  it("keeps a no-email Lark profile across first join, reconnect, messages, and a new channel", async () => {
+    const openId = uniq("on_profile");
+    const displayName = "Lark Profile User";
+    const avatarUrl = "https://cdn.example/lark-profile.png";
+    const avatarThumb = "https://cdn.example/lark-profile-thumb.png";
+
+    fetchMock.get(LARK_ORIGIN)
+      .intercept({ path: "/open-apis/authen/v2/oauth/token", method: "POST" })
+      .reply(200, { code: 0, access_token: "oauth-user-token", expires_in: 3600 });
+    fetchMock.get(LARK_ORIGIN)
+      .intercept({ path: "/open-apis/authen/v1/user_info", method: "GET" })
+      .reply(200, {
+        code: 0,
+        data: {
+          open_id: openId,
+          name: displayName,
+          avatar_url: avatarUrl,
+          avatar_thumb: avatarThumb,
+          tenant_key: "tenant-test",
+        },
+      });
+
+    const callback = await SELF.fetch("http://ap.test/api/auth/lark-main/callback", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ code: "oauth-code", redirect_uri: "https://app.example/callback" }),
+    });
+    expect(callback.status).toBe(200);
+    const session = (await callback.json()) as { access_token: string; email: string | null };
+    expect(session.email).toBeNull();
+
+    const profile = await env.DB.prepare(
+      `SELECT account, handle, display_name, avatar_url, avatar_thumb, provider, provider_user_id
+         FROM account_profiles WHERE provider = 'lark-main' AND provider_user_id = ?`,
+    )
+      .bind(openId)
+      .first<Record<string, string>>();
+    expect(profile).toMatchObject({
+      display_name: displayName,
+      avatar_url: avatarUrl,
+      avatar_thumb: avatarThumb,
+      provider: "lark-main",
+      provider_user_id: openId,
+    });
+
+    const expectedPresence = {
+      kind: "human",
+      account: profile!.account,
+      handle: profile!.handle,
+      display_name: displayName,
+      avatar_url: avatarUrl,
+      avatar_thumb: avatarThumb,
+    };
+    const firstSlug = await createChannel(session.access_token);
+    const watcher = await seedToken("agent", uniq("watcher"), { channelScope: firstSlug });
+    const watcherWs = await WsClient.open(firstSlug, watcher.token);
+    await watcherWs.nextOfType("welcome");
+
+    const first = await WsClient.open(firstSlug, session.access_token);
+    const firstWelcome = await first.nextOfType("welcome");
+    expect(firstWelcome.presence).toContainEqual(expect.objectContaining(expectedPresence));
+
+    first.send({ type: "send", kind: "message", body: "profile snapshot", mentions: [], reply_to: null });
+    await first.nextOfType("sent");
+    const sent = await watcherWs.nextOfType("msg");
+    expect(sent.sender).toMatchObject({
+      kind: "human",
+      handle: profile!.handle,
+      display_name: displayName,
+      avatar_url: avatarUrl,
+      avatar_thumb: avatarThumb,
+    });
+
+    first.close();
+    const offline = await watcherWs.nextOfType("presence");
+    expect(offline).toMatchObject({ name: firstWelcome.self, state: "offline", ...expectedPresence });
+
+    const reconnected = await WsClient.open(firstSlug, session.access_token);
+    const reconnectWelcome = await reconnected.nextOfType("welcome");
+    expect(reconnectWelcome.presence).toContainEqual(expect.objectContaining(expectedPresence));
+
+    const secondSlug = await createChannel(session.access_token);
+    const second = await WsClient.open(secondSlug, session.access_token);
+    const secondWelcome = await second.nextOfType("welcome");
+    expect(secondWelcome.presence).toContainEqual(expect.objectContaining(expectedPresence));
+
+    const restPresence = await api(`/api/channels/${secondSlug}/presence`, session.access_token);
+    expect(restPresence.status).toBe(200);
+    expect((await restPresence.json()) as unknown).toMatchObject({
+      presence: [expect.objectContaining(expectedPresence)],
+    });
+
+    second.close();
+    reconnected.close();
+    watcherWs.close();
+  });
+});


### PR DESCRIPTION
## 变更
- Lark 人类 WebSocket 连接建立时立即物化权威账号资料到 presence
- 消息发送者快照保留 display name 与 avatar，断线和重连后继续保持 human 身份
- 新增 Lark OAuth 到频道 presence、消息 sender、断线、重连和跨频道的端到端 Worker 回归测试

## 验证
- Worker 全量：82 files / 539 passed
- Worker TypeScript 通过
- `git diff --check` 通过

Fixes #527

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化人类连接建立时的在线状态同步，减少状态显示不准确的情况。
  * 改善断线重连、离线及新建频道场景下的人员状态一致性。
  * 消息中的发送者信息现包含更完整的显示名称和头像资料。
  * 即使账号没有邮箱，相关身份资料也能在连接状态、消息及状态接口中保持一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->