### PR TITLE
fix(cli): 支持消息正文换行转义

### DIFF
--- a/cli/src/commands/send.ts
+++ b/cli/src/commands/send.ts
@@ -14,6 +14,7 @@ const SEND_FLAGS = ["channel", "reply-to", "mention", "attach", "debug-auth", "r
 const HELP = `usage: party send <text|-> [--channel C] [--mention name]... [--attach path]... [--reply-to seq] [--debug-auth]
 
 Send one message to a channel. Use "-" as the body to read stdin.
+Command-line text decodes \\n as a newline; use \\\\n for a literal \\n, or stdin for exact text.
 
 With --attach, each file is uploaded to the channel first, then the message is sent
 carrying the attachment refs. Body may be empty when at least one --attach is present.
@@ -52,6 +53,30 @@ const CONTENT_TYPE_BY_EXT: Record<string, string> = {
   zip: "application/zip",
   log: "text/plain",
 };
+
+// #529：shell 的普通引号不会把 `\\n` 变成换行，agent/人类用一行 argv 发送多段结论时
+// 因而会把转义符原样写进频道。只处理命令行正文，stdin 保持逐字节语义；双反斜杠作为
+// literal escape，避免用户无法表达真正的 `\\n` 文本。
+export function decodeCommandLineNewlines(input: string): string {
+  let output = "";
+  for (let i = 0; i < input.length; i++) {
+    if (input[i] !== "\\" || i + 1 >= input.length) {
+      output += input[i];
+      continue;
+    }
+    const next = input[i + 1];
+    if (next === "n") {
+      output += "\n";
+      i++;
+    } else if (next === "\\") {
+      output += "\\";
+      i++;
+    } else {
+      output += input[i];
+    }
+  }
+  return output;
+}
 
 function guessContentType(filename: string): string {
   const ext = filename.includes(".") ? filename.slice(filename.lastIndexOf(".") + 1).toLowerCase() : "";
@@ -143,7 +168,7 @@ export async function resolveSendInput(parsed: Parsed): Promise<SendInput | null
   } else if (trailingStdin && positionals.length === 1) {
     readStdin = true; // send -、send --channel C -、send - --
   } else {
-    text = positionals.length > 0 ? positionals.join(" ") : undefined;
+    text = positionals.length > 0 ? decodeCommandLineNewlines(positionals.join(" ")) : undefined;
   }
 
   const channel = resolveChannel(channelArg);

--- a/cli/test/m3.test.ts
+++ b/cli/test/m3.test.ts
@@ -435,6 +435,19 @@ describe("party send", () => {
     });
   });
 
+  test("命令行正文把 \\n 解码为换行，并允许双反斜杠表达字面量", async () => {
+    mock = startRestMock();
+    writeCfg(mock.url);
+    writeWorkspaceState("dev");
+
+    expect((await runCli(["send", "first\\nsecond"])).code).toBe(0);
+    expect((await runCli(["send", "literal\\\\ntext"])).code).toBe(0);
+
+    const sent = reqsOf(mock, "POST", "/api/channels/dev/messages");
+    expect(sent[0]!.body).toMatchObject({ body: "first\nsecond" });
+    expect(sent[1]!.body).toMatchObject({ body: "literal\\ntext" });
+  });
+
   test("--channel 可在绑定 workspace 中显式发送到其他频道", async () => {
     mock = startRestMock();
     writeCfg(mock.url);
@@ -516,6 +529,15 @@ describe("party send", () => {
     expect(r.code).toBe(0);
     const sendReq = reqsOf(mock, "POST", "/api/channels/dev/messages")[0]!;
     expect(sendReq.body).toMatchObject({ body: "hello from stdin\n" });
+  });
+
+  test("send - 保持 stdin 中的字面量 \\n 不变", async () => {
+    mock = startRestMock();
+    writeCfg(mock.url);
+    const r = await runCli(["send", "--channel", "dev", "-"], {}, "first\\nsecond");
+    expect(r.code).toBe(0);
+    const sendReq = reqsOf(mock, "POST", "/api/channels/dev/messages")[0]!;
+    expect(sendReq.body).toMatchObject({ body: "first\\nsecond" });
   });
 
   test("send <slug> - 把首 positional 当 channel 并从 stdin 读正文", async () => {


### PR DESCRIPTION
## 变更
- `party send` 的命令行正文把 `\n` 解码为真实换行
- `\\n` 保留为字面量 `\n`，stdin 继续保持原始文本语义
- 帮助文本说明换行与字面量写法，并补命令行和 stdin 回归测试

## 验证
- CLI 全量：754 passed
- CLI TypeScript 通过
- `git diff --check` 通过

Fixes #529

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * `party send` 命令行正文现支持将 `\n` 解码为换行。
  * 使用 `\\n` 可保留字面量 `\n`。
  * 通过 stdin 输入时保持原始内容，不进行转义解码。

* **文档**
  * 更新命令帮助文案，说明换行符转义规则。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->