### PR TITLE
test(attachments): 补齐匿名下载回退审查用例

### DIFF
--- a/web/src/components/AttachmentList.test.ts
+++ b/web/src/components/AttachmentList.test.ts
@@ -45,4 +45,13 @@ describe("attachment downloads (#521)", () => {
     });
     expect(blobCalls).toEqual([{ token: "token", url: "/attachment" }]);
   });
+
+  test("skips signed URL exchange and uses a blob directly without a token", async () => {
+    expect(await resolveAttachmentDownloadUrl(null, "/attachment")).toEqual({
+      href: "blob:authenticated-fallback",
+      revoke: true,
+    });
+    expect(signedCalls).toEqual([]);
+    expect(blobCalls).toEqual([{ token: null, url: "/attachment" }]);
+  });
 });


### PR DESCRIPTION
## 改动说明
- 匿名附件下载路径显式验证跳过 signed URL 交换
- 验证无 token 时直接走 blob 回退，并检查 href、revoke 与调用参数
- 这是 #528 合并时竞态漏掉的 CodeRabbit 有效审查测试

## 合并前检查
- [x] host 复核 CodeRabbit 意见
- [x] Web 全量 783 passed，TypeScript 与 Vite build 通过
- [x] `git diff --check` 通过

Follow-up to #528.