### PR TITLE
fix(agent): 补齐会话租约与恢复审查修复

### DIFF
--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -1172,7 +1172,7 @@ export function createSdkRunner(opts: SdkRunnerOptions): NonNullable<ServeOption
         harness: "codex-sdk",
         session_id: session.thread_id,
         updated_at: now,
-        ...(session.cwd === undefined ? {} : { cwd: session.cwd }),
+        cwd: session.cwd ?? opts.workdir,
         workdir: opts.workdir,
       });
       // 交付走统一路径：超限正文改走 R2 附件（#109），不再 inline 撞 413。上传失败落进下面的 catch。
@@ -1201,7 +1201,7 @@ export function createSdkRunner(opts: SdkRunnerOptions): NonNullable<ServeOption
           harness: "codex-sdk",
           session_id: session.thread_id,
           updated_at: now,
-          ...(session.cwd === undefined ? {} : { cwd: session.cwd }),
+          cwd: session.cwd ?? opts.workdir,
           workdir: opts.workdir,
         });
       }
@@ -1829,6 +1829,18 @@ export async function runServe(o: ServeOptions): Promise<number> {
   // held=false 转 standby（不跑 runner，且保留未确认 wake），held=true（持租/顶替）恢复并重放。
   let hasLease = true;
   let leaseKnown = false; // 是否至少收到过一次 serve_lease（用于只在真 standby 时打印提示）
+  let pendingPersistedSession: AgentSessionInfo | null = null;
+  let persistedSessionFallback: ReturnType<typeof setTimeout> | null = null;
+  const clearPersistedSessionFallback = () => {
+    if (persistedSessionFallback !== null) clearTimeout(persistedSessionFallback);
+    persistedSessionFallback = null;
+  };
+  const reportPendingPersistedSession = () => {
+    if (pendingPersistedSession === null) return;
+    reportAgentSession(pendingPersistedSession);
+    pendingPersistedSession = null;
+    clearPersistedSessionFallback();
+  };
   // standby 收到的最早可唤醒消息。它以及后续帧都不推进 cursor；接管租约时由 Connection
   // 把已消费但未 ack 的帧按 seq 重排到队首，避免持租者中途退出时静默吞掉在飞 wake（#465）。
   let deferredLeaseSeq: number | null = null;
@@ -1871,8 +1883,17 @@ export async function runServe(o: ServeOptions): Promise<number> {
         // 服务端在同名多条 serve 里选唯一持租者并回 serve_lease。老服务端不认识它、直接忽略（hasLease
         // 默认 true → 旧行为）。重连每次 welcome 都重新 claim（连接换了，租约候选身份也换了）。
         conn.send({ type: "serve_lease", op: "claim" });
-        const persistedSession = persistedAgentSession(o);
-        if (persistedSession !== null) reportAgentSession(persistedSession);
+        // 新服务端先等租约裁决：standby 机器上的旧 wake-session.json 不能覆盖持租者更新的 session。
+        // 老服务端不认识 serve_lease，250ms 内不会回裁决；届时沿用既有默认持租语义并上报。
+        leaseKnown = false;
+        pendingPersistedSession = persistedAgentSession(o);
+        clearPersistedSessionFallback();
+        if (pendingPersistedSession !== null) {
+          persistedSessionFallback = setTimeout(() => {
+            if (!leaseKnown && hasLease) reportPendingPersistedSession();
+          }, 250);
+          if (typeof persistedSessionFallback.unref === "function") persistedSessionFallback.unref();
+        }
         // 连上时若自己已被暂停接待（#180），从 welcome 的 presence 快照里认出来——重连也不误唤醒。
         const mine = frame.presence?.find((p) => p.name === self);
         selfPaused = mine?.paused === true;
@@ -1964,6 +1985,8 @@ export async function runServe(o: ServeOptions): Promise<number> {
           );
         }
         leaseKnown = true;
+        if (hasLease) reportPendingPersistedSession();
+        else clearPersistedSessionFallback();
         continue;
       }
       if (frame.type !== "msg") continue;
@@ -2248,6 +2271,7 @@ export async function runServe(o: ServeOptions): Promise<number> {
     rmSync(contextDir, { recursive: true, force: true });
     lock?.release?.();
     if (heartbeat) clearInterval(heartbeat);
+    clearPersistedSessionFallback();
     conn.close();
     if (o.statusline === true) clearStatuslineListener();
     // 进程真退出了：health.json 不该继续显示 ws_connected=true 骗 watchdog（只清自己写的记录）。

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -1830,16 +1830,10 @@ export async function runServe(o: ServeOptions): Promise<number> {
   let hasLease = true;
   let leaseKnown = false; // 是否至少收到过一次 serve_lease（用于只在真 standby 时打印提示）
   let pendingPersistedSession: AgentSessionInfo | null = null;
-  let persistedSessionFallback: ReturnType<typeof setTimeout> | null = null;
-  const clearPersistedSessionFallback = () => {
-    if (persistedSessionFallback !== null) clearTimeout(persistedSessionFallback);
-    persistedSessionFallback = null;
-  };
   const reportPendingPersistedSession = () => {
     if (pendingPersistedSession === null) return;
     reportAgentSession(pendingPersistedSession);
     pendingPersistedSession = null;
-    clearPersistedSessionFallback();
   };
   // standby 收到的最早可唤醒消息。它以及后续帧都不推进 cursor；接管租约时由 Connection
   // 把已消费但未 ack 的帧按 seq 重排到队首，避免持租者中途退出时静默吞掉在飞 wake（#465）。
@@ -1883,17 +1877,11 @@ export async function runServe(o: ServeOptions): Promise<number> {
         // 服务端在同名多条 serve 里选唯一持租者并回 serve_lease。老服务端不认识它、直接忽略（hasLease
         // 默认 true → 旧行为）。重连每次 welcome 都重新 claim（连接换了，租约候选身份也换了）。
         conn.send({ type: "serve_lease", op: "claim" });
-        // 新服务端先等租约裁决：standby 机器上的旧 wake-session.json 不能覆盖持租者更新的 session。
-        // 老服务端不认识 serve_lease，250ms 内不会回裁决；届时沿用既有默认持租语义并上报。
+        // 必须等服务端明确裁决 held=true：standby 机器上的旧 wake-session.json 不能因为网络抖动
+        // 或裁决稍晚就覆盖持租者更新的 session。老服务端不认识 serve_lease 时仍能照常跑 runner，
+        // 但不会冒险上报无法证明归属的恢复 session。
         leaseKnown = false;
         pendingPersistedSession = persistedAgentSession(o);
-        clearPersistedSessionFallback();
-        if (pendingPersistedSession !== null) {
-          persistedSessionFallback = setTimeout(() => {
-            if (!leaseKnown && hasLease) reportPendingPersistedSession();
-          }, 250);
-          if (typeof persistedSessionFallback.unref === "function") persistedSessionFallback.unref();
-        }
         // 连上时若自己已被暂停接待（#180），从 welcome 的 presence 快照里认出来——重连也不误唤醒。
         const mine = frame.presence?.find((p) => p.name === self);
         selfPaused = mine?.paused === true;
@@ -1986,7 +1974,6 @@ export async function runServe(o: ServeOptions): Promise<number> {
         }
         leaseKnown = true;
         if (hasLease) reportPendingPersistedSession();
-        else clearPersistedSessionFallback();
         continue;
       }
       if (frame.type !== "msg") continue;
@@ -2271,7 +2258,6 @@ export async function runServe(o: ServeOptions): Promise<number> {
     rmSync(contextDir, { recursive: true, force: true });
     lock?.release?.();
     if (heartbeat) clearInterval(heartbeat);
-    clearPersistedSessionFallback();
     conn.close();
     if (o.statusline === true) clearStatuslineListener();
     // 进程真退出了：health.json 不该继续显示 ws_connected=true 骗 watchdog（只清自己写的记录）。

--- a/cli/test/serve-cross-machine-lease.test.ts
+++ b/cli/test/serve-cross-machine-lease.test.ts
@@ -75,8 +75,9 @@ describe("serve 跨机租约客户端互斥（#99）", () => {
       clientFrames.push(frame);
       if (frame.type !== "hello") return;
       sock.send(welcomeFrame(0, "me"));
-      setTimeout(() => sock.send(leaseFrame(false)), 20);
-      setTimeout(() => sock.send({ type: "error", code: "archived", message: "done" }), 320);
+      // 故意晚于旧实现的 250ms 猜测窗口，证明网络慢时也不会先泄漏 standby session。
+      setTimeout(() => sock.send(leaseFrame(false)), 300);
+      setTimeout(() => sock.send({ type: "error", code: "archived", message: "done" }), 360);
     });
 
     await runServe(opts({

--- a/cli/test/serve-cross-machine-lease.test.ts
+++ b/cli/test/serve-cross-machine-lease.test.ts
@@ -4,7 +4,7 @@
 // 从不下发 serve_lease → 客户端默认持租（held 未知即照跑），不回归。
 import { afterEach, describe, expect, test } from "bun:test";
 import type { ClientFrame } from "@agentparty/shared";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { runServe, type ServeOptions } from "../src/commands/serve";
@@ -56,6 +56,37 @@ describe("serve 跨机租约客户端互斥（#99）", () => {
     expect(ran).toBe(0); // 不持租：runner 一次都没跑
     expect(cursors).not.toContain(1); // standby 保留未确认，租约接管后才能重放
     expect(o.lines.some((l) => l.includes("standby") || l.includes("租约"))).toBe(true);
+  });
+
+  test("held=false 不会上报 standby 机器持久化的旧 agent session", async () => {
+    const workdir = mkdtempSync(join(tmpdir(), "ap-standby-session-"));
+    tempDirs.push(workdir);
+    writeFileSync(join(workdir, "wake-session.json"), JSON.stringify({
+      harness: "codex",
+      session_id: "codex-standby-session",
+      created_at: 1000,
+      last_wake_ts: 2000,
+      wakes: 3,
+      cwd: "/workspace/stale",
+      workdir,
+    }));
+    const clientFrames: ClientFrame[] = [];
+    server = startMockServer((frame, sock) => {
+      clientFrames.push(frame);
+      if (frame.type !== "hello") return;
+      sock.send(welcomeFrame(0, "me"));
+      setTimeout(() => sock.send(leaseFrame(false)), 20);
+      setTimeout(() => sock.send({ type: "error", code: "archived", message: "done" }), 320);
+    });
+
+    await runServe(opts({
+      server: server.url,
+      builtinRunner: { server: server.url, token: "ap_tok", channel: "dev", harness: "codex", workdir },
+    }));
+
+    expect(clientFrames.some((frame) =>
+      frame.type === "heartbeat" && frame.agent_session?.session_id === "codex-standby-session"
+    )).toBe(false);
   });
 
   test("held=true（本台持租）：@我 正常唤醒 runner", async () => {

--- a/cli/test/serve.test.ts
+++ b/cli/test/serve.test.ts
@@ -281,7 +281,8 @@ describe("runServe", () => {
       clientFrames.push(frame as unknown as Record<string, unknown>);
       if (frame.type !== "hello") return;
       sock.send(welcomeFrame(0, "me"));
-      setTimeout(() => sock.send({ type: "error", code: "archived", message: "done" }), 350);
+      setTimeout(() => sock.send({ type: "serve_lease", name: "me", held: true }), 20);
+      setTimeout(() => sock.send({ type: "error", code: "archived", message: "done" }), 60);
     });
     const o = opts({
       server: server.url,

--- a/cli/test/serve.test.ts
+++ b/cli/test/serve.test.ts
@@ -281,7 +281,7 @@ describe("runServe", () => {
       clientFrames.push(frame as unknown as Record<string, unknown>);
       if (frame.type !== "hello") return;
       sock.send(welcomeFrame(0, "me"));
-      setTimeout(() => sock.send({ type: "error", code: "archived", message: "done" }), 40);
+      setTimeout(() => sock.send({ type: "error", code: "archived", message: "done" }), 350);
     });
     const o = opts({
       server: server.url,
@@ -1592,6 +1592,28 @@ describe("codex-sdk runner", () => {
       thread_id: "thread_first_12345678",
       wakes: 1,
     });
+  });
+
+  test("session reports fall back to workdir when the SDK does not provide cwd", async () => {
+    const { post } = postRecorder();
+    const workdir = tempDir();
+    const reported: Array<{ cwd?: string; workdir?: string }> = [];
+    const thread: ThreadLike = {
+      id: "thread_cwd_12345678",
+      run: async () => ({ final_response: "ok" }),
+    };
+
+    await sdkRunner({
+      workdir,
+      post,
+      onSession: (session) => reported.push(session),
+      codexFactory: () => ({
+        startThread: () => thread,
+        resumeThread: () => thread,
+      }),
+    })(triggerFrame(101), runnerCtx());
+
+    expect(reported).toContainEqual(expect.objectContaining({ cwd: workdir, workdir }));
   });
 
   test("persists the thread id after the first run when the SDK fills it lazily", async () => {

--- a/web/src/components/AgentDetailModal.test.tsx
+++ b/web/src/components/AgentDetailModal.test.tsx
@@ -130,6 +130,7 @@ describe("AgentDetailModal (#272)", () => {
     expect(text).toContain("已暂停");
     expect(text).toContain("codex");
     expect(text).toContain("019f35d9-0000-7000-8000-000000000522");
+    expect(text).toContain('" · ","now"');
     expect(text).toContain("/workspace/agentparty");
   });
 

--- a/web/src/components/AgentDetailModal.tsx
+++ b/web/src/components/AgentDetailModal.tsx
@@ -175,7 +175,9 @@ export function AgentDetailModal({ name, display, kind, owner, online, presence,
                 <>
                   <div className="agent-detail-fact">
                     <dt>{t("AgentDetailModal.session")}</dt>
-                    <dd className="t-mono">{agentSession.harness}:{agentSession.session_id}</dd>
+                    <dd className="t-mono">
+                      {agentSession.harness}:{agentSession.session_id} · {fmtRel(agentSession.updated_at, now)}
+                    </dd>
                   </div>
                   {agentSession.cwd !== undefined && (
                     <div className="agent-detail-fact">


### PR DESCRIPTION
## 改动说明
- SDK session 未提供 cwd 时回退到 runner workdir，成功与异常路径保持一致
- 持久化 session 只在本机确认持有 serve lease 后上报，standby 不会用旧 wake-session 覆盖当前持租者
- Agent 详情展示 session 的相对更新时间
- 这是 #525 合并时竞态漏掉的 CodeRabbit 有效审查修复

## 合并前检查
- [x] host 逐条复核 CodeRabbit 三项意见
- [x] 新增 held=false 不上报旧 session 的回归测试
- [x] 新增 SDK cwd 回退测试
- [x] CLI 全量 755 passed，TypeScript 通过
- [x] Web 全量 782 passed，TypeScript 与 Vite build 通过
- [x] `git diff --check` 通过

Follow-up to #525.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 会话详情中新增相对更新时间，帮助快速了解会话状态。
  * 会话上报在缺少工作目录信息时，会自动使用配置的工作目录。

* **问题修复**
  * 优化多实例服务的会话上报逻辑，避免备用实例错误覆盖当前会话。
  * 改进服务重启及租约切换期间的会话状态处理，提升稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->