### PR TITLE
fix(web): 恢复设置面板触发器焦点

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -197,9 +197,17 @@ beforeEach(() => {
 });
 
 test("desktop renders one settings entry and keeps desktop controls in the global panel", async () => {
+  const settingsFocus = mock(() => undefined);
   localStorage.setItem("ap_onboarded", "1");
   await act(async () => {
-    renderer = create(<LocaleProvider><App /></LocaleProvider>);
+    renderer = create(<LocaleProvider><App /></LocaleProvider>, {
+      createNodeMock: (element) => {
+        const props = element.props as { className?: string };
+        return element.type === "button" && props.className === "app-settings-btn"
+          ? { focus: settingsFocus, isConnected: true }
+          : {};
+      },
+    });
     await new Promise((resolve) => setTimeout(resolve, 0));
     await new Promise((resolve) => setTimeout(resolve, 0));
   });
@@ -215,6 +223,12 @@ test("desktop renders one settings entry and keeps desktop controls in the globa
 
   expect(root.findByProps({ id: "desktop-settings-panel" })).toBeTruthy();
   expect(root.findByProps({ className: "desktop-agent" })).toBeTruthy();
+
+  await act(async () => root.findByProps({ className: "settings-close" }).props.onClick());
+  expect(root.findAllByProps({ className: "settings-panel" })).toHaveLength(0);
+  expect(settingsFocus).toHaveBeenCalledTimes(1);
+
+  await act(async () => root.findByProps({ className: "app-settings-btn" }).props.onClick());
 
   const onboardingButton = root.findAll((node) =>
     typeof node.props.className === "string" && node.props.className.split(/\s+/).includes("settings-onboarding"),

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -454,6 +454,17 @@ export function App() {
   // banner 关闭态只在本次会话内记，不落盘。
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [handleBannerDismissed, setHandleBannerDismissed] = useState(false);
+  const settingsButtonRef = useRef<HTMLButtonElement | null>(null);
+  const settingsReturnFocusRef = useRef<HTMLButtonElement | null>(null);
+  const openSettings = useCallback((event?: { currentTarget?: HTMLButtonElement }) => {
+    settingsReturnFocusRef.current = event?.currentTarget ?? settingsButtonRef.current;
+    setSettingsOpen(true);
+  }, []);
+  const closeSettings = useCallback(() => {
+    setSettingsOpen(false);
+    const target = settingsReturnFocusRef.current;
+    (target?.isConnected === false ? settingsButtonRef.current : target ?? settingsButtonRef.current)?.focus();
+  }, []);
 
   // oidc 配置存 ref，供 onAuthFailed/续期在稳定回调里读到最新值（避免进 effect 依赖引发重跑）
   const oidcRef = useRef<OidcConfig | null>(null);
@@ -1082,7 +1093,7 @@ export function App() {
           <button
             type="button"
             className="d-btn handlesetup-trigger handlesetup-trigger--cta"
-            onClick={() => setSettingsOpen(true)}
+            onClick={openSettings}
             title={t("App.handle.setCta")}
           >
             <span className="handlesetup-trigger-edit" aria-hidden="true">
@@ -1105,11 +1116,12 @@ export function App() {
         )}
         <DesktopUpdater />
         <button
+          ref={settingsButtonRef}
           type="button"
           className="app-settings-btn"
           aria-label={t("App.settings.title")}
           title={t("App.settings.title")}
-          onClick={() => setSettingsOpen(true)}
+          onClick={openSettings}
         >
           <span className="ap-sprite ap-sprite--settings" aria-hidden="true" />
         </button>
@@ -1118,7 +1130,7 @@ export function App() {
         <SettingsPanel
           me={me}
           canSetHandle={canSetHandle}
-          onClose={() => setSettingsOpen(false)}
+          onClose={closeSettings}
           onLogout={
             isShareMode() || desktopLogoutPending
               ? null
@@ -1142,7 +1154,7 @@ export function App() {
         <p className="banner banner--yellow handle-banner" role="status">
           <span className="handle-banner-text">{t("App.handle.banner")}</span>
           <span className="handle-banner-actions">
-            <button type="button" className="d-btn" onClick={() => setSettingsOpen(true)}>
+            <button type="button" className="d-btn" onClick={openSettings}>
               {t("App.handle.bannerAction")}
             </button>
             <button


### PR DESCRIPTION
## 问题

关闭全局设置面板后，键盘焦点会落到 `body`，键盘用户无法继续原来的操作位置。

## 修复

- 打开设置时记录实际触发按钮
- 关闭后将焦点还给触发按钮
- 若短期提示中的触发器已卸载，则回退到常驻设置按钮
- 登出和重新进入引导流程保持原有关闭行为，不强行抢焦点

## 验证

- `bun run check:web`
- 782 tests passed
- TypeScript `--noEmit` passed
- Vite production build passed

无 CSS 或视觉样式变更，保留 AgentParty 原有纸张、硬边框和印章视觉。