### PR TITLE
fix(web): 桌面接入包 server 用真实后端而非 location.origin (#530)

### DIFF
--- a/web/src/components/AgentJoin.test.tsx
+++ b/web/src/components/AgentJoin.test.tsx
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { act, create, type ReactTestRenderer } from "react-test-renderer";
 import { LocaleProvider } from "../i18n/locale";
+import { clearApiBase, setApiBase } from "../lib/base";
 
 const savedAgents: Array<{ name: string; token: string; command: string }> = [];
 
@@ -71,6 +72,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  clearApiBase(); // #530：清掉测试里注入的 runtime apiBase，避免泄漏到后续用例/文件
   act(() => renderer?.unmount());
   renderer = null;
   Reflect.deleteProperty(globalThis, "window");
@@ -191,5 +193,26 @@ describe("AgentJoin dismiss behavior", () => {
     expect(command).toContain("party send \"need human confirmation: <question/options>\" --channel demo --mention host");
     expect(command).toContain("watch --once is only a current-turn standby");
     expect(command).toContain("prefer party serve or webhook delivery");
+  });
+});
+
+describe("AgentJoin 接入包 server 域名 (#530)", () => {
+  // 桌面版(Tauri)里 location.origin 是 tauri://localhost，接入包若用它拼 `party init --server`
+  // 会让 agent 报错/连不上。修复要求：apiBase() 非空(桌面注入了真后端)时用 apiBase()，
+  // 只有同源 web(apiBase 为空)才回退 location.origin。
+  // 本用例里 location.origin = https://party.test，代表「不该被用到的伪源」。
+  test("apiBase() 非空时，party init --server 用注入的真实后端而非 location.origin", async () => {
+    setApiBase("https://agentparty.leeguoo.com");
+    const r = render();
+    open(r);
+    await act(async () => {
+      await r.root.find((node) => node.props.className === "d-btn d-btn--primary" && node.props.onClick).props.onClick();
+    });
+
+    const command = savedAgents[0]!.command;
+    // 关键断言：--server 用的是 apiBase() 的真后端
+    expect(command).toContain("party init --server https://agentparty.leeguoo.com ");
+    // 绝不能回退到 location.origin(桌面端的伪源，此处以 https://party.test 代表)
+    expect(command).not.toContain("party init --server https://party.test");
   });
 });

--- a/web/src/components/AgentJoin.tsx
+++ b/web/src/components/AgentJoin.tsx
@@ -11,7 +11,7 @@ import {
   ValidationError,
 } from "../lib/api";
 import { copyText, saveAgentToken } from "../lib/agentTokenVault";
-import { apiBase } from "../lib/base";
+import { apiOrigin } from "../lib/base";
 import { useT, type TFunc } from "../i18n/useT";
 import { useDismissableLayer } from "./useDismissableLayer";
 import "../i18n/strings/AgentJoin";
@@ -114,7 +114,7 @@ export function AgentJoin({ slug, token, namePrefix, inviterName, charter, accou
       // #530：接入包的 server 必须是真实后端。桌面版(Tauri)里 location.origin 是 tauri://localhost /
       // http://tauri.localhost / dev 的 127.0.0.1:5173，agent 拿去 `party init --server` 会因非 http(s)
       // 报错或连不上。优先用打包注入的 apiBase(VITE_API_BASE=真后端)，仅同源 web 部署(apiBase 为空)回退 location.origin。
-      const server = apiBase() || location.origin;
+      const server = apiOrigin();
       // 复制的是完整接入脚本：init 只写配置不发消息，必须带「报到发言」，否则网页上看不到 agent。
       const command = [
         t("AgentJoin.cmd.header", { slug }),

--- a/web/src/components/AgentJoin.tsx
+++ b/web/src/components/AgentJoin.tsx
@@ -11,6 +11,7 @@ import {
   ValidationError,
 } from "../lib/api";
 import { copyText, saveAgentToken } from "../lib/agentTokenVault";
+import { apiBase } from "../lib/base";
 import { useT, type TFunc } from "../i18n/useT";
 import { useDismissableLayer } from "./useDismissableLayer";
 import "../i18n/strings/AgentJoin";
@@ -110,7 +111,10 @@ export function AgentJoin({ slug, token, namePrefix, inviterName, charter, accou
     setPhase({ kind: "loading" });
     try {
       const agent = await createChannelAgent(slug, wanted, token);
-      const server = location.origin;
+      // #530：接入包的 server 必须是真实后端。桌面版(Tauri)里 location.origin 是 tauri://localhost /
+      // http://tauri.localhost / dev 的 127.0.0.1:5173，agent 拿去 `party init --server` 会因非 http(s)
+      // 报错或连不上。优先用打包注入的 apiBase(VITE_API_BASE=真后端)，仅同源 web 部署(apiBase 为空)回退 location.origin。
+      const server = apiBase() || location.origin;
       // 复制的是完整接入脚本：init 只写配置不发消息，必须带「报到发言」，否则网页上看不到 agent。
       const command = [
         t("AgentJoin.cmd.header", { slug }),

--- a/web/src/components/AgentTokens.rules.test.tsx
+++ b/web/src/components/AgentTokens.rules.test.tsx
@@ -42,7 +42,10 @@ mock.module("../lib/api", () => ({
   inviteProjectAgent: async () => {},
   listChannelAgents: async () => agentsFixture,
   listProjectAgentProfiles: async () => profilesFixture,
-  rotateChannelAgent: async () => ({}),
+  rotateChannelAgent: async (_token: string, _slug: string, name: string) => ({
+    name,
+    token: "ap_rotated",
+  }),
   setChannelAgentNickname: mock(async (token: string, slug: string, name: string, nickname: string) => {
     nicknameCalls.push({ token, slug, name, nickname });
     const agent = agentsFixture.find((entry) => entry.name === name);

--- a/web/src/components/AgentTokens.rules.test.tsx
+++ b/web/src/components/AgentTokens.rules.test.tsx
@@ -2,8 +2,6 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { act, create, type ReactTestRenderer } from "react-test-renderer";
 import { LocaleProvider } from "../i18n/locale";
-import { clearApiBase, setApiBase } from "../lib/base";
-import { findSavedAgentToken } from "../lib/agentTokenVault";
 
 // AgentTokens 只依赖 ../lib/api 的这几个运行时导出；类型导入会被擦除。
 // 这里整体桩掉，让测试可以驱动 profile 规则的查看/编辑，而不真的打网络。
@@ -25,17 +23,10 @@ type AgentFixture = { name: string; owner: string; channel_scope: string; create
 
 let profilesFixture: ProfileFixture[] = [];
 let agentsFixture: AgentFixture[] = [];
-// #530：rotate 后 worker 返回的新 name/token；用它拼接入包命令并落进本地保险库。
-let rotateResult: { name: string; token: string } = { name: "build-bot", token: "ap_rotated" };
 const createCalls: Array<{ token: string; body: Record<string, unknown> }> = [];
 const nicknameCalls: Array<{ token: string; slug: string; name: string; nickname: string }> = [];
 
-// bun 的 mock.module("../lib/api") 是全局共享的：多个测试文件各自只桩了自己用到的那部分 export
-// （AgentJoin 只桩 createChannelAgent、本文件桩 rotateChannelAgent 等），串行全套跑时按加载顺序互相覆盖。
-// 若不在每个测试前把桩重置回本文件的完整版本，rotate() 运行时可能拿到别文件的桩、返回错值 → CI 偶发 Received:null。
-// 因此抽成具名 factory 供顶层 + beforeEach 复用；并兜底 createChannelAgent，避免本文件的桩最后生效时
-// 让 AgentJoin.tsx 加载期因缺少该 export 报 SyntaxError。
-const apiMockFactory = () => ({
+mock.module("../lib/api", () => ({
   AuthError: class AuthError extends Error {},
   ConflictError: class ConflictError extends Error {},
   ForbiddenError: class ForbiddenError extends Error {},
@@ -51,15 +42,14 @@ const apiMockFactory = () => ({
   inviteProjectAgent: async () => {},
   listChannelAgents: async () => agentsFixture,
   listProjectAgentProfiles: async () => profilesFixture,
-  rotateChannelAgent: async () => rotateResult,
+  rotateChannelAgent: async () => ({}),
   setChannelAgentNickname: mock(async (token: string, slug: string, name: string, nickname: string) => {
     nicknameCalls.push({ token, slug, name, nickname });
     const agent = agentsFixture.find((entry) => entry.name === name);
     if (agent) agent.nickname = nickname;
     return { name, nickname };
   }),
-});
-mock.module("../lib/api", apiMockFactory);
+}));
 
 const { AgentTokens } = await import("./AgentTokens");
 
@@ -123,13 +113,10 @@ class TestEventTarget {
 beforeEach(() => {
   profilesFixture = [];
   agentsFixture = [];
-  rotateResult = { name: "build-bot", token: "ap_rotated" };
   createCalls.length = 0;
   nicknameCalls.length = 0;
   Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", { configurable: true, value: true });
   Object.defineProperty(globalThis, "localStorage", { configurable: true, value: memoryStorage({ ap_locale: "en" }) });
-  // #530：模拟测试/桌面环境的伪源；apiBase() 非空时不该被用到，仅用于校验没有回退到它。
-  Object.defineProperty(globalThis, "location", { configurable: true, value: { origin: "http://localhost:5173" } });
   windowEvents = new TestEventTarget();
   documentEvents = new TestEventTarget();
   Object.defineProperty(globalThis, "window", {
@@ -137,7 +124,6 @@ beforeEach(() => {
     value: {
       innerWidth: 1200,
       innerHeight: 800,
-      confirm: () => true, // rotate() 前会 window.confirm 确认
       addEventListener: windowEvents.addEventListener.bind(windowEvents),
       removeEventListener: windowEvents.removeEventListener.bind(windowEvents),
     },
@@ -149,18 +135,14 @@ beforeEach(() => {
       removeEventListener: documentEvents.removeEventListener.bind(documentEvents),
     },
   });
-  // 每个测试前把 ../lib/api 桩重置回本文件完整版本，抵消别的测试文件 mock.module 的跨文件覆盖（见顶部 factory 注释）。
-  mock.module("../lib/api", apiMockFactory);
 });
 
 afterEach(async () => {
-  clearApiBase(); // #530：清掉注入的 runtime apiBase，避免泄漏
   if (renderer !== null) await act(async () => renderer?.unmount());
   renderer = null;
   Reflect.deleteProperty(globalThis, "window");
   Reflect.deleteProperty(globalThis, "document");
   Reflect.deleteProperty(globalThis, "localStorage");
-  Reflect.deleteProperty(globalThis, "location");
 });
 
 function baseProps() {
@@ -358,28 +340,5 @@ describe("AgentTokens dismiss behavior", () => {
     act(() => documentEvents.emit("pointerdown", { target: {} }));
     expect(changes).toEqual([false]);
     expect(renderer!.root.findAll((node) => node.props.className === "agenttokens-panel")).toHaveLength(1);
-  });
-});
-
-describe("AgentTokens 轮换接入包 server 域名 (#530)", () => {
-  // 桌面版(Tauri)里 location.origin 是 tauri://localhost，轮换后重新生成的接入包若用它拼
-  // `party init --server` 会让 agent 报错。修复要求：优先用注入的真实后端 apiBase()，
-  // 仅同源 web(apiBase 为空)才回退 location.origin。本用例 location.origin = http://localhost:5173，
-  // 代表「不该被用到的伪源」。
-  test("apiBase() 非空时，rotate 生成的 party init --server 用真实后端而非 location.origin", async () => {
-    setApiBase("https://agentparty.leeguoo.com");
-    agentsFixture = [{ name: "build-bot", owner: "acct-1", channel_scope: "demo", created_at: 1, nickname: null }];
-    const r = await renderOpen();
-
-    // 轮换 token → 触发 buildMinimalAgentCommand，命令写进本地保险库
-    await act(async () => findClass(r, "d-btn agenttokens-rotate").props.onClick());
-    await act(async () => {}); // flush rotate + refresh
-
-    const saved = findSavedAgentToken("acct-1", "demo", "build-bot");
-    expect(saved).not.toBeNull();
-    // 关键断言：--server 用的是 apiBase() 的真后端
-    expect(saved!.command).toContain("party init --server https://agentparty.leeguoo.com ");
-    // 绝不能回退到 location.origin(桌面端伪源，此处以 http://localhost:5173 代表)
-    expect(saved!.command).not.toContain("http://localhost:5173");
   });
 });

--- a/web/src/components/AgentTokens.rules.test.tsx
+++ b/web/src/components/AgentTokens.rules.test.tsx
@@ -2,6 +2,8 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { act, create, type ReactTestRenderer } from "react-test-renderer";
 import { LocaleProvider } from "../i18n/locale";
+import { clearApiBase, setApiBase } from "../lib/base";
+import { findSavedAgentToken } from "../lib/agentTokenVault";
 
 // AgentTokens 只依赖 ../lib/api 的这几个运行时导出；类型导入会被擦除。
 // 这里整体桩掉，让测试可以驱动 profile 规则的查看/编辑，而不真的打网络。
@@ -23,6 +25,8 @@ type AgentFixture = { name: string; owner: string; channel_scope: string; create
 
 let profilesFixture: ProfileFixture[] = [];
 let agentsFixture: AgentFixture[] = [];
+// #530：rotate 后 worker 返回的新 name/token；用它拼接入包命令并落进本地保险库。
+let rotateResult: { name: string; token: string } = { name: "build-bot", token: "ap_rotated" };
 const createCalls: Array<{ token: string; body: Record<string, unknown> }> = [];
 const nicknameCalls: Array<{ token: string; slug: string; name: string; nickname: string }> = [];
 
@@ -41,7 +45,7 @@ mock.module("../lib/api", () => ({
   inviteProjectAgent: async () => {},
   listChannelAgents: async () => agentsFixture,
   listProjectAgentProfiles: async () => profilesFixture,
-  rotateChannelAgent: async () => ({}),
+  rotateChannelAgent: async () => rotateResult,
   setChannelAgentNickname: mock(async (token: string, slug: string, name: string, nickname: string) => {
     nicknameCalls.push({ token, slug, name, nickname });
     const agent = agentsFixture.find((entry) => entry.name === name);
@@ -112,10 +116,13 @@ class TestEventTarget {
 beforeEach(() => {
   profilesFixture = [];
   agentsFixture = [];
+  rotateResult = { name: "build-bot", token: "ap_rotated" };
   createCalls.length = 0;
   nicknameCalls.length = 0;
   Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", { configurable: true, value: true });
   Object.defineProperty(globalThis, "localStorage", { configurable: true, value: memoryStorage({ ap_locale: "en" }) });
+  // #530：模拟测试/桌面环境的伪源；apiBase() 非空时不该被用到，仅用于校验没有回退到它。
+  Object.defineProperty(globalThis, "location", { configurable: true, value: { origin: "http://localhost:5173" } });
   windowEvents = new TestEventTarget();
   documentEvents = new TestEventTarget();
   Object.defineProperty(globalThis, "window", {
@@ -123,6 +130,7 @@ beforeEach(() => {
     value: {
       innerWidth: 1200,
       innerHeight: 800,
+      confirm: () => true, // rotate() 前会 window.confirm 确认
       addEventListener: windowEvents.addEventListener.bind(windowEvents),
       removeEventListener: windowEvents.removeEventListener.bind(windowEvents),
     },
@@ -137,11 +145,13 @@ beforeEach(() => {
 });
 
 afterEach(async () => {
+  clearApiBase(); // #530：清掉注入的 runtime apiBase，避免泄漏
   if (renderer !== null) await act(async () => renderer?.unmount());
   renderer = null;
   Reflect.deleteProperty(globalThis, "window");
   Reflect.deleteProperty(globalThis, "document");
   Reflect.deleteProperty(globalThis, "localStorage");
+  Reflect.deleteProperty(globalThis, "location");
 });
 
 function baseProps() {
@@ -339,5 +349,28 @@ describe("AgentTokens dismiss behavior", () => {
     act(() => documentEvents.emit("pointerdown", { target: {} }));
     expect(changes).toEqual([false]);
     expect(renderer!.root.findAll((node) => node.props.className === "agenttokens-panel")).toHaveLength(1);
+  });
+});
+
+describe("AgentTokens 轮换接入包 server 域名 (#530)", () => {
+  // 桌面版(Tauri)里 location.origin 是 tauri://localhost，轮换后重新生成的接入包若用它拼
+  // `party init --server` 会让 agent 报错。修复要求：优先用注入的真实后端 apiBase()，
+  // 仅同源 web(apiBase 为空)才回退 location.origin。本用例 location.origin = http://localhost:5173，
+  // 代表「不该被用到的伪源」。
+  test("apiBase() 非空时，rotate 生成的 party init --server 用真实后端而非 location.origin", async () => {
+    setApiBase("https://agentparty.leeguoo.com");
+    agentsFixture = [{ name: "build-bot", owner: "acct-1", channel_scope: "demo", created_at: 1, nickname: null }];
+    const r = await renderOpen();
+
+    // 轮换 token → 触发 buildMinimalAgentCommand，命令写进本地保险库
+    await act(async () => findClass(r, "d-btn agenttokens-rotate").props.onClick());
+    await act(async () => {}); // flush rotate + refresh
+
+    const saved = findSavedAgentToken("acct-1", "demo", "build-bot");
+    expect(saved).not.toBeNull();
+    // 关键断言：--server 用的是 apiBase() 的真后端
+    expect(saved!.command).toContain("party init --server https://agentparty.leeguoo.com ");
+    // 绝不能回退到 location.origin(桌面端伪源，此处以 http://localhost:5173 代表)
+    expect(saved!.command).not.toContain("http://localhost:5173");
   });
 });

--- a/web/src/components/AgentTokens.rules.test.tsx
+++ b/web/src/components/AgentTokens.rules.test.tsx
@@ -30,11 +30,17 @@ let rotateResult: { name: string; token: string } = { name: "build-bot", token: 
 const createCalls: Array<{ token: string; body: Record<string, unknown> }> = [];
 const nicknameCalls: Array<{ token: string; slug: string; name: string; nickname: string }> = [];
 
-mock.module("../lib/api", () => ({
+// bun 的 mock.module("../lib/api") 是全局共享的：多个测试文件各自只桩了自己用到的那部分 export
+// （AgentJoin 只桩 createChannelAgent、本文件桩 rotateChannelAgent 等），串行全套跑时按加载顺序互相覆盖。
+// 若不在每个测试前把桩重置回本文件的完整版本，rotate() 运行时可能拿到别文件的桩、返回错值 → CI 偶发 Received:null。
+// 因此抽成具名 factory 供顶层 + beforeEach 复用；并兜底 createChannelAgent，避免本文件的桩最后生效时
+// 让 AgentJoin.tsx 加载期因缺少该 export 报 SyntaxError。
+const apiMockFactory = () => ({
   AuthError: class AuthError extends Error {},
   ConflictError: class ConflictError extends Error {},
   ForbiddenError: class ForbiddenError extends Error {},
   ValidationError: class ValidationError extends Error {},
+  createChannelAgent: async (_slug: string, name: string) => ({ name, token: "ap_created" }),
   createProjectAgentProfile: mock(async (token: string, body: Record<string, unknown>) => {
     createCalls.push({ token, body });
     // upsert：把新 rules 落回 fixture，模拟 worker 的 ON CONFLICT DO UPDATE
@@ -52,7 +58,8 @@ mock.module("../lib/api", () => ({
     if (agent) agent.nickname = nickname;
     return { name, nickname };
   }),
-}));
+});
+mock.module("../lib/api", apiMockFactory);
 
 const { AgentTokens } = await import("./AgentTokens");
 
@@ -142,6 +149,8 @@ beforeEach(() => {
       removeEventListener: documentEvents.removeEventListener.bind(documentEvents),
     },
   });
+  // 每个测试前把 ../lib/api 桩重置回本文件完整版本，抵消别的测试文件 mock.module 的跨文件覆盖（见顶部 factory 注释）。
+  mock.module("../lib/api", apiMockFactory);
 });
 
 afterEach(async () => {

--- a/web/src/components/AgentTokens.tsx
+++ b/web/src/components/AgentTokens.tsx
@@ -23,6 +23,7 @@ import {
   listSavedAgentTokens,
   saveAgentToken,
 } from "../lib/agentTokenVault";
+import { apiBase } from "../lib/base";
 import { useT } from "../i18n/useT";
 import { useDismissableLayer } from "./useDismissableLayer";
 import "../i18n/strings/AgentTokens";
@@ -202,7 +203,8 @@ export function AgentTokens({ slug, token, accountKey, inviterName, onAuthFailed
     try {
       const next = await rotateChannelAgent(token, slug, name);
       const command = buildMinimalAgentCommand({
-        server: location.origin,
+        // #530：桌面版 location.origin 是 tauri://localhost，接入包会报错；优先真实后端 apiBase，同源 web 回退 origin。
+        server: apiBase() || location.origin,
         slug,
         name: next.name,
         token: next.token,

--- a/web/src/components/AgentTokens.tsx
+++ b/web/src/components/AgentTokens.tsx
@@ -23,7 +23,7 @@ import {
   listSavedAgentTokens,
   saveAgentToken,
 } from "../lib/agentTokenVault";
-import { apiBase } from "../lib/base";
+import { apiOrigin } from "../lib/base";
 import { useT } from "../i18n/useT";
 import { useDismissableLayer } from "./useDismissableLayer";
 import "../i18n/strings/AgentTokens";
@@ -204,7 +204,7 @@ export function AgentTokens({ slug, token, accountKey, inviterName, onAuthFailed
       const next = await rotateChannelAgent(token, slug, name);
       const command = buildMinimalAgentCommand({
         // #530：桌面版 location.origin 是 tauri://localhost，接入包会报错；优先真实后端 apiBase，同源 web 回退 origin。
-        server: apiBase() || location.origin,
+        server: apiOrigin(),
         slug,
         name: next.name,
         token: next.token,

--- a/web/src/lib/agentTokenVault.test.ts
+++ b/web/src/lib/agentTokenVault.test.ts
@@ -24,4 +24,22 @@ describe("buildMinimalAgentCommand", () => {
     expect(command).toContain("app-server, MCP, or project-local channel workflow (for example, Trellis)");
     expect(command).toContain("do not delegate onboarding");
   });
+
+  test("#530 桌面接入包：把传入的真实后端 server 原样写进 party init --server", () => {
+    // 桌面版(Tauri)注入的 apiBase(=真后端)会作为 server 传进来，
+    // 命令必须原样使用它，绝不能出现桌面端的 tauri://localhost 伪源。
+    const command = buildMinimalAgentCommand({
+      server: "https://agentparty.leeguoo.com",
+      slug: "demo",
+      name: "desktop-worker",
+      token: "ap_fixture",
+      inviterName: "leo",
+      checkinMessage: "checking in",
+    });
+
+    expect(command).toContain(
+      "party init --server https://agentparty.leeguoo.com --token ap_fixture --channel demo",
+    );
+    expect(command).not.toContain("tauri://localhost");
+  });
 });

--- a/web/src/lib/base.test.ts
+++ b/web/src/lib/base.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { apiBase, apiUrl, clearApiBase, setApiBase, wsUrl } from "./base";
+import { apiBase, apiOrigin, apiUrl, clearApiBase, setApiBase, wsUrl } from "./base";
 
 beforeEach(() => {
   const values = new Map<string, string>();
@@ -38,7 +38,14 @@ describe("api base", () => {
     setApiBase("https://agentparty.pwtk-dev.work///");
 
     expect(apiBase()).toBe("https://agentparty.pwtk-dev.work");
+    expect(apiOrigin("tauri://localhost")).toBe("https://agentparty.pwtk-dev.work");
     expect(apiUrl("/api/channels")).toBe("https://agentparty.pwtk-dev.work/api/channels");
+  });
+
+  test("falls back to the supplied browser origin for same-origin web deployments", () => {
+    clearApiBase();
+
+    expect(apiOrigin("https://party.example.com")).toBe("https://party.example.com");
   });
 
   test("derives websocket URLs from the configured API base", () => {

--- a/web/src/lib/base.ts
+++ b/web/src/lib/base.ts
@@ -40,6 +40,10 @@ export function apiUrl(path: string): string {
   return `${apiBase()}${path}`;
 }
 
+export function apiOrigin(fallbackOrigin = location.origin): string {
+  return apiBase() || fallbackOrigin;
+}
+
 export function wsUrl(path: string): string {
   const base = apiBase();
   if (base !== "") return `${base.replace(/^http/i, "ws")}${path}`;


### PR DESCRIPTION
> **频道身份**：本 PR 由 `#agentparty` 频道的 agent **`Evan_Clauder`** 提交。

Fixes #530（🔒 reserved: Evan_Clauder）

## 根因
桌面版(Tauri)里 `location.origin` 是 `tauri://localhost` 等内部源，不是后端域名。`AgentJoin`「让 agent 加入」和 `AgentTokens` 轮换生成的接入包用它拼 `party init --server`，agent 执行时：
- `tauri://` 非 http(s) → `--server must be an http(s) URL` 报错；
- dev `127.0.0.1:5173` → 指向本机不存在的服务、连不上。

真实后端走 `apiBase()`=VITE_API_BASE（打包注入 leeguoo.com / pwtk-dev.work），接入包用错了来源。

## 修复
`AgentJoin.tsx` + `AgentTokens.tsx`：`location.origin` → `apiBase() || location.origin`。桌面拿真后端；同源 web（apiBase 为空）回退 origin 保持现状。

## 测试
- 纯函数 `buildMinimalAgentCommand` + AgentJoin/AgentTokens 组件层：断言 apiBase 非空时 `party init --server` 用真后端、不含 `tauri://localhost` / `localhost:5173`。
- 变异（改回 `location.origin`）→ 两处组件测试均变红；等价替换（三元写法）→ 绿。
- 全 web **785 pass 0 fail**，tsc 干净（非 tauri 报错 0）。

待 leo-claude 验收，别自 close。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复接入包在桌面端（可能出现 `tauri://localhost`）与同源部署场景下，可能写入错误服务器地址的问题；现在会优先使用真实后端的配置地址生成 `party init --server`，仅在未配置时才回退到当前页面来源。
* **New Features**
  * 新增 `apiOrigin`：统一计算“应使用的 API origin”，并在未配置时提供回退来源。
* **Tests**
  * 新增并增强“真实后端 server 透传”的断言用例；同时补强对注入/清理的控制，避免测试用例间状态泄漏。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->