### PR TITLE
fix(desktop): owner 恢复登录后仍处于围观模式

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { act, create, type ReactTestRenderer } from "react-test-renderer";
 import { LocaleProvider } from "./i18n/locale";
 import { apiBase, clearApiBase } from "./lib/base";
+import { applyShareToken, clearShareToken, currentShareToken, isShareMode } from "./lib/api";
 import {
   __resetDesktopRuntimeForTests,
   __setDesktopRuntimeDependenciesForTests,
@@ -49,6 +50,16 @@ let notificationActionHandler: ((notification: { extra?: Record<string, unknown>
 let desktopFocusCalls: string[] = [];
 let pushedPaths: string[] = [];
 let desktopWindowShownHandler: (() => void) | null = null;
+
+async function waitForCondition(condition: () => boolean, description: string, timeoutMs = 1_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!condition()) {
+    if (Date.now() >= deadline) throw new Error(`Timed out waiting for ${description}`);
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  }
+}
 
 beforeEach(() => {
   Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", { configurable: true, value: true });
@@ -245,6 +256,7 @@ afterEach(async () => {
   renderer = null;
   __resetDesktopRuntimeForTests();
   clearApiBase();
+  clearShareToken();
   for (const key of [
     "IS_REACT_ACT_ENVIRONMENT",
     "__TAURI_INTERNALS__",
@@ -260,6 +272,23 @@ afterEach(async () => {
 });
 
 describe("App desktop server pairing behavior", () => {
+  test("a restored human session clears a stale desktop watch credential", async () => {
+    applyShareToken("stale-watch-token");
+    expect(isShareMode()).toBe(true);
+
+    act(() => {
+      renderer = create(<LocaleProvider><App /></LocaleProvider>);
+    });
+    await waitForCondition(
+      () => !isShareMode() && (renderer?.root.findAllByProps({ className: "app-settings-btn" }).length ?? 0) === 1,
+      "the restored human desktop session",
+    );
+
+    expect(isShareMode()).toBe(false);
+    expect(currentShareToken()).toBeNull();
+    expect(renderer!.root.findByProps({ className: "app-settings-btn" })).toBeTruthy();
+  });
+
   test("hidden desktop startup defers Keychain restore until the main window is shown", async () => {
     let credentialReads = 0;
     invokeHandler = async (command, args) => {

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -324,6 +324,7 @@ describe("App desktop server pairing behavior", () => {
 
     expect(isShareMode()).toBe(true);
     expect(currentShareToken()).toBe("stale-watch-token");
+    expect(renderer!.root.findAllByProps({ className: "app-settings-btn" })).toHaveLength(0);
   });
 
   test("hidden desktop startup defers Keychain restore until the main window is shown", async () => {

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -273,6 +273,16 @@ afterEach(async () => {
 
 describe("App desktop server pairing behavior", () => {
   test("a restored human session clears a stale desktop watch credential", async () => {
+    const requests: Array<{ url: string; authorization: string | null }> = [];
+    const fetchBeforeRestore = globalThis.fetch;
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: async (input: string | URL | Request, init?: RequestInit) => {
+        const headers = new Headers(input instanceof Request ? input.headers : init?.headers);
+        requests.push({ url: String(input), authorization: headers.get("authorization") });
+        return fetchBeforeRestore(input, init);
+      },
+    });
     applyShareToken("stale-watch-token");
     expect(isShareMode()).toBe(true);
 
@@ -286,7 +296,34 @@ describe("App desktop server pairing behavior", () => {
 
     expect(isShareMode()).toBe(false);
     expect(currentShareToken()).toBeNull();
+    expect(requests).toContainEqual({
+      url: `${activeOrigin}/api/channels`,
+      authorization: "Bearer old-access",
+    });
+    expect(requests.some((request) => request.url.includes("stale-watch-token"))).toBe(false);
     expect(renderer!.root.findByProps({ className: "app-settings-btn" })).toBeTruthy();
+  });
+
+  test("a missing restored human credential preserves an active watch session", async () => {
+    storedCredential = null;
+    let credentialReads = 0;
+    const invokeBeforeMissingCredential = invokeHandler;
+    invokeHandler = async (command, args) => {
+      if (command === "desktop_credential_read") credentialReads += 1;
+      return invokeBeforeMissingCredential(command, args);
+    };
+    applyShareToken("stale-watch-token");
+
+    act(() => {
+      renderer = create(<LocaleProvider><App /></LocaleProvider>);
+    });
+    await waitForCondition(
+      () => credentialReads === 1,
+      "the desktop restore without a credential",
+    );
+
+    expect(isShareMode()).toBe(true);
+    expect(currentShareToken()).toBe("stale-watch-token");
   });
 
   test("hidden desktop startup defers Keychain restore until the main window is shown", async () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -148,7 +148,7 @@ export function App() {
   // restore is an explicit return to the signed-in human session. Clear both the in-memory and
   // sessionStorage share markers before installing that credential, otherwise ChannelSocket sends
   // the human token through the readonly query-token path while the rest of the app treats it as owner.
-  const activateDesktopHumanSession = useCallback((accessToken: string | null) => {
+  const activateDesktopHumanSession = useCallback((accessToken: string) => {
     clearShareToken();
     setToken(accessToken);
   }, []);
@@ -221,7 +221,7 @@ export function App() {
     setDesktopNotice(null);
     return restoreDesktopAccess(desktopCredentialVaultForOrigin(activeOrigin), activeOrigin)
       .then((accessToken) => {
-        activateDesktopHumanSession(accessToken);
+        if (accessToken !== null) activateDesktopHumanSession(accessToken);
         setDesktopRestoreFailure("retryable");
         setDesktopBoot("ready");
         return accessToken;
@@ -239,7 +239,7 @@ export function App() {
     setDesktopNotice(null);
     return restoreDesktopAccessInteractive(desktopCredentialVaultForOrigin(activeOrigin), activeOrigin)
       .then((accessToken) => {
-        activateDesktopHumanSession(accessToken);
+        if (accessToken !== null) activateDesktopHumanSession(accessToken);
         setDesktopRestoreFailure("retryable");
         setDesktopBoot("ready");
         return accessToken;
@@ -444,7 +444,7 @@ export function App() {
       return await restoreDesktopAccess(desktopCredentialVaultForOrigin(startupOrigin), startupOrigin);
     })().then((accessToken) => {
         if (!alive) return;
-        activateDesktopHumanSession(accessToken);
+        if (accessToken !== null) activateDesktopHumanSession(accessToken);
         setDesktopRestoreFailure("retryable");
         setDesktopBoot("ready");
       })

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -144,6 +144,14 @@ export function App() {
   });
   const [serverPairingFlow, setServerPairingFlow] = useState(() => initialDesktopServerPairingFlow(activeOrigin));
   const [token, setToken] = useState<string | null>(() => initialTokenForRuntime(desktop, getToken));
+  // A desktop watch invite deliberately enters share mode, but every successful Keychain/pairing
+  // restore is an explicit return to the signed-in human session. Clear both the in-memory and
+  // sessionStorage share markers before installing that credential, otherwise ChannelSocket sends
+  // the human token through the readonly query-token path while the rest of the app treats it as owner.
+  const activateDesktopHumanSession = useCallback((accessToken: string | null) => {
+    clearShareToken();
+    setToken(accessToken);
+  }, []);
   // 本标签当前身份（access token 的 sub）。共享 localStorage 里的 session 是否可用，
   // 必须与它比对——只比 token 字符串没用：同身份续期后 access token 本来就会变。
   const identityRef = useRef<string | null>(null);
@@ -213,7 +221,7 @@ export function App() {
     setDesktopNotice(null);
     return restoreDesktopAccess(desktopCredentialVaultForOrigin(activeOrigin), activeOrigin)
       .then((accessToken) => {
-        setToken(accessToken);
+        activateDesktopHumanSession(accessToken);
         setDesktopRestoreFailure("retryable");
         setDesktopBoot("ready");
         return accessToken;
@@ -224,14 +232,14 @@ export function App() {
         setDesktopBoot("error");
         throw cause;
       });
-  }, [activeOrigin]);
+  }, [activeOrigin, activateDesktopHumanSession]);
 
   const restoreDesktopInteractive = useCallback(() => {
     setDesktopBoot("loading");
     setDesktopNotice(null);
     return restoreDesktopAccessInteractive(desktopCredentialVaultForOrigin(activeOrigin), activeOrigin)
       .then((accessToken) => {
-        setToken(accessToken);
+        activateDesktopHumanSession(accessToken);
         setDesktopRestoreFailure("retryable");
         setDesktopBoot("ready");
         return accessToken;
@@ -242,7 +250,7 @@ export function App() {
         setDesktopBoot("error");
         throw cause;
       });
-  }, [activeOrigin]);
+  }, [activeOrigin, activateDesktopHumanSession]);
 
   // 桌面版贴观看邀请链接（#297）：/c/<slug>?t=<token> 的观看 token 直接落进分享态（复用 #186），
   // 换成只读会话打开频道——与网页命中 ?t= 等价，只是桌面没有地址栏，token 从粘贴框进来。
@@ -399,10 +407,10 @@ export function App() {
     setChannels(null);
     setListError(null);
     setMe(null);
-    setToken(result.accessToken);
+    activateDesktopHumanSession(result.accessToken);
     setDesktopBoot("ready");
     replace("/");
-  }, [replace]);
+  }, [activateDesktopHumanSession, replace]);
 
   useEffect(() => {
     if (!desktop) return;
@@ -436,7 +444,7 @@ export function App() {
       return await restoreDesktopAccess(desktopCredentialVaultForOrigin(startupOrigin), startupOrigin);
     })().then((accessToken) => {
         if (!alive) return;
-        setToken(accessToken);
+        activateDesktopHumanSession(accessToken);
         setDesktopRestoreFailure("retryable");
         setDesktopBoot("ready");
       })
@@ -447,7 +455,7 @@ export function App() {
         setDesktopBoot("error");
       });
     return () => { alive = false; };
-  }, [desktop]);
+  }, [activateDesktopHumanSession, desktop]);
 
   // 全局设置面板（#273）：语言/主题/通知/账号（身份 + @别名编辑 + 退出）都收进这里，由顶栏齿轮开合。
   // 账号 @handle / 昵称编辑复用 HandleSetup，放进面板的账号区（不再在顶栏单独挂一个浮层入口）。
@@ -887,7 +895,7 @@ export function App() {
             setAuthError(null);
             setActiveOrigin(origin);
             setServerPairingFlow(initialDesktopServerPairingFlow(origin));
-            setToken(accessToken);
+            activateDesktopHumanSession(accessToken);
           }}
         />
         <DesktopRecoveryUpdater />
@@ -924,7 +932,7 @@ export function App() {
           setChannels(null);
           setListError(null);
           setMe(null);
-          setToken(accessToken);
+          activateDesktopHumanSession(accessToken);
         }}
       />
     );


### PR DESCRIPTION
## 问题

桌面端曾通过观看邀请进入 share mode 后，即使随后从 Keychain 或配对流程恢复了频道 owner 的人类 token，残留的观看 token 仍让 ChannelSocket 走只读 query-token 通道，表现为 owner 只能围观。

## 修复

- 桌面端每次成功恢复、切换或配对人类会话前，统一清除 share token
- 保留主动打开观看邀请时的只读行为
- 增加残留观看凭证 + Keychain 恢复的回归测试

## 验证

- `bun test web/src/App.test.tsx`
- `bun run check:web`（784 tests pass，tsc 与 Vite build 通过）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复桌面端在恢复登录、切换服务器、完成配对后可能仍停留在分享模式的问题。
  * 恢复为正常会话时统一安装人类会话令牌，并在切换/恢复流程中清理旧分享令牌，避免状态互相干扰。
* **Tests**
  * 新增可等待断言的测试辅助方法，补充桌面配对/恢复场景用例。
  * 验证分享模式的进入与退出、分享令牌清理结果，以及相关请求携带的鉴权信息符合预期。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->