### PR TITLE
fix(web): 分工摘要展示 agent 名称

### DIFF
--- a/web/src/lib/divisionSummary.test.ts
+++ b/web/src/lib/divisionSummary.test.ts
@@ -1,0 +1,32 @@
+// @ts-expect-error Bun executes this test, while the web tsconfig intentionally loads only Vite globals.
+import { describe, expect, test } from "bun:test";
+import { declaredAgentRoles, formatAgentRoleSummary, type DeclaredRoleIdentity } from "./divisionSummary";
+
+const screenshotRoles: DeclaredRoleIdentity[] = [
+  { name: "lark:on_owner", display: "lark:on_owner", role: "host" },
+  { name: "ai-girl", display: "ai-girl", kind: "agent", role: "worker" },
+  { name: "ai-girl-zim", display: "ai-girl-zim", kind: "agent", role: "worker" },
+  { name: "ai-girl-host-codex", display: "ai-girl-host-codex", kind: "agent", role: "host" },
+  { name: "qa", display: "QA", kind: "agent", role: "worker" },
+];
+
+describe("division agent summary", () => {
+  test("lists assigned and self-reported agent names instead of an unresolved owner account and counts", () => {
+    expect(formatAgentRoleSummary(screenshotRoles)).toBe(
+      "host=ai-girl-host-codex · worker=ai-girl, ai-girl-zim, QA",
+    );
+  });
+
+  test("uses explicit agent identities when stale unknown or human role rows coexist", () => {
+    expect(declaredAgentRoles([
+      ...screenshotRoles,
+      { name: "human", display: "Leo", kind: "human", role: "host" },
+    ]).map((role) => role.name)).not.toContain("lark:on_owner");
+  });
+
+  test("keeps legacy unknown agent rows when no typed agent identity is available", () => {
+    expect(formatAgentRoleSummary([
+      { name: "legacy-agent", display: "legacy-agent", role: "reviewer" },
+    ])).toBe("reviewer=legacy-agent");
+  });
+});

--- a/web/src/lib/divisionSummary.test.ts
+++ b/web/src/lib/divisionSummary.test.ts
@@ -22,6 +22,7 @@ describe("division agent summary", () => {
       ...screenshotRoles,
       { name: "human", display: "Leo", kind: "human", role: "host" },
     ]);
+    expect(roles.map((role) => role.name)).toEqual(expect.arrayContaining(["ai-girl", "ai-girl-zim"]));
     expect(roles.map((role) => role.name)).not.toContain("lark:on_owner");
     expect(roles.map((role) => role.name)).not.toContain("human");
   });

--- a/web/src/lib/divisionSummary.test.ts
+++ b/web/src/lib/divisionSummary.test.ts
@@ -18,10 +18,12 @@ describe("division agent summary", () => {
   });
 
   test("uses explicit agent identities when stale unknown or human role rows coexist", () => {
-    expect(declaredAgentRoles([
+    const roles = declaredAgentRoles([
       ...screenshotRoles,
       { name: "human", display: "Leo", kind: "human", role: "host" },
-    ]).map((role) => role.name)).not.toContain("lark:on_owner");
+    ]);
+    expect(roles.map((role) => role.name)).not.toContain("lark:on_owner");
+    expect(roles.map((role) => role.name)).not.toContain("human");
   });
 
   test("keeps legacy unknown agent rows when no typed agent identity is available", () => {

--- a/web/src/lib/divisionSummary.ts
+++ b/web/src/lib/divisionSummary.ts
@@ -1,0 +1,35 @@
+import type { CollaborationRole, SenderKind } from "@agentparty/shared";
+
+const ROLE_ORDER: readonly CollaborationRole[] = ["host", "worker", "reviewer", "observer"];
+
+export interface DeclaredRoleIdentity {
+  name: string;
+  display: string;
+  kind?: SenderKind;
+  role: CollaborationRole;
+}
+
+export function declaredAgentRoles<T extends DeclaredRoleIdentity>(roles: readonly T[]): T[] {
+  const knownAgents = roles.filter((role) => role.kind === "agent");
+  if (knownAgents.length > 0) return knownAgents;
+  return roles.filter((role) => role.kind !== "human");
+}
+
+export function formatAgentRoleSummary(roles: readonly DeclaredRoleIdentity[]): string {
+  const byRole = new Map<CollaborationRole, string[]>();
+  const seen = new Set<string>();
+  for (const item of declaredAgentRoles(roles)) {
+    const key = `${item.role}:${item.name}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    const names = byRole.get(item.role) ?? [];
+    names.push(item.display);
+    byRole.set(item.role, names);
+  }
+  return ROLE_ORDER
+    .flatMap((role) => {
+      const names = byRole.get(role);
+      return names === undefined || names.length === 0 ? [] : [`${role}=${names.join(", ")}`];
+    })
+    .join(" · ");
+}

--- a/web/src/pages/Channel.tsx
+++ b/web/src/pages/Channel.tsx
@@ -64,6 +64,7 @@ import { completionMessages } from "../lib/completions";
 import { catchupKey, summarizeCatchup, type CatchupDigest } from "../lib/digest";
 import { buildOrgTree, type OrgMemberInput } from "../lib/orgTree";
 import { charterHasDivisionSection, formatDivisionSection, mergeDivisionIntoCharter, type DivisionCharterRole } from "../lib/divisionCharter";
+import { declaredAgentRoles, formatAgentRoleSummary } from "../lib/divisionSummary";
 import {
   clearDeliveredMentionNotifications,
   isDesktopRuntime,
@@ -651,13 +652,27 @@ export function DivisionBoard({
   // issue #150\uff1a\u62ff\u5f53\u524d\u5df2\u58f0\u660e\u5206\u5de5\uff08assigned + self\uff0c\u4e0d\u542b\u672a\u5206\u5de5\u5360\u4f4d\uff09\u62fc\u6210 markdown
   // \u5c0f\u8282\uff0c\u5408\u5e76\u8fdb\u73b0\u6709\u516c\u544a\u6587\u672c\u3002\u7eaf\u8ba1\u7b97\u653e\u5728\u6e32\u67d3\u671f\uff0c\u624b\u52a8\u6309\u94ae\u548c\u4e0b\u9762\u7684\u81ea\u52a8\u540c\u6b65 effect
   // \u5171\u7528\u540c\u4e00\u4efd\u5408\u5e76\u7ed3\u679c nextCharterText\u2014\u2014\u4fdd\u8bc1\u300c\u624b\u70b9\u300d\u548c\u300c\u81ea\u52a8\u300d\u5199\u8fdb\u53bb\u7684\u6587\u672c\u4e00\u6a21\u4e00\u6837\u3002
-  const declared: DivisionCharterRole[] = roleViews
+  const declaredRoleIdentities = roleViews
     .filter((view): view is typeof view & { role: NonNullable<typeof view.role> } => view.role !== null)
     .map((view) => ({
+      ...view,
+      kind: view.role.kind ?? identityByName.get(view.name)?.kind ?? presence[view.name]?.kind,
+      roleName: view.role.role,
+    }));
+  const declared: DivisionCharterRole[] = declaredAgentRoles(
+    declaredRoleIdentities.map((view) => ({
+      name: view.name,
       display: view.display,
-      accountLabel: view.accountLabel,
-      role: view.role.role,
-      responsibility: view.role.responsibility,
+      kind: view.kind,
+      role: view.roleName,
+      source: view,
+    })),
+  )
+    .map((view) => ({
+      display: view.source.display,
+      accountLabel: view.source.accountLabel,
+      role: view.source.role.role,
+      responsibility: view.source.role.responsibility,
     }));
   const currentCharterText = charterText ?? "";
   const nextCharterText = mergeDivisionIntoCharter(
@@ -3876,20 +3891,22 @@ export function ChannelPage({
   const agentFilterActive = agentFilter.agents.length > 0 || agentFilter.kind !== null;
   const totalInView = q === "" ? timelineMessages.length : searchHits.length;
   const visibleInView = q === "" ? visibleMessages.length : visibleSearchHits.length;
-  const structuredRoleCount = channelRoles.length + selfReportedRoles(channelRoles, state.presence, channelIdentities).length;
+  const channelSelfRoles = selfReportedRoles(channelRoles, state.presence, channelIdentities);
+  const structuredRoleCount = channelRoles.length + channelSelfRoles.length;
   const channelRolesByName = useMemo(
     () => Object.fromEntries(channelRoles.map((role) => [role.name, role])),
     [channelRoles],
   );
-  // #370 点1：公告面板单列一块「分工摘要」——host + 各角色计数，只读，点开跳团队面板看全貌。
-  const charterDivisionSummary = ((): string => {
-    if (channelRoles.length === 0) return "";
-    const host = channelRoles.find((r) => r.role === "host");
-    const counts = new Map<string, number>();
-    for (const r of channelRoles) if (r.role !== "host") counts.set(r.role, (counts.get(r.role) ?? 0) + 1);
-    const parts = [host ? `host=${host.display ?? host.name}` : null, ...[...counts].map(([role, n]) => `${n} ${role}`)];
-    return parts.filter((p): p is string => p !== null).join(" · ");
-  })();
+  // 公告摘要与团队面板共用「管理员分配 + agent 自报」口径，并直接列出 agent 名。
+  // 已知 agent 存在时排除陈旧的人类/未知 role 行，避免 owner account 抢占 host 展示。
+  const charterDivisionSummary = formatAgentRoleSummary(
+    [...channelRoles, ...channelSelfRoles].map((role) => ({
+      name: role.name,
+      display: identityDisplay[role.name]?.display ?? role.display ?? role.name,
+      kind: role.kind ?? identityDisplay[role.name]?.kind ?? state.presence[role.name]?.kind,
+      role: role.role,
+    })),
+  );
   const taskOpenCount = taskSummary?.open ?? tasks.filter((task) => task.state !== "done").length;
   const taskReviewCount = taskSummary?.needs_review ?? tasks.filter((task) => task.state === "needs_review").length;
   const taskBlockedCount = taskSummary?.blocked ?? tasks.filter((task) => task.state === "blocked").length;

--- a/web/src/pages/DivisionBoard.test.tsx
+++ b/web/src/pages/DivisionBoard.test.tsx
@@ -372,6 +372,30 @@ describe("DivisionBoard org-structure relationships (#168)", () => {
 // 把当前已声明分工（assigned + self）拼成 markdown 小节、合并进现有公告文本、
 // 再把结果通过 onSyncToCharter 交给上层去落盘——按钮本身不发网络请求。
 describe("DivisionBoard sync-to-charter (#150)", () => {
+  test("syncs typed agent names and drops a stale unresolved owner role", () => {
+    let synced: string | null = null;
+    render(
+      baseProps({
+        canModerate: true,
+        charterText: "# Team charter",
+        roles: [
+          { name: "lark:on_owner", role: "host", responsibility: "大脑", assigned_by: "leo", assigned_at: 1 },
+          { name: "ai-girl", role: "worker", responsibility: "服务中台", assigned_by: "leo", assigned_at: 1, kind: "agent", display: "ai-girl" },
+        ],
+        presence: {
+          "ai-girl-host-codex": presenceEntry({ name: "ai-girl-host-codex", role: "host", role_source: "self", note: "大脑大脑" }),
+          "ai-girl": presenceEntry({ name: "ai-girl" }),
+        },
+        onSyncToCharter: (text: string) => { synced = text; },
+      }),
+    );
+    const btn = renderer!.root.find((n) => n.props.className === "d-btn role-sync-charter-btn");
+    act(() => btn.props.onClick());
+    expect(synced).toContain("ai-girl-host-codex");
+    expect(synced).toContain("ai-girl");
+    expect(synced).not.toContain("lark:on_owner");
+  });
+
   test("moderator sees a sync button that merges declared roles into the existing charter text", () => {
     let synced: string | null = null;
     render(

--- a/web/src/pages/DivisionBoard.test.tsx
+++ b/web/src/pages/DivisionBoard.test.tsx
@@ -391,8 +391,8 @@ describe("DivisionBoard sync-to-charter (#150)", () => {
     );
     const btn = renderer!.root.find((n) => n.props.className === "d-btn role-sync-charter-btn");
     act(() => btn.props.onClick());
-    expect(synced).toContain("ai-girl-host-codex");
-    expect(synced).toContain("ai-girl");
+    expect(synced).toContain("**ai-girl-host-codex**（未归属 agent）— host");
+    expect(synced).toContain("**ai-girl**（未归属 agent）— worker");
     expect(synced).not.toContain("lark:on_owner");
   });
 


### PR DESCRIPTION
## 问题

公告底部的分工摘要只读取管理员分配角色，不读取 agent 自报角色；因此真正的 host/worker 名称被漏掉，陈旧的 owner account 反而被显示为 host，且其余角色只显示数量。

## 修复

- 合并管理员分配与 agent 自报角色
- 按 host/worker/reviewer/observer 直接列出 agent 名称
- 已知 agent 存在时排除人类或无法解析的陈旧 role 行
- 公告自动同步区块使用同一 agent 口径，移除 `lark:on_*` 这类 owner 原始 ID

## 验证

- `bun run check:web`：787 tests pass，tsc 与 Vite build 通过
- 覆盖截图同构场景：摘要输出 `host=ai-girl-host-codex · worker=ai-girl, ai-girl-zim, QA`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 优化频道与公告中的分工摘要展示：统一按 host/worker/reviewer/observer 汇总角色身份与名称。
  - 同步到公告时，采用更完整的已解析身份口径，并将自报分工纳入摘要生成。
- **问题修复**
  - 避免在摘要/公告中展示过时或未解析的 owner 相关条目（如旧的 unresolved 行）。
  - 有明确身份时优先使用对应智能体；缺少明确身份时保留兼容的未知信息生成 reviewer 汇总。
- **测试**
  - 新增并扩展单元与页面同步用例，覆盖展示、过滤与优先级行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->