### PR TITLE
fix(worker): 回复 agent 时自动触发唤醒 (#544)

### DIFF
--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -3982,6 +3982,27 @@ export class ChannelDO extends Server<Env> {
     return withExpandedMentions(frame, [...routed]);
   }
 
+  // #544：reply_to 本身就是一条明确的定向消息。若原消息作者是 agent，即使回复正文没有再写
+  // @name，也要把它加入 mentions，才能进入 watch/serve/webhook 的持久唤醒与断线重放路径。
+  // 只补 agent、排除自回，避免把普通人类楼中楼回复改造成额外 @ 通知。
+  private expandAgentReplyMention(frame: SendFrame, senderName: string): SendFrame {
+    if (frame.kind !== "message" || frame.reply_to === null) return frame;
+    const row = this.ctx.storage.sql
+      .exec("SELECT sender_name, sender_kind FROM messages WHERE seq = ?", frame.reply_to)
+      .toArray()[0];
+    if (row === undefined || String(row.sender_kind) !== "agent") return frame;
+    const target = String(row.sender_name);
+    const mentions = frame.mentions ?? [];
+    if (
+      target === senderName ||
+      target === "system" ||
+      !MENTION_NAME_RE.test(target) ||
+      mentions.includes(target) ||
+      mentions.length >= MAX_MENTIONS
+    ) return frame;
+    return withExpandedMentions(frame, [...mentions, target]);
+  }
+
   // 校验 → 分配 seq → 落库 → 修剪/presence，返回待广播帧
   private async handleSend(
     identity: Identity,
@@ -4028,6 +4049,7 @@ export class ChannelDO extends Server<Env> {
     if (byteLength(payload) > BODY_LIMIT) {
       return { ok: false, code: "too_large", message: `body exceeds ${BODY_LIMIT} bytes` };
     }
+    frame = this.expandAgentReplyMention(frame, identity.name);
     frame = await this.expandSquadMentions(frame);
     frame = await this.resolveNicknameMentions(frame);
     const workflowGuard = this.workflowGuardDecision(identity, frame);

--- a/worker/test/serve-watch-wake-ledger.spec.ts
+++ b/worker/test/serve-watch-wake-ledger.spec.ts
@@ -129,20 +129,22 @@ describe("#107 serve/watch wakes land in the server-side wake ledger", () => {
     const bot = await seedToken("agent", uniq("reply-bot"));
     const slug = await createChannel(sender.token);
     const botWs = await registerWakeAgent(slug, bot.token, "watch");
+    try {
+      // seq 1 = watch registration; seq 2 = bot asks; seq 3 = peer replies without @.
+      expect((await sendMessage(slug, bot.token, "can you check this?")).status).toBe(200);
+      expect((await reply(slug, sender.token, "yes, checking", 2)).status).toBe(200);
 
-    // seq 1 = watch registration; seq 2 = bot asks; seq 3 = peer replies without @.
-    expect((await sendMessage(slug, bot.token, "can you check this?")).status).toBe(200);
-    expect((await reply(slug, sender.token, "yes, checking", 2)).status).toBe(200);
-    await new Promise((r) => setTimeout(r, 50));
-
-    expect(await messageMentions(slug, 3)).toEqual([bot.name]);
-    expect(await ledgerRows(slug)).toContainEqual(expect.objectContaining({
-      mention_seq: 3,
-      target_name: bot.name,
-      adapter_kind: "watch",
-      result: "broadcast",
-    }));
-    botWs.close();
+      // REST response waits for afterSend, so the durable wake ledger is already committed here.
+      expect(await messageMentions(slug, 3)).toEqual([bot.name]);
+      expect(await ledgerRows(slug)).toContainEqual(expect.objectContaining({
+        mention_seq: 3,
+        target_name: bot.name,
+        adapter_kind: "watch",
+        result: "broadcast",
+      }));
+    } finally {
+      botWs.close();
+    }
   });
 
   it("does NOT record a serve/watch row for a mention with no wakeable presence", async () => {

--- a/worker/test/serve-watch-wake-ledger.spec.ts
+++ b/worker/test/serve-watch-wake-ledger.spec.ts
@@ -58,6 +58,14 @@ async function wakeVerifiedAt(slug: string, name: string): Promise<number | null
   });
 }
 
+async function messageMentions(slug: string, seq: number): Promise<string[]> {
+  const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+  return runInDurableObject(stub, async (_instance: ChannelDO, state) => {
+    const row = state.storage.sql.exec("SELECT mentions_json FROM messages WHERE seq = ?", seq).toArray()[0];
+    return JSON.parse(String(row?.mentions_json ?? "[]")) as string[];
+  });
+}
+
 // 用真实 WS status 帧把某 agent 登记成 serve/watch（服务端据此盖 presence.wake_kind）。
 async function registerWakeAgent(slug: string, token: string, kind: "serve" | "watch"): Promise<WsClient> {
   const ws = await WsClient.open(slug, token);
@@ -113,6 +121,27 @@ describe("#107 serve/watch wakes land in the server-side wake ledger", () => {
     const rows = await ledgerRows(slug);
     expect(rows).toHaveLength(1);
     expect(rows[0]).toMatchObject({ target_name: bot.name, adapter_kind: "watch", result: "broadcast" });
+    botWs.close();
+  });
+
+  it("treats a reply_to an agent as a durable wake target even without an explicit @ (#544)", async () => {
+    const sender = await seedToken("agent");
+    const bot = await seedToken("agent", uniq("reply-bot"));
+    const slug = await createChannel(sender.token);
+    const botWs = await registerWakeAgent(slug, bot.token, "watch");
+
+    // seq 1 = watch registration; seq 2 = bot asks; seq 3 = peer replies without @.
+    expect((await sendMessage(slug, bot.token, "can you check this?")).status).toBe(200);
+    expect((await reply(slug, sender.token, "yes, checking", 2)).status).toBe(200);
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(await messageMentions(slug, 3)).toEqual([bot.name]);
+    expect(await ledgerRows(slug)).toContainEqual(expect.objectContaining({
+      mention_seq: 3,
+      target_name: bot.name,
+      adapter_kind: "watch",
+      result: "broadcast",
+    }));
     botWs.close();
   });
 


### PR DESCRIPTION
修复普通 reply_to 未进入 agent 唤醒队列的问题：回复目标为 agent 时，服务端自动把原作者加入 mentions，因此 watch、serve、webhook 与断线重放都能收到；正文不变，人类回复通知语义不变。

验证：worker/test/serve-watch-wake-ledger.spec.ts 8/8 通过，覆盖无显式 @ 的 reply_to 写入 mentions 和 wake ledger。

Closes #544

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 回复智能代理发送的消息时，即使未显式添加提及，也会自动识别并通知被回复的代理。
  - 改善相关唤醒与消息传递流程，确保回复目标及时收到消息。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->