### PR TITLE
fix(web): 按使用场景重排频道工具栏

### DIFF
--- a/web/src/i18n/strings/Channel.i18n.source.test.ts
+++ b/web/src/i18n/strings/Channel.i18n.source.test.ts
@@ -174,6 +174,32 @@ describe("Channel i18n source guard (#350)", () => {
     expect(source).toContain("onlineAgentCount");
   });
 
+  test("orders channel tools by content, members, access, then channel management", () => {
+    const toolbar = source.slice(
+      source.indexOf("<ChannelToolstrip"),
+      source.indexOf("{activePanel !== null"),
+    );
+    const controls = [
+      'openPanel("charter")',
+      'openPanel("team")',
+      'openPanel("tasks")',
+      'openPanel("search")',
+      "<AgentJoin",
+      "<AgentTokens",
+      "<VisibilityToggle",
+      "<JoinLink",
+      'openPanel("settings")',
+      'className="d-btn archive-channel-btn"',
+    ];
+    const positions = controls.map((control) => toolbar.indexOf(control));
+
+    expect(positions.every((position) => position >= 0)).toBe(true);
+    expect(positions).toEqual([...positions].sort((a, b) => a - b));
+    expect(toolbar).toContain('className="chan-admin-group chan-admin-group--agents"');
+    expect(toolbar).toContain('className="chan-admin-group chan-admin-group--access"');
+    expect(toolbar).toContain('className="chan-admin-group chan-admin-group--channel"');
+  });
+
   test("reject actions no longer use a browser prompt", () => {
     expect(source).not.toContain("window.prompt");
   });

--- a/web/src/pages/Channel.tsx
+++ b/web/src/pages/Channel.tsx
@@ -4147,15 +4147,6 @@ export function ChannelPage({
             <span>{t("Channel.tools.search")}</span>
             {q !== "" && <span className="t-mono chan-tool-badge">{searchLoading ? "..." : searchHits.length}</span>}
           </button>
-          {canModerate && (
-            <button type="button" className="d-btn chan-tool-btn" onClick={() => openPanel("settings")}>
-              <span className="ap-sprite ap-sprite--settings" aria-hidden="true" />
-              <span>{t("Channel.tools.settings")}</span>
-              <span className="t-mono chan-tool-badge">
-                {localLoopGuardEnabled ? localLoopGuardLimit : t("Channel.settings.unlimited")}
-              </span>
-            </button>
-          )}
           </>
         }
         actions={
@@ -4167,60 +4158,71 @@ export function ChannelPage({
             onJump={jumpToMention}
             onDismiss={dismissToast}
           />
-          {(canMintAgent || canModerate) && !state.archived && (
+          {((canMintAgent && !state.archived) || canModerate) && (
             <div className="chan-admin-actions">
-              {canMintAgent && accountKey !== null && (
-                <AgentJoin
-                  slug={slug}
-                  token={token}
-                  namePrefix={agentNamePrefix}
-                  inviterName={inviterName}
-                  charter={charter}
-                  accountKey={accountKey}
-                  active={activeAdminSurface === "agentJoin"}
-                  onActiveChange={(open) => setAdminSurface("agentJoin", open)}
-                />
+              {canMintAgent && accountKey !== null && !state.archived && (
+                <div className="chan-admin-group chan-admin-group--agents">
+                  <AgentJoin
+                    slug={slug}
+                    token={token}
+                    namePrefix={agentNamePrefix}
+                    inviterName={inviterName}
+                    charter={charter}
+                    accountKey={accountKey}
+                    active={activeAdminSurface === "agentJoin"}
+                    onActiveChange={(open) => setAdminSurface("agentJoin", open)}
+                  />
+                  <AgentTokens
+                    slug={slug}
+                    token={token}
+                    accountKey={accountKey}
+                    inviterName={inviterName}
+                    onAuthFailed={onAuthFailed}
+                    active={activeAdminSurface === "agentTokens"}
+                    onActiveChange={(open) => setAdminSurface("agentTokens", open)}
+                  />
+                </div>
               )}
-              {canMintAgent && accountKey !== null && (
-                <AgentTokens
-                  slug={slug}
-                  token={token}
-                  accountKey={accountKey}
-                  inviterName={inviterName}
-                  onAuthFailed={onAuthFailed}
-                  active={activeAdminSurface === "agentTokens"}
-                  onActiveChange={(open) => setAdminSurface("agentTokens", open)}
-                />
+              {canModerate && !state.archived && (
+                <div className="chan-admin-group chan-admin-group--access">
+                  <VisibilityToggle
+                    slug={slug}
+                    token={token}
+                    visibility={localVisibility}
+                    onChanged={setLocalVisibility}
+                    onAuthFailed={onAuthFailed}
+                  />
+                  <JoinLink
+                    slug={slug}
+                    token={token}
+                    larkDirectoryEnabled={larkDirectoryEnabled}
+                    onAuthFailed={onAuthFailed}
+                    active={activeAdminSurface === "joinLink"}
+                    onActiveChange={(open) => setAdminSurface("joinLink", open)}
+                  />
+                </div>
               )}
               {canModerate && (
-                <VisibilityToggle
-                  slug={slug}
-                  token={token}
-                  visibility={localVisibility}
-                  onChanged={setLocalVisibility}
-                  onAuthFailed={onAuthFailed}
-                />
-              )}
-              {canModerate && (
-                <JoinLink
-                  slug={slug}
-                  token={token}
-                  larkDirectoryEnabled={larkDirectoryEnabled}
-                  onAuthFailed={onAuthFailed}
-                  active={activeAdminSurface === "joinLink"}
-                  onActiveChange={(open) => setAdminSurface("joinLink", open)}
-                />
-              )}
-              {canModerate && (
-                <button
-                  type="button"
-                  className="d-btn archive-channel-btn"
-                  disabled={archiving}
-                  onClick={archiveCurrentChannel}
-                  title={t("Channel.archive.buttonTitle")}
-                >
-                  {archiving ? t("Channel.archive.archiving") : t("Channel.archive.button")}
-                </button>
+                <div className="chan-admin-group chan-admin-group--channel">
+                  <button type="button" className="d-btn chan-tool-btn" onClick={() => openPanel("settings")}>
+                    <span className="ap-sprite ap-sprite--settings" aria-hidden="true" />
+                    <span>{t("Channel.tools.settings")}</span>
+                    <span className="t-mono chan-tool-badge">
+                      {localLoopGuardEnabled ? localLoopGuardLimit : t("Channel.settings.unlimited")}
+                    </span>
+                  </button>
+                  {!state.archived && (
+                    <button
+                      type="button"
+                      className="d-btn archive-channel-btn"
+                      disabled={archiving}
+                      onClick={archiveCurrentChannel}
+                      title={t("Channel.archive.buttonTitle")}
+                    >
+                      {archiving ? t("Channel.archive.archiving") : t("Channel.archive.button")}
+                    </button>
+                  )}
+                </div>
               )}
             </div>
           )}

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -3130,7 +3130,8 @@
 }
 .chan-tool-buttons,
 .chan-tool-actions,
-.chan-admin-actions {
+.chan-admin-actions,
+.chan-admin-group {
   display: flex;
   align-items: center;
   flex-wrap: nowrap;
@@ -3146,6 +3147,15 @@
 }
 .chan-admin-actions {
   flex: 0 0 auto;
+  gap: 0;
+}
+.chan-admin-group {
+  flex: 0 0 auto;
+}
+.chan-admin-group + .chan-admin-group {
+  margin-left: 8px;
+  padding-left: 10px;
+  border-left: 1.4px solid var(--t-faint);
 }
 .chan-tool-btn {
   gap: 5px;
@@ -5593,7 +5603,8 @@
   .chan-toolstrip-content::-webkit-scrollbar-thumb { border-width: 1px; }
   .chan-tool-buttons,
   .chan-tool-actions,
-  .chan-admin-actions {
+  .chan-admin-actions,
+  .chan-admin-group {
     flex: 0 0 auto;
     flex-wrap: nowrap;
     gap: 7px;
@@ -5608,6 +5619,7 @@
     margin-left: 0;
     justify-content: flex-start;
   }
+  .chan-admin-actions { gap: 0; }
   .chan-tool-btn {
     white-space: nowrap;
     min-height: 36px;

--- a/web/src/styles/app.visibilityToggle.test.ts
+++ b/web/src/styles/app.visibilityToggle.test.ts
@@ -18,7 +18,9 @@ describe("channel visibility controls layout", () => {
     expect(ruleBody(".chan-toolstrip")).toContain("flex-wrap: nowrap");
     expect(ruleBody(".chan-toolstrip-content")).toContain("overflow: visible");
     expect(css).toMatch(/@media \(max-width: 1759px\)[\s\S]*\.chan-toolstrip-content\s*{[^}]*overflow-x:\s*auto;/s);
-    expect(css).toMatch(/\.chan-tool-buttons,\s*\.chan-tool-actions,\s*\.chan-admin-actions\s*{[^}]*flex-wrap:\s*nowrap;/s);
+    expect(css).toMatch(/\.chan-tool-buttons,\s*\.chan-tool-actions,\s*\.chan-admin-actions,\s*\.chan-admin-group\s*{[^}]*flex-wrap:\s*nowrap;/s);
+    expect(ruleBody(".chan-admin-actions")).toContain("gap: 0");
+    expect(ruleBody(".chan-admin-group + .chan-admin-group")).toContain("border-left: 1.4px solid var(--t-faint)");
     expect(ruleBody(".chan-toolstrip-content")).not.toContain("flex-direction: column");
   });
 });


### PR DESCRIPTION
## 改动说明
- 按“内容导航 → agent → 权限 → 频道管理”重排频道工具栏
- 将设置与归档收拢到末尾，归档始终为最后一个操作
- 保持旧版纸张、硬边框和硬阴影视觉，仅增加组间细分隔与间距
- 增加控件存在性、顺序和样式回归测试

## 验证
- `bun run check`：CLI 760、Web 794、Worker 543 项测试通过，tsc 与 Vite build 通过
- Chrome 2048×900、1440×900、390×844 实时 QA
- 页面级横向溢出为 0；移动端工具栏保持单行横向滚动，末尾可访问设置与归档
- 设置面板可正常打开和关闭

## 合并前检查（review-ack 强制闸——不留结论合不了）
- [x] 我已读 pr-agent / CodeRabbit 的 review，真问题已处理、误报已判明
- [x] 本地门禁通过（tsc / 测试 / build）
- [x] 本次仅调整 Web 控件顺序与样式，不涉及安全、鉴权或数据路径；权限与归档状态已有源码契约和全仓回归覆盖