### PR TITLE
fix(mentions): 中文路由失败不再静默

### DIFF
--- a/cli/src/commands/send.ts
+++ b/cli/src/commands/send.ts
@@ -1,6 +1,6 @@
 // party send — rest 一次性发消息，成功后推进游标
 import { basename } from "node:path";
-import { extractMentionTokens, type Attachment } from "@agentparty/shared";
+import { extractMentionTokens, MAX_MENTIONS, type Attachment } from "@agentparty/shared";
 import { isHelpArg, parseArgs, str, strArray, unknownFlagError, valueFlagError, type Parsed } from "../args";
 import { advanceCursorPastOwnMessage, resolveChannel, type Config } from "../config";
 import { formatAuthDebugLine, resolveAuthDetailed } from "../oidc-cli";
@@ -189,11 +189,16 @@ export async function resolveSendInput(parsed: Parsed): Promise<SendInput | null
     console.error("--mention must match [a-zA-Z0-9][a-zA-Z0-9._-]{0,63}");
     return null;
   }
+  if (explicitMentions.length > MAX_MENTIONS) {
+    console.error(`too many mentions (max ${MAX_MENTIONS})`);
+    return null;
+  }
   // Keep CLI, Web and Worker on the same body-mention contract. Explicit
   // --mention values stay first; body tokens are appended in source order.
   const mentions = [...explicitMentions];
   const seenMentions = new Set(mentions);
   for (const mention of extractMentionTokens(text)) {
+    if (mentions.length >= MAX_MENTIONS) break;
     if (seenMentions.has(mention)) continue;
     seenMentions.add(mention);
     mentions.push(mention);

--- a/cli/src/commands/send.ts
+++ b/cli/src/commands/send.ts
@@ -193,10 +193,6 @@ export async function resolveSendInput(parsed: Parsed): Promise<SendInput | null
     console.error("--mention cannot target reserved name system");
     return null;
   }
-  if (explicitMentions.length > MAX_MENTIONS) {
-    console.error(`too many mentions (max ${MAX_MENTIONS})`);
-    return null;
-  }
   // Keep CLI, Web and Worker on the same body-mention contract. Explicit
   // --mention values stay first; body tokens are appended in source order.
   const mentions: string[] = [];
@@ -206,6 +202,10 @@ export async function resolveSendInput(parsed: Parsed): Promise<SendInput | null
     if (seenMentions.has(key)) continue;
     seenMentions.add(key);
     mentions.push(mention);
+  }
+  if (mentions.length > MAX_MENTIONS) {
+    console.error(`too many mentions (max ${MAX_MENTIONS})`);
+    return null;
   }
   for (const mention of extractMentionTokens(text)) {
     if (mentions.length >= MAX_MENTIONS) break;

--- a/cli/src/commands/send.ts
+++ b/cli/src/commands/send.ts
@@ -1,6 +1,6 @@
 // party send — rest 一次性发消息，成功后推进游标
 import { basename } from "node:path";
-import type { Attachment } from "@agentparty/shared";
+import { extractMentionTokens, type Attachment } from "@agentparty/shared";
 import { isHelpArg, parseArgs, str, strArray, unknownFlagError, valueFlagError, type Parsed } from "../args";
 import { advanceCursorPastOwnMessage, resolveChannel, type Config } from "../config";
 import { formatAuthDebugLine, resolveAuthDetailed } from "../oidc-cli";
@@ -184,10 +184,19 @@ export async function resolveSendInput(parsed: Parsed): Promise<SendInput | null
       `note: 正发到绑定频道「${channel}」；若想发到「${positionals[0]}」，用：party send --channel ${positionals[0]} "..."（首个词已被当作正文的一部分）`,
     );
   }
-  const mentions = strArray(flags.mention) ?? [];
-  if (mentions.some((mention) => !isName(mention))) {
+  const explicitMentions = strArray(flags.mention) ?? [];
+  if (explicitMentions.some((mention) => !isName(mention))) {
     console.error("--mention must match [a-zA-Z0-9][a-zA-Z0-9._-]{0,63}");
     return null;
+  }
+  // Keep CLI, Web and Worker on the same body-mention contract. Explicit
+  // --mention values stay first; body tokens are appended in source order.
+  const mentions = [...explicitMentions];
+  const seenMentions = new Set(mentions);
+  for (const mention of extractMentionTokens(text)) {
+    if (seenMentions.has(mention)) continue;
+    seenMentions.add(mention);
+    mentions.push(mention);
   }
   return {
     channel,

--- a/cli/src/commands/send.ts
+++ b/cli/src/commands/send.ts
@@ -1,6 +1,6 @@
 // party send — rest 一次性发消息，成功后推进游标
 import { basename } from "node:path";
-import { extractMentionTokens, MAX_MENTIONS, type Attachment } from "@agentparty/shared";
+import { extractMentionTokens, MAX_MENTIONS, mentionMatchKey, type Attachment } from "@agentparty/shared";
 import { isHelpArg, parseArgs, str, strArray, unknownFlagError, valueFlagError, type Parsed } from "../args";
 import { advanceCursorPastOwnMessage, resolveChannel, type Config } from "../config";
 import { formatAuthDebugLine, resolveAuthDetailed } from "../oidc-cli";
@@ -189,18 +189,29 @@ export async function resolveSendInput(parsed: Parsed): Promise<SendInput | null
     console.error("--mention must match [a-zA-Z0-9][a-zA-Z0-9._-]{0,63}");
     return null;
   }
+  if (explicitMentions.some((mention) => mentionMatchKey(mention) === "system")) {
+    console.error("--mention cannot target reserved name system");
+    return null;
+  }
   if (explicitMentions.length > MAX_MENTIONS) {
     console.error(`too many mentions (max ${MAX_MENTIONS})`);
     return null;
   }
   // Keep CLI, Web and Worker on the same body-mention contract. Explicit
   // --mention values stay first; body tokens are appended in source order.
-  const mentions = [...explicitMentions];
-  const seenMentions = new Set(mentions);
+  const mentions: string[] = [];
+  const seenMentions = new Set<string>();
+  for (const mention of explicitMentions) {
+    const key = mentionMatchKey(mention);
+    if (seenMentions.has(key)) continue;
+    seenMentions.add(key);
+    mentions.push(mention);
+  }
   for (const mention of extractMentionTokens(text)) {
     if (mentions.length >= MAX_MENTIONS) break;
-    if (seenMentions.has(mention)) continue;
-    seenMentions.add(mention);
+    const key = mentionMatchKey(mention);
+    if (seenMentions.has(key)) continue;
+    seenMentions.add(key);
     mentions.push(mention);
   }
   return {

--- a/cli/test/send-attach.test.ts
+++ b/cli/test/send-attach.test.ts
@@ -84,6 +84,17 @@ describe("send --attach parsing", () => {
     const input = await resolveSendInput(parsed);
     expect(input?.mentions).toEqual(["all"]);
   });
+
+  test("显式和正文 mention 的总数不超过共享上限", async () => {
+    const flags = Array.from({ length: 50 }, (_, i) => ["--mention", `agent-${i}`]).flat();
+    const parsed = parseArgs(["正文 @overflow", "--channel", "c", ...flags], sendSpec);
+    const input = await resolveSendInput(parsed);
+    expect(input?.mentions).toHaveLength(50);
+    expect(input?.mentions).not.toContain("overflow");
+
+    const tooMany = parseArgs(["正文", "--channel", "c", ...flags, "--mention", "agent-50"], sendSpec);
+    expect(await resolveSendInput(tooMany)).toBeNull();
+  });
 });
 
 describe("resolveAttachments", () => {

--- a/cli/test/send-attach.test.ts
+++ b/cli/test/send-attach.test.ts
@@ -95,6 +95,14 @@ describe("send --attach parsing", () => {
     const tooMany = parseArgs(["正文", "--channel", "c", ...flags, "--mention", "agent-50"], sendSpec);
     expect(await resolveSendInput(tooMany)).toBeNull();
   });
+
+  test("ASCII mention 大小写去重并拒绝保留名 system", async () => {
+    const deduped = parseArgs(["正文 @agent", "--channel", "c", "--mention", "Agent"], sendSpec);
+    expect((await resolveSendInput(deduped))?.mentions).toEqual(["Agent"]);
+
+    const reserved = parseArgs(["正文", "--channel", "c", "--mention", "SYSTEM"], sendSpec);
+    expect(await resolveSendInput(reserved)).toBeNull();
+  });
 });
 
 describe("resolveAttachments", () => {

--- a/cli/test/send-attach.test.ts
+++ b/cli/test/send-attach.test.ts
@@ -66,6 +66,24 @@ describe("send --attach parsing", () => {
     const parsed = parseArgs(["--channel", "c"], sendSpec);
     expect(await resolveSendInput(parsed)).toBeNull();
   });
+
+  test("正文 mention 与 Web/Worker 复用同一套 CJK、全角标点和 email 契约", async () => {
+    const parsed = parseArgs([
+      "请@agent-a看一下，（@程序员小明）；a@example.com 不算",
+      "--channel",
+      "c",
+      "--mention",
+      "explicit",
+    ], sendSpec);
+    const input = await resolveSendInput(parsed);
+    expect(input?.mentions).toEqual(["explicit", "agent-a", "程序员小明"]);
+  });
+
+  test("正文保留 @all 交给服务端给出明确不支持错误", async () => {
+    const parsed = parseArgs(["请 @all 看一下", "--channel", "c"], sendSpec);
+    const input = await resolveSendInput(parsed);
+    expect(input?.mentions).toEqual(["all"]);
+  });
 });
 
 describe("resolveAttachments", () => {

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -30,6 +30,28 @@ export const ROLE_RESPONSIBILITY_LIMIT = 500;
 // 保留名：不得铸成真实 token。"system" 是 webhook 失败通告的发信名，dispatchWebhooks 靠它跳过投递；
 // 若被铸成真实 token，其消息（含被 @）会静默永不触发 webhook。
 export const RESERVED_NAMES: readonly string[] = ["system"];
+export const MAX_MENTIONS = 50;
+
+// Shared lexer for message bodies and the web composer. ASCII identifiers
+// win the alternation, so `请@agent-a看一下` stops at the Chinese prose after
+// the agent name. Mentions that start in CJK still accept full Unicode
+// nicknames. The left boundary rejects ASCII identifier/email characters but
+// accepts adjacent CJK prose and full-width punctuation.
+const BODY_MENTION_RE =
+  /(^|[^A-Za-z0-9._@-])@(?:([A-Za-z0-9][A-Za-z0-9._-]{0,63})|([\p{L}\p{N}][\p{L}\p{N}._-]{0,63}))/gu;
+
+export function extractMentionTokens(text: string, limit: number = MAX_MENTIONS): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const match of text.matchAll(BODY_MENTION_RE)) {
+    const token = match[2] ?? match[3];
+    if (!token || token === "system" || seen.has(token)) continue;
+    seen.add(token);
+    out.push(token);
+    if (out.length >= limit) break;
+  }
+  return out;
+}
 export const MAX_WEBHOOK_QUEUE_ROWS = 200;
 export const WEBHOOK_RETRY_BATCH_SIZE = 25;
 // 死信保留上限（#105）：重试耗尽 / 队列满而被永久放弃的投递不再静默丢弃，落死信表待人重投。

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -49,6 +49,7 @@ export function mentionMatchKey(value: string): string {
 }
 
 export function extractMentionTokens(text: string, limit: number = MAX_MENTIONS): string[] {
+  if (limit <= 0) return [];
   const out: string[] = [];
   const seen = new Set<string>();
   for (const match of text.matchAll(BODY_MENTION_RE)) {

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -40,13 +40,23 @@ export const MAX_MENTIONS = 50;
 const BODY_MENTION_RE =
   /(^|[^A-Za-z0-9._@-])@(?:([A-Za-z0-9][A-Za-z0-9._-]{0,63})|([\p{L}\p{N}][\p{L}\p{N}._-]{0,63}))/gu;
 
+// ASCII token names / human handles are case-insensitive. Unicode nickname
+// and display-name aliases stay exact (NFC), because SQLite NOCASE is
+// ASCII-only and must not silently disagree with client-side matching.
+export function mentionMatchKey(value: string): string {
+  const normalized = value.normalize("NFC");
+  return /^[A-Za-z0-9._-]+$/.test(normalized) ? normalized.toLowerCase() : normalized;
+}
+
 export function extractMentionTokens(text: string, limit: number = MAX_MENTIONS): string[] {
   const out: string[] = [];
   const seen = new Set<string>();
   for (const match of text.matchAll(BODY_MENTION_RE)) {
     const token = match[2] ?? match[3];
-    if (!token || token === "system" || seen.has(token)) continue;
-    seen.add(token);
+    if (!token) continue;
+    const key = mentionMatchKey(token);
+    if (key === "system" || seen.has(key)) continue;
+    seen.add(key);
     out.push(token);
     if (out.length >= limit) break;
   }

--- a/web/src/lib/mentions.test.ts
+++ b/web/src/lib/mentions.test.ts
@@ -413,7 +413,9 @@ describe("parseDraftMentions", () => {
     expect(parseDraftMentions("@小助手 帮我看下")).toEqual(["小助手"]);
     expect(parseDraftMentions("hi @程序员小明 and @bob")).toEqual(["程序员小明", "bob"]);
     expect(parseDraftMentions("mail me@bar.com thanks")).toEqual([]);
-    expect(parseDraftMentions("路人甲@小明")).toEqual([]); // @ 前是中文标识符 → 不当 mention
+    expect(parseDraftMentions("请@agent-a看一下")).toEqual(["agent-a"]);
+    expect(parseDraftMentions("（@agent-a），@agent-b")).toEqual(["agent-a", "agent-b"]);
+    expect(parseDraftMentions("路人甲@小明")).toEqual(["小明"]);
   });
 });
 
@@ -421,5 +423,9 @@ describe("activeMentionQuery — 中文昵称补全（#165）", () => {
   test("打 @中 触发补全下拉", () => {
     expect(activeMentionQuery("@中", 2)).toEqual({ start: 0, query: "中" });
     expect(activeMentionQuery("hi @小助", 6)).toEqual({ start: 3, query: "小助" });
+  });
+  test("中文正文后可触发，ASCII/email 左边界仍拒绝", () => {
+    expect(activeMentionQuery("请@agent", 8)).toEqual({ start: 1, query: "agent" });
+    expect(activeMentionQuery("a@agent", 7)).toBeNull();
   });
 });

--- a/web/src/lib/mentions.test.ts
+++ b/web/src/lib/mentions.test.ts
@@ -400,7 +400,7 @@ describe("parseDraftMentions", () => {
     expect(parseDraftMentions("hi\n@bob")).toEqual(["bob"]);
   });
   test("去重且保序", () => {
-    expect(parseDraftMentions("@bob @alice @bob")).toEqual(["bob", "alice"]);
+    expect(parseDraftMentions("@bob @alice @Bob")).toEqual(["bob", "alice"]);
   });
   test("过滤 system", () => {
     expect(parseDraftMentions("@system hi @bob")).toEqual(["bob"]);

--- a/web/src/lib/mentions.test.ts
+++ b/web/src/lib/mentions.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, test } from "bun:test";
-import type { MsgFrame, PresenceEntry, Sender } from "@agentparty/shared";
+import { extractMentionTokens, type MsgFrame, type PresenceEntry, type Sender } from "@agentparty/shared";
 import { activeMentionQuery, filterCandidates, mentionCandidates, parseDraftMentions } from "./mentions";
 
 const NOW = 1_000_000_000;
+
+test("shared mention lexer respects a zero limit", () => {
+  expect(extractMentionTokens("@alice", 0)).toEqual([]);
+});
 
 function presence(over: Partial<PresenceEntry> & { name: string }): PresenceEntry {
   return { state: "waiting", note: null, ts: NOW, last_seen: NOW, ...over };

--- a/web/src/lib/mentions.ts
+++ b/web/src/lib/mentions.ts
@@ -1,7 +1,7 @@
 // @ 提及候选（issue #39）：把 participants（WS 连着）∪ presence（含 wake 信息）合成一个
 // 分档的候选列表，供 Composer 的 @ 补全下拉用。"可 @" ≠ "在线连接"——本产品最特别的一档是
 // 「可唤醒」：人不在但 @ 了会被 serve/watch/webhook 拉起来。
-import { autoWakeReachable, type ChannelRoleAssignment, type ChannelSquad, type PresenceEntry, type Sender, type WakeKind } from "@agentparty/shared";
+import { autoWakeReachable, extractMentionTokens, type ChannelRoleAssignment, type ChannelSquad, type PresenceEntry, type Sender, type WakeKind } from "@agentparty/shared";
 import { MENTION_SENDER_RETENTION_MS, mergeSenderIdentity, type SenderIdentitySnapshot } from "./senderIdentity";
 
 export type MentionTier = "online" | "wakeable" | "recent";
@@ -199,7 +199,7 @@ export function activeMentionQuery(text: string, caret: number): { start: number
   let i = caret - 1;
   while (i >= 0 && /[\p{L}\p{N}._-]/u.test(text[i]!)) i--;
   if (i < 0 || text[i] !== "@") return null;
-  if (i > 0 && !/\s/.test(text[i - 1]!)) return null; // @ 前不是空白/行首 → 是 email 之类，不触发
+  if (i > 0 && /[A-Za-z0-9._@-]/.test(text[i - 1]!)) return null;
   return { start: i, query: text.slice(i + 1, caret) };
 }
 
@@ -230,21 +230,11 @@ export function mentionLiveness(
   return { tier, wakeKind, reachable: tier === "online" || tier === "wakeable" };
 }
 
-// 从草稿正文里提取 @name（与服务端 BODY_MENTION_RE 一致：@ 前须行首/空白，不吃 email 里的 @）。
+// 从草稿正文里提取 @name（与 shared/server 一致：允许 CJK 正文相邻，不吃 ASCII email 里的 @）。
 // 去重、保序，供发送前状态条渲染。
-// #165：放开为 unicode（含中文昵称）。@ 前的边界字符类同样排除 unicode 字母/数字，@ 前是标识符
-// （含中文）就不当 mention（email/句中 @ 安全）；捕获 token 上界 64（{0,63}）。
-const DRAFT_MENTION_RE = /(^|[^\p{L}\p{N}._@-])@([\p{L}\p{N}][\p{L}\p{N}._-]{0,63})/gu;
+// #165/#552：放开 unicode 昵称；ASCII token 分支优先，避免把紧跟 agent 名的中文正文吞进去。
 export function parseDraftMentions(text: string): string[] {
-  const out: string[] = [];
-  const seen = new Set<string>();
-  for (const m of text.matchAll(DRAFT_MENTION_RE)) {
-    const name = m[2]!;
-    if (name === "system" || seen.has(name)) continue;
-    seen.add(name);
-    out.push(name);
-  }
-  return out;
+  return extractMentionTokens(text);
 }
 
 export function filterCandidates(cands: MentionCandidate[], query: string, limit = 8): MentionCandidate[] {

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -3968,8 +3968,17 @@ export class ChannelDO extends Server<Env> {
     // Pure-CJK aliases have no lexical boundary before following prose
     // (`请@小明看一下`). Load aliases that are prefixes of the raw token; the
     // resolver below applies longest-match and still fails closed on ties.
-    const nicknamePrefixes = candidates.map(() => "? LIKE nickname || '%'").join(" OR ");
-    const displayNamePrefixes = candidates.map(() => "? LIKE display_name || '%'").join(" OR ");
+    // ASCII names never need this fallback: accepting it would turn unknown
+    // `@bobcat` into the existing `bob` target.
+    const cjkPrefixCandidates = candidates.filter((candidate) =>
+      /^[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u.test(candidate)
+    );
+    const nicknamePrefixClause = cjkPrefixCandidates.length === 0
+      ? ""
+      : ` OR (${cjkPrefixCandidates.map(() => "? LIKE nickname || '%'").join(" OR ")})`;
+    const displayNamePrefixClause = cjkPrefixCandidates.length === 0
+      ? ""
+      : ` OR (${cjkPrefixCandidates.map(() => "? LIKE display_name || '%'").join(" OR ")})`;
     type AliasRow = { target: string; alias: string };
     let remote: AliasRow[];
     try {
@@ -3980,8 +3989,8 @@ export class ChannelDO extends Server<Env> {
         ).bind(...candidates).all<AliasRow>(),
         this.env.DB.prepare(
           `SELECT name AS target, nickname AS alias FROM agent_nicknames
-            WHERE nickname COLLATE NOCASE IN (${placeholders}) OR (${nicknamePrefixes})`,
-        ).bind(...candidates, ...candidates).all<AliasRow>(),
+            WHERE nickname COLLATE NOCASE IN (${placeholders})${nicknamePrefixClause}`,
+        ).bind(...candidates, ...cjkPrefixCandidates).all<AliasRow>(),
         this.env.DB.prepare(
           `SELECT handle AS target, handle AS alias FROM account_profiles
             WHERE handle COLLATE NOCASE IN (${placeholders})`,
@@ -3989,8 +3998,8 @@ export class ChannelDO extends Server<Env> {
         this.env.DB.prepare(
           `SELECT handle AS target, display_name AS alias FROM account_profiles
             WHERE display_name IS NOT NULL
-              AND (display_name COLLATE NOCASE IN (${placeholders}) OR (${displayNamePrefixes}))`,
-        ).bind(...candidates, ...candidates).all<AliasRow>(),
+              AND (display_name COLLATE NOCASE IN (${placeholders})${displayNamePrefixClause})`,
+        ).bind(...candidates, ...cjkPrefixCandidates).all<AliasRow>(),
         this.env.DB.prepare(
           `SELECT name AS target, name AS alias FROM channel_squads
             WHERE channel_slug = ? AND name COLLATE NOCASE IN (${placeholders})`,
@@ -4050,12 +4059,12 @@ export class ChannelDO extends Server<Env> {
     const routed: string[] = [];
     const seen = new Set<string>();
     for (const raw of candidates) {
-      if (raw.toLocaleLowerCase("en-US") === "all" || raw === "全体") {
-        return { frame, error: `unsupported mention @${raw}` };
+      if (raw.toLocaleLowerCase("en-US") === "all" || raw.startsWith("全体")) {
+        return { frame, error: `unsupported mention @${raw.startsWith("全体") ? "全体" : raw}` };
       }
       const key = raw.toLocaleLowerCase("en-US");
       let targets = aliases.get(key);
-      if (!targets) {
+      if (!targets && cjkPrefixCandidates.includes(raw)) {
         let longest = 0;
         for (const [alias, aliasTargets] of aliases) {
           if (!key.startsWith(alias) || alias.length < longest) continue;

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -4146,12 +4146,14 @@ export class ChannelDO extends Server<Env> {
     if (byteLength(payload) > BODY_LIMIT) {
       return { ok: false, code: "too_large", message: `body exceeds ${BODY_LIMIT} bytes` };
     }
-    frame = this.expandAgentReplyMention(frame, identity.name);
     const resolvedMentions = await this.resolveMentionTargets(frame);
     if (resolvedMentions.error !== undefined) {
       return { ok: false, code: "bad_request", message: resolvedMentions.error };
     }
-    frame = await this.expandSquadMentions(resolvedMentions.frame);
+    // reply_to author comes from this channel's authoritative message row and
+    // must not depend on the bounded recent-alias lookup above.
+    frame = this.expandAgentReplyMention(resolvedMentions.frame, identity.name);
+    frame = await this.expandSquadMentions(frame);
     const workflowGuard = this.workflowGuardDecision(identity, frame);
     if (workflowGuard !== null) {
       const row = this.workflowGuardRow(workflowGuard.workflow.workflow_id);

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -3969,6 +3969,18 @@ export class ChannelDO extends Server<Env> {
     const candidates = mentions.filter((t) => t.length <= 64);
     if (candidates.length === 0) return { frame };
     const placeholders = candidates.map(() => "?").join(", ");
+    const asciiCandidates = candidates.filter((candidate) => /^[A-Za-z0-9._-]+$/.test(candidate));
+    const unicodeCandidates = candidates.filter((candidate) => !/^[A-Za-z0-9._-]+$/.test(candidate));
+    const aliasExactClause = (column: "nickname" | "display_name") => {
+      const clauses: string[] = [];
+      if (asciiCandidates.length > 0) {
+        clauses.push(`${column} COLLATE NOCASE IN (${asciiCandidates.map(() => "?").join(", ")})`);
+      }
+      if (unicodeCandidates.length > 0) {
+        clauses.push(`${column} IN (${unicodeCandidates.map(() => "?").join(", ")})`);
+      }
+      return clauses.join(" OR ");
+    };
     // Pure-CJK aliases have no lexical boundary before following prose
     // (`请@小明看一下`). Load aliases that are prefixes of the raw token; the
     // resolver below applies longest-match and still fails closed on ties.
@@ -3993,8 +4005,8 @@ export class ChannelDO extends Server<Env> {
         ).bind(...candidates).all<AliasRow>(),
         this.env.DB.prepare(
           `SELECT name AS target, nickname AS alias FROM agent_nicknames
-            WHERE nickname IN (${placeholders})${nicknamePrefixClause}`,
-        ).bind(...candidates, ...cjkPrefixCandidates).all<AliasRow>(),
+            WHERE ${aliasExactClause("nickname")}${nicknamePrefixClause}`,
+        ).bind(...asciiCandidates, ...unicodeCandidates, ...cjkPrefixCandidates).all<AliasRow>(),
         this.env.DB.prepare(
           `SELECT handle AS target, handle AS alias FROM account_profiles
             WHERE handle COLLATE NOCASE IN (${placeholders})`,
@@ -4002,8 +4014,8 @@ export class ChannelDO extends Server<Env> {
         this.env.DB.prepare(
           `SELECT handle AS target, display_name AS alias FROM account_profiles
             WHERE display_name IS NOT NULL
-              AND (display_name IN (${placeholders})${displayNamePrefixClause})`,
-        ).bind(...candidates, ...cjkPrefixCandidates).all<AliasRow>(),
+              AND (${aliasExactClause("display_name")}${displayNamePrefixClause})`,
+        ).bind(...asciiCandidates, ...unicodeCandidates, ...cjkPrefixCandidates).all<AliasRow>(),
         this.env.DB.prepare(
           `SELECT name AS target, name AS alias FROM channel_squads
             WHERE channel_slug = ? AND name COLLATE NOCASE IN (${placeholders})`,

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -9,6 +9,7 @@ import {
   LOOP_GUARD_AGENT_PARTY_N,
   LOOP_GUARD_N,
   LOOP_GUARD_PARTY_N,
+  mentionMatchKey,
   MAX_WEBHOOKS_PER_CHANNEL,
   MAX_MESSAGE_AUDIT_ROWS,
   MAX_WEBHOOK_DEAD_LETTERS,
@@ -3962,7 +3963,10 @@ export class ChannelDO extends Server<Env> {
   private async resolveMentionTargets(frame: SendFrame): Promise<{ frame: SendFrame; error?: string }> {
     const mentions = frame.mentions ?? [];
     if (mentions.length === 0) return { frame };
-    const candidates = mentions.filter((t) => t !== "system" && t.length <= 64);
+    if (mentions.some((mention) => mentionMatchKey(mention) === "system")) {
+      return { frame, error: "reserved mention @system" };
+    }
+    const candidates = mentions.filter((t) => t.length <= 64);
     if (candidates.length === 0) return { frame };
     const placeholders = candidates.map(() => "?").join(", ");
     // Pure-CJK aliases have no lexical boundary before following prose
@@ -3975,10 +3979,10 @@ export class ChannelDO extends Server<Env> {
     );
     const nicknamePrefixClause = cjkPrefixCandidates.length === 0
       ? ""
-      : ` OR (${cjkPrefixCandidates.map(() => "? LIKE nickname || '%'").join(" OR ")})`;
+      : ` OR (${cjkPrefixCandidates.map(() => "substr(?, 1, length(nickname)) = nickname").join(" OR ")})`;
     const displayNamePrefixClause = cjkPrefixCandidates.length === 0
       ? ""
-      : ` OR (${cjkPrefixCandidates.map(() => "? LIKE display_name || '%'").join(" OR ")})`;
+      : ` OR (${cjkPrefixCandidates.map(() => "substr(?, 1, length(display_name)) = display_name").join(" OR ")})`;
     type AliasRow = { target: string; alias: string };
     let remote: AliasRow[];
     try {
@@ -3989,7 +3993,7 @@ export class ChannelDO extends Server<Env> {
         ).bind(...candidates).all<AliasRow>(),
         this.env.DB.prepare(
           `SELECT name AS target, nickname AS alias FROM agent_nicknames
-            WHERE nickname COLLATE NOCASE IN (${placeholders})${nicknamePrefixClause}`,
+            WHERE nickname IN (${placeholders})${nicknamePrefixClause}`,
         ).bind(...candidates, ...cjkPrefixCandidates).all<AliasRow>(),
         this.env.DB.prepare(
           `SELECT handle AS target, handle AS alias FROM account_profiles
@@ -3998,7 +4002,7 @@ export class ChannelDO extends Server<Env> {
         this.env.DB.prepare(
           `SELECT handle AS target, display_name AS alias FROM account_profiles
             WHERE display_name IS NOT NULL
-              AND (display_name COLLATE NOCASE IN (${placeholders})${displayNamePrefixClause})`,
+              AND (display_name IN (${placeholders})${displayNamePrefixClause})`,
         ).bind(...candidates, ...cjkPrefixCandidates).all<AliasRow>(),
         this.env.DB.prepare(
           `SELECT name AS target, name AS alias FROM channel_squads
@@ -4026,7 +4030,7 @@ export class ChannelDO extends Server<Env> {
     const aliases = new Map<string, Set<string>>();
     const add = (alias: unknown, target: unknown) => {
       if (typeof alias !== "string" || typeof target !== "string" || alias === "" || target === "") return;
-      const key = alias.toLocaleLowerCase("en-US");
+      const key = mentionMatchKey(alias);
       const targets = aliases.get(key) ?? new Set<string>();
       targets.add(target);
       aliases.set(key, targets);
@@ -4059,10 +4063,10 @@ export class ChannelDO extends Server<Env> {
     const routed: string[] = [];
     const seen = new Set<string>();
     for (const raw of candidates) {
-      if (raw.toLocaleLowerCase("en-US") === "all" || raw.startsWith("全体")) {
+      if (mentionMatchKey(raw) === "all" || raw.startsWith("全体")) {
         return { frame, error: `unsupported mention @${raw.startsWith("全体") ? "全体" : raw}` };
       }
-      const key = raw.toLocaleLowerCase("en-US");
+      const key = mentionMatchKey(raw);
       let targets = aliases.get(key);
       if (!targets && cjkPrefixCandidates.includes(raw)) {
         let longest = 0;

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -2,6 +2,7 @@
 import {
   applyLiveConnection,
   BODY_LIMIT,
+  extractMentionTokens,
   IDEMPOTENCY_KEY_MAX,
   IDEMPOTENCY_WINDOW_MS,
   LOOP_GUARD_AGENT_N,
@@ -221,18 +222,17 @@ function parseMentions(input: unknown): string[] | null {
   return input as string[];
 }
 
-// 正文里的 @name（@ 须在行首或空白后，避开 email 的 @）。serve/webhook 唤醒只看 mentions
+// 正文里的 @name（允许紧邻 CJK 正文/全角标点，ASCII 标识符左边界仍避开 email）。serve/webhook 唤醒只看 mentions
 // 数组——若发送方只在正文打 @ 没进数组（裸 party send "@name"），目标永不被唤醒。故服务端
 // 从 body/note 兜底提取并 union 进 mentions，去重、剔除 system、总量截到 MAX_MENTIONS。
 // 误报无害：wake ledger 只投给真实可唤醒目标，无对应者的 @ 不会触发任何投递。
-// #165：放开首字为 unicode 字母/数字，能捕获 @中文昵称。@ 前仍须行首/空白（不吃 email 的 @），
+// #165/#552：放开首字为 unicode 字母/数字，能捕获 @中文昵称；ASCII token 优先，
+// 所以 `请@agent-a看一下` 不会把后面的中文正文吞进 token。
 // 长度仍上界 64（[\p{L}\p{N}._-]{0,63}）。捕获到的 @昵称 由 resolveNicknameMentions 解析成真实 name。
-const BODY_MENTION_RE = /(?:^|\s)@([\p{L}\p{N}][\p{L}\p{N}._-]{0,63})/gu;
 function mergeBodyMentions(explicit: string[], text: string): string[] {
   const seen = new Set(explicit);
   const out = [...explicit];
-  for (const match of text.matchAll(BODY_MENTION_RE)) {
-    const name = match[1]!;
+  for (const name of extractMentionTokens(text, MAX_MENTIONS)) {
     if (name === "system" || seen.has(name)) continue;
     seen.add(name);
     out.push(name);
@@ -3956,30 +3956,93 @@ export class ChannelDO extends Server<Env> {
     return withExpandedMentions(frame, [...routed]);
   }
 
-  // #165：把正文/显式 mentions 里的 @昵称（含中文）解析成目标 agent 的真实 ASCII name，union 进 mentions。
-  // 手法镜像 expandSquadMentions（读 D1、大小写不敏感匹配、再重写 mentions），且同样跑在 INSERT 之前——
-  // 这样 serve/watch（msg.mentions.includes(name)）与 webhook（shouldDeliverWebhook 按 hookName=name）
-  // 都能凭真实 name 命中被 @ 的 agent。昵称是全局唯一的，故一个 token 匹配即定位到唯一 agent。
-  private async resolveNicknameMentions(frame: SendFrame): Promise<SendFrame> {
+  // #165/#552：把正文/显式 mentions 的 token 解析成权威 target。agent name、昵称、human handle
+  // 与 squad 全部按 NOCASE 匹配；同一 alias 若指向多个 target 则 fail closed。不存在的 @ 也必须明确
+  // 拒绝，不能落一条看似成功、实际永远不会进入 wake/delivery 的消息。
+  private async resolveMentionTargets(frame: SendFrame): Promise<{ frame: SendFrame; error?: string }> {
     const mentions = frame.mentions ?? [];
-    if (mentions.length === 0) return frame;
+    if (mentions.length === 0) return { frame };
     const candidates = mentions.filter((t) => t !== "system" && t.length <= 64);
-    if (candidates.length === 0) return frame;
+    if (candidates.length === 0) return { frame };
     const placeholders = candidates.map(() => "?").join(", ");
-    const rows = await this.env.DB.prepare(
-      `SELECT name, nickname FROM agent_nicknames WHERE nickname COLLATE NOCASE IN (${placeholders})`,
-    )
-      .bind(...candidates)
-      .all<{ name: string; nickname: string }>()
-      .catch(() => ({ results: [] as { name: string; nickname: string }[] }));
-    if (rows.results.length === 0) return frame;
-    const routed = new Set(mentions);
-    for (const row of rows.results) {
-      if (typeof row.name !== "string" || !MENTION_NAME_RE.test(row.name)) continue;
-      routed.add(row.name);
-      if (routed.size >= MAX_MENTIONS) break;
+    type AliasRow = { target: string; alias: string };
+    let remote: AliasRow[];
+    try {
+      const [tokens, nicknames, handles, squads] = await Promise.all([
+        this.env.DB.prepare(
+          `SELECT name AS target, name AS alias FROM tokens
+            WHERE revoked_at IS NULL AND name COLLATE NOCASE IN (${placeholders})`,
+        ).bind(...candidates).all<AliasRow>(),
+        this.env.DB.prepare(
+          `SELECT name AS target, nickname AS alias FROM agent_nicknames
+            WHERE nickname COLLATE NOCASE IN (${placeholders})`,
+        ).bind(...candidates).all<AliasRow>(),
+        this.env.DB.prepare(
+          `SELECT handle AS target, handle AS alias FROM account_profiles
+            WHERE handle COLLATE NOCASE IN (${placeholders})`,
+        ).bind(...candidates).all<AliasRow>(),
+        this.env.DB.prepare(
+          `SELECT name AS target, name AS alias FROM channel_squads
+            WHERE channel_slug = ? AND name COLLATE NOCASE IN (${placeholders})`,
+        ).bind(this.name, ...candidates).all<AliasRow>(),
+      ]);
+      remote = [...tokens.results, ...nicknames.results, ...handles.results, ...squads.results];
+    } catch {
+      return { frame, error: "mention validation unavailable; retry" };
     }
-    return withExpandedMentions(frame, [...routed]);
+
+    // Recent channel identities remain valid routing targets even if their token was later rotated/revoked.
+    const local = this.ctx.storage.sql
+      .exec(
+        `SELECT sender_name, sender_kind, sender_handle FROM messages
+          WHERE sender_name IS NOT NULL ORDER BY seq DESC LIMIT 1000`,
+      )
+      .toArray();
+    const localPresence = this.ctx.storage.sql
+      .exec("SELECT name, kind, handle FROM presence")
+      .toArray();
+    const localWebhooks = this.ctx.storage.sql
+      .exec("SELECT name FROM webhooks")
+      .toArray();
+    const aliases = new Map<string, Set<string>>();
+    const add = (alias: unknown, target: unknown) => {
+      if (typeof alias !== "string" || typeof target !== "string" || alias === "" || target === "") return;
+      const key = alias.toLocaleLowerCase("en-US");
+      const targets = aliases.get(key) ?? new Set<string>();
+      targets.add(target);
+      aliases.set(key, targets);
+    };
+    for (const row of remote) add(row.alias, row.target);
+    for (const row of local) {
+      const name = String(row.sender_name);
+      add(name, name);
+      if (String(row.sender_kind) === "human" && row.sender_handle !== null) {
+        add(String(row.sender_handle), String(row.sender_handle));
+      }
+    }
+    for (const row of localPresence) {
+      const name = String(row.name);
+      add(name, name);
+      if (String(row.kind) === "human" && row.handle !== null) add(String(row.handle), String(row.handle));
+    }
+    for (const row of localWebhooks) add(String(row.name), String(row.name));
+
+    const routed: string[] = [];
+    const seen = new Set<string>();
+    for (const raw of candidates) {
+      if (raw.toLocaleLowerCase("en-US") === "all" || raw === "全体") {
+        return { frame, error: `unsupported mention @${raw}` };
+      }
+      const targets = aliases.get(raw.toLocaleLowerCase("en-US"));
+      if (!targets || targets.size === 0) return { frame, error: `unknown mention @${raw}` };
+      if (targets.size !== 1) return { frame, error: `ambiguous mention @${raw}` };
+      const target = [...targets][0]!;
+      if (target === "system" || seen.has(target)) continue;
+      seen.add(target);
+      routed.push(target);
+      if (routed.length >= MAX_MENTIONS) break;
+    }
+    return { frame: withExpandedMentions(frame, routed) };
   }
 
   // #544：reply_to 本身就是一条明确的定向消息。若原消息作者是 agent，即使回复正文没有再写
@@ -4050,8 +4113,11 @@ export class ChannelDO extends Server<Env> {
       return { ok: false, code: "too_large", message: `body exceeds ${BODY_LIMIT} bytes` };
     }
     frame = this.expandAgentReplyMention(frame, identity.name);
-    frame = await this.expandSquadMentions(frame);
-    frame = await this.resolveNicknameMentions(frame);
+    const resolvedMentions = await this.resolveMentionTargets(frame);
+    if (resolvedMentions.error !== undefined) {
+      return { ok: false, code: "bad_request", message: resolvedMentions.error };
+    }
+    frame = await this.expandSquadMentions(resolvedMentions.frame);
     const workflowGuard = this.workflowGuardDecision(identity, frame);
     if (workflowGuard !== null) {
       const row = this.workflowGuardRow(workflowGuard.workflow.workflow_id);

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -3965,28 +3965,38 @@ export class ChannelDO extends Server<Env> {
     const candidates = mentions.filter((t) => t !== "system" && t.length <= 64);
     if (candidates.length === 0) return { frame };
     const placeholders = candidates.map(() => "?").join(", ");
+    // Pure-CJK aliases have no lexical boundary before following prose
+    // (`请@小明看一下`). Load aliases that are prefixes of the raw token; the
+    // resolver below applies longest-match and still fails closed on ties.
+    const nicknamePrefixes = candidates.map(() => "? LIKE nickname || '%'").join(" OR ");
+    const displayNamePrefixes = candidates.map(() => "? LIKE display_name || '%'").join(" OR ");
     type AliasRow = { target: string; alias: string };
     let remote: AliasRow[];
     try {
-      const [tokens, nicknames, handles, squads] = await Promise.all([
+      const [tokens, nicknames, handles, displayNames, squads] = await Promise.all([
         this.env.DB.prepare(
           `SELECT name AS target, name AS alias FROM tokens
             WHERE revoked_at IS NULL AND name COLLATE NOCASE IN (${placeholders})`,
         ).bind(...candidates).all<AliasRow>(),
         this.env.DB.prepare(
           `SELECT name AS target, nickname AS alias FROM agent_nicknames
-            WHERE nickname COLLATE NOCASE IN (${placeholders})`,
-        ).bind(...candidates).all<AliasRow>(),
+            WHERE nickname COLLATE NOCASE IN (${placeholders}) OR (${nicknamePrefixes})`,
+        ).bind(...candidates, ...candidates).all<AliasRow>(),
         this.env.DB.prepare(
           `SELECT handle AS target, handle AS alias FROM account_profiles
             WHERE handle COLLATE NOCASE IN (${placeholders})`,
         ).bind(...candidates).all<AliasRow>(),
         this.env.DB.prepare(
+          `SELECT handle AS target, display_name AS alias FROM account_profiles
+            WHERE display_name IS NOT NULL
+              AND (display_name COLLATE NOCASE IN (${placeholders}) OR (${displayNamePrefixes}))`,
+        ).bind(...candidates, ...candidates).all<AliasRow>(),
+        this.env.DB.prepare(
           `SELECT name AS target, name AS alias FROM channel_squads
             WHERE channel_slug = ? AND name COLLATE NOCASE IN (${placeholders})`,
         ).bind(this.name, ...candidates).all<AliasRow>(),
       ]);
-      remote = [...tokens.results, ...nicknames.results, ...handles.results, ...squads.results];
+      remote = [...tokens.results, ...nicknames.results, ...handles.results, ...displayNames.results, ...squads.results];
     } catch {
       return { frame, error: "mention validation unavailable; retry" };
     }
@@ -3994,12 +4004,12 @@ export class ChannelDO extends Server<Env> {
     // Recent channel identities remain valid routing targets even if their token was later rotated/revoked.
     const local = this.ctx.storage.sql
       .exec(
-        `SELECT sender_name, sender_kind, sender_handle FROM messages
+        `SELECT sender_name, sender_kind, sender_handle, sender_display_name FROM messages
           WHERE sender_name IS NOT NULL ORDER BY seq DESC LIMIT 1000`,
       )
       .toArray();
     const localPresence = this.ctx.storage.sql
-      .exec("SELECT name, kind, handle FROM presence")
+      .exec("SELECT name, kind, handle, display_name FROM presence")
       .toArray();
     const localWebhooks = this.ctx.storage.sql
       .exec("SELECT name FROM webhooks")
@@ -4019,11 +4029,21 @@ export class ChannelDO extends Server<Env> {
       if (String(row.sender_kind) === "human" && row.sender_handle !== null) {
         add(String(row.sender_handle), String(row.sender_handle));
       }
+      if (row.sender_display_name !== null) {
+        const target = String(row.sender_kind) === "human" && row.sender_handle !== null
+          ? String(row.sender_handle)
+          : name;
+        add(String(row.sender_display_name), target);
+      }
     }
     for (const row of localPresence) {
       const name = String(row.name);
       add(name, name);
       if (String(row.kind) === "human" && row.handle !== null) add(String(row.handle), String(row.handle));
+      if (row.display_name !== null) {
+        const target = String(row.kind) === "human" && row.handle !== null ? String(row.handle) : name;
+        add(String(row.display_name), target);
+      }
     }
     for (const row of localWebhooks) add(String(row.name), String(row.name));
 
@@ -4033,7 +4053,21 @@ export class ChannelDO extends Server<Env> {
       if (raw.toLocaleLowerCase("en-US") === "all" || raw === "全体") {
         return { frame, error: `unsupported mention @${raw}` };
       }
-      const targets = aliases.get(raw.toLocaleLowerCase("en-US"));
+      const key = raw.toLocaleLowerCase("en-US");
+      let targets = aliases.get(key);
+      if (!targets) {
+        let longest = 0;
+        for (const [alias, aliasTargets] of aliases) {
+          if (!key.startsWith(alias) || alias.length < longest) continue;
+          if (alias.length > longest) {
+            longest = alias.length;
+            targets = new Set(aliasTargets);
+          } else {
+            targets ??= new Set<string>();
+            for (const target of aliasTargets) targets.add(target);
+          }
+        }
+      }
       if (!targets || targets.size === 0) return { frame, error: `unknown mention @${raw}` };
       if (targets.size !== 1) return { frame, error: `ambiguous mention @${raw}` };
       const target = [...targets][0]!;

--- a/worker/test/serve-watch-wake-ledger.spec.ts
+++ b/worker/test/serve-watch-wake-ledger.spec.ts
@@ -147,12 +147,16 @@ describe("#107 serve/watch wakes land in the server-side wake ledger", () => {
     }
   });
 
-  it("does NOT record a serve/watch row for a mention with no wakeable presence", async () => {
+  it("rejects an unknown mention and does NOT record a serve/watch row", async () => {
     const sender = await seedToken("agent");
     const ghost = uniq("ghost"); // never registered any presence
     const slug = await createChannel(sender.token);
 
-    expect((await sendMessage(slug, sender.token, `@${ghost} anybody?`, [ghost])).status).toBe(200);
+    const res = await sendMessage(slug, sender.token, `@${ghost} anybody?`, [ghost]);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({
+      error: { code: "bad_request", message: `unknown mention @${ghost}` },
+    });
     await new Promise((r) => setTimeout(r, 50));
 
     expect(await ledgerRows(slug)).toEqual([]);

--- a/worker/test/ws.spec.ts
+++ b/worker/test/ws.spec.ts
@@ -149,7 +149,17 @@ describe("websocket", () => {
     ws.send({ type: "send", kind: "message", body: "请@ghost看一下", mentions: [], reply_to: null });
     const error = await ws.nextOfType("error");
     expect(error).toMatchObject({ code: "bad_request", message: "unknown mention @ghost" });
+    ws.send({ type: "send", kind: "message", body: "请@bobcat看一下", mentions: [], reply_to: null });
+    expect(await ws.nextOfType("error")).toMatchObject({
+      code: "bad_request",
+      message: "unknown mention @bobcat",
+    });
     ws.send({ type: "send", kind: "message", body: "请 @全体 看一下", mentions: [], reply_to: null });
+    expect(await ws.nextOfType("error")).toMatchObject({
+      code: "bad_request",
+      message: "unsupported mention @全体",
+    });
+    ws.send({ type: "send", kind: "message", body: "请@全体看一下", mentions: [], reply_to: null });
     expect(await ws.nextOfType("error")).toMatchObject({
       code: "bad_request",
       message: "unsupported mention @全体",

--- a/worker/test/ws.spec.ts
+++ b/worker/test/ws.spec.ts
@@ -97,6 +97,10 @@ describe("websocket", () => {
     await env.DB.prepare(
       "INSERT INTO agent_nicknames (name, nickname, created_at, updated_at) VALUES (?, ?, ?, ?)",
     ).bind(nicknameTarget.name, "程序员小明", Date.now(), Date.now()).run();
+    await env.DB.prepare(
+      `INSERT INTO account_profiles (account, handle, created_at, updated_at, display_name)
+       VALUES (?, ?, ?, ?, ?)`,
+    ).bind("account-552", "display552", Date.now(), Date.now(), "测试同事").run();
     const slug = await createChannel(token);
     const ws = await WsClient.open(slug, token);
     await ws.nextOfType("welcome");
@@ -113,13 +117,23 @@ describe("websocket", () => {
     ws.send({
       type: "send",
       kind: "message",
-      body: "请@agent-a看一下，（@程序员小明）也帮忙；a@example.com 不算",
+      body: "请@agent-a看一下，也请@程序员小明帮忙；a@example.com 不算",
       mentions: [],
       reply_to: null,
     });
     await ws.nextOfType("sent");
     const echo3 = await ws.nextOfType("msg");
     expect(echo3.mentions).toEqual(["agent-a", nicknameTarget.name]);
+    ws.send({
+      type: "send",
+      kind: "message",
+      body: "请@测试同事确认一下",
+      mentions: [],
+      reply_to: null,
+    });
+    await ws.nextOfType("sent");
+    const echo4 = await ws.nextOfType("msg");
+    expect(echo4.mentions).toEqual(["display552"]);
 
     await seedToken("agent", "collision552");
     const ambiguousTarget = await seedToken("agent");

--- a/worker/test/ws.spec.ts
+++ b/worker/test/ws.spec.ts
@@ -95,12 +95,16 @@ describe("websocket", () => {
     await seedToken("agent", "agent-a");
     const nicknameTarget = await seedToken("agent");
     const unicodeCaseTarget = await seedToken("agent");
+    const asciiCaseTarget = await seedToken("agent");
     await env.DB.prepare(
       "INSERT INTO agent_nicknames (name, nickname, created_at, updated_at) VALUES (?, ?, ?, ?)",
     ).bind(nicknameTarget.name, "程序员小明", Date.now(), Date.now()).run();
     await env.DB.prepare(
       "INSERT INTO agent_nicknames (name, nickname, created_at, updated_at) VALUES (?, ?, ?, ?)",
     ).bind(unicodeCaseTarget.name, "Éclair", Date.now(), Date.now()).run();
+    await env.DB.prepare(
+      "INSERT INTO agent_nicknames (name, nickname, created_at, updated_at) VALUES (?, ?, ?, ?)",
+    ).bind(asciiCaseTarget.name, "CaseNick", Date.now(), Date.now()).run();
     await env.DB.prepare(
       `INSERT INTO account_profiles (account, handle, created_at, updated_at, display_name)
        VALUES (?, ?, ?, ?, ?)`,
@@ -146,6 +150,9 @@ describe("websocket", () => {
       code: "bad_request",
       message: "unknown mention @éclair",
     });
+    ws.send({ type: "send", kind: "message", body: "请 @casenick 确认", mentions: [], reply_to: null });
+    await ws.nextOfType("sent");
+    expect((await ws.nextOfType("msg")).mentions).toEqual([asciiCaseTarget.name]);
 
     await seedToken("agent", "collision552");
     const ambiguousTarget = await seedToken("agent");

--- a/worker/test/ws.spec.ts
+++ b/worker/test/ws.spec.ts
@@ -94,9 +94,13 @@ describe("websocket", () => {
     await seedToken("agent", "carol.dev");
     await seedToken("agent", "agent-a");
     const nicknameTarget = await seedToken("agent");
+    const unicodeCaseTarget = await seedToken("agent");
     await env.DB.prepare(
       "INSERT INTO agent_nicknames (name, nickname, created_at, updated_at) VALUES (?, ?, ?, ?)",
     ).bind(nicknameTarget.name, "程序员小明", Date.now(), Date.now()).run();
+    await env.DB.prepare(
+      "INSERT INTO agent_nicknames (name, nickname, created_at, updated_at) VALUES (?, ?, ?, ?)",
+    ).bind(unicodeCaseTarget.name, "Éclair", Date.now(), Date.now()).run();
     await env.DB.prepare(
       `INSERT INTO account_profiles (account, handle, created_at, updated_at, display_name)
        VALUES (?, ?, ?, ?, ?)`,
@@ -134,6 +138,14 @@ describe("websocket", () => {
     await ws.nextOfType("sent");
     const echo4 = await ws.nextOfType("msg");
     expect(echo4.mentions).toEqual(["display552"]);
+    ws.send({ type: "send", kind: "message", body: "请 @Éclair 确认", mentions: [], reply_to: null });
+    await ws.nextOfType("sent");
+    expect((await ws.nextOfType("msg")).mentions).toEqual([unicodeCaseTarget.name]);
+    ws.send({ type: "send", kind: "message", body: "请 @éclair 确认", mentions: [], reply_to: null });
+    expect(await ws.nextOfType("error")).toMatchObject({
+      code: "bad_request",
+      message: "unknown mention @éclair",
+    });
 
     await seedToken("agent", "collision552");
     const ambiguousTarget = await seedToken("agent");
@@ -163,6 +175,11 @@ describe("websocket", () => {
     expect(await ws.nextOfType("error")).toMatchObject({
       code: "bad_request",
       message: "unsupported mention @全体",
+    });
+    ws.send({ type: "send", kind: "message", body: "reserved", mentions: ["SYSTEM"], reply_to: null });
+    expect(await ws.nextOfType("error")).toMatchObject({
+      code: "bad_request",
+      message: "reserved mention @system",
     });
     ws.close();
   });

--- a/worker/test/ws.spec.ts
+++ b/worker/test/ws.spec.ts
@@ -90,20 +90,56 @@ describe("websocket", () => {
 
   it("extracts @name from the body into mentions (bare send should wake the target)", async () => {
     const { token } = await seedToken("agent");
+    await seedToken("agent", "bob");
+    await seedToken("agent", "carol.dev");
+    await seedToken("agent", "agent-a");
+    const nicknameTarget = await seedToken("agent");
+    await env.DB.prepare(
+      "INSERT INTO agent_nicknames (name, nickname, created_at, updated_at) VALUES (?, ?, ?, ?)",
+    ).bind(nicknameTarget.name, "程序员小明", Date.now(), Date.now()).run();
     const slug = await createChannel(token);
     const ws = await WsClient.open(slug, token);
     await ws.nextOfType("welcome");
     // 正文打 @bob，mentions 数组留空——服务端应把 bob 提取进 mentions
-    ws.send({ type: "send", kind: "message", body: "hey @bob and @carol.dev, ping", mentions: [], reply_to: null });
+    ws.send({ type: "send", kind: "message", body: "hey @BOB and @carol.dev, ping", mentions: [], reply_to: null });
     await ws.nextOfType("sent");
     const echo = await ws.nextOfType("msg");
-    expect(echo.mentions).toContain("bob");
-    expect(echo.mentions).toContain("carol.dev");
+    expect(echo.mentions).toEqual(["bob", "carol.dev"]);
     // email 里的 @ 不算，显式 mention 与正文 @ 去重合并
     ws.send({ type: "send", kind: "message", body: "mail me@x.com about @bob", mentions: ["bob"], reply_to: null });
     await ws.nextOfType("sent");
     const echo2 = await ws.nextOfType("msg");
     expect(echo2.mentions).toEqual(["bob"]); // 去重，且 me@x.com 不误提
+    ws.send({
+      type: "send",
+      kind: "message",
+      body: "请@agent-a看一下，（@程序员小明）也帮忙；a@example.com 不算",
+      mentions: [],
+      reply_to: null,
+    });
+    await ws.nextOfType("sent");
+    const echo3 = await ws.nextOfType("msg");
+    expect(echo3.mentions).toEqual(["agent-a", nicknameTarget.name]);
+
+    await seedToken("agent", "collision552");
+    const ambiguousTarget = await seedToken("agent");
+    await env.DB.prepare(
+      "INSERT INTO agent_nicknames (name, nickname, created_at, updated_at) VALUES (?, ?, ?, ?)",
+    ).bind(ambiguousTarget.name, "collision552", Date.now(), Date.now()).run();
+    ws.send({ type: "send", kind: "message", body: "请@collision552看一下", mentions: [], reply_to: null });
+    expect(await ws.nextOfType("error")).toMatchObject({
+      code: "bad_request",
+      message: "ambiguous mention @collision552",
+    });
+
+    ws.send({ type: "send", kind: "message", body: "请@ghost看一下", mentions: [], reply_to: null });
+    const error = await ws.nextOfType("error");
+    expect(error).toMatchObject({ code: "bad_request", message: "unknown mention @ghost" });
+    ws.send({ type: "send", kind: "message", body: "请 @全体 看一下", mentions: [], reply_to: null });
+    expect(await ws.nextOfType("error")).toMatchObject({
+      code: "bad_request",
+      message: "unsupported mention @全体",
+    });
     ws.close();
   });
 


### PR DESCRIPTION
## 改动说明

修复 #552：Web、CLI、Worker 共用正文 mention lexer，支持 CJK 连续正文、全角标点和 Unicode 昵称，并排除 ASCII email。Worker 将 token 大小写、昵称、human handle/display name、squad 解析为唯一权威目标；未知、歧义及未支持的 `@all/@全体` 返回可见 `bad_request`，不再落假成功消息。纯中文昵称与后续正文无分隔时，按已知别名最长匹配，最长项仍冲突则 fail closed。

回复作者来自频道权威消息行，在用户 mention 校验后自动追加，不受最近别名窗口影响。CLI 显式与正文 mention 合计限制为共享上限 50。ASCII token/handle/ASCII-form alias 大小写不敏感；Unicode nickname/display_name 采用 NFC 精确匹配。

AgentParty identity: `codex-002`

Closes #552

## 合并前检查（review-ack 强制闸——不留结论合不了）

- [x] 我已读当前 head 的 pr-agent / CodeRabbit review，真问题已处理、误报已判明
- [x] 本地门禁通过（shared/Web/CLI/Worker tsc、Web build；Web 794、CLI 762、Worker 543 tests；追加目标回归测试通过）
- [x] 涉及安全/鉴权/数据的改动已做对抗性验证（email 误判、大小写、昵称/display name、歧义、未知目标、全体提及、mention 上限、reply_to 与 wake ledger）

## 验证

- `bun run check:shared`
- `bun run check:web`
- `bun run check:cli`
- `bun run check:worker`
- Worker 目标 mention / reply / webhook / wake-ledger 套件
- 合并部署后仅在 `qa-issues-20260714` 测试频道做真实 smoke

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 正文提及与显式提及合并去重并保持顺序（显式优先），统一归一化规则并受 50 条上限约束；后端会将提及解析为明确目标并完成后续扩展。
  * Web/CLI 的提及识别更适配中文紧贴 `@`、中文括号/标点包裹等场景，同时避免邮箱类误触发。
* **错误修复**
  * 保留字（SYSTEM）、未知/歧义/不支持（如全体）提及将直接拒收；未知提及不再记录唤醒账本。
* **测试**
  * 更新并补充提及解析、触发边界、去重/顺序、上限截断与拒收行为用例。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->