### PR TITLE
fix(web): 重排频道工具栏两行布局

### DIFF
--- a/web/src/components/PresenceBar.test.ts
+++ b/web/src/components/PresenceBar.test.ts
@@ -271,6 +271,21 @@ describe("presence client version", () => {
   });
 });
 
+describe("presence header controls", () => {
+  test("renders channel controls on the top row before the connection status", () => {
+    const controls = createElement("button", { type: "button" }, "Visibility");
+    const r = renderWith(presenceEntry(), { headerControls: controls });
+    const head = nodesWithClass(r, "presence-head")[0];
+
+    expect(head?.children.map((child) => typeof child === "string" ? child : child.props.className)).toEqual([
+      "presence-meta",
+      "presence-channel-controls",
+      "conn t-mono",
+    ]);
+    expect(nodesWithClass(r, "presence-channel-controls")[0]?.findByType("button").children).toEqual(["Visibility"]);
+  });
+});
+
 // busy + 队列深度（#103）：serve 串行处理长任务时，presence 要显式表达「忙 + N 待处理」，
 // 与 working 蜡笔点区分，让人别把「@ 了没立刻回」当失联。
 describe("busy indicator + queue depth (#103)", () => {

--- a/web/src/components/PresenceBar.tsx
+++ b/web/src/components/PresenceBar.tsx
@@ -1,7 +1,7 @@
 // 顶部 presence 条：每参与者一个手绘胶囊（名字 + 蜡笔状态点 + note + 相对时间），
 // 右端挂连接状态。"对方卡在哪"一眼可见（spec §9 第 3 块）。
 import { evaluateHostLease, wakeableState, type ChannelRoleAssignment, type PresenceEntry, type PresenceState, type Sender } from "@agentparty/shared";
-import { useCallback, useEffect, useRef, useState, type CSSProperties, type ReactNode } from "react";
+import { useCallback, useEffect, useRef, useState, type CSSProperties, type ReactElement } from "react";
 import { agentHue } from "../lib/agentColor";
 import { fmtRel } from "../lib/time";
 import type { SocketStatus } from "../lib/ws";
@@ -23,7 +23,7 @@ interface Props {
   onPauseAgent?: (name: string, resumeAt: number | null) => void;
   onResumeAgent?: (name: string) => void;
   roles?: ChannelRoleAssignment[];
-  headerControls?: ReactNode;
+  headerControls?: ReactElement | null;
   // issue #272（审计重开）：点 presence roster 里的某个人/agent，打开它的单 Agent 详情弹窗。
   onOpenAgentDetail?: (name: string) => void;
 }

--- a/web/src/components/PresenceBar.tsx
+++ b/web/src/components/PresenceBar.tsx
@@ -1,7 +1,7 @@
 // 顶部 presence 条：每参与者一个手绘胶囊（名字 + 蜡笔状态点 + note + 相对时间），
 // 右端挂连接状态。"对方卡在哪"一眼可见（spec §9 第 3 块）。
 import { evaluateHostLease, wakeableState, type ChannelRoleAssignment, type PresenceEntry, type PresenceState, type Sender } from "@agentparty/shared";
-import { useCallback, useEffect, useRef, useState, type CSSProperties } from "react";
+import { useCallback, useEffect, useRef, useState, type CSSProperties, type ReactNode } from "react";
 import { agentHue } from "../lib/agentColor";
 import { fmtRel } from "../lib/time";
 import type { SocketStatus } from "../lib/ws";
@@ -23,6 +23,7 @@ interface Props {
   onPauseAgent?: (name: string, resumeAt: number | null) => void;
   onResumeAgent?: (name: string) => void;
   roles?: ChannelRoleAssignment[];
+  headerControls?: ReactNode;
   // issue #272（审计重开）：点 presence roster 里的某个人/agent，打开它的单 Agent 详情弹窗。
   onOpenAgentDetail?: (name: string) => void;
 }
@@ -240,6 +241,7 @@ export function PresenceBar({
   onPauseAgent,
   onResumeAgent,
   roles = [],
+  headerControls,
   onOpenAgentDetail,
 }: Props) {
   const t = useT();
@@ -751,6 +753,9 @@ export function PresenceBar({
             <span className="presence-toggle-arrow" aria-hidden="true">{rosterOpen ? "▾" : "▸"}</span>
           </button>
         </div>
+        {headerControls !== undefined && headerControls !== null && (
+          <div className="presence-channel-controls">{headerControls}</div>
+        )}
         <span className="conn t-mono" data-s={status} role="status" aria-live="polite">
           {status === "open" ? "● live" : `◌ ${status}…`}
         </span>

--- a/web/src/i18n/strings/Channel.i18n.source.test.ts
+++ b/web/src/i18n/strings/Channel.i18n.source.test.ts
@@ -174,7 +174,11 @@ describe("Channel i18n source guard (#350)", () => {
     expect(source).toContain("onlineAgentCount");
   });
 
-  test("orders channel tools by content, members, access, then channel management", () => {
+  test("places visibility on the presence row and right-aligns channel management after content tools", () => {
+    const presence = source.slice(
+      source.indexOf("<PresenceBar"),
+      source.indexOf("<ChannelToolstrip"),
+    );
     const toolbar = source.slice(
       source.indexOf("<ChannelToolstrip"),
       source.indexOf("{activePanel !== null"),
@@ -186,7 +190,6 @@ describe("Channel i18n source guard (#350)", () => {
       'openPanel("search")',
       "<AgentJoin",
       "<AgentTokens",
-      "<VisibilityToggle",
       "<JoinLink",
       'openPanel("settings")',
       'className="d-btn archive-channel-btn"',
@@ -195,6 +198,9 @@ describe("Channel i18n source guard (#350)", () => {
 
     expect(positions.every((position) => position >= 0)).toBe(true);
     expect(positions).toEqual([...positions].sort((a, b) => a - b));
+    expect(presence).toContain("headerControls=");
+    expect(presence).toContain("<VisibilityToggle");
+    expect(toolbar).not.toContain("<VisibilityToggle");
     expect(toolbar).toContain('className="chan-admin-group chan-admin-group--agents"');
     expect(toolbar).toContain('className="chan-admin-group chan-admin-group--access"');
     expect(toolbar).toContain('className="chan-admin-group chan-admin-group--channel"');

--- a/web/src/i18n/strings/Channel.i18n.source.test.ts
+++ b/web/src/i18n/strings/Channel.i18n.source.test.ts
@@ -195,11 +195,19 @@ describe("Channel i18n source guard (#350)", () => {
       'className="d-btn archive-channel-btn"',
     ];
     const positions = controls.map((control) => toolbar.indexOf(control));
+    const headerControlsStart = presence.indexOf("headerControls={");
+    const headerControlsEndMarker = "\n        ) : null}";
+    const headerControlsEnd = presence.indexOf(headerControlsEndMarker, headerControlsStart);
+    const headerControls = presence.slice(
+      headerControlsStart,
+      headerControlsEnd + headerControlsEndMarker.length,
+    );
 
     expect(positions.every((position) => position >= 0)).toBe(true);
     expect(positions).toEqual([...positions].sort((a, b) => a - b));
-    expect(presence).toContain("headerControls=");
-    expect(presence).toContain("<VisibilityToggle");
+    expect(headerControlsStart).toBeGreaterThanOrEqual(0);
+    expect(headerControlsEnd).toBeGreaterThan(headerControlsStart);
+    expect(headerControls).toContain("<VisibilityToggle");
     expect(toolbar).not.toContain("<VisibilityToggle");
     expect(toolbar).toContain('className="chan-admin-group chan-admin-group--agents"');
     expect(toolbar).toContain('className="chan-admin-group chan-admin-group--access"');

--- a/web/src/pages/Channel.tsx
+++ b/web/src/pages/Channel.tsx
@@ -4102,6 +4102,15 @@ export function ChannelPage({
         onResumeAgent={resumeAgentReception}
         roles={channelRoles}
         onOpenAgentDetail={setOpenAgentDetail}
+        headerControls={canModerate && !state.archived ? (
+          <VisibilityToggle
+            slug={slug}
+            token={token}
+            visibility={localVisibility}
+            onChanged={setLocalVisibility}
+            onAuthFailed={onAuthFailed}
+          />
+        ) : null}
       />
       {kickError !== null && <p className="banner banner--red">{kickError}</p>}
       {pauseError !== null && <p className="banner banner--red">{pauseError}</p>}
@@ -4185,13 +4194,6 @@ export function ChannelPage({
               )}
               {canModerate && !state.archived && (
                 <div className="chan-admin-group chan-admin-group--access">
-                  <VisibilityToggle
-                    slug={slug}
-                    token={token}
-                    visibility={localVisibility}
-                    onChanged={setLocalVisibility}
-                    onAuthFailed={onAuthFailed}
-                  />
                   <JoinLink
                     slug={slug}
                     token={token}

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -1160,6 +1160,15 @@
 .presence-head .conn {
   margin-left: auto;
 } /* ● live 推到第一行最右 */
+.presence-channel-controls {
+  display: flex;
+  align-items: center;
+  flex: 0 0 auto;
+  margin-left: auto;
+}
+.presence-channel-controls + .conn {
+  margin-left: 0;
+}
 .presence-meta,
 .presence-strip {
   display: flex;
@@ -3143,6 +3152,7 @@
 }
 .chan-tool-actions {
   flex: 0 0 auto;
+  margin-left: auto;
   justify-content: flex-start;
 }
 .chan-admin-actions {
@@ -3294,7 +3304,7 @@
 .vis-seg-btn:last-child { border-right: 0; }
 .vis-seg-btn.is-on { background: var(--d-ink); color: var(--t-panel); }
 .vis-seg-btn:disabled:not(.is-on) { opacity: 0.55; cursor: default; }
-/* 功能与管理控件共用一条横向轨道。常见宽屏直接铺开；空间不足时滚动，
+/* 内容入口靠左、管理控件靠右，共用一条横向轨道。空间不足时滚动，
    邀请面板改为视口底部浮层，避免被滚动容器裁切。 */
 @media (max-width: 1759px) {
   .chan-toolstrip-content {
@@ -3303,6 +3313,23 @@
     -webkit-overflow-scrolling: touch;
     scrollbar-width: thin;
     padding-bottom: 2px;
+  }
+  /* A regular 1440px desktop still has room for both semantic groups when the
+     controls use their compact density. Keep every action visible before
+     falling back to horizontal scrolling at genuinely narrow widths. */
+  .chan-toolstrip-content,
+  .chan-tool-buttons,
+  .chan-tool-actions,
+  .chan-admin-group {
+    gap: 4px;
+  }
+  .chan-tool-btn {
+    padding-inline: 6px;
+    font-size: 11.5px;
+  }
+  .chan-admin-group + .chan-admin-group {
+    margin-left: 4px;
+    padding-left: 5px;
   }
   .joinlink-panel {
     position: fixed;

--- a/web/src/styles/app.visibilityToggle.test.ts
+++ b/web/src/styles/app.visibilityToggle.test.ts
@@ -14,13 +14,16 @@ function ruleBody(selector: string): string {
 }
 
 describe("channel visibility controls layout", () => {
-  test("the toolbar uses one non-wrapping horizontal track", () => {
+  test("visibility uses the presence row while management starts at the toolbar's right edge", () => {
     expect(ruleBody(".chan-toolstrip")).toContain("flex-wrap: nowrap");
     expect(ruleBody(".chan-toolstrip-content")).toContain("overflow: visible");
     expect(css).toMatch(/@media \(max-width: 1759px\)[\s\S]*\.chan-toolstrip-content\s*{[^}]*overflow-x:\s*auto;/s);
     expect(css).toMatch(/\.chan-tool-buttons,\s*\.chan-tool-actions,\s*\.chan-admin-actions,\s*\.chan-admin-group\s*{[^}]*flex-wrap:\s*nowrap;/s);
+    expect(ruleBody(".chan-tool-actions")).toContain("margin-left: auto");
+    expect(ruleBody(".presence-channel-controls")).toContain("margin-left: auto");
     expect(ruleBody(".chan-admin-actions")).toContain("gap: 0");
     expect(ruleBody(".chan-admin-group + .chan-admin-group")).toContain("border-left: 1.4px solid var(--t-faint)");
+    expect(css).toMatch(/@media \(max-width: 1759px\)[\s\S]*\.chan-tool-btn\s*{[^}]*padding-inline:\s*6px;[^}]*font-size:\s*11\.5px;/s);
     expect(ruleBody(".chan-toolstrip-content")).not.toContain("flex-direction: column");
   });
 });


### PR DESCRIPTION
## 改动说明
- 将频道可见性控制从操作工具条移到顶部在线状态行右侧
- 第二行保留内容入口在左侧，并以“让 agent 加入”为分界将管理操作整体右对齐
- 为 1440px 桌面宽度增加紧凑密度，确保设置和归档不被裁切；移动端维持单行横向滚动
- 增加组件顺序、源码布局和响应式 CSS 回归测试

## 验证
- [x] `bun run check`
- [x] Chrome 实机 QA：2048x900、1440x900、390x844
- [x] 设置弹窗开关正常；浏览器无 runtime error
- [x] `git diff --check`

## 合并前检查（review-ack 强制闸——不留结论合不了）
- [ ] 我已读 pr-agent / CodeRabbit 的 review，真问题已处理、误报已判明
- [x] 本地门禁通过（tsc / 测试 / build）
- [x] 不涉及安全/鉴权/数据路径

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 频道可见性切换控件已集成到状态栏顶部的头部控制区域（仅在未归档且具备权限时显示）。
* **界面优化**
  * 调整顶部存在状态栏与频道工具条的左右分区与间距；窄屏下同步收紧布局间隙，减少换行与溢出。
* **测试**
  * 更新并新增可见性控件在顶部区域的渲染/排列与布局样式断言，覆盖窄屏与对齐边界场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->