### PR TITLE
fix(ws): 串行化 hello 与后续控制帧

### DIFF
--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -347,7 +347,6 @@ export function connect(
       // 拒绝/半坏实例）会退化成 ~1 次/秒的无限紧循环锤服务端。改到收到首个业务帧才清零
       // （见 onmessage：解析成功=连接真实可用）。
       helloSince = cursor;
-      opts.onStatus?.("open");
       armInboundWatchdog();
       sock.send(JSON.stringify({
         type: "hello",
@@ -356,6 +355,9 @@ export function connect(
         client_version: pkg.version,
         ...(opts.directedDelivery === "v1" ? { directed_delivery: "v1" as const } : {}),
       }));
+      // External status callbacks may synchronously send an actionable frame on reconnect. Publish
+      // OPEN only after hello is on the wire so no callback can overtake the mandatory handshake.
+      opts.onStatus?.("open");
       stopPing();
       pingTimer = setInterval(() => {
         if (sock.readyState === WebSocket.OPEN) sock.send(JSON.stringify({ type: "ping" }));

--- a/cli/test/client.test.ts
+++ b/cli/test/client.test.ts
@@ -405,6 +405,25 @@ describe("ws client", () => {
     expect(statuses.map((s) => s.status)).toEqual(["open", "reconnecting", "open"]);
   });
 
+  test("puts hello on the wire before an open callback can synchronously send an actionable frame", () => {
+    useProbeWebSocket();
+    conn = connect("https://party.invalid", "ap_tok", "dev", 0, {
+      onStatus: (status) => {
+        if (status !== "open") return;
+        expect(conn?.send({
+          type: "heartbeat",
+          current_task: null,
+          task_started_at: null,
+          heartbeat_at: null,
+        })).toBe(true);
+      },
+    });
+
+    const socket = ProbeWebSocket.instances[0]!;
+    socket.open();
+    expect(socket.sent.map((raw) => JSON.parse(raw).type)).toEqual(["hello", "heartbeat"]);
+  });
+
   test("onStatus reports closed with the fatal reason on a terminal 1008 close, and never reconnecting", async () => {
     server = startMockServer((frame, sock) => {
       if (frame.type === "hello") {

--- a/cli/test/mock-server.ts
+++ b/cli/test/mock-server.ts
@@ -21,7 +21,9 @@ export type FrameHandler = (
   connIndex: number,
 ) => void;
 
-export function startMockServer(onFrame: FrameHandler): MockServer {
+export type OpenHandler = (sock: MockSocket, connIndex: number) => void;
+
+export function startMockServer(onFrame: FrameHandler, onOpen?: OpenHandler): MockServer {
   const hellos: number[] = [];
   const auths: (string | null)[] = [];
   const paths: string[] = [];
@@ -37,6 +39,12 @@ export function startMockServer(onFrame: FrameHandler): MockServer {
       return new Response("expected websocket", { status: 400 });
     },
     websocket: {
+      open(ws) {
+        onOpen?.({
+          send: (frame) => ws.send(JSON.stringify(frame)),
+          close: (code, reason) => ws.close(code, reason),
+        }, ws.data.index);
+      },
       message(ws, raw) {
         const frame = JSON.parse(String(raw)) as ClientFrame;
         if (frame.type === "hello") hellos.push(frame.since);

--- a/cli/test/serve-cross-machine-lease.test.ts
+++ b/cli/test/serve-cross-machine-lease.test.ts
@@ -160,17 +160,18 @@ describe("serve 跨机租约客户端互斥（#99）", () => {
     const clientFrames: ClientFrame[] = [];
     server = startMockServer((frame, sock) => {
       clientFrames.push(frame);
-      if (frame.type !== "hello") return;
+      if (frame.type !== "serve_lease") return;
+      sock.send(leaseFrame(true));
+      setTimeout(() => sock.send({ type: "error", code: "archived", message: "done" }), 20);
+    }, (sock) => {
+      // Production sends welcome from onConnect, before it has processed the client's hello.
       sock.send(welcomeFrame(0, "me"));
-      setTimeout(() => sock.send({ type: "error", code: "archived", message: "done" }), 40);
     });
     const o = opts({ server: server.url, runCommand: async () => {} });
     await runServe(o);
-    const hello = clientFrames.find((f) => f.type === "hello");
-    expect(hello).toMatchObject({ directed_delivery: "v1" });
-    const claim = clientFrames.find((f) => (f as { type: string }).type === "serve_lease");
-    expect(claim).toBeDefined();
-    expect((claim as { op?: string }).op).toBe("claim");
-    expect(clientFrames.indexOf(hello!)).toBeLessThan(clientFrames.indexOf(claim!));
+    expect(clientFrames.slice(0, 2)).toMatchObject([
+      { type: "hello", directed_delivery: "v1" },
+      { type: "serve_lease", op: "claim" },
+    ]);
   });
 });

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -1301,6 +1301,10 @@ function snippetFor(frame: MsgFrame, field: SearchHit["match_field"]): string {
 export class ChannelDO extends Server<Env> {
   static options = { hibernate: true };
   private atomicDeliveryEffects: AtomicDeliveryEffects | null = null;
+  // partyserver can invoke async WebSocket handlers for the same connection while an earlier
+  // frame is awaiting I/O. Preserve wire order explicitly: hello must finish token validation and
+  // capability setup before an immediately-following serve lease / adapter / send frame runs.
+  private readonly wsMessageTails = new Map<string, Promise<void>>();
 
   onStart() {
     const sql = this.ctx.storage.sql;
@@ -2100,6 +2104,21 @@ export class ChannelDO extends Server<Env> {
   }
 
   async onMessage(connection: Connection<ConnState>, message: WSMessage) {
+    const previous = this.wsMessageTails.get(connection.id) ?? Promise.resolve();
+    const current = previous
+      .catch(() => undefined)
+      .then(() => this.onMessageSerial(connection, message));
+    this.wsMessageTails.set(connection.id, current);
+    try {
+      await current;
+    } finally {
+      if (this.wsMessageTails.get(connection.id) === current) {
+        this.wsMessageTails.delete(connection.id);
+      }
+    }
+  }
+
+  private async onMessageSerial(connection: Connection<ConnState>, message: WSMessage) {
     const badRequest = () =>
       this.sendFrame(connection, { type: "error", code: "bad_request", message: "invalid frame" });
     if (typeof message !== "string") {
@@ -2366,7 +2385,11 @@ export class ChannelDO extends Server<Env> {
     }
   }
 
-  onClose(connection: Connection<ConnState>) {
+  async onClose(connection: Connection<ConnState>) {
+    // A close event is ordered after all data frames already received on this socket. Do not
+    // reclaim its delivery/serve leases while one of those frames is still queued behind hello or
+    // awaiting D1; otherwise a final replied update can be undone by premature disconnect cleanup.
+    await this.wsMessageTails.get(connection.id)?.catch(() => undefined);
     const st = connection.state;
     if (!st || !st.name || st.archived) return;
     // #551：work 租约属于具体连接，不属于模糊的在线身份。尚未启动的 v1 claim 可安全

--- a/worker/test/directed-delivery.spec.ts
+++ b/worker/test/directed-delivery.spec.ts
@@ -520,6 +520,68 @@ describe("持久定向投递（issue #551）", () => {
     standby.close();
   });
 
+  it("processes an already-received terminal update before disconnect cleanup", async () => {
+    const sender = await seedToken("agent", uniq("sender"));
+    const target = await seedToken("agent", uniq("target"));
+    const slug = await createChannel(sender.token);
+    const holder = await WsClient.open(slug, target.token);
+    await holder.nextOfType("welcome");
+    expect((await claim(holder)).held).toBe(true);
+    await sendMention(slug, sender.token, target.name, "reply then close");
+    const work = (await holder.nextOfType("delivery")) as DirectedDeliveryFrame;
+
+    const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+    await runInDurableObject(stub, async (instance: ChannelDO) => {
+      const runtime = instance as unknown as {
+        isTokenActive(tokenHash: string): Promise<boolean>;
+        onMessage(connection: unknown, message: string): Promise<void>;
+        onClose(connection: unknown): void | Promise<void>;
+      };
+      const connection = [...instance.getConnections<{ name?: string; serveLeaseHeld?: boolean }>()]
+        .find((candidate) =>
+          candidate.state?.name === target.name && candidate.state?.serveLeaseHeld === true
+        );
+      expect(connection).toBeDefined();
+
+      const realIsTokenActive = runtime.isTokenActive.bind(instance);
+      let release!: () => void;
+      const gate = new Promise<void>((resolve) => { release = resolve; });
+      let entered!: () => void;
+      const validationEntered = new Promise<void>((resolve) => { entered = resolve; });
+      runtime.isTokenActive = async (tokenHash: string) => {
+        entered();
+        await gate;
+        return realIsTokenActive(tokenHash);
+      };
+      try {
+        const update = runtime.onMessage(connection!, JSON.stringify({
+          type: "delivery_update",
+          delivery_id: work.delivery.id,
+          request_id: "reply-before-close",
+          state: "replied",
+          work_id: work.delivery.work_id,
+          continuation_ref: work.delivery.continuation_ref,
+        }));
+        await validationEntered;
+        const close = Promise.resolve(runtime.onClose(connection!));
+        release();
+        await Promise.all([update, close]);
+      } finally {
+        release();
+        runtime.isTokenActive = realIsTokenActive;
+      }
+    });
+
+    expect((await deliveryRows(slug))[0]).toMatchObject({
+      id: work.delivery.id,
+      state: "replied",
+      attempt: 1,
+      lease_connection_id: null,
+      lease_adapter: null,
+    });
+    holder.close();
+  });
+
   it("权威 running ACK 后 heartbeat 续租；租约到期显式 failed 而不重放未知副作用", async () => {
     const sender = await seedToken("agent", uniq("sender"));
     const target = await seedToken("agent", uniq("target"));

--- a/worker/test/ws.spec.ts
+++ b/worker/test/ws.spec.ts
@@ -89,6 +89,40 @@ describe("websocket", () => {
     ws.close();
   });
 
+  it("serializes hello before an immediately-following serve claim while token validation awaits", async () => {
+    const { token } = await seedToken("agent");
+    const slug = await createChannel(token);
+    const ws = await WsClient.open(slug, token);
+    await ws.nextOfType("welcome");
+    await ws.nextOfType("participants");
+
+    const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+    await runInDurableObject(stub, async (instance: ChannelDO) => {
+      const target = instance as unknown as {
+        isTokenActive(tokenHash: string): Promise<boolean>;
+      };
+      const realIsTokenActive = target.isTokenActive.bind(instance);
+      let delayNext = true;
+      target.isTokenActive = async (tokenHash: string) => {
+        if (delayNext) {
+          delayNext = false;
+          await new Promise((resolve) => setTimeout(resolve, 75));
+        }
+        return realIsTokenActive(tokenHash);
+      };
+    });
+
+    // The production D1 lookup yields here. partyserver may deliver the claim callback while the
+    // hello callback is still awaiting; it must queue behind hello, not receive hello_required.
+    ws.send({ type: "hello", since: 0, directed_delivery: "v1" });
+    ws.send({ type: "serve_lease", op: "claim" });
+    expect(await ws.next()).toMatchObject({
+      type: "serve_lease",
+      held: true,
+    });
+    ws.close();
+  });
+
   it("extracts @name from the body into mentions (bare send should wake the target)", async () => {
     const { token } = await seedToken("agent");
     const bob = await seedToken("agent", "bob");


### PR DESCRIPTION
## 问题

v0.2.118 发布前的真实生产冒烟发现：`party serve` 连接后，Worker 在 `hello` 的 D1 token 校验尚未完成时并发处理紧随其后的 `serve_lease claim`，误报 `hello_required` 并进入重连循环。发布已拦停，未创建 v0.2.118 GitHub Release。

另外，客户端此前会在发送 `hello` 前触发 `open` 状态回调，回调若同步发送控制帧，也可能越过握手。

## 修复

- Worker 对同一 WebSocket 连接的消息按线序串行处理，同时让断连清理等待已收到的终态投递更新
- CLI 先发送 `hello`，再发布 `open` 状态
- 增加延迟 token 校验、立即 welcome、终态 ACK/断连竞态回归测试

## 验证

- CLI：864/864 通过，TypeScript 类型检查通过
- Worker：625/625 通过，类型检查通过
- `git diff --check` 通过

Refs #543 #548 #550 #551 #552 #553

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
  - 修复 WebSocket 连接建立时的消息顺序问题，确保握手消息始终先于心跳及其他可操作消息发送。
  - 改进消息处理顺序，避免连接关闭时遗漏或回滚已收到的最终状态更新。
  - 提升租约建立及连接初始化期间的稳定性，减少并发时序导致的异常。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->