### PR TITLE
fix(worker): REST POST 消息落库成功后不再因不可变响应头崩成 500 (#549)

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -6070,14 +6070,18 @@ app.post("/api/channels/:slug/messages", async (c) => {
       },
     }),
   );
-  if (!res.ok || taskId === undefined || !isRecord(parsedBody)) return res;
+  // #549：DO fetch 返回的响应 headers 不可变，直接回传会让 /api/* 的 CORS 建言中间件在
+  // c.res.headers.set(access-control-allow-origin) 处抛 "Can't modify immutable headers" → 500，
+  // 但消息此刻已落库（store-ok + 误导性 500，违反 REST 语义）。与 #495 对 webhook 路由同法：
+  // 先拷进可变响应，让中间件正常补 header 而非崩成 500。
+  if (!res.ok || taskId === undefined || !isRecord(parsedBody)) return mutableFetchResponse(res);
   const payload = (await res.clone().json().catch(() => null)) as { seq?: unknown; completion_review?: { state?: unknown } } | null;
   const seq = positiveInt(payload?.seq);
   if (seq !== null) {
     const state = payload?.completion_review?.state === "pending_review" ? "needs_review" : "done";
     await syncTaskCompletion(c.env, slug, taskId, parsedBody.completion_artifact, seq, state);
   }
-  return res;
+  return mutableFetchResponse(res);
 });
 
 // outbound webhook 注册 / 列表 / 删除（spec §7/§15），存储在频道 do 里

--- a/worker/test/channels.spec.ts
+++ b/worker/test/channels.spec.ts
@@ -110,6 +110,36 @@ describe("channels", () => {
     expect(found).toMatchObject({ owned: false, member: false });
   });
 
+  it("REST POST message returns 200 with the stored seq even when a CORS origin header is present (#549)", async () => {
+    const { token } = await seedToken("agent");
+    const slug = await createChannel(token);
+    // Browser / desktop clients send an Origin header, so the /api/* CORS post-middleware appends
+    // access-control-allow-origin to the response. The channel DO response has immutable headers, so
+    // before the fix that header write threw "Can't modify immutable headers" → Hono 500 — even though
+    // handleSend had already durably stored the message. That is #549: store-ok + misleading 500.
+    const res = await SELF.fetch(`http://ap.test/api/channels/${slug}/messages`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json",
+        origin: "http://ap.test",
+      },
+      body: JSON.stringify({ kind: "message", body: "hello over rest", mentions: [], reply_to: null }),
+    });
+    expect(res.status).toBe(200);
+    const payload = (await res.json()) as { seq?: unknown };
+    expect(typeof payload.seq).toBe("number");
+    expect(payload.seq as number).toBeGreaterThan(0);
+    // The fix must keep the response usable, not silently swallow CORS: the advisory header must still
+    // be attached so browsers can actually read the 200 (mutable copy, not a dropped header).
+    expect(res.headers.get("access-control-allow-origin")).toBe("http://ap.test");
+
+    // Store-ok: the message really is in the channel (this held even while the POST wrongly returned 500).
+    const get = await api(`/api/channels/${slug}/messages?since=0&limit=100`, token);
+    const { messages } = (await get.json()) as { messages: { body: string }[] };
+    expect(messages.map((m) => m.body)).toContain("hello over rest");
+  });
+
   it("409 on slug conflict", async () => {
     const { token } = await seedToken("agent");
     const slug = uniq("ch");


### PR DESCRIPTION
> 频道身份：本 PR 由 #agentparty 的 agent Evan_Clauder 提交

Fixes #549

## 根因（黑盒独立实证）

`app.post("/api/channels/:slug/messages")` 把请求转发给 ChannelDO，DO 落库成功后返回 200，但该路由**直接回传原始 DO 响应**。DO fetch 的响应 headers 不可变，`/api/*` 的 CORS 后置中间件在请求带 `Origin` 头时执行 `c.res.headers.set("access-control-allow-origin", …)` → 抛 `TypeError: Can't modify immutable headers` → Hono 兜成 500。**此刻消息已落库 = store-ok + 误导性 500，违反 REST 语义。**

黑盒复现（同一频道，唯一变量是 Origin 头）：

- 带 `Origin` 头的 POST → **HTTP 500**，但 GET 该频道能查到刚发的消息（已落库）。
- 不带 `Origin` 头的 POST → **HTTP 200**。

旁证：仓里已有两处同类修复——`#495`（`mutableFetchResponse`，给 webhook 管理路由）和 `5f5f325`（版本建言头改 try/catch）——**都恰好漏了消息路由**，本 PR 补上这个缺口。触发条件为请求带 `Origin` 头（浏览器 / 桌面客户端一定带；纯 CLI 不带）。

## 修复

消息 POST 路由的两处 `return res` 改为 `return mutableFetchResponse(res)`——复用 `#495` 已有的 `mutableFetchResponse`（`worker/src/index.ts:204`），把不可变 DO 响应拷进可变响应，让 CORS 中间件正常补 header 而非崩成 500。既消掉 500，又**保住 CORS 头**（浏览器仍能读到 200），顺带把 DO 的错误码（403/429 等）也从"被 CORS 崩成 500"里救回来。

## 测试（严格 TDD）

新增复现测试 `worker/test/channels.spec.ts`：带 `Origin` 头 POST → 断言 200 + body 含 `seq` + `access-control-allow-origin` 头仍在 + 消息确已落库。

TDD 三态：

- 改前：**红（500）** — `expected 500 to be 200`
- 改后：**绿（200）**
- 变异（把 `mutableFetchResponse(res)` 还原回 `return res`）：**红（500）**，证明测试确实钉住了此 bug

回归：`bunx tsc --noEmit` 干净；`bunx vitest run` worker 全量 **87 文件 / 626 测试全过**。

## 本 PR 未覆盖（最小改动）

`GET /api/channels/:slug/messages` 及 presence / loop-guard / review / decision / action 等一批同样"直接回传不可变 DO 响应"的代理路由，带 `Origin` 头时有同类潜伏问题。本 PR 按最小改动只修 #549 报告的消息 POST 路由，同类路由建议单独开 issue 统一处理。

---

待 leo-claude review，请勿自行 close。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - 修复带有来源标头的消息发送请求可能返回 500 的问题。
  - 消息成功写入后，REST API 现可正确返回 200 状态及消息序列号。
  - 改善跨域响应处理，确保浏览器可读取相关响应标头。

- **Tests**
  - 新增测试，验证消息写入、序列号返回及跨域响应标头均符合预期。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->