### PR TITLE
test(web): AgentTokens rotate 测试抗 mock.module 加载顺序（修 CI 偶发 Received:null）

### DIFF
--- a/web/src/components/AgentJoin.test.tsx
+++ b/web/src/components/AgentJoin.test.tsx
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { act, create, type ReactTestRenderer } from "react-test-renderer";
 import { LocaleProvider } from "../i18n/locale";
+import { clearApiBase, setApiBase } from "../lib/base";
 
 const savedAgents: Array<{ name: string; token: string; command: string }> = [];
 
@@ -71,6 +72,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  clearApiBase(); // #530：清掉测试里注入的 runtime apiBase，避免泄漏到后续用例/文件
   act(() => renderer?.unmount());
   renderer = null;
   Reflect.deleteProperty(globalThis, "window");
@@ -191,5 +193,26 @@ describe("AgentJoin dismiss behavior", () => {
     expect(command).toContain("party send \"need human confirmation: <question/options>\" --channel demo --mention host");
     expect(command).toContain("watch --once is only a current-turn standby");
     expect(command).toContain("prefer party serve or webhook delivery");
+  });
+});
+
+describe("AgentJoin 接入包 server 域名 (#530)", () => {
+  // 桌面版(Tauri)里 location.origin 是 tauri://localhost，接入包若用它拼 `party init --server`
+  // 会让 agent 报错/连不上。修复要求：apiBase() 非空(桌面注入了真后端)时用 apiBase()，
+  // 只有同源 web(apiBase 为空)才回退 location.origin。
+  // 本用例里 location.origin = https://party.test，代表「不该被用到的伪源」。
+  test("apiBase() 非空时，party init --server 用注入的真实后端而非 location.origin", async () => {
+    setApiBase("https://agentparty.leeguoo.com");
+    const r = render();
+    open(r);
+    await act(async () => {
+      await r.root.find((node) => node.props.className === "d-btn d-btn--primary" && node.props.onClick).props.onClick();
+    });
+
+    const command = savedAgents[0]!.command;
+    // 关键断言：--server 用的是 apiBase() 的真后端
+    expect(command).toContain("party init --server https://agentparty.leeguoo.com ");
+    // 绝不能回退到 location.origin(桌面端的伪源，此处以 https://party.test 代表)
+    expect(command).not.toContain("party init --server https://party.test");
   });
 });

--- a/web/src/components/AgentJoin.tsx
+++ b/web/src/components/AgentJoin.tsx
@@ -11,6 +11,7 @@ import {
   ValidationError,
 } from "../lib/api";
 import { copyText, saveAgentToken } from "../lib/agentTokenVault";
+import { apiBase } from "../lib/base";
 import { useT, type TFunc } from "../i18n/useT";
 import { useDismissableLayer } from "./useDismissableLayer";
 import "../i18n/strings/AgentJoin";
@@ -110,7 +111,10 @@ export function AgentJoin({ slug, token, namePrefix, inviterName, charter, accou
     setPhase({ kind: "loading" });
     try {
       const agent = await createChannelAgent(slug, wanted, token);
-      const server = location.origin;
+      // #530：接入包的 server 必须是真实后端。桌面版(Tauri)里 location.origin 是 tauri://localhost /
+      // http://tauri.localhost / dev 的 127.0.0.1:5173，agent 拿去 `party init --server` 会因非 http(s)
+      // 报错或连不上。优先用打包注入的 apiBase(VITE_API_BASE=真后端)，仅同源 web 部署(apiBase 为空)回退 location.origin。
+      const server = apiBase() || location.origin;
       // 复制的是完整接入脚本：init 只写配置不发消息，必须带「报到发言」，否则网页上看不到 agent。
       const command = [
         t("AgentJoin.cmd.header", { slug }),

--- a/web/src/components/AgentTokens.rules.test.tsx
+++ b/web/src/components/AgentTokens.rules.test.tsx
@@ -2,6 +2,8 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { act, create, type ReactTestRenderer } from "react-test-renderer";
 import { LocaleProvider } from "../i18n/locale";
+import { clearApiBase, setApiBase } from "../lib/base";
+import { findSavedAgentToken } from "../lib/agentTokenVault";
 
 // AgentTokens 只依赖 ../lib/api 的这几个运行时导出；类型导入会被擦除。
 // 这里整体桩掉，让测试可以驱动 profile 规则的查看/编辑，而不真的打网络。
@@ -23,6 +25,8 @@ type AgentFixture = { name: string; owner: string; channel_scope: string; create
 
 let profilesFixture: ProfileFixture[] = [];
 let agentsFixture: AgentFixture[] = [];
+// #530：rotate 后 worker 返回的新 name/token；用它拼接入包命令并落进本地保险库。
+let rotateResult: { name: string; token: string } = { name: "build-bot", token: "ap_rotated" };
 const createCalls: Array<{ token: string; body: Record<string, unknown> }> = [];
 const nicknameCalls: Array<{ token: string; slug: string; name: string; nickname: string }> = [];
 
@@ -41,7 +45,7 @@ mock.module("../lib/api", () => ({
   inviteProjectAgent: async () => {},
   listChannelAgents: async () => agentsFixture,
   listProjectAgentProfiles: async () => profilesFixture,
-  rotateChannelAgent: async () => ({}),
+  rotateChannelAgent: async () => rotateResult,
   setChannelAgentNickname: mock(async (token: string, slug: string, name: string, nickname: string) => {
     nicknameCalls.push({ token, slug, name, nickname });
     const agent = agentsFixture.find((entry) => entry.name === name);
@@ -112,10 +116,13 @@ class TestEventTarget {
 beforeEach(() => {
   profilesFixture = [];
   agentsFixture = [];
+  rotateResult = { name: "build-bot", token: "ap_rotated" };
   createCalls.length = 0;
   nicknameCalls.length = 0;
   Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", { configurable: true, value: true });
   Object.defineProperty(globalThis, "localStorage", { configurable: true, value: memoryStorage({ ap_locale: "en" }) });
+  // #530：模拟测试/桌面环境的伪源；apiBase() 非空时不该被用到，仅用于校验没有回退到它。
+  Object.defineProperty(globalThis, "location", { configurable: true, value: { origin: "http://localhost:5173" } });
   windowEvents = new TestEventTarget();
   documentEvents = new TestEventTarget();
   Object.defineProperty(globalThis, "window", {
@@ -123,6 +130,7 @@ beforeEach(() => {
     value: {
       innerWidth: 1200,
       innerHeight: 800,
+      confirm: () => true, // rotate() 前会 window.confirm 确认
       addEventListener: windowEvents.addEventListener.bind(windowEvents),
       removeEventListener: windowEvents.removeEventListener.bind(windowEvents),
     },
@@ -137,11 +145,13 @@ beforeEach(() => {
 });
 
 afterEach(async () => {
+  clearApiBase(); // #530：清掉注入的 runtime apiBase，避免泄漏
   if (renderer !== null) await act(async () => renderer?.unmount());
   renderer = null;
   Reflect.deleteProperty(globalThis, "window");
   Reflect.deleteProperty(globalThis, "document");
   Reflect.deleteProperty(globalThis, "localStorage");
+  Reflect.deleteProperty(globalThis, "location");
 });
 
 function baseProps() {
@@ -339,5 +349,28 @@ describe("AgentTokens dismiss behavior", () => {
     act(() => documentEvents.emit("pointerdown", { target: {} }));
     expect(changes).toEqual([false]);
     expect(renderer!.root.findAll((node) => node.props.className === "agenttokens-panel")).toHaveLength(1);
+  });
+});
+
+describe("AgentTokens 轮换接入包 server 域名 (#530)", () => {
+  // 桌面版(Tauri)里 location.origin 是 tauri://localhost，轮换后重新生成的接入包若用它拼
+  // `party init --server` 会让 agent 报错。修复要求：优先用注入的真实后端 apiBase()，
+  // 仅同源 web(apiBase 为空)才回退 location.origin。本用例 location.origin = http://localhost:5173，
+  // 代表「不该被用到的伪源」。
+  test("apiBase() 非空时，rotate 生成的 party init --server 用真实后端而非 location.origin", async () => {
+    setApiBase("https://agentparty.leeguoo.com");
+    agentsFixture = [{ name: "build-bot", owner: "acct-1", channel_scope: "demo", created_at: 1, nickname: null }];
+    const r = await renderOpen();
+
+    // 轮换 token → 触发 buildMinimalAgentCommand，命令写进本地保险库
+    await act(async () => findClass(r, "d-btn agenttokens-rotate").props.onClick());
+    await act(async () => {}); // flush rotate + refresh
+
+    const saved = findSavedAgentToken("acct-1", "demo", "build-bot");
+    expect(saved).not.toBeNull();
+    // 关键断言：--server 用的是 apiBase() 的真后端
+    expect(saved!.command).toContain("party init --server https://agentparty.leeguoo.com ");
+    // 绝不能回退到 location.origin(桌面端伪源，此处以 http://localhost:5173 代表)
+    expect(saved!.command).not.toContain("http://localhost:5173");
   });
 });

--- a/web/src/components/AgentTokens.rules.test.tsx
+++ b/web/src/components/AgentTokens.rules.test.tsx
@@ -30,11 +30,17 @@ let rotateResult: { name: string; token: string } = { name: "build-bot", token: 
 const createCalls: Array<{ token: string; body: Record<string, unknown> }> = [];
 const nicknameCalls: Array<{ token: string; slug: string; name: string; nickname: string }> = [];
 
-mock.module("../lib/api", () => ({
+// bun 的 mock.module("../lib/api") 是全局共享的：多个测试文件各自只桩了自己用到的那部分 export
+// （AgentJoin 只桩 createChannelAgent、本文件桩 rotateChannelAgent 等），串行全套跑时按加载顺序互相覆盖。
+// 若不在每个测试前把桩重置回本文件的完整版本，rotate() 运行时可能拿到别文件的桩、返回错值 → CI 偶发 Received:null。
+// 因此抽成具名 factory 供顶层 + beforeEach 复用；并兜底 createChannelAgent，避免本文件的桩最后生效时
+// 让 AgentJoin.tsx 加载期因缺少该 export 报 SyntaxError。
+const apiMockFactory = () => ({
   AuthError: class AuthError extends Error {},
   ConflictError: class ConflictError extends Error {},
   ForbiddenError: class ForbiddenError extends Error {},
   ValidationError: class ValidationError extends Error {},
+  createChannelAgent: async (_slug: string, name: string) => ({ name, token: "ap_created" }),
   createProjectAgentProfile: mock(async (token: string, body: Record<string, unknown>) => {
     createCalls.push({ token, body });
     // upsert：把新 rules 落回 fixture，模拟 worker 的 ON CONFLICT DO UPDATE
@@ -52,7 +58,8 @@ mock.module("../lib/api", () => ({
     if (agent) agent.nickname = nickname;
     return { name, nickname };
   }),
-}));
+});
+mock.module("../lib/api", apiMockFactory);
 
 const { AgentTokens } = await import("./AgentTokens");
 
@@ -142,6 +149,8 @@ beforeEach(() => {
       removeEventListener: documentEvents.removeEventListener.bind(documentEvents),
     },
   });
+  // 每个测试前把 ../lib/api 桩重置回本文件完整版本，抵消别的测试文件 mock.module 的跨文件覆盖（见顶部 factory 注释）。
+  mock.module("../lib/api", apiMockFactory);
 });
 
 afterEach(async () => {

--- a/web/src/components/AgentTokens.tsx
+++ b/web/src/components/AgentTokens.tsx
@@ -23,6 +23,7 @@ import {
   listSavedAgentTokens,
   saveAgentToken,
 } from "../lib/agentTokenVault";
+import { apiBase } from "../lib/base";
 import { useT } from "../i18n/useT";
 import { useDismissableLayer } from "./useDismissableLayer";
 import "../i18n/strings/AgentTokens";
@@ -202,7 +203,8 @@ export function AgentTokens({ slug, token, accountKey, inviterName, onAuthFailed
     try {
       const next = await rotateChannelAgent(token, slug, name);
       const command = buildMinimalAgentCommand({
-        server: location.origin,
+        // #530：桌面版 location.origin 是 tauri://localhost，接入包会报错；优先真实后端 apiBase，同源 web 回退 origin。
+        server: apiBase() || location.origin,
         slug,
         name: next.name,
         token: next.token,

--- a/web/src/lib/agentTokenVault.test.ts
+++ b/web/src/lib/agentTokenVault.test.ts
@@ -24,4 +24,22 @@ describe("buildMinimalAgentCommand", () => {
     expect(command).toContain("app-server, MCP, or project-local channel workflow (for example, Trellis)");
     expect(command).toContain("do not delegate onboarding");
   });
+
+  test("#530 桌面接入包：把传入的真实后端 server 原样写进 party init --server", () => {
+    // 桌面版(Tauri)注入的 apiBase(=真后端)会作为 server 传进来，
+    // 命令必须原样使用它，绝不能出现桌面端的 tauri://localhost 伪源。
+    const command = buildMinimalAgentCommand({
+      server: "https://agentparty.leeguoo.com",
+      slug: "demo",
+      name: "desktop-worker",
+      token: "ap_fixture",
+      inviterName: "leo",
+      checkinMessage: "checking in",
+    });
+
+    expect(command).toContain(
+      "party init --server https://agentparty.leeguoo.com --token ap_fixture --channel demo",
+    );
+    expect(command).not.toContain("tauri://localhost");
+  });
 });


### PR DESCRIPTION
## 是什么
给 `AgentTokens` 的 **rotate 测试**加固，抵抗 bun `mock.module` 的全局共享 / 加载顺序问题——修复 CI 上偶发的 `Received: null`。
源分支 `pr540-evan`（2026-07-15），围绕 #530/#540 桌面接入包工作。

## 问题根因（分支里的注释）
> bun 的 `mock.module("../lib/api")` 是全局共享的：多个测试文件各自只桩了自己用到的那部分 export，串行全套跑时按加载顺序互相覆盖。若不在每个测试前把桩重置回本文件的完整版本，`rotate()` 运行时可能拿到别文件的桩、返回错值 → CI 偶发 `Received: null`。

## 状态
- 该加固**当前不在 `main` 上**（已核实）。
- ⚠️ 与 `main` 有冲突（`AgentJoin.tsx` / `AgentTokens.tsx` / `AgentTokens.rules.test.tsx` 后续都改过），需解冲突后才能合并——先供 review。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复桌面端生成代理接入命令时服务端地址不正确的问题。
  * 代理接入和令牌轮换现在会优先使用实际后端地址，避免错误使用桌面端本地来源。
  * 同源 Web 部署仍会自动使用当前页面地址，确保现有流程正常运行。
* **Tests**
  * 增加桌面端服务地址及命令生成场景的验证，提升相关功能稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->