### PR TITLE
fix(web): 收紧跨尺寸布局与信息卡边界

### DIFF
--- a/web/src/components/MessageCard.agentCardAlignment.test.ts
+++ b/web/src/components/MessageCard.agentCardAlignment.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+import { shouldAlignAgentCardEnd } from "./MessageCard";
+
+describe("agent card viewport alignment", () => {
+  test("keeps the default left edge when the card fits", () => {
+    expect(shouldAlignAgentCardEnd(120, 1024)).toBe(false);
+  });
+
+  test("aligns the card to the trigger end when the default edge would overflow", () => {
+    expect(shouldAlignAgentCardEnd(700, 1024)).toBe(true);
+    expect(shouldAlignAgentCardEnd(380, 390)).toBe(true);
+  });
+});

--- a/web/src/components/MessageCard.presence.test.tsx
+++ b/web/src/components/MessageCard.presence.test.tsx
@@ -13,12 +13,14 @@ const { MessageCard, agentInfoTitleBits, presenceTitleBits } = await import("./M
 let renderer: ReactTestRenderer | null = null;
 let windowEvents: TestEventTarget;
 let documentEvents: TestEventTarget;
+let triggerLeft: number;
 const insidePopoverTarget = {};
 
 const noop = () => undefined;
 
 class TestEventTarget {
   private listeners = new Map<string, Set<(event: unknown) => void>>();
+  innerWidth = 1024;
 
   addEventListener(type: string, listener: (event: unknown) => void) {
     const listeners = this.listeners.get(type) ?? new Set();
@@ -54,6 +56,7 @@ function memoryStorage(): Storage {
 beforeEach(() => {
   windowEvents = new TestEventTarget();
   documentEvents = new TestEventTarget();
+  triggerLeft = 120;
   Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", { configurable: true, value: true });
   Object.defineProperty(globalThis, "localStorage", { configurable: true, value: memoryStorage() });
   Object.defineProperty(globalThis, "window", { configurable: true, value: windowEvents });
@@ -119,7 +122,12 @@ function render(msg: MsgFrame, extra: Record<string, unknown> = {}, locale: "en"
           if (className.includes("msg-agent-popover")) {
             return { contains: (target: unknown) => target === insidePopoverTarget };
           }
-          if (className.includes("msg-agent-trigger")) return { blur: noop };
+          if (className.includes("msg-agent-trigger")) {
+            return {
+              blur: noop,
+              getBoundingClientRect: () => ({ left: triggerLeft }),
+            };
+          }
           return {};
         },
       },
@@ -239,6 +247,24 @@ describe("发送者即时信息卡/@提及悬停展示实时状态 (#274/#490)",
     expect(mentionTrigger(root).props["aria-expanded"]).toBe(false);
     expect(mentionCard(root).parent?.props.className).toContain("msg-agent-popover--closed");
     expect(blurred).toBe(true);
+  });
+
+  test("信息卡打开和 resize 会重算边缘对齐，卸载时移除监听器", () => {
+    triggerLeft = 700;
+    const root = render(baseMsg({ mentions: ["planner"] }));
+    const clickEvent = { currentTarget: { blur: noop } };
+
+    act(() => mentionTrigger(root).props.onClick(clickEvent));
+    expect(mentionCard(root).parent?.props.className).toContain("msg-agent-popover--align-end");
+    expect(windowEvents.count("resize")).toBe(1);
+
+    triggerLeft = 120;
+    act(() => windowEvents.emit("resize", {}));
+    expect(mentionCard(root).parent?.props.className).not.toContain("msg-agent-popover--align-end");
+
+    act(() => renderer?.unmount());
+    renderer = null;
+    expect(windowEvents.count("resize")).toBe(0);
   });
 
   test("打开 @提及信息卡后，站内点击保留，站外点击与 Escape 都会收起", () => {

--- a/web/src/components/MessageCard.tsx
+++ b/web/src/components/MessageCard.tsx
@@ -153,6 +153,16 @@ function activityLine(message: MsgFrame): string {
   return `${line.slice(0, 88)}…`;
 }
 
+/** Returns whether a desktop agent card must anchor to the trigger's end edge. */
+export function shouldAlignAgentCardEnd(
+  triggerLeft: number,
+  viewportWidth: number,
+  cardWidth = 360,
+  viewportGutter = 16,
+): boolean {
+  return triggerLeft + cardWidth > viewportWidth - viewportGutter;
+}
+
 function AgentInfoPopover({
   id,
   label,
@@ -177,8 +187,14 @@ function AgentInfoPopover({
   const t = useT();
   const [open, setOpen] = useState(false);
   const [suppressed, setSuppressed] = useState(false);
+  const [alignCardEnd, setAlignCardEnd] = useState(false);
   const rootRef = useRef<HTMLDivElement | null>(null);
   const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const syncCardAlignment = useCallback(() => {
+    const trigger = triggerRef.current;
+    if (trigger === null || typeof trigger.getBoundingClientRect !== "function" || typeof window === "undefined") return;
+    setAlignCardEnd(shouldAlignAgentCardEnd(trigger.getBoundingClientRect().left, window.innerWidth));
+  }, []);
   const dismiss = useCallback(() => {
     triggerRef.current?.blur();
     setOpen(false);
@@ -199,11 +215,18 @@ function AgentInfoPopover({
     onDismiss: dismiss,
     outsideRef: rootRef,
   });
+  useLayoutEffect(() => {
+    if (!open || typeof window === "undefined") return;
+    syncCardAlignment();
+    window.addEventListener("resize", syncCardAlignment);
+    return () => window.removeEventListener("resize", syncCardAlignment);
+  }, [open, syncCardAlignment]);
   return (
     <div
       ref={rootRef}
-      className={`msg-agent-popover${open ? " msg-agent-popover--open" : ""}${suppressed ? " msg-agent-popover--closed" : ""}`}
+      className={`msg-agent-popover${open ? " msg-agent-popover--open" : ""}${suppressed ? " msg-agent-popover--closed" : ""}${alignCardEnd ? " msg-agent-popover--align-end" : ""}`}
       onMouseEnter={() => {
+        syncCardAlignment();
         if (!open) setSuppressed(false);
       }}
       onMouseLeave={() => {
@@ -217,6 +240,7 @@ function AgentInfoPopover({
         aria-describedby={id}
         aria-expanded={open}
         onClick={(event) => {
+          syncCardAlignment();
           if (open) {
             event.currentTarget.blur();
             setOpen(false);
@@ -226,7 +250,10 @@ function AgentInfoPopover({
             setOpen(true);
           }
         }}
-        onFocus={() => setSuppressed(false)}
+        onFocus={() => {
+          syncCardAlignment();
+          setSuppressed(false);
+        }}
         onKeyDown={(event) => {
           if (event.key === "Escape") {
             event.currentTarget.blur();

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -2666,6 +2666,7 @@
 }
 .msg-agent-card {
   position: absolute;
+  display: none;
   z-index: 65;
   top: calc(100% + 7px);
   left: 0;
@@ -2684,9 +2685,31 @@
   transform: translateY(-2px);
   transition: opacity 60ms linear, transform 60ms linear, visibility 0s linear 60ms;
 }
+@media (min-width: 761px) {
+  .msg-agent-popover--align-end .msg-agent-card {
+    left: auto;
+    right: 0;
+  }
+  .msg-agent-popover:not(.msg-agent-popover--closed):hover::after,
+  .msg-agent-popover:not(.msg-agent-popover--closed):focus-within::after,
+  .msg-agent-popover--open::after {
+    content: "";
+    position: absolute;
+    z-index: 64;
+    top: 100%;
+    left: 0;
+    width: min(360px, calc(100vw - 32px));
+    height: 7px;
+  }
+  .msg-agent-popover--align-end::after {
+    left: auto;
+    right: 0;
+  }
+}
 .msg-agent-popover:not(.msg-agent-popover--closed):hover .msg-agent-card,
 .msg-agent-popover:not(.msg-agent-popover--closed):focus-within .msg-agent-card,
 .msg-agent-popover--open .msg-agent-card {
+  display: block;
   opacity: 1;
   visibility: visible;
   pointer-events: auto;
@@ -3331,19 +3354,6 @@
     margin-left: 4px;
     padding-left: 5px;
   }
-  .joinlink-panel {
-    position: fixed;
-    left: 12px;
-    right: 12px;
-    top: auto;
-    bottom: 12px;
-    width: auto;
-    max-width: 620px;
-    max-height: 72vh;
-    margin-left: auto;
-    overflow-y: auto;
-    z-index: 60;
-  }
 }
 .chan-admin-actions,
 .vis-toggle {
@@ -3545,6 +3555,23 @@
 .joinrequest-status-spinner { display: inline-block; width: 12px; height: 12px; border: 2px solid currentColor; border-right-color: transparent; border-radius: 50%; animation: joinrequest-spin 700ms linear infinite; }
 @keyframes joinrequest-spin { to { transform: rotate(360deg); } }
 @media (prefers-reduced-motion: reduce) { .joinrequest-status-spinner { animation: none; } }
+/* Keep the desktop popover bound to the viewport. This override must follow the
+   base absolute rule above so top and bottom cannot constrain it to 25px. */
+@media (min-width: 761px) and (max-width: 1759px) {
+  .joinlink-panel {
+    position: fixed;
+    left: 12px;
+    right: 12px;
+    top: auto;
+    bottom: 12px;
+    width: auto;
+    max-width: 620px;
+    max-height: 72vh;
+    margin-left: auto;
+    overflow-y: auto;
+    z-index: 60;
+  }
+}
 /* 桌面版贴邀请链接（#297）：入口在左侧栏，浮层左对齐（joinlink 默认右对齐是给顶栏用的）。 */
 .invite-paste { margin-bottom: 8px; }
 .invite-paste-btn { width: 100%; }
@@ -5685,6 +5712,22 @@
     overflow-y: auto;
     z-index: 60;
   }
+  .joinlink-gen-row {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 8px;
+  }
+  .joinlink-expiry {
+    display: grid;
+    min-width: 0;
+    align-items: stretch;
+    gap: 4px;
+  }
+  .joinlink-expiry select { width: 100%; min-width: 0; }
+  .joinlink-gen-row > .d-btn {
+    grid-column: 1 / -1;
+    width: 100%;
+  }
   .agent-join {
     flex: none;
     flex-wrap: nowrap;
@@ -5716,6 +5759,9 @@
   .channel-panel-card {
     width: 100%;
     max-height: calc(100vh - 16px);
+  }
+  .channel-panel-card:has(.guard-settings) {
+    align-self: flex-start;
   }
   .channel-panel-head {
     padding: 10px 11px 9px;
@@ -5836,6 +5882,25 @@
 .app-docs,
 .app-product-link { border: 1.4px solid var(--t-faint); border-radius: 0; }
 
+/* At tablet and compact desktop widths, keep one useful header row by dropping
+   copy already represented by the avatar/name. Primary account controls remain. */
+@media (min-width: 761px) and (max-width: 1100px) {
+  .app-head {
+    flex-wrap: nowrap;
+    gap: 8px;
+    padding: 10px 14px;
+  }
+  .app-tag { display: none; }
+  .app-me {
+    max-width: min(250px, 30vw);
+    gap: 4px;
+  }
+  .app-me-prefix,
+  .app-me-owner { display: none; }
+  .handlesetup-trigger { max-width: 140px; }
+  .app-me + .app-signout { margin-left: 4px; }
+}
+
 /* 满铺框线布局：侧栏贴左带右框线，主区自己留白（桌面端；窄屏保留原媒体查询布局） */
 @media (min-width: 761px) {
   .app-shell { gap: 0; padding: 0; }
@@ -5886,6 +5951,11 @@
 .chan-cat-btn { border-radius: 0; }
 .lang-switch-btn.is-active,
 .chan-cat-btn.is-active { background: var(--d-ink); color: var(--t-bg); }
+.settings-panel .lang-switch {
+  display: inline-flex;
+  width: max-content;
+  max-width: 100%;
+}
 
 /* 归档入口 → 终端提示行 */
 .side-archived-toggle { font-family: var(--t-mono); }
@@ -6164,6 +6234,11 @@
 .feature-tip:focus-within .feature-tip-bubble {
   opacity: 1;
   visibility: visible;
+}
+.vis-toggle > .feature-tip .feature-tip-bubble {
+  left: auto;
+  right: 0;
+  transform: none;
 }
 
 /* @ 唤醒提示（#145）：贴着发送按钮底部对齐，不撑高插话框行。 */
@@ -6774,3 +6849,13 @@
   color: var(--t-muted); font: 12px var(--t-mono); cursor: pointer;
 }
 .task-ledger-panel .task-blog-more:hover { background: var(--t-panel); color: var(--t-text); }
+
+@media (max-width: 760px) {
+  .task-ledger-panel .task-card-main {
+    flex-wrap: wrap;
+  }
+  .task-ledger-panel .task-card-title {
+    order: -1;
+    flex: 1 0 100%;
+  }
+}

--- a/web/src/styles/app.responsivePolish.test.ts
+++ b/web/src/styles/app.responsivePolish.test.ts
@@ -1,0 +1,93 @@
+// @ts-expect-error Bun executes this test, while the web tsconfig intentionally loads only Vite globals.
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const css = readFileSync(fileURLToPath(new URL("./app.css", import.meta.url)), "utf8");
+
+/** Extracts one balanced media block, including nested rule braces. */
+function mediaBlockAt(start: number): string {
+  const openingBrace = css.indexOf("{", start);
+  if (openingBrace < 0) throw new Error(`Missing media block at ${start}`);
+
+  let depth = 0;
+  for (let index = openingBrace; index < css.length; index += 1) {
+    if (css[index] === "{") depth += 1;
+    if (css[index] !== "}") continue;
+    depth -= 1;
+    if (depth === 0) return css.slice(start, index + 1);
+  }
+  throw new Error(`Unclosed media block at ${start}`);
+}
+
+/** Finds the media block for a breakpoint that owns a specific selector. */
+function mediaBlockContaining(query: string, selector: string, from = 0): string {
+  let cursor = from;
+  while (cursor < css.length) {
+    const start = css.indexOf(query, cursor);
+    if (start < 0) break;
+    const block = mediaBlockAt(start);
+    if (block.includes(selector)) return block;
+    cursor = start + query.length;
+  }
+  throw new Error(`No ${query} block contains ${selector}`);
+}
+
+describe("responsive product-shell polish", () => {
+  test("the invite panel keeps a viewport-bound layout after the base popover rule", () => {
+    const inviteSection = css.indexOf("/* ---- 邀请链接");
+    const baseRule = css.indexOf(".joinlink-panel {", inviteSection);
+    const mediumRule = css.indexOf("@media (min-width: 761px) and (max-width: 1759px)", baseRule);
+
+    expect(inviteSection).toBeGreaterThan(-1);
+    expect(baseRule).toBeGreaterThan(-1);
+    expect(mediumRule).toBeGreaterThan(baseRule);
+    expect(mediaBlockAt(mediumRule)).toMatch(/\.joinlink-panel\s*\{[^}]*position:\s*fixed;[^}]*top:\s*auto;[^}]*bottom:\s*12px;/s);
+  });
+
+  test("mobile invite generation gives fields stable columns and the command a full row", () => {
+    const mobileInvite = mediaBlockContaining("@media (max-width: 760px)", ".joinlink-gen-row");
+
+    expect(mobileInvite).toMatch(/\.joinlink-gen-row\s*\{[^}]*display:\s*grid;[^}]*grid-template-columns:\s*repeat\(2,\s*minmax\(0,\s*1fr\)\);/s);
+    expect(mobileInvite).toMatch(/\.joinlink-expiry\s*\{[^}]*display:\s*grid;[^}]*min-width:\s*0;/s);
+    expect(mobileInvite).toMatch(/\.joinlink-expiry select\s*\{[^}]*width:\s*100%;/s);
+    expect(mobileInvite).toMatch(/\.joinlink-gen-row\s*>\s*\.d-btn\s*\{[^}]*grid-column:\s*1\s*\/\s*-1;[^}]*width:\s*100%;/s);
+  });
+
+  test("mobile task cards reserve a full first row for their title", () => {
+    const mobileTasks = mediaBlockContaining("@media (max-width: 760px)", ".task-ledger-panel .task-card-main");
+
+    expect(mobileTasks).toMatch(/\.task-ledger-panel \.task-card-main\s*\{[^}]*flex-wrap:\s*wrap;/s);
+    expect(mobileTasks).toMatch(/\.task-ledger-panel \.task-card-title\s*\{[^}]*order:\s*-1;[^}]*flex:\s*1 0 100%;/s);
+  });
+
+  test("agent cards can align inward instead of widening the message stream", () => {
+    const desktopCards = mediaBlockContaining("@media (min-width: 761px)", ".msg-agent-popover--align-end");
+    const mobileCards = mediaBlockContaining("@media (max-width: 760px)", ".msg-agent-card");
+
+    expect(css).toMatch(/\.msg-agent-card\s*\{[^}]*display:\s*none;/s);
+    expect(css).toMatch(/\.msg-agent-popover:not\(\.msg-agent-popover--closed\):hover \.msg-agent-card,\s*\.msg-agent-popover:not\(\.msg-agent-popover--closed\):focus-within \.msg-agent-card,\s*\.msg-agent-popover--open \.msg-agent-card\s*\{[^}]*display:\s*block;/s);
+    expect(desktopCards).toMatch(/\.msg-agent-popover:not\(\.msg-agent-popover--closed\):hover::after,[\s\S]*\.msg-agent-popover--open::after\s*\{[^}]*width:\s*min\(360px,\s*calc\(100vw - 32px\)\);[^}]*height:\s*7px;/s);
+    expect(desktopCards).toMatch(/\.msg-agent-popover--align-end::after\s*\{[^}]*left:\s*auto;[^}]*right:\s*0;/s);
+    expect(desktopCards).toMatch(/\.msg-agent-popover--align-end \.msg-agent-card\s*\{[^}]*left:\s*auto;[^}]*right:\s*0;/s);
+    expect(mobileCards).toMatch(/\.msg-agent-card\s*\{[^}]*inset:\s*auto 10px/s);
+  });
+
+  test("visibility help opens inward and settings language controls hug their content", () => {
+    expect(css).toMatch(/\.vis-toggle > \.feature-tip \.feature-tip-bubble\s*\{[^}]*left:\s*auto;[^}]*right:\s*0;[^}]*transform:\s*none;/s);
+    expect(css).toMatch(/\.settings-panel \.lang-switch\s*\{[^}]*display:\s*inline-flex;[^}]*width:\s*max-content;[^}]*max-width:\s*100%;/s);
+  });
+
+  test("compact channel settings do not stretch to the full mobile viewport", () => {
+    const mobileSettings = mediaBlockContaining("@media (max-width: 760px)", ".channel-panel-card:has(.guard-settings)");
+    expect(mobileSettings).toMatch(/\.channel-panel-card:has\(\.guard-settings\)\s*\{[^}]*align-self:\s*flex-start;/s);
+  });
+
+  test("the medium header stays on one row after removing secondary identity copy", () => {
+    const mediumHeader = mediaBlockContaining("@media (min-width: 761px) and (max-width: 1100px)", ".app-head");
+
+    expect(mediumHeader).toMatch(/\.app-head\s*\{[^}]*flex-wrap:\s*nowrap;/s);
+    expect(mediumHeader).toMatch(/\.app-tag\s*\{[^}]*display:\s*none;/s);
+    expect(mediumHeader).toMatch(/\.app-me-prefix,[\s\S]*\.app-me-owner\s*\{[^}]*display:\s*none;/s);
+  });
+});


### PR DESCRIPTION
## 改动说明

- 修复信息卡隐藏状态和靠右定位导致的消息流横向溢出，并保留移动端 10px 边距
- 将 1024px 应用头收为单行，保留主操作并隐藏重复身份文案
- 修复邀请面板桌面坍缩、移动端标签竖排和任务标题拥挤
- 收紧设置语言控件、可见性提示和移动端 guard 小面板
- 新增响应式 CSS、信息卡边界与组件生命周期回归测试

保持现有纸张、硬边框、直角组件视觉，不改颜色、字体或组件语言。

## 验证

- 已 rebase 到 `main@0223078`（包含 #569 Lark 组织架构邀请）
- `bun run check:web`：830 tests passed，TypeScript 与生产构建通过
- Chrome 1440/1024/800/761/390px 前后对比及宽度量化
- 761px hover bridge：指针从触发器跨 7px 间隙进入卡片，全程可见，页面 761/761
- 390px 长本地化标签：两列 168.5px，字段宽度无溢出，页面 390/390
- `git diff --check` 通过

## 合并前检查

- [x] 已读 PR Agent 与 CodeRabbit 当前 head review
- [x] 已处理全部有效意见；不采纳项将在 `review-ack:` 中附实测依据
- [x] 本地 Web 门禁、TypeScript、生产构建通过
- [x] Chrome 多断点与 hover/focus 行为已验证
- [x] 未改动鉴权、密钥或其他安全边界

Chrome-use relay 超时另行记录在 leeguooooo/chrome-use#117。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 优化“@提及”代理信息卡：在悬浮、聚焦与打开后自动检测是否需要右侧对齐，并在窗口调整与交互触发时实时重算，降低窄视口溢出。
* **Bug 修复**
  * 修正多断点下浮层/提示气泡、邀请链接与任务卡在不同屏宽的对齐与定位异常（含右侧对齐装饰效果）。
* **测试**
  * 新增对齐判定与打开/收起流程的用例；补充对响应式 CSS 关键规则的断言，覆盖 resize 监听清理与多端布局表现。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->