### PR TITLE
feat(reachability): #543 定向投递自愈收尾

### DIFF
--- a/cli/scripts/issue-543-live-runner.ts
+++ b/cli/scripts/issue-543-live-runner.ts
@@ -231,6 +231,10 @@ function assertOwnerAnswerLineage(context: WakeContext, env: NodeJS.ProcessEnv):
   if (response.chosen_option !== "continue" && response.chosen_option !== "stop") {
     throw new Error("owner response chose an option outside the smoke request");
   }
+  const expectedIndex = response.chosen_option === "continue" ? 0 : 1;
+  if (response.chosen_index !== expectedIndex) {
+    throw new Error("owner response chosen_index does not match chosen_option");
+  }
   return response;
 }
 
@@ -357,7 +361,11 @@ export async function executeIssue543LiveRunner(
       "unattended decision",
     );
     const resolution = recordOf(decision.decision_resolution);
-    if (resolution?.state !== "auto_resolved" || resolution.chosen_option !== "proceed") {
+    if (
+      resolution?.state !== "auto_resolved"
+      || resolution.chosen_index !== 0
+      || resolution.chosen_option !== "proceed"
+    ) {
       throw new Error("unattended decision was not auto_resolved to the first option");
     }
     const seq = decisionSeq(decision, "unattended decision");
@@ -403,13 +411,21 @@ export async function executeIssue543LiveRunner(
   return { kind: "linked_reply", triggerSeq: context.seq, node };
 }
 
+// Strip C0 (0x00-0x1F), DEL (0x7F), and C1 (0x80-0x9F) control characters so
+// untrusted server/command output cannot inject terminal escape sequences.
+export function terminalSafe(value: string): string {
+  // eslint-disable-next-line no-control-regex
+  return value.replace(/[\x00-\x1f\x7f-\x9f]/g, "");
+}
+
 export async function main(): Promise<number> {
   try {
     const outcome = await executeIssue543LiveRunner();
     console.log(JSON.stringify({ ok: true, ...outcome }));
     return 0;
   } catch (error) {
-    console.error(`issue-543 live runner failed: ${error instanceof Error ? error.message : String(error)}`);
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`issue-543 live runner failed: ${terminalSafe(message)}`);
     return 1;
   }
 }

--- a/cli/scripts/issue-543-live-runner.ts
+++ b/cli/scripts/issue-543-live-runner.ts
@@ -1,0 +1,417 @@
+#!/usr/bin/env bun
+
+// Deterministic live runner for the #543 reachability closeout smoke.
+//
+// It deliberately knows nothing about tokens, servers, or fixed channels. `party serve`
+// supplies the authoritative AP_* delivery context, and every channel operation goes
+// through the released `party` executable resolved from PATH.
+
+import { readFileSync } from "node:fs";
+import { isAbsolute } from "node:path";
+
+export const ISSUE_543_TIMEOUT_MS = 5 * 60_000;
+
+const TIMEOUT_MARKER = "QA543-TIMEOUT";
+const UNATTENDED_MARKER = "QA543-UNATTENDED";
+const OWNER_MARKER = "QA543-OWNER-ASK";
+const NODE_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
+
+interface ContextDelivery {
+  id: string;
+  work_id: string | null;
+  continuation_ref: string | null;
+  cause: string;
+  attempt: number;
+}
+
+interface ContextDecisionResponse {
+  request_seq: number;
+  chosen_index: number;
+  chosen_option: string;
+  prompt?: string;
+  delivery_id?: string;
+  origin_seq?: number;
+  origin_channel?: string;
+  work_id?: string;
+  continuation_ref?: string;
+}
+
+interface WakeContext {
+  channel: string;
+  seq: number;
+  body: string;
+  self: string;
+  delivery: ContextDelivery | null;
+  decision_response: ContextDecisionResponse | null;
+}
+
+export interface PartyCommandResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+export interface Issue543RunnerDeps {
+  env?: NodeJS.ProcessEnv;
+  runParty?: (args: string[]) => Promise<PartyCommandResult>;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export type Issue543RunnerOutcome =
+  | { kind: "linked_reply"; triggerSeq: number; node: string }
+  | { kind: "unattended_reply"; triggerSeq: number; decisionSeq: number; node: string }
+  | { kind: "waiting_owner"; triggerSeq: number; decisionSeq: number; node: string }
+  | { kind: "owner_resumed"; triggerSeq: number; originSeq: number; node: string };
+
+function recordOf(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function requiredString(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.length === 0) throw new Error(`${label} is required`);
+  return value;
+}
+
+function positiveInteger(value: unknown, label: string): number {
+  if (!Number.isInteger(value) || Number(value) <= 0) throw new Error(`${label} must be a positive integer`);
+  return Number(value);
+}
+
+function optionalString(value: unknown, label: string): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "string" || value.length === 0) throw new Error(`${label} must be a non-empty string`);
+  return value;
+}
+
+function parseDelivery(value: unknown): ContextDelivery | null {
+  if (value === null || value === undefined) return null;
+  const raw = recordOf(value);
+  if (raw === null) throw new Error("context.delivery must be an object or null");
+  const workId = raw.work_id;
+  const continuationRef = raw.continuation_ref;
+  if (workId !== null && typeof workId !== "string") throw new Error("context.delivery.work_id is invalid");
+  if (continuationRef !== null && typeof continuationRef !== "string") {
+    throw new Error("context.delivery.continuation_ref is invalid");
+  }
+  return {
+    id: requiredString(raw.id, "context.delivery.id"),
+    work_id: workId as string | null,
+    continuation_ref: continuationRef as string | null,
+    cause: requiredString(raw.cause, "context.delivery.cause"),
+    attempt: positiveInteger(raw.attempt, "context.delivery.attempt"),
+  };
+}
+
+function parseDecisionResponse(value: unknown): ContextDecisionResponse | null {
+  if (value === null || value === undefined) return null;
+  const raw = recordOf(value);
+  if (raw === null) throw new Error("context.decision_response must be an object or null");
+  const chosenIndex = raw.chosen_index;
+  if (!Number.isInteger(chosenIndex) || Number(chosenIndex) < 0) {
+    throw new Error("context.decision_response.chosen_index must be a non-negative integer");
+  }
+  return {
+    request_seq: positiveInteger(raw.request_seq, "context.decision_response.request_seq"),
+    chosen_index: Number(chosenIndex),
+    chosen_option: requiredString(raw.chosen_option, "context.decision_response.chosen_option"),
+    prompt: optionalString(raw.prompt, "context.decision_response.prompt"),
+    delivery_id: optionalString(raw.delivery_id, "context.decision_response.delivery_id"),
+    origin_seq: raw.origin_seq === undefined
+      ? undefined
+      : positiveInteger(raw.origin_seq, "context.decision_response.origin_seq"),
+    origin_channel: optionalString(raw.origin_channel, "context.decision_response.origin_channel"),
+    work_id: optionalString(raw.work_id, "context.decision_response.work_id"),
+    continuation_ref: optionalString(raw.continuation_ref, "context.decision_response.continuation_ref"),
+  };
+}
+
+function readWakeContext(path: string): WakeContext {
+  if (!isAbsolute(path)) throw new Error("AP_CONTEXT_FILE must be an absolute path");
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(path, "utf8"));
+  } catch (error) {
+    throw new Error(`AP_CONTEXT_FILE is unreadable JSON: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  const raw = recordOf(parsed);
+  if (raw === null) throw new Error("AP_CONTEXT_FILE must contain a JSON object");
+  return {
+    channel: requiredString(raw.channel, "context.channel"),
+    seq: positiveInteger(raw.seq, "context.seq"),
+    body: requiredString(raw.body, "context.body"),
+    self: requiredString(raw.self, "context.self"),
+    delivery: parseDelivery(raw.delivery),
+    decision_response: parseDecisionResponse(raw.decision_response),
+  };
+}
+
+function envValue(env: NodeJS.ProcessEnv, name: string): string {
+  return requiredString(env[name], name);
+}
+
+function parseEnvSeq(env: NodeJS.ProcessEnv): number {
+  const raw = envValue(env, "AP_SEQ");
+  if (!/^[1-9]\d*$/.test(raw)) throw new Error("AP_SEQ must be a positive integer");
+  return Number(raw);
+}
+
+function ownerPrompt(originSeq: number): string {
+  return `QA543 owner approval for trigger seq ${originSeq}`;
+}
+
+function assertContextEnvelope(context: WakeContext, env: NodeJS.ProcessEnv): { channel: string; node: string } {
+  const channel = envValue(env, "AP_CHANNEL");
+  const self = envValue(env, "AP_SELF");
+  const seq = parseEnvSeq(env);
+  // Optional non-secret label distinguishes two released binaries serving the same agent during
+  // the rolling-upgrade lease smoke. Normal runs fall back to the authoritative agent name.
+  const node = env.QA543_NODE ?? self;
+  if (!NODE_RE.test(node)) throw new Error("QA543_NODE/AP_SELF must match [A-Za-z0-9][A-Za-z0-9._-]{0,63}");
+  if (context.channel !== channel) throw new Error("context.channel does not match AP_CHANNEL");
+  if (context.seq !== seq) throw new Error("context.seq does not match AP_SEQ");
+  if (context.self !== self) throw new Error("context.self does not match AP_SELF");
+  return { channel, node };
+}
+
+function assertCurrentDeliveryLineage(context: WakeContext, env: NodeJS.ProcessEnv): ContextDelivery {
+  const delivery = context.delivery;
+  if (delivery === null) throw new Error("directed delivery context is required for decision smoke");
+  const deliveryId = envValue(env, "AP_DELIVERY_ID");
+  const workId = envValue(env, "AP_WORK_ID");
+  const continuationRef = envValue(env, "AP_CONTINUATION_REF");
+  if (delivery.id !== deliveryId) throw new Error("context delivery id does not match AP_DELIVERY_ID");
+  if (delivery.work_id !== workId) throw new Error("context work id does not match AP_WORK_ID");
+  if (delivery.continuation_ref !== continuationRef) {
+    throw new Error("context continuation does not match AP_CONTINUATION_REF");
+  }
+  return delivery;
+}
+
+function smokeDelivery(
+  context: WakeContext,
+  env: NodeJS.ProcessEnv,
+  alwaysRequired = false,
+): ContextDelivery | null {
+  const setting = env.QA543_REQUIRE_DIRECTED;
+  if (setting !== undefined && setting !== "0" && setting !== "1") {
+    throw new Error("QA543_REQUIRE_DIRECTED must be 0 or 1");
+  }
+  if (alwaysRequired || setting === "1" || context.delivery !== null) {
+    return assertCurrentDeliveryLineage(context, env);
+  }
+  return null;
+}
+
+function deliveryEvidence(delivery: ContextDelivery | null): string {
+  if (delivery === null) return "";
+  return ` delivery=${delivery.id.slice(0, 12)} attempt=${delivery.attempt}`;
+}
+
+function assertOwnerAnswerLineage(context: WakeContext, env: NodeJS.ProcessEnv): ContextDecisionResponse {
+  const delivery = assertCurrentDeliveryLineage(context, env);
+  if (delivery.cause !== "owner_answer") throw new Error("owner response delivery cause must be owner_answer");
+  const response = context.decision_response;
+  if (response === null) throw new Error("owner_answer delivery is missing decision_response");
+  if (response.origin_channel !== context.channel) throw new Error("owner response origin_channel is not this channel");
+  const originSeq = positiveInteger(response.origin_seq, "context.decision_response.origin_seq");
+  if (response.prompt !== ownerPrompt(originSeq)) throw new Error("owner response prompt does not match this smoke work");
+  if (response.work_id !== delivery.work_id) throw new Error("owner response work id does not match current work");
+  if (response.continuation_ref !== delivery.continuation_ref) {
+    throw new Error("owner response continuation does not match current continuation");
+  }
+  const originDeliveryId = requiredString(
+    response.delivery_id,
+    "context.decision_response.delivery_id",
+  );
+  if (originDeliveryId === delivery.id) {
+    throw new Error("owner response origin delivery must differ from the owner_answer delivery");
+  }
+  if (response.chosen_option !== "continue" && response.chosen_option !== "stop") {
+    throw new Error("owner response chose an option outside the smoke request");
+  }
+  return response;
+}
+
+function markerIn(body: string): "timeout" | "unattended" | "owner" | "ordinary" {
+  const markers = [
+    body.includes(TIMEOUT_MARKER) ? "timeout" as const : null,
+    body.includes(UNATTENDED_MARKER) ? "unattended" as const : null,
+    body.includes(OWNER_MARKER) ? "owner" as const : null,
+  ].filter((value): value is "timeout" | "unattended" | "owner" => value !== null);
+  if (markers.length > 1) throw new Error("wake body contains multiple QA543 control markers");
+  return markers[0] ?? "ordinary";
+}
+
+export async function runPartyFromPath(
+  args: string[],
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<PartyCommandResult> {
+  const child = (() => {
+    try {
+      return Bun.spawn(["party", ...args], {
+        env,
+        stdin: "ignore",
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+    } catch (error) {
+      throw new Error(`failed to start party from PATH: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  })();
+  const [stdout, stderr, code] = await Promise.all([
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+    child.exited,
+  ]);
+  return { code, stdout, stderr };
+}
+
+async function checkedParty(
+  runParty: (args: string[]) => Promise<PartyCommandResult>,
+  args: string[],
+  label: string,
+): Promise<PartyCommandResult> {
+  const result = await runParty(args);
+  if (result.code !== 0) {
+    const detail = result.stderr.trim() || result.stdout.trim() || `exit ${result.code}`;
+    throw new Error(`${label} failed: ${detail}`);
+  }
+  return result;
+}
+
+function parseDecisionOutput(result: PartyCommandResult, label: string): Record<string, unknown> {
+  const output = result.stdout.trim();
+  try {
+    const parsed = JSON.parse(output);
+    const record = recordOf(parsed);
+    if (record === null) throw new Error("not an object");
+    return record;
+  } catch (error) {
+    throw new Error(`${label} did not return one JSON object: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+function decisionSeq(output: Record<string, unknown>, label: string): number {
+  return positiveInteger(output.seq, `${label}.seq`);
+}
+
+async function sendLinkedReply(
+  runParty: (args: string[]) => Promise<PartyCommandResult>,
+  channel: string,
+  replyTo: number,
+  body: string,
+): Promise<void> {
+  await checkedParty(
+    runParty,
+    ["send", body, "--channel", channel, "--reply-to", String(replyTo), "--no-reach"],
+    "party send",
+  );
+}
+
+export async function executeIssue543LiveRunner(
+  deps: Issue543RunnerDeps = {},
+): Promise<Issue543RunnerOutcome> {
+  const env = deps.env ?? process.env;
+  const contextPath = envValue(env, "AP_CONTEXT_FILE");
+  const context = readWakeContext(contextPath);
+  const { channel, node } = assertContextEnvelope(context, env);
+  const runParty = deps.runParty ?? ((args: string[]) => runPartyFromPath(args, env));
+  const sleep = deps.sleep ?? ((ms: number) => Bun.sleep(ms));
+
+  if (context.decision_response !== null) {
+    const response = assertOwnerAnswerLineage(context, env);
+    const delivery = context.delivery!;
+    const originSeq = positiveInteger(response.origin_seq, "context.decision_response.origin_seq");
+    await sendLinkedReply(
+      runParty,
+      channel,
+      context.seq,
+      `QA543-OWNER-RESUMED QA543_NODE=${node} origin_seq=${originSeq} answer=${response.chosen_option}`
+        + ` origin_delivery=${response.delivery_id!.slice(0, 12)}${deliveryEvidence(delivery)}`,
+    );
+    return { kind: "owner_resumed", triggerSeq: context.seq, originSeq, node };
+  }
+
+  const marker = markerIn(context.body);
+  if (marker === "timeout") {
+    smokeDelivery(context, env);
+    await sleep(ISSUE_543_TIMEOUT_MS);
+    throw new Error(`QA543 timeout marker survived ${ISSUE_543_TIMEOUT_MS}ms; outer runner timeout did not fire`);
+  }
+
+  if (marker === "unattended") {
+    const delivery = smokeDelivery(context, env, true)!;
+    if (delivery.cause === "owner_answer") throw new Error("unattended request cannot start from owner_answer");
+    const decision = parseDecisionOutput(
+      await checkedParty(
+        runParty,
+        [
+          "decision", "ask", `QA543 unattended choice for trigger seq ${context.seq}`,
+          "--option", "proceed", "--option", "stop",
+          "--channel", channel, "--json",
+        ],
+        "party decision ask (unattended)",
+      ),
+      "unattended decision",
+    );
+    const resolution = recordOf(decision.decision_resolution);
+    if (resolution?.state !== "auto_resolved" || resolution.chosen_option !== "proceed") {
+      throw new Error("unattended decision was not auto_resolved to the first option");
+    }
+    const seq = decisionSeq(decision, "unattended decision");
+    await sendLinkedReply(
+      runParty,
+      channel,
+      context.seq,
+      `QA543-UNATTENDED-REPLY QA543_NODE=${node} trigger_seq=${context.seq} decision_seq=${seq}`
+        + deliveryEvidence(delivery),
+    );
+    return { kind: "unattended_reply", triggerSeq: context.seq, decisionSeq: seq, node };
+  }
+
+  if (marker === "owner") {
+    const delivery = smokeDelivery(context, env, true)!;
+    if (delivery.cause === "owner_answer") throw new Error("owner request cannot start from owner_answer");
+    const decision = parseDecisionOutput(
+      await checkedParty(
+        runParty,
+        [
+          "decision", "ask", ownerPrompt(context.seq),
+          "--option", "continue", "--option", "stop",
+          "--channel", channel, "--json",
+        ],
+        "party decision ask (owner)",
+      ),
+      "owner decision",
+    );
+    if (decision.state !== "waiting_owner") throw new Error("owner decision did not park as waiting_owner");
+    const resolution = recordOf(decision.decision_resolution);
+    if (resolution?.state !== "pending") throw new Error("owner decision is not pending");
+    const seq = decisionSeq(decision, "owner decision");
+    return { kind: "waiting_owner", triggerSeq: context.seq, decisionSeq: seq, node };
+  }
+
+  const delivery = smokeDelivery(context, env);
+  await sendLinkedReply(
+    runParty,
+    channel,
+    context.seq,
+    `QA543-LINKED-REPLY QA543_NODE=${node} trigger_seq=${context.seq}${deliveryEvidence(delivery)}`,
+  );
+  return { kind: "linked_reply", triggerSeq: context.seq, node };
+}
+
+export async function main(): Promise<number> {
+  try {
+    const outcome = await executeIssue543LiveRunner();
+    console.log(JSON.stringify({ ok: true, ...outcome }));
+    return 0;
+  } catch (error) {
+    console.error(`issue-543 live runner failed: ${error instanceof Error ? error.message : String(error)}`);
+    return 1;
+  }
+}
+
+if (import.meta.main) process.exit(await main());

--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -116,21 +116,69 @@ function isSender(value: unknown): boolean {
   return isRecord(value) && typeof value.name === "string" && (value.kind === "agent" || value.kind === "human");
 }
 
+function isStringOrNull(value: unknown): boolean {
+  return value === null || typeof value === "string";
+}
+
+function isFiniteNumberOrNull(value: unknown): boolean {
+  return value === null || Number.isFinite(value);
+}
+
+function isRecordOrNull(value: unknown): boolean {
+  return value === null || isRecord(value);
+}
+
+// MsgFrame (shared/src/protocol.ts): only `type/seq/sender/kind/body/mentions/reply_to/
+// state/note/status/ts` are required. `state`/`note` are `string | null`, `status` is
+// `StatusEvent | null` (an object — status-type frames carry a StatusEvent). Everything
+// else on MsgFrame is optional (`?`) and is intentionally NOT required here.
 function isMessageFrame(value: unknown): boolean {
   return isRecord(value) &&
     (value.type === "msg" || value.type === "status") &&
     Number.isSafeInteger(value.seq) &&
     isSender(value.sender) &&
+    typeof value.kind === "string" &&
     typeof value.body === "string" &&
-    Array.isArray(value.mentions);
+    Array.isArray(value.mentions) &&
+    value.mentions.every((m) => typeof m === "string") &&
+    isFiniteNumberOrNull(value.reply_to) &&
+    isStringOrNull(value.state) &&
+    isStringOrNull(value.note) &&
+    isRecordOrNull(value.status) &&
+    Number.isFinite(value.ts);
 }
 
-function isDelivery(value: unknown): boolean {
+// Full DirectedDelivery, carried only by holder-only `delivery` frames. Nullable fields
+// (lease_until/work_id/continuation_ref/reply_seq/last_error) are validated only for type,
+// allowing null.
+function isDirectedDelivery(value: unknown): boolean {
+  return isRecord(value) &&
+    typeof value.id === "string" &&
+    Number.isSafeInteger(value.message_seq) &&
+    typeof value.target_name === "string" &&
+    typeof value.cause === "string" &&
+    typeof value.state === "string" &&
+    Number.isSafeInteger(value.attempt) &&
+    isFiniteNumberOrNull(value.lease_until) &&
+    isStringOrNull(value.work_id) &&
+    isStringOrNull(value.continuation_ref) &&
+    isFiniteNumberOrNull(value.reply_seq) &&
+    isStringOrNull(value.last_error) &&
+    Number.isFinite(value.created_at) &&
+    Number.isFinite(value.updated_at);
+}
+
+// PublicDirectedDelivery projection, carried by `delivery_state` frames. It intentionally
+// omits cause/attempt/lease_until/work_id/continuation_ref/last_error — those NEVER appear
+// on a state frame, so requiring them (as the old shared isDelivery did) wrongly rejected
+// every valid delivery_state frame.
+function isPublicDelivery(value: unknown): boolean {
   return isRecord(value) &&
     typeof value.id === "string" &&
     Number.isSafeInteger(value.message_seq) &&
     typeof value.target_name === "string" &&
     typeof value.state === "string" &&
+    isFiniteNumberOrNull(value.reply_seq) &&
     Number.isFinite(value.created_at) &&
     Number.isFinite(value.updated_at);
 }
@@ -180,11 +228,11 @@ function parseServerFrame(value: unknown): ServerFrame | null {
     case "delivery_adapter":
       return value.adapter === "watch" && value.registered === true ? value as unknown as ServerFrame : null;
     case "delivery":
-      return isDelivery(value.delivery) && isMessageFrame(value.message)
+      return isDirectedDelivery(value.delivery) && isMessageFrame(value.message)
         ? value as unknown as ServerFrame
         : null;
     case "delivery_state":
-      return isDelivery(value.delivery) ? value as unknown as ServerFrame : null;
+      return isPublicDelivery(value.delivery) ? value as unknown as ServerFrame : null;
     default:
       return null;
   }

--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -108,6 +108,88 @@ function isRetryableNetworkError(error: unknown): boolean {
   return error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError");
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isSender(value: unknown): boolean {
+  return isRecord(value) && typeof value.name === "string" && (value.kind === "agent" || value.kind === "human");
+}
+
+function isMessageFrame(value: unknown): boolean {
+  return isRecord(value) &&
+    (value.type === "msg" || value.type === "status") &&
+    Number.isSafeInteger(value.seq) &&
+    isSender(value.sender) &&
+    typeof value.body === "string" &&
+    Array.isArray(value.mentions);
+}
+
+function isDelivery(value: unknown): boolean {
+  return isRecord(value) &&
+    typeof value.id === "string" &&
+    Number.isSafeInteger(value.message_seq) &&
+    typeof value.target_name === "string" &&
+    typeof value.state === "string" &&
+    Number.isFinite(value.created_at) &&
+    Number.isFinite(value.updated_at);
+}
+
+/** JSON syntax alone is not a protocol heartbeat: validate the discriminant and required shape. */
+function parseServerFrame(value: unknown): ServerFrame | null {
+  if (!isRecord(value) || typeof value.type !== "string") return null;
+  switch (value.type) {
+    case "welcome":
+      return typeof value.channel === "string" && typeof value.self === "string" &&
+        Number.isSafeInteger(value.last_seq) &&
+        (value.participants === undefined || Array.isArray(value.participants)) &&
+        (value.presence === undefined || Array.isArray(value.presence))
+        ? value as unknown as ServerFrame
+        : null;
+    case "participants":
+      return Array.isArray(value.participants) && value.participants.every(isSender)
+        ? value as unknown as ServerFrame
+        : null;
+    case "msg":
+    case "status":
+      return isMessageFrame(value) ? value as unknown as ServerFrame : null;
+    case "message_update":
+      return Number.isSafeInteger(value.target_seq) && isMessageFrame(value.message)
+        ? value as unknown as ServerFrame
+        : null;
+    case "sent":
+      return Number.isSafeInteger(value.seq) ? value as unknown as ServerFrame : null;
+    case "presence":
+      return typeof value.name === "string" && typeof value.state === "string" && Number.isFinite(value.ts)
+        ? value as unknown as ServerFrame
+        : null;
+    case "read_cursor":
+      return typeof value.name === "string" && Number.isSafeInteger(value.last_seen_seq) && Number.isFinite(value.updated_at)
+        ? value as unknown as ServerFrame
+        : null;
+    case "error":
+      return typeof value.code === "string" && typeof value.message === "string"
+        ? value as unknown as ServerFrame
+        : null;
+    case "pong":
+      return value as unknown as ServerFrame;
+    case "serve_lease":
+      return typeof value.name === "string" && typeof value.held === "boolean"
+        ? value as unknown as ServerFrame
+        : null;
+    case "delivery_adapter":
+      return value.adapter === "watch" && value.registered === true ? value as unknown as ServerFrame : null;
+    case "delivery":
+      return isDelivery(value.delivery) && isMessageFrame(value.message)
+        ? value as unknown as ServerFrame
+        : null;
+    case "delivery_state":
+      return isDelivery(value.delivery) ? value as unknown as ServerFrame : null;
+    default:
+      return null;
+  }
+}
+
 export interface ConnectOptions {
   onCursor?: (cursor: number) => void;
   /** Declare that this connection consumes durable directed-delivery v1 frames. */
@@ -119,7 +201,7 @@ export interface ConnectOptions {
   backoffMaxMs?: number;
   pingIntervalMs?: number;
   /**
-   * WebSocket 已 open、但连续多久没有收到任何入站 frame 后主动重连。
+   * WebSocket 已 open、但连续多久没有收到可解析的服务端 frame 后主动重连。
    * 默认 3 个 ping 周期；主要暴露给测试注入较短阈值。
    */
   inboundIdleTimeoutMs?: number;
@@ -300,11 +382,11 @@ export function connect(
     }
   };
 
-  const scheduleReconnect = () => {
+  const scheduleReconnect = (error?: string) => {
     if (closed || reconnectTimer) return;
     const delay = Math.min(base * 2 ** attempt, max);
     attempt++;
-    opts.onStatus?.("reconnecting");
+    opts.onStatus?.("reconnecting", error === undefined ? undefined : { error });
     reconnectTimer = setTimeout(() => {
       reconnectTimer = null;
       if (!closed) open();
@@ -334,7 +416,7 @@ export function connect(
         } catch {
           // The socket is already retired; reconnect scheduling below remains authoritative.
         }
-        scheduleReconnect();
+        scheduleReconnect("inbound idle timeout");
       }, inboundIdleTimeoutMs);
     };
     sock.onopen = () => {
@@ -365,16 +447,19 @@ export function connect(
     };
     sock.onmessage = (ev) => {
       if (closed || ws !== sock) return;
-      // 活性定义是收到任意 WebSocket 入站 frame；即使内容随后无法解析，也说明链路仍可达。
-      armInboundWatchdog();
       for (const line of String(ev.data).split("\n")) {
         if (!line.trim()) continue;
-        let frame: ServerFrame;
+        let parsed: unknown;
         try {
-          frame = JSON.parse(line) as ServerFrame;
+          parsed = JSON.parse(line) as unknown;
         } catch {
           continue;
         }
+        const frame = parseServerFrame(parsed);
+        if (frame === null) continue;
+        // 只有可解析的服务端 frame 才证明应用层仍可用。畸形字节不能无限续命一个
+        // 半坏连接，否则健康探针会持续显示在线而业务帧永远到不了。
+        armInboundWatchdog();
         // #373：只有握手/业务帧能证明这次连接恢复了应用层服务。pong 只证明传输层仍有
         // 回包；过载或半坏实例若只回 pong 后断开，不能借此把指数退避反复清零。
         if (frame.type !== "pong") attempt = 0;

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -2740,7 +2740,9 @@ export async function runServe(o: ServeOptions): Promise<number> {
         reconnecting: true,
         reconnect_count: reconnectCount,
         connected_since: null,
-        last_error: detail?.error ?? null,
+        // 无新错误详情时保留上一条重连原因，避免 inbound timeout 后的替换连接在收到
+        // 有效帧前再次断开时把 last_error 覆盖成 null（丢失原因）。
+        ...(detail?.error === undefined ? {} : { last_error: detail.error }),
       }));
     } else {
       bestEffortLocalState(() => writeHealthCache({ channel: o.channel, ws_connected: false, reconnecting: false, connected_since: null, last_error: detail?.error ?? null }));

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -40,6 +40,7 @@ import { buildContext } from "./status";
 import {
   blockRunnerContinuation,
   continuationPath,
+  deleteRunnerContinuation,
   mergeRunnerContinuation,
   readRunnerContinuation,
   type RunnerContinuationState,
@@ -350,6 +351,8 @@ interface SdkWakeSessionState extends RunnerContinuationState {
 interface ContinuationScope {
   ref: string | null;
   workId: string | null;
+  deliveryId: string | null;
+  deliveryAttempt: number | null;
   path: string;
   ownerAnswer: boolean;
   directed: boolean;
@@ -684,6 +687,8 @@ export interface ServeRunnerContext {
 export type ServeRunner = ((frame: MsgFrame, ctx: ServeRunnerContext) => Promise<void>) & {
   /** Everything that can fail before the model starts. Called before durable `running`. */
   prepare?: (frame: MsgFrame, ctx: ServeRunnerContext) => Promise<void>;
+  /** Release per-work model state only after the Worker confirms a terminal delivery. */
+  onDeliveryTerminal?: (delivery: DirectedDelivery, state: "replied" | "failed") => void | Promise<void>;
 };
 
 export interface ServeOptions {
@@ -745,6 +750,8 @@ export interface ServeOptions {
   now?: () => number;
   /** 单次 runner 的硬超时；默认 30 分钟。到点后恢复监听，不再让 task heartbeat 无限伪装健康。 */
   runnerTimeoutMs?: number;
+  /** WS 入站 watchdog 阈值；仅供诊断/测试注入，默认沿用 client 的 3 个 ping 周期。 */
+  inboundIdleTimeoutMs?: number;
   /** 外层 profile/supervisor 持有的生命周期；存在时 runServe 不再注册进程级 signal listener。 */
   signal?: AbortSignal;
 }
@@ -1068,6 +1075,8 @@ function continuationScope(workdir: string, delivery: DirectedDelivery | null | 
     return {
       ref: null,
       workId: null,
+      deliveryId: null,
+      deliveryAttempt: null,
       path: join(workdir, RUNNER_SESSION_FILE),
       ownerAnswer: false,
       directed: false,
@@ -1084,6 +1093,8 @@ function continuationScope(workdir: string, delivery: DirectedDelivery | null | 
   return {
     ref,
     workId,
+    deliveryId: delivery.id,
+    deliveryAttempt: delivery.attempt,
     // continuation_ref is server data, not a path segment. The shared helper hashes the full opaque
     // value, so both the runner and `party decision ask` commit to exactly the same collision-safe path.
     path: continuationPath(workdir, ref),
@@ -1433,12 +1444,20 @@ export function createSdkRunner(opts: SdkRunnerOptions): NonNullable<ServeOption
     thread: ThreadLike | null;
     session: SdkWakeSessionState | null;
     activeThreadFromPersistedSession: boolean;
+    activeRunKey: string | null;
   }
-  // CodexClientOptions.env is fixed when the SDK client is created. Keep one client per continuation
-  // slot so shell tools spawned by work A can never inherit work B's decision/continuation identity.
-  const codexPromises = new Map<string, Promise<CodexLike>>();
+  // CodexClientOptions.env is fixed when the SDK client is created. A continuation may receive more
+  // than one delivery (initial mention, then one or more owner answers), so a client/thread created
+  // for the first delivery must not be reused with its stale AP_DELIVERY_ID. The durable thread id is
+  // resumed through a fresh client for each delivery attempt; that keeps nested `party decision ask`
+  // bound to the exact delivery currently running while preserving the model conversation.
   const slots = new Map<string, SdkSlot>();
   let queue = Promise.resolve();
+  const runKey = (scope: ContinuationScope): string => JSON.stringify([
+    scope.path,
+    scope.deliveryId,
+    scope.deliveryAttempt,
+  ]);
   const clientOptions = (scope: ContinuationScope, sessionId: string | null): CodexClientOptions => ({
     env: definedEnv({
       ...process.env,
@@ -1449,8 +1468,10 @@ export function createSdkRunner(opts: SdkRunnerOptions): NonNullable<ServeOption
       ...(sessionId === null ? {} : { AP_RUNNER_SESSION_ID: sessionId }),
       ...(scope.directed
         ? {
+            AP_DELIVERY_ID: scope.deliveryId!,
             AP_WORK_ID: scope.workId!,
             AP_CONTINUATION_REF: scope.ref!,
+            AP_DELIVERY_ATTEMPT: String(scope.deliveryAttempt!),
           }
         : {}),
     }),
@@ -1462,18 +1483,15 @@ export function createSdkRunner(opts: SdkRunnerOptions): NonNullable<ServeOption
   };
 
   const codex = (scope: ContinuationScope, sessionId: string | null): Promise<CodexLike> => {
-    let client = codexPromises.get(scope.path);
-    if (client === undefined) {
-      client = Promise.resolve((opts.codexFactory ?? defaultCodexFactory)(clientOptions(scope, sessionId)));
-      codexPromises.set(scope.path, client);
-    }
-    return client;
+    // Do not cache a rejected factory promise: pre-model failures are explicitly retriable and need
+    // a fresh SDK client. Successful clients live only for the delivery attempt whose env they carry.
+    return Promise.resolve((opts.codexFactory ?? defaultCodexFactory)(clientOptions(scope, sessionId)));
   };
 
   const slotFor = (scope: ContinuationScope): SdkSlot => {
     let slot = slots.get(scope.path);
     if (slot === undefined) {
-      slot = { thread: null, session: null, activeThreadFromPersistedSession: false };
+      slot = { thread: null, session: null, activeThreadFromPersistedSession: false, activeRunKey: null };
       slots.set(scope.path, slot);
     }
     return slot;
@@ -1483,6 +1501,7 @@ export function createSdkRunner(opts: SdkRunnerOptions): NonNullable<ServeOption
     slot.thread = null;
     slot.session = null;
     slot.activeThreadFromPersistedSession = false;
+    slot.activeRunKey = null;
   };
 
   const ensureThread = async (
@@ -1490,6 +1509,13 @@ export function createSdkRunner(opts: SdkRunnerOptions): NonNullable<ServeOption
     scope: ContinuationScope,
     slot: SdkSlot,
   ): Promise<{ thread: ThreadLike; session: SdkWakeSessionState | null }> => {
+    const currentRunKey = runKey(scope);
+    if (slot.activeRunKey !== currentRunKey) {
+      // Keep the durable session mapping, but replace the SDK client/thread so tool subprocesses get
+      // this delivery's AP_DELIVERY_ID instead of the previous turn's lineage.
+      slot.thread = null;
+      slot.activeThreadFromPersistedSession = false;
+    }
     // owner_answer is allowed to resume only a durable, exact mapping. Even a resident in-memory
     // thread is rejected if its file disappeared or was replaced: silently cold-starting here would
     // detach the answer from the work that asked the question.
@@ -1525,6 +1551,7 @@ export function createSdkRunner(opts: SdkRunnerOptions): NonNullable<ServeOption
         slot.thread = await client.resumeThread(prior.thread_id, threadOptions);
         slot.session = prior;
         slot.activeThreadFromPersistedSession = true;
+        slot.activeRunKey = currentRunKey;
         return { thread: slot.thread, session: slot.session };
       } catch (error) {
         if (!isInvalidPersistedSessionError(error)) {
@@ -1550,6 +1577,7 @@ export function createSdkRunner(opts: SdkRunnerOptions): NonNullable<ServeOption
     }
     slot.thread = await beforeModel(() => client.startThread(threadOptions));
     slot.activeThreadFromPersistedSession = false;
+    slot.activeRunKey = currentRunKey;
     const threadId = sdkThreadId(slot.thread);
     // thread id 懒初始化：拿不到就先不落 session 文件，等首个 run() 之后补写
     slot.session = threadId
@@ -1772,6 +1800,27 @@ export function createSdkRunner(opts: SdkRunnerOptions): NonNullable<ServeOption
     return next;
   };
   runner.prepare = prepare;
+  runner.onDeliveryTerminal = (delivery) => {
+    if (delivery.work_id === null || delivery.continuation_ref === null) return;
+    const path = continuationPath(opts.workdir, delivery.continuation_ref);
+    const slot = slots.get(path);
+    const cleanup = deleteRunnerContinuation(path, {
+      harness: "codex-sdk",
+      work_id: delivery.work_id,
+      continuation_ref: delivery.continuation_ref,
+    });
+    const slotMatches = slot !== undefined && (
+      slot.session === null ||
+      slot.session.work_id === delivery.work_id &&
+      slot.session.continuation_ref === delivery.continuation_ref
+    );
+    // A disk mismatch belongs to another still-actionable work. Preserve an in-memory slot with
+    // that same identity too; a null session is only the failed delivery's empty preflight slot.
+    if (slotMatches && cleanup !== "mismatch") {
+      resetSlot(slot!);
+      slots.delete(path);
+    }
+  };
   return runner;
 }
 
@@ -1970,6 +2019,14 @@ export function createBuiltinRunner(opts: BuiltinRunnerOptions): NonNullable<Ser
     );
   };
   runner.prepare = prepare;
+  runner.onDeliveryTerminal = (delivery) => {
+    if (delivery.work_id === null || delivery.continuation_ref === null) return;
+    deleteRunnerContinuation(continuationPath(opts.workdir, delivery.continuation_ref), {
+      harness: opts.harness,
+      work_id: delivery.work_id,
+      continuation_ref: delivery.continuation_ref,
+    });
+  };
   return runner;
 }
 
@@ -2532,6 +2589,7 @@ export async function confirmDeliveryUpdate(
   update: DeliveryUpdateFrame,
   timeoutMs = DELIVERY_UPDATE_ACK_TIMEOUT_MS,
   signal?: AbortSignal,
+  acceptedAuthoritativeStates: readonly PublicDirectedDelivery["state"][] = [],
 ): Promise<PublicDirectedDelivery> {
   const requestId = randomUUID();
   const existingErrors = new Set(conn.pendingFrames().filter((frame) => frame.type === "error"));
@@ -2553,6 +2611,11 @@ export async function confirmDeliveryUpdate(
       // The late generic `replied` receipt is intentionally a no-op; the authoritative suspended
       // state is still a successful durable acknowledgement of this turn.
       if (update.state === "replied" && ack.delivery.state === "waiting_owner") return ack.delivery;
+      // Some transitions are probes rather than commands. In particular, a bare `replied` probe
+      // asks the Worker whether a linked REST reply actually committed. The caller may explicitly
+      // accept the authoritative `failed` answer and handle it as a visible silent-runner failure;
+      // keep the default strict for every ordinary state transition.
+      if (acceptedAuthoritativeStates.includes(ack.delivery.state)) return ack.delivery;
       if (ack.delivery.state === "waiting_owner" || ack.delivery.state === "replied" || ack.delivery.state === "failed") {
         throw new Error(`delivery state is ${ack.delivery.state}, expected ${update.state}`);
       }
@@ -2658,10 +2721,27 @@ export async function runServe(o: ServeOptions): Promise<number> {
   };
   const onWsStatus = (status: "open" | "reconnecting" | "closed", detail?: { error?: string }) => {
     if (status === "open") {
-      bestEffortLocalState(() => writeHealthCache({ channel: o.channel, ws_connected: true, reconnecting: false, connected_since: Date.now(), last_error: null }));
+      // A successful TCP/WS handshake is not proof that the application path is alive. Clear the
+      // previous frame timestamp on every replacement socket and keep the reconnect reason until
+      // the frame loop receives a valid server frame; otherwise a half-broken endpoint that only
+      // accepts WebSockets briefly inherits the old socket's fresh timestamp and looks healthy.
+      bestEffortLocalState(() => writeHealthCache({
+        channel: o.channel,
+        ws_connected: true,
+        reconnecting: false,
+        connected_since: Date.now(),
+        last_frame_at: null,
+      }));
     } else if (status === "reconnecting") {
       reconnectCount += 1;
-      bestEffortLocalState(() => writeHealthCache({ channel: o.channel, ws_connected: false, reconnecting: true, reconnect_count: reconnectCount, connected_since: null }));
+      bestEffortLocalState(() => writeHealthCache({
+        channel: o.channel,
+        ws_connected: false,
+        reconnecting: true,
+        reconnect_count: reconnectCount,
+        connected_since: null,
+        last_error: detail?.error ?? null,
+      }));
     } else {
       bestEffortLocalState(() => writeHealthCache({ channel: o.channel, ws_connected: false, reconnecting: false, connected_since: null, last_error: detail?.error ?? null }));
     }
@@ -2688,6 +2768,7 @@ export async function runServe(o: ServeOptions): Promise<number> {
       sinceRev: o.sinceRev,
       onRevCursor: o.onRevCursor,
       onStatus: onWsStatus,
+      inboundIdleTimeoutMs: o.inboundIdleTimeoutMs,
     });
   } catch (error) {
     lock?.release?.();
@@ -2750,6 +2831,15 @@ export async function runServe(o: ServeOptions): Promise<number> {
           },
         })
       : defaultRun);
+  const settleRunnerDelivery = async (delivery: DirectedDelivery, state: "replied" | "failed") => {
+    try {
+      await run.onDeliveryTerminal?.(delivery, state);
+    } catch (error) {
+      // The channel reply/failure is already authoritative. Local cleanup must be visible but can
+      // never roll the durable delivery back or make the runner execute the work again.
+      out(`  delivery ${delivery.id} 本地 continuation 清理失败: ${errText(error)}`);
+    }
+  };
   // 挂载之初就落一份 health 基线：即便还没收到第一帧，watchdog 也能看到「这个 pid 认领了这个频道」，
   // 而不是文件缺失时无法区分「serve 没起来」和「serve 起来了但还没写过健康数据」。
   bestEffortLocalState(() => writeHealthCache({ channel: o.channel, ws_connected: false, reconnecting: false, reconnect_count: 0, last_frame_at: null, last_error: null, connected_since: null }));
@@ -2834,7 +2924,11 @@ export async function runServe(o: ServeOptions): Promise<number> {
       const frame = incoming.type === "delivery" ? incoming.message : incoming;
       // 每收到一帧（含 ping 的 pong 回执）就刷新 last_frame_at——空闲频道也靠 ping 心跳（~25s）
       // 保持新鲜，watchdog 才能把"频道安静"和"连接僵死"分开（issue #254 证据边界）。
-      bestEffortLocalState(() => writeHealthCache({ channel: o.channel, last_frame_at: Date.now() }));
+      bestEffortLocalState(() => writeHealthCache({
+        channel: o.channel,
+        last_frame_at: Date.now(),
+        last_error: null,
+      }));
       if (frame.type === "welcome") {
         self = frame.self;
         if (!welcomeReported) {
@@ -3009,6 +3103,12 @@ export async function runServe(o: ServeOptions): Promise<number> {
         // lastError 必须从盘上接手，否则最终通告里的错误原因是空字符串（门禁 P2）。
         let lastError = (stuck?.seq === frame.seq ? stuck.last_error : "") ?? "";
         let delivered = false;
+        let deliveryCleanupDone = false;
+        const settleCurrentDelivery = async (state: "replied" | "failed") => {
+          if (directedDelivery === null || deliveryCleanupDone) return;
+          await settleRunnerDelivery(directedDelivery, state);
+          deliveryCleanupDone = true;
+        };
         // A crash can happen after a non-retriable model failure was persisted but before the final
         // blocked announcement. Preserve that safety bit across supervisor restarts; old state files
         // omit it and retain the historical retryable behavior for compatibility.
@@ -3119,6 +3219,7 @@ export async function runServe(o: ServeOptions): Promise<number> {
                 state: "failed",
                 error: sanitizeBlockedError(lastError),
               }, undefined, lifecycleController.signal);
+              await settleCurrentDelivery("failed");
             } catch (error) {
               out(`  delivery ${directedDelivery.id} 预处理失败回执发送失败: ${errText(error)}`);
               code = EXIT_STREAM_ENDED;
@@ -3255,6 +3356,44 @@ export async function runServe(o: ServeOptions): Promise<number> {
           await delay(0);
         }
         if (shutdownError !== null) break frameLoop;
+        let deliveryConfirmed = directedDelivery === null;
+        if (delivered && directedDelivery !== null) {
+          try {
+            const completion = await confirmDeliveryUpdate(conn, {
+              type: "delivery_update",
+              delivery_id: directedDelivery.id,
+              state: "replied",
+            }, undefined, lifecycleController.signal, ["failed"]);
+            if (completion.state === "failed") {
+              // Worker is the race-free authority: if a linked REST reply committed, the row was
+              // already replied before that HTTP request returned. A still-active row receiving a
+              // bare success receipt is atomically failed as a silent runner, never guessed from
+              // whether the asynchronous delivery_state broadcast reached this process yet.
+              delivered = false;
+              retriable = false;
+              deliveryConfirmed = true;
+              lastError = "runner exited successfully without a linked channel reply";
+              attemptsUsed = Math.max(attemptsUsed, attemptFloor + 1);
+              out(`  ${lastError}: seq=${frame.seq}`);
+              // The first completion probe already made `failed` authoritative in the Worker.
+              // Clean exact local continuation state now; a disconnect before the redundant
+              // blocked-state receipt below must not leave a terminal work capability on disk.
+              await settleCurrentDelivery("failed");
+            } else {
+              deliveryConfirmed = true;
+              if (completion.state === "replied") {
+                await settleCurrentDelivery("replied");
+              }
+            }
+          } catch (error) {
+            const message = errText(error);
+            // 不伪称已确认：退出本轮。服务端仍保留 claimed/running，随后按明确的
+            // unknown-outcome 规则收口；绝不在本地把 fire-and-forget 当 durable ack。
+            out(`  delivery ${directedDelivery.id} 完成回执发送失败，重连核对: ${message}`);
+            code = EXIT_STREAM_ENDED;
+            stopAfterFrame = true;
+          }
+        }
         if (delivered) {
           // 一条真正送达的 wake 证明 runner 恢复了；此前连续失败不再代表当前健康状态。
           consecutiveWakeAbandons = 0;
@@ -3268,23 +3407,6 @@ export async function runServe(o: ServeOptions): Promise<number> {
           // 这里的 seq 校验在当前 blockedByDebt 守卫之下**不可达**（变异掉它零条测试变红）。
           // 它是第二道闸：一旦有人放宽 blockedByDebt，这行会挡住「A 的成功清掉 B 的欠账」。
           // 不删，理由写在这里。
-          let deliveryConfirmed = directedDelivery === null;
-          if (directedDelivery !== null) {
-            try {
-              await confirmDeliveryUpdate(conn, {
-                type: "delivery_update",
-                delivery_id: directedDelivery.id,
-                state: "replied",
-              }, undefined, lifecycleController.signal);
-              deliveryConfirmed = true;
-            } catch (error) {
-              // 不伪称已确认：退出本轮。服务端仍保留 claimed/running，随后按明确的
-              // unknown-outcome 规则收口；绝不在本地把 fire-and-forget 当 durable ack。
-              out(`  delivery ${directedDelivery.id} 完成回执发送失败，重连核对: ${errText(error)}`);
-              code = EXIT_STREAM_ENDED;
-              stopAfterFrame = true;
-            }
-          }
           if (deliveryConfirmed && stuck !== null && stuck.seq === frame.seq) setStuck(null);
           // busy 清除（#103）：这条 wake 处理完了。若身后已无待处理 wake（队列排空），补一条「空闲」把
           // 之前 working 帧上的 busy 清回 false——否则任务结束后 presence 会永远卡在「忙」（假忙）。
@@ -3338,8 +3460,11 @@ export async function runServe(o: ServeOptions): Promise<number> {
             code = EXIT_WAKE_UNANNOUNCED;
             break;
           }
-          let failureConfirmed = directedDelivery === null;
-          if (directedDelivery !== null) {
+          // A silent-success completion probe may already have atomically returned the Worker's
+          // terminal `failed` state. Do not require a second, redundant ACK after that authority;
+          // a network drop between the two must not turn a known terminal result into "unknown".
+          let failureConfirmed = deliveryConfirmed || directedDelivery === null;
+          if (directedDelivery !== null && !failureConfirmed) {
             try {
               await confirmDeliveryUpdate(conn, {
                 type: "delivery_update",
@@ -3348,6 +3473,7 @@ export async function runServe(o: ServeOptions): Promise<number> {
                 error: sanitizeBlockedError(lastError),
               }, undefined, lifecycleController.signal);
               failureConfirmed = true;
+              await settleCurrentDelivery("failed");
             } catch (error) {
               out(`  delivery ${directedDelivery.id} 失败回执发送失败，重连重试: ${errText(error)}`);
               code = EXIT_STREAM_ENDED;

--- a/cli/src/continuation.ts
+++ b/cli/src/continuation.ts
@@ -220,3 +220,36 @@ export function blockRunnerContinuation(path: string, reason: string, now = Date
     return true;
   });
 }
+
+export interface RunnerContinuationIdentity {
+  harness: RunnerContinuationHarness;
+  work_id: string;
+  continuation_ref: string;
+}
+
+export type DeleteRunnerContinuationResult = "deleted" | "missing" | "mismatch";
+
+/**
+ * Remove one terminal work mapping under the same cross-process lock used by decision parking.
+ * Identity is checked inside that lock: a bad/reused continuation_ref must never let work B delete
+ * work A's still-actionable owner continuation merely because they hash to the same path.
+ *
+ * The shared SQLite mutex remains as one bounded directory-level coordination file; only the
+ * matching per-work JSON is deleted, so completed deliveries cannot grow runner state forever.
+ */
+export function deleteRunnerContinuation(
+  path: string,
+  expected: RunnerContinuationIdentity,
+): DeleteRunnerContinuationResult {
+  return withRunnerContinuationLock(path, () => {
+    const current = readRunnerContinuation(path);
+    if (current === null) return existsSync(path) ? "mismatch" : "missing";
+    if (
+      current.harness !== expected.harness ||
+      current.work_id !== expected.work_id ||
+      current.continuation_ref !== expected.continuation_ref
+    ) return "mismatch";
+    rmSync(path, { force: true });
+    return "deleted";
+  });
+}

--- a/cli/test/client.test.ts
+++ b/cli/test/client.test.ts
@@ -443,13 +443,16 @@ describe("ws client", () => {
   test("inbound watchdog retires a half-open socket and reconnects even without a close event", async () => {
     jest.useFakeTimers();
     useProbeWebSocket();
-    const statuses: string[] = [];
+    const statuses: Array<{ status: string; error?: string }> = [];
     conn = connect("https://party.invalid", "ap_tok", "dev", 0, {
       backoffBaseMs: 5,
       backoffMaxMs: 5,
       pingIntervalMs: 10,
       inboundIdleTimeoutMs: 30,
-      onStatus: (status) => statuses.push(status),
+      onStatus: (status, detail) => statuses.push({
+        status,
+        ...(detail?.error === undefined ? {} : { error: detail.error }),
+      }),
     });
     const first = ProbeWebSocket.instances[0]!;
     first.open();
@@ -458,14 +461,17 @@ describe("ws client", () => {
 
     expect(first.readyState).toBe(ProbeWebSocket.CLOSED);
     expect(first.closeCalls).toContainEqual({ code: 1011, reason: "inbound idle timeout" });
-    expect(statuses).toEqual(["open", "reconnecting"]);
+    expect(statuses).toEqual([
+      { status: "open" },
+      { status: "reconnecting", error: "inbound idle timeout" },
+    ]);
     expect(ProbeWebSocket.instances).toHaveLength(1);
 
     jest.advanceTimersByTime(5);
     expect(ProbeWebSocket.instances).toHaveLength(2);
   });
 
-  test("any inbound frame resets the idle watchdog", async () => {
+  test("a parseable inbound frame resets the idle watchdog", async () => {
     jest.useFakeTimers();
     useProbeWebSocket();
     conn = connect("https://party.invalid", "ap_tok", "dev", 0, {
@@ -485,6 +491,29 @@ describe("ws client", () => {
     expect(first.readyState).toBe(ProbeWebSocket.OPEN);
 
     jest.advanceTimersByTime(40);
+    expect(first.readyState).toBe(ProbeWebSocket.CLOSED);
+  });
+
+  test("malformed or shape-invalid inbound data cannot keep a half-broken connection alive", async () => {
+    jest.useFakeTimers();
+    useProbeWebSocket();
+    conn = connect("https://party.invalid", "ap_tok", "dev", 0, {
+      backoffBaseMs: 5,
+      pingIntervalMs: 10,
+      inboundIdleTimeoutMs: 60,
+    });
+    const first = ProbeWebSocket.instances[0]!;
+    first.open();
+
+    jest.advanceTimersByTime(20);
+    first.deliver("{not-json");
+    jest.advanceTimersByTime(20);
+    first.deliver("null");
+    jest.advanceTimersByTime(10);
+    first.deliver("{}");
+    jest.advanceTimersByTime(10);
+
+    expect(first.closeCalls).toContainEqual({ code: 1011, reason: "inbound idle timeout" });
     expect(first.readyState).toBe(ProbeWebSocket.CLOSED);
   });
 

--- a/cli/test/issue-543-live-runner.test.ts
+++ b/cli/test/issue-543-live-runner.test.ts
@@ -149,6 +149,23 @@ describe("#543 reusable live runner", () => {
     expect(calls).toBe(1);
   });
 
+  test("unattended marker rejects a decision whose index and option disagree", async () => {
+    const file = contextFile({ body: "QA543-UNATTENDED" });
+    let calls = 0;
+    await expect(executeIssue543LiveRunner({
+      env: env(file),
+      runParty: async () => {
+        calls += 1;
+        return successful(JSON.stringify({
+          seq: 54,
+          // Self-contradictory receipt: option "proceed" but index points at the second option.
+          decision_resolution: { state: "auto_resolved", chosen_index: 1, chosen_option: "proceed" },
+        }));
+      },
+    })).rejects.toThrow("was not auto_resolved");
+    expect(calls).toBe(1);
+  });
+
   test("owner marker parks one lineage-bound decision without posting a premature reply", async () => {
     const file = contextFile({ body: "QA543-OWNER-ASK" });
     const calls: string[][] = [];

--- a/cli/test/issue-543-live-runner.test.ts
+++ b/cli/test/issue-543-live-runner.test.ts
@@ -1,0 +1,366 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import {
+  executeIssue543LiveRunner,
+  ISSUE_543_TIMEOUT_MS,
+  type PartyCommandResult,
+} from "../scripts/issue-543-live-runner";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "ap-543-live-runner-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function contextFile(over: Record<string, unknown> = {}): string {
+  const path = join(tempDir(), "wake-context.json");
+  writeFileSync(path, JSON.stringify({
+    channel: "qa-543",
+    seq: 41,
+    body: "ordinary wake",
+    self: "v118-primary",
+    delivery: {
+      id: "delivery-41",
+      work_id: "work-41",
+      continuation_ref: "continuation-41",
+      cause: "mention",
+      attempt: 1,
+    },
+    decision_response: null,
+    ...over,
+  }));
+  return path;
+}
+
+function env(file: string, over: Record<string, string | undefined> = {}): NodeJS.ProcessEnv {
+  return {
+    AP_CONTEXT_FILE: file,
+    AP_CHANNEL: "qa-543",
+    AP_SEQ: "41",
+    AP_SELF: "v118-primary",
+    AP_DELIVERY_ID: "delivery-41",
+    AP_WORK_ID: "work-41",
+    AP_CONTINUATION_REF: "continuation-41",
+    ...over,
+  };
+}
+
+function successful(stdout = "sent seq=99\n"): PartyCommandResult {
+  return { code: 0, stdout, stderr: "" };
+}
+
+describe("#543 reusable live runner", () => {
+  test("ordinary wakes send exactly one linked reply carrying QA543_NODE", async () => {
+    const file = contextFile();
+    const calls: string[][] = [];
+    const result = await executeIssue543LiveRunner({
+      env: env(file, { QA543_NODE: "release-v118" }),
+      runParty: async (args) => {
+        calls.push(args);
+        return successful();
+      },
+    });
+
+    expect(result).toEqual({ kind: "linked_reply", triggerSeq: 41, node: "release-v118" });
+    expect(calls).toEqual([[
+      "send",
+      "QA543-LINKED-REPLY QA543_NODE=release-v118 trigger_seq=41 delivery=delivery-41 attempt=1",
+      "--channel", "qa-543",
+      "--reply-to", "41",
+      "--no-reach",
+    ]]);
+  });
+
+  test("timeout marker sleeps past the outer timeout and never calls party", async () => {
+    const file = contextFile({ body: "please run QA543-TIMEOUT" });
+    const sleeps: number[] = [];
+    let partyCalls = 0;
+    await expect(executeIssue543LiveRunner({
+      env: env(file),
+      sleep: async (ms) => { sleeps.push(ms); },
+      runParty: async () => {
+        partyCalls += 1;
+        return successful();
+      },
+    })).rejects.toThrow("outer runner timeout did not fire");
+    expect(sleeps).toEqual([ISSUE_543_TIMEOUT_MS]);
+    expect(partyCalls).toBe(0);
+  });
+
+  test("unattended marker requires auto-resolution then replies in the same invocation", async () => {
+    const file = contextFile({ body: "请处理 QA543-UNATTENDED" });
+    const calls: string[][] = [];
+    const result = await executeIssue543LiveRunner({
+      env: env(file),
+      runParty: async (args) => {
+        calls.push(args);
+        if (args[0] === "decision") {
+          return successful(JSON.stringify({
+            seq: 52,
+            decision_resolution: { state: "auto_resolved", chosen_index: 0, chosen_option: "proceed" },
+          }));
+        }
+        return successful();
+      },
+    });
+
+    expect(result).toEqual({
+      kind: "unattended_reply",
+      triggerSeq: 41,
+      decisionSeq: 52,
+      node: "v118-primary",
+    });
+    expect(calls).toHaveLength(2);
+    expect(calls[0]).toEqual([
+      "decision", "ask", "QA543 unattended choice for trigger seq 41",
+      "--option", "proceed", "--option", "stop",
+      "--channel", "qa-543", "--json",
+    ]);
+    expect(calls[1]).toEqual([
+      "send",
+      "QA543-UNATTENDED-REPLY QA543_NODE=v118-primary trigger_seq=41 decision_seq=52 delivery=delivery-41 attempt=1",
+      "--channel", "qa-543",
+      "--reply-to", "41",
+      "--no-reach",
+    ]);
+  });
+
+  test("unattended marker refuses a pending decision instead of pretending it resumed", async () => {
+    const file = contextFile({ body: "QA543-UNATTENDED" });
+    let calls = 0;
+    await expect(executeIssue543LiveRunner({
+      env: env(file),
+      runParty: async () => {
+        calls += 1;
+        return successful(JSON.stringify({
+          seq: 53,
+          decision_resolution: { state: "pending" },
+        }));
+      },
+    })).rejects.toThrow("was not auto_resolved");
+    expect(calls).toBe(1);
+  });
+
+  test("owner marker parks one lineage-bound decision without posting a premature reply", async () => {
+    const file = contextFile({ body: "QA543-OWNER-ASK" });
+    const calls: string[][] = [];
+    const result = await executeIssue543LiveRunner({
+      env: env(file),
+      runParty: async (args) => {
+        calls.push(args);
+        return successful(JSON.stringify({
+          seq: 60,
+          state: "waiting_owner",
+          decision_resolution: { state: "pending" },
+        }));
+      },
+    });
+
+    expect(result).toEqual({ kind: "waiting_owner", triggerSeq: 41, decisionSeq: 60, node: "v118-primary" });
+    expect(calls).toEqual([[
+      "decision", "ask", "QA543 owner approval for trigger seq 41",
+      "--option", "continue", "--option", "stop",
+      "--channel", "qa-543", "--json",
+    ]]);
+  });
+
+  test("owner_answer verifies exact work/ref/channel lineage and replies to the answer frame", async () => {
+    const file = contextFile({
+      seq: 72,
+      body: "@qa-agent decision #60 → continue",
+      delivery: {
+        id: "delivery-owner-72",
+        work_id: "work-41",
+        continuation_ref: "continuation-41",
+        cause: "owner_answer",
+        attempt: 1,
+      },
+      decision_response: {
+        request_seq: 60,
+        chosen_index: 0,
+        chosen_option: "continue",
+        prompt: "QA543 owner approval for trigger seq 41",
+        delivery_id: "delivery-41",
+        origin_seq: 41,
+        origin_channel: "qa-543",
+        work_id: "work-41",
+        continuation_ref: "continuation-41",
+      },
+    });
+    const calls: string[][] = [];
+    const result = await executeIssue543LiveRunner({
+      env: env(file, { AP_SEQ: "72", AP_DELIVERY_ID: "delivery-owner-72" }),
+      runParty: async (args) => {
+        calls.push(args);
+        return successful();
+      },
+    });
+
+    expect(result).toEqual({ kind: "owner_resumed", triggerSeq: 72, originSeq: 41, node: "v118-primary" });
+    expect(calls).toEqual([[
+      "send",
+      "QA543-OWNER-RESUMED QA543_NODE=v118-primary origin_seq=41 answer=continue origin_delivery=delivery-41 delivery=delivery-own attempt=1",
+      "--channel", "qa-543",
+      "--reply-to", "72",
+      "--no-reach",
+    ]]);
+  });
+
+  test("owner_answer fails closed before party when continuation lineage is crossed", async () => {
+    const file = contextFile({
+      seq: 72,
+      body: "owner answer",
+      delivery: {
+        id: "delivery-owner-72",
+        work_id: "work-41",
+        continuation_ref: "continuation-41",
+        cause: "owner_answer",
+        attempt: 1,
+      },
+      decision_response: {
+        request_seq: 60,
+        chosen_index: 0,
+        chosen_option: "continue",
+        prompt: "QA543 owner approval for trigger seq 41",
+        delivery_id: "delivery-41",
+        origin_seq: 41,
+        origin_channel: "qa-543",
+        work_id: "work-other",
+        continuation_ref: "continuation-41",
+      },
+    });
+    let calls = 0;
+    await expect(executeIssue543LiveRunner({
+      env: env(file, { AP_SEQ: "72", AP_DELIVERY_ID: "delivery-owner-72" }),
+      runParty: async () => {
+        calls += 1;
+        return successful();
+      },
+    })).rejects.toThrow("owner response work id does not match current work");
+    expect(calls).toBe(0);
+  });
+
+  test("ambiguous control markers fail before party", async () => {
+    const file = contextFile({ body: "QA543-TIMEOUT QA543-UNATTENDED" });
+    let calls = 0;
+    await expect(executeIssue543LiveRunner({
+      env: env(file),
+      sleep: async () => {},
+      runParty: async () => {
+        calls += 1;
+        return successful();
+      },
+    })).rejects.toThrow("multiple QA543 control markers");
+    expect(calls).toBe(0);
+  });
+
+  test("QA543_REQUIRE_DIRECTED rejects a legacy raw wake before posting evidence", async () => {
+    const file = contextFile({ delivery: null });
+    let calls = 0;
+    await expect(executeIssue543LiveRunner({
+      env: env(file, {
+        QA543_REQUIRE_DIRECTED: "1",
+        AP_DELIVERY_ID: undefined,
+        AP_WORK_ID: undefined,
+        AP_CONTINUATION_REF: undefined,
+      }),
+      runParty: async () => {
+        calls += 1;
+        return successful();
+      },
+    })).rejects.toThrow("directed delivery context is required");
+    expect(calls).toBe(0);
+  });
+
+  test("owner_answer requires the original delivery id before posting evidence", async () => {
+    const file = contextFile({
+      seq: 72,
+      body: "owner answer",
+      delivery: {
+        id: "delivery-owner-72",
+        work_id: "work-41",
+        continuation_ref: "continuation-41",
+        cause: "owner_answer",
+        attempt: 1,
+      },
+      decision_response: {
+        request_seq: 60,
+        chosen_index: 0,
+        chosen_option: "continue",
+        prompt: "QA543 owner approval for trigger seq 41",
+        origin_seq: 41,
+        origin_channel: "qa-543",
+        work_id: "work-41",
+        continuation_ref: "continuation-41",
+      },
+    });
+    let calls = 0;
+    await expect(executeIssue543LiveRunner({
+      env: env(file, { AP_SEQ: "72", AP_DELIVERY_ID: "delivery-owner-72" }),
+      runParty: async () => {
+        calls += 1;
+        return successful();
+      },
+    })).rejects.toThrow("context.decision_response.delivery_id is required");
+    expect(calls).toBe(0);
+  });
+
+  test("the executable resolves literal party from PATH and passes no token/server", async () => {
+    const root = tempDir();
+    const bin = join(root, "bin");
+    const capture = join(root, "argv.txt");
+    const context = join(root, "context.json");
+    mkdirSync(bin, { recursive: true });
+    writeFileSync(context, JSON.stringify({
+      channel: "qa-path",
+      seq: 9,
+      body: "ordinary",
+      self: "qa-agent",
+      delivery: null,
+      decision_response: null,
+    }));
+    const fakeParty = join(bin, "party");
+    writeFileSync(fakeParty, `#!/bin/sh\nprintf '%s\\n' "$@" > "$QA543_CAPTURE"\nprintf 'sent seq=10\\n'\n`);
+    chmodSync(fakeParty, 0o755);
+    const script = resolve(import.meta.dir, "../scripts/issue-543-live-runner.ts");
+    const child = Bun.spawn([process.execPath, script], {
+      env: {
+        PATH: `${bin}:${process.env.PATH ?? ""}`,
+        QA543_CAPTURE: capture,
+        AP_CONTEXT_FILE: context,
+        AP_CHANNEL: "qa-path",
+        AP_SEQ: "9",
+        AP_SELF: "qa-agent",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, code] = await Promise.all([
+      new Response(child.stdout).text(),
+      new Response(child.stderr).text(),
+      child.exited,
+    ]);
+
+    expect(code).toBe(0);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toMatchObject({ ok: true, kind: "linked_reply", node: "qa-agent" });
+    const argv = readFileSync(capture, "utf8").trim().split("\n");
+    expect(argv).toEqual([
+      "send",
+      "QA543-LINKED-REPLY QA543_NODE=qa-agent trigger_seq=9",
+      "--channel", "qa-path",
+      "--reply-to", "9",
+      "--no-reach",
+    ]);
+    expect(argv.join(" ")).not.toContain("token");
+    expect(argv.join(" ")).not.toContain("server");
+  });
+});

--- a/cli/test/mock-server.ts
+++ b/cli/test/mock-server.ts
@@ -82,6 +82,7 @@ export function msgFrame(seq: number, body: string, over: Record<string, unknown
     reply_to: null,
     state: null,
     note: null,
+    status: null,
     ts: Date.now(),
     ...over,
   };

--- a/cli/test/serve-continuation.test.ts
+++ b/cli/test/serve-continuation.test.ts
@@ -19,6 +19,7 @@ import { prepareDecisionContinuation } from "../src/commands/decision";
 import {
   blockRunnerContinuation,
   continuationPath,
+  deleteRunnerContinuation,
   mergeRunnerContinuation,
   readRunnerContinuation,
   withRunnerContinuationLock,
@@ -403,6 +404,75 @@ describe("codex-sdk per-work continuations (#548)", () => {
     expect(existsSync(join(workdir, "wake-session.json"))).toBe(false);
   });
 
+  test("refreshes the exact delivery lineage inherited by nested decision asks on owner answers", async () => {
+    const workdir = tempDir();
+    const workId = "work-sdk-decision";
+    const ref = "sdk-decision-ref";
+    const source = delivery(35, workId, ref);
+    const answer = delivery(36, workId, ref, "owner_answer");
+    answer.attempt = 2;
+    const clientEnvs: Record<string, string>[] = [];
+    const starts: string[] = [];
+    const resumes: string[] = [];
+
+    const makeThread = (id: string, env: Record<string, string>): ThreadLike => ({
+      id,
+      run: async () => {
+        const parked = prepareDecisionContinuation({ ...env, CODEX_THREAD_ID: id } as NodeJS.ProcessEnv);
+        expect(parked).toMatchObject({
+          deliveryId: env.AP_DELIVERY_ID,
+          workId,
+          continuationRef: ref,
+          sessionId: id,
+        });
+        return { final_response: `handled ${env.AP_DELIVERY_ID}` };
+      },
+    });
+    const exactRun = createSdkRunner({
+      server: "http://agentparty.test",
+      token: "ap_test",
+      channel: "dev",
+      workdir,
+      codexFactory: (options) => {
+        const env = options?.env ?? {};
+        clientEnvs.push(env);
+        return {
+          startThread: () => {
+            starts.push(env.AP_DELIVERY_ID ?? "missing");
+            return makeThread("thread-sdk-decision", env);
+          },
+          resumeThread: (id) => {
+            resumes.push(env.AP_DELIVERY_ID ?? "missing");
+            return makeThread(id, env);
+          },
+        };
+      },
+      post,
+    });
+
+    await exactRun(message(35), context(source));
+    await exactRun(message(36, {
+      decision_response: { request_seq: 35, chosen_index: 1, chosen_option: "B" },
+    }), context(answer));
+
+    expect(clientEnvs).toHaveLength(2);
+    expect(clientEnvs[0]).toMatchObject({
+      AP_DELIVERY_ID: source.id,
+      AP_WORK_ID: workId,
+      AP_CONTINUATION_REF: ref,
+      AP_DELIVERY_ATTEMPT: "1",
+    });
+    expect(clientEnvs[1]).toMatchObject({
+      AP_DELIVERY_ID: answer.id,
+      AP_WORK_ID: workId,
+      AP_CONTINUATION_REF: ref,
+      AP_DELIVERY_ATTEMPT: "2",
+      AP_RUNNER_SESSION_ID: "thread-sdk-decision",
+    });
+    expect(starts).toEqual([source.id]);
+    expect(resumes).toEqual([answer.id]);
+  });
+
   test("pins child identity and channel worktree into the SDK client and resumed thread", async () => {
     const workdir = tempDir();
     const cwd = tempDir("ap-profile-channel-");
@@ -486,6 +556,78 @@ describe("codex-sdk per-work continuations (#548)", () => {
     expect((mismatch as WakeBlockedError).retriable).toBe(false);
     expect(String((mismatch as Error).message)).toContain("mismatch");
     expect(starts).toBe(1);
+  });
+
+  test("runServe failing mismatched work B never cleans same-ref work A", async () => {
+    const workdir = tempDir();
+    const ref = "sdk-runserve-shared-ref";
+    const path = continuationPath(workdir, ref);
+    writeRunnerContinuation(path, {
+      harness: "codex-sdk",
+      thread_id: "thread-work-a",
+      created_at: 1,
+      last_wake_ts: 2,
+      wakes: 1,
+      work_id: "work-a",
+      continuation_ref: ref,
+    });
+    let starts = 0;
+    let resumes = 0;
+    const runner = sdk(workdir, () => ({
+      startThread: () => {
+        starts += 1;
+        return { id: "wrong-new-thread", run: async () => ({ final_response: "wrong" }) };
+      },
+      resumeThread: (id) => {
+        resumes += 1;
+        return { id, run: async () => ({ final_response: "wrong" }) };
+      },
+    }));
+    const answer = delivery(45, "work-b", ref, "owner_answer");
+    const answerMessage = message(45, {
+      decision_response: { request_seq: 44, chosen_index: 0, chosen_option: "approve" },
+    });
+    const updates: string[] = [];
+    const server = startMockServer((frame, socket) => {
+      if (frame.type === "hello") {
+        socket.send({ ...welcomeFrame(0, "me"), directed_delivery: "v1" });
+      } else if (frame.type === "serve_lease") {
+        socket.send({ type: "serve_lease", name: "me", held: true });
+        socket.send({ type: "delivery", delivery: answer, message: answerMessage });
+      } else if (frame.type === "delivery_update") {
+        updates.push(frame.state);
+        socket.send({
+          type: "delivery_state",
+          request_id: frame.request_id,
+          delivery: { ...answer, state: frame.state, last_error: frame.error ?? null, updated_at: Date.now() },
+        });
+        if (frame.state === "failed") socket.send({ type: "error", code: "archived", message: "done" });
+      }
+    });
+    servers.push(server);
+
+    expect(await runServe({
+      server: server.url,
+      token: "ap_test",
+      channel: "dev",
+      since: 0,
+      cmd: "",
+      mentionsOnly: true,
+      allowMultiple: true,
+      advertise: async () => {},
+      post,
+      runCommand: runner,
+    })).toBe(EXIT_ARCHIVED);
+
+    expect(updates).toEqual(["failed"]);
+    expect(starts).toBe(0);
+    expect(resumes).toBe(0);
+    expect(readRunnerContinuation(path)).toMatchObject({
+      harness: "codex-sdk",
+      thread_id: "thread-work-a",
+      work_id: "work-a",
+      continuation_ref: ref,
+    });
   });
 
   test("SDK timeout preserves and blocks the scoped handle so owner_answer fails without cold-starting", async () => {
@@ -634,6 +776,111 @@ describe("continuation transaction lock", () => {
     withRunnerContinuationLock(path, () => {});
     expect(statSync(join(workdir, "continuations")).mode & 0o777).toBe(0o700);
     expect(statSync(join(workdir, "continuations", ".continuation-lock.sqlite")).mode & 0o777).toBe(0o600);
+  });
+
+  test("deletes terminal per-work mappings under the shared lock and remains idempotent", () => {
+    const workdir = tempDir();
+    const path = continuationPath(workdir, "terminal-work");
+    const identity = {
+      harness: "codex",
+      work_id: "terminal-work-id",
+      continuation_ref: "terminal-work",
+    } as const;
+    writeRunnerContinuation(path, {
+      ...identity,
+      session_id: "terminal-session",
+      created_at: 1,
+      last_wake_ts: 2,
+      wakes: 1,
+    });
+
+    expect(deleteRunnerContinuation(path, identity)).toBe("deleted");
+    expect(existsSync(path)).toBe(false);
+    expect(readRunnerContinuation(path)).toBeNull();
+    expect(deleteRunnerContinuation(path, identity)).toBe("missing");
+    expect(existsSync(join(workdir, "continuations", ".continuation-lock.sqlite"))).toBe(true);
+  });
+
+  test("terminal cleanup preserves a same-ref mapping owned by another work", () => {
+    const workdir = tempDir();
+    const path = continuationPath(workdir, "shared-ref");
+    writeRunnerContinuation(path, {
+      harness: "codex",
+      session_id: "work-a-session",
+      created_at: 1,
+      last_wake_ts: 2,
+      wakes: 1,
+      work_id: "work-a",
+      continuation_ref: "shared-ref",
+    });
+
+    expect(deleteRunnerContinuation(path, {
+      harness: "codex",
+      work_id: "work-b",
+      continuation_ref: "shared-ref",
+    })).toBe("mismatch");
+    expect(readRunnerContinuation(path)).toMatchObject({
+      session_id: "work-a-session",
+      work_id: "work-a",
+      continuation_ref: "shared-ref",
+    });
+  });
+
+  test("builtin and SDK terminal hooks release their exact continuation files", async () => {
+    const cases = [
+      {
+        harness: "codex" as const,
+        runner: (workdir: string) => createBuiltinRunner({
+          server: "https://party.test",
+          token: "ap_test",
+          channel: "dev",
+          harness: "codex",
+          workdir,
+        }),
+        state: (ref: string) => ({
+          harness: "codex" as const,
+          session_id: "builtin-session",
+          created_at: 1,
+          last_wake_ts: 2,
+          wakes: 1,
+          work_id: "terminal-work-id",
+          continuation_ref: ref,
+        }),
+      },
+      {
+        harness: "codex-sdk" as const,
+        runner: (workdir: string) => createSdkRunner({
+          server: "https://party.test",
+          token: "ap_test",
+          channel: "dev",
+          workdir,
+        }),
+        state: (ref: string) => ({
+          harness: "codex-sdk" as const,
+          thread_id: "sdk-thread",
+          created_at: 1,
+          last_wake_ts: 2,
+          wakes: 1,
+          work_id: "terminal-work-id",
+          continuation_ref: ref,
+        }),
+      },
+    ];
+
+    for (const testCase of cases) {
+      const workdir = tempDir(`ap-${testCase.harness}-terminal-`);
+      const ref = `${testCase.harness}-terminal-ref`;
+      const path = continuationPath(workdir, ref);
+      writeRunnerContinuation(path, testCase.state(ref));
+      const runner = testCase.runner(workdir);
+      await runner.onDeliveryTerminal?.(delivery(89, "different-work", ref), "failed");
+      expect(readRunnerContinuation(path)).toMatchObject({
+        work_id: "terminal-work-id",
+        continuation_ref: ref,
+      });
+      await runner.onDeliveryTerminal?.(delivery(90, "terminal-work-id", ref), "replied");
+      expect(existsSync(path)).toBe(false);
+    }
   });
 
   test("block-before-merge and merge-before-block both preserve the monotonic block", () => {

--- a/cli/test/serve-directed-delivery.test.ts
+++ b/cli/test/serve-directed-delivery.test.ts
@@ -90,6 +90,73 @@ describe("serve durable directed delivery (#551)", () => {
     expect(exactAckSent).toBe(true);
   });
 
+  test("a completion probe can explicitly accept the Worker's authoritative failed state", async () => {
+    const work = delivery(2);
+    const failed = {
+      id: work.id,
+      message_seq: work.message_seq,
+      target_name: work.target_name,
+      state: "failed" as const,
+      reply_seq: null,
+      created_at: work.created_at,
+      updated_at: Date.now(),
+    };
+    const frames: ServerFrame[] = [];
+    const conn = {
+      send(frame: ClientFrame) {
+        if (frame.type !== "delivery_update") return false;
+        frames.push({ type: "delivery_state", request_id: frame.request_id, delivery: failed });
+        return true;
+      },
+      pendingFrames: () => frames,
+    };
+
+    await expect(confirmDeliveryUpdate(conn, {
+      type: "delivery_update",
+      delivery_id: work.id,
+      state: "replied",
+    }, 200)).rejects.toThrow("delivery state is failed, expected replied");
+    expect(await confirmDeliveryUpdate(conn, {
+      type: "delivery_update",
+      delivery_id: work.id,
+      state: "replied",
+    }, 200, undefined, ["failed"])).toMatchObject({ id: work.id, state: "failed" });
+  });
+
+  test("waiting_owner is parked work and never triggers terminal continuation cleanup", async () => {
+    const message = msgFrame(3, "ask owner", { mentions: ["me"] }) as unknown as MsgFrame;
+    const work = delivery(3);
+    const terminals: Array<{ id: string; state: "replied" | "failed" }> = [];
+    const runner: ServeRunner = async () => {};
+    runner.onDeliveryTerminal = (terminal, state) => {
+      terminals.push({ id: terminal.id, state });
+    };
+    server = startMockServer((frame, sock) => {
+      if (frame.type === "hello") {
+        sock.send({ ...welcomeFrame(0, "me"), directed_delivery: "v1" });
+      } else if (frame.type === "serve_lease") {
+        sock.send({ type: "serve_lease", name: "me", held: true });
+        sock.send({ type: "delivery", delivery: work, message });
+      } else if (frame.type === "delivery_update" && frame.state === "running") {
+        sock.send({
+          type: "delivery_state",
+          request_id: frame.request_id,
+          delivery: { ...work, state: "running", updated_at: Date.now() },
+        });
+      } else if (frame.type === "delivery_update" && frame.state === "replied") {
+        sock.send({
+          type: "delivery_state",
+          request_id: frame.request_id,
+          delivery: { ...work, state: "waiting_owner", updated_at: Date.now() },
+        });
+        sock.send({ type: "error", code: "archived", message: "parked" });
+      }
+    });
+
+    expect(await runServe(opts({ server: server.url, runCommand: runner }))).toBe(EXIT_ARCHIVED);
+    expect(terminals).toEqual([]);
+  });
+
   test("custom decision resumes as a fresh process on the served channel with exact lineage context", async () => {
     const home = mkdtempSync(join(tmpdir(), "ap-custom-continuation-"));
     const evidencePath = join(home, "owner-answer.json");
@@ -121,8 +188,23 @@ describe("serve durable directed delivery (#551)", () => {
       work_id: source.work_id,
       continuation_ref: source.continuation_ref,
     });
+    let channelSocket: { send(frame: ServerFrame): void } | undefined;
     const rest = startRestMock((request) => {
       if (request.method !== "POST" || request.path !== "/api/channels/serve-b/messages") return undefined;
+      const requestBody = request.body as { decision_request?: unknown; reply_to?: unknown } | null;
+      if (requestBody?.decision_request === undefined) {
+        if (requestBody?.reply_to === ownerMessage.seq) {
+          channelSocket?.send({
+            type: "delivery_state",
+            delivery: { ...owner, state: "replied", reply_seq: 71, updated_at: Date.now() },
+          });
+        }
+        return Response.json({ seq: 71 });
+      }
+      channelSocket?.send({
+        type: "delivery_state",
+        delivery: { ...source, state: "waiting_owner", updated_at: Date.now() },
+      });
       return Response.json({
         seq: 70,
         decision_request: {
@@ -156,6 +238,17 @@ describe("serve durable directed delivery (#551)", () => {
               continuationRef: process.env.AP_CONTINUATION_REF,
             },
           }));
+          const child = Bun.spawn([
+            process.execPath,
+            ${JSON.stringify(indexPath)},
+            "send",
+            "owner continuation complete",
+            "--channel",
+            process.env.AGENTPARTY_CHANNEL,
+            "--reply-to",
+            String(context.reply_to),
+          ], { env: process.env, stdin: "ignore", stdout: "inherit", stderr: "inherit" });
+          process.exit(await child.exited);
         } else {
           const child = Bun.spawn([
             process.execPath,
@@ -171,6 +264,7 @@ describe("serve durable directed delivery (#551)", () => {
       const command = `${JSON.stringify(process.execPath)} ${JSON.stringify(customScriptPath)}`;
       server = startMockServer((frame, sock) => {
         if (frame.type === "hello") {
+          channelSocket = sock;
           sock.send({ ...welcomeFrame(0, "me"), channel: "serve-b", directed_delivery: "v1" });
           return;
         }
@@ -329,6 +423,7 @@ describe("serve durable directed delivery (#551)", () => {
     const updates: Array<Record<string, unknown>> = [];
     const cursors: number[] = [];
     const seen: number[] = [];
+    const terminals: Array<{ id: string; state: "replied" | "failed" }> = [];
     let receivedContext: DirectedDelivery | null | undefined;
     server = startMockServer((frame, sock) => {
       if (frame.type === "hello") {
@@ -352,19 +447,24 @@ describe("serve durable directed delivery (#551)", () => {
       }
     });
 
+    const runner: ServeRunner = async (frame, context) => {
+      seen.push(frame.seq);
+      receivedContext = context.delivery;
+      expect(context.recent.map((item) => item.seq)).not.toContain(frame.seq);
+    };
+    runner.onDeliveryTerminal = (terminal, state) => {
+      terminals.push({ id: terminal.id, state });
+    };
     const code = await runServe(opts({
       server: server.url,
       onCursor: (cursor) => cursors.push(cursor),
-      runCommand: async (frame, context) => {
-        seen.push(frame.seq);
-        receivedContext = context.delivery;
-        expect(context.recent.map((item) => item.seq)).not.toContain(frame.seq);
-      },
+      runCommand: runner,
     }));
 
     expect(code).toBe(EXIT_ARCHIVED);
     expect(seen).toEqual([1]);
     expect(cursors).toEqual([1]);
+    expect(terminals).toEqual([{ id: work.id, state: "replied" }]);
     expect(receivedContext).toMatchObject({ id: work.id, work_id: "work-1", continuation_ref: "codex:thread-1" });
     expect(updates).toEqual([
       expect.objectContaining({
@@ -486,12 +586,127 @@ describe("serve durable directed delivery (#551)", () => {
     expect(String(updates[1]?.error)).toContain("runner exploded");
   });
 
+  test("a zero-exit custom command with no linked reply is blocked instead of reported as delivered", async () => {
+    const message = msgFrame(8, "silent success", { mentions: ["me"] }) as unknown as MsgFrame;
+    const work = delivery(8);
+    const updates: Array<Record<string, unknown>> = [];
+    const posts: Array<{ kind: string; state?: string; note?: string }> = [];
+    const lines: string[] = [];
+    server = startMockServer((frame, sock) => {
+      if (frame.type === "hello") {
+        sock.send({ ...welcomeFrame(0, "me"), directed_delivery: "v1" });
+        return;
+      }
+      if (frame.type === "serve_lease") {
+        sock.send({ type: "serve_lease", name: "me", held: true });
+        sock.send({ type: "delivery", delivery: work, message });
+        return;
+      }
+      if (frame.type !== "delivery_update") return;
+      updates.push(frame as unknown as Record<string, unknown>);
+      const state = frame.state === "replied" ? "failed" : frame.state;
+      sock.send({
+        type: "delivery_state",
+        request_id: frame.request_id,
+        delivery: {
+          ...work,
+          state,
+          last_error: state === "failed" ? "runner reported success without a linked channel reply" : null,
+          updated_at: Date.now(),
+        },
+      });
+      if (frame.state === "replied") {
+        sock.send({ type: "error", code: "archived", message: "done" });
+      }
+    });
+
+    const code = await runServe(opts({
+      server: server.url,
+      cmd: "true",
+      out: (line) => lines.push(line),
+      post: async (_server, _token, _channel, body) => {
+        posts.push(body as { kind: string; state?: string; note?: string });
+        return { seq: 100 + posts.length };
+      },
+    }));
+
+    expect(code).toBe(EXIT_ARCHIVED);
+    expect(updates.map((update) => update.state)).toEqual(["running", "replied"]);
+    expect(posts).toContainEqual(expect.objectContaining({
+      kind: "status",
+      state: "blocked",
+      note: expect.stringContaining("runner exited successfully without a linked channel reply"),
+    }));
+    expect(lines.some((line) => line.includes("runner exited successfully without a linked channel reply"))).toBe(true);
+  });
+
+  test("authoritative silent-success failure cleans continuation before a later ACK disconnect", async () => {
+    const message = msgFrame(81, "silent success cleanup", { mentions: ["me"] }) as unknown as MsgFrame;
+    const work = delivery(81);
+    const updates: string[] = [];
+    const terminals: Array<{ id: string; state: "replied" | "failed" }> = [];
+    server = startMockServer((frame, sock, connectionIndex) => {
+      if (frame.type === "hello") {
+        if (connectionIndex > 0) {
+          sock.send({ ...welcomeFrame(0, "me"), directed_delivery: "v1" });
+          sock.send({ type: "error", code: "archived", message: "done" });
+          return;
+        }
+        sock.send({ ...welcomeFrame(0, "me"), directed_delivery: "v1" });
+        return;
+      }
+      if (frame.type === "serve_lease") {
+        sock.send({ type: "serve_lease", name: "me", held: true });
+        sock.send({ type: "delivery", delivery: work, message });
+        return;
+      }
+      if (frame.type !== "delivery_update") return;
+      updates.push(frame.state);
+      if (frame.state === "running") {
+        sock.send({
+          type: "delivery_state",
+          request_id: frame.request_id,
+          delivery: { ...work, state: "running", updated_at: Date.now() },
+        });
+        return;
+      }
+      if (frame.state === "replied") {
+        sock.send({
+          type: "delivery_state",
+          request_id: frame.request_id,
+          delivery: {
+            ...work,
+            state: "failed",
+            last_error: "runner reported success without a linked channel reply",
+            updated_at: Date.now(),
+          },
+        });
+        setTimeout(() => sock.close(), 0);
+      }
+    });
+    const runner: ServeRunner = async () => {};
+    runner.onDeliveryTerminal = (terminal, state) => {
+      terminals.push({ id: terminal.id, state });
+    };
+
+    const code = await runServe(opts({
+      server: server.url,
+      runCommand: runner,
+      post: async () => ({ seq: 181 }),
+    }));
+
+    expect(code).toBe(EXIT_ARCHIVED);
+    expect(updates).toEqual(["running", "replied"]);
+    expect(terminals).toEqual([{ id: work.id, state: "failed" }]);
+  });
+
   test("a disconnect that loses the terminal update exits unknown-outcome and never runs a redelivery", async () => {
     const message = msgFrame(9, "do not duplicate", { mentions: ["me"] }) as unknown as MsgFrame;
     const work = delivery(9);
     const lines: string[] = [];
     let runnerCalls = 0;
     let updateCalls = 0;
+    const terminals: Array<{ id: string; state: "replied" | "failed" }> = [];
     server = startMockServer((frame, sock, connectionIndex) => {
       if (frame.type === "hello") {
         sock.send({ ...welcomeFrame(0, "me"), directed_delivery: "v1" });
@@ -523,15 +738,20 @@ describe("serve durable directed delivery (#551)", () => {
       }
     });
 
+    const runner: ServeRunner = async () => { runnerCalls += 1; };
+    runner.onDeliveryTerminal = (terminal, state) => {
+      terminals.push({ id: terminal.id, state });
+    };
     const code = await runServe(opts({
       server: server.url,
       out: (line) => lines.push(line),
-      runCommand: async () => { runnerCalls += 1; },
+      runCommand: runner,
     }));
 
     expect(code).toBe(EXIT_STREAM_ENDED);
     expect(runnerCalls).toBe(1);
     expect(updateCalls).toBe(2);
+    expect(terminals).toEqual([]);
     expect(lines.some((line) => line.includes("完成回执发送失败"))).toBe(true);
   });
 

--- a/cli/test/serve-health.test.ts
+++ b/cli/test/serve-health.test.ts
@@ -85,6 +85,82 @@ describe("serve writes local WS health (#254)", () => {
     expect(seen[0]?.reconnect_count).toBeGreaterThanOrEqual(1);
   });
 
+  test("an inbound watchdog reconnect records its exact reason in health", async () => {
+    server = startMockServer((frame, sock, connIndex) => {
+      if (frame.type !== "hello") return;
+      sock.send(welcomeFrame(0, "me"));
+      if (connIndex > 0) {
+        setTimeout(() => sock.send({ type: "error", code: "archived", message: "done" }), 5);
+      }
+    });
+    const running = runServe(opts({
+      server: server.url,
+      runCommand: async () => {},
+      inboundIdleTimeoutMs: 30,
+    }));
+
+    let reconnecting = readHealthCache();
+    const deadline = Date.now() + 500;
+    while (reconnecting?.reconnecting !== true && Date.now() < deadline) {
+      await Bun.sleep(5);
+      reconnecting = readHealthCache();
+    }
+    expect(reconnecting).toMatchObject({
+      ws_connected: false,
+      reconnecting: true,
+      reconnect_count: 1,
+      last_error: "inbound idle timeout",
+    });
+
+    expect(await running).toBe(EXIT_ARCHIVED);
+  });
+
+  test("a replacement socket stays unhealthy until its first valid server frame", async () => {
+    server = startMockServer((frame, sock, connIndex) => {
+      if (frame.type !== "hello") return;
+      if (connIndex === 0) {
+        sock.send(welcomeFrame(0, "me"));
+        return;
+      }
+      // The replacement accepts a WS handshake but withholds application frames long enough for
+      // the test to observe health. A delayed welcome then proves the same socket becomes healthy.
+      setTimeout(() => sock.send(welcomeFrame(0, "me")), 80);
+      setTimeout(() => sock.send({ type: "error", code: "archived", message: "done" }), 130);
+    });
+    const running = runServe(opts({
+      server: server.url,
+      runCommand: async () => {},
+      inboundIdleTimeoutMs: 200,
+    }));
+
+    let replacement = readHealthCache();
+    const openDeadline = Date.now() + 2_000;
+    while (
+      !(replacement?.reconnect_count === 1 && replacement.ws_connected && replacement.last_frame_at === null)
+      && Date.now() < openDeadline
+    ) {
+      await Bun.sleep(5);
+      replacement = readHealthCache();
+    }
+    expect(replacement).toMatchObject({
+      ws_connected: true,
+      reconnecting: false,
+      reconnect_count: 1,
+      last_frame_at: null,
+      last_error: "inbound idle timeout",
+    });
+
+    let recovered = readHealthCache();
+    const frameDeadline = Date.now() + 500;
+    while (recovered?.last_frame_at === null && Date.now() < frameDeadline) {
+      await Bun.sleep(5);
+      recovered = readHealthCache();
+    }
+    expect(recovered?.last_frame_at).not.toBeNull();
+    expect(recovered?.last_error).toBeNull();
+    expect(await running).toBe(EXIT_ARCHIVED);
+  });
+
   test("EXIT_ALREADY_SERVING does not clobber the winning server's health record", async () => {
     server = startMockServer((frame, sock) => {
       if (frame.type === "hello") sock.send(welcomeFrame(0, "me"));

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -205,7 +205,7 @@ export type DecisionKind = "approval" | "choice";
 // pending：等人类；resolved：人类已选；auto_resolved：无人值守模式自动放行。
 export type DecisionState = "pending" | "resolved" | "auto_resolved";
 export type DirectedDeliveryState = "queued" | "claimed" | "running" | "waiting_owner" | "replied" | "failed";
-export type DirectedDeliveryCause = "mention" | "reply" | "owner_answer" | "retry";
+export type DirectedDeliveryCause = "mention" | "mention_edit" | "reply" | "owner_answer" | "retry";
 // decision_request 上限（#284）：与 completion review 同量级，防把 prompt/选项当附加 payload 滥用。
 export const DECISION_PROMPT_LIMIT = 4_000;
 export const DECISION_OPTIONS_MAX = 10;

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -6738,9 +6738,13 @@ export class ChannelDO extends Server<Env> {
       }
     }
     if (seq % 100 === 0) {
+      // 按数量裁剪也必须尊重终态保留窗口：只删已过 DIRECTED_DELIVERY_TERMINAL_RETENTION_MS
+      // 的非活跃 delivery，否则刚终止的审计行会在下一个第 100 条消息时被立即抹掉，绕过
+      // pruneDirectedDeliveryRetention 的 7 天窗口。
       sql.exec(
         `DELETE FROM directed_deliveries
-          WHERE message_seq IN (
+          WHERE updated_at <= ?
+            AND message_seq IN (
             SELECT m.seq FROM messages m
              WHERE m.seq <= ?
                AND (m.completion_review_state IS NULL OR m.completion_review_state != 'pending_review')
@@ -6751,8 +6755,12 @@ export class ChannelDO extends Server<Env> {
                     AND active.state IN ('queued', 'claimed', 'running', 'waiting_owner')
                )
           )`,
+        now - DIRECTED_DELIVERY_TERMINAL_RETENTION_MS,
         seq - RETAIN_N,
       );
+      // 消息删除也要等 delivery 审计行清空后再动，否则保留期内的终态 delivery 会指向已删消息。
+      // 上面的 delivery 裁剪先跑，剩下的 directed_deliveries 只会是活跃行或仍在保留期的终态行；
+      // 任一残留都保住消息，等下一轮 delivery 过期后再一并回收。
       sql.exec(
         `DELETE FROM messages AS m
           WHERE m.seq <= ?
@@ -6761,7 +6769,6 @@ export class ChannelDO extends Server<Env> {
             AND NOT EXISTS (
               SELECT 1 FROM directed_deliveries d
                WHERE d.message_seq = m.seq
-                 AND d.state IN ('queued', 'claimed', 'running', 'waiting_owner')
             )`,
         seq - RETAIN_N,
       );

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -181,6 +181,8 @@ type DeliveryTerminalReason =
   | "unknown_outcome"
   | "owner_answer_failed"
   | "source_retracted"
+  | "source_retention_expired"
+  | "delivery_expired"
   | "orphaned_waiting_owner";
 
 const REVIVABLE_DELIVERY_FAILURES = new Set<DeliveryTerminalReason>(["unknown_outcome"]);
@@ -208,6 +210,13 @@ interface ResolvedMentionFrame {
   frame: SendFrame;
   /** Canonical agent identities proven by the same directory read that validated the mentions. */
   agentTargets: string[];
+}
+
+interface RoutedMentionFrame {
+  frame: SendFrame;
+  /** Canonical, creation-time-bound agent targets that must receive durable work. */
+  deliveryTargets: string[];
+  deliveryTargetOwners: Record<string, string>;
 }
 
 interface ExpectedDecisionLineage {
@@ -280,6 +289,12 @@ const REVIEW_REASON_LIMIT = 4000;
 // （长度 ≤8 的循环里，重访的 tuple 仍在窗口内 → 被判非进展 → 计数累加直到 trip）；又足够小，
 // 让真正线性推进的工作流（每帧都是新 step）永远命中「窗口内没见过」→ 判进展 → 永不误伤。
 const WORKFLOW_GUARD_WINDOW = 8;
+// Durable work cannot outlive its operator indefinitely. Even when message history retention is
+// explicitly off, active delivery capability/lineage expires after 30 days and its terminal audit
+// row is retained for another 7 days. This is far above the hours-long offline replay contract while
+// keeping permanently offline agents and abandoned owner questions bounded.
+const DIRECTED_DELIVERY_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+const DIRECTED_DELIVERY_TERMINAL_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
 
 function byteLength(s: string): number {
   return new TextEncoder().encode(s).byteLength;
@@ -323,6 +338,26 @@ function withExpandedMentions(frame: SendFrame, mentions: string[]): SendFrame {
   return frame.kind === "message"
     ? { ...frame, mentions }
     : { ...frame, mentions };
+}
+
+function parseStoredTargetNames(input: unknown): string[] {
+  if (typeof input !== "string") return [];
+  try {
+    const parsed = JSON.parse(input) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    const seen = new Set<string>();
+    const targets: string[] = [];
+    for (const value of parsed) {
+      if (typeof value !== "string" || !MENTION_NAME_RE.test(value)) continue;
+      const key = mentionMatchKey(value);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      targets.push(value);
+    }
+    return targets;
+  } catch {
+    return [];
+  }
 }
 
 function parseStatusScope(input: unknown): string[] | undefined | null {
@@ -1317,6 +1352,7 @@ export class ChannelDO extends Server<Env> {
       kind TEXT NOT NULL,
       body TEXT NOT NULL,
       mentions_json TEXT NOT NULL DEFAULT '[]',
+      delivery_targets_json TEXT NOT NULL DEFAULT '[]',
       reply_to INTEGER,
       state TEXT,
       note TEXT,
@@ -1392,6 +1428,9 @@ export class ChannelDO extends Server<Env> {
       "ALTER TABLE messages ADD COLUMN retracted_by TEXT",
       "ALTER TABLE messages ADD COLUMN supersedes INTEGER",
       "ALTER TABLE messages ADD COLUMN superseded_by INTEGER",
+      // Compact exactly-once tombstone. Delivery rows may be pruned after their bounded audit
+      // window, but editing the retained source must never recreate work for an old target.
+      "ALTER TABLE messages ADD COLUMN delivery_targets_json TEXT NOT NULL DEFAULT '[]'",
       // 修订序号（issue #33）：每次编辑/撤回/超越递增，hello.since_rev 据此限定补拉重放范围
       "ALTER TABLE messages ADD COLUMN rev_seq INTEGER",
       // 迁移回填：历史修订行按 seq 赋 rev_seq（幂等，只补 NULL），让升级后的客户端能收到一次再推进游标
@@ -1651,6 +1690,25 @@ export class ChannelDO extends Server<Env> {
     sql.exec(
       "CREATE INDEX IF NOT EXISTS idx_directed_deliveries_lease ON directed_deliveries(state, lease_until)",
     );
+    sql.exec(
+      `UPDATE messages
+          SET delivery_targets_json = COALESCE((
+            SELECT json_group_array(target_name)
+              FROM directed_deliveries delivery
+             WHERE delivery.message_seq = messages.seq
+          ), '[]')
+        WHERE CASE
+          WHEN json_valid(delivery_targets_json)
+            THEN json_array_length(delivery_targets_json) = 0
+          ELSE 1
+        END
+          AND messages.retracted_at IS NULL
+          AND messages.body != '[erased]'
+          AND EXISTS (
+            SELECT 1 FROM directed_deliveries delivery
+             WHERE delivery.message_seq = messages.seq
+          )`,
+    );
     sql.exec(`CREATE TABLE IF NOT EXISTS message_audit (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       target_seq INTEGER NOT NULL,
@@ -1684,7 +1742,7 @@ export class ChannelDO extends Server<Env> {
         );
         sql.exec(
           `UPDATE messages
-              SET body = '[retracted]', mentions_json = '[]', original_body = NULL,
+              SET body = '[retracted]', mentions_json = '[]', delivery_targets_json = '[]', original_body = NULL,
                   state = NULL, note = NULL, status_scope_json = NULL, status_blocked_reason = NULL,
                   status_context_json = NULL, status_decision_json = NULL, status_workflow_json = NULL,
                   message_workflow_json = NULL, completion_artifact_json = NULL,
@@ -1928,6 +1986,10 @@ export class ChannelDO extends Server<Env> {
     this.ctx.setWebSocketAutoResponse(
       new WebSocketRequestResponsePair('{"type":"ping"}', '{"type":"pong"}'),
     );
+    // A permanent, otherwise idle channel may have no presence/webhook/temp/retention alarm at all.
+    // Re-arm upgraded active and terminal delivery deadlines on hydration so bounded retention is a
+    // real clock guarantee rather than something that only runs if unrelated traffic wakes the DO.
+    this.scheduleDirectedDeliveryRetentionAlarm();
   }
 
   private hasCompositeSessionPrimaryKey(table: "presence" | "read_cursor"): boolean {
@@ -2445,6 +2507,7 @@ export class ChannelDO extends Server<Env> {
   // 全走已在 DO 单线程内的 sql.exec，热路径零成本；每张表各按「消费者仍需的窗口」定界，见各方法注释。
   private async pruneStorage(now: number) {
     await this.pruneRetainedContent(now);
+    this.pruneDirectedDeliveryRetention(now);
     this.pruneWakeLedger(now);
     this.pruneMessageAudit();
     this.pruneReadCursors(now);
@@ -2464,15 +2527,30 @@ export class ChannelDO extends Server<Env> {
     const attachmentKeys = new Set<string>();
     if (messageRetention !== null) {
       const cutoff = now - messageRetention;
+      const activeRoots = this.ctx.storage.sql
+        .exec(
+          `SELECT d.* FROM directed_deliveries d
+            JOIN messages m ON m.seq = d.message_seq
+           WHERE m.ts <= ?
+             AND d.state IN ('queued', 'claimed', 'running', 'waiting_owner')
+           ORDER BY d.created_at, d.id`,
+          cutoff,
+        )
+        .toArray();
+      if (activeRoots.length > 0) {
+        let invalidatedDecisionSeqs: number[] = [];
+        const effects = this.captureAtomicDeliveryEffects(() => {
+          invalidatedDecisionSeqs = this.failDeliveryTree(activeRoots, now, {
+            error: "source expired by channel message retention policy",
+            terminalReason: "source_retention_expired",
+          });
+        });
+        this.flushAtomicDeliveryEffects(effects);
+        this.broadcastInvalidatedDecisions(invalidatedDecisionSeqs, now);
+      }
       const expired = this.ctx.storage.sql
         .exec(
-          `SELECT m.seq, m.attachments_json FROM messages m
-            WHERE m.ts <= ?
-              AND NOT EXISTS (
-                SELECT 1 FROM directed_deliveries d
-                 WHERE d.message_seq = m.seq
-                   AND d.state IN ('queued', 'claimed', 'running', 'waiting_owner')
-              )`,
+          `SELECT m.seq, m.attachments_json FROM messages m WHERE m.ts <= ?`,
           cutoff,
         )
         .toArray();
@@ -2493,55 +2571,29 @@ export class ChannelDO extends Server<Env> {
             `DELETE FROM webhook_queue
               WHERE json_valid(payload)
                 AND CAST(json_extract(payload, '$.seq') AS INTEGER) IN
-                    (SELECT m.seq FROM messages m WHERE m.ts <= ?
-                       AND NOT EXISTS (
-                         SELECT 1 FROM directed_deliveries d
-                          WHERE d.message_seq = m.seq
-                            AND d.state IN ('queued', 'claimed', 'running', 'waiting_owner')
-                       ))`,
+                    (SELECT m.seq FROM messages m WHERE m.ts <= ?)`,
             cutoff,
           );
           this.ctx.storage.sql.exec(
             `DELETE FROM webhook_dead_letters
               WHERE mention_seq IN (
-                SELECT m.seq FROM messages m WHERE m.ts <= ?
-                  AND NOT EXISTS (
-                    SELECT 1 FROM directed_deliveries d
-                     WHERE d.message_seq = m.seq
-                       AND d.state IN ('queued', 'claimed', 'running', 'waiting_owner')
-                  ))`,
+                SELECT m.seq FROM messages m WHERE m.ts <= ?)`,
             cutoff,
           );
           this.ctx.storage.sql.exec(
             `DELETE FROM wake_delivery_ledger
               WHERE mention_seq IN (
-                SELECT m.seq FROM messages m WHERE m.ts <= ?
-                  AND NOT EXISTS (
-                    SELECT 1 FROM directed_deliveries d
-                     WHERE d.message_seq = m.seq
-                       AND d.state IN ('queued', 'claimed', 'running', 'waiting_owner')
-                  ))`,
+                SELECT m.seq FROM messages m WHERE m.ts <= ?)`,
             cutoff,
           );
           this.ctx.storage.sql.exec(
             `DELETE FROM directed_deliveries
               WHERE message_seq IN (
-                SELECT m.seq FROM messages m WHERE m.ts <= ?
-                  AND NOT EXISTS (
-                    SELECT 1 FROM directed_deliveries active
-                     WHERE active.message_seq = m.seq
-                       AND active.state IN ('queued', 'claimed', 'running', 'waiting_owner')
-                  ))`,
+                SELECT m.seq FROM messages m WHERE m.ts <= ?)`,
             cutoff,
           );
           this.ctx.storage.sql.exec(
-            `DELETE FROM messages AS m
-              WHERE m.ts <= ?
-                AND NOT EXISTS (
-                  SELECT 1 FROM directed_deliveries d
-                   WHERE d.message_seq = m.seq
-                     AND d.state IN ('queued', 'claimed', 'running', 'waiting_owner')
-                )`,
+            `DELETE FROM messages AS m WHERE m.ts <= ?`,
             cutoff,
           );
         });
@@ -2550,6 +2602,62 @@ export class ChannelDO extends Server<Env> {
     if (auditRetention !== null) {
       this.ctx.storage.sql.exec("DELETE FROM message_audit WHERE created_at <= ?", now - auditRetention);
     }
+  }
+
+  private broadcastInvalidatedDecisions(seqs: number[], now: number) {
+    if (seqs.length === 0) return;
+    const actor: Identity = { name: "system", kind: "agent", role: "agent", tokenHash: "" };
+    for (const seq of new Set(seqs)) {
+      const row = this.ctx.storage.sql.exec("SELECT * FROM messages WHERE seq = ?", seq).toArray()[0];
+      if (row !== undefined) {
+        this.broadcastFrame(this.messageUpdate("decision", actor, this.rowToFrame(row), now));
+      }
+    }
+  }
+
+  private pruneDirectedDeliveryRetention(now: number) {
+    const activeCutoff = now - DIRECTED_DELIVERY_MAX_AGE_MS;
+    const activeRoots = this.ctx.storage.sql
+      .exec(
+        `SELECT * FROM directed_deliveries
+          WHERE state IN ('queued', 'claimed', 'running', 'waiting_owner')
+            AND created_at <= ?
+          ORDER BY created_at, id`,
+        activeCutoff,
+      )
+      .toArray();
+    if (activeRoots.length > 0) {
+      let invalidatedDecisionSeqs: number[] = [];
+      const effects = this.captureAtomicDeliveryEffects(() => {
+        invalidatedDecisionSeqs = this.failDeliveryTree(activeRoots, now, {
+          error: "durable delivery expired after 30 days without completion",
+          terminalReason: "delivery_expired",
+        });
+      });
+      this.flushAtomicDeliveryEffects(effects);
+      this.broadcastInvalidatedDecisions(invalidatedDecisionSeqs, now);
+    }
+
+    // Delete only terminal leaves. Parent lineage remains until every descendant is terminal and
+    // pruned; the next alarm removes the now-leaf parent. Pending questions are an additional guard
+    // against deleting a source that has not been invalidated correctly.
+    this.ctx.storage.sql.exec(
+      `DELETE FROM directed_deliveries AS delivery
+        WHERE delivery.state IN ('replied', 'failed')
+          AND delivery.updated_at <= ?
+          AND NOT EXISTS (
+            SELECT 1 FROM directed_deliveries child
+             WHERE child.parent_delivery_id = delivery.id
+          )
+          AND NOT EXISTS (
+            SELECT 1 FROM messages question
+             WHERE question.decision_state = 'pending'
+               AND question.decision_request_json IS NOT NULL
+               AND json_valid(question.decision_request_json)
+               AND json_extract(question.decision_request_json, '$.delivery_id') = delivery.id
+          )`,
+      now - DIRECTED_DELIVERY_TERMINAL_RETENTION_MS,
+    );
   }
 
   // wake_delivery_ledger：按时间窗裁。保留窗口 WAKE_LEDGER_RETENTION_MS 严格大于预算窗口上限
@@ -3082,6 +3190,32 @@ export class ChannelDO extends Server<Env> {
       .exec("SELECT MIN(lease_until) AS t FROM directed_deliveries WHERE state IN ('claimed', 'running') AND lease_until IS NOT NULL")
       .one();
     if (nextDeliveryLease.t !== null) candidates.push(Number(nextDeliveryLease.t));
+    const oldestActiveDelivery = this.ctx.storage.sql
+      .exec("SELECT MIN(created_at) AS t FROM directed_deliveries WHERE state IN ('queued', 'claimed', 'running', 'waiting_owner')")
+      .one();
+    if (oldestActiveDelivery.t !== null) {
+      candidates.push(Number(oldestActiveDelivery.t) + DIRECTED_DELIVERY_MAX_AGE_MS);
+    }
+    const oldestTerminalLeaf = this.ctx.storage.sql
+      .exec(
+        `SELECT MIN(delivery.updated_at) AS t FROM directed_deliveries delivery
+          WHERE delivery.state IN ('replied', 'failed')
+            AND NOT EXISTS (
+              SELECT 1 FROM directed_deliveries child
+               WHERE child.parent_delivery_id = delivery.id
+            )
+            AND NOT EXISTS (
+              SELECT 1 FROM messages question
+               WHERE question.decision_state = 'pending'
+                 AND question.decision_request_json IS NOT NULL
+                 AND json_valid(question.decision_request_json)
+                 AND json_extract(question.decision_request_json, '$.delivery_id') = delivery.id
+            )`,
+      )
+      .one();
+    if (oldestTerminalLeaf.t !== null) {
+      candidates.push(Number(oldestTerminalLeaf.t) + DIRECTED_DELIVERY_TERMINAL_RETENTION_MS);
+    }
     // 暂停接待的定时恢复（issue #180）：取最近的一个未来恢复时刻作为候选，前移 alarm 到点自动恢复。
     const nextResume = this.ctx.storage.sql
       .exec("SELECT MIN(paused_resume_at) AS t FROM presence WHERE paused_resume_at IS NOT NULL")
@@ -4307,8 +4441,16 @@ export class ChannelDO extends Server<Env> {
     return source;
   }
 
-  /** Fail the retracted source plus every still-active owner-answer continuation below it. */
-  private failRetractedDeliveryTree(initial: Record<string, unknown>[], now: number): number[] {
+  /**
+   * Fail a source plus every still-active owner-answer continuation below it, invalidate parked
+   * questions, and scrub reusable capability lineage. Retraction and retention share this exact
+   * closure so neither path can leave a descendant able to resume deleted/expired work.
+   */
+  private failDeliveryTree(
+    initial: Record<string, unknown>[],
+    now: number,
+    failure: { error: string; terminalReason: DeliveryTerminalReason },
+  ): number[] {
     const pending = initial.map((row) => String(row.id));
     const visited = new Set<string>();
     const invalidatedDecisionSeqs = new Set<number>();
@@ -4360,18 +4502,20 @@ export class ChannelDO extends Server<Env> {
       const state = String(row.state);
       if (["queued", "claimed", "running", "waiting_owner"].includes(state)) {
         this.transitionDirectedDeliveryTerminal(id, "failed", now, {
-          error: "source retracted, no retry",
-          terminalReason: "source_retracted",
+          error: failure.error,
+          terminalReason: failure.terminalReason,
           expectedStates: [state],
         });
       } else if (state === "failed") {
-        // Failed rows can still be revivable (typed unknown_outcome or legacy NULL). Retraction is
-        // stronger than that recovery policy, so reclassify every failed descendant authoritatively.
+        // Failed rows can still be revivable (typed unknown_outcome or legacy NULL). Source
+        // invalidation is stronger than that recovery policy, so reclassify every descendant.
         this.ctx.storage.sql.exec(
           `UPDATE directed_deliveries
-              SET last_error = 'source retracted, no retry', terminal_reason = 'source_retracted',
+              SET last_error = ?, terminal_reason = ?,
                   updated_at = ?
             WHERE id = ? AND state = 'failed'`,
+          failure.error,
+          failure.terminalReason,
           now,
           id,
         );
@@ -4390,6 +4534,14 @@ export class ChannelDO extends Server<Env> {
       );
     }
     return [...invalidatedDecisionSeqs];
+  }
+
+  /** Fail the retracted source plus every still-active owner-answer continuation below it. */
+  private failRetractedDeliveryTree(initial: Record<string, unknown>[], now: number): number[] {
+    return this.failDeliveryTree(initial, now, {
+      error: "source retracted, no retry",
+      terminalReason: "source_retracted",
+    });
   }
 
   private isFailedDeliveryRevivable(row: Record<string, unknown>): boolean {
@@ -4428,6 +4580,35 @@ export class ChannelDO extends Server<Env> {
   private async ensureAlarmAt(ts: number) {
     const current = await this.ctx.storage.getAlarm();
     if (current === null || current > ts) await this.ctx.storage.setAlarm(ts);
+  }
+
+  private scheduleDirectedDeliveryRetentionAlarm() {
+    const candidates: number[] = [];
+    const active = this.ctx.storage.sql
+      .exec("SELECT MIN(created_at) AS t FROM directed_deliveries WHERE state IN ('queued', 'claimed', 'running', 'waiting_owner')")
+      .one().t;
+    if (active !== null) candidates.push(Number(active) + DIRECTED_DELIVERY_MAX_AGE_MS);
+    const terminal = this.ctx.storage.sql
+      .exec(
+        `SELECT MIN(delivery.updated_at) AS t FROM directed_deliveries delivery
+          WHERE delivery.state IN ('replied', 'failed')
+            AND NOT EXISTS (
+              SELECT 1 FROM directed_deliveries child
+               WHERE child.parent_delivery_id = delivery.id
+            )
+            AND NOT EXISTS (
+              SELECT 1 FROM messages question
+               WHERE question.decision_state = 'pending'
+                 AND question.decision_request_json IS NOT NULL
+                 AND json_valid(question.decision_request_json)
+                 AND json_extract(question.decision_request_json, '$.delivery_id') = delivery.id
+            )`,
+      )
+      .one().t;
+    if (terminal !== null) candidates.push(Number(terminal) + DIRECTED_DELIVERY_TERMINAL_RETENTION_MS);
+    if (candidates.length > 0) {
+      this.ctx.waitUntil(this.ensureAlarmAt(Math.max(Math.min(...candidates), Date.now() + 1000)));
+    }
   }
 
   private async scheduleAuditRetention(createdAt: number) {
@@ -4688,7 +4869,14 @@ export class ChannelDO extends Server<Env> {
       if (row.retracted_at !== null && row.retracted_at !== undefined) {
         return Response.json({ error: { code: "bad_request", message: "message is already retracted" } }, { status: 400 });
       }
+      // `[erased]` is the authoritative GDPR tombstone, not an editable sender message. Allowing a
+      // moderator to revise/supersede it would recreate content and durable work under an identity
+      // whose owner/profile data was deliberately removed.
+      if (String(row.body) === "[erased]") {
+        return Response.json({ error: { code: "bad_request", message: "message was erased and cannot be revised" } }, { status: 400 });
+      }
       let body: { body?: unknown; mentions?: unknown } | null = null;
+      let editRouting: RoutedMentionFrame | undefined;
       if (action !== "retract") {
         body = (await request.json().catch(() => null)) as { body?: unknown; mentions?: unknown } | null;
         if (body === null || typeof body.body !== "string" || body.body.trim() === "") {
@@ -4697,34 +4885,166 @@ export class ChannelDO extends Server<Env> {
         if (byteLength(body.body) > BODY_LIMIT) {
           return Response.json({ error: { code: "too_large", message: `body exceeds ${BODY_LIMIT} bytes` } }, { status: 413 });
         }
+        if (action === "edit") {
+          const explicitMentions = parseMentions(body.mentions);
+          if (explicitMentions === null) {
+            return Response.json(
+              { error: { code: "bad_request", message: "mentions are invalid or exceed limits" } },
+              { status: 400 },
+            );
+          }
+          const mentions = mergeBodyMentions(explicitMentions, body.body);
+          if (mentions === null) {
+            return Response.json(
+              { error: { code: "too_large", message: "body contains too many mention targets" } },
+              { status: 413 },
+            );
+          }
+          const routed = await this.routeMentionsForDelivery(
+            {
+              type: "send",
+              kind: "message",
+              body: body.body,
+              mentions,
+              reply_to: row.reply_to === null || row.reply_to === undefined ? null : Number(row.reply_to),
+            },
+            identity.name,
+          );
+          if ("ok" in routed) {
+            return Response.json(
+              { error: { code: routed.code, message: routed.message } },
+              { status: ERROR_STATUS[routed.code] },
+            );
+          }
+          editRouting = routed;
+        }
       }
       const now = Date.now();
       const originalBody = row.original_body === null || row.original_body === undefined ? String(row.body) : String(row.original_body);
       if (action === "edit") {
-        this.ctx.storage.sql.exec(
-          `INSERT INTO message_audit (target_seq, action, actor_name, actor_kind, old_body, new_body, created_at)
-           VALUES (?, 'edit', ?, ?, ?, ?, ?)`,
-          seq,
-          identity.name,
-          identity.kind,
-          String(row.body),
-          body!.body,
-          now,
-        );
-        this.ctx.storage.sql.exec(
-          `UPDATE messages
-              SET body = ?, original_body = COALESCE(original_body, ?), edited_at = ?, edited_by = ?, rev_seq = ?
-            WHERE seq = ?`,
-          body!.body,
-          originalBody,
-          now,
-          identity.name,
-          this.nextRevSeq(),
-          seq,
-        );
-        const updated = this.ctx.storage.sql.exec("SELECT * FROM messages WHERE seq = ?", seq).one();
-        const frame = this.rowToFrame(updated);
+        if (editRouting === undefined || editRouting.frame.kind !== "message") {
+          throw new Error("message edit produced no mention routing");
+        }
+        const editState: {
+          failure?: SendErrorOutcome;
+          frame?: MsgFrame;
+        } = {};
+        const effects = this.captureAtomicDeliveryEffects(() => {
+          const current = this.ctx.storage.sql.exec("SELECT * FROM messages WHERE seq = ?", seq).one();
+          if (
+            !current
+            || current.retracted_at !== null && current.retracted_at !== undefined
+            || String(current.body) === "[erased]"
+          ) {
+            editState.failure = { ok: false, code: "bad_request", message: "message is no longer editable" };
+            return;
+          }
+          const currentFrame = this.rowToFrame(current);
+          const oldMentionKeys = new Set(currentFrame.mentions.map(mentionMatchKey));
+          const desiredTargetKeys = new Set(editRouting!.deliveryTargets.map(mentionMatchKey));
+          const existingDeliveries = this.ctx.storage.sql
+            .exec("SELECT target_name FROM directed_deliveries WHERE message_seq = ?", seq)
+            .toArray();
+          const historicalTargets: string[] = [];
+          const historicalTargetKeys = new Set<string>();
+          for (const targetName of [
+            ...parseStoredTargetNames(current.delivery_targets_json),
+            ...existingDeliveries.map((delivery) => String(delivery.target_name)),
+          ]) {
+            const key = mentionMatchKey(targetName);
+            if (historicalTargetKeys.has(key)) continue;
+            historicalTargetKeys.add(key);
+            historicalTargets.push(targetName);
+          }
+
+          // A routed target is an immutable work/audit identity. The compact message tombstone
+          // outlives bounded delivery rows, so pruning a terminal row cannot make a later edit
+          // recreate the same (message_seq,target_name) work. Use supersede/retract to change it.
+          for (const targetName of historicalTargets) {
+            const key = mentionMatchKey(targetName);
+            if (oldMentionKeys.has(key) && !desiredTargetKeys.has(key)) {
+              editState.failure = {
+                ok: false,
+                code: "bad_request",
+                message: `cannot remove routed target @${targetName}; retract or supersede the message instead`,
+              };
+              return;
+            }
+            if (!oldMentionKeys.has(key) && desiredTargetKeys.has(key)) {
+              editState.failure = {
+                ok: false,
+                code: "bad_request",
+                message: `cannot re-add routed target @${targetName} on the same message; send a new message instead`,
+              };
+              return;
+            }
+          }
+          // Before durable deliveries existed, a retained message could already contain @agent but
+          // have neither a delivery row nor a compact tombstone. Preserving that old mention while
+          // merely editing wording is not new work. Tombstone it now, while still routing targets
+          // that are genuinely added by this edit.
+          const preservedLegacyTargets = editRouting!.deliveryTargets.filter((targetName) => {
+            const key = mentionMatchKey(targetName);
+            return oldMentionKeys.has(key) && !historicalTargetKeys.has(key);
+          });
+          const newDeliveryTargets = editRouting!.deliveryTargets.filter((targetName) => {
+            const key = mentionMatchKey(targetName);
+            return !oldMentionKeys.has(key) && !historicalTargetKeys.has(key);
+          });
+          const nextHistoricalTargets = [
+            ...historicalTargets,
+            ...preservedLegacyTargets,
+            ...newDeliveryTargets,
+          ];
+
+          const currentOriginalBody =
+            current.original_body === null || current.original_body === undefined
+              ? String(current.body)
+              : String(current.original_body);
+          this.ctx.storage.sql.exec(
+            `INSERT INTO message_audit (target_seq, action, actor_name, actor_kind, old_body, new_body, created_at)
+             VALUES (?, 'edit', ?, ?, ?, ?, ?)`,
+            seq,
+            identity.name,
+            identity.kind,
+            String(current.body),
+            body!.body,
+            now,
+          );
+          this.ctx.storage.sql.exec(
+            `UPDATE messages
+                SET body = ?, mentions_json = ?, delivery_targets_json = ?,
+                    original_body = COALESCE(original_body, ?),
+                    edited_at = ?, edited_by = ?, rev_seq = ?
+              WHERE seq = ?`,
+            body!.body,
+            JSON.stringify(editRouting!.frame.mentions),
+            JSON.stringify(nextHistoricalTargets),
+            currentOriginalBody,
+            now,
+            identity.name,
+            this.nextRevSeq(),
+            seq,
+          );
+          const updated = this.ctx.storage.sql.exec("SELECT * FROM messages WHERE seq = ?", seq).one();
+          editState.frame = this.rowToFrame(updated);
+          this.ensureDirectedDeliveries(
+            editState.frame,
+            newDeliveryTargets,
+            editRouting!.deliveryTargetOwners,
+            "mention_edit",
+          );
+        });
+        if (editState.failure !== undefined) {
+          return Response.json(
+            { error: { code: editState.failure.code, message: editState.failure.message } },
+            { status: ERROR_STATUS[editState.failure.code] },
+          );
+        }
+        const frame = editState.frame;
+        if (frame === undefined) throw new Error("atomic message edit produced no frame");
         this.broadcastFrame(this.messageUpdate("edit", identity, frame, now));
+        this.flushAtomicDeliveryEffects(effects);
         await this.scheduleAuditRetention(now);
         return Response.json({ message: publicMsgFrame(frame) });
       }
@@ -4751,7 +5071,7 @@ export class ChannelDO extends Server<Env> {
           );
           this.ctx.storage.sql.exec(
             `UPDATE messages
-                SET body = '[retracted]', mentions_json = '[]', original_body = NULL,
+                SET body = '[retracted]', mentions_json = '[]', delivery_targets_json = '[]', original_body = NULL,
                     state = NULL, note = NULL, status_scope_json = NULL, status_blocked_reason = NULL,
                     status_context_json = NULL, status_decision_json = NULL, status_workflow_json = NULL,
                     message_workflow_json = NULL, completion_artifact_json = NULL,
@@ -5962,6 +6282,71 @@ export class ChannelDO extends Server<Env> {
     return withExpandedMentions(frame, [...mentions, target]);
   }
 
+  /**
+   * Resolve/canonicalize every mention and bind agent targets to their creation-time principal.
+   * Message creation and message edits must share this exact path: storing text that visibly says
+   * `@agent` without creating the matching durable delivery is worse than rejecting the write.
+   */
+  private async routeMentionsForDelivery(
+    frame: SendFrame,
+    senderName: string,
+  ): Promise<RoutedMentionFrame | SendErrorOutcome> {
+    const mentionResolution = await this.resolveMentions(frame);
+    if ("ok" in mentionResolution) return mentionResolution;
+    const beforeReplyKeys = new Set((mentionResolution.frame.mentions ?? []).map(mentionMatchKey));
+    frame = this.expandAgentReplyMention(mentionResolution.frame, senderName);
+    const autoReplyTargets = (frame.mentions ?? []).filter(
+      (target) => !beforeReplyKeys.has(mentionMatchKey(target)),
+    );
+    const squadExpansion = await this.expandSquadMentions(frame);
+    if ("ok" in squadExpansion) return squadExpansion;
+    frame = squadExpansion.frame;
+    const requiredDeliveryTargets = [...new Set([
+      ...mentionResolution.agentTargets,
+      ...squadExpansion.agentTargets,
+    ])];
+    const candidateDeliveryTargets = [...new Set([...requiredDeliveryTargets, ...autoReplyTargets])];
+    const ownerLookup = await this.agentOwnersForTargets(candidateDeliveryTargets);
+    if (ownerLookup === null) {
+      return {
+        ok: false,
+        code: "unavailable",
+        message: "agent ownership directory is temporarily unavailable; message was not stored",
+      };
+    }
+    const unboundDeliveryTargets = requiredDeliveryTargets.filter(
+      (target) => !Object.prototype.hasOwnProperty.call(ownerLookup, target),
+    );
+    if (unboundDeliveryTargets.length > 0) {
+      return {
+        ok: false,
+        code: "unavailable",
+        message: `cannot bind delivery identity for @${unboundDeliveryTargets[0]}; retry shortly`,
+      };
+    }
+    // A reply to a historical/revoked agent must remain a valid channel reply, but it must not
+    // create a name-only wake that a future owner could capture. Drop only the server-added mention
+    // when no current creation-time principal exists; explicit mentions keep their own validation.
+    const unboundAutoKeys = new Set(
+      autoReplyTargets
+        .filter((target) => !Object.prototype.hasOwnProperty.call(ownerLookup, target))
+        .map(mentionMatchKey),
+    );
+    if (unboundAutoKeys.size > 0) {
+      frame = withExpandedMentions(
+        frame,
+        (frame.mentions ?? []).filter((target) => !unboundAutoKeys.has(mentionMatchKey(target))),
+      );
+    }
+    return {
+      frame,
+      deliveryTargets: candidateDeliveryTargets.filter((target) =>
+        Object.prototype.hasOwnProperty.call(ownerLookup, target)
+      ),
+      deliveryTargetOwners: ownerLookup,
+    };
+  }
+
   // 校验 → 分配 seq → 落库 → 修剪/presence，返回待广播帧
   private async handleSend(
     identity: Identity,
@@ -6012,57 +6397,10 @@ export class ChannelDO extends Server<Env> {
     if (byteLength(payload) > BODY_LIMIT) {
       return { ok: false, code: "too_large", message: `body exceeds ${BODY_LIMIT} bytes` };
     }
-    const mentionResolution = await this.resolveMentions(frame);
-    if ("ok" in mentionResolution) return mentionResolution;
-    const beforeReplyKeys = new Set((mentionResolution.frame.mentions ?? []).map(mentionMatchKey));
-    frame = this.expandAgentReplyMention(mentionResolution.frame, identity.name);
-    const autoReplyTargets = (frame.mentions ?? []).filter(
-      (target) => !beforeReplyKeys.has(mentionMatchKey(target)),
-    );
-    const squadExpansion = await this.expandSquadMentions(frame);
-    if ("ok" in squadExpansion) return squadExpansion;
-    frame = squadExpansion.frame;
-    const requiredDeliveryTargets = [...new Set([
-      ...mentionResolution.agentTargets,
-      ...squadExpansion.agentTargets,
-    ])];
-    const candidateDeliveryTargets = [...new Set([...requiredDeliveryTargets, ...autoReplyTargets])];
-    const ownerLookup = await this.agentOwnersForTargets(candidateDeliveryTargets);
-    if (ownerLookup === null) {
-      return {
-        ok: false,
-        code: "unavailable",
-        message: "agent ownership directory is temporarily unavailable; message was not stored",
-      };
-    }
-    const unboundDeliveryTargets = requiredDeliveryTargets.filter(
-      (target) => !Object.prototype.hasOwnProperty.call(ownerLookup, target),
-    );
-    if (unboundDeliveryTargets.length > 0) {
-      return {
-        ok: false,
-        code: "unavailable",
-        message: `cannot bind delivery identity for @${unboundDeliveryTargets[0]}; retry shortly`,
-      };
-    }
-    // A reply to a historical/revoked agent must remain a valid channel reply, but it must not
-    // create a name-only wake that a future owner could capture. Drop only the server-added mention
-    // when no current creation-time principal exists; explicit mentions keep their own validation.
-    const unboundAutoKeys = new Set(
-      autoReplyTargets
-        .filter((target) => !Object.prototype.hasOwnProperty.call(ownerLookup, target))
-        .map(mentionMatchKey),
-    );
-    if (unboundAutoKeys.size > 0) {
-      frame = withExpandedMentions(
-        frame,
-        (frame.mentions ?? []).filter((target) => !unboundAutoKeys.has(mentionMatchKey(target))),
-      );
-    }
-    const deliveryTargets = candidateDeliveryTargets.filter((target) =>
-      Object.prototype.hasOwnProperty.call(ownerLookup, target)
-    );
-    const deliveryTargetOwners = ownerLookup;
+    const mentionRouting = await this.routeMentionsForDelivery(frame, identity.name);
+    if ("ok" in mentionRouting) return mentionRouting;
+    frame = mentionRouting.frame;
+    const { deliveryTargets, deliveryTargetOwners } = mentionRouting;
     const workflowGuard = this.workflowGuardDecision(identity, frame);
     if (workflowGuard !== null) {
       const row = this.workflowGuardRow(workflowGuard.workflow.workflow_id);
@@ -6284,14 +6622,14 @@ export class ChannelDO extends Server<Env> {
     sql.exec(
       `INSERT INTO messages (
          seq, sender_name, sender_kind, sender_owner, sender_handle, sender_display_name, sender_avatar_url, sender_avatar_thumb,
-         sender_lineage_json, kind, body, mentions_json, reply_to,
+         sender_lineage_json, kind, body, mentions_json, delivery_targets_json, reply_to,
          state, note, status_scope_json, status_summary_seq, status_blocked_reason, status_context_json,
          status_decision_json, status_workflow_json, message_workflow_json,
          sender_role, sender_role_source, completion_artifact_json, completion_review_state, completion_review_policy,
          completion_review_replaces_seq, decision_request_json, decision_state, decision_resolution_json,
          idempotency_key, attachments_json, sender_client_version, ts
        )
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       seq,
       identity.name,
       identity.kind,
@@ -6304,6 +6642,7 @@ export class ChannelDO extends Server<Env> {
       msg.kind,
       msg.body,
       JSON.stringify(msg.mentions),
+      JSON.stringify(deliveryTargets),
       msg.reply_to,
       msg.state,
       msg.note,
@@ -7228,7 +7567,7 @@ export class ChannelDO extends Server<Env> {
         const revSeq = this.nextRevSeq();
         sql.exec(
         `UPDATE messages
-            SET body = '[erased]', mentions_json = '[]', original_body = NULL,
+            SET body = '[erased]', mentions_json = '[]', delivery_targets_json = '[]', original_body = NULL,
                 state = NULL, note = NULL,
                 status_scope_json = NULL, status_blocked_reason = NULL, status_context_json = NULL,
                 status_decision_json = NULL, status_workflow_json = NULL, message_workflow_json = NULL,
@@ -7763,6 +8102,7 @@ export class ChannelDO extends Server<Env> {
     msg: MsgFrame,
     classifiedTargets: string[],
     targetOwners: Record<string, string> = {},
+    causeOverride?: DirectedDeliveryCause,
   ) {
     // Status/presence frames are coordination metadata, not agent work. Self-mentions likewise must
     // never claim a queue slot the CLI intentionally refuses to run, or one poison row blocks every
@@ -7793,7 +8133,7 @@ export class ChannelDO extends Server<Env> {
         msg.seq,
         targetName,
         targetOwners[targetName] ?? null,
-        this.directedDeliveryCause(msg, targetName),
+        causeOverride ?? this.directedDeliveryCause(msg, targetName),
         workId,
         continuationRef,
         msg.decision_response?.delivery_id ?? null,
@@ -7801,7 +8141,10 @@ export class ChannelDO extends Server<Env> {
         now,
       );
       const inserted = this.directedDeliveryRow(id);
-      if (inserted !== undefined) this.broadcastDirectedDelivery(inserted);
+      if (inserted !== undefined) {
+        this.broadcastDirectedDelivery(inserted);
+        this.ctx.waitUntil(this.ensureAlarmAt(now + DIRECTED_DELIVERY_MAX_AGE_MS));
+      }
     }
     for (const targetName of targets) this.dispatchNextDirectedDelivery(targetName);
   }
@@ -7867,7 +8210,10 @@ export class ChannelDO extends Server<Env> {
         const st = candidate.state;
         return st != null && this.identityDeliveryPrincipal(st) === principal;
       });
-      const matchingLegacy = samePrincipalLegacy.filter((candidate) => {
+      // An edit-created delivery has no new raw `msg` broadcast for legacy consumers to execute.
+      // Never hand it to a v0 adapter and then call the work running; keep it queued until a v1
+      // serve/watch or a bound agent webhook can consume the explicit durable delivery frame.
+      const matchingLegacy = String(queued.cause) === "mention_edit" ? [] : samePrincipalLegacy.filter((candidate) => {
         const st = candidate.state;
         return st != null &&
           typeof st.helloSince === "number" &&
@@ -8188,11 +8534,25 @@ export class ChannelDO extends Server<Env> {
       oldState !== "running" &&
       !(oldState === "failed" && update.state === "replied")
     ) return false;
+    if (update.state === "replied" && update.reply_seq === undefined) {
+      if (oldState !== "claimed" && oldState !== "running") return false;
+      const failed = this.transitionDirectedDeliveryTerminal(update.delivery_id, "failed", now, {
+        error: "runner reported success without a linked channel reply",
+        expectedStates: [oldState],
+        expectedLeaseConnectionId: connectionId,
+      });
+      return failed !== undefined && String(failed.state) === "failed";
+    }
     if (update.reply_seq !== undefined) {
       const reply = this.ctx.storage.sql
-        .exec("SELECT sender_name FROM messages WHERE seq = ?", update.reply_seq)
+        .exec("SELECT sender_name, reply_to, status_summary_seq FROM messages WHERE seq = ?", update.reply_seq)
         .toArray()[0];
       if (reply === undefined || String(reply.sender_name) !== identity.name) return false;
+      if (
+        update.state === "replied" &&
+        Number(reply.reply_to ?? -1) !== Number(row.message_seq) &&
+        Number(reply.status_summary_seq ?? -1) !== Number(row.message_seq)
+      ) return false;
     }
 
     if (update.state === "running") {
@@ -8313,6 +8673,7 @@ export class ChannelDO extends Server<Env> {
     const terminal = this.directedDeliveryRow(deliveryId);
     if (terminal === undefined || String(terminal.state) !== terminalState) return undefined;
     this.broadcastDirectedDelivery(terminal);
+    this.ctx.waitUntil(this.ensureAlarmAt(now + DIRECTED_DELIVERY_TERMINAL_RETENTION_MS));
     if (String(terminal.cause) === "owner_answer") {
       this.settleWaitingOwnerAncestors(terminal, terminalState, replySeq, error, now);
     }

--- a/worker/test/directed-delivery.spec.ts
+++ b/worker/test/directed-delivery.spec.ts
@@ -79,6 +79,83 @@ async function expectUpgradeRequiredWithoutRaw(ws: WsClient, forbiddenSeq?: numb
 }
 
 describe("持久定向投递（issue #551）", () => {
+  it("pause keeps the original delivery queued and resume dispatches that exact work once", async () => {
+    const sender = await seedToken("agent", uniq("sender"));
+    const target = await seedToken("agent", uniq("target"));
+    const slug = await createChannel(sender.token);
+    const holder = await WsClient.open(slug, target.token);
+    await holder.nextOfType("welcome");
+    expect((await claim(holder)).held).toBe(true);
+
+    const paused = await api(`/api/channels/${slug}/presence/${encodeURIComponent(target.name)}/pause`, sender.token, {
+      method: "POST",
+      body: JSON.stringify({}),
+    });
+    expect(paused.status).toBe(200);
+    const posted = await sendMention(slug, sender.token, target.name, "queued while paused");
+    await expect(holder.nextOfType("delivery", 100)).rejects.toThrow("timeout waiting for frame");
+    const queued = (await deliveryRows(slug))[0]!;
+    expect(queued).toMatchObject({
+      message_seq: posted.seq,
+      target_name: target.name,
+      state: "queued",
+      attempt: 0,
+      lease_connection_id: null,
+    });
+
+    const resumed = await api(`/api/channels/${slug}/presence/${encodeURIComponent(target.name)}/resume`, sender.token, {
+      method: "POST",
+    });
+    expect(resumed.status).toBe(200);
+    const work = (await holder.nextOfType("delivery")) as DirectedDeliveryFrame;
+    expect(work.delivery).toMatchObject({ id: queued.id, message_seq: posted.seq, state: "claimed", attempt: 1 });
+    holder.send({
+      type: "delivery_update",
+      delivery_id: work.delivery.id,
+      state: "running",
+      work_id: work.delivery.work_id!,
+      continuation_ref: work.delivery.continuation_ref!,
+    });
+    await nextDeliveryState(holder, work.delivery.id, "running");
+
+    const reply = await api(`/api/channels/${slug}/messages`, target.token, {
+      method: "POST",
+      body: JSON.stringify({ kind: "message", body: "resumed once", mentions: [], reply_to: posted.seq }),
+    });
+    expect(reply.status).toBe(200);
+    const replySeq = ((await reply.json()) as { seq: number }).seq;
+    await nextDeliveryState(holder, work.delivery.id, "replied");
+
+    // The runner's inevitable terminal receipt is idempotent after the linked REST reply already
+    // settled the row; it must not manufacture another delivery or another channel reply.
+    holder.send({
+      type: "delivery_update",
+      delivery_id: work.delivery.id,
+      request_id: "pause-resume-terminal",
+      state: "replied",
+      reply_seq: replySeq,
+    });
+    await nextDeliveryState(holder, work.delivery.id, "replied", "pause-resume-terminal");
+    const settledSource = (await deliveryRows(slug)).filter(
+      (delivery) => delivery.message_seq === posted.seq && delivery.target_name === target.name,
+    );
+    expect(settledSource).toMatchObject([{
+      id: queued.id,
+      state: "replied",
+      attempt: 1,
+      reply_seq: replySeq,
+    }]);
+    const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+    await runInDurableObject(stub, async (_instance: ChannelDO, state) => {
+      expect(Number(state.storage.sql.exec(
+        "SELECT COUNT(*) AS n FROM messages WHERE sender_name = ? AND reply_to = ? AND body = 'resumed once'",
+        target.name,
+        posted.seq,
+      ).one().n)).toBe(1);
+    });
+    holder.close();
+  });
+
   it("legacy serve 已持租时保持 holder，后来的 v1 为 standby 且不重复领取", async () => {
     const sender = await seedToken("agent", uniq("sender"));
     const target = await seedToken("agent", uniq("target"));
@@ -180,7 +257,7 @@ describe("持久定向投递（issue #551）", () => {
     legacy.raw('{"type":"ping"}');
     await legacy.nextOfType("pong");
     const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
-    await runInDurableObject(stub, async (instance: ChannelDO) => {
+    await runInDurableObject(stub, async (instance: ChannelDO, state) => {
       for (const connection of instance.getConnections<Record<string, unknown>>()) {
         const state = connection.state;
         if (state?.name !== target.name || state.clientVersion !== "0.2.117") continue;
@@ -310,7 +387,7 @@ describe("持久定向投递（issue #551）", () => {
       await pending.nextOfType("pong");
     }
     const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
-    await runInDurableObject(stub, async (instance: ChannelDO) => {
+    await runInDurableObject(stub, async (instance: ChannelDO, state) => {
       for (const connection of instance.getConnections<Record<string, unknown>>()) {
         const state = connection.state;
         if (state?.name === target.name && state.helloPending === true) {
@@ -531,7 +608,7 @@ describe("持久定向投递（issue #551）", () => {
     const work = (await holder.nextOfType("delivery")) as DirectedDeliveryFrame;
 
     const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
-    await runInDurableObject(stub, async (instance: ChannelDO) => {
+    await runInDurableObject(stub, async (instance: ChannelDO, state) => {
       const runtime = instance as unknown as {
         isTokenActive(tokenHash: string): Promise<boolean>;
         onMessage(connection: unknown, message: string): Promise<void>;
@@ -542,6 +619,18 @@ describe("持久定向投递（issue #551）", () => {
           candidate.state?.name === target.name && candidate.state?.serveLeaseHeld === true
         );
       expect(connection).toBeDefined();
+      const replySeq = Number(state.storage.sql.exec("SELECT COALESCE(MAX(seq), 0) + 1 AS seq FROM messages").one().seq);
+      // Model a reply that was already persisted by another request but whose linkWakeResume side
+      // effect has not yet run. The terminal receipt may finish this exact linked reply; a bare
+      // zero-exit receipt is covered separately and must fail.
+      state.storage.sql.exec(
+        `INSERT INTO messages (seq, sender_name, sender_kind, kind, body, mentions_json, reply_to, ts)
+         VALUES (?, ?, 'agent', 'message', 'linked reply', '[]', ?, ?)`,
+        replySeq,
+        target.name,
+        work.message.seq,
+        Date.now(),
+      );
 
       const realIsTokenActive = runtime.isTokenActive.bind(instance);
       let release!: () => void;
@@ -559,6 +648,7 @@ describe("持久定向投递（issue #551）", () => {
           delivery_id: work.delivery.id,
           request_id: "reply-before-close",
           state: "replied",
+          reply_seq: replySeq,
           work_id: work.delivery.work_id,
           continuation_ref: work.delivery.continuation_ref,
         }));
@@ -578,6 +668,41 @@ describe("持久定向投递（issue #551）", () => {
       attempt: 1,
       lease_connection_id: null,
       lease_adapter: null,
+    });
+    holder.close();
+  });
+
+  it("fails a bare success receipt that has no linked channel reply", async () => {
+    const sender = await seedToken("agent", uniq("sender"));
+    const target = await seedToken("agent", uniq("target"));
+    const slug = await createChannel(sender.token);
+    const holder = await WsClient.open(slug, target.token);
+    await holder.nextOfType("welcome");
+    expect((await claim(holder)).held).toBe(true);
+    await sendMention(slug, sender.token, target.name, "silent command");
+    const work = (await holder.nextOfType("delivery")) as DirectedDeliveryFrame;
+
+    holder.send({
+      type: "delivery_update",
+      delivery_id: work.delivery.id,
+      state: "running",
+      ...(work.delivery.work_id === null ? {} : { work_id: work.delivery.work_id }),
+      ...(work.delivery.continuation_ref === null ? {} : { continuation_ref: work.delivery.continuation_ref }),
+    });
+    await nextDeliveryState(holder, work.delivery.id, "running");
+    holder.send({
+      type: "delivery_update",
+      delivery_id: work.delivery.id,
+      request_id: "silent-success",
+      state: "replied",
+    });
+    expect(await nextDeliveryState(holder, work.delivery.id, "failed", "silent-success")).toMatchObject({
+      delivery: { id: work.delivery.id, state: "failed", reply_seq: null },
+    });
+    expect((await deliveryRows(slug))[0]).toMatchObject({
+      state: "failed",
+      reply_seq: null,
+      last_error: "runner reported success without a linked channel reply",
     });
     holder.close();
   });

--- a/worker/test/identity-erasure.spec.ts
+++ b/worker/test/identity-erasure.spec.ts
@@ -219,6 +219,39 @@ describe("gdpr identity erasure + export (#421)", () => {
     expect(after.read_cursor).toBeNull();
     expect(after.presence.length).toBe(0);
 
+    const deliveriesBeforeRevise = await runInDurableObject(stub, async (_instance: ChannelDO, state) =>
+      state.storage.sql.exec(
+        "SELECT id, message_seq, target_name, state FROM directed_deliveries ORDER BY id",
+      ).toArray().map((row) => ({
+        id: String(row.id),
+        message_seq: Number(row.message_seq),
+        target_name: String(row.target_name),
+        state: String(row.state),
+      })),
+    );
+
+    for (const [action, init] of [
+      ["edit", { method: "POST", body: JSON.stringify({ body: `@${other.name} forged after erase` }) }],
+      ["supersede", { method: "POST", body: JSON.stringify({ body: `@${other.name} forged replacement` }) }],
+      ["retract", { method: "POST" }],
+    ] as const) {
+      const revise = await api(`/api/channels/${slug}/messages/${firstSeq}/${action}`, owner.token, init);
+      expect(revise.status).toBe(400);
+      expect(await revise.json()).toMatchObject({
+        error: { code: "bad_request", message: "message was erased and cannot be revised" },
+      });
+    }
+    await runInDurableObject(stub, async (_instance: ChannelDO, state) => {
+      expect(state.storage.sql.exec(
+        "SELECT id, message_seq, target_name, state FROM directed_deliveries ORDER BY id",
+      ).toArray().map((row) => ({
+        id: String(row.id),
+        message_seq: Number(row.message_seq),
+        target_name: String(row.target_name),
+        state: String(row.state),
+      }))).toEqual(deliveriesBeforeRevise);
+    });
+
     const otherAfter = (await (
       await api(`/api/channels/${slug}/identity/${encodeURIComponent(other.name)}/data`, owner.token)
     ).json()) as ExportShape;

--- a/worker/test/message-mutations.spec.ts
+++ b/worker/test/message-mutations.spec.ts
@@ -6,6 +6,7 @@ import { WsClient, api, createChannel, postMessage, seedToken, uniq } from "./he
 interface MsgLike {
   seq: number;
   body: string;
+  mentions?: string[];
   note?: string | null;
   edited?: true;
   retracted?: true;
@@ -30,7 +31,7 @@ async function scopedFixture() {
   const slug = await createChannel(owner.token);
   const writer = await seedToken("agent", uniq("writer"), { owner: acct, channelScope: slug });
   const other = await seedToken("agent", uniq("other"), { owner: acct, channelScope: slug });
-  return { slug, owner, writer, other };
+  return { acct, slug, owner, writer, other };
 }
 
 describe("message edit/retract/supersede", () => {
@@ -66,6 +67,226 @@ describe("message edit/retract/supersede", () => {
     expect(audit.status).toBe(200);
     expect((await audit.json()) as { audit: unknown[] }).toMatchObject({
       audit: [{ target_seq: seq, action: "edit", old_body: "wrong body", new_body: "correct body" }],
+    });
+  });
+
+  it("routes body-derived agent mentions added by an edit into durable work", async () => {
+    const { slug, writer, other } = await scopedFixture();
+    const sent = await postMessage(slug, writer.token, "plain draft");
+    const seq = ((await sent.json()) as { seq: number }).seq;
+
+    const edited = await api(`/api/channels/${slug}/messages/${seq}/edit`, writer.token, {
+      method: "POST",
+      body: JSON.stringify({ body: `请@${other.name}处理这个问题` }),
+    });
+    expect(edited.status).toBe(200);
+    expect(((await edited.json()) as { message: MsgLike }).message).toMatchObject({
+      seq,
+      body: `请@${other.name}处理这个问题`,
+      mentions: [other.name],
+      edited: true,
+    });
+
+    const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+    await runInDurableObject(stub, async (_instance: ChannelDO, state) => {
+      const deliveries = state.storage.sql
+        .exec(
+          `SELECT message_seq, target_name, cause, state, target_owner
+             FROM directed_deliveries WHERE message_seq = ?`,
+          seq,
+        )
+        .toArray();
+      expect(deliveries).toHaveLength(1);
+      expect(deliveries[0]).toMatchObject({
+        message_seq: seq,
+        target_name: other.name,
+        cause: "mention_edit",
+        state: "queued",
+        target_owner: expect.any(String),
+      });
+    });
+  });
+
+  it("does not redeliver a preserved pre-v1 mention while routing a genuinely added target", async () => {
+    const { acct, slug, writer, other } = await scopedFixture();
+    const added = await seedToken("agent", uniq("added"), { owner: acct, channelScope: slug });
+    const sent = await postMessage(slug, writer.token, `@${other.name} legacy wording`);
+    const seq = ((await sent.json()) as { seq: number }).seq;
+    const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+
+    await runInDurableObject(stub, async (_instance: ChannelDO, state) => {
+      // Model a message created before durable delivery rows and compact target tombstones existed.
+      state.storage.sql.exec("DELETE FROM directed_deliveries WHERE message_seq = ?", seq);
+      state.storage.sql.exec("UPDATE messages SET delivery_targets_json = '[]' WHERE seq = ?", seq);
+    });
+
+    const edited = await api(`/api/channels/${slug}/messages/${seq}/edit`, writer.token, {
+      method: "POST",
+      body: JSON.stringify({ body: `@${other.name} wording changed; @${added.name} newly assigned` }),
+    });
+    expect(edited.status).toBe(200);
+
+    await runInDurableObject(stub, async (_instance: ChannelDO, state) => {
+      const deliveries = state.storage.sql
+        .exec(
+          `SELECT target_name, cause
+             FROM directed_deliveries WHERE message_seq = ?
+             ORDER BY target_name`,
+          seq,
+        )
+        .toArray();
+      expect(deliveries).toEqual([{ target_name: added.name, cause: "mention_edit" }]);
+      const tombstone = JSON.parse(String(state.storage.sql.exec(
+        "SELECT delivery_targets_json FROM messages WHERE seq = ?",
+        seq,
+      ).one().delivery_targets_json)) as string[];
+      expect(tombstone.sort()).toEqual([added.name, other.name].sort());
+    });
+  });
+
+  it("rejects unknown edited mentions without changing the message or audit", async () => {
+    const { slug, writer } = await scopedFixture();
+    const sent = await postMessage(slug, writer.token, "keep this body");
+    const seq = ((await sent.json()) as { seq: number }).seq;
+    const missing = uniq("missing-agent");
+
+    const edited = await api(`/api/channels/${slug}/messages/${seq}/edit`, writer.token, {
+      method: "POST",
+      body: JSON.stringify({ body: `请@${missing}处理` }),
+    });
+    expect(edited.status).toBe(400);
+    expect(await edited.json()).toMatchObject({ error: { code: "mention_not_found" } });
+
+    const history = await api(`/api/channels/${slug}/messages?since=0`, writer.token);
+    const messages = ((await history.json()) as { messages: MsgLike[] }).messages;
+    expect(messages.find((message) => message.seq === seq)).toMatchObject({
+      body: "keep this body",
+      mentions: [],
+    });
+    const audit = await api(`/api/channels/${slug}/messages/${seq}/audit`, writer.token);
+    expect((await audit.json()) as { audit: unknown[] }).toEqual({ audit: [] });
+  });
+
+  it("rejects removing an already-routed target instead of silently detaching its work", async () => {
+    const { slug, writer, other } = await scopedFixture();
+    const sent = await postMessage(slug, writer.token, `@${other.name} original work`);
+    const seq = ((await sent.json()) as { seq: number }).seq;
+
+    const edited = await api(`/api/channels/${slug}/messages/${seq}/edit`, writer.token, {
+      method: "POST",
+      body: JSON.stringify({ body: "remove the routed target" }),
+    });
+    expect(edited.status).toBe(400);
+    expect(await edited.json()).toMatchObject({
+      error: { code: "bad_request", message: expect.stringContaining("retract or supersede") },
+    });
+
+    const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+    await runInDurableObject(stub, async (_instance: ChannelDO, state) => {
+      const message = state.storage.sql.exec("SELECT body, mentions_json FROM messages WHERE seq = ?", seq).one();
+      expect(message).toMatchObject({ body: `@${other.name} original work` });
+      expect(JSON.parse(String(message.mentions_json))).toEqual([other.name]);
+      const delivery = state.storage.sql
+        .exec("SELECT target_name, state FROM directed_deliveries WHERE message_seq = ?", seq)
+        .one();
+      expect(delivery).toMatchObject({ target_name: other.name, state: "queued" });
+    });
+  });
+
+  it("keeps an exactly-once target tombstone after terminal delivery retention prunes the row", async () => {
+    const { slug, writer, other } = await scopedFixture();
+    const sent = await postMessage(slug, writer.token, `@${other.name} original retained work`);
+    const seq = ((await sent.json()) as { seq: number }).seq;
+    const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+
+    await runInDurableObject(stub, async (instance: ChannelDO, state) => {
+      state.storage.sql.exec(
+        `UPDATE directed_deliveries
+            SET state = 'replied', lease_connection_id = NULL, lease_adapter = NULL,
+                lease_until = NULL, updated_at = ?
+          WHERE message_seq = ?`,
+        Date.now() - 8 * 24 * 60 * 60 * 1000,
+        seq,
+      );
+      await instance.onAlarm();
+      expect(Number(state.storage.sql.exec(
+        "SELECT COUNT(*) AS n FROM directed_deliveries WHERE message_seq = ?",
+        seq,
+      ).one().n)).toBe(0);
+      expect(JSON.parse(String(state.storage.sql.exec(
+        "SELECT delivery_targets_json FROM messages WHERE seq = ?",
+        seq,
+      ).one().delivery_targets_json))).toEqual([other.name]);
+    });
+
+    const edited = await api(`/api/channels/${slug}/messages/${seq}/edit`, writer.token, {
+      method: "POST",
+      body: JSON.stringify({ body: `@${other.name} wording changed, work identity unchanged` }),
+    });
+    expect(edited.status).toBe(200);
+
+    await runInDurableObject(stub, async (_instance: ChannelDO, state) => {
+      expect(Number(state.storage.sql.exec(
+        "SELECT COUNT(*) AS n FROM directed_deliveries WHERE message_seq = ?",
+        seq,
+      ).one().n)).toBe(0);
+    });
+
+    const removal = await api(`/api/channels/${slug}/messages/${seq}/edit`, writer.token, {
+      method: "POST",
+      body: JSON.stringify({ body: "do not recreate or silently detach retained work" }),
+    });
+    expect(removal.status).toBe(400);
+    expect(await removal.json()).toMatchObject({
+      error: { code: "bad_request", message: expect.stringContaining("retract or supersede") },
+    });
+  });
+
+  it("repairs malformed legacy tombstones without re-identifying retracted or erased messages", async () => {
+    const { slug, writer, other } = await scopedFixture();
+    const normal = await postMessage(slug, writer.token, `@${other.name} legacy normal`);
+    const normalSeq = ((await normal.json()) as { seq: number }).seq;
+    const retracted = await postMessage(slug, writer.token, `@${other.name} legacy retracted`);
+    const retractedSeq = ((await retracted.json()) as { seq: number }).seq;
+    const erased = await postMessage(slug, writer.token, `@${other.name} legacy erased`);
+    const erasedSeq = ((await erased.json()) as { seq: number }).seq;
+
+    expect((await api(`/api/channels/${slug}/messages/${retractedSeq}/retract`, writer.token, {
+      method: "POST",
+    })).status).toBe(200);
+    const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+    await runInDurableObject(stub, async (instance: ChannelDO, state) => {
+      // Model the upgrade state: one legacy row has a malformed compact tombstone, while
+      // retraction/GDPR scrubbing is authoritative and must remain empty on restart.
+      state.storage.sql.exec(
+        "UPDATE messages SET delivery_targets_json = '[]' WHERE seq IN (?, ?)",
+        retractedSeq,
+        erasedSeq,
+      );
+      state.storage.sql.exec(
+        "UPDATE messages SET delivery_targets_json = '{broken' WHERE seq = ?",
+        normalSeq,
+      );
+      state.storage.sql.exec(
+        "UPDATE messages SET body = '[erased]', mentions_json = '[]' WHERE seq = ?",
+        erasedSeq,
+      );
+      instance.onStart();
+
+      const rows = state.storage.sql.exec(
+        "SELECT seq, delivery_targets_json FROM messages WHERE seq IN (?, ?, ?) ORDER BY seq",
+        normalSeq,
+        retractedSeq,
+        erasedSeq,
+      ).toArray();
+      expect(rows.map((row) => ({
+        seq: Number(row.seq),
+        targets: JSON.parse(String(row.delivery_targets_json)),
+      }))).toEqual([
+        { seq: normalSeq, targets: [other.name] },
+        { seq: retractedSeq, targets: [] },
+        { seq: erasedSeq, targets: [] },
+      ]);
     });
   });
 

--- a/worker/test/retention-policy.spec.ts
+++ b/worker/test/retention-policy.spec.ts
@@ -9,9 +9,10 @@ describe("channel retention policy (#421)", () => {
     const account = `${uniq("retention")}@example.com`;
     const owner = await seedToken("agent", uniq("owner"), { owner: account });
     const slug = await createChannel(owner.token);
-    const oldResponse = await postMessage(slug, owner.token, "expired secret");
+    const target = await seedToken("agent", uniq("target"), { owner: account, channelScope: slug });
+    const oldResponse = await postMessage(slug, owner.token, `@${target.name} expired secret`);
     const oldSeq = ((await oldResponse.json()) as { seq: number }).seq;
-    const freshResponse = await postMessage(slug, owner.token, "fresh body");
+    const freshResponse = await postMessage(slug, target.token, "fresh pending question");
     const freshSeq = ((await freshResponse.json()) as { seq: number }).seq;
 
     const update = await api(`/api/channels/${slug}/retention`, owner.token, {
@@ -33,6 +34,34 @@ describe("channel retention policy (#421)", () => {
         oldSeq,
       );
       state.storage.sql.exec("UPDATE messages SET ts = ? WHERE seq = ?", now, freshSeq);
+      const source = state.storage.sql
+        .exec("SELECT id, work_id, continuation_ref FROM directed_deliveries WHERE message_seq = ?", oldSeq)
+        .one();
+      state.storage.sql.exec(
+        `UPDATE directed_deliveries
+            SET state = 'waiting_owner', lease_connection_id = NULL, lease_adapter = NULL,
+                lease_until = NULL, updated_at = ?
+          WHERE id = ?`,
+        now - 61_000,
+        source.id,
+      );
+      state.storage.sql.exec(
+        `UPDATE messages
+            SET reply_to = ?, decision_state = 'pending', decision_request_json = ?
+          WHERE seq = ?`,
+        oldSeq,
+        JSON.stringify({
+          kind: "approval",
+          prompt: "retain this question?",
+          options: ["approve", "reject"],
+          delivery_id: source.id,
+          origin_seq: oldSeq,
+          origin_channel: slug,
+          work_id: source.work_id,
+          continuation_ref: source.continuation_ref,
+        }),
+        freshSeq,
+      );
       state.storage.sql.exec(
         `INSERT INTO message_audit (target_seq, action, actor_name, actor_kind, old_body, new_body, created_at)
          VALUES (?, 'edit', ?, 'agent', 'expired audit', 'expired audit 2', ?),
@@ -57,6 +86,9 @@ describe("channel retention policy (#421)", () => {
       expect(state.storage.sql.exec("SELECT target_seq FROM message_audit ORDER BY target_seq").toArray().map((r) => Number(r.target_seq)))
         .toEqual([freshSeq]);
       expect(Number(state.storage.sql.exec("SELECT COUNT(*) AS n FROM webhook_queue").one().n)).toBe(0);
+      expect(Number(state.storage.sql.exec("SELECT COUNT(*) AS n FROM directed_deliveries").one().n)).toBe(0);
+      expect(state.storage.sql.exec("SELECT decision_state, decision_request_json FROM messages WHERE seq = ?", freshSeq).one())
+        .toMatchObject({ decision_state: null, decision_request_json: null });
       expect(state.storage.sql.exec("SELECT value FROM meta WHERE key = 'message_retention_ms'").one().value).toBe("60000");
       expect(state.storage.sql.exec("SELECT value FROM meta WHERE key = 'audit_retention_ms'").one().value).toBe("120000");
     });
@@ -102,5 +134,101 @@ describe("channel retention policy (#421)", () => {
       expect(state.storage.sql.exec("SELECT value FROM meta WHERE key = 'audit_retention_ms'").one().value).toBe("off");
     });
     expect(((await (await api(`/api/channels/${slug}/reconcile`, owner.token)).json()) as { ok: boolean }).ok).toBe(true);
+  });
+
+  it("bounds abandoned durable work even when message history retention is off", async () => {
+    const account = `${uniq("delivery-retention")}@example.com`;
+    const owner = await seedToken("agent", uniq("owner"), { owner: account });
+    const slug = await createChannel(owner.token);
+    const target = await seedToken("agent", uniq("target"), { owner: account, channelScope: slug });
+    const sent = await postMessage(slug, owner.token, `@${target.name} keep the history, expire the work`);
+    const seq = ((await sent.json()) as { seq: number }).seq;
+    const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+
+    await runInDurableObject(stub, async (instance: ChannelDO, state) => {
+      const now = Date.now();
+      const createdAt = Number(state.storage.sql.exec(
+        "SELECT created_at FROM directed_deliveries WHERE message_seq = ?",
+        seq,
+      ).one().created_at);
+      // Simulate an upgraded DO whose historical queued row predates deadline scheduling.
+      await state.storage.deleteAlarm();
+      instance.onStart();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      const initialAlarm = await state.storage.getAlarm();
+      expect(initialAlarm).not.toBeNull();
+      expect(Math.abs(initialAlarm! - (createdAt + 30 * 24 * 60 * 60 * 1000))).toBeLessThan(1_000);
+      state.storage.sql.exec(
+        "UPDATE directed_deliveries SET created_at = ?, updated_at = ? WHERE message_seq = ?",
+        now - 31 * 24 * 60 * 60 * 1000,
+        now - 31 * 24 * 60 * 60 * 1000,
+        seq,
+      );
+      await instance.onAlarm();
+      expect(state.storage.sql.exec(
+        "SELECT state, terminal_reason, work_id, continuation_ref FROM directed_deliveries WHERE message_seq = ?",
+        seq,
+      ).one()).toMatchObject({
+        state: "failed",
+        terminal_reason: "delivery_expired",
+        work_id: null,
+        continuation_ref: null,
+      });
+      // History retention is explicitly off, so the source body remains while only the capability
+      // and work ledger are bounded.
+      expect(state.storage.sql.exec("SELECT body FROM messages WHERE seq = ?", seq).one().body)
+        .toContain("keep the history");
+      const terminalAlarm = await state.storage.getAlarm();
+      expect(terminalAlarm).not.toBeNull();
+      expect(terminalAlarm!).toBeGreaterThanOrEqual(now + 7 * 24 * 60 * 60 * 1000 - 1_000);
+      expect(terminalAlarm!).toBeLessThanOrEqual(now + 7 * 24 * 60 * 60 * 1000 + 1_000);
+
+      state.storage.sql.exec(
+        "UPDATE directed_deliveries SET updated_at = ? WHERE message_seq = ?",
+        now - 8 * 24 * 60 * 60 * 1000,
+        seq,
+      );
+      await instance.onAlarm();
+      expect(Number(state.storage.sql.exec(
+        "SELECT COUNT(*) AS n FROM directed_deliveries WHERE message_seq = ?",
+        seq,
+      ).one().n)).toBe(0);
+      expect(Number(state.storage.sql.exec("SELECT COUNT(*) AS n FROM messages WHERE seq = ?", seq).one().n)).toBe(1);
+    });
+  });
+
+  it("advances a queued delivery's 30-day alarm to terminal retention when dispatch fails immediately", async () => {
+    const owner = await seedToken("agent", uniq("terminal-alarm-owner"));
+    const slug = await createChannel(owner.token);
+    const target = await seedToken("agent", uniq("terminal-alarm-target"), { channelScope: slug });
+    const sent = await postMessage(slug, owner.token, `@${target.name} unsafe legacy principal`);
+    const seq = ((await sent.json()) as { seq: number }).seq;
+    const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+
+    await runInDurableObject(stub, async (instance: ChannelDO, state) => {
+      const runtime = instance as unknown as { dispatchNextDirectedDelivery(name: string): void };
+      const row = state.storage.sql.exec(
+        "SELECT id, created_at FROM directed_deliveries WHERE message_seq = ?",
+        seq,
+      ).one();
+      await state.storage.setAlarm(Number(row.created_at) + 30 * 24 * 60 * 60 * 1000);
+      state.storage.sql.exec("UPDATE directed_deliveries SET target_owner = NULL WHERE id = ?", row.id);
+      const failedAt = Date.now();
+      runtime.dispatchNextDirectedDelivery(target.name);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(state.storage.sql.exec(
+        "SELECT state, terminal_reason, last_error FROM directed_deliveries WHERE id = ?",
+        row.id,
+      ).one()).toMatchObject({
+        state: "failed",
+        terminal_reason: "delivery_failed",
+        last_error: expect.stringContaining("no creation-time target principal"),
+      });
+      const terminalAlarm = await state.storage.getAlarm();
+      expect(terminalAlarm).not.toBeNull();
+      expect(terminalAlarm!).toBeGreaterThanOrEqual(failedAt + 7 * 24 * 60 * 60 * 1000 - 1_000);
+      expect(terminalAlarm!).toBeLessThanOrEqual(failedAt + 7 * 24 * 60 * 60 * 1000 + 1_000);
+    });
   });
 });


### PR DESCRIPTION
## 是什么
`issue-543-closeout` 分支的 **#543 定向投递可达性收尾**（自愈）。

- `serve` / `continuation`：agent 定向投递可恢复、断连后自愈
- CLI `client`：补健康探测；`worker/do.ts`：定向投递 / 身份擦除 / 留存策略路径
- 新增 `issue-543-live-runner` 端到端实测脚本 + 覆盖测试（continuation / directed-delivery / health / identity-erasure / message-mutations / retention-policy）

## 说明
原先本 PR 曾一并包含 #382 Lark 成员邀请，现已拆出——Lark 组织/部门选择器邀请由 **#569** 单独承载（基于当前 main、更干净）。本 PR 瘦身为纯 #543。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 定向投递新增“提及被编辑”触发原因，并完善有序的终态回调/续跑隔离。
  * 新增用于 `#543` reachability 结束的确定性 live runner。
  * `serve` 支持终态回调与 `inboundIdleTimeoutMs` 配置。
* **改进**
  * 入站 WebSocket 只在帧可解析且形状正确时才维持连接健康，并更精确写入健康状态。
  * 续传清理支持按期望身份安全删除，提升终态一致性。
* **错误修复**
  * 避免畸形/不可解析入站导致连接半损坏；directed delivery 的失败探测与谱系一致性更可靠。
  * 消息擦除后不再允许编辑/撤回/替换。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->