### PR TITLE
fix(lark): 串行化组织成员邀请请求

### DIFF
--- a/web/src/components/LarkMemberInvite.test.tsx
+++ b/web/src/components/LarkMemberInvite.test.tsx
@@ -47,6 +47,51 @@ test("searches and directly invites a Lark organization user", async () => {
   expect(JSON.stringify(renderer!.toJSON())).toContain("Added");
 });
 
+test("serializes invitations until the active request finishes", async () => {
+  let finishAlice!: () => void;
+  const alicePending = new Promise<void>((resolve) => { finishAlice = resolve; });
+  const invited: string[] = [];
+  act(() => {
+    renderer = create(
+      <LocaleProvider>
+        <LarkMemberInvite
+          slug="room"
+          token="token"
+          search={async () => ({
+            users: [
+              { id: "on_alice", name: "Alice", avatar_url: null, already_member: false },
+              { id: "on_bob", name: "Bob", avatar_url: null, already_member: false },
+            ],
+            next_cursor: null,
+          })}
+          invite={async (_token, _slug, id) => {
+            invited.push(id);
+            if (id === "on_alice") await alicePending;
+            return { id, name: id === "on_alice" ? "Alice" : "Bob", avatar_url: null, already_member: false };
+          }}
+        />
+      </LocaleProvider>,
+    );
+  });
+  const input = renderer!.root.findByProps({ "aria-label": "Search Lark organization" });
+  act(() => input.props.onChange({ target: { value: "team" } }));
+  await act(async () => renderer!.root.findByType("form").props.onSubmit({ preventDefault() {} }));
+  let aliceRequest!: Promise<void>;
+  await act(async () => {
+    aliceRequest = renderer!.root.findByProps({ "data-lark-user-id": "on_alice" }).props.onClick();
+    await Promise.resolve();
+  });
+  const bob = renderer!.root.findByProps({ "data-lark-user-id": "on_bob" });
+  expect(bob.props.disabled).toBe(true);
+  await act(async () => bob.props.onClick());
+  expect(invited).toEqual(["on_alice"]);
+  await act(async () => {
+    finishAlice();
+    await aliceRequest;
+  });
+  expect(renderer!.root.findByProps({ "data-lark-user-id": "on_bob" }).props.disabled).toBe(false);
+});
+
 test("browses departments and directly invites a selected organization user", async () => {
   const browsed: string[] = [];
   const invited: string[] = [];

--- a/web/src/components/LarkMemberInvite.tsx
+++ b/web/src/components/LarkMemberInvite.tsx
@@ -36,6 +36,7 @@ export function LarkMemberInvite({
   const [searched, setSearched] = useState(false);
   const [busy, setBusy] = useState(false);
   const [inviting, setInviting] = useState<string | null>(null);
+  const invitingUser = useRef<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const activeQuery = useRef("");
   const queryVersion = useRef(0);
@@ -136,6 +137,8 @@ export function LarkMemberInvite({
   }
 
   async function add(user: LarkDirectoryUser) {
+    if (invitingUser.current !== null) return;
+    invitingUser.current = user.id;
     setInviting(user.id);
     setError(null);
     try {
@@ -147,7 +150,8 @@ export function LarkMemberInvite({
       if (isDirectoryPermissionError(cause)) disableDirectoryActions();
       else setError(errorLabel(cause, "LarkInvite.error.invite"));
     } finally {
-      setInviting(null);
+      if (invitingUser.current === user.id) invitingUser.current = null;
+      setInviting((current) => current === user.id ? null : current);
     }
   }
 
@@ -244,7 +248,7 @@ export function LarkMemberInvite({
               type="button"
               className="d-btn"
               data-lark-user-id={user.id}
-              disabled={user.already_member || inviting === user.id}
+              disabled={user.already_member || inviting !== null}
               onClick={() => add(user)}
             >
               {user.already_member


### PR DESCRIPTION
## 改动说明

- 使用同步 ref 将 Lark 成员邀请串行化，避免两个请求覆盖共享 inviting 状态
- 活跃邀请完成前禁用所有邀请按钮；清理时只释放对应用户
- 新增两个成员并发点击的回归测试

## 合并前检查

- [x] 已阅读并处理 review-ack
- [x] 本地门禁：LarkMemberInvite 11 tests + web typecheck + diff check
- [x] 安全/鉴权：不改变服务端鉴权或邀请权限边界，仅收紧客户端重复提交

关联线上紧急修复 #569 的后续评审意见。