### PR TITLE
fix: 收紧投递协议与邀请边界

### DIFF
--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -108,131 +108,219 @@ function isRetryableNetworkError(error: unknown): boolean {
   return error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError");
 }
 
+const SENDER_KINDS = new Set(["agent", "human"]);
+const MESSAGE_KINDS = new Set(["message", "status"]);
+const STATUS_STATES = new Set(["working", "waiting", "blocked", "done"]);
+const PRESENCE_STATES = new Set(["online", "offline", "working", "waiting", "blocked", "done"]);
+const CHANNEL_MODES = new Set(["public", "private", "personal", "public_watch"]);
+const TOKEN_ROLES = new Set(["agent", "readonly", "owner", "member", "moderator"]);
+const DELIVERY_STATES = new Set(["queued", "claimed", "running", "waiting_owner", "replied", "failed"]);
+const DELIVERY_CAUSES = new Set(["mention", "reply", "owner_answer", "retry"]);
+const ERROR_CODES = new Set([
+  "bad_request",
+  "unavailable",
+  "mention_not_found",
+  "mention_ambiguous",
+  "unauthorized",
+  "rate_limited",
+  "too_large",
+  "loop_guard",
+  "workflow_guard",
+  "archived",
+  "quota_exceeded",
+  "channel_full",
+  "not_found",
+]);
+
 function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string");
 }
 
 function isSender(value: unknown): boolean {
-  return isRecord(value) && typeof value.name === "string" && (value.kind === "agent" || value.kind === "human");
+  return isRecord(value) &&
+    typeof value.name === "string" &&
+    SENDER_KINDS.has(String(value.kind)) &&
+    (value.owner === undefined || typeof value.owner === "string") &&
+    (value.handle === undefined || typeof value.handle === "string") &&
+    (value.display_name === undefined || typeof value.display_name === "string") &&
+    (value.avatar_url === undefined || typeof value.avatar_url === "string") &&
+    (value.avatar_thumb === undefined || typeof value.avatar_thumb === "string") &&
+    (value.client_version === undefined || typeof value.client_version === "string") &&
+    (value.connection_count === undefined || isPositiveInteger(value.connection_count));
 }
 
-function isStringOrNull(value: unknown): boolean {
-  return value === null || typeof value === "string";
+function isStatusEvent(value: unknown): boolean {
+  return isRecord(value) &&
+    typeof value.owner === "string" &&
+    STATUS_STATES.has(String(value.state)) &&
+    isStringArray(value.scope) &&
+    (value.summary_seq === null || isPositiveInteger(value.summary_seq)) &&
+    (value.blocked_reason === null || typeof value.blocked_reason === "string") &&
+    isFiniteNumber(value.updated_at);
 }
 
-function isFiniteNumberOrNull(value: unknown): boolean {
-  return value === null || Number.isFinite(value);
+function isPresenceEntry(value: unknown): boolean {
+  return isRecord(value) &&
+    typeof value.name === "string" &&
+    PRESENCE_STATES.has(String(value.state)) &&
+    (value.note === null || typeof value.note === "string") &&
+    isFiniteNumber(value.ts) &&
+    (value.client_version === undefined || typeof value.client_version === "string") &&
+    (value.kind === undefined || SENDER_KINDS.has(String(value.kind))) &&
+    (value.account === undefined || typeof value.account === "string") &&
+    (value.last_seen === undefined || isFiniteNumber(value.last_seen)) &&
+    (value.status === undefined || isStatusEvent(value.status)) &&
+    (value.handle === undefined || typeof value.handle === "string") &&
+    (value.display_name === undefined || typeof value.display_name === "string") &&
+    (value.avatar_url === undefined || typeof value.avatar_url === "string") &&
+    (value.avatar_thumb === undefined || typeof value.avatar_thumb === "string") &&
+    (value.paused === undefined || typeof value.paused === "boolean") &&
+    (value.resume_at === undefined || isFiniteNumber(value.resume_at)) &&
+    (value.live === undefined || typeof value.live === "boolean") &&
+    (value.busy === undefined || typeof value.busy === "boolean") &&
+    (value.queue_depth === undefined || isNonNegativeInteger(value.queue_depth)) &&
+    (value.waiting_owner_count === undefined || isNonNegativeInteger(value.waiting_owner_count)) &&
+    (value.serve_standbys === undefined || isNonNegativeInteger(value.serve_standbys)) &&
+    (value.current_task === undefined || isPositiveInteger(value.current_task)) &&
+    (value.task_started_at === undefined || isFiniteNumber(value.task_started_at)) &&
+    (value.heartbeat_at === undefined || isFiniteNumber(value.heartbeat_at)) &&
+    (value.connection_count === undefined || isPositiveInteger(value.connection_count));
 }
 
-function isRecordOrNull(value: unknown): boolean {
-  return value === null || isRecord(value);
+function isReadCursor(value: unknown): boolean {
+  return isRecord(value) &&
+    typeof value.name === "string" &&
+    (value.kind === undefined || SENDER_KINDS.has(String(value.kind))) &&
+    isNonNegativeInteger(value.last_seen_seq) &&
+    isFiniteNumber(value.updated_at);
 }
 
-// MsgFrame (shared/src/protocol.ts): only `type/seq/sender/kind/body/mentions/reply_to/
-// state/note/status/ts` are required. `state`/`note` are `string | null`, `status` is
-// `StatusEvent | null` (an object — status-type frames carry a StatusEvent). Everything
-// else on MsgFrame is optional (`?`) and is intentionally NOT required here.
 function isMessageFrame(value: unknown): boolean {
   return isRecord(value) &&
     (value.type === "msg" || value.type === "status") &&
-    Number.isSafeInteger(value.seq) &&
+    isPositiveInteger(value.seq) &&
     isSender(value.sender) &&
-    typeof value.kind === "string" &&
+    MESSAGE_KINDS.has(String(value.kind)) &&
     typeof value.body === "string" &&
-    Array.isArray(value.mentions) &&
-    value.mentions.every((m) => typeof m === "string") &&
-    isFiniteNumberOrNull(value.reply_to) &&
-    isStringOrNull(value.state) &&
-    isStringOrNull(value.note) &&
-    isRecordOrNull(value.status) &&
-    Number.isFinite(value.ts);
+    isStringArray(value.mentions) &&
+    (value.reply_to === null || isPositiveInteger(value.reply_to)) &&
+    (value.state === null || STATUS_STATES.has(String(value.state))) &&
+    (value.note === null || typeof value.note === "string") &&
+    (value.status === null || isStatusEvent(value.status)) &&
+    isFiniteNumber(value.ts) &&
+    (value.edited === undefined || value.edited === true) &&
+    (value.edited_at === undefined || isFiniteNumber(value.edited_at)) &&
+    (value.edited_by === undefined || typeof value.edited_by === "string") &&
+    (value.retracted === undefined || value.retracted === true) &&
+    (value.retracted_at === undefined || isFiniteNumber(value.retracted_at)) &&
+    (value.retracted_by === undefined || typeof value.retracted_by === "string") &&
+    (value.supersedes === undefined || isPositiveInteger(value.supersedes)) &&
+    (value.superseded_by === undefined || isPositiveInteger(value.superseded_by)) &&
+    (value.rev_seq === undefined || isPositiveInteger(value.rev_seq));
 }
 
-// Full DirectedDelivery, carried only by holder-only `delivery` frames. Nullable fields
-// (lease_until/work_id/continuation_ref/reply_seq/last_error) are validated only for type,
-// allowing null.
 function isDirectedDelivery(value: unknown): boolean {
   return isRecord(value) &&
     typeof value.id === "string" &&
-    Number.isSafeInteger(value.message_seq) &&
+    isPositiveInteger(value.message_seq) &&
     typeof value.target_name === "string" &&
-    typeof value.cause === "string" &&
-    typeof value.state === "string" &&
-    Number.isSafeInteger(value.attempt) &&
-    isFiniteNumberOrNull(value.lease_until) &&
-    isStringOrNull(value.work_id) &&
-    isStringOrNull(value.continuation_ref) &&
-    isFiniteNumberOrNull(value.reply_seq) &&
-    isStringOrNull(value.last_error) &&
-    Number.isFinite(value.created_at) &&
-    Number.isFinite(value.updated_at);
+    DELIVERY_CAUSES.has(String(value.cause)) &&
+    DELIVERY_STATES.has(String(value.state)) &&
+    isNonNegativeInteger(value.attempt) &&
+    (value.lease_until === null || isFiniteNumber(value.lease_until)) &&
+    (value.work_id === null || typeof value.work_id === "string") &&
+    (value.continuation_ref === null || typeof value.continuation_ref === "string") &&
+    (value.reply_seq === null || isPositiveInteger(value.reply_seq)) &&
+    (value.last_error === null || typeof value.last_error === "string") &&
+    isFiniteNumber(value.created_at) &&
+    isFiniteNumber(value.updated_at);
 }
 
-// PublicDirectedDelivery projection, carried by `delivery_state` frames. It intentionally
-// omits cause/attempt/lease_until/work_id/continuation_ref/last_error — those NEVER appear
-// on a state frame, so requiring them (as the old shared isDelivery did) wrongly rejected
-// every valid delivery_state frame.
-function isPublicDelivery(value: unknown): boolean {
+function isPublicDirectedDelivery(value: unknown): boolean {
   return isRecord(value) &&
     typeof value.id === "string" &&
-    Number.isSafeInteger(value.message_seq) &&
+    isPositiveInteger(value.message_seq) &&
     typeof value.target_name === "string" &&
-    typeof value.state === "string" &&
-    isFiniteNumberOrNull(value.reply_seq) &&
-    Number.isFinite(value.created_at) &&
-    Number.isFinite(value.updated_at);
+    DELIVERY_STATES.has(String(value.state)) &&
+    (value.reply_seq === null || isPositiveInteger(value.reply_seq)) &&
+    isFiniteNumber(value.created_at) &&
+    isFiniteNumber(value.updated_at);
 }
 
-/** JSON syntax alone is not a protocol heartbeat: validate the discriminant and required shape. */
+function asServerFrame(value: Record<string, unknown>): ServerFrame {
+  return value as unknown as ServerFrame;
+}
+
 function parseServerFrame(value: unknown): ServerFrame | null {
   if (!isRecord(value) || typeof value.type !== "string") return null;
   switch (value.type) {
     case "welcome":
-      return typeof value.channel === "string" && typeof value.self === "string" &&
-        Number.isSafeInteger(value.last_seq) &&
-        (value.participants === undefined || Array.isArray(value.participants)) &&
-        (value.presence === undefined || Array.isArray(value.presence))
-        ? value as unknown as ServerFrame
+      return typeof value.channel === "string" &&
+        typeof value.self === "string" &&
+        (value.mode === undefined || CHANNEL_MODES.has(String(value.mode))) &&
+        (value.role === undefined || TOKEN_ROLES.has(String(value.role))) &&
+        (value.loop_guard === undefined || value.loop_guard === null || typeof value.loop_guard === "string") &&
+        Array.isArray(value.participants) &&
+        value.participants.every(isSender) &&
+        isNonNegativeInteger(value.last_seq) &&
+        (value.last_rev_seq === undefined || isNonNegativeInteger(value.last_rev_seq)) &&
+        (value.charter_rev === undefined || isNonNegativeInteger(value.charter_rev)) &&
+        Array.isArray(value.presence) &&
+        value.presence.every(isPresenceEntry) &&
+        (value.read_cursors === undefined || (Array.isArray(value.read_cursors) && value.read_cursors.every(isReadCursor))) &&
+        (value.directed_delivery === undefined || value.directed_delivery === "v1")
+        ? asServerFrame(value)
         : null;
     case "participants":
-      return Array.isArray(value.participants) && value.participants.every(isSender)
-        ? value as unknown as ServerFrame
-        : null;
+      return Array.isArray(value.participants) && value.participants.every(isSender) ? asServerFrame(value) : null;
     case "msg":
     case "status":
-      return isMessageFrame(value) ? value as unknown as ServerFrame : null;
+      return isMessageFrame(value) ? asServerFrame(value) : null;
     case "message_update":
-      return Number.isSafeInteger(value.target_seq) && isMessageFrame(value.message)
-        ? value as unknown as ServerFrame
+      return isPositiveInteger(value.target_seq) &&
+        ["edit", "retract", "supersede", "review", "decision"].includes(String(value.action)) &&
+        isSender(value.actor) &&
+        isFiniteNumber(value.ts) &&
+        isMessageFrame(value.message)
+        ? asServerFrame(value)
         : null;
     case "sent":
-      return Number.isSafeInteger(value.seq) ? value as unknown as ServerFrame : null;
+      return isPositiveInteger(value.seq) ? asServerFrame(value) : null;
     case "presence":
-      return typeof value.name === "string" && typeof value.state === "string" && Number.isFinite(value.ts)
-        ? value as unknown as ServerFrame
-        : null;
+      return isPresenceEntry(value) ? asServerFrame(value) : null;
     case "read_cursor":
-      return typeof value.name === "string" && Number.isSafeInteger(value.last_seen_seq) && Number.isFinite(value.updated_at)
-        ? value as unknown as ServerFrame
-        : null;
+      return isReadCursor(value) ? asServerFrame(value) : null;
     case "error":
-      return typeof value.code === "string" && typeof value.message === "string"
-        ? value as unknown as ServerFrame
-        : null;
+      return ERROR_CODES.has(String(value.code)) && typeof value.message === "string" ? asServerFrame(value) : null;
     case "pong":
-      return value as unknown as ServerFrame;
+      return Object.keys(value).length === 1 ? asServerFrame(value) : null;
     case "serve_lease":
-      return typeof value.name === "string" && typeof value.held === "boolean"
-        ? value as unknown as ServerFrame
-        : null;
+      return typeof value.name === "string" && typeof value.held === "boolean" ? asServerFrame(value) : null;
     case "delivery_adapter":
-      return value.adapter === "watch" && value.registered === true ? value as unknown as ServerFrame : null;
+      return value.adapter === "watch" && value.registered === true ? asServerFrame(value) : null;
     case "delivery":
-      return isDirectedDelivery(value.delivery) && isMessageFrame(value.message)
-        ? value as unknown as ServerFrame
-        : null;
+      return isDirectedDelivery(value.delivery) && isMessageFrame(value.message) ? asServerFrame(value) : null;
     case "delivery_state":
-      return isPublicDelivery(value.delivery) ? value as unknown as ServerFrame : null;
+      return isPublicDirectedDelivery(value.delivery) &&
+        (value.request_id === undefined || typeof value.request_id === "string")
+        ? asServerFrame(value)
+        : null;
     default:
       return null;
   }
@@ -499,7 +587,7 @@ export function connect(
         if (!line.trim()) continue;
         let parsed: unknown;
         try {
-          parsed = JSON.parse(line) as unknown;
+          parsed = JSON.parse(line);
         } catch {
           continue;
         }

--- a/cli/test/client.test.ts
+++ b/cli/test/client.test.ts
@@ -440,6 +440,21 @@ describe("ws client", () => {
     expect(statuses).toEqual([{ status: "open" }, { status: "closed", error: "token revoked, re-run: party init" }]);
   });
 
+  test("drops malformed server frames before delivery to consumers", async () => {
+    server = startMockServer((frame, sock) => {
+      if (frame.type === "hello") {
+        sock.send({ type: "welcome", channel: "dev", self: "me", last_seq: 2, presence: [] });
+        sock.send({ ...msgFrame(1, "missing timestamp"), ts: undefined });
+        sock.send(welcomeFrame(2));
+        sock.send(msgFrame(3, "valid"));
+      }
+    });
+    conn = connect(server.url, "ap_tok", "dev", 0, { backoffBaseMs: 20 });
+    const frames = await collect(conn, 2);
+    expect(frames.map((frame) => frame.type)).toEqual(["welcome", "msg"]);
+    expect(frames[1]).toMatchObject({ seq: 3, body: "valid" });
+  });
+
   test("inbound watchdog retires a half-open socket and reconnects even without a close event", async () => {
     jest.useFakeTimers();
     useProbeWebSocket();
@@ -505,13 +520,15 @@ describe("ws client", () => {
     const first = ProbeWebSocket.instances[0]!;
     first.open();
 
-    jest.advanceTimersByTime(20);
+    jest.advanceTimersByTime(10);
     first.deliver("{not-json");
-    jest.advanceTimersByTime(20);
+    jest.advanceTimersByTime(10);
     first.deliver("null");
     jest.advanceTimersByTime(10);
     first.deliver("{}");
     jest.advanceTimersByTime(10);
+    first.deliver({ type: "pong", extra: true });
+    jest.advanceTimersByTime(20);
 
     expect(first.closeCalls).toContainEqual({ code: 1011, reason: "inbound idle timeout" });
     expect(first.readyState).toBe(ProbeWebSocket.CLOSED);

--- a/cli/test/mock-server.ts
+++ b/cli/test/mock-server.ts
@@ -94,6 +94,7 @@ export function welcomeFrame(lastSeq: number, self = "me", readCursors?: Array<{
     channel: "dev",
     self,
     last_seq: lastSeq,
+    participants: [],
     presence: [],
     ...(readCursors ? { read_cursors: readCursors } : {}),
   };

--- a/cli/test/watch-pause.test.ts
+++ b/cli/test/watch-pause.test.ts
@@ -15,6 +15,7 @@ function pausedWelcome(lastSeq: number, self = "me", over: Record<string, unknow
     channel: "dev",
     self,
     last_seq: lastSeq,
+    participants: [],
     presence: [
       { name: self, state: "online", note: null, ts: Date.now(), paused: true, resume_at: Date.now() + 3_600_000 },
     ],
@@ -23,7 +24,7 @@ function pausedWelcome(lastSeq: number, self = "me", over: Record<string, unknow
 }
 
 function plainWelcome(lastSeq: number, self = "me") {
-  return { type: "welcome", channel: "dev", self, last_seq: lastSeq, presence: [] };
+  return { type: "welcome", channel: "dev", self, last_seq: lastSeq, participants: [], presence: [] };
 }
 
 function presenceFrame(name: string, over: Record<string, unknown> = {}) {

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -2566,7 +2566,23 @@ export class ChannelDO extends Server<Env> {
         for (let i = 0; i < keys.length; i += 1000) {
           await this.env.ATTACHMENTS.delete(keys.slice(i, i + 1000));
         }
-        this.ctx.storage.transactionSync(() => {
+        let invalidatedDecisionSeqs: number[] = [];
+        const atomicEffects = this.captureAtomicDeliveryEffects(() => {
+          const activeRoots = this.ctx.storage.sql.exec(
+            `SELECT d.*
+               FROM directed_deliveries d
+               JOIN messages m ON m.seq = d.message_seq
+              WHERE m.ts <= ?
+                AND d.state IN ('queued', 'claimed', 'running', 'waiting_owner')
+                AND (d.parent_delivery_id IS NULL OR NOT EXISTS (
+                  SELECT 1 FROM directed_deliveries parent WHERE parent.id = d.parent_delivery_id
+                ))`,
+            cutoff,
+          ).toArray();
+          invalidatedDecisionSeqs = this.failDeliveryTree(activeRoots, now, {
+            error: "source expired by channel message retention policy",
+            terminalReason: "source_retention_expired",
+          });
           this.ctx.storage.sql.exec(
             `DELETE FROM webhook_queue
               WHERE json_valid(payload)
@@ -2597,6 +2613,8 @@ export class ChannelDO extends Server<Env> {
             cutoff,
           );
         });
+        this.flushAtomicDeliveryEffects(atomicEffects);
+        this.broadcastInvalidatedDecisions(invalidatedDecisionSeqs, now);
       }
     }
     if (auditRetention !== null) {
@@ -6038,9 +6056,10 @@ export class ChannelDO extends Server<Env> {
       tokenRows = await this.env.DB.prepare(
         `SELECT name FROM tokens
           WHERE role = 'agent' AND revoked_at IS NULL
+            AND (channel_scope IS NULL OR channel_scope = ?)
             AND name COLLATE NOCASE IN (${tokenPlaceholders})`,
       )
-        .bind(...requestedTargets)
+        .bind(this.name, ...requestedTargets)
         .all<{ name: string }>();
     } catch {
       return {
@@ -6083,9 +6102,10 @@ export class ChannelDO extends Server<Env> {
       const rows = await this.env.DB.prepare(
         `SELECT name, owner, hash FROM tokens
           WHERE role = 'agent' AND revoked_at IS NULL
+            AND (channel_scope IS NULL OR channel_scope = ?)
             AND name COLLATE NOCASE IN (${placeholders})`,
       )
-        .bind(...targets)
+        .bind(this.name, ...targets)
         .all<{ name: string; owner: string | null; hash: string }>();
       const byName = new Map(
         rows.results
@@ -6135,14 +6155,19 @@ export class ChannelDO extends Server<Env> {
 
     const [tokens, nicknames, profiles, squads] = await Promise.all([
       this.env.DB.prepare(
-        `SELECT name, role FROM tokens WHERE revoked_at IS NULL AND (${whereFor("name")})`,
-      ).bind(...binds).all<{ name: string; role: string }>(),
+        `SELECT name, role FROM tokens
+          WHERE revoked_at IS NULL
+            AND (channel_scope IS NULL OR channel_scope = ?)
+            AND (${whereFor("name")})`,
+      ).bind(this.name, ...binds).all<{ name: string; role: string }>(),
       this.env.DB.prepare(
         `SELECT n.name, n.nickname
            FROM agent_nicknames n
            JOIN tokens t ON t.name = n.name
-          WHERE t.revoked_at IS NULL AND (${whereFor("n.nickname")})`,
-      ).bind(...binds).all<{ name: string; nickname: string }>(),
+          WHERE t.revoked_at IS NULL
+            AND (t.channel_scope IS NULL OR t.channel_scope = ?)
+            AND (${whereFor("n.nickname")})`,
+      ).bind(this.name, ...binds).all<{ name: string; nickname: string }>(),
       this.env.DB.prepare(
         `SELECT handle, display_name
            FROM account_profiles
@@ -6264,22 +6289,27 @@ export class ChannelDO extends Server<Env> {
   // #544：reply_to 本身就是一条明确的定向消息。若原消息作者是 agent，即使回复正文没有再写
   // @name，也要把它加入 mentions，才能进入 watch/serve/webhook 的持久唤醒与断线重放路径。
   // 只补 agent、排除自回，避免把普通人类楼中楼回复改造成额外 @ 通知。
-  private expandAgentReplyMention(frame: SendFrame, senderName: string): SendFrame {
-    if (frame.kind !== "message" || frame.reply_to === null) return frame;
+  private expandAgentReplyMention(
+    frame: SendFrame,
+    senderName: string,
+  ): { frame: SendFrame; targets: Array<{ name: string; owner: string }> } {
+    if (frame.kind !== "message" || frame.reply_to === null) return { frame, targets: [] };
     const row = this.ctx.storage.sql
-      .exec("SELECT sender_name, sender_kind FROM messages WHERE seq = ?", frame.reply_to)
+      .exec("SELECT sender_name, sender_kind, sender_owner FROM messages WHERE seq = ?", frame.reply_to)
       .toArray()[0];
-    if (row === undefined || String(row.sender_kind) !== "agent") return frame;
+    if (row === undefined || String(row.sender_kind) !== "agent") return { frame, targets: [] };
     const target = String(row.sender_name);
+    const targetOwner = typeof row.sender_owner === "string" && row.sender_owner.length > 0 ? row.sender_owner : null;
     const mentions = frame.mentions ?? [];
     if (
+      targetOwner === null ||
       target === senderName ||
       target === "system" ||
       !MENTION_NAME_RE.test(target) ||
       mentions.includes(target) ||
       mentions.length >= MAX_MENTIONS
-    ) return frame;
-    return withExpandedMentions(frame, [...mentions, target]);
+    ) return { frame, targets: [] };
+    return { frame: withExpandedMentions(frame, [...mentions, target]), targets: [{ name: target, owner: targetOwner }] };
   }
 
   /**
@@ -6293,11 +6323,9 @@ export class ChannelDO extends Server<Env> {
   ): Promise<RoutedMentionFrame | SendErrorOutcome> {
     const mentionResolution = await this.resolveMentions(frame);
     if ("ok" in mentionResolution) return mentionResolution;
-    const beforeReplyKeys = new Set((mentionResolution.frame.mentions ?? []).map(mentionMatchKey));
-    frame = this.expandAgentReplyMention(mentionResolution.frame, senderName);
-    const autoReplyTargets = (frame.mentions ?? []).filter(
-      (target) => !beforeReplyKeys.has(mentionMatchKey(target)),
-    );
+    const autoReplyExpansion = this.expandAgentReplyMention(mentionResolution.frame, senderName);
+    frame = autoReplyExpansion.frame;
+    const autoReplyTargets = autoReplyExpansion.targets;
     const squadExpansion = await this.expandSquadMentions(frame);
     if ("ok" in squadExpansion) return squadExpansion;
     frame = squadExpansion.frame;
@@ -6305,7 +6333,10 @@ export class ChannelDO extends Server<Env> {
       ...mentionResolution.agentTargets,
       ...squadExpansion.agentTargets,
     ])];
-    const candidateDeliveryTargets = [...new Set([...requiredDeliveryTargets, ...autoReplyTargets])];
+    const candidateDeliveryTargets = [...new Set([
+      ...requiredDeliveryTargets,
+      ...autoReplyTargets.map((target) => target.name),
+    ])];
     const ownerLookup = await this.agentOwnersForTargets(candidateDeliveryTargets);
     if (ownerLookup === null) {
       return {
@@ -6326,22 +6357,25 @@ export class ChannelDO extends Server<Env> {
     }
     // A reply to a historical/revoked agent must remain a valid channel reply, but it must not
     // create a name-only wake that a future owner could capture. Drop only the server-added mention
-    // when no current creation-time principal exists; explicit mentions keep their own validation.
-    const unboundAutoKeys = new Set(
+    // when the current principal cannot be proven to match the source message snapshot; explicit
+    // mentions keep their own validation.
+    const expectedAutoOwners = new Map(autoReplyTargets.map((target) => [mentionMatchKey(target.name), target.owner]));
+    const invalidAutoKeys = new Set(
       autoReplyTargets
-        .filter((target) => !Object.prototype.hasOwnProperty.call(ownerLookup, target))
-        .map(mentionMatchKey),
+        .filter((target) => ownerLookup[target.name] !== target.owner)
+        .map((target) => mentionMatchKey(target.name)),
     );
-    if (unboundAutoKeys.size > 0) {
+    if (invalidAutoKeys.size > 0) {
       frame = withExpandedMentions(
         frame,
-        (frame.mentions ?? []).filter((target) => !unboundAutoKeys.has(mentionMatchKey(target))),
+        (frame.mentions ?? []).filter((target) => !invalidAutoKeys.has(mentionMatchKey(target))),
       );
     }
     return {
       frame,
       deliveryTargets: candidateDeliveryTargets.filter((target) =>
-        Object.prototype.hasOwnProperty.call(ownerLookup, target)
+        Object.prototype.hasOwnProperty.call(ownerLookup, target) &&
+        (expectedAutoOwners.get(mentionMatchKey(target)) === undefined || !invalidAutoKeys.has(mentionMatchKey(target)))
       ),
       deliveryTargetOwners: ownerLookup,
     };

--- a/worker/test/directed-delivery.spec.ts
+++ b/worker/test/directed-delivery.spec.ts
@@ -64,6 +64,14 @@ async function deliveryRows(
   );
 }
 
+async function messageMentions(slug: string, seq: number): Promise<string[]> {
+  const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+  return runInDurableObject(stub, async (_instance: ChannelDO, state) => {
+    const row = state.storage.sql.exec("SELECT mentions_json FROM messages WHERE seq = ?", seq).toArray()[0];
+    return JSON.parse(String(row?.mentions_json ?? "[]")) as string[];
+  });
+}
+
 async function expectUpgradeRequiredWithoutRaw(ws: WsClient, forbiddenSeq?: number) {
   for (;;) {
     const frame = await ws.next();
@@ -79,6 +87,58 @@ async function expectUpgradeRequiredWithoutRaw(ws: WsClient, forbiddenSeq?: numb
 }
 
 describe("持久定向投递（issue #551）", () => {
+  it("does not route explicit mentions to an agent token scoped to another channel", async () => {
+    const owner = `${uniq("owner")}@example.com`;
+    const sender = await seedToken("agent", uniq("sender"), { owner });
+    const scopedElsewhere = await seedToken("agent", uniq("scoped"), { owner, channelScope: "other-channel" });
+    const slug = await createChannel(sender.token);
+
+    const response = await api(`/api/channels/${slug}/messages`, sender.token, {
+      method: "POST",
+      body: JSON.stringify({ kind: "message", body: "cross scope", mentions: [scopedElsewhere.name], reply_to: null }),
+    });
+
+    expect(response.status).toBe(400);
+    expect(await deliveryRows(slug)).toEqual([]);
+  });
+
+  it("does not expand squad members whose agent tokens are scoped to another channel", async () => {
+    const owner = `${uniq("owner")}@example.com`;
+    const sender = await seedToken("agent", uniq("sender"), { owner });
+    const inScope = await seedToken("agent", uniq("in-scope"), { owner });
+    const outOfScope = await seedToken("agent", uniq("out-scope"), { owner, channelScope: "other-channel" });
+    const slug = await createChannel(sender.token);
+    const squad = uniq("squad").toLowerCase();
+    await env.DB.prepare(
+      "INSERT INTO channel_squads (channel_slug, name, leader_name, members_json, created_by, created_by_kind, created_at, updated_at) VALUES (?, ?, NULL, ?, ?, 'agent', ?, ?)",
+    ).bind(slug, squad, JSON.stringify([inScope.name, outOfScope.name]), sender.name, Date.now(), Date.now()).run();
+
+    const posted = await sendMention(slug, sender.token, squad, "team work");
+
+    expect(await messageMentions(slug, posted.seq)).toEqual([squad, inScope.name]);
+    expect(await deliveryRows(slug)).toMatchObject([{ target_name: inScope.name }]);
+  });
+
+  it("keeps historical agent replies ordinary when the current owner no longer matches sender_owner", async () => {
+    const oldOwner = `${uniq("old-owner")}@example.com`;
+    const newOwner = `${uniq("new-owner")}@example.com`;
+    const human = await seedToken("human", uniq("human"), { owner: oldOwner });
+    const target = await seedToken("agent", uniq("reply-agent"), { owner: oldOwner });
+    const slug = await createChannel(human.token);
+    const posted = await sendMention(slug, human.token, target.name, "old owner question");
+    await env.DB.prepare("UPDATE tokens SET owner = ? WHERE name = ?").bind(newOwner, target.name).run();
+
+    const reply = await api(`/api/channels/${slug}/messages`, human.token, {
+      method: "POST",
+      body: JSON.stringify({ kind: "message", body: "following up", mentions: [], reply_to: posted.seq }),
+    });
+
+    expect(reply.status).toBe(200);
+    const replySeq = ((await reply.json()) as { seq: number }).seq;
+    expect(await messageMentions(slug, replySeq)).toEqual([]);
+    expect(await deliveryRows(slug)).toHaveLength(1);
+  });
+
   it("pause keeps the original delivery queued and resume dispatches that exact work once", async () => {
     const sender = await seedToken("agent", uniq("sender"));
     const target = await seedToken("agent", uniq("target"));

--- a/worker/test/identity-erasure.spec.ts
+++ b/worker/test/identity-erasure.spec.ts
@@ -22,6 +22,16 @@ interface ExportShape {
   presence: { name: string }[];
 }
 
+function normalizeRows(rows: Record<string, unknown>[]) {
+  return rows.map((row) => Object.fromEntries(
+    Object.entries(row).map(([key, value]) => [key, value === undefined ? null : value]),
+  ));
+}
+
+function deliverySnapshot(state: DurableObjectState) {
+  return normalizeRows(state.storage.sql.exec("SELECT * FROM directed_deliveries ORDER BY id").toArray());
+}
+
 async function fixture() {
   const acct = `${uniq("acct")}@leeguoo.com`;
   const owner = await seedToken("agent", uniq("owner"), { owner: acct });
@@ -157,6 +167,7 @@ describe("gdpr identity erasure + export (#421)", () => {
     expect(exportedDecision).not.toHaveProperty("delivery_id");
     expect(exportedDecision).not.toHaveProperty("work_id");
     expect(exportedDecision).not.toHaveProperty("continuation_ref");
+    const deliveriesBeforeErase = await runInDurableObject(stub, async (_instance: ChannelDO, state) => deliverySnapshot(state));
 
     // 擦除（moderator）：返回各表命中数。
     const eraseRes = await api(`/api/channels/${slug}/identity/${encodeURIComponent(writer.name)}/data`, owner.token, {
@@ -195,6 +206,7 @@ describe("gdpr identity erasure + export (#421)", () => {
       expect(
         Number(state.storage.sql.exec("SELECT COUNT(*) AS n FROM directed_deliveries WHERE target_name = ?", other.name).one().n),
       ).toBe(1);
+      expect(deliverySnapshot(state)).toEqual(deliveriesBeforeErase.filter((row) => row.target_name !== writer.name));
       expect(
         Number(state.storage.sql.exec(
           "SELECT COUNT(*) AS n FROM messages WHERE sender_name = ? AND decision_state IS NOT NULL",

--- a/worker/test/retention-policy.spec.ts
+++ b/worker/test/retention-policy.spec.ts
@@ -231,4 +231,69 @@ describe("channel retention policy (#421)", () => {
       expect(terminalAlarm!).toBeLessThanOrEqual(failedAt + 7 * 24 * 60 * 60 * 1000 + 1_000);
     });
   });
+
+  it("fails active deliveries created during R2 deletion before pruning expired rows", async () => {
+    const account = `${uniq("retention-race")}@example.com`;
+    const owner = await seedToken("agent", uniq("owner"), { owner: account });
+    const target = await seedToken("agent", uniq("target"), { owner: account });
+    const slug = await createChannel(owner.token);
+    const oldResponse = await postMessage(slug, owner.token, "expired with race");
+    const oldSeq = ((await oldResponse.json()) as { seq: number }).seq;
+    await api(`/api/channels/${slug}/retention`, owner.token, {
+      method: "PUT",
+      body: JSON.stringify({ message_retention_ms: 60_000 }),
+    });
+    const attachmentKey = `${slug}/race-object`;
+    await env.ATTACHMENTS.put(attachmentKey, "secret");
+    const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+    await runInDurableObject(stub, async (instance: ChannelDO, state) => {
+      const now = Date.now();
+      state.storage.sql.exec(
+        "UPDATE messages SET ts = ?, attachments_json = ? WHERE seq = ?",
+        now - 61_000,
+        JSON.stringify([{ key: attachmentKey, filename: "race.txt", content_type: "text/plain", size: 6, url: `/api/channels/${slug}/attachments/race-object` }]),
+        oldSeq,
+      );
+      state.storage.sql.exec(
+        `CREATE TRIGGER block_active_delivery_delete
+         BEFORE DELETE ON directed_deliveries
+         WHEN OLD.state IN ('queued', 'claimed', 'running', 'waiting_owner')
+         BEGIN
+           SELECT RAISE(ABORT, 'active delivery deleted without terminal transition');
+         END`,
+      );
+      const bucket = env.ATTACHMENTS as unknown as { delete: (keys: string | string[]) => Promise<void> };
+      const originalDelete = bucket.delete.bind(bucket);
+      let injected = false;
+      bucket.delete = async (keys) => {
+        if (!injected) {
+          injected = true;
+          const id = crypto.randomUUID();
+          state.storage.sql.exec(
+            `INSERT INTO directed_deliveries (
+               id, message_seq, target_name, target_owner, cause, state, attempt,
+               lease_connection_id, last_lease_connection_id, lease_adapter, lease_until,
+               work_id, continuation_ref, reply_seq, last_error, created_at, updated_at
+             ) VALUES (?, ?, ?, ?, 'mention_edit', 'queued', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, ?, ?)`,
+            id,
+            oldSeq,
+            target.name,
+            account,
+            Date.now(),
+            Date.now(),
+          );
+        }
+        await originalDelete(keys);
+      };
+      try {
+        await instance.onAlarm();
+      } finally {
+        bucket.delete = originalDelete;
+        state.storage.sql.exec("DROP TRIGGER IF EXISTS block_active_delivery_delete");
+      }
+      expect(injected).toBe(true);
+      expect(Number(state.storage.sql.exec("SELECT COUNT(*) AS n FROM messages WHERE seq = ?", oldSeq).one().n)).toBe(0);
+      expect(Number(state.storage.sql.exec("SELECT COUNT(*) AS n FROM directed_deliveries WHERE message_seq = ?", oldSeq).one().n)).toBe(0);
+    });
+  });
 });

--- a/worker/test/serve-watch-wake-ledger.spec.ts
+++ b/worker/test/serve-watch-wake-ledger.spec.ts
@@ -125,8 +125,9 @@ describe("#107 serve/watch wakes land in the server-side wake ledger", () => {
   });
 
   it("treats a reply_to an agent as a durable wake target even without an explicit @ (#544)", async () => {
-    const sender = await seedToken("agent");
-    const bot = await seedToken("agent", uniq("reply-bot"));
+    const owner = `${uniq("owner")}@example.com`;
+    const sender = await seedToken("agent", uniq("sender"), { owner });
+    const bot = await seedToken("agent", uniq("reply-bot"), { owner });
     const slug = await createChannel(sender.token);
     const botWs = await registerWakeAgent(slug, bot.token, "watch");
     try {


### PR DESCRIPTION
## Summary
- harden CLI WebSocket frame parsing so malformed server frames cannot reset watchdogs or reach consumers
- preserve channel_scope as a hard mention-routing boundary and require historical reply auto-targets to match the original sender_owner
- rescan active deliveries after R2 retention deletion, snapshot full erasure rows, and keep invite actions serialized through their own request cleanup

## Review comments
- Comment 1: fixed CLI server-frame validation and watchdog behavior; added malformed-frame regressions
- Comment 2: already fixed on latest main via serialized Lark invites; retained and verified the regression
- Comment 3: fixed token alias, squad expansion, and owner lookup channel_scope filters
- Comment 4: already fixed on latest main via page-scoped Lark directory membership lookup; preserved during rebase
- Comment 5: skipped as stale; cli/scripts/issue-543-live-runner.ts and cli/test/issue-543-live-runner.test.ts do not exist on current main
- Comment 6: fixed retention R2 await race by rescanning and terminal-failing active roots before row deletion
- Comment 7: fixed historical reply auto-targeting by carrying sender_owner snapshot and requiring exact current-principal match
- Comment 8: fixed identity-erasure delivery snapshots to compare complete SELECT * rows

## Validation
- bun test cli/test/client.test.ts cli/test/watch-pause.test.ts cli/test/serve.test.ts --test-name-pattern "restart resume|drops malformed|malformed inbound|watch --once"
- cd worker && bunx vitest run test/directed-delivery.spec.ts test/serve-watch-wake-ledger.spec.ts test/retention-policy.spec.ts test/identity-erasure.spec.ts test/lark-directory.spec.ts
- bun test web/src/components/LarkMemberInvite.test.tsx
- bun run check:cli
- bun run check:worker
- bun run check:web
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改进**
  - 增强服务端消息帧校验，格式不完整或字段类型错误的消息将被安全丢弃，避免异常数据传递给客户端。
  - 优化频道范围与身份匹配，减少跨频道或身份不一致导致的误投递、错误唤醒。
  - 提升历史回复中的自动提及准确性，确保消息仅发送给正确的目标。
  - 改进内容保留与附件清理流程，降低清理期间投递记录残留或状态异常的风险。

- **测试**
  - 补充无效消息过滤、定向投递、身份擦除及保留策略等场景验证。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->