### PR TITLE
feat(lark): 移除成员后发送机器人通知

### DIFF
--- a/web/src/01-api.larkDirectory.test.ts
+++ b/web/src/01-api.larkDirectory.test.ts
@@ -57,7 +57,14 @@ describe("Lark directory API", () => {
     expect(request!.method).toBe("DELETE");
     expect(request!.url).toContain("/api/channels/private%20room/lark-members/on_alice");
     expect(request!.headers.get("authorization")).toBe("Bearer session-token");
-    expect(result).toMatchObject({ memberRemoved: true, revokedAgents: 2, notification_status: "sent" });
+    expect(result).toEqual({
+      ok: true,
+      user_id: "on_alice",
+      memberRemoved: true,
+      revokedAgents: 2,
+      revokedProjectAgentInvites: 1,
+      notification_status: "sent",
+    });
   });
 
   test("encodes organization browsing and independent pagination", async () => {

--- a/web/src/01-api.larkDirectory.test.ts
+++ b/web/src/01-api.larkDirectory.test.ts
@@ -43,13 +43,21 @@ describe("Lark directory API", () => {
     let request: Request | null = null;
     globalThis.fetch = (async (input, init) => {
       request = new Request(new URL(String(input), "https://web.test"), init);
-      return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });
+      return new Response(JSON.stringify({
+        ok: true,
+        user_id: "on_alice",
+        memberRemoved: true,
+        revokedAgents: 2,
+        revokedProjectAgentInvites: 1,
+        notification_status: "sent",
+      }), { status: 200, headers: { "content-type": "application/json" } });
     }) as typeof fetch;
 
-    await removeLarkMember("session-token", "private room", "on_alice");
+    const result = await removeLarkMember("session-token", "private room", "on_alice");
     expect(request!.method).toBe("DELETE");
     expect(request!.url).toContain("/api/channels/private%20room/lark-members/on_alice");
     expect(request!.headers.get("authorization")).toBe("Bearer session-token");
+    expect(result).toMatchObject({ memberRemoved: true, revokedAgents: 2, notification_status: "sent" });
   });
 
   test("encodes organization browsing and independent pagination", async () => {

--- a/web/src/components/LarkMemberInvite.test.tsx
+++ b/web/src/components/LarkMemberInvite.test.tsx
@@ -88,7 +88,17 @@ test("removes an existing member after confirmation and makes them inviteable ag
           slug="room"
           token="token"
           search={async () => ({ users: [{ id: "on_alice", name: "Alice", avatar_url: null, already_member: true }], next_cursor: null })}
-          remove={async (_token, _slug, id) => { removed.push(id); }}
+          remove={async (_token, _slug, id) => {
+            removed.push(id);
+            return {
+              ok: true,
+              user_id: id,
+              memberRemoved: true,
+              revokedAgents: 0,
+              revokedProjectAgentInvites: 0,
+              notification_status: "sent",
+            };
+          }}
         />
       </LocaleProvider>,
     );
@@ -99,6 +109,35 @@ test("removes an existing member after confirmation and makes them inviteable ag
   await act(async () => renderer!.root.findByProps({ "data-lark-user-id": "on_alice" }).props.onClick());
   expect(removed).toEqual(["on_alice"]);
   expect(renderer!.root.findByProps({ "data-lark-user-id": "on_alice" }).children.join(" ")).toContain("Invite");
+});
+
+test("keeps the member removed and reports a bot removal-notice failure", async () => {
+  Object.defineProperty(globalThis, "confirm", { configurable: true, value: () => true });
+  act(() => {
+    renderer = create(
+      <LocaleProvider>
+        <LarkMemberInvite
+          slug="room"
+          token="token"
+          search={async () => ({ users: [{ id: "on_alice", name: "Alice", avatar_url: null, already_member: true }], next_cursor: null })}
+          remove={async (_token, _slug, id) => ({
+            ok: true,
+            user_id: id,
+            memberRemoved: true,
+            revokedAgents: 2,
+            revokedProjectAgentInvites: 1,
+            notification_status: "failed",
+          })}
+        />
+      </LocaleProvider>,
+    );
+  });
+  const input = renderer!.root.findByProps({ "aria-label": "Search Lark organization" });
+  act(() => input.props.onChange({ target: { value: "Alice" } }));
+  await act(async () => renderer!.root.findByType("form").props.onSubmit({ preventDefault() {} }));
+  await act(async () => renderer!.root.findByProps({ "data-lark-user-id": "on_alice" }).props.onClick());
+  expect(renderer!.root.findByProps({ "data-lark-user-id": "on_alice" }).children.join(" ")).toContain("Invite");
+  expect(renderer!.root.findByProps({ role: "alert" }).children.join(" ")).toContain("removal notice");
 });
 
 test("serializes invitations until the active request finishes", async () => {

--- a/web/src/components/LarkMemberInvite.tsx
+++ b/web/src/components/LarkMemberInvite.tsx
@@ -170,10 +170,11 @@ export function LarkMemberInvite({
     setInviting(user.id);
     setError(null);
     try {
-      await remove(token, slug, user.id);
+      const removed = await remove(token, slug, user.id);
       setUsers((current) => current.map((item) => item.id === user.id ? { ...item, already_member: false } : item));
       setOrganizationUsers((current) => current.map((item) => item.id === user.id ? { ...item, already_member: false } : item));
       onRemoved?.(user);
+      if (removed.notification_status === "failed") setError(t("LarkInvite.error.removeNotification"));
     } catch (cause) {
       if (isDirectoryPermissionError(cause)) disableDirectoryActions();
       else setError(errorLabel(cause, "LarkInvite.error.remove"));

--- a/web/src/i18n/strings/LarkMemberInvite.ts
+++ b/web/src/i18n/strings/LarkMemberInvite.ts
@@ -35,6 +35,7 @@ export const LarkMemberInviteStrings: LocaleDict = {
     "LarkInvite.error.browse": "The Lark organization could not be loaded.",
     "LarkInvite.error.invite": "The Lark member could not be invited.",
     "LarkInvite.error.notification": "The member was added, but the Lark bot could not send the invitation message.",
+    "LarkInvite.error.removeNotification": "The member and their agents were blocked, but the Lark bot could not send the removal notice.",
     "LarkInvite.error.remove": "The Lark member could not be removed.",
   },
   zh: {
@@ -71,6 +72,7 @@ export const LarkMemberInviteStrings: LocaleDict = {
     "LarkInvite.error.browse": "暂时无法读取 Lark 组织架构。",
     "LarkInvite.error.invite": "无法邀请该 Lark 成员。",
     "LarkInvite.error.notification": "成员已加入频道，但 Lark 机器人未能发送邀请通知。",
+    "LarkInvite.error.removeNotification": "成员及其 agent 已被封禁，但 Lark 机器人未能发送移除通知。",
     "LarkInvite.error.remove": "无法移除该 Lark 成员。",
   },
 };

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -55,6 +55,15 @@ export interface LarkDirectoryUser {
   notification_status?: "sent" | "failed" | "skipped_already_member";
 }
 
+export interface LarkMemberRemovalResult {
+  ok: true;
+  user_id: string;
+  memberRemoved: boolean;
+  revokedAgents: number;
+  revokedProjectAgentInvites: number;
+  notification_status: "sent" | "failed" | "skipped_not_member";
+}
+
 export interface LarkDirectoryPage {
   users: LarkDirectoryUser[];
   next_cursor: string | null;
@@ -128,7 +137,7 @@ export async function inviteLarkMember(
   return (await res.json()) as LarkDirectoryUser;
 }
 
-export async function removeLarkMember(token: string, slug: string, userId: string): Promise<void> {
+export async function removeLarkMember(token: string, slug: string, userId: string): Promise<LarkMemberRemovalResult> {
   const res = await fetchApi(
     `/api/channels/${encodeURIComponent(slug)}/lark-members/${encodeURIComponent(userId)}`,
     {
@@ -139,6 +148,7 @@ export async function removeLarkMember(token: string, slug: string, userId: stri
   if (res.status === 401) throw new AuthError("invalid or revoked token");
   if (res.status === 403) throw new ForbiddenError("only a Lark channel moderator can remove members");
   if (!res.ok) throw await larkDirectoryError(res);
+  return (await res.json()) as LarkMemberRemovalResult;
 }
 
 export function urlToken(): string | null {

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -104,6 +104,7 @@ import { openapiDocument } from "./openapi";
 
 declare const __AGENTPARTY_BUILD_VERSION__: string | undefined;
 declare const __AGENTPARTY_BUILD_COMMIT__: string | undefined;
+const LARK_NOTIFICATION_TIMEOUT_MS = 5_000;
 declare const __AGENTPARTY_DEPLOYED_AT__: string | undefined;
 
 export { ChannelDO };
@@ -4010,6 +4011,7 @@ app.delete("/api/channels/:slug/lark-members/:userId", async (c) => {
         userId,
         inferReceiveIdType(userId),
         buildChannelRemovalCard(slug),
+        AbortSignal.timeout(LARK_NOTIFICATION_TIMEOUT_MS),
       );
       notificationStatus = "sent";
     } catch (notificationError) {

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -87,6 +87,7 @@ import {
   browseLarkOrganization,
   browseScopedLarkUsers,
   buildChannelInviteCard,
+  buildChannelRemovalCard,
   buildMentionCard,
   getLarkDirectoryUser,
   inferReceiveIdType,
@@ -4000,7 +4001,27 @@ app.delete("/api/channels/:slug/lark-members/:userId", async (c) => {
     return c.json(errorBody("bad_request", "channel owner cannot be removed"), 400);
   }
   const result = await removeChannelMemberAndAgents(c.env, slug, account, identity);
-  return c.json({ ok: true, user_id: userId, ...result });
+  let notificationStatus: "sent" | "failed" | "skipped_not_member" = "skipped_not_member";
+  if (result.memberRemoved) {
+    try {
+      await sendLarkCard(
+        c.env,
+        provider,
+        userId,
+        inferReceiveIdType(userId),
+        buildChannelRemovalCard(slug),
+      );
+      notificationStatus = "sent";
+    } catch (notificationError) {
+      notificationStatus = "failed";
+      console.warn("Lark member removal notification failed", {
+        channel: slug,
+        provider: provider.id,
+        error: notificationError instanceof Error ? notificationError.message : String(notificationError),
+      });
+    }
+  }
+  return c.json({ ok: true, user_id: userId, notification_status: notificationStatus, ...result });
 });
 
 app.get("/api/channels/:slug/perms", async (c) => {

--- a/worker/src/integrations/lark.ts
+++ b/worker/src/integrations/lark.ts
@@ -635,7 +635,11 @@ export function inferReceiveIdType(providerUserId: string, email: string | null 
   return "union_id";
 }
 
-export async function getTenantAccessToken(env: EnvLike, provider: LarkProviderConfig): Promise<string> {
+export async function getTenantAccessToken(
+  env: EnvLike,
+  provider: LarkProviderConfig,
+  signal?: AbortSignal,
+): Promise<string> {
   const secret = providerSecret(env, provider);
   const cacheKey = `${provider.id}:${provider.kind}:${provider.clientId}:${secret}`;
   const cached = tokenCache.get(cacheKey);
@@ -645,6 +649,7 @@ export async function getTenantAccessToken(env: EnvLike, provider: LarkProviderC
     method: "POST",
     headers: { "content-type": "application/json; charset=utf-8" },
     body: JSON.stringify({ app_id: provider.clientId, app_secret: secret }),
+    signal,
   });
   const data = (await res.json().catch(() => null)) as unknown;
   if (!res.ok || !isRecord(data)) throw new Error(`tenant_access_token failed (${res.status})`);
@@ -665,8 +670,9 @@ export async function sendLarkCard(
   receiveId: string,
   idType: LarkReceiveIdType,
   card: Record<string, unknown>,
+  signal?: AbortSignal,
 ): Promise<void> {
-  const token = await getTenantAccessToken(env, provider);
+  const token = await getTenantAccessToken(env, provider, signal);
   const res = await fetch(`${larkApiBase(provider.kind)}/open-apis/im/v1/messages?receive_id_type=${idType}`, {
     method: "POST",
     headers: {
@@ -678,6 +684,7 @@ export async function sendLarkCard(
       msg_type: "interactive",
       content: JSON.stringify(card),
     }),
+    signal,
   });
   const data = (await res.json().catch(() => null)) as unknown;
   if (!res.ok || !isRecord(data) || (data.code !== undefined && Number(data.code) !== 0)) {

--- a/worker/src/integrations/lark.ts
+++ b/worker/src/integrations/lark.ts
@@ -746,6 +746,22 @@ export function buildChannelInviteCard(channel: string, permalink: string): Reco
   };
 }
 
+export function buildChannelRemovalCard(channel: string): Record<string, unknown> {
+  return {
+    config: { wide_screen_mode: true },
+    header: {
+      template: "red",
+      title: { tag: "plain_text", content: "AgentParty 频道成员变更" },
+    },
+    elements: [
+      {
+        tag: "markdown",
+        content: `你已被移出 AgentParty 频道 **#${channel}**，你拥有的 agent 已被禁止访问该频道。\n\nYou've been removed from this channel, and your agents can no longer access it.`,
+      },
+    ],
+  };
+}
+
 async function hmacSha256Hex(secret: string, body: string): Promise<string> {
   const key = await crypto.subtle.importKey(
     "raw",

--- a/worker/src/openapi.ts
+++ b/worker/src/openapi.ts
@@ -417,13 +417,13 @@ export const openapiDocument = {
       delete: {
         summary: "remove a same-tenant Lark member and block their agents from this channel",
         security: [{ bearer: [] }],
-        description: "Removes channel membership, creates a channel-level account ban, revokes every active agent token scoped to this channel, revokes active project-agent invitations owned by the account, and disconnects all of that account's active identities. Global agents remain usable elsewhere but cannot re-enter this channel, even if it is public, until a moderator explicitly re-invites the account.",
+        description: "Removes channel membership, creates a channel-level account ban, revokes every active agent token scoped to this channel, revokes active project-agent invitations owned by the account, disconnects all of that account's active identities, and asks the Lark bot to notify the removed member. Global agents remain usable elsewhere but cannot re-enter this channel, even if it is public, until a moderator explicitly re-invites the account. A notification failure does not roll back removal or agent blocking.",
         parameters: [
           { name: "slug", in: "path", required: true, schema: { type: "string" } },
           { name: "userId", in: "path", required: true, schema: { type: "string", minLength: 1, maxLength: 128 } },
         ],
         responses: {
-          "200": { description: "member removed and channel agent access revoked" },
+          "200": { description: "member removal result; notification_status is sent, failed, or skipped_not_member" },
           "400": { description: "invalid user id or attempted owner removal" },
           "403": { description: "not a same-tenant Lark human moderator" },
           "404": { description: "channel not found" },

--- a/worker/test/lark-directory.spec.ts
+++ b/worker/test/lark-directory.spec.ts
@@ -1,6 +1,6 @@
 import { env } from "cloudflare:test";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
-import { clearLarkTokenCache } from "../src/integrations/lark";
+import { clearLarkTokenCache, getTenantAccessToken, resolveLarkProvider } from "../src/integrations/lark";
 import { api, createChannel, seedToken, uniq } from "./helpers";
 import { fetchMock } from "./fetch-mock";
 
@@ -690,17 +690,59 @@ describe("Lark organization member invitations (#358)", () => {
       .intercept({ path: "/open-apis/im/v1/messages?receive_id_type=union_id", method: "POST" })
       .reply(200, { code: 999, msg: "permission denied" });
     const warning = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    try {
+      const response = await api(`/api/channels/${slug}/lark-members/on_remove_notify_fail`, owner.token, { method: "DELETE" });
 
-    const response = await api(`/api/channels/${slug}/lark-members/on_remove_notify_fail`, owner.token, { method: "DELETE" });
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({ memberRemoved: true, revokedAgents: 1, notification_status: "failed" });
+      expect(await env.DB.prepare(
+        "SELECT account FROM channel_members WHERE channel_slug = ? AND account = ?",
+      ).bind(slug, account).first()).toBeNull();
+      expect(await env.DB.prepare("SELECT revoked_at FROM tokens WHERE name = ?").bind(scoped.name).first<{ revoked_at: number | null }>())
+        .toMatchObject({ revoked_at: expect.any(Number) });
+      expect(warning).toHaveBeenCalledOnce();
+    } finally {
+      warning.mockRestore();
+    }
+  });
 
-    expect(response.status).toBe(200);
-    expect(await response.json()).toMatchObject({ memberRemoved: true, revokedAgents: 1, notification_status: "failed" });
-    expect(await env.DB.prepare(
-      "SELECT account FROM channel_members WHERE channel_slug = ? AND account = ?",
-    ).bind(slug, account).first()).toBeNull();
-    expect(await env.DB.prepare("SELECT revoked_at FROM tokens WHERE name = ?").bind(scoped.name).first<{ revoked_at: number | null }>())
-      .toMatchObject({ revoked_at: expect.any(Number) });
-    expect(warning).toHaveBeenCalledOnce();
+  it("bounds a stuck Lark removal notification and still returns the removal result", async () => {
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    let timeout: ReturnType<typeof vi.spyOn> | null = null;
+    try {
+      const owner = await larkHuman();
+      const slug = await createChannel(owner.token);
+      const account = "lark-main:on_remove_timeout";
+      const now = Date.now();
+      await env.DB.prepare(
+        `INSERT INTO account_profiles (
+           account, handle, display_name, provider, provider_user_id, tenant_key, created_at, updated_at
+         ) VALUES (?, ?, 'Remove Timeout', 'lark-main', 'on_remove_timeout', 'tenant-test', ?, ?)`,
+      ).bind(account, uniq("remove_timeout"), now, now).run();
+      await env.DB.prepare(
+        "INSERT INTO channel_members (channel_slug, account, added_by, added_at) VALUES (?, ?, ?, ?)",
+      ).bind(slug, account, owner.account, now).run();
+      mockTenantToken();
+      const larkEnv = env as unknown as Parameters<typeof resolveLarkProvider>[0];
+      const provider = resolveLarkProvider(larkEnv, "lark-main");
+      expect(provider).not.toBeNull();
+      await getTenantAccessToken(larkEnv, provider!);
+      timeout = vi.spyOn(AbortSignal, "timeout").mockReturnValue(
+        AbortSignal.abort(new DOMException("The operation timed out", "TimeoutError")),
+      );
+      const response = await api(`/api/channels/${slug}/lark-members/on_remove_timeout`, owner.token, { method: "DELETE" });
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({ memberRemoved: true, notification_status: "failed" });
+      expect(await env.DB.prepare(
+        "SELECT account FROM channel_members WHERE channel_slug = ? AND account = ?",
+      ).bind(slug, account).first()).toBeNull();
+      expect(timeout).toHaveBeenCalledWith(5_000);
+      expect(warning).toHaveBeenCalledOnce();
+    } finally {
+      warning.mockRestore();
+      timeout?.mockRestore();
+    }
   });
 
   it("reuses an open_id profile during a union_id invite and migrates it to the stable id", async () => {

--- a/worker/test/lark-directory.spec.ts
+++ b/worker/test/lark-directory.spec.ts
@@ -72,6 +72,27 @@ function mockDirectoryPage(options: { permissionDenied?: boolean; persist?: bool
 }
 
 describe("Lark organization member invitations (#358)", () => {
+  it("passes an already-expired notification deadline to tenant token acquisition", async () => {
+    const larkEnv = env as unknown as Parameters<typeof resolveLarkProvider>[0];
+    const provider = resolveLarkProvider(larkEnv, "lark-main");
+    expect(provider).not.toBeNull();
+    const timeout = vi.spyOn(AbortSignal, "timeout").mockReturnValue(
+      AbortSignal.abort(new DOMException("The operation timed out", "TimeoutError")),
+    );
+    fetchMock.get(LARK_ORIGIN)
+      .intercept({ path: "/open-apis/auth/v3/tenant_access_token/internal", method: "POST" })
+      .reply(200, () => {
+        throw new DOMException("The operation was aborted", "AbortError");
+      });
+    try {
+      await expect(getTenantAccessToken(larkEnv, provider!, AbortSignal.timeout(5_000)))
+        .rejects.toMatchObject({ name: "AbortError" });
+      expect(timeout).toHaveBeenCalledWith(5_000);
+    } finally {
+      timeout.mockRestore();
+    }
+  });
+
   it("publishes the moderator-only search and direct-invite contracts without any access token field", async () => {
     const response = await api("/openapi.json", "unused");
     expect(response.status).toBe(200);

--- a/worker/test/lark-directory.spec.ts
+++ b/worker/test/lark-directory.spec.ts
@@ -629,11 +629,23 @@ describe("Lark organization member invitations (#358)", () => {
     const scoped = await seedToken("agent", uniq("scoped_remove"), { owner: account, channelScope: slug });
     const global = await seedToken("agent", uniq("global_remove"), { owner: account });
     const other = await seedToken("agent", uniq("other_remove"), { owner: account, channelScope: uniq("other") });
+    mockTenantToken();
+    let sentMessage: Record<string, unknown> | null = null;
+    fetchMock.get(LARK_ORIGIN)
+      .intercept({ path: "/open-apis/im/v1/messages?receive_id_type=union_id", method: "POST" })
+      .reply(200, (options) => {
+        sentMessage = JSON.parse(String(options.body)) as Record<string, unknown>;
+        return { code: 0, data: { message_id: "om_removed" } };
+      });
 
     const response = await api(`/api/channels/${slug}/lark-members/on_remove`, owner.token, { method: "DELETE" });
 
     expect(response.status).toBe(200);
-    expect(await response.json()).toMatchObject({ memberRemoved: true, revokedAgents: 1 });
+    expect(await response.json()).toMatchObject({ memberRemoved: true, revokedAgents: 1, notification_status: "sent" });
+    expect(sentMessage).toMatchObject({ receive_id: "on_remove", msg_type: "interactive" });
+    const removalCard = JSON.parse(String((sentMessage as unknown as Record<string, unknown>).content)) as Record<string, unknown>;
+    expect(JSON.stringify(removalCard)).toContain(`#${slug}`);
+    expect(JSON.stringify(removalCard)).toContain("agent");
     expect(await env.DB.prepare(
       "SELECT account FROM channel_members WHERE channel_slug = ? AND account = ?",
     ).bind(slug, account).first()).toBeNull();
@@ -657,6 +669,38 @@ describe("Lark organization member invitations (#358)", () => {
       "SELECT account FROM channel_account_bans WHERE channel_slug = ? AND account = ?",
     ).bind(slug, account).first()).toBeNull();
     expect((await api(`/api/channels/${slug}/messages`, global.token)).status).toBe(200);
+  });
+
+  it("keeps the member and agent removal when the Lark bot notification fails", async () => {
+    const owner = await larkHuman();
+    const slug = await createChannel(owner.token);
+    const account = "lark-main:on_remove_notify_fail";
+    const now = Date.now();
+    await env.DB.prepare(
+      `INSERT INTO account_profiles (
+         account, handle, display_name, provider, provider_user_id, tenant_key, created_at, updated_at
+       ) VALUES (?, ?, 'Remove Notify Fail', 'lark-main', 'on_remove_notify_fail', 'tenant-test', ?, ?)`,
+    ).bind(account, uniq("remove_notify_fail"), now, now).run();
+    await env.DB.prepare(
+      "INSERT INTO channel_members (channel_slug, account, added_by, added_at) VALUES (?, ?, ?, ?)",
+    ).bind(slug, account, owner.account, now).run();
+    const scoped = await seedToken("agent", uniq("scoped_notify_fail"), { owner: account, channelScope: slug });
+    mockTenantToken();
+    fetchMock.get(LARK_ORIGIN)
+      .intercept({ path: "/open-apis/im/v1/messages?receive_id_type=union_id", method: "POST" })
+      .reply(200, { code: 999, msg: "permission denied" });
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    const response = await api(`/api/channels/${slug}/lark-members/on_remove_notify_fail`, owner.token, { method: "DELETE" });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ memberRemoved: true, revokedAgents: 1, notification_status: "failed" });
+    expect(await env.DB.prepare(
+      "SELECT account FROM channel_members WHERE channel_slug = ? AND account = ?",
+    ).bind(slug, account).first()).toBeNull();
+    expect(await env.DB.prepare("SELECT revoked_at FROM tokens WHERE name = ?").bind(scoped.name).first<{ revoked_at: number | null }>())
+      .toMatchObject({ revoked_at: expect.any(Number) });
+    expect(warning).toHaveBeenCalledOnce();
   });
 
   it("reuses an open_id profile during a union_id invite and migrates it to the stable id", async () => {


### PR DESCRIPTION
## Summary
- send a Lark bot card after a moderator removes a Lark member
- tell the person that their agents are blocked from the channel
- keep removal and agent blocking committed when notification delivery fails, while surfacing the failure in the UI
- document notification status and add success/failure regressions

## Validation
- `bun run check`
- Web: 836 tests + typecheck + build
- Worker: 645 tests + typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **功能改进**
  - 移除 Lark 频道成员后将发送通知卡片，并在返回结果中携带 `notification_status`（`sent/failed/skipped_not_member`）及相关撤销信息。
  - 通知发送有 5 秒超时：即使通知超时或失败，成员移除与封禁/撤销仍保持生效。
- **错误提示**
  - 通知发送失败时，在界面展示“成员及其 agents 已被封禁，但机器人未能发送移除通知”的提示，并保留相应移除后的状态。
- **文档**
  - 更新成员移除接口的 `200` 响应含义，明确失败不回滚及通知状态返回范围。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->