### PR TITLE
fix: close desktop and CLI issue backlog

### DIFF
--- a/cli/src/commands/doctor.ts
+++ b/cli/src/commands/doctor.ts
@@ -38,7 +38,7 @@ export async function run(argv: string[]): Promise<number> {
   console.log(`latest:    ${latest}`);
   const cmp = compareVersions(latest, RUNNING_VERSION);
   if (cmp > 0) {
-    console.log(`\n有新版可升 → 升级：\n  ${INSTALL_LINE}\n升级后【重启在跑的 serve/watch】才生效（issue #45）。`);
+    console.log(`\n有新版可升 → 升级：\n  party upgrade\n  ${INSTALL_LINE}\n升级后【重启在跑的 serve/watch】才生效；serve --auto-upgrade 会在安全点自动 re-exec。`);
   } else {
     console.log("\n已是最新。");
   }

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -3,7 +3,7 @@
 // 复用 client.connect 的自动重连帧流，真正常驻；命令串行执行（一条处理完再下一条，不并发抢跑）。
 import { BODY_LIMIT, EXIT_ARCHIVED, EXIT_AUTH, EXIT_STREAM_ENDED, EXIT_UPGRADED, type AgentSessionInfo, type Attachment, type DeliveryUpdateFrame, type DirectedDelivery, type MsgFrame, type PublicDirectedDelivery, type ServerFrame } from "@agentparty/shared";
 import { createHash, randomUUID } from "node:crypto";
-import { maybeReexecUpgrade, serverVersionUpgradeNotice, upgradeNotice, type CliUpgradeNotice, type UpgradeDeps } from "../upgrade";
+import { downloadPartyUpgrade, maybeReexecUpgrade, serverVersionUpgradeNotice, upgradeNotice, type CliUpgradeNotice, type UpgradeDeps } from "../upgrade";
 import {
   appendFileSync,
   existsSync,
@@ -60,12 +60,41 @@ const PROTOCOL_REMINDER =
 export async function resolveAvailableUpgrade(
   server: string,
   current: CliUpgradeNotice | null = null,
+  options: { autoDownload?: boolean; upgradeDeps?: UpgradeDeps; out?: (line: string) => void } = {},
 ): Promise<CliUpgradeNotice | null> {
   try {
-    return serverVersionUpgradeNotice((await fetchServerVersion(server)).version);
+    const notice = serverVersionUpgradeNotice((await fetchServerVersion(server)).version, options.upgradeDeps);
+    if (notice === null) return null;
+    if (options.autoDownload !== true) return notice;
+    const installed = upgradeNotice(true, options.upgradeDeps);
+    if (installed !== null && compareUpgradeVersion(installed.available_version, notice.available_version) >= 0) return installed;
+    try {
+      const result = await downloadPartyUpgrade({ version: notice.available_version }, options.upgradeDeps);
+      return {
+        ...notice,
+        installed_version: result.target_version,
+        auto_upgrade: true,
+        action_required: "auto_reexec",
+        message: `AgentParty 服务器已发布 party CLI v${notice.available_version}，已下载并校验新版二进制。本轮唤醒结束后 serve 会自动 re-exec 新版。`,
+      };
+    } catch (error) {
+      options.out?.(`serve: 自动下载 party v${notice.available_version} 失败，保留人工升级提示: ${error instanceof Error ? error.message : String(error)}`);
+      return notice;
+    }
   } catch {
     return current;
   }
+}
+
+function compareUpgradeVersion(left: string, right: string): number {
+  const parse = (version: string) => version.split(".").map((part) => Number.parseInt(part, 10) || 0);
+  const a = parse(left);
+  const b = parse(right);
+  for (let index = 0; index < 3; index += 1) {
+    const diff = (a[index] ?? 0) - (b[index] ?? 0);
+    if (diff !== 0) return diff > 0 ? 1 : -1;
+  }
+  return 0;
 }
 
 // 唤醒未送达（runner 非零退出 / 无 session id / SDK 抛错 / [attach] 被拒）。
@@ -3807,7 +3836,11 @@ export async function run(argv: string[]): Promise<number> {
       console.error("--profile-poll-interval must be an integer >= 500 milliseconds");
       return 1;
     }
-    const availableUpgrade = await resolveAvailableUpgrade(account.session.server);
+    const autoDownloadUpgrade = flags["auto-upgrade"] === true;
+    const availableUpgrade = await resolveAvailableUpgrade(account.session.server, null, {
+      autoDownload: autoDownloadUpgrade,
+      out: (line) => console.error(terminalOutput(line)),
+    });
     if (availableUpgrade !== null) console.error(terminalOutput(`serve: ${availableUpgrade.message}\n  ${availableUpgrade.command}`));
     return runProfileServe({
       server: account.session.server,
@@ -3816,7 +3849,10 @@ export async function run(argv: string[]): Promise<number> {
       handle: profileRef.handle,
       mentionsOnly: flags.all !== true,
       availableUpgrade,
-      refreshAvailableUpgrade: (current) => resolveAvailableUpgrade(account.session.server, current),
+      refreshAvailableUpgrade: (current) => resolveAvailableUpgrade(account.session.server, current, {
+        autoDownload: autoDownloadUpgrade,
+        out: (line) => console.error(terminalOutput(line)),
+      }),
       skipBacklog: flags["replay-backlog"] !== true,
       once: flags["profile-once"] === true,
       pollIntervalMs,
@@ -3846,7 +3882,11 @@ export async function run(argv: string[]): Promise<number> {
     console.error("channel must match [a-z0-9][a-z0-9-]{0,63}");
     return 1;
   }
-  const availableUpgrade = await resolveAvailableUpgrade(server);
+  const autoDownloadUpgrade = flags["auto-upgrade"] === true;
+  const availableUpgrade = await resolveAvailableUpgrade(server, null, {
+    autoDownload: autoDownloadUpgrade,
+    out: (line) => console.error(terminalOutput(line)),
+  });
   if (availableUpgrade !== null) console.error(terminalOutput(`serve: ${availableUpgrade.message}\n  ${availableUpgrade.command}`));
   const explicitRunnerWorkdir = str(flags.workdir);
   let runnerWorkdirPath = explicitRunnerWorkdir === undefined
@@ -3914,7 +3954,10 @@ export async function run(argv: string[]): Promise<number> {
         fetchCharter: (signal) => fetchChannelCharter(currentServer, currentToken, channel, signal),
         autoUpgrade: flags["auto-upgrade"] === true,
         availableUpgrade,
-        refreshAvailableUpgrade: (current) => resolveAvailableUpgrade(currentServer, current),
+        refreshAvailableUpgrade: (current) => resolveAvailableUpgrade(currentServer, current, {
+          autoDownload: flags["auto-upgrade"] === true,
+          out: (line) => console.error(terminalOutput(line)),
+        }),
         statusline: true,
         runnerTimeoutMs,
         builtinRunner: harness

--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -1,0 +1,63 @@
+import { INSTALL_LINE, compareVersions, downloadPartyUpgrade } from "../upgrade";
+
+function help(): string {
+  return [
+    "usage: party upgrade [--version X.Y.Z] [--check]",
+    "",
+    "Download the GitHub Release binary, verify sha256, and atomically replace the running party binary.",
+    "Falls back to the installer when the current executable is not a compiled party binary.",
+  ].join("\n");
+}
+
+export async function run(argv: string[]): Promise<number> {
+  let version = "latest";
+  let checkOnly = false;
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]!;
+    if (arg === "--help" || arg === "-h") {
+      console.log(help());
+      return 0;
+    }
+    if (arg === "--check") {
+      checkOnly = true;
+      continue;
+    }
+    if (arg === "--version") {
+      const next = argv[++i];
+      if (next === undefined || next.startsWith("-")) {
+        console.error("--version requires X.Y.Z");
+        return 1;
+      }
+      version = next;
+      continue;
+    }
+    console.error(`unknown option: ${arg}`);
+    console.log(help());
+    return 1;
+  }
+
+  try {
+    const result = await downloadPartyUpgrade({ version, checkOnly });
+    if (checkOnly) {
+      console.log(`running: ${result.running_version}`);
+      console.log(`target:  ${result.target_version} (${result.target})`);
+      if (compareVersions(result.target_version, result.running_version) > 0) {
+        console.log(`upgrade available: ${result.asset_url}`);
+      } else {
+        console.log("already current");
+      }
+      return 0;
+    }
+    if (result.reason === "already_current") {
+      console.log(`party is already current: v${result.running_version}`);
+      return 0;
+    }
+    console.log(`installed party v${result.target_version} -> ${result.install_path}`);
+    console.log("restart running serve/watch processes to use the new binary; serve --auto-upgrade will re-exec at the next safe point.");
+    return 0;
+  } catch (error) {
+    console.error(`party upgrade failed: ${error instanceof Error ? error.message : String(error)}`);
+    console.error(`fallback: ${INSTALL_LINE}`);
+    return 1;
+  }
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -40,6 +40,7 @@ commands:
   resume    <name> [--channel C]                           resume a paused agent's reception (moderator)
   wake-budget <name> [--limit N [--window D]|--off]        cap an agent's wakes per window; over-budget @ withheld (#108)
   health    [--json] [--channel C] [--stale-after ms]      local serve WS health probe (pid alive != ws alive, #254)
+  upgrade   [--version X.Y.Z] [--check]                    download release binary, verify sha256, atomically replace party
   charter   [slug] [--json] | set [slug] -f file.md|-m text|- | template
   history   [channel|--channel C] [--since seq] [--limit n] [--json] [--completion]
   search    <query> [--channel C] [--from name] [--since seq] [--limit n] [--json]
@@ -153,6 +154,8 @@ export async function main(argv: string[]): Promise<number> {
       return (await import("./commands/doctor")).run(rest);
     case "health":
       return (await import("./commands/health")).run(rest);
+    case "upgrade":
+      return (await import("./commands/upgrade")).run(rest);
     case "worktree":
       return (await import("./commands/worktree")).run(rest);
     default:

--- a/cli/src/upgrade.ts
+++ b/cli/src/upgrade.ts
@@ -1,5 +1,9 @@
 // 自升级支持（issue #45）：已在跑的 serve 是内存里的旧二进制，但 process.execPath 指向的磁盘文件
 // 会被 install.sh 换成新版。这里网络-free 地读磁盘二进制版本、比对、在唤醒间隙 re-exec 新版。
+import { chmodSync, copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, renameSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import pkg from "../package.json" with { type: "json" };
 
 export const RUNNING_VERSION = pkg.version;
@@ -26,6 +30,13 @@ export interface UpgradeDeps {
   execPath?: string;
   readInstalledVersion?: (execPath: string) => string | null;
   reexec?: (execPath: string, argv: string[]) => void;
+  fetch?: typeof fetch;
+  fetchBytes?: (url: string) => Promise<Uint8Array>;
+  extractPartyBinary?: (archivePath: string, outDir: string, platform: NodeJS.Platform) => Promise<string>;
+  installBinary?: (sourcePath: string, targetPath: string) => void;
+  platform?: NodeJS.Platform;
+  arch?: string;
+  mirror?: string;
 }
 
 export interface CliUpgradeNotice {
@@ -51,14 +62,176 @@ function defaultReadInstalledVersion(execPath: string): string | null {
   }
 }
 
+export function isPartyBinaryPath(execPath: string): boolean {
+  return basename(execPath).includes("party");
+}
+
+function normalizeReleaseVersion(version: string): string | null {
+  const trimmed = version.trim().replace(/^v/, "");
+  return /^\d+\.\d+\.\d+$/.test(trimmed) ? trimmed : null;
+}
+
+export function detectReleaseTarget(platform: NodeJS.Platform = process.platform, arch: string = process.arch): string | null {
+  const os =
+    platform === "darwin" ? "darwin" :
+    platform === "linux" ? "linux" :
+    platform === "win32" ? "windows" :
+    null;
+  const cpu =
+    arch === "x64" || arch === "amd64" ? "x64" :
+    arch === "arm64" || arch === "aarch64" ? "arm64" :
+    null;
+  if (os === null || cpu === null) return null;
+  if (os === "windows" && cpu !== "x64") return null;
+  return `${os}-${cpu}`;
+}
+
+async function resolveLatestReleaseVersion(fetcher: typeof fetch): Promise<string> {
+  const api = await fetcher(`https://api.github.com/repos/${OWNER_REPO}/releases/latest`, {
+    headers: { accept: "application/vnd.github+json" },
+  }).catch(() => null);
+  if (api?.ok) {
+    const body = (await api.json().catch(() => null)) as { tag_name?: unknown } | null;
+    const version = typeof body?.tag_name === "string" ? normalizeReleaseVersion(body.tag_name) : null;
+    if (version !== null) return version;
+  }
+  const redirected = await fetcher(`https://github.com/${OWNER_REPO}/releases/latest`, {
+    method: "HEAD",
+    redirect: "follow",
+  });
+  const match = redirected.url.match(/\/tag\/v?(\d+\.\d+\.\d+)/);
+  if (match) return match[1]!;
+  throw new Error("cannot resolve latest release version");
+}
+
+async function defaultFetchBytes(url: string): Promise<Uint8Array> {
+  if (url.startsWith("file://")) return new Uint8Array(readFileSync(fileURLToPath(url)));
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`download failed: ${url} (${res.status})`);
+  return new Uint8Array(await res.arrayBuffer());
+}
+
+function sha256Hex(bytes: Uint8Array): string {
+  const hash = new Bun.CryptoHasher("sha256");
+  hash.update(bytes);
+  return hash.digest("hex");
+}
+
+async function defaultExtractPartyBinary(archivePath: string, outDir: string, platform: NodeJS.Platform): Promise<string> {
+  const proc = Bun.spawn(["tar", "-xzf", archivePath, "-C", outDir], { stdout: "ignore", stderr: "pipe" });
+  const code = await proc.exited;
+  if (code !== 0) {
+    const stderr = new TextDecoder().decode(await new Response(proc.stderr).arrayBuffer()).trim();
+    throw new Error(`tar extraction failed${stderr ? `: ${stderr}` : ""}`);
+  }
+  const binary = join(outDir, platform === "win32" ? "party.exe" : "party");
+  if (!existsSync(binary)) throw new Error("archive missing party binary");
+  return binary;
+}
+
+function defaultInstallBinary(sourcePath: string, targetPath: string): void {
+  const dir = dirname(targetPath);
+  mkdirSync(dir, { recursive: true });
+  const tmp = join(dir, `.party.${process.pid}.${Date.now()}.tmp`);
+  try {
+    copyFileSync(sourcePath, tmp);
+    chmodSync(tmp, 0o755);
+    renameSync(tmp, targetPath);
+  } catch (error) {
+    rmSync(tmp, { force: true });
+    throw error;
+  }
+}
+
+export interface PartyUpgradeOptions {
+  version?: string;
+  checkOnly?: boolean;
+}
+
+export interface PartyUpgradeResult {
+  running_version: string;
+  target_version: string;
+  target: string;
+  asset_url: string;
+  installed: boolean;
+  install_path: string;
+  reason?: "already_current";
+}
+
+export async function downloadPartyUpgrade(
+  options: PartyUpgradeOptions = {},
+  deps: UpgradeDeps = {},
+): Promise<PartyUpgradeResult> {
+  const running = deps.runningVersion ?? RUNNING_VERSION;
+  const execPath = deps.execPath ?? process.execPath;
+  if (!isPartyBinaryPath(execPath)) {
+    throw new Error(`party upgrade must be run from a compiled party binary; fallback: ${INSTALL_LINE}`);
+  }
+  const platform = deps.platform ?? process.platform;
+  const target = detectReleaseTarget(platform, deps.arch ?? process.arch);
+  if (target === null) throw new Error(`unsupported platform for party upgrade: ${platform}/${deps.arch ?? process.arch}`);
+  const fetcher = deps.fetch ?? fetch;
+  const requested = options.version ?? "latest";
+  const explicitVersion = requested !== "latest";
+  const targetVersion = explicitVersion
+    ? normalizeReleaseVersion(requested)
+    : await resolveLatestReleaseVersion(fetcher);
+  if (targetVersion === null) throw new Error(`invalid release version: ${requested}`);
+  const versionDelta = compareVersions(targetVersion, running);
+  if (!explicitVersion && versionDelta < 0) {
+    throw new Error(`refusing downgrade from ${running} to ${targetVersion}`);
+  }
+  if (versionDelta === 0) {
+    return {
+      running_version: running,
+      target_version: targetVersion,
+      target,
+      asset_url: "",
+      installed: false,
+      install_path: execPath,
+      reason: "already_current",
+    };
+  }
+  const mirror = deps.mirror ?? process.env.AGENTPARTY_MIRROR ?? `https://github.com/${OWNER_REPO}/releases/download`;
+  if (!mirror.startsWith("https://") && !mirror.startsWith("file://")) {
+    throw new Error("AGENTPARTY_MIRROR must use https:// or file://");
+  }
+  const base = `${mirror.replace(/\/$/, "")}/v${targetVersion}`;
+  const asset = `party-${target}.tar.gz`;
+  const assetUrl = `${base}/${asset}`;
+  if (options.checkOnly === true) {
+    return { running_version: running, target_version: targetVersion, target, asset_url: assetUrl, installed: false, install_path: execPath };
+  }
+  const fetchBytes = deps.fetchBytes ?? defaultFetchBytes;
+  const [archiveBytes, checksumBytes] = await Promise.all([
+    fetchBytes(assetUrl),
+    fetchBytes(`${assetUrl}.sha256`),
+  ]);
+  const want = new TextDecoder().decode(checksumBytes).trim().split(/\s+/)[0] ?? "";
+  if (!/^[0-9a-fA-F]{64}$/.test(want)) throw new Error("release checksum file is invalid");
+  const got = sha256Hex(archiveBytes);
+  if (got.toLowerCase() !== want.toLowerCase()) {
+    throw new Error(`sha256 mismatch: want ${want} got ${got}`);
+  }
+  const tmpRoot = mkdtempSync(join(tmpdir(), "party-upgrade-"));
+  try {
+    const archivePath = join(tmpRoot, asset);
+    writeFileSync(archivePath, archiveBytes);
+    const extracted = await (deps.extractPartyBinary ?? defaultExtractPartyBinary)(archivePath, tmpRoot, platform);
+    (deps.installBinary ?? defaultInstallBinary)(extracted, execPath);
+  } finally {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  }
+  return { running_version: running, target_version: targetVersion, target, asset_url: assetUrl, installed: true, install_path: execPath };
+}
+
 // 磁盘二进制比运行版新 → 返回新版本号，否则 null。
 export function pendingUpgrade(deps: UpgradeDeps = {}): string | null {
   const running = deps.runningVersion ?? RUNNING_VERSION;
   const execPath = deps.execPath ?? process.execPath;
   const read = deps.readInstalledVersion ?? defaultReadInstalledVersion;
   // 只有 execPath 看起来是 party 二进制（basename 含 party）才比——dev 下 execPath=bun，跳过。
-  const base = execPath.split("/").pop() ?? "";
-  if (!base.includes("party")) return null;
+  if (!isPartyBinaryPath(execPath)) return null;
   const installed = read(execPath);
   if (!installed) return null;
   return compareVersions(installed, running) > 0 ? installed : null;

--- a/cli/test/upgrade.test.ts
+++ b/cli/test/upgrade.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, test } from "bun:test";
-import { compareVersions, maybeReexecUpgrade, pendingUpgrade } from "../src/upgrade";
+import { writeFileSync } from "node:fs";
+import { compareVersions, downloadPartyUpgrade, maybeReexecUpgrade, pendingUpgrade } from "../src/upgrade";
+
+function sha256(bytes: Uint8Array): string {
+  const hash = new Bun.CryptoHasher("sha256");
+  hash.update(bytes);
+  return hash.digest("hex");
+}
 
 describe("upgrade", () => {
   test("compareVersions orders by numeric segments", () => {
@@ -52,5 +59,67 @@ describe("upgrade", () => {
       pending: null,
       reexeced: false,
     });
+  });
+
+  test("downloadPartyUpgrade fetches release assets, verifies sha256, and atomically installs", async () => {
+    const archive = new TextEncoder().encode("fake tarball");
+    const calls: Array<{ source: string; target: string }> = [];
+    const result = await downloadPartyUpgrade({ version: "0.2.61" }, {
+      runningVersion: "0.2.60",
+      execPath: "/usr/local/bin/party",
+      platform: "darwin",
+      arch: "arm64",
+      fetchBytes: async (url) => url.endsWith(".sha256")
+        ? new TextEncoder().encode(`${sha256(archive)}  party-darwin-arm64.tar.gz\n`)
+        : archive,
+      extractPartyBinary: async (_archivePath, outDir) => {
+        const binary = `${outDir}/party`;
+        writeFileSync(binary, "binary");
+        return binary;
+      },
+      installBinary: (source, target) => calls.push({ source, target }),
+    });
+    expect(result).toMatchObject({
+      running_version: "0.2.60",
+      target_version: "0.2.61",
+      target: "darwin-arm64",
+      installed: true,
+      install_path: "/usr/local/bin/party",
+    });
+    expect(result.asset_url).toContain("/v0.2.61/party-darwin-arm64.tar.gz");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.target).toBe("/usr/local/bin/party");
+  });
+
+  test("downloadPartyUpgrade refuses a checksum mismatch before install", async () => {
+    const archive = new TextEncoder().encode("fake tarball");
+    const installs: string[] = [];
+    await expect(downloadPartyUpgrade({ version: "0.2.61" }, {
+      runningVersion: "0.2.60",
+      execPath: "/usr/local/bin/party",
+      platform: "linux",
+      arch: "x64",
+      fetchBytes: async (url) => url.endsWith(".sha256")
+        ? new TextEncoder().encode(`${"0".repeat(64)}  party-linux-x64.tar.gz\n`)
+        : archive,
+      installBinary: (_source, target) => installs.push(target),
+    })).rejects.toThrow("sha256 mismatch");
+    expect(installs).toHaveLength(0);
+  });
+
+  test("downloadPartyUpgrade refuses dev execPath and check mode never installs", async () => {
+    await expect(downloadPartyUpgrade({ version: "0.2.61" }, {
+      runningVersion: "0.2.60",
+      execPath: "/opt/homebrew/bin/bun",
+    })).rejects.toThrow("compiled party binary");
+
+    const result = await downloadPartyUpgrade({ version: "0.2.60", checkOnly: true }, {
+      runningVersion: "0.2.60",
+      execPath: "/usr/local/bin/party",
+      platform: "linux",
+      arch: "arm64",
+      installBinary: () => { throw new Error("must not install"); },
+    });
+    expect(result).toMatchObject({ installed: false, target: "linux-arm64", target_version: "0.2.60" });
   });
 });

--- a/cli/test/version-negotiation.test.ts
+++ b/cli/test/version-negotiation.test.ts
@@ -1,6 +1,14 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { writeFileSync } from "node:fs";
 import { fetchServerVersion } from "../src/rest";
 import { RUNNING_VERSION, serverMinVersionNotice, serverVersionUpgradeNotice } from "../src/upgrade";
+import { resolveAvailableUpgrade } from "../src/commands/serve";
+
+function sha256(bytes: Uint8Array): string {
+  const hash = new Bun.CryptoHasher("sha256");
+  hash.update(bytes);
+  return hash.digest("hex");
+}
 
 const originalFetch = globalThis.fetch;
 afterEach(() => {
@@ -80,5 +88,40 @@ describe("CLI↔worker version negotiation (issue #137)", () => {
     expect(serverVersionUpgradeNotice("dev", { runningVersion: "0.2.107" })).toBeNull();
     expect(serverVersionUpgradeNotice("0.2.108-rc.1", { runningVersion: "0.2.107" })).toBeNull();
     expect(serverVersionUpgradeNotice("v0.2.108+build.7", { runningVersion: "0.2.107" })?.available_version).toBe("0.2.108");
+  });
+
+  test("resolveAvailableUpgrade downloads the release binary when serve --auto-upgrade is enabled (#559)", async () => {
+    globalThis.fetch = (async (_input: string | URL | Request, _init?: RequestInit) =>
+      Response.json({ version: "0.2.108", commit: "abc", deployed_at: null })) as typeof fetch;
+    const archive = new TextEncoder().encode("fake tarball");
+    const installs: string[] = [];
+
+    const notice = await resolveAvailableUpgrade("https://ap.test", null, {
+      autoDownload: true,
+      upgradeDeps: {
+        runningVersion: "0.2.107",
+        execPath: "/usr/local/bin/party",
+        platform: "darwin",
+        arch: "x64",
+        fetchBytes: async (url) => url.endsWith(".sha256")
+          ? new TextEncoder().encode(`${sha256(archive)}  party-darwin-x64.tar.gz\n`)
+          : archive,
+        extractPartyBinary: async (_archivePath, outDir) => {
+          const binary = `${outDir}/party`;
+          writeFileSync(binary, "binary");
+          return binary;
+        },
+        installBinary: (_source, target) => installs.push(target),
+      },
+    });
+
+    expect(notice).toMatchObject({
+      running_version: "0.2.107",
+      available_version: "0.2.108",
+      installed_version: "0.2.108",
+      auto_upgrade: true,
+      action_required: "auto_reexec",
+    });
+    expect(installs).toEqual(["/usr/local/bin/party"]);
   });
 });

--- a/web/src/lib/time.test.ts
+++ b/web/src/lib/time.test.ts
@@ -1,0 +1,17 @@
+// @ts-expect-error Bun executes this test, while the web tsconfig intentionally loads only Vite globals.
+import { describe, expect, test } from "bun:test";
+import { fmtTime } from "./time";
+
+describe("fmtTime", () => {
+  test("omits the date for timestamps on the current local day", () => {
+    const now = new Date(2026, 6, 16, 18, 30, 0).getTime();
+    const ts = new Date(2026, 6, 16, 9, 8, 7).getTime();
+    expect(fmtTime(ts, now)).toBe("09:08:07");
+  });
+
+  test("adds yyyy-MM-dd for timestamps outside the current local day", () => {
+    const now = new Date(2026, 6, 16, 0, 30, 0).getTime();
+    const ts = new Date(2026, 6, 15, 23, 59, 58).getTime();
+    expect(fmtTime(ts, now)).toBe("2026-07-15 23:59:58");
+  });
+});

--- a/web/src/lib/time.ts
+++ b/web/src/lib/time.ts
@@ -1,9 +1,19 @@
 // 时间显示：消息用绝对 HH:MM:SS（mono），presence 用相对时间
 const pad = (n: number) => String(n).padStart(2, "0");
 
-export function fmtTime(ts: number): string {
+function sameLocalDate(left: Date, right: Date): boolean {
+  return (
+    left.getFullYear() === right.getFullYear() &&
+    left.getMonth() === right.getMonth() &&
+    left.getDate() === right.getDate()
+  );
+}
+
+export function fmtTime(ts: number, now = Date.now()): string {
   const d = new Date(ts);
-  return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+  const time = `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+  if (sameLocalDate(d, new Date(now))) return time;
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${time}`;
 }
 
 export function fmtRel(ts: number, now = Date.now()): string {

--- a/web/src/state.test.ts
+++ b/web/src/state.test.ts
@@ -40,6 +40,40 @@ function delivery(over: Partial<DirectedDelivery> = {}): DirectedDelivery {
 }
 
 describe("channel state", () => {
+  test("welcome role clears a previous readonly share-link state when a writable member reconnects", () => {
+    const readonly = channelReducer(initialChannelState, {
+      type: "frame",
+      frame: {
+        type: "welcome",
+        self: "watcher",
+        last_seq: 0,
+        presence: [],
+        participants: [],
+        read_cursors: [],
+        role: "readonly",
+        mode: "normal",
+        loop_guard: null,
+      },
+    });
+    expect(readonly.readonly).toBe(true);
+
+    const writable = channelReducer(readonly, {
+      type: "frame",
+      frame: {
+        type: "welcome",
+        self: "leo",
+        last_seq: 0,
+        presence: [],
+        participants: [],
+        read_cursors: [],
+        role: "human",
+        mode: "normal",
+        loop_guard: null,
+      },
+    });
+    expect(writable.readonly).toBe(false);
+  });
+
   test("ignores duplicate history frames without revision metadata", () => {
     const first = channelReducer(initialChannelState, { type: "frame", frame: msgFrame(6, "original") });
     const duplicate = channelReducer(first, { type: "frame", frame: msgFrame(6, "stale duplicate") });

--- a/web/src/state.ts
+++ b/web/src/state.ts
@@ -219,8 +219,8 @@ function applyFrame(state: ChannelState, frame: ServerFrame): ChannelState {
         participants: frame.participants,
         presence,
         readCursors,
-        // welcome 首帧即知角色，readonly 分享链接不闪现输入框（spec §9）
-        readonly: frame.role === "readonly" ? true : state.readonly,
+        // welcome 是连接身份的权威来源。只读分享链接不闪输入框；重新以成员身份连接时也必须清掉旧只读状态。
+        readonly: frame.role === "readonly",
         loopGuard: frame.loop_guard ?? state.loopGuard,
         loopGuardBaselineSeq: frame.loop_guard != null ? frame.last_seq : state.loopGuardBaselineSeq,
       };

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -3154,7 +3154,8 @@
 }
 .chan-toolstrip-content {
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  align-items: stretch;
   flex: 1 1 auto;
   min-width: 0;
   gap: 6px;
@@ -3175,11 +3176,12 @@
 }
 .chan-tool-actions {
   flex: 0 0 auto;
-  margin-left: auto;
-  justify-content: flex-start;
+  margin-left: 0;
+  justify-content: flex-end;
 }
 .chan-admin-actions {
   flex: 0 0 auto;
+  margin-left: auto;
   gap: 0;
 }
 .chan-admin-group {

--- a/web/src/styles/app.visibilityToggle.test.ts
+++ b/web/src/styles/app.visibilityToggle.test.ts
@@ -16,14 +16,15 @@ function ruleBody(selector: string): string {
 describe("channel visibility controls layout", () => {
   test("visibility uses the presence row while management starts at the toolbar's right edge", () => {
     expect(ruleBody(".chan-toolstrip")).toContain("flex-wrap: nowrap");
+    expect(ruleBody(".chan-toolstrip-content")).toContain("flex-direction: column");
     expect(ruleBody(".chan-toolstrip-content")).toContain("overflow: visible");
     expect(css).toMatch(/@media \(max-width: 1759px\)[\s\S]*\.chan-toolstrip-content\s*{[^}]*overflow-x:\s*auto;/s);
     expect(css).toMatch(/\.chan-tool-buttons,\s*\.chan-tool-actions,\s*\.chan-admin-actions,\s*\.chan-admin-group\s*{[^}]*flex-wrap:\s*nowrap;/s);
-    expect(ruleBody(".chan-tool-actions")).toContain("margin-left: auto");
+    expect(ruleBody(".chan-tool-actions")).toContain("justify-content: flex-end");
+    expect(ruleBody(".chan-admin-actions")).toContain("margin-left: auto");
     expect(ruleBody(".presence-channel-controls")).toContain("margin-left: auto");
     expect(ruleBody(".chan-admin-actions")).toContain("gap: 0");
     expect(ruleBody(".chan-admin-group + .chan-admin-group")).toContain("border-left: 1.4px solid var(--t-faint)");
     expect(css).toMatch(/@media \(max-width: 1759px\)[\s\S]*\.chan-tool-btn\s*{[^}]*padding-inline:\s*6px;[^}]*font-size:\s*11\.5px;/s);
-    expect(ruleBody(".chan-toolstrip-content")).not.toContain("flex-direction: column");
   });
 });

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -215,6 +215,15 @@ export function mutableFetchResponse(response: Response): Response {
   });
 }
 
+async function fetchMutableChannelDO(
+  env: AppEnv,
+  slug: string,
+  request: Request | (() => Request),
+  retries = 1,
+): Promise<Response> {
+  return mutableFetchResponse(await fetchChannelDO(env, slug, request, retries));
+}
+
 function parseRoleResponsibility(body: Record<string, unknown> | null): { present: boolean; value: string | null } | null {
   if (body === null || !Object.prototype.hasOwnProperty.call(body, "responsibility")) {
     return { present: false, value: null };
@@ -4793,7 +4802,7 @@ app.get("/api/channels/:slug/messages", async (c) => {
     return c.json(errorBody("forbidden", "not allowed in this channel"), 403);
   }
   const search = new URL(c.req.url).search;
-  return fetchChannelDO(
+  return fetchMutableChannelDO(
     c.env,
     slug,
     new Request(`https://do/internal/messages${search}`, {
@@ -4810,7 +4819,7 @@ app.get("/api/channels/:slug/presence", async (c) => {
   if (!(await canAccessLoadedChannel(c.env.DB, c.get("identity"), channel))) {
     return c.json(errorBody("forbidden", "not allowed in this channel"), 403);
   }
-  return fetchChannelDO(c.env, slug, new Request("https://do/internal/presence", { headers: { "x-partykit-room": slug } }));
+  return fetchMutableChannelDO(c.env, slug, new Request("https://do/internal/presence", { headers: { "x-partykit-room": slug } }));
 });
 
 app.get("/api/channels/:slug/loop-guard", async (c) => {
@@ -4822,7 +4831,7 @@ app.get("/api/channels/:slug/loop-guard", async (c) => {
   if (!(await canAccessLoadedChannel(c.env.DB, c.get("identity"), channel))) {
     return c.json(errorBody("forbidden", "not allowed in this channel"), 403);
   }
-  return fetchChannelDO(
+  return fetchMutableChannelDO(
     c.env,
     slug,
     new Request("https://do/internal/guard", {
@@ -4902,7 +4911,7 @@ app.get("/api/channels/:slug/search", async (c) => {
     return c.json(errorBody("bad_request", "q required"), 400);
   }
   const search = new URL(c.req.url).search;
-  return fetchChannelDO(
+  return fetchMutableChannelDO(
     c.env,
     slug,
     new Request(`https://do/internal/search${search}`, {
@@ -4919,7 +4928,7 @@ app.get("/api/channels/:slug/wake-deliveries", async (c) => {
     return c.json(errorBody("forbidden", "not allowed in this channel"), 403);
   }
   const search = new URL(c.req.url).search;
-  return fetchChannelDO(
+  return fetchMutableChannelDO(
     c.env,
     slug,
     new Request(`https://do/internal/wake-deliveries${search}`, {
@@ -4938,7 +4947,7 @@ app.get("/api/channels/:slug/wake-budget/:name", async (c) => {
   }
   const name = c.req.param("name");
   if (!name || name.length > 256) return c.json(errorBody("bad_request", "valid name required"), 400);
-  return fetchChannelDO(
+  return fetchMutableChannelDO(
     c.env,
     slug,
     new Request(`https://do/internal/wake-budget/${encodeURIComponent(name)}`, {
@@ -4961,7 +4970,7 @@ app.put("/api/channels/:slug/wake-budget/:name", async (c) => {
     return c.json(errorBody("forbidden", "only the agent itself or a channel moderator can set a wake budget"), 403);
   }
   const body = await c.req.json().catch(() => null);
-  return fetchChannelDO(
+  return fetchMutableChannelDO(
     c.env,
     slug,
     new Request(`https://do/internal/wake-budget/${encodeURIComponent(name)}`, {
@@ -4979,7 +4988,7 @@ app.get("/api/channels/:slug/read-cursors", async (c) => {
   if (!(await canAccessLoadedChannel(c.env.DB, c.get("identity"), channel))) {
     return c.json(errorBody("forbidden", "not allowed in this channel"), 403);
   }
-  return fetchChannelDO(
+  return fetchMutableChannelDO(
     c.env,
     slug,
     new Request("https://do/internal/read-cursors", {
@@ -6062,7 +6071,7 @@ app.post("/api/channels/:slug/messages/:seq/review", async (c) => {
       },
     }),
   );
-  if (!res.ok) return res;
+  if (!res.ok) return mutableFetchResponse(res);
   const payload = (await res.clone().json().catch(() => null)) as { message?: MsgFrame } | null;
   const message = payload?.message;
   const taskId = message?.completion_artifact?.task_id;
@@ -6074,7 +6083,7 @@ app.post("/api/channels/:slug/messages/:seq/review", async (c) => {
       await syncTaskCompletion(c.env, slug, taskId, message.completion_artifact, message.seq, "in_progress");
     }
   }
-  return res;
+  return mutableFetchResponse(res);
 });
 
 // 人类决策回应（#284）：人类/moderator 在频道内对某条 decision_request 点选项/审批。
@@ -6115,7 +6124,7 @@ app.post("/api/channels/:slug/messages/:seq/decision", async (c) => {
       },
     }),
   );
-  return res;
+  return mutableFetchResponse(res);
 });
 
 app.post("/api/channels/:slug/messages/:seq/:action", async (c) => {
@@ -6136,7 +6145,7 @@ app.post("/api/channels/:slug/messages/:seq/:action", async (c) => {
     return c.json(errorBody("bad_request", "action must be edit|retract|supersede"), 400);
   }
   const assignedRole = await loadAssignedRole(c.env.DB, slug, identity);
-  return fetchChannelDO(
+  return fetchMutableChannelDO(
     c.env,
     slug,
     new Request(`https://do/internal/messages/${seq}/${action}`, {
@@ -6174,7 +6183,7 @@ app.get("/api/channels/:slug/messages/:seq/audit", async (c) => {
   }
   const seq = positiveInt(Number(c.req.param("seq")));
   if (seq === null) return c.json(errorBody("bad_request", "seq must be a positive integer"), 400);
-  return fetchChannelDO(
+  return fetchMutableChannelDO(
     c.env,
     slug,
     new Request(`https://do/internal/messages/${seq}/audit`, {
@@ -6197,7 +6206,7 @@ app.get("/api/channels/:slug/identity/:name/data", async (c) => {
   if (!name || name.length > 256) {
     return c.json(errorBody("bad_request", "valid name required"), 400);
   }
-  return fetchChannelDO(
+  return fetchMutableChannelDO(
     c.env,
     slug,
     new Request(`https://do/internal/identity/${encodeURIComponent(name)}/data${new URL(c.req.url).search}`, {
@@ -6249,7 +6258,7 @@ app.delete("/api/channels/:slug/identity/:name/data", async (c) => {
       metadata: summary ?? {},
     });
   }
-  return res;
+  return mutableFetchResponse(res);
 });
 
 // 附件上传（#176）：blob 进 R2，返回引用元数据；发消息时把引用带在 attachments 字段里。
@@ -6525,7 +6534,7 @@ app.get("/api/channels/:slug/webhooks", async (c) => {
   if (channel.archived_at !== null) {
     return c.json(errorBody("archived", "channel is archived"), 410);
   }
-  return fetchChannelDO(
+  return fetchMutableChannelDO(
     c.env,
     slug,
     new Request("https://do/internal/webhooks", { headers: { "x-partykit-room": slug } }),
@@ -6572,7 +6581,7 @@ app.get("/api/channels/:slug/webhooks/dead-letters", async (c) => {
   if (!isChannelModerator(c.get("identity"), channel)) {
     return c.json(errorBody("forbidden", "only the channel owner or an ap_ token can manage webhooks"), 403);
   }
-  return fetchChannelDO(
+  return fetchMutableChannelDO(
     c.env,
     slug,
     new Request("https://do/internal/dead-letters", { headers: { "x-partykit-room": slug } }),
@@ -6779,7 +6788,7 @@ app.post("/api/channels/:slug/presence/:name/pause", async (c) => {
       metadata: { resume_at: body?.resume_at ?? null },
     });
   }
-  return res;
+  return mutableFetchResponse(res);
 });
 
 app.post("/api/channels/:slug/presence/:name/resume", async (c) => {
@@ -6814,7 +6823,7 @@ app.post("/api/channels/:slug/presence/:name/resume", async (c) => {
       channel: slug,
     });
   }
-  return res;
+  return mutableFetchResponse(res);
 });
 
 app.post("/api/channels/:slug/reset-guard", async (c) => {
@@ -6844,7 +6853,7 @@ app.post("/api/channels/:slug/reset-guard", async (c) => {
       metadata: { guard: "loop" },
     });
   }
-  return res;
+  return mutableFetchResponse(res);
 });
 
 app.post("/api/channels/:slug/workflows/:workflow_id/reset-guard", async (c) => {

--- a/worker/test/channels.spec.ts
+++ b/worker/test/channels.spec.ts
@@ -140,6 +140,25 @@ describe("channels", () => {
     expect(messages.map((m) => m.body)).toContain("hello over rest");
   });
 
+  it("REST DO proxy reads return mutable CORS responses when Origin is present (#563)", async () => {
+    const { token } = await seedToken("agent");
+    const slug = await createChannel(token);
+    expect((await postMessage(slug, token, "searchable proxy message")).status).toBe(200);
+
+    for (const path of [
+      `/api/channels/${slug}/messages?limit=1`,
+      `/api/channels/${slug}/presence`,
+      `/api/channels/${slug}/loop-guard`,
+      `/api/channels/${slug}/search?q=searchable`,
+      `/api/channels/${slug}/wake-deliveries?limit=1`,
+      `/api/channels/${slug}/read-cursors`,
+    ]) {
+      const res = await api(path, token, { headers: { origin: "http://ap.test" } });
+      expect(res.status, path).toBe(200);
+      expect(res.headers.get("access-control-allow-origin"), path).toBe("http://ap.test");
+    }
+  });
+
   it("409 on slug conflict", async () => {
     const { token } = await seedToken("agent");
     const slug = uniq("ch");


### PR DESCRIPTION
## Summary
- add `party upgrade` to download GitHub Release binaries, verify sha256, and atomically replace the compiled CLI; wire `serve --auto-upgrade` to download before the existing safe-point re-exec
- fix desktop/web polish issues: stale readonly banner, cross-day message timestamps, and the two-row channel toolbar layout
- wrap Channel DO proxy responses in mutable responses before Hono/CORS handling so REST reads keep CORS headers with `Origin`

## Issues
Fixes #559
Fixes #560
Fixes #561
Fixes #563
Fixes #566

## Validation
- `bun test cli/test/upgrade.test.ts cli/test/version-negotiation.test.ts`
- `bun test web/src/lib/time.test.ts web/src/state.test.ts web/src/styles/app.visibilityToggle.test.ts`
- `cd worker && bunx vitest run test/channels.spec.ts`
- `bun run check:web`
- `bun run check:worker`
- `cd cli && bun test`
- `cd cli && bunx tsc --noEmit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增 `party upgrade` 命令，支持检查、指定版本及自动下载升级。
  * 服务检测到新版本时可自动完成下载、校验与安装，并提示重启。
* **改进**
  * 跨日期消息时间显示日期与时间，提升可读性。
  * 重新连接后正确恢复可编辑状态。
  * 优化频道工具栏布局与操作区对齐。
  * REST 接口支持正确返回跨域响应。
* **修复**
  * 改善升级失败提示及开发环境下的升级保护。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->