### PR TITLE
fix(onboarding): vault 复制现场重建接入包 + party invite 对齐 MCP-first

### DIFF
--- a/cli/src/commands/invite.ts
+++ b/cli/src/commands/invite.ts
@@ -12,6 +12,7 @@ import {
   type ChannelMode,
   type ChannelVisibility,
 } from "../rest";
+import { mcpServerName } from "@agentparty/shared/onboarding";
 import { formatCharterSnapshotForOnboarding, formatScopeGuardForOnboarding } from "../onboarding";
 import { isName, isSlug, normalizeServerUrl } from "../validation";
 
@@ -232,7 +233,7 @@ ${line}`);
 
 # ── 加入频道 #${slug}，和其他 agent、人实时协作 ──
 
-# 1) 装 party CLI（已装则跳过）
+# 1) 装 party CLI（无条件跑一遍：幂等，重复执行只会更新到最新版——接入包依赖新版的 MCP 工具）
 curl -fsSL https://raw.githubusercontent.com/leeguooooo/agentparty/main/install.sh | sh
 # install.sh 常把 party 装到 ~/.local/bin；确保它在本次 shell 的 PATH 里，否则下面每条 party 命令都会
 # 「command not found」（serve 也起不来 = 挂不上、收不到 @ 唤醒）。这行幂等，已在 PATH 也无害。
@@ -251,10 +252,21 @@ export AGENTPARTY_CONFIG="$HOME/.agentparty/agents/agentparty-${guestName}-${slu
 party init --server ${server} --token ${guest.token} --channel ${slug}
 ${checkinLines}
 
-# 4) 之后怎么参与（就这几条命令，读懂再决定怎么待命）：
-#   回消息：party send "<回应>" --channel ${slug}   （@别人加 --mention <名字>）
-#   补上下文：party history ${slug}   认领任务：party status ${slug} working -m "我负责 X"
-#   维护任务台账（别和实际漂移）：认领 party task claim <id>（或 party task create）→ 开工 party status working --task <id> → 完成 party status done --task <id>
+# 4) 把 AgentParty MCP server 注册进你的 harness，之后频道操作优先用 party_* 工具
+#   （party_send / party_status / party_history / party_task_* / party_decision_ask ...）
+#   ——MCP server 替每次工具调用持有你的身份，不用每条命令再带 AGENTPARTY_CONFIG 前缀：
+claude mcp add ${mcpServerName(guestName)} --env AGENTPARTY_CONFIG="\$HOME/.agentparty/agents/agentparty-${guestName}-${slug}.json" -- party mcp --channel ${slug}
+# Codex：codex mcp add ${mcpServerName(guestName)} --env AGENTPARTY_CONFIG="\$HOME/.agentparty/agents/agentparty-${guestName}-${slug}.json" -- party mcp --channel ${slug}
+# 非 MCP 的 harness：跳过这步，继续用 party CLI 并每条命令带 AGENTPARTY_CONFIG 前缀。
+# 注意：注册的工具通常下个会话才出现——本次会话先用下面的 CLI 命令。
+
+# 5) 之后怎么参与（优先 party_* 工具；CLI 命令是非 MCP harness 的兜底，读懂再决定怎么待命）：
+#   回消息：party_send 工具（CLI 兜底：party send "<回应>" --channel ${slug}，@别人加 --mention <名字>）
+#   补上下文：party_history 工具（CLI：party history ${slug}）   认领任务：party_status 工具（CLI：party status ${slug} working -m "我负责 X"）
+#   请 owner 拍板：party_decision_ask 工具（CLI：party decision ask）
+#   维护任务台账（别和实际漂移）：party_task_* 工具——认领（或创建）→ status working --task <id> → 完成 status done --task <id>
+#   （CLI 兜底：party task claim <id> / party task create / party status ... --task <id>）
+# 注意：MCP 通知叫不醒空闲的 harness——保持可被唤醒仍要靠下面的 watch/serve。
 # 保持能被叫醒（先选对 runtime；选错会“看起来在线但没人处理 @”）：
 #   Codex CLI / Codex tool-call shell：不要用 watch 当 wake 层；用 party serve + codex exec resume。
 #   Claude Code 的 run_in_background 可能在回合边界被回收：watch --once 只算当前回合临时等待，绝不算耐久在线。

--- a/cli/test/__snapshots__/m3.test.ts.snap
+++ b/cli/test/__snapshots__/m3.test.ts.snap
@@ -15,7 +15,7 @@ channel:  fix-login-bug  (standing)
 
 # ── 加入频道 #fix-login-bug，和其他 agent、人实时协作 ──
 
-# 1) 装 party CLI（已装则跳过）
+# 1) 装 party CLI（无条件跑一遍：幂等，重复执行只会更新到最新版——接入包依赖新版的 MCP 工具）
 curl -fsSL https://raw.githubusercontent.com/leeguooooo/agentparty/main/install.sh | sh
 # install.sh 常把 party 装到 ~/.local/bin；确保它在本次 shell 的 PATH 里，否则下面每条 party 命令都会
 # 「command not found」（serve 也起不来 = 挂不上、收不到 @ 唤醒）。这行幂等，已在 PATH 也无害。
@@ -34,10 +34,21 @@ export AGENTPARTY_CONFIG="$HOME/.agentparty/agents/agentparty-fix-login-bug-gues
 party init --server https://party.example --token ap_fix-login-bug-guest_secret --channel fix-login-bug
 party send "👋 fix-login-bug-guest 报到，来参与协作" --channel fix-login-bug
 
-# 4) 之后怎么参与（就这几条命令，读懂再决定怎么待命）：
-#   回消息：party send "<回应>" --channel fix-login-bug   （@别人加 --mention <名字>）
-#   补上下文：party history fix-login-bug   认领任务：party status fix-login-bug working -m "我负责 X"
-#   维护任务台账（别和实际漂移）：认领 party task claim <id>（或 party task create）→ 开工 party status working --task <id> → 完成 party status done --task <id>
+# 4) 把 AgentParty MCP server 注册进你的 harness，之后频道操作优先用 party_* 工具
+#   （party_send / party_status / party_history / party_task_* / party_decision_ask ...）
+#   ——MCP server 替每次工具调用持有你的身份，不用每条命令再带 AGENTPARTY_CONFIG 前缀：
+claude mcp add party-fix-login-bug-guest --env AGENTPARTY_CONFIG="$HOME/.agentparty/agents/agentparty-fix-login-bug-guest-fix-login-bug.json" -- party mcp --channel fix-login-bug
+# Codex：codex mcp add party-fix-login-bug-guest --env AGENTPARTY_CONFIG="$HOME/.agentparty/agents/agentparty-fix-login-bug-guest-fix-login-bug.json" -- party mcp --channel fix-login-bug
+# 非 MCP 的 harness：跳过这步，继续用 party CLI 并每条命令带 AGENTPARTY_CONFIG 前缀。
+# 注意：注册的工具通常下个会话才出现——本次会话先用下面的 CLI 命令。
+
+# 5) 之后怎么参与（优先 party_* 工具；CLI 命令是非 MCP harness 的兜底，读懂再决定怎么待命）：
+#   回消息：party_send 工具（CLI 兜底：party send "<回应>" --channel fix-login-bug，@别人加 --mention <名字>）
+#   补上下文：party_history 工具（CLI：party history fix-login-bug）   认领任务：party_status 工具（CLI：party status fix-login-bug working -m "我负责 X"）
+#   请 owner 拍板：party_decision_ask 工具（CLI：party decision ask）
+#   维护任务台账（别和实际漂移）：party_task_* 工具——认领（或创建）→ status working --task <id> → 完成 status done --task <id>
+#   （CLI 兜底：party task claim <id> / party task create / party status ... --task <id>）
+# 注意：MCP 通知叫不醒空闲的 harness——保持可被唤醒仍要靠下面的 watch/serve。
 # 保持能被叫醒（先选对 runtime；选错会“看起来在线但没人处理 @”）：
 #   Codex CLI / Codex tool-call shell：不要用 watch 当 wake 层；用 party serve + codex exec resume。
 #   Claude Code 的 run_in_background 可能在回合边界被回收：watch --once 只算当前回合临时等待，绝不算耐久在线。

--- a/cli/test/m3.test.ts
+++ b/cli/test/m3.test.ts
@@ -124,6 +124,15 @@ describe("party invite", () => {
     expect(r.stdout).toContain('$HOME/.agentparty/agents/agentparty-fix-login-bug-guest-fix-login-bug.json');
     expect(r.stdout).toContain("TMPDIR 清理会抹掉身份和 cursor");
     expect(r.stdout).not.toContain("${TMPDIR");
+    // #585：CLI 邀请包与 web 接入包同一套 MCP-first 世界观——注册名按 agent 唯一（shared mcpServerName），
+    // 附 Codex 行 + 非 MCP 兜底 + 「MCP 通知叫不醒 harness」提醒。
+    expect(r.stdout).toContain(
+      'claude mcp add party-fix-login-bug-guest --env AGENTPARTY_CONFIG="$HOME/.agentparty/agents/agentparty-fix-login-bug-guest-fix-login-bug.json" -- party mcp --channel fix-login-bug',
+    );
+    expect(r.stdout).toContain("# Codex：codex mcp add party-fix-login-bug-guest --env");
+    expect(r.stdout).toContain("非 MCP 的 harness：跳过这步");
+    expect(r.stdout).toContain("party_decision_ask");
+    expect(r.stdout).toContain("MCP 通知叫不醒空闲的 harness");
     expect(r.stdout).toContain("party serve fix-login-bug --on-mention");
     expect(r.stdout).toContain("Codex CLI / Codex tool-call shell：不要用 watch 当 wake 层");
     expect(r.stdout).toContain("watch --follow：只适合 tail/debug");

--- a/shared/package.json
+++ b/shared/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "exports": {
     ".": "./src/protocol.ts",
-    "./mentions": "./src/mentions.ts"
+    "./mentions": "./src/mentions.ts",
+    "./onboarding": "./src/onboarding.ts"
   }
 }

--- a/shared/src/onboarding.ts
+++ b/shared/src/onboarding.ts
@@ -1,0 +1,17 @@
+// 接入包（web AgentJoin / cli party invite）共用的生成规则。两条邀请路径发出的
+// 命令必须逐字节同语义——规则只放这一份，别在 web/cli 各自复刻（#585）。
+
+/**
+ * MCP server 注册名：必须按 agent 唯一。同一目录跑多个 agent 时，固定叫 `party` 会让
+ * 后注册的覆盖先注册的身份 env——重启会话后静默串号（比 CLI 忘带前缀更难察觉）。
+ * agent 名本身是 NAME_RE 约束的 ASCII，但 `.` 在 Codex 的 TOML 键等处不安全，消毒成 `-`；
+ * 消毒有损时（a.b 与 a-b 会同形）追加原名短哈希保持单射，
+ * 别让「防覆盖」的规则自己引入新的覆盖面（#583 评审）。
+ */
+export function mcpServerName(agentName: string): string {
+  const cleaned = agentName.replace(/[^a-zA-Z0-9_-]/g, "-");
+  if (cleaned === agentName) return `party-${agentName}`;
+  let h = 5381;
+  for (let i = 0; i < agentName.length; i += 1) h = (Math.imul(h, 33) ^ agentName.charCodeAt(i)) >>> 0;
+  return `party-${cleaned}-${h.toString(36)}`;
+}

--- a/web/src/components/AgentTokens.copypack.test.tsx
+++ b/web/src/components/AgentTokens.copypack.test.tsx
@@ -1,0 +1,184 @@
+// @ts-expect-error Bun executes this test, while the web tsconfig intentionally loads only Vite globals.
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { LocaleProvider } from "../i18n/locale";
+import * as realVault from "../lib/agentTokenVault";
+
+// #584：vault 里的 command 是生成时刻的冻结文本——旧包会带着 TMPDIR 配置路径、
+// MIN_CLI 0.2.52、无 MCP 步骤继续流通。复制按钮必须现场重建，绝不发存量文本。
+// 这里保留 vault 真实实现（buildMinimalAgentCommand / findSavedAgentToken 都要真的跑），
+// 只桩 copyText 捕获实际发到剪贴板的内容。
+const copiedTexts: string[] = [];
+mock.module("../lib/agentTokenVault", () => ({
+  ...realVault,
+  copyText: async (text: string) => {
+    copiedTexts.push(text);
+    return true;
+  },
+}));
+
+type AgentFixture = { name: string; owner: string; channel_scope: string; created_at: number; nickname?: string | null };
+let agentsFixture: AgentFixture[] = [];
+
+mock.module("../lib/api", () => ({
+  AuthError: class AuthError extends Error {},
+  ConflictError: class ConflictError extends Error {},
+  ForbiddenError: class ForbiddenError extends Error {},
+  ValidationError: class ValidationError extends Error {},
+  createChannelAgent: async (_slug: string, name: string) => ({ name, token: "ap_created" }),
+  createProjectAgentProfile: async () => {
+    throw new Error("unused in this test");
+  },
+  inviteProjectAgent: async () => {},
+  listChannelAgents: async () => agentsFixture,
+  listProjectAgentProfiles: async () => [],
+  rotateChannelAgent: async (_token: string, _slug: string, name: string) => ({ name, token: "ap_rotated" }),
+  setChannelAgentNickname: async (_token: string, _slug: string, name: string, nickname: string) => ({ name, nickname }),
+}));
+
+const { AgentTokens } = await import("./AgentTokens");
+
+// 一份 TMPDIR 时代的冻结接入包：正是 #584 现场抓到的旧格式。
+const FROZEN_LEGACY_COMMAND = [
+  "# ── AgentParty 接入 · 频道 #demo ──",
+  'need=0.2.52; have="$(party --version 2>/dev/null || echo 0)"',
+  'export AGENTPARTY_CONFIG="${TMPDIR:-/tmp}/agentparty-legacy-bot-demo.json"',
+  "party init --server https://old.example --token ap_old_token --channel demo",
+].join("\n");
+
+function memoryStorage(seed: Record<string, string> = {}): Storage {
+  const values = new Map<string, string>(Object.entries(seed));
+  return {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => { values.set(key, value); },
+    removeItem: (key) => { values.delete(key); },
+    clear: () => values.clear(),
+    key: (index) => [...values.keys()][index] ?? null,
+    get length() { return values.size; },
+  };
+}
+
+class TestEventTarget {
+  private listeners = new Map<string, Set<(event: unknown) => void>>();
+  addEventListener(type: string, listener: (event: unknown) => void) {
+    const listeners = this.listeners.get(type) ?? new Set();
+    listeners.add(listener);
+    this.listeners.set(type, listeners);
+  }
+  removeEventListener(type: string, listener: (event: unknown) => void) {
+    this.listeners.get(type)?.delete(listener);
+  }
+}
+
+let renderer: ReactTestRenderer | null = null;
+const insideTarget = {};
+
+beforeEach(() => {
+  agentsFixture = [];
+  copiedTexts.length = 0;
+  Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", { configurable: true, value: true });
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: memoryStorage({
+      ap_locale: "en",
+      "ap_agent_token_vault:v1": JSON.stringify([
+        {
+          account: "acct-1",
+          slug: "demo",
+          name: "legacy-bot",
+          token: "ap_old_token",
+          command: FROZEN_LEGACY_COMMAND,
+          savedAt: 0,
+        },
+      ]),
+    }),
+  });
+  Object.defineProperty(globalThis, "location", {
+    configurable: true,
+    value: { origin: "https://party.example" },
+  });
+  const windowEvents = new TestEventTarget();
+  const documentEvents = new TestEventTarget();
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      innerWidth: 1200,
+      innerHeight: 800,
+      addEventListener: windowEvents.addEventListener.bind(windowEvents),
+      removeEventListener: windowEvents.removeEventListener.bind(windowEvents),
+      setTimeout: globalThis.setTimeout.bind(globalThis),
+    },
+  });
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: {
+      addEventListener: documentEvents.addEventListener.bind(documentEvents),
+      removeEventListener: documentEvents.removeEventListener.bind(documentEvents),
+    },
+  });
+});
+
+afterEach(async () => {
+  if (renderer !== null) await act(async () => renderer?.unmount());
+  renderer = null;
+  Reflect.deleteProperty(globalThis, "window");
+  Reflect.deleteProperty(globalThis, "document");
+  Reflect.deleteProperty(globalThis, "localStorage");
+  Reflect.deleteProperty(globalThis, "location");
+});
+
+async function renderOpen(): Promise<ReactTestRenderer> {
+  let r!: ReactTestRenderer;
+  await act(async () => {
+    r = create(
+      <LocaleProvider>
+        <AgentTokens slug="demo" token="tok-1" accountKey="acct-1" inviterName="host" onAuthFailed={() => {}} />
+      </LocaleProvider>,
+      {
+        createNodeMock(element) {
+          if ((element.props as { className?: string }).className === "agenttokens") {
+            return {
+              contains: (target: unknown) => target === insideTarget,
+              getBoundingClientRect: () => ({ bottom: 40, right: 700 }),
+            };
+          }
+          return {};
+        },
+      },
+    );
+  });
+  renderer = r;
+  await act(async () => {
+    r.root.find((n) => n.props.className === "d-btn agenttokens-btn").props.onClick();
+  });
+  await act(async () => {});
+  return r;
+}
+
+describe("AgentTokens copy join pack (#584)", () => {
+  test("copy rebuilds the pack fresh instead of replaying the frozen vault command", async () => {
+    agentsFixture = [{ name: "legacy-bot", owner: "acct-1", channel_scope: "demo", created_at: 0 }];
+    const r = await renderOpen();
+
+    const copyPackButton = r.root.findAll(
+      (n) => n.type === "button" && Array.isArray(n.props.children) === false && n.props.children === "copy join pack",
+    );
+    expect(copyPackButton.length).toBe(1);
+    await act(async () => {
+      copyPackButton[0]!.props.onClick();
+    });
+
+    expect(copiedTexts.length).toBe(1);
+    const pack = copiedTexts[0]!;
+    // 现场重建：带当前世界观（版本闸 + 持久配置目录 + 按 agent 唯一的 MCP 注册名 + 原 token）……
+    expect(pack).toContain(`need=${realVault.MIN_CLI}; have=`);
+    expect(pack).toContain('AGENTPARTY_CONFIG="$HOME/.agentparty/agents/agentparty-legacy-bot-demo.json"');
+    expect(pack).toContain("claude mcp add party-legacy-bot --env");
+    expect(pack).toContain("--token ap_old_token");
+    expect(pack).toContain("party init --server https://party.example");
+    // ……而不是 vault 里的冻结文本（TMPDIR 路径 / 0.2.52 是旧包指纹）。
+    expect(pack).not.toContain("TMPDIR");
+    expect(pack).not.toContain("0.2.52");
+    expect(pack).not.toBe(FROZEN_LEGACY_COMMAND);
+  });
+});

--- a/web/src/components/AgentTokens.tsx
+++ b/web/src/components/AgentTokens.tsx
@@ -184,6 +184,20 @@ export function AgentTokens({ slug, token, accountKey, inviterName, onAuthFailed
     );
   };
 
+  // #584：vault 里存的 command 是生成时刻的冻结文本，会带着旧世界观（TMPDIR 配置路径、
+  // 旧 MIN_CLI、无 MCP 步骤）继续流通。复制永远现场重建，存量 command 字段只留作兼容不再读。
+  function freshCommand(record: { name: string; token: string }): string {
+    return buildMinimalAgentCommand({
+      // #530：桌面版 location.origin 是 tauri://localhost，接入包会报错；优先真实后端 apiBase，同源 web 回退 origin。
+      server: apiOrigin(),
+      slug,
+      name: record.name,
+      token: record.token,
+      inviterName,
+      checkinMessage: t("AgentTokens.checkinMessage", { name: record.name }),
+    });
+  }
+
   async function copy(name: string, kind: "token" | "command", text: string) {
     const ok = await copyText(text);
     if (!ok) {
@@ -427,7 +441,7 @@ export function AgentTokens({ slug, token, accountKey, inviterName, onAuthFailed
                           <button type="button" className="d-btn" onClick={() => copy(agent.name, "token", saved.token)}>
                             {copied === `${agent.name}:token` ? t("AgentTokens.copied") : t("AgentTokens.copyToken")}
                           </button>
-                          <button type="button" className="d-btn" onClick={() => copy(agent.name, "command", saved.command)}>
+                          <button type="button" className="d-btn" onClick={() => copy(agent.name, "command", freshCommand(saved))}>
                             {copied === `${agent.name}:command` ? t("AgentTokens.copied") : t("AgentTokens.copyPack")}
                           </button>
                         </>

--- a/web/src/lib/agentTokenVault.ts
+++ b/web/src/lib/agentTokenVault.ts
@@ -1,3 +1,5 @@
+import { mcpServerName } from "@agentparty/shared/onboarding";
+
 const VAULT_KEY = "ap_agent_token_vault:v1";
 
 export interface AgentTokenRecord {
@@ -95,17 +97,8 @@ export const MIN_CLI = "0.2.124";
 export const VERSION_GE_SNIPPET =
   `version_ge(){ awk -v a="$1" -v b="$2" 'BEGIN{split(a,A,".");split(b,B,".");for(i=1;i<=3;i++){A[i]+=0;B[i]+=0;if(A[i]>B[i])exit 0;if(A[i]<B[i])exit 1}exit 0}'; }`;
 
-// MCP server 注册名必须按 agent 唯一：同一目录跑多个 agent 时，固定叫 `party` 会让后注册的
-// 覆盖先注册的身份 env——重启会话后静默串号（比 CLI 忘带前缀更难察觉）。agent 名本身是
-// NAME_RE 约束的 ASCII，但 `.` 在 Codex 的 TOML 键等处不安全，消毒成 `-`；消毒有损时
-//（a.b 与 a-b 会同形）追加原名短哈希保持单射，别让「防覆盖」的改动自己引入新的覆盖面。
-export function mcpServerName(agentName: string): string {
-  const cleaned = agentName.replace(/[^a-zA-Z0-9_-]/g, "-");
-  if (cleaned === agentName) return `party-${agentName}`;
-  let h = 5381;
-  for (let i = 0; i < agentName.length; i += 1) h = (Math.imul(h, 33) ^ agentName.charCodeAt(i)) >>> 0;
-  return `party-${cleaned}-${h.toString(36)}`;
-}
+// MCP server 注册名规则挪到 shared 与 cli 的 party invite 共用一份（#585）；语义与来由见那边注释。
+export { mcpServerName } from "@agentparty/shared/onboarding";
 
 export function buildMinimalAgentCommand(input: {
   server: string;


### PR DESCRIPTION
Closes #584, closes #585。

## 变更

- **#584 vault 冻结旧包**：`AgentTokens` 的「复制接入包」不再回放 `saved.command`（生成时刻冻结文本，线上抓到过 TMPDIR 路径 + MIN_CLI 0.2.52 + 无 MCP 步骤的旧包在流通），改为用 `buildMinimalAgentCommand` 现场重建；`command` 字段保留兼容、读路径不再使用。
- **#585 CLI 邀请包 MCP-first**：`party invite` 参与包在 check-in 后插入 MCP 注册步骤（server 名 `party-<agent名>`、Codex 等价行、非 MCP 兜底、「工具下个会话才出现」提醒），参与指引改 party_* 工具优先/CLI 兜底（含 party_decision_ask），加「MCP 通知叫不醒空闲 harness」提醒；step 1 注释改为与命令一致。
- **`mcpServerName` 挪进 `@agentparty/shared/onboarding`**：web 与 cli 共用同一份单射消毒规则（#583 评审定稿的语义原样搬迁），web 侧保留 re-export 不动既有消费者。

## 验证

- `bun run check:cli` — 917 passed（m3 补 5 条 MCP 行断言，快照重生成并逐行核对）
- `bun run check:web` — 852 passed，tsc + 生产构建干净（新增 AgentTokens.copypack.test：用带 TMPDIR/0.2.52 指纹的冻结记录驱动复制，断言产物是现建的新包且不含旧指纹）
- `bun run check:shared` — 通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 优化 CLI 参与接入包，新增 Claude/Codex MCP 工具注册指引。
  - 支持根据参与者名称生成稳定且不易冲突的 MCP 服务名称。
  - 补充 MCP 优先的参与说明，并明确非 MCP 环境下的 CLI 备用方式。

- **改进**
  - 安装步骤改为可重复执行，提升接入可靠性。
  - 复制 Web 接入包时实时生成最新命令，自动匹配当前环境与配置，避免使用过期指令。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->