### PR TITLE
fix(mcp): 长驻 MCP server 接入升级闭环（#588）

### DIFF
--- a/cli/src/commands/mcp.ts
+++ b/cli/src/commands/mcp.ts
@@ -26,6 +26,7 @@ import {
   fetchMessages,
   fetchPresence,
   fetchRecentMessages,
+  fetchServerVersion,
   handleRestError,
   listChannels,
   listTasks,
@@ -34,6 +35,7 @@ import {
   updateTask,
   type Identity,
 } from "../rest";
+import { serverVersionUpgradeNotice, upgradeNotice, type CliUpgradeNotice, type UpgradeDeps } from "../upgrade";
 import { isName, isSlug } from "../validation";
 import { askDecision } from "./decision";
 import { uploadAttachmentPaths } from "./send";
@@ -214,6 +216,56 @@ function charterReminder(boundChannel: string | undefined): string {
   return `read the channel charter first (${where}) — it defines this channel's scope and etiquette before you act.`;
 }
 
+// MCP server 是长驻进程，#485 给 serve 做的升级闭环没有覆盖这里（#588）：磁盘 party 升级后
+// 本进程仍是旧二进制，新注册的 party_* 工具不会出现；服务端发新版时旧进程同样不自知。
+// 两层检测，提示挂在 whoami / watch_once 两个「重锚点」的结构化结果上：
+//   a) 磁盘二进制 > 运行版（upgradeNotice）——命中即短路，零网络。MCP 语境下无需重装、
+//      无需重新注册（注册命令按 PATH 解析 party），重启 harness 会话即可加载新版。
+//      不做 serve 式 auto re-exec：stdio server 自杀会掐断 MCP 连接、丢掉在途工具调用。
+//   b) 服务端 /api/version > 运行版（serverVersionUpgradeNotice）——10 分钟节流缓存；
+//      探测失败（老 worker 无该端点、网络错）静默跳过，绝不为提示挡住或拖慢工具调用。
+const SERVER_VERSION_PROBE_TTL_MS = 10 * 60_000;
+let serverVersionProbe: { at: number; version: string | null } = { at: 0, version: null };
+
+/** 测试缝隙：注入 UpgradeDeps 走磁盘路径、重置节流缓存。 */
+export function resetServerVersionProbeForTest(): void {
+  serverVersionProbe = { at: 0, version: null };
+}
+
+export async function mcpUpgradeNotice(
+  server: string,
+  deps: UpgradeDeps = {},
+  options: { probe?: boolean } = {},
+): Promise<(CliUpgradeNotice & { mcp_note: string }) | null> {
+  const disk = upgradeNotice(false, deps);
+  if (disk !== null) {
+    return {
+      ...disk,
+      mcp_note:
+        "the party binary on disk is already newer than this running MCP server — no reinstall needed. Restart the harness session so the server respawns on the new binary; the MCP registration resolves `party` from PATH, so re-registration is NOT needed.",
+    };
+  }
+  // probe=false（watch_once 唤醒路径）只读缓存：唤醒 replay 是延迟敏感的极简路径（#551 的
+  // 测试固定了它的请求数），版本探测只允许发生在 whoami 这类非关键调用里。
+  const now = Date.now();
+  if (options.probe !== false && now - serverVersionProbe.at > SERVER_VERSION_PROBE_TTL_MS) {
+    serverVersionProbe = { at: now, version: null };
+    try {
+      serverVersionProbe.version = (await fetchServerVersion(server)).version;
+    } catch {
+      // 静默：升级提示是增益信号，不是墙。
+    }
+  }
+  if (serverVersionProbe.version === null) return null;
+  const notice = serverVersionUpgradeNotice(serverVersionProbe.version, deps);
+  if (notice === null) return null;
+  return {
+    ...notice,
+    mcp_note:
+      "after upgrading (`party upgrade`, or the install.sh one-liner), restart the harness session so this MCP server respawns on the new binary. The MCP registration resolves `party` from PATH — do NOT re-register.",
+  };
+}
+
 async function charterData(channel: string): Promise<Record<string, unknown>> {
   const cfg = await auth();
   const body = await fetchChannelCharter(cfg.server, cfg.token, channel);
@@ -250,7 +302,15 @@ export function createMcpServer(defaultChannel?: string): McpServer {
       try {
         const cfg = await auth();
         const me = await fetchMe(cfg.server, cfg.token);
-        return ok({ type: "me", server: cfg.server, identity: me, protocol_reminder: reminder });
+        const upgrade = await mcpUpgradeNotice(cfg.server);
+        return ok({
+          type: "me",
+          server: cfg.server,
+          cli_version: pkg.version,
+          identity: me,
+          protocol_reminder: reminder,
+          ...(upgrade !== null ? { cli_upgrade: upgrade } : {}),
+        });
       } catch (e) {
         return fail(e instanceof Error ? e.message : String(e));
       }
@@ -915,7 +975,16 @@ export function createMcpServer(defaultChannel?: string): McpServer {
             lag: Math.max(0, channelLastSeq - pending.seq),
             skipped_mention_seqs: stuck.skipped_mention_seqs ?? [],
           });
-          return ok({ type: "watch_once", channel: resolved, exit_code: 0, frames: [frame] });
+          // 唤醒返回帧＝一轮的起点：旧进程/旧版的升级提示在这里最可能被看见并转达 owner（#588）。
+          // probe:false——唤醒路径零额外网络（磁盘检测 + whoami 已填充的缓存）。
+          const replayUpgrade = await mcpUpgradeNotice(cfg.server, {}, { probe: false });
+          return ok({
+            type: "watch_once",
+            channel: resolved,
+            exit_code: 0,
+            frames: [frame],
+            ...(replayUpgrade !== null ? { cli_upgrade: replayUpgrade } : {}),
+          });
         }
 
         const lines: string[] = [];
@@ -945,7 +1014,15 @@ export function createMcpServer(defaultChannel?: string): McpServer {
           out: (line) => lines.push(line),
         });
         const frames = lines.map((line) => JSON.parse(line) as Record<string, unknown>);
-        const data = { type: "watch_once", channel: resolved, exit_code: code, frames };
+        // 同 replay 路径：唤醒返回帧带缓存化的升级提示（probe:false，零额外网络）。
+        const liveUpgrade = await mcpUpgradeNotice(cfg.server, {}, { probe: false });
+        const data = {
+          type: "watch_once",
+          channel: resolved,
+          exit_code: code,
+          frames,
+          ...(liveUpgrade !== null ? { cli_upgrade: liveUpgrade } : {}),
+        };
         return code === 0 ? ok(data) : { ...fail(lines.join("\n") || `watch_once failed with exit ${code}`), structuredContent: data };
       } catch (e) {
         return fail(e instanceof Error ? e.message : String(e));

--- a/cli/src/commands/mcp.ts
+++ b/cli/src/commands/mcp.ts
@@ -35,7 +35,7 @@ import {
   updateTask,
   type Identity,
 } from "../rest";
-import { serverVersionUpgradeNotice, upgradeNotice, type CliUpgradeNotice, type UpgradeDeps } from "../upgrade";
+import { serverVersionUpgradeNotice, upgradeNotice, type UpgradeDeps } from "../upgrade";
 import { isName, isSlug } from "../validation";
 import { askDecision } from "./decision";
 import { uploadAttachmentPaths } from "./send";
@@ -232,17 +232,43 @@ export function resetServerVersionProbeForTest(): void {
   serverVersionProbe = { at: 0, version: null };
 }
 
+// MCP 语境的升级提示用自己的形状，不复用 CliUpgradeNotice 的 message/command——那套话术是
+// serve 专属（「重启 serve」「auto re-exec」「重装命令」），在 MCP 场景是矛盾指令（磁盘已新
+// 无需重装；重启对象是 harness 会话不是 serve）。保留 action_required=ask_user 让 runner
+// 复用同一条询问用户的处理流；command 只在真有命令要跑时才给（server 路径的升级命令）。
+export interface McpUpgradeNotice {
+  running_version: string;
+  available_version: string;
+  /** 磁盘路径才有：已安装、等待会话重启加载的版本。 */
+  installed_version?: string;
+  source: "disk" | "server";
+  action_required: "ask_user";
+  message: string;
+  /** 需要用户真的跑命令时才给（server 路径的安装/升级命令）；磁盘路径无命令可跑。 */
+  command?: string;
+}
+
+// 服务端探测是可选增益：3 秒等不到就放弃本轮（缓存留空、下轮再试），
+// 绝不让 whoami 被 rest 默认 30s 超时拖住。
+const SERVER_VERSION_PROBE_TIMEOUT_MS = 3_000;
+
 export async function mcpUpgradeNotice(
   server: string,
   deps: UpgradeDeps = {},
   options: { probe?: boolean } = {},
-): Promise<(CliUpgradeNotice & { mcp_note: string }) | null> {
+): Promise<McpUpgradeNotice | null> {
   const disk = upgradeNotice(false, deps);
   if (disk !== null) {
     return {
-      ...disk,
-      mcp_note:
-        "the party binary on disk is already newer than this running MCP server — no reinstall needed. Restart the harness session so the server respawns on the new binary; the MCP registration resolves `party` from PATH, so re-registration is NOT needed.",
+      running_version: disk.running_version,
+      available_version: disk.available_version,
+      ...(disk.installed_version !== undefined ? { installed_version: disk.installed_version } : {}),
+      source: "disk",
+      action_required: "ask_user",
+      message:
+        `party CLI on disk is already v${disk.available_version} while this MCP server still runs v${disk.running_version}. ` +
+        "No reinstall and no re-registration needed (the MCP registration resolves `party` from PATH) — " +
+        "ask the user to restart this harness session so the server respawns on the new binary.",
     };
   }
   // probe=false（watch_once 唤醒路径）只读缓存：唤醒 replay 是延迟敏感的极简路径（#551 的
@@ -251,7 +277,12 @@ export async function mcpUpgradeNotice(
   if (options.probe !== false && now - serverVersionProbe.at > SERVER_VERSION_PROBE_TTL_MS) {
     serverVersionProbe = { at: now, version: null };
     try {
-      serverVersionProbe.version = (await fetchServerVersion(server)).version;
+      serverVersionProbe.version = await Promise.race([
+        fetchServerVersion(server).then((v) => v.version),
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error("probe timeout")), SERVER_VERSION_PROBE_TIMEOUT_MS),
+        ),
+      ]);
     } catch {
       // 静默：升级提示是增益信号，不是墙。
     }
@@ -260,9 +291,15 @@ export async function mcpUpgradeNotice(
   const notice = serverVersionUpgradeNotice(serverVersionProbe.version, deps);
   if (notice === null) return null;
   return {
-    ...notice,
-    mcp_note:
-      "after upgrading (`party upgrade`, or the install.sh one-liner), restart the harness session so this MCP server respawns on the new binary. The MCP registration resolves `party` from PATH — do NOT re-register.",
+    running_version: notice.running_version,
+    available_version: notice.available_version,
+    source: "server",
+    action_required: "ask_user",
+    message:
+      `AgentParty server has published party CLI v${notice.available_version}; this MCP server still runs v${notice.running_version}. ` +
+      "Ask the user to upgrade with the command below, then restart this harness session so the server respawns on the new binary — " +
+      "do NOT re-register (the MCP registration resolves `party` from PATH).",
+    command: notice.command,
   };
 }
 

--- a/cli/test/mcp-upgrade-notice.test.ts
+++ b/cli/test/mcp-upgrade-notice.test.ts
@@ -1,0 +1,139 @@
+// #588：party mcp 是长驻进程，磁盘/服务端升级后旧 server 必须能自知并给出可执行指引。
+// 单测走 mcpUpgradeNotice 的 deps 注入（磁盘路径、零网络）；集成测走真 MCP stdio server +
+// mock /api/version（服务端路径 + 节流）。
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { mcpUpgradeNotice, resetServerVersionProbeForTest } from "../src/commands/mcp";
+
+const indexPath = join(import.meta.dir, "..", "src", "index.ts");
+
+describe("mcpUpgradeNotice 磁盘路径（deps 注入，零网络）", () => {
+  test("磁盘二进制更新 → 短路返回 restart 指引，不打服务端", async () => {
+    const notice = await mcpUpgradeNotice("http://127.0.0.1:9", {
+      runningVersion: "0.2.100",
+      execPath: "/usr/local/bin/party",
+      readInstalledVersion: () => "0.2.101",
+    });
+    expect(notice).not.toBeNull();
+    expect(notice!.installed_version).toBe("0.2.101");
+    expect(notice!.running_version).toBe("0.2.100");
+    // MCP 语境的关键话术：无需重装、无需重新注册、重启会话即可。
+    expect(notice!.mcp_note).toContain("no reinstall needed");
+    expect(notice!.mcp_note).toContain("re-registration is NOT needed");
+    expect(notice!.mcp_note).toContain("Restart the harness session");
+  });
+
+  test("磁盘与运行版一致且服务端不可达 → null（静默，不因提示报错）", async () => {
+    resetServerVersionProbeForTest();
+    const notice = await mcpUpgradeNotice("http://127.0.0.1:9", {
+      runningVersion: "0.2.100",
+      execPath: "/usr/local/bin/party",
+      readInstalledVersion: () => "0.2.100",
+    });
+    expect(notice).toBeNull();
+  });
+});
+
+describe("party mcp 服务端版本路径（真 stdio server + mock /api/version）", () => {
+  let home: string;
+  let restServer: ReturnType<typeof Bun.serve> | null = null;
+  let versionHits = 0;
+  let serverVersion = "9.9.9";
+
+  function startRest(): void {
+    restServer = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch(req) {
+        const url = new URL(req.url);
+        if (url.pathname === "/api/me") {
+          return Response.json({ name: "me", email: null, kind: "agent", role: "member", owner: null });
+        }
+        if (url.pathname === "/api/version") {
+          versionHits += 1;
+          return Response.json({
+            version: serverVersion,
+            commit: "deadbeef",
+            deployed_at: null,
+            min_client_version: "0.0.0",
+            min_client_enforced: false,
+          });
+        }
+        return Response.json({ error: { code: "not_found", message: "not found" } }, { status: 404 });
+      },
+    });
+    mkdirSync(home, { recursive: true });
+    writeFileSync(
+      join(home, "config.json"),
+      JSON.stringify({ server: `http://127.0.0.1:${restServer.port}`, token: "ap_tok" }),
+    );
+  }
+
+  async function connect(): Promise<Client> {
+    const env: Record<string, string> = {};
+    for (const [k, v] of Object.entries(process.env)) {
+      if (v !== undefined && k !== "AGENTPARTY_CONFIG") env[k] = v;
+    }
+    env.AGENTPARTY_HOME = home;
+    const transport = new StdioClientTransport({
+      command: "bun",
+      args: ["run", indexPath, "mcp", "--channel", "dev"],
+      env,
+      stderr: "pipe",
+    });
+    const client = new Client({ name: "agentparty-test", version: "1.0.0" });
+    await client.connect(transport);
+    return client;
+  }
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "ap-mcp-upgrade-"));
+    versionHits = 0;
+    serverVersion = "9.9.9";
+  });
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+    restServer?.stop(true);
+    restServer = null;
+  });
+
+  test("服务端已发新版 → whoami 带 cli_upgrade + mcp_note；节流让两次调用只探测一次", async () => {
+    startRest();
+    const client = await connect();
+    try {
+      const r1 = await client.callTool({ name: "party_whoami", arguments: {} });
+      expect(r1.isError).not.toBe(true);
+      const c1 = r1.structuredContent as { cli_version?: string; cli_upgrade?: Record<string, unknown> };
+      expect(typeof c1.cli_version).toBe("string");
+      expect(c1.cli_upgrade).toBeDefined();
+      expect(c1.cli_upgrade!.available_version).toBe("9.9.9");
+      expect(String(c1.cli_upgrade!.mcp_note)).toContain("restart the harness session");
+      expect(String(c1.cli_upgrade!.mcp_note)).toContain("do NOT re-register");
+
+      const r2 = await client.callTool({ name: "party_whoami", arguments: {} });
+      expect((r2.structuredContent as { cli_upgrade?: unknown }).cli_upgrade).toBeDefined();
+      // 10 分钟 TTL 内第二次 whoami 用缓存，不再打 /api/version。
+      expect(versionHits).toBe(1);
+    } finally {
+      await client.close();
+    }
+  }, 20000);
+
+  test("服务端版本不高于运行版 → 无 cli_upgrade", async () => {
+    serverVersion = "0.0.1";
+    startRest();
+    const client = await connect();
+    try {
+      const r = await client.callTool({ name: "party_whoami", arguments: {} });
+      expect(r.isError).not.toBe(true);
+      expect((r.structuredContent as { cli_upgrade?: unknown }).cli_upgrade).toBeUndefined();
+    } finally {
+      await client.close();
+    }
+  }, 20000);
+});

--- a/cli/test/mcp-upgrade-notice.test.ts
+++ b/cli/test/mcp-upgrade-notice.test.ts
@@ -19,12 +19,15 @@ describe("mcpUpgradeNotice 磁盘路径（deps 注入，零网络）", () => {
       readInstalledVersion: () => "0.2.101",
     });
     expect(notice).not.toBeNull();
+    expect(notice!.source).toBe("disk");
     expect(notice!.installed_version).toBe("0.2.101");
     expect(notice!.running_version).toBe("0.2.100");
-    // MCP 语境的关键话术：无需重装、无需重新注册、重启会话即可。
-    expect(notice!.mcp_note).toContain("no reinstall needed");
-    expect(notice!.mcp_note).toContain("re-registration is NOT needed");
-    expect(notice!.mcp_note).toContain("Restart the harness session");
+    // MCP 专属话术全部收敛进 message，不再继承 serve 的「重启 serve / 重装」矛盾指令；
+    // 磁盘路径没有可跑的命令——command 必须缺席，否则 runner 会把安装命令当必要步骤。
+    expect(notice!.message).toContain("No reinstall and no re-registration needed");
+    expect(notice!.message).toContain("restart this harness session");
+    expect(notice!.message).not.toMatch(/\bserve\b/); // serve 专属话术不得渗入（“server” 不算）
+    expect(notice!.command).toBeUndefined();
   });
 
   test("磁盘与运行版一致且服务端不可达 → null（静默，不因提示报错）", async () => {
@@ -112,8 +115,14 @@ describe("party mcp 服务端版本路径（真 stdio server + mock /api/version
       expect(typeof c1.cli_version).toBe("string");
       expect(c1.cli_upgrade).toBeDefined();
       expect(c1.cli_upgrade!.available_version).toBe("9.9.9");
-      expect(String(c1.cli_upgrade!.mcp_note)).toContain("restart the harness session");
-      expect(String(c1.cli_upgrade!.mcp_note)).toContain("do NOT re-register");
+      expect(c1.cli_upgrade!.source).toBe("server");
+      // server 路径的三件套必须互不矛盾：message 讲清升级+重启会话+不重注册，command 是
+      // 真正要跑的安装命令，action_required 走 runner 既有的 ask_user 流。
+      expect(String(c1.cli_upgrade!.message)).toContain("restart this harness session");
+      expect(String(c1.cli_upgrade!.message)).toContain("do NOT re-register");
+      expect(String(c1.cli_upgrade!.message)).not.toContain("serve 会自动");
+      expect(String(c1.cli_upgrade!.command)).toContain("install.sh");
+      expect(c1.cli_upgrade!.action_required).toBe("ask_user");
 
       const r2 = await client.callTool({ name: "party_whoami", arguments: {} });
       expect((r2.structuredContent as { cli_upgrade?: unknown }).cli_upgrade).toBeDefined();

--- a/cli/test/mcp-upgrade-notice.test.ts
+++ b/cli/test/mcp-upgrade-notice.test.ts
@@ -120,7 +120,7 @@ describe("party mcp 服务端版本路径（真 stdio server + mock /api/version
       // 真正要跑的安装命令，action_required 走 runner 既有的 ask_user 流。
       expect(String(c1.cli_upgrade!.message)).toContain("restart this harness session");
       expect(String(c1.cli_upgrade!.message)).toContain("do NOT re-register");
-      expect(String(c1.cli_upgrade!.message)).not.toContain("serve 会自动");
+      expect(String(c1.cli_upgrade!.message)).not.toMatch(/\bserve\b/); // 任何 serve 指令（含 restart serve）都不得出现
       expect(String(c1.cli_upgrade!.command)).toContain("install.sh");
       expect(c1.cli_upgrade!.action_required).toBe("ask_user");
 

--- a/skills/agentparty/SKILL.md
+++ b/skills/agentparty/SKILL.md
@@ -95,6 +95,14 @@ CLI for send/status/history/tasks/decisions — same names and semantics, struct
 results, no argv quoting traps. The CLI remains the path for install/init/serve (and the
 only path on harnesses without MCP).
 
+**Upgrades**: the running MCP server is a long-lived process — after the `party` binary
+upgrades (`party upgrade` or the install.sh one-liner), new `party_*` tools appear only
+when the harness session restarts and respawns the server. The registration resolves
+`party` from PATH, so it never needs re-registering. When the server detects it is behind
+(binary on disk newer, or the AgentParty server has published a newer CLI), `party_whoami`
+and `party_watch_once` results carry a `cli_upgrade` field with the exact remediation —
+surface it to the owner instead of ignoring it.
+
 | Intent | Command |
 |---|---|
 | Join a channel (write config + bind) | `export AGENTPARTY_CONFIG="$HOME/.agentparty/agents/<agent>-<slug>.json"` then `printf '%s' '<T>' \| party init --server <URL> --token - --channel <slug>` |


### PR DESCRIPTION
Closes #588。

## 问题

MCP-first 后 `party mcp` 成了标准长驻进程，但 #485 给 serve 做的升级闭环没覆盖它：磁盘 party 升级后旧进程不自知（新工具永不出现），服务端发新版同样无感，agent 只会在「工具不存在」时困惑。

## 变更

- `mcpUpgradeNotice(server, deps?, {probe})`：磁盘>运行版走 `upgradeNotice`（短路零网络）；服务端新版走 `fetchServerVersion`（10 分钟节流缓存）→ `serverVersionUpgradeNotice`。全部复用 upgrade.ts 既有件，MCP 只加 `mcp_note` 语境话术：**无需重装/无需重新注册（注册按 PATH 解析 party），重启 harness 会话即可**。
- 挂载点＝两个「重锚点」：`party_whoami`（可探测）与 `party_watch_once` 两个返回路径（`probe:false` 只读缓存——**唤醒 replay 是延迟敏感的极简路径，#551 测试固定了它的请求数**，这是本 PR 开发中被该测试当场拦下后确立的边界）。
- `party_whoami` 增 `cli_version` 字段；SKILL.md 补「MCP 怎么升级」说明。
- 刻意不做 serve 式 auto re-exec：stdio server 自杀会掐断 MCP 连接、丢在途调用。

## 验证

- `bun run check:cli` — 921 passed。新增 cli/test/mcp-upgrade-notice.test.ts：磁盘路径 deps 注入单测（短路+话术）、真 stdio server + mock /api/version 集成测（9.9.9→带 cli_upgrade；0.0.1→无；两次 whoami 仅一次探测=节流生效）；#551 的 directed-delivery 请求数断言保持 2 个 GET 不变。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - MCP CLI 新增升级提示能力：结合磁盘与服务端版本信息生成结构化升级通知并在检测到可用升级时展示。
  - `party_whoami` 与 `party_watch_once` 在合适场景下向返回结果附带 `cli_upgrade`（包含可用版本与说明；避免重复探测）。
  - 升级检测支持缓存与 TTL 节流；探测失败或无升级信息时不返回提示。  
- **测试**
  - 新增单测覆盖零网络（磁盘路径）与真实 MCP stdio + mock REST 场景，并验证 TTL 缓存节流行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->