### PR TITLE
test(serve): #522 restart-resume 归档事件驱动化，修 CI flaky（#590）

### DIFF
--- a/cli/test/serve.test.ts
+++ b/cli/test/serve.test.ts
@@ -334,12 +334,28 @@ describe("runServe", () => {
       workdir,
     }));
     const clientFrames: Array<Record<string, unknown>> = [];
+    // #590：归档必须事件驱动。welcome 后 serve 才异步读 wake-session.json 并自报 agent_session
+    // 心跳；固定 60ms 掐线在慢 CI 上会赶在心跳前收摊（本用例曾一天咬掉两个无关 PR 的首跑）。
+    // 收到目标心跳立即归档；5s 兜底让回归（心跳缺席）收敛为断言失败而非用例超时。
+    let archived = false;
     server = startMockServer((frame, sock) => {
       clientFrames.push(frame as unknown as Record<string, unknown>);
-      if (frame.type !== "hello") return;
-      sock.send(welcomeFrame(0, "me"));
-      setTimeout(() => sock.send({ type: "serve_lease", name: "me", held: true }), 20);
-      setTimeout(() => sock.send({ type: "error", code: "archived", message: "done" }), 60);
+      const archive = () => {
+        if (archived) return;
+        archived = true;
+        try {
+          sock.send({ type: "error", code: "archived", message: "done" });
+        } catch {
+          // 兜底定时器可能在用例收摊、socket 已关后触发——静默即可。
+        }
+      };
+      if (frame.type === "hello") {
+        sock.send(welcomeFrame(0, "me"));
+        setTimeout(() => sock.send({ type: "serve_lease", name: "me", held: true }), 20);
+        setTimeout(archive, 5000);
+        return;
+      }
+      if (frame.type === "heartbeat" && frame.agent_session !== undefined) archive();
     });
     const o = opts({
       server: server.url,


### PR DESCRIPTION
Closes #590。

## 根因

用例的 mock server 在 hello 后**固定 60ms** 发 `archived` 掐线，而被断言的 agent_session 心跳是 welcome 之后 serve **异步**读 wake-session.json 才发出——慢 CI 上心跳可能落在 60ms 之后，帧没抓到就收摊了。2026-07-17 一天内该用例咬掉 #586 与 #589 两个无关 PR 的首跑（失败耗时都卡在 ~275-300ms 窗口，与 issue 里的推测一致）。

## 修法

归档改事件驱动：**收到带 agent_session 的心跳帧立即归档**；保留 5 秒兜底定时器，让「心跳缺席」的真回归收敛为断言失败而不是用例超时（兜底触发时 socket 可能已关，send 包了 try/catch 防 unhandled error between tests）。不调大固定窗口——那只是把竞态推远。

## 验证

- 单用例本地连跑 **30 次零失败**（原版在快机上也偶发，CI 慢机更甚）
- `bun run check:cli` — 923 passed + tsc 干净

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **测试改进**
  * 优化服务重启恢复场景的测试流程，改为在收到心跳后触发会话归档。
  * 增加归档状态保护，避免重复执行。
  * 保留超时兜底机制，确保缺少心跳时测试能够明确失败。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->