### PR TITLE
feat(serve): managed lane 角色裁剪 MCP 工具集，替换文本信封协议（#581 Phase 2）

### DIFF
--- a/cli/src/commands/mcp-managed.ts
+++ b/cli/src/commands/mcp-managed.ts
@@ -18,7 +18,7 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
-import { readFileSync } from "node:fs";
+import { readFileSync, rmSync } from "node:fs";
 import { basename, join } from "node:path";
 import {
   BODY_LIMIT,
@@ -33,11 +33,10 @@ import {
   appendManagedAction,
   createManagedLineageResolver,
   ManagedActionError,
-  readManagedActions,
   readManagedManifest,
   readManagedWake,
+  reserveManagedExclusive,
   snapshotManagedAttachment,
-  type ManagedActionRecord,
   type ManagedLaneManifest,
   type ManagedWakeState,
 } from "../managed";
@@ -72,9 +71,6 @@ function laneAuth(manifest: ManagedLaneManifest): LaneAuth {
   }
   return { server: manifest.server, token: raw.token };
 }
-
-/** 每回合动作幂等闸：同一 wake 内重复调用同名独占动作直接拒，防模型循环刷屏。 */
-const EXCLUSIVE_ACTIONS = new Set(["owner_decision"]);
 
 /**
  * completion status（血缘续接的收尾遥测，与文本协议路由同语义）：best-effort——
@@ -113,16 +109,6 @@ export function createManagedMcpServer(stateDir: string): McpServer {
       ...(decisionState === undefined ? {} : { decision_state: decisionState }),
       at: Date.now(),
     });
-  };
-  // 幂等闸以 outcome 回执为事实源（持久）：codex 每次 exec 都 spawn 新 MCP 进程，内存态跨
-  // 回合恒空；supervisor 在每个新 wake 的 prepare 里清同 seq 回执，所以这里读到的记录一定
-  // 属于当前回合。失败的尝试不落回执，天然不堵重试；post 成功与 record 落盘之间的崩溃窗口
-  // 存在但极窄（且该回合会因 runner 崩溃按非可重试处理，不会自动重放）。
-  const assertExclusiveUnused = (seq: number, action: ManagedActionRecord["action"]) => {
-    if (!EXCLUSIVE_ACTIONS.has(action)) return;
-    if (readManagedActions(stateDir, seq).some((record) => record.action === action)) {
-      throw new ManagedActionError(`${action} already issued for this wake`);
-    }
   };
 
   const lineage = () => {
@@ -283,11 +269,16 @@ export function createManagedMcpServer(stateDir: string): McpServer {
         try {
           const auth = laneAuth(manifest);
           const state = wake();
-          assertExclusiveUnused(state.frame.seq, "owner_decision");
+          // 原子预约（O_EXCL 锁文件，#592 评审）：并发工具调用只有一个能通过；持久于磁盘，
+          // codex 每 exec 新进程也拦得住；post 失败释放预约，不堵同回合重试。
+          // supervisor 在新 wake 的 prepare 里连同回执一起清。
+          const releaseReservation = reserveManagedExclusive(stateDir, state.frame.seq, "owner_decision");
           if (state.delivery === null || state.delivery.work_id === null || state.delivery.continuation_ref === null) {
+            releaseReservation();
             throw new ManagedActionError("managed owner decision requires an active durable delivery");
           }
           if (state.owner_decision_binding !== true) {
+            releaseReservation();
             throw new ManagedActionError(
               "server does not enforce owner_decision responder binding (owner_decision_binding v1); upgrade the Worker before managed owner decisions",
             );
@@ -295,9 +286,16 @@ export function createManagedMcpServer(stateDir: string): McpServer {
           // null / 缺省 / 空数组统一按 approval（#578 finding 1 的 schema-合法输出绝不再被拒）。
           const normalizedOptions = options ?? [];
           if (normalizedOptions.length === 1) {
+            releaseReservation();
             throw new ManagedActionError("choice decision requires at least 2 options");
           }
-          const origin = await lineage()(state.frame, state.delivery);
+          let origin;
+          try {
+            origin = await lineage()(state.frame, state.delivery);
+          } catch (error) {
+            releaseReservation();
+            throw error;
+          }
           const decisionRequest: SendDecisionRequest = normalizedOptions.length === 0
             ? { kind: "approval", prompt }
             : { kind: "choice", prompt, options: normalizedOptions };
@@ -317,7 +315,13 @@ export function createManagedMcpServer(stateDir: string): McpServer {
             },
             expected_decision_responder_owner: manifest.owner_account,
           };
-          const posted = await postMessage(auth.server, auth.token, manifest.channel, payload);
+          let posted;
+          try {
+            posted = await postMessage(auth.server, auth.token, manifest.channel, payload);
+          } catch (error) {
+            releaseReservation();
+            throw error;
+          }
           const resolution: DecisionResolution | undefined = posted.decision_resolution;
           const decisionState = resolution?.state === "auto_resolved" ? "auto_resolved" : "pending";
           record(state.frame.seq, "owner_decision", posted.seq, decisionState);
@@ -362,11 +366,18 @@ export function createManagedMcpServer(stateDir: string): McpServer {
           // 围栏 + TOCTOU 快照先行：校验后立刻以 O_NOFOLLOW fd 读出字节、落到 supervisor 私有
           // 目录再上传——任何一个路径越界或非普通文件，整个报告不发（#592 评审）。
           const snapshotDir = join(stateDir, `attach-${state.frame.seq}`);
-          const snapshots = (attach ?? []).map((path) =>
-            snapshotManagedAttachment(path, manifest.attachment_root, snapshotDir));
-          const attachments = snapshots.length > 0
-            ? await uploadAttachmentPaths(auth.server, auth.token, manifest.channel, snapshots)
-            : undefined;
+          let attachments;
+          try {
+            const snapshots = (attach ?? []).map((path) =>
+              snapshotManagedAttachment(path, manifest.attachment_root, snapshotDir));
+            attachments = snapshots.length > 0
+              ? await uploadAttachmentPaths(auth.server, auth.token, manifest.channel, snapshots)
+              : undefined;
+          } finally {
+            // 快照只为「读取瞬间的字节」服务，上传后即弃——不清会按每 wake 最多 8 个大文件
+            // 的速度吃磁盘（#592 评审）。
+            rmSync(snapshotDir, { recursive: true, force: true });
+          }
           const posted = await postMessage(auth.server, auth.token, manifest.channel, {
             kind: "message",
             body: body.trim(),

--- a/cli/src/commands/mcp-managed.ts
+++ b/cli/src/commands/mcp-managed.ts
@@ -1,0 +1,385 @@
+// party mcp --managed <stateDir> — managed profile lane 的角色裁剪 MCP server（#581 Phase 2）。
+//
+// 与通用 `party mcp` 的分工：那边是 agent 自愿接入的全工具面；这边是 supervisor（party serve
+// --profile）替 front/worker 两条 lane 拉起的受限工具面——「角色即工具集」：模型没有的能力
+// 不需要靠 reminder 禁止（#578 用散文 + 文本信封约束模型的四条缺陷由此消除）。
+//
+// 文件握手（cli/src/managed.ts 是两侧唯一事实源）：
+//   managed.json  lane 清单（attach 时写一次：身份/频道/角色/token config/附件围栏根）
+//   wake.json     当前 wake（supervisor 每回合覆写：frame/delivery/owner 决策绑定）
+//   outcome-<seq>.ndjson  工具 handler 落盘的动作回执，supervisor 回合结束后消费
+//
+// 安全边界（#578 语义不变处）：
+//   - 模型 env 仍是 denied-home（token 不进模型环境）；token 只在本进程读的 config 文件里。
+//   - front 恒禁主机文件附件；worker 附件 realpath 围栏在 channelWorkdir（工具层拒 symlink 逃逸）。
+//   - 派工/返工消息不再带文本前缀：front 的 party_reply 没有 mentions 能力，任何 front @worker
+//     的消息在结构上就只能出自 dispatch/feedback 工具——worker 侧据 delivery 结构化字段验收。
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+import { readFileSync } from "node:fs";
+import { basename } from "node:path";
+import {
+  BODY_LIMIT,
+  DECISION_OPTION_LIMIT,
+  DECISION_OPTIONS_MAX,
+  DECISION_PROMPT_LIMIT,
+  type DecisionResolution,
+  type SendDecisionRequest,
+} from "@agentparty/shared";
+import { stripTerminalControls } from "../format";
+import {
+  appendManagedAction,
+  createManagedLineageResolver,
+  ManagedActionError,
+  readManagedManifest,
+  readManagedWake,
+  resolveManagedAttachmentPath,
+  type ManagedLaneManifest,
+  type ManagedWakeState,
+} from "../managed";
+import { fetchChannelCharter, fetchRecentMessages, postMessage } from "../rest";
+import { uploadAttachmentPaths } from "./send";
+
+const ACTION_TEXT_MAX = BODY_LIMIT - 1024;
+
+function ok(data: Record<string, unknown>, text?: string): CallToolResult {
+  return {
+    content: [{ type: "text", text: stripTerminalControls(text ?? JSON.stringify(data, null, 2)) }],
+    structuredContent: data,
+  };
+}
+
+function fail(message: string): CallToolResult {
+  return {
+    isError: true,
+    content: [{ type: "text", text: stripTerminalControls(message) }],
+  };
+}
+
+interface LaneAuth {
+  server: string;
+  token: string;
+}
+
+function laneAuth(manifest: ManagedLaneManifest): LaneAuth {
+  const raw = JSON.parse(readFileSync(manifest.config, "utf8")) as { server?: string; token?: string };
+  if (typeof raw.token !== "string" || raw.token === "") {
+    throw new ManagedActionError("managed lane token config is missing or empty");
+  }
+  return { server: manifest.server, token: raw.token };
+}
+
+/** 每回合动作幂等闸：同一 wake 内重复调用同名独占动作直接拒，防模型循环刷屏。 */
+const EXCLUSIVE_ACTIONS = new Set(["owner_decision"]);
+
+export function createManagedMcpServer(stateDir: string): McpServer {
+  const manifest = readManagedManifest(stateDir);
+  const role = manifest.role;
+  const server = new McpServer({ name: `agentparty-managed-${role}`, version: "1.0.0" });
+  const seenExclusive = new Map<number, Set<string>>();
+
+  const wake = (): ManagedWakeState => readManagedWake(stateDir);
+  const record = (
+    seq: number,
+    action: "channel_reply" | "worker_dispatch" | "worker_feedback" | "owner_decision" | "worker_report",
+    postedSeq: number,
+    decisionState?: "pending" | "auto_resolved",
+  ) => {
+    appendManagedAction(stateDir, seq, {
+      action,
+      seq: postedSeq,
+      ...(decisionState === undefined ? {} : { decision_state: decisionState }),
+      at: Date.now(),
+    });
+  };
+  // 幂等闸分两步：调用前只查、动作成功后才落标——失败的尝试不许堵死本回合的重试。
+  const assertExclusiveUnused = (seq: number, action: string) => {
+    if (!EXCLUSIVE_ACTIONS.has(action)) return;
+    if (seenExclusive.get(seq)?.has(action) === true) {
+      throw new ManagedActionError(`${action} already issued for this wake`);
+    }
+  };
+  const markExclusive = (seq: number, action: string) => {
+    if (!EXCLUSIVE_ACTIONS.has(action)) return;
+    const seen = seenExclusive.get(seq) ?? new Set<string>();
+    seen.add(action);
+    seenExclusive.set(seq, seen);
+  };
+
+  const lineage = () => {
+    const auth = laneAuth(manifest);
+    return createManagedLineageResolver({
+      server: auth.server,
+      token: auth.token,
+      channel: manifest.channel,
+      frontName: manifest.front,
+      workerName: manifest.worker,
+      ownerAccount: manifest.owner_account,
+    });
+  };
+
+  // ---------- 只读件（两角色都有）：模型每回合重锚用 ----------
+  server.registerTool(
+    "party_charter",
+    {
+      title: "Read channel charter",
+      description: "Read this channel's charter (scope, etiquette, roles). Read it before acting.",
+      inputSchema: {},
+    },
+    async () => {
+      try {
+        const auth = laneAuth(manifest);
+        const body = await fetchChannelCharter(auth.server, auth.token, manifest.channel);
+        return ok({ type: "charter", channel: manifest.channel, ...body });
+      } catch (e) {
+        return fail(e instanceof Error ? e.message : String(e));
+      }
+    },
+  );
+
+  server.registerTool(
+    "party_history",
+    {
+      title: "Read recent channel messages",
+      description: "Read the most recent messages in this channel (read-only).",
+      inputSchema: {
+        limit: z.number().int().positive().max(50).optional().describe("How many recent messages (default 20)."),
+      },
+    },
+    async ({ limit }) => {
+      try {
+        const auth = laneAuth(manifest);
+        const messages = await fetchRecentMessages(auth.server, auth.token, manifest.channel, limit ?? 20);
+        return ok({ type: "history", channel: manifest.channel, messages });
+      } catch (e) {
+        return fail(e instanceof Error ? e.message : String(e));
+      }
+    },
+  );
+
+  if (role === "front") {
+    // ---------- front：频道回复（无 mentions 能力——@worker 只能走 dispatch/feedback） ----------
+    server.registerTool(
+      "party_reply",
+      {
+        title: "Reply in the channel",
+        description:
+          "Post your synthesis/reply to the channel, threaded onto the conversation origin. This is your ONLY way to speak to channel members; it cannot @-mention your worker (use party_worker_dispatch / party_worker_feedback for that).",
+        inputSchema: {
+          body: z.string().min(1).max(ACTION_TEXT_MAX).describe("Reply body (plain prose is fine)."),
+        },
+      },
+      async ({ body }) => {
+        try {
+          const auth = laneAuth(manifest);
+          const state = wake();
+          const origin = await lineage()(state.frame, state.delivery);
+          const replyTo = origin?.seq ?? state.frame.seq;
+          const posted = await postMessage(auth.server, auth.token, manifest.channel, {
+            kind: "message",
+            body: body.trim(),
+            mentions: [],
+            reply_to: replyTo,
+          });
+          // 血缘续接（worker 报告/owner 答复）时补一条 completion status，与文本协议路由同语义。
+          if (origin !== null) {
+            await postMessage(auth.server, auth.token, manifest.channel, {
+              kind: "status",
+              state: "done",
+              note: `front synthesis delivered for seq=${state.frame.seq}`,
+              mentions: [],
+              summary_seq: state.frame.seq,
+            } as Parameters<typeof postMessage>[3]);
+          }
+          record(state.frame.seq, "channel_reply", posted.seq);
+          return ok({ type: "reply", channel: manifest.channel, seq: posted.seq, reply_to: replyTo });
+        } catch (e) {
+          return fail(e instanceof Error ? e.message : String(e));
+        }
+      },
+    );
+
+    // ---------- front：派工 / 返工（结构化：reply_to=origin + mentions=[worker]，无文本前缀） ----------
+    const dispatchLike = (kind: "worker_dispatch" | "worker_feedback") =>
+      async ({ instruction }: { instruction: string }): Promise<CallToolResult> => {
+        try {
+          const auth = laneAuth(manifest);
+          const state = wake();
+          const origin = await lineage()(state.frame, state.delivery);
+          const replyTo = origin?.seq ?? state.frame.seq;
+          const posted = await postMessage(auth.server, auth.token, manifest.channel, {
+            kind: "message",
+            body: instruction.trim(),
+            mentions: [manifest.worker],
+            reply_to: replyTo,
+          });
+          if (origin !== null) {
+            await postMessage(auth.server, auth.token, manifest.channel, {
+              kind: "status",
+              state: "done",
+              note: `front synthesis delivered for seq=${state.frame.seq}`,
+              mentions: [],
+              summary_seq: state.frame.seq,
+            } as Parameters<typeof postMessage>[3]);
+          }
+          record(state.frame.seq, kind, posted.seq);
+          return ok({ type: kind, channel: manifest.channel, seq: posted.seq, worker: manifest.worker, reply_to: replyTo });
+        } catch (e) {
+          return fail(e instanceof Error ? e.message : String(e));
+        }
+      };
+
+    server.registerTool(
+      "party_worker_dispatch",
+      {
+        title: "Dispatch work to your execution worker",
+        description:
+          "Send a work instruction to your execution worker. Code changes, multi-step investigation, and long-running execution MUST go through this tool — you are the control plane and never execute yourself.",
+        inputSchema: { instruction: z.string().min(1).max(ACTION_TEXT_MAX) },
+      },
+      dispatchLike("worker_dispatch"),
+    );
+
+    server.registerTool(
+      "party_worker_feedback",
+      {
+        title: "Ask the worker for fixes / follow-up",
+        description: "Send follow-up or rework instructions to your execution worker about its last report.",
+        inputSchema: { instruction: z.string().min(1).max(ACTION_TEXT_MAX) },
+      },
+      dispatchLike("worker_feedback"),
+    );
+
+    // ---------- front：owner 决策（绑定 responder；binding 未启用 fail closed，同 #578） ----------
+    server.registerTool(
+      "party_decision_ask",
+      {
+        title: "Ask the channel owner for a decision",
+        description:
+          "Ask the human owner to approve or choose. Non-blocking: after this returns pending, END your turn — the owner's answer wakes you later with full context. Do not poll.",
+        inputSchema: {
+          prompt: z.string().min(1).max(DECISION_PROMPT_LIMIT),
+          options: z.array(z.string().min(1).max(DECISION_OPTION_LIMIT)).max(DECISION_OPTIONS_MAX).optional(),
+        },
+      },
+      async ({ prompt, options }) => {
+        try {
+          const auth = laneAuth(manifest);
+          const state = wake();
+          assertExclusiveUnused(state.frame.seq, "owner_decision");
+          if (state.delivery === null || state.delivery.work_id === null || state.delivery.continuation_ref === null) {
+            throw new ManagedActionError("managed owner decision requires an active durable delivery");
+          }
+          if (state.owner_decision_binding !== true) {
+            throw new ManagedActionError(
+              "server does not enforce owner_decision responder binding (owner_decision_binding v1); upgrade the Worker before managed owner decisions",
+            );
+          }
+          if (options !== undefined && options.length === 1) {
+            throw new ManagedActionError("choice decision requires at least 2 options");
+          }
+          const origin = await lineage()(state.frame, state.delivery);
+          const decisionRequest: SendDecisionRequest = options === undefined || options.length === 0
+            ? { kind: "approval", prompt }
+            : { kind: "choice", prompt, options };
+          const payload: Parameters<typeof postMessage>[3] & {
+            expected_decision_lineage?: { delivery_id: string; work_id: string; continuation_ref: string };
+            expected_decision_responder_owner?: string;
+          } = {
+            kind: "message",
+            body: prompt,
+            mentions: [],
+            reply_to: origin?.seq ?? state.frame.seq,
+            decision_request: decisionRequest,
+            expected_decision_lineage: {
+              delivery_id: state.delivery.id,
+              work_id: state.delivery.work_id,
+              continuation_ref: state.delivery.continuation_ref,
+            },
+            expected_decision_responder_owner: manifest.owner_account,
+          };
+          const posted = await postMessage(auth.server, auth.token, manifest.channel, payload);
+          const resolution: DecisionResolution | undefined = posted.decision_resolution;
+          const decisionState = resolution?.state === "auto_resolved" ? "auto_resolved" : "pending";
+          markExclusive(state.frame.seq, "owner_decision");
+          record(state.frame.seq, "owner_decision", posted.seq, decisionState);
+          if (decisionState === "auto_resolved") {
+            return ok(
+              { type: "decision", seq: posted.seq, state: "auto_resolved", chosen_option: resolution?.chosen_option },
+              `decision #${posted.seq} auto_resolved → ${resolution?.chosen_option ?? "?"} (unattended mode). Continue your work in this same turn.`,
+            );
+          }
+          return ok(
+            { type: "decision", seq: posted.seq, state: "waiting_owner" },
+            `decision #${posted.seq} posted; a HUMAN resolves it. END this turn now — the owner's answer arrives as a new wake with continuation context. Do not poll.`,
+          );
+        } catch (e) {
+          return fail(e instanceof Error ? e.message : String(e));
+        }
+      },
+    );
+  }
+
+  if (role === "worker") {
+    // ---------- worker：结构化报告（reply_to=派工消息；附件过 realpath 围栏） ----------
+    server.registerTool(
+      "party_worker_report",
+      {
+        title: "Report back to your front agent",
+        description:
+          "Report your execution result back to the front agent that dispatched you. Attach deliverables (diffs, logs, screenshots) from your channel workspace via `attach` — paths outside the workspace are rejected.",
+        inputSchema: {
+          body: z.string().min(1).max(ACTION_TEXT_MAX).describe("Report body: what you did, evidence, and outcome."),
+          attach: z
+            .array(z.string())
+            .max(8)
+            .optional()
+            .describe("Absolute file paths inside your channel workspace to upload as attachments (max 25MB each)."),
+        },
+      },
+      async ({ body, attach }) => {
+        try {
+          const auth = laneAuth(manifest);
+          const state = wake();
+          // 围栏先行：任何一个路径越界，整个报告不发（与 CLI attach 的整体失败语义一致）。
+          const realPaths = (attach ?? []).map((path) => resolveManagedAttachmentPath(path, manifest.attachment_root));
+          const attachments = realPaths.length > 0
+            ? await uploadAttachmentPaths(auth.server, auth.token, manifest.channel, realPaths)
+            : undefined;
+          const posted = await postMessage(auth.server, auth.token, manifest.channel, {
+            kind: "message",
+            body: body.trim(),
+            mentions: [],
+            reply_to: state.frame.seq,
+            ...(attachments !== undefined && attachments.length > 0 ? { attachments } : {}),
+          });
+          record(state.frame.seq, "worker_report", posted.seq);
+          return ok({
+            type: "worker_report",
+            channel: manifest.channel,
+            seq: posted.seq,
+            reply_to: state.frame.seq,
+            ...(attachments !== undefined
+              ? { attachments: attachments.map((a) => ({ filename: basename(a.filename), size: a.size })) }
+              : {}),
+          });
+        } catch (e) {
+          return fail(e instanceof Error ? e.message : String(e));
+        }
+      },
+    );
+  }
+
+  return server;
+}
+
+export async function runManagedMcp(stateDir: string): Promise<number> {
+  const server = createManagedMcpServer(stateDir);
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  return new Promise<number>((resolve) => {
+    transport.onclose = () => resolve(0);
+  });
+}

--- a/cli/src/commands/mcp-managed.ts
+++ b/cli/src/commands/mcp-managed.ts
@@ -19,7 +19,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
 import { readFileSync } from "node:fs";
-import { basename } from "node:path";
+import { basename, join } from "node:path";
 import {
   BODY_LIMIT,
   DECISION_OPTION_LIMIT,
@@ -33,9 +33,11 @@ import {
   appendManagedAction,
   createManagedLineageResolver,
   ManagedActionError,
+  readManagedActions,
   readManagedManifest,
   readManagedWake,
-  resolveManagedAttachmentPath,
+  snapshotManagedAttachment,
+  type ManagedActionRecord,
   type ManagedLaneManifest,
   type ManagedWakeState,
 } from "../managed";
@@ -74,11 +76,29 @@ function laneAuth(manifest: ManagedLaneManifest): LaneAuth {
 /** 每回合动作幂等闸：同一 wake 内重复调用同名独占动作直接拒，防模型循环刷屏。 */
 const EXCLUSIVE_ACTIONS = new Set(["owner_decision"]);
 
+/**
+ * completion status（血缘续接的收尾遥测，与文本协议路由同语义）：best-effort——
+ * 主动作已发布且已落账，这条失败只以字段回报给模型，绝不抛错诱发主消息重发（#592 评审）。
+ */
+async function postCompletionStatus(auth: LaneAuth, channel: string, summarySeq: number): Promise<string | null> {
+  try {
+    await postMessage(auth.server, auth.token, channel, {
+      kind: "status",
+      state: "done",
+      note: `front synthesis delivered for seq=${summarySeq}`,
+      mentions: [],
+      summary_seq: summarySeq,
+    } as Parameters<typeof postMessage>[3]);
+    return null;
+  } catch (e) {
+    return e instanceof Error ? e.message : String(e);
+  }
+}
+
 export function createManagedMcpServer(stateDir: string): McpServer {
   const manifest = readManagedManifest(stateDir);
   const role = manifest.role;
   const server = new McpServer({ name: `agentparty-managed-${role}`, version: "1.0.0" });
-  const seenExclusive = new Map<number, Set<string>>();
 
   const wake = (): ManagedWakeState => readManagedWake(stateDir);
   const record = (
@@ -94,18 +114,15 @@ export function createManagedMcpServer(stateDir: string): McpServer {
       at: Date.now(),
     });
   };
-  // 幂等闸分两步：调用前只查、动作成功后才落标——失败的尝试不许堵死本回合的重试。
-  const assertExclusiveUnused = (seq: number, action: string) => {
+  // 幂等闸以 outcome 回执为事实源（持久）：codex 每次 exec 都 spawn 新 MCP 进程，内存态跨
+  // 回合恒空；supervisor 在每个新 wake 的 prepare 里清同 seq 回执，所以这里读到的记录一定
+  // 属于当前回合。失败的尝试不落回执，天然不堵重试；post 成功与 record 落盘之间的崩溃窗口
+  // 存在但极窄（且该回合会因 runner 崩溃按非可重试处理，不会自动重放）。
+  const assertExclusiveUnused = (seq: number, action: ManagedActionRecord["action"]) => {
     if (!EXCLUSIVE_ACTIONS.has(action)) return;
-    if (seenExclusive.get(seq)?.has(action) === true) {
+    if (readManagedActions(stateDir, seq).some((record) => record.action === action)) {
       throw new ManagedActionError(`${action} already issued for this wake`);
     }
-  };
-  const markExclusive = (seq: number, action: string) => {
-    if (!EXCLUSIVE_ACTIONS.has(action)) return;
-    const seen = seenExclusive.get(seq) ?? new Set<string>();
-    seen.add(action);
-    seenExclusive.set(seq, seen);
   };
 
   const lineage = () => {
@@ -183,18 +200,17 @@ export function createManagedMcpServer(stateDir: string): McpServer {
             mentions: [],
             reply_to: replyTo,
           });
-          // 血缘续接（worker 报告/owner 答复）时补一条 completion status，与文本协议路由同语义。
-          if (origin !== null) {
-            await postMessage(auth.server, auth.token, manifest.channel, {
-              kind: "status",
-              state: "done",
-              note: `front synthesis delivered for seq=${state.frame.seq}`,
-              mentions: [],
-              summary_seq: state.frame.seq,
-            } as Parameters<typeof postMessage>[3]);
-          }
+          // 主动作先落账（回执=幂等事实源）；completion status 是可观测性增益，失败绝不能把
+          // 已发布的主消息变成「可重试失败」诱发重复发布（#592 评审）。
           record(state.frame.seq, "channel_reply", posted.seq);
-          return ok({ type: "reply", channel: manifest.channel, seq: posted.seq, reply_to: replyTo });
+          const completionError = origin === null ? null : await postCompletionStatus(auth, manifest.channel, state.frame.seq);
+          return ok({
+            type: "reply",
+            channel: manifest.channel,
+            seq: posted.seq,
+            reply_to: replyTo,
+            ...(completionError === null ? {} : { completion_status_error: completionError }),
+          });
         } catch (e) {
           return fail(e instanceof Error ? e.message : String(e));
         }
@@ -215,17 +231,16 @@ export function createManagedMcpServer(stateDir: string): McpServer {
             mentions: [manifest.worker],
             reply_to: replyTo,
           });
-          if (origin !== null) {
-            await postMessage(auth.server, auth.token, manifest.channel, {
-              kind: "status",
-              state: "done",
-              note: `front synthesis delivered for seq=${state.frame.seq}`,
-              mentions: [],
-              summary_seq: state.frame.seq,
-            } as Parameters<typeof postMessage>[3]);
-          }
           record(state.frame.seq, kind, posted.seq);
-          return ok({ type: kind, channel: manifest.channel, seq: posted.seq, worker: manifest.worker, reply_to: replyTo });
+          const completionError = origin === null ? null : await postCompletionStatus(auth, manifest.channel, state.frame.seq);
+          return ok({
+            type: kind,
+            channel: manifest.channel,
+            seq: posted.seq,
+            worker: manifest.worker,
+            reply_to: replyTo,
+            ...(completionError === null ? {} : { completion_status_error: completionError }),
+          });
         } catch (e) {
           return fail(e instanceof Error ? e.message : String(e));
         }
@@ -261,7 +276,7 @@ export function createManagedMcpServer(stateDir: string): McpServer {
           "Ask the human owner to approve or choose. Non-blocking: after this returns pending, END your turn — the owner's answer wakes you later with full context. Do not poll.",
         inputSchema: {
           prompt: z.string().min(1).max(DECISION_PROMPT_LIMIT),
-          options: z.array(z.string().min(1).max(DECISION_OPTION_LIMIT)).max(DECISION_OPTIONS_MAX).optional(),
+          options: z.array(z.string().min(1).max(DECISION_OPTION_LIMIT)).max(DECISION_OPTIONS_MAX).nullable().optional(),
         },
       },
       async ({ prompt, options }) => {
@@ -277,13 +292,15 @@ export function createManagedMcpServer(stateDir: string): McpServer {
               "server does not enforce owner_decision responder binding (owner_decision_binding v1); upgrade the Worker before managed owner decisions",
             );
           }
-          if (options !== undefined && options.length === 1) {
+          // null / 缺省 / 空数组统一按 approval（#578 finding 1 的 schema-合法输出绝不再被拒）。
+          const normalizedOptions = options ?? [];
+          if (normalizedOptions.length === 1) {
             throw new ManagedActionError("choice decision requires at least 2 options");
           }
           const origin = await lineage()(state.frame, state.delivery);
-          const decisionRequest: SendDecisionRequest = options === undefined || options.length === 0
+          const decisionRequest: SendDecisionRequest = normalizedOptions.length === 0
             ? { kind: "approval", prompt }
-            : { kind: "choice", prompt, options };
+            : { kind: "choice", prompt, options: normalizedOptions };
           const payload: Parameters<typeof postMessage>[3] & {
             expected_decision_lineage?: { delivery_id: string; work_id: string; continuation_ref: string };
             expected_decision_responder_owner?: string;
@@ -303,7 +320,6 @@ export function createManagedMcpServer(stateDir: string): McpServer {
           const posted = await postMessage(auth.server, auth.token, manifest.channel, payload);
           const resolution: DecisionResolution | undefined = posted.decision_resolution;
           const decisionState = resolution?.state === "auto_resolved" ? "auto_resolved" : "pending";
-          markExclusive(state.frame.seq, "owner_decision");
           record(state.frame.seq, "owner_decision", posted.seq, decisionState);
           if (decisionState === "auto_resolved") {
             return ok(
@@ -343,10 +359,13 @@ export function createManagedMcpServer(stateDir: string): McpServer {
         try {
           const auth = laneAuth(manifest);
           const state = wake();
-          // 围栏先行：任何一个路径越界，整个报告不发（与 CLI attach 的整体失败语义一致）。
-          const realPaths = (attach ?? []).map((path) => resolveManagedAttachmentPath(path, manifest.attachment_root));
-          const attachments = realPaths.length > 0
-            ? await uploadAttachmentPaths(auth.server, auth.token, manifest.channel, realPaths)
+          // 围栏 + TOCTOU 快照先行：校验后立刻以 O_NOFOLLOW fd 读出字节、落到 supervisor 私有
+          // 目录再上传——任何一个路径越界或非普通文件，整个报告不发（#592 评审）。
+          const snapshotDir = join(stateDir, `attach-${state.frame.seq}`);
+          const snapshots = (attach ?? []).map((path) =>
+            snapshotManagedAttachment(path, manifest.attachment_root, snapshotDir));
+          const attachments = snapshots.length > 0
+            ? await uploadAttachmentPaths(auth.server, auth.token, manifest.channel, snapshots)
             : undefined;
           const posted = await postMessage(auth.server, auth.token, manifest.channel, {
             kind: "message",

--- a/cli/src/commands/mcp.ts
+++ b/cli/src/commands/mcp.ts
@@ -1139,6 +1139,16 @@ export async function run(argv: string[]): Promise<number> {
     console.log(HELP);
     return 0;
   }
+  // --managed <stateDir>：supervisor（party serve --profile）替 managed lane 拉起的角色裁剪
+  // 工具面（#581 Phase 2），与通用工具面互斥——见 cli/src/commands/mcp-managed.ts。
+  if (argv[0] === "--managed") {
+    if (argv.length !== 2 || argv[1] === undefined || argv[1] === "") {
+      console.error("usage: party mcp --managed <stateDir>");
+      return 1;
+    }
+    const { runManagedMcp } = await import("./mcp-managed");
+    return runManagedMcp(argv[1]);
+  }
   let defaultChannel: string | undefined;
   if (argv.length === 2 && argv[0] === "--channel") {
     defaultChannel = argv[1];

--- a/cli/src/commands/mcp.ts
+++ b/cli/src/commands/mcp.ts
@@ -1142,7 +1142,8 @@ export async function run(argv: string[]): Promise<number> {
   // --managed <stateDir>：supervisor（party serve --profile）替 managed lane 拉起的角色裁剪
   // 工具面（#581 Phase 2），与通用工具面互斥——见 cli/src/commands/mcp-managed.ts。
   if (argv[0] === "--managed") {
-    if (argv.length !== 2 || argv[1] === undefined || argv[1] === "") {
+    // "-" 开头（含 "--" 终止符）不是目录：当缺参报错，别去打开一个叫 "--" 的目录。
+    if (argv.length !== 2 || argv[1] === undefined || argv[1] === "" || argv[1].startsWith("-")) {
       console.error("usage: party mcp --managed <stateDir>");
       return 1;
     }

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -6,6 +6,7 @@ import { createHash, randomUUID } from "node:crypto";
 import { downloadPartyUpgrade, isPartyBinaryPath, maybeReexecUpgrade, serverVersionUpgradeNotice, upgradeNotice, type CliUpgradeNotice, type UpgradeDeps } from "../upgrade";
 import {
   clearManagedActions,
+  clearManagedExclusiveLocks,
   MANAGED_CONFIG_FILE,
   readManagedActions,
   writeManagedManifest,
@@ -2300,6 +2301,7 @@ export function createBuiltinRunner(opts: BuiltinRunnerOptions): NonNullable<Ser
       // 消息编辑会复用原 seq 但产生新 delivery：新回合开工前清同 seq 的历史回执，
       // 旧动作绝不能替新回合的零动作充数（#592 评审）。
       clearManagedActions(opts.managedMcp.stateDir, frame.seq);
+      clearManagedExclusiveLocks(opts.managedMcp.stateDir, frame.seq);
       writeManagedWake(opts.managedMcp.stateDir, {
         version: 1,
         seq: frame.seq,

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -5,6 +5,7 @@ import { BODY_LIMIT, DECISION_OPTION_LIMIT, DECISION_OPTIONS_MAX, DECISION_PROMP
 import { createHash, randomUUID } from "node:crypto";
 import { downloadPartyUpgrade, isPartyBinaryPath, maybeReexecUpgrade, serverVersionUpgradeNotice, upgradeNotice, type CliUpgradeNotice, type UpgradeDeps } from "../upgrade";
 import {
+  clearManagedActions,
   MANAGED_CONFIG_FILE,
   readManagedActions,
   writeManagedManifest,
@@ -2296,6 +2297,9 @@ export function createBuiltinRunner(opts: BuiltinRunnerOptions): NonNullable<Ser
     // #581 managed MCP：每个 wake 前覆写 wake.json——工具 handler 即读即用，天然跟上当前 wake；
     // owner 决策绑定取 welcome 声明的当前值（prepare 必在 welcome 之后）。
     if (opts.managedMcp !== undefined) {
+      // 消息编辑会复用原 seq 但产生新 delivery：新回合开工前清同 seq 的历史回执，
+      // 旧动作绝不能替新回合的零动作充数（#592 评审）。
+      clearManagedActions(opts.managedMcp.stateDir, frame.seq);
       writeManagedWake(opts.managedMcp.stateDir, {
         version: 1,
         seq: frame.seq,

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -3,7 +3,13 @@
 // 复用 client.connect 的自动重连帧流，真正常驻；命令串行执行（一条处理完再下一条，不并发抢跑）。
 import { BODY_LIMIT, DECISION_OPTION_LIMIT, DECISION_OPTIONS_MAX, DECISION_PROMPT_LIMIT, EXIT_ARCHIVED, EXIT_AUTH, EXIT_STREAM_ENDED, EXIT_UPGRADED, type AgentSessionInfo, type Attachment, type DeliveryUpdateFrame, type DirectedDelivery, type MsgFrame, type PublicDirectedDelivery, type SendDecisionRequest, type ServerFrame } from "@agentparty/shared";
 import { createHash, randomUUID } from "node:crypto";
-import { downloadPartyUpgrade, maybeReexecUpgrade, serverVersionUpgradeNotice, upgradeNotice, type CliUpgradeNotice, type UpgradeDeps } from "../upgrade";
+import { downloadPartyUpgrade, isPartyBinaryPath, maybeReexecUpgrade, serverVersionUpgradeNotice, upgradeNotice, type CliUpgradeNotice, type UpgradeDeps } from "../upgrade";
+import {
+  MANAGED_CONFIG_FILE,
+  readManagedActions,
+  writeManagedManifest,
+  writeManagedWake,
+} from "../managed";
 import {
   appendFileSync,
   existsSync,
@@ -73,10 +79,26 @@ const WORKER_REMINDER =
   " 你是 execution worker，不是频道 front。只执行这条有界派工，不再派生其它 agent；完成必要的代码、调查、浏览器或运维工作，并返回证据、风险和验收结果。" +
   " 不要调用 party CLI，也不要直接面向人做最终承诺；supervisor 会把你的回报作为执行记录送回 front，由 front 汇总。";
 
+// #581 Phase 2：MCP 协议 lane 的提醒——动作面即工具面，模型文本输出只进日志。
+const MANAGED_FRONT_MCP_REMINDER =
+  " 你是 managed front agent，是三个方向的通信与调度控制面：对频道交流、对 owner 请求决定、对子 worker 派工/追问/验收；执行 worker 已由 supervisor 独立常驻。你没有执行面权限，也不要调用 party CLI。" +
+  " 一切频道动作都必须通过 party MCP 工具完成：对频道简短交流或 worker 回报汇总用 party_reply；" +
+  " 代码修改、多步排查、浏览器/运维或其它耗时工作用 party_worker_dispatch（instruction 必须自包含：完整任务、范围和验收标准）；需要返工/补证据用 party_worker_feedback；" +
+  " 需要 owner 做权限、取舍或批准用 party_decision_ask（返回 waiting_owner 就结束本轮，owner 的答复会带上下文再次唤醒你）。" +
+  " 你的自由文本输出不会进频道（只进日志）；没有任何工具调用的回合会被判定为未送达。";
+
+const WORKER_MCP_REMINDER =
+  " 你是 execution worker，不是频道 front。只执行这条有界派工，不再派生其它 agent；完成必要的代码、调查、浏览器或运维工作。" +
+  " 完成后必须调用 party MCP 工具 party_worker_report 回报证据、风险和验收结果（交付物用 attach 从频道工作区上传）；" +
+  " 你的自由文本输出不会进频道（只进日志），不调用 party_worker_report 的回合会被判定为未送达。不要调用 party CLI。";
+
 function protocolReminder(projectAgent: ProjectAgentRunContext | null): string {
-  if (projectAgent?.runtime_role === "worker") return COMMON_PROTOCOL_REMINDER + WORKER_REMINDER;
+  const mcp = projectAgent?.protocol === "mcp";
+  if (projectAgent?.runtime_role === "worker") {
+    return COMMON_PROTOCOL_REMINDER + (mcp ? WORKER_MCP_REMINDER : WORKER_REMINDER);
+  }
   if (projectAgent?.runtime_role === "front" && projectAgent.workers.length > 0) {
-    return COMMON_PROTOCOL_REMINDER + MANAGED_FRONT_REMINDER;
+    return COMMON_PROTOCOL_REMINDER + (mcp ? MANAGED_FRONT_MCP_REMINDER : MANAGED_FRONT_REMINDER);
   }
   return COMMON_PROTOCOL_REMINDER + ADVISORY_FRONT_REMINDER;
 }
@@ -514,6 +536,11 @@ export interface BuiltinRunnerOptions {
   outputSchema?: Record<string, unknown>;
   /** null disables host-file markers; a path confines them to that real workspace tree. */
   attachmentRoot?: string | null;
+  /**
+   * #581：managed MCP 协议 lane。runner 给 harness 注入 `party mcp --managed <stateDir>`
+   * 的角色裁剪工具面；每个 wake 前 supervisor 写 wake.json，回合结束读动作回执结算。
+   */
+  managedMcp?: { stateDir: string; ownerDecisionBinding: () => boolean };
   repo?: string;
   runProcess?: RunnerProcess;
   runGit?: RunnerProcess;
@@ -582,6 +609,8 @@ export interface ProjectAgentRunContext {
   rules: string | null;
   /** managed profile 的控制面/执行面角色；普通 serve 不设置。 */
   runtime_role: ServeExecutionRole;
+  /** #581：managed lane 协议。mcp=动作走角色裁剪的 MCP 工具；缺省按 text（旧文本信封）处理。 */
+  protocol?: "mcp" | "text";
   /** 本频道的可对话 front identity。 */
   front_agent: string;
   /** supervisor 已启动、可接 durable delivery 的 execution workers。 */
@@ -785,6 +814,26 @@ function isolatedModelPartyEnv(workdir: string, server: string): Record<string, 
   };
 }
 
+// #581：给 harness 注入的 party 可执行体。编译版直接用自身路径（不受 PATH 漂移影响）；
+// dev（bun test）下回落 PATH 上的 party。
+export function managedPartyBinary(): string {
+  return isPartyBinaryPath(process.execPath) ? process.execPath : "party";
+}
+
+// #581：claude --mcp-config 只认文件/JSON 串；写进 stateDir（0700）与其余 managed 握手文件同处。
+function writeManagedClaudeMcpConfig(stateDir: string): string {
+  const path = join(stateDir, "mcp-config.json");
+  mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+  writeFileSync(
+    path,
+    JSON.stringify({
+      mcpServers: { party: { command: managedPartyBinary(), args: ["mcp", "--managed", stateDir] } },
+    }) + "\n",
+    { mode: 0o600 },
+  );
+  return path;
+}
+
 function writeRunnerOutputSchema(workdir: string, schema: Record<string, unknown>): string {
   const path = join(workdir, "runner-output-schema.json");
   mkdirSync(workdir, { recursive: true, mode: 0o700 });
@@ -817,7 +866,7 @@ export function defaultRunnerWorkdir(channel: string, namespace: string): string
   return runnerWorkdir(join(stateRoot, "runners"), channel, namespace);
 }
 
-const SERVE_FLAGS = ["channel", "on-mention", "all", "runner", "workdir", "repo", "auto-upgrade", "replay-backlog", "profile", "profile-once", "profile-poll-interval", "runner-timeout-seconds"];
+const SERVE_FLAGS = ["channel", "on-mention", "all", "runner", "workdir", "repo", "auto-upgrade", "replay-backlog", "profile", "profile-once", "profile-poll-interval", "runner-timeout-seconds", "protocol"];
 const HELP = `usage: party serve [channel|--channel C] (--on-mention "<cmd>" | --runner codex|claude|codex-sdk) [--all]
        party serve --profile <owner>/<handle>
 
@@ -836,6 +885,8 @@ Options:
   --runner-timeout-seconds N
                        terminate one stuck runner after N seconds (default: ${DEFAULT_RUNNER_TIMEOUT_MS / 1000})
   --profile ref        run the reusable project-agent profile as one resident daemon across all invites
+  --protocol mcp|text  managed lane protocol (default mcp: role-trimmed party MCP tools; text is a
+                       deprecated escape hatch kept for one minor cycle)
   --auto-upgrade       between wakes, if a newer party binary is on disk, re-exec it (issue #45)
   --replay-backlog     on attach, replay the offline backlog one wake per message
                        (default: skip the backlog, advance the cursor, and print
@@ -1730,11 +1781,20 @@ async function runHarness(
     const schemaArgs = opts.outputSchema === undefined
       ? []
       : ["--output-schema", writeRunnerOutputSchema(opts.workdir, opts.outputSchema)];
+    // #581：注入角色裁剪的 party MCP server。command/args 都是 TOML 字面量，路径经 JSON.stringify
+    // 得到合法 TOML basic string；server 自身从 stateDir 读清单/凭据，不需要 env。
+    const mcpArgs = opts.managedMcp === undefined
+      ? []
+      : [
+          "-c", `mcp_servers.party.command=${JSON.stringify(managedPartyBinary())}`,
+          "-c", `mcp_servers.party.args=["mcp","--managed",${JSON.stringify(opts.managedMcp.stateDir)}]`,
+        ];
     const flags = [
       "--skip-git-repo-check",
       "--sandbox",
       opts.sandbox ?? "workspace-write",
       ...schemaArgs,
+      ...mcpArgs,
       "-o",
       outFile,
     ];
@@ -1759,8 +1819,17 @@ async function runHarness(
   const permissionArgs = opts.sandbox === "read-only" ? ["--permission-mode", "plan"] : [];
   const schemaArgs = opts.outputSchema === undefined ? [] : ["--json-schema", JSON.stringify(opts.outputSchema)];
   const jsonOutputArgs = opts.outputSchema === undefined ? [] : ["--output-format", "json"];
+  // #581：--strict-mcp-config 只用注入的 server（隔离用户全局 MCP 配置）；
+  // --allowedTools mcp__party 放行整个 party server 的工具，headless 下不弹权限。
+  const mcpArgs = opts.managedMcp === undefined
+    ? []
+    : [
+        "--mcp-config", writeManagedClaudeMcpConfig(opts.managedMcp.stateDir),
+        "--strict-mcp-config",
+        "--allowedTools", "mcp__party",
+      ];
   const args = sid
-    ? ["claude", "-p", "--disallowed-tools", "AskUserQuestion", ...permissionArgs, ...schemaArgs, ...jsonOutputArgs, "--resume", sid, prompt]
+    ? ["claude", "-p", "--disallowed-tools", "AskUserQuestion", ...permissionArgs, ...schemaArgs, ...jsonOutputArgs, ...mcpArgs, "--resume", sid, prompt]
     : [
         "claude",
         "-p",
@@ -1768,6 +1837,7 @@ async function runHarness(
         "AskUserQuestion",
         ...permissionArgs,
         ...schemaArgs,
+        ...mcpArgs,
         "--session-id",
         coldSessionId!,
         "--output-format",
@@ -2223,6 +2293,24 @@ export function createBuiltinRunner(opts: BuiltinRunnerOptions): NonNullable<Ser
       AP_CONTINUATION_REF: ctx.delivery?.continuation_ref ?? "",
       AP_DELIVERY_ATTEMPT: ctx.delivery ? String(ctx.delivery.attempt) : "",
     };
+    // #581 managed MCP：每个 wake 前覆写 wake.json——工具 handler 即读即用，天然跟上当前 wake；
+    // owner 决策绑定取 welcome 声明的当前值（prepare 必在 welcome 之后）。
+    if (opts.managedMcp !== undefined) {
+      writeManagedWake(opts.managedMcp.stateDir, {
+        version: 1,
+        seq: frame.seq,
+        frame,
+        delivery: ctx.delivery
+          ? {
+              id: ctx.delivery.id,
+              cause: ctx.delivery.cause,
+              work_id: ctx.delivery.work_id,
+              continuation_ref: ctx.delivery.continuation_ref,
+            }
+          : null,
+        owner_decision_binding: opts.managedMcp.ownerDecisionBinding(),
+      });
+    }
     // Clone/pull and continuation validation are model-free and can be slow. They must finish while
     // the durable delivery is still only `claimed`; a crash here is safe for the Worker to requeue.
     const repoCwd = await ensureRepo(opts, env, ctx.signal);
@@ -2340,6 +2428,23 @@ export function createBuiltinRunner(opts: BuiltinRunnerOptions): NonNullable<Ser
           workdir: opts.workdir,
         });
 
+        // #581 managed MCP：动作已由工具即时落频道，文本输出只进日志。这里只验收「本回合
+        // 至少发生一个频道动作」——零动作=未送达（WakeBlockedError，不推游标不吞 @）。
+        // auto-decision 续跑循环也随之退役：unattended 决策在工具返回里就地续行，同一回合完成。
+        if (opts.managedMcp !== undefined) {
+          const actions = readManagedActions(opts.managedMcp.stateDir, frame.seq);
+          appendRunnerLog(
+            opts.workdir,
+            `${new Date(now).toISOString()} seq=${frame.seq} sid=${shortSid(finalSid)} duration_ms=${now - started} exit=${exitCode ?? 0} mcp_actions=${actions.length} text_bytes=${Buffer.byteLength(run.text, "utf8")}`,
+          );
+          if (actions.length === 0) {
+            throw new WakeBlockedError(
+              "managed mcp runner made no channel action: every channel effect must be a party MCP tool call (party_reply / party_worker_dispatch / party_worker_feedback / party_decision_ask / party_worker_report); free-text output is logged only",
+              false,
+            );
+          }
+          break;
+        }
         const marker = oldSid ? null : `[session start: ${shortSid(finalSid)}]`;
         let outcome: RunnerDeliveryOutcome;
         try {
@@ -2545,6 +2650,11 @@ export function profileChildServeOptions(base: {
 }
 
 export interface ProfileServeOptions {
+  /**
+   * #581：managed lane 协议。mcp（默认）=角色裁剪的 MCP 工具面；text=旧文本信封（deprecated，
+   * 保留一个 minor 周期作为逃生舱）。codex-sdk runner 本期尚无 MCP 注入面，强制走 text。
+   */
+  protocol?: "mcp" | "text";
   /** 由 --replay-backlog 决定；透传给每个频道的子 serve。 */
   skipBacklog?: boolean;
   server: string;
@@ -2574,9 +2684,10 @@ export interface ProfileServeOptions {
 function profileContext(
   profile: ProjectAgentProfile,
   prepared: PreparedProfileWorkspace,
-  runtime: { role: ServeExecutionRole; frontAgent: string; workers: readonly string[] },
+  runtime: { role: ServeExecutionRole; frontAgent: string; workers: readonly string[]; protocol?: "mcp" | "text" },
 ): ProjectAgentRunContext {
   return {
+    ...(runtime.protocol === undefined ? {} : { protocol: runtime.protocol }),
     owner_account: profile.owner_account,
     handle: profile.handle,
     name: profile.name,
@@ -2657,6 +2768,8 @@ function boundedActionText(value: unknown, field: string, maxBytes = BODY_LIMIT 
   return text;
 }
 
+// DEPRECATED（#581）：text 信封协议的解析器，仅 --protocol text 逃生舱使用，
+// 保留一个 minor 周期后与 MANAGED_FRONT_OUTPUT_SCHEMA / formatWorkerEnvelope / 前缀比对一并删除。
 export function parseManagedFrontAction(text: string): ManagedFrontAction {
   let raw: unknown;
   try {
@@ -2785,13 +2898,16 @@ function formatWorkerEnvelope(
   return `${verb} ${worker}${lineage}：${instruction}`;
 }
 
-function assertManagedWorkerWake(
+export function assertManagedWorkerWake(
   frame: MsgFrame,
   delivery: DirectedDelivery | null,
   projectAgent: ProjectAgentRunContext | null,
   self: string,
 ): void {
   if (projectAgent?.runtime_role !== "worker") return;
+  // #581 mcp 协议：验收纯结构化。front 的 party_reply 没有 mentions 能力，任何 front @worker 的
+  // 消息在结构上只能出自 dispatch/feedback 工具——文本前缀比对（#578 finding 3 的根源）不再参与。
+  const structuralOnly = projectAgent.protocol === "mcp";
   const dispatchPrefix = `${WORKER_DISPATCH_VERB} ${self}：`;
   const feedbackPrefix = `${WORKER_FEEDBACK_VERB} ${self}`;
   const feedbackSeparator = frame.body.indexOf("：", feedbackPrefix.length);
@@ -2812,7 +2928,7 @@ function assertManagedWorkerWake(
     frame.sender.owner !== projectAgent.owner_account ||
     frame.reply_to === null ||
     !frame.mentions.includes(self) ||
-    (!routedDispatch && !routedFeedback)
+    (!structuralOnly && !routedDispatch && !routedFeedback)
   ) {
     throw new ManagedWorkerUndispatchedError(
       `managed worker rejected unverified wake: expected dispatch/feedback from ${projectAgent.front_agent} owned by ${projectAgent.owner_account}`,
@@ -3104,11 +3220,13 @@ export async function runProfileServe(opts: ProfileServeOptions): Promise<number
       role: "front",
       frontAgent: front.name,
       workers: [worker.name],
+      protocol: profile.runner === "codex-sdk" ? "text" : opts.protocol ?? "mcp",
     });
     const workerContext = profileContext(profile, workerPrepared, {
       role: "worker",
       frontAgent: front.name,
       workers: [],
+      protocol: profile.runner === "codex-sdk" ? "text" : opts.protocol ?? "mcp",
     });
     // Managed child tokens are supervisor capabilities and stay memory-only.  Cursor/debt helpers
     // need only a stable namespace key; writing a real AgentParty config would let the model find
@@ -3126,6 +3244,16 @@ export async function runProfileServe(opts: ProfileServeOptions): Promise<number
       ? (ms: number) => delayWithAbort(ms, channelSignal)
       : (ms: number) => awaitWithAbort(injectedSleep(ms), channelSignal);
 
+    // #581：协议分流。codex-sdk 本期没有 MCP 注入面，强制 text；builtin 默认 mcp。
+    const requestedProtocol = opts.protocol ?? "mcp";
+    const laneProtocol: "mcp" | "text" = profile.runner === "codex-sdk" ? "text" : requestedProtocol;
+    if (laneProtocol === "text") {
+      out(
+        profile.runner === "codex-sdk" && requestedProtocol === "mcp"
+          ? `profile #${channel}: codex-sdk runner has no MCP injection surface yet; falling back to the deprecated text envelope protocol`
+          : `profile #${channel}: text envelope protocol is DEPRECATED and will be removed after one minor cycle; drop --protocol text to use MCP tools`,
+      );
+    }
     const buildLane = (
       role: ServeExecutionRole,
       principal: ProjectAgentChannelRuntime,
@@ -3135,9 +3263,34 @@ export async function runProfileServe(opts: ProfileServeOptions): Promise<number
     ): ServeOptions => {
       // 升级迁移只对 front lane（频道对话的继承者）做一次：迁旧游标/欠账 + 清旧自由文本会话（#7/#10）。
       if (role === "front") migrateLegacyProfileFrontLane(channel, stateKey, prepared.runnerWorkdir);
+      // #581 managed MCP：lane 清单 + child token config 落到 runnerWorkdir/mcp（0600）。
+      // 注意这是 #578「child token 纯内存」边界的有意放宽（issue #581 拍板）：MCP server 进程
+      // 要持有身份就必须能读到它；模型 env 仍是 denied-home，token 不进模型环境。
+      const mcpStateDir = join(prepared.runnerWorkdir, "mcp");
+      if (laneProtocol === "mcp") {
+        writeManagedManifest(mcpStateDir, {
+          version: 1,
+          server: opts.server,
+          channel,
+          role,
+          self: principal.name,
+          front: front.name,
+          worker: worker.name,
+          owner_account: profile.owner_account,
+          config: join(mcpStateDir, MANAGED_CONFIG_FILE),
+          attachment_root: role === "worker" ? prepared.channelWorkdir : null,
+        });
+        writeFileSync(
+          join(mcpStateDir, MANAGED_CONFIG_FILE),
+          JSON.stringify({ server: opts.server, token: principal.token }) + "\n",
+          { mode: 0o600 },
+        );
+      }
       // 每个 welcome 刷新一次；owner 决策路由在 wake（必在 welcome 之后）里读它决定能否发决策。
       let serverOwnerDecisionBinding = false;
-      const resultRoute = role === "front"
+      const resultRoute = laneProtocol === "mcp"
+        ? undefined
+        : role === "front"
         ? createManagedFrontResultRoute({
             server: opts.server,
             token: principal.token,
@@ -3229,8 +3382,16 @@ export async function runProfileServe(opts: ProfileServeOptions): Promise<number
               isolateModelPartyAccess: true,
               sandbox: role === "front" ? "read-only" : "workspace-write",
               resultRoute,
-              outputSchema: role === "front" ? MANAGED_FRONT_OUTPUT_SCHEMA : undefined,
+              outputSchema: laneProtocol === "mcp" ? undefined : role === "front" ? MANAGED_FRONT_OUTPUT_SCHEMA : undefined,
               attachmentRoot: role === "front" ? null : prepared.channelWorkdir,
+              ...(laneProtocol === "mcp"
+                ? {
+                    managedMcp: {
+                      stateDir: mcpStateDir,
+                      ownerDecisionBinding: () => serverOwnerDecisionBinding,
+                    },
+                  }
+                : {}),
             }
           : undefined,
         sdkRunner: profile.runner === "codex-sdk"
@@ -4609,7 +4770,7 @@ export async function run(argv: string[]): Promise<number> {
     console.error(unknown);
     return 1;
   }
-  const flagError = valueFlagError(flags, ["channel", "on-mention", "runner", "workdir", "repo", "profile", "profile-poll-interval", "runner-timeout-seconds"]);
+  const flagError = valueFlagError(flags, ["channel", "on-mention", "runner", "workdir", "repo", "profile", "profile-poll-interval", "runner-timeout-seconds", "protocol"]);
   if (flagError !== null) {
     console.error(flagError);
     return 1;
@@ -4651,6 +4812,12 @@ export async function run(argv: string[]): Promise<number> {
       console.error("--profile-poll-interval must be an integer >= 500 milliseconds");
       return 1;
     }
+    // #581：managed lane 协议开关。默认 mcp；text 是一个 minor 周期的逃生舱（deprecated）。
+    const protocolFlag = str(flags.protocol);
+    if (protocolFlag !== undefined && protocolFlag !== "mcp" && protocolFlag !== "text") {
+      console.error("--protocol must be mcp or text");
+      return 1;
+    }
     const autoDownloadUpgrade = flags["auto-upgrade"] === true;
     const availableUpgrade = await resolveAvailableUpgrade(account.session.server, null, {
       autoDownload: autoDownloadUpgrade,
@@ -4672,6 +4839,7 @@ export async function run(argv: string[]): Promise<number> {
       once: flags["profile-once"] === true,
       pollIntervalMs,
       runnerTimeoutMs,
+      ...(protocolFlag === undefined ? {} : { protocol: protocolFlag }),
     });
   }
   if ((cmd ? 1 : 0) + (runner ? 1 : 0) !== 1) {

--- a/cli/src/managed.ts
+++ b/cli/src/managed.ts
@@ -1,0 +1,215 @@
+// Managed profile lane（#578 front/worker 双 lane）的共享件（#581 Phase 2）：
+// supervisor（serve）与角色裁剪的 MCP server（party mcp --managed）之间的文件握手协议、
+// front 血缘解析、worker 附件工作区围栏。serve.ts 与 mcp-managed.ts 都从这里取——
+// 生产/消费两侧的事实源只有这一份（#578 的教训：前缀协议两侧相隔百行，改一侧全线挂）。
+import { appendFileSync, mkdirSync, readFileSync, realpathSync, statSync, writeFileSync } from "node:fs";
+import { isAbsolute, join, relative, sep } from "node:path";
+import type { MsgFrame } from "@agentparty/shared";
+import { fetchMessages } from "./rest";
+
+/** 供 MCP server 每次工具调用即读的 lane 清单（attach 时写一次）。 */
+export interface ManagedLaneManifest {
+  version: 1;
+  server: string;
+  channel: string;
+  role: "front" | "worker";
+  /** 本 lane 的 child identity 名。 */
+  self: string;
+  front: string;
+  worker: string;
+  owner_account: string;
+  /** child token config 的绝对路径（0600，supervisor 写）。 */
+  config: string;
+  /** worker 附件围栏根；front 恒 null（禁主机文件附件，#578 边界不变）。 */
+  attachment_root: string | null;
+}
+
+/** 每个 wake 开始前由 supervisor 覆写；工具调用即读即用，天然跟上当前 wake。 */
+export interface ManagedWakeState {
+  version: 1;
+  seq: number;
+  frame: MsgFrame;
+  delivery: { id: string; cause: string; work_id: string | null; continuation_ref: string | null } | null;
+  /** welcome 声明的 owner 决策应答人绑定；false 时 front 决策工具 fail closed（同 #578 语义）。 */
+  owner_decision_binding: boolean;
+}
+
+/** 工具 handler 落盘、supervisor 回合结束后消费的动作回执（NDJSON，一行一动作）。 */
+export interface ManagedActionRecord {
+  action: "channel_reply" | "worker_dispatch" | "worker_feedback" | "owner_decision" | "worker_report";
+  seq: number;
+  /** owner_decision 专有：服务端即时 resolution 状态。 */
+  decision_state?: "pending" | "auto_resolved";
+  at: number;
+}
+
+export const MANAGED_MANIFEST_FILE = "managed.json";
+export const MANAGED_WAKE_FILE = "wake.json";
+export const MANAGED_CONFIG_FILE = "config.json";
+
+function outcomeFile(stateDir: string, seq: number): string {
+  return join(stateDir, `outcome-${seq}.ndjson`);
+}
+
+export function writeManagedManifest(stateDir: string, manifest: ManagedLaneManifest): void {
+  mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+  writeFileSync(join(stateDir, MANAGED_MANIFEST_FILE), JSON.stringify(manifest) + "\n", { mode: 0o600 });
+}
+
+export function readManagedManifest(stateDir: string): ManagedLaneManifest {
+  const raw = JSON.parse(readFileSync(join(stateDir, MANAGED_MANIFEST_FILE), "utf8")) as ManagedLaneManifest;
+  if (raw.version !== 1 || (raw.role !== "front" && raw.role !== "worker")) {
+    throw new Error(`unsupported managed lane manifest at ${stateDir}`);
+  }
+  return raw;
+}
+
+export function writeManagedWake(stateDir: string, wake: ManagedWakeState): void {
+  mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+  writeFileSync(join(stateDir, MANAGED_WAKE_FILE), JSON.stringify(wake) + "\n", { mode: 0o600 });
+}
+
+export function readManagedWake(stateDir: string): ManagedWakeState {
+  const raw = JSON.parse(readFileSync(join(stateDir, MANAGED_WAKE_FILE), "utf8")) as ManagedWakeState;
+  if (raw.version !== 1) throw new Error(`unsupported managed wake state at ${stateDir}`);
+  return raw;
+}
+
+export function appendManagedAction(stateDir: string, seq: number, record: ManagedActionRecord): void {
+  appendFileSync(outcomeFile(stateDir, seq), JSON.stringify(record) + "\n", { mode: 0o600 });
+}
+
+export function readManagedActions(stateDir: string, seq: number): ManagedActionRecord[] {
+  let raw: string;
+  try {
+    raw = readFileSync(outcomeFile(stateDir, seq), "utf8");
+  } catch {
+    return [];
+  }
+  const records: ManagedActionRecord[] = [];
+  for (const line of raw.split("\n")) {
+    if (line.trim() === "") continue;
+    try {
+      records.push(JSON.parse(line) as ManagedActionRecord);
+    } catch {
+      // 半行（进程被杀在 append 中途）只丢那一行，不作废整个回合的已完成动作。
+    }
+  }
+  return records;
+}
+
+export class ManagedActionError extends Error {}
+
+/**
+ * worker 附件围栏（从 serve.ts 的 resolveRunnerAttachmentPath 迁来，#581）：
+ * root=null 一律拒（front 禁主机文件附件）；有 root 时 realpath 后必须落在 root 实路径下，
+ * symlink 逃逸在这里被拒。读取的是解析后的真实目标，不是模型给的（可能是链接的）路径。
+ */
+export function resolveManagedAttachmentPath(path: string, attachmentRoot: string | null): string {
+  if (attachmentRoot === null) {
+    throw new ManagedActionError("managed front host-file attachments are disabled");
+  }
+  const realRoot = realpathSync(attachmentRoot);
+  if (!statSync(realRoot).isDirectory()) {
+    throw new ManagedActionError(`runner attachment root is not a directory: ${attachmentRoot}`);
+  }
+  if (!isAbsolute(path)) throw new ManagedActionError(`attachment path must be absolute: ${path}`);
+  const realPath = realpathSync(path);
+  const fromRoot = relative(realRoot, realPath);
+  if (fromRoot === ".." || fromRoot.startsWith(`..${sep}`) || isAbsolute(fromRoot)) {
+    throw new ManagedActionError(`runner attachment escapes allowed workspace: ${path}`);
+  }
+  return realPath;
+}
+
+export interface ManagedOrigin {
+  seq: number;
+  workerReportSeq?: number;
+  workerDispatchSeq?: number;
+}
+
+export interface ManagedLineageOptions {
+  server: string;
+  token: string;
+  channel: string;
+  frontName: string;
+  workerName: string;
+  ownerAccount: string;
+  fetch?: typeof fetchMessages;
+}
+
+/**
+ * front 血缘解析（从 createManagedFrontResultRoute 原样迁出，#581）：把当前 wake（worker 报告 /
+ * owner 决策应答 / 频道消息）追溯到最初的人类 origin，沿途校验每一跳的 principal 与链接。
+ * 文本协议路由与 MCP 工具 handler 共用这一份——校验逻辑绝不双写。
+ */
+export function createManagedLineageResolver(opts: ManagedLineageOptions) {
+  const fetch = opts.fetch ?? fetchMessages;
+  const readExact = async (seq: number): Promise<MsgFrame> => {
+    const message = (await fetch(opts.server, opts.token, opts.channel, Math.max(0, seq - 1), 1))
+      .find((candidate) => candidate.seq === seq);
+    if (message === undefined) throw new ManagedActionError(`managed front lineage message #${seq} is unavailable`);
+    return message;
+  };
+  const resolveFrame = async (frame: MsgFrame, seen: Set<number>, depth: number): Promise<ManagedOrigin> => {
+    if (depth > 12 || seen.has(frame.seq)) {
+      throw new ManagedActionError("managed front lineage is cyclic or too deep");
+    }
+    seen.add(frame.seq);
+    if (frame.sender.name === opts.workerName) {
+      if (frame.sender.owner !== opts.ownerAccount || frame.reply_to === null) {
+        throw new ManagedActionError("worker report principal or dispatch link could not be verified");
+      }
+      const dispatch = await readExact(frame.reply_to);
+      if (
+        dispatch.sender.name !== opts.frontName ||
+        dispatch.sender.owner !== opts.ownerAccount ||
+        !dispatch.mentions.includes(opts.workerName) ||
+        dispatch.reply_to === null ||
+        dispatch.seq >= frame.seq
+      ) {
+        throw new ManagedActionError("worker report dispatch lineage could not be verified");
+      }
+      const root = await resolveFrame(await readExact(dispatch.reply_to), seen, depth + 1);
+      return {
+        ...root,
+        workerReportSeq: frame.seq,
+        workerDispatchSeq: dispatch.seq,
+      };
+    }
+    if (frame.decision_response !== undefined) {
+      const question = await readExact(frame.decision_response.request_seq);
+      if (
+        frame.sender.kind !== "human" ||
+        frame.sender.owner !== opts.ownerAccount ||
+        frame.reply_to !== frame.decision_response.request_seq ||
+        question.sender.name !== opts.frontName ||
+        question.sender.owner !== opts.ownerAccount ||
+        question.decision_request === undefined ||
+        question.reply_to === null ||
+        question.seq >= frame.seq
+      ) {
+        throw new ManagedActionError("owner decision question lineage could not be verified");
+      }
+      return resolveFrame(await readExact(question.reply_to), seen, depth + 1);
+    }
+    return { seq: frame.seq };
+  };
+  return async (
+    frame: MsgFrame,
+    delivery: { cause?: string; work_id: string | null; continuation_ref: string | null } | null,
+  ): Promise<ManagedOrigin | null> => {
+    if (frame.sender.name === opts.workerName) return resolveFrame(frame, new Set(), 0);
+    if (frame.decision_response === undefined) return null;
+    if (
+      delivery?.cause !== "owner_answer" ||
+      delivery.work_id === null ||
+      delivery.continuation_ref === null ||
+      frame.decision_response.work_id !== delivery.work_id ||
+      frame.decision_response.continuation_ref !== delivery.continuation_ref
+    ) {
+      throw new ManagedActionError("owner answer delivery lineage could not be verified");
+    }
+    return resolveFrame(frame, new Set(), 0);
+  };
+}

--- a/cli/src/managed.ts
+++ b/cli/src/managed.ts
@@ -137,6 +137,8 @@ export function resolveManagedAttachmentPath(path: string, attachmentRoot: strin
  * 从同一个 fd 读出字节，再落到 supervisor 私有目录（工作区之外）的不可变快照——上传只碰快照，
  * 模型此后怎么动工作区都影响不到已读内容。
  */
+export const MANAGED_ATTACHMENT_SIZE_LIMIT = 25 * 1024 * 1024;
+
 export function snapshotManagedAttachment(path: string, attachmentRoot: string | null, snapshotDir: string): string {
   const realPath = resolveManagedAttachmentPath(path, attachmentRoot);
   let fd: number;
@@ -146,18 +148,34 @@ export function snapshotManagedAttachment(path: string, attachmentRoot: string |
     throw new ManagedActionError(`runner attachment is not a plain readable file: ${path}`);
   }
   try {
-    if (!fstatSync(fd).isFile()) {
+    const opened = fstatSync(fd);
+    if (!opened.isFile()) {
       throw new ManagedActionError(`runner attachment is not a regular file: ${path}`);
+    }
+    // 读入内存之前先按上传上限拒超大文件——否则模型可用一个巨型文件把本进程 OOM（#592 评审）。
+    if (opened.size > MANAGED_ATTACHMENT_SIZE_LIMIT) {
+      throw new ManagedActionError(`runner attachment exceeds 25MB limit: ${path}`);
+    }
+    // O_NOFOLLOW 只挡最后一段 symlink；祖先目录仍可能在 realpath 之后被换成指向工作区外的
+    // 链接。开 fd 后重新做一次 realpath+围栏校验，并以 dev/ino 核对「校验过的路径」就是
+    // 「已打开的这个文件」——fd 的身份不可再被换。同 uid 的 hardlink/主动拷贝不在本围栏的
+    // 威胁模型内（sandbox 本就允许模型读全盘，围栏的价值是边界显式，不是保密）。
+    const recheck = resolveManagedAttachmentPath(path, attachmentRoot);
+    const rechecked = statSync(recheck);
+    if (rechecked.dev !== opened.dev || rechecked.ino !== opened.ino) {
+      throw new ManagedActionError(`runner attachment changed during validation: ${path}`);
     }
     const bytes = readFileSync(fd);
     mkdirSync(snapshotDir, { recursive: true, mode: 0o700 });
-    // 保留 basename（上传链按文件名定 content-type/展示名）；同名冲突加序号。
+    // 保留 basename（上传链按文件名定 content-type/展示名）；同名冲突加序号，
+    // 只对 EEXIST 重试——磁盘满等永久错误必须立即冒出去（#592 评审）。
     let target = join(snapshotDir, basename(realPath));
     for (let index = 1; ; index += 1) {
       try {
         writeFileSync(target, bytes, { mode: 0o600, flag: "wx" });
         break;
-      } catch {
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
         target = join(snapshotDir, `${index}-${basename(realPath)}`);
       }
     }
@@ -165,6 +183,29 @@ export function snapshotManagedAttachment(path: string, attachmentRoot: string |
   } finally {
     closeSync(fd);
   }
+}
+
+/**
+ * owner 决策的原子预约（#592 评审）：并发工具调用都可能在回执尚未落盘时通过读检查。
+ * O_EXCL 锁文件是同一 wake 内的原子闸——先到先得，后来者直接拒；post 失败时释放预约。
+ */
+export function reserveManagedExclusive(stateDir: string, seq: number, action: string): () => void {
+  mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+  const lockPath = join(stateDir, `${action}-${seq}.lock`);
+  try {
+    closeSync(openSync(lockPath, fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_WRONLY, 0o600));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+      throw new ManagedActionError(`${action} already issued for this wake`);
+    }
+    throw error;
+  }
+  return () => rmSync(lockPath, { force: true });
+}
+
+/** 供 supervisor 在新 wake 的 prepare 里连同回执一起清理。 */
+export function clearManagedExclusiveLocks(stateDir: string, seq: number): void {
+  rmSync(join(stateDir, `owner_decision-${seq}.lock`), { force: true });
 }
 
 export interface ManagedOrigin {

--- a/cli/src/managed.ts
+++ b/cli/src/managed.ts
@@ -2,8 +2,8 @@
 // supervisor（serve）与角色裁剪的 MCP server（party mcp --managed）之间的文件握手协议、
 // front 血缘解析、worker 附件工作区围栏。serve.ts 与 mcp-managed.ts 都从这里取——
 // 生产/消费两侧的事实源只有这一份（#578 的教训：前缀协议两侧相隔百行，改一侧全线挂）。
-import { appendFileSync, mkdirSync, readFileSync, realpathSync, statSync, writeFileSync } from "node:fs";
-import { isAbsolute, join, relative, sep } from "node:path";
+import { appendFileSync, closeSync, constants as fsConstants, fstatSync, mkdirSync, openSync, readFileSync, realpathSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { basename, isAbsolute, join, relative, sep } from "node:path";
 import type { MsgFrame } from "@agentparty/shared";
 import { fetchMessages } from "./rest";
 
@@ -76,7 +76,16 @@ export function readManagedWake(stateDir: string): ManagedWakeState {
 }
 
 export function appendManagedAction(stateDir: string, seq: number, record: ManagedActionRecord): void {
+  mkdirSync(stateDir, { recursive: true, mode: 0o700 });
   appendFileSync(outcomeFile(stateDir, seq), JSON.stringify(record) + "\n", { mode: 0o600 });
+}
+
+/**
+ * 新 wake 开工前清掉同 seq 的历史回执（supervisor 在 prepare 里调）：消息编辑会复用原 seq 但
+ * 产生新 delivery，旧回执绝不能替新回合充数（CodeRabbit #592 finding）。
+ */
+export function clearManagedActions(stateDir: string, seq: number): void {
+  rmSync(outcomeFile(stateDir, seq), { force: true });
 }
 
 export function readManagedActions(stateDir: string, seq: number): ManagedActionRecord[] {
@@ -120,6 +129,42 @@ export function resolveManagedAttachmentPath(path: string, attachmentRoot: strin
     throw new ManagedActionError(`runner attachment escapes allowed workspace: ${path}`);
   }
   return realPath;
+}
+
+/**
+ * 附件快照（#592 评审的 TOCTOU 修复）：realpath 围栏校验和上传打开之间，worker 可把工作区内
+ * 文件换成指向外部的 symlink。这里在校验后立刻以 O_NOFOLLOW 打开、fstat 验普通文件、
+ * 从同一个 fd 读出字节，再落到 supervisor 私有目录（工作区之外）的不可变快照——上传只碰快照，
+ * 模型此后怎么动工作区都影响不到已读内容。
+ */
+export function snapshotManagedAttachment(path: string, attachmentRoot: string | null, snapshotDir: string): string {
+  const realPath = resolveManagedAttachmentPath(path, attachmentRoot);
+  let fd: number;
+  try {
+    fd = openSync(realPath, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+  } catch {
+    throw new ManagedActionError(`runner attachment is not a plain readable file: ${path}`);
+  }
+  try {
+    if (!fstatSync(fd).isFile()) {
+      throw new ManagedActionError(`runner attachment is not a regular file: ${path}`);
+    }
+    const bytes = readFileSync(fd);
+    mkdirSync(snapshotDir, { recursive: true, mode: 0o700 });
+    // 保留 basename（上传链按文件名定 content-type/展示名）；同名冲突加序号。
+    let target = join(snapshotDir, basename(realPath));
+    for (let index = 1; ; index += 1) {
+      try {
+        writeFileSync(target, bytes, { mode: 0o600, flag: "wx" });
+        break;
+      } catch {
+        target = join(snapshotDir, `${index}-${basename(realPath)}`);
+      }
+    }
+    return target;
+  } finally {
+    closeSync(fd);
+  }
 }
 
 export interface ManagedOrigin {

--- a/cli/test/mcp-managed.test.ts
+++ b/cli/test/mcp-managed.test.ts
@@ -216,6 +216,24 @@ describe("front 角色工具面（#581）", () => {
       });
       expect((r.content as { text: string }[])[0]!.text).toContain("END this turn");
       expect(readManagedActions(stateDir, 50).at(-1)).toMatchObject({ action: "owner_decision", decision_state: "pending" });
+
+      // 幂等闸持久于 outcome 回执：同一 wake 内第二次决策直接拒（哪怕换一个 MCP 进程也一样）。
+      const dup = await client.callTool({ name: "party_decision_ask", arguments: { prompt: "再问一次？" } });
+      expect(dup.isError).toBe(true);
+      expect((dup.content as { text: string }[])[0]!.text).toContain("already issued");
+      expect(messagePosts().filter((post) => post.decision_request !== undefined)).toHaveLength(1);
+    } finally {
+      await client.close();
+    }
+  }, 20000);
+
+  test("party_decision_ask：options:null 是 schema 合法输入，按 approval 处理（#578 finding 1 语义）", async () => {
+    writeLane("front", { owner_decision_binding: true });
+    const client = await connect();
+    try {
+      const r = await client.callTool({ name: "party_decision_ask", arguments: { prompt: "可以发布吗？", options: null } });
+      expect(r.isError).not.toBe(true);
+      expect(messagePosts()[0]!.decision_request).toMatchObject({ kind: "approval", prompt: "可以发布吗？" });
     } finally {
       await client.close();
     }

--- a/cli/test/mcp-managed.test.ts
+++ b/cli/test/mcp-managed.test.ts
@@ -1,0 +1,278 @@
+// #581 Phase 2 验收（MCP server 侧）：party mcp --managed 的角色裁剪工具面。
+// 真 stdio server + mock REST：
+//   - 角色即工具集：front 无 worker_report/attach 面；worker 无 dispatch/decision/reply 面；
+//   - front 派工/返工消息零前缀（body=instruction 原文，mentions=[worker]）；
+//   - owner 决策：binding 未启用 fail closed；启用时带 expected lineage + responder owner；
+//   - worker 附件 symlink 逃逸在工具层被拒且一字不发（issue 验收标准原文场景）。
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { MsgFrame } from "@agentparty/shared";
+import {
+  MANAGED_CONFIG_FILE,
+  writeManagedManifest,
+  writeManagedWake,
+  readManagedActions,
+  type ManagedWakeState,
+} from "../src/managed";
+import { msgFrame } from "./mock-server";
+
+const indexPath = join(import.meta.dir, "..", "src", "index.ts");
+
+let home: string;
+let stateDir: string;
+let channelWorkdir: string;
+let restServer: ReturnType<typeof Bun.serve> | null = null;
+const seen: { method: string; path: string; body: unknown }[] = [];
+let nextSeq = 100;
+
+function startRest(): void {
+  restServer = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+      const isUpload = url.pathname === "/api/channels/dev/attachments";
+      const body = req.method === "GET" ? null : isUpload ? await req.text() : await req.json().catch(() => null);
+      seen.push({ method: req.method, path: `${url.pathname}${url.search}`, body });
+      if (url.pathname === "/api/channels/dev/charter") {
+        return Response.json({ charter: "be nice", charter_rev: 1, updated_at: null, updated_by: null });
+      }
+      if (url.pathname === "/api/channels/dev/messages" && req.method === "GET") {
+        return Response.json({ messages: [] });
+      }
+      if (isUpload && req.method === "POST") {
+        const filename = url.searchParams.get("filename") ?? "unknown";
+        return Response.json(
+          {
+            key: `dev/sha256/${filename}`,
+            filename,
+            content_type: "application/octet-stream",
+            size: (body as string).length,
+            url: `/api/channels/dev/attachments/sha256/${filename}`,
+          },
+          { status: 201 },
+        );
+      }
+      if (url.pathname === "/api/channels/dev/messages" && req.method === "POST") {
+        const frame = body as Record<string, unknown>;
+        nextSeq += 1;
+        return Response.json({
+          seq: nextSeq,
+          ...(frame.decision_request !== undefined
+            ? { decision_request: frame.decision_request, decision_resolution: { state: "pending" } }
+            : {}),
+        });
+      }
+      return Response.json({ error: { code: "not_found", message: "not found" } }, { status: 404 });
+    },
+  });
+}
+
+function wakeFrame(seq: number, over: Partial<MsgFrame> = {}): MsgFrame {
+  return { ...(msgFrame(seq, `wake ${seq}`, { mentions: ["me"] }) as unknown as MsgFrame), ...over };
+}
+
+function writeLane(role: "front" | "worker", wakeOver: Partial<ManagedWakeState> = {}): void {
+  writeManagedManifest(stateDir, {
+    version: 1,
+    server: `http://127.0.0.1:${restServer!.port}`,
+    channel: "dev",
+    role,
+    self: role === "front" ? "front-1" : "worker-1",
+    front: "front-1",
+    worker: "worker-1",
+    owner_account: "owner@example.com",
+    config: join(stateDir, MANAGED_CONFIG_FILE),
+    attachment_root: role === "worker" ? channelWorkdir : null,
+  });
+  writeFileSync(
+    join(stateDir, MANAGED_CONFIG_FILE),
+    JSON.stringify({ server: `http://127.0.0.1:${restServer!.port}`, token: "ap_child" }) + "\n",
+    { mode: 0o600 },
+  );
+  writeManagedWake(stateDir, {
+    version: 1,
+    seq: 50,
+    frame: wakeFrame(50),
+    delivery: { id: "d-50", cause: "mention", work_id: "w-50", continuation_ref: "ref-50" },
+    owner_decision_binding: false,
+    ...wakeOver,
+  });
+}
+
+async function connect(): Promise<Client> {
+  const env: Record<string, string> = {};
+  for (const [k, v] of Object.entries(process.env)) {
+    if (v !== undefined && k !== "AGENTPARTY_CONFIG") env[k] = v;
+  }
+  env.AGENTPARTY_HOME = home;
+  const transport = new StdioClientTransport({
+    command: "bun",
+    args: ["run", indexPath, "mcp", "--managed", stateDir],
+    env,
+    stderr: "pipe",
+  });
+  const client = new Client({ name: "agentparty-test", version: "1.0.0" });
+  await client.connect(transport);
+  return client;
+}
+
+function messagePosts(): Record<string, unknown>[] {
+  return seen
+    .filter((s) => s.method === "POST" && s.path === "/api/channels/dev/messages")
+    .map((s) => s.body as Record<string, unknown>);
+}
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "ap-mcp-managed-"));
+  stateDir = join(home, "mcp-state");
+  channelWorkdir = join(home, "channel-workdir");
+  mkdirSync(channelWorkdir, { recursive: true });
+  seen.length = 0;
+  nextSeq = 100;
+  startRest();
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+  restServer?.stop(true);
+  restServer = null;
+});
+
+describe("front 角色工具面（#581）", () => {
+  test("角色即工具集：只暴露 front 面，无 worker_report、无通用 send/attach", async () => {
+    writeLane("front");
+    const client = await connect();
+    try {
+      const tools = (await client.listTools()).tools.map((t) => t.name).sort();
+      expect(tools).toEqual(
+        ["party_charter", "party_decision_ask", "party_history", "party_reply", "party_worker_dispatch", "party_worker_feedback"].sort(),
+      );
+    } finally {
+      await client.close();
+    }
+  }, 20000);
+
+  test("party_reply：prose 正文原样进频道、reply_to 锚到 wake；回执落盘", async () => {
+    writeLane("front");
+    const client = await connect();
+    try {
+      const r = await client.callTool({ name: "party_reply", arguments: { body: "这是一段随意的自然语言汇总。" } });
+      expect(r.isError).not.toBe(true);
+      const posts = messagePosts();
+      expect(posts).toHaveLength(1);
+      expect(posts[0]).toMatchObject({ kind: "message", body: "这是一段随意的自然语言汇总。", reply_to: 50, mentions: [] });
+      const actions = readManagedActions(stateDir, 50);
+      expect(actions).toHaveLength(1);
+      expect(actions[0]).toMatchObject({ action: "channel_reply", seq: 101 });
+    } finally {
+      await client.close();
+    }
+  }, 20000);
+
+  test("party_worker_dispatch：零前缀、mentions=[worker]、instruction 原文即 body", async () => {
+    writeLane("front");
+    const client = await connect();
+    try {
+      const instruction = "修复登录页 bug：复现步骤如下……验收标准：所有 e2e 通过。";
+      const r = await client.callTool({ name: "party_worker_dispatch", arguments: { instruction } });
+      expect(r.isError).not.toBe(true);
+      const posts = messagePosts();
+      expect(posts).toHaveLength(1);
+      expect(posts[0]).toMatchObject({ body: instruction, mentions: ["worker-1"], reply_to: 50 });
+      expect(String(posts[0]!.body)).not.toContain("已派工");
+      expect(readManagedActions(stateDir, 50)[0]).toMatchObject({ action: "worker_dispatch", seq: 101 });
+    } finally {
+      await client.close();
+    }
+  }, 20000);
+
+  test("party_decision_ask：binding 未启用 fail closed 一字不发；启用后带 lineage+responder 且提示结束回合", async () => {
+    writeLane("front");
+    const client = await connect();
+    try {
+      const refused = await client.callTool({ name: "party_decision_ask", arguments: { prompt: "可以合并吗？" } });
+      expect(refused.isError).toBe(true);
+      expect(messagePosts()).toHaveLength(0);
+
+      writeManagedWake(stateDir, {
+        version: 1,
+        seq: 50,
+        frame: wakeFrame(50),
+        delivery: { id: "d-50", cause: "mention", work_id: "w-50", continuation_ref: "ref-50" },
+        owner_decision_binding: true,
+      });
+      const r = await client.callTool({ name: "party_decision_ask", arguments: { prompt: "可以合并吗？" } });
+      expect(r.isError).not.toBe(true);
+      const post = messagePosts()[0]!;
+      expect(post).toMatchObject({
+        decision_request: { kind: "approval", prompt: "可以合并吗？" },
+        expected_decision_lineage: { delivery_id: "d-50", work_id: "w-50", continuation_ref: "ref-50" },
+        expected_decision_responder_owner: "owner@example.com",
+      });
+      expect((r.content as { text: string }[])[0]!.text).toContain("END this turn");
+      expect(readManagedActions(stateDir, 50).at(-1)).toMatchObject({ action: "owner_decision", decision_state: "pending" });
+    } finally {
+      await client.close();
+    }
+  }, 20000);
+});
+
+describe("worker 角色工具面（#581）", () => {
+  test("角色即工具集：只暴露 report + 只读件，无 dispatch/decision/reply", async () => {
+    writeLane("worker");
+    const client = await connect();
+    try {
+      const tools = (await client.listTools()).tools.map((t) => t.name).sort();
+      expect(tools).toEqual(["party_charter", "party_history", "party_worker_report"].sort());
+    } finally {
+      await client.close();
+    }
+  }, 20000);
+
+  test("party_worker_report：回执 reply_to=派工消息，工作区内附件走上传链", async () => {
+    writeLane("worker");
+    const deliverable = join(channelWorkdir, "result.diff");
+    writeFileSync(deliverable, "diff --git a/x b/x\n");
+    const client = await connect();
+    try {
+      const r = await client.callTool({
+        name: "party_worker_report",
+        arguments: { body: "改完了，diff 附上。", attach: [deliverable] },
+      });
+      expect(r.isError).not.toBe(true);
+      const post = messagePosts()[0]!;
+      expect(post).toMatchObject({ body: "改完了，diff 附上。", reply_to: 50 });
+      expect(Array.isArray(post.attachments)).toBe(true);
+      expect(readManagedActions(stateDir, 50)[0]).toMatchObject({ action: "worker_report" });
+    } finally {
+      await client.close();
+    }
+  }, 20000);
+
+  test("attach symlink 逃逸 → isError 且零上传零消息（issue 验收标准）", async () => {
+    writeLane("worker");
+    const outside = join(home, "outside-secret.txt");
+    writeFileSync(outside, "host secret");
+    const escape = join(channelWorkdir, "innocent-link.txt");
+    symlinkSync(outside, escape);
+    const client = await connect();
+    try {
+      const r = await client.callTool({
+        name: "party_worker_report",
+        arguments: { body: "带个附件", attach: [escape] },
+      });
+      expect(r.isError).toBe(true);
+      expect((r.content as { text: string }[])[0]!.text).toContain("escapes allowed workspace");
+      expect(messagePosts()).toHaveLength(0);
+      expect(seen.some((s) => s.path.startsWith("/api/channels/dev/attachments"))).toBe(false);
+      expect(readManagedActions(stateDir, 50)).toHaveLength(0);
+    } finally {
+      await client.close();
+    }
+  }, 20000);
+});

--- a/cli/test/serve-managed-mcp.test.ts
+++ b/cli/test/serve-managed-mcp.test.ts
@@ -13,10 +13,14 @@ import {
   assertManagedWorkerWake,
   createBuiltinRunner,
   ManagedWorkerUndispatchedError,
+  runProfileServe,
   WakeBlockedError,
   type ProjectAgentRunContext,
+  type ServeOptions,
 } from "../src/commands/serve";
-import { appendManagedAction, readManagedWake, writeManagedManifest, writeManagedWake } from "../src/managed";
+import { run as runMcpCommand } from "../src/commands/mcp";
+import { appendManagedAction, readManagedActions, readManagedManifest, readManagedWake } from "../src/managed";
+import { existsSync } from "node:fs";
 import { msgFrame } from "./mock-server";
 
 const dirs: string[] = [];
@@ -258,5 +262,129 @@ describe("已派工前缀退役方向（#581 验收：mcp 主路径零前缀）"
     const mcpManaged = readFileSync(join(import.meta.dir, "..", "src", "commands", "mcp-managed.ts"), "utf8");
     expect(mcpManaged).not.toContain("已派工");
     expect(mcpManaged).not.toContain("已要求补充/返工");
+  });
+});
+
+describe("supervisor 侧回执治理与入口参数（#592 评审）", () => {
+  test("新 wake 的 prepare 清掉同 seq 的历史回执：旧动作不能替新回合充数", async () => {
+    const workdir = tempDir();
+    const stateDir = join(workdir, "mcp");
+    // 上一条 delivery（比如消息编辑前）留下的旧回执。
+    appendManagedAction(stateDir, 30, { action: "channel_reply", seq: 77, at: 1 });
+    const run = createBuiltinRunner(managedRunnerOpts(workdir, stateDir, {
+      runProcess: async (args: string[]) => {
+        writeFileSync(args[args.indexOf("-o") + 1]!, "本回合什么工具都没调\n");
+        return { code: 0, stdout: "session id: 019f35d9-0000-7000-8000-000000000030\n", stderr: "" };
+      },
+    }));
+    await expect(run(message(30), context(delivery(30)))).rejects.toThrow(/no channel action/);
+    expect(readManagedActions(stateDir, 30)).toHaveLength(0);
+  });
+
+  test("party mcp --managed 拒绝 '-' 开头的 stateDir（含 '--' 终止符）", async () => {
+    expect(await runMcpCommand(["--managed", "--"])).toBe(1);
+    expect(await runMcpCommand(["--managed", "-x"])).toBe(1);
+    expect(await runMcpCommand(["--managed"])).toBe(1);
+  });
+});
+
+describe("runProfileServe 协议装配（buildLane 回归网，#592 评审）", () => {
+  async function assembleLanes(runner: "codex" | "codex-sdk", protocol?: "mcp" | "text"): Promise<ServeOptions[]> {
+    const home = tempDir();
+    const oldHome = process.env.AGENTPARTY_HOME;
+    const oldConfig = process.env.AGENTPARTY_CONFIG;
+    process.env.AGENTPARTY_HOME = home;
+    const ownerConfig = join(home, "owner.json");
+    writeFileSync(ownerConfig, JSON.stringify({ server: "http://agentparty.test", token: "ap_owner" }));
+    process.env.AGENTPARTY_CONFIG = ownerConfig;
+    const profile = {
+      owner_account: "asm@example.com",
+      handle: "asm-dev",
+      name: "Asm Dev",
+      runner,
+      repo_url: null,
+      workdir: null,
+      base_branch: "main",
+      worktree_strategy: "branch" as const,
+      rules: null,
+      invitable_by: "owner" as const,
+      created_at: 1,
+      updated_at: 1,
+    };
+    const served: ServeOptions[] = [];
+    try {
+      const code = await runProfileServe({
+        server: "http://agentparty.test",
+        humanToken: "acc-human",
+        ownerAccount: profile.owner_account,
+        handle: profile.handle,
+        mentionsOnly: true,
+        once: true,
+        ...(protocol === undefined ? {} : { protocol }),
+        post: async () => ({ seq: 1 }),
+        mintRuntime: async () => ({ token: "ap_rt", profile }),
+        listInvites: async () => [{
+          id: 1,
+          channel_slug: "asm",
+          owner_account: profile.owner_account,
+          profile_handle: profile.handle,
+          invited_by: "owner@example.com",
+          invited_at: 1,
+          profile,
+        }],
+        ensureChannelRuntime: async (_s, _t, slug, owner, _h, childName) => ({
+          token: `ap_${childName}`,
+          name: childName,
+          role: "agent" as const,
+          owner,
+          channel_scope: slug,
+          lineage: { parent_agent: profile.handle, root_agent: profile.handle, team_id: profile.handle, depth: 1, expires_at: null },
+          profile,
+        }),
+        runChannelServe: async (opts) => {
+          served.push(opts);
+          return 0;
+        },
+      });
+      expect(code).toBe(0);
+    } finally {
+      if (oldHome === undefined) delete process.env.AGENTPARTY_HOME;
+      else process.env.AGENTPARTY_HOME = oldHome;
+      if (oldConfig === undefined) delete process.env.AGENTPARTY_CONFIG;
+      else process.env.AGENTPARTY_CONFIG = oldConfig;
+    }
+    return served;
+  }
+
+  test("builtin 默认 mcp：managedMcp 装配、schema 退场、manifest 落盘且角色/围栏正确", async () => {
+    const served = await assembleLanes("codex");
+    expect(served).toHaveLength(2);
+    for (const lane of served) {
+      expect(lane.builtinRunner?.managedMcp).toBeDefined();
+      expect(lane.builtinRunner?.outputSchema).toBeUndefined();
+      expect(lane.builtinRunner?.resultRoute).toBeUndefined();
+      const manifest = readManagedManifest(lane.builtinRunner!.managedMcp!.stateDir);
+      expect(manifest.role).toBe(lane.projectAgent!.runtime_role);
+      if (manifest.role === "worker") expect(manifest.attachment_root).toBe(lane.builtinRunner!.cwd!);
+      else expect(manifest.attachment_root).toBeNull();
+      expect(lane.projectAgent?.protocol).toBe("mcp");
+    }
+  });
+
+  test("--protocol text：不写 manifest，front 仍带六字段 schema（逃生舱原样）", async () => {
+    const served = await assembleLanes("codex", "text");
+    const front = served.find((lane) => lane.projectAgent?.runtime_role === "front")!;
+    expect(front.builtinRunner?.managedMcp).toBeUndefined();
+    expect(front.builtinRunner?.outputSchema).toBeDefined();
+    expect(front.builtinRunner?.resultRoute).toBeDefined();
+    expect(existsSync(join(front.builtinRunner!.workdir, "mcp", "managed.json"))).toBe(false);
+    expect(front.projectAgent?.protocol).toBe("text");
+  });
+
+  test("codex-sdk 默认被强制 text（本期无 MCP 注入面）", async () => {
+    const served = await assembleLanes("codex-sdk");
+    const front = served.find((lane) => lane.projectAgent?.runtime_role === "front")!;
+    expect(front.sdkRunner?.outputSchema).toBeDefined();
+    expect(front.projectAgent?.protocol).toBe("text");
   });
 });

--- a/cli/test/serve-managed-mcp.test.ts
+++ b/cli/test/serve-managed-mcp.test.ts
@@ -289,7 +289,9 @@ describe("supervisor 侧回执治理与入口参数（#592 评审）", () => {
 });
 
 describe("runProfileServe 协议装配（buildLane 回归网，#592 评审）", () => {
+  const assemblyOut: string[] = [];
   async function assembleLanes(runner: "codex" | "codex-sdk", protocol?: "mcp" | "text"): Promise<ServeOptions[]> {
+    assemblyOut.length = 0;
     const home = tempDir();
     const oldHome = process.env.AGENTPARTY_HOME;
     const oldConfig = process.env.AGENTPARTY_CONFIG;
@@ -345,6 +347,7 @@ describe("runProfileServe 协议装配（buildLane 回归网，#592 评审）", 
           served.push(opts);
           return 0;
         },
+        out: (line) => assemblyOut.push(line),
       });
       expect(code).toBe(0);
     } finally {
@@ -381,10 +384,12 @@ describe("runProfileServe 协议装配（buildLane 回归网，#592 评审）", 
     expect(front.projectAgent?.protocol).toBe("text");
   });
 
-  test("codex-sdk 默认被强制 text（本期无 MCP 注入面）", async () => {
+  test("codex-sdk 默认被强制 text（本期无 MCP 注入面）：警告可见、不写 manifest", async () => {
     const served = await assembleLanes("codex-sdk");
     const front = served.find((lane) => lane.projectAgent?.runtime_role === "front")!;
     expect(front.sdkRunner?.outputSchema).toBeDefined();
     expect(front.projectAgent?.protocol).toBe("text");
+    expect(assemblyOut.some((line) => line.includes("no MCP injection surface"))).toBe(true);
+    expect(existsSync(join(front.sdkRunner!.workdir, "mcp", "managed.json"))).toBe(false);
   });
 });

--- a/cli/test/serve-managed-mcp.test.ts
+++ b/cli/test/serve-managed-mcp.test.ts
@@ -1,0 +1,262 @@
+// #581 Phase 2 验收（serve 侧）：managed lane 的 MCP 协议——
+//   1) front 模型输出任意 prose（含字面 [attach:] 行）不再产生 WakeBlockedError；
+//   2) 零工具动作的回合被判未送达（WakeBlockedError，不推游标）；
+//   3) codex/claude 的 harness 参数注入角色裁剪的 party MCP server；
+//   4) wake.json 每回合覆写并带 delivery 快照与 owner 决策绑定；
+//   5) worker 验派工在 mcp 协议下纯结构化（#578 finding 3 的前缀比对退役），text 协议原样保留。
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { DirectedDelivery, MsgFrame } from "@agentparty/shared";
+import {
+  assertManagedWorkerWake,
+  createBuiltinRunner,
+  ManagedWorkerUndispatchedError,
+  WakeBlockedError,
+  type ProjectAgentRunContext,
+} from "../src/commands/serve";
+import { appendManagedAction, readManagedWake, writeManagedManifest, writeManagedWake } from "../src/managed";
+import { msgFrame } from "./mock-server";
+
+const dirs: string[] = [];
+afterEach(() => {
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function tempDir(prefix = "ap-managed-mcp-"): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  dirs.push(dir);
+  return dir;
+}
+
+function message(seq: number, over: Partial<MsgFrame> = {}): MsgFrame {
+  return {
+    ...(msgFrame(seq, `work ${seq}`, { mentions: ["me"] }) as unknown as MsgFrame),
+    ...over,
+  };
+}
+
+function delivery(seq: number, cause: DirectedDelivery["cause"] = "mention"): DirectedDelivery {
+  return {
+    id: `delivery-${seq}-${cause}`,
+    message_seq: seq,
+    target_name: "me",
+    cause,
+    state: "claimed",
+    attempt: 1,
+    lease_until: Date.now() + 90_000,
+    work_id: `work-${seq}`,
+    continuation_ref: `ref-${seq}`,
+    reply_seq: null,
+    last_error: null,
+    created_at: Date.now(),
+    updated_at: Date.now(),
+  };
+}
+
+function context(item: DirectedDelivery | null) {
+  return {
+    cmd: "",
+    channel: "dev",
+    self: "me",
+    contextDir: tempDir("ap-managed-mcp-context-"),
+    recent: [] as MsgFrame[],
+    ...(item === null ? {} : { delivery: item }),
+  };
+}
+
+const post = async () => ({ seq: 99 });
+
+function managedRunnerOpts(workdir: string, stateDir: string, over: Record<string, unknown> = {}) {
+  return {
+    server: "http://agentparty.test",
+    token: "ap_test",
+    channel: "dev",
+    harness: "codex" as const,
+    workdir,
+    post,
+    managedMcp: { stateDir, ownerDecisionBinding: () => true },
+    ...over,
+  };
+}
+
+describe("managed mcp lane：动作即工具，文本即日志（#581）", () => {
+  test("front 任意 prose + 字面 [attach:] 行 + 一个工具动作 → 回合完成，不 WakeBlockedError", async () => {
+    const workdir = tempDir();
+    const stateDir = join(workdir, "mcp");
+    const posted: unknown[] = [];
+    const run = createBuiltinRunner(managedRunnerOpts(workdir, stateDir, {
+      post: async (_s: string, _t: string, _c: string, payload: unknown) => {
+        posted.push(payload);
+        return { seq: 99 };
+      },
+      runProcess: async (args: string[]) => {
+        const out = args[args.indexOf("-o") + 1]!;
+        // 模型输出随意 prose——含 #578 会 brick 整个 wake 的两种毒样本：
+        // 非 JSON 文本 + 字面 [attach:/绝对路径] 行。mcp 协议下它们只进日志。
+        writeFileSync(out, "我先复述一下任务。\n[attach:/etc/passwd]\n然后开始派工。\n");
+        // 模拟 MCP 工具在回合内完成了一次派工（工具 handler 落的回执）。
+        appendManagedAction(stateDir, 7, { action: "worker_dispatch", seq: 42, at: Date.now() });
+        return { code: 0, stdout: "session id: 019f35d9-0000-7000-8000-000000000007\n", stderr: "" };
+      },
+    }));
+    await run(message(7), context(delivery(7)));
+    // runner 自己没发任何频道消息（wake ack status 除外）——发消息是工具的事。
+    expect(posted.filter((p) => (p as { kind?: string }).kind === "message")).toHaveLength(0);
+  });
+
+  test("零工具动作的回合 → WakeBlockedError（未送达，不吞 @）", async () => {
+    const workdir = tempDir();
+    const stateDir = join(workdir, "mcp");
+    const run = createBuiltinRunner(managedRunnerOpts(workdir, stateDir, {
+      runProcess: async (args: string[]) => {
+        const out = args[args.indexOf("-o") + 1]!;
+        writeFileSync(out, "我认为这个问题很有意思，但我什么工具都没调。\n");
+        return { code: 0, stdout: "session id: 019f35d9-0000-7000-8000-000000000008\n", stderr: "" };
+      },
+    }));
+    await expect(run(message(8), context(delivery(8)))).rejects.toThrow(WakeBlockedError);
+    await expect(
+      createBuiltinRunner(managedRunnerOpts(tempDir(), join(tempDir(), "mcp"), {
+        runProcess: async (args: string[]) => {
+          writeFileSync(args[args.indexOf("-o") + 1]!, "still nothing\n");
+          return { code: 0, stdout: "session id: 019f35d9-0000-7000-8000-000000000009\n", stderr: "" };
+        },
+      }))(message(9), context(delivery(9))),
+    ).rejects.toThrow(/no channel action/);
+  });
+
+  test("codex 参数注入 party MCP server；wake.json 带 delivery 快照与决策绑定", async () => {
+    const workdir = tempDir();
+    const stateDir = join(workdir, "mcp");
+    let seen: string[] = [];
+    let binding = false;
+    const run = createBuiltinRunner(managedRunnerOpts(workdir, stateDir, {
+      managedMcp: { stateDir, ownerDecisionBinding: () => binding },
+      runProcess: async (args: string[]) => {
+        seen = args;
+        writeFileSync(args[args.indexOf("-o") + 1]!, "ok\n");
+        appendManagedAction(stateDir, 11, { action: "channel_reply", seq: 43, at: Date.now() });
+        return { code: 0, stdout: "session id: 019f35d9-0000-7000-8000-000000000011\n", stderr: "" };
+      },
+    }));
+    binding = true;
+    await run(message(11), context(delivery(11)));
+    const joined = seen.join(" ");
+    expect(joined).toContain('mcp_servers.party.command=');
+    expect(joined).toContain(`mcp_servers.party.args=["mcp","--managed",${JSON.stringify(stateDir)}]`);
+    // mcp 协议不再给 harness 传 --output-schema（六字段 JSON 时代的产物）。
+    expect(seen).not.toContain("--output-schema");
+    const wake = readManagedWake(stateDir);
+    expect(wake).toMatchObject({
+      version: 1,
+      seq: 11,
+      owner_decision_binding: true,
+      delivery: { cause: "mention", work_id: "work-11", continuation_ref: "ref-11" },
+    });
+    expect(wake.frame.seq).toBe(11);
+  });
+
+  test("claude 参数注入 --mcp-config/--strict-mcp-config/--allowedTools，config 指回 stateDir", async () => {
+    const workdir = tempDir();
+    const stateDir = join(workdir, "mcp");
+    let seen: string[] = [];
+    const run = createBuiltinRunner(managedRunnerOpts(workdir, stateDir, {
+      harness: "claude" as const,
+      runProcess: async (args: string[]) => {
+        seen = args;
+        appendManagedAction(stateDir, 12, { action: "channel_reply", seq: 44, at: Date.now() });
+        const sid = args[args.indexOf("--session-id") + 1]!;
+        return { code: 0, stdout: JSON.stringify({ session_id: sid, result: "prose goes to log" }), stderr: "" };
+      },
+    }));
+    await run(message(12), context(delivery(12)));
+    expect(seen).toContain("--strict-mcp-config");
+    expect(seen).toContain("--allowedTools");
+    expect(seen[seen.indexOf("--allowedTools") + 1]).toBe("mcp__party");
+    const configPath = seen[seen.indexOf("--mcp-config") + 1]!;
+    const config = JSON.parse(readFileSync(configPath, "utf8")) as {
+      mcpServers: { party: { args: string[] } };
+    };
+    expect(config.mcpServers.party.args).toEqual(["mcp", "--managed", stateDir]);
+  });
+});
+
+describe("assertManagedWorkerWake：mcp 纯结构化，text 保留前缀（#581/#578）", () => {
+  const workerContext = (protocol: "mcp" | "text"): ProjectAgentRunContext => ({
+    owner_account: "owner@example.com",
+    handle: "builder",
+    name: "builder",
+    runner: "codex",
+    repo_url: null,
+    workdir: null,
+    base_branch: "main",
+    worktree_strategy: "branch",
+    rules: null,
+    runtime_role: "worker",
+    protocol,
+    front_agent: "front-1",
+    workers: [],
+    channel_workdir: "/w",
+    runner_workdir: "/r",
+    delivery_workflow: {
+      steps: [
+        "work_in_channel_worktree",
+        "create_pull_request",
+        "report_pull_request_url_in_channel",
+        "verify_deployment",
+        "prune_merged_worktree",
+      ],
+      cleanup_command: "true",
+      cleanup_guard: "guard",
+    },
+  });
+  const dispatchFrame = (body: string): MsgFrame =>
+    message(20, {
+      body,
+      reply_to: 5,
+      mentions: ["me"],
+      sender: { name: "front-1", kind: "agent", owner: "owner@example.com" } as MsgFrame["sender"],
+    });
+
+  test("mcp：无前缀的自由文本派工被结构化验收接受", () => {
+    expect(() =>
+      assertManagedWorkerWake(dispatchFrame("请把登录页的 bug 修了，验收标准如下……"), delivery(20), workerContext("mcp"), "me"),
+    ).not.toThrow();
+  });
+
+  test("mcp：结构缺陷（无 reply_to / 非 front 发送者）仍被拒", () => {
+    expect(() =>
+      assertManagedWorkerWake(dispatchFrame("x") && { ...dispatchFrame("x"), reply_to: null }, delivery(20), workerContext("mcp"), "me"),
+    ).toThrow(ManagedWorkerUndispatchedError);
+    expect(() =>
+      assertManagedWorkerWake(
+        { ...dispatchFrame("x"), sender: { name: "someone-else", kind: "agent", owner: "owner@example.com" } as MsgFrame["sender"] },
+        delivery(20),
+        workerContext("mcp"),
+        "me",
+      ),
+    ).toThrow(ManagedWorkerUndispatchedError);
+  });
+
+  test("text：无前缀文本仍被拒（旧协议逃生舱行为不变）", () => {
+    expect(() =>
+      assertManagedWorkerWake(dispatchFrame("请把登录页的 bug 修了"), delivery(20), workerContext("text"), "me"),
+    ).toThrow(ManagedWorkerUndispatchedError);
+    expect(() =>
+      assertManagedWorkerWake(dispatchFrame("已派工 me：修登录页 bug"), delivery(20), workerContext("text"), "me"),
+    ).not.toThrow();
+  });
+});
+
+describe("已派工前缀退役方向（#581 验收：mcp 主路径零前缀）", () => {
+  test("managed.ts（mcp 两侧共享件）没有任何中文动词前缀", () => {
+    const source = readFileSync(join(import.meta.dir, "..", "src", "managed.ts"), "utf8");
+    expect(source).not.toContain("已派工");
+    expect(source).not.toContain("已要求补充/返工");
+    const mcpManaged = readFileSync(join(import.meta.dir, "..", "src", "commands", "mcp-managed.ts"), "utf8");
+    expect(mcpManaged).not.toContain("已派工");
+    expect(mcpManaged).not.toContain("已要求补充/返工");
+  });
+});


### PR DESCRIPTION
Closes #581。

## 核心改变

managed profile 的模型操作面从「散文 reminder + 六字段 JSON 文本输出再解析」改为**角色裁剪的 MCP 工具调用**：模型文本输出只进日志，一切频道动作＝工具调用。#578 评审确认的四条文本协议缺陷从结构上消除。

## 设计（含与 issue 原文的三处有意偏差，均写明理由）

**1. supervisor↔MCP server 文件握手**（`cli/src/managed.ts`，两侧唯一事实源）：`managed.json`（lane 清单，attach 时一次）+ `wake.json`（每 wake 覆写，工具即读即用）+ `outcome-<seq>.ndjson`（动作回执，supervisor 回合结束消费）。此方案对 claude/codex/未来 sdk 三种 harness 形态统一——比 issue 提的 per-role flag 传参多出「supervisor 能感知回合内动作」的能力，零动作回合可判未送达（不吞 @）。

**2. 派工验收纯结构化，且零 Worker(CF) 改动**：front 的 `party_reply` 没有 mentions 能力 ⇒ 任何 front @worker 的消息在结构上只能出自 dispatch/feedback 工具。`assertManagedWorkerWake` 在 mcp 协议下只验 delivery 结构化字段 + sender=front + mentions=self + reply_to 非空——「已派工」前缀比对（#578 finding 3 根源）退役。**角色即工具集，这正是 issue 的第一性原理**。

**3. auto-decision 续跑循环退役**：unattended 决策在工具返回里就地告知 chosen option，模型同回合继续——不再需要 supervisor 的 MAX_AUTO_DECISION_CONTINUATIONS 外层循环。

**偏差 a（超时）**：issue 提「runnerTimeoutMs 改按模型轮计时」。MCP 协议下 auto-continuation 循环消失，一个 wake＝一次 harness 进程＝一轮——per-turn 与 per-wake 合一，#578 finding 1（60s 罩 5 轮模型+REST）的病灶不复存在，无需再做定时器手术。front 默认 10min 不变。

**偏差 b（codex-sdk）**：CodexLike 接口本期没有 MCP 注入面，codex-sdk lane 强制 text 并打提示；builtin claude/codex 全量默认 mcp。SDK 注入面留待后续（不阻塞主路径）。

**偏差 c（child token 落盘）**：#578 的「child token 纯内存」在此按 issue 拍板有意放宽——MCP server 进程要持有身份就必须能读到它（`runnerWorkdir/mcp/config.json`，0600）。模型 env 仍是 denied-home。代码注释已写明这是 conscious trade-off。

**兼容窗**：`--protocol mcp|text`，默认 mcp；text 保留一个 minor 周期（deprecation 警告），parseManagedFrontAction 等已标 DEPRECATED 注释；「serve.ts grep 不到前缀」的验收在逃生舱移除时兑现，本 PR 先以「mcp 主路径共享件零前缀」的 grep 断言守住方向。

## 验收标准对照

| issue 验收 | 测试 |
|---|---|
| front 任意 prose 不再 WakeBlockedError | serve-managed-mcp「front 任意 prose + 字面 [attach:] 行」 |
| options:null 回归 | 既有 serve-finding-fixes 保留（text 逃生舱路径） |
| 字面 [attach:] 回归 | 同上 prose 用例（毒样本直接进 run.text） |
| 前缀消失（grep 级） | 「managed.ts/mcp-managed.ts 零中文动词前缀」断言（全量移除随逃生舱退役） |
| worker symlink 逃逸工具层被拒 | mcp-managed「symlink 逃逸 → isError 且零上传零消息」 |
| check:cli 全绿 | 938 passed（923 存量零破坏 + 15 新增） |

check:web/check:worker 无涉（无 web/worker 面改动）；dogfood 全链路（派工→执行→回报→审批）需要真 profile 频道，合并发版后单独跑并回报。

## 关联
#503（分层决策）#553（MCP 不做唤醒面，serve 唤醒机制不动）#578（四条 finding）#580（Phase 1）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增托管 MCP：`party mcp --managed <stateDir>`，按前端/工人角色裁剪工具集，支持频道读取、回复、派工/反馈、负责人决策与结构化回执落盘。
  - `party serve` 新增 `--protocol mcp|text`（默认 mcp），自动装配 managed 配置，并在回合间写入/核验 `wake.json` 与工具回执。

- **安全改进**
  - 附件加入真实路径边界与符号链接逃逸防护；越界拒绝并阻止相关动作推进。
  - 强化血缘/线程与决策链路校验；重复独占动作与“无通道动作”场景下 fail-closed。

- **可靠性**
  - 改善同回合工具完成状态识别与回执清理，降低旧动作回填误用风险。

- **测试**
  - 新增 managed MCP 与 managed lane 的端到端与协议差异用例，覆盖附件与拒绝边界场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->