### PR TITLE
fix(watch): capability 门禁、party ack、MCP 输出流——watch 可用性三连修

### DIFF
--- a/cli/src/commands/ack.ts
+++ b/cli/src/commands/ack.ts
@@ -2,7 +2,7 @@
 // 没有合法的清账手段，被迫发一条无信息量的消息——这正是频道礼仪劝阻的行为。
 // 只清 watch 源的债；serve 的 directed 债由 serve 闭环自己管（误清=静默丢 @，#198 红线）。
 import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
-import { clearStuck, loadStuck, resolveChannel } from "../config";
+import { ackWatchStuck, resolveChannel } from "../config";
 import { isSlug, parsePositiveIntFlag } from "../validation";
 
 const FLAGS = ["channel", "seq"];
@@ -50,23 +50,23 @@ export async function run(argv: string[]): Promise<number> {
     console.error("channel must match [a-z0-9][a-z0-9-]{0,63}");
     return 1;
   }
-  const stuck = loadStuck(channel);
-  if (stuck === null) {
-    console.log(`no pending wake debt in #${channel}`);
-    return 0;
+  // 校验与清除同处一个跨进程临界区（ackWatchStuck）：读后清会误吞窗口内新落的债（#599 评审）。
+  const acked = ackWatchStuck(channel, seqFlag);
+  switch (acked.outcome) {
+    case "none":
+      console.log(`no pending wake debt in #${channel}`);
+      return 0;
+    case "serve_owned":
+      console.error(
+        `refusing to ack: pending debt at seq=${acked.seq} is owned by party serve (source=${acked.source}); ` +
+          "serve replays it durably — clearing it by hand would silently drop that @",
+      );
+      return 1;
+    case "seq_mismatch":
+      console.error(`refusing to ack: pending watch debt is seq=${acked.seq}, not seq=${seqFlag}`);
+      return 1;
+    case "cleared":
+      console.log(`acked watch wake seq=${acked.seq} in #${channel}`);
+      return 0;
   }
-  if (stuck.source !== "watch") {
-    console.error(
-      `refusing to ack: pending debt at seq=${stuck.seq} is owned by party serve (source=${stuck.source}); ` +
-        "serve replays it durably — clearing it by hand would silently drop that @",
-    );
-    return 1;
-  }
-  if (seqFlag !== undefined && stuck.seq !== seqFlag) {
-    console.error(`refusing to ack: pending watch debt is seq=${stuck.seq}, not seq=${seqFlag}`);
-    return 1;
-  }
-  clearStuck(channel);
-  console.log(`acked watch wake seq=${stuck.seq} in #${channel}`);
-  return 0;
 }

--- a/cli/src/commands/ack.ts
+++ b/cli/src/commands/ack.ts
@@ -1,0 +1,72 @@
+// party ack — 显式了结 watch 欠账（#594）：纯读场景（读到别人的 status/不需要回应的消息）
+// 没有合法的清账手段，被迫发一条无信息量的消息——这正是频道礼仪劝阻的行为。
+// 只清 watch 源的债；serve 的 directed 债由 serve 闭环自己管（误清=静默丢 @，#198 红线）。
+import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
+import { clearStuck, loadStuck, resolveChannel } from "../config";
+import { isSlug, parsePositiveIntFlag } from "../validation";
+
+const FLAGS = ["channel", "seq"];
+const HELP = `usage: party ack [--channel C] [--seq N]
+
+Acknowledge the pending watch wake debt without posting a message. Use it after
+a watch --once delivered a frame that warrants no reply (someone else's status,
+FYI messages) — replying with empty acks burns the loop guard; leaving the debt
+unacknowledged makes every later watch replay the same frame (#594).
+
+Only watch-sourced debt can be acked. Debt owned by party serve is never touched
+here: serve replays it durably and clearing it by hand would silently drop an @.
+
+Options:
+  --channel C   channel to ack in (defaults to the bound channel)
+  --seq N       only ack if the pending debt is exactly seq N (guard against races)`;
+
+export async function run(argv: string[]): Promise<number> {
+  if (isHelpArg(argv, { allowHelpPositional: true })) {
+    console.log(HELP);
+    return 0;
+  }
+  const { positionals, flags } = parseArgs(argv);
+  const unknown = unknownFlagError(flags, FLAGS);
+  if (unknown !== null) {
+    console.error(unknown);
+    return 1;
+  }
+  const flagError = valueFlagError(flags, ["channel", "seq"]);
+  if (flagError !== null) {
+    console.error(flagError);
+    return 1;
+  }
+  const seqFlag = parsePositiveIntFlag(str(flags.seq), "seq");
+  if (typeof seqFlag === "string") {
+    console.error(seqFlag);
+    return 1;
+  }
+  const channel = resolveChannel(str(flags.channel) ?? positionals[0]);
+  if (!channel) {
+    console.error("no channel, pass --channel C or bind with: party init --channel C");
+    return 1;
+  }
+  if (!isSlug(channel)) {
+    console.error("channel must match [a-z0-9][a-z0-9-]{0,63}");
+    return 1;
+  }
+  const stuck = loadStuck(channel);
+  if (stuck === null) {
+    console.log(`no pending wake debt in #${channel}`);
+    return 0;
+  }
+  if (stuck.source !== "watch") {
+    console.error(
+      `refusing to ack: pending debt at seq=${stuck.seq} is owned by party serve (source=${stuck.source}); ` +
+        "serve replays it durably — clearing it by hand would silently drop that @",
+    );
+    return 1;
+  }
+  if (seqFlag !== undefined && stuck.seq !== seqFlag) {
+    console.error(`refusing to ack: pending watch debt is seq=${stuck.seq}, not seq=${seqFlag}`);
+    return 1;
+  }
+  clearStuck(channel);
+  console.log(`acked watch wake seq=${stuck.seq} in #${channel}`);
+  return 0;
+}

--- a/cli/src/commands/mcp.ts
+++ b/cli/src/commands/mcp.ts
@@ -7,8 +7,8 @@ import { z } from "zod";
 import { stripTerminalControls } from "../format";
 import pkg from "../../package.json" with { type: "json" };
 import {
+  ackWatchStuck,
   advanceCursorPastOwnMessage,
-  clearStuck,
   loadCursor,
   loadRevCursor,
   loadStuck,
@@ -1100,19 +1100,19 @@ export function createMcpServer(defaultChannel?: string): McpServer {
     async ({ channel, seq }) => {
       try {
         const resolved = normalizeChannel(channel, defaultChannel);
-        const stuck = loadStuck(resolved);
-        if (stuck === null) return ok({ type: "ack", channel: resolved, acked: false, note: "no pending wake debt" });
-        if (stuck.source !== "watch") {
+        // 与 CLI party ack 共用原子 compare-and-clear（#599 评审）：读后清会误吞窗口内新债。
+        const acked = ackWatchStuck(resolved, seq);
+        if (acked.outcome === "none") return ok({ type: "ack", channel: resolved, acked: false, note: "no pending wake debt" });
+        if (acked.outcome === "serve_owned") {
           return fail(
-            `refusing to ack: pending debt at seq=${stuck.seq} is owned by party serve (source=${stuck.source}); ` +
+            `refusing to ack: pending debt at seq=${acked.seq} is owned by party serve (source=${acked.source}); ` +
               "serve replays it durably — clearing it by hand would silently drop that @",
           );
         }
-        if (seq !== undefined && stuck.seq !== seq) {
-          return fail(`refusing to ack: pending watch debt is seq=${stuck.seq}, not seq=${seq}`);
+        if (acked.outcome === "seq_mismatch") {
+          return fail(`refusing to ack: pending watch debt is seq=${acked.seq}, not seq=${seq}`);
         }
-        clearStuck(resolved);
-        return ok({ type: "ack", channel: resolved, acked: true, seq: stuck.seq });
+        return ok({ type: "ack", channel: resolved, acked: true, seq: acked.seq });
       } catch (e) {
         return fail(e instanceof Error ? e.message : String(e));
       }

--- a/cli/src/commands/mcp.ts
+++ b/cli/src/commands/mcp.ts
@@ -8,6 +8,7 @@ import { stripTerminalControls } from "../format";
 import pkg from "../../package.json" with { type: "json" };
 import {
   advanceCursorPastOwnMessage,
+  clearStuck,
   loadCursor,
   loadRevCursor,
   loadStuck,
@@ -40,7 +41,7 @@ import { isName, isSlug } from "../validation";
 import { askDecision } from "./decision";
 import { uploadAttachmentPaths } from "./send";
 import { buildContext } from "./status";
-import { runWatch } from "./watch";
+import { EXIT_ALREADY_WATCHING, runWatch } from "./watch";
 
 const HELP = `usage: party mcp
 
@@ -78,6 +79,7 @@ Tools:
   task_block
   party_spawn_worker
   party_watch_once
+  party_ack         (clear a watch wake that needs no reply, #594)
   party_wake_test
 
 Resources:
@@ -1050,7 +1052,24 @@ export function createMcpServer(defaultChannel?: string): McpServer {
           onRevCursor: (r) => saveRevCursor(resolved, r),
           out: (line) => lines.push(line),
         });
-        const frames = lines.map((line) => JSON.parse(line) as Record<string, unknown>);
+        const frames = lines.map((line) => {
+          try {
+            return JSON.parse(line) as Record<string, unknown>;
+          } catch {
+            // json 模式下仍可能混入人类可读提示（如单实例冲突）；保留为文本帧，别让整个结果炸掉。
+            return { type: "text", text: line };
+          }
+        });
+        // #596：单 watcher 冲突对 MCP 调用方是可编程状态，不是不可解析的散文。
+        if (code === EXIT_ALREADY_WATCHING) {
+          return {
+            ...fail(
+              `another watcher already holds #${resolved} (likely a CLI \`party watch\` in a terminal). ` +
+                "Wait for it to exit or kill it; a second concurrent watcher would double-fire every @.",
+            ),
+            structuredContent: { type: "watch_once", channel: resolved, exit_code: code, reason: "watcher_conflict", frames },
+          };
+        }
         // 同 replay 路径：唤醒返回帧带缓存化的升级提示（probe:false，零额外网络）。
         const liveUpgrade = await mcpUpgradeNotice(cfg.server, {}, { probe: false });
         const data = {
@@ -1061,6 +1080,39 @@ export function createMcpServer(defaultChannel?: string): McpServer {
           ...(liveUpgrade !== null ? { cli_upgrade: liveUpgrade } : {}),
         };
         return code === 0 ? ok(data) : { ...fail(lines.join("\n") || `watch_once failed with exit ${code}`), structuredContent: data };
+      } catch (e) {
+        return fail(e instanceof Error ? e.message : String(e));
+      }
+    },
+  );
+
+  server.registerTool(
+    "party_ack",
+    {
+      title: "Acknowledge a watch wake that needs no reply",
+      description:
+        "Clear the pending watch wake debt without posting a message (#594). Use after party_watch_once delivered a frame that warrants no reply — replying with empty acks burns the loop guard; leaving the debt makes every later watch replay the same frame. Serve-owned debt is never touched.",
+      inputSchema: {
+        channel: z.string().optional().describe("Channel slug. Defaults to the workspace-bound channel."),
+        seq: z.number().int().positive().optional().describe("Only ack if the pending debt is exactly this seq."),
+      },
+    },
+    async ({ channel, seq }) => {
+      try {
+        const resolved = normalizeChannel(channel, defaultChannel);
+        const stuck = loadStuck(resolved);
+        if (stuck === null) return ok({ type: "ack", channel: resolved, acked: false, note: "no pending wake debt" });
+        if (stuck.source !== "watch") {
+          return fail(
+            `refusing to ack: pending debt at seq=${stuck.seq} is owned by party serve (source=${stuck.source}); ` +
+              "serve replays it durably — clearing it by hand would silently drop that @",
+          );
+        }
+        if (seq !== undefined && stuck.seq !== seq) {
+          return fail(`refusing to ack: pending watch debt is seq=${stuck.seq}, not seq=${seq}`);
+        }
+        clearStuck(resolved);
+        return ok({ type: "ack", channel: resolved, acked: true, seq: stuck.seq });
       } catch (e) {
         return fail(e instanceof Error ? e.message : String(e));
       }
@@ -1150,6 +1202,9 @@ export async function run(argv: string[]): Promise<number> {
     console.error("usage: party mcp [--channel C]");
     return 1;
   }
+  // #596：stdio 模式下 stdout 是 JSON-RPC 信道。任何库/命令路径的 console.log（如 watch 的
+  // 单实例冲突提示）落到 stdout 都会把客户端的解析打碎成 "JSON Parse error"。统一改道 stderr。
+  console.log = (...args: unknown[]) => console.error(...args);
   const server = createMcpServer(defaultChannel);
   await server.connect(new StdioServerTransport());
   return new Promise<number>((resolve) => {

--- a/cli/src/commands/watch.ts
+++ b/cli/src/commands/watch.ts
@@ -817,7 +817,7 @@ export async function run(argv: string[]): Promise<number> {
                 : "") +
               `channel_last_seq=${channelLastSeq} lag=${lag} ` +
               `skipped_mention_seqs=${JSON.stringify(skippedMentionSeqs)}; ` +
-              `send a reply/status after handling it to clear this debt (or \`party ack\` if it needs no response).` +
+              `send a reply/status after handling it to clear this debt (or \`party ack --seq ${stuck.seq}\` if it needs no response).` +
               (lag > 0 ? ` 补上下文：party history ${channel} --since ${stuck.seq}` : ""),
           ));
           console.log(formatMsg(pending));

--- a/cli/src/commands/watch.ts
+++ b/cli/src/commands/watch.ts
@@ -278,9 +278,12 @@ export async function runWatch(o: WatchOptions): Promise<number> {
   // Only the single-shot watcher whose caller can persist and acknowledge directed debt is an
   // actionable v1 adapter. Declare this in the first hello so the Worker never has to guess in the
   // welcome -> register window; observers deliberately omit the capability.
+  // #598：mentionsOnly 不是必要条件——非 mentions-only 的 --once watcher 同样接了完整的
+  // debt 回调（directed 帧本就是 @self 的 mention，两种过滤都匹配）；把它留在条件里会让
+  // `party watch <slug> --once` 在存在 pending durable delivery 时被服务端 upgrade_required
+  // 硬闭，而 latest CLI 明明有能力处理。
   const acceptsDirectedDelivery =
     o.once === true &&
-    o.mentionsOnly &&
     o.onStuck !== undefined &&
     o.onDirectedAccepted !== undefined;
   // 先抢锁，再连服务端：第二个 watcher 连 WS 都不该建，否则它已经开始消费 @ 了（#195）
@@ -537,6 +540,14 @@ export async function runWatch(o: WatchOptions): Promise<number> {
           out(JSON.stringify(jsonFrame({ ...frame, retryable: false, ts: nowTs() })));
         }
         else console.error(terminalOutput(`error: ${frame.code} ${frame.message}`));
+        if (frame.message.startsWith("upgrade_required: durable")) {
+          // #598：别让 upgrade_required 指向死路——说明哪种姿势能接住 durable delivery。
+          console.error(terminalOutput(
+            "hint: durable directed delivery needs an actionable adapter — run `party watch <channel> --once`" +
+              " (CLI >= 0.2.127), or `party serve`; --follow observers cannot attach while a directed delivery" +
+              " is pending for this identity.",
+          ));
+        }
         if (frame.code === "unauthorized") code = EXIT_AUTH;
         else if (frame.code === "loop_guard") code = EXIT_LOOP_GUARD;
         else if (frame.code === "archived") code = EXIT_ARCHIVED;
@@ -806,7 +817,7 @@ export async function run(argv: string[]): Promise<number> {
                 : "") +
               `channel_last_seq=${channelLastSeq} lag=${lag} ` +
               `skipped_mention_seqs=${JSON.stringify(skippedMentionSeqs)}; ` +
-              `send a reply/status after handling it to clear this debt.` +
+              `send a reply/status after handling it to clear this debt (or \`party ack\` if it needs no response).` +
               (lag > 0 ? ` 补上下文：party history ${channel} --since ${stuck.seq}` : ""),
           ));
           console.log(formatMsg(pending));

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -649,6 +649,41 @@ export function markWatchDirectedStuckAccepted(channel: string, deliveryId: stri
   return accepted;
 }
 
+/**
+ * 显式 ack（#594/#599 评审）：校验与清除必须在同一个跨进程临界区里完成——
+ * 读后清的窗口里可能落下新的 watch 债（另一个 watcher 正在跑），裸 clear 会误吞它。
+ * 只清 watch 源；serve 债与 seq 不匹配都原样保留并回报原因。
+ */
+export type AckWatchStuckOutcome =
+  | { outcome: "cleared"; seq: number }
+  | { outcome: "none" }
+  | { outcome: "serve_owned"; seq: number; source: string }
+  | { outcome: "seq_mismatch"; seq: number };
+
+export function ackWatchStuck(channel: string, expectedSeq?: number, cwd?: string): AckWatchStuckOutcome {
+  let result: AckWatchStuckOutcome = { outcome: "none" };
+  updateChannelCursor(channel, (cur) => {
+    const stuck = cur.stuck;
+    if (stuck === undefined) {
+      result = { outcome: "none" };
+      return null;
+    }
+    if (stuck.source !== "watch") {
+      // 旧格式债可能缺 source：来源不明按 serve 保守处理，绝不清（误清=静默丢 @）。
+      result = { outcome: "serve_owned", seq: stuck.seq, source: stuck.source ?? "unknown" };
+      return null;
+    }
+    if (expectedSeq !== undefined && stuck.seq !== expectedSeq) {
+      result = { outcome: "seq_mismatch", seq: stuck.seq };
+      return null;
+    }
+    result = { outcome: "cleared", seq: stuck.seq };
+    const { stuck: _dropped, ...rest } = cur;
+    return rest;
+  }, cwd);
+  return result;
+}
+
 /** 了结欠账：送达成功，或有界重试耗尽后显式放弃。 */
 export function clearStuck(channel: string, cwd?: string): void {
   updateChannelCursor(channel, (cur) => {

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -26,6 +26,7 @@ commands:
   retract   <seq> [--channel C] [--json]
   supersede <seq> <text|-> [--channel C] [--json]
   watch     [channel|--channel C] [--timeout N] [--mentions-only] [--follow] [--json]
+  ack       [--channel C] [--seq N]                acknowledge a watch wake that needs no reply (#594)
   serve     [channel|--channel C] (--on-mention "<cmd>" | --runner codex|claude|codex-sdk) [--all] | --profile owner/handle
   mcp                                                structured control plane (not an idle wake provider)
   lark      notify on|off|status [--channel C]       send channel @mentions to your Lark/Feishu account
@@ -99,6 +100,8 @@ export async function main(argv: string[]): Promise<number> {
       return (await import("./commands/revise")).run(cmd, rest);
     case "watch":
       return (await import("./commands/watch")).run(rest);
+    case "ack":
+      return (await import("./commands/ack")).run(rest);
     case "serve":
       return (await import("./commands/serve")).run(rest);
     case "mcp":

--- a/cli/test/ack.test.ts
+++ b/cli/test/ack.test.ts
@@ -1,0 +1,65 @@
+// #594：party ack——纯读场景的显式清账。只清 watch 源债；serve 债误清=静默丢 @（#198 红线）。
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { run as runAck } from "../src/commands/ack";
+import { loadStuck, saveStuck, saveWatchStuck } from "../src/config";
+
+let home: string;
+let cwd: string;
+let originalCwd: string;
+const oldEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "ap-ack-home-"));
+  cwd = mkdtempSync(join(tmpdir(), "ap-ack-cwd-"));
+  for (const key of ["AGENTPARTY_HOME", "AGENTPARTY_CONFIG", "AGENTPARTY_CHANNEL"]) {
+    oldEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+  process.env.AGENTPARTY_HOME = home;
+  originalCwd = process.cwd();
+  process.chdir(cwd);
+});
+
+afterEach(() => {
+  // check:cli 不带 --isolate：cwd 是进程级状态，不还原会污染后续测试文件的游标路径解析。
+  process.chdir(originalCwd);
+  for (const [key, value] of Object.entries(oldEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  rmSync(home, { recursive: true, force: true });
+  rmSync(cwd, { recursive: true, force: true });
+});
+
+const watchDebt = (seq: number) => ({
+  seq,
+  wake_ts: 1,
+  attempts: 1,
+  source: "watch" as const,
+});
+
+describe("party ack（#594）", () => {
+  test("watch 债被清账；再跑一次报无债", async () => {
+    expect(saveWatchStuck("dev", watchDebt(19))).toBe(true);
+    expect(await runAck(["--channel", "dev"])).toBe(0);
+    expect(loadStuck("dev")).toBeNull();
+    expect(await runAck(["--channel", "dev"])).toBe(0);
+  });
+
+  test("--seq 不匹配拒绝清账", async () => {
+    expect(saveWatchStuck("dev", watchDebt(19))).toBe(true);
+    expect(await runAck(["--channel", "dev", "--seq", "20"])).toBe(1);
+    expect(loadStuck("dev")).not.toBeNull();
+    expect(await runAck(["--channel", "dev", "--seq", "19"])).toBe(0);
+    expect(loadStuck("dev")).toBeNull();
+  });
+
+  test("serve 源债绝不触碰", async () => {
+    saveStuck("dev", { seq: 7, wake_ts: 1, attempts: 1, source: "serve" } as never);
+    expect(await runAck(["--channel", "dev"])).toBe(1);
+    expect(loadStuck("dev")).not.toBeNull();
+  });
+});

--- a/cli/test/watch-598-capability.test.ts
+++ b/cli/test/watch-598-capability.test.ts
@@ -1,0 +1,68 @@
+// #598：`party watch <slug> --once`（不带 --mentions-only）也必须声明 directed_delivery v1——
+// 债务回调齐备的 --once watcher 就是 actionable adapter；把 mentionsOnly 留在 capability 条件里，
+// 会让存在 pending durable delivery 的身份被服务端 upgrade_required 硬闭，而 latest CLI 明明接得住。
+import { afterEach, describe, expect, test } from "bun:test";
+import { EXIT_ARCHIVED } from "@agentparty/shared";
+import { runWatch, type WatchOptions } from "../src/commands/watch";
+import { startMockServer, welcomeFrame, type MockServer } from "./mock-server";
+
+let server: MockServer | null = null;
+
+afterEach(() => {
+  server?.stop();
+  server = null;
+});
+
+function baseOpts(over: Partial<WatchOptions> & Pick<WatchOptions, "server">): WatchOptions {
+  return {
+    token: "ap_test",
+    channel: "dev",
+    since: 0,
+    timeoutSec: 2,
+    follow: false,
+    once: true,
+    mentionsOnly: false,
+    allowMultiple: true,
+    backoffBaseMs: 20,
+    onStuck: () => true,
+    onDirectedAccepted: () => true,
+    out: () => {},
+    ...over,
+  };
+}
+
+async function helloOf(over: Partial<WatchOptions>): Promise<Record<string, unknown> | null> {
+  let hello: Record<string, unknown> | null = null;
+  server = startMockServer((frame, sock) => {
+    if (frame.type !== "hello") return;
+    hello = frame as unknown as Record<string, unknown>;
+    sock.send(welcomeFrame(0, "me"));
+    setTimeout(() => sock.send({ type: "error", code: "archived", message: "done" }), 20);
+  });
+  const code = await runWatch(baseOpts({ server: server.url, ...over }));
+  expect(code).toBe(EXIT_ARCHIVED);
+  return hello;
+}
+
+describe("watch directed_delivery capability（#598）", () => {
+  test("--once 不带 --mentions-only：hello 仍声明 v1", async () => {
+    const hello = await helloOf({ mentionsOnly: false });
+    expect(hello).not.toBeNull();
+    expect(hello!.directed_delivery).toBe("v1");
+  });
+
+  test("--once + --mentions-only：v1 照常（原行为不回归）", async () => {
+    const hello = await helloOf({ mentionsOnly: true });
+    expect(hello!.directed_delivery).toBe("v1");
+  });
+
+  test("--follow 观察者仍不声明（observers deliberately omit）", async () => {
+    const hello = await helloOf({ follow: true, once: false, timeoutSec: 1 });
+    expect(hello!.directed_delivery).toBeUndefined();
+  });
+
+  test("缺债务回调的 --once 不声明（不能 ack 的 adapter 不许骗服务端）", async () => {
+    const hello = await helloOf({ onStuck: undefined, onDirectedAccepted: undefined });
+    expect(hello!.directed_delivery).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #594, closes #596, closes #598。

## #598（最重：生产 watch 全瘫的真相）

不是服务端发早了——门禁是 #557 就有的。真正的缺口在 CLI：`acceptsDirectedDelivery` 把 `--mentions-only` 当必要条件，而 `party watch <slug> --once`（不带该 flag）的债务回调其实是齐备的。身份名下存在 pending durable delivery 时，服务端对不声明 v1 的连接 upgrade_required 硬闭 → 「latest CLI 也不支持」的死路观感。修复：capability 条件去掉 mentionsOnly（directed 帧本就是 @self 的 mention，两种过滤都匹配）；upgrade_required 报错追加出路提示。--follow 观察者维持不声明（deliberately omit）。

## #594

新增 `party ack [--channel C] [--seq N]` + MCP `party_ack`：只清 watch 源债；serve 债拒绝触碰并说明原因；--seq 不匹配拒绝（防竞态）。replay 提示文案补 ack 出路。

## #596

MCP stdio 的 stdout 是 JSON-RPC 信道：进 server 模式即全局 console.log→stderr（治的是整类问题，不只这一处泄漏）；watcher 冲突从裸文本变结构化 `reason: watcher_conflict` + 可读指引；json 行解析失败降级为文本帧。

## 验证

- `bun run check:cli` — 930 passed（新增 capability 四象限、ack 三场景；开发中还抓到自测的 cwd 进程级污染并修正）
- 手工核对 #598 复现命令的 hello 帧现在带 `directed_delivery: "v1"`（测试断言）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增 `party ack` 命令：可按频道/`--seq` 确认 watch 欠账并进行校验，提供清晰成功/失败与帮助提示。
  - MCP 新增工具 `party_ack`，支持按 `seq` 原子清账并返回处理结果。
- **改进**
  - `party watch --once` 对定向投递能力判断更准确；遇到 durable 不可接收时给出可执行指引。
  - JSON 模式遇到非 JSON 行不再中断整体；watch 冲突返回更结构化。
- **测试**
  - 补充 `ack` 行为、`--seq` 校验、来源保护、定向投递能力等用例。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->