### PR TITLE
fix(worker): Lark @ 通知自动入册——登录/入会即订阅，退订被记住（#595）

### DIFF
--- a/worker/migrations/0040_lark_notify_optouts.sql
+++ b/worker/migrations/0040_lark_notify_optouts.sql
@@ -1,0 +1,9 @@
+-- #595：Lark DM 通知改为成员默认在场（登录/入会自动入册）后，显式关闭必须被记住——
+-- 否则用户 DELETE 退订，下次登录又被自动重开。optout 行存在即跳过自动入册；
+-- 手动重新开启（POST /lark-notify）时删除 optout。
+CREATE TABLE lark_notify_optouts (
+  channel_slug TEXT NOT NULL,
+  account      TEXT NOT NULL,
+  opted_out_at INTEGER NOT NULL,
+  PRIMARY KEY (channel_slug, account)
+);

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -3261,12 +3261,16 @@ async function ensureLarkNotifySubscription(
   );
   if (!doRes.ok) return "skipped";
   const now = Date.now();
-  await env.DB.prepare(
+  // 原子化（#604 评审）：入口的 optout 检查和这次写入之间，用户可能显式退订——把 NOT EXISTS
+  // 放进同一条 INSERT，D1 单语句原子，晚到的自动入册绝不压过刚落的退订；被跳过时回收 DO webhook。
+  const inserted = await env.DB.prepare(
     `INSERT INTO lark_notify_subscriptions (
        channel_slug, account, target_name, provider_id, provider_kind,
        receive_id, receive_id_type, secret, created_at, updated_at
-     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-     ON CONFLICT(channel_slug, account) DO NOTHING`,
+     )
+     SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+      WHERE NOT EXISTS (SELECT 1 FROM lark_notify_optouts WHERE channel_slug = ? AND account = ?)
+        AND NOT EXISTS (SELECT 1 FROM lark_notify_subscriptions WHERE channel_slug = ? AND account = ?)`,
   )
     .bind(
       slug,
@@ -3279,8 +3283,23 @@ async function ensureLarkNotifySubscription(
       secret,
       now,
       now,
+      slug,
+      account,
+      slug,
+      account,
     )
     .run();
+  if (inserted.meta.changes === 0) {
+    await fetchChannelDO(
+      env,
+      slug,
+      new Request(`https://do/internal/webhooks?name=${encodeURIComponent(profile.handle)}`, {
+        method: "DELETE",
+        headers: { "x-partykit-room": slug },
+      }),
+    ).catch(() => null);
+    return "skipped";
+  }
   return "created";
 }
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -3263,41 +3263,50 @@ async function ensureLarkNotifySubscription(
   const now = Date.now();
   // 原子化（#604 评审）：入口的 optout 检查和这次写入之间，用户可能显式退订——把 NOT EXISTS
   // 放进同一条 INSERT，D1 单语句原子，晚到的自动入册绝不压过刚落的退订；被跳过时回收 DO webhook。
-  const inserted = await env.DB.prepare(
-    `INSERT INTO lark_notify_subscriptions (
-       channel_slug, account, target_name, provider_id, provider_kind,
-       receive_id, receive_id_type, secret, created_at, updated_at
-     )
-     SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
-      WHERE NOT EXISTS (SELECT 1 FROM lark_notify_optouts WHERE channel_slug = ? AND account = ?)
-        AND NOT EXISTS (SELECT 1 FROM lark_notify_subscriptions WHERE channel_slug = ? AND account = ?)`,
-  )
-    .bind(
-      slug,
-      account,
-      profile.handle,
-      provider.id,
-      provider.kind,
-      profile.provider_user_id,
-      inferReceiveIdType(profile.provider_user_id),
-      secret,
-      now,
-      now,
-      slug,
-      account,
-      slug,
-      account,
-    )
-    .run();
-  if (inserted.meta.changes === 0) {
-    await fetchChannelDO(
+  const reclaimWebhook = () =>
+    fetchChannelDO(
       env,
       slug,
-      new Request(`https://do/internal/webhooks?name=${encodeURIComponent(profile.handle)}`, {
+      new Request(`https://do/internal/webhooks?name=${encodeURIComponent(profile.handle!)}`, {
         method: "DELETE",
         headers: { "x-partykit-room": slug },
       }),
     ).catch(() => null);
+  let inserted: D1Result;
+  try {
+    inserted = await env.DB.prepare(
+      `INSERT INTO lark_notify_subscriptions (
+         channel_slug, account, target_name, provider_id, provider_kind,
+         receive_id, receive_id_type, secret, created_at, updated_at
+       )
+       SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+        WHERE NOT EXISTS (SELECT 1 FROM lark_notify_optouts WHERE channel_slug = ? AND account = ?)
+          AND NOT EXISTS (SELECT 1 FROM lark_notify_subscriptions WHERE channel_slug = ? AND account = ?)`,
+    )
+      .bind(
+        slug,
+        account,
+        profile.handle,
+        provider.id,
+        provider.kind,
+        profile.provider_user_id,
+        inferReceiveIdType(profile.provider_user_id),
+        secret,
+        now,
+        now,
+        slug,
+        account,
+        slug,
+        account,
+      )
+      .run();
+  } catch (error) {
+    // INSERT 抛异常（非零行跳过）同样不能留下无主 DO webhook（CodeRabbit #604 复审）。
+    await reclaimWebhook();
+    throw error;
+  }
+  if (inserted.meta.changes === 0) {
+    await reclaimWebhook();
     return "skipped";
   }
   return "created";
@@ -3309,9 +3318,13 @@ async function autoEnrollLarkNotify(env: AppEnv, requestOrigin: string, account:
     const rows = await env.DB.prepare(
       "SELECT channel_slug FROM channel_members WHERE account = ? LIMIT 50",
     ).bind(account).all<{ channel_slug: string }>();
-    for (const row of rows.results ?? []) {
-      await ensureLarkNotifySubscription(env, requestOrigin, account, row.channel_slug).catch(() => "skipped");
-    }
+    // 并行 ensure（CodeRabbit #604 复审）：50 个频道串行 = 50×(多次 D1 + DO fetch)，可能吃穿
+    // waitUntil 预算；并行后墙钟 = 最慢单频道。每个 promise 各自吞错，互不拖累。
+    await Promise.all(
+      (rows.results ?? []).map((row) =>
+        ensureLarkNotifySubscription(env, requestOrigin, account, row.channel_slug).catch(() => "skipped"),
+      ),
+    );
   } catch {
     // 自动入册是增益：任何失败都不打扰登录主流程。
   }
@@ -3461,6 +3474,13 @@ app.delete("/api/channels/:slug/lark-notify", async (c) => {
   if (!(await canAccessLoadedChannel(c.env.DB, identity, channel))) {
     return c.json(errorBody("forbidden", "not allowed in this channel"), 403);
   }
+  // 显式退订要被记住（#595），且必须【先落 optout 再删订阅】（CodeRabbit #604 复审）：
+  // 反序时删订阅→写 optout 的窗口里，并发自动入册的条件 INSERT 见不到 optout 会重插一行，
+  // 最终落成「已退订但订阅仍在」的矛盾态。optout 先持久化，自动入册即不可能再通过。
+  await c.env.DB.prepare(
+    `INSERT INTO lark_notify_optouts (channel_slug, account, opted_out_at) VALUES (?, ?, ?)
+     ON CONFLICT(channel_slug, account) DO UPDATE SET opted_out_at = excluded.opted_out_at`,
+  ).bind(slug, identity.account, Date.now()).run();
   const sub = await c.env.DB.prepare(
     "SELECT target_name FROM lark_notify_subscriptions WHERE channel_slug = ? AND account = ?",
   )
@@ -3479,11 +3499,6 @@ app.delete("/api/channels/:slug/lark-notify", async (c) => {
       .bind(slug, identity.account)
       .run();
   }
-  // 显式退订要被记住（#595）：自动入册（登录/入会）见 optout 即跳过，绝不压过用户手选。
-  await c.env.DB.prepare(
-    `INSERT INTO lark_notify_optouts (channel_slug, account, opted_out_at) VALUES (?, ?, ?)
-     ON CONFLICT(channel_slug, account) DO UPDATE SET opted_out_at = excluded.opted_out_at`,
-  ).bind(slug, identity.account, Date.now()).run();
   return c.json({ enabled: false, channel_slug: slug });
 });
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -2312,6 +2312,8 @@ app.post("/api/auth/:provider/callback", async (c) => {
       metadata: { added_by: `oauth:${provider.id}` },
     });
   }
+  // #595：Lark 登录即把该账号所有成员频道的 @ 通知自动入册（异步、幂等、尊重 optout、失败静默）。
+  c.executionCtx.waitUntil(autoEnrollLarkNotify(c.env, new URL(c.req.url).origin, exchanged.account));
   return c.json({
     access_token: sess.token,
     token_type: "Bearer",
@@ -3211,6 +3213,91 @@ app.get("/api/channels/:slug/management-audit", async (c) => {
 });
 app.use("/api/join/*", requireBearer);
 
+// #595：Lark DM 通知自动入册。此前唯一开关是 CLI `party lark notify on`——web 没有任何入口、
+// 登录也不自动订阅，Lark 用户被 @ 后收不到任何 DM（xdream 实锤：全库仅 owner 手动开过一条）。
+// 成员的 @ 通知应当默认在场：Lark 登录与被拉进频道时自动 ensure。幂等；显式退订（DELETE）落
+// lark_notify_optouts，自动入册永不压过用户手选；任何失败静默——登录/加成员绝不因通知挂掉。
+async function ensureLarkNotifySubscription(
+  env: AppEnv,
+  requestOrigin: string,
+  account: string,
+  slug: string,
+): Promise<"created" | "exists" | "skipped"> {
+  const existing = await env.DB.prepare(
+    "SELECT target_name FROM lark_notify_subscriptions WHERE channel_slug = ? AND account = ?",
+  ).bind(slug, account).first<{ target_name: string }>();
+  if (existing) return "exists";
+  const optedOut = await env.DB.prepare(
+    "SELECT 1 FROM lark_notify_optouts WHERE channel_slug = ? AND account = ?",
+  ).bind(slug, account).first();
+  if (optedOut) return "skipped";
+  const profile = await env.DB.prepare(
+    "SELECT handle, provider, provider_user_id FROM account_profiles WHERE account = ?",
+  ).bind(account).first<{ handle: string | null; provider: string | null; provider_user_id: string | null }>();
+  if (!profile?.handle || !NAME_RE.test(profile.handle) || !profile.provider || !profile.provider_user_id) {
+    return "skipped";
+  }
+  const provider = resolveLarkProvider(env, profile.provider);
+  if (!provider || provider.id !== profile.provider) return "skipped";
+  const channel = await loadChannel(env.DB, slug);
+  if (!channel || channel.archived_at !== null) return "skipped";
+  const secret = randomToken();
+  const relayUrl = new URL(requestOrigin);
+  relayUrl.pathname = "/api/integrations/lark/relay";
+  relayUrl.search = "";
+  const doRes = await fetchChannelDO(
+    env,
+    slug,
+    new Request("https://do/internal/webhooks", {
+      method: "POST",
+      body: JSON.stringify({
+        name: profile.handle,
+        url: relayUrl.toString().replace(/^http:/, "https:"),
+        secret,
+        filter: "mentions",
+      }),
+      headers: { "content-type": "application/json", "x-partykit-room": slug },
+    }),
+  );
+  if (!doRes.ok) return "skipped";
+  const now = Date.now();
+  await env.DB.prepare(
+    `INSERT INTO lark_notify_subscriptions (
+       channel_slug, account, target_name, provider_id, provider_kind,
+       receive_id, receive_id_type, secret, created_at, updated_at
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(channel_slug, account) DO NOTHING`,
+  )
+    .bind(
+      slug,
+      account,
+      profile.handle,
+      provider.id,
+      provider.kind,
+      profile.provider_user_id,
+      inferReceiveIdType(profile.provider_user_id),
+      secret,
+      now,
+      now,
+    )
+    .run();
+  return "created";
+}
+
+// 登录后把该账号所有成员频道逐一 ensure（waitUntil 异步，有界，失败静默）。
+async function autoEnrollLarkNotify(env: AppEnv, requestOrigin: string, account: string): Promise<void> {
+  try {
+    const rows = await env.DB.prepare(
+      "SELECT channel_slug FROM channel_members WHERE account = ? LIMIT 50",
+    ).bind(account).all<{ channel_slug: string }>();
+    for (const row of rows.results ?? []) {
+      await ensureLarkNotifySubscription(env, requestOrigin, account, row.channel_slug).catch(() => "skipped");
+    }
+  } catch {
+    // 自动入册是增益：任何失败都不打扰登录主流程。
+  }
+}
+
 app.get("/api/channels/:slug/lark-notify", async (c) => {
   const identity = c.get("identity");
   if (identity.role !== "human" || identity.account == null) {
@@ -3290,6 +3377,10 @@ app.post("/api/channels/:slug/lark-notify", async (c) => {
       }),
     ).catch(() => null);
   }
+  // 手动开启即撤销显式退订（#595）：用户意图以最后一次手选为准。
+  await c.env.DB.prepare("DELETE FROM lark_notify_optouts WHERE channel_slug = ? AND account = ?")
+    .bind(slug, identity.account)
+    .run();
   const secret = randomToken();
   const relayUrl = new URL(c.req.url);
   relayUrl.pathname = "/api/integrations/lark/relay";
@@ -3369,6 +3460,11 @@ app.delete("/api/channels/:slug/lark-notify", async (c) => {
       .bind(slug, identity.account)
       .run();
   }
+  // 显式退订要被记住（#595）：自动入册（登录/入会）见 optout 即跳过，绝不压过用户手选。
+  await c.env.DB.prepare(
+    `INSERT INTO lark_notify_optouts (channel_slug, account, opted_out_at) VALUES (?, ?, ?)
+     ON CONFLICT(channel_slug, account) DO UPDATE SET opted_out_at = excluded.opted_out_at`,
+  ).bind(slug, identity.account, Date.now()).run();
   return c.json({ enabled: false, channel_slug: slug });
 });
 
@@ -4164,6 +4260,10 @@ app.put("/api/channels/:slug/members/:account", async (c) => {
     channel: slug,
     timestamp: addedAt,
   });
+  // #595：Lark 人类被拉进频道即自动订阅 @ 通知（幂等，尊重 optout，失败静默）。
+  c.executionCtx.waitUntil(
+    ensureLarkNotifySubscription(c.env, new URL(c.req.url).origin, account, slug).then(() => undefined, () => undefined),
+  );
   return c.json({ account, added_by: addedBy, added_at: addedAt });
 });
 

--- a/worker/test/lark-oauth-presence.spec.ts
+++ b/worker/test/lark-oauth-presence.spec.ts
@@ -14,6 +14,44 @@ afterEach(() => fetchMock.assertNoPendingInterceptors());
 afterAll(() => fetchMock.deactivate());
 
 describe("Lark OAuth human presence (#527)", () => {
+  it("#595: OAuth 登录自动把成员频道的 @ 通知入册（waitUntil 落库）", async () => {
+    const openId = uniq("on_enroll");
+    // 账号形状 = directoryAccount(providerId, openId) = "<providerId>:<openId>"。
+    const account = `lark-main:${openId}`;
+    // 预置成员关系与 handle（模拟老成员回来登录）；登录回调应触发 autoEnrollLarkNotify。
+    const owner = await seedToken("human", uniq("human"), { owner: `lark-email:${uniq("o")}@example.com` });
+    const slug = await createChannel(owner.token);
+    await env.DB.prepare(
+      "INSERT INTO channel_members (channel_slug, account, added_by, added_at) VALUES (?, ?, 'test', ?)",
+    ).bind(slug, account, Date.now()).run();
+
+    fetchMock.get(LARK_ORIGIN)
+      .intercept({ path: "/open-apis/authen/v2/oauth/token", method: "POST" })
+      .reply(200, { code: 0, access_token: "oauth-user-token", expires_in: 3600 });
+    fetchMock.get(LARK_ORIGIN)
+      .intercept({ path: "/open-apis/authen/v1/user_info", method: "GET" })
+      .reply(200, {
+        code: 0,
+        data: { open_id: openId, name: "Enroll User", tenant_key: "tenant-test" },
+      });
+    const callback = await SELF.fetch("http://ap.test/api/auth/lark-main/callback", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ code: "oauth-code", redirect_uri: "https://app.example/callback" }),
+    });
+    expect(callback.status).toBe(200);
+
+    const deadline = Date.now() + 2000;
+    let sub: { target_name: string } | null = null;
+    while (sub === null && Date.now() < deadline) {
+      sub = await env.DB.prepare(
+        "SELECT target_name FROM lark_notify_subscriptions WHERE channel_slug = ? AND account = ?",
+      ).bind(slug, account).first<{ target_name: string }>();
+      if (sub === null) await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    expect(sub).not.toBeNull();
+  });
+
   it("keeps a no-email Lark profile across first join, reconnect, messages, and a new channel", async () => {
     const openId = uniq("on_profile");
     const displayName = "Lark Profile User";

--- a/worker/test/lark.spec.ts
+++ b/worker/test/lark.spec.ts
@@ -126,6 +126,16 @@ describe("lark notification integration", () => {
     expect(await webhookRows(slug)).toEqual([]);
   });
 
+  async function waitFor<T>(probe: () => Promise<T | null>, timeoutMs = 2000): Promise<T | null> {
+    const deadline = Date.now() + timeoutMs;
+    for (;;) {
+      const value = await probe();
+      if (value !== null) return value;
+      if (Date.now() >= deadline) return null;
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+  }
+
   it("#595: adding a lark member auto-enrolls the mention subscription (idempotent, optout respected)", async () => {
     const ownerAccount = `lark-email:${uniq("owner")}@example.com`;
     await seedLarkProfile(ownerAccount, "larkowner");
@@ -137,10 +147,10 @@ describe("lark notification integration", () => {
     // 被拉进频道 → waitUntil 自动入册。
     const add = await api(`/api/channels/${slug}/members/${encodeURIComponent(memberAccount)}`, owner.token, { method: "PUT" });
     expect(add.status).toBe(200);
-    await new Promise((resolve) => setTimeout(resolve, 50));
-    const sub = await env.DB.prepare(
+    // waitUntil 的落库时机不保证：条件轮询而非固定 sleep（评审意见）。
+    const sub = await waitFor(() => env.DB.prepare(
       "SELECT target_name FROM lark_notify_subscriptions WHERE channel_slug = ? AND account = ?",
-    ).bind(slug, memberAccount).first<{ target_name: string }>();
+    ).bind(slug, memberAccount).first<{ target_name: string }>());
     expect(sub?.target_name).toBe(memberProfile.handle);
     expect((await webhookRows(slug)).some((row) => row.name === memberProfile.handle)).toBe(true);
 
@@ -148,11 +158,11 @@ describe("lark notification integration", () => {
     const member = await seedToken("human", uniq("member"), { owner: memberAccount });
     expect((await api(`/api/channels/${slug}/lark-notify`, member.token, { method: "DELETE" })).status).toBe(200);
     expect((await api(`/api/channels/${slug}/members/${encodeURIComponent(memberAccount)}`, owner.token, { method: "PUT" })).status).toBe(200);
-    await new Promise((resolve) => setTimeout(resolve, 50));
-    const after = await env.DB.prepare(
+    // 负向断言没有「落库事件」可等：等一个足以让 waitUntil 完成的窗口（轮询确认始终为空）。
+    const reappeared = await waitFor(() => env.DB.prepare(
       "SELECT 1 FROM lark_notify_subscriptions WHERE channel_slug = ? AND account = ?",
-    ).bind(slug, memberAccount).first();
-    expect(after).toBeNull();
+    ).bind(slug, memberAccount).first(), 300);
+    expect(reappeared).toBeNull();
 
     // 手动重新开启 → optout 撤销。
     expect((await api(`/api/channels/${slug}/lark-notify`, member.token, { method: "POST" })).status).toBe(201);

--- a/worker/test/lark.spec.ts
+++ b/worker/test/lark.spec.ts
@@ -126,6 +126,42 @@ describe("lark notification integration", () => {
     expect(await webhookRows(slug)).toEqual([]);
   });
 
+  it("#595: adding a lark member auto-enrolls the mention subscription (idempotent, optout respected)", async () => {
+    const ownerAccount = `lark-email:${uniq("owner")}@example.com`;
+    await seedLarkProfile(ownerAccount, "larkowner");
+    const owner = await seedToken("human", uniq("human"), { owner: ownerAccount });
+    const slug = await createChannel(owner.token);
+
+    const memberAccount = "lark:on_auto_enroll_target";
+    const memberProfile = await seedLarkProfile(memberAccount, "larkkarl");
+    // 被拉进频道 → waitUntil 自动入册。
+    const add = await api(`/api/channels/${slug}/members/${encodeURIComponent(memberAccount)}`, owner.token, { method: "PUT" });
+    expect(add.status).toBe(200);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    const sub = await env.DB.prepare(
+      "SELECT target_name FROM lark_notify_subscriptions WHERE channel_slug = ? AND account = ?",
+    ).bind(slug, memberAccount).first<{ target_name: string }>();
+    expect(sub?.target_name).toBe(memberProfile.handle);
+    expect((await webhookRows(slug)).some((row) => row.name === memberProfile.handle)).toBe(true);
+
+    // 显式退订 → optout 记忆；再次入会不得重开。
+    const member = await seedToken("human", uniq("member"), { owner: memberAccount });
+    expect((await api(`/api/channels/${slug}/lark-notify`, member.token, { method: "DELETE" })).status).toBe(200);
+    expect((await api(`/api/channels/${slug}/members/${encodeURIComponent(memberAccount)}`, owner.token, { method: "PUT" })).status).toBe(200);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    const after = await env.DB.prepare(
+      "SELECT 1 FROM lark_notify_subscriptions WHERE channel_slug = ? AND account = ?",
+    ).bind(slug, memberAccount).first();
+    expect(after).toBeNull();
+
+    // 手动重新开启 → optout 撤销。
+    expect((await api(`/api/channels/${slug}/lark-notify`, member.token, { method: "POST" })).status).toBe(201);
+    const optout = await env.DB.prepare(
+      "SELECT 1 FROM lark_notify_optouts WHERE channel_slug = ? AND account = ?",
+    ).bind(slug, memberAccount).first();
+    expect(optout).toBeNull();
+  });
+
   it("relays a valid signed mention webhook to a Lark private card", async () => {
     const account = `lark-email:${uniq("relay")}@example.com`;
     const profile = await seedLarkProfile(account, "larkrelay");


### PR DESCRIPTION
Closes #595。

## 诊断（生产取证）

@karl（王路，真实 Lark 用户，已登录过）无 Feishu DM 的根因：**通知是纯 opt-in，唯一开关是 CLI `party lark notify on`**——web 没有任何入口，Lark 登录也不自动订阅。xdream 全库 `lark_notify_subscriptions` 只有 owner 自己手动开过的一条；karl 是 kyc/leo-code-space 成员却零订阅。机器人「没发通知」是按实现工作、按产品期望坏掉。

## 修法：成员的 @ 通知默认在场

- `ensureLarkNotifySubscription`：幂等 ensure（已订阅/已 optout/profile 不完整/provider 未配置/频道归档均静默跳过），webhook+落库形状与手动 POST 完全一致
- **钩子①** Lark OAuth callback：登录成功即 waitUntil 批量入册该账号的全部成员频道（`channel_members`，有界 50）
- **钩子②** `PUT /api/channels/:slug/members/:account`：owner 拉 lark 人类入会即入册该频道
- **显式退订被记住**（migration 0039 `lark_notify_optouts`）：DELETE 落 optout，自动入册见 optout 即跳过——机器永不压过用户手选；手动 POST 重开即撤销 optout
- 全部 waitUntil + 静默失败：登录/加成员主流程绝不因通知增益挂掉

## 验证

- worker vitest 88 文件 / 658 全过（先 build web）
- 新增集成测试：入会自动入册（webhook 落 DO）→ 显式退订 → 再入会不重开 → 手动重开撤销 optout 全链路
- 部署后 karl 的场景闭环：他下次 Lark 登录即自动订阅 kyc/leo-code-space，@karl 出 DM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - Lark 登录成功后，后台异步自动为账号已加入的频道开通“提及（mentions）”通知订阅。
  - 新成员加入频道后，将自动触发对应“提及”通知订阅（幂等处理）。

- **改进**
  - 新增退订记忆：显式关闭会持久化 opt-out，阻止后续自动重新订阅。
  - 手动重新开启会清除对应退订记录，使自动订阅恢复。

- **测试**
  - 补充集成测试，覆盖自动入册、退订不复开、以及手动开启恢复的场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->