### PR TITLE
feat(presence): Claude Code hooks 活动上报——频道看得见 agent 在干什么（#602）

### DIFF
--- a/cli/src/activity.ts
+++ b/cli/src/activity.ts
@@ -58,11 +58,13 @@ export function writeActivityFile(path: string, activity: AgentActivity): void {
   atomicWriteJson(path, activity);
 }
 
-/** serve 心跳侧读取：文件缺失/脏值/超 TTL 都返回 null（本拍不带 activity）。 */
+/** serve 心跳侧读取：文件缺失/脏值/超 TTL/未来时间戳都返回 null（本拍不带 activity）。 */
 export function readActivityFile(path: string, now: number, ttlMs: number = ACTIVITY_TTL_MS): AgentActivity | null {
   try {
     const parsed = parseAgentActivity(JSON.parse(readFileSync(path, "utf8")) as unknown);
     if (parsed === undefined) return null;
+    // 未来时间戳（写坏/时钟跳变）会让 TTL 永不过期，按脏值丢弃；容忍 1 分钟正常时钟抖动。
+    if (parsed.ts - now > 60_000) return null;
     return now - parsed.ts <= ttlMs ? parsed : null;
   } catch {
     return null;

--- a/cli/src/activity.ts
+++ b/cli/src/activity.ts
@@ -1,0 +1,79 @@
+// 模型 session 活动上报（issue #602）的本地契约：hook 进程只写文件、serve 心跳只读文件。
+// hook 每次工具调用都会触发，绝不能走网络热路径；serve 本来就有 15s 心跳帧，捎带即可。
+// 文件路径由 serve 经 AP_ACTIVITY_FILE env 显式递给 runner（hook 子进程继承），
+// 双方对同一路径达成一致，完全绕开「hook 的 session_id 与 serve 已知句柄对不上」的映射问题。
+import { readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { parseAgentActivity, type AgentActivity, type AgentActivityPhase } from "@agentparty/shared";
+import { atomicWriteJson } from "./atomic-json";
+
+/** hook 落盘超过这个岁数即视为陈旧，不再随心跳上行（模型进程可能已死，别让频道看僵活动）。 */
+export const ACTIVITY_TTL_MS = 5 * 60_000;
+
+/** serve 为某个 runner workdir 约定的 activity 文件路径；经 AP_ACTIVITY_FILE 递给 runner。 */
+export function runnerActivityFile(workdir: string): string {
+  return join(workdir, "activity.json");
+}
+
+// Claude Code hook stdin payload → activity 快照。认不出的事件返回 null（不覆盖现状）：
+// SubagentStop 时主 session 还在跑、盲目写 idle 会说谎。tool 只取名字，入参正文绝不落盘。
+export function activityFromHookEvent(payload: Record<string, unknown>, now: number): AgentActivity | null {
+  const event = typeof payload.hook_event_name === "string" ? payload.hook_event_name : "";
+  const tool = typeof payload.tool_name === "string" && payload.tool_name.length > 0
+    ? payload.tool_name.slice(0, 64)
+    : undefined;
+  const snapshot = (phase: AgentActivityPhase, withTool = false): AgentActivity => ({
+    phase,
+    ...(withTool && tool !== undefined ? { tool } : {}),
+    ts: now,
+  });
+  switch (event) {
+    case "SessionStart":
+      return snapshot("starting");
+    case "UserPromptSubmit":
+    case "PostToolUse":
+      return snapshot("working");
+    case "PreToolUse":
+      return snapshot("tool", true);
+    case "PreCompact":
+      return snapshot("compacting");
+    case "Stop":
+    case "SessionEnd":
+      return snapshot("idle");
+    case "Notification": {
+      // Notification 一帧多义：权限请求（headless 最致命的静默挂法）vs 等输入 vs 其它杂音。
+      // 按 message 文案区分；认不出的一律忽略，宁可少报不误报。
+      const message = typeof payload.message === "string" ? payload.message : "";
+      if (/permission/i.test(message)) return snapshot("waiting_permission", true);
+      if (/waiting for (your )?input/i.test(message)) return snapshot("waiting_input");
+      return null;
+    }
+    default:
+      return null;
+  }
+}
+
+/** hook 侧原子落盘。失败让它抛——调用方（hook 命令）统一静默吞。 */
+export function writeActivityFile(path: string, activity: AgentActivity): void {
+  atomicWriteJson(path, activity);
+}
+
+/** serve 心跳侧读取：文件缺失/脏值/超 TTL 都返回 null（本拍不带 activity）。 */
+export function readActivityFile(path: string, now: number, ttlMs: number = ACTIVITY_TTL_MS): AgentActivity | null {
+  try {
+    const parsed = parseAgentActivity(JSON.parse(readFileSync(path, "utf8")) as unknown);
+    if (parsed === undefined) return null;
+    return now - parsed.ts <= ttlMs ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/** 任务冷起前清掉上一轮残留，避免新 turn 首个 hook 到来前展示旧活动。 */
+export function clearActivityFile(path: string): void {
+  try {
+    rmSync(path, { force: true });
+  } catch {
+    // 清不掉就留给 TTL 兜底
+  }
+}

--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -1,4 +1,5 @@
 // ws 客户端：帧异步迭代 + 指数退避重连 + seq 去重 + ack 驱动的游标推进
+import { parseAgentActivity } from "@agentparty/shared";
 import type { ClientFrame, ServerFrame } from "@agentparty/shared";
 import pkg from "../package.json" with { type: "json" };
 
@@ -200,6 +201,7 @@ function isPresenceEntry(value: unknown): boolean {
     (value.current_task === undefined || isPositiveInteger(value.current_task)) &&
     (value.task_started_at === undefined || isFiniteNumber(value.task_started_at)) &&
     (value.heartbeat_at === undefined || isFiniteNumber(value.heartbeat_at)) &&
+    (value.activity === undefined || parseAgentActivity(value.activity) !== undefined) &&
     (value.connection_count === undefined || isPositiveInteger(value.connection_count));
 }
 

--- a/cli/src/commands/hook.ts
+++ b/cli/src/commands/hook.ts
@@ -1,0 +1,85 @@
+// party hook — Claude Code hooks 接入点（issue #602）。
+// `party hook report` 挂在模型 session 的 PreToolUse/Stop/Notification 等 hook 上，
+// 把「正在干什么」落成本地 activity 文件，由 serve 的任务心跳帧捎带给频道 presence。
+//
+// 铁律（hook 跑在模型的工具调用热路径上）：
+//   1. stdout 永远为空——hook 的 stdout 会被灌进模型上下文；
+//   2. 任何失败都静默 exit 0——exit 2 会 block 模型的工具调用，坏 JSON/写盘失败都不配阻断模型；
+//   3. 不走网络——上行由 serve 心跳负责，这里只写文件。
+import { join } from "node:path";
+import { activityFromHookEvent, writeActivityFile } from "../activity";
+import { agentpartyHome } from "../config";
+import { isHelpArg } from "../args";
+
+const HELP = `usage: party hook report
+
+Claude Code hook adapter (issue #602). Wire it into a session's hook config:
+
+  { "hooks": { "PreToolUse": [ { "hooks": [ { "type": "command", "command": "party hook report" } ] } ] } }
+
+Reads the hook event JSON from stdin and records a local activity snapshot
+(what tool is running / waiting on permission / compacting / idle). A local
+\`party serve\` picks the snapshot up and reports it with its presence
+heartbeat — the channel sees what the agent is actually doing, not just busy.
+
+Target file: $AP_ACTIVITY_FILE when set (serve-managed runners), otherwise
+~/.agentparty/state/activity/<session_id>.json.
+
+Never blocks the model: any failure exits 0 silently, stdout stays empty.`;
+
+// stdin 兜底上限：hook payload 正常几 KB，超过说明喂错了东西，读满即止防内存放大。
+const MAX_STDIN_BYTES = 256 * 1024;
+
+// 未走 serve 托管（无 AP_ACTIVITY_FILE）时按 session_id 落到全局 state 目录。
+// session_id 直接进路径，白名单校验防穿越。
+const SESSION_ID_RE = /^[A-Za-z0-9._-]{1,128}$/;
+
+async function readStdin(maxBytes: number): Promise<string> {
+  const chunks: Buffer[] = [];
+  let total = 0;
+  for await (const chunk of process.stdin) {
+    const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    total += buf.length;
+    chunks.push(buf);
+    if (total >= maxBytes) break;
+  }
+  return Buffer.concat(chunks).toString("utf8", 0, Math.min(total, maxBytes));
+}
+
+export function activityTargetFile(
+  env: Record<string, string | undefined>,
+  payload: Record<string, unknown>,
+  home: string,
+): string | null {
+  const explicit = env.AP_ACTIVITY_FILE;
+  if (typeof explicit === "string" && explicit.length > 0) return explicit;
+  const sessionId = payload.session_id;
+  if (typeof sessionId !== "string" || !SESSION_ID_RE.test(sessionId)) return null;
+  return join(home, "state", "activity", `${sessionId}.json`);
+}
+
+export async function run(argv: string[]): Promise<number> {
+  if (isHelpArg(argv, { allowHelpPositional: true })) {
+    console.log(HELP);
+    return 0;
+  }
+  if (argv[0] !== "report") {
+    // 唯一会写 stderr 的分支：人在终端敲错子命令。真 hook 调用恒为 `hook report`，不受影响。
+    console.error(HELP);
+    return 1;
+  }
+  try {
+    const raw = await readStdin(MAX_STDIN_BYTES);
+    const payload = JSON.parse(raw) as unknown;
+    if (typeof payload !== "object" || payload === null) return 0;
+    const record = payload as Record<string, unknown>;
+    const activity = activityFromHookEvent(record, Date.now());
+    if (activity === null) return 0;
+    const target = activityTargetFile(process.env, record, agentpartyHome());
+    if (target === null) return 0;
+    writeActivityFile(target, activity);
+  } catch {
+    // 静默：hook 绝不阻断模型（exit 2 才 block，这里连非零都不给）。
+  }
+  return 0;
+}

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -1761,8 +1761,10 @@ interface HarnessRun {
 // party）；dev（bun run）下 execPath 是 bun，回退裸 `party`。timeout 收紧到 10s：hook 挂死不许拖模型。
 export function claudeHookSettingsJson(execPath: string = process.execPath): string {
   const partyBin = isPartyBinaryPath(execPath) ? execPath : "party";
-  // 路径含空白时用 JSON.stringify 包双引号并转义——hook command 是交给 shell 的一整串。
-  const command = `${/\s/.test(partyBin) ? JSON.stringify(partyBin) : partyBin} hook report`;
+  // hook command 是交给 shell 的一整串：绝对路径一律 JSON.stringify 包双引号并转义（空白、引号、
+  // 反斜杠都盖住；双引号在 POSIX sh 与 cmd 下都成立——单引号会破 Windows）。裸 `party` 不引，
+  // 保持 PATH 查找语义。路径里的 `$` 反引号属 POSIX 双引号残余风险，party 安装路径不含此类字符。
+  const command = `${partyBin === "party" ? partyBin : JSON.stringify(partyBin)} hook report`;
   const hook = [{ hooks: [{ type: "command", command, timeout: 10 }] }];
   return JSON.stringify({
     hooks: {

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -12,6 +12,7 @@ import {
   writeManagedManifest,
   writeManagedWake,
 } from "../managed";
+import { clearActivityFile, readActivityFile, runnerActivityFile } from "../activity";
 import {
   appendFileSync,
   existsSync,
@@ -1754,6 +1755,29 @@ interface HarnessRun {
   outFile?: string;
 }
 
+// 活动上报（#602）：给 builtin claude runner 注入 session 级 hooks——每个关键 hook 事件都管道进
+// `party hook report`，把「正在跑哪个工具 / 卡权限 / compact / turn 结束」落成 AP_ACTIVITY_FILE
+// 指向的本地文件，serve 的 15s 任务心跳捎带上行。编译版二进制用绝对路径（runner 的 PATH 里未必有
+// party）；dev（bun run）下 execPath 是 bun，回退裸 `party`。timeout 收紧到 10s：hook 挂死不许拖模型。
+export function claudeHookSettingsJson(execPath: string = process.execPath): string {
+  const partyBin = isPartyBinaryPath(execPath) ? execPath : "party";
+  // 路径含空白时用 JSON.stringify 包双引号并转义——hook command 是交给 shell 的一整串。
+  const command = `${/\s/.test(partyBin) ? JSON.stringify(partyBin) : partyBin} hook report`;
+  const hook = [{ hooks: [{ type: "command", command, timeout: 10 }] }];
+  return JSON.stringify({
+    hooks: {
+      PreToolUse: hook,
+      PostToolUse: hook,
+      Notification: hook,
+      Stop: hook,
+      SessionStart: hook,
+      SessionEnd: hook,
+      PreCompact: hook,
+      UserPromptSubmit: hook,
+    },
+  });
+}
+
 async function runHarness(
   opts: BuiltinRunnerOptions,
   prompt: string,
@@ -1830,8 +1854,11 @@ async function runHarness(
         "--strict-mcp-config",
         "--allowedTools", "mcp__party",
       ];
+  // 活动上报（#602）：session 级注入 hooks，把模型「正在干什么」经 `party hook report` 落盘，
+  // 由外层 serve 心跳捎带进频道 presence。--settings 只作用于本次 session，不碰用户/项目 settings。
+  const hookArgs = ["--settings", claudeHookSettingsJson()];
   const args = sid
-    ? ["claude", "-p", "--disallowed-tools", "AskUserQuestion", ...permissionArgs, ...schemaArgs, ...jsonOutputArgs, ...mcpArgs, "--resume", sid, prompt]
+    ? ["claude", "-p", "--disallowed-tools", "AskUserQuestion", ...permissionArgs, ...schemaArgs, ...jsonOutputArgs, ...mcpArgs, ...hookArgs, "--resume", sid, prompt]
     : [
         "claude",
         "-p",
@@ -1840,6 +1867,7 @@ async function runHarness(
         ...permissionArgs,
         ...schemaArgs,
         ...mcpArgs,
+        ...hookArgs,
         "--session-id",
         coldSessionId!,
         "--output-format",
@@ -2271,6 +2299,8 @@ export function createBuiltinRunner(opts: BuiltinRunnerOptions): NonNullable<Ser
     if (prepared.has(frame)) return;
     const started = opts.now?.() ?? Date.now();
     mkdirSync(opts.workdir, { recursive: true });
+    // 活动上报（#602）：新 wake 冷起前清掉上一轮残留，首个 hook 到来前不展示旧活动。
+    if (opts.harness === "claude") clearActivityFile(runnerActivityFile(opts.workdir));
     const baseEnv = opts.harness === "codex" ? prepareCodexHome(opts.workdir, opts.authSourceFile) : { ...process.env };
     const scope = continuationScope(opts.workdir, ctx.delivery);
     const sessionPath = scope.path;
@@ -2289,6 +2319,9 @@ export function createBuiltinRunner(opts: BuiltinRunnerOptions): NonNullable<Ser
       // subprocesses; resumed turns additionally receive this explicit, runner-owned handle.
       AP_RUNNER_WORKDIR: opts.workdir,
       AP_RUNNER_HARNESS: opts.harness,
+      // 活动上报（#602）：hook 子进程继承这个路径落盘，serve 心跳读同一路径——双方对文件位置
+      // 显式约定，不靠 session_id 映射（resume 会换 id）。codex 无 hooks 机制，不设。
+      ...(opts.harness === "claude" ? { AP_ACTIVITY_FILE: runnerActivityFile(opts.workdir) } : {}),
       AP_RUNNER_SESSION_ID: prior?.session_id ?? coldSessionId ?? "",
       AP_DELIVERY_ID: ctx.delivery?.id ?? "",
       AP_WORK_ID: ctx.delivery?.work_id ?? "",
@@ -4270,17 +4303,21 @@ export async function runServe(o: ServeOptions): Promise<number> {
         const nowFn = o.now ?? (() => Date.now());
         const taskStartedAt = nowFn();
         const heartbeatIntervalMs = o.heartbeatIntervalMs ?? DEFAULT_TASK_HEARTBEAT_MS;
+        // 活动上报（#602）：builtin claude runner 的 hooks 会把「正在干什么」落到约定文件；
+        // 每拍读一次捎带进心跳帧。其它 runner（codex/sdk/custom）没有 hook 落盘，恒不带。
+        const activityFile = o.builtinRunner?.harness === "claude" ? runnerActivityFile(o.builtinRunner.workdir) : null;
         const emitTaskBeat = (active: boolean, at: number) => {
           const fields = active
             ? { current_task: frame.seq, task_started_at: taskStartedAt, heartbeat_at: at }
             : { current_task: null, task_started_at: null, heartbeat_at: null };
+          const activity = active && activityFile !== null ? readActivityFile(activityFile, at) : null;
           try {
             bestEffortLocalState(() => writeHealthCache({ channel: o.channel, ...fields }));
           } catch {
             /* 本机 health 落盘失败不影响唤醒 */
           }
           try {
-            conn.send({ type: "heartbeat", ...fields });
+            conn.send({ type: "heartbeat", ...fields, ...(activity === null ? {} : { activity }) });
           } catch {
             /* WS 未就绪就漏一拍：本机 health 仍新鲜，且下一拍/清除会补 */
           }

--- a/cli/src/commands/who.ts
+++ b/cli/src/commands/who.ts
@@ -215,11 +215,13 @@ export function activityNote(r: Row, now: number): string {
   const activity = r.activity;
   if (activity === undefined) return "";
   const age = humanAge(Math.max(0, now - activity.ts));
+  // tool 名来自远端 presence（REST 路径不过帧校验），渲染前统一归一化控制字符，防终端转义注入。
+  const tool = activity.tool === undefined ? undefined : terminalIdentityText(activity.tool) || undefined;
   switch (activity.phase) {
     case "tool":
-      return ` · ⚙ ${activity.tool ?? "tool"} (${age})`;
+      return ` · ⚙ ${tool ?? "tool"} (${age})`;
     case "waiting_permission":
-      return ` · ⏸ awaiting permission${activity.tool !== undefined ? `: ${activity.tool}` : ""} (${age})`;
+      return ` · ⏸ awaiting permission${tool !== undefined ? `: ${tool}` : ""} (${age})`;
     case "waiting_input":
       return ` · ⏸ awaiting input (${age})`;
     case "compacting":

--- a/cli/src/commands/who.ts
+++ b/cli/src/commands/who.ts
@@ -1,6 +1,6 @@
 // party who — 从终端看频道里谁在线/可唤醒/最近，便于接着 party send --mention 把人拉进来/唤醒。
 // Claude Code 原生 @ 只认本地文件/技能，塞不进远程动态列表；本命令就是那个「动态在线列表」。
-import { autoWakeReachable, type PresenceEntry, type SenderKind, type WakeKind, wakeableState } from "@agentparty/shared";
+import { autoWakeReachable, type AgentActivity, type PresenceEntry, type SenderKind, type WakeKind, wakeableState } from "@agentparty/shared";
 import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
 import { resolveChannel } from "../config";
 import { resolveAuth } from "../oidc-cli";
@@ -35,7 +35,7 @@ session name), so mention the "@handle" shown here — not a UUID session name.
 Options:
   --channel C   read channel C instead of the bound channel
   --json        emit one JSON object per line
-                (name/kind/tier/wake/wake_unverified/busy/queue_depth/waiting_owner_count/current_task/task_started_at/heartbeat_at/agent_session/account/handle/display_name/age_ms/read_seq)`;
+                (name/kind/tier/wake/wake_unverified/busy/queue_depth/waiting_owner_count/current_task/task_started_at/heartbeat_at/activity/agent_session/account/handle/display_name/age_ms/read_seq)`;
 
 const STALE_MS = 60_000; // 与 DO presence 扫描一致
 const DEAD_MS = 14 * 24 * 60 * 60 * 1000; // 14 天没露面视为幽灵，不再列
@@ -76,6 +76,9 @@ interface Row {
   current_task?: number;
   task_started_at?: number;
   heartbeat_at?: number;
+  // 模型 session 活动（#602）：hook 落盘、serve 心跳捎带的「正在干什么」——比 current_task 更细：
+  // 正在跑哪个工具 / 卡权限确认 / compact / turn 已结束。仅在有活跃任务时带出。
+  activity?: AgentActivity;
   // runner 自报、worker 持久化的模型会话句柄（#522）；不是 websocket session。
   agent_session?: PresenceEntry["agent_session"];
 }
@@ -137,6 +140,7 @@ export function classify(e: PresenceEntry, now: number): Row | null {
           current_task: e.current_task,
           ...(typeof e.task_started_at === "number" ? { task_started_at: e.task_started_at } : {}),
           ...(typeof e.heartbeat_at === "number" ? { heartbeat_at: e.heartbeat_at } : {}),
+          ...(e.activity === undefined ? {} : { activity: e.activity }),
         }
       : {}),
     ...(e.agent_session === undefined ? {} : { agent_session: e.agent_session }),
@@ -203,6 +207,32 @@ export function taskNote(r: Row, now: number): string {
   const beat =
     typeof r.heartbeat_at === "number" ? ` · ♥ ${humanAge(Math.max(0, now - r.heartbeat_at))}` : " · ♥ (none)";
   return ` · ▶ seq ${r.current_task}${beat}`;
+}
+
+// 模型 session 活动标注（#602）：比「▶ seq X」再细一层——具体在干什么。waiting_permission 是
+// 无人值守最致命的静默挂法（headless 权限确认没人点），单独用 ⏸ 高亮出来。
+export function activityNote(r: Row, now: number): string {
+  const activity = r.activity;
+  if (activity === undefined) return "";
+  const age = humanAge(Math.max(0, now - activity.ts));
+  switch (activity.phase) {
+    case "tool":
+      return ` · ⚙ ${activity.tool ?? "tool"} (${age})`;
+    case "waiting_permission":
+      return ` · ⏸ awaiting permission${activity.tool !== undefined ? `: ${activity.tool}` : ""} (${age})`;
+    case "waiting_input":
+      return ` · ⏸ awaiting input (${age})`;
+    case "compacting":
+      return ` · ⚙ compacting (${age})`;
+    case "starting":
+      return ` · ⚙ starting (${age})`;
+    case "working":
+      return ` · ⚙ thinking (${age})`;
+    case "idle":
+      return ` · ⚙ turn done (${age})`;
+    default:
+      return "";
+  }
 }
 
 export function sessionNote(r: Row): string {
@@ -304,7 +334,7 @@ export async function run(argv: string[]): Promise<number> {
           ? ` · ${r.wake_unverified === true ? "unverified" : "verified"}${r.wake ? ` (${r.wake})` : ""}`
           : "";
       const age = r.tier === "online" ? "" : ` (${humanAge(r.age_ms)})`;
-      console.log(`${DOT[r.tier]} ${r.tier.padEnd(8)} ${r.name}  [${r.kind}]${identityNote(r)}${busyNote(r)}${waitingOwnerNote(r)}${taskNote(r, now)}${sessionNote(r)}${wake}${read}${duplicate}${age}`);
+      console.log(`${DOT[r.tier]} ${r.tier.padEnd(8)} ${r.name}  [${r.kind}]${identityNote(r)}${busyNote(r)}${waitingOwnerNote(r)}${taskNote(r, now)}${activityNote(r, now)}${sessionNote(r)}${wake}${read}${duplicate}${age}`);
     }
     return 0;
   } catch (e) {

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -41,6 +41,7 @@ commands:
   resume    <name> [--channel C]                           resume a paused agent's reception (moderator)
   wake-budget <name> [--limit N [--window D]|--off]        cap an agent's wakes per window; over-budget @ withheld (#108)
   health    [--json] [--channel C] [--stale-after ms]      local serve WS health probe (pid alive != ws alive, #254)
+  hook      report                                          Claude Code hook adapter: record model activity for presence (#602)
   upgrade   [--version X.Y.Z] [--check]                    download release binary, verify sha256, atomically replace party
   charter   [slug] [--json] | set [slug] -f file.md|-m text|- | template
   history   [channel|--channel C] [--since seq] [--limit n] [--json] [--completion]
@@ -157,6 +158,8 @@ export async function main(argv: string[]): Promise<number> {
       return (await import("./commands/doctor")).run(rest);
     case "health":
       return (await import("./commands/health")).run(rest);
+    case "hook":
+      return (await import("./commands/hook")).run(rest);
     case "upgrade":
       return (await import("./commands/upgrade")).run(rest);
     case "worktree":

--- a/cli/test/activity.test.ts
+++ b/cli/test/activity.test.ts
@@ -190,3 +190,17 @@ describe("claudeHookSettingsJson", () => {
     expect(settings.hooks.Stop[0]!.hooks[0]!.command).toBe("party hook report");
   });
 });
+
+// tool 字段只在 tool / waiting_permission 阶段有意义（协议约定）：其余阶段丢字段保留活动。
+import { parseAgentActivity } from "@agentparty/shared";
+describe("parseAgentActivity phase-gated tool", () => {
+  test("drops tool on phases that do not allow it, keeps the activity", () => {
+    expect(parseAgentActivity({ phase: "idle", tool: "Bash", ts: 1 })).toEqual({ phase: "idle", ts: 1 });
+    expect(parseAgentActivity({ phase: "tool", tool: "Bash", ts: 1 })).toEqual({ phase: "tool", tool: "Bash", ts: 1 });
+    expect(parseAgentActivity({ phase: "waiting_permission", tool: "Bash", ts: 1 })).toEqual({
+      phase: "waiting_permission",
+      tool: "Bash",
+      ts: 1,
+    });
+  });
+});

--- a/cli/test/activity.test.ts
+++ b/cli/test/activity.test.ts
@@ -80,6 +80,21 @@ describe("activity file contract", () => {
     expect(readActivityFile(file, NOW + ACTIVITY_TTL_MS + 1)).toBeNull();
   });
 
+  test("a future timestamp is rejected (it would defeat the TTL forever)", () => {
+    const file = runnerActivityFile(tempDir());
+    writeActivityFile(file, { phase: "tool", tool: "Bash", ts: NOW + 10 * 60_000 });
+    expect(readActivityFile(file, NOW)).toBeNull();
+    // 1 分钟内的正常时钟抖动仍容忍
+    writeActivityFile(file, { phase: "tool", tool: "Bash", ts: NOW + 30_000 });
+    expect(readActivityFile(file, NOW)).not.toBeNull();
+  });
+
+  test("control characters in a stored tool name are stripped on read (terminal-injection hygiene)", () => {
+    const file = runnerActivityFile(tempDir());
+    writeFileSync(file, JSON.stringify({ phase: "tool", tool: "Bash\u001b[31mevil\u0007", ts: NOW }));
+    expect(readActivityFile(file, NOW)?.tool).toBe("Bash[31mevil");
+  });
+
   test("missing file / garbage content read as null, clear is idempotent", () => {
     const dir = tempDir();
     const file = runnerActivityFile(dir);
@@ -155,7 +170,8 @@ describe("claudeHookSettingsJson", () => {
     for (const event of ["PreToolUse", "PostToolUse", "Notification", "Stop", "SessionStart", "SessionEnd", "PreCompact", "UserPromptSubmit"]) {
       const entry = settings.hooks[event]?.[0]?.hooks[0];
       expect(entry?.type).toBe("command");
-      expect(entry?.command).toBe("/usr/local/bin/party hook report");
+      // 绝对路径一律加引号转义（不只空白路径）——引号在 POSIX sh 与 cmd 下都成立
+      expect(entry?.command).toBe('"/usr/local/bin/party" hook report');
       expect(entry?.timeout).toBe(10);
     }
   });

--- a/cli/test/activity.test.ts
+++ b/cli/test/activity.test.ts
@@ -1,0 +1,176 @@
+// 模型 session 活动上报（issue #602）：hook 事件映射、落盘/读取契约、hook 命令的「绝不阻断模型」铁律。
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  ACTIVITY_TTL_MS,
+  activityFromHookEvent,
+  clearActivityFile,
+  readActivityFile,
+  runnerActivityFile,
+  writeActivityFile,
+} from "../src/activity";
+import { activityTargetFile } from "../src/commands/hook";
+import { claudeHookSettingsJson } from "../src/commands/serve";
+
+const NOW = 1_700_000_000_000;
+
+function tempDir(): string {
+  return mkdtempSync(join(tmpdir(), "party-activity-"));
+}
+
+describe("activityFromHookEvent", () => {
+  test("maps the hook lifecycle to activity phases", () => {
+    expect(activityFromHookEvent({ hook_event_name: "SessionStart" }, NOW)).toEqual({ phase: "starting", ts: NOW });
+    expect(activityFromHookEvent({ hook_event_name: "UserPromptSubmit" }, NOW)).toEqual({ phase: "working", ts: NOW });
+    expect(activityFromHookEvent({ hook_event_name: "PreToolUse", tool_name: "Bash" }, NOW)).toEqual({
+      phase: "tool",
+      tool: "Bash",
+      ts: NOW,
+    });
+    expect(activityFromHookEvent({ hook_event_name: "PostToolUse", tool_name: "Bash" }, NOW)).toEqual({
+      phase: "working",
+      ts: NOW,
+    });
+    expect(activityFromHookEvent({ hook_event_name: "PreCompact" }, NOW)).toEqual({ phase: "compacting", ts: NOW });
+    expect(activityFromHookEvent({ hook_event_name: "Stop" }, NOW)).toEqual({ phase: "idle", ts: NOW });
+    expect(activityFromHookEvent({ hook_event_name: "SessionEnd" }, NOW)).toEqual({ phase: "idle", ts: NOW });
+  });
+
+  test("splits Notification into waiting_permission / waiting_input, ignores the rest", () => {
+    expect(
+      activityFromHookEvent(
+        { hook_event_name: "Notification", message: "Claude needs your permission to use Bash", tool_name: "Bash" },
+        NOW,
+      ),
+    ).toEqual({ phase: "waiting_permission", tool: "Bash", ts: NOW });
+    expect(
+      activityFromHookEvent({ hook_event_name: "Notification", message: "Claude is waiting for your input" }, NOW),
+    ).toEqual({ phase: "waiting_input", ts: NOW });
+    expect(activityFromHookEvent({ hook_event_name: "Notification", message: "something else" }, NOW)).toBeNull();
+  });
+
+  test("ignores unknown events and SubagentStop (main session is still running)", () => {
+    expect(activityFromHookEvent({ hook_event_name: "SubagentStop" }, NOW)).toBeNull();
+    expect(activityFromHookEvent({ hook_event_name: "SomethingNew" }, NOW)).toBeNull();
+    expect(activityFromHookEvent({}, NOW)).toBeNull();
+  });
+
+  test("carries only the tool NAME, never tool input (secret hygiene)", () => {
+    const activity = activityFromHookEvent(
+      { hook_event_name: "PreToolUse", tool_name: "Bash", tool_input: { command: "echo TOP_SECRET" } },
+      NOW,
+    );
+    expect(JSON.stringify(activity)).not.toContain("TOP_SECRET");
+    expect(activity).toEqual({ phase: "tool", tool: "Bash", ts: NOW });
+  });
+
+  test("truncates oversized tool names to 64 chars", () => {
+    const activity = activityFromHookEvent({ hook_event_name: "PreToolUse", tool_name: "x".repeat(200) }, NOW);
+    expect(activity?.tool).toHaveLength(64);
+  });
+});
+
+describe("activity file contract", () => {
+  test("write → read round-trips while fresh, goes null past TTL", () => {
+    const file = runnerActivityFile(tempDir());
+    writeActivityFile(file, { phase: "tool", tool: "Bash", ts: NOW });
+    expect(readActivityFile(file, NOW + 1000)).toEqual({ phase: "tool", tool: "Bash", ts: NOW });
+    expect(readActivityFile(file, NOW + ACTIVITY_TTL_MS + 1)).toBeNull();
+  });
+
+  test("missing file / garbage content read as null, clear is idempotent", () => {
+    const dir = tempDir();
+    const file = runnerActivityFile(dir);
+    expect(readActivityFile(file, NOW)).toBeNull();
+    writeFileSync(file, "not json");
+    expect(readActivityFile(file, NOW)).toBeNull();
+    writeFileSync(file, JSON.stringify({ phase: "hacking", ts: NOW }));
+    expect(readActivityFile(file, NOW)).toBeNull();
+    clearActivityFile(file);
+    clearActivityFile(file); // 已删除再删不抛
+    expect(readActivityFile(file, NOW)).toBeNull();
+  });
+});
+
+describe("party hook report target resolution", () => {
+  test("prefers AP_ACTIVITY_FILE (serve-managed lane)", () => {
+    const target = activityTargetFile({ AP_ACTIVITY_FILE: "/tmp/x/activity.json" }, { session_id: "abc" }, "/home/.agentparty");
+    expect(target).toBe("/tmp/x/activity.json");
+  });
+
+  test("falls back to the session-id keyed state file", () => {
+    const target = activityTargetFile({}, { session_id: "0199-abc.DEF_1" }, "/home/.agentparty");
+    expect(target).toBe(join("/home/.agentparty", "state", "activity", "0199-abc.DEF_1.json"));
+  });
+
+  test("rejects traversal-shaped or missing session ids", () => {
+    expect(activityTargetFile({}, { session_id: "../../etc/passwd" }, "/home/.agentparty")).toBeNull();
+    expect(activityTargetFile({}, { session_id: "a/b" }, "/home/.agentparty")).toBeNull();
+    expect(activityTargetFile({}, {}, "/home/.agentparty")).toBeNull();
+  });
+});
+
+describe("party hook report end-to-end", () => {
+  // 铁律验证：真 hook 调用永远 exit 0、stdout 永远为空——坏 JSON 也一样。
+  async function runHookReport(stdin: string, activityFile: string): Promise<{ code: number; stdout: string }> {
+    const proc = Bun.spawn(["bun", join(import.meta.dir, "..", "src", "index.ts"), "hook", "report"], {
+      stdin: new TextEncoder().encode(stdin),
+      stdout: "pipe",
+      stderr: "pipe",
+      env: { ...process.env, AP_ACTIVITY_FILE: activityFile },
+    });
+    const [code, stdout] = await Promise.all([proc.exited, new Response(proc.stdout).text()]);
+    return { code, stdout };
+  }
+
+  test("records a PreToolUse snapshot from stdin", async () => {
+    const file = runnerActivityFile(tempDir());
+    const r = await runHookReport(
+      JSON.stringify({ hook_event_name: "PreToolUse", tool_name: "Bash", session_id: "s1" }),
+      file,
+    );
+    expect(r.code).toBe(0);
+    expect(r.stdout).toBe("");
+    const written = JSON.parse(readFileSync(file, "utf8")) as { phase: string; tool: string };
+    expect(written.phase).toBe("tool");
+    expect(written.tool).toBe("Bash");
+  });
+
+  test("bad JSON stays silent and exits 0 (never blocks the model)", async () => {
+    const file = runnerActivityFile(tempDir());
+    const r = await runHookReport("this is not json", file);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toBe("");
+    expect(readActivityFile(file, NOW)).toBeNull();
+  });
+});
+
+describe("claudeHookSettingsJson", () => {
+  test("wires every lifecycle hook to `party hook report`", () => {
+    const settings = JSON.parse(claudeHookSettingsJson("/usr/local/bin/party")) as {
+      hooks: Record<string, Array<{ hooks: Array<{ type: string; command: string; timeout: number }> }>>;
+    };
+    for (const event of ["PreToolUse", "PostToolUse", "Notification", "Stop", "SessionStart", "SessionEnd", "PreCompact", "UserPromptSubmit"]) {
+      const entry = settings.hooks[event]?.[0]?.hooks[0];
+      expect(entry?.type).toBe("command");
+      expect(entry?.command).toBe("/usr/local/bin/party hook report");
+      expect(entry?.timeout).toBe(10);
+    }
+  });
+
+  test("quotes a party path containing whitespace", () => {
+    const settings = JSON.parse(claudeHookSettingsJson("/Applications/My Tools/party")) as {
+      hooks: { Stop: Array<{ hooks: Array<{ command: string }> }> };
+    };
+    expect(settings.hooks.Stop[0]!.hooks[0]!.command).toBe('"/Applications/My Tools/party" hook report');
+  });
+
+  test("falls back to bare `party` for non-party exec paths (bun dev)", () => {
+    const settings = JSON.parse(claudeHookSettingsJson("/opt/homebrew/bin/bun")) as {
+      hooks: { Stop: Array<{ hooks: Array<{ command: string }> }> };
+    };
+    expect(settings.hooks.Stop[0]!.hooks[0]!.command).toBe("party hook report");
+  });
+});

--- a/cli/test/serve-continuation.test.ts
+++ b/cli/test/serve-continuation.test.ts
@@ -337,12 +337,12 @@ describe("builtin per-work continuations (#548)", () => {
       expect(args[args.indexOf("--disallowed-tools") + 1]).toBe("AskUserQuestion");
     }
     expect(calls[0]!.args).toEqual([
-      "claude", "-p", "--disallowed-tools", "AskUserQuestion", "--session-id", coldSessionId,
-      "--output-format", "json", expect.any(String),
+      "claude", "-p", "--disallowed-tools", "AskUserQuestion", "--settings", expect.any(String),
+      "--session-id", coldSessionId, "--output-format", "json", expect.any(String),
     ]);
     expect(calls[1]!.args).toEqual([
-      "claude", "-p", "--disallowed-tools", "AskUserQuestion", "--resume", coldSessionId,
-      expect.any(String),
+      "claude", "-p", "--disallowed-tools", "AskUserQuestion", "--settings", expect.any(String),
+      "--resume", coldSessionId, expect.any(String),
     ]);
     expect(calls[1]!.env.AP_RUNNER_SESSION_ID).toBe(coldSessionId);
   });

--- a/cli/test/serve.test.ts
+++ b/cli/test/serve.test.ts
@@ -28,6 +28,7 @@ import {
   type ServeOptions,
   type ThreadLike,
 } from "../src/commands/serve";
+import { runnerActivityFile, writeActivityFile } from "../src/activity";
 import type { MessagePayload } from "../src/rest";
 import { writeWorkspaceConfigOnly } from "../src/config";
 import type { CliUpgradeNotice } from "../src/upgrade";
@@ -320,6 +321,43 @@ describe("runServe", () => {
     const clears = beats.filter((b) => b.current_task === null);
     expect(clears.length, "must clear the running task once it finishes").toBeGreaterThanOrEqual(1);
     expect(beats.lastIndexOf(active[active.length - 1]!)).toBeLessThan(beats.indexOf(clears[0]!));
+  });
+
+  // 模型 session 活动（#602）：builtin claude runner 的 hooks 把「正在干什么」落到 workdir 的
+  // activity.json，serve 每拍心跳读一次捎带上行；清除帧（current_task=null）不带 activity。
+  test("task heartbeat: carries the hook-reported model activity for a claude builtin runner (#602)", async () => {
+    const beats: Array<{ current_task: number | null; activity?: { phase: string; tool?: string } }> = [];
+    server = startMockServer((frame, sock) => {
+      if (frame.type === "heartbeat") {
+        beats.push(frame as unknown as (typeof beats)[number]);
+        return;
+      }
+      if (frame.type !== "hello") return;
+      sock.send(welcomeFrame(0, "me"));
+      setTimeout(() => sock.send(msgFrame(1, "long task", { mentions: ["me"] })), 10);
+      setTimeout(() => sock.send({ type: "error", code: "archived", message: "done" }), 250);
+    });
+    const workdir = tempDir();
+    const o = opts({
+      server: server.url,
+      heartbeatIntervalMs: 8,
+      // builtinRunner 只为提供 activity 文件约定（harness=claude + workdir）；实际执行仍走注入的
+      // runCommand（它扮演「hook 已落盘」的模型进程）。
+      builtinRunner: { server: "http://unused", token: "t", channel: "dev", harness: "claude", workdir },
+      runCommand: async () => {
+        writeActivityFile(runnerActivityFile(workdir), { phase: "tool", tool: "Bash", ts: Date.now() });
+        await new Promise((r) => setTimeout(r, 70));
+      },
+    });
+
+    expect(await runServe(o)).toBe(EXIT_ARCHIVED);
+
+    const withActivity = beats.filter((b) => b.current_task === 1 && b.activity !== undefined);
+    expect(withActivity.length, "periodic beats must pick up the hook-written activity").toBeGreaterThanOrEqual(1);
+    expect(withActivity[withActivity.length - 1]!.activity).toMatchObject({ phase: "tool", tool: "Bash" });
+    const clear = beats.find((b) => b.current_task === null);
+    expect(clear, "task must still clear on completion").toBeDefined();
+    expect(clear!.activity).toBeUndefined();
   });
 
   test("restart resume: serve reports the persisted runner session on welcome (#522)", async () => {
@@ -1489,7 +1527,8 @@ describe("builtin runner", () => {
     expect(calls[0]).toContain("--output-format");
     expect(calls[0]).toContain("--session-id");
     expect(calls[1]).toEqual([
-      "claude", "-p", "--disallowed-tools", "AskUserQuestion", "--resume", coldSessionId, expect.any(String),
+      "claude", "-p", "--disallowed-tools", "AskUserQuestion", "--settings", expect.any(String),
+      "--resume", coldSessionId, expect.any(String),
     ]);
   });
 

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -553,8 +553,10 @@ export function parseAgentActivity(input: unknown): AgentActivity | undefined {
   const value = input as Record<string, unknown>;
   if (!AGENT_ACTIVITY_PHASES.includes(value.phase as AgentActivityPhase)) return undefined;
   if (typeof value.ts !== "number" || !Number.isSafeInteger(value.ts) || value.ts < 0) return undefined;
+  // tool 只在 tool / waiting_permission 阶段有意义（见 AgentActivity 注释）；其余阶段丢字段留活动，兼容旧客户端。
+  const allowsTool = value.phase === "tool" || value.phase === "waiting_permission";
   const tool =
-    typeof value.tool === "string" && value.tool.length > 0
+    allowsTool && typeof value.tool === "string" && value.tool.length > 0
       ? // eslint-disable-next-line no-control-regex
         value.tool.replace(/[\u0000-\u001f\u007f-\u009f]/g, "").slice(0, 64)
       : undefined;

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -546,17 +546,21 @@ export interface AgentActivity {
 }
 
 // activity 校验的统一口径：CLI 读 hook 落盘文件、DO 收 heartbeat 帧共用。
-// 脏值返回 undefined（调用方各自决定丢字段还是丢整帧）。tool 名截断到 64 字符——只是展示用途。
+// 脏值返回 undefined（调用方各自决定丢字段还是丢整帧）。tool 名截断到 64 字符——只是展示用途；
+// 剥掉 ESC/C0/C1 控制字符（tool 名来自远端，会被直接渲染进终端，不给转义序列注入留门）。
 export function parseAgentActivity(input: unknown): AgentActivity | undefined {
   if (typeof input !== "object" || input === null) return undefined;
   const value = input as Record<string, unknown>;
   if (!AGENT_ACTIVITY_PHASES.includes(value.phase as AgentActivityPhase)) return undefined;
   if (typeof value.ts !== "number" || !Number.isSafeInteger(value.ts) || value.ts < 0) return undefined;
   const tool =
-    typeof value.tool === "string" && value.tool.length > 0 ? value.tool.slice(0, 64) : undefined;
+    typeof value.tool === "string" && value.tool.length > 0
+      ? // eslint-disable-next-line no-control-regex
+        value.tool.replace(/[\u0000-\u001f\u007f-\u009f]/g, "").slice(0, 64)
+      : undefined;
   return {
     phase: value.phase as AgentActivityPhase,
-    ...(tool === undefined ? {} : { tool }),
+    ...(tool === undefined || tool === "" ? {} : { tool }),
     ts: value.ts,
   };
 }

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -514,8 +514,51 @@ export interface PresenceEntry {
    * 心跳还在推进 = 活着，长时间不动 = 卡死。不参与可达性/租约判定。
    */
   heartbeat_at?: number;
+  /**
+   * 模型 session 内的细粒度活动（issue #602）：正在跑哪个工具、是否卡在权限确认、是否在 compact。
+   * 由 Claude Code hooks 落盘、serve 的任务心跳帧捎带上行；与 current_task 同生共死（任务结束即清），
+   * 仅 state != offline 且有活跃任务时下发。旧客户端忽略。
+   */
+  activity?: AgentActivity;
   /** Agent 自报并由频道持久化的模型会话句柄；供重启后精确 resume（issue #522）。 */
   agent_session?: AgentSessionInfo;
+}
+
+// 模型 session 活动阶段（issue #602）。busy/current_task 只说「在忙哪条」，activity 说「具体在干什么」：
+// waiting_permission 是无人值守最致命的静默挂法（headless 权限确认没人点），必须让频道看得见。
+export const AGENT_ACTIVITY_PHASES = [
+  "starting", // SessionStart：session 刚起
+  "working", // 模型在推理/工具间隙（UserPromptSubmit/PostToolUse）
+  "tool", // PreToolUse：正在跑某个工具（tool 字段带工具名）
+  "waiting_permission", // Notification 权限请求：卡在权限确认
+  "waiting_input", // Notification 等输入：交互式 session 空闲等人
+  "compacting", // PreCompact：正在压缩上下文
+  "idle", // Stop/SessionEnd：turn 结束
+] as const;
+export type AgentActivityPhase = (typeof AGENT_ACTIVITY_PHASES)[number];
+
+export interface AgentActivity {
+  phase: AgentActivityPhase;
+  /** 仅 phase=tool / waiting_permission 时可带：工具名（绝不带入参正文，防 secret 泄漏）。 */
+  tool?: string;
+  /** 该活动的发生时刻（epoch ms）；消费方据 now-ts 判新鲜度。 */
+  ts: number;
+}
+
+// activity 校验的统一口径：CLI 读 hook 落盘文件、DO 收 heartbeat 帧共用。
+// 脏值返回 undefined（调用方各自决定丢字段还是丢整帧）。tool 名截断到 64 字符——只是展示用途。
+export function parseAgentActivity(input: unknown): AgentActivity | undefined {
+  if (typeof input !== "object" || input === null) return undefined;
+  const value = input as Record<string, unknown>;
+  if (!AGENT_ACTIVITY_PHASES.includes(value.phase as AgentActivityPhase)) return undefined;
+  if (typeof value.ts !== "number" || !Number.isSafeInteger(value.ts) || value.ts < 0) return undefined;
+  const tool =
+    typeof value.tool === "string" && value.tool.length > 0 ? value.tool.slice(0, 64) : undefined;
+  return {
+    phase: value.phase as AgentActivityPhase,
+    ...(tool === undefined ? {} : { tool }),
+    ts: value.ts,
+  };
 }
 
 export interface ChannelRoleAssignment {
@@ -756,6 +799,11 @@ export interface HeartbeatFrame {
   task_started_at: number | null;
   /** 本次心跳时刻（epoch ms），周期性推进；随 current_task 一起清空。 */
   heartbeat_at: number | null;
+  /**
+   * 模型 session 内的细粒度活动（issue #602）：serve 每拍从 hook 落盘文件读到什么就捎带什么。
+   * 缺省即「本拍无活动信息」，服务端把 activity 清空（活动新鲜度与心跳同生共死，绝不留僵值）。
+   */
+  activity?: AgentActivity;
   /**
    * 可选的模型会话自报。可与任务心跳同帧，也可在三个任务字段均为 null 时单独上报；
    * 服务端持久化但不落聊天 history。缺省表示不更新已有会话。

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -3441,6 +3441,7 @@ export class ChannelDO extends Server<Env> {
     if (!exists) return;
     this.ctx.storage.sql.exec(
       // activity（#602）不走 COALESCE：新鲜度与心跳同生共死，本拍没带就清空，绝不留僵值。
+      // 清除帧（current_task=null）即便捎带了 activity 也一并清——没有任务就没有活动可言。
       `UPDATE presence SET current_task = ?, task_started_at = ?, heartbeat_at = ?,
          activity_json = ?,
          agent_session_json = COALESCE(?, agent_session_json)
@@ -3448,7 +3449,7 @@ export class ChannelDO extends Server<Env> {
       hb.current_task,
       hb.task_started_at,
       hb.heartbeat_at,
-      hb.activity === undefined ? null : JSON.stringify(hb.activity),
+      hb.current_task === null || hb.activity === undefined ? null : JSON.stringify(hb.activity),
       hb.agent_session === undefined ? null : JSON.stringify(hb.agent_session),
       name,
       sessionId,

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -37,6 +37,8 @@ import {
   DELIVERY_CONTINUATION_REF_LIMIT,
   DELIVERY_ORIGIN_CHANNEL_LIMIT,
   DELIVERY_WORK_ID_LIMIT,
+  parseAgentActivity,
+  type AgentActivity,
   type AgentLineage,
   type AgentSessionInfo,
   type Attachment,
@@ -1214,6 +1216,7 @@ export interface ParsedTaskHeartbeat {
   current_task: number | null;
   task_started_at: number | null;
   heartbeat_at: number | null;
+  activity?: AgentActivity;
   agent_session?: AgentSessionInfo;
 }
 
@@ -1255,10 +1258,14 @@ function parseHeartbeatFrame(input: unknown): ParsedTaskHeartbeat | null {
   if (current === undefined || started === undefined || heartbeat === undefined) return null;
   const agentSession = f.agent_session === undefined ? undefined : parseAgentSessionInfo(f.agent_session);
   if (f.agent_session !== undefined && agentSession === undefined) return null;
+  // 模型 session 活动（#602）：可选捎带；脏 activity 与脏 agent_session 同口径——整帧丢弃。
+  const activity = f.activity === undefined ? undefined : parseAgentActivity(f.activity);
+  if (f.activity !== undefined && activity === undefined) return null;
   return {
     current_task: current,
     task_started_at: started,
     heartbeat_at: heartbeat,
+    ...(activity === undefined ? {} : { activity }),
     ...(agentSession === undefined ? {} : { agent_session: agentSession }),
   };
 }
@@ -1568,6 +1575,9 @@ export class ChannelDO extends Server<Env> {
       "ALTER TABLE presence ADD COLUMN current_task INTEGER",
       "ALTER TABLE presence ADD COLUMN task_started_at INTEGER",
       "ALTER TABLE presence ADD COLUMN heartbeat_at INTEGER",
+      // 模型 session 活动（#602）：hook 落盘、serve 心跳捎带的「正在干什么」快照 JSON。
+      // 与心跳字段同生共死（任务结束/离线即清）。
+      "ALTER TABLE presence ADD COLUMN activity_json TEXT",
     ]) {
       try {
         sql.exec(ddl);
@@ -2086,6 +2096,7 @@ export class ChannelDO extends Server<Env> {
         current_task INTEGER,
         task_started_at INTEGER,
         heartbeat_at INTEGER,
+        activity_json TEXT,
         agent_session_json TEXT,
         PRIMARY KEY (name, session_id)
       )`);
@@ -2095,14 +2106,14 @@ export class ChannelDO extends Server<Env> {
         status_decision_json, status_workflow_json, role, role_source, residency, wake_kind,
         wake_verified_at, context_json, lineage_json, kind, account, client_version, handle,
         display_name, avatar_url, avatar_thumb, paused_at, paused_resume_at, busy, queue_depth,
-        current_task, task_started_at, heartbeat_at, agent_session_json
+        current_task, task_started_at, heartbeat_at, activity_json, agent_session_json
       ) SELECT
         name, COALESCE(NULLIF(session_id, ''), '${LEGACY_SESSION_ID}'), state, note, updated_at,
         status_scope_json, status_summary_seq, status_blocked_reason, status_context_json,
         status_decision_json, status_workflow_json, role, role_source, residency, wake_kind,
         wake_verified_at, context_json, lineage_json, kind, account, client_version, handle,
         display_name, avatar_url, avatar_thumb, paused_at, paused_resume_at, busy, queue_depth,
-        current_task, task_started_at, heartbeat_at, agent_session_json
+        current_task, task_started_at, heartbeat_at, activity_json, agent_session_json
       FROM presence`);
       sql.exec("DROP TABLE presence");
       sql.exec("ALTER TABLE presence_session_v2 RENAME TO presence");
@@ -3318,7 +3329,7 @@ export class ChannelDO extends Server<Env> {
       // 会借尸还魂显示成「还在处理」。心跳字段与「活着」正交，离线即无任务，直接清空最干净。
       `INSERT INTO presence (name, session_id, state, note, updated_at) VALUES (?, ?, 'offline', NULL, ?)
        ON CONFLICT(name, session_id) DO UPDATE SET state = 'offline', updated_at = excluded.updated_at,
-         current_task = NULL, task_started_at = NULL, heartbeat_at = NULL,
+         current_task = NULL, task_started_at = NULL, heartbeat_at = NULL, activity_json = NULL,
          -- #454：watch 只有活着的本地 listener 才能接住 @。最后一条连接断开后立即撤销 wake 声明，
          -- 不让被 harness kill 的 watch --once 继续以 wakeable 身份吸收 mention。serve/webhook 有独立
          -- supervisor/服务端投递语义，保持原样；watch 重挂后会由 advertiseWatchWake 重新声明。
@@ -3429,12 +3440,15 @@ export class ChannelDO extends Server<Env> {
         .toArray().length > 0;
     if (!exists) return;
     this.ctx.storage.sql.exec(
+      // activity（#602）不走 COALESCE：新鲜度与心跳同生共死，本拍没带就清空，绝不留僵值。
       `UPDATE presence SET current_task = ?, task_started_at = ?, heartbeat_at = ?,
+         activity_json = ?,
          agent_session_json = COALESCE(?, agent_session_json)
        WHERE name = ? AND session_id = ?`,
       hb.current_task,
       hb.task_started_at,
       hb.heartbeat_at,
+      hb.activity === undefined ? null : JSON.stringify(hb.activity),
       hb.agent_session === undefined ? null : JSON.stringify(hb.agent_session),
       name,
       sessionId,
@@ -6874,7 +6888,7 @@ export class ChannelDO extends Server<Env> {
       // are left alone. The CLI's later clear heartbeat remains idempotent.
       this.ctx.storage.sql.exec(
         `UPDATE presence
-            SET busy = 0, current_task = NULL, task_started_at = NULL, heartbeat_at = NULL
+            SET busy = 0, current_task = NULL, task_started_at = NULL, heartbeat_at = NULL, activity_json = NULL
           WHERE name = ? AND (current_task = ? OR current_task IS NULL)`,
         identity.name,
         activeDecision.lineage.origin_seq,
@@ -9175,7 +9189,7 @@ export class ChannelDO extends Server<Env> {
                 state, note, updated_at, status_scope_json, status_summary_seq, status_blocked_reason,
                 status_context_json, status_decision_json, status_workflow_json, role, role_source, residency, wake_kind, wake_verified_at,
                 context_json, lineage_json, paused_at, paused_resume_at, busy, queue_depth,
-                current_task, task_started_at, heartbeat_at, agent_session_json`;
+                current_task, task_started_at, heartbeat_at, activity_json, agent_session_json`;
 
   private presenceList(): PresenceEntry[] {
     const liveCounts = this.liveConnectionCounts();
@@ -9362,6 +9376,16 @@ export class ChannelDO extends Server<Env> {
             current_task: Number(r.current_task),
             ...(r.task_started_at === null || r.task_started_at === undefined ? {} : { task_started_at: Number(r.task_started_at) }),
             ...(r.heartbeat_at === null || r.heartbeat_at === undefined ? {} : { heartbeat_at: Number(r.heartbeat_at) }),
+            // 模型 session 活动（#602）：与心跳同生共死，只在有活跃任务时带出。
+            ...(() => {
+              if (typeof r.activity_json !== "string" || r.activity_json === "") return {};
+              try {
+                const activity = parseAgentActivity(JSON.parse(r.activity_json) as unknown);
+                return activity === undefined ? {} : { activity };
+              } catch {
+                return {};
+              }
+            })(),
           }
         : {}),
       ...(() => {

--- a/worker/test/presence-task-heartbeat.spec.ts
+++ b/worker/test/presence-task-heartbeat.spec.ts
@@ -115,6 +115,8 @@ describe("presence per-task heartbeat (issue #228)", () => {
     await ws.nextOfType("welcome");
     ws.send({ type: "hello", since: 0 });
     await seedPresence(ws);
+    // 排掉 seedPresence 自己触发的 presence 广播，后续每个 nextOfType("presence") 都对齐一拍心跳
+    await ws.nextOfType("presence");
 
     ws.send({
       type: "heartbeat",
@@ -143,6 +145,7 @@ describe("presence per-task heartbeat (issue #228)", () => {
     await ws.nextOfType("welcome");
     ws.send({ type: "hello", since: 0 });
     await seedPresence(ws);
+    await ws.nextOfType("presence");
 
     ws.send({
       type: "heartbeat",
@@ -152,7 +155,14 @@ describe("presence per-task heartbeat (issue #228)", () => {
       activity: { phase: "waiting_permission", tool: "Bash", ts: 1000 },
     });
     await ws.nextOfType("presence");
-    ws.send({ type: "heartbeat", current_task: null, task_started_at: null, heartbeat_at: null });
+    // 清除帧即便捎带 activity 也一并清：没有任务就没有活动可言
+    ws.send({
+      type: "heartbeat",
+      current_task: null,
+      task_started_at: null,
+      heartbeat_at: null,
+      activity: { phase: "idle", ts: 2000 },
+    });
     await ws.nextOfType("presence");
 
     const entry = (await fetchPresence(slug, agent.token)).find((e) => e.name === agent.name);
@@ -169,6 +179,7 @@ describe("presence per-task heartbeat (issue #228)", () => {
     await ws.nextOfType("welcome");
     ws.send({ type: "hello", since: 0 });
     await seedPresence(ws);
+    await ws.nextOfType("presence");
 
     // 未知 phase → 整帧丢弃；随后的干净帧照常生效（不炸连接）
     ws.send({
@@ -185,7 +196,9 @@ describe("presence per-task heartbeat (issue #228)", () => {
       heartbeat_at: 1000,
       activity: { phase: "working", ts: 1000 },
     });
-    await ws.nextOfType("presence");
+    // 排掉 seed 后第一条到达的 presence 就是干净帧的广播——脏帧被丢弃、从未广播
+    const frame = await ws.nextOfType("presence");
+    expect(frame).toMatchObject({ name: agent.name, current_task: 6, activity: { phase: "working", ts: 1000 } });
 
     const entry = (await fetchPresence(slug, agent.token)).find((e) => e.name === agent.name);
     expect(entry).toMatchObject({ current_task: 6, activity: { phase: "working", ts: 1000 } });

--- a/worker/test/presence-task-heartbeat.spec.ts
+++ b/worker/test/presence-task-heartbeat.spec.ts
@@ -106,6 +106,92 @@ describe("presence per-task heartbeat (issue #228)", () => {
     watcher.close();
   });
 
+  // 模型 session 活动（issue #602）：hook 落盘、serve 心跳捎带的「正在干什么」快照。
+  // 新鲜度与心跳同生共死：本拍没带就清空，任务结束/离线一并清除。
+  it("stamps activity from a heartbeat and clears it when the next beat omits it (#602)", async () => {
+    const agent = await seedToken("agent");
+    const slug = await createChannel(agent.token);
+    const ws = await WsClient.open(slug, agent.token);
+    await ws.nextOfType("welcome");
+    ws.send({ type: "hello", since: 0 });
+    await seedPresence(ws);
+
+    ws.send({
+      type: "heartbeat",
+      current_task: 7,
+      task_started_at: 1000,
+      heartbeat_at: 1000,
+      activity: { phase: "tool", tool: "Bash", ts: 1000 },
+    });
+    await ws.nextOfType("presence");
+    let entry = (await fetchPresence(slug, agent.token)).find((e) => e.name === agent.name);
+    expect(entry).toMatchObject({ current_task: 7, activity: { phase: "tool", tool: "Bash", ts: 1000 } });
+
+    // 下一拍没带 activity（hook 文件缺失/过期）→ 清空，绝不留僵值
+    ws.send({ type: "heartbeat", current_task: 7, task_started_at: 1000, heartbeat_at: 2000 });
+    await ws.nextOfType("presence");
+    entry = (await fetchPresence(slug, agent.token)).find((e) => e.name === agent.name);
+    expect(entry).toMatchObject({ current_task: 7, heartbeat_at: 2000 });
+    expect(entry).not.toHaveProperty("activity");
+    ws.close();
+  });
+
+  it("clears activity together with the task fields on the current_task=null clear beat (#602)", async () => {
+    const agent = await seedToken("agent");
+    const slug = await createChannel(agent.token);
+    const ws = await WsClient.open(slug, agent.token);
+    await ws.nextOfType("welcome");
+    ws.send({ type: "hello", since: 0 });
+    await seedPresence(ws);
+
+    ws.send({
+      type: "heartbeat",
+      current_task: 7,
+      task_started_at: 1000,
+      heartbeat_at: 1000,
+      activity: { phase: "waiting_permission", tool: "Bash", ts: 1000 },
+    });
+    await ws.nextOfType("presence");
+    ws.send({ type: "heartbeat", current_task: null, task_started_at: null, heartbeat_at: null });
+    await ws.nextOfType("presence");
+
+    const entry = (await fetchPresence(slug, agent.token)).find((e) => e.name === agent.name);
+    expect(entry).toBeDefined();
+    expect(entry).not.toHaveProperty("current_task");
+    expect(entry).not.toHaveProperty("activity");
+    ws.close();
+  });
+
+  it("drops a heartbeat carrying a malformed activity, same as a dirty agent_session (#602)", async () => {
+    const agent = await seedToken("agent");
+    const slug = await createChannel(agent.token);
+    const ws = await WsClient.open(slug, agent.token);
+    await ws.nextOfType("welcome");
+    ws.send({ type: "hello", since: 0 });
+    await seedPresence(ws);
+
+    // 未知 phase → 整帧丢弃；随后的干净帧照常生效（不炸连接）
+    ws.send({
+      type: "heartbeat",
+      current_task: 5,
+      task_started_at: 1000,
+      heartbeat_at: 1000,
+      activity: { phase: "hacking", ts: 1000 },
+    });
+    ws.send({
+      type: "heartbeat",
+      current_task: 6,
+      task_started_at: 1000,
+      heartbeat_at: 1000,
+      activity: { phase: "working", ts: 1000 },
+    });
+    await ws.nextOfType("presence");
+
+    const entry = (await fetchPresence(slug, agent.token)).find((e) => e.name === agent.name);
+    expect(entry).toMatchObject({ current_task: 6, activity: { phase: "working", ts: 1000 } });
+    ws.close();
+  });
+
   it("ignores a malformed heartbeat (negative / non-integer) without erroring the socket", async () => {
     const agent = await seedToken("agent");
     const slug = await createChannel(agent.token);


### PR DESCRIPTION
Closes #602

## 干了什么

presence 之前只能回答「在忙第几条、忙了多久」（busy/current_task/heartbeat_at），回答不了「在干什么」。本 PR 把 Claude Code hooks 接进来，频道从此能看见 agent 正在跑哪个工具、是否卡在权限确认、是否在 compact、turn 是否已结束。

数据流（hook 进程绝不碰网络）：

```
claude -p（serve 注入 --settings hooks）
  └─ hook 事件 → party hook report → 原子写 $AP_ACTIVITY_FILE（workdir/activity.json）
        └─ serve 15s 任务心跳读文件 → HeartbeatFrame.activity → DO presence.activity_json
              └─ party who：· ⚙ Bash (12s) / · ⏸ awaiting permission: Bash (3m)
```

## 分层改动

**shared**（`protocol.ts`）
- 新增 `AgentActivity`（phase: starting/working/tool/waiting_permission/waiting_input/compacting/idle + 可选 tool 名 + ts）与统一校验 `parseAgentActivity`；`PresenceEntry.activity` / `HeartbeatFrame.activity` 全可选，新旧客户端双向兼容。

**cli**
- 新命令 `party hook report`（`commands/hook.ts`）：stdin 读 hook JSON → 映射 → 原子落盘。铁律：stdout 永远空（hook stdout 会进模型上下文）、任何失败静默 exit 0（绝不 block 模型工具调用）、只报 tool 名绝不报入参（防 secret）。落盘目标优先 `AP_ACTIVITY_FILE`，否则按 session_id（白名单校验防路径穿越）落 `~/.agentparty/state/activity/`。
- `activity.ts`：文件契约（写/读/清 + 5min TTL——模型进程死了别让频道看僵活动）。
- serve builtin claude runner：spawn 时注入 `--settings`（session 级 hooks 配置，8 个生命周期事件全指到 `party hook report`，不污染用户/项目 settings；编译版用 process.execPath 绝对路径，dev 回退裸 `party`）；env 注入 `AP_ACTIVITY_FILE`；每次冷起前清残留文件。
- serve 任务心跳：每拍读 activity 文件捎带进 heartbeat 帧；非 claude runner（codex/sdk/custom）恒不带。
- `party who`：`activityNote` 渲染——`⚙ Bash (12s)`、`⏸ awaiting permission: Bash (3m)` 等；--json 带 `activity` 字段。

**worker**（DO）
- presence 表补 `activity_json` 列（幂等 ALTER + v2 迁移 CREATE/INSERT 两侧，同 heartbeat_at 先例）。
- heartbeat 帧解析：脏 activity 与脏 agent_session 同口径（整帧丢弃、不炸连接）；写入不走 COALESCE——本拍没带就清空，activity 新鲜度与心跳同生共死。
- 清理路径全覆盖：任务结束清除帧、markOffline、waiting_owner 释放 runner，三处一并清 activity。
- 序列化仅在 `state != offline && current_task 非空` 时带出（与 #228 心跳字段同门禁）。

## 为什么这么设计

- **hook 只写文件、serve 心跳捎带上行**：hook 每次工具调用都触发，REST 热路径不可接受；serve 本来就有 15s presence-only 心跳，捎带零新增连接/端点。
- **路径经 `AP_ACTIVITY_FILE` 显式约定**：不做 session_id 映射——`--resume` 会换 session id，靠 id 对账必然漂。
- **`waiting_permission` 是核心收益**：headless `-p` 权限确认没人点，是无人值守最致命的静默挂法之一；现在 `party who` 直接看得见。

## 测试

- `cli/test/activity.test.ts`（新，15 用例）：事件映射（含 Notification 三分支、SubagentStop 忽略、tool 入参不落盘、64 字符截断）、文件契约（TTL/坏 JSON/幂等清除）、`party hook report` 端到端（真 spawn：坏 JSON 静默 exit 0 + stdout 为空）、`--settings` JSON 生成（8 事件、空白路径引号、bun dev 回退）。
- `cli/test/serve.test.ts`：新增「claude builtin runner 心跳捎带 activity、清除帧不带」；既有两处 claude argv 精确断言补 `--settings`。
- `worker/test/presence-task-heartbeat.spec.ts`：新增 3 用例——落库+缺省即清、current_task=null 一并清、脏 activity 整帧丢弃不炸连接。
- 全量：cli bun test ✅ / worker vitest ✅ / web test+tsc+build ✅ / shared·cli·worker tsc ✅（见 PR checks）。

## 非目标（后续 issue）

- 交互式（非 serve）session 的 `party hook install`、codex `notify` 等效上报、web UI 展示。
- 探活分级（在线但没在听/干不动）→ #603。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增本地活动上报链路：通过 `party hook report` 生成并写入活动快照；`party who` 增加模型会话活动（阶段、工具、等待权限/输入）展示与持续时间。
  * 服务端心跳与在线状态支持携带活动信息，并在活动结束或下一拍无活动时自动清理，避免展示旧状态。
* **改进**
  * 加强活动数据校验与净化：仅允许已知阶段、校验时间戳，并清洗工具名与限制长度；无效帧将被丢弃。
  * 完善活动上报/落盘/读取/清理及端到端与容错测试覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->