### PR TITLE
feat(presence): 探活分级——区分「挂了」「没在听」「干不动」（#603）

### DIFF
--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -1,5 +1,5 @@
 // ws 客户端：帧异步迭代 + 指数退避重连 + seq 去重 + ack 驱动的游标推进
-import { parseAgentActivity } from "@agentparty/shared";
+import { parseAgentActivity, parseRunnerHealth } from "@agentparty/shared";
 import type { ClientFrame, ServerFrame } from "@agentparty/shared";
 import pkg from "../package.json" with { type: "json" };
 
@@ -202,6 +202,8 @@ function isPresenceEntry(value: unknown): boolean {
     (value.task_started_at === undefined || isFiniteNumber(value.task_started_at)) &&
     (value.heartbeat_at === undefined || isFiniteNumber(value.heartbeat_at)) &&
     (value.activity === undefined || parseAgentActivity(value.activity) !== undefined) &&
+    (value.runner_health === undefined || parseRunnerHealth(value.runner_health) !== undefined) &&
+    (value.listening === undefined || value.listening === "suspect" || value.listening === "deaf") &&
     (value.connection_count === undefined || isPositiveInteger(value.connection_count));
 }
 

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -4309,6 +4309,9 @@ export async function runServe(o: ServeOptions): Promise<number> {
         const nowFn = o.now ?? (() => Date.now());
         const taskStartedAt = nowFn();
         const heartbeatIntervalMs = o.heartbeatIntervalMs ?? DEFAULT_TASK_HEARTBEAT_MS;
+        // runner 健康（#603）：finally 里的结账以「当时的 delivered」为准；随后的 completion probe
+        // 可能把 delivered 翻成 false（silent runner）。记住任务前的连败基数，供 probe 纠账。
+        const runnerFailuresBeforeTask = runnerHealth.consecutive_failures;
         // 活动上报（#602）：builtin claude runner 的 hooks 会把「正在干什么」落到约定文件；
         // 每拍读一次捎带进心跳帧。其它 runner（codex/sdk/custom）没有 hook 落盘，恒不带。
         const activityFile = o.builtinRunner?.harness === "claude" ? runnerActivityFile(o.builtinRunner.workdir) : null;
@@ -4448,6 +4451,12 @@ export async function runServe(o: ServeOptions): Promise<number> {
               deliveryConfirmed = true;
               lastError = "runner exited successfully without a linked channel reply";
               attemptsUsed = Math.max(attemptsUsed, attemptFloor + 1);
+              // runner 健康纠账（#603）：finally 已按「当时 delivered=true」清零；silent runner 是
+              // 真失败，按任务前基数 +1 恢复连败计数（下一拍心跳把纠正带给频道）。
+              runnerHealth = {
+                consecutive_failures: runnerFailuresBeforeTask + 1,
+                last_error: sanitizeBlockedError(lastError).slice(0, 160),
+              };
               out(`  ${lastError}: seq=${frame.seq}`);
               // The first completion probe already made `failed` authoritative in the Worker.
               // Clean exact local continuation state now; a disconnect before the redundant

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -3895,6 +3895,10 @@ export async function runServe(o: ServeOptions): Promise<number> {
   let code = 0;
   let consecutiveWakeAbandons = 0;
   let wakeAbandonCircuitTripped = false;
+  // runner 健康自报（#603）：连败计数 + 最后错误，随任务心跳（含清除帧）上行。熔断
+  // （MAX_CONSECUTIVE_WAKE_ABANDONS）退出前那段「presence 全绿但 @ 了没人应」的窗口，
+  // 频道从此看得见「在线但干不动」。送达一次即清零（与 consecutiveWakeAbandons 同口径）。
+  let runnerHealth: { consecutive_failures: number; last_error?: string } = { consecutive_failures: 0 };
   let advertised = false;
   // 人为暂停接待（#180）：服务端对 webhook 已抑制，但 serve 是本地 supervisor、消息照样广播给它。
   // 收到自己的 paused presence 帧就自我抑制唤醒——被 @ 也不触发 runner，直到收到恢复帧。消息仍进历史。
@@ -4313,13 +4317,23 @@ export async function runServe(o: ServeOptions): Promise<number> {
             ? { current_task: frame.seq, task_started_at: taskStartedAt, heartbeat_at: at }
             : { current_task: null, task_started_at: null, heartbeat_at: null };
           const activity = active && activityFile !== null ? readActivityFile(activityFile, at) : null;
+          // runner 健康（#603）：有连败才带；恢复后缺省即清（服务端不 COALESCE）。
+          const runnerHealthField = runnerHealth.consecutive_failures > 0
+            ? {
+                runner_health: {
+                  ok: runnerHealth.consecutive_failures < 2,
+                  consecutive_failures: runnerHealth.consecutive_failures,
+                  ...(runnerHealth.last_error === undefined ? {} : { last_error: runnerHealth.last_error }),
+                },
+              }
+            : {};
           try {
             bestEffortLocalState(() => writeHealthCache({ channel: o.channel, ...fields }));
           } catch {
             /* 本机 health 落盘失败不影响唤醒 */
           }
           try {
-            conn.send({ type: "heartbeat", ...fields, ...(activity === null ? {} : { activity }) });
+            conn.send({ type: "heartbeat", ...fields, ...(activity === null ? {} : { activity }), ...runnerHealthField });
           } catch {
             /* WS 未就绪就漏一拍：本机 health 仍新鲜，且下一拍/清除会补 */
           }
@@ -4399,6 +4413,16 @@ export async function runServe(o: ServeOptions): Promise<number> {
           // 任务收尾：无论送达、放弃还是抛异常穿透，都停心跳并清除本机+频道的「正在处理」状态。
           // 若身后还有排队的 wake，下一条自己的 started 拍会把 current_task 覆盖成新 seq。
           clearInterval(taskBeat);
+          // runner 健康（#603）先于清除帧结账：让这一拍就把「本条送达/放弃」的结论带给频道。
+          // 关停（shutdown）不算 runner 失败——那是 supervisor 生命周期，不是执行力问题。
+          if (shutdownError === null) {
+            runnerHealth = delivered
+              ? { consecutive_failures: 0 }
+              : {
+                  consecutive_failures: runnerHealth.consecutive_failures + 1,
+                  ...(lastError === "" ? {} : { last_error: sanitizeBlockedError(lastError).slice(0, 160) }),
+                };
+          }
           emitTaskBeat(false, nowFn());
           // WebSocket.send 只把帧交给本地发送队列；若服务端的终局帧已在入站队列里，下一轮会
           // 立刻 break 并 close socket。让出一拍，确保仍处于 OPEN 的连接有机会把 idle-clear

--- a/cli/src/commands/wake.ts
+++ b/cli/src/commands/wake.ts
@@ -26,7 +26,10 @@ Options:
   --timeout N    seconds to wait for linked ack/status (default: 30)
   --json         emit one structured wake_test frame`;
 
-type WakeResult = "not_auto_wakeable" | "healthy" | "timeout" | "self_target";
+// #603：把笼统的 timeout 按 presence 的探活分级细分——not_listening（服务端观测到 delivery
+// 租约对活连接反复过期）与 runner_failing（serve 自报 runner 连败）。处置完全不同：
+// 前者重启 supervisor / 查事件循环，后者修 runner 环境（二进制/凭据/沙箱）。
+type WakeResult = "not_auto_wakeable" | "healthy" | "timeout" | "self_target" | "not_listening" | "runner_failing";
 type AckEvidence = "reply_to" | "status.summary_seq";
 
 interface WakePresence {
@@ -35,6 +38,9 @@ interface WakePresence {
   wake_kind: string | null;
   wake_verified_at: number | null;
   last_seen: number | null;
+  // 探活分级（#603）：缺省即无恙。
+  listening?: PresenceEntry["listening"];
+  runner_health?: PresenceEntry["runner_health"];
 }
 
 interface WakeTestFrame extends Record<string, unknown> {
@@ -65,6 +71,8 @@ function summarizePresence(p: PresenceEntry | null): WakePresence {
     wake_kind: p?.wake?.kind ?? null,
     wake_verified_at: p?.wake?.verified_at ?? null,
     last_seen: p?.last_seen ?? p?.ts ?? null,
+    ...(p?.listening === undefined ? {} : { listening: p.listening }),
+    ...(p?.runner_health === undefined ? {} : { runner_health: p.runner_health }),
   };
 }
 
@@ -205,6 +213,11 @@ function printHuman(frame: WakeTestFrame) {
     frame.presence.state ? `state=${frame.presence.state}` : null,
     frame.presence.residency ? `residency=${frame.presence.residency}` : null,
     frame.presence.wake_kind ? `wake=${frame.presence.wake_kind}` : null,
+    // 探活分级（#603）：有负面证据才展示，缺省即无恙。
+    frame.presence.listening ? `listening=${frame.presence.listening}` : null,
+    frame.presence.runner_health && !frame.presence.runner_health.ok
+      ? `runner=failing x${frame.presence.runner_health.consecutive_failures}`
+      : null,
   ].filter((bit): bit is string => bit !== null);
   if (presenceBits.length > 0) console.log(`presence: ${presenceBits.join(" ")}`);
   console.log(
@@ -379,13 +392,37 @@ export async function run(argv: string[]): Promise<number> {
     // 只要它真的答复了就是可达的）。没 ack 时，若 heartbeat 视角本就负面（没声明适配器），
     // 结论仍是 not_auto_wakeable 但标注「探针已投递、未答复、未确认」——把 heartbeat 判定
     // 和投递判定摊开，而不是当初那句不可证伪的 mention: not sent。
-    const result: WakeResult = ack !== null ? "healthy" : gate.advisory !== null ? "not_auto_wakeable" : "timeout";
-    const frameReason =
+    let result: WakeResult = ack !== null ? "healthy" : gate.advisory !== null ? "not_auto_wakeable" : "timeout";
+    let frameReason =
       ack !== null
         ? null
         : gate.advisory !== null
           ? `${gate.advisory} (unconfirmed — probe delivered #${seq}, no reply within ${timeoutSec}s)`
           : timeoutReason;
+    // 探活分级（#603）：timeout 不再一锅端。重取一次 presence——若服务端/自报已给出证据，
+    // 细分为可处置的结论：runner_failing（修 runner 环境）优先于 not_listening（重启 supervisor），
+    // 因为「唤醒了起不来」比「没在消费」更接近根因。
+    let finalPresence = presence;
+    if (result === "timeout") {
+      try {
+        finalPresence = (await fetchPresence(cfg.server, cfg.token, channel)).find((p) => p.name === target) ?? presence;
+      } catch {
+        /* 刷新失败就用探针前的快照定级 */
+      }
+      const health = finalPresence?.runner_health;
+      if (health !== undefined && !health.ok) {
+        result = "runner_failing";
+        frameReason =
+          `probe delivered #${seq} but the target's runner keeps failing (x${health.consecutive_failures}` +
+          `${health.last_error !== undefined ? `: ${health.last_error}` : ""}) — fix the runner environment ` +
+          "(binary/credentials/sandbox) instead of re-mentioning";
+      } else if (finalPresence?.listening === "deaf" || finalPresence?.listening === "suspect") {
+        result = "not_listening";
+        frameReason =
+          `probe delivered #${seq} but the target's live connection is not consuming deliveries ` +
+          `(listening=${finalPresence.listening}) — restart its serve/watch supervisor instead of re-mentioning`;
+      }
+    }
     const wakeInvoked =
       gate.advisory !== null && wakeDelivery === null
         ? { ok: false as const, adapter, evidence: gate.advisory }
@@ -399,7 +436,7 @@ export async function run(argv: string[]): Promise<number> {
       result,
       generated_at: nowTs(),
       timeout_sec: timeoutSec,
-      presence: summarizePresence(presence),
+      presence: summarizePresence(finalPresence),
       phases: {
         mention_delivered: { ok: true, seq, evidence: "message accepted by channel history" },
         wake_invoked: wakeInvoked,

--- a/cli/src/commands/who.ts
+++ b/cli/src/commands/who.ts
@@ -1,6 +1,6 @@
 // party who — 从终端看频道里谁在线/可唤醒/最近，便于接着 party send --mention 把人拉进来/唤醒。
 // Claude Code 原生 @ 只认本地文件/技能，塞不进远程动态列表；本命令就是那个「动态在线列表」。
-import { autoWakeReachable, type AgentActivity, type PresenceEntry, type SenderKind, type WakeKind, wakeableState } from "@agentparty/shared";
+import { autoWakeReachable, type AgentActivity, type ListeningVerdict, type PresenceEntry, type RunnerHealth, type SenderKind, type WakeKind, wakeableState } from "@agentparty/shared";
 import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
 import { resolveChannel } from "../config";
 import { resolveAuth } from "../oidc-cli";
@@ -35,7 +35,7 @@ session name), so mention the "@handle" shown here — not a UUID session name.
 Options:
   --channel C   read channel C instead of the bound channel
   --json        emit one JSON object per line
-                (name/kind/tier/wake/wake_unverified/busy/queue_depth/waiting_owner_count/current_task/task_started_at/heartbeat_at/activity/agent_session/account/handle/display_name/age_ms/read_seq)`;
+                (name/kind/tier/wake/wake_unverified/busy/queue_depth/waiting_owner_count/current_task/task_started_at/heartbeat_at/activity/listening/runner_health/agent_session/account/handle/display_name/age_ms/read_seq)`;
 
 const STALE_MS = 60_000; // 与 DO presence 扫描一致
 const DEAD_MS = 14 * 24 * 60 * 60 * 1000; // 14 天没露面视为幽灵，不再列
@@ -79,6 +79,10 @@ interface Row {
   // 模型 session 活动（#602）：hook 落盘、serve 心跳捎带的「正在干什么」——比 current_task 更细：
   // 正在跑哪个工具 / 卡权限确认 / compact / turn 已结束。仅在有活跃任务时带出。
   activity?: AgentActivity;
+  // 探活分级（#603）：listening 是服务端从 delivery 租约状态机派生的「在线但没在听」；
+  // runner_health 是 serve 自报的「在线但干不动」（runner 连败）。两者正交，都缺省即无恙。
+  listening?: ListeningVerdict;
+  runner_health?: RunnerHealth;
   // runner 自报、worker 持久化的模型会话句柄（#522）；不是 websocket session。
   agent_session?: PresenceEntry["agent_session"];
 }
@@ -143,6 +147,9 @@ export function classify(e: PresenceEntry, now: number): Row | null {
           ...(e.activity === undefined ? {} : { activity: e.activity }),
         }
       : {}),
+    // 探活分级（#603）：服务端只对有活连接的身份下发 listening；runner_health 独立于任务生命周期。
+    ...(e.listening === "suspect" || e.listening === "deaf" ? { listening: e.listening } : {}),
+    ...(e.runner_health === undefined ? {} : { runner_health: e.runner_health }),
     ...(e.agent_session === undefined ? {} : { agent_session: e.agent_session }),
     age_ms: age,
     ...(typeof e.connection_count === "number" && e.connection_count > 1
@@ -207,6 +214,19 @@ export function taskNote(r: Row, now: number): string {
   const beat =
     typeof r.heartbeat_at === "number" ? ` · ♥ ${humanAge(Math.max(0, now - r.heartbeat_at))}` : " · ♥ (none)";
   return ` · ▶ seq ${r.current_task}${beat}`;
+}
+
+// 探活分级标注（#603）：live 只证明连接活着，这两条说的是「活着但没在用」——
+// listening（服务端从 delivery 租约派生：投喂了不吃）与 runner_health（自报：唤醒了起不来）。
+export function livenessNote(r: Row): string {
+  const parts: string[] = [];
+  if (r.listening === "deaf") parts.push("⚠ not listening (deliveries expiring)");
+  else if (r.listening === "suspect") parts.push("⚠ slow to consume (1 delivery lease expired)");
+  if (r.runner_health !== undefined && !r.runner_health.ok) {
+    const err = r.runner_health.last_error !== undefined ? `: ${r.runner_health.last_error}` : "";
+    parts.push(`⚠ runner failing x${r.runner_health.consecutive_failures}${err}`);
+  }
+  return parts.length > 0 ? ` · ${parts.join(" · ")}` : "";
 }
 
 // 模型 session 活动标注（#602）：比「▶ seq X」再细一层——具体在干什么。waiting_permission 是
@@ -336,7 +356,7 @@ export async function run(argv: string[]): Promise<number> {
           ? ` · ${r.wake_unverified === true ? "unverified" : "verified"}${r.wake ? ` (${r.wake})` : ""}`
           : "";
       const age = r.tier === "online" ? "" : ` (${humanAge(r.age_ms)})`;
-      console.log(`${DOT[r.tier]} ${r.tier.padEnd(8)} ${r.name}  [${r.kind}]${identityNote(r)}${busyNote(r)}${waitingOwnerNote(r)}${taskNote(r, now)}${activityNote(r, now)}${sessionNote(r)}${wake}${read}${duplicate}${age}`);
+      console.log(`${DOT[r.tier]} ${r.tier.padEnd(8)} ${r.name}  [${r.kind}]${identityNote(r)}${busyNote(r)}${waitingOwnerNote(r)}${taskNote(r, now)}${activityNote(r, now)}${livenessNote(r)}${sessionNote(r)}${wake}${read}${duplicate}${age}`);
     }
     return 0;
   } catch (e) {

--- a/cli/test/serve.test.ts
+++ b/cli/test/serve.test.ts
@@ -360,6 +360,86 @@ describe("runServe", () => {
     expect(clear!.activity).toBeUndefined();
   });
 
+  // runner 健康自报（#603）：连败计数随任务收尾拍上行——熔断前那段「presence 全绿但 @ 了没人应」
+  // 的窗口从此可见。单次失败 ok 仍为 true（有重试兜底），≥2 连败才翻 false。
+  test("task heartbeat: reports runner_health on consecutive failures with the last error (#603)", async () => {
+    const beats: Array<{
+      current_task: number | null;
+      runner_health?: { ok: boolean; consecutive_failures: number; last_error?: string };
+    }> = [];
+    server = startMockServer((frame, sock) => {
+      if (frame.type === "heartbeat") {
+        beats.push(frame as unknown as (typeof beats)[number]);
+        return;
+      }
+      if (frame.type !== "hello") return;
+      sock.send(welcomeFrame(0, "me"));
+      // 两条 @ 先后失败（第一条放弃宣告后欠账即了结、游标前移，第二条照常触发）→ 连败 2。
+      setTimeout(() => sock.send(msgFrame(1, "doomed wake", { mentions: ["me"] })), 10);
+      setTimeout(() => sock.send(msgFrame(2, "doomed again", { mentions: ["me"] })), 90);
+      setTimeout(() => sock.send({ type: "error", code: "archived", message: "done" }), 180);
+    });
+    const o = opts({
+      server: server.url,
+      maxWakeAttempts: 1,
+      wakeRetryDelayMs: 0,
+      post: async () => ({ seq: 99 }),
+      runCommand: async () => {
+        throw new Error("runner boom");
+      },
+    });
+
+    expect(await runServe(o)).toBe(EXIT_ARCHIVED);
+
+    const clears = beats.filter((b) => b.current_task === null);
+    expect(clears.length).toBeGreaterThanOrEqual(2);
+    // 第一次放弃：failures=1、ok 仍 true、带脱敏后的错误摘要
+    expect(clears[0]!.runner_health).toMatchObject({ ok: true, consecutive_failures: 1 });
+    expect(clears[0]!.runner_health!.last_error).toContain("runner boom");
+    // 第二次放弃：failures=2 → ok=false（「在线但干不动」）
+    expect(clears[1]!.runner_health).toMatchObject({ ok: false, consecutive_failures: 2 });
+    // 活跃拍也携带既有连败（第二条任务开跑时频道还能看见此前的失败史）
+    const secondStart = beats.filter((b) => b.current_task === 2 && b.runner_health !== undefined);
+    expect(secondStart.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("task heartbeat: in-task retry that ends delivered reports no runner_health (#603)", async () => {
+    const beats: Array<{
+      current_task: number | null;
+      runner_health?: { ok: boolean; consecutive_failures: number };
+    }> = [];
+    server = startMockServer((frame, sock) => {
+      if (frame.type === "heartbeat") {
+        beats.push(frame as unknown as (typeof beats)[number]);
+        return;
+      }
+      if (frame.type !== "hello") return;
+      sock.send(welcomeFrame(0, "me"));
+      setTimeout(() => sock.send(msgFrame(1, "flaky then fine", { mentions: ["me"] })), 10);
+      setTimeout(() => sock.send({ type: "error", code: "archived", message: "done" }), 120);
+    });
+    let calls = 0;
+    const o = opts({
+      server: server.url,
+      maxWakeAttempts: 2,
+      wakeRetryDelayMs: 0,
+      post: async () => ({ seq: 99 }),
+      runCommand: async () => {
+        calls += 1;
+        // 第一次尝试失败（可重试），第二次成功——最终送达的任务不算 runner 失败。
+        if (calls === 1) throw new WakeBlockedError("spawn boom", true);
+      },
+    });
+
+    expect(await runServe(o)).toBe(EXIT_ARCHIVED);
+
+    expect(calls).toBe(2);
+    const clears = beats.filter((b) => b.current_task === null);
+    expect(clears.length).toBeGreaterThanOrEqual(1);
+    // 任务内重试后仍然送达 → 收尾拍不带 runner_health（服务端据此保持/恢复健康档）
+    expect(clears[clears.length - 1]!.runner_health).toBeUndefined();
+  });
+
   test("restart resume: serve reports the persisted runner session on welcome (#522)", async () => {
     const workdir = tempDir();
     writeFileSync(join(workdir, "wake-session.json"), JSON.stringify({

--- a/cli/test/wake.test.ts
+++ b/cli/test/wake.test.ts
@@ -198,6 +198,66 @@ function freshServeWatchPresence(kind: "serve" | "watch") {
   };
 }
 
+// ── 探活分级（#603）：timeout 不再一锅端，按 presence 的负面证据细分为可处置结论 ──
+describe("wake test liveness tiers (#603)", () => {
+  function tieredMock(extra: Record<string, unknown>) {
+    return startRestMock((req) => {
+      if (req.method === "GET" && req.path === "/api/channels/dev/presence") {
+        return Response.json({ presence: [{ ...freshServeWatchPresence("serve"), ...extra }] });
+      }
+      if (req.method === "POST" && req.path === "/api/channels/dev/messages") {
+        return Response.json({ seq: 50 });
+      }
+      if (req.method === "GET" && req.path === "/api/channels/dev/wake-deliveries") {
+        return Response.json({ deliveries: [] });
+      }
+      if (req.method === "GET" && req.path === "/api/channels/dev/messages") {
+        return Response.json({ messages: [] });
+      }
+      return undefined;
+    });
+  }
+
+  test("deaf presence refines timeout to not_listening with a supervisor-restart hint", async () => {
+    mock = tieredMock({ live: true, listening: "deaf" });
+    writeCfg(mock.url);
+
+    const r = await runCli(["wake", "test", "@agent", "dev", "--timeout", "1", "--json"]);
+    expect(r.code).toBe(2);
+    const frame = JSON.parse(r.stdout.trim());
+    expect(frame).toMatchObject({ type: "wake_test", result: "not_listening" });
+    expect(frame.reason).toContain("not consuming deliveries");
+    expect(frame.reason).toContain("restart its serve/watch supervisor");
+    expect(frame.presence.listening).toBe("deaf");
+  });
+
+  test("failing runner_health refines timeout to runner_failing and outranks the listening verdict", async () => {
+    mock = tieredMock({
+      live: true,
+      listening: "suspect",
+      runner_health: { ok: false, consecutive_failures: 2, last_error: "spawn claude ENOENT" },
+    });
+    writeCfg(mock.url);
+
+    const r = await runCli(["wake", "test", "@agent", "dev", "--timeout", "1", "--json"]);
+    expect(r.code).toBe(2);
+    const frame = JSON.parse(r.stdout.trim());
+    expect(frame).toMatchObject({ type: "wake_test", result: "runner_failing" });
+    expect(frame.reason).toContain("spawn claude ENOENT");
+    expect(frame.reason).toContain("fix the runner environment");
+    expect(frame.presence.runner_health).toMatchObject({ ok: false, consecutive_failures: 2 });
+  });
+
+  test("no adverse evidence keeps the plain timeout verdict", async () => {
+    mock = tieredMock({ live: true });
+    writeCfg(mock.url);
+
+    const r = await runCli(["wake", "test", "@agent", "dev", "--timeout", "1", "--json"]);
+    expect(r.code).toBe(2);
+    expect(JSON.parse(r.stdout.trim())).toMatchObject({ type: "wake_test", result: "timeout" });
+  });
+});
+
 describe("wake test audits serve/watch ledger (#107)", () => {
   test("serve broadcast (not yet consumed): wake_invoked reads the ledger, not 'not audited'", async () => {
     mock = startRestMock((req) => {

--- a/cli/test/who.test.ts
+++ b/cli/test/who.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { PresenceEntry } from "@agentparty/shared";
-import { busyNote, classify, identityNote, sessionNote, taskNote, terminalIdentityText, waitingOwnerNote } from "../src/commands/who";
+import { busyNote, classify, identityNote, livenessNote, sessionNote, taskNote, terminalIdentityText, waitingOwnerNote } from "../src/commands/who";
 
 const NOW = 1_000_000_000;
 
@@ -308,5 +308,32 @@ describe("who busy + queue depth (#103)", () => {
     // 离线 presence 服务端本就不下发这些字段；即便脏数据混进来，classify 也不该把它当成「正在处理」。
     const offline = classify(p({ name: "bot", state: "offline", wake: { kind: "serve" } }), NOW);
     expect(offline?.current_task).toBeUndefined();
+  });
+});
+
+// 探活分级（#603）：listening（服务端派生「没在听」）与 runner_health（自报「干不动」）的展示与透传。
+describe("who liveness tiers (#603)", () => {
+  test("classify 透传 listening 与 runner_health（缺省即无恙、不无中生有）", () => {
+    const row = classify(p({ name: "bot", live: true, listening: "deaf", runner_health: { ok: false, consecutive_failures: 3, last_error: "boom" } }), NOW);
+    expect(row?.listening).toBe("deaf");
+    expect(row?.runner_health).toMatchObject({ ok: false, consecutive_failures: 3 });
+    const clean = classify(p({ name: "ok-bot", live: true }), NOW);
+    expect(clean?.listening).toBeUndefined();
+    expect(clean?.runner_health).toBeUndefined();
+  });
+
+  test("livenessNote：deaf/suspect 与 runner 连败分别标注，健康时为空", () => {
+    const deaf = classify(p({ name: "bot", live: true, listening: "deaf" }), NOW)!;
+    expect(livenessNote(deaf)).toContain("not listening");
+    const suspect = classify(p({ name: "bot", live: true, listening: "suspect" }), NOW)!;
+    expect(livenessNote(suspect)).toContain("slow to consume");
+    const failing = classify(p({ name: "bot", live: true, runner_health: { ok: false, consecutive_failures: 2, last_error: "spawn ENOENT" } }), NOW)!;
+    expect(livenessNote(failing)).toContain("runner failing x2");
+    expect(livenessNote(failing)).toContain("spawn ENOENT");
+    // 单次失败（ok=true）不告警：有重试兜底，别制造噪音
+    const single = classify(p({ name: "bot", live: true, runner_health: { ok: true, consecutive_failures: 1 } }), NOW)!;
+    expect(livenessNote(single)).toBe("");
+    const healthy = classify(p({ name: "bot", live: true }), NOW)!;
+    expect(livenessNote(healthy)).toBe("");
   });
 });

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -576,10 +576,13 @@ export function parseRunnerHealth(input: unknown): RunnerHealth | undefined {
     value.consecutive_failures < 0 ||
     value.consecutive_failures > 1_000_000
   ) return undefined;
-  const lastError =
-    typeof value.last_error === "string" && value.last_error.length > 0
-      ? value.last_error.slice(0, 160)
-      : undefined;
+  // last_error 会被 who/wake 直接拼进终端输出：与 activity.tool 同口径剥 ESC/C0/C1，防转义序列注入。
+  const cleanedError =
+    typeof value.last_error === "string"
+      ? // eslint-disable-next-line no-control-regex
+        value.last_error.replace(/[\u0000-\u001f\u007f-\u009f]/g, "").slice(0, 160)
+      : "";
+  const lastError = cleanedError.length > 0 ? cleanedError : undefined;
   return {
     ok: value.ok,
     consecutive_failures: value.consecutive_failures,

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -520,6 +520,17 @@ export interface PresenceEntry {
    * 仅 state != offline 且有活跃任务时下发。旧客户端忽略。
    */
   activity?: AgentActivity;
+  /**
+   * runner 健康自报（issue #603）：serve runner 连败中（“在线但干不动”）。仅 state != offline 且
+   * 有连败（consecutive_failures ≥ 1）时下发；恢复由后续心跳缺省即清。旧客户端忽略。
+   */
+  runner_health?: RunnerHealth;
+  /**
+   * 服务端派生的监听力判定（issue #603）：directed delivery 租约对活连接过期 → suspect，
+   * 连续 ≥2 次 → deaf（“在线但没在听”）。仅有活 WS 连接且存在负面信号时下发；缺省 = 无恙。
+   * 目标任何一次确认 delivery 更新即清零。旧客户端忽略。
+   */
+  listening?: ListeningVerdict;
   /** Agent 自报并由频道持久化的模型会话句柄；供重启后精确 resume（issue #522）。 */
   agent_session?: AgentSessionInfo;
 }
@@ -544,6 +555,42 @@ export interface AgentActivity {
   /** 该活动的发生时刻（epoch ms）；消费方据 now-ts 判新鲜度。 */
   ts: number;
 }
+
+// runner 健康自报（issue #603）：serve 的 runner 连败（spawn 失败/硬超时/放弃）时，频道视角是
+// 「@ 了没人应」而 presence 全绿——熔断（MAX_CONSECUTIVE_WAKE_ABANDONS）退出前那段窗口完全不可见。
+// serve 把连败计数与最后错误随心跳帧自报；单次失败有重试兜底不算不健康（ok 在 ≥2 连败才翻 false）。
+export interface RunnerHealth {
+  ok: boolean;
+  consecutive_failures: number;
+  /** 最后一次失败的截断摘要（≤160 字符，已过 serve 侧脱敏）。 */
+  last_error?: string;
+}
+
+export function parseRunnerHealth(input: unknown): RunnerHealth | undefined {
+  if (typeof input !== "object" || input === null) return undefined;
+  const value = input as Record<string, unknown>;
+  if (typeof value.ok !== "boolean") return undefined;
+  if (
+    typeof value.consecutive_failures !== "number" ||
+    !Number.isInteger(value.consecutive_failures) ||
+    value.consecutive_failures < 0 ||
+    value.consecutive_failures > 1_000_000
+  ) return undefined;
+  const lastError =
+    typeof value.last_error === "string" && value.last_error.length > 0
+      ? value.last_error.slice(0, 160)
+      : undefined;
+  return {
+    ok: value.ok,
+    consecutive_failures: value.consecutive_failures,
+    ...(lastError === undefined ? {} : { last_error: lastError }),
+  };
+}
+
+// 监听力判定（issue #603）：live 只证明 TCP+握手活着；这里由服务端从 directed delivery 租约
+// 状态机派生「投喂了吃不吃」——租约对活连接过期一次 = suspect，连续 ≥2 次 = deaf。
+// 任何一次被目标确认的 delivery 更新（running/waiting_owner/replied/failed 都证明它在听）即清零。
+export type ListeningVerdict = "suspect" | "deaf";
 
 // activity 校验的统一口径：CLI 读 hook 落盘文件、DO 收 heartbeat 帧共用。
 // 脏值返回 undefined（调用方各自决定丢字段还是丢整帧）。tool 名截断到 64 字符——只是展示用途；
@@ -810,6 +857,11 @@ export interface HeartbeatFrame {
    * 缺省即「本拍无活动信息」，服务端把 activity 清空（活动新鲜度与心跳同生共死，绝不留僵值）。
    */
   activity?: AgentActivity;
+  /**
+   * runner 健康自报（issue #603）：serve 在任务收尾拍（含清除帧）带上连败计数。
+   * 缺省即「无连败」，服务端把已存的 runner_health 清空（恢复自动清零，绝不留僵值）。
+   */
+  runner_health?: RunnerHealth;
   /**
    * 可选的模型会话自报。可与任务心跳同帧，也可在三个任务字段均为 null 时单独上报；
    * 服务端持久化但不落聊天 history。缺省表示不更新已有会话。

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -38,7 +38,10 @@ import {
   DELIVERY_ORIGIN_CHANNEL_LIMIT,
   DELIVERY_WORK_ID_LIMIT,
   parseAgentActivity,
+  parseRunnerHealth,
   type AgentActivity,
+  type ListeningVerdict,
+  type RunnerHealth,
   type AgentLineage,
   type AgentSessionInfo,
   type Attachment,
@@ -1217,6 +1220,7 @@ export interface ParsedTaskHeartbeat {
   task_started_at: number | null;
   heartbeat_at: number | null;
   activity?: AgentActivity;
+  runner_health?: RunnerHealth;
   agent_session?: AgentSessionInfo;
 }
 
@@ -1261,11 +1265,15 @@ function parseHeartbeatFrame(input: unknown): ParsedTaskHeartbeat | null {
   // 模型 session 活动（#602）：可选捎带；脏 activity 与脏 agent_session 同口径——整帧丢弃。
   const activity = f.activity === undefined ? undefined : parseAgentActivity(f.activity);
   if (f.activity !== undefined && activity === undefined) return null;
+  // runner 健康自报（#603）：同口径。
+  const runnerHealth = f.runner_health === undefined ? undefined : parseRunnerHealth(f.runner_health);
+  if (f.runner_health !== undefined && runnerHealth === undefined) return null;
   return {
     current_task: current,
     task_started_at: started,
     heartbeat_at: heartbeat,
     ...(activity === undefined ? {} : { activity }),
+    ...(runnerHealth === undefined ? {} : { runner_health: runnerHealth }),
     ...(agentSession === undefined ? {} : { agent_session: agentSession }),
   };
 }
@@ -1578,6 +1586,9 @@ export class ChannelDO extends Server<Env> {
       // 模型 session 活动（#602）：hook 落盘、serve 心跳捎带的「正在干什么」快照 JSON。
       // 与心跳字段同生共死（任务结束/离线即清）。
       "ALTER TABLE presence ADD COLUMN activity_json TEXT",
+      // runner 健康自报（#603）：serve runner 连败计数 + 最后错误。独立于 current_task 生命周期
+      //（空闲期也要能看见「干不动」）；恢复由心跳缺省即清，离线一并清。
+      "ALTER TABLE presence ADD COLUMN runner_health_json TEXT",
     ]) {
       try {
         sql.exec(ddl);
@@ -1586,6 +1597,13 @@ export class ChannelDO extends Server<Env> {
       }
     }
     this.migratePresenceSessionSchema();
+    // 监听力判定（#603）：directed delivery 租约对「仍活着的连接」过期的连续次数，按身份聚合。
+    // live 只证明 TCP 活着；这张表回答「投喂了吃不吃」。任何一次被目标确认的 delivery 更新即清零。
+    sql.exec(`CREATE TABLE IF NOT EXISTS listening_health (
+      name TEXT PRIMARY KEY,
+      streak INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )`);
     sql.exec(`CREATE TABLE IF NOT EXISTS meta (
       key TEXT PRIMARY KEY,
       value TEXT NOT NULL
@@ -2097,6 +2115,7 @@ export class ChannelDO extends Server<Env> {
         task_started_at INTEGER,
         heartbeat_at INTEGER,
         activity_json TEXT,
+        runner_health_json TEXT,
         agent_session_json TEXT,
         PRIMARY KEY (name, session_id)
       )`);
@@ -2106,14 +2125,14 @@ export class ChannelDO extends Server<Env> {
         status_decision_json, status_workflow_json, role, role_source, residency, wake_kind,
         wake_verified_at, context_json, lineage_json, kind, account, client_version, handle,
         display_name, avatar_url, avatar_thumb, paused_at, paused_resume_at, busy, queue_depth,
-        current_task, task_started_at, heartbeat_at, activity_json, agent_session_json
+        current_task, task_started_at, heartbeat_at, activity_json, runner_health_json, agent_session_json
       ) SELECT
         name, COALESCE(NULLIF(session_id, ''), '${LEGACY_SESSION_ID}'), state, note, updated_at,
         status_scope_json, status_summary_seq, status_blocked_reason, status_context_json,
         status_decision_json, status_workflow_json, role, role_source, residency, wake_kind,
         wake_verified_at, context_json, lineage_json, kind, account, client_version, handle,
         display_name, avatar_url, avatar_thumb, paused_at, paused_resume_at, busy, queue_depth,
-        current_task, task_started_at, heartbeat_at, activity_json, agent_session_json
+        current_task, task_started_at, heartbeat_at, activity_json, runner_health_json, agent_session_json
       FROM presence`);
       sql.exec("DROP TABLE presence");
       sql.exec("ALTER TABLE presence_session_v2 RENAME TO presence");
@@ -2418,6 +2437,9 @@ export class ChannelDO extends Server<Env> {
       if (update === null || !this.applyDirectedDeliveryUpdate(st, connection.id, update, Date.now())) {
         badRequest();
       } else {
+        // 监听力判定（#603）：任何一次被接受的 delivery 更新（running/waiting_owner/replied/failed
+        // 都证明目标在消费投递，failed 也是「听见了」）即清零负面 streak，并把恢复广播出去。
+        if (this.clearListeningStreak(st.name)) this.broadcastPresenceFor(st.name);
         // Explicit per-connection ACK. A broadcast alone is insufficient: idempotent retries do not
         // change state, and the CLI must not advance durable work until it sees server confirmation.
         const row = this.directedDeliveryRow(update.delivery_id);
@@ -3330,6 +3352,7 @@ export class ChannelDO extends Server<Env> {
       `INSERT INTO presence (name, session_id, state, note, updated_at) VALUES (?, ?, 'offline', NULL, ?)
        ON CONFLICT(name, session_id) DO UPDATE SET state = 'offline', updated_at = excluded.updated_at,
          current_task = NULL, task_started_at = NULL, heartbeat_at = NULL, activity_json = NULL,
+         runner_health_json = NULL,
          -- #454：watch 只有活着的本地 listener 才能接住 @。最后一条连接断开后立即撤销 wake 声明，
          -- 不让被 harness kill 的 watch --once 继续以 wakeable 身份吸收 mention。serve/webhook 有独立
          -- supervisor/服务端投递语义，保持原样；watch 重挂后会由 advertiseWatchWake 重新声明。
@@ -3440,16 +3463,19 @@ export class ChannelDO extends Server<Env> {
         .toArray().length > 0;
     if (!exists) return;
     this.ctx.storage.sql.exec(
-      // activity（#602）不走 COALESCE：新鲜度与心跳同生共死，本拍没带就清空，绝不留僵值。
+      // activity（#602）/ runner_health（#603）不走 COALESCE：本拍没带就清空，绝不留僵值
+      //（activity 新鲜度与心跳同生共死；runner_health 恢复即自动清零）。
       // 清除帧（current_task=null）即便捎带了 activity 也一并清——没有任务就没有活动可言。
       `UPDATE presence SET current_task = ?, task_started_at = ?, heartbeat_at = ?,
          activity_json = ?,
+         runner_health_json = ?,
          agent_session_json = COALESCE(?, agent_session_json)
        WHERE name = ? AND session_id = ?`,
       hb.current_task,
       hb.task_started_at,
       hb.heartbeat_at,
       hb.current_task === null || hb.activity === undefined ? null : JSON.stringify(hb.activity),
+      hb.runner_health === undefined ? null : JSON.stringify(hb.runner_health),
       hb.agent_session === undefined ? null : JSON.stringify(hb.agent_session),
       name,
       sessionId,
@@ -6030,6 +6056,7 @@ export class ChannelDO extends Server<Env> {
         const now = Date.now();
         this.setMeta(this.removedPresenceKey(name), String(now));
         this.ctx.storage.sql.exec("DELETE FROM presence WHERE name = ?", name);
+        this.ctx.storage.sql.exec("DELETE FROM listening_health WHERE name = ?", name);
         this.broadcastFrame({ type: "presence", name, state: "offline", note: null, ts: now });
         this.insertSystemStatus(`removed ${name} from channel`, now, false, { state: "done" });
       }
@@ -7818,6 +7845,8 @@ export class ChannelDO extends Server<Env> {
       sql.exec("DELETE FROM read_cursor WHERE name = ?", name);
       presence_deleted = countOne("SELECT COUNT(*) AS n FROM presence WHERE name = ?", name);
       sql.exec("DELETE FROM presence WHERE name = ?", name);
+      // 监听力 streak（#603）按身份聚合，同属可识别数据，随擦除一并物理删除。
+      sql.exec("DELETE FROM listening_health WHERE name = ?", name);
     });
     const erasedAt = Date.now();
     for (const seq of updatedSeqs) {
@@ -8640,12 +8669,19 @@ export class ChannelDO extends Server<Env> {
       const expiredConnectionId = expiredConnections.get(targetName);
       if (expiredConnectionId !== undefined) {
         for (const connection of this.getConnections<ConnState>()) {
-          if (connection.id === expiredConnectionId) connection.close(1012, "delivery lease expired");
+          if (connection.id === expiredConnectionId) {
+            // 监听力判定（#603）：租约过期时连接还活着 = 「投喂了不吃」的实锤（断连的租约由
+            // requeueDirectedDeliveriesForConnection 即时回收，不会走到这里）。计一次负面 streak，
+            // presence 据此下发 suspect/deaf——过去这里只默默换人，谁在反复超时频道看不见。
+            this.bumpListeningStreak(targetName, now);
+            connection.close(1012, "delivery lease expired");
+          }
         }
       }
       // 明确排除超时 runner，让同名 standby 立即接棒；没有 standby 时 work 留在 queued 等重连。
       this.reconcileServeLease(targetName, expiredConnectionId);
       this.dispatchNextDirectedDelivery(targetName, expiredConnectionId);
+      this.broadcastPresenceFor(targetName);
     }
   }
 
@@ -9190,7 +9226,7 @@ export class ChannelDO extends Server<Env> {
                 state, note, updated_at, status_scope_json, status_summary_seq, status_blocked_reason,
                 status_context_json, status_decision_json, status_workflow_json, role, role_source, residency, wake_kind, wake_verified_at,
                 context_json, lineage_json, paused_at, paused_resume_at, busy, queue_depth,
-                current_task, task_started_at, heartbeat_at, activity_json, agent_session_json`;
+                current_task, task_started_at, heartbeat_at, activity_json, runner_health_json, agent_session_json`;
 
   private presenceList(): PresenceEntry[] {
     const liveCounts = this.liveConnectionCounts();
@@ -9207,12 +9243,14 @@ export class ChannelDO extends Server<Env> {
       group.push(row);
       grouped.set(name, group);
     }
+    const listeningStreaks = this.listeningStreaks();
     return [...grouped.entries()].map(([name, group]) =>
       this.withLivePresence(
         this.presenceRowToEntry(this.aggregatePresenceRow(name, group, liveSessions)),
         liveCounts,
         serveCounts,
         waitingOwnerCounts,
+        listeningStreaks,
       ),
     );
   }
@@ -9231,6 +9269,7 @@ export class ChannelDO extends Server<Env> {
           liveCounts,
           serveCounts,
           waitingOwnerCounts,
+          this.listeningStreaks(),
         )
       : null;
   }
@@ -9289,6 +9328,7 @@ export class ChannelDO extends Server<Env> {
     liveCounts: Map<string, number>,
     serveCounts?: Map<string, number>,
     waitingOwnerCounts?: Map<string, number>,
+    listeningStreaks?: Map<string, number>,
   ): PresenceEntry {
     const count = liveCounts.get(entry.name) ?? 0;
     const live = applyLiveConnection(entry, count > 0);
@@ -9298,7 +9338,38 @@ export class ChannelDO extends Server<Env> {
     const standbys = (serveCounts?.get(entry.name) ?? 0) - 1;
     const withStandbys = standbys > 0 ? { ...withCount, serve_standbys: standbys } : withCount;
     const waitingOwner = waitingOwnerCounts?.get(entry.name) ?? 0;
-    return waitingOwner > 0 ? { ...withStandbys, waiting_owner_count: waitingOwner } : withStandbys;
+    const withWaiting = waitingOwner > 0 ? { ...withStandbys, waiting_owner_count: waitingOwner } : withStandbys;
+    // 监听力判定（#603）：只对「当前有活连接」的身份下发——没有连接的身份是 offline/wakeable，
+    // 不是 deaf。streak 1 次 = suspect，连续 ≥2 次 = deaf。缺省 = 无恙。
+    const streak = count > 0 ? (listeningStreaks?.get(entry.name) ?? 0) : 0;
+    const listening: ListeningVerdict | null = streak >= 2 ? "deaf" : streak === 1 ? "suspect" : null;
+    return listening === null ? withWaiting : { ...withWaiting, listening };
+  }
+
+  // 监听力 streak（#603）：directed delivery 租约对活连接过期的连续次数，按身份聚合。
+  private listeningStreaks(): Map<string, number> {
+    const map = new Map<string, number>();
+    for (const row of this.ctx.storage.sql.exec("SELECT name, streak FROM listening_health").toArray()) {
+      map.set(String(row.name), Number(row.streak));
+    }
+    return map;
+  }
+
+  private bumpListeningStreak(name: string, now: number) {
+    this.ctx.storage.sql.exec(
+      `INSERT INTO listening_health (name, streak, updated_at) VALUES (?, 1, ?)
+       ON CONFLICT(name) DO UPDATE SET streak = streak + 1, updated_at = excluded.updated_at`,
+      name,
+      now,
+    );
+  }
+
+  /** 返回是否真的清掉了一条负面记录（调用方据此决定要不要广播 presence 变化）。 */
+  private clearListeningStreak(name: string): boolean {
+    const existed =
+      this.ctx.storage.sql.exec("SELECT 1 FROM listening_health WHERE name = ? LIMIT 1", name).toArray().length > 0;
+    if (existed) this.ctx.storage.sql.exec("DELETE FROM listening_health WHERE name = ?", name);
+    return existed;
   }
 
   private waitingOwnerCounts(): Map<string, number> {
@@ -9389,6 +9460,16 @@ export class ChannelDO extends Server<Env> {
             })(),
           }
         : {}),
+      // runner 健康（#603）：独立于 current_task——空闲期也要能看见「干不动」；offline 不带。
+      ...(() => {
+        if (state === "offline" || typeof r.runner_health_json !== "string" || r.runner_health_json === "") return {};
+        try {
+          const health = parseRunnerHealth(JSON.parse(r.runner_health_json) as unknown);
+          return health === undefined ? {} : { runner_health: health };
+        } catch {
+          return {};
+        }
+      })(),
       ...(() => {
         if (typeof r.agent_session_json !== "string" || r.agent_session_json === "") return {};
         try {

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -9357,8 +9357,9 @@ export class ChannelDO extends Server<Env> {
 
   private bumpListeningStreak(name: string, now: number) {
     this.ctx.storage.sql.exec(
+      // 判定只区分 1（suspect）与 ≥2（deaf），封顶 1000 防长期僵尸把计数器涨成天文数字。
       `INSERT INTO listening_health (name, streak, updated_at) VALUES (?, 1, ?)
-       ON CONFLICT(name) DO UPDATE SET streak = streak + 1, updated_at = excluded.updated_at`,
+       ON CONFLICT(name) DO UPDATE SET streak = MIN(streak + 1, 1000), updated_at = excluded.updated_at`,
       name,
       now,
     );

--- a/worker/test/listening-health.spec.ts
+++ b/worker/test/listening-health.spec.ts
@@ -1,0 +1,119 @@
+import type { PresenceEntry } from "@agentparty/shared";
+import { env, runInDurableObject } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import type { ChannelDO } from "../src/do";
+import { WsClient, api, createChannel, seedToken, uniq } from "./helpers";
+
+// 探活分级（issue #603）：live 只证明 TCP+握手活着。这里验证服务端从 directed delivery 租约
+// 状态机派生的监听力判定——租约对活连接过期一次 = suspect，连续 ≥2 次 = deaf；目标任何一次
+// 被接受的 delivery 更新即清零。判定只对「当前有活连接」的身份下发（离线是 offline，不是 deaf）。
+
+async function fetchPresence(slug: string, token: string): Promise<PresenceEntry[]> {
+  const res = await api(`/api/channels/${slug}/presence`, token);
+  expect(res.status).toBe(200);
+  return ((await res.json()) as { presence: PresenceEntry[] }).presence;
+}
+
+async function sendMention(slug: string, token: string, target: string, body: string) {
+  const response = await api(`/api/channels/${slug}/messages`, token, {
+    method: "POST",
+    body: JSON.stringify({ kind: "message", body: `@${target} ${body}`, mentions: [target], reply_to: null }),
+  });
+  expect(response.status).toBe(200);
+  return (await response.json()) as { seq: number };
+}
+
+// seedPresence 只在首次挂载用（与 CLI 挂上先报 status 的行为一致）。重连时绝不发：
+// helpers 的 nextOfType 会丢弃不匹配帧，等 `sent` 会把重连即刻重派的 `delivery` 帧吞掉。
+async function attachServe(slug: string, token: string, opts: { seedPresence?: boolean } = {}): Promise<WsClient> {
+  const ws = await WsClient.open(slug, token);
+  await ws.nextOfType("welcome");
+  ws.send({ type: "hello", since: 0, directed_delivery: "v1" });
+  ws.send({ type: "serve_lease", op: "claim" });
+  expect(await ws.nextOfType("serve_lease")).toMatchObject({ held: true });
+  if (opts.seedPresence === true) {
+    ws.send({ type: "send", kind: "status", state: "waiting", note: "attached", mentions: [] });
+    await ws.nextOfType("sent");
+  }
+  return ws;
+}
+
+/** 回拨该频道所有在租 delivery 的 lease_until 并触发 alarm——模拟「投喂了 90s 没人吃」。 */
+async function expireLeases(slug: string) {
+  const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+  await runInDurableObject(stub, async (instance: ChannelDO, state) => {
+    state.storage.sql.exec(
+      "UPDATE directed_deliveries SET lease_until = ? WHERE lease_until IS NOT NULL",
+      Date.now() - 1,
+    );
+    await instance.onAlarm();
+  });
+}
+
+describe("listening verdict from delivery-lease expiry (issue #603)", () => {
+  it("suspect after one live-connection lease expiry, deaf after two, cleared by an accepted update", async () => {
+    const owner = `${uniq("listen-owner")}@example.com`;
+    const sender = await seedToken("human", uniq("sender"), { owner });
+    const slug = await createChannel(sender.token);
+    const target = await seedToken("agent", uniq("listen-target"), { owner, channelScope: slug });
+
+    // 第一轮：领取后装死（不 ack），租约对活连接过期 → streak=1
+    let serve = await attachServe(slug, target.token, { seedPresence: true });
+    await sendMention(slug, sender.token, target.name, "are you listening");
+    const first = (await serve.nextOfType("delivery")) as { delivery: { id: string; work_id?: string; continuation_ref?: string } };
+    await expireLeases(slug);
+    serve.close();
+
+    // 重连（live 恢复）后判定可见：suspect
+    serve = await attachServe(slug, target.token);
+    let entry = (await fetchPresence(slug, target.token)).find((e) => e.name === target.name);
+    expect(entry?.listening).toBe("suspect");
+
+    // 第二轮：重派后继续装死 → streak=2 → deaf
+    await serve.nextOfType("delivery");
+    await expireLeases(slug);
+    serve.close();
+    serve = await attachServe(slug, target.token);
+    entry = (await fetchPresence(slug, target.token)).find((e) => e.name === target.name);
+    expect(entry?.listening).toBe("deaf");
+
+    // 第三轮：终于消费（running ACK）→ 任何被接受的更新即清零
+    const replayed = (await serve.nextOfType("delivery")) as { delivery: { id: string; work_id?: string; continuation_ref?: string } };
+    expect(replayed.delivery.id).toBe(first.delivery.id);
+    serve.send({
+      type: "delivery_update",
+      delivery_id: replayed.delivery.id,
+      state: "running",
+      work_id: replayed.delivery.work_id ?? undefined,
+      continuation_ref: replayed.delivery.continuation_ref ?? undefined,
+    });
+    for (;;) {
+      const state = await serve.nextOfType("delivery_state");
+      if (
+        (state as { delivery: { id: string; state: string } }).delivery.id === replayed.delivery.id &&
+        (state as { delivery: { state: string } }).delivery.state === "running"
+      ) break;
+    }
+    entry = (await fetchPresence(slug, target.token)).find((e) => e.name === target.name);
+    expect(entry).toBeDefined();
+    expect(entry).not.toHaveProperty("listening");
+    serve.close();
+  });
+
+  it("does not emit a verdict for an identity with no live connection (offline is not deaf)", async () => {
+    const owner = `${uniq("offline-owner")}@example.com`;
+    const sender = await seedToken("human", uniq("sender"), { owner });
+    const slug = await createChannel(sender.token);
+    const target = await seedToken("agent", uniq("offline-target"), { owner, channelScope: slug });
+
+    const serve = await attachServe(slug, target.token, { seedPresence: true });
+    await sendMention(slug, sender.token, target.name, "going deaf then offline");
+    await serve.nextOfType("delivery");
+    await expireLeases(slug);
+    serve.close();
+
+    // 不重连：连接没了就是 offline/wakeable 语义，绝不给 deaf 判定
+    const entry = (await fetchPresence(slug, sender.token)).find((e) => e.name === target.name);
+    if (entry !== undefined) expect(entry).not.toHaveProperty("listening");
+  });
+});

--- a/worker/test/presence-task-heartbeat.spec.ts
+++ b/worker/test/presence-task-heartbeat.spec.ts
@@ -283,3 +283,29 @@ describe("presence per-task heartbeat (issue #228)", () => {
     ws.close();
   });
 });
+
+
+// runner_health.last_error 会被 who/wake 直接拼进终端：控制字符在协议校验层统一剥离（#603 复审）。
+describe("runner_health last_error hygiene (#603)", () => {
+  it("strips control characters from last_error before persisting", async () => {
+    const agent = await seedToken("agent");
+    const slug = await createChannel(agent.token);
+    const ws = await WsClient.open(slug, agent.token);
+    await ws.nextOfType("welcome");
+    ws.send({ type: "hello", since: 0 });
+    await seedPresence(ws);
+    await ws.nextOfType("presence");
+
+    ws.send({
+      type: "heartbeat",
+      current_task: null,
+      task_started_at: null,
+      heartbeat_at: null,
+      runner_health: { ok: false, consecutive_failures: 2, last_error: "boom\u001b[31mevil\u0007end" },
+    });
+    await ws.nextOfType("presence");
+    const entry = (await fetchPresence(slug, agent.token)).find((e) => e.name === agent.name);
+    expect(entry?.runner_health?.last_error).toBe("boom[31mevilend");
+    ws.close();
+  });
+});

--- a/worker/test/presence-task-heartbeat.spec.ts
+++ b/worker/test/presence-task-heartbeat.spec.ts
@@ -214,6 +214,8 @@ describe("presence per-task heartbeat (issue #228)", () => {
     await ws.nextOfType("welcome");
     ws.send({ type: "hello", since: 0 });
     await seedPresence(ws);
+    // 排掉 seedPresence 的 presence 广播，后续 nextOfType("presence") 对齐一拍心跳（防竞态）
+    await ws.nextOfType("presence");
 
     // 任务放弃后的清除帧：task 字段全 null，但 runner_health 留在 presence 上（空闲期可见）
     ws.send({
@@ -245,6 +247,7 @@ describe("presence per-task heartbeat (issue #228)", () => {
     await ws.nextOfType("welcome");
     ws.send({ type: "hello", since: 0 });
     await seedPresence(ws);
+    await ws.nextOfType("presence");
 
     ws.send({
       type: "heartbeat",

--- a/worker/test/presence-task-heartbeat.spec.ts
+++ b/worker/test/presence-task-heartbeat.spec.ts
@@ -205,6 +205,63 @@ describe("presence per-task heartbeat (issue #228)", () => {
     ws.close();
   });
 
+  // runner 健康自报（issue #603）：serve 在任务收尾拍带上连败计数；独立于 current_task 生命周期
+  //（空闲期也要能看见「干不动」），恢复由后续心跳缺省即清。
+  it("stamps runner_health from a clear beat and keeps it visible while idle (#603)", async () => {
+    const agent = await seedToken("agent");
+    const slug = await createChannel(agent.token);
+    const ws = await WsClient.open(slug, agent.token);
+    await ws.nextOfType("welcome");
+    ws.send({ type: "hello", since: 0 });
+    await seedPresence(ws);
+
+    // 任务放弃后的清除帧：task 字段全 null，但 runner_health 留在 presence 上（空闲期可见）
+    ws.send({
+      type: "heartbeat",
+      current_task: null,
+      task_started_at: null,
+      heartbeat_at: null,
+      runner_health: { ok: false, consecutive_failures: 2, last_error: "spawn claude ENOENT" },
+    });
+    await ws.nextOfType("presence");
+    let entry = (await fetchPresence(slug, agent.token)).find((e) => e.name === agent.name);
+    expect(entry).toMatchObject({
+      runner_health: { ok: false, consecutive_failures: 2, last_error: "spawn claude ENOENT" },
+    });
+    expect(entry).not.toHaveProperty("current_task");
+
+    // 恢复：下一拍缺省 runner_health 即清空
+    ws.send({ type: "heartbeat", current_task: null, task_started_at: null, heartbeat_at: null });
+    await ws.nextOfType("presence");
+    entry = (await fetchPresence(slug, agent.token)).find((e) => e.name === agent.name);
+    expect(entry).not.toHaveProperty("runner_health");
+    ws.close();
+  });
+
+  it("drops a heartbeat carrying a malformed runner_health (#603)", async () => {
+    const agent = await seedToken("agent");
+    const slug = await createChannel(agent.token);
+    const ws = await WsClient.open(slug, agent.token);
+    await ws.nextOfType("welcome");
+    ws.send({ type: "hello", since: 0 });
+    await seedPresence(ws);
+
+    ws.send({
+      type: "heartbeat",
+      current_task: 5,
+      task_started_at: 1000,
+      heartbeat_at: 1000,
+      runner_health: { ok: "nope", consecutive_failures: -1 },
+    });
+    ws.send({ type: "heartbeat", current_task: 6, task_started_at: 1000, heartbeat_at: 1000 });
+    await ws.nextOfType("presence");
+
+    const entry = (await fetchPresence(slug, agent.token)).find((e) => e.name === agent.name);
+    expect(entry).toMatchObject({ current_task: 6 });
+    expect(entry).not.toHaveProperty("runner_health");
+    ws.close();
+  });
+
   it("ignores a malformed heartbeat (negative / non-integer) without erroring the socket", async () => {
     const agent = await seedToken("agent");
     const slug = await createChannel(agent.token);


### PR DESCRIPTION
Closes #603

> **Stacked on #606**（同区代码：心跳解析、PRESENCE_COLUMNS、emitTaskBeat）。#606 合并后本 PR base 自动落回 main；合并顺序：先 #606 后本 PR。

## 干了什么

presence 之前只能证明「连接活着」。本 PR 把三种长一个样的状态拆开，全部沉淀进 presence、`party who` 与 `party wake test`：

| 状态 | 信号 | 来源 |
|---|---|---|
| 挂了 | last_seen 陈旧 / 无 live | 既有 |
| **活着但没在听** | `listening: suspect/deaf` | 服务端从 directed delivery 租约状态机派生（新） |
| **活着但干不动** | `runner_health: {ok, consecutive_failures, last_error}` | serve 自报 runner 连败（新） |

## 机制（全部复用既有状态机，零新计时器/探针）

**listening（DO 派生）**
- 租约超时路径（`requeueExpiredDirectedDeliveries`）本就会对超时 runner `close(1012)` + standby 接棒——但判定从不落 presence，谁在反复超时频道看不见。现在：**租约对「仍在 getConnections 里的活连接」过期**才计一次负面 streak（断连的租约由 disconnect 路径即时回收，不算）；streak=1 → `suspect`，≥2 → `deaf`。
- 清零：目标任何一次被接受的 `delivery_update`（running/waiting_owner/replied/failed 都证明它在听，failed 也是「听见了」）。
- 只对有活连接的身份下发（离线是 offline，不是 deaf）；存 `listening_health` 表（name 主键），GDPR 擦除/成员移除一并物理删除。

**runner_health（serve 自报）**
- 复用 `consecutiveWakeAbandons` 同口径：任务收尾拍结账——送达清零、放弃递增（shutdown 不算失败）；连败 ≥2 才 `ok:false`（单次失败有重试兜底，不告警）。last_error 过 `sanitizeBlockedError` 截断 160 字符。
- 这填的是熔断（MAX_CONSECUTIVE_WAKE_ABANDONS=3 退出）**之前**那段「presence 全绿但 @ 了没人应」的盲窗；心跳缺省即清，恢复自动出档。

**消费**
- `party who`：`⚠ not listening (deliveries expiring)` / `⚠ runner failing x2: spawn claude ENOENT`；--json 带 `listening`/`runner_health`。
- `party wake test`：timeout 时重取 presence，细分为 `not_listening`（提示重启 supervisor）/ `runner_failing`（提示修 runner 环境），runner_failing 更接近根因、优先；无负面证据保持原 `timeout`。

## 分层改动

- shared：`RunnerHealth` + `parseRunnerHealth`、`ListeningVerdict`；`PresenceEntry.listening/runner_health`、`HeartbeatFrame.runner_health`（全可选，四象限兼容）。
- cli：serve 连败结账进心跳；client.ts 校验新字段；who `livenessNote`；wake test verdict 细分。
- worker：presence 加 `runner_health_json` 列（幂等 ALTER + v2 迁移两侧）；`listening_health` 表；租约超时 bump + update 清零 + presence 广播；序列化门禁（offline 不带、无 live 不带 listening）。

## 测试

- `worker/test/listening-health.spec.ts`（新）：真跑 DO——领取后装死 → 租约过期 → 重连见 `suspect`；再装死 → `deaf`；running ACK 清零；无活连接绝不给判定。
- `worker/test/presence-task-heartbeat.spec.ts`：runner_health 空闲期可见、缺省即清、脏值整帧丢弃。
- `cli/test/serve.test.ts`：两条 wake 连败 → 清除拍带 `{ok:true,x1}` → `{ok:false,x2}`+last_error，活跃拍携带失败史；任务内重试成功不算失败。
- `cli/test/wake.test.ts`：deaf → `not_listening`、runner_health 失败 → `runner_failing`（优先于 listening）、无证据保持 `timeout`。
- `cli/test/who.test.ts`：透传与标注、单次失败不告警。
- 全量 cli/worker/web 测试 + 三包 tsc ✅（见 PR checks）。

## 非目标

- 服务端主动 probe 帧（租约信号已覆盖端到端「投了要吃」，probe 只能证明事件循环活着，更弱）。
- watch lane 的 turn-scoped 监听不参与 deaf 判定（#191 已定性）。
- web UI 展示另拆。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增运行器健康状态与监听状态展示，帮助识别在线但无法正常工作的服务。
  - `wake` 将超时进一步区分为“未监听”和“运行器故障”，并提供更明确的原因提示。
  - `who` 命令显示监听异常、连续失败次数及最近错误摘要。
- **改进**
  - 任务心跳会持续报告运行器连续失败状态，并在恢复成功后自动清除。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->