### PR TITLE
fix: #607 @ 一个收不到通知的人类时给出可见警示，不再静默吞

### DIFF
--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -4258,6 +4258,12 @@ export class ChannelDO extends Server<Env> {
       return;
     }
     const now = Date.now();
+    // 写入前顺手清掉已出窗的去重键（CodeRabbit #611）：每个新 handle 都会永久占一行 meta，
+    // 长寿频道会无界增长；清理后存储只保留活跃窗口内的键。
+    this.ctx.storage.sql.exec(
+      "DELETE FROM meta WHERE key LIKE 'unreachable_mention_warned:%' AND CAST(value AS INTEGER) < ?",
+      now - 30 * 60_000,
+    );
     const unreachable = candidates.filter((mention) => {
       if (excluded.has(mentionMatchKey(mention))) return false;
       // per-target 30 分钟去重（仿 wake budget 通告）：反复 @ 同一个不可达的人只提醒一次。

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -3616,6 +3616,8 @@ export class ChannelDO extends Server<Env> {
     this.recordServeWatchWakes(msg);
     // 首投移出发送关键路径：坏/慢端点不再让每条消息阻塞 N×10s 才返回 seq（DoS 频道）
     this.ctx.waitUntil(this.dispatchWebhooks(msg));
+    // #607：@ 到「谁都收不到」的人类时给发送者可见反馈，不再静默吞。
+    this.ctx.waitUntil(this.warnUnreachableHumanMentions(msg));
     if (this.getMeta("ckind") === "temp" && !this.isArchived()) {
       await this.ensureAlarmAt(msg.ts + this.tempIdleMs());
     }
@@ -4215,6 +4217,65 @@ export class ChannelDO extends Server<Env> {
 
   // 频道内可观测：预算用尽时通告一条 system status。按窗口去重（一个窗口内只播一次），避免
   // 高频 @ 把频道刷屏。用 waiting 而非 blocked——这是节流不是熔断，blocked 会让守 etiquette 的 agent 停手。
+  // #607：mention 决议走全实例 handle 面（account_profiles 不分频道），所以 @ 一个从未连过
+  // 本频道、也没订阅任何通知渠道的人类会正常落库，然后无声无息（生产实例：@karl 在么 → karl
+  // 不在 presence、无 lark-notify webhook → 无人收到、无任何反馈）。消息落库后异步核对每个
+  // 非 agent mention 的可达面：presence 非 offline（按 name 或 human handle 匹配）、或本频道
+  // 任一同名 webhook（lark-notify 订阅在此注册）。全都没有 → 落一条 system status 让发送者
+  // 看见。agent 目标不归这里管（离线 agent 有 directed delivery 持久重放），squad 会另行展开。
+  private async warnUnreachableHumanMentions(msg: MsgFrame): Promise<void> {
+    if (msg.sender.name === "system") return;
+    const mentions = msg.mentions ?? [];
+    if (mentions.length === 0) return;
+    const reachable = new Set<string>();
+    for (const row of this.ctx.storage.sql.exec("SELECT name, handle, state FROM presence").toArray()) {
+      if (String(row.state) === "offline") continue;
+      reachable.add(mentionMatchKey(String(row.name)));
+      if (row.handle !== null && row.handle !== undefined) reachable.add(mentionMatchKey(String(row.handle)));
+    }
+    for (const row of this.ctx.storage.sql.exec("SELECT name FROM webhooks").toArray()) {
+      reachable.add(mentionMatchKey(String(row.name)));
+    }
+    const candidates = mentions.filter((mention) => !reachable.has(mentionMatchKey(mention)));
+    if (candidates.length === 0) return;
+    const placeholders = candidates.map(() => "?").join(", ");
+    let excluded: Set<string>;
+    try {
+      const [agents, squads] = await Promise.all([
+        this.env.DB.prepare(
+          `SELECT name FROM tokens
+            WHERE revoked_at IS NULL AND role = 'agent'
+              AND (channel_scope IS NULL OR channel_scope = ?)
+              AND name IN (${placeholders})`,
+        ).bind(this.name, ...candidates).all<{ name: string }>(),
+        this.env.DB.prepare(
+          `SELECT name FROM channel_squads WHERE channel_slug = ? AND name IN (${placeholders})`,
+        ).bind(this.name, ...candidates).all<{ name: string }>(),
+      ]);
+      excluded = new Set([...agents.results, ...squads.results].map((row) => mentionMatchKey(row.name)));
+    } catch {
+      // 纯观测性告警：目录查询抖动时宁可少报一次，也不能让 waitUntil 抛错。
+      return;
+    }
+    const now = Date.now();
+    const unreachable = candidates.filter((mention) => {
+      if (excluded.has(mentionMatchKey(mention))) return false;
+      // per-target 30 分钟去重（仿 wake budget 通告）：反复 @ 同一个不可达的人只提醒一次。
+      const key = `unreachable_mention_warned:${mentionMatchKey(mention)}`;
+      const last = Number(this.getMeta(key) ?? "");
+      if (Number.isInteger(last) && now - last < 30 * 60_000) return false;
+      this.setMeta(key, String(now));
+      return true;
+    });
+    if (unreachable.length === 0) return;
+    this.insertSystemStatus(
+      `${unreachable.map((name) => `@${name}`).join(" ")} won't see this mention: offline and not subscribed to any notification for this channel (they can enable Lark notify or open the channel page)`,
+      now,
+      false,
+      { state: "waiting" },
+    );
+  }
+
   private alertWakeBudget(name: string, now: number) {
     const cfg = this.wakeBudgetConfig(name);
     if (cfg === null) return;

--- a/worker/test/unreachable-mention.spec.ts
+++ b/worker/test/unreachable-mention.spec.ts
@@ -1,0 +1,86 @@
+// #607：mention 决议走全实例 handle 面（account_profiles 不分频道），@ 一个从未连过本频道、
+// 也没订阅任何通知渠道的人类会正常落库，然后无声无息。修复后：消息落库后异步核对可达面
+// （presence 非 offline / 本频道同名 webhook），全都没有 → 频道内落一条 system status 警示，
+// 并按 target 30 分钟去重。agent 目标不警示（离线 agent 有 directed delivery 持久重放）。
+import { env } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import { api, createChannel, seedToken, uniq } from "./helpers";
+
+async function seedProfile(handle: string): Promise<string> {
+  const account = `lark:${uniq("acct")}`;
+  const now = Date.now();
+  await env.DB.prepare(
+    `INSERT INTO account_profiles (account, handle, display_name, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?)`,
+  ).bind(account, handle, handle, now, now).run();
+  return account;
+}
+
+function send(slug: string, token: string, body: string, mentions: string[]): Promise<Response> {
+  return api(`/api/channels/${slug}/messages`, token, {
+    method: "POST",
+    body: JSON.stringify({ kind: "message", body, mentions, reply_to: null }),
+  });
+}
+
+async function frames(slug: string, token: string): Promise<Array<{ sender: { name: string }; kind: string; note?: string | null }>> {
+  const res = await api(`/api/channels/${slug}/messages?limit=100`, token);
+  expect(res.status).toBe(200);
+  return ((await res.json()) as { messages: Array<{ sender: { name: string }; kind: string; note?: string | null }> }).messages;
+}
+
+function warnings(msgs: Array<{ sender: { name: string }; kind: string; note?: string | null }>): string[] {
+  return msgs
+    .filter((m) => m.sender.name === "system" && (m.note ?? "").includes("won't see this mention"))
+    .map((m) => m.note ?? "");
+}
+
+describe("#607 unreachable human mention warning", () => {
+  it("mentioning a global handle that never joined the channel produces a system warning", async () => {
+    const sender = await seedToken("human", uniq("sender"), { owner: "warn-sender@leeguoo.com" });
+    const handle = uniq("karl");
+    await seedProfile(handle);
+    const slug = await createChannel(sender.token);
+
+    expect((await send(slug, sender.token, `@${handle} 在么`, [handle])).status).toBe(200);
+    // waitUntil 副作用在响应后落库；vitest pool workers 会排空 waitUntil，但再读一次以防竞态。
+    const found = warnings(await frames(slug, sender.token));
+    expect(found.length).toBe(1);
+    expect(found[0]).toContain(`@${handle}`);
+  });
+
+  it("dedupes repeat warnings for the same target within the window", async () => {
+    const sender = await seedToken("human", uniq("sender"), { owner: "warn-dedupe@leeguoo.com" });
+    const handle = uniq("karl");
+    await seedProfile(handle);
+    const slug = await createChannel(sender.token);
+
+    expect((await send(slug, sender.token, `@${handle} ping`, [handle])).status).toBe(200);
+    expect((await send(slug, sender.token, `@${handle} ping again`, [handle])).status).toBe(200);
+    expect(warnings(await frames(slug, sender.token)).length).toBe(1);
+  });
+
+  it("does not warn for offline agents (directed delivery replays those)", async () => {
+    const sender = await seedToken("human", uniq("sender"), { owner: "warn-agent@leeguoo.com" });
+    const slug = await createChannel(sender.token);
+    const agent = await seedToken("agent", uniq("bot"), { channelScope: slug });
+
+    expect((await send(slug, sender.token, `@${agent.name} do it`, [agent.name])).status).toBe(200);
+    expect(warnings(await frames(slug, sender.token)).length).toBe(0);
+  });
+
+  it("does not warn when the mentioned human has a notify webhook in this channel", async () => {
+    const owner = await seedToken("human", uniq("sender"), { owner: "warn-hook@leeguoo.com" });
+    const handle = uniq("subscribed");
+    await seedProfile(handle);
+    const slug = await createChannel(owner.token);
+    const hook = await api(`/api/channels/${slug}/webhooks`, owner.token, {
+      method: "POST",
+      body: JSON.stringify({ name: handle, url: "https://relay.test/notify", secret: "s3cret" }),
+    });
+    expect(hook.status).toBe(201);
+
+    expect((await send(slug, owner.token, `@${handle} check`, [handle])).status).toBe(200);
+    expect(warnings(await frames(slug, owner.token)).length).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #607.

## 根因（生产取证）

#607 的现场：leo 在 `#kyc` 发「@karl 在么」（seq 512），无任何反应。查生产 presence 名册——**karl 根本不在频道里**（从未连过，无 presence 行；kw-pw-zhenren 一直在转述场外的 karl）。但 mention 决议走的是全实例 handle 面（`account_profiles` 不分频道），所以 `@karl` 决议成功、消息正常落库，然后：无 WS 连接、无 lark-notify webhook → **无人收到，且发送者得不到任何反馈**。系统把一次注定失败的传达静默吞掉了。

## 修复

`afterSend` 后 `waitUntil` 异步核对每个 mention 的可达面：

- presence 非 offline（按 name 或 human handle 匹配）→ 可达（人在线，看得见）；
- 本频道任一同名 webhook（lark-notify 订阅在此注册）→ 可达（离线也会收到 Lark 卡片）；
- agent 目标豁免（离线 agent 有 directed delivery 持久重放）；squad 豁免（另行展开）；
- 全都不占 → 频道内落一条 system status：`@karl won't see this mention: offline and not subscribed…`，让发送者当场知道这条 @ 送达不了谁。

噪声控制：per-target 30 分钟去重（仿 wake budget 通告的 meta-key 模式）；目录查询抖动时宁可漏报一次也不让 waitUntil 抛错；system 发送者的帧不检查（防自激）。

## 与 #604 的关系

#604（Lark @ 通知登录/入会自动入册）是系统性修复面——karl 下次 Lark 登录后会自动订阅其成员频道。本 PR 补的是另一半：**订阅覆盖不到的人（如从未入会、从未再登录），发送者至少能看见「这条 @ 没人收到」**，而不是等一小时后去提 bug。

## 测试

`worker/test/unreachable-mention.spec.ts` 4 条：@ 从未入频道的全局 handle → 警示出现；同 target 重复 @ → 窗口内只警一次；@ 离线 agent → 不警；被 @ 人类有 notify webhook → 不警。全量 worker vitest 672/672 过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 当消息提及的成员无法接收通知时，在频道内显示系统等待提示，避免消息被静默忽略。
  * 对相同目标的重复提示进行时间窗口内去重。

* **问题修复**
  * 优化不可达成员的提及处理，区分离线代理和已配置通知渠道的成员，减少误报。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->