### PR TITLE
feat(presence): 不跑 serve 也能被看见——hook install + 交互 lane 活动直报（#615）

### DIFF
--- a/cli/src/activity.ts
+++ b/cli/src/activity.ts
@@ -4,11 +4,11 @@
 // 双方对同一路径达成一致，完全绕开「hook 的 session_id 与 serve 已知句柄对不上」的映射问题。
 import { readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
-import { parseAgentActivity, type AgentActivity, type AgentActivityPhase } from "@agentparty/shared";
+import { AGENT_ACTIVITY_TTL_MS, parseAgentActivity, type AgentActivity, type AgentActivityPhase } from "@agentparty/shared";
 import { atomicWriteJson } from "./atomic-json";
 
 /** hook 落盘超过这个岁数即视为陈旧，不再随心跳上行（模型进程可能已死，别让频道看僵活动）。 */
-export const ACTIVITY_TTL_MS = 5 * 60_000;
+export const ACTIVITY_TTL_MS: number = AGENT_ACTIVITY_TTL_MS;
 
 /** serve 为某个 runner workdir 约定的 activity 文件路径；经 AP_ACTIVITY_FILE 递给 runner。 */
 export function runnerActivityFile(workdir: string): string {

--- a/cli/src/commands/hook.ts
+++ b/cli/src/commands/hook.ts
@@ -1,31 +1,43 @@
-// party hook — Claude Code hooks 接入点（issue #602）。
+// party hook — Claude Code hooks 接入点（issue #602 / #615）。
 // `party hook report` 挂在模型 session 的 PreToolUse/Stop/Notification 等 hook 上，
-// 把「正在干什么」落成本地 activity 文件，由 serve 的任务心跳帧捎带给频道 presence。
+// 把「正在干什么」落成本地 activity 文件：
+//   - serve 托管 lane（AP_ACTIVITY_FILE 有值）：serve 的任务心跳帧捎带上行，hook 零网络；
+//   - 交互 lane（#615，不跑 serve）：节流后 spawn 一个 detached 的 `party hook push`
+//     子进程直报 REST——hook 本体仍然即写即退，绝不等网络。
+// `party hook install` 把 hooks 写进 Claude Code settings，让任何 session 接入即可见。
 //
-// 铁律（hook 跑在模型的工具调用热路径上）：
+// report 铁律（跑在模型的工具调用热路径上）：
 //   1. stdout 永远为空——hook 的 stdout 会被灌进模型上下文；
 //   2. 任何失败都静默 exit 0——exit 2 会 block 模型的工具调用，坏 JSON/写盘失败都不配阻断模型；
-//   3. 不走网络——上行由 serve 心跳负责，这里只写文件。
-import { join } from "node:path";
-import { activityFromHookEvent, writeActivityFile } from "../activity";
-import { agentpartyHome } from "../config";
+//   3. 本体不等网络——上行要么归 serve 心跳，要么交给 detached 子进程。
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { AGENT_ACTIVITY_TTL_MS, type AgentActivity } from "@agentparty/shared";
+import { activityFromHookEvent, readActivityFile, writeActivityFile } from "../activity";
+import { agentpartyHome, readState } from "../config";
+import { atomicWriteJson } from "../atomic-json";
 import { isHelpArg } from "../args";
+import { isPartyBinaryPath } from "../upgrade";
 
-const HELP = `usage: party hook report
+const HELP = `usage: party hook <report|push|install|uninstall|status>
 
-Claude Code hook adapter (issue #602). Wire it into a session's hook config:
+Claude Code hook adapter (issues #602/#615): report what the model session is
+actually doing (running a tool / waiting on permission / compacting / idle)
+into channel presence, so \`party who\` and the web can see it.
 
-  { "hooks": { "PreToolUse": [ { "hooks": [ { "type": "command", "command": "party hook report" } ] } ] } }
+  install [--user]     write the hooks into Claude Code settings
+                       (default: <cwd>/.claude/settings.local.json — project-local,
+                        normally git-ignored; --user: ~/.claude/settings.json)
+  uninstall [--user]   remove exactly the entries install added
+  status [--user]      show whether the hooks are installed
+  report               (wired by install / party serve) read one hook event from
+                       stdin, record the local activity snapshot. Under a managed
+                       \`party serve\` runner the serve heartbeat uplinks it; in an
+                       interactive session a throttled detached push uplinks it.
+  push <file> --channel C            internal: best-effort REST uplink (detached)
 
-Reads the hook event JSON from stdin and records a local activity snapshot
-(what tool is running / waiting on permission / compacting / idle). A local
-\`party serve\` picks the snapshot up and reports it with its presence
-heartbeat — the channel sees what the agent is actually doing, not just busy.
-
-Target file: $AP_ACTIVITY_FILE when set (serve-managed runners), otherwise
-~/.agentparty/state/activity/<session_id>.json.
-
-Never blocks the model: any failure exits 0 silently, stdout stays empty.`;
+report never blocks the model: any failure exits 0 silently, stdout stays empty.`;
 
 // stdin 兜底上限：hook payload 正常几 KB，超过说明喂错了东西，读满即止防内存放大。
 const MAX_STDIN_BYTES = 256 * 1024;
@@ -33,6 +45,11 @@ const MAX_STDIN_BYTES = 256 * 1024;
 // 未走 serve 托管（无 AP_ACTIVITY_FILE）时按 session_id 落到全局 state 目录。
 // session_id 直接进路径，白名单校验防穿越。
 const SESSION_ID_RE = /^[A-Za-z0-9._-]{1,128}$/;
+
+// 交互 lane 直报节流（#615）：普通活动 ≥15s 一报；waiting_permission 是无人值守最致命的
+// 静默挂法，放宽到 3s——既立即可见，又不被重复 Notification 打成风暴。
+export const PUSH_INTERVAL_MS = 15_000;
+export const PUSH_INTERVAL_URGENT_MS = 3_000;
 
 async function readStdin(maxBytes: number): Promise<string> {
   const chunks: Buffer[] = [];
@@ -58,13 +75,220 @@ export function activityTargetFile(
   return join(home, "state", "activity", `${sessionId}.json`);
 }
 
+// ---- 交互 lane 直报（#615）----
+
+/** 节流判定（导出仅为单测）：sidecar 记上次上报时刻，waiting_permission 用更紧的紧急间隔。 */
+export function shouldPushActivity(activity: AgentActivity, lastPushTs: number | null, now: number): boolean {
+  const interval = activity.phase === "waiting_permission" ? PUSH_INTERVAL_URGENT_MS : PUSH_INTERVAL_MS;
+  return lastPushTs === null || now - lastPushTs >= interval;
+}
+
+function pushMarkerFile(activityFile: string): string {
+  return `${activityFile}.push.json`;
+}
+
+function readLastPushTs(activityFile: string): number | null {
+  try {
+    const body = JSON.parse(readFileSync(pushMarkerFile(activityFile), "utf8")) as { last_push_ts?: unknown };
+    return typeof body.last_push_ts === "number" && Number.isFinite(body.last_push_ts) ? body.last_push_ts : null;
+  } catch {
+    return null;
+  }
+}
+
+// 交互 lane：解析出频道 + 身份就 spawn 一个 detached push 子进程，本体立刻返回。
+// 节流标记在 spawn 前先落（乐观占位）：hook 风暴下绝不并发起一堆子进程。
+function maybeSpawnPush(activityFile: string, activity: AgentActivity, payload: Record<string, unknown>, now: number): void {
+  const cwd = typeof payload.cwd === "string" && payload.cwd.length > 0 ? payload.cwd : process.cwd();
+  const channel = process.env.AGENTPARTY_CHANNEL ?? readState(cwd)?.channel;
+  if (!channel) return;
+  if (!shouldPushActivity(activity, readLastPushTs(activityFile), now)) return;
+  atomicWriteJson(pushMarkerFile(activityFile), { last_push_ts: now });
+  // 编译版二进制：execPath 即 party；dev（bun run）：execPath 是 bun，argv[1] 是入口脚本。
+  const self = isPartyBinaryPath(process.execPath) || process.argv[1] === undefined
+    ? [process.execPath]
+    : [process.execPath, process.argv[1]];
+  // 子进程直接落在 session 的 cwd 里：readConfig/resolveAuthDetailed 都按 process.cwd() 解析
+  // workspace 级配置，让 push 拿到与该项目一致的身份与服务端。
+  const proc = Bun.spawn([...self, "hook", "push", activityFile, "--channel", channel], {
+    cwd,
+    stdin: "ignore",
+    stdout: "ignore",
+    stderr: "ignore",
+  });
+  proc.unref();
+}
+
+async function runPush(argv: string[]): Promise<number> {
+  // 全程静默 best-effort：这是 detached 后台子进程，没有任何人看它的输出。
+  try {
+    const file = argv[0];
+    const channelIdx = argv.indexOf("--channel");
+    const channel = channelIdx >= 0 ? argv[channelIdx + 1] : undefined;
+    if (!file || !channel) return 0;
+    const activity = readActivityFile(file, Date.now(), AGENT_ACTIVITY_TTL_MS);
+    if (activity === null) return 0;
+    const { resolveAuthDetailed } = await import("../oidc-cli");
+    const { readConfig } = await import("../config");
+    const auth = await resolveAuthDetailed();
+    const name = readConfig()?.identity?.name;
+    if (!auth.server || !auth.token || !name) return 0;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 8_000);
+    try {
+      await fetch(
+        `${auth.server}/api/channels/${encodeURIComponent(channel)}/presence/${encodeURIComponent(name)}/activity`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json", authorization: `Bearer ${auth.token}` },
+          body: JSON.stringify({ activity }),
+          signal: controller.signal,
+        },
+      );
+    } finally {
+      clearTimeout(timer);
+    }
+  } catch {
+    // 断网/凭据缺失/服务端拒绝——全部静默，下一次节流窗口自然重试
+  }
+  return 0;
+}
+
+// ---- hooks 安装（#615）----
+
+const HOOK_COMMAND_MARKER = "hook report";
+
+interface HookEntry {
+  matcher?: string;
+  hooks: Array<{ type: string; command: string; timeout?: number }>;
+}
+
+function isOurEntry(entry: unknown): boolean {
+  if (typeof entry !== "object" || entry === null) return false;
+  const hooks = (entry as HookEntry).hooks;
+  return Array.isArray(hooks) && hooks.some((h) => typeof h?.command === "string" && h.command.includes(HOOK_COMMAND_MARKER));
+}
+
+export function settingsPath(scope: "project" | "user", cwd: string = process.cwd()): string {
+  return scope === "user"
+    ? join(homedir(), ".claude", "settings.json")
+    : join(cwd, ".claude", "settings.local.json");
+}
+
+/**
+ * 幂等合并：只增删「command 含 hook report」的条目，绝不动用户已有 hooks。
+ * source 为 null 表示文件不存在（从空对象起步）；JSON 坏了抛错（拒绝覆盖用户手写内容）。
+ */
+export function mergeHookSettings(source: string | null, hookSettingsJson: string): string {
+  const settings = source === null ? {} : (JSON.parse(source) as Record<string, unknown>);
+  if (typeof settings !== "object" || settings === null || Array.isArray(settings)) {
+    throw new Error("settings file is not a JSON object");
+  }
+  const ours = JSON.parse(hookSettingsJson) as { hooks: Record<string, HookEntry[]> };
+  const hooks = (typeof settings.hooks === "object" && settings.hooks !== null && !Array.isArray(settings.hooks)
+    ? settings.hooks
+    : {}) as Record<string, unknown>;
+  for (const [event, entries] of Object.entries(ours.hooks)) {
+    const existing = Array.isArray(hooks[event]) ? (hooks[event] as unknown[]) : [];
+    const kept = existing.filter((entry) => !isOurEntry(entry));
+    hooks[event] = [...kept, ...entries];
+  }
+  settings.hooks = hooks;
+  return `${JSON.stringify(settings, null, 2)}\n`;
+}
+
+export function removeHookSettings(source: string): string {
+  const settings = JSON.parse(source) as Record<string, unknown>;
+  if (typeof settings !== "object" || settings === null || Array.isArray(settings)) {
+    throw new Error("settings file is not a JSON object");
+  }
+  const hooks = settings.hooks;
+  if (typeof hooks === "object" && hooks !== null && !Array.isArray(hooks)) {
+    const record = hooks as Record<string, unknown>;
+    for (const event of Object.keys(record)) {
+      if (!Array.isArray(record[event])) continue;
+      const kept = (record[event] as unknown[]).filter((entry) => !isOurEntry(entry));
+      if (kept.length > 0) record[event] = kept;
+      else delete record[event];
+    }
+    if (Object.keys(record).length === 0) delete settings.hooks;
+  }
+  return `${JSON.stringify(settings, null, 2)}\n`;
+}
+
+function hookScope(argv: string[]): "project" | "user" {
+  return argv.includes("--user") ? "user" : "project";
+}
+
+async function runInstall(argv: string[]): Promise<number> {
+  const scope = hookScope(argv);
+  const path = settingsPath(scope);
+  const source = existsSync(path) ? readFileSync(path, "utf8") : null;
+  // serve 用同一份 hooks 配置生成器（#602），装出来的行为与托管 lane 完全一致。
+  const { claudeHookSettingsJson } = await import("./serve");
+  let next: string;
+  try {
+    next = mergeHookSettings(source, claudeHookSettingsJson());
+  } catch (e) {
+    console.error(`无法解析 ${path}（${e instanceof Error ? e.message : String(e)}）；请先手工修复该文件`);
+    return 1;
+  }
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, next);
+  console.log(`hooks installed -> ${path}`);
+  console.log("任何在此生效范围内的 Claude Code session（交互或 -p）都会把活动上报进频道 presence。");
+  return 0;
+}
+
+async function runUninstall(argv: string[]): Promise<number> {
+  const scope = hookScope(argv);
+  const path = settingsPath(scope);
+  if (!existsSync(path)) {
+    console.log(`nothing to remove（${path} 不存在）`);
+    return 0;
+  }
+  let next: string;
+  try {
+    next = removeHookSettings(readFileSync(path, "utf8"));
+  } catch (e) {
+    console.error(`无法解析 ${path}（${e instanceof Error ? e.message : String(e)}）；请先手工修复该文件`);
+    return 1;
+  }
+  writeFileSync(path, next);
+  console.log(`hooks removed <- ${path}`);
+  return 0;
+}
+
+function runStatus(argv: string[]): number {
+  const scope = hookScope(argv);
+  const path = settingsPath(scope);
+  const source = existsSync(path) ? readFileSync(path, "utf8") : null;
+  let installed = false;
+  if (source !== null) {
+    try {
+      const hooks = (JSON.parse(source) as { hooks?: Record<string, unknown[]> }).hooks ?? {};
+      installed = Object.values(hooks).some((entries) => Array.isArray(entries) && entries.some(isOurEntry));
+    } catch {
+      console.error(`无法解析 ${path}`);
+      return 1;
+    }
+  }
+  console.log(`${installed ? "installed" : "not installed"} (${path})`);
+  return installed ? 0 : 1;
+}
+
 export async function run(argv: string[]): Promise<number> {
   if (isHelpArg(argv, { allowHelpPositional: true })) {
     console.log(HELP);
     return 0;
   }
-  if (argv[0] !== "report") {
-    // 唯一会写 stderr 的分支：人在终端敲错子命令。真 hook 调用恒为 `hook report`，不受影响。
+  const [sub, ...rest] = argv;
+  if (sub === "install") return runInstall(rest);
+  if (sub === "uninstall") return runUninstall(rest);
+  if (sub === "status") return runStatus(rest);
+  if (sub === "push") return runPush(rest);
+  if (sub !== "report") {
+    // 会写 stderr 的分支只剩人在终端敲错子命令。真 hook 调用恒为 `hook report`，不受影响。
     console.error(HELP);
     return 1;
   }
@@ -73,11 +297,14 @@ export async function run(argv: string[]): Promise<number> {
     const payload = JSON.parse(raw) as unknown;
     if (typeof payload !== "object" || payload === null) return 0;
     const record = payload as Record<string, unknown>;
-    const activity = activityFromHookEvent(record, Date.now());
+    const now = Date.now();
+    const activity = activityFromHookEvent(record, now);
     if (activity === null) return 0;
     const target = activityTargetFile(process.env, record, agentpartyHome());
     if (target === null) return 0;
     writeActivityFile(target, activity);
+    // 交互 lane（#615）：serve 托管时（AP_ACTIVITY_FILE 有值）上行归 serve 心跳，这里绝不直报。
+    if (!process.env.AP_ACTIVITY_FILE) maybeSpawnPush(target, activity, record, now);
   } catch {
     // 静默：hook 绝不阻断模型（exit 2 才 block，这里连非零都不给）。
   }

--- a/cli/src/commands/hook.ts
+++ b/cli/src/commands/hook.ts
@@ -211,8 +211,12 @@ export function mergeHookSettings(source: string | null, hookSettingsJson: strin
   }
   const hooks = (settings.hooks ?? {}) as Record<string, unknown>;
   for (const [event, entries] of Object.entries(ours.hooks)) {
-    const existing = Array.isArray(hooks[event]) ? (hooks[event] as unknown[]) : [];
-    const kept = stripOurCommands(existing);
+    // 事件值存在但不是数组（用户写坏了）：拒绝覆盖——「仅管理自身 hook」不容许吞掉用户内容。
+    const current = hooks[event];
+    if (current !== undefined && !Array.isArray(current)) {
+      throw new Error(`settings.hooks.${event} is not an array`);
+    }
+    const kept = stripOurCommands((current ?? []) as unknown[]);
     hooks[event] = [...kept, ...entries];
   }
   settings.hooks = hooks;

--- a/cli/src/commands/hook.ts
+++ b/cli/src/commands/hook.ts
@@ -77,10 +77,12 @@ export function activityTargetFile(
 
 // ---- 交互 lane 直报（#615）----
 
-/** 节流判定（导出仅为单测）：sidecar 记上次上报时刻，waiting_permission 用更紧的紧急间隔。 */
+/** 节流判定（导出仅为单测）：sidecar 记上次上报时刻，waiting_permission 用更紧的紧急间隔。
+ * 未来时间戳（时钟回跳后残留的标记）视为无效——否则时钟追上前会永久静默。 */
 export function shouldPushActivity(activity: AgentActivity, lastPushTs: number | null, now: number): boolean {
+  if (lastPushTs === null || lastPushTs > now) return true;
   const interval = activity.phase === "waiting_permission" ? PUSH_INTERVAL_URGENT_MS : PUSH_INTERVAL_MS;
-  return lastPushTs === null || now - lastPushTs >= interval;
+  return now - lastPushTs >= interval;
 }
 
 function pushMarkerFile(activityFile: string): string {
@@ -163,10 +165,28 @@ interface HookEntry {
   hooks: Array<{ type: string; command: string; timeout?: number }>;
 }
 
+function isOurCommand(hook: unknown): boolean {
+  return typeof (hook as { command?: unknown })?.command === "string" &&
+    ((hook as { command: string }).command.includes(HOOK_COMMAND_MARKER));
+}
+
 function isOurEntry(entry: unknown): boolean {
   if (typeof entry !== "object" || entry === null) return false;
   const hooks = (entry as HookEntry).hooks;
-  return Array.isArray(hooks) && hooks.some((h) => typeof h?.command === "string" && h.command.includes(HOOK_COMMAND_MARKER));
+  return Array.isArray(hooks) && hooks.some(isOurCommand);
+}
+
+// 逐命令摘除：用户若把自己的命令混进了含我们命令的条目里，只摘我们的那条，绝不整条目连坐。
+// 摘空 hooks 数组的条目才整体删除。
+function stripOurCommands(entries: unknown[]): unknown[] {
+  return entries
+    .map((entry) => {
+      if (!isOurEntry(entry)) return entry;
+      const rec = entry as HookEntry;
+      const kept = rec.hooks.filter((h) => !isOurCommand(h));
+      return kept.length > 0 ? { ...rec, hooks: kept } : null;
+    })
+    .filter((entry): entry is NonNullable<typeof entry> => entry !== null);
 }
 
 export function settingsPath(scope: "project" | "user", cwd: string = process.cwd()): string {
@@ -185,12 +205,14 @@ export function mergeHookSettings(source: string | null, hookSettingsJson: strin
     throw new Error("settings file is not a JSON object");
   }
   const ours = JSON.parse(hookSettingsJson) as { hooks: Record<string, HookEntry[]> };
-  const hooks = (typeof settings.hooks === "object" && settings.hooks !== null && !Array.isArray(settings.hooks)
-    ? settings.hooks
-    : {}) as Record<string, unknown>;
+  // hooks 键存在但不是对象（用户写坏了）：拒绝覆盖，和坏 JSON 同等对待——绝不静默吞掉用户内容。
+  if (settings.hooks !== undefined && (typeof settings.hooks !== "object" || settings.hooks === null || Array.isArray(settings.hooks))) {
+    throw new Error("settings.hooks is not a JSON object");
+  }
+  const hooks = (settings.hooks ?? {}) as Record<string, unknown>;
   for (const [event, entries] of Object.entries(ours.hooks)) {
     const existing = Array.isArray(hooks[event]) ? (hooks[event] as unknown[]) : [];
-    const kept = existing.filter((entry) => !isOurEntry(entry));
+    const kept = stripOurCommands(existing);
     hooks[event] = [...kept, ...entries];
   }
   settings.hooks = hooks;
@@ -207,7 +229,7 @@ export function removeHookSettings(source: string): string {
     const record = hooks as Record<string, unknown>;
     for (const event of Object.keys(record)) {
       if (!Array.isArray(record[event])) continue;
-      const kept = (record[event] as unknown[]).filter((entry) => !isOurEntry(entry));
+      const kept = stripOurCommands(record[event] as unknown[]);
       if (kept.length > 0) record[event] = kept;
       else delete record[event];
     }
@@ -217,7 +239,16 @@ export function removeHookSettings(source: string): string {
 }
 
 function hookScope(argv: string[]): "project" | "user" {
-  return argv.includes("--user") ? "user" : "project";
+  // 只认 `--` 终止符之前的 --user；`hook install -- --user` 保持 project 作用域。
+  const boundary = argv.indexOf("--");
+  const flags = boundary === -1 ? argv : argv.slice(0, boundary);
+  return flags.includes("--user") ? "user" : "project";
+}
+
+// 终端输出的动态部分（路径/异常消息）统一剥控制字符——路径可能来自不受信的 repo 目录名。
+function termText(value: string): string {
+  // eslint-disable-next-line no-control-regex
+  return value.replace(/[\u0000-\u001f\u007f-\u009f]/g, "");
 }
 
 async function runInstall(argv: string[]): Promise<number> {
@@ -230,12 +261,12 @@ async function runInstall(argv: string[]): Promise<number> {
   try {
     next = mergeHookSettings(source, claudeHookSettingsJson());
   } catch (e) {
-    console.error(`无法解析 ${path}（${e instanceof Error ? e.message : String(e)}）；请先手工修复该文件`);
+    console.error(`无法解析 ${termText(path)}（${termText(e instanceof Error ? e.message : String(e))}）；请先手工修复该文件`);
     return 1;
   }
   mkdirSync(dirname(path), { recursive: true });
   writeFileSync(path, next);
-  console.log(`hooks installed -> ${path}`);
+  console.log(`hooks installed -> ${termText(path)}`);
   console.log("任何在此生效范围内的 Claude Code session（交互或 -p）都会把活动上报进频道 presence。");
   return 0;
 }
@@ -244,18 +275,18 @@ async function runUninstall(argv: string[]): Promise<number> {
   const scope = hookScope(argv);
   const path = settingsPath(scope);
   if (!existsSync(path)) {
-    console.log(`nothing to remove（${path} 不存在）`);
+    console.log(`nothing to remove（${termText(path)} 不存在）`);
     return 0;
   }
   let next: string;
   try {
     next = removeHookSettings(readFileSync(path, "utf8"));
   } catch (e) {
-    console.error(`无法解析 ${path}（${e instanceof Error ? e.message : String(e)}）；请先手工修复该文件`);
+    console.error(`无法解析 ${termText(path)}（${termText(e instanceof Error ? e.message : String(e))}）；请先手工修复该文件`);
     return 1;
   }
   writeFileSync(path, next);
-  console.log(`hooks removed <- ${path}`);
+  console.log(`hooks removed <- ${termText(path)}`);
   return 0;
 }
 
@@ -269,11 +300,11 @@ function runStatus(argv: string[]): number {
       const hooks = (JSON.parse(source) as { hooks?: Record<string, unknown[]> }).hooks ?? {};
       installed = Object.values(hooks).some((entries) => Array.isArray(entries) && entries.some(isOurEntry));
     } catch {
-      console.error(`无法解析 ${path}`);
+      console.error(`无法解析 ${termText(path)}`);
       return 1;
     }
   }
-  console.log(`${installed ? "installed" : "not installed"} (${path})`);
+  console.log(`${installed ? "installed" : "not installed"} (${termText(path)})`);
   return installed ? 0 : 1;
 }
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -41,7 +41,7 @@ commands:
   resume    <name> [--channel C]                           resume a paused agent's reception (moderator)
   wake-budget <name> [--limit N [--window D]|--off]        cap an agent's wakes per window; over-budget @ withheld (#108)
   health    [--json] [--channel C] [--stale-after ms]      local serve WS health probe (pid alive != ws alive, #254)
-  hook      report                                          Claude Code hook adapter: record model activity for presence (#602)
+  hook      install|uninstall|status [--user] | report      Claude Code hooks: report model activity into presence; install makes any session visible without serve (#602/#615)
   upgrade   [--version X.Y.Z] [--check]                    download release binary, verify sha256, atomically replace party
   charter   [slug] [--json] | set [slug] -f file.md|-m text|- | template
   history   [channel|--channel C] [--since seq] [--limit n] [--json] [--completion]

--- a/cli/test/hook-install.test.ts
+++ b/cli/test/hook-install.test.ts
@@ -79,6 +79,8 @@ describe("shouldPushActivity (#615)", () => {
     expect(shouldPushActivity(tool, NOW - PUSH_INTERVAL_MS, NOW)).toBe(true);
     expect(shouldPushActivity(perm, NOW - PUSH_INTERVAL_URGENT_MS + 1, NOW)).toBe(false);
     expect(shouldPushActivity(perm, NOW - PUSH_INTERVAL_URGENT_MS, NOW)).toBe(true);
+    // 未来标记（时钟回跳残留）视为无效：立即放行，而不是永久静默到时钟追上
+    expect(shouldPushActivity(tool, NOW + 60_000, NOW)).toBe(true);
   });
 });
 
@@ -160,6 +162,8 @@ describe("party hook push end-to-end (#615)", () => {
     writeActivityFile(file, { phase: "tool", tool: "Bash", ts: Date.now() - 10 * 60_000 });
     expect(await runPush(file)).toBe(0); // 超 TTL → 不发也不炸
 
+    // 缺配置断言前恢复新鲜活动：确保这条走的是「无配置静默」路径，而不是搭 TTL 的便车。
+    writeActivityFile(file, { phase: "tool", tool: "Bash", ts: Date.now() });
     rmSync(join(home, "config.json"));
     expect(await runPush(file)).toBe(0); // 无配置 → 静默
   });

--- a/cli/test/hook-install.test.ts
+++ b/cli/test/hook-install.test.ts
@@ -67,6 +67,9 @@ describe("mergeHookSettings / removeHookSettings (#615)", () => {
   test("refuses to touch a broken settings file", () => {
     expect(() => mergeHookSettings("{not json", ours)).toThrow();
     expect(() => removeHookSettings("[1,2,3]")).toThrow();
+    // hooks 键或某个事件值不是期望形状：拒改，绝不静默吞掉用户内容
+    expect(() => mergeHookSettings(JSON.stringify({ hooks: "broken" }), ours)).toThrow();
+    expect(() => mergeHookSettings(JSON.stringify({ hooks: { Stop: { not: "array" } } }), ours)).toThrow();
   });
 });
 

--- a/cli/test/hook-install.test.ts
+++ b/cli/test/hook-install.test.ts
@@ -1,0 +1,166 @@
+// #615：hook install 的幂等合并 / 交互 lane 直报的节流与 push 端到端。
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { writeActivityFile } from "../src/activity";
+import { mergeHookSettings, removeHookSettings, shouldPushActivity, PUSH_INTERVAL_MS, PUSH_INTERVAL_URGENT_MS } from "../src/commands/hook";
+import { claudeHookSettingsJson } from "../src/commands/serve";
+import { startRestMock, type RestMock } from "./rest-mock";
+
+const indexPath = join(import.meta.dir, "..", "src", "index.ts");
+const NOW = 1_700_000_000_000;
+
+let home: string;
+let mock: RestMock | null = null;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "ap-hook615-"));
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+  mock?.stop();
+  mock = null;
+});
+
+describe("mergeHookSettings / removeHookSettings (#615)", () => {
+  const ours = claudeHookSettingsJson("/usr/local/bin/party");
+
+  test("installs into an empty file and is idempotent", () => {
+    const once = mergeHookSettings(null, ours);
+    const twice = mergeHookSettings(once, ours);
+    expect(twice).toBe(once);
+    const parsed = JSON.parse(once) as { hooks: Record<string, Array<{ hooks: Array<{ command: string }> }>> };
+    expect(parsed.hooks.PreToolUse![0]!.hooks[0]!.command).toContain("hook report");
+    expect(Object.keys(parsed.hooks).length).toBe(8);
+  });
+
+  test("preserves foreign hooks and unknown settings keys", () => {
+    const existing = JSON.stringify({
+      model: "opus",
+      hooks: {
+        PreToolUse: [{ matcher: "Bash", hooks: [{ type: "command", command: "my-linter --check" }] }],
+      },
+    });
+    const merged = mergeHookSettings(existing, ours);
+    const parsed = JSON.parse(merged) as {
+      model: string;
+      hooks: Record<string, Array<{ hooks: Array<{ command: string }> }>>;
+    };
+    expect(parsed.model).toBe("opus");
+    expect(parsed.hooks.PreToolUse!.some((e) => e.hooks.some((h) => h.command === "my-linter --check"))).toBe(true);
+    expect(parsed.hooks.PreToolUse!.some((e) => e.hooks.some((h) => h.command.includes("hook report")))).toBe(true);
+
+    // uninstall 只摘我们的条目，外来 hooks 原样保留
+    const removed = JSON.parse(removeHookSettings(merged)) as {
+      model: string;
+      hooks?: Record<string, Array<{ hooks: Array<{ command: string }> }>>;
+    };
+    expect(removed.model).toBe("opus");
+    expect(removed.hooks?.PreToolUse!.every((e) => e.hooks.every((h) => !h.command.includes("hook report")))).toBe(true);
+    expect(removed.hooks?.PreToolUse!.length).toBe(1);
+    // 我们独占的事件（如 Stop）被摘空后连键一起清掉
+    expect(removed.hooks?.Stop).toBeUndefined();
+  });
+
+  test("refuses to touch a broken settings file", () => {
+    expect(() => mergeHookSettings("{not json", ours)).toThrow();
+    expect(() => removeHookSettings("[1,2,3]")).toThrow();
+  });
+});
+
+describe("shouldPushActivity (#615)", () => {
+  test("15s throttle for ordinary phases, 3s for waiting_permission, always on first push", () => {
+    const tool = { phase: "tool" as const, tool: "Bash", ts: NOW };
+    const perm = { phase: "waiting_permission" as const, ts: NOW };
+    expect(shouldPushActivity(tool, null, NOW)).toBe(true);
+    expect(shouldPushActivity(tool, NOW - PUSH_INTERVAL_MS + 1, NOW)).toBe(false);
+    expect(shouldPushActivity(tool, NOW - PUSH_INTERVAL_MS, NOW)).toBe(true);
+    expect(shouldPushActivity(perm, NOW - PUSH_INTERVAL_URGENT_MS + 1, NOW)).toBe(false);
+    expect(shouldPushActivity(perm, NOW - PUSH_INTERVAL_URGENT_MS, NOW)).toBe(true);
+  });
+});
+
+describe("party hook install end-to-end (project scope)", () => {
+  test("install writes .claude/settings.local.json in cwd; status/uninstall round-trip", async () => {
+    const project = mkdtempSync(join(tmpdir(), "ap-hook-proj-"));
+    const runIn = async (...args: string[]) => {
+      const proc = Bun.spawn(["bun", "run", indexPath, "hook", ...args], {
+        cwd: project,
+        env: { ...process.env, AGENTPARTY_HOME: home },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [code, stdout] = await Promise.all([proc.exited, new Response(proc.stdout).text()]);
+      return { code, stdout };
+    };
+
+    expect((await runIn("status")).code).toBe(1); // 未装
+    expect((await runIn("install")).code).toBe(0);
+    const settings = JSON.parse(readFileSync(join(project, ".claude", "settings.local.json"), "utf8")) as {
+      hooks: Record<string, unknown[]>;
+    };
+    expect(Object.keys(settings.hooks).length).toBe(8);
+    const status = await runIn("status");
+    expect(status.code).toBe(0);
+    expect(status.stdout).toContain("installed");
+    expect((await runIn("uninstall")).code).toBe(0);
+    expect((await runIn("status")).code).toBe(1);
+    rmSync(project, { recursive: true, force: true });
+  });
+});
+
+describe("party hook push end-to-end (#615)", () => {
+  function writeCfg(server: string) {
+    mkdirSync(home, { recursive: true });
+    writeFileSync(
+      join(home, "config.json"),
+      JSON.stringify({
+        server,
+        token: "ap_tok",
+        identity: { name: "mini", email: null, kind: "agent", role: "agent", owner: "o", channel_scope: null, verified_at: NOW },
+      }),
+    );
+  }
+
+  async function runPush(file: string): Promise<number> {
+    const proc = Bun.spawn(["bun", "run", indexPath, "hook", "push", file, "--channel", "dev"], {
+      env: { ...process.env, AGENTPARTY_HOME: home, AGENTPARTY_CONFIG: undefined },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    return proc.exited;
+  }
+
+  test("posts the activity to the presence activity endpoint", async () => {
+    let captured: unknown = null;
+    mock = startRestMock((req) => {
+      if (req.method === "POST" && req.path === "/api/channels/dev/presence/mini/activity") {
+        captured = req.body;
+        return Response.json({ ok: true, attached: true });
+      }
+      return undefined;
+    });
+    writeCfg(mock.url);
+    const file = join(home, "activity.json");
+    writeActivityFile(file, { phase: "waiting_permission", tool: "Bash", ts: Date.now() });
+
+    expect(await runPush(file)).toBe(0);
+    expect(captured).toMatchObject({ activity: { phase: "waiting_permission", tool: "Bash" } });
+  });
+
+  test("stays silent (exit 0) on server failure, stale file, or missing config", async () => {
+    mock = startRestMock(() => new Response("boom", { status: 500 }));
+    writeCfg(mock.url);
+    const file = join(home, "activity.json");
+    writeActivityFile(file, { phase: "tool", tool: "Bash", ts: Date.now() });
+    expect(await runPush(file)).toBe(0); // 服务端 500 → 静默
+
+    writeActivityFile(file, { phase: "tool", tool: "Bash", ts: Date.now() - 10 * 60_000 });
+    expect(await runPush(file)).toBe(0); // 超 TTL → 不发也不炸
+
+    rmSync(join(home, "config.json"));
+    expect(await runPush(file)).toBe(0); // 无配置 → 静默
+  });
+});

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -548,6 +548,10 @@ export const AGENT_ACTIVITY_PHASES = [
 ] as const;
 export type AgentActivityPhase = (typeof AGENT_ACTIVITY_PHASES)[number];
 
+// 活动新鲜度统一口径（#602 serve 心跳捎带 / #615 交互 lane 直报共用）：
+// 超过这个岁数的活动视为陈旧——写它的 session 大概率已死，不再展示、不再上行。
+export const AGENT_ACTIVITY_TTL_MS = 5 * 60_000;
+
 export interface AgentActivity {
   phase: AgentActivityPhase;
   /** 仅 phase=tool / waiting_permission 时可带：工具名（绝不带入参正文，防 secret 泄漏）。 */

--- a/skills/agentparty/SKILL.md
+++ b/skills/agentparty/SKILL.md
@@ -106,6 +106,7 @@ surface it to the owner instead of ignoring it.
 | Intent | Command |
 |---|---|
 | Join a channel (write config + bind) | `export AGENTPARTY_CONFIG="$HOME/.agentparty/agents/<agent>-<slug>.json"` then `printf '%s' '<T>' \| party init --server <URL> --token - --channel <slug>` |
+| Make this session's activity visible in the channel (#615) | `party hook install` — one-time per project; after that ANY Claude Code session here reports what it is doing (tool runs / waiting on permission) into presence, no `party serve` needed |
 | See who to mention (online/wakeable/recent) | `party who <slug> [--json]` — run this BEFORE mentioning so you pick a real, reachable name |
 | Send a message | `party send "<text>" --channel <slug> [--mention <name>]... [--reply-to <seq>]` |
 | Send, reading body from stdin | `party send <slug> -`  **or**  `cmd \| party send -` (bound channel) |

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -1398,6 +1398,9 @@ function snippetFor(frame: MsgFrame, field: SearchHit["match_field"]): string {
 export class ChannelDO extends Server<Env> {
   static options = { hibernate: true };
   private atomicDeliveryEffects: AtomicDeliveryEffects | null = null;
+  // 交互 lane 活动直报（#615）的服务端时钟节流标记：name → 上次接受时刻。内存态即可——
+  // DO 休眠清空的代价只是偶尔多接受一次，而 client 自带 ts 不可信、不能当节流依据。
+  private readonly activityPushAcceptedAt = new Map<string, number>();
   // partyserver can invoke async WebSocket handlers for the same connection while an earlier
   // frame is awaiting I/O. Preserve wire order explicitly: hello must finish token validation and
   // capability setup before an immediately-following serve lease / adapter / send frame runs.
@@ -3475,7 +3478,11 @@ export class ChannelDO extends Server<Env> {
       hb.current_task,
       hb.task_started_at,
       hb.heartbeat_at,
-      hb.current_task === null || hb.activity === undefined ? null : JSON.stringify(hb.activity),
+      // 未来时间戳与 REST 直报同口径按脏值丢弃（容忍 60s 抖动）——ts 是序列化 TTL 的输入，
+      // 远未来值会让僵活动永不过期。
+      hb.current_task === null || hb.activity === undefined || hb.activity.ts - Date.now() > 60_000
+        ? null
+        : JSON.stringify(hb.activity),
       hb.runner_health === undefined ? null : JSON.stringify(hb.runner_health),
       hb.agent_session === undefined ? null : JSON.stringify(hb.agent_session),
       name,
@@ -6140,23 +6147,22 @@ export class ChannelDO extends Server<Env> {
       }
       const body = (await request.json().catch(() => null)) as { activity?: unknown } | null;
       const activity = parseAgentActivity(body?.activity);
+      const now = Date.now();
       if (activity === undefined) {
         return Response.json({ error: { code: "bad_request", message: "valid activity required" } }, { status: 400 });
       }
-      // 兜底节流（客户端已 15s 节流，这里防绕过）：3s 内的重复上报直接吞，不写不播。
-      const prior = this.ctx.storage.sql
-        .exec("SELECT activity_json FROM presence WHERE name = ? AND activity_json IS NOT NULL LIMIT 1", name)
-        .toArray()[0];
-      if (prior !== undefined) {
-        try {
-          const previous = parseAgentActivity(JSON.parse(String(prior.activity_json)) as unknown);
-          if (previous !== undefined && activity.ts - previous.ts < 3_000 && previous.phase === activity.phase) {
-            return Response.json({ ok: true, throttled: true });
-          }
-        } catch {
-          // 旧值坏了就当没有，照常覆盖
-        }
+      // 未来时间戳拒收（容忍 60s 时钟抖动）：ts 是序列化侧 TTL 的输入，放进来一个远未来值
+      // 会让僵活动永不过期地钉在 presence 上。
+      if (activity.ts - now > 60_000) {
+        return Response.json({ error: { code: "bad_request", message: "activity.ts is in the future" } }, { status: 400 });
       }
+      // 兜底节流（客户端已 15s 节流，这里防绕过）：按**服务端时钟**记上次接受时刻——client 提供的
+      // ts 不可信，不能当节流依据。DO 休眠会清掉内存标记，代价只是偶尔多接受一次，可承受。
+      const lastAccepted = this.activityPushAcceptedAt.get(name);
+      if (lastAccepted !== undefined && now - lastAccepted < 3_000) {
+        return Response.json({ ok: true, throttled: true });
+      }
+      this.activityPushAcceptedAt.set(name, now);
       const updated = this.ctx.storage.sql.exec(
         "UPDATE presence SET activity_json = ? WHERE name = ?",
         JSON.stringify(activity),

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -37,6 +37,7 @@ import {
   DELIVERY_CONTINUATION_REF_LIMIT,
   DELIVERY_ORIGIN_CHANNEL_LIMIT,
   DELIVERY_WORK_ID_LIMIT,
+  AGENT_ACTIVITY_TTL_MS,
   parseAgentActivity,
   parseRunnerHealth,
   type AgentActivity,
@@ -6129,6 +6130,41 @@ export class ChannelDO extends Server<Env> {
       }
       return Response.json({ ok: true, owners: [...owners] });
     }
+    // 交互 lane 活动直报（issue #615）：不跑 serve 的 Claude Code session 经 REST 自报活动。
+    // 授权在 worker 侧已判（agent 只准自报），do 只落状态。presence 无行则无从附着，静默吞。
+    const activityMatch = url.pathname.match(/^\/internal\/presence\/([^/]+)\/activity$/);
+    if (activityMatch && request.method === "POST") {
+      const name = decodeURIComponent(activityMatch[1] ?? "");
+      if (!name) {
+        return Response.json({ error: { code: "bad_request", message: "name required" } }, { status: 400 });
+      }
+      const body = (await request.json().catch(() => null)) as { activity?: unknown } | null;
+      const activity = parseAgentActivity(body?.activity);
+      if (activity === undefined) {
+        return Response.json({ error: { code: "bad_request", message: "valid activity required" } }, { status: 400 });
+      }
+      // 兜底节流（客户端已 15s 节流，这里防绕过）：3s 内的重复上报直接吞，不写不播。
+      const prior = this.ctx.storage.sql
+        .exec("SELECT activity_json FROM presence WHERE name = ? AND activity_json IS NOT NULL LIMIT 1", name)
+        .toArray()[0];
+      if (prior !== undefined) {
+        try {
+          const previous = parseAgentActivity(JSON.parse(String(prior.activity_json)) as unknown);
+          if (previous !== undefined && activity.ts - previous.ts < 3_000 && previous.phase === activity.phase) {
+            return Response.json({ ok: true, throttled: true });
+          }
+        } catch {
+          // 旧值坏了就当没有，照常覆盖
+        }
+      }
+      const updated = this.ctx.storage.sql.exec(
+        "UPDATE presence SET activity_json = ? WHERE name = ?",
+        JSON.stringify(activity),
+        name,
+      );
+      if (updated.rowsWritten > 0) this.broadcastPresenceFor(name);
+      return Response.json({ ok: true, attached: updated.rowsWritten > 0 });
+    }
     // 人为暂停/恢复接待（issue #180）。授权在 worker 侧已判（moderator），do 只落状态。
     const pauseMatch = url.pathname.match(/^\/internal\/presence\/([^/]+)\/(pause|resume)$/);
     if (pauseMatch && request.method === "POST") {
@@ -9516,18 +9552,21 @@ export class ChannelDO extends Server<Env> {
             current_task: Number(r.current_task),
             ...(r.task_started_at === null || r.task_started_at === undefined ? {} : { task_started_at: Number(r.task_started_at) }),
             ...(r.heartbeat_at === null || r.heartbeat_at === undefined ? {} : { heartbeat_at: Number(r.heartbeat_at) }),
-            // 模型 session 活动（#602）：与心跳同生共死，只在有活跃任务时带出。
-            ...(() => {
-              if (typeof r.activity_json !== "string" || r.activity_json === "") return {};
-              try {
-                const activity = parseAgentActivity(JSON.parse(r.activity_json) as unknown);
-                return activity === undefined ? {} : { activity };
-              } catch {
-                return {};
-              }
-            })(),
           }
         : {}),
+      // 模型 session 活动（#602/#615）：不再绑死 current_task——交互 lane（不跑 serve）经 REST 直报
+      // 的活动没有任务上下文。改按 TTL 判新鲜：serve lane 任务结束仍主动清（activity_json=NULL），
+      // 交互 lane 靠 TTL 自然过期，不留僵活动。offline 一律不带。
+      ...(() => {
+        if (state === "offline" || typeof r.activity_json !== "string" || r.activity_json === "") return {};
+        try {
+          const activity = parseAgentActivity(JSON.parse(r.activity_json) as unknown);
+          if (activity === undefined || Date.now() - activity.ts > AGENT_ACTIVITY_TTL_MS) return {};
+          return { activity };
+        } catch {
+          return {};
+        }
+      })(),
       // runner 健康（#603）：独立于 current_task——空闲期也要能看见「干不动」；offline 不带。
       ...(() => {
         if (state === "offline" || typeof r.runner_health_json !== "string" || r.runner_health_json === "") return {};

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -7299,6 +7299,36 @@ async function isActiveAgentReceptionTarget(db: D1Database, slug: string, name: 
 // 人为暂停/恢复某 agent 的接待（issue #180/#439）。房主 / legacy ap_ 保持原权限；频道 host agent
 // 也可在本频道止损，但只能控制有效且未被 scope 到其他频道的 agent token，不能借此管理人类。
 // 暂停后该 agent 被 @ 也不唤醒（webhook 不投、serve/watch 自我抑制），消息仍进历史；可带 resume_at 定时恢复。
+// 交互 lane 活动自报（issue #615）：不跑 serve 的 Claude Code session 由 hook 经此端点直报
+// 「正在干什么」。只准 agent 自报（name 必须等于 token 身份），presence-only、不落 history。
+app.post("/api/channels/:slug/presence/:name/activity", async (c) => {
+  const slug = c.req.param("slug");
+  const channel = await loadChannel(c.env.DB, slug);
+  if (!channel) return c.json(errorBody("not_found", "channel not found"), 404);
+  const identity = c.get("identity");
+  const name = c.req.param("name");
+  if (!name || name.length > 256) {
+    return c.json(errorBody("bad_request", "valid name required"), 400);
+  }
+  if (identity.kind !== "agent" || identity.name !== name) {
+    return c.json(errorBody("forbidden", "an agent may only report its own activity"), 403);
+  }
+  const body = (await c.req.json().catch(() => null)) as { activity?: unknown } | null;
+  if (body?.activity === undefined) {
+    return c.json(errorBody("bad_request", "activity required"), 400);
+  }
+  const res = await fetchMutableChannelDO(
+    c.env,
+    slug,
+    new Request(`https://do/internal/presence/${encodeURIComponent(name)}/activity`, {
+      method: "POST",
+      body: JSON.stringify({ activity: body.activity }),
+      headers: { "content-type": "application/json", "x-partykit-room": slug },
+    }),
+  );
+  return mutableFetchResponse(res);
+});
+
 app.post("/api/channels/:slug/presence/:name/pause", async (c) => {
   const slug = c.req.param("slug");
   const channel = await loadChannel(c.env.DB, slug);

--- a/worker/test/presence-activity-rest.spec.ts
+++ b/worker/test/presence-activity-rest.spec.ts
@@ -76,6 +76,9 @@ describe("interactive-lane activity self-report (issue #615)", () => {
     expect(asHuman.status).toBe(403);
     const garbage = await postActivity(slug, agent.token, agent.name, { phase: "hacking", ts: Date.now() });
     expect(garbage.status).toBe(400);
+    // 远未来时间戳拒收：ts 是 TTL 的输入，放进来会让僵活动永不过期
+    const future = await postActivity(slug, agent.token, agent.name, { phase: "working", ts: Date.now() + 10 * 60_000 });
+    expect(future.status).toBe(400);
     ws.close();
   });
 

--- a/worker/test/presence-activity-rest.spec.ts
+++ b/worker/test/presence-activity-rest.spec.ts
@@ -1,0 +1,111 @@
+import type { PresenceEntry } from "@agentparty/shared";
+import { env, runInDurableObject } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import type { ChannelDO } from "../src/do";
+import { WsClient, api, createChannel, seedToken, uniq } from "./helpers";
+
+// 交互 lane 活动直报（issue #615）：不跑 serve 的 Claude Code session 由 hook 经 REST 端点
+// 自报「正在干什么」。关键变化：presence 序列化不再把 activity 绑死 current_task——
+// 交互 lane 没有任务上下文，改按 TTL(5min) 判新鲜。
+
+async function fetchPresence(slug: string, token: string): Promise<PresenceEntry[]> {
+  const res = await api(`/api/channels/${slug}/presence`, token);
+  expect(res.status).toBe(200);
+  return ((await res.json()) as { presence: PresenceEntry[] }).presence;
+}
+
+async function postActivity(slug: string, token: string, name: string, activity: unknown): Promise<Response> {
+  return api(`/api/channels/${slug}/presence/${encodeURIComponent(name)}/activity`, token, {
+    method: "POST",
+    body: JSON.stringify({ activity }),
+  });
+}
+
+async function attachPresence(slug: string, token: string): Promise<WsClient> {
+  const ws = await WsClient.open(slug, token);
+  await ws.nextOfType("welcome");
+  ws.send({ type: "hello", since: 0 });
+  ws.send({ type: "send", kind: "status", state: "waiting", note: "interactive", mentions: [] });
+  await ws.nextOfType("sent");
+  return ws;
+}
+
+describe("interactive-lane activity self-report (issue #615)", () => {
+  it("attaches a fresh activity to presence WITHOUT any current_task", async () => {
+    const agent = await seedToken("agent");
+    const slug = await createChannel(agent.token);
+    const ws = await attachPresence(slug, agent.token);
+
+    const ts = Date.now();
+    const res = await postActivity(slug, agent.token, agent.name, { phase: "tool", tool: "Bash", ts });
+    expect(res.status).toBe(200);
+
+    const entry = (await fetchPresence(slug, agent.token)).find((e) => e.name === agent.name);
+    // #615 的核心：没有 current_task 也能看见活动（交互 lane 没有任务上下文）
+    expect(entry).toMatchObject({ activity: { phase: "tool", tool: "Bash", ts } });
+    expect(entry).not.toHaveProperty("current_task");
+    ws.close();
+  });
+
+  it("waiting_permission reaches the channel from a serve-less session", async () => {
+    const agent = await seedToken("agent");
+    const slug = await createChannel(agent.token);
+    const ws = await attachPresence(slug, agent.token);
+
+    const res = await postActivity(slug, agent.token, agent.name, {
+      phase: "waiting_permission",
+      tool: "Bash",
+      ts: Date.now(),
+    });
+    expect(res.status).toBe(200);
+    const entry = (await fetchPresence(slug, agent.token)).find((e) => e.name === agent.name);
+    expect(entry?.activity?.phase).toBe("waiting_permission");
+    ws.close();
+  });
+
+  it("rejects reporting for another name and rejects humans", async () => {
+    const agent = await seedToken("agent");
+    const other = await seedToken("agent", uniq("other"));
+    const human = await seedToken("human");
+    const slug = await createChannel(agent.token);
+    const ws = await attachPresence(slug, agent.token);
+
+    const impersonate = await postActivity(slug, other.token, agent.name, { phase: "working", ts: Date.now() });
+    expect(impersonate.status).toBe(403);
+    const asHuman = await postActivity(slug, human.token, agent.name, { phase: "working", ts: Date.now() });
+    expect(asHuman.status).toBe(403);
+    const garbage = await postActivity(slug, agent.token, agent.name, { phase: "hacking", ts: Date.now() });
+    expect(garbage.status).toBe(400);
+    ws.close();
+  });
+
+  it("a stale activity (past the 5min TTL) is not serialized into presence", async () => {
+    const agent = await seedToken("agent");
+    const slug = await createChannel(agent.token);
+    const ws = await attachPresence(slug, agent.token);
+
+    // 直接把远古活动塞进存储：序列化侧的 TTL 门禁必须把它过滤掉（僵活动不外泄）。
+    const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+    await runInDurableObject(stub, async (_instance: ChannelDO, state) => {
+      state.storage.sql.exec(
+        "UPDATE presence SET activity_json = ? WHERE name = ?",
+        JSON.stringify({ phase: "tool", tool: "Bash", ts: Date.now() - 6 * 60_000 }),
+        agent.name,
+      );
+    });
+
+    const entry = (await fetchPresence(slug, agent.token)).find((e) => e.name === agent.name);
+    expect(entry).toBeDefined();
+    expect(entry).not.toHaveProperty("activity");
+    ws.close();
+  });
+
+  it("no presence rows -> reported as not attached, no error", async () => {
+    const agent = await seedToken("agent");
+    const slug = await createChannel(agent.token);
+    // 从未在频道露过面（没有 presence 行）
+    const res = await postActivity(slug, agent.token, agent.name, { phase: "working", ts: Date.now() });
+    expect(res.status).toBe(200);
+    expect((await res.json()) as Record<string, unknown>).toMatchObject({ ok: true, attached: false });
+  });
+});

--- a/worker/test/presence-task-heartbeat.spec.ts
+++ b/worker/test/presence-task-heartbeat.spec.ts
@@ -118,16 +118,18 @@ describe("presence per-task heartbeat (issue #228)", () => {
     // 排掉 seedPresence 自己触发的 presence 广播，后续每个 nextOfType("presence") 都对齐一拍心跳
     await ws.nextOfType("presence");
 
+    // ts 用当前时间：#615 起序列化按 TTL(5min) 判新鲜，远古时间戳会被正确过滤（另有专测）。
+    const activityTs = Date.now();
     ws.send({
       type: "heartbeat",
       current_task: 7,
       task_started_at: 1000,
       heartbeat_at: 1000,
-      activity: { phase: "tool", tool: "Bash", ts: 1000 },
+      activity: { phase: "tool", tool: "Bash", ts: activityTs },
     });
     await ws.nextOfType("presence");
     let entry = (await fetchPresence(slug, agent.token)).find((e) => e.name === agent.name);
-    expect(entry).toMatchObject({ current_task: 7, activity: { phase: "tool", tool: "Bash", ts: 1000 } });
+    expect(entry).toMatchObject({ current_task: 7, activity: { phase: "tool", tool: "Bash", ts: activityTs } });
 
     // 下一拍没带 activity（hook 文件缺失/过期）→ 清空，绝不留僵值
     ws.send({ type: "heartbeat", current_task: 7, task_started_at: 1000, heartbeat_at: 2000 });
@@ -152,7 +154,7 @@ describe("presence per-task heartbeat (issue #228)", () => {
       current_task: 7,
       task_started_at: 1000,
       heartbeat_at: 1000,
-      activity: { phase: "waiting_permission", tool: "Bash", ts: 1000 },
+      activity: { phase: "waiting_permission", tool: "Bash", ts: Date.now() },
     });
     await ws.nextOfType("presence");
     // 清除帧即便捎带 activity 也一并清：没有任务就没有活动可言
@@ -161,7 +163,7 @@ describe("presence per-task heartbeat (issue #228)", () => {
       current_task: null,
       task_started_at: null,
       heartbeat_at: null,
-      activity: { phase: "idle", ts: 2000 },
+      activity: { phase: "idle", ts: Date.now() },
     });
     await ws.nextOfType("presence");
 
@@ -187,21 +189,22 @@ describe("presence per-task heartbeat (issue #228)", () => {
       current_task: 5,
       task_started_at: 1000,
       heartbeat_at: 1000,
-      activity: { phase: "hacking", ts: 1000 },
+      activity: { phase: "hacking", ts: Date.now() },
     });
+    const cleanTs = Date.now();
     ws.send({
       type: "heartbeat",
       current_task: 6,
       task_started_at: 1000,
       heartbeat_at: 1000,
-      activity: { phase: "working", ts: 1000 },
+      activity: { phase: "working", ts: cleanTs },
     });
     // 排掉 seed 后第一条到达的 presence 就是干净帧的广播——脏帧被丢弃、从未广播
     const frame = await ws.nextOfType("presence");
-    expect(frame).toMatchObject({ name: agent.name, current_task: 6, activity: { phase: "working", ts: 1000 } });
+    expect(frame).toMatchObject({ name: agent.name, current_task: 6, activity: { phase: "working", ts: cleanTs } });
 
     const entry = (await fetchPresence(slug, agent.token)).find((e) => e.name === agent.name);
-    expect(entry).toMatchObject({ current_task: 6, activity: { phase: "working", ts: 1000 } });
+    expect(entry).toMatchObject({ current_task: 6, activity: { phase: "working", ts: cleanTs } });
     ws.close();
   });
 


### PR DESCRIPTION
Closes #615

## 干了什么

#602 的活动可见性此前只覆盖 `party serve --runner claude` 托管 lane——**不跑 serve 的 agent 依旧是黑盒**，而「交互式 Claude Code + skill/watch 待命」恰恰是最常见的使用形态。本 PR 让这条 lane 也接入：

```
party hook install（一次性，写 .claude/settings.local.json）
  └─ 任何 Claude Code session 的 hook 事件 → party hook report → 落本地活动文件
        ├─ serve 托管（AP_ACTIVITY_FILE 有值）→ 照旧走 serve 心跳，hook 零网络
        └─ 交互 lane（#615 新增）→ 节流后 spawn detached `party hook push`
              → POST /api/channels/:slug/presence/:name/activity → presence.activity
```

## 分层改动

**cli**
- `party hook install [--user] / uninstall / status`：幂等合并进 Claude Code settings（默认项目级 `settings.local.json`，不进 git；`--user` 写 `~/.claude/settings.json`）。只增删「command 含 hook report」的条目，**绝不动用户已有 hooks**；JSON 坏了拒绝覆盖。hooks 配置与 serve 注入的是同一个生成器（`claudeHookSettingsJson`），两条 lane 行为一致。
- `hook report` 交互 lane 直报：落盘后若能解析出频道（`AGENTPARTY_CHANNEL` env 或 workspace state）且过节流闸（普通活动 15s；**waiting_permission 3s**——最致命的静默挂法必须立即可见），spawn 一个 detached `party hook push` 子进程后立刻退出。**hook 本体铁律不变**：零等待网络、stdout 恒空、失败静默 exit 0；节流标记在 spawn 前乐观落盘，hook 风暴下绝不并发起子进程堆。
- `hook push`（内部命令）：读活动文件（TTL 门禁）→ REST 上报，8s 超时，全程静默 best-effort。

**worker**
- 新端点 `POST /api/channels/:slug/presence/:name/activity`：**只准 agent 自报**（token 身份必须等于 :name，human/冒名 403），复用 pause/resume 的 DO internal 转发骨架。DO 侧再加 3s 同相位兜底节流；presence 无行则 attached:false 静默（从没露过面无从附着）。
- **序列化门禁放宽（关键）**：`activity` 不再绑死 `current_task`——交互 lane 没有任务上下文。改为 `state != offline` 且 `now - activity.ts ≤ 5min`（`AGENT_ACTIVITY_TTL_MS`，与 CLI 同口径，常量上移 shared）。serve lane 语义不变（任务结束/离线仍主动清 activity_json）；交互 lane 靠 TTL 自然过期，不留僵活动。

**skill**：接入表格新增一行——join 后跑 `party hook install`，让「接入即可见」成为默认。

## 测试

- `worker/test/presence-activity-rest.spec.ts`（新，5 用例）：**无 current_task 也能看见活动**（核心门禁变化）、serve-less session 的 waiting_permission 到达频道、冒名/human 403 + 脏 phase 400、超 TTL 的僵活动不外泄（直塞存储验证序列化侧过滤）、无 presence 行 no-op。
- `worker/test/presence-task-heartbeat.spec.ts`：既有 #602 用例的活动时间戳改为当前时钟（TTL 门禁下 ts:1000 会被正确过滤——这本身就是门禁生效的证据）。
- `cli/test/hook-install.test.ts`（新，7 用例）：merge 幂等/保留外来 hooks 与未知设置键/坏 JSON 拒改、uninstall 只摘自家条目且摘空清键、节流判定边界（15s/3s/首推）、install→status→uninstall 项目级端到端、push 端到端（POST body 断言）、500/超 TTL/无配置三种静默路径。
- 全量 cli/worker/web + 三包 tsc ✅（见 checks）。

## 非目标

- codex runner 等效上报（codex notify）——另 issue。
- wake 语义不变：本 PR 只解决「活动可见性」，不让交互 session 冒充可唤醒。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增 Claude Code Hook 的安装、卸载和状态查看（支持按项目或用户范围），并支持将模型活动上报到 Presence。
  * 新增代理活动上报接口：Agent 可直接上报当前活动；未找到对应 Presence 时也有明确返回语义。
* **改进**
  * 活动统一有效期为 5 分钟：超时或时间异常的活动不再展示，并避免僵活动残留。
  * 上报增加节流与静默失败策略，交互推送支持普通/紧急间隔并防并发风暴。
  * Hook 配置合并与移除更幂等，卸载不误改外部设置。
* **测试**
  * 补充了 Hook 安装/卸载/推送与活动 TTL/权限校验的覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->