### PR TITLE
feat(desktop): 值守多实例 + workdir/repo 选择（#616 第 1、2 块）

### DIFF
--- a/desktop/src-tauri/src/agent.rs
+++ b/desktop/src-tauri/src/agent.rs
@@ -154,6 +154,26 @@ pub(crate) struct AgentManager(Arc<Mutex<HashMap<String, ManagedAgent>>>);
 /// 活跃（starting/running/stopping）实例上限：桌面机资源兜底，不是产品限制。
 const MAX_ACTIVE_INSTANCES: usize = 8;
 
+/// 终止态（stopped/failed）实例的保留上限：超出按 started_at 淘汰最旧——历史与日志
+/// 不能随「用过的频道数」无限长（CodeRabbit #618 finding）。
+const MAX_TERMINAL_INSTANCES: usize = 16;
+
+/// 淘汰多余的终止态实例。只动非活跃项；活跃实例永不淘汰。
+fn evict_terminal_overflow(instances: &mut HashMap<String, ManagedAgent>) {
+    let mut terminal: Vec<(String, Option<u64>)> = instances
+        .iter()
+        .filter(|(_, agent)| !is_active_phase(agent.runtime.phase))
+        .map(|(key, agent)| (key.clone(), agent.runtime.started_at))
+        .collect();
+    if terminal.len() <= MAX_TERMINAL_INSTANCES {
+        return;
+    }
+    terminal.sort_by_key(|(_, started_at)| *started_at);
+    for (key, _) in terminal.iter().take(terminal.len() - MAX_TERMINAL_INSTANCES) {
+        instances.remove(key);
+    }
+}
+
 fn instance_key(config_id: &str, channel: &str) -> String {
     format!("{config_id}:{channel}")
 }
@@ -678,8 +698,11 @@ pub(crate) fn desktop_agent_start(
             .values()
             .filter(|agent| is_active_phase(agent.runtime.phase))
             .count();
-        let entry = instances.entry(key.clone()).or_default();
-        if is_active_phase(entry.runtime.phase) {
+        // 上限校验先于插入：拒绝路径绝不留下字段全空的幽灵记录（CodeRabbit #618 finding）。
+        if instances
+            .get(&key)
+            .is_some_and(|existing| is_active_phase(existing.runtime.phase))
+        {
             return Err("this desktop agent instance is already running".to_string());
         }
         if active >= MAX_ACTIVE_INSTANCES {
@@ -687,6 +710,8 @@ pub(crate) fn desktop_agent_start(
                 "at most {MAX_ACTIVE_INSTANCES} desktop agent instances can run at once"
             ));
         }
+        evict_terminal_overflow(&mut instances);
+        let entry = instances.entry(key.clone()).or_default();
         entry.generation = entry.generation.wrapping_add(1);
         entry.logs.clear();
         entry.stop_requested = false;
@@ -1066,6 +1091,24 @@ mod tests {
         assert!(super::validate_repo("https://x.com/a b").is_err());
         assert!(super::validate_repo("file:///etc").is_err());
         assert!(super::validate_repo(&format!("https://x.com/{}", "a".repeat(600))).is_err());
+    }
+
+    #[test]
+    fn terminal_history_is_capped_and_never_evicts_active() {
+        use std::collections::HashMap;
+        let mut instances: HashMap<String, super::ManagedAgent> = HashMap::new();
+        for index in 0..30u64 {
+            let mut agent = super::ManagedAgent::default();
+            agent.runtime.started_at = Some(index);
+            agent.runtime.phase = if index == 0 { AgentPhase::Running } else { AgentPhase::Stopped };
+            instances.insert(format!("cfg:{index}"), agent);
+        }
+        super::evict_terminal_overflow(&mut instances);
+        // 活跃实例（index 0）永不淘汰；终止态收敛到上限，且留下的是最新的。
+        assert!(instances.contains_key("cfg:0"));
+        assert_eq!(instances.len(), 1 + 16);
+        assert!(instances.contains_key("cfg:29"));
+        assert!(!instances.contains_key("cfg:1"));
     }
 
     #[test]

--- a/desktop/src-tauri/src/agent.rs
+++ b/desktop/src-tauri/src/agent.rs
@@ -518,7 +518,9 @@ impl AgentManager {
                 "party sidecar did not exit within the stop timeout".to_string(),
             );
         }
-        Ok(agent.runtime.clone())
+        let runtime = agent.runtime.clone();
+        evict_terminal_overflow(&mut instances);
+        Ok(runtime)
     }
 
     /// 旧 stop 命令语义：停掉所有活跃实例（旧 UI 只可能起过一个，行为等价）。
@@ -760,7 +762,9 @@ pub(crate) fn desktop_agent_start(
                 agent.runtime.mark_exited(None, Some(&message));
                 AgentManager::push_log(agent, message);
             }
-            return Ok(agent.runtime.clone());
+            let runtime = agent.runtime.clone();
+            evict_terminal_overflow(&mut instances);
+            return Ok(runtime);
         }
     };
 
@@ -823,6 +827,8 @@ pub(crate) fn desktop_agent_start(
                         }
                     };
                     AgentManager::push_log(agent, message);
+                    // 每个转入终止态的路径都立即收敛历史上限，不等下一次 start（CodeRabbit #618）。
+                    evict_terminal_overflow(&mut instances);
                     return;
                 }
                 _ => {}
@@ -851,6 +857,7 @@ pub(crate) fn desktop_agent_start(
                             "party sidecar event stream closed unexpectedly".to_string(),
                         );
                     }
+                    evict_terminal_overflow(&mut instances);
                 }
             }
         }

--- a/desktop/src-tauri/src/agent.rs
+++ b/desktop/src-tauri/src/agent.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashSet, VecDeque},
+    collections::{HashMap, HashSet, VecDeque},
     env, fs,
     path::{Path, PathBuf},
     sync::{Arc, Mutex, OnceLock},
@@ -71,10 +71,24 @@ pub(crate) struct AgentRuntime {
     pub(crate) started_at: Option<u64>,
     pub(crate) exit_code: Option<i32>,
     pub(crate) last_error: Option<String>,
+    // #616 多实例：instance_id = config_id:channel；旧 UI（单实例面板）忽略未知字段，不破坏兼容。
+    pub(crate) instance_id: Option<String>,
+    pub(crate) workdir: Option<String>,
+    pub(crate) repo: Option<String>,
 }
 
 impl AgentRuntime {
-    fn begin_start(&mut self, config_id: &str, name: &str, channel: &str, runner: &str) {
+    #[allow(clippy::too_many_arguments)]
+    fn begin_start(
+        &mut self,
+        instance_id: &str,
+        config_id: &str,
+        name: &str,
+        channel: &str,
+        runner: &str,
+        workdir: Option<&str>,
+        repo: Option<&str>,
+    ) {
         self.phase = AgentPhase::Starting;
         self.pid = None;
         self.config_id = Some(config_id.to_string());
@@ -84,6 +98,9 @@ impl AgentRuntime {
         self.started_at = Some(now_millis());
         self.exit_code = None;
         self.last_error = None;
+        self.instance_id = Some(instance_id.to_string());
+        self.workdir = workdir.map(str::to_string);
+        self.repo = repo.map(str::to_string);
     }
 
     fn mark_running(&mut self, pid: u32) {
@@ -110,7 +127,11 @@ impl AgentRuntime {
     }
 
     fn mark_stopped(&mut self) {
-        *self = Self::default();
+        // 保留身份字段（instance_id/config/频道/目录）供停止后的列表展示；只清运行态。
+        self.phase = AgentPhase::Stopped;
+        self.pid = None;
+        self.exit_code = None;
+        self.last_error = None;
     }
 }
 
@@ -124,9 +145,25 @@ struct ManagedAgent {
     stop_requested: bool,
 }
 
+/// #616 多实例：以 instance_id（config_id:channel）为键，一台机器可同时值守多个频道/身份。
+/// 终止态（stopped/failed）的实例保留在表里供 UI 展示与重启；活跃实例数量另有上限。
 #[cfg(desktop)]
 #[derive(Clone, Default)]
-pub(crate) struct AgentManager(Arc<Mutex<ManagedAgent>>);
+pub(crate) struct AgentManager(Arc<Mutex<HashMap<String, ManagedAgent>>>);
+
+/// 活跃（starting/running/stopping）实例上限：桌面机资源兜底，不是产品限制。
+const MAX_ACTIVE_INSTANCES: usize = 8;
+
+fn instance_key(config_id: &str, channel: &str) -> String {
+    format!("{config_id}:{channel}")
+}
+
+fn is_active_phase(phase: AgentPhase) -> bool {
+    matches!(
+        phase,
+        AgentPhase::Starting | AgentPhase::Running | AgentPhase::Stopping
+    )
+}
 
 fn now_millis() -> u64 {
     SystemTime::now()
@@ -378,7 +415,7 @@ fn push_bounded_log(logs: &mut VecDeque<String>, line: String) {
 
 #[cfg(desktop)]
 impl AgentManager {
-    fn lock(&self) -> Result<std::sync::MutexGuard<'_, ManagedAgent>, String> {
+    fn lock(&self) -> Result<std::sync::MutexGuard<'_, HashMap<String, ManagedAgent>>, String> {
         self.0
             .lock()
             .map_err(|_| "desktop agent state is unavailable".to_string())
@@ -388,9 +425,29 @@ impl AgentManager {
         push_bounded_log(&mut agent.logs, line);
     }
 
-    async fn stop(&self) -> Result<AgentRuntime, String> {
+    /// 旧单实例 UI 的状态口径：优先第一个活跃实例，其次最近失败的，最后默认 stopped。
+    fn primary_runtime(instances: &HashMap<String, ManagedAgent>) -> AgentRuntime {
+        let mut sorted: Vec<&ManagedAgent> = instances.values().collect();
+        sorted.sort_by_key(|agent| std::cmp::Reverse(agent.runtime.started_at));
+        sorted
+            .iter()
+            .find(|agent| is_active_phase(agent.runtime.phase))
+            .or_else(|| {
+                sorted
+                    .iter()
+                    .find(|agent| agent.runtime.phase == AgentPhase::Failed)
+            })
+            .map(|agent| agent.runtime.clone())
+            .unwrap_or_default()
+    }
+
+    /// 停一个实例：kill child → 等事件泵把 phase 收敛出 Stopping → 超时兜底标记失败。
+    async fn stop_instance_key(&self, key: &str) -> Result<AgentRuntime, String> {
         let child = {
-            let mut agent = self.lock()?;
+            let mut instances = self.lock()?;
+            let Some(agent) = instances.get_mut(key) else {
+                return Err("unknown desktop agent instance".to_string());
+            };
             let child = agent.child.take();
             if child.is_none() {
                 agent.runtime.mark_stopped();
@@ -403,25 +460,33 @@ impl AgentManager {
 
         let kill_error = child.and_then(|child| child.kill().err());
         if let Some(error) = kill_error {
-            let mut agent = self.lock()?;
+            let mut instances = self.lock()?;
+            let Some(agent) = instances.get_mut(key) else {
+                return Err("unknown desktop agent instance".to_string());
+            };
             agent.stop_requested = false;
             if agent.runtime.phase == AgentPhase::Stopping {
                 let message = redact_line(&format!("failed to stop party sidecar: {error}"));
                 agent.runtime.mark_exited(None, Some(&message));
-                Self::push_log(&mut agent, message);
+                Self::push_log(agent, message);
             }
             return Ok(agent.runtime.clone());
         }
 
         for _ in 0..80 {
             tokio::time::sleep(std::time::Duration::from_millis(25)).await;
-            let agent = self.lock()?;
-            if agent.runtime.phase != AgentPhase::Stopping {
-                return Ok(agent.runtime.clone());
+            let instances = self.lock()?;
+            match instances.get(key) {
+                Some(agent) if agent.runtime.phase == AgentPhase::Stopping => {}
+                Some(agent) => return Ok(agent.runtime.clone()),
+                None => return Err("unknown desktop agent instance".to_string()),
             }
         }
 
-        let mut agent = self.lock()?;
+        let mut instances = self.lock()?;
+        let Some(agent) = instances.get_mut(key) else {
+            return Err("unknown desktop agent instance".to_string());
+        };
         if agent.runtime.phase == AgentPhase::Stopping {
             agent.stop_requested = false;
             agent.runtime.mark_exited(
@@ -429,21 +494,40 @@ impl AgentManager {
                 Some("party sidecar did not exit within the stop timeout"),
             );
             Self::push_log(
-                &mut agent,
+                agent,
                 "party sidecar did not exit within the stop timeout".to_string(),
             );
         }
         Ok(agent.runtime.clone())
     }
 
+    /// 旧 stop 命令语义：停掉所有活跃实例（旧 UI 只可能起过一个，行为等价）。
+    async fn stop_all(&self) -> Result<AgentRuntime, String> {
+        let keys: Vec<String> = {
+            let instances = self.lock()?;
+            instances
+                .iter()
+                .filter(|(_, agent)| is_active_phase(agent.runtime.phase))
+                .map(|(key, _)| key.clone())
+                .collect()
+        };
+        for key in &keys {
+            let _ = self.stop_instance_key(key).await;
+        }
+        let instances = self.lock()?;
+        Ok(Self::primary_runtime(&instances))
+    }
+
     pub(crate) fn kill_on_exit(&self) {
-        if let Ok(mut agent) = self.0.lock() {
-            agent.generation = agent.generation.wrapping_add(1);
-            if let Some(child) = agent.child.take() {
-                let _ = child.kill();
+        if let Ok(mut instances) = self.0.lock() {
+            for agent in instances.values_mut() {
+                agent.generation = agent.generation.wrapping_add(1);
+                if let Some(child) = agent.child.take() {
+                    let _ = child.kill();
+                }
+                agent.runtime.mark_stopped();
+                agent.stop_requested = false;
             }
-            agent.runtime.mark_stopped();
-            agent.stop_requested = false;
         }
     }
 }
@@ -460,13 +544,65 @@ pub(crate) fn desktop_agent_list_configs() -> Result<Vec<AgentConfigSummary>, St
 #[cfg(desktop)]
 #[tauri::command]
 pub(crate) fn desktop_agent_status(state: State<'_, AgentManager>) -> Result<AgentRuntime, String> {
-    Ok(state.lock()?.runtime.clone())
+    let instances = state.lock()?;
+    Ok(AgentManager::primary_runtime(&instances))
+}
+
+/// #616：全部实例状态（含终止态，供列表展示与重启）。按 started_at 倒序稳定输出。
+#[cfg(desktop)]
+#[tauri::command]
+pub(crate) fn desktop_agent_status_all(
+    state: State<'_, AgentManager>,
+) -> Result<Vec<AgentRuntime>, String> {
+    let instances = state.lock()?;
+    let mut runtimes: Vec<AgentRuntime> =
+        instances.values().map(|agent| agent.runtime.clone()).collect();
+    runtimes.sort_by(|left, right| {
+        right
+            .started_at
+            .cmp(&left.started_at)
+            .then_with(|| left.instance_id.cmp(&right.instance_id))
+    });
+    Ok(runtimes)
 }
 
 #[cfg(desktop)]
 #[tauri::command]
 pub(crate) fn desktop_agent_logs(state: State<'_, AgentManager>) -> Result<Vec<String>, String> {
-    Ok(state.lock()?.logs.iter().cloned().collect())
+    // 旧命令的多实例口径：单实例时原样；多实例时带 [name#channel] 前缀合并，旧 UI 仍可读。
+    let instances = state.lock()?;
+    if instances.len() <= 1 {
+        return Ok(instances
+            .values()
+            .next()
+            .map(|agent| agent.logs.iter().cloned().collect())
+            .unwrap_or_default());
+    }
+    let mut lines = Vec::new();
+    let mut sorted: Vec<&ManagedAgent> = instances.values().collect();
+    sorted.sort_by(|left, right| left.runtime.instance_id.cmp(&right.runtime.instance_id));
+    for agent in sorted {
+        let label = format!(
+            "[{}#{}]",
+            agent.runtime.name.as_deref().unwrap_or("agent"),
+            agent.runtime.channel.as_deref().unwrap_or("-"),
+        );
+        lines.extend(agent.logs.iter().map(|line| format!("{label} {line}")));
+    }
+    Ok(lines)
+}
+
+#[cfg(desktop)]
+#[tauri::command]
+pub(crate) fn desktop_agent_logs_instance(
+    state: State<'_, AgentManager>,
+    instance_id: String,
+) -> Result<Vec<String>, String> {
+    let instances = state.lock()?;
+    instances
+        .get(&instance_id)
+        .map(|agent| agent.logs.iter().cloned().collect())
+        .ok_or_else(|| "unknown desktop agent instance".to_string())
 }
 
 #[cfg(desktop)]
@@ -474,7 +610,43 @@ pub(crate) fn desktop_agent_logs(state: State<'_, AgentManager>) -> Result<Vec<S
 pub(crate) async fn desktop_agent_stop(
     state: State<'_, AgentManager>,
 ) -> Result<AgentRuntime, String> {
-    state.stop().await
+    state.stop_all().await
+}
+
+#[cfg(desktop)]
+#[tauri::command]
+pub(crate) async fn desktop_agent_stop_instance(
+    state: State<'_, AgentManager>,
+    instance_id: String,
+) -> Result<AgentRuntime, String> {
+    state.stop_instance_key(&instance_id).await
+}
+
+/// workdir 必须是已存在的绝对路径目录——错误路径宁可拒绝，不能让 serve 静默落到默认目录。
+fn validate_workdir(workdir: &str) -> Result<&str, String> {
+    let path = Path::new(workdir);
+    if !path.is_absolute() {
+        return Err("workdir must be an absolute path".to_string());
+    }
+    if !path.is_dir() {
+        return Err("workdir does not exist or is not a directory".to_string());
+    }
+    Ok(workdir)
+}
+
+/// repo 只透传给 `party serve --repo`（serve 内部 git clone/pull）；这里挡明显的坏值与注入面。
+fn validate_repo(repo: &str) -> Result<&str, String> {
+    let valid_scheme = repo.starts_with("https://")
+        || repo.starts_with("http://")
+        || repo.starts_with("ssh://")
+        || repo.starts_with("git@");
+    if repo.len() > 512
+        || repo.chars().any(|value| value.is_whitespace() || value.is_control())
+        || !valid_scheme
+    {
+        return Err("repo must be an http(s)/ssh/git@ URL".to_string());
+    }
+    Ok(repo)
 }
 
 #[cfg(desktop)]
@@ -485,34 +657,67 @@ pub(crate) fn desktop_agent_start(
     config_id: String,
     channel: String,
     runner: String,
+    workdir: Option<String>,
+    repo: Option<String>,
 ) -> Result<AgentRuntime, String> {
     validate_channel(&channel)?;
     validate_runner(&runner)?;
+    if let Some(dir) = workdir.as_deref() {
+        validate_workdir(dir)?;
+    }
+    if let Some(url) = repo.as_deref() {
+        validate_repo(url)?;
+    }
     let (config_path, summary) = resolve_config(&config_id)?;
     let secrets = config_secrets(&config_path);
+    let key = instance_key(&config_id, &channel);
 
     let generation = {
-        let mut agent = state.lock()?;
-        if matches!(
-            agent.runtime.phase,
-            AgentPhase::Starting | AgentPhase::Running
-        ) {
-            return Err("a desktop agent is already running".to_string());
+        let mut instances = state.lock()?;
+        let active = instances
+            .values()
+            .filter(|agent| is_active_phase(agent.runtime.phase))
+            .count();
+        let entry = instances.entry(key.clone()).or_default();
+        if is_active_phase(entry.runtime.phase) {
+            return Err("this desktop agent instance is already running".to_string());
         }
-        agent.generation = agent.generation.wrapping_add(1);
-        agent.logs.clear();
-        agent.stop_requested = false;
-        agent
-            .runtime
-            .begin_start(&config_id, &summary.name, &channel, &runner);
-        agent.generation
+        if active >= MAX_ACTIVE_INSTANCES {
+            return Err(format!(
+                "at most {MAX_ACTIVE_INSTANCES} desktop agent instances can run at once"
+            ));
+        }
+        entry.generation = entry.generation.wrapping_add(1);
+        entry.logs.clear();
+        entry.stop_requested = false;
+        entry.runtime.begin_start(
+            &key,
+            &config_id,
+            &summary.name,
+            &channel,
+            &runner,
+            workdir.as_deref(),
+            repo.as_deref(),
+        );
+        entry.generation
     };
 
     let spawn_result = app.shell().sidecar("party").and_then(|command| {
-        command
-            .args(["serve", channel.as_str(), "--runner", runner.as_str()])
-            .env("AGENTPARTY_CONFIG", &config_path)
-            .spawn()
+        let mut args = vec![
+            "serve".to_string(),
+            channel.clone(),
+            "--runner".to_string(),
+            runner.clone(),
+        ];
+        if let Some(dir) = workdir.as_deref() {
+            args.push("--workdir".to_string());
+            args.push(dir.to_string());
+        }
+        if let Some(url) = repo.as_deref() {
+            args.push("--repo".to_string());
+            args.push(url.to_string());
+        }
+        command.args(args).env("AGENTPARTY_CONFIG", &config_path).spawn()
     });
 
     let (mut events, child) = match spawn_result {
@@ -522,10 +727,13 @@ pub(crate) fn desktop_agent_start(
                 &format!("failed to start party sidecar: {error}"),
                 &secrets,
             );
-            let mut agent = state.lock()?;
+            let mut instances = state.lock()?;
+            let Some(agent) = instances.get_mut(&key) else {
+                return Err(message);
+            };
             if agent.generation == generation {
                 agent.runtime.mark_exited(None, Some(&message));
-                AgentManager::push_log(&mut agent, message);
+                AgentManager::push_log(agent, message);
             }
             return Ok(agent.runtime.clone());
         }
@@ -533,22 +741,30 @@ pub(crate) fn desktop_agent_start(
 
     let pid = child.pid();
     {
-        let mut agent = state.lock()?;
+        let mut instances = state.lock()?;
+        let Some(agent) = instances.get_mut(&key) else {
+            let _ = child.kill();
+            return Err("desktop agent start was cancelled".to_string());
+        };
         if agent.generation != generation {
             let _ = child.kill();
             return Err("desktop agent start was cancelled".to_string());
         }
         agent.child = Some(child);
         agent.runtime.mark_running(pid);
-        AgentManager::push_log(&mut agent, format!("party sidecar started (pid {pid})"));
+        AgentManager::push_log(agent, format!("party sidecar started (pid {pid})"));
     }
 
     let manager = state.inner().clone();
+    let pump_key = key.clone();
     tauri::async_runtime::spawn(async move {
         while let Some(event) = events.recv().await {
-            let mut agent = match manager.lock() {
-                Ok(agent) => agent,
+            let mut instances = match manager.lock() {
+                Ok(instances) => instances,
                 Err(_) => return,
+            };
+            let Some(agent) = instances.get_mut(&pump_key) else {
+                return;
             };
             if agent.generation != generation {
                 return;
@@ -556,16 +772,13 @@ pub(crate) fn desktop_agent_start(
             match event {
                 CommandEvent::Stdout(bytes) | CommandEvent::Stderr(bytes) => {
                     for line in String::from_utf8_lossy(&bytes).lines() {
-                        AgentManager::push_log(
-                            &mut agent,
-                            redact_line_with_secrets(line, &secrets),
-                        );
+                        AgentManager::push_log(agent, redact_line_with_secrets(line, &secrets));
                     }
                 }
                 CommandEvent::Error(error) => {
                     let message = redact_line_with_secrets(&error, &secrets);
                     agent.runtime.last_error = Some(bound_text(&message, ERROR_BYTES));
-                    AgentManager::push_log(&mut agent, message);
+                    AgentManager::push_log(agent, message);
                 }
                 CommandEvent::Terminated(payload) => {
                     agent.child = None;
@@ -584,38 +797,45 @@ pub(crate) fn desktop_agent_start(
                             None => "party sidecar exited".to_string(),
                         }
                     };
-                    AgentManager::push_log(&mut agent, message);
+                    AgentManager::push_log(agent, message);
                     return;
                 }
                 _ => {}
             }
         }
-        if let Ok(mut agent) = manager.lock() {
-            if agent.generation == generation
-                && matches!(
-                    agent.runtime.phase,
-                    AgentPhase::Running | AgentPhase::Stopping
-                )
-            {
-                agent.child = None;
-                if agent.stop_requested {
-                    agent.stop_requested = false;
-                    agent.runtime.mark_stopped();
-                    AgentManager::push_log(&mut agent, "party sidecar stopped".to_string());
-                } else {
-                    agent
-                        .runtime
-                        .mark_exited(None, Some("party sidecar event stream closed unexpectedly"));
-                    AgentManager::push_log(
-                        &mut agent,
-                        "party sidecar event stream closed unexpectedly".to_string(),
-                    );
+        if let Ok(mut instances) = manager.lock() {
+            if let Some(agent) = instances.get_mut(&pump_key) {
+                if agent.generation == generation
+                    && matches!(
+                        agent.runtime.phase,
+                        AgentPhase::Running | AgentPhase::Stopping
+                    )
+                {
+                    agent.child = None;
+                    if agent.stop_requested {
+                        agent.stop_requested = false;
+                        agent.runtime.mark_stopped();
+                        AgentManager::push_log(agent, "party sidecar stopped".to_string());
+                    } else {
+                        agent.runtime.mark_exited(
+                            None,
+                            Some("party sidecar event stream closed unexpectedly"),
+                        );
+                        AgentManager::push_log(
+                            agent,
+                            "party sidecar event stream closed unexpectedly".to_string(),
+                        );
+                    }
                 }
             }
         }
     });
 
-    Ok(state.lock()?.runtime.clone())
+    let instances = state.lock()?;
+    instances
+        .get(&key)
+        .map(|agent| agent.runtime.clone())
+        .ok_or_else(|| "desktop agent instance vanished during start".to_string())
 }
 
 #[cfg(test)]
@@ -826,12 +1046,51 @@ mod tests {
     }
 
     #[test]
+    fn workdir_must_be_an_existing_absolute_directory() {
+        let temp = TempDir::new().unwrap();
+        let dir = temp.path().to_string_lossy().into_owned();
+        assert!(super::validate_workdir(&dir).is_ok());
+        assert!(super::validate_workdir("relative/path").is_err());
+        assert!(super::validate_workdir(&format!("{dir}/missing")).is_err());
+        let file = temp.path().join("plain.txt");
+        fs::write(&file, "x").unwrap();
+        assert!(super::validate_workdir(&file.to_string_lossy()).is_err());
+    }
+
+    #[test]
+    fn repo_rejects_injection_shaped_values() {
+        assert!(super::validate_repo("https://github.com/leeguooooo/agentparty.git").is_ok());
+        assert!(super::validate_repo("git@github.com:leeguooooo/agentparty.git").is_ok());
+        assert!(super::validate_repo("ssh://git@host/repo.git").is_ok());
+        assert!(super::validate_repo("--upload-pack=touch /tmp/pwn").is_err());
+        assert!(super::validate_repo("https://x.com/a b").is_err());
+        assert!(super::validate_repo("file:///etc").is_err());
+        assert!(super::validate_repo(&format!("https://x.com/{}", "a".repeat(600))).is_err());
+    }
+
+    #[test]
+    fn instance_key_is_config_and_channel_scoped() {
+        assert_eq!(super::instance_key("abc", "dev"), "abc:dev");
+        assert_ne!(super::instance_key("abc", "dev"), super::instance_key("abc", "ops"));
+    }
+
+    #[test]
     fn runtime_transitions_start_run_fail_and_stop() {
         let mut runtime = AgentRuntime::default();
         assert_eq!(runtime.phase, AgentPhase::Stopped);
 
-        runtime.begin_start("config-id", "worker", "native-r4", "codex");
+        runtime.begin_start(
+            "config-id:native-r4",
+            "config-id",
+            "worker",
+            "native-r4",
+            "codex",
+            Some("/tmp/duty"),
+            None,
+        );
         assert_eq!(runtime.phase, AgentPhase::Starting);
+        assert_eq!(runtime.instance_id.as_deref(), Some("config-id:native-r4"));
+        assert_eq!(runtime.workdir.as_deref(), Some("/tmp/duty"));
         let serialized = serde_json::to_value(&runtime).unwrap();
         assert_eq!(serialized["state"], "starting");
         assert!(serialized.get("status").is_none());

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -1176,9 +1176,12 @@ pub fn run() {
             desktop_ui_storage_snapshot,
             agent::desktop_agent_list_configs,
             agent::desktop_agent_status,
+            agent::desktop_agent_status_all,
             agent::desktop_agent_start,
             agent::desktop_agent_stop,
-            agent::desktop_agent_logs
+            agent::desktop_agent_stop_instance,
+            agent::desktop_agent_logs,
+            agent::desktop_agent_logs_instance
         ]);
 
     #[cfg(mobile)]

--- a/web/src/components/DesktopAgentPanel.test.tsx
+++ b/web/src/components/DesktopAgentPanel.test.tsx
@@ -30,15 +30,24 @@ const stopped: DesktopAgentStatus = {
   startedAt: null,
   exitCode: null,
   lastError: null,
+  instanceId: null,
+  workdir: null,
+  repo: null,
 };
 
 function adapter(overrides: Partial<DesktopAgentAdapter> = {}): DesktopAgentAdapter {
   return {
     listConfigs: async () => [config],
     status: async () => stopped,
+    // 默认模拟旧 shell：statusAll 不存在 → 面板走单实例回退路径（存量用例语义不变）。
+    statusAll: async () => {
+      throw new Error("desktop_agent_status_all is not available");
+    },
     start: async () => ({ ...stopped, state: "running", pid: 42 }),
     stop: async () => stopped,
+    stopInstance: async () => stopped,
     logs: async () => [],
+    logsInstance: async () => [],
     ...overrides,
   };
 }
@@ -72,6 +81,97 @@ beforeEach(() => {
 afterEach(async () => {
   if (renderer !== null) await act(async () => renderer?.unmount());
   renderer = null;
+});
+
+// #616：statusAll 可用（新 shell）时的多实例路径
+describe("DesktopAgentPanel 多实例 (#616)", () => {
+  const running: DesktopAgentStatus = {
+    ...stopped,
+    state: "running",
+    pid: 41,
+    configId: "local-main",
+    name: "Leo Codex",
+    channel: "agentparty",
+    runner: "codex",
+    startedAt: 100,
+    instanceId: "local-main:agentparty",
+    workdir: "/srv/duty",
+  };
+  const failed: DesktopAgentStatus = {
+    ...stopped,
+    state: "failed",
+    configId: "local-main",
+    name: "Leo Codex",
+    channel: "ops",
+    runner: "claude",
+    startedAt: 90,
+    instanceId: "local-main:ops",
+    lastError: "party sidecar exited with code 1",
+  };
+
+  test("渲染实例列表：每行状态/身份/workdir，活跃行有停止按钮并调 stopInstance", async () => {
+    const stops: string[] = [];
+    const root = await render(adapter({
+      statusAll: async () => [running, failed],
+      stopInstance: async (instanceId: string) => {
+        stops.push(instanceId);
+        return { ...running, state: "stopped", pid: null };
+      },
+    }));
+
+    const list = root.find((node) => node.props["aria-label"] === "Duty instances");
+    expect(list.findAllByType("li")).toHaveLength(2);
+    expect(JSON.stringify(renderer!.toJSON())).toContain("/srv/duty");
+
+    const stopButton = button("Stop local-main:agentparty");
+    expect(root.findAll((node) => node.type === "button" && node.props["aria-label"] === "Stop local-main:ops")).toHaveLength(0);
+    await act(async () => {
+      await stopButton.props.onClick();
+    });
+    expect(stops).toEqual(["local-main:agentparty"]);
+  });
+
+  test("start 透传 workdir/repo；同键实例活跃时禁用启动", async () => {
+    const starts: DesktopAgentStartInput[] = [];
+    const root = await render(adapter({
+      statusAll: async () => [failed],
+      start: async (input: DesktopAgentStartInput) => {
+        starts.push(input);
+        return running;
+      },
+    }));
+
+    const workdirInput = root.find((node) => node.props.name === "desktop-agent-workdir");
+    const repoInput = root.find((node) => node.props.name === "desktop-agent-repo");
+    await act(async () => {
+      workdirInput.props.onChange({ target: { value: "/srv/duty" } });
+      repoInput.props.onChange({ target: { value: "https://github.com/org/repo.git" } });
+    });
+    await act(async () => {
+      await button("Start local agent").props.onClick();
+    });
+    // 初始选中值来自 primary（failed 行：#ops / claude）——断言透传的正是表单当前值。
+    expect(starts).toEqual([
+      {
+        configId: "local-main",
+        channel: "ops",
+        runner: "claude",
+        workdir: "/srv/duty",
+        repo: "https://github.com/org/repo.git",
+      },
+    ]);
+  });
+
+  test("同键实例活跃时启动按钮禁用，但可以为其它频道再起实例", async () => {
+    const root = await render(adapter({ statusAll: async () => [running] }));
+    // 预填频道 = running 实例的 agentparty → 目标键已活跃 → 禁用
+    expect(button("Start local agent").props.disabled).toBe(true);
+    const channelInput = root.find((node) => node.props.name === "desktop-agent-channel");
+    await act(async () => {
+      channelInput.props.onChange({ target: { value: "ops" } });
+    });
+    expect(button("Start local agent").props.disabled).toBe(false);
+  });
 });
 
 describe("DesktopAgentPanel", () => {

--- a/web/src/components/DesktopAgentPanel.tsx
+++ b/web/src/components/DesktopAgentPanel.tsx
@@ -44,32 +44,63 @@ function canRequestStop(status: DesktopAgentStatus | null): boolean {
   return status?.state === "starting" || status?.state === "running";
 }
 
+// #616 多实例：statusAll 可用（新 shell）时用实例列表；旧 shell 抛错则回退单实例视图。
+function derivePrimary(instances: DesktopAgentStatus[]): DesktopAgentStatus | null {
+  return (
+    instances.find((item) => isActive(item)) ??
+    instances.find((item) => item.state === "failed") ??
+    instances[0] ??
+    null
+  );
+}
+
 export function DesktopAgentPanel({ t, adapter = desktopAgentAdapter, scheduler = defaultScheduler }: Props) {
   const [configs, setConfigs] = useState<DesktopAgentConfig[] | null>(null);
   const [status, setStatus] = useState<DesktopAgentStatus | null>(null);
+  const [instances, setInstances] = useState<DesktopAgentStatus[] | null>(null);
   const [configId, setConfigId] = useState("");
   const [channel, setChannel] = useState("");
   const [runner, setRunner] = useState<DesktopAgentRunner>("codex");
+  const [workdir, setWorkdir] = useState("");
+  const [repo, setRepo] = useState("");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [logsOpen, setLogsOpen] = useState(false);
+  const [logsFor, setLogsFor] = useState<string | null>(null);
   const [logs, setLogs] = useState<string[] | null>(null);
   const [loadAttempt, setLoadAttempt] = useState(0);
   const aliveRef = useRef(true);
   const operationRef = useRef(false);
+  // null=未探测，true/false=statusAll 是否可用（探测一次，之后不再打旧 shell 的未知命令）。
+  const multiRef = useRef<boolean | null>(null);
+
+  const fetchStatus = async (): Promise<DesktopAgentStatus | null> => {
+    if (multiRef.current !== false) {
+      try {
+        const all = await adapter.statusAll();
+        multiRef.current = true;
+        if (aliveRef.current) setInstances(all);
+        return derivePrimary(all);
+      } catch {
+        if (multiRef.current === true) throw new Error("desktop agent status is unavailable");
+        multiRef.current = false;
+      }
+    }
+    return await adapter.status();
+  };
 
   useEffect(() => {
     aliveRef.current = true;
     let active = true;
-    void Promise.all([adapter.listConfigs(), adapter.status()]).then(([nextConfigs, nextStatus]) => {
+    void Promise.all([adapter.listConfigs(), fetchStatus()]).then(([nextConfigs, nextStatus]) => {
       if (!active) return;
       setConfigs(nextConfigs);
       setStatus(nextStatus);
-      const selected = nextConfigs.find((item) => item.configId === nextStatus.configId) ?? nextConfigs[0];
+      const selected = nextConfigs.find((item) => item.configId === nextStatus?.configId) ?? nextConfigs[0];
       setConfigId(selected?.configId ?? "");
-      setChannel(nextStatus.channel ?? selected?.channel ?? "");
-      if (RUNNERS.includes(nextStatus.runner as DesktopAgentRunner)) {
-        setRunner(nextStatus.runner as DesktopAgentRunner);
+      setChannel(nextStatus?.channel ?? selected?.channel ?? "");
+      if (RUNNERS.includes(nextStatus?.runner as DesktopAgentRunner)) {
+        setRunner(nextStatus?.runner as DesktopAgentRunner);
       }
     }).catch((cause) => {
       if (!active) return;
@@ -79,20 +110,28 @@ export function DesktopAgentPanel({ t, adapter = desktopAgentAdapter, scheduler 
       active = false;
       aliveRef.current = false;
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [adapter, loadAttempt]);
 
+  const anyActive = isActive(status) || (instances ?? []).some((item) => isActive(item));
+
+  const fetchLogs = async (): Promise<string[]> => {
+    if (logsFor !== null && multiRef.current === true) return await adapter.logsInstance(logsFor);
+    return await adapter.logs();
+  };
+
   useEffect(() => {
-    if (!isActive(status)) return;
+    if (!anyActive) return;
     let active = true;
     const cancel = scheduler.every(() => {
       if (!active) return;
-      void adapter.status().then((next) => {
+      void fetchStatus().then((next) => {
         if (active) setStatus(next);
       }).catch((cause) => {
         if (active) setError(safeError(cause));
       });
       if (logsOpen) {
-        void adapter.logs().then((next) => {
+        void fetchLogs().then((next) => {
           if (active) setLogs(next.map(safeError));
         }).catch((cause) => {
           if (active) setError(safeError(cause));
@@ -103,7 +142,8 @@ export function DesktopAgentPanel({ t, adapter = desktopAgentAdapter, scheduler 
       active = false;
       cancel();
     };
-  }, [adapter, logsOpen, scheduler, status?.state]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [adapter, anyActive, logsFor, logsOpen, scheduler, status?.state]);
 
   const runOperation = async (operation: () => Promise<DesktopAgentStatus>) => {
     if (operationRef.current) return;
@@ -115,9 +155,21 @@ export function DesktopAgentPanel({ t, adapter = desktopAgentAdapter, scheduler 
       const next = await operation();
       if (aliveRef.current) {
         setStatus(next);
+        // 多实例：任何操作后刷新整表，别让列表与单实例回执漂移。
+        if (multiRef.current === true) {
+          try {
+            const all = await adapter.statusAll();
+            if (aliveRef.current) {
+              setInstances(all);
+              setStatus(derivePrimary(all));
+            }
+          } catch {
+            // 刷新失败不吞操作结果；下一轮轮询会补上。
+          }
+        }
         if (logsOpen) {
           try {
-            const nextLogs = (await adapter.logs()).map(safeError);
+            const nextLogs = (await fetchLogs()).map(safeError);
             if (aliveRef.current) setLogs(nextLogs);
           } catch (cause) {
             if (aliveRef.current) setError(safeError(cause));
@@ -143,7 +195,19 @@ export function DesktopAgentPanel({ t, adapter = desktopAgentAdapter, scheduler 
     setLogsOpen(nextOpen);
     if (!nextOpen || logs !== null) return;
     try {
-      const nextLogs = (await adapter.logs()).map(safeError);
+      const nextLogs = (await fetchLogs()).map(safeError);
+      if (aliveRef.current) setLogs(nextLogs);
+    } catch (cause) {
+      if (aliveRef.current) setError(safeError(cause));
+    }
+  };
+
+  const openInstanceLogs = async (instanceId: string) => {
+    setLogsFor(instanceId);
+    setLogsOpen(true);
+    setLogs(null);
+    try {
+      const nextLogs = (await adapter.logsInstance(instanceId)).map(safeError);
       if (aliveRef.current) setLogs(nextLogs);
     } catch (cause) {
       if (aliveRef.current) setError(safeError(cause));
@@ -154,8 +218,15 @@ export function DesktopAgentPanel({ t, adapter = desktopAgentAdapter, scheduler 
     ? t("DesktopSettings.agent.state.loading")
     : t(`DesktopSettings.agent.state.${status.state}`);
   const noConfig = configs !== null && configs.length === 0;
-  const canStart = !busy && !noConfig && configId !== "" && channel.trim() !== "" && !isActive(status);
-  const canStop = !busy && canRequestStop(status);
+  const targetKey = `${configId}:${channel.trim()}`;
+  const targetActive = instances === null
+    ? isActive(status)
+    : instances.some((item) => item.instanceId === targetKey && isActive(item));
+  const activeCount = (instances ?? []).filter((item) => isActive(item)).length;
+  const canStart =
+    !busy && !noConfig && configId !== "" && channel.trim() !== "" && !targetActive &&
+    (instances === null || activeCount < 8);
+  const canStop = !busy && (instances === null ? canRequestStop(status) : activeCount > 0);
   const channels = [...new Set((configs ?? []).map((item) => item.channel).filter((value): value is string => Boolean(value)))];
 
   return (
@@ -175,7 +246,7 @@ export function DesktopAgentPanel({ t, adapter = desktopAgentAdapter, scheduler 
             <span>{t("DesktopSettings.agent.identity")}</span>
             <select
               value={configId}
-              disabled={busy || configs === null || isActive(status)}
+              disabled={busy || configs === null || (instances === null && isActive(status))}
               onChange={(event) => changeConfig(event.target.value)}
             >
               {(configs ?? []).map((item) => (
@@ -190,7 +261,7 @@ export function DesktopAgentPanel({ t, adapter = desktopAgentAdapter, scheduler 
               name="desktop-agent-channel"
               value={channel}
               list="desktop-agent-channels"
-              disabled={busy || configs === null || isActive(status)}
+              disabled={busy || configs === null || (instances === null && isActive(status))}
               onChange={(event) => setChannel(event.target.value)}
               autoComplete="off"
             />
@@ -202,16 +273,83 @@ export function DesktopAgentPanel({ t, adapter = desktopAgentAdapter, scheduler 
             <span>{t("DesktopSettings.agent.runner")}</span>
             <select
               value={runner}
-              disabled={busy || configs === null || isActive(status)}
+              disabled={busy || configs === null || (instances === null && isActive(status))}
               onChange={(event) => setRunner(event.target.value as DesktopAgentRunner)}
             >
               {RUNNERS.map((value) => <option key={value} value={value}>{value}</option>)}
             </select>
           </label>
+          <label>
+            <span>{t("DesktopSettings.agent.workdir")}</span>
+            <input
+              className="t-mono"
+              name="desktop-agent-workdir"
+              value={workdir}
+              placeholder="/absolute/path"
+              disabled={busy || configs === null}
+              onChange={(event) => setWorkdir(event.target.value)}
+              autoComplete="off"
+              spellCheck={false}
+            />
+          </label>
+          <label>
+            <span>{t("DesktopSettings.agent.repo")}</span>
+            <input
+              className="t-mono"
+              name="desktop-agent-repo"
+              value={repo}
+              placeholder="https://github.com/org/repo.git"
+              disabled={busy || configs === null}
+              onChange={(event) => setRepo(event.target.value)}
+              autoComplete="off"
+              spellCheck={false}
+            />
+          </label>
         </div>
       )}
 
-      {status !== null && status.state !== "stopped" && (
+      {instances !== null && instances.length > 0 && (
+        <ul className="desktop-agent-instances" aria-label={t("DesktopSettings.agent.instances")}>
+          {instances.map((item) => (
+            <li key={item.instanceId ?? `${item.configId}:${item.channel}`} className="desktop-agent-instance">
+              <span className={`desktop-agent-state desktop-agent-state--${item.state}`}>
+                {t(`DesktopSettings.agent.state.${item.state}`)}
+              </span>
+              <span className="t-mono desktop-agent-instance-name">
+                {[item.name, item.channel ? `#${item.channel}` : null, item.runner].filter(Boolean).join(" · ")}
+              </span>
+              {item.workdir !== null && (
+                <span className="t-mono desktop-agent-instance-dir" title={item.workdir}>{item.workdir}</span>
+              )}
+              {item.instanceId !== null && (
+                <>
+                  <button
+                    type="button"
+                    className="d-btn"
+                    aria-label={`${t("DesktopSettings.agent.instanceLogs")} ${item.instanceId}`}
+                    onClick={() => void openInstanceLogs(item.instanceId!)}
+                  >
+                    {t("DesktopSettings.agent.instanceLogs")}
+                  </button>
+                  {isActive(item) && (
+                    <button
+                      type="button"
+                      className="d-btn"
+                      aria-label={`${t("DesktopSettings.agent.instanceStop")} ${item.instanceId}`}
+                      disabled={busy || item.state === "stopping"}
+                      onClick={() => runOperation(() => adapter.stopInstance(item.instanceId!))}
+                    >
+                      {t("DesktopSettings.agent.instanceStop")}
+                    </button>
+                  )}
+                </>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {instances === null && status !== null && status.state !== "stopped" && (
         <p className="desktop-agent-detail">
           {[status.name, status.channel ? `#${status.channel}` : null, status.runner].filter(Boolean).join(" · ")}
         </p>
@@ -238,7 +376,17 @@ export function DesktopAgentPanel({ t, adapter = desktopAgentAdapter, scheduler 
           className="d-btn"
           aria-label={t("DesktopSettings.agent.start")}
           disabled={!canStart}
-          onClick={() => runOperation(() => adapter.start({ configId, channel: channel.trim(), runner }))}
+          onClick={() =>
+            runOperation(() =>
+              adapter.start({
+                configId,
+                channel: channel.trim(),
+                runner,
+                workdir: workdir.trim() === "" ? undefined : workdir.trim(),
+                repo: repo.trim() === "" ? undefined : repo.trim(),
+              }),
+            )
+          }
         >
           {t("DesktopSettings.agent.start")}
         </button>

--- a/web/src/i18n/strings/DesktopSettings.ts
+++ b/web/src/i18n/strings/DesktopSettings.ts
@@ -36,6 +36,11 @@ export const DesktopSettingsStrings: LocaleDict = {
     "DesktopSettings.agent.logs.label": "Local agent logs",
     "DesktopSettings.agent.logs.loading": "Loading logs",
     "DesktopSettings.agent.logs.empty": "No logs yet.",
+    "DesktopSettings.agent.workdir": "Working directory (optional)",
+    "DesktopSettings.agent.repo": "Repo URL (optional)",
+    "DesktopSettings.agent.instances": "Duty instances",
+    "DesktopSettings.agent.instanceStop": "Stop",
+    "DesktopSettings.agent.instanceLogs": "Logs",
   },
   zh: {
     "DesktopSettings.control.label": "应用设置",
@@ -72,6 +77,11 @@ export const DesktopSettingsStrings: LocaleDict = {
     "DesktopSettings.agent.logs.label": "本机 agent 日志",
     "DesktopSettings.agent.logs.loading": "正在加载日志",
     "DesktopSettings.agent.logs.empty": "暂无日志。",
+    "DesktopSettings.agent.workdir": "工作目录（可选）",
+    "DesktopSettings.agent.repo": "仓库地址（可选）",
+    "DesktopSettings.agent.instances": "值守实例",
+    "DesktopSettings.agent.instanceStop": "停止",
+    "DesktopSettings.agent.instanceLogs": "日志",
   },
 };
 

--- a/web/src/lib/desktopAgent.test.ts
+++ b/web/src/lib/desktopAgent.test.ts
@@ -17,7 +17,16 @@ describe("desktop agent native adapter", () => {
           role: "worker",
         }];
       }
-      if (command === "desktop_agent_logs") return ["ready", "watching #agentparty"];
+      if (command === "desktop_agent_logs" || command === "desktop_agent_logs_instance") {
+        return ["ready", "watching #agentparty"];
+      }
+      if (command === "desktop_agent_status_all") {
+        return [{
+          state: "stopped", pid: null, configId: null, name: null, channel: null, runner: null,
+          startedAt: null, exitCode: null, lastError: null,
+          instanceId: "local-main:agentparty", workdir: "/tmp/duty", repo: null,
+        }];
+      }
       return {
         state: command === "desktop_agent_start" ? "running" : "stopped",
         pid: command === "desktop_agent_start" ? 42 : null,
@@ -37,10 +46,18 @@ describe("desktop agent native adapter", () => {
     expect((await adapter.start({ configId: "local-main", channel: "agentparty", runner: "codex" })).pid).toBe(42);
     expect((await adapter.stop()).state).toBe("stopped");
     expect(await adapter.logs()).toEqual(["ready", "watching #agentparty"]);
-    expect(calls).toEqual([
+    expect((await adapter.statusAll())[0]!.state).toBe("stopped");
+    expect((await adapter.stopInstance("local-main:agentparty")).state).toBe("stopped");
+    expect(await adapter.logsInstance("local-main:agentparty")).toEqual(["ready", "watching #agentparty"]);
+    expect(calls.slice(-3)).toEqual([
+      { command: "desktop_agent_status_all", args: undefined },
+      { command: "desktop_agent_stop_instance", args: { instanceId: "local-main:agentparty" } },
+      { command: "desktop_agent_logs_instance", args: { instanceId: "local-main:agentparty" } },
+    ]);
+    expect(calls.slice(0, 5)).toEqual([
       { command: "desktop_agent_list_configs", args: undefined },
       { command: "desktop_agent_status", args: undefined },
-      { command: "desktop_agent_start", args: { configId: "local-main", channel: "agentparty", runner: "codex" } },
+      { command: "desktop_agent_start", args: { configId: "local-main", channel: "agentparty", runner: "codex", workdir: null, repo: null } },
       { command: "desktop_agent_stop", args: undefined },
       { command: "desktop_agent_logs", args: undefined },
     ]);

--- a/web/src/lib/desktopAgent.ts
+++ b/web/src/lib/desktopAgent.ts
@@ -20,20 +20,30 @@ export interface DesktopAgentStatus {
   startedAt: number | null;
   exitCode: number | null;
   lastError: string | null;
+  // #616 多实例字段；旧 shell 不下发时为 null（parse 兜底），面板据此回退单实例视图。
+  instanceId: string | null;
+  workdir: string | null;
+  repo: string | null;
 }
 
 export interface DesktopAgentStartInput {
   configId: string;
   channel: string;
   runner: DesktopAgentRunner;
+  workdir?: string;
+  repo?: string;
 }
 
 export interface DesktopAgentAdapter {
   listConfigs(): Promise<DesktopAgentConfig[]>;
   status(): Promise<DesktopAgentStatus>;
+  /** #616：全部实例（含终止态）。旧 shell 无此命令时 reject——调用方回退 status()。 */
+  statusAll(): Promise<DesktopAgentStatus[]>;
   start(input: DesktopAgentStartInput): Promise<DesktopAgentStatus>;
   stop(): Promise<DesktopAgentStatus>;
+  stopInstance(instanceId: string): Promise<DesktopAgentStatus>;
   logs(): Promise<string[]>;
+  logsInstance(instanceId: string): Promise<string[]>;
 }
 
 export type DesktopAgentInvoker = <T>(command: string, args?: Record<string, unknown>) => Promise<T>;
@@ -91,6 +101,8 @@ function parseStatus(value: unknown): DesktopAgentStatus {
     !isNullableNumber(value.exitCode) ||
     !isNullableString(value.lastError)
   ) throw new Error("invalid desktop agent status");
+  // #616 的三个新字段对旧 shell 是 undefined——按 null 归一，不因缺字段拒帧。
+  const optional = (field: unknown): string | null => (typeof field === "string" ? field : null);
   return {
     state,
     pid: value.pid,
@@ -101,6 +113,9 @@ function parseStatus(value: unknown): DesktopAgentStatus {
     startedAt: value.startedAt,
     exitCode: value.exitCode,
     lastError: value.lastError,
+    instanceId: optional(value.instanceId),
+    workdir: optional(value.workdir),
+    repo: optional(value.repo),
   };
 }
 
@@ -119,18 +134,31 @@ export function createDesktopAgentAdapter(invoke: DesktopAgentInvoker): DesktopA
     async status() {
       return parseStatus(await invoke<unknown>("desktop_agent_status"));
     },
+    async statusAll() {
+      const value = await invoke<unknown>("desktop_agent_status_all");
+      if (!Array.isArray(value)) throw new Error("invalid desktop agent status list");
+      return value.map(parseStatus);
+    },
     async start(input) {
       return parseStatus(await invoke<unknown>("desktop_agent_start", {
         configId: input.configId,
         channel: input.channel,
         runner: input.runner,
+        workdir: input.workdir ?? null,
+        repo: input.repo ?? null,
       }));
     },
     async stop() {
       return parseStatus(await invoke<unknown>("desktop_agent_stop"));
     },
+    async stopInstance(instanceId) {
+      return parseStatus(await invoke<unknown>("desktop_agent_stop_instance", { instanceId }));
+    },
     async logs() {
       return parseLogs(await invoke<unknown>("desktop_agent_logs"));
+    },
+    async logsInstance(instanceId) {
+      return parseLogs(await invoke<unknown>("desktop_agent_logs_instance", { instanceId }));
     },
   };
 }

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -313,7 +313,14 @@
   gap: 8px;
   min-width: 0;
 }
-.desktop-agent-instance-name { font-size: 12px; flex: none; }
+.desktop-agent-instance-name {
+  font-size: 12px;
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .desktop-agent-instance-dir {
   font-size: 11px;
   color: var(--t-dim);

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -298,6 +298,32 @@
 .desktop-agent-fields select:focus-visible,
 .desktop-agent-fields input:focus-visible { border-color: var(--t-accent); outline: 1px solid var(--t-accent); }
 .desktop-agent-empty,
+/* #616 多实例值守列表 */
+.desktop-agent-instances {
+  list-style: none;
+  margin: 10px 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.desktop-agent-instance {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+.desktop-agent-instance-name { font-size: 12px; flex: none; }
+.desktop-agent-instance-dir {
+  font-size: 11px;
+  color: var(--t-dim);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+  flex: 1;
+}
+
 .desktop-agent-detail,
 .desktop-agent-error { margin: 7px 0 0; overflow-wrap: anywhere; font-size: 10px; line-height: 1.4; }
 .desktop-agent-empty,


### PR DESCRIPTION
## 背景

#616（owner 拍板）：无人值守值守应由桌面客户端管理。桌面端已有单实例地基（agent.rs 的 start/stop/status/logs + 内嵌 party sidecar），本 PR 落第 1、2 块；第 3 块（launchd 系统级常驻）与第 4 块（web 一键接管 deep link）后续单独 PR。

## 改动

### Rust（desktop/src-tauri/src/agent.rs）

- `AgentManager` 单 slot → `HashMap<instance_id, ManagedAgent>`，`instance_id = config_id:channel`。一机多值守；活跃实例上限 8（资源兜底，非产品限制）；终止态实例保留供展示与重启
- 新 tauri 命令：`desktop_agent_status_all` / `desktop_agent_stop_instance` / `desktop_agent_logs_instance`
- **旧命令全兼容**：`status` 返回主实例（活跃优先）、`stop` 停全部（旧 UI 只可能起过一个，语义等价）、`logs` 多实例时带 `[name#channel]` 前缀合并——旧版下载 UI 打新 shell 不破；`AgentRuntime` 新增 instanceId/workdir/repo 字段（旧 UI 忽略未知字段）
- `--workdir`：必须已存在的绝对路径目录（错误宁拒绝，不让 serve 静默落默认目录）；`--repo`：限 http(s)/ssh/git@ 且无空白/控制字符（挡 `--upload-pack` 形注入），二者透传给 `party serve`
- 事件泵/停止收敛/kill_on_exit 全部按实例隔离，generation 防串号逻辑保持

### Web（DesktopAgentPanel + desktopAgent adapter）

- adapter 增 `statusAll/stopInstance/logsInstance` 与 start 的 workdir/repo 透传；parseStatus 对旧 shell 缺字段按 null 归一
- 面板：实例列表（状态 chip / 身份 / workdir / 每行停止+日志按钮）；workdir/repo 输入框；同键（同身份同频道）实例活跃时禁用启动、其它频道可再起；**statusAll 探测一次失败即回退旧单实例视图**（版本偏斜安全：新 UI + 旧 shell 也能用）

## 测试

- Rust：workdir/repo 校验（含注入形参与超长拒绝）、instance_key、runtime 转移含新字段——cargo test 79 通过
- Web：多实例渲染/每行 stopInstance/start 透传 workdir+repo/同键禁用异键放行/旧 shell 回退路径（默认 mock 即旧 shell）——check:web 871 通过（tests+tsc+vite build）

Refs #616（不 close：第 3、4 块未落）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 桌面端支持多实例同时运行与管理。
  * 可为每个实例配置工作目录和仓库地址；新增实例列表，可查看单实例日志并停止单个实例。
* **改进**
  * 多实例状态/日志支持聚合展示；启动/停止后自动刷新实例列表与主状态。
  * 启动时加入工作目录/仓库地址校验，并在多实例启用时相应禁用输入以降低误操作；活跃并发上限为 8，避免重复启动。
* **文档/界面**
  * 补充多实例相关中英文文案与列表样式。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->