### PR TITLE
fix(hook/worker): #617 评审三条 follow-up——settings 原子写 + scope 显式拒 + waiting_input 紧急档

### DIFF
--- a/cli/src/atomic-json.ts
+++ b/cli/src/atomic-json.ts
@@ -1,11 +1,18 @@
 import { randomUUID } from "node:crypto";
-import { chmodSync, mkdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, renameSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
 
-/** 原子写文本（tmp+rename）：settings 这类「用户手写、半截即毁」的文件绝不能直写。 */
-export function atomicWriteText(path: string, text: string, mode: number = 0o644): void {
+/** 原子写文本（tmp+rename）：settings 这类「用户手写、半截即毁」的文件绝不能直写。
+ * 目标已存在时沿用其现有权限（用户可能自行收紧过），不存在才用 defaultMode（CodeRabbit #619）。 */
+export function atomicWriteText(path: string, text: string, defaultMode: number = 0o644): void {
   const dir = dirname(path);
   mkdirSync(dir, { recursive: true });
+  let mode = defaultMode;
+  try {
+    mode = statSync(path).mode & 0o777;
+  } catch {
+    // 文件不存在：用默认权限
+  }
   const tmp = join(dir, `.${basename(path)}.${process.pid}.${randomUUID()}.tmp`);
   try {
     writeFileSync(tmp, text, { flag: "wx", mode });

--- a/cli/src/atomic-json.ts
+++ b/cli/src/atomic-json.ts
@@ -2,6 +2,20 @@ import { randomUUID } from "node:crypto";
 import { chmodSync, mkdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
 
+/** 原子写文本（tmp+rename）：settings 这类「用户手写、半截即毁」的文件绝不能直写。 */
+export function atomicWriteText(path: string, text: string, mode: number = 0o644): void {
+  const dir = dirname(path);
+  mkdirSync(dir, { recursive: true });
+  const tmp = join(dir, `.${basename(path)}.${process.pid}.${randomUUID()}.tmp`);
+  try {
+    writeFileSync(tmp, text, { flag: "wx", mode });
+    renameSync(tmp, path);
+  } catch (error) {
+    rmSync(tmp, { force: true });
+    throw error;
+  }
+}
+
 export function atomicWriteJson(path: string, value: unknown, mode: number = 0o600): void {
   const dir = dirname(path);
   mkdirSync(dir, { recursive: true });

--- a/cli/src/commands/hook.ts
+++ b/cli/src/commands/hook.ts
@@ -10,13 +10,13 @@
 //   1. stdout 永远为空——hook 的 stdout 会被灌进模型上下文；
 //   2. 任何失败都静默 exit 0——exit 2 会 block 模型的工具调用，坏 JSON/写盘失败都不配阻断模型；
 //   3. 本体不等网络——上行要么归 serve 心跳，要么交给 detached 子进程。
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { dirname, join } from "node:path";
+import { join } from "node:path";
 import { AGENT_ACTIVITY_TTL_MS, type AgentActivity } from "@agentparty/shared";
 import { activityFromHookEvent, readActivityFile, writeActivityFile } from "../activity";
 import { agentpartyHome, readState } from "../config";
-import { atomicWriteJson } from "../atomic-json";
+import { atomicWriteJson, atomicWriteText } from "../atomic-json";
 import { isHelpArg } from "../args";
 import { isPartyBinaryPath } from "../upgrade";
 
@@ -81,7 +81,10 @@ export function activityTargetFile(
  * 未来时间戳（时钟回跳后残留的标记）视为无效——否则时钟追上前会永久静默。 */
 export function shouldPushActivity(activity: AgentActivity, lastPushTs: number | null, now: number): boolean {
   if (lastPushTs === null || lastPushTs > now) return true;
-  const interval = activity.phase === "waiting_permission" ? PUSH_INTERVAL_URGENT_MS : PUSH_INTERVAL_MS;
+  // waiting_input 与 waiting_permission 同级：都是「无人值守卡死等人」，#608 UI 也同级高亮。
+  const interval = activity.phase === "waiting_permission" || activity.phase === "waiting_input"
+    ? PUSH_INTERVAL_URGENT_MS
+    : PUSH_INTERVAL_MS;
   return now - lastPushTs >= interval;
 }
 
@@ -268,8 +271,8 @@ async function runInstall(argv: string[]): Promise<number> {
     console.error(`无法解析 ${termText(path)}（${termText(e instanceof Error ? e.message : String(e))}）；请先手工修复该文件`);
     return 1;
   }
-  mkdirSync(dirname(path), { recursive: true });
-  writeFileSync(path, next);
+  // 进程死在写中途会留半截 JSON——毁掉的正是 merge 拼命保护的用户手写配置（#617 评审）。
+  atomicWriteText(path, next);
   console.log(`hooks installed -> ${termText(path)}`);
   console.log("任何在此生效范围内的 Claude Code session（交互或 -p）都会把活动上报进频道 presence。");
   return 0;
@@ -289,7 +292,7 @@ async function runUninstall(argv: string[]): Promise<number> {
     console.error(`无法解析 ${termText(path)}（${termText(e instanceof Error ? e.message : String(e))}）；请先手工修复该文件`);
     return 1;
   }
-  writeFileSync(path, next);
+  atomicWriteText(path, next);
   console.log(`hooks removed <- ${termText(path)}`);
   return 0;
 }

--- a/cli/test/hook-install.test.ts
+++ b/cli/test/hook-install.test.ts
@@ -85,6 +85,12 @@ describe("shouldPushActivity (#615)", () => {
     // 未来标记（时钟回跳残留）视为无效：立即放行，而不是永久静默到时钟追上
     expect(shouldPushActivity(tool, NOW + 60_000, NOW)).toBe(true);
   });
+
+  test("waiting_input 与 waiting_permission 同级紧急档（#617 评审 follow-up）", () => {
+    const input = { phase: "waiting_input" as const, ts: NOW };
+    expect(shouldPushActivity(input, NOW - PUSH_INTERVAL_URGENT_MS + 1, NOW)).toBe(false);
+    expect(shouldPushActivity(input, NOW - PUSH_INTERVAL_URGENT_MS, NOW)).toBe(true);
+  });
 });
 
 describe("party hook install end-to-end (project scope)", () => {

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -7313,6 +7313,12 @@ app.post("/api/channels/:slug/presence/:name/activity", async (c) => {
   if (identity.kind !== "agent" || identity.name !== name) {
     return c.json(errorBody("forbidden", "an agent may only report its own activity"), 403);
   }
+  // 防御纵深（#617 评审）：现状 token 名全局唯一 + scoped token 无法 attach 到 scope 外频道，
+  // 本无冒充面；但同族端点（pause/resume）的惯例是显式拒 scope 外频道——安全在本端点自证，
+  // 不依赖远处那张表的唯一约束永远成立。
+  if (identity.channel_scope != null && identity.channel_scope !== slug) {
+    return c.json(errorBody("forbidden", "token is scoped to another channel"), 403);
+  }
   const body = (await c.req.json().catch(() => null)) as { activity?: unknown } | null;
   if (body?.activity === undefined) {
     return c.json(errorBody("bad_request", "activity required"), 400);

--- a/worker/test/presence-activity-rest.spec.ts
+++ b/worker/test/presence-activity-rest.spec.ts
@@ -82,6 +82,14 @@ describe("interactive-lane activity self-report (issue #615)", () => {
     ws.close();
   });
 
+  it("a token scoped to another channel is rejected even for its own name (#617 follow-up)", async () => {
+    const agent = await seedToken("agent");
+    const slug = await createChannel(agent.token);
+    const scoped = await seedToken("agent", uniq("scoped"), { channelScope: uniq("elsewhere") });
+    const res = await postActivity(slug, scoped.token, scoped.name, { phase: "working", ts: Date.now() });
+    expect(res.status).toBe(403);
+  });
+
   it("a stale activity (past the 5min TTL) is not serialized into presence", async () => {
     const agent = await seedToken("agent");
     const slug = await createChannel(agent.token);


### PR DESCRIPTION
#617 合并时我在 review 里留的三条（https://github.com/leeguooooo/AgentParty/pull/617#pullrequestreview 评论）未及处理，本 PR 补上：

1. **[medium] settings 文件原子写**：`party hook install/uninstall` 原来 `writeFileSync` 直写 `.claude/settings.local.json` / `~/.claude/settings.json`——进程死在写中途留半截 JSON，毁掉的正是 merge 逻辑拼命保护的用户手写配置（且此后 install/uninstall 全部因坏 JSON 拒绝，只能手修）。新增 `atomicWriteText`（tmp+rename，与 `atomicWriteJson` 同模式）。

2. **[defense-in-depth] activity 端点显式 scope 拒**：`POST /presence/:name/activity` 补 `channel_scope != slug → 403`。现状 token 名全局唯一 + scoped token 无法 attach 到 scope 外频道，没有可利用面；但同族端点 pause/resume（agentReceptionController）的惯例是显式拒——安全在本端点自证，不依赖远处那张表的唯一约束永远成立。

3. **[对齐] waiting_input 纳入紧急节流档**：与 waiting_permission 同为「无人值守卡死等人」的状态，#608 UI 同级高亮，但原来只有 permission 走 3s 档、input 要等 15s 窗口。口径对齐。

## 测试
- cli：hook-install 套件 + 新增 waiting_input 紧急档断言——985 全过
- worker：presence-activity-rest 新增「scope 外频道 403」用例——6 过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 增强活动状态上报权限校验：当凭证属于 agent 且其授权范围与目标频道不一致时，返回 403 并拒绝上报。
  * 等待输入/等待授权阶段的活动上报节流策略升级为更及时的紧急间隔。
* **错误修复**
  * 改进设置写入流程：在安装/卸载钩子时采用原子写入，避免异常导致 JSON 配置残缺。
* **测试**
  * 扩展活动上报间隔与 scope 拒绝场景用例覆盖范围。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->