### PR TITLE
feat(desktop): launchd 系统级常驻值守（#616 第 3 块）

### DIFF
--- a/desktop/src-tauri/src/agent.rs
+++ b/desktop/src-tauri/src/agent.rs
@@ -331,7 +331,7 @@ pub(crate) fn parse_config_summary(path: &Path) -> Result<AgentConfigSummary, St
     })
 }
 
-fn resolve_config(config_id: &str) -> Result<(PathBuf, AgentConfigSummary), String> {
+pub(crate) fn resolve_config(config_id: &str) -> Result<(PathBuf, AgentConfigSummary), String> {
     trusted_configs(&agentparty_home()?)?
         .into_iter()
         .find(|(_, summary)| summary.config_id == config_id)
@@ -540,6 +540,16 @@ impl AgentManager {
         Ok(Self::primary_runtime(&instances))
     }
 
+    /// #616 phase 3：转系统常驻前停掉 app 内同键实例（同身份双 serve 会互抢租约）。
+    /// 实例不存在不是错——常驻可以直接从表单发起。
+    pub(crate) async fn stop_instance_for_duty(&self, instance_id: &str) -> Result<(), String> {
+        match self.stop_instance_key(instance_id).await {
+            Ok(_) => Ok(()),
+            Err(error) if error.contains("unknown desktop agent instance") => Ok(()),
+            Err(error) => Err(error),
+        }
+    }
+
     pub(crate) fn kill_on_exit(&self) {
         if let Ok(mut instances) = self.0.lock() {
             for agent in instances.values_mut() {
@@ -645,7 +655,7 @@ pub(crate) async fn desktop_agent_stop_instance(
 }
 
 /// workdir 必须是已存在的绝对路径目录——错误路径宁可拒绝，不能让 serve 静默落到默认目录。
-fn validate_workdir(workdir: &str) -> Result<&str, String> {
+pub(crate) fn validate_workdir(workdir: &str) -> Result<&str, String> {
     let path = Path::new(workdir);
     if !path.is_absolute() {
         return Err("workdir must be an absolute path".to_string());
@@ -657,7 +667,7 @@ fn validate_workdir(workdir: &str) -> Result<&str, String> {
 }
 
 /// repo 只透传给 `party serve --repo`（serve 内部 git clone/pull）；这里挡明显的坏值与注入面。
-fn validate_repo(repo: &str) -> Result<&str, String> {
+pub(crate) fn validate_repo(repo: &str) -> Result<&str, String> {
     let valid_scheme = repo.starts_with("https://")
         || repo.starts_with("http://")
         || repo.starts_with("ssh://")

--- a/desktop/src-tauri/src/duty.rs
+++ b/desktop/src-tauri/src/duty.rs
@@ -1,0 +1,404 @@
+// #616 第 3 块：系统级常驻值守（launchd）。
+// 桌面 app 进程内的 serve child 随 app 退出而死，与「无人值守」自相矛盾；本模块把一个
+// 值守实例落成 macOS LaunchAgent：RunAtLoad + KeepAlive，退出 app 不断线、重启机器自动拉起。
+//
+// 安全边界（#221 教训）：plist 里绝不放 token——只放 AGENTPARTY_CONFIG 的文件路径；
+// 二进制拷贝到 ~/.agentparty/desktop/bin 的稳定路径（app bundle 路径随更新/挪动会失效），
+// 并给 serve 挂 --auto-upgrade，让常驻进程在 wake 间隙自行换新。
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+};
+
+use serde::Serialize;
+
+#[cfg(desktop)]
+use tauri::{AppHandle, Manager, State};
+
+use crate::agent::{validate_channel, validate_runner};
+
+pub(crate) const DUTY_LABEL_PREFIX: &str = "com.agentparty.duty.";
+
+/// launchd label 只收 [A-Za-z0-9.-]：instance_id 的 config_id 是 sha256 hex、channel 是 slug，
+/// 唯一的越界字符是分隔用的冒号——映射成 '.'；其余越界字符一律 '-'（防御，不该出现）。
+pub(crate) fn duty_label(instance_id: &str) -> String {
+    let safe: String = instance_id
+        .chars()
+        .map(|value| match value {
+            'a'..='z' | 'A'..='Z' | '0'..='9' | '.' | '-' => value,
+            ':' => '.',
+            _ => '-',
+        })
+        .collect();
+    format!("{DUTY_LABEL_PREFIX}{safe}")
+}
+
+fn xml_escape(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+
+pub(crate) struct DutyPlistSpec<'a> {
+    pub(crate) label: &'a str,
+    pub(crate) party_bin: &'a str,
+    pub(crate) config_path: &'a str,
+    pub(crate) channel: &'a str,
+    pub(crate) runner: &'a str,
+    pub(crate) workdir: Option<&'a str>,
+    pub(crate) repo: Option<&'a str>,
+    pub(crate) log_path: &'a str,
+}
+
+/// 生成 LaunchAgent plist。token 绝不入内——只引用 config 文件路径。
+pub(crate) fn duty_plist_content(spec: &DutyPlistSpec<'_>) -> String {
+    let mut args: Vec<String> = vec![
+        spec.party_bin.to_string(),
+        "serve".to_string(),
+        spec.channel.to_string(),
+        "--runner".to_string(),
+        spec.runner.to_string(),
+        // 常驻进程没有 app 帮它换新二进制：wake 间隙发现磁盘上有更新的 party 就自我重启（#45 机制）。
+        "--auto-upgrade".to_string(),
+    ];
+    if let Some(dir) = spec.workdir {
+        args.push("--workdir".to_string());
+        args.push(dir.to_string());
+    }
+    if let Some(url) = spec.repo {
+        args.push("--repo".to_string());
+        args.push(url.to_string());
+    }
+    let args_xml: String = args
+        .iter()
+        .map(|value| format!("    <string>{}</string>\n", xml_escape(value)))
+        .collect();
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>{label}</string>
+  <key>ProgramArguments</key>
+  <array>
+{args_xml}  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>AGENTPARTY_CONFIG</key>
+    <string>{config}</string>
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>ProcessType</key>
+  <string>Background</string>
+  <key>StandardOutPath</key>
+  <string>{log}</string>
+  <key>StandardErrorPath</key>
+  <string>{log}</string>
+</dict>
+</plist>
+"#,
+        label = xml_escape(spec.label),
+        args_xml = args_xml,
+        config = xml_escape(spec.config_path),
+        log = xml_escape(spec.log_path),
+    )
+}
+
+fn home_dir() -> Result<PathBuf, String> {
+    env::var_os("HOME")
+        .map(PathBuf::from)
+        .ok_or_else(|| "cannot locate the home directory".to_string())
+}
+
+pub(crate) fn duty_plist_path(home: &Path, label: &str) -> PathBuf {
+    home.join("Library/LaunchAgents").join(format!("{label}.plist"))
+}
+
+pub(crate) fn duty_log_path(home: &Path, label: &str) -> PathBuf {
+    home.join(".agentparty/desktop/logs").join(format!("{label}.log"))
+}
+
+pub(crate) fn duty_bin_path(home: &Path) -> PathBuf {
+    home.join(".agentparty/desktop/bin/party")
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct DutyEntry {
+    pub(crate) label: String,
+    pub(crate) instance_id: String,
+    pub(crate) plist_path: String,
+    pub(crate) log_path: String,
+    pub(crate) loaded: bool,
+}
+
+/// 从 plist 文件名还原 instance_id 的展示形态：label 里 config_id 与 channel 以最后一个 '.' 相接。
+/// （config_id 是 hex，不含 '.'；channel 是 slug，也不含 '.'——所以最后一个 '.' 就是原来的 ':'。）
+pub(crate) fn instance_id_from_label(label: &str) -> Option<String> {
+    let rest = label.strip_prefix(DUTY_LABEL_PREFIX)?;
+    let (config, channel) = rest.rsplit_once('.')?;
+    Some(format!("{config}:{channel}"))
+}
+
+#[cfg(all(desktop, target_os = "macos"))]
+fn launchctl(args: &[&str]) -> Result<std::process::Output, String> {
+    std::process::Command::new("launchctl")
+        .args(args)
+        .output()
+        .map_err(|error| format!("failed to run launchctl: {error}"))
+}
+
+#[cfg(all(desktop, target_os = "macos"))]
+fn gui_domain() -> String {
+    // launchctl 的 GUI 域按 uid 定位；桌面 app 恒跑在登录用户会话里。
+    // 不引 libc：`id -u` 是 POSIX 标配，一次性调用开销可忽略。
+    let uid = std::process::Command::new("id")
+        .arg("-u")
+        .output()
+        .ok()
+        .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_string())
+        .unwrap_or_default();
+    format!("gui/{uid}")
+}
+
+#[cfg(all(desktop, target_os = "macos"))]
+fn duty_loaded(label: &str) -> bool {
+    launchctl(&["print", &format!("{}/{label}", gui_domain())])
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+}
+
+/// 把当前 app 内嵌的 party sidecar 拷贝到稳定路径（bundle 路径随 app 更新/挪动失效）。
+#[cfg(desktop)]
+fn ensure_duty_binary(app: &AppHandle, home: &Path) -> Result<PathBuf, String> {
+    let target = duty_bin_path(home);
+    if let Some(parent) = target.parent() {
+        fs::create_dir_all(parent).map_err(|error| format!("cannot create duty bin dir: {error}"))?;
+    }
+    // tauri sidecar 的真实路径：<resource>/binaries 之外，运行期在可执行文件旁（externalBin 约定）。
+    let sidecar = app
+        .path()
+        .resolve("party", tauri::path::BaseDirectory::Executable)
+        .map_err(|error| format!("cannot resolve party sidecar path: {error}"))?;
+    let source = if sidecar.exists() {
+        sidecar
+    } else {
+        // dev 模式（未打包）：可执行目录里是带 target triple 的名字
+        let dir = sidecar.parent().map(Path::to_path_buf).unwrap_or_default();
+        fs::read_dir(&dir)
+            .ok()
+            .and_then(|entries| {
+                entries
+                    .flatten()
+                    .map(|entry| entry.path())
+                    .find(|path| {
+                        path.file_name()
+                            .and_then(|name| name.to_str())
+                            .is_some_and(|name| name.starts_with("party"))
+                    })
+            })
+            .ok_or_else(|| "party sidecar binary not found next to the app executable".to_string())?
+    };
+    // 先写临时名再原子 rename：正在运行的旧常驻进程继续持有旧 inode，不会被写坏。
+    let tmp = target.with_extension("tmp");
+    fs::copy(&source, &tmp).map_err(|error| format!("cannot stage duty binary: {error}"))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = fs::set_permissions(&tmp, fs::Permissions::from_mode(0o755));
+    }
+    fs::rename(&tmp, &target).map_err(|error| format!("cannot install duty binary: {error}"))?;
+    Ok(target)
+}
+
+#[cfg(desktop)]
+#[tauri::command]
+pub(crate) fn desktop_duty_list() -> Result<Vec<DutyEntry>, String> {
+    let home = home_dir()?;
+    let agents_dir = home.join("Library/LaunchAgents");
+    let mut entries = Vec::new();
+    let Ok(dir) = fs::read_dir(&agents_dir) else {
+        return Ok(entries);
+    };
+    for item in dir.flatten() {
+        let name = item.file_name();
+        let Some(name) = name.to_str() else { continue };
+        let Some(label) = name.strip_suffix(".plist") else { continue };
+        if !label.starts_with(DUTY_LABEL_PREFIX) {
+            continue;
+        }
+        let Some(instance_id) = instance_id_from_label(label) else { continue };
+        entries.push(DutyEntry {
+            label: label.to_string(),
+            instance_id,
+            plist_path: item.path().to_string_lossy().into_owned(),
+            log_path: duty_log_path(&home, label).to_string_lossy().into_owned(),
+            #[cfg(target_os = "macos")]
+            loaded: duty_loaded(label),
+            #[cfg(not(target_os = "macos"))]
+            loaded: false,
+        });
+    }
+    entries.sort_by(|left, right| left.label.cmp(&right.label));
+    Ok(entries)
+}
+
+#[cfg(desktop)]
+#[tauri::command]
+pub(crate) async fn desktop_duty_persist(
+    app: AppHandle,
+    agent_state: State<'_, crate::agent::AgentManager>,
+    config_id: String,
+    channel: String,
+    runner: String,
+    workdir: Option<String>,
+    repo: Option<String>,
+) -> Result<DutyEntry, String> {
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = (app, agent_state, config_id, channel, runner, workdir, repo);
+        return Err("system-level duty is currently macOS-only (launchd)".to_string());
+    }
+    #[cfg(target_os = "macos")]
+    {
+        validate_channel(&channel)?;
+        validate_runner(&runner)?;
+        if let Some(dir) = workdir.as_deref() {
+            crate::agent::validate_workdir(dir)?;
+        }
+        if let Some(url) = repo.as_deref() {
+            crate::agent::validate_repo(url)?;
+        }
+        let (config_path, _summary) = crate::agent::resolve_config(&config_id)?;
+        let home = home_dir()?;
+        let instance_id = format!("{config_id}:{channel}");
+        let label = duty_label(&instance_id);
+
+        // 同一实例不允许 app 内 child 与 launchd 常驻双跑（同身份两个 serve 会互抢租约）：
+        // 先停掉 app 内的同键实例。
+        let _ = agent_state.stop_instance_for_duty(&instance_id).await;
+
+        let party_bin = ensure_duty_binary(&app, &home)?;
+        let log_path = duty_log_path(&home, &label);
+        if let Some(parent) = log_path.parent() {
+            fs::create_dir_all(parent).map_err(|error| format!("cannot create duty log dir: {error}"))?;
+        }
+        let plist = duty_plist_content(&DutyPlistSpec {
+            label: &label,
+            party_bin: &party_bin.to_string_lossy(),
+            config_path: &config_path.to_string_lossy(),
+            channel: &channel,
+            runner: &runner,
+            workdir: workdir.as_deref(),
+            repo: repo.as_deref(),
+            log_path: &log_path.to_string_lossy(),
+        });
+        let plist_path = duty_plist_path(&home, &label);
+        if let Some(parent) = plist_path.parent() {
+            fs::create_dir_all(parent).map_err(|error| format!("cannot create LaunchAgents dir: {error}"))?;
+        }
+        let tmp = plist_path.with_extension("plist.tmp");
+        fs::write(&tmp, plist).map_err(|error| format!("cannot write duty plist: {error}"))?;
+        fs::rename(&tmp, &plist_path).map_err(|error| format!("cannot install duty plist: {error}"))?;
+
+        // 已加载的旧实例先卸再装（幂等重装）；bootout 对未加载的 label 报错，忽略。
+        let domain = gui_domain();
+        let _ = launchctl(&["bootout", &format!("{domain}/{label}")]);
+        let boot = launchctl(&["bootstrap", &domain, &plist_path.to_string_lossy()])?;
+        if !boot.status.success() {
+            let detail = String::from_utf8_lossy(&boot.stderr);
+            return Err(format!(
+                "launchctl bootstrap failed: {}",
+                detail.trim().chars().take(200).collect::<String>()
+            ));
+        }
+        Ok(DutyEntry {
+            label: label.clone(),
+            instance_id,
+            plist_path: plist_path.to_string_lossy().into_owned(),
+            log_path: log_path.to_string_lossy().into_owned(),
+            loaded: duty_loaded(&label),
+        })
+    }
+}
+
+#[cfg(desktop)]
+#[tauri::command]
+pub(crate) fn desktop_duty_unpersist(instance_id: String) -> Result<(), String> {
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = instance_id;
+        Err("system-level duty is currently macOS-only (launchd)".to_string())
+    }
+    #[cfg(target_os = "macos")]
+    {
+        let home = home_dir()?;
+        let label = duty_label(&instance_id);
+        let plist_path = duty_plist_path(&home, &label);
+        // 先 bootout 再删 plist：顺序反了会留一个「加载中但文件已没了」的孤儿任务。
+        let _ = launchctl(&["bootout", &format!("{}/{label}", gui_domain())]);
+        if plist_path.exists() {
+            fs::remove_file(&plist_path).map_err(|error| format!("cannot remove duty plist: {error}"))?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{duty_label, duty_plist_content, instance_id_from_label, DutyPlistSpec};
+
+    #[test]
+    fn label_maps_colon_to_dot_and_round_trips() {
+        let label = duty_label("abc123:native-r4");
+        assert_eq!(label, "com.agentparty.duty.abc123.native-r4");
+        assert_eq!(instance_id_from_label(&label).as_deref(), Some("abc123:native-r4"));
+        assert_eq!(instance_id_from_label("com.other.thing"), None);
+    }
+
+    #[test]
+    fn plist_never_contains_tokens_and_escapes_xml() {
+        let plist = duty_plist_content(&DutyPlistSpec {
+            label: "com.agentparty.duty.x.dev",
+            party_bin: "/Users/leo/.agentparty/desktop/bin/party",
+            config_path: "/Users/leo/.agentparty/agents/agentparty-a&b-dev.json",
+            channel: "dev",
+            runner: "claude",
+            workdir: Some("/srv/<duty>"),
+            repo: None,
+            log_path: "/Users/leo/.agentparty/desktop/logs/x.log",
+        });
+        assert!(plist.contains("a&amp;b"));
+        assert!(plist.contains("&lt;duty&gt;"));
+        assert!(!plist.contains("ap_"));
+        assert!(plist.contains("<key>RunAtLoad</key>"));
+        assert!(plist.contains("<string>--auto-upgrade</string>"));
+        assert!(plist.contains("<key>AGENTPARTY_CONFIG</key>"));
+        // --repo 未指定时绝不出现
+        assert!(!plist.contains("--repo"));
+    }
+
+    #[test]
+    fn plist_includes_workdir_and_repo_when_given() {
+        let plist = duty_plist_content(&DutyPlistSpec {
+            label: "l",
+            party_bin: "/bin/party",
+            config_path: "/cfg.json",
+            channel: "dev",
+            runner: "codex",
+            workdir: Some("/srv/duty"),
+            repo: Some("https://github.com/org/repo.git"),
+            log_path: "/log",
+        });
+        assert!(plist.contains("<string>--workdir</string>"));
+        assert!(plist.contains("<string>/srv/duty</string>"));
+        assert!(plist.contains("<string>--repo</string>"));
+        assert!(plist.contains("<string>https://github.com/org/repo.git</string>"));
+    }
+}

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -15,6 +15,7 @@ use std::collections::BTreeMap;
 use serde::{Deserialize, Serialize};
 
 mod agent;
+mod duty;
 #[cfg(desktop)]
 mod ui_download;
 #[cfg(desktop)]
@@ -1181,7 +1182,10 @@ pub fn run() {
             agent::desktop_agent_stop,
             agent::desktop_agent_stop_instance,
             agent::desktop_agent_logs,
-            agent::desktop_agent_logs_instance
+            agent::desktop_agent_logs_instance,
+            duty::desktop_duty_list,
+            duty::desktop_duty_persist,
+            duty::desktop_duty_unpersist
         ]);
 
     #[cfg(mobile)]

--- a/web/src/components/DesktopAgentPanel.test.tsx
+++ b/web/src/components/DesktopAgentPanel.test.tsx
@@ -48,6 +48,11 @@ function adapter(overrides: Partial<DesktopAgentAdapter> = {}): DesktopAgentAdap
     stopInstance: async () => stopped,
     logs: async () => [],
     logsInstance: async () => [],
+    dutyList: async () => [],
+    dutyPersist: async () => {
+      throw new Error("duty persist unavailable");
+    },
+    dutyUnpersist: async () => {},
     ...overrides,
   };
 }
@@ -170,6 +175,65 @@ describe("DesktopAgentPanel 多实例 (#616)", () => {
     await act(async () => {
       channelInput.props.onChange({ target: { value: "ops" } });
     });
+    expect(button("Start local agent").props.disabled).toBe(false);
+  });
+});
+
+// #616 phase 3：launchd 常驻
+describe("DesktopAgentPanel 系统常驻 (#616 phase 3)", () => {
+  const duty = {
+    label: "com.agentparty.duty.local-main.agentparty",
+    instanceId: "local-main:agentparty",
+    plistPath: "/Users/x/Library/LaunchAgents/com.agentparty.duty.local-main.agentparty.plist",
+    logPath: "/Users/x/.agentparty/desktop/logs/duty.log",
+    loaded: true,
+  };
+
+  test("勾选常驻后启动走 dutyPersist；常驻列表渲染并可卸载", async () => {
+    const persisted: unknown[] = [];
+    const removed: string[] = [];
+    let entries = [duty];
+    const root = await render(adapter({
+      dutyList: async () => entries,
+      dutyPersist: async (input: unknown) => {
+        persisted.push(input);
+        return duty;
+      },
+      dutyUnpersist: async (instanceId: string) => {
+        removed.push(instanceId);
+        entries = [];
+      },
+    }));
+
+    const section = root.find((node) => node.props["aria-label"] === "System resident duty");
+    expect(section.findAllByType("li")).toHaveLength(1);
+    expect(JSON.stringify(renderer!.toJSON())).toContain("resident");
+
+    const persistBox = root.find((node) => node.props.name === "desktop-agent-persist");
+    await act(async () => {
+      persistBox.props.onChange({ target: { checked: true } });
+    });
+    await act(async () => {
+      await button("Start local agent").props.onClick();
+    });
+    expect(persisted).toHaveLength(1);
+    expect((persisted[0] as { channel: string }).channel).toBe("agentparty");
+
+    await act(async () => {
+      await button("Remove local-main:agentparty").props.onClick();
+    });
+    expect(removed).toEqual(["local-main:agentparty"]);
+    expect(root.findAll((node) => node.props["aria-label"] === "System resident duty")).toHaveLength(0);
+  });
+
+  test("dutyList 不可用（非 macOS/旧 shell）：常驻区块与勾选框整体隐藏/禁用，面板其余功能不受影响", async () => {
+    const root = await render(adapter({
+      dutyList: async () => {
+        throw new Error("unsupported");
+      },
+    }));
+    expect(root.findAll((node) => node.props["aria-label"] === "System resident duty")).toHaveLength(0);
+    expect(root.find((node) => node.props.name === "desktop-agent-persist").props.disabled).toBe(true);
     expect(button("Start local agent").props.disabled).toBe(false);
   });
 });

--- a/web/src/components/DesktopAgentPanel.tsx
+++ b/web/src/components/DesktopAgentPanel.tsx
@@ -6,6 +6,7 @@ import {
   type DesktopAgentConfig,
   type DesktopAgentRunner,
   type DesktopAgentStatus,
+  type DesktopDutyEntry,
 } from "../lib/desktopAgent";
 
 const RUNNERS: readonly DesktopAgentRunner[] = ["codex", "claude", "codex-sdk"];
@@ -63,6 +64,9 @@ export function DesktopAgentPanel({ t, adapter = desktopAgentAdapter, scheduler 
   const [runner, setRunner] = useState<DesktopAgentRunner>("codex");
   const [workdir, setWorkdir] = useState("");
   const [repo, setRepo] = useState("");
+  // #616 phase 3：launchd 常驻。duties=null 表示不可用（非 macOS / 旧 shell），整个区块隐藏。
+  const [persistMode, setPersistMode] = useState(false);
+  const [duties, setDuties] = useState<DesktopDutyEntry[] | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [logsOpen, setLogsOpen] = useState(false);
@@ -92,6 +96,11 @@ export function DesktopAgentPanel({ t, adapter = desktopAgentAdapter, scheduler 
   useEffect(() => {
     aliveRef.current = true;
     let active = true;
+    void adapter.dutyList().then((entries) => {
+      if (active) setDuties(entries);
+    }).catch(() => {
+      // 非 macOS / 旧 shell：常驻不可用，静默隐藏
+    });
     void Promise.all([adapter.listConfigs(), fetchStatus()]).then(([nextConfigs, nextStatus]) => {
       if (!active) return;
       setConfigs(nextConfigs);
@@ -202,6 +211,58 @@ export function DesktopAgentPanel({ t, adapter = desktopAgentAdapter, scheduler 
     }
   };
 
+  const persistDuty = async () => {
+    if (operationRef.current) return;
+    operationRef.current = true;
+    setBusy(true);
+    setError(null);
+    try {
+      await adapter.dutyPersist({
+        configId,
+        channel: channel.trim(),
+        runner,
+        workdir: workdir.trim() === "" ? undefined : workdir.trim(),
+        repo: repo.trim() === "" ? undefined : repo.trim(),
+      });
+      const entries = await adapter.dutyList();
+      if (aliveRef.current) setDuties(entries);
+      // 转常驻会顺带停掉 app 内同键实例——刷新实例表别让两处状态漂移
+      if (multiRef.current === true) {
+        try {
+          const all = await adapter.statusAll();
+          if (aliveRef.current) {
+            setInstances(all);
+            setStatus(derivePrimary(all));
+          }
+        } catch {
+          // 下一轮轮询补上
+        }
+      }
+    } catch (cause) {
+      if (aliveRef.current) setError(safeError(cause));
+    } finally {
+      operationRef.current = false;
+      if (aliveRef.current) setBusy(false);
+    }
+  };
+
+  const unpersistDuty = async (instanceId: string) => {
+    if (operationRef.current) return;
+    operationRef.current = true;
+    setBusy(true);
+    setError(null);
+    try {
+      await adapter.dutyUnpersist(instanceId);
+      const entries = await adapter.dutyList();
+      if (aliveRef.current) setDuties(entries);
+    } catch (cause) {
+      if (aliveRef.current) setError(safeError(cause));
+    } finally {
+      operationRef.current = false;
+      if (aliveRef.current) setBusy(false);
+    }
+  };
+
   const openInstanceLogs = async (instanceId: string) => {
     setLogsFor(instanceId);
     setLogsOpen(true);
@@ -292,6 +353,16 @@ export function DesktopAgentPanel({ t, adapter = desktopAgentAdapter, scheduler 
               spellCheck={false}
             />
           </label>
+          <label className="desktop-agent-persist">
+            <input
+              type="checkbox"
+              name="desktop-agent-persist"
+              checked={persistMode}
+              disabled={busy || duties === null}
+              onChange={(event) => setPersistMode(event.target.checked)}
+            />
+            <span>{t("DesktopSettings.agent.persistMode")}</span>
+          </label>
           <label>
             <span>{t("DesktopSettings.agent.repo")}</span>
             <input
@@ -306,6 +377,32 @@ export function DesktopAgentPanel({ t, adapter = desktopAgentAdapter, scheduler 
             />
           </label>
         </div>
+      )}
+
+      {duties !== null && duties.length > 0 && (
+        <section aria-label={t("DesktopSettings.agent.dutyTitle")} className="desktop-agent-duties">
+          <strong className="desktop-agent-duties-title">{t("DesktopSettings.agent.dutyTitle")}</strong>
+          <ul className="desktop-agent-instances">
+            {duties.map((entry) => (
+              <li key={entry.label} className="desktop-agent-instance">
+                <span className={`desktop-agent-state desktop-agent-state--${entry.loaded ? "running" : "stopped"}`}>
+                  {t(entry.loaded ? "DesktopSettings.agent.dutyLoaded" : "DesktopSettings.agent.dutyNotLoaded")}
+                </span>
+                <span className="t-mono desktop-agent-instance-name">{entry.instanceId}</span>
+                <span className="t-mono desktop-agent-instance-dir" title={entry.logPath}>{entry.logPath}</span>
+                <button
+                  type="button"
+                  className="d-btn"
+                  aria-label={`${t("DesktopSettings.agent.dutyUnload")} ${entry.instanceId}`}
+                  disabled={busy}
+                  onClick={() => void unpersistDuty(entry.instanceId)}
+                >
+                  {t("DesktopSettings.agent.dutyUnload")}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </section>
       )}
 
       {instances !== null && instances.length > 0 && (
@@ -376,8 +473,12 @@ export function DesktopAgentPanel({ t, adapter = desktopAgentAdapter, scheduler 
           className="d-btn"
           aria-label={t("DesktopSettings.agent.start")}
           disabled={!canStart}
-          onClick={() =>
-            runOperation(() =>
+          onClick={() => {
+            if (persistMode && duties !== null) {
+              void persistDuty();
+              return;
+            }
+            void runOperation(() =>
               adapter.start({
                 configId,
                 channel: channel.trim(),
@@ -385,8 +486,8 @@ export function DesktopAgentPanel({ t, adapter = desktopAgentAdapter, scheduler 
                 workdir: workdir.trim() === "" ? undefined : workdir.trim(),
                 repo: repo.trim() === "" ? undefined : repo.trim(),
               }),
-            )
-          }
+            );
+          }}
         >
           {t("DesktopSettings.agent.start")}
         </button>

--- a/web/src/i18n/strings/DesktopSettings.ts
+++ b/web/src/i18n/strings/DesktopSettings.ts
@@ -41,6 +41,11 @@ export const DesktopSettingsStrings: LocaleDict = {
     "DesktopSettings.agent.instances": "Duty instances",
     "DesktopSettings.agent.instanceStop": "Stop",
     "DesktopSettings.agent.instanceLogs": "Logs",
+    "DesktopSettings.agent.persistMode": "Start at login (launchd resident — survives quitting the app)",
+    "DesktopSettings.agent.dutyTitle": "System resident duty",
+    "DesktopSettings.agent.dutyLoaded": "resident",
+    "DesktopSettings.agent.dutyNotLoaded": "not loaded",
+    "DesktopSettings.agent.dutyUnload": "Remove",
   },
   zh: {
     "DesktopSettings.control.label": "应用设置",
@@ -82,6 +87,11 @@ export const DesktopSettingsStrings: LocaleDict = {
     "DesktopSettings.agent.instances": "值守实例",
     "DesktopSettings.agent.instanceStop": "停止",
     "DesktopSettings.agent.instanceLogs": "日志",
+    "DesktopSettings.agent.persistMode": "随系统启动（launchd 常驻，退出 App 不断线）",
+    "DesktopSettings.agent.dutyTitle": "系统常驻值守",
+    "DesktopSettings.agent.dutyLoaded": "常驻中",
+    "DesktopSettings.agent.dutyNotLoaded": "未加载",
+    "DesktopSettings.agent.dutyUnload": "卸载",
   },
 };
 

--- a/web/src/lib/desktopAgent.ts
+++ b/web/src/lib/desktopAgent.ts
@@ -34,6 +34,15 @@ export interface DesktopAgentStartInput {
   repo?: string;
 }
 
+// #616 phase 3：launchd 系统级常驻值守条目。
+export interface DesktopDutyEntry {
+  label: string;
+  instanceId: string;
+  plistPath: string;
+  logPath: string;
+  loaded: boolean;
+}
+
 export interface DesktopAgentAdapter {
   listConfigs(): Promise<DesktopAgentConfig[]>;
   status(): Promise<DesktopAgentStatus>;
@@ -44,6 +53,10 @@ export interface DesktopAgentAdapter {
   stopInstance(instanceId: string): Promise<DesktopAgentStatus>;
   logs(): Promise<string[]>;
   logsInstance(instanceId: string): Promise<string[]>;
+  /** #616 phase 3：系统级常驻（launchd）。非 macOS / 旧 shell 会 reject，调用方按不可用处理。 */
+  dutyList(): Promise<DesktopDutyEntry[]>;
+  dutyPersist(input: DesktopAgentStartInput): Promise<DesktopDutyEntry>;
+  dutyUnpersist(instanceId: string): Promise<void>;
 }
 
 export type DesktopAgentInvoker = <T>(command: string, args?: Record<string, unknown>) => Promise<T>;
@@ -119,6 +132,24 @@ function parseStatus(value: unknown): DesktopAgentStatus {
   };
 }
 
+function parseDutyEntry(value: unknown): DesktopDutyEntry {
+  if (!isRecord(value)) throw new Error("invalid desktop duty entry");
+  if (
+    typeof value.label !== "string" ||
+    typeof value.instanceId !== "string" ||
+    typeof value.plistPath !== "string" ||
+    typeof value.logPath !== "string" ||
+    typeof value.loaded !== "boolean"
+  ) throw new Error("invalid desktop duty entry");
+  return {
+    label: value.label,
+    instanceId: value.instanceId,
+    plistPath: value.plistPath,
+    logPath: value.logPath,
+    loaded: value.loaded,
+  };
+}
+
 function parseLogs(value: unknown): string[] {
   if (!Array.isArray(value) || !value.every((line) => typeof line === "string")) {
     throw new Error("invalid desktop agent logs");
@@ -159,6 +190,23 @@ export function createDesktopAgentAdapter(invoke: DesktopAgentInvoker): DesktopA
     },
     async logsInstance(instanceId) {
       return parseLogs(await invoke<unknown>("desktop_agent_logs_instance", { instanceId }));
+    },
+    async dutyList() {
+      const value = await invoke<unknown>("desktop_duty_list");
+      if (!Array.isArray(value)) throw new Error("invalid desktop duty list");
+      return value.map(parseDutyEntry);
+    },
+    async dutyPersist(input) {
+      return parseDutyEntry(await invoke<unknown>("desktop_duty_persist", {
+        configId: input.configId,
+        channel: input.channel,
+        runner: input.runner,
+        workdir: input.workdir ?? null,
+        repo: input.repo ?? null,
+      }));
+    },
+    async dutyUnpersist(instanceId) {
+      await invoke<unknown>("desktop_duty_unpersist", { instanceId });
     },
   };
 }

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -298,6 +298,15 @@
 .desktop-agent-fields select:focus-visible,
 .desktop-agent-fields input:focus-visible { border-color: var(--t-accent); outline: 1px solid var(--t-accent); }
 .desktop-agent-empty,
+/* #616 phase 3：常驻值守 */
+.desktop-agent-persist {
+  flex-direction: row !important;
+  align-items: center;
+  gap: 8px;
+}
+.desktop-agent-duties { margin-top: 12px; }
+.desktop-agent-duties-title { font-size: 12px; color: var(--t-dim); }
+
 /* #616 多实例值守列表 */
 .desktop-agent-instances {
   list-style: none;


### PR DESCRIPTION
## 背景

#616 第 3 块（关键块）：现在 serve 是桌面 app 的子进程，**退出 app 值守就死**，与「无人值守」自相矛盾。本 PR 用 launchd 把值守实例落成系统级常驻：退出 app 不断线、重启机器自动拉起。

## 改动

### Rust（新模块 desktop/src-tauri/src/duty.rs）

- `desktop_duty_persist(config_id, channel, runner, workdir?, repo?)`：校验复用 phase 1/2 的同一套（channel/runner/workdir/repo）→ 停掉 app 内同键实例（同身份双 serve 互抢租约）→ 拷贝 sidecar 到 `~/.agentparty/desktop/bin/party` 稳定路径（bundle 路径随 app 更新/挪动失效；staging+rename 不写坏运行中的旧 inode）→ 写 plist → `launchctl bootout`（幂等重装）+ `bootstrap gui/<uid>`
- plist：`RunAtLoad` + `KeepAlive` + `ProcessType Background`，stdout/stderr 落 `~/.agentparty/desktop/logs/<label>.log`；ProgramArguments 带 `--auto-upgrade`（#45 机制——常驻进程没有 app 帮它换新，wake 间隙自行换）
- **安全（#221 红线）：plist 绝不含 token**——只引用 `AGENTPARTY_CONFIG` 文件路径；XML 全量转义（单测断言 `ap_` 不出现）
- `desktop_duty_unpersist`：先 bootout 再删 plist（顺序反了会留「加载中但文件没了」的孤儿任务）；`desktop_duty_list`：扫 LaunchAgents 的 `com.agentparty.duty.*` + `launchctl print` 探加载态
- label 往返：`instance_id` 的 `:` ↔ `.`（config_id 是 hex、channel 是 slug，都不含 `.`，最后一个 `.` 即分隔符）——有单测
- 非 macOS 返回明确的 unsupported 错误（Windows/Linux 在 issue 的非目标里）

### Web

- 表单新增「随系统启动（launchd 常驻，退出 App 不断线）」勾选：启动按钮路由到 `dutyPersist`
- 「系统常驻值守」区块：实例、加载态、日志路径、卸载按钮
- `dutyList` 拒绝（非 macOS / 旧 shell）→ 区块隐藏、勾选禁用，面板其余功能不受影响（有测试）

## 测试

- Rust：label 往返、plist 生成（XML 转义、无 token、--auto-upgrade、workdir/repo 条件出现）——cargo test 83 通过
- Web：常驻路由/列表渲染/卸载、不可用降级——check:web 873 通过
- launchctl 实调不可在 CI 复现：本机验收步骤——面板勾选常驻启动 → `launchctl print gui/$(id -u)/com.agentparty.duty.*` 可见、退出 app 后 `party who` 仍显示 wakeable → 面板卸载 → plist 消失且 launchctl 查无此 label

Refs #616（第 4 块 web 一键接管 deep link 另行 PR）