### PR TITLE
feat(desktop/web): 无人值守一键接管——token 经 IPC 直达常驻（#616 第 4 块）

### DIFF
--- a/desktop/src-tauri/src/agent.rs
+++ b/desktop/src-tauri/src/agent.rs
@@ -546,11 +546,12 @@ impl AgentManager {
     pub(crate) async fn stop_instance_for_duty(&self, instance_id: &str) -> Result<(), String> {
         match self.stop_instance_key(instance_id).await {
             Ok(runtime) => {
-                let kill_failed = runtime
-                    .last_error
-                    .as_deref()
-                    .is_some_and(|error| error.contains("failed to stop party sidecar"));
-                if is_active_phase(runtime.phase) || kill_failed {
+                // 两条已知的「停失败」文案都算失败：kill 报错 与 停止超时（进程可能仍活着）。
+                let stop_failed = runtime.last_error.as_deref().is_some_and(|error| {
+                    error.contains("failed to stop party sidecar")
+                        || error.contains("did not exit within the stop timeout")
+                });
+                if is_active_phase(runtime.phase) || stop_failed {
                     return Err(
                         "could not stop the in-app instance; refusing to install a resident duty alongside it"
                             .to_string(),

--- a/desktop/src-tauri/src/agent.rs
+++ b/desktop/src-tauri/src/agent.rs
@@ -541,10 +541,23 @@ impl AgentManager {
     }
 
     /// #616 phase 3：转系统常驻前停掉 app 内同键实例（同身份双 serve 会互抢租约）。
-    /// 实例不存在不是错——常驻可以直接从表单发起。
+    /// 实例不存在不是错——常驻可以直接从表单发起。停完必须确认不再活跃且 kill 没失败：
+    /// 进程可能还活着（kill 失败只会把 runtime 标成 Failed），带病装常驻就是双跑。
     pub(crate) async fn stop_instance_for_duty(&self, instance_id: &str) -> Result<(), String> {
         match self.stop_instance_key(instance_id).await {
-            Ok(_) => Ok(()),
+            Ok(runtime) => {
+                let kill_failed = runtime
+                    .last_error
+                    .as_deref()
+                    .is_some_and(|error| error.contains("failed to stop party sidecar"));
+                if is_active_phase(runtime.phase) || kill_failed {
+                    return Err(
+                        "could not stop the in-app instance; refusing to install a resident duty alongside it"
+                            .to_string(),
+                    );
+                }
+                Ok(())
+            }
             Err(error) if error.contains("unknown desktop agent instance") => Ok(()),
             Err(error) => Err(error),
         }

--- a/desktop/src-tauri/src/duty.rs
+++ b/desktop/src-tauri/src/duty.rs
@@ -275,56 +275,168 @@ pub(crate) async fn desktop_duty_persist(
         if let Some(url) = repo.as_deref() {
             crate::agent::validate_repo(url)?;
         }
-        let (config_path, _summary) = crate::agent::resolve_config(&config_id)?;
+        duty_persist_inner(
+            &app,
+            &agent_state,
+            &config_id,
+            &channel,
+            &runner,
+            workdir.as_deref(),
+            repo.as_deref(),
+        )
+        .await
+    }
+}
+
+/// persist 的共同内核：desktop_duty_persist（面板路径）与 desktop_duty_adopt（web 一键接管）
+/// 共用——校验已由调用方完成。
+#[cfg(all(desktop, target_os = "macos"))]
+async fn duty_persist_inner(
+    app: &AppHandle,
+    agent_state: &State<'_, crate::agent::AgentManager>,
+    config_id: &str,
+    channel: &str,
+    runner: &str,
+    workdir: Option<&str>,
+    repo: Option<&str>,
+) -> Result<DutyEntry, String> {
+    let (config_path, _summary) = crate::agent::resolve_config(config_id)?;
+    let home = home_dir()?;
+    let instance_id = format!("{config_id}:{channel}");
+    let label = duty_label(&instance_id);
+
+    // 同一实例不允许 app 内 child 与 launchd 常驻双跑（同身份两个 serve 会互抢租约）：
+    // 先停掉 app 内的同键实例。
+    let _ = agent_state.stop_instance_for_duty(&instance_id).await;
+
+    let party_bin = ensure_duty_binary(app, &home)?;
+    let log_path = duty_log_path(&home, &label);
+    if let Some(parent) = log_path.parent() {
+        fs::create_dir_all(parent).map_err(|error| format!("cannot create duty log dir: {error}"))?;
+    }
+    let plist = duty_plist_content(&DutyPlistSpec {
+        label: &label,
+        party_bin: &party_bin.to_string_lossy(),
+        config_path: &config_path.to_string_lossy(),
+        channel,
+        runner,
+        workdir,
+        repo,
+        log_path: &log_path.to_string_lossy(),
+    });
+    let plist_path = duty_plist_path(&home, &label);
+    if let Some(parent) = plist_path.parent() {
+        fs::create_dir_all(parent).map_err(|error| format!("cannot create LaunchAgents dir: {error}"))?;
+    }
+    let tmp = plist_path.with_extension("plist.tmp");
+    fs::write(&tmp, plist).map_err(|error| format!("cannot write duty plist: {error}"))?;
+    fs::rename(&tmp, &plist_path).map_err(|error| format!("cannot install duty plist: {error}"))?;
+
+    // 已加载的旧实例先卸再装（幂等重装）；bootout 对未加载的 label 报错，忽略。
+    let domain = gui_domain();
+    let _ = launchctl(&["bootout", &format!("{domain}/{label}")]);
+    let boot = launchctl(&["bootstrap", &domain, &plist_path.to_string_lossy()])?;
+    if !boot.status.success() {
+        let detail = String::from_utf8_lossy(&boot.stderr);
+        return Err(format!(
+            "launchctl bootstrap failed: {}",
+            detail.trim().chars().take(200).collect::<String>()
+        ));
+    }
+    Ok(DutyEntry {
+        label: label.clone(),
+        instance_id,
+        plist_path: plist_path.to_string_lossy().into_owned(),
+        log_path: log_path.to_string_lossy().into_owned(),
+        loaded: duty_loaded(&label),
+    })
+}
+
+/// #616 第 4 块：web「无人值守」流程在桌面 webview 内一键接管。
+/// token 经 tauri IPC 本机直达（绝不进 URL / 剪贴板 / 终端），写成与 party init 同构的
+/// 配置文件后走 persist 同一条链路。name 校验对齐 CLI 的 agent 名正则。
+#[cfg(desktop)]
+fn validate_adopt_inputs(server: &str, token: &str, name: &str) -> Result<(), String> {
+    if !token.starts_with("ap_")
+        || token.len() <= 3
+        || token.len() > 256
+        || token.chars().any(|value| value.is_whitespace() || value.is_control())
+    {
+        return Err("token must be a valid agent token".to_string());
+    }
+    let name_ok = name.len() <= 64
+        && name.chars().next().is_some_and(|value| value.is_ascii_alphanumeric())
+        && name
+            .chars()
+            .all(|value| value.is_ascii_alphanumeric() || matches!(value, '.' | '_' | '-'));
+    if !name_ok {
+        return Err("name must match the agent name grammar".to_string());
+    }
+    if server.len() > 512 || server.chars().any(|value| value.is_whitespace() || value.is_control()) {
+        return Err("server origin is invalid".to_string());
+    }
+    Ok(())
+}
+
+#[cfg(desktop)]
+#[tauri::command]
+pub(crate) async fn desktop_duty_adopt(
+    app: AppHandle,
+    agent_state: State<'_, crate::agent::AgentManager>,
+    server: String,
+    token: String,
+    name: String,
+    channel: String,
+    runner: String,
+) -> Result<DutyEntry, String> {
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = (app, agent_state, server, token, name, channel, runner);
+        return Err("system-level duty is currently macOS-only (launchd)".to_string());
+    }
+    #[cfg(target_os = "macos")]
+    {
+        validate_channel(&channel)?;
+        validate_runner(&runner)?;
+        validate_adopt_inputs(&server, &token, &name)?;
         let home = home_dir()?;
-        let instance_id = format!("{config_id}:{channel}");
-        let label = duty_label(&instance_id);
-
-        // 同一实例不允许 app 内 child 与 launchd 常驻双跑（同身份两个 serve 会互抢租约）：
-        // 先停掉 app 内的同键实例。
-        let _ = agent_state.stop_instance_for_duty(&instance_id).await;
-
-        let party_bin = ensure_duty_binary(&app, &home)?;
-        let log_path = duty_log_path(&home, &label);
-        if let Some(parent) = log_path.parent() {
-            fs::create_dir_all(parent).map_err(|error| format!("cannot create duty log dir: {error}"))?;
-        }
-        let plist = duty_plist_content(&DutyPlistSpec {
-            label: &label,
-            party_bin: &party_bin.to_string_lossy(),
-            config_path: &config_path.to_string_lossy(),
-            channel: &channel,
-            runner: &runner,
-            workdir: workdir.as_deref(),
-            repo: repo.as_deref(),
-            log_path: &log_path.to_string_lossy(),
+        // 与 join pack 的 AGENTPARTY_CONFIG 约定同路径：CLI 与桌面端看见的是同一个身份文件。
+        let config_dir = home.join(".agentparty/agents");
+        fs::create_dir_all(&config_dir).map_err(|error| format!("cannot create agents dir: {error}"))?;
+        let config_path = config_dir.join(format!("agentparty-{name}-{channel}.json"));
+        let config = serde_json::json!({
+            "server": server,
+            "token": token,
+            "identity": {
+                "name": name,
+                "email": null,
+                "kind": "agent",
+                "role": "agent",
+                "owner": null,
+                "channel_scope": channel,
+                "verified_at": std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|value| value.as_millis() as u64)
+                    .unwrap_or(0),
+            },
         });
-        let plist_path = duty_plist_path(&home, &label);
-        if let Some(parent) = plist_path.parent() {
-            fs::create_dir_all(parent).map_err(|error| format!("cannot create LaunchAgents dir: {error}"))?;
+        // 0600 + tmp/rename：token 文件既不给同机他人可读，也不落半截。
+        let tmp = config_path.with_extension("json.tmp");
+        fs::write(&tmp, serde_json::to_vec_pretty(&config).map_err(|error| error.to_string())?)
+            .map_err(|error| format!("cannot write agent config: {error}"))?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = fs::set_permissions(&tmp, fs::Permissions::from_mode(0o600));
         }
-        let tmp = plist_path.with_extension("plist.tmp");
-        fs::write(&tmp, plist).map_err(|error| format!("cannot write duty plist: {error}"))?;
-        fs::rename(&tmp, &plist_path).map_err(|error| format!("cannot install duty plist: {error}"))?;
-
-        // 已加载的旧实例先卸再装（幂等重装）；bootout 对未加载的 label 报错，忽略。
-        let domain = gui_domain();
-        let _ = launchctl(&["bootout", &format!("{domain}/{label}")]);
-        let boot = launchctl(&["bootstrap", &domain, &plist_path.to_string_lossy()])?;
-        if !boot.status.success() {
-            let detail = String::from_utf8_lossy(&boot.stderr);
-            return Err(format!(
-                "launchctl bootstrap failed: {}",
-                detail.trim().chars().take(200).collect::<String>()
-            ));
+        fs::rename(&tmp, &config_path).map_err(|error| format!("cannot install agent config: {error}"))?;
+        // 写完立刻用现有解析器回验（server 白名单、identity 完整性都在里面）；不合格就删掉退出。
+        if let Err(error) = crate::agent::parse_config_summary(&config_path) {
+            let _ = fs::remove_file(&config_path);
+            return Err(format!("adopted config failed validation: {error}"));
         }
-        Ok(DutyEntry {
-            label: label.clone(),
-            instance_id,
-            plist_path: plist_path.to_string_lossy().into_owned(),
-            log_path: log_path.to_string_lossy().into_owned(),
-            loaded: duty_loaded(&label),
-        })
+        let config_id = crate::agent::config_id(&config_path)?;
+        duty_persist_inner(&app, &agent_state, &config_id, &channel, &runner, None, None).await
     }
 }
 

--- a/desktop/src-tauri/src/duty.rs
+++ b/desktop/src-tauri/src/duty.rs
@@ -306,8 +306,8 @@ async fn duty_persist_inner(
     let label = duty_label(&instance_id);
 
     // 同一实例不允许 app 内 child 与 launchd 常驻双跑（同身份两个 serve 会互抢租约）：
-    // 先停掉 app 内的同键实例。
-    let _ = agent_state.stop_instance_for_duty(&instance_id).await;
+    // 先停掉 app 内的同键实例。停不掉（kill 失败/超时后仍活跃）必须中止，不能带病装常驻。
+    agent_state.stop_instance_for_duty(&instance_id).await?;
 
     let party_bin = ensure_duty_binary(app, &home)?;
     let log_path = duty_log_path(&home, &label);
@@ -343,12 +343,25 @@ async fn duty_persist_inner(
             detail.trim().chars().take(200).collect::<String>()
         ));
     }
+    // bootstrap 返回成功但任务未必立刻可见——短轮询确认；确认不了按失败报，
+    // 绝不把 loaded=false 包装成成功让 UI 显示「已常驻」（CodeRabbit #621）。
+    let mut loaded = false;
+    for _ in 0..10 {
+        if duty_loaded(&label) {
+            loaded = true;
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    }
+    if !loaded {
+        return Err("launchctl bootstrap reported success but the duty job is not loaded".to_string());
+    }
     Ok(DutyEntry {
         label: label.clone(),
         instance_id,
         plist_path: plist_path.to_string_lossy().into_owned(),
         log_path: log_path.to_string_lossy().into_owned(),
-        loaded: duty_loaded(&label),
+        loaded: true,
     })
 }
 
@@ -420,23 +433,63 @@ pub(crate) async fn desktop_duty_adopt(
                     .unwrap_or(0),
             },
         });
-        // 0600 + tmp/rename：token 文件既不给同机他人可读，也不落半截。
+        // tmp 从创建那一刻就是 0600（create_new + mode）——敏感内容一个瞬间也不以宽权限存在；
+        // 任何失败都清掉 tmp（CodeRabbit #621）。
         let tmp = config_path.with_extension("json.tmp");
-        fs::write(&tmp, serde_json::to_vec_pretty(&config).map_err(|error| error.to_string())?)
-            .map_err(|error| format!("cannot write agent config: {error}"))?;
-        #[cfg(unix)]
+        let body = serde_json::to_vec_pretty(&config).map_err(|error| error.to_string())?;
         {
-            use std::os::unix::fs::PermissionsExt;
-            let _ = fs::set_permissions(&tmp, fs::Permissions::from_mode(0o600));
+            use std::io::Write;
+            let mut options = fs::OpenOptions::new();
+            options.write(true).create_new(true);
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::OpenOptionsExt;
+                options.mode(0o600);
+            }
+            let mut file = options
+                .open(&tmp)
+                .map_err(|error| format!("cannot create agent config tmp: {error}"))?;
+            if let Err(error) = file.write_all(&body) {
+                drop(file);
+                let _ = fs::remove_file(&tmp);
+                return Err(format!("cannot write agent config: {error}"));
+            }
         }
-        fs::rename(&tmp, &config_path).map_err(|error| format!("cannot install agent config: {error}"))?;
-        // 写完立刻用现有解析器回验（server 白名单、identity 完整性都在里面）；不合格就删掉退出。
-        if let Err(error) = crate::agent::parse_config_summary(&config_path) {
-            let _ = fs::remove_file(&config_path);
+        // 先验 tmp 再替换：坏内容绝不覆盖同名旧配置（CodeRabbit #621）。
+        if let Err(error) = crate::agent::parse_config_summary(&tmp) {
+            let _ = fs::remove_file(&tmp);
             return Err(format!("adopted config failed validation: {error}"));
         }
-        let config_id = crate::agent::config_id(&config_path)?;
-        duty_persist_inner(&app, &agent_state, &config_id, &channel, &runner, None, None).await
+        // rename 会覆盖同名旧配置：先留备份，后续任何失败都恢复原状（无旧文件则删除新文件）。
+        let backup = fs::read(&config_path).ok();
+        if let Err(error) = fs::rename(&tmp, &config_path) {
+            let _ = fs::remove_file(&tmp);
+            return Err(format!("cannot install agent config: {error}"));
+        }
+        let restore = |reason: String| -> String {
+            match &backup {
+                Some(bytes) => {
+                    let _ = fs::write(&config_path, bytes);
+                    #[cfg(unix)]
+                    {
+                        use std::os::unix::fs::PermissionsExt;
+                        let _ = fs::set_permissions(&config_path, fs::Permissions::from_mode(0o600));
+                    }
+                }
+                None => {
+                    let _ = fs::remove_file(&config_path);
+                }
+            }
+            reason
+        };
+        let config_id = match crate::agent::config_id(&config_path) {
+            Ok(value) => value,
+            Err(error) => return Err(restore(error)),
+        };
+        match duty_persist_inner(&app, &agent_state, &config_id, &channel, &runner, None, None).await {
+            Ok(entry) => Ok(entry),
+            Err(error) => Err(restore(error)),
+        }
     }
 }
 

--- a/desktop/src-tauri/src/duty.rs
+++ b/desktop/src-tauri/src/duty.rs
@@ -460,35 +460,71 @@ pub(crate) async fn desktop_duty_adopt(
             let _ = fs::remove_file(&tmp);
             return Err(format!("adopted config failed validation: {error}"));
         }
-        // rename 会覆盖同名旧配置：先留备份，后续任何失败都恢复原状（无旧文件则删除新文件）。
-        let backup = fs::read(&config_path).ok();
+        // rename 会覆盖同名旧配置：先留备份。备份读取失败 ≠ 无旧文件——读不出来就中止，
+        // 绝不冒着丢原配置的风险继续（CodeRabbit #621 复审）。
+        let backup = match fs::read(&config_path) {
+            Ok(bytes) => Some(bytes),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+            Err(error) => {
+                let _ = fs::remove_file(&tmp);
+                return Err(format!("cannot back up the existing agent config: {error}"));
+            }
+        };
         if let Err(error) = fs::rename(&tmp, &config_path) {
             let _ = fs::remove_file(&tmp);
             return Err(format!("cannot install agent config: {error}"));
         }
+        // 恢复失败必须传播——静默吞掉等于用户在不知情下丢了原身份文件。
         let restore = |reason: String| -> String {
-            match &backup {
-                Some(bytes) => {
-                    let _ = fs::write(&config_path, bytes);
+            let outcome: Result<(), std::io::Error> = match &backup {
+                Some(bytes) => fs::write(&config_path, bytes).map(|()| {
                     #[cfg(unix)]
                     {
                         use std::os::unix::fs::PermissionsExt;
                         let _ = fs::set_permissions(&config_path, fs::Permissions::from_mode(0o600));
                     }
-                }
-                None => {
-                    let _ = fs::remove_file(&config_path);
-                }
+                }),
+                None => match fs::remove_file(&config_path) {
+                    Err(error) if error.kind() != std::io::ErrorKind::NotFound => Err(error),
+                    _ => Ok(()),
+                },
+            };
+            match outcome {
+                Ok(()) => reason,
+                Err(error) => format!("{reason}; ALSO failed to restore the previous agent config: {error}"),
             }
-            reason
         };
         let config_id = match crate::agent::config_id(&config_path) {
             Ok(value) => value,
             Err(error) => return Err(restore(error)),
         };
+        // launchd 面同样要可回滚：记录 persist 之前该 label 的 plist 原状（不存在 / 原内容）。
+        let label = duty_label(&format!("{config_id}:{channel}"));
+        let plist_path = duty_plist_path(&home, &label);
+        let old_plist = match fs::read(&plist_path) {
+            Ok(bytes) => Some(bytes),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+            Err(error) => return Err(restore(format!("cannot back up the existing duty plist: {error}"))),
+        };
         match duty_persist_inner(&app, &agent_state, &config_id, &channel, &runner, None, None).await {
             Ok(entry) => Ok(entry),
-            Err(error) => Err(restore(error)),
+            Err(error) => {
+                // 卸掉可能已装上的新任务，plist 恢复原状（原有旧值守则连内容带加载态一起还原）。
+                let domain = gui_domain();
+                let _ = launchctl(&["bootout", &format!("{domain}/{label}")]);
+                match &old_plist {
+                    Some(bytes) => {
+                        let plist_restored = fs::write(&plist_path, bytes).is_ok();
+                        if plist_restored {
+                            let _ = launchctl(&["bootstrap", &domain, &plist_path.to_string_lossy()]);
+                        }
+                    }
+                    None => {
+                        let _ = fs::remove_file(&plist_path);
+                    }
+                }
+                Err(restore(error))
+            }
         }
     }
 }

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -1185,6 +1185,7 @@ pub fn run() {
             agent::desktop_agent_logs_instance,
             duty::desktop_duty_list,
             duty::desktop_duty_persist,
+            duty::desktop_duty_adopt,
             duty::desktop_duty_unpersist
         ]);
 

--- a/web/src/components/AgentJoin.test.tsx
+++ b/web/src/components/AgentJoin.test.tsx
@@ -86,6 +86,7 @@ afterEach(() => {
 function render(
   onActiveChange?: (open: boolean) => void,
   charter: React.ComponentProps<typeof AgentJoin>["charter"] = null,
+  extra: Partial<React.ComponentProps<typeof AgentJoin>> = {},
 ): ReactTestRenderer {
   act(() => {
     renderer = create(
@@ -98,6 +99,7 @@ function render(
           charter={charter}
           accountKey="acct-1"
           onActiveChange={onActiveChange}
+          {...extra}
         />
       </LocaleProvider>,
     );
@@ -253,6 +255,73 @@ describe("AgentJoin 无人值守值守预设 (#612)", () => {
     expect(saved.mode).toBe("interactive");
     expect(saved.command).toContain("claude mcp add");
     expect(saved.command).not.toContain("--runner claude");
+  });
+});
+
+describe("AgentJoin 桌面一键接管 (#616 phase 4)", () => {
+  function pickUnattended(r: ReactTestRenderer) {
+    act(() =>
+      r.root
+        .find((node) => node.props.name === "agent-join-mode" && node.props.value === "unattended")
+        .props.onChange(),
+    );
+  }
+  async function generate(r: ReactTestRenderer) {
+    await act(async () => {
+      await r.root.find((node) => node.props.className === "d-btn d-btn--primary" && node.props.onClick).props.onClick();
+    });
+  }
+
+  test("桌面环境 + 无人值守：一键接管调 dutyAdopt，token 走 IPC 而非 URL", async () => {
+    localStorage.setItem("ap_locale", "en");
+    setApiBase("https://agentparty.leeguoo.com");
+    const adopts: unknown[] = [];
+    const r = render(undefined, null, {
+      desktopDetect: () => true,
+      dutyAdapter: {
+        dutyAdopt: async (input: unknown) => {
+          adopts.push(input);
+          return {
+            label: "com.agentparty.duty.x.demo",
+            instanceId: "x:demo",
+            plistPath: "/p",
+            logPath: "/l",
+            loaded: true,
+          };
+        },
+      },
+    });
+    open(r);
+    pickUnattended(r);
+    await generate(r);
+
+    const adoptBtn = r.root.find(
+      (node) => node.type === "button" && String(node.children[0] ?? "").includes("Keep resident on this Mac"),
+    );
+    await act(async () => {
+      await adoptBtn.props.onClick();
+    });
+    expect(adopts).toEqual([
+      {
+        server: "https://agentparty.leeguoo.com",
+        token: "ap_created",
+        name: "leo-demo",
+        channel: "demo",
+        runner: "claude",
+      },
+    ]);
+    expect(JSON.stringify(renderer!.toJSON())).toContain("resident ✓");
+  });
+
+  test("非桌面环境或交互模式：不渲染接管按钮", async () => {
+    localStorage.setItem("ap_locale", "en");
+    const r = render(undefined, null, { desktopDetect: () => false });
+    open(r);
+    pickUnattended(r);
+    await generate(r);
+    expect(
+      r.root.findAll((node) => node.type === "button" && String(node.children[0] ?? "").includes("Keep resident")),
+    ).toHaveLength(0);
   });
 });
 

--- a/web/src/components/AgentJoin.tsx
+++ b/web/src/components/AgentJoin.tsx
@@ -12,6 +12,8 @@ import {
 } from "../lib/api";
 import { copyText, saveAgentToken } from "../lib/agentTokenVault";
 import { buildJoinPack, type JoinPackMode } from "../lib/joinPack";
+import { desktopAgentAdapter, type DesktopAgentAdapter } from "../lib/desktopAgent";
+import { isDesktopRuntime } from "../lib/desktopRuntime";
 import { apiOrigin } from "../lib/base";
 import { useT } from "../i18n/useT";
 import { useDismissableLayer } from "./useDismissableLayer";
@@ -19,6 +21,9 @@ import "../i18n/strings/AgentJoin";
 
 interface Props {
   slug: string;
+  /** 测试注入；生产恒为默认值。 */
+  dutyAdapter?: Pick<DesktopAgentAdapter, "dutyAdopt">;
+  desktopDetect?: () => boolean;
   token: string; // 当前登录人类会话 token（铸造凭据）
   namePrefix: string; // 生成 agent 名的前缀来源（email/name 前缀，退回 slug）
   inviterName: string; // 邀请人在频道里的身份名，报到时 @ 他让他知道你来了
@@ -53,16 +58,19 @@ type Phase =
   | { kind: "idle" }
   | { kind: "compose" } // 起名中
   | { kind: "loading" }
-  | { kind: "done"; name: string; command: string; mode: JoinPackMode }
+  | { kind: "done"; name: string; token: string; command: string; mode: JoinPackMode }
   | { kind: "error"; message: string };
 
-export function AgentJoin({ slug, token, namePrefix, inviterName, charter, accountKey, active, onActiveChange }: Props) {
+export function AgentJoin({ slug, token, namePrefix, inviterName, charter, accountKey, active, onActiveChange, dutyAdapter = desktopAgentAdapter, desktopDetect = isDesktopRuntime }: Props) {
   const t = useT();
   const [phase, setPhase] = useState<Phase>({ kind: "idle" });
   const [name, setName] = useState("");
   // #612：无人值守值守预设——unattended 生成「装 CLI → init → party serve --runner claude」的
   // 运维脚本，interactive 仍是贴给 agent harness 的完整接入包。
   const [mode, setMode] = useState<JoinPackMode>("interactive");
+  // #616 phase 4：桌面 webview 内的无人值守一键接管状态
+  const [adoptState, setAdoptState] = useState<"idle" | "busy" | "done" | "error">("idle");
+  const [adoptError, setAdoptError] = useState<string | null>(null);
   const [nameErr, setNameErr] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
 
@@ -126,7 +134,9 @@ export function AgentJoin({ slug, token, namePrefix, inviterName, charter, accou
         savedAt: Date.now(),
       });
       setCopied(false);
-      setPhase({ kind: "done", name: agent.name, command, mode });
+      setAdoptState("idle");
+      setAdoptError(null);
+      setPhase({ kind: "done", name: agent.name, token: agent.token, command, mode });
     } catch (err) {
       // 同名占用 → 停在起名步，让用户换个有意义的名字（不静默塞随机后缀）
       if (err instanceof ConflictError) {
@@ -145,6 +155,25 @@ export function AgentJoin({ slug, token, namePrefix, inviterName, charter, accou
       setPhase({ kind: "error", message });
     }
   }, [accountKey, charter, inviterName, mode, name, slug, token, t]);
+
+  const adopt = useCallback(async () => {
+    if (phase.kind !== "done" || adoptState === "busy" || adoptState === "done") return;
+    setAdoptState("busy");
+    setAdoptError(null);
+    try {
+      await dutyAdapter.dutyAdopt({
+        server: apiOrigin(),
+        token: phase.token,
+        name: phase.name,
+        channel: slug,
+        runner: "claude",
+      });
+      setAdoptState("done");
+    } catch (err) {
+      setAdoptState("error");
+      setAdoptError(err instanceof Error ? err.message : String(err));
+    }
+  }, [adoptState, dutyAdapter, phase, slug]);
 
   const onCopy = useCallback(async () => {
     if (phase.kind !== "done") return;
@@ -258,6 +287,31 @@ export function AgentJoin({ slug, token, namePrefix, inviterName, charter, accou
             <p className="agent-join-lead">
               {t(phase.mode === "unattended" ? "AgentJoin.doneLeadUnattended" : "AgentJoin.doneLead")}
             </p>
+
+            {phase.mode === "unattended" && desktopDetect() && (
+              <div className="agent-join-adopt">
+                <button
+                  type="button"
+                  className="d-btn d-btn--primary"
+                  disabled={adoptState === "busy" || adoptState === "done"}
+                  onClick={() => void adopt()}
+                >
+                  {t(
+                    adoptState === "busy"
+                      ? "AgentJoin.adoptBusy"
+                      : adoptState === "done"
+                        ? "AgentJoin.adoptDone"
+                        : "AgentJoin.adoptButton",
+                  )}
+                </button>
+                <span className="agent-join-hint t-mono">
+                  {adoptState === "done" ? t("AgentJoin.adoptDoneHint") : t("AgentJoin.adoptHint")}
+                </span>
+                {adoptState === "error" && adoptError !== null && (
+                  <p className="banner banner--red" role="alert">{adoptError}</p>
+                )}
+              </div>
+            )}
 
             <div className="agent-join-cmd">
               <pre className="t-mono agent-join-cmd-text">{phase.command}</pre>

--- a/web/src/components/AgentJoin.tsx
+++ b/web/src/components/AgentJoin.tsx
@@ -14,6 +14,12 @@ import { copyText, saveAgentToken } from "../lib/agentTokenVault";
 import { buildJoinPack, type JoinPackMode } from "../lib/joinPack";
 import { desktopAgentAdapter, type DesktopAgentAdapter } from "../lib/desktopAgent";
 import { isDesktopRuntime } from "../lib/desktopRuntime";
+
+// #616 phase 4 的常驻是 launchd（macOS-only）：非 mac 桌面端不渲染接管按钮，
+// 免得点了必然吃后端 unsupported 错误。
+function isMacDesktop(): boolean {
+  return isDesktopRuntime() && /mac/i.test(globalThis.navigator?.userAgent ?? "");
+}
 import { apiOrigin } from "../lib/base";
 import { useT } from "../i18n/useT";
 import { useDismissableLayer } from "./useDismissableLayer";
@@ -61,7 +67,7 @@ type Phase =
   | { kind: "done"; name: string; token: string; command: string; mode: JoinPackMode }
   | { kind: "error"; message: string };
 
-export function AgentJoin({ slug, token, namePrefix, inviterName, charter, accountKey, active, onActiveChange, dutyAdapter = desktopAgentAdapter, desktopDetect = isDesktopRuntime }: Props) {
+export function AgentJoin({ slug, token, namePrefix, inviterName, charter, accountKey, active, onActiveChange, dutyAdapter = desktopAgentAdapter, desktopDetect = isMacDesktop }: Props) {
   const t = useT();
   const [phase, setPhase] = useState<Phase>({ kind: "idle" });
   const [name, setName] = useState("");

--- a/web/src/components/DesktopAgentPanel.test.tsx
+++ b/web/src/components/DesktopAgentPanel.test.tsx
@@ -53,6 +53,9 @@ function adapter(overrides: Partial<DesktopAgentAdapter> = {}): DesktopAgentAdap
       throw new Error("duty persist unavailable");
     },
     dutyUnpersist: async () => {},
+    dutyAdopt: async () => {
+      throw new Error("duty adopt unavailable");
+    },
     ...overrides,
   };
 }

--- a/web/src/i18n/strings/AgentJoin.ts
+++ b/web/src/i18n/strings/AgentJoin.ts
@@ -95,6 +95,11 @@ export const AgentJoinStrings: LocaleDict = {
     "AgentJoin.ua.note2": "#   · project code: add --repo <git url> to auto git pull before each wake, or --workdir DIR to pin the working directory",
     "AgentJoin.ua.note3": "#   · the channel page shows duty health live: runner failing / not listening / awaiting permission all get red-amber badges",
     "AgentJoin.ua.note4": "#   · unattended claude -p needs its permissions pre-approved in Claude Code settings, or wakes will stall on \"awaiting permission\"",
+    "AgentJoin.adoptButton": "⚡ Keep resident on this Mac (launchd)",
+    "AgentJoin.adoptBusy": "setting up…",
+    "AgentJoin.adoptDone": "resident ✓",
+    "AgentJoin.adoptHint": "one click: writes the identity locally and installs a launchd duty — the token never leaves this machine. The script below stays for servers.",
+    "AgentJoin.adoptDoneHint": "duty installed — survives quitting the app and reboots. Manage it in desktop settings.",
   },
   zh: {
     "AgentJoin.minting": "铸 token…",
@@ -188,6 +193,11 @@ export const AgentJoinStrings: LocaleDict = {
     "AgentJoin.ua.note2": "#   · 项目代码：加 --repo <git url> 每次唤醒前自动 git pull，或 --workdir DIR 固定工作目录",
     "AgentJoin.ua.note3": "#   · 频道页 presence 实时可见值守健康：runner 连败 / 没在听 / 等权限确认 都有红黄警示",
     "AgentJoin.ua.note4": "#   · 无人值守跑 claude -p 需预先在 Claude Code 设置里放行所需权限，否则唤醒会卡在「等权限确认」",
+    "AgentJoin.adoptButton": "⚡ 在本机常驻值守（launchd）",
+    "AgentJoin.adoptBusy": "配置中…",
+    "AgentJoin.adoptDone": "已常驻 ✓",
+    "AgentJoin.adoptHint": "一键完成：身份写入本机 + 装 launchd 常驻，token 全程不出本机。下方脚本保留给服务器场景。",
+    "AgentJoin.adoptDoneHint": "常驻已装好——退出 App、重启机器都不断线。可在桌面设置里管理。",
   },
 };
 

--- a/web/src/i18n/strings/AgentJoin.ts
+++ b/web/src/i18n/strings/AgentJoin.ts
@@ -98,7 +98,7 @@ export const AgentJoinStrings: LocaleDict = {
     "AgentJoin.adoptButton": "⚡ Keep resident on this Mac (launchd)",
     "AgentJoin.adoptBusy": "setting up…",
     "AgentJoin.adoptDone": "resident ✓",
-    "AgentJoin.adoptHint": "one click: writes the identity locally and installs a launchd duty — the token never leaves this machine. The script below stays for servers.",
+    "AgentJoin.adoptHint": "one click: hands the token to the app over local IPC (never via URL, clipboard, or terminal), stores it in a 0600 config file, and installs a launchd duty. The script below stays for servers.",
     "AgentJoin.adoptDoneHint": "duty installed — survives quitting the app and reboots. Manage it in desktop settings.",
   },
   zh: {
@@ -196,7 +196,7 @@ export const AgentJoinStrings: LocaleDict = {
     "AgentJoin.adoptButton": "⚡ 在本机常驻值守（launchd）",
     "AgentJoin.adoptBusy": "配置中…",
     "AgentJoin.adoptDone": "已常驻 ✓",
-    "AgentJoin.adoptHint": "一键完成：身份写入本机 + 装 launchd 常驻，token 全程不出本机。下方脚本保留给服务器场景。",
+    "AgentJoin.adoptHint": "一键完成：token 经本机 IPC 交给 App（不走 URL / 剪贴板 / 终端），落成 0600 权限的配置文件并装 launchd 常驻。下方脚本保留给服务器场景。",
     "AgentJoin.adoptDoneHint": "常驻已装好——退出 App、重启机器都不断线。可在桌面设置里管理。",
   },
 };

--- a/web/src/lib/desktopAgent.ts
+++ b/web/src/lib/desktopAgent.ts
@@ -57,6 +57,8 @@ export interface DesktopAgentAdapter {
   dutyList(): Promise<DesktopDutyEntry[]>;
   dutyPersist(input: DesktopAgentStartInput): Promise<DesktopDutyEntry>;
   dutyUnpersist(instanceId: string): Promise<void>;
+  /** #616 phase 4：web 无人值守流程一键接管——token 经本机 IPC 直达，绝不进 URL/剪贴板。 */
+  dutyAdopt(input: { server: string; token: string; name: string; channel: string; runner: DesktopAgentRunner }): Promise<DesktopDutyEntry>;
 }
 
 export type DesktopAgentInvoker = <T>(command: string, args?: Record<string, unknown>) => Promise<T>;
@@ -207,6 +209,15 @@ export function createDesktopAgentAdapter(invoke: DesktopAgentInvoker): DesktopA
     },
     async dutyUnpersist(instanceId) {
       await invoke<unknown>("desktop_duty_unpersist", { instanceId });
+    },
+    async dutyAdopt(input) {
+      return parseDutyEntry(await invoke<unknown>("desktop_duty_adopt", {
+        server: input.server,
+        token: input.token,
+        name: input.name,
+        channel: input.channel,
+        runner: input.runner,
+      }));
     },
   };
 }

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -298,6 +298,15 @@
 .desktop-agent-fields select:focus-visible,
 .desktop-agent-fields input:focus-visible { border-color: var(--t-accent); outline: 1px solid var(--t-accent); }
 .desktop-agent-empty,
+/* #616 phase 4：接入包一键接管 */
+.agent-join-adopt {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin: 0 0 10px;
+}
+
 /* #616 phase 3：常驻值守 */
 .desktop-agent-persist {
   flex-direction: row !important;


### PR DESCRIPTION
## 背景

#616 最后一块：web「无人值守」预设在装了桌面端的机器上应一键接管，全程不出现明文 token 复制。

原 issue 提的是 `agentparty://` deep link（浏览器→app）；实现时选了更强的形态：**桌面 app 本身就承载 web UI**——在桌面 webview 里，「＋ 让 agent 加入」的无人值守流程可以直接经 tauri IPC 把 token 交给 shell，**不需要 deep link、token 不进 URL / 剪贴板 / 终端**（#616 的安全红线原文：token 绝不进 URL query）。浏览器→app 的 deep link 因 token 无安全通道（URL 违红线、剪贴板可被嗅探），不做；浏览器用户走脚本或桌面 app 里重新生成。

## 改动

### Rust
- `desktop_duty_adopt(server, token, name, channel, runner)`：
  1. 校验：token 形制（ap_ 前缀/长度/无空白控制字符）、name 对齐 CLI agent 名正则、channel/runner 复用现有校验
  2. 写 `party init` 同构身份配置到 `~/.agentparty/agents/agentparty-<name>-<channel>.json`（0600 + tmp/rename 原子落盘）——CLI 与桌面端从此看见同一个身份文件
  3. `parse_config_summary` 回验（server 白名单、identity 完整性都在其中），不合格即删文件退出
  4. 走 `duty_persist_inner`（与面板 persist 同一内核，phase 3 抽出）装 launchd 常驻
- 非 macOS 明确 unsupported

### Web
- AgentJoin 无人值守 done 页 + `isDesktopRuntime()` → 「⚡ 在本机常驻值守（launchd）」按钮：busy/done/error 三态，成功提示「退出 App、重启机器都不断线」；脚本仍保留在下方给服务器场景
- 非桌面环境 / 交互模式不渲染（有测试）

## 测试
- adopt 参数断言（server 取 apiOrigin 真后端，#530 口径）、成功态渲染、非桌面隐藏
- cargo test 83 通过；check:web 875 通过（tests+tsc+vite build）

Closes #616

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 桌面端无人值守接入包新增“一键接管”，仅在 macOS 桌面场景生效。
  - 接入流程增加令牌驱动的接管状态（空闲/执行中/完成/失败）与对应中英文展示。

- **改进**
  - 强化 macOS 常驻任务的安装/加载校验与恢复策略，失败时提供更清晰的错误信息。
  - 常驻前置停止更可靠，避免重复同身份安装风险。

- **测试与样式**
  - 补充接管交互与按钮渲染相关测试；新增接管区域样式与文案。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->