### PR TITLE
fix(cli): 修 #622 CLI 丢弃所有 welcome 帧——mode 词表对齐 wire ChannelMode

### DIFF
--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -113,10 +113,16 @@ const SENDER_KINDS = new Set(["agent", "human"]);
 const MESSAGE_KINDS = new Set(["message", "status"]);
 const STATUS_STATES = new Set(["working", "waiting", "blocked", "done"]);
 const PRESENCE_STATES = new Set(["online", "offline", "working", "waiting", "blocked", "done"]);
-const CHANNEL_MODES = new Set(["public", "private", "personal", "public_watch"]);
+// welcome.mode carries the wire ChannelMode (shared/src/protocol.ts: "normal" | "party"), NOT the
+// REST channel-visibility vocabulary (public/private/personal/public_watch). The worker sends mode on
+// every welcome, so this MUST stay in lockstep with ChannelMode or parseServerFrame drops every
+// welcome frame (serve never learns `self`, watch never registers its delivery adapter).
+const CHANNEL_MODES = new Set(["normal", "party"]);
 const TOKEN_ROLES = new Set(["agent", "readonly", "owner", "member", "moderator"]);
 const DELIVERY_STATES = new Set(["queued", "claimed", "running", "waiting_owner", "replied", "failed"]);
-const DELIVERY_CAUSES = new Set(["mention", "reply", "owner_answer", "retry"]);
+// Mirror DirectedDeliveryCause in shared/src/protocol.ts exactly — "mention_edit" (a mention added by
+// editing an existing message) is a real cause; omitting it drops those delivery frames.
+const DELIVERY_CAUSES = new Set(["mention", "mention_edit", "reply", "owner_answer", "retry"]);
 const ERROR_CODES = new Set([
   "bad_request",
   "unavailable",

--- a/cli/test/client.test.ts
+++ b/cli/test/client.test.ts
@@ -111,6 +111,57 @@ describe("ws client", () => {
     expect(conn.cursor).toBe(1);
   });
 
+  // Regression: the worker sends a wire ChannelMode ("normal" | "party") on EVERY welcome; the CLI
+  // validator once checked it against the REST visibility vocabulary and silently dropped every
+  // welcome frame (serve never learned `self`, watch never registered its delivery adapter).
+  test("accepts a welcome carrying the wire ChannelMode (normal and party), never dropping it", async () => {
+    for (const mode of ["normal", "party"] as const) {
+      server = startMockServer((frame, sock) => {
+        if (frame.type === "hello") {
+          sock.send({ ...welcomeFrame(1), mode });
+          sock.send(msgFrame(1, "a"));
+        }
+      });
+      conn = connect(server.url, "ap_tok", "dev", 0, {});
+      const frames = await collect(conn, 2, 3000, false);
+      expect(frames.map((f) => f.type)).toEqual(["welcome", "msg"]);
+      conn.close();
+      await server.stop();
+    }
+  });
+
+  // Regression: DELIVERY_CAUSES must mirror DirectedDeliveryCause in the protocol; "mention_edit"
+  // (a mention added by editing an existing message) was missing, so those delivery frames were dropped.
+  test("accepts a directed-delivery frame whose cause is mention_edit", async () => {
+    server = startMockServer((frame, sock) => {
+      if (frame.type === "hello") {
+        sock.send(welcomeFrame(1));
+        sock.send({
+          type: "delivery",
+          delivery: {
+            id: "d-1",
+            message_seq: 1,
+            target_name: "me",
+            cause: "mention_edit",
+            state: "queued",
+            attempt: 0,
+            lease_until: null,
+            work_id: null,
+            continuation_ref: null,
+            reply_seq: null,
+            last_error: null,
+            created_at: 1,
+            updated_at: 1,
+          },
+          message: msgFrame(1, "edited @me in"),
+        });
+      }
+    });
+    conn = connect(server.url, "ap_tok", "dev", 0, {});
+    const frames = await collect(conn, 2, 3000, false);
+    expect(frames.map((f) => f.type)).toEqual(["welcome", "delivery"]);
+  });
+
   test("replayUnacked puts consumed standby frames back before newer queued frames", async () => {
     server = startMockServer((frame, sock) => {
       if (frame.type !== "hello") return;

--- a/cli/test/mock-server.ts
+++ b/cli/test/mock-server.ts
@@ -92,6 +92,9 @@ export function welcomeFrame(lastSeq: number, self = "me", readCursors?: Array<{
   return {
     type: "welcome",
     channel: "dev",
+    // Match the production wire frame: the worker sends mode on EVERY welcome (ChannelMode = "normal"
+    // | "party"). Emitting it here keeps the whole suite honest against parseServerFrame's validator.
+    mode: "normal",
     self,
     last_seq: lastSeq,
     participants: [],


### PR DESCRIPTION
Fixes #622

## 问题
`parseServerFrame` 的 `CHANNEL_MODES`（client.ts:116）用的是 REST 频道 visibility 词表 `{public,private,personal,public_watch}`，但 `welcome.mode` 是 **wire `ChannelMode`**（shared/src/protocol.ts:181 = `normal|party`）。worker（do.ts:2231）在**每个** welcome 上无条件发 `mode`，两词表不相交 → client.ts:280 校验恒 false → **每个 welcome 帧被静默丢弃**（client.ts:599 `if (frame === null) continue;`）。

`party serve`/`party watch` 都消费 `connect()`（client.ts:406）的帧流：
- serve 的 `self` 停在 `""`（只在 welcome 分支 serve.ts:3970 赋值）→ `delivery.target_name !== self` 恒真 → **跳过所有定向 @ 投递**。
- watch 永不进 welcome 分支 → 永不注册 delivery adapter。

回归自 664079e（随 v0.2.120 起所有版本出货）。

## 修复
- `CHANNEL_MODES` → `{normal, party}`，镜像 `ChannelMode`（仅在 welcome 校验处使用，改动安全）。
- `DELIVERY_CAUSES` 补 `mention_edit`，镜像 `DirectedDeliveryCause`（protocol.ts:208）——否则「编辑消息新增 @」产生的 delivery 帧同样被丢。

## 测试盲区 + 回归守卫
现有测试全绿，是因为 mock `welcomeFrame` 从不发 `mode`（`undefined` 直接通过）。本 PR 让它发 production wire `mode:"normal"`，于是**整个 client 测试套自动跑真实线格式**（welcome 被丢 → `client.test.ts:106` 的 `["welcome","msg","msg"]` 断言就会红）。另加两条显式用例：`mode=party` 的 welcome 被接受、`cause=mention_edit` 的 delivery 帧被接受。

`check:cli` 987 pass、`tsc --noEmit` 通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 修正欢迎消息中频道模式的解析，支持协议定义的 `normal` 和 `party` 模式。
  * 修复特定原因的投递消息可能被客户端丢弃的问题。

* **测试**
  * 增加对欢迎消息模式及相关投递消息处理的回归测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->