### PR TITLE
fix(desktop): 修 #623 一键接管值守始终失败——config discovery 纳入 ~/.agentparty/agents/

### DIFF
--- a/desktop/src-tauri/src/agent.rs
+++ b/desktop/src-tauri/src/agent.rs
@@ -213,6 +213,20 @@ fn candidate_config_paths(home: &Path) -> Vec<PathBuf> {
             }
         }
     }
+    // ~/.agentparty/agents/*.json — the join-pack AGENTPARTY_CONFIG convention and where
+    // desktop_duty_adopt writes the adopted identity file. Without this the adopted config is
+    // undiscoverable, so resolve_config (and thus duty_persist_inner) always fails and adopt rolls
+    // back. Skip the *.json.tmp staging files (extension is "tmp", not "json").
+    if let Ok(entries) = fs::read_dir(home.join("agents")) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if entry.file_type().is_ok_and(|kind| kind.is_file())
+                && path.extension().is_some_and(|ext| ext == "json")
+            {
+                paths.push(path);
+            }
+        }
+    }
     paths
 }
 
@@ -954,6 +968,45 @@ mod tests {
         assert_eq!(config_id(&first).unwrap(), first_id);
         assert_ne!(config_id(&second).unwrap(), first_id);
         assert_eq!(first_id.len(), 64);
+    }
+
+    #[test]
+    fn trusted_configs_discovers_adopted_configs_under_agents_dir() {
+        // desktop_duty_adopt writes ~/.agentparty/agents/agentparty-<name>-<channel>.json; resolve_config
+        // must find it there or one-click adopt always fails (config undiscoverable -> persist rolls back).
+        let home = TempDir::new().unwrap();
+        let agents = home.path().join("agents");
+        fs::create_dir_all(&agents).unwrap();
+        let adopted = agents.join("agentparty-bot-dev.json");
+        fs::write(
+            &adopted,
+            r#"{
+                "server":"https://party.example.com",
+                "token":"ap_adopted-secret-token",
+                "identity":{
+                    "name":"bot",
+                    "kind":"agent",
+                    "role":"agent",
+                    "channel_scope":"dev"
+                }
+            }"#,
+        )
+        .unwrap();
+        // the 0600 staging tmp must be ignored — it is not a real config (extension is .tmp, not .json).
+        fs::write(agents.join("agentparty-bot-dev.json.tmp"), "{ partial").unwrap();
+
+        let configs = trusted_configs(home.path()).unwrap();
+        let found = configs.iter().find(|(path, _)| {
+            path.file_name().and_then(|n| n.to_str()) == Some("agentparty-bot-dev.json")
+        });
+        assert!(
+            found.is_some(),
+            "adopted config under agents/ must be discoverable by resolve_config"
+        );
+        let (path, summary) = found.unwrap();
+        assert_eq!(summary.name, "bot");
+        assert_eq!(summary.channel.as_deref(), Some("dev"));
+        assert_eq!(summary.config_id, config_id(path).unwrap());
     }
 
     #[test]

--- a/desktop/src-tauri/src/agent.rs
+++ b/desktop/src-tauri/src/agent.rs
@@ -992,8 +992,22 @@ mod tests {
             }"#,
         )
         .unwrap();
-        // the 0600 staging tmp must be ignored — it is not a real config (extension is .tmp, not .json).
-        fs::write(agents.join("agentparty-bot-dev.json.tmp"), "{ partial").unwrap();
+        // The 0600 staging tmp must be excluded by EXTENSION, not merely by a parse failure — give it
+        // valid contents + a distinct identity so a broken/removed filter would surface "bot-staging".
+        fs::write(
+            agents.join("agentparty-bot-dev.json.tmp"),
+            r#"{
+                "server":"https://party.example.com",
+                "token":"ap_staging-tmp-distinct-token",
+                "identity":{
+                    "name":"bot-staging",
+                    "kind":"agent",
+                    "role":"agent",
+                    "channel_scope":"dev"
+                }
+            }"#,
+        )
+        .unwrap();
 
         let configs = trusted_configs(home.path()).unwrap();
         let found = configs.iter().find(|(path, _)| {
@@ -1007,6 +1021,10 @@ mod tests {
         assert_eq!(summary.name, "bot");
         assert_eq!(summary.channel.as_deref(), Some("dev"));
         assert_eq!(summary.config_id, config_id(path).unwrap());
+        assert!(
+            !configs.iter().any(|(_, s)| s.name == "bot-staging"),
+            ".json.tmp staging config must be excluded by extension, not discovered"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #623

## 问题（#621 一键接管从未成功过）
`desktop_duty_adopt` 把接管的身份文件写到 `~/.agentparty/agents/agentparty-{name}-{channel}.json`（duty.rs:419，join-pack 的 AGENTPARTY_CONFIG 约定同路径）。随后 `duty_persist_inner`（duty.rs:303）调 `resolve_config(config_id)` → `trusted_configs` → `candidate_config_paths`（agent.rs:207）**只扫** `~/.agentparty/config.json` 与 `~/.agentparty/state/*/config.json`，**从不扫 `agents/`**。于是 resolve_config 恒返回 `unknown AgentParty config ID`，adopt 走进回滚分支（duty.rs:509-527）→ 整个接管失败。

## 修复
`candidate_config_paths` 纳入 `~/.agentparty/agents/*.json`（跳过 `.json.tmp` 暂存文件）。副作用（正向）：被接管的常驻同时对 `desktop_agent_status` 可见。

## 测试
新增 `trusted_configs_discovers_adopted_configs_under_agents_dir`：在 `agents/` 下写一份合法 adopted config + 一个 `.json.tmp` 暂存文件，断言前者被 `trusted_configs` 发现、后者被忽略，且 `config_id` 一致。

`cargo test --lib` 84 pass（含新用例）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 现在会自动发现并加载 `~/.agentparty/agents/` 目录下的已采用配置文件（包含对应的名称/频道/配置标识）。
  * 会基于扩展名过滤并忽略如 `agentparty-<name>-<channel>.json.tmp` 的临时/暂存文件，避免即使内容有效也被误当作配置。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->