### PR TITLE
fix(worker): 修 #624 #625 #626 #627 #640 #644 —— 附件安全 / seq 单调 / 投递唤醒 / schema

### DIFF
--- a/worker/src/attachments.ts
+++ b/worker/src/attachments.ts
@@ -29,6 +29,24 @@ export function parseAttachments(raw: unknown): Attachment[] | null | undefined 
   return out;
 }
 
+// #624：把每个附件的 url 强制锚定到本频道的下载端点（由 key 推导），绝不信任客户端传入的 url。
+// 否则频道成员可把 url 指向攻击者源；其他成员的客户端渲染时会携带自己的 bearer token 去 fetch 该
+// url（见 web AttachmentList useAttachmentBlobUrl / resolveAttachmentDownloadUrl），token 即外泄。
+// 下载端点（GET /api/channels/:slug/attachments/:path）按 URL 里的 slug 从 R2 取对象，key 只是引用，
+// 所以这里只需保证落库/回传的 url 永远是同源相对路径。key 未按频道前缀（上传端点构造为 `${slug}/…`）
+// 时仍强制锚定成同源路径——最坏是个无效链接，绝不外泄。入站落库与出站回传两侧都要过一遍。
+export function anchorAttachmentUrls(
+  attachments: Attachment[] | undefined,
+  slug: string,
+): Attachment[] | undefined {
+  if (attachments === undefined) return undefined;
+  const prefix = `${slug}/`;
+  return attachments.map((a) => ({
+    ...a,
+    url: `/api/channels/${slug}/attachments/${a.key.startsWith(prefix) ? a.key.slice(prefix.length) : a.key}`,
+  }));
+}
+
 // 出站：库里存的 attachments_json 字符串 → Attachment[]（非法/空 → undefined，序列化时省略字段）。
 export function parseStoredAttachments(input: unknown): Attachment[] | undefined {
   if (typeof input !== "string" || input === "") return undefined;

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -5437,6 +5437,16 @@ export class ChannelDO extends Server<Env> {
       }
       const now = Date.now();
       const state: CompletionReviewState = action === "approve" ? "approved" : "rejected";
+      // #627 / CodeRabbit #650：驳回回复要定向投递给完成作者（agent）。必须用落库时快照的
+      // creation-time principal（row.sender_owner），不是当前同名 token 的 owner——原 agent 被撤、
+      // 同名 token 被别的 owner 重建时，按当前 owner 投递会送错人。缺快照则在改动 review 状态**前**
+      // fail closed，绝不静默投给错误 owner 或原地失败。
+      if (action === "reject" && String(row.sender_kind) === "agent" && senderOwner === undefined) {
+        return Response.json(
+          { error: { code: "unavailable", message: "completion is missing its creation-time principal; cannot bind reject reply delivery" } },
+          { status: 503 },
+        );
+      }
       this.ctx.storage.sql.exec(
         `UPDATE messages
             SET completion_review_state = ?,
@@ -5468,13 +5478,12 @@ export class ChannelDO extends Server<Env> {
       const mentions = action === "reject" ? [senderName] : [];
       const reply = this.insertReviewerReply(identity, replyBody, mentions, seq, now);
       this.broadcastFrame(reply);
-      // #627：驳回回复 @ 原作者（agent）必须绑定 creation-time principal，否则 ensureDirectedDeliveries
-      // 存 target_owner=null，dispatchNextDirectedDelivery 的 null-principal 守卫立即把行置 failed
-      // (delivery_failed 不在 REVIVABLE_DELIVERY_FAILURES)→ agent 永远不被唤醒重交。镜像决策回应路径
-      // 的 agentOwnersForTargets 绑定。
+      // #627：驳回回复 @ 原作者（agent）必须绑定 creation-time principal（上面 fail-closed 已保证
+      // agent sender 时 senderOwner 存在），否则 ensureDirectedDeliveries 存 target_owner=null，
+      // dispatchNextDirectedDelivery 的 null-principal 守卫立即把行置 failed（delivery_failed 不在
+      // REVIVABLE_DELIVERY_FAILURES）→ agent 永远不被唤醒重交。
       const rejectTargets = String(row.sender_kind) === "agent" ? [senderName] : [];
-      const rejectTargetOwners =
-        rejectTargets.length > 0 ? ((await this.agentOwnersForTargets([senderName])) ?? {}) : {};
+      const rejectTargetOwners = senderOwner !== undefined ? { [senderName]: senderOwner } : {};
       await this.afterSend(reply, rejectTargets, false, rejectTargetOwners);
       return Response.json({ message: publicMsgFrame(message), reply: publicMsgFrame(reply) });
     }

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -5427,8 +5427,10 @@ export class ChannelDO extends Server<Env> {
           ? "sender"
           : (String(row.completion_review_policy) as CompletionReviewPolicy);
       const senderName = String(row.sender_name);
+      // #650 CodeRabbit：空串 sender_owner 视同缺失快照——绝不能当成一个合法 principal 绕过 fail-closed
+      // 守卫，也不能在 owner-policy 校验里让两个「空 owner」误相等。
       const senderOwner =
-        row.sender_owner === null || row.sender_owner === undefined ? undefined : String(row.sender_owner);
+        typeof row.sender_owner === "string" && row.sender_owner.length > 0 ? row.sender_owner : undefined;
       if (identity.name === senderName) {
         return Response.json({ error: { code: "forbidden", message: "completion sender cannot review their own completion" } }, { status: 403 });
       }

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -98,7 +98,7 @@ import {
   resolveMentionToken,
   type MentionAlias,
 } from "@agentparty/shared/mentions";
-import { parseAttachments, parseStoredAttachments } from "./attachments";
+import { anchorAttachmentUrls, parseAttachments, parseStoredAttachments } from "./attachments";
 import { sha256Hex } from "./auth";
 import { Server, type Connection, type ConnectionContext, type WSMessage } from "partyserver";
 
@@ -4466,7 +4466,7 @@ export class ChannelDO extends Server<Env> {
     notifyWebhooks = false,
     options: { mentions?: string[]; workflow?: StatusWorkflow; broadcast?: boolean; state?: StatusState } = {},
   ): MsgFrame {
-    const seq = this.lastSeq() + 1;
+    const seq = this.nextSeq();
     // 默认 waiting 而非 blocked（#143）：信息类系统事件是常态、blocked 是例外，默认值失误的方向
     // 必须是安全的。blocked 会让守 etiquette 的 agent 停手等人类，误报的代价远大于漏报。
     const state = options.state ?? "waiting";
@@ -4514,7 +4514,7 @@ export class ChannelDO extends Server<Env> {
   }
 
   private insertReviewerReply(identity: Identity, body: string, mentions: string[], replyTo: number, now: number): MsgFrame {
-    const seq = this.lastSeq() + 1;
+    const seq = this.nextSeq();
     const effectiveRole = identity.collabRole;
     const roleSource: CollaborationRoleSource | undefined = identity.collabRole === undefined ? undefined : "assigned";
     this.ctx.storage.sql.exec(
@@ -4554,7 +4554,7 @@ export class ChannelDO extends Server<Env> {
     response: DecisionResponse,
     now: number,
   ): MsgFrame {
-    const seq = this.lastSeq() + 1;
+    const seq = this.nextSeq();
     const effectiveRole = identity.collabRole;
     const roleSource: CollaborationRoleSource | undefined = identity.collabRole === undefined ? undefined : "assigned";
     this.ctx.storage.sql.exec(
@@ -5468,7 +5468,14 @@ export class ChannelDO extends Server<Env> {
       const mentions = action === "reject" ? [senderName] : [];
       const reply = this.insertReviewerReply(identity, replyBody, mentions, seq, now);
       this.broadcastFrame(reply);
-      await this.afterSend(reply, String(row.sender_kind) === "agent" ? [senderName] : []);
+      // #627：驳回回复 @ 原作者（agent）必须绑定 creation-time principal，否则 ensureDirectedDeliveries
+      // 存 target_owner=null，dispatchNextDirectedDelivery 的 null-principal 守卫立即把行置 failed
+      // (delivery_failed 不在 REVIVABLE_DELIVERY_FAILURES)→ agent 永远不被唤醒重交。镜像决策回应路径
+      // 的 agentOwnersForTargets 绑定。
+      const rejectTargets = String(row.sender_kind) === "agent" ? [senderName] : [];
+      const rejectTargetOwners =
+        rejectTargets.length > 0 ? ((await this.agentOwnersForTargets([senderName])) ?? {}) : {};
+      await this.afterSend(reply, rejectTargets, false, rejectTargetOwners);
       return Response.json({ message: publicMsgFrame(message), reply: publicMsgFrame(reply) });
     }
     // 人类决策回应（#284）：镜像 completion review 的收口——resolve 请求 + 广播 message_update("decision")
@@ -6735,7 +6742,7 @@ export class ChannelDO extends Server<Env> {
     const now = Date.now();
 
     const sql = this.ctx.storage.sql;
-    const seq = this.lastSeq() + 1;
+    const seq = this.nextSeq();
     const sender: Sender = senderFromIdentity(identity);
     const hostDecision = frame.kind === "status" ? hostDecisionFromSend(frame.decision, identity.name) : undefined;
     const workflow = frame.kind === "status" ? statusWorkflowFromSend(frame.workflow) : undefined;
@@ -6764,7 +6771,8 @@ export class ChannelDO extends Server<Env> {
     const completionGate = this.getMeta("completion_gate");
     const completionReviewPolicy = (this.getMeta("completion_review_policy") ?? "sender") as CompletionReviewPolicy;
     const completionArtifact = frame.kind === "message" ? frame.completion_artifact : undefined;
-    const attachments = frame.kind === "message" ? frame.attachments : undefined;
+    // #624：落库前把附件 url 强制锚定到本频道（由 key 推导），不信任客户端传入的 url，杜绝 token 外泄。
+    const attachments = frame.kind === "message" ? anchorAttachmentUrls(frame.attachments, this.name) : undefined;
     // decision_request（#284/#548）：public parser 只保留 prompt/kind/options，并主动丢掉客户端
     // 自称的 delivery/work/thread。仅 sender 恰好有一条 active durable work 时由服务端绑定血缘；
     // 多条 active 说明 invariant 已破坏，fail closed，不能猜错 owner answer 应恢复哪一条。
@@ -7755,9 +7763,26 @@ export class ChannelDO extends Server<Env> {
     }
   }
 
+  // seq 计数器同样落 meta，绝不从 MAX(seq) 派生（#626）。与 rev_seq 同源的坑：保留期修剪
+  // 按 ts 删行（DELETE FROM messages WHERE ts <= cutoff，无「保留最后 N 条」下限），一个配了
+  // message_retention_ms 的频道久静默后会把整张表清空；此时 MAX(seq) 塌回 0，下条消息从 seq=1
+  // 重启、复用已被在线端消费过的号。recordSeen 因老 read_cursor 已 >= 复用 seq 而不推进，
+  // 流式消费端（serve/watch/web）按 seq > cursor 过滤 → 新 @ 帧被当积压丢掉，永久漏收唤醒。
+  // 首次读取时从 MAX(seq) 播种，存量 DO 无需迁移即可平滑升级。
   private lastSeq(): number {
+    const cached = this.getMeta("seq");
+    if (cached !== null) return Number(cached);
     const row = this.ctx.storage.sql.exec("SELECT COALESCE(MAX(seq), 0) AS last FROM messages").one();
-    return Number(row.last);
+    const seeded = Number(row.last);
+    this.setMeta("seq", String(seeded));
+    return seeded;
+  }
+
+  // 单调递增，且立即落盘——即便本次写入随后失败，号也不会被复用（与 nextRevSeq 一致）。
+  private nextSeq(): number {
+    const next = this.lastSeq() + 1;
+    this.setMeta("seq", String(next));
+    return next;
   }
 
   // 已读游标快照（welcome 首帧下发）。
@@ -9651,7 +9676,8 @@ export class ChannelDO extends Server<Env> {
       if (decisionResponse !== undefined) frame.decision_response = decisionResponse;
       const workflowRef = parseStoredStatusWorkflow(r.message_workflow_json);
       if (workflowRef !== undefined) frame.workflow_ref = workflowRef;
-      const attachments = parseStoredAttachments(r.attachments_json);
+      // #624 出站防御：即便库里存了历史/恶意的绝对 url，回传前也一律锚定成同源相对路径。
+      const attachments = anchorAttachmentUrls(parseStoredAttachments(r.attachments_json), this.name);
       if (attachments !== undefined) frame.attachments = attachments;
     }
     if (r.edited_at !== null && r.edited_at !== undefined) {

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -5242,9 +5242,13 @@ app.put("/api/channels/:slug/visibility", async (c) => {
     timestamp: now,
     metadata: { visibility },
   });
-  // #644：visibility 改动此刻已提交（init 已成、审计已落）。系统状态是 best-effort 旁路，写失败
-  // 绝不能反回 503 让客户端以为整体失败——忽略其结果，照常返回成功。
-  await insertSystemStatus(c.env, slug, `visibility changed to ${visibility} by ${identity.name}`, "waiting", now);
+  // #644：visibility 改动此刻已提交（init 已成、审计已落）。系统状态是 best-effort 旁路，返回 false
+  // 或**抛错**（DO 调用异常）都绝不能让客户端以为整体失败——吞掉结果与异常，照常返回成功（CodeRabbit #650）。
+  try {
+    await insertSystemStatus(c.env, slug, `visibility changed to ${visibility} by ${identity.name}`, "waiting", now);
+  } catch {
+    // best-effort：系统状态写失败不影响已提交的 visibility 改动。
+  }
   const recentSpeakers =
     visibility === "private" ? await recentNonMemberSpeakers(c.env.DB, c.env, slug, channel.owner_account) : [];
   return c.json({

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -3510,7 +3510,9 @@ app.post("/api/channels/:slug/lark-notify", async (c) => {
       headers: { "content-type": "application/json", "x-partykit-room": slug },
     }),
   );
-  if (!doRes.ok) return doRes;
+  // #644：DO 响应的 headers 不可变；直接透传会让下游 CORS 中间件改 header 时抛异常 → 500 掩盖真错。
+  // 重建成 headers 可变的响应再回传，让真实错误码/正文透出来。
+  if (!doRes.ok) return new Response(doRes.body, { status: doRes.status, headers: new Headers(doRes.headers) });
   const now = Date.now();
   await c.env.DB.prepare(
     `INSERT INTO lark_notify_subscriptions (
@@ -5240,8 +5242,9 @@ app.put("/api/channels/:slug/visibility", async (c) => {
     timestamp: now,
     metadata: { visibility },
   });
-  const ok = await insertSystemStatus(c.env, slug, `visibility changed to ${visibility} by ${identity.name}`, "waiting", now);
-  if (!ok) return c.json(errorBody("unavailable", "visibility changed but audit status failed"), 503);
+  // #644：visibility 改动此刻已提交（init 已成、审计已落）。系统状态是 best-effort 旁路，写失败
+  // 绝不能反回 503 让客户端以为整体失败——忽略其结果，照常返回成功。
+  await insertSystemStatus(c.env, slug, `visibility changed to ${visibility} by ${identity.name}`, "waiting", now);
   const recentSpeakers =
     visibility === "private" ? await recentNonMemberSpeakers(c.env.DB, c.env, slug, channel.owner_account) : [];
   return c.json({
@@ -6901,6 +6904,17 @@ app.get("/api/channels/:slug/attachments/:path{.+}", async (c) => {
   if (!headers.has("content-type")) headers.set("content-type", "application/octet-stream");
   // nosniff：即便 content-type 被伪造也不让浏览器嗅探成可执行类型，缓解存储型 XSS
   headers.set("x-content-type-options", "nosniff");
+  // #625：content_type 是上传者可控的。nosniff 挡不住【显式】的 text/html 或 image/svg+xml——
+  // 直接在浏览器打开该 url 就会内联渲染、在 worker 源上执行脚本，窃取同源 ap_token。除了少数
+  // 一定安全内联的栅格图，其余一律 Content-Disposition: attachment 强制下载而非渲染。
+  const servedType = (headers.get("content-type") ?? "").split(";")[0]!.trim().toLowerCase();
+  const INLINE_SAFE_TYPES = new Set(["image/png", "image/jpeg", "image/gif", "image/webp", "image/avif"]);
+  if (!INLINE_SAFE_TYPES.has(servedType)) {
+    const rawName = object.customMetadata?.filename;
+    const downloadName = typeof rawName === "string" && rawName.length > 0 ? rawName : "download";
+    // filename* 走 RFC 5987 百分号编码，杜绝借文件名注入 header。
+    headers.set("content-disposition", `attachment; filename*=UTF-8''${encodeURIComponent(downloadName)}`);
+  }
   headers.set("referrer-policy", "no-referrer");
   if (signedRequest) headers.set("cache-control", "private, max-age=900");
   return new Response(object.body, { headers });

--- a/worker/src/nickname.ts
+++ b/worker/src/nickname.ts
@@ -19,7 +19,10 @@ export async function nicknameConflict(
   nickname: string,
   forName: string,
 ): Promise<"reserved" | "token_name" | "handle" | "taken" | null> {
-  if (RESERVED_NAMES.includes(nickname)) return "reserved";
+  // #644：保留名比较必须大小写不敏感——其余各项都用 COLLATE NOCASE，而 @ 解析也是大小写不敏感的，
+  // 若这里区分大小写，agent 就能用 "Everyone"/"OWNER" 等变体抢注保留 @ 命名空间、遮蔽广播语义。
+  const loweredNickname = nickname.toLowerCase();
+  if (RESERVED_NAMES.some((reserved) => reserved.toLowerCase() === loweredNickname)) return "reserved";
   const tok = await db.prepare("SELECT 1 FROM tokens WHERE name = ? COLLATE NOCASE").bind(nickname).first();
   if (tok) return "token_name";
   const handle = await db

--- a/worker/src/openapi.ts
+++ b/worker/src/openapi.ts
@@ -493,6 +493,9 @@ export const openapiDocument = {
                   role: { type: "string", enum: ["agent", "human", "readonly"] },
                   owner: {
                     type: "string",
+                    minLength: 1,
+                    maxLength: 128,
+                    pattern: "^[\\x20-\\x7e]+$",
                     description: "owner account label (printable ascii, <= 128 chars) — required since P1",
                   },
                 },

--- a/worker/src/openapi.ts
+++ b/worker/src/openapi.ts
@@ -487,13 +487,13 @@ export const openapiDocument = {
             "application/json": {
               schema: {
                 type: "object",
-                required: ["name", "role"],
+                required: ["name", "role", "owner"],
                 properties: {
                   name: { type: "string" },
                   role: { type: "string", enum: ["agent", "human", "readonly"] },
                   owner: {
                     type: "string",
-                    description: "optional owner label (printable ascii, <= 128 chars)",
+                    description: "owner account label (printable ascii, <= 128 chars) — required since P1",
                   },
                 },
               },
@@ -611,6 +611,11 @@ export const openapiDocument = {
                   title: { type: "string" },
                   kind: { type: "string", enum: ["standing", "temp"] },
                   mode: { type: "string", enum: ["normal", "party"], default: "normal" },
+                  visibility: {
+                    type: "string",
+                    enum: ["public", "private", "public_watch"],
+                    default: "private",
+                  },
                 },
               },
             },
@@ -618,9 +623,10 @@ export const openapiDocument = {
         },
         responses: {
           "201": { description: "created" },
-          "400": { description: "invalid slug/kind/mode" },
+          "400": { description: "invalid slug/kind/mode/visibility" },
           "403": { description: "readonly token" },
           "409": { description: "slug conflict" },
+          "429": { description: "channel creation rate limit exceeded" },
           "503": { description: "temp channel initialization failed" },
         },
       },
@@ -1539,6 +1545,12 @@ export const openapiDocument = {
                     enum: ["mentions", "status", "needs-human", "all"],
                     default: "mentions",
                   },
+                  mode: {
+                    type: "string",
+                    enum: ["notify", "agent"],
+                    default: "notify",
+                    description: "notify = fire-and-forget wake; agent = the webhook acts as a channel agent",
+                  },
                 },
               },
             },
@@ -1546,7 +1558,7 @@ export const openapiDocument = {
         },
         responses: {
           "201": { description: "registered (same name overwrites)" },
-          "400": { description: "invalid name/url/secret/filter" },
+          "400": { description: "invalid name/url/secret/filter/mode" },
           "403": { description: "readonly token" },
           "410": { description: "channel archived" },
         },

--- a/worker/test/attachments.spec.ts
+++ b/worker/test/attachments.spec.ts
@@ -160,6 +160,66 @@ describe("channel attachments (R2)", () => {
     });
   });
 
+  it("#624: re-anchors a client-forged attachment url to the channel download path (no token exfil)", async () => {
+    const { token } = await seedToken("agent", uniq("owner"), { owner: "owner@ap.test" });
+    const slug = await createChannel(token);
+    const bytes = new TextEncoder().encode("real bytes");
+    const meta = (await (await upload(slug, token, "doc.pdf", bytes, "application/pdf")).json()) as {
+      key: string;
+      filename: string;
+      content_type: string;
+      size: number;
+      url: string;
+    };
+    // 客户端伪造 url 指向攻击者源（key 仍是合法频道 key）。服务端必须落库/回传时锚定回同源路径，
+    // 否则其他成员的客户端携带自己的 bearer token 去 fetch 该 url 就外泄了 token。
+    const send = await api(`/api/channels/${slug}/messages`, token, {
+      method: "POST",
+      body: JSON.stringify({
+        kind: "message",
+        body: "forged url",
+        mentions: [],
+        reply_to: null,
+        attachments: [{ ...meta, url: "https://attacker.example/steal" }],
+      }),
+    });
+    expect(send.status).toBe(200);
+
+    const list = await api(`/api/channels/${slug}/messages`, token);
+    const { messages } = (await list.json()) as { messages: MsgFrame[] };
+    const served = messages.find((m) => m.body === "forged url")?.attachments?.[0]?.url ?? "";
+    expect(served).not.toContain("attacker.example");
+    expect(served.startsWith(`/api/channels/${slug}/attachments/`)).toBe(true);
+    expect(served).toBe(meta.url);
+  });
+
+  it("#625: forces Content-Disposition attachment for uploader-controlled text/html; images stay inline", async () => {
+    const { token } = await seedToken("agent", uniq("owner"), { owner: "owner@ap.test" });
+    const slug = await createChannel(token);
+    // 上传者可控 content_type；text/html 内联渲染就是存储型 XSS（nosniff 挡不住显式类型）。
+    const html = (await (await upload(
+      slug,
+      token,
+      "x.html",
+      new TextEncoder().encode("<script>alert(document.cookie)</script>"),
+      "text/html",
+    )).json()) as { url: string };
+    const dl = await download(slug, token, html.url.split("/attachments/")[1]!);
+    expect(dl.status).toBe(200);
+    expect(dl.headers.get("content-disposition") ?? "").toContain("attachment");
+
+    // 栅格图仍可内联，图片预览不受影响。
+    const png = (await (await upload(
+      slug,
+      token,
+      "p.png",
+      new Uint8Array([0x89, 0x50, 0x4e, 0x47, 1, 2, 3]),
+      "image/png",
+    )).json()) as { url: string };
+    const pdl = await download(slug, token, png.url.split("/attachments/")[1]!);
+    expect(pdl.headers.get("content-disposition")).toBeNull();
+  });
+
   it("dedupes by content hash: same bytes+filename → same key; different bytes → different key (#387)", async () => {
     const { token } = await seedToken("agent", uniq("owner"), { owner: "owner@ap.test" });
     const slug = await createChannel(token);

--- a/worker/test/nickname.spec.ts
+++ b/worker/test/nickname.spec.ts
@@ -53,6 +53,15 @@ describe("agent 设昵称 + 全局唯一（#165）", () => {
     expect((await setNickname(a2.token, "唯一名")).status).toBe(409);
   });
 
+  it("#644: 保留名大小写不敏感——agent 不能用 System/SYSTEM 变体抢注保留 @ 命名空间", async () => {
+    const agent = await seedToken("agent", uniq("a"));
+    // RESERVED_NAMES=["system"]；@ 解析大小写不敏感，若保留名闸区分大小写，变体就能遮蔽广播语义。
+    // 修复前这些变体不撞保留名、也不撞任何 token/handle → 会 200 通过；修复后一律判冲突（409）。
+    expect((await setNickname(agent.token, "System")).status).toBe(409);
+    expect((await setNickname(agent.token, "SYSTEM")).status).toBe(409);
+    expect((await setNickname(agent.token, "SyStEm")).status).toBe(409);
+  });
+
   it("昵称不能撞人类 handle（共用 @ 命名空间）", async () => {
     const owner = uniq("acct");
     const human = await seedToken("human", uniq("h"), { owner });

--- a/worker/test/seq-counter.spec.ts
+++ b/worker/test/seq-counter.spec.ts
@@ -1,0 +1,67 @@
+// #626：seq 必须来自单调计数器，绝不能从 MAX(seq) 派生（与 #125 的 rev_seq 同源问题）。
+//
+// 保留期修剪按 ts 删行（DELETE FROM messages WHERE ts <= cutoff），没有「保留最后 N 条」下限。
+// 一个配了 message_retention_ms 的频道久静默后会把整张表清空；此时 MAX(seq) 塌回 0，下条消息
+// 从 seq=1 重启、复用已被在线端消费过的号。recordSeen 因老 read_cursor 已 >= 复用 seq 而不推进，
+// 流式消费端（serve/watch/web）按 seq > cursor 过滤 → 新 @ 帧被当积压丢掉，永久漏收唤醒。
+import { env, runInDurableObject } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import type { ChannelDO } from "../src/do";
+import { createChannel, postMessage, seedToken, uniq, WsClient } from "./helpers";
+
+/** 精确模拟保留期把整张表清空（久静默频道会被 pruneRetainedContent 清到空）。 */
+async function drainMessages(slug: string): Promise<void> {
+  const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+  await runInDurableObject(stub, async (_i: ChannelDO, state) => {
+    state.storage.sql.exec("DELETE FROM messages");
+  });
+}
+
+async function tableMaxSeq(slug: string): Promise<number> {
+  const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+  return runInDurableObject(stub, async (_i: ChannelDO, state) => {
+    const row = state.storage.sql.exec("SELECT COALESCE(MAX(seq), 0) AS m FROM messages").one();
+    return Number(row.m);
+  });
+}
+
+async function welcomeLastSeq(slug: string, token: string): Promise<number> {
+  const ws = await WsClient.open(slug, token);
+  const welcome = (await ws.nextOfType("welcome")) as { last_seq?: number };
+  ws.close();
+  return welcome.last_seq ?? 0;
+}
+
+describe("seq monotonic counter (#626)", () => {
+  it("never reuses a seq after retention drains the whole messages table", async () => {
+    const author = await seedToken("human", uniq("a"));
+    const slug = await createChannel(author.token);
+
+    let lastSeq = 0;
+    for (let i = 0; i < 4; i++) {
+      const m = (await (await postMessage(slug, author.token, `m${i}`)).json()) as { seq: number };
+      lastSeq = m.seq;
+    }
+    expect(lastSeq).toBeGreaterThanOrEqual(4);
+
+    await drainMessages(slug);
+    expect(await tableMaxSeq(slug)).toBe(0); // 表已空——修复前 MAX(seq) 会塌回 0
+
+    // 清空后再发一条：修复前复用 seq=1，修复后必须严格大于已消费过的 lastSeq。
+    const next = (await (await postMessage(slug, author.token, "after drain")).json()) as { seq: number };
+    expect(next.seq).toBeGreaterThan(lastSeq);
+  }, 30_000);
+
+  it("welcome.last_seq never goes backwards even after the table is drained", async () => {
+    const author = await seedToken("human", uniq("a"));
+    const slug = await createChannel(author.token);
+    for (let i = 0; i < 3; i++) expect((await postMessage(slug, author.token, `m${i}`)).status).toBe(200);
+
+    const before = await welcomeLastSeq(slug, author.token);
+    expect(before).toBeGreaterThanOrEqual(3);
+
+    await drainMessages(slug);
+    const after = await welcomeLastSeq(slug, author.token);
+    expect(after).toBeGreaterThanOrEqual(before); // 修复前会随 MAX 回退到 0
+  }, 30_000);
+});


### PR DESCRIPTION
大筛查 worker 层修复，6 个 issue。`check:worker` 全绿（697 vitest pass、tsc、verify:test-runtime）。

- **#624**（security）附件 `url` 未锚定频道 → token 外泄。新增 `anchorAttachmentUrls`（attachments.ts 单实现），在**落库**（do.ts 消息持久化）与**回传**（rowToFrame）两侧都用 channel-anchored `key` 重推 `url`，绝不信任客户端 url。加 round-trip 伪造 url 被锚定的用例。
- **#625**（security）附件下载对上传者可控 Content-Type 强制 `Content-Disposition: attachment`（栅格图除外），堵住显式 `text/html`/`svg` 内联 XSS（nosniff 挡不住显式类型）。加 text/html 强制下载 + png 仍内联的用例。
- **#626**（data-loss）`seq` 改持久 meta 计数器，镜像 `rev_seq`/`nextRevSeq`；保留期把 messages 清空后不再从 `MAX(seq)` 塌回 0 复用已消费的号（否则 recordSeen 不推进、流式端按 `seq>cursor` 丢新 @ 帧）。新增 `seq-counter.spec.ts`。
- **#627**（data-loss）完成复审**驳回**回复 @ agent 现绑定 creation-time principal（`agentOwnersForTargets`），否则 null-principal 定向投递被立即置 `failed`、agent 永不被唤醒重交。镜像决策回应路径。
- **#640**（doc）OpenAPI 对齐实现：`POST /api/tokens` `owner` 必填、webhooks `mode`(notify|agent)、`POST /api/channels` `visibility` 字段 + 429 响应（均已核实 impl）。
- **#644**（bug）lark-notify enable 重建 headers 可变的响应（不再让 CORS 中间件改 immutable header 抛 500 掩盖真错）；`PUT visibility` 的 best-effort 审计写失败不再误回 503（改动此刻已提交）；nickname 保留名闸改**大小写不敏感**（挡住 `System`/`SYSTEM` 抢注保留 @ 命名空间）。加 nickname 用例。

Fixes #624
Fixes #625
Fixes #626
Fixes #627
Fixes #640
Fixes #644

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **安全性**
  * 附件 URL 回传与历史回放统一锚定为当前频道同源下载路径，防止伪造外链。
  * 下载附件按内容类型控制内联/附件行为；不安全类型强制以附件下载，降低内联渲染风险；保留昵称冲突改为大小写不敏感。
* **可靠性**
  * 消息序号改为持久化单调计数，避免历史清理/修剪导致序号回退；驳回相关投递与错误处理更一致。
  * 通知创建失败与可见性切换失败的返回策略更符合预期。
* **文档**
  * 更新 OpenAPI：令牌 `owner` 必填；频道创建新增 `visibility`；Webhook 注册新增 `mode`，并补充相关校验与速率限制说明。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->