### PR TITLE
fix(cli): 修 #628 #629 #643 —— WS 重连超时+瞬时退避 / 剥离终端控制序列 / watch 锁与无界集合

### DIFF
--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -72,6 +72,10 @@ class FrameQueue {
 
 export const DEFAULT_MAX_UNACKED_FRAMES = 4096;
 
+// #628：升级被拒后的 REST 探测必须带超时，否则半开/黑洞网络下 fetch promise 永不 settle，
+// onclose 的 .then/.catch 都不触发，重连永不推进（rest.ts 每个请求同样用 30s 超时兜底，#116）。
+const PROBE_TIMEOUT_MS = 10_000;
+
 const RETRYABLE_NETWORK_CODES = new Set([
   "EAI_AGAIN",
   "ECONNABORTED",
@@ -487,7 +491,8 @@ export function connect(
     try {
       const res = await fetch(
         `${httpBase}/api/channels/${encodeURIComponent(slug)}/messages?since=0&limit=1`,
-        { headers: { authorization: `Bearer ${token}` } },
+        // #628：带超时的探测——超时抛 TimeoutError，isRetryableNetworkError 认它可重试，落回 scheduleReconnect()。
+        { headers: { authorization: `Bearer ${token}` }, signal: AbortSignal.timeout(PROBE_TIMEOUT_MS) },
       );
       if (res.status === 401) {
         return { type: "error", code: "unauthorized", message: "invalid or revoked token, re-run: party init" };
@@ -497,6 +502,13 @@ export function connect(
       }
       if (res.status === 404) {
         return { type: "error", code: "not_found", message: `channel not found: ${slug}` };
+      }
+      // #628：429（限流）与 5xx（滚动部署 / Cloudflare 过载）是瞬时的，返回 null 让 onclose
+      // 退避重连，而非致命化——否则一次瞬时抖动就把长跑的 serve/watch 打死。只有真正非预期
+      // 的状态（400 等，重试也不会好）才走 throw → queue.fail 终止帧流。
+      if (res.status === 429 || res.status >= 500) {
+        console.debug(`party ws probe: transient HTTP ${res.status}; reconnecting`);
+        return null;
       }
       if (!res.ok) {
         throw new Error(`websocket probe failed: HTTP ${res.status}${res.statusText ? ` ${res.statusText}` : ""}`);

--- a/cli/src/commands/board.ts
+++ b/cli/src/commands/board.ts
@@ -2,6 +2,7 @@
 import type { TaskRecord, TaskState } from "@agentparty/shared";
 import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
 import { resolveChannel } from "../config";
+import { stripTerminalControls } from "../format";
 import { jsonFrame } from "../json";
 import { resolveAuth } from "../oidc-cli";
 import { fetchMe, handleRestError, listTasks } from "../rest";
@@ -30,10 +31,11 @@ function compact(text: string): string {
   return text.replace(/\s+/g, " ").trim();
 }
 
-function formatTask(task: TaskRecord): string {
+export function formatTask(task: TaskRecord): string {
   const assignee = task.assignee === null ? "unassigned" : `@${task.assignee.name}`;
   const labels = task.labels.length > 0 ? ` [${task.labels.join(",")}]` : "";
-  return `  #${task.id} P${task.priority} ${assignee}${labels} ${compact(task.title)}`;
+  // #629：title/assignee/labels 都是服务端存的参与者可控自由文本，剥离终端控制序列后再打印（同 task.ts:93）。
+  return stripTerminalControls(`  #${task.id} P${task.priority} ${assignee}${labels} ${compact(task.title)}`);
 }
 
 function summarize(tasks: TaskRecord[]) {

--- a/cli/src/commands/board.ts
+++ b/cli/src/commands/board.ts
@@ -2,7 +2,7 @@
 import type { TaskRecord, TaskState } from "@agentparty/shared";
 import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
 import { resolveChannel } from "../config";
-import { stripTerminalControls } from "../format";
+import { sanitizeSingleLine } from "../format";
 import { jsonFrame } from "../json";
 import { resolveAuth } from "../oidc-cli";
 import { fetchMe, handleRestError, listTasks } from "../rest";
@@ -34,8 +34,10 @@ function compact(text: string): string {
 export function formatTask(task: TaskRecord): string {
   const assignee = task.assignee === null ? "unassigned" : `@${task.assignee.name}`;
   const labels = task.labels.length > 0 ? ` [${task.labels.join(",")}]` : "";
-  // #629：title/assignee/labels 都是服务端存的参与者可控自由文本，剥离终端控制序列后再打印（同 task.ts:93）。
-  return stripTerminalControls(`  #${task.id} P${task.priority} ${assignee}${labels} ${compact(task.title)}`);
+  // #629/#652：title/assignee/labels 都是服务端存的参与者可控自由文本。整行单列（无可信 TAB 分隔），
+  // 故整行过 sanitizeSingleLine：既剥离终端控制序列（同 task.ts:93），又把残留 TAB/换行折叠成空格，
+  // 防止塞入 \n 伪造整行、塞入 \t 伪造列。
+  return sanitizeSingleLine(`  #${task.id} P${task.priority} ${assignee}${labels} ${compact(task.title)}`);
 }
 
 function summarize(tasks: TaskRecord[]) {

--- a/cli/src/commands/channel.ts
+++ b/cli/src/commands/channel.ts
@@ -1,6 +1,7 @@
 // party channel create|list|archive|reset-guard
 import { isHelpArg, parseArgs, str, strArray, unknownFlagError, valueFlagError } from "../args";
 import { resolveChannel } from "../config";
+import { stripTerminalControls } from "../format";
 import { resolveAuth } from "../oidc-cli";
 import {
   createJoinLink,
@@ -654,7 +655,8 @@ export async function run(argv: string[]): Promise<number> {
           const roles = await listChannelRoles(cfg.server, cfg.token, slug);
           for (const r of roles) {
             const responsibility = r.responsibility === null ? "" : `\t${r.responsibility}`;
-            console.log(`${r.name}\t${r.role}\t${r.assigned_by}\t${new Date(r.assigned_at).toISOString()}${responsibility}`);
+            // #629：name/assigned_by/responsibility 都是服务端存的参与者可控自由文本，整行剥离终端控制序列后再打印。
+            console.log(stripTerminalControls(`${r.name}\t${r.role}\t${r.assigned_by}\t${new Date(r.assigned_at).toISOString()}${responsibility}`));
           }
           return 0;
         }

--- a/cli/src/commands/channel.ts
+++ b/cli/src/commands/channel.ts
@@ -1,7 +1,7 @@
 // party channel create|list|archive|reset-guard
 import { isHelpArg, parseArgs, str, strArray, unknownFlagError, valueFlagError } from "../args";
 import { resolveChannel } from "../config";
-import { stripTerminalControls } from "../format";
+import { sanitizeSingleLine } from "../format";
 import { resolveAuth } from "../oidc-cli";
 import {
   createJoinLink,
@@ -654,9 +654,11 @@ export async function run(argv: string[]): Promise<number> {
           }
           const roles = await listChannelRoles(cfg.server, cfg.token, slug);
           for (const r of roles) {
-            const responsibility = r.responsibility === null ? "" : `\t${r.responsibility}`;
-            // #629：name/assigned_by/responsibility 都是服务端存的参与者可控自由文本，整行剥离终端控制序列后再打印。
-            console.log(stripTerminalControls(`${r.name}\t${r.role}\t${r.assigned_by}\t${new Date(r.assigned_at).toISOString()}${responsibility}`));
+            const responsibility = r.responsibility === null ? "" : `\t${sanitizeSingleLine(r.responsibility)}`;
+            // #629/#652：name/role/assigned_by/responsibility 都是服务端存的参与者可控自由文本，且这一行用 TAB 分列。
+            // 逐字段过 sanitizeSingleLine（剥离终端控制序列 + 折叠残留 TAB/换行），再拼接可信的列 TAB，
+            // 否则字段里塞 \n 能伪造整行、塞 \t 能伪造列。ISO 时间戳是本地生成的可信值，无需清理。
+            console.log(`${sanitizeSingleLine(r.name)}\t${sanitizeSingleLine(r.role)}\t${sanitizeSingleLine(r.assigned_by)}\t${new Date(r.assigned_at).toISOString()}${responsibility}`);
           }
           return 0;
         }

--- a/cli/src/commands/host.ts
+++ b/cli/src/commands/host.ts
@@ -7,6 +7,7 @@ import {
 } from "@agentparty/shared";
 import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
 import { resolveChannel } from "../config";
+import { stripTerminalControls } from "../format";
 import { jsonFrame } from "../json";
 import { resolveAuth } from "../oidc-cli";
 import { fetchMessages, fetchPresence, fetchRecentMessages, handleRestError, listTasks } from "../rest";
@@ -98,42 +99,44 @@ function printBoard(board: HostBoard, window: BoardWindow) {
   console.log(`host board ${board.channel} last_seq=${board.last_seq}`);
   for (const line of formatWindowLines(window)) console.log(line);
   console.log(`hosts: ${board.hosts.length}`);
+  // #629：board 逐条行里 name/owner/scope/blocked_reason/note/decision/reason/stale_reason 等都是服务端存的
+  // 参与者可控自由文本，整行剥离终端控制序列后再打印（同 format.ts/formatMsg），避免 OSC52/CSI 注入。
   for (const host of board.hosts) {
     const reason = host.stale_reason === null ? "" : ` reason=${host.stale_reason}`;
-    console.log(`- ${host.name} ${host.lease} residency=${host.residency} wake=${host.wake_kind}${reason}`);
+    console.log(stripTerminalControls(`- ${host.name} ${host.lease} residency=${host.residency} wake=${host.wake_kind}${reason}`));
   }
   console.log(`open claims: ${board.open_claims.length}`);
   for (const claim of board.open_claims) {
     const blocked = claim.blocked_reason === null ? "" : ` blocked=${claim.blocked_reason}`;
     const workflow = claim.workflow === null ? "" : ` workflow=${claim.workflow.workflow_id}/${claim.workflow.kind}`;
-    console.log(`- ${claimRef(claim)} ${claim.owner} ${claim.state} scope=${scopeLabel(claim.scope)}${workflow}${blocked}`);
+    console.log(stripTerminalControls(`- ${claimRef(claim)} ${claim.owner} ${claim.state} scope=${scopeLabel(claim.scope)}${workflow}${blocked}`));
   }
   console.log(`blockers: ${board.blockers.length}`);
   for (const blocker of board.blockers) {
-    console.log(`- ${claimRef(blocker)} ${blocker.owner} ${blocker.blocked_reason ?? blocker.note ?? "blocked"}`);
+    console.log(stripTerminalControls(`- ${claimRef(blocker)} ${blocker.owner} ${blocker.blocked_reason ?? blocker.note ?? "blocked"}`));
   }
   console.log(`conflicts: ${board.conflicts.length}`);
   for (const conflict of board.conflicts) {
     const claims = conflict.claims.map((claim) => `${claimRef(claim)} ${claim.owner}`).join(" vs ");
-    console.log(`- ${conflict.scope}: ${claims}`);
+    console.log(stripTerminalControls(`- ${conflict.scope}: ${claims}`));
   }
   console.log(`decisions: ${board.decisions.length}`);
   for (const decision of board.decisions) {
     const handoff = decision.handoff_to === null ? "" : ` handoff=${decision.handoff_to}`;
     const takeover = decision.takeover_from === null ? "" : ` takeover=${decision.takeover_from}`;
-    console.log(`- #${decision.seq} ${decision.owner} ${decision.kind}: ${decision.decision}${handoff}${takeover}`);
+    console.log(stripTerminalControls(`- #${decision.seq} ${decision.owner} ${decision.kind}: ${decision.decision}${handoff}${takeover}`));
   }
   // #204 legacy 段：没有对应 task 的历史 status claim。独立成段、不混进 open claims；给出转成 task 的命令。
   console.log(`unlinked status claims (no task, legacy): ${board.unlinked_claims.length}`);
   for (const claim of board.unlinked_claims) {
-    console.log(`- ${claimRef(claim)} ${claim.owner} ${claim.state} scope=${scopeLabel(claim.scope)}  (no task; run: party task from ${claim.seq})`);
+    console.log(stripTerminalControls(`- ${claimRef(claim)} ${claim.owner} ${claim.state} scope=${scopeLabel(claim.scope)}  (no task; run: party task from ${claim.seq})`));
   }
   console.log(`recommended actions: ${board.recommended_actions.length}`);
   for (const action of board.recommended_actions) {
     const human = action.requires_human ? " human" : "";
     const target = action.target === null ? "" : ` target=${action.target}`;
     const command = action.command === null ? "" : ` command=${action.command}`;
-    console.log(`- ${action.kind}${human}${target}: ${action.reason}${command}`);
+    console.log(stripTerminalControls(`- ${action.kind}${human}${target}: ${action.reason}${command}`));
   }
 }
 

--- a/cli/src/commands/host.ts
+++ b/cli/src/commands/host.ts
@@ -7,7 +7,7 @@ import {
 } from "@agentparty/shared";
 import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
 import { resolveChannel } from "../config";
-import { stripTerminalControls } from "../format";
+import { sanitizeSingleLine } from "../format";
 import { jsonFrame } from "../json";
 import { resolveAuth } from "../oidc-cli";
 import { fetchMessages, fetchPresence, fetchRecentMessages, handleRestError, listTasks } from "../rest";
@@ -99,44 +99,45 @@ function printBoard(board: HostBoard, window: BoardWindow) {
   console.log(`host board ${board.channel} last_seq=${board.last_seq}`);
   for (const line of formatWindowLines(window)) console.log(line);
   console.log(`hosts: ${board.hosts.length}`);
-  // #629：board 逐条行里 name/owner/scope/blocked_reason/note/decision/reason/stale_reason 等都是服务端存的
-  // 参与者可控自由文本，整行剥离终端控制序列后再打印（同 format.ts/formatMsg），避免 OSC52/CSI 注入。
+  // #629/#652：board 逐条行里 name/owner/scope/blocked_reason/note/decision/reason/stale_reason 等都是服务端存的
+  // 参与者可控自由文本。这些行是空格分隔的单行（无可信 TAB 列），故整行过 sanitizeSingleLine：既剥离终端控制
+  // 序列（同 format.ts/formatMsg）避免 OSC52/CSI 注入，又把字段里残留的 \n/\t 折叠成空格，防止伪造整行/列。
   for (const host of board.hosts) {
     const reason = host.stale_reason === null ? "" : ` reason=${host.stale_reason}`;
-    console.log(stripTerminalControls(`- ${host.name} ${host.lease} residency=${host.residency} wake=${host.wake_kind}${reason}`));
+    console.log(sanitizeSingleLine(`- ${host.name} ${host.lease} residency=${host.residency} wake=${host.wake_kind}${reason}`));
   }
   console.log(`open claims: ${board.open_claims.length}`);
   for (const claim of board.open_claims) {
     const blocked = claim.blocked_reason === null ? "" : ` blocked=${claim.blocked_reason}`;
     const workflow = claim.workflow === null ? "" : ` workflow=${claim.workflow.workflow_id}/${claim.workflow.kind}`;
-    console.log(stripTerminalControls(`- ${claimRef(claim)} ${claim.owner} ${claim.state} scope=${scopeLabel(claim.scope)}${workflow}${blocked}`));
+    console.log(sanitizeSingleLine(`- ${claimRef(claim)} ${claim.owner} ${claim.state} scope=${scopeLabel(claim.scope)}${workflow}${blocked}`));
   }
   console.log(`blockers: ${board.blockers.length}`);
   for (const blocker of board.blockers) {
-    console.log(stripTerminalControls(`- ${claimRef(blocker)} ${blocker.owner} ${blocker.blocked_reason ?? blocker.note ?? "blocked"}`));
+    console.log(sanitizeSingleLine(`- ${claimRef(blocker)} ${blocker.owner} ${blocker.blocked_reason ?? blocker.note ?? "blocked"}`));
   }
   console.log(`conflicts: ${board.conflicts.length}`);
   for (const conflict of board.conflicts) {
     const claims = conflict.claims.map((claim) => `${claimRef(claim)} ${claim.owner}`).join(" vs ");
-    console.log(stripTerminalControls(`- ${conflict.scope}: ${claims}`));
+    console.log(sanitizeSingleLine(`- ${conflict.scope}: ${claims}`));
   }
   console.log(`decisions: ${board.decisions.length}`);
   for (const decision of board.decisions) {
     const handoff = decision.handoff_to === null ? "" : ` handoff=${decision.handoff_to}`;
     const takeover = decision.takeover_from === null ? "" : ` takeover=${decision.takeover_from}`;
-    console.log(stripTerminalControls(`- #${decision.seq} ${decision.owner} ${decision.kind}: ${decision.decision}${handoff}${takeover}`));
+    console.log(sanitizeSingleLine(`- #${decision.seq} ${decision.owner} ${decision.kind}: ${decision.decision}${handoff}${takeover}`));
   }
   // #204 legacy 段：没有对应 task 的历史 status claim。独立成段、不混进 open claims；给出转成 task 的命令。
   console.log(`unlinked status claims (no task, legacy): ${board.unlinked_claims.length}`);
   for (const claim of board.unlinked_claims) {
-    console.log(stripTerminalControls(`- ${claimRef(claim)} ${claim.owner} ${claim.state} scope=${scopeLabel(claim.scope)}  (no task; run: party task from ${claim.seq})`));
+    console.log(sanitizeSingleLine(`- ${claimRef(claim)} ${claim.owner} ${claim.state} scope=${scopeLabel(claim.scope)}  (no task; run: party task from ${claim.seq})`));
   }
   console.log(`recommended actions: ${board.recommended_actions.length}`);
   for (const action of board.recommended_actions) {
     const human = action.requires_human ? " human" : "";
     const target = action.target === null ? "" : ` target=${action.target}`;
     const command = action.command === null ? "" : ` command=${action.command}`;
-    console.log(stripTerminalControls(`- ${action.kind}${human}${target}: ${action.reason}${command}`));
+    console.log(sanitizeSingleLine(`- ${action.kind}${human}${target}: ${action.reason}${command}`));
   }
 }
 

--- a/cli/src/commands/squad.ts
+++ b/cli/src/commands/squad.ts
@@ -2,7 +2,7 @@
 import type { ChannelSquad } from "@agentparty/shared";
 import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
 import { resolveChannel } from "../config";
-import { stripTerminalControls } from "../format";
+import { sanitizeSingleLine } from "../format";
 import { resolveAuth } from "../oidc-cli";
 import { createSquad, deleteSquad, handleRestError, listSquads, updateSquad } from "../rest";
 import { isName, isSlug } from "../validation";
@@ -42,10 +42,13 @@ function leaderFrom(raw: string | undefined): string | null | undefined {
 }
 
 export function formatSquad(squad: ChannelSquad): string {
-  const leader = squad.leader === null ? "" : ` leader:@${squad.leader}`;
-  const title = squad.title === null ? "" : ` ${squad.title}`;
-  // #629：name/leader/members/title 都是服务端存的参与者可控自由文本，整行剥离终端控制序列后再打印。
-  return stripTerminalControls(`@${squad.name}\t${squad.members.length} members${leader}\t${squad.members.map((m) => `@${m}`).join(",")}${title}`);
+  const leader = squad.leader === null ? "" : ` leader:@${sanitizeSingleLine(squad.leader)}`;
+  const title = squad.title === null ? "" : ` ${sanitizeSingleLine(squad.title)}`;
+  const members = squad.members.map((m) => `@${sanitizeSingleLine(m)}`).join(",");
+  // #629/#652：name/leader/members/title 都是服务端存的参与者可控自由文本，且这一行用 TAB 分列。
+  // 逐字段过 sanitizeSingleLine（剥离终端控制序列 + 折叠残留 TAB/换行），再拼接可信的列 TAB，
+  // 否则字段里塞 \n 能伪造整行、塞 \t 能伪造列。
+  return `@${sanitizeSingleLine(squad.name)}\t${squad.members.length} members${leader}\t${members}${title}`;
 }
 
 export async function run(argv: string[]): Promise<number> {

--- a/cli/src/commands/squad.ts
+++ b/cli/src/commands/squad.ts
@@ -2,6 +2,7 @@
 import type { ChannelSquad } from "@agentparty/shared";
 import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
 import { resolveChannel } from "../config";
+import { stripTerminalControls } from "../format";
 import { resolveAuth } from "../oidc-cli";
 import { createSquad, deleteSquad, handleRestError, listSquads, updateSquad } from "../rest";
 import { isName, isSlug } from "../validation";
@@ -40,10 +41,11 @@ function leaderFrom(raw: string | undefined): string | null | undefined {
   return cleanName(raw);
 }
 
-function formatSquad(squad: ChannelSquad): string {
+export function formatSquad(squad: ChannelSquad): string {
   const leader = squad.leader === null ? "" : ` leader:@${squad.leader}`;
   const title = squad.title === null ? "" : ` ${squad.title}`;
-  return `@${squad.name}\t${squad.members.length} members${leader}\t${squad.members.map((m) => `@${m}`).join(",")}${title}`;
+  // #629：name/leader/members/title 都是服务端存的参与者可控自由文本，整行剥离终端控制序列后再打印。
+  return stripTerminalControls(`@${squad.name}\t${squad.members.length} members${leader}\t${squad.members.map((m) => `@${m}`).join(",")}${title}`);
 }
 
 export async function run(argv: string[]): Promise<number> {

--- a/cli/src/commands/watch.ts
+++ b/cli/src/commands/watch.ts
@@ -612,7 +612,10 @@ export async function runWatch(o: WatchOptions): Promise<number> {
           out(o.json ? JSON.stringify(jsonFrame(frame as unknown as Record<string, unknown>)) : formatMsg(msg));
         }
         printed++;
-        displayedMessageSeqs.add(msg.seq);
+        // #643：displayedMessageSeqs 只有 --once 的 directed 去重路径（line ~504，受 acceptsDirectedDelivery
+        // 门控，要求 o.once）会读它。--follow / 默认模式永远读不到，逐条 add 会随频道消息无界增长（内存泄漏）。
+        // 只在 --once 下写：once 收到首个唤醒即 break，集合天然有界。
+        if (o.once === true) displayedMessageSeqs.add(msg.seq);
       }
       // 打印（或有意跳过）之后才推进游标，退出时入队未消费的消息留给下次补拉
       if (msg.seq > 0) conn.ack(msg.seq);
@@ -750,83 +753,104 @@ export async function run(argv: string[]): Promise<number> {
   // pending wake 比任何显式快进选择都优先。即使调用者误用 --latest，也不能先把仍未被模型
   // 确认的 @ 丢掉。REST 精确补拉后立即退出，避免重新挂起一个可能又被 harness 回收的后台任务。
   if (flags.once === true && stuck !== null) {
-    if (stuck.source !== "watch") {
+    // #643：pending-wake 重放本身就是一次唤醒投递，必须走与正常路径同一把单实例锁。否则两个并发的
+    // `watch --once` 重挂会各自读到同一条 debt、各自重放同一条 @ → agent 把同一条消息回两遍
+    // （instance-lock.ts 头注释描述的正是这种重复唤醒）。锁的目标/目录与 runWatch 的默认路径一致。
+    // 无论重放成功、拒绝，还是 directed-未确认落回正常路径交给 runWatch 重新抢锁，都在 finally 里释放。
+    const replayLockDir = defaultInstanceLockDir();
+    const replayLockTarget = instanceLockTarget(cfg.server, cfg.token, channel);
+    const replayLock =
+      flags["allow-multiple"] === true ? null : acquireInstanceLock("watch", replayLockTarget, replayLockDir);
+    if (replayLock && !replayLock.ok) {
       console.error(terminalOutput(
-        `error: #${channel} has a pending serve wake at seq=${stuck.seq}; ` +
-          "watch will not overwrite that delivery debt. Resume the existing party serve supervisor first.",
+        `watch: 已有 watcher 挂在 #${channel} 上（pid ${replayLock.heldByPid}）；` +
+          ` 不重放 pending wake seq=${stuck.seq}，避免同一条 @ 被回两遍——欠账已保留。` +
+          ` 等它退出或 kill ${replayLock.heldByPid}；确实想并存请加 --allow-multiple。`,
       ));
-      return 1;
+      return EXIT_ALREADY_WATCHING;
     }
-    // Directed debt 在 running ACK 前只是 unknown outcome。按旧 seq-only 路径直接重放会与
-    // Worker 租约超时后的重新分配并发执行同一 work；保持 debt，重新注册等该 delivery 的新 claim。
-    if (stuck.delivery_id !== undefined && stuck.delivery_acceptance !== "accepted") {
-      console.error(terminalOutput(
-        `watch: directed delivery=${stuck.delivery_id} 尚未确认 running；不会本地回放 seq=${stuck.seq}，` +
-          "正在重新挂接，等待服务端重新授予合法 claim。",
-      ));
-    } else {
-      try {
-        const [pendingPage, tail] = await Promise.all([
-          fetchMessages(cfg.server, cfg.token, channel, Math.max(0, stuck.seq - 1), 1),
-          fetchRecentMessages(cfg.server, cfg.token, channel, 1),
-        ]);
-        const pending = pendingPage.find((msg) => msg.seq === stuck.seq);
-        if (pending === undefined) {
-          console.error(terminalOutput(
-            `error: pending watch wake seq=${stuck.seq} is no longer retained; debt was preserved. ` +
-              `Inspect channel history before clearing or advancing this workspace state.`,
-          ));
-          return 1;
-        }
-        const replay = { ...stuck, attempts: stuck.attempts + 1 };
-        if (!saveWatchStuck(channel, replay)) {
-          console.error(terminalOutput(
-            `error: #${channel} acquired a pending serve wake while replaying seq=${stuck.seq}; ` +
-              "watch preserved that delivery debt and did not acknowledge this wake.",
-          ));
-          return 1;
-        }
-        const channelLastSeq = Math.max(stuck.channel_last_seq ?? 0, tail.at(-1)?.seq ?? 0, pending.seq);
-        const lag = Math.max(0, channelLastSeq - pending.seq);
-        const skippedMentionSeqs = stuck.skipped_mention_seqs ?? [];
-        if (flags.json === true) {
-          console.log(
-            JSON.stringify(
-              jsonFrame({
-                ...(pending as unknown as Record<string, unknown>),
-                watch_replay: true,
-                pending_ack: true,
-                replay_attempt: replay.attempts,
-                ...(stuck.delivery_id !== undefined ? { delivery_id: stuck.delivery_id } : {}),
-                ...(stuck.work_id !== undefined ? { work_id: stuck.work_id } : {}),
-                ...(stuck.continuation_ref !== undefined ? { continuation_ref: stuck.continuation_ref } : {}),
-                ...(stuck.delivery_acceptance !== undefined
-                  ? { delivery_acceptance: stuck.delivery_acceptance }
-                  : {}),
-                channel_last_seq: channelLastSeq,
-                lag,
-                skipped_mention_seqs: skippedMentionSeqs,
-              }),
-            ),
-          );
-        } else {
-          console.log(terminalOutput(
-            `watch: replaying pending unacknowledged wake seq=${stuck.seq} attempt=${replay.attempts}; ` +
-              (stuck.delivery_id !== undefined
-                ? `delivery=${stuck.delivery_id}${stuck.work_id !== undefined ? ` work_id=${stuck.work_id}` : ""}${stuck.continuation_ref !== undefined ? ` continuation_ref=${stuck.continuation_ref}` : ""}; `
-                : "") +
-              `channel_last_seq=${channelLastSeq} lag=${lag} ` +
-              `skipped_mention_seqs=${JSON.stringify(skippedMentionSeqs)}; ` +
-              `send a reply/status after handling it to clear this debt (or \`party ack --seq ${stuck.seq}\` if it needs no response).` +
-              (lag > 0 ? ` 补上下文：party history ${channel} --since ${stuck.seq}` : ""),
-          ));
-          console.log(formatMsg(pending));
-        }
-        if (flags.json !== true) console.error(ONCE_REARM_ADVISORY);
-        return 0;
-      } catch (e) {
-        return handleRestError(e);
+    try {
+      if (stuck.source !== "watch") {
+        console.error(terminalOutput(
+          `error: #${channel} has a pending serve wake at seq=${stuck.seq}; ` +
+            "watch will not overwrite that delivery debt. Resume the existing party serve supervisor first.",
+        ));
+        return 1;
       }
+      // Directed debt 在 running ACK 前只是 unknown outcome。按旧 seq-only 路径直接重放会与
+      // Worker 租约超时后的重新分配并发执行同一 work；保持 debt，重新注册等该 delivery 的新 claim。
+      if (stuck.delivery_id !== undefined && stuck.delivery_acceptance !== "accepted") {
+        console.error(terminalOutput(
+          `watch: directed delivery=${stuck.delivery_id} 尚未确认 running；不会本地回放 seq=${stuck.seq}，` +
+            "正在重新挂接，等待服务端重新授予合法 claim。",
+        ));
+      } else {
+        try {
+          const [pendingPage, tail] = await Promise.all([
+            fetchMessages(cfg.server, cfg.token, channel, Math.max(0, stuck.seq - 1), 1),
+            fetchRecentMessages(cfg.server, cfg.token, channel, 1),
+          ]);
+          const pending = pendingPage.find((msg) => msg.seq === stuck.seq);
+          if (pending === undefined) {
+            console.error(terminalOutput(
+              `error: pending watch wake seq=${stuck.seq} is no longer retained; debt was preserved. ` +
+                `Inspect channel history before clearing or advancing this workspace state.`,
+            ));
+            return 1;
+          }
+          const replay = { ...stuck, attempts: stuck.attempts + 1 };
+          if (!saveWatchStuck(channel, replay)) {
+            console.error(terminalOutput(
+              `error: #${channel} acquired a pending serve wake while replaying seq=${stuck.seq}; ` +
+                "watch preserved that delivery debt and did not acknowledge this wake.",
+            ));
+            return 1;
+          }
+          const channelLastSeq = Math.max(stuck.channel_last_seq ?? 0, tail.at(-1)?.seq ?? 0, pending.seq);
+          const lag = Math.max(0, channelLastSeq - pending.seq);
+          const skippedMentionSeqs = stuck.skipped_mention_seqs ?? [];
+          if (flags.json === true) {
+            console.log(
+              JSON.stringify(
+                jsonFrame({
+                  ...(pending as unknown as Record<string, unknown>),
+                  watch_replay: true,
+                  pending_ack: true,
+                  replay_attempt: replay.attempts,
+                  ...(stuck.delivery_id !== undefined ? { delivery_id: stuck.delivery_id } : {}),
+                  ...(stuck.work_id !== undefined ? { work_id: stuck.work_id } : {}),
+                  ...(stuck.continuation_ref !== undefined ? { continuation_ref: stuck.continuation_ref } : {}),
+                  ...(stuck.delivery_acceptance !== undefined
+                    ? { delivery_acceptance: stuck.delivery_acceptance }
+                    : {}),
+                  channel_last_seq: channelLastSeq,
+                  lag,
+                  skipped_mention_seqs: skippedMentionSeqs,
+                }),
+              ),
+            );
+          } else {
+            console.log(terminalOutput(
+              `watch: replaying pending unacknowledged wake seq=${stuck.seq} attempt=${replay.attempts}; ` +
+                (stuck.delivery_id !== undefined
+                  ? `delivery=${stuck.delivery_id}${stuck.work_id !== undefined ? ` work_id=${stuck.work_id}` : ""}${stuck.continuation_ref !== undefined ? ` continuation_ref=${stuck.continuation_ref}` : ""}; `
+                  : "") +
+                `channel_last_seq=${channelLastSeq} lag=${lag} ` +
+                `skipped_mention_seqs=${JSON.stringify(skippedMentionSeqs)}; ` +
+                `send a reply/status after handling it to clear this debt (or \`party ack --seq ${stuck.seq}\` if it needs no response).` +
+                (lag > 0 ? ` 补上下文：party history ${channel} --since ${stuck.seq}` : ""),
+            ));
+            console.log(formatMsg(pending));
+          }
+          if (flags.json !== true) console.error(ONCE_REARM_ADVISORY);
+          return 0;
+        } catch (e) {
+          return handleRestError(e);
+        }
+      }
+    } finally {
+      // directed-未确认落回正常路径前必须先放锁，否则 runWatch 会把同 pid 的自己误判成"已有 watcher"而被闭。
+      replayLock?.release?.();
     }
   }
   const initialLatest =

--- a/cli/src/commands/watch.ts
+++ b/cli/src/commands/watch.ts
@@ -749,7 +749,7 @@ export async function run(argv: string[]): Promise<number> {
   else if (flags.once === true && isCodexRuntimeEnv()) console.error(ONCE_CODEX_ADVISORY);
   if (flags.once === true && flags.latest === true) console.error(ONCE_LATEST_ADVISORY);
   const localCursor = loadCursor(channel);
-  const stuck = loadStuck(channel);
+  let stuck = loadStuck(channel);
   // pending wake 比任何显式快进选择都优先。即使调用者误用 --latest，也不能先把仍未被模型
   // 确认的 @ 丢掉。REST 精确补拉后立即退出，避免重新挂起一个可能又被 harness 回收的后台任务。
   if (flags.once === true && stuck !== null) {
@@ -770,6 +770,16 @@ export async function run(argv: string[]): Promise<number> {
       return EXIT_ALREADY_WATCHING;
     }
     try {
+      // #652：拿到锁后**权威重读** debt。上面的 stuck 是锁前快照——两个并发 `watch --once` 会各自
+      // 在锁前读到同一条 debt；先抢到锁的重放并释放后，另一个若还用锁前的过期快照，就会重放已被处理
+      // 的同一条 wake（TOCTOU）。锁内重读把决策基准换成当前真值：另一进程已清账则本次不再重放。
+      stuck = loadStuck(channel);
+      if (stuck === null) {
+        console.error(terminalOutput(
+          `watch: #${channel} 的 pending wake 已被另一进程重放/清账，本次不再重放。`,
+        ));
+        return 0;
+      }
       if (stuck.source !== "watch") {
         console.error(terminalOutput(
           `error: #${channel} has a pending serve wake at seq=${stuck.seq}; ` +
@@ -786,11 +796,14 @@ export async function run(argv: string[]): Promise<number> {
         ));
       } else {
         try {
+          // #652：stuck 现在是 let（锁内会被权威重读重新赋值），闭包捕获 let 会被 TS 放宽回可空。
+          // 上面已 `if (stuck === null) return 0`，这里锁内的 stuck 必非空——把 seq 固定成 const 供闭包使用。
+          const pendingSeq = stuck.seq;
           const [pendingPage, tail] = await Promise.all([
-            fetchMessages(cfg.server, cfg.token, channel, Math.max(0, stuck.seq - 1), 1),
+            fetchMessages(cfg.server, cfg.token, channel, Math.max(0, pendingSeq - 1), 1),
             fetchRecentMessages(cfg.server, cfg.token, channel, 1),
           ]);
-          const pending = pendingPage.find((msg) => msg.seq === stuck.seq);
+          const pending = pendingPage.find((msg) => msg.seq === pendingSeq);
           if (pending === undefined) {
             console.error(terminalOutput(
               `error: pending watch wake seq=${stuck.seq} is no longer retained; debt was preserved. ` +

--- a/cli/src/format.ts
+++ b/cli/src/format.ts
@@ -13,6 +13,14 @@ export function stripTerminalControls(text: string): string {
   return text.replace(ANSI_CSI, "").replace(TERMINAL_CONTROL, "");
 }
 
+// #652 单行字段清理：stripTerminalControls 特意保留了 \t\n（formatMsg 的多行结构靠它们），但渲染成
+// 「一行一条」的 list/table 行时，服务端可控自由文本里的 \n 能伪造整行、\t 能伪造列。这些字段必须先
+// 过本函数把残留 TAB/换行折叠成单个空格，再和可信的结构分隔符（列 TAB、换行）拼接。多行消息体仍用
+// 纯 stripTerminalControls，不要在那里折叠换行。
+export function sanitizeSingleLine(text: string): string {
+  return stripTerminalControls(text).replace(/[\t\n]+/g, " ");
+}
+
 function formatSender(m: MsgFrame): string {
   const owner = m.sender.owner && m.sender.owner !== m.sender.name ? ` owner=${m.sender.owner}` : "";
   const lineage = m.sender.lineage ? ` parent=${m.sender.lineage.parent_agent} team=${m.sender.lineage.team_id}` : "";

--- a/cli/test/client.test.ts
+++ b/cli/test/client.test.ts
@@ -741,4 +741,65 @@ describe("ws client", () => {
     await Bun.sleep(15);
     expect(ProbeWebSocket.instances).toHaveLength(1);
   });
+
+  // #628：半开/黑洞网络下探测 fetch 永不自行 settle。修复给它挂了 AbortSignal.timeout，
+  // 超时抛 TimeoutError（isRetryableNetworkError 认可），落回 scheduleReconnect() 而非永久卡死。
+  test("a fatal probe that never settles is aborted by its timeout and reconnects instead of hanging", async () => {
+    jest.useFakeTimers();
+    useProbeWebSocket();
+    let capturedSignal: AbortSignal | null = null;
+    globalThis.fetch = ((_url: string, init?: RequestInit) => {
+      capturedSignal = init?.signal ?? null;
+      // 半开网络：只有超时 signal 触发才 settle（按 TimeoutError 拒绝），否则永远挂起。
+      return new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () =>
+          reject(new DOMException("The operation timed out.", "TimeoutError")),
+        );
+      });
+    }) as unknown as typeof fetch;
+    console.debug = () => {};
+    const statuses: string[] = [];
+    conn = connect("https://party.invalid", "ap_tok", "dev", 0, {
+      backoffBaseMs: 5,
+      backoffMaxMs: 5,
+      onStatus: (status) => statuses.push(status),
+    });
+    ProbeWebSocket.instances[0]!.failHandshake();
+
+    // 探测 fetch 已带上超时 signal；未到时间前探测挂起，连接既不重连也不终止（正是修复前的僵尸态）。
+    expect(capturedSignal).toBeInstanceOf(AbortSignal);
+    expect(statuses).not.toContain("reconnecting");
+    expect(ProbeWebSocket.instances).toHaveLength(1);
+
+    // 超时触发 → 探测按 TimeoutError 拒绝 → 退避重连。
+    jest.advanceTimersByTime(10_000);
+    for (let i = 0; i < 10; i++) await Promise.resolve();
+    jest.advanceTimersByTime(5);
+    expect(statuses).toContain("reconnecting");
+    expect(ProbeWebSocket.instances.length).toBeGreaterThan(1);
+  });
+
+  // #628：探测 GET 命中瞬时 429/5xx（限流 / 滚动部署 / Cloudflare 过载）时退避重连，
+  // 而非把长跑的 serve/watch 打成致命终局。
+  test("a transient 429/5xx from the fatal probe reconnects with backoff instead of failing fatally", async () => {
+    for (const status of [429, 503]) {
+      useProbeWebSocket();
+      console.debug = () => {};
+      const statuses: Array<{ status: string; error?: string }> = [];
+      globalThis.fetch = (async () => new Response(null, { status })) as unknown as typeof fetch;
+      conn = connect("https://party.invalid", "ap_tok", "dev", 0, {
+        backoffBaseMs: 5,
+        backoffMaxMs: 5,
+        onStatus: (s, detail) => statuses.push({ status: s, ...(detail?.error ? { error: detail.error } : {}) }),
+      });
+      ProbeWebSocket.instances[0]!.failHandshake();
+      await Bun.sleep(20);
+
+      expect(statuses.map((s) => s.status)).toContain("reconnecting");
+      expect(statuses.map((s) => s.status)).not.toContain("closed");
+      expect(ProbeWebSocket.instances.length).toBeGreaterThan(1);
+      conn.close();
+      conn = null;
+    }
+  });
 });

--- a/cli/test/escape-injection.test.ts
+++ b/cli/test/escape-injection.test.ts
@@ -1,0 +1,166 @@
+// #629：party board / channel role list / host board / squad list 都把服务端存的参与者可控自由文本
+// 打到终端。这些字段必须先过 stripTerminalControls（同 #372 的消息路径），否则攻击者塞进
+// OSC52 / CSI / 清屏序列，就能在受害者终端上劫持剪贴板、伪造或隐藏输出。
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { ChannelSquad, TaskRecord } from "@agentparty/shared";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { formatTask } from "../src/commands/board";
+import { run as hostRun } from "../src/commands/host";
+import { run as channelRun } from "../src/commands/channel";
+import { formatSquad } from "../src/commands/squad";
+
+// 典型注入载荷：ESC[2J 清屏 + OSC 改标题栏 + OSC52 写剪贴板 + BEL 收尾。
+const PAYLOAD = "\x1b[2J\x1b]0;pwned\x07\x1b]52;c;cHduZWQ=\x07legit";
+
+// 剥离干净 = 不残留任何 ESC(\x1b) / BEL(\x07) / CR(\x0d) / C1 等控制字节。可见文本 "legit" 应保留。
+function expectNoControls(rendered: string): void {
+  // eslint-disable-next-line no-control-regex
+  expect(rendered).not.toMatch(/[\x00-\x08\x0b-\x1f\x7f-\x9f]/);
+  expect(rendered).toContain("legit");
+}
+
+function task(overrides: Partial<TaskRecord>): TaskRecord {
+  return {
+    type: "task",
+    id: 1,
+    channel: "dev",
+    title: "t",
+    desc: null,
+    state: "assigned",
+    assignee: { name: "worker", kind: "agent" },
+    created_by: "creator",
+    created_by_kind: "agent",
+    priority: 2,
+    labels: [],
+    parent_id: null,
+    anchor_seqs: [],
+    scope: [],
+    blocked_reason: null,
+    external_ref: null,
+    completion_artifact: null,
+    workflow_id: null,
+    created_at: 0,
+    updated_at: 0,
+    completed_at: null,
+    ...overrides,
+  };
+}
+
+describe("#629 terminal control-sequence stripping", () => {
+  test("board formatTask strips control sequences from the task title", () => {
+    const rendered = formatTask(task({ id: 7, title: PAYLOAD }));
+    expectNoControls(rendered);
+    expect(rendered).toContain("#7");
+  });
+
+  test("board formatTask strips control sequences from labels", () => {
+    const rendered = formatTask(task({ id: 8, title: "clean", labels: [PAYLOAD] }));
+    expectNoControls(rendered);
+  });
+
+  test("squad formatSquad strips control sequences from the squad title", () => {
+    const squad: ChannelSquad = {
+      type: "squad",
+      channel: "dev",
+      name: "team",
+      title: PAYLOAD,
+      description: null,
+      leader: null,
+      members: ["a"],
+      created_by: "creator",
+      created_by_kind: "agent",
+      created_at: 0,
+      updated_at: 0,
+    };
+    const rendered = formatSquad(squad);
+    expectNoControls(rendered);
+    expect(rendered).toContain("@team");
+  });
+});
+
+// host board / channel role list 的渲染在 run() 内部（printBoard / role list 分支），不是纯函数，
+// 用 host.test.ts 已有的模式：起本地 mock server + 写 config，跑 run() 后断言 stdout 已被剥离。
+describe("#629 e2e: host board and channel role list strip control sequences", () => {
+  let home: string;
+  let oldHome: string | undefined;
+  let restServer: ReturnType<typeof Bun.serve> | null = null;
+  const originalLog = console.log;
+  const originalError = console.error;
+  let stdout: string[] = [];
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "ap-esc-"));
+    oldHome = process.env.AGENTPARTY_HOME;
+    process.env.AGENTPARTY_HOME = home;
+    mkdirSync(home, { recursive: true });
+    stdout = [];
+    console.log = (...args: unknown[]) => stdout.push(args.join(" "));
+    console.error = (...args: unknown[]) => stdout.push(args.join(" "));
+  });
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+    if (oldHome === undefined) delete process.env.AGENTPARTY_HOME;
+    else process.env.AGENTPARTY_HOME = oldHome;
+    console.log = originalLog;
+    console.error = originalError;
+    restServer?.stop(true);
+    restServer = null;
+  });
+
+  function serve(handler: (url: URL) => Response): void {
+    restServer = Bun.serve({ hostname: "127.0.0.1", port: 0, fetch: (req) => handler(new URL(req.url)) });
+    writeFileSync(
+      join(home, "config.json"),
+      JSON.stringify({ server: `http://127.0.0.1:${restServer.port}`, token: "ap_tok" }),
+    );
+  }
+
+  test("host board strips control sequences from blocked_reason and scope", async () => {
+    serve((url) => {
+      if (url.pathname.endsWith("/presence")) return Response.json({ presence: [] });
+      if (url.pathname.endsWith("/tasks")) {
+        return Response.json({
+          tasks: [
+            task({ id: 41, state: "blocked", assignee: null, blocked_reason: PAYLOAD }),
+            task({ id: 42, state: "in_progress", scope: [PAYLOAD] }),
+          ],
+        });
+      }
+      if (url.pathname.endsWith("/messages")) return Response.json({ messages: [{ seq: 42 }] });
+      return Response.json({ error: { code: "not_found", message: "not found" } }, { status: 404 });
+    });
+    const code = await hostRun(["board", "dev", "--since", "0"]);
+    expect(code).toBe(0);
+    const joined = stdout.join("\n");
+    expect(joined).toContain("#41"); // blocker line present
+    expect(joined).toContain("task #42"); // open-claim line present
+    expectNoControls(joined);
+  });
+
+  test("channel role list strips control sequences from responsibility", async () => {
+    serve((url) => {
+      if (url.pathname.endsWith("/roles")) {
+        return Response.json({
+          roles: [
+            {
+              name: "worker",
+              role: "worker",
+              responsibility: PAYLOAD,
+              assigned_by: "host",
+              assigned_at: 0,
+            },
+          ],
+        });
+      }
+      return Response.json({ error: { code: "not_found", message: "not found" } }, { status: 404 });
+    });
+    const code = await channelRun(["role", "list", "dev"]);
+    expect(code).toBe(0);
+    const joined = stdout.join("\n");
+    expect(joined).toContain("worker");
+    expectNoControls(joined);
+  });
+});

--- a/cli/test/escape-injection.test.ts
+++ b/cli/test/escape-injection.test.ts
@@ -11,14 +11,30 @@ import { run as hostRun } from "../src/commands/host";
 import { run as channelRun } from "../src/commands/channel";
 import { formatSquad } from "../src/commands/squad";
 
-// 典型注入载荷：ESC[2J 清屏 + OSC 改标题栏 + OSC52 写剪贴板 + BEL 收尾。
-const PAYLOAD = "\x1b[2J\x1b]0;pwned\x07\x1b]52;c;cHduZWQ=\x07legit";
+// 典型注入载荷：ESC[2J 清屏 + OSC 改标题栏 + OSC52 写剪贴板 + BEL；再塞 \n（伪造整行）+ \t（伪造列）。
+// #652：stripTerminalControls 特意保留 \t\n（formatMsg 的多行结构靠它们），故单行 list/table 字段必须额外
+// 折叠残留 TAB/换行，否则服务端可控文本能在受害者终端上多打一行或多分一列。折叠后 FORGED-ROW/FORGED-COL
+// 应落在同一行、以单空格分隔。
+const PAYLOAD = "\x1b[2J\x1b]0;pwned\x07\x1b]52;c;cHduZWQ=\x07\nFORGED-ROW\tFORGED-COL legit";
 
 // 剥离干净 = 不残留任何 ESC(\x1b) / BEL(\x07) / CR(\x0d) / C1 等控制字节。可见文本 "legit" 应保留。
 function expectNoControls(rendered: string): void {
   // eslint-disable-next-line no-control-regex
   expect(rendered).not.toMatch(/[\x00-\x08\x0b-\x1f\x7f-\x9f]/);
   expect(rendered).toContain("legit");
+}
+
+// #652：单行渲染必须把字段里残留的 \t\n 折叠掉——断言没有裸换行（无伪造行）、TAB 数恰好等于可信列分隔符
+// 数量（无伪造列），且被折叠的 FORGED-ROW/FORGED-COL 落在同一行以空格分隔。
+function expectSingleLine(rendered: string, trustedTabs: number): void {
+  expect(rendered).not.toContain("\n");
+  expect((rendered.match(/\t/g) ?? []).length).toBe(trustedTabs);
+  expect(rendered).toContain("FORGED-ROW FORGED-COL");
+}
+
+// #652：e2e 里逐个 console.log 元素都不该含裸换行——否则字段里的 \n 会把一行渲染拆成伪造的多行。
+function expectNoForgedRows(lines: string[]): void {
+  for (const line of lines) expect(line).not.toContain("\n");
 }
 
 function task(overrides: Partial<TaskRecord>): TaskRecord {
@@ -53,14 +69,16 @@ describe("#629 terminal control-sequence stripping", () => {
     const rendered = formatTask(task({ id: 7, title: PAYLOAD }));
     expectNoControls(rendered);
     expect(rendered).toContain("#7");
+    expectSingleLine(rendered, 0); // #652：board 行无可信 TAB，字段里的 \n/\t 全部折叠成空格
   });
 
   test("board formatTask strips control sequences from labels", () => {
     const rendered = formatTask(task({ id: 8, title: "clean", labels: [PAYLOAD] }));
     expectNoControls(rendered);
+    expectSingleLine(rendered, 0); // #652：label 里的 \n/\t 不能伪造行/列
   });
 
-  test("squad formatSquad strips control sequences from the squad title", () => {
+  test("squad formatSquad strips control sequences from the squad title and members", () => {
     const squad: ChannelSquad = {
       type: "squad",
       channel: "dev",
@@ -68,7 +86,7 @@ describe("#629 terminal control-sequence stripping", () => {
       title: PAYLOAD,
       description: null,
       leader: null,
-      members: ["a"],
+      members: ["a", PAYLOAD],
       created_by: "creator",
       created_by_kind: "agent",
       created_at: 0,
@@ -77,6 +95,8 @@ describe("#629 terminal control-sequence stripping", () => {
     const rendered = formatSquad(squad);
     expectNoControls(rendered);
     expect(rendered).toContain("@team");
+    // #652：formatSquad 用 2 个可信 TAB 分列；title/members 里的 \n/\t 折叠后列数/行数不变。
+    expectSingleLine(rendered, 2);
   });
 });
 
@@ -138,6 +158,8 @@ describe("#629 e2e: host board and channel role list strip control sequences", (
     expect(joined).toContain("#41"); // blocker line present
     expect(joined).toContain("task #42"); // open-claim line present
     expectNoControls(joined);
+    // #652：blocked_reason / scope 里的 \n 不能把一行渲染拆成伪造的多行。
+    expectNoForgedRows(stdout);
   });
 
   test("channel role list strips control sequences from responsibility", async () => {
@@ -162,5 +184,9 @@ describe("#629 e2e: host board and channel role list strip control sequences", (
     const joined = stdout.join("\n");
     expect(joined).toContain("worker");
     expectNoControls(joined);
+    // #652：单条 role 只渲染一行，responsibility 里的 \n 不能伪造额外行，\t 不能伪造额外列。
+    expect(stdout.length).toBe(1);
+    expectNoForgedRows(stdout);
+    expect((stdout[0].match(/\t/g) ?? []).length).toBe(4); // name\trole\tassigned_by\tISO\tresponsibility
   });
 });

--- a/cli/test/watch-643.test.ts
+++ b/cli/test/watch-643.test.ts
@@ -1,0 +1,114 @@
+// #643：`watch --once` 的 pending-wake 重放（run() 内、runWatch 之前）过去绕过单实例锁——两个并发重挂
+// 会各自重放同一条 @ → 重复唤醒。修复让重放路径也走同一把锁，并在每条返回路径（含 directed-未确认
+// 落回正常路径）释放。这里断言的是**过程**：锁被别人占着时重放被拒、不产生重复唤醒；且成功重放后
+// 锁被释放（同进程内连续两次重挂都能替补上）。
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { workspaceId } from "../src/config";
+import { EXIT_ALREADY_WATCHING, run } from "../src/commands/watch";
+import { acquireInstanceLock, defaultInstanceLockDir, instanceLockTarget } from "../src/instance-lock";
+import { msgFrame } from "./mock-server";
+
+let home: string | null = null;
+let apiServer: ReturnType<typeof Bun.serve> | null = null;
+let previousHome: string | undefined;
+const originalLog = console.log;
+const originalError = console.error;
+let stdout: string[] = [];
+
+function seedStuck(server: string): void {
+  writeFileSync(join(home!, "config.json"), JSON.stringify({ server, token: "ap_tok" }));
+  const dir = join(home!, "state", workspaceId(process.cwd()));
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, "state.json"),
+    JSON.stringify({
+      channel: "dev",
+      cursor: 10,
+      cursors: {
+        dev: {
+          cursor: 10,
+          stuck: { seq: 10, attempts: 0, last_error: "watch wake awaiting agent acknowledgement", source: "watch" },
+        },
+      },
+    }),
+  );
+}
+
+function stuckAttempts(): number {
+  const dir = join(home!, "state", workspaceId(process.cwd()));
+  return JSON.parse(readFileSync(join(dir, "state.json"), "utf8")).cursors.dev.stuck.attempts;
+}
+
+afterEach(() => {
+  console.log = originalLog;
+  console.error = originalError;
+  apiServer?.stop(true);
+  apiServer = null;
+  if (previousHome === undefined) delete process.env.AGENTPARTY_HOME;
+  else process.env.AGENTPARTY_HOME = previousHome;
+  if (home) rmSync(home, { recursive: true, force: true });
+  home = null;
+});
+
+function begin(): void {
+  home = mkdtempSync(join(tmpdir(), "ap-watch-643-"));
+  previousHome = process.env.AGENTPARTY_HOME;
+  process.env.AGENTPARTY_HOME = home;
+  stdout = [];
+  console.log = (...args: unknown[]) => stdout.push(args.join(" "));
+  console.error = () => {};
+}
+
+describe("#643 watch --once pending-wake replay respects the instance lock", () => {
+  test("锁被别人占着时重放被拒，不重放、不产生重复唤醒（欠账保留、attempts 不变）", async () => {
+    begin();
+    const server = "http://127.0.0.1:65500"; // 拒绝路径在任何 REST 调用之前返回，URL 无需可达
+    seedStuck(server);
+    // 模拟"已有一个 watcher 挂在这条频道上"：先在同一锁作用域抢下锁。
+    const held = acquireInstanceLock("watch", instanceLockTarget(server, "ap_tok", "dev"), defaultInstanceLockDir());
+    expect(held.ok).toBe(true);
+    try {
+      const code = await run(["dev", "--once", "--json"]);
+      expect(code).toBe(EXIT_ALREADY_WATCHING);
+      // 关键：没有把 pending wake 重放出去（否则就是重复唤醒）。
+      expect(stdout.join("\n")).not.toContain("watch_replay");
+      // 欠账未被消费：attempts 保持 0。
+      expect(stuckAttempts()).toBe(0);
+    } finally {
+      held.release?.();
+    }
+  });
+
+  test("成功重放后释放锁：同一进程内连续两次重挂都能替补（attempts 1 → 2）", async () => {
+    begin();
+    const pending = msgFrame(10, "@me pending wake", { mentions: ["me"] });
+    apiServer = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch(req) {
+        const url = new URL(req.url);
+        if (url.pathname === "/api/channels/dev/messages") return Response.json({ messages: [pending] });
+        return new Response("not found", { status: 404 });
+      },
+    });
+    const server = `http://127.0.0.1:${apiServer.port}`;
+    seedStuck(server);
+
+    const first = await run(["dev", "--once", "--json"]);
+    expect(first).toBe(0);
+    expect(JSON.parse(stdout.at(-1)!)).toMatchObject({ seq: 10, watch_replay: true, replay_attempt: 1 });
+    expect(stuckAttempts()).toBe(1);
+    // 第一次重放必须已释放锁，否则第二次会把同 pid 的自己误判成"已有 watcher"。
+    const lockFile = join(defaultInstanceLockDir(), `watch-${instanceLockTarget(server, "ap_tok", "dev")}.lock`);
+    expect(existsSync(lockFile)).toBe(false);
+
+    stdout = [];
+    const second = await run(["dev", "--once", "--json"]);
+    expect(second).toBe(0);
+    expect(JSON.parse(stdout.at(-1)!)).toMatchObject({ seq: 10, watch_replay: true, replay_attempt: 2 });
+    expect(stuckAttempts()).toBe(2);
+  });
+});

--- a/cli/test/watch-643.test.ts
+++ b/cli/test/watch-643.test.ts
@@ -2,10 +2,11 @@
 // 会各自重放同一条 @ → 重复唤醒。修复让重放路径也走同一把锁，并在每条返回路径（含 directed-未确认
 // 落回正常路径）释放。这里断言的是**过程**：锁被别人占着时重放被拒、不产生重复唤醒；且成功重放后
 // 锁被释放（同进程内连续两次重挂都能替补上）。
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
 import { mkdirSync, mkdtempSync, existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import * as config from "../src/config";
 import { workspaceId } from "../src/config";
 import { EXIT_ALREADY_WATCHING, run } from "../src/commands/watch";
 import { acquireInstanceLock, defaultInstanceLockDir, instanceLockTarget } from "../src/instance-lock";
@@ -79,6 +80,38 @@ describe("#643 watch --once pending-wake replay respects the instance lock", () 
       expect(stuckAttempts()).toBe(0);
     } finally {
       held.release?.();
+    }
+  });
+
+  test("#652 锁内权威重读发现 debt 已被另一进程清账 → 本次不重放、返回 0（TOCTOU）", async () => {
+    begin();
+    // 锁内重读为 null 时在任何 REST 调用之前 return 0，URL 无需可达。
+    const server = "http://127.0.0.1:65500";
+    seedStuck(server); // 写 config.json + on-disk stuck（attempts=0），下面用 spy 覆盖 loadStuck 的返回值
+    // 复刻 TOCTOU 时序：两个并发 `watch --once` 都在锁前读到同一条 debt；先抢到锁的那个重放并清账后释放，
+    // 本进程随后才拿到锁——锁前快照（第 1 次读）仍是非空，锁内权威重读（第 2 次读）已是 null。
+    const debt = {
+      seq: 10,
+      attempts: 0,
+      last_error: "watch wake awaiting agent acknowledgement",
+      source: "watch" as const,
+    };
+    const spy = spyOn(config, "loadStuck");
+    spy.mockReturnValueOnce(debt); // 锁前读：还看得到 debt，于是进入重放分支去抢锁
+    spy.mockReturnValue(null); // 锁内权威重读：另一进程已清账
+    try {
+      const code = await run(["dev", "--once", "--json"]);
+      // 锁内重读为 null → 不重放，正常退出。
+      expect(code).toBe(0);
+      // 关键回归：没有把已被处理的同一条 wake 再重放一遍（否则就是 TOCTOU 重复唤醒）。
+      expect(stdout.join("\n")).not.toContain("watch_replay");
+      expect(stdout.join("\n")).not.toContain("replay_attempt");
+      // 证明确实发生了锁前 + 锁内两次读（锁内重读把决策基准换成了当前真值）。
+      expect(spy).toHaveBeenCalledTimes(2);
+      // 欠账未被本进程消费：on-disk attempts 未被 +1（saveWatchStuck 从未触发）。
+      expect(stuckAttempts()).toBe(0);
+    } finally {
+      spy.mockRestore();
     }
   });
 


### PR DESCRIPTION
大筛查 cli 命令层修复。`check:cli` 全绿（996 pass、tsc）。

- **#628** `probeFatal` 探测 `fetch` 加 `AbortSignal.timeout(10s)`（半开网络不再永久卡死重连）；瞬时 `429`/`5xx` 改退避重连而非当致命 `throw`（401/403/404 仍终局）。
- **#629**（security）board / channel role list / host board / squad list 打印服务端可控自由文本前统一 `stripTerminalControls`（复用 format 里已有实现），堵住 ANSI/CSI/OSC 转义注入。
- **#643** `--once` pending-wake 重放改走与正常路径同一把单实例锁（避免两个并发 watch 把同一条 @ 回两遍），try/finally 释放；`displayedMessageSeqs` 仅 `--once` 下写（消除 `--follow` 无界增长内存泄漏）。

新增 client / escape-injection / watch-643 三个测试文件。

Fixes #628
Fixes #629
Fixes #643

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **安全性**
  - CLI 看板、频道、主机和小队信息会自动过滤终端控制序列，避免服务端文本影响终端显示。

- **稳定性**
  - 网络探测新增超时机制，避免连接在异常网络环境下长期卡住。
  - 遇到临时性服务错误时将自动进入退避重连，而非直接终止连接。

- **可靠性**
  - `watch --once` 增强并发保护，避免重复唤醒任务。
  - 长时间运行模式减少不必要的内存占用。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->