### PR TITLE
fix(web): 修 #632 #633 #634 —— presence delta 合并活动/探活 / pendingSends 清账 / WS 心跳按时钟+jitter

### DIFF
--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -1689,6 +1689,21 @@ export interface PresenceFrame {
   agent_session?: AgentSessionInfo;
   /** 同一身份当前活跃连接数。 */
   connection_count?: number;
+  /**
+   * 模型 session 内的细粒度活动（issue #602）：跑哪个工具、是否卡权限确认、是否 compact。
+   * 与 current_task 同生共死；presence delta 帧照常捎带，前端据此渲染活动徽章（#608）。旧客户端忽略。
+   */
+  activity?: AgentActivity;
+  /**
+   * runner 健康自报（issue #603）：serve runner 连败中（"在线但干不动"）。仅有连败时下发，
+   * 恢复由后续心跳缺省即清；presence delta 帧照常捎带，前端据此渲染探活徽章（#608）。旧客户端忽略。
+   */
+  runner_health?: RunnerHealth;
+  /**
+   * 服务端派生的监听力判定（issue #603）：suspect / deaf（"在线但没在听"）。仅有负面信号时下发；
+   * presence delta 帧照常捎带，前端据此渲染探活徽章（#608）。旧客户端忽略。
+   */
+  listening?: ListeningVerdict;
 }
 
 export interface ErrorFrame {

--- a/web/src/lib/ws.heartbeat.test.ts
+++ b/web/src/lib/ws.heartbeat.test.ts
@@ -200,6 +200,35 @@ describe("ChannelSocket 心跳 pong 看门狗 (issue #130)", () => {
     sock.dispose();
   });
 
+  test("后台标签页 timer 被节流到 ~60s/次、但每 tick 服务端仍即时回 pong → 绝不误判掉线重连 (issue #634)", () => {
+    const { statuses, handlers } = statusRecorder();
+    const sock = new ChannelSocket("demo", "tok", handlers);
+    sock.connect();
+    const s0 = FakeSocket.instances[0]!;
+    s0.open();
+    s0.deliver(welcome());
+
+    // 节流：tick 间隔被浏览器拉到 60s（> PONG_TIMEOUT_MS=50s）。旧看门狗按「lastFrameAt 超 2×interval」
+    // 会在每个 tick 前就把健康连接误判成死连接、每分钟无谓重连；新看门狗只认「发了 ping 又一帧未回」的
+    // 真实沉默窗口——上一个 ping 每次都被紧随的 pong 归零，节流拉长的 tick 间隔完全不触发判死。
+    const THROTTLED_INTERVAL = 60_000;
+    for (let i = 0; i < 6; i++) {
+      clock += THROTTLED_INTERVAL;
+      fireHeartbeat();
+      s0.deliver({ type: "pong" }); // do 的 auto-response，紧随 ping 立即到达
+    }
+
+    // 过程断言：健康连接从不被 close、从不翻 reconnecting、只有一个 socket（没有惊群重连）
+    expect(s0.closed).toBe(false);
+    expect(FakeSocket.instances.length).toBe(1);
+    expect(statuses).not.toContain("reconnecting");
+    expect(statuses[statuses.length - 1]).toBe("open");
+    // 心跳没被误停：每个 tick 都照常发了 ping
+    expect(s0.pings().length).toBe(6);
+
+    sock.dispose();
+  });
+
   test("连上后迟迟没有 welcome/任何帧：看门狗以 open 时刻为基线，首个周期内不误杀、超阈值后照样判死", () => {
     const { handlers } = statusRecorder();
     const sock = new ChannelSocket("demo", "tok", handlers);

--- a/web/src/lib/ws.reconnect.test.ts
+++ b/web/src/lib/ws.reconnect.test.ts
@@ -1,0 +1,155 @@
+// issue #634 回归测试：重连退避必须带 jitter。同频道多客户端常被同一次 DO 驱逐/部署/网络抖动同时
+// 断开，纯确定性退避（1s/2s/4s…）会让它们精确同拍重连、惊群反复打垮刚恢复的 ChannelDO。断言调度延迟
+// 被抖到 [0.5, 1)×backoff，且天花板仍按 backoff 确定性翻倍。
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { ServerFrame } from "@agentparty/shared";
+import { ChannelSocket } from "./ws";
+
+const originalLocation = Object.getOwnPropertyDescriptor(globalThis, "location");
+const originalWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+const originalWebSocket = Object.getOwnPropertyDescriptor(globalThis, "WebSocket");
+const realRandom = Math.random;
+
+// 捕获 window.setTimeout 的 (回调, 延迟)；scheduledDelays 记录每次重连排定的延迟。
+let scheduledDelays: number[];
+let pendingTimers: Array<() => void>;
+function flushTimers() {
+  const due = pendingTimers.splice(0);
+  for (const fn of due) fn();
+}
+
+class FakeSocket {
+  static instances: FakeSocket[] = [];
+  static OPEN = 1;
+  static reset() {
+    FakeSocket.instances = [];
+  }
+  readyState = 0; // CONNECTING
+  onopen: (() => void) | null = null;
+  onmessage: ((ev: { data: unknown }) => void) | null = null;
+  onclose: ((ev: { code: number; reason: string }) => void) | null = null;
+  sent: string[] = [];
+  constructor(
+    public url: string,
+    public protocols?: string[],
+  ) {
+    FakeSocket.instances.push(this);
+  }
+  send(data: string) {
+    this.sent.push(data);
+  }
+  close() {
+    this.readyState = 3;
+  }
+  open() {
+    this.readyState = FakeSocket.OPEN;
+    this.onopen?.();
+  }
+  deliver(frame: ServerFrame) {
+    this.onmessage?.({ data: JSON.stringify(frame) });
+  }
+  // 传输层断线（非 1008），opened=true 走 scheduleReconnect
+  drop(code = 1006, reason = "") {
+    this.readyState = 3;
+    this.onclose?.({ code, reason });
+  }
+}
+
+function noopHandlers() {
+  return { onFrame: () => {}, onStatus: () => {}, onFatal: () => {} };
+}
+
+beforeEach(() => {
+  FakeSocket.reset();
+  scheduledDelays = [];
+  pendingTimers = [];
+  Object.defineProperty(globalThis, "WebSocket", { configurable: true, writable: true, value: FakeSocket });
+  Object.defineProperty(globalThis, "location", {
+    configurable: true,
+    writable: true,
+    value: { protocol: "http:", host: "localhost" },
+  });
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    writable: true,
+    value: {
+      setInterval: () => 0,
+      clearInterval: () => {},
+      setTimeout: (fn: () => void, delay?: number) => {
+        scheduledDelays.push(delay ?? 0);
+        pendingTimers.push(fn);
+        return pendingTimers.length;
+      },
+      clearTimeout: () => {},
+    },
+  });
+});
+
+afterEach(() => {
+  Math.random = realRandom;
+  for (const [key, descriptor] of [
+    ["WebSocket", originalWebSocket],
+    ["window", originalWindow],
+    ["location", originalLocation],
+  ] as const) {
+    if (descriptor === undefined) Reflect.deleteProperty(globalThis, key);
+    else Object.defineProperty(globalThis, key, descriptor);
+  }
+});
+
+const BACKOFF_MIN = 1_000;
+
+// connect + open + drop 一次，返回本次重连排定的延迟。
+function firstReconnectDelay(): number {
+  const sock = new ChannelSocket("demo", "tok", noopHandlers());
+  sock.connect();
+  const s0 = FakeSocket.instances[FakeSocket.instances.length - 1]!;
+  s0.open(); // everConnected=true, backoff 复位为 BACKOFF_MIN
+  s0.drop();
+  const delay = scheduledDelays[scheduledDelays.length - 1]!;
+  sock.dispose();
+  return delay;
+}
+
+describe("ChannelSocket 重连退避 jitter (issue #634)", () => {
+  test("jitter 下界：Math.random=0 → 0.5×backoff", () => {
+    Math.random = () => 0;
+    expect(firstReconnectDelay()).toBe(BACKOFF_MIN * 0.5);
+  });
+
+  test("jitter 上界：Math.random→1 时延迟趋近但严格 < backoff（绝不同拍撞满）", () => {
+    Math.random = () => 0.999_999;
+    const delay = firstReconnectDelay();
+    expect(delay).toBeGreaterThan(BACKOFF_MIN * 0.5);
+    expect(delay).toBeLessThan(BACKOFF_MIN);
+  });
+
+  test("任意随机取值都落在 [0.5, 1)×backoff：同拍断开的一群客户端被摊开而非同步重连", () => {
+    for (const r of [0, 0.1, 0.37, 0.5, 0.73, 0.9, 0.999_999]) {
+      Math.random = () => r;
+      const delay = firstReconnectDelay();
+      expect(delay).toBeGreaterThanOrEqual(BACKOFF_MIN * 0.5);
+      expect(delay).toBeLessThan(BACKOFF_MIN);
+    }
+  });
+
+  test("加 jitter 不改天花板翻倍：持续握手失败时排定延迟按 backoff 逐轮翻番（各自 0.5× 下界）", () => {
+    // 固定 random=0 让每轮落在各自 backoff 下界，凸显翻倍：backoff 1000 → 2000。onopen 会把 backoff 复位，
+    // 故走「从未 open 的握手失败」分支才能观察到累积翻倍；只跑 2 轮，止步于 HANDSHAKE_PROBE_AFTER=3
+    // 的 rest 探测分支（那条走 fetch，不在本用例范围）。
+    Math.random = () => 0;
+    const sock = new ChannelSocket("demo", "tok", noopHandlers());
+    sock.connect();
+
+    const delays: number[] = [];
+    for (let round = 0; round < 2; round++) {
+      const s = FakeSocket.instances[FakeSocket.instances.length - 1]!;
+      s.drop(); // 从未 open：backoff 不被 onopen 复位，逐轮翻倍
+      delays.push(scheduledDelays[scheduledDelays.length - 1]!);
+      flushTimers(); // 排定的重连回调拉起下一条连接
+    }
+
+    expect(delays).toEqual([BACKOFF_MIN * 0.5, BACKOFF_MIN]); // 500, 1000 —— 即 0.5×1000, 0.5×2000
+    sock.dispose();
+  });
+});

--- a/web/src/lib/ws.ts
+++ b/web/src/lib/ws.ts
@@ -44,6 +44,10 @@ export class ChannelSocket {
   private backoff = BACKOFF_MIN_MS;
   private pingTimer: number | null = null;
   private lastFrameAt = 0; // 最近一次收到任何入站帧（含 pong）的时刻，心跳看门狗判活用（issue #130）
+  // 当前这段「已发 ping 但一帧未回」沉默窗口的起点（epoch ms）；0 = 无在途未答 ping。
+  // 看门狗据 now - lastPingAt 判死，而不是「lastFrameAt 超 2×interval」——后台标签页 timer 被节流到
+  // ~60s/次时，后者会把每个 ping 都即时收到 pong 的健康连接误判掉线、每分钟无谓重连一次（issue #634）。
+  private lastPingAt = 0;
   private reconnectTimer: number | null = null;
   private everConnected = false;
   private handshakeFails = 0; // 连续「从未 open 就被关」的次数
@@ -78,6 +82,7 @@ export class ChannelSocket {
       this.handshakeFails = 0;
       this.backoff = BACKOFF_MIN_MS;
       this.lastFrameAt = Date.now(); // 看门狗基线：刚连上视为"此刻收到过帧"，避免首个周期误判死连接
+      this.lastPingAt = 0; // 新连接尚无在途未答 ping
       this.handlers.onStatus("open");
       // hello 等 welcome 到了再发（见 onmessage）：welcome.last_rev_seq 作 since_rev，
       // 服务端就不会把全部历史修订快照无条件重放进来——IM 窗口模式下，一条被编辑的
@@ -85,22 +90,30 @@ export class ChannelSocket {
       // 字面量须与 do 的 setWebSocketAutoResponse 配对，不唤醒 do
       this.pingTimer = window.setInterval(() => {
         if (ws.readyState !== WebSocket.OPEN) return;
+        const now = Date.now();
         // 静默死连接（TCP 半开）看门狗：健康连接下每个 ping 都会被 do 即时 pong 回来刷新 lastFrameAt。
-        // 若连续 PONG_TIMEOUT_MS 一帧未回（含 pong），说明发出去的 ping 全部石沉大海——链路已死但
-        // readyState 仍是 OPEN、onclose 迟迟不来。此时必须主动 close + 重连，绝不能把"沉默"当成健康
-        // 继续对用户显示 open（issue #130：一个 supervisor 挂着却收不到消息，presence 还显示在线）。
-        if (Date.now() - this.lastFrameAt > PONG_TIMEOUT_MS) {
+        // 判死只认「确实发过 ping，且自那以后一帧未回（含 pong），且真实墙钟已过 PONG_TIMEOUT_MS」——
+        // 用 now - lastPingAt 这个真实时间戳差判活，而不是假设 interval 准点触发。后台标签页 timer 被浏览器
+        // 节流到 ~60s/次时，旧的「lastFrameAt 超 2×interval」会把每个 ping 都即时收到 pong 的健康连接
+        // 误判掉线、每分钟无谓重连（issue #634）；这里只要上一个 ping 收到过回帧，沉默窗口就被 onmessage
+        // 归零，节流拉长的 tick 间隔完全不触发判死。真死连接（ping 发出、pong 石沉大海）照样在窗口越界后
+        // 主动 close + 重连，绝不把"沉默"当成健康继续显示 open（issue #130）。
+        if (this.lastPingAt > 0 && now - this.lastPingAt > PONG_TIMEOUT_MS) {
           this.handleStaleConnection(ws);
           return;
         }
         ws.send('{"type":"ping"}');
+        // 沉默窗口起点只在「上一个 ping 已被回帧确认」（lastPingAt 已被 onmessage 归零）时才前移，
+        // 已有在途未答 ping 则保留旧起点，否则每 tick 重发 ping 会不断刷新窗口、把死连接拖成永不判定。
+        if (this.lastPingAt === 0) this.lastPingAt = now;
       }, PING_INTERVAL_MS);
     };
 
     ws.onmessage = (ev) => {
       if (typeof ev.data !== "string") return;
-      // 任何入站帧（含 pong）都证明链路还活着 → 刷新看门狗时钟（issue #130）
+      // 任何入站帧（含 pong）都证明链路还活着 → 刷新看门狗时钟、归零在途未答 ping 窗口（issue #130 / #634）
       this.lastFrameAt = Date.now();
+      this.lastPingAt = 0;
       let frame: ServerFrame;
       try {
         frame = JSON.parse(ev.data) as ServerFrame;
@@ -167,7 +180,11 @@ export class ChannelSocket {
   }
 
   private scheduleReconnect() {
-    this.reconnectTimer = window.setTimeout(() => this.connect(), this.backoff);
+    // 退避加 jitter（issue #634）：同频道多客户端常被同一次 DO 驱逐/重启/worker 部署/网络抖动同时断开，
+    // 纯确定性退避会让它们在 1s/2s/4s 精确同拍重连，形成惊群反复打垮刚恢复的 ChannelDO，再把整群
+    // 同步到下一轮。抖到 [0.5, 1)×backoff 把重连摊开到窗口内，天花板仍按 backoff 确定性翻倍。
+    const delay = this.backoff * (0.5 + Math.random() * 0.5);
+    this.reconnectTimer = window.setTimeout(() => this.connect(), delay);
     this.backoff = Math.min(this.backoff * 2, BACKOFF_MAX_MS);
   }
 

--- a/web/src/pages/Channel.tsx
+++ b/web/src/pages/Channel.tsx
@@ -2718,7 +2718,10 @@ export function ChannelPage({
   }, []);
   const sockRef = useRef<ChannelSocket | null>(null);
   const streamRef = useRef<HTMLDivElement | null>(null);
-  const pendingSendsRef = useRef<Array<{ draft: string; replyTo: number | null }>>([]);
+  // 每条已写出 ws 的待发消息一个条目，按客户端自增 id 标识；服务端每回一个终局帧（sent 或 error）
+  // 就按 id 精确摘掉队头一条。用 id 而非无脑 shift：即便同一次归约被 React 触发两次也幂等（issue #633）。
+  const pendingSendsRef = useRef<Array<{ id: number; draft: string; replyTo: number | null }>>([]);
+  const pendingSendIdRef = useRef(0);
   const stickBottom = useRef(true);
   const authFailedRef = useRef(onAuthFailed);
   authFailedRef.current = onAuthFailed;
@@ -3365,14 +3368,32 @@ export function ChannelPage({
     if (el.scrollTop < TOP_LOAD_PX) loadOlder();
   }, [loadOlder, sendSeen]);
 
+  // 按 id 精确摘掉待发队头一条（已被服务端终结的那次 send），返回被摘条目；队空即 no-op。
+  // 摘队头而非按内容匹配：ws 有序，服务端对每次 send 恰好回一个终局帧（sent 或 error），FIFO 对齐。
+  const reconcilePendingSend = useCallback(() => {
+    const head = pendingSendsRef.current[0];
+    if (head === undefined) return undefined;
+    pendingSendsRef.current = pendingSendsRef.current.filter((p) => p.id !== head.id);
+    return head;
+  }, []);
+
   // 服务端 sent 确认后才清对应草稿；用户已输入的新内容不能被旧 ack 清掉。
   useEffect(() => {
     if (state.lastSentSeq <= 0) return;
-    const submitted = pendingSendsRef.current.shift();
+    const submitted = reconcilePendingSend();
     if (submitted === undefined) return;
     setDraft((current) => (current === submitted.draft ? "" : current));
     setReplyTo((current) => (current === submitted.replyTo ? null : current));
-  }, [state.lastSentSeq]);
+  }, [state.lastSentSeq, reconcilePendingSend]);
+
+  // 服务端 error 帧（loop_guard / rate_limited / too_large / unauthorized / archived）即一次 send 被拒：
+  // 它永不发 sent，若不在此摘掉对应待发条目，FIFO 队列永久错位一位——之后一次成功发送的 sent ack 会去
+  // 清那条陈旧草稿、清不掉真正已发出的 composer，用户误以为没发出去而重复发送（issue #633）。被拒时草稿
+  // 保留供重试，故这里只摘队头、不动 composer。
+  useEffect(() => {
+    if (state.sendRejectedSeq <= 0) return;
+    reconcilePendingSend();
+  }, [state.sendRejectedSeq, reconcilePendingSend]);
 
   const send = useCallback(() => {
     const body = draft.trim();
@@ -3393,7 +3414,7 @@ export function ChannelPage({
       }) ?? false;
     // ⌘⏎ 不受按钮 disabled 门控，断线窗口内发送失败要内联提示（草稿保留）
     if (ok) {
-      pendingSendsRef.current.push({ draft, replyTo });
+      pendingSendsRef.current.push({ id: ++pendingSendIdRef.current, draft, replyTo });
       // 附件已落 R2，ws 已接收帧 → 乐观清空待发引用（失败上传一并丢弃，失败时保留草稿由 ack 逻辑处理）
       setAttachments([]);
       setUploads([]);

--- a/web/src/pages/Channel.tsx
+++ b/web/src/pages/Channel.tsx
@@ -3370,6 +3370,11 @@ export function ChannelPage({
 
   // 按 id 精确摘掉待发队头一条（已被服务端终结的那次 send），返回被摘条目；队空即 no-op。
   // 摘队头而非按内容匹配：ws 有序，服务端对每次 send 恰好回一个终局帧（sent 或 error），FIFO 对齐。
+  // #633：按 FIFO 摘队头。服务端在同一条 WebSocket 上**串行**处理 send 并**按序**回终局帧——每条 send
+  // 恰好对应一个 sent 或一个 send-拒绝 error（见 state.ts 仅对 send-拒绝码 bump sendRejectedSeq，连接级
+  // 的 forbidden 不算），故终局帧与待发条目严格同序，摘队头即摘其对应条目。head.id 用于幂等（万一某个
+  // reconcile effect 重入也只删这一条、不误删两条）。若未来终局回执会乱序/去重/合并，需服务端在 sent/error
+  // 帧里回带一个 client_id 精确关联——那是跨 worker+shared+web 的协议强化，非本 bug 修复范围。
   const reconcilePendingSend = useCallback(() => {
     const head = pendingSendsRef.current[0];
     if (head === undefined) return undefined;

--- a/web/src/state.test.ts
+++ b/web/src/state.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import type { DirectedDelivery, MsgFrame, PresenceFrame } from "@agentparty/shared";
+import type { DirectedDelivery, ErrorCode, MsgFrame, PresenceFrame } from "@agentparty/shared";
 import { channelReducer, initialChannelState } from "./state";
 
 const NOW_FOR_RETENTION = 1_725_000_000_000;
@@ -506,5 +506,98 @@ describe("channel state", () => {
       frame: { ...frame, ts: frame.ts + 1, waiting_owner_count: undefined },
     });
     expect(cleared.presence["runner-a"]?.waiting_owner_count).toBeUndefined();
+  });
+
+  test("carries activity / runner_health / listening through incremental presence frames (#608/#632)", () => {
+    // 全量 welcome 之外，activity/探活字段只走 presence delta 下发；漏合并则 #608 徽章只在连接那一瞬
+    // 亮起、第一拍增量就被抹掉——恰是无人值守 agent 卡 waiting_permission / runner 熔断前最该看见的时刻。
+    const frame: PresenceFrame = {
+      type: "presence",
+      name: "runner-a",
+      kind: "agent",
+      state: "working",
+      note: "handling wake",
+      ts: 1_725_000_000_000,
+      live: true,
+      busy: true,
+      current_task: 45,
+      activity: { phase: "waiting_permission", tool: "Bash", ts: 1_725_000_000_500 },
+      runner_health: { ok: false, consecutive_failures: 2, last_error: "spawn failed" },
+      listening: "suspect",
+    };
+    const next = channelReducer(initialChannelState, { type: "frame", frame });
+
+    expect(next.presence["runner-a"]?.activity).toEqual({
+      phase: "waiting_permission",
+      tool: "Bash",
+      ts: 1_725_000_000_500,
+    });
+    expect(next.presence["runner-a"]?.runner_health).toEqual({
+      ok: false,
+      consecutive_failures: 2,
+      last_error: "spawn failed",
+    });
+    expect(next.presence["runner-a"]?.listening).toBe("suspect");
+
+    // 活动/探活与心跳同生共死：下一拍缺省即清，绝不留僵值。
+    const cleared = channelReducer(next, {
+      type: "frame",
+      frame: { ...frame, ts: frame.ts + 1, activity: undefined, runner_health: undefined, listening: undefined },
+    });
+    expect(cleared.presence["runner-a"]?.activity).toBeUndefined();
+    expect(cleared.presence["runner-a"]?.runner_health).toBeUndefined();
+    expect(cleared.presence["runner-a"]?.listening).toBeUndefined();
+  });
+
+  test("send-rejecting error frames bump sendRejectedSeq so the composer queue drops the stale entry (#633)", () => {
+    // sendRejectedSeq 是 composer 侧 pendingSends 摘账用的单调触发器：被拒的 send 永不发 sent、
+    // 不推进 lastSentSeq，只有靠它 +1 才能把错位的待发条目摘掉。
+    expect(initialChannelState.sendRejectedSeq).toBe(0);
+
+    const loopGuard = channelReducer(initialChannelState, {
+      type: "frame",
+      frame: { type: "error", code: "loop_guard", message: "loop detected" },
+    });
+    expect(loopGuard.sendRejectedSeq).toBe(1);
+    expect(loopGuard.loopGuard).toBe("loop detected");
+
+    const rateLimited = channelReducer(loopGuard, {
+      type: "frame",
+      frame: { type: "error", code: "rate_limited", message: "slow down" },
+    });
+    expect(rateLimited.sendRejectedSeq).toBe(2);
+    expect(rateLimited.sendError).toBe("slow down");
+
+    const unauthorized = channelReducer(rateLimited, {
+      type: "frame",
+      frame: { type: "error", code: "unauthorized", message: "nope" },
+    });
+    expect(unauthorized.sendRejectedSeq).toBe(3);
+    expect(unauthorized.readonly).toBe(true);
+
+    const archived = channelReducer(unauthorized, {
+      type: "frame",
+      frame: { type: "error", code: "archived", message: "gone" },
+    });
+    expect(archived.sendRejectedSeq).toBe(4);
+    expect(archived.archived).toBe(true);
+  });
+
+  test("a sent ack never bumps sendRejectedSeq; connect-time forbidden never does either (#633)", () => {
+    // sent 走 lastSentSeq 摘账，不该同时被算作一次拒绝。
+    const sent = channelReducer(initialChannelState, {
+      type: "frame",
+      frame: { type: "sent", seq: 9 },
+    });
+    expect(sent.sendRejectedSeq).toBe(0);
+    expect(sent.lastSentSeq).toBe(9);
+
+    // forbidden 是连接期 ACL 拒入、不对应任何已入队 send，若也 +1 会误摘一条无辜的待发条目。
+    const forbidden = channelReducer(initialChannelState, {
+      type: "frame",
+      frame: { type: "error", code: "forbidden" as ErrorCode, message: "private" },
+    });
+    expect(forbidden.forbidden).toBe(true);
+    expect(forbidden.sendRejectedSeq).toBe(0);
   });
 });

--- a/web/src/state.ts
+++ b/web/src/state.ts
@@ -32,6 +32,10 @@ export interface ChannelState {
   loopGuardBaselineSeq: number | null; // welcome/error 时的游标；历史回放中的旧 human 消息不能清黄条
   sendError: string | null; // rate_limited / too_large 红条
   lastSentSeq: number; // sent 确认，composer 据此清空草稿
+  // 服务端拒绝一次 send 的累计次数（loop_guard / rate_limited / too_large / unauthorized / archived）。
+  // 被拒的 send 永不发 sent、不推进 lastSentSeq，composer 侧据此计数从待发队列摘掉对应条目，
+  // 避免 FIFO 永久错位（issue #633）。只增不减，值本身无意义，只作单调触发器用。
+  sendRejectedSeq: number;
 }
 
 export const initialChannelState: ChannelState = {
@@ -51,6 +55,7 @@ export const initialChannelState: ChannelState = {
   loopGuardBaselineSeq: null,
   sendError: null,
   lastSentSeq: 0,
+  sendRejectedSeq: 0,
 };
 
 export type ChannelAction =
@@ -336,26 +341,41 @@ function applyFrame(state: ChannelState, frame: ServerFrame): ChannelState {
             current_task: frame.current_task,
             task_started_at: frame.task_started_at,
             heartbeat_at: frame.heartbeat_at,
+            // #608 的活动与探活徽章靠这三条：presence delta 每拍都下发（活动新鲜度与心跳同生共死），
+            // 漏合并则徽章只在 welcome 快照那一瞬亮起、第一拍增量就被抹掉（issue #632）。
+            activity: frame.activity,
+            runner_health: frame.runner_health,
+            listening: frame.listening,
           },
         },
       };
     case "sent":
       return { ...state, lastSentSeq: frame.seq, sendError: null, loopGuard: null, loopGuardBaselineSeq: null };
-    case "error":
+    case "error": {
       // worker 可能先发 error:forbidden 再 1008 关连（private ACL 拒入，spec §3）。
-      // "forbidden" 尚未进 shared ErrorCode 联合类型，运行时按字符串识别。
+      // "forbidden" 尚未进 shared ErrorCode 联合类型，运行时按字符串识别。它是连接期 ACL 拒入、
+      // 不对应任何已入队的 send，故不计入 sendRejectedSeq（否则会误摘一条无辜的待发条目）。
       if ((frame.code as string) === "forbidden") return { ...state, forbidden: true };
+      // 走到这里的 error 帧都是对一次 send 的拒答（loop_guard/rate_limited/too_large/unauthorized/archived）——
+      // 永不发 sent，故计数 +1 让 composer 侧摘掉对应待发条目，队列不再错位（issue #633）。
+      const sendRejectedSeq = state.sendRejectedSeq + 1;
       switch (frame.code) {
         case "unauthorized":
           // 契约：send 被拒 unauthorized 即视为 readonly token（吊销场景随后会被 1008 踢线接管）
-          return { ...state, readonly: true };
+          return { ...state, readonly: true, sendRejectedSeq };
         case "loop_guard":
-          return { ...state, loopGuard: frame.message, loopGuardBaselineSeq: state.messages.at(-1)?.seq ?? 0 };
+          return {
+            ...state,
+            loopGuard: frame.message,
+            loopGuardBaselineSeq: state.messages.at(-1)?.seq ?? 0,
+            sendRejectedSeq,
+          };
         case "archived":
-          return { ...state, archived: true };
+          return { ...state, archived: true, sendRejectedSeq };
         default:
-          return { ...state, sendError: frame.message };
+          return { ...state, sendError: frame.message, sendRejectedSeq };
       }
+    }
     default:
       return state; // pong 等
   }


### PR DESCRIPTION
大筛查 web 实时数据修复。`check:web` 全绿（883 pass、tsc、vite build）。

- **#632** presence delta reducer 合并 `activity`/`listening`/`runner_health`（#608 的活动与探活徽章增量更新恢复）；`shared/src/protocol.ts` 的 `PresenceFrame` 补上这三个可选字段（worker 已在广播）。
- **#633** 被拒发送按 client-side id 精确移除 pendingSends 头项（`reconcilePendingSend`，幂等），FIFO 不再错位、后续成功发送能清空 composer；拒绝保留草稿。
- **#634** WS 心跳看门狗改用真实墙钟沉默窗口（`lastPingAt`，onmessage 归零）判死，后台标签页 timer 节流下健康连接不再误判重连；重连退避加 `[0.5,1)×` jitter 摊开惊群。

Fixes #632
Fixes #633
Fixes #634

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - Presence 状态支持活动阶段、运行健康度和监听状态徽章。
  - 增加发送失败状态反馈，帮助准确处理未发送成功的消息。

- **问题修复**
  - 修复后台标签页计时受限时连接被误判为失效并重连的问题。
  - 优化重连延迟，减少多个客户端同时重连造成的拥堵。
  - 修复消息发送确认或拒绝时草稿队列错位、误清空的问题。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->