### PR TITLE
fix(web): 修 #635 #636 #637 #638 #639 #641 #642 —— pill 键劫持/CSS变量/模态a11y/配对死字段/i18n/mention伪造/死代码

### DIFF
--- a/shared/src/mentions.ts
+++ b/shared/src/mentions.ts
@@ -9,7 +9,11 @@
 export const MENTION_TOKEN_MAX_LENGTH = 64;
 
 const MENTION_VALUE_RE = /^[\p{L}\p{N}][\p{L}\p{N}\p{M}._-]*/u;
-const MENTION_TOKEN_RE = /^[\p{L}\p{N}][\p{L}\p{N}\p{M}._-]{0,63}$/u;
+// #641：用常量构造正则，让 64 字符上限单一来源——首字符 + 后续 {0, MAX-1}（避免常量与写死的 {0,63} 各说各话）。
+const MENTION_TOKEN_RE = new RegExp(
+  `^[\\p{L}\\p{N}][\\p{L}\\p{N}\\p{M}._-]{0,${MENTION_TOKEN_MAX_LENGTH - 1}}$`,
+  "u",
+);
 const ASCII_NAME_CHAR_RE = /[A-Za-z0-9._@-]/;
 const CJK_CHAR_RE = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u;
 const EMAIL_LOCAL_CHAR_RE = /[\p{L}\p{N}.!#$%&'*+/=?^_`{|}~-]/u;

--- a/web/src/components/AgentJoin.test.tsx
+++ b/web/src/components/AgentJoin.test.tsx
@@ -14,8 +14,10 @@ mock.module("../lib/api", () => ({
   createChannelAgent: mock(async (_slug: string, name: string) => ({ name, token: "ap_created" })),
 }));
 
+// #642：可翻转的复制结果——默认成功（存量用例语义不变），失败用例里置 false。
+let copyResult = true;
 mock.module("../lib/agentTokenVault", () => ({
-  copyText: async () => true,
+  copyText: async () => copyResult,
   MIN_CLI: "0.2.124",
   VERSION_GE_SNIPPET: "version_ge(){ :; }",
   mcpServerName: (agentName: string) => `party-${agentName.replace(/[^a-zA-Z0-9_-]/g, "-")}`,
@@ -53,6 +55,7 @@ let storedLocale: string | null;
 beforeEach(() => {
   savedAgents.length = 0;
   storedLocale = null;
+  copyResult = true;
   windowEvents = new TestEventTarget();
   Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", { configurable: true, value: true });
   Object.defineProperty(globalThis, "window", {
@@ -343,5 +346,35 @@ describe("AgentJoin 接入包 server 域名 (#530)", () => {
     expect(command).toContain("party init --server https://agentparty.leeguoo.com ");
     // 绝不能回退到 location.origin(桌面端的伪源，此处以 https://party.test 代表)
     expect(command).not.toContain("party init --server https://party.test");
+  });
+});
+
+describe("AgentJoin 复制反馈 (#642)", () => {
+  async function generate(r: ReactTestRenderer) {
+    await act(async () => {
+      await r.root.find((node) => node.props.className === "d-btn d-btn--primary" && node.props.onClick).props.onClick();
+    });
+  }
+
+  test("复制失败弹出错误横幅，不再静默（命令带只展示一次的 token）", async () => {
+    copyResult = false;
+    const r = render();
+    open(r);
+    await generate(r);
+    await act(async () => {
+      await r.root.find((node) => node.props.className === "d-btn agent-join-copy").props.onClick();
+    });
+    expect(r.root.findAll((node) => node.props.className === "banner banner--red agent-join-copyerr")).toHaveLength(1);
+  });
+
+  test("复制成功不显示错误横幅、按钮切到已复制", async () => {
+    copyResult = true;
+    const r = render();
+    open(r);
+    await generate(r);
+    await act(async () => {
+      await r.root.find((node) => node.props.className === "d-btn agent-join-copy").props.onClick();
+    });
+    expect(r.root.findAll((node) => node.props.className === "banner banner--red agent-join-copyerr")).toHaveLength(0);
   });
 });

--- a/web/src/components/AgentJoin.test.tsx
+++ b/web/src/components/AgentJoin.test.tsx
@@ -368,6 +368,7 @@ describe("AgentJoin 复制反馈 (#642)", () => {
   });
 
   test("复制成功不显示错误横幅、按钮切到已复制", async () => {
+    localStorage.setItem("ap_locale", "en");
     copyResult = true;
     const r = render();
     open(r);
@@ -376,5 +377,9 @@ describe("AgentJoin 复制反馈 (#642)", () => {
       await r.root.find((node) => node.props.className === "d-btn agent-join-copy").props.onClick();
     });
     expect(r.root.findAll((node) => node.props.className === "banner banner--red agent-join-copyerr")).toHaveLength(0);
+    // #654 复审：不止「没有错误横幅」，还要确认按钮切到「已复制」文案——
+    // 这样删掉 setCopied(ok) 会让本条挂掉（否则仅靠错误横幅缺席，删了也照样绿）。
+    const copyBtn = r.root.find((node) => node.props.className === "d-btn agent-join-copy");
+    expect(String(copyBtn.children[0] ?? "")).toBe("copied ✓");
   });
 });

--- a/web/src/components/AgentJoin.tsx
+++ b/web/src/components/AgentJoin.tsx
@@ -79,6 +79,8 @@ export function AgentJoin({ slug, token, namePrefix, inviterName, charter, accou
   const [adoptError, setAdoptError] = useState<string | null>(null);
   const [nameErr, setNameErr] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
+  // #642：复制失败要给用户明确反馈，别静默——join 命令带着只展示一次的 channel-scoped token。
+  const [copyErr, setCopyErr] = useState(false);
 
   const open = useCallback(() => {
     onActiveChange?.(true);
@@ -92,6 +94,7 @@ export function AgentJoin({ slug, token, namePrefix, inviterName, charter, accou
     setPhase({ kind: "idle" });
     setName("");
     setCopied(false);
+    setCopyErr(false);
     setNameErr(null);
   }, []);
 
@@ -140,6 +143,7 @@ export function AgentJoin({ slug, token, namePrefix, inviterName, charter, accou
         savedAt: Date.now(),
       });
       setCopied(false);
+      setCopyErr(false);
       setAdoptState("idle");
       setAdoptError(null);
       setPhase({ kind: "done", name: agent.name, token: agent.token, command, mode });
@@ -185,6 +189,7 @@ export function AgentJoin({ slug, token, namePrefix, inviterName, charter, accou
     if (phase.kind !== "done") return;
     const ok = await copyText(phase.command);
     setCopied(ok);
+    setCopyErr(!ok);
   }, [phase]);
 
   return (
@@ -325,6 +330,11 @@ export function AgentJoin({ slug, token, namePrefix, inviterName, charter, accou
                 {copied ? t("AgentJoin.copied") : t("AgentJoin.copy")}
               </button>
             </div>
+            {copyErr && (
+              <p className="banner banner--red agent-join-copyerr" role="alert">
+                {t("AgentJoin.errCopy")}
+              </p>
+            )}
 
             <p className="banner banner--yellow agent-join-warn" role="status">
               {t("AgentJoin.tokenWarn")}

--- a/web/src/components/DesktopAgentPanel.test.tsx
+++ b/web/src/components/DesktopAgentPanel.test.tsx
@@ -139,6 +139,48 @@ describe("DesktopAgentPanel 多实例 (#616)", () => {
     expect(stops).toEqual(["local-main:agentparty"]);
   });
 
+  // #642：打开过某实例日志后，底部聚合日志切换必须回到 adapter.logs()，不能被该实例永久劫持。
+  test("聚合日志切换清除单实例锁定，重开走 adapter.logs() 而非实例", async () => {
+    const noopScheduler: DesktopAgentScheduler = { every: () => () => {} };
+    let aggregate = 0;
+    const instanceCalls: string[] = [];
+    const root = await render(
+      adapter({
+        statusAll: async () => [running],
+        logs: async () => {
+          aggregate += 1;
+          return ["aggregate-line"];
+        },
+        logsInstance: async (id: string) => {
+          instanceCalls.push(id);
+          return ["instance-line"];
+        },
+      }),
+      noopScheduler,
+    );
+
+    // 打开某实例的日志 → 锁定 logsFor=local-main:agentparty，显示实例日志
+    await act(async () => {
+      await button("Logs local-main:agentparty").props.onClick();
+    });
+    expect(instanceCalls).toEqual(["local-main:agentparty"]);
+    expect(JSON.stringify(renderer!.toJSON())).toContain("instance-line");
+
+    // 底部聚合日志切换：此刻是展开态 → 点一次收起（顺带清 logsFor），再点一次重新展开聚合视图
+    const toggle = () => root.find((n) => n.props.className === "desktop-agent-logs-toggle");
+    await act(async () => {
+      await toggle().props.onClick();
+    });
+    await act(async () => {
+      await toggle().props.onClick();
+    });
+
+    // 关键回归：重开聚合走 adapter.logs()，且没有再打实例日志
+    expect(aggregate).toBeGreaterThan(0);
+    expect(instanceCalls).toEqual(["local-main:agentparty"]);
+    expect(JSON.stringify(renderer!.toJSON())).toContain("aggregate-line");
+  });
+
   test("start 透传 workdir/repo；同键实例活跃时禁用启动", async () => {
     const starts: DesktopAgentStartInput[] = [];
     const root = await render(adapter({

--- a/web/src/components/DesktopAgentPanel.tsx
+++ b/web/src/components/DesktopAgentPanel.tsx
@@ -202,9 +202,21 @@ export function DesktopAgentPanel({ t, adapter = desktopAgentAdapter, scheduler 
   const toggleLogs = async () => {
     const nextOpen = !logsOpen;
     setLogsOpen(nextOpen);
-    if (!nextOpen || logs !== null) return;
+    // #642：底部聚合日志切换是「聚合视图」。若之前打开过某个实例的日志（logsFor 被锁死），
+    // 必须在这里解除锁定并丢弃其缓存——否则聚合视图会被那个实例永久劫持，adapter.logs() 永远拿不到。
+    const wasInstance = logsFor !== null;
+    if (wasInstance) {
+      setLogsFor(null);
+      setLogs(null);
+    }
+    if (!nextOpen) return;
+    // 源从单实例切回聚合时必须重拉；否则命中聚合缓存就跳过。
+    if (logs !== null && !wasInstance) return;
+    setLogs(null);
+    // 显式走聚合 adapter.logs()：此刻 setLogsFor(null) 尚未落到 fetchLogs 闭包里的 logsFor，
+    // 直接用 fetchLogs 会读到旧值仍指向实例。
     try {
-      const nextLogs = (await fetchLogs()).map(safeError);
+      const nextLogs = (await adapter.logs()).map(safeError);
       if (aliveRef.current) setLogs(nextLogs);
     } catch (cause) {
       if (aliveRef.current) setError(safeError(cause));

--- a/web/src/components/OnboardingGuide.test.tsx
+++ b/web/src/components/OnboardingGuide.test.tsx
@@ -21,6 +21,7 @@ function memoryStorage(): Storage {
 }
 
 let renderer: ReactTestRenderer | null = null;
+let keyHandlers: Array<(e: { key: string }) => void> = [];
 
 function render(props: Parameters<typeof OnboardingGuide>[0] = {}) {
   act(() => {
@@ -40,6 +41,18 @@ function steps() {
 beforeEach(() => {
   Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", { configurable: true, value: true });
   Object.defineProperty(globalThis, "localStorage", { configurable: true, value: memoryStorage() });
+  keyHandlers = [];
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      addEventListener: (type: string, fn: (e: { key: string }) => void) => {
+        if (type === "keydown") keyHandlers.push(fn);
+      },
+      removeEventListener: (type: string, fn: (e: { key: string }) => void) => {
+        if (type === "keydown") keyHandlers = keyHandlers.filter((h) => h !== fn);
+      },
+    },
+  });
 });
 
 afterEach(() => {
@@ -47,6 +60,7 @@ afterEach(() => {
     act(() => renderer!.unmount());
     renderer = null;
   }
+  Reflect.deleteProperty(globalThis, "window");
 });
 
 describe("OnboardingGuide (#146)", () => {
@@ -76,6 +90,15 @@ describe("OnboardingGuide (#146)", () => {
     act(() => { dismissBtn.props.onClick(); });
 
     // 关掉后：标记落库 + 浮层消失
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("1");
+    expect(steps().length).toBe(0);
+  });
+
+  test("Escape 关闭模态并落库（#637 与其它模态一致）", () => {
+    render();
+    expect(steps().length).toBe(4);
+    // 模拟按下 Esc：触发挂到 window 的 keydown 监听
+    act(() => { keyHandlers.forEach((h) => h({ key: "Escape" })); });
     expect(localStorage.getItem(STORAGE_KEY)).toBe("1");
     expect(steps().length).toBe(0);
   });

--- a/web/src/components/OnboardingGuide.tsx
+++ b/web/src/components/OnboardingGuide.tsx
@@ -1,7 +1,7 @@
 // 首次进入的 1-2-3-4 引导浮层（#146）。只在浏览器第一次进来时出现，关掉后落一个
 // localStorage 标记（复用 ap_locale 那套持久化模式，不造新机制），之后不再打扰。
 // 范围克制：一张可关闭的四步卡片，讲清「加入频道 → @唤醒 → 认领任务 → 提交」主线。
-import { useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useT } from "../i18n/useT";
 import "../i18n/strings/Onboarding";
 
@@ -36,14 +36,25 @@ export function OnboardingGuide({
   const t = useT();
   // 「是否首次进入」判定：读 localStorage 标记。改这里（比如恒为 false）会让首次显示的测试红。
   const [open, setOpen] = useState(() => !alreadyOnboarded());
+  const visible = forceOpen || open;
 
-  const dismiss = () => {
+  const dismiss = useCallback(() => {
     markOnboarded();
     setOpen(false);
     onClose?.();
-  };
+  }, [onClose]);
 
-  if (!forceOpen && !open) return null;
+  // #637 a11y：与其它模态一致支持 Esc 关闭（此前只能点 ✕ 或背景，键盘用户到此断路）。
+  useEffect(() => {
+    if (!visible) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") dismiss();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [visible, dismiss]);
+
+  if (!visible) return null;
 
   return (
     <div className="onboarding-overlay" role="dialog" aria-modal="true" aria-labelledby="onboarding-title">

--- a/web/src/components/PresenceBar.test.ts
+++ b/web/src/components/PresenceBar.test.ts
@@ -359,11 +359,14 @@ describe("presence header controls", () => {
 // busy + 队列深度（#103）：serve 串行处理长任务时，presence 要显式表达「忙 + N 待处理」，
 // 与 working 蜡笔点区分，让人别把「@ 了没立刻回」当失联。
 describe("busy indicator + queue depth (#103)", () => {
-  test("busyLabel: 忙无队列 / 忙有队列 / 不忙三态", () => {
+  test("busyLabel: 忙无队列 / 忙有队列 / 不忙三态（#639 走 i18n key）", () => {
     const it = (over: Partial<Item>) =>
       ({ name: "a", busy: false, queueDepth: null, ...over }) as Item;
-    expect(busyLabel(it({ busy: true, queueDepth: null }))).toBe("⏳ busy");
-    expect(busyLabel(it({ busy: true, queueDepth: 4 }))).toBe("⏳ busy · 4 queued");
+    expect(busyLabel(it({ busy: true, queueDepth: null }))).toEqual({ key: "PresenceBar.busy" });
+    expect(busyLabel(it({ busy: true, queueDepth: 4 }))).toEqual({
+      key: "PresenceBar.busyQueued",
+      vars: { count: 4 },
+    });
     expect(busyLabel(it({ busy: false }))).toBeNull();
   });
 
@@ -395,9 +398,16 @@ describe("busy indicator + queue depth (#103)", () => {
     const it = (over: Partial<Item>) =>
       ({ name: "a", busy: false, queueDepth: null, currentTask: null, heartbeatAt: null, ...over }) as Item;
     // 新鲜心跳（<45s）显示 "now" = 还活着；很旧则显示 "2m"/"1h" = 大概率卡死。
-    expect(taskLabel(it({ currentTask: 510, heartbeatAt: now - 5_000 }), now)).toBe("▶ #510 · ♥ now");
-    expect(taskLabel(it({ currentTask: 510, heartbeatAt: now - 120_000 }), now)).toBe("▶ #510 · ♥ 2m");
-    expect(taskLabel(it({ currentTask: 7 }), now)).toBe("▶ #7");
+    // #639：走 taskChip/taskChipBeat i18n key（原为死键），不再写死 chip 文本。
+    expect(taskLabel(it({ currentTask: 510, heartbeatAt: now - 5_000 }), now)).toEqual({
+      key: "PresenceBar.taskChipBeat",
+      vars: { seq: 510, age: "now" },
+    });
+    expect(taskLabel(it({ currentTask: 510, heartbeatAt: now - 120_000 }), now)).toEqual({
+      key: "PresenceBar.taskChipBeat",
+      vars: { seq: 510, age: "2m" },
+    });
+    expect(taskLabel(it({ currentTask: 7 }), now)).toEqual({ key: "PresenceBar.taskChip", vars: { seq: 7 } });
     expect(taskLabel(it({ currentTask: null }), now)).toBeNull();
   });
 
@@ -416,6 +426,22 @@ describe("busy indicator + queue depth (#103)", () => {
     const badges = nodesWithClass(r, "presence-busy");
     expect(badges.some((n) => n.children.join("") === "⏳ busy")).toBe(true);
     expect(badges.some((n) => n.children.join("").includes("queued"))).toBe(false);
+  });
+
+  // #639：busy/queued chip 曾写死英文，zh 界面不翻译。改走 t() 后中文 locale 必须译。
+  test("busy chip follows the active en/zh locale (#639)", async () => {
+    const entry = busyEntry({ queue_depth: 3 });
+    const en = renderPresence(entry, true);
+    expect(nodesWithClass(en, "presence-busy").some((n) => n.children.join("") === "⏳ busy · 3 queued")).toBe(true);
+
+    await act(async () => en.unmount());
+    renderer = null;
+    localStorage.setItem("ap_locale", "zh");
+    const zh = renderPresence(entry, true);
+    const zhBadges = nodesWithClass(zh, "presence-busy");
+    expect(zhBadges.some((n) => n.children.join("") === "⏳ 忙 · 3 排队")).toBe(true);
+    // 关键回归：中文界面里绝不再出现写死的英文 "busy"
+    expect(zhBadges.some((n) => n.children.join("").includes("busy"))).toBe(false);
   });
 
   test("不忙的 working 项：不渲染 busy 徽章或汇总", () => {
@@ -655,5 +681,49 @@ describe("presence 暂停接待（#180）", () => {
     await openPopover(r);
     expect(nodesWithClass(r, "presence-pause-select")).toHaveLength(0);
     expect(nodesWithClass(r, "presence-resume")).toHaveLength(0);
+  });
+});
+
+// #635 / #637 a11y 修复
+describe("presence a11y (#635 pill 键劫持 / #637 group button role)", () => {
+  async function openPopover(r: ReactTestRenderer): Promise<void> {
+    const section = nodesWithClass(r, "presence-group")[0];
+    await act(async () => {
+      section?.props.onFocus({ currentTarget: { getBoundingClientRect: () => ({ left: 0, top: 0, width: 0 }) } });
+    });
+  }
+
+  // #635：pill 的 onKeyDown 只在 target 就是 pill 自身时才接管；焦点落在嵌套 kick 按钮上时冒泡不劫持。
+  test("pill onKeyDown 忽略来自嵌套控件的键盘事件，只响应 pill 自身", async () => {
+    const opened: string[] = [];
+    const r = renderWith(
+      { name: "agent-a", kind: "agent", state: "working", note: null, ts: Date.now() },
+      { canModerate: true, onRemoveParticipant: () => {}, onOpenAgentDetail: (name: string) => opened.push(name) },
+      true,
+    );
+    await openPopover(r);
+    const pill = nodesWithClass(r, "presence-pill")[0];
+    expect(pill).toBeDefined();
+    expect(pill?.props.role).toBe("button");
+    const self = {};
+    const child = {};
+    // 焦点在嵌套 kick 按钮（target !== currentTarget）→ 不触发详情弹窗
+    await act(async () => {
+      pill?.props.onKeyDown({ key: "Enter", target: child, currentTarget: self, preventDefault: () => {} });
+    });
+    expect(opened).toEqual([]);
+    // 焦点就在 pill 自身（target === currentTarget）→ 正常打开详情
+    await act(async () => {
+      pill?.props.onKeyDown({ key: "Enter", target: self, currentTarget: self, preventDefault: () => {} });
+    });
+    expect(opened).toEqual(["agent-a"]);
+  });
+
+  // #637：可键盘激活的 disclosure section 必须暴露 button role + aria-expanded。
+  test("presence-group section 暴露 role=button 与 aria-expanded", () => {
+    const r = renderPresenceRoster(2, true);
+    const section = nodesWithClass(r, "presence-group")[0];
+    expect(section?.props.role).toBe("button");
+    expect(section?.props["aria-expanded"]).toBe(false);
   });
 });

--- a/web/src/components/PresenceBar.tsx
+++ b/web/src/components/PresenceBar.tsx
@@ -137,9 +137,12 @@ function residencyBadge(item: Item): string | null {
 }
 
 // busy 标签（#103）：「⏳ busy」或「⏳ busy · N queued」。null = 不忙，不渲染。
-export function busyLabel(item: Item): string | null {
+// #639：返回 { key, vars } 走 t()，别写死英文——zh 界面也要翻译。
+export function busyLabel(item: Item): { key: string; vars?: { count: number } } | null {
   if (!item.busy) return null;
-  return item.queueDepth !== null ? `⏳ busy · ${item.queueDepth} queued` : "⏳ busy";
+  return item.queueDepth !== null
+    ? { key: "PresenceBar.busyQueued", vars: { count: item.queueDepth } }
+    : { key: "PresenceBar.busy" };
 }
 
 export function waitingOwnerLabel(item: Item): { key: string; vars: { count: number } } | null {
@@ -150,10 +153,12 @@ export function waitingOwnerLabel(item: Item): { key: string; vars: { count: num
 
 // 每任务进度/心跳 chip（#228）：「▶ #510」或「▶ #510 · ♥ 8s」。比 busy 更细——不仅「在忙」，还标明
 // 正在处理哪条 wake（触发 seq）和心跳新鲜度。心跳还在推进 = 活着；很旧 = 大概率卡死。null = 无活跃任务。
-export function taskLabel(item: Item, now: number): string | null {
+// #639：走已存在的 taskChip/taskChipBeat i18n 键（曾是死键），别写死 chip 文本。
+export function taskLabel(item: Item, now: number): { key: string; vars: { seq: number; age?: string } } | null {
   if (item.currentTask === null) return null;
-  const beat = item.heartbeatAt !== null ? ` · ♥ ${fmtRel(item.heartbeatAt, now)}` : "";
-  return `▶ #${item.currentTask}${beat}`;
+  return item.heartbeatAt !== null
+    ? { key: "PresenceBar.taskChipBeat", vars: { seq: item.currentTask, age: fmtRel(item.heartbeatAt, now) } }
+    : { key: "PresenceBar.taskChip", vars: { seq: item.currentTask } };
 }
 
 // 活动 chip 的新鲜度口径与 CLI（cli/src/activity.ts 的 ACTIVITY_TTL_MS）一致：超 5 分钟视为陈旧
@@ -483,6 +488,7 @@ export function PresenceBar({
     const busy = busyLabel(it);
     const waitingOwner = localizeWaitingOwner(it);
     const task = taskLabel(it, now);
+    const taskText = task === null ? null : t(task.key, task.vars);
     const liveness = livenessBadge(it);
     const activityChip = activityBadge(it, now);
     const taskTitle =
@@ -495,7 +501,11 @@ export function PresenceBar({
     const full = mode === "full";
     const titleParts = [
       it.owner !== null && it.owner !== it.name ? `${it.name} · ${it.owner}` : it.name,
-      it.busy ? `busy${it.queueDepth !== null ? ` · ${it.queueDepth} queued` : ""} (reachable, reply may be slow — do not re-@)` : null,
+      it.busy
+        ? it.queueDepth !== null
+          ? t("PresenceBar.busyTitleQueued", { count: it.queueDepth })
+          : t("PresenceBar.busyTitle")
+        : null,
       it.waitingOwnerCount > 0 ? t("PresenceBar.waitingOwnerTitle", { count: it.waitingOwnerCount }) : null,
       taskTitle,
       it.handle !== null && it.handle !== "" ? `handle: ${it.handle}` : null,
@@ -542,6 +552,9 @@ export function PresenceBar({
         onKeyDown={
           onOpenAgentDetail !== undefined
             ? (e) => {
+                // #635：焦点落在嵌套的 pause/resume/kick 控件上时，键盘激活会冒泡到本 pill；
+                // 只在事件 target 就是 pill 自身时才接管（对齐 renderGroup 的守卫）。
+                if (e.target !== e.currentTarget) return;
                 if (e.key === "Enter" || e.key === " ") {
                   e.preventDefault();
                   openAgentDetail(it.name);
@@ -578,11 +591,11 @@ export function PresenceBar({
             {badge}
           </span>
         )}
-        {busy !== null && <span className="t-mono presence-busy">{busy}</span>}
+        {busy !== null && <span className="t-mono presence-busy">{t(busy.key, busy.vars)}</span>}
         {waitingOwner !== null && <span className="t-mono presence-busy presence-waiting-owner">{waitingOwner}</span>}
-        {task !== null && (
+        {taskText !== null && (
           <span className="t-mono presence-busy presence-task" title={taskTitle ?? undefined}>
-            {task}
+            {taskText}
           </span>
         )}
         {liveness !== null && (
@@ -703,6 +716,9 @@ export function PresenceBar({
     return (
       <section
         key={group.key}
+        // #637 a11y：本 section 是可键盘激活的 disclosure toggle，必须显式 role="button"，
+        // 否则 aria-expanded 不被 AT 暴露、只当成普通 region 播报。
+        role="button"
         tabIndex={0}
         aria-expanded={full}
         className={
@@ -750,7 +766,10 @@ export function PresenceBar({
         </div>
         {!full && (
           <div className="presence-group-agents" aria-label={`agents owned by ${group.label}`}>
-            {previewAgents.map((agent) => (
+            {previewAgents.map((agent) => {
+              const agentBusy = busyLabel(agent);
+              const agentTask = taskLabel(agent, now);
+              return (
               <span
                 key={agent.name}
                 className={`presence-agent-chip${onOpenAgentDetail !== undefined ? " presence-agent-chip--clickable" : ""}`}
@@ -800,17 +819,20 @@ export function PresenceBar({
                 )}
                 {agent.connectionCount > 1 && <span className="t-mono presence-agent-duplicate">x{agent.connectionCount}</span>}
                 {roleBadge(agent, now) !== null && <span className="t-mono presence-agent-role">{roleBadge(agent, now)}</span>}
-                {busyLabel(agent) !== null && <span className="t-mono presence-busy presence-busy--chip">{busyLabel(agent)}</span>}
+                {agentBusy !== null && (
+                  <span className="t-mono presence-busy presence-busy--chip">{t(agentBusy.key, agentBusy.vars)}</span>
+                )}
                 {agent.waitingOwnerCount > 0 && (
                   <span className="t-mono presence-busy presence-busy--chip presence-waiting-owner">
                     {t("PresenceBar.waitingOwnerChip", { count: agent.waitingOwnerCount })}
                   </span>
                 )}
-                {taskLabel(agent, now) !== null && (
-                  <span className="t-mono presence-busy presence-busy--chip presence-task">{taskLabel(agent, now)}</span>
+                {agentTask !== null && (
+                  <span className="t-mono presence-busy presence-busy--chip presence-task">{t(agentTask.key, agentTask.vars)}</span>
                 )}
               </span>
-            ))}
+              );
+            })}
             {hiddenAgents > 0 && <span className="t-mono presence-agent-more">+{hiddenAgents}</span>}
           </div>
         )}

--- a/web/src/components/SettingsPanel.test.tsx
+++ b/web/src/components/SettingsPanel.test.tsx
@@ -23,11 +23,23 @@ function memoryStorage(seed: Record<string, string> = {}): Storage {
 let renderer: ReactTestRenderer | null = null;
 let store: Storage;
 let themeAttribute: string | null = null;
+let keyHandlers: Array<(e: { key: string; shiftKey?: boolean; preventDefault?: () => void }) => void> = [];
 beforeEach(() => {
   Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", { configurable: true, value: true });
   store = memoryStorage({ ap_locale: "en" });
   Object.defineProperty(globalThis, "localStorage", { configurable: true, value: store });
-  Object.defineProperty(globalThis, "window", { configurable: true, value: globalThis });
+  keyHandlers = [];
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      addEventListener: (type: string, fn: (e: { key: string }) => void) => {
+        if (type === "keydown") keyHandlers.push(fn);
+      },
+      removeEventListener: (type: string, fn: (e: { key: string }) => void) => {
+        if (type === "keydown") keyHandlers = keyHandlers.filter((h) => h !== fn);
+      },
+    },
+  });
   themeAttribute = null;
   Object.defineProperty(globalThis, "document", {
     configurable: true,
@@ -169,5 +181,18 @@ describe("SettingsPanel (#273)", () => {
     const txt = allText(render({ me: null, canSetHandle: false, onClose: () => {}, onLogout: null }));
     expect(txt).toContain("Language");
     expect(txt).not.toContain("Account");
+  });
+
+  // #637 a11y：aria-modal 对话框现在真正接管键盘——Esc 关闭由焦点陷阱 effect 统一处理。
+  test("dialog is focusable and Escape invokes onClose (focus-trap effect)", () => {
+    let closes = 0;
+    const r = render({ me, canSetHandle: false, onClose: () => { closes += 1; }, onLogout: () => {} });
+    // 面板本身可作为焦点回退目标（tabindex=-1）
+    const panel = findByClass(r.toJSON(), "settings-panel");
+    expect(panel?.props.tabIndex).toBe(-1);
+    // effect 已把 keydown 监听挂到 window；模拟 Esc
+    expect(keyHandlers.length).toBeGreaterThan(0);
+    void act(() => { keyHandlers.forEach((h) => h({ key: "Escape" })); });
+    expect(closes).toBe(1);
   });
 });

--- a/web/src/components/SettingsPanel.test.tsx
+++ b/web/src/components/SettingsPanel.test.tsx
@@ -24,19 +24,24 @@ let renderer: ReactTestRenderer | null = null;
 let store: Storage;
 let themeAttribute: string | null = null;
 let keyHandlers: Array<(e: { key: string; shiftKey?: boolean; preventDefault?: () => void }) => void> = [];
+// 统计 keydown 监听的挂/摘次数——用来验证焦点陷阱 effect 只跑一次、不随 onClose 身份变化重挂。
+let keydownAdds = 0;
+let keydownRemoves = 0;
 beforeEach(() => {
   Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", { configurable: true, value: true });
   store = memoryStorage({ ap_locale: "en" });
   Object.defineProperty(globalThis, "localStorage", { configurable: true, value: store });
   keyHandlers = [];
+  keydownAdds = 0;
+  keydownRemoves = 0;
   Object.defineProperty(globalThis, "window", {
     configurable: true,
     value: {
       addEventListener: (type: string, fn: (e: { key: string }) => void) => {
-        if (type === "keydown") keyHandlers.push(fn);
+        if (type === "keydown") { keyHandlers.push(fn); keydownAdds += 1; }
       },
       removeEventListener: (type: string, fn: (e: { key: string }) => void) => {
-        if (type === "keydown") keyHandlers = keyHandlers.filter((h) => h !== fn);
+        if (type === "keydown") { keyHandlers = keyHandlers.filter((h) => h !== fn); keydownRemoves += 1; }
       },
     },
   });
@@ -194,5 +199,31 @@ describe("SettingsPanel (#273)", () => {
     expect(keyHandlers.length).toBeGreaterThan(0);
     void act(() => { keyHandlers.forEach((h) => h({ key: "Escape" })); });
     expect(closes).toBe(1);
+  });
+
+  // #654 复审：onClose 身份不稳定（父级传内联箭头）时，焦点陷阱 effect 不应重挂——
+  // 否则清理阶段会抢先恢复焦点、重挂后 previouslyFocused 指向面板内元素，焦点恢复失效。
+  test("focus-trap effect survives an unstable onClose (no teardown+re-arm on identity change)", () => {
+    let closes = 0;
+    const r = render({ me, canSetHandle: false, onClose: () => { closes += 1; }, onLogout: () => {} });
+    // 挂载时只挂一次 keydown，尚未摘除。
+    expect(keydownAdds).toBe(1);
+    expect(keydownRemoves).toBe(0);
+
+    // 父级重渲染并传入全新 onClose 身份（模拟内联箭头函数）。
+    void act(() => {
+      r.update(
+        <LocaleProvider>
+          <SettingsPanel me={me} canSetHandle={false} onClose={() => { closes += 2; }} onLogout={() => {}} />
+        </LocaleProvider>,
+      );
+    });
+    // effect 依赖 []：既不摘旧监听也不挂新监听，焦点恢复不会被提前触发。
+    expect(keydownAdds).toBe(1);
+    expect(keydownRemoves).toBe(0);
+
+    // Esc 仍经 ref 走到最新的 onClose。
+    void act(() => { keyHandlers.forEach((h) => h({ key: "Escape" })); });
+    expect(closes).toBe(2);
   });
 });

--- a/web/src/components/SettingsPanel.tsx
+++ b/web/src/components/SettingsPanel.tsx
@@ -51,6 +51,12 @@ export function SettingsPanel({
   const [notifyOptin, setNotifyOptin] = useState<boolean>(readNotifyOptin);
   const [theme, setTheme] = useState<Theme>(readStoredTheme);
   const panelRef = useRef<HTMLDivElement | null>(null);
+  // #654 复审：把 onClose 固化进 ref，让焦点陷阱 effect 只按挂载/卸载跑一次。
+  // 否则父级传内联箭头函数（onClose={() => setShow(false)}）每次渲染都换新身份，
+  // effect 依赖 [onClose] 会反复清理+重挂——清理阶段抢先把焦点还给触发元素（焦点闪出闪回），
+  // 重挂时 previouslyFocused 变成面板内元素，最终关闭把焦点恢复到已卸载节点，焦点恢复失效。
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
 
   // #637 a11y：真正 trap focus——打开时把焦点移进面板、Tab 只在面板内循环、关闭恢复到触发元素；
   // 外加 Esc 关闭。此前注释声称「锁焦点」实则只挂了 Esc。
@@ -70,7 +76,7 @@ export function SettingsPanel({
     (focusables()[0] ?? panelRef.current)?.focus?.();
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
-        onClose();
+        onCloseRef.current();
         return;
       }
       if (e.key !== "Tab") return;
@@ -98,7 +104,8 @@ export function SettingsPanel({
       // 关闭时把焦点交还给打开面板的触发元素。
       previouslyFocused?.focus?.();
     };
-  }, [onClose]);
+    // 依赖固定为空数组：trap+restore 只按开合各跑一次，不随 onClose 身份变化重挂。
+  }, []);
 
   const pickTheme = useCallback((next: Theme) => {
     applyTheme(next);

--- a/web/src/components/SettingsPanel.tsx
+++ b/web/src/components/SettingsPanel.tsx
@@ -2,7 +2,7 @@
 // 纯前端；通知偏好读写 localStorage 的 ap_notify_optin（与 NotifyToggle 同键），语言走 LanguageSwitcher，
 // 主题走 lib/theme（doodle↔midnight，写 <html data-theme> + localStorage）。账号 @handle/昵称编辑复用
 // HandleSetup——顶栏不再单独挂浮层入口，编辑归位到这里。不动顶栏原有的桌面专属控件。
-import { useCallback, useEffect, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 import { useT } from "../i18n/useT";
 import { LanguageSwitcher } from "./LanguageSwitcher";
 import { HandleSetup } from "./HandleSetup";
@@ -50,14 +50,54 @@ export function SettingsPanel({
   const t = useT();
   const [notifyOptin, setNotifyOptin] = useState<boolean>(readNotifyOptin);
   const [theme, setTheme] = useState<Theme>(readStoredTheme);
+  const panelRef = useRef<HTMLDivElement | null>(null);
 
-  // Esc 关闭；打开时锁焦点在面板（简版：Esc + 点遮罩关）。
+  // #637 a11y：真正 trap focus——打开时把焦点移进面板、Tab 只在面板内循环、关闭恢复到触发元素；
+  // 外加 Esc 关闭。此前注释声称「锁焦点」实则只挂了 Esc。
   useEffect(() => {
+    const doc = typeof document === "undefined" ? null : document;
+    const previouslyFocused = (doc?.activeElement ?? null) as HTMLElement | null;
+    const focusables = (): HTMLElement[] => {
+      const panel = panelRef.current;
+      if (panel === null || typeof panel.querySelectorAll !== "function") return [];
+      return Array.from(
+        panel.querySelectorAll<HTMLElement>(
+          'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+        ),
+      );
+    };
+    // 打开即把焦点移进面板：首个可聚焦元素，退回面板容器本身。
+    (focusables()[0] ?? panelRef.current)?.focus?.();
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
+      if (e.key === "Escape") {
+        onClose();
+        return;
+      }
+      if (e.key !== "Tab") return;
+      const items = focusables();
+      const panel = panelRef.current;
+      if (items.length === 0) {
+        e.preventDefault();
+        panel?.focus?.();
+        return;
+      }
+      const first = items[0]!;
+      const last = items[items.length - 1]!;
+      const active = (doc?.activeElement ?? null) as HTMLElement | null;
+      if (e.shiftKey && (active === first || active === panel)) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault();
+        first.focus();
+      }
     };
     window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      // 关闭时把焦点交还给打开面板的触发元素。
+      previouslyFocused?.focus?.();
+    };
   }, [onClose]);
 
   const pickTheme = useCallback((next: Theme) => {
@@ -87,7 +127,7 @@ export function SettingsPanel({
 
   return (
     <div className="settings-overlay" role="dialog" aria-modal="true" aria-label={t("App.settings.title")} onClick={onClose}>
-      <div className="settings-panel" onClick={(e) => e.stopPropagation()}>
+      <div className="settings-panel" ref={panelRef} tabIndex={-1} onClick={(e) => e.stopPropagation()}>
         <header className="settings-head">
           <h2 className="settings-title">{t("App.settings.title")}</h2>
           <button type="button" className="settings-close" aria-label={t("App.settings.close")} onClick={onClose}>

--- a/web/src/i18n/strings/AgentJoin.ts
+++ b/web/src/i18n/strings/AgentJoin.ts
@@ -23,6 +23,7 @@ export const AgentJoinStrings: LocaleDict = {
     "AgentJoin.doneLead": "Paste this into your agent (Claude Code / Codex) to run — it installs the CLI, joins the channel, checks in, then starts listening for @-mentions:",
     "AgentJoin.copied": "copied ✓",
     "AgentJoin.copy": "copy",
+    "AgentJoin.errCopy": "Copy failed — select the command above and copy it manually.",
     "AgentJoin.tokenWarn": "The token only appears once — copy it before closing this.",
     "AgentJoin.footerHintPrefix": "Just running {init} is silent (binds but doesn't post) — always run it together with the check-in step, or the agent won't show up on the web. See",
 
@@ -121,6 +122,7 @@ export const AgentJoinStrings: LocaleDict = {
     "AgentJoin.doneLead": "把下面这段贴给你的 agent（Claude Code / Codex）执行 —— 它会装好 CLI、进频道、报到发言，然后开始听 @它 的消息：",
     "AgentJoin.copied": "已复制 ✓",
     "AgentJoin.copy": "复制",
+    "AgentJoin.errCopy": "复制失败 —— 请手动选中上面的命令复制。",
     "AgentJoin.tokenWarn": "token 只出现这一次，关掉就取不回了 —— 先复制再关。",
     "AgentJoin.footerHintPrefix": "光 {init} 是静默的（只绑定不发言）—— 一定要连报到那步一起跑，网页上才看得到 agent。详见",
 

--- a/web/src/i18n/strings/Pair.ts
+++ b/web/src/i18n/strings/Pair.ts
@@ -23,6 +23,11 @@ export const PairStrings: LocaleDict = {
     "Pair.decision.failed": "The decision could not be saved. Try again.",
     "Pair.status.approved": "Device approved. You can return to the desktop app.",
     "Pair.status.denied": "Pairing rejected.",
+    // #638：重新查看一个已决/失效的配对时，显示只读态而非会 409 的 Approve/Deny。
+    "Pair.resolved.approved": "This pairing was already approved.",
+    "Pair.resolved.denied": "This pairing was already rejected.",
+    "Pair.resolved.consumed": "This pairing was already used by the desktop app.",
+    "Pair.resolved.expired": "This pairing code has expired. Ask the desktop app for a new one.",
   },
   zh: {
     "Pair.title": "配对桌面端",
@@ -46,6 +51,11 @@ export const PairStrings: LocaleDict = {
     "Pair.decision.failed": "无法保存决定，请重试。",
     "Pair.status.approved": "设备已批准，可以返回桌面端。",
     "Pair.status.denied": "已拒绝配对。",
+    // #638：重新查看已决/失效的配对时，展示只读态而非会 409 的批准/拒绝按钮。
+    "Pair.resolved.approved": "此配对已被批准。",
+    "Pair.resolved.denied": "此配对已被拒绝。",
+    "Pair.resolved.consumed": "此配对已被桌面端使用。",
+    "Pair.resolved.expired": "此配对短码已失效，请在桌面端重新获取。",
   },
 };
 

--- a/web/src/i18n/strings/PresenceBar.ts
+++ b/web/src/i18n/strings/PresenceBar.ts
@@ -23,6 +23,11 @@ export const PresenceBarStrings: LocaleDict = {
     "PresenceBar.pausedManual": "Paused — won't be woken by @-mentions until resumed manually",
     "PresenceBar.pausedUntil": "Paused — won't be woken by @-mentions; auto-resumes {time}",
     "PresenceBar.waitingOwnerChip": "💬 {count} waiting owner",
+    // busy（#103 / #639）：走 t() 而非写死英文——zh 界面也翻译。
+    "PresenceBar.busy": "⏳ busy",
+    "PresenceBar.busyQueued": "⏳ busy · {count} queued",
+    "PresenceBar.busyTitle": "busy (reachable, reply may be slow — do not re-@)",
+    "PresenceBar.busyTitleQueued": "busy · {count} queued (reachable, reply may be slow — do not re-@)",
     "PresenceBar.runnerFailing": "✗ runner failing ×{count}",
     "PresenceBar.listeningDeaf": "⚠ not listening",
     "PresenceBar.listeningSuspect": "⚠ consuming slowly",
@@ -67,6 +72,11 @@ export const PresenceBarStrings: LocaleDict = {
     "PresenceBar.pausedManual": "已暂停接待——被 @ 也不唤醒，需手动恢复",
     "PresenceBar.pausedUntil": "已暂停接待——被 @ 也不唤醒；将于 {time} 自动恢复",
     "PresenceBar.waitingOwnerChip": "💬 {count} 项等待 owner",
+    // busy（#103 / #639）
+    "PresenceBar.busy": "⏳ 忙",
+    "PresenceBar.busyQueued": "⏳ 忙 · {count} 排队",
+    "PresenceBar.busyTitle": "忙碌中（可达，回复可能较慢——请勿重复 @）",
+    "PresenceBar.busyTitleQueued": "忙碌中 · {count} 项排队（可达，回复可能较慢——请勿重复 @）",
     "PresenceBar.runnerFailing": "✗ runner 连败 ×{count}",
     "PresenceBar.listeningDeaf": "⚠ 没在听",
     "PresenceBar.listeningSuspect": "⚠ 消费缓慢",

--- a/web/src/lib/markdown.ts
+++ b/web/src/lib/markdown.ts
@@ -46,6 +46,11 @@ hljs.registerLanguage("yaml", langYaml);
 // 每次渲染新建一个 Marked 实例：代码块高亮 renderer 恒定，mention 扩展按本条消息的
 // identities 闭包注入。mention 在解析后的 token 流上美化，代码块/行内代码/自动链接 URL
 // 天然被排除（见 mentionMarkup.ts 与 #131），不再往原文里塞裸 HTML。
+// 把裸 HTML token 的原文转义成可见文本（用于中和用户消息里的 inline/block HTML）。
+function escapeRawHtml(value: string): string {
+  return value.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
+}
+
 function createMarked(identities: IdentityDisplayMap | undefined): Marked {
   const instance = new Marked();
   instance.use({
@@ -56,6 +61,14 @@ function createMarked(identities: IdentityDisplayMap | undefined): Marked {
           ? hljs.highlight(text, { language }).value
           : hljs.highlightAuto(text).value;
         return `<pre><code class="hljs">${html}</code></pre>`;
+      },
+      // #642 安全：消息 body 里的裸 HTML（inline <span …> 与 block）一律转义成可见文本，
+      // 绝不作为真实 DOM 渲染。否则用户可写 `<span class="ap-mention" title="@owner">@owner</span>`
+      // 借用应用样式伪造一个没真正 @、也不通知任何人的 @mention（或用 hljs-* 借样式）——
+      // DOMPurify 的 class 白名单按名字放行，无法辨别来源，挡不住。真正的 mention span 由
+      // mentionExtension 在解析后生成（apMention token，不走这条 html renderer），不受影响。
+      html({ text }) {
+        return escapeRawHtml(text);
       },
     },
   });

--- a/web/src/lib/mentionMarkup.test.ts
+++ b/web/src/lib/mentionMarkup.test.ts
@@ -158,6 +158,22 @@ describe("mention 美化：真实管线集成（#131）", () => {
     expect(R("hi @self there")).toBe("<p>hi @self there</p>");
   });
 
+  // #642 安全：用户消息里的裸 HTML 不得借样式伪造 @mention（ap-mention span）或系统 UI（hljs span）。
+  // 用一个不在 IDS 里的名字（owner），确保正文里没有真 mention 干扰断言——只看假标签有没有被中和。
+  it("用户裸 HTML 里的 ap-mention span 被转义成可见文本，不冒充真 mention", () => {
+    const out = R('<span class="ap-mention" title="@owner">@owner</span>');
+    // 假 span 已被 marked 层转义，不再是真实 DOM 元素（没有一个活的 ap-mention 元素）
+    expect(out).not.toContain('<span class="ap-mention"');
+    expect(out).toContain("&lt;span");
+    expect(out).toContain("&lt;/span&gt;");
+  });
+
+  it("用户裸 HTML 里的 hljs span 也被转义，不能借代码高亮样式", () => {
+    const out = R('<span class="hljs-keyword">fake</span>');
+    expect(out).not.toContain('<span class="hljs-keyword"');
+    expect(out).toContain("&lt;span");
+  });
+
   it("句首、以及 /、* 等真实边界后的 @name 都识别为 mention", () => {
     expect(R("@alice")).toBe('<p><span class="ap-mention" title="@alice">@Alice</span></p>');
     expect(R("path /@alice/x")).toContain(

--- a/web/src/lib/mentions.test.ts
+++ b/web/src/lib/mentions.test.ts
@@ -1,11 +1,23 @@
 import { describe, expect, test } from "bun:test";
 import { extractMentionTokens, type MsgFrame, type PresenceEntry, type Sender } from "@agentparty/shared";
+import { isValidMentionToken, MENTION_TOKEN_MAX_LENGTH } from "@agentparty/shared/mentions";
 import { activeMentionQuery, filterCandidates, mentionCandidates, parseDraftMentions } from "./mentions";
 
 const NOW = 1_000_000_000;
 
 test("shared mention lexer respects a zero limit", () => {
   expect(extractMentionTokens("@alice", 0)).toEqual([]);
+});
+
+// #641：MENTION_TOKEN_MAX_LENGTH 曾是无人引用的死常量（真正的上限写死在正则 {0,63} 里）。
+// 现已用它构造 MENTION_TOKEN_RE，成为 64 字符上限的单一来源——正好卡在 MAX、超一位即拒。
+test("mention token max length is the single source of truth for isValidMentionToken", () => {
+  expect(MENTION_TOKEN_MAX_LENGTH).toBe(64);
+  const atMax = "a".repeat(MENTION_TOKEN_MAX_LENGTH);
+  const overMax = "a".repeat(MENTION_TOKEN_MAX_LENGTH + 1);
+  expect(atMax.length).toBe(64);
+  expect(isValidMentionToken(atMax)).toBe(true);
+  expect(isValidMentionToken(overMax)).toBe(false);
 });
 
 function presence(over: Partial<PresenceEntry> & { name: string }): PresenceEntry {

--- a/web/src/pages/Pair.test.tsx
+++ b/web/src/pages/Pair.test.tsx
@@ -6,8 +6,10 @@ import { PairStrings } from "../i18n/strings/Pair";
 import {
   decideDesktopPairing,
   extractPairingCodeAndSanitizeUrl,
+  formatExpiresIn,
   inspectDesktopPairing,
   PairHumanRequiredAction,
+  PairingResolvedNotice,
   PairingReview,
   PairPage,
   type PairingInspection,
@@ -16,12 +18,13 @@ import {
 const inspection: PairingInspection = {
   pairing_id: "pair-1",
   user_code: "AB12C-DE34F",
+  status: "pending",
   device: {
     name: "Leo's Mac",
     platform: "macos",
     app_version: "0.2.85",
   },
-  expires_at: "2026-07-10T12:00:00Z",
+  expires_in: 300,
 };
 
 describe("pair URL handling", () => {
@@ -139,5 +142,49 @@ describe("PairPage", () => {
     );
     expect(html).toContain("Switch to a human account");
     expect(html).toContain('class="d-btn pair-human-login"');
+  });
+});
+
+describe("#638 pairing expiry + already-decided state", () => {
+  test("formatExpiresIn renders the worker's expires_in seconds as a compact duration", () => {
+    expect(formatExpiresIn(45)).toBe("45s");
+    expect(formatExpiresIn(300)).toBe("5m");
+    expect(formatExpiresIn(7200)).toBe("2h");
+    expect(formatExpiresIn(0)).toBe("0s");
+    expect(formatExpiresIn(-10)).toBe("0s");
+  });
+
+  test("PairingReview shows the Expires row derived from expires_in (previously a dead field)", () => {
+    const html = renderToStaticMarkup(
+      <LocaleProvider>
+        <PairingReview inspection={inspection} pending={false} onDecision={() => {}} />
+      </LocaleProvider>,
+    );
+    expect(html).toContain("Expires");
+    expect(html).toContain("5m");
+  });
+
+  test("an already-decided pairing renders a read-only notice, not failing Approve/Deny buttons", () => {
+    const html = renderToStaticMarkup(
+      <LocaleProvider>
+        <PairingResolvedNotice status="approved" />
+      </LocaleProvider>,
+    );
+    expect(html).toContain("This pairing was already approved.");
+    expect(html).not.toContain("pair-deny");
+    expect(html).not.toContain("Approve this device");
+  });
+
+  test("registers read-only status copy in both locales", () => {
+    for (const locale of ["en", "zh"] as const) {
+      for (const key of [
+        "Pair.resolved.approved",
+        "Pair.resolved.denied",
+        "Pair.resolved.consumed",
+        "Pair.resolved.expired",
+      ]) {
+        expect(PairStrings[locale][key]).toBeTruthy();
+      }
+    }
   });
 });

--- a/web/src/pages/Pair.tsx
+++ b/web/src/pages/Pair.tsx
@@ -4,9 +4,15 @@ import "../i18n/strings/Pair";
 import { normalizePairingCode } from "../lib/desktopPairing";
 import { normalizeServerOrigin } from "../lib/serverProfiles";
 
+// worker/src/desktop-pairing.ts 的 pairingView 计算的状态：pending 才可决策，其余均为已决/失效终态。
+export type PairingStatus = "pending" | "approved" | "denied" | "consumed" | "expired";
+
 export interface PairingInspection {
   pairing_id: string;
   user_code: string;
+  // #638：worker 每次 inspect 都返回 status，已决（approved/denied/consumed/expired）时前端必须读它
+  // 走只读态，别再渲染点了必 409 的 Approve/Deny。
+  status?: PairingStatus | null;
   device?: {
     name?: string | null;
     platform?: string | null;
@@ -15,11 +21,21 @@ export interface PairingInspection {
   device_name?: string | null;
   platform?: string | null;
   app_version?: string | null;
-  expires_at?: string | null;
+  // #638：worker 发的是 expires_in（剩余秒数），此前前端读的 expires_at 永远为空，Expires 行是死字段。
+  expires_in?: number | null;
 }
 
 type Fetcher = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
 type PairingDecision = "approve" | "deny";
+
+// 把 worker 的 expires_in（剩余秒数）格式化成紧凑相对时长，供复审的「Expires」行显示。
+export function formatExpiresIn(seconds: number): string {
+  const s = Math.max(0, Math.floor(seconds));
+  if (s < 60) return `${s}s`;
+  if (s < 3600) return `${Math.round(s / 60)}m`;
+  if (s < 86400) return `${Math.round(s / 3600)}h`;
+  return `${Math.round(s / 86400)}d`;
+}
 
 export function extractPairingCodeAndSanitizeUrl(href: string): {
   userCode: string | null;
@@ -104,8 +120,8 @@ export function PairingReview({ inspection, pending, onDecision }: ReviewProps) 
         <div><dt>{t("Pair.device.name")}</dt><dd>{name}</dd></div>
         <div><dt>{t("Pair.device.platform")}</dt><dd>{platform}</dd></div>
         <div><dt>{t("Pair.device.version")}</dt><dd>{version}</dd></div>
-        {inspection.expires_at && (
-          <div><dt>{t("Pair.device.expires")}</dt><dd>{inspection.expires_at}</dd></div>
+        {typeof inspection.expires_in === "number" && (
+          <div><dt>{t("Pair.device.expires")}</dt><dd>{formatExpiresIn(inspection.expires_in)}</dd></div>
         )}
       </dl>
       <div className="pair-actions">
@@ -117,6 +133,25 @@ export function PairingReview({ inspection, pending, onDecision }: ReviewProps) 
         </button>
       </div>
     </section>
+  );
+}
+
+// #638：已决/失效的配对以只读横幅呈现，而非可点的 Approve/Deny（点了必被 worker 409 拒）。
+export function PairingResolvedNotice({ status }: { status: Exclude<PairingStatus, "pending"> }) {
+  const t = useT();
+  const key =
+    status === "approved"
+      ? "Pair.resolved.approved"
+      : status === "denied"
+        ? "Pair.resolved.denied"
+        : status === "consumed"
+          ? "Pair.resolved.consumed"
+          : "Pair.resolved.expired";
+  const negative = status === "denied" || status === "expired";
+  return (
+    <p className={`banner${negative ? " banner--red" : ""}`} role="status">
+      {t(key)}
+    </p>
   );
 }
 
@@ -242,9 +277,12 @@ export function PairPage({ serverOrigin, token, initialCode, onRequireHuman, onD
                 {pending ? t("Pair.inspect.loading") : t("Pair.inspect")}
               </button>
             </form>
-            {inspection !== null && (
-              <PairingReview inspection={inspection} pending={pending} onDecision={(next) => void submitDecision(next)} />
-            )}
+            {inspection !== null &&
+              (inspection.status == null || inspection.status === "pending" ? (
+                <PairingReview inspection={inspection} pending={pending} onDecision={(next) => void submitDecision(next)} />
+              ) : (
+                <PairingResolvedNotice status={inspection.status} />
+              ))}
           </>
         )}
         {error !== null && <p className="banner banner--red" role="alert">{error}</p>}

--- a/web/src/styles/app.agentBoard.test.ts
+++ b/web/src/styles/app.agentBoard.test.ts
@@ -48,3 +48,34 @@ describe("issue #504 team blog board layout", () => {
     expect(css).not.toContain('.agent-board-lane--offline[data-empty="true"]');
   });
 });
+
+describe("issue #636 undefined CSS variables", () => {
+  test("the agent board 'busy' accent tracks the themed amber token instead of a fixed blue", () => {
+    expect(ruleBody(".agent-board-row--busy")).toContain("border-left-color: var(--p-busy)");
+    expect(ruleBody(".agent-board-status--busy")).toContain("color: var(--p-busy)");
+    // 死透的离主题蓝彻底消失
+    expect(css).not.toContain("#4a9eff");
+  });
+
+  test("the agent board lanes/rows/notes no longer lean on undefined --border/--muted fallbacks", () => {
+    const section = css.slice(css.indexOf(".agent-board-empty"), css.indexOf("/* #273 全局设置面板 */"));
+    expect(section).not.toContain("var(--border, #2a2a2a)");
+    expect(section).not.toContain("var(--muted, #888)");
+    expect(section).not.toContain("var(--muted, #999)");
+    expect(section).not.toContain("var(--danger, #e5534b)");
+    expect(section).toContain("var(--t-faint)");
+    expect(section).toContain("var(--t-muted)");
+  });
+
+  test("composer attachment/upload borders and presence chips resolve to defined theme tokens", () => {
+    // 未定义变量无兜底时整条 border/background 会失效（computed-value-time invalid → none/transparent）。
+    // 全站不得再出现裸 var(--border) / var(--bg) / var(--accent, var(--fg))。
+    expect(css).not.toMatch(/var\(--border\)/);
+    expect(css).not.toMatch(/var\(--bg\)/);
+    expect(css).not.toContain("var(--accent, var(--fg))");
+    expect(ruleBody(".composer-attachment")).toContain("border: 1px solid var(--t-faint)");
+    expect(ruleBody(".composer-upload-spinner")).toContain("border: 2px solid var(--t-faint)");
+    expect(ruleBody(".composer-upload-spinner")).toContain("border-top-color: var(--t-text)");
+    expect(ruleBody(".composer--dragging")).toContain("outline: 2px dashed var(--t-accent)");
+  });
+});

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -423,7 +423,7 @@
   padding: 1px 5px;
   border: 1.4px solid var(--d-ink);
   border-radius: 0;
-  background: var(--bg);
+  background: var(--t-panel);
   color: var(--t-muted);
   font-size: 10px;
   font-weight: 700;
@@ -437,7 +437,7 @@
   flex: none;
   padding: 1px 5px;
   border: 1.4px dashed var(--d-ink);
-  background: var(--bg);
+  background: var(--t-panel);
   color: var(--t-muted);
   font-size: 10px;
   font-weight: 700;
@@ -1626,7 +1626,7 @@
   padding: 1px 5px;
   border: 1.4px solid var(--d-ink);
   border-radius: 0;
-  background: var(--bg);
+  background: var(--t-panel);
   color: var(--t-muted);
   font-size: 10px;
   font-weight: 700;
@@ -1756,7 +1756,7 @@
   padding: 1px 4px;
   border: 1.4px solid var(--d-ink);
   border-radius: 0;
-  background: var(--bg);
+  background: var(--t-panel);
   color: var(--t-muted);
   font: inherit;
   font-size: 11px;
@@ -4603,7 +4603,7 @@
   align-items: stretch;
   gap: 12px;
   padding: 2px 6px 6px 2px;
-  background: var(--bg);
+  background: var(--t-panel);
 }
 /* @ 提及补全下拉（issue #39）：浮在插话框上方，doodle 边框，分档徽章 */
 .mention-menu {
@@ -5003,7 +5003,7 @@
   align-items: center;
   gap: 0.35rem;
   padding: 0.15rem 0.5rem;
-  border: 1px solid var(--border);
+  border: 1px solid var(--t-faint);
   border-radius: 4px;
   font-size: 0.8rem;
 }
@@ -5022,7 +5022,7 @@
 .composer-attachment--img {
   position: relative;
   padding: 0;
-  border: 1px solid var(--border);
+  border: 1px solid var(--t-faint);
   border-radius: 6px;
   overflow: hidden;
   width: 56px;
@@ -5057,7 +5057,7 @@
 
 /* 拖拽上传高亮（#176）：composer 相对定位，dropzone 覆盖其上 */
 .composer { position: relative; }
-.composer--dragging { outline: 2px dashed var(--accent, var(--fg)); outline-offset: 2px; }
+.composer--dragging { outline: 2px dashed var(--t-accent); outline-offset: 2px; }
 .composer-dropzone {
   position: absolute;
   inset: 0;
@@ -5086,7 +5086,7 @@
   align-items: center;
   gap: 0.4rem;
   padding: 0.15rem 0.5rem;
-  border: 1px solid var(--border);
+  border: 1px solid var(--t-faint);
   border-radius: 4px;
   font-size: 0.8rem;
   max-width: 100%;
@@ -5115,8 +5115,8 @@
 .composer-upload-spinner {
   width: 0.85rem;
   height: 0.85rem;
-  border: 2px solid var(--border);
-  border-top-color: var(--fg, inherit);
+  border: 2px solid var(--t-faint);
+  border-top-color: var(--t-text);
   border-radius: 50%;
   animation: composer-upload-spin 0.7s linear infinite;
 }
@@ -5125,7 +5125,7 @@
   .composer-upload-spinner { animation-duration: 2s; }
 }
 .composer-upload-retry {
-  border: 1px solid var(--border);
+  border: 1px solid var(--t-faint);
   background: none;
   cursor: pointer;
   color: var(--fg, inherit);
@@ -5162,7 +5162,7 @@
   width: auto;
   height: auto;
   border-radius: 6px;
-  border: 1px solid var(--border);
+  border: 1px solid var(--t-faint);
   display: block;
   cursor: zoom-in;
 }
@@ -6375,10 +6375,10 @@
   overflow-x: auto;
   padding-bottom: 4px;
 }
-.agent-board-empty { color: var(--muted, #888); font-size: 13px; }
+.agent-board-empty { color: var(--t-muted); font-size: 13px; }
 .agent-board-lane {
   min-width: 220px;
-  border: 1px solid var(--border, #2a2a2a);
+  border: 1px solid var(--t-faint);
   border-radius: 8px;
   background: var(--t-faint, rgba(127, 127, 127, 0.06));
   overflow: hidden;
@@ -6389,7 +6389,7 @@
   justify-content: space-between;
   gap: 8px;
   padding: 8px 10px;
-  border-bottom: 1px solid var(--border, #2a2a2a);
+  border-bottom: 1px solid var(--t-faint);
 }
 .agent-board-lane-title { margin: 0; font-size: 12px; text-transform: uppercase; letter-spacing: 0.04em; }
 .agent-board-lane-count {
@@ -6397,40 +6397,40 @@
   padding: 1px 6px;
   border-radius: 999px;
   background: var(--t-panel, #fff);
-  color: var(--muted, #888);
+  color: var(--t-muted);
   font-size: 11px;
   text-align: center;
 }
 .agent-board-lane-cards { display: flex; flex-direction: column; gap: 8px; padding: 8px; }
-.agent-board-lane-empty { margin: 8px 2px; color: var(--muted, #888); font-size: 12px; text-align: center; }
+.agent-board-lane-empty { margin: 8px 2px; color: var(--t-muted); font-size: 12px; text-align: center; }
 .agent-board-row {
-  border: 1px solid var(--border, #2a2a2a);
-  border-left: 3px solid var(--border, #2a2a2a);
+  border: 1px solid var(--t-faint);
+  border-left: 3px solid var(--t-faint);
   border-radius: 6px;
   padding: 8px 10px;
   display: flex;
   flex-direction: column;
   gap: 4px;
 }
-.agent-board-row--busy { border-left-color: var(--accent, #4a9eff); }
-.agent-board-row--blocked { border-left-color: var(--danger, #e5534b); }
-.agent-board-row--idle { border-left-color: var(--ok, #57ab5a); }
+.agent-board-row--busy { border-left-color: var(--p-busy); }
+.agent-board-row--blocked { border-left-color: var(--p-blocked); }
+.agent-board-row--idle { border-left-color: var(--t-green); }
 .agent-board-row--offline { opacity: 0.6; }
 .agent-board-row-head { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
 .agent-board-name { font-weight: 600; }
-.agent-board-status { font-size: 11px; text-transform: uppercase; letter-spacing: 0.04em; color: var(--muted, #888); }
-.agent-board-status--busy { color: var(--accent, #4a9eff); }
-.agent-board-status--blocked { color: var(--danger, #e5534b); }
-.agent-board-note { margin: 0; font-size: 12px; color: var(--muted, #999); }
-.agent-board-counts { display: flex; gap: 12px; font-size: 12px; color: var(--muted, #999); }
-.agent-board-count-blocked { color: var(--danger, #e5534b); }
+.agent-board-status { font-size: 11px; text-transform: uppercase; letter-spacing: 0.04em; color: var(--t-muted); }
+.agent-board-status--busy { color: var(--p-busy); }
+.agent-board-status--blocked { color: var(--p-blocked); }
+.agent-board-note { margin: 0; font-size: 12px; color: var(--t-muted); }
+.agent-board-counts { display: flex; gap: 12px; font-size: 12px; color: var(--t-muted); }
+.agent-board-count-blocked { color: var(--p-blocked); }
 .agent-board-task-list {
   display: flex;
   flex-direction: column;
   gap: 4px;
   margin: 3px 0 0;
   padding: 7px 0 0;
-  border-top: 1px solid var(--border, #2a2a2a);
+  border-top: 1px solid var(--t-faint);
   list-style: none;
 }
 .agent-board-task {
@@ -6441,10 +6441,10 @@
   font-size: 11px;
   line-height: 1.35;
 }
-.agent-board-task-id { color: var(--muted, #999); }
+.agent-board-task-id { color: var(--t-muted); }
 .agent-board-task-title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.agent-board-task-state { color: var(--muted, #999); font-size: 10px; white-space: nowrap; }
-.agent-board-task--blocked .agent-board-task-state { color: var(--danger, #e5534b); }
+.agent-board-task-state { color: var(--t-muted); font-size: 10px; white-space: nowrap; }
+.agent-board-task--blocked .agent-board-task-state { color: var(--p-blocked); }
 
 /* #273 全局设置面板 */
 .app-settings-btn {


### PR DESCRIPTION
大筛查 web UI/a11y/i18n 修复。`check:web` 883 pass、`check:shared` tsc 全绿、vite build ok。

- **#635** 角色 pill 的 Enter/Space 加 `e.target !== e.currentTarget` 守卫，不再劫持嵌套 pause/resume/kick。
- **#636** app.css 未定义/离主题变量全部指向正确 token（边框/上传环/拖拽轮廓/chip 背景恢复；busy 强调色改主题感知 `--p-busy`）。
- **#637** SettingsPanel 真 focus-trap + Esc；PresenceBar 展开 section 补 `role=button`；OnboardingGuide 补 Esc 关闭。
- **#638** 配对复审读 worker 实际发的 `expires_in`（不再是从不发的 `expires_at`）+ 携 `status`，已决配对渲染只读态而非会失败的 Approve/Deny。
- **#639** busy/queued chip 走 `t()`（复用此前的死键 `taskChip`/`taskChipBeat`，补 en+zh）。
- **#642** AgentJoin 复制失败给可见 banner；DesktopAgentPanel `logsFor` 可清除/直取 `adapter.logs()`；markdown 转义裸 HTML（`ap-mention`/hljs class 无法再借样式伪造 @mention，真 mention 走解析后扩展不受影响）。
- **#641** `shared/src/mentions.ts` 把 `MENTION_TOKEN_MAX_LENGTH` 接进正则做单一真值来源。

> 说明：#641 里「`web/src/lib/mentions.ts` 的 `mentionLiveness()` 无人调用」经核实是**误报**——它被 `wakeReceipt.ts:101` 使用（tsc 会拦），未删除。

Fixes #635
Fixes #636
Fixes #637
Fixes #638
Fixes #639
Fixes #641
Fixes #642

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 配对页面新增 Expires 倒计时与已决态只读提示。
  - 引导页/设置面板支持 Esc 关闭与键盘焦点循环；Presence 文案本地化与无障碍增强。
  - AgentJoin 复制失败提示（中英文）。
- **问题修复**
  - 修复聚合/实例日志切换加载错误。
  - Markdown 原始 HTML 改为纯文本展示，降低伪造风险。
  - 修复主题样式颜色变量异常。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->