### PR TITLE
fix(desktop): 修 #631 #645 —— 更新器回滚同步 high-water + ui_storage allowlist / kill 失败路径补 evict

### DIFF
--- a/desktop/src-tauri/src/agent.rs
+++ b/desktop/src-tauri/src/agent.rs
@@ -1222,6 +1222,14 @@ mod tests {
         // 复现 #645：stop_instance_key 的 kill 失败路径把实例标 Failed。若不淘汰，
         // 反复 kill 失败会让终止态历史超出 MAX_TERMINAL_INSTANCES。这里断言 Failed
         // 实例与其它终止态一样参与收敛，且活跃实例永不被淘汰。
+        //
+        // 为什么测不到 stop_instance_key 本体（CodeRabbit #655 复审）：那条 kill 失败分支
+        // 需要一个 .kill() 会报错的真实子进程——child 字段是 tauri_plugin_shell 的
+        // CommandChild，无公开构造函数，只能由 AppHandle 背后的 shell 运行时 spawn 得到；
+        // 而 stop_instance_key 又是 AgentManager 上的 async 方法。单元测试里既造不出会失败
+        // 的 CommandChild，也起不了 Tauri 运行时。因此这里改测该分支所依赖的不变量：kill
+        // 失败落 Failed 后（见 stop_instance_key 第 504、509 行的 mark_exited + evict），
+        // evict_terminal_overflow 会把 Failed 与其它终止态一并收敛、且不碰活跃实例。
         let mut instances: HashMap<String, super::ManagedAgent> = HashMap::new();
         let mut active = super::ManagedAgent::default();
         active.runtime.started_at = Some(1000);

--- a/desktop/src-tauri/src/agent.rs
+++ b/desktop/src-tauri/src/agent.rs
@@ -504,7 +504,10 @@ impl AgentManager {
                 agent.runtime.mark_exited(None, Some(&message));
                 Self::push_log(agent, message);
             }
-            return Ok(agent.runtime.clone());
+            // kill 失败也是转入终止态，和超时兜底路径一样立即收敛历史上限（CodeRabbit #618）。
+            let runtime = agent.runtime.clone();
+            evict_terminal_overflow(&mut instances);
+            return Ok(runtime);
         }
 
         for _ in 0..80 {
@@ -1211,6 +1214,33 @@ mod tests {
         assert_eq!(instances.len(), 1 + 16);
         assert!(instances.contains_key("cfg:29"));
         assert!(!instances.contains_key("cfg:1"));
+    }
+
+    #[test]
+    fn evict_converges_terminal_history_after_kill_error_failures() {
+        use std::collections::HashMap;
+        // 复现 #645：stop_instance_key 的 kill 失败路径把实例标 Failed。若不淘汰，
+        // 反复 kill 失败会让终止态历史超出 MAX_TERMINAL_INSTANCES。这里断言 Failed
+        // 实例与其它终止态一样参与收敛，且活跃实例永不被淘汰。
+        let mut instances: HashMap<String, super::ManagedAgent> = HashMap::new();
+        let mut active = super::ManagedAgent::default();
+        active.runtime.started_at = Some(1000);
+        active.runtime.phase = AgentPhase::Running;
+        instances.insert("cfg:active".to_string(), active);
+        for index in 0..30u64 {
+            let mut agent = super::ManagedAgent::default();
+            agent.runtime.started_at = Some(index);
+            // kill 失败落到 Failed（mark_exited 带错误信息即 Failed）。
+            agent.runtime.mark_exited(None, Some("failed to stop party sidecar"));
+            assert_eq!(agent.runtime.phase, AgentPhase::Failed);
+            instances.insert(format!("cfg:{index}"), agent);
+        }
+        super::evict_terminal_overflow(&mut instances);
+        assert!(instances.contains_key("cfg:active"));
+        assert_eq!(instances.len(), 1 + super::MAX_TERMINAL_INSTANCES);
+        // 最新的终止态保留，最旧的被淘汰。
+        assert!(instances.contains_key("cfg:29"));
+        assert!(!instances.contains_key("cfg:0"));
     }
 
     #[test]

--- a/desktop/src-tauri/src/ui_storage.rs
+++ b/desktop/src-tauri/src/ui_storage.rs
@@ -191,6 +191,11 @@ fn valid_value(key: &str, value: &str) -> bool {
         "ap_onboarded" => value == "1",
         "ap_desktop_updater_diagnostic" => valid_updater_diagnostic(value),
         "ap_desktop_updater_last_success" => valid_non_negative_integer(value),
+        // 与 web/src/lib/desktopStorage.ts 的 validValue 对齐：更新器写入的两个版本键
+        // （notified/shown），漏掉任意一个都会让整个 settings 快照校验失败并静默丢弃。
+        "ap_desktop_updater_notified_version" | "ap_desktop_updater_shown_version" => {
+            SAFE_VERSION_PATTERN.is_match(value)
+        }
         "ap_locale" => matches!(value, "en" | "zh"),
         "ap_server_profiles_v1" => valid_server_profiles(value),
         "ap_theme" => matches!(value, "doodle" | "midnight"),
@@ -362,6 +367,14 @@ mod tests {
                 r#"{"status":"success","source":"manual","stage":"check","category":null,"timestamp":1720000000000,"appVersion":"0.2.94"}"#.to_string(),
             ),
             (
+                "ap_desktop_updater_notified_version".to_string(),
+                "0.2.130".to_string(),
+            ),
+            (
+                "ap_desktop_updater_shown_version".to_string(),
+                "0.2.130".to_string(),
+            ),
+            (
                 "ap_active_server_origin_v1".to_string(),
                 "https://private.example".to_string(),
             ),
@@ -465,6 +478,29 @@ mod tests {
                 write_snapshot(root.path(), &entries).is_err(),
                 "accepted {key}={value}"
             );
+        }
+    }
+
+    #[test]
+    fn accepts_updater_notified_and_shown_version_keys_and_rejects_bad_versions() {
+        let root = tempdir().unwrap();
+        // 两个键必须与 TS 侧一样接受合法 semver 并原样往返，否则更新器一跑快照就全废。
+        for key in [
+            "ap_desktop_updater_notified_version",
+            "ap_desktop_updater_shown_version",
+        ] {
+            for version in ["0.2.130", "1.4.0", "0.2.130-beta.1+build.7"] {
+                let entries = BTreeMap::from([(key.to_string(), version.to_string())]);
+                write_snapshot(root.path(), &entries).unwrap();
+                assert_eq!(read_snapshot(root.path()).unwrap(), entries);
+            }
+            for bad in ["latest", "1.2", "1.2.3.4", "not a version", ""] {
+                let entries = BTreeMap::from([(key.to_string(), bad.to_string())]);
+                assert!(
+                    write_snapshot(root.path(), &entries).is_err(),
+                    "accepted {key}={bad}"
+                );
+            }
         }
     }
 

--- a/desktop/src-tauri/src/ui_update.rs
+++ b/desktop/src-tauri/src/ui_update.rs
@@ -1983,6 +1983,79 @@ mod tests {
     }
 
     #[test]
+    fn quarantine_lowers_the_high_water_mark_so_the_restored_build_stays_servable() {
+        let app_data = tempdir().unwrap();
+        let store = UiUpdateStore::new(app_data.path());
+        let verifier = RecordingVerifier::default();
+        let limits = UpdateLimits::default();
+
+        // 上一版 A：默认 published_at 2026-07-11。
+        let first_bundle = archive(&[("index.html", b"v1", None), ("assets/app.js", b"1", None)]);
+        let first = signed_manifest(&first_bundle)
+            .verify_for_core("0.2.94", SUPPORTED_UI_ABI, &verifier)
+            .unwrap()
+            .verify_archive(&first_bundle, &verifier)
+            .unwrap();
+        let first_staged = store.stage(&first, &first_bundle, &limits).unwrap();
+        store.activate(&first_staged).unwrap();
+        store
+            .mark_ready(first.build_id(), SUPPORTED_UI_ABI)
+            .unwrap();
+
+        // 新版 B：published_at 严格晚于 A，并且 mark_ready 后是一个“已证实”的当前
+        // 构建——这正是 quarantine_current（而非 fail_and_rollback）的入口：确认过的
+        // 构建在服务期才暴露故障。
+        let second_bundle = archive(&[("index.html", b"v2", None), ("assets/app.js", b"2", None)]);
+        let mut second_manifest = signed_manifest(&second_bundle).manifest;
+        second_manifest.version = "1.5.0".to_string();
+        second_manifest.build_id = "a33a665e06f3b3dcb1d45f9cccbad0be83581637".to_string();
+        second_manifest.published_at = "2026-07-12T07:30:00Z".to_string();
+        second_manifest.archive.name = "agentparty-desktop-ui-v1.5.0.tar.gz".to_string();
+        second_manifest.archive.url = "https://github.com/leeguooooo/AgentParty/releases/download/desktop-ui/agentparty-desktop-ui-v1.5.0.tar.gz".to_string();
+        let second = SignedUiManifest::new(second_manifest, "manifest-signature")
+            .unwrap()
+            .verify_for_core("0.2.94", SUPPORTED_UI_ABI, &verifier)
+            .unwrap()
+            .verify_archive(&second_bundle, &verifier)
+            .unwrap();
+        let second_staged = store.stage(&second, &second_bundle, &limits).unwrap();
+        let t_a = first_staged.published_at;
+        let t_b = second_staged.published_at;
+        assert!(t_b > t_a, "fixture must have a strictly newer failed build");
+        store.activate(&second_staged).unwrap();
+        store
+            .mark_ready(second.build_id(), SUPPORTED_UI_ABI)
+            .unwrap();
+
+        // activate 乐观地把 high-water 前移到 B，mark_ready 不改动它。
+        assert_eq!(store.load_metadata().unwrap().highest_published_at, Some(t_b));
+
+        store
+            .quarantine_current(second.build_id(), FailureReason::BootFailed)
+            .unwrap();
+
+        let failed = store.load_metadata().unwrap();
+        assert_eq!(failed.current.as_deref(), Some(first.build_id()));
+        assert_eq!(failed.status, UpdateStatus::Failed);
+        // 隔离后 high-water 降回 A 的 published_at，而不是停在被隔离的 B 上。
+        assert_eq!(failed.highest_published_at, Some(t_a));
+
+        // 关键回归：服务层用 Some(highest) 作 minimum 时，恢复的 A 仍可服务，
+        // 不再被自身的降级校验当成 rollback 拒绝（修复前这里会返回 RollbackRejected）。
+        let served = store
+            .verified_current_archive_at_least(
+                "0.2.94",
+                SUPPORTED_UI_ABI,
+                &verifier,
+                &limits,
+                failed.highest_published_at,
+            )
+            .unwrap()
+            .expect("restored previous build must still be servable after quarantine");
+        assert_eq!(served.build_id(), first.build_id());
+    }
+
+    #[test]
     fn rejects_a_signed_manifest_older_than_the_accepted_high_water_mark() {
         let app_data = tempdir().unwrap();
         let store = UiUpdateStore::new(app_data.path());

--- a/desktop/src-tauri/src/ui_update.rs
+++ b/desktop/src-tauri/src/ui_update.rs
@@ -511,8 +511,14 @@ pub enum FailureReason {
 pub struct UiUpdateMetadata {
     pub current: Option<String>,
     pub current_ui_abi: Option<u32>,
+    // current/previous 各自的 published_at，用于回滚时把服务层的 high-water 地板
+    // 降回被恢复构建自身满足的值（否则 highest 停在失败构建上，恢复的旧构建被自身
+    // 降级校验当成 rollback 丢弃）。老 metadata 缺该字段时 default 为 None，随下一次
+    // activate 自愈。
+    pub current_published_at: Option<i64>,
     pub previous: Option<String>,
     pub previous_ui_abi: Option<u32>,
+    pub previous_published_at: Option<i64>,
     pub pending: Option<String>,
     pub pending_ui_abi: Option<u32>,
     pub status: UpdateStatus,
@@ -527,8 +533,10 @@ impl Default for UiUpdateMetadata {
         Self {
             current: None,
             current_ui_abi: None,
+            current_published_at: None,
             previous: None,
             previous_ui_abi: None,
+            previous_published_at: None,
             pending: None,
             pending_ui_abi: None,
             status: UpdateStatus::Ready,
@@ -813,8 +821,10 @@ impl UiUpdateStore {
 
         metadata.previous = metadata.current.take();
         metadata.previous_ui_abi = metadata.current_ui_abi.take();
+        metadata.previous_published_at = metadata.current_published_at.take();
         metadata.current = Some(staged.build_id.clone());
         metadata.current_ui_abi = Some(staged.ui_abi);
+        metadata.current_published_at = Some(staged.published_at);
         metadata.pending = Some(staged.build_id.clone());
         metadata.pending_ui_abi = Some(staged.ui_abi);
         metadata.status = UpdateStatus::Pending;
@@ -880,9 +890,15 @@ impl UiUpdateStore {
         metadata.failure_count = metadata.failure_count.saturating_add(1);
         metadata.current = metadata.previous.take();
         metadata.current_ui_abi = metadata.previous_ui_abi.take();
+        metadata.current_published_at = metadata.previous_published_at.take();
         metadata.pending = None;
         metadata.pending_ui_abi = None;
         metadata.status = UpdateStatus::Failed;
+        // 回滚失败构建后，high-water 必须降回被恢复构建自身的 published_at，否则它会被
+        // 服务层的降级校验（verified_current_archive_at_least 的 minimum）当成 rollback
+        // 拒绝，进而被 quarantine 到 current=None，退回 bundled UI。恢复的构建是当下最新
+        // 的可用构建，用它的 published_at 作地板即正确的防回滚下限。
+        metadata.highest_published_at = metadata.current_published_at;
         self.write_metadata(&metadata)
     }
 
@@ -901,9 +917,13 @@ impl UiUpdateStore {
         metadata.failure_count = metadata.failure_count.saturating_add(1);
         metadata.current = metadata.previous.take();
         metadata.current_ui_abi = metadata.previous_ui_abi.take();
+        metadata.current_published_at = metadata.previous_published_at.take();
         metadata.pending = None;
         metadata.pending_ui_abi = None;
         metadata.status = UpdateStatus::Failed;
+        // 同 fail_and_rollback：隔离当前构建、恢复上一版后，high-water 降回恢复构建的
+        // published_at，避免它被自身降级校验拒绝。恢复到 None 时 high-water 也随之清空。
+        metadata.highest_published_at = metadata.current_published_at;
         self.write_metadata(&metadata)
     }
 
@@ -1891,6 +1911,75 @@ mod tests {
             .join("index.html")
             .is_file());
         assert!(!store.metadata_path().with_extension("json.tmp").exists());
+    }
+
+    #[test]
+    fn rollback_lowers_the_high_water_mark_so_the_restored_build_stays_servable() {
+        let app_data = tempdir().unwrap();
+        let store = UiUpdateStore::new(app_data.path());
+        let verifier = RecordingVerifier::default();
+        let limits = UpdateLimits::default();
+
+        // 上一版 A：默认 published_at 2026-07-11。
+        let first_bundle = archive(&[("index.html", b"v1", None), ("assets/app.js", b"1", None)]);
+        let first = signed_manifest(&first_bundle)
+            .verify_for_core("0.2.94", SUPPORTED_UI_ABI, &verifier)
+            .unwrap()
+            .verify_archive(&first_bundle, &verifier)
+            .unwrap();
+        let first_staged = store.stage(&first, &first_bundle, &limits).unwrap();
+        store.activate(&first_staged).unwrap();
+        store
+            .mark_ready(first.build_id(), SUPPORTED_UI_ABI)
+            .unwrap();
+
+        // 待命更新 B：published_at 严格晚于 A（生产里 published_at 单调递增），
+        // 这正是旧的同 published_at 测试夹具遮住本 bug 的地方。
+        let second_bundle = archive(&[("index.html", b"v2", None), ("assets/app.js", b"2", None)]);
+        let mut second_manifest = signed_manifest(&second_bundle).manifest;
+        second_manifest.version = "1.5.0".to_string();
+        second_manifest.build_id = "a33a665e06f3b3dcb1d45f9cccbad0be83581637".to_string();
+        second_manifest.published_at = "2026-07-12T07:30:00Z".to_string();
+        second_manifest.archive.name = "agentparty-desktop-ui-v1.5.0.tar.gz".to_string();
+        second_manifest.archive.url = "https://github.com/leeguooooo/AgentParty/releases/download/desktop-ui/agentparty-desktop-ui-v1.5.0.tar.gz".to_string();
+        let second = SignedUiManifest::new(second_manifest, "manifest-signature")
+            .unwrap()
+            .verify_for_core("0.2.94", SUPPORTED_UI_ABI, &verifier)
+            .unwrap()
+            .verify_archive(&second_bundle, &verifier)
+            .unwrap();
+        let second_staged = store.stage(&second, &second_bundle, &limits).unwrap();
+        let t_a = first_staged.published_at;
+        let t_b = second_staged.published_at;
+        assert!(t_b > t_a, "fixture must have a strictly newer failed build");
+        store.activate(&second_staged).unwrap();
+
+        // activate 乐观地把 high-water 前移到未证实的 B。
+        assert_eq!(store.load_metadata().unwrap().highest_published_at, Some(t_b));
+
+        store
+            .fail_and_rollback(second.build_id(), FailureReason::BootFailed)
+            .unwrap();
+
+        let failed = store.load_metadata().unwrap();
+        assert_eq!(failed.current.as_deref(), Some(first.build_id()));
+        assert_eq!(failed.status, UpdateStatus::Failed);
+        // 回滚后 high-water 降回 A 的 published_at，而不是停在失败构建 B 上。
+        assert_eq!(failed.highest_published_at, Some(t_a));
+
+        // 关键回归：服务层用 Some(highest) 作 minimum 时，恢复的 A 仍可服务，
+        // 不再被当成 rollback 拒绝（修复前这里会返回 StoreError::RollbackRejected）。
+        let served = store
+            .verified_current_archive_at_least(
+                "0.2.94",
+                SUPPORTED_UI_ABI,
+                &verifier,
+                &limits,
+                failed.highest_published_at,
+            )
+            .unwrap()
+            .expect("restored previous build must still be servable after rollback");
+        assert_eq!(served.build_id(), first.build_id());
     }
 
     #[test]


### PR DESCRIPTION
大筛查 desktop 修复。`cargo test --lib` 87 pass、`cargo build --lib` 无警告。

- **#631** 更新失败回滚时把 `current_published_at` 复原、并把 `highest_published_at` 一并降回被恢复的旧构建，使旧构建不再被自身降级校验当 downgrade 丢弃（`fail_and_rollback` 与 `quarantine_current` 两条终局路径都覆盖，新增 published_at 字段 serde-default 兼容旧元数据）；`ui_storage` allowlist 补 `ap_desktop_updater_notified_version`/`ap_desktop_updater_shown_version` 两个 updater 键（否则更新器一跑，整个原生 settings 快照静默失败）。
- **#645** `stop_instance_key` 的 `child.kill()` 失败路径转 Failed 时补 `evict_terminal_overflow`，守住「每条终局转换都收敛淘汰」不变量。

新增 rollback high-water / allowlist / kill-error evict 三个用例。

Fixes #631
Fixes #645

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复实例终止失败后历史记录持续累积的问题，确保记录数量保持在上限内，同时保留活跃实例和最新状态。
  * 修复更新回滚后的版本状态校验问题，确保恢复的上一版本可正常继续使用。
  * 改进更新版本信息的校验，避免无效版本数据被保存。
* **更新体验**
  * 优化更新激活、回滚及失败处理流程，提升版本状态记录的准确性与可靠性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->