### PR TITLE
fix(web): 修 #656 消息 markdown 表格/块级元素无样式

### DIFF
--- a/web/src/lib/markdown.test.ts
+++ b/web/src/lib/markdown.test.ts
@@ -1,0 +1,33 @@
+// markdown 渲染管线的解析层回归（纯 marked，不依赖 DOM——DOMPurify 净化只在浏览器里跑，见 markdown.ts）。
+// 钉住 GFM 表格与任务列表能被解析出结构化标签：DOMPurify 白名单已放行 table/th/td/input（disabled 复选框）
+// 与 align 属性，正文样式在 app.css 的 .msg-body 段。用户曾报「没办法展示表格」——根因是表格根本没样式，
+// 但前提是 marked 必须先把它解析成 <table>；本用例守住这个前提，防未来关掉 GFM 又静默回归。
+// @ts-expect-error Bun executes this test, while the web tsconfig intentionally loads only Vite globals.
+import { describe, expect, test } from "bun:test";
+import { markdownToHtmlUnsafe } from "./markdown";
+
+describe("markdown 解析", () => {
+  test("GFM 表格解析成结构化 <table>（表头 + 数据单元格 + 列对齐）", () => {
+    const html = markdownToHtmlUnsafe("| h1 | h2 | h3 |\n|:-:|--:|:--|\n| a | b | c |");
+    expect(html).toContain("<table>");
+    expect(html).toContain("<thead>");
+    expect(html).toContain("<th");
+    expect(html).toContain("<td");
+    // 列对齐要落成 align 属性（DOMPurify 白名单已放行 align），否则对齐意图丢失
+    expect(html).toContain('align="center"');
+    expect(html).toContain('align="right"');
+  });
+
+  test("GFM 任务列表解析成 disabled 复选框（勾选态保留）", () => {
+    const html = markdownToHtmlUnsafe("- [ ] todo\n- [x] done");
+    expect(html).toContain('type="checkbox"');
+    expect(html).toContain("disabled");
+    expect(html).toContain("checked");
+  });
+
+  test("代码块与行内代码分别落成 <pre><code> 与裸 <code>", () => {
+    const html = markdownToHtmlUnsafe("行内 `x` 与\n\n```\nblock\n```\n");
+    expect(html).toContain("<pre>");
+    expect(html).toContain("<code");
+  });
+});

--- a/web/src/lib/markdown.ts
+++ b/web/src/lib/markdown.ts
@@ -87,9 +87,14 @@ const ALLOWED_TAGS = [
   "ul", "ol", "li",
   "strong", "em", "del", "blockquote",
   "table", "thead", "tbody", "tr", "th", "td",
+  // input 只为 GFM 任务列表 `- [ ]` 的复选框：marked 的 html renderer 已把消息正文里的裸 HTML
+  // 整体转义（#642），所以能到达 DOMPurify 的 <input> 只可能是 marked 任务列表 token 生成的；
+  // 下面的 hook 再把它强制成 disabled 复选框，杜绝任何交互/表单面。
+  "input",
   "h1", "h2", "h3", "h4", "h5", "h6",
 ];
-const ALLOWED_ATTR = ["href", "title", "class", "start"];
+// align：保留 GFM 表格列对齐（marked 发 <th align="center">）。type/checked/disabled：任务列表复选框。
+const ALLOWED_ATTR = ["href", "title", "class", "start", "align", "type", "checked", "disabled"];
 
 // class 只留 hljs 产物和受控 mention 产物，防止消息正文借用应用自身样式伪装系统 UI。
 const SAFE_CLASS_RE = /^(?:hljs(?:-[\w-]+)?|ap-mention)$/;
@@ -103,6 +108,15 @@ if (typeof DOMPurify.addHook === "function") {
     if (node.tagName === "A" && node.hasAttribute("href")) {
       node.setAttribute("target", "_blank");
       node.setAttribute("rel", "noopener noreferrer");
+    }
+    // 任务列表复选框：强制成不可交互的 disabled 复选框（type 只能是 checkbox），并删掉除
+    // type/checked/disabled 外的一切属性——即便未来有别的路径塞进 <input>，也没有任何表单/交互面。
+    if (node.tagName === "INPUT") {
+      node.setAttribute("type", "checkbox");
+      node.setAttribute("disabled", "");
+      for (const attr of [...node.attributes]) {
+        if (!["type", "checked", "disabled"].includes(attr.name)) node.removeAttribute(attr.name);
+      }
     }
     if (node.hasAttribute("class")) {
       const kept = (node.getAttribute("class") ?? "")

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -735,6 +735,65 @@
   padding-top: 8px;
   border-top: 1.4px dashed var(--t-faint);
 }
+
+/* ── Markdown 正文块级排版（消息卡片 + charter 共用 .msg-body）────────────────────
+   之前只有 .msg-body 的容器样式，marked 出的 <table>/<blockquote>/<hr>/标题/列表全无样式，
+   按浏览器默认裸渲染——表格没有边框看着就像挤在一起的纯文本（用户报的「没办法展示表格」）。
+   这里补一套主题感知（明/暗都走 --t-* / --code-* token）的正文排版。代码块沿用 hljs 主题，不动。 */
+.msg-body > :first-child { margin-top: 0; }
+.msg-body > :last-child { margin-bottom: 0; }
+.msg-body p { margin: 6px 0; }
+.msg-body a { color: var(--t-link); text-decoration: underline; text-underline-offset: 2px; }
+.msg-body h1, .msg-body h2, .msg-body h3,
+.msg-body h4, .msg-body h5, .msg-body h6 {
+  margin: 14px 0 6px;
+  line-height: 1.25;
+  font-weight: 700;
+}
+.msg-body h1 { font-size: 1.35em; }
+.msg-body h2 { font-size: 1.2em; }
+.msg-body h3 { font-size: 1.08em; }
+.msg-body h4, .msg-body h5, .msg-body h6 { font-size: 1em; }
+.msg-body ul, .msg-body ol { margin: 6px 0; padding-left: 22px; }
+.msg-body li { margin: 2px 0; }
+.msg-body li > input[type="checkbox"] { margin: 0 6px 0 0; vertical-align: middle; }
+/* GFM 任务列表项：复选框自己当标记，去掉圆点 */
+.msg-body li:has(> input[type="checkbox"]) { list-style: none; }
+.msg-body hr { margin: 12px 0; border: 0; border-top: 1.4px solid var(--t-faint); }
+.msg-body blockquote {
+  margin: 8px 0;
+  padding: 2px 12px;
+  border-left: 3px solid var(--t-faint);
+  color: var(--t-muted);
+}
+/* 行内代码（不含代码块里的 code——那由 hljs 负责）*/
+.msg-body :not(pre) > code {
+  font-family: var(--t-mono);
+  font-size: 0.9em;
+  background: var(--code-bg);
+  border: 1px solid var(--code-border);
+  border-radius: 3px;
+  padding: 0.1em 0.35em;
+  overflow-wrap: anywhere;
+}
+/* 表格：GitHub 式带边框；窄屏时表格自身横向滚动，不把整条消息撑宽 */
+.msg-body table {
+  display: block;
+  width: max-content;
+  max-width: 100%;
+  overflow-x: auto;
+  margin: 8px 0;
+  border-collapse: collapse;
+  font-size: 0.92em;
+}
+.msg-body th, .msg-body td {
+  padding: 5px 10px;
+  border: 1px solid var(--t-border);
+  text-align: left;
+}
+.msg-body th { background: var(--t-panel2); font-weight: 700; }
+.msg-body tbody tr:nth-child(even) td { background: color-mix(in srgb, var(--t-panel2) 55%, transparent); }
+
 .charter-empty {
   margin: 0;
   padding-top: 8px;

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -789,8 +789,10 @@
 .msg-body th, .msg-body td {
   padding: 5px 10px;
   border: 1px solid var(--t-border);
-  text-align: left;
 }
+/* 只给未显式 align 的单元格默认左对齐（否则 <th> 浏览器默认居中）；带 align="center|right" 的
+   保留 GFM 列对齐——若无这层 :not([align])，text-align:left 会盖掉刚放行的 align 属性（CodeRabbit #657）。 */
+.msg-body th:not([align]), .msg-body td:not([align]) { text-align: left; }
 .msg-body th { background: var(--t-panel2); font-weight: 700; }
 .msg-body tbody tr:nth-child(even) td { background: color-mix(in srgb, var(--t-panel2) 55%, transparent); }
 


### PR DESCRIPTION
Fixes #656

## 现象
消息里的 markdown **表格没办法正常展示**——渲染成挤在一起的纯文本，没有边框/网格。

## 根因
链路本身没问题：marked 确实把 GFM 表格解析成 `<table>`，DOMPurify 白名单也放行 `table/thead/tbody/tr/th/td`。**问题在 CSS**——`app.css` 里 `.msg-body`（消息正文容器）只有 `.charter-body .msg-body` 的容器样式，对 marked 产出的块级元素（`table/th/td/blockquote/hr/h1-h6/ul/ol/行内 code`）**没有任何规则** → 全按浏览器默认裸渲染，表格 `border-collapse` 未设、无边框、无表头背景。

## 修复
- **`app.css`**：新增一套主题感知（明/暗都走 `--t-*` / `--code-*` token）的 `.msg-body` 块级排版。表格带 `border-collapse` + `--t-border` 边框 + `--t-panel2` 表头 + **窄屏表格自身横向滚动**（`display:block; width:max-content; max-width:100%; overflow-x:auto`，不撑宽消息）；blockquote 左边框、hr、标题梯度、列表缩进、行内 code 盒子（`:not(pre) > code`，不碰 hljs 代码块）。
- **`markdown.ts`**：白名单放行 `input`（+ `type/checked/disabled`）支持 GFM 任务列表复选框、放行 `align` 保留表格列对齐；加 hook 把任何 `<input>` 强制成 disabled 复选框。**安全**：裸 HTML 已被 #642 的 html renderer 整体转义，`<input>` 唯一来源只能是 marked 任务列表 token。
- **`markdown.test.ts`**：钉住 GFM 表格/任务列表/代码块解析成结构化标签，防未来关掉 GFM 又静默回归。

## 范围说明
代码块语法高亮的暗色主题（`github.css` 仅浅色 → `midnight` 主题下代码块白底）是独立问题，本 PR 不含，已在 #656 记为后续。

`check:web` 全绿（bun test + tsc + vite build）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **测试**
  - 新增 Markdown 渲染回归测试：覆盖 GFM 表格（含结构与列对齐）、任务列表（复选框勾选状态）、代码块与行内代码，防止关键解析回归。
- **样式优化**
  - 完善 `.msg-body` 下 Markdown 正文块级排版：标题层级、段落/链接、列表缩进与间距、任务列表与条目样式、分隔线、引用、行内代码，以及 GitHub 风格表格与窄屏横向滚动。
- **安全与解析增强**
  - 强化任务列表复选框的净化结果：仅保留必要属性，设置为不可交互的禁用复选框，保持勾选状态。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->