### PR TITLE
fix(web): markdown 丢弃纯 HTML 注释，charter 的 ap:division marker 不再漏成可见文字

### DIFF
--- a/web/src/lib/markdown.test.ts
+++ b/web/src/lib/markdown.test.ts
@@ -48,4 +48,18 @@ describe("markdown 解析", () => {
     expect(html).toContain("&lt;span");
     expect(html).not.toContain('<span class="ap-mention"');
   });
+
+  test("#642 边界：注释后紧跟正文（<!-- -->evil）不因注释判断而丢正文，整段仍转义成可见文本", () => {
+    // marked 把 `<!-- -->evil` 收成单个 html token——纯注释分支绝不能匹配它、把 evil 一起吞掉。
+    const html = markdownToHtmlUnsafe("<!-- x -->evil");
+    expect(html).toContain("evil"); // 正文不被丢弃
+    expect(html).toContain("&lt;!--"); // 注释头也转义成可见文本，而非当注释隐藏
+    expect(html).not.toContain("<!-- x -->"); // 绝不作为真实注释/HTML 渲染
+  });
+
+  test("缩进注释（marked 保留的 0–3 空格）也被丢弃，不漏成可见文字", () => {
+    const html = markdownToHtmlUnsafe("   <!-- ap:division:start -->");
+    expect(html).not.toContain("ap:division");
+    expect(html).not.toContain("&lt;!--");
+  });
 });

--- a/web/src/lib/markdown.test.ts
+++ b/web/src/lib/markdown.test.ts
@@ -30,4 +30,22 @@ describe("markdown 解析", () => {
     expect(html).toContain("<pre>");
     expect(html).toContain("<code");
   });
+
+  test("纯 HTML 注释被丢弃（charter 的 ap:division marker 不再漏成可见文字），正文照常渲染", () => {
+    const section = "<!-- ap:division:start -->\n### Division of labor (synced)\n- **leo-claude**（lark:x）— host：#126\n<!-- ap:division:end -->";
+    const html = markdownToHtmlUnsafe(section);
+    // marker 注释不落任何可见文本（既不裸露也不被转义成 &lt;!--）
+    expect(html).not.toContain("ap:division");
+    expect(html).not.toContain("&lt;!--");
+    // marker 之间的正文正常渲染
+    expect(html).toContain("<h3>Division of labor (synced)</h3>");
+    expect(html).toContain("<strong>leo-claude</strong>");
+  });
+
+  test("#642 不回归：混了内容的裸 HTML 仍转义成可见文本，绝不真渲染", () => {
+    // 只有「整段就是一个注释」才丢弃；注释后跟内容的混合 token 仍走转义，不给伪造 UI 的绕过面。
+    const html = markdownToHtmlUnsafe('<span class="ap-mention" title="@owner">@owner</span>');
+    expect(html).toContain("&lt;span");
+    expect(html).not.toContain('<span class="ap-mention"');
+  });
 });

--- a/web/src/lib/markdown.ts
+++ b/web/src/lib/markdown.ts
@@ -68,6 +68,12 @@ function createMarked(identities: IdentityDisplayMap | undefined): Marked {
       // DOMPurify 的 class 白名单按名字放行，无法辨别来源，挡不住。真正的 mention span 由
       // mentionExtension 在解析后生成（apMention token，不走这条 html renderer），不受影响。
       html({ text }) {
+        // 纯 HTML 注释（<!-- ... -->）不含可渲染/可执行内容，标准 markdown 本就隐藏它，
+        // 而 DOMPurify 默认也会剥注释——把它转义成可见文字纯属副作用，会让内部注释 marker
+        // （如 charter 的 ap:division 合并 marker，见 divisionCharter.ts）漏成一行乱码。
+        // 因此纯注释 token 直接丢弃；其余裸 HTML 仍按 #642 转义成可见文本、绝不真渲染。
+        // 只在整段就是一个注释时丢弃，`<!-- -->evil` 之类混合内容仍走转义，不给绕过面。
+        if (/^<!--[\s\S]*?-->\s*$/.test(text)) return "";
         return escapeRawHtml(text);
       },
     },

--- a/web/src/lib/markdown.ts
+++ b/web/src/lib/markdown.ts
@@ -72,8 +72,9 @@ function createMarked(identities: IdentityDisplayMap | undefined): Marked {
         // 而 DOMPurify 默认也会剥注释——把它转义成可见文字纯属副作用，会让内部注释 marker
         // （如 charter 的 ap:division 合并 marker，见 divisionCharter.ts）漏成一行乱码。
         // 因此纯注释 token 直接丢弃；其余裸 HTML 仍按 #642 转义成可见文本、绝不真渲染。
-        // 只在整段就是一个注释时丢弃，`<!-- -->evil` 之类混合内容仍走转义，不给绕过面。
-        if (/^<!--[\s\S]*?-->\s*$/.test(text)) return "";
+        // 只在整段就是一个注释时丢弃：允许 marked 保留的 0–3 空格缩进（前导 \s*），但用非贪婪
+        // 匹配到首个 `-->` 后要求余下全是空白——`<!-- -->evil` 之类混合内容不匹配，仍走转义，不给绕过面。
+        if (/^\s*<!--[\s\S]*?-->\s*$/.test(text)) return "";
         return escapeRawHtml(text);
       },
     },


### PR DESCRIPTION
## 问题（截图现场）

频道公告里「Division of labor (synced)」区块上下多出两行乱码 `←!— ap:division:start —→` / `end`——它们是内部合并用的 **HTML 注释 marker**（`<!-- ap:division:start -->`，见 `web/src/lib/divisionCharter.ts`），本该不可见。

## 根因

#642 安全加固把消息/公告正文里**所有裸 HTML 转义成可见文本**（`web/src/lib/markdown.ts` 的 `html` renderer → `escapeRawHtml`），用来中和伪造 mention / 借用应用样式的攻击面。HTML 注释被一并扫进去 → `<!-- … -->` 转义成 `&lt;!-- … --&gt;` 显示出来。标准 markdown 与 DOMPurify 默认都隐藏注释。

## 改法

`html` renderer 里「整段就是一个注释」的 token 直接**丢弃**（注释无可渲染/可执行内容，安全，与 DOMPurify 剥注释一致）；其余裸 HTML 仍照 #642 转义。

```ts
if (/^<!--[\s\S]*?-->\s*$/.test(text)) return "";
return escapeRawHtml(text);
```

- 只匹配「整段就是一个注释」，`<!-- -->evil` 这类混合 token 仍走转义，不给伪造 UI 的绕过面。
- 通用修复：任何注释泄漏（不止 division marker）都一并修好。

## 验证

- 新增 2 条用例：① division marker 不再漏出、正文照常渲染；② #642 不回归（混内容的裸 `<span>` 仍转义）。
- `bun test --isolate` **908 pass / 0 fail**；`tsc --noEmit` 通过；`vite build` 通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug 修复**
  - 优化 Markdown 渲染：仅包含的纯 HTML 注释会被正确丢弃，不再以乱码、裸文本或可见转义形式展示。
  - 注释中的特殊标记不会被意外泄露；相邻正文内容仍会正常渲染。
  - 混合 HTML（注释与其他片段同处）将继续以安全可见文本形式展示，避免误渲染为真实 HTML。
- **测试**
  - 新增回归测试，覆盖纯注释、注释紧跟正文、带缩进注释及混合内容边界场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->