### PR TITLE
feat(web): owner 进入页面时引导升级过时 CLI 的 agent (#662)

### DIFF
--- a/web/src/components/OutdatedAgentsNotice.test.tsx
+++ b/web/src/components/OutdatedAgentsNotice.test.tsx
@@ -99,6 +99,22 @@ test("点关闭后即隐藏（本会话不再骚扰）", () => {
   expect(root.findAllByType("div")).toHaveLength(0);
 });
 
+test("dismissal 按 min 独立记忆：关掉 0.3.0 后升到 0.4.0 仍提示，回退 0.3.0 不再骚扰（#670）", () => {
+  // 关掉当前 min=0.3.0
+  let root = render({ presence: mixedPresence, accountKey: MINE, minVersion: "0.3.0" });
+  expect(labels(root).length).toBe(1);
+  act(() => byClass(root, "outdated-agents-notice-dismiss")[0]!.props.onClick());
+  expect(root.findAllByType("div")).toHaveLength(0);
+  // 服务端升到新 min=0.4.0：这是不同版本，应重新提示（不被 0.3.0 的忽略顶掉）。
+  root = render({ presence: mixedPresence, accountKey: MINE, minVersion: "0.4.0" });
+  expect(labels(root).length).toBeGreaterThan(0);
+  act(() => byClass(root, "outdated-agents-notice-dismiss")[0]!.props.onClick());
+  expect(root.findAllByType("div")).toHaveLength(0);
+  // 服务端回退到曾被忽略的 0.3.0：不再提示（每个 min 的忽略独立持久）。
+  root = render({ presence: mixedPresence, accountKey: MINE, minVersion: "0.3.0" });
+  expect(root.findAllByType("div")).toHaveLength(0);
+});
+
 test("每个过时 agent 有升级 CTA，点击回调带 agent name", () => {
   const opened: string[] = [];
   const root = render({ presence: mixedPresence, accountKey: MINE, minVersion: "0.3.0", onUpgrade: (name) => opened.push(name) });

--- a/web/src/components/OutdatedAgentsNotice.test.tsx
+++ b/web/src/components/OutdatedAgentsNotice.test.tsx
@@ -1,0 +1,107 @@
+// #662：owner 视角的过时 CLI 汇总提醒。bun react-test-renderer 无 window，useMinClientVersion 恒 null，
+// 故用 minVersion prop 注入服务端最低版本，覆盖「只列过时 + 只列本 owner」「min 未知不渲染」「边界不误报」「关闭即隐藏」。
+// @ts-expect-error Bun executes this test, while the web tsconfig intentionally loads only Vite globals.
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { act, create, type ReactTestInstance, type ReactTestRenderer } from "react-test-renderer";
+import type { PresenceEntry } from "@agentparty/shared";
+import { LocaleProvider } from "../i18n/locale";
+import { OutdatedAgentsNotice } from "./OutdatedAgentsNotice";
+
+let renderer: ReactTestRenderer | null = null;
+
+beforeEach(() => {
+  Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", { configurable: true, value: true });
+  // 每个用例独立的 sessionStorage 存根，避免「已忽略」跨用例串味。
+  const store = new Map<string, string>();
+  Object.defineProperty(globalThis, "sessionStorage", {
+    configurable: true,
+    value: {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => void store.set(k, v),
+      removeItem: (k: string) => void store.delete(k),
+      clear: () => store.clear(),
+      key: () => null,
+      length: 0,
+    },
+  });
+});
+
+afterEach(() => {
+  act(() => renderer?.unmount());
+  renderer = null;
+});
+
+function entry(over: Partial<PresenceEntry> & { name: string }): PresenceEntry {
+  return { state: "working", note: null, ts: 1, ...over } as PresenceEntry;
+}
+
+function render(props: React.ComponentProps<typeof OutdatedAgentsNotice>): ReactTestInstance {
+  act(() => {
+    renderer = create(
+      <LocaleProvider>
+        <OutdatedAgentsNotice {...props} />
+      </LocaleProvider>,
+    );
+  });
+  return renderer!.root;
+}
+
+function byClass(root: ReactTestInstance, cls: string): ReactTestInstance[] {
+  return root.findAll((n) => String(n.props.className ?? "").split(/\s+/).includes(cls));
+}
+
+function labels(root: ReactTestInstance): string[] {
+  return byClass(root, "outdated-agents-notice-name").map((n) => n.children.filter((c): c is string => typeof c === "string").join(""));
+}
+
+const MINE = "me@corp.dev";
+const OTHER = "someone@else.dev";
+
+// 混合版本 + 混合归属：只有「我名下 + 过时」的 agent 该被列出。
+const mixedPresence: Record<string, PresenceEntry> = {
+  planner: entry({ name: "planner", kind: "agent", account: MINE, client_version: "0.2.100" }), // 我的、过时 → 列
+  builder: entry({ name: "builder", kind: "agent", account: MINE, client_version: "0.3.5" }), // 我的、够新 → 不列
+  edge: entry({ name: "edge", kind: "agent", account: MINE, client_version: "0.3.0" }), // 我的、恰等 min → 不列（边界）
+  scout: entry({ name: "scout", kind: "agent", account: OTHER, client_version: "0.1.0" }), // 别人的、过时 → 不列
+  human: entry({ name: "human", kind: "human", account: MINE, client_version: "0.1.0" }), // 我的人类会话 → 排除
+  nover: entry({ name: "nover", kind: "agent", account: MINE }), // 我的、无版本（未知）→ 不误报
+};
+
+test("只列出本 owner 名下且过时的 agent（边界等于 min 不算过时）", () => {
+  const root = render({ presence: mixedPresence, accountKey: MINE, minVersion: "0.3.0" });
+  expect(labels(root)).toEqual(["planner"]);
+  // 计数标注也应为 1。
+  expect(byClass(root, "outdated-agents-notice")[0]!.props["data-outdated-count"]).toBe(1);
+});
+
+test("min 未知（离线/拿不到 /api/version）→ 不渲染", () => {
+  const root = render({ presence: mixedPresence, accountKey: MINE, minVersion: null });
+  expect(root.findAllByType("div")).toHaveLength(0);
+});
+
+test("accountKey 为空 → 不渲染", () => {
+  const root = render({ presence: mixedPresence, accountKey: null, minVersion: "0.3.0" });
+  expect(root.findAllByType("div")).toHaveLength(0);
+});
+
+test("无过时 agent → 不渲染", () => {
+  const fresh: Record<string, PresenceEntry> = {
+    builder: entry({ name: "builder", kind: "agent", account: MINE, client_version: "0.3.5" }),
+  };
+  const root = render({ presence: fresh, accountKey: MINE, minVersion: "0.3.0" });
+  expect(root.findAllByType("div")).toHaveLength(0);
+});
+
+test("点关闭后即隐藏（本会话不再骚扰）", () => {
+  const root = render({ presence: mixedPresence, accountKey: MINE, minVersion: "0.3.0" });
+  expect(labels(root).length).toBe(1);
+  act(() => byClass(root, "outdated-agents-notice-dismiss")[0]!.props.onClick());
+  expect(root.findAllByType("div")).toHaveLength(0);
+});
+
+test("每个过时 agent 有升级 CTA，点击回调带 agent name", () => {
+  const opened: string[] = [];
+  const root = render({ presence: mixedPresence, accountKey: MINE, minVersion: "0.3.0", onUpgrade: (name) => opened.push(name) });
+  act(() => byClass(root, "outdated-agents-notice-upgrade")[0]!.props.onClick());
+  expect(opened).toEqual(["planner"]);
+});

--- a/web/src/components/OutdatedAgentsNotice.tsx
+++ b/web/src/components/OutdatedAgentsNotice.tsx
@@ -32,21 +32,23 @@ function agentLabel(entry: PresenceEntry): string {
   return entry.handle ?? entry.display_name ?? entry.name;
 }
 
-const DISMISS_KEY = "ap:outdatedAgentsNoticeDismissedMin";
+// 按「每个 min 版本」独立记忆 dismissal（#670 评审）：忽略 0.4.0 不会顶掉 0.3.0 的忽略；
+// 服务端回退到某个曾被忽略的旧 min 时不再骚扰。用版本后缀 key，而非单一覆盖值。
+const DISMISS_KEY_PREFIX = "ap:outdatedAgentsNoticeDismissedMin:";
 
-function readDismissedMin(): string | null {
+function isDismissed(min: string): boolean {
   try {
-    if (typeof sessionStorage === "undefined") return null;
-    return sessionStorage.getItem(DISMISS_KEY);
+    if (typeof sessionStorage === "undefined") return false;
+    return sessionStorage.getItem(DISMISS_KEY_PREFIX + min) === "1";
   } catch {
-    return null;
+    return false;
   }
 }
 
-function persistDismissedMin(min: string): void {
+function persistDismissed(min: string): void {
   try {
     if (typeof sessionStorage === "undefined") return;
-    sessionStorage.setItem(DISMISS_KEY, min);
+    sessionStorage.setItem(DISMISS_KEY_PREFIX + min, "1");
   } catch {
     // sessionStorage 不可用（隐私模式/无 DOM）时静默——本会话内的 React state 仍能隐藏。
   }
@@ -56,8 +58,8 @@ export function OutdatedAgentsNotice({ presence, accountKey, onUpgrade, minVersi
   const t = useT();
   const hookMin = useMinClientVersion();
   const min = minVersion !== undefined ? minVersion : hookMin;
-  // 按 min 记忆「已忽略」：换了 min（发了新版）dismissal 自然失效、重新提醒，避免每次刷新骚扰。
-  const [dismissedMin, setDismissedMin] = useState<string | null>(readDismissedMin);
+  // 本会话内点过「忽略」的 min 集合；与 sessionStorage 的持久记忆并用（后者覆盖跨挂载/刷新）。
+  const [dismissedMins, setDismissedMins] = useState<Set<string>>(() => new Set());
 
   const outdated = useMemo<OutdatedAgent[]>(() => {
     if (accountKey === null || min === null) return [];
@@ -72,8 +74,9 @@ export function OutdatedAgentsNotice({ presence, accountKey, onUpgrade, minVersi
     return rows.sort((a, b) => a.label.localeCompare(b.label));
   }, [presence, accountKey, min]);
 
-  // 空态一律不渲染：min 未知 / 无过时 agent / 本 min 已被忽略。
-  if (min === null || outdated.length === 0 || dismissedMin === min) return null;
+  // 空态一律不渲染：min 未知 / 无过时 agent / 本 min 已被忽略（本会话或已持久化）。
+  const dismissed = min !== null && (dismissedMins.has(min) || isDismissed(min));
+  if (min === null || outdated.length === 0 || dismissed) return null;
 
   const title =
     outdated.length === 1
@@ -88,8 +91,8 @@ export function OutdatedAgentsNotice({ presence, accountKey, onUpgrade, minVersi
           type="button"
           className="d-btn outdated-agents-notice-dismiss"
           onClick={() => {
-            setDismissedMin(min);
-            persistDismissedMin(min);
+            persistDismissed(min);
+            setDismissedMins((s) => new Set(s).add(min));
           }}
         >
           {t("OutdatedAgentsNotice.dismiss")}

--- a/web/src/components/OutdatedAgentsNotice.tsx
+++ b/web/src/components/OutdatedAgentsNotice.tsx
@@ -1,0 +1,114 @@
+// #662：owner 进入/刷新页面时主动汇总——列出自己名下跑着过时 CLI 的 agent，引导用接入包升级。
+// 与 MessageCard 的单条被动徽标（msg-client-version--outdated）互补：那是「某条消息发送时的快照」，
+// 这里是 presence 级、owner 视角的一次性提醒，落点是「重跑接入包 = 重装最新 CLI」。
+//
+// 判定复用 lib/clientVersion（isClientVersionOutdated / useMinClientVersion），不另写版本比较，
+// 三端口径一致；min 未知（离线/拿不到 /api/version）一律不渲染（沿用「未知不误报」原则）。
+import { useMemo, useState } from "react";
+import type { PresenceEntry } from "@agentparty/shared";
+import { isClientVersionOutdated, useMinClientVersion } from "../lib/clientVersion";
+import { useT } from "../i18n/useT";
+import "../i18n/strings/OutdatedAgentsNotice";
+
+interface OutdatedAgent {
+  name: string;
+  label: string;
+  version: string;
+}
+
+interface Props {
+  // 频道 presence（按 name 索引），每个 agent 最近一次 hello 上报的 client_version 随之下发。
+  presence: Record<string, PresenceEntry>;
+  // 当前登录身份的账号锚点（App 传入的 accountKey）；agent 的 account 与其 owner 同源，据此筛「我名下的」。
+  accountKey: string | null;
+  // 「用接入包升级」CTA：打开 AgentJoin 接入面板（复用现有 join-pack 生成流程）。
+  onUpgrade?: (agentName: string) => void;
+  // 测试注入用：覆盖 useMinClientVersion() 的结果（bun react-test-renderer 无 window，hook 恒 null）。
+  minVersion?: string | null;
+}
+
+// 过时 agent 的展示名：全局昵称 > SSO display name > 原始 name。
+function agentLabel(entry: PresenceEntry): string {
+  return entry.handle ?? entry.display_name ?? entry.name;
+}
+
+const DISMISS_KEY = "ap:outdatedAgentsNoticeDismissedMin";
+
+function readDismissedMin(): string | null {
+  try {
+    if (typeof sessionStorage === "undefined") return null;
+    return sessionStorage.getItem(DISMISS_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function persistDismissedMin(min: string): void {
+  try {
+    if (typeof sessionStorage === "undefined") return;
+    sessionStorage.setItem(DISMISS_KEY, min);
+  } catch {
+    // sessionStorage 不可用（隐私模式/无 DOM）时静默——本会话内的 React state 仍能隐藏。
+  }
+}
+
+export function OutdatedAgentsNotice({ presence, accountKey, onUpgrade, minVersion }: Props) {
+  const t = useT();
+  const hookMin = useMinClientVersion();
+  const min = minVersion !== undefined ? minVersion : hookMin;
+  // 按 min 记忆「已忽略」：换了 min（发了新版）dismissal 自然失效、重新提醒，避免每次刷新骚扰。
+  const [dismissedMin, setDismissedMin] = useState<string | null>(readDismissedMin);
+
+  const outdated = useMemo<OutdatedAgent[]>(() => {
+    if (accountKey === null || min === null) return [];
+    const rows: OutdatedAgent[] = [];
+    for (const entry of Object.values(presence)) {
+      // 只看自己名下的 agent：human 会话排除（网页人类无 CLI 版本），account 需与当前身份同源。
+      if (entry.kind === "human") continue;
+      if (entry.account !== accountKey) continue;
+      if (!isClientVersionOutdated(entry.client_version, min)) continue;
+      rows.push({ name: entry.name, label: agentLabel(entry), version: entry.client_version! });
+    }
+    return rows.sort((a, b) => a.label.localeCompare(b.label));
+  }, [presence, accountKey, min]);
+
+  // 空态一律不渲染：min 未知 / 无过时 agent / 本 min 已被忽略。
+  if (min === null || outdated.length === 0 || dismissedMin === min) return null;
+
+  const title =
+    outdated.length === 1
+      ? t("OutdatedAgentsNotice.title.one")
+      : t("OutdatedAgentsNotice.title.many", { count: outdated.length });
+
+  return (
+    <div className="banner banner--yellow outdated-agents-notice" role="status" aria-live="polite" data-outdated-count={outdated.length}>
+      <div className="outdated-agents-notice-head">
+        <span className="outdated-agents-notice-title">⚠ {title}</span>
+        <button
+          type="button"
+          className="d-btn outdated-agents-notice-dismiss"
+          onClick={() => {
+            setDismissedMin(min);
+            persistDismissedMin(min);
+          }}
+        >
+          {t("OutdatedAgentsNotice.dismiss")}
+        </button>
+      </div>
+      <p className="outdated-agents-notice-lead">{t("OutdatedAgentsNotice.lead", { min })}</p>
+      <ul className="outdated-agents-notice-list">
+        {outdated.map((agent) => (
+          <li key={agent.name} className="outdated-agents-notice-item">
+            <span className="outdated-agents-notice-name">{agent.label}</span>
+            <span className="outdated-agents-notice-ver t-mono">{t("OutdatedAgentsNotice.agentVersion", { current: agent.version, min })}</span>
+            {onUpgrade && (
+              <button type="button" className="d-btn d-btn--primary outdated-agents-notice-upgrade" onClick={() => onUpgrade(agent.name)}>
+                {t("OutdatedAgentsNotice.upgrade")}
+              </button>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/web/src/i18n/strings/OutdatedAgentsNotice.ts
+++ b/web/src/i18n/strings/OutdatedAgentsNotice.ts
@@ -1,0 +1,24 @@
+import { registerDict, type LocaleDict } from "../dict";
+
+// #662：owner 进入/刷新页面时，若自己名下有 agent 跑着过时 CLI，主动汇总引导升级。
+// 与 MessageCard 的单条被动徽标互补——这里是 presence 级、owner 视角的一次性提醒。
+export const OutdatedAgentsNoticeStrings: LocaleDict = {
+  en: {
+    "OutdatedAgentsNotice.title.one": "One of your agents is running an outdated CLI",
+    "OutdatedAgentsNotice.title.many": "{count} of your agents are running an outdated CLI",
+    "OutdatedAgentsNotice.lead": "Re-run the join pack for each one to reinstall the party CLI and bring it up to v{min}. An outdated CLI can misreport its token as invalid and drop the agent off the channel.",
+    "OutdatedAgentsNotice.agentVersion": "cli v{current} → needs v{min}",
+    "OutdatedAgentsNotice.upgrade": "upgrade with join pack",
+    "OutdatedAgentsNotice.dismiss": "dismiss",
+  },
+  zh: {
+    "OutdatedAgentsNotice.title.one": "你名下有 1 个 agent 在跑过时的 CLI",
+    "OutdatedAgentsNotice.title.many": "你名下有 {count} 个 agent 在跑过时的 CLI",
+    "OutdatedAgentsNotice.lead": "对每个 agent 重跑接入包即可重装 party CLI 并升到 v{min}。CLI 过时会把 token 误报成失效、让 agent 从频道掉线。",
+    "OutdatedAgentsNotice.agentVersion": "cli v{current} → 需升到 v{min}",
+    "OutdatedAgentsNotice.upgrade": "用接入包升级",
+    "OutdatedAgentsNotice.dismiss": "知道了",
+  },
+};
+
+registerDict(OutdatedAgentsNoticeStrings);

--- a/web/src/pages/Channel.tsx
+++ b/web/src/pages/Channel.tsx
@@ -10,6 +10,7 @@ import { AgentTokens } from "../components/AgentTokens";
 import { VisibilityToggle } from "../components/VisibilityToggle";
 import { JoinLink } from "../components/JoinLink";
 import { JoinRequestBanner } from "../components/JoinRequestBanner";
+import { OutdatedAgentsNotice } from "../components/OutdatedAgentsNotice";
 import { Composer, type UploadItem } from "../components/Composer";
 import { Markdown } from "../components/Markdown";
 import { MessageCard } from "../components/MessageCard";
@@ -4237,6 +4238,16 @@ export function ChannelPage({
       {kickError !== null && <p className="banner banner--red">{kickError}</p>}
       {pauseError !== null && <p className="banner banner--red">{pauseError}</p>}
       {archiveError !== null && <p className="banner banner--red">{archiveError}</p>}
+      {/* #662：owner 进入/刷新页面时，主动提醒名下跑着过时 CLI 的 agent，引导用接入包升级。
+          CTA 打开 AgentJoin 接入面板（复用 join-pack 生成）；只有能铸 agent 的 owner 才挂该面板，
+          故 onUpgrade 仅在 canMintAgent && accountKey!=null 时接线，否则退化为纯提醒（无升级按钮）。 */}
+      {!state.archived && (
+        <OutdatedAgentsNotice
+          presence={state.presence}
+          accountKey={accountKey}
+          onUpgrade={canMintAgent && accountKey !== null ? () => setAdminSurface("agentJoin", true) : undefined}
+        />
+      )}
       <ChannelToolstrip
         buttons={
           <>

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -4607,6 +4607,30 @@
 .banner--yellow { background: var(--d-yellow); }
 .banner--gray { background: var(--t-panel2); color: var(--t-muted); }
 .banner--red { background: var(--d-red-soft); }
+/* #662：过时 CLI 提醒——黄底告警，列出名下过时 agent + 每个一个「用接入包升级」按钮。 */
+.outdated-agents-notice { display: flex; flex-direction: column; gap: 6px; }
+.outdated-agents-notice-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+.outdated-agents-notice-title { font-weight: 600; }
+.outdated-agents-notice-dismiss { flex: none; font-size: 12px; }
+.outdated-agents-notice-lead { margin: 0; font-size: 12px; opacity: 0.85; }
+.outdated-agents-notice-list { margin: 0; padding: 0; list-style: none; display: flex; flex-direction: column; gap: 6px; }
+.outdated-agents-notice-item {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.outdated-agents-notice-name { font-weight: 600; }
+.outdated-agents-notice-ver { font-size: 11px; opacity: 0.8; }
+.outdated-agents-notice-upgrade { flex: none; margin-left: auto; font-size: 12px; }
+@media (max-width: 640px) {
+  .outdated-agents-notice-upgrade { margin-left: 0; }
+}
 .reply-banner {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## 背景
Closes #662。owner 在网页/桌面端进入或刷新页面时,若自己名下有 agent 跑着过时的 CLI,主动汇总提醒并引导用接入包升级。与 `MessageCard` 的单条被动版本徽标(`msg-client-version--outdated`)互补:那是「某条消息发送时的版本快照」,这里是 presence 级、owner 视角的一次性提醒。

## 改动
- 新增 `web/src/components/OutdatedAgentsNotice.tsx`:owner 专属,复用 `isClientVersionOutdated` / `useMinClientVersion`(**不另写版本比较**,三端口径一致),按 `account` 筛出自己名下过时 agent,渲染可关闭黄条,列出各 agent 当前版本 + 目标 min,带「用接入包升级」CTA。
- 新增 i18n `OutdatedAgentsNotice.ts`(中英)。
- `web/src/pages/Channel.tsx`:挂在 `PresenceBar` 下方(owner 主频道面,桌面端复用同一页,一并覆盖)。
- `app.css`:黄色告警条样式,沿用现有 `.banner` 观感。

## 判定 / 边界
- 数据来源:`presence.client_version` 已随 hello 上报下发,**无需改协议/worker**。
- min 未知(离线/拿不到 `/api/version`)、无过时 agent、accountKey 为空 → 一律不渲染(沿用「未知不误报」)。
- dismissal 按 min 记忆(`sessionStorage`):发了新版 min 变化 → 重新提醒;同会话刷新不骚扰。

## 测试
- `OutdatedAgentsNotice.test.tsx` 6 例:混合版本 roster、边界(=min 不算过时)、min=null 不渲染、无过时不渲染、关闭后隐藏、CTA 回调。
- 全量 web 套件 916 pass / 0 fail;`tsc --noEmit` exit 0;`vite build` exit 0。

## 设计取舍
- 用可关闭黄条而非 modal(与现有 kick/pause 条幅一致,更不打扰)。
- CTA 打开通用 AgentJoin 接入面板(该面 owner 才有、按名生成新接入包);组件已把 agent 名传入回调,后续可无痛改成按 agent 精确定位。

🤖 由 agent 在隔离 worktree 实现,人工审阅 diff 后提交。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 在未归档频道顶部新增“过时 CLI Agent”提醒横幅。
  - 按当前账户汇总过时条目，展示版本对比与升级入口（如支持）。
  - 可关闭提醒：按最小版本分别记忆，避免重复提示；无可提醒内容时不显示。
  - 新增中英文文案并优化小屏样式与布局。

- **测试**
  - 增补横幅渲染与交互测试：筛选逻辑、关闭后隐藏、升级回调参数、以及最小版本变更场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->