### PR TITLE
feat(web): presence 显式标注不可唤醒/未监听的 agent (#666)

### DIFF
--- a/web/src/components/AgentDetailModal.test.tsx
+++ b/web/src/components/AgentDetailModal.test.tsx
@@ -136,6 +136,42 @@ describe("AgentDetailModal (#272)", () => {
     expect(text).toContain("/workspace/agentparty");
   });
 
+  // #666：离线且不可达（被收割的 watch --once / 从未验证）时，wake 事实别再显示「可唤醒·未验证」——
+  // 那会让人误以为叫得醒。改由 autoWakeReachable 判定后如实标 unreachable。
+  test("offline + watch declared but stale last_seen → wake fact reads unreachable, not wakeable", () => {
+    const stale = Date.now() - 10 * 60_000;
+    render({
+      name: "worker-a",
+      display: "worker-a",
+      kind: "agent",
+      owner: null,
+      online: false,
+      presence: presenceEntry({ state: "offline", ts: stale, last_seen: stale, wake: { kind: "watch" } }),
+      messages: [],
+      onClose: () => {},
+    });
+    const text = JSON.stringify(renderer!.toJSON());
+    expect(text).toContain("未监听 · @ 只会进历史");
+    expect(text).not.toContain("可唤醒 · 未验证");
+  });
+
+  test("offline + fresh verified watch → still reads wakeable (not misflagged unreachable)", () => {
+    const now = Date.now();
+    render({
+      name: "worker-a",
+      display: "worker-a",
+      kind: "agent",
+      owner: null,
+      online: false,
+      presence: presenceEntry({ state: "offline", ts: now - 2_000, last_seen: now - 2_000, wake: { kind: "watch", verified_at: now - 1_000 } }),
+      messages: [],
+      onClose: () => {},
+    });
+    const text = JSON.stringify(renderer!.toJSON());
+    expect(text).toContain("可唤醒 · 已验证");
+    expect(text).not.toContain("未监听");
+  });
+
   test("history section lists only that agent's messages", () => {
     const root = render({
       name: "worker-a",

--- a/web/src/components/AgentDetailModal.tsx
+++ b/web/src/components/AgentDetailModal.tsx
@@ -2,7 +2,7 @@
 // 独立看它的工作状态（presence 已有字段）、历史工作内容（本频道已加载消息里过滤出它发的）、
 // 在线状态。不建新后端——所有数据来自调用方已经持有的 presence/messages。
 import type { MsgFrame, PresenceEntry, Sender } from "@agentparty/shared";
-import { wakeableState } from "@agentparty/shared";
+import { autoWakeReachable, wakeableState } from "@agentparty/shared";
 import { useEffect } from "react";
 import { fmtRel } from "../lib/time";
 import { useT } from "../i18n/useT";
@@ -51,6 +51,10 @@ export function AgentDetailModal({ name, display, kind, owner, online, presence,
   const history = filterAgentHistory(messages, name);
   const state = presence !== null && presence.state !== "offline" ? presence.state : online ? "online" : "offline";
   const wake = presence !== null ? wakeableState(presence, now) : null;
+  // #666：wakeableState 只看 wake layer + 服务端校验，不看 freshness——一个被 harness 收割的 watch --once
+  // 会仍报 wakeable_unverified，让人误以为叫得醒。离线且 autoWakeReachable 判不可达时，如实标 unreachable，
+  // 与 PresenceBar 的未监听徽章同口径（watch 已退出 / 从未验证，@ 只进历史）。
+  const unreachable = state === "offline" && wake !== null && wake !== "offline" && !(presence !== null && autoWakeReachable(presence, now));
   const busy = presence?.busy === true;
   const queueDepth = busy && typeof presence?.queue_depth === "number" ? presence.queue_depth : null;
   const waitingOwnerCount =
@@ -141,7 +145,9 @@ export function AgentDetailModal({ name, display, kind, owner, online, presence,
               {wake !== null && (
                 <div className="agent-detail-fact">
                   <dt>{t("AgentDetailModal.wake")}</dt>
-                  <dd className={`t-mono agent-detail-wake agent-detail-wake--${wake}`}>{t(`AgentDetailModal.wake.${wake}`)}</dd>
+                  <dd className={`t-mono agent-detail-wake agent-detail-wake--${unreachable ? "unreachable" : wake}`}>
+                    {t(unreachable ? "AgentDetailModal.wake.unreachable" : `AgentDetailModal.wake.${wake}`)}
+                  </dd>
                 </div>
               )}
             </dl>

--- a/web/src/components/PresenceBar.test.ts
+++ b/web/src/components/PresenceBar.test.ts
@@ -3,7 +3,7 @@ import type { PresenceEntry, Sender } from "@agentparty/shared";
 import { createElement } from "react";
 import { act, create, type ReactTestRenderer } from "react-test-renderer";
 import { LocaleProvider } from "../i18n/locale";
-import { ACTIVITY_TTL_MS, activityBadge, buildGroups, busyLabel, countLiveGroups, livenessBadge, ownerKey, pauseResumeAt, PresenceBar, taskLabel, waitingOwnerLabel, wakeabilityBadge, type Item } from "./PresenceBar";
+import { ACTIVITY_TTL_MS, activityBadge, buildGroups, busyLabel, countLiveGroups, livenessBadge, ownerKey, pauseResumeAt, PresenceBar, presenceTier, PRESENCE_STALE_MS, taskLabel, unreachableBadge, waitingOwnerLabel, wakeabilityBadge, type Item } from "./PresenceBar";
 
 function item(over: Partial<Item> = {}): Item {
   return {
@@ -136,6 +136,85 @@ describe("wakeabilityBadge (#191 可唤醒·待命 + 服务端校验)", () => {
     expect(wakeabilityBadge(item({ wakeKind: "none" }), NOW)?.key).toBe("PresenceBar.wake.off");
     expect(wakeabilityBadge(item({ wakeKind: "watch", wakeVerifiedAt: NOW, residency: "human_driven" }), NOW)?.tone).toBe("off");
     expect(wakeabilityBadge(item({ wakeKind: "serve", wakeVerifiedAt: NOW, residency: "bare" }), NOW)?.tone).toBe("off");
+  });
+});
+
+// #666：把 CLI `party who` 的三档分级搬到 web，把「离线且不可唤醒」（被收割的 watch --once /
+// 从未验证 / 无 wake layer）从「可唤醒·待命」里拆出来显式标注。tier 复用共享 wakeableState +
+// autoWakeReachable，与 who.ts classify 同口径。
+describe("presenceTier / unreachableBadge (#666 未监听)", () => {
+  const NOW = 10_000_000;
+  const FRESH = NOW - 5_000; // < STALE_MS：新鲜
+  const STALE = NOW - PRESENCE_STALE_MS - 60_000; // 远超 STALE_MS：被收割 / 陈旧
+
+  test("presenceTier：在线 → online（不看 wake）", () => {
+    expect(presenceTier(item({ state: "working" }), NOW)).toBe("online");
+    expect(presenceTier(item({ state: "waiting", wakeKind: null }), NOW)).toBe("online");
+  });
+
+  test("presenceTier：离线 + 无 wake layer → recent（不可唤醒）", () => {
+    expect(presenceTier(item({ state: "offline", wakeKind: null, lastSeen: STALE }), NOW)).toBe("recent");
+    expect(presenceTier(item({ state: "offline", wakeKind: "none", lastSeen: FRESH }), NOW)).toBe("recent");
+  });
+
+  test("presenceTier：离线 + serve/watch + 新鲜 last_seen → wakeable（可达待命）", () => {
+    expect(presenceTier(item({ state: "offline", wakeKind: "watch", wakeVerifiedAt: null, lastSeen: FRESH }), NOW)).toBe(
+      "wakeable",
+    );
+    expect(presenceTier(item({ state: "offline", wakeKind: "serve", wakeVerifiedAt: NOW - 1_000, lastSeen: FRESH }), NOW)).toBe(
+      "wakeable",
+    );
+  });
+
+  test("presenceTier：离线 + watch 声明还在但 last_seen 陈旧（被 harness 收割的 --once）→ recent", () => {
+    expect(presenceTier(item({ state: "offline", wakeKind: "watch", wakeVerifiedAt: null, lastSeen: STALE }), NOW)).toBe(
+      "recent",
+    );
+    // verified_at 新鲜也不能救——freshness 决定当前可达，与 who.ts 同口径（#454）。
+    expect(presenceTier(item({ state: "offline", wakeKind: "watch", wakeVerifiedAt: NOW - 1_000, lastSeen: STALE }), NOW)).toBe(
+      "recent",
+    );
+  });
+
+  test("presenceTier：离线 + webhook → wakeable（服务端投递，天然可达）", () => {
+    expect(presenceTier(item({ state: "offline", wakeKind: "webhook", lastSeen: STALE }), NOW)).toBe("wakeable");
+  });
+
+  test("presenceTier：human_driven / bare 不承诺可唤醒 → recent", () => {
+    expect(
+      presenceTier(item({ state: "offline", wakeKind: "watch", wakeVerifiedAt: NOW, residency: "human_driven", lastSeen: FRESH }), NOW),
+    ).toBe("recent");
+    expect(presenceTier(item({ state: "offline", wakeKind: "serve", residency: "bare", lastSeen: FRESH }), NOW)).toBe("recent");
+  });
+
+  test("unreachableBadge：离线不可唤醒的 agent → 标注未监听", () => {
+    expect(unreachableBadge(item({ kind: "agent", state: "offline", wakeKind: null, lastSeen: STALE }), NOW)).toEqual({
+      key: "PresenceBar.unreachable",
+      titleKey: "PresenceBar.unreachableTitle",
+    });
+    // 被收割的 watch --once 同样标注（这是 #666 的核心：别再假报可唤醒）。
+    expect(
+      unreachableBadge(item({ kind: "agent", state: "offline", wakeKind: "watch", wakeVerifiedAt: null, lastSeen: STALE }), NOW),
+    ).not.toBeNull();
+  });
+
+  test("unreachableBadge：在线 / 可唤醒待命 / paused / 人类 → 不标注", () => {
+    expect(unreachableBadge(item({ kind: "agent", state: "working" }), NOW)).toBeNull();
+    expect(
+      unreachableBadge(item({ kind: "agent", state: "offline", wakeKind: "watch", wakeVerifiedAt: null, lastSeen: FRESH }), NOW),
+    ).toBeNull();
+    // paused 是人主动设的有意状态、已有独立 ⏸ chip，不叠加未监听。
+    expect(
+      unreachableBadge(item({ kind: "agent", state: "offline", paused: true, wakeKind: null, lastSeen: STALE }), NOW),
+    ).toBeNull();
+    // 人类离线本就靠人接续，不算「未监听」。
+    expect(unreachableBadge(item({ kind: "human", state: "offline", wakeKind: null, lastSeen: STALE }), NOW)).toBeNull();
+  });
+
+  test("verified-wakeable 的离线 agent：显示可唤醒，不显示未监听", () => {
+    const it = item({ kind: "agent", state: "offline", wakeKind: "watch", wakeVerifiedAt: NOW - 1_000, lastSeen: FRESH });
+    expect(unreachableBadge(it, NOW)).toBeNull();
+    expect(wakeabilityBadge(it, NOW)).toEqual({ key: "PresenceBar.wake.verified", tone: "on" });
   });
 });
 
@@ -725,5 +804,68 @@ describe("presence a11y (#635 pill 键劫持 / #637 group button role)", () => {
     const section = nodesWithClass(r, "presence-group")[0];
     expect(section?.props.role).toBe("button");
     expect(section?.props["aria-expanded"]).toBe(false);
+  });
+});
+
+// #666：离线且不可唤醒的 agent 必须在页面上显式可见（红色 chip + 空心红点），
+// 别再和「可唤醒·待命」混成一个中性的 offline 点。用 presence（无对应 participant → 离线）驱动渲染。
+describe("presence 未监听/不可唤醒可见性 (#666)", () => {
+  function renderOffline(entry: PresenceEntry): ReactTestRenderer {
+    let next!: ReactTestRenderer;
+    void act(() => {
+      next = create(
+        createElement(
+          LocaleProvider,
+          null,
+          createElement(PresenceBar, {
+            presence: { [entry.name]: entry },
+            participants: [] as Sender[], // 无活连接 → 离线
+            status: "open",
+          }),
+        ),
+      );
+    });
+    renderer = next;
+    openRoster(next);
+    return next;
+  }
+
+  test("离线 + 无 wake layer + 陈旧 last_seen → 渲染未监听 chip + 空心红点", () => {
+    const stale = Date.now() - PRESENCE_STALE_MS - 60_000;
+    const r = renderOffline({ name: "ghost", kind: "agent", state: "offline", note: null, ts: stale, last_seen: stale });
+    expect(nodesWithClass(r, "presence-unreachable").length).toBeGreaterThan(0);
+    expect(nodesWithClass(r, "d-dot--unreachable").length).toBeGreaterThan(0);
+  });
+
+  test("被 harness 收割的 watch --once（wake=watch 但 last_seen 陈旧）→ 也标未监听，不再假报可唤醒", () => {
+    const stale = Date.now() - PRESENCE_STALE_MS - 60_000;
+    const r = renderOffline({
+      name: "ghost",
+      kind: "agent",
+      state: "offline",
+      note: null,
+      ts: stale,
+      last_seen: stale,
+      wake: { kind: "watch" },
+    });
+    expect(nodesWithClass(r, "presence-unreachable").length).toBeGreaterThan(0);
+  });
+
+  test("在线 agent → 不渲染未监听 chip", () => {
+    const r = renderPresence(presenceEntry(), true);
+    expect(nodesWithClass(r, "presence-unreachable")).toHaveLength(0);
+    expect(nodesWithClass(r, "d-dot--unreachable")).toHaveLength(0);
+  });
+
+  test("未监听 chip 跟随中英文 locale", async () => {
+    const stale = Date.now() - PRESENCE_STALE_MS - 60_000;
+    const en = renderOffline({ name: "ghost", kind: "agent", state: "offline", note: null, ts: stale, last_seen: stale });
+    expect(nodesWithClass(en, "presence-unreachable").some((n) => n.children.join("") === "⚠ unreachable")).toBe(true);
+
+    await act(async () => en.unmount());
+    renderer = null;
+    localStorage.setItem("ap_locale", "zh");
+    const zh = renderOffline({ name: "ghost", kind: "agent", state: "offline", note: null, ts: stale, last_seen: stale });
+    expect(nodesWithClass(zh, "presence-unreachable").some((n) => n.children.join("") === "⚠ 未监听")).toBe(true);
   });
 });

--- a/web/src/components/PresenceBar.tsx
+++ b/web/src/components/PresenceBar.tsx
@@ -1,6 +1,6 @@
 // 顶部 presence 条：每参与者一个手绘胶囊（名字 + 蜡笔状态点 + note + 相对时间），
 // 右端挂连接状态。"对方卡在哪"一眼可见（spec §9 第 3 块）。
-import { autoWakeReachable, evaluateHostLease, wakeableState, type ChannelRoleAssignment, type PresenceEntry, type PresenceState, type Sender } from "@agentparty/shared";
+import { autoWakeReachable, evaluateHostLease, PRESENCE_TIMEOUT_MS, wakeableState, type ChannelRoleAssignment, type PresenceEntry, type PresenceState, type Sender } from "@agentparty/shared";
 import { useCallback, useEffect, useRef, useState, type CSSProperties, type ReactElement } from "react";
 import { agentHue } from "../lib/agentColor";
 import { fmtRel } from "../lib/time";
@@ -232,7 +232,8 @@ export function wakeabilityBadge(item: Item, now: number): { key: string; tone: 
   return { key: "PresenceBar.wake.off", tone: "off" };}
 
 // 与 CLI who.ts 的 STALE_MS / DO presence 扫描一致：last_seen 超过它且无活连接即视为不新鲜、不可达。
-export const PRESENCE_STALE_MS = 60_000;
+// 复用协议侧 freshness 常量，避免前端与 shared 的陈旧判定分叉（#671 评审）。
+export const PRESENCE_STALE_MS = PRESENCE_TIMEOUT_MS;
 
 export type PresenceTier = "online" | "wakeable" | "recent";
 

--- a/web/src/components/PresenceBar.tsx
+++ b/web/src/components/PresenceBar.tsx
@@ -1,6 +1,6 @@
 // 顶部 presence 条：每参与者一个手绘胶囊（名字 + 蜡笔状态点 + note + 相对时间），
 // 右端挂连接状态。"对方卡在哪"一眼可见（spec §9 第 3 块）。
-import { evaluateHostLease, wakeableState, type ChannelRoleAssignment, type PresenceEntry, type PresenceState, type Sender } from "@agentparty/shared";
+import { autoWakeReachable, evaluateHostLease, wakeableState, type ChannelRoleAssignment, type PresenceEntry, type PresenceState, type Sender } from "@agentparty/shared";
 import { useCallback, useEffect, useRef, useState, type CSSProperties, type ReactElement } from "react";
 import { agentHue } from "../lib/agentColor";
 import { fmtRel } from "../lib/time";
@@ -230,6 +230,49 @@ export function wakeabilityBadge(item: Item, now: number): { key: string; tone: 
   if (state === "wakeable_verified") return { key: "PresenceBar.wake.verified", tone: "on" };
   if (state === "wakeable_unverified") return { key: "PresenceBar.wake.unverified", tone: "pending" };
   return { key: "PresenceBar.wake.off", tone: "off" };}
+
+// 与 CLI who.ts 的 STALE_MS / DO presence 扫描一致：last_seen 超过它且无活连接即视为不新鲜、不可达。
+export const PRESENCE_STALE_MS = 60_000;
+
+export type PresenceTier = "online" | "wakeable" | "recent";
+
+// #666：把 CLI `party who` 的三档分级（online / wakeable / recent）搬到 web，让人一眼区分
+// 「离线但可唤醒·待命」（watch --once 的正常 standby）与「离线且不可唤醒」——watch 已被 harness
+// 收割 / 从未验证 / 根本没有 wake layer（@ 它只会进历史、可能没人处理）。判定完全复用共享的
+// wakeableState + autoWakeReachable，与 who.ts classify 同口径：wakeableState 看 wake layer + 服务端
+// 校验，autoWakeReachable 看 freshness/live——两者都成立才算真「可唤醒」，freshness 决定当前可达，
+// 于是被 kill 的 watch --once 会如实落到 recent，而不是永久假在线。
+export function presenceTier(item: Item, now: number, staleMs = PRESENCE_STALE_MS): PresenceTier {
+  // online：与 web 其余口径一致——state 非 offline 即在线（上游已把活连接 live 折叠进 state）。
+  if (item.state !== "offline") return "online";
+  const entry = {
+    ...(item.wakeKind === null
+      ? {}
+      : {
+          wake:
+            item.wakeVerifiedAt === null
+              ? { kind: item.wakeKind }
+              : { kind: item.wakeKind, verified_at: item.wakeVerifiedAt },
+        }),
+    ...(item.residency === null ? {} : { residency: item.residency }),
+    ...(item.lastSeen === null ? {} : { last_seen: item.lastSeen }),
+    ts: item.ts ?? 0,
+  };
+  // bare（无常驻）与 wakeabilityBadge 同待遇：不承诺可唤醒。
+  const wstate = item.residency === "bare" ? "offline" : wakeableState(entry, now);
+  const reachable = item.residency !== "bare" && autoWakeReachable(entry, now, staleMs);
+  return wstate !== "offline" && reachable ? "wakeable" : "recent";
+}
+
+// #666：不可唤醒/未监听徽章。仅当 agent 既非在线、也非可唤醒待命（tier=recent）时显式标注：
+// 它的 watch 已退出或从未验证可唤醒，@ 只会进历史、可能不被处理。paused 是人主动设的有意状态、
+// 已有独立 ⏸ chip，不叠加；人类离线本就靠人接续，不算「未监听」，只对 agent 标。
+export function unreachableBadge(item: Item, now: number): { key: string; titleKey: string } | null {
+  if (item.kind !== "agent") return null;
+  if (item.paused) return null;
+  if (presenceTier(item, now) !== "recent") return null;
+  return { key: "PresenceBar.unreachable", titleKey: "PresenceBar.unreachableTitle" };
+}
 
 function presenceRank(item: Item, now: number): number {
   if (hasActiveHostLease(item, now)) return 0;
@@ -491,6 +534,7 @@ export function PresenceBar({
     const taskText = task === null ? null : t(task.key, task.vars);
     const liveness = livenessBadge(it);
     const activityChip = activityBadge(it, now);
+    const unreachable = unreachableBadge(it, now);
     const taskTitle =
       it.currentTask === null
         ? null
@@ -564,7 +608,9 @@ export function PresenceBar({
         }
         style={{ "--ah": agentHue(it.name) } as CSSProperties}
       >
-        <span className={`d-dot d-dot--${it.state}${it.paused ? " d-dot--paused" : ""}`} />
+        <span
+          className={`d-dot d-dot--${it.state}${it.paused ? " d-dot--paused" : ""}${unreachable !== null ? " d-dot--unreachable" : ""}`}
+        />
         <span className="presence-name">{it.display}</span>
         <span className={`t-mono presence-kind presence-kind--${it.kind}`}>{it.kind}</span>
         {it.paused && (
@@ -617,8 +663,14 @@ export function PresenceBar({
           <span className="t-mono presence-lineage">child:{it.lineage.parent_agent}</span>
         )}
         {full && residency !== null && <span className="t-mono presence-residency">{residency}</span>}
-        {full && wakeability !== null && (
+        {/* #666：真不可唤醒时不再显示「可唤醒·未验证」——那会让人误以为叫得醒；改由下方 unreachable 徽章如实标注。 */}
+        {full && wakeability !== null && unreachable === null && (
           <span className={`t-mono presence-wake presence-wake--${wakeability.tone}`}>{t(wakeability.key)}</span>
+        )}
+        {unreachable !== null && (
+          <span className="t-mono presence-busy presence-unreachable" title={t(unreachable.titleKey)}>
+            {t(unreachable.key)}
+          </span>
         )}
         {full && it.context?.worktree_label !== undefined && (
           <span className="t-mono presence-context">{it.context.worktree_label}</span>
@@ -769,6 +821,7 @@ export function PresenceBar({
             {previewAgents.map((agent) => {
               const agentBusy = busyLabel(agent);
               const agentTask = taskLabel(agent, now);
+              const agentUnreachable = unreachableBadge(agent, now);
               return (
               <span
                 key={agent.name}
@@ -795,7 +848,9 @@ export function PresenceBar({
                     : undefined
                 }
               >
-                <span className={`d-dot d-dot--${agent.state}${agent.paused ? " d-dot--paused" : ""}`} />
+                <span
+                  className={`d-dot d-dot--${agent.state}${agent.paused ? " d-dot--paused" : ""}${agentUnreachable !== null ? " d-dot--unreachable" : ""}`}
+                />
                 <span>{agent.display}</span>
                 <span className={`t-mono presence-agent-kind presence-kind--${agent.kind}`}>{agent.kind}</span>
                 {agent.paused && (
@@ -829,6 +884,14 @@ export function PresenceBar({
                 )}
                 {agentTask !== null && (
                   <span className="t-mono presence-busy presence-busy--chip presence-task">{t(agentTask.key, agentTask.vars)}</span>
+                )}
+                {agentUnreachable !== null && (
+                  <span
+                    className="t-mono presence-busy presence-busy--chip presence-unreachable"
+                    title={t(agentUnreachable.titleKey)}
+                  >
+                    {t(agentUnreachable.key)}
+                  </span>
                 )}
               </span>
               );

--- a/web/src/i18n/strings/AgentDetailModal.ts
+++ b/web/src/i18n/strings/AgentDetailModal.ts
@@ -25,6 +25,8 @@ export const AgentDetailModalStrings: LocaleDict = {
     "AgentDetailModal.wake.offline": "not wakeable",
     "AgentDetailModal.wake.wakeable_verified": "wakeable · verified",
     "AgentDetailModal.wake.wakeable_unverified": "wakeable · unverified",
+    // #666：离线且不可达——watch 已退出或从未验证，@ 只进历史。
+    "AgentDetailModal.wake.unreachable": "unreachable — @ only lands in history",
     "AgentDetailModal.history": "recent work",
     "AgentDetailModal.historyEmpty": "no messages from this agent yet",
     "AgentDetailModal.info": "basic info",
@@ -58,6 +60,8 @@ export const AgentDetailModalStrings: LocaleDict = {
     "AgentDetailModal.wake.offline": "不可唤醒",
     "AgentDetailModal.wake.wakeable_verified": "可唤醒 · 已验证",
     "AgentDetailModal.wake.wakeable_unverified": "可唤醒 · 未验证",
+    // #666：离线且不可达——watch 已退出或从未验证，@ 只进历史。
+    "AgentDetailModal.wake.unreachable": "未监听 · @ 只会进历史",
     "AgentDetailModal.history": "历史工作内容",
     "AgentDetailModal.historyEmpty": "这个 agent 还没发过消息",
     "AgentDetailModal.info": "基本信息",

--- a/web/src/i18n/strings/PresenceBar.ts
+++ b/web/src/i18n/strings/PresenceBar.ts
@@ -49,6 +49,10 @@ export const PresenceBarStrings: LocaleDict = {
     "PresenceBar.wake.verified": "⏾ wakeable · verified",
     "PresenceBar.wake.unverified": "⏾ wakeable · unverified",
     "PresenceBar.wake.off": "not wakeable",
+    // #666：离线且不可唤醒（无 wake layer / 被收割的 watch --once / 从未验证）——@ 只进历史。
+    "PresenceBar.unreachable": "⚠ unreachable",
+    "PresenceBar.unreachableTitle":
+      "watch has exited or was never verified wakeable — @-mentions only land in history and may go unhandled",
   },
   zh: {
     "PresenceBar.kickTitle": "踢出 {name}",
@@ -98,6 +102,9 @@ export const PresenceBarStrings: LocaleDict = {
     "PresenceBar.wake.verified": "⏾ 可唤醒 · 已验证",
     "PresenceBar.wake.unverified": "⏾ 可唤醒 · 未验证",
     "PresenceBar.wake.off": "不可唤醒",
+    // #666：离线且不可唤醒（无 wake layer / 被收割的 watch --once / 从未验证）——@ 只进历史。
+    "PresenceBar.unreachable": "⚠ 未监听",
+    "PresenceBar.unreachableTitle": "watch 已退出或从未验证可唤醒；@ 只会进历史，可能不被处理",
   },
 };
 

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -1752,6 +1752,17 @@
   color: var(--d-green);
   background: var(--d-green-soft);
 }
+/* 不可唤醒/未监听（#666）：红色 chip + 空心红点，与「可唤醒·待命」的灰、paused 的琥珀明确区分——
+   watch 已退出或从未验证，@ 只进历史。 */
+.presence-unreachable {
+  border-color: var(--d-red);
+  background: var(--d-red-soft);
+  color: var(--d-red);
+}
+.d-dot--unreachable {
+  background: var(--t-panel2);
+  border-color: var(--d-red);
+}
 .presence-ts { font-size: 10px; font-weight: 400; color: var(--t-dim); }
 .presence-kick {
   flex: none;


### PR DESCRIPTION
## 背景
Closes #666。agent 的后台 `watch --once` 被 harness 回收后不再可唤醒,但网页此前把它显示成「wakeable · unverified」,人类以为它在监听——@ 只进 history 石沉大海。本 PR 让不可唤醒/未监听的 agent 在网页一眼可见。

## 改动(纯展示,不动协议/worker)
- `PresenceBar.tsx`:新增 `presenceTier()`(online/wakeable/recent,**镜像 `cli/src/commands/who.ts` 的 classify**)+ `unreachableBadge()`,复用 shared 的 `wakeableState` + `autoWakeReachable`。tier 为 `recent`(非在线且不可唤醒)时渲染红色「⚠ unreachable / 未监听」chip + 空心红点,并抑制会误导的「wakeable · unverified」。
- `AgentDetailModal.tsx`:wakeability 事实改为 reachability-aware——offline 且不可达显示 unreachable,不再谎报 wakeable。
- i18n(中英)+ `app.css`(红 chip / 空心红点)。

## 判定口径
- 与 who.ts 权威分级一致:`recent` = 非 online 且非 wakeable = 不可达。修掉网页把 reaped `watch --once`(wake 声明了但 `last_seen` 陈旧,或 `verified_at` 新但 last_seen 陈旧)显示成「可唤醒·未验证」的假信号。
- 只对 **agent** 标注(human offline 是 human_driven,非故障);**paused** 的 agent 抑制(有自己的 chip)。
- tooltip 说清后果:「watch 已退出或从未验证可唤醒;@ 只会进历史,可能不被处理」。

## 测试
- `PresenceBar.test.ts` + `AgentDetailModal.test.tsx`:64 pass / 0 fail(含 stale-no-wake、reaped watch --once、online、中英 locale、fresh-verified 仍 wakeable)。
- web `typecheck` + `build` PASS。
- 注:全量 web 套件另有 2 个**预存**失败在 `agentTokenVault.test.ts`(CLI 版本门/消毒),与本 PR 改动无关。

🤖 由 agent 在隔离 worktree 实现,人工审阅 diff 后提交。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 优化离线代理唤醒可达性判断：区分“可唤醒”和“未监听/不可达”，并调整状态在状态栏与详情弹窗中的展示与徽章/点样式。
  * 当 `last_seen` 新鲜且 `wake.verified_at` 存在时，继续正确显示“可唤醒·已验证”。
* **本地化**
  * 新增中英文“未监听/不可达”相关文案与标题说明。
* **测试**
  * 增加针对不可唤醒分级与可见性的回归用例覆盖。
* **样式**
  * 新增“不可唤醒”红色提示 chip 与空心红点样式。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->