### PR TITLE
fix(mention): 区分显式与正文 @,正文未命中降级为文本不再硬拒 (#663)

### DIFF
--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -315,7 +315,11 @@ function parseServerFrame(value: unknown): ServerFrame | null {
         ? asServerFrame(value)
         : null;
     case "sent":
-      return isPositiveInteger(value.seq) ? asServerFrame(value) : null;
+      // unresolved_mentions（#663）：正文便利提取里服务端未能路由的 token，已降级为文本；缺省=无未解析项。
+      return isPositiveInteger(value.seq) &&
+        (value.unresolved_mentions === undefined || isStringArray(value.unresolved_mentions))
+        ? asServerFrame(value)
+        : null;
     case "presence":
       return isPresenceEntry(value) ? asServerFrame(value) : null;
     case "read_cursor":

--- a/cli/src/commands/mcp.ts
+++ b/cli/src/commands/mcp.ts
@@ -438,7 +438,7 @@ export function createMcpServer(defaultChannel?: string): McpServer {
           attachPaths.length > 0
             ? await uploadAttachmentPaths(cfg.server, cfg.token, resolved, attachPaths)
             : undefined;
-        const { seq } = await postMessage(cfg.server, cfg.token, resolved, {
+        const { seq, unresolved_mentions } = await postMessage(cfg.server, cfg.token, resolved, {
           kind: "message",
           body: effectiveBody,
           mentions: normalizedMentions,
@@ -450,6 +450,10 @@ export function createMcpServer(defaultChannel?: string): McpServer {
           type: "send",
           channel: resolved,
           seq,
+          // #663：正文里未能路由的 @token（如自然语言「@我」）已按文本原样发出；回执告知调用方，绝不阻断发送。
+          ...(unresolved_mentions !== undefined && unresolved_mentions.length > 0
+            ? { unresolved_mentions }
+            : {}),
           ...(attachments !== undefined
             ? { attachments: attachments.map((a) => ({ filename: a.filename, size: a.size, url: a.url })) }
             : {}),

--- a/cli/src/commands/send.ts
+++ b/cli/src/commands/send.ts
@@ -282,7 +282,7 @@ export async function doSend(cfg: Config, input: SendInput): Promise<number | { 
     // #663：正文里的 @token 服务端未能路由，已按普通文本原样发出。打一条非阻断 warning（不改变发送成功），
     // 兑现 #552「未命中要给发送方可见反馈」的诉求，同时不再把正文自然语言 @（如「@我」）整条硬拒。
     if (unresolved_mentions !== undefined && unresolved_mentions.length > 0) {
-      const tokens = unresolved_mentions.map((t) => `@${t}`).join(", ");
+      const tokens = unresolved_mentions.map((t) => `@${stripTerminalControls(t)}`).join(", ");
       console.error(
         `warn: ${unresolved_mentions.length} @-token(s) in body were not routable and sent as text: ${tokens}`,
       );

--- a/cli/src/commands/send.ts
+++ b/cli/src/commands/send.ts
@@ -71,7 +71,10 @@ export interface AttachSource {
 export interface SendInput {
   channel: string;
   body: string;
+  /** 权威显式 mention：来自 `--mention`。服务端硬解析——拼错即整条报错（#663）。 */
   mentions: string[];
+  /** 正文便利提取的 `@token`（#663）：服务端命中即路由、未命中降级为文本，绝不阻断发送。 */
+  bodyMentions: string[];
   replyTo: number | null;
   attachPaths: string[];
 }
@@ -207,8 +210,10 @@ export async function resolveSendInput(parsed: Parsed): Promise<SendInput | null
     console.error("--mention cannot target reserved name system");
     return null;
   }
-  // Keep CLI, Web and Worker on the same body-mention contract. Explicit
-  // --mention values stay first; body tokens are appended in source order.
+  // Keep CLI, Web and Worker on the same split contract (#663): explicit `--mention` values are the
+  // AUTHORITATIVE list (server hard-rejects typos); body-extracted `@tokens` are convenience-only and
+  // go into a separate `body_mentions` — the server routes the ones that resolve and silently downgrades
+  // the rest to plain text, so a natural-language `@我` in prose can never hard-fail the whole send.
   const mentions: string[] = [];
   const seenMentions = new Set<string>();
   for (const mention of explicitMentions) {
@@ -221,17 +226,19 @@ export async function resolveSendInput(parsed: Parsed): Promise<SendInput | null
     console.error(`too many mentions (max ${MAX_MENTIONS})`);
     return null;
   }
+  const bodyMentions: string[] = [];
   for (const mention of extractMentionTokens(text)) {
-    if (mentions.length >= MAX_MENTIONS) break;
+    if (mentions.length + bodyMentions.length >= MAX_MENTIONS) break;
     const key = mentionMatchKey(mention);
     if (seenMentions.has(key)) continue;
     seenMentions.add(key);
-    mentions.push(mention);
+    bodyMentions.push(mention);
   }
   return {
     channel,
     body: text,
     mentions,
+    bodyMentions,
     replyTo: replyTo ?? null,
     attachPaths,
   };
@@ -264,13 +271,22 @@ export async function doSend(cfg: Config, input: SendInput): Promise<number | { 
     for (const ref of attachments) console.error(`uploaded ${ref.filename} (${formatSize(ref.size)})`);
   }
   try {
-    const { seq } = await postMessage(cfg.server, cfg.token, input.channel, {
+    const { seq, unresolved_mentions } = await postMessage(cfg.server, cfg.token, input.channel, {
       kind: "message",
       body: input.body,
       mentions: input.mentions,
+      ...(input.bodyMentions.length > 0 ? { body_mentions: input.bodyMentions } : {}),
       reply_to: input.replyTo,
       ...(attachments !== undefined && attachments.length > 0 ? { attachments } : {}),
     });
+    // #663：正文里的 @token 服务端未能路由，已按普通文本原样发出。打一条非阻断 warning（不改变发送成功），
+    // 兑现 #552「未命中要给发送方可见反馈」的诉求，同时不再把正文自然语言 @（如「@我」）整条硬拒。
+    if (unresolved_mentions !== undefined && unresolved_mentions.length > 0) {
+      const tokens = unresolved_mentions.map((t) => `@${t}`).join(", ");
+      console.error(
+        `warn: ${unresolved_mentions.length} @-token(s) in body were not routable and sent as text: ${tokens}`,
+      );
+    }
     advanceCursorPastOwnMessage(input.channel, seq);
     writeStatuslineCache({
       ...localStatuslineBase(input.channel),

--- a/cli/src/rest.ts
+++ b/cli/src/rest.ts
@@ -1230,6 +1230,8 @@ export async function postMessage(
   signal?: AbortSignal,
 ): Promise<{
   seq: number;
+  /** 正文便利提取里服务端未能路由、已降级为文本的 token（#663）；空/缺省=无。 */
+  unresolved_mentions?: string[];
   completion_review?: CompletionReview;
   decision_request?: DecisionRequest;
   decision_resolution?: DecisionResolution;

--- a/cli/test/send-attach.test.ts
+++ b/cli/test/send-attach.test.ts
@@ -76,13 +76,16 @@ describe("send --attach parsing", () => {
       "explicit",
     ], sendSpec);
     const input = await resolveSendInput(parsed);
-    expect(input?.mentions).toEqual(["explicit", "agent-a", "程序员小明"]);
+    // #663：显式 --mention 是权威列表；正文提取的 @ 归入 body_mentions（未命中不阻断）。email 内 @ 不算。
+    expect(input?.mentions).toEqual(["explicit"]);
+    expect(input?.bodyMentions).toEqual(["agent-a", "程序员小明"]);
   });
 
-  test("正文保留 @all 交给服务端给出明确不支持错误", async () => {
+  test("正文 @all 归入 body_mentions，交给服务端降级为文本而非硬拒（#663）", async () => {
     const parsed = parseArgs(["请 @all 看一下", "--channel", "c"], sendSpec);
     const input = await resolveSendInput(parsed);
-    expect(input?.mentions).toEqual(["all"]);
+    expect(input?.mentions).toEqual([]);
+    expect(input?.bodyMentions).toEqual(["all"]);
   });
 
   test("显式和正文 mention 的总数不超过共享上限", async () => {

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -787,7 +787,18 @@ export interface SendMessageFrame {
   type: "send";
   kind: "message";
   body: string;
+  /**
+   * 权威显式 mention 列表：来自 `--mention` / MCP `mentions[]`。服务端硬解析——未命中/歧义/保留字一律报错，
+   * 因为发送方明确指定了目标，拼错应当可见地失败（回归守卫，见 #663）。
+   */
   mentions: string[];
+  /**
+   * 正文便利提取的 `@token`（#663）：来自 `extractMentionTokens(body)`，属于「顺手识别」而非权威指定。
+   * 服务端逐个尝试解析——命中即照常路由/唤醒，未命中/歧义/保留字则**跳过、降级为普通文本、绝不阻断整条发送**，
+   * 未解析的原始 token 汇总进回执 SentFrame.unresolved_mentions。缺省（旧客户端）→ 行为与今天一致（正文 @ 曾并入
+   * mentions，仍走硬拒，这是可接受的向后兼容）。
+   */
+  body_mentions?: string[];
   reply_to: number | null;
   completion_artifact?: CompletionArtifact;
   /** 人类决策请求（#284）；带上它 = 这条 message 是一个 decision_request。与 completion_artifact 互斥。 */
@@ -1641,6 +1652,12 @@ export interface MessageUpdateFrame {
 export interface SentFrame {
   type: "sent";
   seq: number;
+  /**
+   * 正文便利提取（SendMessageFrame.body_mentions）里服务端**未能路由**的原始 token（#663）：未命中/歧义/保留字，
+   * 已降级为普通文本随消息原样发出。客户端据此打一条非阻断 warning，兑现 #552「未命中要给发送方可见反馈」的诉求，
+   * 但不再拒发。空则省略（无未解析项）。显式 mentions 的未命中不走这里——那会直接 mention_not_found 报错。
+   */
+  unresolved_mentions?: string[];
 }
 
 export interface PresenceFrame {

--- a/web/src/lib/mentions.test.ts
+++ b/web/src/lib/mentions.test.ts
@@ -426,8 +426,9 @@ describe("parseDraftMentions", () => {
   test("去重且保序", () => {
     expect(parseDraftMentions("@bob @alice @Bob")).toEqual(["bob", "alice"]);
   });
-  test("过滤 system", () => {
-    // 保留并上报：服务端会明确拒绝不可路由的保留名，不能静默降级成普通正文。
+  test("保留字仍被提取上报（映射到 body_mentions，由服务端裁决）", () => {
+    // #663：网页把提取结果整体放进 body_mentions（正文便利提取，非权威）。这里仍原样提取保留名/未知 token，
+    // 交给服务端——命中即路由，未命中/保留字（如 system）降级为普通文本并回执 unresolved_mentions，绝不硬拒整条。
     expect(parseDraftMentions("@system hi @bob")).toEqual(["system", "bob"]);
   });
   test("没有 mention 时返回空数组", () => {

--- a/web/src/pages/Channel.tsx
+++ b/web/src/pages/Channel.tsx
@@ -3406,14 +3406,18 @@ export function ChannelPage({
     if (uploads.some((u) => u.status === "uploading")) return;
     // 有附件时允许空正文（纯图片/文件消息）
     if (body === "" && attachments.length === 0) return;
-    // 与草稿 chips / 服务端 BODY_MENTION_RE 同一份语义：@ 前须行首或非标识符字符，不吃 email 里的 @
-    const mentions = parseDraftMentions(body, mentionNames);
+    // 与草稿 chips / 服务端 BODY_MENTION_RE 同一份语义：@ 前须行首或非标识符字符，不吃 email 里的 @。
+    // #663：网页没有独立的「显式 mention」输入口，所有 @ 都来自正文提取，故整体走 body_mentions——
+    // 命中的照常路由/唤醒，未命中的（如自然语言「@我」）由服务端降级为文本，绝不硬拒整条发送。
+    // 权威 mentions 留空，与 CLI/Worker 共享同一条「显式 vs 正文」契约。
+    const bodyMentions = parseDraftMentions(body, mentionNames);
     const ok =
       sockRef.current?.send({
         type: "send",
         kind: "message",
         body,
-        mentions,
+        mentions: [],
+        ...(bodyMentions.length > 0 ? { body_mentions: bodyMentions } : {}),
         reply_to: replyTo,
         ...(attachments.length > 0 ? { attachments } : {}),
       }) ?? false;

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -206,6 +206,8 @@ type SendSuccessOutcome =
       /** Durable delivery rows whose state changed while handling the send. Broadcast by id only. */
       deliveryStateIds?: string[];
       atomicEffects?: AtomicDeliveryEffects;
+      /** 正文便利提取未能路由、降级为文本的原始 token（#663）；回执 SentFrame.unresolved_mentions 的来源，空=省略。 */
+      unresolvedMentions?: string[];
     };
 
 type SendOutcome =
@@ -217,6 +219,11 @@ interface ResolvedMentionFrame {
   frame: SendFrame;
   /** Canonical agent identities proven by the same directory read that validated the mentions. */
   agentTargets: string[];
+  /**
+   * 正文便利提取（body_mentions）里无法路由的原始 token（#663）：未命中/歧义/保留字。这些被降级为普通文本，
+   * 绝不阻断发送；服务端把它们回给发送方作非阻断 warning。显式 mentions 的未命中不入此列——那会直接报错。
+   */
+  unresolved?: string[];
 }
 
 interface RoutedMentionFrame {
@@ -224,6 +231,8 @@ interface RoutedMentionFrame {
   /** Canonical, creation-time-bound agent targets that must receive durable work. */
   deliveryTargets: string[];
   deliveryTargetOwners: Record<string, string>;
+  /** 正文便利提取未能路由、降级为文本的原始 token（#663）；空=无。 */
+  unresolved?: string[];
 }
 
 interface ExpectedDecisionLineage {
@@ -337,6 +346,31 @@ function mergeBodyMentions(explicit: string[], text: string): string[] | null {
     if (out.length >= MAX_MENTIONS) return null;
     seen.add(key);
     out.push(name);
+  }
+  return byteLength(JSON.stringify(out)) <= MENTIONS_JSON_LIMIT ? out : null;
+}
+
+// #663：正文便利提取的 @token 收进 body_mentions（soft），与显式 mentions（hard）分道。来源有二并集去重：
+// 客户端显式传的 body_mentions（新 CLI/Web），以及服务端就地从正文文本再提取一遍（旧客户端或漏传时兜底，
+// 且服务端不轻信客户端提取的完整性）。已在 explicit 里的 key 跳过（显式优先，resolveMentions 会再 dedup）。
+// 词法规则与显式 mentions 共用 @agentparty/shared/mentions；总量仍受 MAX_MENTIONS / JSON 上限约束（DoS 守卫）。
+function collectBodyMentions(explicit: string[], clientBody: string[], text: string): string[] | null {
+  const explicitKeys = new Set(explicit.map(mentionMatchKey));
+  const seen = new Set<string>();
+  const out: string[] = [];
+  const push = (name: string): boolean => {
+    const key = mentionMatchKey(name);
+    if (explicitKeys.has(key) || seen.has(key)) return true;
+    if (explicit.length + out.length >= MAX_MENTIONS) return false;
+    seen.add(key);
+    out.push(name);
+    return true;
+  };
+  for (const name of clientBody) {
+    if (!push(name)) return null;
+  }
+  for (const mention of extractMentionTokens(text)) {
+    if (!push(mention.value)) return null;
   }
   return byteLength(JSON.stringify(out)) <= MENTIONS_JSON_LIMIT ? out : null;
 }
@@ -1111,9 +1145,13 @@ function parseSendFrame(input: unknown): SendFrame | null {
     if (typeof f.body !== "string") return null;
     const explicit = parseMentions(f.mentions);
     if (explicit === null) return null;
-    // 正文里的 @name 也当 mention（否则裸 party send "@name" 不会唤醒目标）
-    const mentions = mergeBodyMentions(explicit, f.body);
-    if (mentions === null) return null;
+    // #663：显式 mentions 保持权威（拼错硬拒）；正文 @token 归入 body_mentions（未命中降级为文本、不阻断）。
+    // client body_mentions（新客户端）与服务端就地再提取的正文 token 取并集，旧客户端漏传也能兜底。
+    const clientBodyMentions = parseMentions(f.body_mentions);
+    if (clientBodyMentions === null) return null;
+    const bodyMentions = collectBodyMentions(explicit, clientBodyMentions, f.body);
+    if (bodyMentions === null) return null;
+    const mentions = explicit;
     const reply_to =
       f.reply_to === undefined || f.reply_to === null
         ? null
@@ -1139,6 +1177,7 @@ function parseSendFrame(input: unknown): SendFrame | null {
       kind: "message",
       body: f.body,
       mentions,
+      ...(bodyMentions.length > 0 ? { body_mentions: bodyMentions } : {}),
       reply_to,
       ...(completionArtifact !== undefined ? { completion_artifact: completionArtifact } : {}),
       ...(decisionRequest !== undefined ? { decision_request: decisionRequest } : {}),
@@ -2526,7 +2565,14 @@ export class ChannelDO extends Server<Env> {
       // not leave a committed queued webhook waiting for unrelated future traffic to wake the DO.
       this.flushAtomicDeliveryEffects(out.atomicEffects);
       // sent 先于 raw self-echo 到达发送方，客户端先推进游标再看到自己的回声。
-      this.sendFrame(connection, { type: "sent", seq: out.seq });
+      // unresolved_mentions（#663）：正文便利提取里未能路由、已降级为文本的 token，供客户端打非阻断 warning。
+      this.sendFrame(connection, {
+        type: "sent",
+        seq: out.seq,
+        ...(out.unresolvedMentions !== undefined && out.unresolvedMentions.length > 0
+          ? { unresolved_mentions: out.unresolvedMentions }
+          : {}),
+      });
       // 广播必须紧跟 INSERT，中间不能有任何 await（#114）：
       // 并发发送时 A 落库 seq=N 后若在这里等 D1，B 落库 N+1 先广播，watcher ack 了 N+1，
       // 后到的 N 就被客户端当作「已消费」永久丢弃（client.ts: seq <= cursor 静默丢），
@@ -5954,6 +6000,10 @@ export class ChannelDO extends Server<Env> {
       const sent = out.frames[0] as MsgFrame;
       return Response.json({
         seq: out.seq,
+        // #663：正文便利提取未能路由、已降级为文本的 token；CLI 据此打非阻断 warning，不影响发送成功。
+        ...(out.unresolvedMentions !== undefined && out.unresolvedMentions.length > 0
+          ? { unresolved_mentions: out.unresolvedMentions }
+          : {}),
         ...(sent.completion_review === undefined ? {} : { completion_review: sent.completion_review }),
         ...(sent.decision_request === undefined
           ? {}
@@ -6503,11 +6553,16 @@ export class ChannelDO extends Server<Env> {
   // are rejected to the sender instead of being stored as an ordinary, unwakeable message. This also
   // canonicalizes case-insensitive agent names and agent nicknames for exact includes(self) consumers.
   private async resolveMentions(frame: SendFrame): Promise<ResolvedMentionFrame | SendErrorOutcome> {
+    // 权威显式 mention（--mention / mentions[]）与正文便利提取（body_mentions，#663）走同一目录读、两套判罚：
+    // 显式未命中/歧义/保留字 → 硬拒（发送方明确指定了目标，拼错应可见失败）；
+    // 正文未命中/歧义/保留字 → 跳过、降级为普通文本、绝不阻断，原始 token 汇总进 unresolved 回执。
     const mentions = frame.mentions ?? [];
-    if (mentions.length === 0) return { frame, agentTargets: [] };
+    const bodyMentions = frame.kind === "message" ? frame.body_mentions ?? [] : [];
+    if (mentions.length === 0 && bodyMentions.length === 0) return { frame, agentTargets: [], unresolved: [] };
     let directory: Awaited<ReturnType<ChannelDO["mentionAliasDirectory"]>>;
     try {
-      directory = await this.mentionAliasDirectory(mentions);
+      // 目录读同时覆盖显式与正文候选，正文 token 才有机会命中真 handle 并照常路由/唤醒。
+      directory = await this.mentionAliasDirectory([...mentions, ...bodyMentions]);
     } catch {
       return {
         ok: false,
@@ -6515,11 +6570,20 @@ export class ChannelDO extends Server<Env> {
         message: "mention directory is temporarily unavailable; message was not stored",
       };
     }
+    const RESERVED = ["all", "everyone", "here", "system"];
     const routed: string[] = [];
     const agentTargets = new Set<string>();
     const seen = new Set<string>();
+    const addRouted = (target: string) => {
+      const key = mentionMatchKey(target);
+      if (seen.has(key)) return;
+      seen.add(key);
+      routed.push(target);
+      if (directory.agentTargets.has(key)) agentTargets.add(target);
+    };
+    // 1) 显式 mentions：保持硬拒行为，任何未命中/歧义/保留字即整条报错（回归守卫：真拼错仍要失败）。
     for (const mention of mentions) {
-      if (["all", "everyone", "here", "system"].includes(mentionMatchKey(mention))) {
+      if (RESERVED.includes(mentionMatchKey(mention))) {
         return {
           ok: false,
           code: "mention_not_found",
@@ -6541,13 +6605,30 @@ export class ChannelDO extends Server<Env> {
           message: `mention target @${mention} is ambiguous; use an exact channel handle`,
         };
       }
-      const key = mentionMatchKey(resolution.target);
-      if (seen.has(key)) continue;
-      seen.add(key);
-      routed.push(resolution.target);
-      if (directory.agentTargets.has(key)) agentTargets.add(resolution.target);
+      addRouted(resolution.target);
     }
-    return { frame: withExpandedMentions(frame, routed), agentTargets: [...agentTargets] };
+    // 2) 正文 body_mentions：命中即照常路由；未命中/歧义/保留字降级为文本、收进 unresolved，绝不阻断。
+    const unresolved: string[] = [];
+    const unresolvedSeen = new Set<string>();
+    const markUnresolved = (token: string) => {
+      const key = mentionMatchKey(token);
+      if (unresolvedSeen.has(key)) return;
+      unresolvedSeen.add(key);
+      unresolved.push(token);
+    };
+    for (const token of bodyMentions) {
+      if (RESERVED.includes(mentionMatchKey(token))) {
+        markUnresolved(token);
+        continue;
+      }
+      const resolution = resolveMentionToken(token, directory.aliases);
+      if (resolution.status === "unknown" || resolution.status === "ambiguous") {
+        markUnresolved(token);
+        continue;
+      }
+      addRouted(resolution.target);
+    }
+    return { frame: withExpandedMentions(frame, routed), agentTargets: [...agentTargets], unresolved };
   }
 
   // #544：reply_to 本身就是一条明确的定向消息。若原消息作者是 agent，即使回复正文没有再写
@@ -6587,6 +6668,7 @@ export class ChannelDO extends Server<Env> {
   ): Promise<RoutedMentionFrame | SendErrorOutcome> {
     const mentionResolution = await this.resolveMentions(frame);
     if ("ok" in mentionResolution) return mentionResolution;
+    const unresolved = mentionResolution.unresolved ?? [];
     const autoReplyExpansion = this.expandAgentReplyMention(mentionResolution.frame, senderName);
     frame = autoReplyExpansion.frame;
     const autoReplyTargets = autoReplyExpansion.targets;
@@ -6642,6 +6724,7 @@ export class ChannelDO extends Server<Env> {
         (expectedAutoOwners.get(mentionMatchKey(target)) === undefined || !invalidAutoKeys.has(mentionMatchKey(target)))
       ),
       deliveryTargetOwners: ownerLookup,
+      unresolved,
     };
   }
 
@@ -6728,6 +6811,7 @@ export class ChannelDO extends Server<Env> {
     if ("ok" in mentionRouting) return mentionRouting;
     frame = mentionRouting.frame;
     const { deliveryTargets, deliveryTargetOwners } = mentionRouting;
+    const unresolvedBodyMentions = mentionRouting.unresolved ?? [];
     const workflowGuard = this.workflowGuardDecision(identity, frame);
     if (workflowGuard !== null) {
       const row = this.workflowGuardRow(workflowGuard.workflow.workflow_id);
@@ -7199,6 +7283,7 @@ export class ChannelDO extends Server<Env> {
       frames,
       deliveryTargets,
       deliveryTargetOwners,
+      ...(unresolvedBodyMentions.length > 0 ? { unresolvedMentions: unresolvedBodyMentions } : {}),
     };
     });
     if (decisionPreconditionFailure !== null) return decisionPreconditionFailure;

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -356,6 +356,10 @@ function mergeBodyMentions(explicit: string[], text: string): string[] | null {
 // 词法规则与显式 mentions 共用 @agentparty/shared/mentions；总量仍受 MAX_MENTIONS / JSON 上限约束（DoS 守卫）。
 function collectBodyMentions(explicit: string[], clientBody: string[], text: string): string[] | null {
   const explicitKeys = new Set(explicit.map(mentionMatchKey));
+  // 服务端就地从正文提取 = 权威集合。客户端提交的 body_mentions **只有确实出现在正文里**才被采信——
+  // 否则可用 body:"无需通知" 搭配 body_mentions:[agent] 制造正文里根本看不见的隐形路由/唤醒（#673 评审）。
+  const extracted = extractMentionTokens(text).map((m) => m.value);
+  const extractedKeys = new Set(extracted.map(mentionMatchKey));
   const seen = new Set<string>();
   const out: string[] = [];
   const push = (name: string): boolean => {
@@ -366,11 +370,14 @@ function collectBodyMentions(explicit: string[], clientBody: string[], text: str
     out.push(name);
     return true;
   };
+  // 客户端 body_mentions 先按其顺序纳入，但丢弃任何正文中不存在的 token（防隐形唤醒）。
   for (const name of clientBody) {
+    if (!extractedKeys.has(mentionMatchKey(name))) continue;
     if (!push(name)) return null;
   }
-  for (const mention of extractMentionTokens(text)) {
-    if (!push(mention.value)) return null;
+  // 服务端提取兜底（旧客户端漏传 body_mentions 时仍能识别正文 @）。
+  for (const mention of extracted) {
+    if (!push(mention)) return null;
   }
   return byteLength(JSON.stringify(out)) <= MENTIONS_JSON_LIMIT ? out : null;
 }

--- a/worker/test/body-mentions.spec.ts
+++ b/worker/test/body-mentions.spec.ts
@@ -113,6 +113,28 @@ describe("#663 explicit vs body mentions", () => {
     expect(row?.mentions).toContain(agent.name);
   });
 
+  it("client body_mentions NOT present in the body are dropped — no invisible wake (#673 review)", async () => {
+    const acct = "s663-e@leeguoo.com";
+    const sender = await seedToken("human", uniq("sender"), { owner: acct });
+    const agent = await seedToken("agent", uniq("worker663hidden"), { owner: acct });
+    const slug = await createChannel(sender.token);
+
+    // 恶意/异常客户端：正文里根本没有 @agent，却在 body_mentions 塞入该 agent 想偷偷路由/唤醒它。
+    const res = await send(slug, sender.token, {
+      body: "无需通知任何人",
+      mentions: [],
+      body_mentions: [agent.name],
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { seq: number; unresolved_mentions?: string[] };
+    const listed = await api(`/api/channels/${slug}/messages?limit=200`, sender.token);
+    const { messages } = (await listed.json()) as { messages: Array<{ seq: number; mentions: string[] }> };
+    const row = messages.find((m) => m.seq === json.seq);
+    // 正文中不存在该 @ → 绝不进 mentions[]（不路由、不唤醒），也不算 unresolved（它压根不该出现）。
+    expect(row?.mentions ?? []).not.toContain(agent.name);
+    expect(json.unresolved_mentions ?? []).not.toContain(agent.name);
+  });
+
   it("reserved-word body @全体/@all downgrade to text (unresolved), never hard-fail", async () => {
     const sender = await seedToken("human", uniq("sender"), { owner: "s663-e@leeguoo.com" });
     const slug = await createChannel(sender.token);

--- a/worker/test/body-mentions.spec.ts
+++ b/worker/test/body-mentions.spec.ts
@@ -1,0 +1,161 @@
+// #663：区分「显式 mention」与「正文附带 @」。
+// - 显式 mentions[]（--mention / MCP mentions[]）是权威来源：未命中/歧义/保留字仍硬拒（回归守卫）。
+// - body_mentions[]（正文便利提取）：命中即照常路由/唤醒；未命中/歧义/保留字降级为普通文本、不阻断整条发送，
+//   原始 token 汇总进 REST 回执 unresolved_mentions（WS 回执同字段）。
+// 反转 #552 的过度修复：自然语言「@我」不该把一条正常消息整条打回。
+import { env } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import { WsClient, api, createChannel, seedToken, uniq } from "./helpers";
+
+async function seedProfile(handle: string): Promise<string> {
+  const account = `lark:${uniq("acct")}`;
+  const now = Date.now();
+  await env.DB.prepare(
+    `INSERT INTO account_profiles (account, handle, display_name, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?)`,
+  ).bind(account, handle, handle, now, now).run();
+  return account;
+}
+
+interface SendBody {
+  kind: "message";
+  body: string;
+  mentions: string[];
+  body_mentions?: string[];
+  reply_to: number | null;
+}
+
+function send(slug: string, token: string, payload: Omit<SendBody, "kind" | "reply_to"> & { reply_to?: number | null }): Promise<Response> {
+  return api(`/api/channels/${slug}/messages`, token, {
+    method: "POST",
+    body: JSON.stringify({ kind: "message", reply_to: null, ...payload }),
+  });
+}
+
+async function storedBody(slug: string, token: string, seq: number): Promise<string> {
+  const res = await api(`/api/channels/${slug}/messages?limit=200`, token);
+  expect(res.status).toBe(200);
+  const { messages } = (await res.json()) as { messages: Array<{ seq: number; body: string }> };
+  const row = messages.find((m) => m.seq === seq);
+  expect(row).toBeDefined();
+  return row!.body;
+}
+
+describe("#663 explicit vs body mentions", () => {
+  it("natural-language @我 in body_mentions sends successfully, stored verbatim, reported unresolved (not an error)", async () => {
+    const sender = await seedToken("human", uniq("sender"), { owner: "s663-a@leeguoo.com" });
+    const slug = await createChannel(sender.token);
+    const body = "有补充或纠正的 @我。";
+
+    const res = await send(slug, sender.token, { body, mentions: [], body_mentions: ["我"] });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { seq: number; unresolved_mentions?: string[] };
+    expect(json.unresolved_mentions).toEqual(["我"]);
+    // 正文原样保留，绝不被裁剪。
+    expect(await storedBody(slug, sender.token, json.seq)).toBe(body);
+  });
+
+  it("explicit --mention typo still hard-errors even when a body @ coexists", async () => {
+    const sender = await seedToken("human", uniq("sender"), { owner: "s663-b@leeguoo.com" });
+    const slug = await createChannel(sender.token);
+
+    const res = await send(slug, sender.token, {
+      body: "@nosuchhandle 见正文 @我",
+      mentions: ["nosuchhandle"],
+      body_mentions: ["我"],
+    });
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ error: { code: "mention_not_found" } });
+  });
+
+  it("explicit mention is authoritative and routes; body @我 rides along as unresolved text", async () => {
+    const acct = "s663-c@leeguoo.com";
+    const sender = await seedToken("human", uniq("sender"), { owner: acct });
+    const slug = await createChannel(sender.token);
+    const handle = uniq("realhandle");
+    await seedProfile(handle);
+
+    const res = await send(slug, sender.token, {
+      body: `@${handle} 有补充 @我`,
+      mentions: [handle],
+      body_mentions: ["我"],
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { seq: number; unresolved_mentions?: string[] };
+    expect(json.unresolved_mentions).toEqual(["我"]);
+    // 权威 mention 落库为路由目标。
+    const listed = await api(`/api/channels/${slug}/messages?limit=200`, sender.token);
+    const { messages } = (await listed.json()) as { messages: Array<{ seq: number; mentions: string[] }> };
+    const row = messages.find((m) => m.seq === json.seq);
+    expect(row?.mentions).toContain(handle);
+  });
+
+  it("a resolvable body @handle still routes/wakes with no regression (no unresolved)", async () => {
+    const acct = "s663-d@leeguoo.com";
+    const sender = await seedToken("human", uniq("sender"), { owner: acct });
+    const agent = await seedToken("agent", uniq("worker663"), { owner: acct });
+    const slug = await createChannel(sender.token);
+
+    // 一个真实存在的 agent handle 出现在正文里 → 命中即照常路由（进 mentions[]），这正是 wake 的机制来源。
+    const res = await send(slug, sender.token, {
+      body: `请 @${agent.name} 看一下`,
+      mentions: [],
+      body_mentions: [agent.name],
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { seq: number; unresolved_mentions?: string[] };
+    // 命中的 body @ 不进 unresolved。
+    expect(json.unresolved_mentions).toBeUndefined();
+    const listed = await api(`/api/channels/${slug}/messages?limit=200`, sender.token);
+    const { messages } = (await listed.json()) as { messages: Array<{ seq: number; mentions: string[] }> };
+    const row = messages.find((m) => m.seq === json.seq);
+    // 落库 mentions[] 含该 agent，即命中的 body @ 已进入路由/唤醒路径（wake 的机制来源）。
+    expect(row?.mentions).toContain(agent.name);
+  });
+
+  it("reserved-word body @全体/@all downgrade to text (unresolved), never hard-fail", async () => {
+    const sender = await seedToken("human", uniq("sender"), { owner: "s663-e@leeguoo.com" });
+    const slug = await createChannel(sender.token);
+    const body = "@all 请注意 @everyone";
+
+    const res = await send(slug, sender.token, { body, mentions: [], body_mentions: ["all", "everyone"] });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { seq: number; unresolved_mentions?: string[] };
+    expect(json.unresolved_mentions).toEqual(["all", "everyone"]);
+    expect(await storedBody(slug, sender.token, json.seq)).toBe(body);
+  });
+
+  it("no body_mentions field (legacy client) preserves today's behavior exactly", async () => {
+    const sender = await seedToken("human", uniq("sender"), { owner: "s663-f@leeguoo.com" });
+    const slug = await createChannel(sender.token);
+
+    // 旧客户端把正文 @ 并进 mentions[] → 仍走硬拒，这是可接受的向后兼容。
+    const res = await send(slug, sender.token, { body: "结尾 @我", mentions: ["我"] });
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ error: { code: "mention_not_found" } });
+
+    // 完全不带任何 @ 的消息照常发。
+    const clean = await send(slug, sender.token, { body: "a@example.com 是邮箱", mentions: [] });
+    expect(clean.status).toBe(200);
+  });
+
+  it("WS send surfaces unresolved_mentions on the sent ack", async () => {
+    const sender = await seedToken("human", uniq("sender"), { owner: "s663-g@leeguoo.com" });
+    const slug = await createChannel(sender.token);
+
+    const ws = await WsClient.open(slug, sender.token);
+    await ws.nextOfType("welcome");
+    ws.send({ type: "hello", since: 0 });
+    ws.send({
+      type: "send",
+      kind: "message",
+      body: "有补充或纠正的 @我。",
+      mentions: [],
+      body_mentions: ["我"],
+      reply_to: null,
+    });
+    const ack = await ws.nextOfType("sent");
+    expect((ack as { unresolved_mentions?: string[] }).unresolved_mentions).toEqual(["我"]);
+    ws.close();
+  });
+});

--- a/worker/test/nickname.spec.ts
+++ b/worker/test/nickname.spec.ts
@@ -189,7 +189,7 @@ describe("@中文昵称 解析成真实 name 并唤醒（#165）", () => {
     ws.close();
   });
 
-  it("唯一 display 可路由；同名 display 明确报 mention_ambiguous", async () => {
+  it("唯一 display 可路由；同名 display 在正文里降级为文本（#663，不再硬拒）", async () => {
     const now = Date.now();
     const uniqueHandle = uniq("humanhandle");
     const uniqueDisplay = uniq("ReadableHuman");
@@ -213,24 +213,30 @@ describe("@中文昵称 解析成真实 name 并唤醒（#165）", () => {
          VALUES (?, ?, ?, ?, ?)`,
       ).bind(uniq(`account-${suffix}`), uniq(`handle-${suffix}`), duplicateDisplay, now, now).run();
     }
+    // #663：正文里的歧义 @ 不再报 mention_ambiguous——降级为普通文本，原始 token 进 sent.unresolved_mentions，
+    // 消息照常落库、mentions 不含它。显式 mentions 里的歧义仍走硬拒（见下方用例）。
     ws.send({ type: "send", kind: "message", body: `@${duplicateDisplay} hello`, mentions: [], reply_to: null });
-    const error = await ws.nextOfType("error");
-    expect(error.code).toBe("mention_ambiguous");
-    expect(error.message).toContain(`@${duplicateDisplay}`);
+    expect((await ws.nextOfType("sent")).unresolved_mentions).toEqual([duplicateDisplay]);
+    expect((await ws.nextOfType("msg")).mentions).toEqual([]);
     ws.close();
   });
 
-  it("unknown、@all 和显式 ghost target 都明确失败，不落成普通消息", async () => {
+  it("正文里 unknown/@all 降级为文本（#663）；显式 ghost target 仍硬拒", async () => {
     const sender = await seedToken("agent", uniq("sender"));
     const slug = await createChannel(sender.token);
     const ws = await WsClient.open(slug, sender.token);
     await completeCapabilityHello(ws);
 
+    // 正文里未知 @：不再硬拒，降级为文本。
     ws.send({ type: "send", kind: "message", body: "@ghost-target ping", mentions: [], reply_to: null });
-    expect((await ws.nextOfType("error")).code).toBe("mention_not_found");
+    expect((await ws.nextOfType("sent")).unresolved_mentions).toEqual(["ghost-target"]);
+    expect((await ws.nextOfType("msg")).mentions).toEqual([]);
+    // 正文里保留字 @all：同样降级为文本。
     ws.send({ type: "send", kind: "message", body: "@all ping", mentions: [], reply_to: null });
-    expect((await ws.nextOfType("error")).code).toBe("mention_not_found");
+    expect((await ws.nextOfType("sent")).unresolved_mentions).toEqual(["all"]);
+    expect((await ws.nextOfType("msg")).mentions).toEqual([]);
 
+    // 显式 mentions[] 里的未知目标仍硬拒（发送方明确指定，回归守卫）。
     const rest = await api(`/api/channels/${slug}/messages`, sender.token, {
       method: "POST",
       body: JSON.stringify({ kind: "message", body: "explicit ghost", mentions: ["missing-agent"], reply_to: null }),

--- a/worker/test/ws.spec.ts
+++ b/worker/test/ws.spec.ts
@@ -181,11 +181,11 @@ describe("websocket", () => {
     ws.send({ type: "send", kind: "message", body: "请 @Éclair 确认", mentions: [], reply_to: null });
     await ws.nextOfType("sent");
     expect((await ws.nextOfType("msg")).mentions).toEqual([unicodeCaseTarget.name]);
+    // #663：正文里未命中的 @（大小写不符/歧义/未知/保留字）不再硬拒整条 send——降级为普通文本，原始 token
+    // 进 sent.unresolved_mentions；消息照常落库、正文原样、mentions 只保留命中的目标。反转 #552 的过度阻断。
     ws.send({ type: "send", kind: "message", body: "请 @éclair 确认", mentions: [], reply_to: null });
-    expect(await ws.nextOfType("error")).toMatchObject({
-      code: "mention_not_found",
-      message: expect.stringContaining("@éclair"),
-    });
+    expect((await ws.nextOfType("sent")).unresolved_mentions).toEqual(["éclair"]);
+    expect((await ws.nextOfType("msg")).mentions).toEqual([]);
     ws.send({ type: "send", kind: "message", body: "请 @casenick 确认", mentions: [], reply_to: null });
     await ws.nextOfType("sent");
     expect((await ws.nextOfType("msg")).mentions).toEqual([asciiCaseTarget.name]);
@@ -195,30 +195,23 @@ describe("websocket", () => {
     await env.DB.prepare(
       "INSERT INTO agent_nicknames (name, nickname, created_at, updated_at) VALUES (?, ?, ?, ?)",
     ).bind(ambiguousTarget.name, "collision552", Date.now(), Date.now()).run();
-    ws.send({ type: "send", kind: "message", body: "请@collision552看一下", mentions: [], reply_to: null });
-    expect(await ws.nextOfType("error")).toMatchObject({
-      code: "mention_ambiguous",
-      message: expect.stringContaining("@collision552"),
-    });
+    // 正文里歧义 @：不再报 mention_ambiguous，降级为文本。
+    ws.send({ type: "send", kind: "message", body: "请 @collision552 看一下", mentions: [], reply_to: null });
+    expect((await ws.nextOfType("sent")).unresolved_mentions).toEqual(["collision552"]);
+    expect((await ws.nextOfType("msg")).mentions).toEqual([]);
 
-    ws.send({ type: "send", kind: "message", body: "请@ghost看一下", mentions: [], reply_to: null });
-    const error = await ws.nextOfType("error");
-    expect(error).toMatchObject({ code: "mention_not_found", message: expect.stringContaining("@ghost") });
-    ws.send({ type: "send", kind: "message", body: "请@bobcat看一下", mentions: [], reply_to: null });
-    expect(await ws.nextOfType("error")).toMatchObject({
-      code: "mention_not_found",
-      message: expect.stringContaining("@bobcat"),
-    });
+    // 正文里未知/保留字 @：同样降级为文本，绝不阻断整条发送。
+    ws.send({ type: "send", kind: "message", body: "请 @ghost 看一下", mentions: [], reply_to: null });
+    expect((await ws.nextOfType("sent")).unresolved_mentions).toEqual(["ghost"]);
+    expect((await ws.nextOfType("msg")).mentions).toEqual([]);
+    ws.send({ type: "send", kind: "message", body: "请 @bobcat 看一下", mentions: [], reply_to: null });
+    expect((await ws.nextOfType("sent")).unresolved_mentions).toEqual(["bobcat"]);
+    expect((await ws.nextOfType("msg")).mentions).toEqual([]);
     ws.send({ type: "send", kind: "message", body: "请 @全体 看一下", mentions: [], reply_to: null });
-    expect(await ws.nextOfType("error")).toMatchObject({
-      code: "mention_not_found",
-      message: expect.stringContaining("@全体"),
-    });
-    ws.send({ type: "send", kind: "message", body: "请@全体看一下", mentions: [], reply_to: null });
-    expect(await ws.nextOfType("error")).toMatchObject({
-      code: "mention_not_found",
-      message: expect.stringContaining("@全体"),
-    });
+    expect((await ws.nextOfType("sent")).unresolved_mentions).toEqual(["全体"]);
+    expect((await ws.nextOfType("msg")).mentions).toEqual([]);
+
+    // 显式 mentions 数组里的保留字仍硬拒（发送方明确指定目标，回归守卫：真拼错/误用仍要可见失败）。
     ws.send({ type: "send", kind: "message", body: "reserved", mentions: ["SYSTEM"], reply_to: null });
     expect(await ws.nextOfType("error")).toMatchObject({
       code: "mention_not_found",


### PR DESCRIPTION
## 背景
Closes #663。正文里的自然语言 `@词`(如 `@我`、`@全体`、`a@example.com`)会让**整条 send 被硬拒**(`mention_not_found`),即使已用显式 `--mention`/`mentions[]` 指定了目标。这是把 #552「未命中要给发送方可见反馈」**过度修正成了硬阻断**。

## 根因(两处,都改了)
- CLI `send.ts` 把 `extractMentionTokens(body)` **并入权威 `mentions[]`**。
- **worker `parseSendFrame()` 也重扫正文**并入 `mentions` —— 所以只改 CLI 不够,服务端无论如何都会重新合并。

## 修法:协议区分 explicit(hard) 与 body(soft)
- `shared/protocol.ts`:`SendMessageFrame` 加 `body_mentions?`(正文便利提取);`SentFrame` 加 `unresolved_mentions?`(服务端未能路由、已降级为文本的原始 token)。`mentions` 保持权威显式列表。
- `worker/do.ts`:新增 `collectBodyMentions()`(client body_mentions ∪ 服务端就地再提取,去重、保 MAX_MENTIONS/JSON DoS 上限);`resolveMentions()` 对**显式**保持硬拒(未命中/歧义/保留字→报错,回归守卫),对 **body** 软解析(命中→照常路由/唤醒;否则→跳过、收进 `unresolved`、绝不阻断)。正文原样落库。`unresolved` 贯穿到 REST 响应 + WS `sent` 回执。
- `cli/send.ts`:`--mention`→`mentions`(权威);正文提取→`body_mentions`;发送成功后若回执带 `unresolved_mentions`,打**非阻断 stderr warning**(兑现 #552 诉求,但不拒发)。
- `cli/mcp.ts`:`party_send` 回显 `unresolved_mentions`。
- `web/Channel.tsx`:网页无显式 mention UI,提取结果全进 `body_mentions`,`mentions: []` —— 三端同一契约。
- 向后兼容:旧客户端把正文 @ 并入 `mentions` 数组发来,服务端无法区分 → 仍硬拒(可接受;升级 CLI 即获修复,呼应 #662)。

## 测试(全绿)
- 新 `worker/test/body-mentions.spec.ts` 7 例:`@我。` 发得出+正文原样+进 unresolved;显式拼错仍报错;显式权威+body 搭车;可解析 body `@handle` 仍路由;保留字降级;旧客户端仍硬拒;WS 回执带 unresolved。
- 反转既有 `ws.spec.ts`/`nickname.spec.ts` 里编码了 #552 过度阻断的用例(改为断言降级),**并保留显式数组硬拒的回归守卫**。
- tsc 全清;worker 704 pass、cli 999 pass、web 910 pass。

## 已知范围
- edit 路径(`/messages/:seq/edit`)仍走旧合并(硬拒),本 PR 只修 send;如需 edit 同等软化可后续跟进。

🤖 由 agent 在隔离 worktree 实现,人工逐段审阅协议/worker/测试 diff 后提交。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 支持从消息正文自动识别并路由 `@提及`，并在回执中返回未解析的提及列表。
* **改进**
  * 明确指定的提及仍保持严格校验；正文提及遇到无法路由、歧义或保留字时会降级为普通文本，不再阻断发送。
  * CLI 与网页端在“显式提及 vs 正文提及”的处理与提示上保持一致。
* **问题修复**
  * 修复自然语言中的 `@` 内容可能导致发送失败的问题。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->