### PR TITLE
fix(send): --mention 目标不可唤醒时给发送方非阻断警告 + --require-wakeable (#664)

### DIFF
--- a/cli/src/commands/send.ts
+++ b/cli/src/commands/send.ts
@@ -1,17 +1,17 @@
 // party send — rest 一次性发消息，成功后推进游标
 import { basename } from "node:path";
-import { extractMentionTokens, MAX_MENTIONS, mentionMatchKey, type Attachment } from "@agentparty/shared";
+import { EXIT_UNREACHABLE, extractMentionTokens, MAX_MENTIONS, mentionMatchKey, type Attachment } from "@agentparty/shared";
 import { isHelpArg, parseArgs, str, strArray, unknownFlagError, valueFlagError, type Parsed } from "../args";
 import { advanceCursorPastOwnMessage, resolveChannel, type Config } from "../config";
 import { stripTerminalControls } from "../format";
 import { formatAuthDebugLine, resolveAuthDetailed } from "../oidc-cli";
 import { fetchMe, fetchPresence, handleRestError, postMessage, RestError, uploadAttachment } from "../rest";
-import { formatReachLine, reachOf } from "../reach";
+import { formatReachLine, formatUnreachable, reachOf, unreachableOf } from "../reach";
 import { localStatuslineBase, statuslinePreview, unreadFromCursor, writeStatuslineCache } from "../statusline-cache";
 import { isName, isSlug, parsePositiveIntFlag } from "../validation";
 
-export const sendSpec = { repeatable: ["mention", "attach"], booleans: ["debug-auth", "reach", "no-reach"] };
-const SEND_FLAGS = ["channel", "reply-to", "mention", "attach", "debug-auth", "reach", "no-reach"];
+export const sendSpec = { repeatable: ["mention", "attach"], booleans: ["debug-auth", "reach", "no-reach", "require-wakeable"] };
+const SEND_FLAGS = ["channel", "reply-to", "mention", "attach", "debug-auth", "reach", "no-reach", "require-wakeable"];
 const HELP = `usage: party send <text|-> [--channel C] [--mention name]... [--attach path]... [--reply-to seq] [--debug-auth]
 
 Send one message to a channel. Use "-" as the body to read stdin.
@@ -24,14 +24,22 @@ After a send with --mention, a reachability line prints to stderr — whether ea
 target is ● online / ◐ wakeable / ○ offline (won't reach until it reconnects).
 On by default in an interactive terminal; --reach forces it, --no-reach silences it.
 
+If any mentioned target is neither online nor auto-wakeable (offline with no wake
+layer, or a stale/dead wake adapter), a non-blocking "warn:" line also prints to
+stderr — the send still succeeds, but the mention only lands in history and will not
+wake anyone. This warning shows even without a TTY (agent loops); --no-reach silences
+it. Use --require-wakeable to make such a send exit non-zero (after sending).
+
 Options:
-  --channel C      send to channel C instead of the bound channel
-  --mention name   mention a user or agent; repeatable
-  --attach path    upload a local file and attach it; repeatable (max 25MB each)
-  --reply-to seq   attach this message as a reply to seq
-  --reach          show mention reachability even when not a TTY (agent loops)
-  --no-reach       never show mention reachability
-  --debug-auth     print resolved auth/config source to stderr`;
+  --channel C         send to channel C instead of the bound channel
+  --mention name      mention a user or agent; repeatable
+  --attach path       upload a local file and attach it; repeatable (max 25MB each)
+  --reply-to seq      attach this message as a reply to seq
+  --reach             show mention reachability even when not a TTY (agent loops)
+  --no-reach          never show mention reachability (also silences the warn line)
+  --require-wakeable  exit non-zero if any mentioned target is not auto-wakeable
+                      (the message is still sent; the warn line always prints)
+  --debug-auth        print resolved auth/config source to stderr`;
 
 // 附件上限与文件名规则与 worker 侧保持一致（#176）：本地先挡一刀，给出比服务端 413 更贴切的文案。
 const ATTACH_SIZE_LIMIT = 25 * 1024 * 1024;
@@ -332,21 +340,50 @@ export async function run(argv: string[]): Promise<number> {
   if (typeof result === "number") return result;
   const attachNote = input.attachPaths.length > 0 ? ` (+${input.attachPaths.length} attachment${input.attachPaths.length > 1 ? "s" : ""})` : "";
   console.log(`sent seq=${result.seq}${attachNote}`);
-  await showReach(auth.server, auth.token, parsed, input);
+  const { unreachable } = await showReach(auth.server, auth.token, parsed, input);
+  // #664：--require-wakeable 严格模式——目标不可唤醒时，消息照发（seq 已打），但用独立非零码退出，
+  // 让调用方能编程判定「派发未落地」。非严格模式永远返回 0（warning 只提示、不阻断）。
+  if (parsed.flags["require-wakeable"] === true && unreachable.length > 0) return EXIT_UNREACHABLE;
   return 0;
 }
 
-// 发送后的可达性反馈：@ 的目标现在能不能收到。默认仅交互终端下开（脚本/agent 循环不额外拉 presence），
-// --reach 强开、--no-reach 关。拉不到 presence 不影响已发成功（只是没这行提示）。
-async function showReach(server: string, token: string, parsed: Parsed, input: SendInput): Promise<void> {
-  const want =
+// 发送后的可达性反馈：@ 的目标现在能不能收到。
+// 两条独立输出：
+//  1) reach 行（→ @a ● online · @b ○ offline …）——锦上添花，默认仅交互终端下开，--reach 强开、--no-reach 关。
+//  2) #664 的 "warn:" 行——@ 目标既不在线也无活 wake 通道时的醒目非阻断告警。这是纠错信号而非装饰：
+//     出问题的正是非 TTY 的 agent 循环（reach 行不出，发送方零反馈）。故 warn 行默认常开（含非 TTY），
+//     仅 --no-reach 显式静默；--require-wakeable 时强制打出，好解释随后的非零退出。
+// 返回不可达目标名单，供 --require-wakeable 决定退出码。拉不到 presence 不影响已发成功（只是没这些提示）。
+async function showReach(
+  server: string,
+  token: string,
+  parsed: Parsed,
+  input: SendInput,
+): Promise<{ unreachable: string[] }> {
+  if (input.mentions.length === 0) return { unreachable: [] };
+  const requireWakeable = parsed.flags["require-wakeable"] === true;
+  const wantLine =
     parsed.flags.reach === true ? true : parsed.flags["no-reach"] === true ? false : Boolean(process.stdout.isTTY);
-  if (!want || input.mentions.length === 0) return;
+  // warn 行：--require-wakeable 强制开；否则默认开，仅 --no-reach 静默。
+  const wantWarn = requireWakeable ? true : parsed.flags["no-reach"] !== true;
+  if (!wantLine && !wantWarn) return { unreachable: [] };
+  let presence;
   try {
-    const presence = await fetchPresence(server, token, input.channel);
-    const now = Date.now();
-    console.error(formatReachLine(input.mentions.map((m) => reachOf(m, presence, now))));
+    presence = await fetchPresence(server, token, input.channel);
   } catch {
     /* 锦上添花：presence 拉取失败不报错，消息已发成功 */
+    return { unreachable: [] };
   }
+  const now = Date.now();
+  if (wantLine) console.error(formatReachLine(input.mentions.map((m) => reachOf(m, presence, now))));
+  const unreachable: string[] = [];
+  if (wantWarn) {
+    for (const mention of input.mentions) {
+      const u = unreachableOf(mention, presence, now);
+      if (u === null) continue;
+      console.error(formatUnreachable(u));
+      unreachable.push(u.name);
+    }
+  }
+  return { unreachable };
 }

--- a/cli/src/commands/who.ts
+++ b/cli/src/commands/who.ts
@@ -20,7 +20,10 @@ List who is in a channel, tiered by how you can reach them:
                                        or it was seen resuming after an @-mention
                 · wakeable unverified  self-declared serve/watch the server has NOT
                                        verified — may or may not actually wake up
-  ○ recent    seen lately, no wake layer; mention delivers, wake not guaranteed
+  ○ recent    seen lately, no wake layer; mention delivers, wake not guaranteed.
+              A "⚠ unreachable" tag flags the genuinely-dead subset: no live wake
+              channel AND stale — the mention only lands in history and will wake
+              no one (JSON: "unreachable":true). Prove otherwise: party wake test @name
 A "⏳ busy" tag means the target is serially handling a wake (e.g. a long run): it
 is reachable but a reply will be slow — an ask that times out means "busy", not
 "offline", so do not re-@ it. "N queued" shows how many wakes are already waiting.
@@ -35,7 +38,7 @@ session name), so mention the "@handle" shown here — not a UUID session name.
 Options:
   --channel C   read channel C instead of the bound channel
   --json        emit one JSON object per line
-                (name/kind/tier/wake/wake_unverified/busy/queue_depth/waiting_owner_count/current_task/task_started_at/heartbeat_at/activity/listening/runner_health/agent_session/account/handle/display_name/age_ms/read_seq)`;
+                (name/kind/tier/unreachable/wake/wake_unverified/busy/queue_depth/waiting_owner_count/current_task/task_started_at/heartbeat_at/activity/listening/runner_health/agent_session/account/handle/display_name/age_ms/read_seq)`;
 
 const STALE_MS = 60_000; // 与 DO presence 扫描一致
 const DEAD_MS = 14 * 24 * 60 * 60 * 1000; // 14 天没露面视为幽灵，不再列
@@ -56,6 +59,11 @@ interface Row {
   age_ms: number;
   connection_count?: number;
   read_seq?: number; // 读到的最大 seq（Phase 2）；无游标 = 不逐帧流式读，不标注
+  // #664：recent（○）档把「最近露过面、只是没保证唤醒」与「真·死了、@ 落历史无人应」混在一起，
+  // 误导人以为 recent = 还能叫醒。这里对真正不可达的子集单独标注：不在线 + 无活 wake 通道
+  // （offline + 无 wake layer / 适配器陈旧）+ 已陈旧（>STALE_MS）。判定同 send 侧 unreachableOf、
+  // 走 autoWakeReachable 权威口径。仅 recent 档、命中时带出；JSON 追加字段（向后兼容，不改旧字段）。
+  unreachable?: true;
   // 人为暂停接待（#180）：与 offline 视觉区分——不是「掉线丢了」，是「人主动按下暂停」。
   // 暂停期该 agent 被 @ 也不唤醒（webhook 不投、serve/watch 自我抑制），消息仍进历史。
   paused?: true;
@@ -114,6 +122,9 @@ export function classify(e: PresenceEntry, now: number): Row | null {
   // 即降级 recent；webhook 由服务端投递，仍可离线 wakeable。避免被 harness kill 的 watch --once 永久假在线。
   else if (wstate !== "offline" && wakeReachable && age <= DEAD_MS) tier = "wakeable";
   else tier = "recent";
+  // #664：recent 档里真正不可达的子集——不在线、不可自动唤醒、且已陈旧（>STALE_MS，非刚断线）。
+  // 与 send 侧 unreachableOf 同口径；只标 recent，别把「online/wakeable/刚断线」误标死。
+  const unreachable = tier === "recent" && !wakeReachable && age >= STALE_MS;
   if (tier !== "online") {
     // 暂停是人主动设的、有意保留的状态：不当人类/幽灵清掉，始终列出，让人看得见「谁被按了暂停」。
     if (!paused && kind === "human") return null; // 围观的人类只在线才列
@@ -123,6 +134,7 @@ export function classify(e: PresenceEntry, now: number): Row | null {
     name: e.name,
     kind,
     tier,
+    ...(unreachable ? { unreachable: true as const } : {}),
     ...(paused ? { paused: true as const, ...(typeof e.resume_at === "number" ? { resume_at: e.resume_at } : {}) } : {}),
     ...(wake === undefined ? {} : { wake }),
     // #191：可唤醒但未经服务端验证（自报的 serve/watch，服务端从没观测到它被 @ 后 resume）如实标注。
@@ -356,7 +368,9 @@ export async function run(argv: string[]): Promise<number> {
           ? ` · ${r.wake_unverified === true ? "unverified" : "verified"}${r.wake ? ` (${r.wake})` : ""}`
           : "";
       const age = r.tier === "online" ? "" : ` (${humanAge(r.age_ms)})`;
-      console.log(`${DOT[r.tier]} ${r.tier.padEnd(8)} ${r.name}  [${r.kind}]${identityNote(r)}${busyNote(r)}${waitingOwnerNote(r)}${taskNote(r, now)}${activityNote(r, now)}${livenessNote(r)}${sessionNote(r)}${wake}${read}${duplicate}${age}`);
+      // #664：recent 档里真·不可达的（无活 wake 通道 + 陈旧）单独标出，别和「最近露面、或许在轮询」混淆。
+      const unreach = r.unreachable === true ? " · ⚠ unreachable (mention lands in history only)" : "";
+      console.log(`${DOT[r.tier]} ${r.tier.padEnd(8)} ${r.name}  [${r.kind}]${identityNote(r)}${busyNote(r)}${waitingOwnerNote(r)}${taskNote(r, now)}${activityNote(r, now)}${livenessNote(r)}${sessionNote(r)}${wake}${unreach}${read}${duplicate}${age}`);
     }
     return 0;
   } catch (e) {

--- a/cli/src/reach.ts
+++ b/cli/src/reach.ts
@@ -63,6 +63,64 @@ export function formatReachLine(rs: Reachability[]): string {
   return "→ " + rs.map(formatReach).join("  ·  ");
 }
 
+// #664：`--mention X` 时 X 既不在线也无活 wake 通道——@ 只落进历史、永远不会唤醒任何人。发送方
+// 之前对此零反馈（reach 行仅在 TTY/--reach 下出，agent 循环里静默）。这里给一个独立的、非阻断的
+// 「不可达」判定，供 send 在 stderr 打醒目 warning，并支撑 --require-wakeable 的非零退出。
+// 判定严格镜像 reachOf/who.classify 的 online / wakeable 门限（同 autoWakeReachable 权威口径），
+// 只对「不在线 + 不可自动唤醒 + 已陈旧」的目标告警，避免误伤刚断线（<STALE_MS）或在线的目标。
+export interface Unreachable {
+  name: string;
+  // 距最近一次露面的毫秒；无 last_seen/ts 时为 null（几乎不出现，presence 行通常带 ts）。
+  ageMs: number | null;
+  // 声明的 wake 类型（用于文案区分「压根没 wake 通道」与「适配器陈旧」）；缺省即无。
+  wake?: WakeKind;
+  // no_wake：wake=none/缺失，压根没有唤醒路径；stale_adapter：声明了 serve/watch 但心跳陈旧（supervisor 大概率已死）。
+  reason: "no_wake" | "stale_adapter";
+}
+
+// 返回该 @ 目标的不可达详情，或 null（在线 / 可自动唤醒 / 刚断线未过 STALE / 不在 presence / 人类）。
+// 不在 presence：#663 已让服务端硬校验显式 --mention 名字，走到这里名字必然合法；缺 presence 行
+// 说明该身份从未在频道露面，无可靠信号，从简不告警。人类会话异步看通知，@ 离线人类不算「白发」，跳过。
+export function unreachableOf(name: string, presence: PresenceEntry[], now: number): Unreachable | null {
+  const e = presence.find((p) => p.name === name);
+  if (e === undefined) return null;
+  if (e.kind === "human") return null;
+  const seen = e.last_seen ?? e.ts ?? 0;
+  const age = now - seen;
+  // online：与 reachOf/who 一致——当前有活 WS 连接（live）或新鲜即视为在线，@ 直达，不告警。
+  if (e.state !== "offline" && (e.live === true || age < STALE_MS)) return null;
+  // 可自动唤醒且未越幽灵线：webhook 服务端投递、或 serve/watch 心跳新鲜 → 叫得醒，不告警。
+  if (e.wake?.kind !== undefined && autoWakeReachable(e, now, STALE_MS) && age <= DEAD_MS) return null;
+  // 刚断线（<STALE_MS）：给一个宽限，可能马上重连，先不判死。
+  if (age < STALE_MS) return null;
+  const wake = e.wake?.kind;
+  const reason: Unreachable["reason"] = wake === undefined || wake === "none" ? "no_wake" : "stale_adapter";
+  return { name, ageMs: seen > 0 ? age : null, ...(wake !== undefined ? { wake } : {}), reason };
+}
+
+// 紧凑的时龄文案：45m / 88h / 15d，用于 warning 里的 last_seen 提示。刻意把「小时」一路显示到 10 天，
+// 因为「88h」比「3d」更能让发送方一眼感到「死太久了」（issue #664 的原始诉求就用小时表达陈旧）。
+function ageText(ageMs: number | null): string {
+  if (ageMs === null) return "last_seen unknown";
+  const s = Math.floor(ageMs / 1000);
+  if (s < 60) return `last_seen ${s}s ago`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `last_seen ${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 240) return `last_seen ${h}h ago`;
+  return `last_seen ${Math.floor(h / 24)}d ago`;
+}
+
+// stderr 上打的一行非阻断 warning。示意：
+//   warn: kyc-claude has no live wake channel (last_seen 88h ago) — mention delivered to history only; run 'party wake test @kyc-claude' to verify
+export function formatUnreachable(u: Unreachable): string {
+  const what =
+    u.reason === "stale_adapter"
+      ? `${u.name}'s ${u.wake ?? "wake"} adapter looks dead`
+      : `${u.name} has no live wake channel`;
+  return `warn: ${what} (${ageText(u.ageMs)}) — mention delivered to history only; run 'party wake test @${u.name}' to verify`;
+}
+
 // ask 超时提示（#103）：party ask 委托 watch，超时只吐裸 TIMEOUT，看不出对方是「忙」还是「失联」。
 // 用 reachOf 查被 @ 的目标此刻是否仍标 busy（serve 正串行处理一条 wake）：若有，返回一行富提示，
 // 让调用方把超时当「忙、回复慢」而非「离线」，别反复 @ 堆重复唤醒。无 busy 目标返回 null，

--- a/cli/test/reach.test.ts
+++ b/cli/test/reach.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { applyLiveConnection, type PresenceEntry } from "@agentparty/shared";
-import { busyTimeoutHint, formatReach, formatReachLine, reachOf } from "../src/reach";
+import { busyTimeoutHint, formatReach, formatReachLine, formatUnreachable, reachOf, unreachableOf } from "../src/reach";
+
+const HOUR = 60 * 60 * 1000;
 
 const NOW = 1_000_000_000;
 
@@ -160,6 +162,71 @@ describe("busyTimeoutHint (#103)", () => {
 
   test("目标离线（查不到）→ null，不无中生有", () => {
     expect(busyTimeoutHint(["ghost"], [], NOW)).toBeNull();
+  });
+});
+
+// #664：@ 目标既不在线也无活 wake 通道 → 只落历史、不会唤醒任何人。send 据此打非阻断 warn，
+// 并支撑 --require-wakeable 的非零退出。判定严格镜像 reachOf 的 online/wakeable 门限。
+describe("unreachableOf (#664)", () => {
+  test("offline + no wake layer + stale (88h) → no_wake, carries age", () => {
+    const u = unreachableOf("kyc-claude", [p({ name: "kyc-claude", state: "offline", wake: { kind: "none" }, last_seen: NOW - 88 * HOUR })], NOW);
+    expect(u).not.toBeNull();
+    expect(u?.reason).toBe("no_wake");
+    expect(u?.ageMs).toBe(88 * HOUR);
+  });
+
+  test("offline with no wake field at all + stale → no_wake", () => {
+    const u = unreachableOf("bot", [p({ name: "bot", state: "offline", last_seen: NOW - 10 * HOUR })], NOW);
+    expect(u?.reason).toBe("no_wake");
+  });
+
+  test("stale serve/watch adapter (13m, supervisor dead) → stale_adapter, carries wake kind", () => {
+    const serve = unreachableOf("bot", [p({ name: "bot", state: "offline", wake: { kind: "serve" }, last_seen: NOW - 780_000 })], NOW);
+    expect(serve?.reason).toBe("stale_adapter");
+    expect(serve?.wake).toBe("serve");
+  });
+
+  test("online (fresh) → null, never warns on a connected target even with no wake layer", () => {
+    expect(unreachableOf("bot", [p({ name: "bot", wake: { kind: "none" } })], NOW)).toBeNull();
+  });
+
+  test("live connection short-circuits freshness → null even if last_seen stale", () => {
+    // 服务端 applyLiveConnection 会把有活连接的行 state 从 offline 提升为 waiting，所以真实 presence 里
+    // live=true 必伴随非 offline state；此时当在线处理，@ 直达，不告警。
+    expect(unreachableOf("bot", [p({ name: "bot", state: "waiting", wake: { kind: "none" }, live: true, last_seen: NOW - 88 * HOUR })], NOW)).toBeNull();
+  });
+
+  test("auto-wakeable webhook (offline) → null, mention truly wakes it", () => {
+    expect(unreachableOf("hook", [p({ name: "hook", state: "offline", wake: { kind: "webhook" }, last_seen: NOW - 2 * HOUR })], NOW)).toBeNull();
+  });
+
+  test("fresh serve → null (supervisor alive)", () => {
+    expect(unreachableOf("bot", [p({ name: "bot", state: "offline", wake: { kind: "serve" } })], NOW)).toBeNull();
+  });
+
+  test("just disconnected (< STALE_MS) with no wake → null: grace before calling it dead", () => {
+    expect(unreachableOf("bot", [p({ name: "bot", state: "offline", wake: { kind: "none" }, last_seen: NOW - 30_000 })], NOW)).toBeNull();
+  });
+
+  test("offline human → null: @-ing a human is async notify, not a broken wake", () => {
+    expect(unreachableOf("leo", [p({ name: "leo", kind: "human", state: "offline", wake: { kind: "none" }, last_seen: NOW - 88 * HOUR })], NOW)).toBeNull();
+  });
+
+  test("not in presence at all → null: name already server-validated (#663), no reliable signal", () => {
+    expect(unreachableOf("ghost", [], NOW)).toBeNull();
+  });
+
+  test("format: no_wake line names the target, age, and the wake-test remedy (issue #664 shape)", () => {
+    const line = formatUnreachable({ name: "kyc-claude", ageMs: 88 * HOUR, reason: "no_wake" });
+    expect(line).toContain("kyc-claude has no live wake channel");
+    expect(line).toContain("last_seen 88h ago");
+    expect(line).toContain("mention delivered to history only");
+    expect(line).toContain("party wake test @kyc-claude");
+  });
+
+  test("format: stale_adapter line names the adapter kind", () => {
+    const line = formatUnreachable({ name: "bot", ageMs: 13 * 60 * 1000, reason: "stale_adapter", wake: "serve" });
+    expect(line).toContain("bot's serve adapter looks dead");
   });
 });
 

--- a/cli/test/send-wakeability.test.ts
+++ b/cli/test/send-wakeability.test.ts
@@ -1,0 +1,117 @@
+// #664：party send --mention 目标不可唤醒时，发送方要拿到非阻断 warning（消息仍发成功），
+// --require-wakeable 则在发送后非零退出。端到端跑真 CLI（spawn = 非 TTY，正是出问题的 agent 循环场景），
+// 用 rest-mock 供 presence + messages。EXIT_UNREACHABLE=10 是「已发出但没落地」的独立退出码。
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { EXIT_UNREACHABLE, type PresenceEntry } from "@agentparty/shared";
+import { startRestMock, type RestMock } from "./rest-mock";
+
+const indexPath = join(import.meta.dir, "..", "src", "index.ts");
+const HOUR = 60 * 60 * 1000;
+
+let home: string;
+let configPath: string;
+let restMock: RestMock | null = null;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "ap-send-wake-"));
+  configPath = join(home, "config.json");
+});
+
+afterEach(() => {
+  restMock?.stop();
+  restMock = null;
+  rmSync(home, { recursive: true, force: true });
+});
+
+function writeCfg(server: string, token = "ap_tok") {
+  mkdirSync(dirname(configPath), { recursive: true });
+  writeFileSync(configPath, JSON.stringify({ server, token }, null, 2) + "\n");
+}
+
+// presence 用真实 now 相对时刻（CLI 子进程按 Date.now() 判新鲜度）。
+function presenceMock(entries: (Partial<PresenceEntry> & { name: string })[]): RestMock {
+  return startRestMock((req) => {
+    if (req.method === "GET" && /^\/api\/channels\/[^/]+\/presence$/.test(req.path)) {
+      const now = Date.now();
+      const presence = entries.map((e) => ({
+        state: "offline",
+        note: null,
+        ts: now - 88 * HOUR,
+        last_seen: now - 88 * HOUR,
+        kind: "agent" as const,
+        ...e,
+      }));
+      return Response.json({ presence });
+    }
+    return undefined; // messages POST 走默认 { seq: 1 }
+  });
+}
+
+async function runCli(args: string[]): Promise<{ code: number; stdout: string; stderr: string }> {
+  const proc = Bun.spawn(["bun", "run", indexPath, ...args], {
+    env: { ...process.env, AGENTPARTY_CONFIG: configPath, AGENTPARTY_HOME: home },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, code] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { code, stdout, stderr };
+}
+
+describe("party send --mention wakeability warning (#664)", () => {
+  test("no-wake + stale target → non-blocking warn on stderr, message still sent, exit 0", async () => {
+    restMock = presenceMock([{ name: "kyc-claude", wake: { kind: "none" } }]);
+    writeCfg(restMock.url);
+    const r = await runCli(["send", "dispatch P0 fix", "--channel", "kyc", "--mention", "kyc-claude"]);
+    expect(r.code).toBe(0); // 非阻断：消息发成功
+    expect(r.stdout).toContain("sent seq="); // 消息确实发出去了
+    expect(r.stderr).toContain("warn:");
+    expect(r.stderr).toContain("kyc-claude has no live wake channel");
+    expect(r.stderr).toContain("party wake test @kyc-claude");
+  });
+
+  test("wakeable target (webhook) → no warn line, exit 0", async () => {
+    restMock = presenceMock([{ name: "hook-bot", wake: { kind: "webhook" }, last_seen: Date.now() - 2 * HOUR, ts: Date.now() - 2 * HOUR }]);
+    writeCfg(restMock.url);
+    const r = await runCli(["send", "ping", "--channel", "dev", "--mention", "hook-bot"]);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain("sent seq=");
+    expect(r.stderr).not.toContain("warn:");
+    expect(r.stderr).not.toContain("has no live wake channel");
+  });
+
+  test("--require-wakeable + unreachable target → exit EXIT_UNREACHABLE, message still sent", async () => {
+    restMock = presenceMock([{ name: "kyc-claude", wake: { kind: "none" } }]);
+    writeCfg(restMock.url);
+    const r = await runCli(["send", "dispatch P0 fix", "--channel", "kyc", "--mention", "kyc-claude", "--require-wakeable"]);
+    expect(r.code).toBe(EXIT_UNREACHABLE);
+    expect(r.code).not.toBe(0);
+    expect(r.stdout).toContain("sent seq="); // 消息仍发成功（严格模式只影响退出码）
+    expect(r.stderr).toContain("has no live wake channel");
+    // 消息确实 POST 到服务端了
+    expect(restMock.requests.some((q) => q.method === "POST" && /\/messages$/.test(q.path))).toBe(true);
+  });
+
+  test("--require-wakeable + wakeable target → exit 0", async () => {
+    restMock = presenceMock([{ name: "hook-bot", wake: { kind: "webhook" }, last_seen: Date.now() - 2 * HOUR, ts: Date.now() - 2 * HOUR }]);
+    writeCfg(restMock.url);
+    const r = await runCli(["send", "ping", "--channel", "dev", "--mention", "hook-bot", "--require-wakeable"]);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain("sent seq=");
+  });
+
+  test("--no-reach silences the warn line (message still sent, exit 0)", async () => {
+    restMock = presenceMock([{ name: "kyc-claude", wake: { kind: "none" } }]);
+    writeCfg(restMock.url);
+    const r = await runCli(["send", "dispatch", "--channel", "kyc", "--mention", "kyc-claude", "--no-reach"]);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain("sent seq=");
+    expect(r.stderr).not.toContain("warn:");
+  });
+});

--- a/cli/test/who.test.ts
+++ b/cli/test/who.test.ts
@@ -60,6 +60,44 @@ describe("who classify（#47：可唤醒判定按 wake.kind 分口径）", () =>
   });
 });
 
+// #664：recent 档把「最近露面、或许在轮询」和「真·死了、@ 落历史无人应」混在一起，误导人以为 recent = 还能叫醒。
+// 对后者（无活 wake 通道 + 陈旧）单独标 unreachable，让人一眼看清「@ 它白发」。
+describe("who classify recent unreachable 标注（#664）", () => {
+  test("offline + 无 wake layer + 陈旧(88h) → recent 且 unreachable", () => {
+    const r = classify(p({ name: "kyc-claude", state: "offline", wake: { kind: "none" }, last_seen: NOW - 88 * 60 * 60 * 1000 }), NOW);
+    expect(r?.tier).toBe("recent");
+    expect(r?.unreachable).toBe(true);
+  });
+
+  test("陈旧的 serve（supervisor 已死）→ recent 且 unreachable（无活 wake 通道）", () => {
+    const r = classify(p({ name: "bot", state: "offline", wake: { kind: "serve" }, last_seen: NOW - 780_000 }), NOW);
+    expect(r?.tier).toBe("recent");
+    expect(r?.unreachable).toBe(true);
+  });
+
+  test("fresh 的 serve → wakeable，不标 unreachable", () => {
+    const r = classify(p({ name: "bot", state: "offline", wake: { kind: "serve" } }), NOW);
+    expect(r?.tier).toBe("wakeable");
+    expect(r?.unreachable).toBeUndefined();
+  });
+
+  test("offline webhook → wakeable，不标 unreachable（服务端投递真能唤醒）", () => {
+    const r = classify(p({ name: "hook", state: "offline", wake: { kind: "webhook" }, last_seen: NOW - 2 * 60 * 60 * 1000 }), NOW);
+    expect(r?.tier).toBe("wakeable");
+    expect(r?.unreachable).toBeUndefined();
+  });
+
+  test("online → 不标 unreachable", () => {
+    expect(classify(p({ name: "bob" }), NOW)?.unreachable).toBeUndefined();
+  });
+
+  test("刚断线(<STALE_MS)且无 wake → recent 但不急着判死，不标 unreachable", () => {
+    const r = classify(p({ name: "bot", state: "offline", wake: { kind: "none" }, last_seen: NOW - 30_000 }), NOW);
+    expect(r?.tier).toBe("recent");
+    expect(r?.unreachable).toBeUndefined();
+  });
+});
+
 describe("who classify 暂停接待（#180：paused 与 offline 视觉/语义区分）", () => {
   test("被暂停的 agent 带出 paused + resume_at，供 who 独立渲染", () => {
     const r = classify(p({ name: "bot", state: "waiting", paused: true, resume_at: NOW + 3_600_000 }), NOW);

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -172,6 +172,10 @@ export const EXIT_WORKFLOW_GUARD = 8;
 // 速率限制（429，issue #122）：退避后再试，别立刻连打。
 // 之前同样塌缩成 exit 1，agent 无从判断该等还是该停。
 export const EXIT_RATE_LIMITED = 9;
+// send --mention --require-wakeable（issue #664）：消息已成功发出，但至少一个被 @ 的目标既不在线、
+// 也无活的 wake 通道（离线 + 无 wake layer / 适配器陈旧），@ 只落进历史、不会唤醒任何人。严格模式下
+// 用独立非零码让调用方能编程判定「派发未落地」，而不是把成功发送误当完全失败（消息确实发出去了）。
+export const EXIT_UNREACHABLE = 10;
 
 // ---- 基础类型 ----
 


### PR DESCRIPTION
> ⚠️ **Stacked PR**,base = `fix/663-mention-explicit-vs-body`(PR #673)。**先合 #663**,本 PR base 会自动改指 main。

## 背景
Closes #664。`party send --mention X` 若 X 无 wake adapter / 已离线,只打印 `sent seq=`,发送方零反馈——mention 只进 history 永不被处理(真实案例:目标 watcher 死了 88h,派的 P0 任务石沉大海)。

## 修法(纯 CLI,不动协议/worker)
- `cli/reach.ts`:新增 `unreachableOf()`——复用**权威** `autoWakeReachable`,严格镜像 `reachOf`/`who.classify` 的 online/wakeable 判定:目标既非在线、又不可自动唤醒、且陈旧(>60s)才判死;跳过 human(异步通知)与 presence 中不存在的名字。
- `cli/send.ts`:**扩展现有 `--reach` 路径**(非重复),在装饰性 reach 行之外,对真正不可达的目标向 stderr 打**非阻断 `warn:` 行**;新增 `--require-wakeable`(发送成功后以 `EXIT_UNREACHABLE=10` 退出);更新 HELP。warn 行默认对非 TTY 也开(#664 的真实故障就是 agent 非 TTY 发送拿不到反馈),`--no-reach` 静默。
- `cli/who.ts`:把 `recent`(○)里真正死掉的子集标 ` · ⚠ unreachable`,JSON 加向后兼容字段 `unreachable: true`(仅为真时加,不改名)。
- `shared/protocol.ts`:加 `EXIT_UNREACHABLE = 10`(与其它 `EXIT_*` 并列,无 wire 改动)。

## 测试(全绿)
- CLI 全套 **1022 pass / 0 fail**;tsc 清。
- 新增 `send-wakeability.test.ts` E2E:no-wake+stale → stderr warn + `sent seq=` + exit 0;webhook 可唤醒 → 无 warn;`--require-wakeable`+不可达 → exit 10 但消息已发;`--no-reach` 静默;`who` 标注 unreachable 子集。

🤖 由 agent 在隔离 worktree 实现(基于 #663),人工审 diff 后提交。