### PR TITLE
fix(onboarding): 接入包默认用 AGENTPARTY_TOKEN 环境变量,不再把 token 明文放 argv (#676)

### DIFF
--- a/cli/src/commands/agent.ts
+++ b/cli/src/commands/agent.ts
@@ -84,7 +84,10 @@ export async function run(argv: string[]): Promise<number> {
       const res = await createAgent(account.server, account.token, name, channelScope);
       // 明文 token 只出现这一次
       console.log(JSON.stringify(res));
-      console.error(`give it to the agent: party init --server ${account.server} --token ${res.token}`);
+      // token 走 AGENTPARTY_TOKEN 环境变量传入，不进 argv：同机任意用户 `ps -axww` 看不到它（#676）。
+      console.error(
+        `give it to the agent (token via env, not argv): AGENTPARTY_TOKEN='${res.token}' party init --server ${account.server}`,
+      );
       return 0;
     }
 

--- a/cli/src/commands/invite.ts
+++ b/cli/src/commands/invite.ts
@@ -196,7 +196,7 @@ party send "👋 ${guestName} 报到，来参与协作" --channel ${slug} --ment
       const watchToken = shareToken;
       const initLine =
         watchToken !== null
-          ? `party init --server ${server} --token ${watchToken} --channel ${slug}`
+          ? `AGENTPARTY_TOKEN='${watchToken}' party init --server ${server} --channel ${slug}`
           : `# 该频道的只读分享 token 已存在，明文无法重现——沿用已分发的 ${shareName} 链接，或先手动撤销再重发邀请`;
       console.log(`${packHeader("观看模式 (watch · readonly)")}
 
@@ -212,7 +212,7 @@ export PATH="\$HOME/.local/bin:\$PATH"
 # 2) 隔离本地配置（同机多身份不串号；必须放持久目录，TMPDIR 清理会抹掉身份和 cursor）
 export AGENTPARTY_CONFIG="$HOME/.agentparty/agents/agentparty-${shareName}-${slug}.json"
 
-# 3) 绑定频道（readonly token，只出现这一次）
+# 3) 绑定频道（readonly token，只出现这一次；走 AGENTPARTY_TOKEN 环境变量传入，不进 argv/ps）
 ${initLine}
 
 # 4) 怎么围观（观看模式只读，不能 send）：
@@ -249,7 +249,9 @@ export AGENTPARTY_CONFIG="$HOME/.agentparty/agents/agentparty-${guestName}-${slu
 #   AGENTPARTY_CONFIG="$HOME/.agentparty/agents/agentparty-${guestName}-${slug}.json" party send ... 前缀内联。
 
 # 3) 绑定频道 + 报到（token 只出现这一次；报到不能省，否则网页看不到你）
-party init --server ${server} --token ${guest.token} --channel ${slug}
+#    token 走 AGENTPARTY_TOKEN 环境变量传入，不写进 argv：同机任意用户 \`ps -axww\` 看不到它。
+#    最严格可改从 stdin 读：printf '%s' '<token>' | party init --server ${server} --token - --channel ${slug}
+AGENTPARTY_TOKEN='${guest.token}' party init --server ${server} --channel ${slug}
 ${checkinLines}
 
 # 4) 把 AgentParty MCP server 注册进你的 harness，之后频道操作优先用 party_* 工具

--- a/cli/test/__snapshots__/m3.test.ts.snap
+++ b/cli/test/__snapshots__/m3.test.ts.snap
@@ -31,7 +31,9 @@ export AGENTPARTY_CONFIG="$HOME/.agentparty/agents/agentparty-fix-login-bug-gues
 #   AGENTPARTY_CONFIG="$HOME/.agentparty/agents/agentparty-fix-login-bug-guest-fix-login-bug.json" party send ... 前缀内联。
 
 # 3) 绑定频道 + 报到（token 只出现这一次；报到不能省，否则网页看不到你）
-party init --server https://party.example --token ap_fix-login-bug-guest_secret --channel fix-login-bug
+#    token 走 AGENTPARTY_TOKEN 环境变量传入，不写进 argv：同机任意用户 \`ps -axww\` 看不到它。
+#    最严格可改从 stdin 读：printf '%s' '<token>' | party init --server https://party.example --token - --channel fix-login-bug
+AGENTPARTY_TOKEN='ap_fix-login-bug-guest_secret' party init --server https://party.example --channel fix-login-bug
 party send "👋 fix-login-bug-guest 报到，来参与协作" --channel fix-login-bug
 
 # 4) 把 AgentParty MCP server 注册进你的 harness，之后频道操作优先用 party_* 工具

--- a/cli/test/invite-mode.test.ts
+++ b/cli/test/invite-mode.test.ts
@@ -69,7 +69,9 @@ describe("party invite --mode", () => {
     expect(r.code).toBe(0);
     // a readonly token was minted and it is the one the invitee inits with
     expect(minted.some((m) => m.role === "readonly")).toBe(true);
-    expect(r.stdout).toMatch(/party init .*--token ap_readonly/);
+    // #676：token 走 AGENTPARTY_TOKEN 环境变量，不写进 argv——可拷贝命令里不得再有明文 `--token ap`
+    expect(r.stdout).toMatch(/AGENTPARTY_TOKEN='ap_readonly\d*' party init --server .* --channel watchroom/);
+    expect(r.stdout).not.toContain("--token ap_readonly");
     const watchGuardIndex = r.stdout.indexOf("AgentParty onboarding scope: join the existing channel #watchroom");
     expect(watchGuardIndex).toBeGreaterThan(-1);
     expect(watchGuardIndex).toBeLessThan(r.stdout.indexOf("party init "));
@@ -85,7 +87,8 @@ describe("party invite --mode", () => {
     const r = await runInvite(["Part Room", "--slug", "partroom", "--mode", "participate", "--server", server]);
     expect(r.code).toBe(0);
     expect(minted.some((m) => m.role === "agent")).toBe(true);
-    expect(r.stdout).toMatch(/party init .*--token ap_agenttok/);
+    expect(r.stdout).toMatch(/AGENTPARTY_TOKEN='ap_agenttok\d*' party init --server .* --channel partroom/);
+    expect(r.stdout).not.toContain("--token ap_agenttok");
     const participateGuardIndex = r.stdout.indexOf("AgentParty onboarding scope: join the existing channel #partroom");
     expect(participateGuardIndex).toBeGreaterThan(-1);
     expect(participateGuardIndex).toBeLessThan(r.stdout.indexOf("party init "));
@@ -98,7 +101,8 @@ describe("party invite --mode", () => {
     const server = startRest();
     const r = await runInvite(["Def Room", "--slug", "defroom", "--server", server]);
     expect(r.code).toBe(0);
-    expect(r.stdout).toMatch(/party init .*--token ap_agenttok/);
+    expect(r.stdout).toMatch(/AGENTPARTY_TOKEN='ap_agenttok\d*' party init --server .* --channel defroom/);
+    expect(r.stdout).not.toContain("--token ap_agenttok");
     expect(r.stdout).toMatch(/party send .*报到/);
   });
 

--- a/cli/test/m3.test.ts
+++ b/cli/test/m3.test.ts
@@ -106,9 +106,11 @@ describe("party invite", () => {
     expect(chanReq.headers.authorization).toBe("Bearer ap_fix-login-bug-guest_secret");
 
     // 接入包内容可整段粘贴
+    // #676：token 走 AGENTPARTY_TOKEN 环境变量传入，不写进 argv——可拷贝命令里不得再出现明文 `--token ap`
     expect(r.stdout).toContain(
-      `party init --server ${mock.url} --token ap_fix-login-bug-guest_secret --channel fix-login-bug`,
+      `AGENTPARTY_TOKEN='ap_fix-login-bug-guest_secret' party init --server ${mock.url} --channel fix-login-bug`,
     );
+    expect(r.stdout).not.toContain("--token ap_fix-login-bug-guest_secret");
     const scopeGuardIndex = r.stdout.indexOf("AgentParty onboarding scope: join the existing channel #fix-login-bug");
     const initIndex = r.stdout.indexOf("party init --server");
     expect(scopeGuardIndex).toBeGreaterThan(-1);
@@ -218,7 +220,8 @@ describe("party invite", () => {
       visibility: "private",
     });
     expect(r.stdout).toContain("(temp · party)");
-    expect(r.stdout).toContain("--token ap_bob_secret --channel hotfix");
+    expect(r.stdout).toContain(`AGENTPARTY_TOKEN='ap_bob_secret' party init --server ${mock.url} --channel hotfix`);
+    expect(r.stdout).not.toContain("--token ap_bob_secret");
   });
 
   test("--owner 覆盖默认标签，写在 guest agent 与 share readonly 两个 token 上", async () => {

--- a/web/src/components/AgentTokens.copypack.test.tsx
+++ b/web/src/components/AgentTokens.copypack.test.tsx
@@ -175,8 +175,9 @@ describe("AgentTokens copy join pack (#584)", () => {
     expect(pack).toContain(`need=${realVault.MIN_CLI}; have=`);
     expect(pack).toContain('AGENTPARTY_CONFIG="$HOME/.agentparty/agents/agentparty-legacy-bot-demo.json"');
     expect(pack).toContain("claude mcp add party-legacy-bot --env");
-    expect(pack).toContain("--token ap_old_token");
-    expect(pack).toContain("party init --server https://party.example");
+    // #676：token 走 AGENTPARTY_TOKEN 环境变量传入，不写进 argv——可拷贝命令里不得再有明文 `--token ap`
+    expect(pack).toContain("AGENTPARTY_TOKEN='ap_old_token' party init --server https://party.example");
+    expect(pack).not.toContain("--token ap_old_token");
     // ……而且是与「＋ 让 agent 加入」同构的【完整包】：charter 快照 + 待命/唤醒指引 + 参与指引，
     // 不是只有 init/check-in 的最小包（否则新 agent 报到完就不知道怎么挂 watch/serve）。
     expect(pack).toContain("# read the pinned rules before posting");

--- a/web/src/lib/agentTokenVault.test.ts
+++ b/web/src/lib/agentTokenVault.test.ts
@@ -16,6 +16,9 @@ describe("buildMinimalAgentCommand", () => {
       'export AGENTPARTY_CONFIG="$HOME/.agentparty/agents/agentparty-desktop-worker-release-room.json"',
     );
     expect(command).not.toContain("TMPDIR");
+    // #676：token 走 AGENTPARTY_TOKEN 环境变量传入，不写进 argv——命令里不得再出现明文 `--token ap`
+    expect(command).toContain("AGENTPARTY_TOKEN='ap_fixture' party init --server https://agentparty.example.com");
+    expect(command).not.toContain("--token ap_fixture");
     const guardIndex = command.indexOf("AgentParty onboarding scope: join the existing channel #release-room");
     expect(guardIndex).toBeGreaterThan(-1);
     expect(guardIndex).toBeLessThan(command.indexOf("party init "));
@@ -122,8 +125,9 @@ describe("buildMinimalAgentCommand", () => {
     });
 
     expect(command).toContain(
-      "party init --server https://agentparty.leeguoo.com --token ap_fixture --channel demo",
+      "AGENTPARTY_TOKEN='ap_fixture' party init --server https://agentparty.leeguoo.com --channel demo",
     );
+    expect(command).not.toContain("--token ap_fixture");
     expect(command).not.toContain("tauri://localhost");
   });
 });

--- a/web/src/lib/agentTokenVault.ts
+++ b/web/src/lib/agentTokenVault.ts
@@ -121,7 +121,9 @@ export function buildMinimalAgentCommand(input: {
     VERSION_GE_SNIPPET,
     `need=${MIN_CLI}; have="$(party --version 2>/dev/null || echo 0)"; version_ge "$have" "$need" || curl -fsSL https://raw.githubusercontent.com/leeguooooo/agentparty/main/install.sh | sh`,
     `export AGENTPARTY_CONFIG="${configPath}"`,
-    `party init --server ${input.server} --token ${input.token} --channel ${input.slug}`,
+    // #676: pass the token via AGENTPARTY_TOKEN (env), never in argv — `ps -axww` can't see it and it
+    // doesn't trip party init's own "--token leaks into argv/history" warning (strictest: `--token -` via stdin).
+    `AGENTPARTY_TOKEN='${input.token}' party init --server ${input.server} --channel ${input.slug}`,
     checkin,
     "# Register the AgentParty MCP server with your harness, then use the party_* tools (party_send / party_status / party_history / party_decision_ask ...) for all channel actions — they carry your identity automatically, no AGENTPARTY_CONFIG prefix needed per command:",
     `claude mcp add ${mcpName} --env AGENTPARTY_CONFIG="${configPath}" -- party mcp --channel ${input.slug}`,

--- a/web/src/lib/joinPack.ts
+++ b/web/src/lib/joinPack.ts
@@ -80,7 +80,9 @@ export function buildFullJoinPack(input: FullJoinPackInput): string {
     t("AgentJoin.cmd.turnWarn4", { agentName, slug }),
     ``,
     t("AgentJoin.cmd.step3"),
-    `party init --server ${server} --token ${agentToken} --channel ${slug}`,
+    // #676：token 走 AGENTPARTY_TOKEN 环境变量传入，不写进 argv——同机任意用户 `ps -axww` 看不到它，
+    // 也不触发 party init 自身「--token 会进 argv/history」的告警（最严格可改 `--token -` 从 stdin 读）。
+    `AGENTPARTY_TOKEN='${agentToken}' party init --server ${server} --channel ${slug}`,
     inviterName === null ? t("AgentJoin.cmd.step3noteNoMention", { slug }) : t("AgentJoin.cmd.step3note"),
     inviterName === null
       ? `party send "${t("AgentJoin.cmd.checkinMessage", { agentName })}" --channel ${slug}`
@@ -153,7 +155,8 @@ export function buildUnattendedJoinPack(input: FullJoinPackInput): string {
     t("AgentJoin.ua.step2"),
     `mkdir -p "$HOME/.agentparty/agents"`,
     `export AGENTPARTY_CONFIG="$HOME/.agentparty/agents/agentparty-${agentName}-${slug}.json"`,
-    `party init --server ${server} --token ${agentToken} --channel ${slug}`,
+    // #676：token 走 AGENTPARTY_TOKEN 环境变量传入，不写进 argv（同机 `ps -axww` 看不到），也不触发 CLI 自身告警。
+    `AGENTPARTY_TOKEN='${agentToken}' party init --server ${server} --channel ${slug}`,
     inviterName === null
       ? `party send "${t("AgentJoin.ua.checkinMessage", { agentName })}" --channel ${slug}`
       : `party send "${t("AgentJoin.ua.checkinMessage", { agentName })}" --channel ${slug} --mention ${inviterName}`,


### PR DESCRIPTION
## 背景
Closes #676。官方接入包教 `party init … --token ap_xxx`,但 `party init` 自己会告警该用法把 token 泄进 argv(`ps -axww`)与 shell history——**官方接入包正好触发 CLI 自己的安全告警**,还真的泄露长期有效的频道 token。

## 修法
所有生成接入包的出口改为**token 走 `AGENTPARTY_TOKEN` 环境变量**(不进 argv):
```
AGENTPARTY_TOKEN='ap_xxx' party init --server … --channel …
```
- `cli/invite.ts`(participate + watch 两种模式)、`cli/agent.ts`(agent add 交接提示)、`web/joinPack.ts`(网页接入包/无人值守包)、`web/agentTokenVault.ts`(桌面最小包/vault 复制)。
- 注释说明 token 走 env 不进 argv,并给出最严格的 `--token -` stdin 形式。
- 用**一次性 env 前缀**(非 `export`),token 只出现一次、不残留进 shell 环境,与 spawn.ts(#111)既有安全姿势一致。
- 已核实 `party init` 读 `AGENTPARTY_TOKEN`(`resolveTokenInput`,优先级 --token > env > config),无需额外接线。
- `skills/agentparty/SKILL.md` 本就教 env/stdin 安全形式,无需改。

## 测试
- 更新 `invite-mode` / `m3`(含快照)/ `AgentTokens.copypack` / `agentTokenVault` 测试断言 env-var 形式,并加 `not.toContain("--token ap…")` 防明文写法回潮。
- cli 999 pass;web(--isolate)37 pass;shared/cli/web typecheck 全过。

🤖 由 agent 在隔离 worktree 实现,rebase 到最新 main,人工审 diff 后提交。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **安全性改进**
  * 接入命令改用 `AGENTPARTY_TOKEN` 环境变量传递令牌，不再将令牌直接放在命令行参数中。
  * 降低令牌出现在进程列表、命令历史记录或安全警告中的风险。

* **改进**
  * `party invite`、Agent 创建提示及网页接入包均已采用新的令牌传递方式。
  * 更新 watch、participate 等模式下生成的命令，保持现有接入流程不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->