### PR TITLE
fix(send): 路由到不可唤醒 agent 时回执 undeliverable_mentions,发送方当场知情 (#665)

### DIFF
--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -316,8 +316,10 @@ function parseServerFrame(value: unknown): ServerFrame | null {
         : null;
     case "sent":
       // unresolved_mentions（#663）：正文便利提取里服务端未能路由的 token，已降级为文本；缺省=无未解析项。
+      // undeliverable_mentions（#665）：路由成功但对端 wake 通道不可达的 agent 目标；缺省=无不可达目标。
       return isPositiveInteger(value.seq) &&
-        (value.unresolved_mentions === undefined || isStringArray(value.unresolved_mentions))
+        (value.unresolved_mentions === undefined || isStringArray(value.unresolved_mentions)) &&
+        (value.undeliverable_mentions === undefined || isStringArray(value.undeliverable_mentions))
         ? asServerFrame(value)
         : null;
     case "presence":

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -1658,6 +1658,15 @@ export interface SentFrame {
    * 但不再拒发。空则省略（无未解析项）。显式 mentions 的未命中不走这里——那会直接 mention_not_found 报错。
    */
   unresolved_mentions?: string[];
+  /**
+   * 已解析的 agent mention，但服务端权威 presence 判定其 wake 通道当前**不可达**（#665）：offline / 无 wake layer /
+   * 心跳过期（`autoWakeReachable` 为 false）。这类目标 mention 仍照常入 delivery ledger，但不会唤醒对端会话——
+   * 真实案例里一个被 harness reaped 的 `watch --once` 让三条 @ 石沉大海十几分钟，靠人肉兜底才发现。回执带上它，
+   * 让**任意客户端**（不止升级过的 CLI）当场看到「已入队但对端不可唤醒」。与 unresolved_mentions 正交：那些是正文
+   * token 压根没解析到任何身份；这些是解析成功的 agent 目标、只是没有活的 wake 通道。human 目标（human_driven，靠人
+   * 接续、非 wake 故障）与人为 paused 的 agent（#180，有意暂停）不计入。空则省略。
+   */
+  undeliverable_mentions?: string[];
 }
 
 export interface PresenceFrame {

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -21,6 +21,7 @@ import {
   DECISION_RESPONDER_OWNER_LIMIT,
   MAX_CONNECTIONS_PER_CHANNEL,
   PRESENCE_TIMEOUT_MS,
+  autoWakeReachable,
   RATE_LIMIT_PER_MIN,
   RETAIN_N,
   TEMP_IDLE_ARCHIVE_MS,
@@ -208,6 +209,11 @@ type SendSuccessOutcome =
       atomicEffects?: AtomicDeliveryEffects;
       /** 正文便利提取未能路由、降级为文本的原始 token（#663）；回执 SentFrame.unresolved_mentions 的来源，空=省略。 */
       unresolvedMentions?: string[];
+      /**
+       * 已解析、路由成功的 agent 目标，但服务端权威 presence 判定其 wake 通道当前不可达（#665，autoWakeReachable=false）；
+       * 回执 SentFrame.undeliverable_mentions 的来源，空=省略。人为 paused（#180）不计入。
+       */
+      undeliverableMentions?: string[];
     };
 
 type SendOutcome =
@@ -2578,6 +2584,10 @@ export class ChannelDO extends Server<Env> {
         seq: out.seq,
         ...(out.unresolvedMentions !== undefined && out.unresolvedMentions.length > 0
           ? { unresolved_mentions: out.unresolvedMentions }
+          : {}),
+        // undeliverable_mentions（#665）：路由成功但对端 wake 通道不可达的 agent 目标，供发送方当场知情。
+        ...(out.undeliverableMentions !== undefined && out.undeliverableMentions.length > 0
+          ? { undeliverable_mentions: out.undeliverableMentions }
           : {}),
       });
       // 广播必须紧跟 INSERT，中间不能有任何 await（#114）：
@@ -6011,6 +6021,10 @@ export class ChannelDO extends Server<Env> {
         ...(out.unresolvedMentions !== undefined && out.unresolvedMentions.length > 0
           ? { unresolved_mentions: out.unresolvedMentions }
           : {}),
+        // #665：路由成功但对端 wake 通道不可达的 agent 目标；所有 REST 客户端据此当场知情，不止升级过的 CLI。
+        ...(out.undeliverableMentions !== undefined && out.undeliverableMentions.length > 0
+          ? { undeliverable_mentions: out.undeliverableMentions }
+          : {}),
         ...(sent.completion_review === undefined ? {} : { completion_review: sent.completion_review }),
         ...(sent.decision_request === undefined
           ? {}
@@ -6735,6 +6749,24 @@ export class ChannelDO extends Server<Env> {
     };
   }
 
+  // #665：路由到 agent 的 mention，但对端 wake 通道当前不可达——消息只入 delivery ledger、不会唤醒会话。
+  // 据服务端权威 presence（DO 本就持有）当场算出这些「投递不到」的目标，经回执透给发送方，别再让 @ 石沉大海
+  // 靠人肉兜底。判定复用 autoWakeReachable（issue #47 统一口径，不另造逻辑）：offline / 无 wake layer / 心跳过期
+  // 均为不可达；webhook 恒可达、live 或新鲜的 serve/watch 可达。
+  //   • 人为 paused（#180）：有意暂停接待，不是 wake 故障，跳过——否则每次 @ 一个暂停的 agent 都误报。
+  //   • 无 presence 记录：从未上报过 wake layer 的身份，本函数不臆断（可能是刚建、异步补齐中），保守不标。
+  // human 目标天然不入 deliveryTargets（只有 agent 目标拿持久 delivery），故人类不会被误标。
+  private undeliverableAgentMentions(deliveryTargets: string[], now: number): string[] {
+    const undeliverable: string[] = [];
+    for (const target of deliveryTargets) {
+      const entry = this.presenceFor(target);
+      if (entry === null) continue;
+      if (entry.paused === true) continue;
+      if (!autoWakeReachable(entry, now)) undeliverable.push(target);
+    }
+    return undeliverable;
+  }
+
   // 校验 → 分配 seq → 落库 → 修剪/presence，返回待广播帧
   private async handleSend(
     identity: Identity,
@@ -7284,6 +7316,8 @@ export class ChannelDO extends Server<Env> {
       const entry = this.presenceFor(identity.name);
       frames.push(entry ? { type: "presence", ...entry } : { type: "presence", name: identity.name, state: frame.state, note: frame.note, ts: now });
     }
+    // #665：路由成功但 wake 通道不可达的 agent 目标，据当前权威 presence 当场算出，回执透给发送方。
+    const undeliverableMentions = this.undeliverableAgentMentions(deliveryTargets, now);
     stagedOutcome = {
       ok: true,
       seq,
@@ -7291,6 +7325,7 @@ export class ChannelDO extends Server<Env> {
       deliveryTargets,
       deliveryTargetOwners,
       ...(unresolvedBodyMentions.length > 0 ? { unresolvedMentions: unresolvedBodyMentions } : {}),
+      ...(undeliverableMentions.length > 0 ? { undeliverableMentions } : {}),
     };
     });
     if (decisionPreconditionFailure !== null) return decisionPreconditionFailure;

--- a/worker/test/undeliverable-mentions.spec.ts
+++ b/worker/test/undeliverable-mentions.spec.ts
@@ -1,0 +1,225 @@
+// #665：一个曾「可被唤醒」的 agent（如后台 `watch --once`）被 harness 在 turn 边界 reaped 后，
+// presence 却仍像它在待命，其它 agent 连发三条 @ 全部石沉大海、靠人肉兜底才发现。修复：send 路由 agent
+// mention 时，服务端据自己权威 presence（autoWakeReachable，issue #47 统一口径）当场算出哪些已解析的 agent
+// 目标 wake 通道不可达，经回执 SentFrame.undeliverable_mentions（REST 同字段）透给**所有**客户端，不止升级过
+// 的 CL(#664)/web(#666)。与 #663 的 unresolved_mentions 正交：那些是正文 token 压根没解析到身份；这些是解析
+// 成功的 agent 目标、只是没有活的 wake 通道。
+import { autoWakeReachable, wakeableState, PRESENCE_TIMEOUT_MS, type PresenceEntry } from "@agentparty/shared";
+import { env } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import { WsClient, api, completeCapabilityHello, createChannel, seedToken, uniq } from "./helpers";
+
+interface SentJson {
+  seq: number;
+  unresolved_mentions?: string[];
+  undeliverable_mentions?: string[];
+}
+
+function send(slug: string, token: string, body: string, mentions: string[]): Promise<Response> {
+  return api(`/api/channels/${slug}/messages`, token, {
+    method: "POST",
+    body: JSON.stringify({ kind: "message", body, mentions, reply_to: null }),
+  });
+}
+
+async function seedProfile(handle: string): Promise<void> {
+  const account = `lark:${uniq("acct")}`;
+  const now = Date.now();
+  await env.DB.prepare(
+    `INSERT INTO account_profiles (account, handle, display_name, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?)`,
+  ).bind(account, handle, handle, now, now).run();
+}
+
+async function presenceOf(slug: string, token: string, name: string): Promise<PresenceEntry | undefined> {
+  const res = await api(`/api/channels/${slug}/presence`, token);
+  expect(res.status).toBe(200);
+  return ((await res.json()) as { presence: PresenceEntry[] }).presence.find((p) => p.name === name);
+}
+
+// 断开一条连接并等到 markOffline 广播落定（消 onClose 竞态，复用 presence-liveness 的做法）。
+async function closeAndAwaitOffline(target: WsClient, observer: WsClient, name: string): Promise<void> {
+  target.close();
+  for (;;) {
+    const frame = await observer.nextOfType("presence");
+    if (frame.name === name && frame.state === "offline") return;
+  }
+}
+
+describe("#665 undeliverable agent mentions (server-authoritative wakeability truth)", () => {
+  it("路由到 live / 可唤醒的 agent → 不标 undeliverable", async () => {
+    const acct = "u665-live@leeguoo.com";
+    const sender = await seedToken("human", uniq("sender"), { owner: acct });
+    const slug = await createChannel(sender.token);
+    const agent = await seedToken("agent", uniq("livebot"), { channelScope: slug });
+
+    const ws = await WsClient.open(slug, agent.token);
+    await completeCapabilityHello(ws);
+    ws.send({
+      type: "send",
+      kind: "status",
+      state: "working",
+      note: "on it",
+      mentions: [],
+      residency: "supervised",
+      wake: { kind: "serve", verified_at: 1 },
+    });
+    await ws.nextOfType("sent");
+    // 前置断言：服务端权威 presence 判定它可达。
+    expect(autoWakeReachable((await presenceOf(slug, sender.token, agent.name))!, Date.now())).toBe(true);
+
+    const res = await send(slug, sender.token, `@${agent.name} 看一下`, [agent.name]);
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as SentJson;
+    expect(json.undeliverable_mentions).toBeUndefined();
+    ws.close();
+  });
+
+  it("watcher 被回收（连接断开 → markOffline 撤销 watch wake）后，@ 它 → 回执标 undeliverable", async () => {
+    const acct = "u665-reaped@leeguoo.com";
+    const sender = await seedToken("human", uniq("sender"), { owner: acct });
+    const slug = await createChannel(sender.token);
+    const agent = await seedToken("agent", uniq("reapedbot"), { channelScope: slug });
+
+    // 常驻观察者，用它的 presence 帧同步 markOffline 时机。
+    const observer = await WsClient.open(slug, sender.token);
+    await completeCapabilityHello(observer);
+
+    const watch = await WsClient.open(slug, agent.token);
+    await completeCapabilityHello(watch);
+    watch.send({
+      type: "send",
+      kind: "status",
+      state: "waiting",
+      note: "watching",
+      mentions: [],
+      residency: "supervised",
+      wake: { kind: "watch" },
+    });
+    await watch.nextOfType("sent");
+
+    // 模拟 harness reap：连接断开 → onClose → markOffline，watch wake 声明被撤销（#454）。
+    await closeAndAwaitOffline(watch, observer, agent.name);
+    const offline = (await presenceOf(slug, sender.token, agent.name))!;
+    expect(offline.state).toBe("offline");
+    expect(autoWakeReachable(offline, Date.now())).toBe(false);
+
+    const res = await send(slug, sender.token, `@${agent.name} 上线看下这个 bug`, [agent.name]);
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as SentJson;
+    expect(json.undeliverable_mentions).toEqual([agent.name]);
+    observer.close();
+  });
+
+  it("被人为 paused（#180）的 agent 即便不可唤醒也不标 undeliverable（有意暂停 ≠ wake 故障）", async () => {
+    const acct = "u665-paused@leeguoo.com";
+    const sender = await seedToken("human", uniq("sender"), { owner: acct });
+    const slug = await createChannel(sender.token);
+    const agent = await seedToken("agent", uniq("pausedbot"), { channelScope: slug });
+
+    const observer = await WsClient.open(slug, sender.token);
+    await completeCapabilityHello(observer);
+
+    const watch = await WsClient.open(slug, agent.token);
+    await completeCapabilityHello(watch);
+    watch.send({
+      type: "send",
+      kind: "status",
+      state: "waiting",
+      note: "watching",
+      mentions: [],
+      residency: "supervised",
+      wake: { kind: "watch" },
+    });
+    await watch.nextOfType("sent");
+
+    // 人为暂停（moderator = 频道创建者）。
+    const paused = await api(`/api/channels/${slug}/presence/${encodeURIComponent(agent.name)}/pause`, sender.token, {
+      method: "POST",
+      body: JSON.stringify({}),
+    });
+    expect(paused.status).toBe(200);
+
+    // 断开使其不可唤醒（wake 被撤销），但 paused 状态持久。
+    await closeAndAwaitOffline(watch, observer, agent.name);
+    const entry = (await presenceOf(slug, sender.token, agent.name))!;
+    expect(entry.paused).toBe(true);
+    expect(autoWakeReachable(entry, Date.now())).toBe(false);
+
+    const res = await send(slug, sender.token, `@${agent.name} 恢复后看下`, [agent.name]);
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as SentJson;
+    // paused 是有意暂停，不是 wake 故障 → 不进 undeliverable。
+    expect(json.undeliverable_mentions).toBeUndefined();
+    observer.close();
+  });
+
+  it("human 目标不进 undeliverable（human_driven 靠人接续，非 wake 故障，也不入 deliveryTargets）", async () => {
+    const acct = "u665-human@leeguoo.com";
+    const sender = await seedToken("human", uniq("sender"), { owner: acct });
+    const slug = await createChannel(sender.token);
+    const handle = uniq("colleague");
+    await seedProfile(handle);
+
+    const res = await send(slug, sender.token, `@${handle} 有空吗`, [handle]);
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as SentJson;
+    expect(json.undeliverable_mentions).toBeUndefined();
+  });
+
+  it("WS send 的 sent 回执同样带 undeliverable_mentions", async () => {
+    const acct = "u665-ws@leeguoo.com";
+    const sender = await seedToken("human", uniq("sender"), { owner: acct });
+    const slug = await createChannel(sender.token);
+    const agent = await seedToken("agent", uniq("wsbot"), { channelScope: slug });
+
+    const senderWs = await WsClient.open(slug, sender.token);
+    await completeCapabilityHello(senderWs);
+
+    const watch = await WsClient.open(slug, agent.token);
+    await completeCapabilityHello(watch);
+    watch.send({
+      type: "send",
+      kind: "status",
+      state: "waiting",
+      note: "watching",
+      mentions: [],
+      residency: "supervised",
+      wake: { kind: "watch" },
+    });
+    await watch.nextOfType("sent");
+    await closeAndAwaitOffline(watch, senderWs, agent.name);
+
+    senderWs.send({ type: "send", kind: "message", body: `@${agent.name} ping`, mentions: [agent.name], reply_to: null });
+    const ack = await senderWs.nextOfType("sent");
+    expect((ack as SentJson).undeliverable_mentions).toEqual([agent.name]);
+    senderWs.close();
+  });
+
+  // 纯函数：证明「租约随心跳过期而失活」的真相由 autoWakeReachable 承载——last_seen 超过 PRESENCE_TIMEOUT_MS
+  // 且无活连接即判不可达。wakeableState 只分类 wake 层（watch=unverified），可达性另由 autoWakeReachable 判，
+  // 二者共同构成 who/send 的「wakeable」真相（cli who: wstate!=offline && autoWakeReachable）。
+  it("租约随 last_seen 老化过期：autoWakeReachable 由可达翻转为不可达（宽限期口径）", () => {
+    const now = Date.now();
+    const base = {
+      name: "reaped",
+      kind: "agent" as const,
+      state: "waiting" as const,
+      note: null,
+      residency: "supervised" as const,
+      wake: { kind: "watch" as const },
+    };
+    // 新鲜心跳 + 活连接 → 可达。
+    const fresh: PresenceEntry = { ...base, ts: now, last_seen: now, live: true };
+    expect(autoWakeReachable(fresh, now)).toBe(true);
+    // 心跳早已过期（> PRESENCE_TIMEOUT_MS）且无活连接 → 不可达。
+    const stale: PresenceEntry = {
+      ...base,
+      ts: now - (PRESENCE_TIMEOUT_MS + 60_000),
+      last_seen: now - (PRESENCE_TIMEOUT_MS + 60_000),
+    };
+    expect(autoWakeReachable(stale, now)).toBe(false);
+    // wake 层分类不看新鲜度：仍是 watch → unverified；真相靠 autoWakeReachable。
+    expect(wakeableState(stale, now)).toBe("wakeable_unverified");
+  });
+});


### PR DESCRIPTION
Closes #665。(接替被基分支删除而自动关闭的 #678;已 rebase 到 main,单提交。)

## 修法(服务端权威回执)
- `shared/protocol.ts`:`SentFrame.undeliverable_mentions?`——路由成功但对端 wake 通道不可达的 agent 目标(与 #663 的 unresolved_mentions 正交)。
- `worker/do.ts` `undeliverableAgentMentions()`:读权威 presence(`presenceFor`),`autoWakeReachable` 为 false 即标;跳过 paused/无 presence;WS+REST 回执都带,空省略。
- `cli/client.ts`:`sent` 帧校验镜像新字段(防 #622 漂移)。
- 确认 onClose→markOffline / onAlarm 已让 reaped watcher 转不可达,无需改后端。

## 测试
worker 710 pass、cli 999 pass;新 spec 6 例(陈旧/无 wake→undeliverable;活/paused/human→不标;lease 陈旧转不可达)。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 发送消息回执新增不可投递的 Agent 提及提示，帮助识别已成功路由但当前无法唤醒的目标。
  * WebSocket 与 REST 发送结果均支持返回该提示。
  * 区分未解析的提及、人工处理目标及暂停状态，提供更准确的投递反馈。

* **错误修复**
  * 增强消息回执字段校验，避免无效格式导致解析异常。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->