### PR TITLE
fix(watch): 积压可一次排空 + ack --all/--through + --ensure 幂等 + 挂载默认静默 (#668 #669 #674 #675)

### DIFF
--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -352,6 +352,11 @@ export interface ConnectOptions {
   onCursor?: (cursor: number) => void;
   /** Declare that this connection consumes durable directed-delivery v1 frames. */
   directedDelivery?: "v1";
+  /**
+   * #675：带内声明「本连接有 watch 唤醒层」。设为 "watch" 时 hello 带上 wake_kind，服务端在 presence 落
+   * wake_kind=watch（residency=supervised），无需往时间线发 waiting 状态消息。断开由 markOffline 撤销。
+   */
+  advertiseWakeKind?: "watch";
   /** 修订游标：已见过的最大 rev_seq，随 hello.since_rev 上报，服务端据此限定修订重放（issue #33） */
   sinceRev?: number;
   onRevCursor?: (revCursor: number) => void;
@@ -602,6 +607,7 @@ export function connect(
         since_rev: revCursor,
         client_version: pkg.version,
         ...(opts.directedDelivery === "v1" ? { directed_delivery: "v1" as const } : {}),
+        ...(opts.advertiseWakeKind === "watch" ? { wake_kind: "watch" as const } : {}),
       }));
       // External status callbacks may synchronously send an actionable frame on reconnect. Publish
       // OPEN only after hello is on the wire so no callback can overtake the mandatory handshake.

--- a/cli/src/commands/ack.ts
+++ b/cli/src/commands/ack.ts
@@ -1,44 +1,78 @@
 // party ack — 显式了结 watch 欠账（#594）：纯读场景（读到别人的 status/不需要回应的消息）
 // 没有合法的清账手段，被迫发一条无信息量的消息——这正是频道礼仪劝阻的行为。
 // 只清 watch 源的债；serve 的 directed 债由 serve 闭环自己管（误清=静默丢 @，#198 红线）。
+//
+// #668/#674：深积压场景下逐条 `ack --seq N` 是 O(n) 空转。加 --all / --through / --before：
+// 一条命令把游标推到（head / 指定 seq）并清掉这之前的全部 pending watch 债，「从现在起只看新的」。
 import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
-import { ackWatchStuck, resolveChannel } from "../config";
-import { isSlug, parsePositiveIntFlag } from "../validation";
+import { ackWatchStuck, drainWatchStuck, resolveChannel } from "../config";
+import { resolveAuthDetailed } from "../oidc-cli";
+import { fetchRecentMessages, handleRestError } from "../rest";
+import { isSlug, parseNonNegativeIntFlag, parsePositiveIntFlag } from "../validation";
 
-const FLAGS = ["channel", "seq"];
-const HELP = `usage: party ack [--channel C] [--seq N]
+const FLAGS = ["channel", "seq", "all", "through", "before"];
+const HELP = `usage: party ack [--channel C] [--seq N | --all | --through N | --before N]
 
 Acknowledge the pending watch wake debt without posting a message. Use it after
 a watch --once delivered a frame that warrants no reply (someone else's status,
 FYI messages) — replying with empty acks burns the loop guard; leaving the debt
 unacknowledged makes every later watch replay the same frame (#594).
 
+For a deep backlog, --all / --through / --before drain in one command instead of
+acking one seq per re-mount (#668/#674): they advance the read cursor and clear
+all pending watch wake debt up through the target, so watch only wakes on NEW
+messages from there.
+
 Only watch-sourced debt can be acked. Debt owned by party serve is never touched
 here: serve replays it durably and clearing it by hand would silently drop an @.
 
 Options:
   --channel C   channel to ack in (defaults to the bound channel)
-  --seq N       only ack if the pending debt is exactly seq N (guard against races)`;
+  --seq N       only ack if the pending debt is exactly seq N (guard against races)
+  --all         drain: advance cursor to channel head + clear all pending watch debt
+  --through N   drain everything up to and including seq N (advance cursor to N)
+  --before N    drain everything strictly before seq N (advance cursor to N-1)`;
 
 export async function run(argv: string[]): Promise<number> {
   if (isHelpArg(argv, { allowHelpPositional: true })) {
     console.log(HELP);
     return 0;
   }
-  const { positionals, flags } = parseArgs(argv);
+  const { positionals, flags } = parseArgs(argv, { booleans: ["all"] });
   const unknown = unknownFlagError(flags, FLAGS);
   if (unknown !== null) {
     console.error(unknown);
     return 1;
   }
-  const flagError = valueFlagError(flags, ["channel", "seq"]);
+  const flagError = valueFlagError(flags, ["channel", "seq", "through", "before"]);
   if (flagError !== null) {
     console.error(flagError);
+    return 1;
+  }
+  // --seq / --all / --through / --before 互斥：混用语义含糊，直接拒绝。
+  const drainSelectors = [
+    flags.all === true ? "--all" : null,
+    flags.through !== undefined ? "--through" : null,
+    flags.before !== undefined ? "--before" : null,
+    flags.seq !== undefined ? "--seq" : null,
+  ].filter((f): f is string => f !== null);
+  if (drainSelectors.length > 1) {
+    console.error(`mutually exclusive selectors: ${drainSelectors.join(", ")} — pass at most one`);
     return 1;
   }
   const seqFlag = parsePositiveIntFlag(str(flags.seq), "seq");
   if (typeof seqFlag === "string") {
     console.error(seqFlag);
+    return 1;
+  }
+  const throughFlag = parsePositiveIntFlag(str(flags.through), "through");
+  if (typeof throughFlag === "string") {
+    console.error(throughFlag);
+    return 1;
+  }
+  const beforeFlag = parseNonNegativeIntFlag(str(flags.before), "before");
+  if (typeof beforeFlag === "string") {
+    console.error(beforeFlag);
     return 1;
   }
   const channel = resolveChannel(str(flags.channel) ?? positionals[0]);
@@ -50,7 +84,46 @@ export async function run(argv: string[]): Promise<number> {
     console.error("channel must match [a-z0-9][a-z0-9-]{0,63}");
     return 1;
   }
-  // 校验与清除同处一个跨进程临界区（ackWatchStuck）：读后清会误吞窗口内新落的债（#599 评审）。
+
+  // --all / --through / --before：批量排空（#668/#674）。
+  if (flags.all === true || throughFlag !== undefined || beforeFlag !== undefined) {
+    let throughSeq: number;
+    if (flags.all === true) {
+      // --all：查频道 head，把游标推到 head，清 head 及之前的全部 watch 债。
+      const auth = await resolveAuthDetailed();
+      if (!auth.server || !auth.token) {
+        console.error("no config, run: party login or party init --server URL --token T");
+        return 1;
+      }
+      try {
+        const tail = await fetchRecentMessages(auth.server, auth.token, channel, 1);
+        throughSeq = tail.at(-1)?.seq ?? 0;
+      } catch (e) {
+        return handleRestError(e);
+      }
+    } else if (throughFlag !== undefined) {
+      throughSeq = throughFlag;
+    } else {
+      // --before N：清严格早于 N 的债，游标推到 N-1。
+      throughSeq = Math.max(0, (beforeFlag as number) - 1);
+    }
+    const drained = drainWatchStuck(channel, throughSeq);
+    if (drained.outcome === "serve_owned") {
+      console.log(
+        `advanced cursor to seq=${drained.cursor} in #${channel}, but pending debt at seq=${drained.seq} is ` +
+          `owned by party serve (source=${drained.source}) — preserved, not cleared (serve replays it durably).`,
+      );
+      return 0;
+    }
+    console.log(
+      drained.clearedSeq !== null
+        ? `drained #${channel}: cleared pending watch wake seq=${drained.clearedSeq}, cursor advanced to seq=${drained.cursor}`
+        : `drained #${channel}: no pending watch wake debt, cursor advanced to seq=${drained.cursor}`,
+    );
+    return 0;
+  }
+
+  // 单条 ack（默认）：校验与清除同处一个跨进程临界区（ackWatchStuck）：读后清会误吞窗口内新落的债（#599 评审）。
   const acked = ackWatchStuck(channel, seqFlag);
   switch (acked.outcome) {
     case "none":

--- a/cli/src/commands/watch.ts
+++ b/cli/src/commands/watch.ts
@@ -12,6 +12,7 @@ import { acquireInstanceLock, defaultInstanceLockDir, instanceLockTarget } from 
 import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
 import { connect } from "../client";
 import {
+  drainWatchStuck,
   loadCursor,
   loadRevCursor,
   loadStuck,
@@ -38,13 +39,18 @@ import {
   writeStatuslineCache,
 } from "../statusline-cache";
 
-const WATCH_FLAGS = ["channel", "timeout", "follow", "once", "mentions-only", "exclude-self", "json", "allow-multiple", "latest", "since"];
+const WATCH_FLAGS = ["channel", "timeout", "follow", "once", "mentions-only", "exclude-self", "json", "allow-multiple", "latest", "since", "ensure", "drain", "status", "no-status", "quiet"];
 const WATCH_SKIP_PAGE_SIZE = 1000;
 const WATCH_SKIP_SCAN_LIMIT = 10_000;
 const WATCH_DELIVERY_ACK_TIMEOUT_MS = 5_000;
 const WATCH_DELIVERY_ACK_POLL_MS = 10;
+/**
+ * #668/#674：pending watch 唤醒债的过期阈值。first_wake_ts 早于 now-该值的债，重挂时自动降级为
+ * history-only（不再回放），并把游标推过它——几天前早已别处处理过的 @ 不该反复叫醒任何人。
+ */
+export const WATCH_WAKE_DEBT_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 const terminalOutput = (value: string) => stripTerminalControls(value);
-const HELP = `usage: party watch [channel|--channel C] [--timeout N] [--mentions-only] [--exclude-self] [--follow|--once] [--latest|--since seq] [--json] [--allow-multiple]
+const HELP = `usage: party watch [channel|--channel C] [--timeout N] [--mentions-only] [--exclude-self] [--follow|--once] [--latest|--since seq|--drain] [--ensure] [--status|--no-status] [--json] [--allow-multiple]
 
 Watch a channel for new messages. By default this waits up to 240 seconds.
 With --follow, it stays attached unless --timeout N is explicit.
@@ -53,9 +59,17 @@ exits 0. It is only a wake signal while the harness keeps that background task
 alive. Claude Code may kill run_in_background tasks at turn boundaries, so this
 is turn-scoped best effort, not durable unattended presence.
 Re-arm --once with the persisted cursor (omit --latest). If the previous result
-was lost before the agent replied, the pending wake is replayed first.
+was lost before the agent replied, the pending wake is replayed first. A pending
+wake older than 7 days auto-downgrades to history-only (no replay).
+--latest now TRULY attaches at head: it drains any pending unacknowledged wake
+first, then attaches at the current channel head (no backlog replay).
+--drain is a one-shot: it advances the cursor to head and clears all pending
+watch wake debt, then exits — say "I'm caught up, only new messages from here".
 For --mentions-only --once, an uninitialized cursor (0) attaches at the current
 channel head to avoid replaying old mentions. Use --since 0 to request backlog.
+Mount is SILENT by default (no auto waiting-status posted to the timeline);
+"wakeable" presence is advertised in-band (hello.wake_kind), not as a message.
+Pass --status to also post a human-visible waiting status (opt-in).
 Self messages are skipped by default; --exclude-self is accepted as an explicit
 automation hint for scripts that want to document that behavior.
 NOTE: --follow only PRINTS messages. Most harnesses (Codex included) never turn
@@ -74,8 +88,13 @@ Options:
   --exclude-self    explicitly skip this agent's own messages (default)
   --follow          keep watching after the first matching message
   --once            exit 0 right after the first matching message
-  --latest          explicitly skip backlog, attach at the current channel head
+  --latest          skip backlog: drain pending wake debt, then attach at head
   --since seq       explicitly start after seq (mutually exclusive with --latest)
+  --drain           one-shot: advance cursor to head + clear all pending debt, exit 0
+  --ensure          idempotent re-mount: if a same-identity watcher is already
+                    attached, exit 0 ("no-op") instead of exit 10 (for per-turn harnesses)
+  --status          also post a human-visible waiting status on mount (default: silent)
+  --no-status       explicit opt-out of the mount status (alias: --quiet; this is the default)
   --json            emit structured NDJSON frames`;
 
 // --follow 的假在线陷阱（issue #55/#60）：watcher 打印了 mention、presence 也新鲜，但多数
@@ -103,8 +122,9 @@ export const ONCE_REARM_ADVISORY =
   "For unattended presence, use `party serve --runner claude|codex --replay-backlog`.";
 
 export const ONCE_LATEST_ADVISORY =
-  "warning: re-arming `party watch --once` with --latest explicitly discards backlog. " +
-  "Use the persisted cursor (omit --latest); any pending unacknowledged wake will be replayed first.";
+  "warning: re-arming `party watch --once` with --latest explicitly discards backlog: it drains any " +
+  "pending unacknowledged wake (no replay) and attaches at the current channel head. " +
+  "To keep the backlog and replay pending wakes one at a time, omit --latest.";
 
 /** Claude Code 环境：可做回合内 --once，但 run_in_background 可能在回合边界被回收（#454）。 */
 export function isClaudeCodeEnv(env: Record<string, string | undefined> = process.env): boolean {
@@ -147,8 +167,13 @@ export interface WatchOptions {
   allowMultiple?: boolean;
   /** durable delivery running 回执等待上限；生产默认 5s，测试可注入更短时间。 */
   deliveryAckTimeoutMs?: number;
-  // watch 挂上（连上 WS、开始监听）后声明自己「有 watch 唤醒层」的钩子；run() 注入真实实现，测试可省略/替换。
+  // watch 挂上（连上 WS、开始监听）后往时间线发一条 waiting 状态的钩子。#675：默认**不**注入（静默挂载），
+  // 只有 --status 显式要人类可见的广播时才注入 advertiseWatchWake；presence 的「可唤醒」声明改走 advertiseWakeKind。
   advertise?: () => Promise<void>;
+  /** #675：带内 presence 声明「有 watch 唤醒层」，随 hello 上报，不往时间线发消息。 */
+  advertiseWakeKind?: "watch";
+  /** #669：同身份 watcher 已挂时，幂等退出 0（no-op）而非 exit 10 报错，供 harness 每轮例行重挂。 */
+  ensure?: boolean;
 }
 
 async function confirmWatchDeliveryRunning(
@@ -291,10 +316,16 @@ export async function runWatch(o: WatchOptions): Promise<number> {
   const lockTarget = o.lockDir === undefined ? instanceLockTarget(o.server, o.token, o.channel) : o.channel;
   const lock = o.allowMultiple === true ? null : acquireInstanceLock("watch", lockTarget, lockDir);
   if (lock && !lock.ok) {
+    // #669：--ensure 让 harness 的每轮例行重挂在「同身份已挂」时幂等收场（exit 0, no-op），
+    // 不再以 exit 10 报错刷「background task failed」假失败。不带 --ensure 仍保留 exit 10 硬拒。
+    if (o.ensure === true) {
+      out(`watch: already attached (pid ${lock.heldByPid}), no-op`);
+      return 0;
+    }
     out(
       `watch: 已有 watcher 挂在 #${o.channel} 上（pid ${lock.heldByPid}）。` +
         ` 再挂一个会让同一条 @ 触发 N 次唤醒——agent 会把同一条消息回 N 遍，并给 loop guard 上膛。` +
-        ` 要么等它退出，要么 kill ${lock.heldByPid}；确实想并存请加 --allow-multiple。`,
+        ` 要么等它退出，要么 kill ${lock.heldByPid}；确实想并存请加 --allow-multiple 或 --ensure 幂等重挂。`,
     );
     return EXIT_ALREADY_WATCHING;
   }
@@ -306,6 +337,7 @@ export async function runWatch(o: WatchOptions): Promise<number> {
     conn = connect(o.server, o.token, o.channel, o.since, {
       onCursor: o.onCursor,
       ...(acceptsDirectedDelivery ? { directedDelivery: "v1" as const } : {}),
+      ...(o.advertiseWakeKind === "watch" ? { advertiseWakeKind: "watch" as const } : {}),
       sinceRev: o.sinceRev,
       onRevCursor: o.onRevCursor,
       backoffBaseMs: o.backoffBaseMs,
@@ -594,6 +626,7 @@ export async function runWatch(o: WatchOptions): Promise<number> {
           source: "watch",
           channel_last_seq: lastSeq,
           skipped_mention_seqs: o.skippedMentionSeqs ?? [],
+          first_wake_ts: Date.now(),
         });
       }
       if (qualifies) {
@@ -696,7 +729,7 @@ export async function run(argv: string[]): Promise<number> {
     console.log(HELP);
     return 0;
   }
-  const { positionals, flags } = parseArgs(argv, { booleans: ["follow", "once", "mentions-only", "exclude-self", "json", "allow-multiple", "latest"] });
+  const { positionals, flags } = parseArgs(argv, { booleans: ["follow", "once", "mentions-only", "exclude-self", "json", "allow-multiple", "latest", "ensure", "drain", "status", "no-status", "quiet"] });
   if (flags.follow === true && flags.once === true) {
     console.error("--follow and --once are mutually exclusive: follow keeps watching, once exits after the first match");
     return 1;
@@ -705,6 +738,14 @@ export async function run(argv: string[]): Promise<number> {
     console.error("--latest and --since are mutually exclusive");
     return 1;
   }
+  // #675：--status（要人类可见的时间线广播）与 --no-status/--quiet（显式静默，默认即静默）互斥。
+  const wantsTimelineStatus = flags.status === true;
+  const silencedTimelineStatus = flags["no-status"] === true || flags.quiet === true;
+  if (wantsTimelineStatus && silencedTimelineStatus) {
+    console.error("--status and --no-status/--quiet are mutually exclusive");
+    return 1;
+  }
+  const ensure = flags.ensure === true;
   if (flags.since === true) {
     console.error("--since requires a value");
     return 1;
@@ -749,7 +790,89 @@ export async function run(argv: string[]): Promise<number> {
   else if (flags.once === true && isCodexRuntimeEnv()) console.error(ONCE_CODEX_ADVISORY);
   if (flags.once === true && flags.latest === true) console.error(ONCE_LATEST_ADVISORY);
   const localCursor = loadCursor(channel);
+  // #674：--drain 是一次性排空——把游标推到频道 head、清掉全部 pending watch 唤醒债，然后退出，
+  // 让 agent 明确「积压这些我不处理了，从现在起只看新的」。不挂 WS、不等消息，O(1) 收场。
+  if (flags.drain === true) {
+    if (flags.follow === true) {
+      console.error("--drain and --follow are mutually exclusive: drain is a one-shot cursor advance");
+      return 1;
+    }
+    try {
+      // best-effort：探 head，再有界扫描 localCursor→head 之间还压着的 @self（供 agent 知道跳过了什么）。
+      // 与 --latest 不同，drain 不要求「精确从 cursor+1 起」的严格闸——积压本就可能有空洞，扫描只为报数。
+      const [identity, tail] = await Promise.all([
+        fetchMe(cfg.server, cfg.token),
+        fetchRecentMessages(cfg.server, cfg.token, channel, 1),
+      ]);
+      const head = tail.at(-1)?.seq ?? Math.max(localCursor, 0);
+      const pending: number[] = [];
+      let scanCursor = localCursor;
+      while (scanCursor < head && pending.length < WATCH_SKIP_SCAN_LIMIT) {
+        const page = await fetchMessages(cfg.server, cfg.token, channel, scanCursor, WATCH_SKIP_PAGE_SIZE);
+        if (page.length === 0) break;
+        for (const m of page) {
+          if (m.seq <= head && m.sender.name !== identity.name && m.mentions.includes(identity.name)) pending.push(m.seq);
+        }
+        const pageLast = page.at(-1)?.seq ?? scanCursor;
+        if (pageLast <= scanCursor) break;
+        scanCursor = pageLast;
+      }
+      const drained = drainWatchStuck(channel, head);
+      if (flags.json === true) {
+        console.log(
+          JSON.stringify(
+            jsonFrame({
+              type: "watch_drained",
+              channel,
+              cursor: drained.cursor,
+              head,
+              drained_debt_seq: drained.outcome === "drained" ? drained.clearedSeq : null,
+              serve_owned_seq: drained.outcome === "serve_owned" ? drained.seq : null,
+              pending_mentions: pending.length,
+              pending_mention_seqs: pending,
+            }),
+          ),
+        );
+      } else if (drained.outcome === "serve_owned") {
+        console.log(terminalOutput(
+          `watch: 游标已推进到 head seq=${head}（跳过 ${pending.length} 条未读 @：${JSON.stringify(pending)}）；` +
+            ` 但存在 serve 源唤醒债 seq=${drained.seq}，未清除——serve 会用租约语义投递它，别手动丢弃（#198）。`,
+        ));
+      } else {
+        console.log(terminalOutput(
+          `watch: 已排空 #${channel}——游标推进到 head seq=${head}` +
+            (drained.clearedSeq !== null ? `，清除 pending 唤醒债 seq=${drained.clearedSeq}` : "") +
+            `，跳过 ${pending.length} 条未读 @：${JSON.stringify(pending)}。从现在起只唤醒新消息。`,
+        ));
+      }
+      return 0;
+    } catch (e) {
+      if (e instanceof Error && e.message.startsWith("refusing to skip more than")) {
+        console.error(`error: ${e.message}`);
+        return 1;
+      }
+      return handleRestError(e);
+    }
+  }
   let stuck = loadStuck(channel);
+  // #674：显式 --latest（真的「跳到 head 只看新的」）时，pending 未确认债应当被**排空**而不是先回放，
+  // 否则 --latest 名不副实（旧行为：先重放旧债、等于没跳过）。清 watch 债 + 把游标推进到 head 后，
+  // 落到下方 latest 解析走真正的 head attach。serve 源债仍保留（drainWatchStuck 只推游标、不碰 serve 债）。
+  if (flags.once === true && flags.latest === true && stuck !== null && stuck.source === "watch") {
+    try {
+      const tail = await fetchRecentMessages(cfg.server, cfg.token, channel, 1);
+      const head = Math.max(tail.at(-1)?.seq ?? 0, stuck.channel_last_seq ?? 0, stuck.seq);
+      const drained = drainWatchStuck(channel, head);
+      console.error(terminalOutput(
+        `watch: --latest 排空 pending 唤醒债` +
+          (drained.outcome === "drained" && drained.clearedSeq !== null ? ` seq=${drained.clearedSeq}` : "") +
+          `，游标推进到 head seq=${head}——不再回放旧债，attach 到最新。`,
+      ));
+      stuck = loadStuck(channel);
+    } catch (e) {
+      return handleRestError(e);
+    }
+  }
   // pending wake 比任何显式快进选择都优先。即使调用者误用 --latest，也不能先把仍未被模型
   // 确认的 @ 丢掉。REST 精确补拉后立即退出，避免重新挂起一个可能又被 harness 回收的后台任务。
   if (flags.once === true && stuck !== null) {
@@ -762,10 +885,15 @@ export async function run(argv: string[]): Promise<number> {
     const replayLock =
       flags["allow-multiple"] === true ? null : acquireInstanceLock("watch", replayLockTarget, replayLockDir);
     if (replayLock && !replayLock.ok) {
+      // #669：--ensure 幂等——同身份 watcher 已挂时，重挂不重放（欠账留给活着的那个 watcher），退出 0 no-op。
+      if (ensure) {
+        console.log(`watch: already attached (pid ${replayLock.heldByPid}), no-op`);
+        return 0;
+      }
       console.error(terminalOutput(
         `watch: 已有 watcher 挂在 #${channel} 上（pid ${replayLock.heldByPid}）；` +
           ` 不重放 pending wake seq=${stuck.seq}，避免同一条 @ 被回两遍——欠账已保留。` +
-          ` 等它退出或 kill ${replayLock.heldByPid}；确实想并存请加 --allow-multiple。`,
+          ` 等它退出或 kill ${replayLock.heldByPid}；确实想并存请加 --allow-multiple 或 --ensure 幂等重挂。`,
       ));
       return EXIT_ALREADY_WATCHING;
     }
@@ -787,14 +915,32 @@ export async function run(argv: string[]): Promise<number> {
         ));
         return 1;
       }
+      // #668/#674：债过期降级——first_wake_ts 早于 now-阈值（默认 7 天）的 pending wake 不再回放。
+      // 几天前早已别处处理过的 @ 反复叫醒只有噪音价值。清债 + 把游标推过它（history-only），不作为唤醒。
+      // directed debt（有 delivery_id）不走这条：它由 serve 的租约/retention 语义管，不能本地按时限丢弃。
+      if (
+        stuck.delivery_id === undefined &&
+        typeof stuck.first_wake_ts === "number" &&
+        Date.now() - stuck.first_wake_ts > WATCH_WAKE_DEBT_MAX_AGE_MS
+      ) {
+        const ageDays = Math.floor((Date.now() - stuck.first_wake_ts) / (24 * 60 * 60 * 1000));
+        const drained = drainWatchStuck(channel, stuck.seq);
+        console.error(terminalOutput(
+          `watch: pending 唤醒债 seq=${stuck.seq} 已过期（${ageDays} 天前首次产生，超过 ${Math.floor(WATCH_WAKE_DEBT_MAX_AGE_MS / (24 * 60 * 60 * 1000))} 天阈值）——` +
+            `降级为 history-only，不再回放；游标推进到 seq=${drained.cursor}。补看：party history ${channel} --since ${Math.max(0, stuck.seq - 1)}`,
+        ));
+        // 债已过期清除：stuck=null 落回下方正常 attach 路径（不 return，finally 释放重放锁）。
+        stuck = loadStuck(channel);
+      }
+      // 过期降级后 stuck===null：跳过重放，落回正常 attach（接手更新的积压或新消息）。
       // Directed debt 在 running ACK 前只是 unknown outcome。按旧 seq-only 路径直接重放会与
       // Worker 租约超时后的重新分配并发执行同一 work；保持 debt，重新注册等该 delivery 的新 claim。
-      if (stuck.delivery_id !== undefined && stuck.delivery_acceptance !== "accepted") {
+      if (stuck !== null && stuck.delivery_id !== undefined && stuck.delivery_acceptance !== "accepted") {
         console.error(terminalOutput(
           `watch: directed delivery=${stuck.delivery_id} 尚未确认 running；不会本地回放 seq=${stuck.seq}，` +
             "正在重新挂接，等待服务端重新授予合法 claim。",
         ));
-      } else {
+      } else if (stuck !== null) {
         try {
           // #652：stuck 现在是 let（锁内会被权威重读重新赋值），闭包捕获 let 会被 TS 放宽回可空。
           // 上面已 `if (stuck === null) return 0`，这里锁内的 stuck 必非空——把 seq 固定成 const 供闭包使用。
@@ -851,7 +997,10 @@ export async function run(argv: string[]): Promise<number> {
                 `channel_last_seq=${channelLastSeq} lag=${lag} ` +
                 `skipped_mention_seqs=${JSON.stringify(skippedMentionSeqs)}; ` +
                 `send a reply/status after handling it to clear this debt (or \`party ack --seq ${stuck.seq}\` if it needs no response).` +
-                (lag > 0 ? ` 补上下文：party history ${channel} --since ${stuck.seq}` : ""),
+                (lag > 0
+                  ? ` 补上下文：party history ${channel} --since ${stuck.seq}。` +
+                    ` 深积压不想逐条爬？一次跳到最新：party watch ${channel} --drain（或 party ack ${channel} --all）。`
+                  : ""),
             ));
             console.log(formatMsg(pending));
           }
@@ -932,7 +1081,11 @@ export async function run(argv: string[]): Promise<number> {
     onRevCursor: (r) => saveRevCursor(channel, r),
     statusline: true,
     allowMultiple: flags["allow-multiple"] === true,
-    advertise: () => advertiseWatchWake(auth, channel),
+    ensure,
+    // #675：可唤醒声明改走带内 presence（hello.wake_kind），默认不往时间线发 waiting 状态消息。
+    advertiseWakeKind: "watch",
+    // 只有 --status 显式要人类可见的挂载广播时才往时间线发一条（旧行为，opt-in）。
+    ...(wantsTimelineStatus ? { advertise: () => advertiseWatchWake(auth, channel) } : {}),
   });
   if (flags.once === true && flags.json !== true && code === 0) console.error(ONCE_REARM_ADVISORY);
   return code;

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -76,6 +76,12 @@ export interface StuckWake {
   source?: "serve" | "watch";
   /** watch 首次输出时看到的频道 head；重放时会再探测并取较新者。 */
   channel_last_seq?: number;
+  /**
+   * #668/#674：这条唤醒债**首次**产生的时刻（epoch ms）。重放不刷新它——据此判定债过期：
+   * 超过 WATCH_WAKE_DEBT_MAX_AGE_MS 的 pending wake 自动降级为 history-only（不再回放），
+   * 几天前早已别处处理过的 @ 不该反复叫醒任何人。
+   */
+  first_wake_ts?: number;
   /** 首次显式快进时跳过的 mentions，随 pending wake 一起保留。 */
   skipped_mention_seqs?: number[];
 }
@@ -680,6 +686,37 @@ export function ackWatchStuck(channel: string, expectedSeq?: number, cwd?: strin
     result = { outcome: "cleared", seq: stuck.seq };
     const { stuck: _dropped, ...rest } = cur;
     return rest;
+  }, cwd);
+  return result;
+}
+
+/**
+ * 批量排空（#668/#674）：把游标一次性推进到 throughSeq，并清掉 throughSeq 及之前的 watch 唤醒债，
+ * 让 agent 明确「这些我不处理了，从现在起只看新的」。取代逐条 ack + 逐条重挂的 O(n) 空转。
+ * serve 源债绝不触碰（误清=静默丢 @，#198 红线）：遇到 serve 债时**只推进游标、保留债**并回报。
+ * 校验与写入同处一个跨进程临界区，避免读后写误吞窗口内新落的债（#599 评审同款）。
+ */
+export type DrainWatchStuckOutcome =
+  | { outcome: "drained"; clearedSeq: number | null; cursor: number }
+  | { outcome: "serve_owned"; seq: number; source: string; cursor: number };
+
+export function drainWatchStuck(channel: string, throughSeq: number, cwd?: string): DrainWatchStuckOutcome {
+  let result: DrainWatchStuckOutcome = { outcome: "drained", clearedSeq: null, cursor: 0 };
+  updateChannelCursor(channel, (cur) => {
+    const nextCursor = Math.max(cur.cursor, throughSeq);
+    const stuck = cur.stuck;
+    // serve 债：只推进游标，绝不清债。serve 会用自己的租约语义把它投出去。
+    if (stuck !== undefined && stuck.source !== "watch") {
+      result = { outcome: "serve_owned", seq: stuck.seq, source: stuck.source ?? "unknown", cursor: nextCursor };
+      const next: ChannelCursor = { ...cur, cursor: nextCursor };
+      return next;
+    }
+    const clearsDebt = stuck !== undefined && stuck.seq <= throughSeq;
+    result = { outcome: "drained", clearedSeq: clearsDebt ? stuck!.seq : null, cursor: nextCursor };
+    const next: ChannelCursor = { ...cur, cursor: nextCursor };
+    // 债 seq 高于排空点（例如刚落一条更靠后的债）就保留，不误清。
+    if (clearsDebt) delete next.stuck;
+    return next;
   }, cwd);
   return result;
 }

--- a/cli/test/ack.test.ts
+++ b/cli/test/ack.test.ts
@@ -4,7 +4,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { run as runAck } from "../src/commands/ack";
-import { loadStuck, saveStuck, saveWatchStuck } from "../src/config";
+import { loadCursor, loadStuck, saveCursor, saveStuck, saveWatchStuck } from "../src/config";
 
 let home: string;
 let cwd: string;
@@ -61,5 +61,72 @@ describe("party ack（#594）", () => {
     saveStuck("dev", { seq: 7, wake_ts: 1, attempts: 1, source: "serve" } as never);
     expect(await runAck(["--channel", "dev"])).toBe(1);
     expect(loadStuck("dev")).not.toBeNull();
+  });
+});
+
+describe("party ack 批量排空（#668/#674）", () => {
+  test("--through N：清 <=N 的 watch 债并把游标推进到 N", async () => {
+    saveCursor("dev", 5);
+    expect(saveWatchStuck("dev", watchDebt(10))).toBe(true);
+    expect(await runAck(["--channel", "dev", "--through", "10"])).toBe(0);
+    expect(loadStuck("dev")).toBeNull();
+    expect(loadCursor("dev")).toBe(10);
+  });
+
+  test("--before N：游标推进到 N-1，清严格早于 N 的债", async () => {
+    saveCursor("dev", 3);
+    expect(saveWatchStuck("dev", watchDebt(8))).toBe(true);
+    expect(await runAck(["--channel", "dev", "--before", "20"])).toBe(0);
+    expect(loadStuck("dev")).toBeNull();
+    expect(loadCursor("dev")).toBe(19);
+  });
+
+  test("--through 低于债 seq 时保留债、只推游标", async () => {
+    saveCursor("dev", 5);
+    expect(saveWatchStuck("dev", watchDebt(30))).toBe(true);
+    expect(await runAck(["--channel", "dev", "--through", "20"])).toBe(0);
+    // 债 seq=30 高于排空点 20，保留；游标推进到 20。
+    expect(loadStuck("dev")).not.toBeNull();
+    expect(loadCursor("dev")).toBe(20);
+  });
+
+  test("--all 拉频道 head 排空多条积压债（一条命令清完，不逐条 ack）", async () => {
+    saveCursor("dev", 5);
+    expect(saveWatchStuck("dev", watchDebt(12))).toBe(true);
+    const api = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch(req) {
+        const url = new URL(req.url);
+        if (url.pathname === "/api/channels/dev/messages") {
+          return Response.json({ messages: [{ seq: 182, type: "msg", sender: { name: "x" }, mentions: [], body: "head" }] });
+        }
+        return new Response("not found", { status: 404 });
+      },
+    });
+    try {
+      const configDir = join(home, "state");
+      // ack --all 走 resolveAuthDetailed → 读 AGENTPARTY_HOME/config.json
+      const { writeFileSync, mkdirSync } = await import("node:fs");
+      mkdirSync(configDir, { recursive: true });
+      writeFileSync(join(home, "config.json"), JSON.stringify({ server: `http://127.0.0.1:${api.port}`, token: "ap_tok" }));
+      expect(await runAck(["--channel", "dev", "--all"])).toBe(0);
+      expect(loadStuck("dev")).toBeNull();
+      expect(loadCursor("dev")).toBe(182);
+    } finally {
+      api.stop(true);
+    }
+  });
+
+  test("--all / --seq 互斥", async () => {
+    expect(await runAck(["--channel", "dev", "--all", "--seq", "5"])).toBe(1);
+  });
+
+  test("--through 遇 serve 源债：保留债、推游标、退出 0 并提示", async () => {
+    saveCursor("dev", 2);
+    saveStuck("dev", { seq: 9, wake_ts: 1, attempts: 1, source: "serve" } as never);
+    expect(await runAck(["--channel", "dev", "--through", "50"])).toBe(0);
+    expect(loadStuck("dev")).not.toBeNull();
+    expect(loadCursor("dev")).toBe(50);
   });
 });

--- a/cli/test/watch-backlog.test.ts
+++ b/cli/test/watch-backlog.test.ts
@@ -1,0 +1,222 @@
+// #668/#674/#675：深积压未读 @ 的一次性排空 + 债过期降级 + 挂载默认静默。
+// 覆盖 party watch --drain / 债过期 history-only 降级 / 默认不往时间线发 waiting 状态。
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { workspaceId } from "../src/config";
+import { WATCH_WAKE_DEBT_MAX_AGE_MS } from "../src/commands/watch";
+
+let apiServer: ReturnType<typeof Bun.serve> | null = null;
+let home: string | null = null;
+const indexPath = join(import.meta.dir, "..", "src", "index.ts");
+
+async function runCli(args: string[]): Promise<{ code: number; stdout: string; stderr: string }> {
+  const proc = Bun.spawn(["bun", "run", indexPath, ...args], {
+    env: { ...process.env, AGENTPARTY_HOME: home! },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, code] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { code, stdout, stderr };
+}
+
+function msg(seq: number, body: string, mentions: string[] = []) {
+  return { seq, type: "msg", sender: { name: "other" }, mentions, body };
+}
+
+function writeState(cursor: number, stuck?: Record<string, unknown>) {
+  const dir = join(home!, "state", workspaceId(process.cwd()));
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, "state.json"),
+    JSON.stringify({ channel: "dev", cursor, cursors: { dev: { cursor, ...(stuck ? { stuck } : {}) } } }),
+  );
+  return join(dir, "state.json");
+}
+
+afterEach(() => {
+  apiServer?.stop(true);
+  apiServer = null;
+  if (home) rmSync(home, { recursive: true, force: true });
+  home = null;
+});
+
+describe("party watch --drain（#674）", () => {
+  test("把游标推进到 head、清 pending 债、报跳过的 @ 数、退出 0，不建 WS", async () => {
+    home = mkdtempSync(join(tmpdir(), "ap-drain-"));
+    let upgrades = 0;
+    // 积压：cursor 5，head 200，其间有两条 @me 未读（seq 40/120）。
+    const backlog = [msg(40, "@me old", ["me"]), msg(120, "@me older", ["me"]), msg(200, "head")];
+    apiServer = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch(req, srv) {
+        const url = new URL(req.url);
+        if (url.pathname === "/api/me") {
+          return Response.json({ name: "me", kind: "agent", role: "agent", email: null, owner: null });
+        }
+        if (url.pathname === "/api/channels/dev/messages") {
+          const since = Number(url.searchParams.get("since") ?? 0);
+          return Response.json({ messages: backlog.filter((m) => m.seq > since) });
+        }
+        upgrades++;
+        if (srv.upgrade(req, { data: undefined })) return;
+        return new Response("not found", { status: 404 });
+      },
+      websocket: { message() {} },
+    });
+    writeFileSync(join(home, "config.json"), JSON.stringify({ server: `http://127.0.0.1:${apiServer.port}`, token: "ap_tok" }));
+    const statePath = writeState(5, { seq: 40, attempts: 1, source: "watch" });
+
+    const result = await runCli(["watch", "dev", "--mentions-only", "--drain"]);
+    expect(result.code).toBe(0);
+    expect(upgrades).toBe(0); // 一次性排空，绝不建 WS
+    expect(result.stdout).toContain("head seq=200");
+    const state = JSON.parse(readFileSync(statePath, "utf8"));
+    expect(state.cursors.dev.cursor).toBe(200);
+    expect(state.cursors.dev.stuck).toBeUndefined();
+  }, 15_000);
+
+  test("--drain --json 输出结构化排空结果 + pending 列表", async () => {
+    home = mkdtempSync(join(tmpdir(), "ap-drain-json-"));
+    const backlog = [msg(7, "@me", ["me"]), msg(9, "head")];
+    apiServer = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch(req) {
+        const url = new URL(req.url);
+        if (url.pathname === "/api/me") return Response.json({ name: "me", kind: "agent", role: "agent", email: null, owner: null });
+        if (url.pathname === "/api/channels/dev/messages") {
+          const since = Number(url.searchParams.get("since") ?? 0);
+          return Response.json({ messages: backlog.filter((m) => m.seq > since) });
+        }
+        return new Response("not found", { status: 404 });
+      },
+      websocket: { message() {} },
+    });
+    writeFileSync(join(home, "config.json"), JSON.stringify({ server: `http://127.0.0.1:${apiServer.port}`, token: "ap_tok" }));
+    writeState(0);
+    const result = await runCli(["watch", "dev", "--mentions-only", "--drain", "--json"]);
+    expect(result.code).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({ type: "watch_drained", channel: "dev", cursor: 9, head: 9, pending_mentions: 1, pending_mention_seqs: [7] });
+  }, 15_000);
+});
+
+describe("pending 唤醒债过期降级（#668/#674）", () => {
+  test("first_wake_ts 超过阈值：不回放、清债、游标推过它，落回正常 attach", async () => {
+    home = mkdtempSync(join(tmpdir(), "ap-expire-"));
+    let upgrades = 0;
+    const pending = msg(10, "@me days-old", ["me"]);
+    apiServer = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch(req, srv) {
+        const url = new URL(req.url);
+        if (url.pathname === "/api/me") return Response.json({ name: "me", kind: "agent", role: "agent", email: null, owner: null });
+        if (url.pathname === "/api/channels/dev/messages") {
+          const since = Number(url.searchParams.get("since") ?? 0);
+          return Response.json({ messages: pending.seq > since ? [pending] : [] });
+        }
+        upgrades++;
+        if (srv.upgrade(req, { data: undefined })) return;
+        return new Response("not found", { status: 404 });
+      },
+      websocket: {
+        open(ws) {
+          ws.send(JSON.stringify({ type: "welcome", channel: "dev", self: "me", last_seq: 10, participants: [], presence: [], read_cursors: [] }));
+        },
+        message() {},
+      },
+    });
+    writeFileSync(join(home, "config.json"), JSON.stringify({ server: `http://127.0.0.1:${apiServer.port}`, token: "ap_tok" }));
+    const staleTs = Date.now() - (WATCH_WAKE_DEBT_MAX_AGE_MS + 60_000);
+    const statePath = writeState(10, { seq: 10, attempts: 3, source: "watch", first_wake_ts: staleTs });
+
+    const result = await runCli(["watch", "dev", "--once", "--mentions-only", "--timeout", "1"]);
+    // 过期债不回放
+    expect(result.stdout).not.toContain("replaying pending unacknowledged wake");
+    expect(result.stderr).toContain("已过期");
+    expect(result.stderr).toContain("history-only");
+    const state = JSON.parse(readFileSync(statePath, "utf8"));
+    expect(state.cursors.dev.stuck).toBeUndefined();
+    expect(upgrades).toBeGreaterThanOrEqual(1); // 降级后落回正常 attach
+  }, 15_000);
+
+  test("未过期债（含旧格式缺 first_wake_ts）仍照常回放", async () => {
+    home = mkdtempSync(join(tmpdir(), "ap-noexpire-"));
+    const pending = msg(10, "@me fresh", ["me"]);
+    apiServer = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch(req) {
+        const url = new URL(req.url);
+        if (url.pathname === "/api/me") return Response.json({ name: "me", kind: "agent", role: "agent", email: null, owner: null });
+        if (url.pathname === "/api/channels/dev/messages") {
+          const since = Number(url.searchParams.get("since") ?? 0);
+          return Response.json({ messages: pending.seq > since ? [pending] : [] });
+        }
+        return new Response("not found", { status: 404 });
+      },
+      websocket: { message() {} },
+    });
+    writeFileSync(join(home, "config.json"), JSON.stringify({ server: `http://127.0.0.1:${apiServer.port}`, token: "ap_tok" }));
+    // 旧格式债：无 first_wake_ts → 永不过期（保守，不误丢）。
+    writeState(10, { seq: 10, attempts: 0, source: "watch" });
+    const result = await runCli(["watch", "dev", "--once", "--mentions-only", "--json"]);
+    expect(result.code).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({ seq: 10, watch_replay: true });
+  }, 15_000);
+});
+
+describe("挂载默认静默（#675）", () => {
+  function mkServer(onPost: () => void) {
+    return Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch(req, srv) {
+        const url = new URL(req.url);
+        if (url.pathname === "/api/channels/dev/messages" && req.method === "POST") {
+          onPost();
+          return Response.json({ seq: 1 });
+        }
+        if (url.pathname === "/api/me") return Response.json({ name: "me", kind: "agent", role: "agent", email: null, owner: null });
+        if (url.pathname === "/api/channels/dev/messages") return Response.json({ messages: [] });
+        if (srv.upgrade(req, { data: undefined })) return;
+        return new Response("not found", { status: 404 });
+      },
+      websocket: {
+        open(ws) {
+          ws.send(JSON.stringify({ type: "welcome", channel: "dev", self: "me", last_seq: 0, participants: [], presence: [], read_cursors: [] }));
+        },
+        message() {},
+      },
+    });
+  }
+
+  test("默认不往时间线发 waiting 状态（无 POST /messages）", async () => {
+    home = mkdtempSync(join(tmpdir(), "ap-silent-"));
+    let posts = 0;
+    apiServer = mkServer(() => posts++);
+    writeFileSync(join(home, "config.json"), JSON.stringify({ server: `http://127.0.0.1:${apiServer.port}`, token: "ap_tok" }));
+    writeState(0);
+    const result = await runCli(["watch", "dev", "--once", "--mentions-only", "--timeout", "1"]);
+    // 正常挂载后无新 @：超时(2)或流结束(6)都行，只要不是用法/鉴权错误(1/3)。
+    expect([2, 6]).toContain(result.code);
+    expect(posts).toBe(0); // 关键：静默挂载，零时间线噪音
+  }, 15_000);
+
+  test("--status 显式 opt-in 时才发一条 waiting 状态", async () => {
+    home = mkdtempSync(join(tmpdir(), "ap-status-optin-"));
+    let posts = 0;
+    apiServer = mkServer(() => posts++);
+    writeFileSync(join(home, "config.json"), JSON.stringify({ server: `http://127.0.0.1:${apiServer.port}`, token: "ap_tok" }));
+    writeState(0);
+    await runCli(["watch", "dev", "--once", "--mentions-only", "--status", "--timeout", "1"]);
+    expect(posts).toBeGreaterThanOrEqual(1);
+  }, 15_000);
+});

--- a/cli/test/watch-once-lag.test.ts
+++ b/cli/test/watch-once-lag.test.ts
@@ -208,7 +208,7 @@ describe("watch --once pending wake replay (#508)", () => {
     expect(JSON.parse(readFileSync(join(dir, "state.json"), "utf8")).cursors.dev.stuck).toEqual(debt);
   }, 15_000);
 
-  test("重挂先从 REST 重放欠账，--latest 也不能越过，且不再建立 WS", async () => {
+  test("重挂不带 --latest 先从 REST 重放欠账，且不再建立 WS", async () => {
     home = mkdtempSync(join(tmpdir(), "ap-watch-pending-replay-"));
     const pending = msgFrame(10, "@me must survive reaper", { mentions: ["me"] });
     let upgrades = 0;
@@ -250,7 +250,7 @@ describe("watch --once pending wake replay (#508)", () => {
       }),
     );
 
-    const first = await runCli(["watch", "dev", "--once", "--mentions-only", "--latest", "--json"]);
+    const first = await runCli(["watch", "dev", "--once", "--mentions-only", "--json"]);
     expect(first.code).toBe(0);
     expect(upgrades).toBe(0);
     expect(JSON.parse(first.stdout)).toMatchObject({
@@ -263,13 +263,73 @@ describe("watch --once pending wake replay (#508)", () => {
       lag: 0,
       skipped_mention_seqs: [],
     });
-    expect(first.stderr).toContain("--latest explicitly discards backlog");
     expect(JSON.parse(readFileSync(join(dir, "state.json"), "utf8")).cursors.dev.stuck.attempts).toBe(1);
 
     const second = await runCli(["watch", "dev", "--once", "--mentions-only", "--json"]);
     expect(second.code).toBe(0);
     expect(JSON.parse(second.stdout)).toMatchObject({ seq: 10, watch_replay: true, replay_attempt: 2 });
     expect(JSON.parse(readFileSync(join(dir, "state.json"), "utf8")).cursors.dev.stuck.attempts).toBe(2);
+  }, 15_000);
+
+  test("--latest 排空 pending 债、attach 到 head、绝不回放旧债 (#674)", async () => {
+    home = mkdtempSync(join(tmpdir(), "ap-watch-latest-drain-"));
+    // head 就是这条 pending（seq10）。--latest 应清债 + 把游标推到 10，然后 attach WS 到 head 等新消息，
+    // 而不是像旧行为那样先把 seq10 回放一遍。
+    const pending = msgFrame(10, "@me stale backlog", { mentions: ["me"] });
+    let upgrades = 0;
+    apiServer = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch(req, srv) {
+        const url = new URL(req.url);
+        if (url.pathname === "/api/channels/dev/messages") {
+          const since = Number(url.searchParams.get("since") ?? 0);
+          return Response.json({ messages: pending.seq > since ? [pending] : [] });
+        }
+        if (url.pathname === "/api/me") {
+          return Response.json({ name: "me", kind: "agent", role: "agent", email: null, owner: null });
+        }
+        upgrades++;
+        if (srv.upgrade(req, { data: undefined })) return;
+        return new Response("not found", { status: 404 });
+      },
+      websocket: {
+        open(ws) {
+          // 收 hello 前不知 self；直接回 welcome(head=10) 让 --latest attach 到 head，随后无新消息超时退出。
+          ws.send(JSON.stringify(welcomeFrame(10, "me")));
+        },
+        message() {},
+      },
+    });
+    writeFileSync(
+      join(home, "config.json"),
+      JSON.stringify({ server: `http://127.0.0.1:${apiServer.port}`, token: "ap_tok" }),
+    );
+    const dir = join(home, "state", workspaceId(process.cwd()));
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "state.json"),
+      JSON.stringify({
+        channel: "dev",
+        cursor: 10,
+        cursors: {
+          dev: {
+            cursor: 10,
+            stuck: { seq: 10, attempts: 0, last_error: "watch wake awaiting agent acknowledgement", source: "watch" },
+          },
+        },
+      }),
+    );
+
+    const result = await runCli(["watch", "dev", "--once", "--mentions-only", "--latest", "--json", "--timeout", "1"]);
+    // 旧行为会先 REST 回放 seq10（不建 WS）；新行为清债后 attach WS 到 head。
+    expect(upgrades).toBeGreaterThanOrEqual(1);
+    expect(result.stdout).not.toContain("watch_replay");
+    expect(result.stderr).toContain("--latest 排空 pending 唤醒债");
+    // pending 债被清、游标推进到 head=10。
+    const state = JSON.parse(readFileSync(join(dir, "state.json"), "utf8"));
+    expect(state.cursors.dev.stuck).toBeUndefined();
+    expect(state.cursors.dev.cursor).toBe(10);
   }, 15_000);
 
   test("重放帧重新探测频道 head，并保留首次快进的 mention 元数据 (#508)", async () => {

--- a/cli/test/watch-single-instance.test.ts
+++ b/cli/test/watch-single-instance.test.ts
@@ -200,6 +200,66 @@ describe("runWatch 接线 (#195)", () => {
     }
   });
 
+  test("--ensure：同身份已挂时幂等退出 0（no-op），不建 WS，不报 exit 10 (#669)", async () => {
+    const d = dir();
+    let connections = 0;
+    const server = startMockServer((f, sock) => {
+      if (f.type !== "hello") return;
+      connections++;
+      sock.send(welcomeFrame(0, "me"));
+    });
+    try {
+      writeFileSync(join(d, "watch-dev.lock"), JSON.stringify({ pid: process.pid, channel: "dev" }));
+      const lines: string[] = [];
+      const code = await runWatch({
+        server: server.url,
+        token: "ap_tok",
+        channel: "dev",
+        since: 0,
+        timeoutSec: 2,
+        follow: false,
+        mentionsOnly: true,
+        once: true,
+        lockDir: d,
+        ensure: true,
+        out: (l) => lines.push(l),
+        backoffBaseMs: 20,
+      });
+      expect(code).toBe(0); // 幂等：不是 exit 10
+      expect(connections).toBe(0); // 仍不建 WS（活着的 watcher 在消费）
+      expect(lines.some((l) => l.includes("already attached") && l.includes("no-op"))).toBe(true);
+    } finally {
+      server.stop();
+    }
+  });
+
+  test("不带 --ensure：同身份已挂仍保留 exit 10 硬拒 (#669 回归)", async () => {
+    const d = dir();
+    const server = startMockServer((f, sock) => {
+      if (f.type !== "hello") return;
+      sock.send(welcomeFrame(0, "me"));
+    });
+    try {
+      writeFileSync(join(d, "watch-dev.lock"), JSON.stringify({ pid: process.pid, channel: "dev" }));
+      const code = await runWatch({
+        server: server.url,
+        token: "ap_tok",
+        channel: "dev",
+        since: 0,
+        timeoutSec: 2,
+        follow: false,
+        mentionsOnly: true,
+        once: true,
+        lockDir: d,
+        out: () => {},
+        backoffBaseMs: 20,
+      });
+      expect(code).toBe(EXIT_ALREADY_WATCHING);
+    } finally {
+      server.stop();
+    }
+  });
+
   test("--allow-multiple 是逃生舱：明知故犯时放行", async () => {
     const d = dir();
     writeFileSync(join(d, "watch-dev.lock"), JSON.stringify({ pid: process.pid, channel: "dev" }));

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -771,6 +771,13 @@ export interface HelloFrame {
    * 旧客户端不带 → 服务端保持旧行为（全量重放）。
    */
   since_rev?: number;
+  /**
+   * #675：带内 presence 声明「本连接有 watch 唤醒层」（residency=supervised + wake.kind=watch），
+   * 取代原先每次挂载往时间线发一条 waiting 状态消息（per-turn 重挂刷屏、推高 seq）。
+   * 服务端在这条连接的 presence 行上落 wake_kind，最后一条连接断开时由 markOffline 撤销（#454）。
+   * 旧客户端不带 → 服务端不改 wake_kind（保持旧行为）。仅 'watch' 合法；其余值服务端忽略。
+   */
+  wake_kind?: "watch";
 }
 
 /**

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -2389,6 +2389,11 @@ export class ChannelDO extends Server<Env> {
       if (clientVersion !== null) {
         this.recordClientVersion(st.name, connection.id, clientVersion, Date.now());
       }
+      // #675：带内 watch presence 声明。取代原先挂载往时间线发 waiting 状态消息（刷屏 + 推高 seq）。
+      // 只 agent 连接可声明可唤醒；wake_kind 断连由 markOffline 撤销。仅 'watch' 合法，其余忽略。
+      if (frame.wake_kind === "watch" && st.kind === "agent") {
+        this.advertiseWatchWakePresence(st.name, connection.id, Date.now());
+      }
       // Finish capability identity before replay. Live broadcasts were withheld while helloPending;
       // DO message handling is serialized, so dispatch + backfill below form one gap-free handoff.
       st = connection.setState({
@@ -3533,6 +3538,27 @@ export class ChannelDO extends Server<Env> {
       sessionId,
       ts,
       clientVersion,
+    );
+    const entry = this.presenceFor(name);
+    if (entry) this.broadcastFrame({ type: "presence", ...entry });
+  }
+
+  // #675：带内声明 watch 唤醒层。取代原先每次挂载往时间线发一条 waiting 状态消息（per-turn
+  // 重挂刷屏、推高 seq）。只在这条连接的 presence 行上落 wake_kind=watch + residency=supervised，
+  // 不落 history、不产生 seq。断开由 markOffline 撤销（#454，wake_kind='watch' 的行断连即清）。
+  // #191：wake_verified_at 绝不吃客户端自报——kind 变了就清空，等服务端观测到 resume 才盖。
+  private advertiseWatchWakePresence(name: string, sessionId: string, ts: number) {
+    this.ctx.storage.sql.exec(
+      `INSERT INTO presence (name, session_id, state, note, updated_at, wake_kind, residency)
+         VALUES (?, ?, 'waiting', NULL, ?, 'watch', 'supervised')
+       ON CONFLICT(name, session_id) DO UPDATE SET
+         updated_at = excluded.updated_at,
+         wake_verified_at = CASE WHEN presence.wake_kind IS 'watch' THEN presence.wake_verified_at ELSE NULL END,
+         wake_kind = 'watch',
+         residency = COALESCE(presence.residency, 'supervised')`,
+      name,
+      sessionId,
+      ts,
     );
     const entry = this.presenceFor(name);
     if (entry) this.broadcastFrame({ type: "presence", ...entry });

--- a/worker/test/hello-wake-advertise.spec.ts
+++ b/worker/test/hello-wake-advertise.spec.ts
@@ -1,0 +1,77 @@
+// #675：watch 挂载默认静默——不再往时间线发一条 waiting 状态消息（per-turn 重挂刷屏、推高 seq）。
+// 「可被唤醒」改由带内 presence 声明：hello 带 wake_kind=watch，服务端在这条连接的 presence 行上
+// 落 wake_kind=watch + residency=supervised，不产生任何时间线消息/seq。断开由 markOffline 撤销。
+import { wakeableState, type PresenceEntry } from "@agentparty/shared";
+import { describe, expect, it } from "vitest";
+import { WsClient, api, createChannel, seedToken } from "./helpers";
+
+async function fetchPresence(slug: string, token: string): Promise<PresenceEntry[]> {
+  const res = await api(`/api/channels/${slug}/presence`, token);
+  expect(res.status).toBe(200);
+  return ((await res.json()) as { presence: PresenceEntry[] }).presence;
+}
+
+async function messageCount(slug: string, token: string): Promise<number> {
+  const res = await api(`/api/channels/${slug}/messages`, token);
+  expect(res.status).toBe(200);
+  return ((await res.json()) as { messages: unknown[] }).messages.length;
+}
+
+describe("hello.wake_kind 带内 watch presence 声明 (#675)", () => {
+  it("hello 带 wake_kind=watch → presence 落 wake_kind=watch，零时间线消息", async () => {
+    const agent = await seedToken("agent");
+    const slug = await createChannel(agent.token);
+    const before = await messageCount(slug, agent.token);
+
+    const ws = await WsClient.open(slug, agent.token);
+    await ws.nextOfType("welcome");
+    ws.send({ type: "hello", since: 0, directed_delivery: "v1", wake_kind: "watch" });
+    // 等一个 presence 广播以确保服务端已处理 hello
+    await ws.nextOfType("presence");
+
+    const me = (await fetchPresence(slug, agent.token)).find((p) => p.name === agent.name)!;
+    expect(me.wake?.kind).toBe("watch");
+    expect(me.residency).toBe("supervised");
+    // #191：自报绝不算已验证。
+    expect(me.wake?.verified_at).toBeUndefined();
+    expect(wakeableState(me, Date.now())).toBe("wakeable_unverified");
+
+    // 关键：没有往时间线塞任何消息（默认静默）。
+    expect(await messageCount(slug, agent.token)).toBe(before);
+    ws.close();
+  });
+
+  it("不带 wake_kind 的 hello 不改 wake_kind（旧客户端保持旧行为）", async () => {
+    const agent = await seedToken("agent");
+    const slug = await createChannel(agent.token);
+
+    const ws = await WsClient.open(slug, agent.token);
+    await ws.nextOfType("welcome");
+    ws.send({ type: "hello", since: 0, directed_delivery: "v1" });
+    // 发一帧 ping 让服务端处理完 hello（ping→pong 往返证明 hello 已消费）。
+    ws.send({ type: "ping" });
+    await ws.nextOfType("pong");
+
+    // 无 wake 声明的 agent 不会被凭空标成 wakeable（要么没 presence 行，要么行里无 wake_kind）。
+    const me = (await fetchPresence(slug, agent.token)).find((p) => p.name === agent.name);
+    expect(me?.wake?.kind ?? undefined).toBeUndefined();
+    ws.close();
+  });
+
+  it("wake_kind=watch 的连接断开后撤销 wake 声明 (#454)", async () => {
+    const agent = await seedToken("agent");
+    const slug = await createChannel(agent.token);
+
+    const ws = await WsClient.open(slug, agent.token);
+    await ws.nextOfType("welcome");
+    ws.send({ type: "hello", since: 0, directed_delivery: "v1", wake_kind: "watch" });
+    await ws.nextOfType("presence");
+    expect((await fetchPresence(slug, agent.token)).find((p) => p.name === agent.name)?.wake?.kind).toBe("watch");
+
+    ws.close();
+    // 断连回收后 wake_kind 撤销（markOffline 对 wake_kind='watch' 清零）。
+    await new Promise((r) => setTimeout(r, 50));
+    const after = (await fetchPresence(slug, agent.token)).find((p) => p.name === agent.name);
+    expect(after?.wake?.kind ?? undefined).toBeUndefined();
+  });
+});


### PR DESCRIPTION
一个 coherent PR 收 4 个同簇的 watch 可靠性问题(per-turn 重挂 + 深积压)。

Closes #668, Closes #669, Closes #674, Closes #675.

## #674 + #668 — 积压排空 / 批量 / 债过期 / ack-through
- **`party ack --all` / `--through N` / `--before N`**:一条命令清完历史债(不再一次一条);与 `--seq` 互斥,单 seq 路径不变。
- **`party watch --drain`**:一次性消费+ack 全部 pending,把游标推到 head 再退出(「我追平了,从现在起只看新的」)。
- **`--latest` 真 attach 到 head**:先排空 pending 债再 attach,不再先回放旧债(旧行为等于没跳过);HELP/advisory 更新。
- **债过期**:pending wake 超过 `WATCH_WAKE_DEBT_MAX_AGE_MS=7d` 自动降级 history-only,不再回放。
  - 注:mention-wake 债存在**本地 CLI config**(DO 看不见),故过期逻辑落在 watch 回放路径(client 侧),而非 server onAlarm——债在哪就在哪治。directed-delivery 的服务端债仍走既有 lease/retention。

## #669 — `--ensure` 幂等重挂
- `party watch --once --ensure`:已有同身份 watcher → **exit 0** `already attached, no-op`,不再 exit 10 假失败(harness 每轮例行重挂不再刷「background task failed」)。不带 `--ensure` 仍保 exit-10 守卫。

## #675 — 挂载默认静默
- 挂载**默认不再自动发**「watch 已挂上」时间线状态(per-turn 重挂刷屏、推高 seq、淹没真消息)。可唤醒性改由**带内 `HelloFrame.wake_kind:"watch"`** 表达(presence 层,非消息时间线);`markOffline` 断线即清(#454)。`--status` 显式 opt-in 才发。

## 「reply/status 清债」裁决 — 文档/UX 缺口,非清债 bug
`advanceCursorPastOwnMessage` 已在 send/status 时清掉当前 seq 的债;报告者的「从不清」是因为清债**不推进游标越过其余积压**,下次 `--once` 又在旧游标捡下一条债(397→403→404 轮转)。根因=积压游标不前进,已由 `--drain`/`ack --all` 修掉。

## 测试(全绿)
- cli **1037 pass**、worker **717 pass**、全 tsc + web build 过。
- 新 `watch-backlog.test.ts`(drain/债过期/静默挂载)、`hello-wake-advertise.spec.ts`;`ack.test.ts` +7;`watch-single-instance` +2(ensure/exit-10 守卫);`watch-once-lag` 改写 --latest 为 drain 行为 + 新增 --latest drain 用例(保留 no-latest 回放用例)。

## 新 wire 字段
- `HelloFrame.wake_kind?:"watch"`(仅 client→server;服务端 `frame.wake_kind==="watch"` 松散解析;无 server-frame 校验器需镜像)。无新 REST/WS 端点。

🤖 由 agent 在隔离 worktree 实现(基于最新 main),人工审 diff + 测试改写后提交。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - `party ack` 支持使用 `--all`、`--through`、`--before` 批量清理待处理唤醒。
  - `party watch` 新增 `--drain`、`--ensure` 及状态输出控制选项。
  - Watch 连接可声明唤醒能力，减少不必要的时间线状态消息。
- **改进**
  - 过期的待处理唤醒将自动降级为仅保留历史记录，避免重复唤醒。
  - 重复启动相同 Watch 时可安全幂等返回。
  - 增强积压提示，提供更明确的排空操作建议。
- **测试**
  - 补充批量确认、积压排空、过期处理及单实例行为测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->