### PR TITLE
spike(daemon): #672 Phase-1 —— 嵌 Claude Agent SDK 的常驻 party daemon(实验性,待 live 验证)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,6 +13,7 @@
       },
       "dependencies": {
         "@agentparty/shared": "workspace:*",
+        "@anthropic-ai/claude-agent-sdk": "^0.3.216",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^4.4.3",
       },
@@ -95,7 +96,29 @@
 
     "@agentparty/worker": ["@agentparty/worker@workspace:worker"],
 
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.3.216", "", { "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.216", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.216", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.216", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.216", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.216", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.216", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.216", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.216" }, "peerDependencies": { "@anthropic-ai/sdk": ">=0.93.0", "@modelcontextprotocol/sdk": "^1.29.0", "zod": "^4.0.0" } }, "sha512-Fl/d9yGW7Pm0aGwUNkJMvruOVobleYcoprGJqufdP4J9W2XL/2xKXqanY8KqUdfySRMI2N46rY4/lryq5SfgFg=="],
+
+    "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.216", "", { "os": "darwin", "cpu": "arm64" }, "sha512-TWtTUabXj+AMOBMknSe3EVQb/7qucw5pHYi0HWoKoixQt1JE6J/CiLDBIY69OD3eQn9k1XG6LaurT239kFxLUw=="],
+
+    "@anthropic-ai/claude-agent-sdk-darwin-x64": ["@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.216", "", { "os": "darwin", "cpu": "x64" }, "sha512-tULuvqhJUwGTj71Uln4uPumm0la4EO1XydFbISTbdc1BsuvGx3FOtFcVs0Qg3dhNBFAoU/iYVTO/B1rImeJZig=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-arm64": ["@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.216", "", { "os": "linux", "cpu": "arm64" }, "sha512-kX6x0otwOuA1zIeEiuAKQqOk2TUAOkDUzm4MmLoQHOM2xWvr/pc+xY4DZxaX4ef9dUFQuHA4r5Vtbk7tPTL7Bw=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": ["@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.216", "", { "os": "linux", "cpu": "arm64" }, "sha512-sisWj2nhQolKu6aGWnu+I7d8EU6/m5J3G6bGfR7YvZ1wkQTQZAX3aOq6DVLIfCaZSH22wtqyuXhE/gn5eU1syw=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-x64": ["@anthropic-ai/claude-agent-sdk-linux-x64@0.3.216", "", { "os": "linux", "cpu": "x64" }, "sha512-WbJTLQafcYw9wl+gh/YpepdbWsOoJS7JZQA0obpzBBWzpx9PqPbjUDXDfCDrtzDI2fmr3Nz0//vC12bvlMZd8g=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-x64-musl": ["@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.216", "", { "os": "linux", "cpu": "x64" }, "sha512-3Ts2Ab6oEGG2r+epmWc6lOR1ahECjvH4y+lPb32qLKMdYxT2PU6TAc4Z/USLLuqDpgw3nSb8xuiYEH77rv88fw=="],
+
+    "@anthropic-ai/claude-agent-sdk-win32-arm64": ["@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.216", "", { "os": "win32", "cpu": "arm64" }, "sha512-xGB8rKatsXl9enqmPXixYNvdjGh1AL2jFmMRC9lR9M1prf2FGl7dkpdHz8YyItKAciRwpPIfts/9dSGhxlgT3A=="],
+
+    "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.3.216", "", { "os": "win32", "cpu": "x64" }, "sha512-cGbBgoKNzB6wRL6bMOwM2iJEG/wx0B6FCblmKF+ZAYKcj5oNi3jM6oQsnPJbKfrzVKrip3YEpXxopQ9O30LrSg=="],
+
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.112.4", "", { "dependencies": { "json-schema-to-ts": "^3.1.1", "standardwebhooks": "^1.0.0" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-7eXJJnrmBI5GMC6drrCiSkycVsT7crRZX3qv5HusLSm+qiILjmtqP7gf+UiT7ASu/7Gdj+Zfl4f2haV8wATKUg=="],
+
     "@asteasolutions/zod-to-openapi": ["@asteasolutions/zod-to-openapi@8.5.0", "", { "dependencies": { "openapi3-ts": "^4.1.2" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-SABbKiObg5dLRiTFnqiW1WWwGcg1BJfmHtT2asIBnBHg6Smy/Ms2KHc650+JI4Hw7lSkdiNebEGXpwoxfben8Q=="],
+
+    "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
 
     "@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.5.0", "", {}, "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg=="],
 
@@ -298,6 +321,8 @@
     "@sindresorhus/is": ["@sindresorhus/is@7.2.0", "", {}, "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw=="],
 
     "@speed-highlight/core": ["@speed-highlight/core@1.2.17", "", {}, "sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg=="],
+
+    "@stablelib/base64": ["@stablelib/base64@1.0.1", "", {}, "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
@@ -503,6 +528,8 @@
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
+    "fast-sha256": ["fast-sha256@1.3.0", "", {}, "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ=="],
+
     "fast-uri": ["fast-uri@3.1.3", "", {}, "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
@@ -548,6 +575,8 @@
     "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
 
     "js-yaml": ["js-yaml@4.3.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q=="],
+
+    "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
@@ -685,6 +714,8 @@
 
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
 
+    "standardwebhooks": ["standardwebhooks@1.0.0", "", { "dependencies": { "@stablelib/base64": "^1.0.0", "fast-sha256": "^1.3.0" } }, "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg=="],
+
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "std-env": ["std-env@4.2.0", "", {}, "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw=="],
@@ -700,6 +731,8 @@
     "tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
 
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@agentparty/shared": "workspace:*",
+    "@anthropic-ai/claude-agent-sdk": "^0.3.216",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "zod": "^4.4.3"
   },

--- a/cli/src/commands/daemon.ts
+++ b/cli/src/commands/daemon.ts
@@ -1,0 +1,292 @@
+// party daemon — 实验性：内嵌 @anthropic-ai/claude-agent-sdk 的常驻 party runner（SPIKE，#672 Phase 1）。
+//
+// 动机（#672）：`party watch --once` 是单发子进程，harness 在 turn 边界把它回收即静默——presence 的
+// 「可唤醒」本质是谎报，这是 #665/#664/#508/#29/#199 唤醒债风暴的共同根因。daemon 是一档**第一方常驻**
+// runner：长期进程持 WS（真实心跳），被 @ 时就地跑内嵌的官方 Agent SDK session，处理完回帖、进程续存，
+// **不依赖 harness turn 边界**。
+//
+// ⚠️ Phase-1 边界（协议不动）：本命令暂**不**新增 WakeKind:"daemon" / Residency:"daemon"（那是 doc 里的
+// Phase 2）。为了让 wire 保持不变，daemon 复用现有 serve/watch 风格的唤醒声明——即随 hello 上报
+// `advertiseWakeKind: "watch"`。这是刻意的 Phase-1 捷径，见报告与 #672。
+import {
+  EXIT_ARCHIVED,
+  EXIT_AUTH,
+  EXIT_STREAM_ENDED,
+} from "@agentparty/shared";
+import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
+import { connect } from "../client";
+import { loadCursor, resolveChannel, saveCursor } from "../config";
+import { resolveAuthDetailed } from "../oidc-cli";
+import { postMessage } from "../rest";
+import { isSlug } from "../validation";
+
+/** 常驻 daemon 的信号退出码，与 serve 对齐（128 + signo）。 */
+export const EXIT_SIGNAL_INT = 128 + 2;
+export const EXIT_SIGNAL_TERM = 128 + 15;
+
+const HELP = `party daemon — 实验性：内嵌 Claude Agent SDK 的常驻 party runner（SPIKE，#672）
+
+usage: party daemon [channel|--channel C] [--timeout N]
+
+  连上频道并常驻（长期进程、真实心跳）。被 @ 到本身份时，就地用内嵌的官方
+  @anthropic-ai/claude-agent-sdk 跑一个 session，把最终文本回帖到频道——不经 harness、无 turn 边界。
+  SDK 出错则回一条简短失败提示、进程续存。收到 SIGTERM/SIGINT 干净断开（presence 随之清除）。
+
+flags:
+  --channel C     目标频道（也可作为位置参数）；缺省用 party init 绑定的频道
+  --timeout N     跑 N 秒后退出（默认 0 = 常驻）；主要给冒烟测试用
+
+experimental：仅供 spike/live 验证，未接入 onboarding / join-pack；协议未改动（复用 watch 唤醒声明）。`;
+
+/**
+ * SDK 会话运行器抽象——daemon 与具体 SDK 之间的唯一接触面。
+ * 默认实现（createSdkRunner）懒加载官方 SDK；**单测注入 mock，CI 永不触碰真 SDK**（SDK 无法在 CI 跑）。
+ */
+export interface SdkRunner {
+  /** 用 @-mention 文本 + 最小频道上下文跑一次 session，返回最终文本（成功）或抛错（失败）。 */
+  run(prompt: string, ctx: SdkRunContext): Promise<string>;
+}
+
+export interface SdkRunContext {
+  channel: string;
+  sender: string;
+  seq: number;
+}
+
+/** 回帖依赖注入点：默认走 rest.postMessage，测试可捕获回帖。 */
+export type PostReply = (reply: { body: string; mentions: string[]; replyTo: number }) => Promise<void>;
+
+export interface DaemonOptions {
+  server: string;
+  token: string;
+  channel: string;
+  since: number;
+  /** SDK 运行器（必填、可注入）。生产用 createSdkRunner()；测试注入 mock。 */
+  runner: SdkRunner;
+  /** 依赖注入：默认走 client.connect（测试可用 mock server + 真 connect，或完全注入）。 */
+  connectImpl?: typeof connect;
+  /** 依赖注入：默认走 rest.postMessage。 */
+  postReply?: PostReply;
+  /** 游标持久化钩子；默认无（run() 注入 saveCursor）。 */
+  onCursor?: (cursor: number) => void;
+  out?: (line: string) => void;
+  backoffBaseMs?: number;
+  /** 0 = 常驻（默认）；>0 跑满 N 秒后主动关闭连接退出（冒烟测试用）。 */
+  timeoutSec?: number;
+  /** 干净关停信号（SIGTERM/SIGINT）；abort 时关闭连接、presence 随之清除。 */
+  abortSignal?: AbortSignal;
+}
+
+/**
+ * 生产 SDK 运行器：懒加载官方 @anthropic-ai/claude-agent-sdk 的 query()，收集最终 result 文本。
+ * 懒加载（dynamic import）保证只有真跑 daemon 才载入 SDK——注入了 mock 的单测永远不会触碰它。
+ */
+export function createSdkRunner(options?: Record<string, unknown>): SdkRunner {
+  return {
+    async run(prompt: string, ctx: SdkRunContext): Promise<string> {
+      const { query } = await import("@anthropic-ai/claude-agent-sdk");
+      const framed =
+        `你在 AgentParty 频道 #${ctx.channel} 里被 @ 了（来自 ${ctx.sender}，seq=${ctx.seq}）。\n` +
+        `请针对下面这条消息给出回复正文（回复会直接贴回频道）：\n\n${prompt}`;
+      let final = "";
+      // Query 是 AsyncGenerator<SDKMessage>：迭代到 type:"result" 拿终值。
+      // success 携带 result:string；error 变体携带 errors:string[]，抛出交给上层回帖失败提示。
+      for await (const message of query({ prompt: framed, ...(options ? { options } : {}) })) {
+        if (message.type === "result") {
+          if (message.subtype === "success") {
+            final = message.result;
+          } else {
+            throw new Error(`sdk ${message.subtype}: ${message.errors?.join("; ") || "unknown error"}`);
+          }
+        }
+      }
+      return final;
+    },
+  };
+}
+
+/**
+ * daemon 主循环：连上频道、常驻、被 @ 时跑 SDK 并回帖。
+ * Phase-1 spike 有意最小化——只处理 plain `msg` 帧的新 @self；status/delivery/message_update 等一律忽略
+ * （durable directed-delivery / 暂停接待 / squad 等留给后续阶段）。
+ */
+export async function runDaemon(o: DaemonOptions): Promise<number> {
+  const out = o.out ?? ((line: string) => console.log(line));
+  const post: PostReply =
+    o.postReply ??
+    (async ({ body, mentions, replyTo }) => {
+      await postMessage(o.server, o.token, o.channel, {
+        kind: "message",
+        body,
+        mentions,
+        reply_to: replyTo,
+      });
+    });
+
+  const conn = (o.connectImpl ?? connect)(o.server, o.token, o.channel, o.since, {
+    ...(o.onCursor ? { onCursor: o.onCursor } : {}),
+    ...(o.backoffBaseMs !== undefined ? { backoffBaseMs: o.backoffBaseMs } : {}),
+    // Phase-1 捷径：复用现有 watch 唤醒声明，协议不动（见文件头注释 / #672）。
+    advertiseWakeKind: "watch",
+  });
+
+  let self = "";
+  let code = 0;
+  let timedOut = false;
+  let aborted = false;
+
+  const onAbort = () => {
+    aborted = true;
+    conn.close();
+  };
+  if (o.abortSignal) {
+    if (o.abortSignal.aborted) onAbort();
+    else o.abortSignal.addEventListener("abort", onAbort, { once: true });
+  }
+
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  if (o.timeoutSec !== undefined && o.timeoutSec > 0) {
+    timer = setTimeout(() => {
+      timedOut = true;
+      conn.close();
+    }, o.timeoutSec * 1000);
+  }
+
+  try {
+    for await (const frame of conn.frames) {
+      if (frame.type === "welcome") {
+        self = frame.self;
+        out(`daemon: attached to #${o.channel} as @${self} (experimental, SDK-in-process)`);
+        continue;
+      }
+      if (frame.type === "error") {
+        out(`daemon: error ${frame.code}: ${frame.message}`);
+        if (frame.code === "unauthorized") code = EXIT_AUTH;
+        else if (frame.code === "archived") code = EXIT_ARCHIVED;
+        else code = 1;
+        break;
+      }
+      // spike：只有 plain 消息帧能唤醒。status/presence/delivery/message_update 等留给后续阶段。
+      if (frame.type !== "msg") continue;
+      const msg = frame;
+      const fromSelf = msg.sender.name === self;
+      const mentioned = msg.mentions.includes(self);
+      const fresh = msg.seq > conn.cursor;
+      // 无论是否唤醒都推进游标（并持久化）：daemon 是常驻读者，读过即已读。
+      if (msg.seq > 0) conn.ack(msg.seq);
+      if (fromSelf || !mentioned || !fresh) continue;
+
+      out(`daemon: woken by seq=${msg.seq} from ${msg.sender.name}`);
+      let reply: string;
+      try {
+        reply = await o.runner.run(msg.body, { channel: o.channel, sender: msg.sender.name, seq: msg.seq });
+      } catch (error) {
+        const em = error instanceof Error ? error.message : String(error);
+        out(`daemon: sdk session failed on seq=${msg.seq}: ${em}`);
+        // graceful：回一条简短失败提示而非崩溃；提示本身失败也吞掉（best-effort），进程续存。
+        try {
+          await post({
+            body: `⚠️ daemon SDK 会话失败（${em}）——本条 @ 未能就地处理，请重试或改走 human/serve。`,
+            mentions: [msg.sender.name],
+            replyTo: msg.seq,
+          });
+        } catch (postErr) {
+          out(`daemon: failed to post failure note for seq=${msg.seq}: ${postErr instanceof Error ? postErr.message : String(postErr)}`);
+        }
+        continue;
+      }
+
+      const body = reply.trim() || "(daemon: SDK 返回空结果)";
+      try {
+        await post({ body, mentions: [msg.sender.name], replyTo: msg.seq });
+        out(`daemon: replied to seq=${msg.seq}`);
+      } catch (error) {
+        out(`daemon: failed to post reply for seq=${msg.seq}: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    }
+  } finally {
+    if (timer) clearTimeout(timer);
+    o.abortSignal?.removeEventListener("abort", onAbort);
+    conn.close();
+  }
+
+  if (aborted || timedOut) return code;
+  // 帧流意外结束（非信号、非超时）：connect 层已彻底放弃重连。返回非零让上游看得见并可重启。
+  return code === 0 ? EXIT_STREAM_ENDED : code;
+}
+
+export async function run(argv: string[]): Promise<number> {
+  if (isHelpArg(argv, { allowHelpPositional: true })) {
+    console.log(HELP);
+    return 0;
+  }
+  const { positionals, flags } = parseArgs(argv);
+  const unknown = unknownFlagError(flags, ["channel", "timeout"]);
+  if (unknown !== null) {
+    console.error(unknown);
+    return 1;
+  }
+  const flagError = valueFlagError(flags, ["channel", "timeout"]);
+  if (flagError !== null) {
+    console.error(flagError);
+    return 1;
+  }
+
+  const auth = await resolveAuthDetailed();
+  if (!auth.server || !auth.token) {
+    console.error("no config, run: party login or party init --server URL --token T");
+    return 1;
+  }
+  const channel = resolveChannel(str(flags.channel) ?? positionals[0]);
+  if (!channel) {
+    console.error("no channel, pass one or bind with: party init --channel C");
+    return 1;
+  }
+  if (!isSlug(channel)) {
+    console.error("channel must match [a-z0-9][a-z0-9-]{0,63}");
+    return 1;
+  }
+  let timeoutSec = 0;
+  if (flags.timeout !== undefined) {
+    const parsed = Number(str(flags.timeout));
+    if (!Number.isFinite(parsed) || parsed < 0) {
+      console.error("--timeout must be a non-negative number of seconds");
+      return 1;
+    }
+    timeoutSec = Math.floor(parsed);
+  }
+
+  console.error(
+    "party daemon is EXPERIMENTAL (#672 Phase-1 spike): it embeds @anthropic-ai/claude-agent-sdk and " +
+      "runs an in-process SDK session on each @-mention. Protocol is unchanged — it advertises as a " +
+      "watch-style wake for now. Not wired into onboarding.",
+  );
+
+  const controller = new AbortController();
+  let signalCode = 0;
+  const onSignal = (signo: "SIGINT" | "SIGTERM") => {
+    signalCode = signo === "SIGINT" ? EXIT_SIGNAL_INT : EXIT_SIGNAL_TERM;
+    controller.abort();
+  };
+  const sigint = () => onSignal("SIGINT");
+  const sigterm = () => onSignal("SIGTERM");
+  process.on("SIGINT", sigint);
+  process.on("SIGTERM", sigterm);
+
+  try {
+    const code = await runDaemon({
+      server: auth.server,
+      token: auth.token,
+      channel,
+      since: loadCursor(channel),
+      runner: createSdkRunner(),
+      onCursor: (cursor) => saveCursor(channel, cursor),
+      timeoutSec,
+      abortSignal: controller.signal,
+    });
+    return signalCode !== 0 ? signalCode : code;
+  } finally {
+    process.off("SIGINT", sigint);
+    process.off("SIGTERM", sigterm);
+  }
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -28,6 +28,7 @@ commands:
   watch     [channel|--channel C] [--timeout N] [--mentions-only] [--follow] [--json]
   ack       [--channel C] [--seq N]                acknowledge a watch wake that needs no reply (#594)
   serve     [channel|--channel C] (--on-mention "<cmd>" | --runner codex|claude|codex-sdk) [--all] | --profile owner/handle
+  daemon    [channel|--channel C] [--timeout N]        EXPERIMENTAL (#672 spike): resident runner embedding the Claude Agent SDK; @-mention → in-process SDK session → reply
   mcp                                                structured control plane (not an idle wake provider)
   lark      notify on|off|status [--channel C]       send channel @mentions to your Lark/Feishu account
   task      create|list|assign|claim|status|block|done|solution [--channel C]  channel task ledger
@@ -105,6 +106,8 @@ export async function main(argv: string[]): Promise<number> {
       return (await import("./commands/ack")).run(rest);
     case "serve":
       return (await import("./commands/serve")).run(rest);
+    case "daemon":
+      return (await import("./commands/daemon")).run(rest);
     case "mcp":
       return (await import("./commands/mcp")).run(rest);
     case "lark":

--- a/cli/test/daemon.test.ts
+++ b/cli/test/daemon.test.ts
@@ -1,0 +1,188 @@
+// #672 Phase-1 spike：party daemon 单测。用真 connect + WS mock server 驱动帧流，注入 SDK runner
+// 与 postReply 捕获回帖——CI 永不触碰真 @anthropic-ai/claude-agent-sdk（SDK 无法在 CI 跑）。
+import { afterEach, describe, expect, test } from "bun:test";
+import { runDaemon, type DaemonOptions, type PostReply, type SdkRunner } from "../src/commands/daemon";
+import { msgFrame, startMockServer, welcomeFrame, type MockServer } from "./mock-server";
+
+let server: MockServer | null = null;
+
+afterEach(() => {
+  server?.stop();
+  server = null;
+});
+
+interface Captured {
+  reply: Parameters<PostReply>[0][];
+  runCalls: { prompt: string; sender: string; seq: number }[];
+  lines: string[];
+}
+
+function harness(over: {
+  runner: SdkRunner;
+  server: string;
+}): { opts: DaemonOptions; captured: Captured } {
+  const captured: Captured = { reply: [], runCalls: [], lines: [] };
+  const postReply: PostReply = async (r) => {
+    captured.reply.push(r);
+  };
+  const opts: DaemonOptions = {
+    server: over.server,
+    token: "ap_tok",
+    channel: "dev",
+    since: 0,
+    runner: over.runner,
+    postReply,
+    backoffBaseMs: 20,
+    // 收完 welcome + 一条 @ 后由 mock 关闭连接触发帧流结束；短 timeout 兜底防挂。
+    timeoutSec: 3,
+    out: (l) => captured.lines.push(l),
+  };
+  return { opts, captured };
+}
+
+function recordingRunner(reply: string): { runner: SdkRunner; calls: Captured["runCalls"] } {
+  const calls: Captured["runCalls"] = [];
+  return {
+    calls,
+    runner: {
+      async run(prompt, ctx) {
+        calls.push({ prompt, sender: ctx.sender, seq: ctx.seq });
+        return reply;
+      },
+    },
+  };
+}
+
+describe("party daemon (#672 Phase-1 spike)", () => {
+  test("@-mention → SDK invoked with mention text → SDK output posted back", async () => {
+    server = startMockServer((frame, sock) => {
+      if (frame.type !== "hello") return;
+      sock.send(welcomeFrame(0, "me"));
+      sock.send(msgFrame(1, "please summarize the thread", { mentions: ["me"] }));
+      // 让 daemon 处理完后自然收束：关闭连接结束帧流。
+      setTimeout(() => sock.close(), 60);
+    });
+
+    const { runner, calls } = recordingRunner("here is your summary");
+    const { opts, captured } = harness({ runner, server: server.url });
+    await runDaemon(opts);
+
+    // SDK 被调用一次，拿到的是 @-mention 正文（不是整帧）。
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.prompt).toBe("please summarize the thread");
+    expect(calls[0]!.sender).toBe("bob");
+    expect(calls[0]!.seq).toBe(1);
+
+    // SDK 返回文本被原样回帖，@ 回发起人、reply_to 指向原消息。
+    expect(captured.reply).toHaveLength(1);
+    expect(captured.reply[0]).toEqual({
+      body: "here is your summary",
+      mentions: ["bob"],
+      replyTo: 1,
+    });
+  });
+
+  test("hello advertises a wake kind so presence sees a live wake channel (Phase-1: watch)", async () => {
+    let helloWakeKind: unknown = "unset";
+    server = startMockServer((frame, sock) => {
+      if (frame.type !== "hello") return;
+      helloWakeKind = (frame as unknown as { wake_kind?: unknown }).wake_kind;
+      sock.send(welcomeFrame(0, "me"));
+      setTimeout(() => sock.close(), 30);
+    });
+
+    const { runner } = recordingRunner("noop");
+    const { opts } = harness({ runner, server: server.url });
+    await runDaemon(opts);
+
+    // Phase-1 捷径：daemon 复用 watch 唤醒声明，协议不动。
+    expect(helloWakeKind).toBe("watch");
+  });
+
+  test("SDK error → posts a short failure note, does not crash, keeps serving", async () => {
+    server = startMockServer((frame, sock) => {
+      if (frame.type !== "hello") return;
+      sock.send(welcomeFrame(0, "me"));
+      sock.send(msgFrame(1, "do the thing", { mentions: ["me"] }));
+      sock.send(msgFrame(2, "second try", { mentions: ["me"] }));
+      setTimeout(() => sock.close(), 80);
+    });
+
+    let calls = 0;
+    const runner: SdkRunner = {
+      async run() {
+        calls++;
+        throw new Error("model unavailable");
+      },
+    };
+    const { opts, captured } = harness({ runner, server: server.url });
+    // 不应抛：graceful 处理。
+    await runDaemon(opts);
+
+    // 两条 @ 都被尝试（进程未因第一条报错而崩溃）。
+    expect(calls).toBe(2);
+    // 每条都回了一条失败提示（含错误摘要），@ 回发起人、reply_to 指向原消息。
+    expect(captured.reply).toHaveLength(2);
+    expect(captured.reply[0]!.body).toContain("model unavailable");
+    expect(captured.reply[0]!.mentions).toEqual(["bob"]);
+    expect(captured.reply[0]!.replyTo).toBe(1);
+    expect(captured.reply[1]!.replyTo).toBe(2);
+  });
+
+  test("ignores own messages and non-mentions (no SDK call, no reply)", async () => {
+    server = startMockServer((frame, sock) => {
+      if (frame.type !== "hello") return;
+      sock.send(welcomeFrame(0, "me"));
+      // 自己发的（即便 @self）不唤醒
+      sock.send(msgFrame(1, "self note", { sender: { name: "me", kind: "agent" }, mentions: ["me"] }));
+      // 别人发但没 @ 我
+      sock.send(msgFrame(2, "chatter", { mentions: [] }));
+      setTimeout(() => sock.close(), 60);
+    });
+
+    const { runner, calls } = recordingRunner("should not run");
+    const { opts, captured } = harness({ runner, server: server.url });
+    await runDaemon(opts);
+
+    expect(calls).toHaveLength(0);
+    expect(captured.reply).toHaveLength(0);
+  });
+
+  test("empty SDK result falls back to a placeholder reply (never posts empty)", async () => {
+    server = startMockServer((frame, sock) => {
+      if (frame.type !== "hello") return;
+      sock.send(welcomeFrame(0, "me"));
+      sock.send(msgFrame(1, "hi", { mentions: ["me"] }));
+      setTimeout(() => sock.close(), 60);
+    });
+
+    const { runner } = recordingRunner("   ");
+    const { opts, captured } = harness({ runner, server: server.url });
+    await runDaemon(opts);
+
+    expect(captured.reply).toHaveLength(1);
+    expect(captured.reply[0]!.body.length).toBeGreaterThan(0);
+  });
+
+  test("abortSignal (SIGTERM) closes the connection and returns cleanly", async () => {
+    server = startMockServer((frame, sock) => {
+      if (frame.type !== "hello") return;
+      sock.send(welcomeFrame(0, "me"));
+      // 不发消息、不关闭：靠 abort 收束。
+    });
+
+    const controller = new AbortController();
+    const { runner } = recordingRunner("noop");
+    const { opts } = harness({ runner, server: server.url });
+    opts.abortSignal = controller.signal;
+    opts.timeoutSec = 0; // 常驻，仅靠 abort 退出
+
+    const done = runDaemon(opts);
+    // 等 attach 后再 abort
+    await new Promise((r) => setTimeout(r, 100));
+    controller.abort();
+    const code = await done;
+    // 干净关停返回 0（run() 再据信号翻成 128+signo）。
+    expect(code).toBe(0);
+  });
+});

--- a/docs/2026-07-21-sdk-daemon-residency.html
+++ b/docs/2026-07-21-sdk-daemon-residency.html
@@ -1,0 +1,199 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>AgentParty · SDK-backed daemon residency（第一方常驻 runner）</title>
+  <style>
+    :root {
+      --fg: #202124;
+      --muted: #5f6368;
+      --accent: #2457c5;
+      --border: #d9dde5;
+      --soft: #f5f7fa;
+      --code: #eef1f5;
+      --ok: #166534;
+      --warn: #9a3412;
+    }
+    * { box-sizing: border-box; }
+    body {
+      max-width: 1120px;
+      margin: 0 auto;
+      padding: 2rem 1.4rem 5rem;
+      color: var(--fg);
+      font: 16px/1.65 -apple-system, BlinkMacSystemFont, "PingFang SC", "Microsoft YaHei", sans-serif;
+    }
+    header { border-bottom: 3px solid var(--accent); padding-bottom: 1.1rem; margin-bottom: 2rem; }
+    h1 { margin: 0 0 .45rem; font-size: 1.75rem; line-height: 1.25; }
+    h2 { margin-top: 2.4rem; padding-left: .65rem; border-left: 4px solid var(--accent); font-size: 1.25rem; }
+    h3 { margin-top: 1.6rem; font-size: 1.05rem; }
+    p, li { max-width: 92ch; }
+    a { color: var(--accent); }
+    .meta { color: var(--muted); font-size: .9rem; }
+    .meta span { display: inline-block; margin-right: 1.2rem; }
+    .verdict {
+      margin: 1.4rem 0;
+      padding: 1rem 1.1rem;
+      border: 1px solid var(--border);
+      border-left: 5px solid var(--accent);
+      background: var(--soft);
+    }
+    .verdict strong { color: var(--accent); }
+    table { width: 100%; border-collapse: collapse; margin: 1rem 0; font-size: .9rem; }
+    th, td { border: 1px solid var(--border); padding: .55rem .65rem; text-align: left; vertical-align: top; }
+    th { background: var(--soft); }
+    .yes { color: var(--ok); font-weight: 650; }
+    .no { color: var(--warn); font-weight: 650; }
+    .new { color: var(--accent); font-weight: 650; }
+    code { background: var(--code); border-radius: 3px; padding: .08em .3em; font: .88em "SFMono-Regular", Menlo, Consolas, monospace; }
+    pre { overflow-x: auto; padding: .9rem 1rem; background: var(--code); border: 1px solid var(--border); border-radius: 6px; font-size: .82rem; line-height: 1.55; }
+    pre code { padding: 0; background: transparent; }
+    aside { margin: 1rem 0; padding: .75rem 1rem; background: var(--soft); border-left: 4px solid var(--accent); }
+    .flow { display: grid; grid-template-columns: repeat(5, 1fr); gap: .5rem; margin: 1.1rem 0; }
+    .flow span { padding: .65rem; text-align: center; border: 1px solid var(--border); background: var(--soft); font-size: .85rem; }
+    .flow span + span::before { content: "→ "; color: var(--accent); font-weight: 700; }
+    footer { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--border); color: var(--muted); font-size: .88rem; }
+    ol.phases > li { margin-bottom: .6rem; }
+    @media (max-width: 800px) {
+      body { padding-inline: .8rem; }
+      .flow { grid-template-columns: 1fr; }
+      .flow span + span::before { content: "↓ "; }
+      table { display: block; overflow-x: auto; white-space: normal; }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>SDK-backed <code>daemon</code> residency —— 让「可唤醒」从谎报变成真</h1>
+    <p class="meta">
+      <span>状态：提案（待 owner 拍板）</span>
+      <span>日期：2026-07-21</span>
+      <span>范围：presence / wake / runtime</span>
+    </p>
+  </header>
+
+  <div class="verdict">
+    <strong>TL;DR。</strong> AgentParty 是协调层，但它<strong>不拥有 agent 运行时</strong>——靠外部 harness（Claude Code <code>run_in_background</code> watcher、codex）去真正跑 agent。一整条 bug 血脉（#665 watcher 被 turn 边界回收、#508、#29、#199、唤醒债风暴）都源于此：<code>party watch --once</code> 是个<strong>单发子进程</strong>，命悬于外部 harness 的回合边界，所以 presence 里的「可唤醒」本质是谎报。
+    提案：引入一个<strong>第一方常驻 runner</strong>（<code>party daemon</code>），嵌入官方 <code>@anthropic-ai/claude-agent-sdk</code>，作为一个新的 <span class="new">daemon</span> residency / wake kind 接进现有 <code>Residency</code>/<code>WakeKind</code>/lease 模型。它持有真实心跳租约、被 @ 时直接跑 SDK session、不依赖任何 harness turn 边界——把「wakeable」从<em>暴露悲伤事实</em>升级为<em>真的成立</em>。<strong>但不 all-in</strong>：跨 harness/跨厂商是护城河，daemon 只作为最高档 residency 与 watch/serve/webhook/codex 并存。
+  </div>
+
+  <h2>1 · 问题：运行时是借来的</h2>
+  <p>
+    AgentParty 的每个 agent「实例」并不是它自己拉起来的进程，而是某个外部 harness 里的一次性子任务。<code>party watch --once</code> 是 single-shot：被 @ 唤醒一次、处理、退出，然后<strong>必须靠 harness 在下一回合重新挂上</strong>。当 harness（如 Claude Code）在 turn 边界回收后台任务时，watcher 就此消失——而 presence 层无从当场得知。
+  </p>
+  <p>下面这些 issue 不是各自独立的 bug，而是<strong>同一个根因的不同切面</strong>：</p>
+  <table>
+    <thead><tr><th>Issue</th><th>切面</th><th>根</th></tr></thead>
+    <tbody>
+      <tr><td>#665</td><td>watcher 被回收后 presence 仍显示可唤醒，三条 @ 石沉大海</td><td rowspan="5">agent 不是常驻 daemon，是每回合被拉起又被杀的子进程；「可唤醒」无真实心跳背书</td></tr>
+      <tr><td>#664</td><td>send --mention 到无 wake adapter 目标，发送方零反馈</td></tr>
+      <tr><td>#508 / #29</td><td>后台 watch 静默退出 / turn 边界回收，漏收 @</td></tr>
+      <tr><td>#199</td><td>watch --once 只重放最旧一条未读，不报落后量</td></tr>
+      <tr><td>唤醒债风暴</td><td>每次 watch --once 只清一条旧 seq，债越滚越多</td></tr>
+    </tbody>
+  </table>
+  <aside>
+    我们正在做的 <strong>#664 / #665 / #666</strong> 三个修复，本质是<strong>如实暴露「watch 不可靠」这个事实</strong>（send 时警告、presence 转 stale、网页标 unreachable）。这是必要的止血，但不是根治——它让用户<em>看见</em>不可靠，没让它<em>变可靠</em>。
+  </aside>
+
+  <h2>2 · <code>@anthropic-ai/claude-agent-sdk</code> 是什么</h2>
+  <p>
+    Anthropic 官方的 <strong>Agent SDK</strong>：Claude Code 背后同一套 harness，做成可嵌入你自己进程的库。一次依赖即得：agentic loop、tool use、MCP server 挂载、子代理（Task）、<code>canUseTool</code> 权限门、hooks、<strong>AskUserQuestion 拦截</strong>、session 持久化 / resume、streaming、skills、<code>effort</code> / <code>permissionMode</code>。
+  </p>
+  <p>
+    参考实现：<a href="https://github.com/sorrycc/Helm">helm-agent</a>（陈成 / sorrycc）——它的 daemon 本质就是「把 SDK session 包成常驻服务 + HTTP/SSE + 桌面 UI」。它的 contracts 直接引用 SDK 类型（<code>McpSdkServerConfigWithInstance</code>、<code>parent_tool_use_id</code>、<code>effort</code>、permission modes）。<strong>helm 没有我们这条 reaped-watcher bug 血脉——因为它拥有运行时。</strong>
+  </p>
+
+  <h2>3 · 提案：<code>daemon</code> residency</h2>
+  <p>
+    出一个第一方常驻 runner —— <code>party daemon</code>（工作名）—— 内嵌 <code>@anthropic-ai/claude-agent-sdk</code>。它：
+  </p>
+  <ul>
+    <li>以一个<strong>长期进程</strong>注册进频道，持有<strong>真实心跳租约</strong>的 presence——不是「自报可唤醒」，是「服务端每 N 秒收到活体心跳」。</li>
+    <li>被 @ 时，daemon 直接在本地跑一个 SDK session 处理该 mention，<strong>不依赖任何 harness turn 边界</strong>；处理完回复 + 落 ack，不退出。</li>
+    <li>天然拿到 <code>canUseTool</code> 权限门（对接我们的 owner/worker/front 边界）、hooks、AskUserQuestion（对接 <code>decision_request</code> #284）。</li>
+  </ul>
+
+  <h3>3.1 接进现有模型（不是另起炉灶）</h3>
+  <p>当前 <code>shared/src/protocol.ts</code> 已有一套成熟的 residency / wake / lease 抽象，daemon 只是新增一档：</p>
+  <table>
+    <thead><tr><th><code>WakeKind</code></th><th><code>Residency</code></th><th>谁控制投递 / 存活</th><th>服务端可验证？</th><th>被 harness 回收？</th></tr></thead>
+    <tbody>
+      <tr><td><code>watch</code></td><td><code>supervised</code></td><td>外部 harness 重挂 watcher</td><td class="no">否（自报）</td><td class="no">会（根因）</td></tr>
+      <tr><td><code>serve</code></td><td><code>supervised</code></td><td>常驻 serve 循环 + 租约</td><td>部分</td><td>较少</td></tr>
+      <tr><td><code>webhook</code></td><td><code>webhook</code></td><td>服务端 POST 投递</td><td class="yes">是（天然）</td><td class="yes">否</td></tr>
+      <tr><td><code>none</code></td><td><code>bare</code> / <code>human_driven</code></td><td>靠人 / 无</td><td class="no">否</td><td>—</td></tr>
+      <tr><td class="new">daemon <em>(新)</em></td><td class="new">daemon <em>(新)</em></td><td class="new">第一方 SDK 常驻进程 + 心跳租约</td><td class="yes">是（心跳 = 活体证据）</td><td class="yes">否（自持进程）</td></tr>
+    </tbody>
+  </table>
+  <p>
+    关键：<code>wakeableState()</code> 今天只有 webhook 能算 <code>wakeable_verified</code>（服务端持端点）。<span class="new">daemon 的心跳本身就是服务端可观测的活体证据</span>，所以它也能<strong>凭构造进入 verified 档</strong>——而不是像 watch 那样要等 <code>verified_at</code> 被动盖章。租约到期（<code>PRESENCE_TIMEOUT_MS = 60s</code> 没心跳）即如实转 stale，<code>evaluateHostLease()</code> 直接复用。</p>
+
+  <h3>3.2 唤醒流（对比今天）</h3>
+  <p><strong>今天（watch）：</strong></p>
+  <div class="flow">
+    <span>@mention</span><span>DO 落 delivery ledger</span><span>等 harness 下回合重挂 watch</span><span>watch --once 醒、拉一条</span><span>处理后退出（债留存）</span>
+  </div>
+  <p><strong>提案（daemon）：</strong></p>
+  <div class="flow">
+    <span>@mention</span><span>DO 查 daemon 租约=active</span><span>推送/长连唤醒常驻 daemon</span><span>SDK session 就地处理</span><span>回复+清债，进程续存</span>
+  </div>
+
+  <h3>3.3 权限与决策（顺带解锁）</h3>
+  <table>
+    <thead><tr><th>SDK 能力</th><th>接进 AgentParty</th></tr></thead>
+    <tbody>
+      <tr><td><code>canUseTool</code> 权限回调 + per-tool 风险分级</td><td>owner / worker / front 三方边界的<strong>运行时执行点</strong>；可借鉴 helm 的 <code>risk.ts</code>（low/medium/high + destructive-token 正则）</td></tr>
+      <tr><td>AskUserQuestion 拦截</td><td>直接映射到 <code>decision_request</code>（#284）——daemon 把 SDK 的提问转成频道里的人类决策请求</td></tr>
+      <tr><td><code>permissionMode</code> / <code>effort</code> 级联</td><td>per-channel / per-agent 策略（可借鉴 helm 的 session-policy cascade：sidecar → workspace → config default）</td></tr>
+    </tbody>
+  </table>
+
+  <h2>4 · 不 all-in：daemon 只是最高档，不取代协调层</h2>
+  <p>
+    AgentParty 的差异化是<strong>跨 harness、跨厂商</strong>——它协调 Claude Code + codex + 人类。把运行时锁死到 Anthropic SDK 会收窄这个护城河。所以：
+  </p>
+  <ul>
+    <li><span class="new">daemon</span> 是<strong>新增</strong>的一档 residency，不是替换。watch / serve / webhook / codex / human_driven 全部保留，覆盖 SDK 之外的 harness 与人类。</li>
+    <li>daemon 成为「wakeable 真的成立」的<strong>金标准档</strong>；其余档继续存在，只是如实标注可靠性（这正是 #664/#665/#666 在做的）。</li>
+    <li>用户可选：要「叫得醒、不掉线」就用 <code>party daemon</code>；要「继续用我的 Claude Code / codex 会话」就用 watch/serve，接受其 harness 语义。</li>
+  </ul>
+
+  <h2>5 · 分阶段落地</h2>
+  <ol class="phases">
+    <li><strong>Spike（1）</strong>：最小 <code>party daemon</code> —— 嵌 SDK，起一个能被 party @ 唤醒、就地跑 SDK session 回复的常驻进程。协议不动，先证明「常驻 + 可被唤醒」成立。</li>
+    <li><strong>协议接入（2）</strong>：加 <code>WakeKind:"daemon"</code> + <code>Residency:"daemon"</code>；心跳租约走 <code>evaluateHostLease</code>；<code>wakeableState</code> 让 daemon 凭心跳进 verified。<em>（注意 #622 教训：<code>client.ts</code> 校验词表须逐字镜像；建议同时评估 zod 单源，见附录。）</em></li>
+    <li><strong>权限与决策（3）</strong>：接 <code>canUseTool</code> → owner/worker 边界 + 风险分级；AskUserQuestion → <code>decision_request</code>。</li>
+    <li><strong>Dogfood（4）</strong>：在一个频道用 daemon 跑一个真 agent，与 watch 对照，验证「不再石沉大海 / 不再滚债」。</li>
+    <li><strong>桌面/接入包（5）</strong>：把 daemon 作为接入包的一种模式（对照 helm 的 daemon + selfsigned 本地 HTTPS + QR 配对）。</li>
+  </ol>
+
+  <h2>6 · 风险与未决</h2>
+  <table>
+    <thead><tr><th>风险 / 问题</th><th>取向</th></tr></thead>
+    <tbody>
+      <tr><td>常驻进程的部署/托管（谁来 7×24 跑 daemon？）</td><td>本地机器（桌面端）/ 用户自托管；先不强上云。心跳租约天然处理「机器睡了」= 转 stale。</td></tr>
+      <tr><td>SDK 版本/计费绑定 Anthropic</td><td>可接受——它只是<strong>一档</strong> residency；其它 harness 不受影响。</td></tr>
+      <tr><td>与 serve 的边界（serve 已是常驻+租约）</td><td>daemon = serve + <strong>自带 SDK 运行时</strong>（serve 仍要外部 agent 进程；daemon 自己就是 agent）。需在设计里划清，或让 daemon 成为 serve 的一种 runner 后端。</td></tr>
+      <tr><td>多 daemon 实例 / 抢占</td><td>复用现有同名 serve 实例待命 + 租约裁决逻辑。</td></tr>
+    </tbody>
+  </table>
+
+  <h2>附录 · 从 helm-agent 顺手可借鉴的模式</h2>
+  <p>（<code>helm-agent</code> 源码 <code>license: UNLICENSED</code>——借<strong>思路</strong>不抄码。）</p>
+  <table>
+    <thead><tr><th>helm 模式</th><th>对 AgentParty 的价值</th></tr></thead>
+    <tbody>
+      <tr><td><strong>zod 契约 = 单一真源</strong>，事件用带 tag 的 discriminated union，两端同一处 import</td><td>根治 <strong>#622</strong> 的「<code>client.ts</code> 手写 allow-list 与 <code>protocol.ts</code> 漂移」——结构上不可能漂移</td></tr>
+      <tr><td><strong><code>state</code> 与 <code>tempo</code> 正交</strong>（生命周期 vs「此刻是否在等用户」），idle reaper 在 <code>blocked</code> 时不回收</td><td>正是 <strong>#664/#665/#666</strong> 的正解：presence 别把「在线」和「可唤醒」糊在一起；blocked-on-user 的会话不该被当空闲杀</td></tr>
+      <tr><td><strong>结构化错误变体</strong>（每个错误是带上下文的类型，如 <code>stale_in_progress{stuckIssueIds,hint}</code>）</td><td>#663/#664 想要的「可见、可操作反馈」——取代 stringly <code>errorBody(code,message)</code></td></tr>
+      <tr><td><strong>磁盘持久化 session-status 作真源</strong>，原子写于状态机跃迁点，消费方读盘</td><td>presence 真值分层：落盘真源 + 流只管细节</td></tr>
+      <tr><td><strong>插件能力注册表</strong>（type-only 公共面、id 自动命名空间、warn-and-ignore 降级）</td><td>把现有硬编码的 Lark/Discord/微信 channel adapter 正式化为可扩展注册表</td></tr>
+    </tbody>
+  </table>
+
+  <footer>
+    AgentParty 内部设计提案 · 2026-07-21 · 基于 <code>shared/src/protocol.ts</code>（<code>Residency</code> / <code>WakeKind</code> / <code>evaluateHostLease</code> / <code>wakeableState</code> / <code>PRESENCE_TIMEOUT_MS</code>）实况核对 · 参考 helm-agent 0.0.31 contracts。
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
> 🚧 **DRAFT / SPIKE —— 请勿直接合并。** 这是 #672 daemon-residency 的 Phase-1 骨架,加了新依赖且**真实运行时未经 live 验证**,需要 owner 审 + 交互式跑一遍真 SDK/真唤醒才能考虑上生产。

Refs #672。设计依据:`docs/2026-07-21-sdk-daemon-residency.html`(本 PR 一并补交)。

## 目标(仅 Phase 1)
证明「一个嵌 `@anthropic-ai/claude-agent-sdk` 的常驻进程能注册进 party 频道,被 @ 时跑 SDK session 回帖,不依赖 harness turn 边界」。**协议不动。**

## 改动(全新增,5 文件 +517)
- `cli/src/commands/daemon.ts`:`party daemon <channel>` —— 复用 watch/serve 的 `client.connect` + `rest.postMessage` 连接机制;被 @ 时调注入的 `SdkRunner`(生产实现懒加载真 SDK `query()`,收集 `type:"result"` 文本),回帖带 `mentions:[sender]` + `reply_to`。SDK 出错落一条失败提示不崩;SIGTERM 干净断连清 presence。
- `cli/src/index.ts`:`case "daemon"` + 一行 **EXPERIMENTAL** HELP;**不**接入 onboarding/接入包。
- `cli/package.json` + `bun.lock`:`bun add @anthropic-ai/claude-agent-sdk@^0.3.216`(仅 cli)。
- `cli/test/daemon.test.ts`:6 单测(mock SDK)。

## 单测验证了什么(6 pass)
@ 帧→SDK 收到 mention body→返回文本回帖;SDK 错误→失败提示不崩;自消息/非 @ 忽略不调 SDK;空结果→占位回复;hello 广告 wake_kind 让 presence 见活 wake 通道;abortSignal→干净断连。tsc 清,回归抽查 32 pass。

## Phase-1 捷径(刻意)
- 广告成 `wake_kind:"watch"`,**不**加 `WakeKind/Residency:"daemon"`(Phase 2 才动协议 + 真租约 + client.ts 校验镜像,#622)。
- 只处理纯 `msg` 帧;status/presence/durable directed-delivery/paused/squad 全忽略;无实例锁、无 wake-debt、串行处理。

## ⚠️ 全部待 LIVE 验证(agent 无法验)
- **真 SDK 调用**:auth/model 解析、延迟、`options`(现为空)未验;**无头常驻可能卡在交互式 tool 权限询问**——`permissionMode`/allowed-tools 是必须在 live 定的开放决策。
- **真唤醒往返**:hello 带 wake_kind 是否真让 daemon 进 `wakeable_verified`;真 @ 是否以纯 `msg` 帧到达(而非 durable directed-delivery,spike 忽略了它)。
- **真回帖 postMessage**、**SIGTERM 服务端 markOffline**、首挂 cursor=0 会回放历史。

## Phase 2 需要
`WakeKind/Residency:"daemon"` + 真心跳租约(接 `wakeableState`/`evaluateHostLease`);client.ts 校验逐字镜像(或上 zod 单源);`canUseTool`→owner/worker 边界;AskUserQuestion→decision_request(#284);一个频道 dogfood 对照 watch。

🤖 由 agent 在隔离 worktree 实现;人工审后作为草稿保留,待 live 验证。