### PR TITLE
feat(web): 频道常驻焦点栏——聚合 task/status/decision 显示球在谁手里 (#682)

### DIFF
--- a/web/src/components/ChannelFocusBar.test.tsx
+++ b/web/src/components/ChannelFocusBar.test.tsx
@@ -1,0 +1,156 @@
+// #682：ChannelFocusBar 渲染——三态视觉可区分、「在等你」高亮、无在途项则不渲染、下钻回调接线。
+// @ts-expect-error Bun executes this test, while the web tsconfig intentionally loads only Vite globals.
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { LocaleProvider } from "../i18n/locale";
+import type { ChannelFocus, FocusItem } from "../lib/channelFocus";
+import { ChannelFocusBar } from "./ChannelFocusBar";
+
+let renderer: ReactTestRenderer | null = null;
+
+function memoryStorage(): Storage {
+  const values = new Map<string, string>();
+  return {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => { values.set(key, value); },
+    removeItem: (key) => { values.delete(key); },
+    clear: () => values.clear(),
+    key: (index) => [...values.keys()][index] ?? null,
+    get length() { return values.size; },
+  };
+}
+
+beforeEach(() => {
+  Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", { configurable: true, value: true });
+  Object.defineProperty(globalThis, "localStorage", { configurable: true, value: memoryStorage() });
+});
+
+afterEach(() => {
+  act(() => { renderer?.unmount(); });
+  renderer = null;
+});
+
+function item(overrides: Partial<FocusItem> & { key: string }): FocusItem {
+  return {
+    name: "Evan",
+    label: "真机跑单",
+    state: "working",
+    blockedOn: null,
+    taskId: null,
+    seq: null,
+    waitingOnMe: false,
+    stale: false,
+    ...overrides,
+  };
+}
+
+function focus(overrides: Partial<ChannelFocus> = {}): ChannelFocus {
+  const items = overrides.items ?? [];
+  return {
+    focus: null,
+    focusSource: null,
+    items,
+    waitingOnMe: items.filter((i) => i.waitingOnMe),
+    counts: { working: 0, blocked: 0, waitingDecision: 0, stalled: 0 },
+    empty: items.length === 0,
+    ...overrides,
+  };
+}
+
+function render(props: Parameters<typeof ChannelFocusBar>[0]) {
+  localStorage.setItem("ap_locale", "en");
+  act(() => {
+    renderer = create(
+      <LocaleProvider>
+        <ChannelFocusBar {...props} />
+      </LocaleProvider>,
+    );
+  });
+}
+
+function classNames(): string[] {
+  const out: string[] = [];
+  const walk = (node: unknown) => {
+    if (node === null || typeof node !== "object") return;
+    const el = node as { props?: { className?: string }; children?: unknown[] };
+    if (typeof el.props?.className === "string") out.push(el.props.className);
+    if (Array.isArray(el.children)) el.children.forEach(walk);
+  };
+  const json = renderer!.toJSON();
+  (Array.isArray(json) ? json : [json]).forEach(walk);
+  return out;
+}
+
+describe("ChannelFocusBar (#682)", () => {
+  test("renders nothing when nothing is in flight and there is no override", () => {
+    render({ focus: focus() });
+    expect(renderer!.toJSON()).toBeNull();
+  });
+
+  test("renders the three states with visually distinct modifier classes", () => {
+    render({
+      focus: focus({
+        items: [
+          item({ key: "a", name: "Evan", state: "working" }),
+          item({ key: "b", name: "kw", state: "blocked", blockedOn: "等结果", label: "x" }),
+          item({ key: "c", name: "front", state: "waiting_decision", label: "prod A/B?", seq: 9 }),
+          item({ key: "d", name: "ghost", state: "stalled", stale: true }),
+        ],
+        counts: { working: 1, blocked: 1, waitingDecision: 1, stalled: 1 },
+      }),
+    });
+    const cls = classNames().join(" ");
+    expect(cls).toContain("focus-item--working");
+    expect(cls).toContain("focus-item--blocked");
+    expect(cls).toContain("focus-item--waiting_decision");
+    expect(cls).toContain("focus-item--stalled");
+    // distinct dots per state
+    expect(cls).toContain("focus-dot--working");
+    expect(cls).toContain("focus-dot--blocked");
+    expect(cls).toContain("focus-dot--waiting_decision");
+    expect(cls).toContain("focus-dot--stalled");
+  });
+
+  test("blocked item shows the blocked reason inline", () => {
+    render({ focus: focus({ items: [item({ key: "b", state: "blocked", blockedOn: "等 KycFeign 结果", label: "x" })] }) });
+    expect(JSON.stringify(renderer!.toJSON())).toContain("等 KycFeign 结果");
+  });
+
+  test("highlights the 'waiting on you' block for owner/moderator", () => {
+    const me = item({ key: "d", name: "front", state: "waiting_decision", label: "approve prod", seq: 5, waitingOnMe: true });
+    render({ focus: focus({ items: [me], counts: { working: 0, blocked: 0, waitingDecision: 1, stalled: 0 } }), viewerIsModerator: true });
+    const cls = classNames().join(" ");
+    expect(cls).toContain("focus-me");
+    expect(cls).toContain("focus-item--me");
+    // moderator wording
+    expect(JSON.stringify(renderer!.toJSON())).toContain("needs your call");
+  });
+
+  test("wires task drill-down to onOpenTask and decision drill-down to onJumpSeq", () => {
+    const openedTasks: number[] = [];
+    const jumped: number[] = [];
+    render({
+      focus: focus({
+        items: [
+          item({ key: "task-3", state: "working", taskId: 3 }),
+          item({ key: "decision-9", name: "front", state: "waiting_decision", label: "d", seq: 9 }),
+        ],
+      }),
+      onOpenTask: (id) => openedTasks.push(id),
+      onJumpSeq: (seq) => jumped.push(seq),
+    });
+    // find the two drill buttons and click them
+    const buttons = renderer!.root.findAllByType("button");
+    expect(buttons.length).toBeGreaterThanOrEqual(2);
+    act(() => { buttons[0]!.props.onClick(); });
+    act(() => { buttons[1]!.props.onClick(); });
+    expect(openedTasks).toEqual([3]);
+    expect(jumped).toEqual([9]);
+  });
+
+  test("shows a manual focus line when host set an override even with no items", () => {
+    render({ focus: focus({ focus: "结果查询 + 上传端到端联调", focusSource: "manual" }) });
+    expect(renderer!.toJSON()).not.toBeNull();
+    expect(JSON.stringify(renderer!.toJSON())).toContain("结果查询 + 上传端到端联调");
+  });
+});

--- a/web/src/components/ChannelFocusBar.tsx
+++ b/web/src/components/ChannelFocusBar.tsx
@@ -1,0 +1,117 @@
+// 频道常驻焦点栏（#682）：进频道第一屏就看到「球在谁手里、在等谁、谁在等我」，不用往回翻几十条。
+// 纯渲染视图——数据全来自已有的 presence + 任务台账 + 未闭合决策（见 lib/channelFocus），
+// 就地更新、不产生 seq、不发帧（不重蹈 #675 刷屏）。三态用不同颜色/图标区分，stalled 单列第四态
+// 提示「可能停滞」而非谎报在做（#665）。栏空（无在途项且无 override）时不渲染，不占屏。
+import { useT } from "../i18n/useT";
+import "../i18n/strings/ChannelFocusBar";
+import type { ChannelFocus, FocusItem, FocusItemState } from "../lib/channelFocus";
+
+// 三态（+stalled）→ 图标/CSS 修饰。owner 扫「等人拍板」，用醒目 ◆；被卡 ■；在做 ●；停滞 ◌（空心=不确定还活着）。
+const STATE_ICON: Record<FocusItemState, string> = {
+  waiting_decision: "◆",
+  blocked: "■",
+  working: "●",
+  stalled: "◌",
+};
+
+function stateLabel(item: FocusItem, t: ReturnType<typeof useT>): string {
+  if (item.state === "blocked" && item.blockedOn !== null) {
+    return t("ChannelFocusBar.state.blockedOn", { reason: item.blockedOn });
+  }
+  return t(`ChannelFocusBar.state.${item.state}`);
+}
+
+export function ChannelFocusBar({
+  focus,
+  viewerIsModerator = false,
+  onOpenTask,
+  onJumpSeq,
+}: {
+  focus: ChannelFocus;
+  /** owner/moderator 视角：把「在等你」文案换成「等你拍板」，更贴 owner 最关心的那一类。 */
+  viewerIsModerator?: boolean;
+  /** 下钻：点 task 派生项 → 打开任务台账（可定位到该 id）。 */
+  onOpenTask?: (taskId: number) => void;
+  /** 下钻：点 decision 派生项 → 跳到对应消息。 */
+  onJumpSeq?: (seq: number) => void;
+}) {
+  const t = useT();
+  // 无 override 焦点 + 无任何在途项 = 什么都不显示（issue：nothing in flight → 不渲染）。
+  if (focus.empty && focus.focus === null) return null;
+
+  const drill = (item: FocusItem): (() => void) | undefined => {
+    if (item.taskId !== null && onOpenTask !== undefined) return () => onOpenTask(item.taskId!);
+    if (item.seq !== null && onJumpSeq !== undefined) return () => onJumpSeq(item.seq!);
+    return undefined;
+  };
+  const drillTitle = (item: FocusItem): string | undefined => {
+    if (item.taskId !== null) return t("ChannelFocusBar.openTask", { id: item.taskId });
+    if (item.seq !== null) return t("ChannelFocusBar.openDecision", { seq: item.seq });
+    return undefined;
+  };
+
+  const meLabel = viewerIsModerator ? t("ChannelFocusBar.waitingOnMeOwner") : t("ChannelFocusBar.waitingOnMe");
+
+  const renderItem = (item: FocusItem, opts: { me?: boolean } = {}) => {
+    const onClick = drill(item);
+    const title = drillTitle(item);
+    const cls =
+      `focus-item focus-item--${item.state}` +
+      (item.waitingOnMe ? " focus-item--me" : "") +
+      (onClick !== undefined ? " focus-item--drill" : "");
+    const body = (
+      <>
+        <span className={`focus-dot focus-dot--${item.state}`} aria-hidden="true">{STATE_ICON[item.state]}</span>
+        <span className="focus-item-name">{item.name}</span>
+        <span className="focus-item-label" title={item.label}>{item.label}</span>
+        <span className={`focus-item-state focus-item-state--${item.state}`} title={item.state === "stalled" ? t("ChannelFocusBar.stalledHint") : undefined}>
+          {stateLabel(item, t)}
+        </span>
+        {opts.me === true && <span className="focus-item-me-badge t-mono">{meLabel}</span>}
+      </>
+    );
+    if (onClick !== undefined) {
+      return (
+        <li key={item.key} className={cls}>
+          <button type="button" className="focus-item-btn" onClick={onClick} title={title}>{body}</button>
+        </li>
+      );
+    }
+    return <li key={item.key} className={cls}>{body}</li>;
+  };
+
+  return (
+    <section className="channel-focus-bar" aria-label={t("ChannelFocusBar.aria")}>
+      <header className="focus-head">
+        <span className="t-mono focus-heading">{t("ChannelFocusBar.heading")}</span>
+        {focus.focus !== null && <span className="focus-line">{focus.focus}</span>}
+        <span className="t-mono focus-counts" aria-hidden="true">
+          {t("ChannelFocusBar.counts", {
+            working: focus.counts.working,
+            blocked: focus.counts.blocked,
+            decision: focus.counts.waitingDecision,
+            stalled: focus.counts.stalled,
+          })}
+        </span>
+      </header>
+
+      {focus.waitingOnMe.length > 0 && (
+        <div className="focus-me" role="group" aria-label={meLabel}>
+          <span className="t-mono focus-me-label">{meLabel}</span>
+          <ul className="focus-list focus-list--me">
+            {focus.waitingOnMe.map((item) => renderItem(item, { me: false }))}
+          </ul>
+        </div>
+      )}
+
+      {focus.items.length > 0 && (
+        <>
+          <span className="t-mono focus-waiting-label">{t("ChannelFocusBar.waitingOn")}</span>
+          <ul className="focus-list">
+            {focus.items.map((item) => renderItem(item))}
+          </ul>
+        </>
+      )}
+    </section>
+  );
+}

--- a/web/src/i18n/strings/ChannelFocusBar.ts
+++ b/web/src/i18n/strings/ChannelFocusBar.ts
@@ -1,0 +1,41 @@
+import { registerDict, type LocaleDict } from "../dict";
+
+// 频道焦点栏（#682）词典：一眼看清「球在谁手里、在等谁、谁在等我」。zh/en 双语。
+export const ChannelFocusBarStrings: LocaleDict = {
+  en: {
+    "ChannelFocusBar.aria": "Channel focus — who the ball is with",
+    "ChannelFocusBar.heading": "focus",
+    "ChannelFocusBar.focusManual": "focus",
+    "ChannelFocusBar.waitingOn": "waiting on",
+    "ChannelFocusBar.waitingOnMe": "waiting on you",
+    "ChannelFocusBar.waitingOnMeOwner": "needs your call",
+    "ChannelFocusBar.state.working": "working",
+    "ChannelFocusBar.state.blocked": "blocked",
+    "ChannelFocusBar.state.blockedOn": "blocked on {reason}",
+    "ChannelFocusBar.state.waiting_decision": "waiting on human decision",
+    "ChannelFocusBar.state.stalled": "possibly stalled / offline",
+    "ChannelFocusBar.stalledHint": "reported working but presence is stale — may be stalled or offline",
+    "ChannelFocusBar.openTask": "open task #{id}",
+    "ChannelFocusBar.openDecision": "open decision #{seq}",
+    "ChannelFocusBar.counts": "{working} working · {blocked} blocked · {decision} awaiting decision · {stalled} stalled",
+  },
+  zh: {
+    "ChannelFocusBar.aria": "频道焦点——球在谁手里",
+    "ChannelFocusBar.heading": "焦点",
+    "ChannelFocusBar.focusManual": "焦点",
+    "ChannelFocusBar.waitingOn": "在等",
+    "ChannelFocusBar.waitingOnMe": "在等你",
+    "ChannelFocusBar.waitingOnMeOwner": "等你拍板",
+    "ChannelFocusBar.state.working": "在做",
+    "ChannelFocusBar.state.blocked": "被卡",
+    "ChannelFocusBar.state.blockedOn": "被卡：{reason}",
+    "ChannelFocusBar.state.waiting_decision": "等人拍板",
+    "ChannelFocusBar.state.stalled": "可能停滞 / 离线",
+    "ChannelFocusBar.stalledHint": "自报在做，但 presence 已陈旧——可能已停滞或离线",
+    "ChannelFocusBar.openTask": "打开任务 #{id}",
+    "ChannelFocusBar.openDecision": "打开决策 #{seq}",
+    "ChannelFocusBar.counts": "{working} 在做 · {blocked} 被卡 · {decision} 待拍板 · {stalled} 停滞",
+  },
+};
+
+registerDict(ChannelFocusBarStrings);

--- a/web/src/lib/channelFocus.test.ts
+++ b/web/src/lib/channelFocus.test.ts
@@ -1,0 +1,295 @@
+// @ts-expect-error Bun executes this test, while the web tsconfig intentionally loads only Vite globals.
+import { describe, expect, test } from "bun:test";
+import type { MsgFrame, PresenceEntry, TaskRecord } from "@agentparty/shared";
+import { computeChannelFocus, pendingDecisionsFromMessages, type PendingDecision } from "./channelFocus";
+
+const NOW = 1_700_000_000_000;
+
+function presence(overrides: Partial<PresenceEntry> & { name: string }): PresenceEntry {
+  return {
+    name: overrides.name,
+    kind: "agent",
+    state: "working",
+    note: null,
+    ts: NOW,
+    last_seen: NOW,
+    ...overrides,
+  } as PresenceEntry;
+}
+
+function task(overrides: Partial<TaskRecord> & { id: number }): TaskRecord {
+  return {
+    type: "task",
+    id: overrides.id,
+    channel: "kyc",
+    title: `task ${overrides.id}`,
+    desc: null,
+    state: "in_progress",
+    assignee: { name: "Evan", kind: "agent" },
+    created_by: "front",
+    created_by_kind: "agent",
+    priority: 0,
+    labels: [],
+    parent_id: null,
+    anchor_seqs: [],
+    scope: [],
+    blocked_reason: null,
+    external_ref: null,
+    completion_artifact: null,
+    workflow_id: null,
+    created_at: NOW,
+    updated_at: NOW,
+    completed_at: null,
+    ...overrides,
+  } as TaskRecord;
+}
+
+function msg(overrides: Partial<MsgFrame> & { seq: number }): MsgFrame {
+  return {
+    type: "msg",
+    seq: overrides.seq,
+    sender: { name: "planner", kind: "agent" },
+    kind: "message",
+    body: "body",
+    mentions: [],
+    reply_to: null,
+    state: null,
+    note: null,
+    status: null,
+    ts: NOW,
+    ...overrides,
+  } as MsgFrame;
+}
+
+const NO_VIEWER = { name: null, account: null, canModerate: false };
+
+describe("computeChannelFocus — aggregation across the three states", () => {
+  test("live assignee on an in_progress task reads as working; drill-down keeps the task id", () => {
+    const focus = computeChannelFocus({
+      presence: [presence({ name: "Evan", live: true })],
+      tasks: [task({ id: 1, title: "真机跑单", assignee: { name: "Evan", kind: "agent" } })],
+      decisions: [],
+      viewer: NO_VIEWER,
+      now: NOW,
+    });
+    expect(focus.items).toHaveLength(1);
+    const [item] = focus.items;
+    expect(item!.state).toBe("working");
+    expect(item!.name).toBe("Evan");
+    expect(item!.label).toBe("真机跑单");
+    expect(item!.taskId).toBe(1);
+    expect(focus.counts.working).toBe(1);
+    expect(focus.empty).toBe(false);
+  });
+
+  test("blocked task surfaces the blocked_reason and stays blocked regardless of presence freshness", () => {
+    const focus = computeChannelFocus({
+      // 全员 offline，但 blocked 与在场无关，不降级为 stalled。
+      presence: [presence({ name: "kw", state: "offline", last_seen: NOW - 3_600_000 })],
+      tasks: [task({ id: 2, state: "blocked", blocked_reason: "等 KycFeign 结果", assignee: { name: "kw", kind: "agent" } })],
+      decisions: [],
+      viewer: NO_VIEWER,
+      now: NOW,
+    });
+    const [item] = focus.items;
+    expect(item!.state).toBe("blocked");
+    expect(item!.blockedOn).toBe("等 KycFeign 结果");
+    expect(focus.counts.blocked).toBe(1);
+  });
+
+  test("pending decision becomes a waiting_decision item carrying the message seq", () => {
+    const focus = computeChannelFocus({
+      presence: [],
+      tasks: [],
+      decisions: [{ seq: 42, prompt: "prod 走 A 还是 B?", asker: "front", expectedResponderOwner: null }],
+      viewer: NO_VIEWER,
+      now: NOW,
+    });
+    const [item] = focus.items;
+    expect(item!.state).toBe("waiting_decision");
+    expect(item!.name).toBe("front");
+    expect(item!.label).toBe("prod 走 A 还是 B?");
+    expect(item!.seq).toBe(42);
+    expect(focus.counts.waitingDecision).toBe(1);
+  });
+
+  test("orders items by urgency: waiting_decision > blocked > working > stalled", () => {
+    const focus = computeChannelFocus({
+      presence: [
+        presence({ name: "Live", live: true }),
+        presence({ name: "Gone", state: "working", live: false, last_seen: NOW - 3_600_000 }),
+      ],
+      tasks: [
+        task({ id: 1, assignee: { name: "Live", kind: "agent" } }),
+        task({ id: 2, assignee: { name: "Gone", kind: "agent" } }),
+        task({ id: 3, state: "blocked", blocked_reason: "x", assignee: { name: "kw", kind: "agent" } }),
+      ],
+      decisions: [{ seq: 9, prompt: "decide", asker: "front", expectedResponderOwner: null }],
+      viewer: NO_VIEWER,
+      now: NOW,
+    });
+    expect(focus.items.map((i) => i.state)).toEqual(["waiting_decision", "blocked", "working", "stalled"]);
+  });
+});
+
+describe("computeChannelFocus — staleness downgrade (#665 guard)", () => {
+  test("working task whose assignee is offline/stale downgrades to stalled, not working", () => {
+    const focus = computeChannelFocus({
+      presence: [presence({ name: "Evan", state: "working", live: false, last_seen: NOW - 10 * 60_000 })],
+      tasks: [task({ id: 1, assignee: { name: "Evan", kind: "agent" } })],
+      decisions: [],
+      viewer: NO_VIEWER,
+      now: NOW,
+    });
+    const [item] = focus.items;
+    expect(item!.state).toBe("stalled");
+    expect(item!.stale).toBe(true);
+    expect(focus.counts.working).toBe(0);
+    expect(focus.counts.stalled).toBe(1);
+  });
+
+  test("assignee with no presence row at all is treated as stalled, not working", () => {
+    const focus = computeChannelFocus({
+      presence: [],
+      tasks: [task({ id: 1, assignee: { name: "Ghost", kind: "agent" } })],
+      decisions: [],
+      viewer: NO_VIEWER,
+      now: NOW,
+    });
+    expect(focus.items[0]!.state).toBe("stalled");
+  });
+
+  test("fresh last_seen within window keeps working even without a live socket", () => {
+    const focus = computeChannelFocus({
+      presence: [presence({ name: "Evan", state: "working", live: false, wake: { kind: "serve" }, last_seen: NOW - 30_000 })],
+      tasks: [task({ id: 1, assignee: { name: "Evan", kind: "agent" } })],
+      decisions: [],
+      viewer: NO_VIEWER,
+      now: NOW,
+    });
+    expect(focus.items[0]!.state).toBe("working");
+  });
+});
+
+describe("computeChannelFocus — presence-only fallback (no task ledger row)", () => {
+  test("self-reported blocked member without a task is still surfaced", () => {
+    const focus = computeChannelFocus({
+      presence: [presence({ name: "solo", state: "blocked", status: { owner: "solo", state: "blocked", scope: [], summary_seq: null, blocked_reason: "waiting on infra", updated_at: NOW } })],
+      tasks: [],
+      decisions: [],
+      viewer: NO_VIEWER,
+      now: NOW,
+    });
+    const [item] = focus.items;
+    expect(item!.state).toBe("blocked");
+    expect(item!.blockedOn).toBe("waiting on infra");
+    expect(item!.taskId).toBeNull();
+  });
+
+  test("a member's task item wins over their presence fallback (no double-count)", () => {
+    const focus = computeChannelFocus({
+      presence: [presence({ name: "Evan", state: "working", live: true })],
+      tasks: [task({ id: 1, assignee: { name: "Evan", kind: "agent" } })],
+      decisions: [],
+      viewer: NO_VIEWER,
+      now: NOW,
+    });
+    expect(focus.items.filter((i) => i.name === "Evan")).toHaveLength(1);
+    expect(focus.items[0]!.taskId).toBe(1);
+  });
+
+  test("human sessions never occupy the ball via presence fallback", () => {
+    const focus = computeChannelFocus({
+      presence: [presence({ name: "owner", kind: "human", state: "working", live: true })],
+      tasks: [],
+      decisions: [],
+      viewer: NO_VIEWER,
+      now: NOW,
+    });
+    expect(focus.empty).toBe(true);
+  });
+});
+
+describe("computeChannelFocus — 'waiting on me' highlight", () => {
+  test("owner-only decision matched by account highlights for that viewer", () => {
+    const decisions: PendingDecision[] = [{ seq: 1, prompt: "approve prod cutover", asker: "front", expectedResponderOwner: "owner@x.com" }];
+    const mine = computeChannelFocus({ presence: [], tasks: [], decisions, viewer: { name: "leo", account: "owner@x.com", canModerate: true }, now: NOW });
+    expect(mine.waitingOnMe).toHaveLength(1);
+    expect(mine.items[0]!.waitingOnMe).toBe(true);
+
+    const notMine = computeChannelFocus({ presence: [], tasks: [], decisions, viewer: { name: "kw", account: "kw@x.com", canModerate: false }, now: NOW });
+    expect(notMine.waitingOnMe).toHaveLength(0);
+  });
+
+  test("unrestricted decision highlights for any moderator (owner-scans-for-this)", () => {
+    const decisions: PendingDecision[] = [{ seq: 1, prompt: "pick a path", asker: "front", expectedResponderOwner: null }];
+    const mod = computeChannelFocus({ presence: [], tasks: [], decisions, viewer: { name: "leo", account: "a", canModerate: true }, now: NOW });
+    expect(mod.waitingOnMe).toHaveLength(1);
+    const worker = computeChannelFocus({ presence: [], tasks: [], decisions, viewer: { name: "w", account: "b", canModerate: false }, now: NOW });
+    expect(worker.waitingOnMe).toHaveLength(0);
+  });
+
+  test("a task assigned to the viewing human is 'waiting on me' and sorts first", () => {
+    const focus = computeChannelFocus({
+      presence: [presence({ name: "Evan", live: true })],
+      tasks: [
+        task({ id: 1, assignee: { name: "Evan", kind: "agent" } }),
+        task({ id: 2, state: "assigned", title: "your call on prod opts", assignee: { name: "leo", kind: "human" } }),
+      ],
+      decisions: [],
+      viewer: { name: "leo", account: "owner@x.com", canModerate: true },
+      now: NOW,
+    });
+    expect(focus.waitingOnMe.map((i) => i.taskId)).toEqual([2]);
+    expect(focus.items[0]!.taskId).toBe(2); // waiting-on-me floats to the top
+  });
+});
+
+describe("computeChannelFocus — focus override + empty state", () => {
+  test("host one-liner override sets focus + manual source", () => {
+    const focus = computeChannelFocus({
+      presence: [], tasks: [], decisions: [],
+      viewer: NO_VIEWER, now: NOW,
+      focusOverride: "  结果查询 + 上传端到端联调  ",
+    });
+    expect(focus.focus).toBe("结果查询 + 上传端到端联调");
+    expect(focus.focusSource).toBe("manual");
+  });
+
+  test("nothing in flight → empty, so the bar can render nothing", () => {
+    const focus = computeChannelFocus({
+      presence: [presence({ name: "idle", state: "waiting", live: true })],
+      tasks: [task({ id: 1, state: "done", assignee: { name: "Evan", kind: "agent" } })],
+      decisions: [],
+      viewer: NO_VIEWER,
+      now: NOW,
+    });
+    expect(focus.empty).toBe(true);
+    expect(focus.items).toHaveLength(0);
+    expect(focus.focus).toBeNull();
+  });
+});
+
+describe("pendingDecisionsFromMessages", () => {
+  test("keeps only unresolved, non-retracted decision_request messages", () => {
+    const messages: MsgFrame[] = [
+      msg({ seq: 1, decision_request: { kind: "choice", prompt: "open one", options: ["a", "b"] }, decision_resolution: { state: "pending" } }),
+      msg({ seq: 2, decision_request: { kind: "approval", prompt: "resolved one", options: ["approve", "reject"] }, decision_resolution: { state: "resolved", chosen_index: 0 } }),
+      msg({ seq: 3, decision_request: { kind: "approval", prompt: "auto one", options: ["approve", "reject"] }, decision_resolution: { state: "auto_resolved" } }),
+      msg({ seq: 4, decision_request: { kind: "choice", prompt: "retracted one", options: ["a"] }, retracted: true }),
+      msg({ seq: 5, decision_request: { kind: "choice", prompt: "no-resolution one", options: ["a"] } }),
+      msg({ seq: 6, body: "plain message" }),
+    ];
+    const pending = pendingDecisionsFromMessages(messages);
+    expect(pending.map((d) => d.seq)).toEqual([1, 5]);
+    expect(pending[0]!.prompt).toBe("open one");
+    expect(pending[0]!.asker).toBe("planner");
+  });
+
+  test("carries expected_responder_owner through when present", () => {
+    const messages: MsgFrame[] = [
+      msg({ seq: 1, sender: { name: "front", kind: "agent" }, decision_request: { kind: "approval", prompt: "owner only", options: ["approve", "reject"], expected_responder_owner: "owner@x.com" }, decision_resolution: { state: "pending" } }),
+    ];
+    expect(pendingDecisionsFromMessages(messages)[0]!.expectedResponderOwner).toBe("owner@x.com");
+  });
+});

--- a/web/src/lib/channelFocus.ts
+++ b/web/src/lib/channelFocus.ts
@@ -1,0 +1,244 @@
+// 频道「焦点栏」聚合（#682）：把已有的三份原料——任务台账（TaskRecord）、成员 presence/status、
+// 未闭合的人类决策请求（decision_request）——跨成员聚成一句「球在谁手里、在等谁、谁在等我」。
+//
+// 纯函数、无副作用、无网络：栏是「已有数据的一块渲染视图」，绝不产生 seq、绝不发帧（避免 #675 刷屏）。
+// staleness 复用 shared 的 autoWakeReachable/presenceLastSeen——status=working 但 presence 不新鲜时
+// 降级为「可能停滞」而非谎报「在做」（避免 #665 的 false-presence）。
+import type { MsgFrame, PresenceEntry, TaskRecord } from "@agentparty/shared";
+import { autoWakeReachable, presenceLastSeen } from "@agentparty/shared";
+
+// 焦点项的四态。前三态即 issue 要求「视觉可区分」的三态；stalled 是 working 因 presence 不新鲜被降级的结果，
+// 单独成态好让 UI 用第四种语气标注「可能停滞/离线」，不与真正在做的 working 混淆。
+export type FocusItemState = "working" | "blocked" | "waiting_decision" | "stalled";
+
+// 「活跃在做」的新鲜度窗口（#682）：presence 无活连接（live）且 last_seen 超过这个岁数，就不再算「在做」。
+// 比 PRESENCE_TIMEOUT_MS(60s) 宽松——面向人类的焦点栏不该因 agent 安静一分钟就翻成「停滞」；
+// 真正健康的 serve/watch 有 live=true 会短路这道判定，安静但活着不受影响。
+export const FOCUS_STALE_MS = 5 * 60_000;
+
+export interface FocusItem {
+  /** 稳定去重键：task-<id> / presence-<name> / decision-<seq>。 */
+  key: string;
+  /** 球在谁手里（assignee / 自报成员 / 提问者）。 */
+  name: string;
+  /** 这一项在做/卡在的一句话（task 标题、blocked_reason、decision prompt）。 */
+  label: string;
+  state: FocusItemState;
+  /** blocked 时的阻塞原因（尽量结构化）；其他态为 null。 */
+  blockedOn: string | null;
+  /** 下钻锚点：关联任务 id（task 派生项）。 */
+  taskId: number | null;
+  /** 下钻锚点：关联消息 seq（decision 派生项）。 */
+  seq: number | null;
+  /** 从进来者视角：这一项是否在等本人拍板/交付。owner 最关心第三态里等自己的那些。 */
+  waitingOnMe: boolean;
+  /** 该项对应成员的 presence 是否已陈旧（working→stalled 的直接原因）。 */
+  stale: boolean;
+}
+
+export interface ChannelFocus {
+  /** 当前焦点一句话：host override 优先，否则最佳努力留空（自动焦点由 items 本身表达）。 */
+  focus: string | null;
+  focusSource: "manual" | null;
+  /** 「球在谁手里」——按紧要度排序（等决策 > 被卡 > 在做 > 停滞）。 */
+  items: FocusItem[];
+  /** items 中「在等我」的子集（进来者视角高亮）。 */
+  waitingOnMe: FocusItem[];
+  counts: { working: number; blocked: number; waitingDecision: number; stalled: number };
+  /** 没有任何在途项（无活跃任务、无阻塞、无待决）——UI 据此不渲染，不占屏。 */
+  empty: boolean;
+}
+
+/** 进来者身份：用于判定「谁在等我」。account = OIDC/账号主体；canModerate = 能对无限定决策拍板。 */
+export interface FocusViewer {
+  name: string | null;
+  account: string | null;
+  canModerate: boolean;
+}
+
+/** 未闭合的人类决策请求（#284）投影，供焦点栏「等人拍板」一项使用。 */
+export interface PendingDecision {
+  seq: number;
+  prompt: string;
+  /** 提问者名（球从这里被抛出，在等人类回应）。 */
+  asker: string;
+  /** 若绑定了指定回应账号（owner-only），据此判「在等我」；服务端可能已从公开投影裁掉，缺省视为任意 moderator 可答。 */
+  expectedResponderOwner: string | null;
+}
+
+export interface ChannelFocusInput {
+  presence: PresenceEntry[];
+  tasks: TaskRecord[];
+  decisions: PendingDecision[];
+  viewer: FocusViewer;
+  now: number;
+  /** host 一句话 override 当前焦点；空/缺省则不显式设焦点。 */
+  focusOverride?: string | null;
+  staleMs?: number;
+}
+
+// 从消息流里筛出「未闭合」的人类决策请求（#284）：带 decision_request、未撤回、且 resolution 仍为 pending
+// （缺 resolution 视同 pending——请求刚落库还没状态）。resolved/auto_resolved 的不再挂到栏上。
+export function pendingDecisionsFromMessages(messages: MsgFrame[]): PendingDecision[] {
+  const out: PendingDecision[] = [];
+  for (const m of messages) {
+    const req = m.decision_request;
+    if (req === undefined) continue;
+    if (m.retracted === true) continue;
+    const state = m.decision_resolution?.state ?? "pending";
+    if (state !== "pending") continue;
+    out.push({
+      seq: m.seq,
+      prompt: req.prompt,
+      asker: m.sender.name,
+      expectedResponderOwner: req.expected_responder_owner ?? null,
+    });
+  }
+  return out;
+}
+
+// 任务台账里「占着球」的活跃态：有 assignee 且处于这些态。done/triage/backlog 不占球，不上栏。
+const ACTIVE_TASK_STATES = new Set<TaskRecord["state"]>(["assigned", "in_progress", "needs_review", "blocked"]);
+
+// 「还在活跃地做」的判定，复用 shared 的可达性/新鲜度口径（#682 要求 reuse the shared helper）：
+//   • 有活 WS 连接（live）           → 在场（serve/watch 安静但活着不误判）。
+//   • 显式 offline                   → 不在场。
+//   • last_seen 超过 staleMs         → 陈旧，不在场。
+//   • autoWakeReachable=false        → 叫不醒（supervisor 大概率已死），不在场。
+// 都不满足 → 在场。只用来把 working 降级成 stalled；blocked/等决策与在场无关，不受此判定影响。
+function activelyPresent(entry: PresenceEntry | undefined, now: number, staleMs: number): boolean {
+  if (entry === undefined) return false;
+  if (entry.live === true) return true;
+  if (entry.state === "offline") return false;
+  const seen = presenceLastSeen(entry);
+  if (seen === null) return false;
+  if (now - seen > staleMs) return false;
+  return autoWakeReachable(entry, now);
+}
+
+function firstNonEmpty(...vals: Array<string | null | undefined>): string | null {
+  for (const v of vals) {
+    if (typeof v === "string" && v.trim() !== "") return v.trim();
+  }
+  return null;
+}
+
+const STATE_ORDER: Record<FocusItemState, number> = { waiting_decision: 0, blocked: 1, working: 2, stalled: 3 };
+
+export function computeChannelFocus(input: ChannelFocusInput): ChannelFocus {
+  const { presence, tasks, decisions, viewer, now } = input;
+  const staleMs = input.staleMs ?? FOCUS_STALE_MS;
+  const presenceByName = new Map(presence.map((p) => [p.name, p]));
+  const items: FocusItem[] = [];
+  const namesWithTaskItem = new Set<string>();
+
+  // 1) 任务台账 → 「球在谁手里」（主来源）。每条活跃且有 assignee 的任务成一项。
+  for (const task of tasks) {
+    if (!ACTIVE_TASK_STATES.has(task.state)) continue;
+    const assignee = task.assignee;
+    if (assignee === null) continue;
+    namesWithTaskItem.add(assignee.name);
+    const entry = presenceByName.get(assignee.name);
+    let state: FocusItemState;
+    let stale = false;
+    if (task.state === "blocked") {
+      state = "blocked";
+    } else if (activelyPresent(entry, now, staleMs)) {
+      state = "working";
+    } else {
+      // status=working（有活跃任务）但 presence 不新鲜/叫不醒 → 降级为「可能停滞」，不谎报在做（#665）。
+      state = "stalled";
+      stale = true;
+    }
+    // 「在等我」：人类被指派、且就是进来的这个人（等本人交付/推进）。
+    const waitingOnMe =
+      assignee.kind === "human" && viewer.name !== null && assignee.name === viewer.name;
+    items.push({
+      key: `task-${task.id}`,
+      name: assignee.name,
+      label: task.title,
+      state,
+      blockedOn: task.state === "blocked" ? firstNonEmpty(task.blocked_reason) : null,
+      taskId: task.id,
+      seq: null,
+      waitingOnMe,
+      stale,
+    });
+  }
+
+  // 2) 成员 presence/status → 兜底：自报 blocked / working 但台账里没有对应任务的成员，别漏。
+  //    blocked 一定纳入（是强信号）；working 也纳入（#kyc 里 Evan/kw 曾靠 status 才拼出「在做」）。
+  for (const entry of presence) {
+    if (namesWithTaskItem.has(entry.name)) continue;
+    if (entry.kind === "human") continue; // 人类会话不是「在干活的 agent」，不占球
+    const reason = firstNonEmpty(entry.status?.blocked_reason, entry.note);
+    if (entry.state === "blocked") {
+      items.push({
+        key: `presence-${entry.name}`,
+        name: entry.name,
+        label: reason ?? entry.name,
+        state: "blocked",
+        blockedOn: reason,
+        taskId: null,
+        seq: null,
+        waitingOnMe: false,
+        stale: false,
+      });
+    } else if (entry.state === "working") {
+      const present = activelyPresent(entry, now, staleMs);
+      items.push({
+        key: `presence-${entry.name}`,
+        name: entry.name,
+        label: firstNonEmpty(entry.note) ?? entry.name,
+        state: present ? "working" : "stalled",
+        blockedOn: null,
+        taskId: null,
+        seq: null,
+        waitingOnMe: false,
+        stale: !present,
+      });
+    }
+  }
+
+  // 3) 未闭合决策 → 「等人拍板」。waitingOnMe：指定了回应账号且匹配本人；或无限定但本人可 moderate（owner 视角）。
+  for (const d of decisions) {
+    const waitingOnMe =
+      (d.expectedResponderOwner !== null && d.expectedResponderOwner === viewer.account) ||
+      (d.expectedResponderOwner === null && viewer.canModerate);
+    items.push({
+      key: `decision-${d.seq}`,
+      name: d.asker,
+      label: d.prompt,
+      state: "waiting_decision",
+      blockedOn: null,
+      taskId: null,
+      seq: d.seq,
+      waitingOnMe,
+      stale: false,
+    });
+  }
+
+  items.sort(
+    (a, b) =>
+      Number(b.waitingOnMe) - Number(a.waitingOnMe) ||
+      STATE_ORDER[a.state] - STATE_ORDER[b.state] ||
+      a.name.localeCompare(b.name),
+  );
+
+  const counts = {
+    working: items.filter((i) => i.state === "working").length,
+    blocked: items.filter((i) => i.state === "blocked").length,
+    waitingDecision: items.filter((i) => i.state === "waiting_decision").length,
+    stalled: items.filter((i) => i.state === "stalled").length,
+  };
+
+  const focus = firstNonEmpty(input.focusOverride);
+  return {
+    focus,
+    focusSource: focus !== null ? "manual" : null,
+    items,
+    waitingOnMe: items.filter((i) => i.waitingOnMe),
+    counts,
+    empty: items.length === 0,
+  };
+}

--- a/web/src/pages/Channel.tsx
+++ b/web/src/pages/Channel.tsx
@@ -16,6 +16,8 @@ import { Markdown } from "../components/Markdown";
 import { MessageCard } from "../components/MessageCard";
 import { MentionHeaderNotice, type MentionToastItem } from "../components/MentionToast";
 import { PresenceBar } from "../components/PresenceBar";
+import { ChannelFocusBar } from "../components/ChannelFocusBar";
+import { computeChannelFocus, pendingDecisionsFromMessages } from "../lib/channelFocus";
 import { AttachmentList } from "../components/AttachmentList";
 import { OrgTreePreview } from "../components/OrgTreePreview";
 import {
@@ -4058,6 +4060,19 @@ export function ChannelPage({
     t,
   ).length;
 
+  // 频道常驻焦点栏（#682）：跨成员把任务台账 + presence/status + 未闭合决策聚成「球在谁手里」。
+  // teamNow 已每秒推进（团队面板复用），焦点的 staleness/时间判定跟着刷新，无需另起计时器。
+  const channelFocus = useMemo(
+    () => computeChannelFocus({
+      presence: Object.values(state.presence),
+      tasks,
+      decisions: pendingDecisionsFromMessages(state.messages),
+      viewer: { name: state.self, account: accountKey, canModerate },
+      now: teamNow,
+    }),
+    [state.presence, state.messages, state.self, tasks, accountKey, canModerate, teamNow],
+  );
+
   const setAgentMode = useCallback((mode: AgentFilterMode) => {
     setAgentFilter((current) => ({ ...current, mode }));
   }, []);
@@ -4238,6 +4253,12 @@ export function ChannelPage({
             onAuthFailed={onAuthFailed}
           />
         ) : null}
+      />
+      <ChannelFocusBar
+        focus={channelFocus}
+        viewerIsModerator={canModerate}
+        onOpenTask={() => openPanel("tasks")}
+        onJumpSeq={jumpToMention}
       />
       {kickError !== null && <p className="banner banner--red">{kickError}</p>}
       {pauseError !== null && <p className="banner banner--red">{pauseError}</p>}

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -2659,6 +2659,135 @@
   overflow-wrap: anywhere;
 }
 
+/* 频道常驻焦点栏（#682）：进频道第一屏就看到「球在谁手里、在等谁、谁在等我」。
+   墨线硬边 + 米纸底，三态各自语气色；「在等你」区块用主色珊瑚红把 owner 的目光钉住。 */
+.channel-focus-bar {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin: 6px 0 2px;
+  padding: 8px 10px;
+  border: 1.6px solid var(--d-ink);
+  border-radius: 0;
+  background: var(--t-panel2);
+  box-shadow: 3px 3px 0 var(--d-shadow);
+}
+.focus-head {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 8px;
+  min-width: 0;
+}
+.focus-heading {
+  flex: none;
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--t-muted);
+}
+.focus-line {
+  min-width: 0;
+  color: var(--t-text);
+  font-weight: 600;
+  overflow-wrap: anywhere;
+}
+.focus-counts {
+  margin-left: auto;
+  flex: none;
+  font-size: 10px;
+  color: var(--t-dim);
+}
+.focus-waiting-label,
+.focus-me-label {
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--t-muted);
+}
+.focus-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 2px 0 0;
+  padding: 0;
+  list-style: none;
+}
+.focus-item {
+  min-width: 0;
+}
+.focus-item-btn {
+  width: 100%;
+  text-align: left;
+  cursor: pointer;
+  background: none;
+  border: 0;
+  padding: 0;
+  font: inherit;
+  color: inherit;
+}
+.focus-item-btn:hover .focus-item-name,
+.focus-item--drill:hover .focus-item-name {
+  text-decoration: underline;
+}
+.focus-item-btn,
+.focus-item > :not(button) {
+  display: flex;
+  align-items: baseline;
+  gap: 7px;
+  min-width: 0;
+}
+.focus-dot {
+  flex: none;
+  font-size: 11px;
+  line-height: 1;
+}
+.focus-dot--working { color: var(--p-working); }
+.focus-dot--blocked { color: var(--p-blocked); }
+.focus-dot--waiting_decision { color: var(--t-purple); }
+.focus-dot--stalled { color: var(--t-muted); }
+.focus-item-name {
+  flex: none;
+  font-weight: 600;
+  color: var(--t-text);
+}
+.focus-item-label {
+  min-width: 0;
+  flex: 1;
+  color: var(--t-body);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.focus-item-state {
+  flex: none;
+  padding: 0 6px;
+  font-size: 10px;
+  border: 1.2px solid currentColor;
+  border-radius: 0;
+}
+.focus-item-state--working { color: var(--p-working); background: var(--d-green-soft); }
+.focus-item-state--blocked { color: var(--p-blocked); background: var(--d-red-soft); }
+.focus-item-state--waiting_decision { color: var(--t-purple); background: var(--d-blue-soft); }
+.focus-item-state--stalled { color: var(--t-muted); background: var(--t-panel); }
+/* 「在等你」区块：珊瑚红左描边 + 软底，owner 一眼扫到 */
+.focus-me {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: 5px 8px;
+  border-left: 3px solid var(--t-accent);
+  background: var(--d-red-soft);
+}
+.focus-me-label { color: var(--t-accent); font-weight: 700; }
+.focus-item-me-badge {
+  flex: none;
+  padding: 0 6px;
+  font-size: 9.5px;
+  color: var(--t-accent-ink);
+  background: var(--t-accent);
+}
+
 /* 频道搜索行：server-side retained-history search + sender/time filters */
 .chan-search-panel {
   display: flex;


### PR DESCRIPTION
Closes #682。人进频道最想立刻知道「卡在哪、球在谁手里、在等谁」,现在要翻几十条消息 + 自己拼(还被 #675 的 watch 状态噪音淹没)。这块本该一眼可见。

## 方案:常驻「频道焦点」活面板(非时间线消息)
挂在频道顶部(PresenceBar 下方),聚合现有数据答三问:当前焦点 / 球在谁手里(在等谁)/ 谁在等我。就地更新,**不产 seq**(不重蹈 #675 刷屏)。

## 数据源(全是现成 client 侧数据,无新 API)
- **task ledger**(已 `fetchTasks`):active + assignee → 球在谁手里;`blocked_reason` 内联。
- **成员 presence/status**:陈旧判定 + 无 task 行的自报 blocked/working 兜底(不漏人)。
- **未闭合 `decision_request`**(#284):从 messages 过滤 pending 未撤销 → 「等人拍板」。

## 四态 + 陈旧检测(#665 同源防失真)
- 视觉区分三态:`working` ●绿 / `blocked` ■红 / `waiting_decision` ◆紫;`stalled` ◌灰 = working 但 presence 陈旧被降级。
- `activelyPresent()` 复用 shared `autoWakeReachable` + `presenceLastSeen`:assignee 只有 live 或(非 offline 且 `last_seen` 在 `FOCUS_STALE_MS=5min` 内且可唤醒)才算真在做;否则 `in_progress` 降级 `stalled`(「可能停滞/离线」)——直击 #kyc 全员 offline 却显示「在做」的失真。
- 「等我拍板」项(owner 视角)珊瑚色浮到顶。task/decision 项可点开下钻(接现有 `openPanel("tasks")`/`jumpToMention`)。

## 测试(全绿)
- `channelFocus.test.ts` + `ChannelFocusBar.test.tsx` **23 pass**;i18n parity 11;回归 28;shared/web tsc 0;vite build 过。

## 范围
- host 一句话 focus override:lib/组件已实现,但**未接持久化输入面**(charter/state 无该字段,接它要加 worker 字段)——留作扩展点,自动算的焦点今天就能用。

🤖 由 agent 在隔离 worktree 实现(基于最新 main),人工审 diff + 测试后提交。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 频道页面新增常驻焦点栏，集中展示进行中、受阻、等待决策及疑似停滞事项。
  - 根据当前查看者突出显示“等待你处理”的任务或决策。
  - 支持点击焦点项打开任务或跳转至相关消息。
  - 新增中英文界面文案及状态统计，并支持手动焦点提示。
- **样式**
  - 为不同状态、可交互项目及“等待你”提示增加清晰的视觉区分。
- **测试**
  - 补充焦点聚合、状态展示、过期降级、交互回调及决策筛选测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->