### PR TITLE
fix: 跟进合并后 CodeRabbit 评审——paused alarm 空转 / 幂等丢 undeliverable / reach 判 paused 等

### DIFF
--- a/cli/src/commands/send.ts
+++ b/cli/src/commands/send.ts
@@ -28,7 +28,8 @@ If any mentioned target is neither online nor auto-wakeable (offline with no wak
 layer, or a stale/dead wake adapter), a non-blocking "warn:" line also prints to
 stderr — the send still succeeds, but the mention only lands in history and will not
 wake anyone. This warning shows even without a TTY (agent loops); --no-reach silences
-it. Use --require-wakeable to make such a send exit non-zero (after sending).
+it — except under --require-wakeable, which always prints the warn line (so the non-zero
+exit is explained). Use --require-wakeable to make such a send exit non-zero (after sending).
 
 Options:
   --channel C         send to channel C instead of the bound channel
@@ -36,9 +37,11 @@ Options:
   --attach path       upload a local file and attach it; repeatable (max 25MB each)
   --reply-to seq      attach this message as a reply to seq
   --reach             show mention reachability even when not a TTY (agent loops)
-  --no-reach          never show mention reachability (also silences the warn line)
+  --no-reach          never show mention reachability (also silences the warn line,
+                      UNLESS --require-wakeable is set, which forces the warn line)
   --require-wakeable  exit non-zero if any mentioned target is not auto-wakeable
-                      (the message is still sent; the warn line always prints)
+                      (the message is still sent; the warn line always prints —
+                      this overrides --no-reach's silencing of the warn line)
   --debug-auth        print resolved auth/config source to stderr`;
 
 // 附件上限与文件名规则与 worker 侧保持一致（#176）：本地先挡一刀，给出比服务端 413 更贴切的文案。

--- a/cli/src/commands/watch.ts
+++ b/cli/src/commands/watch.ts
@@ -807,11 +807,16 @@ export async function run(argv: string[]): Promise<number> {
       const head = tail.at(-1)?.seq ?? Math.max(localCursor, 0);
       const pending: number[] = [];
       let scanCursor = localCursor;
-      while (scanCursor < head && pending.length < WATCH_SKIP_SCAN_LIMIT) {
+      // 报数扫描只 best-effort：以「已扫过的总消息数」为界（对齐 resolveExplicitWatchCursor 的 skipped.length），
+      // 而非只数命中的 @self——否则稀疏 @ 的深积压里 pending 长期为 0，会把几乎整段历史串行翻完（#674 报数不值这代价）。
+      let scanned = 0;
+      while (scanCursor < head && scanned < WATCH_SKIP_SCAN_LIMIT) {
         const page = await fetchMessages(cfg.server, cfg.token, channel, scanCursor, WATCH_SKIP_PAGE_SIZE);
         if (page.length === 0) break;
         for (const m of page) {
-          if (m.seq <= head && m.sender.name !== identity.name && m.mentions.includes(identity.name)) pending.push(m.seq);
+          if (m.seq > head) continue;
+          scanned += 1;
+          if (m.sender.name !== identity.name && m.mentions.includes(identity.name)) pending.push(m.seq);
         }
         const pageLast = page.at(-1)?.seq ?? scanCursor;
         if (pageLast <= scanCursor) break;

--- a/cli/src/reach.ts
+++ b/cli/src/reach.ts
@@ -74,8 +74,9 @@ export interface Unreachable {
   ageMs: number | null;
   // 声明的 wake 类型（用于文案区分「压根没 wake 通道」与「适配器陈旧」）；缺省即无。
   wake?: WakeKind;
-  // no_wake：wake=none/缺失，压根没有唤醒路径；stale_adapter：声明了 serve/watch 但心跳陈旧（supervisor 大概率已死）。
-  reason: "no_wake" | "stale_adapter";
+  // no_wake：wake=none/缺失，压根没有唤醒路径；stale_adapter：声明了 serve/watch 但心跳陈旧（supervisor 大概率已死）；
+  // paused：owner 主动暂停接待（#180），被 @ 也不唤醒——有唤醒通道也无用。
+  reason: "no_wake" | "stale_adapter" | "paused";
 }
 
 // 返回该 @ 目标的不可达详情，或 null（在线 / 可自动唤醒 / 刚断线未过 STALE / 不在 presence / 人类）。
@@ -89,6 +90,12 @@ export function unreachableOf(name: string, presence: PresenceEntry[], now: numb
   const age = now - seen;
   // online：与 reachOf/who 一致——当前有活 WS 连接（live）或新鲜即视为在线，@ 直达，不告警。
   if (e.state !== "offline" && (e.live === true || age < STALE_MS)) return null;
+  // #664：paused（#180）优先于任何 wake 通道判定——owner 主动暂停接待，被 @ 也不唤醒，
+  // 即便声明了 serve/watch/webhook 也不会响应，故直接判不可达（distinct reason=paused）供发送方知情。
+  if (e.paused === true) {
+    const wake = e.wake?.kind;
+    return { name, ageMs: seen > 0 ? age : null, ...(wake !== undefined ? { wake } : {}), reason: "paused" };
+  }
   // 可自动唤醒且未越幽灵线：webhook 服务端投递、或 serve/watch 心跳新鲜 → 叫得醒，不告警。
   if (e.wake?.kind !== undefined && autoWakeReachable(e, now, STALE_MS) && age <= DEAD_MS) return null;
   // 刚断线（<STALE_MS）：给一个宽限，可能马上重连，先不判死。
@@ -115,9 +122,11 @@ function ageText(ageMs: number | null): string {
 //   warn: kyc-claude has no live wake channel (last_seen 88h ago) — mention delivered to history only; run 'party wake test @kyc-claude' to verify
 export function formatUnreachable(u: Unreachable): string {
   const what =
-    u.reason === "stale_adapter"
-      ? `${u.name}'s ${u.wake ?? "wake"} adapter looks dead`
-      : `${u.name} has no live wake channel`;
+    u.reason === "paused"
+      ? `${u.name} is paused, 被 @ 也不唤醒`
+      : u.reason === "stale_adapter"
+        ? `${u.name}'s ${u.wake ?? "wake"} adapter looks dead`
+        : `${u.name} has no live wake channel`;
   return `warn: ${what} (${ageText(u.ageMs)}) — mention delivered to history only; run 'party wake test @${u.name}' to verify`;
 }
 

--- a/cli/test/reach.test.ts
+++ b/cli/test/reach.test.ts
@@ -228,6 +228,31 @@ describe("unreachableOf (#664)", () => {
     const line = formatUnreachable({ name: "bot", ageMs: 13 * 60 * 1000, reason: "stale_adapter", wake: "serve" });
     expect(line).toContain("bot's serve adapter looks dead");
   });
+
+  // #664：paused（#180）= owner 主动暂停接待，被 @ 也不唤醒。unreachableOf 之前只看 wake/autoWakeReachable，
+  // paused 目标即便有可用 adapter 也会逃过告警——修复：paused 优先于 adapter 判定，独立 reason=paused。
+  test("paused agent with an otherwise-reachable (fresh webhook) adapter → paused, overrides wake reachability", () => {
+    const u = unreachableOf("held", [p({ name: "held", state: "offline", paused: true, wake: { kind: "webhook" } })], NOW);
+    expect(u).not.toBeNull();
+    expect(u?.reason).toBe("paused");
+    expect(u?.wake).toBe("webhook");
+  });
+
+  test("paused agent with no wake layer → paused (not no_wake)", () => {
+    const u = unreachableOf("held", [p({ name: "held", state: "offline", paused: true, wake: { kind: "none" }, last_seen: NOW - 88 * HOUR })], NOW);
+    expect(u?.reason).toBe("paused");
+  });
+
+  test("paused but genuinely online (live) → null: live connection still receives, pause check is after the online gate", () => {
+    expect(unreachableOf("held", [p({ name: "held", state: "waiting", paused: true, live: true })], NOW)).toBeNull();
+  });
+
+  test("format: paused line says paused / 被 @ 也不唤醒 and keeps the wake-test remedy", () => {
+    const line = formatUnreachable({ name: "held", ageMs: 5 * 60 * 1000, reason: "paused" });
+    expect(line).toContain("held is paused, 被 @ 也不唤醒");
+    expect(line).toContain("mention delivered to history only");
+    expect(line).toContain("party wake test @held");
+  });
 });
 
 describe("formatting", () => {

--- a/cli/test/send-wakeability.test.ts
+++ b/cli/test/send-wakeability.test.ts
@@ -106,6 +106,26 @@ describe("party send --mention wakeability warning (#664)", () => {
     expect(r.stdout).toContain("sent seq=");
   });
 
+  test("paused target (#180) → warn 'paused, 被 @ 也不唤醒', message still sent, exit 0", async () => {
+    // 有一个新鲜 webhook adapter（本可服务端投递），但 paused → 被 @ 也不唤醒，仍应告警。
+    restMock = presenceMock([{ name: "held-bot", paused: true, wake: { kind: "webhook" }, last_seen: Date.now() - 2 * HOUR, ts: Date.now() - 2 * HOUR }]);
+    writeCfg(restMock.url);
+    const r = await runCli(["send", "恢复后看下", "--channel", "dev", "--mention", "held-bot"]);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain("sent seq=");
+    expect(r.stderr).toContain("warn:");
+    expect(r.stderr).toContain("held-bot is paused, 被 @ 也不唤醒");
+  });
+
+  test("--require-wakeable + paused target → exit EXIT_UNREACHABLE, message still sent", async () => {
+    restMock = presenceMock([{ name: "held-bot", paused: true, wake: { kind: "webhook" }, last_seen: Date.now() - 2 * HOUR, ts: Date.now() - 2 * HOUR }]);
+    writeCfg(restMock.url);
+    const r = await runCli(["send", "恢复后看下", "--channel", "dev", "--mention", "held-bot", "--require-wakeable"]);
+    expect(r.code).toBe(EXIT_UNREACHABLE);
+    expect(r.stdout).toContain("sent seq=");
+    expect(r.stderr).toContain("held-bot is paused");
+  });
+
   test("--no-reach silences the warn line (message still sent, exit 0)", async () => {
     restMock = presenceMock([{ name: "kyc-claude", wake: { kind: "none" } }]);
     writeCfg(restMock.url);

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -316,7 +316,7 @@ const WORKFLOW_GUARD_WINDOW = 8;
 // explicitly off, active delivery capability/lineage expires after 30 days and its terminal audit
 // row is retained for another 7 days. This is far above the hours-long offline replay contract while
 // keeping permanently offline agents and abandoned owner questions bounded.
-const DIRECTED_DELIVERY_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+export const DIRECTED_DELIVERY_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
 const DIRECTED_DELIVERY_TERMINAL_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
 // #667：一条 @ 一旦落 `queued`（无任何 serve/watch/webhook adapter 可领取）就永不收敛——发送方
 // 永远看到 ⏳「已排队」，分不清「还在等」「送到了没醒」还是「永远送不到」。给排队态一个超时闸：
@@ -2584,8 +2584,15 @@ export class ChannelDO extends Server<Env> {
         return;
       }
       // 幂等去重命中（#98）：只回 sent（原 seq），不重复广播/唤醒。ws 发送目前不带 key，故常态为 false。
+      // #665：即便是重试命中，也要把（按当前 presence 重算的）undeliverable_mentions 带回，避免首发 ack 丢失后静默漏掉不可唤醒目标。
       if (out.deduped) {
-        this.sendFrame(connection, { type: "sent", seq: out.seq });
+        this.sendFrame(connection, {
+          type: "sent",
+          seq: out.seq,
+          ...(out.undeliverableMentions !== undefined && out.undeliverableMentions.length > 0
+            ? { undeliverable_mentions: out.undeliverableMentions }
+            : {}),
+        });
         return;
       }
       const sent = out.frames[0] as MsgFrame;
@@ -3384,8 +3391,17 @@ export class ChannelDO extends Server<Env> {
       candidates.push(Number(oldestActiveDelivery.t) + DIRECTED_DELIVERY_MAX_AGE_MS);
     }
     // #667：排队超时闸。取最老的 queued 行，到点跑 failStaleQueuedDeliveries 收敛未送达的 @。
+    // 但 paused（#180）目标的 queued 行永不被 failStaleQueuedDeliveries 收敛（owner 主动持债），
+    // 若把它算进候选，10 分钟过后每秒重挂 now+1000 空转唤醒 DO——故与 skip 条件对齐，排除 paused 目标。
     const oldestQueued = this.ctx.storage.sql
-      .exec("SELECT MIN(created_at) AS t FROM directed_deliveries WHERE state = 'queued'")
+      .exec(
+        `SELECT MIN(d.created_at) AS t FROM directed_deliveries d
+          WHERE d.state = 'queued'
+            AND NOT EXISTS (
+              SELECT 1 FROM presence p
+               WHERE p.name = d.target_name AND p.paused_at IS NOT NULL
+            )`,
+      )
       .one();
     if (oldestQueued.t !== null) {
       candidates.push(Number(oldestQueued.t) + DIRECTED_DELIVERY_QUEUED_TIMEOUT_MS);
@@ -3555,7 +3571,9 @@ export class ChannelDO extends Server<Env> {
          updated_at = excluded.updated_at,
          wake_verified_at = CASE WHEN presence.wake_kind IS 'watch' THEN presence.wake_verified_at ELSE NULL END,
          wake_kind = 'watch',
-         residency = COALESCE(presence.residency, 'supervised')`,
+         -- wake_kind='watch' 与 residency 必须同为 supervised：直接写死，别用 COALESCE 保留旧的非 supervised 残值，
+         -- 否则会产出 wake=watch + residency=<非supervised> 的协议不一致组合。
+         residency = 'supervised'`,
       name,
       sessionId,
       ts,
@@ -4883,8 +4901,16 @@ export class ChannelDO extends Server<Env> {
       .one().t;
     if (active !== null) candidates.push(Number(active) + DIRECTED_DELIVERY_MAX_AGE_MS);
     // #667：DO 水合后也要重挂排队超时闸，否则驱逐/迁移后陈旧的 queued 行再无扫描把它收敛。
+    // 同 scheduleNextAlarm：排除 paused（#180）目标，避免其永不收敛的 queued 行触发每秒空转重挂。
     const oldestQueued = this.ctx.storage.sql
-      .exec("SELECT MIN(created_at) AS t FROM directed_deliveries WHERE state = 'queued'")
+      .exec(
+        `SELECT MIN(d.created_at) AS t FROM directed_deliveries d
+          WHERE d.state = 'queued'
+            AND NOT EXISTS (
+              SELECT 1 FROM presence p
+               WHERE p.name = d.target_name AND p.paused_at IS NOT NULL
+            )`,
+      )
       .one().t;
     if (oldestQueued !== null) candidates.push(Number(oldestQueued) + DIRECTED_DELIVERY_QUEUED_TIMEOUT_MS);
     const terminal = this.ctx.storage.sql
@@ -6888,7 +6914,19 @@ export class ChannelDO extends Server<Env> {
             };
           }
         }
-        return { ok: true, seq: Number(priorRow.seq), frames: [this.rowToFrame(priorRow)], deduped: true };
+        // #665：幂等命中（重试）也要重算 undeliverable_mentions——首发的 sent ack 可能已丢，
+        // 用存库的 delivery_targets_json 对齐当前 presence 重算，让重发仍能给发送方当场知情。
+        const dedupUndeliverable = this.undeliverableAgentMentions(
+          parseStoredTargetNames(priorRow.delivery_targets_json),
+          Date.now(),
+        );
+        return {
+          ok: true,
+          seq: Number(priorRow.seq),
+          frames: [this.rowToFrame(priorRow)],
+          deduped: true,
+          ...(dedupUndeliverable.length > 0 ? { undeliverableMentions: dedupUndeliverable } : {}),
+        };
       }
     }
     const payload = frame.kind === "message" ? frame.body : frame.note;

--- a/worker/test/directed-delivery.spec.ts
+++ b/worker/test/directed-delivery.spec.ts
@@ -1081,6 +1081,35 @@ describe("排队超时收敛为终态（issue #667）", () => {
     });
   }
 
+  async function currentAlarm(slug: string): Promise<number | null> {
+    const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+    return runInDurableObject(stub, async (_i: ChannelDO, state) => state.storage.getAlarm());
+  }
+
+  it("paused 目标的超时排队投递不会把 alarm 钉在 now+1000 空转", async () => {
+    const sender = await seedToken("agent", uniq("sender"));
+    const target = await seedToken("agent", uniq("paused-target"));
+    const slug = await createChannel(sender.token);
+    const paused = await api(`/api/channels/${slug}/presence/${encodeURIComponent(target.name)}/pause`, sender.token, {
+      method: "POST",
+      body: JSON.stringify({}),
+    });
+    expect(paused.status).toBe(200);
+    const posted = await sendMention(slug, sender.token, target.name, `@${target.name} held while paused`);
+    const queued = (await deliveryRows(slug))[0]!;
+    expect(queued).toMatchObject({ message_seq: posted.seq, state: "queued" });
+
+    // 把 queued 回填到超时线之外后跑 alarm：paused 目标永不被 failStale 收敛，若排队超时闸仍把它算进候选，
+    // 候选落在过去 → 被 max(min, now+1000) 钉到 now+1000，导致每秒空转。
+    await backdateAndSweep(slug, queued.id);
+
+    // 仍 queued（owner 持债，不被误判），且 alarm 不再是每秒重挂：应落在长期 retention/lease 线（created_at + 30d）附近。
+    expect((await deliveryRows(slug))[0]).toMatchObject({ id: queued.id, state: "queued" });
+    const alarm = await currentAlarm(slug);
+    expect(alarm).not.toBeNull();
+    expect(alarm! - Date.now()).toBeGreaterThan(60_000);
+  });
+
   it("对无唤醒通道的死目标，排队超时后转 failed(undelivered) 并广播 delivery_state", async () => {
     const sender = await seedToken("agent", uniq("sender"));
     const target = await seedToken("agent", uniq("dead-target"));

--- a/worker/test/hello-wake-advertise.spec.ts
+++ b/worker/test/hello-wake-advertise.spec.ts
@@ -69,9 +69,14 @@ describe("hello.wake_kind 带内 watch presence 声明 (#675)", () => {
     expect((await fetchPresence(slug, agent.token)).find((p) => p.name === agent.name)?.wake?.kind).toBe("watch");
 
     ws.close();
-    // 断连回收后 wake_kind 撤销（markOffline 对 wake_kind='watch' 清零）。
-    await new Promise((r) => setTimeout(r, 50));
-    const after = (await fetchPresence(slug, agent.token)).find((p) => p.name === agent.name);
+    // 断连回收后 wake_kind 撤销（markOffline 对 wake_kind='watch' 清零）。固定 50ms 等待在 CI 上会抖：
+    // 有界轮询直到 presence 里的 wake.kind 消失（最多 ~2s），既不 flaky 也不掩盖真回归。
+    let after: PresenceEntry | undefined;
+    for (let i = 0; i < 40; i++) {
+      after = (await fetchPresence(slug, agent.token)).find((p) => p.name === agent.name);
+      if ((after?.wake?.kind ?? undefined) === undefined) break;
+      await new Promise((r) => setTimeout(r, 50));
+    }
     expect(after?.wake?.kind ?? undefined).toBeUndefined();
   });
 });

--- a/worker/test/retention-policy.spec.ts
+++ b/worker/test/retention-policy.spec.ts
@@ -1,7 +1,7 @@
 // #421: D1-authoritative retention policy + DO alarm physical deletion.
 import { env, runInDurableObject } from "cloudflare:test";
 import { describe, expect, it } from "vitest";
-import { type ChannelDO, DIRECTED_DELIVERY_QUEUED_TIMEOUT_MS } from "../src/do";
+import { type ChannelDO, DIRECTED_DELIVERY_MAX_AGE_MS, DIRECTED_DELIVERY_QUEUED_TIMEOUT_MS } from "../src/do";
 import { api, createChannel, postMessage, seedToken, uniq } from "./helpers";
 
 describe("channel retention policy (#421)", () => {
@@ -144,6 +144,8 @@ describe("channel retention policy (#421)", () => {
     // #667：暂停接待让这条 queued 投递成为 owner 主动持债的持久工作——10 分钟排队超时闸会跳过它，
     // 于是仍能验证 30 天 delivery_expired 兜底与 7 天终态保留这条更慢的路径（未暂停的死目标已由
     // undelivered_timeout 在 10 分钟收敛，另有独立用例覆盖）。
+    // 关键：既然 failStale 永远跳过 paused 目标，排队超时闸就绝不能把它算进 alarm 候选——否则 10 分钟
+    // 到点后每秒空转重挂（本用例正守住这条：初始 alarm 应落在 30 天 delivery_expired 兜底，而非 10 分钟线）。
     const paused = await api(`/api/channels/${slug}/presence/${encodeURIComponent(target.name)}/pause`, owner.token, {
       method: "POST",
       body: JSON.stringify({}),
@@ -165,8 +167,11 @@ describe("channel retention policy (#421)", () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
       const initialAlarm = await state.storage.getAlarm();
       expect(initialAlarm).not.toBeNull();
-      // onStart 现在先挂更近的排队超时闸（issue #667）；30 天兜底仍在，只是不再是最近的候选。
-      expect(Math.abs(initialAlarm! - (createdAt + DIRECTED_DELIVERY_QUEUED_TIMEOUT_MS))).toBeLessThan(1_000);
+      // #667：paused 目标的 queued 行被排队超时闸排除（否则 10 分钟后每秒空转），故初始 alarm 落在
+      // 30 天 delivery_expired 兜底，而非 10 分钟排队超时线。
+      expect(Math.abs(initialAlarm! - (createdAt + DIRECTED_DELIVERY_MAX_AGE_MS))).toBeLessThan(1_000);
+      // 且明确不是 10 分钟排队超时线（回归守卫：paused 不再触发短周期重挂）。
+      expect(Math.abs(initialAlarm! - (createdAt + DIRECTED_DELIVERY_QUEUED_TIMEOUT_MS))).toBeGreaterThan(1_000);
       state.storage.sql.exec(
         "UPDATE directed_deliveries SET created_at = ?, updated_at = ? WHERE message_seq = ?",
         now - 31 * 24 * 60 * 60 * 1000,

--- a/worker/test/undeliverable-mentions.spec.ts
+++ b/worker/test/undeliverable-mentions.spec.ts
@@ -196,6 +196,80 @@ describe("#665 undeliverable agent mentions (server-authoritative wakeability tr
     senderWs.close();
   });
 
+  it("REST 幂等重试命中也重算并带出 undeliverable_mentions（首发 ack 丢了不静默漏）", async () => {
+    const acct = "u665-rest-idem@leeguoo.com";
+    const sender = await seedToken("human", uniq("sender"), { owner: acct });
+    const slug = await createChannel(sender.token);
+    const agent = await seedToken("agent", uniq("idembot"), { channelScope: slug });
+
+    const observer = await WsClient.open(slug, sender.token);
+    await completeCapabilityHello(observer);
+    const watch = await WsClient.open(slug, agent.token);
+    await completeCapabilityHello(watch);
+    watch.send({
+      type: "send",
+      kind: "status",
+      state: "waiting",
+      note: "watching",
+      mentions: [],
+      residency: "supervised",
+      wake: { kind: "watch" },
+    });
+    await watch.nextOfType("sent");
+    await closeAndAwaitOffline(watch, observer, agent.name);
+
+    const key = `idem-${crypto.randomUUID()}`;
+    const body = JSON.stringify({ kind: "message", body: `@${agent.name} ping`, mentions: [agent.name], reply_to: null, idempotency_key: key });
+    const first = await api(`/api/channels/${slug}/messages`, sender.token, { method: "POST", body });
+    expect(first.status).toBe(200);
+    const firstJson = (await first.json()) as SentJson;
+    expect(firstJson.undeliverable_mentions).toEqual([agent.name]);
+
+    // 同 key 重试 → 幂等命中（同 seq），但仍须重算 undeliverable_mentions 带回，不静默丢失。
+    const retry = await api(`/api/channels/${slug}/messages`, sender.token, { method: "POST", body });
+    expect(retry.status).toBe(200);
+    const retryJson = (await retry.json()) as SentJson;
+    expect(retryJson.seq).toBe(firstJson.seq);
+    expect(retryJson.undeliverable_mentions).toEqual([agent.name]);
+    observer.close();
+  });
+
+  it("WS 幂等重试命中的 sent 回执也带 undeliverable_mentions", async () => {
+    const acct = "u665-ws-idem@leeguoo.com";
+    const sender = await seedToken("human", uniq("sender"), { owner: acct });
+    const slug = await createChannel(sender.token);
+    const agent = await seedToken("agent", uniq("wsidembot"), { channelScope: slug });
+
+    const senderWs = await WsClient.open(slug, sender.token);
+    await completeCapabilityHello(senderWs);
+    const watch = await WsClient.open(slug, agent.token);
+    await completeCapabilityHello(watch);
+    watch.send({
+      type: "send",
+      kind: "status",
+      state: "waiting",
+      note: "watching",
+      mentions: [],
+      residency: "supervised",
+      wake: { kind: "watch" },
+    });
+    await watch.nextOfType("sent");
+    await closeAndAwaitOffline(watch, senderWs, agent.name);
+
+    const key = `idem-${crypto.randomUUID()}`;
+    const frame = { type: "send" as const, kind: "message" as const, body: `@${agent.name} ping`, mentions: [agent.name], reply_to: null, idempotency_key: key };
+    senderWs.send(frame);
+    const firstAck = (await senderWs.nextOfType("sent")) as SentJson;
+    expect(firstAck.undeliverable_mentions).toEqual([agent.name]);
+
+    // 同 key 重发 → 服务端幂等去重命中，回同一 seq，且仍带 undeliverable_mentions。
+    senderWs.send(frame);
+    const retryAck = (await senderWs.nextOfType("sent")) as SentJson;
+    expect(retryAck.seq).toBe(firstAck.seq);
+    expect(retryAck.undeliverable_mentions).toEqual([agent.name]);
+    senderWs.close();
+  });
+
   // 纯函数：证明「租约随心跳过期而失活」的真相由 autoWakeReachable 承载——last_seen 超过 PRESENCE_TIMEOUT_MS
   // 且无活连接即判不可达。wakeableState 只分类 wake 层（watch=unverified），可达性另由 autoWakeReachable 判，
   // 二者共同构成 who/send 的「wakeable」真相（cli who: wstate!=offline && autoWakeReachable）。


### PR DESCRIPTION
处理已合并 PR(#664/#665/#667/#684)上 CodeRabbit 报的真问题,一个 follow-up 收齐。

## Major
- **[#667] paused 目标致每秒 alarm 空转(稳定性)**:`failStaleQueuedDeliveries` 跳过 paused 行,但两处 queued-timeout alarm 候选查询仍把 paused 行选为「最老 queued」→ 候选落在过去 → `setAlarm(max(min, now+1000))` 每秒重挂,长期暂停的频道每秒唤醒 DO(成本回归)。两处候选查询加 `NOT EXISTS(... paused_at IS NOT NULL)`,只让可终态化的 queued 行参与 10min 候选。
- **[#665] 幂等成功路径丢 undeliverable_mentions**:命中幂等键的重试,WS `sent` 回执不再重算不可达目标。`handleSend` dedup 返回处按 `delivery_targets_json` + 当前 presence 用 `undeliverableAgentMentions` 重算并附上(REST 侧原本就在 dedup 分支外发,只需 handleSend 填充)。
- **[#664] reach 未判 paused**:`paused` 语义是「被 @ 也不唤醒」,但 `unreachableOf` 只看 wake/autoWakeReachable,漏了 send 侧 warning / `--require-wakeable` 退出。在 autoWakeReachable 前拦截 `e.paused===true`,`reason:"paused"` 打「paused,被 @ 也不唤醒」。
  - 保留 worker `undeliverableAgentMentions` 跳过 paused 的**刻意不对称**:CLI 警告发送方「现在不会应」,服务端不失败该投递。

## Minor
- send.ts:`--no-reach`/`--require-wakeable` 帮助文案交代优先级(后者强制打 warn)。
- watch.ts:`--drain` 扫描按**已扫消息总数**封顶(而非命中 @self 数),稀疏 @ 深积压不再串行翻整段历史。
- do.ts:watch presence 直写 `residency='supervised'`(不再 COALESCE 保留旧非 supervised 值)。
- hello-wake-advertise.spec:固定 50ms 等待改**有界轮询**,除 CI 抖动。

## Skip(文档化)
- #676 token 进 shell history:env-var 形式是 #676 刻意接受的权衡(已修更严重的跨用户 argv/ps 泄露;彻底避 history 需更笨的 `--token -` stdin,已作为更严选项文档化)。不改。

## 测试
- cli **1043 pass**、worker **720 pass**、全 tsc 过。
- 新回归:paused 目标 alarm 不重挂 now+1000;REST+WS 幂等重试仍出 undeliverable;reach paused 单测;`--require-wakeable`+paused e2e 非零退出。
- 修正一条**编码了 finding-A bug** 的既有用例(原断言 paused 初始 alarm 在 10min 线)→ 改断言 30 天 delivery_expired 兜底 + 守卫非 10min 线。

🤖 由 agent 在隔离 worktree 实现,人工审两个 Major 修法后提交。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增“已暂停”目标的不可达提示，明确说明即使被提及也不会唤醒。
  - 重试相同发送请求时，仍会返回不可投递提及信息。
- **改进**
  - `--no-reach` 与 `--require-wakeable` 的告警和退出码说明更加清晰。
  - 暂停目标不会触发无效的重复唤醒尝试。
  - `party watch --drain` 扫描行为更加稳定，避免遗漏待处理消息。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->