### PR TITLE
feat(daemon): #672/#688 第一方 daemon residency —— 嵌 Claude Agent SDK 的常驻可唤醒 runner(experimental)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,6 +13,7 @@
       },
       "dependencies": {
         "@agentparty/shared": "workspace:*",
+        "@anthropic-ai/claude-agent-sdk": "^0.3.216",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^4.4.3",
       },
@@ -95,7 +96,29 @@
 
     "@agentparty/worker": ["@agentparty/worker@workspace:worker"],
 
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.3.216", "", { "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.216", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.216", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.216", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.216", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.216", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.216", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.216", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.216" }, "peerDependencies": { "@anthropic-ai/sdk": ">=0.93.0", "@modelcontextprotocol/sdk": "^1.29.0", "zod": "^4.0.0" } }, "sha512-Fl/d9yGW7Pm0aGwUNkJMvruOVobleYcoprGJqufdP4J9W2XL/2xKXqanY8KqUdfySRMI2N46rY4/lryq5SfgFg=="],
+
+    "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.216", "", { "os": "darwin", "cpu": "arm64" }, "sha512-TWtTUabXj+AMOBMknSe3EVQb/7qucw5pHYi0HWoKoixQt1JE6J/CiLDBIY69OD3eQn9k1XG6LaurT239kFxLUw=="],
+
+    "@anthropic-ai/claude-agent-sdk-darwin-x64": ["@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.216", "", { "os": "darwin", "cpu": "x64" }, "sha512-tULuvqhJUwGTj71Uln4uPumm0la4EO1XydFbISTbdc1BsuvGx3FOtFcVs0Qg3dhNBFAoU/iYVTO/B1rImeJZig=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-arm64": ["@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.216", "", { "os": "linux", "cpu": "arm64" }, "sha512-kX6x0otwOuA1zIeEiuAKQqOk2TUAOkDUzm4MmLoQHOM2xWvr/pc+xY4DZxaX4ef9dUFQuHA4r5Vtbk7tPTL7Bw=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": ["@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.216", "", { "os": "linux", "cpu": "arm64" }, "sha512-sisWj2nhQolKu6aGWnu+I7d8EU6/m5J3G6bGfR7YvZ1wkQTQZAX3aOq6DVLIfCaZSH22wtqyuXhE/gn5eU1syw=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-x64": ["@anthropic-ai/claude-agent-sdk-linux-x64@0.3.216", "", { "os": "linux", "cpu": "x64" }, "sha512-WbJTLQafcYw9wl+gh/YpepdbWsOoJS7JZQA0obpzBBWzpx9PqPbjUDXDfCDrtzDI2fmr3Nz0//vC12bvlMZd8g=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-x64-musl": ["@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.216", "", { "os": "linux", "cpu": "x64" }, "sha512-3Ts2Ab6oEGG2r+epmWc6lOR1ahECjvH4y+lPb32qLKMdYxT2PU6TAc4Z/USLLuqDpgw3nSb8xuiYEH77rv88fw=="],
+
+    "@anthropic-ai/claude-agent-sdk-win32-arm64": ["@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.216", "", { "os": "win32", "cpu": "arm64" }, "sha512-xGB8rKatsXl9enqmPXixYNvdjGh1AL2jFmMRC9lR9M1prf2FGl7dkpdHz8YyItKAciRwpPIfts/9dSGhxlgT3A=="],
+
+    "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.3.216", "", { "os": "win32", "cpu": "x64" }, "sha512-cGbBgoKNzB6wRL6bMOwM2iJEG/wx0B6FCblmKF+ZAYKcj5oNi3jM6oQsnPJbKfrzVKrip3YEpXxopQ9O30LrSg=="],
+
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.112.4", "", { "dependencies": { "json-schema-to-ts": "^3.1.1", "standardwebhooks": "^1.0.0" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-7eXJJnrmBI5GMC6drrCiSkycVsT7crRZX3qv5HusLSm+qiILjmtqP7gf+UiT7ASu/7Gdj+Zfl4f2haV8wATKUg=="],
+
     "@asteasolutions/zod-to-openapi": ["@asteasolutions/zod-to-openapi@8.5.0", "", { "dependencies": { "openapi3-ts": "^4.1.2" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-SABbKiObg5dLRiTFnqiW1WWwGcg1BJfmHtT2asIBnBHg6Smy/Ms2KHc650+JI4Hw7lSkdiNebEGXpwoxfben8Q=="],
+
+    "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
 
     "@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.5.0", "", {}, "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg=="],
 
@@ -298,6 +321,8 @@
     "@sindresorhus/is": ["@sindresorhus/is@7.2.0", "", {}, "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw=="],
 
     "@speed-highlight/core": ["@speed-highlight/core@1.2.17", "", {}, "sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg=="],
+
+    "@stablelib/base64": ["@stablelib/base64@1.0.1", "", {}, "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
@@ -503,6 +528,8 @@
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
+    "fast-sha256": ["fast-sha256@1.3.0", "", {}, "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ=="],
+
     "fast-uri": ["fast-uri@3.1.3", "", {}, "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
@@ -548,6 +575,8 @@
     "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
 
     "js-yaml": ["js-yaml@4.3.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q=="],
+
+    "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
@@ -685,6 +714,8 @@
 
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
 
+    "standardwebhooks": ["standardwebhooks@1.0.0", "", { "dependencies": { "@stablelib/base64": "^1.0.0", "fast-sha256": "^1.3.0" } }, "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg=="],
+
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "std-env": ["std-env@4.2.0", "", {}, "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw=="],
@@ -700,6 +731,8 @@
     "tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
 
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@agentparty/shared": "workspace:*",
+    "@anthropic-ai/claude-agent-sdk": "^0.3.216",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "zod": "^4.4.3"
   },

--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -353,10 +353,12 @@ export interface ConnectOptions {
   /** Declare that this connection consumes durable directed-delivery v1 frames. */
   directedDelivery?: "v1";
   /**
-   * #675：带内声明「本连接有 watch 唤醒层」。设为 "watch" 时 hello 带上 wake_kind，服务端在 presence 落
-   * wake_kind=watch（residency=supervised），无需往时间线发 waiting 状态消息。断开由 markOffline 撤销。
+   * #675/#688：带内声明「本连接有唤醒层」。设值时 hello 带上 wake_kind，服务端在 presence 落对应 wake_kind，
+   * 无需往时间线发 waiting 状态消息。断开由 markOffline 撤销。
+   *   "watch"  → residency=supervised（#675）
+   *   "daemon" → residency=daemon（#688，内嵌 SDK 的第一方常驻 party daemon）
    */
-  advertiseWakeKind?: "watch";
+  advertiseWakeKind?: "watch" | "daemon";
   /** 修订游标：已见过的最大 rev_seq，随 hello.since_rev 上报，服务端据此限定修订重放（issue #33） */
   sinceRev?: number;
   onRevCursor?: (revCursor: number) => void;
@@ -607,7 +609,7 @@ export function connect(
         since_rev: revCursor,
         client_version: pkg.version,
         ...(opts.directedDelivery === "v1" ? { directed_delivery: "v1" as const } : {}),
-        ...(opts.advertiseWakeKind === "watch" ? { wake_kind: "watch" as const } : {}),
+        ...(opts.advertiseWakeKind !== undefined ? { wake_kind: opts.advertiseWakeKind } : {}),
       }));
       // External status callbacks may synchronously send an actionable frame on reconnect. Publish
       // OPEN only after hello is on the wire so no callback can overtake the mandatory handshake.

--- a/cli/src/commands/daemon.ts
+++ b/cli/src/commands/daemon.ts
@@ -107,6 +107,11 @@ export interface DaemonOptions {
  * 懒加载（dynamic import）保证只有真跑 daemon 才载入 SDK——注入了 mock 的单测永远不会触碰它。
  */
 export function createSdkRunner(options?: Record<string, unknown>): SdkRunner {
+  // #691 评审(Major)：无头 daemon 必须显式设 permissionMode。SDK 默认 'default' 会在 headless（无 TTY、
+  // 未提供 canUseTool）下遇到需批准的工具时挂起/行为不定。'dontAsk' = 不提示、未预批的工具一律拒绝——
+  // experimental daemon 只产文本、绝不被一条 @ 触发任意工具执行（安全）。完整的 owner/worker 边界权限模型
+  // （canUseTool → 三方边界、allowedTools、scope options）见 Phase-2.2 #692；调用方可覆盖本默认。
+  const sdkOptions: Record<string, unknown> = { permissionMode: "dontAsk", ...(options ?? {}) };
   return {
     async run(prompt: string, ctx: SdkRunContext): Promise<string> {
       const { query } = await import("@anthropic-ai/claude-agent-sdk");
@@ -116,7 +121,7 @@ export function createSdkRunner(options?: Record<string, unknown>): SdkRunner {
       let final = "";
       // Query 是 AsyncGenerator<SDKMessage>：迭代到 type:"result" 拿终值。
       // success 携带 result:string；error 变体携带 errors:string[]，抛出交给上层回帖失败提示。
-      for await (const message of query({ prompt: framed, ...(options ? { options } : {}) })) {
+      for await (const message of query({ prompt: framed, options: sdkOptions })) {
         if (message.type === "result") {
           if (message.subtype === "success") {
             final = message.result;

--- a/cli/src/commands/daemon.ts
+++ b/cli/src/commands/daemon.ts
@@ -1,0 +1,292 @@
+// party daemon — 实验性：内嵌 @anthropic-ai/claude-agent-sdk 的常驻 party runner（SPIKE，#672 Phase 1）。
+//
+// 动机（#672）：`party watch --once` 是单发子进程，harness 在 turn 边界把它回收即静默——presence 的
+// 「可唤醒」本质是谎报，这是 #665/#664/#508/#29/#199 唤醒债风暴的共同根因。daemon 是一档**第一方常驻**
+// runner：长期进程持 WS（真实心跳），被 @ 时就地跑内嵌的官方 Agent SDK session，处理完回帖、进程续存，
+// **不依赖 harness turn 边界**。
+//
+// ⚠️ Phase-1 边界（协议不动）：本命令暂**不**新增 WakeKind:"daemon" / Residency:"daemon"（那是 doc 里的
+// Phase 2）。为了让 wire 保持不变，daemon 复用现有 serve/watch 风格的唤醒声明——即随 hello 上报
+// `advertiseWakeKind: "watch"`。这是刻意的 Phase-1 捷径，见报告与 #672。
+import {
+  EXIT_ARCHIVED,
+  EXIT_AUTH,
+  EXIT_STREAM_ENDED,
+} from "@agentparty/shared";
+import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
+import { connect } from "../client";
+import { loadCursor, resolveChannel, saveCursor } from "../config";
+import { resolveAuthDetailed } from "../oidc-cli";
+import { postMessage } from "../rest";
+import { isSlug } from "../validation";
+
+/** 常驻 daemon 的信号退出码，与 serve 对齐（128 + signo）。 */
+export const EXIT_SIGNAL_INT = 128 + 2;
+export const EXIT_SIGNAL_TERM = 128 + 15;
+
+const HELP = `party daemon — 实验性：内嵌 Claude Agent SDK 的常驻 party runner（SPIKE，#672）
+
+usage: party daemon [channel|--channel C] [--timeout N]
+
+  连上频道并常驻（长期进程、真实心跳）。被 @ 到本身份时，就地用内嵌的官方
+  @anthropic-ai/claude-agent-sdk 跑一个 session，把最终文本回帖到频道——不经 harness、无 turn 边界。
+  SDK 出错则回一条简短失败提示、进程续存。收到 SIGTERM/SIGINT 干净断开（presence 随之清除）。
+
+flags:
+  --channel C     目标频道（也可作为位置参数）；缺省用 party init 绑定的频道
+  --timeout N     跑 N 秒后退出（默认 0 = 常驻）；主要给冒烟测试用
+
+experimental：仅供 spike/live 验证，未接入 onboarding / join-pack；协议未改动（复用 watch 唤醒声明）。`;
+
+/**
+ * SDK 会话运行器抽象——daemon 与具体 SDK 之间的唯一接触面。
+ * 默认实现（createSdkRunner）懒加载官方 SDK；**单测注入 mock，CI 永不触碰真 SDK**（SDK 无法在 CI 跑）。
+ */
+export interface SdkRunner {
+  /** 用 @-mention 文本 + 最小频道上下文跑一次 session，返回最终文本（成功）或抛错（失败）。 */
+  run(prompt: string, ctx: SdkRunContext): Promise<string>;
+}
+
+export interface SdkRunContext {
+  channel: string;
+  sender: string;
+  seq: number;
+}
+
+/** 回帖依赖注入点：默认走 rest.postMessage，测试可捕获回帖。 */
+export type PostReply = (reply: { body: string; mentions: string[]; replyTo: number }) => Promise<void>;
+
+export interface DaemonOptions {
+  server: string;
+  token: string;
+  channel: string;
+  since: number;
+  /** SDK 运行器（必填、可注入）。生产用 createSdkRunner()；测试注入 mock。 */
+  runner: SdkRunner;
+  /** 依赖注入：默认走 client.connect（测试可用 mock server + 真 connect，或完全注入）。 */
+  connectImpl?: typeof connect;
+  /** 依赖注入：默认走 rest.postMessage。 */
+  postReply?: PostReply;
+  /** 游标持久化钩子；默认无（run() 注入 saveCursor）。 */
+  onCursor?: (cursor: number) => void;
+  out?: (line: string) => void;
+  backoffBaseMs?: number;
+  /** 0 = 常驻（默认）；>0 跑满 N 秒后主动关闭连接退出（冒烟测试用）。 */
+  timeoutSec?: number;
+  /** 干净关停信号（SIGTERM/SIGINT）；abort 时关闭连接、presence 随之清除。 */
+  abortSignal?: AbortSignal;
+}
+
+/**
+ * 生产 SDK 运行器：懒加载官方 @anthropic-ai/claude-agent-sdk 的 query()，收集最终 result 文本。
+ * 懒加载（dynamic import）保证只有真跑 daemon 才载入 SDK——注入了 mock 的单测永远不会触碰它。
+ */
+export function createSdkRunner(options?: Record<string, unknown>): SdkRunner {
+  return {
+    async run(prompt: string, ctx: SdkRunContext): Promise<string> {
+      const { query } = await import("@anthropic-ai/claude-agent-sdk");
+      const framed =
+        `你在 AgentParty 频道 #${ctx.channel} 里被 @ 了（来自 ${ctx.sender}，seq=${ctx.seq}）。\n` +
+        `请针对下面这条消息给出回复正文（回复会直接贴回频道）：\n\n${prompt}`;
+      let final = "";
+      // Query 是 AsyncGenerator<SDKMessage>：迭代到 type:"result" 拿终值。
+      // success 携带 result:string；error 变体携带 errors:string[]，抛出交给上层回帖失败提示。
+      for await (const message of query({ prompt: framed, ...(options ? { options } : {}) })) {
+        if (message.type === "result") {
+          if (message.subtype === "success") {
+            final = message.result;
+          } else {
+            throw new Error(`sdk ${message.subtype}: ${message.errors?.join("; ") || "unknown error"}`);
+          }
+        }
+      }
+      return final;
+    },
+  };
+}
+
+/**
+ * daemon 主循环：连上频道、常驻、被 @ 时跑 SDK 并回帖。
+ * Phase-1 spike 有意最小化——只处理 plain `msg` 帧的新 @self；status/delivery/message_update 等一律忽略
+ * （durable directed-delivery / 暂停接待 / squad 等留给后续阶段）。
+ */
+export async function runDaemon(o: DaemonOptions): Promise<number> {
+  const out = o.out ?? ((line: string) => console.log(line));
+  const post: PostReply =
+    o.postReply ??
+    (async ({ body, mentions, replyTo }) => {
+      await postMessage(o.server, o.token, o.channel, {
+        kind: "message",
+        body,
+        mentions,
+        reply_to: replyTo,
+      });
+    });
+
+  const conn = (o.connectImpl ?? connect)(o.server, o.token, o.channel, o.since, {
+    ...(o.onCursor ? { onCursor: o.onCursor } : {}),
+    ...(o.backoffBaseMs !== undefined ? { backoffBaseMs: o.backoffBaseMs } : {}),
+    // Phase-1 捷径：复用现有 watch 唤醒声明，协议不动（见文件头注释 / #672）。
+    advertiseWakeKind: "watch",
+  });
+
+  let self = "";
+  let code = 0;
+  let timedOut = false;
+  let aborted = false;
+
+  const onAbort = () => {
+    aborted = true;
+    conn.close();
+  };
+  if (o.abortSignal) {
+    if (o.abortSignal.aborted) onAbort();
+    else o.abortSignal.addEventListener("abort", onAbort, { once: true });
+  }
+
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  if (o.timeoutSec !== undefined && o.timeoutSec > 0) {
+    timer = setTimeout(() => {
+      timedOut = true;
+      conn.close();
+    }, o.timeoutSec * 1000);
+  }
+
+  try {
+    for await (const frame of conn.frames) {
+      if (frame.type === "welcome") {
+        self = frame.self;
+        out(`daemon: attached to #${o.channel} as @${self} (experimental, SDK-in-process)`);
+        continue;
+      }
+      if (frame.type === "error") {
+        out(`daemon: error ${frame.code}: ${frame.message}`);
+        if (frame.code === "unauthorized") code = EXIT_AUTH;
+        else if (frame.code === "archived") code = EXIT_ARCHIVED;
+        else code = 1;
+        break;
+      }
+      // spike：只有 plain 消息帧能唤醒。status/presence/delivery/message_update 等留给后续阶段。
+      if (frame.type !== "msg") continue;
+      const msg = frame;
+      const fromSelf = msg.sender.name === self;
+      const mentioned = msg.mentions.includes(self);
+      const fresh = msg.seq > conn.cursor;
+      // 无论是否唤醒都推进游标（并持久化）：daemon 是常驻读者，读过即已读。
+      if (msg.seq > 0) conn.ack(msg.seq);
+      if (fromSelf || !mentioned || !fresh) continue;
+
+      out(`daemon: woken by seq=${msg.seq} from ${msg.sender.name}`);
+      let reply: string;
+      try {
+        reply = await o.runner.run(msg.body, { channel: o.channel, sender: msg.sender.name, seq: msg.seq });
+      } catch (error) {
+        const em = error instanceof Error ? error.message : String(error);
+        out(`daemon: sdk session failed on seq=${msg.seq}: ${em}`);
+        // graceful：回一条简短失败提示而非崩溃；提示本身失败也吞掉（best-effort），进程续存。
+        try {
+          await post({
+            body: `⚠️ daemon SDK 会话失败（${em}）——本条 @ 未能就地处理，请重试或改走 human/serve。`,
+            mentions: [msg.sender.name],
+            replyTo: msg.seq,
+          });
+        } catch (postErr) {
+          out(`daemon: failed to post failure note for seq=${msg.seq}: ${postErr instanceof Error ? postErr.message : String(postErr)}`);
+        }
+        continue;
+      }
+
+      const body = reply.trim() || "(daemon: SDK 返回空结果)";
+      try {
+        await post({ body, mentions: [msg.sender.name], replyTo: msg.seq });
+        out(`daemon: replied to seq=${msg.seq}`);
+      } catch (error) {
+        out(`daemon: failed to post reply for seq=${msg.seq}: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    }
+  } finally {
+    if (timer) clearTimeout(timer);
+    o.abortSignal?.removeEventListener("abort", onAbort);
+    conn.close();
+  }
+
+  if (aborted || timedOut) return code;
+  // 帧流意外结束（非信号、非超时）：connect 层已彻底放弃重连。返回非零让上游看得见并可重启。
+  return code === 0 ? EXIT_STREAM_ENDED : code;
+}
+
+export async function run(argv: string[]): Promise<number> {
+  if (isHelpArg(argv, { allowHelpPositional: true })) {
+    console.log(HELP);
+    return 0;
+  }
+  const { positionals, flags } = parseArgs(argv);
+  const unknown = unknownFlagError(flags, ["channel", "timeout"]);
+  if (unknown !== null) {
+    console.error(unknown);
+    return 1;
+  }
+  const flagError = valueFlagError(flags, ["channel", "timeout"]);
+  if (flagError !== null) {
+    console.error(flagError);
+    return 1;
+  }
+
+  const auth = await resolveAuthDetailed();
+  if (!auth.server || !auth.token) {
+    console.error("no config, run: party login or party init --server URL --token T");
+    return 1;
+  }
+  const channel = resolveChannel(str(flags.channel) ?? positionals[0]);
+  if (!channel) {
+    console.error("no channel, pass one or bind with: party init --channel C");
+    return 1;
+  }
+  if (!isSlug(channel)) {
+    console.error("channel must match [a-z0-9][a-z0-9-]{0,63}");
+    return 1;
+  }
+  let timeoutSec = 0;
+  if (flags.timeout !== undefined) {
+    const parsed = Number(str(flags.timeout));
+    if (!Number.isFinite(parsed) || parsed < 0) {
+      console.error("--timeout must be a non-negative number of seconds");
+      return 1;
+    }
+    timeoutSec = Math.floor(parsed);
+  }
+
+  console.error(
+    "party daemon is EXPERIMENTAL (#672 Phase-1 spike): it embeds @anthropic-ai/claude-agent-sdk and " +
+      "runs an in-process SDK session on each @-mention. Protocol is unchanged — it advertises as a " +
+      "watch-style wake for now. Not wired into onboarding.",
+  );
+
+  const controller = new AbortController();
+  let signalCode = 0;
+  const onSignal = (signo: "SIGINT" | "SIGTERM") => {
+    signalCode = signo === "SIGINT" ? EXIT_SIGNAL_INT : EXIT_SIGNAL_TERM;
+    controller.abort();
+  };
+  const sigint = () => onSignal("SIGINT");
+  const sigterm = () => onSignal("SIGTERM");
+  process.on("SIGINT", sigint);
+  process.on("SIGTERM", sigterm);
+
+  try {
+    const code = await runDaemon({
+      server: auth.server,
+      token: auth.token,
+      channel,
+      since: loadCursor(channel),
+      runner: createSdkRunner(),
+      onCursor: (cursor) => saveCursor(channel, cursor),
+      timeoutSec,
+      abortSignal: controller.signal,
+    });
+    return signalCode !== 0 ? signalCode : code;
+  } finally {
+    process.off("SIGINT", sigint);
+    process.off("SIGTERM", sigterm);
+  }
+}

--- a/cli/src/commands/daemon.ts
+++ b/cli/src/commands/daemon.ts
@@ -14,15 +14,18 @@
 // 标 replied，无需 work_id/continuation_ref）。SDK 出错也回一条带 reply_to 的失败提示，同样了结 delivery，
 // 避免它租约过期后被无限重投。
 //
-// ⚠️ 仍是 Phase-1 捷径（协议不动）：本命令暂**不**新增 WakeKind:"daemon" / Residency:"daemon"（那是 doc 里
-// 更后的阶段）。为了让 wire 保持不变，daemon 复用现有 serve/watch 风格的唤醒声明——即随 hello 上报
-// `advertiseWakeKind: "watch"`。且**不**跑 serve 的完整 delivery 状态机（不发 delivery_update running/replied
-// 的显式回执，靠 reply_to 隐式了结）——因此长于 delivery 租约（90s，DIRECTED_DELIVERY_LEASE_MS）的 SDK 会话
-// 有被重投/重跑的窗口。取舍见报告与 #672/#688。
+// #688 Phase-2.1（本次）：daemon 升为**一级唤醒类型**——不再复用 watch 捷径。
+//   ① 随 hello 上报 `advertiseWakeKind: "daemon"`：服务端在 presence 落 wake_kind='daemon'、residency='daemon'
+//      （见 worker/src/do.ts advertiseDaemonWakePresence）。who / PresenceBar 据此把它显式标为第一方常驻的强可唤醒档。
+//   ② delivery 租约续期：跑 SDK 期间周期性发 `delivery_update running`（间隔远小于 90s 租约，默认 45s）把
+//      lease_until 顶上去；turn 一结束即停。修掉「SDK 会话长于 DIRECTED_DELIVERY_LEASE_MS(90s) → 服务端租约到期
+//      重派/重跑（重复模型副作用）」的窗口（#688 B）。快 turn（<45s）不发续租、只走终局 reply（reply_to 了结）。
 import {
+  DIRECTED_DELIVERY_LEASE_MS,
   EXIT_ARCHIVED,
   EXIT_AUTH,
   EXIT_STREAM_ENDED,
+  type DirectedDelivery,
 } from "@agentparty/shared";
 import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
 import { connect } from "../client";
@@ -52,7 +55,8 @@ flags:
 auth：内嵌 SDK 走**订阅**凭据，从环境变量 CLAUDE_CODE_OAUTH_TOKEN 读取（Phase-1 live 已验证，零 API key）。
   起 daemon 前请确保该变量是有效的订阅 token/session；过期时 SDK 会话会失败并回一条失败提示（不崩进程）。
 
-experimental：仅供 spike/live 验证，未接入 onboarding / join-pack；协议未改动（复用 watch 唤醒声明）。`;
+experimental：仅供 spike/live 验证，未接入 onboarding / join-pack。声明一级 wake_kind:daemon（residency=daemon），
+  处理 delivery 期间周期续租（delivery_update running），>90s 会话不再被服务端重派。`;
 
 /**
  * SDK 会话运行器抽象——daemon 与具体 SDK 之间的唯一接触面。
@@ -89,6 +93,11 @@ export interface DaemonOptions {
   backoffBaseMs?: number;
   /** 0 = 常驻（默认）；>0 跑满 N 秒后主动关闭连接退出（冒烟测试用）。 */
   timeoutSec?: number;
+  /**
+   * #688 B：处理一条 claimed delivery 期间的租约续期间隔（发 delivery_update running 的周期）。
+   * 默认 DIRECTED_DELIVERY_LEASE_MS/2(≈45s)，远小于 90s 租约。测试注入极小值以在毫秒级验证续租。
+   */
+  leaseRenewIntervalMs?: number;
   /** 干净关停信号（SIGTERM/SIGINT）；abort 时关闭连接、presence 随之清除。 */
   abortSignal?: AbortSignal;
 }
@@ -146,8 +155,9 @@ export async function runDaemon(o: DaemonOptions): Promise<number> {
     // #688：声明本连接消费持久化 directed-delivery v1 帧——不声明就会在真被 @（durable 投递）时收到
     // `upgrade_required` 报错并退出（Phase-1 的崩溃根因）。
     directedDelivery: "v1",
-    // Phase-1 捷径：复用现有 watch 唤醒声明，协议不动（见文件头注释 / #672）。
-    advertiseWakeKind: "watch",
+    // #688 Phase-2.1：一级 daemon 唤醒声明（不再是 watch 捷径）。服务端据此落 wake_kind='daemon'、
+    // residency='daemon'（第一方常驻活体），who / PresenceBar 显式标强可唤醒档。断连由 markOffline 撤销。
+    advertiseWakeKind: "daemon",
   });
 
   let self = "";
@@ -178,8 +188,32 @@ export async function runDaemon(o: DaemonOptions): Promise<number> {
   // 跑 SDK 并回帖的公共路径：delivery 与 plain-msg 两条唤醒都汇到这里。回复始终带 reply_to=msg.seq——
   // 对 delivery 而言这就是了结机制（服务端见目标身份 + reply_to==message_seq 即把 delivery 标 replied，
   // 见文件头 / worker/src/do.ts）；失败提示同样带 reply_to，一样了结 delivery，避免租约过期后被重投。
-  const wake = async (msg: { seq: number; body: string; sender: { name: string } }): Promise<void> => {
+  const wake = async (
+    msg: { seq: number; body: string; sender: { name: string } },
+    delivery: DirectedDelivery | null,
+  ): Promise<void> => {
     out(`daemon: woken by seq=${msg.seq} from ${msg.sender.name}`);
+    // #688 B：claimed delivery 的租约续期。SDK 会话可能长于 DIRECTED_DELIVERY_LEASE_MS(90s)——期间不续租，
+    // 服务端租约到期会把这条 delivery 重新派发/重跑（重复模型副作用）。跑 SDK 期间用一个 setInterval 周期性
+    // 发 delivery_update running（间隔远小于租约）把 lease_until 顶上去；SDK turn 一结束（成功/失败/早退）由
+    // 下方 finally 停表。fire-and-forget：丢一拍无妨，下一拍或终局 reply(reply_to 了结)会补。带 work_id/
+    // continuation_ref 精确锁定这条 work（镜像 serve confirmDeliveryUpdate 的 running 帧参数）。
+    // 快 turn（< 续租间隔）→ 定时器一拍未到就被 finally 清掉，零续租，只走终局 reply。
+    let renewTimer: ReturnType<typeof setInterval> | null = null;
+    if (delivery !== null) {
+      const intervalMs = o.leaseRenewIntervalMs ?? Math.floor(DIRECTED_DELIVERY_LEASE_MS / 2);
+      renewTimer = setInterval(() => {
+        conn.send({
+          type: "delivery_update",
+          delivery_id: delivery.id,
+          state: "running",
+          ...(delivery.work_id === null ? {} : { work_id: delivery.work_id }),
+          ...(delivery.continuation_ref === null ? {} : { continuation_ref: delivery.continuation_ref }),
+        });
+        out(`daemon: renewed delivery ${delivery.id} lease (delivery_update running)`);
+      }, intervalMs);
+      if (typeof renewTimer.unref === "function") renewTimer.unref();
+    }
     let reply: string;
     try {
       reply = await o.runner.run(msg.body, { channel: o.channel, sender: msg.sender.name, seq: msg.seq });
@@ -198,6 +232,10 @@ export async function runDaemon(o: DaemonOptions): Promise<number> {
         out(`daemon: failed to post failure note for seq=${msg.seq}: ${postErr instanceof Error ? postErr.message : String(postErr)}`);
       }
       return;
+    } finally {
+      // SDK turn 结束即停续租——无论成功、失败早退还是抛穿。之后的终局 reply（带 reply_to）负责把 delivery
+      // 从 running 推到 replied，不再需要续租。
+      if (renewTimer) clearInterval(renewTimer);
     }
 
     const body = reply.trim() || "(daemon: SDK 返回空结果)";
@@ -253,7 +291,7 @@ export async function runDaemon(o: DaemonOptions): Promise<number> {
         }
         // 自己发的 @ 不唤醒自己。delivery 是独立 work cursor，不看 conn.cursor 的 fresh。
         if (msg.sender.name === self) continue;
-        await wake(msg);
+        await wake(msg, directedDelivery);
         continue;
       }
 
@@ -267,7 +305,8 @@ export async function runDaemon(o: DaemonOptions): Promise<number> {
       if (directedDeliveryMode && mentioned) continue;
       if (fromSelf || !mentioned || !fresh) continue;
 
-      await wake(msg);
+      // plain-msg 兜底路径没有 delivery 租约，无需续租。
+      await wake(msg, null);
     }
   } finally {
     if (timer) clearTimeout(timer);
@@ -322,9 +361,10 @@ export async function run(argv: string[]): Promise<number> {
   }
 
   console.error(
-    "party daemon is EXPERIMENTAL (#672 Phase-2 spike): it embeds @anthropic-ai/claude-agent-sdk and " +
+    "party daemon is EXPERIMENTAL (#672/#688 Phase-2.1 spike): it embeds @anthropic-ai/claude-agent-sdk and " +
       "runs an in-process SDK session on each @-mention, receiving durable directed deliveries " +
-      "(directedDelivery:v1). Protocol is unchanged — it still advertises as a watch-style wake. " +
+      "(directedDelivery:v1). It advertises a first-class wake_kind:'daemon' (residency=daemon) and renews " +
+      "the delivery lease (delivery_update running) so >90s turns are not re-dispatched. " +
       "Subscription auth comes from CLAUDE_CODE_OAUTH_TOKEN. Not wired into onboarding.",
   );
 

--- a/cli/src/commands/daemon.ts
+++ b/cli/src/commands/daemon.ts
@@ -214,6 +214,12 @@ export async function runDaemon(o: DaemonOptions): Promise<number> {
       if (incoming.type === "welcome") {
         self = incoming.self;
         directedDeliveryMode = incoming.directed_delivery === "v1";
+        // #688：声明 directedDelivery:v1 还不够——服务端只把「已注册的 live delivery adapter」当作
+        // 可实时派发目标(do.ts:2490)。必须像 watch 一样发一帧 register,服务端才会 dispatchNextDirectedDelivery
+        // 把投给本身份的 delivery 实时推过来。逐连接状态,每次重连收到 welcome 都要重发。
+        if (directedDeliveryMode) {
+          conn.send({ type: "delivery_adapter", adapter: "watch", op: "register" });
+        }
         out(
           `daemon: attached to #${o.channel} as @${self} (experimental, SDK-in-process` +
             `${directedDeliveryMode ? ", directed-delivery v1" : ""})`,

--- a/cli/src/commands/daemon.ts
+++ b/cli/src/commands/daemon.ts
@@ -1,13 +1,24 @@
-// party daemon — 实验性：内嵌 @anthropic-ai/claude-agent-sdk 的常驻 party runner（SPIKE，#672 Phase 1）。
+// party daemon — 实验性：内嵌 @anthropic-ai/claude-agent-sdk 的常驻 party runner（SPIKE，#672 Phase 2）。
 //
 // 动机（#672）：`party watch --once` 是单发子进程，harness 在 turn 边界把它回收即静默——presence 的
 // 「可唤醒」本质是谎报，这是 #665/#664/#508/#29/#199 唤醒债风暴的共同根因。daemon 是一档**第一方常驻**
 // runner：长期进程持 WS（真实心跳），被 @ 时就地跑内嵌的官方 Agent SDK session，处理完回帖、进程续存，
 // **不依赖 harness turn 边界**。
 //
-// ⚠️ Phase-1 边界（协议不动）：本命令暂**不**新增 WakeKind:"daemon" / Residency:"daemon"（那是 doc 里的
-// Phase 2）。为了让 wire 保持不变，daemon 复用现有 serve/watch 风格的唤醒声明——即随 hello 上报
-// `advertiseWakeKind: "watch"`。这是刻意的 Phase-1 捷径，见报告与 #672。
+// #688 Phase-2（本次）：Phase-1 只处理普通 `msg` 帧、connect 不声明 directed_delivery——真被 agent @ 时
+// 服务端把 @ 走**持久化 directed delivery**，daemon 收到 `upgrade_required` 报错就崩（`● online` 一被 @
+// 就死，正是 #665 假在线陷阱）。本阶段移植 serve 的 directed-delivery 接收路径：connect 声明
+// `directedDelivery:"v1"`，握手进 directedDeliveryMode 后接住 `delivery` 帧、认领投给本身份的 delivery、
+// 跑 SDK、把回复**带 reply_to 链回 delivery 的原消息**——服务端据此把 delivery 从 claimed 推到 replied
+// （见 worker/src/do.ts `linkWakeResume`→`completeDirectedDelivery`：目标身份 + reply_to==message_seq 即
+// 标 replied，无需 work_id/continuation_ref）。SDK 出错也回一条带 reply_to 的失败提示，同样了结 delivery，
+// 避免它租约过期后被无限重投。
+//
+// ⚠️ 仍是 Phase-1 捷径（协议不动）：本命令暂**不**新增 WakeKind:"daemon" / Residency:"daemon"（那是 doc 里
+// 更后的阶段）。为了让 wire 保持不变，daemon 复用现有 serve/watch 风格的唤醒声明——即随 hello 上报
+// `advertiseWakeKind: "watch"`。且**不**跑 serve 的完整 delivery 状态机（不发 delivery_update running/replied
+// 的显式回执，靠 reply_to 隐式了结）——因此长于 delivery 租约（90s，DIRECTED_DELIVERY_LEASE_MS）的 SDK 会话
+// 有被重投/重跑的窗口。取舍见报告与 #672/#688。
 import {
   EXIT_ARCHIVED,
   EXIT_AUTH,
@@ -24,17 +35,22 @@ import { isSlug } from "../validation";
 export const EXIT_SIGNAL_INT = 128 + 2;
 export const EXIT_SIGNAL_TERM = 128 + 15;
 
-const HELP = `party daemon — 实验性：内嵌 Claude Agent SDK 的常驻 party runner（SPIKE，#672）
+const HELP = `party daemon — 实验性：内嵌 Claude Agent SDK 的常驻 party runner（SPIKE，#672 Phase 2）
 
 usage: party daemon [channel|--channel C] [--timeout N]
 
   连上频道并常驻（长期进程、真实心跳）。被 @ 到本身份时，就地用内嵌的官方
   @anthropic-ai/claude-agent-sdk 跑一个 session，把最终文本回帖到频道——不经 harness、无 turn 边界。
-  SDK 出错则回一条简短失败提示、进程续存。收到 SIGTERM/SIGINT 干净断开（presence 随之清除）。
+  真 agent 的 @ 走持久化 directed delivery：daemon connect 声明 directedDelivery:"v1"，认领投给本身份的
+  delivery、跑 SDK、回复带 reply_to 链回原消息使服务端把 delivery 标为 replied。SDK 出错则回一条带
+  reply_to 的失败提示（同样了结 delivery），进程续存。收到 SIGTERM/SIGINT 干净断开（presence 随之清除）。
 
 flags:
   --channel C     目标频道（也可作为位置参数）；缺省用 party init 绑定的频道
   --timeout N     跑 N 秒后退出（默认 0 = 常驻）；主要给冒烟测试用
+
+auth：内嵌 SDK 走**订阅**凭据，从环境变量 CLAUDE_CODE_OAUTH_TOKEN 读取（Phase-1 live 已验证，零 API key）。
+  起 daemon 前请确保该变量是有效的订阅 token/session；过期时 SDK 会话会失败并回一条失败提示（不崩进程）。
 
 experimental：仅供 spike/live 验证，未接入 onboarding / join-pack；协议未改动（复用 watch 唤醒声明）。`;
 
@@ -107,8 +123,9 @@ export function createSdkRunner(options?: Record<string, unknown>): SdkRunner {
 
 /**
  * daemon 主循环：连上频道、常驻、被 @ 时跑 SDK 并回帖。
- * Phase-1 spike 有意最小化——只处理 plain `msg` 帧的新 @self；status/delivery/message_update 等一律忽略
- * （durable directed-delivery / 暂停接待 / squad 等留给后续阶段）。
+ * #688 Phase-2：既接住持久化 `delivery` 帧（真 agent @ 的主路径），也保留 plain `msg` 帧的 @self 唤醒
+ * （老服务端 / 非持久投递的兜底）。status/presence/message_update 等一律忽略（暂停接待 / squad 等留给后续
+ * 阶段）。delivery 的了结靠回复带 reply_to 链回原消息——服务端据此标 replied（见文件头注释）。
  */
 export async function runDaemon(o: DaemonOptions): Promise<number> {
   const out = o.out ?? ((line: string) => console.log(line));
@@ -126,11 +143,17 @@ export async function runDaemon(o: DaemonOptions): Promise<number> {
   const conn = (o.connectImpl ?? connect)(o.server, o.token, o.channel, o.since, {
     ...(o.onCursor ? { onCursor: o.onCursor } : {}),
     ...(o.backoffBaseMs !== undefined ? { backoffBaseMs: o.backoffBaseMs } : {}),
+    // #688：声明本连接消费持久化 directed-delivery v1 帧——不声明就会在真被 @（durable 投递）时收到
+    // `upgrade_required` 报错并退出（Phase-1 的崩溃根因）。
+    directedDelivery: "v1",
     // Phase-1 捷径：复用现有 watch 唤醒声明，协议不动（见文件头注释 / #672）。
     advertiseWakeKind: "watch",
   });
 
   let self = "";
+  // 服务端是否按 directed-delivery v1 路由 @：为 true 时普通 @self 的 `msg` 帧由 delivery 帧接管，
+  // plain-msg 路径不再据此唤醒（避免同一条 @ 双跑）。老服务端不发 directed_delivery → 保持 msg 路径唤醒。
+  let directedDeliveryMode = false;
   let code = 0;
   let timedOut = false;
   let aborted = false;
@@ -152,57 +175,93 @@ export async function runDaemon(o: DaemonOptions): Promise<number> {
     }, o.timeoutSec * 1000);
   }
 
+  // 跑 SDK 并回帖的公共路径：delivery 与 plain-msg 两条唤醒都汇到这里。回复始终带 reply_to=msg.seq——
+  // 对 delivery 而言这就是了结机制（服务端见目标身份 + reply_to==message_seq 即把 delivery 标 replied，
+  // 见文件头 / worker/src/do.ts）；失败提示同样带 reply_to，一样了结 delivery，避免租约过期后被重投。
+  const wake = async (msg: { seq: number; body: string; sender: { name: string } }): Promise<void> => {
+    out(`daemon: woken by seq=${msg.seq} from ${msg.sender.name}`);
+    let reply: string;
+    try {
+      reply = await o.runner.run(msg.body, { channel: o.channel, sender: msg.sender.name, seq: msg.seq });
+    } catch (error) {
+      const em = error instanceof Error ? error.message : String(error);
+      out(`daemon: sdk session failed on seq=${msg.seq}: ${em}`);
+      // graceful：回一条简短失败提示而非崩溃；提示本身失败也吞掉（best-effort），进程续存。
+      // 该回帖带 reply_to → 即使 SDK 失败也把 delivery 标 replied（一次交付语义），不留悬挂重投。
+      try {
+        await post({
+          body: `⚠️ daemon SDK 会话失败（${em}）——本条 @ 未能就地处理，请重试或改走 human/serve。`,
+          mentions: [msg.sender.name],
+          replyTo: msg.seq,
+        });
+      } catch (postErr) {
+        out(`daemon: failed to post failure note for seq=${msg.seq}: ${postErr instanceof Error ? postErr.message : String(postErr)}`);
+      }
+      return;
+    }
+
+    const body = reply.trim() || "(daemon: SDK 返回空结果)";
+    try {
+      await post({ body, mentions: [msg.sender.name], replyTo: msg.seq });
+      out(`daemon: replied to seq=${msg.seq}`);
+    } catch (error) {
+      out(`daemon: failed to post reply for seq=${msg.seq}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  };
+
   try {
-    for await (const frame of conn.frames) {
-      if (frame.type === "welcome") {
-        self = frame.self;
-        out(`daemon: attached to #${o.channel} as @${self} (experimental, SDK-in-process)`);
+    for await (const incoming of conn.frames) {
+      if (incoming.type === "welcome") {
+        self = incoming.self;
+        directedDeliveryMode = incoming.directed_delivery === "v1";
+        out(
+          `daemon: attached to #${o.channel} as @${self} (experimental, SDK-in-process` +
+            `${directedDeliveryMode ? ", directed-delivery v1" : ""})`,
+        );
         continue;
       }
-      if (frame.type === "error") {
-        out(`daemon: error ${frame.code}: ${frame.message}`);
-        if (frame.code === "unauthorized") code = EXIT_AUTH;
-        else if (frame.code === "archived") code = EXIT_ARCHIVED;
+      if (incoming.type === "error") {
+        out(`daemon: error ${incoming.code}: ${incoming.message}`);
+        if (incoming.code === "unauthorized") code = EXIT_AUTH;
+        else if (incoming.code === "archived") code = EXIT_ARCHIVED;
         else code = 1;
         break;
       }
-      // spike：只有 plain 消息帧能唤醒。status/presence/delivery/message_update 等留给后续阶段。
-      if (frame.type !== "msg") continue;
-      const msg = frame;
+
+      // #688：真 agent 的 @ 走持久化 directed delivery。像 serve 一样把 delivery 帧拆成 delivery 元信息 +
+      // 内嵌的原消息（frame.message）。plain `msg` 帧则 delivery=null、msg=frame 自身。
+      const directedDelivery = incoming.type === "delivery" ? incoming.delivery : null;
+      const msg = incoming.type === "delivery" ? incoming.message : incoming;
+
+      // delivery 帧内嵌的永远是 message，其余（status/presence/…）一律忽略——留给后续阶段。
+      if (msg.type !== "msg") continue;
+
+      // ── 持久化 directed delivery 路径（真 @ 的主路径）──
+      if (directedDelivery !== null) {
+        // 只处理认领给本身份、且处于 claimed 的 delivery；其余（别人的、或状态不对的）记一笔即忽略。
+        if (directedDelivery.target_name !== self || directedDelivery.state !== "claimed") {
+          out(
+            `daemon: ignored invalid delivery ${directedDelivery.id} for target=${directedDelivery.target_name} state=${directedDelivery.state}`,
+          );
+          continue;
+        }
+        // 自己发的 @ 不唤醒自己。delivery 是独立 work cursor，不看 conn.cursor 的 fresh。
+        if (msg.sender.name === self) continue;
+        await wake(msg);
+        continue;
+      }
+
+      // ── plain `msg` 路径（老服务端 / 非持久投递的兜底）──
       const fromSelf = msg.sender.name === self;
       const mentioned = msg.mentions.includes(self);
       const fresh = msg.seq > conn.cursor;
       // 无论是否唤醒都推进游标（并持久化）：daemon 是常驻读者，读过即已读。
       if (msg.seq > 0) conn.ack(msg.seq);
+      // directedDeliveryMode 下，@self 的普通 msg 由 delivery 帧接管——这里不再据它唤醒（否则同一条 @ 双跑）。
+      if (directedDeliveryMode && mentioned) continue;
       if (fromSelf || !mentioned || !fresh) continue;
 
-      out(`daemon: woken by seq=${msg.seq} from ${msg.sender.name}`);
-      let reply: string;
-      try {
-        reply = await o.runner.run(msg.body, { channel: o.channel, sender: msg.sender.name, seq: msg.seq });
-      } catch (error) {
-        const em = error instanceof Error ? error.message : String(error);
-        out(`daemon: sdk session failed on seq=${msg.seq}: ${em}`);
-        // graceful：回一条简短失败提示而非崩溃；提示本身失败也吞掉（best-effort），进程续存。
-        try {
-          await post({
-            body: `⚠️ daemon SDK 会话失败（${em}）——本条 @ 未能就地处理，请重试或改走 human/serve。`,
-            mentions: [msg.sender.name],
-            replyTo: msg.seq,
-          });
-        } catch (postErr) {
-          out(`daemon: failed to post failure note for seq=${msg.seq}: ${postErr instanceof Error ? postErr.message : String(postErr)}`);
-        }
-        continue;
-      }
-
-      const body = reply.trim() || "(daemon: SDK 返回空结果)";
-      try {
-        await post({ body, mentions: [msg.sender.name], replyTo: msg.seq });
-        out(`daemon: replied to seq=${msg.seq}`);
-      } catch (error) {
-        out(`daemon: failed to post reply for seq=${msg.seq}: ${error instanceof Error ? error.message : String(error)}`);
-      }
+      await wake(msg);
     }
   } finally {
     if (timer) clearTimeout(timer);
@@ -257,9 +316,10 @@ export async function run(argv: string[]): Promise<number> {
   }
 
   console.error(
-    "party daemon is EXPERIMENTAL (#672 Phase-1 spike): it embeds @anthropic-ai/claude-agent-sdk and " +
-      "runs an in-process SDK session on each @-mention. Protocol is unchanged — it advertises as a " +
-      "watch-style wake for now. Not wired into onboarding.",
+    "party daemon is EXPERIMENTAL (#672 Phase-2 spike): it embeds @anthropic-ai/claude-agent-sdk and " +
+      "runs an in-process SDK session on each @-mention, receiving durable directed deliveries " +
+      "(directedDelivery:v1). Protocol is unchanged — it still advertises as a watch-style wake. " +
+      "Subscription auth comes from CLAUDE_CODE_OAUTH_TOKEN. Not wired into onboarding.",
   );
 
   const controller = new AbortController();

--- a/cli/src/commands/status.ts
+++ b/cli/src/commands/status.ts
@@ -20,8 +20,8 @@ import { isName, isSlug, parsePositiveIntFlag } from "../validation";
 
 const STATES: StatusState[] = ["working", "waiting", "blocked", "done"];
 const COLLAB_ROLES: CollaborationRole[] = ["host", "worker", "reviewer", "observer"];
-const RESIDENCIES: Residency[] = ["supervised", "webhook", "bare", "human_driven", "unknown"];
-const WAKE_KINDS: WakeKind[] = ["none", "watch", "serve", "webhook"];
+const RESIDENCIES: Residency[] = ["supervised", "webhook", "bare", "human_driven", "unknown", "daemon"];
+const WAKE_KINDS: WakeKind[] = ["none", "watch", "serve", "webhook", "daemon"];
 const SESSION_HARNESSES: AgentSessionInfo["harness"][] = ["codex", "claude", "codex-sdk"];
 const DECISION_KINDS: HostDecisionKind[] = ["decision", "handoff", "takeover"];
 const WORKFLOW_KINDS: WorkflowKind[] = ["pipeline", "parallel", "orchestrator-workers", "evaluator-optimizer"];

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -28,6 +28,7 @@ commands:
   watch     [channel|--channel C] [--timeout N] [--mentions-only] [--follow] [--json]
   ack       [--channel C] [--seq N]                acknowledge a watch wake that needs no reply (#594)
   serve     [channel|--channel C] (--on-mention "<cmd>" | --runner codex|claude|codex-sdk) [--all] | --profile owner/handle
+  daemon    [channel|--channel C] [--timeout N]        EXPERIMENTAL (#672 spike): resident runner embedding the Claude Agent SDK; @-mention → in-process SDK session → reply
   mcp                                                structured control plane (not an idle wake provider)
   lark      notify on|off|status [--channel C]       send channel @mentions to your Lark/Feishu account
   task      create|list|assign|claim|status|block|done|solution [--channel C]  channel task ledger
@@ -105,6 +106,8 @@ export async function main(argv: string[]): Promise<number> {
       return (await import("./commands/ack")).run(rest);
     case "serve":
       return (await import("./commands/serve")).run(rest);
+    case "daemon":
+      return (await import("./commands/daemon")).run(rest);
     case "mcp":
       return (await import("./commands/mcp")).run(rest);
     case "lark":

--- a/cli/test/daemon.test.ts
+++ b/cli/test/daemon.test.ts
@@ -1,0 +1,188 @@
+// #672 Phase-1 spike：party daemon 单测。用真 connect + WS mock server 驱动帧流，注入 SDK runner
+// 与 postReply 捕获回帖——CI 永不触碰真 @anthropic-ai/claude-agent-sdk（SDK 无法在 CI 跑）。
+import { afterEach, describe, expect, test } from "bun:test";
+import { runDaemon, type DaemonOptions, type PostReply, type SdkRunner } from "../src/commands/daemon";
+import { msgFrame, startMockServer, welcomeFrame, type MockServer } from "./mock-server";
+
+let server: MockServer | null = null;
+
+afterEach(() => {
+  server?.stop();
+  server = null;
+});
+
+interface Captured {
+  reply: Parameters<PostReply>[0][];
+  runCalls: { prompt: string; sender: string; seq: number }[];
+  lines: string[];
+}
+
+function harness(over: {
+  runner: SdkRunner;
+  server: string;
+}): { opts: DaemonOptions; captured: Captured } {
+  const captured: Captured = { reply: [], runCalls: [], lines: [] };
+  const postReply: PostReply = async (r) => {
+    captured.reply.push(r);
+  };
+  const opts: DaemonOptions = {
+    server: over.server,
+    token: "ap_tok",
+    channel: "dev",
+    since: 0,
+    runner: over.runner,
+    postReply,
+    backoffBaseMs: 20,
+    // 收完 welcome + 一条 @ 后由 mock 关闭连接触发帧流结束；短 timeout 兜底防挂。
+    timeoutSec: 3,
+    out: (l) => captured.lines.push(l),
+  };
+  return { opts, captured };
+}
+
+function recordingRunner(reply: string): { runner: SdkRunner; calls: Captured["runCalls"] } {
+  const calls: Captured["runCalls"] = [];
+  return {
+    calls,
+    runner: {
+      async run(prompt, ctx) {
+        calls.push({ prompt, sender: ctx.sender, seq: ctx.seq });
+        return reply;
+      },
+    },
+  };
+}
+
+describe("party daemon (#672 Phase-1 spike)", () => {
+  test("@-mention → SDK invoked with mention text → SDK output posted back", async () => {
+    server = startMockServer((frame, sock) => {
+      if (frame.type !== "hello") return;
+      sock.send(welcomeFrame(0, "me"));
+      sock.send(msgFrame(1, "please summarize the thread", { mentions: ["me"] }));
+      // 让 daemon 处理完后自然收束：关闭连接结束帧流。
+      setTimeout(() => sock.close(), 60);
+    });
+
+    const { runner, calls } = recordingRunner("here is your summary");
+    const { opts, captured } = harness({ runner, server: server.url });
+    await runDaemon(opts);
+
+    // SDK 被调用一次，拿到的是 @-mention 正文（不是整帧）。
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.prompt).toBe("please summarize the thread");
+    expect(calls[0]!.sender).toBe("bob");
+    expect(calls[0]!.seq).toBe(1);
+
+    // SDK 返回文本被原样回帖，@ 回发起人、reply_to 指向原消息。
+    expect(captured.reply).toHaveLength(1);
+    expect(captured.reply[0]).toEqual({
+      body: "here is your summary",
+      mentions: ["bob"],
+      replyTo: 1,
+    });
+  });
+
+  test("hello advertises a wake kind so presence sees a live wake channel (Phase-1: watch)", async () => {
+    let helloWakeKind: unknown = "unset";
+    server = startMockServer((frame, sock) => {
+      if (frame.type !== "hello") return;
+      helloWakeKind = (frame as unknown as { wake_kind?: unknown }).wake_kind;
+      sock.send(welcomeFrame(0, "me"));
+      setTimeout(() => sock.close(), 30);
+    });
+
+    const { runner } = recordingRunner("noop");
+    const { opts } = harness({ runner, server: server.url });
+    await runDaemon(opts);
+
+    // Phase-1 捷径：daemon 复用 watch 唤醒声明，协议不动。
+    expect(helloWakeKind).toBe("watch");
+  });
+
+  test("SDK error → posts a short failure note, does not crash, keeps serving", async () => {
+    server = startMockServer((frame, sock) => {
+      if (frame.type !== "hello") return;
+      sock.send(welcomeFrame(0, "me"));
+      sock.send(msgFrame(1, "do the thing", { mentions: ["me"] }));
+      sock.send(msgFrame(2, "second try", { mentions: ["me"] }));
+      setTimeout(() => sock.close(), 80);
+    });
+
+    let calls = 0;
+    const runner: SdkRunner = {
+      async run() {
+        calls++;
+        throw new Error("model unavailable");
+      },
+    };
+    const { opts, captured } = harness({ runner, server: server.url });
+    // 不应抛：graceful 处理。
+    await runDaemon(opts);
+
+    // 两条 @ 都被尝试（进程未因第一条报错而崩溃）。
+    expect(calls).toBe(2);
+    // 每条都回了一条失败提示（含错误摘要），@ 回发起人、reply_to 指向原消息。
+    expect(captured.reply).toHaveLength(2);
+    expect(captured.reply[0]!.body).toContain("model unavailable");
+    expect(captured.reply[0]!.mentions).toEqual(["bob"]);
+    expect(captured.reply[0]!.replyTo).toBe(1);
+    expect(captured.reply[1]!.replyTo).toBe(2);
+  });
+
+  test("ignores own messages and non-mentions (no SDK call, no reply)", async () => {
+    server = startMockServer((frame, sock) => {
+      if (frame.type !== "hello") return;
+      sock.send(welcomeFrame(0, "me"));
+      // 自己发的（即便 @self）不唤醒
+      sock.send(msgFrame(1, "self note", { sender: { name: "me", kind: "agent" }, mentions: ["me"] }));
+      // 别人发但没 @ 我
+      sock.send(msgFrame(2, "chatter", { mentions: [] }));
+      setTimeout(() => sock.close(), 60);
+    });
+
+    const { runner, calls } = recordingRunner("should not run");
+    const { opts, captured } = harness({ runner, server: server.url });
+    await runDaemon(opts);
+
+    expect(calls).toHaveLength(0);
+    expect(captured.reply).toHaveLength(0);
+  });
+
+  test("empty SDK result falls back to a placeholder reply (never posts empty)", async () => {
+    server = startMockServer((frame, sock) => {
+      if (frame.type !== "hello") return;
+      sock.send(welcomeFrame(0, "me"));
+      sock.send(msgFrame(1, "hi", { mentions: ["me"] }));
+      setTimeout(() => sock.close(), 60);
+    });
+
+    const { runner } = recordingRunner("   ");
+    const { opts, captured } = harness({ runner, server: server.url });
+    await runDaemon(opts);
+
+    expect(captured.reply).toHaveLength(1);
+    expect(captured.reply[0]!.body.length).toBeGreaterThan(0);
+  });
+
+  test("abortSignal (SIGTERM) closes the connection and returns cleanly", async () => {
+    server = startMockServer((frame, sock) => {
+      if (frame.type !== "hello") return;
+      sock.send(welcomeFrame(0, "me"));
+      // 不发消息、不关闭：靠 abort 收束。
+    });
+
+    const controller = new AbortController();
+    const { runner } = recordingRunner("noop");
+    const { opts } = harness({ runner, server: server.url });
+    opts.abortSignal = controller.signal;
+    opts.timeoutSec = 0; // 常驻，仅靠 abort 退出
+
+    const done = runDaemon(opts);
+    // 等 attach 后再 abort
+    await new Promise((r) => setTimeout(r, 100));
+    controller.abort();
+    const code = await done;
+    // 干净关停返回 0（run() 再据信号翻成 128+signo）。
+    expect(code).toBe(0);
+  });
+});

--- a/cli/test/daemon.test.ts
+++ b/cli/test/daemon.test.ts
@@ -89,7 +89,7 @@ describe("party daemon (#672 Phase-1/2 spike)", () => {
     });
   });
 
-  test("hello advertises a wake kind so presence sees a live wake channel (Phase-1: watch)", async () => {
+  test("hello advertises a first-class wake_kind:daemon (#688 Phase-2.1, not the watch shortcut)", async () => {
     let helloWakeKind: unknown = "unset";
     server = startMockServer((frame, sock) => {
       if (frame.type !== "hello") return;
@@ -102,8 +102,8 @@ describe("party daemon (#672 Phase-1/2 spike)", () => {
     const { opts } = harness({ runner, server: server.url });
     await runDaemon(opts);
 
-    // Phase-1 捷径：daemon 复用 watch 唤醒声明，协议不动。
-    expect(helloWakeKind).toBe("watch");
+    // #688：一级 daemon 唤醒声明（服务端落 wake_kind='daemon'、residency='daemon'），不再是 Phase-1 的 watch 捷径。
+    expect(helloWakeKind).toBe("daemon");
   });
 
   test("SDK error → posts a short failure note, does not crash, keeps serving", async () => {
@@ -239,6 +239,67 @@ describe("party daemon (#672 Phase-1/2 spike)", () => {
       mentions: ["bob"],
       replyTo: 7,
     });
+  });
+
+  test("slow delivery turn (> renew interval) → daemon renews the lease with ≥1 delivery_update running (#688 B)", async () => {
+    // >90s SDK 会话若不续租，服务端租约到期会重派/重跑（重复模型副作用）。跑 SDK 期间 daemon 周期性发
+    // delivery_update running 顶住 lease_until。这里把续租间隔压到 20ms、runner 拖 150ms，验证真发了续租。
+    const updates: Array<{ delivery_id: string; state: string; work_id?: string; continuation_ref?: string }> = [];
+    server = startMockServer((frame, sock, connIndex) => {
+      if (frame.type === "delivery_update") {
+        updates.push(frame as unknown as (typeof updates)[number]);
+        return;
+      }
+      if (frame.type !== "hello") return;
+      sock.send(welcomeDirectedFrame(0, "me"));
+      if (connIndex !== 0) return;
+      sock.send(deliveryFrame(20, "long migration", { target_name: "me", id: "del-20", work_id: "w20", continuation_ref: "c20" }));
+      setTimeout(() => sock.close(), 300);
+    });
+
+    const runner: SdkRunner = {
+      async run() {
+        await new Promise((r) => setTimeout(r, 150));
+        return "done";
+      },
+    };
+    const { opts, captured } = harness({ runner, server: server.url });
+    opts.leaseRenewIntervalMs = 20;
+    await runDaemon(opts);
+
+    // 至少一拍续租，且都是这条 delivery 的 running、带 work_id/continuation_ref（镜像 serve 的 running 帧参数）。
+    const running = updates.filter((u) => u.state === "running" && u.delivery_id === "del-20");
+    expect(running.length).toBeGreaterThanOrEqual(1);
+    expect(running[0]!.work_id).toBe("w20");
+    expect(running[0]!.continuation_ref).toBe("c20");
+    // 续租不影响正常了结：SDK turn 结束后照常回帖（reply_to=message_seq 使服务端标 replied）。
+    expect(captured.reply).toHaveLength(1);
+    expect(captured.reply[0]!.replyTo).toBe(20);
+  });
+
+  test("fast delivery turn (< renew interval) → zero lease renewals, normal completion (#688 B)", async () => {
+    // 快 turn：定时器一拍未到就被 finally 清掉，零续租，只走终局 reply——不给频道刷多余的 running。
+    const updates: Array<{ state: string }> = [];
+    server = startMockServer((frame, sock, connIndex) => {
+      if (frame.type === "delivery_update") {
+        updates.push(frame as unknown as (typeof updates)[number]);
+        return;
+      }
+      if (frame.type !== "hello") return;
+      sock.send(welcomeDirectedFrame(0, "me"));
+      if (connIndex !== 0) return;
+      sock.send(deliveryFrame(21, "quick question", { target_name: "me", id: "del-21" }));
+      setTimeout(() => sock.close(), 120);
+    });
+
+    const { runner } = recordingRunner("instant"); // 立即返回，远快于续租间隔
+    const { opts, captured } = harness({ runner, server: server.url });
+    opts.leaseRenewIntervalMs = 500; // 远大于 turn 时长
+    await runDaemon(opts);
+
+    expect(updates.filter((u) => u.state === "running")).toHaveLength(0);
+    expect(captured.reply).toHaveLength(1);
+    expect(captured.reply[0]!.replyTo).toBe(21);
   });
 
   test("delivery for a different target is ignored (no SDK, no reply)", async () => {

--- a/cli/test/daemon.test.ts
+++ b/cli/test/daemon.test.ts
@@ -1,8 +1,15 @@
-// #672 Phase-1 spike：party daemon 单测。用真 connect + WS mock server 驱动帧流，注入 SDK runner
+// #672 Phase-1/2 spike：party daemon 单测。用真 connect + WS mock server 驱动帧流，注入 SDK runner
 // 与 postReply 捕获回帖——CI 永不触碰真 @anthropic-ai/claude-agent-sdk（SDK 无法在 CI 跑）。
 import { afterEach, describe, expect, test } from "bun:test";
 import { runDaemon, type DaemonOptions, type PostReply, type SdkRunner } from "../src/commands/daemon";
-import { msgFrame, startMockServer, welcomeFrame, type MockServer } from "./mock-server";
+import {
+  deliveryFrame,
+  msgFrame,
+  startMockServer,
+  welcomeDirectedFrame,
+  welcomeFrame,
+  type MockServer,
+} from "./mock-server";
 
 let server: MockServer | null = null;
 
@@ -53,7 +60,7 @@ function recordingRunner(reply: string): { runner: SdkRunner; calls: Captured["r
   };
 }
 
-describe("party daemon (#672 Phase-1 spike)", () => {
+describe("party daemon (#672 Phase-1/2 spike)", () => {
   test("@-mention → SDK invoked with mention text → SDK output posted back", async () => {
     server = startMockServer((frame, sock) => {
       if (frame.type !== "hello") return;
@@ -162,6 +169,138 @@ describe("party daemon (#672 Phase-1 spike)", () => {
 
     expect(captured.reply).toHaveLength(1);
     expect(captured.reply[0]!.body.length).toBeGreaterThan(0);
+  });
+
+  // ── #688 Phase-2：持久化 directed delivery 接收路径 ──
+
+  test("hello advertises directed_delivery v1 so durable @ deliveries are received", async () => {
+    let helloDirected: unknown = "unset";
+    server = startMockServer((frame, sock) => {
+      if (frame.type !== "hello") return;
+      helloDirected = (frame as unknown as { directed_delivery?: unknown }).directed_delivery;
+      sock.send(welcomeDirectedFrame(0, "me"));
+      setTimeout(() => sock.close(), 30);
+    });
+
+    const { runner } = recordingRunner("noop");
+    const { opts } = harness({ runner, server: server.url });
+    await runDaemon(opts);
+
+    // 不声明就会在真被 @（durable 投递）时收到 upgrade_required 并崩——Phase-1 的根因。
+    expect(helloDirected).toBe("v1");
+  });
+
+  test("delivery frame for self (claimed) → SDK runs on message body → reply linked via reply_to", async () => {
+    // delivery 没有 read-cursor 去重（是独立 work cursor），真服务端了结后不再重投——mock 用 connIndex
+    // 只在首连投递一次来模拟：否则重连会把同一条 claimed delivery 反复重投、SDK 重跑。
+    server = startMockServer((frame, sock, connIndex) => {
+      if (frame.type !== "hello") return;
+      sock.send(welcomeDirectedFrame(0, "me"));
+      if (connIndex !== 0) return;
+      // 真 agent @dbot：服务端投递一条持久 directed delivery（target=me, state=claimed）。
+      sock.send(deliveryFrame(7, "run the migration", { target_name: "me" }));
+      setTimeout(() => sock.close(), 80);
+    });
+
+    const { runner, calls } = recordingRunner("migration complete");
+    const { opts, captured } = harness({ runner, server: server.url });
+    await runDaemon(opts);
+
+    // SDK 拿到的是 delivery 内嵌原消息的正文。
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.prompt).toBe("run the migration");
+    expect(calls[0]!.seq).toBe(7);
+
+    // 回复带 reply_to=message_seq——这正是服务端把 delivery 标 replied 的了结机制（do.ts completeDirectedDelivery）。
+    expect(captured.reply).toHaveLength(1);
+    expect(captured.reply[0]).toEqual({
+      body: "migration complete",
+      mentions: ["bob"],
+      replyTo: 7,
+    });
+  });
+
+  test("delivery for a different target is ignored (no SDK, no reply)", async () => {
+    server = startMockServer((frame, sock, connIndex) => {
+      if (frame.type !== "hello") return;
+      sock.send(welcomeDirectedFrame(0, "me"));
+      if (connIndex !== 0) return;
+      // 投给别人（target=other）——本 daemon 不认领。
+      sock.send(deliveryFrame(8, "not for me", { target_name: "other" }));
+      setTimeout(() => sock.close(), 60);
+    });
+
+    const { runner, calls } = recordingRunner("should not run");
+    const { opts, captured } = harness({ runner, server: server.url });
+    await runDaemon(opts);
+
+    expect(calls).toHaveLength(0);
+    expect(captured.reply).toHaveLength(0);
+  });
+
+  test("delivery in a non-claimed state is ignored (no SDK, no reply)", async () => {
+    server = startMockServer((frame, sock, connIndex) => {
+      if (frame.type !== "hello") return;
+      sock.send(welcomeDirectedFrame(0, "me"));
+      if (connIndex !== 0) return;
+      // 已是 running（例如别处已认领）——不重复处理。
+      sock.send(deliveryFrame(9, "already claimed elsewhere", { target_name: "me", state: "running" }));
+      setTimeout(() => sock.close(), 60);
+    });
+
+    const { runner, calls } = recordingRunner("should not run");
+    const { opts, captured } = harness({ runner, server: server.url });
+    await runDaemon(opts);
+
+    expect(calls).toHaveLength(0);
+    expect(captured.reply).toHaveLength(0);
+  });
+
+  test("SDK error on a delivery → posts a failure note linked via reply_to, does not crash", async () => {
+    server = startMockServer((frame, sock, connIndex) => {
+      if (frame.type !== "hello") return;
+      sock.send(welcomeDirectedFrame(0, "me"));
+      if (connIndex !== 0) return;
+      sock.send(deliveryFrame(10, "do the thing", { target_name: "me" }));
+      sock.send(deliveryFrame(11, "again", { target_name: "me" }));
+      setTimeout(() => sock.close(), 100);
+    });
+
+    let calls = 0;
+    const runner: SdkRunner = {
+      async run() {
+        calls++;
+        throw new Error("model unavailable");
+      },
+    };
+    const { opts, captured } = harness({ runner, server: server.url });
+    await runDaemon(opts);
+
+    // 两条 delivery 都被尝试（第一条报错未崩溃）。
+    expect(calls).toBe(2);
+    // 失败提示同样带 reply_to（=message_seq）——即便 SDK 失败也了结 delivery，避免租约过期后被无限重投。
+    expect(captured.reply).toHaveLength(2);
+    expect(captured.reply[0]!.body).toContain("model unavailable");
+    expect(captured.reply[0]!.replyTo).toBe(10);
+    expect(captured.reply[1]!.replyTo).toBe(11);
+  });
+
+  test("in directed-delivery mode a plain @self msg is not double-woken (delivery owns it)", async () => {
+    server = startMockServer((frame, sock) => {
+      if (frame.type !== "hello") return;
+      sock.send(welcomeDirectedFrame(0, "me"));
+      // 服务端也把 @ 作为普通 msg 广播进时间线；directedDeliveryMode 下它由 delivery 帧接管，
+      // plain-msg 路径绝不能据它再唤醒一次（否则同一条 @ 双跑）。
+      sock.send(msgFrame(12, "please help", { mentions: ["me"] }));
+      setTimeout(() => sock.close(), 60);
+    });
+
+    const { runner, calls } = recordingRunner("should not run twice");
+    const { opts, captured } = harness({ runner, server: server.url });
+    await runDaemon(opts);
+
+    expect(calls).toHaveLength(0);
+    expect(captured.reply).toHaveLength(0);
   });
 
   test("abortSignal (SIGTERM) closes the connection and returns cleanly", async () => {

--- a/cli/test/daemon.test.ts
+++ b/cli/test/daemon.test.ts
@@ -190,6 +190,27 @@ describe("party daemon (#672 Phase-1/2 spike)", () => {
     expect(helloDirected).toBe("v1");
   });
 
+  test("welcome 后发 delivery_adapter register，否则服务端永不实时派发 delivery（#688 live 验证发现）", async () => {
+    // live 验证：只声明 directedDelivery:v1 还不够——服务端仅向「已注册的 delivery adapter」实时派发
+    // （do.ts:2490 收到 register 才 dispatchNextDirectedDelivery）。不发 register → daemon 常驻却收不到任何 @。
+    let registered = false;
+    server = startMockServer((frame, sock) => {
+      if (frame.type === "hello") {
+        sock.send(welcomeDirectedFrame(0, "me"));
+        setTimeout(() => sock.close(), 40);
+        return;
+      }
+      const f = frame as unknown as { type?: string; adapter?: string; op?: string };
+      if (f.type === "delivery_adapter" && f.adapter === "watch" && f.op === "register") registered = true;
+    });
+
+    const { runner } = recordingRunner("noop");
+    const { opts } = harness({ runner, server: server.url });
+    await runDaemon(opts);
+
+    expect(registered).toBe(true);
+  });
+
   test("delivery frame for self (claimed) → SDK runs on message body → reply linked via reply_to", async () => {
     // delivery 没有 read-cursor 去重（是独立 work cursor），真服务端了结后不再重投——mock 用 connIndex
     // 只在首连投递一次来模拟：否则重连会把同一条 claimed delivery 反复重投、SDK 重跑。

--- a/cli/test/mock-server.ts
+++ b/cli/test/mock-server.ts
@@ -102,3 +102,50 @@ export function welcomeFrame(lastSeq: number, self = "me", readCursors?: Array<{
     ...(readCursors ? { read_cursors: readCursors } : {}),
   };
 }
+
+// A welcome that advertises directed-delivery v1 — the server routes real agent @-mentions as durable
+// `delivery` frames only after this negotiation (see cli/src/commands/serve.ts + daemon.ts).
+export function welcomeDirectedFrame(lastSeq: number, self = "me") {
+  return { ...welcomeFrame(lastSeq, self), directed_delivery: "v1" };
+}
+
+// A durable directed-delivery frame: `{ delivery, message }` where message is the @-mention MsgFrame and
+// delivery is the server-owned work row. Mirrors DirectedDelivery in shared/src/protocol.ts; the client
+// validator (parseServerFrame → isDirectedDelivery) requires every field below.
+export function deliveryFrame(
+  seq: number,
+  body: string,
+  over: {
+    target_name?: string;
+    state?: string;
+    sender?: { name: string; kind: string };
+    mentions?: string[];
+    id?: string;
+    work_id?: string | null;
+    continuation_ref?: string | null;
+  } = {},
+) {
+  const now = Date.now();
+  return {
+    type: "delivery",
+    delivery: {
+      id: over.id ?? `del-${seq}`,
+      message_seq: seq,
+      target_name: over.target_name ?? "me",
+      cause: "mention",
+      state: over.state ?? "claimed",
+      attempt: 1,
+      lease_until: now + 90_000,
+      work_id: over.work_id ?? `work-${seq}`,
+      continuation_ref: over.continuation_ref ?? `cont-${seq}`,
+      reply_seq: null,
+      last_error: null,
+      created_at: now,
+      updated_at: now,
+    },
+    message: msgFrame(seq, body, {
+      ...(over.sender ? { sender: over.sender } : {}),
+      mentions: over.mentions ?? [over.target_name ?? "me"],
+    }),
+  };
+}

--- a/cli/test/wakeable-presence.test.ts
+++ b/cli/test/wakeable-presence.test.ts
@@ -21,6 +21,15 @@ describe("wakeableState (#191 可唤醒离线待命 + 服务端校验)", () => {
     expect(wakeableState(e({ name: "b2", wake: { kind: "serve" } }), NOW)).toBe("wakeable_unverified");
   });
 
+  test("daemon（#688）刻意与 serve/watch 同档，而非 webhook：只有服务端盖过 verified_at 才 verified", () => {
+    // 声明了 daemon 但服务端从没观测到「被 @ 后回帖 resume」→ 未验证（honesty #665：不因声明就打包票）。
+    expect(wakeableState(e({ name: "dbot", residency: "daemon", wake: { kind: "daemon" } }), NOW)).toBe("wakeable_unverified");
+    // 服务端 markWakeVerified 盖过 verified_at → 升级为 verified（DO 观测到真回帖，非客户端自报）。
+    expect(
+      wakeableState(e({ name: "dbot2", residency: "daemon", wake: { kind: "daemon", verified_at: NOW - 1000 } }), NOW),
+    ).toBe("wakeable_verified");
+  });
+
   test("没有 wake layer（none / 缺失）→ offline（进程没了，@ 它落不了地）", () => {
     expect(wakeableState(e({ name: "bot", wake: { kind: "none" } }), NOW)).toBe("offline");
     expect(wakeableState(e({ name: "b2" }), NOW)).toBe("offline");

--- a/docs/2026-07-21-sdk-daemon-residency.html
+++ b/docs/2026-07-21-sdk-daemon-residency.html
@@ -123,11 +123,11 @@
       <tr><td><code>serve</code></td><td><code>supervised</code></td><td>常驻 serve 循环 + 租约</td><td>部分</td><td>较少</td></tr>
       <tr><td><code>webhook</code></td><td><code>webhook</code></td><td>服务端 POST 投递</td><td class="yes">是（天然）</td><td class="yes">否</td></tr>
       <tr><td><code>none</code></td><td><code>bare</code> / <code>human_driven</code></td><td>靠人 / 无</td><td class="no">否</td><td>—</td></tr>
-      <tr><td class="new">daemon <em>(新)</em></td><td class="new">daemon <em>(新)</em></td><td class="new">第一方 SDK 常驻进程 + 心跳租约</td><td class="yes">是（心跳 = 活体证据）</td><td class="yes">否（自持进程）</td></tr>
+      <tr><td class="new">daemon <em>(新)</em></td><td class="new">daemon <em>(新)</em></td><td class="new">第一方 SDK 常驻进程 + 心跳租约</td><td>在线即可达；<strong>verified 须服务端观测 @→reply</strong>（同 serve/watch，非凭心跳）</td><td class="yes">否（自持进程）</td></tr>
     </tbody>
   </table>
   <p>
-    关键：<code>wakeableState()</code> 今天只有 webhook 能算 <code>wakeable_verified</code>（服务端持端点）。<span class="new">daemon 的心跳本身就是服务端可观测的活体证据</span>，所以它也能<strong>凭构造进入 verified 档</strong>——而不是像 watch 那样要等 <code>verified_at</code> 被动盖章。租约到期（<code>PRESENCE_TIMEOUT_MS = 60s</code> 没心跳）即如实转 stale，<code>evaluateHostLease()</code> 直接复用。</p>
+    关键（已按实现更正）：webhook 是唯一<strong>凭构造 verified</strong> 的档（服务端持端点、进程离线也能投）。<span class="new">daemon 刻意<strong>不</strong>如此</span>——它与 serve/watch 同档：活着/新鲜时靠 <code>autoWakeReachable(live=true)</code> 判为<strong>可达</strong>，但<strong>只有服务端亲眼观测到「被 @ 后回帖 resume」并盖下 <code>verified_at</code> 才算 <code>wakeable_verified</code></strong>（DO 侧 <code>markWakeVerified</code> 已纳入 daemon）。绝不因「声明了 daemon / 有心跳」就打包票 verified——那正是 <a href="#">#665</a> 的 false-online 陷阱。WS 断/心跳过期（adapter 随之注销）即如实转 stale，<code>evaluateHostLease()</code> 复用。</p>
 
   <h3>3.2 唤醒流（对比今天）</h3>
   <p><strong>今天（watch）：</strong></p>
@@ -162,7 +162,7 @@
   <h2>5 · 分阶段落地</h2>
   <ol class="phases">
     <li><strong>Spike（1）</strong>：最小 <code>party daemon</code> —— 嵌 SDK，起一个能被 party @ 唤醒、就地跑 SDK session 回复的常驻进程。协议不动，先证明「常驻 + 可被唤醒」成立。</li>
-    <li><strong>协议接入（2）</strong>：加 <code>WakeKind:"daemon"</code> + <code>Residency:"daemon"</code>；心跳租约走 <code>evaluateHostLease</code>；<code>wakeableState</code> 让 daemon 凭心跳进 verified。<em>（注意 #622 教训：<code>client.ts</code> 校验词表须逐字镜像；建议同时评估 zod 单源，见附录。）</em></li>
+    <li><strong>协议接入（2）</strong>：加 <code>WakeKind:"daemon"</code> + <code>Residency:"daemon"</code>；心跳租约走 <code>evaluateHostLease</code>；<code>wakeableState</code> 让 daemon 与 serve/watch 同档——只有服务端观测到 @→reply 才 verified（<strong>非</strong>凭心跳）。<em>（注意 #622 教训：<code>client.ts</code> 校验词表须逐字镜像；建议同时评估 zod 单源，见附录。）</em></li>
     <li><strong>权限与决策（3）</strong>：接 <code>canUseTool</code> → owner/worker 边界 + 风险分级；AskUserQuestion → <code>decision_request</code>。</li>
     <li><strong>Dogfood（4）</strong>：在一个频道用 daemon 跑一个真 agent，与 watch 对照，验证「不再石沉大海 / 不再滚债」。</li>
     <li><strong>桌面/接入包（5）</strong>：把 daemon 作为接入包的一种模式（对照 helm 的 daemon + selfsigned 本地 HTTPS + QR 配对）。</li>
@@ -186,7 +186,7 @@
     <tbody>
       <tr><td>Phase-1</td><td>嵌 SDK、connect 常驻、被 @ 就地跑 SDK 回帖</td><td class="yes">✅ live</td></tr>
       <tr><td>Phase-2</td><td>真接住 durable directed delivery：<code>directedDelivery:"v1"</code> + welcome 后 <code>delivery_adapter register</code>（<strong>live 抓到的关键 bug</strong>：只声明 v1 不注册 adapter，服务端永不实时派发）→ 收 <code>delivery</code> 帧、认领、跑 SDK、<code>reply_to</code> 回帖标 <code>replied</code></td><td class="yes">✅ live</td></tr>
-      <tr><td>Phase-2.1</td><td>一级 <code>WakeKind/Residency:"daemon"</code>（不再伪装 watch；<code>wakeableState</code> 只认服务端观测 verified，不重蹈 #665 假在线）+ 投递续租（SDK 跑期间发 <code>delivery_update running</code> 顶 <code>lease_until</code>，解 >90s 重派）</td><td class="yes">✅ live</td></tr>
+      <tr><td>Phase-2.1</td><td>一级 <code>WakeKind/Residency:"daemon"</code>（不再伪装 watch；<code>wakeableState</code> 只认服务端观测 verified，不重蹈 #665 假在线）+ 投递续租（SDK 跑期间发 <code>delivery_update running</code> 顶 <code>lease_until</code>，解 &gt;90s 重派）</td><td class="yes">✅ live</td></tr>
       <tr><td>真 SDK 往返</td><td>隔离频道 connect→真 @→真订阅 SDK→回帖→replied，全绿（零 API key，用订阅登录）</td><td class="yes">✅ live</td></tr>
     </tbody>
   </table>

--- a/docs/2026-07-21-sdk-daemon-residency.html
+++ b/docs/2026-07-21-sdk-daemon-residency.html
@@ -1,0 +1,199 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>AgentParty · SDK-backed daemon residency（第一方常驻 runner）</title>
+  <style>
+    :root {
+      --fg: #202124;
+      --muted: #5f6368;
+      --accent: #2457c5;
+      --border: #d9dde5;
+      --soft: #f5f7fa;
+      --code: #eef1f5;
+      --ok: #166534;
+      --warn: #9a3412;
+    }
+    * { box-sizing: border-box; }
+    body {
+      max-width: 1120px;
+      margin: 0 auto;
+      padding: 2rem 1.4rem 5rem;
+      color: var(--fg);
+      font: 16px/1.65 -apple-system, BlinkMacSystemFont, "PingFang SC", "Microsoft YaHei", sans-serif;
+    }
+    header { border-bottom: 3px solid var(--accent); padding-bottom: 1.1rem; margin-bottom: 2rem; }
+    h1 { margin: 0 0 .45rem; font-size: 1.75rem; line-height: 1.25; }
+    h2 { margin-top: 2.4rem; padding-left: .65rem; border-left: 4px solid var(--accent); font-size: 1.25rem; }
+    h3 { margin-top: 1.6rem; font-size: 1.05rem; }
+    p, li { max-width: 92ch; }
+    a { color: var(--accent); }
+    .meta { color: var(--muted); font-size: .9rem; }
+    .meta span { display: inline-block; margin-right: 1.2rem; }
+    .verdict {
+      margin: 1.4rem 0;
+      padding: 1rem 1.1rem;
+      border: 1px solid var(--border);
+      border-left: 5px solid var(--accent);
+      background: var(--soft);
+    }
+    .verdict strong { color: var(--accent); }
+    table { width: 100%; border-collapse: collapse; margin: 1rem 0; font-size: .9rem; }
+    th, td { border: 1px solid var(--border); padding: .55rem .65rem; text-align: left; vertical-align: top; }
+    th { background: var(--soft); }
+    .yes { color: var(--ok); font-weight: 650; }
+    .no { color: var(--warn); font-weight: 650; }
+    .new { color: var(--accent); font-weight: 650; }
+    code { background: var(--code); border-radius: 3px; padding: .08em .3em; font: .88em "SFMono-Regular", Menlo, Consolas, monospace; }
+    pre { overflow-x: auto; padding: .9rem 1rem; background: var(--code); border: 1px solid var(--border); border-radius: 6px; font-size: .82rem; line-height: 1.55; }
+    pre code { padding: 0; background: transparent; }
+    aside { margin: 1rem 0; padding: .75rem 1rem; background: var(--soft); border-left: 4px solid var(--accent); }
+    .flow { display: grid; grid-template-columns: repeat(5, 1fr); gap: .5rem; margin: 1.1rem 0; }
+    .flow span { padding: .65rem; text-align: center; border: 1px solid var(--border); background: var(--soft); font-size: .85rem; }
+    .flow span + span::before { content: "→ "; color: var(--accent); font-weight: 700; }
+    footer { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--border); color: var(--muted); font-size: .88rem; }
+    ol.phases > li { margin-bottom: .6rem; }
+    @media (max-width: 800px) {
+      body { padding-inline: .8rem; }
+      .flow { grid-template-columns: 1fr; }
+      .flow span + span::before { content: "↓ "; }
+      table { display: block; overflow-x: auto; white-space: normal; }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>SDK-backed <code>daemon</code> residency —— 让「可唤醒」从谎报变成真</h1>
+    <p class="meta">
+      <span>状态：提案（待 owner 拍板）</span>
+      <span>日期：2026-07-21</span>
+      <span>范围：presence / wake / runtime</span>
+    </p>
+  </header>
+
+  <div class="verdict">
+    <strong>TL;DR。</strong> AgentParty 是协调层，但它<strong>不拥有 agent 运行时</strong>——靠外部 harness（Claude Code <code>run_in_background</code> watcher、codex）去真正跑 agent。一整条 bug 血脉（#665 watcher 被 turn 边界回收、#508、#29、#199、唤醒债风暴）都源于此：<code>party watch --once</code> 是个<strong>单发子进程</strong>，命悬于外部 harness 的回合边界，所以 presence 里的「可唤醒」本质是谎报。
+    提案：引入一个<strong>第一方常驻 runner</strong>（<code>party daemon</code>），嵌入官方 <code>@anthropic-ai/claude-agent-sdk</code>，作为一个新的 <span class="new">daemon</span> residency / wake kind 接进现有 <code>Residency</code>/<code>WakeKind</code>/lease 模型。它持有真实心跳租约、被 @ 时直接跑 SDK session、不依赖任何 harness turn 边界——把「wakeable」从<em>暴露悲伤事实</em>升级为<em>真的成立</em>。<strong>但不 all-in</strong>：跨 harness/跨厂商是护城河，daemon 只作为最高档 residency 与 watch/serve/webhook/codex 并存。
+  </div>
+
+  <h2>1 · 问题：运行时是借来的</h2>
+  <p>
+    AgentParty 的每个 agent「实例」并不是它自己拉起来的进程，而是某个外部 harness 里的一次性子任务。<code>party watch --once</code> 是 single-shot：被 @ 唤醒一次、处理、退出，然后<strong>必须靠 harness 在下一回合重新挂上</strong>。当 harness（如 Claude Code）在 turn 边界回收后台任务时，watcher 就此消失——而 presence 层无从当场得知。
+  </p>
+  <p>下面这些 issue 不是各自独立的 bug，而是<strong>同一个根因的不同切面</strong>：</p>
+  <table>
+    <thead><tr><th>Issue</th><th>切面</th><th>根</th></tr></thead>
+    <tbody>
+      <tr><td>#665</td><td>watcher 被回收后 presence 仍显示可唤醒，三条 @ 石沉大海</td><td rowspan="5">agent 不是常驻 daemon，是每回合被拉起又被杀的子进程；「可唤醒」无真实心跳背书</td></tr>
+      <tr><td>#664</td><td>send --mention 到无 wake adapter 目标，发送方零反馈</td></tr>
+      <tr><td>#508 / #29</td><td>后台 watch 静默退出 / turn 边界回收，漏收 @</td></tr>
+      <tr><td>#199</td><td>watch --once 只重放最旧一条未读，不报落后量</td></tr>
+      <tr><td>唤醒债风暴</td><td>每次 watch --once 只清一条旧 seq，债越滚越多</td></tr>
+    </tbody>
+  </table>
+  <aside>
+    我们正在做的 <strong>#664 / #665 / #666</strong> 三个修复，本质是<strong>如实暴露「watch 不可靠」这个事实</strong>（send 时警告、presence 转 stale、网页标 unreachable）。这是必要的止血，但不是根治——它让用户<em>看见</em>不可靠，没让它<em>变可靠</em>。
+  </aside>
+
+  <h2>2 · <code>@anthropic-ai/claude-agent-sdk</code> 是什么</h2>
+  <p>
+    Anthropic 官方的 <strong>Agent SDK</strong>：Claude Code 背后同一套 harness，做成可嵌入你自己进程的库。一次依赖即得：agentic loop、tool use、MCP server 挂载、子代理（Task）、<code>canUseTool</code> 权限门、hooks、<strong>AskUserQuestion 拦截</strong>、session 持久化 / resume、streaming、skills、<code>effort</code> / <code>permissionMode</code>。
+  </p>
+  <p>
+    参考实现：<a href="https://github.com/sorrycc/Helm">helm-agent</a>（陈成 / sorrycc）——它的 daemon 本质就是「把 SDK session 包成常驻服务 + HTTP/SSE + 桌面 UI」。它的 contracts 直接引用 SDK 类型（<code>McpSdkServerConfigWithInstance</code>、<code>parent_tool_use_id</code>、<code>effort</code>、permission modes）。<strong>helm 没有我们这条 reaped-watcher bug 血脉——因为它拥有运行时。</strong>
+  </p>
+
+  <h2>3 · 提案：<code>daemon</code> residency</h2>
+  <p>
+    出一个第一方常驻 runner —— <code>party daemon</code>（工作名）—— 内嵌 <code>@anthropic-ai/claude-agent-sdk</code>。它：
+  </p>
+  <ul>
+    <li>以一个<strong>长期进程</strong>注册进频道，持有<strong>真实心跳租约</strong>的 presence——不是「自报可唤醒」，是「服务端每 N 秒收到活体心跳」。</li>
+    <li>被 @ 时，daemon 直接在本地跑一个 SDK session 处理该 mention，<strong>不依赖任何 harness turn 边界</strong>；处理完回复 + 落 ack，不退出。</li>
+    <li>天然拿到 <code>canUseTool</code> 权限门（对接我们的 owner/worker/front 边界）、hooks、AskUserQuestion（对接 <code>decision_request</code> #284）。</li>
+  </ul>
+
+  <h3>3.1 接进现有模型（不是另起炉灶）</h3>
+  <p>当前 <code>shared/src/protocol.ts</code> 已有一套成熟的 residency / wake / lease 抽象，daemon 只是新增一档：</p>
+  <table>
+    <thead><tr><th><code>WakeKind</code></th><th><code>Residency</code></th><th>谁控制投递 / 存活</th><th>服务端可验证？</th><th>被 harness 回收？</th></tr></thead>
+    <tbody>
+      <tr><td><code>watch</code></td><td><code>supervised</code></td><td>外部 harness 重挂 watcher</td><td class="no">否（自报）</td><td class="no">会（根因）</td></tr>
+      <tr><td><code>serve</code></td><td><code>supervised</code></td><td>常驻 serve 循环 + 租约</td><td>部分</td><td>较少</td></tr>
+      <tr><td><code>webhook</code></td><td><code>webhook</code></td><td>服务端 POST 投递</td><td class="yes">是（天然）</td><td class="yes">否</td></tr>
+      <tr><td><code>none</code></td><td><code>bare</code> / <code>human_driven</code></td><td>靠人 / 无</td><td class="no">否</td><td>—</td></tr>
+      <tr><td class="new">daemon <em>(新)</em></td><td class="new">daemon <em>(新)</em></td><td class="new">第一方 SDK 常驻进程 + 心跳租约</td><td class="yes">是（心跳 = 活体证据）</td><td class="yes">否（自持进程）</td></tr>
+    </tbody>
+  </table>
+  <p>
+    关键：<code>wakeableState()</code> 今天只有 webhook 能算 <code>wakeable_verified</code>（服务端持端点）。<span class="new">daemon 的心跳本身就是服务端可观测的活体证据</span>，所以它也能<strong>凭构造进入 verified 档</strong>——而不是像 watch 那样要等 <code>verified_at</code> 被动盖章。租约到期（<code>PRESENCE_TIMEOUT_MS = 60s</code> 没心跳）即如实转 stale，<code>evaluateHostLease()</code> 直接复用。</p>
+
+  <h3>3.2 唤醒流（对比今天）</h3>
+  <p><strong>今天（watch）：</strong></p>
+  <div class="flow">
+    <span>@mention</span><span>DO 落 delivery ledger</span><span>等 harness 下回合重挂 watch</span><span>watch --once 醒、拉一条</span><span>处理后退出（债留存）</span>
+  </div>
+  <p><strong>提案（daemon）：</strong></p>
+  <div class="flow">
+    <span>@mention</span><span>DO 查 daemon 租约=active</span><span>推送/长连唤醒常驻 daemon</span><span>SDK session 就地处理</span><span>回复+清债，进程续存</span>
+  </div>
+
+  <h3>3.3 权限与决策（顺带解锁）</h3>
+  <table>
+    <thead><tr><th>SDK 能力</th><th>接进 AgentParty</th></tr></thead>
+    <tbody>
+      <tr><td><code>canUseTool</code> 权限回调 + per-tool 风险分级</td><td>owner / worker / front 三方边界的<strong>运行时执行点</strong>；可借鉴 helm 的 <code>risk.ts</code>（low/medium/high + destructive-token 正则）</td></tr>
+      <tr><td>AskUserQuestion 拦截</td><td>直接映射到 <code>decision_request</code>（#284）——daemon 把 SDK 的提问转成频道里的人类决策请求</td></tr>
+      <tr><td><code>permissionMode</code> / <code>effort</code> 级联</td><td>per-channel / per-agent 策略（可借鉴 helm 的 session-policy cascade：sidecar → workspace → config default）</td></tr>
+    </tbody>
+  </table>
+
+  <h2>4 · 不 all-in：daemon 只是最高档，不取代协调层</h2>
+  <p>
+    AgentParty 的差异化是<strong>跨 harness、跨厂商</strong>——它协调 Claude Code + codex + 人类。把运行时锁死到 Anthropic SDK 会收窄这个护城河。所以：
+  </p>
+  <ul>
+    <li><span class="new">daemon</span> 是<strong>新增</strong>的一档 residency，不是替换。watch / serve / webhook / codex / human_driven 全部保留，覆盖 SDK 之外的 harness 与人类。</li>
+    <li>daemon 成为「wakeable 真的成立」的<strong>金标准档</strong>；其余档继续存在，只是如实标注可靠性（这正是 #664/#665/#666 在做的）。</li>
+    <li>用户可选：要「叫得醒、不掉线」就用 <code>party daemon</code>；要「继续用我的 Claude Code / codex 会话」就用 watch/serve，接受其 harness 语义。</li>
+  </ul>
+
+  <h2>5 · 分阶段落地</h2>
+  <ol class="phases">
+    <li><strong>Spike（1）</strong>：最小 <code>party daemon</code> —— 嵌 SDK，起一个能被 party @ 唤醒、就地跑 SDK session 回复的常驻进程。协议不动，先证明「常驻 + 可被唤醒」成立。</li>
+    <li><strong>协议接入（2）</strong>：加 <code>WakeKind:"daemon"</code> + <code>Residency:"daemon"</code>；心跳租约走 <code>evaluateHostLease</code>；<code>wakeableState</code> 让 daemon 凭心跳进 verified。<em>（注意 #622 教训：<code>client.ts</code> 校验词表须逐字镜像；建议同时评估 zod 单源，见附录。）</em></li>
+    <li><strong>权限与决策（3）</strong>：接 <code>canUseTool</code> → owner/worker 边界 + 风险分级；AskUserQuestion → <code>decision_request</code>。</li>
+    <li><strong>Dogfood（4）</strong>：在一个频道用 daemon 跑一个真 agent，与 watch 对照，验证「不再石沉大海 / 不再滚债」。</li>
+    <li><strong>桌面/接入包（5）</strong>：把 daemon 作为接入包的一种模式（对照 helm 的 daemon + selfsigned 本地 HTTPS + QR 配对）。</li>
+  </ol>
+
+  <h2>6 · 风险与未决</h2>
+  <table>
+    <thead><tr><th>风险 / 问题</th><th>取向</th></tr></thead>
+    <tbody>
+      <tr><td>常驻进程的部署/托管（谁来 7×24 跑 daemon？）</td><td>本地机器（桌面端）/ 用户自托管；先不强上云。心跳租约天然处理「机器睡了」= 转 stale。</td></tr>
+      <tr><td>SDK 版本/计费绑定 Anthropic</td><td>可接受——它只是<strong>一档</strong> residency；其它 harness 不受影响。</td></tr>
+      <tr><td>与 serve 的边界（serve 已是常驻+租约）</td><td>daemon = serve + <strong>自带 SDK 运行时</strong>（serve 仍要外部 agent 进程；daemon 自己就是 agent）。需在设计里划清，或让 daemon 成为 serve 的一种 runner 后端。</td></tr>
+      <tr><td>多 daemon 实例 / 抢占</td><td>复用现有同名 serve 实例待命 + 租约裁决逻辑。</td></tr>
+    </tbody>
+  </table>
+
+  <h2>附录 · 从 helm-agent 顺手可借鉴的模式</h2>
+  <p>（<code>helm-agent</code> 源码 <code>license: UNLICENSED</code>——借<strong>思路</strong>不抄码。）</p>
+  <table>
+    <thead><tr><th>helm 模式</th><th>对 AgentParty 的价值</th></tr></thead>
+    <tbody>
+      <tr><td><strong>zod 契约 = 单一真源</strong>，事件用带 tag 的 discriminated union，两端同一处 import</td><td>根治 <strong>#622</strong> 的「<code>client.ts</code> 手写 allow-list 与 <code>protocol.ts</code> 漂移」——结构上不可能漂移</td></tr>
+      <tr><td><strong><code>state</code> 与 <code>tempo</code> 正交</strong>（生命周期 vs「此刻是否在等用户」），idle reaper 在 <code>blocked</code> 时不回收</td><td>正是 <strong>#664/#665/#666</strong> 的正解：presence 别把「在线」和「可唤醒」糊在一起；blocked-on-user 的会话不该被当空闲杀</td></tr>
+      <tr><td><strong>结构化错误变体</strong>（每个错误是带上下文的类型，如 <code>stale_in_progress{stuckIssueIds,hint}</code>）</td><td>#663/#664 想要的「可见、可操作反馈」——取代 stringly <code>errorBody(code,message)</code></td></tr>
+      <tr><td><strong>磁盘持久化 session-status 作真源</strong>，原子写于状态机跃迁点，消费方读盘</td><td>presence 真值分层：落盘真源 + 流只管细节</td></tr>
+      <tr><td><strong>插件能力注册表</strong>（type-only 公共面、id 自动命名空间、warn-and-ignore 降级）</td><td>把现有硬编码的 Lark/Discord/微信 channel adapter 正式化为可扩展注册表</td></tr>
+    </tbody>
+  </table>
+
+  <footer>
+    AgentParty 内部设计提案 · 2026-07-21 · 基于 <code>shared/src/protocol.ts</code>（<code>Residency</code> / <code>WakeKind</code> / <code>evaluateHostLease</code> / <code>wakeableState</code> / <code>PRESENCE_TIMEOUT_MS</code>）实况核对 · 参考 helm-agent 0.0.31 contracts。
+  </footer>
+</body>
+</html>

--- a/docs/2026-07-21-sdk-daemon-residency.html
+++ b/docs/2026-07-21-sdk-daemon-residency.html
@@ -179,6 +179,30 @@
     </tbody>
   </table>
 
+  <h2>7 · 实现进展（已 live 验收，2026-07-21）</h2>
+  <p>本提案已从设计走到<strong>实测可用</strong>（分支 <code>spike/672-daemon-phase2</code>，PR #691；取代 Phase-1 草稿 #685）：</p>
+  <table>
+    <thead><tr><th>阶段</th><th>内容</th><th>状态</th></tr></thead>
+    <tbody>
+      <tr><td>Phase-1</td><td>嵌 SDK、connect 常驻、被 @ 就地跑 SDK 回帖</td><td class="yes">✅ live</td></tr>
+      <tr><td>Phase-2</td><td>真接住 durable directed delivery：<code>directedDelivery:"v1"</code> + welcome 后 <code>delivery_adapter register</code>（<strong>live 抓到的关键 bug</strong>：只声明 v1 不注册 adapter，服务端永不实时派发）→ 收 <code>delivery</code> 帧、认领、跑 SDK、<code>reply_to</code> 回帖标 <code>replied</code></td><td class="yes">✅ live</td></tr>
+      <tr><td>Phase-2.1</td><td>一级 <code>WakeKind/Residency:"daemon"</code>（不再伪装 watch；<code>wakeableState</code> 只认服务端观测 verified，不重蹈 #665 假在线）+ 投递续租（SDK 跑期间发 <code>delivery_update running</code> 顶 <code>lease_until</code>，解 >90s 重派）</td><td class="yes">✅ live</td></tr>
+      <tr><td>真 SDK 往返</td><td>隔离频道 connect→真 @→真订阅 SDK→回帖→replied，全绿（零 API key，用订阅登录）</td><td class="yes">✅ live</td></tr>
+    </tbody>
+  </table>
+  <aside><strong>部署顺序</strong>：presence 显示 <code>daemon</code> 与协议枚举需<strong>先部署 worker</strong>；旧服务端下客户端发 <code>daemon</code> 无害、delivery 靠 <code>delivery_adapter register</code> 照常（向后兼容，已实测）。</aside>
+
+  <h2>8 · daemon ↔ 交互式 Claude CLI 共存（Phase-2.2 · #692）</h2>
+  <p>SDK 就是 Claude Code 打包成库——能与同机 <code>claude</code> CLI 并存（<strong>无硬冲突</strong>），但<strong>共享几处</strong>，生产化前须处理：</p>
+  <table>
+    <thead><tr><th>共享面</th><th>取向</th></tr></thead>
+    <tbody>
+      <tr><td><strong>凭据 + refresh 竞态</strong>：两边读同一份 OAuth，近过期并发刷新会互相打架；多账号时默认路径可能选错账号</td><td>daemon 用<strong>专用 <code>CLAUDE_CODE_OAUTH_TOKEN</code></strong>（<code>claude setup-token</code>）隔离，不蹭交互式凭据 churn</td></tr>
+      <tr><td><strong>配置继承</strong>：<code>query()</code> 默认继承全局 <code>~/.claude</code> 设置、MCP servers、hooks、CLAUDE.md → daemon agent 带全家桶 + hooks 全触发</td><td>起 SDK 时 scope <code>options</code>（<code>cwd</code>/<code>settingSources</code>/allowed-tools/<code>permissionMode</code>）；无头常驻不设 permissionMode 会卡 tool 权限询问</td></tr>
+      <tr><td><strong>订阅额度</strong>：daemon SDK 调用与交互式同池</td><td>文档提示；必要时限流/预算</td></tr>
+    </tbody>
+  </table>
+
   <h2>附录 · 从 helm-agent 顺手可借鉴的模式</h2>
   <p>（<code>helm-agent</code> 源码 <code>license: UNLICENSED</code>——借<strong>思路</strong>不抄码。）</p>
   <table>

--- a/docs/2026-07-21-sdk-daemon-residency.html
+++ b/docs/2026-07-21-sdk-daemon-residency.html
@@ -127,7 +127,7 @@
     </tbody>
   </table>
   <p>
-    关键（已按实现更正）：webhook 是唯一<strong>凭构造 verified</strong> 的档（服务端持端点、进程离线也能投）。<span class="new">daemon 刻意<strong>不</strong>如此</span>——它与 serve/watch 同档：活着/新鲜时靠 <code>autoWakeReachable(live=true)</code> 判为<strong>可达</strong>，但<strong>只有服务端亲眼观测到「被 @ 后回帖 resume」并盖下 <code>verified_at</code> 才算 <code>wakeable_verified</code></strong>（DO 侧 <code>markWakeVerified</code> 已纳入 daemon）。绝不因「声明了 daemon / 有心跳」就打包票 verified——那正是 <a href="#">#665</a> 的 false-online 陷阱。WS 断/心跳过期（adapter 随之注销）即如实转 stale，<code>evaluateHostLease()</code> 复用。</p>
+    关键（已按实现更正）：webhook 是唯一<strong>凭构造 verified</strong> 的档（服务端持端点、进程离线也能投）。<span class="new">daemon 刻意<strong>不</strong>如此</span>——它与 serve/watch 同档：活着/新鲜时靠 <code>autoWakeReachable(live=true)</code> 判为<strong>可达</strong>，但<strong>只有服务端亲眼观测到「被 @ 后回帖 resume」并盖下 <code>verified_at</code> 才算 <code>wakeable_verified</code></strong>（DO 侧 <code>markWakeVerified</code> 已纳入 daemon）。绝不因「声明了 daemon / 有心跳」就打包票 verified——那正是 #665 的 false-online 陷阱。WS 断/心跳过期（adapter 随之注销）即如实转 stale，<code>evaluateHostLease()</code> 复用。</p>
 
   <h3>3.2 唤醒流（对比今天）</h3>
   <p><strong>今天（watch）：</strong></p>

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -193,8 +193,11 @@ export type StatusState = "working" | "waiting" | "blocked" | "done";
 export type PresenceState = StatusState | "offline";
 export type CollaborationRole = "host" | "worker" | "reviewer" | "observer";
 export type CollaborationRoleSource = "self" | "assigned";
-export type Residency = "supervised" | "webhook" | "bare" | "human_driven" | "unknown";
-export type WakeKind = "none" | "watch" | "serve" | "webhook";
+// daemon（#672/#688）：内嵌官方 Agent SDK 的**第一方常驻** runner——长期进程持 WS（真实心跳）、注册
+// delivery adapter，被 @ 时就地跑 SDK 并回帖，不依赖 harness turn 边界。是 supervised 的等价活体（服务端
+// 亲眼看它在线），故在 host 租约 / autoWake 处与 supervised/webhook 同列（见 evaluateHostLease / wakeReachable）。
+export type Residency = "supervised" | "webhook" | "bare" | "human_driven" | "unknown" | "daemon";
+export type WakeKind = "none" | "watch" | "serve" | "webhook" | "daemon";
 export type HostDecisionKind = "decision" | "handoff" | "takeover";
 export type WorkflowKind = "pipeline" | "parallel" | "orchestrator-workers" | "evaluator-optimizer";
 export type HostLeaseState = "active" | "stale";
@@ -662,7 +665,9 @@ export function wakeReachable(
   live = false,
 ): boolean {
   if (kind === "webhook") return true;
-  return (kind === "serve" || kind === "watch") && (live || ageMs < staleMs);
+  // daemon 与 serve/watch 同类：靠一条活着的本地常驻进程接住 @——WS 断/心跳过期（adapter 随之注销）就叫不醒，
+  // 故同样受 live/新鲜度约束。只有 webhook（服务端持端点、离线也能 POST）不受此限。
+  return (kind === "serve" || kind === "watch" || kind === "daemon") && (live || ageMs < staleMs);
 }
 
 // issue #97：presence 的新鲜度不变量没人维护。presence.updated_at 只由 status 帧和 markOffline 写，
@@ -720,7 +725,12 @@ export function wakeableState(
   if (entry.residency === "human_driven") return "offline";
   // webhook：服务端持有端点、自己 POST 投递 → 天然可服务端验证，离线也真能唤醒。
   if (kind === "webhook") return "wakeable_verified";
-  // serve/watch：只有服务端记录过「近期成功唤醒」（verified_at，由 DO 盖，非客户端自报）才算已验证。
+  // daemon（#688）：**刻意与 serve/watch 同档，而非 webhook**。虽是第一方常驻、服务端能看它在线，但它的
+  // 实时投递能力绑定在活着的 WS 上（断连即 markOffline 注销 delivery adapter），和 serve 的 supervisor 一样
+  // 会随进程死去——honesty #665：绝不因「声明了 daemon」就打包票 verified（那正是 false-online 陷阱），
+  // 只认服务端亲眼观测到「被 @ 后回帖 resume」盖下的 verified_at（DO 侧 markWakeVerified 已纳入 daemon）。
+  // 活着但尚未验证的 daemon 仍会被 autoWakeReachable(live=true) 判为可达，不会因此被误标叫不醒。
+  // serve/watch/daemon：只有服务端记录过「近期成功唤醒」（verified_at，由 DO 盖，非客户端自报）才算已验证。
   const verifiedAt = entry.wake?.verified_at;
   if (typeof verifiedAt === "number" && verifiedAt > 0 && now - verifiedAt <= verifyTtlMs) {
     return "wakeable_verified";
@@ -741,7 +751,8 @@ export function evaluateHostLease(
     return { lease: "stale", reason: `role=${entry.role ?? "missing"}`, last_seen: seen, residency, wake_kind: wakeKind };
   }
   if (entry.state === "offline") return { lease: "stale", reason: "offline", last_seen: seen, residency, wake_kind: wakeKind };
-  if (residency !== "supervised" && residency !== "webhook") {
+  // daemon（#688）是 supervised 的等价活体（第一方常驻、服务端见其在线），与 supervised/webhook 同样可持 host 租约。
+  if (residency !== "supervised" && residency !== "webhook" && residency !== "daemon") {
     return { lease: "stale", reason: `residency=${residency}`, last_seen: seen, residency, wake_kind: wakeKind };
   }
   if (wakeKind === "none" || wakeKind === "unknown") {
@@ -775,9 +786,11 @@ export interface HelloFrame {
    * #675：带内 presence 声明「本连接有 watch 唤醒层」（residency=supervised + wake.kind=watch），
    * 取代原先每次挂载往时间线发一条 waiting 状态消息（per-turn 重挂刷屏、推高 seq）。
    * 服务端在这条连接的 presence 行上落 wake_kind，最后一条连接断开时由 markOffline 撤销（#454）。
-   * 旧客户端不带 → 服务端不改 wake_kind（保持旧行为）。仅 'watch' 合法；其余值服务端忽略。
+   * 旧客户端不带 → 服务端不改 wake_kind（保持旧行为）。
+   * 'watch'（#675，residency=supervised）与 'daemon'（#688，residency=daemon，内嵌 SDK 的第一方常驻）合法；
+   * 其余值服务端忽略。两者断连都由 markOffline 撤销（活体死了就不该继续以 wakeable 身份吸收 @）。
    */
-  wake_kind?: "watch";
+  wake_kind?: "watch" | "daemon";
 }
 
 /**

--- a/web/src/components/PresenceBar.test.ts
+++ b/web/src/components/PresenceBar.test.ts
@@ -132,6 +132,16 @@ describe("wakeabilityBadge (#191 可唤醒·待命 + 服务端校验)", () => {
     });
   });
 
+  test("daemon（#688）与 serve/watch 同档：无 verified_at → unverified，有 → verified", () => {
+    expect(wakeabilityBadge(item({ wakeKind: "daemon", wakeVerifiedAt: null, residency: "daemon" }), NOW)?.key).toBe(
+      "PresenceBar.wake.unverified",
+    );
+    expect(wakeabilityBadge(item({ wakeKind: "daemon", wakeVerifiedAt: NOW - 1000, residency: "daemon" }), NOW)).toEqual({
+      key: "PresenceBar.wake.verified",
+      tone: "on",
+    });
+  });
+
   test("wake=none / human_driven / bare → not wakeable（off）", () => {
     expect(wakeabilityBadge(item({ wakeKind: "none" }), NOW)?.key).toBe("PresenceBar.wake.off");
     expect(wakeabilityBadge(item({ wakeKind: "watch", wakeVerifiedAt: NOW, residency: "human_driven" }), NOW)?.tone).toBe("off");

--- a/web/src/components/PresenceBar.tsx
+++ b/web/src/components/PresenceBar.tsx
@@ -280,7 +280,7 @@ function presenceRank(item: Item, now: number): number {
   if (item.state === "blocked") return 1;
   if (item.state === "working") return 2;
   if (item.state !== "offline") return 3;
-  if (item.wakeKind === "serve" || item.wakeKind === "watch" || item.wakeKind === "webhook") return 4;
+  if (item.wakeKind === "serve" || item.wakeKind === "watch" || item.wakeKind === "webhook" || item.wakeKind === "daemon") return 4;
   return 5;
 }
 

--- a/web/src/lib/teams.ts
+++ b/web/src/lib/teams.ts
@@ -69,6 +69,8 @@ interface MemberDraft {
 
 const RESIDENCY_RANK: Record<TeamResidency, number> = {
   webhook: 5,
+  // daemon（#688）：内嵌 SDK 的第一方常驻活体，与 supervised 同为「服务端见其在线」的强档，同 rank。
+  daemon: 4,
   supervised: 4,
   bare: 3,
   human_driven: 2,

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -282,8 +282,8 @@ export const HELLO_TIMEOUT_MS = 8_000;
 const STATUS_STATES: readonly string[] = ["working", "waiting", "blocked", "done"];
 const COLLAB_ROLES: readonly string[] = ["host", "worker", "reviewer", "observer"];
 const ROLE_SOURCES: readonly string[] = ["self", "assigned"];
-const RESIDENCIES: readonly string[] = ["supervised", "webhook", "bare", "human_driven", "unknown"];
-const WAKE_KINDS: readonly string[] = ["none", "watch", "serve", "webhook"];
+const RESIDENCIES: readonly string[] = ["supervised", "webhook", "bare", "human_driven", "unknown", "daemon"];
+const WAKE_KINDS: readonly string[] = ["none", "watch", "serve", "webhook", "daemon"];
 // agent-webhook 接到 2xx 只证明通知越过 HTTP 边界，不能冒充 replied。给外部 harness
 // 留出完成模型 turn 并回频道的时间；期间同一 principal 的 serve/watch 不得重复执行。
 const DIRECTED_WEBHOOK_LEASE_MS = 10 * 60_000;
@@ -2389,10 +2389,15 @@ export class ChannelDO extends Server<Env> {
       if (clientVersion !== null) {
         this.recordClientVersion(st.name, connection.id, clientVersion, Date.now());
       }
-      // #675：带内 watch presence 声明。取代原先挂载往时间线发 waiting 状态消息（刷屏 + 推高 seq）。
-      // 只 agent 连接可声明可唤醒；wake_kind 断连由 markOffline 撤销。仅 'watch' 合法，其余忽略。
-      if (frame.wake_kind === "watch" && st.kind === "agent") {
-        this.advertiseWatchWakePresence(st.name, connection.id, Date.now());
+      // #675/#688：带内唤醒声明。取代原先挂载往时间线发 waiting 状态消息（刷屏 + 推高 seq）。
+      // 只 agent 连接可声明可唤醒；wake_kind 断连由 markOffline 撤销。'watch'（residency=supervised）与
+      // 'daemon'（residency=daemon，内嵌 SDK 的第一方常驻）合法，其余忽略。
+      if (st.kind === "agent") {
+        if (frame.wake_kind === "watch") {
+          this.advertiseWatchWakePresence(st.name, connection.id, Date.now());
+        } else if (frame.wake_kind === "daemon") {
+          this.advertiseDaemonWakePresence(st.name, connection.id, Date.now());
+        }
       }
       // Finish capability identity before replay. Live broadcasts were withheld while helloPending;
       // DO message handling is serialized, so dispatch + backfill below form one gap-free handoff.
@@ -3443,11 +3448,11 @@ export class ChannelDO extends Server<Env> {
        ON CONFLICT(name, session_id) DO UPDATE SET state = 'offline', updated_at = excluded.updated_at,
          current_task = NULL, task_started_at = NULL, heartbeat_at = NULL, activity_json = NULL,
          runner_health_json = NULL,
-         -- #454：watch 只有活着的本地 listener 才能接住 @。最后一条连接断开后立即撤销 wake 声明，
-         -- 不让被 harness kill 的 watch --once 继续以 wakeable 身份吸收 mention。serve/webhook 有独立
-         -- supervisor/服务端投递语义，保持原样；watch 重挂后会由 advertiseWatchWake 重新声明。
-         wake_verified_at = CASE WHEN wake_kind = 'watch' THEN NULL ELSE wake_verified_at END,
-         wake_kind = CASE WHEN wake_kind = 'watch' THEN NULL ELSE wake_kind END`,
+         -- #454/#688：watch / daemon 都只有活着的本地进程才能接住 @。最后一条连接断开后立即撤销 wake 声明，
+         -- 不让被 harness kill 的 watch --once（或已死的 daemon）继续以 wakeable 身份吸收 mention。serve/webhook
+         -- 有独立 supervisor/服务端投递语义，保持原样；watch/daemon 重挂后由 advertiseWatch/DaemonWake 重新声明。
+         wake_verified_at = CASE WHEN wake_kind IN ('watch', 'daemon') THEN NULL ELSE wake_verified_at END,
+         wake_kind = CASE WHEN wake_kind IN ('watch', 'daemon') THEN NULL ELSE wake_kind END`,
       name,
       sessionId,
       ts,
@@ -3556,6 +3561,28 @@ export class ChannelDO extends Server<Env> {
          wake_verified_at = CASE WHEN presence.wake_kind IS 'watch' THEN presence.wake_verified_at ELSE NULL END,
          wake_kind = 'watch',
          residency = COALESCE(presence.residency, 'supervised')`,
+      name,
+      sessionId,
+      ts,
+    );
+    const entry = this.presenceFor(name);
+    if (entry) this.broadcastFrame({ type: "presence", ...entry });
+  }
+
+  // #688：带内声明 daemon 唤醒层——内嵌 SDK 的第一方常驻 runner（长期进程持 WS、注册 delivery adapter、
+  // 被 @ 时就地跑 SDK 回帖）。与 watch 同机制：只在这条连接的 presence 行落 wake_kind='daemon' +
+  // residency='daemon'，不落 history、不产生 seq；断开由 markOffline 撤销（活体死了就不该继续以 wakeable
+  // 身份吸收 @）。wake_verified_at 绝不吃客户端自报——kind 变了就清空，等服务端观测到「被 @ 后回帖 resume」
+  // 才由 markWakeVerified 盖（#191/#665 honesty：daemon 的 verified 也只认服务端事实，不因声明就打包票）。
+  private advertiseDaemonWakePresence(name: string, sessionId: string, ts: number) {
+    this.ctx.storage.sql.exec(
+      `INSERT INTO presence (name, session_id, state, note, updated_at, wake_kind, residency)
+         VALUES (?, ?, 'waiting', NULL, ?, 'daemon', 'daemon')
+       ON CONFLICT(name, session_id) DO UPDATE SET
+         updated_at = excluded.updated_at,
+         wake_verified_at = CASE WHEN presence.wake_kind IS 'daemon' THEN presence.wake_verified_at ELSE NULL END,
+         wake_kind = 'daemon',
+         residency = 'daemon'`,
       name,
       sessionId,
       ts,
@@ -7437,8 +7464,10 @@ export class ChannelDO extends Server<Env> {
   // 只在观测到真实 @→resume 闭环时调用；只盖 serve/watch（webhook 本就服务端投递、恒 verified，
   // wake=none/缺失不无中生有）。这是「可唤醒·已验证」区别于「自称可唤醒·未验证」的唯一可信来源。
   private markWakeVerified(name: string, now: number) {
+    // #688：daemon 与 serve/watch 一样，只有服务端亲眼观测到「被 @ 后回帖 resume」才盖 verified_at
+    // （wakeableState 据此把 daemon 从 unverified 升级为 verified）。webhook 不进此表（天然 verified）。
     this.ctx.storage.sql.exec(
-      "UPDATE presence SET wake_verified_at = ? WHERE name = ? AND wake_kind IN ('serve', 'watch')",
+      "UPDATE presence SET wake_verified_at = ? WHERE name = ? AND wake_kind IN ('serve', 'watch', 'daemon')",
       now,
       name,
     );

--- a/worker/test/hello-wake-advertise.spec.ts
+++ b/worker/test/hello-wake-advertise.spec.ts
@@ -41,6 +41,45 @@ describe("hello.wake_kind 带内 watch presence 声明 (#675)", () => {
     ws.close();
   });
 
+  it("hello 带 wake_kind=daemon → presence 落 wake_kind=daemon + residency=daemon，零时间线消息 (#688)", async () => {
+    const agent = await seedToken("agent");
+    const slug = await createChannel(agent.token);
+    const before = await messageCount(slug, agent.token);
+
+    const ws = await WsClient.open(slug, agent.token);
+    await ws.nextOfType("welcome");
+    ws.send({ type: "hello", since: 0, directed_delivery: "v1", wake_kind: "daemon" });
+    await ws.nextOfType("presence");
+
+    const me = (await fetchPresence(slug, agent.token)).find((p) => p.name === agent.name)!;
+    expect(me.wake?.kind).toBe("daemon");
+    expect(me.residency).toBe("daemon");
+    // #688/#665：daemon 与 serve/watch 同档——自报绝不算已验证，未盖 verified_at 前是 unverified。
+    expect(me.wake?.verified_at).toBeUndefined();
+    expect(wakeableState(me, Date.now())).toBe("wakeable_unverified");
+
+    // 默认静默：没有往时间线塞任何消息。
+    expect(await messageCount(slug, agent.token)).toBe(before);
+    ws.close();
+  });
+
+  it("wake_kind=daemon 的连接断开后撤销 wake 声明（活体死了不再吸收 @）(#688)", async () => {
+    const agent = await seedToken("agent");
+    const slug = await createChannel(agent.token);
+
+    const ws = await WsClient.open(slug, agent.token);
+    await ws.nextOfType("welcome");
+    ws.send({ type: "hello", since: 0, directed_delivery: "v1", wake_kind: "daemon" });
+    await ws.nextOfType("presence");
+    expect((await fetchPresence(slug, agent.token)).find((p) => p.name === agent.name)?.wake?.kind).toBe("daemon");
+
+    ws.close();
+    // 断连回收后 wake_kind 撤销（markOffline 对 wake_kind IN ('watch','daemon') 清零）。
+    await new Promise((r) => setTimeout(r, 50));
+    const after = (await fetchPresence(slug, agent.token)).find((p) => p.name === agent.name);
+    expect(after?.wake?.kind ?? undefined).toBeUndefined();
+  });
+
   it("不带 wake_kind 的 hello 不改 wake_kind（旧客户端保持旧行为）", async () => {
     const agent = await seedToken("agent");
     const slug = await createChannel(agent.token);


### PR DESCRIPTION
> 🧪 **Experimental**。新增隐藏命令 `party daemon`,不接入 onboarding/join-pack。取代 Phase-1 草稿 #685(本分支已含其全部内容)。
> ⚠️ **部署顺序**:presence 显示 `daemon` + 协议枚举(WakeKind/Residency `daemon`)需**先部署 worker**;旧服务端下客户端发 `daemon` 无害、delivery 靠 `delivery_adapter register` 照常(向后兼容,已 live 实测)。

Closes #672(总设计)、Closes #688(接住 directed delivery + 一级 wake kind + 续租)。设计文档:`docs/2026-07-21-sdk-daemon-residency.html`。

## 它做什么
`party daemon <channel>`:一个内嵌官方 `@anthropic-ai/claude-agent-sdk` 的**第一方常驻进程**。连上频道常驻,被 @ 时**就地跑一个 SDK 会话**生成回复贴回频道——不经外部 harness、无 turn 边界。这是 #665/#664/#667/#668… 这条「watcher 被回收→假在线→@ 石沉大海」血脉的**根治方向**(拥有运行时,而非借外部 harness)。

## 分阶段(全部 live 验收)
- **Phase-1**:嵌 SDK,connect 常驻,被 @ 就地跑 SDK 回帖。
- **Phase-2**:真接住 **durable directed delivery**——connect `directedDelivery:"v1"` + welcome 后发 `delivery_adapter register`(**live 验证抓到的关键 bug**:只声明 v1 不够,不注册 adapter 则服务端永不实时派发),收 `delivery` 帧、认领(target==self&&claimed)、跑 SDK、带 `reply_to` 回帖把投递标 `replied`。
- **Phase-2.1**:一级 `WakeKind:"daemon"` + `Residency:"daemon"`(不再伪装 watch);`wakeableState` 刻意与 serve/watch 同档——**只认服务端观测到的 @→reply verified,绝不因自报就 verified**(不重蹈 #665 假在线);**投递续租**:SDK 跑期间每 ~45s 发 `delivery_update running` 顶 `lease_until`,解 >90s 单轮被重派/双跑。

## Live 验收(隔离频道,真订阅 SDK)
connect → 收 directed delivery → 唤醒 → **真 SDK 生成回复** → 回帖 replied,全绿。续租实测发出并被服务端接受。真回帖示例:「我是内嵌 Claude Agent SDK 的常驻 daemon,收到 @ 不重启新进程、就地跑会话回帖」。

## auth
daemon 的 SDK 走**订阅**(`CLAUDE_CODE_OAUTH_TOKEN` 或新鲜的 Claude 登录),**零 API key**——和 helm-agent 同源。HELP 已注明。

## 测试
全套:cli **1052** / worker **719** / web **935** / shared·cli·worker·web tsc 全清。含 daemon delivery/register/续租/wake_kind 广告回归 + worker hello wake_kind:daemon presence + web/cli 显示。

## 仍是 experimental 的边界(见 #688 + 后续 Phase-2.2)
- 串行处理(长 SDK turn 阻塞帧循环);失败关成 `replied`+错误正文而非真 `failed`;
- daemon↔交互式 Claude CLI 共存(auth 隔离 / SDK options 收口 / 订阅额度)见 Phase-2.2。

🤖 由 agent 在隔离 worktree 分阶段实现;每阶段人工审 diff + 我亲自 live 验收(含真 SDK 往返)。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增实验性 `party daemon` 常驻命令：嵌入 Agent SDK 处理被唤醒事件并自动回帖（支持定向投递、lease 续租与完成确认）。
* **改进**
  * `daemon` 居留与唤醒类型现已贯通：连接声明、服务器 verified/租约评估、离线撤销、以及状态展示与排序均支持 `daemon`；状态/参数校验新增 `daemon` 选项。
* **测试**
  * 新增端到端集成测试，覆盖 `@mention` 唤醒、定向投递流程、续租行为、异常与退出信号。
* **文档**
  * 新增 `daemon` 常驻方案提案文档与落地说明。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->