### PR TITLE
fix: 唤醒观测三修 —— wake test 采信 current_task / runner 认证失败正确归类 / daemon SDK options 收口 (#689 #690 #692)

### DIFF
--- a/cli/src/commands/daemon.ts
+++ b/cli/src/commands/daemon.ts
@@ -52,8 +52,17 @@ flags:
   --channel C     目标频道（也可作为位置参数）；缺省用 party init 绑定的频道
   --timeout N     跑 N 秒后退出（默认 0 = 常驻）；主要给冒烟测试用
 
-auth：内嵌 SDK 走**订阅**凭据，从环境变量 CLAUDE_CODE_OAUTH_TOKEN 读取（Phase-1 live 已验证，零 API key）。
-  起 daemon 前请确保该变量是有效的订阅 token/session；过期时 SDK 会话会失败并回一条失败提示（不崩进程）。
+auth（#692①，认证隔离）：内嵌 SDK 走**订阅**凭据，零 API key。强烈建议起 daemon 前 \`claude setup-token\` 生成
+  专用 token 并 export CLAUDE_CODE_OAUTH_TOKEN——daemon 优先用它，与交互式 \`claude\` 的凭据 churn（近过期并发
+  refresh 互相打架 / 多账号选错默认账号）隔离开。未设则回退共享 OAuth creds（有上述竞态风险）。token 过期时 SDK
+  会话失败并回一条失败提示（不崩进程）。
+
+scope（#692②，别继承交互式全家桶）：SDK session 被收口到 settingSources:[]（不读全局 ~/.claude 设置 / MCP
+  servers / hooks / CLAUDE.md）、allowedTools:[]（不授予任何工具）、permissionMode:dontAsk（headless 不挂权限询问）。
+  daemon 只产文本回帖。
+
+quota（#692③，订阅额度感知）：每次 SDK 调用与交互式 Claude Code 吃**同一个订阅额度**。常驻高频被 @ 会啃上限——
+  酌情限流。
 
 experimental：仅供 spike/live 验证，未接入 onboarding / join-pack。声明一级 wake_kind:daemon（residency=daemon），
   处理 delivery 期间周期续租（delivery_update running），>90s 会话不再被服务端重派。`;
@@ -103,15 +112,45 @@ export interface DaemonOptions {
 }
 
 /**
+ * #692 Phase-2.2：收口 SDK `options`，别继承交互式 Claude Code 的「全家桶」。
+ *
+ * SDK `query()` 跑的是完整 Claude Code 引擎，默认继承全局 `~/.claude` 设置、**MCP servers、hooks、CLAUDE.md**。
+ * 常驻 daemon 被一条 @ 唤起时，那个 agent 会带着 owner 所有 MCP 工具 + 全部 hooks 触发 + 全局规则跑——几乎
+ * 都不是想要的，还平白扩大权限面。这里把 options scope 到「无头、纯文本、零工具、不读全局配置」的最小面：
+ *   - `permissionMode:"dontAsk"`（#691 评审 Major）：headless 无 TTY，默认 'default' 遇到需批准的工具会挂起；
+ *     dontAsk = 不提示、未预批工具一律拒绝。
+ *   - `settingSources:[]`：不加载全局 ~/.claude 设置 / MCP servers / hooks / CLAUDE.md。
+ *   - `allowedTools:[]`：不授予任何工具（与 dontAsk 叠成 defense-in-depth：既不问、也无工具可用）。daemon 只产文本回帖。
+ *   - 认证隔离（#692①）：设了专用 `CLAUDE_CODE_OAUTH_TOKEN`（`claude setup-token`）就显式喂给 SDK 子进程 env——
+ *     把 daemon 的 auth 与交互式 CLI 的凭据 churn（近过期并发 refresh 互相打架 / 多账号选错默认凭据）隔离开。
+ *
+ * 后续（owner/worker 边界的 `canUseTool` → 三方边界、AskUserQuestion→decision_request #284）在此基础上放开受控工具。
+ * 调用方可用 overrides 覆盖任意默认（如 live 调试临时放开某工具）。
+ */
+export function buildSdkOptions(
+  overrides?: Record<string, unknown>,
+  env: NodeJS.ProcessEnv = process.env,
+): Record<string, unknown> {
+  const base: Record<string, unknown> = {
+    permissionMode: "dontAsk",
+    settingSources: [],
+    allowedTools: [],
+  };
+  const oauthToken = env.CLAUDE_CODE_OAUTH_TOKEN;
+  if (oauthToken) {
+    // 保留其余环境（PATH 等），只把专用订阅 token 钉进子进程 env——SDK 优先用它，绕开共享 OAuth creds 文件的
+    // refresh 竞态。未设时不加 env 键：SDK 走默认凭据路径（多账号下可能不是当前登录账号，见 run() 的启动告警）。
+    base.env = { ...env, CLAUDE_CODE_OAUTH_TOKEN: oauthToken };
+  }
+  return { ...base, ...(overrides ?? {}) };
+}
+
+/**
  * 生产 SDK 运行器：懒加载官方 @anthropic-ai/claude-agent-sdk 的 query()，收集最终 result 文本。
  * 懒加载（dynamic import）保证只有真跑 daemon 才载入 SDK——注入了 mock 的单测永远不会触碰它。
  */
 export function createSdkRunner(options?: Record<string, unknown>): SdkRunner {
-  // #691 评审(Major)：无头 daemon 必须显式设 permissionMode。SDK 默认 'default' 会在 headless（无 TTY、
-  // 未提供 canUseTool）下遇到需批准的工具时挂起/行为不定。'dontAsk' = 不提示、未预批的工具一律拒绝——
-  // experimental daemon 只产文本、绝不被一条 @ 触发任意工具执行（安全）。完整的 owner/worker 边界权限模型
-  // （canUseTool → 三方边界、allowedTools、scope options）见 Phase-2.2 #692；调用方可覆盖本默认。
-  const sdkOptions: Record<string, unknown> = { permissionMode: "dontAsk", ...(options ?? {}) };
+  const sdkOptions = buildSdkOptions(options);
   return {
     async run(prompt: string, ctx: SdkRunContext): Promise<string> {
       const { query } = await import("@anthropic-ai/claude-agent-sdk");
@@ -370,8 +409,23 @@ export async function run(argv: string[]): Promise<number> {
       "runs an in-process SDK session on each @-mention, receiving durable directed deliveries " +
       "(directedDelivery:v1). It advertises a first-class wake_kind:'daemon' (residency=daemon) and renews " +
       "the delivery lease (delivery_update running) so >90s turns are not re-dispatched. " +
-      "Subscription auth comes from CLAUDE_CODE_OAUTH_TOKEN. Not wired into onboarding.",
+      "The SDK session is scoped (settingSources:[], allowedTools:[], permissionMode:dontAsk) so it does NOT " +
+      "inherit your global ~/.claude MCP servers / hooks / CLAUDE.md — it only produces text replies. " +
+      "Not wired into onboarding.",
   );
+  // #692①：认证隔离。有专用 CLAUDE_CODE_OAUTH_TOKEN（`claude setup-token`）→ daemon 走它，与交互式 CLI 的凭据
+  // churn 隔离；没有 → 回退共享 OAuth creds，近过期并发 refresh 会互相打架、多账号下可能选错默认账号。明说，别静默。
+  if (process.env.CLAUDE_CODE_OAUTH_TOKEN) {
+    console.error("party daemon: using dedicated CLAUDE_CODE_OAUTH_TOKEN (auth isolated from interactive `claude` CLI).");
+  } else {
+    console.error(
+      "party daemon: CLAUDE_CODE_OAUTH_TOKEN not set — falling back to the shared Claude Code OAuth credentials. " +
+        "Near expiry the daemon and an interactive `claude` may fight over refresh, and on multi-account machines the " +
+        "SDK may pick the wrong (default) account. Recommended: run `claude setup-token` and export CLAUDE_CODE_OAUTH_TOKEN " +
+        "before launching the daemon. Every SDK call also draws on the SAME subscription quota as interactive Claude Code — " +
+        "a high-frequency @-driven daemon can exhaust it.",
+    );
+  }
 
   const controller = new AbortController();
   let signalCode = 0;

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -199,10 +199,18 @@ export class WakeBlockedError extends Error {
    * 只有「runner 根本没起来」（spawn 失败）才置 true。
    */
   readonly retriable: boolean;
-  constructor(message: string, retriable = false) {
+  /**
+   * #690：runner **环境性**失败——认证过期 / 二进制缺失 / 沙箱拒权等在**模型启动之前**就崩的错。
+   * 与 retriable 正交：environment=true 时模型确定没跑（放弃留痕不该再说「model may have run」），
+   * 但认证/二进制没修好前立刻重试也是白烧（默认仍 retriable=false，快速放弃、把清晰的环境错拍进 runner_health
+   * 让 owner 从 `party who` / `party wake test` 看得见），修好后由下一条 @ 或重连自愈。
+   */
+  readonly environment: boolean;
+  constructor(message: string, retriable = false, opts?: { environment?: boolean }) {
     super(message);
     this.name = "WakeBlockedError";
     this.retriable = retriable;
+    this.environment = opts?.environment ?? false;
   }
 }
 
@@ -1560,6 +1568,34 @@ function isInvalidPersistedSessionError(error: unknown): boolean {
   return structuredErrorCode(error) !== null;
 }
 
+// #690：识别 runner **环境性**失败——凭据过期 / 未登录 / 二进制缺失 / 沙箱拒权。这类错在模型启动**之前**
+// 就把 runner 崩掉（`claude -p` 秒退 exit 1），既非「model may have run」也非可 cold-start 重跑的 session 失效。
+// 只匹配明确的环境指纹（保守：宁可漏判也不把真实的模型失败误标成环境错），命中即：
+//   ① 放弃留痕说「runner environment failure — model did not run」而非「model may have run」；
+//   ② 拍进 runner_health.last_error，owner 从 `party who` / `party wake test` 看得见（#603 观测面）。
+const RUNNER_ENV_FAILURE_PATTERNS: readonly RegExp[] = [
+  /oauth[^\n]*(expired|refresh)/i,
+  /(session|token|credential)[^\n]*expired/i,
+  /failed to authenticate/i,
+  /authentication[_\s-]*(error|failed|required)/i,
+  /not (logged in|authenticated)/i,
+  /please run\b[^\n]*login/i,
+  /\bclaude (login|setup-token)\b/i,
+  /invalid api key/i,
+  /\b(401|403)\b[^\n]*(unauthorized|forbidden)/i,
+  /\bunauthorized\b/i,
+  // 二进制缺失 / 无法执行（spawn 前后都可能落到 stderr）。
+  /command not found/i,
+  /no such file or directory/i,
+  /\benoent\b/i,
+  /permission denied/i,
+];
+
+export function isRunnerEnvFailure(result: Pick<RunnerProcessResult, "stdout" | "stderr">): boolean {
+  const haystack = `${result.stderr}\n${result.stdout}`;
+  return RUNNER_ENV_FAILURE_PATTERNS.some((re) => re.test(haystack));
+}
+
 function writeSdkSession(path: string, state: SdkWakeSessionState): SdkWakeSessionState {
   return mergeRunnerContinuation(path, state) as SdkWakeSessionState;
 }
@@ -2435,11 +2471,17 @@ export function createBuiltinRunner(opts: BuiltinRunnerOptions): NonNullable<Ser
         exitCode = run.result.code;
         const now = opts.now?.() ?? Date.now();
         if (run.result.code !== 0) {
+          // #690：认证过期 / 二进制缺失 / 沙箱拒权等环境性失败在模型启动前就崩，别归为「model may have run」。
+          const envFailure = isRunnerEnvFailure(run.result);
           appendRunnerLog(
             opts.workdir,
-            `${new Date(now).toISOString()} seq=${frame.seq} sid=${shortSid(oldSid)} duration_ms=${now - started} exit=${run.result.code}`,
+            `${new Date(now).toISOString()} seq=${frame.seq} sid=${shortSid(oldSid)} duration_ms=${now - started} exit=${run.result.code}${envFailure ? " env_failure=true" : ""}`,
           );
-          throw new WakeBlockedError(`builtin ${opts.harness} runner blocked: exit code ${run.result.code}; log: ${join(opts.workdir, RUNNER_LOG_FILE)}`);
+          throw new WakeBlockedError(
+            `builtin ${opts.harness} runner blocked: exit code ${run.result.code}${envFailure ? " (runner environment failure: credentials/binary/sandbox — model did not run)" : ""}; log: ${join(opts.workdir, RUNNER_LOG_FILE)}`,
+            false,
+            { environment: envFailure },
+          );
         }
 
         finalSid = run.sessionId;
@@ -4436,7 +4478,14 @@ export async function runServe(o: ServeOptions): Promise<number> {
               // 抛错不等于「模型没跑过」。只有 runner 明确声明可重试（spawn 都没成功）才重试；
               // 否则重跑会重复模型与外部副作用（git push / 开 PR）。见门禁 P1③。
               retriable = e instanceof WakeBlockedError ? e.retriable : false;
-              if (!retriable) lastError += " (not retriable: model may have run)";
+              // #690：环境性失败（认证/二进制/沙箱）模型确定没跑——别再挂「model may have run」的免责标签，
+              // 那会误导 owner 以为副作用可能已发生。说清是环境坏了、修好再 @ 即可（保守：仅明确指纹命中）。
+              const envFailure = e instanceof WakeBlockedError && e.environment;
+              if (!retriable) {
+                lastError += envFailure
+                  ? " (runner environment failure: model did not run — fix credentials/binary/sandbox, e.g. `claude login`, then re-mention)"
+                  : " (not retriable: model may have run)";
+              }
               out(`  命令失败 (${attempt}/${maxAttempts}): ${lastError}`);
               // 先落盘再重试：此刻进程崩掉，重启后不会把已经烧掉的次数忘干净
               // Directed work has its own server-side lease/state machine. Mirroring it into the

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -1591,9 +1591,11 @@ const RUNNER_ENV_FAILURE_PATTERNS: readonly RegExp[] = [
   /permission denied/i,
 ];
 
-export function isRunnerEnvFailure(result: Pick<RunnerProcessResult, "stdout" | "stderr">): boolean {
-  const haystack = `${result.stderr}\n${result.stdout}`;
-  return RUNNER_ENV_FAILURE_PATTERNS.some((re) => re.test(haystack));
+// 只扫 stderr，绝不扫 stdout：环境错（认证/spawn/权限）都落 stderr；而 stdout 是**模型输出**——若模型正好
+// 写了「unauthorized」「permission denied」之类的字样，扫进来就会把一次真实的模型运行误判成「model did not run」，
+// 正好颠倒 environment 标志的语义（CodeRabbit #693）。stderr-only 既覆盖真实指纹又杜绝这条误报路径。
+export function isRunnerEnvFailure(result: Pick<RunnerProcessResult, "stderr">): boolean {
+  return RUNNER_ENV_FAILURE_PATTERNS.some((re) => re.test(result.stderr));
 }
 
 function writeSdkSession(path: string, state: SdkWakeSessionState): SdkWakeSessionState {

--- a/cli/src/commands/wake.ts
+++ b/cli/src/commands/wake.ts
@@ -29,7 +29,10 @@ Options:
 // #603：把笼统的 timeout 按 presence 的探活分级细分——not_listening（服务端观测到 delivery
 // 租约对活连接反复过期）与 runner_failing（serve 自报 runner 连败）。处置完全不同：
 // 前者重启 supervisor / 查事件循环，后者修 runner 环境（二进制/凭据/沙箱）。
-type WakeResult = "not_auto_wakeable" | "healthy" | "timeout" | "self_target" | "not_listening" | "runner_failing";
+// #689：headless runner（builtin claude/codex）处理一条 @ 要数分钟，30s 探测窗口内不可能有最终回复。
+// 但只要 presence.current_task 指向本探针的 seq，就证明 runner 已被唤起、正在处理——这是「wake invoked: yes」
+// 的明确信号，不该误报失败。wake_pending = 唤醒确凿、最终回复待定（介于 healthy 与 timeout 之间的成功态）。
+type WakeResult = "not_auto_wakeable" | "healthy" | "wake_pending" | "timeout" | "self_target" | "not_listening" | "runner_failing";
 type AckEvidence = "reply_to" | "status.summary_seq";
 
 interface WakePresence {
@@ -41,6 +44,8 @@ interface WakePresence {
   // 探活分级（#603）：缺省即无恙。
   listening?: PresenceEntry["listening"];
   runner_health?: PresenceEntry["runner_health"];
+  // #689：runner 当前正在处理的触发 seq（缺省=空闲）。等于本探针 seq 即「已唤起、正在处理这条 @」。
+  current_task?: PresenceEntry["current_task"];
 }
 
 interface WakeTestFrame extends Record<string, unknown> {
@@ -73,6 +78,7 @@ function summarizePresence(p: PresenceEntry | null): WakePresence {
     last_seen: p?.last_seen ?? p?.ts ?? null,
     ...(p?.listening === undefined ? {} : { listening: p.listening }),
     ...(p?.runner_health === undefined ? {} : { runner_health: p.runner_health }),
+    ...(p?.current_task === undefined ? {} : { current_task: p.current_task }),
   };
 }
 
@@ -230,7 +236,10 @@ function printHuman(frame: WakeTestFrame) {
       frame.phases.wake_invoked.ok === null
         ? frame.phases.wake_invoked.evidence
         : frame.phases.wake_invoked.ok
-          ? "yes"
+          ? // #689：唤起确凿但最终回复未到（headless runner 数分钟）——明说 reply pending，别让读者误当彻底成功或失败。
+            frame.result === "wake_pending"
+            ? "yes (reply pending)"
+            : "yes"
           : "no"
     }`,
   );
@@ -238,7 +247,9 @@ function printHuman(frame: WakeTestFrame) {
     `resumed: ${
       frame.phases.agent_resumed.ok
         ? `yes #${frame.phases.agent_resumed.seq} evidence=${frame.phases.agent_resumed.evidence}`
-        : "no"
+        : frame.result === "wake_pending"
+          ? "pending (runner still working)"
+          : "no"
     }`,
   );
 }
@@ -399,36 +410,56 @@ export async function run(argv: string[]): Promise<number> {
         : gate.advisory !== null
           ? `${gate.advisory} (unconfirmed — probe delivered #${seq}, no reply within ${timeoutSec}s)`
           : timeoutReason;
-    // 探活分级（#603）：timeout 不再一锅端。重取一次 presence——若服务端/自报已给出证据，
-    // 细分为可处置的结论：runner_failing（修 runner 环境）优先于 not_listening（重启 supervisor），
-    // 因为「唤醒了起不来」比「没在消费」更接近根因。
+    // 探活分级（#603/#689）：没收到最终回复不再一锅端。重取一次 presence——若服务端/自报已给出证据，
+    // 细分为可处置的结论。优先级（先真、再故障、后不消费）：
+    //   ① current_task==本探针 seq → runner 已唤起、正在处理这条 @：wake_pending（唤醒确凿，reply pending）。
+    //      #689：headless runner 跑一条要数分钟，30s 内没有最终回复是正常的，绝不能误报「no wake adapter」/失败。
+    //      这条对「没声明适配器」(advisory) 与「timeout」两条路径都适用——current_task 是活体执行的直接证据，
+    //      不依赖 presence 是否同步了 wake 适配器声明。
+    //   ② runner_health 报连败 → runner_failing（修 runner 环境，优先于不消费——「唤醒了起不来」更接近根因）。
+    //   ③ listening=deaf/suspect → not_listening（重启 supervisor）。
     let finalPresence = presence;
-    if (result === "timeout") {
+    if (ack === null) {
       try {
         finalPresence = (await fetchPresence(cfg.server, cfg.token, channel)).find((p) => p.name === target) ?? presence;
       } catch {
         /* 刷新失败就用探针前的快照定级 */
       }
-      const health = finalPresence?.runner_health;
-      if (health !== undefined && !health.ok) {
-        result = "runner_failing";
+      if (finalPresence?.current_task === seq) {
+        result = "wake_pending";
         frameReason =
-          `probe delivered #${seq} but the target's runner keeps failing (x${health.consecutive_failures}` +
-          `${health.last_error !== undefined ? `: ${health.last_error}` : ""}) — fix the runner environment ` +
-          "(binary/credentials/sandbox) instead of re-mentioning";
-      } else if (finalPresence?.listening === "deaf" || finalPresence?.listening === "suspect") {
-        result = "not_listening";
-        frameReason =
-          `probe delivered #${seq} but the target's live connection is not consuming deliveries ` +
-          `(listening=${finalPresence.listening}) — restart its serve/watch supervisor instead of re-mentioning`;
+          `probe delivered #${seq}; target's runner is actively processing it (presence.current_task=#${seq}) — ` +
+          "wake invoked, final reply pending (a headless builtin runner may take minutes to reply)";
+      } else if (result === "timeout") {
+        const health = finalPresence?.runner_health;
+        if (health !== undefined && !health.ok) {
+          result = "runner_failing";
+          frameReason =
+            `probe delivered #${seq} but the target's runner keeps failing (x${health.consecutive_failures}` +
+            `${health.last_error !== undefined ? `: ${health.last_error}` : ""}) — fix the runner environment ` +
+            "(binary/credentials/sandbox) instead of re-mentioning";
+        } else if (finalPresence?.listening === "deaf" || finalPresence?.listening === "suspect") {
+          result = "not_listening";
+          frameReason =
+            `probe delivered #${seq} but the target's live connection is not consuming deliveries ` +
+            `(listening=${finalPresence.listening}) — restart its serve/watch supervisor instead of re-mentioning`;
+        }
       }
     }
+    // #689：runner 正在处理本探针（current_task 命中）是唤醒确凿的最强证据——盖过「没声明适配器」的负面 heartbeat
+    // 视角与 ledger 未审计。此时 wake_invoked 直接判 yes、reply pending。
     const wakeInvoked =
-      gate.advisory !== null && wakeDelivery === null
-        ? { ok: false as const, adapter, evidence: gate.advisory }
-        : adapter === "serve" || adapter === "watch"
-          ? summarizeServeWatchDelivery(wakeDelivery, adapter)
-          : summarizeWakeDelivery(wakeDelivery, adapter);
+      result === "wake_pending"
+        ? {
+            ok: true as const,
+            adapter,
+            evidence: `target's runner is processing mention #${seq} (presence.current_task) — wake invoked; final reply pending`,
+          }
+        : gate.advisory !== null && wakeDelivery === null
+          ? { ok: false as const, adapter, evidence: gate.advisory }
+          : adapter === "serve" || adapter === "watch"
+            ? summarizeServeWatchDelivery(wakeDelivery, adapter)
+            : summarizeWakeDelivery(wakeDelivery, adapter);
     const frame: WakeTestFrame = {
       type: "wake_test",
       channel,
@@ -446,7 +477,8 @@ export async function run(argv: string[]): Promise<number> {
     };
     if (flags.json === true) console.log(JSON.stringify(jsonFrame(frame)));
     else printHuman(frame);
-    return ack === null ? EXIT_TIMEOUT : 0;
+    // #689：wake_pending（唤醒确凿、reply pending）与 healthy 同为成功——不再退 EXIT_TIMEOUT 误报失败。
+    return ack !== null || result === "wake_pending" ? 0 : EXIT_TIMEOUT;
   } catch (e) {
     return handleRestError(e);
   }

--- a/cli/test/daemon.test.ts
+++ b/cli/test/daemon.test.ts
@@ -1,7 +1,7 @@
 // #672 Phase-1/2 spike：party daemon 单测。用真 connect + WS mock server 驱动帧流，注入 SDK runner
 // 与 postReply 捕获回帖——CI 永不触碰真 @anthropic-ai/claude-agent-sdk（SDK 无法在 CI 跑）。
 import { afterEach, describe, expect, test } from "bun:test";
-import { runDaemon, type DaemonOptions, type PostReply, type SdkRunner } from "../src/commands/daemon";
+import { buildSdkOptions, runDaemon, type DaemonOptions, type PostReply, type SdkRunner } from "../src/commands/daemon";
 import {
   deliveryFrame,
   msgFrame,
@@ -59,6 +59,34 @@ function recordingRunner(reply: string): { runner: SdkRunner; calls: Captured["r
     },
   };
 }
+
+// #692 Phase-2.2：SDK options 收口——别继承交互式 Claude Code 的 MCP / hooks / CLAUDE.md，并隔离认证。
+describe("party daemon buildSdkOptions scoping (#692)", () => {
+  test("scopes to text-only: settingSources:[], allowedTools:[], permissionMode:dontAsk", () => {
+    const opts = buildSdkOptions(undefined, {});
+    expect(opts.permissionMode).toBe("dontAsk");
+    expect(opts.settingSources).toEqual([]);
+    expect(opts.allowedTools).toEqual([]);
+    // 未设专用 token → 不注入 env（走默认凭据路径，run() 会告警）。
+    expect(opts.env).toBeUndefined();
+  });
+
+  test("dedicated CLAUDE_CODE_OAUTH_TOKEN is pinned into the SDK subprocess env (auth isolation)", () => {
+    const opts = buildSdkOptions(undefined, { PATH: "/usr/bin", CLAUDE_CODE_OAUTH_TOKEN: "sk-oauth-xyz" });
+    const env = opts.env as Record<string, string>;
+    expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe("sk-oauth-xyz");
+    // 保留其余环境（PATH 等），只把订阅 token 钉进去。
+    expect(env.PATH).toBe("/usr/bin");
+  });
+
+  test("caller overrides win over the scoped defaults", () => {
+    const opts = buildSdkOptions({ permissionMode: "default", allowedTools: ["Read"] }, {});
+    expect(opts.permissionMode).toBe("default");
+    expect(opts.allowedTools).toEqual(["Read"]);
+    // 未被覆盖的默认仍在。
+    expect(opts.settingSources).toEqual([]);
+  });
+});
 
 describe("party daemon (#672 Phase-1/2 spike)", () => {
   test("@-mention → SDK invoked with mention text → SDK output posted back", async () => {

--- a/cli/test/serve-failure-ack.test.ts
+++ b/cli/test/serve-failure-ack.test.ts
@@ -6,7 +6,7 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { EXIT_ARCHIVED, type MsgFrame } from "@agentparty/shared";
-import { createBuiltinRunner, createSdkRunner, EXIT_WAKE_ABANDON_CIRCUIT, profileChildServeOptions, runServe, WakeBlockedError, type BuiltinRunnerOptions, type RunnerProcess, type ServeOptions } from "../src/commands/serve";
+import { createBuiltinRunner, createSdkRunner, EXIT_WAKE_ABANDON_CIRCUIT, isRunnerEnvFailure, profileChildServeOptions, runServe, WakeBlockedError, type BuiltinRunnerOptions, type RunnerProcess, type ServeOptions } from "../src/commands/serve";
 import type { StuckWake } from "../src/config";
 import { msgFrame, startMockServer, welcomeFrame, type MockServer } from "./mock-server";
 
@@ -187,6 +187,86 @@ describe("serve wake delivery (#118 / #198)", () => {
     await expect(run(triggerFrame(1), runnerCtx())).rejects.toThrow(/blocked|exit code 3/);
     // 但它**不该自己发** blocked：外层还要重试，瞬态失败不该污染频道状态（#206 门禁 P1②）
     expect(posts.some((p) => p.state === "blocked")).toBe(false);
+  });
+
+  // #690：认证过期 / 二进制缺失等环境性失败在模型启动前就崩，别归为「model may have run」。
+  test("an auth-failure runner exit is flagged environment=true and says the model did not run (#690)", async () => {
+    const run = createBuiltinRunner({
+      server: "http://agentparty.test",
+      token: "ap_tok",
+      channel: "dev",
+      harness: "claude",
+      workdir: tempDir(),
+      // 复刻 #690 现场：`claude -p` 秒退 exit 1，stderr 是 OAuth 过期。
+      runProcess: async () => ({
+        code: 1,
+        stdout: "",
+        stderr: "Failed to authenticate: OAuth session expired and could not be refreshed",
+      }),
+      post: async () => ({ seq: 1 }),
+    });
+
+    let caught: unknown;
+    try {
+      await run(triggerFrame(1), runnerCtx());
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(WakeBlockedError);
+    const err = caught as WakeBlockedError;
+    expect(err.environment).toBe(true);
+    expect(err.retriable).toBe(false); // 认证没修好前立刻重试是白烧
+    expect(err.message).toContain("runner environment failure");
+    expect(err.message).toContain("model did not run");
+    expect(err.message).not.toContain("model may have run");
+  });
+
+  test("isRunnerEnvFailure matches environment fingerprints and ignores ordinary model failures (#690)", () => {
+    const env = [
+      "Failed to authenticate: OAuth session expired and could not be refreshed",
+      "OAuth token could not be refreshed",
+      "error: not logged in — please run `claude login`",
+      "Invalid API key provided",
+      "sh: claude: command not found",
+      "spawn claude ENOENT",
+      "permission denied",
+      "HTTP 401 Unauthorized",
+    ];
+    for (const stderr of env) {
+      expect(isRunnerEnvFailure({ stdout: "", stderr })).toBe(true);
+    }
+    const notEnv = [
+      "diff apply conflict in src/foo.ts",
+      "TypeError: cannot read property 'x' of undefined",
+      "the model produced no channel action",
+      "git push rejected: non-fast-forward",
+      "",
+    ];
+    for (const stderr of notEnv) {
+      expect(isRunnerEnvFailure({ stdout: "", stderr })).toBe(false);
+    }
+  });
+
+  test("a non-environment runner failure keeps environment=false (no false positives)", async () => {
+    const run = createBuiltinRunner({
+      server: "http://agentparty.test",
+      token: "ap_tok",
+      channel: "dev",
+      harness: "codex",
+      workdir: tempDir(),
+      // 模型真跑过后在交付阶段崩：不含任何认证/二进制指纹——绝不能误标成环境错。
+      runProcess: async () => ({ code: 1, stdout: "partial model output...", stderr: "diff apply conflict in src/foo.ts" }),
+      post: async () => ({ seq: 1 }),
+    });
+
+    let caught: unknown;
+    try {
+      await run(triggerFrame(1), runnerCtx());
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(WakeBlockedError);
+    expect((caught as WakeBlockedError).environment).toBe(false);
   });
 
   test("a succeeding runner advances the cursor and leaves no debt", async () => {

--- a/cli/test/serve-failure-ack.test.ts
+++ b/cli/test/serve-failure-ack.test.ts
@@ -233,7 +233,7 @@ describe("serve wake delivery (#118 / #198)", () => {
       "HTTP 401 Unauthorized",
     ];
     for (const stderr of env) {
-      expect(isRunnerEnvFailure({ stdout: "", stderr })).toBe(true);
+      expect(isRunnerEnvFailure({ stderr })).toBe(true);
     }
     const notEnv = [
       "diff apply conflict in src/foo.ts",
@@ -243,7 +243,16 @@ describe("serve wake delivery (#118 / #198)", () => {
       "",
     ];
     for (const stderr of notEnv) {
-      expect(isRunnerEnvFailure({ stdout: "", stderr })).toBe(false);
+      expect(isRunnerEnvFailure({ stderr })).toBe(false);
+    }
+  });
+
+  // CodeRabbit #693：只扫 stderr。模型 stdout 里恰好写了环境错字样，不该被误判成「model did not run」。
+  test("isRunnerEnvFailure ignores environment fingerprints that appear only in model stdout (#690)", () => {
+    for (const noise of ["unauthorized", "spawn foo ENOENT", "permission denied", "command not found", "401 Unauthorized"]) {
+      // stdout 命中但 stderr 干净 → 不算环境失败（模型真跑过、只是它的输出里提到了这些词）。
+      const result: { stdout: string; stderr: string } = { stdout: noise, stderr: "" };
+      expect(isRunnerEnvFailure(result)).toBe(false);
     }
   });
 

--- a/cli/test/wake.test.ts
+++ b/cli/test/wake.test.ts
@@ -158,6 +158,103 @@ describe("wake test falsifiability (#181)", () => {
   });
 });
 
+// ── #689：headless runner 已唤起、正在处理本探针（presence.current_task 命中），30s 内无最终回复不是失败 ──
+describe("wake test wake_pending when runner is actively processing the probe (#689)", () => {
+  // 复刻 #689 现场：builtin claude runner 被 serve 唤起、正在跑（current_task=353），但 presence 没同步
+  // wake 适配器声明（advisory「no wake adapter」）。旧行为误报 not_auto_wakeable/失败；新行为判 wake_pending。
+  test("no advertised adapter but current_task==probe seq: wake_pending, exit 0, wake invoked yes", async () => {
+    mock = startRestMock((req) => {
+      if (req.method === "GET" && req.path === "/api/channels/dev/presence") {
+        const now = Date.now();
+        return Response.json({
+          presence: [
+            { name: "bot", state: "working", note: null, ts: now, last_seen: now, residency: "supervised", current_task: 91 },
+          ],
+        });
+      }
+      if (req.method === "POST" && req.path === "/api/channels/dev/messages") {
+        return Response.json({ seq: 91 });
+      }
+      if (req.method === "GET" && req.path === "/api/channels/dev/messages") {
+        return Response.json({ messages: [] });
+      }
+      return undefined;
+    });
+    writeCfg(mock.url, "me");
+
+    const r = await runCli(["wake", "test", "@bot", "dev", "--timeout", "1", "--json"]);
+    // 关键回归：不再退 EXIT_TIMEOUT(2)——唤醒确凿即成功
+    expect(r.code).toBe(0);
+    expect(reqsOf(mock, "POST", "/api/channels/dev/messages")).toHaveLength(1);
+    const frame = JSON.parse(r.stdout.trim());
+    expect(frame).toMatchObject({
+      type: "wake_test",
+      result: "wake_pending",
+      phases: {
+        mention_delivered: { ok: true, seq: 91 },
+        wake_invoked: { ok: true },
+        agent_resumed: { ok: false, seq: null },
+      },
+    });
+    expect(frame.phases.wake_invoked.evidence).toContain("wake invoked");
+    expect(frame.phases.wake_invoked.evidence).toContain("reply pending");
+    expect(frame.reason).toContain("current_task=#91");
+    expect(frame.presence.current_task).toBe(91);
+  });
+
+  test("current_task outranks a plain serve/watch timeout verdict", async () => {
+    mock = startRestMock((req) => {
+      if (req.method === "GET" && req.path === "/api/channels/dev/presence") {
+        return Response.json({
+          presence: [{ ...freshServeWatchPresence("serve"), live: true, current_task: 92 }],
+        });
+      }
+      if (req.method === "POST" && req.path === "/api/channels/dev/messages") {
+        return Response.json({ seq: 92 });
+      }
+      if (req.method === "GET" && req.path === "/api/channels/dev/wake-deliveries") {
+        return Response.json({ deliveries: [] });
+      }
+      if (req.method === "GET" && req.path === "/api/channels/dev/messages") {
+        return Response.json({ messages: [] });
+      }
+      return undefined;
+    });
+    writeCfg(mock.url);
+
+    const r = await runCli(["wake", "test", "@agent", "dev", "--timeout", "1", "--json"]);
+    expect(r.code).toBe(0);
+    const frame = JSON.parse(r.stdout.trim());
+    expect(frame).toMatchObject({ type: "wake_test", result: "wake_pending" });
+  });
+
+  test("human output shows 'wake invoked: yes (reply pending)' and 'resumed: pending'", async () => {
+    mock = startRestMock((req) => {
+      if (req.method === "GET" && req.path === "/api/channels/dev/presence") {
+        const now = Date.now();
+        return Response.json({
+          presence: [
+            { name: "bot", state: "working", note: null, ts: now, last_seen: now, residency: "supervised", current_task: 93 },
+          ],
+        });
+      }
+      if (req.method === "POST" && req.path === "/api/channels/dev/messages") {
+        return Response.json({ seq: 93 });
+      }
+      if (req.method === "GET" && req.path === "/api/channels/dev/messages") {
+        return Response.json({ messages: [] });
+      }
+      return undefined;
+    });
+    writeCfg(mock.url, "me");
+
+    const r = await runCli(["wake", "test", "@bot", "dev", "--timeout", "1"]);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain("wake invoked: yes (reply pending)");
+    expect(r.stdout).toContain("resumed: pending");
+  });
+});
+
 // ── #194：目标解析为自己身份时，别发真探针、别等满 timeout，立刻失败 ──
 describe("wake test self-target fast-fail (#194)", () => {
   test("self-target (cached identity) fails immediately with no probe and no network call", async () => {


### PR DESCRIPTION
一次性收口三个唤醒/常驻子系统的观测与分类问题（均为 #672 daemon residency 的 live 跟进）。全 CLI 内部改动，无 shared/worker/web 变更。

## #689 — wake test 误报「no wake adapter」/ wake invoked: no
**现场**：`party serve --runner claude` 值守的 agent 被 `party wake test` 探测，runner 已起、频道里紧跟 `[working] runner started` + `wake ack`，但 probe 判 `wake invoked: no` / `no wake adapter`、退 EXIT_TIMEOUT。headless runner 处理一条要数分钟，30s 窗口内不可能有最终回复。

**修**：probe 在没收到最终回复时重取 presence，若 `current_task == 本探针 seq`（runner 正在处理这条 @）→ 新结论 `wake_pending`（唤醒确凿、reply pending），`wake invoked: yes (reply pending)`、`resumed: pending`、**exit 0**。`current_task` 是活体执行的直接证据，盖过「没声明适配器」的负面 heartbeat 视角，对 advisory 与 timeout 两条路径都适用——不依赖 presence 是否同步了 wake 适配器声明。

## #690 — runner 认证失败被误判「model may have run」不可重试
**现场**：Claude CLI OAuth 过期，`claude -p` 秒退 exit 1（2.3s），serve 归为「model may have run」不可重试、静默 idle。认证失败是环境性错误，模型根本没跑。

**修**：新增 `isRunnerEnvFailure()` 识别 OAuth 过期 / 未登录 / `command not found` / ENOENT / 权限拒绝等**明确指纹**（保守：不把真实模型失败误标成环境错）。命中即 `WakeBlockedError{environment:true}`，放弃留痕改说「runner environment failure: model did not run — fix credentials/binary/sandbox, e.g. \`claude login\`」，并经既有 `runner_health.last_error` 通道让 owner 从 `party who` / `party wake test`（叠加 #689 后现在会清楚显示 runner_failing + 真实认证错）看得见。
> 说明：本 PR 覆盖 #690 的**误分类 + owner 可观测**。issue 里的「本机/私信推送告警」与「认证修复后自动重放被放弃的 seq」需要独立的 pending-queue / 周期自检设计（改动游标/欠账语义风险高），留作后续。

## #692 — Phase-2.2 daemon SDK options 收口 + 认证隔离
抽出可测的 `buildSdkOptions()`：
- `settingSources:[]` — 不继承全局 `~/.claude` 设置 / MCP servers / hooks / CLAUDE.md（被 @ 的 daemon 不再带着 owner 全套工具+hooks 跑）
- `allowedTools:[]` + `permissionMode:dontAsk` — 纯文本、零工具、headless 不挂权限询问
- 专用 `CLAUDE_CODE_OAUTH_TOKEN` 钉进 SDK 子进程 env（与交互式 `claude` 的凭据 refresh 竞态/多账号选错隔离），未设时启动告警 + 提示订阅额度同池
> 覆盖 #692 的 ②SDK options 收口 + ①认证隔离 + ③额度感知（文档/告警）。owner/worker 边界的 `canUseTool`（放开受控工具）接 #284，仍留 Phase-2.2 后续。

## 测试
- `wake.test.ts`：wake_pending 三例（含 #689 现场复刻：无适配器 + current_task 命中 + 无回复 → wake_pending / exit 0）
- `serve-failure-ack.test.ts`：env-failure 归类三例（auth exit → environment=true / 非 auth 失败 → false）+ `isRunnerEnvFailure` 词表
- `daemon.test.ts`：`buildSdkOptions` scope 三例（默认收口 / token 注入 / 调用方覆盖）
- **cli 全量 1068 pass, 0 fail**；`tsc --noEmit` 干净

Closes #689
Closes #690

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - daemon 帮助与运行配置更清晰：优先使用专用 OAuth token，并进一步收紧 SDK 会话作用域与权限范围。
  - 唤醒流程新增“回复待处理（wake_pending）”判定：会在提示与证据中反映 pending 状态，并避免误判为超时。
- **错误提示**
  - 更准确区分“runner 环境失败”（认证/权限/二进制/沙箱等）与“模型执行失败”，并明确提示“模型未运行”、给出需修复的方向与重试建议；同时提示共享凭据可能带来的刷新竞态与订阅额度影响。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->