### PR TITLE
feat(worker,cli): #695 建频道撞名自增后缀而非硬 409

### DIFF
--- a/cli/src/commands/channel.ts
+++ b/cli/src/commands/channel.ts
@@ -229,7 +229,7 @@ export async function run(argv: string[]): Promise<number> {
         const slug = positionals[1];
         if (!slug) {
           console.error(
-            "usage: party channel create <slug> [--title t] [--temp] [--party] [--public]",
+            "usage: party channel create <slug> [--title t] [--temp] [--party] [--public] [--exact]",
           );
           return 1;
         }
@@ -237,14 +237,18 @@ export async function run(argv: string[]): Promise<number> {
           console.error("slug must match [a-z0-9][a-z0-9-]{0,63}");
           return 1;
         }
-        await createChannel(cfg.server, cfg.token, {
+        // #695：显式建频道时，撞名不再硬失败——默认让服务端自增后缀取下一个空位；
+        // --exact 保留旧行为（撞名 409）。回显真实建出的 slug（可能带后缀）。
+        const created = await createChannel(cfg.server, cfg.token, {
           slug,
           title: str(flags.title),
           kind: flags.temp === true ? "temp" : "standing",
           mode: flags.party === true ? "party" : "normal",
           visibility: flags.public === true ? "public" : "private",
+          auto_suffix: flags.exact !== true,
         });
-        console.log(`created ${slug}`);
+        if (created !== slug) console.log(`created ${created} ("${slug}" was taken)`);
+        else console.log(`created ${created}`);
         return 0;
       }
       case "list": {

--- a/cli/src/commands/channel.ts
+++ b/cli/src/commands/channel.ts
@@ -248,8 +248,10 @@ export async function run(argv: string[]): Promise<number> {
           visibility: flags.public === true ? "public" : "private",
           auto_suffix: flags.exact !== true,
         });
-        if (created !== slug) console.log(`created ${created} ("${slug}" was taken)`);
-        else console.log(`created ${created}`);
+        // created 来自远端响应：过 sanitizeSingleLine 剥离控制序列，防恶意服务端注入终端（#699 评审）。
+        const createdLabel = sanitizeSingleLine(created);
+        if (created !== slug) console.log(`created ${createdLabel} ("${slug}" was taken)`);
+        else console.log(`created ${createdLabel}`);
         return 0;
       }
       case "list": {

--- a/cli/src/commands/channel.ts
+++ b/cli/src/commands/channel.ts
@@ -45,6 +45,7 @@ const CHANNEL_FLAGS = [
   "temp",
   "party",
   "public",
+  "exact",
   "policy",
   "confirm",
   "expires",
@@ -199,7 +200,7 @@ export async function run(argv: string[]): Promise<number> {
     return 0;
   }
   const { positionals, flags } = parseArgs(argv, {
-    booleans: ["temp", "party", "public", "confirm", "remove", "json"],
+    booleans: ["temp", "party", "public", "exact", "confirm", "remove", "json"],
     repeatable: ["agent", "members-agent"],
     aliases: { m: "responsibility" },
   });

--- a/cli/src/rest.ts
+++ b/cli/src/rest.ts
@@ -566,13 +566,18 @@ export async function createChannel(
     kind: ChannelKind;
     mode?: ChannelMode;
     visibility?: ChannelVisibility;
+    // #695：撞名时让服务端自增后缀取下一个空位（slug → slug-2 …），返回真实建出的 slug。
+    // 默认 false：init 的 create-or-join、invite 的 scoped 建频道都要精确 slug，不能被改名。
+    auto_suffix?: boolean;
   },
-): Promise<void> {
-  await req(server, "/api/channels", {
+): Promise<string> {
+  const res = (await req(server, "/api/channels", {
     method: "POST",
     headers: bearerJson(token),
     body: JSON.stringify(body),
-  });
+  })) as { slug?: unknown };
+  // 服务端回真实 slug（auto_suffix 撞名时会与请求不同）；缺字段则回落请求值，兼容老服务端。
+  return typeof res?.slug === "string" ? res.slug : body.slug;
 }
 
 export async function addWebhook(

--- a/cli/test/m3.test.ts
+++ b/cli/test/m3.test.ts
@@ -2684,6 +2684,21 @@ describe("party channel create mode", () => {
     expect(r.code).not.toBe(0);
   });
 
+  test("回显剥离服务端 slug 里的终端控制序列（防注入）", async () => {
+    mock = startRestMock((req) => {
+      if (req.method === "POST" && req.path === "/api/channels") {
+        // 恶意服务端塞入清屏 CSI（ESC[2J）+ 换行伪造整行
+        return Response.json({ slug: "dev-2\u001b[2J\nforged" }, { status: 201 });
+      }
+      return undefined;
+    });
+    writeCfg(mock.url);
+    const r = await runCli(["channel", "create", "dev"]);
+    expect(r.code).toBe(0);
+    expect(r.stdout).not.toContain("\u001b");
+    expect(r.stdout).not.toContain("\nforged");
+  });
+
   test("--title 缺值退出 1 且不发请求", async () => {
     mock = startRestMock();
     writeCfg(mock.url);

--- a/cli/test/m3.test.ts
+++ b/cli/test/m3.test.ts
@@ -2656,6 +2656,34 @@ describe("party channel create mode", () => {
     });
   });
 
+  test("撞名取变体时回显服务端返回的真实 slug", async () => {
+    mock = startRestMock((req) => {
+      if (req.method === "POST" && req.path === "/api/channels") {
+        return Response.json(
+          { slug: "dev-2", kind: "standing", mode: "normal", visibility: "private" },
+          { status: 201 },
+        );
+      }
+      return undefined;
+    });
+    writeCfg(mock.url);
+    const r = await runCli(["channel", "create", "dev"]);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain('created dev-2 ("dev" was taken)');
+  });
+
+  test("--exact 撞名时服务端 409 → CLI 失败退出", async () => {
+    mock = startRestMock((req) => {
+      if (req.method === "POST" && req.path === "/api/channels") {
+        return Response.json({ error: { code: "conflict", message: "slug already exists" } }, { status: 409 });
+      }
+      return undefined;
+    });
+    writeCfg(mock.url);
+    const r = await runCli(["channel", "create", "dev", "--exact"]);
+    expect(r.code).not.toBe(0);
+  });
+
   test("--title 缺值退出 1 且不发请求", async () => {
     mock = startRestMock();
     writeCfg(mock.url);

--- a/cli/test/m3.test.ts
+++ b/cli/test/m3.test.ts
@@ -2603,12 +2603,14 @@ describe("party channel create mode", () => {
     writeCfg(mock.url);
     const r = await runCli(["channel", "create", "war-room", "--party", "--title", "作战室"]);
     expect(r.code).toBe(0);
+    // #695：channel create 默认带 auto_suffix=true，撞名让服务端取下一个空位而非硬 409。
     expect(reqsOf(mock, "POST", "/api/channels")[0]!.body).toEqual({
       slug: "war-room",
       title: "作战室",
       kind: "standing",
       mode: "party",
       visibility: "private",
+      auto_suffix: true,
     });
   });
 
@@ -2622,6 +2624,7 @@ describe("party channel create mode", () => {
       kind: "standing",
       mode: "normal",
       visibility: "private",
+      auto_suffix: true,
     });
   });
 
@@ -2635,6 +2638,21 @@ describe("party channel create mode", () => {
       kind: "standing",
       mode: "normal",
       visibility: "public",
+      auto_suffix: true,
+    });
+  });
+
+  test("--exact 发送 auto_suffix=false（撞名仍硬 409）", async () => {
+    mock = startRestMock();
+    writeCfg(mock.url);
+    const r = await runCli(["channel", "create", "dev", "--exact"]);
+    expect(r.code).toBe(0);
+    expect(reqsOf(mock, "POST", "/api/channels")[0]!.body).toEqual({
+      slug: "dev",
+      kind: "standing",
+      mode: "normal",
+      visibility: "private",
+      auto_suffix: false,
     });
   });
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -146,6 +146,19 @@ type AppContext = {
 
 const NAME_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$/;
 const SLUG_RE = /^[a-z0-9][a-z0-9-]{0,63}$/;
+// #695 撞名自增后缀：foo → foo-2 → foo-3 …，最多试这么多个空位后放弃（返 409）。
+const SLUG_SUFFIX_MAX_ATTEMPTS = 50;
+// 生成第 n 个后缀候选（n>=2）。SLUG_RE 上限 64 字符：后缀占位后裁基名，结果仍满足 SLUG_RE。
+function suffixedSlug(base: string, n: number): string {
+  const suffix = `-${n}`;
+  const room = Math.max(1, 64 - suffix.length);
+  return `${base.slice(0, room)}${suffix}`;
+}
+// D1/SQLite 的 UNIQUE 约束冲突（撞名）——与真故障（DO/D1 不可达）区分，避免把故障误报成 409。
+function isUniqueConstraintError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /UNIQUE constraint failed|SQLITE_CONSTRAINT|constraint failed/i.test(message);
+}
 const ROLES: readonly string[] = ["agent", "human", "readonly"] satisfies TokenRole[];
 const KINDS: readonly string[] = ["standing", "temp"] satisfies ChannelKind[];
 const MODES: readonly string[] = ["normal", "party"] satisfies ChannelMode[];
@@ -3672,9 +3685,13 @@ app.get("/api/channels", async (c) => {
 
 app.post("/api/channels", async (c) => {
   const body = (await c.req.json().catch(() => null)) as
-    | { slug?: unknown; title?: unknown; kind?: unknown; mode?: unknown; visibility?: unknown }
+    | { slug?: unknown; title?: unknown; kind?: unknown; mode?: unknown; visibility?: unknown; auto_suffix?: unknown }
     | null;
   const slug = typeof body?.slug === "string" ? body.slug : "";
+  // #695 slug 撞名不再硬 409：显式建频道（party channel create）传 auto_suffix，撞名自动取下一个空位
+  // slug（foo → foo-2 → foo-3 …）。默认关（init 的 create-or-join、invite 的 scoped 建频道都要精确 slug，
+  // 不能被改名），故此处仅当客户端主动请求时才启用，向后完全兼容。
+  const autoSuffix = body?.auto_suffix === true;
   const kind = body?.kind === undefined ? "standing" : body.kind;
   const mode = body?.mode === undefined ? "normal" : body.mode;
   // 默认 private = 零破坏（spec §3.1）
@@ -3738,36 +3755,57 @@ app.post("/api/channels", async (c) => {
       );
     }
   }
-  try {
-    await c.env.DB.prepare(
+  // created_by 记具体铸造者（审计）；owner_account = 创建者账号（ACL 依据）。
+  // legacy token 无 account → owner_account = null（老频道，仅 legacy 过渡放行）。
+  // loop_guard_enabled=1（#96）：新频道开箱即有熔断，否则两个 agent 可在无人值守下
+  // 互相唤醒到天亮（唯一约束仅 30 msg/min）。limit 留空 → 回退 mode 默认 30/200。
+  // 存量频道保持关闭：强开会立刻熔断正在工作的频道。房主可随时 PUT loop-guard 关闭。
+  const insertChannel = (candidate: string) =>
+    c.env.DB.prepare(
       "INSERT INTO channels (slug, title, kind, mode, visibility, created_by, owner_account, created_at, loop_guard_enabled) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1)",
     )
-      // created_by 记具体铸造者（审计）；owner_account = 创建者账号（ACL 依据）。
-      // legacy token 无 account → owner_account = null（老频道，仅 legacy 过渡放行）。
-      // loop_guard_enabled=1（#96）：新频道开箱即有熔断，否则两个 agent 可在无人值守下
-      // 互相唤醒到天亮（唯一约束仅 30 msg/min）。limit 留空 → 回退 mode 默认 30/200。
-      // 存量频道保持关闭：强开会立刻熔断正在工作的频道。房主可随时 PUT loop-guard 关闭。
-      .bind(slug, title, kind, mode, visibility, creator.name, creator.account ?? null, now)
+      .bind(candidate, title, kind, mode, visibility, creator.name, creator.account ?? null, now)
       .run();
-  } catch {
-    return c.json(errorBody("conflict", "slug already exists"), 409);
+  // #695：撞名时（且客户端请求 auto_suffix）自增后缀取下一个空位——slug、slug-2、slug-3 …。
+  // INSERT 是唯一真相源：并发下两方算出同一候选，只有一方插入成功，另一方接着试下一个，无需额外锁。
+  // scoped token 建的是它被邀请的那一个精确 slug（见上方 scope 闸），不参与改名；故基于 slug 本身即可。
+  let createdSlug = slug;
+  const maxSuffixAttempts = autoSuffix ? SLUG_SUFFIX_MAX_ATTEMPTS : 1;
+  let inserted = false;
+  for (let attempt = 0; attempt < maxSuffixAttempts; attempt++) {
+    const candidate = attempt === 0 ? slug : suffixedSlug(slug, attempt + 1);
+    try {
+      await insertChannel(candidate);
+      createdSlug = candidate;
+      inserted = true;
+      break;
+    } catch (error) {
+      // 非 auto_suffix：保持历史行为——任何插入失败都当撞名 409，不改老客户端的错误契约。
+      if (!autoSuffix) return c.json(errorBody("conflict", "slug already exists"), 409);
+      // auto_suffix：撞名（UNIQUE 约束）试下一个后缀；非撞名的真故障别误报成 409。
+      if (isUniqueConstraintError(error)) continue;
+      return c.json(errorBody("unavailable", "channel create failed"), 503);
+    }
+  }
+  if (!inserted) {
+    return c.json(errorBody("conflict", `no free slug variant for "${slug}" within ${SLUG_SUFFIX_MAX_ATTEMPTS} tries`), 409);
   }
   if (kind === "temp") {
     try {
       await fetchChannelDO(
         c.env,
-        slug,
+        createdSlug,
         new Request("https://do/internal/init", {
           method: "POST",
           headers: {
-            "x-partykit-room": slug,
+            "x-partykit-room": createdSlug,
             ...channelHeaders({ kind, mode }, c.req.url),
           },
         }),
       );
     } catch {
       await c.env.DB.prepare("DELETE FROM channels WHERE slug = ? AND created_at = ?")
-        .bind(slug, now)
+        .bind(createdSlug, now)
         .run()
         .catch(() => null);
       return c.json(errorBody("unavailable", "temp channel initialization failed"), 503);
@@ -3776,12 +3814,12 @@ app.post("/api/channels", async (c) => {
   await bestEffortRecordManagementAudit(c.env.DB, {
     actor: managementAuditActor(creator),
     action: "channel.create",
-    resource: `channel/${slug}`,
-    channel: slug,
+    resource: `channel/${createdSlug}`,
+    channel: createdSlug,
     timestamp: now,
     metadata: { kind, mode, visibility },
   });
-  return c.json({ slug, title, kind, mode, visibility }, 201);
+  return c.json({ slug: createdSlug, title, kind, mode, visibility }, 201);
 });
 
 app.post("/api/channels/:slug/project-agents", async (c) => {

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -154,10 +154,11 @@ function suffixedSlug(base: string, n: number): string {
   const room = Math.max(1, 64 - suffix.length);
   return `${base.slice(0, room)}${suffix}`;
 }
-// D1/SQLite 的 UNIQUE 约束冲突（撞名）——与真故障（DO/D1 不可达）区分，避免把故障误报成 409。
+// 只认「撞名」= UNIQUE / PRIMARY KEY 冲突。泛化的 SQLITE_CONSTRAINT 还涵盖 CHECK/NOT NULL/FK，
+// 不能一并当撞名，否则会把真实数据/D1 故障伪装成 409（#699 评审）。其余错误一律走 503。
 function isUniqueConstraintError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
-  return /UNIQUE constraint failed|SQLITE_CONSTRAINT|constraint failed/i.test(message);
+  return /UNIQUE constraint failed|SQLITE_CONSTRAINT_(UNIQUE|PRIMARYKEY)/i.test(message);
 }
 const ROLES: readonly string[] = ["agent", "human", "readonly"] satisfies TokenRole[];
 const KINDS: readonly string[] = ["standing", "temp"] satisfies ChannelKind[];
@@ -3780,11 +3781,14 @@ app.post("/api/channels", async (c) => {
       inserted = true;
       break;
     } catch (error) {
-      // 非 auto_suffix：保持历史行为——任何插入失败都当撞名 409，不改老客户端的错误契约。
+      // 只有真正的 UNIQUE 冲突（撞名）才是 409。CHECK/NOT NULL/FK/D1 故障一律 503，
+      // 绝不把真实故障伪装成撞名（#699 评审）。
+      if (!isUniqueConstraintError(error)) {
+        return c.json(errorBody("unavailable", "channel create failed"), 503);
+      }
+      // 撞名：非 auto_suffix 直接 409（老客户端契约不变）；auto_suffix 试下一个后缀。
       if (!autoSuffix) return c.json(errorBody("conflict", "slug already exists"), 409);
-      // auto_suffix：撞名（UNIQUE 约束）试下一个后缀；非撞名的真故障别误报成 409。
-      if (isUniqueConstraintError(error)) continue;
-      return c.json(errorBody("unavailable", "channel create failed"), 503);
+      continue;
     }
   }
   if (!inserted) {

--- a/worker/src/openapi.ts
+++ b/worker/src/openapi.ts
@@ -619,13 +619,19 @@ export const openapiDocument = {
                     enum: ["public", "private", "public_watch"],
                     default: "private",
                   },
+                  auto_suffix: {
+                    type: "boolean",
+                    default: false,
+                    description:
+                      "on slug collision, auto-pick the next free variant (slug → slug-2 → slug-3 …) instead of 409; the response slug reflects the actual channel created. ignored for channel-scoped tokens (which must create their exact scope).",
+                  },
                 },
               },
             },
           },
         },
         responses: {
-          "201": { description: "created" },
+          "201": { description: "created (response slug may differ from request when auto_suffix picked a variant)" },
           "400": { description: "invalid slug/kind/mode/visibility" },
           "403": { description: "readonly token" },
           "409": { description: "slug conflict" },

--- a/worker/test/channels.spec.ts
+++ b/worker/test/channels.spec.ts
@@ -168,6 +168,39 @@ describe("channels", () => {
     expect((await create()).status).toBe(409);
   });
 
+  it("auto_suffix 撞名自增后缀取下一个空位（#695）", async () => {
+    const { token } = await seedToken("agent");
+    const slug = uniq("dup");
+    const create = (body: Record<string, unknown>) =>
+      api("/api/channels", token, { method: "POST", body: JSON.stringify({ slug, kind: "standing", ...body }) });
+
+    const createdSlug = async (res: Response) => ((await res.json()) as { slug: string }).slug;
+
+    // 首建拿原名
+    const first = await create({});
+    expect(first.status).toBe(201);
+    expect(await createdSlug(first)).toBe(slug);
+
+    // 撞名 + auto_suffix → 201，slug 变体 -2
+    const second = await create({ auto_suffix: true });
+    expect(second.status).toBe(201);
+    expect(await createdSlug(second)).toBe(`${slug}-2`);
+
+    // 再撞 → -3（跳过已占用的 -2）
+    const third = await create({ auto_suffix: true });
+    expect(third.status).toBe(201);
+    expect(await createdSlug(third)).toBe(`${slug}-3`);
+
+    // 不带 auto_suffix 仍是硬 409（老客户端契约不变）
+    expect((await create({})).status).toBe(409);
+
+    // 变体是真频道：出现在频道列表里
+    const list = await api("/api/channels", token);
+    const slugs = ((await list.json()) as { channels: { slug: string }[] }).channels.map((c) => c.slug);
+    expect(slugs).toContain(`${slug}-2`);
+    expect(slugs).toContain(`${slug}-3`);
+  });
+
   it("400 on invalid slug or kind", async () => {
     const { token } = await seedToken("agent");
     const bad = await api("/api/channels", token, {


### PR DESCRIPTION
## 背景
Closes #695

频道 slug 全局唯一。用久了，热门名字（`guessadmin`、`bug001`…）必然撞名，此前撞名直接 `409 slug already exists`，用户得手动换名。owner 建议「新建时自动拼接一个 id」。

## 方案
撞名时**自动取下一个空位 slug**（`foo` → `foo-2` → `foo-3` …），而不是给每个频道都加前缀（`1-foo` 会让没撞名的频道也变丑）。冲突才加后缀，保留可读名。

### worker `POST /api/channels`
- 新增 `auto_suffix`（默认 `false`）。为真**且非 channel-scoped token** 时，撞名沿 `-2/-3…` 试到空位。
- `INSERT` 作唯一真相源：并发下两方算出同一候选，只有一方成功，另一方接着试下一个，无需额外锁。
- 区分 UNIQUE 冲突与真故障（DO/D1 不可达）：后者返 `503`，不再一律误报 `409`。
- **默认关 = 完全向后兼容**：`init` 的 create-or-join、`invite` 的 scoped 建频道都要精确 slug，不参与改名。响应 `slug` 反映实际建出的频道。

### cli
- `createChannel` 返回真实 slug（读响应，缺字段回落请求值，兼容老服务端）。
- `party channel create` 默认开 `auto_suffix`，撞名回显 `created foo-2 ("foo" was taken)`；`--exact` 保留旧硬 `409` 行为。

## 验证
- worker + cli typecheck 通过。
- 新增 worker 测试：撞名 → `-2`/`-3`、无 `auto_suffix` 仍 `409`、变体是真频道进列表；既有「409 on slug conflict」不变。
- CLI 全量套件本地跑通（`serve-cross-machine-lease` 的并发计时 flaky 与本改动无关，单跑 7/0 绿）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 频道创建新增 `--exact`：关闭 slug 撞名时的自动变体/后缀补全；启用时冲突将保持硬性 409。
  * 默认在 slug 撞名时自动尝试生成下一个可用后缀（如 `-2`、`-3`）并创建成功。
* **行为变更**
  * CLI 回显以服务端实际创建的 `slug` 为准；若被占用则提示对应已使用情况；更安全的输出处理避免异常字符影响显示。
* **文档更新**
  * 更新创建频道接口 OpenAPI：新增请求字段 `auto_suffix`，并说明响应中的 `slug` 可能与请求不同。
* **测试**
  * 补充 `--exact` 与自动后缀递增的创建/列表展示用例覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->