### PR TITLE
fix(desktop): #696 本机 agent 常驻 sidecar 定位改用 current_exe()

### DIFF
--- a/desktop/src-tauri/src/duty.rs
+++ b/desktop/src-tauri/src/duty.rs
@@ -13,7 +13,7 @@ use std::{
 use serde::Serialize;
 
 #[cfg(desktop)]
-use tauri::{AppHandle, Manager, State};
+use tauri::{AppHandle, State};
 
 use crate::agent::{validate_channel, validate_runner};
 
@@ -176,16 +176,21 @@ fn duty_loaded(label: &str) -> bool {
 
 /// 把当前 app 内嵌的 party sidecar 拷贝到稳定路径（bundle 路径随 app 更新/挪动失效）。
 #[cfg(desktop)]
-fn ensure_duty_binary(app: &AppHandle, home: &Path) -> Result<PathBuf, String> {
+fn ensure_duty_binary(home: &Path) -> Result<PathBuf, String> {
     let target = duty_bin_path(home);
     if let Some(parent) = target.parent() {
         fs::create_dir_all(parent).map_err(|error| format!("cannot create duty bin dir: {error}"))?;
     }
-    // tauri sidecar 的真实路径：<resource>/binaries 之外，运行期在可执行文件旁（externalBin 约定）。
-    let sidecar = app
-        .path()
-        .resolve("party", tauri::path::BaseDirectory::Executable)
-        .map_err(|error| format!("cannot resolve party sidecar path: {error}"))?;
+    // externalBin sidecar 运行期就躺在主可执行文件旁（tauri externalBin 约定）。#696：
+    // 别用 tauri 的 BaseDirectory::Executable —— 它映射到 dirs::executable_dir()（XDG $EXE 目录），
+    // 在 macOS/Windows 上恒为 None → Err(UnknownPath)，正是「cannot resolve party sidecar path:
+    // unknown path」的来源。current_exe() 才是「当前可执行文件」，跨平台都对。
+    let exe = std::env::current_exe()
+        .map_err(|error| format!("cannot resolve current executable: {error}"))?;
+    let exe_dir = exe
+        .parent()
+        .ok_or_else(|| "current executable has no parent directory".to_string())?;
+    let sidecar = exe_dir.join("party");
     let source = if sidecar.exists() {
         sidecar
     } else {
@@ -292,7 +297,10 @@ pub(crate) async fn desktop_duty_persist(
 /// 共用——校验已由调用方完成。
 #[cfg(all(desktop, target_os = "macos"))]
 async fn duty_persist_inner(
-    app: &AppHandle,
+    // #696：sidecar 定位改用 current_exe() 后这里不再需要 app。仍保留形参（下划线标未用）：两个
+    // 调用命令是注入了 AppHandle 的 #[tauri::command]，继续把 &app 传进来即让命令层的 app 保持「已用」，
+    // 免得彻底删参把 unused 警告冒到命令签名上（macOS 分支会因此 deny(warnings) 失败）。
+    _app: &AppHandle,
     agent_state: &State<'_, crate::agent::AgentManager>,
     config_id: &str,
     channel: &str,
@@ -309,7 +317,7 @@ async fn duty_persist_inner(
     // 先停掉 app 内的同键实例。停不掉（kill 失败/超时后仍活跃）必须中止，不能带病装常驻。
     agent_state.stop_instance_for_duty(&instance_id).await?;
 
-    let party_bin = ensure_duty_binary(app, &home)?;
+    let party_bin = ensure_duty_binary(&home)?;
     let log_path = duty_log_path(&home, &label);
     if let Some(parent) = log_path.parent() {
         fs::create_dir_all(parent).map_err(|error| format!("cannot create duty log dir: {error}"))?;


### PR DESCRIPTION
## 背景
Closes #696

桌面「本机 agent」勾选「随系统启动」转常驻（launchd）时，面板报红：
`cannot resolve party sidecar path: unknown path`，本机 agent 无法常驻（见 #696 截图）。

## 根因（源码级确认）
`desktop/src-tauri/src/duty.rs` 的 `ensure_duty_binary` 用 tauri 的 `BaseDirectory::Executable` 定位内嵌的 `party` sidecar：

```rust
app.path().resolve("party", tauri::path::BaseDirectory::Executable)
```

但在 tauri 2.11.5 里 `BaseDirectory::Executable => resolver.executable_dir()`，而 `executable_dir()` = `dirs::executable_dir().ok_or(Error::UnknownPath)`。`dirs` 的 `executable_dir()` 是 **XDG `$EXE`（用户可执行目录）**，在 **macOS/Windows 上恒返回 `None`**（`dirs/src/mac.rs`、`win.rs` 都是 `{ None }`）→ `Err(UnknownPath)` → 于是每次都抛「unknown path」。它压根不是「当前可执行文件所在目录」的意思。

## 改动
改用 `std::env::current_exe()` 定位——externalBin sidecar 运行期就躺在主可执行文件旁（tauri externalBin 约定），跨平台都对。dev 模式（未打包）里同目录带 target-triple 名字的回退扫描逻辑保持不变。

`app` 形参随之从 `ensure_duty_binary` 下放；`duty_persist_inner` 仍保留 `&app` 转发形参（下划线标未用），避免彻底删参把 unused 警告冒到 `#[tauri::command]` 签名上（macOS 分支会因 `deny(warnings)` 失败）。顺手清掉不再用到的 `Manager` import。

## 验证
- `cargo check` + `cargo clippy` 均通过、**零警告**（本地补了个占位 sidecar 让 tauri build-script 过后再 check，未提交）。
- 无法在纯 checkout 里跑起真实 .app（sidecar 二进制仅在 release bundling 时产出），但根因已在 tauri/dirs 源码层坐实，改动直白。

## 关于 #696 的另外 4 点面板体验诉求
「频道里能管理 / 独立弹窗 / 全局按频道视角 / 可检索」是一次面板重构，已拆成独立 issue #700 跟踪（纯前端），不混进这个崩溃修复。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复 macOS 桌面端常驻服务安装流程中辅助程序路径解析问题，提升 duty 安装与启动的稳定性。
  * 优化桌面端相关流程，确保在不同运行环境下能够正确定位所需程序。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->