### PR TITLE
feat(desktop): agentparty://channel/<slug> deep link 直达频道

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -47,6 +47,9 @@ let renderer: ReactTestRenderer | null = null;
 let credentialDeletes = 0;
 let storedCredential: string | null = null;
 let notificationActionHandler: ((notification: { extra?: Record<string, unknown> }) => void) | null = null;
+// 认证态桌面下，只有 App 级的 listenForDesktopChannelLinks 会注册 onOpenUrl（配对 listener 只在
+// 配对闸里挂），所以这里抓到的就是频道 deep link 的投递回调，测试可拿它模拟外部 open 链接。
+let channelLinkOpenHandler: ((urls: string[]) => void) | null = null;
 let desktopFocusCalls: string[] = [];
 let pushedPaths: string[] = [];
 let desktopWindowShownHandler: (() => void) | null = null;
@@ -116,6 +119,7 @@ beforeEach(() => {
   saveActiveServerOrigin(localStorage, activeOrigin);
   credentialDeletes = 0;
   notificationActionHandler = null;
+  channelLinkOpenHandler = null;
   desktopFocusCalls = [];
   pushedPaths = [];
   desktopWindowShownHandler = null;
@@ -147,7 +151,10 @@ beforeEach(() => {
     isTauri: () => true,
     loadDeepLink: async () => ({
       getCurrent: async () => null,
-      onOpenUrl: async () => () => {},
+      onOpenUrl: async (handler) => {
+        channelLinkOpenHandler = handler;
+        return () => {};
+      },
     }),
     loadNotification: async () => ({
       isPermissionGranted: async () => true,
@@ -406,6 +413,105 @@ describe("App desktop server pairing behavior", () => {
     expect(desktopFocusCalls).toEqual(["show", "unminimize", "focus"]);
     expect(pushedPaths).toContain("/c/general");
     expect(location.hash).toBe("#msg-42");
+  });
+
+  test("channel deep link focuses the window and opens the channel on the current server", async () => {
+    await act(async () => {
+      renderer = create(<LocaleProvider><App /></LocaleProvider>);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(channelLinkOpenHandler).not.toBeNull();
+    await act(async () => {
+      // 无 server：直接在当前实例按 slug 跳。
+      channelLinkOpenHandler?.(["agentparty://channel/general"]);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    expect(desktopFocusCalls).toEqual(["show", "unminimize", "focus"]);
+    expect(pushedPaths).toContain("/c/general");
+
+    await act(async () => {
+      // server 指向未配对实例（不在 profiles 里）：忽略 server，仍在当前实例跳，绝不切服。
+      channelLinkOpenHandler?.([`agentparty://channel/off-server?server=${encodeURIComponent(unpairedOrigin)}`]);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    expect(pushedPaths).toContain("/c/off-server");
+    expect(loadActiveServerOrigin(localStorage)).toBe(activeOrigin);
+  });
+
+  test("channel deep link with a paired other server switches instances then lands on the channel", async () => {
+    const privateOrigin = "https://private.example.com";
+    const replacements: string[] = [];
+    history.replaceState = (_state: unknown, _unused: string, url?: string | URL | null) => {
+      const next = String(url ?? "");
+      replacements.push(next);
+      location.pathname = next.split(/[?#]/)[0] || "/";
+    };
+
+    const credentials = new Map([
+      [activeOrigin, storedCredential!],
+      [privateOrigin, JSON.stringify({
+        refreshToken: "private-refresh",
+        deviceSecret: "private-device-secret",
+        serverOrigin: privateOrigin,
+        sessionId: "private-session",
+      })],
+    ]);
+    invokeHandler = async (command, args) => {
+      const origin = String(args?.origin ?? "");
+      if (command === "desktop_window_has_been_shown") return true;
+      if (command === "desktop_credential_migrate") return null;
+      if (command === "desktop_credential_read") return credentials.get(origin) ?? null;
+      if (command === "desktop_credential_write") {
+        credentials.set(origin, String(args?.credential));
+        return null;
+      }
+      if (command === "desktop_credential_delete") {
+        credentials.delete(origin);
+        return null;
+      }
+      throw new Error(`unexpected native command: ${command}`);
+    };
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: async (input: string | URL | Request) => {
+        const url = String(input);
+        if (url.endsWith("/api/desktop/sessions/refresh")) {
+          const isPrivate = url.startsWith(privateOrigin);
+          return new Response(JSON.stringify({
+            access_token: isPrivate ? "private-access" : "old-access",
+            refresh_token: isPrivate ? "rotated-private-refresh" : "rotated-old-refresh",
+            expires_in: 600,
+            session_id: isPrivate ? "private-session" : "old-session",
+          }), { status: 200 });
+        }
+        if (url.endsWith("/api/config")) return new Response("{}", { status: 200 });
+        if (url.endsWith("/api/channels")) return new Response('{"channels":[]}', { status: 200 });
+        if (url.endsWith("/api/me")) return new Response(JSON.stringify({
+          name: "human", email: null, kind: "human", handle: null, display_name: "Human",
+          avatar_url: null, avatar_thumb: null, provider: "oidc", tenant_key: null, role: "human", owner: null,
+        }), { status: 200 });
+        throw new Error(`unexpected request: ${url}`);
+      },
+    });
+
+    await act(async () => {
+      renderer = create(<LocaleProvider><App /></LocaleProvider>);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    await act(async () => {
+      channelLinkOpenHandler?.([`agentparty://channel/team?server=${encodeURIComponent(privateOrigin)}`]);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(loadActiveServerOrigin(localStorage)).toBe(privateOrigin);
+    // 切服与落频道同帧完成：replace 直接到 /c/team，不经中转的 Home（"/"）。
+    expect(replacements).toContain("/c/team");
+    expect(replacements).not.toContain("/");
   });
 
   test("successful server switch leaves a channel route from the previous server", async () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -407,7 +407,9 @@ export function App() {
     replace(`/c/${slug}`);
   }, [path, replace, temporaryHumanToken, t]);
 
-  const switchDesktopOrigin = useCallback(async (origin: string, restoredAccessToken?: string) => {
+  // destination 缺省回 Home；跨实例直达频道时传 `/c/<slug>`，让「切实例」和「落频道」在同一次
+  // replace 里完成——否则先 replace("/") 再由外层微任务 navigate，中间会闪一帧空 channels 的 Home。
+  const switchDesktopOrigin = useCallback(async (origin: string, restoredAccessToken?: string, destination = "/") => {
     const result = restoredAccessToken === undefined
       ? await switchActiveDesktopServer(origin)
       : activateDesktopServerWithAccessToken(origin, restoredAccessToken);
@@ -419,7 +421,7 @@ export function App() {
     setMe(null);
     activateDesktopHumanSession(result.accessToken);
     setDesktopBoot("ready");
-    replace("/");
+    replace(destination);
   }, [activateDesktopHumanSession, replace]);
 
   // 桌面版：外部工具（如 claude-statusbar 的 `cs hud`）通过 agentparty://channel/<slug>?server=<origin>
@@ -437,10 +439,9 @@ export function App() {
         ? link.serverOrigin
         : null;
     if (target !== null) {
-      // 目标是另一台已配对实例：先切服（恢复该实例凭据），成功与否都落到频道页——切服失败也不应
+      // 目标是另一台已配对实例：切服并在同一次 replace 里落到频道页（不闪 Home）。切服失败也不应
       // 把用户卡在原地，退化成在当前实例按 slug 打开即可。
-      void switchDesktopOrigin(target)
-        .then(() => navigate(`/c/${link.slug}`))
+      void switchDesktopOrigin(target, undefined, `/c/${link.slug}`)
         .catch(() => navigate(`/c/${link.slug}`));
     } else {
       navigate(`/c/${link.slug}`);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -81,10 +81,12 @@ import {
 } from "./lib/desktopCredentials";
 import {
   isDesktopRuntime,
+  listenForDesktopChannelLinks,
   listenForDesktopNotificationActions,
   showAndFocusDesktopWindow,
   waitForDesktopWindowShown,
 } from "./lib/desktopRuntime";
+import type { ChannelDeepLink } from "./lib/channelLink";
 import { setApiBase } from "./lib/base";
 import {
   addCustomServerProfile,
@@ -419,6 +421,45 @@ export function App() {
     setDesktopBoot("ready");
     replace("/");
   }, [activateDesktopHumanSession, replace]);
+
+  // 桌面版：外部工具（如 claude-statusbar 的 `cs hud`）通过 agentparty://channel/<slug>?server=<origin>
+  // 直达频道。scheme 已在 Tauri 侧注册，这里接住 onOpenUrl → 聚焦窗口 → 切到目标实例（仅当 server 指向
+  // 另一台已配对实例）→ 跳频道页。与配对 deep link（agentparty://pair/...）靠 hostname 分流，互不干扰。
+  // 用 ref 存回调、effect 只依赖 desktop：listener 只注册一次，冷启动链接经 getCurrent 也只投递一次，
+  // 避免 activeOrigin / 频道列表变化时重挂 listener 反复触发同一次跳转。
+  const channelLinkHandler = useRef<(link: ChannelDeepLink) => void>(() => {});
+  channelLinkHandler.current = (link) => {
+    void showAndFocusDesktopWindow();
+    const target =
+      link.serverOrigin !== null &&
+      link.serverOrigin !== activeOrigin &&
+      serverProfiles.some((profile) => profile.origin === link.serverOrigin)
+        ? link.serverOrigin
+        : null;
+    if (target !== null) {
+      // 目标是另一台已配对实例：先切服（恢复该实例凭据），成功与否都落到频道页——切服失败也不应
+      // 把用户卡在原地，退化成在当前实例按 slug 打开即可。
+      void switchDesktopOrigin(target)
+        .then(() => navigate(`/c/${link.slug}`))
+        .catch(() => navigate(`/c/${link.slug}`));
+    } else {
+      navigate(`/c/${link.slug}`);
+    }
+  };
+
+  useEffect(() => {
+    if (!desktop) return;
+    let alive = true;
+    let stop = () => {};
+    void listenForDesktopChannelLinks((link) => channelLinkHandler.current(link)).then((unlisten) => {
+      if (alive) stop = unlisten;
+      else unlisten();
+    });
+    return () => {
+      alive = false;
+      stop();
+    };
+  }, [desktop]);
 
   useEffect(() => {
     if (!desktop) return;

--- a/web/src/lib/channelLink.test.ts
+++ b/web/src/lib/channelLink.test.ts
@@ -1,0 +1,103 @@
+// @ts-expect-error Bun executes this test, while the web tsconfig intentionally loads only Vite globals.
+import { describe, expect, test } from "bun:test";
+import { parseChannelDeepLink } from "./channelLink";
+
+// 桌面版「从外部工具直达频道」的 deep link（agentparty://channel/<slug>?server=<origin>）纯解析层。
+// 来源是 claude-statusbar 的 `cs hud`——点某个 channel 会 open 这条链接，桌面壳收到后跳频道页。
+// 它与配对邀请（agentparty://pair/...）、网页邀请链接（http(s)）靠 scheme + hostname 分流、互不干扰。
+const SERVER = "https://agentparty.pwtk-dev.work";
+
+describe("parseChannelDeepLink", () => {
+  test("channel link with server → slug + normalized server origin", () => {
+    const link = parseChannelDeepLink(
+      `agentparty://channel/guessadmin?server=${encodeURIComponent(SERVER)}`,
+    );
+    expect(link).toEqual({ slug: "guessadmin", serverOrigin: SERVER });
+  });
+
+  test("channel link without server → slug + null server (channel is the primary key)", () => {
+    expect(parseChannelDeepLink("agentparty://channel/general")).toEqual({
+      slug: "general",
+      serverOrigin: null,
+    });
+  });
+
+  test("trailing slash on the channel path still parses", () => {
+    expect(parseChannelDeepLink("agentparty://channel/general/")).toEqual({
+      slug: "general",
+      serverOrigin: null,
+    });
+  });
+
+  test("hyphenated slug is accepted", () => {
+    expect(parseChannelDeepLink("agentparty://channel/team-alpha-2")).toEqual({
+      slug: "team-alpha-2",
+      serverOrigin: null,
+    });
+  });
+
+  test("server with an explicit port is preserved in the origin", () => {
+    const link = parseChannelDeepLink(
+      `agentparty://channel/general?server=${encodeURIComponent("http://localhost:8787")}`,
+    );
+    expect(link).toEqual({ slug: "general", serverOrigin: "http://localhost:8787" });
+  });
+
+  test("a malformed server degrades to null without blocking the channel jump", () => {
+    expect(parseChannelDeepLink("agentparty://channel/general?server=not-a-url")).toEqual({
+      slug: "general",
+      serverOrigin: null,
+    });
+    // server 带路径 / 查询串都不是干净 origin → 忽略，仍按 slug 跳。
+    expect(
+      parseChannelDeepLink(
+        `agentparty://channel/general?server=${encodeURIComponent("https://evil.example/c/x?t=1")}`,
+      ),
+    ).toEqual({ slug: "general", serverOrigin: null });
+    // 非 http(s) 的 server 一律拒（降级为 null）。
+    expect(
+      parseChannelDeepLink(
+        `agentparty://channel/general?server=${encodeURIComponent("agentparty://pair/ABCDE-12345")}`,
+      ),
+    ).toEqual({ slug: "general", serverOrigin: null });
+  });
+
+  test("extra query params are ignored; only server is read", () => {
+    expect(
+      parseChannelDeepLink(
+        `agentparty://channel/general?foo=1&server=${encodeURIComponent(SERVER)}&bar=2`,
+      ),
+    ).toEqual({ slug: "general", serverOrigin: SERVER });
+  });
+
+  test("the pairing deep link (hostname=pair) is never mistaken for a channel", () => {
+    expect(parseChannelDeepLink("agentparty://pair/ABCDE-12345")).toBeNull();
+  });
+
+  test("non-agentparty schemes are rejected", () => {
+    expect(parseChannelDeepLink(`${SERVER}/c/general`)).toBeNull();
+    expect(parseChannelDeepLink("javascript:alert(1)")).toBeNull();
+  });
+
+  test("non-URL garbage → null", () => {
+    expect(parseChannelDeepLink("")).toBeNull();
+    expect(parseChannelDeepLink("not a url")).toBeNull();
+  });
+
+  test("missing, empty, or multi-segment channel path → null", () => {
+    expect(parseChannelDeepLink("agentparty://channel")).toBeNull();
+    expect(parseChannelDeepLink("agentparty://channel/")).toBeNull();
+    expect(parseChannelDeepLink("agentparty://channel/a/b")).toBeNull();
+  });
+
+  test("invalid slug (uppercase / path traversal / leading hyphen) → null", () => {
+    expect(parseChannelDeepLink("agentparty://channel/GeneralChan")).toBeNull();
+    expect(parseChannelDeepLink("agentparty://channel/..")).toBeNull();
+    expect(parseChannelDeepLink("agentparty://channel/-lead")).toBeNull();
+  });
+
+  test("credentials or a fragment on the deep link are rejected", () => {
+    expect(parseChannelDeepLink("agentparty://user:pass@channel/general")).toBeNull();
+    expect(parseChannelDeepLink("agentparty://channel/general#frag")).toBeNull();
+  });
+});

--- a/web/src/lib/channelLink.ts
+++ b/web/src/lib/channelLink.ts
@@ -1,0 +1,51 @@
+// 桌面版「从外部工具直达频道」的 deep link：agentparty://channel/<slug>?server=<url-encoded-origin>。
+// 来源是 claude-statusbar 的 `cs hud` 浮窗——列出 AgentParty channel，点某条 → "Open in AgentParty"
+// 会 `open "agentparty://channel/<slug>?server=<server>"`。桌面壳（Tauri）已注册 agentparty scheme，
+// onOpenUrl 收到后要跳到对应频道页。协议格式在 claude-statusbar 侧定死，这边只解析 + 分发。
+//
+// 三条 deep/邀请入口靠 scheme + hostname 天然分流、互不干扰：
+//   · agentparty://pair/<code>     → 配对邀请（parsePairDeepLink，hostname=pair）
+//   · agentparty://channel/<slug>  → 本文件，直达频道（hostname=channel）
+//   · https://…/c|/join|/invite    → 网页邀请链接（inviteLink，http(s)）
+// channel host 的链接 parsePairDeepLink 必回 null；pair host 的链接这里也必回 null——不会串。
+//
+// server 只是「选实例」提示，不是主键：解析成规范 origin 交给宿主，由宿主决定是否切服（未配对的
+// 实例切不过去就忽略、只按 slug 在当前实例跳）。缺省或非法的 server 一律降级为 null，绝不阻断跳转。
+
+export interface ChannelDeepLink {
+  slug: string;
+  serverOrigin: string | null;
+}
+
+function normalizeServerOrigin(input: string): string | null {
+  try {
+    const url = new URL(input);
+    if (url.username || url.password || url.search || url.hash) return null;
+    if (url.pathname !== "/" && url.pathname !== "") return null;
+    if (url.protocol !== "https:" && url.protocol !== "http:") return null;
+    return url.origin;
+  } catch {
+    return null;
+  }
+}
+
+export function parseChannelDeepLink(input: string): ChannelDeepLink | null {
+  let url: URL;
+  try {
+    url = new URL(input);
+  } catch {
+    return null;
+  }
+  if (url.protocol !== "agentparty:" || url.hostname !== "channel" || url.username || url.password || url.hash) {
+    return null;
+  }
+  const segments = url.pathname.split("/").filter(Boolean);
+  if (segments.length !== 1) return null;
+  // 频道 slug 用与通知投递 / matchChannel 同一套字符集，小写打头、只含 [a-z0-9-]，限长 64。
+  const slug = segments[0] ?? "";
+  if (!/^[a-z0-9][a-z0-9-]{0,63}$/.test(slug)) return null;
+
+  const rawServer = url.searchParams.get("server");
+  const serverOrigin = rawServer === null ? null : normalizeServerOrigin(rawServer);
+  return { slug, serverOrigin };
+}

--- a/web/src/lib/desktopRuntime.test.ts
+++ b/web/src/lib/desktopRuntime.test.ts
@@ -7,6 +7,7 @@ import {
   isAutostartEnabled,
   isDesktopNotificationPermissionGranted,
   isDesktopNotificationSupported,
+  listenForDesktopChannelLinks,
   listenForDesktopNotificationActions,
   listenForDesktopPairLinks,
   openDesktopVerificationUrl,
@@ -84,6 +85,8 @@ describe("browser fallback", () => {
     expect(await sendMentionNotification({ title: "Mention", body: "hello", slug: "general", seq: 7 })).toBe(false);
     const stopNotificationActions = await listenForDesktopNotificationActions(() => {});
     stopNotificationActions();
+    const stopChannelLinks = await listenForDesktopChannelLinks(() => {});
+    stopChannelLinks();
     expect(await setDesktopBadge(4)).toBe(false);
     expect(await showAndFocusDesktopWindow()).toBe(false);
     const unlisten = await listenForDesktopUpdateChecks(() => {});
@@ -382,6 +385,42 @@ describe("desktop window", () => {
       "AB12C-DE34F:https://agentparty.leeguoo.com",
       "ZX90Y-WV87U:null",
     ]);
+  });
+
+  test("delivers cold-start and live channel deep links, ignoring pairing links", async () => {
+    let liveHandler: ((urls: string[]) => void) | null = null;
+    let unlistened = false;
+    const links: string[] = [];
+    __setDesktopRuntimeDependenciesForTests({
+      isTauri: () => true,
+      loadDeepLink: async () => ({
+        // 冷启动：混着一条 channel 链接和一条配对链接——只有 channel 那条应被投递。
+        getCurrent: async () => [
+          "agentparty://channel/guessadmin?server=https%3A%2F%2Fagentparty.pwtk-dev.work",
+          "agentparty://pair/AB12C-DE34F",
+        ],
+        onOpenUrl: async (handler) => {
+          liveHandler = handler;
+          return () => { unlistened = true; };
+        },
+      }),
+    });
+
+    const unlisten = await listenForDesktopChannelLinks(
+      (link) => links.push(`${link.slug}:${link.serverOrigin}`),
+    );
+    // live：一条无 server 的 channel 链接 + 一条配对链接（后者被 hostname 分流丢弃）。
+    liveHandler?.([
+      "agentparty://channel/general",
+      "agentparty://pair/ZX90Y-WV87U",
+    ]);
+    unlisten();
+
+    expect(links).toEqual([
+      "guessadmin:https://agentparty.pwtk-dev.work",
+      "general:null",
+    ]);
+    expect(unlistened).toBe(true);
   });
 
   test("forwards native tray update checks and exposes cleanup", async () => {

--- a/web/src/lib/desktopRuntime.ts
+++ b/web/src/lib/desktopRuntime.ts
@@ -1,5 +1,6 @@
 import { isTauriEnvironment } from "./desktopUpdater";
 import { parsePairDeepLink, resolveAllowedVerificationUrl, type PairDeepLink } from "./desktopPairing";
+import { parseChannelDeepLink, type ChannelDeepLink } from "./channelLink";
 
 export type DesktopNotificationPermission =
   | "granted"
@@ -305,6 +306,30 @@ export async function listenForDesktopPairLinks(
       for (const input of urls) {
         const parsed = parsePairDeepLink(input, allowedOrigins);
         if (parsed !== null) onPairLink(parsed);
+      }
+    };
+    const unlisten = await deepLink.onOpenUrl(deliver);
+    const current = await deepLink.getCurrent();
+    if (current !== null) deliver(current);
+    return unlisten;
+  } catch {
+    return () => {};
+  }
+}
+
+// 桌面版：接住外部工具打来的「直达频道」deep link（agentparty://channel/<slug>?server=<origin>）。
+// 结构与 listenForDesktopPairLinks 对称——onOpenUrl 收 live 链接、getCurrent 收冷启动链接，逐条解析后
+// 分发给宿主导航。channel host 与 pair host 靠 hostname 分流，两个 listener 各取所需、互不误吞。
+export async function listenForDesktopChannelLinks(
+  onChannelLink: (link: ChannelDeepLink) => void,
+): Promise<() => void> {
+  if (!isDesktopRuntime()) return () => {};
+  try {
+    const deepLink = await dependencies.loadDeepLink();
+    const deliver = (urls: string[]) => {
+      for (const input of urls) {
+        const parsed = parseChannelDeepLink(input);
+        if (parsed !== null) onChannelLink(parsed);
       }
     };
     const unlisten = await deepLink.onOpenUrl(deliver);


### PR DESCRIPTION
## 背景
claude-statusbar 的 `cs hud` 浮窗有个 AgentParty channel 列表，点某条 channel → "Open in AgentParty" 会 `open "agentparty://channel/<slug>?server=<url-encoded-server>"`。协议格式在 statusbar 侧定死，这边桌面客户端实现 handler 接住、跳到对应频道页。

## 改动
新增第三条、与现有入口彻底隔离的 deep link：`agentparty://channel/<slug>?server=<origin>`。它复用已注册的 `agentparty` scheme，与配对 deep link(`agentparty://pair/...`)靠 `hostname` 天然分流——两个 `onOpenUrl` listener 各取所需、互不误吞。

- **解析** `web/src/lib/channelLink.ts` — `parseChannelDeepLink`：校验 `protocol=agentparty:` + `hostname=channel`，单段 path 作 slug(`^[a-z0-9][a-z0-9-]{0,63}$`，与 `matchChannel`/通知路由同字符集)，拒绝带凭据/fragment 的链接。`server` 只是「选实例」提示、不是主键：规范化为干净 http(s) origin，缺省或非法一律降级为 `null`，绝不阻断跳转。
- **接收** `web/src/lib/desktopRuntime.ts` — `listenForDesktopChannelLinks`：与 `listenForDesktopPairLinks` 对称(live `onOpenUrl` + 冷启动 `getCurrent`)。
- **接线** `web/src/App.tsx` — 用 `useRef` 存回调、effect 只依赖 `[desktop]`，listener 只注册一次(避免 `activeOrigin`/频道列表变化重挂导致冷启动链接反复触发)。仅当 `server` 指向**另一台已配对**实例时才切服；切服失败也回退到当前实例按 slug 打开。

## 不破坏现有邀请配对
`parsePairDeepLink` 对 `hostname=channel` 必回 null，反之亦然；`inviteLink`(http(s))完全不受影响。

## 测试
- 新增 `web/src/lib/channelLink.test.ts`(解析层，含分流/降级/非法 slug/凭据 fragment 等 13 例)。
- `desktopRuntime.test.ts` 加 listener 冷启动+live 投递、pair 链接被忽略、浏览器 fallback no-op。
- `bun run check:web` 全绿：`bun test` 973 pass、`tsc --noEmit` clean、`vite build` ok。

## 手动验证
桌面 app 运行且登录后：
```
open "agentparty://channel/guessadmin?server=https%3A%2F%2Fagentparty.pwtk-dev.work"
```
窗口聚焦并跳到 guessadmin 频道。无 server 形式 `agentparty://channel/general` 在当前实例跳转。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 支持桌面端通过外部 deep link 直达并打开指定频道。
  - 解析 deep link 时进行安全校验与参数规范化；仅在链接有效时执行跳转。
  - 打开频道链接后自动聚焦桌面窗口；在需要时先切换目标服务器并避免中转闪屏，直接落到频道页。
- **测试**
  - 新增桌面端冷启动与实时 deep link 投递测试，覆盖切服与落频道行为。
  - 新增频道 deep link 解析单元测试，覆盖多种非法/异常输入与边界情况。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->