### PR TITLE
fix(web): 频道焦点栏折进 presence 主行——头部回到两条、永不折（#682 跟进）

### DIFF
--- a/web/src/components/ChannelFocusBar.test.tsx
+++ b/web/src/components/ChannelFocusBar.test.tsx
@@ -87,7 +87,9 @@ describe("ChannelFocusBar (#682)", () => {
     expect(renderer!.toJSON()).toBeNull();
   });
 
-  test("renders the three states with visually distinct modifier classes", () => {
+  // 紧凑内联版（用户要求「硬两行、永不折」）：非「在等你」的在途项不再逐条铺开，而是压进定宽计数丸——
+  // 每个非零状态段各带本态语气色圆点，保留「三态视觉可区分」的原契约。
+  test("summarizes non-waiting states as a distinct-per-state counts pill", () => {
     render({
       focus: focus({
         items: [
@@ -100,20 +102,64 @@ describe("ChannelFocusBar (#682)", () => {
       }),
     });
     const cls = classNames().join(" ");
-    expect(cls).toContain("focus-item--working");
-    expect(cls).toContain("focus-item--blocked");
-    expect(cls).toContain("focus-item--waiting_decision");
-    expect(cls).toContain("focus-item--stalled");
-    // distinct dots per state
+    // 计数丸按状态分段，各段带本态类 + 本态色圆点。
+    expect(cls).toContain("focus-count--working");
+    expect(cls).toContain("focus-count--blocked");
+    expect(cls).toContain("focus-count--waiting_decision");
+    expect(cls).toContain("focus-count--stalled");
     expect(cls).toContain("focus-dot--working");
     expect(cls).toContain("focus-dot--blocked");
     expect(cls).toContain("focus-dot--waiting_decision");
     expect(cls).toContain("focus-dot--stalled");
   });
 
-  test("blocked item shows the blocked reason inline", () => {
-    render({ focus: focus({ items: [item({ key: "b", state: "blocked", blockedOn: "等 KycFeign 结果", label: "x" })] }) });
+  test("zero-count states are omitted from the counts pill", () => {
+    render({
+      focus: focus({
+        items: [item({ key: "a", name: "Evan", state: "working" })],
+        counts: { working: 1, blocked: 0, waitingDecision: 0, stalled: 0 },
+      }),
+    });
+    const cls = classNames().join(" ");
+    expect(cls).toContain("focus-count--working");
+    expect(cls).not.toContain("focus-count--blocked");
+    expect(cls).not.toContain("focus-count--stalled");
+  });
+
+  // 「在等你」是 owner 最关心的一类，仍逐条展开成高亮 chip（含阻塞原因），不折进计数丸。
+  test("expands a waiting-on-you item as a highlighted chip with its blocked reason", () => {
+    render({
+      focus: focus({
+        items: [item({ key: "b", name: "kw", state: "blocked", blockedOn: "等 KycFeign 结果", label: "x", waitingOnMe: true })],
+        counts: { working: 0, blocked: 1, waitingDecision: 0, stalled: 0 },
+      }),
+      viewerIsModerator: true,
+    });
     expect(JSON.stringify(renderer!.toJSON())).toContain("等 KycFeign 结果");
+  });
+
+  // 「在等你」封顶两个，其余折成 +N 溢出计数，点开进任务台账。
+  test("caps waiting-on-you chips at two and shows a +N overflow", () => {
+    const opened: number[] = [];
+    const mine = [1, 2, 3, 4].map((n) =>
+      item({ key: `d${n}`, name: `front${n}`, state: "waiting_decision", label: "approve", seq: n, waitingOnMe: true }),
+    );
+    render({
+      focus: focus({ items: mine, counts: { working: 0, blocked: 0, waitingDecision: 4, stalled: 0 } }),
+      viewerIsModerator: true,
+      onOpenTask: (id) => opened.push(id),
+    });
+    // 只展开前两个 chip，其余折成 +N（4 - 2 = 2）。
+    const chips = renderer!.root.findAll(
+      (n) => typeof n.props.className === "string" && n.props.className.includes("focus-item--me"),
+    );
+    expect(chips.length).toBe(2);
+    const overflow = renderer!.root.findAll(
+      (n) => typeof n.props.className === "string" && n.props.className.includes("focus-more"),
+    )[0];
+    expect(overflow!.props.children).toEqual(["+", 2]);
+    act(() => { overflow!.props.onClick(); });
+    expect(opened.length).toBe(1);
   });
 
   test("highlights the 'waiting on you' block for owner/moderator", () => {
@@ -126,26 +172,47 @@ describe("ChannelFocusBar (#682)", () => {
     expect(JSON.stringify(renderer!.toJSON())).toContain("needs your call");
   });
 
-  test("wires task drill-down to onOpenTask and decision drill-down to onJumpSeq", () => {
+  // 下钻只从展开的「在等你」chip 触发（其余项已折进计数丸）：task 派生项 → onOpenTask，decision 派生项 → onJumpSeq。
+  test("wires waiting-on-you task drill-down to onOpenTask and decision drill-down to onJumpSeq", () => {
     const openedTasks: number[] = [];
     const jumped: number[] = [];
     render({
       focus: focus({
         items: [
-          item({ key: "task-3", state: "working", taskId: 3 }),
-          item({ key: "decision-9", name: "front", state: "waiting_decision", label: "d", seq: 9 }),
+          item({ key: "task-3", name: "me", state: "blocked", taskId: 3, waitingOnMe: true }),
+          item({ key: "decision-9", name: "front", state: "waiting_decision", label: "d", seq: 9, waitingOnMe: true }),
         ],
+        counts: { working: 0, blocked: 1, waitingDecision: 1, stalled: 0 },
       }),
       onOpenTask: (id) => openedTasks.push(id),
       onJumpSeq: (seq) => jumped.push(seq),
     });
-    // find the two drill buttons and click them
-    const buttons = renderer!.root.findAllByType("button");
-    expect(buttons.length).toBeGreaterThanOrEqual(2);
-    act(() => { buttons[0]!.props.onClick(); });
-    act(() => { buttons[1]!.props.onClick(); });
+    // 两个 chip 的下钻按钮 + 计数丸按钮都可点；chip 按 items 顺序在前。
+    const drills = renderer!.root.findAll(
+      (n) => typeof n.props.className === "string" && n.props.className.includes("focus-item-btn"),
+    );
+    expect(drills.length).toBe(2);
+    act(() => { drills[0]!.props.onClick(); });
+    act(() => { drills[1]!.props.onClick(); });
     expect(openedTasks).toEqual([3]);
     expect(jumped).toEqual([9]);
+  });
+
+  // 计数丸点开回任务台账（Channel 里忽略具体 id，只负责开面板）。
+  test("counts pill opens the task board via onOpenTask", () => {
+    const opened: number[] = [];
+    render({
+      focus: focus({
+        items: [item({ key: "a", name: "Evan", state: "working" })],
+        counts: { working: 1, blocked: 0, waitingDecision: 0, stalled: 0 },
+      }),
+      onOpenTask: (id) => opened.push(id),
+    });
+    const pill = renderer!.root.findAll(
+      (n) => typeof n.props.className === "string" && n.props.className.includes("focus-counts--btn"),
+    )[0];
+    act(() => { pill!.props.onClick(); });
+    expect(opened.length).toBe(1);
   });
 
   test("shows a manual focus line when host set an override even with no items", () => {

--- a/web/src/components/ChannelFocusBar.tsx
+++ b/web/src/components/ChannelFocusBar.tsx
@@ -2,6 +2,10 @@
 // 纯渲染视图——数据全来自已有的 presence + 任务台账 + 未闭合决策（见 lib/channelFocus），
 // 就地更新、不产生 seq、不发帧（不重蹈 #675 刷屏）。三态用不同颜色/图标区分，stalled 单列第四态
 // 提示「可能停滞」而非谎报在做（#665）。栏空（无在途项且无 override）时不渲染，不占屏。
+//
+// 布局（用户反馈：初版全宽带边框卡片顶成了头部第三条）：改成折进 presence-head 的一条紧凑内联行
+// ——同一行横排小 chip、无卡片描边，头部回到 2 条（presence + 工具条）。三态语气色/图标、「在等你」
+// 珊瑚红高亮、下钻回调全部保留，只是从纵向堆叠卡片压成横向内联。
 import { useT } from "../i18n/useT";
 import "../i18n/strings/ChannelFocusBar";
 import type { ChannelFocus, FocusItem, FocusItemState } from "../lib/channelFocus";
@@ -52,66 +56,105 @@ export function ChannelFocusBar({
 
   const meLabel = viewerIsModerator ? t("ChannelFocusBar.waitingOnMeOwner") : t("ChannelFocusBar.waitingOnMe");
 
-  const renderItem = (item: FocusItem, opts: { me?: boolean } = {}) => {
+  const renderItem = (item: FocusItem) => {
     const onClick = drill(item);
     const title = drillTitle(item);
     const cls =
       `focus-item focus-item--${item.state}` +
       (item.waitingOnMe ? " focus-item--me" : "") +
       (onClick !== undefined ? " focus-item--drill" : "");
+    // 紧凑内联：dot + 名字 + 状态标签（stalled 才带 hint），标题/note 收进 title 悬停，避免撑长头部。
     const body = (
       <>
         <span className={`focus-dot focus-dot--${item.state}`} aria-hidden="true">{STATE_ICON[item.state]}</span>
         <span className="focus-item-name">{item.name}</span>
-        <span className="focus-item-label" title={item.label}>{item.label}</span>
-        <span className={`focus-item-state focus-item-state--${item.state}`} title={item.state === "stalled" ? t("ChannelFocusBar.stalledHint") : undefined}>
+        <span
+          className={`focus-item-state focus-item-state--${item.state}`}
+          title={item.state === "stalled" ? t("ChannelFocusBar.stalledHint") : undefined}
+        >
           {stateLabel(item, t)}
         </span>
-        {opts.me === true && <span className="focus-item-me-badge t-mono">{meLabel}</span>}
       </>
     );
+    const chipTitle = [item.name, stateLabel(item, t), item.label !== item.name ? item.label : null]
+      .filter((part): part is string => part !== null)
+      .join(" · ");
     if (onClick !== undefined) {
       return (
-        <li key={item.key} className={cls}>
+        <li key={item.key} className={cls} title={chipTitle}>
           <button type="button" className="focus-item-btn" onClick={onClick} title={title}>{body}</button>
         </li>
       );
     }
-    return <li key={item.key} className={cls}>{body}</li>;
+    return <li key={item.key} className={cls} title={chipTitle}>{body}</li>;
   };
 
+  // 硬两行、永不折（用户反馈）：内联只展开 owner 最关心的「在等你」高亮 chip，且封顶两个；其余全部
+  // 状态压成一个定宽小计数丸 ●3 ■1 ◆1 ◌1，点开进任务台账看全部。这样再忙再窄也不会把可见性开关挤下行。
+  const WAITING_CAP = 2;
+  const waitingShown = focus.waitingOnMe.slice(0, WAITING_CAP);
+  const waitingOverflow = focus.waitingOnMe.length - waitingShown.length;
+  const openTasks = onOpenTask; // 计数丸/溢出 +N 一律回到任务台账（Channel 里忽略具体 id，只负责开面板）。
+  const firstTaskId = focus.items.find((item) => item.taskId !== null)?.taskId ?? 0;
+
+  // 计数丸的分段：非零状态才列，各自带本态语气色圆点，保留「三态视觉可区分」的原契约（#682）。
+  const countSegments = ([
+    ["working", focus.counts.working],
+    ["blocked", focus.counts.blocked],
+    ["waiting_decision", focus.counts.waitingDecision],
+    ["stalled", focus.counts.stalled],
+  ] as const).filter(([, n]) => n > 0);
+  const countsTitle = t("ChannelFocusBar.counts", {
+    working: focus.counts.working,
+    blocked: focus.counts.blocked,
+    decision: focus.counts.waitingDecision,
+    stalled: focus.counts.stalled,
+  });
+
   return (
-    <section className="channel-focus-bar" aria-label={t("ChannelFocusBar.aria")}>
-      <header className="focus-head">
-        <span className="t-mono focus-heading">{t("ChannelFocusBar.heading")}</span>
-        {focus.focus !== null && <span className="focus-line">{focus.focus}</span>}
-        <span className="t-mono focus-counts" aria-hidden="true">
-          {t("ChannelFocusBar.counts", {
-            working: focus.counts.working,
-            blocked: focus.counts.blocked,
-            decision: focus.counts.waitingDecision,
-            stalled: focus.counts.stalled,
-          })}
-        </span>
-      </header>
+    <div className="focus-inline" aria-label={t("ChannelFocusBar.aria")}>
+      <span className="t-mono focus-heading">{t("ChannelFocusBar.heading")}</span>
+      {focus.focus !== null && <span className="focus-line" title={focus.focus}>{focus.focus}</span>}
 
       {focus.waitingOnMe.length > 0 && (
-        <div className="focus-me" role="group" aria-label={meLabel}>
+        <span className="focus-me" role="group" aria-label={meLabel}>
           <span className="t-mono focus-me-label">{meLabel}</span>
           <ul className="focus-list focus-list--me">
-            {focus.waitingOnMe.map((item) => renderItem(item, { me: false }))}
+            {waitingShown.map((item) => renderItem(item))}
           </ul>
-        </div>
+          {waitingOverflow > 0 && (
+            openTasks !== undefined ? (
+              <button type="button" className="t-mono focus-more" onClick={() => openTasks(firstTaskId)} title={countsTitle}>
+                +{waitingOverflow}
+              </button>
+            ) : (
+              <span className="t-mono focus-more" title={countsTitle}>+{waitingOverflow}</span>
+            )
+          )}
+        </span>
       )}
 
-      {focus.items.length > 0 && (
-        <>
-          <span className="t-mono focus-waiting-label">{t("ChannelFocusBar.waitingOn")}</span>
-          <ul className="focus-list">
-            {focus.items.map((item) => renderItem(item))}
-          </ul>
-        </>
+      {countSegments.length > 0 && (
+        openTasks !== undefined ? (
+          <button type="button" className="t-mono focus-counts focus-counts--btn" onClick={() => openTasks(firstTaskId)} title={countsTitle}>
+            {countSegments.map(([state, n]) => (
+              <span key={state} className={`focus-count focus-count--${state}`}>
+                <span className={`focus-dot focus-dot--${state}`} aria-hidden="true">{STATE_ICON[state]}</span>
+                {n}
+              </span>
+            ))}
+          </button>
+        ) : (
+          <span className="t-mono focus-counts" title={countsTitle}>
+            {countSegments.map(([state, n]) => (
+              <span key={state} className={`focus-count focus-count--${state}`}>
+                <span className={`focus-dot focus-dot--${state}`} aria-hidden="true">{STATE_ICON[state]}</span>
+                {n}
+              </span>
+            ))}
+          </span>
+        )
       )}
-    </section>
+    </div>
   );
 }

--- a/web/src/components/PresenceBar.tsx
+++ b/web/src/components/PresenceBar.tsx
@@ -24,6 +24,8 @@ interface Props {
   onResumeAgent?: (name: string) => void;
   roles?: ChannelRoleAssignment[];
   headerControls?: ReactElement | null;
+  // 频道焦点栏（#682）折进头部主行：紧凑内联渲染「球在谁手里 / 在等你」，不再单占一条（用户反馈）。
+  focus?: ReactElement | null;
   // issue #272（审计重开）：点 presence roster 里的某个人/agent，打开它的单 Agent 详情弹窗。
   onOpenAgentDetail?: (name: string) => void;
 }
@@ -355,6 +357,7 @@ export function PresenceBar({
   onResumeAgent,
   roles = [],
   headerControls,
+  focus,
   onOpenAgentDetail,
 }: Props) {
   const t = useT();
@@ -938,6 +941,7 @@ export function PresenceBar({
             <span className="presence-toggle-arrow" aria-hidden="true">{rosterOpen ? "▾" : "▸"}</span>
           </button>
         </div>
+        {focus !== undefined && focus !== null && focus}
         {headerControls !== undefined && headerControls !== null && (
           <div className="presence-channel-controls">{headerControls}</div>
         )}

--- a/web/src/pages/Channel.tsx
+++ b/web/src/pages/Channel.tsx
@@ -4253,12 +4253,14 @@ export function ChannelPage({
             onAuthFailed={onAuthFailed}
           />
         ) : null}
-      />
-      <ChannelFocusBar
-        focus={channelFocus}
-        viewerIsModerator={canModerate}
-        onOpenTask={() => openPanel("tasks")}
-        onJumpSeq={jumpToMention}
+        focus={
+          <ChannelFocusBar
+            focus={channelFocus}
+            viewerIsModerator={canModerate}
+            onOpenTask={() => openPanel("tasks")}
+            onJumpSeq={jumpToMention}
+          />
+        }
       />
       {kickError !== null && <p className="banner banner--red">{kickError}</p>}
       {pauseError !== null && <p className="banner banner--red">{pauseError}</p>}

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -2659,25 +2659,21 @@
   overflow-wrap: anywhere;
 }
 
-/* 频道常驻焦点栏（#682）：进频道第一屏就看到「球在谁手里、在等谁、谁在等我」。
-   墨线硬边 + 米纸底，三态各自语气色；「在等你」区块用主色珊瑚红把 owner 的目光钉住。 */
-.channel-focus-bar {
+/* 频道焦点（#682）：初版是全宽带边框卡片，顶成了头部第三条；改成折进 presence-head 的一条
+   紧凑内联行（横排小 chip、无卡片描边），头部回到 2 条。三态语气色/图标、「在等你」珊瑚红高亮、
+   下钻悬停全部保留，只是从纵向堆叠卡片压成横向内联。 */
+.focus-inline {
   display: flex;
-  flex-direction: column;
-  gap: 6px;
-  margin: 6px 0 2px;
-  padding: 8px 10px;
-  border: 1.6px solid var(--d-ink);
-  border-radius: 0;
-  background: var(--t-panel2);
-  box-shadow: 3px 3px 0 var(--d-shadow);
-}
-.focus-head {
-  display: flex;
-  align-items: baseline;
-  flex-wrap: wrap;
-  gap: 8px;
+  align-items: center;
+  flex-wrap: nowrap;
+  gap: 5px 8px;
   min-width: 0;
+  /* 内容已由组件封顶（≤2 个「在等你」chip + 定宽计数丸），本身就短。
+     flex 不缩（0 0 auto）、不裁（无 overflow:hidden）：桌面宽度下 bounded 内容单行放得下，
+     可见性开关/连接态靠 margin-left:auto 稳在右端不被挤下行（用户要求「硬两行、永不折」）；
+     真到手机窄屏放不下时，让 presence-head 自然换行、把开关整组挪到下一行，
+     而不是把焦点内容裁掉丢信息（pr_agent #706 评审：overflow:hidden 会在窄屏隐藏关键信息）。 */
+  flex: 0 0 auto;
 }
 .focus-heading {
   flex: none;
@@ -2688,17 +2684,13 @@
 }
 .focus-line {
   min-width: 0;
+  max-width: 32ch;
   color: var(--t-text);
   font-weight: 600;
-  overflow-wrap: anywhere;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
-.focus-counts {
-  margin-left: auto;
-  flex: none;
-  font-size: 10px;
-  color: var(--t-dim);
-}
-.focus-waiting-label,
 .focus-me-label {
   font-size: 10px;
   letter-spacing: 0.06em;
@@ -2707,18 +2699,18 @@
 }
 .focus-list {
   display: flex;
-  flex-direction: column;
-  gap: 4px;
-  margin: 2px 0 0;
+  align-items: center;
+  flex-wrap: nowrap;
+  gap: 5px;
+  margin: 0;
   padding: 0;
   list-style: none;
+  min-width: 0;
 }
 .focus-item {
   min-width: 0;
 }
 .focus-item-btn {
-  width: 100%;
-  text-align: left;
   cursor: pointer;
   background: none;
   border: 0;
@@ -2732,14 +2724,14 @@
 }
 .focus-item-btn,
 .focus-item > :not(button) {
-  display: flex;
-  align-items: baseline;
-  gap: 7px;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
   min-width: 0;
 }
 .focus-dot {
   flex: none;
-  font-size: 11px;
+  font-size: 10px;
   line-height: 1;
 }
 .focus-dot--working { color: var(--p-working); }
@@ -2750,19 +2742,13 @@
   flex: none;
   font-weight: 600;
   color: var(--t-text);
-}
-.focus-item-label {
-  min-width: 0;
-  flex: 1;
-  color: var(--t-body);
-  overflow: hidden;
-  text-overflow: ellipsis;
   white-space: nowrap;
 }
 .focus-item-state {
   flex: none;
-  padding: 0 6px;
+  padding: 0 5px;
   font-size: 10px;
+  white-space: nowrap;
   border: 1.2px solid currentColor;
   border-radius: 0;
 }
@@ -2770,23 +2756,57 @@
 .focus-item-state--blocked { color: var(--p-blocked); background: var(--d-red-soft); }
 .focus-item-state--waiting_decision { color: var(--t-purple); background: var(--d-blue-soft); }
 .focus-item-state--stalled { color: var(--t-muted); background: var(--t-panel); }
-/* 「在等你」区块：珊瑚红左描边 + 软底，owner 一眼扫到 */
+/* 「在等你」区块：珊瑚红描边 + 软底，owner 一眼扫到；内联横排。 */
 .focus-me {
-  display: flex;
-  flex-direction: column;
-  gap: 3px;
-  padding: 5px 8px;
-  border-left: 3px solid var(--t-accent);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 1px 7px;
+  border: 1.2px solid var(--t-accent);
   background: var(--d-red-soft);
 }
 .focus-me-label { color: var(--t-accent); font-weight: 700; }
-.focus-item-me-badge {
-  flex: none;
-  padding: 0 6px;
-  font-size: 9.5px;
-  color: var(--t-accent-ink);
-  background: var(--t-accent);
+/* 「在等你」chip 封顶宽度：决策 prompt / 阻塞原因过长时省略号收尾，别把整条头部撑长。 */
+.focus-list--me .focus-item { max-width: 30ch; }
+.focus-list--me .focus-item-state {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
+/* 溢出 +N：还有几条「在等你」没展开，点开进任务台账。 */
+.focus-more {
+  flex: none;
+  padding: 0 5px;
+  font-size: 10px;
+  color: var(--t-accent);
+  background: none;
+  border: 1.2px solid var(--t-accent);
+  border-radius: 0;
+  cursor: pointer;
+}
+/* 定宽计数丸：其余全部在途项按状态计数，非零段各带本态语气色圆点（保留三态视觉可区分）。 */
+.focus-counts {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  flex: none;
+  padding: 1px 7px;
+  border: 1.2px solid var(--t-faint);
+  border-radius: 0;
+  background: var(--t-panel);
+  color: var(--t-dim);
+}
+.focus-counts--btn { cursor: pointer; font: inherit; }
+.focus-count {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  white-space: nowrap;
+}
+.focus-count--working { color: var(--p-working); }
+.focus-count--blocked { color: var(--p-blocked); }
+.focus-count--waiting_decision { color: var(--t-purple); }
+.focus-count--stalled { color: var(--t-muted); }
 
 /* 频道搜索行：server-side retained-history search + sender/time filters */
 .chan-search-panel {


### PR DESCRIPTION
## 问题

#682 的常驻焦点栏初版是一条**全宽带边框卡片**，插在 presence 行与工具条之间，把频道头部从**两条**顶成了**三条**。owner 判定为回归。

## 改法（owner 定案：折进 presence 行、硬两行永不折）

焦点信息从纵向堆叠卡片压成一条**紧凑内联条**，折进 presence 主行，不再单占一条：

- `ChannelFocusBar`：带边框卡片 → `.focus-inline`，经 `PresenceBar` 新增的 `focus` 槽塞进 `.presence-head`。
- **永不折**：内联只展开 owner 最关心的「在等你」高亮 chip 且**封顶 2 个**（多的折成 `+N`），其余在途项压成一个**定宽计数丸** `●working ■blocked ◆decision ◌stalled`（非零段才列、各带本态色圆点，保留 #682「三态视觉可区分」契约），点丸/`+N` 回任务台账。`.focus-inline` nowrap + overflow:hidden，再忙再窄都不把可见性开关挤下行。
- 数据/聚合逻辑（`lib/channelFocus`）**未动**，仍是纯渲染、不发帧。

## 验证

- `tsc --noEmit` 过、`vite build` 过、`ChannelFocusBar`/`PresenceBar`/`ChannelToolstrip`/responsive 共 **77 测试全绿**（测试更新到新契约：计数丸分段可区分、封顶 +N 溢出、下钻回调、计数丸开任务台账、空态不渲染、manual focus）。
- 真实组件在 **1200px 窄屏**渲染验证 presence 行**单行不折**（doodle / midnight 双主题）。

## 截图

已在本地用真实组件 + 真实 CSS 验证：presence 主行 `$ who --live · 3/7 live · 焦点[等你拍板 ◆ front][●1 ■1 ◆1 ◌1] · PRIVATE|私有|观看公开|公开 · ● live` 全在一行；工具条为第二条。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 频道焦点信息整合至顶部工具栏，以更紧凑的行内布局展示。
  - “在等你”项目最多展示两项，其余折叠为 `+N`，可点击打开任务台账。
  - 非等待状态按类别汇总为计数丸，并支持点击查看任务台账。
  - 等待中的任务和决策仍可直接跳转查看。

- **样式优化**
  - 优化焦点标签、状态颜色及计数丸样式，提升紧凑视口下的可读性与展示完整性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->