### PR TITLE
feat(web): #700 本机 agent 概览——独立弹窗 + 按频道视角 + 可检索

### DIFF
--- a/web/src/components/DesktopSettings.tsx
+++ b/web/src/components/DesktopSettings.tsx
@@ -7,6 +7,7 @@ import {
 import { useT, type TFunc } from "../i18n/useT";
 import "../i18n/strings/DesktopSettings";
 import { DesktopAgentPanel } from "./DesktopAgentPanel";
+import { LocalAgentsOverview } from "./LocalAgentsOverview";
 import { desktopAgentAdapter, type DesktopAgentAdapter } from "../lib/desktopAgent";
 import {
   loadDesktopReleaseInfo,
@@ -188,6 +189,8 @@ export function DesktopSettingsPanel({
           {t("DesktopSettings.release.previewWarning")}
         </p>
       )}
+      {/* #700：全局「本机 agent」概览——按频道分组 + 可检索（不限频道）。下方 DesktopAgentPanel 仍是启动器。 */}
+      <LocalAgentsOverview t={t} adapter={agentAdapter} />
       <DesktopAgentPanel adapter={agentAdapter} t={t} />
     </section>
   );

--- a/web/src/components/LocalAgentsOverview.test.tsx
+++ b/web/src/components/LocalAgentsOverview.test.tsx
@@ -1,0 +1,147 @@
+// @ts-expect-error Bun executes this test, while the web tsconfig intentionally loads only Vite globals.
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { act, create, type ReactTestInstance, type ReactTestRenderer } from "react-test-renderer";
+import { LocaleProvider } from "../i18n/locale";
+import { DesktopSettingsStrings } from "../i18n/strings/DesktopSettings";
+import { LocalAgentsOverviewStrings } from "../i18n/strings/LocalAgentsOverview";
+import type { DesktopAgentAdapter, DesktopAgentStatus, DesktopDutyEntry } from "../lib/desktopAgent";
+import { LocalAgentsOverview } from "./LocalAgentsOverview";
+import type { DesktopAgentScheduler } from "./DesktopAgentPanel";
+
+const merged: Record<string, string> = { ...DesktopSettingsStrings.en, ...LocalAgentsOverviewStrings.en };
+const t = (key: string, vars?: Record<string, string | number>) => {
+  const raw = merged[key] ?? key;
+  return vars ? raw.replace(/\{(\w+)\}/g, (_, k) => String(vars[k] ?? `{${k}}`)) : raw;
+};
+const noScheduler: DesktopAgentScheduler = { every: () => () => {} };
+
+function inst(over: Partial<DesktopAgentStatus>): DesktopAgentStatus {
+  return {
+    state: "running", pid: 1, configId: "cfg", name: "planner", channel: "ops", runner: "codex",
+    startedAt: null, exitCode: null, lastError: null, instanceId: "cfg:ops", workdir: null, repo: null, ...over,
+  };
+}
+function duty(over: Partial<DesktopDutyEntry>): DesktopDutyEntry {
+  return { label: "l", instanceId: "cfg:ops", plistPath: "/p", logPath: "/log", loaded: true, ...over };
+}
+
+function adapter(over: Partial<DesktopAgentAdapter> = {}): DesktopAgentAdapter {
+  return {
+    listConfigs: async () => [],
+    status: async () => inst({ state: "stopped", instanceId: null }),
+    statusAll: async () => [],
+    start: async () => inst({}),
+    stop: async () => inst({ state: "stopped" }),
+    stopInstance: async () => inst({ state: "stopped" }),
+    logs: async () => [],
+    logsInstance: async () => [],
+    dutyList: async () => [],
+    dutyPersist: async () => { throw new Error("na"); },
+    dutyUnpersist: async () => {},
+    dutyAdopt: async () => { throw new Error("na"); },
+    ...over,
+  };
+}
+
+let renderer: ReactTestRenderer | null = null;
+
+beforeEach(() => {
+  Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", { configurable: true, value: true });
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: { getItem: () => "en", setItem: () => {}, removeItem: () => {} },
+  });
+});
+afterEach(async () => {
+  if (renderer !== null) await act(async () => renderer?.unmount());
+  renderer = null;
+});
+
+async function render(a: DesktopAgentAdapter, scopeChannel?: string | null): Promise<ReactTestInstance> {
+  await act(async () => {
+    renderer = create(
+      <LocaleProvider>
+        <LocalAgentsOverview t={t} adapter={a} scheduler={noScheduler} scopeChannel={scopeChannel ?? null} />
+      </LocaleProvider>,
+    );
+  });
+  // flush the mount refresh() microtasks
+  await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+  return renderer!.root;
+}
+
+function byClass(root: ReactTestInstance, cls: string): ReactTestInstance[] {
+  return root.findAll((n) => String(n.props.className ?? "").split(/\s+/).includes(cls));
+}
+function groupLabels(root: ReactTestInstance): string[] {
+  return byClass(root, "local-agents-group").map((g) => String(g.props["aria-label"]));
+}
+function names(root: ReactTestInstance): string[] {
+  return byClass(root, "local-agents-name").map((n) => n.children.filter((c): c is string => typeof c === "string").join(""));
+}
+
+test("按频道分组渲染 app 实例 + 常驻，未分配排最后", async () => {
+  const root = await render(adapter({
+    statusAll: async () => [
+      inst({ name: "web-planner", channel: "web", instanceId: "a:web" }),
+      inst({ name: "ops-builder", channel: "ops", instanceId: "b:ops" }),
+      inst({ name: "orphan", channel: null, instanceId: null, configId: "o" }),
+    ],
+    dutyList: async () => [duty({ instanceId: "c:ops", loaded: true })],
+  }));
+  // 频道升序 + 未分配(unassigned)最后
+  expect(groupLabels(root)).toEqual(["ops", "web", "unassigned"]);
+  // ops 组内常驻(c)在实例(ops-builder)前
+  const opsGroup = byClass(root, "local-agents-group")[0]!;
+  expect(byClass(opsGroup, "local-agents-name").map((n) => n.children.join(""))).toEqual(["c", "ops-builder"]);
+});
+
+test("检索按频道/身份/runner/状态过滤", async () => {
+  const root = await render(adapter({
+    statusAll: async () => [
+      inst({ name: "planner", channel: "ops", runner: "codex", instanceId: "a:ops" }),
+      inst({ name: "builder", channel: "web", runner: "claude", state: "failed", instanceId: "b:web" }),
+    ],
+  }));
+  expect(names(root).sort()).toEqual(["builder", "planner"]);
+  const search = root.find((n) => n.props.className?.includes?.("local-agents-search"));
+  await act(async () => { search.props.onChange({ target: { value: "claude" } }); });
+  expect(names(root)).toEqual(["builder"]);
+  await act(async () => { search.props.onChange({ target: { value: "ops" } }); });
+  expect(names(root)).toEqual(["planner"]);
+});
+
+test("scopeChannel 预过滤到当前频道（频道页唤起）", async () => {
+  const root = await render(adapter({
+    statusAll: async () => [
+      inst({ name: "planner", channel: "ops", instanceId: "a:ops" }),
+      inst({ name: "builder", channel: "web", instanceId: "b:web" }),
+    ],
+  }), "web");
+  expect(groupLabels(root)).toEqual(["web"]);
+  expect(names(root)).toEqual(["builder"]);
+});
+
+test("statusAll 与 dutyList 都不可用 → 显示不可用文案", async () => {
+  const root = await render(adapter({
+    statusAll: async () => { throw new Error("na"); },
+    status: async () => { throw new Error("na"); },
+    dutyList: async () => { throw new Error("na"); },
+  }));
+  expect(byClass(root, "local-agents-empty")[0]!.children.join("")).toBe(LocalAgentsOverviewStrings.en["LocalAgents.unavailable"]);
+});
+
+test("停止活跃实例调 stopInstance；卸载常驻调 dutyUnpersist", async () => {
+  const stopped: string[] = [];
+  const unloaded: string[] = [];
+  const root = await render(adapter({
+    statusAll: async () => [inst({ name: "planner", channel: "ops", state: "running", instanceId: "a:ops" })],
+    dutyList: async () => [duty({ instanceId: "d:ops", loaded: true })],
+    stopInstance: async (id) => { stopped.push(id); return inst({ state: "stopped" }); },
+    dutyUnpersist: async (id) => { unloaded.push(id); },
+  }));
+  await act(async () => { byClass(root, "local-agents-stop")[0]!.props.onClick(); await Promise.resolve(); });
+  await act(async () => { byClass(root, "local-agents-unload")[0]!.props.onClick(); await Promise.resolve(); });
+  expect(stopped).toEqual(["a:ops"]);
+  expect(unloaded).toEqual(["d:ops"]);
+});

--- a/web/src/components/LocalAgentsOverview.tsx
+++ b/web/src/components/LocalAgentsOverview.tsx
@@ -1,0 +1,190 @@
+// #700：本机 agent 概览——独立弹窗、全局按频道视角、可检索。
+// 与 DesktopAgentPanel（设置里的「启动器」，管单次起停 + 转常驻）互补：这里是「监控/管理」面
+// ——把 app 内实例（statusAll）与 launchd 常驻（dutyList）归一、按频道分组、支持检索，并就地停止/卸载。
+// 可从频道页工具条唤起（scopeChannel 预过滤到当前频道），也可全局打开。
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { TFunc } from "../i18n/useT";
+import {
+  desktopAgentAdapter,
+  type DesktopAgentAdapter,
+  type DesktopAgentStatus,
+  type DesktopDutyEntry,
+} from "../lib/desktopAgent";
+import { aggregateLocalAgents, filterLocalAgents, groupLocalAgentsByChannel } from "../lib/localAgents";
+import type { DesktopAgentScheduler } from "./DesktopAgentPanel";
+import "../i18n/strings/LocalAgentsOverview";
+
+const defaultScheduler: DesktopAgentScheduler = {
+  every(callback, intervalMs) {
+    const timer = globalThis.setInterval(callback, intervalMs);
+    return () => globalThis.clearInterval(timer);
+  },
+};
+
+interface Props {
+  t: TFunc;
+  adapter?: DesktopAgentAdapter;
+  scheduler?: DesktopAgentScheduler;
+  // 从频道页唤起时预过滤到该频道（点 ①「频道里能管理」）；全局打开则不传，看全部。
+  scopeChannel?: string | null;
+}
+
+function isActive(state: string): boolean {
+  return state === "starting" || state === "running" || state === "stopping";
+}
+
+export function LocalAgentsOverview({ t, adapter = desktopAgentAdapter, scheduler = defaultScheduler, scopeChannel = null }: Props) {
+  // available=null 未探测；false=不可用（非 macOS/旧壳，statusAll 与 dutyList 都失败）。
+  const [available, setAvailable] = useState<boolean | null>(null);
+  const [instances, setInstances] = useState<DesktopAgentStatus[]>([]);
+  const [duties, setDuties] = useState<DesktopDutyEntry[]>([]);
+  const [query, setQuery] = useState("");
+  const [busy, setBusy] = useState(false);
+  const aliveRef = useRef(true);
+  const opRef = useRef(false);
+
+  const refresh = async (): Promise<void> => {
+    let anyOk = false;
+    let nextInstances: DesktopAgentStatus[] = [];
+    try {
+      nextInstances = await adapter.statusAll();
+      anyOk = true;
+    } catch {
+      try {
+        const single = await adapter.status();
+        nextInstances = single.instanceId !== null || single.state !== "stopped" ? [single] : [];
+        anyOk = true;
+      } catch {
+        // statusAll 与 status 都失败：本机 agent 不可用
+      }
+    }
+    let nextDuties: DesktopDutyEntry[] = [];
+    try {
+      nextDuties = await adapter.dutyList();
+      anyOk = true;
+    } catch {
+      // 非 macOS / 旧壳：无常驻，忽略
+    }
+    if (!aliveRef.current) return;
+    // 只列活跃/存在的实例：stopped 且无 instanceId 的空位不进概览（与启动器的完整实例表不同）。
+    setInstances(nextInstances.filter((item) => item.state !== "stopped" || item.instanceId !== null));
+    setDuties(nextDuties);
+    setAvailable(anyOk);
+  };
+
+  useEffect(() => {
+    aliveRef.current = true;
+    void refresh();
+    const cancel = scheduler.every(() => void refresh(), 3_000);
+    return () => {
+      aliveRef.current = false;
+      cancel();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [adapter, scheduler]);
+
+  const groups = useMemo(() => {
+    const rows = aggregateLocalAgents(instances, duties);
+    const scoped = scopeChannel === null || scopeChannel === "" ? rows : rows.filter((row) => row.channel === scopeChannel);
+    return groupLocalAgentsByChannel(filterLocalAgents(scoped, query));
+  }, [instances, duties, query, scopeChannel]);
+
+  const runAction = async (action: () => Promise<unknown>): Promise<void> => {
+    if (opRef.current) return;
+    opRef.current = true;
+    setBusy(true);
+    try {
+      await action();
+      await refresh();
+    } catch {
+      // 就地动作失败：下一轮轮询会纠正显示，不弹错打断概览。
+    } finally {
+      opRef.current = false;
+      if (aliveRef.current) setBusy(false);
+    }
+  };
+
+  const totalRows = groups.reduce((sum, g) => sum + g.rows.length, 0);
+
+  return (
+    <section className="local-agents" aria-labelledby="local-agents-title">
+      <header className="local-agents-head">
+        <strong id="local-agents-title">{t("LocalAgents.title")}</strong>
+        <p className="local-agents-subtitle">{t("LocalAgents.subtitle")}</p>
+      </header>
+
+      {available === false ? (
+        <p className="local-agents-empty" role="status">{t("LocalAgents.unavailable")}</p>
+      ) : (
+        <>
+          <input
+            type="search"
+            className="local-agents-search t-mono"
+            name="local-agents-search"
+            value={query}
+            placeholder={t("LocalAgents.search")}
+            aria-label={t("LocalAgents.searchLabel")}
+            autoComplete="off"
+            spellCheck={false}
+            onChange={(event) => setQuery(event.target.value)}
+          />
+
+          {totalRows === 0 ? (
+            <p className="local-agents-empty" role="status">
+              {query.trim() !== "" ? t("LocalAgents.emptyFiltered") : t("LocalAgents.empty")}
+            </p>
+          ) : (
+            <div className="local-agents-groups">
+              {groups.map((group) => (
+                <section key={group.channel || "unassigned"} className="local-agents-group" aria-label={group.channel || t("LocalAgents.unassigned")}>
+                  <h4 className="local-agents-group-title">
+                    <span className="t-mono">{group.channel || t("LocalAgents.unassigned")}</span>
+                    <span className="local-agents-group-count">{t("LocalAgents.count", { count: group.rows.length })}</span>
+                  </h4>
+                  <ul className="local-agents-list">
+                    {group.rows.map((row) => (
+                      <li key={row.key} className={`local-agents-row local-agents-row--${row.kind}`}>
+                        <span className={`local-agents-badge local-agents-badge--${row.kind}`}>
+                          {t(row.kind === "duty" ? "LocalAgents.kind.duty" : "LocalAgents.kind.instance")}
+                        </span>
+                        <span className="t-mono local-agents-name">{row.name}</span>
+                        {row.runner !== null && <span className="local-agents-runner">{row.runner}</span>}
+                        <span className={`desktop-agent-state desktop-agent-state--${row.state}`}>
+                          {row.kind === "duty"
+                            ? t(row.duty!.loaded ? "DesktopSettings.agent.dutyLoaded" : "DesktopSettings.agent.dutyNotLoaded")
+                            : t(`DesktopSettings.agent.state.${row.state}`)}
+                        </span>
+                        {row.kind === "instance" && row.instanceId !== null && isActive(row.state) && (
+                          <button
+                            type="button"
+                            className="d-btn local-agents-stop"
+                            disabled={busy}
+                            aria-label={`${t("DesktopSettings.agent.instanceStop")} ${row.instanceId}`}
+                            onClick={() => void runAction(() => adapter.stopInstance(row.instanceId!))}
+                          >
+                            {t("DesktopSettings.agent.instanceStop")}
+                          </button>
+                        )}
+                        {row.kind === "duty" && (
+                          <button
+                            type="button"
+                            className="d-btn local-agents-unload"
+                            disabled={busy}
+                            aria-label={`${t("DesktopSettings.agent.dutyUnload")} ${row.instanceId}`}
+                            onClick={() => void runAction(() => adapter.dutyUnpersist(row.instanceId!))}
+                          >
+                            {t("DesktopSettings.agent.dutyUnload")}
+                          </button>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </section>
+  );
+}

--- a/web/src/components/LocalAgentsOverview.tsx
+++ b/web/src/components/LocalAgentsOverview.tsx
@@ -42,8 +42,12 @@ export function LocalAgentsOverview({ t, adapter = desktopAgentAdapter, schedule
   const [busy, setBusy] = useState(false);
   const aliveRef = useRef(true);
   const opRef = useRef(false);
+  // #707 评审：挂载刷新 / 轮询 / 操作后刷新可并发，早发的请求后到会把新快照覆盖成旧的。
+  // 单调序号——只让「最新一次 refresh」的结果落地，乱序完成的旧结果丢弃。
+  const refreshSeqRef = useRef(0);
 
   const refresh = async (): Promise<void> => {
+    const seq = ++refreshSeqRef.current;
     let anyOk = false;
     let nextInstances: DesktopAgentStatus[] = [];
     try {
@@ -65,7 +69,7 @@ export function LocalAgentsOverview({ t, adapter = desktopAgentAdapter, schedule
     } catch {
       // 非 macOS / 旧壳：无常驻，忽略
     }
-    if (!aliveRef.current) return;
+    if (!aliveRef.current || seq !== refreshSeqRef.current) return;
     // 只列活跃/存在的实例：stopped 且无 instanceId 的空位不进概览（与启动器的完整实例表不同）。
     setInstances(nextInstances.filter((item) => item.state !== "stopped" || item.instanceId !== null));
     setDuties(nextDuties);
@@ -78,6 +82,7 @@ export function LocalAgentsOverview({ t, adapter = desktopAgentAdapter, schedule
     const cancel = scheduler.every(() => void refresh(), 3_000);
     return () => {
       aliveRef.current = false;
+      refreshSeqRef.current += 1;
       cancel();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/web/src/i18n/strings/LocalAgentsOverview.ts
+++ b/web/src/i18n/strings/LocalAgentsOverview.ts
@@ -1,0 +1,36 @@
+import { registerDict, type LocaleDict } from "../dict";
+
+// #700：本机 agent 概览——按频道分组 + 可检索的独立面板/弹窗。文案与 DesktopSettings.agent.* 互补，
+// 复用其 state.* / instanceStop / dutyUnload / dutyLoaded 等键，这里只加概览特有的标题、搜索、空态。
+export const LocalAgentsOverviewStrings: LocaleDict = {
+  en: {
+    "LocalAgents.title": "Local agents",
+    "LocalAgents.subtitle": "Every agent running on this machine — app instances and system-resident (launchd) duties — grouped by channel.",
+    "LocalAgents.search": "Search by channel, identity, runner, or state",
+    "LocalAgents.searchLabel": "Search local agents",
+    "LocalAgents.empty": "No local agents are running on this machine.",
+    "LocalAgents.emptyFiltered": "No local agents match this search.",
+    "LocalAgents.unavailable": "Local agents are unavailable (non-macOS host or an older desktop shell).",
+    "LocalAgents.unassigned": "unassigned",
+    "LocalAgents.kind.instance": "app",
+    "LocalAgents.kind.duty": "resident",
+    "LocalAgents.count": "{count} agent(s)",
+    "LocalAgents.close": "Close",
+  },
+  zh: {
+    "LocalAgents.title": "本机 agent",
+    "LocalAgents.subtitle": "这台机器上跑着的每个 agent——app 内实例 + 系统常驻（launchd）——按频道归组。",
+    "LocalAgents.search": "按频道、身份、运行器或状态检索",
+    "LocalAgents.searchLabel": "检索本机 agent",
+    "LocalAgents.empty": "这台机器上没有本机 agent 在跑。",
+    "LocalAgents.emptyFiltered": "没有匹配此检索的本机 agent。",
+    "LocalAgents.unavailable": "本机 agent 不可用（非 macOS 或较旧的桌面壳）。",
+    "LocalAgents.unassigned": "未分配频道",
+    "LocalAgents.kind.instance": "app",
+    "LocalAgents.kind.duty": "常驻",
+    "LocalAgents.count": "{count} 个",
+    "LocalAgents.close": "关闭",
+  },
+};
+
+registerDict(LocalAgentsOverviewStrings);

--- a/web/src/lib/localAgents.test.ts
+++ b/web/src/lib/localAgents.test.ts
@@ -55,13 +55,22 @@ describe("aggregateLocalAgents", () => {
     expect(dty).toMatchObject({ channel: "bug001", name: "cfg2", state: "loaded", runner: null });
   });
 
-  test("unloaded duty reports state 'unloaded'; null instance channel → empty", () => {
+  test("unloaded duty reports state 'unloaded'; null channel + null instanceId → empty", () => {
     const rows = aggregateLocalAgents(
       [instance({ channel: null, instanceId: null, configId: "c", name: "x" })],
       [duty({ instanceId: "c:ch", loaded: false })],
     );
     expect(rows.find((r) => r.kind === "instance")!.channel).toBe("");
     expect(rows.find((r) => r.kind === "duty")!.state).toBe("unloaded");
+  });
+
+  test("channel 为 null 但 instanceId 含 configId:channel → 从 instanceId 回退频道（#707 评审）", () => {
+    const rows = aggregateLocalAgents(
+      [instance({ channel: null, instanceId: "cfg:web", name: "planner" })],
+      [],
+    );
+    // 不因 channel 字段缺失就误归「未分配」——否则频道页 scopeChannel 会过滤掉它
+    expect(rows[0]!.channel).toBe("web");
   });
 });
 

--- a/web/src/lib/localAgents.test.ts
+++ b/web/src/lib/localAgents.test.ts
@@ -1,0 +1,103 @@
+// @ts-expect-error Bun executes this test, while the web tsconfig intentionally loads only Vite globals.
+import { describe, expect, test } from "bun:test";
+import type { DesktopAgentStatus, DesktopDutyEntry } from "./desktopAgent";
+import {
+  aggregateLocalAgents,
+  channelOfInstanceId,
+  configIdOfInstanceId,
+  filterLocalAgents,
+  groupLocalAgentsByChannel,
+} from "./localAgents";
+
+function instance(over: Partial<DesktopAgentStatus>): DesktopAgentStatus {
+  return {
+    state: "running",
+    pid: null,
+    configId: "cfg",
+    name: "planner",
+    channel: "ops",
+    runner: "codex",
+    startedAt: null,
+    exitCode: null,
+    lastError: null,
+    instanceId: "cfg:ops",
+    workdir: null,
+    repo: null,
+    ...over,
+  };
+}
+
+function duty(over: Partial<DesktopDutyEntry>): DesktopDutyEntry {
+  return { label: "l", instanceId: "cfg:ops", plistPath: "/p", logPath: "/log", loaded: true, ...over };
+}
+
+describe("channelOfInstanceId / configIdOfInstanceId", () => {
+  test("splits at first colon", () => {
+    expect(channelOfInstanceId("abc123:guessadmin")).toBe("guessadmin");
+    expect(configIdOfInstanceId("abc123:guessadmin")).toBe("abc123");
+  });
+  test("no colon → channel unknown, whole is configId", () => {
+    expect(channelOfInstanceId("abc123")).toBe("");
+    expect(configIdOfInstanceId("abc123")).toBe("abc123");
+  });
+});
+
+describe("aggregateLocalAgents", () => {
+  test("merges instances and duties into unified rows with parsed channels", () => {
+    const rows = aggregateLocalAgents(
+      [instance({ name: "planner", channel: "ops", runner: "codex", state: "running", instanceId: "cfg:ops" })],
+      [duty({ instanceId: "cfg2:bug001", loaded: true })],
+    );
+    expect(rows).toHaveLength(2);
+    const inst = rows.find((r) => r.kind === "instance")!;
+    expect(inst).toMatchObject({ channel: "ops", name: "planner", runner: "codex", state: "running" });
+    const dty = rows.find((r) => r.kind === "duty")!;
+    expect(dty).toMatchObject({ channel: "bug001", name: "cfg2", state: "loaded", runner: null });
+  });
+
+  test("unloaded duty reports state 'unloaded'; null instance channel → empty", () => {
+    const rows = aggregateLocalAgents(
+      [instance({ channel: null, instanceId: null, configId: "c", name: "x" })],
+      [duty({ instanceId: "c:ch", loaded: false })],
+    );
+    expect(rows.find((r) => r.kind === "instance")!.channel).toBe("");
+    expect(rows.find((r) => r.kind === "duty")!.state).toBe("unloaded");
+  });
+});
+
+describe("filterLocalAgents", () => {
+  const rows = aggregateLocalAgents(
+    [
+      instance({ name: "planner", channel: "ops", runner: "codex", state: "running", instanceId: "a:ops" }),
+      instance({ name: "builder", channel: "web", runner: "claude", state: "failed", instanceId: "b:web" }),
+    ],
+    [duty({ instanceId: "c:ops", loaded: true })],
+  );
+  test("empty query passes all", () => {
+    expect(filterLocalAgents(rows, "")).toHaveLength(3);
+    expect(filterLocalAgents(rows, "   ")).toHaveLength(3);
+  });
+  test("matches by channel / name / runner / state, case-insensitive", () => {
+    expect(filterLocalAgents(rows, "ops").map((r) => r.key).sort()).toEqual(["duty:c:ops", "instance:a:ops"]);
+    expect(filterLocalAgents(rows, "PLANNER").map((r) => r.name)).toEqual(["planner"]);
+    expect(filterLocalAgents(rows, "claude").map((r) => r.name)).toEqual(["builder"]);
+    expect(filterLocalAgents(rows, "failed").map((r) => r.name)).toEqual(["builder"]);
+  });
+});
+
+describe("groupLocalAgentsByChannel", () => {
+  test("groups by channel, sorted asc, unknown channel last; duty before instance within a group", () => {
+    const rows = aggregateLocalAgents(
+      [
+        instance({ name: "z", channel: "web", instanceId: "z:web" }),
+        instance({ name: "a", channel: "ops", instanceId: "a:ops" }),
+        instance({ name: "orphan", channel: null, instanceId: null, configId: "o" }),
+      ],
+      [duty({ instanceId: "d:ops", loaded: true })],
+    );
+    const groups = groupLocalAgentsByChannel(rows);
+    expect(groups.map((g) => g.channel)).toEqual(["ops", "web", ""]);
+    // ops group: duty (d) before instance (a)
+    expect(groups[0]!.rows.map((r) => r.kind)).toEqual(["duty", "instance"]);
+  });
+});

--- a/web/src/lib/localAgents.ts
+++ b/web/src/lib/localAgents.ts
@@ -1,0 +1,107 @@
+// #700：把「本机 agent」从设置里埋着的一段列表，抽成一个「全局按频道视角 + 可检索」的概览。
+// 数据来源两路——app 内实例（statusAll，DesktopAgentStatus）+ launchd 常驻（dutyList，DesktopDutyEntry），
+// 归一成 LocalAgentRow，按频道分组、可按频道/身份/runner/状态检索。纯函数，便于单测；渲染与动作在组件层。
+import type { DesktopAgentStatus, DesktopDutyEntry } from "./desktopAgent";
+
+export type LocalAgentKind = "instance" | "duty";
+
+export interface LocalAgentRow {
+  /** 稳定 react key。 */
+  key: string;
+  kind: LocalAgentKind;
+  /** 归属频道；未知（拿不到）时为 ""，分组时归入「未分配」并排最后。 */
+  channel: string;
+  /** 展示名：实例用 name，常驻用 instanceId 的 configId 段。 */
+  name: string;
+  runner: string | null;
+  /** 归一状态标签：实例用 state；常驻用 loaded→"loaded"/"unloaded"。 */
+  state: string;
+  instanceId: string | null;
+  /** 原始引用，供动作层（停止/卸载/看日志）回指。 */
+  instance?: DesktopAgentStatus;
+  duty?: DesktopDutyEntry;
+}
+
+// 常驻 instanceId 形如 `${configId}:${channel}`：configId 无冒号、channel 是 slug（无冒号），
+// 取第一个冒号后为 channel、之前为 configId。无冒号则整体当 configId、频道未知。
+export function channelOfInstanceId(instanceId: string): string {
+  const idx = instanceId.indexOf(":");
+  return idx >= 0 ? instanceId.slice(idx + 1) : "";
+}
+
+export function configIdOfInstanceId(instanceId: string): string {
+  const idx = instanceId.indexOf(":");
+  return idx >= 0 ? instanceId.slice(0, idx) : instanceId;
+}
+
+// 归一两路数据源为统一行。instances 的 channel 直接来自字段（可能为 null → ""）；
+// duties 的 channel 从 instanceId 解析。不去重：同一 (configId,channel) 既可有 app 内实例、也可有
+// launchd 常驻（转常驻会停 app 内同键实例，但列表是各自的真相，都要看得见）。
+export function aggregateLocalAgents(
+  instances: readonly DesktopAgentStatus[],
+  duties: readonly DesktopDutyEntry[],
+): LocalAgentRow[] {
+  const rows: LocalAgentRow[] = [];
+  for (const item of instances) {
+    const instanceId = item.instanceId ?? (item.configId !== null && item.channel !== null ? `${item.configId}:${item.channel}` : null);
+    rows.push({
+      key: `instance:${instanceId ?? `${item.configId ?? "?"}:${item.channel ?? "?"}`}`,
+      kind: "instance",
+      channel: item.channel ?? "",
+      name: item.name ?? item.configId ?? "?",
+      runner: item.runner,
+      state: item.state,
+      instanceId,
+      instance: item,
+    });
+  }
+  for (const duty of duties) {
+    rows.push({
+      key: `duty:${duty.instanceId}`,
+      kind: "duty",
+      channel: channelOfInstanceId(duty.instanceId),
+      name: configIdOfInstanceId(duty.instanceId),
+      runner: null,
+      state: duty.loaded ? "loaded" : "unloaded",
+      instanceId: duty.instanceId,
+      duty,
+    });
+  }
+  return rows;
+}
+
+// 大小写不敏感、按频道/身份/runner/状态任一子串匹配。空查询=全通过。
+export function filterLocalAgents(rows: readonly LocalAgentRow[], query: string): LocalAgentRow[] {
+  const q = query.trim().toLowerCase();
+  if (q === "") return [...rows];
+  return rows.filter((row) => {
+    const haystack = [row.channel, row.name, row.runner ?? "", row.state, row.kind].join(" ").toLowerCase();
+    return haystack.includes(q);
+  });
+}
+
+export interface LocalAgentChannelGroup {
+  channel: string;
+  rows: LocalAgentRow[];
+}
+
+// 按频道分组：频道名升序（localeCompare），未分配（channel==""）永远排最后。
+// 组内先常驻后实例、再按名字，给出稳定顺序。
+export function groupLocalAgentsByChannel(rows: readonly LocalAgentRow[]): LocalAgentChannelGroup[] {
+  const byChannel = new Map<string, LocalAgentRow[]>();
+  for (const row of rows) {
+    const list = byChannel.get(row.channel);
+    if (list === undefined) byChannel.set(row.channel, [row]);
+    else list.push(row);
+  }
+  const channels = [...byChannel.keys()].sort((a, b) => {
+    if (a === "") return 1;
+    if (b === "") return -1;
+    return a.localeCompare(b);
+  });
+  const kindRank: Record<LocalAgentKind, number> = { duty: 0, instance: 1 };
+  return channels.map((channel) => ({
+    channel,
+    rows: byChannel.get(channel)!.slice().sort((a, b) => kindRank[a.kind] - kindRank[b.kind] || a.name.localeCompare(b.name)),
+  }));
+}

--- a/web/src/lib/localAgents.ts
+++ b/web/src/lib/localAgents.ts
@@ -47,7 +47,9 @@ export function aggregateLocalAgents(
     rows.push({
       key: `instance:${instanceId ?? `${item.configId ?? "?"}:${item.channel ?? "?"}`}`,
       kind: "instance",
-      channel: item.channel ?? "",
+      // channel 字段优先；缺失时从 instanceId(configId:channel) 回退解析，别把带 instanceId 的实例
+      // 误归「未分配」而被频道页 scopeChannel 过滤掉（#707 评审）。
+      channel: item.channel ?? (instanceId === null ? "" : channelOfInstanceId(instanceId)),
       name: item.name ?? item.configId ?? "?",
       runner: item.runner,
       state: item.state,

--- a/web/src/pages/Channel.tsx
+++ b/web/src/pages/Channel.tsx
@@ -11,6 +11,7 @@ import { VisibilityToggle } from "../components/VisibilityToggle";
 import { JoinLink } from "../components/JoinLink";
 import { JoinRequestBanner } from "../components/JoinRequestBanner";
 import { OutdatedAgentsNotice } from "../components/OutdatedAgentsNotice";
+import { LocalAgentsOverview } from "../components/LocalAgentsOverview";
 import { Composer, type UploadItem } from "../components/Composer";
 import { Markdown } from "../components/Markdown";
 import { MessageCard } from "../components/MessageCard";
@@ -197,7 +198,7 @@ export interface RoleDraft {
   responsibility: string;
 }
 
-type ChannelPanel = "charter" | "team" | "tasks" | "search" | "settings";
+type ChannelPanel = "charter" | "team" | "tasks" | "search" | "settings" | "localAgents";
 type AdminSurface = "agentJoin" | "agentTokens" | "joinLink";
 const TASK_BOARD_STATES: readonly TaskState[] = ["triage", "backlog", "assigned", "in_progress", "needs_review", "blocked", "done"];
 
@@ -4314,6 +4315,13 @@ export function ChannelPage({
             <span>{t("Channel.tools.search")}</span>
             {q !== "" && <span className="t-mono chan-tool-badge">{searchLoading ? "..." : searchHits.length}</span>}
           </button>
+          {/* #700：本机 agent 概览——桌面端才有本机 agent，故仅桌面壳露此入口；打开的面板预过滤到本频道。 */}
+          {isDesktopRuntime() && (
+            <button type="button" className="d-btn chan-tool-btn" onClick={() => openPanel("localAgents")}>
+              <span className="ap-sprite ap-sprite--agent" aria-hidden="true" />
+              <span>{t("LocalAgents.title")}</span>
+            </button>
+          )}
           </>
         }
         actions={
@@ -4397,6 +4405,7 @@ export function ChannelPage({
             activePanel === "team" ? t("Channel.tools.team") :
             activePanel === "tasks" ? t("Channel.tasks.title") :
             activePanel === "settings" ? t("Channel.tools.settings") :
+            activePanel === "localAgents" ? t("LocalAgents.title") :
             t("Channel.tools.search")
           }
           subtitle={
@@ -4531,6 +4540,8 @@ export function ChannelPage({
             />
           )}
           {activePanel === "search" && searchContent}
+          {/* #700：本机 agent 概览，预过滤到本频道（点①「频道里能管理」）。桌面专属，非桌面壳该入口不渲染。 */}
+          {activePanel === "localAgents" && <LocalAgentsOverview t={t} scopeChannel={slug} />}
         </ChannelPanelModal>
       )}
       {openAgentDetail !== null && (

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -316,6 +316,51 @@
 .desktop-agent-duties { margin-top: 12px; }
 .desktop-agent-duties-title { font-size: 12px; color: var(--t-dim); }
 
+/* #700 本机 agent 概览：按频道分组 + 可检索 */
+.local-agents { margin-top: 10px; }
+.local-agents-head { margin-bottom: 8px; }
+.local-agents-subtitle { margin: 2px 0 0; font-size: 11px; color: var(--t-dim); }
+.local-agents-search {
+  width: 100%;
+  box-sizing: border-box;
+  margin: 8px 0;
+  padding: 5px 8px;
+  font-size: 12px;
+  border: 1px solid var(--t-faint);
+  background: var(--d-bg, transparent);
+  color: inherit;
+}
+.local-agents-empty { font-size: 12px; color: var(--t-dim); margin: 10px 0; }
+.local-agents-groups { display: flex; flex-direction: column; gap: 12px; }
+.local-agents-group-title {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin: 0 0 4px;
+  font-size: 12px;
+  font-weight: 700;
+  border-bottom: 1px solid var(--t-faint);
+  padding-bottom: 2px;
+}
+.local-agents-group-count { font-size: 10px; font-weight: 400; color: var(--t-dim); }
+.local-agents-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 6px; }
+.local-agents-row { display: flex; align-items: center; gap: 8px; min-width: 0; }
+.local-agents-badge {
+  font-size: 9px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--t-dim);
+  border: 1px solid var(--t-faint);
+  border-radius: 3px;
+  padding: 0 4px;
+  flex: 0 0 auto;
+}
+.local-agents-badge--duty { color: var(--d-green-dark, var(--d-green)); }
+.local-agents-name { font-size: 12px; flex: 0 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.local-agents-runner { font-size: 11px; color: var(--t-dim); flex: 0 0 auto; }
+.local-agents-stop, .local-agents-unload { margin-left: auto; flex: 0 0 auto; }
+
 /* #616 多实例值守列表 */
 .desktop-agent-instances {
   list-style: none;


### PR DESCRIPTION
## 背景
Closes #700（拆自 #696 的面板重构诉求，崩溃部分已由 #701 修复）。

owner 对「本机 agent」面板的 4 点诉求：① 频道里也能管理；② 做成独立弹窗；③ 全局按频道视角管理；④ 可检索。

## 方案
新增 **LocalAgentsOverview**：把两路本机 agent 数据源——app 内实例（`statusAll`）+ launchd 系统常驻（`dutyList`）——归一、**按频道分组**、支持**检索**，并就地**停止实例 / 卸载常驻**。与现有 `DesktopAgentPanel`（设置里的启动器，管起停+转常驻）互补，不动它。

- **`web/src/lib/localAgents.ts`**（纯函数，全单测）：`aggregateLocalAgents` 归一、`filterLocalAgents` 检索、`groupLocalAgentsByChannel` 分组；常驻 `instanceId` 解析出 `configId:channel`。
- **频道页**（点①②）：工具条加**桌面专属**入口 → 复用 `ChannelPanelModal` 打开概览、`scopeChannel` 预过滤到本频道。
- **DesktopSettings**（点③）：挂一份**不限频道**的全局概览。
- **点④**：搜索框对 channel/identity/runner/state 客户端过滤。
- 复用 `DesktopSettings.agent.*` 状态/动作文案，新增 `LocalAgents.*` 中英；补 CSS（黑白克制风）。

## 验证
- `web` typecheck 通过；`cd web && bun test --isolate` **989 pass / 0 fail**（含 i18n 完整性与既有 DesktopSettings/DesktopAgentPanel 用例，无回归）。
- 新增单测：`localAgents.test.ts`（分组/检索/instanceId 解析）、`LocalAgentsOverview.test.tsx`（分组渲染/检索/scopeChannel 预过滤/不可用态/停止·卸载动作）。
- 桌面 UI 无法在此视觉验证——与本仓所有桌面 UI 一致，靠 adapter 注入单测覆盖逻辑。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增本机 Agent 概览：可按频道分组查看运行实例与常驻项。
  * 支持搜索筛选（频道/名称/运行器/状态），并在频道页按当前频道预过滤展示。
  * 支持停止运行实例与卸载常驻项，完成后自动刷新；不可用状态有明确提示。
  * 桌面设置与频道页新增入口/面板渲染。
  * 新增中英文界面文案及多语言字典。
* **测试**
  * 新增本机 Agent 相关渲染、交互与数据处理（解析/聚合/过滤/分组）测试覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->