### PR TITLE
feat(cli): #703 watch 挂载时提示落后版本，引导 party upgrade（免重绑）

### DIFF
--- a/cli/src/cache-slot.ts
+++ b/cli/src/cache-slot.ts
@@ -6,7 +6,7 @@ function safeChannel(channel: string): string {
   return channel.replace(/[^a-zA-Z0-9._-]/g, "_") || "channel";
 }
 
-export function cacheSlotPath(kind: "health" | "statusline", channel: string, cwd: string): string {
+export function cacheSlotPath(kind: "health" | "statusline" | "upgrade-hint", channel: string, cwd: string): string {
   const { source } = readConfigWithSource(cwd);
   const fingerprint = createHash("sha256")
     .update(JSON.stringify({ channel, kind: source.kind, path: source.path, token: source.token_fingerprint }))

--- a/cli/src/commands/watch.ts
+++ b/cli/src/commands/watch.ts
@@ -318,8 +318,6 @@ async function emitWatchUpgradeHint(server: string, channel: string): Promise<vo
 export async function runWatch(o: WatchOptions): Promise<number> {
   const rawOut = o.out ?? ((line: string) => console.log(line));
   const out = (line: string) => rawOut(o.json ? line : terminalOutput(line));
-  // #703：非 json 模式且命令层开启时，挂载即 fire-and-forget 探一次升级提示（磁盘节流，不阻塞 attach）。
-  if (o.probeUpgrade === true && !o.json) void emitWatchUpgradeHint(o.server, o.channel);
   // Only the single-shot watcher whose caller can persist and acknowledge directed debt is an
   // actionable v1 adapter. Declare this in the first hello so the Worker never has to guess in the
   // welcome -> register window; observers deliberately omit the capability.
@@ -349,6 +347,10 @@ export async function runWatch(o: WatchOptions): Promise<number> {
     );
     return EXIT_ALREADY_WATCHING;
   }
+  // #703：升级提示放在抢到实例锁之后——只有持锁的那个 watcher 会探测，靠既有实例锁串行化，
+  // 天然消除「两个进程都过节流读取、各自探测」的竞态（#715 评审），无需另造原子租约。
+  // 非 json、命令层开启时才探；fire-and-forget，不阻塞 attach；磁盘节流仍限 6h/次。
+  if (o.probeUpgrade === true && !o.json) void emitWatchUpgradeHint(o.server, o.channel);
   // Capture transport interruptions by generation. A delivery received after an earlier reconnect
   // may proceed, but a disconnect between update and ACK invalidates that exact claim attempt.
   let connectionGeneration = 0;

--- a/cli/src/commands/watch.ts
+++ b/cli/src/commands/watch.ts
@@ -25,7 +25,9 @@ import {
 } from "../config";
 import { resolveAuthDetailed, type ResolvedAuthDetailed } from "../oidc-cli";
 import { formatMsg, stripTerminalControls } from "../format";
-import { fetchMe, fetchMessages, fetchRecentMessages, handleRestError, postMessage } from "../rest";
+import { fetchMe, fetchMessages, fetchRecentMessages, fetchServerVersion, handleRestError, postMessage } from "../rest";
+import { upgradeHintForServer } from "../upgrade";
+import { shouldProbeUpgrade } from "../upgrade-hint-cache";
 import { buildContext } from "./status";
 import { MAX_TIMEOUT_SEC, isSlug, parseNonNegativeIntFlag, parsePositiveIntFlag } from "../validation";
 import { jsonFrame, nowTs } from "../json";
@@ -161,6 +163,9 @@ export interface WatchOptions {
   out?: (line: string) => void;
   backoffBaseMs?: number;
   statusline?: boolean;
+  /** #703：挂载时 best-effort 探一次服务端版本，落后/低于 min 就打非阻断升级提示（磁盘节流 6h 一次）。
+   *  命令层默认开；单测构造 WatchOptions 不设 → 不探测、不发网络，既有用例零影响。 */
+  probeUpgrade?: boolean;
   /** 单实例锁目录（#195/#465）。默认全机共享、再按 server/token 身份隔离；测试注入。 */
   lockDir?: string;
   /** 关掉单实例保护（逃生舱）。 */
@@ -297,9 +302,24 @@ async function resolveExplicitWatchCursor(
   };
 }
 
+// #703：挂在 watch 上的 agent 此前收不到「你落后于最新 / 低于 min」的升级提示（只有 serve/mcp 有），
+// 于是常年靠人肉重发接入包 + curl install.sh + 重绑。挂载时 best-effort 探一次服务端版本，落后就打一条
+// 非阻断 stderr 提示，引导 `party upgrade`（原地换二进制、免重绑）。磁盘节流每 6h 一次，探测失败静默。
+async function emitWatchUpgradeHint(server: string, channel: string): Promise<void> {
+  if (!shouldProbeUpgrade(channel, process.cwd(), Date.now())) return;
+  try {
+    const hint = upgradeHintForServer(await fetchServerVersion(server));
+    if (hint !== null) console.error(stripTerminalControls(`watch: ${hint}`));
+  } catch {
+    // 版本探测是增益信号，不是墙——拿不到就静默，绝不因它把 watch 搞挂。
+  }
+}
+
 export async function runWatch(o: WatchOptions): Promise<number> {
   const rawOut = o.out ?? ((line: string) => console.log(line));
   const out = (line: string) => rawOut(o.json ? line : terminalOutput(line));
+  // #703：非 json 模式且命令层开启时，挂载即 fire-and-forget 探一次升级提示（磁盘节流，不阻塞 attach）。
+  if (o.probeUpgrade === true && !o.json) void emitWatchUpgradeHint(o.server, o.channel);
   // Only the single-shot watcher whose caller can persist and acknowledge directed debt is an
   // actionable v1 adapter. Declare this in the first hello so the Worker never has to guess in the
   // welcome -> register window; observers deliberately omit the capability.
@@ -1087,6 +1107,8 @@ export async function run(argv: string[]): Promise<number> {
     statusline: true,
     allowMultiple: flags["allow-multiple"] === true,
     ensure,
+    // #703：真实 watch 调用默认探升级提示（磁盘节流 6h/次）；单测直接构造 WatchOptions 不设此项，行为不变。
+    probeUpgrade: true,
     // #675：可唤醒声明改走带内 presence（hello.wake_kind），默认不往时间线发 waiting 状态消息。
     advertiseWakeKind: "watch",
     // 只有 --status 显式要人类可见的挂载广播时才往时间线发一条（旧行为，opt-in）。

--- a/cli/src/upgrade-hint-cache.ts
+++ b/cli/src/upgrade-hint-cache.ts
@@ -1,0 +1,33 @@
+// #703：watch --once 每轮重挂都是新进程，内存节流拦不住。用磁盘时间戳把「探一次服务端版本 + 打升级
+// 提示」限到每 TTL 一次（默认 6h），既避免每轮重挂都发 /api/version（延迟/请求数敏感），也不刷 stderr。
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { cacheSlotPath } from "./cache-slot";
+
+// 升级提示探测节流窗口：behind-latest 是增益信号，不必频繁——6 小时一次足够温和又不烦。
+export const UPGRADE_HINT_TTL_MS = 6 * 60 * 60 * 1000;
+
+// 返回 true = 现在应探测（并已把「本次探测时间」落盘，消费掉本窗口的额度）；false = 仍在窗口内，跳过。
+// 消费的是「探测」额度而非「打印」额度：即便本次探测发现已是最新，也占掉窗口，故最多每 TTL 一次网络探测。
+// 全 best-effort：读不到/解析失败当作「该探测」；写失败也照常返回 true（宁可偶尔多探，不静默永不提示）。
+export function shouldProbeUpgrade(
+  channel: string,
+  cwd: string,
+  now: number,
+  ttlMs: number = UPGRADE_HINT_TTL_MS,
+): boolean {
+  const path = cacheSlotPath("upgrade-hint", channel, cwd);
+  try {
+    const at = (JSON.parse(readFileSync(path, "utf8")) as { at?: unknown }).at;
+    if (typeof at === "number" && now - at < ttlMs) return false;
+  } catch {
+    // 无记录 / 不可读 / 坏 JSON：视为该探测
+  }
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, JSON.stringify({ at: now }));
+  } catch {
+    // 落盘失败（只读 home 等）：仍返回 true，本次照常探测——大不了下轮再探一次
+  }
+  return true;
+}

--- a/cli/src/upgrade.ts
+++ b/cli/src/upgrade.ts
@@ -310,6 +310,25 @@ export function serverMinVersionNotice(
   };
 }
 
+// #703：给挂在 watch 上的 agent 一条「该升级了」的单行非阻断提示。
+// 优先级：低于服务端 min（协议可能已破，enforced 时更急）> 落后于最新发布版。都不落后则返回 null。
+// 引导用 `party upgrade`——原地校验+替换二进制、**无需重跑接入包 / party init 重绑**（这正是 #703
+// owner 的痛点：agent 常年靠人肉 curl install.sh + 重绑）。装二进制失败的兜底安装串仍随附。
+export function upgradeHintForServer(
+  serverVersion: { version: string; min_client_version: string; min_client_enforced: boolean },
+  deps: { runningVersion?: string } = {},
+): string | null {
+  const min = serverMinVersionNotice(serverVersion.min_client_version, serverVersion.min_client_enforced, deps);
+  if (min !== null) {
+    return `${min.message} 原地升级：party upgrade（回退：${INSTALL_LINE}）`;
+  }
+  const behind = serverVersionUpgradeNotice(serverVersion.version, deps);
+  if (behind !== null) {
+    return `party CLI 有新版 v${behind.available_version}（当前 v${behind.running_version}）。原地升级：party upgrade，无需重跑接入包/重绑。`;
+  }
+  return null;
+}
+
 // re-exec 磁盘上的新二进制：spawn 同 argv、继承 stdio、detach，然后让调用方退出。
 // PID 会变——launchctl KeepAlive 天然重启；nohup 场景新进程接管（旧进程退出）。
 function defaultReexec(execPath: string, argv: string[]): void {

--- a/cli/test/upgrade-hint-cache.test.ts
+++ b/cli/test/upgrade-hint-cache.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { shouldProbeUpgrade, UPGRADE_HINT_TTL_MS } from "../src/upgrade-hint-cache";
+
+// shouldProbeUpgrade 的落盘目录由 AGENTPARTY_HOME 决定（cache-slot → config.agentpartyHome）。
+// 用临时 home 隔离，避免碰真实 ~/.agentparty。
+let home: string;
+let cwd: string;
+const origHome = process.env.AGENTPARTY_HOME;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "ap-uhc-home-"));
+  cwd = mkdtempSync(join(tmpdir(), "ap-uhc-cwd-"));
+  process.env.AGENTPARTY_HOME = home;
+  // cache-slot 会读 config 指纹；给个最小 config 让 readConfigWithSource 有据可依（缺了也只是 fingerprint 变化，不影响节流语义）。
+  writeFileSync(join(cwd, ".agentparty.json"), JSON.stringify({ server: "https://s", token: "ap_x" }));
+});
+
+afterEach(() => {
+  if (origHome === undefined) delete process.env.AGENTPARTY_HOME;
+  else process.env.AGENTPARTY_HOME = origHome;
+  rmSync(home, { recursive: true, force: true });
+  rmSync(cwd, { recursive: true, force: true });
+});
+
+test("首次探测放行并落盘；同窗口内再问被拦", () => {
+  const t0 = 1_000_000;
+  expect(shouldProbeUpgrade("kyc", cwd, t0)).toBe(true);
+  // 立即再问：仍在窗口内 → false
+  expect(shouldProbeUpgrade("kyc", cwd, t0 + 1000)).toBe(false);
+  expect(shouldProbeUpgrade("kyc", cwd, t0 + UPGRADE_HINT_TTL_MS - 1)).toBe(false);
+});
+
+test("超过 TTL 后再次放行", () => {
+  const t0 = 2_000_000;
+  expect(shouldProbeUpgrade("kyc", cwd, t0)).toBe(true);
+  expect(shouldProbeUpgrade("kyc", cwd, t0 + UPGRADE_HINT_TTL_MS)).toBe(true);
+  // 放行后又落了新时间戳，紧接着再问被拦
+  expect(shouldProbeUpgrade("kyc", cwd, t0 + UPGRADE_HINT_TTL_MS + 5)).toBe(false);
+});
+
+test("不同频道各自独立节流", () => {
+  const t0 = 3_000_000;
+  expect(shouldProbeUpgrade("kyc", cwd, t0)).toBe(true);
+  // 另一个频道第一次仍放行
+  expect(shouldProbeUpgrade("ops", cwd, t0 + 1000)).toBe(true);
+  // 各自窗口内再问都被拦
+  expect(shouldProbeUpgrade("kyc", cwd, t0 + 2000)).toBe(false);
+  expect(shouldProbeUpgrade("ops", cwd, t0 + 2000)).toBe(false);
+});

--- a/cli/test/version-negotiation.test.ts
+++ b/cli/test/version-negotiation.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { writeFileSync } from "node:fs";
 import { fetchServerVersion } from "../src/rest";
-import { RUNNING_VERSION, serverMinVersionNotice, serverVersionUpgradeNotice } from "../src/upgrade";
+import { RUNNING_VERSION, serverMinVersionNotice, serverVersionUpgradeNotice, upgradeHintForServer } from "../src/upgrade";
 import { resolveAvailableUpgrade } from "../src/commands/serve";
 
 function sha256(bytes: Uint8Array): string {
@@ -123,5 +123,46 @@ describe("CLI↔worker version negotiation (issue #137)", () => {
       action_required: "auto_reexec",
     });
     expect(installs).toEqual(["/usr/local/bin/party"]);
+  });
+});
+
+describe("upgradeHintForServer（#703：watch 挂载升级提示）", () => {
+  const server = (over: Partial<{ version: string; min_client_version: string; min_client_enforced: boolean }> = {}) => ({
+    version: "0.2.100",
+    min_client_version: "0.0.0",
+    min_client_enforced: false,
+    ...over,
+  });
+
+  test("已是最新且不低于 min → 无提示", () => {
+    expect(upgradeHintForServer(server({ version: "0.2.100" }), { runningVersion: "0.2.100" })).toBeNull();
+    expect(upgradeHintForServer(server({ version: "0.2.90" }), { runningVersion: "0.2.100" })).toBeNull();
+  });
+
+  test("落后于最新发布版 → 提示原地 party upgrade、免重绑", () => {
+    const hint = upgradeHintForServer(server({ version: "0.2.136" }), { runningVersion: "0.2.100" });
+    expect(hint).not.toBeNull();
+    expect(hint).toContain("party upgrade");
+    expect(hint).toContain("0.2.136");
+    expect(hint).toContain("无需重跑接入包");
+  });
+
+  test("低于 min 优先于落后提示（协议可能已破）", () => {
+    // 同时落后最新且低于 min：min 提示优先
+    const hint = upgradeHintForServer(
+      server({ version: "0.2.136", min_client_version: "0.2.120", min_client_enforced: false }),
+      { runningVersion: "0.2.100" },
+    );
+    expect(hint).not.toBeNull();
+    expect(hint).toContain("最低");
+    expect(hint).toContain("party upgrade");
+  });
+
+  test("enforced min → 提示措辞更硬（已被拒绝）", () => {
+    const hint = upgradeHintForServer(
+      server({ min_client_version: "9.9.9", min_client_enforced: true }),
+      { runningVersion: "0.2.100" },
+    );
+    expect(hint).toContain("已被拒绝");
   });
 });


### PR DESCRIPTION
## 背景
Closes #703

owner 反馈：kyc agent 常年挂在 `party watch --once`，接入包被反复重发、`need=` 版本一路抬高（0.2.118→136），每次都得人肉走 `curl install.sh` → `party init` 重绑 → 重挂 watch，反复打断值守。

## 根因
CLI 早已有完整的升级机制——`party upgrade`（下载+校验 sha256+原地替换）、`serve --auto-upgrade`（自动 re-exec）、版本协商（`serverVersionUpgradeNotice` / `serverMinVersionNotice`）。但这些**升级提示只在 `serve` / `mcp` 露出**，挂在 `watch` 上的 agent 收不到，于是不知道该 `party upgrade`，只能走人肉重装。

## 改动（安全、有界的一刀）
- **`upgradeHintForServer(serverVersion)`**（`upgrade.ts`，纯函数）：把「低于服务端 min」（协议可能已破，优先）与「落后最新发布版」合成一行非阻断提示，引导 **`party upgrade`**——原地换二进制、**无需重跑接入包 / 重绑**（正对 #703 痛点）。
- **`watch` 挂载时** best-effort 探一次 `/api/version`，落后就打一条 stderr 提示（fire-and-forget，不阻塞 attach）。新增 `WatchOptions.probeUpgrade`：命令层默认开；单测直接构造 `WatchOptions` 不设 → 不探测、不发网络，**既有 watch 用例零影响**。
- **磁盘节流** `upgrade-hint-cache`：`watch --once` 每轮是新进程，内存节流拦不住；用磁盘时间戳把「探测+提示」限到每 6h 一次（也避免每轮重挂都打 `/api/version`），best-effort、失败静默。

## 未做（有意）
owner 建议①的**全自动升级+重启**侵入性大（自动下载执行二进制 + re-exec）：`serve` 已有 `--auto-upgrade`；`watch` 先给**安全的非阻断提示**，不擅自 re-exec。若要 `watch --auto-upgrade` 全自动化可另议。

## 验证
- 新增测试：`upgradeHintForServer`（最新/落后/低于 min 优先/enforced 措辞）、磁盘节流（首次放行/窗口内拦/超 TTL 再放行/跨频道独立）。
- **CLI 全量 1083 pass / 0 fail**、typecheck 通过；`watch.test.ts` 25 pass 无回归。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 在非 JSON 模式下启动 `watch` 时，自动探测并展示升级提示（必要时输出升级命令）。
  - 支持基于服务端最低客户端版本约束、最新发布版本差异与强制升级状态生成提示文案。
  - 探测与生成提示采用最佳努力策略，失败不影响正常连接与使用。
- **优化**
  - 升级提示探测做跨重挂节流：默认每 6 小时最多执行一次，且按频道独立生效。
- **测试**
  - 新增升级提示节流与升级提示内容的用例覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->