### PR TITLE
fix(cli): 一批 DX 错误信息/子命令优化 (#711 #712 #713 #714)

### DIFF
--- a/cli/src/commands/charter.ts
+++ b/cli/src/commands/charter.ts
@@ -117,9 +117,10 @@ export async function run(argv: string[]): Promise<number> {
       }
       return 0;
     }
-    // #713：兼容 `party charter get <slug>`——与 `set` 对称、符合直觉。把 get 当读取子命令，
-    // slug 取下一个位置参数（缺省则回退到绑定频道），别把 "get" 当频道名去查、报误导性的「频道不存在」。
-    const readSlugArg = positionals[0] === "get" ? positionals[1] : positionals[0];
+    // #713：兼容 `party charter get <slug>`——与 `set` 对称、符合直觉。把 get 当读取子命令、
+    // slug 取下一个位置参数。仅当其后确有 slug 时才这么解（#717 评审）：`party charter get`（无第二个
+    // 位置参数）仍按字面读名为 "get" 的频道，不因兼容语法吃掉一个合法频道名。
+    const readSlugArg = positionals[0] === "get" && positionals[1] !== undefined ? positionals[1] : positionals[0];
     const slug = resolveChannel(readSlugArg);
     if (!slug) {
       console.error("no channel, pass one or bind with: party init --channel C");

--- a/cli/src/commands/charter.ts
+++ b/cli/src/commands/charter.ts
@@ -117,7 +117,10 @@ export async function run(argv: string[]): Promise<number> {
       }
       return 0;
     }
-    const slug = resolveChannel(positionals[0]);
+    // #713：兼容 `party charter get <slug>`——与 `set` 对称、符合直觉。把 get 当读取子命令，
+    // slug 取下一个位置参数（缺省则回退到绑定频道），别把 "get" 当频道名去查、报误导性的「频道不存在」。
+    const readSlugArg = positionals[0] === "get" ? positionals[1] : positionals[0];
+    const slug = resolveChannel(readSlugArg);
     if (!slug) {
       console.error("no channel, pass one or bind with: party init --channel C");
       return 1;

--- a/cli/src/commands/history.ts
+++ b/cli/src/commands/history.ts
@@ -48,7 +48,9 @@ export async function run(argv: string[]): Promise<number> {
   }
   const since = parseNonNegativeIntFlag(str(flags.since), "since");
   if (typeof since === "string") {
-    console.error(since);
+    // #714：--since 收的是消息 seq（整数），不是时间戳。「since」这词强烈暗示时间，报错要点破语义，
+    // 别只甩「必须是非负整数」让人一头雾水。
+    console.error(`${since} — --since 需要消息 seq（整数），不是时间戳；先跑 party history <channel> 看当前 seq`);
     return 1;
   }
   const before = parseNonNegativeIntFlag(str(flags.before), "before");

--- a/cli/src/commands/watch.ts
+++ b/cli/src/commands/watch.ts
@@ -90,7 +90,8 @@ Options:
   --exclude-self    explicitly skip this agent's own messages (default)
   --follow          keep watching after the first matching message
   --once            exit 0 right after the first matching message
-  --latest          skip backlog: drain pending wake debt, then attach at head.
+  --latest          skip backlog: discard watch-owned pending wake debt, then attach at head.
+                    Serve-owned durable delivery is preserved (resume party serve).
                     ⚠️  almost always MISSES messages on 0.2.114+ (it discards unacked pending
                     backlog). Only old CLIs (<0.2.91) needed it. Normally omit --latest.
   --since seq       explicitly start after seq (mutually exclusive with --latest)
@@ -139,8 +140,9 @@ export const ONCE_REARM_ADVISORY =
 // 多行里的 warning。加醒目前缀顶格喊，把「几乎总是别带 --latest」说死。
 export const ONCE_LATEST_ADVISORY =
   "⚠️  WARNING: `party watch --once --latest` almost always MISSES messages on this CLI. " +
-  "--latest here DISCARDS the backlog: it drains any pending unacknowledged wake (no replay) and attaches at head — " +
+  "--latest here DISCARDS the backlog: it discards watch-owned pending wake debt (no replay) and attaches at head — " +
   "the opposite of old CLIs (<0.2.91) where --latest was required to avoid replaying all history. " +
+  "(Serve-owned durable delivery is preserved; resume `party serve` for that.) " +
   "Re-arm WITHOUT --latest to keep the backlog and replay pending wakes one at a time.";
 
 /** Claude Code 环境：可做回合内 --once，但 run_in_background 可能在回合边界被回收（#454）。 */

--- a/cli/src/commands/watch.ts
+++ b/cli/src/commands/watch.ts
@@ -26,7 +26,7 @@ import {
 import { resolveAuthDetailed, type ResolvedAuthDetailed } from "../oidc-cli";
 import { formatMsg, stripTerminalControls } from "../format";
 import { fetchMe, fetchMessages, fetchRecentMessages, fetchServerVersion, handleRestError, postMessage } from "../rest";
-import { upgradeHintForServer } from "../upgrade";
+import { INSTALL_LINE, upgradeHintForServer } from "../upgrade";
 import { shouldProbeUpgrade } from "../upgrade-hint-cache";
 import { buildContext } from "./status";
 import { MAX_TIMEOUT_SEC, isSlug, parseNonNegativeIntFlag, parsePositiveIntFlag } from "../validation";
@@ -90,7 +90,9 @@ Options:
   --exclude-self    explicitly skip this agent's own messages (default)
   --follow          keep watching after the first matching message
   --once            exit 0 right after the first matching message
-  --latest          skip backlog: drain pending wake debt, then attach at head
+  --latest          skip backlog: drain pending wake debt, then attach at head.
+                    ⚠️  almost always MISSES messages on 0.2.114+ (it discards unacked pending
+                    backlog). Only old CLIs (<0.2.91) needed it. Normally omit --latest.
   --since seq       explicitly start after seq (mutually exclusive with --latest)
   --drain           one-shot: advance cursor to head + clear all pending debt, exit 0
   --ensure          idempotent re-mount: if a same-identity watcher is already
@@ -123,10 +125,14 @@ export const ONCE_REARM_ADVISORY =
   "note: --once is single-shot and harness-scoped. Re-arm it every turn without --latest; pending wakes are replayed until this identity sends a message/status. " +
   "For unattended presence, use `party serve --runner claude|codex --replay-backlog`.";
 
+// #711：--latest 语义跨版本反转过——旧版（<0.2.91）不带会空转所以「必须带」，0.2.114+ 带了反而
+// 跳过未 ack 的 pending backlog、漏消息所以「必须不带」。带着旧认知的人极易踩坑，且此前只是一条混在
+// 多行里的 warning。加醒目前缀顶格喊，把「几乎总是别带 --latest」说死。
 export const ONCE_LATEST_ADVISORY =
-  "warning: re-arming `party watch --once` with --latest explicitly discards backlog: it drains any " +
-  "pending unacknowledged wake (no replay) and attaches at the current channel head. " +
-  "To keep the backlog and replay pending wakes one at a time, omit --latest.";
+  "⚠️  WARNING: `party watch --once --latest` almost always MISSES messages on this CLI. " +
+  "--latest here DISCARDS the backlog: it drains any pending unacknowledged wake (no replay) and attaches at head — " +
+  "the opposite of old CLIs (<0.2.91) where --latest was required to avoid replaying all history. " +
+  "Re-arm WITHOUT --latest to keep the backlog and replay pending wakes one at a time.";
 
 /** Claude Code 环境：可做回合内 --once，但 run_in_background 可能在回合边界被回收（#454）。 */
 export function isClaudeCodeEnv(env: Record<string, string | undefined> = process.env): boolean {
@@ -601,6 +607,8 @@ export async function runWatch(o: WatchOptions): Promise<number> {
               " (CLI >= 0.2.127), or `party serve`; --follow observers cannot attach while a directed delivery" +
               " is pending for this identity.",
           ));
+          // #712：upgrade_required 本质是 CLI 太旧，错误里必须给出升级命令，别让人 strings 扒二进制才找到。
+          console.error(terminalOutput(`      升级：party upgrade（原地换二进制、免重绑；回退：${INSTALL_LINE}）`));
         }
         if (frame.code === "unauthorized") code = EXIT_AUTH;
         else if (frame.code === "loop_guard") code = EXIT_LOOP_GUARD;

--- a/cli/src/commands/watch.ts
+++ b/cli/src/commands/watch.ts
@@ -121,9 +121,13 @@ export const ONCE_CLAUDE_ADVISORY =
   "This --once listener is only a turn-scoped wait; re-arm it every turn and do not claim durable presence. " +
   "For unattended wake, run `party serve <channel> --runner claude --replay-backlog` from a persistent terminal/project agent.";
 
+// #710：pending wake 是逐投递（per-delivery）追踪的——`--reply-to A` 只清 A，不连带清掉 B；未清的会
+// 每次重挂重放（易被误以为 bug）。纯客套的 @（「收工」「辛苦」）不必再回一条刷屏，用 `party ack` 显式清账。
 export const ONCE_REARM_ADVISORY =
-  "note: --once is single-shot and harness-scoped. Re-arm it every turn without --latest; pending wakes are replayed until this identity sends a message/status. " +
-  "For unattended presence, use `party serve --runner claude|codex --replay-backlog`.";
+  "note: --once is single-shot and harness-scoped. Re-arm it every turn without --latest. " +
+  "Pending wakes are tracked PER DELIVERY and each replays until cleared: `party send --reply-to A` clears only A, " +
+  "not other pending @s. For an @ you won't reply to, clear it with `party ack` (or `party ack --all`/`--through N`) " +
+  "instead of posting filler. For unattended presence, use `party serve --runner claude|codex --replay-backlog`.";
 
 // #711：--latest 语义跨版本反转过——旧版（<0.2.91）不带会空转所以「必须带」，0.2.114+ 带了反而
 // 跳过未 ack 的 pending backlog、漏消息所以「必须不带」。带着旧认知的人极易踩坑，且此前只是一条混在

--- a/cli/src/commands/watch.ts
+++ b/cli/src/commands/watch.ts
@@ -127,7 +127,12 @@ export const ONCE_REARM_ADVISORY =
   "note: --once is single-shot and harness-scoped. Re-arm it every turn without --latest. " +
   "Pending wakes are tracked PER DELIVERY and each replays until cleared: `party send --reply-to A` clears only A, " +
   "not other pending @s. For an @ you won't reply to, clear it with `party ack` (or `party ack --all`/`--through N`) " +
-  "instead of posting filler. For unattended presence, use `party serve --runner claude|codex --replay-backlog`.";
+  "instead of posting filler. " +
+  // #708：Claude Code 会话内 watch --once / serve 都会被 turn 边界杀，无法可靠在线。真正的持久待命是
+  // 「会话外」的第一方常驻——party daemon（持 WS、被 @ 就地跑 SDK、不依赖 turn 边界；桌面端可用 launchd 托管）。
+  "For persistent presence that survives harness turn boundaries, run the first-party resident runner " +
+  "`party daemon <channel>` (experimental) from a persistent terminal or the desktop app's launchd duty, " +
+  "or `party serve --runner claude|codex --replay-backlog`.";
 
 // #711：--latest 语义跨版本反转过——旧版（<0.2.91）不带会空转所以「必须带」，0.2.114+ 带了反而
 // 跳过未 ack 的 pending backlog、漏消息所以「必须不带」。带着旧认知的人极易踩坑，且此前只是一条混在

--- a/cli/test/charter.test.ts
+++ b/cli/test/charter.test.ts
@@ -77,4 +77,20 @@ describe("party charter command", () => {
     expect(JSON.parse(stdout.pop() ?? "{}").charter).toBe("hello charter");
     expect(stderr).toEqual([]);
   });
+
+  test("#717：`charter get`（无后续 slug）仍按字面读名为 get 的频道，不被兼容语法吃掉", async () => {
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      const req = input instanceof Request ? input : new Request(String(input), init);
+      const url = new URL(req.url);
+      if (url.pathname === "/api/channels/get/charter" && req.method === "GET") {
+        return Response.json({ charter: "the get channel", charter_rev: 1, updated_at: 1, updated_by: "a" });
+      }
+      return new Response("not found", { status: 404 });
+    }) as typeof fetch;
+
+    // 没有第二个位置参数 → "get" 当作频道名，而不是读取子命令
+    expect(await run(["get", "--json"])).toBe(0);
+    expect(JSON.parse(stdout.pop() ?? "{}").charter).toBe("the get channel");
+    expect(stderr).toEqual([]);
+  });
 });

--- a/cli/test/charter.test.ts
+++ b/cli/test/charter.test.ts
@@ -61,4 +61,20 @@ describe("party charter command", () => {
     expect(charter).toBe("updated charter");
     expect(stderr).toEqual([]);
   });
+
+  test("#713：party charter get <slug> 与 set 对称，按 slug 读取而非把 get 当频道名", async () => {
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      const req = input instanceof Request ? input : new Request(String(input), init);
+      const url = new URL(req.url);
+      if (url.pathname === "/api/channels/dev/charter" && req.method === "GET") {
+        return Response.json({ charter: "hello charter", charter_rev: 1, updated_at: 1, updated_by: "a" });
+      }
+      // 若把 "get" 误当频道名，会打到 /api/channels/get/charter → 这里 404 → 命令报「channel not found」
+      return new Response("not found", { status: 404 });
+    }) as typeof fetch;
+
+    expect(await run(["get", "dev", "--json"])).toBe(0);
+    expect(JSON.parse(stdout.pop() ?? "{}").charter).toBe("hello charter");
+    expect(stderr).toEqual([]);
+  });
 });

--- a/cli/test/history.test.ts
+++ b/cli/test/history.test.ts
@@ -116,6 +116,13 @@ describe("party history 参数解析（#151）", () => {
     expect(stderr.join("\n")).toContain("no config");
   });
 
+  test("#714：--since 传时间戳给出点破语义的报错（需要 seq，不是时间戳）", async () => {
+    expect(await run(["dev", "--since", "2026-07-15T12:00:00Z"])).toBe(1);
+    const err = stderr.join("\n");
+    expect(err).toContain("seq");
+    expect(err).toContain("时间戳");
+  });
+
   test("attachment-only history output contains actionable metadata (#362)", async () => {
     globalThis.fetch = (async () => Response.json({
       messages: [{


### PR DESCRIPTION
owner 一轮 dogfooding 暴露的 4 处 CLI 易踩坑，集中修一批（都是小而独立的错误信息/子命令改进）。

- **Closes #713** — `party charter get <slug>` 此前把 `get` 当频道名去查、报误导性的 `channel not found`。改为接受 `get` 读取子命令（与 `set` 对称、符合直觉），slug 取下一个位置参数。
- **Closes #714** — `party history --since <时间戳>` 只报「必须是非负整数」太含糊。点破语义：`--since` 收的是消息 **seq**、不是时间戳，并提示先 `party history <ch>` 看当前 seq。
- **Closes #712** — `upgrade_required` 错误此前不含升级命令（owner 靠 `strings` 扒二进制才找到）。在该 hint 后直接附 `party upgrade`（+ 回退 `INSTALL_LINE`）。
- **Closes #711** — `watch --latest` 语义跨版本反转过（旧版 <0.2.91 必须带 / 0.2.114+ 必须**不**带、否则跳过未 ack 的 pending backlog 漏消息）。此前只是混在多行里的 warning。advisory 加醒目 `⚠️` 前缀顶格喊「几乎总是别带 --latest」，`--help` 里写明版本分界。

## 验证
- 新增测试：`charter get <slug>` 按 slug 读取（不误当频道名）、`history --since <时间戳>` 点破语义的报错。
- CLI 全量 **1085 pass / 0 fail**、typecheck 通过。

（#711 有意不做「带 --latest 直接报错拒绝」——那是行为变更、可能打断存量脚本；先做低风险的醒目提示 + help 文档。）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **错误修复**
  * `party charter get <slug>` 现在能正确按频道 slug 读取；避免在 `party charter get` 无第二参数时把字面 `get` 当作频道名导致误导性错误。
  * `party history --since` 的参数错误提示更明确：说明需提供消息 seq（整数）而非时间戳，并输出可执行示例。
* **改进说明**
  * 强化 `party watch` 的 durable 升级引导与版本误用警告；细化 `--once`/`--latest` 的语义，提示可能的回放/遗漏情况。
* **测试**
  * 新增 `party charter get` 命令解析用例，并补充 `party history --since` 错误场景覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

- **Closes #710** — `party ack`（`--seq`/`--all`/`--through`/`--before`，#594 已有）本就是显式清账手段；改进 `ONCE_REARM_ADVISORY` 讲清 wake 逐投递追踪（`--reply-to A` 不连带 ack B）并指向 `party ack`。
