### PR TITLE
perf(ci): release 提速——Rust 缓存 + bun 缓存 + 解耦 build 门禁

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,6 +129,12 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/bun-install
+      # Rust 依赖（tauri/wry/objc2… ~400 crate）编译占了这个 job 的大头；缓存 ~/.cargo + target/
+      # 后每次只增量编译改动，冷编 ~3min → 温编数十秒。key 随 Cargo.lock 变化，工具链升级自动失效。
+      - name: cache Rust build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: desktop/src-tauri
       - name: verify desktop version consistency
         run: |
           set -euo pipefail
@@ -238,7 +244,15 @@ jobs:
   build:
     name: build ${{ matrix.target }}
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: check
+    # 解耦门禁：CLI 交叉编译只依赖 CLI/worker/shared/scripts 相关 check + 版本契约，不再等最慢的
+    # macOS check-desktop（~3min）。publish 仍 needs build+desktop，desktop needs check-desktop，
+    # 故 union 仍覆盖全部 check——"全绿才发布"的保证不变，只是各 build 一拿到自己那份绿就开跑。
+    needs:
+      - check-cli
+      - check-rest
+      - check-worker
+      - check-worker-types
+      - version-contract
     runs-on: ubuntu-latest
     permissions:
       contents: read # checkout
@@ -268,13 +282,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.3.14"
-
-      # 用根 lockfile 装全 workspace，保证 workspace:* 依赖（@agentparty/shared）可解析
-      - name: install deps
-        run: bun install --frozen-lockfile
+      # 复合 action：pin bun 1.3.14 + 缓存 ~/.bun/install/cache + frozen install（与 check 各 job 一致）。
+      - uses: ./.github/actions/bun-install
 
       - name: derive version
         id: ver
@@ -357,7 +366,10 @@ jobs:
   desktop:
     name: build desktop ${{ matrix.asset }}
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: check
+    # 解耦门禁：桌面构建只等 macOS check-desktop + 版本契约，不再被 CLI/worker check 拖住。
+    needs:
+      - check-desktop
+      - version-contract
     runs-on: ${{ matrix.runner }}
     environment:
       name: release
@@ -376,12 +388,15 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.3.14"
+      # 复合 action：pin bun 1.3.14 + 缓存 ~/.bun/install/cache + frozen install。
+      - uses: ./.github/actions/bun-install
 
-      - name: install deps
-        run: bun install --frozen-lockfile
+      # release 全量 Rust 编译是这个 job 的大头，缓存 ~/.cargo + target/（按 runner 架构/Cargo.lock 分键，
+      # arm 与 intel 各自成缓存）。冷编数分钟 → 温编增量。
+      - name: cache Rust build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: desktop/src-tauri
 
       - name: prepare and verify desktop sidecar
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,6 +135,9 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: desktop/src-tauri
+          # 只让受信任的 ref（main / v* tag）写缓存；PR（含 fork）只读，杜绝不受信任的运行往缓存里
+          # 塞污染的编译产物再被后续 release 命中（#719 评审的供应链加固）。
+          save-if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') }}
       - name: verify desktop version consistency
         run: |
           set -euo pipefail
@@ -397,6 +400,8 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: desktop/src-tauri
+          # 只让受信任的 ref（v* tag —— desktop 本就 if: tag）写缓存，PR/fork 只读，防缓存投毒（#719 评审）。
+          save-if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') }}
 
       - name: prepare and verify desktop sidecar
         env:

--- a/scripts/ci-paths-filter.test.ts
+++ b/scripts/ci-paths-filter.test.ts
@@ -77,6 +77,8 @@ describe("release.yml 并行门禁 + CI 拆分不变量 (#247 phase 2)", () => {
       expect(buildJob).toContain(`- ${dep}`);
     }
     expect(buildJob).not.toContain("- check-desktop");
+    // 整行负向断言：build 不得回归依赖聚合 check（否则解耦悄悄失效，又被最慢那个拖住）。
+    expect(buildJob).not.toMatch(/^\s+- check\s*$/m);
     // desktop 只等 macOS check-desktop + 版本契约。
     expect(desktopJob).toContain("- check-desktop");
     expect(desktopJob).toContain("- version-contract");

--- a/scripts/ci-paths-filter.test.ts
+++ b/scripts/ci-paths-filter.test.ts
@@ -68,7 +68,20 @@ describe("release.yml 并行门禁 + CI 拆分不变量 (#247 phase 2)", () => {
     expect(yml).toContain("required check job did not pass");
   });
 
-  test("build/desktop 仍 needs: check（聚合门禁是发布前置）", () => {
-    expect(yml).toMatch(/needs: check\b/);
+  test("build/desktop 解耦门禁：各只等相关 check，publish 经 build+desktop 传递闭包仍覆盖全部 check（全绿才发布）", () => {
+    const buildJob = yml.slice(yml.indexOf("  build:\n"), yml.indexOf("  desktop:\n"));
+    const desktopJob = yml.slice(yml.indexOf("  desktop:\n"), yml.indexOf("  release:\n"));
+    const releaseJob = yml.slice(yml.indexOf("  release:\n"));
+    // build（CLI 交叉编译）等非 desktop 的 check + 版本契约，不被最慢的 macOS check-desktop 拖住。
+    for (const dep of ["check-cli", "check-rest", "check-worker", "check-worker-types", "version-contract"]) {
+      expect(buildJob).toContain(`- ${dep}`);
+    }
+    expect(buildJob).not.toContain("- check-desktop");
+    // desktop 只等 macOS check-desktop + 版本契约。
+    expect(desktopJob).toContain("- check-desktop");
+    expect(desktopJob).toContain("- version-contract");
+    // publish（release）仍 needs build + desktop —— 传递闭包 = 全部 check，"全绿才发布"不变。
+    expect(releaseJob).toContain("- build");
+    expect(releaseJob).toContain("- desktop");
   });
 });

--- a/scripts/ci-paths-filter.test.ts
+++ b/scripts/ci-paths-filter.test.ts
@@ -82,6 +82,9 @@ describe("release.yml 并行门禁 + CI 拆分不变量 (#247 phase 2)", () => {
     // desktop 只等 macOS check-desktop + 版本契约。
     expect(desktopJob).toContain("- check-desktop");
     expect(desktopJob).toContain("- version-contract");
+    // 同样禁 desktop 回归依赖聚合 check 或 build（否则又被非桌面检查拖慢）。
+    expect(desktopJob).not.toMatch(/^\s+- check\s*$/m);
+    expect(desktopJob).not.toMatch(/^\s+- build\s*$/m);
     // publish（release）仍 needs build + desktop —— 传递闭包 = 全部 check，"全绿才发布"不变。
     expect(releaseJob).toContain("- build");
     expect(releaseJob).toContain("- desktop");


### PR DESCRIPTION
## 背景
release 关键路径 ≈ `changes → [最慢 check：check-desktop macOS ~3m11s] → full check → build∥desktop → publish`,大头是 macOS 上 ~400 个 Rust crate 的全量编译,且**完全没有缓存**。

## 三处提速
1. **Rust 构建缓存**（最大头）：`check-desktop` 与 `desktop` 加 `Swatinem/rust-cache@v2`(缓存 `~/.cargo` + `desktop/src-tauri/target`)。冷编 ~3min → 温编增量,预热后每次省 2–4 分钟。**原先唯一没做的大项。**
2. **bun 依赖缓存**：`build` / `desktop` 从裸 `setup-bun` + `frozen install`(无缓存)换成已缓存的复合 action `./.github/actions/bun-install`(pin 同版本 `1.3.14` + 缓存 `~/.bun/install/cache`)。
3. **解耦 build 门禁**：`build`(CLI 交叉编译)不再 `needs: check`(等最慢那个),只等 CLI/worker/shared/scripts + 版本契约;`desktop` 只等 macOS `check-desktop`。各 build 一拿到自己那份绿就开跑,不被最慢的 `check-desktop` 拖住。

### 安全性:"全绿才发布"不变
`publish`(release)仍 `needs: [build, desktop]`;`build` needs 非 desktop 的全部 check、`desktop` needs `check-desktop` —— **传递闭包 = 全部 check**,任一 check 红则对应 build 被 skip → publish 被 skip,不会发出坏版本。build/desktop 都 `if: tag`,只在发布路径跑(那里所有 check 都跑,无 skip 干扰)。

## 验证
- YAML 合法;`ci-paths-filter` / `desktop-release-workflow` / `supply-chain-deps` 结构测试 + scripts `tsc` 全绿(`ci-paths-filter` 的"build/desktop needs"用例同步改断新的解耦不变量)。
- 首次跑因缓存冷启动无提速,**第二次起** rust-cache 命中才见效。

## 预期
release 关键路径从 ~7–8min → ~3–4min(缓存预热后)。PR 路径的 `check-cli`(~2m32s)分片是后续可再叠加的第 4 项(本 PR 未含)。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **构建与发布**
  - 优化发布流程门禁依赖：CLI 与桌面构建所需检查结果解耦，按各自需求锁定依赖；发布阶段仍覆盖构建与桌面，确保“全绿才发布”。
  - 引入 Rust/Cargo 缓存，加速桌面与 macOS 构建；并统一 Bun 环境准备以提升构建一致性与速度。
- **测试**
  - 更新 CI 工作流依赖关系校验：对 build/desktop 的 per-job 依赖更精确断言，防止回归聚合门禁；同时确认发布仍依赖构建与桌面。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->