### PR TITLE
perf(ci): check-cli 按文件分 6 片并行（~2m36s → ~1min）

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -233,6 +233,7 @@ jobs:
   check:
     name: full check
     needs:
+      - changes
       - check-cli
       - check-cli-types
       - check-rest
@@ -247,6 +248,10 @@ jobs:
     steps:
       - name: aggregate workspace check results
         env:
+          # changes 必进判定：它挂了会让所有 check-* 因缺上游而 skipped，而 skipped 记作通过——
+          # 不纳入的话 paths-filter 一失败就「全跳过 = 全绿」漏测（CodeRabbit #723）。changes 无 if，
+          # 只会 success/failure，纳入循环即可让其失败直接红。
+          R_CHANGES: ${{ needs.changes.result }}
           R_CLI: ${{ needs.check-cli.result }}
           R_CLI_TYPES: ${{ needs.check-cli-types.result }}
           R_REST: ${{ needs.check-rest.result }}
@@ -256,9 +261,9 @@ jobs:
           R_VERSION: ${{ needs.version-contract.result }}
         run: |
           set -euo pipefail
-          echo "cli=$R_CLI cli-types=$R_CLI_TYPES rest=$R_REST worker=$R_WORKER worker-types=$R_WORKER_TYPES desktop=$R_DESKTOP version=$R_VERSION"
+          echo "changes=$R_CHANGES cli=$R_CLI cli-types=$R_CLI_TYPES rest=$R_REST worker=$R_WORKER worker-types=$R_WORKER_TYPES desktop=$R_DESKTOP version=$R_VERSION"
           fail=0
-          for r in "$R_CLI" "$R_CLI_TYPES" "$R_REST" "$R_WORKER" "$R_WORKER_TYPES" "$R_DESKTOP" "$R_VERSION"; do
+          for r in "$R_CHANGES" "$R_CLI" "$R_CLI_TYPES" "$R_REST" "$R_WORKER" "$R_WORKER_TYPES" "$R_DESKTOP" "$R_VERSION"; do
             case "$r" in
               success|skipped) ;;
               *) echo "::error::required check job did not pass: result=$r"; fail=1 ;;

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -227,7 +227,9 @@ jobs:
 
   # 唯一的 required 门禁，名字保持 "full check"（分支保护映射的就是它，不用改设置）。
   # if: always() → 无论上游成功/跳过/失败都跑；任一 workspace job 结论为 failure/cancelled
-  # 则本 job 失败，skipped（快路径跳过的）与 success 都算通过。build/desktop 仍 needs: check。
+  # 则本 job 失败，skipped（快路径跳过的）与 success 都算通过。
+  # 注：build/desktop 已解耦、各自只 needs 相关 check（#719），不再 needs 这个聚合 job；
+  # 但 publish 经 build+desktop 的传递闭包仍覆盖全部 check，"全绿才发布"不变。
   check:
     name: full check
     needs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,8 +49,27 @@ jobs:
   # 按「PR + cli 变更 + 无任何非 cli 变更」判定，配错只多跑绝不漏测；tag/main push
   # 非 PR，cli_only 恒 false，5 个 workspace 全跑。
 
-  # cli 在两条路径下都要跑，所以无条件执行。
+  # cli 在两条路径下都要跑，所以无条件执行。bun test 原生支持 --shard：按文件切 6 片并行，
+  # 墙上时间 ≈ 最重那一片而非全部串行（原 ~2m36s → ~1min）。tsc 单独一次跑，见 check-cli-types。
   check-cli:
+    name: check cli (shard ${{ matrix.shard }}/6)
+    needs: changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4, 5, 6]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/bun-install
+      - working-directory: cli
+        run: bun test --shard=${{ matrix.shard }}/6
+
+  # cli tsc 只跑一次（不放进分片，避免每片重复 typecheck）。
+  check-cli-types:
+    name: check cli (types)
     needs: changes
     runs-on: ubuntu-latest
     permissions:
@@ -58,7 +77,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/bun-install
-      - run: bun run check:cli
+      - working-directory: cli
+        run: bunx tsc --noEmit
 
   # web/shared/scripts：非纯 CLI（或非 PR）才跑，纯 CLI 快路径下 skip。
   # worker 因为一个 workerd 串行跑 43 个 spec 太慢（~6min），单独拆分片 job，见下。
@@ -212,6 +232,7 @@ jobs:
     name: full check
     needs:
       - check-cli
+      - check-cli-types
       - check-rest
       - check-worker
       - check-worker-types
@@ -225,6 +246,7 @@ jobs:
       - name: aggregate workspace check results
         env:
           R_CLI: ${{ needs.check-cli.result }}
+          R_CLI_TYPES: ${{ needs.check-cli-types.result }}
           R_REST: ${{ needs.check-rest.result }}
           R_WORKER: ${{ needs.check-worker.result }}
           R_WORKER_TYPES: ${{ needs.check-worker-types.result }}
@@ -232,9 +254,9 @@ jobs:
           R_VERSION: ${{ needs.version-contract.result }}
         run: |
           set -euo pipefail
-          echo "cli=$R_CLI rest=$R_REST worker=$R_WORKER worker-types=$R_WORKER_TYPES desktop=$R_DESKTOP version=$R_VERSION"
+          echo "cli=$R_CLI cli-types=$R_CLI_TYPES rest=$R_REST worker=$R_WORKER worker-types=$R_WORKER_TYPES desktop=$R_DESKTOP version=$R_VERSION"
           fail=0
-          for r in "$R_CLI" "$R_REST" "$R_WORKER" "$R_WORKER_TYPES" "$R_DESKTOP" "$R_VERSION"; do
+          for r in "$R_CLI" "$R_CLI_TYPES" "$R_REST" "$R_WORKER" "$R_WORKER_TYPES" "$R_DESKTOP" "$R_VERSION"; do
             case "$r" in
               success|skipped) ;;
               *) echo "::error::required check job did not pass: result=$r"; fail=1 ;;
@@ -252,6 +274,7 @@ jobs:
     # 故 union 仍覆盖全部 check——"全绿才发布"的保证不变，只是各 build 一拿到自己那份绿就开跑。
     needs:
       - check-cli
+      - check-cli-types
       - check-rest
       - check-worker
       - check-worker-types

--- a/scripts/ci-paths-filter.test.ts
+++ b/scripts/ci-paths-filter.test.ts
@@ -72,12 +72,15 @@ describe("release.yml 并行门禁 + CI 拆分不变量 (#247 phase 2)", () => {
     expect(yml).toMatch(/check:\s*\n\s*name: full check/);
     // 限定在 check job 片段内，且把 check-desktop 一并纳入断言（漏了 desktop 依赖也该红，#723 评审）。
     const fullCheckJob = yml.slice(yml.indexOf("  check:\n"), yml.indexOf("  build:\n"));
-    for (const dep of ["check-cli", "check-cli-types", "check-rest", "check-worker", "check-worker-types", "check-desktop", "version-contract"]) {
+    // changes 必进 needs：它挂了会让所有 check-* skipped（记作通过）= 全跳过全绿漏测（#723 CodeRabbit）。
+    for (const dep of ["changes", "check-cli", "check-cli-types", "check-rest", "check-worker", "check-worker-types", "check-desktop", "version-contract"]) {
       expect(fullCheckJob).toContain(`- ${dep}`);
     }
-    // check-cli-types 不仅进 needs，还要进失败判定（env + for 循环），否则 types 挂了聚合仍绿。
+    // check-cli-types 与 changes 不仅进 needs，还要进失败判定（env + for 循环），否则挂了聚合仍绿。
     expect(fullCheckJob).toContain("R_CLI_TYPES: ${{ needs.check-cli-types.result }}");
+    expect(fullCheckJob).toContain("R_CHANGES: ${{ needs.changes.result }}");
     expect(fullCheckJob).toMatch(/for r in[\s\S]*"\$R_CLI_TYPES"/);
+    expect(fullCheckJob).toMatch(/for r in[\s\S]*"\$R_CHANGES"/);
     expect(fullCheckJob).toContain("if: always()");
   });
 

--- a/scripts/ci-paths-filter.test.ts
+++ b/scripts/ci-paths-filter.test.ts
@@ -13,6 +13,12 @@ import { join } from "node:path";
 
 const yml = readFileSync(join(import.meta.dir, "..", ".github", "workflows", "release.yml"), "utf8");
 
+// 整行匹配一条 needs 依赖项——避免前缀误命中：`- check-cli` 不能被 `- check-cli-types`
+// 满足，否则删了必需依赖测试仍绿、发布门禁失守（#723 CodeRabbit）。
+function hasDep(block: string, dep: string): boolean {
+  return new RegExp(`^\\s*- ${dep}\\s*$`, "m").test(block);
+}
+
 describe("release.yml 并行门禁 + CI 拆分不变量 (#247 phase 2)", () => {
   test('required 门禁 job 名字仍是 "full check"（改名会让分支保护的 required check 消失）', () => {
     expect(yml).toContain("name: full check");
@@ -74,7 +80,7 @@ describe("release.yml 并行门禁 + CI 拆分不变量 (#247 phase 2)", () => {
     const fullCheckJob = yml.slice(yml.indexOf("  check:\n"), yml.indexOf("  build:\n"));
     // changes 必进 needs：它挂了会让所有 check-* skipped（记作通过）= 全跳过全绿漏测（#723 CodeRabbit）。
     for (const dep of ["changes", "check-cli", "check-cli-types", "check-rest", "check-worker", "check-worker-types", "check-desktop", "version-contract"]) {
-      expect(fullCheckJob).toContain(`- ${dep}`);
+      expect(hasDep(fullCheckJob, dep)).toBe(true);
     }
     // check-cli-types 与 changes 不仅进 needs，还要进失败判定（env + for 循环），否则挂了聚合仍绿。
     expect(fullCheckJob).toContain("R_CLI_TYPES: ${{ needs.check-cli-types.result }}");
@@ -95,19 +101,19 @@ describe("release.yml 并行门禁 + CI 拆分不变量 (#247 phase 2)", () => {
     const releaseJob = yml.slice(yml.indexOf("  release:\n"));
     // build（CLI 交叉编译）等非 desktop 的 check + 版本契约，不被最慢的 macOS check-desktop 拖住。
     for (const dep of ["check-cli", "check-cli-types", "check-rest", "check-worker", "check-worker-types", "version-contract"]) {
-      expect(buildJob).toContain(`- ${dep}`);
+      expect(hasDep(buildJob, dep)).toBe(true);
     }
-    expect(buildJob).not.toContain("- check-desktop");
+    expect(hasDep(buildJob, "check-desktop")).toBe(false);
     // 整行负向断言：build 不得回归依赖聚合 check（否则解耦悄悄失效，又被最慢那个拖住）。
     expect(buildJob).not.toMatch(/^\s+- check\s*$/m);
     // desktop 只等 macOS check-desktop + 版本契约。
-    expect(desktopJob).toContain("- check-desktop");
-    expect(desktopJob).toContain("- version-contract");
+    expect(hasDep(desktopJob, "check-desktop")).toBe(true);
+    expect(hasDep(desktopJob, "version-contract")).toBe(true);
     // 同样禁 desktop 回归依赖聚合 check 或 build（否则又被非桌面检查拖慢）。
     expect(desktopJob).not.toMatch(/^\s+- check\s*$/m);
     expect(desktopJob).not.toMatch(/^\s+- build\s*$/m);
     // publish（release）仍 needs build + desktop —— 传递闭包 = 全部 check，"全绿才发布"不变。
-    expect(releaseJob).toContain("- build");
-    expect(releaseJob).toContain("- desktop");
+    expect(hasDep(releaseJob, "build")).toBe(true);
+    expect(hasDep(releaseJob, "desktop")).toBe(true);
   });
 });

--- a/scripts/ci-paths-filter.test.ts
+++ b/scripts/ci-paths-filter.test.ts
@@ -54,19 +54,31 @@ describe("release.yml 并行门禁 + CI 拆分不变量 (#247 phase 2)", () => {
   });
 
   test("check-cli 分片无条件跑 + tsc 单列（cli 在快路径与全量下都要测）", () => {
-    expect(yml).toMatch(/check-cli:\s*\n\s*name: check cli \(shard/);
-    expect(yml).toContain("bun test --shard=${{ matrix.shard }}/6");
-    expect(yml).toContain("shard: [1, 2, 3, 4, 5, 6]");
-    expect(yml).toMatch(/check-cli-types:\s*\n\s*name: check cli \(types\)/);
-    expect(yml).toContain("bunx tsc --noEmit");
+    // 截到各自 job 片段验证，别用全局 yml（否则别的 job 的命令也能让断言通过，#723 评审）。
+    const cliJob = yml.slice(yml.indexOf("  check-cli:\n"), yml.indexOf("  check-cli-types:\n"));
+    const cliTypesJob = yml.slice(yml.indexOf("  check-cli-types:\n"), yml.indexOf("  check-rest:\n"));
+    expect(cliJob).toContain("name: check cli (shard");
+    expect(cliJob).toContain("bun test --shard=${{ matrix.shard }}/6");
+    expect(cliJob).toContain("shard: [1, 2, 3, 4, 5, 6]");
+    expect(cliJob).toContain("working-directory: cli");
+    expect(cliTypesJob).toContain("name: check cli (types)");
+    expect(cliTypesJob).toContain("bunx tsc --noEmit");
+    // 无条件跑：cli 在 cli_only 快路径下也要测，故两个 job 都不带 if: 门。
+    expect(cliJob).not.toMatch(/^\s+if:/m);
+    expect(cliTypesJob).not.toMatch(/^\s+if:/m);
   });
 
-  test('聚合 "full check" needs 全部 workspace job（含 worker 分片与 types），且 if: always()', () => {
+  test('聚合 "full check" needs 全部 workspace job（含 worker 分片与 types + desktop），且 if: always()', () => {
     expect(yml).toMatch(/check:\s*\n\s*name: full check/);
-    for (const dep of ["check-cli", "check-cli-types", "check-rest", "check-worker", "check-worker-types", "version-contract"]) {
-      expect(yml).toContain(`- ${dep}`);
+    // 限定在 check job 片段内，且把 check-desktop 一并纳入断言（漏了 desktop 依赖也该红，#723 评审）。
+    const fullCheckJob = yml.slice(yml.indexOf("  check:\n"), yml.indexOf("  build:\n"));
+    for (const dep of ["check-cli", "check-cli-types", "check-rest", "check-worker", "check-worker-types", "check-desktop", "version-contract"]) {
+      expect(fullCheckJob).toContain(`- ${dep}`);
     }
-    expect(yml).toContain("if: always()");
+    // check-cli-types 不仅进 needs，还要进失败判定（env + for 循环），否则 types 挂了聚合仍绿。
+    expect(fullCheckJob).toContain("R_CLI_TYPES: ${{ needs.check-cli-types.result }}");
+    expect(fullCheckJob).toMatch(/for r in[\s\S]*"\$R_CLI_TYPES"/);
+    expect(fullCheckJob).toContain("if: always()");
   });
 
   test("聚合门禁把 failure/cancelled 变成自己失败，只有 success|skipped 通过（漏配不漏测）", () => {

--- a/scripts/ci-paths-filter.test.ts
+++ b/scripts/ci-paths-filter.test.ts
@@ -31,7 +31,9 @@ describe("release.yml 并行门禁 + CI 拆分不变量 (#247 phase 2)", () => {
   });
 
   test("cli + web/shared/scripts 各自 check:* 都在 workflow 里（漏配某个 = 漏测该 workspace）", () => {
-    expect(yml).toContain("bun run check:cli");
+    // cli 分片：bun test --shard + 独立 tsc（替代原 `bun run check:cli` 串行）。
+    expect(yml).toContain("bun test --shard=${{ matrix.shard }}/6");
+    expect(yml).toContain("bunx tsc --noEmit");
     // web/shared/scripts 走 matrix：bun run check:${{ matrix.ws }}
     expect(yml).toContain("bun run check:${{ matrix.ws }}");
     expect(yml).toContain("ws: [web, shared, scripts]");
@@ -51,13 +53,17 @@ describe("release.yml 并行门禁 + CI 拆分不变量 (#247 phase 2)", () => {
     expect(yml).toContain("if: needs.changes.outputs.cli_only != 'true'");
   });
 
-  test("check-cli 无条件跑（cli 在快路径与全量下都要测）", () => {
-    expect(yml).toMatch(/check-cli:\s*\n\s*needs: changes\s*\n\s*runs-on:/);
+  test("check-cli 分片无条件跑 + tsc 单列（cli 在快路径与全量下都要测）", () => {
+    expect(yml).toMatch(/check-cli:\s*\n\s*name: check cli \(shard/);
+    expect(yml).toContain("bun test --shard=${{ matrix.shard }}/6");
+    expect(yml).toContain("shard: [1, 2, 3, 4, 5, 6]");
+    expect(yml).toMatch(/check-cli-types:\s*\n\s*name: check cli \(types\)/);
+    expect(yml).toContain("bunx tsc --noEmit");
   });
 
   test('聚合 "full check" needs 全部 workspace job（含 worker 分片与 types），且 if: always()', () => {
     expect(yml).toMatch(/check:\s*\n\s*name: full check/);
-    for (const dep of ["check-cli", "check-rest", "check-worker", "check-worker-types", "version-contract"]) {
+    for (const dep of ["check-cli", "check-cli-types", "check-rest", "check-worker", "check-worker-types", "version-contract"]) {
       expect(yml).toContain(`- ${dep}`);
     }
     expect(yml).toContain("if: always()");
@@ -73,7 +79,7 @@ describe("release.yml 并行门禁 + CI 拆分不变量 (#247 phase 2)", () => {
     const desktopJob = yml.slice(yml.indexOf("  desktop:\n"), yml.indexOf("  release:\n"));
     const releaseJob = yml.slice(yml.indexOf("  release:\n"));
     // build（CLI 交叉编译）等非 desktop 的 check + 版本契约，不被最慢的 macOS check-desktop 拖住。
-    for (const dep of ["check-cli", "check-rest", "check-worker", "check-worker-types", "version-contract"]) {
+    for (const dep of ["check-cli", "check-cli-types", "check-rest", "check-worker", "check-worker-types", "version-contract"]) {
       expect(buildJob).toContain(`- ${dep}`);
     }
     expect(buildJob).not.toContain("- check-desktop");


### PR DESCRIPTION
接着上一轮 CI 提速(#719)。desktop check 有了 rust-cache 后降到 ~70s,现在 PR 门禁的次长杆是 **check-cli(~2m36s)**。

## 改动
- `bun test` 原生支持 `--shard`——像 worker 那样把 CLI 测试按文件切 **6 片并行**,墙上时间 ≈ 最重那一片(本地实测 shard 1/6 **~59s**)而非全部串行 ~156s。
- `tsc` 单列成 `check-cli-types`(不进分片,免每片重复 typecheck)。
- 聚合 `full check` 与解耦后的 `build` 门禁都补上 `check-cli-types` 依赖;传递闭包不变、"全绿才发布"不变。
- `ci-paths-filter` 结构断言同步更新。

## 关于上一版那个 442s 的 desktop 构建
排查了:那是**一次性冷启**——#721 加 tauri-plugin-dialog 改了 Cargo.lock,使 rust-cache 的 key 失效("No cache found"),整段 Rust release 重编 5m39s。**本次已把新 cache 存盘**(日志确认 "Saving cache"),下一个同 Cargo.lock 的版本会命中,desktop Rust 编译从 5m39s 降到增量。所以那个大数不需要额外改动,会自愈。

## 验证
- `scripts` 测试(ci-paths-filter/desktop-release-workflow/deploy-ci/supply-chain-deps)52 pass + scripts `tsc` 通过。
- 本地实跑 6 个分片均绿、覆盖全部 CLI 测试文件。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 优化发布门禁流程：将 CLI 校验改为按 6 片并行执行以提升速度。
  * 新增独立的 CLI 类型检查，并纳入全量门禁必需结果判定（与变更检查一起参与失败判定）。
  * 调整构建任务依赖：开始交叉编译前等待 CLI 类型检查完成。
* **测试**
  * 强化 CI 覆盖：验证 CLI 分片执行、类型检查无条件运行，并确认其依赖与聚合失败判断逻辑一致。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->