### PR TITLE
fix(serve): codex 解析不到 session id 也交付答案,不再吞掉本回合 (#726/#725)

### DIFF
--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -2498,9 +2498,11 @@ export function createBuiltinRunner(opts: BuiltinRunnerOptions): NonNullable<Ser
         // 落一条运维告警到 serve-runner.log，正常走投递；只跳过 writeSession/onSession。
         let committed: WakeSessionState | null = null;
         if (!finalSid) {
+          // 只记录「解析不到 sid、将走无续跑投递」——真正的送达结果由下面投递/验收后的日志行落账,
+          // 这里别抢先写 delivered=true(附件/发送失败或 managed 零动作时会留下假的已交付审计,#728 CodeRabbit)。
           appendRunnerLog(
             opts.workdir,
-            `${new Date(now).toISOString()} seq=${frame.seq} sid=unknown duration_ms=${now - started} exit=${exitCode ?? 0} missing_session_id=true delivered=true text_bytes=${Buffer.byteLength(run.text, "utf8")} note=session_continuity_unavailable`,
+            `${new Date(now).toISOString()} seq=${frame.seq} sid=unknown duration_ms=${now - started} exit=${exitCode ?? 0} missing_session_id=true text_bytes=${Buffer.byteLength(run.text, "utf8")} note=session_continuity_unavailable`,
           );
         } else {
           committed = writeSession(sessionPath, {

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -1641,8 +1641,14 @@ function appendServeLifecycleLog(workdir: string, line: string): void {
   appendFileSync(join(workdir, SERVE_LIFECYCLE_LOG_FILE), line + "\n");
 }
 
-function parseCodexSessionId(stdout: string): string | null {
-  return stdout.match(/session id:\s*([0-9a-fA-F][0-9a-fA-F-]{7,})/i)?.[1] ?? null;
+// Codex 打印 session id 的格式在版本间漂移过（`session id:` / `session_id:`，有时落 stderr）。
+// 宽松匹配 id/_id、大小写无关、两个流都扫，避免因一行文案变化就丢掉会话续跑（#726）。
+function parseCodexSessionId(...streams: (string | null | undefined)[]): string | null {
+  for (const s of streams) {
+    const m = s?.match(/session[ _]id:\s*([0-9a-fA-F][0-9a-fA-F-]{7,})/i)?.[1];
+    if (m) return m;
+  }
+  return null;
 }
 
 function sdkPrompt(
@@ -1871,7 +1877,7 @@ async function runHarness(
       : ["codex", "exec", ...flags, prompt];
     const result = await runProcess(args, { cwd, env, signal });
     const text = result.code === 0 && existsSync(outFile) ? readFileSync(outFile, "utf8").trimEnd() : "";
-    return { result, text, sessionId: sid ? sid : parseCodexSessionId(result.stdout), outFile };
+    return { result, text, sessionId: sid ? sid : parseCodexSessionId(result.stdout, result.stderr), outFile };
   }
 
   // A resident unattended serve must never let Claude block its one serial consumer on an
@@ -2487,31 +2493,34 @@ export function createBuiltinRunner(opts: BuiltinRunnerOptions): NonNullable<Ser
         }
 
         finalSid = run.sessionId;
+        // 解析不到 session id 不再吞掉本回合答案（#726）：codex 已 exit 0 且产出在 run.text 里，
+        // 唯一代价是无法持久化可续跑句柄——下一次 @ 冷启动而非 resume，远好于静默丢答案。
+        // 落一条运维告警到 serve-runner.log，正常走投递；只跳过 writeSession/onSession。
+        let committed: WakeSessionState | null = null;
         if (!finalSid) {
           appendRunnerLog(
             opts.workdir,
-            `${new Date(now).toISOString()} seq=${frame.seq} sid=unknown duration_ms=${now - started} exit=${exitCode ?? 0} missing_session_id=true`,
+            `${new Date(now).toISOString()} seq=${frame.seq} sid=unknown duration_ms=${now - started} exit=${exitCode ?? 0} missing_session_id=true delivered=true text_bytes=${Buffer.byteLength(run.text, "utf8")} note=session_continuity_unavailable`,
           );
-          throw new WakeBlockedError(`builtin ${opts.harness} runner blocked: no session id parsed; log: ${join(opts.workdir, RUNNER_LOG_FILE)}`);
+        } else {
+          committed = writeSession(sessionPath, {
+            harness: opts.harness,
+            session_id: finalSid,
+            created_at: prior ? prior.created_at : now,
+            last_wake_ts: now,
+            wakes: prior ? prior.wakes + 1 : 1,
+            cwd,
+            workdir: opts.workdir,
+            ...(scope.directed ? { work_id: scope.workId!, continuation_ref: scope.ref! } : {}),
+          });
+          opts.onSession?.({
+            harness: opts.harness,
+            session_id: committed.session_id,
+            updated_at: now,
+            cwd,
+            workdir: opts.workdir,
+          });
         }
-
-        const committed = writeSession(sessionPath, {
-          harness: opts.harness,
-          session_id: finalSid,
-          created_at: prior ? prior.created_at : now,
-          last_wake_ts: now,
-          wakes: prior ? prior.wakes + 1 : 1,
-          cwd,
-          workdir: opts.workdir,
-          ...(scope.directed ? { work_id: scope.workId!, continuation_ref: scope.ref! } : {}),
-        });
-        opts.onSession?.({
-          harness: opts.harness,
-          session_id: committed.session_id,
-          updated_at: now,
-          cwd,
-          workdir: opts.workdir,
-        });
 
         // #581 managed MCP：动作已由工具即时落频道，文本输出只进日志。这里只验收「本回合
         // 至少发生一个频道动作」——零动作=未送达（WakeBlockedError，不推游标不吞 @）。
@@ -2530,7 +2539,8 @@ export function createBuiltinRunner(opts: BuiltinRunnerOptions): NonNullable<Ser
           }
           break;
         }
-        const marker = oldSid ? null : `[session start: ${shortSid(finalSid)}]`;
+        // 无 sid（#726 续跑不可用）不打 "[session start: unknown]" 噪声——告警已进 runner 日志。
+        const marker = finalSid && !oldSid ? `[session start: ${shortSid(finalSid)}]` : null;
         let outcome: RunnerDeliveryOutcome;
         try {
           outcome = await deliverRunnerResult({

--- a/cli/test/serve.test.ts
+++ b/cli/test/serve.test.ts
@@ -1186,15 +1186,19 @@ describe("builtin runner", () => {
     // 答案照常投递到频道
     const finalPost = posts.at(-1)!;
     expect(finalPost.body).toMatchObject({ kind: "message", reply_to: 659 });
-    expect((finalPost.body as { body: string }).body).toContain("answer without a parsable session id");
+    const deliveredBody = (finalPost.body as { body: string }).body;
+    expect(deliveredBody).toContain("answer without a parsable session id");
+    // 无 sid 不打 "[session start: unknown]" marker 噪声
+    expect(deliveredBody).not.toContain("[session start");
     // 没 sid → 不持久化会话、不上报 onSession（下次冷启动）
     expect(reported).toEqual([]);
     expect(existsSync(join(workdir, "wake-session.json"))).toBe(false);
-    // 运维告警落日志:交付了但续跑不可用
+    // 运维告警落日志:sid 未知、续跑不可用（但不抢先写 delivered=true，交付结果由后续日志行落账）
     const log = readFileSync(join(workdir, "serve-runner.log"), "utf8");
     expect(log).toContain("seq=659 sid=unknown");
     expect(log).toContain("missing_session_id=true");
-    expect(log).toContain("delivered=true");
+    expect(log).toContain("note=session_continuity_unavailable");
+    expect(log).not.toContain("delivered=true");
   });
 
   test("codex session id 落 stderr 或写作 session_id 仍能解析（#726 宽松匹配）", async () => {
@@ -1204,8 +1208,8 @@ describe("builtin runner", () => {
     const runProcess: RunnerProcess = async (args) => {
       const out = args[args.indexOf("-o") + 1]!;
       writeFileSync(out, "answer\n");
-      // 下划线写法 + 落 stderr，两处都得能捞到
-      return { code: 0, stdout: "no id here\n", stderr: `session_id: ${uuid(1)}\n` };
+      // 下划线写法 + 大小写变体 + 落 stderr，都得能捞到（宽松匹配）
+      return { code: 0, stdout: "no id here\n", stderr: `Session_ID: ${uuid(1)}\n` };
     };
 
     await createBuiltinRunner({

--- a/cli/test/serve.test.ts
+++ b/cli/test/serve.test.ts
@@ -1160,6 +1160,70 @@ describe("builtin runner", () => {
     expect(log).toContain("exit=0");
   });
 
+  test("codex 无 session id 也交付答案而非吞掉（#726：exit 0 有产出，只是没解析出 sid）", async () => {
+    const { posts, post } = postRecorder();
+    const workdir = tempDir();
+    const reported: Array<{ session_id: string }> = [];
+    const runProcess: RunnerProcess = async (args) => {
+      const out = args[args.indexOf("-o") + 1]!;
+      writeFileSync(out, "answer without a parsable session id\n");
+      // codex exit 0、有答案，但 stdout/stderr 都不含 `session id:` 行（版本漂移症状）
+      return { code: 0, stdout: "done\n", stderr: "" };
+    };
+
+    // 不抛 WakeBlockedError（不吞 @）
+    await createBuiltinRunner({
+      server: "http://agentparty.test",
+      token: "ap_tok",
+      channel: "dev",
+      harness: "codex",
+      workdir,
+      runProcess,
+      post,
+      onSession: (session) => reported.push(session),
+    })(triggerFrame(659), runnerCtx());
+
+    // 答案照常投递到频道
+    const finalPost = posts.at(-1)!;
+    expect(finalPost.body).toMatchObject({ kind: "message", reply_to: 659 });
+    expect((finalPost.body as { body: string }).body).toContain("answer without a parsable session id");
+    // 没 sid → 不持久化会话、不上报 onSession（下次冷启动）
+    expect(reported).toEqual([]);
+    expect(existsSync(join(workdir, "wake-session.json"))).toBe(false);
+    // 运维告警落日志:交付了但续跑不可用
+    const log = readFileSync(join(workdir, "serve-runner.log"), "utf8");
+    expect(log).toContain("seq=659 sid=unknown");
+    expect(log).toContain("missing_session_id=true");
+    expect(log).toContain("delivered=true");
+  });
+
+  test("codex session id 落 stderr 或写作 session_id 仍能解析（#726 宽松匹配）", async () => {
+    const { post } = postRecorder();
+    const workdir = tempDir();
+    const reported: Array<{ session_id: string }> = [];
+    const runProcess: RunnerProcess = async (args) => {
+      const out = args[args.indexOf("-o") + 1]!;
+      writeFileSync(out, "answer\n");
+      // 下划线写法 + 落 stderr，两处都得能捞到
+      return { code: 0, stdout: "no id here\n", stderr: `session_id: ${uuid(1)}\n` };
+    };
+
+    await createBuiltinRunner({
+      server: "http://agentparty.test",
+      token: "ap_tok",
+      channel: "dev",
+      harness: "codex",
+      workdir,
+      runProcess,
+      post,
+      onSession: (session) => reported.push(session),
+    })(triggerFrame(1), runnerCtx());
+
+    const state = JSON.parse(readFileSync(join(workdir, "wake-session.json"), "utf8"));
+    expect(state).toMatchObject({ harness: "codex", session_id: uuid(1) });
+    expect(reported).toEqual([expect.objectContaining({ session_id: uuid(1) })]);
+  });
+
   test("[attach:path] uploads the file to R2 and references it as an attachment, not inlined (#41/#109)", async () => {
     const { posts, post } = postRecorder();
     const { uploads, upload } = uploadRecorder();


### PR DESCRIPTION
## 问题 (#726)

`party serve --runner codex` 收到 @mention,codex 跑完(exit 0、答案已写进 `-o outFile`),但内置 runner 因为 stdout 里没匹配到 `session id:` 就抛 `WakeBlockedError`,把这回合当成「模型根本没跑过」——**答案静默丢失,频道无回复,游标也不推进**。日志:`seq=659 sid=unknown ... exit=0 missing_session_id=true`。codex CLI 版本间 session id 的打印文案漂移(报告里是 0.144.1)极易触发。

## 修复

- **解析不到 sid 不再吞答案**:答案本就与 sid 来自两个独立来源(答案在 `-o` outFile,sid 从 stdout 解析)。现在解析失败时落一条运维告警到 `serve-runner.log`(`missing_session_id=true delivered=true`),**照常投递答案**,只跳过 `writeSession`/`onSession`——唯一代价是下次 @ 冷启动而非 resume,远好于静默丢答案。这正是 issue 期望的「recoverable case」。
- **放宽 sid 解析**:兼容 `session_id` 下划线写法、大小写无关、`stdout`+`stderr` 两个流都扫,减少因一行文案变化就丢续跑。
- 无 sid 时不打 `[session start: unknown]` 频道噪声。

## 关联 #725

`#725` 的「设置 codex 常驻,频道 @ 没反应」与本 bug 同源(codex 常驻收到 @ 但答案被吞)。#725 另有「常驻不让选 codex/claude 与目录」的 UI 诉求 + 「桌面看常驻日志」诉求,单独跟进。

## 测试

新增两个回归:
1. codex exit 0 有产出但无 `session id:` → 答案仍投递到频道、不抛 WakeBlockedError、不写 wake-session.json、日志含 `missing_session_id=true delivered=true`。
2. session id 落 stderr / 写作 `session_id` → 仍能解析并持久化。

`cli/test/serve.test.ts` 全绿(76 pass)、`tsc --noEmit` 通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 改进 Codex 会话 ID 识别：支持从标准输出与错误输出中进行大小写不敏感提取，并适配 `session id`/`session_id` 等格式。
* **错误修复**
  * 当 Codex 退出码为 0 但无法解析到会话 ID 时，不再阻断本轮执行；改为写入 `serve-runner.log` 告警，并避免更新持久化会话状态或触发会话上报。
  * 仅在成功获取新会话 ID 且非续跑时生成 `[session start ...]` 标记。
* **测试**
  * 新增 builtin runner（harness=codex）会话 ID 解析与缺失场景用例。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->