### PR TITLE
fix(web): 编辑消息后保存键可点——去掉「等于原文即禁用」的死键陷阱 (#722)

### DIFF
--- a/web/src/components/MessageCard.editing.test.tsx
+++ b/web/src/components/MessageCard.editing.test.tsx
@@ -221,3 +221,38 @@ describe("message edit keyboard shortcuts (#343)", () => {
     expect(saveEvent.wasPrevented()).toBe(false);
   });
 });
+
+describe("save button 可点性 (#722：编辑后点不了保存)", () => {
+  function saveButton(): ReactTestInstance {
+    return renderer!.root.findAll((node) => node.type === "button" && node.props.className === "d-btn d-btn--primary")[0]!;
+  }
+
+  test("草稿等于原文时保存键仍可点(不再一打开就变灰)", () => {
+    renderEditor({ editDraft: "original" }); // baseMsg().body === "original"
+    expect(saveButton().props.disabled).toBe(false);
+  });
+
+  test("草稿有改动时保存键可点", () => {
+    renderEditor({ editDraft: "original edited" });
+    expect(saveButton().props.disabled).toBe(false);
+  });
+
+  test("空 / 纯空白草稿禁用保存(避免存出空消息)", () => {
+    renderEditor({ editDraft: "   " });
+    expect(saveButton().props.disabled).toBe(true);
+  });
+
+  test("保存中禁用保存(防重复提交)", () => {
+    renderEditor({ editDraft: "original", editSaving: true });
+    expect(saveButton().props.disabled).toBe(true);
+  });
+
+  test("草稿等于原文时 Cmd+Enter 会触发 onEditSave(交由上层关掉编辑器)", () => {
+    let saveCalls = 0;
+    const textarea = renderEditor({ editDraft: "original", onEditSave: () => { saveCalls += 1; } });
+    const saveEvent = keyEvent("Enter", { metaKey: true });
+    act(() => textarea.props.onKeyDown(saveEvent));
+    expect(saveCalls).toBe(1);
+    expect(saveEvent.wasPrevented()).toBe(true);
+  });
+});

--- a/web/src/components/MessageCard.editing.test.tsx
+++ b/web/src/components/MessageCard.editing.test.tsx
@@ -255,4 +255,13 @@ describe("save button 可点性 (#722：编辑后点不了保存)", () => {
     expect(saveCalls).toBe(1);
     expect(saveEvent.wasPrevented()).toBe(true);
   });
+
+  test("草稿等于原文时 Ctrl+Enter(非 mac)同样触发 onEditSave", () => {
+    let saveCalls = 0;
+    const textarea = renderEditor({ editDraft: "original", onEditSave: () => { saveCalls += 1; } });
+    const saveEvent = keyEvent("Enter", { ctrlKey: true });
+    act(() => textarea.props.onKeyDown(saveEvent));
+    expect(saveCalls).toBe(1);
+    expect(saveEvent.wasPrevented()).toBe(true);
+  });
 });

--- a/web/src/components/MessageCard.tsx
+++ b/web/src/components/MessageCard.tsx
@@ -433,7 +433,10 @@ function MessageCardImpl({
   const canTask = canReply && canCreateTask;
   const canEdit = canReply && canRevise;
   const canRetract = canReply && canRevise;
-  const saveDisabled = editSaving || editDraft.trim() === "" || editDraft === msg.body;
+  // #722：只在「保存中」或「空」时禁用。原来还带 `editDraft === msg.body`——编辑器一打开草稿
+  // 就等于原文,保存键当场变灰、看着像坏了(用户报「编辑后点不了保存」)。改为始终可点:未改动就
+  // 点保存时由 onEditSave 直接关掉编辑器(见 Channel.saveEdit),不发无谓请求。
+  const saveDisabled = editSaving || editDraft.trim() === "";
   const menuItemCount = Number(canReply) + Number(canTask) + Number(canEdit) + Number(canRetract) + 1;
   // 引用预览：quotedMessage 为 null 有两种含义——没引用，或引用目标不在已加载窗口内；
   // 后者在渲染处降级回纯编号 ↩ #N（见下方 JSX），这里只在真有内容时才算标签/预览文字。

--- a/web/src/pages/Channel.tsx
+++ b/web/src/pages/Channel.tsx
@@ -3824,7 +3824,15 @@ export function ChannelPage({
 
   const saveEdit = useCallback(() => {
     if (editingSeq === null || editSaving || editingMessage === null || editingMessage.kind !== "message") return;
-    if (editDraft.trim() === "" || editDraft === editingMessage.body) return;
+    if (editDraft.trim() === "") return;
+    // #722：未改动就点保存 → 直接关掉编辑器(等价取消),不发无谓请求。保存键不再因此变灰,
+    // 所以这里必须把「无变化」当成一次干净的关闭,而不是静默 no-op(否则又变成点了没反应)。
+    if (editDraft.trim() === editingMessage.body.trim()) {
+      setEditingSeq(null);
+      setEditDraft("");
+      setMessageActionError(null);
+      return;
+    }
     setEditSaving(true);
     setMessageActionBusySeq(editingSeq);
     setMessageActionError(null);


### PR DESCRIPTION
## 问题 (#722)

「编辑消息后,点不了保存」。根因:保存键的禁用条件里带了 `editDraft === msg.body`——而编辑器一打开,草稿就被预填成原文,于是**保存键从打开那刻起就是灰的**,直到文字真的和原文分叉。没有任何提示说明为何禁用,用户看到的就是「编辑了却点不了保存」。

## 修复

- **MessageCard**:`saveDisabled` 只保留「保存中 / 内容为空(trim 后)」两个条件,保存键始终可点。
- **Channel.saveEdit**:未改动(trim 后等于原文)时不再静默 no-op,而是**直接关掉编辑器**(等价取消),不发无谓请求;真有改动才发 `edit`。Cmd/Ctrl+Enter 路径同理。
- trim 对齐:原来「空」判断 trim、「未改动」判断不 trim,现统一按 trim 比较。

## 关于撤回(#722 后半「撤回也失败」)

排查后**未改撤回逻辑**:`window.confirm` 在本应用 web 与桌面都通用(kick / archive / roles / token 删改都在用,工作正常),撤回真失败会弹红色 banner(`Channel.revise.retract.failed` / `.forbidden`),不是静默。若你那边撤回有具体报错,请把那条 **红条文案**发我——据此定位是服务端 revise/retract 路由的问题再单独修。

## 测试

`MessageCard.editing.test.tsx` 新增 `saveDisabled` 矩阵:等于原文可点 / 有改动可点 / 空禁用 / 保存中禁用 / 等于原文时 Cmd+Enter 触发 onEditSave。web 全量 **1009 pass**、typecheck + build 通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 编辑消息时，即使内容未修改，也可正常点击“保存”并退出编辑状态。
  * “保存”按钮仅在“保存中”或草稿为空/纯空白时禁用；未修改的草稿不再被禁用。
  * 点击保存后会清空编辑草稿并清除相关错误提示，避免界面无响应。
* **测试**
  * 新增对“保存按钮可点击性”及 `Cmd/Ctrl + Enter` 快捷键触发保存行为的覆盖用例。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->