### PR TITLE
fix(serve): 没开 --auto-upgrade 时启动提醒一次 (#720)

### DIFF
--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -4027,6 +4027,11 @@ export async function runServe(o: ServeOptions): Promise<number> {
     out(
       `serving #${o.channel} — 每条${o.mentionsOnly ? " @你 的" : ""}消息触发一次命令（Ctrl-C 停）`,
     );
+    // #720：没开 --auto-upgrade 的常驻会卡在旧版——权限墙拦 `curl … | sh`、重启又自毁本轮会话。
+    // 提醒一次:加 --auto-upgrade(唤醒间隙自行下载+校验+re-exec,无需人工),或用桌面版 launchd 常驻(默认带)。
+    if (o.autoUpgrade !== true) {
+      out("serve: 未开 --auto-upgrade——本进程不会自升级，落后版本需人工重启。加 --auto-upgrade 让它在唤醒间隙自行换新，或用桌面版「转为常驻」(launchd，默认带)。");
+    }
     if (o.statusline === true) {
       heartbeat = setInterval(() => {
         bestEffortLocalState(() => writeStatuslineCache({

--- a/cli/test/serve-health.test.ts
+++ b/cli/test/serve-health.test.ts
@@ -39,6 +39,30 @@ function opts(over: Partial<ServeOptions> & { server: string }): ServeOptions {
   };
 }
 
+describe("serve --auto-upgrade 启动提醒 (#720)", () => {
+  function archiveAfterWelcome(): MockServer {
+    return startMockServer((frame, sock) => {
+      if (frame.type !== "hello") return;
+      sock.send(welcomeFrame(1, "me"));
+      setTimeout(() => sock.send({ type: "error", code: "archived", message: "done" }), 30);
+    });
+  }
+
+  test("没开 --auto-upgrade：启动时提醒一次不会自升级", async () => {
+    server = archiveAfterWelcome();
+    const lines: string[] = [];
+    await runServe(opts({ server: server.url, runCommand: async () => {}, out: (l) => lines.push(l) }));
+    expect(lines.filter((l) => l.includes("未开 --auto-upgrade")).length).toBe(1);
+  });
+
+  test("开了 --auto-upgrade：不提醒", async () => {
+    server = archiveAfterWelcome();
+    const lines: string[] = [];
+    await runServe(opts({ server: server.url, autoUpgrade: true, runCommand: async () => {}, out: (l) => lines.push(l) }));
+    expect(lines.some((l) => l.includes("未开 --auto-upgrade"))).toBe(false);
+  });
+});
+
 describe("serve writes local WS health (#254)", () => {
   test("welcome + frames mark ws_connected and stamp a fresh last_frame_at", async () => {
     server = startMockServer((frame, sock) => {


### PR DESCRIPTION
## 背景 (#720)

Issue 截图:权限墙里的常驻 welcome runner 卡在旧版(v0.2.136)无法自升级——收到「可以升级」批准后报告失败,原因:①`curl … | sh` 被 runner 权限墙拦;②`install.sh` 装完重启 `serve`,而 serve 正是承载当前会话的进程,重启即自毁本轮。

## 现状其实已解决大半

`party serve --auto-upgrade` 早已能在**唤醒间隙自行下载 + 校验 + re-exec** 新二进制(无需人工、不吃权限墙),桌面版「转为常驻」(launchd)也**默认带** `--auto-upgrade`。截图里那个 runner 只是被裸 `serve` 手启、没带这个 flag。

## 改动(option A:补上缺的信号)

裸 `serve` 对「我不会自升级」**毫无提示**。补一条启动提醒:未开 `--auto-upgrade` 时打印一次,指路加 `--auto-upgrade`(唤醒间隙自升级)或用桌面版「转为常驻」(launchd,默认带)。开了则不打扰。

这样以后再有人裸启常驻,一眼就知道该怎么让它自愈,而不是等升级批准后才发现走不通。

## 测试

新增开/关 `--auto-upgrade` 两个用例(关时提醒恰一次、开时不提醒)。`serve-health.test.ts` 全绿、tsc 通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 使用 `serve` 启动常驻进程且未启用自动升级时，新增启动提示。
  - 提示用户该进程不会自动更新，版本落后时需手动重启，或使用默认支持自动升级的桌面版常驻方式。

- **测试**
  - 增加自动升级开关相关验证，确保未启用时提示仅显示一次，启用后不再显示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->