### PR TITLE
feat(desktop): 常驻 agent 日志查看器 (#725)

### DIFF
--- a/desktop/src-tauri/src/duty.rs
+++ b/desktop/src-tauri/src/duty.rs
@@ -585,14 +585,29 @@ pub(crate) fn desktop_duty_log_read(label: String, max_bytes: Option<usize>) -> 
     if label.contains('/') || label.contains("..") {
         return Err("invalid duty label".to_string());
     }
+    use std::io::{Read as _, Seek as _};
     let home = home_dir()?;
     let path = duty_log_path(&home, &label);
-    let cap = max_bytes.unwrap_or(64 * 1024).min(1024 * 1024);
-    match fs::read(&path) {
-        Ok(bytes) => Ok(tail_utf8(&bytes, cap)),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(String::new()),
-        Err(error) => Err(format!("cannot read duty log: {error}")),
+    let cap = (max_bytes.unwrap_or(64 * 1024).min(1024 * 1024)) as u64;
+    // 只读尾部 cap 字节:launchd 日志无轮转、可能很大,seek 到末尾前 cap 处再读,别整文件进内存。
+    let mut file = match std::fs::File::open(&path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(String::new()),
+        Err(error) => return Err(format!("cannot open duty log: {error}")),
+    };
+    let len = file
+        .metadata()
+        .map_err(|error| format!("cannot stat duty log: {error}"))?
+        .len();
+    if len > cap {
+        file.seek(std::io::SeekFrom::Start(len - cap))
+            .map_err(|error| format!("cannot seek duty log: {error}"))?;
     }
+    let mut buf = Vec::new();
+    file.read_to_end(&mut buf)
+        .map_err(|error| format!("cannot read duty log: {error}"))?;
+    // seek 可能切在多字节字符中间——tail_utf8 前移到字符边界。
+    Ok(tail_utf8(&buf, buf.len()))
 }
 
 #[cfg(test)]

--- a/desktop/src-tauri/src/duty.rs
+++ b/desktop/src-tauri/src/duty.rs
@@ -124,6 +124,16 @@ pub(crate) fn duty_log_path(home: &Path, label: &str) -> PathBuf {
     home.join(".agentparty/desktop/logs").join(format!("{label}.log"))
 }
 
+/// 取日志尾部 cap 字节，并前移到 UTF-8 字符边界（不截断多字节字符）。#725：桌面看常驻日志。
+fn tail_utf8(bytes: &[u8], cap: usize) -> String {
+    let mut start = bytes.len().saturating_sub(cap);
+    // 0b10xx_xxxx 是 UTF-8 续接字节；从这种字节起会切坏字符，往后挪到一个首字节。
+    while start < bytes.len() && (bytes[start] & 0xC0) == 0x80 {
+        start += 1;
+    }
+    String::from_utf8_lossy(&bytes[start..]).into_owned()
+}
+
 pub(crate) fn duty_bin_path(home: &Path) -> PathBuf {
     home.join(".agentparty/desktop/bin/party")
 }
@@ -563,9 +573,43 @@ pub(crate) fn desktop_duty_unpersist(instance_id: String) -> Result<(), String> 
     }
 }
 
+/// 读某个常驻实例的 launchd 日志尾部（#725：桌面排查常驻 agent）。
+/// 只按 label 派生路径、且 label 必须是我们生成的前缀——杜绝任意路径读取。日志不存在时返回空串。
+#[cfg(desktop)]
+#[tauri::command]
+pub(crate) fn desktop_duty_log_read(label: String, max_bytes: Option<usize>) -> Result<String, String> {
+    if !label.starts_with(DUTY_LABEL_PREFIX) {
+        return Err("not a duty label".to_string());
+    }
+    // label 只允许 launchd 合法字符（生成时已限定）——再挡一次 '/' 与 '..' 目录穿越。
+    if label.contains('/') || label.contains("..") {
+        return Err("invalid duty label".to_string());
+    }
+    let home = home_dir()?;
+    let path = duty_log_path(&home, &label);
+    let cap = max_bytes.unwrap_or(64 * 1024).min(1024 * 1024);
+    match fs::read(&path) {
+        Ok(bytes) => Ok(tail_utf8(&bytes, cap)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(String::new()),
+        Err(error) => Err(format!("cannot read duty log: {error}")),
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{duty_label, duty_plist_content, instance_id_from_label, DutyPlistSpec};
+    use super::{duty_label, duty_plist_content, instance_id_from_label, tail_utf8, DutyPlistSpec};
+
+    #[test]
+    fn tail_utf8_keeps_char_boundary_and_caps_length() {
+        // 多字节内容:每个「日/志」是 3 字节。cap 落在字符中间时应前移到边界,不产生替换符。
+        let full = "abc日志日志".to_string();
+        let bytes = full.as_bytes();
+        let tail = tail_utf8(bytes, 5); // 落在某个多字节字符中间
+        assert!(!tail.contains('\u{FFFD}'), "tail must not split a multibyte char: {tail:?}");
+        assert!(full.ends_with(&tail));
+        assert_eq!(tail_utf8(bytes, 9999), full); // cap 超长 → 原样
+        assert_eq!(tail_utf8(b"", 10), ""); // 空输入
+    }
 
     #[test]
     fn label_maps_colon_to_dot_and_round_trips() {

--- a/desktop/src-tauri/src/duty.rs
+++ b/desktop/src-tauri/src/duty.rs
@@ -604,7 +604,9 @@ pub(crate) fn desktop_duty_log_read(label: String, max_bytes: Option<usize>) -> 
             .map_err(|error| format!("cannot seek duty log: {error}"))?;
     }
     let mut buf = Vec::new();
-    file.read_to_end(&mut buf)
+    // take(cap):serve 正在往日志追加,seek 后到 EOF 可能已超过 cap——硬性封顶到 cap 字节。
+    file.take(cap)
+        .read_to_end(&mut buf)
         .map_err(|error| format!("cannot read duty log: {error}"))?;
     // seek 可能切在多字节字符中间——tail_utf8 前移到字符边界。
     Ok(tail_utf8(&buf, buf.len()))

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -1187,7 +1187,8 @@ pub fn run() {
             duty::desktop_duty_list,
             duty::desktop_duty_persist,
             duty::desktop_duty_adopt,
-            duty::desktop_duty_unpersist
+            duty::desktop_duty_unpersist,
+            duty::desktop_duty_log_read
         ]);
 
     #[cfg(mobile)]

--- a/web/src/components/DesktopAgentPanel.test.tsx
+++ b/web/src/components/DesktopAgentPanel.test.tsx
@@ -56,6 +56,7 @@ function adapter(overrides: Partial<DesktopAgentAdapter> = {}): DesktopAgentAdap
     dutyAdopt: async () => {
       throw new Error("duty adopt unavailable");
     },
+    dutyLogRead: async () => "",
     ...overrides,
   };
 }

--- a/web/src/components/DesktopSettings.tsx
+++ b/web/src/components/DesktopSettings.tsx
@@ -7,6 +7,7 @@ import {
 import { useT, type TFunc } from "../i18n/useT";
 import "../i18n/strings/DesktopSettings";
 import { DesktopAgentPanel } from "./DesktopAgentPanel";
+import { ResidentDutyLogs } from "./ResidentDutyLogs";
 import { LocalAgentsOverview } from "./LocalAgentsOverview";
 import { desktopAgentAdapter, type DesktopAgentAdapter } from "../lib/desktopAgent";
 import {
@@ -192,6 +193,8 @@ export function DesktopSettingsPanel({
       {/* #700：全局「本机 agent」概览——按频道分组 + 可检索（不限频道）。下方 DesktopAgentPanel 仍是启动器。 */}
       <LocalAgentsOverview t={t} adapter={agentAdapter} />
       <DesktopAgentPanel adapter={agentAdapter} t={t} />
+      {/* #725：常驻(launchd) agent 的日志查看——排查「设了常驻、@ 没反应」。 */}
+      <ResidentDutyLogs t={t} adapter={agentAdapter} />
     </section>
   );
 }

--- a/web/src/components/LocalAgentsOverview.test.tsx
+++ b/web/src/components/LocalAgentsOverview.test.tsx
@@ -39,6 +39,7 @@ function adapter(over: Partial<DesktopAgentAdapter> = {}): DesktopAgentAdapter {
     dutyPersist: async () => { throw new Error("na"); },
     dutyUnpersist: async () => {},
     dutyAdopt: async () => { throw new Error("na"); },
+    dutyLogRead: async () => "",
     ...over,
   };
 }

--- a/web/src/components/ResidentDutyLogs.test.tsx
+++ b/web/src/components/ResidentDutyLogs.test.tsx
@@ -81,6 +81,26 @@ describe("ResidentDutyLogs (#725)", () => {
     expect(JSON.stringify(r.toJSON())).toContain("serve: online");
   });
 
+  test("快速切换条目:慢请求不覆盖后点击的日志(#734 排序保护)", async () => {
+    const resolvers: Record<string, (v: string) => void> = {};
+    const r = await renderPanel({
+      dutyList: async () => [
+        entry({ label: "com.agentparty.duty.a.one", instanceId: "a:one" }),
+        entry({ label: "com.agentparty.duty.b.two", instanceId: "b:two" }),
+      ],
+      dutyLogRead: (label: string) => new Promise<string>((resolve) => { resolvers[label] = resolve; }),
+    });
+    const items = buttons(r).filter((b) => JSON.stringify(b.props.className).includes("resident-logs-item"));
+    await act(async () => { void items[0]!.props.onClick(); }); // 点 one(未 resolve)
+    await act(async () => { void items[1]!.props.onClick(); }); // 再点 two(未 resolve)
+    // two 先回,再让 one 回——one 是过期请求,不该覆盖 two 的日志
+    await act(async () => { resolvers["com.agentparty.duty.b.two"]!("LOG TWO"); });
+    await act(async () => { resolvers["com.agentparty.duty.a.one"]!("LOG ONE"); });
+    const text = JSON.stringify(r.toJSON());
+    expect(text).toContain("LOG TWO");
+    expect(text).not.toContain("LOG ONE");
+  });
+
   test("无常驻实例 → 空状态", async () => {
     const r = await renderPanel({ dutyList: async () => [], dutyLogRead: async () => "" });
     expect(JSON.stringify(r.toJSON())).toContain("ResidentDutyLogs.empty");

--- a/web/src/components/ResidentDutyLogs.test.tsx
+++ b/web/src/components/ResidentDutyLogs.test.tsx
@@ -1,0 +1,93 @@
+// @ts-expect-error Bun executes this test, while the web tsconfig intentionally loads only Vite globals.
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { act, create, type ReactTestInstance, type ReactTestRenderer } from "react-test-renderer";
+import { LocaleProvider } from "../i18n/locale";
+import type { DesktopDutyEntry } from "../lib/desktopAgent";
+
+const { ResidentDutyLogs } = await import("./ResidentDutyLogs");
+
+function memoryStorage(): Storage {
+  const values = new Map<string, string>();
+  return {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => { values.set(key, value); },
+    removeItem: (key) => { values.delete(key); },
+    clear: () => values.clear(),
+    key: (index) => [...values.keys()][index] ?? null,
+    get length() { return values.size; },
+  } as Storage;
+}
+
+function entry(over: Partial<DesktopDutyEntry> = {}): DesktopDutyEntry {
+  return {
+    label: "com.agentparty.duty.abc123.kyc",
+    instanceId: "abc123:kyc",
+    plistPath: "/p.plist",
+    logPath: "/l.log",
+    loaded: true,
+    ...over,
+  };
+}
+
+let renderer: ReactTestRenderer | null = null;
+
+beforeEach(() => {
+  Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", { configurable: true, value: true });
+  Object.defineProperty(globalThis, "localStorage", { configurable: true, value: memoryStorage() });
+  localStorage.setItem("ap_locale", "en");
+});
+
+afterEach(() => {
+  act(() => renderer?.unmount());
+  renderer = null;
+});
+
+async function renderPanel(adapter: { dutyList: () => Promise<DesktopDutyEntry[]>; dutyLogRead: (label: string) => Promise<string> }): Promise<ReactTestRenderer> {
+  await act(async () => {
+    renderer = create(
+      <LocaleProvider>
+        <ResidentDutyLogs t={((k: string) => k) as never} adapter={adapter} />
+      </LocaleProvider>,
+    );
+  });
+  return renderer!;
+}
+
+function buttons(r: ReactTestRenderer): ReactTestInstance[] {
+  return r.root.findAll((n) => n.type === "button");
+}
+
+describe("ResidentDutyLogs (#725)", () => {
+  test("列出常驻实例并显示频道名", async () => {
+    const r = await renderPanel({
+      dutyList: async () => [entry({ instanceId: "abc:kyc" }), entry({ label: "com.agentparty.duty.def.dev", instanceId: "def:dev", loaded: false })],
+      dutyLogRead: async () => "",
+    });
+    const text = JSON.stringify(r.toJSON());
+    // JSX 的 `#{channel}` 会被拆成 ["#","kyc"] 两个文本节点,断言频道名本身即可。
+    expect(text).toContain('"kyc"');
+    expect(text).toContain('"dev"');
+  });
+
+  test("点某个实例 → 读取并展示其日志尾部", async () => {
+    const reads: string[] = [];
+    const r = await renderPanel({
+      dutyList: async () => [entry()],
+      dutyLogRead: async (label) => { reads.push(label); return "▶ wake seq=42\nserve: online"; },
+    });
+    const item = buttons(r).find((b) => JSON.stringify(b.props.className).includes("resident-logs-item"))!;
+    await act(async () => { await item.props.onClick(); });
+    expect(reads).toEqual(["com.agentparty.duty.abc123.kyc"]);
+    expect(JSON.stringify(r.toJSON())).toContain("serve: online");
+  });
+
+  test("无常驻实例 → 空状态", async () => {
+    const r = await renderPanel({ dutyList: async () => [], dutyLogRead: async () => "" });
+    expect(JSON.stringify(r.toJSON())).toContain("ResidentDutyLogs.empty");
+  });
+
+  test("dutyList 失败 → 展示错误横幅,不崩", async () => {
+    const r = await renderPanel({ dutyList: async () => { throw new Error("launchctl down"); }, dutyLogRead: async () => "" });
+    expect(JSON.stringify(r.toJSON())).toContain("launchctl down");
+  });
+});

--- a/web/src/components/ResidentDutyLogs.tsx
+++ b/web/src/components/ResidentDutyLogs.tsx
@@ -1,0 +1,116 @@
+// #725：桌面端「常驻 agent 日志」——枚举本机 launchd 常驻实例，点开看它的 serve 日志尾部，
+// 方便排查「设了常驻、@ 没反应」这类问题(日志里能看到 ▶ wake / serve: / runner 报错)。
+import { useCallback, useEffect, useState } from "react";
+import type { TFunc } from "../i18n/useT";
+import { desktopAgentAdapter, type DesktopAgentAdapter, type DesktopDutyEntry } from "../lib/desktopAgent";
+import "../i18n/strings/ResidentDutyLogs";
+
+interface Props {
+  t: TFunc;
+  adapter?: Pick<DesktopAgentAdapter, "dutyList" | "dutyLogRead">;
+}
+
+// instanceId 形如 "<config_id>:<channel>"；频道名给人看，config 短哈希只作区分。
+function channelOf(entry: DesktopDutyEntry): string {
+  const idx = entry.instanceId.lastIndexOf(":");
+  return idx >= 0 ? entry.instanceId.slice(idx + 1) : entry.instanceId;
+}
+
+export function ResidentDutyLogs({ t, adapter = desktopAgentAdapter }: Props) {
+  const [entries, setEntries] = useState<DesktopDutyEntry[] | null>(null);
+  const [listError, setListError] = useState<string | null>(null);
+  const [selected, setSelected] = useState<string | null>(null); // 选中的 label
+  const [log, setLog] = useState<string>("");
+  const [logBusy, setLogBusy] = useState(false);
+  const [logError, setLogError] = useState<string | null>(null);
+
+  const refreshList = useCallback(async () => {
+    setListError(null);
+    try {
+      const list = await adapter.dutyList();
+      setEntries(list);
+      // 选中项若已消失，清掉日志。
+      setSelected((current) => (current !== null && list.some((e) => e.label === current) ? current : null));
+    } catch (err) {
+      setEntries([]);
+      setListError(err instanceof Error ? err.message : String(err));
+    }
+  }, [adapter]);
+
+  const loadLog = useCallback(
+    async (label: string) => {
+      setSelected(label);
+      setLogBusy(true);
+      setLogError(null);
+      try {
+        setLog(await adapter.dutyLogRead(label));
+      } catch (err) {
+        setLog("");
+        setLogError(err instanceof Error ? err.message : String(err));
+      } finally {
+        setLogBusy(false);
+      }
+    },
+    [adapter],
+  );
+
+  useEffect(() => {
+    void refreshList();
+  }, [refreshList]);
+
+  return (
+    <div className="resident-logs">
+      <div className="resident-logs-head">
+        <h3 className="resident-logs-title">{t("ResidentDutyLogs.title")}</h3>
+        <button type="button" className="d-btn resident-logs-refresh" onClick={() => void refreshList()}>
+          {t("ResidentDutyLogs.refresh")}
+        </button>
+      </div>
+      <p className="resident-logs-lead">{t("ResidentDutyLogs.lead")}</p>
+
+      {listError !== null && <p className="banner banner--red" role="alert">{listError}</p>}
+
+      {entries !== null && entries.length === 0 && listError === null ? (
+        <p className="resident-logs-empty">{t("ResidentDutyLogs.empty")}</p>
+      ) : (
+        <ul className="resident-logs-list">
+          {(entries ?? []).map((entry) => (
+            <li key={entry.label}>
+              <button
+                type="button"
+                className={`d-btn resident-logs-item${selected === entry.label ? " resident-logs-item--active" : ""}`}
+                onClick={() => void loadLog(entry.label)}
+              >
+                <span className="resident-logs-chan">#{channelOf(entry)}</span>
+                <span className={`resident-logs-dot${entry.loaded ? " resident-logs-dot--on" : ""}`} aria-hidden="true">
+                  ●
+                </span>
+                <span className="resident-logs-state">
+                  {entry.loaded ? t("ResidentDutyLogs.loaded") : t("ResidentDutyLogs.stopped")}
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {selected !== null && (
+        <div className="resident-logs-view">
+          <div className="resident-logs-view-head">
+            <span className="t-mono resident-logs-label">{selected}</span>
+            <button type="button" className="d-btn resident-logs-reload" disabled={logBusy} onClick={() => void loadLog(selected)}>
+              {logBusy ? t("ResidentDutyLogs.loading") : t("ResidentDutyLogs.reload")}
+            </button>
+          </div>
+          {logError !== null && <p className="banner banner--red" role="alert">{logError}</p>}
+          {logError === null &&
+            (log.trim() === "" ? (
+              <p className="resident-logs-empty">{t("ResidentDutyLogs.noLog")}</p>
+            ) : (
+              <pre className="t-mono resident-logs-pre">{log}</pre>
+            ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/ResidentDutyLogs.tsx
+++ b/web/src/components/ResidentDutyLogs.tsx
@@ -1,6 +1,6 @@
 // #725：桌面端「常驻 agent 日志」——枚举本机 launchd 常驻实例，点开看它的 serve 日志尾部，
 // 方便排查「设了常驻、@ 没反应」这类问题(日志里能看到 ▶ wake / serve: / runner 报错)。
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { TFunc } from "../i18n/useT";
 import { desktopAgentAdapter, type DesktopAgentAdapter, type DesktopDutyEntry } from "../lib/desktopAgent";
 import "../i18n/strings/ResidentDutyLogs";
@@ -23,6 +23,8 @@ export function ResidentDutyLogs({ t, adapter = desktopAgentAdapter }: Props) {
   const [log, setLog] = useState<string>("");
   const [logBusy, setLogBusy] = useState(false);
   const [logError, setLogError] = useState<string | null>(null);
+  // 请求排序保护:快速切换条目时,只让「最后一次点击」的结果落地,避免慢请求覆盖新选中的日志。
+  const loadSeqRef = useRef(0);
 
   const refreshList = useCallback(async () => {
     setListError(null);
@@ -39,16 +41,20 @@ export function ResidentDutyLogs({ t, adapter = desktopAgentAdapter }: Props) {
 
   const loadLog = useCallback(
     async (label: string) => {
+      const seq = ++loadSeqRef.current;
       setSelected(label);
       setLogBusy(true);
       setLogError(null);
       try {
-        setLog(await adapter.dutyLogRead(label));
+        const text = await adapter.dutyLogRead(label);
+        if (seq !== loadSeqRef.current) return; // 已被更晚的点击取代——丢弃这次结果
+        setLog(text);
       } catch (err) {
+        if (seq !== loadSeqRef.current) return;
         setLog("");
         setLogError(err instanceof Error ? err.message : String(err));
       } finally {
-        setLogBusy(false);
+        if (seq === loadSeqRef.current) setLogBusy(false);
       }
     },
     [adapter],

--- a/web/src/components/ResidentDutyLogs.tsx
+++ b/web/src/components/ResidentDutyLogs.tsx
@@ -43,6 +43,7 @@ export function ResidentDutyLogs({ t, adapter = desktopAgentAdapter }: Props) {
     async (label: string) => {
       const seq = ++loadSeqRef.current;
       setSelected(label);
+      setLog(""); // 先清掉旧日志,别让上一条实例的内容残留在新标题下(加载中会显示 loading)
       setLogBusy(true);
       setLogError(null);
       try {

--- a/web/src/i18n/strings/ResidentDutyLogs.ts
+++ b/web/src/i18n/strings/ResidentDutyLogs.ts
@@ -1,0 +1,29 @@
+import { registerDict, type LocaleDict } from "../dict";
+
+// #725：桌面「常驻 agent 日志」查看器的文案。
+export const ResidentDutyLogsStrings: LocaleDict = {
+  en: {
+    "ResidentDutyLogs.title": "Resident agent logs",
+    "ResidentDutyLogs.lead": "Launchd-resident agents on this Mac. Open one to read its serve log — useful when a resident agent isn't responding to @-mentions.",
+    "ResidentDutyLogs.refresh": "refresh",
+    "ResidentDutyLogs.empty": "No resident agents on this Mac. Make one resident from an agent's “make resident”.",
+    "ResidentDutyLogs.loaded": "running",
+    "ResidentDutyLogs.stopped": "not loaded",
+    "ResidentDutyLogs.reload": "reload log",
+    "ResidentDutyLogs.loading": "loading…",
+    "ResidentDutyLogs.noLog": "Log is empty (the agent may not have woken yet).",
+  },
+  zh: {
+    "ResidentDutyLogs.title": "常驻 agent 日志",
+    "ResidentDutyLogs.lead": "本机 launchd 常驻的 agent。点开看它的 serve 日志——「设了常驻、@ 没反应」时靠它排查。",
+    "ResidentDutyLogs.refresh": "刷新",
+    "ResidentDutyLogs.empty": "本机没有常驻 agent。可在某个 agent 上「转为常驻」。",
+    "ResidentDutyLogs.loaded": "运行中",
+    "ResidentDutyLogs.stopped": "未加载",
+    "ResidentDutyLogs.reload": "重载日志",
+    "ResidentDutyLogs.loading": "加载中…",
+    "ResidentDutyLogs.noLog": "日志为空（agent 可能还没被唤醒过）。",
+  },
+};
+
+registerDict(ResidentDutyLogsStrings);

--- a/web/src/lib/desktopAgent.ts
+++ b/web/src/lib/desktopAgent.ts
@@ -59,6 +59,8 @@ export interface DesktopAgentAdapter {
   dutyUnpersist(instanceId: string): Promise<void>;
   /** #616 phase 4：web 无人值守流程一键接管——token 经本机 IPC 直达，绝不进 URL/剪贴板。 */
   dutyAdopt(input: { server: string; token: string; name: string; channel: string; runner: DesktopAgentRunner; workdir?: string }): Promise<DesktopDutyEntry>;
+  /** #725：读某个常驻实例的 launchd 日志尾部（排查「@ 没反应」等）。日志不存在返回空串。 */
+  dutyLogRead(label: string, maxBytes?: number): Promise<string>;
 }
 
 export type DesktopAgentInvoker = <T>(command: string, args?: Record<string, unknown>) => Promise<T>;
@@ -219,6 +221,13 @@ export function createDesktopAgentAdapter(invoke: DesktopAgentInvoker): DesktopA
         runner: input.runner,
         workdir: input.workdir ?? null,
       }));
+    },
+    async dutyLogRead(label, maxBytes) {
+      const value = await invoke<unknown>("desktop_duty_log_read", {
+        label,
+        maxBytes: maxBytes ?? null,
+      });
+      return typeof value === "string" ? value : "";
     },
   };
 }

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -273,6 +273,23 @@
   font-size: 10px;
   line-height: 1.45;
 }
+/* #725：常驻 agent 日志查看器 */
+.resident-logs { margin-top: 10px; padding-top: 10px; border-top: 1px solid var(--t-faint); }
+.resident-logs-head { display: flex; align-items: center; justify-content: space-between; gap: 10px; }
+.resident-logs-title { margin: 0; font-size: 12px; }
+.resident-logs-lead { margin: 4px 0 8px; font-size: 12px; color: var(--t-dim); }
+.resident-logs-empty { margin: 6px 0; font-size: 12px; color: var(--t-dim); }
+.resident-logs-list { list-style: none; margin: 0 0 8px; padding: 0; display: flex; flex-direction: column; gap: 4px; }
+.resident-logs-item { display: flex; align-items: center; gap: 8px; width: 100%; justify-content: flex-start; text-align: left; }
+.resident-logs-item--active { border-color: var(--d-blue); color: var(--d-blue); }
+.resident-logs-chan { font-weight: 600; }
+.resident-logs-dot { color: var(--t-faint); font-size: 10px; }
+.resident-logs-dot--on { color: var(--d-green); }
+.resident-logs-state { font-size: 11px; color: var(--t-dim); }
+.resident-logs-view-head { display: flex; align-items: center; justify-content: space-between; gap: 10px; margin-bottom: 6px; }
+.resident-logs-label { font-size: 11px; color: var(--t-dim); word-break: break-all; }
+.resident-logs-pre { max-height: 320px; overflow: auto; margin: 0; padding: 8px; font-size: 11px; line-height: 1.5; background: var(--t-faint); border-radius: 4px; white-space: pre-wrap; word-break: break-word; }
+
 .desktop-agent { margin-top: 10px; padding-top: 10px; border-top: 1px solid var(--t-faint); }
 .desktop-agent-head { display: flex; align-items: center; justify-content: space-between; gap: 10px; }
 .desktop-agent-head strong { font-size: 12px; }

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -288,7 +288,7 @@
 .resident-logs-state { font-size: 11px; color: var(--t-dim); }
 .resident-logs-view-head { display: flex; align-items: center; justify-content: space-between; gap: 10px; margin-bottom: 6px; }
 .resident-logs-label { font-size: 11px; color: var(--t-dim); word-break: break-all; }
-.resident-logs-pre { max-height: 320px; overflow: auto; margin: 0; padding: 8px; font-size: 11px; line-height: 1.5; background: var(--t-faint); border-radius: 4px; white-space: pre-wrap; word-break: break-word; }
+.resident-logs-pre { max-height: 320px; overflow: auto; margin: 0; padding: 8px; font-size: 11px; line-height: 1.5; background: var(--t-faint); border-radius: 4px; white-space: pre-wrap; overflow-wrap: anywhere; }
 
 .desktop-agent { margin-top: 10px; padding-top: 10px; border-top: 1px solid var(--t-faint); }
 .desktop-agent-head { display: flex; align-items: center; justify-content: space-between; gap: 10px; }


### PR DESCRIPTION
## 背景

#725 评论:「桌面端应该有地方可以看所有常驻 agent 的工作日志,方便排查问题」。此前 `dutyList()` 有适配器接口但**没有任何 UI 消费它**——launchd 常驻实例的 serve 日志(`▶ wake` / `serve:` / runner 报错)无处可看,「设了常驻、@ 没反应」只能干瞪眼。

## 改动

- **Rust**:新增 `desktop_duty_log_read(label, max_bytes?)` 命令——按 label 派生 launchd 日志路径读尾部(默认 64KB、封顶 1MB)。label 必须是 `com.agentparty.duty.` 前缀且挡 `/`、`..` 目录穿越;日志不存在返回空串。抽 `tail_utf8()` 保证按 UTF-8 字符边界截断(不切坏多字节字),带单测。注册进 `generate_handler`。
- **desktopAgent.ts**:补 `dutyLogRead` 适配器方法。
- **ResidentDutyLogs 组件**:列出本机常驻实例(频道名 + 运行中/未加载徽标),点开读其日志尾部,带刷新/重载、空状态、错误横幅。嵌进 `DesktopSettings`(`DesktopAgentPanel` 下方)。en/zh i18n + CSS。

## 关联 #725

至此 #725 三块全覆盖:(a) codex 常驻 @ 没反应 = #728 已发(v0.2.140);(b) 转常驻可选 codex/claude = #731 已发;(c) 本 PR = 看常驻日志。

## 测试

- 组件 4 例:列出实例 / 点开读日志 / 空态 / `dutyList` 失败不崩。
- 两个既有 mock adapter 补 `dutyLogRead`。
- Rust `tail_utf8` 单测(字符边界 + 封顶 + 空输入)。

web 全量 **1014 pass**、typecheck + build 通过。桌面 Rust 由 CI `check-desktop` (macOS `cargo test/check`) 验证——本地磁盘紧张未跑。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 在桌面设置新增“常驻 Agent 日志查看器”：支持刷新实例、选择条目展示 loaded/serve 状态，并按需读取日志尾部。
  * 前端与桌面端新增日志读取能力，按最大字节读取并避免 UTF-8 字符被截断。
  * 补充中文/英文界面文案。
* **桌面端**
  * 新增日志尾部读取命令，并对非法输入做安全校验；文件不存在时返回空结果。
* **样式**
  * 增加日志查看器面板与日志预览相关样式。
* **测试**
  * 新增组件测试与 UTF-8 截断边界用例；更新适配器 mock，并覆盖快速切换不覆盖旧请求、空态与错误态。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->