### PR TITLE
fix(web): 输入法确认候选的回车不再误发消息 (#729)

### DIFF
--- a/web/src/components/Composer.ime.test.tsx
+++ b/web/src/components/Composer.ime.test.tsx
@@ -1,0 +1,93 @@
+// #729：输入法确认候选的回车不能误发消息。WebKit/WKWebView(桌面版)里 compositionend 早于
+// 确认键 keydown,那一刻 isComposing 已是 false——只靠 isComposing 会漏拦。这里用可控的 rAF
+// 精确复现「compositionend → 确认 Enter(isComposing=false) → 才放开护栏」的时序。
+// @ts-expect-error Bun executes this test, while the web tsconfig intentionally loads only Vite globals.
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { LocaleProvider } from "../i18n/locale";
+import { Composer } from "./Composer";
+
+let renderer: ReactTestRenderer | null = null;
+let rafQueue: Array<() => void> = [];
+
+function memoryStorage(): Storage {
+  const values = new Map<string, string>([["ap_locale", "en"]]);
+  return {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => { values.set(key, value); },
+    removeItem: (key) => { values.delete(key); },
+    clear: () => values.clear(),
+    key: (index) => [...values.keys()][index] ?? null,
+    get length() { return values.size; },
+  } as Storage;
+}
+
+beforeEach(() => {
+  rafQueue = [];
+  Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", { configurable: true, value: true });
+  Object.defineProperty(globalThis, "localStorage", { configurable: true, value: memoryStorage() });
+  Object.defineProperty(globalThis, "window", { configurable: true, value: { innerHeight: 844 } });
+  // 可控 rAF:攒起来,由测试决定何时放开护栏。
+  Object.defineProperty(globalThis, "requestAnimationFrame", {
+    configurable: true,
+    value: (cb: () => void) => { rafQueue.push(cb); return rafQueue.length; },
+  });
+});
+
+afterEach(() => {
+  act(() => renderer?.unmount());
+  renderer = null;
+  Reflect.deleteProperty(globalThis, "requestAnimationFrame");
+});
+
+function render(onSend: () => void) {
+  act(() => {
+    renderer = create(
+      <LocaleProvider>
+        <Composer
+          draft="你好"
+          setDraft={() => undefined}
+          onSend={onSend}
+          ready
+          candidates={[]}
+          mentionStatuses={[]}
+        />
+      </LocaleProvider>,
+    );
+  });
+  return renderer!.root.findByProps({ className: "composer-input t-mono" });
+}
+
+function enter(isComposing = false) {
+  return { key: "Enter", preventDefault() {}, nativeEvent: { isComposing }, shiftKey: false, metaKey: false, ctrlKey: false };
+}
+
+describe("Composer 输入法回车不误发 (#729)", () => {
+  test("WebKit 时序:compositionend 后、护栏未放开时的确认 Enter(isComposing=false) 不发送", () => {
+    let sends = 0;
+    const ta = render(() => { sends += 1; });
+    act(() => ta.props.onCompositionStart());
+    act(() => ta.props.onCompositionEnd()); // 把放开动作压进 rafQueue(未执行)
+    act(() => ta.props.onKeyDown(enter(false))); // 确认候选的回车
+    expect(sends).toBe(0);
+    // 放开护栏后,真正的回车才发送
+    act(() => { rafQueue.forEach((cb) => cb()); });
+    act(() => ta.props.onKeyDown(enter(false)));
+    expect(sends).toBe(1);
+  });
+
+  test("合成中(isComposing=true)的 Enter 一律不发送", () => {
+    let sends = 0;
+    const ta = render(() => { sends += 1; });
+    act(() => ta.props.onCompositionStart());
+    act(() => ta.props.onKeyDown(enter(true)));
+    expect(sends).toBe(0);
+  });
+
+  test("非合成状态下普通 Enter 正常发送", () => {
+    let sends = 0;
+    const ta = render(() => { sends += 1; });
+    act(() => ta.props.onKeyDown(enter(false)));
+    expect(sends).toBe(1);
+  });
+});

--- a/web/src/components/Composer.ime.test.tsx
+++ b/web/src/components/Composer.ime.test.tsx
@@ -9,6 +9,12 @@ import { Composer } from "./Composer";
 
 let renderer: ReactTestRenderer | null = null;
 let rafQueue: Array<() => void> = [];
+const savedDescriptors: Record<string, PropertyDescriptor | undefined> = {};
+
+function stubGlobal(key: string, value: unknown) {
+  savedDescriptors[key] = Object.getOwnPropertyDescriptor(globalThis, key);
+  Object.defineProperty(globalThis, key, { configurable: true, value });
+}
 
 function memoryStorage(): Storage {
   const values = new Map<string, string>([["ap_locale", "en"]]);
@@ -24,20 +30,22 @@ function memoryStorage(): Storage {
 
 beforeEach(() => {
   rafQueue = [];
-  Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", { configurable: true, value: true });
-  Object.defineProperty(globalThis, "localStorage", { configurable: true, value: memoryStorage() });
-  Object.defineProperty(globalThis, "window", { configurable: true, value: { innerHeight: 844 } });
+  stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  stubGlobal("localStorage", memoryStorage());
+  stubGlobal("window", { innerHeight: 844 });
   // 可控 rAF:攒起来,由测试决定何时放开护栏。
-  Object.defineProperty(globalThis, "requestAnimationFrame", {
-    configurable: true,
-    value: (cb: () => void) => { rafQueue.push(cb); return rafQueue.length; },
-  });
+  stubGlobal("requestAnimationFrame", (cb: () => void) => { rafQueue.push(cb); return rafQueue.length; });
 });
 
 afterEach(() => {
   act(() => renderer?.unmount());
   renderer = null;
-  Reflect.deleteProperty(globalThis, "requestAnimationFrame");
+  // 还原被替换的全局对象,避免泄漏到后续用例/文件(#735 CodeRabbit)。
+  for (const [key, desc] of Object.entries(savedDescriptors)) {
+    if (desc === undefined) Reflect.deleteProperty(globalThis, key);
+    else Object.defineProperty(globalThis, key, desc);
+    delete savedDescriptors[key];
+  }
 });
 
 function render(onSend: () => void) {
@@ -89,5 +97,29 @@ describe("Composer 输入法回车不误发 (#729)", () => {
     const ta = render(() => { sends += 1; });
     act(() => ta.props.onKeyDown(enter(false)));
     expect(sends).toBe(1);
+  });
+
+  test("无 requestAnimationFrame(SSR/测试环境)时走微任务回退,仍在合成周期内拦住 Enter", async () => {
+    stubGlobal("requestAnimationFrame", undefined); // 触发 Promise 微任务回退分支
+    let sends = 0;
+    const ta = render(() => { sends += 1; });
+    act(() => ta.props.onCompositionStart());
+    act(() => ta.props.onCompositionEnd()); // 放开动作压进微任务(未 flush)
+    act(() => ta.props.onKeyDown(enter(false)));
+    expect(sends).toBe(0);
+    await act(async () => { await Promise.resolve(); }); // flush 微任务 → 放开护栏
+    act(() => ta.props.onKeyDown(enter(false)));
+    expect(sends).toBe(1);
+  });
+
+  test("旧合成周期的延迟回调不清掉新周期的护栏(#735)", () => {
+    let sends = 0;
+    const ta = render(() => { sends += 1; });
+    act(() => ta.props.onCompositionStart()); // 周期1
+    act(() => ta.props.onCompositionEnd());    // 压入周期1的放开(gen=1)
+    act(() => ta.props.onCompositionStart()); // 周期2 立起新护栏(gen=2)
+    act(() => { rafQueue.forEach((cb) => cb()); }); // 周期1的放开触发,但 gen 已变 → 不清
+    act(() => ta.props.onKeyDown(enter(false))); // 仍在周期2合成中 → 不发
+    expect(sends).toBe(0);
   });
 });

--- a/web/src/components/Composer.ime.test.tsx
+++ b/web/src/components/Composer.ime.test.tsx
@@ -12,7 +12,9 @@ let rafQueue: Array<() => void> = [];
 const savedDescriptors: Record<string, PropertyDescriptor | undefined> = {};
 
 function stubGlobal(key: string, value: unknown) {
-  savedDescriptors[key] = Object.getOwnPropertyDescriptor(globalThis, key);
+  // 只在本周期首次替换该 key 时存原始描述符——否则同一用例里二次 stub(如把 rAF 改成 undefined)
+  // 会用「上一个 stub 的描述符」覆盖掉真·原始值,afterEach 还原就会漏(#735 CodeRabbit)。
+  if (!(key in savedDescriptors)) savedDescriptors[key] = Object.getOwnPropertyDescriptor(globalThis, key);
   Object.defineProperty(globalThis, key, { configurable: true, value });
 }
 

--- a/web/src/components/Composer.tsx
+++ b/web/src/components/Composer.tsx
@@ -155,6 +155,10 @@ export function Composer({
     return t("WakeReceipt.pre.offline");
   };
   const taRef = useRef<HTMLTextAreaElement | null>(null);
+  // 输入法合成护栏（#729）：单靠 keydown 的 isComposing 不够——WebKit/WKWebView（桌面版）
+  // 确认候选时 compositionend 先于确认键的 keydown 触发，那一刻 isComposing 已是 false，
+  // 回车会把半成品误发出去。用一个 ref 顶住合成期，并延到下一帧才放开，盖住那次确认 keydown。
+  const composingRef = useRef(false);
   const activeMentionRef = useRef<HTMLDivElement | null>(null);
   const [menu, setMenu] = useState<MentionMenuState | null>(null);
 
@@ -225,8 +229,23 @@ export function Composer({
     [draft, menu, setDraft],
   );
 
+  const onCompositionStart = () => {
+    composingRef.current = true;
+  };
+  const onCompositionEnd = () => {
+    // WebKit/WKWebView 里确认候选的 compositionend 早于确认键 keydown——保持护栏到本轮事件结束后
+    // 的下一帧再放开，确保那次 Enter 的 keydown 仍被拦住。没有 rAF（测试/SSR）时退回微任务。
+    const release = () => {
+      composingRef.current = false;
+    };
+    if (typeof requestAnimationFrame === "function") requestAnimationFrame(release);
+    else void Promise.resolve().then(release);
+  };
+
   const onKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.nativeEvent.isComposing) return;
+    // isComposing 或护栏 ref 任一为真都视为合成中：前者覆盖 Chrome（keydown 时仍 true），
+    // 后者覆盖 WebKit（compositionend 先行、keydown 时已 false）。
+    if (e.nativeEvent.isComposing || composingRef.current) return;
     if (menu !== null) {
       if (e.key === "ArrowDown") {
         e.preventDefault();
@@ -384,6 +403,8 @@ export function Composer({
         onKeyUp={onKeyUp}
         onClick={(e) => recompute(e.currentTarget.value, e.currentTarget.selectionStart ?? 0)}
         onKeyDown={onKeyDown}
+        onCompositionStart={onCompositionStart}
+        onCompositionEnd={onCompositionEnd}
         onPaste={onPaste}
         onBlur={() => setTimeout(() => setMenu(null), 120)}
       />

--- a/web/src/components/Composer.tsx
+++ b/web/src/components/Composer.tsx
@@ -159,6 +159,9 @@ export function Composer({
   // 确认候选时 compositionend 先于确认键的 keydown 触发，那一刻 isComposing 已是 false，
   // 回车会把半成品误发出去。用一个 ref 顶住合成期，并延到下一帧才放开，盖住那次确认 keydown。
   const composingRef = useRef(false);
+  // 合成周期代号:每次 compositionstart 自增,延迟放开只在「还是同一周期」时才清护栏——
+  // 否则上一周期的延迟回调会误清掉新周期刚立起的护栏(#735 CodeRabbit)。
+  const composingGenRef = useRef(0);
   const activeMentionRef = useRef<HTMLDivElement | null>(null);
   const [menu, setMenu] = useState<MentionMenuState | null>(null);
 
@@ -230,13 +233,15 @@ export function Composer({
   );
 
   const onCompositionStart = () => {
+    composingGenRef.current += 1;
     composingRef.current = true;
   };
   const onCompositionEnd = () => {
     // WebKit/WKWebView 里确认候选的 compositionend 早于确认键 keydown——保持护栏到本轮事件结束后
     // 的下一帧再放开，确保那次 Enter 的 keydown 仍被拦住。没有 rAF（测试/SSR）时退回微任务。
+    const gen = composingGenRef.current;
     const release = () => {
-      composingRef.current = false;
+      if (gen === composingGenRef.current) composingRef.current = false; // 新周期已开始就别清
     };
     if (typeof requestAnimationFrame === "function") requestAnimationFrame(release);
     else void Promise.resolve().then(release);


### PR DESCRIPTION
## 问题 (#729)

用输入法(中文/日文等)打字,按回车确认候选词时,消息被**直接发出去**(半成品)。

## 根因

主输入框已有 `if (e.nativeEvent.isComposing) return;` 的护栏,但在 **WebKit/WKWebView**(桌面版的 webview 引擎)里,确认候选时 `compositionend` **早于**确认键的 `keydown` 触发——那一刻 `isComposing` 已经是 `false`,护栏拦不住,回车走到发送分支。(Chrome 是 keydown 时 `isComposing` 仍为 true,所以只在 WebKit/桌面端复现。)

## 修复

加一个 `composingRef`:
- `onCompositionStart` → 置真;
- `onCompositionEnd` → 延到**下一帧**(`requestAnimationFrame`,无 rAF 时退回微任务)才放开,正好盖住那次确认键的 keydown;
- `onKeyDown`:`isComposing || composingRef.current` 任一为真都不发送——前者覆盖 Chrome,后者覆盖 WebKit。

## 测试

用可控 rAF 精确复现 WebKit 时序:compositionend → 确认 Enter(`isComposing=false`)不发送 → 放开护栏后普通 Enter 才发送;另有「合成中 Enter 不发」「普通 Enter 正常发」。web 全量 **1018 pass**、typecheck + build 通过。

## 未覆盖

issue 里另提「输入内容时有时突然断线」较模糊(疑似 WS 重连抖动),需要复现步骤/频率/是否桌面版再单独排查——本 PR 不含。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug 修复**
  - 优化 `Composer` 的 IME 合成期防护：在合成开始设置护栏，合成结束后等下一帧（无 `requestAnimationFrame` 则回退到微任务）才放行回车发送，并避免跨合成周期误释放。
  - 同时拦截合成态与非合成态的异常顺序场景，确保合成态回车始终不发送、普通回车行为保持正常。
- **测试**
  - 新增 IME 合成期覆盖性测试，模拟可控回调时序与跨周期回归用例，验证护栏不会误清除。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->