### PR TITLE
fix(cli): 同步睡眠不再依赖 SharedArrayBuffer——堵住常驻日志刷屏 (#738)

### DIFF
--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -3,6 +3,7 @@ import { homedir, tmpdir } from "node:os";
 import { basename, dirname, join, resolve, sep } from "node:path";
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
+import { sleepSyncMs } from "./sync-sleep";
 import {
   closeSync,
   existsSync,
@@ -444,7 +445,6 @@ export function cwdStatePath(cwd: string = process.cwd()): string {
 
 const STATE_LOCK_TIMEOUT_MS = 5_000;
 const STATE_LOCK_STALE_MS = 30_000;
-const lockWaiter = new Int32Array(new SharedArrayBuffer(4));
 
 function processAlive(pid: number): boolean {
   try {
@@ -487,7 +487,7 @@ function withStateLock<T>(path: string, fn: () => T): T {
       if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
       removeStaleLock(lockPath);
       if (Date.now() >= deadline) throw new Error(`timed out waiting for state lock: ${lockPath}`);
-      Atomics.wait(lockWaiter, 0, 0, 2);
+      sleepSyncMs(2);
     }
   }
 

--- a/cli/src/instance-lock.ts
+++ b/cli/src/instance-lock.ts
@@ -15,6 +15,7 @@ import { createHash, randomUUID } from "node:crypto";
 import { spawnSync } from "node:child_process";
 import { join } from "node:path";
 import { agentpartyHome } from "./config";
+import { sleepSyncMs } from "./sync-sleep";
 
 export type InstanceKind = "watch" | "serve";
 
@@ -145,7 +146,7 @@ export function acquireInstanceLock(kind: InstanceKind, channel: string, dir: st
           /* Another contender already removed the stale reclaim lock. */
         }
       } else {
-        Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 1);
+        sleepSyncMs(1);
       }
       continue;
     }

--- a/cli/src/sync-sleep.ts
+++ b/cli/src/sync-sleep.ts
@@ -1,0 +1,18 @@
+// 同步阻塞睡眠——仅用于同步锁竞争的极短重试(1-2ms),那些代码路径拿不到 async 上下文。
+// 首选 Atomics.wait(SharedArrayBuffer),但某些运行时/沙箱里 SharedArrayBuffer 未定义
+// (#738:常驻 serve 的日志被 "SharedArrayBuffer is not defined" 反复刷屏——根因是有处在模块
+// 顶层就 new SharedArrayBuffer,SAB 缺席时一 import 就抛)。这里每次调用现探测 + 退化忙等,
+// 既不在模块顶层分配、也保证无论环境有没有 SAB 都不再抛异常;ms 极小,忙等开销可忽略。
+
+/** 同步睡眠 ms 毫秒。SharedArrayBuffer 可用则走 Atomics.wait,否则退化为忙等(不抛)。 */
+export function sleepSyncMs(ms: number): void {
+  if (ms <= 0) return;
+  if (typeof SharedArrayBuffer === "function") {
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+    return;
+  }
+  const end = Date.now() + ms;
+  while (Date.now() < end) {
+    /* SAB 不可用时的退化忙等；ms 很小(1-2ms) */
+  }
+}

--- a/cli/test/sync-sleep.test.ts
+++ b/cli/test/sync-sleep.test.ts
@@ -1,0 +1,33 @@
+// #738:同步睡眠不能依赖 SharedArrayBuffer——某些运行时/沙箱里它未定义,原来在模块顶层
+// new SharedArrayBuffer 会让 import 直接抛,常驻 serve 日志被刷屏。
+import { afterEach, describe, expect, test } from "bun:test";
+import { sleepSyncMs } from "../src/sync-sleep";
+
+const realSAB = globalThis.SharedArrayBuffer;
+
+afterEach(() => {
+  // 还原(某些用例会临时删掉 SharedArrayBuffer)
+  Object.defineProperty(globalThis, "SharedArrayBuffer", { configurable: true, value: realSAB });
+});
+
+describe("sleepSyncMs (#738)", () => {
+  test("SharedArrayBuffer 可用:睡够时长且不抛", () => {
+    const start = Date.now();
+    sleepSyncMs(5);
+    expect(Date.now() - start).toBeGreaterThanOrEqual(4);
+  });
+
+  test("SharedArrayBuffer 未定义:退化忙等,仍睡够时长、绝不抛", () => {
+    // @ts-expect-error 故意删掉全局以模拟 SAB 缺席环境
+    delete globalThis.SharedArrayBuffer;
+    expect(typeof SharedArrayBuffer).toBe("undefined");
+    const start = Date.now();
+    expect(() => sleepSyncMs(5)).not.toThrow();
+    expect(Date.now() - start).toBeGreaterThanOrEqual(4);
+  });
+
+  test("ms<=0 直接返回,不分配也不忙等", () => {
+    expect(() => sleepSyncMs(0)).not.toThrow();
+    expect(() => sleepSyncMs(-3)).not.toThrow();
+  });
+});

--- a/cli/test/sync-sleep.test.ts
+++ b/cli/test/sync-sleep.test.ts
@@ -1,13 +1,19 @@
 // #738:同步睡眠不能依赖 SharedArrayBuffer——某些运行时/沙箱里它未定义,原来在模块顶层
 // new SharedArrayBuffer 会让 import 直接抛,常驻 serve 日志被刷屏。
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { sleepSyncMs } from "../src/sync-sleep";
 
-const realSAB = globalThis.SharedArrayBuffer;
+// 逐字保存原始属性描述符再原样还原——直接 defineProperty({configurable,value}) 会丢掉
+// writable/enumerable,让后续代码/用例看到一个语义不同的 SharedArrayBuffer(#739 CodeRabbit)。
+let sabDescriptor: PropertyDescriptor | undefined;
+
+beforeEach(() => {
+  sabDescriptor = Object.getOwnPropertyDescriptor(globalThis, "SharedArrayBuffer");
+});
 
 afterEach(() => {
-  // 还原(某些用例会临时删掉 SharedArrayBuffer)
-  Object.defineProperty(globalThis, "SharedArrayBuffer", { configurable: true, value: realSAB });
+  if (sabDescriptor === undefined) Reflect.deleteProperty(globalThis, "SharedArrayBuffer");
+  else Object.defineProperty(globalThis, "SharedArrayBuffer", sabDescriptor);
 });
 
 describe("sleepSyncMs (#738)", () => {


### PR DESCRIPTION
## 问题 (#738)

常驻 agent 的日志被 `error: SharedArrayBuffer is not defined` 反复刷屏。

## 根因

`cli/src/config.ts` 在**模块顶层**就执行 `const lockWaiter = new Int32Array(new SharedArrayBuffer(4))`(作为同步 state 锁的 `Atomics.wait` 等待区)。某些运行时/沙箱里 `SharedArrayBuffer` 未定义,于是**一 `import config` 就抛**;而 `config` 几乎被所有代码路径 import——常驻 serve 每 fork 一个 party 子进程(status/reply)都在这里炸,日志被刷屏。`cli/src/instance-lock.ts:148` 也有同款「`Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), …)`」用法。

## 修复

抽 `sleepSyncMs(ms)`(`cli/src/sync-sleep.ts`):**每次调用现探测** `SharedArrayBuffer`——可用走 `Atomics.wait`,不可用退化为忙等(ms 极小 1-2ms,开销可忽略)。既**不在模块顶层分配**(消除 import 期抛出),也保证无论环境有没有 SAB 都不再抛未捕获异常。`config.ts` 与 `instance-lock.ts` 两处同步睡眠都切过去。

## 测试

新增 `sync-sleep.test.ts`:① SAB 可用 → 睡够时长不抛;② 删掉 `globalThis.SharedArrayBuffer` → 退化忙等仍睡够时长、`not.toThrow`;③ `ms<=0` 直接返回。cli 全量 **1093 pass**、tsc 通过;代码里已无 `sync-sleep.ts` 之外的 SharedArrayBuffer 引用。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 优化 CLI 状态锁与实例锁的等待/重试逻辑，统一为新的同步阻塞睡眠方式，以提升跨运行环境的兼容性与稳定性。
  * 在不支持相关能力时自动降级为备用等待实现，避免异常并保持合理等待时长。
* **新增**
  * 提供 `sleepSyncMs` 同步等待能力，并在锁竞争场景中使用。
* **测试**
  * 新增 `sleepSyncMs` 测试：覆盖正常等待、能力缺失降级、不抛异常与 `ms<=0` 情况。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->