### PR TITLE
fix(cli): worker 报 blocked 不再拉黑父任务全局 state (#737)

### DIFF
--- a/cli/src/commands/mcp.ts
+++ b/cli/src/commands/mcp.ts
@@ -33,6 +33,7 @@ import {
   listTasks,
   postMessage,
   spawnAgent,
+  taskStateFromReportedStatus,
   updateTask,
   type Identity,
 } from "../rest";
@@ -543,11 +544,9 @@ export function createMcpServer(defaultChannel?: string): McpServer {
         });
         let task = undefined;
         if (task_id !== undefined) {
-          const taskState: TaskState =
-            state === "working" ? "in_progress" :
-            state === "waiting" ? "assigned" :
-            state as TaskState;
-          task = await updateTask(authInfo.server, authInfo.token, resolved, task_id, { state: taskState });
+          // #737:worker 报自己那端 blocked 不再拉黑父任务全局 state(见 taskStateFromReportedStatus)。
+          const taskState = taskStateFromReportedStatus(state);
+          if (taskState !== null) task = await updateTask(authInfo.server, authInfo.token, resolved, task_id, { state: taskState });
         }
         advanceCursorPastOwnMessage(resolved, seq);
         return ok({ type: "status", channel: resolved, seq, state, ...(task !== undefined ? { task } : {}) });

--- a/cli/src/commands/status.ts
+++ b/cli/src/commands/status.ts
@@ -8,14 +8,13 @@ import type {
   SendHostDecision,
   SendStatusWorkflow,
   StatusState,
-  TaskState,
   WakeKind,
   WorkflowKind,
 } from "@agentparty/shared";
 import { isHelpArg, parseArgs, str, strArray, unknownFlagError, valueFlagError } from "../args";
 import { advanceCursorPastOwnMessage, resolveChannel, workspaceId, workspaceLabel, worktreeLabel } from "../config";
 import { formatAuthDebugLine, resolveAuthDetailed } from "../oidc-cli";
-import { fetchMe, handleRestError, postMessage, updateTask } from "../rest";
+import { fetchMe, handleRestError, postMessage, taskStateFromReportedStatus, updateTask } from "../rest";
 import { isName, isSlug, parsePositiveIntFlag } from "../validation";
 
 const STATES: StatusState[] = ["working", "waiting", "blocked", "done"];
@@ -371,11 +370,9 @@ export async function run(argv: string[]): Promise<number> {
       context: buildContext(auth),
     });
     if (taskId !== undefined) {
-      const taskState: TaskState =
-        state === "working" ? "in_progress" :
-        state === "waiting" ? "assigned" :
-        state as TaskState;
-      await updateTask(auth.server, auth.token, channel, taskId, { state: taskState });
+      // #737:worker 报自己那端 blocked 不再拉黑父任务全局 state(见 taskStateFromReportedStatus)。
+      const taskState = taskStateFromReportedStatus(state);
+      if (taskState !== null) await updateTask(auth.server, auth.token, channel, taskId, { state: taskState });
     }
     advanceCursorPastOwnMessage(channel, seq);
     console.log(`status seq=${seq}`);

--- a/cli/src/rest.ts
+++ b/cli/src/rest.ts
@@ -697,6 +697,17 @@ export async function createTask(
   })) as TaskRecord;
 }
 
+// worker 的 `status --task N` 报的是「它自己这一端」的进度,不该把父任务的**全局** state 拉黑(#737):
+// blocked → 返回 null = 不传播到任务全局 state(worker 的 blocked 仍在它的 status 帧 + task:N scope 里
+// 可见;父任务是否 blocked 由 host 用 `party task block` 显式决定)。其余状态仍映射并传播。
+// status.ts(CLI)与 mcp.ts(内置 runner 的 party_status 工具)共用这一份,免两处漂移。
+export function taskStateFromReportedStatus(state: string): TaskState | null {
+  if (state === "blocked") return null;
+  if (state === "working") return "in_progress";
+  if (state === "waiting") return "assigned";
+  return state as TaskState;
+}
+
 export async function updateTask(
   server: string,
   token: string,

--- a/cli/test/task-state-report.test.ts
+++ b/cli/test/task-state-report.test.ts
@@ -1,0 +1,18 @@
+// #737:worker 的 `status --task N` 报自己那端的进度,blocked 不该拉黑父任务全局 state。
+import { describe, expect, test } from "bun:test";
+import { taskStateFromReportedStatus } from "../src/rest";
+
+describe("taskStateFromReportedStatus (#737)", () => {
+  test("blocked → null:不传播到父任务全局 state(由 host 用 party task block 决定)", () => {
+    expect(taskStateFromReportedStatus("blocked")).toBeNull();
+  });
+
+  test("working → in_progress、waiting → assigned:非阻塞进度仍映射并传播", () => {
+    expect(taskStateFromReportedStatus("working")).toBe("in_progress");
+    expect(taskStateFromReportedStatus("waiting")).toBe("assigned");
+  });
+
+  test("done 原样传播(完成仍需能推进任务)", () => {
+    expect(taskStateFromReportedStatus("done")).toBe("done");
+  });
+});


### PR DESCRIPTION
## 问题 (#737)

对接任务 #147 底下,一个 worker(kyc-build-codex)负责「安卓真机打包」这一端,构建失败后报 `status blocked --task 147`。结果 **system 把整个 #147 标成 blocked**(seq 674/677),而此刻 #147 其它环节全绿——host 得手动改回 in_progress。任何 worker 一 `status blocked` 就能把父任务拉黑,状态失真。

## 根因

任务模型只有**一个全局 `state` 字段**,没有 per-worker 子状态。而两条上报路径:
- `status.ts`(`party status blocked --task N`)
- `mcp.ts`(`party_status` MCP 工具——内置 codex runner 正是走这条)

都**无条件**把 worker 自己的 `blocked` 映射成 `updateTask({state:"blocked"})`,覆盖父任务唯一的全局 `state`,不区分「我这一端」和「整个任务」。

## 修复(issue 建议 #1,最小正确改动)

抽 `taskStateFromReportedStatus()` 两处共用:
- `blocked → null`:**不传播到父任务全局 state**。worker 的 blocked 仍在它的 status 帧 + `task:N` scope 里可见;父任务是否 blocked 由 **host 用 `party task block` 显式决定**。
- `working→in_progress`、`waiting→assigned`、`done` 等非阻塞进度仍映射并传播。

`party task block/update`(task.ts)与服务端 PATCH `/tasks/:id` 路径**不动**——host 显式阻塞任务、`system-status-state.spec.ts` 的 host-driven blocked 用例都不受影响。

## 测试

新增 helper 三态断言;task/mcp/status/m3/host-board 全绿(**205 pass**)、tsc 通过。

## 后续(未含)

issue 建议 #2/#3 的 `has_blocked_children` 聚合信号 + 服务端 assignee 闸(defense-in-depth,版本无关)是更大改动,可另开 PR;本 PR 先按最小正确改动堵住污染。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **功能改进**
  * 优化任务状态同步逻辑，避免将 `blocked` 状态错误传播到任务全局状态。
  * 统一命令行状态上报与任务更新的状态映射。
  * 对 `working`、`waiting` 和 `done` 等状态进行更准确的任务状态转换。

* **Bug 修复**
  * 无需更新任务状态时将跳过写回，减少不必要或错误的状态更新。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->