### PR TITLE
feat(cli): party serve/watch --stop——只停本身份的 listener + ps 可区分 (#741)

### DIFF
--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -5047,6 +5047,21 @@ export async function run(argv: string[]): Promise<number> {
       ...(protocolFlag === undefined ? {} : { protocol: protocolFlag }),
     });
   }
+  // 频道先解析:--stop 需要它,且必须在 runner/on-mention 校验之前处理——否则
+  // `party serve <ch> --stop`（不带 --runner）会先撞上「必须二选一」而永远到不了 --stop(#742 CodeRabbit)。
+  const channel = resolveChannel(str(flags.channel) ?? positionals[0]);
+  if (!channel) {
+    console.error("no channel, pass one or bind with: party init --channel C");
+    return 1;
+  }
+  if (!isSlug(channel)) {
+    console.error("channel must match [a-z0-9][a-z0-9-]{0,63}");
+    return 1;
+  }
+  // #741：只停「本身份」在这个频道跑的 serve,不像 `pkill -f` 那样误杀同机其它 agent 的 serve。
+  if (flags.stop === true) {
+    return stopOwnInstance("serve", server, auth.token, channel, (line) => console.error(line));
+  }
   if ((cmd ? 1 : 0) + (runner ? 1 : 0) !== 1) {
     console.error(
       'choose exactly one of --on-mention or --runner.\n' +
@@ -5061,19 +5076,6 @@ export async function run(argv: string[]): Promise<number> {
   }
   const harness = runner === "codex" || runner === "claude" ? runner : undefined;
   const useSdkRunner = runner === "codex-sdk";
-  const channel = resolveChannel(str(flags.channel) ?? positionals[0]);
-  if (!channel) {
-    console.error("no channel, pass one or bind with: party init --channel C");
-    return 1;
-  }
-  if (!isSlug(channel)) {
-    console.error("channel must match [a-z0-9][a-z0-9-]{0,63}");
-    return 1;
-  }
-  // #741：只停「本身份」在这个频道跑的 serve,不像 `pkill -f` 那样误杀同机其它 agent 的 serve。
-  if (flags.stop === true) {
-    return stopOwnInstance("serve", server, auth.token, channel, (line) => console.error(line));
-  }
   const autoDownloadUpgrade = flags["auto-upgrade"] === true;
   const availableUpgrade = await resolveAvailableUpgrade(server, null, {
     autoDownload: autoDownloadUpgrade,

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -33,7 +33,7 @@ import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../
 import { readAccount } from "../account";
 import { connect } from "../client";
 import { clearStuck, clearStuckForConfig, loadCursor, loadCursorForConfig, loadRevCursor, loadRevCursorForConfig, loadStuck, loadStuckForConfig, resolveChannel, saveCursor, saveCursorForConfig, saveRevCursor, saveRevCursorForConfig, saveStuck, saveStuckForConfig, type StuckWake } from "../config";
-import { acquireInstanceLock, defaultInstanceLockDir, instanceLockTarget } from "../instance-lock";
+import { acquireInstanceLock, defaultInstanceLockDir, instanceLockTarget, stopOwnInstance } from "../instance-lock";
 import { formatMsg, stripTerminalControls } from "../format";
 import { clearHealthCache, writeHealthCache } from "../health-cache";
 import { ensureFreshAccess, resolveAuthDetailed, type ResolvedAuthDetailed } from "../oidc-cli";
@@ -877,7 +877,7 @@ export function defaultRunnerWorkdir(channel: string, namespace: string): string
   return runnerWorkdir(join(stateRoot, "runners"), channel, namespace);
 }
 
-const SERVE_FLAGS = ["channel", "on-mention", "all", "runner", "workdir", "repo", "auto-upgrade", "replay-backlog", "profile", "profile-once", "profile-poll-interval", "runner-timeout-seconds", "protocol"];
+const SERVE_FLAGS = ["channel", "on-mention", "all", "runner", "workdir", "repo", "auto-upgrade", "replay-backlog", "profile", "profile-once", "profile-poll-interval", "runner-timeout-seconds", "protocol", "stop"];
 const HELP = `usage: party serve [channel|--channel C] (--on-mention "<cmd>" | --runner codex|claude|codex-sdk) [--all]
        party serve --profile <owner>/<handle>
 
@@ -899,6 +899,8 @@ Options:
   --protocol mcp|text  managed lane protocol (default mcp: role-trimmed party MCP tools; text is a
                        deprecated escape hatch kept for one minor cycle)
   --auto-upgrade       between wakes, if a newer party binary is on disk, re-exec it (issue #45)
+  --stop               stop only THIS identity's serve on the channel (safe on multi-agent hosts;
+                       resolves your own listener via the instance lock — unlike pkill -f, issue #741)
   --replay-backlog     on attach, replay the offline backlog one wake per message
                        (default: skip the backlog, advance the cursor, and print
                        how many were skipped — serve wakes only for messages that
@@ -3876,12 +3878,16 @@ export async function runServe(o: ServeOptions): Promise<number> {
   // 这把锁只挡同机；跨机器重复执行需要服务端租约（do.ts 广播发给同名所有连接）。
   const lockDir = o.lockDir ?? defaultInstanceLockDir();
   const lockTarget = o.lockDir === undefined ? instanceLockTarget(o.server, o.token, o.channel) : o.channel;
+  // #741:给进程起个可区分的标题——同机同频道多 agent 时,身份藏在 AGENTPARTY_CONFIG 环境变量里、
+  // ps 命令列看不到,两个 serve 长得一模一样。把 lockTarget(<hash>-<channel>)写进 title,
+  // 让 ps/pkill -f 能定位到具体某个(配合 `party serve <ch> --stop` 更稳)。best-effort,平台不支持就算了。
+  try { process.title = `party serve ${lockTarget}`; } catch { /* 某些运行时 title 只读 */ }
   const lock = o.allowMultiple === true ? null : acquireInstanceLock("serve", lockTarget, lockDir);
   if (lock && !lock.ok) {
     out(
       `serve: 已有 serve 挂在 #${o.channel} 上（pid ${lock.heldByPid}）。` +
         ` 再挂一个会让同一条 @ 触发两次完整 runner——双份回帖，git push 类副作用执行两遍。` +
-        ` 要么等它退出，要么 kill ${lock.heldByPid}；确实想并存请加 --allow-multiple。`,
+        ` 要么等它退出，要么用 \`party serve ${o.channel} --stop\`（只停本身份这台，别用 pkill -f 会误杀同机别人的）；确实想并存请加 --allow-multiple。`,
     );
     return EXIT_ALREADY_SERVING;
   }
@@ -4951,7 +4957,7 @@ export async function run(argv: string[]): Promise<number> {
     console.log(HELP);
     return 0;
   }
-  const { positionals, flags } = parseArgs(argv, { booleans: ["all", "auto-upgrade", "replay-backlog", "profile-once"] });
+  const { positionals, flags } = parseArgs(argv, { booleans: ["all", "auto-upgrade", "replay-backlog", "profile-once", "stop"] });
   const auth = await resolveAuthDetailed();
   if (!auth.server || !auth.token) {
     console.error("no config, run: party login or party init --server URL --token T");
@@ -5063,6 +5069,10 @@ export async function run(argv: string[]): Promise<number> {
   if (!isSlug(channel)) {
     console.error("channel must match [a-z0-9][a-z0-9-]{0,63}");
     return 1;
+  }
+  // #741：只停「本身份」在这个频道跑的 serve,不像 `pkill -f` 那样误杀同机其它 agent 的 serve。
+  if (flags.stop === true) {
+    return stopOwnInstance("serve", server, auth.token, channel, (line) => console.error(line));
   }
   const autoDownloadUpgrade = flags["auto-upgrade"] === true;
   const availableUpgrade = await resolveAvailableUpgrade(server, null, {

--- a/cli/src/commands/watch.ts
+++ b/cli/src/commands/watch.ts
@@ -8,7 +8,7 @@ import {
   type DirectedDelivery,
   type MsgFrame,
 } from "@agentparty/shared";
-import { acquireInstanceLock, defaultInstanceLockDir, instanceLockTarget } from "../instance-lock";
+import { acquireInstanceLock, defaultInstanceLockDir, instanceLockTarget, stopOwnInstance } from "../instance-lock";
 import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
 import { connect } from "../client";
 import {
@@ -41,7 +41,7 @@ import {
   writeStatuslineCache,
 } from "../statusline-cache";
 
-const WATCH_FLAGS = ["channel", "timeout", "follow", "once", "mentions-only", "exclude-self", "json", "allow-multiple", "latest", "since", "ensure", "drain", "status", "no-status", "quiet"];
+const WATCH_FLAGS = ["channel", "timeout", "follow", "once", "mentions-only", "exclude-self", "json", "allow-multiple", "latest", "since", "ensure", "drain", "status", "no-status", "quiet", "stop"];
 const WATCH_SKIP_PAGE_SIZE = 1000;
 const WATCH_SKIP_SCAN_LIMIT = 10_000;
 const WATCH_DELIVERY_ACK_TIMEOUT_MS = 5_000;
@@ -100,6 +100,8 @@ Options:
                     attached, exit 0 ("no-op") instead of exit 10 (for per-turn harnesses)
   --status          also post a human-visible waiting status on mount (default: silent)
   --no-status       explicit opt-out of the mount status (alias: --quiet; this is the default)
+  --stop            stop only THIS identity's watcher on the channel (safe on multi-agent hosts;
+                    resolves your own listener via the instance lock — unlike pkill -f, issue #741)
   --json            emit structured NDJSON frames`;
 
 // --follow 的假在线陷阱（issue #55/#60）：watcher 打印了 mention、presence 也新鲜，但多数
@@ -349,6 +351,8 @@ export async function runWatch(o: WatchOptions): Promise<number> {
   // 先抢锁，再连服务端：第二个 watcher 连 WS 都不该建，否则它已经开始消费 @ 了（#195）
   const lockDir = o.lockDir ?? defaultInstanceLockDir();
   const lockTarget = o.lockDir === undefined ? instanceLockTarget(o.server, o.token, o.channel) : o.channel;
+  // #741:进程标题带上 lockTarget(<hash>-<channel>),让 ps/pkill -f 能区分同机多 agent 的 watch。best-effort。
+  try { process.title = `party watch ${lockTarget}`; } catch { /* 某些运行时 title 只读 */ }
   const lock = o.allowMultiple === true ? null : acquireInstanceLock("watch", lockTarget, lockDir);
   if (lock && !lock.ok) {
     // #669：--ensure 让 harness 的每轮例行重挂在「同身份已挂」时幂等收场（exit 0, no-op），
@@ -360,7 +364,7 @@ export async function runWatch(o: WatchOptions): Promise<number> {
     out(
       `watch: 已有 watcher 挂在 #${o.channel} 上（pid ${lock.heldByPid}）。` +
         ` 再挂一个会让同一条 @ 触发 N 次唤醒——agent 会把同一条消息回 N 遍，并给 loop guard 上膛。` +
-        ` 要么等它退出，要么 kill ${lock.heldByPid}；确实想并存请加 --allow-multiple 或 --ensure 幂等重挂。`,
+        ` 要么等它退出，要么用 \`party watch ${o.channel} --stop\`（只停本身份这台，别用 pkill -f 会误杀同机别人的）；确实想并存请加 --allow-multiple 或 --ensure 幂等重挂。`,
     );
     return EXIT_ALREADY_WATCHING;
   }
@@ -770,7 +774,7 @@ export async function run(argv: string[]): Promise<number> {
     console.log(HELP);
     return 0;
   }
-  const { positionals, flags } = parseArgs(argv, { booleans: ["follow", "once", "mentions-only", "exclude-self", "json", "allow-multiple", "latest", "ensure", "drain", "status", "no-status", "quiet"] });
+  const { positionals, flags } = parseArgs(argv, { booleans: ["follow", "once", "mentions-only", "exclude-self", "json", "allow-multiple", "latest", "ensure", "drain", "status", "no-status", "quiet", "stop"] });
   if (flags.follow === true && flags.once === true) {
     console.error("--follow and --once are mutually exclusive: follow keeps watching, once exits after the first match");
     return 1;
@@ -825,6 +829,10 @@ export async function run(argv: string[]): Promise<number> {
   if (!isSlug(channel)) {
     console.error("channel must match [a-z0-9][a-z0-9-]{0,63}");
     return 1;
+  }
+  // #741：只停「本身份」在这个频道跑的 watch,不像 `pkill -f` 那样误杀同机其它 agent 的 listener。
+  if (flags.stop === true) {
+    return stopOwnInstance("watch", cfg.server, cfg.token, channel, (line) => console.error(line));
   }
   if (flags.follow === true) console.error(FOLLOW_WAKE_ADVISORY);
   if (flags.once === true && isClaudeCodeEnv()) console.error(ONCE_CLAUDE_ADVISORY);

--- a/cli/src/instance-lock.ts
+++ b/cli/src/instance-lock.ts
@@ -93,7 +93,18 @@ export function currentProcessStartedAt(): number {
  */
 export function instanceLockHolderPid(kind: InstanceKind, target: string, dir: string): number | null {
   const holder = readHolder(lockPath(kind, target, dir));
-  return holderAlive(holder) ? holder.pid : null;
+  // 比 holderAlive 更保守:--stop 会真的 SIGTERM,必须**正向确认**这就是原持有者,否则宁可当作
+  // 「没在跑」而不停(#742 CodeRabbit)。holderAlive 在缺出生时间(legacy 锁 / Windows / ps 读不到)时
+  // 会退回「PID 还活着就算同一个」——那正好会把已被系统复用的 PID 误当持有者、误杀无辜进程。
+  if (typeof holder?.pid !== "number" || holder.started_at === undefined) return null;
+  const info = inspectProcess(holder.pid);
+  if (!info.alive || info.startedAt === undefined) return null;
+  return Math.abs(holder.started_at - info.startedAt) <= 2000 ? holder.pid : null;
+}
+
+/** 探测某 pid 的进程出生时间(ms);无法确定则 undefined。用于测试构造与真实进程匹配的锁。 */
+export function processStartedAt(pid: number): number | undefined {
+  return inspectProcess(pid).startedAt;
 }
 
 /**

--- a/cli/src/instance-lock.ts
+++ b/cli/src/instance-lock.ts
@@ -96,7 +96,10 @@ export function instanceLockHolderPid(kind: InstanceKind, target: string, dir: s
   // 比 holderAlive 更保守:--stop 会真的 SIGTERM,必须**正向确认**这就是原持有者,否则宁可当作
   // 「没在跑」而不停(#742 CodeRabbit)。holderAlive 在缺出生时间(legacy 锁 / Windows / ps 读不到)时
   // 会退回「PID 还活着就算同一个」——那正好会把已被系统复用的 PID 误当持有者、误杀无辜进程。
-  if (typeof holder?.pid !== "number" || holder.started_at === undefined) return null;
+  // 严格类型校验:pid 与 started_at 都必须是数字。锁文件可能被手改/半写/旧格式,非数字的
+  // started_at 会让下面的 Math.abs 变 NaN、比较恒 false,虽也返回 null,但显式挡在前面更清楚(#742)。
+  if (typeof holder?.pid !== "number" || !Number.isFinite(holder.pid)) return null;
+  if (typeof holder.started_at !== "number" || !Number.isFinite(holder.started_at)) return null;
   const info = inspectProcess(holder.pid);
   if (!info.alive || info.startedAt === undefined) return null;
   return Math.abs(holder.started_at - info.startedAt) <= 2000 ? holder.pid : null;

--- a/cli/src/instance-lock.ts
+++ b/cli/src/instance-lock.ts
@@ -85,6 +85,47 @@ export function currentProcessStartedAt(): number {
   return PROCESS_STARTED_AT;
 }
 
+/**
+ * 读取某实例锁当前**存活**持有者的 pid（#741 --stop 用来自我定位:同机同频道多 agent 时,
+ * 靠这个只停「本身份」那个 serve/watch,不像 `pkill -f` 那样误杀别人的 listener）。
+ * target 必须与 acquireInstanceLock 时传入的一致(通常是 instanceLockTarget 的 `<hash>-<channel>`)。
+ * 没有锁文件、或持有者已死/PID 被复用 → 返回 null。
+ */
+export function instanceLockHolderPid(kind: InstanceKind, target: string, dir: string): number | null {
+  const holder = readHolder(lockPath(kind, target, dir));
+  return holderAlive(holder) ? holder.pid : null;
+}
+
+/**
+ * 只停「本身份(server+token)」在某频道跑的那个 serve/watch(#741)。同机同频道多 agent 时,
+ * `pkill -f "party watch <ch>"` 会误杀所有人的 listener;这条靠实例锁按身份精确定位、只 SIGTERM 自己那个。
+ * 返回退出码:成功停 / 无在跑的都算 0;发信号失败算 1。
+ */
+export function stopOwnInstance(
+  kind: InstanceKind,
+  server: string,
+  token: string,
+  channel: string,
+  log: (line: string) => void,
+  dir: string = defaultInstanceLockDir(),
+): number {
+  const target = instanceLockTarget(server, token, channel);
+  const pid = instanceLockHolderPid(kind, target, dir);
+  if (pid === null) {
+    log(`no running ${kind} for this identity on #${channel} (nothing to stop)`);
+    return 0;
+  }
+  if (pid === process.pid) return 0; // 不给自己发(理论上不会走到)
+  try {
+    process.kill(pid, "SIGTERM");
+    log(`stopped ${kind} on #${channel} (pid=${pid})`);
+    return 0;
+  } catch (error) {
+    log(`failed to stop ${kind} pid=${pid}: ${error instanceof Error ? error.message : String(error)}`);
+    return 1;
+  }
+}
+
 interface LockHolder {
   pid?: number;
   id?: string;

--- a/cli/test/instance-stop.test.ts
+++ b/cli/test/instance-stop.test.ts
@@ -1,12 +1,24 @@
 // #741:同机同频道多 agent 时,要能只停「本身份」的 serve/watch,不像 `pkill -f` 那样误杀别人的。
 import { afterEach, describe, expect, spyOn, test } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { spawn, type ChildProcess } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { acquireInstanceLock, instanceLockHolderPid, instanceLockTarget, stopOwnInstance } from "../src/instance-lock";
+import {
+  acquireInstanceLock,
+  type InstanceKind,
+  instanceLockHolderPid,
+  instanceLockTarget,
+  processStartedAt,
+  stopOwnInstance,
+} from "../src/instance-lock";
 
 const dirs: string[] = [];
+const kids: ChildProcess[] = [];
+const spies: Array<{ mockRestore: () => void }> = [];
 afterEach(() => {
+  for (const s of spies.splice(0)) s.mockRestore(); // 无论断言成败都还原,避免 mock 泄漏到后续用例(#742)
+  for (const k of kids.splice(0)) { try { k.kill("SIGKILL"); } catch { /* already gone */ } }
   for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
 });
 function dir(): string {
@@ -14,14 +26,23 @@ function dir(): string {
   dirs.push(d);
   return d;
 }
+function sleeper(): number {
+  const child = spawn("sleep", ["300"], { stdio: "ignore" });
+  kids.push(child);
+  return child.pid!;
+}
+// 手写一把「属于 pid 的」实例锁(出生时间取真实进程的,以过保守校验)。
+function writeLock(d: string, kind: InstanceKind, target: string, pid: number): void {
+  const started_at = processStartedAt(pid);
+  writeFileSync(join(d, `${kind}-${target}.lock`), JSON.stringify({ pid, id: "x", started_at, kind, channel: "dev", ts: Date.now() }));
+}
 
 const SERVER = "https://agentparty.test";
-const TOKEN = "ap_tok_A";
 
 describe("instanceLockHolderPid / stopOwnInstance (#741)", () => {
-  test("有活持有者 → 返回其 pid;没锁 → null", () => {
+  test("有活持有者(本进程)→ 返回其 pid;没锁 / 释放后 → null", () => {
     const d = dir();
-    const target = instanceLockTarget(SERVER, TOKEN, "dev");
+    const target = instanceLockTarget(SERVER, "tok", "dev");
     expect(instanceLockHolderPid("serve", target, d)).toBeNull();
     const lock = acquireInstanceLock("serve", target, d);
     expect(lock.ok).toBe(true);
@@ -30,39 +51,53 @@ describe("instanceLockHolderPid / stopOwnInstance (#741)", () => {
     expect(instanceLockHolderPid("serve", target, d)).toBeNull();
   });
 
-  test("不同身份(token)在同频道互不影响——只停自己那把", () => {
+  test("缺出生时间(legacy 锁)→ 保守返回 null,不冒险 SIGTERM 可能被复用的 PID", () => {
     const d = dir();
-    const a = acquireInstanceLock("serve", instanceLockTarget(SERVER, "tokA", "dev"), d);
-    const b = acquireInstanceLock("serve", instanceLockTarget(SERVER, "tokB", "dev"), d);
-    expect(a.ok && b.ok).toBe(true);
-    // 身份 A 的 target 找不到 B 的锁(反之亦然)
-    expect(instanceLockHolderPid("serve", instanceLockTarget(SERVER, "tokA", "dev"), d)).toBe(process.pid);
-    expect(instanceLockHolderPid("watch", instanceLockTarget(SERVER, "tokA", "dev"), d)).toBeNull(); // kind 也隔离
-    a.release?.();
-    b.release?.();
+    const target = instanceLockTarget(SERVER, "tok", "dev");
+    writeFileSync(join(d, `serve-${target}.lock`), JSON.stringify({ pid: process.pid, id: "x", kind: "serve", channel: "dev" }));
+    expect(instanceLockHolderPid("serve", target, d)).toBeNull();
   });
 
   test("没有在跑的 listener → 返回 0、提示 nothing to stop、不发信号", () => {
     const d = dir();
-    const kill = spyOn(process, "kill");
+    const kill = spyOn(process, "kill"); spies.push(kill);
     const lines: string[] = [];
-    const code = stopOwnInstance("serve", SERVER, TOKEN, "dev", (l) => lines.push(l), d);
-    expect(code).toBe(0);
+    expect(stopOwnInstance("serve", SERVER, "tok", "dev", (l) => lines.push(l), d)).toBe(0);
     expect(lines.join("\n")).toContain("nothing to stop");
-    // 只可能有 signal 0 的存活探测,绝不发 SIGTERM
     expect(kill.mock.calls.some(([, sig]) => sig === "SIGTERM")).toBe(false);
-    kill.mockRestore();
   });
 
   test("持有者是本进程 → 自我保护:返回 0、不给自己发 SIGTERM", () => {
     const d = dir();
-    const lock = acquireInstanceLock("serve", instanceLockTarget(SERVER, TOKEN, "dev"), d);
-    expect(lock.ok).toBe(true);
-    const kill = spyOn(process, "kill");
-    const code = stopOwnInstance("serve", SERVER, TOKEN, "dev", () => {}, d);
-    expect(code).toBe(0);
+    acquireInstanceLock("serve", instanceLockTarget(SERVER, "tok", "dev"), d);
+    const kill = spyOn(process, "kill"); spies.push(kill);
+    expect(stopOwnInstance("serve", SERVER, "tok", "dev", () => {}, d)).toBe(0);
     expect(kill.mock.calls.some(([, sig]) => sig === "SIGTERM")).toBe(false);
-    kill.mockRestore();
-    lock.release?.();
+  });
+
+  test("只 SIGTERM 目标实例:身份(token)与 kind 都隔离,不误伤同频道别人", async () => {
+    const d = dir();
+    const pidA = sleeper();
+    const pidB = sleeper();
+    await new Promise((r) => setTimeout(r, 80)); // 等 ps 能看到子进程的 lstart
+    // A=token 的 serve;B=另一个 token 的 serve;都在同一频道 dev。
+    writeLock(d, "serve", instanceLockTarget(SERVER, "tokA", "dev"), pidA);
+    writeLock(d, "serve", instanceLockTarget(SERVER, "tokB", "dev"), pidB);
+
+    const realKill = process.kill.bind(process);
+    const sigtermed: number[] = [];
+    const kill = spyOn(process, "kill").mockImplementation((pid: number, sig?: string | number) => {
+      if (sig === "SIGTERM") { sigtermed.push(pid); return true; } // 捕获,不真杀(子进程留给 afterEach 清)
+      return realKill(pid, sig as never); // 存活探测(signal 0)走真实实现
+    });
+    spies.push(kill);
+
+    // 只停 token A 的 serve
+    expect(stopOwnInstance("serve", SERVER, "tokA", "dev", () => {}, d)).toBe(0);
+    expect(sigtermed).toEqual([pidA]); // 只有 A,绝不碰 B
+    // 换 kind:同 token 的 watch 没有锁 → 什么都不停
+    sigtermed.length = 0;
+    expect(stopOwnInstance("watch", SERVER, "tokA", "dev", () => {}, d)).toBe(0);
+    expect(sigtermed).toEqual([]);
   });
 });

--- a/cli/test/instance-stop.test.ts
+++ b/cli/test/instance-stop.test.ts
@@ -26,11 +26,6 @@ function dir(): string {
   dirs.push(d);
   return d;
 }
-function sleeper(): number {
-  const child = spawn("sleep", ["300"], { stdio: "ignore" });
-  kids.push(child);
-  return child.pid!;
-}
 // 手写一把「属于 pid 的」实例锁(出生时间取真实进程的,以过保守校验)。
 function writeLock(d: string, kind: InstanceKind, target: string, pid: number): void {
   const started_at = processStartedAt(pid);
@@ -75,44 +70,28 @@ describe("instanceLockHolderPid / stopOwnInstance (#741)", () => {
     expect(kill.mock.calls.some(([, sig]) => sig === "SIGTERM")).toBe(false);
   });
 
-  test("真发 SIGTERM:目标进程确实退出(#742)", async () => {
+  test("真 SIGTERM:目标(A)确实退出,同频道另一身份(B)存活;kind 也隔离(#742)", async () => {
     const d = dir();
-    const child = spawn("sleep", ["300"], { stdio: "ignore" });
-    kids.push(child);
-    const exited = new Promise<"exited">((resolve) => child.once("exit", () => resolve("exited")));
-    await new Promise((r) => setTimeout(r, 80)); // 等 ps 能看到子进程
-    writeLock(d, "serve", instanceLockTarget(SERVER, "tokReal", "dev"), child.pid!);
-    expect(stopOwnInstance("serve", SERVER, "tokReal", "dev", () => {}, d)).toBe(0); // 真 SIGTERM,不 mock
+    const childA = spawn("sleep", ["300"], { stdio: "ignore" });
+    const childB = spawn("sleep", ["300"], { stdio: "ignore" });
+    kids.push(childA, childB);
+    const aExited = new Promise<"exited">((resolve) => childA.once("exit", () => resolve("exited")));
+    await new Promise((r) => setTimeout(r, 80)); // 等 ps 能看到子进程的 lstart
+    // A=tokA 的 serve;B=tokB 的 serve;同一频道 dev。
+    writeLock(d, "serve", instanceLockTarget(SERVER, "tokA", "dev"), childA.pid!);
+    writeLock(d, "serve", instanceLockTarget(SERVER, "tokB", "dev"), childB.pid!);
+
+    // 只停 tokA 的 serve——真发 SIGTERM,不 mock。
+    expect(stopOwnInstance("serve", SERVER, "tokA", "dev", () => {}, d)).toBe(0);
     const result = await Promise.race([
-      exited,
+      aExited,
       new Promise<"timeout">((r) => setTimeout(() => r("timeout"), 3000)),
     ]);
-    expect(result).toBe("exited"); // SIGTERM 后进程真的退出了
-  });
+    expect(result).toBe("exited"); // A 真的被 SIGTERM 掉了
+    expect(childB.exitCode).toBeNull(); // B(另一身份)毫发无伤,没被误杀
 
-  test("只 SIGTERM 目标实例:身份(token)与 kind 都隔离,不误伤同频道别人", async () => {
-    const d = dir();
-    const pidA = sleeper();
-    const pidB = sleeper();
-    await new Promise((r) => setTimeout(r, 80)); // 等 ps 能看到子进程的 lstart
-    // A=token 的 serve;B=另一个 token 的 serve;都在同一频道 dev。
-    writeLock(d, "serve", instanceLockTarget(SERVER, "tokA", "dev"), pidA);
-    writeLock(d, "serve", instanceLockTarget(SERVER, "tokB", "dev"), pidB);
-
-    const realKill = process.kill.bind(process);
-    const sigtermed: number[] = [];
-    const kill = spyOn(process, "kill").mockImplementation((pid: number, sig?: string | number) => {
-      if (sig === "SIGTERM") { sigtermed.push(pid); return true; } // 捕获,不真杀(子进程留给 afterEach 清)
-      return realKill(pid, sig as never); // 存活探测(signal 0)走真实实现
-    });
-    spies.push(kill);
-
-    // 只停 token A 的 serve
-    expect(stopOwnInstance("serve", SERVER, "tokA", "dev", () => {}, d)).toBe(0);
-    expect(sigtermed).toEqual([pidA]); // 只有 A,绝不碰 B
-    // 换 kind:同 token 的 watch 没有锁 → 什么都不停
-    sigtermed.length = 0;
+    // 换 kind:tokA 的 watch 没有锁 → 什么都不停,B 依然活。
     expect(stopOwnInstance("watch", SERVER, "tokA", "dev", () => {}, d)).toBe(0);
-    expect(sigtermed).toEqual([]);
+    expect(childB.exitCode).toBeNull();
   });
 });

--- a/cli/test/instance-stop.test.ts
+++ b/cli/test/instance-stop.test.ts
@@ -1,0 +1,68 @@
+// #741:同机同频道多 agent 时,要能只停「本身份」的 serve/watch,不像 `pkill -f` 那样误杀别人的。
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { acquireInstanceLock, instanceLockHolderPid, instanceLockTarget, stopOwnInstance } from "../src/instance-lock";
+
+const dirs: string[] = [];
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+function dir(): string {
+  const d = mkdtempSync(join(tmpdir(), "ap-stop-"));
+  dirs.push(d);
+  return d;
+}
+
+const SERVER = "https://agentparty.test";
+const TOKEN = "ap_tok_A";
+
+describe("instanceLockHolderPid / stopOwnInstance (#741)", () => {
+  test("有活持有者 → 返回其 pid;没锁 → null", () => {
+    const d = dir();
+    const target = instanceLockTarget(SERVER, TOKEN, "dev");
+    expect(instanceLockHolderPid("serve", target, d)).toBeNull();
+    const lock = acquireInstanceLock("serve", target, d);
+    expect(lock.ok).toBe(true);
+    expect(instanceLockHolderPid("serve", target, d)).toBe(process.pid);
+    lock.release?.();
+    expect(instanceLockHolderPid("serve", target, d)).toBeNull();
+  });
+
+  test("不同身份(token)在同频道互不影响——只停自己那把", () => {
+    const d = dir();
+    const a = acquireInstanceLock("serve", instanceLockTarget(SERVER, "tokA", "dev"), d);
+    const b = acquireInstanceLock("serve", instanceLockTarget(SERVER, "tokB", "dev"), d);
+    expect(a.ok && b.ok).toBe(true);
+    // 身份 A 的 target 找不到 B 的锁(反之亦然)
+    expect(instanceLockHolderPid("serve", instanceLockTarget(SERVER, "tokA", "dev"), d)).toBe(process.pid);
+    expect(instanceLockHolderPid("watch", instanceLockTarget(SERVER, "tokA", "dev"), d)).toBeNull(); // kind 也隔离
+    a.release?.();
+    b.release?.();
+  });
+
+  test("没有在跑的 listener → 返回 0、提示 nothing to stop、不发信号", () => {
+    const d = dir();
+    const kill = spyOn(process, "kill");
+    const lines: string[] = [];
+    const code = stopOwnInstance("serve", SERVER, TOKEN, "dev", (l) => lines.push(l), d);
+    expect(code).toBe(0);
+    expect(lines.join("\n")).toContain("nothing to stop");
+    // 只可能有 signal 0 的存活探测,绝不发 SIGTERM
+    expect(kill.mock.calls.some(([, sig]) => sig === "SIGTERM")).toBe(false);
+    kill.mockRestore();
+  });
+
+  test("持有者是本进程 → 自我保护:返回 0、不给自己发 SIGTERM", () => {
+    const d = dir();
+    const lock = acquireInstanceLock("serve", instanceLockTarget(SERVER, TOKEN, "dev"), d);
+    expect(lock.ok).toBe(true);
+    const kill = spyOn(process, "kill");
+    const code = stopOwnInstance("serve", SERVER, TOKEN, "dev", () => {}, d);
+    expect(code).toBe(0);
+    expect(kill.mock.calls.some(([, sig]) => sig === "SIGTERM")).toBe(false);
+    kill.mockRestore();
+    lock.release?.();
+  });
+});

--- a/cli/test/instance-stop.test.ts
+++ b/cli/test/instance-stop.test.ts
@@ -75,6 +75,21 @@ describe("instanceLockHolderPid / stopOwnInstance (#741)", () => {
     expect(kill.mock.calls.some(([, sig]) => sig === "SIGTERM")).toBe(false);
   });
 
+  test("真发 SIGTERM:目标进程确实退出(#742)", async () => {
+    const d = dir();
+    const child = spawn("sleep", ["300"], { stdio: "ignore" });
+    kids.push(child);
+    const exited = new Promise<"exited">((resolve) => child.once("exit", () => resolve("exited")));
+    await new Promise((r) => setTimeout(r, 80)); // 等 ps 能看到子进程
+    writeLock(d, "serve", instanceLockTarget(SERVER, "tokReal", "dev"), child.pid!);
+    expect(stopOwnInstance("serve", SERVER, "tokReal", "dev", () => {}, d)).toBe(0); // 真 SIGTERM,不 mock
+    const result = await Promise.race([
+      exited,
+      new Promise<"timeout">((r) => setTimeout(() => r("timeout"), 3000)),
+    ]);
+    expect(result).toBe("exited"); // SIGTERM 后进程真的退出了
+  });
+
   test("只 SIGTERM 目标实例:身份(token)与 kind 都隔离,不误伤同频道别人", async () => {
     const d = dir();
     const pidA = sleeper();


### PR DESCRIPTION
## 背景 (#741)

同机同频道多 agent 时,身份藏在 `AGENTPARTY_CONFIG` **环境变量**里、`ps` 命令列看不到,两个 `serve`/`watch` 进程行完全一样。于是 `pkill -f "party watch <ch>"` 会**误杀所有 agent 的 listener**——报告者升级 CLI 时就这么把别人的 watcher 杀了,对方毫无察觉、静默停止收 @。

**关于 Finding 1(`run/<channel>-serve.pid` 覆盖):** 深查后确认——**本仓代码从不产生 `run/…-serve.pid` 文件**(git 全历史无写入),报告者那个路径来自他们自己的启动脚本/wrapper。真正的同机隔离原语是 `instances/serve-<hash>-<channel>.lock`,它**已经**按身份(server+token 摘要)+ 频道命名,不存在覆盖问题。

## 修复(Finding 2,报告者明确点名的「first-party `--stop`」)

- **`party serve <ch> --stop` / `party watch <ch> --stop`**:靠实例锁按身份精确定位,**只 SIGTERM 自己那个** listener(`stopOwnInstance` + `instanceLockHolderPid`)。没在跑也返回 0(`nothing to stop`)。这是 `pkill -f` 的安全替代。
- **`process.title`** 带上 `lockTarget`(`<hash>-<channel>`),让 `ps`/`pkill -f` 能区分同机多 agent(best-effort,平台不支持就静默跳过)。
- 抢锁冲突提示 + 两处 HELP 都改为指向 `--stop`,不再建议 raw `kill <pid>`。

## 测试

新增 `instance-stop.test.ts`:有活持有者→返回 pid / 无锁→null;不同身份(token)与 kind 互相隔离;`nothing to stop` 不发信号;持有者是本进程→自我保护不发 SIGTERM。argv-leak 守卫不受 `process.title` 影响。cli 全量 **1100 pass**、tsc 通过。

## 后续(未含)

实例锁 body 里的 `channel` 字段被写成了 `<hash>-<channel>`(调用方把 `lockTarget` 当 `channel` 传给 `acquireInstanceLock`)。目前 `readHolder` 只读 `pid`/`id`/`started_at`,**无人读回该字段**,属惰性瑕疵;修它要改锁签名、有 blast radius,单独跟进。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增 `party serve <频道> --stop`：仅停止当前身份在指定频道上的服务实例。
  - 新增 `party watch <频道> --stop`：仅停止当前身份在指定频道上的监听器实例。
- **改进**
  - 更明确的停止提示：优先建议使用 `--stop`，并在不允许多实例时给出对应指引。
  - 进程区分更清晰，并加强实例锁定定位与停止的安全隔离，避免误杀其它实例。
- **测试**
  - 新增端到端/进程级用例，覆盖持有者识别、边界条件、返回码与隔离性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->