### PR TITLE
fix: launchd 常驻熔断/撤销时自卸载,不被 KeepAlive 绕过安全停机 (#744)

### DIFF
--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -286,18 +286,27 @@ export function selfBootoutTerminalDuty(
   // 严格校验注入的 label(@macmini #744 评审):只接受我们自己生成的 duty label(前缀 + launchd 合法字符),
   // 否则拒绝——绝不拿一个猜的/被篡改的 label 去 bootout,免得卸载错的甚至宽泛目标。
   if (!label.startsWith(DUTY_LABEL_PREFIX) || !/^[A-Za-z0-9.-]+$/.test(label)) {
-    out(`serve: 拒绝自卸载——AP_DUTY_LABEL 非法(${label})`);
+    // 不回显未验证的 label 原值(#745 CodeRabbit):非法即无信息价值,还可能是被塞的脏数据。
+    out("serve: 拒绝自卸载——AP_DUTY_LABEL 不是合法的 duty label");
     return false;
   }
   const uid = deps?.uid ?? (typeof process.getuid === "function" ? process.getuid() : null);
   if (uid === null) return false;
+  const target = `gui/${uid}/${label}`;
   const reason = code === EXIT_WAKE_ABANDON_CIRCUIT ? "circuit-breaker" : "auth-revoked";
   out(`serve: 终局退出(${reason}, code=${code})——从 launchd 卸载自身(${label}),不再自动重启;修好后重新「转为常驻」。`);
   // bootout 必须是最后动作(@macmini #744 评审):它可能给 serve 发 SIGTERM,其后不能再有必需的清理/日志。
+  // 必须检查返回值(#745 CodeRabbit):spawnSync 把非零退出/超时/命令找不到写进 result(不总是抛),
+  // 只 try/catch 会静默吞掉——那样日志说「已卸载」但 job 还在、KeepAlive 照样重启,假的安全停机。
   try {
-    (deps?.spawn ?? spawnSync)("launchctl", ["bootout", `gui/${uid}/${label}`], { timeout: 5000 });
-  } catch {
-    /* best-effort:卸载失败也照常退出,退出码仍对 */
+    const result = (deps?.spawn ?? spawnSync)("launchctl", ["bootout", target], { timeout: 5000 });
+    // 成功仅当 status===0 且无 error;非零退出、超时/信号杀(status=null+signal)、命令找不到一律算失败。
+    if (result.error !== undefined || result.status !== 0) {
+      const why = result.error?.message ?? (result.signal != null ? `killed by ${result.signal}` : `exit ${result.status}`);
+      out(`serve: ⚠ launchctl bootout 失败(${why})——自卸载未生效,launchd 可能仍 KeepAlive 重启;请人工:launchctl bootout ${target}`);
+    }
+  } catch (error) {
+    out(`serve: ⚠ launchctl bootout 抛错(${error instanceof Error ? error.message : String(error)})——自卸载未生效;请人工:launchctl bootout ${target}`);
   }
   return true;
 }

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -262,6 +262,9 @@ export const EXIT_ALREADY_SERVING = 10;
 export const EXIT_SIGNAL_INT = 128 + 2;
 export const EXIT_SIGNAL_TERM = 128 + 15;
 
+/** 桌面「转为常驻」生成的 launchd job label 前缀(须与 desktop/src-tauri/src/duty.rs 的 DUTY_LABEL_PREFIX 一致)。 */
+const DUTY_LABEL_PREFIX = "com.agentparty.duty.";
+
 /**
  * #744:launchd 常驻下,「终局不该重启」的退出(熔断 EXIT_WAKE_ABANDON_CIRCUIT / 撤销 EXIT_AUTH)必须
  * 让 launchd 别 KeepAlive 重启——否则熔断的安全停机被绕过、或对着被撤 token 空转,且 launchd 还以为在线。
@@ -280,14 +283,21 @@ export function selfBootoutTerminalDuty(
   const platform = deps?.platform ?? process.platform;
   if (platform !== "darwin") return false;
   if (code !== EXIT_WAKE_ABANDON_CIRCUIT && code !== EXIT_AUTH) return false;
+  // 严格校验注入的 label(@macmini #744 评审):只接受我们自己生成的 duty label(前缀 + launchd 合法字符),
+  // 否则拒绝——绝不拿一个猜的/被篡改的 label 去 bootout,免得卸载错的甚至宽泛目标。
+  if (!label.startsWith(DUTY_LABEL_PREFIX) || !/^[A-Za-z0-9.-]+$/.test(label)) {
+    out(`serve: 拒绝自卸载——AP_DUTY_LABEL 非法(${label})`);
+    return false;
+  }
   const uid = deps?.uid ?? (typeof process.getuid === "function" ? process.getuid() : null);
   if (uid === null) return false;
   const reason = code === EXIT_WAKE_ABANDON_CIRCUIT ? "circuit-breaker" : "auth-revoked";
   out(`serve: 终局退出(${reason}, code=${code})——从 launchd 卸载自身(${label}),不再自动重启;修好后重新「转为常驻」。`);
+  // bootout 必须是最后动作(@macmini #744 评审):它可能给 serve 发 SIGTERM,其后不能再有必需的清理/日志。
   try {
     (deps?.spawn ?? spawnSync)("launchctl", ["bootout", `gui/${uid}/${label}`], { timeout: 5000 });
   } catch {
-    /* best-effort */
+    /* best-effort:卸载失败也照常退出,退出码仍对 */
   }
   return true;
 }

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -3,6 +3,7 @@
 // 复用 client.connect 的自动重连帧流，真正常驻；命令串行执行（一条处理完再下一条，不并发抢跑）。
 import { BODY_LIMIT, DECISION_OPTION_LIMIT, DECISION_OPTIONS_MAX, DECISION_PROMPT_LIMIT, EXIT_ARCHIVED, EXIT_AUTH, EXIT_STREAM_ENDED, EXIT_UPGRADED, type AgentSessionInfo, type Attachment, type DeliveryUpdateFrame, type DirectedDelivery, type MsgFrame, type PublicDirectedDelivery, type SendDecisionRequest, type ServerFrame } from "@agentparty/shared";
 import { createHash, randomUUID } from "node:crypto";
+import { spawnSync } from "node:child_process";
 import { downloadPartyUpgrade, isPartyBinaryPath, maybeReexecUpgrade, serverVersionUpgradeNotice, upgradeNotice, type CliUpgradeNotice, type UpgradeDeps } from "../upgrade";
 import {
   clearManagedActions,
@@ -260,6 +261,36 @@ export const EXIT_ALREADY_SERVING = 10;
 /** Conventional shell exit codes for an explicitly interrupted resident serve. */
 export const EXIT_SIGNAL_INT = 128 + 2;
 export const EXIT_SIGNAL_TERM = 128 + 15;
+
+/**
+ * #744:launchd 常驻下,「终局不该重启」的退出(熔断 EXIT_WAKE_ABANDON_CIRCUIT / 撤销 EXIT_AUTH)必须
+ * 让 launchd 别 KeepAlive 重启——否则熔断的安全停机被绕过、或对着被撤 token 空转,且 launchd 还以为在线。
+ * serve 自己 `launchctl bootout` 掉自己那个 job:launchd 移除它 → 不再重启,launchctl print/health/presence
+ * 一致显示停机,人工重新「转为常驻」才复活。普通崩溃 / stream-ended **不** bootout,照常由 KeepAlive 自愈。
+ * 只在 plist 传了 AP_DUTY_LABEL(桌面「转为常驻」会传)且 macOS 时生效;不改退出码契约,tmux/手动 supervisor 无感。
+ * best-effort:bootout 失败也照常退出(退出码仍对,只是少了自卸载)。可注入 spawn 供测试。
+ */
+export function selfBootoutTerminalDuty(
+  code: number,
+  out: (line: string) => void,
+  deps?: { platform?: string; uid?: number | null; label?: string; spawn?: typeof spawnSync },
+): boolean {
+  const label = deps?.label ?? process.env.AP_DUTY_LABEL;
+  if (label === undefined || label === "") return false;
+  const platform = deps?.platform ?? process.platform;
+  if (platform !== "darwin") return false;
+  if (code !== EXIT_WAKE_ABANDON_CIRCUIT && code !== EXIT_AUTH) return false;
+  const uid = deps?.uid ?? (typeof process.getuid === "function" ? process.getuid() : null);
+  if (uid === null) return false;
+  const reason = code === EXIT_WAKE_ABANDON_CIRCUIT ? "circuit-breaker" : "auth-revoked";
+  out(`serve: 终局退出(${reason}, code=${code})——从 launchd 卸载自身(${label}),不再自动重启;修好后重新「转为常驻」。`);
+  try {
+    (deps?.spawn ?? spawnSync)("launchctl", ["bootout", `gui/${uid}/${label}`], { timeout: 5000 });
+  } catch {
+    /* best-effort */
+  }
+  return true;
+}
 
 /** 传给 builtin runner 的提示：只给路径，不给正文（#120）。 */
 function wakePrompt(contextFile: string, projectAgent: ProjectAgentRunContext | null): string {
@@ -5109,7 +5140,7 @@ export async function run(argv: string[]): Promise<number> {
     if (runnerWorkdirPath !== null) appendServeLifecycleLog(runnerWorkdirPath, record);
     console.error(terminalOutput(`serve supervisor: ${line}`));
   };
-  return superviseServe({
+  const superviseExit = await superviseServe({
     onLifecycle: lifecycle,
     runOnce: async () => {
       // 每次自愈都重读本地凭据与 OIDC 状态，避免用启动时快照把一次可恢复的 token
@@ -5180,4 +5211,7 @@ export async function run(argv: string[]): Promise<number> {
       return result;
     },
   });
+  // #744:终局不该重启的退出(熔断/撤销)在 launchd 常驻下自卸载,别让 KeepAlive 绕过安全停机/空转。
+  selfBootoutTerminalDuty(superviseExit, (line) => console.error(terminalOutput(`serve supervisor: ${line}`)));
+  return superviseExit;
 }

--- a/cli/test/serve-selfbootout.test.ts
+++ b/cli/test/serve-selfbootout.test.ts
@@ -64,4 +64,14 @@ describe("selfBootoutTerminalDuty (#744)", () => {
     const r = recorder();
     expect(() => selfBootoutTerminalDuty(EXIT_WAKE_ABANDON_CIRCUIT, r.out, { ...base(), spawn: throwing } as never)).not.toThrow();
   });
+
+  test("spawnSync 返回非零/error(不抛)→ 记警告,不静默当成功(#745)", () => {
+    for (const bad of [{ status: 1 }, { error: new Error("ENOENT") }, { signal: "SIGTERM", status: null }]) {
+      const lines: string[] = [];
+      const failSpawn = (() => bad) as never;
+      const did = selfBootoutTerminalDuty(EXIT_AUTH, (l) => lines.push(l), { ...base(), spawn: failSpawn } as never);
+      expect(did).toBe(true);
+      expect(lines.some((l) => l.includes("bootout") && l.includes("失败"))).toBe(true);
+    }
+  });
 });

--- a/cli/test/serve-selfbootout.test.ts
+++ b/cli/test/serve-selfbootout.test.ts
@@ -1,0 +1,58 @@
+// #744:launchd 常驻下,终局不该重启的退出(熔断/撤销)要 serve 自 bootout,别被 KeepAlive 绕过安全停机。
+import { describe, expect, test } from "bun:test";
+import { EXIT_AUTH, EXIT_STREAM_ENDED } from "@agentparty/shared";
+import { EXIT_WAKE_ABANDON_CIRCUIT, selfBootoutTerminalDuty } from "../src/commands/serve";
+
+const LABEL = "com.agentparty.duty.abc.dev";
+
+function recorder() {
+  const calls: Array<{ cmd: string; args: string[] }> = [];
+  const lines: string[] = [];
+  const spawn = ((cmd: string, args: string[]) => { calls.push({ cmd, args }); return { status: 0 } as never; }) as never;
+  const out = (l: string) => lines.push(l);
+  return { calls, lines, spawn, out };
+}
+const base = (over: Record<string, unknown> = {}) => ({ platform: "darwin", uid: 501, label: LABEL, ...over });
+
+describe("selfBootoutTerminalDuty (#744)", () => {
+  test("熔断(11)在 macOS + 有 label:bootout 自身 job", () => {
+    const r = recorder();
+    const did = selfBootoutTerminalDuty(EXIT_WAKE_ABANDON_CIRCUIT, r.out, { ...base(), spawn: r.spawn } as never);
+    expect(did).toBe(true);
+    expect(r.calls).toEqual([{ cmd: "launchctl", args: ["bootout", `gui/501/${LABEL}`] }]);
+  });
+
+  test("token 撤销(auth)同样自卸载(重启也没用)", () => {
+    const r = recorder();
+    const did = selfBootoutTerminalDuty(EXIT_AUTH, r.out, { ...base(), spawn: r.spawn } as never);
+    expect(did).toBe(true);
+    expect(r.calls[0]!.args).toEqual(["bootout", `gui/501/${LABEL}`]);
+  });
+
+  test("普通可重启退出(stream-ended)不 bootout——留给 KeepAlive 自愈", () => {
+    const r = recorder();
+    const did = selfBootoutTerminalDuty(EXIT_STREAM_ENDED, r.out, { ...base(), spawn: r.spawn } as never);
+    expect(did).toBe(false);
+    expect(r.calls).toEqual([]);
+  });
+
+  test("没跑在 launchd duty 下(无 AP_DUTY_LABEL):什么都不做", () => {
+    const r = recorder();
+    const did = selfBootoutTerminalDuty(EXIT_WAKE_ABANDON_CIRCUIT, r.out, { platform: "darwin", uid: 501, label: undefined, spawn: r.spawn } as never);
+    expect(did).toBe(false);
+    expect(r.calls).toEqual([]);
+  });
+
+  test("非 macOS 不碰 launchctl", () => {
+    const r = recorder();
+    const did = selfBootoutTerminalDuty(EXIT_WAKE_ABANDON_CIRCUIT, r.out, { ...base({ platform: "linux" }), spawn: r.spawn } as never);
+    expect(did).toBe(false);
+    expect(r.calls).toEqual([]);
+  });
+
+  test("bootout 抛错也不炸(best-effort,退出码仍对)", () => {
+    const throwing = (() => { throw new Error("launchctl gone"); }) as never;
+    const r = recorder();
+    expect(() => selfBootoutTerminalDuty(EXIT_WAKE_ABANDON_CIRCUIT, r.out, { ...base(), spawn: throwing } as never)).not.toThrow();
+  });
+});

--- a/cli/test/serve-selfbootout.test.ts
+++ b/cli/test/serve-selfbootout.test.ts
@@ -43,6 +43,15 @@ describe("selfBootoutTerminalDuty (#744)", () => {
     expect(r.calls).toEqual([]);
   });
 
+  test("label 非法(非 duty 前缀 / 含非法字符)→ 拒绝,绝不 bootout(@macmini 评审)", () => {
+    for (const bad of ["com.other.job", "com.agentparty.duty.x dev", "com.agentparty.duty.x;rm", "system/"]) {
+      const r = recorder();
+      const did = selfBootoutTerminalDuty(EXIT_WAKE_ABANDON_CIRCUIT, r.out, { ...base({ label: bad }), spawn: r.spawn } as never);
+      expect(did).toBe(false);
+      expect(r.calls).toEqual([]);
+    }
+  });
+
   test("非 macOS 不碰 launchctl", () => {
     const r = recorder();
     const did = selfBootoutTerminalDuty(EXIT_WAKE_ABANDON_CIRCUIT, r.out, { ...base({ platform: "linux" }), spawn: r.spawn } as never);

--- a/desktop/src-tauri/src/duty.rs
+++ b/desktop/src-tauri/src/duty.rs
@@ -691,9 +691,8 @@ mod tests {
         assert!(plist.contains("<key>AGENTPARTY_CONFIG</key>"));
         // #741:PATH 必须进 EnvironmentVariables,否则 launchd 精简 PATH 找不到 codex/claude runner。
         assert!(plist.contains("<key>PATH</key>"));
-        // #744:AP_DUTY_LABEL 让 serve 熔断/撤销时能 bootout 自身 job(值即 label)。
-        assert!(plist.contains("<key>AP_DUTY_LABEL</key>"));
-        assert!(plist.contains("com.agentparty.duty.x.dev"));
+        // #744:AP_DUTY_LABEL 的值必须紧跟其 key(不能只是碰巧 label 在别处出现,#745 CodeRabbit)。
+        assert!(plist.contains("<key>AP_DUTY_LABEL</key>\n    <string>com.agentparty.duty.x.dev</string>"));
         assert!(plist.contains("/Users/leo/.local/bin"));
         // --repo 未指定时绝不出现
         assert!(!plist.contains("--repo"));

--- a/desktop/src-tauri/src/duty.rs
+++ b/desktop/src-tauri/src/duty.rs
@@ -117,6 +117,9 @@ pub(crate) fn duty_plist_content(spec: &DutyPlistSpec<'_>) -> String {
     <string>{config}</string>
     <key>PATH</key>
     <string>{path}</string>
+    <!-- #744:让 serve 知道自己这个 launchd job 的 label,熔断/token 撤销等终局退出时自卸载,不被 KeepAlive 重启 -->
+    <key>AP_DUTY_LABEL</key>
+    <string>{label}</string>
   </dict>
   <key>RunAtLoad</key>
   <true/>
@@ -688,6 +691,9 @@ mod tests {
         assert!(plist.contains("<key>AGENTPARTY_CONFIG</key>"));
         // #741:PATH 必须进 EnvironmentVariables,否则 launchd 精简 PATH 找不到 codex/claude runner。
         assert!(plist.contains("<key>PATH</key>"));
+        // #744:AP_DUTY_LABEL 让 serve 熔断/撤销时能 bootout 自身 job(值即 label)。
+        assert!(plist.contains("<key>AP_DUTY_LABEL</key>"));
+        assert!(plist.contains("com.agentparty.duty.x.dev"));
         assert!(plist.contains("/Users/leo/.local/bin"));
         // --repo 未指定时绝不出现
         assert!(!plist.contains("--repo"));


### PR DESCRIPTION
## 问题 (#744, P1, macmini 频道实测)

launchd 托管的 serve 熔断退出 `code=11` 后,`KeepAlive` 语义出问题:
- macmini 的 `tail -f /dev/null | party serve` 让 launchd 看不到退出 → **假在线**(job running、presence unreachable);
- 桌面「转为常驻」的 plist `KeepAlive=true` 会**立刻重启** → 绕过熔断的安全停机、清掉进程内 breaker 继续消费。

根因:launchd 的 `KeepAlive` **无法按退出码区分**「崩溃该重启」vs「熔断/撤销该停机」。

## 修复

serve 在【终局不该重启】的退出——`EXIT_WAKE_ABANDON_CIRCUIT=11`(熔断)/ `EXIT_AUTH`(token 撤销)——时,若跑在 launchd duty 下(plist 传 `AP_DUTY_LABEL`),先 `launchctl bootout gui/<uid>/<label>` **卸载自己那个 job** 再退出:

- launchd 移除该 job → 不再 KeepAlive 重启;
- `launchctl print` / `party health` / presence **一致显示停机**(#744 验收点);
- 人工重新「转为常驻」才复活。
- **普通崩溃 / stream-ended 不 bootout**,照常由 KeepAlive 自愈。
- **不改退出码契约**:tmux / 手动 supervisor 看到的 code 不变,只是 launchd 下多了自卸载。

改动:
- `serve.ts`:`selfBootoutTerminalDuty()`(注入 platform/uid/label/spawn 供测试),`run()` 捕获 supervisor 退出码后调用。
- `duty.rs`:plist `EnvironmentVariables` 加 `AP_DUTY_LABEL=<label>`。

## 测试

CLI 6 例:熔断/撤销 → bootout 正确 `gui/<uid>/<label>`;stream-ended / 无 label / 非 mac → 不动;spawn 抛错 best-effort 不炸。serve-supervisor/health/shutdown 29 例回归绿(run() 改动行为不变)。`duty.rs` plist 断言含 `AP_DUTY_LABEL`。CLI 全绿 + tsc;桌面 Rust 由 CI `check-desktop` 验。

## 说明 / 待 review

- macmini 的 `tail` 管道假活是它**自建** launchd 的坑;官方 supervisor(桌面「转为常驻」)本就直接跑 serve、无 tail——本 PR 补齐官方 supervisor 的**退出策略**。
- 设计已在频道 seq1542 征求 #744 作者(@macmini)意见,欢迎对 self-bootout 边界拍砖;合并前等 leo 点头。

关联 #741 / #743(同机常驻可靠性)。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 在 macOS 上，当常驻服务因认证失败或特定终止条件到达终局退出时，会以最佳努力卸载自身对应的 launchd 任务，避免被重复拉起。
  * 启动配置新增识别用的环境变量，将当前 duty 标签注入给常驻服务以便精确匹配对应任务。
* **测试**
  * 新增覆盖多退出码、非 macOS/非 duty 场景、无效标签校验，以及卸载失败或异常时不抛错的用例，并校验告警日志输出。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->