### PR TITLE
fix(serve): 内置 runner prompt 讲清「输出由 serve 自动发回」,别让 codex 常驻自己 party send

### DIFF
--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -68,7 +68,10 @@ const COMMON_PROTOCOL_REMINDER =
 const ADVISORY_FRONT_REMINDER =
   " 你是留在主频道沟通和调度的 front agent。简短对话和一次只读路由检查可直接处理；代码修改、多步排查、浏览器/运维及其它耗时工作，优先交给 harness 的 subagent/worker，让它回报证据由你汇总。" +
   " 这是兼容模式（CLI 不能证明 worker 已启动）：harness 支持子 agent 就委派；确实无法创建 worker 时，就在本会话内把活干完，不要只报 blocked 停住。" +
-  " 需要 owner 给权限、取舍或批准时用 `party decision ask <问题> [--option ...]`；需要更多上下文用 `party history <channel>`；结论用 `party send --reply-to <seq>` 发回本频道。";
+  " 你的最终输出会由 serve 自动发回本频道（上下文里的 reply_to 已指好这条）——直接把回复写成你的输出即可，" +
+  "【不要自己调用 `party send`】：会重复投递，且常驻的 codex runner 跑在无网络沙箱里根本发不出去、还会把『连接失败』误写进回复。" +
+  " 同理 `party history` / `party decision ask` 等直连服务的 CLI 在该沙箱也会失败——上下文已含 charter 与 recent，据此作答；" +
+  " 确需 owner 决策或更多上下文却当前拿不到时，在你的输出里说清（由 serve 发回频道请人跟进），不要反复重试直连命令。";
 
 const MANAGED_FRONT_REMINDER =
   " 你是 managed front agent，是三个方向的通信与调度控制面：对频道交流、对 owner 请求决定、对子 worker 派工/追问/验收；执行 worker 已由 supervisor 独立常驻。你没有执行面权限，也不要调用 party CLI。" +
@@ -312,7 +315,7 @@ export function selfBootoutTerminalDuty(
 }
 
 /** 传给 builtin runner 的提示：只给路径，不给正文（#120）。 */
-function wakePrompt(contextFile: string, projectAgent: ProjectAgentRunContext | null): string {
+export function wakePrompt(contextFile: string, projectAgent: ProjectAgentRunContext | null): string {
   return (
     `你在 AgentParty 频道里被 @ 了。唤醒上下文是一个 JSON 文件：${contextFile}\n` +
     `先读它（含 channel / seq / sender / body / mentions / charter / recent），再动手。\n` +

--- a/cli/test/wake-prompt.test.ts
+++ b/cli/test/wake-prompt.test.ts
@@ -1,0 +1,28 @@
+// 频道实测(leo-zego-im/macmini/codex-002):内置 codex runner 跑在无网络沙箱,原 prompt 却教模型
+// 用 `party send --reply-to` 自己发回频道 → 连续连接失败,还把「未能发回频道」误写进回复。
+// 内置 runner 的输出本就由 serve 自动投递,模型不该(codex 也不能)自己 party send。
+import { describe, expect, test } from "bun:test";
+import { wakePrompt } from "../src/commands/serve";
+
+describe("wakePrompt 内置 runner 投递契约", () => {
+  const prompt = wakePrompt("/tmp/ctx.json", null); // 普通单频道内置 runner(非 managed profile)
+
+  test("告诉模型:输出由 serve 自动发回,别自己 party send", () => {
+    expect(prompt).toContain("serve 自动发回");
+    expect(prompt).toContain("不要自己调用 `party send`");
+  });
+
+  test("不再教模型用 `party send --reply-to` 自己发回(无网络沙箱会失败的老指令已删)", () => {
+    expect(prompt).not.toContain("`party send --reply-to <seq>` 发回本频道");
+  });
+
+  test("警告无网络沙箱下 party history/decision 直连会失败", () => {
+    expect(prompt).toContain("无网络沙箱");
+    expect(prompt).toContain("party history");
+  });
+
+  test("仍带上下文文件路径与先读上下文的引导", () => {
+    expect(prompt).toContain("/tmp/ctx.json");
+    expect(prompt).toContain("先读它");
+  });
+});

--- a/cli/test/wake-prompt.test.ts
+++ b/cli/test/wake-prompt.test.ts
@@ -41,6 +41,7 @@ describe("wakePrompt 内置 runner 投递契约", () => {
   test("worker 路径不受影响:走 execution worker 契约、无内置 advisory 措辞", () => {
     const p = wakePrompt("/tmp/ctx.json", worker);
     expect(p).not.toContain("serve 自动发回");
+    expect(p).not.toContain("不要自己调用 `party send`");
     expect(p).toContain("execution worker"); // worker 契约仍在
   });
 });

--- a/cli/test/wake-prompt.test.ts
+++ b/cli/test/wake-prompt.test.ts
@@ -25,4 +25,22 @@ describe("wakePrompt 内置 runner 投递契约", () => {
     expect(prompt).toContain("/tmp/ctx.json");
     expect(prompt).toContain("先读它");
   });
+
+  // 隔离验证(#747 CodeRabbit):ADVISORY_FRONT_REMINDER 的改动不得泄漏到 managed/worker 路径——
+  // 它们各自用 MANAGED_FRONT_/WORKER_ reminder,不该出现内置 advisory 特有的「serve 自动发回」措辞。
+  const managedFront = { runtime_role: "front", protocol: "mcp", workers: [{ name: "w1" }] } as never;
+  const worker = { runtime_role: "worker", protocol: "mcp", workers: [] } as never;
+
+  test("managed front(有 worker)路径不受影响:走 JSON 契约、无内置 advisory 措辞", () => {
+    const p = wakePrompt("/tmp/ctx.json", managedFront);
+    expect(p).not.toContain("serve 自动发回");
+    expect(p).not.toContain("不要自己调用 `party send`");
+    expect(p).toContain("managed front agent"); // managed front 自己的契约仍在
+  });
+
+  test("worker 路径不受影响:走 execution worker 契约、无内置 advisory 措辞", () => {
+    const p = wakePrompt("/tmp/ctx.json", worker);
+    expect(p).not.toContain("serve 自动发回");
+    expect(p).toContain("execution worker"); // worker 契约仍在
+  });
 });


### PR DESCRIPTION
## 问题(频道实测:leo-zego-im / macmini / codex-002)

内置 codex runner 跑在 `codex exec --sandbox workspace-write` 的**无网络沙箱**里。但 `ADVISORY_FRONT_REMINDER`(`serve.ts`,给普通单频道内置 runner 的 wake prompt)却教模型:

> 「需要更多上下文用 `party history`;结论用 `party send --reply-to <seq>` 发回本频道。」

于是模型试着**自己 party send**,连续 3 次连接失败,还把「未能发回频道」当成回复内容写出去(leo 追问「那你这条消息怎么回的」正是这个矛盾)。

**而实际上**:内置 runner 的输出本就由 **serve**(父进程、可联网)经 `deliverRunnerResult` 自动投递到频道(`reply_to` 已在上下文里)。模型**既不该**(会重复投递)**也不能**(无网络)自己发。

## 修复

改 `ADVISORY_FRONT_REMINDER`:
- 明确「你的最终输出会由 serve 自动发回本频道——直接把回复写成输出即可,**不要自己 `party send`**」;
- 警告 `party history` / `party decision ask` 等直连服务的 CLI 在该沙箱会失败,用已给的 charter+recent 作答;
- 确需 owner 决策或更多上下文而当前拿不到时,在输出里说清(由 serve 转达),别反复重试直连命令。

只影响内置 runner(`ADVISORY_FRONT_REMINDER` 仅经 `wakePrompt` 用于 builtin 路径,已核实);managed profile / 自定义 `--on-mention` 不受影响。

## 测试

`export wakePrompt` + 新增 `wake-prompt.test.ts`:断言新投递契约在、旧的 `party send --reply-to` 自发指令已删、无网络警告在、上下文引导仍在。`serve.test.ts` 80 pass、tsc 通过。

关联 #744(常驻可靠性)、频道 leo-zego-im 的 codex-not-reconnect 现象。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改进**
  - 更新常驻沙箱提示文案：最终输出将由 `serve` 自动回传；禁止手动直连相关命令；当缺少 owner 决策或更多上下文时，引导在输出中请求跟进。
- **改进**
  - 提示词生成能力现可复用：`wakePrompt` 现在支持被外部按签名导入使用。
- **测试**
  - 新增/补强用例：覆盖不同运行配置下的契约文本（包含上下文路径与“先读它”引导、无网络下的直连失败警告、以及托管/执行角色文案不泄露规则）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->