### PR TITLE
fix(serve): 识别 claude runner 落在 stdout JSON 的结构化 auth/api 失败 (#748)

### DIFF
--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -1653,6 +1653,24 @@ export function isRunnerEnvFailure(result: Pick<RunnerProcessResult, "stderr">):
   return RUNNER_ENV_FAILURE_PATTERNS.some((re) => re.test(result.stderr));
 }
 
+// #748：claude `-p --output-format json` 命中环境性 auth/api 失败时，结构化错误落在 **stdout 的 JSON**
+// （`is_error:true, terminal_reason:"api_error", result:"...OAuth session expired..."`）而非 stderr，exit 1。
+// isRunnerEnvFailure 只扫 stderr（#693 为躲模型输出误报），会把这类漏判成通用「exit-1 / model may have run」：
+// 不标 env failure、不触发 #744 自卸载、频道只显示没头没脑的 exit-1，owner 看不出是凭据过期。
+// 这里只吃**结构化字段**：仅当 `is_error===true && terminal_reason==="api_error"` 且 `result` 命中环境错指纹
+// 才判 env failure——正常模型输出 `is_error:false`（即便正文含「unauthorized」），绝不误报，不重犯 #693。
+export function claudeJsonEnvFailure(stdout: string): boolean {
+  let body: Record<string, unknown>;
+  try {
+    body = JSON.parse(stdout) as Record<string, unknown>;
+  } catch {
+    return false;
+  }
+  if (body.is_error !== true || body.terminal_reason !== "api_error") return false;
+  const result = typeof body.result === "string" ? body.result : "";
+  return RUNNER_ENV_FAILURE_PATTERNS.some((re) => re.test(result));
+}
+
 function writeSdkSession(path: string, state: SdkWakeSessionState): SdkWakeSessionState {
   return mergeRunnerContinuation(path, state) as SdkWakeSessionState;
 }
@@ -2535,7 +2553,10 @@ export function createBuiltinRunner(opts: BuiltinRunnerOptions): NonNullable<Ser
         const now = opts.now?.() ?? Date.now();
         if (run.result.code !== 0) {
           // #690：认证过期 / 二进制缺失 / 沙箱拒权等环境性失败在模型启动前就崩，别归为「model may have run」。
-          const envFailure = isRunnerEnvFailure(run.result);
+          // #748：claude 的 auth/api 失败落在 stdout 的结构化 JSON（非 stderr），补一条只吃结构化字段的判定。
+          const envFailure =
+            isRunnerEnvFailure(run.result) ||
+            (opts.harness === "claude" && claudeJsonEnvFailure(run.result.stdout));
           appendRunnerLog(
             opts.workdir,
             `${new Date(now).toISOString()} seq=${frame.seq} sid=${shortSid(oldSid)} duration_ms=${now - started} exit=${run.result.code}${envFailure ? " env_failure=true" : ""}`,

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -1660,12 +1660,16 @@ export function isRunnerEnvFailure(result: Pick<RunnerProcessResult, "stderr">):
 // 这里只吃**结构化字段**：仅当 `is_error===true && terminal_reason==="api_error"` 且 `result` 命中环境错指纹
 // 才判 env failure——正常模型输出 `is_error:false`（即便正文含「unauthorized」），绝不误报，不重犯 #693。
 export function claudeJsonEnvFailure(stdout: string): boolean {
-  let body: Record<string, unknown>;
+  let parsed: unknown;
   try {
-    body = JSON.parse(stdout) as Record<string, unknown>;
+    parsed = JSON.parse(stdout);
   } catch {
     return false;
   }
+  // JSON.parse 对 "null"/数字/字符串等合法 JSON 返回非对象值——直接取属性会抛(合法 null 更会),
+  // 别让失败处理自身崩(CodeRabbit #752)。只认对象体。
+  if (typeof parsed !== "object" || parsed === null) return false;
+  const body = parsed as Record<string, unknown>;
   if (body.is_error !== true || body.terminal_reason !== "api_error") return false;
   const result = typeof body.result === "string" ? body.result : "";
   return RUNNER_ENV_FAILURE_PATTERNS.some((re) => re.test(result));

--- a/cli/test/serve-failure-ack.test.ts
+++ b/cli/test/serve-failure-ack.test.ts
@@ -6,7 +6,7 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { EXIT_ARCHIVED, type MsgFrame } from "@agentparty/shared";
-import { createBuiltinRunner, createSdkRunner, EXIT_WAKE_ABANDON_CIRCUIT, isRunnerEnvFailure, profileChildServeOptions, runServe, WakeBlockedError, type BuiltinRunnerOptions, type RunnerProcess, type ServeOptions } from "../src/commands/serve";
+import { claudeJsonEnvFailure, createBuiltinRunner, createSdkRunner, EXIT_WAKE_ABANDON_CIRCUIT, isRunnerEnvFailure, profileChildServeOptions, runServe, WakeBlockedError, type BuiltinRunnerOptions, type RunnerProcess, type ServeOptions } from "../src/commands/serve";
 import type { StuckWake } from "../src/config";
 import { msgFrame, startMockServer, welcomeFrame, type MockServer } from "./mock-server";
 
@@ -254,6 +254,34 @@ describe("serve wake delivery (#118 / #198)", () => {
       const result: { stdout: string; stderr: string } = { stdout: noise, stderr: "" };
       expect(isRunnerEnvFailure(result)).toBe(false);
     }
+  });
+
+  // #748：claude `-p --output-format json` 的 auth/api 失败落在 **stdout 的结构化 JSON**，stderr 干净——
+  // 只吃结构化字段判 env failure，且绝不误报正常模型输出（不重犯 #693）。
+  test("claudeJsonEnvFailure 认出 claude JSON 里的结构化 auth/api 失败 (#748)", () => {
+    const authExpired = JSON.stringify({
+      type: "result",
+      subtype: "success",
+      is_error: true,
+      result: "Failed to authenticate: OAuth session expired and could not be refreshed",
+      terminal_reason: "api_error",
+      session_id: "4f1dc51f-9413-430b-abe7-8436e1637e53",
+    });
+    expect(claudeJsonEnvFailure(authExpired)).toBe(true);
+    // 401 / invalid api key 同样命中
+    expect(claudeJsonEnvFailure(JSON.stringify({ is_error: true, terminal_reason: "api_error", result: "HTTP 401 Unauthorized" }))).toBe(true);
+  });
+
+  test("claudeJsonEnvFailure 不误判正常/非环境失败 (#748 回归护栏，配合 #693)", () => {
+    // 正常成功输出——即便模型正文写了「unauthorized」，is_error:false → 不算环境失败。
+    expect(claudeJsonEnvFailure(JSON.stringify({ is_error: false, terminal_reason: "completed", result: "here is the unauthorized access audit you asked for" }))).toBe(false);
+    // is_error 但非 api_error（如 max turns / 模型侧失败）→ 不算环境失败。
+    expect(claudeJsonEnvFailure(JSON.stringify({ is_error: true, terminal_reason: "max_turns", result: "OAuth session expired" }))).toBe(false);
+    // api_error 但 result 无环境指纹（真·模型/内容错）→ 不算环境失败。
+    expect(claudeJsonEnvFailure(JSON.stringify({ is_error: true, terminal_reason: "api_error", result: "overloaded_error: please retry" }))).toBe(false);
+    // 非 JSON（resume 明文输出）→ 优雅返回 false，交回 stderr 判定。
+    expect(claudeJsonEnvFailure("plain text answer mentioning unauthorized")).toBe(false);
+    expect(claudeJsonEnvFailure("")).toBe(false);
   });
 
   test("a non-environment runner failure keeps environment=false (no false positives)", async () => {

--- a/cli/test/serve-failure-ack.test.ts
+++ b/cli/test/serve-failure-ack.test.ts
@@ -282,6 +282,10 @@ describe("serve wake delivery (#118 / #198)", () => {
     // 非 JSON（resume 明文输出）→ 优雅返回 false，交回 stderr 判定。
     expect(claudeJsonEnvFailure("plain text answer mentioning unauthorized")).toBe(false);
     expect(claudeJsonEnvFailure("")).toBe(false);
+    // 合法但非对象的 JSON（null / 数字 / 字符串 / 数组 / 布尔）→ 绝不能对其取属性抛异常(CodeRabbit #752)。
+    for (const legal of ["null", "42", "\"unauthorized\"", "[]", "true"]) {
+      expect(claudeJsonEnvFailure(legal)).toBe(false);
+    }
   });
 
   test("a non-environment runner failure keeps environment=false (no false positives)", async () => {


### PR DESCRIPTION
## 问题

本机所有 `--runner claude` 常驻曾集体哑火(zego-voice/short-video/guessadmin),频道只显示:
```
builtin claude runner blocked: exit code 1 (not retriable: model may have run)
```
真因是**本机 claude 的 OAuth 过期**,但排查耗时很久——因为这个 auth 失败对 serve **隐形**。

`claude -p --output-format json` 命中 auth/api 失败时,结构化错误落在 **stdout 的 JSON**、exit 1:
```json
{"is_error":true, "terminal_reason":"api_error",
 "result":"Failed to authenticate: OAuth session expired and could not be refreshed", ...}
```
而 `isRunnerEnvFailure` **只扫 stderr**(#693 为躲模型输出误报,故意的),`parseClaudeJson` 又只取 sessionId+text 不看 `is_error`。→ 归成通用「exit-1 / model may have run」:不标 env failure、不触发 #744 自卸载、频道无「凭据过期」提示。

## 修法

新增 `claudeJsonEnvFailure(stdout)`,**只吃结构化字段**:仅当 `is_error===true && terminal_reason==="api_error"` 且 `result` 命中现有 `RUNNER_ENV_FAILURE_PATTERNS`(oauth expired / 401 / invalid api key …)才判 env failure。非零分支:
```ts
const envFailure = isRunnerEnvFailure(run.result) ||
  (opts.harness === "claude" && claudeJsonEnvFailure(run.result.stdout));
```
- 正常模型输出 `is_error:false`(即便正文含「unauthorized」)绝不误报——**不重犯 #693**。
- 命中后:标 env failure、走 EXIT_AUTH 语义、频道错误文案带「environment failure: credentials — model did not run」、#744 自卸载生效。
- 仅 claude harness 生效,codex 路径不受影响(结构不同,留作后续)。

## 验证
- `cli` **36 pass / 0 fail**,`tsc --noEmit` 干净。
- 新增回归护栏:auth 过期/401 命中;`is_error:false`+含 unauthorized、非 api_error、api_error 无指纹、非 JSON、空串——全**不**误报。

Closes #748 · 关联 #744(自卸载)、#693(stderr-only 由来)、#749(runner 被错设 claude 的连锁)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - 改进 Claude 结构化 JSON 错误识别：当 `stdout` 为 Claude 结构化 JSON 且指向认证/API 错误时，准确判断为环境性失败。
  - 在内建 runner 中扩展环境性失败判定：当运行结果非零退出且为 Claude 输出时，结合结构化 JSON 判断并按对应阻塞语义处理。
  - 新增与扩展回归测试：覆盖认证过期、HTTP 401/无效密钥等命中场景，并确保对非 `api_error`、非 JSON、以及非对象 JSON 不误判。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->