### PR TITLE
feat(web): 文档站 SEO 基建 —— robots.txt / sitemap / canonical / OG

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -5,7 +5,15 @@
     <meta name="referrer" content="no-referrer" />
     <meta name="viewport" content="width=device-width, initial-scale=1, interactive-widget=resizes-content" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <title>AgentParty</title>
+    <title>AgentParty — 多 agent 协作频道</title>
+    <meta name="description" content="AgentParty：让 Codex、Claude Code 和其他 AI agent 在同一个频道里交接、待命、唤醒和协作的多 agent 协作平台。" />
+    <link rel="canonical" href="https://agentparty.leeguoo.com/" />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="AgentParty" />
+    <meta property="og:title" content="AgentParty — 多 agent 协作频道" />
+    <meta property="og:description" content="AgentParty：让 Codex、Claude Code 和其他 AI agent 在同一个频道里交接、待命、唤醒和协作的多 agent 协作平台。" />
+    <meta property="og:url" content="https://agentparty.leeguoo.com/" />
+    <meta name="twitter:card" content="summary" />
   </head>
   <body>
     <div id="root"></div>

--- a/web/public/docs/desktop/index.html
+++ b/web/public/docs/desktop/index.html
@@ -5,6 +5,16 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="referrer" content="no-referrer" />
     <title>桌面应用 R4 · AgentParty 文档</title>
+    <link rel="canonical" href="https://agentparty.leeguoo.com/docs/desktop/" />
+    <meta property="og:type" content="article" />
+    <meta property="og:site_name" content="AgentParty" />
+    <meta property="og:title" content="桌面应用 R4 · AgentParty 文档" />
+    <meta property="og:description" content="AgentParty Desktop R4：私有部署与浏览器配对、按服务器隔离凭据、签名更新，以及无需终端的本机 agent 管理。" />
+    <meta property="og:url" content="https://agentparty.leeguoo.com/docs/desktop/" />
+    <meta property="og:locale" content="zh_CN" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="桌面应用 R4 · AgentParty 文档" />
+    <meta name="twitter:description" content="AgentParty Desktop R4：私有部署与浏览器配对、按服务器隔离凭据、签名更新，以及无需终端的本机 agent 管理。" />
     <meta name="description" content="AgentParty Desktop R4：私有部署与浏览器配对、按服务器隔离凭据、签名更新，以及无需终端的本机 agent 管理。" />
     <meta name="theme-color" content="#fcfbf4" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/web/public/docs/index.html
+++ b/web/public/docs/index.html
@@ -5,6 +5,16 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="referrer" content="no-referrer" />
     <title>AgentParty 文档</title>
+    <link rel="canonical" href="https://agentparty.leeguoo.com/docs/" />
+    <meta property="og:type" content="article" />
+    <meta property="og:site_name" content="AgentParty" />
+    <meta property="og:title" content="AgentParty 文档" />
+    <meta property="og:description" content="AgentParty 文档：让 Codex、Claude Code 和其他 agent 在同一个频道里交接、待命、唤醒和协作。" />
+    <meta property="og:url" content="https://agentparty.leeguoo.com/docs/" />
+    <meta property="og:locale" content="zh_CN" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="AgentParty 文档" />
+    <meta name="twitter:description" content="AgentParty 文档：让 Codex、Claude Code 和其他 agent 在同一个频道里交接、待命、唤醒和协作。" />
     <meta name="description" content="AgentParty 文档：让 Codex、Claude Code 和其他 agent 在同一个频道里交接、待命、唤醒和协作。" />
     <meta name="theme-color" content="#fcfbf4" />
 

--- a/web/public/docs/spec/index.html
+++ b/web/public/docs/spec/index.html
@@ -5,6 +5,16 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="referrer" content="no-referrer">
 <title>技术规格 · AgentParty 文档</title>
+    <link rel="canonical" href="https://agentparty.leeguoo.com/docs/spec/" />
+    <meta property="og:type" content="article" />
+    <meta property="og:site_name" content="AgentParty" />
+    <meta property="og:title" content="技术规格 · AgentParty 文档" />
+    <meta property="og:description" content="AgentParty RFC 级技术规格书：系统架构、Wire Protocol、REST API、数据模型、鉴权与 ACL、party 协作、agent 编队与血缘、host 协调、工作产物、生态、分发、运维与测试。全书 15 章 + 4 附录。" />
+    <meta property="og:url" content="https://agentparty.leeguoo.com/docs/spec/" />
+    <meta property="og:locale" content="zh_CN" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="技术规格 · AgentParty 文档" />
+    <meta name="twitter:description" content="AgentParty RFC 级技术规格书：系统架构、Wire Protocol、REST API、数据模型、鉴权与 ACL、party 协作、agent 编队与血缘、host 协调、工作产物、生态、分发、运维与测试。全书 15 章 + 4 附录。" />
 <meta name="description" content="AgentParty RFC 级技术规格书：系统架构、Wire Protocol、REST API、数据模型、鉴权与 ACL、party 协作、agent 编队与血缘、host 协调、工作产物、生态、分发、运维与测试。全书 15 章 + 4 附录。">
 
 <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/web/public/docs/statusline/index.html
+++ b/web/public/docs/statusline/index.html
@@ -5,6 +5,16 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="referrer" content="no-referrer" />
     <title>状态栏契约 · AgentParty 文档</title>
+    <link rel="canonical" href="https://agentparty.leeguoo.com/docs/statusline/" />
+    <meta property="og:type" content="article" />
+    <meta property="og:site_name" content="AgentParty" />
+    <meta property="og:title" content="状态栏契约 · AgentParty 文档" />
+    <meta property="og:description" content="AgentParty statusline.json 本地状态契约：Codex、Claude Code、tmux 和 shell prompt 如何安全显示频道、身份、未读和监听状态。" />
+    <meta property="og:url" content="https://agentparty.leeguoo.com/docs/statusline/" />
+    <meta property="og:locale" content="zh_CN" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="状态栏契约 · AgentParty 文档" />
+    <meta name="twitter:description" content="AgentParty statusline.json 本地状态契约：Codex、Claude Code、tmux 和 shell prompt 如何安全显示频道、身份、未读和监听状态。" />
     <meta name="description" content="AgentParty statusline.json 本地状态契约：Codex、Claude Code、tmux 和 shell prompt 如何安全显示频道、身份、未读和监听状态。" />
     <meta name="theme-color" content="#fcfbf4" />
 

--- a/web/public/robots.txt
+++ b/web/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://agentparty.leeguoo.com/sitemap.xml

--- a/web/public/sitemap.xml
+++ b/web/public/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://agentparty.leeguoo.com/</loc></url>
+  <url><loc>https://agentparty.leeguoo.com/docs/</loc></url>
+  <url><loc>https://agentparty.leeguoo.com/docs/desktop/</loc></url>
+  <url><loc>https://agentparty.leeguoo.com/docs/spec/</loc></url>
+  <url><loc>https://agentparty.leeguoo.com/docs/statusline/</loc></url>
+</urlset>

--- a/web/public/sitemap.xml
+++ b/web/public/sitemap.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url><loc>https://agentparty.leeguoo.com/</loc></url>
-  <url><loc>https://agentparty.leeguoo.com/docs/</loc></url>
-  <url><loc>https://agentparty.leeguoo.com/docs/desktop/</loc></url>
-  <url><loc>https://agentparty.leeguoo.com/docs/spec/</loc></url>
-  <url><loc>https://agentparty.leeguoo.com/docs/statusline/</loc></url>
+  <url><loc>https://agentparty.leeguoo.com/</loc><lastmod>2026-07-24</lastmod></url>
+  <url><loc>https://agentparty.leeguoo.com/docs/</loc><lastmod>2026-07-24</lastmod></url>
+  <url><loc>https://agentparty.leeguoo.com/docs/desktop/</loc><lastmod>2026-07-24</lastmod></url>
+  <url><loc>https://agentparty.leeguoo.com/docs/spec/</loc><lastmod>2026-07-24</lastmod></url>
+  <url><loc>https://agentparty.leeguoo.com/docs/statusline/</loc><lastmod>2026-07-24</lastmod></url>
 </urlset>


### PR DESCRIPTION
## 背景
https://agentparty.leeguoo.com/docs/ 在搜索引擎完全搜不到。排查发现：

- **没有 robots.txt / sitemap.xml** —— 请求这两个路径落到 SPA fallback，返回 200 + HTML 壳（搜索引擎视角是软 404 垃圾页）
- 4 个预渲染文档页（/docs/、/docs/desktop/、/docs/spec/、/docs/statusline/）没有 canonical、没有任何 og:/twitter meta
- 站点根 index.html 是 CSR 壳，title 只有 AgentParty，连 description 都没有

## 改动
- 新增 web/public/robots.txt（Allow all + Sitemap 指针）
- 新增 web/public/sitemap.xml（5 个可索引 URL）
- 4 个文档页 + 根 index.html 补 canonical / og / twitter meta；根页补 description、title 加描述性后缀

## 验证
- web 下 bun run build 通过；dist 里 robots.txt / sitemap.xml / canonical 均在

## 后续（需要 owner 操作）
1. Google Search Console / Bing Webmaster 验证域名并提交 sitemap —— 新域名不主动提交基本不会被收录
2. 域名权重为 0，最有效的是外链：GitHub README 指向 docs、发布帖带链接
3. GEO 方面已有 /llms.txt，方向是对的

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **SEO 与分享优化**
  * 更新网站及文档页面标题、描述和品牌信息。
  * 新增规范链接及 Open Graph、Twitter Card 元数据，改善搜索结果和社交分享预览。
* **网站抓取**
  * 新增 `robots.txt`，允许搜索引擎抓取并指向站点地图。
  * 新增包含主要页面地址的 `sitemap.xml`。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->