### PR TITLE
fix(serve): 修复终态回执重连与积压误重放

### DIFF
--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -429,6 +429,9 @@ const MAX_SUPERVISOR_RESTART_DELAY_MS = 30_000;
 const RUNNER_TERMINATION_GRACE_MS = 1_000;
 const RUNNER_TERMINATION_BARRIER_MS = RUNNER_TERMINATION_GRACE_MS + 500;
 const DELIVERY_UPDATE_ACK_TIMEOUT_MS = 5_000;
+const DELIVERY_TERMINAL_RETRY_MIN_MS = 250;
+const DELIVERY_TERMINAL_RETRY_MAX_MS = 5_000;
+const RECENTLY_SETTLED_DELIVERY_MAX = 256;
 
 export type RunnerHarness = "codex" | "claude";
 
@@ -1002,6 +1005,11 @@ export interface ServeOptions {
   // 但「积压」与「欠账」是两回事（#198）：跳过的只能是**已离线堆积、从未送达**的历史；
   // 送达失败被钉住的 stuck 无论多旧都必须重放，否则 #118 救下的那条 @ 会被这里吃掉。
   skipBacklog?: boolean;
+  /**
+   * 首次成功挂载时的频道水位。内部 supervisor 重启沿用它区分“启动前积压”和“重启窗口新消息”：
+   * 前者继续跳过，后者仍可由 legacy 服务消费；V1 work 另由 durable delivery 帧保证。
+   */
+  backlogCutoff?: number;
   /** 单实例锁目录（#99/#465）。默认全机共享、再按 server/token 身份隔离；测试注入。 */
   lockDir?: string;
   /** 关掉单实例保护（逃生舱）。 */
@@ -1015,6 +1023,8 @@ export interface ServeOptions {
   /** 有界重放：同一条 seq 连续送达失败上限，到顶就响亮放弃。 */
   maxWakeAttempts?: number;
   wakeRetryDelayMs?: number;
+  /** Delivery ACK timeout override for deterministic tests; production defaults to 5 seconds. */
+  deliveryUpdateAckTimeoutMs?: number;
   post?: typeof postMessage;
   /** 入站附件下载注入点；默认走当前 server 的鉴权 REST 路径。 */
   downloadAttachment?: typeof downloadAttachment;
@@ -1028,7 +1038,7 @@ export interface ServeOptions {
    * 把后续连接视为「内部重启」；连 welcome 都没收到的失败仍必须保留用户的
    * 首次 backlog 策略。
    */
-  onWelcome?: () => void;
+  onWelcome?: (lastSeq: number) => void;
   /** 每个 welcome 上报服务端能力位（用于 managed front 判断 owner 决策绑定是否被强制）。 */
   onServerCapabilities?: (caps: { ownerDecisionBinding: boolean }) => void;
   charter?: ChannelCharter | null;
@@ -3642,17 +3652,20 @@ export async function runProfileServe(opts: ProfileServeOptions): Promise<number
     const frontServeOpts = buildLane("front", front, frontPrepared, frontStateKey, frontContext);
     const workerServeOpts = buildLane("worker", worker, workerPrepared, workerStateKey, workerContext);
     const startLane = (label: ServeExecutionRole, lane: ServeOptions, stateKey: string): Promise<number> => {
-      let firstAttach = true;
+      let backlogCutoff: number | null = null;
       return superviseServe({
         runOnce: () => {
-          const skipBacklog = firstAttach ? lane.skipBacklog : false;
           return runChannelServe({
             ...lane,
             since: loadCursorForConfig(channel, stateKey),
             stuck: loadStuckForConfig(channel, stateKey),
             sinceRev: loadRevCursorForConfig(channel, stateKey),
-            skipBacklog,
-            onWelcome: () => { firstAttach = false; },
+            skipBacklog: lane.skipBacklog,
+            ...(backlogCutoff === null ? {} : { backlogCutoff }),
+            onWelcome: (lastSeq) => {
+              if (backlogCutoff === null) backlogCutoff = lastSeq;
+              lane.onWelcome?.(lastSeq);
+            },
           });
         },
         maxRestarts: opts.once ? 0 : undefined,
@@ -3865,6 +3878,56 @@ export async function confirmDeliveryUpdate(
   }
 }
 
+/**
+ * A runner that has crossed its side-effect boundary must never be restarted merely because the
+ * terminal ACK raced a websocket replacement. Keep the same runServe invocation parked and resend
+ * the idempotent completion probe until the current socket returns the authoritative delivery row.
+ */
+export async function confirmDeliveryCompletion(
+  conn: Pick<ReturnType<typeof connect>, "send" | "pendingFrames">,
+  deliveryId: string,
+  signal?: AbortSignal,
+  options: {
+    timeoutMs?: number;
+    retryDelayMs?: number;
+    onRetry?: (error: unknown, attempt: number) => void;
+  } = {},
+): Promise<PublicDirectedDelivery> {
+  let attempt = 0;
+  for (;;) {
+    try {
+      return await confirmDeliveryUpdate(
+        conn,
+        {
+          type: "delivery_update",
+          delivery_id: deliveryId,
+          state: "replied",
+        },
+        options.timeoutMs,
+        signal,
+        ["failed"],
+      );
+    } catch (error) {
+      if (signal?.aborted) throw signal.reason;
+      const fatal = [...conn.pendingFrames()].reverse().find(
+        (frame): frame is Extract<ServerFrame, { type: "error" }> =>
+          frame.type === "error" && (frame.code === "unauthorized" || frame.code === "archived"),
+      );
+      if (fatal !== undefined) throw error;
+      attempt += 1;
+      options.onRetry?.(error, attempt);
+      const baseDelay = Math.max(0, options.retryDelayMs ?? DELIVERY_TERMINAL_RETRY_MIN_MS);
+      const retryDelay = Math.min(
+        baseDelay * (2 ** Math.min(attempt - 1, 8)),
+        DELIVERY_TERMINAL_RETRY_MAX_MS,
+      );
+      if (retryDelay === 0) await Promise.resolve();
+      else if (signal === undefined) await delay(retryDelay);
+      else await delayWithAbort(retryDelay, signal);
+    }
+  }
+}
+
 export async function runWithRunnerTimeout(
   run: NonNullable<ServeOptions["runCommand"]>,
   frame: MsgFrame,
@@ -4071,7 +4134,20 @@ export async function runServe(o: ServeOptions): Promise<number> {
           },
         })
       : defaultRun);
+  const recentlySettledDeliveryIds = new Set<string>();
+  const rememberSettledDelivery = (deliveryId: string) => {
+    recentlySettledDeliveryIds.delete(deliveryId);
+    recentlySettledDeliveryIds.add(deliveryId);
+    while (recentlySettledDeliveryIds.size > RECENTLY_SETTLED_DELIVERY_MAX) {
+      const oldest = recentlySettledDeliveryIds.values().next().value;
+      if (oldest === undefined) break;
+      recentlySettledDeliveryIds.delete(oldest);
+    }
+  };
   const settleRunnerDelivery = async (delivery: DirectedDelivery, state: "replied" | "failed") => {
+    // A reconnect may already have buffered a stale redelivery before the terminal probe is ACKed.
+    // Remember authority before best-effort local cleanup so that stale frame cannot run the model.
+    rememberSettledDelivery(delivery.id);
     try {
       await run.onDeliveryTerminal?.(delivery, state);
     } catch (error) {
@@ -4178,10 +4254,14 @@ export async function runServe(o: ServeOptions): Promise<number> {
         last_frame_at: Date.now(),
         last_error: null,
       }));
+      if (directedDelivery !== null && recentlySettledDeliveryIds.has(directedDelivery.id)) {
+        out(`serve: ignored already-settled redelivery ${directedDelivery.id}`);
+        continue;
+      }
       if (frame.type === "welcome") {
         self = frame.self;
         if (!welcomeReported) {
-          o.onWelcome?.();
+          o.onWelcome?.(frame.last_seq);
           welcomeReported = true;
         }
         directedDeliveryMode = frame.directed_delivery === "v1";
@@ -4208,14 +4288,30 @@ export async function runServe(o: ServeOptions): Promise<number> {
           attachHead = frame.last_seq;
           const pending = Math.max(0, attachHead - o.since);
           if (pending > 0) {
-            const range = `seq ${o.since + 1}..${attachHead}`;
             const debt = stuck !== null && stuck.seq <= attachHead ? ` 欠账 seq=${stuck.seq} 不在跳过之列，将重放（#198）。` : "";
-            out(
-              skipBacklog
-                ? `serve: 跳过 ${pending} 条离线积压（${range}）——不逐条唤醒 runner。${debt}` +
-                    ` 查看：party history ${o.channel}；要逐条重放请重启并加 --replay-backlog`
-                : `serve: --replay-backlog：将逐条重放 ${pending} 条离线积压（${range}），每条唤醒一次 runner（可能重放副作用）`,
-            );
+            if (skipBacklog) {
+              const cutoff = Math.min(attachHead, Math.max(0, o.backlogCutoff ?? attachHead));
+              const skipped = Math.max(0, cutoff - o.since);
+              const recoveryStart = Math.max(o.since, cutoff) + 1;
+              const recovery = Math.max(0, attachHead - Math.max(o.since, cutoff));
+              if (skipped > 0) {
+                out(
+                  `serve: 跳过 ${skipped} 条离线积压（启动前，seq ${o.since + 1}..${cutoff}）——不逐条唤醒 runner。${debt}` +
+                    ` 查看：party history ${o.channel}；要逐条重放请重启并加 --replay-backlog`,
+                );
+              }
+              if (recovery > 0) {
+                out(
+                  `serve: 内部恢复，继续处理重启窗口内 ${recovery} 条新消息` +
+                    `（seq ${recoveryStart}..${attachHead}）；未启用 --replay-backlog。`,
+                );
+              }
+            } else {
+              out(
+                `serve: --replay-backlog：将逐条重放 ${pending} 条离线积压` +
+                  `（seq ${o.since + 1}..${attachHead}），每条唤醒一次 runner（可能重放副作用）`,
+              );
+            }
           }
         }
         if (o.statusline === true) {
@@ -4313,7 +4409,11 @@ export async function runServe(o: ServeOptions): Promise<number> {
       // 反例（190-codex-dev on PR #206）：--all 下一条非 mention 失败留下欠账，重启回默认
       // mentions-only 后 qualifies=false → 不重试、不清欠账、却无条件 ack 越过它。
       const isDebt = stuck !== null && frame.seq === stuck.seq;
-      const isBacklog = directedDelivery === null && skipBacklog && attachHead !== null && frame.seq <= attachHead;
+      const isBacklog =
+        directedDelivery === null &&
+        skipBacklog &&
+        attachHead !== null &&
+        frame.seq <= Math.min(attachHead, Math.max(0, o.backlogCutoff ?? attachHead));
       const mentionOwnedByDelivery =
         directedDeliveryMode && directedDelivery === null && frame.mentions.includes(self);
       const passesFilter =
@@ -4682,11 +4782,20 @@ export async function runServe(o: ServeOptions): Promise<number> {
         let deliveryConfirmed = directedDelivery === null;
         if (delivered && directedDelivery !== null) {
           try {
-            const completion = await confirmDeliveryUpdate(conn, {
-              type: "delivery_update",
-              delivery_id: directedDelivery.id,
-              state: "replied",
-            }, undefined, lifecycleController.signal, ["failed"]);
+            const completion = await confirmDeliveryCompletion(
+              conn,
+              directedDelivery.id,
+              lifecycleController.signal,
+              {
+                timeoutMs: o.deliveryUpdateAckTimeoutMs,
+                onRetry: (error, attempt) => {
+                  out(
+                    `  delivery ${directedDelivery.id} 完成确认未落地，保持本轮并重连补确认` +
+                    `（attempt=${attempt}）: ${errText(error)}`,
+                  );
+                },
+              },
+            );
             if (completion.state === "failed") {
               // Worker is the race-free authority: if a linked REST reply committed, the row was
               // already replied before that HTTP request returned. A still-active row receiving a
@@ -4716,9 +4825,9 @@ export async function runServe(o: ServeOptions): Promise<number> {
             }
           } catch (error) {
             const message = errText(error);
-            // 不伪称已确认：退出本轮。服务端仍保留 claimed/running，随后按明确的
-            // unknown-outcome 规则收口；绝不在本地把 fire-and-forget 当 durable ack。
-            out(`  delivery ${directedDelivery.id} 完成回执发送失败，重连核对: ${message}`);
+            // Only lifecycle abort or a terminal server error can escape confirmDeliveryCompletion;
+            // transient disconnects and rolling-upgrade protocol windows stay in the same turn.
+            out(`  delivery ${directedDelivery.id} 完成确认被终局中断: ${message}`);
             code = EXIT_STREAM_ENDED;
             stopAfterFrame = true;
           }
@@ -5223,7 +5332,7 @@ export async function run(argv: string[]): Promise<number> {
     // A transient startup outage should not prevent the WS supervisor from doing its own retry.
     // The first successful /api/me below establishes the immutable identity boundary.
   }
-  let firstAttach = true;
+  let backlogCutoff: number | null = null;
   const lifecycle = (line: string) => {
     const record = `${new Date().toISOString()} ${line}`;
     if (runnerWorkdirPath !== null) appendServeLifecycleLog(runnerWorkdirPath, record);
@@ -5247,7 +5356,6 @@ export async function run(argv: string[]): Promise<number> {
       }
       const currentRunnerWorkdir = runnerWorkdirPath ?? defaultRunnerWorkdir(channel, boundary.namespace);
       runnerWorkdirPath = currentRunnerWorkdir;
-      const skipBacklogThisAttach = firstAttach ? flags["replay-backlog"] !== true : false;
       const result = await runServe({
         server: currentServer,
         token: currentToken,
@@ -5258,10 +5366,13 @@ export async function run(argv: string[]): Promise<number> {
         sinceRev: loadRevCursor(channel),
         cmd: cmd ?? "",
         mentionsOnly: flags.all !== true,
-        // Only the process's first attachment applies the user's backlog policy.  Internal recovery
-        // always resumes from the durable cursor, so mentions received during the restart gap survive.
-        skipBacklog: skipBacklogThisAttach,
-        onWelcome: () => { firstAttach = false; },
+        // Internal recovery is not user-requested replay. Keep the first attach cutoff so legacy
+        // messages from the restart gap still run while pre-existing history remains skipped.
+        skipBacklog: flags["replay-backlog"] !== true,
+        ...(backlogCutoff === null ? {} : { backlogCutoff }),
+        onWelcome: (lastSeq) => {
+          if (backlogCutoff === null) backlogCutoff = lastSeq;
+        },
         onCursor: (c) => saveCursor(channel, c),
         onRevCursor: (r) => saveRevCursor(channel, r),
         advertise: (signal) => advertiseServeWake(currentAuth, channel, signal),

--- a/cli/test/serve-daemon-resilience.test.ts
+++ b/cli/test/serve-daemon-resilience.test.ts
@@ -193,7 +193,7 @@ describe("profile daemon resilience (#115)", () => {
         if (role === "worker" && attempts.worker === 1) {
           throw new Error("pre-welcome child crash"); // no welcome callback
         }
-        serveOpts.onWelcome?.();
+        serveOpts.onWelcome?.(0);
         return await new Promise<number>((resolve) => {
           const finish = () => resolve(EXIT_SIGNAL_TERM);
           serveOpts.signal?.addEventListener("abort", finish, { once: true });

--- a/cli/test/serve-directed-delivery.test.ts
+++ b/cli/test/serve-directed-delivery.test.ts
@@ -10,7 +10,13 @@ import {
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { confirmDeliveryUpdate, runServe, type ServeOptions, type ServeRunner } from "../src/commands/serve";
+import {
+  confirmDeliveryCompletion,
+  confirmDeliveryUpdate,
+  runServe,
+  type ServeOptions,
+  type ServeRunner,
+} from "../src/commands/serve";
 import { writeConfig, writeState } from "../src/config";
 import { msgFrame, startMockServer, welcomeFrame, type MockServer } from "./mock-server";
 import { startRestMock } from "./rest-mock";
@@ -121,6 +127,46 @@ describe("serve durable directed delivery (#551)", () => {
       delivery_id: work.id,
       state: "replied",
     }, 200, undefined, ["failed"])).toMatchObject({ id: work.id, state: "failed" });
+  });
+
+  test("completion confirmation retries an invalid-frame rolling window without restarting work", async () => {
+    const work = delivery(21);
+    const frames: ServerFrame[] = [];
+    let sends = 0;
+    const conn = {
+      send(frame: ClientFrame) {
+        if (frame.type !== "delivery_update") return false;
+        sends += 1;
+        if (sends === 1) {
+          frames.push({ type: "error", code: "bad_request", message: "invalid frame" });
+        } else {
+          frames.push({
+            type: "delivery_state",
+            request_id: frame.request_id,
+            delivery: {
+              id: work.id,
+              message_seq: work.message_seq,
+              target_name: work.target_name,
+              state: "replied",
+              reply_seq: 42,
+              created_at: work.created_at,
+              updated_at: Date.now(),
+            },
+          });
+        }
+        return true;
+      },
+      pendingFrames: () => frames,
+    };
+    const retries: string[] = [];
+
+    expect(await confirmDeliveryCompletion(conn, work.id, undefined, {
+      timeoutMs: 100,
+      retryDelayMs: 0,
+      onRetry: (error) => retries.push(String(error)),
+    })).toMatchObject({ id: work.id, state: "replied", reply_seq: 42 });
+    expect(sends).toBe(2);
+    expect(retries).toEqual([expect.stringContaining("bad_request: invalid frame")]);
   });
 
   test("waiting_owner is parked work and never triggers terminal continuation cleanup", async () => {
@@ -763,7 +809,7 @@ describe("serve durable directed delivery (#551)", () => {
     expect(terminals).toEqual([{ id: work.id, state: "failed" }]);
   });
 
-  test("a disconnect that loses the terminal update exits unknown-outcome and never runs a redelivery", async () => {
+  test("a disconnect that loses the terminal ACK reconnects, confirms, and ignores buffered redelivery", async () => {
     const message = msgFrame(9, "do not duplicate", { mentions: ["me"] }) as unknown as MsgFrame;
     const work = delivery(9);
     const lines: string[] = [];
@@ -774,10 +820,9 @@ describe("serve durable directed delivery (#551)", () => {
       if (frame.type === "hello") {
         sock.send({ ...welcomeFrame(0, "me"), directed_delivery: "v1" });
         if (connectionIndex > 0) {
-          // The replacement connection can already have the same durable work buffered. The first
-          // run's unknown terminal outcome must stop this runServe invocation before it consumes it.
+          // The replacement socket may receive a stale redelivery before the idempotent terminal
+          // probe is acknowledged. The same runServe invocation must settle first, then ignore it.
           sock.send({ type: "delivery", delivery: work, message });
-          sock.send({ type: "error", code: "archived", message: "replacement connection" });
         }
         return;
       }
@@ -794,9 +839,16 @@ describe("serve durable directed delivery (#551)", () => {
             request_id: frame.request_id,
             delivery: { ...work, state: "running", updated_at: Date.now() },
           });
-        } else {
+        } else if (connectionIndex === 0) {
           // Drop the connection before an authoritative terminal delivery_state can echo the update.
           sock.close();
+        } else {
+          sock.send({
+            type: "delivery_state",
+            request_id: frame.request_id,
+            delivery: { ...work, state: "replied", reply_seq: 99, updated_at: Date.now() },
+          });
+          sock.send({ type: "error", code: "archived", message: "done" });
         }
       }
     });
@@ -809,14 +861,16 @@ describe("serve durable directed delivery (#551)", () => {
       server: server.url,
       out: (line) => lines.push(line),
       runCommand: runner,
+      deliveryUpdateAckTimeoutMs: 100,
     }));
 
-    expect(code).toBe(EXIT_STREAM_ENDED);
+    expect(code).toBe(EXIT_ARCHIVED);
     expect(runnerCalls).toBe(1);
-    expect(updateCalls).toBe(2);
-    expect(terminals).toEqual([]);
-    expect(lines.some((line) => line.includes("完成回执发送失败"))).toBe(true);
-  });
+    expect(updateCalls).toBe(3);
+    expect(terminals).toEqual([{ id: work.id, state: "replied" }]);
+    expect(lines.some((line) => line.includes("保持本轮并重连补确认"))).toBe(true);
+    expect(lines.some((line) => line.includes("ignored already-settled redelivery"))).toBe(true);
+  }, 10_000);
 
   test("a disconnect before the authoritative running acknowledgement never starts the runner", async () => {
     const message = msgFrame(12, "must not start", { mentions: ["me"] }) as unknown as MsgFrame;

--- a/cli/test/serve-supervisor.test.ts
+++ b/cli/test/serve-supervisor.test.ts
@@ -153,7 +153,7 @@ describe("serve lifecycle supervisor (#550)", () => {
     expect(calls).toBe(2);
   });
 
-  test("an internal restart replays mentions that arrived after the first attach instead of classifying them as backlog", async () => {
+  test("an internal restart preserves skip-backlog while processing only messages after the first attach cutoff", async () => {
     const server = startMockServer((frame, sock, connection) => {
       if (frame.type !== "hello") return;
       if (connection === 0) {
@@ -167,14 +167,14 @@ describe("serve lifecycle supervisor (#550)", () => {
     });
     const seen: number[] = [];
     let cursor = 0;
-    let firstAttach = true;
-    const policies: boolean[] = [];
+    let backlogCutoff: number | null = null;
+    const cutoffs: Array<number | null> = [];
     try {
       const code = await superviseServe({
         baseDelayMs: 0,
         sleep: async () => {},
         runOnce: () => {
-          policies.push(firstAttach);
+          cutoffs.push(backlogCutoff);
           return runServe({
             server: server.url,
             token: "ap_test",
@@ -182,8 +182,11 @@ describe("serve lifecycle supervisor (#550)", () => {
             since: cursor,
             cmd: "",
             mentionsOnly: true,
-            skipBacklog: firstAttach,
-            onWelcome: () => { firstAttach = false; },
+            skipBacklog: true,
+            ...(backlogCutoff === null ? {} : { backlogCutoff }),
+            onWelcome: (lastSeq) => {
+              if (backlogCutoff === null) backlogCutoff = lastSeq;
+            },
             allowMultiple: true,
             advertise: async () => {},
             post: async () => ({ seq: 99 }),
@@ -196,7 +199,7 @@ describe("serve lifecycle supervisor (#550)", () => {
       expect(code).toBe(EXIT_ARCHIVED);
       expect(seen).toEqual([1]);
       expect(cursor).toBe(1);
-      expect(policies).toEqual([true, false]);
+      expect(cutoffs).toEqual([null, 0]);
       expect(server.hellos).toEqual([0, 0]);
     } finally {
       server.stop();
@@ -214,15 +217,15 @@ describe("serve lifecycle supervisor (#550)", () => {
       sock.send(msgFrame(1, "offline backlog", { mentions: ["me"] }));
       setTimeout(() => sock.send({ type: "error", code: "archived", message: "done" }), 20);
     });
-    let firstAttach = true;
-    const policies: boolean[] = [];
+    let backlogCutoff: number | null = null;
+    const cutoffs: Array<number | null> = [];
     const seen: number[] = [];
     try {
       const code = await superviseServe({
         baseDelayMs: 0,
         sleep: async () => {},
         runOnce: () => {
-          policies.push(firstAttach);
+          cutoffs.push(backlogCutoff);
           return runServe({
             server: server.url,
             token: "ap_test",
@@ -230,8 +233,11 @@ describe("serve lifecycle supervisor (#550)", () => {
             since: 0,
             cmd: "",
             mentionsOnly: true,
-            skipBacklog: firstAttach,
-            onWelcome: () => { firstAttach = false; },
+            skipBacklog: true,
+            ...(backlogCutoff === null ? {} : { backlogCutoff }),
+            onWelcome: (lastSeq) => {
+              if (backlogCutoff === null) backlogCutoff = lastSeq;
+            },
             allowMultiple: true,
             advertise: async () => {},
             post: async () => ({ seq: 99 }),
@@ -241,7 +247,7 @@ describe("serve lifecycle supervisor (#550)", () => {
       });
 
       expect(code).toBe(EXIT_ARCHIVED);
-      expect(policies).toEqual([true, true]);
+      expect(cutoffs).toEqual([null, null]);
       expect(seen).toEqual([]);
     } finally {
       server.stop();

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -10003,19 +10003,27 @@ export class ChannelDO extends Server<Env> {
     const ownsCurrentLease = String(row.lease_connection_id ?? "") === connectionId;
     const ownsFormerLease = String(row.last_lease_connection_id ?? "") === connectionId;
     // handleSend can persist the question and detach the lease before the runner's success receipt
-    // arrives. ACK that exact former holder as a no-op and return the authoritative waiting_owner
-    // row; never let the generic replied receipt erase the human handoff.
+    // arrives. ACK a same-principal no-op and return the authoritative waiting_owner row; never let
+    // the generic replied receipt erase the human handoff.
     if (oldState === "waiting_owner") {
-      return ownsFormerLease && (update.state === "waiting_owner" || update.state === "replied");
+      // A websocket replacement changes connectionId while preserving the authenticated delivery
+      // principal. This is a read-only terminal probe: accepting it cannot release or mutate work.
+      return update.state === "waiting_owner" || update.state === "replied";
     }
 
     // Terminal receipts detach the current lease but retain its last holder for idempotent ACKs.
     // Only an explicitly typed unknown outcome (or a legacy untyped row) may converge on a late
     // success. Policy/retract failures are final and must never be revived by a stale receipt.
-    if (oldState === "replied") return update.state === "replied" && (ownsCurrentLease || ownsFormerLease);
+    if (oldState === "replied") {
+      // Same-principal reconnects must recover an ACK lost after a linked REST reply. Active rows
+      // still require exact lease ownership below, so a standby cannot forge success.
+      return update.state === "replied";
+    }
     if (oldState === "failed") {
-      if (!(ownsCurrentLease || ownsFormerLease)) return false;
+      // Confirming an already-failed row is likewise a no-op. Reviving an explicitly recoverable
+      // unknown outcome to replied remains restricted to the exact current/former lease holder.
       if (update.state === "failed") return true;
+      if (!(ownsCurrentLease || ownsFormerLease)) return false;
       if (update.state !== "replied") return false;
       if (!this.isFailedDeliveryRevivable(row)) return false;
     } else if (!ownsCurrentLease) {

--- a/worker/test/directed-delivery.spec.ts
+++ b/worker/test/directed-delivery.spec.ts
@@ -216,6 +216,57 @@ describe("持久定向投递（issue #551）", () => {
     holder.close();
   });
 
+  it("same-principal reconnect can idempotently confirm a linked reply after the original socket is gone", async () => {
+    const sender = await seedToken("agent", uniq("sender"));
+    const target = await seedToken("agent", uniq("target"));
+    const slug = await createChannel(sender.token);
+    const holder = await WsClient.open(slug, target.token);
+    await holder.nextOfType("welcome");
+    expect((await claim(holder)).held).toBe(true);
+
+    const posted = await sendMention(slug, sender.token, target.name, "reply across reconnect");
+    const work = (await holder.nextOfType("delivery")) as DirectedDeliveryFrame;
+    holder.send({
+      type: "delivery_update",
+      delivery_id: work.delivery.id,
+      request_id: "reconnect-running",
+      state: "running",
+    });
+    await nextDeliveryState(holder, work.delivery.id, "running", "reconnect-running");
+
+    const reply = await api(`/api/channels/${slug}/messages`, target.token, {
+      method: "POST",
+      body: JSON.stringify({ kind: "message", body: "already committed", mentions: [], reply_to: posted.seq }),
+    });
+    expect(reply.status).toBe(200);
+    const replySeq = ((await reply.json()) as { seq: number }).seq;
+    await nextDeliveryState(holder, work.delivery.id, "replied");
+    holder.close();
+
+    const replacement = await WsClient.open(slug, target.token);
+    await replacement.nextOfType("welcome");
+    replacement.send({ type: "hello", since: replySeq, directed_delivery: "v1" });
+    replacement.send({
+      type: "delivery_update",
+      delivery_id: work.delivery.id,
+      request_id: "reconnect-terminal",
+      state: "replied",
+    });
+    const confirmation = await nextDeliveryState(
+      replacement,
+      work.delivery.id,
+      "replied",
+      "reconnect-terminal",
+    );
+    expect(confirmation.delivery.reply_seq).toBe(replySeq);
+    expect(await deliveryRows(slug)).toMatchObject([{
+      id: work.delivery.id,
+      state: "replied",
+      reply_seq: replySeq,
+    }]);
+    replacement.close();
+  });
+
   it("legacy serve 已持租时保持 holder，后来的 v1 为 standby 且不重复领取", async () => {
     const sender = await seedToken("agent", uniq("sender"));
     const target = await seedToken("agent", uniq("target"));


### PR DESCRIPTION
## 结果

- 同一身份重连后可幂等确认已经 replied/failed/waiting_owner 的终态，不放宽活跃租约或 failed→replied 复活
- CLI 在终态 ACK 丢失时留在同一轮重连探测，避免重复执行模型副作用
- 忽略重连缓冲中的已结算重复 delivery
- supervisor 保留首次挂载水位，只跳过启动前积压，继续处理内部重启窗口的新消息

## 验证

- CLI 全量：1123 pass
- Worker 全量：739 pass
- CLI / Worker typecheck 通过
- git diff --check 通过

Stacked on #758; #758 合并后改回 main 基线。

Closes #757