### PR TITLE
fix(web): 隔离频道筛选并优先显示在线成员

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1373,6 +1373,7 @@ export function App() {
             />
           )}
           <ChannelList
+            scopeKey={activeOrigin}
             channels={channels}
             active={slug}
             error={listError}

--- a/web/src/components/ChannelList.test.tsx
+++ b/web/src/components/ChannelList.test.tsx
@@ -4,7 +4,7 @@ import type { PresenceEntry } from "@agentparty/shared";
 import { act, create, type ReactTestRenderer } from "react-test-renderer";
 import { LocaleProvider } from "../i18n/locale";
 import type { ChannelInfo } from "../lib/api";
-import { ChannelList, PresenceDots } from "./ChannelList";
+import { ChannelList, lastMessagePreview, PresenceDots } from "./ChannelList";
 
 let renderer: ReactTestRenderer | null = null;
 
@@ -170,5 +170,32 @@ describe("PresenceDots priority", () => {
       "offline-1 — offline",
       "offline-2 — offline",
     ]);
+  });
+
+  test("treats an omitted presence field as an empty legacy response", () => {
+    const value = channel("legacy-response");
+    delete (value as Partial<ChannelInfo>).presence;
+    act(() => {
+      renderer = create(
+        <LocaleProvider>
+          <PresenceDots channel={value} />
+        </LocaleProvider>,
+      );
+    });
+
+    expect(
+      renderer!.root.findAll(
+        (node) => node.type === "span" && node.props.className === "d-dot d-dot--offline",
+      ),
+    ).toHaveLength(1);
+  });
+});
+
+describe("lastMessagePreview", () => {
+  test("treats an omitted last_message field as no preview", () => {
+    const value = channel("legacy-response");
+    delete (value as Partial<ChannelInfo>).last_message;
+
+    expect(lastMessagePreview(value)).toBeNull();
   });
 });

--- a/web/src/components/ChannelList.test.tsx
+++ b/web/src/components/ChannelList.test.tsx
@@ -1,0 +1,174 @@
+// @ts-expect-error Bun executes this test, while the web tsconfig intentionally loads only Vite globals.
+import { afterEach, describe, expect, test } from "bun:test";
+import type { PresenceEntry } from "@agentparty/shared";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { LocaleProvider } from "../i18n/locale";
+import type { ChannelInfo } from "../lib/api";
+import { ChannelList, PresenceDots } from "./ChannelList";
+
+let renderer: ReactTestRenderer | null = null;
+
+Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", { configurable: true, value: true });
+
+function presence(name: string, state: PresenceEntry["state"]): PresenceEntry {
+  return { name, state, note: null, ts: 1 };
+}
+
+function channel(
+  slug: string,
+  options: {
+    owned?: boolean;
+    member?: boolean;
+    presence?: PresenceEntry[];
+  } = {},
+): ChannelInfo {
+  return {
+    slug,
+    title: slug,
+    topic: null,
+    kind: "standing",
+    mode: "normal",
+    visibility: "private",
+    owned: options.owned,
+    member: options.member,
+    created_at: 1,
+    archived_at: null,
+    last_message: null,
+    presence: options.presence ?? [],
+  };
+}
+
+function listView(scope: string, channels: ChannelInfo[], active: string | null = null) {
+  return (
+    <LocaleProvider>
+      <ChannelList
+        scopeKey={scope}
+        channels={channels}
+        active={active}
+        error={null}
+        onOpen={() => {}}
+      />
+    </LocaleProvider>
+  );
+}
+
+function categoryButton(r: ReactTestRenderer, category: "all" | "created" | "joined") {
+  const categories = r.root.findAll(
+    (node) => node.type === "button" && String(node.props.className ?? "").includes("chan-cat-btn"),
+  );
+  const index = category === "all" ? 0 : category === "created" ? 1 : 2;
+  return categories[index]!;
+}
+
+function visibleChannelSlugs(r: ReactTestRenderer): string[] {
+  return r.root
+    .findAll((node) => node.type === "button" && String(node.props.className ?? "").includes("chan-pill"))
+    .map((node) => String(node.props.title));
+}
+
+afterEach(() => {
+  act(() => renderer?.unmount());
+  renderer = null;
+});
+
+describe("ChannelList view-scoped filters", () => {
+  test("server change resets a stale joined filter so the new server's real channels remain visible", () => {
+    act(() => {
+      renderer = create(
+        listView("https://server-a.example:/", [
+          channel("created-a", { owned: true }),
+          channel("joined-a", { member: true }),
+        ]),
+      );
+    });
+    const r = renderer!;
+
+    act(() => (categoryButton(r, "joined").props.onClick as () => void)());
+    expect(visibleChannelSlugs(r)).toEqual(["joined-a"]);
+    expect(categoryButton(r, "joined").props["aria-pressed"]).toBe(true);
+
+    act(() => {
+      r.update(
+        listView("https://server-b.example:/", [
+          channel("created-b", { owned: true }),
+        ]),
+      );
+    });
+    expect(visibleChannelSlugs(r)).toEqual(["created-b"]);
+    expect(categoryButton(r, "all").props["aria-pressed"]).toBe(true);
+  });
+
+  test("route change resets the filter before rendering an externally opened active channel", () => {
+    const channels = [
+      channel("created-a", { owned: true }),
+      channel("joined-a", { member: true }),
+    ];
+    act(() => {
+      renderer = create(listView("https://server-a.example:/", channels));
+    });
+    const r = renderer!;
+
+    act(() => (categoryButton(r, "joined").props.onClick as () => void)());
+    expect(visibleChannelSlugs(r)).toEqual(["joined-a"]);
+
+    act(() => {
+      r.update(listView("https://server-a.example:/", channels, "created-a"));
+    });
+    expect(visibleChannelSlugs(r)).toEqual(["created-a", "joined-a"]);
+    const active = r.root.findAll(
+      (node) =>
+        node.type === "button" &&
+        String(node.props.className ?? "").includes("chan-pill") &&
+        String(node.props.className ?? "").includes("is-active"),
+    );
+    expect(active).toHaveLength(1);
+    expect(active[0]!.props.title).toBe("created-a");
+  });
+
+  test("an explicit category choice remains active while the current route is unchanged", () => {
+    const channels = [
+      channel("created-a", { owned: true }),
+      channel("joined-a", { member: true }),
+    ];
+    act(() => {
+      renderer = create(listView("https://server-a.example", channels, "created-a"));
+    });
+
+    act(() => (categoryButton(renderer!, "joined").props.onClick as () => void)());
+
+    expect(visibleChannelSlugs(renderer!)).toEqual(["joined-a"]);
+    expect(categoryButton(renderer!, "joined").props["aria-pressed"]).toBe(true);
+  });
+});
+
+describe("PresenceDots priority", () => {
+  test("working and online members are selected before earlier offline records", () => {
+    const value = channel("priority", {
+      presence: [
+        presence("offline-1", "offline"),
+        presence("offline-2", "offline"),
+        presence("offline-3", "offline"),
+        presence("offline-4", "offline"),
+        presence("waiting-live", "waiting"),
+        presence("working-live", "working"),
+      ],
+    });
+    act(() => {
+      renderer = create(
+        <LocaleProvider>
+          <PresenceDots channel={value} />
+        </LocaleProvider>,
+      );
+    });
+
+    const dots = renderer!.root
+      .findAll((node) => node.type === "span" && String(node.props.className ?? "").startsWith("d-dot "))
+      .map((node) => String(node.props.title));
+    expect(dots).toEqual([
+      "working-live — working",
+      "waiting-live — waiting",
+      "offline-1 — offline",
+      "offline-2 — offline",
+    ]);
+  });
+});

--- a/web/src/components/ChannelList.tsx
+++ b/web/src/components/ChannelList.tsx
@@ -42,7 +42,7 @@ export function PresenceDots({ channel }: { channel: ChannelInfo }) {
   const t = useT();
   // 列表最多只能放四颗点：先把正在工作和其他在线成员提到离线记录前面，再截断。
   // sort 是稳定的，同一优先级内继续沿用服务端顺序，不让状态点在每次刷新时乱跳。
-  const entries = [...channel.presence]
+  const entries = [...(channel.presence ?? [])]
     .sort((a, b) => presenceDotPriority(a.state) - presenceDotPriority(b.state))
     .slice(0, MAX_DOTS);
   return (
@@ -56,7 +56,7 @@ export function PresenceDots({ channel }: { channel: ChannelInfo }) {
 }
 
 export function lastMessagePreview(c: ChannelInfo): string | null {
-  if (c.last_message === null) return null;
+  if (c.last_message == null) return null;
   const body = c.last_message.body.replace(/\s+/g, " ").trim();
   return `${c.last_message.sender}: ${body === "" ? `[${c.last_message.kind}]` : body}`;
 }

--- a/web/src/components/ChannelList.tsx
+++ b/web/src/components/ChannelList.tsx
@@ -1,11 +1,13 @@
 // 左侧频道列表：频道名 + 最近一条消息 + 参与者状态点（spec §9 第 1 块）
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { ChannelInfo } from "../lib/api";
 import { useT } from "../i18n/useT";
 import "../i18n/strings/Home"; // 复用 "已归档 (N)" key，两处折叠开关文案一致
 import "../i18n/strings/App";
 
 interface Props {
+  /** 服务器视图身份；切换实例时分类和归档展开状态必须从默认值重新开始。 */
+  scopeKey: string;
   channels: ChannelInfo[] | null;
   active: string | null;
   error: string | null;
@@ -29,10 +31,20 @@ const CATEGORY_EMPTY_KEY: Record<Exclude<ChannelCategory, "all">, string> = {
 
 const MAX_DOTS = 4;
 
+function presenceDotPriority(state: ChannelInfo["presence"][number]["state"]): number {
+  if (state === "working") return 0;
+  if (state === "offline") return 2;
+  return 1;
+}
+
 // 参与者状态点：每人一个蜡笔点，色 = presence 状态；没人报过 presence 给一颗灰点占位
 export function PresenceDots({ channel }: { channel: ChannelInfo }) {
   const t = useT();
-  const entries = channel.presence.slice(0, MAX_DOTS);
+  // 列表最多只能放四颗点：先把正在工作和其他在线成员提到离线记录前面，再截断。
+  // sort 是稳定的，同一优先级内继续沿用服务端顺序，不让状态点在每次刷新时乱跳。
+  const entries = [...channel.presence]
+    .sort((a, b) => presenceDotPriority(a.state) - presenceDotPriority(b.state))
+    .slice(0, MAX_DOTS);
   return (
     <span className="chan-dots">
       {entries.length === 0 && <span className="d-dot d-dot--offline" title={t("Home.noParticipants")} />}
@@ -83,9 +95,12 @@ function ChannelPill({
   );
 }
 
-export function ChannelList({ channels, active, error, onOpen, onRetry }: Props) {
+type ScopedProps = Omit<Props, "scopeKey">;
+
+function ScopedChannelList({ channels, active, error, onOpen, onRetry }: ScopedProps) {
   const [showArchived, setShowArchived] = useState(false);
   const [category, setCategory] = useState<ChannelCategory>("all");
+  const previousActiveRef = useRef<string | null | undefined>(undefined);
   const t = useT();
   // 默认只显示活跃频道；归档的（联调用完的 temp 等）折叠起来，避免刷屏
   const live = channels?.filter((c) => c.archived_at === null) ?? null;
@@ -98,6 +113,21 @@ export function ChannelList({ channels, active, error, onOpen, onRetry }: Props)
     created: createdCount,
     joined: joinedCount,
   };
+  useEffect(() => {
+    if (channels === null || previousActiveRef.current === active) return;
+    previousActiveRef.current = active;
+    if (active === null) return;
+    const activeChannel = channels.find((channel) => channel.slug === active);
+    if (activeChannel === undefined) return;
+    if (activeChannel.archived_at !== null) {
+      setShowArchived(true);
+      return;
+    }
+    const excluded =
+      (category === "created" && activeChannel.owned !== true) ||
+      (category === "joined" && activeChannel.member !== true);
+    if (excluded) setCategory("all");
+  }, [active, category, channels]);
   const filteredLive =
     live === null
       ? null
@@ -162,4 +192,8 @@ export function ChannelList({ channels, active, error, onOpen, onRetry }: Props)
       )}
     </nav>
   );
+}
+
+export function ChannelList({ scopeKey, ...props }: Props) {
+  return <ScopedChannelList key={scopeKey} {...props} />;
 }


### PR DESCRIPTION
## 结果

- 频道分类/归档展开状态按服务器隔离，切实例不会继承旧筛选
- 外部路由进入被当前分类排除的频道时自动回到全部；用户主动筛选仍保持
- 状态点先按 working、在线、offline 排序再截断，在线成员不再被离线历史遮住

## 验证

- ChannelList：4 pass
- Web typecheck 通过
- Web 全量基线：1028 pass
- git diff --check 通过

Stacked on #758; #758 合并后改回 main 基线。