### PR TITLE
fix(serve): 修复 Claude 常驻审批死锁与状态回退

### DIFF
--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -1965,7 +1965,15 @@ async function runHarness(
   // Claude accepts an official UUID session handle on cold start. Allocate it during preflight so
   // nested `party decision ask` can durably park the exact handle before this turn returns. Parsing
   // a session id from stdout is too late: the Worker may already have released an owner_answer.
-  const permissionArgs = opts.sandbox === "read-only" ? ["--permission-mode", "plan"] : [];
+  // `claude -p` has no human sitting at a TTY to approve tool calls. Leaving its default
+  // permission mode in a resident workspace-write lane turns every Read/Bash/Edit request into an
+  // unanswerable prompt: the process exits nonzero and the agent becomes an online-looking black
+  // hole. Read-only managed fronts stay in plan mode; an explicitly unattended execution lane must
+  // skip interactive permission prompts so it can actually do the work it was started to perform.
+  const permissionArgs = [
+    "--permission-mode",
+    opts.sandbox === "read-only" ? "plan" : "bypassPermissions",
+  ];
   const schemaArgs = opts.outputSchema === undefined ? [] : ["--json-schema", JSON.stringify(opts.outputSchema)];
   const jsonOutputArgs = opts.outputSchema === undefined ? [] : ["--output-format", "json"];
   // #581：--strict-mcp-config 只用注入的 server（隔离用户全局 MCP 配置）；
@@ -4676,8 +4684,8 @@ export async function runServe(o: ServeOptions): Promise<number> {
         // #646：busy 清除（#103）抽成闭包，送达与放弃两条终局都要调用——否则放弃分支永不清 busy，
         // 任务结束后 presence 永远卡在「忙」（假忙）。只在队列真排空时清：还有 @ 排队就保持 busy=true，
         // 等下一条 wake 的 working 帧继续覆盖 queue_depth（避免闪烁）。
-        const clearBusyIfDrained = async (idleNote: string) => {
-          if (!busyReported) return;
+        const takeBusyClearIfDrained = (force = false): { busy?: false; queue_depth?: 0 } => {
+          if (!busyReported) return {};
           const remaining = pendingWakeDepth(
             conn.pendingFrames(),
             self,
@@ -4685,16 +4693,20 @@ export async function runServe(o: ServeOptions): Promise<number> {
             conn.cursor,
             directedDeliveryMode,
           );
-          if (remaining !== 0) return;
+          if (!force && remaining !== 0) return {};
           busyReported = false;
+          return { busy: false, queue_depth: 0 };
+        };
+        const clearBusyIfDrained = async (idleNote: string) => {
+          const busyClear = takeBusyClearIfDrained();
+          if (busyClear.busy !== false) return;
           try {
             await (o.post ?? postMessage)(o.server, o.token, o.channel, {
               kind: "status",
               state: "waiting",
               note: idleNote,
               mentions: [],
-              busy: false,
-              queue_depth: 0,
+              ...busyClear,
             }, lifecycleController.signal);
           } catch (e) {
             // 清 busy 只是锦上添花：发不出去就下条 wake 的 working 帧会重置 queue_depth，或下次排空再补。
@@ -4731,6 +4743,10 @@ export async function runServe(o: ServeOptions): Promise<number> {
               note,
               mentions: [],
               blocked_reason: note,
+              // Failure is already the authoritative terminal status for this wake. Clear the
+              // busy bit on this same frame when the queue drained; a follow-up `waiting` frame
+              // would erase the blocker and make the broken resident look healthy again (#756).
+              ...takeBusyClearIfDrained(),
             }, lifecycleController.signal);
           } catch (e) {
             // 通告发不出去 = 没宣告过 = 没了结。此时清欠账 + ack 就是恢复 #118 的静默丢失。
@@ -4776,6 +4792,9 @@ export async function runServe(o: ServeOptions): Promise<number> {
                 note: finalNote,
                 mentions: [],
                 blocked_reason: finalNote,
+                // A circuit exits without consuming buffered mentions, so force-clear busy while
+                // preserving `blocked` as the final externally visible state.
+                ...takeBusyClearIfDrained(true),
               }, lifecycleController.signal);
             } catch (e) {
               out(`  熔断通告发送失败，立即退出: ${sanitizeBlockedError(e instanceof Error ? e.message : String(e))}`);
@@ -4784,9 +4803,6 @@ export async function runServe(o: ServeOptions): Promise<number> {
             wakeAbandonCircuitTripped = true;
             code = EXIT_WAKE_ABANDON_CIRCUIT;
           }
-          // #646：放弃这条 wake 后若队列已排空，同样把 busy 清回 false（否则假忙永久卡住，
-          // 只有下一次真正送达的 wake 或进程退出才自愈）。已宣告过 blocked，这里只收 busy。
-          await clearBusyIfDrained(`idle: ${self} gave up wake seq=${frame.seq}, waiting for next @`);
         }
       }
       const heldForLease = deferredLeaseSeq !== null && frame.seq >= deferredLeaseSeq;

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -4353,6 +4353,22 @@ export async function runServe(o: ServeOptions): Promise<number> {
           frame.seq,
           directedDeliveryMode,
         );
+        // #646：busy 清除（#103）由所有终局路径共用——包括在模型启动前失败的 preflight。
+        // 只在队列真排空时清：还有 @ 排队就保持 busy=true，等下一条 wake 的 working 帧继续覆盖
+        // queue_depth（避免闪烁）。
+        const takeBusyClearIfDrained = (force = false): { busy?: false; queue_depth?: 0 } => {
+          if (!busyReported) return {};
+          const remaining = pendingWakeDepth(
+            conn.pendingFrames(),
+            self,
+            o.mentionsOnly === true,
+            conn.cursor,
+            directedDeliveryMode,
+          );
+          if (!force && remaining !== 0) return {};
+          busyReported = false;
+          return { busy: false, queue_depth: 0 };
+        };
         // 先把入站附件放进本 serve 实例的 0700 临时目录。runner 只拿 0600 本地文件与
         // 鉴权端点元数据，context 中绝不出现 bearer token；单个下载失败也不吞掉整次唤醒。
         let wakeAttachments: WakeContextAttachment[] = [];
@@ -4452,6 +4468,9 @@ export async function runServe(o: ServeOptions): Promise<number> {
                 note,
                 mentions: [],
                 blocked_reason: note,
+                // 上一条 wake 因身后仍有积压而延续 busy 时，本条 preflight 终局负责在排空后
+                // 原子清掉它；若仍有其它 wake，则继续保持 busy，避免中途闪成空闲。
+                ...takeBusyClearIfDrained(),
               }, lifecycleController.signal);
             } catch {
               code = EXIT_WAKE_UNANNOUNCED;
@@ -4681,22 +4700,6 @@ export async function runServe(o: ServeOptions): Promise<number> {
             stopAfterFrame = true;
           }
         }
-        // #646：busy 清除（#103）抽成闭包，送达与放弃两条终局都要调用——否则放弃分支永不清 busy，
-        // 任务结束后 presence 永远卡在「忙」（假忙）。只在队列真排空时清：还有 @ 排队就保持 busy=true，
-        // 等下一条 wake 的 working 帧继续覆盖 queue_depth（避免闪烁）。
-        const takeBusyClearIfDrained = (force = false): { busy?: false; queue_depth?: 0 } => {
-          if (!busyReported) return {};
-          const remaining = pendingWakeDepth(
-            conn.pendingFrames(),
-            self,
-            o.mentionsOnly === true,
-            conn.cursor,
-            directedDeliveryMode,
-          );
-          if (!force && remaining !== 0) return {};
-          busyReported = false;
-          return { busy: false, queue_depth: 0 };
-        };
         const clearBusyIfDrained = async (idleNote: string) => {
           const busyClear = takeBusyClearIfDrained();
           if (busyClear.busy !== false) return;

--- a/cli/test/serve-continuation.test.ts
+++ b/cli/test/serve-continuation.test.ts
@@ -335,13 +335,16 @@ describe("builtin per-work continuations (#548)", () => {
     for (const { args } of calls) {
       expect(args).toContain("--disallowed-tools");
       expect(args[args.indexOf("--disallowed-tools") + 1]).toBe("AskUserQuestion");
+      expect(args[args.indexOf("--permission-mode") + 1]).toBe("bypassPermissions");
     }
     expect(calls[0]!.args).toEqual([
-      "claude", "-p", "--disallowed-tools", "AskUserQuestion", "--settings", expect.any(String),
+      "claude", "-p", "--disallowed-tools", "AskUserQuestion",
+      "--permission-mode", "bypassPermissions", "--settings", expect.any(String),
       "--session-id", coldSessionId, "--output-format", "json", expect.any(String),
     ]);
     expect(calls[1]!.args).toEqual([
-      "claude", "-p", "--disallowed-tools", "AskUserQuestion", "--settings", expect.any(String),
+      "claude", "-p", "--disallowed-tools", "AskUserQuestion",
+      "--permission-mode", "bypassPermissions", "--settings", expect.any(String),
       "--resume", coldSessionId, expect.any(String),
     ]);
     expect(calls[1]!.env.AP_RUNNER_SESSION_ID).toBe(coldSessionId);

--- a/cli/test/serve-continuation.test.ts
+++ b/cli/test/serve-continuation.test.ts
@@ -349,6 +349,48 @@ describe("builtin per-work continuations (#548)", () => {
     ]);
     expect(calls[1]!.env.AP_RUNNER_SESSION_ID).toBe(coldSessionId);
   });
+
+  test("Claude read-only cold start and owner-answer resume both use plan permission mode", async () => {
+    const workdir = tempDir();
+    const ref = "ref-C-read-only";
+    const workId = "work-C-read-only";
+    const calls: string[][] = [];
+    let coldSessionId = "";
+    const runProcess: RunnerProcess = async (args) => {
+      calls.push(args);
+      if (args.includes("--resume")) {
+        return { code: 0, stdout: "resumed", stderr: "" };
+      }
+      coldSessionId = args[args.indexOf("--session-id") + 1]!;
+      return { code: 0, stdout: JSON.stringify({ result: "cold" }), stderr: "" };
+    };
+    const run = createBuiltinRunner({
+      server: "http://agentparty.test",
+      token: "ap_test",
+      channel: "dev",
+      harness: "claude",
+      workdir,
+      sandbox: "read-only",
+      runProcess,
+      post,
+    });
+
+    await run(message(22), context(delivery(22, workId, ref)));
+    await run(message(23), context(delivery(23, workId, ref, "owner_answer")));
+
+    expect(calls).toHaveLength(2);
+    expect(calls.map((args) => args[args.indexOf("--permission-mode") + 1])).toEqual(["plan", "plan"]);
+    expect(calls[0]).toEqual([
+      "claude", "-p", "--disallowed-tools", "AskUserQuestion",
+      "--permission-mode", "plan", "--settings", expect.any(String),
+      "--session-id", coldSessionId, "--output-format", "json", expect.any(String),
+    ]);
+    expect(calls[1]).toEqual([
+      "claude", "-p", "--disallowed-tools", "AskUserQuestion",
+      "--permission-mode", "plan", "--settings", expect.any(String),
+      "--resume", coldSessionId, expect.any(String),
+    ]);
+  });
 });
 
 describe("codex-sdk per-work continuations (#548)", () => {

--- a/cli/test/serve.test.ts
+++ b/cli/test/serve.test.ts
@@ -282,6 +282,47 @@ describe("runServe", () => {
     expect(posts.indexOf(working!)).toBeLessThan(posts.indexOf(idle!));
   });
 
+  test("builtin failure clears busy on blocked without falling back to waiting (#756)", async () => {
+    const s = closeAfterOneMention();
+    const { posts, post } = postRecorder();
+    const workdir = tempDir();
+    const o = opts({
+      server: s.url,
+      post,
+      builtinRunner: {
+        server: s.url,
+        token: "ap_tok",
+        channel: "dev",
+        harness: "claude",
+        workdir,
+        runProcess: async () => ({
+          code: 1,
+          stdout: "",
+          stderr: "tool use requires approval, but no interactive approver is available",
+        }),
+        post,
+      },
+    });
+
+    expect(await runServe(o)).toBe(EXIT_ARCHIVED);
+
+    const blockedIdx = posts.findIndex((entry) =>
+      (entry.body as { state?: string; note?: string }).state === "blocked" &&
+      (entry.body as { note?: string }).note?.includes("wake undelivered")
+    );
+    expect(blockedIdx).toBeGreaterThanOrEqual(0);
+    expect(posts[blockedIdx]!.body).toMatchObject({
+      kind: "status",
+      state: "blocked",
+      busy: false,
+      queue_depth: 0,
+      blocked_reason: expect.stringContaining("builtin claude runner blocked"),
+    });
+    expect(posts.slice(blockedIdx + 1).some((entry) =>
+      (entry.body as { state?: string }).state === "waiting"
+    )).toBe(false);
+  });
+
   // 每任务进度/心跳（#228，扩 #103 busy）：run() 阻塞串行循环数分钟时，靠 setInterval 侧信道
   // 周期性发 presence-only 的 heartbeat 帧（不落 history），频道/本机都能看到「正在处理 seq=X、活到 T」。
   test("task heartbeat: while a wake runs, serve emits advancing heartbeats with current_task, then clears on completion", async () => {
@@ -1674,8 +1715,12 @@ describe("builtin runner", () => {
     expect(JSON.parse(readFileSync(join(workdir, "wake-session.json"), "utf8")).session_id).toBe(coldSessionId);
     expect(calls[0]).toContain("--output-format");
     expect(calls[0]).toContain("--session-id");
+    expect(calls.every((args) =>
+      args[args.indexOf("--permission-mode") + 1] === "bypassPermissions"
+    )).toBe(true);
     expect(calls[1]).toEqual([
-      "claude", "-p", "--disallowed-tools", "AskUserQuestion", "--settings", expect.any(String),
+      "claude", "-p", "--disallowed-tools", "AskUserQuestion",
+      "--permission-mode", "bypassPermissions", "--settings", expect.any(String),
       "--resume", coldSessionId, expect.any(String),
     ]);
   });

--- a/cli/test/serve.test.ts
+++ b/cli/test/serve.test.ts
@@ -323,6 +323,76 @@ describe("runServe", () => {
     )).toBe(false);
   });
 
+  test("preflight failure clears carried busy once the queued wake drains (#756)", async () => {
+    server = startMockServer((frame, sock) => {
+      if (frame.type !== "hello") return;
+      sock.send(welcomeFrame(0, "me"));
+      setTimeout(() => sock.send(msgFrame(1, "first", { mentions: ["me"] })), 10);
+      // 首条模型运行期间再入队第二条：首条收尾必须延续 busy，而不是先发 waiting。
+      setTimeout(() => sock.send(msgFrame(2, "second", { mentions: ["me"] })), 25);
+      setTimeout(() => sock.send({ type: "error", code: "archived", message: "done" }), 150);
+    });
+    const { posts, post } = postRecorder();
+    const workdir = tempDir();
+    let gitCalls = 0;
+    let modelCalls = 0;
+    const o = opts({
+      server: server.url,
+      post,
+      builtinRunner: {
+        server: server.url,
+        token: "ap_tok",
+        channel: "dev",
+        harness: "codex",
+        workdir,
+        repo: "https://example.test/repo.git",
+        runGit: async () => {
+          gitCalls += 1;
+          if (gitCalls === 2) throw new WakeBlockedError("repo preflight exploded", false);
+          mkdirSync(join(workdir, "repo"), { recursive: true });
+          return { code: 0, stdout: "", stderr: "" };
+        },
+        runProcess: async (args) => {
+          modelCalls += 1;
+          await Bun.sleep(40);
+          const out = args[args.indexOf("-o") + 1]!;
+          writeFileSync(out, "answer\n");
+          return { code: 0, stdout: `session id: ${uuid(2)}\n`, stderr: "" };
+        },
+        post,
+      },
+    });
+
+    expect(await runServe(o)).toBe(EXIT_ARCHIVED);
+    expect(gitCalls).toBe(2);
+    expect(modelCalls).toBe(1);
+
+    const working = posts.find((entry) =>
+      (entry.body as { state?: string; busy?: boolean }).state === "working" &&
+      (entry.body as { busy?: boolean }).busy === true
+    );
+    expect(working?.body).toMatchObject({ busy: true });
+
+    const blockedIdx = posts.findIndex((entry) =>
+      (entry.body as { state?: string; note?: string }).state === "blocked" &&
+      (entry.body as { note?: string }).note?.includes("before model start")
+    );
+    expect(blockedIdx).toBeGreaterThanOrEqual(0);
+    expect(posts.slice(0, blockedIdx).some((entry) =>
+      (entry.body as { state?: string }).state === "waiting"
+    )).toBe(false);
+    expect(posts[blockedIdx]!.body).toMatchObject({
+      kind: "status",
+      state: "blocked",
+      busy: false,
+      queue_depth: 0,
+      blocked_reason: expect.stringContaining("repo preflight exploded"),
+    });
+    expect(posts.slice(blockedIdx + 1).some((entry) =>
+      (entry.body as { state?: string }).state === "waiting"
+    )).toBe(false);
+  });
+
   // 每任务进度/心跳（#228，扩 #103 busy）：run() 阻塞串行循环数分钟时，靠 setInterval 侧信道
   // 周期性发 presence-only 的 heartbeat 帧（不落 history），频道/本机都能看到「正在处理 seq=X、活到 T」。
   test("task heartbeat: while a wake runs, serve emits advancing heartbeats with current_task, then clears on completion", async () => {


### PR DESCRIPTION
## 改动说明

- writable/unattended Claude runner 冷启动与 resume 统一使用 `--permission-mode bypassPermissions`，避免 headless 工具审批无人响应
- runner 失败时在最终 `blocked` 帧原子清除 busy，不再随后用 `waiting` 覆盖故障
- 熔断退出即使仍有缓冲消息也强制清 busy，并保持最终状态为 `blocked`
- 补齐普通唤醒、continuation 与失败收尾回归测试

> 安全边界：`bypassPermissions` 仅用于明确的无人值守 workspace-write lane；read-only front 仍保持 `plan`。

Closes #756

## 验证

- CLI 全量：1118 pass / 0 fail
- 针对性测试：134 pass / 0 fail
- CLI TypeScript：通过
- `git diff --check`：通过
- Claude Code 2.1.218 本机参数兼容性：通过

## 合并前检查

- [x] 已核对无人值守权限边界
- [x] 已验证 blocked 不再被 waiting 覆盖
- [x] 未运行真实付费模型唤醒（待发布后测试频道冒烟）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能改进**
  - 优化无人值守执行场景下的内置运行器权限处理，提升持续运行时的稳定性。
  - 改进任务队列状态管理，确保任务终止或被阻止时及时反映空闲状态与队列数量。

- **问题修复**
  - 修复部分异常终止场景下状态显示不一致的问题，避免错误清除或状态闪烁。
  - 修复任务被阻止后仍错误进入等待状态的问题。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->