### PR TITLE
fix(watch): 修复孤儿监听与按序销账

### DIFF
--- a/cli/src/commands/ack.ts
+++ b/cli/src/commands/ack.ts
@@ -28,10 +28,13 @@ here: serve replays it durably and clearing it by hand would silently drop an @.
 
 Options:
   --channel C   channel to ack in (defaults to the bound channel)
-  --seq N       only ack if the pending debt is exactly seq N (guard against races)
+  --seq N       acknowledge through exactly N; a newer pending wake is preserved
   --all         drain: advance cursor to channel head + clear all pending watch debt
   --through N   drain everything up to and including seq N (advance cursor to N)
-  --before N    drain everything strictly before seq N (advance cursor to N-1)`;
+  --before N    drain everything strictly before seq N (advance cursor to N-1)
+
+A successful later \`party send\` or status update acknowledges an earlier watch wake.
+Use \`party ack --seq N\` when no channel message is warranted.`;
 
 export async function run(argv: string[]): Promise<number> {
   if (isHelpArg(argv, { allowHelpPositional: true })) {
@@ -136,8 +139,17 @@ export async function run(argv: string[]): Promise<number> {
       );
       return 1;
     case "seq_mismatch":
-      console.error(`refusing to ack: pending watch debt is seq=${acked.seq}, not seq=${seqFlag}`);
+      console.error(
+        `refusing to ack seq=${seqFlag}: older pending watch debt seq=${acked.seq} must be handled first` +
+          " (or explicitly drain with --through)",
+      );
       return 1;
+    case "acknowledged_prior":
+      console.log(
+        `acked watch wake through seq=${acked.seq} in #${channel}; ` +
+          `newer pending wake seq=${acked.pendingSeq} was preserved`,
+      );
+      return 0;
     case "cleared":
       console.log(`acked watch wake seq=${acked.seq} in #${channel}`);
       return 0;

--- a/cli/src/commands/mcp.ts
+++ b/cli/src/commands/mcp.ts
@@ -1097,7 +1097,9 @@ export function createMcpServer(defaultChannel?: string): McpServer {
         "Clear the pending watch wake debt without posting a message (#594). Use after party_watch_once delivered a frame that warrants no reply — replying with empty acks burns the loop guard; leaving the debt makes every later watch replay the same frame. Serve-owned debt is never touched.",
       inputSchema: {
         channel: z.string().optional().describe("Channel slug. Defaults to the workspace-bound channel."),
-        seq: z.number().int().positive().optional().describe("Only ack if the pending debt is exactly this seq."),
+        seq: z.number().int().positive().optional().describe(
+          "Acknowledge through this exact seq; a newer pending watch wake is preserved and reported.",
+        ),
       },
     },
     async ({ channel, seq }) => {
@@ -1113,7 +1115,20 @@ export function createMcpServer(defaultChannel?: string): McpServer {
           );
         }
         if (acked.outcome === "seq_mismatch") {
-          return fail(`refusing to ack: pending watch debt is seq=${acked.seq}, not seq=${seq}`);
+          return fail(
+            `refusing to ack seq=${seq}: older pending watch debt seq=${acked.seq} must be handled first` +
+              " (or explicitly drained with party ack --through)",
+          );
+        }
+        if (acked.outcome === "acknowledged_prior") {
+          return ok({
+            type: "ack",
+            channel: resolved,
+            acked: true,
+            seq: acked.seq,
+            pending_preserved: true,
+            pending_seq: acked.pendingSeq,
+          });
         }
         return ok({ type: "ack", channel: resolved, acked: true, seq: acked.seq });
       } catch (e) {

--- a/cli/src/commands/watch.ts
+++ b/cli/src/commands/watch.ts
@@ -8,7 +8,14 @@ import {
   type DirectedDelivery,
   type MsgFrame,
 } from "@agentparty/shared";
-import { acquireInstanceLock, defaultInstanceLockDir, instanceLockTarget, stopOwnInstance } from "../instance-lock";
+import {
+  acquireInstanceLock,
+  captureParentProcessOwner,
+  defaultInstanceLockDir,
+  instanceLockTarget,
+  stopOwnInstance,
+  type ProcessOwner,
+} from "../instance-lock";
 import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
 import { connect } from "../client";
 import {
@@ -160,6 +167,7 @@ export function isCodexRuntimeEnv(env: Record<string, string | undefined> = proc
 }
 
 export const EXIT_ALREADY_WATCHING = 10;
+const WATCH_PARENT_CHECK_MS = 1_000;
 
 export interface WatchOptions {
   server: string;
@@ -198,6 +206,10 @@ export interface WatchOptions {
   advertiseWakeKind?: "watch";
   /** #669：同身份 watcher 已挂时，幂等退出 0（no-op）而非 exit 10 报错，供 harness 每轮例行重挂。 */
   ensure?: boolean;
+  /** `watch --once` 启动者身份；生产自动捕获，测试可注入。 */
+  parentOwner?: ProcessOwner;
+  /** 启动者存活检查周期；生产 1s，测试可缩短。 */
+  parentCheckMs?: number;
 }
 
 async function confirmWatchDeliveryRunning(
@@ -351,9 +363,21 @@ export async function runWatch(o: WatchOptions): Promise<number> {
   // 先抢锁，再连服务端：第二个 watcher 连 WS 都不该建，否则它已经开始消费 @ 了（#195）
   const lockDir = o.lockDir ?? defaultInstanceLockDir();
   const lockTarget = o.lockDir === undefined ? instanceLockTarget(o.server, o.token, o.channel) : o.channel;
+  const parentOwner = o.once === true ? (o.parentOwner ?? captureParentProcessOwner()) : null;
+  const orphanExit = () => {
+    console.error("watch exited: parent process is gone; released orphaned --once listener");
+    return 1;
+  };
   // #741:进程标题带上 lockTarget(<hash>-<channel>),让 ps/pkill -f 能区分同机多 agent 的 watch。best-effort。
   try { process.title = `party watch ${lockTarget}`; } catch { /* 某些运行时 title 只读 */ }
-  const lock = o.allowMultiple === true ? null : acquireInstanceLock("watch", lockTarget, lockDir);
+  // 启动者在命令真正 attach 前已经退出时，连 WS 都不能建：否则第一个 1s guard tick 前仍可能
+  // claim delivery / 推进游标，而它的输出已经无人承接。
+  if (parentOwner !== null && !parentOwner.alive()) return orphanExit();
+  const lock = o.allowMultiple === true
+    ? null
+    : acquireInstanceLock("watch", lockTarget, lockDir, {
+        ...(parentOwner === null ? {} : { parentOwner }),
+      });
   if (lock && !lock.ok) {
     // #669：--ensure 让 harness 的每轮例行重挂在「同身份已挂」时幂等收场（exit 0, no-op），
     // 不再以 exit 10 报错刷「background task failed」假失败。不带 --ensure 仍保留 exit 10 硬拒。
@@ -367,6 +391,11 @@ export async function runWatch(o: WatchOptions): Promise<number> {
         ` 要么等它退出，要么用 \`party watch ${o.channel} --stop\`（只停本身份这台，别用 pkill -f 会误杀同机别人的）；确实想并存请加 --allow-multiple 或 --ensure 幂等重挂。`,
     );
     return EXIT_ALREADY_WATCHING;
+  }
+  // 父进程可能在抢锁期间退出；成功持锁后再核一次，失败必须先释放再返回。
+  if (parentOwner !== null && !parentOwner.alive()) {
+    lock?.release?.();
+    return orphanExit();
   }
   // #703：升级提示放在抢到实例锁之后——只有持锁的那个 watcher 会探测，靠既有实例锁串行化，
   // 天然消除「两个进程都过节流读取、各自探测」的竞态（#715 评审），无需另造原子租约。
@@ -392,6 +421,12 @@ export async function runWatch(o: WatchOptions): Promise<number> {
     lock?.release?.();
     throw error;
   }
+  // connect 构造与上面的核验之间仍有极窄竞态；进入帧循环前最后同步挡住。
+  if (parentOwner !== null && !parentOwner.alive()) {
+    conn.close();
+    lock?.release?.();
+    return orphanExit();
+  }
 
   let self = "";
   let lastSeq = 0;
@@ -409,6 +444,7 @@ export async function runWatch(o: WatchOptions): Promise<number> {
   let selfPaused = false;
   // 挂上即声明「有 watch 唤醒层」（best-effort，只做一次；重连再收 welcome 不重复刷）——见 advertiseWatchWake。
   let advertised = false;
+  let orphaned = false;
   let timer: ReturnType<typeof setTimeout> | null = null;
   if (o.timeoutSec > 0) {
     timer = setTimeout(() => {
@@ -428,6 +464,18 @@ export async function runWatch(o: WatchOptions): Promise<number> {
       });
     }, 60_000);
     if (typeof heartbeat.unref === "function") heartbeat.unref();
+  }
+  // #755：`watch --once &` 的启动 shell / harness 退出后，watch 进程可能继续存活，却已没有任何
+  // 上游会读取它的输出并开启新 turn。它既唤不醒人，又占着唯一锁。绑定父进程后主动收口；锁文件
+  // 中同一份 parent identity 也让下一次重挂能立即把它判为 stale 并接管。
+  let parentGuard: ReturnType<typeof setInterval> | null = null;
+  if (parentOwner !== null) {
+    parentGuard = setInterval(() => {
+      if (parentOwner.alive()) return;
+      orphaned = true;
+      conn.close();
+    }, o.parentCheckMs ?? WATCH_PARENT_CHECK_MS);
+    if (typeof parentGuard.unref === "function") parentGuard.unref();
   }
 
   try {
@@ -540,7 +588,7 @@ export async function runWatch(o: WatchOptions): Promise<number> {
             frame.delivery,
             self,
             o.deliveryAckTimeoutMs ?? WATCH_DELIVERY_ACK_TIMEOUT_MS,
-            () => timedOut || connectionGeneration !== claimConnectionGeneration,
+            () => orphaned || timedOut || connectionGeneration !== claimConnectionGeneration,
           );
         } catch (error) {
           console.error(terminalOutput(
@@ -744,10 +792,14 @@ export async function runWatch(o: WatchOptions): Promise<number> {
     lock?.release?.();
     if (timer) clearTimeout(timer);
     if (heartbeat) clearInterval(heartbeat);
+    if (parentGuard) clearInterval(parentGuard);
     conn.close();
     if (o.statusline === true) clearStatuslineListener();
   }
 
+  if (orphaned) {
+    return orphanExit();
+  }
   // 超时判定：--once 只有 onceDone 才算被唤醒（打印过重放的修订快照不算）；
   // 非 follow/once 沿用「打印过即成功」；follow 超时一律 TIMEOUT
   const unfulfilled = o.once === true ? !onceDone : printed === 0;
@@ -937,7 +989,9 @@ export async function run(argv: string[]): Promise<number> {
     const replayLockDir = defaultInstanceLockDir();
     const replayLockTarget = instanceLockTarget(cfg.server, cfg.token, channel);
     const replayLock =
-      flags["allow-multiple"] === true ? null : acquireInstanceLock("watch", replayLockTarget, replayLockDir);
+      flags["allow-multiple"] === true
+        ? null
+        : acquireInstanceLock("watch", replayLockTarget, replayLockDir);
     if (replayLock && !replayLock.ok) {
       // #669：--ensure 幂等——同身份 watcher 已挂时，重挂不重放（欠账留给活着的那个 watcher），退出 0 no-op。
       if (ensure) {

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -661,7 +661,8 @@ export function markWatchDirectedStuckAccepted(channel: string, deliveryId: stri
  * 只清 watch 源；serve 债与 seq 不匹配都原样保留并回报原因。
  */
 export type AckWatchStuckOutcome =
-  | { outcome: "cleared"; seq: number }
+  | { outcome: "cleared"; seq: number; cursor: number }
+  | { outcome: "acknowledged_prior"; seq: number; pendingSeq: number; cursor: number }
   | { outcome: "none" }
   | { outcome: "serve_owned"; seq: number; source: string }
   | { outcome: "seq_mismatch"; seq: number };
@@ -679,13 +680,21 @@ export function ackWatchStuck(channel: string, expectedSeq?: number, cwd?: strin
       result = { outcome: "serve_owned", seq: stuck.seq, source: stuck.source ?? "unknown" };
       return null;
     }
-    if (expectedSeq !== undefined && stuck.seq !== expectedSeq) {
+    if (expectedSeq !== undefined && expectedSeq < stuck.seq) {
+      // #755：调用方正在确认一条已经处理完的较早 wake，而它处理期间新的 wake 已把单值 debt
+      // 指针推进到更高 seq。确认到 expectedSeq 即可；更晚的 debt 必须原样保留，不能谎称已处理。
+      const cursor = Math.max(cur.cursor, expectedSeq);
+      result = { outcome: "acknowledged_prior", seq: expectedSeq, pendingSeq: stuck.seq, cursor };
+      return cursor === cur.cursor ? null : { ...cur, cursor };
+    }
+    if (expectedSeq !== undefined && expectedSeq > stuck.seq) {
       result = { outcome: "seq_mismatch", seq: stuck.seq };
       return null;
     }
-    result = { outcome: "cleared", seq: stuck.seq };
+    const cursor = Math.max(cur.cursor, stuck.seq);
+    result = { outcome: "cleared", seq: stuck.seq, cursor };
     const { stuck: _dropped, ...rest } = cur;
-    return rest;
+    return { ...rest, cursor };
   }, cwd);
   return result;
 }

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -174,12 +174,44 @@ export async function main(argv: string[]): Promise<number> {
   }
 }
 
+const EXIT_FLUSH_TIMEOUT_MS = 500;
+
+async function flushBeforeExit(stream: NodeJS.WriteStream): Promise<void> {
+  if (stream.destroyed || !stream.writable) return;
+  await new Promise<void>((resolve) => {
+    let settled = false;
+    const done = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      resolve();
+    };
+    const timeout = setTimeout(done, EXIT_FLUSH_TIMEOUT_MS);
+    timeout.unref();
+    try {
+      // Writable callbacks are ordered after earlier console writes on the same stream. Waiting for
+      // this empty write prevents process.exit() from truncating the only diagnostic (#755).
+      stream.write("", done);
+    } catch {
+      done();
+    }
+  });
+}
+
+async function exitAfterFlush(code: number): Promise<never> {
+  // Set this first: if a broken/destroyed stream lets the event loop empty before callbacks fire,
+  // natural exit still carries the command's real code.
+  process.exitCode = code;
+  await Promise.all([flushBeforeExit(process.stdout), flushBeforeExit(process.stderr)]);
+  process.exit(code);
+}
+
 if (import.meta.main) {
   main(process.argv.slice(2)).then(
-    (code) => process.exit(code),
+    (code) => void exitAfterFlush(code),
     (e) => {
       console.error(`error: ${e instanceof Error ? e.message : String(e)}`);
-      process.exit(1);
+      void exitAfterFlush(1);
     },
   );
 }

--- a/cli/src/instance-lock.ts
+++ b/cli/src/instance-lock.ts
@@ -26,6 +26,21 @@ export interface InstanceLock {
   release?: () => void;
 }
 
+export interface ProcessOwner {
+  pid: number;
+  startedAt?: number;
+  alive: () => boolean;
+}
+
+export interface InstanceLockOptions {
+  /**
+   * 把锁的有效期绑定到启动者。只用于 `watch --once`：父进程退出后，即使 watcher
+   * 本身还活着，也已无法唤醒原 harness。调用方还必须用同一 owner 主动关闭旧连接。
+   */
+  parentOwner?: ProcessOwner;
+}
+
+const PARENT_BOUND_RELEASE_WAIT_MS = 2_500;
 function lockPath(kind: InstanceKind, channel: string, dir: string): string {
   return join(dir, `${kind}-${channel.replace(/[^a-zA-Z0-9._-]/g, "_")}.lock`);
 }
@@ -73,16 +88,40 @@ function inspectProcess(pid: number): ProcessIdentity {
 const PROCESS_STARTED_AT =
   inspectProcess(process.pid).startedAt ?? Math.floor((Date.now() - process.uptime() * 1000) / 1000) * 1000;
 
+function sameLiveProcess(pid: number, startedAt?: number): boolean {
+  if (!Number.isFinite(pid) || pid <= 0) return false;
+  const processIdentity = inspectProcess(pid);
+  if (!processIdentity.alive) return false;
+  if (startedAt === undefined || processIdentity.startedAt === undefined) return true;
+  return Math.abs(startedAt - processIdentity.startedAt) <= 2000;
+}
+
 function holderAlive(holder: LockHolder | null): holder is LockHolder & { pid: number } {
   if (typeof holder?.pid !== "number") return false;
-  const processIdentity = inspectProcess(holder.pid);
-  if (!processIdentity.alive) return false;
-  if (holder.started_at === undefined || processIdentity.startedAt === undefined) return true;
-  return Math.abs(holder.started_at - processIdentity.startedAt) <= 2000;
+  if (!sameLiveProcess(holder.pid, holder.started_at)) return false;
+  if (holder.parent_bound !== true) return true;
+  // pid=1 表示创建时已经是孤儿；它没有能承接一次性 wake 输出的上游，不能占住唯一 watcher 槽位。
+  if (typeof holder.parent_pid !== "number" || holder.parent_pid <= 1) return false;
+  return sameLiveProcess(holder.parent_pid, holder.parent_started_at);
+}
+
+function holderProcessAlive(holder: LockHolder | null): holder is LockHolder & { pid: number } {
+  return typeof holder?.pid === "number" && sameLiveProcess(holder.pid, holder.started_at);
 }
 
 export function currentProcessStartedAt(): number {
   return PROCESS_STARTED_AT;
+}
+
+/** 捕获启动本进程的父进程身份，PID 复用时用出生时间区分。 */
+export function captureParentProcessOwner(): ProcessOwner {
+  const pid = process.ppid;
+  const startedAt = inspectProcess(pid).startedAt;
+  return {
+    pid,
+    ...(startedAt === undefined ? {} : { startedAt }),
+    alive: () => pid > 1 && sameLiveProcess(pid, startedAt),
+  };
 }
 
 /**
@@ -144,6 +183,9 @@ interface LockHolder {
   pid?: number;
   id?: string;
   started_at?: number;
+  parent_bound?: boolean;
+  parent_pid?: number;
+  parent_started_at?: number;
 }
 
 function readHolder(path: string): LockHolder | null {
@@ -158,11 +200,31 @@ function isAlreadyExists(error: unknown): boolean {
   return error instanceof Error && "code" in error && error.code === "EEXIST";
 }
 
-export function acquireInstanceLock(kind: InstanceKind, channel: string, dir: string): InstanceLock {
+export function acquireInstanceLock(
+  kind: InstanceKind,
+  channel: string,
+  dir: string,
+  options: InstanceLockOptions = {},
+): InstanceLock {
   const path = lockPath(kind, channel, dir);
   const reclaimPath = `${path}.reclaim`;
   const lockId = randomUUID();
-  const body = JSON.stringify({ pid: process.pid, id: lockId, started_at: PROCESS_STARTED_AT, kind, channel, ts: Date.now() });
+  const parentIdentity = options.parentOwner ?? null;
+  const body = JSON.stringify({
+    pid: process.pid,
+    id: lockId,
+    started_at: PROCESS_STARTED_AT,
+    ...(parentIdentity === null
+      ? {}
+      : {
+          parent_bound: true,
+          parent_pid: parentIdentity.pid,
+          ...(parentIdentity.startedAt === undefined ? {} : { parent_started_at: parentIdentity.startedAt }),
+        }),
+    kind,
+    channel,
+    ts: Date.now(),
+  });
   let staleGeneration: string | null = null;
   mkdirSync(dir, { recursive: true });
 
@@ -177,6 +239,27 @@ export function acquireInstanceLock(kind: InstanceKind, channel: string, dir: st
     const held = readHolder(path);
     if (holderAlive(held)) {
       return { ok: false, heldByPid: held.pid };
+    }
+    if (holderProcessAlive(held)) {
+      // parent-bound holder 的进程还活着，只是启动者已死。旧 watcher 有 parent guard，会
+      // 主动 close + release；新实例在此等待它退场，绝不能先删锁建第二条 WS 形成双重 claim。
+      const observedGeneration = held.id ?? `legacy:${held.pid}`;
+      const deadline = Date.now() + PARENT_BOUND_RELEASE_WAIT_MS;
+      let current: LockHolder | null = held;
+      while (Date.now() < deadline) {
+        sleepSyncMs(10);
+        current = readHolder(path);
+        const generation = current?.id ?? `legacy:${current?.pid ?? "invalid"}`;
+        if (generation !== observedGeneration || !holderProcessAlive(current)) break;
+      }
+      const currentGeneration = current?.id ?? `legacy:${current?.pid ?? "invalid"}`;
+      if (currentGeneration !== observedGeneration) continue;
+      if (holderProcessAlive(current)) {
+        // guard 未能在有界时间内收口：保守拒绝，交给 `party watch --stop`，不冒险双挂。
+        return { ok: false, heldByPid: current.pid };
+      }
+      // 旧进程已经退场（锁文件可能还留着）；重新走一轮，按普通 stale generation 接管。
+      continue;
     }
     const generation = held?.id ?? `legacy:${held?.pid ?? "invalid"}`;
     // If the file changed since this contender observed the stale owner, another

--- a/cli/test/ack.test.ts
+++ b/cli/test/ack.test.ts
@@ -49,11 +49,32 @@ describe("party ack（#594）", () => {
     expect(await runAck(["--channel", "dev"])).toBe(0);
   });
 
-  test("--seq 不匹配拒绝清账", async () => {
+  test("--seq 高于当前 debt 时拒绝清账", async () => {
     expect(saveWatchStuck("dev", watchDebt(19))).toBe(true);
     expect(await runAck(["--channel", "dev", "--seq", "20"])).toBe(1);
     expect(loadStuck("dev")).not.toBeNull();
     expect(await runAck(["--channel", "dev", "--seq", "19"])).toBe(0);
+    expect(loadStuck("dev")).toBeNull();
+  });
+
+  test("--seq 可确认较早 wake，同时保留处理期间到达的较新 debt (#755)", async () => {
+    saveCursor("dev", 5);
+    expect(saveWatchStuck("dev", watchDebt(20))).toBe(true);
+
+    expect(await runAck(["--channel", "dev", "--seq", "19"])).toBe(0);
+    expect(loadCursor("dev")).toBe(19);
+    expect(loadStuck("dev")?.seq).toBe(20);
+
+    expect(await runAck(["--channel", "dev", "--seq", "20"])).toBe(0);
+    expect(loadCursor("dev")).toBe(20);
+    expect(loadStuck("dev")).toBeNull();
+  });
+
+  test("精确 ack 会原子推进落后游标，避免清 debt 后再次作为普通新消息重放", async () => {
+    saveCursor("dev", 5);
+    expect(saveWatchStuck("dev", watchDebt(19))).toBe(true);
+    expect(await runAck(["--channel", "dev", "--seq", "19"])).toBe(0);
+    expect(loadCursor("dev")).toBe(19);
     expect(loadStuck("dev")).toBeNull();
   });
 

--- a/cli/test/cli.test.ts
+++ b/cli/test/cli.test.ts
@@ -724,6 +724,16 @@ describe("cli subprocess", () => {
     expect(r.stderr).toContain("unknown command");
   });
 
+  test("non-zero CLI exits flush their diagnostic before process termination (#755)", async () => {
+    const attempts = await Promise.all(
+      Array.from({ length: 12 }, () => runCli(["watch", "--follow", "--once"])),
+    );
+    for (const result of attempts) {
+      expect(result.code).toBe(1);
+      expect(result.stderr).toContain("--follow and --once are mutually exclusive");
+    }
+  });
+
   test("watch without config exits 1", async () => {
     const r = await runCli(["watch", "dev", "--timeout", "1"]);
     expect(r.code).toBe(1);

--- a/cli/test/mcp-watch-directed-delivery.test.ts
+++ b/cli/test/mcp-watch-directed-delivery.test.ts
@@ -281,4 +281,34 @@ describe("MCP party_watch_once durable delivery (#551)", () => {
       await client.close();
     }
   }, 20_000);
+
+  test("party_ack confirms an older seq while reporting and preserving the newer debt (#755)", async () => {
+    writeRuntime("http://127.0.0.1:1", {
+      seq: 20,
+      attempts: 0,
+      source: "watch",
+      last_error: "newer wake pending",
+    });
+    const client = await connectClient();
+    try {
+      const earlier = await client.callTool({ name: "party_ack", arguments: { seq: 19 } });
+      expect(earlier.isError).not.toBe(true);
+      expect(earlier.structuredContent).toMatchObject({
+        type: "ack",
+        channel: "dev",
+        acked: true,
+        seq: 19,
+        pending_preserved: true,
+        pending_seq: 20,
+      });
+      expect(readDebt()?.seq).toBe(20);
+
+      const current = await client.callTool({ name: "party_ack", arguments: { seq: 20 } });
+      expect(current.isError).not.toBe(true);
+      expect(current.structuredContent).toMatchObject({ acked: true, seq: 20 });
+      expect(readDebt()).toBeUndefined();
+    } finally {
+      await client.close();
+    }
+  }, 20_000);
 });

--- a/cli/test/watch-directed-delivery.test.ts
+++ b/cli/test/watch-directed-delivery.test.ts
@@ -362,6 +362,43 @@ describe("watch durable directed-delivery adapter (#551)", () => {
     expect(o.lines).toEqual([]);
   });
 
+  test("parent death interrupts a running ACK wait before accepting the delivery (#755)", async () => {
+    const msg = message(81);
+    const work = delivery(81);
+    let parentAlive = true;
+    let accepted = false;
+    server = startMockServer((frame, sock) => {
+      if (frame.type === "hello") {
+        sock.send({ ...welcomeFrame(81, "me"), directed_delivery: "v1" });
+        return;
+      }
+      if (frame.type === "delivery_adapter") {
+        sock.send({ type: "delivery_adapter", adapter: "watch", registered: true });
+        sock.send({ type: "delivery", delivery: work, message: msg });
+        return;
+      }
+      if (frame.type === "delivery_update") parentAlive = false;
+    });
+
+    const startedAt = Date.now();
+    const o = opts({
+      server: server.url,
+      json: true,
+      onStuck: () => {},
+      onDirectedAccepted: () => {
+        accepted = true;
+        return true;
+      },
+      parentOwner: { pid: 123, alive: () => parentAlive },
+      parentCheckMs: 5,
+      deliveryAckTimeoutMs: 5_000,
+    });
+    expect(await runWatch(o)).toBe(1);
+    expect(Date.now() - startedAt).toBeLessThan(500);
+    expect(accepted).toBe(false);
+    expect(o.lines).toEqual([]);
+  });
+
   test("accepted-state persistence failure after running ACK is unknown outcome and produces no output", async () => {
     const msg = message(9);
     const work = delivery(9);

--- a/cli/test/watch-single-instance.test.ts
+++ b/cli/test/watch-single-instance.test.ts
@@ -9,7 +9,14 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "nod
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { EXIT_ALREADY_WATCHING, runWatch } from "../src/commands/watch";
-import { acquireInstanceLock, currentProcessStartedAt, defaultInstanceLockDir, instanceLockTarget } from "../src/instance-lock";
+import {
+  acquireInstanceLock,
+  captureParentProcessOwner,
+  currentProcessStartedAt,
+  defaultInstanceLockDir,
+  instanceLockTarget,
+  processStartedAt,
+} from "../src/instance-lock";
 import { startMockServer, welcomeFrame } from "./mock-server";
 
 const dirs: string[] = [];
@@ -77,6 +84,46 @@ describe("watch 单实例保护 (#195)", () => {
     const d = dir();
     writeFileSync(join(d, "watch-dev.lock"), JSON.stringify({ pid: process.pid, channel: "dev" }));
     const lock = acquireInstanceLock("watch", "dev", d);
+    expect(lock.ok).toBe(false);
+    expect(lock.heldByPid).toBe(process.pid);
+  });
+
+  test("parent-bound watcher 启动者已死但旧 pid 未退时拒绝重叠接管 (#755)", () => {
+    const d = dir();
+    const deadParent = 999_999;
+    expect(() => process.kill(deadParent, 0)).toThrow();
+    writeFileSync(
+      join(d, "watch-dev.lock"),
+      JSON.stringify({
+        pid: process.pid,
+        started_at: currentProcessStartedAt(),
+        parent_bound: true,
+        parent_pid: deadParent,
+        channel: "dev",
+      }),
+    );
+
+    const lock = acquireInstanceLock("watch", "dev", d, { parentOwner: captureParentProcessOwner() });
+    expect(lock.ok).toBe(false);
+    expect(lock.heldByPid).toBe(process.pid);
+  });
+
+  test("parent-bound watcher 的启动者仍是原进程时不会误接管", () => {
+    const d = dir();
+    const parentStartedAt = processStartedAt(process.ppid);
+    writeFileSync(
+      join(d, "watch-dev.lock"),
+      JSON.stringify({
+        pid: process.pid,
+        started_at: currentProcessStartedAt(),
+        parent_bound: true,
+        parent_pid: process.ppid,
+        ...(parentStartedAt === undefined ? {} : { parent_started_at: parentStartedAt }),
+        channel: "dev",
+      }),
+    );
+
+    const lock = acquireInstanceLock("watch", "dev", d, { parentOwner: captureParentProcessOwner() });
     expect(lock.ok).toBe(false);
     expect(lock.heldByPid).toBe(process.pid);
   });
@@ -283,6 +330,74 @@ describe("runWatch 接线 (#195)", () => {
         backoffBaseMs: 20,
       });
       expect(code).not.toBe(EXIT_ALREADY_WATCHING);
+    } finally {
+      server.stop();
+    }
+  });
+
+  test("--allow-multiple 只关闭互斥，不关闭 --once 的父进程孤儿守卫 (#755)", async () => {
+    const d = dir();
+    let connections = 0;
+    const server = startMockServer((f, sock) => {
+      if (f.type === "hello") {
+        connections++;
+        sock.send(welcomeFrame(0, "me"));
+      }
+    });
+    try {
+      const code = await runWatch({
+        server: server.url,
+        token: "ap_tok",
+        channel: "dev",
+        since: 0,
+        timeoutSec: 2,
+        follow: false,
+        mentionsOnly: true,
+        once: true,
+        lockDir: d,
+        allowMultiple: true,
+        parentOwner: { pid: 999_999, alive: () => false },
+        parentCheckMs: 5,
+        out: () => {},
+        backoffBaseMs: 20,
+      });
+      expect(code).toBe(1);
+      expect(connections).toBe(0);
+    } finally {
+      server.stop();
+    }
+  });
+
+  test("父进程孤儿守卫关闭默认 watcher 后释放锁，下一次重挂可接管 (#755)", async () => {
+    const d = dir();
+    let parentAlive = true;
+    const server = startMockServer((f, sock) => {
+      if (f.type === "hello") {
+        sock.send(welcomeFrame(0, "me"));
+        parentAlive = false;
+      }
+    });
+    try {
+      const code = await runWatch({
+        server: server.url,
+        token: "ap_tok",
+        channel: "dev",
+        since: 0,
+        timeoutSec: 2,
+        follow: false,
+        mentionsOnly: true,
+        once: true,
+        lockDir: d,
+        parentOwner: { pid: 999_999, alive: () => parentAlive },
+        parentCheckMs: 5,
+        out: () => {},
+        backoffBaseMs: 20,
+      });
+      expect(code).toBe(1);
+
+      const replacement = acquireInstanceLock("watch", "dev", d);
+      expect(replacement.ok).toBe(true);
+      replacement.release?.();
     } finally {
       server.stop();
     }


### PR DESCRIPTION
## 问题

修复 #755 中一次性 watcher 生命周期、手工销账与异常退出诊断的三组可靠性问题。

## 改动

- `party ack` 按目标 seq 销账：旧 wake 可单独确认，同时保留更新欠账；CLI 与 MCP 都返回清晰的 pending-preserved 结果
- `watch --once` 绑定父进程身份（PID + 启动时间），父进程消失时主动退出；默认实例锁等待旧孤儿释放，避免重叠连接和重复 claim
- 父进程死亡可中断 directed-delivery running ACK 等待，且 `--allow-multiple` 仍保留生命周期守卫
- 非零 CLI 退出先刷新 stdout/stderr，再结束进程，避免极短失败路径出现 exit 1 但诊断为空
- 补齐精确销账、孤儿回收、锁竞争、ACK 中断及并行 stderr 刷新回归测试

## 验证

- `bun test cli/test`：1126 pass / 0 fail
- #755 定向与实例锁回归：100 pass / 0 fail
- CLI TypeScript：通过
- `git diff --check`：通过

Closes #755