### PR TITLE
fix(web): 修复通知竞态与未决项分页边界

### DIFF
--- a/web/src/components/NotifyToggle.tsx
+++ b/web/src/components/NotifyToggle.tsx
@@ -1,7 +1,7 @@
 // 被@浏览器通知的铃铛开关（Task C2）。opt-in 是全局设置（跨频道生效），落 localStorage；
 // 真正的“要不要弹”判定在纯函数 shouldNotify（lib/notify.ts）里，本组件只管开关本身：
 // 读/写 opt-in、申请浏览器通知权限、把结果上报给持有 optin state 的应用 header。
-import { useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { useT } from "../i18n/useT";
 import { FeatureTip } from "./FeatureTip";
 import { isDesktopRuntime, requestDesktopNotificationPermission } from "../lib/desktopRuntime";
@@ -45,28 +45,37 @@ interface Props {
   onChange(next: boolean): void;
 }
 
-export function NotifyToggle({ optin, onChange }: Props) {
-  const t = useT();
+export function useNotifyOptinToggle(
+  optin: boolean,
+  onChange: (next: boolean) => void,
+  inAppOnlyHint: string,
+): { hint: string | null; toggle: () => void } {
   const [hint, setHint] = useState<string | null>(null);
   const requestRef = useRef(0);
 
-  const toggle = () => {
+  const toggle = useCallback(() => {
+    const next = !optin;
     const requestId = ++requestRef.current;
     setHint(null);
-    if (optin) {
-      // 关闭：立即生效
-      writeNotifyOptin(false);
-      onChange(false);
-      return;
+    writeNotifyOptin(next);
+    onChange(next);
+    if (next) {
+      void requestNotifySystemPermission().then((granted) => {
+        if (requestId === requestRef.current && !granted) setHint(inAppOnlyHint);
+      });
     }
-    // 开启：立即生效——页内 toast 不需要浏览器授权，铃铛先开起来
-    writeNotifyOptin(true);
-    onChange(true);
-    // 系统通知只是额外能力；拒绝/不支持不回滚页内通知，只提示降级。
-    void requestNotifySystemPermission().then((granted) => {
-      if (requestId === requestRef.current && !granted) setHint(t("Channel.notify.inAppOnly"));
-    });
-  };
+  }, [inAppOnlyHint, onChange, optin]);
+
+  return { hint, toggle };
+}
+
+export function NotifyToggle({ optin, onChange }: Props) {
+  const t = useT();
+  const { hint, toggle } = useNotifyOptinToggle(
+    optin,
+    onChange,
+    t("Channel.notify.inAppOnly"),
+  );
 
   return (
     <span className="notify-toggle">

--- a/web/src/components/SettingsPanel.test.tsx
+++ b/web/src/components/SettingsPanel.test.tsx
@@ -61,6 +61,7 @@ afterEach(async () => {
   Reflect.deleteProperty(globalThis, "localStorage");
   Reflect.deleteProperty(globalThis, "window");
   Reflect.deleteProperty(globalThis, "document");
+  Reflect.deleteProperty(globalThis, "Notification");
 });
 
 const me: SettingsMe = { name: "alice", kind: "agent", role: "agent", handle: null, display_name: null, owner: null };
@@ -173,6 +174,56 @@ describe("SettingsPanel (#273)", () => {
     expect(notifyOptin).toBe(true);
     expect(store.getItem("ap_notify_optin")).toBe("1");
     expect(allText(r)).toContain("System notifications are unavailable");
+  });
+
+  test("ignores an obsolete notification permission result after the setting is turned off", async () => {
+    let resolvePermission!: (permission: NotificationPermission) => void;
+    const permission = new Promise<NotificationPermission>((resolve) => {
+      resolvePermission = resolve;
+    });
+    const notification = {
+      permission: "default" as NotificationPermission,
+      requestPermission: () => permission,
+    };
+    Object.defineProperty(globalThis, "Notification", {
+      configurable: true,
+      value: notification,
+    });
+    Object.assign(window, { Notification: notification });
+
+    let notifyOptin = false;
+    const common = {
+      me,
+      canSetHandle: false,
+      onClose: () => {},
+      onLogout: () => {},
+      onNotifyOptinChange: (next: boolean) => { notifyOptin = next; },
+    };
+    const r = render({ ...common, notifyOptin });
+
+    void act(() => {
+      (findByClass(r.toJSON(), "settings-toggle")!.props.onClick as () => void)();
+    });
+    expect(notifyOptin).toBe(true);
+
+    void act(() => {
+      r.update(
+        <LocaleProvider>
+          <SettingsPanel {...common} notifyOptin={notifyOptin} />
+        </LocaleProvider>,
+      );
+    });
+    void act(() => {
+      (findByClass(r.toJSON(), "settings-toggle")!.props.onClick as () => void)();
+    });
+    expect(notifyOptin).toBe(false);
+
+    await act(async () => {
+      resolvePermission("denied");
+      await permission;
+    });
+
+    expect(allText(r)).not.toContain("System notifications are unavailable");
   });
 
   test("uses explicit sections and exposes only the selected panel", () => {

--- a/web/src/components/SettingsPanel.tsx
+++ b/web/src/components/SettingsPanel.tsx
@@ -1,13 +1,10 @@
 // 全局设置只承载个人与设备设置。跨频道的本机 Agent 监控、启停、常驻和日志
 // 已移到独立 LocalAgentCenter，避免打开偏好设置就启动多套本机 IPC/轮询。
-import { useCallback, useRef, useState, type ReactNode } from "react";
+import { useCallback, useState, type ReactNode } from "react";
 import { useT } from "../i18n/useT";
 import { LanguageSwitcher } from "./LanguageSwitcher";
 import { HandleSetup } from "./HandleSetup";
-import {
-  requestNotifySystemPermission,
-  writeNotifyOptin,
-} from "./NotifyToggle";
+import { useNotifyOptinToggle } from "./NotifyToggle";
 import {
   SectionedDialog,
   type SectionedDialogSection,
@@ -55,28 +52,17 @@ export function SettingsPanel({
 }) {
   const t = useT();
   const [theme, setTheme] = useState<Theme>(readStoredTheme);
-  const [notifyHint, setNotifyHint] = useState<string | null>(null);
-  const notifyRequestRef = useRef(0);
 
   const pickTheme = useCallback((next: Theme) => {
     applyTheme(next);
     setTheme(next);
   }, []);
 
-  const toggleNotify = useCallback(() => {
-    const next = !notifyOptin;
-    const requestId = ++notifyRequestRef.current;
-    setNotifyHint(null);
-    writeNotifyOptin(next);
-    onNotifyOptinChange(next);
-    if (next) {
-      void requestNotifySystemPermission().then((granted) => {
-        if (requestId === notifyRequestRef.current && !granted) {
-          setNotifyHint(t("App.settings.notify.inAppOnly"));
-        }
-      });
-    }
-  }, [notifyOptin, onNotifyOptinChange, t]);
+  const { hint: notifyHint, toggle: toggleNotify } = useNotifyOptinToggle(
+    notifyOptin,
+    onNotifyOptinChange,
+    t("App.settings.notify.inAppOnly"),
+  );
 
   const sections: SectionedDialogSection<SettingsSectionId>[] = [
     {

--- a/web/src/lib/api.pendingDecisions.test.ts
+++ b/web/src/lib/api.pendingDecisions.test.ts
@@ -1,0 +1,55 @@
+// @ts-expect-error Bun executes this test, while the web tsconfig intentionally loads only Vite globals.
+import { afterEach, describe, expect, test } from "bun:test";
+import { fetchPendingDecisions } from "./api";
+
+const originalFetch = Object.getOwnPropertyDescriptor(globalThis, "fetch");
+
+afterEach(() => {
+  if (originalFetch === undefined) Reflect.deleteProperty(globalThis, "fetch");
+  else Object.defineProperty(globalThis, "fetch", originalFetch);
+});
+
+function mockPendingDecisionPages(
+  totalPages: number,
+  finalPageHasNext: boolean,
+): { calls: () => number } {
+  let calls = 0;
+  Object.defineProperty(globalThis, "fetch", {
+    configurable: true,
+    value: async () => {
+      calls += 1;
+      const hasNext = calls < totalPages || finalPageHasNext;
+      return Response.json({
+        decisions: [{
+          seq: totalPages - calls + 1,
+          prompt: `decision ${calls}`,
+          asker: "agent",
+          waiting_on_me: calls % 2 === 0,
+        }],
+        next_after: hasNext ? calls : null,
+      });
+    },
+  });
+  return { calls: () => calls };
+}
+
+describe("fetchPendingDecisions page limit", () => {
+  test("accepts exactly 200 pages when the final page terminates", async () => {
+    const mock = mockPendingDecisionPages(200, false);
+
+    const decisions = await fetchPendingDecisions("tok", "demo");
+
+    expect(mock.calls()).toBe(200);
+    expect(decisions).toHaveLength(200);
+    expect(decisions[0]?.seq).toBe(1);
+    expect(decisions.at(-1)?.seq).toBe(200);
+  });
+
+  test("stops before a 201st request when page 200 advertises more data", async () => {
+    const mock = mockPendingDecisionPages(200, true);
+
+    await expect(fetchPendingDecisions("tok", "demo"))
+      .rejects.toThrow("pending decisions exceeded max page count");
+    expect(mock.calls()).toBe(200);
+  });
+});

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -749,6 +749,8 @@ interface PendingDecisionPage {
   next_after: number | null;
 }
 
+const MAX_PENDING_DECISION_PAGES = 200;
+
 // Focus 的未决项来自 DO 持久 decision_state，不复用页面当前 300 条消息窗口。
 // 端点按 seq 分页；完整拉取保证长期未决问题不会因超过单页上限再次消失。
 export async function fetchPendingDecisions(
@@ -757,7 +759,9 @@ export async function fetchPendingDecisions(
 ): Promise<AuthoritativePendingDecision[]> {
   const bySeq = new Map<number, AuthoritativePendingDecision>();
   let after = 0;
+  let pages = 0;
   for (;;) {
+    pages += 1;
     const params = new URLSearchParams({ after: String(after), limit: "200" });
     const res = await fetchApi(
       `/api/channels/${encodeURIComponent(slug)}/pending-decisions?${params.toString()}`,
@@ -778,6 +782,9 @@ export async function fetchPendingDecisions(
     if (page.next_after === null) break;
     if (!Number.isInteger(page.next_after) || page.next_after <= after) {
       throw new Error("pending decision cursor did not advance");
+    }
+    if (pages >= MAX_PENDING_DECISION_PAGES) {
+      throw new Error("pending decisions exceeded max page count");
     }
     after = page.next_after;
   }

--- a/worker/test/participant-binding-write.spec.ts
+++ b/worker/test/participant-binding-write.spec.ts
@@ -33,11 +33,7 @@ describe("channel participant binding writes", () => {
     ).toBeNull();
 
     expect((await postMessage(slug, reader.token, "bind on mutation")).status).toBe(200);
-    expect(
-      await env.DB.prepare(
-        "SELECT account FROM channel_participant_bindings WHERE channel_slug = ? AND participant_name = ?",
-      ).bind(slug, reader.name).first<{ account: string }>(),
-    ).toEqual({ account });
+    expect(await waitForParticipantBinding(slug, reader.name)).toEqual({ account });
   });
 
   it("still records an accepted WebSocket participant", async () => {


### PR DESCRIPTION
## 改动说明

- 抽取共享通知 opt-in 切换 hook，NotifyToggle 与 SettingsPanel 复用同一 request-id 竞态守卫
- 保留两处本地化降级提示，并验证关闭后旧权限请求不会污染 UI
- 为未决决策分页设置 200 页硬上限，第 200 页正常结束仍完整返回
- participant binding 的 HTTP/WS 异步落库断言统一使用 2 秒有界轮询

## 合并前检查

- [x] 已阅读 PR Agent 与 CodeRabbit 当前 head review；CodeRabbit 无 actionable finding
- [x] 通知开启→关闭→旧权限拒绝的竞态测试通过
- [x] 未决项第 200 页正常结束与拒绝第 201 次请求的边界测试通过
- [x] Web focused 15 passed；Worker participant binding 2 passed
- [x] Web/Worker TypeScript 与 git diff --check 通过

Addresses the latest CodeRabbit review findings.