### PR TITLE
feat(channel): 接入 Claude 与 Codex 同会话桥接

### DIFF
--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -257,6 +257,8 @@ function isDirectedDelivery(value: unknown): boolean {
     DELIVERY_CAUSES.has(String(value.cause)) &&
     DELIVERY_STATES.has(String(value.state)) &&
     isNonNegativeInteger(value.attempt) &&
+    (value.lease_epoch === undefined || isPositiveInteger(value.lease_epoch)) &&
+    (value.lease_token === undefined || typeof value.lease_token === "string") &&
     (value.lease_until === null || isFiniteNumber(value.lease_until)) &&
     (value.work_id === null || typeof value.work_id === "string") &&
     (value.continuation_ref === null || typeof value.continuation_ref === "string") &&
@@ -300,7 +302,8 @@ function parseServerFrame(value: unknown): ServerFrame | null {
         Array.isArray(value.presence) &&
         value.presence.every(isPresenceEntry) &&
         (value.read_cursors === undefined || (Array.isArray(value.read_cursors) && value.read_cursors.every(isReadCursor))) &&
-        (value.directed_delivery === undefined || value.directed_delivery === "v1")
+        (value.directed_delivery === undefined || value.directed_delivery === "v1") &&
+        (value.delivery_recovery === undefined || value.delivery_recovery === "v1")
         ? asServerFrame(value)
         : null;
     case "participants":
@@ -351,6 +354,19 @@ function parseServerFrame(value: unknown): ServerFrame | null {
         (value.request_id === undefined || typeof value.request_id === "string")
         ? asServerFrame(value)
         : null;
+    case "delivery_recovery":
+      return typeof value.delivery_id === "string" &&
+        typeof value.request_id === "string" &&
+        ["recovered", "superseded_safe", "terminal", "terminal_unknown"].includes(String(value.result)) &&
+        DELIVERY_STATES.has(String(value.state)) &&
+        isPositiveInteger(value.attempt) &&
+        isPositiveInteger(value.lease_epoch) &&
+        (value.lease_token === undefined || typeof value.lease_token === "string") &&
+        (value.lease_until === undefined || isFiniteNumber(value.lease_until)) &&
+        (value.result !== "recovered" ||
+          (typeof value.lease_token === "string" && isFiniteNumber(value.lease_until)))
+        ? asServerFrame(value)
+        : null;
     default:
       return null;
   }
@@ -360,6 +376,8 @@ export interface ConnectOptions {
   onCursor?: (cursor: number) => void;
   /** Declare that this connection consumes durable directed-delivery v1 frames. */
   directedDelivery?: "v1";
+  /** Negotiate token-fenced ownership recovery for durable delivery. */
+  deliveryRecovery?: "v1";
   /**
    * #675/#688：带内声明「本连接有唤醒层」。设值时 hello 带上 wake_kind，服务端在 presence 落对应 wake_kind，
    * 无需往时间线发 waiting 状态消息。断开由 markOffline 撤销。
@@ -617,6 +635,7 @@ export function connect(
         since_rev: revCursor,
         client_version: pkg.version,
         ...(opts.directedDelivery === "v1" ? { directed_delivery: "v1" as const } : {}),
+        ...(opts.deliveryRecovery === "v1" ? { delivery_recovery: "v1" as const } : {}),
         ...(opts.advertiseWakeKind !== undefined ? { wake_kind: opts.advertiseWakeKind } : {}),
       }));
       // External status callbacks may synchronously send an actionable frame on reconnect. Publish

--- a/cli/src/codex-app-server-bridge.ts
+++ b/cli/src/codex-app-server-bridge.ts
@@ -1,0 +1,4119 @@
+/**
+ * Codex app-server bridge.
+ *
+ * One app-server connection is owned by this process and exposed to the Codex
+ * TUI through a private Unix socket. Both interactive TUI writes and
+ * AgentParty delivery pass through the same CodexTurnArbiter; forwarding raw
+ * bytes from two clients would allow a second turn/start to replace live work.
+ */
+import {
+  BODY_LIMIT,
+  DIRECTED_DELIVERY_LEASE_MS,
+  EXIT_ARCHIVED,
+  EXIT_AUTH,
+  EXIT_STREAM_ENDED,
+  type ClientFrame,
+  type DeliveryRecoverFrame,
+  type DeliveryRecoveryResultFrame,
+  type DirectedDelivery,
+  type MsgFrame,
+  type ServerFrame,
+} from "@agentparty/shared";
+import type { ServerWebSocket } from "bun";
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { chmodSync } from "node:fs";
+import { createInterface, type Interface as ReadLineInterface } from "node:readline";
+import pkg from "../package.json" with { type: "json" };
+import {
+  CodexBridgeQueueFullError,
+  CodexRetryableBeforeWriteError,
+  CodexTurnArbiter,
+  type CodexBridgeInput,
+  type CodexDispatch,
+  type CodexInteractiveMutation,
+  type CodexTurnTransport,
+} from "./codex-turn-arbiter";
+import type { Connection } from "./client";
+import {
+  DeliveryRecoveryJournal,
+  type DeliveryRecoveryEntry,
+} from "./delivery-recovery-journal";
+
+export type JsonRpcId = string | number | null;
+
+export interface JsonRpcRequest {
+  id: JsonRpcId;
+  method: string;
+  params?: unknown;
+}
+
+export interface JsonRpcNotification {
+  method: string;
+  params?: unknown;
+}
+
+export interface JsonRpcResponse {
+  id: JsonRpcId;
+  result?: unknown;
+  error?: {
+    code: number;
+    message: string;
+    data?: unknown;
+  };
+}
+
+export type JsonRpcMessage = JsonRpcRequest | JsonRpcNotification | JsonRpcResponse;
+
+export class CodexRpcError extends Error {
+  constructor(
+    readonly code: number,
+    message: string,
+    readonly data?: unknown,
+  ) {
+    super(message);
+    this.name = "CodexRpcError";
+  }
+}
+
+export class CodexRpcDisconnectedError extends Error {
+  readonly codexBridgeRequestWritten: boolean;
+
+  constructor(
+    message = "Codex app-server control connection closed",
+    options: { requestWritten?: boolean } = {},
+  ) {
+    super(message);
+    this.name = "CodexRpcDisconnectedError";
+    this.codexBridgeRequestWritten = options.requestWritten ?? true;
+  }
+}
+
+interface PendingRpc {
+  resolve: (result: unknown) => void;
+  reject: (error: unknown) => void;
+}
+
+export interface CodexRpcClientOptions {
+  spawnProxy: () => ChildProcessWithoutNullStreams;
+  reconnectDelayMs?: number;
+  maxReconnectDelayMs?: number;
+  log?: (line: string) => void;
+}
+
+type MessageListener = (message: JsonRpcRequest | JsonRpcNotification) => void | Promise<void>;
+type ReconnectListener = (generation: number) => void | Promise<void>;
+type DisconnectListener = (generation: number) => void;
+export interface CodexFrontendReset {
+  disconnectedGeneration: number;
+  threadId: string | null;
+}
+type FrontendResetListener = (event: CodexFrontendReset) => void;
+type ThreadSwitchMethod =
+  | "thread/start"
+  | "thread/resume"
+  | "thread/fork"
+  | "thread/rollback"
+  | "thread/inject_items";
+type ThreadSwitchGuard = (attempt: {
+  method: ThreadSwitchMethod;
+  currentThreadId: string;
+  targetThreadId: string | null;
+}) => void;
+type SessionMutationGuard = (attempt: {
+  method: ThreadSwitchMethod | CodexInteractiveMutation;
+  currentThreadId: string | null;
+  mode: "wait" | "check";
+}) => void | Promise<void>;
+type UnresolvedUnknownListener = (event: {
+  threadId: string;
+  input: CodexBridgeInput;
+}) => void | Promise<void>;
+export type CodexFrontendRecovery =
+  | {
+    disposition: "resume";
+    threadId: string;
+    generation: number;
+  }
+  | {
+    disposition: "restart";
+    threadId: null;
+    generation: number;
+  }
+  | {
+    disposition: "restart_thread_with_prompt";
+    threadId: string;
+    generation: number;
+    initialInput?: unknown;
+  }
+  | {
+    disposition: "unknown";
+    threadId: string | null;
+    generation: number;
+    reason: string;
+  };
+type FrontendRecoveryListener = (event: CodexFrontendRecovery) => void | Promise<void>;
+
+function rpcIdKey(id: JsonRpcId): string {
+  return `${typeof id}:${String(id)}`;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asJsonRpcMessage(value: unknown): JsonRpcMessage | null {
+  if (!isObject(value)) return null;
+  if (typeof value.method === "string") {
+    if ("id" in value) {
+      const id = value.id;
+      if (typeof id !== "string" && typeof id !== "number" && id !== null) return null;
+      return {
+        id,
+        method: value.method,
+        ...("params" in value ? { params: value.params } : {}),
+      };
+    }
+    return {
+      method: value.method,
+      ...("params" in value ? { params: value.params } : {}),
+    };
+  }
+  if (!("id" in value)) return null;
+  const id = value.id;
+  if (typeof id !== "string" && typeof id !== "number" && id !== null) return null;
+  if ("error" in value) {
+    if (!isObject(value.error) || typeof value.error.code !== "number" || typeof value.error.message !== "string") {
+      return null;
+    }
+    return {
+      id,
+      error: {
+        code: value.error.code,
+        message: value.error.message,
+        ...("data" in value.error ? { data: value.error.data } : {}),
+      },
+    };
+  }
+  return { id, ...("result" in value ? { result: value.result } : {}) };
+}
+
+function isRpcResponse(message: JsonRpcMessage): message is JsonRpcResponse {
+  return "id" in message && !("method" in message);
+}
+
+function errorDetail(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Reconnecting JSON-RPC client over `codex app-server proxy --sock …` stdio.
+ *
+ * Requests whose connection closes after write are rejected, never replayed.
+ * The session controller resumes the thread and lets the arbiter reconcile
+ * clientUserMessageId before deciding whether an AgentParty input is safe to
+ * retry.
+ */
+export class CodexRpcClient {
+  private child: ChildProcessWithoutNullStreams | null = null;
+  private reader: ReadLineInterface | null = null;
+  private connectPromise: Promise<void> | null = null;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private closing = false;
+  private generation = 0;
+  private requestSeq = 1;
+  private reconnectDelay: number;
+  private initializeValue: unknown = null;
+  private readonly pending = new Map<string, PendingRpc>();
+  private readonly messageListeners = new Set<MessageListener>();
+  private readonly reconnectListeners = new Set<ReconnectListener>();
+  private readonly disconnectListeners = new Set<DisconnectListener>();
+  private lastDisconnectedGeneration = 0;
+  private readonly log: (line: string) => void;
+
+  constructor(private readonly options: CodexRpcClientOptions) {
+    this.log = options.log ?? ((line) => console.error(line));
+    this.reconnectDelay = options.reconnectDelayMs ?? 100;
+  }
+
+  get initializeResult(): unknown {
+    return this.initializeValue;
+  }
+
+  get connected(): boolean {
+    return this.child !== null &&
+      this.initializeValue !== null &&
+      !this.child.stdin.destroyed &&
+      this.child.stdin.writable;
+  }
+
+  get connectionGeneration(): number | null {
+    return this.connected ? this.generation : null;
+  }
+
+  onMessage(listener: MessageListener): () => void {
+    this.messageListeners.add(listener);
+    return () => this.messageListeners.delete(listener);
+  }
+
+  onReconnect(listener: ReconnectListener): () => void {
+    this.reconnectListeners.add(listener);
+    return () => this.reconnectListeners.delete(listener);
+  }
+
+  onDisconnect(listener: DisconnectListener): () => void {
+    this.disconnectListeners.add(listener);
+    return () => this.disconnectListeners.delete(listener);
+  }
+
+  private write(message: JsonRpcMessage): void {
+    const child = this.child;
+    if (!child || child.stdin.destroyed || !child.stdin.writable) {
+      throw new CodexRpcDisconnectedError(
+        "Codex app-server control connection closed before request write",
+        { requestWritten: false },
+      );
+    }
+    child.stdin.write(`${JSON.stringify(message)}\n`);
+  }
+
+  private rawRequest(method: string, params?: unknown): Promise<unknown> {
+    const id = `agentparty:${this.generation}:${this.requestSeq++}`;
+    return new Promise((resolve, reject) => {
+      this.pending.set(rpcIdKey(id), { resolve, reject });
+      try {
+        this.write({ id, method, ...(params === undefined ? {} : { params }) });
+      } catch (error) {
+        this.pending.delete(rpcIdKey(id));
+        reject(error);
+      }
+    });
+  }
+
+  private rejectPending(error: Error): void {
+    for (const pending of this.pending.values()) pending.reject(error);
+    this.pending.clear();
+  }
+
+  private handleLine(line: string, generation: number): void {
+    if (generation !== this.generation || line.trim() === "") return;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      this.log("codex-bridge: app-server emitted invalid JSON; reconnecting control proxy");
+      this.child?.kill("SIGTERM");
+      return;
+    }
+    const message = asJsonRpcMessage(parsed);
+    if (message === null) {
+      this.log("codex-bridge: app-server emitted an invalid JSON-RPC frame; reconnecting control proxy");
+      this.child?.kill("SIGTERM");
+      return;
+    }
+    if (isRpcResponse(message)) {
+      const pending = this.pending.get(rpcIdKey(message.id));
+      if (!pending) return;
+      this.pending.delete(rpcIdKey(message.id));
+      if (message.error) {
+        pending.reject(new CodexRpcError(message.error.code, message.error.message, message.error.data));
+      } else {
+        pending.resolve(message.result);
+      }
+      return;
+    }
+    for (const listener of this.messageListeners) {
+      void Promise.resolve(listener(message)).catch((error) => {
+        this.log(`codex-bridge: JSON-RPC listener failed: ${errorDetail(error)}`);
+      });
+    }
+  }
+
+  private scheduleReconnect(): void {
+    if (this.closing || this.reconnectTimer) return;
+    const delay = this.reconnectDelay;
+    const max = this.options.maxReconnectDelayMs ?? 2_000;
+    this.reconnectDelay = Math.min(max, Math.max(delay, 1) * 2);
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      void this.start().catch((error) => {
+        this.log(`codex-bridge: app-server proxy reconnect failed: ${errorDetail(error)}`);
+        this.scheduleReconnect();
+      });
+    }, delay);
+    if (typeof this.reconnectTimer.unref === "function") this.reconnectTimer.unref();
+  }
+
+  private disconnected(generation: number): void {
+    if (generation !== this.generation) return;
+    if (this.lastDisconnectedGeneration === generation) return;
+    this.lastDisconnectedGeneration = generation;
+    this.reader?.close();
+    this.reader = null;
+    this.child = null;
+    this.initializeValue = null;
+    this.rejectPending(new CodexRpcDisconnectedError());
+    if (!this.closing) {
+      for (const listener of this.disconnectListeners) {
+        try {
+          listener(generation);
+        } catch (error) {
+          this.log(`codex-bridge: disconnect listener failed: ${errorDetail(error)}`);
+        }
+      }
+      this.log("codex-bridge: app-server stdio proxy disconnected; reconnecting");
+      this.scheduleReconnect();
+    }
+  }
+
+  private async connectOnce(): Promise<void> {
+    if (this.closing) throw new CodexRpcDisconnectedError("Codex RPC client is closed");
+    const generation = ++this.generation;
+    const child = this.options.spawnProxy();
+    this.child = child;
+    this.reader = createInterface({ input: child.stdout });
+    this.reader.on("line", (line) => this.handleLine(line, generation));
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk: string | Buffer) => {
+      const text = String(chunk).trimEnd();
+      if (text) this.log(`codex app-server: ${text}`);
+    });
+    child.once("exit", () => this.disconnected(generation));
+    child.once("error", () => this.disconnected(generation));
+
+    const initialized = await this.rawRequest("initialize", {
+      clientInfo: {
+        name: "agentparty-codex-bridge",
+        title: "AgentParty Codex session bridge",
+        version: pkg.version,
+      },
+      capabilities: {
+        experimentalApi: true,
+        requestAttestation: false,
+      },
+    });
+    if (generation !== this.generation || this.child !== child) {
+      throw new CodexRpcDisconnectedError();
+    }
+    this.write({ method: "initialized" });
+    this.initializeValue = initialized;
+    const reconnected = generation > 1;
+    this.reconnectDelay = this.options.reconnectDelayMs ?? 100;
+    if (reconnected) {
+      for (const listener of this.reconnectListeners) {
+        void Promise.resolve(listener(generation)).catch((error) => {
+          this.log(`codex-bridge: reconnect reconciliation failed: ${errorDetail(error)}`);
+        });
+      }
+    }
+  }
+
+  async start(): Promise<void> {
+    if (this.connected) return;
+    if (!this.connectPromise) {
+      this.connectPromise = this.connectOnce().finally(() => {
+        this.connectPromise = null;
+      });
+    }
+    return await this.connectPromise;
+  }
+
+  async request(method: string, params?: unknown): Promise<unknown> {
+    await this.start();
+    return await this.rawRequest(method, params);
+  }
+
+  requestConnected(
+    method: string,
+    params?: unknown,
+    expectedGeneration?: number,
+  ): Promise<unknown> {
+    if (
+      !this.child ||
+      this.initializeValue === null ||
+      (expectedGeneration !== undefined && expectedGeneration !== this.generation)
+    ) {
+      return Promise.reject(new CodexRpcDisconnectedError(
+        expectedGeneration !== undefined && expectedGeneration !== this.generation
+          ? `Codex app-server generation changed before ${method} request write`
+          : "Codex app-server control connection closed before request write",
+        { requestWritten: false },
+      ));
+    }
+    return this.rawRequest(method, params);
+  }
+
+  async notify(method: string, params?: unknown): Promise<void> {
+    await this.start();
+    this.write({ method, ...(params === undefined ? {} : { params }) });
+  }
+
+  notifyConnected(method: string, params?: unknown): void {
+    if (!this.child || this.initializeValue === null) {
+      throw new CodexRpcDisconnectedError(
+        "Codex app-server control connection closed before notification write",
+        { requestWritten: false },
+      );
+    }
+    this.write({ method, ...(params === undefined ? {} : { params }) });
+  }
+
+  respond(id: JsonRpcId, result?: unknown, error?: JsonRpcResponse["error"]): void {
+    this.write({
+      id,
+      ...(error === undefined ? { result } : { error }),
+    });
+  }
+
+  close(): void {
+    this.closing = true;
+    if (this.reconnectTimer) clearTimeout(this.reconnectTimer);
+    this.reconnectTimer = null;
+    this.reader?.close();
+    this.reader = null;
+    this.rejectPending(new CodexRpcDisconnectedError("Codex RPC client closed"));
+    const child = this.child;
+    this.child = null;
+    if (child && child.exitCode === null && child.signalCode === null) child.kill("SIGTERM");
+  }
+}
+
+export interface CodexRpcPeer {
+  readonly initializeResult: unknown;
+  readonly connected?: boolean;
+  readonly connectionGeneration: number | null;
+  start(): Promise<void>;
+  request(method: string, params?: unknown): Promise<unknown>;
+  requestConnected(
+    method: string,
+    params?: unknown,
+    expectedGeneration?: number,
+  ): Promise<unknown>;
+  notify(method: string, params?: unknown): Promise<void>;
+  notifyConnected?(method: string, params?: unknown): void | Promise<void>;
+  respond(id: JsonRpcId, result?: unknown, error?: JsonRpcResponse["error"]): void;
+  onMessage(listener: MessageListener): () => void;
+  onReconnect(listener: ReconnectListener): () => void;
+  onDisconnect?(listener: DisconnectListener): () => void;
+}
+
+export interface CodexTurn {
+  id: string;
+  status: "completed" | "interrupted" | "failed" | "inProgress";
+  items?: CodexThreadItem[];
+}
+
+export interface CodexThreadItem extends Record<string, unknown> {
+  type: string;
+  clientId?: string | null;
+}
+
+export interface CodexThread {
+  id: string;
+  status: { type: "idle" | "active" | "notLoaded" | "systemError" };
+  turns: CodexTurn[];
+}
+
+type DispatchListener = (input: CodexBridgeInput, dispatch: CodexDispatch) => void | Promise<void>;
+type CompletedTurnListener = (turn: CodexTurn) => void | Promise<void>;
+
+function asThread(value: unknown): CodexThread | null {
+  if (!isObject(value) || typeof value.id !== "string" || !isObject(value.status) || typeof value.status.type !== "string") {
+    return null;
+  }
+  const status = value.status.type;
+  if (status !== "idle" && status !== "active" && status !== "notLoaded" && status !== "systemError") return null;
+  const turns = Array.isArray(value.turns) ? value.turns.flatMap((turn) => {
+    if (!isObject(turn) || typeof turn.id !== "string" || typeof turn.status !== "string") return [];
+    if (
+      turn.status !== "completed" &&
+      turn.status !== "interrupted" &&
+      turn.status !== "failed" &&
+      turn.status !== "inProgress"
+    ) {
+      return [];
+    }
+    return [{
+      id: turn.id,
+      status: turn.status,
+      ...(Array.isArray(turn.items) ? { items: turn.items.flatMap(asThreadItem) } : {}),
+    } satisfies CodexTurn];
+  }) : [];
+  return { id: value.id, status: { type: status }, turns };
+}
+
+function responseThread(value: unknown): CodexThread | null {
+  return isObject(value) ? asThread(value.thread) : null;
+}
+
+function requireRecoveryThreadIdentity(
+  value: unknown,
+  expectedThreadId: string,
+  method: "thread/resume" | "thread/read",
+): CodexThread {
+  const thread = responseThread(value);
+  if (thread === null) {
+    throw new Error(`${method} returned no valid thread while restoring ${expectedThreadId}`);
+  }
+  if (thread.id !== expectedThreadId) {
+    throw new Error(
+      `${method} restored thread ${thread.id}, expected ${expectedThreadId}`,
+    );
+  }
+  return thread;
+}
+
+function requireRecoveryThreadSnapshot(
+  value: unknown,
+  expectedThreadId: string,
+): CodexThread {
+  const thread = requireRecoveryThreadIdentity(value, expectedThreadId, "thread/read");
+  const rawThread = isObject(value) && isObject(value.thread) ? value.thread : null;
+  if (rawThread === null || !Array.isArray(rawThread.turns)) {
+    throw new Error(
+      `thread/read did not return a complete turn snapshot for ${expectedThreadId}`,
+    );
+  }
+  if (thread.turns.length !== rawThread.turns.length) {
+    throw new Error(
+      `thread/read returned malformed turn history for ${expectedThreadId}`,
+    );
+  }
+  for (let index = 0; index < rawThread.turns.length; index += 1) {
+    const rawTurn = rawThread.turns[index];
+    const parsedTurn = thread.turns[index];
+    if (
+      !isObject(rawTurn) ||
+      !Array.isArray(rawTurn.items) ||
+      parsedTurn === undefined ||
+      (parsedTurn.items?.length ?? 0) !== rawTurn.items.length
+    ) {
+      throw new Error(
+        `thread/read returned an incomplete turn snapshot for ${expectedThreadId}`,
+      );
+    }
+  }
+  return thread;
+}
+
+function clientIds(turn: CodexTurn): string[] {
+  return (turn.items ?? []).flatMap((item) =>
+    item.type === "userMessage" && typeof item.clientId === "string" ? [item.clientId] : []
+  );
+}
+
+function paramsRecord(value: unknown): Record<string, unknown> {
+  return isObject(value) ? value : {};
+}
+
+function sameJsonValue(left: unknown, right: unknown): boolean {
+  try {
+    return JSON.stringify(left) === JSON.stringify(right);
+  } catch {
+    return false;
+  }
+}
+
+const INTERACTIVE_MUTATIONS = new Set<CodexInteractiveMutation>([
+  "turn/start",
+  "turn/steer",
+  "turn/interrupt",
+  "review/start",
+  "thread/compact/start",
+  "thread/shellCommand",
+]);
+
+class CodexSessionReadinessChanged extends Error {}
+class CodexSessionMutationReadinessChanged extends CodexRetryableBeforeWriteError {}
+class CodexRecoverySuperseded extends Error {}
+class CodexInitialThreadStartRestartRequired extends Error {}
+
+interface CodexRecoveryState {
+  attempt: number;
+  generation: number;
+  threadId: string | null;
+  status: "restoring" | "ready" | "failed";
+  error: Error | null;
+  retryAttempt: number;
+  cancelRetry: (() => void) | null;
+  promise: Promise<void>;
+}
+
+interface InitialThreadStartAttempt {
+  operation: "initial thread/start" | "initial turn/start";
+  params: Record<string, unknown>;
+  phase: "waiting" | "writing" | "finished";
+  cancelled: boolean;
+  outcome: "resume" | "restart" | "unknown" | null;
+  unknownReason: string | null;
+  readonly cancelledRun: Promise<void>;
+  readonly finished: Promise<void>;
+  cancel(): void;
+  finish(): void;
+}
+
+function initialThreadStartAttempt(
+  operation: InitialThreadStartAttempt["operation"],
+  params: Record<string, unknown>,
+): InitialThreadStartAttempt {
+  let cancel!: () => void;
+  let finish!: () => void;
+  const cancelledRun = new Promise<void>((resolve) => {
+    cancel = resolve;
+  });
+  const finished = new Promise<void>((resolve) => {
+    finish = resolve;
+  });
+  return {
+    operation,
+    params,
+    phase: "waiting",
+    cancelled: false,
+    outcome: null,
+    unknownReason: null,
+    cancelledRun,
+    finished,
+    cancel,
+    finish,
+  };
+}
+
+function disconnectedBeforeWrite(error: unknown): boolean {
+  return error instanceof CodexRpcDisconnectedError &&
+    error.codexBridgeRequestWritten === false;
+}
+
+/**
+ * Protocol/state router shared by the Unix TUI proxy and AgentParty delivery.
+ */
+export class CodexSessionController {
+  private threadId: string | null = null;
+  private arbiter: CodexTurnArbiter | null = null;
+  private sessionLane: Promise<void> = Promise.resolve();
+  private restoreTail: Promise<void> = Promise.resolve();
+  private recovery: CodexRecoveryState | null = null;
+  private requestGenerationFence: number | null = null;
+  private reconnectAttempt = 0;
+  private readonly beforeSession: CodexBridgeInput[] = [];
+  private readonly dispatchListeners = new Set<DispatchListener>();
+  private readonly completedListeners = new Set<CompletedTurnListener>();
+  private readonly frontendListeners = new Set<MessageListener>();
+  private readonly frontendResetListeners = new Set<FrontendResetListener>();
+  private readonly frontendRecoveryListeners = new Set<FrontendRecoveryListener>();
+  private readonly threadSwitchGuards = new Set<ThreadSwitchGuard>();
+  private readonly sessionMutationGuards = new Set<SessionMutationGuard>();
+  private readonly unresolvedUnknownListeners = new Set<UnresolvedUnknownListener>();
+  private readonly turnByClientId = new Map<string, string>();
+  private readonly turns = new Map<string, CodexTurn>();
+  private readonly log: (line: string) => void;
+  private beforeSessionFlushTimer: ReturnType<typeof setTimeout> | null = null;
+  private initialThreadStart: InitialThreadStartAttempt | null = null;
+  private initialPromptStart: InitialThreadStartAttempt | null = null;
+  private bootstrapThreadId: string | null = null;
+  private noThreadRecovery:
+    | { disposition: "restart" }
+    | { disposition: "unknown"; reason: string }
+    | null = null;
+  private bootstrapRecovery:
+    | { disposition: "restart_thread_with_prompt"; initialInput?: unknown }
+    | { disposition: "unknown"; reason: string; initialInput: unknown }
+    | null = null;
+
+  constructor(
+    private readonly rpc: CodexRpcPeer,
+    private readonly options: {
+      maxQueue?: number;
+      log?: (line: string) => void;
+      /** Hold pre-attach AgentParty input until the TUI's initial prompt is accepted. */
+      expectBootstrapPrompt?: boolean;
+      /** Base delay for same-generation app-server recovery retries. */
+      recoveryRetryDelayMs?: number;
+    } = {},
+  ) {
+    this.log = options.log ?? ((line) => console.error(line));
+    rpc.onMessage((message) => this.handleBackendMessage(message));
+    const hasDisconnectBoundary = rpc.onDisconnect !== undefined;
+    rpc.onDisconnect?.((disconnectedGeneration) => {
+      // Wake a same-generation recovery that is sleeping in backoff. Its
+      // generation check will retire the old barrier so a waiting writer can
+      // drive rpc.start() and the successor recovery instead of waiting for a
+      // stale timer.
+      this.recovery?.cancelRetry?.();
+      if (this.threadId === null) {
+        const attempt = this.initialThreadStart;
+        if (attempt?.phase === "waiting") {
+          this.cancelInitialThreadStart(attempt);
+        } else if (!attempt && this.noThreadRecovery?.disposition !== "unknown") {
+          this.noThreadRecovery = { disposition: "restart" };
+        }
+      } else if (this.bootstrapThreadId === this.threadId) {
+        const attempt = this.initialPromptStart;
+        if (attempt?.phase === "waiting") {
+          this.cancelInitialPromptStart(attempt);
+        } else if (
+          !attempt &&
+          this.bootstrapRecovery === null
+        ) {
+          this.bootstrapRecovery = {
+            disposition: "restart_thread_with_prompt",
+          };
+        }
+      }
+      const event = {
+        disconnectedGeneration,
+        threadId: this.threadId,
+      };
+      for (const listener of this.frontendResetListeners) listener(event);
+    });
+    rpc.onReconnect(async (generation) => {
+      const attempt = ++this.reconnectAttempt;
+      // Older/test peers expose only reconnect. Real CodexRpcClient announces
+      // reset at disconnect time so the supervisor can quiesce the old TUI
+      // before it exits and accidentally terminates the whole bridge.
+      if (!hasDisconnectBoundary) {
+        const event = {
+          disconnectedGeneration: Math.max(0, generation - 1),
+          threadId: this.threadId,
+        };
+        for (const listener of this.frontendResetListeners) listener(event);
+      }
+      const state = this.scheduleRecovery(attempt, generation);
+      await state.promise;
+    });
+  }
+
+  get activeThreadId(): string | null {
+    return this.threadId;
+  }
+
+  get initializeResult(): unknown {
+    return this.rpc.initializeResult;
+  }
+
+  onDispatch(listener: DispatchListener): () => void {
+    this.dispatchListeners.add(listener);
+    return () => this.dispatchListeners.delete(listener);
+  }
+
+  onTurnCompleted(listener: CompletedTurnListener): () => void {
+    this.completedListeners.add(listener);
+    return () => this.completedListeners.delete(listener);
+  }
+
+  onFrontendMessage(listener: MessageListener): () => void {
+    this.frontendListeners.add(listener);
+    return () => this.frontendListeners.delete(listener);
+  }
+
+  onFrontendReset(listener: FrontendResetListener): () => void {
+    this.frontendResetListeners.add(listener);
+    return () => this.frontendResetListeners.delete(listener);
+  }
+
+  onFrontendRecovery(listener: FrontendRecoveryListener): () => void {
+    this.frontendRecoveryListeners.add(listener);
+    return () => this.frontendRecoveryListeners.delete(listener);
+  }
+
+  onThreadSwitch(listener: ThreadSwitchGuard): () => void {
+    this.threadSwitchGuards.add(listener);
+    return () => this.threadSwitchGuards.delete(listener);
+  }
+
+  onSessionMutation(listener: SessionMutationGuard): () => void {
+    this.sessionMutationGuards.add(listener);
+    return () => this.sessionMutationGuards.delete(listener);
+  }
+
+  private async waitForSessionMutationGuards(method: CodexInteractiveMutation): Promise<void> {
+    for (const guard of this.sessionMutationGuards) {
+      await guard({
+        method,
+        currentThreadId: this.threadId,
+        mode: "wait",
+      });
+    }
+  }
+
+  private checkSessionMutationGuards(method: CodexInteractiveMutation): void {
+    for (const guard of this.sessionMutationGuards) {
+      const result = guard({
+        method,
+        currentThreadId: this.threadId,
+        mode: "check",
+      });
+      if (result !== undefined) {
+        // A check-mode guard must never wait while the arbiter writer lane is
+        // held; recovery itself may need that lane to restore queued delivery.
+        void Promise.resolve(result).catch(() => {});
+        throw new CodexSessionMutationReadinessChanged(
+          "AgentParty ownership recovery changed before the Codex write boundary",
+        );
+      }
+    }
+  }
+
+  onUnresolvedUnknown(listener: UnresolvedUnknownListener): () => void {
+    this.unresolvedUnknownListeners.add(listener);
+    return () => this.unresolvedUnknownListeners.delete(listener);
+  }
+
+  async abandonUnknownOutcome(
+    threadId: string,
+    input: CodexBridgeInput,
+  ): Promise<CodexDispatch> {
+    const arbiter = this.arbiter;
+    if (!arbiter || this.threadId !== threadId) {
+      throw new Error(`Cannot abandon an uncertain write for inactive Codex thread ${threadId}`);
+    }
+    return await arbiter.resolveUnknownOutcome(input, "abandoned");
+  }
+
+  private emitDispatch(input: CodexBridgeInput, dispatch: CodexDispatch): void {
+    if (dispatch.turnId) this.turnByClientId.set(input.clientUserMessageId, dispatch.turnId);
+    for (const listener of this.dispatchListeners) {
+      void Promise.resolve(listener(input, dispatch)).catch((error) => {
+        this.log(`codex-bridge: dispatch listener failed: ${errorDetail(error)}`);
+      });
+    }
+  }
+
+  private emitCompleted(turn: CodexTurn): void {
+    this.turns.set(turn.id, turn);
+    for (const listener of this.completedListeners) {
+      void Promise.resolve(listener(turn)).catch((error) => {
+        this.log(`codex-bridge: completion listener failed: ${errorDetail(error)}`);
+      });
+    }
+  }
+
+  private serializeSession<T>(operation: () => Promise<T>): Promise<T> {
+    const run = this.sessionLane.then(operation, operation);
+    this.sessionLane = run.then(() => {}, () => {});
+    return run;
+  }
+
+  private assertRecoveryCurrent(state: CodexRecoveryState): void {
+    if (
+      this.recovery !== state ||
+      this.rpc.connectionGeneration !== state.generation ||
+      this.rpc.connected === false
+    ) {
+      throw new CodexRecoverySuperseded();
+    }
+  }
+
+  private async waitForRecoveryRetry(
+    state: CodexRecoveryState,
+    delayMs: number,
+  ): Promise<void> {
+    await new Promise<void>((resolve) => {
+      let settled = false;
+      const finish = () => {
+        if (settled) return;
+        settled = true;
+        if (state.cancelRetry === cancel) state.cancelRetry = null;
+        resolve();
+      };
+      const timer = setTimeout(finish, delayMs);
+      const cancel = () => {
+        clearTimeout(timer);
+        finish();
+      };
+      state.cancelRetry = cancel;
+      if (typeof timer.unref === "function") timer.unref();
+    });
+  }
+
+  private scheduleRecovery(attempt: number, generation: number): CodexRecoveryState {
+    const active = this.recovery;
+    if (
+      active !== null &&
+      active.generation === generation &&
+      (active.status === "restoring" || active.status === "ready")
+    ) {
+      return active;
+    }
+    active?.cancelRetry?.();
+    const state: CodexRecoveryState = {
+      attempt,
+      generation,
+      threadId: this.threadId,
+      status: "restoring",
+      error: null,
+      retryAttempt: 0,
+      cancelRetry: null,
+      promise: Promise.resolve(),
+    };
+    this.recovery = state;
+    const preceding = this.restoreTail.catch(() => {});
+    state.promise = preceding.then(async () => {
+      if (this.recovery !== state) return;
+      for (;;) {
+        try {
+          this.assertRecoveryCurrent(state);
+          await this.restoreGeneration(state);
+          this.assertRecoveryCurrent(state);
+          state.status = "ready";
+          state.error = null;
+          state.retryAttempt = 0;
+          return;
+        } catch (error) {
+          if (
+            error instanceof CodexRecoverySuperseded ||
+            this.recovery !== state ||
+            this.rpc.connectionGeneration !== state.generation ||
+            this.rpc.connected === false
+          ) {
+            return;
+          }
+          state.status = "restoring";
+          state.error = error instanceof Error ? error : new Error(String(error));
+          const baseDelayMs = Math.max(1, this.options.recoveryRetryDelayMs ?? 1_000);
+          const retryDelayMs = Math.min(
+            30_000,
+            baseDelayMs * 2 ** Math.min(state.retryAttempt, 5),
+          );
+          state.retryAttempt += 1;
+          this.log(
+            `codex-bridge: app-server generation ${state.generation} recovery failed; ` +
+              `retrying on the same connection in ${retryDelayMs}ms: ${state.error.message}`,
+          );
+          await this.waitForRecoveryRetry(state, retryDelayMs);
+        }
+      }
+    });
+    this.restoreTail = state.promise.catch(() => {});
+    return state;
+  }
+
+  private async awaitRestoreBarrier(): Promise<void> {
+    for (;;) {
+      const state = this.recovery;
+      if (!state) return;
+      try {
+        await state.promise;
+      } catch {
+        // The current state's structured failure is handled below. A replaced
+        // state must never leak its rejection into the new generation.
+      }
+      if (state !== this.recovery) continue;
+      if (state.status === "failed") throw state.error!;
+      if (state.status === "ready") return;
+      if (
+        this.rpc.connected === false ||
+        this.rpc.connectionGeneration !== state.generation
+      ) {
+        // The settled restoring promise belongs to a disconnected generation.
+        // Return to ensureBackendReady so it can call rpc.start(); repeatedly
+        // awaiting this already-settled promise would otherwise form a
+        // microtask spin loop that can starve the reconnect timer.
+        return;
+      }
+    }
+  }
+
+  /**
+   * Establish/reconcile the backend before entering either the session lane or
+   * the turn arbiter. A reconnect listener may need both locks while restoring,
+   * so triggering reconnect from inside either lock would deadlock.
+   */
+  private throwIfInitialThreadStartCancelled(
+    attempt: InitialThreadStartAttempt | undefined,
+  ): void {
+    if (attempt?.cancelled) {
+      throw new CodexInitialThreadStartRestartRequired(
+        `Codex backend disconnected before the ${attempt.operation} write`,
+      );
+    }
+  }
+
+  private async waitForInitialThreadStartCancellation<T>(
+    operation: Promise<T>,
+    attempt: InitialThreadStartAttempt | undefined,
+  ): Promise<T> {
+    if (!attempt) return await operation;
+    this.throwIfInitialThreadStartCancelled(attempt);
+    return await Promise.race([
+      operation,
+      attempt.cancelledRun.then(() => {
+        throw new CodexInitialThreadStartRestartRequired(
+          `Codex backend disconnected before the ${attempt.operation} write`,
+        );
+      }),
+    ]);
+  }
+
+  private cancelInitialThreadStart(attempt: InitialThreadStartAttempt): void {
+    if (attempt.phase !== "waiting" || attempt.cancelled) return;
+    attempt.cancelled = true;
+    attempt.outcome = "restart";
+    this.noThreadRecovery = { disposition: "restart" };
+    attempt.cancel();
+  }
+
+  private cancelInitialPromptStart(attempt: InitialThreadStartAttempt): void {
+    if (attempt.phase !== "waiting" || attempt.cancelled) return;
+    attempt.cancelled = true;
+    attempt.outcome = "restart";
+    this.bootstrapRecovery = {
+      disposition: "restart_thread_with_prompt",
+      initialInput: attempt.params.input,
+    };
+    attempt.cancel();
+  }
+
+  private async ensureBackendReady(
+    initialStart?: InitialThreadStartAttempt,
+  ): Promise<{ attempt: number; generation: number }> {
+    for (;;) {
+      await this.waitForInitialThreadStartCancellation(
+        this.rpc.start(),
+        initialStart,
+      );
+      this.throwIfInitialThreadStartCancelled(initialStart);
+      const generation = this.rpc.connectionGeneration;
+      if (generation === null) {
+        throw new CodexRpcDisconnectedError(
+          "Codex app-server control connection is not ready",
+          { requestWritten: false },
+        );
+      }
+      await this.waitForInitialThreadStartCancellation(
+        this.awaitRestoreBarrier(),
+        initialStart,
+      );
+      this.throwIfInitialThreadStartCancelled(initialStart);
+      if (
+        this.rpc.connected !== false &&
+        this.rpc.connectionGeneration === generation
+      ) {
+        return { attempt: this.reconnectAttempt, generation };
+      }
+    }
+  }
+
+  /**
+   * Acquire a stable session generation without reconnecting while the session
+   * lane is held. Reconnect restoration itself needs this lane, so a generation
+   * change or a proven pre-write disconnect releases the lane and retries only
+   * after the restore barrier has completed.
+   */
+  private async withReadySession<T>(
+    operation: () => Promise<T>,
+    initialStart?: InitialThreadStartAttempt,
+  ): Promise<T> {
+    for (;;) {
+      const ready = await this.ensureBackendReady(initialStart);
+      this.throwIfInitialThreadStartCancelled(initialStart);
+      try {
+        return await this.serializeSession(async () => {
+          this.throwIfInitialThreadStartCancelled(initialStart);
+          const previousFence = this.requestGenerationFence;
+          this.requestGenerationFence = ready.generation;
+          try {
+            if (
+              ready.attempt !== this.reconnectAttempt ||
+              ready.generation !== this.rpc.connectionGeneration ||
+              this.recovery?.status === "restoring" ||
+              this.recovery?.status === "failed" ||
+              this.rpc.connected === false
+            ) {
+              throw new CodexSessionReadinessChanged();
+            }
+            try {
+              return await operation();
+            } catch (error) {
+              if (disconnectedBeforeWrite(error)) {
+                throw new CodexSessionReadinessChanged();
+              }
+              throw error;
+            }
+          } finally {
+            if (this.requestGenerationFence === ready.generation) {
+              this.requestGenerationFence = previousFence;
+            }
+          }
+        });
+      } catch (error) {
+        if (error instanceof CodexSessionReadinessChanged) continue;
+        throw error;
+      }
+    }
+  }
+
+  private requestConnected(
+    method: string,
+    params?: unknown,
+    expectedGeneration?: number,
+  ): Promise<unknown> {
+    return this.rpc.requestConnected(
+      method,
+      params,
+      expectedGeneration ?? this.requestGenerationFence ?? undefined,
+    );
+  }
+
+  private async notifyConnected(method: string, params?: unknown): Promise<void> {
+    if (this.rpc.notifyConnected) {
+      await this.rpc.notifyConnected(method, params);
+      return;
+    }
+    await this.rpc.notify(method, params);
+  }
+
+  private transport(): CodexTurnTransport {
+    return {
+      turnStart: async (params) =>
+        await this.requestConnected("turn/start", params) as { turn: { id: string } },
+      turnSteer: async (params) =>
+        await this.requestConnected("turn/steer", params) as { turnId: string },
+    };
+  }
+
+  private async attachThread(
+    thread: CodexThread,
+    options: { backendRestarted?: boolean; deferQueuedInputs?: boolean } = {},
+  ): Promise<void> {
+    const threadChanged = this.threadId !== thread.id;
+    const replacing = threadChanged || this.arbiter === null;
+    // Every attached Thread payload is an authoritative history snapshot.
+    // Rebuild affinity indexes even for the same thread so rollback cannot
+    // leave a removed source clientId cached and authorize owner_answer.
+    this.turns.clear();
+    this.turnByClientId.clear();
+    this.threadId = thread.id;
+    this.noThreadRecovery = null;
+    if (replacing) {
+      this.arbiter = new CodexTurnArbiter(thread.id, this.transport(), {
+        maxQueue: this.options.maxQueue,
+        onQueuedDispatch: ({ input, dispatch }) => this.emitDispatch(input, dispatch),
+        onQueuedError: ({ input, error }) => {
+          this.log(
+            `codex-bridge: queued input ${input.clientUserMessageId} remains pending: ` +
+              errorDetail(error),
+          );
+        },
+      });
+    }
+    await this.arbiter!.observeResume({ thread }, options);
+
+    for (const turn of thread.turns) {
+      this.turns.set(turn.id, turn);
+      for (const clientId of clientIds(turn)) {
+        this.turnByClientId.set(clientId, turn.id);
+        this.emitDispatch(
+          { text: "recovered AgentParty input", clientUserMessageId: clientId },
+          { kind: "duplicate", turnId: turn.id },
+        );
+      }
+      if (turn.status !== "inProgress") this.emitCompleted(turn);
+    }
+
+    const bootstrapPromptPending =
+      this.options.expectBootstrapPrompt === true &&
+      this.bootstrapThreadId !== null &&
+      this.bootstrapThreadId === thread.id;
+    if (options.deferQueuedInputs !== true && !bootstrapPromptPending) {
+      await this.flushBeforeSessionSafely();
+    }
+  }
+
+  private async flushBeforeSession(): Promise<void> {
+    if (!this.arbiter) return;
+    while (this.beforeSession.length > 0) {
+      const input = this.beforeSession.shift()!;
+      try {
+        const dispatch = await this.arbiter.submit(input);
+        this.emitDispatch(input, dispatch);
+      } catch (error) {
+        this.beforeSession.unshift(input);
+        throw error;
+      }
+    }
+  }
+
+  private async flushBeforeSessionSafely(): Promise<void> {
+    if (this.beforeSessionFlushTimer !== null) {
+      clearTimeout(this.beforeSessionFlushTimer);
+      this.beforeSessionFlushTimer = null;
+    }
+    try {
+      await this.flushBeforeSession();
+    } catch (error) {
+      // The frontend thread/start or initial turn/start may already have
+      // succeeded upstream. A side-channel delivery WAL failure must not
+      // rewrite that authoritative response into a TUI error. Keep the input
+      // at the head of beforeSession and retry independently.
+      this.log(
+        `codex-bridge: queued AgentParty delivery flush is still pending: ${errorDetail(error)}`,
+      );
+      if (this.beforeSession.length === 0 || this.beforeSessionFlushTimer !== null) return;
+      this.beforeSessionFlushTimer = setTimeout(() => {
+        this.beforeSessionFlushTimer = null;
+        void this.flushBeforeSessionSafely();
+      }, 100);
+      if (typeof this.beforeSessionFlushTimer.unref === "function") {
+        this.beforeSessionFlushTimer.unref();
+      }
+    }
+  }
+
+  async start(): Promise<void> {
+    await this.rpc.start();
+  }
+
+  async submit(input: CodexBridgeInput): Promise<CodexDispatch> {
+    return await this.withReadySession(async () => {
+      if (
+        !this.arbiter ||
+        (
+          this.options.expectBootstrapPrompt === true &&
+          this.bootstrapThreadId !== null &&
+          this.bootstrapThreadId === this.threadId
+        )
+      ) {
+        const duplicate = this.beforeSession.find((entry) =>
+          entry.clientUserMessageId === input.clientUserMessageId
+        );
+        if (duplicate) {
+          return {
+            kind: "queued",
+            queuePosition: this.beforeSession.indexOf(duplicate) + 1,
+            reason: "unknown",
+          };
+        }
+        const limit = this.options.maxQueue ?? 128;
+        if (this.beforeSession.length >= limit) throw new CodexBridgeQueueFullError(limit);
+        this.beforeSession.push(input);
+        return { kind: "queued", queuePosition: this.beforeSession.length, reason: "unknown" };
+      }
+      const dispatch = await this.arbiter.submit(input);
+      this.emitDispatch(input, dispatch);
+      return dispatch;
+    });
+  }
+
+  /**
+   * Revoke an AgentParty input only while it is still on a pre-write queue.
+   * This intentionally bypasses backend readiness: cancellation is local
+   * bookkeeping needed while an AgentParty reconnect is reconciling ownership.
+   */
+  async cancelQueued(clientUserMessageId: string): Promise<boolean> {
+    return await this.serializeSession(async () => {
+      const beforeSessionIndex = this.beforeSession.findIndex((entry) =>
+        entry.clientUserMessageId === clientUserMessageId
+      );
+      if (beforeSessionIndex >= 0) {
+        this.beforeSession.splice(beforeSessionIndex, 1);
+        if (this.beforeSession.length === 0 && this.beforeSessionFlushTimer !== null) {
+          clearTimeout(this.beforeSessionFlushTimer);
+          this.beforeSessionFlushTimer = null;
+        }
+        return true;
+      }
+      return await this.arbiter?.cancelQueued(clientUserMessageId) ?? false;
+    });
+  }
+
+  turnForClientId(clientId: string): CodexTurn | null {
+    const turnId = this.turnByClientId.get(clientId);
+    return turnId ? this.turns.get(turnId) ?? null : null;
+  }
+
+  private async routeThreadResponse(
+    method: string,
+    result: unknown,
+    params: Record<string, unknown>,
+    options: { backendRestarted?: boolean; deferQueuedInputs?: boolean } = {},
+  ): Promise<void> {
+    const thread = responseThread(result);
+    if (!thread) return;
+    if (method === "thread/read" && params.includeTurns !== true) return;
+    await this.attachThread(thread, options);
+  }
+
+  private async requestInitialThreadStart(params?: unknown): Promise<unknown> {
+    if (this.initialThreadStart !== null) {
+      throw new CodexRpcError(
+        -32_002,
+        "Cannot start a second Codex thread while the initial thread/start is pending",
+      );
+    }
+    if (this.noThreadRecovery?.disposition === "unknown") {
+      throw new CodexRpcError(
+        -32_097,
+        this.noThreadRecovery.reason,
+      );
+    }
+
+    const record = paramsRecord(params);
+    const attempt = initialThreadStartAttempt("initial thread/start", record);
+    this.initialThreadStart = attempt;
+    try {
+      return await this.withReadySession(async () => {
+        this.throwIfInitialThreadStartCancelled(attempt);
+        attempt.phase = "writing";
+        try {
+          const result = await this.requestConnected("thread/start", params);
+          const thread = responseThread(result);
+          if (thread !== null) {
+            await this.attachThread(thread, {
+              deferQueuedInputs: this.options.expectBootstrapPrompt === true,
+            });
+          }
+          this.bootstrapThreadId = this.threadId;
+          this.bootstrapRecovery = {
+            disposition: "restart_thread_with_prompt",
+          };
+          if (this.options.expectBootstrapPrompt !== true) {
+            await this.flushBeforeSessionSafely();
+          }
+          attempt.outcome = "resume";
+          return result;
+        } catch (error) {
+          if (disconnectedBeforeWrite(error)) {
+            attempt.outcome = "restart";
+            this.noThreadRecovery = { disposition: "restart" };
+            throw new CodexInitialThreadStartRestartRequired(
+              "Codex backend disconnected before the initial thread/start write",
+            );
+          }
+          if (error instanceof CodexRpcDisconnectedError) {
+            const reason =
+              "Codex backend disconnected after the initial thread/start write; " +
+              "its outcome is unknown, so the initial prompt will not be replayed";
+            attempt.outcome = "unknown";
+            attempt.unknownReason = reason;
+            this.noThreadRecovery = { disposition: "unknown", reason };
+          }
+          throw error;
+        }
+      }, attempt);
+    } finally {
+      attempt.phase = "finished";
+      if (this.initialThreadStart === attempt) this.initialThreadStart = null;
+      attempt.finish();
+    }
+  }
+
+  private async requestInitialPromptTurnStart(
+    params: unknown,
+    record: Record<string, unknown>,
+  ): Promise<unknown> {
+    if (!this.arbiter || this.threadId === null || this.bootstrapThreadId !== this.threadId) {
+      throw new CodexRpcError(
+        -32_002,
+        "Cannot start the initial Codex prompt without its bootstrap thread",
+      );
+    }
+    if (this.initialPromptStart !== null) {
+      throw new CodexRpcError(
+        -32_002,
+        "Cannot start a second Codex prompt while the initial turn/start is pending",
+      );
+    }
+    if (this.bootstrapRecovery?.disposition === "unknown") {
+      throw new CodexRpcError(-32_097, this.bootstrapRecovery.reason);
+    }
+
+    const attempt = initialThreadStartAttempt("initial turn/start", record);
+    this.initialPromptStart = attempt;
+    try {
+      return await this.withReadySession(async () => {
+        const requestThreadId =
+          typeof record.threadId === "string" ? record.threadId : null;
+        if (
+          !this.arbiter ||
+          requestThreadId === null ||
+          requestThreadId !== this.threadId ||
+          requestThreadId !== this.bootstrapThreadId
+        ) {
+          throw new CodexRpcError(
+            -32_002,
+            requestThreadId === null
+              ? "Cannot start the initial Codex prompt without an active thread id"
+              : `Cannot run Codex turn/start for inactive thread ${requestThreadId}`,
+          );
+        }
+        try {
+          const result = await this.arbiter.runInteractiveMutation(
+            "turn/start",
+            record,
+            async () => {
+              this.checkSessionMutationGuards("turn/start");
+              this.throwIfInitialThreadStartCancelled(attempt);
+              attempt.phase = "writing";
+              try {
+                return await this.requestConnected("turn/start", params);
+              } catch (error) {
+                if (disconnectedBeforeWrite(error)) {
+                  attempt.outcome = "restart";
+                  this.bootstrapRecovery = {
+                    disposition: "restart_thread_with_prompt",
+                    initialInput: record.input,
+                  };
+                } else if (error instanceof CodexRpcDisconnectedError) {
+                  const reason =
+                    "Codex backend disconnected after the initial turn/start write; " +
+                    "its outcome is unknown, so the initial prompt will not be replayed";
+                  attempt.outcome = "unknown";
+                  attempt.unknownReason = reason;
+                  this.bootstrapRecovery = {
+                    disposition: "unknown",
+                    reason,
+                    initialInput: record.input,
+                  };
+                }
+                throw error;
+              }
+            },
+          );
+          attempt.outcome = "resume";
+          this.bootstrapThreadId = null;
+          this.bootstrapRecovery = null;
+          await this.flushBeforeSessionSafely();
+          return result;
+        } catch (error) {
+          if (disconnectedBeforeWrite(error)) {
+            throw new CodexInitialThreadStartRestartRequired(
+              "Codex backend disconnected before the initial turn/start write",
+            );
+          }
+          throw error;
+        }
+      }, attempt);
+    } finally {
+      attempt.phase = "finished";
+      if (this.initialPromptStart === attempt) this.initialPromptStart = null;
+      attempt.finish();
+    }
+  }
+
+  async request(method: string, params?: unknown): Promise<unknown> {
+    if (method === "initialize") {
+      await this.rpc.start();
+      return this.rpc.initializeResult;
+    }
+    const record = paramsRecord(params);
+    if (method === "thread/start" && this.threadId === null) {
+      return await this.requestInitialThreadStart(params);
+    }
+    const requestThreadId = typeof record.threadId === "string" ? record.threadId : null;
+    if (
+      method === "turn/start" &&
+      requestThreadId !== null &&
+      requestThreadId === this.bootstrapThreadId
+    ) {
+      for (;;) {
+        await this.waitForSessionMutationGuards("turn/start");
+        try {
+          return await this.requestInitialPromptTurnStart(params, record);
+        } catch (error) {
+          if (error instanceof CodexSessionMutationReadinessChanged) continue;
+          throw error;
+        }
+      }
+    }
+    if (method === "thread/start" || method === "thread/resume" || method === "thread/fork") {
+      return await this.withReadySession(async () => {
+        if (this.threadId !== null) {
+          const targetThreadId = method === "thread/fork"
+            ? null
+            : typeof record.threadId === "string"
+              ? record.threadId
+              : null;
+          const switching =
+            method === "thread/start" ||
+            method === "thread/fork" ||
+            targetThreadId !== this.threadId;
+          if (switching) {
+            for (const guard of this.threadSwitchGuards) {
+              guard({
+                method,
+                currentThreadId: this.threadId,
+                targetThreadId,
+              });
+            }
+          }
+        }
+        const result = await this.requestConnected(method, params);
+        await this.routeThreadResponse(method, result, record);
+        return result;
+      });
+    }
+
+    if (method === "thread/rollback" || method === "thread/inject_items") {
+      return await this.withReadySession(async () => {
+        if (requestThreadId === null || requestThreadId !== this.threadId) {
+          throw new CodexRpcError(
+            -32_002,
+            requestThreadId === null
+              ? `Cannot run Codex ${method} without an active thread id`
+              : `Cannot run Codex ${method} for inactive thread ${requestThreadId}`,
+          );
+        }
+        for (const guard of this.threadSwitchGuards) {
+          guard({
+            method,
+            currentThreadId: requestThreadId,
+            targetThreadId: requestThreadId,
+          });
+        }
+        const result = await this.requestConnected(method, params);
+        if (method === "thread/rollback") {
+          await this.routeThreadResponse(method, result, record);
+        }
+        return result;
+      });
+    }
+    if (INTERACTIVE_MUTATIONS.has(method as CodexInteractiveMutation)) {
+      const mutation = method as CodexInteractiveMutation;
+      for (;;) {
+        await this.waitForSessionMutationGuards(mutation);
+        try {
+          return await this.withReadySession(async () => {
+            if (!this.arbiter || requestThreadId === null || requestThreadId !== this.threadId) {
+              throw new CodexRpcError(
+                -32_002,
+                requestThreadId === null
+                  ? `Cannot run Codex ${method} without an active thread id`
+                  : `Cannot run Codex ${method} for inactive thread ${requestThreadId}`,
+              );
+            }
+            return await this.arbiter.runInteractiveMutation(
+              mutation,
+              record,
+              () => {
+                this.checkSessionMutationGuards(mutation);
+                return this.requestConnected(method, params);
+              },
+            );
+          });
+        } catch (error) {
+          if (error instanceof CodexSessionMutationReadinessChanged) continue;
+          throw error;
+        }
+      }
+    }
+
+    await this.ensureBackendReady();
+    const result = await this.requestConnected(method, params);
+    if ((method === "thread/read" || method === "thread/resume") && requestThreadId === this.threadId) {
+      await this.routeThreadResponse(method, result, record);
+    }
+    return result;
+  }
+
+  async notify(method: string, params?: unknown): Promise<void> {
+    // The bridge owns the only backend initialize handshake. A reconnect uses
+    // the same sequence before restoring the active thread.
+    if (method === "initialized") return;
+    await this.ensureBackendReady();
+    await this.notifyConnected(method, params);
+  }
+
+  respond(id: JsonRpcId, result?: unknown, error?: JsonRpcResponse["error"]): void {
+    this.rpc.respond(id, result, error);
+  }
+
+  private async handleBackendMessage(message: JsonRpcRequest | JsonRpcNotification): Promise<void> {
+    if (!("id" in message)) {
+      const params = paramsRecord(message.params);
+      const notificationThreadId = typeof params.threadId === "string" ? params.threadId : null;
+      if (this.arbiter && notificationThreadId === this.threadId) {
+        if (message.method === "turn/started") {
+          const turn = asTurn(params.turn);
+          if (turn) {
+            this.turns.set(turn.id, turn);
+            for (const clientId of clientIds(turn)) {
+              this.turnByClientId.set(clientId, turn.id);
+              this.emitDispatch(
+                { text: "observed AgentParty input", clientUserMessageId: clientId },
+                { kind: "duplicate", turnId: turn.id },
+              );
+            }
+            await this.arbiter.observeTurnStarted(turn.id, clientIds(turn));
+          }
+        } else if (message.method === "turn/completed") {
+          const turn = asTurn(params.turn);
+          if (turn) {
+            for (const clientId of clientIds(turn)) this.turnByClientId.set(clientId, turn.id);
+            this.emitCompleted(turn);
+            await this.arbiter.observeTurnCompleted(turn.id);
+          }
+        } else if (
+          (message.method === "item/started" || message.method === "item/completed") &&
+          typeof params.turnId === "string" &&
+          isObject(params.item) &&
+          typeof params.item.id === "string" &&
+          params.item.type === "commandExecution" &&
+          params.item.source === "userShell"
+        ) {
+          if (message.method === "item/started") {
+            await this.arbiter.observeUserShellStarted(params.turnId, params.item.id);
+          } else {
+            await this.arbiter.observeUserShellCompleted(params.turnId, params.item.id);
+          }
+        } else if (
+          message.method === "thread/status/changed" &&
+          isObject(params.status) &&
+          params.status.type === "idle"
+        ) {
+          await this.arbiter.observeThreadIdle();
+        }
+      }
+    }
+    for (const listener of this.frontendListeners) {
+      void Promise.resolve(listener(message)).catch((error) => {
+        this.log(`codex-bridge: frontend notification failed: ${errorDetail(error)}`);
+      });
+    }
+  }
+
+  private recoveredBootstrapInput(initialInput: unknown): boolean {
+    if (!Array.isArray(initialInput)) return false;
+    const matches = [...this.turns.values()].flatMap((turn) =>
+      (turn.items ?? []).filter((item) =>
+        item.type === "userMessage" &&
+        item.clientId === null &&
+        sameJsonValue(item.content, initialInput)
+      )
+    );
+    return matches.length === 1;
+  }
+
+  private async restoreGeneration(state: CodexRecoveryState): Promise<void> {
+    let threadId = state.threadId;
+    if (!threadId) {
+      const initialStart = this.initialThreadStart;
+      if (initialStart?.phase === "waiting") {
+        // The old frontend request has not crossed the authoritative transport
+        // write boundary. Cancel it before advertising that replaying the
+        // original argv (including its positional prompt) is safe.
+        this.cancelInitialThreadStart(initialStart);
+      }
+      if (initialStart) await initialStart.finished;
+      this.assertRecoveryCurrent(state);
+      threadId = this.threadId;
+      if (!threadId) {
+        const disposition = this.noThreadRecovery ?? { disposition: "restart" as const };
+        const event: CodexFrontendRecovery = disposition.disposition === "unknown"
+          ? {
+            disposition: "unknown",
+            threadId: null,
+            generation: state.generation,
+            reason: disposition.reason,
+          }
+          : {
+            disposition: "restart",
+            threadId: null,
+            generation: state.generation,
+          };
+        for (const listener of this.frontendRecoveryListeners) {
+          try {
+            await listener(event);
+          } catch (error) {
+            this.log(`codex-bridge: frontend recovery listener failed: ${errorDetail(error)}`);
+          }
+          this.assertRecoveryCurrent(state);
+        }
+        this.log(
+          event.disposition === "restart"
+            ? `codex-bridge: app-server generation ${state.generation} is ready; ` +
+              "the initial thread/start was proven not written"
+            : `codex-bridge: app-server generation ${state.generation} is ready, but ` +
+              "the initial thread/start outcome is unknown",
+        );
+        return;
+      }
+    }
+    if (threadId === this.bootstrapThreadId) {
+      const initialPrompt = this.initialPromptStart;
+      if (initialPrompt?.phase === "waiting") {
+        this.cancelInitialPromptStart(initialPrompt);
+      }
+      if (initialPrompt) await initialPrompt.finished;
+      this.assertRecoveryCurrent(state);
+    }
+    await this.serializeSession(async () => {
+      this.assertRecoveryCurrent(state);
+      this.requestGenerationFence = state.generation;
+      try {
+        // A resume response is intentionally not applied on its own. Recovery
+        // becomes authoritative only after resume and the full history read
+        // both complete on this exact app-server process.
+        const resumeResult = await this.requestConnected(
+          "thread/resume",
+          { threadId },
+          state.generation,
+        );
+        this.assertRecoveryCurrent(state);
+        requireRecoveryThreadIdentity(resumeResult, threadId, "thread/resume");
+        const result = await this.requestConnected(
+          "thread/read",
+          { threadId, includeTurns: true },
+          state.generation,
+        );
+        this.assertRecoveryCurrent(state);
+        const restoredThread = requireRecoveryThreadSnapshot(result, threadId);
+        await this.attachThread(restoredThread, {
+          backendRestarted: true,
+          // A bootstrap prompt that is about to be replayed (or whose outcome
+          // is still unknown) always retains priority over pre-attach delivery.
+          deferQueuedInputs: this.bootstrapThreadId === threadId,
+        });
+        this.assertRecoveryCurrent(state);
+
+        let frontendEvent: CodexFrontendRecovery = {
+          disposition: "resume",
+          threadId,
+          generation: state.generation,
+        };
+        if (this.bootstrapThreadId === threadId) {
+          const bootstrap = this.bootstrapRecovery ?? {
+            disposition: "restart_thread_with_prompt" as const,
+          };
+          if (bootstrap.disposition === "unknown") {
+            if (this.recoveredBootstrapInput(bootstrap.initialInput)) {
+              this.bootstrapThreadId = null;
+              this.bootstrapRecovery = null;
+              await this.flushBeforeSessionSafely();
+              this.assertRecoveryCurrent(state);
+            } else {
+              frontendEvent = {
+                disposition: "unknown",
+                threadId,
+                generation: state.generation,
+                reason: bootstrap.reason,
+              };
+            }
+          } else {
+            frontendEvent = {
+              disposition: "restart_thread_with_prompt",
+              threadId,
+              generation: state.generation,
+              ...("initialInput" in bootstrap
+                ? { initialInput: bootstrap.initialInput }
+                : {}),
+            };
+          }
+        }
+
+        // A full scan can positively reconcile accepted client IDs. Absence is
+        // deliberately not treated as proof of non-execution: a hard crash may
+        // occur between an external side effect and durable history.
+        const arbiter = this.threadId === threadId ? this.arbiter : null;
+        if (arbiter) {
+          for (const input of arbiter.unresolvedUnknownInputs()) {
+            this.assertRecoveryCurrent(state);
+            if (this.unresolvedUnknownListeners.size === 0) {
+              this.log(
+                `codex-bridge: unresolved transport outcome for ${input.clientUserMessageId}; ` +
+                  "no delivery ledger is attached to record terminal-unknown",
+              );
+              continue;
+            }
+            for (const listener of this.unresolvedUnknownListeners) {
+              try {
+                await listener({ threadId, input });
+              } catch (error) {
+                this.log(
+                  `codex-bridge: could not terminalize uncertain input ` +
+                    `${input.clientUserMessageId}: ${errorDetail(error)}`,
+                );
+              }
+              this.assertRecoveryCurrent(state);
+            }
+          }
+        }
+        this.assertRecoveryCurrent(state);
+        for (const listener of this.frontendRecoveryListeners) {
+          try {
+            await listener(frontendEvent);
+          } catch (error) {
+            this.log(`codex-bridge: frontend recovery listener failed: ${errorDetail(error)}`);
+          }
+          this.assertRecoveryCurrent(state);
+        }
+        this.log(
+          `codex-bridge: restored thread ${threadId} on app-server generation ${state.generation}`,
+        );
+      } finally {
+        if (this.requestGenerationFence === state.generation) {
+          this.requestGenerationFence = null;
+        }
+      }
+    });
+  }
+}
+
+function asTurn(value: unknown): CodexTurn | null {
+  if (!isObject(value) || typeof value.id !== "string" || typeof value.status !== "string") return null;
+  if (
+    value.status !== "completed" &&
+    value.status !== "interrupted" &&
+    value.status !== "failed" &&
+    value.status !== "inProgress"
+  ) {
+    return null;
+  }
+  return {
+    id: value.id,
+    status: value.status,
+    ...(Array.isArray(value.items) ? { items: value.items.flatMap(asThreadItem) } : {}),
+  };
+}
+
+function asThreadItem(value: unknown): CodexThreadItem[] {
+  if (!isObject(value) || typeof value.type !== "string") return [];
+  return [{
+    ...value,
+    type: value.type,
+    ...(typeof value.clientId === "string" || value.clientId === null
+      ? { clientId: value.clientId }
+      : {}),
+  }];
+}
+
+function jsonRpcError(error: unknown): JsonRpcResponse["error"] {
+  if (error instanceof CodexRpcError) {
+    return {
+      code: error.code,
+      message: error.message,
+      ...(error.data === undefined ? {} : { data: error.data }),
+    };
+  }
+  if (
+    error instanceof Error &&
+    isObject(error) &&
+    typeof error.code === "number"
+  ) {
+    return {
+      code: error.code,
+      message: error.message,
+      ...("data" in error ? { data: error.data } : {}),
+    };
+  }
+  if (error instanceof CodexRpcDisconnectedError) {
+    return { code: -32_097, message: error.message };
+  }
+  return { code: -32_000, message: errorDetail(error) };
+}
+
+interface PendingFrontendServerRequest {
+  backendId: JsonRpcId;
+  frontendId: string;
+  request: JsonRpcRequest;
+}
+
+export const CODEX_TUI_WEBSOCKET_IDLE_TIMEOUT_SECONDS = 0;
+
+/**
+ * Private Unix WebSocket JSON-RPC endpoint used by
+ * `codex --remote unix://PATH`.
+ *
+ * Codex app-server stdio is newline-delimited JSON, but the Unix transport is
+ * WebSocket-framed. Keeping that boundary explicit avoids treating a raw Unix
+ * stream as the remote protocol.
+ * Exactly one TUI client is accepted at a time; a disconnected TUI can attach
+ * again without replacing the backend app-server or AgentParty delivery loop.
+ */
+export class CodexUnixJsonRpcProxy {
+  private static readonly MAX_PENDING_SERVER_REQUESTS = 128;
+  private static readonly MAX_OUTBOUND_QUEUE_ENTRIES = 1_024;
+  private static readonly MAX_OUTBOUND_QUEUE_BYTES = 1_048_576;
+  private server: ReturnType<typeof Bun.serve> | null = null;
+  private socket: ServerWebSocket<{ connectionId: string }> | null = null;
+  private frontendReady = false;
+  private frontendInvalidated = false;
+  private backendGeneration = 0;
+  private nextFrontendRequestId = 0;
+  private backpressuredSocket: ServerWebSocket<{ connectionId: string }> | null = null;
+  private readonly outboundQueue: Array<{
+    socket: ServerWebSocket<{ connectionId: string }>;
+    payload: string;
+    bytes: number;
+  }> = [];
+  private outboundQueueBytes = 0;
+  private readonly pendingServerRequestsByBackendId =
+    new Map<string, PendingFrontendServerRequest>();
+  private readonly pendingServerRequestsByFrontendId =
+    new Map<string, PendingFrontendServerRequest>();
+  private readonly unsubscribeMessages: () => void;
+  private readonly unsubscribeReset: () => void;
+  private readonly log: (line: string) => void;
+
+  constructor(
+    private readonly controller: CodexSessionController,
+    options: { log?: (line: string) => void } = {},
+  ) {
+    this.log = options.log ?? ((line) => console.error(line));
+    this.unsubscribeMessages = controller.onFrontendMessage((message) => {
+      let outbound: JsonRpcRequest | JsonRpcNotification = message;
+      if ("id" in message) {
+        const backendKey = rpcIdKey(message.id);
+        const existing = this.pendingServerRequestsByBackendId.get(backendKey);
+        if (
+          !existing &&
+          this.pendingServerRequestsByBackendId.size >=
+            CodexUnixJsonRpcProxy.MAX_PENDING_SERVER_REQUESTS
+        ) {
+          this.log(
+            `codex-bridge: refusing server request ${message.method}; TUI request replay queue is full`,
+          );
+          try {
+            this.controller.respond(message.id, undefined, {
+              code: -32_000,
+              message: "Codex TUI request replay queue is full",
+            });
+          } catch (error) {
+            this.log(`codex-bridge: failed to reject overflowed server request: ${errorDetail(error)}`);
+          }
+          return;
+        }
+        const frontendId = existing?.frontendId ??
+          `agentparty-server:${this.backendGeneration}:${++this.nextFrontendRequestId}`;
+        const pending = {
+          backendId: message.id,
+          frontendId,
+          request: { ...message, id: frontendId },
+        };
+        this.pendingServerRequestsByBackendId.set(backendKey, pending);
+        this.pendingServerRequestsByFrontendId.set(rpcIdKey(frontendId), pending);
+        if (this.frontendReady) this.send(pending.request);
+        return;
+      } else if (message.method === "serverRequest/resolved") {
+        const params = paramsRecord(message.params);
+        const requestId = params.requestId;
+        if (
+          typeof requestId === "string" ||
+          typeof requestId === "number" ||
+          requestId === null
+        ) {
+          const pending = this.pendingServerRequestsByBackendId.get(rpcIdKey(requestId));
+          if (pending) {
+            outbound = {
+              ...message,
+              params: { ...params, requestId: pending.frontendId },
+            };
+            this.pendingServerRequestsByBackendId.delete(rpcIdKey(pending.backendId));
+            this.pendingServerRequestsByFrontendId.delete(rpcIdKey(pending.frontendId));
+          }
+        }
+      }
+      if (this.frontendReady) this.send(outbound);
+    });
+    this.unsubscribeReset = controller.onFrontendReset(() => {
+      // Request IDs belong to one app-server process. A cold backend reconnect
+      // invalidates the old IDs; thread/resume will emit any still-pending
+      // server requests with IDs owned by the new process.
+      const staleRequests = [...this.pendingServerRequestsByBackendId.values()];
+      this.backendGeneration += 1;
+      this.pendingServerRequestsByBackendId.clear();
+      this.pendingServerRequestsByFrontendId.clear();
+      if (this.frontendReady) {
+        for (const pending of staleRequests) {
+          const threadId = paramsRecord(pending.request.params).threadId;
+          // app-server's lifecycle cleanup notification is the protocol-defined
+          // way to dismiss an approval/input prompt. A JSON-RPC error response
+          // would travel in the wrong direction for a backend-initiated request.
+          if (typeof threadId === "string") {
+            this.send({
+              method: "serverRequest/resolved",
+              params: { threadId, requestId: pending.frontendId },
+            });
+          }
+        }
+      }
+      if (this.socket) this.frontendInvalidated = true;
+      this.frontendReady = false;
+    });
+  }
+
+  get frontendAttached(): boolean {
+    return this.socket !== null;
+  }
+
+  /**
+   * Synchronously revoke the current frontend slot before a replacement TUI
+   * can attach. Old socket callbacks/messages are fenced by object identity;
+   * pending backend requests remain durable for replay to the replacement.
+   */
+  quiesceFrontend(reason = "Codex app-server backend restarted"): boolean {
+    const socket = this.socket;
+    if (!socket) return true;
+    this.socket = null;
+    this.frontendReady = false;
+    this.frontendInvalidated = false;
+    this.backpressuredSocket = null;
+    this.outboundQueue.length = 0;
+    this.outboundQueueBytes = 0;
+    try {
+      socket.close(1012, reason);
+    } catch (error) {
+      this.log(`codex-bridge: failed to close stale TUI socket: ${errorDetail(error)}`);
+    }
+    return this.socket === null;
+  }
+
+  private send(message: JsonRpcMessage): void {
+    if (!this.socket) return;
+    this.sendPayloadTo(this.socket, JSON.stringify(message));
+  }
+
+  private sendTo(
+    socket: ServerWebSocket<{ connectionId: string }>,
+    message: JsonRpcMessage,
+  ): void {
+    if (this.socket !== socket) return;
+    this.sendPayloadTo(socket, JSON.stringify(message));
+  }
+
+  private sendPayloadTo(
+    socket: ServerWebSocket<{ connectionId: string }>,
+    payload: string,
+  ): void {
+    if (this.socket !== socket) return;
+    if (this.backpressuredSocket === socket) {
+      const bytes = Buffer.byteLength(payload);
+      if (
+        this.outboundQueue.length >= CodexUnixJsonRpcProxy.MAX_OUTBOUND_QUEUE_ENTRIES ||
+        this.outboundQueueBytes + bytes > CodexUnixJsonRpcProxy.MAX_OUTBOUND_QUEUE_BYTES
+      ) {
+        this.failFrontendSocket(socket, "Codex bridge outbound queue exceeded its safety limit");
+        return;
+      }
+      this.outboundQueue.push({ socket, payload, bytes });
+      this.outboundQueueBytes += bytes;
+      return;
+    }
+    const status = socket.send(payload);
+    if (status === -1) {
+      // Bun already enqueued this payload. Pause subsequent writes until drain
+      // instead of duplicating the backpressured frame.
+      this.backpressuredSocket = socket;
+      return;
+    }
+    if (status === 0) {
+      // A dropped JSON-RPC response or approval must never be treated as sent.
+      // Fail the transport visibly; durable backend requests remain mapped and
+      // will replay if the user reattaches.
+      this.failFrontendSocket(socket, "Codex bridge could not deliver a JSON-RPC frame");
+    }
+  }
+
+  private failFrontendSocket(
+    socket: ServerWebSocket<{ connectionId: string }>,
+    reason: string,
+  ): void {
+    if (this.socket !== socket) return;
+    this.frontendReady = false;
+    this.backpressuredSocket = null;
+    this.outboundQueue.length = 0;
+    this.outboundQueueBytes = 0;
+    this.log(`codex-bridge: ${reason}; closing the unhealthy TUI socket`);
+    socket.close(1011, reason);
+  }
+
+  private drain(socket: ServerWebSocket<{ connectionId: string }>): void {
+    if (this.socket !== socket || this.backpressuredSocket !== socket) return;
+    this.backpressuredSocket = null;
+    while (this.outboundQueue.length > 0 && this.socket === socket) {
+      const next = this.outboundQueue.shift()!;
+      this.outboundQueueBytes -= next.bytes;
+      if (next.socket !== socket) continue;
+      this.sendPayloadTo(socket, next.payload);
+      if (this.backpressuredSocket === socket || this.socket !== socket) return;
+    }
+  }
+
+  private flushPendingServerRequests(): void {
+    if (!this.frontendReady) return;
+    for (const pending of this.pendingServerRequestsByBackendId.values()) {
+      this.send(pending.request);
+    }
+  }
+
+  private async handleLine(
+    line: string,
+    socket: ServerWebSocket<{ connectionId: string }>,
+  ): Promise<void> {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      this.sendTo(socket, { id: null, error: { code: -32_700, message: "Parse error" } });
+      return;
+    }
+    const message = asJsonRpcMessage(parsed);
+    if (!message) {
+      this.sendTo(socket, { id: null, error: { code: -32_600, message: "Invalid Request" } });
+      return;
+    }
+    if (this.frontendInvalidated && !isRpcResponse(message)) {
+      if ("id" in message) {
+        this.sendTo(socket, {
+          id: message.id,
+          error: {
+            code: -32_098,
+            message: "Codex frontend must reattach after backend recovery",
+          },
+        });
+      }
+      return;
+    }
+    if (isRpcResponse(message)) {
+      const key = rpcIdKey(message.id);
+      const pending = this.pendingServerRequestsByFrontendId.get(key);
+      if (!pending) {
+        this.log(`codex-bridge: ignored response for unknown server request ${String(message.id)}`);
+        return;
+      }
+      try {
+        this.controller.respond(pending.backendId, message.result, message.error);
+        this.pendingServerRequestsByBackendId.delete(rpcIdKey(pending.backendId));
+        this.pendingServerRequestsByFrontendId.delete(key);
+      } catch (error) {
+        this.log(`codex-bridge: failed to forward server response: ${errorDetail(error)}`);
+      }
+      return;
+    }
+    if (!("id" in message)) {
+      try {
+        await this.controller.notify(message.method, message.params);
+        if (message.method === "initialized" && this.socket === socket) {
+          this.frontendReady = true;
+          this.flushPendingServerRequests();
+        }
+      } catch (error) {
+        this.log(`codex-bridge: failed to forward TUI notification ${message.method}: ${errorDetail(error)}`);
+      }
+      return;
+    }
+    try {
+      const result = await this.controller.request(message.method, message.params);
+      this.sendTo(socket, { id: message.id, result });
+    } catch (error) {
+      this.sendTo(socket, { id: message.id, error: jsonRpcError(error) });
+    }
+  }
+
+  private accept(socket: ServerWebSocket<{ connectionId: string }>): void {
+    if (this.socket) {
+      socket.close(1008, "one Codex TUI is already attached");
+      this.log("codex-bridge: rejected a second TUI connection; one interactive writer is already attached");
+      return;
+    }
+    this.socket = socket;
+    this.frontendReady = false;
+    this.frontendInvalidated = false;
+    this.backpressuredSocket = null;
+    this.outboundQueue.length = 0;
+    this.outboundQueueBytes = 0;
+  }
+
+  async listen(socketPath: string): Promise<void> {
+    if (this.server) throw new Error("Codex Unix proxy is already listening");
+    const self = this;
+    this.server = Bun.serve<{ connectionId: string }>({
+      unix: socketPath,
+      fetch(request, server) {
+        if (server.upgrade(request, {
+          data: { connectionId: crypto.randomUUID() },
+        })) {
+          return;
+        }
+        return new Response("Codex app-server bridge requires WebSocket upgrade", { status: 426 });
+      },
+      websocket: {
+        // The official Codex remote client does not send application pings.
+        // A session bridge must remain attached while a user or approval is
+        // legitimately quiet for longer than Bun's 120-second default.
+        idleTimeout: CODEX_TUI_WEBSOCKET_IDLE_TIMEOUT_SECONDS,
+        open(socket) {
+          self.accept(socket);
+        },
+        message(socket, message) {
+          if (self.socket !== socket) return;
+          if (typeof message !== "string") {
+            self.sendTo(socket, {
+              id: null,
+              error: { code: -32_600, message: "Codex JSON-RPC frames must be text" },
+            });
+            return;
+          }
+          void self.handleLine(message, socket);
+        },
+        drain(socket) {
+          self.drain(socket);
+        },
+        close(socket) {
+          if (self.socket !== socket) return;
+          self.socket = null;
+          self.frontendReady = false;
+          self.frontendInvalidated = false;
+          self.backpressuredSocket = null;
+          self.outboundQueue.length = 0;
+          self.outboundQueueBytes = 0;
+          self.log("codex-bridge: TUI disconnected; bridge remains ready for the same session to reattach");
+        },
+      },
+    });
+    chmodSync(socketPath, 0o600);
+  }
+
+  async close(): Promise<void> {
+    this.unsubscribeMessages();
+    this.unsubscribeReset();
+    this.pendingServerRequestsByBackendId.clear();
+    this.pendingServerRequestsByFrontendId.clear();
+    this.socket?.close(1001, "AgentParty bridge stopped");
+    this.socket = null;
+    this.frontendInvalidated = false;
+    this.backpressuredSocket = null;
+    this.outboundQueue.length = 0;
+    this.outboundQueueBytes = 0;
+    const server = this.server;
+    this.server = null;
+    if (!server) return;
+    server.stop(true);
+  }
+}
+
+type BridgeConnection = Pick<Connection, "frames" | "send" | "ack" | "close" | "cursor">;
+type DeliveryUpdateFrame = Extract<ClientFrame, { type: "delivery_update" }>;
+type AuthoritativeDeliveryState =
+  Extract<ServerFrame, { type: "delivery_state" }>["delivery"]["state"];
+
+interface PendingDeliveryAck {
+  deliveryId: string;
+  state: DeliveryUpdateFrame["state"];
+  resolve: (state: AuthoritativeDeliveryState) => void;
+  reject: (error: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+interface PendingDeliveryRecovery {
+  deliveryId: string;
+  resolve: (frame: DeliveryRecoveryResultFrame) => void;
+  reject: (error: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+interface PendingCodexDelivery {
+  message: MsgFrame;
+  delivery: DirectedDelivery | null;
+  clientId: string;
+  turnId: string | null;
+  threadId: string | null;
+  renewTimer: ReturnType<typeof setInterval> | null;
+  retryTimer: ReturnType<typeof setTimeout> | null;
+  retryAttempt: number;
+  settling: boolean;
+  terminalError: string | null;
+  replyIdempotencyKey: string;
+  replyBody: string | null;
+  replySeq: number | null;
+  continuationKey: string | null;
+  continuationSourceDeliveryId: string | null;
+  /**
+   * AgentParty welcome generation that positively authorized the next
+   * pre-harness app-server write. Reconnect increments the bridge generation
+   * synchronously, invalidating every queued input before recovery awaits I/O.
+   */
+  authorizationGeneration: number;
+}
+
+interface ParkedCodexContinuation {
+  key: string;
+  workId: string;
+  continuationRef: string;
+  sourceDeliveryId: string;
+  sourceMessageSeq: number;
+  threadId: string;
+}
+
+export interface CodexAgentPartyBridgeOptions {
+  channel: string;
+  connection: BridgeConnection;
+  session: CodexSessionController;
+  postReply: (reply: {
+    body: string;
+    mentions: string[];
+    replyTo: number;
+    idempotencyKey: string;
+  }) => Promise<{ seq: number }>;
+  leaseRenewIntervalMs?: number;
+  deliveryAckTimeoutMs?: number;
+  retryDelayMs?: number;
+  recoveryJournal?: DeliveryRecoveryJournal;
+  /** Production refuses a Worker that cannot CAS-recover private ownership. */
+  requireDeliveryRecovery?: boolean;
+  /** Test/embedding seam; production uses request_id + delivery_state. */
+  confirmDeliveryUpdate?: (
+    update: DeliveryUpdateFrame,
+  ) => Promise<AuthoritativeDeliveryState | void>;
+  log?: (line: string) => void;
+}
+
+function deliveryUpdate(
+  delivery: DirectedDelivery,
+  state: "running" | "replied" | "failed",
+  extra: { replySeq?: number; error?: string } = {},
+): DeliveryUpdateFrame {
+  return {
+    type: "delivery_update",
+    delivery_id: delivery.id,
+    state,
+    attempt: delivery.attempt,
+    ...(delivery.lease_epoch === undefined ? {} : { lease_epoch: delivery.lease_epoch }),
+    ...(delivery.lease_token === undefined ? {} : { lease_token: delivery.lease_token }),
+    ...(delivery.work_id === null ? {} : { work_id: delivery.work_id }),
+    ...(delivery.continuation_ref === null ? {} : { continuation_ref: delivery.continuation_ref }),
+    ...(extra.replySeq === undefined ? {} : { reply_seq: extra.replySeq }),
+    ...(extra.error === undefined ? {} : { error: extra.error }),
+  };
+}
+
+function codexInput(
+  channel: string,
+  message: MsgFrame,
+  delivery: DirectedDelivery | null,
+): CodexBridgeInput {
+  const clientId = `agentparty:${delivery?.id ?? `${channel}:${message.seq}`}`;
+  return {
+    clientUserMessageId: clientId,
+    text:
+      `AgentParty message in #${channel} from @${message.sender.name} (seq=${message.seq}):\n\n` +
+      `${message.body}\n\n` +
+      "Answer this message in the current Codex session. AgentParty will persist the final answer as a linked reply.",
+    metadata: {
+      source: "agentparty",
+      channel,
+      seq: String(message.seq),
+      sender: message.sender.name,
+      ...(delivery === null
+        ? {}
+        : {
+            delivery_id: delivery.id,
+            delivery_cause: delivery.cause,
+            ...(delivery.work_id === null ? {} : { work_id: delivery.work_id }),
+            ...(delivery.continuation_ref === null
+              ? {}
+              : { continuation_ref: delivery.continuation_ref }),
+          }),
+    },
+  };
+}
+
+function replyIdempotencyKey(
+  channel: string,
+  message: MsgFrame,
+  delivery: DirectedDelivery | null,
+): string {
+  return delivery === null
+    ? `codex-bridge-reply:${channel}:${message.seq}`
+    : `codex-bridge-reply:${delivery.id}`;
+}
+
+function continuationKey(delivery: DirectedDelivery): string | null {
+  if (delivery.work_id === null || delivery.continuation_ref === null) return null;
+  return `${delivery.work_id}\u0000${delivery.continuation_ref}`;
+}
+
+function finalAgentText(turn: CodexTurn): string | null {
+  const agents = (turn.items ?? []).filter((item) =>
+    item.type === "agentMessage" && typeof item.text === "string"
+  );
+  const text = agents.length > 0 ? String(agents[agents.length - 1]!.text).trim() : "";
+  return text || null;
+}
+
+class CodexDeliveryConnectionReplacedError extends Error {}
+class CodexDeliveryAuthorizationStaleError extends CodexRetryableBeforeWriteError {}
+
+/**
+ * AgentParty delivery ledger for the Codex session.
+ *
+ * A successful turn/start or turn/steer is only an accepted wake. Directed
+ * delivery remains running until the corresponding turn completes and the
+ * linked REST reply succeeds.
+ */
+export class CodexAgentPartyBridge {
+  private self = "";
+  private directedDeliveryMode = false;
+  private exitCode = 0;
+  private intentionalClose = false;
+  private readonly pending = new Map<string, PendingCodexDelivery>();
+  private readonly parkedContinuations = new Map<string, ParkedCodexContinuation>();
+  private readonly completedContinuationKeys = new Set<string>();
+  private readonly settledDeliveryIds = new Set<string>();
+  private readonly seenPlainSeqs = new Set<number>();
+  private readonly deliveryAcks = new Map<string, PendingDeliveryAck>();
+  private readonly deliveryRecoveries = new Map<string, PendingDeliveryRecovery>();
+  private readonly log: (line: string) => void;
+  private readonly unsubscribeDispatch: () => void;
+  private readonly unsubscribeCompleted: () => void;
+  private readonly unsubscribeThreadSwitch: () => void;
+  private readonly unsubscribeSessionMutation: () => void;
+  private readonly unsubscribeUnresolvedUnknown: () => void;
+  private frameWork: Promise<void> = Promise.resolve();
+  private recoveryWork: Promise<void> = Promise.resolve();
+  private welcomeGeneration = 0;
+  private recoveryReadyGeneration = -1;
+  private recoveryRetryTimer: ReturnType<typeof setTimeout> | null = null;
+  private recoveryRetryAttempt = 0;
+  private recoveryPassGeneration: number | null = null;
+  private recoveryPassDirty = false;
+  private readonly recoveryReadyWaiters = new Set<{
+    resolve: () => void;
+    reject: (error: Error) => void;
+  }>();
+
+  constructor(private readonly options: CodexAgentPartyBridgeOptions) {
+    if (options.requireDeliveryRecovery === true && options.recoveryJournal === undefined) {
+      throw new Error("Codex delivery recovery requires a durable recovery journal");
+    }
+    this.log = options.log ?? ((line) => console.error(line));
+    this.unsubscribeDispatch = options.session.onDispatch((input, dispatch) => {
+      this.observeDispatch(input, dispatch);
+    });
+    this.unsubscribeCompleted = options.session.onTurnCompleted((turn) => this.settleTurn(turn));
+    this.unsubscribeThreadSwitch = options.session.onThreadSwitch(({ currentThreadId, method }) => {
+      const durableObligations = this.options.recoveryJournal?.entries().length ?? 0;
+      const obligations = Math.max(
+        durableObligations,
+        this.pending.size + this.parkedContinuations.size,
+      );
+      if (obligations === 0) return;
+      const action = method === "thread/rollback" || method === "thread/inject_items"
+        ? `mutate the history of Codex thread ${currentThreadId} with ${method}`
+        : `leave Codex thread ${currentThreadId}`;
+      throw new CodexRpcError(
+        -32_002,
+        `Cannot ${action} while ${obligations} AgentParty ` +
+        `deliver${obligations === 1 ? "y is" : "ies are"} still pending or parked`,
+      );
+    });
+    this.unsubscribeSessionMutation = options.session.onSessionMutation(({ mode }) => {
+      const durableObligations = this.options.recoveryJournal?.entries().length ?? 0;
+      if (
+        durableObligations === 0 ||
+        this.recoveryReadyGeneration === this.welcomeGeneration
+      ) {
+        return;
+      }
+      if (mode === "check") {
+        throw new CodexSessionMutationReadinessChanged(
+          "AgentParty ownership recovery changed before the Codex write boundary",
+        );
+      }
+      return this.waitForRecoveryReady();
+    });
+    this.unsubscribeUnresolvedUnknown = options.session.onUnresolvedUnknown(
+      async ({ threadId, input }) => {
+        const pending = this.pending.get(input.clientUserMessageId);
+        if (!pending) {
+          throw new Error(
+            `no AgentParty delivery ledger exists for ${input.clientUserMessageId}`,
+          );
+        }
+        pending.threadId ??= threadId;
+        if (pending.renewTimer) clearInterval(pending.renewTimer);
+        pending.renewTimer = null;
+        if (pending.delivery) {
+          this.options.recoveryJournal?.update(pending.delivery.id, {
+            threadId: pending.threadId,
+          });
+        }
+        // Absence from a cold resume/read is not proof that an after-write
+        // input had no effect. Release the arbiter's global writer fence so
+        // unrelated work can proceed, but retain the delivery WAL and exact
+        // bearer token for a later authoritative turn/completed event.
+        await this.options.session.abandonUnknownOutcome(threadId, input);
+        this.log(
+          `codex-bridge: preserved unknown post-write delivery ` +
+            `${pending.delivery?.id ?? pending.clientId} for late reply; input was not replayed`,
+        );
+      },
+    );
+  }
+
+  get pendingCount(): number {
+    return this.pending.size;
+  }
+
+  get parkedContinuationCount(): number {
+    return this.parkedContinuations.size;
+  }
+
+  /**
+   * Fence queued app-server writes at websocket transport loss, not only when
+   * the next welcome eventually arrives. Worker ownership may already have
+   * expired while Codex backend notifications continue to flush local queues.
+   */
+  handleConnectionStatus(status: "open" | "reconnecting" | "closed"): void {
+    if (status === "open") return;
+    this.welcomeGeneration += 1;
+    this.recoveryReadyGeneration = -1;
+    if (this.recoveryRetryTimer !== null) {
+      clearTimeout(this.recoveryRetryTimer);
+      this.recoveryRetryTimer = null;
+    }
+    for (const [requestId, pending] of this.deliveryAcks) {
+      clearTimeout(pending.timer);
+      pending.reject(new CodexDeliveryConnectionReplacedError(
+        "AgentParty websocket disconnected before the delivery acknowledgement arrived",
+      ));
+      this.deliveryAcks.delete(requestId);
+    }
+    for (const [requestId, pending] of this.deliveryRecoveries) {
+      clearTimeout(pending.timer);
+      pending.reject(new CodexDeliveryConnectionReplacedError(
+        "AgentParty websocket disconnected before ownership recovery completed",
+      ));
+      this.deliveryRecoveries.delete(requestId);
+    }
+    for (const pending of this.pending.values()) {
+      if (pending.renewTimer) clearInterval(pending.renewTimer);
+      pending.renewTimer = null;
+    }
+  }
+
+  private async waitForRecoveryReady(): Promise<void> {
+    if (this.recoveryReadyGeneration === this.welcomeGeneration) return;
+    await new Promise<void>((resolve, reject) => {
+      this.recoveryReadyWaiters.add({ resolve, reject });
+    });
+  }
+
+  private releaseRecoveryReadyWaiters(): void {
+    for (const waiter of this.recoveryReadyWaiters) waiter.resolve();
+    this.recoveryReadyWaiters.clear();
+  }
+
+  private rejectRecoveryReadyWaiters(error: Error): void {
+    for (const waiter of this.recoveryReadyWaiters) waiter.reject(error);
+    this.recoveryReadyWaiters.clear();
+  }
+
+  private rememberBounded<T extends string | number>(set: Set<T>, value: T): void {
+    set.add(value);
+    if (set.size <= 4_096) return;
+    const oldest = set.values().next().value as T | undefined;
+    if (oldest !== undefined) set.delete(oldest);
+  }
+
+  private clearPending(clientId: string): PendingCodexDelivery | null {
+    const pending = this.pending.get(clientId) ?? null;
+    if (!pending) return null;
+    // Invalidate synchronously before the asynchronous local queue removal.
+    // A backend notification may already be trying to flush this input.
+    pending.authorizationGeneration = -1;
+    if (pending.renewTimer) clearInterval(pending.renewTimer);
+    if (pending.retryTimer) clearTimeout(pending.retryTimer);
+    this.pending.delete(clientId);
+    void this.options.session.cancelQueued(clientId).catch((error) => {
+      this.log(
+        `codex-bridge: could not remove revoked queued input ${clientId}: ${errorDetail(error)}`,
+      );
+    });
+    return pending;
+  }
+
+  private createPending(
+    message: MsgFrame,
+    delivery: DirectedDelivery | null,
+    threadId: string | null,
+    continuation: string | null,
+    continuationSourceDeliveryId: string | null = null,
+  ): PendingCodexDelivery {
+    const input = codexInput(this.options.channel, message, delivery);
+    return {
+      message,
+      delivery,
+      clientId: input.clientUserMessageId,
+      turnId: null,
+      threadId,
+      renewTimer: null,
+      retryTimer: null,
+      retryAttempt: 0,
+      settling: false,
+      terminalError: null,
+      replyIdempotencyKey: replyIdempotencyKey(this.options.channel, message, delivery),
+      replyBody: null,
+      replySeq: null,
+      continuationKey: continuation,
+      continuationSourceDeliveryId,
+      authorizationGeneration: delivery === null ? this.welcomeGeneration : -1,
+    };
+  }
+
+  private inputForPending(pending: PendingCodexDelivery): CodexBridgeInput {
+    const input = codexInput(this.options.channel, pending.message, pending.delivery);
+    const delivery = pending.delivery;
+    const journal = this.options.recoveryJournal;
+    if (delivery === null || journal === undefined) return input;
+    const assertWriteAuthorized = () => {
+      if (
+        this.pending.get(pending.clientId) !== pending ||
+        pending.authorizationGeneration !== this.welcomeGeneration
+      ) {
+        throw new CodexDeliveryAuthorizationStaleError(
+          `AgentParty delivery ${delivery.id} must complete current ownership recovery before write`,
+        );
+      }
+    };
+    return {
+      ...input,
+      beforeWrite: () => {
+        assertWriteAuthorized();
+        const activeThreadId = this.options.session.activeThreadId;
+        if (activeThreadId === null) {
+          throw new Error(
+            `cannot write AgentParty delivery ${delivery.id} without an active Codex thread`,
+          );
+        }
+        if (pending.threadId !== null && pending.threadId !== activeThreadId) {
+          throw new Error(
+            `AgentParty delivery ${delivery.id} is bound to Codex thread ` +
+              `${pending.threadId}, not active thread ${activeThreadId}`,
+          );
+        }
+        // A delivery may be queued before the TUI attaches. Capture the
+        // authoritative thread at the single-writer boundary, before the WAL
+        // crosses harness_issued and before turn/start or turn/steer is sent.
+        // A crash after the transport write can then cold-resume this exact
+        // thread without replaying the input.
+        pending.threadId = activeThreadId;
+        try {
+          journal.update(delivery.id, {
+            phase: "harness_issued",
+            threadId: activeThreadId,
+          });
+        } catch (error) {
+          throw new CodexRetryableBeforeWriteError(
+            `could not durably authorize Codex write for ${delivery.id}: ${errorDetail(error)}`,
+            { cause: error },
+          );
+        }
+      },
+      checkWriteAuthorized: assertWriteAuthorized,
+      onWriteRejected: () => {
+        journal.update(delivery.id, {
+          phase: "running_authorized",
+          threadId: pending.threadId,
+          turnId: null,
+        });
+      },
+    };
+  }
+
+  private restorePending(entry: DeliveryRecoveryEntry): PendingCodexDelivery {
+    const clientId = `agentparty:${entry.delivery.id}`;
+    const existing = this.pending.get(clientId);
+    if (existing) {
+      if (existing.renewTimer) clearInterval(existing.renewTimer);
+      existing.renewTimer = null;
+      existing.delivery = entry.delivery;
+      existing.threadId = entry.threadId;
+      existing.turnId = entry.turnId;
+      existing.replyBody = entry.replyBody;
+      existing.replySeq = entry.replySeq;
+      existing.terminalError = entry.terminalError;
+      existing.continuationSourceDeliveryId =
+        entry.delivery.cause === "owner_answer"
+          ? entry.message.decision_response?.delivery_id ?? null
+          : null;
+      return existing;
+    }
+    const pending = this.createPending(
+      entry.message,
+      entry.delivery,
+      entry.threadId,
+      entry.delivery.cause === "owner_answer" ? continuationKey(entry.delivery) : null,
+      entry.delivery.cause === "owner_answer"
+        ? entry.message.decision_response?.delivery_id ?? null
+        : null,
+    );
+    pending.turnId = entry.turnId;
+    pending.replyBody = entry.replyBody;
+    pending.replySeq = entry.replySeq;
+    pending.terminalError = entry.terminalError;
+    this.pending.set(clientId, pending);
+    return pending;
+  }
+
+  private prepareJournalRecovery(
+    journal: DeliveryRecoveryJournal,
+    deliveryId: string,
+  ): { entry: DeliveryRecoveryEntry; frame: DeliveryRecoverFrame } {
+    const current = journal.get(deliveryId);
+    if (current === null) throw new Error(`no recovery journal entry for ${deliveryId}`);
+    // Codex task content crosses the harness boundary as soon as submit is
+    // issued. Only the two phases strictly before submit may ask Worker to
+    // revive an exact terminal_unknown assignment.
+    const replaySafe =
+      current.phase === "claimed" || current.phase === "running_authorized";
+    const frame = journal.prepareRecovery(deliveryId, {
+      replaySafe,
+      expected: {
+        phase: current.phase,
+        updatedAt: current.updatedAt,
+        attempt: current.delivery.attempt,
+        leaseEpoch: current.delivery.lease_epoch!,
+        leaseToken: current.delivery.lease_token!,
+      },
+    });
+    const prepared = journal.get(deliveryId);
+    if (prepared === null || prepared.nextLeaseToken !== frame.next_lease_token) {
+      throw new Error(`delivery ${deliveryId} changed while recovery was being prepared`);
+    }
+    return { entry: prepared, frame };
+  }
+
+  private startLeaseRenewal(pending: PendingCodexDelivery): void {
+    if (
+      pending.delivery === null ||
+      (pending.delivery.state !== "claimed" && pending.delivery.state !== "running") ||
+      pending.renewTimer !== null ||
+      pending.settling ||
+      pending.terminalError !== null ||
+      !this.pending.has(pending.clientId)
+    ) {
+      return;
+    }
+    const interval = this.options.leaseRenewIntervalMs ??
+      Math.floor(DIRECTED_DELIVERY_LEASE_MS / 2);
+    pending.renewTimer = setInterval(() => {
+      const delivery = pending.delivery;
+      if (
+        delivery === null ||
+        !this.pending.has(pending.clientId) ||
+        pending.settling ||
+        pending.terminalError !== null
+      ) {
+        return;
+      }
+      void this.confirmDeliveryUpdate(deliveryUpdate(delivery, "running")).catch((error) => {
+        this.log(
+          `codex-bridge: delivery ${delivery.id} lease renewal was not confirmed: ` +
+            errorDetail(error),
+        );
+      });
+    }, interval);
+    if (typeof pending.renewTimer.unref === "function") pending.renewTimer.unref();
+  }
+
+  private scheduleRetry(
+    pending: PendingCodexDelivery,
+    operation: () => Promise<void>,
+  ): void {
+    if (pending.retryTimer || !this.pending.has(pending.clientId)) return;
+    const base = this.options.retryDelayMs ?? 1_000;
+    const delay = Math.min(30_000, Math.max(1, base) * 2 ** Math.min(pending.retryAttempt, 5));
+    pending.retryAttempt += 1;
+    pending.retryTimer = setTimeout(() => {
+      pending.retryTimer = null;
+      void operation().catch((error) => {
+        this.log(
+          `codex-bridge: pending delivery retry failed for seq=${pending.message.seq}: ` +
+            errorDetail(error),
+        );
+      });
+    }, delay);
+    if (typeof pending.retryTimer.unref === "function") pending.retryTimer.unref();
+  }
+
+  private async confirmDeliveryUpdate(
+    update: DeliveryUpdateFrame,
+  ): Promise<AuthoritativeDeliveryState> {
+    if (this.options.confirmDeliveryUpdate) {
+      return await this.options.confirmDeliveryUpdate(update) ?? update.state;
+    }
+    const requestId = randomUUID();
+    const timeoutMs = this.options.deliveryAckTimeoutMs ?? 5_000;
+    return await new Promise<AuthoritativeDeliveryState>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.deliveryAcks.delete(requestId);
+        reject(new Error(`delivery update acknowledgement timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+      if (typeof timer.unref === "function") timer.unref();
+      this.deliveryAcks.set(requestId, {
+        deliveryId: update.delivery_id,
+        state: update.state,
+        resolve: (state) => {
+          clearTimeout(timer);
+          resolve(state);
+        },
+        reject: (error) => {
+          clearTimeout(timer);
+          reject(error);
+        },
+        timer,
+      });
+      if (!this.options.connection.send({ ...update, request_id: requestId })) {
+        this.deliveryAcks.delete(requestId);
+        clearTimeout(timer);
+        reject(new Error("AgentParty websocket is not open"));
+      }
+    });
+  }
+
+  private observeDeliveryAck(incoming: Extract<ServerFrame, { type: "delivery_state" }>): void {
+    if (!incoming.request_id) {
+      this.reconcileUnsolicitedDeliveryState(incoming);
+      return;
+    }
+    const pending = this.deliveryAcks.get(incoming.request_id);
+    if (!pending || pending.deliveryId !== incoming.delivery.id) return;
+    this.deliveryAcks.delete(incoming.request_id);
+    if (
+      incoming.delivery.state === pending.state ||
+      (pending.state === "replied" &&
+        (incoming.delivery.state === "replied" || incoming.delivery.state === "waiting_owner"))
+    ) {
+      pending.resolve(incoming.delivery.state);
+      return;
+    }
+    pending.reject(
+      new Error(`delivery state is ${incoming.delivery.state}, expected ${pending.state}`),
+    );
+  }
+
+  private reconcileUnsolicitedDeliveryState(
+    incoming: Extract<ServerFrame, { type: "delivery_state" }>,
+  ): void {
+    const journal = this.options.recoveryJournal;
+    const stored = journal?.get(incoming.delivery.id) ?? null;
+    if (!journal || !stored) return;
+    try {
+      if (incoming.delivery.state === "replied") {
+        journal.remove(incoming.delivery.id);
+        this.clearPending(`agentparty:${incoming.delivery.id}`);
+        for (const [key, parked] of this.parkedContinuations) {
+          if (parked.sourceDeliveryId === incoming.delivery.id) {
+            this.parkedContinuations.delete(key);
+          }
+        }
+        this.rememberBounded(this.settledDeliveryIds, incoming.delivery.id);
+        if (journal.entries().length === 0) {
+          this.recoveryReadyGeneration = this.welcomeGeneration;
+          this.releaseRecoveryReadyWaiters();
+        }
+        return;
+      }
+      if (incoming.delivery.state === "failed") {
+        // Public state intentionally omits terminal_reason. In particular,
+        // failed/unknown_outcome may still be replay-safe before the harness
+        // boundary or must retain late-reply debt after it. Fence writers and
+        // ask the token-bearing recovery protocol to classify it.
+        const pending = this.pending.get(`agentparty:${incoming.delivery.id}`);
+        if (pending) pending.authorizationGeneration = -1;
+        this.recoveryReadyGeneration = -1;
+        this.queueJournalRecovery(this.welcomeGeneration);
+        return;
+      }
+      if (
+        incoming.delivery.state === "waiting_owner" &&
+        stored.replyBody !== null &&
+        (stored.phase === "reply_posted" || stored.phase === "waiting_owner")
+      ) {
+        const entry = journal.update(incoming.delivery.id, {
+          phase: "waiting_owner",
+          delivery: {
+            ...stored.delivery,
+            state: "waiting_owner",
+            reply_seq: incoming.delivery.reply_seq ?? stored.replySeq,
+            lease_until: null,
+          },
+          replySeq: incoming.delivery.reply_seq ?? stored.replySeq,
+        });
+        this.clearPending(`agentparty:${incoming.delivery.id}`);
+        this.restoreParkedContinuation(entry);
+      }
+    } catch (error) {
+      this.log(
+        `codex-bridge: could not reconcile authoritative delivery state for ` +
+          `${incoming.delivery.id}: ${errorDetail(error)}`,
+      );
+      this.scheduleJournalRecoveryRetry(this.welcomeGeneration);
+    }
+  }
+
+  private async confirmDeliveryRecovery(
+    recovery: DeliveryRecoverFrame,
+  ): Promise<DeliveryRecoveryResultFrame> {
+    const timeoutMs = this.options.deliveryAckTimeoutMs ?? 5_000;
+    return await new Promise<DeliveryRecoveryResultFrame>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.deliveryRecoveries.delete(recovery.request_id);
+        reject(new Error(`delivery recovery acknowledgement timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+      if (typeof timer.unref === "function") timer.unref();
+      this.deliveryRecoveries.set(recovery.request_id, {
+        deliveryId: recovery.delivery_id,
+        resolve: (frame) => {
+          clearTimeout(timer);
+          resolve(frame);
+        },
+        reject: (error) => {
+          clearTimeout(timer);
+          reject(error);
+        },
+        timer,
+      });
+      if (!this.options.connection.send(recovery)) {
+        this.deliveryRecoveries.delete(recovery.request_id);
+        clearTimeout(timer);
+        reject(new Error("AgentParty websocket is not open"));
+      }
+    });
+  }
+
+  private observeDeliveryRecovery(incoming: DeliveryRecoveryResultFrame): void {
+    const pending = this.deliveryRecoveries.get(incoming.request_id);
+    if (!pending || pending.deliveryId !== incoming.delivery_id) return;
+    this.deliveryRecoveries.delete(incoming.request_id);
+    pending.resolve(incoming);
+  }
+
+  private async settleRecoveredReply(pending: PendingCodexDelivery): Promise<void> {
+    if (pending.replyBody === null || pending.delivery === null) return;
+    if (pending.settling || !this.pending.has(pending.clientId)) return;
+    pending.settling = true;
+    if (pending.renewTimer) clearInterval(pending.renewTimer);
+    pending.renewTimer = null;
+    try {
+      if (pending.replySeq === null) {
+        const posted = await this.options.postReply({
+          body: pending.replyBody,
+          mentions: [pending.message.sender.name],
+          replyTo: pending.message.seq,
+          idempotencyKey: pending.replyIdempotencyKey,
+        });
+        pending.replySeq = posted.seq;
+        this.options.recoveryJournal?.update(pending.delivery.id, {
+          phase: "reply_posted",
+          replyBody: pending.replyBody,
+          replySeq: posted.seq,
+        });
+      }
+      const replySeq = pending.replySeq;
+      if (replySeq === null) throw new Error("recovered reply has no persisted sequence");
+      const state = await this.confirmDeliveryUpdate(deliveryUpdate(pending.delivery, "replied", {
+        replySeq,
+      }));
+      if (state === "waiting_owner") {
+        const parked = this.parkContinuation(pending);
+        if (parked !== null) {
+          this.options.recoveryJournal?.update(pending.delivery.id, {
+            phase: "waiting_owner",
+            delivery: {
+              ...pending.delivery,
+              state: "waiting_owner",
+              reply_seq: replySeq,
+            },
+            threadId: parked.threadId,
+            turnId: pending.turnId,
+            replyBody: pending.replyBody,
+            replySeq,
+          });
+        } else {
+          // The owner answer already completed while this source ACK was in
+          // flight. Persistently discard the late source obligation before
+          // clearing pending, otherwise a restart could resurrect it.
+          this.options.recoveryJournal?.remove(pending.delivery.id);
+        }
+      } else if (state !== "replied") {
+        throw new Error(`delivery state is ${state}, expected replied or waiting_owner`);
+      }
+      if (state !== "waiting_owner") this.removeSettledJournalEntries(pending);
+      const completed = this.clearPending(pending.clientId);
+      if (completed?.delivery) {
+        this.rememberBounded(this.settledDeliveryIds, completed.delivery.id);
+        if (state === "replied") this.releaseParkedContinuation(completed);
+      }
+    } catch (error) {
+      pending.settling = false;
+      this.log(
+        `codex-bridge: recovered reply for ${pending.delivery.id} did not settle: ` +
+          errorDetail(error),
+      );
+      this.scheduleRetry(pending, async () => {
+        await this.settleRecoveredReply(pending);
+      });
+    }
+  }
+
+  private async resumeRecoveredExecution(
+    entry: DeliveryRecoveryEntry,
+    options: {
+      confirmRunning: boolean;
+      allowSubmit: boolean;
+      authorizationGeneration: number;
+    },
+  ): Promise<void> {
+    const pending = this.restorePending(entry);
+    const delivery = pending.delivery;
+    if (delivery === null) return;
+    const input = this.inputForPending(pending);
+    if (delivery.cause === "owner_answer") {
+      const binding = this.bindingFor(delivery, pending.message);
+      const activeThreadId = this.options.session.activeThreadId;
+      if (
+        binding === null ||
+        activeThreadId === null ||
+        binding.threadId !== activeThreadId
+      ) {
+        await this.failPending(
+          pending.clientId,
+          "recovered owner answer has no exact active Codex thread/work/continuation lineage",
+        );
+        return;
+      }
+      pending.threadId = binding.threadId;
+      pending.continuationKey = binding.key;
+    }
+    if (options.confirmRunning) {
+      try {
+        const state = await this.confirmDeliveryUpdate(deliveryUpdate(delivery, "running"));
+        if (state !== "running") throw new Error(`delivery state is ${state}, expected running`);
+        if (options.authorizationGeneration !== this.welcomeGeneration) return;
+        pending.delivery = { ...delivery, state: "running" };
+        this.options.recoveryJournal?.update(delivery.id, {
+          phase: "running_authorized",
+          delivery: pending.delivery,
+          threadId: pending.threadId,
+        });
+        pending.authorizationGeneration = options.authorizationGeneration;
+      } catch (error) {
+        if (error instanceof CodexDeliveryConnectionReplacedError) return;
+        await this.failPending(
+          pending.clientId,
+          `could not confirm recovered running delivery: ${errorDetail(error)}`,
+        );
+        return;
+      }
+    }
+    this.startLeaseRenewal(pending);
+    const existingTurn = this.options.session.turnForClientId(pending.clientId);
+    if (existingTurn) {
+      pending.turnId = existingTurn.id;
+      pending.threadId ??= this.options.session.activeThreadId;
+      this.options.recoveryJournal?.update(delivery.id, {
+        phase: "harness_accepted",
+        turnId: pending.turnId,
+        threadId: pending.threadId,
+      });
+      if (existingTurn.status !== "inProgress") await this.settleOne(pending, existingTurn);
+      return;
+    }
+    if (!options.allowSubmit) {
+      if (pending.renewTimer) clearInterval(pending.renewTimer);
+      pending.renewTimer = null;
+      this.log(
+        `codex-bridge: Codex input ${pending.clientId} is absent from authoritative history ` +
+          "after the harness write boundary; preserving late-reply debt without replay",
+      );
+      return;
+    }
+    try {
+      const dispatch = await this.options.session.submit(input);
+      this.observeDispatch(input, dispatch);
+    } catch (error) {
+      if (error instanceof CodexDeliveryAuthorizationStaleError) {
+        this.log(
+          `codex-bridge: recovered delivery ${delivery.id} is waiting for the current recovery generation`,
+        );
+        return;
+      }
+      await this.failPending(
+        pending.clientId,
+        `recovered Codex session injection failed: ${errorDetail(error)}`,
+      );
+    }
+  }
+
+  private scheduleJournalRecoveryRetry(generation: number): void {
+    if (
+      generation !== this.welcomeGeneration ||
+      this.recoveryRetryTimer !== null
+    ) {
+      return;
+    }
+    const delay = Math.min(30_000, 100 * 2 ** Math.min(this.recoveryRetryAttempt, 8));
+    this.recoveryRetryAttempt += 1;
+    this.recoveryRetryTimer = setTimeout(() => {
+      this.recoveryRetryTimer = null;
+      this.queueJournalRecovery(generation);
+    }, delay);
+    if (typeof this.recoveryRetryTimer.unref === "function") {
+      this.recoveryRetryTimer.unref();
+    }
+  }
+
+  private queueJournalRecovery(generation: number): void {
+    if (generation !== this.welcomeGeneration) return;
+    if (this.recoveryPassGeneration === generation) {
+      this.recoveryPassDirty = true;
+      return;
+    }
+    this.recoveryPassGeneration = generation;
+    this.recoveryPassDirty = false;
+    const preceding = this.frameWork;
+    let succeeded = false;
+    const recovery = preceding
+      .then(async () => {
+        if (generation !== this.welcomeGeneration) return;
+        await this.recoverJournalEntries(generation);
+        if (generation !== this.welcomeGeneration) return;
+        succeeded = true;
+        if (!this.recoveryPassDirty) {
+          this.recoveryReadyGeneration = generation;
+          this.releaseRecoveryReadyWaiters();
+        }
+        this.recoveryRetryAttempt = 0;
+      })
+      .catch((error) => {
+        if (generation !== this.welcomeGeneration) return;
+        this.log(`codex-bridge: delivery recovery failed: ${errorDetail(error)}`);
+        // Ownership uncertainty is a writer fence, not a best-effort warning.
+        // Control frames remain readable while this independent backoff retries.
+        this.scheduleJournalRecoveryRetry(generation);
+      })
+      .then(() => {
+        if (this.recoveryPassGeneration !== generation) return;
+        const rerun =
+          succeeded &&
+          this.recoveryPassDirty &&
+          generation === this.welcomeGeneration;
+        this.recoveryPassGeneration = null;
+        this.recoveryPassDirty = false;
+        if (rerun) this.queueJournalRecovery(generation);
+      });
+    this.recoveryWork = recovery;
+    this.frameWork = recovery;
+  }
+
+  private async recoverJournalEntries(generation = this.welcomeGeneration): Promise<void> {
+    const journal = this.options.recoveryJournal;
+    if (!journal) return;
+    for (const initial of journal.entries()) {
+      if (generation !== this.welcomeGeneration) return;
+      let prepared = this.prepareJournalRecovery(journal, initial.delivery.id);
+      let stored = prepared.entry;
+      let request = prepared.frame;
+      let outcome: DeliveryRecoveryResultFrame;
+      try {
+        outcome = await this.confirmDeliveryRecovery(request);
+      } catch (firstError) {
+        if (generation !== this.welcomeGeneration) return;
+        prepared = this.prepareJournalRecovery(journal, stored.delivery.id);
+        stored = prepared.entry;
+        request = prepared.frame;
+        try {
+          outcome = await this.confirmDeliveryRecovery(request);
+        } catch (retryError) {
+          throw new Error(
+            `could not recover delivery ${stored.delivery.id}: ` +
+              `${errorDetail(retryError)} (first: ${errorDetail(firstError)})`,
+          );
+        }
+      }
+      if (generation !== this.welcomeGeneration) return;
+      // The harness writer may have advanced this exact entry while the
+      // recovery CAS was awaiting its ACK. Classify the result from the latest
+      // durable phase, never from the pre-request replay_safe snapshot.
+      const requestSnapshot = stored;
+      const latest = journal.get(stored.delivery.id);
+      if (latest === null) continue;
+      const snapshotWasPostHarness =
+        requestSnapshot.phase === "harness_issued" ||
+        requestSnapshot.phase === "harness_accepted" ||
+        requestSnapshot.phase === "reply_posted" ||
+        requestSnapshot.replyBody !== null;
+      const latestIsPostHarness =
+        latest.phase === "harness_issued" ||
+        latest.phase === "harness_accepted" ||
+        latest.phase === "reply_posted" ||
+        latest.replyBody !== null;
+      const crossedHarnessDuringRecovery =
+        !snapshotWasPostHarness &&
+        latestIsPostHarness &&
+        (
+          latest.updatedAt !== requestSnapshot.updatedAt ||
+          latest.phase !== requestSnapshot.phase
+        );
+      stored = latest;
+
+      let entry: DeliveryRecoveryEntry;
+      let activeLease = outcome.result === "recovered";
+      if (outcome.result === "recovered") {
+        entry = journal.acceptRecovery(outcome);
+      } else {
+        if (
+          outcome.result === "terminal" &&
+          outcome.state === "waiting_owner" &&
+          (
+            stored.phase === "waiting_owner" ||
+            (
+              stored.phase === "reply_posted" &&
+              stored.replyBody !== null &&
+              stored.replySeq !== null
+            )
+          )
+        ) {
+          // Worker terminal/waiting_owner is positive authority that the
+          // linked reply/source binding still exists. A local waiting_owner WAL
+          // is never trusted by itself: another legitimate holder may have
+          // completed the owner answer while this bridge was offline.
+          entry = journal.update(stored.delivery.id, {
+            phase: "waiting_owner",
+            delivery: {
+              ...stored.delivery,
+              state: "waiting_owner",
+              reply_seq: stored.replySeq ?? stored.delivery.reply_seq,
+              lease_until: null,
+            },
+          });
+          this.clearPending(`agentparty:${stored.delivery.id}`);
+          this.restoreParkedContinuation(entry);
+          continue;
+        }
+        const postHarness =
+          stored.phase === "harness_issued" ||
+          stored.phase === "harness_accepted" ||
+          stored.phase === "reply_posted" ||
+          stored.replyBody !== null;
+        const waitingOwnerReplyDebt =
+          outcome.result === "terminal" &&
+          outcome.state === "waiting_owner" &&
+          stored.replyBody !== null;
+        if (
+          (
+            outcome.result === "terminal" &&
+            !crossedHarnessDuringRecovery &&
+            !waitingOwnerReplyDebt
+          ) ||
+          stored.phase === "failed_pending" ||
+          !postHarness
+        ) {
+          journal.remove(stored.delivery.id);
+          this.clearPending(`agentparty:${stored.delivery.id}`);
+          continue;
+        }
+        if (outcome.result === "superseded_safe") {
+          entry = journal.update(stored.delivery.id, {
+            delivery: {
+              ...stored.delivery,
+              state: outcome.state,
+              lease_until: null,
+            },
+          });
+          activeLease = false;
+          this.log(
+            `codex-bridge: preserving unexpected post-harness superseded debt ` +
+              `${stored.delivery.id} without replay`,
+          );
+        } else {
+          entry = journal.update(stored.delivery.id, {
+            delivery: { ...stored.delivery, state: outcome.state, lease_until: null },
+          });
+          activeLease = false;
+        }
+      }
+
+      const pending = this.restorePending(entry);
+      if (entry.replyBody !== null || entry.phase === "reply_posted") {
+        await this.settleRecoveredReply(pending);
+        continue;
+      }
+      if (entry.phase === "failed_pending") {
+        await this.failPending(
+          pending.clientId,
+          entry.terminalError ?? "recovered Codex delivery was pending failure",
+        );
+        continue;
+      }
+      if (entry.phase === "claimed" || entry.phase === "running_authorized") {
+        if (!activeLease) {
+          journal.remove(entry.delivery.id);
+          this.clearPending(pending.clientId);
+          continue;
+        }
+        await this.resumeRecoveredExecution(entry, {
+          confirmRunning: true,
+          allowSubmit: true,
+          authorizationGeneration: generation,
+        });
+        continue;
+      }
+      if (entry.phase === "harness_issued") {
+        await this.resumeRecoveredExecution(entry, {
+          confirmRunning: false,
+          allowSubmit: false,
+          authorizationGeneration: generation,
+        });
+        continue;
+      }
+      if (entry.phase === "harness_accepted") {
+        await this.resumeRecoveredExecution(entry, {
+          confirmRunning: false,
+          allowSubmit: false,
+          authorizationGeneration: generation,
+        });
+      }
+    }
+  }
+
+  private restoreParkedContinuation(entry: DeliveryRecoveryEntry): void {
+    const delivery = entry.delivery;
+    const key = continuationKey(delivery);
+    const activeThreadId = this.options.session.activeThreadId;
+    if (
+      key === null ||
+      delivery.work_id === null ||
+      delivery.continuation_ref === null ||
+      entry.threadId === null ||
+      entry.replySeq === null ||
+      activeThreadId !== entry.threadId
+    ) {
+      this.log(
+        `codex-bridge: retained waiting-owner journal ${delivery.id}, but its exact ` +
+          `thread/continuation affinity is not active`,
+      );
+      return;
+    }
+    this.parkedContinuations.set(key, {
+      key,
+      workId: delivery.work_id,
+      continuationRef: delivery.continuation_ref,
+      sourceDeliveryId: delivery.id,
+      sourceMessageSeq: entry.message.seq,
+      threadId: entry.threadId,
+    });
+    this.rememberBounded(this.settledDeliveryIds, delivery.id);
+  }
+
+  private continuationMatches(
+    delivery: DirectedDelivery,
+    message: MsgFrame,
+    binding: ParkedCodexContinuation,
+  ): boolean {
+    const decision = message.decision_response;
+    return (
+      decision !== undefined &&
+      delivery.work_id !== null &&
+      delivery.continuation_ref !== null &&
+      binding.workId === delivery.work_id &&
+      binding.continuationRef === delivery.continuation_ref &&
+      decision.delivery_id === binding.sourceDeliveryId &&
+      decision.origin_seq === binding.sourceMessageSeq &&
+      decision.origin_channel === this.options.channel &&
+      decision.work_id === binding.workId &&
+      decision.continuation_ref === binding.continuationRef &&
+      message.reply_to === decision.request_seq
+    );
+  }
+
+  private bindingFor(
+    delivery: DirectedDelivery,
+    message: MsgFrame,
+  ): ParkedCodexContinuation | null {
+    const key = continuationKey(delivery);
+    const decision = message.decision_response;
+    if (
+      key === null ||
+      this.completedContinuationKeys.has(key) ||
+      decision === undefined ||
+      decision.delivery_id === undefined ||
+      decision.origin_seq === undefined ||
+      delivery.work_id === null ||
+      delivery.continuation_ref === null
+    ) {
+      return null;
+    }
+    const parked = this.parkedContinuations.get(key);
+    if (parked) return this.continuationMatches(delivery, message, parked) ? parked : null;
+    for (const pending of this.pending.values()) {
+      if (
+        pending.threadId !== null &&
+        pending.delivery !== null &&
+        continuationKey(pending.delivery) === key &&
+        pending.delivery.id === decision.delivery_id &&
+        pending.message.seq === decision.origin_seq
+      ) {
+        const inFlight = {
+          key,
+          workId: delivery.work_id!,
+          continuationRef: delivery.continuation_ref!,
+          sourceDeliveryId: pending.delivery.id,
+          sourceMessageSeq: pending.message.seq,
+          threadId: pending.threadId,
+        };
+        return this.continuationMatches(delivery, message, inFlight) ? inFlight : null;
+      }
+    }
+    const activeThreadId = this.options.session.activeThreadId;
+    if (
+      activeThreadId === null ||
+      this.options.session.turnForClientId(`agentparty:${decision.delivery_id}`) === null
+    ) {
+      return null;
+    }
+    // decision_response is Worker-authored lineage. Combining its exact
+    // delivery/work/request chain with a recovered userMessage.clientId in the
+    // currently attached thread reconstructs the durable continuation after
+    // this bridge process restarts, without trusting another thread's cache.
+    const recovered = {
+      key,
+      workId: delivery.work_id,
+      continuationRef: delivery.continuation_ref,
+      sourceDeliveryId: decision.delivery_id,
+      sourceMessageSeq: decision.origin_seq,
+      threadId: activeThreadId,
+    };
+    return this.continuationMatches(delivery, message, recovered) ? recovered : null;
+  }
+
+  private parkContinuation(
+    pending: PendingCodexDelivery,
+  ): ParkedCodexContinuation | null {
+    const delivery = pending.delivery;
+    const key = delivery === null ? null : continuationKey(delivery);
+    if (
+      delivery === null ||
+      key === null ||
+      delivery.work_id === null ||
+      delivery.continuation_ref === null ||
+      pending.threadId === null
+    ) {
+      throw new Error(
+        `waiting_owner delivery ${delivery?.id ?? pending.clientId} has no complete Codex session affinity`,
+      );
+    }
+    if (this.completedContinuationKeys.has(key)) return null;
+    const parked = {
+      key,
+      workId: delivery.work_id,
+      continuationRef: delivery.continuation_ref,
+      sourceDeliveryId: delivery.id,
+      sourceMessageSeq: pending.message.seq,
+      threadId: pending.threadId,
+    };
+    this.parkedContinuations.set(key, parked);
+    return parked;
+  }
+
+  private releaseParkedContinuation(pending: PendingCodexDelivery): void {
+    if (pending.delivery?.cause !== "owner_answer" || pending.continuationKey === null) return;
+    const parked = this.parkedContinuations.get(pending.continuationKey) ?? null;
+    this.rememberBounded(this.completedContinuationKeys, pending.continuationKey);
+    this.parkedContinuations.delete(pending.continuationKey);
+    if (parked !== null) {
+      this.options.recoveryJournal?.remove(parked.sourceDeliveryId);
+    }
+  }
+
+  private removeSettledJournalEntries(pending: PendingCodexDelivery): void {
+    const delivery = pending.delivery;
+    const journal = this.options.recoveryJournal;
+    if (delivery === null || journal === undefined) return;
+    const sourceDeliveryId =
+      delivery.cause === "owner_answer"
+        ? pending.continuationSourceDeliveryId ??
+          (
+            pending.continuationKey === null
+              ? null
+              : this.parkedContinuations.get(pending.continuationKey)?.sourceDeliveryId ?? null
+          )
+        : null;
+    journal.removeMany(
+      sourceDeliveryId === null
+        ? [delivery.id]
+        : [delivery.id, sourceDeliveryId],
+    );
+  }
+
+  private async failPending(clientId: string, error: string): Promise<boolean> {
+    const pending = this.pending.get(clientId) ?? null;
+    if (!pending) return true;
+    pending.terminalError = error;
+    try {
+      if (pending.delivery) {
+        this.options.recoveryJournal?.update(pending.delivery.id, {
+          phase: "failed_pending",
+          terminalError: error,
+        });
+      }
+    } catch (journalError) {
+      // settleOne may enter with settling=true. A failed WAL write must reopen
+      // the exact same pending object and retry before any irreversible failed
+      // update is sent to Worker.
+      pending.settling = false;
+      this.log(
+        `codex-bridge: could not durably record failed delivery ` +
+          `${pending.delivery?.id ?? pending.clientId}: ${errorDetail(journalError)}`,
+      );
+      this.scheduleRetry(pending, async () => {
+        await this.failPending(clientId, pending.terminalError ?? error);
+      });
+      return false;
+    }
+    pending.settling = true;
+    if (pending.renewTimer) clearInterval(pending.renewTimer);
+    pending.renewTimer = null;
+    try {
+      if (pending.delivery) {
+        const state = await this.confirmDeliveryUpdate(deliveryUpdate(pending.delivery, "failed", {
+          error: error.slice(0, 500),
+        }));
+        if (state !== "failed") {
+          throw new Error(`delivery state is ${state}, expected failed`);
+        }
+      }
+      // Persist deletion of an owner answer and its parked source binding in
+      // one snapshot before dropping the only retryable pending object.
+      this.removeSettledJournalEntries(pending);
+      const completed = this.clearPending(clientId);
+      if (completed?.delivery) {
+        this.rememberBounded(this.settledDeliveryIds, completed.delivery.id);
+        this.releaseParkedContinuation(completed);
+      }
+      return true;
+    } catch (updateError) {
+      pending.settling = false;
+      this.log(
+        `codex-bridge: could not confirm failed delivery ` +
+          `${pending.delivery?.id ?? pending.clientId}: ${errorDetail(updateError)}`,
+      );
+      this.scheduleRetry(pending, async () => {
+        await this.failPending(clientId, pending.terminalError ?? error);
+      });
+      return false;
+    }
+  }
+
+  private observeDispatch(input: CodexBridgeInput, dispatch: CodexDispatch): void {
+    const pending = this.pending.get(input.clientUserMessageId);
+    if (!pending) return;
+    if (dispatch.turnId) {
+      pending.turnId = dispatch.turnId;
+      pending.threadId ??= this.options.session.activeThreadId;
+      this.persistHarnessAccepted(pending);
+    }
+    const recovered = this.options.session.turnForClientId(input.clientUserMessageId);
+    if (recovered) {
+      pending.turnId = recovered.id;
+      pending.threadId ??= this.options.session.activeThreadId;
+      this.persistHarnessAccepted(pending);
+      if (recovered.status !== "inProgress") void this.settleOne(pending, recovered);
+    }
+  }
+
+  private persistHarnessAccepted(pending: PendingCodexDelivery): void {
+    const delivery = pending.delivery;
+    const journal = this.options.recoveryJournal;
+    if (delivery === null || journal === undefined || pending.turnId === null) return;
+    try {
+      journal.update(delivery.id, {
+        phase: "harness_accepted",
+        turnId: pending.turnId,
+        threadId: pending.threadId,
+      });
+      pending.retryAttempt = 0;
+    } catch (error) {
+      // turn/start or turn/steer already returned an accepted turn. Failure to
+      // promote the local WAL cannot turn that external write into an ordinary
+      // failed delivery or authorize replay. Keep harness_issued debt. A later
+      // dispatch/history observation or terminal completion will advance the
+      // same journal; no retry timer is occupied by this advisory promotion,
+      // so reply/failed settlement always retains its own retry opportunity.
+      this.log(
+        `codex-bridge: could not durably promote accepted Codex turn ` +
+          `${pending.turnId} for ${delivery.id}: ${errorDetail(error)}`,
+      );
+    }
+  }
+
+  private async inject(message: MsgFrame, delivery: DirectedDelivery | null): Promise<boolean> {
+    const inputIdentity = codexInput(this.options.channel, message, delivery);
+    const existing = this.pending.get(inputIdentity.clientUserMessageId);
+    if (existing) {
+      if (existing.terminalError !== null && !existing.settling) {
+        await this.failPending(existing.clientId, existing.terminalError);
+      }
+      return true;
+    }
+    if (delivery) this.options.recoveryJournal?.recordClaim(delivery, message);
+    const ownerAnswerBinding = delivery?.cause === "owner_answer"
+      ? this.bindingFor(delivery, message)
+      : null;
+    if (delivery?.cause === "owner_answer") {
+      const activeThreadId = this.options.session.activeThreadId;
+      if (
+        ownerAnswerBinding === null ||
+        activeThreadId === null ||
+        ownerAnswerBinding.threadId !== activeThreadId
+      ) {
+        const detail = ownerAnswerBinding === null
+          ? "owner answer has no matching parked work_id/continuation_ref"
+          : `owner answer belongs to Codex thread ${ownerAnswerBinding.threadId}, ` +
+            `but the active thread is ${activeThreadId ?? "not attached"}`;
+        try {
+          const state = await this.confirmDeliveryUpdate(deliveryUpdate(delivery, "failed", {
+            error: detail.slice(0, 500),
+          }));
+          if (state !== "failed") {
+            throw new Error(`delivery state is ${state}, expected failed`);
+          }
+          const key = continuationKey(delivery);
+          const sourceDeliveryId =
+            key === null
+              ? null
+              : this.parkedContinuations.get(key)?.sourceDeliveryId ?? null;
+          this.options.recoveryJournal?.removeMany(
+            sourceDeliveryId === null
+              ? [delivery.id]
+              : [delivery.id, sourceDeliveryId],
+          );
+          this.rememberBounded(this.settledDeliveryIds, delivery.id);
+          if (key !== null) {
+            this.rememberBounded(this.completedContinuationKeys, key);
+            this.parkedContinuations.delete(key);
+          }
+        } catch (error) {
+          this.log(
+            `codex-bridge: rejected unbound owner answer ${delivery.id}, but failed state ` +
+              `was not confirmed: ${errorDetail(error)}`,
+          );
+          return false;
+        }
+        this.log(`codex-bridge: rejected owner answer ${delivery.id}: ${detail}`);
+        return true;
+      }
+    }
+    const pending = this.createPending(
+      message,
+      delivery,
+      ownerAnswerBinding?.threadId ?? this.options.session.activeThreadId,
+      delivery?.cause === "owner_answer" ? continuationKey(delivery) : null,
+      ownerAnswerBinding?.sourceDeliveryId ?? null,
+    );
+    this.pending.set(inputIdentity.clientUserMessageId, pending);
+    if (delivery) {
+      const authorizationGeneration = this.welcomeGeneration;
+      try {
+        // Thread affinity is known before the asynchronous Worker running CAS.
+        // Persist it while the entry is still replay-safe so a crash at any
+        // point before the app-server writer can cold-resume the exact session.
+        this.options.recoveryJournal?.update(delivery.id, {
+          threadId: pending.threadId,
+        });
+        const state = await this.confirmDeliveryUpdate(deliveryUpdate(delivery, "running"));
+        if (state !== "running") throw new Error(`delivery state is ${state}, expected running`);
+        if (authorizationGeneration !== this.welcomeGeneration) {
+          throw new CodexDeliveryAuthorizationStaleError(
+            `AgentParty delivery ${delivery.id} changed websocket generation during running claim`,
+          );
+        }
+        pending.delivery = { ...delivery, state: "running" };
+        this.options.recoveryJournal?.update(delivery.id, {
+          phase: "running_authorized",
+          delivery: pending.delivery,
+          threadId: pending.threadId,
+        });
+        if (this.recoveryReadyGeneration === authorizationGeneration) {
+          pending.authorizationGeneration = authorizationGeneration;
+        }
+      } catch (error) {
+        if (error instanceof CodexDeliveryConnectionReplacedError) {
+          this.log(
+            `codex-bridge: running acknowledgement for ${delivery.id} was interrupted by reconnect; ` +
+              "recovering durable ownership before Codex submission",
+          );
+          return false;
+        }
+        if (error instanceof CodexDeliveryAuthorizationStaleError) {
+          this.log(
+            `codex-bridge: running delivery ${delivery.id} is waiting for current ownership recovery`,
+          );
+          return false;
+        }
+        this.log(`codex-bridge: could not claim running delivery ${delivery.id}: ${errorDetail(error)}`);
+        await this.failPending(
+          pending.clientId,
+          `could not confirm running delivery before Codex submission: ${errorDetail(error)}`,
+        );
+        return false;
+      }
+      this.startLeaseRenewal(pending);
+    }
+    const input = this.inputForPending(pending);
+    try {
+      const dispatch = await this.options.session.submit(input);
+      this.observeDispatch(input, dispatch);
+      this.log(
+        `codex-bridge: accepted #${this.options.channel} seq=${message.seq} ` +
+          `(${dispatch.kind}${dispatch.queuePosition ? ` position=${dispatch.queuePosition}` : ""})`,
+      );
+      return true;
+    } catch (error) {
+      if (error instanceof CodexDeliveryAuthorizationStaleError) {
+        this.log(
+          `codex-bridge: delivery ${delivery?.id ?? pending.clientId} remains queued until ` +
+            "current ownership recovery completes",
+        );
+        return false;
+      }
+      await this.failPending(input.clientUserMessageId, `Codex session injection failed: ${errorDetail(error)}`);
+      this.log(`codex-bridge: failed to inject seq=${message.seq}: ${errorDetail(error)}`);
+      return false;
+    }
+  }
+
+  async handleFrame(incoming: ServerFrame): Promise<void> {
+    if (incoming.type === "delivery_recovery") {
+      this.observeDeliveryRecovery(incoming);
+      return;
+    }
+    if (incoming.type === "delivery_state") {
+      this.observeDeliveryAck(incoming);
+      return;
+    }
+    if (incoming.type === "welcome") {
+      const reconnect = this.welcomeGeneration > 0;
+      this.welcomeGeneration += 1;
+      if (this.recoveryRetryTimer !== null) {
+        clearTimeout(this.recoveryRetryTimer);
+        this.recoveryRetryTimer = null;
+      }
+      if (reconnect) {
+        for (const [requestId, pending] of this.deliveryAcks) {
+          clearTimeout(pending.timer);
+          pending.reject(new CodexDeliveryConnectionReplacedError(
+            "AgentParty websocket was replaced before the delivery acknowledgement arrived",
+          ));
+          this.deliveryAcks.delete(requestId);
+        }
+        for (const [requestId, pending] of this.deliveryRecoveries) {
+          clearTimeout(pending.timer);
+          pending.reject(new CodexDeliveryConnectionReplacedError(
+            "AgentParty websocket was replaced before ownership recovery completed",
+          ));
+          this.deliveryRecoveries.delete(requestId);
+        }
+        for (const pending of this.pending.values()) {
+          if (pending.renewTimer) clearInterval(pending.renewTimer);
+          pending.renewTimer = null;
+        }
+      }
+      this.self = incoming.self;
+      this.directedDeliveryMode = incoming.directed_delivery === "v1";
+      if (
+        this.options.requireDeliveryRecovery === true &&
+        (!this.directedDeliveryMode || incoming.delivery_recovery !== "v1")
+      ) {
+        this.exitCode = 1;
+        this.log(
+          "codex-bridge: Worker lacks directed_delivery v1 + delivery_recovery v1; " +
+            "refusing Codex submission without durable ownership",
+        );
+        this.options.connection.close();
+        return;
+      }
+      if (this.directedDeliveryMode) {
+        this.options.connection.send({ type: "delivery_adapter", adapter: "watch", op: "register" });
+        const generation = this.welcomeGeneration;
+        // Incrementing welcomeGeneration above synchronously fences every old
+        // pending input. Recovery and delivery frames are then serialized, while
+        // control ACKs remain readable by run() to avoid handshake deadlock.
+        // With no durable debt there is nothing to recover, so new assignments
+        // may be authorized immediately.
+        if ((this.options.recoveryJournal?.entries().length ?? 0) === 0) {
+          this.recoveryReadyGeneration = generation;
+          this.releaseRecoveryReadyWaiters();
+        }
+        this.queueJournalRecovery(generation);
+      }
+      this.log(
+        `codex-bridge: attached to #${this.options.channel} as @${this.self}` +
+          (this.directedDeliveryMode ? " (directed-delivery v1)" : " (legacy message fallback)"),
+      );
+      return;
+    }
+    if (incoming.type === "error") {
+      if (
+        incoming.code === "bad_request" &&
+        (this.deliveryAcks.size > 0 || this.deliveryRecoveries.size > 0)
+      ) {
+        this.log(
+          `codex-bridge: ignored uncorrelated delivery error while awaiting ACK: ${incoming.message}`,
+        );
+        return;
+      }
+      this.log(`codex-bridge: AgentParty error ${incoming.code}: ${incoming.message}`);
+      if (incoming.code === "unauthorized") this.exitCode = EXIT_AUTH;
+      else if (incoming.code === "archived") this.exitCode = EXIT_ARCHIVED;
+      else this.exitCode = 1;
+      this.options.connection.close();
+      return;
+    }
+
+    const delivery = incoming.type === "delivery" ? incoming.delivery : null;
+    const message = incoming.type === "delivery" ? incoming.message : incoming;
+    if (message.type !== "msg") return;
+    if (delivery) {
+      if (
+        delivery.target_name !== this.self ||
+        delivery.state !== "claimed" ||
+        message.sender.name === this.self ||
+        this.settledDeliveryIds.has(delivery.id)
+      ) {
+        return;
+      }
+      await this.inject(message, delivery);
+      return;
+    }
+
+    const fresh = message.seq > this.options.connection.cursor;
+    const mentioned = message.mentions.includes(this.self);
+    if (this.directedDeliveryMode && mentioned) {
+      if (fresh) this.options.connection.ack(message.seq);
+      return;
+    }
+    if (!fresh || !mentioned || message.sender.name === this.self || this.seenPlainSeqs.has(message.seq)) {
+      if (fresh) this.options.connection.ack(message.seq);
+      return;
+    }
+    if (await this.inject(message, null)) {
+      this.rememberBounded(this.seenPlainSeqs, message.seq);
+      this.options.connection.ack(message.seq);
+    }
+  }
+
+  private async settleOne(pending: PendingCodexDelivery, turn: CodexTurn): Promise<void> {
+    if (pending.terminalError !== null) {
+      if (!pending.settling) await this.failPending(pending.clientId, pending.terminalError);
+      return;
+    }
+    if (pending.settling || !this.pending.has(pending.clientId)) return;
+    pending.settling = true;
+    if (turn.status !== "completed") {
+      await this.failPending(pending.clientId, `Codex turn ${turn.id} ended with ${turn.status}`);
+      return;
+    }
+    const text = finalAgentText(turn);
+    if (!text) {
+      await this.failPending(pending.clientId, `Codex turn ${turn.id} completed without a final agent message`);
+      return;
+    }
+    if (new TextEncoder().encode(text).byteLength > BODY_LIMIT) {
+      await this.failPending(pending.clientId, `Codex final response exceeds AgentParty's ${BODY_LIMIT}-byte limit`);
+      return;
+    }
+    pending.replyBody ??= text;
+    try {
+      if (pending.delivery) {
+        this.options.recoveryJournal?.update(pending.delivery.id, {
+          replyBody: pending.replyBody,
+        });
+      }
+    } catch (error) {
+      pending.settling = false;
+      this.log(
+        `codex-bridge: could not durably record reply body for seq=${pending.message.seq}; ` +
+          `will retry before posting: ${errorDetail(error)}`,
+      );
+      this.scheduleRetry(pending, async () => {
+        await this.settleOne(pending, turn);
+      });
+      return;
+    }
+    if (pending.replySeq === null) {
+      try {
+        const posted = await this.options.postReply({
+          body: pending.replyBody,
+          mentions: [pending.message.sender.name],
+          replyTo: pending.message.seq,
+          idempotencyKey: pending.replyIdempotencyKey,
+        });
+        pending.replySeq = posted.seq;
+        if (pending.delivery) {
+          this.options.recoveryJournal?.update(pending.delivery.id, {
+            phase: "reply_posted",
+            replyBody: pending.replyBody,
+            replySeq: posted.seq,
+          });
+        }
+        pending.retryAttempt = 0;
+        if (pending.renewTimer) clearInterval(pending.renewTimer);
+        pending.renewTimer = null;
+      } catch (error) {
+        // The request may have persisted before its response was lost. Retry
+        // the same logical reply with one durable idempotency key; never mint a
+        // second key for this inbound delivery.
+        pending.settling = false;
+        this.log(
+          `codex-bridge: linked reply for seq=${pending.message.seq} has an unknown ` +
+            `persistence outcome; retrying with the same idempotency key: ${errorDetail(error)}`,
+        );
+        this.scheduleRetry(pending, async () => {
+          await this.settleOne(pending, turn);
+        });
+        return;
+      }
+    }
+
+    const replySeq = pending.replySeq;
+    if (replySeq === null) {
+      pending.settling = false;
+      return;
+    }
+    if (pending.delivery === null) {
+      this.clearPending(pending.clientId);
+      this.log(`codex-bridge: replied to seq=${pending.message.seq} with seq=${replySeq}`);
+      return;
+    }
+
+    try {
+      const state = await this.confirmDeliveryUpdate(deliveryUpdate(pending.delivery, "replied", {
+        replySeq,
+      }));
+      if (state === "waiting_owner") {
+        const parked = this.parkContinuation(pending);
+        if (parked) {
+          this.options.recoveryJournal?.update(pending.delivery.id, {
+            phase: "waiting_owner",
+            delivery: {
+              ...pending.delivery,
+              state: "waiting_owner",
+              reply_seq: replySeq,
+            },
+            threadId: parked.threadId,
+            turnId: pending.turnId,
+            replyBody: pending.replyBody,
+            replySeq,
+          });
+          this.log(
+            `codex-bridge: parked delivery ${pending.delivery.id} on Codex thread ` +
+              `${parked.threadId} until its owner answer arrives`,
+          );
+        } else {
+          this.options.recoveryJournal?.remove(pending.delivery.id);
+          this.log(
+            `codex-bridge: ignored late waiting_owner acknowledgement for completed ` +
+              `continuation ${pending.delivery.id}`,
+          );
+        }
+      } else if (state !== "replied") {
+        throw new Error(`delivery state is ${state}, expected replied or waiting_owner`);
+      }
+      if (state !== "waiting_owner") this.removeSettledJournalEntries(pending);
+      const completed = this.clearPending(pending.clientId);
+      if (completed?.delivery) {
+        this.rememberBounded(this.settledDeliveryIds, completed.delivery.id);
+        if (state === "replied") this.releaseParkedContinuation(completed);
+      }
+      this.log(`codex-bridge: replied to seq=${pending.message.seq} with seq=${replySeq}`);
+    } catch (error) {
+      pending.settling = false;
+      this.log(
+        `codex-bridge: linked reply seq=${replySeq} persisted but delivery ` +
+          `acknowledgement did not settle: ${errorDetail(error)}`,
+      );
+      this.scheduleRetry(pending, async () => {
+        await this.settleOne(pending, turn);
+      });
+    }
+  }
+
+  private async settleTurn(turn: CodexTurn): Promise<void> {
+    const matches = [...this.pending.values()].filter((pending) => pending.turnId === turn.id);
+    await Promise.all(matches.map((pending) => this.settleOne(pending, turn)));
+  }
+
+  close(): void {
+    this.intentionalClose = true;
+    this.unsubscribeDispatch();
+    this.unsubscribeCompleted();
+    this.unsubscribeThreadSwitch();
+    this.unsubscribeSessionMutation();
+    this.unsubscribeUnresolvedUnknown();
+    if (this.recoveryRetryTimer !== null) {
+      clearTimeout(this.recoveryRetryTimer);
+      this.recoveryRetryTimer = null;
+    }
+    this.rejectRecoveryReadyWaiters(new Error("Codex AgentParty bridge closed"));
+    for (const clientId of [...this.pending.keys()]) this.clearPending(clientId);
+    this.parkedContinuations.clear();
+    this.completedContinuationKeys.clear();
+    for (const [requestId, pending] of this.deliveryAcks) {
+      clearTimeout(pending.timer);
+      pending.reject(new Error("Codex AgentParty bridge closed"));
+      this.deliveryAcks.delete(requestId);
+    }
+    for (const [requestId, pending] of this.deliveryRecoveries) {
+      clearTimeout(pending.timer);
+      pending.reject(new Error("Codex AgentParty bridge closed"));
+      this.deliveryRecoveries.delete(requestId);
+    }
+    this.options.connection.close();
+  }
+
+  async run(): Promise<number> {
+    try {
+      for await (const frame of this.options.connection.frames) {
+        if (
+          frame.type === "delivery_state" ||
+          frame.type === "delivery_recovery" ||
+          frame.type === "welcome" ||
+          frame.type === "error"
+        ) {
+          await this.handleFrame(frame);
+          continue;
+        }
+        // Keep the frame reader available for the delivery_state ACK that the
+        // scheduled work may be awaiting. Work itself stays serialized so two
+        // deliveries or a reconnect recovery cannot race through the session
+        // arbiter or local ledger.
+        this.frameWork = this.frameWork
+          .then(() => this.handleFrame(frame))
+          .catch((error) => {
+            this.log(`codex-bridge: failed to process AgentParty frame: ${errorDetail(error)}`);
+          });
+      }
+    } finally {
+      this.unsubscribeDispatch();
+      this.unsubscribeCompleted();
+      this.unsubscribeThreadSwitch();
+      this.unsubscribeSessionMutation();
+      this.unsubscribeUnresolvedUnknown();
+      if (this.recoveryRetryTimer !== null) {
+        clearTimeout(this.recoveryRetryTimer);
+        this.recoveryRetryTimer = null;
+      }
+      this.rejectRecoveryReadyWaiters(new Error("Codex AgentParty frame stream stopped"));
+      for (const [requestId, pending] of this.deliveryAcks) {
+        clearTimeout(pending.timer);
+        pending.reject(new Error("Codex AgentParty frame stream stopped"));
+        this.deliveryAcks.delete(requestId);
+      }
+      for (const [requestId, pending] of this.deliveryRecoveries) {
+        clearTimeout(pending.timer);
+        pending.reject(new Error("Codex AgentParty frame stream stopped"));
+        this.deliveryRecoveries.delete(requestId);
+      }
+      await this.recoveryWork.catch(() => {});
+      await this.frameWork;
+      for (const clientId of [...this.pending.keys()]) this.clearPending(clientId);
+      this.parkedContinuations.clear();
+      this.completedContinuationKeys.clear();
+      this.options.connection.close();
+    }
+    if (this.intentionalClose) return this.exitCode;
+    return this.exitCode === 0 ? EXIT_STREAM_ENDED : this.exitCode;
+  }
+}

--- a/cli/src/codex-app-server-bridge.ts
+++ b/cli/src/codex-app-server-bridge.ts
@@ -1327,9 +1327,19 @@ export class CodexSessionController {
     params: Record<string, unknown>,
     options: { backendRestarted?: boolean; deferQueuedInputs?: boolean } = {},
   ): Promise<void> {
-    const thread = responseThread(result);
-    if (!thread) return;
     if (method === "thread/read" && params.includeTurns !== true) return;
+    const thread = responseThread(result);
+    if (thread === null) {
+      throw new Error(`${method} returned no valid thread`);
+    }
+    const expectedThreadId =
+      (method === "thread/resume" || method === "thread/read" || method === "thread/rollback") &&
+        typeof params.threadId === "string"
+        ? params.threadId
+        : null;
+    if (expectedThreadId !== null && thread.id !== expectedThreadId) {
+      throw new Error(`${method} returned thread ${thread.id}, expected ${expectedThreadId}`);
+    }
     await this.attachThread(thread, options);
   }
 
@@ -1357,11 +1367,12 @@ export class CodexSessionController {
         try {
           const result = await this.requestConnected("thread/start", params);
           const thread = responseThread(result);
-          if (thread !== null) {
-            await this.attachThread(thread, {
-              deferQueuedInputs: this.options.expectBootstrapPrompt === true,
-            });
+          if (thread === null) {
+            throw new Error("thread/start returned no valid thread");
           }
+          await this.attachThread(thread, {
+            deferQueuedInputs: this.options.expectBootstrapPrompt === true,
+          });
           this.bootstrapThreadId = this.threadId;
           this.bootstrapRecovery = {
             disposition: "restart_thread_with_prompt",

--- a/cli/src/codex-turn-arbiter.ts
+++ b/cli/src/codex-turn-arbiter.ts
@@ -1,0 +1,1339 @@
+/**
+ * Single-writer input arbiter for a Codex app-server session.
+ *
+ * Codex 0.144.x permits multiple clients to `thread/resume` the same running
+ * thread, but that does not make concurrent writers safe: `turn/start`
+ * replaces/aborts the active task. Every TUI and AgentParty input must therefore
+ * pass through one proxy-owned arbiter. This module is the protocol core for
+ * that proxy and deliberately exposes no "optimistic start" operation.
+ */
+
+export interface CodexTextInput {
+  type: "text";
+  text: string;
+  text_elements: [];
+}
+
+export interface CodexTurnStartParams {
+  threadId: string;
+  clientUserMessageId?: string | null;
+  input: CodexTextInput[];
+  responsesapiClientMetadata?: Record<string, string> | null;
+}
+
+export interface CodexTurnSteerParams {
+  threadId: string;
+  clientUserMessageId?: string | null;
+  input: CodexTextInput[];
+  responsesapiClientMetadata?: Record<string, string> | null;
+  /** Required compare-and-swap precondition in Codex app-server 0.144.x. */
+  expectedTurnId: string;
+}
+
+export interface CodexTurnTransport {
+  turnStart(params: CodexTurnStartParams): Promise<{ turn: { id: string } }>;
+  turnSteer(params: CodexTurnSteerParams): Promise<{ turnId: string }>;
+}
+
+export type CodexUnsteerableState = "review" | "compact" | "shell" | "unknown";
+export type CodexArbiterPhase =
+  | { type: "idle" }
+  | { type: "normal"; turnId: string }
+  | { type: CodexUnsteerableState; turnId: string | null };
+type CodexShellBasePhase =
+  | { type: "idle" }
+  | { type: "normal"; turnId: string }
+  | { type: "review" | "compact"; turnId: string | null };
+
+interface CodexShellLifecycle {
+  basePhase: CodexShellBasePhase;
+  baseTurnId: string | null;
+  baseCompleted: boolean;
+  baselineItemIds: ReadonlySet<string>;
+  requestOutcome: "pending" | "accepted" | "uncertain";
+  standaloneTurnId: string | null;
+  standaloneCompleted: boolean;
+  itemId: string | null;
+  itemTurnId: string | null;
+  itemCompleted: boolean;
+  itemAborted: boolean;
+}
+
+export interface CodexBridgeInput {
+  text: string;
+  /**
+   * Durable proxy-owned command id, e.g. `agentparty:<delivery-id>`.
+   * Codex stores this as ThreadItem.userMessage.clientId but does NOT dedupe it;
+   * the arbiter journal below owns deduplication.
+   */
+  clientUserMessageId: string;
+  metadata?: Record<string, string>;
+  /**
+   * Durable write-ahead boundary owned by the delivery ledger. It runs in the
+   * single-writer lane immediately before turn/start or turn/steer can write.
+   */
+  beforeWrite?: () => void | Promise<void>;
+  /**
+   * Synchronous final ownership fence, called after awaited WAL preparation
+   * and immediately before invoking the transport write.
+   */
+  checkWriteAuthorized?: () => void;
+  /** Roll the WAL back to replay-safe when transport proves no input was accepted. */
+  onWriteRejected?: () => void | Promise<void>;
+}
+
+export interface CodexDispatch {
+  kind: "started" | "steered" | "queued" | "uncertain" | "duplicate";
+  turnId?: string;
+  queuePosition?: number;
+  reason?: CodexUnsteerableState | "steer_rejected" | "start_rejected" | "unknown_outcome";
+}
+
+interface QueuedInput {
+  id: number;
+  input: CodexBridgeInput;
+  reason: CodexDispatch["reason"];
+}
+
+export type CodexInteractiveMutation =
+  | "turn/start"
+  | "turn/steer"
+  | "turn/interrupt"
+  | "review/start"
+  | "thread/compact/start"
+  | "thread/shellCommand";
+
+export class CodexBridgeQueueFullError extends Error {
+  constructor(readonly limit: number) {
+    super(`Codex session bridge queue is full (${limit})`);
+    this.name = "CodexBridgeQueueFullError";
+  }
+}
+
+/** A local pre-write durability/fence failure that is safe to retry. */
+export class CodexRetryableBeforeWriteError extends Error {
+  constructor(message: string, options: { cause?: unknown } = {}) {
+    super(message, options);
+    this.name = "CodexRetryableBeforeWriteError";
+  }
+}
+
+export class CodexInteractiveMutationBlockedError extends Error {
+  readonly code = -32_000;
+  readonly data: {
+    codexBridgeInfo: {
+      type: "interactiveMutationBlocked";
+      method: CodexInteractiveMutation;
+      reason: "phase_not_idle" | "uncertain_outcome";
+      phase: CodexArbiterPhase;
+      uncertainCount: number;
+    };
+  };
+
+  constructor(
+    method: CodexInteractiveMutation,
+    reason: "phase_not_idle" | "uncertain_outcome",
+    phase: CodexArbiterPhase,
+    uncertainCount: number,
+  ) {
+    super(
+      reason === "uncertain_outcome"
+        ? `Codex ${method} is blocked until an uncertain delivery is reconciled`
+        : `Codex ${method} is blocked while the authoritative phase is ${phase.type}`,
+    );
+    this.name = "CodexInteractiveMutationBlockedError";
+    this.data = {
+      codexBridgeInfo: {
+        type: "interactiveMutationBlocked",
+        method,
+        reason,
+        phase: { ...phase },
+        uncertainCount,
+      },
+    };
+  }
+}
+
+export interface CodexTurnArbiterOptions {
+  maxQueue?: number;
+  onQueuedDispatch?: (entry: {
+    id: number;
+    input: CodexBridgeInput;
+    dispatch: CodexDispatch;
+  }) => void | Promise<void>;
+  onQueuedError?: (entry: {
+    input: CodexBridgeInput;
+    error: unknown;
+  }) => void | Promise<void>;
+}
+
+function asTextInput(text: string): CodexTextInput {
+  return { type: "text", text, text_elements: [] };
+}
+
+function compactInput(input: CodexBridgeInput): CodexBridgeInput {
+  const text = input.text.trim();
+  if (text.length === 0) throw new Error("Codex bridge input must not be empty");
+  return {
+    text,
+    clientUserMessageId: input.clientUserMessageId,
+    ...(input.metadata === undefined ? {} : { metadata: { ...input.metadata } }),
+    ...(input.beforeWrite === undefined ? {} : { beforeWrite: input.beforeWrite }),
+    ...(input.checkWriteAuthorized === undefined
+      ? {}
+      : { checkWriteAuthorized: input.checkWriteAuthorized }),
+    ...(input.onWriteRejected === undefined ? {} : { onWriteRejected: input.onWriteRejected }),
+  };
+}
+
+type JournalState = "queued" | "accepted" | "abandoned" | "uncertain";
+
+function rpcErrorData(error: unknown): unknown {
+  if (typeof error !== "object" || error === null) return undefined;
+  const direct = (error as { data?: unknown }).data;
+  if (direct !== undefined) return direct;
+  return (error as { error?: { data?: unknown } }).error?.data;
+}
+
+/** Parse the structured app-server error; never depend on localized text. */
+export function nonSteerableTurnKind(error: unknown): "review" | "compact" | null {
+  const data = rpcErrorData(error);
+  if (typeof data !== "object" || data === null) return null;
+  const info = (data as { codexErrorInfo?: unknown }).codexErrorInfo;
+  if (typeof info !== "object" || info === null) return null;
+  const active = (info as { activeTurnNotSteerable?: unknown }).activeTurnNotSteerable;
+  if (typeof active !== "object" || active === null) return null;
+  const kind = (active as { turnKind?: unknown }).turnKind;
+  return kind === "review" || kind === "compact" ? kind : null;
+}
+
+/** A numeric JSON-RPC code proves app-server returned a rejection. */
+function isDefinitiveRpcRejection(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) return false;
+  if (typeof (error as { code?: unknown }).code === "number") return true;
+  return typeof (error as { error?: { code?: unknown } }).error?.code === "number";
+}
+
+/** The controller/RPC layer can prove a disconnect happened before any write. */
+function isProvenNotWritten(error: unknown): boolean {
+  return typeof error === "object" &&
+    error !== null &&
+    (error as { codexBridgeRequestWritten?: unknown }).codexBridgeRequestWritten === false;
+}
+
+/**
+ * All mutating methods are serialized through `exclusive`. The transport call
+ * happens while holding that lane, so two callers can never both observe idle
+ * and issue `turn/start`.
+ */
+export class CodexTurnArbiter {
+  private phase: CodexArbiterPhase = { type: "unknown", turnId: null };
+  private readonly queue: QueuedInput[] = [];
+  private nextQueueId = 1;
+  private exclusive: Promise<void> = Promise.resolve();
+  private readonly maxQueue: number;
+  private readonly journal = new Map<string, JournalState>();
+  private readonly uncertainInputs = new Map<string, CodexBridgeInput>();
+  private readonly rollbackDebts = new Map<string, () => Promise<void>>();
+  private readonly observedUserShellItemIds = new Set<string>();
+  private shellLifecycle: CodexShellLifecycle | null = null;
+  private flushRetryTimer: ReturnType<typeof setTimeout> | null = null;
+  private flushRetryAttempt = 0;
+
+  constructor(
+    private readonly threadId: string,
+    private readonly transport: CodexTurnTransport,
+    private readonly options: CodexTurnArbiterOptions = {},
+  ) {
+    this.maxQueue = options.maxQueue ?? 128;
+    if (!Number.isSafeInteger(this.maxQueue) || this.maxQueue <= 0) {
+      throw new Error("maxQueue must be a positive integer");
+    }
+  }
+
+  snapshot(): { phase: CodexArbiterPhase; queueDepth: number; uncertainCount: number } {
+    return {
+      phase: { ...this.phase },
+      queueDepth: this.queue.length,
+      uncertainCount: this.uncertainCount(),
+    };
+  }
+
+  /**
+   * Snapshot the writes whose transport outcome is still unknown. Callers must
+   * only use this after an authoritative resume + full thread/read scan: an
+   * absent client id is not proof that the original write had no side effects.
+   */
+  unresolvedUnknownInputs(): CodexBridgeInput[] {
+    return [...this.uncertainInputs.values()].map((input) => ({
+      ...input,
+      ...(input.metadata === undefined ? {} : { metadata: { ...input.metadata } }),
+    }));
+  }
+
+  private uncertainCount(): number {
+    return [...this.journal.values()].filter((state) => state === "uncertain").length;
+  }
+
+  private hasUncertainOutcome(): boolean {
+    return this.uncertainCount() > 0;
+  }
+
+  private serialize<T>(operation: () => Promise<T> | T): Promise<T> {
+    const run = this.exclusive.then(operation, operation);
+    this.exclusive = run.then(() => {}, () => {});
+    return run;
+  }
+
+  private enqueue(input: CodexBridgeInput, reason: QueuedInput["reason"]): CodexDispatch {
+    const existing = this.journal.get(input.clientUserMessageId);
+    if (existing === "accepted" || existing === "abandoned") return { kind: "duplicate" };
+    if (existing === "uncertain") return { kind: "uncertain", reason: "unknown_outcome" };
+    if (existing === "queued") {
+      const index = this.queue.findIndex((entry) =>
+        entry.input.clientUserMessageId === input.clientUserMessageId
+      );
+      return { kind: "queued", queuePosition: index < 0 ? undefined : index + 1, reason };
+    }
+    if (this.queue.length >= this.maxQueue) throw new CodexBridgeQueueFullError(this.maxQueue);
+    this.queue.push({ id: this.nextQueueId++, input, reason });
+    this.journal.set(input.clientUserMessageId, "queued");
+    return {
+      kind: "queued",
+      queuePosition: this.queue.length,
+      reason,
+    };
+  }
+
+  private startParams(input: CodexBridgeInput): CodexTurnStartParams {
+    return {
+      threadId: this.threadId,
+      input: [asTextInput(input.text)],
+      clientUserMessageId: input.clientUserMessageId,
+      ...(input.metadata === undefined ? {} : { responsesapiClientMetadata: input.metadata }),
+    };
+  }
+
+  private steerParams(input: CodexBridgeInput, expectedTurnId: string): CodexTurnSteerParams {
+    return {
+      threadId: this.threadId,
+      input: [asTextInput(input.text)],
+      expectedTurnId,
+      clientUserMessageId: input.clientUserMessageId,
+      ...(input.metadata === undefined ? {} : { responsesapiClientMetadata: input.metadata }),
+    };
+  }
+
+  private async start(input: CodexBridgeInput): Promise<CodexDispatch> {
+    // Move out of idle before awaiting I/O. The serialize lane already prevents
+    // another writer, and unknown is fail-closed if an observer reads state.
+    this.phase = { type: "unknown", turnId: null };
+    let prepared = false;
+    try {
+      await this.settleRollbackDebt(input);
+      await input.beforeWrite?.();
+      prepared = true;
+      input.checkWriteAuthorized?.();
+    } catch (error) {
+      this.phase = { type: "idle" };
+      if (error instanceof CodexRetryableBeforeWriteError) {
+        if (prepared) {
+          try {
+            await input.onWriteRejected?.();
+          } catch {
+            this.registerRollbackDebt(input);
+          }
+        }
+        const dispatch = this.enqueue(input, "start_rejected");
+        const entry = this.queue.find((queued) =>
+          queued.input.clientUserMessageId === input.clientUserMessageId
+        );
+        if (entry) this.notifyQueuedError(entry, error);
+        this.scheduleFlushRetry();
+        return dispatch;
+      }
+      throw error;
+    }
+    try {
+      const response = await this.transport.turnStart(this.startParams(input));
+      this.phase = { type: "normal", turnId: response.turn.id };
+      this.journal.set(input.clientUserMessageId, "accepted");
+      this.uncertainInputs.delete(input.clientUserMessageId);
+      return { kind: "started", turnId: response.turn.id };
+    } catch (error) {
+      this.phase = { type: "unknown", turnId: null };
+      if (isDefinitiveRpcRejection(error) || isProvenNotWritten(error)) {
+        // The transport proved no write occurred. Restore idle before the WAL
+        // rollback callback: if that local commit fails, the queued-flush
+        // retry lane can safely attempt the same input again.
+        this.phase = { type: "idle" };
+        try {
+          await input.onWriteRejected?.();
+        } catch {
+          // The app-server proved the request was not written, but replay must
+          // not happen until the delivery WAL also durably rolls back. Make
+          // that rollback the first step of the queued write boundary.
+          this.registerRollbackDebt(input);
+        }
+        const dispatch = this.enqueue(input, "start_rejected");
+        // There may be no later backend notification after a definitive
+        // pre-acceptance rejection. Keep the replay-safe input live on the
+        // bounded retry lane instead of leaving an idle arbiter permanently
+        // wedged with queued work.
+        this.scheduleFlushRetry();
+        return dispatch;
+      }
+      // Network close/timeout has an unknown outcome. Codex does not dedupe
+      // clientUserMessageId, so never retry until a resume/read reconciliation
+      // proves whether ThreadItem.userMessage.clientId exists.
+      this.journal.set(input.clientUserMessageId, "uncertain");
+      this.uncertainInputs.set(input.clientUserMessageId, input);
+      return { kind: "uncertain", reason: "unknown_outcome" };
+    }
+  }
+
+  private async steer(input: CodexBridgeInput, expectedTurnId: string): Promise<CodexDispatch> {
+    let prepared = false;
+    try {
+      await this.settleRollbackDebt(input);
+      await input.beforeWrite?.();
+      prepared = true;
+      input.checkWriteAuthorized?.();
+    } catch (error) {
+      if (error instanceof CodexRetryableBeforeWriteError) {
+        if (prepared) {
+          try {
+            await input.onWriteRejected?.();
+          } catch {
+            this.registerRollbackDebt(input);
+          }
+        }
+        const dispatch = this.enqueue(input, "steer_rejected");
+        const entry = this.queue.find((queued) =>
+          queued.input.clientUserMessageId === input.clientUserMessageId
+        );
+        if (entry) this.notifyQueuedError(entry, error);
+        this.scheduleFlushRetry();
+        return dispatch;
+      }
+      throw error;
+    }
+    try {
+      const response = await this.transport.turnSteer(this.steerParams(input, expectedTurnId));
+      // A valid response retains the same active turn. Do not accept a response
+      // as authority to change the CAS id; turn/started is the authority.
+      this.phase = { type: "normal", turnId: expectedTurnId };
+      this.journal.set(input.clientUserMessageId, "accepted");
+      this.uncertainInputs.delete(input.clientUserMessageId);
+      return { kind: "steered", turnId: response.turnId };
+    } catch (error) {
+      const turnKind = nonSteerableTurnKind(error);
+      if (turnKind !== null) {
+        this.phase = { type: turnKind, turnId: expectedTurnId };
+        try {
+          await input.onWriteRejected?.();
+        } catch {
+          this.registerRollbackDebt(input);
+        }
+        const dispatch = this.enqueue(input, turnKind);
+        if (this.rollbackDebts.has(input.clientUserMessageId)) this.scheduleFlushRetry();
+        return dispatch;
+      }
+      if (!isDefinitiveRpcRejection(error) && !isProvenNotWritten(error)) {
+        this.phase = { type: "unknown", turnId: null };
+        this.journal.set(input.clientUserMessageId, "uncertain");
+        this.uncertainInputs.set(input.clientUserMessageId, input);
+        return { kind: "uncertain", reason: "unknown_outcome" };
+      }
+      try {
+        await input.onWriteRejected?.();
+      } catch {
+        this.registerRollbackDebt(input);
+      }
+      // A stale expectedTurnId or a currently non-steerable server state must
+      // never fall through to turn/start: that would abort/replace real work.
+      this.phase = { type: "unknown", turnId: null };
+      const dispatch = this.enqueue(input, "steer_rejected");
+      if (this.rollbackDebts.has(input.clientUserMessageId)) this.scheduleFlushRetry();
+      return dispatch;
+    }
+  }
+
+  private registerRollbackDebt(input: CodexBridgeInput): void {
+    this.rollbackDebts.set(input.clientUserMessageId, async () => {
+      await input.onWriteRejected?.();
+    });
+  }
+
+  private async settleRollbackDebt(input: CodexBridgeInput): Promise<void> {
+    const rollback = this.rollbackDebts.get(input.clientUserMessageId);
+    if (!rollback) return;
+    try {
+      await rollback();
+      this.rollbackDebts.delete(input.clientUserMessageId);
+    } catch (error) {
+      throw new CodexRetryableBeforeWriteError(
+        `Codex delivery WAL rollback is still pending: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+        { cause: error },
+      );
+    }
+  }
+
+  async submit(input: CodexBridgeInput): Promise<CodexDispatch> {
+    const normalized = compactInput(input);
+    return await this.serialize(async () => {
+      const journal = this.journal.get(normalized.clientUserMessageId);
+      if (journal === "accepted" || journal === "abandoned") return { kind: "duplicate" };
+      if (journal === "uncertain") return { kind: "uncertain", reason: "unknown_outcome" };
+      if (journal === "queued") return this.enqueue(normalized, "steer_rejected");
+      if (this.queue.length > 0) {
+        const reason = this.phase.type === "idle"
+          ? "start_rejected"
+          : this.phase.type === "normal"
+            ? "steer_rejected"
+            : this.phase.type;
+        const dispatch = this.enqueue(normalized, reason);
+        if (this.phase.type === "idle" || this.phase.type === "normal") {
+          this.scheduleFlushRetry();
+        }
+        return dispatch;
+      }
+      // A transport-unknown write may already have changed the upstream turn.
+      // Until every such journal entry has positive reconciliation, no later
+      // input may start or steer. Retain it in the bounded queue instead.
+      if (this.hasUncertainOutcome()) return this.enqueue(normalized, "unknown_outcome");
+      if (this.phase.type === "idle") return await this.start(normalized);
+      if (this.phase.type === "normal") return await this.steer(normalized, this.phase.turnId);
+      return this.enqueue(normalized, this.phase.type);
+    });
+  }
+
+  /**
+   * Remove an input only while it is still locally queued and therefore has
+   * not crossed the app-server write boundary. Accepted/uncertain writes are
+   * deliberately immutable here because cancelling either would manufacture
+   * a false negative about upstream execution.
+   */
+  async cancelQueued(clientUserMessageId: string): Promise<boolean> {
+    return await this.serialize(() => {
+      if (this.journal.get(clientUserMessageId) !== "queued") return false;
+      const index = this.queue.findIndex((entry) =>
+        entry.input.clientUserMessageId === clientUserMessageId
+      );
+      if (index < 0) return false;
+      this.queue.splice(index, 1);
+      this.journal.delete(clientUserMessageId);
+      this.rollbackDebts.delete(clientUserMessageId);
+      if (this.queue.length === 0 && this.flushRetryTimer !== null) {
+        clearTimeout(this.flushRetryTimer);
+        this.flushRetryTimer = null;
+        this.flushRetryAttempt = 0;
+      }
+      return true;
+    });
+  }
+
+  /**
+   * Called by the proxy before forwarding review/start or
+   * thread/compact/start. AgentParty inputs are bounded-queued until an
+   * authoritative idle/completed event arrives.
+   */
+  async enterUnsteerable(state: "review" | "compact", turnId: string | null = null): Promise<void> {
+    await this.serialize(() => {
+      this.shellLifecycle = null;
+      this.phase = { type: state, turnId };
+    });
+  }
+
+  /**
+   * Route interactive TUI mutations through the same exclusive lane as
+   * AgentParty input. Merely serializing bytes is insufficient: a TUI
+   * `turn/start` must move the phase away from idle before the RPC write, or a
+   * concurrent AgentParty submission could also decide to start and replace it.
+   */
+  async runInteractiveMutation<T>(
+    method: CodexInteractiveMutation,
+    params: Record<string, unknown>,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    return await this.serialize(async () => {
+      if (this.rollbackDebts.size > 0) {
+        const rollbackReady = await this.flushRollbackDebts();
+        if (!rollbackReady) {
+          this.scheduleFlushRetry();
+          throw new CodexRetryableBeforeWriteError(
+            "Codex delivery WAL rollback must finish before another interactive write",
+          );
+        }
+      }
+      const previous = this.phase;
+      const previousShellLifecycle = this.shellLifecycle;
+      if (this.hasUncertainOutcome()) {
+        throw new CodexInteractiveMutationBlockedError(
+          method,
+          "uncertain_outcome",
+          previous,
+          this.uncertainCount(),
+        );
+      }
+      // app-server's turn/start replaces an active task. Only an authoritative
+      // idle phase permits forwarding it; all other phases fail locally
+      // without invoking the upstream operation.
+      if (method === "turn/start" && previous.type !== "idle") {
+        throw new CodexInteractiveMutationBlockedError(
+          method,
+          "phase_not_idle",
+          previous,
+          0,
+        );
+      }
+      if (
+        (previous.type === "shell" && method !== "turn/interrupt") ||
+        (method === "thread/shellCommand" &&
+          (previous.type === "shell" || previous.type === "unknown"))
+      ) {
+        throw new CodexInteractiveMutationBlockedError(
+          method,
+          "phase_not_idle",
+          previous,
+          0,
+        );
+      }
+      if (method === "turn/start" || method === "turn/interrupt") {
+        this.shellLifecycle = null;
+        this.phase = { type: "unknown", turnId: previous.type === "idle" ? null : previous.turnId };
+      } else if (method === "review/start" && params.delivery !== "detached") {
+        this.shellLifecycle = null;
+        this.phase = {
+          type: "review",
+          turnId: previous.type === "idle" ? null : previous.turnId,
+        };
+      } else if (method === "thread/compact/start") {
+        this.shellLifecycle = null;
+        this.phase = {
+          type: "compact",
+          turnId: previous.type === "idle" ? null : previous.turnId,
+        };
+      } else if (method === "thread/shellCommand") {
+        let basePhase: CodexShellBasePhase;
+        if (previous.type === "idle") {
+          basePhase = { type: "idle" };
+        } else if (previous.type === "normal") {
+          basePhase = { type: "normal", turnId: previous.turnId };
+        } else if (previous.type === "review" || previous.type === "compact") {
+          basePhase = { type: previous.type, turnId: previous.turnId };
+        } else {
+          throw new CodexInteractiveMutationBlockedError(
+            method,
+            "phase_not_idle",
+            previous,
+            0,
+          );
+        }
+        this.shellLifecycle = {
+          basePhase,
+          baseTurnId: "turnId" in basePhase ? basePhase.turnId : null,
+          baseCompleted: basePhase.type === "idle",
+          baselineItemIds: new Set(this.observedUserShellItemIds),
+          requestOutcome: "pending",
+          standaloneTurnId: null,
+          standaloneCompleted: false,
+          itemId: null,
+          itemTurnId: null,
+          itemCompleted: false,
+          itemAborted: false,
+        };
+        this.phase = {
+          type: "shell",
+          turnId: "turnId" in basePhase ? basePhase.turnId : null,
+        };
+      }
+
+      try {
+        const response = await operation();
+        if (method === "turn/start") {
+          const turnId = responseTurnId(response);
+          this.phase = turnId === null
+            ? { type: "unknown", turnId: null }
+            : { type: "normal", turnId };
+          if (turnId !== null) await this.flushIntoNormalTurn();
+        } else if (method === "turn/steer") {
+          const expected = typeof params.expectedTurnId === "string" ? params.expectedTurnId : null;
+          const turnId = responseTurnId(response) ?? expected;
+          this.phase = turnId === null
+            ? { type: "unknown", turnId: null }
+            : { type: "normal", turnId };
+          if (turnId !== null) await this.flushIntoNormalTurn();
+        } else if (method === "review/start" && params.delivery !== "detached") {
+          const turnId = responseTurnId(response);
+          this.phase = { type: "review", turnId };
+        } else if (method === "thread/shellCommand" && this.shellLifecycle) {
+          this.shellLifecycle.requestOutcome = "accepted";
+        }
+        return response;
+      } catch (error) {
+        const turnKind = nonSteerableTurnKind(error);
+        if (error instanceof CodexRetryableBeforeWriteError) {
+          this.phase = previous;
+          this.shellLifecycle = previousShellLifecycle;
+        } else if (isProvenNotWritten(error)) {
+          this.phase = previous;
+          this.shellLifecycle = previousShellLifecycle;
+        } else if (
+          method === "thread/shellCommand" &&
+          isDefinitiveRpcRejection(error)
+        ) {
+          this.phase = previous;
+          this.shellLifecycle = previousShellLifecycle;
+        } else if (method === "thread/shellCommand" && this.shellLifecycle) {
+          // The operation may already be queued in core even though its RPC
+          // response was lost. Preserve the exact shell lifecycle across
+          // recovery; projecting an in-progress shell turn as normal would let
+          // AgentParty steer into a task that never runs the model.
+          this.shellLifecycle.requestOutcome = "uncertain";
+        } else if (turnKind !== null) {
+          this.shellLifecycle = null;
+          this.phase = {
+            type: turnKind,
+            turnId: previous.type === "idle" ? null : previous.turnId,
+          };
+        } else if (
+          isDefinitiveRpcRejection(error) &&
+          (
+            method === "review/start" ||
+            method === "thread/compact/start"
+          )
+        ) {
+          // A rejected review/compact request never entered the special turn;
+          // restore the phase observed while holding the same writer lane.
+          this.phase = previous;
+          this.shellLifecycle = previousShellLifecycle;
+        } else {
+          // A start/steer/interrupt rejection can prove our turn snapshot
+          // stale, while a transport close has an unknown outcome. Both must
+          // resync before any new start is allowed.
+          this.shellLifecycle = null;
+          this.phase = { type: "unknown", turnId: null };
+        }
+        throw error;
+      }
+    });
+  }
+
+  /**
+   * Bootstrap from thread/resume. A running thread is steerable only when the
+   * response includes exactly one identifiable in-progress turn. "active" by
+   * itself is insufficient and remains fail-closed.
+   */
+  async observeResume(response: {
+    thread: {
+      status: { type: "idle" | "active" | "notLoaded" | "systemError" };
+      turns: Array<{
+        id: string;
+        status: "completed" | "interrupted" | "failed" | "inProgress";
+        items?: Array<{
+          type: string;
+          id?: string;
+          clientId?: string | null;
+          source?: string;
+          status?: string;
+        }>;
+      }>;
+    };
+  }, options: { backendRestarted?: boolean } = {}): Promise<void> {
+    await this.serialize(async () => {
+      const acceptedClientIds = response.thread.turns.flatMap((turn) =>
+          (turn.items ?? [])
+            .filter((item) => item.type === "userMessage" && typeof item.clientId === "string")
+            .map((item) => item.clientId as string)
+        );
+      const userShellItems = response.thread.turns.flatMap((turn) =>
+        (turn.items ?? []).flatMap((item) =>
+          item.type === "commandExecution" &&
+            item.source === "userShell" &&
+            typeof item.id === "string"
+            ? [{
+              itemId: item.id,
+              itemStatus: item.status,
+              turnId: turn.id,
+              turnStatus: turn.status,
+            }]
+            : []
+        )
+      );
+      this.reconcileAcceptedClientIds(acceptedClientIds);
+      if (this.shellLifecycle) {
+        const shell = this.shellLifecycle;
+        const historyMatch = shell.itemId === null
+          ? (() => {
+            const candidates = userShellItems.filter((item) =>
+              !shell.baselineItemIds.has(item.itemId)
+            );
+            return candidates.length === 1 ? candidates[0]! : null;
+          })()
+          : userShellItems.find((item) =>
+            item.itemId === shell.itemId && item.turnId === shell.itemTurnId
+          ) ?? null;
+        if (historyMatch !== null) {
+          if (shell.itemId === null) {
+            shell.itemId = historyMatch.itemId;
+            shell.itemTurnId = historyMatch.turnId;
+            if (shell.basePhase.type === "idle") {
+              shell.standaloneTurnId ??= historyMatch.turnId;
+            } else if (shell.baseTurnId === null) {
+              shell.baseTurnId = historyMatch.turnId;
+            } else if (shell.baseTurnId !== historyMatch.turnId) {
+              shell.standaloneTurnId ??= historyMatch.turnId;
+            }
+          }
+          if (
+            historyMatch.itemStatus === "completed" ||
+            historyMatch.itemStatus === "failed" ||
+            historyMatch.itemStatus === "declined"
+          ) {
+            shell.itemCompleted = true;
+          }
+          if (historyMatch.turnStatus !== "inProgress") {
+            if (shell.standaloneTurnId === historyMatch.turnId) {
+              shell.standaloneCompleted = true;
+            } else if (shell.baseTurnId === historyMatch.turnId) {
+              shell.baseCompleted = true;
+            }
+          }
+        }
+        if (
+          historyMatch === null &&
+          shell.itemId !== null &&
+          shell.itemTurnId !== null &&
+          options.backendRestarted === true &&
+          response.thread.status.type === "idle"
+        ) {
+          const rememberedTurn = response.thread.turns.find((turn) =>
+            turn.id === shell.itemTurnId
+          );
+          if (rememberedTurn && rememberedTurn.status !== "inProgress") {
+            // Codex 0.144.x history is intentionally lossy for user-shell
+            // commandExecution items. After an app-server crash, a started
+            // shell can rehydrate as an interrupted/failed turn with
+            // itemsView=full but no command item. The exact terminal turn plus
+            // authoritative idle proves the shell can no longer own a writer;
+            // record it as aborted (never successful) and release the fence.
+            shell.itemCompleted = true;
+            shell.itemAborted = true;
+            if (shell.standaloneTurnId === rememberedTurn.id) {
+              shell.standaloneCompleted = true;
+            } else if (shell.baseTurnId === rememberedTurn.id) {
+              shell.baseCompleted = true;
+            }
+          }
+        }
+        for (const item of userShellItems) this.observedUserShellItemIds.add(item.itemId);
+        if (response.thread.status.type === "idle") {
+          // A reconnect can race both the shell request and stale idle
+          // notifications from the base turn. Without the exact
+          // commandExecution lifecycle, idle alone cannot prove that the
+          // user-shell operation completed.
+          if (shell.basePhase.type !== "idle") shell.baseCompleted = true;
+          if (shell.standaloneTurnId !== null) shell.standaloneCompleted = true;
+          this.phase = {
+            type: "shell",
+            turnId: shell.standaloneTurnId ?? shell.baseTurnId,
+          };
+          if (shell.itemCompleted && (
+            shell.standaloneTurnId !== null
+              ? shell.standaloneCompleted
+              : shell.basePhase.type !== "idle" && shell.baseCompleted
+          )) {
+            await this.finishShellIdle();
+          } else if (
+            shell.itemCompleted &&
+            shell.standaloneTurnId === null &&
+            !shell.baseCompleted
+          ) {
+            await this.restoreShellBase();
+          }
+          return;
+        }
+        if (response.thread.status.type === "active") {
+          const running = response.thread.turns.filter((turn) => turn.status === "inProgress");
+          if (running.length === 1) {
+            const runningTurnId = running[0]!.id;
+            if (
+              shell.basePhase.type === "idle" ||
+              (shell.baseTurnId !== null && shell.baseTurnId !== runningTurnId)
+            ) {
+              shell.standaloneTurnId ??= runningTurnId;
+            } else if (shell.baseTurnId === null) {
+              shell.baseTurnId = runningTurnId;
+            }
+            this.phase = {
+              type: "shell",
+              turnId: shell.standaloneTurnId ?? shell.baseTurnId,
+            };
+            if (shell.itemCompleted) {
+              if (shell.standaloneTurnId !== null) {
+                if (shell.standaloneCompleted) await this.finishShellIdle();
+              } else if (shell.baseCompleted) {
+                await this.finishShellIdle();
+              } else {
+                await this.restoreShellBase();
+              }
+            }
+            return;
+          }
+        }
+        // The request may have reached core even when recovery cannot identify
+        // its exact turn. Preserve the shell fence instead of projecting an
+        // ordinary steerable turn.
+        this.phase = { type: "shell", turnId: shell.standaloneTurnId ?? shell.baseTurnId };
+        return;
+      }
+      for (const item of userShellItems) this.observedUserShellItemIds.add(item.itemId);
+      if (response.thread.status.type === "idle") {
+        this.phase = { type: "idle" };
+        await this.flushFromIdle();
+        return;
+      }
+      if (response.thread.status.type === "active") {
+        const running = response.thread.turns.filter((turn) => turn.status === "inProgress");
+        if (running.length === 1) {
+          const active = running[0]!;
+          const items = active.items ?? [];
+          let lastEnteredReview = -1;
+          let lastExitedReview = -1;
+          for (let index = 0; index < items.length; index += 1) {
+            if (items[index]!.type === "enteredReviewMode") lastEnteredReview = index;
+            if (items[index]!.type === "exitedReviewMode") lastExitedReview = index;
+          }
+          const specialBase = lastEnteredReview > lastExitedReview
+            ? "review"
+            : items.some((item) => item.type === "contextCompaction")
+              ? "compact"
+              : null;
+          const activeShellItems = items.filter((item) =>
+            item.type === "commandExecution" &&
+            item.source === "userShell" &&
+            typeof item.id === "string"
+          );
+          const inProgressShellItems = activeShellItems.filter((item) =>
+            item.status === "inProgress"
+          );
+          const hasAmbiguousShellStatus = activeShellItems.some((item) =>
+            item.status !== "inProgress" &&
+            item.status !== "completed" &&
+            item.status !== "failed" &&
+            item.status !== "declined"
+          );
+          const coldShellItem = inProgressShellItems.length === 1
+            ? inProgressShellItems[0]!
+            : inProgressShellItems.length === 0 &&
+                activeShellItems.length === 1 &&
+                !hasAmbiguousShellStatus
+              ? activeShellItems[0]!
+              : null;
+          if (coldShellItem !== null) {
+            const shellItem = coldShellItem;
+            const itemCompleted =
+              shellItem.status === "completed" ||
+              shellItem.status === "failed" ||
+              shellItem.status === "declined";
+            const hasModelTurnEvidence = items.some((item) =>
+              item.type !== "commandExecution" &&
+              item.type !== "enteredReviewMode" &&
+              item.type !== "exitedReviewMode" &&
+              item.type !== "contextCompaction"
+            );
+            const basePhase: CodexShellBasePhase = specialBase !== null
+              ? { type: specialBase, turnId: active.id }
+              : hasModelTurnEvidence
+                ? { type: "normal", turnId: active.id }
+                : { type: "idle" };
+            // A completed auxiliary item can immediately project its still
+            // active base phase. A standalone shell owns the turn until the
+            // turn itself completes, even if its command item already did.
+            if (!itemCompleted || basePhase.type === "idle") {
+              this.shellLifecycle = {
+                basePhase,
+                baseTurnId: basePhase.type === "idle" ? null : active.id,
+                baseCompleted: basePhase.type === "idle",
+                baselineItemIds: new Set(
+                  [...this.observedUserShellItemIds].filter((id) => id !== shellItem.id),
+                ),
+                requestOutcome: "accepted",
+                standaloneTurnId: basePhase.type === "idle" ? active.id : null,
+                standaloneCompleted: false,
+                itemId: shellItem.id!,
+                itemTurnId: active.id,
+                itemCompleted,
+                itemAborted: false,
+              };
+              this.phase = { type: "shell", turnId: active.id };
+              return;
+            }
+          }
+          if (
+            inProgressShellItems.length > 1 ||
+            hasAmbiguousShellStatus ||
+            (
+              inProgressShellItems.length === 0 &&
+              activeShellItems.length > 1 &&
+              !items.some((item) =>
+                item.type !== "commandExecution" &&
+                item.type !== "enteredReviewMode" &&
+                item.type !== "exitedReviewMode" &&
+                item.type !== "contextCompaction"
+              )
+            )
+          ) {
+            // Full ThreadItem history is authoritative, but multiple current
+            // shell candidates (or a status outside the 0.144.x schema) is not
+            // enough information to safely classify the turn as steerable.
+            this.phase = { type: "unknown", turnId: null };
+            return;
+          }
+          if (specialBase !== null) {
+            this.phase = { type: specialBase, turnId: active.id };
+            return;
+          }
+          this.phase = { type: "normal", turnId: active.id };
+          await this.flushIntoNormalTurn();
+          return;
+        }
+      }
+      this.phase = { type: "unknown", turnId: null };
+    });
+  }
+
+  async observeTurnStarted(turnId: string, clientIds: string[] = []): Promise<void> {
+    await this.serialize(async () => {
+      this.reconcileAcceptedClientIds(clientIds);
+      // A review/compact request remains non-steerable even if it internally
+      // emits turn/started. Only its completion/idle event opens the queue.
+      if (
+        this.phase.type === "review" ||
+        this.phase.type === "compact" ||
+        this.phase.type === "shell"
+      ) {
+        if (this.phase.type === "shell") {
+          const shell = this.shellLifecycle;
+          if (!shell) {
+            this.phase = { type: "shell", turnId };
+            return;
+          }
+          if (shell.basePhase.type === "idle") {
+            shell.standaloneTurnId ??= turnId;
+          } else if (shell.baseTurnId === null) {
+            // review/compact can be entered before their turn/started event.
+            shell.baseTurnId = turnId;
+          } else if (shell.baseTurnId !== turnId) {
+            shell.standaloneTurnId ??= turnId;
+          }
+          this.phase = {
+            type: "shell",
+            turnId: shell.standaloneTurnId ?? shell.baseTurnId,
+          };
+          return;
+        }
+        this.phase = { ...this.phase, turnId };
+        return;
+      }
+      this.phase = { type: "normal", turnId };
+      await this.flushIntoNormalTurn();
+    });
+  }
+
+  async observeTurnCompleted(turnId: string): Promise<void> {
+    await this.serialize(async () => {
+      if (this.phase.type === "shell" && this.shellLifecycle) {
+        const shell = this.shellLifecycle;
+        if (shell.standaloneTurnId === turnId) {
+          shell.standaloneCompleted = true;
+          if (shell.itemCompleted) await this.finishShellIdle();
+          return;
+        }
+        if (shell.baseTurnId === turnId) {
+          shell.baseCompleted = true;
+          if (shell.itemCompleted && shell.standaloneTurnId === null) {
+            await this.finishShellIdle();
+          }
+        }
+        return;
+      }
+      // In unknown state a completed event alone cannot prove the thread is
+      // idle: another turn may already have replaced it. Wait for
+      // thread/status/changed=idle or an authoritative resume.
+      if (this.phase.type === "unknown" || this.phase.type === "idle") return;
+      if (this.phase.turnId === null || this.phase.turnId !== turnId) return;
+      this.shellLifecycle = null;
+      this.phase = { type: "idle" };
+      await this.flushFromIdle();
+    });
+  }
+
+  async observeThreadIdle(): Promise<void> {
+    await this.serialize(async () => {
+      if (this.phase.type === "shell" && this.shellLifecycle) {
+        const shell = this.shellLifecycle;
+        if (shell.standaloneTurnId !== null) {
+          shell.standaloneCompleted = true;
+          if (shell.itemCompleted) await this.finishShellIdle();
+        } else if (shell.basePhase.type !== "idle") {
+          shell.baseCompleted = true;
+          if (shell.itemCompleted) await this.finishShellIdle();
+        }
+        // For an idle-base shell, an idle notification can predate the exact
+        // item/started event. It is intentionally not a completion signal.
+        return;
+      }
+      this.shellLifecycle = null;
+      this.phase = { type: "idle" };
+      await this.flushFromIdle();
+    });
+  }
+
+  /**
+   * An active-turn user shell command has no dedicated turn/completed event.
+   * Its commandExecution item completion is the authoritative point at which
+   * queued AgentParty input may steer into the original turn again. A shell
+   * started from idle owns a standalone turn and remains blocked until that
+   * turn completes or the thread reports idle.
+   */
+  async observeUserShellStarted(turnId: string, itemId: string): Promise<void> {
+    await this.serialize(async () => {
+      if (this.phase.type !== "shell" || !this.shellLifecycle) return;
+      const shell = this.shellLifecycle;
+      this.observedUserShellItemIds.add(itemId);
+      if (shell.itemId !== null) {
+        // Only the commandExecution item that authoritatively started this
+        // shell request may release the fence.
+        return;
+      }
+      shell.itemId = itemId;
+      shell.itemTurnId = turnId;
+      if (shell.basePhase.type === "idle") {
+        shell.standaloneTurnId ??= turnId;
+      } else if (shell.baseTurnId === null) {
+        shell.baseTurnId = turnId;
+      } else if (shell.baseTurnId !== turnId) {
+        shell.standaloneTurnId ??= turnId;
+      }
+      this.phase = {
+        type: "shell",
+        turnId: shell.standaloneTurnId ?? shell.baseTurnId,
+      };
+    });
+  }
+
+  async observeUserShellCompleted(turnId: string, itemId: string): Promise<void> {
+    await this.serialize(async () => {
+      if (this.phase.type !== "shell" || !this.shellLifecycle) return;
+      const shell = this.shellLifecycle;
+      this.observedUserShellItemIds.add(itemId);
+      if (shell.itemId !== itemId || shell.itemTurnId !== turnId) return;
+      shell.itemCompleted = true;
+      if (shell.standaloneTurnId !== null) {
+        if (shell.standaloneCompleted) await this.finishShellIdle();
+        return;
+      }
+      if (shell.baseCompleted) {
+        await this.finishShellIdle();
+        return;
+      }
+      await this.restoreShellBase();
+    });
+  }
+
+  private async restoreShellBase(): Promise<void> {
+    const shell = this.shellLifecycle;
+    if (!shell) return;
+    this.shellLifecycle = null;
+    if (shell.basePhase.type === "idle") {
+      this.phase = { type: "idle" };
+      await this.flushFromIdle();
+      return;
+    }
+    if (shell.basePhase.type === "normal") {
+      this.phase = { type: "normal", turnId: shell.basePhase.turnId };
+      await this.flushIntoNormalTurn();
+      return;
+    }
+    this.phase = {
+      type: shell.basePhase.type,
+      turnId: shell.baseTurnId,
+    };
+  }
+
+  private async finishShellIdle(): Promise<void> {
+    this.shellLifecycle = null;
+    this.phase = { type: "idle" };
+    await this.flushFromIdle();
+  }
+
+  /**
+   * Resolve a transport unknown outcome only after an authoritative
+   * thread/resume or thread/read scan. `accepted` suppresses all retries;
+   * `notAccepted` moves the original command back to the bounded queue.
+   */
+  async resolveUnknownOutcome(
+    input: CodexBridgeInput,
+    outcome: "accepted" | "notAccepted" | "abandoned",
+  ): Promise<CodexDispatch> {
+    const normalized = compactInput(input);
+    return await this.serialize(async () => {
+      if (this.journal.get(normalized.clientUserMessageId) !== "uncertain") {
+        const state = this.journal.get(normalized.clientUserMessageId);
+        return state === "accepted" || state === "abandoned"
+          ? { kind: "duplicate" }
+          : this.enqueue(normalized, "steer_rejected");
+      }
+      if (outcome === "accepted") {
+        this.journal.set(normalized.clientUserMessageId, "accepted");
+        this.uncertainInputs.delete(normalized.clientUserMessageId);
+        await this.flushAuthoritativePhase();
+        return { kind: "duplicate" };
+      }
+      this.uncertainInputs.delete(normalized.clientUserMessageId);
+      if (outcome === "abandoned") {
+        // A cold-process resume/read that does not contain the client id is
+        // still not a negative idempotency proof. The delivery layer first
+        // records a visible terminal-unknown failure, then abandons this exact
+        // write without replaying it so later independent work can proceed.
+        this.journal.set(normalized.clientUserMessageId, "abandoned");
+        await this.flushAuthoritativePhase();
+        return { kind: "duplicate" };
+      }
+      this.journal.delete(normalized.clientUserMessageId);
+      const dispatch = this.enqueue(normalized, "steer_rejected");
+      await this.flushAuthoritativePhase();
+      return dispatch;
+    });
+  }
+
+  private reconcileAcceptedClientIds(clientIds: Iterable<string>): void {
+    const accepted = new Set(clientIds);
+    if (accepted.size === 0) return;
+    for (const clientId of accepted) {
+      this.journal.set(clientId, "accepted");
+      this.uncertainInputs.delete(clientId);
+    }
+    for (let index = this.queue.length - 1; index >= 0; index -= 1) {
+      if (accepted.has(this.queue[index]!.input.clientUserMessageId)) this.queue.splice(index, 1);
+    }
+  }
+
+  private async notifyQueuedDispatch(entry: QueuedInput, dispatch: CodexDispatch): Promise<void> {
+    if (dispatch.kind !== "started" && dispatch.kind !== "steered") return;
+    await this.options.onQueuedDispatch?.({ id: entry.id, input: entry.input, dispatch });
+  }
+
+  private notifyQueuedError(entry: QueuedInput, error: unknown): void {
+    void Promise.resolve(this.options.onQueuedError?.({ input: entry.input, error })).catch(() => {});
+  }
+
+  private scheduleFlushRetry(): void {
+    if (this.flushRetryTimer !== null || this.queue.length === 0) return;
+    const delay = Math.min(30_000, 100 * 2 ** Math.min(this.flushRetryAttempt, 8));
+    this.flushRetryAttempt += 1;
+    this.flushRetryTimer = setTimeout(() => {
+      this.flushRetryTimer = null;
+      void this.serialize(async () => {
+        const rollbackReady = await this.flushRollbackDebts();
+        if (rollbackReady) await this.flushAuthoritativePhase();
+        else this.scheduleFlushRetry();
+      }).catch((error) => {
+        const entry = this.queue[0];
+        if (entry) this.notifyQueuedError(entry, error);
+        this.scheduleFlushRetry();
+      });
+    }, delay);
+    if (typeof this.flushRetryTimer.unref === "function") this.flushRetryTimer.unref();
+  }
+
+  private async flushRollbackDebts(): Promise<boolean> {
+    let ready = true;
+    for (const entry of this.queue) {
+      if (!this.rollbackDebts.has(entry.input.clientUserMessageId)) continue;
+      try {
+        await this.settleRollbackDebt(entry.input);
+      } catch (error) {
+        ready = false;
+        this.notifyQueuedError(entry, error);
+      }
+    }
+    return ready;
+  }
+
+  private restoreQueuedAfterFlushError(entry: QueuedInput, error: unknown): void {
+    this.queue.unshift(entry);
+    this.journal.set(entry.input.clientUserMessageId, "queued");
+    this.notifyQueuedError(entry, error);
+    this.scheduleFlushRetry();
+  }
+
+  private async flushFromIdle(): Promise<void> {
+    if (this.hasUncertainOutcome()) return;
+    const entry = this.queue.shift();
+    if (!entry) return;
+    this.journal.delete(entry.input.clientUserMessageId);
+    let dispatch: CodexDispatch;
+    try {
+      dispatch = await this.start(entry.input);
+    } catch (error) {
+      this.restoreQueuedAfterFlushError(entry, error);
+      return;
+    }
+    if (dispatch.kind === "started") {
+      this.flushRetryAttempt = 0;
+      await this.notifyQueuedDispatch(entry, dispatch);
+    }
+  }
+
+  private async flushIntoNormalTurn(): Promise<void> {
+    if (this.hasUncertainOutcome()) return;
+    while (
+      !this.hasUncertainOutcome() &&
+      this.phase.type === "normal" &&
+      this.queue.length > 0
+    ) {
+      const entry = this.queue.shift()!;
+      this.journal.delete(entry.input.clientUserMessageId);
+      const expectedTurnId = this.phase.turnId;
+      let dispatch: CodexDispatch;
+      try {
+        dispatch = await this.steer(entry.input, expectedTurnId);
+      } catch (error) {
+        this.restoreQueuedAfterFlushError(entry, error);
+        return;
+      }
+      if (dispatch.kind === "queued" || dispatch.kind === "uncertain") {
+        // steer() re-enqueued at the tail after a CAS/state rejection. Stop;
+        // waiting for the next authoritative event avoids a retry loop.
+        return;
+      }
+      this.flushRetryAttempt = 0;
+      await this.notifyQueuedDispatch(entry, dispatch);
+    }
+  }
+
+  private async flushAuthoritativePhase(): Promise<void> {
+    if (this.hasUncertainOutcome()) return;
+    if (this.phase.type === "idle") {
+      await this.flushFromIdle();
+    } else if (this.phase.type === "normal") {
+      await this.flushIntoNormalTurn();
+    }
+  }
+}
+
+function responseTurnId(response: unknown): string | null {
+  if (typeof response !== "object" || response === null) return null;
+  const direct = (response as { turnId?: unknown }).turnId;
+  if (typeof direct === "string") return direct;
+  const turn = (response as { turn?: unknown }).turn;
+  if (typeof turn !== "object" || turn === null) return null;
+  return typeof (turn as { id?: unknown }).id === "string"
+    ? (turn as { id: string }).id
+    : null;
+}

--- a/cli/src/codex-turn-arbiter.ts
+++ b/cli/src/codex-turn-arbiter.ts
@@ -49,7 +49,7 @@ interface CodexShellLifecycle {
   basePhase: CodexShellBasePhase;
   baseTurnId: string | null;
   baseCompleted: boolean;
-  baselineItemIds: ReadonlySet<string>;
+  baselineItemId: string | null;
   requestOutcome: "pending" | "accepted" | "uncertain";
   standaloneTurnId: string | null;
   standaloneCompleted: boolean;
@@ -64,7 +64,7 @@ export interface CodexBridgeInput {
   /**
    * Durable proxy-owned command id, e.g. `agentparty:<delivery-id>`.
    * Codex stores this as ThreadItem.userMessage.clientId but does NOT dedupe it;
-   * the arbiter journal below owns deduplication.
+   * the arbiter's bounded hot journal and durable delivery ledger own deduplication.
    */
   clientUserMessageId: string;
   metadata?: Record<string, string>;
@@ -107,6 +107,16 @@ export class CodexBridgeQueueFullError extends Error {
   constructor(readonly limit: number) {
     super(`Codex session bridge queue is full (${limit})`);
     this.name = "CodexBridgeQueueFullError";
+  }
+}
+
+export class CodexBridgeJournalOverflowError extends Error {
+  constructor(readonly limit: number) {
+    super(
+      `Codex active-turn duplicate fence exceeded its safe limit (${limit}); ` +
+        "restart with a new session before accepting more input",
+    );
+    this.name = "CodexBridgeJournalOverflowError";
   }
 }
 
@@ -156,6 +166,10 @@ export class CodexInteractiveMutationBlockedError extends Error {
 
 export interface CodexTurnArbiterOptions {
   maxQueue?: number;
+  /** Recent terminal ids retained for in-process duplicate suppression. */
+  maxTerminalJournalEntries?: number;
+  /** Accepted ids pinned until their active turn reaches a terminal boundary. */
+  maxActiveTurnJournalEntries?: number;
   onQueuedDispatch?: (entry: {
     id: number;
     input: CodexBridgeInput;
@@ -187,6 +201,7 @@ function compactInput(input: CodexBridgeInput): CodexBridgeInput {
 }
 
 type JournalState = "queued" | "accepted" | "abandoned" | "uncertain";
+const DEFAULT_MAX_TERMINAL_JOURNAL_ENTRIES = 4_096;
 
 function rpcErrorData(error: unknown): unknown {
   if (typeof error !== "object" || error === null) return undefined;
@@ -232,10 +247,21 @@ export class CodexTurnArbiter {
   private nextQueueId = 1;
   private exclusive: Promise<void> = Promise.resolve();
   private readonly maxQueue: number;
+  private readonly maxTerminalJournalEntries: number;
+  private readonly maxActiveTurnJournalEntries: number;
   private readonly journal = new Map<string, JournalState>();
+  private readonly terminalJournalOrder = new Map<string, undefined>();
+  private activeTurnId: string | null = null;
+  private readonly activeTurnAcceptedClientIds = new Set<string>();
+  /**
+   * Sticky fail-closed fence. Once authoritative history contains more active
+   * ids than can be retained exactly, accepting any unknown id could replay an
+   * evicted write. A fresh arbiter/session is required to restore exactness.
+   */
+  private activeTurnJournalOverflowed = false;
   private readonly uncertainInputs = new Map<string, CodexBridgeInput>();
   private readonly rollbackDebts = new Map<string, () => Promise<void>>();
-  private readonly observedUserShellItemIds = new Set<string>();
+  private lastObservedUserShellItemId: string | null = null;
   private shellLifecycle: CodexShellLifecycle | null = null;
   private flushRetryTimer: ReturnType<typeof setTimeout> | null = null;
   private flushRetryAttempt = 0;
@@ -248,6 +274,22 @@ export class CodexTurnArbiter {
     this.maxQueue = options.maxQueue ?? 128;
     if (!Number.isSafeInteger(this.maxQueue) || this.maxQueue <= 0) {
       throw new Error("maxQueue must be a positive integer");
+    }
+    this.maxTerminalJournalEntries = options.maxTerminalJournalEntries ??
+      DEFAULT_MAX_TERMINAL_JOURNAL_ENTRIES;
+    if (
+      !Number.isSafeInteger(this.maxTerminalJournalEntries) ||
+      this.maxTerminalJournalEntries <= 0
+    ) {
+      throw new Error("maxTerminalJournalEntries must be a positive integer");
+    }
+    this.maxActiveTurnJournalEntries = options.maxActiveTurnJournalEntries ??
+      DEFAULT_MAX_TERMINAL_JOURNAL_ENTRIES;
+    if (
+      !Number.isSafeInteger(this.maxActiveTurnJournalEntries) ||
+      this.maxActiveTurnJournalEntries <= 0
+    ) {
+      throw new Error("maxActiveTurnJournalEntries must be a positive integer");
     }
   }
 
@@ -272,7 +314,7 @@ export class CodexTurnArbiter {
   }
 
   private uncertainCount(): number {
-    return [...this.journal.values()].filter((state) => state === "uncertain").length;
+    return this.uncertainInputs.size + (this.activeTurnJournalOverflowed ? 1 : 0);
   }
 
   private hasUncertainOutcome(): boolean {
@@ -283,6 +325,76 @@ export class CodexTurnArbiter {
     const run = this.exclusive.then(operation, operation);
     this.exclusive = run.then(() => {}, () => {});
     return run;
+  }
+
+  private setJournalState(clientId: string, state: JournalState): void {
+    this.activeTurnAcceptedClientIds.delete(clientId);
+    this.terminalJournalOrder.delete(clientId);
+    this.journal.set(clientId, state);
+    if (state !== "accepted" && state !== "abandoned") return;
+
+    // Queued and transport-unknown writes are correctness state and are never
+    // evicted. Accepted/abandoned ids are a hot duplicate-suppression cache;
+    // the durable delivery ledger owns older terminal history.
+    this.terminalJournalOrder.set(clientId, undefined);
+    while (this.terminalJournalOrder.size > this.maxTerminalJournalEntries) {
+      const oldest = this.terminalJournalOrder.keys().next().value;
+      if (oldest === undefined) break;
+      this.terminalJournalOrder.delete(oldest);
+      const oldestState = this.journal.get(oldest);
+      if (oldestState === "accepted" || oldestState === "abandoned") {
+        this.journal.delete(oldest);
+      }
+    }
+  }
+
+  private deleteJournalState(clientId: string): void {
+    this.activeTurnAcceptedClientIds.delete(clientId);
+    this.terminalJournalOrder.delete(clientId);
+    this.journal.delete(clientId);
+  }
+
+  private setAcceptedJournalState(clientId: string, turnId: string | null): void {
+    if (turnId !== null && turnId === this.activeTurnId) {
+      if (
+        !this.activeTurnAcceptedClientIds.has(clientId) &&
+        this.activeTurnAcceptedClientIds.size >= this.maxActiveTurnJournalEntries
+      ) {
+        // Never demote a still-active accepted id into the evictable terminal
+        // cache. We can no longer distinguish that id from a future retry, so
+        // preserve bounded memory and stop every unknown write fail-closed.
+        this.activeTurnJournalOverflowed = true;
+        return;
+      }
+      this.terminalJournalOrder.delete(clientId);
+      this.journal.set(clientId, "accepted");
+      this.activeTurnAcceptedClientIds.add(clientId);
+      return;
+    }
+    this.setJournalState(clientId, "accepted");
+  }
+
+  private setActiveTurn(turnId: string | null): void {
+    if (this.activeTurnId === turnId) return;
+    const completedTurnClientIds = [...this.activeTurnAcceptedClientIds];
+    this.activeTurnAcceptedClientIds.clear();
+    this.activeTurnId = turnId;
+    for (const clientId of completedTurnClientIds) {
+      this.setJournalState(clientId, "accepted");
+    }
+  }
+
+  private canAcceptIntoActiveTurn(clientId: string, turnId: string): boolean {
+    if (this.activeTurnJournalOverflowed) return false;
+    if (this.activeTurnId !== turnId) this.setActiveTurn(turnId);
+    return this.activeTurnAcceptedClientIds.has(clientId) ||
+      this.activeTurnAcceptedClientIds.size < this.maxActiveTurnJournalEntries;
+  }
+
+  private rememberUserShellHistory(items: ReadonlyArray<{ itemId: string }>): void {
+    this.lastObservedUserShellItemId = items.length === 0
+      ? null
+      : items[items.length - 1]!.itemId;
   }
 
   private enqueue(input: CodexBridgeInput, reason: QueuedInput["reason"]): CodexDispatch {
@@ -297,7 +409,7 @@ export class CodexTurnArbiter {
     }
     if (this.queue.length >= this.maxQueue) throw new CodexBridgeQueueFullError(this.maxQueue);
     this.queue.push({ id: this.nextQueueId++, input, reason });
-    this.journal.set(input.clientUserMessageId, "queued");
+    this.setJournalState(input.clientUserMessageId, "queued");
     return {
       kind: "queued",
       queuePosition: this.queue.length,
@@ -356,8 +468,9 @@ export class CodexTurnArbiter {
     }
     try {
       const response = await this.transport.turnStart(this.startParams(input));
+      this.setActiveTurn(response.turn.id);
       this.phase = { type: "normal", turnId: response.turn.id };
-      this.journal.set(input.clientUserMessageId, "accepted");
+      this.setAcceptedJournalState(input.clientUserMessageId, response.turn.id);
       this.uncertainInputs.delete(input.clientUserMessageId);
       return { kind: "started", turnId: response.turn.id };
     } catch (error) {
@@ -386,7 +499,7 @@ export class CodexTurnArbiter {
       // Network close/timeout has an unknown outcome. Codex does not dedupe
       // clientUserMessageId, so never retry until a resume/read reconciliation
       // proves whether ThreadItem.userMessage.clientId exists.
-      this.journal.set(input.clientUserMessageId, "uncertain");
+      this.setJournalState(input.clientUserMessageId, "uncertain");
       this.uncertainInputs.set(input.clientUserMessageId, input);
       return { kind: "uncertain", reason: "unknown_outcome" };
     }
@@ -422,8 +535,9 @@ export class CodexTurnArbiter {
       const response = await this.transport.turnSteer(this.steerParams(input, expectedTurnId));
       // A valid response retains the same active turn. Do not accept a response
       // as authority to change the CAS id; turn/started is the authority.
+      this.setActiveTurn(expectedTurnId);
       this.phase = { type: "normal", turnId: expectedTurnId };
-      this.journal.set(input.clientUserMessageId, "accepted");
+      this.setAcceptedJournalState(input.clientUserMessageId, expectedTurnId);
       this.uncertainInputs.delete(input.clientUserMessageId);
       return { kind: "steered", turnId: response.turnId };
     } catch (error) {
@@ -441,7 +555,7 @@ export class CodexTurnArbiter {
       }
       if (!isDefinitiveRpcRejection(error) && !isProvenNotWritten(error)) {
         this.phase = { type: "unknown", turnId: null };
-        this.journal.set(input.clientUserMessageId, "uncertain");
+        this.setJournalState(input.clientUserMessageId, "uncertain");
         this.uncertainInputs.set(input.clientUserMessageId, input);
         return { kind: "uncertain", reason: "unknown_outcome" };
       }
@@ -488,6 +602,9 @@ export class CodexTurnArbiter {
       if (journal === "accepted" || journal === "abandoned") return { kind: "duplicate" };
       if (journal === "uncertain") return { kind: "uncertain", reason: "unknown_outcome" };
       if (journal === "queued") return this.enqueue(normalized, "steer_rejected");
+      if (this.activeTurnJournalOverflowed) {
+        throw new CodexBridgeJournalOverflowError(this.maxActiveTurnJournalEntries);
+      }
       if (this.queue.length > 0) {
         const reason = this.phase.type === "idle"
           ? "start_rejected"
@@ -495,7 +612,16 @@ export class CodexTurnArbiter {
             ? "steer_rejected"
             : this.phase.type;
         const dispatch = this.enqueue(normalized, reason);
-        if (this.phase.type === "idle" || this.phase.type === "normal") {
+        if (
+          this.phase.type === "idle" ||
+          (
+            this.phase.type === "normal" &&
+            this.canAcceptIntoActiveTurn(
+              this.queue[0]!.input.clientUserMessageId,
+              this.phase.turnId,
+            )
+          )
+        ) {
           this.scheduleFlushRetry();
         }
         return dispatch;
@@ -505,7 +631,12 @@ export class CodexTurnArbiter {
       // input may start or steer. Retain it in the bounded queue instead.
       if (this.hasUncertainOutcome()) return this.enqueue(normalized, "unknown_outcome");
       if (this.phase.type === "idle") return await this.start(normalized);
-      if (this.phase.type === "normal") return await this.steer(normalized, this.phase.turnId);
+      if (this.phase.type === "normal") {
+        if (!this.canAcceptIntoActiveTurn(normalized.clientUserMessageId, this.phase.turnId)) {
+          return this.enqueue(normalized, "steer_rejected");
+        }
+        return await this.steer(normalized, this.phase.turnId);
+      }
       return this.enqueue(normalized, this.phase.type);
     });
   }
@@ -524,7 +655,7 @@ export class CodexTurnArbiter {
       );
       if (index < 0) return false;
       this.queue.splice(index, 1);
-      this.journal.delete(clientUserMessageId);
+      this.deleteJournalState(clientUserMessageId);
       this.rollbackDebts.delete(clientUserMessageId);
       if (this.queue.length === 0 && this.flushRetryTimer !== null) {
         clearTimeout(this.flushRetryTimer);
@@ -636,7 +767,7 @@ export class CodexTurnArbiter {
           basePhase,
           baseTurnId: "turnId" in basePhase ? basePhase.turnId : null,
           baseCompleted: basePhase.type === "idle",
-          baselineItemIds: new Set(this.observedUserShellItemIds),
+          baselineItemId: this.lastObservedUserShellItemId,
           requestOutcome: "pending",
           standaloneTurnId: null,
           standaloneCompleted: false,
@@ -655,6 +786,7 @@ export class CodexTurnArbiter {
         const response = await operation();
         if (method === "turn/start") {
           const turnId = responseTurnId(response);
+          this.setActiveTurn(turnId);
           this.phase = turnId === null
             ? { type: "unknown", turnId: null }
             : { type: "normal", turnId };
@@ -662,6 +794,7 @@ export class CodexTurnArbiter {
         } else if (method === "turn/steer") {
           const expected = typeof params.expectedTurnId === "string" ? params.expectedTurnId : null;
           const turnId = responseTurnId(response) ?? expected;
+          this.setActiveTurn(turnId);
           this.phase = turnId === null
             ? { type: "unknown", turnId: null }
             : { type: "normal", turnId };
@@ -763,14 +896,24 @@ export class CodexTurnArbiter {
             : []
         )
       );
-      this.reconcileAcceptedClientIds(acceptedClientIds);
+      const runningTurns = response.thread.turns.filter((turn) => turn.status === "inProgress");
+      const resumedActiveTurn = runningTurns.length === 1 ? runningTurns[0]! : null;
+      this.setActiveTurn(resumedActiveTurn?.id ?? null);
+      const activeClientIds = resumedActiveTurn === null
+        ? []
+        : (resumedActiveTurn.items ?? [])
+          .filter((item) => item.type === "userMessage" && typeof item.clientId === "string")
+          .map((item) => item.clientId as string);
+      this.reconcileAcceptedClientIds(acceptedClientIds, activeClientIds);
       if (this.shellLifecycle) {
         const shell = this.shellLifecycle;
         const historyMatch = shell.itemId === null
           ? (() => {
-            const candidates = userShellItems.filter((item) =>
-              !shell.baselineItemIds.has(item.itemId)
-            );
+            const baselineIndex = shell.baselineItemId === null
+              ? -1
+              : userShellItems.findIndex((item) => item.itemId === shell.baselineItemId);
+            if (shell.baselineItemId !== null && baselineIndex < 0) return null;
+            const candidates = userShellItems.slice(baselineIndex + 1);
             return candidates.length === 1 ? candidates[0]! : null;
           })()
           : userShellItems.find((item) =>
@@ -805,6 +948,23 @@ export class CodexTurnArbiter {
         }
         if (
           historyMatch === null &&
+          shell.itemId === null &&
+          shell.requestOutcome !== "pending" &&
+          options.backendRestarted === true &&
+          response.thread.status.type === "idle"
+        ) {
+          // A restarted backend cannot still be executing the shell. Codex
+          // history may permanently omit the commandExecution item, including
+          // when its start notification was lost with the old transport.
+          // Abort (never replay) the shell and release only the local fence.
+          shell.itemCompleted = true;
+          shell.itemAborted = true;
+          this.rememberUserShellHistory(userShellItems);
+          await this.finishShellIdle();
+          return;
+        }
+        if (
+          historyMatch === null &&
           shell.itemId !== null &&
           shell.itemTurnId !== null &&
           options.backendRestarted === true &&
@@ -829,7 +989,7 @@ export class CodexTurnArbiter {
             }
           }
         }
-        for (const item of userShellItems) this.observedUserShellItemIds.add(item.itemId);
+        this.rememberUserShellHistory(userShellItems);
         if (response.thread.status.type === "idle") {
           // A reconnect can race both the shell request and stale idle
           // notifications from the base turn. Without the exact
@@ -890,7 +1050,7 @@ export class CodexTurnArbiter {
         this.phase = { type: "shell", turnId: shell.standaloneTurnId ?? shell.baseTurnId };
         return;
       }
-      for (const item of userShellItems) this.observedUserShellItemIds.add(item.itemId);
+      this.rememberUserShellHistory(userShellItems);
       if (response.thread.status.type === "idle") {
         this.phase = { type: "idle" };
         await this.flushFromIdle();
@@ -958,9 +1118,7 @@ export class CodexTurnArbiter {
                 basePhase,
                 baseTurnId: basePhase.type === "idle" ? null : active.id,
                 baseCompleted: basePhase.type === "idle",
-                baselineItemIds: new Set(
-                  [...this.observedUserShellItemIds].filter((id) => id !== shellItem.id),
-                ),
+                baselineItemId: null,
                 requestOutcome: "accepted",
                 standaloneTurnId: basePhase.type === "idle" ? active.id : null,
                 standaloneCompleted: false,
@@ -1008,7 +1166,8 @@ export class CodexTurnArbiter {
 
   async observeTurnStarted(turnId: string, clientIds: string[] = []): Promise<void> {
     await this.serialize(async () => {
-      this.reconcileAcceptedClientIds(clientIds);
+      this.setActiveTurn(turnId);
+      this.reconcileAcceptedClientIds(clientIds, clientIds);
       // A review/compact request remains non-steerable even if it internally
       // emits turn/started. Only its completion/idle event opens the queue.
       if (
@@ -1046,6 +1205,7 @@ export class CodexTurnArbiter {
 
   async observeTurnCompleted(turnId: string): Promise<void> {
     await this.serialize(async () => {
+      if (this.activeTurnId === turnId) this.setActiveTurn(null);
       if (this.phase.type === "shell" && this.shellLifecycle) {
         const shell = this.shellLifecycle;
         if (shell.standaloneTurnId === turnId) {
@@ -1074,6 +1234,7 @@ export class CodexTurnArbiter {
 
   async observeThreadIdle(): Promise<void> {
     await this.serialize(async () => {
+      this.setActiveTurn(null);
       if (this.phase.type === "shell" && this.shellLifecycle) {
         const shell = this.shellLifecycle;
         if (shell.standaloneTurnId !== null) {
@@ -1104,7 +1265,7 @@ export class CodexTurnArbiter {
     await this.serialize(async () => {
       if (this.phase.type !== "shell" || !this.shellLifecycle) return;
       const shell = this.shellLifecycle;
-      this.observedUserShellItemIds.add(itemId);
+      this.lastObservedUserShellItemId = itemId;
       if (shell.itemId !== null) {
         // Only the commandExecution item that authoritatively started this
         // shell request may release the fence.
@@ -1130,7 +1291,6 @@ export class CodexTurnArbiter {
     await this.serialize(async () => {
       if (this.phase.type !== "shell" || !this.shellLifecycle) return;
       const shell = this.shellLifecycle;
-      this.observedUserShellItemIds.add(itemId);
       if (shell.itemId !== itemId || shell.itemTurnId !== turnId) return;
       shell.itemCompleted = true;
       if (shell.standaloneTurnId !== null) {
@@ -1189,7 +1349,7 @@ export class CodexTurnArbiter {
           : this.enqueue(normalized, "steer_rejected");
       }
       if (outcome === "accepted") {
-        this.journal.set(normalized.clientUserMessageId, "accepted");
+        this.setAcceptedJournalState(normalized.clientUserMessageId, this.activeTurnId);
         this.uncertainInputs.delete(normalized.clientUserMessageId);
         await this.flushAuthoritativePhase();
         return { kind: "duplicate" };
@@ -1200,26 +1360,37 @@ export class CodexTurnArbiter {
         // still not a negative idempotency proof. The delivery layer first
         // records a visible terminal-unknown failure, then abandons this exact
         // write without replaying it so later independent work can proceed.
-        this.journal.set(normalized.clientUserMessageId, "abandoned");
+        this.setJournalState(normalized.clientUserMessageId, "abandoned");
         await this.flushAuthoritativePhase();
         return { kind: "duplicate" };
       }
-      this.journal.delete(normalized.clientUserMessageId);
+      this.deleteJournalState(normalized.clientUserMessageId);
       const dispatch = this.enqueue(normalized, "steer_rejected");
       await this.flushAuthoritativePhase();
       return dispatch;
     });
   }
 
-  private reconcileAcceptedClientIds(clientIds: Iterable<string>): void {
+  private reconcileAcceptedClientIds(
+    clientIds: Iterable<string>,
+    activeClientIds: Iterable<string> = [],
+  ): void {
     const accepted = new Set(clientIds);
     if (accepted.size === 0) return;
-    for (const clientId of accepted) {
-      this.journal.set(clientId, "accepted");
-      this.uncertainInputs.delete(clientId);
-    }
+    const active = new Set(activeClientIds);
     for (let index = this.queue.length - 1; index >= 0; index -= 1) {
-      if (accepted.has(this.queue[index]!.input.clientUserMessageId)) this.queue.splice(index, 1);
+      const clientId = this.queue[index]!.input.clientUserMessageId;
+      if (!accepted.has(clientId)) continue;
+      this.queue.splice(index, 1);
+      this.rollbackDebts.delete(clientId);
+    }
+    for (const clientId of accepted) {
+      this.uncertainInputs.delete(clientId);
+      if (active.has(clientId)) {
+        this.setAcceptedJournalState(clientId, this.activeTurnId);
+      } else {
+        this.setJournalState(clientId, "accepted");
+      }
     }
   }
 
@@ -1267,7 +1438,7 @@ export class CodexTurnArbiter {
 
   private restoreQueuedAfterFlushError(entry: QueuedInput, error: unknown): void {
     this.queue.unshift(entry);
-    this.journal.set(entry.input.clientUserMessageId, "queued");
+    this.setJournalState(entry.input.clientUserMessageId, "queued");
     this.notifyQueuedError(entry, error);
     this.scheduleFlushRetry();
   }
@@ -1276,7 +1447,7 @@ export class CodexTurnArbiter {
     if (this.hasUncertainOutcome()) return;
     const entry = this.queue.shift();
     if (!entry) return;
-    this.journal.delete(entry.input.clientUserMessageId);
+    this.deleteJournalState(entry.input.clientUserMessageId);
     let dispatch: CodexDispatch;
     try {
       dispatch = await this.start(entry.input);
@@ -1295,10 +1466,14 @@ export class CodexTurnArbiter {
     while (
       !this.hasUncertainOutcome() &&
       this.phase.type === "normal" &&
-      this.queue.length > 0
+      this.queue.length > 0 &&
+      this.canAcceptIntoActiveTurn(
+        this.queue[0]!.input.clientUserMessageId,
+        this.phase.turnId,
+      )
     ) {
       const entry = this.queue.shift()!;
-      this.journal.delete(entry.input.clientUserMessageId);
+      this.deleteJournalState(entry.input.clientUserMessageId);
       const expectedTurnId = this.phase.turnId;
       let dispatch: CodexDispatch;
       try {

--- a/cli/src/commands/bridge.ts
+++ b/cli/src/commands/bridge.ts
@@ -1,0 +1,549 @@
+// party bridge — attach AgentParty to an already-open interactive harness session.
+//
+// The Claude lane uses Claude Code's dedicated experimental `claude/channel`
+// capability. This is intentionally different from ordinary MCP notifications:
+// a channel notification is a harness-supported input path that queues a new
+// turn in the current session, while logging/resource/tool-list notifications
+// remain diagnostics and must never be treated as delivery.
+import {
+  accessSync,
+  closeSync,
+  constants,
+  existsSync,
+  openSync,
+  readSync,
+  realpathSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { delimiter as pathDelimiter, dirname, isAbsolute, resolve } from "node:path";
+import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
+import { resolveChannel } from "../config";
+import { isPartyBinaryPath } from "../upgrade";
+import { isSlug } from "../validation";
+import { runCodexSessionBridge, type CodexBridgeRuntimeOptions } from "./codex-bridge";
+
+const CLAUDE_CHANNEL_MIN_VERSION = [2, 1, 80] as const;
+const CODEX_BRIDGE_MIN_VERSION = [0, 144, 0] as const;
+const CHANNEL_SERVER_NAME = "agentparty-channel";
+
+const HELP = `usage: party bridge <claude|codex> [channel] [options] [-- <harness args...>]
+
+forms:
+  party bridge claude [channel|--channel C] [-- <claude args...>]
+  party bridge codex  [channel|--channel C] [--codex-bin PATH] [-- <codex args...>]
+
+Attach AgentParty to the same interactive harness session:
+  claude  native Claude Channel input and linked reply tool
+  codex   one app-server writer shared by the Unix-remote TUI and AgentParty
+
+requirements:
+  Claude Code >= 2.1.80 with development Channels enabled by the local/org policy.
+  Codex CLI >= 0.144.0 with app-server --stdio and TUI --remote unix:// support.
+
+examples:
+  party bridge claude
+  party bridge claude dev
+  party bridge claude --channel dev -- --model opus
+  party bridge codex dev
+  party bridge codex --channel dev -- --model gpt-5.4
+  party bridge codex dev --codex-bin /opt/homebrew/bin/codex
+
+Tokens after -- are passed to the selected interactive CLI. The bridge never
+uses PTY input injection and never starts a second writer against a live turn.`;
+
+export interface CommandSpec {
+  command: string;
+  args: string[];
+}
+
+export interface ClaudeBridgeLaunch {
+  command: string;
+  args: string[];
+  mcpConfig: {
+    mcpServers: Record<string, {
+      type: "stdio";
+      command: string;
+      args: string[];
+    }>;
+  };
+}
+
+export interface BridgeDeps {
+  execPath?: string;
+  processArgv?: string[];
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  codexBinary?: string;
+  probeClaudeVersion?: () => Promise<string>;
+  probeCodexCapabilities?: (
+    codexBinary: string,
+    options: { cwd: string; env: NodeJS.ProcessEnv },
+  ) => Promise<CodexCapabilityProbe>;
+  launch?: (command: string, args: string[], options: { cwd: string; env: NodeJS.ProcessEnv }) => Promise<number>;
+  runCodexBridge?: (options: CodexBridgeRuntimeOptions) => Promise<number>;
+}
+
+export interface CodexCapabilityProbe {
+  version: string;
+  rootHelp: string;
+  appServerHelp: string;
+}
+
+const CODEX_APP_DIRS = [
+  "/Applications/Codex.app/Contents/Resources",
+  "/Applications/ChatGPT.app/Contents/Resources",
+] as const;
+
+const CODEX_FALLBACK_PATH_DIRS = [
+  resolve(homedir(), ".local/bin"),
+  resolve(homedir(), ".npm-global/bin"),
+  resolve(homedir(), ".bun/bin"),
+  resolve(homedir(), ".deno/bin"),
+  "/opt/homebrew/bin",
+  "/usr/local/bin",
+  ...CODEX_APP_DIRS,
+  "/usr/bin",
+  "/bin",
+] as const;
+
+function executable(path: string): boolean {
+  try {
+    accessSync(path, constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function pathEntries(value: string | undefined): string[] {
+  return value?.split(pathDelimiter).filter((entry) => entry !== "") ?? [];
+}
+
+/**
+ * Construct the exact PATH inherited by both Codex children. The fallback
+ * directories are deliberately explicit: launchd GUI sessions commonly omit
+ * Homebrew and application bundle paths even when the same command works in a
+ * login shell.
+ */
+export function buildCodexChildEnv(
+  env: NodeJS.ProcessEnv = process.env,
+  preferredPathDirs: string[] = [],
+): NodeJS.ProcessEnv {
+  const seen = new Set<string>();
+  const entries: string[] = [];
+  for (const entry of [
+    ...preferredPathDirs,
+    ...pathEntries(env.PATH),
+    ...CODEX_FALLBACK_PATH_DIRS,
+  ]) {
+    if (!entry || seen.has(entry)) continue;
+    seen.add(entry);
+    entries.push(entry);
+  }
+  return { ...env, PATH: entries.join(pathDelimiter) };
+}
+
+function executableOnPath(
+  command: string,
+  env: NodeJS.ProcessEnv,
+  cwd: string,
+): string | null {
+  if (isAbsolute(command) || command.includes("/")) {
+    const candidate = isAbsolute(command) ? command : resolve(cwd, command);
+    return executable(candidate) ? candidate : null;
+  }
+  for (const entry of pathEntries(env.PATH)) {
+    const candidate = resolve(cwd, entry, command);
+    if (executable(candidate)) return candidate;
+  }
+  return null;
+}
+
+/**
+ * Resolve one absolute binary for both app-server and TUI. launchd often lacks
+ * Homebrew's PATH, which caused the resident runner's
+ * "Executable not found in $PATH: codex" failure.
+ */
+export function resolveCodexBinary(
+  explicit?: string,
+  env: NodeJS.ProcessEnv = process.env,
+  cwd: string = process.cwd(),
+): string | null {
+  const configured = explicit || env.AGENTPARTY_CODEX_BIN;
+  if (configured) {
+    const path = isAbsolute(configured) ? configured : resolve(cwd, configured);
+    return executable(path) ? realpathSync(path) : null;
+  }
+  const fromPath = executableOnPath("codex", buildCodexChildEnv(env), cwd);
+  if (fromPath && executable(fromPath)) return realpathSync(fromPath);
+  for (const appDir of CODEX_APP_DIRS) {
+    const candidate = resolve(appDir, "codex");
+    if (existsSync(candidate) && executable(candidate)) return realpathSync(candidate);
+  }
+  return null;
+}
+
+function shebangEnvCommand(path: string): string | null {
+  const fd = openSync(path, "r");
+  try {
+    const prefix = Buffer.alloc(512);
+    const bytes = readSync(fd, prefix, 0, prefix.length, 0);
+    const firstLine = prefix.subarray(0, bytes).toString("utf8").split(/\r?\n/, 1)[0] ?? "";
+    if (!firstLine.startsWith("#!")) return null;
+    const parts = firstLine.slice(2).trim().split(/\s+/);
+    const interpreter = parts[0] ?? "";
+    if (interpreter !== "/usr/bin/env" && interpreter !== "/bin/env") return null;
+    let index = 1;
+    if (parts[index] === "-S") index += 1;
+    while (parts[index]?.includes("=")) index += 1;
+    const command = parts[index];
+    return command && !command.startsWith("-") ? command : null;
+  } finally {
+    closeSync(fd);
+  }
+}
+
+export type CodexLaunchResolution =
+  | {
+    ok: true;
+    codexBinary: string;
+    cwd: string;
+    env: NodeJS.ProcessEnv;
+  }
+  | {
+    ok: false;
+    error: string;
+  };
+
+/**
+ * Resolve binary, cwd, and environment as one unit. Probing with a different
+ * PATH than the eventual app-server/TUI launch can produce a false-positive
+ * preflight, especially for npm shims using `#!/usr/bin/env node`.
+ */
+export function resolveCodexLaunch(
+  explicit?: string,
+  env: NodeJS.ProcessEnv = process.env,
+  cwd: string = process.cwd(),
+): CodexLaunchResolution {
+  const configured = explicit || env.AGENTPARTY_CODEX_BIN;
+  const configuredPath = configured
+    ? (isAbsolute(configured) ? configured : resolve(cwd, configured))
+    : null;
+  const lookupEnv = buildCodexChildEnv(
+    env,
+    configuredPath === null ? [] : [dirname(configuredPath)],
+  );
+  const codexBinary = resolveCodexBinary(explicit, lookupEnv, cwd);
+  if (!codexBinary) {
+    return {
+      ok: false,
+      error:
+        "could not find an executable Codex CLI. Pass --codex-bin PATH or set AGENTPARTY_CODEX_BIN",
+    };
+  }
+  const childEnv = buildCodexChildEnv(lookupEnv, [
+    ...(configuredPath === null ? [] : [dirname(configuredPath)]),
+    dirname(codexBinary),
+  ]);
+  let envCommand: string | null;
+  try {
+    envCommand = shebangEnvCommand(codexBinary);
+  } catch (error) {
+    return {
+      ok: false,
+      error: `could not inspect Codex CLI ${codexBinary}: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+  if (envCommand && executableOnPath(envCommand, childEnv, cwd) === null) {
+    return {
+      ok: false,
+      error:
+        `Codex CLI ${codexBinary} uses /usr/bin/env ${envCommand}, but ${envCommand} is not executable ` +
+        "on the child PATH. Install its runtime or pass a standalone Codex binary",
+    };
+  }
+  return { ok: true, codexBinary, cwd, env: childEnv };
+}
+
+/** Extract the first semver-looking tuple from `claude --version`. */
+export function parseClaudeVersion(raw: string): [number, number, number] | null {
+  const match = raw.match(/(?:^|\s|v)(\d+)\.(\d+)\.(\d+)(?:\s|$|\()/);
+  if (!match) return null;
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+export function supportsClaudeChannels(raw: string): boolean {
+  const parsed = parseClaudeVersion(raw);
+  if (!parsed) return false;
+  for (let index = 0; index < CLAUDE_CHANNEL_MIN_VERSION.length; index += 1) {
+    if (parsed[index]! > CLAUDE_CHANNEL_MIN_VERSION[index]!) return true;
+    if (parsed[index]! < CLAUDE_CHANNEL_MIN_VERSION[index]!) return false;
+  }
+  return true;
+}
+
+export function parseCodexVersion(raw: string): [number, number, number] | null {
+  const match = raw.match(/(?:^|\s|v)(\d+)\.(\d+)\.(\d+)(?:[-+\s]|$|\()/);
+  if (!match) return null;
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+function atLeast(
+  version: readonly number[],
+  minimum: readonly number[],
+): boolean {
+  for (let index = 0; index < minimum.length; index += 1) {
+    if (version[index]! > minimum[index]!) return true;
+    if (version[index]! < minimum[index]!) return false;
+  }
+  return true;
+}
+
+export function supportsCodexSessionBridge(probe: CodexCapabilityProbe): boolean {
+  const version = parseCodexVersion(probe.version);
+  return version !== null &&
+    atLeast(version, CODEX_BRIDGE_MIN_VERSION) &&
+    probe.rootHelp.includes("--remote") &&
+    probe.rootHelp.includes("unix://") &&
+    probe.appServerHelp.includes("--stdio");
+}
+
+/**
+ * Resolve the command Claude should spawn for the channel MCP subprocess.
+ * Compiled installs point directly at `party`; source/dev runs preserve
+ * `bun <entry.ts>` so tests and contributors do not need a global binary.
+ */
+export function selfCommand(
+  execPath: string = process.execPath,
+  processArgv: string[] = process.argv,
+): CommandSpec {
+  if (isPartyBinaryPath(execPath) || processArgv[1] === undefined) {
+    return { command: execPath, args: [] };
+  }
+  return { command: execPath, args: [processArgv[1]] };
+}
+
+export function buildClaudeBridgeLaunch(options: {
+  channel: string;
+  claudeArgs?: string[];
+  execPath?: string;
+  processArgv?: string[];
+}): ClaudeBridgeLaunch {
+  const self = selfCommand(options.execPath, options.processArgv);
+  const mcpConfig: ClaudeBridgeLaunch["mcpConfig"] = {
+    mcpServers: {
+      [CHANNEL_SERVER_NAME]: {
+        type: "stdio",
+        command: self.command,
+        args: [...self.args, "claude-channel", "--channel", options.channel],
+      },
+    },
+  };
+  return {
+    command: "claude",
+    args: [
+      "--mcp-config",
+      JSON.stringify(mcpConfig),
+      "--dangerously-load-development-channels",
+      `server:${CHANNEL_SERVER_NAME}`,
+      ...(options.claudeArgs ?? []),
+    ],
+    mcpConfig,
+  };
+}
+
+async function defaultProbeClaudeVersion(): Promise<string> {
+  const proc = Bun.spawn(["claude", "--version"], {
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, code] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  if (code !== 0) {
+    const detail = stderr.trim() || `exit ${code}`;
+    throw new Error(`could not run claude --version (${detail})`);
+  }
+  return stdout.trim();
+}
+
+async function capture(
+  command: string[],
+  options: { cwd: string; env: NodeJS.ProcessEnv },
+): Promise<string> {
+  const proc = Bun.spawn(command, {
+    cwd: options.cwd,
+    env: options.env,
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, code] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  if (code !== 0) {
+    throw new Error(`${command.join(" ")} failed (${stderr.trim() || `exit ${code}`})`);
+  }
+  return stdout;
+}
+
+async function defaultProbeCodexCapabilities(
+  codexBinary: string,
+  options: { cwd: string; env: NodeJS.ProcessEnv },
+): Promise<CodexCapabilityProbe> {
+  const [version, rootHelp, appServerHelp] = await Promise.all([
+    capture([codexBinary, "--version"], options),
+    capture([codexBinary, "--help"], options),
+    capture([codexBinary, "app-server", "--help"], options),
+  ]);
+  return { version: version.trim(), rootHelp, appServerHelp };
+}
+
+async function defaultLaunch(
+  command: string,
+  args: string[],
+  options: { cwd: string; env: NodeJS.ProcessEnv },
+): Promise<number> {
+  const proc = Bun.spawn([command, ...args], {
+    cwd: options.cwd,
+    env: options.env,
+    stdin: "inherit",
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  return await proc.exited;
+}
+
+export async function run(argv: string[], deps: BridgeDeps = {}): Promise<number> {
+  if (isHelpArg(argv, { allowHelpPositional: true })) {
+    console.log(HELP);
+    return 0;
+  }
+
+  // `--` is a hard ownership boundary: flags after it belong to the selected
+  // harness, not AgentParty.
+  const delimiter = argv.indexOf("--");
+  const bridgeArgs = delimiter < 0 ? argv : argv.slice(0, delimiter);
+  const harnessArgs = delimiter < 0 ? [] : argv.slice(delimiter + 1);
+  const { positionals, flags } = parseArgs(bridgeArgs);
+  const unknown = unknownFlagError(flags, ["channel", "codex-bin"]);
+  if (unknown !== null) {
+    console.error(`${unknown}; put harness flags after --`);
+    return 1;
+  }
+  const flagError = valueFlagError(flags, ["channel", "codex-bin"]);
+  if (flagError !== null) {
+    console.error(flagError);
+    return 1;
+  }
+  const harness = positionals[0];
+  if (harness !== "claude" && harness !== "codex") {
+    console.error("bridge supports: party bridge claude|codex [channel|--channel C] [-- <harness args...>]");
+    return 1;
+  }
+  if (positionals.length > 2) {
+    console.error("too many bridge arguments; put harness arguments after --");
+    return 1;
+  }
+  if (harness === "claude" && flags["codex-bin"] !== undefined) {
+    console.error("--codex-bin is only valid with party bridge codex");
+    return 1;
+  }
+  const channel = resolveChannel(str(flags.channel) ?? positionals[1]);
+  if (!channel) {
+    console.error("no channel, pass one or bind with: party init --channel C");
+    return 1;
+  }
+  if (!isSlug(channel)) {
+    console.error("channel must match [a-z0-9][a-z0-9-]{0,63}");
+    return 1;
+  }
+
+  if (harness === "codex") {
+    const ownedFlag = harnessArgs.find((arg) =>
+      arg === "--remote" ||
+      arg.startsWith("--remote=") ||
+      arg === "--remote-auth-token-env" ||
+      arg.startsWith("--remote-auth-token-env=")
+    );
+    if (ownedFlag) {
+      console.error(
+        `party bridge codex owns ${ownedFlag}; remove it so all TUI and AgentParty writes stay on the single bridge endpoint`,
+      );
+      return 1;
+    }
+    const cwd = deps.cwd ?? process.cwd();
+    const launch = resolveCodexLaunch(
+      str(flags["codex-bin"]) ?? deps.codexBinary,
+      deps.env ?? process.env,
+      cwd,
+    );
+    if (!launch.ok) {
+      console.error(
+        `party bridge codex ${launch.error}. ` +
+          "The bridge will not rely on launchd's often-incomplete PATH.",
+      );
+      return 1;
+    }
+    let probe: CodexCapabilityProbe;
+    try {
+      probe = await (deps.probeCodexCapabilities ?? defaultProbeCodexCapabilities)(
+        launch.codexBinary,
+        { cwd: launch.cwd, env: launch.env },
+      );
+    } catch (error) {
+      console.error(`party bridge codex: ${error instanceof Error ? error.message : String(error)}`);
+      return 1;
+    }
+    if (!supportsCodexSessionBridge(probe)) {
+      console.error(
+        `party bridge codex requires Codex CLI >= ${CODEX_BRIDGE_MIN_VERSION.join(".")} with ` +
+          `app-server --stdio and --remote unix:// support; found ${probe.version || "unknown"}. ` +
+          "Update Codex before attaching a live session. AgentParty will not fall back to PTY injection.",
+      );
+      return 1;
+    }
+    return await (deps.runCodexBridge ?? ((options) => runCodexSessionBridge(options)))({
+      channel,
+      codexBinary: launch.codexBinary,
+      codexArgs: harnessArgs,
+      cwd: launch.cwd,
+      env: launch.env,
+    });
+  }
+
+  let rawVersion: string;
+  try {
+    rawVersion = await (deps.probeClaudeVersion ?? defaultProbeClaudeVersion)();
+  } catch (error) {
+    console.error(`party bridge claude: ${error instanceof Error ? error.message : String(error)}`);
+    return 1;
+  }
+  if (!supportsClaudeChannels(rawVersion)) {
+    console.error(
+      `party bridge claude requires Claude Code >= ${CLAUDE_CHANNEL_MIN_VERSION.join(".")}; found ${rawVersion || "unknown"}. ` +
+        "Update Claude Code before attaching a live session. AgentParty will not fall back to PTY injection or concurrently resume it.",
+    );
+    return 1;
+  }
+
+  const launch = buildClaudeBridgeLaunch({
+    channel,
+    claudeArgs: harnessArgs,
+    execPath: deps.execPath,
+    processArgv: deps.processArgv,
+  });
+  console.error(
+    `party bridge: launching Claude Code with native AgentParty Channel for #${channel}. ` +
+      "If organization policy disables development Channels, Claude will reject the channel explicitly; no unsafe resume fallback is attempted.",
+  );
+  return await (deps.launch ?? defaultLaunch)(launch.command, launch.args, {
+    cwd: deps.cwd ?? process.cwd(),
+    env: deps.env ?? process.env,
+  });
+}

--- a/cli/src/commands/bridge.ts
+++ b/cli/src/commands/bridge.ts
@@ -15,7 +15,7 @@ import {
   realpathSync,
 } from "node:fs";
 import { homedir } from "node:os";
-import { delimiter as pathDelimiter, dirname, isAbsolute, resolve } from "node:path";
+import { delimiter as pathDelimiter, dirname, extname, isAbsolute, resolve } from "node:path";
 import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
 import { resolveChannel } from "../config";
 import { isPartyBinaryPath } from "../upgrade";
@@ -78,6 +78,7 @@ export interface BridgeDeps {
   probeCodexCapabilities?: (
     codexBinary: string,
     options: { cwd: string; env: NodeJS.ProcessEnv },
+    codexArgsPrefix?: string[],
   ) => Promise<CodexCapabilityProbe>;
   launch?: (command: string, args: string[], options: { cwd: string; env: NodeJS.ProcessEnv }) => Promise<number>;
   runCodexBridge?: (options: CodexBridgeRuntimeOptions) => Promise<number>;
@@ -120,6 +121,25 @@ function pathEntries(value: string | undefined): string[] {
 }
 
 /**
+ * Windows does not resolve an extensionless command name without consulting
+ * PATHEXT. Only return directly executable formats here: cmd/bat wrappers need
+ * a shell and must not be selected for the bridge's single-writer subprocesses.
+ */
+export function executableCommandNames(
+  command: string,
+  env: NodeJS.ProcessEnv = process.env,
+  platform: NodeJS.Platform = process.platform,
+): string[] {
+  if (platform !== "win32" || extname(command) !== "") return [command];
+  const configured = (env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD")
+    .split(";")
+    .map((entry) => entry.trim().toLowerCase())
+    .filter((entry) => entry === ".exe" || entry === ".com");
+  const extensions = [...new Set([".exe", ...configured, ".com"])];
+  return extensions.map((extension) => `${command}${extension}`);
+}
+
+/**
  * Construct the exact PATH inherited by both Codex children. The fallback
  * directories are deliberately explicit: launchd GUI sessions commonly omit
  * Homebrew and application bundle paths even when the same command works in a
@@ -147,14 +167,17 @@ function executableOnPath(
   command: string,
   env: NodeJS.ProcessEnv,
   cwd: string,
+  platform: NodeJS.Platform = process.platform,
 ): string | null {
   if (isAbsolute(command) || command.includes("/")) {
     const candidate = isAbsolute(command) ? command : resolve(cwd, command);
     return executable(candidate) ? candidate : null;
   }
   for (const entry of pathEntries(env.PATH)) {
-    const candidate = resolve(cwd, entry, command);
-    if (executable(candidate)) return candidate;
+    for (const name of executableCommandNames(command, env, platform)) {
+      const candidate = resolve(cwd, entry, name);
+      if (executable(candidate)) return candidate;
+    }
   }
   return null;
 }
@@ -168,13 +191,19 @@ export function resolveCodexBinary(
   explicit?: string,
   env: NodeJS.ProcessEnv = process.env,
   cwd: string = process.cwd(),
+  options: { platform?: NodeJS.Platform } = {},
 ): string | null {
   const configured = explicit || env.AGENTPARTY_CODEX_BIN;
   if (configured) {
     const path = isAbsolute(configured) ? configured : resolve(cwd, configured);
     return executable(path) ? realpathSync(path) : null;
   }
-  const fromPath = executableOnPath("codex", buildCodexChildEnv(env), cwd);
+  const fromPath = executableOnPath(
+    "codex",
+    buildCodexChildEnv(env),
+    cwd,
+    options.platform,
+  );
   if (fromPath && executable(fromPath)) return realpathSync(fromPath);
   for (const appDir of CODEX_APP_DIRS) {
     const candidate = resolve(appDir, "codex");
@@ -206,7 +235,14 @@ function shebangEnvCommand(path: string): string | null {
 export type CodexLaunchResolution =
   | {
     ok: true;
+    /** The directly executable program shared by every Codex child. */
     codexBinary: string;
+    /**
+     * Fixed argv inserted before every Codex subcommand. This is empty for a
+     * native CLI and contains the npm package entrypoint for a Windows npm
+     * `codex.cmd` shim, so neither child needs a shell to invoke it.
+     */
+    codexArgsPrefix: string[];
     cwd: string;
     env: NodeJS.ProcessEnv;
   }
@@ -214,6 +250,60 @@ export type CodexLaunchResolution =
     ok: false;
     error: string;
   };
+
+function isWindowsCmdShim(path: string, platform: NodeJS.Platform): boolean {
+  return platform === "win32" && extname(path).toLowerCase() === ".cmd";
+}
+
+function isWindowsBatShim(path: string, platform: NodeJS.Platform): boolean {
+  return platform === "win32" && extname(path).toLowerCase() === ".bat";
+}
+
+function windowsNpmCodexCmdOnPath(
+  env: NodeJS.ProcessEnv,
+  cwd: string,
+): string | null {
+  for (const entry of pathEntries(env.PATH)) {
+    const candidate = resolve(cwd, entry, "codex.cmd");
+    if (executable(candidate)) return candidate;
+  }
+  return null;
+}
+
+function resolveWindowsNpmCodexShim(
+  shim: string,
+  env: NodeJS.ProcessEnv,
+  cwd: string,
+  platform: NodeJS.Platform,
+): CodexLaunchResolution {
+  const entrypoint = resolve(dirname(shim), "node_modules", "@openai", "codex", "bin", "codex.js");
+  if (!existsSync(entrypoint)) {
+    return {
+      ok: false,
+      error:
+        `Windows Codex npm shim ${shim} does not have the expected @openai/codex entrypoint. ` +
+        "Install Codex with the official Windows installer or pass --codex-bin pointing to codex.exe",
+    };
+  }
+  const nodeBinary = executableOnPath("node", env, cwd, platform);
+  if (nodeBinary === null) {
+    return {
+      ok: false,
+      error:
+        `Windows Codex npm shim ${shim} requires node.exe on PATH. ` +
+        "Install Node with the npm package or pass --codex-bin pointing to codex.exe",
+    };
+  }
+  const codexBinary = realpathSync(nodeBinary);
+  const childEnv = buildCodexChildEnv(env, [dirname(shim), dirname(codexBinary)]);
+  return {
+    ok: true,
+    codexBinary,
+    codexArgsPrefix: [realpathSync(entrypoint)],
+    cwd,
+    env: childEnv,
+  };
+}
 
 /**
  * Resolve binary, cwd, and environment as one unit. Probing with a different
@@ -224,7 +314,9 @@ export function resolveCodexLaunch(
   explicit?: string,
   env: NodeJS.ProcessEnv = process.env,
   cwd: string = process.cwd(),
+  options: { platform?: NodeJS.Platform } = {},
 ): CodexLaunchResolution {
+  const platform = options.platform ?? process.platform;
   const configured = explicit || env.AGENTPARTY_CODEX_BIN;
   const configuredPath = configured
     ? (isAbsolute(configured) ? configured : resolve(cwd, configured))
@@ -233,8 +325,29 @@ export function resolveCodexLaunch(
     env,
     configuredPath === null ? [] : [dirname(configuredPath)],
   );
-  const codexBinary = resolveCodexBinary(explicit, lookupEnv, cwd);
-  if (!codexBinary) {
+  if (configuredPath !== null && isWindowsBatShim(configuredPath, platform)) {
+    return {
+      ok: false,
+      error:
+        `Windows batch wrapper ${configuredPath} cannot be launched safely without a shell. ` +
+        "Pass --codex-bin pointing to codex.exe or the official npm codex.cmd shim",
+    };
+  }
+  if (
+    configuredPath !== null &&
+    isWindowsCmdShim(configuredPath, platform) &&
+    executable(configuredPath)
+  ) {
+    return resolveWindowsNpmCodexShim(configuredPath, lookupEnv, cwd, platform);
+  }
+  const codexBinary = resolveCodexBinary(explicit, lookupEnv, cwd, options);
+  const npmShim = codexBinary === null && configuredPath === null && platform === "win32"
+    ? windowsNpmCodexCmdOnPath(lookupEnv, cwd)
+    : null;
+  if (npmShim !== null) {
+    return resolveWindowsNpmCodexShim(npmShim, lookupEnv, cwd, platform);
+  }
+  if (codexBinary === null) {
     return {
       ok: false,
       error:
@@ -254,7 +367,10 @@ export function resolveCodexLaunch(
       error: `could not inspect Codex CLI ${codexBinary}: ${error instanceof Error ? error.message : String(error)}`,
     };
   }
-  if (envCommand && executableOnPath(envCommand, childEnv, cwd) === null) {
+  if (
+    envCommand &&
+    executableOnPath(envCommand, childEnv, cwd, options.platform) === null
+  ) {
     return {
       ok: false,
       error:
@@ -262,7 +378,7 @@ export function resolveCodexLaunch(
         "on the child PATH. Install its runtime or pass a standalone Codex binary",
     };
   }
-  return { ok: true, codexBinary, cwd, env: childEnv };
+  return { ok: true, codexBinary, codexArgsPrefix: [], cwd, env: childEnv };
 }
 
 /** Extract the first semver-looking tuple from `claude --version`. */
@@ -395,11 +511,12 @@ async function capture(
 async function defaultProbeCodexCapabilities(
   codexBinary: string,
   options: { cwd: string; env: NodeJS.ProcessEnv },
+  codexArgsPrefix: string[] = [],
 ): Promise<CodexCapabilityProbe> {
   const [version, rootHelp, appServerHelp] = await Promise.all([
-    capture([codexBinary, "--version"], options),
-    capture([codexBinary, "--help"], options),
-    capture([codexBinary, "app-server", "--help"], options),
+    capture([codexBinary, ...codexArgsPrefix, "--version"], options),
+    capture([codexBinary, ...codexArgsPrefix, "--help"], options),
+    capture([codexBinary, ...codexArgsPrefix, "app-server", "--help"], options),
   ]);
   return { version: version.trim(), rootHelp, appServerHelp };
 }
@@ -495,6 +612,7 @@ export async function run(argv: string[], deps: BridgeDeps = {}): Promise<number
       probe = await (deps.probeCodexCapabilities ?? defaultProbeCodexCapabilities)(
         launch.codexBinary,
         { cwd: launch.cwd, env: launch.env },
+        launch.codexArgsPrefix,
       );
     } catch (error) {
       console.error(`party bridge codex: ${error instanceof Error ? error.message : String(error)}`);
@@ -511,6 +629,7 @@ export async function run(argv: string[], deps: BridgeDeps = {}): Promise<number
     return await (deps.runCodexBridge ?? ((options) => runCodexSessionBridge(options)))({
       channel,
       codexBinary: launch.codexBinary,
+      codexArgsPrefix: launch.codexArgsPrefix,
       codexArgs: harnessArgs,
       cwd: launch.cwd,
       env: launch.env,

--- a/cli/src/commands/claude-channel.ts
+++ b/cli/src/commands/claude-channel.ts
@@ -1,0 +1,2247 @@
+// Hidden stdio subprocess used by `party bridge claude`.
+//
+// Claude Code Channels are a dedicated MCP extension. Declaring the
+// `claude/channel` capability and emitting `notifications/claude/channel`
+// injects a queued input into the *current* Claude session. Do not replace this
+// with ordinary MCP logging/resource notifications: those were proven not to
+// wake an idle harness in #553.
+import {
+  BODY_LIMIT,
+  DIRECTED_DELIVERY_LEASE_MS,
+  EXIT_ARCHIVED,
+  EXIT_AUTH,
+  EXIT_STREAM_ENDED,
+  type ClientFrame,
+  type DeliveryRecoverFrame,
+  type DeliveryRecoveryResultFrame,
+  type DirectedDelivery,
+  type MsgFrame,
+  type ServerFrame,
+} from "@agentparty/shared";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+  type Notification,
+  type Request,
+  type Result,
+} from "@modelcontextprotocol/sdk/types.js";
+import { randomUUID } from "node:crypto";
+import pkg from "../../package.json" with { type: "json" };
+import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
+import { connect, type Connection } from "../client";
+import { loadCursor, resolveChannel, saveCursor } from "../config";
+import {
+  DeliveryRecoveryJournal,
+  deliveryRecoveryJournalPath,
+  type DeliveryRecoveryEntry,
+} from "../delivery-recovery-journal";
+import { acquireInstanceLock, defaultInstanceLockDir, instanceLockTarget } from "../instance-lock";
+import { resolveAuthDetailed } from "../oidc-cli";
+import { fetchMessages, postMessage } from "../rest";
+import { isSlug } from "../validation";
+
+const REPLY_TOOL = "party_channel_reply";
+const CLAIM_TOOL = "party_channel_claim";
+const ACCEPT_TOOL = "party_channel_accept";
+
+const HELP = `usage: party claude-channel [channel|--channel C]
+
+Internal stdio MCP adapter for \`party bridge claude\`.
+
+It declares Claude Code's dedicated experimental claude/channel capability,
+holds AgentParty directed delivery, injects messages into the current Claude
+session, and links replies back through ${REPLY_TOOL}. Run \`party bridge
+claude\` instead of starting this command manually.`;
+
+export interface ClaudeChannelNotification extends Notification {
+  method: "notifications/claude/channel";
+  params: {
+    content: string;
+    meta: Record<string, string>;
+  };
+}
+
+export interface ChannelNotification {
+  content: string;
+  meta: Record<string, string>;
+}
+
+export type ChannelNotify = (notification: ChannelNotification) => Promise<void>;
+export type ChannelPostReply = (reply: {
+  body: string;
+  mentions: string[];
+  replyTo: number;
+  idempotencyKey: string;
+}) => Promise<{ seq: number }>;
+export type ChannelLoadMessage = (seq: number) => Promise<MsgFrame | null>;
+
+type BridgeConnection = Pick<Connection, "frames" | "send" | "ack" | "close" | "cursor">;
+type DeliveryUpdateFrame = Extract<ClientFrame, { type: "delivery_update" }>;
+type AuthoritativeDeliveryState =
+  Extract<ServerFrame, { type: "delivery_state" }>["delivery"]["state"];
+
+interface PendingDeliveryAck {
+  deliveryId: string;
+  state: DeliveryUpdateFrame["state"];
+  resolve: (state: AuthoritativeDeliveryState) => void;
+  reject: (error: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+interface PendingDeliveryRecovery {
+  deliveryId: string;
+  resolve: (frame: DeliveryRecoveryResultFrame) => void;
+  reject: (error: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+interface PendingChannelMessage {
+  message: MsgFrame;
+  delivery: DirectedDelivery | null;
+  renewTimer: ReturnType<typeof setInterval> | null;
+  renewEpoch: number;
+  renewing: boolean;
+  retryTimer: ReturnType<typeof setTimeout> | null;
+  retryRound: number;
+  replying: boolean;
+  settling: boolean;
+  terminalError: string | null;
+  recoveryTimer: ReturnType<typeof setTimeout> | null;
+  harnessClaimed: boolean;
+  claimReceipt: string | null;
+  claimNotificationAttempts: number;
+  replyIdempotencyKey: string;
+  replyBody: string | null;
+  replySeq: number | null;
+  continuationKey: string | null;
+}
+
+interface ParkedClaudeContinuation {
+  key: string;
+  workId: string;
+  continuationRef: string;
+  sourceDeliveryId: string;
+  sourceMessage: MsgFrame;
+  questionSeq: number;
+}
+
+export interface ClaudeChannelDeliveryBridgeOptions {
+  channel: string;
+  connection: BridgeConnection;
+  notify: ChannelNotify;
+  postReply: ChannelPostReply;
+  out?: (line: string) => void;
+  leaseRenewIntervalMs?: number;
+  deliveryAckTimeoutMs?: number;
+  deliveryAckMaxAttempts?: number;
+  deliveryAckRetryDelayMs?: number;
+  deliveryRecoveryRetryDelayMs?: number;
+  deliverySettleRetryMaxRounds?: number;
+  deliverySettleRetryDelayMs?: number;
+  deliverySettleRetryCooldownMs?: number;
+  recoveryUncertaintyTimeoutMs?: number;
+  harnessClaimRetryDelayMs?: number;
+  harnessClaimMaxNotifications?: number;
+  harnessClaimNotifyTimeoutMs?: number;
+  /** Production enables an idempotent claim gate before Claude sees task content. */
+  requireHarnessClaim?: boolean;
+  recoveryJournal?: DeliveryRecoveryJournal;
+  /** Reads the Worker's durable channel history for restart/reconciliation. */
+  loadMessage?: ChannelLoadMessage;
+  /** Test/embedding seam; production uses request_id + delivery_state. */
+  confirmDeliveryUpdate?: (
+    update: DeliveryUpdateFrame,
+  ) => Promise<AuthoritativeDeliveryState | void>;
+}
+
+class DeliveryUpdateRejectedError extends Error {}
+class DeliveryUpdateCancelledError extends Error {}
+class DeliveryConnectionReplacedError extends Error {}
+
+function delay(ms: number): Promise<void> {
+  if (ms <= 0) return Promise.resolve();
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function deliveryUpdate(
+  delivery: DirectedDelivery,
+  state: "running" | "replied" | "failed",
+  extra: { replySeq?: number; error?: string } = {},
+): DeliveryUpdateFrame {
+  return {
+    type: "delivery_update",
+    delivery_id: delivery.id,
+    state,
+    attempt: delivery.attempt,
+    ...(delivery.lease_epoch === undefined ? {} : { lease_epoch: delivery.lease_epoch }),
+    ...(delivery.lease_token === undefined ? {} : { lease_token: delivery.lease_token }),
+    ...(delivery.work_id === null ? {} : { work_id: delivery.work_id }),
+    ...(delivery.continuation_ref === null ? {} : { continuation_ref: delivery.continuation_ref }),
+    ...(extra.replySeq === undefined ? {} : { reply_seq: extra.replySeq }),
+    ...(extra.error === undefined ? {} : { error: extra.error }),
+  };
+}
+
+function notificationFor(
+  channel: string,
+  message: MsgFrame,
+  delivery: DirectedDelivery | null,
+  continuation: ParkedClaudeContinuation | null = null,
+): ChannelNotification {
+  const sender = message.sender.name;
+  const decision = message.decision_response;
+  const continuationContext = continuation === null
+    ? ""
+    : (
+      `This is the owner answer for an AgentParty continuation that may no longer be present ` +
+      "in Claude's conversation context (for example after /clear).\n\n" +
+      `Original source message in #${channel} from @${continuation.sourceMessage.sender.name} ` +
+      `(seq=${continuation.sourceMessage.seq}, delivery=${continuation.sourceDeliveryId}):\n\n` +
+      `${continuation.sourceMessage.body}\n\n` +
+      `Owner decision${decision?.prompt ? ` for "${decision.prompt}"` : ""}: ` +
+      `${decision?.chosen_option ?? message.body}` +
+      `${decision?.reason ? ` (${decision.reason})` : ""}\n\n`
+    );
+  return {
+    content:
+      continuationContext +
+      `AgentParty message in #${channel} from @${sender} (seq=${message.seq}):\n\n` +
+      `${message.body}\n\n` +
+      `Respond to this exact message by calling ${REPLY_TOOL} with seq=${message.seq} and your reply text. ` +
+      "Do not use party_send for this reply.",
+    meta: {
+      source: "agentparty",
+      channel,
+      seq: String(message.seq),
+      sender,
+      sender_kind: message.sender.kind,
+      ...(message.sender.owner === undefined ? {} : { sender_owner: message.sender.owner }),
+      ...(delivery === null
+        ? {}
+        : {
+            delivery_id: delivery.id,
+            delivery_cause: delivery.cause,
+            ...(delivery.work_id === null ? {} : { work_id: delivery.work_id }),
+            ...(delivery.continuation_ref === null
+              ? {}
+              : { continuation_ref: delivery.continuation_ref }),
+          }),
+      ...(continuation === null
+        ? {}
+        : {
+            continuation_source_delivery_id: continuation.sourceDeliveryId,
+            continuation_source_seq: String(continuation.sourceMessage.seq),
+            continuation_source_sender: continuation.sourceMessage.sender.name,
+          }),
+    },
+  };
+}
+
+function claimNotificationFor(
+  channel: string,
+  message: MsgFrame,
+  delivery: DirectedDelivery,
+): ChannelNotification {
+  return {
+    content:
+      `AgentParty durable input is ready for #${channel} (execution_id=${delivery.id}, seq=${message.seq}). ` +
+      `Call ${CLAIM_TOOL} with execution_id=${delivery.id} to receive a stable claim receipt and task body. ` +
+      `After reading the full result, call ${ACCEPT_TOOL} with that exact receipt before doing any work ` +
+      "or causing any side effect. An unaccepted claim may be fetched again; never execute the same receipt twice.",
+    meta: {
+      source: "agentparty",
+      channel,
+      seq: String(message.seq),
+      sender: message.sender.name,
+      sender_kind: message.sender.kind,
+      delivery_id: delivery.id,
+      execution_id: delivery.id,
+      delivery_cause: delivery.cause,
+    },
+  };
+}
+
+function replyIdempotencyKey(
+  channel: string,
+  message: MsgFrame,
+  delivery: DirectedDelivery | null,
+): string {
+  // Deterministic from the durable inbound identity, so retries and a process
+  // restart reuse the same server-side dedupe key for one logical reply.
+  return delivery === null
+    ? `claude-channel-reply:${channel}:${message.seq}`
+    : `claude-channel-reply:${delivery.id}`;
+}
+
+function continuationKey(delivery: DirectedDelivery): string | null {
+  if (delivery.work_id === null || delivery.continuation_ref === null) return null;
+  return `${delivery.work_id}\u0000${delivery.continuation_ref}`;
+}
+
+/**
+ * Delivery ledger on the AgentParty side of a Claude Channel.
+ *
+ * A successful notification write only means Claude accepted a queued channel
+ * input. It is not completion. The delivery remains `running` (with lease
+ * renewal) until Claude explicitly calls the linked reply tool, the REST reply
+ * carrying `reply_to` succeeds, and Worker confirms `replied` or parks it as
+ * `waiting_owner`.
+ */
+export class ClaudeChannelDeliveryBridge {
+  private self = "";
+  private directedDeliveryMode = false;
+  private exitCode = 0;
+  private intentionalClose = false;
+  private readonly pending = new Map<number, PendingChannelMessage>();
+  private readonly parkedContinuations = new Map<string, ParkedClaudeContinuation>();
+  private readonly completedContinuationKeys = new Set<string>();
+  private readonly settledDeliveryIds = new Set<string>();
+  private readonly seenPlainSeqs = new Set<number>();
+  private readonly recoveringDeliveryIds = new Map<
+    string,
+    { generation: number; token: symbol }
+  >();
+  private readonly deliveryAcks = new Map<string, PendingDeliveryAck>();
+  private readonly deliveryRecoveries = new Map<string, PendingDeliveryRecovery>();
+  private readonly out: (line: string) => void;
+  private frameWork: Promise<void> = Promise.resolve();
+  private welcomeGeneration = 0;
+  private stopped = false;
+  private journalRecoveryRetryTimer: ReturnType<typeof setTimeout> | null = null;
+  private journalRecoveryRetryGeneration = 0;
+  private journalRecoveryRetryRound = 0;
+  private journalRecoveryRun: {
+    generation: number;
+    promise: Promise<void>;
+  } | null = null;
+
+  constructor(private readonly options: ClaudeChannelDeliveryBridgeOptions) {
+    if (options.requireHarnessClaim === true && options.recoveryJournal === undefined) {
+      throw new Error("Claude harness claim gate requires a durable recovery journal");
+    }
+    this.out = options.out ?? ((line) => console.error(line));
+  }
+
+  get pendingCount(): number {
+    return this.pending.size;
+  }
+
+  get parkedContinuationCount(): number {
+    return this.parkedContinuations.size;
+  }
+
+  private cancelJournalRecoveryRetry(): void {
+    if (this.journalRecoveryRetryTimer !== null) {
+      clearTimeout(this.journalRecoveryRetryTimer);
+      this.journalRecoveryRetryTimer = null;
+    }
+  }
+
+  private resetJournalRecoveryBackoff(generation: number): void {
+    this.cancelJournalRecoveryRetry();
+    this.journalRecoveryRetryGeneration = generation;
+    this.journalRecoveryRetryRound = 0;
+  }
+
+  private scheduleJournalRecoveryRetry(generation: number): void {
+    if (
+      this.stopped ||
+      generation !== this.welcomeGeneration ||
+      this.journalRecoveryRetryTimer !== null
+    ) {
+      return;
+    }
+    if (this.journalRecoveryRetryGeneration !== generation) {
+      this.journalRecoveryRetryGeneration = generation;
+      this.journalRecoveryRetryRound = 0;
+    }
+    const baseDelayMs = Math.max(
+      1,
+      this.options.deliveryRecoveryRetryDelayMs ?? 1_000,
+    );
+    const delayMs = Math.min(
+      30_000,
+      baseDelayMs * 2 ** Math.min(this.journalRecoveryRetryRound, 5),
+    );
+    this.journalRecoveryRetryRound += 1;
+    const timer = setTimeout(() => {
+      if (this.journalRecoveryRetryTimer !== timer) return;
+      this.journalRecoveryRetryTimer = null;
+      if (this.stopped || generation !== this.welcomeGeneration) return;
+      this.joinJournalRecovery(generation);
+    }, delayMs);
+    this.journalRecoveryRetryTimer = timer;
+    if (typeof timer.unref === "function") timer.unref();
+  }
+
+  private startJournalRecovery(generation: number): Promise<void> {
+    const active = this.journalRecoveryRun;
+    if (active !== null && active.generation === generation) return active.promise;
+    const run = {
+      generation,
+      promise: Promise.resolve(),
+    };
+    run.promise = this.recoverJournalEntries(generation)
+      .catch((error) => {
+        if (!this.stopped && generation === this.welcomeGeneration) {
+          this.scheduleJournalRecoveryRetry(generation);
+        }
+        throw error;
+      })
+      .finally(() => {
+        if (this.journalRecoveryRun === run) this.journalRecoveryRun = null;
+      });
+    this.journalRecoveryRun = run;
+    return run.promise;
+  }
+
+  private joinJournalRecovery(generation: number): void {
+    const oldLane = this.frameWork.catch(() => undefined);
+    const recovery = this.startJournalRecovery(generation);
+    this.frameWork = Promise.all([oldLane, recovery])
+      .then(() => undefined)
+      .catch((error) => {
+        if (this.stopped || generation !== this.welcomeGeneration) return;
+        this.out(
+          `claude-channel: delivery recovery failed: ` +
+            `${error instanceof Error ? error.message : String(error)}`,
+        );
+      });
+  }
+
+  private stopLeaseRenewal(pending: PendingChannelMessage): void {
+    pending.renewEpoch += 1;
+    if (pending.renewTimer) clearInterval(pending.renewTimer);
+    pending.renewTimer = null;
+  }
+
+  private stopPendingRetry(pending: PendingChannelMessage): void {
+    if (pending.retryTimer) clearTimeout(pending.retryTimer);
+    pending.retryTimer = null;
+  }
+
+  private schedulePendingRetry(
+    pending: PendingChannelMessage,
+    label: string,
+    action: () => Promise<void>,
+  ): void {
+    if (
+      this.pending.get(pending.message.seq) !== pending ||
+      pending.retryTimer !== null
+    ) {
+      return;
+    }
+    const configuredRounds = this.options.deliverySettleRetryMaxRounds ?? 4;
+    const maxRounds = Number.isSafeInteger(configuredRounds)
+      ? Math.max(0, Math.min(10, configuredRounds))
+      : 4;
+    if (maxRounds === 0) return;
+    const baseDelayMs = Math.max(1, this.options.deliverySettleRetryDelayMs ?? 500);
+    const exhaustedFastRetries = pending.retryRound >= maxRounds;
+    const delayMs = exhaustedFastRetries
+      ? Math.max(baseDelayMs, this.options.deliverySettleRetryCooldownMs ?? 30_000)
+      : Math.min(30_000, baseDelayMs * (2 ** pending.retryRound));
+    if (!exhaustedFastRetries) pending.retryRound += 1;
+    pending.retryTimer = setTimeout(() => {
+      pending.retryTimer = null;
+      if (this.pending.get(pending.message.seq) !== pending) return;
+      void action().catch((error) => {
+        this.out(
+          `claude-channel: background ${label} ` +
+            `${exhaustedFastRetries ? "cooldown reconciliation" : `retry ${pending.retryRound}/${maxRounds}`} failed ` +
+            `for delivery ${pending.delivery?.id ?? pending.message.seq}: ` +
+            `${error instanceof Error ? error.message : String(error)}`,
+        );
+        this.schedulePendingRetry(pending, label, action);
+      });
+    }, delayMs);
+    if (typeof pending.retryTimer.unref === "function") pending.retryTimer.unref();
+  }
+
+  private startLeaseRenewal(pending: PendingChannelMessage): void {
+    const delivery = pending.delivery;
+    if (
+      delivery === null ||
+      (delivery.state !== "claimed" && delivery.state !== "running") ||
+      pending.renewTimer !== null ||
+      pending.replying ||
+      pending.settling ||
+      pending.terminalError !== null
+    ) {
+      return;
+    }
+    const intervalMs = this.options.leaseRenewIntervalMs ?? Math.floor(DIRECTED_DELIVERY_LEASE_MS / 2);
+    const epoch = pending.renewEpoch + 1;
+    pending.renewEpoch = epoch;
+    const isCurrent = () =>
+      this.pending.get(pending.message.seq) === pending &&
+      pending.renewEpoch === epoch &&
+      !pending.replying &&
+      !pending.settling &&
+      pending.terminalError === null;
+    pending.renewTimer = setInterval(() => {
+      if (!isCurrent() || pending.renewing) return;
+      pending.renewing = true;
+      void this.confirmDeliveryUpdate(deliveryUpdate(delivery, "running"), isCurrent)
+        .catch((error) => {
+          if (error instanceof DeliveryUpdateCancelledError) return;
+          this.out(
+            `claude-channel: delivery ${delivery.id} lease renewal was not confirmed: ` +
+              `${error instanceof Error ? error.message : String(error)}`,
+          );
+        })
+        .finally(() => {
+          pending.renewing = false;
+        });
+    }, intervalMs);
+    if (typeof pending.renewTimer.unref === "function") pending.renewTimer.unref();
+  }
+
+  private clearPending(seq: number): PendingChannelMessage | null {
+    const pending = this.pending.get(seq) ?? null;
+    if (!pending) return null;
+    this.stopLeaseRenewal(pending);
+    this.stopPendingRetry(pending);
+    if (pending.recoveryTimer) clearTimeout(pending.recoveryTimer);
+    pending.recoveryTimer = null;
+    this.pending.delete(seq);
+    return pending;
+  }
+
+  private scheduleHarnessClaimRetry(pending: PendingChannelMessage): void {
+    if (
+      this.options.requireHarnessClaim !== true ||
+      pending.delivery === null ||
+      pending.harnessClaimed ||
+      pending.recoveryTimer !== null ||
+      this.pending.get(pending.message.seq) !== pending
+    ) {
+      return;
+    }
+    const configuredMax = this.options.harnessClaimMaxNotifications ?? 12;
+    const maxNotifications = Number.isSafeInteger(configuredMax)
+      ? Math.max(1, Math.min(100, configuredMax))
+      : 12;
+    const baseDelayMs = Math.max(1, this.options.harnessClaimRetryDelayMs ?? 5_000);
+    const delayMs = Math.min(
+      5 * 60_000,
+      baseDelayMs * 2 ** Math.min(Math.max(0, pending.claimNotificationAttempts - 1), 12),
+    );
+    pending.recoveryTimer = setTimeout(() => {
+      pending.recoveryTimer = null;
+      if (
+        pending.harnessClaimed ||
+        pending.delivery === null ||
+        this.pending.get(pending.message.seq) !== pending
+      ) {
+        return;
+      }
+      if (pending.claimNotificationAttempts >= maxNotifications) {
+        // Channel notifications are transport writes, not consumption ACKs.
+        // Claude may simply be busy and process them on its next turn. Stop
+        // renewing after the bounded, exponentially-spaced reminders so the
+        // Worker can surface terminal_unknown, but retain the exact journal
+        // and claim path for a delayed claim and revivable late reply.
+        this.stopLeaseRenewal(pending);
+        this.out(
+          `claude-channel: delivery ${pending.delivery.id} remains unclaimed after ` +
+            `${maxNotifications} claim-only notifications; preserving delayed-claim debt`,
+        );
+        return;
+      }
+      pending.claimNotificationAttempts += 1;
+      void this.sendHarnessClaimNotification(pending).then(() => {
+        this.scheduleHarnessClaimRetry(pending);
+      }).catch((error) => {
+        this.out(
+          `claude-channel: claim-only notification retry failed for ${pending.delivery?.id}: ` +
+            `${error instanceof Error ? error.message : String(error)}`,
+        );
+        this.scheduleHarnessClaimRetry(pending);
+      });
+    }, delayMs);
+    if (typeof pending.recoveryTimer.unref === "function") pending.recoveryTimer.unref();
+  }
+
+  /**
+   * A full-body Channel notification has no consumption acknowledgement. Once
+   * the transport call was issued, a thrown error cannot prove that Claude did
+   * not queue the input. Keep the exact journal/bearer debt for a late tool
+   * reply and never replay the body or turn that uncertainty into an ordinary
+   * permanent failure. Renewal is bounded so the Worker can eventually expose
+   * terminal_unknown without losing the late-reply capability.
+   */
+  private preservePostHarnessDebt(
+    pending: PendingChannelMessage,
+    detail: string,
+  ): void {
+    if (pending.delivery === null || this.pending.get(pending.message.seq) !== pending) return;
+    if (pending.recoveryTimer) clearTimeout(pending.recoveryTimer);
+    const timeoutMs = Math.max(
+      1,
+      this.options.recoveryUncertaintyTimeoutMs ?? 5 * 60_000,
+    );
+    pending.recoveryTimer = setTimeout(() => {
+      pending.recoveryTimer = null;
+      if (
+        this.pending.get(pending.message.seq) !== pending ||
+        pending.replyBody !== null ||
+        pending.replying
+      ) {
+        return;
+      }
+      this.stopLeaseRenewal(pending);
+      this.out(
+        `claude-channel: stopped renewing uncertain post-harness delivery ` +
+          `${pending.delivery?.id ?? pending.message.seq}; preserving late-reply debt`,
+      );
+    }, timeoutMs);
+    if (typeof pending.recoveryTimer.unref === "function") pending.recoveryTimer.unref();
+    this.out(
+      `claude-channel: ${detail}; task content will not be replayed and its ` +
+        "late-reply debt remains durable",
+    );
+  }
+
+  private async sendHarnessClaimNotification(
+    pending: PendingChannelMessage,
+  ): Promise<void> {
+    if (pending.delivery === null) throw new Error("claim notification requires a directed delivery");
+    const timeoutMs = Math.max(1, this.options.harnessClaimNotifyTimeoutMs ?? 5_000);
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    try {
+      await Promise.race([
+        this.options.notify(
+          claimNotificationFor(this.options.channel, pending.message, pending.delivery),
+        ),
+        new Promise<never>((_resolve, reject) => {
+          timer = setTimeout(() => {
+            reject(new Error(`claim-only notification timed out after ${timeoutMs}ms`));
+          }, timeoutMs);
+          if (typeof timer.unref === "function") timer.unref();
+        }),
+      ]);
+    } finally {
+      if (timer !== null) clearTimeout(timer);
+    }
+  }
+
+  private async notifyHarnessClaim(pending: PendingChannelMessage): Promise<void> {
+    if (pending.delivery === null) throw new Error("claim notification requires a directed delivery");
+    pending.claimNotificationAttempts += 1;
+    try {
+      await this.sendHarnessClaimNotification(pending);
+    } catch (error) {
+      // This write contains only execution_id. Its outcome is not a harness
+      // consumption ACK, so both a rejection and an unknown transport result
+      // are safe to retry without releasing task content twice.
+      this.out(
+        `claude-channel: claim-only notification was not confirmed for ${pending.delivery.id}: ` +
+          `${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+    this.scheduleHarnessClaimRetry(pending);
+  }
+
+  private rememberBounded<T extends string | number>(set: Set<T>, value: T): void {
+    set.add(value);
+    if (set.size <= 4_096) return;
+    const oldest = set.values().next().value as T | undefined;
+    if (oldest !== undefined) set.delete(oldest);
+  }
+
+  private async confirmDeliveryUpdateOnce(
+    update: DeliveryUpdateFrame,
+  ): Promise<AuthoritativeDeliveryState> {
+    if (this.options.confirmDeliveryUpdate) {
+      return await this.options.confirmDeliveryUpdate(update) ?? update.state;
+    }
+    const requestId = randomUUID();
+    const timeoutMs = this.options.deliveryAckTimeoutMs ?? 5_000;
+    return await new Promise<AuthoritativeDeliveryState>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.deliveryAcks.delete(requestId);
+        reject(new Error(`delivery update acknowledgement timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+      if (typeof timer.unref === "function") timer.unref();
+      this.deliveryAcks.set(requestId, {
+        deliveryId: update.delivery_id,
+        state: update.state,
+        resolve: (state) => {
+          clearTimeout(timer);
+          resolve(state);
+        },
+        reject: (error) => {
+          clearTimeout(timer);
+          reject(error);
+        },
+        timer,
+      });
+      if (!this.options.connection.send({ ...update, request_id: requestId })) {
+        this.deliveryAcks.delete(requestId);
+        clearTimeout(timer);
+        reject(new Error("AgentParty websocket is not open"));
+      }
+    });
+  }
+
+  private async confirmDeliveryUpdate(
+    update: DeliveryUpdateFrame,
+    shouldContinue: (() => boolean) | null = null,
+  ): Promise<AuthoritativeDeliveryState> {
+    const configuredAttempts = this.options.deliveryAckMaxAttempts ?? 3;
+    const maxAttempts = Number.isSafeInteger(configuredAttempts)
+      ? Math.max(1, Math.min(10, configuredAttempts))
+      : 3;
+    const retryDelayMs = Math.max(0, this.options.deliveryAckRetryDelayMs ?? 25);
+    let lastError: Error | null = null;
+    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+      if (shouldContinue !== null && !shouldContinue()) {
+        throw new DeliveryUpdateCancelledError(
+          `delivery ${update.delivery_id} ${update.state} acknowledgement was superseded`,
+        );
+      }
+      try {
+        return await this.confirmDeliveryUpdateOnce(update);
+      } catch (error) {
+        const normalized = error instanceof Error ? error : new Error(String(error));
+        if (
+          normalized instanceof DeliveryUpdateRejectedError ||
+          normalized instanceof DeliveryUpdateCancelledError ||
+          normalized instanceof DeliveryConnectionReplacedError
+        ) {
+          throw normalized;
+        }
+        lastError = normalized;
+        if (attempt === maxAttempts) break;
+        this.out(
+          `claude-channel: retrying ${update.state} acknowledgement for ${update.delivery_id} ` +
+            `after attempt ${attempt}/${maxAttempts}: ${normalized.message}`,
+        );
+        await delay(retryDelayMs);
+      }
+    }
+    throw lastError ?? new Error(`delivery ${update.delivery_id} acknowledgement failed`);
+  }
+
+  private observeDeliveryAck(incoming: Extract<ServerFrame, { type: "delivery_state" }>): void {
+    if (!incoming.request_id) return;
+    const pending = this.deliveryAcks.get(incoming.request_id);
+    if (!pending || pending.deliveryId !== incoming.delivery.id) return;
+    this.deliveryAcks.delete(incoming.request_id);
+    if (
+      incoming.delivery.state === pending.state ||
+      (pending.state === "replied" &&
+        (incoming.delivery.state === "replied" || incoming.delivery.state === "waiting_owner"))
+    ) {
+      pending.resolve(incoming.delivery.state);
+      return;
+    }
+    pending.reject(new DeliveryUpdateRejectedError(
+      `delivery state is ${incoming.delivery.state}, expected ${pending.state}`,
+    ));
+  }
+
+  private async confirmDeliveryRecovery(
+    recovery: DeliveryRecoverFrame,
+  ): Promise<DeliveryRecoveryResultFrame> {
+    const timeoutMs = this.options.deliveryAckTimeoutMs ?? 5_000;
+    return await new Promise<DeliveryRecoveryResultFrame>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.deliveryRecoveries.delete(recovery.request_id);
+        reject(new Error(`delivery recovery acknowledgement timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+      if (typeof timer.unref === "function") timer.unref();
+      this.deliveryRecoveries.set(recovery.request_id, {
+        deliveryId: recovery.delivery_id,
+        resolve: (frame) => {
+          clearTimeout(timer);
+          resolve(frame);
+        },
+        reject: (error) => {
+          clearTimeout(timer);
+          reject(error);
+        },
+        timer,
+      });
+      if (!this.options.connection.send(recovery)) {
+        this.deliveryRecoveries.delete(recovery.request_id);
+        clearTimeout(timer);
+        reject(new Error("AgentParty websocket is not open"));
+      }
+    });
+  }
+
+  private observeDeliveryRecovery(incoming: DeliveryRecoveryResultFrame): void {
+    const pending = this.deliveryRecoveries.get(incoming.request_id);
+    if (!pending || pending.deliveryId !== incoming.delivery_id) return;
+    this.deliveryRecoveries.delete(incoming.request_id);
+    pending.resolve(incoming);
+  }
+
+  private restorePending(entry: DeliveryRecoveryEntry): PendingChannelMessage {
+    const existing = this.pending.get(entry.message.seq);
+    if (existing !== undefined) {
+      this.stopLeaseRenewal(existing);
+      existing.delivery = entry.delivery;
+      existing.replyBody = entry.replyBody;
+      existing.replySeq = entry.replySeq;
+      existing.terminalError = entry.terminalError;
+      existing.claimReceipt = entry.claimReceipt;
+      existing.harnessClaimed =
+        entry.phase === "harness_accepted" || entry.phase === "reply_posted";
+      return existing;
+    }
+    const pending: PendingChannelMessage = {
+      message: entry.message,
+      delivery: entry.delivery,
+      renewTimer: null,
+      renewEpoch: 0,
+      renewing: false,
+      retryTimer: null,
+      retryRound: 0,
+      replying: false,
+      settling: false,
+      terminalError: entry.terminalError,
+      recoveryTimer: null,
+      harnessClaimed: entry.phase === "harness_accepted" || entry.phase === "reply_posted",
+      claimReceipt: entry.claimReceipt,
+      claimNotificationAttempts: 0,
+      replyIdempotencyKey: replyIdempotencyKey(
+        this.options.channel,
+        entry.message,
+        entry.delivery,
+      ),
+      replyBody: entry.replyBody,
+      replySeq: entry.replySeq,
+      continuationKey: entry.delivery.cause === "owner_answer"
+        ? continuationKey(entry.delivery)
+        : null,
+    };
+    this.pending.set(entry.message.seq, pending);
+    return pending;
+  }
+
+  private prepareJournalRecovery(
+    journal: DeliveryRecoveryJournal,
+    deliveryId: string,
+  ): { entry: DeliveryRecoveryEntry; frame: DeliveryRecoverFrame } {
+    const current = journal.get(deliveryId);
+    if (current === null) throw new Error(`no recovery journal entry for ${deliveryId}`);
+    const replaySafe =
+      current.phase === "claimed" ||
+      current.phase === "running_authorized" ||
+      (current.phase === "harness_issued" && this.options.requireHarnessClaim === true);
+    const frame = journal.prepareRecovery(deliveryId, {
+      replaySafe,
+      expected: {
+        phase: current.phase,
+        updatedAt: current.updatedAt,
+        attempt: current.delivery.attempt,
+        leaseEpoch: current.delivery.lease_epoch!,
+        leaseToken: current.delivery.lease_token!,
+      },
+    });
+    // prepareRecovery may durably add nextLeaseToken and advance updatedAt.
+    // Bind all result interpretation to that exact post-prepare snapshot.
+    const prepared = journal.get(deliveryId);
+    if (prepared === null || prepared.nextLeaseToken !== frame.next_lease_token) {
+      throw new Error(`delivery ${deliveryId} changed while recovery was being prepared`);
+    }
+    return { entry: prepared, frame };
+  }
+
+  private async recoverJournalEntries(generation = this.welcomeGeneration): Promise<void> {
+    const journal = this.options.recoveryJournal;
+    if (journal === undefined) return;
+    if (this.stopped || generation !== this.welcomeGeneration) return;
+    let retryNeeded = false;
+    const recoveryEntries = journal.entries().map((initial) => {
+      const deliveryId = initial.delivery.id;
+      const recoveryGate = { generation, token: Symbol(deliveryId) };
+      // Install every gate from one journal snapshot before the first CAS can
+      // yield. Otherwise a slow earlier recovery leaves later entries
+      // claimable under the old ownership generation.
+      this.recoveringDeliveryIds.set(deliveryId, recoveryGate);
+      return { initial, recoveryGate };
+    });
+    for (const { initial, recoveryGate } of recoveryEntries) {
+      if (generation !== this.welcomeGeneration) return;
+      const deliveryId = initial.delivery.id;
+      const gateCurrent = () =>
+        !this.stopped &&
+        generation === this.welcomeGeneration &&
+        this.recoveringDeliveryIds.get(deliveryId) === recoveryGate;
+      let releaseRecoveryGate = false;
+      let stored = initial;
+      let recovered: DeliveryRecoveryResultFrame;
+      try {
+        let prepared = this.prepareJournalRecovery(journal, deliveryId);
+        stored = prepared.entry;
+        let recovery = prepared.frame;
+        try {
+          recovered = await this.confirmDeliveryRecovery(recovery);
+        } catch (firstError) {
+          if (!gateCurrent()) return;
+          // If the first CAS committed but its ACK was lost, the journal already
+          // contains next_lease_token. Re-read the exact phase/revision before
+          // retrying so a concurrent harness transition cannot inherit a stale
+          // replay_safe assertion.
+          prepared = this.prepareJournalRecovery(journal, stored.delivery.id);
+          stored = prepared.entry;
+          recovery = prepared.frame;
+          try {
+            recovered = await this.confirmDeliveryRecovery(recovery);
+          } catch (retryError) {
+            if (!gateCurrent()) return;
+            this.out(
+              `claude-channel: could not recover delivery ${stored.delivery.id}: ` +
+                `${retryError instanceof Error ? retryError.message : String(retryError)} ` +
+                `(first: ${firstError instanceof Error ? firstError.message : String(firstError)})`,
+            );
+            retryNeeded = true;
+            continue;
+          }
+        }
+      if (!gateCurrent()) return;
+      let entry: DeliveryRecoveryEntry;
+      let ownsActiveLease = recovered.result === "recovered";
+      if (recovered.result === "recovered") {
+        entry = journal.acceptRecovery(recovered);
+      } else {
+        const bodyMayHaveBeenReleased =
+          stored.phase === "harness_accepted" ||
+          stored.phase === "reply_posted" ||
+          stored.replyBody !== null ||
+          (stored.phase === "harness_issued" && this.options.requireHarnessClaim !== true);
+        const delayedClaimIsSafe =
+          recovered.result === "terminal_unknown" &&
+          this.options.requireHarnessClaim === true &&
+          (
+            stored.phase === "claimed" ||
+            stored.phase === "running_authorized" ||
+            stored.phase === "harness_issued"
+          );
+        const failureAlreadySettled =
+          stored.phase === "failed_pending" &&
+          (recovered.result === "terminal" || recovered.result === "terminal_unknown");
+        const isFinalTerminal = recovered.result === "terminal";
+        if (
+          (!bodyMayHaveBeenReleased && !delayedClaimIsSafe) ||
+          failureAlreadySettled ||
+          isFinalTerminal
+        ) {
+          journal.remove(stored.delivery.id);
+          const existing = this.pending.get(stored.message.seq);
+          if (existing !== undefined) this.clearPending(stored.message.seq);
+          this.out(
+            `claude-channel: recovery for delivery ${stored.delivery.id} resolved as ` +
+              `${recovered.result}/${recovered.state}; no live harness debt remains`,
+          );
+          releaseRecoveryGate = true;
+          continue;
+        }
+        // terminal_unknown is deliberately revivable by an exact late replied
+        // receipt. The claim may already have released task content, so keep
+        // the local reply path and bearer token even though there is no active
+        // lease to renew. A superseded_safe result in a post-harness phase
+        // violates the protocol invariant; preserving rather than discarding
+        // the debt is the fail-closed behavior.
+        entry = journal.update(stored.delivery.id, {
+          delivery: {
+            ...stored.delivery,
+            state: recovered.state,
+            lease_until: null,
+          },
+        });
+        if (
+          delayedClaimIsSafe &&
+          (entry.phase === "claimed" || entry.phase === "running_authorized")
+        ) {
+          entry = journal.update(stored.delivery.id, { phase: "harness_issued" });
+        }
+        ownsActiveLease = false;
+        this.out(
+          `claude-channel: recovery for delivery ${stored.delivery.id} resolved as ` +
+            `${recovered.result}/${recovered.state}; preserving post-harness reply debt`,
+        );
+      }
+      if (
+        ownsActiveLease &&
+        (entry.phase === "claimed" || entry.phase === "running_authorized")
+      ) {
+        if (this.pending.has(entry.message.seq)) this.clearPending(entry.message.seq);
+        const injected = await this.inject(entry.message, entry.delivery, true);
+        if (!gateCurrent()) return;
+        if (!injected) continue;
+        releaseRecoveryGate = true;
+        continue;
+      }
+      const pending = this.restorePending(entry);
+      if (entry.phase === "reply_posted") {
+        pending.replying = true;
+        this.stopLeaseRenewal(pending);
+        try {
+          await this.settlePendingReply(pending);
+        } catch (error) {
+          if (!gateCurrent()) return;
+          pending.replying = false;
+          this.scheduleReplyRetry(pending);
+          this.out(
+            `claude-channel: recovered reply settlement is still pending for ` +
+              `${entry.delivery.id}: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+        releaseRecoveryGate = true;
+        continue;
+      }
+      if (entry.phase === "failed_pending") {
+        await this.failPending(
+          pending.message.seq,
+          entry.terminalError ?? "recovered delivery was pending failure",
+        );
+        if (!gateCurrent()) return;
+        releaseRecoveryGate = true;
+        continue;
+      }
+      if (entry.replyBody !== null) {
+        pending.replying = true;
+        this.stopLeaseRenewal(pending);
+        try {
+          await this.persistAndSettlePendingReply(pending);
+        } catch (error) {
+          if (!gateCurrent()) return;
+          pending.replying = false;
+          this.scheduleReplyRetry(pending);
+          this.out(
+            `claude-channel: recovered idempotent reply is still pending for ${entry.delivery.id}: ` +
+              `${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+        releaseRecoveryGate = true;
+        continue;
+      }
+      if (ownsActiveLease) this.startLeaseRenewal(pending);
+      if (entry.phase === "harness_issued") {
+        if (this.options.requireHarnessClaim === true) {
+          // A recovered ownership generation gets a fresh bounded delivery
+          // budget. Attempts from the replaced connection cannot suppress the
+          // claim-only notification for this new bearer.
+          pending.claimNotificationAttempts = 0;
+          if (entry.delivery.cause === "owner_answer") {
+            let binding: ParkedClaudeContinuation | null;
+            try {
+              binding = await this.bindingFor(entry.delivery, entry.message);
+            } catch (error) {
+              if (!gateCurrent()) return;
+              this.out(
+                `claude-channel: could not restore owner-answer context for ${entry.delivery.id}: ` +
+                  `${error instanceof Error ? error.message : String(error)}; claim remains withheld`,
+              );
+              continue;
+            }
+            if (!gateCurrent()) return;
+            if (binding === null) {
+              await this.failPending(
+                pending.message.seq,
+                "recovered owner answer has no exact parked delivery/work/continuation lineage",
+              );
+              if (!gateCurrent()) return;
+              releaseRecoveryGate = true;
+              continue;
+            }
+            pending.continuationKey = binding.key;
+          }
+          try {
+            await this.notifyHarnessClaim(pending);
+          } catch (error) {
+            if (!gateCurrent()) return;
+            await this.failPending(
+              pending.message.seq,
+              `could not restore Claude claim notification: ${
+                error instanceof Error ? error.message : String(error)
+              }`,
+            );
+          }
+          if (!gateCurrent()) return;
+          releaseRecoveryGate = true;
+          continue;
+        }
+        this.preservePostHarnessDebt(
+          pending,
+          "Claude channel notification outcome remained uncertain after process restart",
+        );
+        releaseRecoveryGate = true;
+      } else if (entry.phase === "harness_accepted") {
+        // The prior claim tool may have released the body before the bridge
+        // restarted. Preserve that execution and its reply path. After the
+        // bounded grace period, stop renewing rather than declaring an
+        // ordinary permanent failure: the Worker will converge the expired
+        // running lease to terminal_unknown, whose exact bearer token still
+        // permits one late idempotent reply from a long-running Claude turn.
+        this.preservePostHarnessDebt(
+          pending,
+          `recovered Claude execution ${entry.delivery.id} may still be running`,
+        );
+        releaseRecoveryGate = true;
+      }
+      } finally {
+        if (
+          releaseRecoveryGate &&
+          this.recoveringDeliveryIds.get(deliveryId) === recoveryGate
+        ) {
+          this.recoveringDeliveryIds.delete(deliveryId);
+        } else if (gateCurrent()) {
+          // Every current gate must end in either an authoritative release or
+          // another recovery pass. This also covers transient failures after
+          // the ownership CAS, such as lineage restoration or harness
+          // injection, rather than retrying only lost recovery ACKs.
+          retryNeeded = true;
+        }
+      }
+    }
+    if (this.stopped || generation !== this.welcomeGeneration) return;
+    // A harness execution may settle and remove both its WAL entry and pending
+    // record while a recovery pass is awaiting another entry or being replaced
+    // by a new welcome generation. Such a delivery no longer has ownership
+    // debt, so do not retain an orphan gate future snapshots can never visit.
+    for (const [deliveryId, recoveryGate] of this.recoveringDeliveryIds) {
+      if (journal.get(deliveryId) !== null) continue;
+      const stillPending = [...this.pending.values()].some(
+        (pending) => pending.delivery?.id === deliveryId,
+      );
+      if (stillPending) {
+        retryNeeded = true;
+      } else if (this.recoveringDeliveryIds.get(deliveryId) === recoveryGate) {
+        this.recoveringDeliveryIds.delete(deliveryId);
+      }
+    }
+    if (retryNeeded) {
+      this.scheduleJournalRecoveryRetry(generation);
+    } else {
+      this.resetJournalRecoveryBackoff(generation);
+    }
+  }
+
+  private continuationMatches(
+    delivery: DirectedDelivery,
+    message: MsgFrame,
+    parked: ParkedClaudeContinuation,
+  ): boolean {
+    const decision = message.decision_response;
+    return (
+      decision !== undefined &&
+      parked.workId === delivery.work_id &&
+      parked.continuationRef === delivery.continuation_ref &&
+      decision.delivery_id === parked.sourceDeliveryId &&
+      decision.origin_seq === parked.sourceMessage.seq &&
+      decision.origin_channel === this.options.channel &&
+      decision.work_id === parked.workId &&
+      decision.continuation_ref === parked.continuationRef &&
+      decision.request_seq === parked.questionSeq &&
+      message.reply_to === parked.questionSeq
+    );
+  }
+
+  private async recoverContinuationBinding(
+    delivery: DirectedDelivery,
+    message: MsgFrame,
+    key: string,
+    sourcePending: PendingChannelMessage | null,
+  ): Promise<ParkedClaudeContinuation | null> {
+    const decision = message.decision_response;
+    const loadMessage = this.options.loadMessage;
+    const recoveryGate = this.recoveringDeliveryIds.get(delivery.id) ?? null;
+    if (
+      decision === undefined ||
+      decision.delivery_id === undefined ||
+      decision.origin_seq === undefined ||
+      decision.origin_channel !== this.options.channel ||
+      decision.work_id !== delivery.work_id ||
+      decision.continuation_ref !== delivery.continuation_ref ||
+      message.reply_to !== decision.request_seq ||
+      loadMessage === undefined
+    ) {
+      return null;
+    }
+    const sourceMessage = await loadMessage(decision.origin_seq);
+    if (
+      recoveryGate !== null &&
+      (
+        recoveryGate.generation !== this.welcomeGeneration ||
+        this.recoveringDeliveryIds.get(delivery.id) !== recoveryGate
+      )
+    ) {
+      return null;
+    }
+    if (
+      sourceMessage === null ||
+      sourceMessage.seq !== decision.origin_seq
+    ) {
+      return null;
+    }
+    const parked: ParkedClaudeContinuation = {
+      key,
+      workId: delivery.work_id!,
+      continuationRef: delivery.continuation_ref!,
+      sourceDeliveryId: decision.delivery_id,
+      sourceMessage,
+      questionSeq: decision.request_seq,
+    };
+    if (!this.continuationMatches(delivery, message, parked)) return null;
+
+    // The privileged owner_answer delivery can only be created from the
+    // Worker's durable waiting_owner lineage. Together with the exact retained
+    // source row and the owner answer's snapshotted prompt/request_seq it is
+    // authoritative evidence that a source POST whose HTTP response was lost
+    // did persist. The old question itself may already be pruned. Recover its
+    // reply seq and stop stale running renewals without reposting the question.
+    if (
+      sourcePending !== null &&
+      sourcePending.delivery?.id === parked.sourceDeliveryId &&
+      sourcePending.message.seq === parked.sourceMessage.seq
+    ) {
+      sourcePending.replySeq = parked.questionSeq;
+      this.stopLeaseRenewal(sourcePending);
+      if (!sourcePending.replying) this.clearPending(sourcePending.message.seq);
+    }
+    this.parkedContinuations.set(key, parked);
+    return parked;
+  }
+
+  private async bindingFor(
+    delivery: DirectedDelivery,
+    message: MsgFrame,
+  ): Promise<ParkedClaudeContinuation | null> {
+    const key = continuationKey(delivery);
+    const decision = message.decision_response;
+    if (
+      key === null ||
+      this.completedContinuationKeys.has(key) ||
+      decision === undefined ||
+      delivery.work_id === null ||
+      delivery.continuation_ref === null
+    ) {
+      return null;
+    }
+    const sourcePending = [...this.pending.values()].find((pending) =>
+      pending.delivery !== null &&
+      pending.delivery.cause !== "owner_answer" &&
+      continuationKey(pending.delivery) === key &&
+      pending.delivery.id === decision.delivery_id &&
+      pending.message.seq === decision.origin_seq
+    ) ?? null;
+    const parked = this.parkedContinuations.get(key);
+    if (parked !== undefined) {
+      return this.continuationMatches(delivery, message, parked) ? parked : null;
+    }
+    if (sourcePending?.replySeq !== null && sourcePending?.replySeq !== undefined) {
+      const inFlight: ParkedClaudeContinuation = {
+        key,
+        workId: delivery.work_id,
+        continuationRef: delivery.continuation_ref,
+        sourceDeliveryId: sourcePending.delivery!.id,
+        sourceMessage: sourcePending.message,
+        questionSeq: sourcePending.replySeq,
+      };
+      if (!this.continuationMatches(delivery, message, inFlight)) return null;
+      // The owner answer can arrive before the source replied ACK finishes.
+      // Persist the exact in-memory binding now: claim-gated delivery stores
+      // only its key, and the later claim tool must still recover the source
+      // body + owner decision even if the source ACK lane is unresolved.
+      this.parkedContinuations.set(key, inFlight);
+      return inFlight;
+    }
+    return await this.recoverContinuationBinding(delivery, message, key, sourcePending);
+  }
+
+  private parkContinuation(pending: PendingChannelMessage): ParkedClaudeContinuation | null {
+    const delivery = pending.delivery;
+    const key = delivery === null ? null : continuationKey(delivery);
+    if (
+      delivery === null ||
+      key === null ||
+      delivery.work_id === null ||
+      delivery.continuation_ref === null ||
+      pending.replySeq === null
+    ) {
+      throw new Error(
+        `waiting_owner delivery ${delivery?.id ?? pending.message.seq} has incomplete continuation lineage`,
+      );
+    }
+    if (this.completedContinuationKeys.has(key)) return null;
+    const parked = {
+      key,
+      workId: delivery.work_id,
+      continuationRef: delivery.continuation_ref,
+      sourceDeliveryId: delivery.id,
+      sourceMessage: pending.message,
+      questionSeq: pending.replySeq,
+    };
+    this.parkedContinuations.set(key, parked);
+    return parked;
+  }
+
+  private releaseParkedContinuation(pending: PendingChannelMessage): void {
+    if (pending.delivery?.cause !== "owner_answer" || pending.continuationKey === null) return;
+    this.rememberBounded(this.completedContinuationKeys, pending.continuationKey);
+    this.parkedContinuations.delete(pending.continuationKey);
+  }
+
+  private async failPending(seq: number, error: string): Promise<void> {
+    const pending = this.pending.get(seq) ?? null;
+    if (!pending) return;
+    if (pending.settling) return;
+    if (!pending.delivery) {
+      this.clearPending(seq);
+      return;
+    }
+    pending.terminalError = error;
+    try {
+      if (pending.delivery) {
+        this.options.recoveryJournal?.update(pending.delivery.id, {
+          phase: "failed_pending",
+          terminalError: error,
+        });
+      }
+    } catch (journalError) {
+      pending.settling = false;
+      this.out(
+        `claude-channel: could not durably record failed delivery ${pending.delivery.id}: ` +
+          `${journalError instanceof Error ? journalError.message : String(journalError)}`,
+      );
+      this.schedulePendingRetry(pending, "failed-delivery journal", async () => {
+        await this.failPending(seq, pending.terminalError ?? error);
+      });
+      return;
+    }
+    pending.settling = true;
+    this.stopLeaseRenewal(pending);
+    try {
+      const state = await this.confirmDeliveryUpdate(deliveryUpdate(pending.delivery, "failed", {
+        error: error.slice(0, 500),
+      }));
+      if (state !== "failed") {
+        throw new Error(`delivery state is ${state}, expected failed`);
+      }
+      const completed = this.clearPending(seq);
+      if (completed?.delivery) {
+        this.options.recoveryJournal?.remove(completed.delivery.id);
+        this.rememberBounded(this.settledDeliveryIds, completed.delivery.id);
+        this.releaseParkedContinuation(completed);
+      }
+    } catch (updateError) {
+      pending.settling = false;
+      this.out(
+        `claude-channel: could not confirm failed delivery ${pending.delivery.id}: ` +
+          `${updateError instanceof Error ? updateError.message : String(updateError)}`,
+      );
+      this.schedulePendingRetry(pending, "failed acknowledgement", async () => {
+        await this.failPending(seq, error);
+      });
+    }
+  }
+
+  private async inject(
+    message: MsgFrame,
+    delivery: DirectedDelivery | null,
+    claimAlreadyJournaled = false,
+  ): Promise<boolean> {
+    const existing = this.pending.get(message.seq);
+    if (existing) {
+      if (
+        existing.terminalError !== null &&
+        !existing.settling &&
+        existing.retryTimer === null
+      ) {
+        await this.failPending(message.seq, existing.terminalError);
+      } else if (
+        existing.terminalError === null &&
+        existing.replyBody !== null &&
+        !existing.replying
+      ) {
+        // A reconnect/redelivery is another authoritative opportunity to
+        // reconcile the same stable REST idempotency key or terminal ACK.
+        // Accelerate out of a long cooldown, while retaining one single-flight
+        // timer/action for the pending row.
+        this.stopPendingRetry(existing);
+        existing.retryRound = 0;
+        this.scheduleReplyRetry(existing);
+      }
+      return true;
+    }
+    if (delivery !== null && !claimAlreadyJournaled) {
+      this.options.recoveryJournal?.recordClaim(delivery, message);
+    }
+    let ownerAnswerBinding: ParkedClaudeContinuation | null = null;
+    if (delivery?.cause === "owner_answer") {
+      try {
+        ownerAnswerBinding = await this.bindingFor(delivery, message);
+      } catch (error) {
+        // A history outage is not proof that the privileged owner answer is
+        // invalid. Leave it claimed so the Worker can retry rather than
+        // emitting an irreversible failed receipt from incomplete evidence.
+        this.out(
+          `claude-channel: could not reconcile owner answer ${delivery.id} from durable history: ` +
+            `${error instanceof Error ? error.message : String(error)}`,
+        );
+        return false;
+      }
+    }
+    if (delivery?.cause === "owner_answer" && ownerAnswerBinding === null) {
+      const detail = "owner answer has no exact parked delivery/work/continuation lineage";
+      const rejected: PendingChannelMessage = {
+        message,
+        delivery,
+        renewTimer: null,
+        renewEpoch: 0,
+        renewing: false,
+        retryTimer: null,
+        retryRound: 0,
+        replying: false,
+        settling: false,
+        terminalError: detail,
+        recoveryTimer: null,
+        harnessClaimed: false,
+        claimReceipt: null,
+        claimNotificationAttempts: 0,
+        replyIdempotencyKey: replyIdempotencyKey(this.options.channel, message, delivery),
+        replyBody: null,
+        replySeq: null,
+        // An invalid owner answer must not release a possibly unrelated parked
+        // continuation even if its failed ACK is accepted.
+        continuationKey: null,
+      };
+      this.pending.set(message.seq, rejected);
+      await this.failPending(message.seq, detail);
+      this.out(`claude-channel: rejected owner answer ${delivery.id}: ${detail}`);
+      return true;
+    }
+    const pending: PendingChannelMessage = {
+      message,
+      delivery,
+      renewTimer: null,
+      renewEpoch: 0,
+      renewing: false,
+      retryTimer: null,
+      retryRound: 0,
+      replying: false,
+      settling: false,
+      terminalError: null,
+      recoveryTimer: null,
+      harnessClaimed: false,
+      claimReceipt: null,
+      claimNotificationAttempts: 0,
+      replyIdempotencyKey: replyIdempotencyKey(this.options.channel, message, delivery),
+      replyBody: null,
+      replySeq: null,
+      continuationKey: ownerAnswerBinding?.key ?? null,
+    };
+    this.pending.set(message.seq, pending);
+    if (delivery !== null) {
+      try {
+        const state = await this.confirmDeliveryUpdate(deliveryUpdate(delivery, "running"));
+        if (state !== "running") {
+          throw new Error(`delivery state is ${state}, expected running`);
+        }
+        this.options.recoveryJournal?.update(delivery.id, {
+          phase: "running_authorized",
+          delivery: { ...delivery, state: "running" },
+        });
+      } catch (error) {
+        if (error instanceof DeliveryConnectionReplacedError) {
+          this.out(
+            `claude-channel: running acknowledgement for ${delivery.id} was interrupted by reconnect; ` +
+              "recovering its durable ownership before notification",
+          );
+          return false;
+        }
+        const detail = error instanceof Error ? error.message : String(error);
+        await this.failPending(
+          message.seq,
+          `could not confirm running delivery before Claude notification: ${detail}`.slice(0, 500),
+        );
+        this.out(
+          `claude-channel: could not claim running delivery ${delivery.id}: ` +
+            detail,
+        );
+        return false;
+      }
+      this.startLeaseRenewal(pending);
+    }
+    try {
+      if (delivery !== null) {
+        this.options.recoveryJournal?.update(delivery.id, { phase: "harness_issued" });
+      }
+      if (this.options.requireHarnessClaim === true && delivery !== null) {
+        await this.notifyHarnessClaim(pending);
+      } else {
+        await this.options.notify(
+          notificationFor(this.options.channel, message, delivery, ownerAnswerBinding),
+        );
+      }
+      if (delivery !== null && this.options.requireHarnessClaim !== true) {
+        pending.harnessClaimed = true;
+        this.options.recoveryJournal?.update(delivery.id, { phase: "harness_accepted" });
+      }
+      this.out(
+        `claude-channel: queued #${this.options.channel} seq=${message.seq} from @${message.sender.name}` +
+          (delivery === null ? "" : ` delivery=${delivery.id}`),
+      );
+      return true;
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      if (delivery !== null && this.options.requireHarnessClaim !== true) {
+        // The full task body was handed to the Channel transport. A rejection
+        // and an after-write disconnect are observationally identical here:
+        // neither authorizes replay or an ordinary failed receipt.
+        this.preservePostHarnessDebt(
+          pending,
+          `Claude channel notification outcome is uncertain: ${detail}`,
+        );
+        this.out(`claude-channel: uncertain injection for seq=${message.seq}: ${detail}`);
+        return true;
+      }
+      await this.failPending(
+        message.seq,
+        `claude channel notification failed: ${detail}`.slice(0, 500),
+      );
+      this.out(`claude-channel: failed to inject seq=${message.seq}: ${detail}`);
+      return false;
+    }
+  }
+
+  async handleFrame(incoming: ServerFrame): Promise<void> {
+    if (incoming.type === "delivery_recovery") {
+      this.observeDeliveryRecovery(incoming);
+      return;
+    }
+    if (incoming.type === "delivery_state") {
+      this.observeDeliveryAck(incoming);
+      return;
+    }
+    if (incoming.type === "welcome") {
+      const reconnect = this.welcomeGeneration > 0;
+      this.welcomeGeneration += 1;
+      this.resetJournalRecoveryBackoff(this.welcomeGeneration);
+      if (reconnect) {
+        for (const [requestId, pending] of this.deliveryAcks) {
+          clearTimeout(pending.timer);
+          pending.reject(new DeliveryConnectionReplacedError(
+            "AgentParty websocket was replaced before the delivery acknowledgement arrived",
+          ));
+          this.deliveryAcks.delete(requestId);
+        }
+        for (const [requestId, pending] of this.deliveryRecoveries) {
+          clearTimeout(pending.timer);
+          pending.reject(new DeliveryConnectionReplacedError(
+            "AgentParty websocket was replaced before ownership recovery completed",
+          ));
+          this.deliveryRecoveries.delete(requestId);
+        }
+        for (const pending of this.pending.values()) {
+          this.stopLeaseRenewal(pending);
+          if (pending.recoveryTimer) clearTimeout(pending.recoveryTimer);
+          pending.recoveryTimer = null;
+        }
+      }
+      this.self = incoming.self;
+      this.directedDeliveryMode = incoming.directed_delivery === "v1";
+      if (
+        this.options.requireHarnessClaim === true &&
+        (!this.directedDeliveryMode || incoming.delivery_recovery !== "v1")
+      ) {
+        this.exitCode = 1;
+        this.out(
+          "claude-channel: Worker lacks directed_delivery v1 + delivery_recovery v1; " +
+            "refusing same-session execution without durable ownership",
+        );
+        this.options.connection.close();
+        return;
+      }
+      if (this.directedDeliveryMode) {
+        this.options.connection.send({ type: "delivery_adapter", adapter: "watch", op: "register" });
+        // Recovery starts immediately instead of sitting behind a running-ACK
+        // waiter from the dead socket. New work remains behind the joined
+        // barrier until both the cancelled old lane and ownership CAS settle.
+        const generation = this.welcomeGeneration;
+        this.joinJournalRecovery(generation);
+      }
+      this.out(
+        `claude-channel: attached to #${this.options.channel} as @${this.self}` +
+          (this.directedDeliveryMode ? " (directed-delivery v1)" : " (legacy message fallback)"),
+      );
+      return;
+    }
+    if (incoming.type === "error") {
+      // delivery_update errors are not correlated with request_id on the wire.
+      // A renewal already in flight can race a REST reply that made the row
+      // terminal. Keep the bridge alive and let the bounded ACK waiter
+      // timeout/cancel instead of treating that stale receipt as a session-wide
+      // fatal error.
+      if (
+        incoming.code === "bad_request" &&
+        (this.deliveryAcks.size > 0 || this.deliveryRecoveries.size > 0)
+      ) {
+        this.out(
+          `claude-channel: ignored uncorrelated delivery update error while awaiting ACK: ${incoming.message}`,
+        );
+        return;
+      }
+      this.out(`claude-channel: AgentParty error ${incoming.code}: ${incoming.message}`);
+      if (incoming.code === "unauthorized") this.exitCode = EXIT_AUTH;
+      else if (incoming.code === "archived") this.exitCode = EXIT_ARCHIVED;
+      else this.exitCode = 1;
+      this.options.connection.close();
+      return;
+    }
+
+    const delivery = incoming.type === "delivery" ? incoming.delivery : null;
+    const message = incoming.type === "delivery" ? incoming.message : incoming;
+    if (message.type !== "msg") return;
+
+    if (delivery !== null) {
+      // Server-side membership and target routing are the trust boundary. The
+      // adapter additionally fails closed on a mismatched target/state and
+      // never lets the current session wake itself.
+      if (
+        delivery.target_name !== this.self ||
+        delivery.state !== "claimed" ||
+        message.sender.name === this.self ||
+        this.settledDeliveryIds.has(delivery.id)
+      ) {
+        return;
+      }
+      await this.inject(message, delivery);
+      return;
+    }
+
+    const fresh = message.seq > this.options.connection.cursor;
+    const mentioned = message.mentions.includes(this.self);
+    if (this.directedDeliveryMode && mentioned) {
+      if (fresh) this.options.connection.ack(message.seq);
+      return;
+    }
+    if (
+      !fresh ||
+      !mentioned ||
+      message.sender.name === this.self ||
+      this.seenPlainSeqs.has(message.seq)
+    ) {
+      if (fresh) this.options.connection.ack(message.seq);
+      return;
+    }
+    const injected = await this.inject(message, null);
+    if (injected) {
+      this.rememberBounded(this.seenPlainSeqs, message.seq);
+      if (fresh) this.options.connection.ack(message.seq);
+    }
+  }
+
+  private async postPendingReply(pending: PendingChannelMessage): Promise<void> {
+    if (pending.replySeq !== null) return;
+    if (pending.replyBody === null) {
+      throw new Error(`linked reply for seq=${pending.message.seq} has no persisted body`);
+    }
+    const posted = await this.options.postReply({
+      body: pending.replyBody,
+      mentions: [pending.message.sender.name],
+      replyTo: pending.message.seq,
+      idempotencyKey: pending.replyIdempotencyKey,
+    });
+    pending.replySeq = posted.seq;
+    if (pending.delivery) {
+      this.options.recoveryJournal?.update(pending.delivery.id, {
+        phase: "reply_posted",
+        replyBody: pending.replyBody,
+        replySeq: posted.seq,
+      });
+    }
+    pending.retryRound = 0;
+  }
+
+  private async settlePendingReply(pending: PendingChannelMessage): Promise<{ seq: number }> {
+    const seq = pending.message.seq;
+    const replySeq = pending.replySeq;
+    if (replySeq === null) {
+      throw new Error(`linked reply for seq=${seq} did not return a sequence`);
+    }
+    if (pending.delivery === null) {
+      this.clearPending(seq);
+      this.out(`claude-channel: replied to seq=${seq} with seq=${replySeq}`);
+      return { seq: replySeq };
+    }
+
+    const state = await this.confirmDeliveryUpdate(
+      deliveryUpdate(pending.delivery, "replied", { replySeq }),
+    );
+    if (state === "waiting_owner") {
+      if (pending.delivery.cause === "owner_answer") {
+        throw new Error("owner answer delivery unexpectedly remained waiting_owner");
+      }
+      const parked = this.parkContinuation(pending);
+      if (parked) {
+        this.out(
+          `claude-channel: parked delivery ${pending.delivery.id} as ` +
+            `${parked.workId}/${parked.continuationRef} until its owner answer arrives`,
+        );
+      } else {
+        this.out(
+          `claude-channel: ignored late waiting_owner acknowledgement for completed ` +
+            `continuation ${pending.delivery.id}`,
+        );
+      }
+    } else if (state !== "replied") {
+      throw new Error(`delivery state is ${state}, expected replied or waiting_owner`);
+    }
+    const completed = this.clearPending(seq);
+    if (completed?.delivery) {
+      this.options.recoveryJournal?.remove(completed.delivery.id);
+      this.rememberBounded(this.settledDeliveryIds, completed.delivery.id);
+      if (state === "replied") this.releaseParkedContinuation(completed);
+    }
+    this.out(`claude-channel: replied to seq=${seq} with seq=${replySeq}`);
+    return { seq: replySeq };
+  }
+
+  private async persistAndSettlePendingReply(
+    pending: PendingChannelMessage,
+  ): Promise<{ seq: number }> {
+    try {
+      await this.postPendingReply(pending);
+    } catch (error) {
+      if (pending.replySeq === null) throw error;
+      // An owner_answer may have arrived while the source POST response was
+      // lost. Its privileged request_seq + durable source history recovered
+      // the exact reply sequence, so continue as success instead of returning
+      // a false tool error and asking Claude to repost.
+      this.out(
+        `claude-channel: recovered linked reply seq=${pending.replySeq} for ` +
+          `source seq=${pending.message.seq} from authoritative owner answer`,
+      );
+    }
+    return await this.settlePendingReply(pending);
+  }
+
+  private scheduleReplyRetry(pending: PendingChannelMessage): void {
+    this.schedulePendingRetry(pending, "linked reply settlement", async () => {
+      if (this.pending.get(pending.message.seq) !== pending || pending.replying) return;
+      pending.replying = true;
+      this.stopLeaseRenewal(pending);
+      try {
+        await this.persistAndSettlePendingReply(pending);
+      } catch (error) {
+        pending.replying = false;
+        if (pending.replySeq === null) this.startLeaseRenewal(pending);
+        throw error;
+      }
+    });
+  }
+
+  claim(executionId: string): { claimed: boolean; receipt: string | null; content: string } {
+    const pending = [...this.pending.values()].find(
+      (candidate) => candidate.delivery?.id === executionId,
+    );
+    if (pending === undefined || pending.delivery === null) {
+      throw new Error(`no recoverable AgentParty execution for ${executionId}`);
+    }
+    if (pending.terminalError !== null) {
+      throw new Error(`AgentParty execution ${executionId} is already failing`);
+    }
+    if (this.recoveringDeliveryIds.has(executionId)) {
+      throw new Error(
+        `AgentParty execution ${executionId} is recovering ownership; retry the claim`,
+      );
+    }
+    if (pending.harnessClaimed) {
+      return {
+        claimed: false,
+        receipt: pending.claimReceipt,
+        content:
+          `Execution ${executionId} receipt ${pending.claimReceipt ?? "(unknown)"} was already accepted. ` +
+          "Do not execute it again and do not send another reply.",
+      };
+    }
+    const journal = this.options.recoveryJournal;
+    if (journal === undefined) {
+      throw new Error(`AgentParty execution ${executionId} has no durable claim journal`);
+    }
+    let receipt = pending.claimReceipt;
+    if (receipt === null) {
+      const candidate = randomUUID();
+      // Persist the invocation identity before returning any task content.
+      // If this commit fails, no body is released. If the MCP response is lost
+      // afterward, the same generation returns the same receipt and body.
+      const entry = journal.update(executionId, { claimReceipt: candidate });
+      receipt = entry.claimReceipt;
+      pending.claimReceipt = receipt;
+    }
+    if (receipt === null) {
+      throw new Error(`AgentParty execution ${executionId} could not allocate a claim receipt`);
+    }
+    const continuation = pending.continuationKey === null
+      ? null
+      : this.parkedContinuations.get(pending.continuationKey) ?? null;
+    return {
+      claimed: true,
+      receipt,
+      content:
+        `AgentParty claim receipt: ${receipt}\n` +
+        `Before doing any work or causing any side effect, call ${ACCEPT_TOOL} with ` +
+        `execution_id=${executionId} and claim_receipt=${receipt}. ` +
+        "If this exact receipt is already present in the session, do not execute it twice.\n\n" +
+        notificationFor(
+          this.options.channel,
+          pending.message,
+          pending.delivery,
+          continuation,
+        ).content,
+    };
+  }
+
+  accept(executionId: string, claimReceipt: string): { accepted: boolean; content: string } {
+    const pending = [...this.pending.values()].find(
+      (candidate) => candidate.delivery?.id === executionId,
+    );
+    if (pending === undefined || pending.delivery === null) {
+      throw new Error(`no recoverable AgentParty execution for ${executionId}`);
+    }
+    if (pending.terminalError !== null) {
+      throw new Error(`AgentParty execution ${executionId} is already failing`);
+    }
+    if (this.recoveringDeliveryIds.has(executionId)) {
+      throw new Error(
+        `AgentParty execution ${executionId} is recovering ownership; retry acceptance`,
+      );
+    }
+    if (
+      pending.claimReceipt === null ||
+      claimReceipt.length === 0 ||
+      claimReceipt !== pending.claimReceipt
+    ) {
+      throw new Error(
+        `claim receipt for AgentParty execution ${executionId} is invalid or belongs to an old ownership generation`,
+      );
+    }
+    if (pending.harnessClaimed) {
+      return {
+        accepted: false,
+        content:
+          `Execution ${executionId} receipt ${claimReceipt} was already durably accepted. ` +
+          "Continue the existing execution; do not execute it twice.",
+      };
+    }
+    const journal = this.options.recoveryJournal;
+    if (journal === undefined) {
+      throw new Error(`AgentParty execution ${executionId} has no durable claim journal`);
+    }
+    const current = journal.get(executionId);
+    if (
+      current === null ||
+      current.phase !== "harness_issued" ||
+      current.claimReceipt !== claimReceipt
+    ) {
+      throw new Error(
+        `claim receipt for AgentParty execution ${executionId} is no longer current`,
+      );
+    }
+    // The accept request itself proves the harness received the full claim
+    // result (the unpredictable receipt is only present there). Commit before
+    // acknowledging the tool call; an ACK loss is therefore idempotent.
+    journal.update(executionId, {
+      phase: "harness_accepted",
+      claimReceipt,
+    });
+    pending.harnessClaimed = true;
+    if (pending.recoveryTimer) clearTimeout(pending.recoveryTimer);
+    pending.recoveryTimer = null;
+    return {
+      accepted: true,
+      content:
+        `Execution ${executionId} receipt ${claimReceipt} is durably accepted. ` +
+        "Execute it once, then send exactly one linked reply.",
+    };
+  }
+
+  async reply(seq: number, text: string): Promise<{ seq: number }> {
+    if (!Number.isSafeInteger(seq) || seq <= 0) {
+      throw new Error("seq must be a positive integer");
+    }
+    const body = text.trim();
+    if (body.length === 0) throw new Error("reply text must not be empty");
+    if (new TextEncoder().encode(body).byteLength > BODY_LIMIT) {
+      throw new Error(`reply exceeds ${BODY_LIMIT} UTF-8 bytes`);
+    }
+    const pending = this.pending.get(seq);
+    if (!pending) {
+      throw new Error(`no pending AgentParty channel message for seq=${seq}; it may already have been replied to`);
+    }
+    if (pending.terminalError !== null) {
+      throw new Error(`delivery for seq=${seq} already failed before Claude could reply`);
+    }
+    if (
+      this.options.requireHarnessClaim === true &&
+      pending.delivery !== null &&
+      !pending.harnessClaimed
+    ) {
+      throw new Error(
+        `delivery for seq=${seq} must be claimed with ${CLAIM_TOOL} and accepted with ` +
+          `${ACCEPT_TOOL} before replying`,
+      );
+    }
+    if (pending.replying) throw new Error(`reply already in progress for seq=${seq}`);
+    pending.replyBody ??= body;
+    if (pending.delivery) {
+      this.options.recoveryJournal?.update(pending.delivery.id, {
+        replyBody: pending.replyBody,
+      });
+    }
+    // A durable reply body supersedes every claim/recovery timeout. Clear the
+    // timer before the first asynchronous persistence boundary so no callback
+    // can race this exact late-success path into a permanent failed state.
+    if (pending.recoveryTimer) clearTimeout(pending.recoveryTimer);
+    pending.recoveryTimer = null;
+    pending.replying = true;
+    this.stopPendingRetry(pending);
+    // Stop/epoch-guard renewal before REST persistence starts. The Worker may
+    // make the delivery terminal/waiting_owner before the HTTP response reaches
+    // us; a stale running update after that point would otherwise be rejected
+    // and could tear down the whole channel bridge.
+    this.stopLeaseRenewal(pending);
+
+    try {
+      return await this.persistAndSettlePendingReply(pending);
+    } catch (error) {
+      pending.replying = false;
+      if (pending.replySeq === null) this.startLeaseRenewal(pending);
+      this.scheduleReplyRetry(pending);
+      const phase = pending.replySeq === null ? "persistence" : "delivery acknowledgement";
+      this.out(
+        `claude-channel: linked reply ${phase} did not settle for seq=${seq}: ` +
+          `${error instanceof Error ? error.message : String(error)}`,
+      );
+      throw error;
+    }
+  }
+
+  close(): void {
+    this.intentionalClose = true;
+    this.stopped = true;
+    this.cancelJournalRecoveryRetry();
+    for (const seq of [...this.pending.keys()]) this.clearPending(seq);
+    this.parkedContinuations.clear();
+    this.completedContinuationKeys.clear();
+    for (const [requestId, pending] of this.deliveryAcks) {
+      clearTimeout(pending.timer);
+      pending.reject(new Error("Claude Channel bridge closed"));
+      this.deliveryAcks.delete(requestId);
+    }
+    for (const [requestId, pending] of this.deliveryRecoveries) {
+      clearTimeout(pending.timer);
+      pending.reject(new Error("Claude Channel bridge closed"));
+      this.deliveryRecoveries.delete(requestId);
+    }
+    this.options.connection.close();
+  }
+
+  async run(): Promise<number> {
+    try {
+      for await (const frame of this.options.connection.frames) {
+        if (
+          frame.type === "delivery_state" ||
+          frame.type === "delivery_recovery" ||
+          frame.type === "welcome" ||
+          frame.type === "error"
+        ) {
+          await this.handleFrame(frame);
+          continue;
+        }
+        // Keep the stream reader available for delivery_state ACKs while the
+        // ordered work lane waits for those confirmations.
+        this.frameWork = this.frameWork
+          .then(() => this.handleFrame(frame))
+          .catch((error) => {
+            this.out(
+              `claude-channel: failed to process AgentParty frame: ` +
+                `${error instanceof Error ? error.message : String(error)}`,
+            );
+          });
+      }
+    } finally {
+      this.stopped = true;
+      this.cancelJournalRecoveryRetry();
+      for (const [requestId, pending] of this.deliveryAcks) {
+        clearTimeout(pending.timer);
+        pending.reject(new Error("Claude Channel frame stream stopped"));
+        this.deliveryAcks.delete(requestId);
+      }
+      for (const [requestId, pending] of this.deliveryRecoveries) {
+        clearTimeout(pending.timer);
+        pending.reject(new Error("Claude Channel frame stream stopped"));
+        this.deliveryRecoveries.delete(requestId);
+      }
+      await this.frameWork;
+      for (const seq of [...this.pending.keys()]) this.clearPending(seq);
+      this.parkedContinuations.clear();
+      this.completedContinuationKeys.clear();
+      this.options.connection.close();
+    }
+    if (this.intentionalClose) return this.exitCode;
+    return this.exitCode === 0 ? EXIT_STREAM_ENDED : this.exitCode;
+  }
+}
+
+function toolResult(text: string, isError = false): {
+  content: Array<{ type: "text"; text: string }>;
+  isError?: true;
+} {
+  return {
+    content: [{ type: "text", text }],
+    ...(isError ? { isError: true as const } : {}),
+  };
+}
+
+export async function run(argv: string[]): Promise<number> {
+  if (isHelpArg(argv, { allowHelpPositional: true })) {
+    console.log(HELP);
+    return 0;
+  }
+  const { positionals, flags } = parseArgs(argv);
+  const unknown = unknownFlagError(flags, ["channel"]);
+  if (unknown !== null) {
+    console.error(unknown);
+    return 1;
+  }
+  const flagError = valueFlagError(flags, ["channel"]);
+  if (flagError !== null) {
+    console.error(flagError);
+    return 1;
+  }
+  if (positionals.length > 1) {
+    console.error("usage: party claude-channel [channel|--channel C]");
+    return 1;
+  }
+
+  const auth = await resolveAuthDetailed();
+  if (!auth.server || !auth.token) {
+    console.error("claude-channel: no config, run: party login or party init --server URL --token T");
+    return 1;
+  }
+  const serverUrl = auth.server;
+  const token = auth.token;
+  const channel = resolveChannel(str(flags.channel) ?? positionals[0]);
+  if (!channel) {
+    console.error("claude-channel: no channel, pass one or bind with: party init --channel C");
+    return 1;
+  }
+  if (!isSlug(channel)) {
+    console.error("claude-channel: channel must match [a-z0-9][a-z0-9-]{0,63}");
+    return 1;
+  }
+
+  // Reuse the serve lock namespace: `party serve` and a live-session channel
+  // adapter are two delivery consumers for the same identity/channel and must
+  // never execute the same work concurrently.
+  const lock = acquireInstanceLock(
+    "serve",
+    instanceLockTarget(serverUrl, token, channel),
+    defaultInstanceLockDir(),
+  );
+  if (!lock.ok) {
+    console.error(
+      `claude-channel: another serve/session bridge already owns #${channel}` +
+        (lock.heldByPid === undefined ? "" : ` (pid=${lock.heldByPid})`),
+    );
+    return 1;
+  }
+
+  const connection = connect(serverUrl, token, channel, loadCursor(channel), {
+    directedDelivery: "v1",
+    deliveryRecovery: "v1",
+    advertiseWakeKind: "daemon",
+    onCursor: (cursor) => saveCursor(channel, cursor),
+  });
+  const recoveryJournal = new DeliveryRecoveryJournal(
+    deliveryRecoveryJournalPath("claude", serverUrl, token, channel),
+    channel,
+    "claude",
+  );
+  const server = new Server<Request, ClaudeChannelNotification, Result>(
+    { name: "agentparty-channel", version: pkg.version },
+    {
+      capabilities: {
+        experimental: { "claude/channel": {} },
+        tools: {},
+      },
+      instructions:
+        `Durable AgentParty inputs must first be fetched with ${CLAIM_TOOL}. The same unaccepted ` +
+        "ownership generation returns one stable receipt and body. After reading the complete result, " +
+        `call ${ACCEPT_TOOL} with the exact execution id and receipt before doing any work or causing ` +
+        `any side effect. Only after that durable acceptance may you execute and reply once with ${REPLY_TOOL}; ` +
+        "do not use party_send for a channel reply. A tool success means the linked AgentParty reply was persisted.",
+    },
+  );
+  let markMcpInitialized!: (ready: boolean) => void;
+  const mcpInitialized = new Promise<boolean>((resolve) => {
+    markMcpInitialized = resolve;
+  });
+  const bridge = new ClaudeChannelDeliveryBridge({
+    channel,
+    connection,
+    recoveryJournal,
+    requireHarnessClaim: true,
+    notify: async (notification) => {
+      if (!await mcpInitialized) throw new Error("Claude closed the MCP channel before initialization");
+      await server.notification({
+        method: "notifications/claude/channel",
+        params: notification,
+      });
+    },
+    postReply: async ({ body, mentions, replyTo, idempotencyKey }) => {
+      const posted = await postMessage(serverUrl, token, channel, {
+        kind: "message",
+        body,
+        mentions,
+        reply_to: replyTo,
+        idempotency_key: idempotencyKey,
+      });
+      return { seq: posted.seq };
+    },
+    loadMessage: async (seq) => {
+      const messages = await fetchMessages(
+        serverUrl,
+        token,
+        channel,
+        Math.max(0, seq - 1),
+        1,
+      );
+      return messages.find((message) => message.seq === seq) ?? null;
+    },
+  });
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: [
+      {
+        name: CLAIM_TOOL,
+        title: "Claim one durable AgentParty delivery",
+        description:
+          "Fetch a stable claim receipt and task body. Repeating an unaccepted claim in the same ownership generation returns the same receipt and body.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            execution_id: {
+              type: "string",
+              minLength: 1,
+              description: "execution_id from the AgentParty channel notification",
+            },
+          },
+          required: ["execution_id"],
+          additionalProperties: false,
+        },
+      },
+      {
+        name: ACCEPT_TOOL,
+        title: "Accept one claimed AgentParty delivery",
+        description:
+          "Durably acknowledge that the full claim result reached this Claude session. Call this with the exact receipt before any work or side effect.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            execution_id: {
+              type: "string",
+              minLength: 1,
+              description: "execution_id returned by the claim notification",
+            },
+            claim_receipt: {
+              type: "string",
+              minLength: 1,
+              description: "exact stable receipt returned by party_channel_claim",
+            },
+          },
+          required: ["execution_id", "claim_receipt"],
+          additionalProperties: false,
+        },
+      },
+      {
+        name: REPLY_TOOL,
+        title: "Reply to an AgentParty Channel message",
+        description:
+          "Persist one reply to the exact AgentParty message that entered this Claude session. Use the seq from the channel input.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            seq: { type: "integer", minimum: 1, description: "AgentParty message sequence from the channel input" },
+            text: { type: "string", minLength: 1, description: "Reply body" },
+          },
+          required: ["seq", "text"],
+          additionalProperties: false,
+        },
+      },
+    ],
+  }));
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    if (request.params.name === CLAIM_TOOL) {
+      const executionId = request.params.arguments?.execution_id;
+      if (typeof executionId !== "string") {
+        return toolResult(`${CLAIM_TOOL} requires string execution_id`, true);
+      }
+      try {
+        const claimed = bridge.claim(executionId);
+        return toolResult(claimed.content, !claimed.claimed);
+      } catch (error) {
+        return toolResult(error instanceof Error ? error.message : String(error), true);
+      }
+    }
+    if (request.params.name === ACCEPT_TOOL) {
+      const executionId = request.params.arguments?.execution_id;
+      const claimReceipt = request.params.arguments?.claim_receipt;
+      if (typeof executionId !== "string" || typeof claimReceipt !== "string") {
+        return toolResult(
+          `${ACCEPT_TOOL} requires string execution_id and string claim_receipt`,
+          true,
+        );
+      }
+      try {
+        const accepted = bridge.accept(executionId, claimReceipt);
+        return toolResult(accepted.content);
+      } catch (error) {
+        return toolResult(error instanceof Error ? error.message : String(error), true);
+      }
+    }
+    if (request.params.name !== REPLY_TOOL) {
+      return toolResult(`unknown tool: ${request.params.name}`, true);
+    }
+    const args = request.params.arguments;
+    const seq = args?.seq;
+    const text = args?.text;
+    if (typeof seq !== "number" || typeof text !== "string") {
+      return toolResult(`${REPLY_TOOL} requires integer seq and string text`, true);
+    }
+    try {
+      const posted = await bridge.reply(seq, text);
+      return toolResult(`AgentParty reply persisted as seq=${posted.seq} (reply_to=${seq}).`);
+    } catch (error) {
+      return toolResult(error instanceof Error ? error.message : String(error), true);
+    }
+  });
+
+  server.oninitialized = () => markMcpInitialized(true);
+  server.onclose = () => {
+    markMcpInitialized(false);
+    bridge.close();
+  };
+  try {
+    await server.connect(new StdioServerTransport());
+    return await bridge.run();
+  } finally {
+    bridge.close();
+    try {
+      await server.close();
+    } catch {
+      // Transport may already be closed because Claude ended the session.
+    }
+    lock.release?.();
+  }
+}

--- a/cli/src/commands/codex-bridge.ts
+++ b/cli/src/commands/codex-bridge.ts
@@ -1,0 +1,942 @@
+// Runtime wiring for `party bridge codex`.
+//
+// The interactive Codex TUI connects to a private Unix WebSocket endpoint.
+// This process owns the only stdio app-server connection and also consumes
+// AgentParty delivery, so every writer crosses one CodexSessionController.
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { chmodSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  CodexAgentPartyBridge,
+  CodexRpcClient,
+  CodexSessionController,
+  CodexUnixJsonRpcProxy,
+  type CodexFrontendReset,
+  type CodexFrontendRecovery,
+} from "../codex-app-server-bridge";
+import { connect, type Connection } from "../client";
+import { loadCursor, saveCursor } from "../config";
+import {
+  DeliveryRecoveryJournal,
+  deliveryRecoveryJournalPath,
+} from "../delivery-recovery-journal";
+import {
+  acquireInstanceLock,
+  defaultInstanceLockDir,
+  instanceLockTarget,
+  type InstanceLock,
+} from "../instance-lock";
+import { resolveAuthDetailed } from "../oidc-cli";
+import { postMessage } from "../rest";
+
+export interface CodexBridgeRuntimeOptions {
+  channel: string;
+  codexBinary: string;
+  codexArgs?: string[];
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+}
+
+export interface BridgeChildProcess {
+  readonly exited: Promise<number>;
+  kill(signal?: number | NodeJS.Signals): void;
+}
+
+export interface CodexBridgeRuntimeDeps {
+  resolveAuth?: typeof resolveAuthDetailed;
+  connectAgentParty?: typeof connect;
+  spawnAppServer?: (options: {
+    codexBinary: string;
+    cwd: string;
+    env: NodeJS.ProcessEnv;
+  }) => ChildProcessWithoutNullStreams;
+  launchTui?: (
+    codexBinary: string,
+    args: string[],
+    options: { cwd: string; env: NodeJS.ProcessEnv },
+  ) => BridgeChildProcess;
+  runtimeDir?: () => string;
+  removeRuntimeDir?: (path: string) => void;
+  installSignalHandlers?: (
+    handler: (signal: "SIGINT" | "SIGTERM") => void,
+  ) => () => void;
+  terminationGraceMs?: number;
+  killWaitMs?: number;
+  log?: (line: string) => void;
+}
+
+export function buildCodexTuiArgs(socketPath: string, codexArgs: string[] = []): string[] {
+  return ["--remote", `unix://${socketPath}`, ...codexArgs];
+}
+
+const CODEX_REPLAY_VALUE_FLAGS = new Set([
+  "-c",
+  "--config",
+  "--enable",
+  "--disable",
+  "--remote-auth-token-env",
+  "-m",
+  "--model",
+  "--local-provider",
+  "-p",
+  "--profile",
+  "-s",
+  "--sandbox",
+  "-C",
+  "--cd",
+  "--add-dir",
+  "-a",
+  "--ask-for-approval",
+]);
+const CODEX_REPLAY_BOOLEAN_FLAGS = new Set([
+  "--strict-config",
+  "--oss",
+  "--dangerously-bypass-approvals-and-sandbox",
+  "--dangerously-bypass-hook-trust",
+  "--search",
+  "--no-alt-screen",
+]);
+
+function replayableCodexArgs(codexArgs: string[]): string[] {
+  const replayable: string[] = [];
+  for (let index = 0; index < codexArgs.length; index += 1) {
+    const token = codexArgs[index]!;
+    if (token === "--") break;
+    if (token === "-i" || token === "--image") {
+      // Initial attachments belong to the original prompt and must not be
+      // re-submitted during an ordinary exact-thread resume.
+      while (
+        index + 1 < codexArgs.length &&
+        codexArgs[index + 1] !== "--" &&
+        !codexArgs[index + 1]!.startsWith("-")
+      ) {
+        index += 1;
+      }
+      continue;
+    }
+    if (token.startsWith("--image=") || token.startsWith("-i=")) continue;
+    if (CODEX_REPLAY_VALUE_FLAGS.has(token)) {
+      const value = codexArgs[index + 1];
+      if (value !== undefined) {
+        replayable.push(token, value);
+        index += 1;
+      }
+      continue;
+    }
+    const equals = token.indexOf("=");
+    if (
+      equals > 0 &&
+      CODEX_REPLAY_VALUE_FLAGS.has(token.slice(0, equals))
+    ) {
+      replayable.push(token);
+      continue;
+    }
+    if (CODEX_REPLAY_BOOLEAN_FLAGS.has(token)) replayable.push(token);
+    // Every non-option is the original positional prompt. Unknown flags are
+    // not replayed because their arity/side effects cannot be established.
+  }
+  return replayable;
+}
+
+export function buildCodexTuiResumeArgs(
+  socketPath: string,
+  threadId: string,
+  codexArgs: string[] = [],
+): string[] {
+  return [
+    "resume",
+    "--remote",
+    `unix://${socketPath}`,
+    ...replayableCodexArgs(codexArgs),
+    threadId,
+  ];
+}
+
+interface InitialCodexInvocation {
+  options: string[];
+  imageOptions: string[];
+  prompt: string | null;
+}
+
+function parseInitialCodexInvocation(codexArgs: string[]): InitialCodexInvocation | null {
+  const options: string[] = [];
+  const imageOptions: string[] = [];
+  let prompt: string | null = null;
+  for (let index = 0; index < codexArgs.length; index += 1) {
+    const token = codexArgs[index]!;
+    if (token === "--") {
+      const positional = codexArgs.slice(index + 1);
+      if (positional.length > 1 || (prompt !== null && positional.length > 0)) return null;
+      if (positional.length === 1) prompt = positional[0]!;
+      break;
+    }
+    if (token === "-i" || token === "--image") {
+      imageOptions.push(token);
+      let values = 0;
+      while (
+        index + 1 < codexArgs.length &&
+        codexArgs[index + 1] !== "--" &&
+        !codexArgs[index + 1]!.startsWith("-")
+      ) {
+        imageOptions.push(codexArgs[++index]!);
+        values += 1;
+      }
+      if (values === 0) return null;
+      continue;
+    }
+    if (token.startsWith("--image=") || token.startsWith("-i=")) {
+      imageOptions.push(token);
+      continue;
+    }
+    if (CODEX_REPLAY_VALUE_FLAGS.has(token)) {
+      const value = codexArgs[index + 1];
+      if (value === undefined) return null;
+      options.push(token, value);
+      index += 1;
+      continue;
+    }
+    const equals = token.indexOf("=");
+    if (equals > 0 && CODEX_REPLAY_VALUE_FLAGS.has(token.slice(0, equals))) {
+      options.push(token);
+      continue;
+    }
+    if (CODEX_REPLAY_BOOLEAN_FLAGS.has(token)) {
+      options.push(token);
+      continue;
+    }
+    if (token.startsWith("-")) return null;
+    if (prompt !== null) return null;
+    prompt = token;
+  }
+  return { options, imageOptions, prompt };
+}
+
+function invocationFromInitialInput(
+  input: unknown,
+): { imageOptions: string[]; prompt: string | null } | null {
+  if (!Array.isArray(input)) return null;
+  const imageOptions: string[] = [];
+  let prompt: string | null = null;
+  for (const item of input) {
+    if (typeof item !== "object" || item === null || Array.isArray(item)) return null;
+    const record = item as Record<string, unknown>;
+    if (record.type === "text" && typeof record.text === "string") {
+      if (prompt !== null) return null;
+      prompt = record.text;
+      continue;
+    }
+    if (
+      (record.type === "localImage" || record.type === "image") &&
+      typeof record.path === "string"
+    ) {
+      imageOptions.push("--image", record.path);
+      continue;
+    }
+    return null;
+  }
+  return { imageOptions, prompt };
+}
+
+/**
+ * Re-enter an already-created bootstrap thread while replaying only the
+ * initial prompt that was proven not written. The thread itself is never
+ * created twice.
+ */
+export function buildCodexTuiResumeWithPromptArgs(
+  socketPath: string,
+  threadId: string,
+  codexArgs: string[] = [],
+  initialInput?: unknown,
+): string[] | null {
+  const invocation = parseInitialCodexInvocation(codexArgs);
+  if (!invocation) return null;
+  const initial = initialInput === undefined
+    ? { imageOptions: invocation.imageOptions, prompt: invocation.prompt }
+    : invocationFromInitialInput(initialInput);
+  if (!initial) return null;
+  return [
+    "resume",
+    "--remote",
+    `unix://${socketPath}`,
+    ...invocation.options,
+    ...initial.imageOptions,
+    ...(initial.imageOptions.length === 0 ? [] : ["--"]),
+    threadId,
+    ...(initial.prompt === null ? [] : [initial.prompt]),
+  ];
+}
+
+export function resolveCodexRecoveryThreadId(
+  entries: ReadonlyArray<{ threadId: string | null }>,
+): string | null {
+  const threadIds = new Set(
+    entries.flatMap((entry) => entry.threadId === null ? [] : [entry.threadId]),
+  );
+  if (threadIds.size > 1) {
+    throw new Error(
+      "Codex delivery recovery journal spans multiple threads; refusing to choose one",
+    );
+  }
+  return threadIds.values().next().value ?? null;
+}
+
+export class CodexFrontendRecoveryQueue {
+  private pending: CodexFrontendRecovery | null = null;
+  private waiter: ((event: CodexFrontendRecovery) => void) | null = null;
+  private newestGeneration = 0;
+
+  push(event: CodexFrontendRecovery): void {
+    if (event.generation <= this.newestGeneration) return;
+    this.newestGeneration = event.generation;
+    const waiter = this.waiter;
+    if (waiter) {
+      this.waiter = null;
+      waiter(event);
+      return;
+    }
+    this.pending = event;
+  }
+
+  next(): Promise<CodexFrontendRecovery> {
+    if (this.pending) {
+      const event = this.pending;
+      this.pending = null;
+      return Promise.resolve(event);
+    }
+    return new Promise((resolve) => {
+      this.waiter = resolve;
+    });
+  }
+}
+
+type CodexFrontendLifecycleEvent =
+  | { type: "reset"; event: CodexFrontendReset }
+  | { type: "recovered"; event: CodexFrontendRecovery };
+
+export class CodexFrontendLifecycleQueue {
+  private readonly pending: CodexFrontendLifecycleEvent[] = [];
+  private waiter: ((event: CodexFrontendLifecycleEvent) => void) | null = null;
+  private resetGeneration = 0;
+  private recoveryPending = false;
+
+  reset(event: CodexFrontendReset): void {
+    this.recoveryPending = true;
+    this.resetGeneration = Math.max(
+      this.resetGeneration,
+      event.disconnectedGeneration,
+    );
+    this.push({ type: "reset", event });
+  }
+
+  recovered(event: CodexFrontendRecovery): void {
+    this.push({ type: "recovered", event });
+  }
+
+  get inRecoveryWindow(): boolean {
+    return this.recoveryPending;
+  }
+
+  get latestResetGeneration(): number {
+    return this.resetGeneration;
+  }
+
+  acceptRecovery(event: CodexFrontendRecovery): boolean {
+    if (event.generation <= this.resetGeneration) return false;
+    this.recoveryPending = false;
+    return true;
+  }
+
+  private push(event: CodexFrontendLifecycleEvent): void {
+    const waiter = this.waiter;
+    if (waiter) {
+      this.waiter = null;
+      waiter(event);
+      return;
+    }
+    this.pending.push(event);
+    if (this.pending.length > 32) this.pending.splice(0, this.pending.length - 32);
+  }
+
+  next(): Promise<CodexFrontendLifecycleEvent> {
+    const event = this.pending.shift();
+    if (event) return Promise.resolve(event);
+    return new Promise((resolve) => {
+      this.waiter = resolve;
+    });
+  }
+}
+
+function defaultSpawnAppServer(options: {
+  codexBinary: string;
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+}): ChildProcessWithoutNullStreams {
+  return spawn(options.codexBinary, ["app-server", "--stdio"], {
+    cwd: options.cwd,
+    env: options.env,
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+}
+
+function defaultLaunchTui(
+  codexBinary: string,
+  args: string[],
+  options: { cwd: string; env: NodeJS.ProcessEnv },
+): BridgeChildProcess {
+  const child = Bun.spawn([codexBinary, ...args], {
+    cwd: options.cwd,
+    env: options.env,
+    stdin: "inherit",
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  return {
+    exited: child.exited,
+    kill: (signal) => child.kill(signal),
+  };
+}
+
+function defaultRuntimeDir(): string {
+  const path = mkdtempSync(join(tmpdir(), "agentparty-codex-"));
+  chmodSync(path, 0o700);
+  return path;
+}
+
+function defaultRemoveRuntimeDir(path: string): void {
+  // `path` is a freshly-created, bridge-owned mkdtemp directory; never accept
+  // a caller/environment path as this recursive cleanup target.
+  rmSync(path, { recursive: true, force: true });
+}
+
+function defaultInstallSignalHandlers(
+  handler: (signal: "SIGINT" | "SIGTERM") => void,
+): () => void {
+  const onSigint = () => handler("SIGINT");
+  const onSigterm = () => handler("SIGTERM");
+  process.once("SIGINT", onSigint);
+  process.once("SIGTERM", onSigterm);
+  return () => {
+    process.off("SIGINT", onSigint);
+    process.off("SIGTERM", onSigterm);
+  };
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Reap a bridge-owned child without waiting forever. SIGKILL is intentionally
+ * attempted even when SIGTERM is ignored; all failures are best-effort because
+ * the child may have exited between the checks.
+ */
+export async function terminateBridgeChild(
+  child: BridgeChildProcess | null,
+  graceMs: number = 1_000,
+  killWaitMs: number = 500,
+  wait: (ms: number) => Promise<void> = delay,
+): Promise<boolean> {
+  if (!child) return true;
+  const exited = child.exited.then(
+    () => true,
+    () => true,
+  );
+  try {
+    child.kill("SIGTERM");
+  } catch {
+    return await Promise.race([
+      exited,
+      wait(graceMs).then(() => false),
+    ]);
+  }
+  const stopped = await Promise.race([
+    exited,
+    wait(graceMs).then(() => false),
+  ]);
+  if (stopped) return true;
+  try {
+    child.kill("SIGKILL");
+  } catch {
+    return await Promise.race([
+      exited,
+      wait(killWaitMs).then(() => false),
+    ]);
+  }
+  return await Promise.race([exited, wait(killWaitMs).then(() => false)]);
+}
+
+function childProcessExited(child: ChildProcessWithoutNullStreams): Promise<number> {
+  if (child.exitCode !== null) return Promise.resolve(child.exitCode);
+  if (child.signalCode !== null) return Promise.resolve(1);
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (code: number) => {
+      if (settled) return;
+      settled = true;
+      resolve(code);
+    };
+    child.once("exit", (code) => finish(code ?? 1));
+    child.once("error", () => finish(1));
+  });
+}
+
+class CodexBridgeTerminated extends Error {}
+
+function terminationExitCode(signal: "SIGINT" | "SIGTERM"): number {
+  return signal === "SIGINT" ? 130 : 143;
+}
+
+export interface CodexBridgeTerminalResult {
+  source: "delivery" | "signal";
+  code: number;
+}
+
+export async function superviseCodexTui(options: {
+  channel: string;
+  codexBinary: string;
+  codexArgs?: string[];
+  initialThreadId?: string | null;
+  socketPath: string;
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  lifecycle: CodexFrontendLifecycleQueue;
+  proxy: Pick<CodexUnixJsonRpcProxy, "quiesceFrontend">;
+  launchTui: NonNullable<CodexBridgeRuntimeDeps["launchTui"]>;
+  terminalRun: Promise<CodexBridgeTerminalResult>;
+  terminalNow: () => CodexBridgeTerminalResult | null;
+  terminationGraceMs: number;
+  killWaitMs: number;
+  log: (line: string) => void;
+  onTuiChange?: (child: BridgeChildProcess | null) => void;
+}): Promise<number> {
+  let tui: BridgeChildProcess | null = null;
+  let tuiArgs = options.initialThreadId
+    ? buildCodexTuiResumeArgs(
+      options.socketPath,
+      options.initialThreadId,
+      options.codexArgs,
+    )
+    : buildCodexTuiArgs(options.socketPath, options.codexArgs);
+  let lifecycleRun: Promise<{
+    source: "frontend-lifecycle";
+    event: CodexFrontendLifecycleEvent;
+    code: number;
+  }> | null = null;
+  const nextLifecycle = () => {
+    lifecycleRun ??= options.lifecycle.next().then((event) => ({
+      source: "frontend-lifecycle" as const,
+      event,
+      code: 0,
+    }));
+    return lifecycleRun;
+  };
+  try {
+    for (;;) {
+      const terminalBeforeRecovery = options.terminalNow();
+      if (terminalBeforeRecovery) return terminalBeforeRecovery.code;
+
+      if (options.lifecycle.inRecoveryWindow) {
+        let recovered: CodexFrontendRecovery | null = null;
+        while (recovered === null) {
+          const terminal = options.terminalNow();
+          if (terminal) return terminal.code;
+          const next = await Promise.race([
+            options.terminalRun,
+            nextLifecycle(),
+          ]);
+          if (next.source !== "frontend-lifecycle") return next.code;
+          lifecycleRun = null;
+          if (
+            next.event.type === "recovered" &&
+            options.lifecycle.acceptRecovery(next.event.event)
+          ) {
+            recovered = next.event.event;
+          }
+        }
+
+        const terminalAfterRecovery = options.terminalNow();
+        if (terminalAfterRecovery) return terminalAfterRecovery.code;
+        if (recovered.disposition === "unknown") {
+          options.log(`codex-bridge: ${recovered.reason}; refusing to replay the initial prompt`);
+          return 1;
+        }
+        if (recovered.disposition === "restart") {
+          options.log(
+            `codex-bridge: app-server generation ${recovered.generation} recovered before ` +
+              "thread/start was written; restarting the original TUI invocation",
+          );
+          tuiArgs = buildCodexTuiArgs(options.socketPath, options.codexArgs);
+        } else if (recovered.disposition === "restart_thread_with_prompt") {
+          const replayArgs = buildCodexTuiResumeWithPromptArgs(
+            options.socketPath,
+            recovered.threadId,
+            options.codexArgs,
+            recovered.initialInput,
+          );
+          if (!replayArgs) {
+            options.log(
+              "codex-bridge: initial turn/start was not written, but its input cannot be " +
+                "represented by the Codex resume CLI; refusing a lossy replay",
+            );
+            return 1;
+          }
+          options.log(
+            `codex-bridge: app-server generation ${recovered.generation} recovered after ` +
+              "thread creation; resuming the exact thread with its proven-not-written prompt",
+          );
+          tuiArgs = replayArgs;
+        } else {
+          options.log(
+            `codex-bridge: app-server generation ${recovered.generation} recovered; ` +
+              `restarting the TUI on exact thread ${recovered.threadId}`,
+          );
+          tuiArgs = buildCodexTuiResumeArgs(
+            options.socketPath,
+            recovered.threadId,
+            options.codexArgs,
+          );
+        }
+        // Re-enter both pre-launch gates. A newer reset or an already-settled
+        // terminal source must win the resume-to-launch gap.
+        continue;
+      }
+
+      const terminalBeforeLaunch = options.terminalNow();
+      if (terminalBeforeLaunch) return terminalBeforeLaunch.code;
+      options.log(
+        `codex-bridge: launching Codex TUI for #${options.channel}; ` +
+          "TUI and AgentParty now share one app-server writer",
+      );
+      tui = options.launchTui(
+        options.codexBinary,
+        tuiArgs,
+        { cwd: options.cwd, env: options.env },
+      );
+      options.onTuiChange?.(tui);
+      const currentTui = tui;
+      const tuiRun = currentTui.exited.then(
+        (code) => ({ source: "tui" as const, code }),
+        (error) => {
+          options.log(
+            `codex-bridge: TUI failed: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+          return { source: "tui" as const, code: 1 };
+        },
+      );
+      for (;;) {
+        const finished = await Promise.race([
+          options.terminalRun,
+          nextLifecycle(),
+          tuiRun,
+        ]);
+        if (finished.source === "delivery" || finished.source === "signal") {
+          return finished.code;
+        }
+        if (finished.source === "frontend-lifecycle") {
+          lifecycleRun = null;
+          if (!options.lifecycle.inRecoveryWindow) {
+            // A duplicate/stale recovery frame cannot evict a healthy TUI.
+            continue;
+          }
+        } else if (!options.lifecycle.inRecoveryWindow) {
+          return finished.code;
+        }
+        break;
+      }
+
+      if (!options.proxy.quiesceFrontend("Codex backend generation changed")) {
+        options.log(
+          "codex-bridge: could not detach the stale TUI frontend; refusing replacement",
+        );
+        return 1;
+      }
+      const stopped = await terminateBridgeChild(
+        currentTui,
+        options.terminationGraceMs,
+        options.killWaitMs,
+      );
+      if (!stopped) {
+        options.log(
+          "codex-bridge: stale Codex TUI did not exit after SIGKILL; refusing replacement",
+        );
+        return 1;
+      }
+      if (tui === currentTui) {
+        tui = null;
+        options.onTuiChange?.(null);
+      }
+    }
+  } finally {
+    await terminateBridgeChild(
+      tui,
+      options.terminationGraceMs,
+      options.killWaitMs,
+    );
+    options.onTuiChange?.(null);
+  }
+}
+
+/**
+ * Run the same-session Codex bridge until either the TUI exits or AgentParty
+ * delivery reaches a terminal stream error.
+ */
+export async function runCodexSessionBridge(
+  options: CodexBridgeRuntimeOptions,
+  deps: CodexBridgeRuntimeDeps = {},
+): Promise<number> {
+  const log = deps.log ?? ((line) => console.error(line));
+  const cwd = options.cwd ?? process.cwd();
+  const env = options.env ?? process.env;
+  let lock: InstanceLock | null = null;
+  let runtimeDir: string | null = null;
+  let connection: Connection | null = null;
+  let delivery: CodexAgentPartyBridge | null = null;
+  let rpc: CodexRpcClient | null = null;
+  let proxy: CodexUnixJsonRpcProxy | null = null;
+  let tui: BridgeChildProcess | null = null;
+  let unsubscribeFrontendReset: (() => void) | null = null;
+  let unsubscribeFrontendRecovery: (() => void) | null = null;
+  const appServers = new Map<ChildProcessWithoutNullStreams, Promise<number>>();
+  let terminationSignal: "SIGINT" | "SIGTERM" | null = null;
+  let resolveTermination!: (signal: "SIGINT" | "SIGTERM") => void;
+  const termination = new Promise<"SIGINT" | "SIGTERM">((resolve) => {
+    resolveTermination = resolve;
+  });
+  const onSignal = (signal: "SIGINT" | "SIGTERM") => {
+    if (terminationSignal !== null) return;
+    terminationSignal = signal;
+    resolveTermination(signal);
+  };
+  const removeSignalHandlers = (deps.installSignalHandlers ?? defaultInstallSignalHandlers)(onSignal);
+  const throwIfTerminated = () => {
+    if (terminationSignal !== null) throw new CodexBridgeTerminated();
+  };
+  const awaitStartup = async <T>(operation: Promise<T>): Promise<T> => {
+    throwIfTerminated();
+    return await Promise.race([
+      operation,
+      termination.then(() => {
+        throw new CodexBridgeTerminated();
+      }),
+    ]);
+  };
+  const graceMs = deps.terminationGraceMs ?? 1_000;
+  const killWaitMs = deps.killWaitMs ?? 500;
+
+  try {
+    const auth = await awaitStartup(
+      Promise.resolve().then(() => (deps.resolveAuth ?? resolveAuthDetailed)()),
+    );
+    if (!auth.server || !auth.token) {
+      log("codex-bridge: no config, run: party login or party init --server URL --token T");
+      return 1;
+    }
+    const serverUrl = auth.server;
+    const token = auth.token;
+    const recoveryJournal = new DeliveryRecoveryJournal(
+      deliveryRecoveryJournalPath("codex", serverUrl, token, options.channel),
+      options.channel,
+      "codex",
+    );
+    let initialThreadId: string | null;
+    try {
+      initialThreadId = resolveCodexRecoveryThreadId(recoveryJournal.entries());
+    } catch (error) {
+      log(`codex-bridge: ${error instanceof Error ? error.message : String(error)}`);
+      return 1;
+    }
+    throwIfTerminated();
+    lock = acquireInstanceLock(
+      "serve",
+      instanceLockTarget(serverUrl, token, options.channel),
+      defaultInstanceLockDir(),
+    );
+    if (!lock.ok) {
+      log(
+        `codex-bridge: another serve/session bridge already owns #${options.channel}` +
+          (lock.heldByPid === undefined ? "" : ` (pid=${lock.heldByPid})`),
+      );
+      return 1;
+    }
+
+    throwIfTerminated();
+    runtimeDir = (deps.runtimeDir ?? defaultRuntimeDir)();
+    const socketPath = join(runtimeDir, "codex.sock");
+    rpc = new CodexRpcClient({
+      spawnProxy: () => {
+        const child = (deps.spawnAppServer ?? defaultSpawnAppServer)({
+          codexBinary: options.codexBinary,
+          cwd,
+          env,
+        });
+        const exited = childProcessExited(child);
+        appServers.set(child, exited);
+        void exited.then(() => appServers.delete(child));
+        return child;
+      },
+      log,
+    });
+    const initialInvocation = parseInitialCodexInvocation(options.codexArgs ?? []);
+    const expectBootstrapPrompt =
+      initialThreadId === null &&
+      initialInvocation !== null &&
+      (
+        initialInvocation.prompt !== null ||
+        initialInvocation.imageOptions.length > 0
+      );
+    const session = new CodexSessionController(rpc, {
+      log,
+      expectBootstrapPrompt,
+    });
+    const frontendLifecycle = new CodexFrontendLifecycleQueue();
+    unsubscribeFrontendReset = session.onFrontendReset((event) => {
+      frontendLifecycle.reset(event);
+    });
+    unsubscribeFrontendRecovery = session.onFrontendRecovery((event) => {
+      frontendLifecycle.recovered(event);
+    });
+    await awaitStartup(session.start());
+    if (initialThreadId !== null) {
+      await awaitStartup(session.request("thread/resume", {
+        threadId: initialThreadId,
+      }));
+      if (session.activeThreadId !== initialThreadId) {
+        throw new Error(
+          `Codex app-server resumed ${session.activeThreadId ?? "no thread"} instead of ` +
+            `recovery thread ${initialThreadId}`,
+        );
+      }
+      await awaitStartup(session.request("thread/read", {
+        threadId: initialThreadId,
+        includeTurns: true,
+      }));
+      if (session.activeThreadId !== initialThreadId) {
+        throw new Error(
+          `Codex app-server read ${session.activeThreadId ?? "no thread"} instead of ` +
+            `recovery thread ${initialThreadId}`,
+        );
+      }
+    }
+    proxy = new CodexUnixJsonRpcProxy(session, { log });
+    await awaitStartup(proxy.listen(socketPath));
+
+    throwIfTerminated();
+    connection = (deps.connectAgentParty ?? connect)(
+      serverUrl,
+      token,
+      options.channel,
+      loadCursor(options.channel),
+      {
+        directedDelivery: "v1",
+        deliveryRecovery: "v1",
+        advertiseWakeKind: "daemon",
+        onCursor: (cursor) => saveCursor(options.channel, cursor),
+        onStatus: (status) => {
+          if (status !== "open") delivery?.handleConnectionStatus(status);
+        },
+      },
+    );
+    delivery = new CodexAgentPartyBridge({
+      channel: options.channel,
+      connection,
+      session,
+      recoveryJournal,
+      requireDeliveryRecovery: true,
+      postReply: async ({ body, mentions, replyTo, idempotencyKey }) => {
+        const posted = await postMessage(serverUrl, token, options.channel, {
+          kind: "message",
+          body,
+          mentions,
+          reply_to: replyTo,
+          idempotency_key: idempotencyKey,
+        });
+        return { seq: posted.seq };
+      },
+      log,
+    });
+
+    let deliveryTerminal: { source: "delivery"; code: number } | null = null;
+    const deliveryRun = delivery.run().then(
+      (code) => ({ source: "delivery" as const, code }),
+      (error) => {
+        log(`codex-bridge: delivery failed: ${error instanceof Error ? error.message : String(error)}`);
+        return { source: "delivery" as const, code: 1 };
+      },
+    ).then((result) => {
+      deliveryTerminal = result;
+      return result;
+    });
+    const signalRun = termination.then((signal) => ({
+      source: "signal" as const,
+      code: terminationExitCode(signal),
+    }));
+    const terminalNow = (): { source: "delivery" | "signal"; code: number } | null => {
+      if (terminationSignal !== null) {
+        return { source: "signal", code: terminationExitCode(terminationSignal) };
+      }
+      return deliveryTerminal;
+    };
+    const terminalRun = Promise.race([signalRun, deliveryRun]).then((terminal) => {
+      if (terminal.source === "signal") {
+        log(`codex-bridge: received ${terminationSignal}; shutting down`);
+      }
+      return terminal;
+    });
+    return await superviseCodexTui({
+      channel: options.channel,
+      codexBinary: options.codexBinary,
+      codexArgs: options.codexArgs,
+      initialThreadId,
+      socketPath,
+      cwd,
+      env,
+      lifecycle: frontendLifecycle,
+      proxy,
+      launchTui: deps.launchTui ?? defaultLaunchTui,
+      terminalRun,
+      terminalNow,
+      terminationGraceMs: graceMs,
+      killWaitMs,
+      log,
+      onTuiChange: (child) => {
+        tui = child;
+      },
+    });
+  } catch (error) {
+    if (error instanceof CodexBridgeTerminated && terminationSignal !== null) {
+      log(`codex-bridge: received ${terminationSignal}; shutting down`);
+      return terminationExitCode(terminationSignal);
+    }
+    throw error;
+  } finally {
+    // Restore the platform's default second-signal behavior before asynchronous
+    // cleanup, so a stuck cleanup cannot make Ctrl-C/TERM disappear.
+    removeSignalHandlers();
+    try { unsubscribeFrontendReset?.(); } catch { /* best-effort shutdown */ }
+    try { unsubscribeFrontendRecovery?.(); } catch { /* best-effort shutdown */ }
+    try { delivery?.close(); } catch { /* best-effort shutdown */ }
+    try { connection?.close(); } catch { /* best-effort shutdown */ }
+    try { await proxy?.close(); } catch { /* best-effort shutdown */ }
+    try { rpc?.close(); } catch { /* best-effort shutdown */ }
+    await terminateBridgeChild(tui, graceMs, killWaitMs);
+    await Promise.all(
+      [...appServers.entries()].map(([child, exited]) =>
+        terminateBridgeChild(
+          { exited, kill: (signal) => child.kill(signal) },
+          graceMs,
+          killWaitMs,
+        )),
+    );
+    try { lock?.release?.(); } catch { /* best-effort lock release */ }
+    if (runtimeDir !== null) {
+      try {
+        (deps.removeRuntimeDir ?? defaultRemoveRuntimeDir)(runtimeDir);
+      } catch {
+        /* best-effort removal of the bridge-owned mkdtemp */
+      }
+    }
+  }
+}

--- a/cli/src/commands/codex-bridge.ts
+++ b/cli/src/commands/codex-bridge.ts
@@ -33,6 +33,8 @@ import { postMessage } from "../rest";
 export interface CodexBridgeRuntimeOptions {
   channel: string;
   codexBinary: string;
+  /** Fixed argv before Codex subcommands (used by the Windows npm adapter). */
+  codexArgsPrefix?: string[];
   codexArgs?: string[];
   cwd?: string;
   env?: NodeJS.ProcessEnv;
@@ -48,6 +50,7 @@ export interface CodexBridgeRuntimeDeps {
   connectAgentParty?: typeof connect;
   spawnAppServer?: (options: {
     codexBinary: string;
+    codexArgsPrefix: string[];
     cwd: string;
     env: NodeJS.ProcessEnv;
   }) => ChildProcessWithoutNullStreams;
@@ -369,10 +372,11 @@ export class CodexFrontendLifecycleQueue {
 
 function defaultSpawnAppServer(options: {
   codexBinary: string;
+  codexArgsPrefix: string[];
   cwd: string;
   env: NodeJS.ProcessEnv;
 }): ChildProcessWithoutNullStreams {
-  return spawn(options.codexBinary, ["app-server", "--stdio"], {
+  return spawn(options.codexBinary, [...options.codexArgsPrefix, "app-server", "--stdio"], {
     cwd: options.cwd,
     env: options.env,
     stdio: ["pipe", "pipe", "pipe"],
@@ -495,6 +499,7 @@ export interface CodexBridgeTerminalResult {
 export async function superviseCodexTui(options: {
   channel: string;
   codexBinary: string;
+  codexArgsPrefix?: string[];
   codexArgs?: string[];
   initialThreadId?: string | null;
   socketPath: string;
@@ -610,7 +615,7 @@ export async function superviseCodexTui(options: {
       );
       tui = options.launchTui(
         options.codexBinary,
-        tuiArgs,
+        [...(options.codexArgsPrefix ?? []), ...tuiArgs],
         { cwd: options.cwd, env: options.env },
       );
       options.onTuiChange?.(tui);
@@ -769,6 +774,7 @@ export async function runCodexSessionBridge(
       spawnProxy: () => {
         const child = (deps.spawnAppServer ?? defaultSpawnAppServer)({
           codexBinary: options.codexBinary,
+          codexArgsPrefix: options.codexArgsPrefix ?? [],
           cwd,
           env,
         });
@@ -888,6 +894,7 @@ export async function runCodexSessionBridge(
     return await superviseCodexTui({
       channel: options.channel,
       codexBinary: options.codexBinary,
+      codexArgsPrefix: options.codexArgsPrefix,
       codexArgs: options.codexArgs,
       initialThreadId,
       socketPath,

--- a/cli/src/commands/mcp.ts
+++ b/cli/src/commands/mcp.ts
@@ -50,11 +50,17 @@ const HELP = `usage: party mcp
 Run an AgentParty stdio MCP server.
 
 Boundary:
-  MCP is a structured control plane. In Codex 0.144.4 and Claude Code 2.1.210
-  probes, successful server notification sends did not create a new model turn
-  after the harness became idle. A client may render a diagnostic event, but
-  that is not a model-delivery guarantee. Use persistent directed delivery with
-  party serve for unattended wake; never rely on MCP notifications alone.
+  MCP is a structured control plane for ordinary tools/resources. In Codex
+  0.144.4 and Claude Code 2.1.210 probes, successful ordinary notification
+  sends did not create a new model turn after the harness became idle. A client may render
+  a diagnostic event, but that is not a model-delivery guarantee. Use persistent
+  directed delivery with party serve for unattended wake; never rely on ordinary
+  MCP notifications alone.
+
+  Claude Code's dedicated experimental claude/channel capability is a different
+  harness input contract: \`party bridge claude\` uses it to queue AgentParty
+  messages into the current interactive Claude session. It still keeps the
+  AgentParty delivery running until the model persists a linked reply.
 
 Example (name the server per agent — a shared name like "party" lets agents in the
 same directory overwrite each other's env-pinned identity):

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -61,6 +61,7 @@ import {
   RUNNER_CONTINUATIONS_DIR,
   type RunnerContinuationState,
 } from "../continuation";
+import { resolveCodexLaunch } from "./bridge";
 
 export type ServeExecutionRole = "front" | "worker";
 
@@ -1080,6 +1081,8 @@ export interface BuiltinRunnerOptions {
   token: string;
   channel: string;
   harness: RunnerHarness;
+  /** Absolute/relative Codex CLI override. AGENTPARTY_CODEX_BIN is used when omitted. */
+  codexBinary?: string;
   workdir: string;
   cwd?: string;
   /** Child-only CLI identity pinned into the model process (#548). */
@@ -1454,7 +1457,7 @@ export function defaultRunnerWorkdir(channel: string, namespace: string): string
   return runnerWorkdir(join(stateRoot, "runners"), channel, namespace);
 }
 
-const SERVE_FLAGS = ["channel", "on-mention", "all", "runner", "workdir", "repo", "auto-upgrade", "replay-backlog", "profile", "profile-once", "profile-poll-interval", "runner-timeout-seconds", "protocol", "stop"];
+const SERVE_FLAGS = ["channel", "on-mention", "all", "runner", "codex-bin", "workdir", "repo", "auto-upgrade", "replay-backlog", "profile", "profile-once", "profile-poll-interval", "runner-timeout-seconds", "protocol", "stop"];
 const HELP = `usage: party serve [channel|--channel C] (--on-mention "<cmd>" | --runner codex|claude|codex-sdk) [--all]
        party serve --profile <owner>/<handle>
 
@@ -1468,6 +1471,8 @@ Options:
                        and decision_response in AP_CONTEXT_FILE; no model session is resumed
   --runner codex|claude|codex-sdk
                        use the built-in isolated wake runner instead of a custom command
+  --codex-bin PATH     Codex CLI override for --runner codex (or set AGENTPARTY_CODEX_BIN);
+                       otherwise search child PATH, Homebrew, Codex.app, and ChatGPT.app
   --workdir DIR        runner workdir (default: ~/.agentparty/runners/<principal-sha256>/<channel>)
   --repo URL           clone into workdir/repo once, then git pull --ff-only before each wake
   --runner-timeout-seconds N
@@ -2455,6 +2460,7 @@ export function builtinRunnerCommand(
 
 async function runHarness(
   opts: BuiltinRunnerOptions,
+  codexBinary: string,
   prompt: string,
   sid: string | null,
   coldSessionId: string | null,
@@ -2478,7 +2484,6 @@ async function runHarness(
     }
   };
   if (opts.harness === "codex") {
-    const runnerCommand = builtinRunnerCommand("codex", env);
     const outFile = join(opts.workdir, `runner-${seq}-${Date.now()}.out`);
     const schemaArgs = opts.outputSchema === undefined
       ? []
@@ -2503,8 +2508,8 @@ async function runHarness(
     // exec-level flags must precede the `resume` subcommand.  Putting --sandbox after the session
     // id is parsed as a resume-only flag and current Codex rejects the second managed turn.
     const args = sid
-      ? [runnerCommand, "exec", ...flags, "resume", sid, prompt]
-      : [runnerCommand, "exec", ...flags, prompt];
+      ? [codexBinary, "exec", ...flags, "resume", sid, prompt]
+      : [codexBinary, "exec", ...flags, prompt];
     const result = await runProcess(args, { cwd, env, signal });
     const text = result.code === 0 && existsSync(outFile) ? readFileSync(outFile, "utf8").trimEnd() : "";
     return { result, text, sessionId: sid ? sid : parseCodexSessionId(result.stdout, result.stderr), outFile };
@@ -2978,6 +2983,7 @@ export function createBuiltinRunner(opts: BuiltinRunnerOptions): NonNullable<Ser
     coldSessionId: string | null;
     env: Record<string, string | undefined>;
     cwd: string;
+    codexBinary: string;
   }
   const prepared = new WeakMap<MsgFrame, PreparedBuiltinRun>();
   const prepare = async (frame: MsgFrame, ctx: ServeRunnerContext): Promise<void> => {
@@ -2986,7 +2992,30 @@ export function createBuiltinRunner(opts: BuiltinRunnerOptions): NonNullable<Ser
     mkdirSync(opts.workdir, { recursive: true });
     // 活动上报（#602）：新 wake 冷起前清掉上一轮残留，首个 hook 到来前不展示旧活动。
     if (opts.harness === "claude") clearActivityFile(runnerActivityFile(opts.workdir));
-    const baseEnv = opts.harness === "codex" ? prepareCodexHome(opts.workdir, opts.authSourceFile) : { ...process.env };
+    let baseEnv = opts.harness === "codex" ? prepareCodexHome(opts.workdir, opts.authSourceFile) : { ...process.env };
+    let codexBinary = "codex";
+    // Production must resolve the same absolute executable and child PATH before a wake reaches the
+    // model boundary. GUI/launchd processes commonly have no Homebrew path, and Codex may exist only
+    // inside Codex.app or ChatGPT.app. Test doubles keep the historical literal command unless they
+    // explicitly ask to exercise this resolver.
+    if (opts.harness === "codex" && (opts.runProcess === undefined || opts.codexBinary !== undefined)) {
+      let configuredBinary = opts.codexBinary;
+      if (
+        configuredBinary === undefined &&
+        !baseEnv.AGENTPARTY_CODEX_BIN?.trim() &&
+        baseEnv.AGENTPARTY_RUNNER_BIN?.trim()
+      ) {
+        configuredBinary = builtinRunnerCommand("codex", baseEnv);
+      }
+      const launch = resolveCodexLaunch(configuredBinary, baseEnv, process.cwd());
+      if (!launch.ok) {
+        throw new WakeBlockedError(`builtin codex runner did not start: ${launch.error}`, true, {
+          environment: true,
+        });
+      }
+      codexBinary = launch.codexBinary;
+      baseEnv = launch.env;
+    }
     const scope = continuationScope(opts.workdir, ctx.delivery);
     const sessionPath = scope.path;
     const prior = scopedSession(scope, (path) => readSession(path, opts.harness), `builtin ${opts.harness}`);
@@ -3046,6 +3075,7 @@ export function createBuiltinRunner(opts: BuiltinRunnerOptions): NonNullable<Ser
       coldSessionId,
       env,
       cwd: opts.cwd ?? repoCwd ?? opts.workdir,
+      codexBinary,
     });
   };
 
@@ -3053,7 +3083,7 @@ export function createBuiltinRunner(opts: BuiltinRunnerOptions): NonNullable<Ser
     if (!prepared.has(frame)) await prepare(frame, ctx);
     const ready = prepared.get(frame)!;
     prepared.delete(frame);
-    const { started, scope, sessionPath, coldSessionId, env, cwd } = ready;
+    const { started, scope, sessionPath, coldSessionId, env, cwd, codexBinary } = ready;
     let prior = ready.prior;
     let oldSid = prior?.session_id ?? null;
     let exitCode: number | null = null;
@@ -3092,7 +3122,17 @@ export function createBuiltinRunner(opts: BuiltinRunnerOptions): NonNullable<Ser
         // session_not_found，也只能清理句柄供下一条独立 wake 使用，绝不能 cold-start 重跑当前 wake。
         let run: HarnessRun;
         try {
-          run = await runHarness(opts, nextPrompt, oldSid, coldSessionId, cwd, env, frame.seq, ctx.signal);
+          run = await runHarness(
+            opts,
+            codexBinary,
+            nextPrompt,
+            oldSid,
+            coldSessionId,
+            cwd,
+            env,
+            frame.seq,
+            ctx.signal,
+          );
         } catch (error) {
           if (error instanceof ServeShutdownError && prior !== null) {
             blockRunnerContinuation(
@@ -3401,6 +3441,8 @@ export interface ProfileServeOptions {
   ownerAccount: string;
   handle: string;
   mentionsOnly: boolean;
+  /** Optional Codex CLI override propagated to every Codex profile lane. */
+  codexBinary?: string;
   availableUpgrade?: CliUpgradeNotice | null;
   refreshAvailableUpgrade?: (current: CliUpgradeNotice | null) => Promise<CliUpgradeNotice | null>;
   upgradeProbeIntervalMs?: number;
@@ -3903,6 +3945,24 @@ export async function runProfileServe(opts: ProfileServeOptions): Promise<number
   if (profile.owner_account !== opts.ownerAccount || profile.handle !== opts.handle) {
     throw new Error(`profile token mismatch: requested ${opts.ownerAccount}/${opts.handle}, got ${profile.owner_account}/${profile.handle}`);
   }
+  if (opts.codexBinary !== undefined && profile.runner !== "codex") {
+    throw new Error("--codex-bin can only be used with a codex project-agent profile");
+  }
+  let resolvedProfileCodexBinary = opts.codexBinary;
+  let checkedProfileCodexBinary = false;
+  const profileCodexBinary = (): string | undefined => {
+    if (profile.runner !== "codex") return undefined;
+    // Injected channel runners are test/embedding boundaries and may not launch a harness at all.
+    // Production resolves on the first invited channel, before either resident lane advertises
+    // readiness, so a GUI/launchd PATH failure cannot masquerade as an online project agent.
+    if (opts.runChannelServe !== undefined) return resolvedProfileCodexBinary;
+    if (checkedProfileCodexBinary) return resolvedProfileCodexBinary;
+    checkedProfileCodexBinary = true;
+    const launch = resolveCodexLaunch(opts.codexBinary, process.env, process.cwd());
+    if (!launch.ok) throw new Error(`builtin codex runner did not start: ${launch.error}`);
+    resolvedProfileCodexBinary = launch.codexBinary;
+    return resolvedProfileCodexBinary;
+  };
   out(`serving project agent ${profile.owner_account}/${profile.handle} — runner=${profile.runner}`);
 
   const attachInvite = async (invite: ChannelProjectAgentInvite) => {
@@ -4134,6 +4194,9 @@ export async function runProfileServe(opts: ProfileServeOptions): Promise<number
               token: principal.token,
               channel,
               harness: profile.runner,
+              ...(profile.runner === "codex"
+                ? { codexBinary: profileCodexBinary() }
+                : {}),
               workdir: prepared.runnerWorkdir,
               cwd: prepared.channelWorkdir,
               isolateModelPartyAccess: true,
@@ -5731,13 +5794,14 @@ export async function run(argv: string[]): Promise<number> {
     console.error(unknown);
     return 1;
   }
-  const flagError = valueFlagError(flags, ["channel", "on-mention", "runner", "workdir", "repo", "profile", "profile-poll-interval", "runner-timeout-seconds", "protocol"]);
+  const flagError = valueFlagError(flags, ["channel", "on-mention", "runner", "codex-bin", "workdir", "repo", "profile", "profile-poll-interval", "runner-timeout-seconds", "protocol"]);
   if (flagError !== null) {
     console.error(flagError);
     return 1;
   }
   const cmd = str(flags["on-mention"]);
   const runner = str(flags.runner);
+  const codexBinaryFlag = str(flags["codex-bin"]);
   const runnerTimeoutSecondsRaw = str(flags["runner-timeout-seconds"]);
   // #646：flag 未显式提供时保持 undefined，让各 lane 用自己的默认（front 10min / worker+单 runner
   // 30min，见下游 `?? DEFAULT_FRONT_RUNNER_TIMEOUT_MS` / `?? DEFAULT_RUNNER_TIMEOUT_MS`）。此前这里
@@ -5797,6 +5861,7 @@ export async function run(argv: string[]): Promise<number> {
       ownerAccount: profileRef.owner,
       handle: profileRef.handle,
       mentionsOnly: flags.all !== true,
+      ...(codexBinaryFlag === undefined ? {} : { codexBinary: codexBinaryFlag }),
       availableUpgrade,
       refreshAvailableUpgrade: (current) => resolveAvailableUpgrade(account.session.server, current, {
         autoDownload: autoDownloadUpgrade,
@@ -5836,8 +5901,21 @@ export async function run(argv: string[]): Promise<number> {
     console.error("--runner must be codex, claude, or codex-sdk");
     return 1;
   }
+  if (codexBinaryFlag !== undefined && runner !== "codex") {
+    console.error("--codex-bin requires --runner codex");
+    return 1;
+  }
   const harness = runner === "codex" || runner === "claude" ? runner : undefined;
   const useSdkRunner = runner === "codex-sdk";
+  let codexBinary: string | undefined;
+  if (harness === "codex") {
+    const launch = resolveCodexLaunch(codexBinaryFlag, process.env, process.cwd());
+    if (!launch.ok) {
+      console.error(`builtin codex runner did not start: ${launch.error}`);
+      return 1;
+    }
+    codexBinary = launch.codexBinary;
+  }
   const autoDownloadUpgrade = flags["auto-upgrade"] === true;
   const availableUpgrade = await resolveAvailableUpgrade(server, null, {
     autoDownload: autoDownloadUpgrade,
@@ -5924,6 +6002,7 @@ export async function run(argv: string[]): Promise<number> {
               token: currentToken,
               channel,
               harness,
+              ...(codexBinary === undefined ? {} : { codexBinary }),
               workdir: currentRunnerWorkdir,
               repo: str(flags.repo),
             }

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -61,7 +61,7 @@ import {
   RUNNER_CONTINUATIONS_DIR,
   type RunnerContinuationState,
 } from "../continuation";
-import { resolveCodexLaunch } from "./bridge";
+import { resolveCodexLaunch, type CodexLaunchResolution } from "./bridge";
 
 export type ServeExecutionRole = "front" | "worker";
 
@@ -1083,6 +1083,13 @@ export interface BuiltinRunnerOptions {
   harness: RunnerHarness;
   /** Absolute/relative Codex CLI override. AGENTPARTY_CODEX_BIN is used when omitted. */
   codexBinary?: string;
+  /** Fixed argv before Codex subcommands, supplied by a resolved Windows npm shim. */
+  codexArgsPrefix?: string[];
+  /**
+   * One immutable preflight result shared with the eventual wake. This prevents a
+   * later PATH/npm update from changing the executable after readiness was accepted.
+   */
+  codexLaunch?: Extract<CodexLaunchResolution, { ok: true }>;
   workdir: string;
   cwd?: string;
   /** Child-only CLI identity pinned into the model process (#548). */
@@ -2356,7 +2363,11 @@ function parseClaudeJson(stdout: string): { sessionId: string | null; text: stri
   }
 }
 
-function prepareCodexHome(workdir: string, authSourceFile?: string): Record<string, string | undefined> {
+function prepareCodexHome(
+  workdir: string,
+  authSourceFile?: string,
+  baseEnv: NodeJS.ProcessEnv = process.env,
+): Record<string, string | undefined> {
   const codexHome = join(workdir, ".codex");
   mkdirSync(codexHome, { recursive: true });
   const authDest = join(codexHome, "auth.json");
@@ -2381,7 +2392,7 @@ function prepareCodexHome(workdir: string, authSourceFile?: string): Record<stri
       symlinkSync(authSource, authDest);
     }
   }
-  return { ...process.env, CODEX_HOME: codexHome };
+  return { ...baseEnv, CODEX_HOME: codexHome };
 }
 
 async function ensureRepo(
@@ -2458,9 +2469,38 @@ export function builtinRunnerCommand(
   return configured;
 }
 
+/**
+ * Resolve the Codex executable using the same precedence at every resident-runner
+ * boundary: an explicit flag, AGENTPARTY_CODEX_BIN, then the desktop/launchd
+ * AGENTPARTY_RUNNER_BIN binding, and finally normal Codex discovery.
+ */
+export function resolveBuiltinCodexLaunch(
+  explicit: string | undefined,
+  env: NodeJS.ProcessEnv,
+  cwd: string,
+): ReturnType<typeof resolveCodexLaunch> {
+  let configured = explicit;
+  if (
+    configured === undefined &&
+    !env.AGENTPARTY_CODEX_BIN?.trim() &&
+    env.AGENTPARTY_RUNNER_BIN?.trim()
+  ) {
+    try {
+      configured = builtinRunnerCommand("codex", env);
+    } catch (error) {
+      return {
+        ok: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+  return resolveCodexLaunch(configured, env, cwd);
+}
+
 async function runHarness(
   opts: BuiltinRunnerOptions,
   codexBinary: string,
+  codexArgsPrefix: string[],
   prompt: string,
   sid: string | null,
   coldSessionId: string | null,
@@ -2508,8 +2548,8 @@ async function runHarness(
     // exec-level flags must precede the `resume` subcommand.  Putting --sandbox after the session
     // id is parsed as a resume-only flag and current Codex rejects the second managed turn.
     const args = sid
-      ? [codexBinary, "exec", ...flags, "resume", sid, prompt]
-      : [codexBinary, "exec", ...flags, prompt];
+      ? [codexBinary, ...codexArgsPrefix, "exec", ...flags, "resume", sid, prompt]
+      : [codexBinary, ...codexArgsPrefix, "exec", ...flags, prompt];
     const result = await runProcess(args, { cwd, env, signal });
     const text = result.code === 0 && existsSync(outFile) ? readFileSync(outFile, "utf8").trimEnd() : "";
     return { result, text, sessionId: sid ? sid : parseCodexSessionId(result.stdout, result.stderr), outFile };
@@ -2984,6 +3024,7 @@ export function createBuiltinRunner(opts: BuiltinRunnerOptions): NonNullable<Ser
     env: Record<string, string | undefined>;
     cwd: string;
     codexBinary: string;
+    codexArgsPrefix: string[];
   }
   const prepared = new WeakMap<MsgFrame, PreparedBuiltinRun>();
   const prepare = async (frame: MsgFrame, ctx: ServeRunnerContext): Promise<void> => {
@@ -2992,28 +3033,34 @@ export function createBuiltinRunner(opts: BuiltinRunnerOptions): NonNullable<Ser
     mkdirSync(opts.workdir, { recursive: true });
     // 活动上报（#602）：新 wake 冷起前清掉上一轮残留，首个 hook 到来前不展示旧活动。
     if (opts.harness === "claude") clearActivityFile(runnerActivityFile(opts.workdir));
-    let baseEnv = opts.harness === "codex" ? prepareCodexHome(opts.workdir, opts.authSourceFile) : { ...process.env };
-    let codexBinary = "codex";
+    let baseEnv = opts.harness === "codex"
+      ? prepareCodexHome(opts.workdir, opts.authSourceFile, opts.codexLaunch?.env)
+      : { ...process.env };
+    let codexBinary = opts.codexLaunch?.codexBinary ??
+      (opts.harness === "codex" && opts.codexArgsPrefix !== undefined
+        ? opts.codexBinary ?? "codex"
+        : "codex");
+    let codexArgsPrefix = [
+      ...(opts.codexLaunch?.codexArgsPrefix ?? opts.codexArgsPrefix ?? []),
+    ];
     // Production must resolve the same absolute executable and child PATH before a wake reaches the
     // model boundary. GUI/launchd processes commonly have no Homebrew path, and Codex may exist only
     // inside Codex.app or ChatGPT.app. Test doubles keep the historical literal command unless they
     // explicitly ask to exercise this resolver.
-    if (opts.harness === "codex" && (opts.runProcess === undefined || opts.codexBinary !== undefined)) {
-      let configuredBinary = opts.codexBinary;
-      if (
-        configuredBinary === undefined &&
-        !baseEnv.AGENTPARTY_CODEX_BIN?.trim() &&
-        baseEnv.AGENTPARTY_RUNNER_BIN?.trim()
-      ) {
-        configuredBinary = builtinRunnerCommand("codex", baseEnv);
-      }
-      const launch = resolveCodexLaunch(configuredBinary, baseEnv, process.cwd());
+    if (
+      opts.harness === "codex" &&
+      opts.codexLaunch === undefined &&
+      opts.codexArgsPrefix === undefined &&
+      (opts.runProcess === undefined || opts.codexBinary !== undefined)
+    ) {
+      const launch = resolveBuiltinCodexLaunch(opts.codexBinary, baseEnv, process.cwd());
       if (!launch.ok) {
         throw new WakeBlockedError(`builtin codex runner did not start: ${launch.error}`, true, {
           environment: true,
         });
       }
       codexBinary = launch.codexBinary;
+      codexArgsPrefix = launch.codexArgsPrefix;
       baseEnv = launch.env;
     }
     const scope = continuationScope(opts.workdir, ctx.delivery);
@@ -3076,6 +3123,7 @@ export function createBuiltinRunner(opts: BuiltinRunnerOptions): NonNullable<Ser
       env,
       cwd: opts.cwd ?? repoCwd ?? opts.workdir,
       codexBinary,
+      codexArgsPrefix,
     });
   };
 
@@ -3083,7 +3131,7 @@ export function createBuiltinRunner(opts: BuiltinRunnerOptions): NonNullable<Ser
     if (!prepared.has(frame)) await prepare(frame, ctx);
     const ready = prepared.get(frame)!;
     prepared.delete(frame);
-    const { started, scope, sessionPath, coldSessionId, env, cwd, codexBinary } = ready;
+    const { started, scope, sessionPath, coldSessionId, env, cwd, codexBinary, codexArgsPrefix } = ready;
     let prior = ready.prior;
     let oldSid = prior?.session_id ?? null;
     let exitCode: number | null = null;
@@ -3125,6 +3173,7 @@ export function createBuiltinRunner(opts: BuiltinRunnerOptions): NonNullable<Ser
           run = await runHarness(
             opts,
             codexBinary,
+            codexArgsPrefix,
             nextPrompt,
             oldSid,
             coldSessionId,
@@ -3443,6 +3492,8 @@ export interface ProfileServeOptions {
   mentionsOnly: boolean;
   /** Optional Codex CLI override propagated to every Codex profile lane. */
   codexBinary?: string;
+  /** Test/embedding seam for proving that one preflight result reaches every profile lane. */
+  resolveCodexLaunch?: typeof resolveBuiltinCodexLaunch;
   availableUpgrade?: CliUpgradeNotice | null;
   refreshAvailableUpgrade?: (current: CliUpgradeNotice | null) => Promise<CliUpgradeNotice | null>;
   upgradeProbeIntervalMs?: number;
@@ -3948,20 +3999,22 @@ export async function runProfileServe(opts: ProfileServeOptions): Promise<number
   if (opts.codexBinary !== undefined && profile.runner !== "codex") {
     throw new Error("--codex-bin can only be used with a codex project-agent profile");
   }
-  let resolvedProfileCodexBinary = opts.codexBinary;
-  let checkedProfileCodexBinary = false;
-  const profileCodexBinary = (): string | undefined => {
+  let resolvedProfileCodexLaunch: Extract<CodexLaunchResolution, { ok: true }> | undefined;
+  const profileCodexLaunch = (): Extract<CodexLaunchResolution, { ok: true }> | undefined => {
     if (profile.runner !== "codex") return undefined;
     // Injected channel runners are test/embedding boundaries and may not launch a harness at all.
     // Production resolves on the first invited channel, before either resident lane advertises
     // readiness, so a GUI/launchd PATH failure cannot masquerade as an online project agent.
-    if (opts.runChannelServe !== undefined) return resolvedProfileCodexBinary;
-    if (checkedProfileCodexBinary) return resolvedProfileCodexBinary;
-    checkedProfileCodexBinary = true;
-    const launch = resolveCodexLaunch(opts.codexBinary, process.env, process.cwd());
+    if (opts.runChannelServe !== undefined && opts.resolveCodexLaunch === undefined) return undefined;
+    if (resolvedProfileCodexLaunch !== undefined) return resolvedProfileCodexLaunch;
+    const launch = (opts.resolveCodexLaunch ?? resolveBuiltinCodexLaunch)(
+      opts.codexBinary,
+      process.env,
+      process.cwd(),
+    );
     if (!launch.ok) throw new Error(`builtin codex runner did not start: ${launch.error}`);
-    resolvedProfileCodexBinary = launch.codexBinary;
-    return resolvedProfileCodexBinary;
+    resolvedProfileCodexLaunch = launch;
+    return resolvedProfileCodexLaunch;
   };
   out(`serving project agent ${profile.owner_account}/${profile.handle} — runner=${profile.runner}`);
 
@@ -4195,7 +4248,9 @@ export async function runProfileServe(opts: ProfileServeOptions): Promise<number
               channel,
               harness: profile.runner,
               ...(profile.runner === "codex"
-                ? { codexBinary: profileCodexBinary() }
+                ? opts.runChannelServe !== undefined && opts.resolveCodexLaunch === undefined
+                  ? (opts.codexBinary === undefined ? {} : { codexBinary: opts.codexBinary })
+                  : { codexLaunch: profileCodexLaunch()! }
                 : {}),
               workdir: prepared.runnerWorkdir,
               cwd: prepared.channelWorkdir,
@@ -5684,6 +5739,14 @@ export interface ServePrincipal {
   owner: string | null;
 }
 
+export interface ServeCommandDeps {
+  resolveBuiltinCodexLaunch?: typeof resolveBuiltinCodexLaunch;
+  resolveAvailableUpgrade?: typeof resolveAvailableUpgrade;
+  verifyServeIdentityBoundary?: typeof verifyServeIdentityBoundary;
+  runServe?: typeof runServe;
+  superviseServe?: typeof superviseServe;
+}
+
 export type ServeIdentityBoundaryResult =
   | { ok: true; principal: ServePrincipal; namespace: string }
   | { ok: false; code: typeof EXIT_AUTH; reason: string };
@@ -5777,7 +5840,7 @@ export async function verifyServeIdentityBoundary(
   };
 }
 
-export async function run(argv: string[]): Promise<number> {
+export async function run(argv: string[], deps: ServeCommandDeps = {}): Promise<number> {
   if (isHelpArg(argv, { allowHelpPositional: true })) {
     console.log(HELP);
     return 0;
@@ -5789,6 +5852,11 @@ export async function run(argv: string[]): Promise<number> {
     return 1;
   }
   const server = auth.server;
+  const resolveCodexForServe = deps.resolveBuiltinCodexLaunch ?? resolveBuiltinCodexLaunch;
+  const resolveUpgradeForServe = deps.resolveAvailableUpgrade ?? resolveAvailableUpgrade;
+  const verifyIdentityForServe = deps.verifyServeIdentityBoundary ?? verifyServeIdentityBoundary;
+  const runServeForCommand = deps.runServe ?? runServe;
+  const superviseForCommand = deps.superviseServe ?? superviseServe;
   const unknown = unknownFlagError(flags, SERVE_FLAGS);
   if (unknown !== null) {
     console.error(unknown);
@@ -5850,7 +5918,7 @@ export async function run(argv: string[]): Promise<number> {
       return 1;
     }
     const autoDownloadUpgrade = flags["auto-upgrade"] === true;
-    const availableUpgrade = await resolveAvailableUpgrade(account.session.server, null, {
+    const availableUpgrade = await resolveUpgradeForServe(account.session.server, null, {
       autoDownload: autoDownloadUpgrade,
       out: (line) => console.error(terminalOutput(line)),
     });
@@ -5862,8 +5930,11 @@ export async function run(argv: string[]): Promise<number> {
       handle: profileRef.handle,
       mentionsOnly: flags.all !== true,
       ...(codexBinaryFlag === undefined ? {} : { codexBinary: codexBinaryFlag }),
+      ...(deps.resolveBuiltinCodexLaunch === undefined
+        ? {}
+        : { resolveCodexLaunch: deps.resolveBuiltinCodexLaunch }),
       availableUpgrade,
-      refreshAvailableUpgrade: (current) => resolveAvailableUpgrade(account.session.server, current, {
+      refreshAvailableUpgrade: (current) => resolveUpgradeForServe(account.session.server, current, {
         autoDownload: autoDownloadUpgrade,
         out: (line) => console.error(terminalOutput(line)),
       }),
@@ -5907,17 +5978,17 @@ export async function run(argv: string[]): Promise<number> {
   }
   const harness = runner === "codex" || runner === "claude" ? runner : undefined;
   const useSdkRunner = runner === "codex-sdk";
-  let codexBinary: string | undefined;
+  let codexLaunch: Extract<CodexLaunchResolution, { ok: true }> | undefined;
   if (harness === "codex") {
-    const launch = resolveCodexLaunch(codexBinaryFlag, process.env, process.cwd());
+    const launch = resolveCodexForServe(codexBinaryFlag, process.env, process.cwd());
     if (!launch.ok) {
       console.error(`builtin codex runner did not start: ${launch.error}`);
       return 1;
     }
-    codexBinary = launch.codexBinary;
+    codexLaunch = launch;
   }
   const autoDownloadUpgrade = flags["auto-upgrade"] === true;
-  const availableUpgrade = await resolveAvailableUpgrade(server, null, {
+  const availableUpgrade = await resolveUpgradeForServe(server, null, {
     autoDownload: autoDownloadUpgrade,
     out: (line) => console.error(terminalOutput(line)),
   });
@@ -5931,7 +6002,7 @@ export async function run(argv: string[]): Promise<number> {
     rejectedAccountToken: null,
   };
   try {
-    const initialBoundary = await verifyServeIdentityBoundary(server, auth, identityState);
+    const initialBoundary = await verifyIdentityForServe(server, auth, identityState);
     if (!initialBoundary.ok) {
       console.error(terminalOutput(initialBoundary.reason));
       return initialBoundary.code;
@@ -5949,7 +6020,7 @@ export async function run(argv: string[]): Promise<number> {
     if (runnerWorkdirPath !== null) appendServeLifecycleLog(runnerWorkdirPath, record);
     console.error(terminalOutput(`serve supervisor: ${line}`));
   };
-  const superviseExit = await superviseServe({
+  const superviseExit = await superviseForCommand({
     onLifecycle: lifecycle,
     runOnce: async () => {
       // 每次自愈都重读本地凭据与 OIDC 状态，避免用启动时快照把一次可恢复的 token
@@ -5960,14 +6031,14 @@ export async function run(argv: string[]): Promise<number> {
       const currentToken = currentAuth.token;
       // Cursor, stuck debt and model session are scoped to the original server+principal.  Token
       // rotation is safe only inside that boundary; config switching must start a new serve process.
-      const boundary = await verifyServeIdentityBoundary(server, currentAuth, identityState);
+      const boundary = await verifyIdentityForServe(server, currentAuth, identityState);
       if (!boundary.ok) {
         console.error(terminalOutput(`${boundary.reason}; exiting`));
         return boundary.code;
       }
       const currentRunnerWorkdir = runnerWorkdirPath ?? defaultRunnerWorkdir(channel, boundary.namespace);
       runnerWorkdirPath = currentRunnerWorkdir;
-      const result = await runServe({
+      const result = await runServeForCommand({
         server: currentServer,
         token: currentToken,
         channel,
@@ -5990,7 +6061,7 @@ export async function run(argv: string[]): Promise<number> {
         fetchCharter: (signal) => fetchChannelCharter(currentServer, currentToken, channel, signal),
         autoUpgrade: flags["auto-upgrade"] === true,
         availableUpgrade,
-        refreshAvailableUpgrade: (current) => resolveAvailableUpgrade(currentServer, current, {
+        refreshAvailableUpgrade: (current) => resolveUpgradeForServe(currentServer, current, {
           autoDownload: flags["auto-upgrade"] === true,
           out: (line) => console.error(terminalOutput(line)),
         }),
@@ -6002,7 +6073,7 @@ export async function run(argv: string[]): Promise<number> {
               token: currentToken,
               channel,
               harness,
-              ...(codexBinary === undefined ? {} : { codexBinary }),
+              ...(codexLaunch === undefined ? {} : { codexLaunch }),
               workdir: currentRunnerWorkdir,
               repo: str(flags.repo),
             }

--- a/cli/src/delivery-recovery-journal.ts
+++ b/cli/src/delivery-recovery-journal.ts
@@ -1,0 +1,499 @@
+import type {
+  DeliveryRecoverFrame,
+  DeliveryRecoveryResultFrame,
+  DirectedDelivery,
+  MsgFrame,
+} from "@agentparty/shared";
+import { createHash, randomUUID } from "node:crypto";
+import {
+  chmodSync,
+  closeSync,
+  existsSync,
+  fsyncSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { basename, dirname, join } from "node:path";
+import { agentpartyHome } from "./config";
+
+export type DeliveryRecoveryPhase =
+  | "claimed"
+  | "running_authorized"
+  | "harness_issued"
+  | "harness_accepted"
+  | "reply_posted"
+  | "waiting_owner"
+  | "failed_pending";
+
+export interface DeliveryRecoveryEntry {
+  delivery: DirectedDelivery;
+  message: MsgFrame;
+  phase: DeliveryRecoveryPhase;
+  /** Persisted before recovery is sent, making an ACK-loss retry idempotent. */
+  nextLeaseToken: string | null;
+  replyBody: string | null;
+  replySeq: number | null;
+  /** Stable Claude claim receipt; null for adapters without a claim gate. */
+  claimReceipt: string | null;
+  terminalError: string | null;
+  threadId: string | null;
+  turnId: string | null;
+  updatedAt: number;
+}
+
+export interface DeliveryRecoveryJournalOptions {
+  /** Fault-injection seam. Production always executes the durable commit. */
+  persist?: (commit: () => void) => void;
+}
+
+interface DeliveryRecoveryFile {
+  version: 1;
+  channel: string;
+  bridge: "claude" | "codex";
+  entries: DeliveryRecoveryEntry[];
+}
+
+const MAX_RECOVERY_ENTRIES = 64;
+
+function unsupportedDirectoryFsync(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) return false;
+  const code = (error as { code?: unknown }).code;
+  return code === "EINVAL" ||
+    code === "ENOTSUP" ||
+    code === "EOPNOTSUPP" ||
+    code === "ENOSYS";
+}
+
+function fsyncDirectory(path: string): void {
+  let fd: number | null = null;
+  try {
+    fd = openSync(path, "r");
+    fsyncSync(fd);
+  } catch (error) {
+    if (!unsupportedDirectoryFsync(error)) throw error;
+  } finally {
+    if (fd !== null) closeSync(fd);
+  }
+}
+
+/**
+ * Commit the recovery WAL through the actual storage boundary: fsync the
+ * complete same-directory temporary file, rename it, then fsync the parent
+ * directory. Worker ownership is not acknowledged until this returns.
+ */
+function writeRecoveryJournalDurably(path: string, value: unknown): void {
+  const directory = dirname(path);
+  const missingDirectories: string[] = [];
+  for (
+    let candidate = directory;
+    !existsSync(candidate) && dirname(candidate) !== candidate;
+    candidate = dirname(candidate)
+  ) {
+    missingDirectories.push(candidate);
+  }
+  mkdirSync(directory, { recursive: true, mode: 0o700 });
+  for (const created of missingDirectories) chmodSync(created, 0o700);
+  chmodSync(directory, 0o700);
+  // fsync every newly-created directory and its parent entry. Fsyncing only
+  // the leaf directory does not make the leaf's name durable in its parent
+  // after a machine crash on the first ever journal write.
+  for (const created of missingDirectories) {
+    fsyncDirectory(created);
+    fsyncDirectory(dirname(created));
+  }
+  const temporary = join(
+    directory,
+    `.${basename(path)}.${process.pid}.${randomUUID()}.tmp`,
+  );
+  let fd: number | null = null;
+  try {
+    fd = openSync(temporary, "wx", 0o600);
+    writeFileSync(fd, JSON.stringify(value, null, 2) + "\n", "utf8");
+    fsyncSync(fd);
+    closeSync(fd);
+    fd = null;
+    renameSync(temporary, path);
+    chmodSync(path, 0o600);
+    fsyncDirectory(directory);
+  } finally {
+    if (fd !== null) closeSync(fd);
+    if (existsSync(temporary)) rmSync(temporary, { force: true });
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseEntry(value: unknown): DeliveryRecoveryEntry | null {
+  if (!isRecord(value) || !isRecord(value.delivery) || !isRecord(value.message)) return null;
+  const delivery = value.delivery as unknown as DirectedDelivery;
+  const message = value.message as unknown as MsgFrame;
+  const phases = new Set<DeliveryRecoveryPhase>([
+    "claimed",
+    "running_authorized",
+    "harness_issued",
+    "harness_accepted",
+    "reply_posted",
+    "waiting_owner",
+    "failed_pending",
+  ]);
+  if (
+    typeof delivery.id !== "string" ||
+    !Number.isSafeInteger(delivery.attempt) ||
+    delivery.attempt <= 0 ||
+    !Number.isSafeInteger(delivery.lease_epoch) ||
+    (delivery.lease_epoch ?? 0) <= 0 ||
+    typeof delivery.lease_token !== "string" ||
+    delivery.lease_token.length === 0 ||
+    message.type !== "msg" ||
+    !Number.isSafeInteger(message.seq) ||
+    message.seq <= 0 ||
+    delivery.message_seq !== message.seq ||
+    !phases.has(value.phase as DeliveryRecoveryPhase) ||
+    (value.nextLeaseToken !== null && typeof value.nextLeaseToken !== "string") ||
+    (value.replyBody !== null && typeof value.replyBody !== "string") ||
+    (value.replySeq !== null && (!Number.isSafeInteger(value.replySeq) || Number(value.replySeq) <= 0)) ||
+    (
+      value.claimReceipt !== undefined &&
+      value.claimReceipt !== null &&
+      (typeof value.claimReceipt !== "string" || value.claimReceipt.length === 0)
+    ) ||
+    (value.terminalError !== null && typeof value.terminalError !== "string") ||
+    (value.threadId !== null && typeof value.threadId !== "string") ||
+    (value.turnId !== null && typeof value.turnId !== "string") ||
+    typeof value.updatedAt !== "number"
+  ) {
+    return null;
+  }
+  return {
+    ...(value as unknown as DeliveryRecoveryEntry),
+    // Compatibility for journals written before the explicit Claude
+    // claim/accept receipt was introduced.
+    claimReceipt: typeof value.claimReceipt === "string" ? value.claimReceipt : null,
+  };
+}
+
+export function deliveryRecoveryJournalPath(
+  bridge: "claude" | "codex",
+  server: string,
+  token: string,
+  channel: string,
+): string {
+  const principal = createHash("sha256")
+    .update(server)
+    .update("\0")
+    .update(token)
+    .update("\0")
+    .update(channel)
+    .digest("hex")
+    .slice(0, 32);
+  return join(agentpartyHome(), "delivery-recovery", `${bridge}-${channel}-${principal}.json`);
+}
+
+/**
+ * A small, mode-0600 write-ahead journal for the gap between Worker ownership
+ * and harness acceptance. The instance lock ensures a single normal writer;
+ * atomic rename protects process and machine crashes.
+ */
+export class DeliveryRecoveryJournal {
+  private readonly entriesById = new Map<string, DeliveryRecoveryEntry>();
+
+  constructor(
+    readonly path: string,
+    readonly channel: string,
+    readonly bridge: "claude" | "codex",
+    private readonly options: DeliveryRecoveryJournalOptions = {},
+  ) {
+    if (!existsSync(path)) return;
+    let raw: unknown;
+    try {
+      raw = JSON.parse(readFileSync(path, "utf8")) as unknown;
+    } catch (error) {
+      throw new Error(
+        `could not read delivery recovery journal ${path}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+    if (
+      !isRecord(raw) ||
+      raw.version !== 1 ||
+      raw.channel !== channel ||
+      raw.bridge !== bridge ||
+      !Array.isArray(raw.entries) ||
+      raw.entries.length > MAX_RECOVERY_ENTRIES
+    ) {
+      throw new Error(`invalid delivery recovery journal ${path}`);
+    }
+    for (const value of raw.entries) {
+      const entry = parseEntry(value);
+      if (entry === null || this.entriesById.has(entry.delivery.id)) {
+        throw new Error(`invalid delivery recovery journal entry in ${path}`);
+      }
+      this.entriesById.set(entry.delivery.id, entry);
+    }
+  }
+
+  entries(): DeliveryRecoveryEntry[] {
+    return [...this.entriesById.values()]
+      .sort((left, right) => left.message.seq - right.message.seq)
+      .map((entry) => structuredClone(entry));
+  }
+
+  get(deliveryId: string): DeliveryRecoveryEntry | null {
+    const entry = this.entriesById.get(deliveryId);
+    return entry === undefined ? null : structuredClone(entry);
+  }
+
+  recordClaim(delivery: DirectedDelivery, message: MsgFrame): DeliveryRecoveryEntry {
+    if (
+      delivery.state !== "claimed" ||
+      delivery.message_seq !== message.seq ||
+      delivery.lease_epoch === undefined ||
+      delivery.lease_epoch <= 0 ||
+      delivery.lease_token === undefined ||
+      delivery.lease_token.length === 0
+    ) {
+      throw new Error(`delivery ${delivery.id} is not a valid claimed message assignment`);
+    }
+    const current = this.entriesById.get(delivery.id);
+    if (current !== undefined) {
+      const sameLogicalDelivery =
+        current.delivery.message_seq === delivery.message_seq &&
+        current.delivery.target_name === delivery.target_name &&
+        current.delivery.cause === delivery.cause &&
+        current.delivery.work_id === delivery.work_id &&
+        current.delivery.continuation_ref === delivery.continuation_ref &&
+        current.delivery.created_at === delivery.created_at &&
+        JSON.stringify(current.message) === JSON.stringify(message);
+      if (!sameLogicalDelivery) {
+        throw new Error(`delivery ${delivery.id} changed logical identity while recovery debt exists`);
+      }
+      if (
+        current.delivery.attempt !== delivery.attempt ||
+        current.delivery.lease_epoch !== delivery.lease_epoch
+      ) {
+        if (
+          current.phase === "claimed" &&
+          delivery.attempt > current.delivery.attempt &&
+          (delivery.lease_epoch ?? 0) > (current.delivery.lease_epoch ?? 0)
+        ) {
+          const replacement: DeliveryRecoveryEntry = {
+            delivery: structuredClone(delivery),
+            message: structuredClone(message),
+            phase: "claimed",
+            nextLeaseToken: null,
+            replyBody: null,
+            replySeq: null,
+            claimReceipt: null,
+            terminalError: null,
+            threadId: null,
+            turnId: null,
+            updatedAt: Date.now(),
+          };
+          const nextEntries = new Map(this.entriesById);
+          nextEntries.set(delivery.id, replacement);
+          this.persistSnapshot(nextEntries);
+          this.entriesById.set(delivery.id, replacement);
+          return structuredClone(replacement);
+        }
+        throw new Error(`delivery ${delivery.id} changed assignment while recovery debt exists`);
+      }
+      if (current.delivery.lease_token !== delivery.lease_token) {
+        throw new Error(`delivery ${delivery.id} changed lease token without recovery acknowledgement`);
+      }
+      return structuredClone(current);
+    }
+    if (this.entriesById.size >= MAX_RECOVERY_ENTRIES) {
+      throw new Error(`delivery recovery journal exceeded ${MAX_RECOVERY_ENTRIES} active entries`);
+    }
+    const entry: DeliveryRecoveryEntry = {
+      delivery: structuredClone(delivery),
+      message: structuredClone(message),
+      phase: "claimed",
+      nextLeaseToken: null,
+      replyBody: null,
+      replySeq: null,
+      claimReceipt: null,
+      terminalError: null,
+      threadId: null,
+      turnId: null,
+      updatedAt: Date.now(),
+    };
+    const nextEntries = new Map(this.entriesById);
+    nextEntries.set(delivery.id, entry);
+    this.persistSnapshot(nextEntries);
+    this.entriesById.set(delivery.id, entry);
+    return structuredClone(entry);
+  }
+
+  update(
+    deliveryId: string,
+    patch: Partial<Omit<DeliveryRecoveryEntry, "delivery" | "message">> & {
+      delivery?: DirectedDelivery;
+    },
+  ): DeliveryRecoveryEntry {
+    const current = this.entriesById.get(deliveryId);
+    if (current === undefined) throw new Error(`no recovery journal entry for ${deliveryId}`);
+    const next: DeliveryRecoveryEntry = {
+      ...current,
+      ...patch,
+      delivery: patch.delivery === undefined ? current.delivery : structuredClone(patch.delivery),
+      message: current.message,
+      updatedAt: Date.now(),
+    };
+    const nextEntries = new Map(this.entriesById);
+    nextEntries.set(deliveryId, next);
+    this.persistSnapshot(nextEntries);
+    this.entriesById.set(deliveryId, next);
+    return structuredClone(next);
+  }
+
+  prepareRecovery(
+    deliveryId: string,
+    options: {
+      replaySafe?: boolean;
+      /**
+       * Recovery decisions are made from an immutable journal snapshot. The
+       * exact phase/revision fence prevents a stale lane from publishing
+       * replay_safe after another callback has crossed the harness boundary.
+       */
+      expected?: {
+        phase: DeliveryRecoveryPhase;
+        updatedAt: number;
+        attempt: number;
+        leaseEpoch: number;
+        leaseToken: string;
+      };
+    } = {},
+  ): DeliveryRecoverFrame {
+    const current = this.entriesById.get(deliveryId);
+    if (current === undefined) throw new Error(`no recovery journal entry for ${deliveryId}`);
+    const leaseEpoch = current.delivery.lease_epoch;
+    const leaseToken = current.delivery.lease_token;
+    if (leaseEpoch === undefined || leaseToken === undefined) {
+      throw new Error(`delivery ${deliveryId} omitted reconnect ownership`);
+    }
+    const expected = options.expected;
+    if (
+      expected !== undefined &&
+      (
+        current.phase !== expected.phase ||
+        current.updatedAt !== expected.updatedAt ||
+        current.delivery.attempt !== expected.attempt ||
+        leaseEpoch !== expected.leaseEpoch ||
+        leaseToken !== expected.leaseToken
+      )
+    ) {
+      throw new Error(`delivery ${deliveryId} changed while recovery was being prepared`);
+    }
+    if (options.replaySafe === true && expected === undefined) {
+      throw new Error(`replay-safe recovery for ${deliveryId} requires an exact journal snapshot`);
+    }
+    const nextLeaseToken = current.nextLeaseToken ?? randomUUID();
+    if (current.nextLeaseToken === null) {
+      const next = {
+        ...current,
+        nextLeaseToken,
+        updatedAt: Date.now(),
+      };
+      const nextEntries = new Map(this.entriesById);
+      nextEntries.set(deliveryId, next);
+      this.persistSnapshot(nextEntries);
+      this.entriesById.set(deliveryId, next);
+    }
+    return {
+      type: "delivery_recover",
+      delivery_id: deliveryId,
+      request_id: randomUUID(),
+      attempt: current.delivery.attempt,
+      lease_epoch: leaseEpoch,
+      lease_token: leaseToken,
+      next_lease_token: nextLeaseToken,
+      ...(options.replaySafe === true ? { replay_safe: true as const } : {}),
+    };
+  }
+
+  acceptRecovery(frame: DeliveryRecoveryResultFrame): DeliveryRecoveryEntry {
+    const current = this.entriesById.get(frame.delivery_id);
+    if (
+      frame.result !== "recovered" ||
+      frame.lease_token === undefined ||
+      frame.lease_until === undefined ||
+      current === undefined ||
+      current.delivery.attempt !== frame.attempt ||
+      current.delivery.lease_epoch !== frame.lease_epoch ||
+      current.nextLeaseToken !== frame.lease_token
+    ) {
+      throw new Error(`delivery recovery acknowledgement does not match ${frame.delivery_id}`);
+    }
+    const next: DeliveryRecoveryEntry = {
+      ...current,
+      delivery: {
+        ...current.delivery,
+        state: frame.state,
+        lease_token: frame.lease_token,
+        lease_until: frame.lease_until,
+      },
+      nextLeaseToken: null,
+      // Ownership recovery rotates the Worker bearer token, not the logical
+      // harness invocation. Preserve an unaccepted receipt so a claim whose
+      // MCP response was delayed/lost can be fetched or accepted idempotently
+      // after websocket or process recovery. A genuinely new attempt gets a
+      // fresh entry/receipt through recordClaim instead.
+      claimReceipt: current.claimReceipt,
+      updatedAt: Date.now(),
+    };
+    const nextEntries = new Map(this.entriesById);
+    nextEntries.set(frame.delivery_id, next);
+    this.persistSnapshot(nextEntries);
+    this.entriesById.set(frame.delivery_id, next);
+    return structuredClone(next);
+  }
+
+  remove(deliveryId: string): void {
+    this.removeMany([deliveryId]);
+  }
+
+  /** Atomically clear related obligations (for example owner answer + source binding). */
+  removeMany(deliveryIds: readonly string[]): void {
+    const unique = new Set(deliveryIds);
+    if (![...unique].some((deliveryId) => this.entriesById.has(deliveryId))) return;
+    const nextEntries = new Map(this.entriesById);
+    for (const deliveryId of unique) nextEntries.delete(deliveryId);
+    this.persistSnapshot(nextEntries);
+    for (const deliveryId of unique) this.entriesById.delete(deliveryId);
+  }
+
+  /**
+   * Persist a complete prospective snapshot before publishing it in memory.
+   * Every caller therefore has transaction-like failure semantics: an I/O
+   * error leaves entriesById unchanged and a retry must cross the durability
+   * boundary again before any recovery frame can be returned.
+   */
+  private persistSnapshot(entries: Map<string, DeliveryRecoveryEntry>): void {
+    const commit = () => {
+      if (entries.size === 0) {
+        rmSync(this.path, { force: true });
+        if (existsSync(dirname(this.path))) fsyncDirectory(dirname(this.path));
+        return;
+      }
+      const file: DeliveryRecoveryFile = {
+        version: 1,
+        channel: this.channel,
+        bridge: this.bridge,
+        entries: [...entries.values()].sort(
+          (left, right) => left.message.seq - right.message.seq,
+        ),
+      };
+      writeRecoveryJournalDurably(this.path, file);
+    };
+    if (this.options.persist) this.options.persist(commit);
+    else commit();
+  }
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -28,6 +28,7 @@ commands:
   watch     [channel|--channel C] [--timeout N] [--mentions-only] [--follow] [--json]
   ack       [--channel C] [--seq N]                acknowledge a watch wake that needs no reply (#594)
   serve     [channel|--channel C] (--on-mention "<cmd>" | --runner codex|claude|codex-sdk) [--all] | --profile owner/handle
+  bridge    claude|codex [channel|--channel C] [-- <args...>] attach AgentParty to the current interactive harness session
   daemon    [channel|--channel C] [--timeout N]        EXPERIMENTAL (#672 spike): resident runner embedding the Claude Agent SDK; @-mention → in-process SDK session → reply
   mcp                                                structured control plane (not an idle wake provider)
   lark      notify on|off|status [--channel C]       send channel @mentions to your Lark/Feishu account
@@ -106,6 +107,13 @@ export async function main(argv: string[]): Promise<number> {
       return (await import("./commands/ack")).run(rest);
     case "serve":
       return (await import("./commands/serve")).run(rest);
+    case "bridge":
+      return (await import("./commands/bridge")).run(rest);
+    // Internal stdio subprocess spawned by `party bridge claude`. It remains
+    // hidden from top-level help so users enter through the version/capability
+    // preflight and interactive launcher.
+    case "claude-channel":
+      return (await import("./commands/claude-channel")).run(rest);
     case "daemon":
       return (await import("./commands/daemon")).run(rest);
     case "mcp":

--- a/cli/test/claude-channel-mcp.test.ts
+++ b/cli/test/claude-channel-mcp.test.ts
@@ -1,0 +1,227 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { ClientFrame } from "@agentparty/shared";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { deliveryFrame, welcomeDirectedFrame } from "./mock-server";
+
+const indexPath = join(import.meta.dir, "..", "src", "index.ts");
+
+let home: string;
+let backend: ReturnType<typeof Bun.serve> | null = null;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "ap-claude-channel-mcp-"));
+});
+
+afterEach(() => {
+  backend?.stop(true);
+  backend = null;
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe("claude-channel stdio MCP adapter", () => {
+  test("declares the dedicated capability, emits a channel notification, and persists a linked reply", async () => {
+    const clientFrames: ClientFrame[] = [];
+    const posts: unknown[] = [];
+    const directed = deliveryFrame(12, "same-session work", {
+      id: "delivery-12",
+      target_name: "me",
+      sender: { name: "alice", kind: "human" },
+    });
+    backend = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      async fetch(request, server) {
+        const url = new URL(request.url);
+        if (url.pathname === "/api/channels/dev/ws" && server.upgrade(request, { data: undefined })) return;
+        if (url.pathname === "/api/channels/dev/messages" && request.method === "POST") {
+          posts.push(await request.json());
+          return Response.json({ seq: 99 });
+        }
+        return Response.json({ error: { code: "not_found", message: "not found" } }, { status: 404 });
+      },
+      websocket: {
+        message(socket, raw) {
+          const frame = JSON.parse(String(raw)) as ClientFrame;
+          clientFrames.push(frame);
+          if (frame.type === "hello") {
+            socket.send(JSON.stringify(welcomeDirectedFrame(0, "me")));
+          } else if (frame.type === "delivery_adapter") {
+            socket.send(JSON.stringify({ type: "delivery_adapter", adapter: "watch", registered: true }));
+            socket.send(JSON.stringify(directed));
+          } else if (frame.type === "delivery_update" && frame.request_id) {
+            socket.send(JSON.stringify({
+              type: "delivery_state",
+              request_id: frame.request_id,
+              delivery: {
+                ...directed.delivery,
+                state: frame.state,
+                reply_seq: frame.reply_seq ?? directed.delivery.reply_seq,
+              },
+            }));
+          }
+        },
+      },
+    });
+    mkdirSync(home, { recursive: true });
+    writeFileSync(
+      join(home, "config.json"),
+      JSON.stringify({ server: `http://127.0.0.1:${backend.port}`, token: "ap_tok" }),
+    );
+
+    const env: Record<string, string> = {};
+    for (const [key, value] of Object.entries(process.env)) {
+      if (value !== undefined && key !== "AGENTPARTY_CONFIG") env[key] = value;
+    }
+    env.AGENTPARTY_HOME = home;
+    const transport = new StdioClientTransport({
+      command: "bun",
+      args: ["run", indexPath, "claude-channel", "--channel", "dev"],
+      env,
+      stderr: "pipe",
+    });
+    const notifications: Array<{ method: string; params?: unknown }> = [];
+    let notify!: (value: void) => void;
+    const received = new Promise<void>((resolve) => {
+      notify = resolve;
+    });
+    const client = new Client({ name: "claude-channel-contract-test", version: "1.0.0" });
+    client.fallbackNotificationHandler = async (notification) => {
+      notifications.push(notification);
+      if (notification.method === "notifications/claude/channel") notify();
+    };
+
+    await client.connect(transport);
+    try {
+      expect(client.getServerCapabilities()?.experimental).toMatchObject({
+        "claude/channel": {},
+      });
+      expect(client.getInstructions()).toContain("party_channel_claim");
+      expect(client.getInstructions()).toContain("party_channel_accept");
+      expect(client.getInstructions()).toContain("party_channel_reply");
+      const tools = await client.listTools();
+      expect(tools.tools.map((tool) => tool.name)).toEqual([
+        "party_channel_claim",
+        "party_channel_accept",
+        "party_channel_reply",
+      ]);
+
+      await Promise.race([
+        received,
+        new Promise((_, reject) => setTimeout(() => reject(new Error("channel notification timeout")), 3_000)),
+      ]);
+      const channelEvent = notifications.find((entry) => entry.method === "notifications/claude/channel");
+      expect(channelEvent?.params).toMatchObject({
+        content: expect.stringContaining("execution_id=delivery-12"),
+        meta: {
+          source: "agentparty",
+          channel: "dev",
+          seq: "12",
+          sender: "alice",
+          sender_kind: "human",
+          delivery_id: "delivery-12",
+          execution_id: "delivery-12",
+        },
+      });
+      expect(JSON.stringify(channelEvent?.params)).not.toContain("same-session work");
+
+      const unclaimedReply = await client.callTool({
+        name: "party_channel_reply",
+        arguments: { seq: 12, text: "must not persist before claim" },
+      });
+      expect(unclaimedReply.isError).toBe(true);
+      expect(posts).toEqual([]);
+
+      const claim = await client.callTool({
+        name: "party_channel_claim",
+        arguments: { execution_id: "delivery-12" },
+      });
+      expect(claim.isError).not.toBe(true);
+      const claimContent = JSON.stringify(claim.content);
+      expect(claimContent).toContain("same-session work");
+      const receipt = /AgentParty claim receipt: ([0-9a-f-]+)/.exec(claimContent)?.[1];
+      expect(typeof receipt).toBe("string");
+
+      // Model an MCP response lost after the claim WAL commit. Until accept,
+      // an equivalent retry must return the exact same receipt and body.
+      const duplicateClaim = await client.callTool({
+        name: "party_channel_claim",
+        arguments: { execution_id: "delivery-12" },
+      });
+      expect(duplicateClaim.isError).not.toBe(true);
+      expect(duplicateClaim.content).toEqual(claim.content);
+
+      const preAcceptReply = await client.callTool({
+        name: "party_channel_reply",
+        arguments: { seq: 12, text: "must not persist before accept" },
+      });
+      expect(preAcceptReply.isError).toBe(true);
+      expect(JSON.stringify(preAcceptReply.content)).toContain("accepted");
+      expect(posts).toEqual([]);
+
+      const wrongReceipt = await client.callTool({
+        name: "party_channel_accept",
+        arguments: {
+          execution_id: "delivery-12",
+          claim_receipt: "receipt-from-an-old-generation",
+        },
+      });
+      expect(wrongReceipt.isError).toBe(true);
+      expect(JSON.stringify(wrongReceipt.content)).toContain(
+        "invalid or belongs to an old ownership generation",
+      );
+
+      const accept = await client.callTool({
+        name: "party_channel_accept",
+        arguments: { execution_id: "delivery-12", claim_receipt: receipt! },
+      });
+      expect(accept.isError).not.toBe(true);
+      expect(JSON.stringify(accept.content)).toContain("durably accepted");
+
+      // Model the accept ACK being lost after its WAL commit. The exact retry
+      // is a successful no-op, and a later claim cannot release the body again.
+      const duplicateAccept = await client.callTool({
+        name: "party_channel_accept",
+        arguments: { execution_id: "delivery-12", claim_receipt: receipt! },
+      });
+      expect(duplicateAccept.isError).not.toBe(true);
+      expect(JSON.stringify(duplicateAccept.content)).toContain("already durably accepted");
+      const postAcceptClaim = await client.callTool({
+        name: "party_channel_claim",
+        arguments: { execution_id: "delivery-12" },
+      });
+      expect(postAcceptClaim.isError).toBe(true);
+      expect(JSON.stringify(postAcceptClaim.content)).toContain("already accepted");
+      expect(JSON.stringify(postAcceptClaim.content)).not.toContain("same-session work");
+
+      const reply = await client.callTool({
+        name: "party_channel_reply",
+        arguments: { seq: 12, text: "linked response" },
+      });
+      expect(reply.isError).not.toBe(true);
+      expect(posts).toEqual([expect.objectContaining({
+        kind: "message",
+        body: "linked response",
+        mentions: ["alice"],
+        reply_to: 12,
+        idempotency_key: "claude-channel-reply:delivery-12",
+      })]);
+      expect(clientFrames).toContainEqual(expect.objectContaining({
+        type: "delivery_update",
+        delivery_id: "delivery-12",
+        state: "running",
+      }));
+      expect(clientFrames).toContainEqual(expect.objectContaining({
+        type: "delivery_update",
+        delivery_id: "delivery-12",
+        state: "replied",
+        reply_seq: 99,
+      }));
+    } finally {
+      await client.close();
+    }
+  }, 10_000);
+});

--- a/cli/test/claude-channel.test.ts
+++ b/cli/test/claude-channel.test.ts
@@ -1,0 +1,2008 @@
+import { describe, expect, test } from "bun:test";
+import type { ClientFrame, MsgFrame, ServerFrame } from "@agentparty/shared";
+import { buildClaudeBridgeLaunch, parseClaudeVersion, run as runBridge, supportsClaudeChannels } from "../src/commands/bridge";
+import {
+  ClaudeChannelDeliveryBridge,
+  type ChannelNotification,
+  type ChannelPostReply,
+} from "../src/commands/claude-channel";
+import { DeliveryRecoveryJournal } from "../src/delivery-recovery-journal";
+import { deliveryFrame, msgFrame, welcomeDirectedFrame, welcomeFrame } from "./mock-server";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+function fakeConnection(initialCursor = 0) {
+  let cursor = initialCursor;
+  const sent: ClientFrame[] = [];
+  const acked: number[] = [];
+  let closed = false;
+  return {
+    sent,
+    acked,
+    get closed() {
+      return closed;
+    },
+    connection: {
+      frames: (async function* (): AsyncGenerator<ServerFrame> {})(),
+      send(frame: ClientFrame) {
+        sent.push(frame);
+        return true;
+      },
+      ack(seq: number) {
+        acked.push(seq);
+        cursor = Math.max(cursor, seq);
+      },
+      close() {
+        closed = true;
+      },
+      get cursor() {
+        return cursor;
+      },
+    },
+  };
+}
+
+function streamingConnection() {
+  let cursor = 0;
+  const sent: ClientFrame[] = [];
+  const acked: number[] = [];
+  const queued: ServerFrame[] = [];
+  let ended = false;
+  let wake: (() => void) | null = null;
+  const signal = () => {
+    const resolve = wake;
+    wake = null;
+    resolve?.();
+  };
+  const frames = (async function* (): AsyncGenerator<ServerFrame> {
+    for (;;) {
+      const frame = queued.shift();
+      if (frame) {
+        yield frame;
+        continue;
+      }
+      if (ended) return;
+      await new Promise<void>((resolve) => {
+        wake = resolve;
+      });
+    }
+  })();
+  return {
+    sent,
+    push(frame: ServerFrame) {
+      queued.push(frame);
+      signal();
+    },
+    connection: {
+      frames,
+      send(frame: ClientFrame) {
+        sent.push(frame);
+        return true;
+      },
+      ack(seq: number) {
+        acked.push(seq);
+        cursor = Math.max(cursor, seq);
+      },
+      close() {
+        ended = true;
+        signal();
+      },
+      get cursor() {
+        return cursor;
+      },
+    },
+  };
+}
+
+async function waitFor(predicate: () => boolean, message: string): Promise<void> {
+  const deadline = Date.now() + 3_000;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error(message);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+function ownerAnswerFrame(options: {
+  seq: number;
+  deliveryId: string;
+  sourceDeliveryId: string;
+  sourceSeq: number;
+  questionSeq: number;
+  workId: string;
+  continuationRef: string;
+  body?: string;
+}): Extract<ServerFrame, { type: "delivery" }> {
+  const frame = deliveryFrame(options.seq, options.body ?? "owner approved", {
+    id: options.deliveryId,
+    target_name: "me",
+    sender: { name: "owner", kind: "human" },
+    work_id: options.workId,
+    continuation_ref: options.continuationRef,
+  }) as Extract<ServerFrame, { type: "delivery" }>;
+  frame.delivery.cause = "owner_answer";
+  frame.message = {
+    ...frame.message,
+    reply_to: options.questionSeq,
+    decision_response: {
+      request_seq: options.questionSeq,
+      chosen_index: 0,
+      chosen_option: "approve",
+      prompt: "May this continue?",
+      delivery_id: options.sourceDeliveryId,
+      origin_seq: options.sourceSeq,
+      origin_channel: "dev",
+      work_id: options.workId,
+      continuation_ref: options.continuationRef,
+    },
+  };
+  return frame;
+}
+
+describe("party bridge claude capability preflight", () => {
+  test("parses Claude's decorated version output and enforces the Channels boundary", () => {
+    expect(parseClaudeVersion("2.1.218 (Claude Code)")).toEqual([2, 1, 218]);
+    expect(parseClaudeVersion("claude v2.1.80")).toEqual([2, 1, 80]);
+    expect(parseClaudeVersion("not-semver")).toBeNull();
+    expect(supportsClaudeChannels("2.1.79 (Claude Code)")).toBe(false);
+    expect(supportsClaudeChannels("2.1.80 (Claude Code)")).toBe(true);
+    expect(supportsClaudeChannels("2.2.0 (Claude Code)")).toBe(true);
+  });
+
+  test("launch config uses the dedicated channel capability and preserves Claude args", () => {
+    const launch = buildClaudeBridgeLaunch({
+      channel: "dev",
+      claudeArgs: ["--model", "opus"],
+      execPath: "/opt/homebrew/bin/bun",
+      processArgv: ["/opt/homebrew/bin/bun", "/repo/cli/src/index.ts", "bridge", "claude"],
+    });
+    expect(launch.command).toBe("claude");
+    expect(launch.args).toContain("--dangerously-load-development-channels");
+    expect(launch.args).toContain("server:agentparty-channel");
+    expect(launch.args.slice(-2)).toEqual(["--model", "opus"]);
+    expect(launch.mcpConfig.mcpServers["agentparty-channel"]).toEqual({
+      type: "stdio",
+      command: "/opt/homebrew/bin/bun",
+      args: ["/repo/cli/src/index.ts", "claude-channel", "--channel", "dev"],
+    });
+  });
+
+  test("old Claude fails closed without launching or choosing an unsafe resume path", async () => {
+    let launches = 0;
+    const errors: string[] = [];
+    const oldError = console.error;
+    console.error = (...args: unknown[]) => errors.push(args.map(String).join(" "));
+    try {
+      const code = await runBridge(["claude", "dev"], {
+        probeClaudeVersion: async () => "2.1.79 (Claude Code)",
+        launch: async () => {
+          launches += 1;
+          return 0;
+        },
+      });
+      expect(code).toBe(1);
+      expect(launches).toBe(0);
+      expect(errors.join("\n")).toContain("will not fall back to PTY injection or concurrently resume");
+    } finally {
+      console.error = oldError;
+    }
+  });
+});
+
+describe("Claude Channel directed-delivery ledger", () => {
+  test("production frame loop waits for the authoritative running ACK before notifying Claude", async () => {
+    const stream = streamingConnection();
+    const notifications: ChannelNotification[] = [];
+    const bridge = new ClaudeChannelDeliveryBridge({
+      channel: "dev",
+      connection: stream.connection,
+      notify: async (notification) => {
+        notifications.push(notification);
+      },
+      postReply: async () => ({ seq: 1 }),
+      deliveryAckTimeoutMs: 1_000,
+      out: () => {},
+    });
+    const run = bridge.run();
+    stream.push(welcomeDirectedFrame(0, "me") as ServerFrame);
+    const incoming = deliveryFrame(6, "wait for Worker", {
+      id: "delivery-6",
+      target_name: "me",
+      sender: { name: "alice", kind: "human" },
+    });
+    stream.push(incoming as ServerFrame);
+    await waitFor(
+      () => stream.sent.some((frame) => frame.type === "delivery_update"),
+      "running update was not sent",
+    );
+    expect(notifications).toHaveLength(0);
+    const running = stream.sent.find((frame) => frame.type === "delivery_update") as
+      Extract<ClientFrame, { type: "delivery_update" }> & { request_id: string };
+    expect(running.request_id).toEqual(expect.any(String));
+    stream.push({
+      type: "delivery_state",
+      request_id: running.request_id,
+      delivery: {
+        ...incoming.delivery,
+        state: "running",
+      },
+    } as ServerFrame);
+    await waitFor(() => notifications.length === 1, "running ACK did not release notification");
+    bridge.close();
+    await expect(run).resolves.toBe(0);
+  });
+
+  test("production ACK path returns waiting_owner and keeps the source parked", async () => {
+    const stream = streamingConnection();
+    let notifications = 0;
+    const bridge = new ClaudeChannelDeliveryBridge({
+      channel: "dev",
+      connection: stream.connection,
+      notify: async () => {
+        notifications += 1;
+      },
+      postReply: async () => ({ seq: 101 }),
+      deliveryAckTimeoutMs: 1_000,
+      leaseRenewIntervalMs: 60_000,
+      out: () => {},
+    });
+    const run = bridge.run();
+    stream.push(welcomeDirectedFrame(0, "me") as ServerFrame);
+    const incoming = deliveryFrame(24, "production waiting owner", {
+      id: "delivery-production-park",
+      target_name: "me",
+      work_id: "work-production-park",
+      continuation_ref: "continuation-production-park",
+    });
+    stream.push(incoming as ServerFrame);
+    await waitFor(
+      () => stream.sent.some((frame) =>
+        frame.type === "delivery_update" &&
+        frame.delivery_id === "delivery-production-park" &&
+        frame.state === "running"
+      ),
+      "running update was not sent",
+    );
+    const running = stream.sent.find((frame) =>
+      frame.type === "delivery_update" &&
+      frame.delivery_id === "delivery-production-park" &&
+      frame.state === "running"
+    ) as Extract<ClientFrame, { type: "delivery_update" }> & { request_id: string };
+    stream.push({
+      type: "delivery_state",
+      request_id: running.request_id,
+      delivery: { ...incoming.delivery, state: "running" },
+    } as ServerFrame);
+    await waitFor(() => notifications === 1, "notification was not released");
+
+    const reply = bridge.reply(24, "owner question persisted");
+    await waitFor(
+      () => stream.sent.some((frame) =>
+        frame.type === "delivery_update" &&
+        frame.delivery_id === "delivery-production-park" &&
+        frame.state === "replied"
+      ),
+      "replied update was not sent",
+    );
+    expect(bridge.pendingCount).toBe(1);
+    const replied = stream.sent.find((frame) =>
+      frame.type === "delivery_update" &&
+      frame.delivery_id === "delivery-production-park" &&
+      frame.state === "replied"
+    ) as Extract<ClientFrame, { type: "delivery_update" }> & { request_id: string };
+    stream.push({
+      type: "delivery_state",
+      request_id: replied.request_id,
+      delivery: { ...incoming.delivery, state: "waiting_owner", reply_seq: 101 },
+    } as ServerFrame);
+    await expect(reply).resolves.toEqual({ seq: 101 });
+    expect(bridge.pendingCount).toBe(0);
+    expect(bridge.parkedContinuationCount).toBe(1);
+    bridge.close();
+    await expect(run).resolves.toBe(0);
+  });
+
+  test("running ACK timeout never notifies Claude or silently clears unsettled work", async () => {
+    const fake = fakeConnection();
+    let notifications = 0;
+    const bridge = new ClaudeChannelDeliveryBridge({
+      channel: "dev",
+      connection: fake.connection,
+      notify: async () => {
+        notifications += 1;
+      },
+      postReply: async () => ({ seq: 1 }),
+      deliveryAckTimeoutMs: 20,
+      deliveryAckMaxAttempts: 1,
+      deliverySettleRetryMaxRounds: 0,
+      out: () => {},
+    });
+    await bridge.handleFrame(welcomeDirectedFrame(0, "me") as ServerFrame);
+    await bridge.handleFrame(deliveryFrame(5, "do not notify", {
+      id: "delivery-5",
+      target_name: "me",
+    }) as ServerFrame);
+    expect(notifications).toBe(0);
+    expect(bridge.pendingCount).toBe(1);
+    expect(fake.sent).toContainEqual(expect.objectContaining({
+      type: "delivery_update",
+      delivery_id: "delivery-5",
+      state: "running",
+      request_id: expect.any(String),
+    }));
+    bridge.close();
+  });
+
+  test("a running update applied with a lost direct ACK retries before Claude is notified", async () => {
+    const fake = fakeConnection();
+    let runningAttempts = 0;
+    let workerState: "claimed" | "running" = "claimed";
+    let notifications = 0;
+    const bridge = new ClaudeChannelDeliveryBridge({
+      channel: "dev",
+      connection: fake.connection,
+      notify: async () => {
+        notifications += 1;
+      },
+      postReply: async () => ({ seq: 1 }),
+      confirmDeliveryUpdate: async (update) => {
+        if (update.state !== "running") return update.state;
+        runningAttempts += 1;
+        if (runningAttempts === 1) {
+          workerState = "running";
+          throw new Error("direct running ACK was lost after apply");
+        }
+        expect(workerState).toBe("running");
+        return "running";
+      },
+      deliveryAckRetryDelayMs: 0,
+      leaseRenewIntervalMs: 60_000,
+      out: () => {},
+    });
+    await bridge.handleFrame(welcomeDirectedFrame(0, "me") as ServerFrame);
+    await bridge.handleFrame(deliveryFrame(55, "claim exactly once", {
+      id: "delivery-running-ack-loss",
+      target_name: "me",
+    }) as ServerFrame);
+
+    expect(runningAttempts).toBe(2);
+    expect(notifications).toBe(1);
+    expect(bridge.pendingCount).toBe(1);
+    bridge.close();
+  });
+
+  test("an unaccepted claim keeps the same receipt and body across process restart recovery", async () => {
+    const root = mkdtempSync(join(tmpdir(), "ap-claude-recovery-"));
+    const path = join(root, "journal.json");
+    try {
+      const incoming = deliveryFrame(57, "recover after process restart", {
+        id: "delivery-process-restart",
+        target_name: "me",
+      });
+      const firstJournal = new DeliveryRecoveryJournal(path, "dev", "claude");
+      const first = new ClaudeChannelDeliveryBridge({
+        channel: "dev",
+        connection: fakeConnection().connection,
+        recoveryJournal: firstJournal,
+        requireHarnessClaim: true,
+        notify: async () => {},
+        postReply: async () => ({ seq: 1 }),
+        confirmDeliveryUpdate: async (update) => update.state,
+        leaseRenewIntervalMs: 60_000,
+        out: () => {},
+      });
+      await first.handleFrame(welcomeDirectedFrame(0, "me") as ServerFrame);
+      await first.handleFrame(incoming as ServerFrame);
+      const originalClaim = first.claim(incoming.delivery.id);
+      const originalReceipt = originalClaim.receipt;
+      expect(originalClaim.claimed).toBe(true);
+      expect(typeof originalReceipt).toBe("string");
+      expect(originalClaim.content).toContain("recover after process restart");
+      expect(firstJournal.get(incoming.delivery.id)).toMatchObject({
+        phase: "harness_issued",
+        claimReceipt: originalReceipt,
+      });
+      first.close();
+
+      const secondStream = streamingConnection();
+      let notifications = 0;
+      const restartedJournal = new DeliveryRecoveryJournal(path, "dev", "claude");
+      expect(restartedJournal.get("delivery-process-restart")).toMatchObject({
+        phase: "harness_issued",
+        claimReceipt: originalReceipt,
+      });
+      const second = new ClaudeChannelDeliveryBridge({
+        channel: "dev",
+        connection: secondStream.connection,
+        recoveryJournal: restartedJournal,
+        requireHarnessClaim: true,
+        notify: async () => {
+          notifications += 1;
+        },
+        postReply: async () => ({ seq: 1 }),
+        deliveryAckTimeoutMs: 1_000,
+        leaseRenewIntervalMs: 60_000,
+        out: () => {},
+      });
+      const secondRun = second.run();
+      secondStream.push(welcomeDirectedFrame(57, "me") as ServerFrame);
+      await waitFor(
+        () => secondStream.sent.some((frame) => frame.type === "delivery_recover"),
+        "replacement process did not request ownership recovery",
+      );
+      const recover = secondStream.sent.find((frame) =>
+        frame.type === "delivery_recover"
+      ) as Extract<ClientFrame, { type: "delivery_recover" }>;
+      secondStream.push({
+        type: "delivery_recovery",
+        delivery_id: recover.delivery_id,
+        request_id: recover.request_id,
+        result: "recovered",
+        state: "running",
+        attempt: recover.attempt,
+        lease_epoch: recover.lease_epoch,
+        lease_token: recover.next_lease_token,
+        lease_until: Date.now() + 90_000,
+      });
+      await waitFor(() => notifications === 1, "recovered claim notification was not queued");
+      const recoveredClaim = second.claim(recover.delivery_id);
+      expect(recoveredClaim).toEqual(originalClaim);
+      expect(second.accept(recover.delivery_id, recoveredClaim.receipt!)).toMatchObject({
+        accepted: true,
+      });
+      expect(notifications).toBe(1);
+      expect(restartedJournal.get(recover.delivery_id)).toMatchObject({
+        phase: "harness_accepted",
+        claimReceipt: originalReceipt,
+        delivery: { lease_token: recover.next_lease_token },
+      });
+      second.close();
+      await expect(secondRun).resolves.toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("reply persistence stops lease renewal before the HTTP response returns", async () => {
+    const fake = fakeConnection();
+    let runningUpdates = 0;
+    let lateRunningUpdates = 0;
+    let workerTerminal = false;
+    let releaseResponse!: () => void;
+    const responseGate = new Promise<void>((resolve) => {
+      releaseResponse = resolve;
+    });
+    const bridge = new ClaudeChannelDeliveryBridge({
+      channel: "dev",
+      connection: fake.connection,
+      notify: async () => {},
+      postReply: async () => {
+        workerTerminal = true;
+        await responseGate;
+        return { seq: 56 };
+      },
+      confirmDeliveryUpdate: async (update) => {
+        if (update.state === "running") {
+          runningUpdates += 1;
+          if (workerTerminal) {
+            lateRunningUpdates += 1;
+            throw new Error("stale running update reached terminal Worker row");
+          }
+        }
+        return update.state;
+      },
+      leaseRenewIntervalMs: 2,
+      deliveryAckRetryDelayMs: 0,
+      out: () => {},
+    });
+    await bridge.handleFrame(welcomeDirectedFrame(0, "me") as ServerFrame);
+    await bridge.handleFrame(deliveryFrame(56, "persist before response", {
+      id: "delivery-stop-renewal-before-post",
+      target_name: "me",
+    }) as ServerFrame);
+    const runningBeforeReply = runningUpdates;
+    const reply = bridge.reply(56, "done");
+    await waitFor(() => workerTerminal, "postReply did not enter its response delay");
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(runningUpdates).toBe(runningBeforeReply);
+    expect(lateRunningUpdates).toBe(0);
+    releaseResponse();
+    await expect(reply).resolves.toEqual({ seq: 56 });
+    expect(bridge.pendingCount).toBe(0);
+    bridge.close();
+  });
+
+  test("an in-flight renewal cannot retry after reply settlement supersedes its epoch", async () => {
+    const fake = fakeConnection();
+    let runningUpdates = 0;
+    let renewalEntered = false;
+    let workerTerminal = false;
+    let releaseRenewal!: () => void;
+    const renewalGate = new Promise<void>((resolve) => {
+      releaseRenewal = resolve;
+    });
+    const bridge = new ClaudeChannelDeliveryBridge({
+      channel: "dev",
+      connection: fake.connection,
+      notify: async () => {},
+      postReply: async () => {
+        workerTerminal = true;
+        return { seq: 57 };
+      },
+      confirmDeliveryUpdate: async (update) => {
+        if (update.state !== "running") return update.state;
+        runningUpdates += 1;
+        if (runningUpdates === 2) {
+          renewalEntered = true;
+          await renewalGate;
+          if (workerTerminal) throw new Error("late renewal rejected by terminal row");
+        }
+        return "running";
+      },
+      leaseRenewIntervalMs: 2,
+      deliveryAckRetryDelayMs: 0,
+      out: () => {},
+    });
+    await bridge.handleFrame(welcomeDirectedFrame(0, "me") as ServerFrame);
+    await bridge.handleFrame(deliveryFrame(57, "renewal race", {
+      id: "delivery-renewal-epoch",
+      target_name: "me",
+    }) as ServerFrame);
+    await waitFor(() => renewalEntered, "lease renewal did not enter its ACK wait");
+    await bridge.reply(57, "settle while renewal is in flight");
+    releaseRenewal();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(runningUpdates).toBe(2);
+    expect(bridge.pendingCount).toBe(0);
+    bridge.close();
+  });
+
+  test("dedicated channel notification stays running until a linked reply is persisted", async () => {
+    const fake = fakeConnection();
+    const notifications: ChannelNotification[] = [];
+    const posts: Parameters<ChannelPostReply>[0][] = [];
+    const bridge = new ClaudeChannelDeliveryBridge({
+      channel: "dev",
+      connection: fake.connection,
+      notify: async (notification) => {
+        notifications.push(notification);
+      },
+      postReply: async (reply) => {
+        posts.push(reply);
+        return { seq: 91 };
+      },
+      confirmDeliveryUpdate: async (update) => {
+        fake.connection.send(update);
+      },
+      leaseRenewIntervalMs: 60_000,
+      out: () => {},
+    });
+
+    await bridge.handleFrame(welcomeDirectedFrame(0, "me") as ServerFrame);
+    await bridge.handleFrame(deliveryFrame(7, "please inspect this", {
+      id: "delivery-7",
+      target_name: "me",
+      sender: { name: "alice", kind: "human" },
+      work_id: "work-7",
+      continuation_ref: "turn-7",
+    }) as ServerFrame);
+
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0]!.meta).toMatchObject({
+      source: "agentparty",
+      channel: "dev",
+      seq: "7",
+      sender: "alice",
+      delivery_id: "delivery-7",
+    });
+    expect(notifications[0]!.content).toContain("party_channel_reply");
+    expect(bridge.pendingCount).toBe(1);
+    expect(fake.sent).toContainEqual({ type: "delivery_adapter", adapter: "watch", op: "register" });
+    expect(fake.sent).toContainEqual(expect.objectContaining({
+      type: "delivery_update",
+      delivery_id: "delivery-7",
+      state: "running",
+      work_id: "work-7",
+      continuation_ref: "turn-7",
+    }));
+
+    await bridge.reply(7, "done");
+    expect(posts).toEqual([{
+      body: "done",
+      mentions: ["alice"],
+      replyTo: 7,
+      idempotencyKey: "claude-channel-reply:delivery-7",
+    }]);
+    expect(bridge.pendingCount).toBe(0);
+    expect(fake.sent).toContainEqual(expect.objectContaining({
+      type: "delivery_update",
+      delivery_id: "delivery-7",
+      state: "replied",
+      work_id: "work-7",
+      continuation_ref: "turn-7",
+      reply_seq: 91,
+    }));
+  });
+
+  test("waiting_owner parks exact lineage, retries a lost ACK without reposting, and restores source context", async () => {
+    const fake = fakeConnection();
+    const notifications: ChannelNotification[] = [];
+    const posts: Parameters<ChannelPostReply>[0][] = [];
+    const updates: Array<Extract<ClientFrame, { type: "delivery_update" }>> = [];
+    let sourceReplyAcks = 0;
+    const bridge = new ClaudeChannelDeliveryBridge({
+      channel: "dev",
+      connection: fake.connection,
+      notify: async (notification) => {
+        notifications.push(notification);
+      },
+      postReply: async (reply) => {
+        posts.push(reply);
+        return { seq: 70 + posts.length };
+      },
+      confirmDeliveryUpdate: async (update) => {
+        updates.push(update);
+        if (update.delivery_id === "delivery-source" && update.state === "replied") {
+          sourceReplyAcks += 1;
+          if (sourceReplyAcks === 1) throw new Error("replied ACK was lost");
+          return "waiting_owner";
+        }
+        return update.state;
+      },
+      leaseRenewIntervalMs: 10,
+      out: () => {},
+    });
+
+    await bridge.handleFrame(welcomeDirectedFrame(0, "me") as ServerFrame);
+    await bridge.handleFrame(deliveryFrame(18, "original source details survive /clear", {
+      id: "delivery-source",
+      target_name: "me",
+      sender: { name: "alice", kind: "human" },
+      work_id: "work-affinity",
+      continuation_ref: "continuation-affinity",
+    }) as ServerFrame);
+
+    await bridge.reply(18, "I need owner approval");
+    expect(sourceReplyAcks).toBe(2);
+    expect(bridge.pendingCount).toBe(0);
+    expect(bridge.parkedContinuationCount).toBe(1);
+    expect(posts).toHaveLength(1);
+    expect(posts[0]!.idempotencyKey).toBe("claude-channel-reply:delivery-source");
+
+    expect(posts).toHaveLength(1);
+    const runningAtPark = updates.filter((update) =>
+      update.delivery_id === "delivery-source" && update.state === "running"
+    ).length;
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    expect(updates.filter((update) =>
+      update.delivery_id === "delivery-source" && update.state === "running"
+    )).toHaveLength(runningAtPark);
+
+    const owner = ownerAnswerFrame({
+      seq: 19,
+      deliveryId: "delivery-owner-answer",
+      sourceDeliveryId: "delivery-source",
+      sourceSeq: 18,
+      questionSeq: 71,
+      workId: "work-affinity",
+      continuationRef: "continuation-affinity",
+    });
+    await bridge.handleFrame(owner);
+    expect(bridge.pendingCount).toBe(1);
+    expect(bridge.parkedContinuationCount).toBe(1);
+    expect(notifications).toHaveLength(2);
+    expect(notifications[1]!.content).toContain("Original source message");
+    expect(notifications[1]!.content).toContain("original source details survive /clear");
+    expect(notifications[1]!.content).toContain("Owner decision for \"May this continue?\": approve");
+    expect(notifications[1]!.meta).toMatchObject({
+      delivery_id: "delivery-owner-answer",
+      delivery_cause: "owner_answer",
+      work_id: "work-affinity",
+      continuation_ref: "continuation-affinity",
+      continuation_source_delivery_id: "delivery-source",
+      continuation_source_seq: "18",
+      continuation_source_sender: "alice",
+    });
+
+    await bridge.reply(19, "continued after approval");
+    expect(bridge.pendingCount).toBe(0);
+    expect(bridge.parkedContinuationCount).toBe(0);
+    expect(posts.map((post) => ({
+      replyTo: post.replyTo,
+      key: post.idempotencyKey,
+    }))).toEqual([
+      { replyTo: 18, key: "claude-channel-reply:delivery-source" },
+      { replyTo: 19, key: "claude-channel-reply:delivery-owner-answer" },
+    ]);
+    bridge.close();
+  });
+
+  test("a fresh bridge restores waiting_owner lineage when the old question was pruned", async () => {
+    const fake = fakeConnection();
+    const notifications: ChannelNotification[] = [];
+    const source = deliveryFrame(60, "durable source survives bridge restart", {
+      id: "delivery-restart-source",
+      target_name: "me",
+      sender: { name: "alice", kind: "human" },
+      work_id: "work-restart",
+      continuation_ref: "continuation-restart",
+    }).message as MsgFrame;
+    const loadedSeqs: number[] = [];
+    const bridge = new ClaudeChannelDeliveryBridge({
+      channel: "dev",
+      connection: fake.connection,
+      notify: async (notification) => {
+        notifications.push(notification);
+      },
+      postReply: async () => ({ seq: 903 }),
+      loadMessage: async (seq) => {
+        loadedSeqs.push(seq);
+        // The decision question can be pruned after a long wait. The Worker's
+        // privileged owner_answer snapshots its prompt and private lineage;
+        // only the still-retained source row is required from public history.
+        return seq === source.seq ? source : null;
+      },
+      confirmDeliveryUpdate: async (update) => update.state,
+      leaseRenewIntervalMs: 60_000,
+      out: () => {},
+    });
+    await bridge.handleFrame(welcomeDirectedFrame(0, "me") as ServerFrame);
+    const owner = ownerAnswerFrame({
+      seq: 62,
+      deliveryId: "delivery-restart-owner",
+      sourceDeliveryId: "delivery-restart-source",
+      sourceSeq: 60,
+      questionSeq: 61,
+      workId: "work-restart",
+      continuationRef: "continuation-restart",
+    });
+    await bridge.handleFrame(owner);
+
+    expect(loadedSeqs).toEqual([60]);
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0]!.content).toContain("durable source survives bridge restart");
+    expect(notifications[0]!.content).toContain("Owner decision for \"May this continue?\": approve");
+    expect(bridge.parkedContinuationCount).toBe(1);
+    await bridge.reply(62, "continued in the restored current session");
+    expect(bridge.parkedContinuationCount).toBe(0);
+    expect(bridge.pendingCount).toBe(0);
+    bridge.close();
+  });
+
+  test("an owner answer reconciles a persisted source POST whose HTTP response is still lost", async () => {
+    const fake = fakeConnection();
+    const notifications: ChannelNotification[] = [];
+    const posts: Parameters<ChannelPostReply>[0][] = [];
+    let sourcePostEntered = false;
+    let releaseSourceResponse!: () => void;
+    const sourceResponseGate = new Promise<void>((resolve) => {
+      releaseSourceResponse = resolve;
+    });
+    const sourceFrame = deliveryFrame(70, "source persisted before its HTTP response", {
+      id: "delivery-source-http-loss",
+      target_name: "me",
+      sender: { name: "alice", kind: "human" },
+      work_id: "work-http-loss",
+      continuation_ref: "continuation-http-loss",
+    }) as Extract<ServerFrame, { type: "delivery" }>;
+    const bridge = new ClaudeChannelDeliveryBridge({
+      channel: "dev",
+      connection: fake.connection,
+      notify: async (notification) => {
+        notifications.push(notification);
+      },
+      postReply: async (reply) => {
+        posts.push(reply);
+        if (reply.replyTo === 70) {
+          sourcePostEntered = true;
+          await sourceResponseGate;
+          throw new Error("HTTP response was lost after Worker persistence");
+        }
+        return { seq: 73 };
+      },
+      loadMessage: async (seq) => seq === 70 ? sourceFrame.message : null,
+      confirmDeliveryUpdate: async (update) => {
+        if (update.delivery_id === "delivery-source-http-loss" && update.state === "replied") {
+          return "waiting_owner";
+        }
+        return update.state;
+      },
+      leaseRenewIntervalMs: 2,
+      deliveryAckRetryDelayMs: 0,
+      out: () => {},
+    });
+    await bridge.handleFrame(welcomeDirectedFrame(0, "me") as ServerFrame);
+    await bridge.handleFrame(sourceFrame);
+    const sourceReply = bridge.reply(70, "ask owner");
+    await waitFor(() => sourcePostEntered, "source post did not reach its response-loss window");
+
+    await bridge.handleFrame(ownerAnswerFrame({
+      seq: 72,
+      deliveryId: "delivery-owner-http-loss",
+      sourceDeliveryId: "delivery-source-http-loss",
+      sourceSeq: 70,
+      questionSeq: 71,
+      workId: "work-http-loss",
+      continuationRef: "continuation-http-loss",
+    }));
+    expect(notifications).toHaveLength(2);
+    expect(notifications[1]!.content).toContain("source persisted before its HTTP response");
+    expect(bridge.parkedContinuationCount).toBe(1);
+
+    releaseSourceResponse();
+    await expect(sourceReply).resolves.toEqual({ seq: 71 });
+    await bridge.reply(72, "continue after authoritative reconciliation");
+    expect(posts.map((post) => post.idempotencyKey)).toEqual([
+      "claude-channel-reply:delivery-source-http-loss",
+      "claude-channel-reply:delivery-owner-http-loss",
+    ]);
+    expect(bridge.pendingCount).toBe(0);
+    expect(bridge.parkedContinuationCount).toBe(0);
+    bridge.close();
+  });
+
+  test("an early owner answer cannot be rejected or resurrected by a late source ACK", async () => {
+    const fake = fakeConnection();
+    const notifications: ChannelNotification[] = [];
+    const posts: Parameters<ChannelPostReply>[0][] = [];
+    let sourceAckRequested = false;
+    let releaseSourceAck: (() => void) | null = null;
+    const sourceAck = new Promise<"waiting_owner">((resolve) => {
+      releaseSourceAck = () => resolve("waiting_owner");
+    });
+    const bridge = new ClaudeChannelDeliveryBridge({
+      channel: "dev",
+      connection: fake.connection,
+      notify: async (notification) => {
+        notifications.push(notification);
+      },
+      postReply: async (reply) => {
+        posts.push(reply);
+        return { seq: 120 + posts.length };
+      },
+      confirmDeliveryUpdate: async (update) => {
+        if (update.delivery_id === "delivery-source-race" && update.state === "replied") {
+          sourceAckRequested = true;
+          return await sourceAck;
+        }
+        return update.state;
+      },
+      leaseRenewIntervalMs: 60_000,
+      out: () => {},
+    });
+    await bridge.handleFrame(welcomeDirectedFrame(0, "me") as ServerFrame);
+    await bridge.handleFrame(deliveryFrame(30, "source whose ACK arrives late", {
+      id: "delivery-source-race",
+      target_name: "me",
+      sender: { name: "alice", kind: "human" },
+      work_id: "work-race",
+      continuation_ref: "continuation-race",
+    }) as ServerFrame);
+
+    const sourceReply = bridge.reply(30, "ask the owner");
+    await waitFor(() => sourceAckRequested, "source reply did not reach its ACK wait");
+    const owner = ownerAnswerFrame({
+      seq: 31,
+      deliveryId: "delivery-owner-race",
+      sourceDeliveryId: "delivery-source-race",
+      sourceSeq: 30,
+      questionSeq: 121,
+      workId: "work-race",
+      continuationRef: "continuation-race",
+    });
+    await bridge.handleFrame(owner);
+    expect(notifications[1]!.content).toContain("source whose ACK arrives late");
+
+    await bridge.reply(31, "continued before the source ACK returned");
+    expect(bridge.parkedContinuationCount).toBe(0);
+    releaseSourceAck!();
+    await sourceReply;
+    expect(bridge.pendingCount).toBe(0);
+    expect(bridge.parkedContinuationCount).toBe(0);
+    expect(posts.map((post) => post.idempotencyKey)).toEqual([
+      "claude-channel-reply:delivery-source-race",
+      "claude-channel-reply:delivery-owner-race",
+    ]);
+    bridge.close();
+  });
+
+  test("owner_answer is never injected unless every parked lineage field matches", async () => {
+    const fake = fakeConnection();
+    const notifications: ChannelNotification[] = [];
+    const bridge = new ClaudeChannelDeliveryBridge({
+      channel: "dev",
+      connection: fake.connection,
+      notify: async (notification) => {
+        notifications.push(notification);
+      },
+      postReply: async () => ({ seq: 81 }),
+      confirmDeliveryUpdate: async (update) => {
+        if (update.delivery_id === "delivery-source-strict" && update.state === "replied") {
+          return "waiting_owner";
+        }
+        return update.state;
+      },
+      leaseRenewIntervalMs: 60_000,
+      out: () => {},
+    });
+    await bridge.handleFrame(welcomeDirectedFrame(0, "me") as ServerFrame);
+    await bridge.handleFrame(deliveryFrame(20, "strict source", {
+      id: "delivery-source-strict",
+      target_name: "me",
+      work_id: "work-strict",
+      continuation_ref: "continuation-strict",
+    }) as ServerFrame);
+    await bridge.reply(20, "owner question");
+    expect(bridge.parkedContinuationCount).toBe(1);
+
+    const crossed = ownerAnswerFrame({
+      seq: 21,
+      deliveryId: "delivery-crossed-answer",
+      sourceDeliveryId: "wrong-source-delivery",
+      sourceSeq: 20,
+      questionSeq: 81,
+      workId: "work-strict",
+      continuationRef: "continuation-strict",
+    });
+    await bridge.handleFrame(crossed);
+    expect(notifications).toHaveLength(1);
+    expect(fake.sent).toContainEqual(expect.objectContaining({
+      type: "delivery_adapter",
+      adapter: "watch",
+      op: "register",
+    }));
+    expect(bridge.pendingCount).toBe(0);
+    expect(bridge.parkedContinuationCount).toBe(1);
+    await expect(bridge.reply(21, "must not run")).rejects.toThrow("no pending");
+    bridge.close();
+  });
+
+  test("owner_answer notification uncertainty keeps parked lineage for an exact late reply", async () => {
+    const fake = fakeConnection();
+    let notifications = 0;
+    let ownerFailureAcks = 0;
+    const bridge = new ClaudeChannelDeliveryBridge({
+      channel: "dev",
+      connection: fake.connection,
+      notify: async () => {
+        notifications += 1;
+        if (notifications === 2) throw new Error("Claude cleared the channel");
+      },
+      postReply: async () => ({ seq: 91 }),
+      confirmDeliveryUpdate: async (update) => {
+        if (update.delivery_id === "delivery-source-failure" && update.state === "replied") {
+          return "waiting_owner";
+        }
+        if (update.delivery_id === "delivery-owner-failure" && update.state === "failed") {
+          ownerFailureAcks += 1;
+          if (ownerFailureAcks === 1) throw new Error("failed ACK was lost");
+        }
+        return update.state;
+      },
+      leaseRenewIntervalMs: 60_000,
+      out: () => {},
+    });
+    await bridge.handleFrame(welcomeDirectedFrame(0, "me") as ServerFrame);
+    await bridge.handleFrame(deliveryFrame(22, "source awaiting owner", {
+      id: "delivery-source-failure",
+      target_name: "me",
+      work_id: "work-owner-failure",
+      continuation_ref: "continuation-owner-failure",
+    }) as ServerFrame);
+    await bridge.reply(22, "owner question");
+    expect(bridge.parkedContinuationCount).toBe(1);
+
+    const owner = ownerAnswerFrame({
+      seq: 23,
+      deliveryId: "delivery-owner-failure",
+      sourceDeliveryId: "delivery-source-failure",
+      sourceSeq: 22,
+      questionSeq: 91,
+      workId: "work-owner-failure",
+      continuationRef: "continuation-owner-failure",
+    });
+    await bridge.handleFrame(owner);
+    expect(ownerFailureAcks).toBe(0);
+    expect(notifications).toBe(2);
+    expect(bridge.pendingCount).toBe(1);
+    expect(bridge.parkedContinuationCount).toBe(1);
+    await expect(bridge.reply(23, "late owner continuation success")).resolves.toEqual({ seq: 91 });
+    expect(bridge.pendingCount).toBe(0);
+    expect(bridge.parkedContinuationCount).toBe(0);
+    bridge.close();
+  });
+
+  test("claim and accept are WAL-first, receipt-stable, and idempotent across lost MCP responses", async () => {
+    const root = mkdtempSync(join(tmpdir(), "ap-claude-claim-gate-"));
+    const path = join(root, "journal.json");
+    try {
+      let failNextCommit = false;
+      const journal = new DeliveryRecoveryJournal(path, "dev", "claude", {
+        persist(commit) {
+          if (failNextCommit) {
+            failNextCommit = false;
+            throw Object.assign(new Error("claim WAL is full"), { code: "ENOSPC" });
+          }
+          commit();
+        },
+      });
+      const fake = fakeConnection();
+      const notifications: ChannelNotification[] = [];
+      let failedUpdates = 0;
+      const bridge = new ClaudeChannelDeliveryBridge({
+        channel: "dev",
+        connection: fake.connection,
+        recoveryJournal: journal,
+        requireHarnessClaim: true,
+        harnessClaimRetryDelayMs: 1,
+        harnessClaimMaxNotifications: 3,
+        leaseRenewIntervalMs: 60_000,
+        notify: async (notification) => {
+          notifications.push(notification);
+          if (notifications.length === 1) throw new Error("transient channel write failure");
+        },
+        postReply: async () => ({ seq: 1 }),
+        confirmDeliveryUpdate: async (update) => {
+          fake.connection.send(update);
+          if (update.state === "failed") failedUpdates += 1;
+          return update.state;
+        },
+        out: () => {},
+      });
+      await bridge.handleFrame(welcomeDirectedFrame(0, "me") as ServerFrame);
+      await bridge.handleFrame(deliveryFrame(8, "secret body exactly once", {
+        id: "delivery-claim-gate",
+        target_name: "me",
+      }) as ServerFrame);
+      await waitFor(
+        () => notifications.length >= 2,
+        "claim-only notification did not retry its transient transport failure",
+      );
+
+      expect(failedUpdates).toBe(0);
+      expect(bridge.pendingCount).toBe(1);
+      expect(notifications.every((notification) =>
+        !notification.content.includes("secret body exactly once")
+      )).toBe(true);
+      expect(journal.get("delivery-claim-gate")).toMatchObject({ phase: "harness_issued" });
+
+      failNextCommit = true;
+      let claimWalError: Error | null = null;
+      try {
+        bridge.claim("delivery-claim-gate");
+      } catch (error) {
+        claimWalError = error instanceof Error ? error : new Error(String(error));
+      }
+      expect(claimWalError?.message).toContain("claim WAL is full");
+      expect(claimWalError?.message).not.toContain("secret body exactly once");
+      expect(journal.get("delivery-claim-gate")).toMatchObject({
+        phase: "harness_issued",
+        claimReceipt: null,
+      });
+
+      // Treat the first successful return as if the MCP response were lost:
+      // an equivalent retry must expose the exact same invocation identity
+      // and body until that receipt is durably accepted.
+      const firstClaim = bridge.claim("delivery-claim-gate");
+      const firstReceipt = firstClaim.receipt;
+      expect(firstClaim.claimed).toBe(true);
+      expect(typeof firstReceipt).toBe("string");
+      expect(firstClaim.content).toContain("secret body exactly once");
+      const retriedClaim = bridge.claim("delivery-claim-gate");
+      expect(retriedClaim).toEqual(firstClaim);
+      expect(journal.get("delivery-claim-gate")).toMatchObject({
+        phase: "harness_issued",
+        claimReceipt: firstReceipt,
+      });
+      await expect(bridge.reply(8, "must wait for durable acceptance")).rejects.toThrow(
+        "accepted",
+      );
+      expect(bridge.claim("delivery-claim-gate")).toEqual(firstClaim);
+      expect(() =>
+        bridge.accept("delivery-claim-gate", "receipt-from-an-old-generation")
+      ).toThrow("invalid or belongs to an old ownership generation");
+      expect(bridge.claim("delivery-claim-gate")).toEqual(firstClaim);
+
+      // Likewise, ignore the first accept result to model an ACK lost after
+      // its WAL commit. Repeating the exact receipt succeeds idempotently and
+      // never releases another copy of the body.
+      const accepted = bridge.accept("delivery-claim-gate", firstReceipt!);
+      expect(accepted).toMatchObject({ accepted: true });
+      expect(journal.get("delivery-claim-gate")).toMatchObject({
+        phase: "harness_accepted",
+        claimReceipt: firstReceipt,
+      });
+      expect(bridge.accept("delivery-claim-gate", firstReceipt!)).toMatchObject({
+        accepted: false,
+        content: expect.stringContaining("already durably accepted"),
+      });
+      expect(bridge.claim("delivery-claim-gate")).toMatchObject({
+        claimed: false,
+        receipt: firstReceipt,
+        content: expect.not.stringContaining("secret body exactly once"),
+      });
+      await expect(bridge.reply(8, "accepted linked response")).resolves.toEqual({ seq: 1 });
+      expect(journal.get("delivery-claim-gate")).toBeNull();
+      bridge.close();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("A-to-B-to-C ownership recovery keeps claim and accept closed until the newest CAS completes", async () => {
+    const root = mkdtempSync(join(tmpdir(), "ap-claude-recovery-gate-"));
+    try {
+      const journal = new DeliveryRecoveryJournal(
+        join(root, "journal.json"),
+        "dev",
+        "claude",
+      );
+      const stream = streamingConnection();
+      const notifications: ChannelNotification[] = [];
+      const bridge = new ClaudeChannelDeliveryBridge({
+        channel: "dev",
+        connection: stream.connection,
+        recoveryJournal: journal,
+        requireHarnessClaim: true,
+        harnessClaimRetryDelayMs: 60_000,
+        notify: async (notification) => {
+          notifications.push(notification);
+        },
+        postReply: async () => ({ seq: 1 }),
+        confirmDeliveryUpdate: async (update) => update.state,
+        leaseRenewIntervalMs: 60_000,
+        deliveryAckTimeoutMs: 1_000,
+        out: () => {},
+      });
+      const incoming = deliveryFrame(58, "one logical invocation across A B C", {
+        id: "delivery-recovery-gate",
+        target_name: "me",
+      }) as Extract<ServerFrame, { type: "delivery" }>;
+
+      await bridge.handleFrame(welcomeDirectedFrame(0, "me") as ServerFrame);
+      await bridge.handleFrame(incoming);
+      expect(notifications).toHaveLength(1);
+      const claimOnA = bridge.claim(incoming.delivery.id);
+      const receiptOnA = claimOnA.receipt;
+      expect(claimOnA.claimed).toBe(true);
+      expect(typeof receiptOnA).toBe("string");
+      expect(claimOnA.content).toContain("one logical invocation across A B C");
+
+      await bridge.handleFrame(welcomeDirectedFrame(58, "me") as ServerFrame);
+      await waitFor(
+        () => stream.sent.filter((frame) => frame.type === "delivery_recover").length === 1,
+        "B did not begin ownership recovery",
+      );
+      const recoveryB = stream.sent.find((frame) =>
+        frame.type === "delivery_recover"
+      ) as Extract<ClientFrame, { type: "delivery_recover" }>;
+      expect(() => bridge.claim(incoming.delivery.id)).toThrow("recovering ownership");
+      expect(() => bridge.accept(incoming.delivery.id, receiptOnA!)).toThrow(
+        "recovering ownership",
+      );
+
+      await bridge.handleFrame(welcomeDirectedFrame(58, "me") as ServerFrame);
+      await waitFor(
+        () => stream.sent.filter((frame) => frame.type === "delivery_recover").length === 2,
+        "C did not replace B's ownership recovery",
+      );
+      const recoveryC = stream.sent.filter((frame) =>
+        frame.type === "delivery_recover"
+      )[1] as Extract<ClientFrame, { type: "delivery_recover" }>;
+      expect(recoveryC.request_id).not.toBe(recoveryB.request_id);
+
+      // B's delayed result is no longer correlated. In particular, B's
+      // finally block must not delete C's object-identity claim gate.
+      await bridge.handleFrame({
+        type: "delivery_recovery",
+        delivery_id: recoveryB.delivery_id,
+        request_id: recoveryB.request_id,
+        result: "recovered",
+        state: "running",
+        attempt: recoveryB.attempt,
+        lease_epoch: recoveryB.lease_epoch,
+        lease_token: recoveryB.next_lease_token,
+        lease_until: Date.now() + 90_000,
+      });
+      expect(() => bridge.claim(incoming.delivery.id)).toThrow("recovering ownership");
+      expect(() => bridge.accept(incoming.delivery.id, receiptOnA!)).toThrow(
+        "recovering ownership",
+      );
+
+      await bridge.handleFrame({
+        type: "delivery_recovery",
+        delivery_id: recoveryC.delivery_id,
+        request_id: recoveryC.request_id,
+        result: "recovered",
+        state: "running",
+        attempt: recoveryC.attempt,
+        lease_epoch: recoveryC.lease_epoch,
+        lease_token: recoveryC.next_lease_token,
+        lease_until: Date.now() + 90_000,
+      });
+      await waitFor(
+        () =>
+          journal.get(incoming.delivery.id)?.delivery.lease_token ===
+            recoveryC.next_lease_token &&
+          notifications.length === 2,
+        "C did not finish recovery and restore the claim-only notification",
+      );
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      const claimOnC = bridge.claim(incoming.delivery.id);
+      expect(claimOnC).toEqual(claimOnA);
+      expect(bridge.accept(incoming.delivery.id, claimOnC.receipt!)).toMatchObject({
+        accepted: true,
+      });
+      expect(journal.get(incoming.delivery.id)).toMatchObject({
+        phase: "harness_accepted",
+        claimReceipt: receiptOnA,
+        delivery: { lease_token: recoveryC.next_lease_token },
+      });
+      bridge.close();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("one journal snapshot gates every claim before its first recovery await", async () => {
+    const root = mkdtempSync(join(tmpdir(), "ap-claude-multi-recovery-gate-"));
+    try {
+      const journal = new DeliveryRecoveryJournal(
+        join(root, "journal.json"),
+        "dev",
+        "claude",
+      );
+      const stream = streamingConnection();
+      const notifications: ChannelNotification[] = [];
+      const bridge = new ClaudeChannelDeliveryBridge({
+        channel: "dev",
+        connection: stream.connection,
+        recoveryJournal: journal,
+        requireHarnessClaim: true,
+        harnessClaimRetryDelayMs: 60_000,
+        notify: async (notification) => {
+          notifications.push(notification);
+        },
+        postReply: async () => ({ seq: 1 }),
+        confirmDeliveryUpdate: async (update) => update.state,
+        leaseRenewIntervalMs: 60_000,
+        deliveryAckTimeoutMs: 1_000,
+        out: () => {},
+      });
+      const first = deliveryFrame(60, "first recovery blocks on its CAS", {
+        id: "delivery-multi-recovery-first",
+        target_name: "me",
+      }) as Extract<ServerFrame, { type: "delivery" }>;
+      const second = deliveryFrame(61, "second body must already be gated", {
+        id: "delivery-multi-recovery-second",
+        target_name: "me",
+      }) as Extract<ServerFrame, { type: "delivery" }>;
+
+      await bridge.handleFrame(welcomeDirectedFrame(0, "me") as ServerFrame);
+      await bridge.handleFrame(first);
+      await bridge.handleFrame(second);
+      const firstClaim = bridge.claim(first.delivery.id);
+      const secondClaim = bridge.claim(second.delivery.id);
+      expect(notifications).toHaveLength(2);
+
+      await bridge.handleFrame(welcomeDirectedFrame(61, "me") as ServerFrame);
+      await waitFor(
+        () => stream.sent.filter((frame) => frame.type === "delivery_recover").length === 1,
+        "first journal entry did not begin ownership recovery",
+      );
+      const firstRecovery = stream.sent.find((frame) =>
+        frame.type === "delivery_recover"
+      ) as Extract<ClientFrame, { type: "delivery_recover" }>;
+      expect(firstRecovery.delivery_id).toBe(first.delivery.id);
+
+      // The recovery loop has not reached the second entry yet. Its gate must
+      // nevertheless have been installed synchronously from the same snapshot.
+      expect(() => bridge.claim(second.delivery.id)).toThrow("recovering ownership");
+      expect(() =>
+        bridge.accept(second.delivery.id, secondClaim.receipt!)
+      ).toThrow("recovering ownership");
+
+      await bridge.handleFrame({
+        type: "delivery_recovery",
+        delivery_id: firstRecovery.delivery_id,
+        request_id: firstRecovery.request_id,
+        result: "recovered",
+        state: "running",
+        attempt: firstRecovery.attempt,
+        lease_epoch: firstRecovery.lease_epoch,
+        lease_token: firstRecovery.next_lease_token,
+        lease_until: Date.now() + 90_000,
+      });
+      await waitFor(
+        () => stream.sent.filter((frame) => frame.type === "delivery_recover").length === 2,
+        "second journal entry did not begin ownership recovery",
+      );
+      const secondRecovery = stream.sent.filter((frame) =>
+        frame.type === "delivery_recover"
+      )[1] as Extract<ClientFrame, { type: "delivery_recover" }>;
+      expect(secondRecovery.delivery_id).toBe(second.delivery.id);
+      expect(() => bridge.claim(second.delivery.id)).toThrow("recovering ownership");
+      expect(() =>
+        bridge.accept(second.delivery.id, secondClaim.receipt!)
+      ).toThrow("recovering ownership");
+
+      await bridge.handleFrame({
+        type: "delivery_recovery",
+        delivery_id: secondRecovery.delivery_id,
+        request_id: secondRecovery.request_id,
+        result: "recovered",
+        state: "running",
+        attempt: secondRecovery.attempt,
+        lease_epoch: secondRecovery.lease_epoch,
+        lease_token: secondRecovery.next_lease_token,
+        lease_until: Date.now() + 90_000,
+      });
+      await waitFor(
+        () =>
+          notifications.length === 4 &&
+          journal.get(second.delivery.id)?.delivery.lease_token ===
+            secondRecovery.next_lease_token,
+        "second journal entry did not finish its own reconciliation",
+      );
+
+      expect(bridge.claim(first.delivery.id)).toEqual(firstClaim);
+      expect(bridge.claim(second.delivery.id)).toEqual(secondClaim);
+      expect(bridge.accept(second.delivery.id, secondClaim.receipt!)).toMatchObject({
+        accepted: true,
+      });
+      bridge.close();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("reconnect resets an exhausted claim-notification budget and retries on the new ownership", async () => {
+    const root = mkdtempSync(join(tmpdir(), "ap-claude-reconnect-notify-budget-"));
+    try {
+      const journal = new DeliveryRecoveryJournal(
+        join(root, "journal.json"),
+        "dev",
+        "claude",
+      );
+      const stream = streamingConnection();
+      const notifications: ChannelNotification[] = [];
+      let reconnecting = false;
+      let reconnectNotifications = 0;
+      const bridge = new ClaudeChannelDeliveryBridge({
+        channel: "dev",
+        connection: stream.connection,
+        recoveryJournal: journal,
+        requireHarnessClaim: true,
+        harnessClaimRetryDelayMs: 20,
+        harnessClaimMaxNotifications: 2,
+        notify: async (notification) => {
+          notifications.push(notification);
+          if (!reconnecting) return;
+          reconnectNotifications += 1;
+          if (reconnectNotifications === 1) {
+            throw new Error("first notification on replacement connection failed");
+          }
+        },
+        postReply: async () => ({ seq: 1 }),
+        confirmDeliveryUpdate: async (update) => update.state,
+        leaseRenewIntervalMs: 60_000,
+        deliveryAckTimeoutMs: 1_000,
+        out: () => {},
+      });
+      const incoming = deliveryFrame(62, "retry this receipt after reconnect", {
+        id: "delivery-reconnect-notify-budget",
+        target_name: "me",
+      }) as Extract<ServerFrame, { type: "delivery" }>;
+
+      await bridge.handleFrame(welcomeDirectedFrame(0, "me") as ServerFrame);
+      await bridge.handleFrame(incoming);
+      const originalClaim = bridge.claim(incoming.delivery.id);
+      await waitFor(
+        () => notifications.length === 2,
+        "initial ownership did not consume its bounded notification attempts",
+      );
+
+      // At this point the counter is at its maximum and the old generation
+      // still owns a scheduled timer. Reconnect must cancel that timer and
+      // grant the recovered bearer a fresh budget.
+      reconnecting = true;
+      await bridge.handleFrame(welcomeDirectedFrame(62, "me") as ServerFrame);
+      await waitFor(
+        () => stream.sent.some((frame) => frame.type === "delivery_recover"),
+        "replacement connection did not begin ownership recovery",
+      );
+      const recovery = stream.sent.find((frame) =>
+        frame.type === "delivery_recover"
+      ) as Extract<ClientFrame, { type: "delivery_recover" }>;
+      await bridge.handleFrame({
+        type: "delivery_recovery",
+        delivery_id: recovery.delivery_id,
+        request_id: recovery.request_id,
+        result: "recovered",
+        state: "running",
+        attempt: recovery.attempt,
+        lease_epoch: recovery.lease_epoch,
+        lease_token: recovery.next_lease_token,
+        lease_until: Date.now() + 90_000,
+      });
+      await waitFor(
+        () => reconnectNotifications === 2,
+        "replacement ownership did not retry its first failed notification",
+      );
+
+      expect(notifications.every((notification) =>
+        !notification.content.includes("retry this receipt after reconnect")
+      )).toBe(true);
+      expect(bridge.claim(incoming.delivery.id)).toEqual(originalClaim);
+      expect(bridge.accept(incoming.delivery.id, originalClaim.receipt!)).toMatchObject({
+        accepted: true,
+      });
+      bridge.close();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("authoritative recovery retries on the same connection and keeps the receipt gated until success", async () => {
+    const root = mkdtempSync(join(tmpdir(), "ap-claude-recovery-failure-gate-"));
+    try {
+      const journal = new DeliveryRecoveryJournal(
+        join(root, "journal.json"),
+        "dev",
+        "claude",
+      );
+      const stream = streamingConnection();
+      const logs: string[] = [];
+      const bridge = new ClaudeChannelDeliveryBridge({
+        channel: "dev",
+        connection: stream.connection,
+        recoveryJournal: journal,
+        requireHarnessClaim: true,
+        harnessClaimRetryDelayMs: 60_000,
+        notify: async () => {},
+        postReply: async () => ({ seq: 1 }),
+        confirmDeliveryUpdate: async (update) => update.state,
+        leaseRenewIntervalMs: 60_000,
+        deliveryAckTimeoutMs: 50,
+        deliveryRecoveryRetryDelayMs: 50,
+        out: (line) => logs.push(line),
+      });
+      const incoming = deliveryFrame(59, "withhold until recovery is authoritative", {
+        id: "delivery-recovery-failure-gate",
+        target_name: "me",
+      }) as Extract<ServerFrame, { type: "delivery" }>;
+
+      await bridge.handleFrame(welcomeDirectedFrame(0, "me") as ServerFrame);
+      await bridge.handleFrame(incoming);
+      const originalClaim = bridge.claim(incoming.delivery.id);
+      const originalReceipt = originalClaim.receipt;
+      expect(typeof originalReceipt).toBe("string");
+
+      // Neither of the two bounded recovery attempts receives an authoritative
+      // result. That is uncertainty, not evidence that the old bearer or the
+      // harness invocation is safe to use.
+      await bridge.handleFrame(welcomeDirectedFrame(59, "me") as ServerFrame);
+      await waitFor(
+        () => stream.sent.filter((frame) => frame.type === "delivery_recover").length >= 2,
+        "recovery did not reach its second immediate attempt",
+      );
+      expect(() => bridge.claim(incoming.delivery.id)).toThrow("recovering ownership");
+      expect(() => bridge.accept(incoming.delivery.id, originalReceipt!)).toThrow(
+        "recovering ownership",
+      );
+      expect(journal.get(incoming.delivery.id)).toMatchObject({
+        phase: "harness_issued",
+        claimReceipt: originalReceipt,
+      });
+
+      // The bridge must keep reconciling on this healthy websocket rather than
+      // waiting forever for another welcome frame. A CAS from the next
+      // recovery pass receives the authoritative result and is the only event
+      // that re-opens the gate.
+      await waitFor(
+        () =>
+          logs.some((line) => line.includes("could not recover delivery")) &&
+          stream.sent.filter((frame) => frame.type === "delivery_recover").length >= 3,
+        "recovery did not retry on the same connection",
+      );
+      const recoveries = stream.sent.filter((frame) =>
+        frame.type === "delivery_recover"
+      ) as Array<Extract<ClientFrame, { type: "delivery_recover" }>>;
+      expect(new Set(recoveries.map((frame) => frame.request_id)).size).toBeGreaterThanOrEqual(3);
+      const retryRecovery = recoveries.at(-1)!;
+      expect(() => bridge.claim(incoming.delivery.id)).toThrow("recovering ownership");
+      await bridge.handleFrame({
+        type: "delivery_recovery",
+        delivery_id: retryRecovery.delivery_id,
+        request_id: retryRecovery.request_id,
+        result: "recovered",
+        state: "running",
+        attempt: retryRecovery.attempt,
+        lease_epoch: retryRecovery.lease_epoch,
+        lease_token: retryRecovery.next_lease_token,
+        lease_until: Date.now() + 90_000,
+      });
+      await waitFor(
+        () =>
+          journal.get(incoming.delivery.id)?.delivery.lease_token ===
+          retryRecovery.next_lease_token,
+        "same-connection retry result did not become authoritative",
+      );
+      expect(bridge.claim(incoming.delivery.id)).toEqual(originalClaim);
+      expect(bridge.accept(incoming.delivery.id, originalReceipt!)).toMatchObject({
+        accepted: true,
+      });
+      bridge.close();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("an early owner answer claim retains exact source context while the source replied ACK is pending", async () => {
+    const root = mkdtempSync(join(tmpdir(), "ap-claude-owner-claim-race-"));
+    try {
+      const journal = new DeliveryRecoveryJournal(
+        join(root, "journal.json"),
+        "dev",
+        "claude",
+      );
+      const fake = fakeConnection();
+      const notifications: ChannelNotification[] = [];
+      const posts: Parameters<ChannelPostReply>[0][] = [];
+      let sourceAckRequested = false;
+      let releaseSourceAck!: () => void;
+      const sourceAck = new Promise<"waiting_owner">((resolve) => {
+        releaseSourceAck = () => resolve("waiting_owner");
+      });
+      const bridge = new ClaudeChannelDeliveryBridge({
+        channel: "dev",
+        connection: fake.connection,
+        recoveryJournal: journal,
+        requireHarnessClaim: true,
+        harnessClaimRetryDelayMs: 60_000,
+        notify: async (notification) => {
+          notifications.push(notification);
+        },
+        postReply: async (reply) => {
+          posts.push(reply);
+          return { seq: reply.replyTo === 30 ? 121 : 122 };
+        },
+        confirmDeliveryUpdate: async (update) => {
+          if (update.delivery_id === "delivery-source-claim-race" && update.state === "replied") {
+            sourceAckRequested = true;
+            return await sourceAck;
+          }
+          return update.state;
+        },
+        leaseRenewIntervalMs: 60_000,
+        out: () => {},
+      });
+      const source = deliveryFrame(30, "private source survives the early owner race", {
+        id: "delivery-source-claim-race",
+        target_name: "me",
+        sender: { name: "alice", kind: "human" },
+        work_id: "work-claim-race",
+        continuation_ref: "continuation-claim-race",
+      }) as Extract<ServerFrame, { type: "delivery" }>;
+
+      await bridge.handleFrame(welcomeDirectedFrame(0, "me") as ServerFrame);
+      await bridge.handleFrame(source);
+      const sourceClaim = bridge.claim(source.delivery.id);
+      bridge.accept(source.delivery.id, sourceClaim.receipt!);
+      const sourceReply = bridge.reply(30, "ask the owner");
+      await waitFor(() => sourceAckRequested, "source reply did not enter its ACK window");
+
+      const owner = ownerAnswerFrame({
+        seq: 31,
+        deliveryId: "delivery-owner-claim-race",
+        sourceDeliveryId: "delivery-source-claim-race",
+        sourceSeq: 30,
+        questionSeq: 121,
+        workId: "work-claim-race",
+        continuationRef: "continuation-claim-race",
+      });
+      await bridge.handleFrame(owner);
+      expect(notifications).toHaveLength(2);
+      const ownerClaim = bridge.claim(owner.delivery.id);
+      expect(ownerClaim.content).toContain("private source survives the early owner race");
+      expect(ownerClaim.content).toContain('Owner decision for "May this continue?": approve');
+      expect(ownerClaim.content).toContain("owner approved");
+      bridge.accept(owner.delivery.id, ownerClaim.receipt!);
+      await expect(bridge.reply(31, "continued exactly once")).resolves.toEqual({ seq: 122 });
+      expect(bridge.pendingCount).toBe(1);
+      expect(bridge.parkedContinuationCount).toBe(0);
+
+      releaseSourceAck();
+      await expect(sourceReply).resolves.toEqual({ seq: 121 });
+      expect(bridge.pendingCount).toBe(0);
+      expect(bridge.parkedContinuationCount).toBe(0);
+      expect(posts.map((post) => post.idempotencyKey)).toEqual([
+        "claude-channel-reply:delivery-source-claim-race",
+        "claude-channel-reply:delivery-owner-claim-race",
+      ]);
+      bridge.close();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("a hung claim-only transport attempt times out and retries without releasing the body", async () => {
+    const root = mkdtempSync(join(tmpdir(), "ap-claude-claim-timeout-"));
+    try {
+      const journal = new DeliveryRecoveryJournal(
+        join(root, "journal.json"),
+        "dev",
+        "claude",
+      );
+      const fake = fakeConnection();
+      const notifications: ChannelNotification[] = [];
+      let failedUpdates = 0;
+      const bridge = new ClaudeChannelDeliveryBridge({
+        channel: "dev",
+        connection: fake.connection,
+        recoveryJournal: journal,
+        requireHarnessClaim: true,
+        harnessClaimNotifyTimeoutMs: 5,
+        harnessClaimRetryDelayMs: 1,
+        harnessClaimMaxNotifications: 3,
+        leaseRenewIntervalMs: 60_000,
+        notify: async (notification) => {
+          notifications.push(notification);
+          if (notifications.length === 1) await new Promise<never>(() => {});
+        },
+        postReply: async () => ({ seq: 1 }),
+        confirmDeliveryUpdate: async (update) => {
+          if (update.state === "failed") failedUpdates += 1;
+          return update.state;
+        },
+        out: () => {},
+      });
+      await bridge.handleFrame(welcomeDirectedFrame(0, "me") as ServerFrame);
+      await bridge.handleFrame(deliveryFrame(9, "body remains behind claim", {
+        id: "delivery-hung-claim-notify",
+        target_name: "me",
+      }) as ServerFrame);
+      await waitFor(
+        () => notifications.length >= 2,
+        "hung claim notification did not yield to a bounded retry",
+      );
+      expect(notifications.every((notification) =>
+        !notification.content.includes("body remains behind claim")
+      )).toBe(true);
+      expect(failedUpdates).toBe(0);
+      expect(bridge.pendingCount).toBe(1);
+      expect(journal.get("delivery-hung-claim-notify")).toMatchObject({
+        phase: "harness_issued",
+      });
+      bridge.close();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("a full-body notification error remains late-reply debt instead of ordinary failed", async () => {
+    const fake = fakeConnection();
+    let notifications = 0;
+    let failedUpdates = 0;
+    const bridge = new ClaudeChannelDeliveryBridge({
+      channel: "dev",
+      connection: fake.connection,
+      notify: async () => {
+        notifications += 1;
+        throw new Error("response lost after Channel transport write");
+      },
+      postReply: async () => ({ seq: 108 }),
+      confirmDeliveryUpdate: async (update) => {
+        fake.connection.send(update);
+        if (update.state === "failed") failedUpdates += 1;
+        return update.state;
+      },
+      recoveryUncertaintyTimeoutMs: 5,
+      leaseRenewIntervalMs: 60_000,
+      out: () => {},
+    });
+    await bridge.handleFrame(welcomeDirectedFrame(0, "me") as ServerFrame);
+    await bridge.handleFrame(deliveryFrame(8, "may already be in Claude", {
+      id: "delivery-after-write-unknown",
+      target_name: "me",
+    }) as ServerFrame);
+    await new Promise((resolve) => setTimeout(resolve, 15));
+
+    expect(notifications).toBe(1);
+    expect(failedUpdates).toBe(0);
+    expect(bridge.pendingCount).toBe(1);
+    await expect(bridge.reply(8, "late success")).resolves.toEqual({ seq: 108 });
+    expect(bridge.pendingCount).toBe(0);
+    bridge.close();
+  });
+
+  test("restart never replays an uncertain full-body notification and still accepts its late reply", async () => {
+    const root = mkdtempSync(join(tmpdir(), "ap-claude-after-write-"));
+    const path = join(root, "journal.json");
+    try {
+      const incoming = deliveryFrame(80, "do not replay this body", {
+        id: "delivery-after-write-restart",
+        target_name: "me",
+      }) as Extract<ServerFrame, { type: "delivery" }>;
+      const firstJournal = new DeliveryRecoveryJournal(path, "dev", "claude");
+      const first = new ClaudeChannelDeliveryBridge({
+        channel: "dev",
+        connection: fakeConnection().connection,
+        recoveryJournal: firstJournal,
+        notify: async () => {
+          throw new Error("stdio disconnected after notification write");
+        },
+        postReply: async () => ({ seq: 1 }),
+        confirmDeliveryUpdate: async (update) => update.state,
+        leaseRenewIntervalMs: 60_000,
+        recoveryUncertaintyTimeoutMs: 5,
+        out: () => {},
+      });
+      await first.handleFrame(welcomeDirectedFrame(0, "me") as ServerFrame);
+      await first.handleFrame(incoming);
+      expect(firstJournal.get(incoming.delivery.id)).toMatchObject({ phase: "harness_issued" });
+      first.close();
+
+      const stream = streamingConnection();
+      const restartedJournal = new DeliveryRecoveryJournal(path, "dev", "claude");
+      let replayedNotifications = 0;
+      let failedUpdates = 0;
+      const restarted = new ClaudeChannelDeliveryBridge({
+        channel: "dev",
+        connection: stream.connection,
+        recoveryJournal: restartedJournal,
+        notify: async () => {
+          replayedNotifications += 1;
+        },
+        postReply: async () => ({ seq: 180 }),
+        confirmDeliveryUpdate: async (update) => {
+          if (update.state === "failed") failedUpdates += 1;
+          return update.state;
+        },
+        recoveryUncertaintyTimeoutMs: 5,
+        leaseRenewIntervalMs: 60_000,
+        out: () => {},
+      });
+      const run = restarted.run();
+      stream.push(welcomeDirectedFrame(80, "me") as ServerFrame);
+      await waitFor(
+        () => stream.sent.some((frame) => frame.type === "delivery_recover"),
+        "restart did not request durable ownership recovery",
+      );
+      const recovery = stream.sent.find((frame) =>
+        frame.type === "delivery_recover"
+      ) as Extract<ClientFrame, { type: "delivery_recover" }>;
+      expect(recovery.replay_safe).toBeUndefined();
+      stream.push({
+        type: "delivery_recovery",
+        delivery_id: recovery.delivery_id,
+        request_id: recovery.request_id,
+        result: "recovered",
+        state: "running",
+        attempt: recovery.attempt,
+        lease_epoch: recovery.lease_epoch,
+        lease_token: recovery.next_lease_token,
+        lease_until: Date.now() + 90_000,
+      });
+      await waitFor(() => restarted.pendingCount === 1, "late-reply debt was not restored");
+      await new Promise((resolve) => setTimeout(resolve, 15));
+      expect(replayedNotifications).toBe(0);
+      expect(failedUpdates).toBe(0);
+      await expect(restarted.reply(80, "late recovered success")).resolves.toEqual({ seq: 180 });
+      expect(restarted.pendingCount).toBe(0);
+      restarted.close();
+      await expect(run).resolves.toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("a persisted reply ACK settles in the background after a longer websocket outage", async () => {
+    const fake = fakeConnection();
+    let replyPosts = 0;
+    let repliedAttempts = 0;
+    let acknowledgeReply = false;
+    const bridge = new ClaudeChannelDeliveryBridge({
+      channel: "dev",
+      connection: fake.connection,
+      notify: async () => {},
+      postReply: async () => {
+        replyPosts += 1;
+        return { seq: 181 };
+      },
+      confirmDeliveryUpdate: async (update) => {
+        if (update.state !== "replied") return update.state;
+        repliedAttempts += 1;
+        if (!acknowledgeReply) throw new Error("replied ACK path unavailable");
+        return "replied";
+      },
+      deliveryAckMaxAttempts: 2,
+      deliveryAckRetryDelayMs: 0,
+      deliverySettleRetryDelayMs: 5,
+      deliverySettleRetryMaxRounds: 1,
+      deliverySettleRetryCooldownMs: 5,
+      leaseRenewIntervalMs: 60_000,
+      out: () => {},
+    });
+    await bridge.handleFrame(welcomeDirectedFrame(0, "me") as ServerFrame);
+    await bridge.handleFrame(deliveryFrame(81, "reply across reconnect", {
+      id: "delivery-replied-background-retry",
+      target_name: "me",
+    }) as ServerFrame);
+    await expect(bridge.reply(81, "persisted once")).rejects.toThrow("replied ACK path unavailable");
+    expect(replyPosts).toBe(1);
+    expect(bridge.pendingCount).toBe(1);
+    await waitFor(() => repliedAttempts >= 6, "cooldown replied ACK reconciliation did not continue");
+    acknowledgeReply = true;
+    await waitFor(() => bridge.pendingCount === 0, "persisted reply did not settle after recovery");
+
+    expect(replyPosts).toBe(1);
+    expect(repliedAttempts).toBeGreaterThanOrEqual(7);
+    bridge.close();
+  });
+
+  test("redelivery restarts settlement from an exhausted cooldown without reposting", async () => {
+    const fake = fakeConnection();
+    let replyPosts = 0;
+    let repliedAttempts = 0;
+    let acknowledgeReply = false;
+    const incoming = deliveryFrame(82, "redelivered settlement", {
+      id: "delivery-redelivery-reconcile",
+      target_name: "me",
+    }) as ServerFrame;
+    const bridge = new ClaudeChannelDeliveryBridge({
+      channel: "dev",
+      connection: fake.connection,
+      notify: async () => {},
+      postReply: async () => {
+        replyPosts += 1;
+        return { seq: 182 };
+      },
+      confirmDeliveryUpdate: async (update) => {
+        if (update.state !== "replied") return update.state;
+        repliedAttempts += 1;
+        if (!acknowledgeReply) throw new Error("replied ACK unavailable");
+        return "replied";
+      },
+      deliveryAckMaxAttempts: 1,
+      deliveryAckRetryDelayMs: 0,
+      deliverySettleRetryDelayMs: 5,
+      deliverySettleRetryMaxRounds: 1,
+      deliverySettleRetryCooldownMs: 60_000,
+      leaseRenewIntervalMs: 60_000,
+      out: () => {},
+    });
+    await bridge.handleFrame(welcomeDirectedFrame(0, "me") as ServerFrame);
+    await bridge.handleFrame(incoming);
+    await expect(bridge.reply(82, "persist once")).rejects.toThrow("replied ACK unavailable");
+    await waitFor(() => repliedAttempts >= 2, "fast settlement round did not exhaust");
+    expect(bridge.pendingCount).toBe(1);
+
+    acknowledgeReply = true;
+    await bridge.handleFrame(incoming);
+    await waitFor(() => bridge.pendingCount === 0, "redelivery did not restart settlement");
+    expect(replyPosts).toBe(1);
+    expect(repliedAttempts).toBe(3);
+    bridge.close();
+  });
+
+  test("a lost REST response retries automatically with one stable logical reply", async () => {
+    const fake = fakeConnection();
+    let notifications = 0;
+    let attempts = 0;
+    let returnPersistedResponse = false;
+    const keys: string[] = [];
+    const logicalReplies = new Map<string, number>();
+    const bridge = new ClaudeChannelDeliveryBridge({
+      channel: "dev",
+      connection: fake.connection,
+      notify: async () => {
+        notifications += 1;
+      },
+      postReply: async (reply) => {
+        attempts += 1;
+        keys.push(reply.idempotencyKey);
+        const persisted = logicalReplies.get(reply.idempotencyKey) ?? 100;
+        logicalReplies.set(reply.idempotencyKey, persisted);
+        if (!returnPersistedResponse) throw new Error("response lost after persistence");
+        return { seq: persisted };
+      },
+      confirmDeliveryUpdate: async (update) => {
+        fake.connection.send(update);
+      },
+      deliverySettleRetryDelayMs: 5,
+      deliverySettleRetryMaxRounds: 1,
+      deliverySettleRetryCooldownMs: 5,
+      out: () => {},
+    });
+    await bridge.handleFrame(welcomeDirectedFrame(0, "me") as ServerFrame);
+    const delivery = deliveryFrame(9, "retry me", { id: "delivery-9" }) as ServerFrame;
+    await bridge.handleFrame(delivery);
+    await bridge.handleFrame(delivery);
+    expect(notifications).toBe(1);
+    await expect(bridge.reply(9, "first")).rejects.toThrow("response lost after persistence");
+    expect(bridge.pendingCount).toBe(1);
+    await waitFor(() => attempts >= 3, "cooldown REST reconciliation did not continue");
+    returnPersistedResponse = true;
+    await waitFor(() => bridge.pendingCount === 0, "REST reply did not settle after response recovery");
+    expect(keys.length).toBeGreaterThanOrEqual(4);
+    expect(new Set(keys)).toEqual(new Set(["claude-channel-reply:delivery-9"]));
+    expect(logicalReplies.size).toBe(1);
+    expect(notifications).toBe(1);
+    bridge.close();
+  });
+
+  test("directed mode suppresses duplicate plain @ frames; legacy mode keeps a bounded fallback", async () => {
+    const directed = fakeConnection();
+    let directedNotifications = 0;
+    const directedBridge = new ClaudeChannelDeliveryBridge({
+      channel: "dev",
+      connection: directed.connection,
+      notify: async () => {
+        directedNotifications += 1;
+      },
+      postReply: async () => ({ seq: 1 }),
+      confirmDeliveryUpdate: async (update) => {
+        directed.connection.send(update);
+      },
+      out: () => {},
+    });
+    await directedBridge.handleFrame(welcomeDirectedFrame(0, "me") as ServerFrame);
+    await directedBridge.handleFrame(msgFrame(1, "plain duplicate", { mentions: ["me"] }) as ServerFrame);
+    expect(directedNotifications).toBe(0);
+    expect(directed.acked).toEqual([1]);
+
+    const legacy = fakeConnection();
+    let legacyNotifications = 0;
+    const legacyBridge = new ClaudeChannelDeliveryBridge({
+      channel: "dev",
+      connection: legacy.connection,
+      notify: async () => {
+        legacyNotifications += 1;
+      },
+      postReply: async () => ({ seq: 2 }),
+      out: () => {},
+    });
+    await legacyBridge.handleFrame(welcomeFrame(0, "me") as ServerFrame);
+    const plain = msgFrame(1, "legacy wake", { mentions: ["me"] }) as ServerFrame;
+    await legacyBridge.handleFrame(plain);
+    await legacyBridge.handleFrame(plain);
+    expect(legacyNotifications).toBe(1);
+    expect(legacy.acked).toEqual([1]);
+  });
+
+  test("concurrent reply tool calls cannot persist two linked replies", async () => {
+    const fake = fakeConnection();
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let posts = 0;
+    const bridge = new ClaudeChannelDeliveryBridge({
+      channel: "dev",
+      connection: fake.connection,
+      notify: async () => {},
+      postReply: async () => {
+        posts += 1;
+        await gate;
+        return { seq: 42 };
+      },
+      confirmDeliveryUpdate: async (update) => {
+        fake.connection.send(update);
+      },
+      out: () => {},
+    });
+    await bridge.handleFrame(welcomeDirectedFrame(0, "me") as ServerFrame);
+    await bridge.handleFrame(deliveryFrame(10, "reply once", { id: "delivery-10" }) as ServerFrame);
+
+    const first = bridge.reply(10, "first");
+    await Promise.resolve();
+    await expect(bridge.reply(10, "second")).rejects.toThrow("reply already in progress");
+    release();
+    await first;
+    expect(posts).toBe(1);
+  });
+});

--- a/cli/test/cli.test.ts
+++ b/cli/test/cli.test.ts
@@ -65,6 +65,7 @@ describe("cli subprocess", () => {
       "logout",
       "agent",
       "serve",
+      "bridge",
       "mcp",
       "lark",
       "task",

--- a/cli/test/codex-agentparty-bridge.test.ts
+++ b/cli/test/codex-agentparty-bridge.test.ts
@@ -1,0 +1,2041 @@
+import { describe, expect, test } from "bun:test";
+import type {
+  ClientFrame,
+  DirectedDeliveryFrame,
+  ServerFrame,
+} from "@agentparty/shared";
+import {
+  CodexAgentPartyBridge,
+  CodexSessionController,
+  type CodexRpcPeer,
+  type JsonRpcId,
+  type JsonRpcNotification,
+  type JsonRpcRequest,
+  type JsonRpcResponse,
+} from "../src/codex-app-server-bridge";
+import { DeliveryRecoveryJournal } from "../src/delivery-recovery-journal";
+import { deliveryFrame, welcomeDirectedFrame } from "./mock-server";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+class DeliveryRpcPeer implements CodexRpcPeer {
+  readonly initializeResult = {};
+  readonly calls: Array<{ method: string; params?: unknown }> = [];
+  private readonly messages = new Set<(message: JsonRpcRequest | JsonRpcNotification) => void | Promise<void>>();
+  private readonly reconnects = new Set<(generation: number) => void | Promise<void>>();
+  connectionGeneration = 1;
+  blockRestore: Promise<void> | null = null;
+  restoreFailures = 0;
+  disconnectTurnStarts = 0;
+  turnIds: string[] = [];
+  threadId = "thread-delivery";
+  restoredTurns: Array<{
+    id: string;
+    status: "completed" | "interrupted" | "failed" | "inProgress";
+    items: Array<Record<string, unknown>>;
+  }> = [];
+  restoredStatus: "idle" | "active" = "idle";
+
+  async start(): Promise<void> {}
+
+  async request(method: string, params?: unknown): Promise<unknown> {
+    this.calls.push({ method, params });
+    if (method === "thread/start" || method === "thread/resume" || method === "thread/read") {
+      if (method === "thread/resume" || method === "thread/read") await this.blockRestore;
+      if (method === "thread/resume" && this.restoreFailures > 0) {
+        this.restoreFailures -= 1;
+        throw new Error("restore failed once");
+      }
+      return {
+        thread: {
+          id: this.threadId,
+          status: { type: this.restoredStatus },
+          turns: this.restoredTurns,
+        },
+      };
+    }
+    if (method === "turn/start") {
+      if (this.disconnectTurnStarts > 0) {
+        this.disconnectTurnStarts -= 1;
+        throw new Error("stdio proxy disconnected after write");
+      }
+      const turnId = this.turnIds.shift() ?? "turn-delivery";
+      return {
+        turn: {
+          id: turnId,
+          status: "inProgress",
+          items: [{
+            type: "userMessage",
+            clientId: (params as { clientUserMessageId: string }).clientUserMessageId,
+          }],
+        },
+      };
+    }
+    throw new Error(`unexpected method ${method}`);
+  }
+
+  async requestConnected(
+    method: string,
+    params?: unknown,
+    expectedGeneration?: number,
+  ): Promise<unknown> {
+    if (
+      expectedGeneration !== undefined &&
+      expectedGeneration !== this.connectionGeneration
+    ) {
+      throw new Error("fake generation changed before request write");
+    }
+    return await this.request(method, params);
+  }
+
+  async notify(): Promise<void> {}
+  respond(_id: JsonRpcId, _result?: unknown, _error?: JsonRpcResponse["error"]): void {}
+
+  onMessage(
+    listener: (message: JsonRpcRequest | JsonRpcNotification) => void | Promise<void>,
+  ): () => void {
+    this.messages.add(listener);
+    return () => this.messages.delete(listener);
+  }
+
+  onReconnect(listener: (generation: number) => void | Promise<void>): () => void {
+    this.reconnects.add(listener);
+    return () => this.reconnects.delete(listener);
+  }
+
+  emit(message: JsonRpcRequest | JsonRpcNotification): void {
+    for (const listener of this.messages) void listener(message);
+  }
+
+  emitReconnect(): void {
+    this.connectionGeneration += 1;
+    for (const listener of this.reconnects) {
+      void Promise.resolve(listener(this.connectionGeneration)).catch(() => {});
+    }
+  }
+}
+
+function fakeConnection() {
+  let cursor = 0;
+  const sent: ClientFrame[] = [];
+  const acked: number[] = [];
+  let closed = false;
+  return {
+    sent,
+    acked,
+    get closed() {
+      return closed;
+    },
+    connection: {
+      frames: (async function* (): AsyncGenerator<ServerFrame> {})(),
+      send(frame: ClientFrame) {
+        sent.push(frame);
+        return true;
+      },
+      ack(seq: number) {
+        acked.push(seq);
+        cursor = Math.max(cursor, seq);
+      },
+      close() {
+        closed = true;
+      },
+      get cursor() {
+        return cursor;
+      },
+    },
+  };
+}
+
+function streamingConnection() {
+  let cursor = 0;
+  const sent: ClientFrame[] = [];
+  const acked: number[] = [];
+  const queued: ServerFrame[] = [];
+  let ended = false;
+  let wake: (() => void) | null = null;
+  const signal = () => {
+    const resolve = wake;
+    wake = null;
+    resolve?.();
+  };
+  const frames = (async function* (): AsyncGenerator<ServerFrame> {
+    for (;;) {
+      const frame = queued.shift();
+      if (frame) {
+        yield frame;
+        continue;
+      }
+      if (ended) return;
+      await new Promise<void>((resolve) => {
+        wake = resolve;
+      });
+    }
+  })();
+  return {
+    sent,
+    acked,
+    push(frame: ServerFrame) {
+      queued.push(frame);
+      signal();
+    },
+    connection: {
+      frames,
+      send(frame: ClientFrame) {
+        sent.push(frame);
+        return true;
+      },
+      ack(seq: number) {
+        acked.push(seq);
+        cursor = Math.max(cursor, seq);
+      },
+      close() {
+        ended = true;
+        signal();
+      },
+      get cursor() {
+        return cursor;
+      },
+    },
+  };
+}
+
+async function waitFor(predicate: () => boolean, message: string): Promise<void> {
+  const deadline = Date.now() + 3_000;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error(message);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+function ownerAnswerFrame(options: {
+  seq: number;
+  deliveryId: string;
+  sourceDeliveryId: string;
+  sourceSeq: number;
+  workId: string;
+  continuationRef: string;
+  requestSeq: number;
+}): DirectedDeliveryFrame {
+  const source = deliveryFrame(options.seq, "owner approved", {
+    id: options.deliveryId,
+    target_name: "me",
+    work_id: options.workId,
+    continuation_ref: options.continuationRef,
+    sender: { name: "alice", kind: "human" },
+  }) as unknown as DirectedDeliveryFrame;
+  return {
+    ...source,
+    delivery: { ...source.delivery, cause: "owner_answer" },
+    message: {
+      ...source.message,
+      reply_to: options.requestSeq,
+      decision_response: {
+        request_seq: options.requestSeq,
+        chosen_index: 0,
+        chosen_option: "approve",
+        delivery_id: options.sourceDeliveryId,
+        origin_seq: options.sourceSeq,
+        origin_channel: "dev",
+        work_id: options.workId,
+        continuation_ref: options.continuationRef,
+      },
+    },
+  };
+}
+
+describe("Codex AgentParty delivery integration", () => {
+  test("same-generation recovery retries transient restore failures before releasing writers", async () => {
+    const rpc = new DeliveryRpcPeer();
+    const session = new CodexSessionController(rpc, {
+      recoveryRetryDelayMs: 50,
+    });
+    await session.request("thread/start", {});
+    rpc.restoreFailures = 2;
+    rpc.emitReconnect();
+    const submission = session.submit({
+      text: "first write after successful recovery",
+      clientUserMessageId: "agentparty:restore-retry",
+    });
+    await waitFor(
+      () => rpc.calls.filter((call) => call.method === "thread/resume").length === 2,
+      "same connection did not retry its first transient restore failure",
+    );
+    expect(rpc.connectionGeneration).toBe(2);
+    expect(rpc.calls.filter((call) => call.method === "turn/start")).toHaveLength(0);
+    await expect(submission).resolves.toEqual({
+      kind: "started",
+      turnId: "turn-delivery",
+    });
+    expect(rpc.connectionGeneration).toBe(2);
+    expect(rpc.calls.filter((call) => call.method === "thread/resume")).toHaveLength(3);
+  });
+
+  test("holds new writes behind thread resume/read after the backend reconnects", async () => {
+    const rpc = new DeliveryRpcPeer();
+    const session = new CodexSessionController(rpc);
+    await session.request("thread/start", {});
+    let release!: () => void;
+    rpc.blockRestore = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    rpc.emitReconnect();
+    await waitFor(
+      () => rpc.calls.some((call) => call.method === "thread/resume"),
+      "restore did not begin",
+    );
+    const submission = session.submit({
+      text: "wait for restore",
+      clientUserMessageId: "agentparty:restore-barrier",
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(rpc.calls.filter((call) => call.method === "turn/start")).toHaveLength(0);
+    release();
+    await expect(submission).resolves.toMatchObject({
+      kind: "started",
+      turnId: "turn-delivery",
+    });
+    expect(rpc.calls.filter((call) => call.method === "turn/start")).toHaveLength(1);
+  });
+
+  test("the production frame loop keeps reading while a delivery waits for its running ACK", async () => {
+    const rpc = new DeliveryRpcPeer();
+    const session = new CodexSessionController(rpc);
+    const conn = streamingConnection();
+    const bridge = new CodexAgentPartyBridge({
+      channel: "dev",
+      connection: conn.connection,
+      session,
+      deliveryAckTimeoutMs: 1_000,
+      postReply: async () => ({ seq: 1 }),
+    });
+    const run = bridge.run();
+    conn.push(welcomeDirectedFrame(0, "me") as ServerFrame);
+    const incoming = deliveryFrame(14, "read the ACK on the same stream", {
+      id: "delivery-14",
+      target_name: "me",
+      sender: { name: "alice", kind: "human" },
+    });
+    conn.push(incoming as ServerFrame);
+    await waitFor(
+      () => conn.sent.some((frame) => frame.type === "delivery_update"),
+      "running update was not sent",
+    );
+    const running = conn.sent.find((frame) => frame.type === "delivery_update") as
+      Extract<ClientFrame, { type: "delivery_update" }> & { request_id: string };
+    conn.push({
+      type: "delivery_state",
+      request_id: running.request_id,
+      delivery: {
+        ...incoming.delivery,
+        state: "running",
+      },
+    } as ServerFrame);
+    await waitFor(
+      () => bridge.pendingCount === 1,
+      "delivery ACK from the production frame loop did not unblock injection",
+    );
+    bridge.close();
+    await expect(run).resolves.toBe(0);
+  });
+
+  test("does not inject until Worker confirms the authoritative running state", async () => {
+    const rpc = new DeliveryRpcPeer();
+    const session = new CodexSessionController(rpc);
+    const conn = fakeConnection();
+    const bridge = new CodexAgentPartyBridge({
+      channel: "dev",
+      connection: conn.connection,
+      session,
+      deliveryAckTimeoutMs: 1_000,
+      postReply: async () => ({ seq: 1 }),
+    });
+    await bridge.handleFrame(welcomeDirectedFrame(0, "me") as ServerFrame);
+    const incoming = deliveryFrame(13, "must wait for running ack", {
+      id: "delivery-13",
+      target_name: "me",
+      sender: { name: "alice", kind: "human" },
+    });
+    const handling = bridge.handleFrame(incoming as ServerFrame);
+    await waitFor(
+      () => conn.sent.some((frame) => frame.type === "delivery_update"),
+      "running update was not sent",
+    );
+    expect(rpc.calls.filter((call) => call.method.startsWith("turn/"))).toHaveLength(0);
+    const running = conn.sent.find((frame) => frame.type === "delivery_update") as
+      Extract<ClientFrame, { type: "delivery_update" }> & { request_id: string };
+    await bridge.handleFrame({
+      type: "delivery_state",
+      request_id: running.request_id,
+      delivery: {
+        ...incoming.delivery,
+        state: "running",
+      },
+    } as ServerFrame);
+    await handling;
+    expect(bridge.pendingCount).toBe(1);
+    bridge.close();
+  });
+
+  test("holds a delivery before TUI thread attach, injects it once, and persists the final linked reply", async () => {
+    const rpc = new DeliveryRpcPeer();
+    const session = new CodexSessionController(rpc);
+    const conn = fakeConnection();
+    const posts: unknown[] = [];
+    const bridge = new CodexAgentPartyBridge({
+      channel: "dev",
+      connection: conn.connection,
+      session,
+      leaseRenewIntervalMs: 60_000,
+      confirmDeliveryUpdate: async (update) => {
+        conn.connection.send(update);
+      },
+      postReply: async (reply) => {
+        posts.push(reply);
+        return { seq: 88 };
+      },
+    });
+
+    await bridge.handleFrame(welcomeDirectedFrame(0, "me") as ServerFrame);
+    await bridge.handleFrame(deliveryFrame(12, "same-session work", {
+      id: "delivery-12",
+      target_name: "me",
+      sender: { name: "alice", kind: "human" },
+    }) as ServerFrame);
+    expect(bridge.pendingCount).toBe(1);
+    expect(rpc.calls.filter((call) => call.method.startsWith("turn/"))).toHaveLength(0);
+    expect(conn.sent).toContainEqual(expect.objectContaining({
+      type: "delivery_update",
+      delivery_id: "delivery-12",
+      state: "running",
+    }));
+
+    await session.request("thread/start", {});
+    expect(rpc.calls.filter((call) => call.method === "turn/start")).toHaveLength(1);
+    expect(rpc.calls.find((call) => call.method === "turn/start")?.params).toMatchObject({
+      threadId: "thread-delivery",
+      clientUserMessageId: "agentparty:delivery-12",
+      responsesapiClientMetadata: {
+        source: "agentparty",
+        channel: "dev",
+        seq: "12",
+        sender: "alice",
+        delivery_id: "delivery-12",
+      },
+    });
+    await expect(session.request("thread/start", {})).rejects.toThrow(
+      "while 1 AgentParty delivery is still pending",
+    );
+    expect(rpc.calls.filter((call) => call.method === "thread/start")).toHaveLength(1);
+
+    rpc.emit({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-delivery",
+        turn: {
+          id: "turn-delivery",
+          status: "completed",
+          items: [{
+            type: "agentMessage",
+            id: "agent-final",
+            text: "same-session answer",
+          }],
+        },
+      },
+    });
+    await waitFor(() => posts.length === 1, "linked reply was not posted");
+    await waitFor(() => bridge.pendingCount === 0, "linked reply did not settle the delivery");
+    expect(posts).toEqual([{
+      body: "same-session answer",
+      idempotencyKey: "codex-bridge-reply:delivery-12",
+      mentions: ["alice"],
+      replyTo: 12,
+    }]);
+    expect(conn.sent).toContainEqual(expect.objectContaining({
+      type: "delivery_update",
+      delivery_id: "delivery-12",
+      state: "replied",
+      reply_seq: 88,
+    }));
+    expect(bridge.pendingCount).toBe(0);
+    expect(rpc.calls.filter((call) => call.method === "turn/start")).toHaveLength(1);
+    bridge.close();
+  });
+
+  test("persists the exact attached thread at the writer boundary and cold-recovers an unknown write without replay", async () => {
+    const root = mkdtempSync(join(tmpdir(), "ap-codex-write-boundary-"));
+    let bridge: CodexAgentPartyBridge | null = null;
+    let restartedBridge: CodexAgentPartyBridge | null = null;
+    try {
+      const path = join(root, "journal.json");
+      const rpc = new DeliveryRpcPeer();
+      rpc.threadId = "thread-exact-write-boundary";
+      const session = new CodexSessionController(rpc);
+      const conn = fakeConnection();
+      const journal = new DeliveryRecoveryJournal(
+        path,
+        "dev",
+        "codex",
+      );
+      bridge = new CodexAgentPartyBridge({
+        channel: "dev",
+        connection: conn.connection,
+        session,
+        recoveryJournal: journal,
+        leaseRenewIntervalMs: 60_000,
+        confirmDeliveryUpdate: async (update) => update.state,
+        postReply: async () => ({ seq: 1 }),
+      });
+
+      await bridge.handleFrame(welcomeDirectedFrame(0, "me") as ServerFrame);
+      await bridge.handleFrame(deliveryFrame(112, "queued before thread attach", {
+        id: "delivery-write-boundary",
+        target_name: "me",
+      }) as ServerFrame);
+      expect(rpc.calls.filter((call) => call.method.startsWith("turn/"))).toHaveLength(0);
+      expect(journal.get("delivery-write-boundary")).toMatchObject({
+        phase: "running_authorized",
+        threadId: null,
+      });
+
+      rpc.disconnectTurnStarts = 1;
+      await session.request("thread/start", {});
+      expect(rpc.calls.filter((call) => call.method === "turn/start")).toHaveLength(1);
+      expect(journal.get("delivery-write-boundary")).toMatchObject({
+        phase: "harness_issued",
+        threadId: "thread-exact-write-boundary",
+        turnId: null,
+      });
+      expect(rpc.calls.find((call) => call.method === "turn/start")?.params).toMatchObject({
+        threadId: "thread-exact-write-boundary",
+        clientUserMessageId: "agentparty:delivery-write-boundary",
+      });
+      bridge.close();
+      bridge = null;
+
+      const restartedJournal = new DeliveryRecoveryJournal(path, "dev", "codex");
+      expect(restartedJournal.get("delivery-write-boundary")).toMatchObject({
+        phase: "harness_issued",
+        threadId: "thread-exact-write-boundary",
+        turnId: null,
+      });
+
+      const restartedRpc = new DeliveryRpcPeer();
+      restartedRpc.threadId = "thread-exact-write-boundary";
+      restartedRpc.restoredTurns = [];
+      const restartedSession = new CodexSessionController(restartedRpc);
+      await restartedSession.request("thread/resume", {
+        threadId: "thread-exact-write-boundary",
+      });
+      const restartedConnection = fakeConnection();
+      restartedBridge = new CodexAgentPartyBridge({
+        channel: "dev",
+        connection: restartedConnection.connection,
+        session: restartedSession,
+        recoveryJournal: restartedJournal,
+        requireDeliveryRecovery: true,
+        leaseRenewIntervalMs: 60_000,
+        deliveryAckTimeoutMs: 1_000,
+        confirmDeliveryUpdate: async (update) => update.state,
+        postReply: async () => ({ seq: 1 }),
+      });
+      await restartedBridge.handleFrame(welcomeDirectedFrame(0, "me") as ServerFrame);
+      await waitFor(
+        () => restartedConnection.sent.some((frame) => frame.type === "delivery_recover"),
+        "cold bridge did not request exact ownership recovery",
+      );
+      const recovery = restartedConnection.sent.find((frame) =>
+        frame.type === "delivery_recover"
+      ) as Extract<ClientFrame, { type: "delivery_recover" }>;
+      await restartedBridge.handleFrame({
+        type: "delivery_recovery",
+        delivery_id: recovery.delivery_id,
+        request_id: recovery.request_id,
+        result: "recovered",
+        state: "running",
+        attempt: recovery.attempt,
+        lease_epoch: recovery.lease_epoch,
+        lease_token: recovery.next_lease_token,
+        lease_until: Date.now() + 90_000,
+      } as ServerFrame);
+      await waitFor(
+        () =>
+          restartedJournal.get("delivery-write-boundary")?.delivery.lease_token ===
+            recovery.next_lease_token,
+        "cold bridge did not durably accept recovered ownership",
+      );
+
+      expect(restartedBridge.pendingCount).toBe(1);
+      expect(restartedJournal.get("delivery-write-boundary")).toMatchObject({
+        phase: "harness_issued",
+        threadId: "thread-exact-write-boundary",
+        turnId: null,
+      });
+      expect(restartedRpc.calls.filter((call) => call.method === "turn/start")).toHaveLength(0);
+    } finally {
+      restartedBridge?.close();
+      bridge?.close();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("persists active-thread affinity before the running ACK can reach the writer", async () => {
+    const root = mkdtempSync(join(tmpdir(), "ap-codex-pre-writer-thread-"));
+    let bridge: CodexAgentPartyBridge | null = null;
+    try {
+      const path = join(root, "journal.json");
+      const rpc = new DeliveryRpcPeer();
+      rpc.threadId = "thread-pre-writer-crash";
+      rpc.restoredStatus = "active";
+      rpc.restoredTurns = [{
+        id: "review-pre-writer",
+        status: "inProgress",
+        items: [{ type: "enteredReviewMode", id: "entered-review" }],
+      }];
+      const session = new CodexSessionController(rpc);
+      await session.request("thread/resume", { threadId: rpc.threadId });
+      const journal = new DeliveryRecoveryJournal(path, "dev", "codex");
+      bridge = new CodexAgentPartyBridge({
+        channel: "dev",
+        connection: fakeConnection().connection,
+        session,
+        recoveryJournal: journal,
+        leaseRenewIntervalMs: 60_000,
+        confirmDeliveryUpdate: async (update) => update.state,
+        postReply: async () => ({ seq: 1 }),
+      });
+
+      await bridge.handleFrame(welcomeDirectedFrame(0, "me") as ServerFrame);
+      await bridge.handleFrame(deliveryFrame(113, "queue on the exact active thread", {
+        id: "delivery-pre-writer-thread",
+        target_name: "me",
+      }) as ServerFrame);
+      expect(rpc.calls.filter((call) => call.method.startsWith("turn/"))).toHaveLength(0);
+      expect(journal.get("delivery-pre-writer-thread")).toMatchObject({
+        phase: "running_authorized",
+        threadId: "thread-pre-writer-crash",
+      });
+
+      bridge.close();
+      bridge = null;
+      const restarted = new DeliveryRecoveryJournal(path, "dev", "codex");
+      expect(restarted.entries().map((entry) => entry.threadId)).toEqual([
+        "thread-pre-writer-crash",
+      ]);
+    } finally {
+      bridge?.close();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("does not POST until replyBody WAL succeeds, then retries once and settles", async () => {
+    const root = mkdtempSync(join(tmpdir(), "ap-codex-reply-wal-"));
+    let bridge: CodexAgentPartyBridge | null = null;
+    try {
+      let failNextCommit = false;
+      let walFailures = 0;
+      const journal = new DeliveryRecoveryJournal(
+        join(root, "journal.json"),
+        "dev",
+        "codex",
+        {
+          persist: (commit) => {
+            if (failNextCommit) {
+              failNextCommit = false;
+              walFailures += 1;
+              const error = new Error("replyBody WAL is full") as NodeJS.ErrnoException;
+              error.code = "ENOSPC";
+              throw error;
+            }
+            commit();
+          },
+        },
+      );
+      const rpc = new DeliveryRpcPeer();
+      const session = new CodexSessionController(rpc);
+      const conn = fakeConnection();
+      const posts: string[] = [];
+      const repliedUpdates: number[] = [];
+      bridge = new CodexAgentPartyBridge({
+        channel: "dev",
+        connection: conn.connection,
+        session,
+        recoveryJournal: journal,
+        leaseRenewIntervalMs: 60_000,
+        retryDelayMs: 100,
+        confirmDeliveryUpdate: async (update) => {
+          if (update.state === "replied" && update.reply_seq !== undefined) {
+            repliedUpdates.push(update.reply_seq);
+          }
+          return update.state;
+        },
+        postReply: async ({ idempotencyKey }) => {
+          posts.push(idempotencyKey);
+          return { seq: 1_181 };
+        },
+      });
+
+      await bridge.handleFrame(welcomeDirectedFrame(0, "me") as ServerFrame);
+      await bridge.handleFrame(deliveryFrame(118, "persist before REST", {
+        id: "delivery-reply-wal",
+        target_name: "me",
+        sender: { name: "alice", kind: "human" },
+      }) as ServerFrame);
+      await session.request("thread/start", {});
+      failNextCommit = true;
+      rpc.emit({
+        method: "turn/completed",
+        params: {
+          threadId: "thread-delivery",
+          turn: {
+            id: "turn-delivery",
+            status: "completed",
+            items: [{
+              type: "agentMessage",
+              id: "reply-wal-final",
+              text: "durable before posting",
+            }],
+          },
+        },
+      });
+
+      await waitFor(() => walFailures === 1, "replyBody WAL fault was not injected");
+      expect(posts).toHaveLength(0);
+      expect(repliedUpdates).toHaveLength(0);
+      expect(bridge.pendingCount).toBe(1);
+      expect(journal.get("delivery-reply-wal")).toMatchObject({
+        phase: "harness_accepted",
+        replyBody: null,
+        replySeq: null,
+      });
+
+      await waitFor(
+        () => bridge?.pendingCount === 0,
+        "replyBody WAL retry did not settle the delivery",
+      );
+      expect(posts).toEqual(["codex-bridge-reply:delivery-reply-wal"]);
+      expect(repliedUpdates).toEqual([1_181]);
+      expect(journal.get("delivery-reply-wal")).toBeNull();
+    } finally {
+      bridge?.close();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("retries a lost REST response with one stable linked-reply idempotency key", async () => {
+    const rpc = new DeliveryRpcPeer();
+    const session = new CodexSessionController(rpc);
+    const conn = fakeConnection();
+    const postKeys: string[] = [];
+    const bridge = new CodexAgentPartyBridge({
+      channel: "dev",
+      connection: conn.connection,
+      session,
+      leaseRenewIntervalMs: 60_000,
+      retryDelayMs: 1,
+      confirmDeliveryUpdate: async (update) => {
+        conn.connection.send(update);
+      },
+      postReply: async ({ idempotencyKey }) => {
+        postKeys.push(idempotencyKey);
+        if (postKeys.length === 1) throw new Error("response lost after persistence");
+        return { seq: 91 };
+      },
+    });
+    await bridge.handleFrame(welcomeDirectedFrame(0, "me") as ServerFrame);
+    await bridge.handleFrame(deliveryFrame(15, "reply once", {
+      id: "delivery-15",
+      target_name: "me",
+      sender: { name: "alice", kind: "human" },
+    }) as ServerFrame);
+    await session.request("thread/start", {});
+    const completed = {
+      method: "turn/completed",
+      params: {
+        threadId: "thread-delivery",
+        turn: {
+          id: "turn-delivery",
+          status: "completed",
+          items: [{ type: "agentMessage", id: "agent-final", text: "one reply" }],
+        },
+      },
+    } as const;
+    rpc.emit(completed);
+    await waitFor(() => bridge.pendingCount === 0, "stable-key retry did not settle the delivery");
+    expect(postKeys).toEqual([
+      "codex-bridge-reply:delivery-15",
+      "codex-bridge-reply:delivery-15",
+    ]);
+    expect(conn.sent).toContainEqual(expect.objectContaining({
+      type: "delivery_update",
+      delivery_id: "delivery-15",
+      state: "replied",
+      reply_seq: 91,
+    }));
+    bridge.close();
+  });
+
+  test("cold reconnect preserves an absent after-write input for one exact late reply without replay", async () => {
+    const root = mkdtempSync(join(tmpdir(), "ap-codex-after-write-"));
+    try {
+      const rpc = new DeliveryRpcPeer();
+      const session = new CodexSessionController(rpc);
+      const conn = fakeConnection();
+      const journal = new DeliveryRecoveryJournal(
+        join(root, "journal.json"),
+        "dev",
+        "codex",
+      );
+      const failedUpdates: string[] = [];
+      const repliedUpdates: number[] = [];
+      const posts: Array<{ replyTo: number; body: string }> = [];
+      const bridge = new CodexAgentPartyBridge({
+        channel: "dev",
+        connection: conn.connection,
+        session,
+        recoveryJournal: journal,
+        leaseRenewIntervalMs: 60_000,
+        retryDelayMs: 1,
+        confirmDeliveryUpdate: async (update) => {
+          if (update.state === "failed") failedUpdates.push(update.error ?? "");
+          if (update.state === "replied" && update.reply_seq !== undefined) {
+            repliedUpdates.push(update.reply_seq);
+          }
+          return update.state;
+        },
+        postReply: async ({ replyTo, body }) => {
+          posts.push({ replyTo, body });
+          return { seq: 117 };
+        },
+      });
+
+      await bridge.handleFrame(welcomeDirectedFrame(0, "me") as ServerFrame);
+      await session.request("thread/start", {});
+      rpc.disconnectTurnStarts = 1;
+      await bridge.handleFrame(deliveryFrame(17, "unknown write", {
+        id: "delivery-17",
+        target_name: "me",
+        sender: { name: "alice", kind: "human" },
+      }) as ServerFrame);
+      expect(bridge.pendingCount).toBe(1);
+      expect(rpc.calls.filter((call) => call.method === "turn/start")).toHaveLength(1);
+      expect(journal.get("delivery-17")).toMatchObject({ phase: "harness_issued" });
+
+      rpc.emitReconnect();
+      await waitFor(
+        () => rpc.calls.filter((call) => call.method === "thread/read").length >= 1,
+        "cold recovery did not scan authoritative Codex history",
+      );
+      await expect(session.submit({
+        text: "independent later work",
+        clientUserMessageId: "agentparty:after-terminal-unknown",
+      })).resolves.toMatchObject({ kind: "started" });
+      expect(bridge.pendingCount).toBe(1);
+      expect(failedUpdates).toHaveLength(0);
+      expect(
+        rpc.calls
+          .filter((call) => call.method === "turn/start")
+          .map((call) => (call.params as { clientUserMessageId?: string }).clientUserMessageId),
+      ).toEqual([
+        "agentparty:delivery-17",
+        "agentparty:after-terminal-unknown",
+      ]);
+
+      rpc.restoredTurns = [{
+        id: "turn-late-delivery-17",
+        status: "completed",
+        items: [
+          { type: "userMessage", clientId: "agentparty:delivery-17" },
+          { type: "agentMessage", id: "late-final", text: "late authoritative result" },
+        ],
+      }];
+      rpc.emitReconnect();
+      await waitFor(
+        () => bridge.pendingCount === 0,
+        "late authoritative Codex result did not settle preserved delivery debt",
+      );
+      expect(posts).toEqual([{ replyTo: 17, body: "late authoritative result" }]);
+      expect(repliedUpdates).toEqual([117]);
+      expect(failedUpdates).toHaveLength(0);
+      expect(journal.get("delivery-17")).toBeNull();
+      bridge.close();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("cold recovery promotes reply_posted plus terminal waiting_owner into a durable parked binding", async () => {
+    const root = mkdtempSync(join(tmpdir(), "ap-codex-waiting-owner-crash-"));
+    let bridgeA: CodexAgentPartyBridge | null = null;
+    let bridgeB: CodexAgentPartyBridge | null = null;
+    try {
+      const path = join(root, "journal.json");
+      const journalA = new DeliveryRecoveryJournal(path, "dev", "codex");
+      const rpcA = new DeliveryRpcPeer();
+      rpcA.turnIds = ["turn-waiting-owner-crash"];
+      const sessionA = new CodexSessionController(rpcA);
+      const connA = fakeConnection();
+      let sourceAckRequested = false;
+      const neverAck = new Promise<"waiting_owner">(() => {});
+      bridgeA = new CodexAgentPartyBridge({
+        channel: "dev",
+        connection: connA.connection,
+        session: sessionA,
+        recoveryJournal: journalA,
+        leaseRenewIntervalMs: 60_000,
+        confirmDeliveryUpdate: async (update) => {
+          if (
+            update.delivery_id === "delivery-waiting-owner-crash" &&
+            update.state === "replied"
+          ) {
+            sourceAckRequested = true;
+            return await neverAck;
+          }
+          return update.state;
+        },
+        postReply: async () => ({ seq: 2_120 }),
+      });
+
+      await bridgeA.handleFrame(welcomeDirectedFrame(0, "me") as ServerFrame);
+      await sessionA.request("thread/start", {});
+      await bridgeA.handleFrame(deliveryFrame(120, "persist reply before waiting-owner ACK", {
+        id: "delivery-waiting-owner-crash",
+        target_name: "me",
+        work_id: "work-waiting-owner-crash",
+        continuation_ref: "continuation-waiting-owner-crash",
+        sender: { name: "alice", kind: "human" },
+      }) as ServerFrame);
+      rpcA.emit({
+        method: "turn/completed",
+        params: {
+          threadId: "thread-delivery",
+          turn: {
+            id: "turn-waiting-owner-crash",
+            status: "completed",
+            items: [{
+              type: "agentMessage",
+              id: "waiting-owner-crash-final",
+              text: "waiting on the owner",
+            }],
+          },
+        },
+      });
+      await waitFor(
+        () =>
+          sourceAckRequested &&
+          journalA.get("delivery-waiting-owner-crash")?.phase === "reply_posted",
+        "source did not cross reply_posted before the simulated crash",
+      );
+      expect(journalA.get("delivery-waiting-owner-crash")).toMatchObject({
+        phase: "reply_posted",
+        replyBody: "waiting on the owner",
+        replySeq: 2_120,
+        threadId: "thread-delivery",
+      });
+      bridgeA.close();
+      bridgeA = null;
+
+      const journalB = new DeliveryRecoveryJournal(path, "dev", "codex");
+      const rpcB = new DeliveryRpcPeer();
+      rpcB.turnIds = ["turn-owner-after-crash"];
+      const sessionB = new CodexSessionController(rpcB);
+      await sessionB.request("thread/resume", { threadId: "thread-delivery" });
+      const connB = streamingConnection();
+      const postsAfterCrash: string[] = [];
+      bridgeB = new CodexAgentPartyBridge({
+        channel: "dev",
+        connection: connB.connection,
+        session: sessionB,
+        recoveryJournal: journalB,
+        requireDeliveryRecovery: true,
+        leaseRenewIntervalMs: 60_000,
+        deliveryAckTimeoutMs: 1_000,
+        confirmDeliveryUpdate: async (update) => update.state,
+        postReply: async ({ idempotencyKey }) => {
+          postsAfterCrash.push(idempotencyKey);
+          return { seq: 2_121 };
+        },
+      });
+      const runB = bridgeB.run();
+      connB.push(welcomeDirectedFrame(0, "me") as ServerFrame);
+      await waitFor(
+        () =>
+          connB.sent.some((frame) =>
+            frame.type === "delivery_recover" &&
+            frame.delivery_id === "delivery-waiting-owner-crash"
+          ),
+        "cold bridge did not request source ownership reconciliation",
+      );
+      const recovery = connB.sent.find((frame) =>
+        frame.type === "delivery_recover" &&
+        frame.delivery_id === "delivery-waiting-owner-crash"
+      ) as Extract<ClientFrame, { type: "delivery_recover" }>;
+      connB.push({
+        type: "delivery_recovery",
+        delivery_id: recovery.delivery_id,
+        request_id: recovery.request_id,
+        result: "terminal",
+        state: "waiting_owner",
+        attempt: recovery.attempt,
+        lease_epoch: recovery.lease_epoch,
+      } as ServerFrame);
+      await waitFor(
+        () =>
+          bridgeB?.parkedContinuationCount === 1 &&
+          journalB.get("delivery-waiting-owner-crash")?.phase === "waiting_owner",
+        "terminal waiting_owner did not promote the durable parked binding",
+      );
+      expect(bridgeB.pendingCount).toBe(0);
+      expect(postsAfterCrash).toHaveLength(0);
+      expect(journalB.get("delivery-waiting-owner-crash")).toMatchObject({
+        phase: "waiting_owner",
+        replyBody: "waiting on the owner",
+        replySeq: 2_120,
+        threadId: "thread-delivery",
+        delivery: {
+          id: "delivery-waiting-owner-crash",
+          state: "waiting_owner",
+          reply_seq: 2_120,
+        },
+      });
+
+      connB.push(ownerAnswerFrame({
+        seq: 121,
+        deliveryId: "delivery-owner-after-crash",
+        sourceDeliveryId: "delivery-waiting-owner-crash",
+        sourceSeq: 120,
+        workId: "work-waiting-owner-crash",
+        continuationRef: "continuation-waiting-owner-crash",
+        requestSeq: 2_120,
+      }) as ServerFrame);
+      await waitFor(
+        () =>
+          rpcB.calls.some((call) =>
+            call.method === "turn/start" &&
+            (call.params as { clientUserMessageId?: string }).clientUserMessageId ===
+              "agentparty:delivery-owner-after-crash"
+          ),
+        "owner answer did not consume the recovered parked binding",
+      );
+      rpcB.emit({
+        method: "turn/completed",
+        params: {
+          threadId: "thread-delivery",
+          turn: {
+            id: "turn-owner-after-crash",
+            status: "completed",
+            items: [{
+              type: "agentMessage",
+              id: "owner-after-crash-final",
+              text: "continued after recovery",
+            }],
+          },
+        },
+      });
+      await waitFor(
+        () =>
+          bridgeB?.pendingCount === 0 &&
+          bridgeB.parkedContinuationCount === 0 &&
+          journalB.entries().length === 0,
+        "owner answer did not atomically clear the recovered source binding",
+      );
+      expect(postsAfterCrash).toEqual([
+        "codex-bridge-reply:delivery-owner-after-crash",
+      ]);
+      bridgeB.close();
+      await runB;
+      bridgeB = null;
+    } finally {
+      bridgeB?.close();
+      bridgeA?.close();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test.each(["replied", "failed", "waiting_owner"] as const)(
+    "cold waiting_owner WAL follows authoritative terminal %s instead of blind local restore",
+    async (authoritativeState) => {
+      const root = mkdtempSync(join(tmpdir(), `ap-codex-stale-waiting-${authoritativeState}-`));
+      let bridge: CodexAgentPartyBridge | null = null;
+      try {
+        const journal = new DeliveryRecoveryJournal(
+          join(root, "journal.json"),
+          "dev",
+          "codex",
+        );
+        const seeded = deliveryFrame(127, "parked before another holder settles", {
+          id: `delivery-stale-waiting-${authoritativeState}`,
+          target_name: "me",
+          work_id: "work-stale-waiting",
+          continuation_ref: "continuation-stale-waiting",
+        }) as unknown as DirectedDeliveryFrame;
+        journal.recordClaim(seeded.delivery, seeded.message);
+        journal.update(seeded.delivery.id, {
+          phase: "waiting_owner",
+          delivery: {
+            ...seeded.delivery,
+            state: "waiting_owner",
+            reply_seq: 8_127,
+            lease_until: null,
+          },
+          threadId: "thread-delivery",
+          turnId: "turn-stale-waiting",
+          replyBody: "waiting for owner",
+          replySeq: 8_127,
+        });
+
+        const rpc = new DeliveryRpcPeer();
+        const session = new CodexSessionController(rpc);
+        await session.request("thread/resume", { threadId: "thread-delivery" });
+        const conn = streamingConnection();
+        bridge = new CodexAgentPartyBridge({
+          channel: "dev",
+          connection: conn.connection,
+          session,
+          recoveryJournal: journal,
+          requireDeliveryRecovery: true,
+          leaseRenewIntervalMs: 60_000,
+          deliveryAckTimeoutMs: 1_000,
+          confirmDeliveryUpdate: async (update) => update.state,
+          postReply: async () => ({ seq: 1 }),
+        });
+        const run = bridge.run();
+        conn.push(welcomeDirectedFrame(0, "me") as ServerFrame);
+        await waitFor(
+          () => conn.sent.some((frame) =>
+            frame.type === "delivery_recover" &&
+            frame.delivery_id === seeded.delivery.id
+          ),
+          "waiting_owner recovery was not requested",
+        );
+        // A local waiting_owner snapshot is not enough to park anything before
+        // the Worker classifies the current source state.
+        expect(bridge.parkedContinuationCount).toBe(0);
+        const recovery = conn.sent.find((frame) =>
+          frame.type === "delivery_recover" &&
+          frame.delivery_id === seeded.delivery.id
+        ) as Extract<ClientFrame, { type: "delivery_recover" }>;
+        expect(recovery.replay_safe).toBeUndefined();
+        conn.push({
+          type: "delivery_recovery",
+          delivery_id: recovery.delivery_id,
+          request_id: recovery.request_id,
+          result: "terminal",
+          state: authoritativeState,
+          attempt: recovery.attempt,
+          lease_epoch: recovery.lease_epoch,
+        } as ServerFrame);
+
+        if (authoritativeState === "waiting_owner") {
+          await waitFor(
+            () => bridge?.parkedContinuationCount === 1,
+            "authoritative waiting_owner did not restore the parked binding",
+          );
+          expect(journal.get(seeded.delivery.id)?.phase).toBe("waiting_owner");
+          conn.push({
+            type: "delivery_state",
+            delivery: {
+              id: seeded.delivery.id,
+              message_seq: seeded.delivery.message_seq,
+              target_name: seeded.delivery.target_name,
+              state: "replied",
+              reply_seq: 8_128,
+              created_at: seeded.delivery.created_at,
+              updated_at: Date.now(),
+            },
+          } as ServerFrame);
+          await waitFor(
+            () =>
+              bridge?.parkedContinuationCount === 0 &&
+              journal.get(seeded.delivery.id) === null,
+            "unsolicited authoritative source terminal did not clear stale parked state",
+          );
+        } else {
+          await waitFor(
+            () => journal.get(seeded.delivery.id) === null,
+            `authoritative ${authoritativeState} did not clear stale waiting_owner WAL`,
+          );
+          expect(bridge.parkedContinuationCount).toBe(0);
+        }
+        bridge.close();
+        await run;
+        bridge = null;
+      } finally {
+        bridge?.close();
+        rmSync(root, { recursive: true, force: true });
+      }
+    },
+  );
+
+  test("cold recovery re-POSTs a response-lost reply with the same idempotency key and restores waiting_owner", async () => {
+    const root = mkdtempSync(join(tmpdir(), "ap-codex-response-lost-crash-"));
+    let bridgeA: CodexAgentPartyBridge | null = null;
+    let bridgeB: CodexAgentPartyBridge | null = null;
+    try {
+      const path = join(root, "journal.json");
+      const postKeys: string[] = [];
+      const journalA = new DeliveryRecoveryJournal(path, "dev", "codex");
+      const rpcA = new DeliveryRpcPeer();
+      rpcA.turnIds = ["turn-response-lost"];
+      const sessionA = new CodexSessionController(rpcA);
+      const connA = fakeConnection();
+      bridgeA = new CodexAgentPartyBridge({
+        channel: "dev",
+        connection: connA.connection,
+        session: sessionA,
+        recoveryJournal: journalA,
+        leaseRenewIntervalMs: 60_000,
+        retryDelayMs: 60_000,
+        confirmDeliveryUpdate: async (update) => update.state,
+        postReply: async ({ idempotencyKey }) => {
+          postKeys.push(idempotencyKey);
+          throw new Error("REST response lost after durable persistence");
+        },
+      });
+
+      await bridgeA.handleFrame(welcomeDirectedFrame(0, "me") as ServerFrame);
+      await sessionA.request("thread/start", {});
+      await bridgeA.handleFrame(deliveryFrame(122, "response lost before reply seq", {
+        id: "delivery-response-lost-crash",
+        target_name: "me",
+        work_id: "work-response-lost-crash",
+        continuation_ref: "continuation-response-lost-crash",
+        sender: { name: "alice", kind: "human" },
+      }) as ServerFrame);
+      rpcA.emit({
+        method: "turn/completed",
+        params: {
+          threadId: "thread-delivery",
+          turn: {
+            id: "turn-response-lost",
+            status: "completed",
+            items: [{
+              type: "agentMessage",
+              id: "response-lost-final",
+              text: "durably persisted but response was lost",
+            }],
+          },
+        },
+      });
+      await waitFor(
+        () =>
+          postKeys.length === 1 &&
+          journalA.get("delivery-response-lost-crash")?.replyBody !== null,
+        "first process did not retain replyBody after losing the REST response",
+      );
+      expect(journalA.get("delivery-response-lost-crash")).toMatchObject({
+        phase: "harness_accepted",
+        replyBody: "durably persisted but response was lost",
+        replySeq: null,
+        threadId: "thread-delivery",
+      });
+      bridgeA.close();
+      bridgeA = null;
+
+      const journalB = new DeliveryRecoveryJournal(path, "dev", "codex");
+      const rpcB = new DeliveryRpcPeer();
+      const sessionB = new CodexSessionController(rpcB);
+      await sessionB.request("thread/resume", { threadId: "thread-delivery" });
+      const connB = streamingConnection();
+      bridgeB = new CodexAgentPartyBridge({
+        channel: "dev",
+        connection: connB.connection,
+        session: sessionB,
+        recoveryJournal: journalB,
+        requireDeliveryRecovery: true,
+        leaseRenewIntervalMs: 60_000,
+        deliveryAckTimeoutMs: 1_000,
+        confirmDeliveryUpdate: async (update) =>
+          update.state === "replied" &&
+            update.delivery_id === "delivery-response-lost-crash"
+            ? "waiting_owner"
+            : update.state,
+        postReply: async ({ idempotencyKey }) => {
+          postKeys.push(idempotencyKey);
+          return { seq: 2_122 };
+        },
+      });
+      const runB = bridgeB.run();
+      connB.push(welcomeDirectedFrame(0, "me") as ServerFrame);
+      await waitFor(
+        () =>
+          connB.sent.some((frame) =>
+            frame.type === "delivery_recover" &&
+            frame.delivery_id === "delivery-response-lost-crash"
+          ),
+        "cold bridge did not reconcile the response-lost source",
+      );
+      const recovery = connB.sent.find((frame) =>
+        frame.type === "delivery_recover" &&
+        frame.delivery_id === "delivery-response-lost-crash"
+      ) as Extract<ClientFrame, { type: "delivery_recover" }>;
+      connB.push({
+        type: "delivery_recovery",
+        delivery_id: recovery.delivery_id,
+        request_id: recovery.request_id,
+        result: "terminal",
+        state: "waiting_owner",
+        attempt: recovery.attempt,
+        lease_epoch: recovery.lease_epoch,
+      } as ServerFrame);
+      await waitFor(
+        () =>
+          bridgeB?.pendingCount === 0 &&
+          bridgeB.parkedContinuationCount === 1 &&
+          journalB.get("delivery-response-lost-crash")?.phase === "waiting_owner",
+        "same-key re-POST did not reconstruct the waiting_owner binding",
+      );
+      expect(postKeys).toEqual([
+        "codex-bridge-reply:delivery-response-lost-crash",
+        "codex-bridge-reply:delivery-response-lost-crash",
+      ]);
+      expect(journalB.get("delivery-response-lost-crash")).toMatchObject({
+        phase: "waiting_owner",
+        replyBody: "durably persisted but response was lost",
+        replySeq: 2_122,
+        delivery: {
+          id: "delivery-response-lost-crash",
+          state: "waiting_owner",
+          reply_seq: 2_122,
+        },
+      });
+      bridgeB.close();
+      await runB;
+      bridgeB = null;
+    } finally {
+      bridgeB?.close();
+      bridgeA?.close();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("owner_answer atomically removes its journal and an in-flight source before a late waiting_owner ACK", async () => {
+    const root = mkdtempSync(join(tmpdir(), "ap-codex-owner-atomic-remove-"));
+    let bridge: CodexAgentPartyBridge | null = null;
+    try {
+      const journal = new DeliveryRecoveryJournal(
+        join(root, "journal.json"),
+        "dev",
+        "codex",
+      );
+      const rpc = new DeliveryRpcPeer();
+      rpc.turnIds = ["turn-atomic-source", "turn-atomic-owner"];
+      const session = new CodexSessionController(rpc);
+      const conn = fakeConnection();
+      let sourceAckRequested = false;
+      let resolveSourceAck!: (state: "waiting_owner") => void;
+      const sourceAck = new Promise<"waiting_owner">((resolve) => {
+        resolveSourceAck = resolve;
+      });
+      bridge = new CodexAgentPartyBridge({
+        channel: "dev",
+        connection: conn.connection,
+        session,
+        recoveryJournal: journal,
+        leaseRenewIntervalMs: 60_000,
+        confirmDeliveryUpdate: async (update) => {
+          if (
+            update.delivery_id === "delivery-atomic-source" &&
+            update.state === "replied"
+          ) {
+            sourceAckRequested = true;
+            return await sourceAck;
+          }
+          return update.state;
+        },
+        postReply: async ({ replyTo }) => ({ seq: 3_000 + replyTo }),
+      });
+
+      await bridge.handleFrame(welcomeDirectedFrame(0, "me") as ServerFrame);
+      await session.request("thread/start", {});
+      await bridge.handleFrame(deliveryFrame(123, "source ACK will arrive late", {
+        id: "delivery-atomic-source",
+        target_name: "me",
+        work_id: "work-atomic-remove",
+        continuation_ref: "continuation-atomic-remove",
+        sender: { name: "alice", kind: "human" },
+      }) as ServerFrame);
+      rpc.emit({
+        method: "turn/completed",
+        params: {
+          threadId: "thread-delivery",
+          turn: {
+            id: "turn-atomic-source",
+            status: "completed",
+            items: [{
+              type: "agentMessage",
+              id: "atomic-source-final",
+              text: "ask owner",
+            }],
+          },
+        },
+      });
+      await waitFor(
+        () =>
+          sourceAckRequested &&
+          journal.get("delivery-atomic-source")?.phase === "reply_posted",
+        "source did not reach its delayed waiting_owner ACK",
+      );
+
+      await bridge.handleFrame(ownerAnswerFrame({
+        seq: 124,
+        deliveryId: "delivery-atomic-owner",
+        sourceDeliveryId: "delivery-atomic-source",
+        sourceSeq: 123,
+        workId: "work-atomic-remove",
+        continuationRef: "continuation-atomic-remove",
+        requestSeq: 3_123,
+      }) as ServerFrame);
+      rpc.emit({
+        method: "turn/completed",
+        params: {
+          threadId: "thread-delivery",
+          turn: {
+            id: "turn-atomic-owner",
+            status: "completed",
+            items: [{
+              type: "agentMessage",
+              id: "atomic-owner-final",
+              text: "owner resolved",
+            }],
+          },
+        },
+      });
+      await waitFor(
+        () =>
+          bridge?.pendingCount === 1 &&
+          journal.get("delivery-atomic-source") === null &&
+          journal.get("delivery-atomic-owner") === null,
+        "owner answer did not atomically remove both durable obligations",
+      );
+      expect(journal.entries()).toHaveLength(0);
+      expect(bridge.parkedContinuationCount).toBe(0);
+
+      resolveSourceAck("waiting_owner");
+      await waitFor(
+        () => bridge?.pendingCount === 0,
+        "late source ACK left the source pending",
+      );
+      expect(bridge.parkedContinuationCount).toBe(0);
+      expect(journal.entries()).toHaveLength(0);
+    } finally {
+      bridge?.close();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("an ENOSPC during atomic owner/source removal retains pending state and retries without resurrection", async () => {
+    const root = mkdtempSync(join(tmpdir(), "ap-codex-owner-remove-enospc-"));
+    let bridge: CodexAgentPartyBridge | null = null;
+    try {
+      let insideAtomicRemoval = false;
+      let failAtomicRemoval = true;
+      let atomicRemovalFailures = 0;
+      const journal = new DeliveryRecoveryJournal(
+        join(root, "journal.json"),
+        "dev",
+        "codex",
+        {
+          persist: (commit) => {
+            if (insideAtomicRemoval && failAtomicRemoval) {
+              failAtomicRemoval = false;
+              atomicRemovalFailures += 1;
+              const error = new Error("atomic owner/source WAL is full") as NodeJS.ErrnoException;
+              error.code = "ENOSPC";
+              throw error;
+            }
+            commit();
+          },
+        },
+      );
+      const durableRemoveMany = journal.removeMany.bind(journal);
+      journal.removeMany = (deliveryIds) => {
+        insideAtomicRemoval = true;
+        try {
+          durableRemoveMany(deliveryIds);
+        } finally {
+          insideAtomicRemoval = false;
+        }
+      };
+
+      const rpc = new DeliveryRpcPeer();
+      rpc.turnIds = ["turn-enospc-source", "turn-enospc-owner"];
+      const session = new CodexSessionController(rpc);
+      const conn = fakeConnection();
+      let sourceAckRequested = false;
+      let resolveSourceAck!: (state: "waiting_owner") => void;
+      const sourceAck = new Promise<"waiting_owner">((resolve) => {
+        resolveSourceAck = resolve;
+      });
+      bridge = new CodexAgentPartyBridge({
+        channel: "dev",
+        connection: conn.connection,
+        session,
+        recoveryJournal: journal,
+        leaseRenewIntervalMs: 60_000,
+        retryDelayMs: 100,
+        confirmDeliveryUpdate: async (update) => {
+          if (
+            update.delivery_id === "delivery-enospc-source" &&
+            update.state === "replied"
+          ) {
+            sourceAckRequested = true;
+            return await sourceAck;
+          }
+          return update.state;
+        },
+        postReply: async ({ replyTo }) => ({ seq: 4_000 + replyTo }),
+      });
+
+      await bridge.handleFrame(welcomeDirectedFrame(0, "me") as ServerFrame);
+      await session.request("thread/start", {});
+      await bridge.handleFrame(deliveryFrame(125, "source survives atomic remove ENOSPC", {
+        id: "delivery-enospc-source",
+        target_name: "me",
+        work_id: "work-remove-enospc",
+        continuation_ref: "continuation-remove-enospc",
+        sender: { name: "alice", kind: "human" },
+      }) as ServerFrame);
+      rpc.emit({
+        method: "turn/completed",
+        params: {
+          threadId: "thread-delivery",
+          turn: {
+            id: "turn-enospc-source",
+            status: "completed",
+            items: [{
+              type: "agentMessage",
+              id: "enospc-source-final",
+              text: "owner required",
+            }],
+          },
+        },
+      });
+      await waitFor(
+        () =>
+          sourceAckRequested &&
+          journal.get("delivery-enospc-source")?.phase === "reply_posted",
+        "source did not reach the delayed ACK before ENOSPC",
+      );
+
+      await bridge.handleFrame(ownerAnswerFrame({
+        seq: 126,
+        deliveryId: "delivery-enospc-owner",
+        sourceDeliveryId: "delivery-enospc-source",
+        sourceSeq: 125,
+        workId: "work-remove-enospc",
+        continuationRef: "continuation-remove-enospc",
+        requestSeq: 4_125,
+      }) as ServerFrame);
+      rpc.emit({
+        method: "turn/completed",
+        params: {
+          threadId: "thread-delivery",
+          turn: {
+            id: "turn-enospc-owner",
+            status: "completed",
+            items: [{
+              type: "agentMessage",
+              id: "enospc-owner-final",
+              text: "owner resolved after WAL retry",
+            }],
+          },
+        },
+      });
+      await waitFor(
+        () => atomicRemovalFailures === 1,
+        "atomic owner/source removal did not hit the ENOSPC seam",
+      );
+      expect(bridge.pendingCount).toBe(2);
+      expect(journal.get("delivery-enospc-source")).not.toBeNull();
+      expect(journal.get("delivery-enospc-owner")).not.toBeNull();
+
+      await waitFor(
+        () =>
+          bridge?.pendingCount === 1 &&
+          journal.get("delivery-enospc-source") === null &&
+          journal.get("delivery-enospc-owner") === null,
+        "owner/source removal retry did not durably clear both entries",
+      );
+      expect(journal.entries()).toHaveLength(0);
+
+      resolveSourceAck("waiting_owner");
+      await waitFor(
+        () => bridge?.pendingCount === 0,
+        "late source ACK left a resurrected pending obligation",
+      );
+      expect(bridge.parkedContinuationCount).toBe(0);
+      expect(journal.entries()).toHaveLength(0);
+    } finally {
+      bridge?.close();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("waiting_owner parks the original Codex thread and owner_answer resumes that affinity", async () => {
+    const rpc = new DeliveryRpcPeer();
+    rpc.turnIds = ["turn-source", "turn-owner-answer"];
+    const session = new CodexSessionController(rpc);
+    const conn = fakeConnection();
+    const posts: Array<{ replyTo: number; idempotencyKey: string }> = [];
+    const bridge = new CodexAgentPartyBridge({
+      channel: "dev",
+      connection: conn.connection,
+      session,
+      leaseRenewIntervalMs: 60_000,
+      confirmDeliveryUpdate: async (update) => {
+        if (update.state === "replied" && update.delivery_id === "delivery-source") {
+          return "waiting_owner";
+        }
+        return update.state;
+      },
+      postReply: async ({ replyTo, idempotencyKey }) => {
+        posts.push({ replyTo, idempotencyKey });
+        return { seq: 80 + posts.length };
+      },
+    });
+
+    await bridge.handleFrame(welcomeDirectedFrame(0, "me") as ServerFrame);
+    await session.request("thread/start", {});
+    await bridge.handleFrame(deliveryFrame(18, "ask the owner", {
+      id: "delivery-source",
+      target_name: "me",
+      work_id: "work-affinity",
+      continuation_ref: "continuation-affinity",
+      sender: { name: "alice", kind: "human" },
+    }) as ServerFrame);
+    rpc.emit({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-delivery",
+        turn: {
+          id: "turn-source",
+          status: "completed",
+          items: [{ type: "agentMessage", id: "source-final", text: "waiting for owner" }],
+        },
+      },
+    });
+    await waitFor(
+      () => bridge.parkedContinuationCount === 1 && bridge.pendingCount === 0,
+      "source delivery was not parked on waiting_owner",
+    );
+    await expect(session.request("thread/fork", {
+      threadId: "thread-delivery",
+    })).rejects.toThrow("still pending or parked");
+    await expect(session.request("thread/rollback", {
+      threadId: "thread-delivery",
+      numTurns: 1,
+    })).rejects.toThrow("mutate the history");
+    await expect(session.request("thread/inject_items", {
+      threadId: "thread-delivery",
+      items: [],
+    })).rejects.toThrow("mutate the history");
+    expect(rpc.calls.filter((call) => call.method === "thread/fork")).toHaveLength(0);
+    expect(rpc.calls.filter((call) => call.method === "thread/rollback")).toHaveLength(0);
+    expect(rpc.calls.filter((call) => call.method === "thread/inject_items")).toHaveLength(0);
+
+    const ownerFrame = ownerAnswerFrame({
+      seq: 19,
+      deliveryId: "delivery-owner-answer",
+      sourceDeliveryId: "delivery-source",
+      sourceSeq: 18,
+      workId: "work-affinity",
+      continuationRef: "continuation-affinity",
+      requestSeq: 1_018,
+    });
+    await bridge.handleFrame(ownerFrame as ServerFrame);
+    expect(
+      rpc.calls
+        .filter((call) => call.method === "turn/start")
+        .at(-1)?.params,
+    ).toMatchObject({
+      threadId: "thread-delivery",
+      clientUserMessageId: "agentparty:delivery-owner-answer",
+      responsesapiClientMetadata: {
+        work_id: "work-affinity",
+        continuation_ref: "continuation-affinity",
+      },
+    });
+
+    rpc.emit({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-delivery",
+        turn: {
+          id: "turn-owner-answer",
+          status: "completed",
+          items: [{ type: "agentMessage", id: "owner-final", text: "continued answer" }],
+        },
+      },
+    });
+    await waitFor(
+      () => bridge.pendingCount === 0 && bridge.parkedContinuationCount === 0,
+      "owner answer did not settle the parked continuation",
+    );
+    expect(posts).toEqual([
+      { replyTo: 18, idempotencyKey: "codex-bridge-reply:delivery-source" },
+      { replyTo: 19, idempotencyKey: "codex-bridge-reply:delivery-owner-answer" },
+    ]);
+    bridge.close();
+  });
+
+  test("a new bridge process reconstructs owner_answer affinity from exact recovered thread history", async () => {
+    const rpcA = new DeliveryRpcPeer();
+    rpcA.turnIds = ["turn-restart-source"];
+    const sessionA = new CodexSessionController(rpcA);
+    const connA = fakeConnection();
+    const bridgeA = new CodexAgentPartyBridge({
+      channel: "dev",
+      connection: connA.connection,
+      session: sessionA,
+      leaseRenewIntervalMs: 60_000,
+      confirmDeliveryUpdate: async (update) =>
+        update.state === "replied" && update.delivery_id === "delivery-restart-source"
+          ? "waiting_owner"
+          : update.state,
+      postReply: async () => ({ seq: 2_022 }),
+    });
+    await bridgeA.handleFrame(welcomeDirectedFrame(0, "me") as ServerFrame);
+    await sessionA.request("thread/start", {});
+    await bridgeA.handleFrame(deliveryFrame(22, "ask owner before restart", {
+      id: "delivery-restart-source",
+      target_name: "me",
+      work_id: "work-restart",
+      continuation_ref: "continuation-restart",
+      sender: { name: "alice", kind: "human" },
+    }) as ServerFrame);
+    rpcA.emit({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-delivery",
+        turn: {
+          id: "turn-restart-source",
+          status: "completed",
+          items: [{
+            type: "agentMessage",
+            id: "source-restart-final",
+            text: "waiting for owner",
+          }],
+        },
+      },
+    });
+    await waitFor(
+      () => bridgeA.parkedContinuationCount === 1,
+      "source continuation was not parked before restart",
+    );
+    bridgeA.close();
+
+    const rpcB = new DeliveryRpcPeer();
+    rpcB.turnIds = ["turn-after-restart-owner"];
+    rpcB.restoredTurns = [{
+      id: "turn-restart-source",
+      status: "completed",
+      items: [{
+        type: "userMessage",
+        id: "source-restart-user",
+        clientId: "agentparty:delivery-restart-source",
+      }],
+    }];
+    const sessionB = new CodexSessionController(rpcB);
+    await sessionB.request("thread/resume", { threadId: "thread-delivery" });
+    const connB = fakeConnection();
+    const bridgeB = new CodexAgentPartyBridge({
+      channel: "dev",
+      connection: connB.connection,
+      session: sessionB,
+      leaseRenewIntervalMs: 60_000,
+      confirmDeliveryUpdate: async (update) => update.state,
+      postReply: async () => ({ seq: 2_023 }),
+    });
+    await bridgeB.handleFrame(welcomeDirectedFrame(0, "me") as ServerFrame);
+    await bridgeB.handleFrame(ownerAnswerFrame({
+      seq: 23,
+      deliveryId: "delivery-restart-owner",
+      sourceDeliveryId: "delivery-restart-source",
+      sourceSeq: 22,
+      workId: "work-restart",
+      continuationRef: "continuation-restart",
+      requestSeq: 2_022,
+    }) as ServerFrame);
+
+    expect(
+      rpcB.calls
+        .filter((call) => call.method === "turn/start")
+        .at(-1)?.params,
+    ).toMatchObject({
+      threadId: "thread-delivery",
+      clientUserMessageId: "agentparty:delivery-restart-owner",
+      responsesapiClientMetadata: {
+        work_id: "work-restart",
+        continuation_ref: "continuation-restart",
+      },
+    });
+    bridgeB.close();
+  });
+
+  test("recovered owner_answer affinity fails closed when history is absent or belongs to a prior thread", async () => {
+    for (const priorThreadOnly of [false, true]) {
+      const rpc = new DeliveryRpcPeer();
+      const session = new CodexSessionController(rpc);
+      if (priorThreadOnly) {
+        rpc.restoredTurns = [{
+          id: "source-prior-turn",
+          status: "completed",
+          items: [{
+            type: "userMessage",
+            id: "source-prior-user",
+            clientId: "agentparty:delivery-restart-source",
+          }],
+        }];
+        await session.request("thread/resume", { threadId: "thread-delivery" });
+        rpc.threadId = "thread-other";
+        rpc.restoredTurns = [];
+      }
+      await session.request("thread/resume", {
+        threadId: priorThreadOnly ? "thread-other" : "thread-delivery",
+      });
+      const conn = fakeConnection();
+      const failed: string[] = [];
+      const bridge = new CodexAgentPartyBridge({
+        channel: "dev",
+        connection: conn.connection,
+        session,
+        leaseRenewIntervalMs: 60_000,
+        confirmDeliveryUpdate: async (update) => {
+          if (update.state === "failed") failed.push(update.error ?? "");
+          return update.state;
+        },
+        postReply: async () => ({ seq: 1 }),
+      });
+      await bridge.handleFrame(welcomeDirectedFrame(0, "me") as ServerFrame);
+      await bridge.handleFrame(ownerAnswerFrame({
+        seq: priorThreadOnly ? 25 : 24,
+        deliveryId: priorThreadOnly
+          ? "delivery-owner-prior-thread"
+          : "delivery-owner-missing-history",
+        sourceDeliveryId: "delivery-restart-source",
+        sourceSeq: 22,
+        workId: "work-restart",
+        continuationRef: "continuation-restart",
+        requestSeq: 2_022,
+      }) as ServerFrame);
+
+      expect(failed).toHaveLength(1);
+      expect(failed[0]).toContain("no matching parked");
+      expect(rpc.calls.filter((call) => call.method === "turn/start")).toHaveLength(0);
+      bridge.close();
+    }
+  });
+
+  test("a late source waiting_owner ACK cannot resurrect a completed owner continuation", async () => {
+    const rpc = new DeliveryRpcPeer();
+    rpc.turnIds = ["turn-source-late", "turn-owner-fast"];
+    const session = new CodexSessionController(rpc);
+    const conn = fakeConnection();
+    let sourceAckRequested = false;
+    let resolveSourceAck!: (state: "waiting_owner") => void;
+    const sourceAck = new Promise<"waiting_owner">((resolve) => {
+      resolveSourceAck = resolve;
+    });
+    const bridge = new CodexAgentPartyBridge({
+      channel: "dev",
+      connection: conn.connection,
+      session,
+      leaseRenewIntervalMs: 60_000,
+      confirmDeliveryUpdate: async (update) => {
+        if (update.delivery_id === "delivery-late-source" && update.state === "replied") {
+          sourceAckRequested = true;
+          return await sourceAck;
+        }
+        return update.state;
+      },
+      postReply: async ({ replyTo }) => ({ seq: 100 + replyTo }),
+    });
+
+    await bridge.handleFrame(welcomeDirectedFrame(0, "me") as ServerFrame);
+    await session.request("thread/start", {});
+    await bridge.handleFrame(deliveryFrame(20, "source waits on owner", {
+      id: "delivery-late-source",
+      target_name: "me",
+      work_id: "work-late",
+      continuation_ref: "continuation-late",
+      sender: { name: "alice", kind: "human" },
+    }) as ServerFrame);
+    rpc.emit({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-delivery",
+        turn: {
+          id: "turn-source-late",
+          status: "completed",
+          items: [{ type: "agentMessage", id: "source-late-final", text: "owner needed" }],
+        },
+      },
+    });
+    await waitFor(() => sourceAckRequested, "source replied ACK was not delayed");
+
+    const ownerFrame = ownerAnswerFrame({
+      seq: 21,
+      deliveryId: "delivery-owner-fast",
+      sourceDeliveryId: "delivery-late-source",
+      sourceSeq: 20,
+      workId: "work-late",
+      continuationRef: "continuation-late",
+      requestSeq: 1_020,
+    });
+    await bridge.handleFrame(ownerFrame as ServerFrame);
+    rpc.emit({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-delivery",
+        turn: {
+          id: "turn-owner-fast",
+          status: "completed",
+          items: [{ type: "agentMessage", id: "owner-fast-final", text: "done" }],
+        },
+      },
+    });
+    await waitFor(
+      () => bridge.pendingCount === 1 && bridge.parkedContinuationCount === 0,
+      "owner answer did not finish before the delayed source ACK",
+    );
+
+    resolveSourceAck("waiting_owner");
+    await waitFor(
+      () => bridge.pendingCount === 0 && bridge.parkedContinuationCount === 0,
+      "late source ACK resurrected a completed parked continuation",
+    );
+    await expect(session.request("thread/start", {})).resolves.toMatchObject({
+      thread: { id: "thread-delivery" },
+    });
+    bridge.close();
+  });
+
+  test("keeps a failed delivery unsettled until Worker confirms the failed state", async () => {
+    const rpc = new DeliveryRpcPeer();
+    const session = new CodexSessionController(rpc);
+    const conn = fakeConnection();
+    let failedUpdates = 0;
+    const bridge = new CodexAgentPartyBridge({
+      channel: "dev",
+      connection: conn.connection,
+      session,
+      leaseRenewIntervalMs: 60_000,
+      confirmDeliveryUpdate: async (update) => {
+        if (update.state !== "failed") return;
+        failedUpdates += 1;
+        if (failedUpdates === 1) throw new Error("failed ACK was lost");
+      },
+      postReply: async () => ({ seq: 1 }),
+    });
+    await bridge.handleFrame(welcomeDirectedFrame(0, "me") as ServerFrame);
+    const incoming = deliveryFrame(16, "terminal failure", {
+      id: "delivery-16",
+      target_name: "me",
+      sender: { name: "alice", kind: "human" },
+    }) as ServerFrame;
+    await bridge.handleFrame(incoming);
+    await session.request("thread/start", {});
+    rpc.emit({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-delivery",
+        turn: {
+          id: "turn-delivery",
+          status: "failed",
+          items: [],
+        },
+      },
+    });
+    await waitFor(() => failedUpdates === 1, "first failed update was not attempted");
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(bridge.pendingCount).toBe(1);
+
+    await bridge.handleFrame(incoming);
+    expect(failedUpdates).toBe(2);
+    expect(bridge.pendingCount).toBe(0);
+    bridge.close();
+  });
+
+  test("retries failed_pending WAL after ENOSPC before sending one failed update", async () => {
+    const root = mkdtempSync(join(tmpdir(), "ap-codex-failed-wal-"));
+    let bridge: CodexAgentPartyBridge | null = null;
+    try {
+      let failNextCommit = false;
+      let walFailures = 0;
+      const journal = new DeliveryRecoveryJournal(
+        join(root, "journal.json"),
+        "dev",
+        "codex",
+        {
+          persist: (commit) => {
+            if (failNextCommit) {
+              failNextCommit = false;
+              walFailures += 1;
+              const error = new Error("failed_pending WAL is full") as NodeJS.ErrnoException;
+              error.code = "ENOSPC";
+              throw error;
+            }
+            commit();
+          },
+        },
+      );
+      const rpc = new DeliveryRpcPeer();
+      const session = new CodexSessionController(rpc);
+      const conn = fakeConnection();
+      const failedUpdates: string[] = [];
+      bridge = new CodexAgentPartyBridge({
+        channel: "dev",
+        connection: conn.connection,
+        session,
+        recoveryJournal: journal,
+        leaseRenewIntervalMs: 60_000,
+        retryDelayMs: 100,
+        confirmDeliveryUpdate: async (update) => {
+          if (update.state === "failed") failedUpdates.push(update.error ?? "");
+          return update.state;
+        },
+        postReply: async () => ({ seq: 1 }),
+      });
+
+      await bridge.handleFrame(welcomeDirectedFrame(0, "me") as ServerFrame);
+      await bridge.handleFrame(deliveryFrame(119, "fail after durable terminal WAL", {
+        id: "delivery-failed-wal",
+        target_name: "me",
+        sender: { name: "alice", kind: "human" },
+      }) as ServerFrame);
+      await session.request("thread/start", {});
+      failNextCommit = true;
+      rpc.emit({
+        method: "turn/completed",
+        params: {
+          threadId: "thread-delivery",
+          turn: {
+            id: "turn-delivery",
+            status: "failed",
+            items: [],
+          },
+        },
+      });
+
+      await waitFor(() => walFailures === 1, "failed_pending WAL fault was not injected");
+      expect(failedUpdates).toHaveLength(0);
+      expect(bridge.pendingCount).toBe(1);
+      expect(journal.get("delivery-failed-wal")).toMatchObject({
+        phase: "harness_accepted",
+        terminalError: null,
+      });
+
+      await waitFor(
+        () => bridge?.pendingCount === 0,
+        "failed_pending WAL retry left the delivery permanently settling",
+      );
+      expect(failedUpdates).toHaveLength(1);
+      expect(failedUpdates[0]).toContain("turn-delivery ended with failed");
+      expect(journal.get("delivery-failed-wal")).toBeNull();
+    } finally {
+      bridge?.close();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/cli/test/codex-app-server-rpc.test.ts
+++ b/cli/test/codex-app-server-rpc.test.ts
@@ -1,0 +1,1307 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { spawn } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  CodexRpcDisconnectedError,
+  CodexRpcClient,
+  CodexSessionController,
+  type CodexFrontendRecovery,
+  type CodexRpcPeer,
+  type CodexTurn,
+  type JsonRpcId,
+  type JsonRpcNotification,
+  type JsonRpcRequest,
+  type JsonRpcResponse,
+} from "../src/codex-app-server-bridge";
+import type { CodexTurnArbiter } from "../src/codex-turn-arbiter";
+
+const fixture = join(import.meta.dir, "fixtures", "mock-codex-app-server.ts");
+
+let temp: string;
+let clients: CodexRpcClient[];
+
+beforeEach(() => {
+  temp = mkdtempSync(join(tmpdir(), "ap-codex-rpc-"));
+  clients = [];
+});
+
+afterEach(() => {
+  for (const client of clients) client.close();
+  rmSync(temp, { recursive: true, force: true });
+});
+
+async function waitFor(
+  predicate: () => boolean,
+  message: string,
+  timeoutMs = 5_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error(message);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: unknown) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+interface RpcCall {
+  method: string;
+  params?: unknown;
+  generation: number;
+}
+
+type RpcResponder = (params: unknown) => unknown | Promise<unknown>;
+
+class ScriptedCodexRpc implements CodexRpcPeer {
+  readonly initializeResult = {
+    userAgent: "scripted-codex-app-server/0.144.4",
+    platformFamily: "unix",
+  };
+  readonly calls: RpcCall[] = [];
+  connected = true;
+  connectionGeneration = 1;
+  startCalls = 0;
+  private readonly responders = new Map<string, RpcResponder[]>();
+  private readonly reconnects = new Set<(generation: number) => void | Promise<void>>();
+  private readonly disconnects = new Set<(generation: number) => void>();
+  private readonly messages =
+    new Set<(message: JsonRpcRequest | JsonRpcNotification) => void | Promise<void>>();
+
+  queue(method: string, responder: RpcResponder | unknown): void {
+    const responses = this.responders.get(method) ?? [];
+    responses.push(
+      typeof responder === "function"
+        ? responder as RpcResponder
+        : () => responder,
+    );
+    this.responders.set(method, responses);
+  }
+
+  async start(): Promise<void> {
+    this.startCalls += 1;
+    if (this.connected) return;
+    this.connected = true;
+    this.connectionGeneration += 1;
+    for (const listener of this.reconnects) {
+      void Promise.resolve(listener(this.connectionGeneration)).catch(() => {});
+    }
+  }
+
+  async request(method: string, params?: unknown): Promise<unknown> {
+    return await this.dispatch(method, params);
+  }
+
+  async requestConnected(
+    method: string,
+    params?: unknown,
+    expectedGeneration?: number,
+  ): Promise<unknown> {
+    if (!this.connected || (
+      expectedGeneration !== undefined &&
+      expectedGeneration !== this.connectionGeneration
+    )) {
+      throw new CodexRpcDisconnectedError(
+        "disconnected before scripted request write",
+        { requestWritten: false },
+      );
+    }
+    const generation = this.connectionGeneration;
+    const result = await this.dispatch(method, params);
+    if (
+      expectedGeneration !== undefined &&
+      (!this.connected || generation !== this.connectionGeneration)
+    ) {
+      throw new CodexRpcDisconnectedError("scripted request lost its backend generation");
+    }
+    return result;
+  }
+
+  async notify(_method: string, _params?: unknown): Promise<void> {}
+
+  respond(
+    _id: JsonRpcId,
+    _result?: unknown,
+    _error?: JsonRpcResponse["error"],
+  ): void {}
+
+  onMessage(
+    listener: (message: JsonRpcRequest | JsonRpcNotification) => void | Promise<void>,
+  ): () => void {
+    this.messages.add(listener);
+    return () => this.messages.delete(listener);
+  }
+
+  onReconnect(listener: (generation: number) => void | Promise<void>): () => void {
+    this.reconnects.add(listener);
+    return () => this.reconnects.delete(listener);
+  }
+
+  onDisconnect(listener: (generation: number) => void): () => void {
+    this.disconnects.add(listener);
+    return () => this.disconnects.delete(listener);
+  }
+
+  disconnect(): void {
+    if (!this.connected) return;
+    this.connected = false;
+    for (const listener of this.disconnects) listener(this.connectionGeneration);
+  }
+
+  async emit(message: JsonRpcRequest | JsonRpcNotification): Promise<void> {
+    await Promise.all([...this.messages].map(async (listener) => await listener(message)));
+  }
+
+  reconnect(): Promise<void> {
+    this.connected = true;
+    this.connectionGeneration += 1;
+    return Promise.all(
+      [...this.reconnects].map(async (listener) => await listener(this.connectionGeneration)),
+    ).then(() => {});
+  }
+
+  private async dispatch(method: string, params?: unknown): Promise<unknown> {
+    this.calls.push({
+      method,
+      generation: this.connectionGeneration,
+      ...(params === undefined ? {} : { params }),
+    });
+    const responses = this.responders.get(method);
+    const responder = responses?.shift();
+    if (!responder) throw new Error(`unexpected RPC call: ${method}`);
+    return await responder(params);
+  }
+}
+
+function idleThread(id: string): {
+  thread: {
+    id: string;
+    status: { type: "idle" };
+    turns: [];
+  };
+} {
+  return {
+    thread: {
+      id,
+      status: { type: "idle" },
+      turns: [],
+    },
+  };
+}
+
+describe("Codex app-server stdio JSON-RPC and reconnect recovery", () => {
+  for (const method of ["thread/start", "thread/resume"] as const) {
+    test(`${method} serializes a concurrent submit behind the thread switch`, async () => {
+      const rpc = new ScriptedCodexRpc();
+      const switchResponse = deferred<ReturnType<typeof idleThread>>();
+      rpc.queue("thread/start", idleThread("thread-old"));
+      rpc.queue(method, () => switchResponse.promise);
+      rpc.queue("turn/start", (params: unknown) => {
+        const threadId = (params as { threadId?: unknown }).threadId;
+        return { turn: { id: `turn-for-${String(threadId)}` } };
+      });
+      const session = new CodexSessionController(rpc);
+
+      await session.start();
+      await session.request("thread/start", {});
+      expect(session.activeThreadId).toBe("thread-old");
+
+      const switching = session.request(
+        method,
+        method === "thread/resume" ? { threadId: "thread-new" } : {},
+      );
+      const expectedSwitchCalls = method === "thread/start" ? 2 : 1;
+      await waitFor(
+        () => rpc.calls.filter((call) => call.method === method).length === expectedSwitchCalls,
+        `${method} did not reach the backend`,
+      );
+
+      let submitSettled = false;
+      const submitted = session.submit({
+        text: "must use the replacement thread",
+        clientUserMessageId: `agentparty:${method}:concurrent`,
+      }).finally(() => {
+        submitSettled = true;
+      });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(rpc.calls.filter((call) => call.method === "turn/start")).toHaveLength(0);
+      expect(submitSettled).toBe(false);
+
+      switchResponse.resolve(idleThread("thread-new"));
+      await switching;
+      expect(session.activeThreadId).toBe("thread-new");
+      expect(await submitted).toEqual({
+        kind: "started",
+        turnId: "turn-for-thread-new",
+      });
+      expect(rpc.calls.filter((call) => call.method === "turn/start")).toEqual([
+        expect.objectContaining({
+          params: expect.objectContaining({
+            threadId: "thread-new",
+            clientUserMessageId: `agentparty:${method}:concurrent`,
+          }),
+        }),
+      ]);
+    });
+  }
+
+  for (
+    const method of [
+      "turn/start",
+      "turn/steer",
+      "turn/interrupt",
+      "review/start",
+      "thread/compact/start",
+      "thread/shellCommand",
+    ] as const
+  ) {
+    test(`${method} cannot overtake an in-flight thread switch`, async () => {
+      const rpc = new ScriptedCodexRpc();
+      const switchResponse = deferred<ReturnType<typeof idleThread>>();
+      rpc.queue("thread/start", idleThread("thread-old"));
+      rpc.queue("thread/resume", () => switchResponse.promise);
+      const session = new CodexSessionController(rpc);
+
+      await session.start();
+      await session.request("thread/start", {});
+      const switching = session.request("thread/resume", { threadId: "thread-new" });
+      await waitFor(
+        () => rpc.calls.some((call) => call.method === "thread/resume"),
+        "thread switch did not reach the backend",
+      );
+      const mutation = session.request(method, {
+        threadId: "thread-old",
+        ...(method === "turn/steer" ? { expectedTurnId: "turn-old" } : {}),
+        ...(method === "review/start" ? { delivery: "detached" } : {}),
+      });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(rpc.calls.filter((call) => call.method === method)).toHaveLength(0);
+
+      switchResponse.resolve(idleThread("thread-new"));
+      await switching;
+      await expect(mutation).rejects.toThrow(`inactive thread thread-old`);
+      expect(rpc.calls.filter((call) => call.method === method)).toHaveLength(0);
+    });
+  }
+
+  test("a pre-thread-start disconnect emits a safe restart only after cancelling the old request", async () => {
+    const rpc = new ScriptedCodexRpc();
+    const recoveries: CodexFrontendRecovery[] = [];
+    const session = new CodexSessionController(rpc);
+    session.onFrontendRecovery((event) => {
+      recoveries.push(event);
+    });
+
+    rpc.disconnect();
+    const starting = session.request("thread/start", {
+      prompt: "the TUI positional prompt is still local",
+    });
+    await expect(starting).rejects.toThrow(
+      "disconnected before the initial thread/start write",
+    );
+    await waitFor(
+      () => recoveries.length === 1,
+      "proven-not-written recovery was not published",
+    );
+
+    expect(rpc.calls.filter((call) => call.method === "thread/start")).toHaveLength(0);
+    expect(recoveries).toEqual([{
+      disposition: "restart",
+      threadId: null,
+      generation: 2,
+    }]);
+  });
+
+  test("the transport requestWritten marker is authoritative for safe initial replay", async () => {
+    const rpc = new ScriptedCodexRpc();
+    const recoveries: CodexFrontendRecovery[] = [];
+    rpc.queue(
+      "thread/start",
+      () => {
+        throw new CodexRpcDisconnectedError(
+          "scripted disconnect before write",
+          { requestWritten: false },
+        );
+      },
+    );
+    const session = new CodexSessionController(rpc);
+    session.onFrontendRecovery((event) => {
+      recoveries.push(event);
+    });
+
+    await expect(session.request("thread/start", {})).rejects.toThrow(
+      "disconnected before the initial thread/start write",
+    );
+    rpc.disconnect();
+    await rpc.reconnect();
+
+    expect(rpc.calls.filter((call) => call.method === "thread/start")).toHaveLength(1);
+    expect(recoveries).toEqual([{
+      disposition: "restart",
+      threadId: null,
+      generation: 2,
+    }]);
+  });
+
+  test("an after-write initial thread/start disconnect is terminal-unknown and never replayed", async () => {
+    const rpc = new ScriptedCodexRpc();
+    const startResponse = deferred<ReturnType<typeof idleThread>>();
+    const recoveries: CodexFrontendRecovery[] = [];
+    rpc.queue("thread/start", () => startResponse.promise);
+    const session = new CodexSessionController(rpc);
+    session.onFrontendRecovery((event) => {
+      recoveries.push(event);
+    });
+
+    const starting = session.request("thread/start", { prompt: "run once" });
+    await waitFor(
+      () => rpc.calls.some((call) => call.method === "thread/start"),
+      "initial thread/start did not cross the scripted transport",
+    );
+    rpc.disconnect();
+    startResponse.reject(new CodexRpcDisconnectedError("lost after write"));
+    await expect(starting).rejects.toBeInstanceOf(CodexRpcDisconnectedError);
+    await rpc.reconnect();
+
+    expect(rpc.calls.filter((call) => call.method === "thread/start")).toHaveLength(1);
+    expect(recoveries).toEqual([{
+      disposition: "unknown",
+      threadId: null,
+      generation: 2,
+      reason:
+        "Codex backend disconnected after the initial thread/start write; " +
+        "its outcome is unknown, so the initial prompt will not be replayed",
+    }]);
+  });
+
+  test("a created bootstrap thread replays its prompt without creating the thread twice", async () => {
+    const rpc = new ScriptedCodexRpc();
+    const recoveries: CodexFrontendRecovery[] = [];
+    rpc.queue("thread/start", idleThread("thread-bootstrap"));
+    rpc.queue("thread/resume", idleThread("thread-bootstrap"));
+    rpc.queue("thread/read", idleThread("thread-bootstrap"));
+    const session = new CodexSessionController(rpc);
+    session.onFrontendRecovery((event) => {
+      recoveries.push(event);
+    });
+
+    await session.request("thread/start", {});
+    rpc.disconnect();
+    await rpc.reconnect();
+
+    expect(rpc.calls.filter((call) => call.method === "thread/start")).toHaveLength(1);
+    expect(recoveries).toEqual([{
+      disposition: "restart_thread_with_prompt",
+      threadId: "thread-bootstrap",
+      generation: 2,
+    }]);
+  });
+
+  test("bootstrap prompt stays ahead of queued AgentParty input across same-thread read and resume", async () => {
+    const rpc = new ScriptedCodexRpc();
+    rpc.queue("thread/start", idleThread("thread-bootstrap-order"));
+    rpc.queue("thread/read", idleThread("thread-bootstrap-order"));
+    rpc.queue("thread/resume", idleThread("thread-bootstrap-order"));
+    rpc.queue("turn/start", {
+      turn: { id: "turn-bootstrap-order", status: "inProgress", items: [] },
+    });
+    rpc.queue("turn/steer", { turnId: "turn-bootstrap-order" });
+    const session = new CodexSessionController(rpc, {
+      expectBootstrapPrompt: true,
+    });
+
+    await session.request("thread/start", {});
+    expect(await session.submit({
+      text: "recovered AgentParty delivery",
+      clientUserMessageId: "agentparty:bootstrap-order",
+    })).toMatchObject({ kind: "queued", reason: "unknown" });
+    await session.request("thread/read", {
+      threadId: "thread-bootstrap-order",
+      includeTurns: true,
+    });
+    await session.request("thread/resume", {
+      threadId: "thread-bootstrap-order",
+    });
+    expect(
+      rpc.calls.filter((call) =>
+        call.method === "turn/start" || call.method === "turn/steer"
+      ),
+    ).toHaveLength(0);
+
+    await session.request("turn/start", {
+      threadId: "thread-bootstrap-order",
+      clientUserMessageId: null,
+      input: [{
+        type: "text",
+        text: "the user's initial prompt",
+        text_elements: [],
+      }],
+    });
+    const writes = rpc.calls.filter((call) =>
+      call.method === "turn/start" || call.method === "turn/steer"
+    );
+    expect(writes.map((call) => call.method)).toEqual(["turn/start", "turn/steer"]);
+    expect(writes[1]!.params).toMatchObject({
+      threadId: "thread-bootstrap-order",
+      expectedTurnId: "turn-bootstrap-order",
+      clientUserMessageId: "agentparty:bootstrap-order",
+    });
+  });
+
+  test("initial prompt replay requires the turn/start transport to prove not-written", async () => {
+    const rpc = new ScriptedCodexRpc();
+    const recoveries: CodexFrontendRecovery[] = [];
+    const initialInput = [{
+      type: "text",
+      text: "WIRE_PROMPT_746",
+      text_elements: [],
+    }];
+    rpc.queue("thread/start", idleThread("thread-bootstrap"));
+    rpc.queue("turn/start", () => {
+      throw new CodexRpcDisconnectedError(
+        "scripted initial turn disconnect before write",
+        { requestWritten: false },
+      );
+    });
+    rpc.queue("thread/resume", idleThread("thread-bootstrap"));
+    rpc.queue("thread/read", idleThread("thread-bootstrap"));
+    const session = new CodexSessionController(rpc);
+    session.onFrontendRecovery((event) => {
+      recoveries.push(event);
+    });
+
+    await session.request("thread/start", {});
+    await expect(session.request("turn/start", {
+      threadId: "thread-bootstrap",
+      clientUserMessageId: null,
+      input: initialInput,
+    })).rejects.toThrow("disconnected before the initial turn/start write");
+    rpc.disconnect();
+    await rpc.reconnect();
+
+    expect(rpc.calls.filter((call) => call.method === "turn/start")).toHaveLength(1);
+    expect(recoveries).toEqual([{
+      disposition: "restart_thread_with_prompt",
+      threadId: "thread-bootstrap",
+      generation: 2,
+      initialInput,
+    }]);
+  });
+
+  test("an after-write initial prompt is unknown unless full history positively matches it", async () => {
+    for (const historyMatches of [false, true]) {
+      const rpc = new ScriptedCodexRpc();
+      const turnResponse = deferred<unknown>();
+      const recoveries: CodexFrontendRecovery[] = [];
+      const initialInput = [{
+        type: "text",
+        text: "WIRE_PROMPT_746",
+        text_elements: [],
+      }];
+      rpc.queue("thread/start", idleThread("thread-bootstrap"));
+      rpc.queue("turn/start", () => turnResponse.promise);
+      rpc.queue("thread/resume", idleThread("thread-bootstrap"));
+      rpc.queue("thread/read", historyMatches
+        ? {
+          thread: {
+            id: "thread-bootstrap",
+            status: { type: "active" },
+            turns: [{
+              id: "turn-bootstrap",
+              status: "inProgress",
+              items: [{
+                type: "userMessage",
+                id: "user-bootstrap",
+                clientId: null,
+                content: initialInput,
+              }],
+            }],
+          },
+        }
+        : idleThread("thread-bootstrap"));
+      const session = new CodexSessionController(rpc);
+      session.onFrontendRecovery((event) => {
+        recoveries.push(event);
+      });
+
+      await session.request("thread/start", {});
+      const starting = session.request("turn/start", {
+        threadId: "thread-bootstrap",
+        clientUserMessageId: null,
+        input: initialInput,
+      });
+      await waitFor(
+        () => rpc.calls.some((call) => call.method === "turn/start"),
+        "initial prompt did not cross the scripted transport",
+      );
+      rpc.disconnect();
+      turnResponse.reject(new CodexRpcDisconnectedError("lost after initial prompt write"));
+      await expect(starting).rejects.toBeInstanceOf(CodexRpcDisconnectedError);
+      await rpc.reconnect();
+
+      expect(rpc.calls.filter((call) => call.method === "turn/start")).toHaveLength(1);
+      if (historyMatches) {
+        expect(recoveries).toEqual([{
+          disposition: "resume",
+          threadId: "thread-bootstrap",
+          generation: 2,
+        }]);
+      } else {
+        expect(recoveries).toEqual([{
+          disposition: "unknown",
+          threadId: "thread-bootstrap",
+          generation: 2,
+          reason:
+            "Codex backend disconnected after the initial turn/start write; " +
+            "its outcome is unknown, so the initial prompt will not be replayed",
+        }]);
+      }
+    }
+  });
+
+  test("an accepted initial turn resumes even if the backend drops before the TUI sees its response", async () => {
+    const rpc = new ScriptedCodexRpc();
+    const recoveries: CodexFrontendRecovery[] = [];
+    const initialInput = [{
+      type: "text",
+      text: "WIRE_PROMPT_746",
+      text_elements: [],
+    }];
+    rpc.queue("thread/start", idleThread("thread-bootstrap"));
+    rpc.queue("turn/start", {
+      turn: {
+        id: "turn-bootstrap",
+        status: "inProgress",
+        items: [{
+          type: "userMessage",
+          id: "user-bootstrap",
+          clientId: null,
+          content: initialInput,
+        }],
+      },
+    });
+    rpc.queue("thread/resume", idleThread("thread-bootstrap"));
+    rpc.queue("thread/read", {
+      thread: {
+        id: "thread-bootstrap",
+        status: { type: "active" },
+        turns: [{
+          id: "turn-bootstrap",
+          status: "inProgress",
+          items: [{
+            type: "userMessage",
+            id: "user-bootstrap",
+            clientId: null,
+            content: initialInput,
+          }],
+        }],
+      },
+    });
+    const session = new CodexSessionController(rpc);
+    session.onFrontendRecovery((event) => {
+      recoveries.push(event);
+    });
+
+    await session.request("thread/start", {});
+    await session.request("turn/start", {
+      threadId: "thread-bootstrap",
+      clientUserMessageId: null,
+      input: initialInput,
+    });
+    rpc.disconnect();
+    await rpc.reconnect();
+
+    expect(recoveries).toEqual([{
+      disposition: "resume",
+      threadId: "thread-bootstrap",
+      generation: 2,
+    }]);
+  });
+
+  test("shellCommand owns the turn until authoritative completion before AgentParty starts", async () => {
+    const rpc = new ScriptedCodexRpc();
+    const shellAccepted = deferred<Record<string, never>>();
+    rpc.queue("thread/start", idleThread("thread-shell"));
+    rpc.queue("thread/shellCommand", () => shellAccepted.promise);
+    rpc.queue("turn/start", { turn: { id: "turn-agentparty" } });
+    const session = new CodexSessionController(rpc);
+
+    await session.start();
+    await session.request("thread/start", {});
+    const shell = session.request("thread/shellCommand", {
+      threadId: "thread-shell",
+      command: "git status --short",
+    });
+    await waitFor(
+      () => rpc.calls.some((call) => call.method === "thread/shellCommand"),
+      "shellCommand did not reach the backend",
+    );
+    const submitted = session.submit({
+      text: "must wait for the user shell command",
+      clientUserMessageId: "agentparty:after-shell",
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(rpc.calls.filter((call) => call.method === "turn/start")).toHaveLength(0);
+
+    shellAccepted.resolve({});
+    await shell;
+    await expect(submitted).resolves.toMatchObject({
+      kind: "queued",
+      reason: "shell",
+    });
+    expect(rpc.calls.filter((call) => call.method === "turn/start")).toHaveLength(0);
+
+    await rpc.emit({
+      method: "turn/started",
+      params: {
+        threadId: "thread-shell",
+        turn: { id: "turn-user-shell", status: "inProgress", items: [] },
+      },
+    });
+    await rpc.emit({
+      method: "item/started",
+      params: {
+        threadId: "thread-shell",
+        turnId: "turn-user-shell",
+        item: {
+          id: "item-user-shell",
+          type: "commandExecution",
+          source: "userShell",
+        },
+      },
+    });
+    await rpc.emit({
+      method: "item/completed",
+      params: {
+        threadId: "thread-shell",
+        turnId: "turn-user-shell",
+        item: {
+          id: "item-user-shell",
+          type: "commandExecution",
+          source: "userShell",
+        },
+      },
+    });
+    expect(rpc.calls.filter((call) => call.method === "turn/start")).toHaveLength(0);
+
+    await rpc.emit({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-shell",
+        turn: { id: "turn-user-shell", status: "completed", items: [] },
+      },
+    });
+    expect(rpc.calls.filter((call) => call.method === "turn/start")).toEqual([
+      expect.objectContaining({
+        params: expect.objectContaining({
+          threadId: "thread-shell",
+          clientUserMessageId: "agentparty:after-shell",
+        }),
+      }),
+    ]);
+  });
+
+  test("an after-write thread switch disconnect stays unknown while later submit restores the prior thread", async () => {
+    const rpc = new ScriptedCodexRpc();
+    const switchResponse = deferred<ReturnType<typeof idleThread>>();
+    rpc.queue("thread/start", idleThread("thread-old"));
+    rpc.queue("thread/start", () => switchResponse.promise);
+    rpc.queue("thread/resume", idleThread("thread-old"));
+    rpc.queue("thread/read", idleThread("thread-old"));
+    rpc.queue("turn/start", {
+      turn: { id: "turn-after-restore" },
+    });
+    const session = new CodexSessionController(rpc);
+
+    await session.start();
+    await session.request("thread/start", {});
+    const switching = session.request("thread/start", {});
+    await waitFor(
+      () => rpc.calls.filter((call) => call.method === "thread/start").length === 2,
+      "replacement thread/start did not take the session lane",
+    );
+    const expectedStartCalls = rpc.startCalls + 1;
+    const submitted = session.submit({
+      text: "must wait for reconnect restoration",
+      clientUserMessageId: "agentparty:lane-disconnect",
+    });
+    await waitFor(
+      () => rpc.startCalls >= expectedStartCalls,
+      "submit did not pass its first readiness barrier",
+    );
+
+    rpc.connected = false;
+    switchResponse.resolve(idleThread("thread-new"));
+    await expect(switching).rejects.toBeInstanceOf(CodexRpcDisconnectedError);
+    await expect(submitted).resolves.toEqual({
+      kind: "started",
+      turnId: "turn-after-restore",
+    });
+    expect(
+      rpc.calls
+        .filter((call) => call.method === "turn/start")
+        .map((call) => call.params),
+    ).toEqual([
+      expect.objectContaining({
+        threadId: "thread-old",
+        clientUserMessageId: "agentparty:lane-disconnect",
+      }),
+    ]);
+    expect(rpc.calls.filter((call) => call.method === "thread/resume")).toHaveLength(1);
+    expect(rpc.calls.filter((call) => call.method === "thread/read")).toHaveLength(1);
+  });
+
+  test("overlapping reconnects run a distinct full recovery for the newest generation", async () => {
+    const rpc = new ScriptedCodexRpc();
+    const generationTwoResume = deferred<ReturnType<typeof idleThread>>();
+    rpc.queue("thread/start", idleThread("thread-recovery"));
+    rpc.queue("thread/resume", () => generationTwoResume.promise);
+    rpc.queue("thread/resume", idleThread("thread-recovery"));
+    rpc.queue("thread/read", idleThread("thread-recovery"));
+    const session = new CodexSessionController(rpc);
+
+    await session.request("thread/start", {});
+    const generationTwo = rpc.reconnect();
+    await waitFor(
+      () => rpc.calls.some((call) =>
+        call.method === "thread/resume" && call.generation === 2
+      ),
+      "generation 2 restore did not start",
+    );
+    const generationThree = rpc.reconnect();
+    generationTwoResume.resolve(idleThread("thread-recovery"));
+    await Promise.all([generationTwo, generationThree]);
+
+    expect(
+      rpc.calls
+        .filter((call) => call.method === "thread/resume")
+        .map((call) => call.generation),
+    ).toEqual([2, 3]);
+    expect(
+      rpc.calls
+        .filter((call) => call.method === "thread/read")
+        .map((call) => call.generation),
+    ).toEqual([3]);
+  });
+
+  test("a writer waiting on interrupted recovery drives the next generation without spinning", async () => {
+    const rpc = new ScriptedCodexRpc();
+    const generationTwoResume = deferred<ReturnType<typeof idleThread>>();
+    rpc.queue("thread/start", idleThread("thread-recovery-waiter"));
+    rpc.queue("thread/resume", () => generationTwoResume.promise);
+    rpc.queue("thread/resume", idleThread("thread-recovery-waiter"));
+    rpc.queue("thread/read", idleThread("thread-recovery-waiter"));
+    rpc.queue("turn/start", { turn: { id: "turn-after-recovery-waiter" } });
+    const session = new CodexSessionController(rpc);
+
+    await session.request("thread/start", {});
+    const generationTwo = rpc.reconnect();
+    await waitFor(
+      () => rpc.calls.some((call) =>
+        call.method === "thread/resume" && call.generation === 2
+      ),
+      "generation 2 restore did not start",
+    );
+    const submission = session.submit({
+      text: "resume only after generation 3 is authoritative",
+      clientUserMessageId: "agentparty:recovery-waiter-generation-three",
+    });
+
+    rpc.disconnect();
+    generationTwoResume.resolve(idleThread("thread-recovery-waiter"));
+    await generationTwo;
+    await expect(submission).resolves.toEqual({
+      kind: "started",
+      turnId: "turn-after-recovery-waiter",
+    });
+
+    expect(
+      rpc.calls
+        .filter((call) => call.method === "thread/resume" || call.method === "thread/read")
+        .map((call) => `${call.method}@${call.generation}`),
+    ).toEqual([
+      "thread/resume@2",
+      "thread/resume@3",
+      "thread/read@3",
+    ]);
+    expect(
+      rpc.calls
+        .filter((call) => call.method === "turn/start")
+        .map((call) => call.generation),
+    ).toEqual([3]);
+    expect(rpc.startCalls).toBeGreaterThanOrEqual(2);
+  });
+
+  test("a partial restore cannot apply a stale snapshot or continue its read on a new generation", async () => {
+    const rpc = new ScriptedCodexRpc();
+    const generationTwoResume = deferred<{
+      thread: {
+        id: string;
+        status: { type: "active" };
+        turns: Array<{
+          id: string;
+          status: "inProgress";
+          items: Array<{ type: "userMessage"; clientId: string }>;
+        }>;
+      };
+    }>();
+    rpc.queue("thread/start", idleThread("thread-fenced"));
+    rpc.queue("thread/resume", () => generationTwoResume.promise);
+    rpc.queue("thread/resume", idleThread("thread-fenced"));
+    rpc.queue("thread/read", idleThread("thread-fenced"));
+    const session = new CodexSessionController(rpc);
+    const recoveredClientIds: string[] = [];
+    session.onDispatch((input) => {
+      recoveredClientIds.push(input.clientUserMessageId);
+    });
+
+    await session.request("thread/start", {});
+    const generationTwo = rpc.reconnect();
+    await waitFor(
+      () => rpc.calls.some((call) =>
+        call.method === "thread/resume" && call.generation === 2
+      ),
+      "generation 2 resume did not start",
+    );
+    generationTwoResume.resolve({
+      thread: {
+        id: "thread-fenced",
+        status: { type: "active" },
+        turns: [{
+          id: "stale-turn",
+          status: "inProgress",
+          items: [{
+            type: "userMessage",
+            clientId: "agentparty:stale-generation-two",
+          }],
+        }],
+      },
+    });
+    const generationThree = rpc.reconnect();
+    await Promise.all([generationTwo, generationThree]);
+
+    expect(
+      rpc.calls
+        .filter((call) => call.method === "thread/resume" || call.method === "thread/read")
+        .map((call) => `${call.method}@${call.generation}`),
+    ).toEqual([
+      "thread/resume@2",
+      "thread/resume@3",
+      "thread/read@3",
+    ]);
+    expect(recoveredClientIds).not.toContain("agentparty:stale-generation-two");
+  });
+
+  test("a superseded restore failure cannot poison the healthy generation", async () => {
+    const rpc = new ScriptedCodexRpc();
+    const generationTwoResume = deferred<ReturnType<typeof idleThread>>();
+    rpc.queue("thread/start", idleThread("thread-failure-fence"));
+    rpc.queue("thread/resume", () => generationTwoResume.promise);
+    rpc.queue("thread/resume", idleThread("thread-failure-fence"));
+    rpc.queue("thread/read", idleThread("thread-failure-fence"));
+    rpc.queue("turn/start", { turn: { id: "turn-after-healthy-recovery" } });
+    const session = new CodexSessionController(rpc);
+
+    await session.request("thread/start", {});
+    const generationTwo = rpc.reconnect();
+    await waitFor(
+      () => rpc.calls.some((call) =>
+        call.method === "thread/resume" && call.generation === 2
+      ),
+      "generation 2 resume did not start",
+    );
+    const generationThree = rpc.reconnect();
+    generationTwoResume.reject(new Error("restore-generation-two-failed"));
+    await Promise.all([generationTwo, generationThree]);
+
+    await expect(session.submit({
+      text: "healthy generation must remain usable",
+      clientUserMessageId: "agentparty:healthy-generation",
+    })).resolves.toEqual({
+      kind: "started",
+      turnId: "turn-after-healthy-recovery",
+    });
+    expect(
+      rpc.calls
+        .filter((call) => call.method === "turn/start")
+      .map((call) => call.generation),
+    ).toEqual([3]);
+  });
+
+  test.each([
+    ["missing", {}],
+    ["mismatched", idleThread("thread-wrong-recovery-target")],
+  ] as const)(
+    "a %s full-history snapshot keeps recovery closed until the exact thread is readable",
+    async (_kind, invalidRead) => {
+      const threadId = "thread-strict-recovery";
+      const validRead = deferred<ReturnType<typeof idleThread>>();
+      const rpc = new ScriptedCodexRpc();
+      rpc.queue("thread/start", idleThread(threadId));
+      rpc.queue("thread/resume", idleThread(threadId));
+      rpc.queue("thread/read", invalidRead);
+      rpc.queue("thread/resume", idleThread(threadId));
+      rpc.queue("thread/read", () => validRead.promise);
+      rpc.queue("turn/start", { turn: { id: "turn-after-strict-recovery" } });
+      const session = new CodexSessionController(rpc, {
+        recoveryRetryDelayMs: 20,
+      });
+
+      await session.request("thread/start", {});
+      const recovery = rpc.reconnect();
+      const submission = session.submit({
+        text: "must wait for an exact recovery snapshot",
+        clientUserMessageId: `agentparty:strict-recovery-${_kind}`,
+      });
+      await waitFor(
+        () => rpc.calls.filter((call) => call.method === "thread/read").length === 2,
+        "invalid recovery snapshot was not retried on the same generation",
+      );
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      expect(rpc.calls.filter((call) => call.method === "turn/start")).toHaveLength(0);
+
+      validRead.resolve(idleThread(threadId));
+      await recovery;
+      await expect(submission).resolves.toEqual({
+        kind: "started",
+        turnId: "turn-after-strict-recovery",
+      });
+      expect(rpc.calls.filter((call) => call.method === "turn/start")).toHaveLength(1);
+      expect(
+        rpc.calls
+          .filter((call) => call.method === "thread/resume" || call.method === "thread/read")
+          .map((call) => `${call.method}@${call.generation}`),
+      ).toEqual([
+        "thread/resume@2",
+        "thread/read@2",
+        "thread/resume@2",
+        "thread/read@2",
+      ]);
+    },
+  );
+
+  test("a reconnect while submit waits on the arbiter cannot write before same-generation recovery", async () => {
+    const rpc = new ScriptedCodexRpc();
+    rpc.queue("thread/start", idleThread("thread-operation-fence"));
+    rpc.queue("thread/resume", idleThread("thread-operation-fence"));
+    rpc.queue("thread/read", idleThread("thread-operation-fence"));
+    rpc.queue("turn/start", { turn: { id: "turn-after-operation-fence" } });
+    const session = new CodexSessionController(rpc);
+    await session.request("thread/start", {});
+
+    const arbiter = (session as unknown as {
+      arbiter: CodexTurnArbiter | null;
+    }).arbiter!;
+    const releaseArbiter = deferred<void>();
+    const occupyingArbiter = arbiter.runInteractiveMutation(
+      "turn/steer",
+      { threadId: "thread-operation-fence", expectedTurnId: "turn-before-reconnect" },
+      async () => {
+        await releaseArbiter.promise;
+        return { turnId: "turn-before-reconnect" };
+      },
+    );
+    const expectedStartCalls = rpc.startCalls + 1;
+    const submitted = session.submit({
+      text: "must not write before generation recovery",
+      clientUserMessageId: "agentparty:operation-generation-fence",
+    });
+    await waitFor(
+      () => rpc.startCalls >= expectedStartCalls,
+      "submit did not pass its initial readiness barrier",
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const recovery = rpc.reconnect();
+    releaseArbiter.resolve();
+    await occupyingArbiter;
+    await expect(submitted).resolves.toMatchObject({
+      kind: "queued",
+      reason: "steer_rejected",
+    });
+    await recovery;
+
+    expect(
+      rpc.calls
+        .filter((call) =>
+          call.method === "thread/resume" ||
+          call.method === "thread/read" ||
+          call.method === "turn/start" ||
+          call.method === "turn/steer"
+        )
+        .map((call) => `${call.method}@${call.generation}`),
+    ).toEqual([
+      "thread/resume@2",
+      "thread/read@2",
+      "turn/start@2",
+    ]);
+  });
+
+  test("thread/fork passes the switch guard and attaches the returned thread", async () => {
+    const rpc = new ScriptedCodexRpc();
+    rpc.queue("thread/start", idleThread("thread-old"));
+    rpc.queue("thread/fork", idleThread("thread-forked"));
+    rpc.queue("turn/start", (params: unknown) => {
+      const threadId = (params as { threadId?: unknown }).threadId;
+      return { turn: { id: `turn-for-${String(threadId)}` } };
+    });
+    const session = new CodexSessionController(rpc);
+    const switchAttempts: Array<{
+      method: string;
+      currentThreadId: string;
+      targetThreadId: string | null;
+    }> = [];
+    session.onThreadSwitch((attempt) => {
+      switchAttempts.push(attempt);
+    });
+
+    await session.start();
+    await session.request("thread/start", {});
+    expect(session.activeThreadId).toBe("thread-old");
+
+    await session.request("thread/fork", { threadId: "thread-old" });
+    expect(switchAttempts).toEqual([{
+      method: "thread/fork",
+      currentThreadId: "thread-old",
+      targetThreadId: null,
+    }]);
+    expect(session.activeThreadId).toBe("thread-forked");
+
+    await expect(session.submit({
+      text: "continue in the fork",
+      clientUserMessageId: "agentparty:forked-thread",
+    })).resolves.toEqual({
+      kind: "started",
+      turnId: "turn-for-thread-forked",
+    });
+    expect(rpc.calls.filter((call) => call.method === "turn/start")).toEqual([
+      expect.objectContaining({
+        params: expect.objectContaining({
+          threadId: "thread-forked",
+          clientUserMessageId: "agentparty:forked-thread",
+        }),
+      }),
+    ]);
+  });
+
+  test("thread/rollback serializes a concurrent AgentParty submit behind authoritative history", async () => {
+    const rpc = new ScriptedCodexRpc();
+    const rollbackResponse = deferred<ReturnType<typeof idleThread>>();
+    rpc.queue("thread/start", idleThread("thread-rollback"));
+    rpc.queue("thread/rollback", () => rollbackResponse.promise);
+    rpc.queue("turn/start", { turn: { id: "turn-after-rollback" } });
+    const session = new CodexSessionController(rpc);
+    await session.start();
+    await session.request("thread/start", {});
+
+    const rollback = session.request("thread/rollback", {
+      threadId: "thread-rollback",
+      numTurns: 1,
+    });
+    await waitFor(
+      () => rpc.calls.some((call) => call.method === "thread/rollback"),
+      "rollback did not reach the backend",
+    );
+    const submitted = session.submit({
+      text: "must see post-rollback history",
+      clientUserMessageId: "agentparty:after-rollback",
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(rpc.calls.filter((call) => call.method === "turn/start")).toHaveLength(0);
+
+    rollbackResponse.resolve(idleThread("thread-rollback"));
+    await rollback;
+    await expect(submitted).resolves.toEqual({
+      kind: "started",
+      turnId: "turn-after-rollback",
+    });
+  });
+
+  test("thread/rollback rebuilds same-thread clientId affinity instead of retaining removed turns", async () => {
+    const rpc = new ScriptedCodexRpc();
+    rpc.queue("thread/resume", {
+      thread: {
+        id: "thread-rollback-affinity",
+        status: { type: "idle" },
+        turns: [{
+          id: "source-turn",
+          status: "completed",
+          items: [{
+            type: "userMessage",
+            id: "source-user",
+            clientId: "agentparty:source-delivery",
+          }],
+        }],
+      },
+    });
+    rpc.queue("thread/rollback", idleThread("thread-rollback-affinity"));
+    const session = new CodexSessionController(rpc);
+    await session.start();
+    await session.request("thread/resume", { threadId: "thread-rollback-affinity" });
+    expect(session.turnForClientId("agentparty:source-delivery")?.id).toBe("source-turn");
+
+    await session.request("thread/rollback", {
+      threadId: "thread-rollback-affinity",
+      numTurns: 1,
+    });
+    expect(session.turnForClientId("agentparty:source-delivery")).toBeNull();
+  });
+
+  test("a submit that triggers reconnect restores before taking the arbiter lane", async () => {
+    const statePath = join(temp, "state.json");
+    const logs: string[] = [];
+    let spawns = 0;
+    const rpc = new CodexRpcClient({
+      reconnectDelayMs: 1_000,
+      maxReconnectDelayMs: 1_000,
+      log: (line) => logs.push(line),
+      spawnProxy: () => {
+        spawns += 1;
+        return spawn("bun", ["run", fixture], {
+          stdio: ["pipe", "pipe", "pipe"],
+          env: { ...process.env, MOCK_CODEX_STATE_PATH: statePath },
+        });
+      },
+    });
+    clients.push(rpc);
+    const session = new CodexSessionController(rpc, {
+      log: (line) => logs.push(line),
+    });
+    await session.start();
+    await session.request("thread/start", {});
+    await expect(rpc.request("mock/disconnect", {})).rejects.toThrow(
+      "Codex app-server control connection closed",
+    );
+
+    const dispatch = await Promise.race([
+      session.submit({
+        text: "submit owns the reconnect",
+        clientUserMessageId: "agentparty:submit-reconnect",
+      }),
+      new Promise<never>((_, reject) => {
+        setTimeout(() => reject(new Error("submit deadlocked during reconnect")), 2_000);
+      }),
+    ]);
+    expect(dispatch).toEqual({ kind: "started", turnId: "turn-1" });
+    expect(spawns).toBeGreaterThanOrEqual(2);
+    expect(logs.some((line) => line.includes("restored thread thread-mock"))).toBe(true);
+  }, 10_000);
+
+  test("initializes real JSONL, resumes after an unknown write, and reconciles clientId without duplicate start", async () => {
+    const statePath = join(temp, "state.json");
+    let spawns = 0;
+    const logs: string[] = [];
+    const rpc = new CodexRpcClient({
+      reconnectDelayMs: 5,
+      maxReconnectDelayMs: 20,
+      log: (line) => logs.push(line),
+      spawnProxy: () => {
+        spawns += 1;
+        return spawn("bun", ["run", fixture], {
+          stdio: ["pipe", "pipe", "pipe"],
+          env: { ...process.env, MOCK_CODEX_STATE_PATH: statePath },
+        });
+      },
+    });
+    clients.push(rpc);
+    const session = new CodexSessionController(rpc, {
+      log: (line) => logs.push(line),
+    });
+    const completed: CodexTurn[] = [];
+    session.onTurnCompleted((turn) => {
+      completed.push(turn);
+    });
+
+    await session.start();
+    expect(rpc.initializeResult).toMatchObject({
+      userAgent: "mock-codex-app-server/0.144.4",
+      platformFamily: "unix",
+    });
+    await session.request("thread/start", {});
+    expect(session.activeThreadId).toBe("thread-mock");
+
+    const input = {
+      text: "__disconnect_after_accept__",
+      clientUserMessageId: "agentparty:delivery-lost-response",
+      metadata: { delivery_id: "delivery-lost-response" },
+    };
+    await expect(session.submit(input)).resolves.toEqual({
+      kind: "uncertain",
+      reason: "unknown_outcome",
+    });
+
+    await waitFor(
+      () => session.turnForClientId(input.clientUserMessageId) !== null,
+      "reconnected controller did not recover the accepted client id",
+    );
+    expect(spawns).toBeGreaterThanOrEqual(2);
+    expect(await session.submit(input)).toEqual({
+      kind: "duplicate",
+    });
+
+    const recovered = session.turnForClientId(input.clientUserMessageId)!;
+    await rpc.request("mock/complete", {
+      turnId: recovered.id,
+      text: "linked answer after reconnect",
+    });
+    await waitFor(() => completed.some((turn) => turn.id === recovered.id), "completion notification not routed");
+    expect(completed.find((turn) => turn.id === recovered.id)?.items).toContainEqual(
+      expect.objectContaining({
+        type: "agentMessage",
+        text: "linked answer after reconnect",
+      }),
+    );
+
+    const state = JSON.parse(readFileSync(statePath, "utf8")) as {
+      generations: number;
+      turns: unknown[];
+    };
+    expect(state.generations).toBeGreaterThanOrEqual(2);
+    expect(state.turns).toHaveLength(1);
+    expect(logs.some((line) => line.includes("restored thread thread-mock"))).toBe(true);
+  }, 15_000);
+
+  test("routes app-server requests to the frontend and sends the frontend response back", async () => {
+    const statePath = join(temp, "state.json");
+    const rpc = new CodexRpcClient({
+      spawnProxy: () => spawn("bun", ["run", fixture], {
+        stdio: ["pipe", "pipe", "pipe"],
+        env: { ...process.env, MOCK_CODEX_STATE_PATH: statePath },
+      }),
+    });
+    clients.push(rpc);
+    const session = new CodexSessionController(rpc);
+    const frontend: Array<{ method: string; id?: string | number | null }> = [];
+    session.onFrontendMessage((message) => {
+      frontend.push(message);
+      if ("id" in message) session.respond(message.id, { decision: "accept" });
+    });
+    await session.start();
+    await session.request("thread/start", {});
+    await rpc.request("mock/serverRequest", {});
+    await waitFor(
+      () => frontend.some((message) => message.method === "item/commandExecution/requestApproval"),
+      "server request was not forwarded",
+    );
+    expect(frontend).toContainEqual(expect.objectContaining({
+      id: "server-approval-1",
+      method: "item/commandExecution/requestApproval",
+    }));
+  });
+});

--- a/cli/test/codex-app-server-rpc.test.ts
+++ b/cli/test/codex-app-server-rpc.test.ts
@@ -390,6 +390,61 @@ describe("Codex app-server stdio JSON-RPC and reconnect recovery", () => {
     }]);
   });
 
+  test("an invalid initial thread/start response fails closed and remains retryable", async () => {
+    const rpc = new ScriptedCodexRpc();
+    rpc.queue("thread/start", {});
+    rpc.queue("thread/start", idleThread("thread-after-invalid"));
+    const session = new CodexSessionController(rpc);
+
+    await expect(session.request("thread/start", {})).rejects.toThrow(
+      "thread/start returned no valid thread",
+    );
+    expect(session.activeThreadId).toBeNull();
+
+    await expect(session.request("thread/start", {})).resolves.toEqual(
+      idleThread("thread-after-invalid"),
+    );
+    expect(session.activeThreadId).toBe("thread-after-invalid");
+    expect(rpc.calls.filter((call) => call.method === "thread/start")).toHaveLength(2);
+  });
+
+  test("thread switching and authoritative snapshots reject invalid thread identity", async () => {
+    const rpc = new ScriptedCodexRpc();
+    rpc.queue("thread/start", idleThread("thread-current"));
+    rpc.queue("thread/start", {});
+    rpc.queue("thread/resume", idleThread("thread-wrong"));
+    rpc.queue("thread/read", idleThread("thread-wrong"));
+    rpc.queue("thread/rollback", idleThread("thread-wrong"));
+    const session = new CodexSessionController(rpc);
+
+    await session.request("thread/start", {});
+    await expect(session.request("thread/start", {})).rejects.toThrow(
+      "thread/start returned no valid thread",
+    );
+    await expect(
+      session.request("thread/resume", { threadId: "thread-requested" }),
+    ).rejects.toThrow(
+      "thread/resume returned thread thread-wrong, expected thread-requested",
+    );
+    await expect(
+      session.request("thread/read", {
+        threadId: "thread-current",
+        includeTurns: true,
+      }),
+    ).rejects.toThrow(
+      "thread/read returned thread thread-wrong, expected thread-current",
+    );
+    await expect(
+      session.request("thread/rollback", {
+        threadId: "thread-current",
+        numTurns: 1,
+      }),
+    ).rejects.toThrow(
+      "thread/rollback returned thread thread-wrong, expected thread-current",
+    );
+    expect(session.activeThreadId).toBe("thread-current");
+  });
+
   test("a created bootstrap thread replays its prompt without creating the thread twice", async () => {
     const rpc = new ScriptedCodexRpc();
     const recoveries: CodexFrontendRecovery[] = [];

--- a/cli/test/codex-bridge-command.test.ts
+++ b/cli/test/codex-bridge-command.test.ts
@@ -1,0 +1,1066 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import type { DirectedDelivery, MsgFrame } from "@agentparty/shared";
+import { spawn } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { delimiter as pathDelimiter, join } from "node:path";
+import type { Connection } from "../src/client";
+import {
+  buildCodexChildEnv,
+  parseCodexVersion,
+  resolveCodexBinary,
+  resolveCodexLaunch,
+  run as runBridge,
+  supportsCodexSessionBridge,
+  type CodexCapabilityProbe,
+} from "../src/commands/bridge";
+import {
+  CodexFrontendLifecycleQueue,
+  CodexFrontendRecoveryQueue,
+  buildCodexTuiArgs,
+  buildCodexTuiResumeArgs,
+  buildCodexTuiResumeWithPromptArgs,
+  resolveCodexRecoveryThreadId,
+  runCodexSessionBridge,
+  superviseCodexTui,
+  terminateBridgeChild,
+  type BridgeChildProcess,
+  type CodexBridgeTerminalResult,
+  type CodexBridgeRuntimeOptions,
+} from "../src/commands/codex-bridge";
+import {
+  DeliveryRecoveryJournal,
+  deliveryRecoveryJournalPath,
+} from "../src/delivery-recovery-journal";
+
+const supported: CodexCapabilityProbe = {
+  version: "codex-cli 0.144.4",
+  rootHelp: "--remote <ADDR> ws://host unix://PATH",
+  appServerHelp: "--listen <URL> --stdio",
+};
+
+const mockCodexFixture = join(import.meta.dir, "fixtures", "mock-codex-app-server.ts");
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const path of tempDirs.splice(0)) rmSync(path, { recursive: true, force: true });
+});
+
+function tempDir(): string {
+  const path = mkdtempSync(join(tmpdir(), "agentparty-codex-command-"));
+  tempDirs.push(path);
+  return path;
+}
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  message: string,
+  timeoutMs = 2_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error(message);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+function controlledBridgeChild(options: {
+  exitOnSignal?: boolean;
+  events?: string[];
+  label?: string;
+} = {}): BridgeChildProcess & {
+  resolveExit(code: number): void;
+  signals: Array<number | NodeJS.Signals | undefined>;
+} {
+  const exit = deferred<number>();
+  const signals: Array<number | NodeJS.Signals | undefined> = [];
+  return {
+    exited: exit.promise,
+    signals,
+    resolveExit: exit.resolve,
+    kill(signal) {
+      signals.push(signal);
+      options.events?.push(`kill:${options.label ?? "child"}:${String(signal)}`);
+      if (options.exitOnSignal !== false) exit.resolve(signal === "SIGKILL" ? 137 : 143);
+    },
+  };
+}
+
+function terminalControl(): {
+  run: Promise<CodexBridgeTerminalResult>;
+  now: () => CodexBridgeTerminalResult | null;
+  finish: (result: CodexBridgeTerminalResult) => void;
+} {
+  const terminal = deferred<CodexBridgeTerminalResult>();
+  let settled: CodexBridgeTerminalResult | null = null;
+  return {
+    run: terminal.promise,
+    now: () => settled,
+    finish(result) {
+      settled = result;
+      terminal.resolve(result);
+    },
+  };
+}
+
+function recordCodexRecoveryDebt(
+  journal: DeliveryRecoveryJournal,
+  index: number,
+  threadId: string,
+): void {
+  const now = Date.now();
+  const delivery: DirectedDelivery = {
+    id: `delivery-runtime-${index}`,
+    message_seq: 700 + index,
+    target_name: "front",
+    cause: "mention",
+    state: "claimed",
+    attempt: 1,
+    lease_epoch: 1,
+    lease_token: `lease-${index}`,
+    lease_until: now + 90_000,
+    work_id: `work-${index}`,
+    continuation_ref: `continuation-${index}`,
+    reply_seq: null,
+    last_error: null,
+    created_at: now,
+    updated_at: now,
+  };
+  const message: MsgFrame = {
+    type: "msg",
+    seq: delivery.message_seq,
+    sender: { name: "owner", kind: "human" },
+    kind: "message",
+    body: `@front recover ${index}`,
+    mentions: ["front"],
+    reply_to: null,
+    state: null,
+    note: null,
+    status: null,
+    ts: now,
+  };
+  journal.recordClaim(delivery, message);
+  journal.update(delivery.id, {
+    phase: "harness_issued",
+    threadId,
+    delivery: { ...delivery, state: "running" },
+  });
+}
+
+function dormantConnection(): Connection {
+  let closeFrames!: () => void;
+  const closed = new Promise<void>((resolve) => {
+    closeFrames = resolve;
+  });
+  return {
+    frames: (async function* () {
+      await closed;
+    })(),
+    send: () => true,
+    ack: () => {},
+    close: closeFrames,
+    pendingFrames: () => [],
+    replayUnacked: () => 0,
+    cursor: 0,
+    revCursor: 0,
+  };
+}
+
+describe("party bridge codex capability and argv boundary", () => {
+  test("requires the app-server stdio and Unix-remote capabilities", () => {
+    expect(parseCodexVersion("codex-cli 0.144.4")).toEqual([0, 144, 4]);
+    expect(parseCodexVersion("codex 0.146.0-alpha.3")).toEqual([0, 146, 0]);
+    expect(parseCodexVersion("unknown")).toBeNull();
+    expect(supportsCodexSessionBridge(supported)).toBe(true);
+    expect(supportsCodexSessionBridge({ ...supported, version: "codex-cli 0.143.9" })).toBe(false);
+    expect(supportsCodexSessionBridge({ ...supported, rootHelp: "--remote ws://host" })).toBe(false);
+    expect(supportsCodexSessionBridge({ ...supported, appServerHelp: "--listen stdio://" })).toBe(false);
+    expect(resolveCodexBinary(process.execPath)).toBe(realpathSync(process.execPath));
+  });
+
+  test("the bridge owns --remote and passes other Codex flags after --", async () => {
+    const calls: CodexBridgeRuntimeOptions[] = [];
+    let probed:
+      | { codexBinary: string; options: { cwd: string; env: NodeJS.ProcessEnv } }
+      | undefined;
+    const code = await runBridge(
+      ["codex", "dev", "--", "--model", "gpt-5.4", "--no-alt-screen"],
+      {
+        probeCodexCapabilities: async (codexBinary, options) => {
+          probed = { codexBinary, options };
+          return supported;
+        },
+        codexBinary: process.execPath,
+        cwd: "/workspace",
+        env: { PATH: "/bin" },
+        runCodexBridge: async (options) => {
+          calls.push(options);
+          return 17;
+        },
+      },
+    );
+    expect(code).toBe(17);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      channel: "dev",
+      codexBinary: realpathSync(process.execPath),
+      codexArgs: ["--model", "gpt-5.4", "--no-alt-screen"],
+      cwd: "/workspace",
+    });
+    expect(probed?.codexBinary).toBe(calls[0]?.codexBinary);
+    expect(probed?.options.cwd).toBe(calls[0]?.cwd);
+    expect(probed?.options.env).toBe(calls[0]?.env);
+    const childPath = calls[0]?.env?.PATH?.split(pathDelimiter) ?? [];
+    expect(childPath).toContain("/bin");
+    expect(childPath).toContain(join(homedir(), ".local/bin"));
+    expect(childPath).toContain(join(homedir(), ".npm-global/bin"));
+    expect(childPath).toContain("/opt/homebrew/bin");
+    expect(childPath).toContain("/usr/local/bin");
+    expect(childPath).toContain("/Applications/Codex.app/Contents/Resources");
+    expect(childPath).toContain("/Applications/ChatGPT.app/Contents/Resources");
+    expect(buildCodexTuiArgs("/tmp/private.sock", ["--model", "gpt-5.4"])).toEqual([
+      "--remote",
+      "unix:///tmp/private.sock",
+      "--model",
+      "gpt-5.4",
+    ]);
+    expect(buildCodexTuiResumeArgs("/tmp/private.sock", "thread-recovered")).toEqual([
+      "resume",
+      "--remote",
+      "unix:///tmp/private.sock",
+      "thread-recovered",
+    ]);
+    expect(buildCodexTuiResumeArgs(
+      "/tmp/private.sock",
+      "thread-recovered",
+      [
+        "--model",
+        "gpt-5.4",
+        "-m=gpt-5.4-mini",
+        "--profile=work",
+        "-p=fast",
+        "--sandbox",
+        "read-only",
+        "-s=workspace-write",
+        "--ask-for-approval",
+        "never",
+        "-a=on-request",
+        "--cd",
+        "/workspace",
+        "-C=/workspace/short",
+        "--add-dir",
+        "/shared",
+        "--search",
+        "--no-alt-screen",
+        "--image",
+        "/tmp/initial.png",
+        "original positional prompt",
+      ],
+    )).toEqual([
+      "resume",
+      "--remote",
+      "unix:///tmp/private.sock",
+      "--model",
+      "gpt-5.4",
+      "-m=gpt-5.4-mini",
+      "--profile=work",
+      "-p=fast",
+      "--sandbox",
+      "read-only",
+      "-s=workspace-write",
+      "--ask-for-approval",
+      "never",
+      "-a=on-request",
+      "--cd",
+      "/workspace",
+      "-C=/workspace/short",
+      "--add-dir",
+      "/shared",
+      "--search",
+      "--no-alt-screen",
+      "thread-recovered",
+    ]);
+    expect(buildCodexTuiResumeWithPromptArgs(
+      "/tmp/private.sock",
+      "thread-recovered",
+      ["-i", "/tmp/one.png", "/tmp/two.png", "--", "multi-image prompt"],
+    )).toEqual([
+      "resume",
+      "--remote",
+      "unix:///tmp/private.sock",
+      "-i",
+      "/tmp/one.png",
+      "/tmp/two.png",
+      "--",
+      "thread-recovered",
+      "multi-image prompt",
+    ]);
+    expect(buildCodexTuiResumeWithPromptArgs(
+      "/tmp/private.sock",
+      "thread-recovered",
+      ["--model", "gpt-5.4", "--image", "/tmp/initial.png", "original prompt"],
+      [{
+        type: "text",
+        text: "WIRE_PROMPT_746",
+        text_elements: [],
+      }],
+    )).toEqual([
+      "resume",
+      "--remote",
+      "unix:///tmp/private.sock",
+      "--model",
+      "gpt-5.4",
+      "thread-recovered",
+      "WIRE_PROMPT_746",
+    ]);
+    expect(buildCodexTuiResumeArgs(
+      "/tmp/private.sock",
+      "thread-recovered",
+      ["-i", "/tmp/one.png", "/tmp/two.png", "--", "multi-image prompt"],
+    )).toEqual([
+      "resume",
+      "--remote",
+      "unix:///tmp/private.sock",
+      "thread-recovered",
+    ]);
+    expect(buildCodexTuiResumeWithPromptArgs(
+      "/tmp/private.sock",
+      "thread-recovered",
+      [
+        "--model",
+        "gpt-5.4",
+        "-i",
+        "/tmp/old-one.png",
+        "/tmp/old-two.png",
+        "--",
+        "old prompt",
+      ],
+      [
+        { type: "localImage", path: "/tmp/one.png" },
+        { type: "localImage", path: "/tmp/two.png" },
+        { type: "text", text: "multi-image prompt", text_elements: [] },
+      ],
+    )).toEqual([
+      "resume",
+      "--remote",
+      "unix:///tmp/private.sock",
+      "--model",
+      "gpt-5.4",
+      "--image",
+      "/tmp/one.png",
+      "--image",
+      "/tmp/two.png",
+      "--",
+      "thread-recovered",
+      "multi-image prompt",
+    ]);
+    expect(resolveCodexRecoveryThreadId([])).toBeNull();
+    expect(resolveCodexRecoveryThreadId([
+      { threadId: null },
+      { threadId: "thread-recovered" },
+      { threadId: "thread-recovered" },
+    ])).toBe("thread-recovered");
+    expect(() => resolveCodexRecoveryThreadId([
+      { threadId: "thread-one" },
+      { threadId: "thread-two" },
+    ])).toThrow("spans multiple threads");
+  });
+
+  test("frontend recovery queue deduplicates generations and retains the newest restart", async () => {
+    const queue = new CodexFrontendRecoveryQueue();
+    const first = queue.next();
+    queue.push({ disposition: "resume", threadId: "thread-one", generation: 2 });
+    expect(await first).toEqual({
+      disposition: "resume",
+      threadId: "thread-one",
+      generation: 2,
+    });
+
+    queue.push({ disposition: "resume", threadId: "stale-duplicate", generation: 2 });
+    queue.push({ disposition: "resume", threadId: "thread-newest", generation: 3 });
+    expect(await queue.next()).toEqual({
+      disposition: "resume",
+      threadId: "thread-newest",
+      generation: 3,
+    });
+  });
+
+  test("rejects an alternate remote endpoint instead of creating a second writer", async () => {
+    let launched = false;
+    const code = await runBridge(
+      ["codex", "dev", "--", "--remote", "unix:///tmp/other.sock"],
+      {
+        probeCodexCapabilities: async () => supported,
+        runCodexBridge: async () => {
+          launched = true;
+          return 0;
+        },
+      },
+    );
+    expect(code).toBe(1);
+    expect(launched).toBe(false);
+  });
+
+  test("fails closed when the installed Codex lacks the bridge protocol", async () => {
+    let launched = false;
+    const code = await runBridge(["codex", "dev"], {
+      probeCodexCapabilities: async () => ({
+        version: "codex-cli 0.143.0",
+        rootHelp: "",
+        appServerHelp: "",
+      }),
+      codexBinary: process.execPath,
+      runCodexBridge: async () => {
+        launched = true;
+        return 0;
+      },
+    });
+    expect(code).toBe(1);
+    expect(launched).toBe(false);
+  });
+
+  test("resolves Codex against the final child PATH and cwd", () => {
+    const root = tempDir();
+    const bin = join(root, "bin");
+    mkdirSync(bin);
+    const codex = join(bin, "codex");
+    writeFileSync(codex, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+
+    expect(resolveCodexBinary(undefined, { PATH: "bin" }, root)).toBe(realpathSync(codex));
+    const env = buildCodexChildEnv({ PATH: "bin" });
+    expect(env.PATH?.split(pathDelimiter)).toEqual(expect.arrayContaining([
+      "bin",
+      "/opt/homebrew/bin",
+      "/usr/local/bin",
+    ]));
+  });
+
+  test("honors AGENTPARTY_CODEX_BIN under a minimized GUI/launchd PATH", () => {
+    const root = tempDir();
+    const bin = join(root, "private-bin");
+    mkdirSync(bin);
+    const codex = join(bin, "codex");
+    writeFileSync(codex, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+
+    const launch = resolveCodexLaunch(undefined, {
+      PATH: "/usr/bin:/bin",
+      AGENTPARTY_CODEX_BIN: codex,
+    }, root);
+    expect(launch.ok).toBe(true);
+    if (launch.ok) {
+      expect(launch.codexBinary).toBe(realpathSync(codex));
+      expect(launch.env.PATH?.split(pathDelimiter)[0]).toBe(bin);
+      expect(launch.env.PATH?.split(pathDelimiter)).toContain(
+        "/Applications/ChatGPT.app/Contents/Resources",
+      );
+    }
+  });
+
+  test("makes an env-node shim runnable on the same child PATH or fails fast", () => {
+    const root = tempDir();
+    const bin = join(root, "custom-bin");
+    mkdirSync(bin);
+    const codex = join(bin, "codex");
+    const node = join(bin, "node");
+    writeFileSync(codex, "#!/usr/bin/env node\n", { mode: 0o755 });
+    writeFileSync(node, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+
+    const runnable = resolveCodexLaunch(codex, { PATH: "/bin" }, root);
+    expect(runnable.ok).toBe(true);
+    if (runnable.ok) {
+      expect(runnable.env.PATH?.split(pathDelimiter)[0]).toBe(bin);
+    }
+
+    const broken = join(bin, "broken-codex");
+    writeFileSync(broken, "#!/usr/bin/env agentparty-missing-runtime\n", { mode: 0o755 });
+    const missing = resolveCodexLaunch(broken, { PATH: "/bin" }, root);
+    expect(missing.ok).toBe(false);
+    if (!missing.ok) expect(missing.error).toContain("agentparty-missing-runtime is not executable");
+  });
+});
+
+describe("party bridge codex process lifecycle", () => {
+  test("SIGINT and SIGTERM abort authentication startup instead of being swallowed", async () => {
+    for (const [signal, expectedCode] of [["SIGINT", 130], ["SIGTERM", 143]] as const) {
+      let handler: ((received: "SIGINT" | "SIGTERM") => void) | undefined;
+      let removed = false;
+      let markAuthStarted!: () => void;
+      const authStarted = new Promise<void>((resolve) => {
+        markAuthStarted = resolve;
+      });
+      const result = runCodexSessionBridge(
+        {
+          channel: "dev",
+          codexBinary: realpathSync(process.execPath),
+          cwd: "/workspace",
+          env: { PATH: "/bin" },
+        },
+        {
+          installSignalHandlers: (installed) => {
+            handler = installed;
+            return () => {
+              removed = true;
+            };
+          },
+          resolveAuth: async () => {
+            markAuthStarted();
+            return await new Promise<never>(() => {});
+          },
+          runtimeDir: () => {
+            throw new Error("runtime directory must not be created after startup abort");
+          },
+          terminationGraceMs: 0,
+          killWaitMs: 0,
+          log: () => {},
+        },
+      );
+      await authStarted;
+      handler?.(signal);
+      expect(await result).toBe(expectedCode);
+      expect(removed).toBe(true);
+    }
+  });
+
+  test("runtime cold start follows the journal's exact thread affinity and rejects conflicts", async () => {
+    const previousAgentPartyHome = process.env.AGENTPARTY_HOME;
+    const runWithThreads = async (threadIds: string[]) => {
+      const root = tempDir();
+      process.env.AGENTPARTY_HOME = root;
+      const server = "https://runtime-recovery.example";
+      const token = "ap_runtime_recovery";
+      const journal = new DeliveryRecoveryJournal(
+        deliveryRecoveryJournalPath("codex", server, token, "dev"),
+        "dev",
+        "codex",
+      );
+      threadIds.forEach((threadId, index) => {
+        recordCodexRecoveryDebt(journal, index, threadId);
+      });
+      const runtimePath = join(root, "runtime");
+      const statePath = join(root, "mock-state.json");
+      if (threadIds.length === 1) {
+        writeFileSync(statePath, JSON.stringify({
+          threadId: threadIds[0],
+          turns: [],
+          nextTurn: 1,
+          generations: 0,
+        }));
+      }
+      const launches: string[][] = [];
+      let requestsAtConnect: string[] = [];
+      let appServerSpawns = 0;
+      const result = await runCodexSessionBridge(
+        {
+          channel: "dev",
+          codexBinary: process.execPath,
+          codexArgs: [
+            "--model",
+            "gpt-5.4",
+            "--image",
+            "/tmp/input.png",
+            "do not replay this prompt",
+          ],
+          cwd: root,
+          env: { ...process.env },
+        },
+        {
+          resolveAuth: async () => ({
+            server,
+            token,
+            auth_source: "runtime_config",
+            config: { kind: "none", path: null },
+            account: { present: false, path: join(root, "account.json") },
+          }),
+          spawnAppServer: () => {
+            appServerSpawns += 1;
+            return spawn(process.execPath, ["run", mockCodexFixture], {
+              stdio: ["pipe", "pipe", "pipe"],
+              env: { ...process.env, MOCK_CODEX_STATE_PATH: statePath },
+            });
+          },
+          connectAgentParty: () => {
+            const state = JSON.parse(readFileSync(statePath, "utf8")) as {
+              requests?: string[];
+            };
+            requestsAtConnect = state.requests ?? [];
+            return dormantConnection();
+          },
+          runtimeDir: () => {
+            mkdirSync(runtimePath);
+            return runtimePath;
+          },
+          launchTui: (_binary, args) => {
+            launches.push(args);
+            return {
+              exited: Promise.resolve(0),
+              kill: () => {},
+            };
+          },
+          installSignalHandlers: () => () => {},
+          terminationGraceMs: 0,
+          killWaitMs: 0,
+          log: () => {},
+        },
+      );
+      return {
+        appServerSpawns,
+        launches,
+        requestsAtConnect,
+        result,
+        runtimePath,
+        statePath,
+      };
+    };
+
+    try {
+      const empty = await runWithThreads([]);
+      expect(empty.result).toBe(0);
+      expect(empty.appServerSpawns).toBe(1);
+      expect(empty.launches).toEqual([[
+        "--remote",
+        `unix://${join(empty.runtimePath, "codex.sock")}`,
+        "--model",
+        "gpt-5.4",
+        "--image",
+        "/tmp/input.png",
+        "do not replay this prompt",
+      ]]);
+
+      const exact = await runWithThreads(["thread-journal"]);
+      expect(exact.result).toBe(0);
+      expect(exact.appServerSpawns).toBe(1);
+      expect(exact.launches).toEqual([[
+        "resume",
+        "--remote",
+        `unix://${join(exact.runtimePath, "codex.sock")}`,
+        "--model",
+        "gpt-5.4",
+        "thread-journal",
+      ]]);
+      const exactState = JSON.parse(readFileSync(exact.statePath, "utf8")) as {
+        requests?: string[];
+      };
+      expect(exactState.requests).toEqual(expect.arrayContaining([
+        "thread/resume",
+        "thread/read",
+      ]));
+      expect(exactState.requests!.indexOf("thread/resume")).toBeLessThan(
+        exactState.requests!.indexOf("thread/read"),
+      );
+      expect(exact.requestsAtConnect).toEqual(expect.arrayContaining([
+        "thread/resume",
+        "thread/read",
+      ]));
+
+      const conflicting = await runWithThreads(["thread-one", "thread-two"]);
+      expect(conflicting.result).toBe(1);
+      expect(conflicting.appServerSpawns).toBe(0);
+      expect(conflicting.launches).toEqual([]);
+    } finally {
+      if (previousAgentPartyHome === undefined) {
+        delete process.env.AGENTPARTY_HOME;
+      } else {
+        process.env.AGENTPARTY_HOME = previousAgentPartyHome;
+      }
+    }
+  }, 15_000);
+
+  test("child shutdown escalates from SIGTERM to SIGKILL with bounded waits", async () => {
+    let finish!: (code: number) => void;
+    const exited = new Promise<number>((resolve) => {
+      finish = resolve;
+    });
+    const signals: Array<number | NodeJS.Signals | undefined> = [];
+    expect(await terminateBridgeChild(
+      {
+        exited,
+        kill: (signal) => {
+          signals.push(signal);
+          if (signal === "SIGKILL") finish(137);
+        },
+      },
+      0,
+      0,
+      async () => {},
+    )).toBe(true);
+    expect(signals).toEqual(["SIGTERM", "SIGKILL"]);
+  });
+
+  test("child shutdown reports failure when SIGKILL cannot confirm process exit", async () => {
+    const signals: Array<number | NodeJS.Signals | undefined> = [];
+    expect(await terminateBridgeChild(
+      {
+        exited: new Promise<number>(() => {}),
+        kill: (signal) => signals.push(signal),
+      },
+      0,
+      0,
+      async () => {},
+    )).toBe(false);
+    expect(signals).toEqual(["SIGTERM", "SIGKILL"]);
+  });
+
+  test("supervisor treats the old TUI exit as expected and resumes only after detach", async () => {
+    const lifecycle = new CodexFrontendLifecycleQueue();
+    const terminal = terminalControl();
+    const events: string[] = [];
+    const launches: Array<{ args: string[]; child: ReturnType<typeof controlledBridgeChild> }> = [];
+    const result = superviseCodexTui({
+      channel: "dev",
+      codexBinary: "codex",
+      codexArgs: ["--model", "gpt-5.4", "do not replay me"],
+      socketPath: "/tmp/codex.sock",
+      cwd: "/workspace",
+      env: {},
+      lifecycle,
+      proxy: {
+        quiesceFrontend: () => {
+          events.push("quiesce");
+          return true;
+        },
+      },
+      launchTui: (_binary, args) => {
+        const label = `tui-${launches.length + 1}`;
+        events.push(`launch:${label}`);
+        const child = controlledBridgeChild({ events, label });
+        launches.push({ args, child });
+        return child;
+      },
+      terminalRun: terminal.run,
+      terminalNow: terminal.now,
+      terminationGraceMs: 0,
+      killWaitMs: 0,
+      log: () => {},
+    });
+
+    await waitFor(() => launches.length === 1, "initial TUI was not launched");
+    lifecycle.reset({ disconnectedGeneration: 1, threadId: "thread-exact" });
+    // The process may observe its closed backend and exit before the reset
+    // promise wins. That exit is expected inside this recovery window.
+    launches[0]!.child.resolveExit(1);
+    lifecycle.recovered({
+      disposition: "resume",
+      threadId: "thread-exact",
+      generation: 2,
+    });
+    await waitFor(() => launches.length === 2, "replacement TUI was not launched");
+
+    expect(events.indexOf("quiesce")).toBeGreaterThan(events.indexOf("launch:tui-1"));
+    expect(events.indexOf("launch:tui-2")).toBeGreaterThan(events.indexOf("quiesce"));
+    expect(launches[1]!.args).toEqual([
+      "resume",
+      "--remote",
+      "unix:///tmp/codex.sock",
+      "--model",
+      "gpt-5.4",
+      "thread-exact",
+    ]);
+
+    terminal.finish({ source: "delivery", code: 0 });
+    expect(await result).toBe(0);
+  });
+
+  test("supervisor cold-starts on the journal's exact thread without replaying argv input", async () => {
+    const lifecycle = new CodexFrontendLifecycleQueue();
+    const terminal = terminalControl();
+    const launches: string[][] = [];
+    const result = superviseCodexTui({
+      channel: "dev",
+      codexBinary: "codex",
+      codexArgs: ["--model", "gpt-5.4", "--image", "/tmp/input.png", "do not replay"],
+      initialThreadId: "thread-journal",
+      socketPath: "/tmp/codex.sock",
+      cwd: "/workspace",
+      env: {},
+      lifecycle,
+      proxy: { quiesceFrontend: () => true },
+      launchTui: (_binary, args) => {
+        launches.push(args);
+        return controlledBridgeChild();
+      },
+      terminalRun: terminal.run,
+      terminalNow: terminal.now,
+      terminationGraceMs: 0,
+      killWaitMs: 0,
+      log: () => {},
+    });
+
+    await waitFor(() => launches.length === 1, "journal-affine TUI was not launched");
+    expect(launches[0]).toEqual([
+      "resume",
+      "--remote",
+      "unix:///tmp/codex.sock",
+      "--model",
+      "gpt-5.4",
+      "thread-journal",
+    ]);
+    terminal.finish({ source: "delivery", code: 0 });
+    expect(await result).toBe(0);
+  });
+
+  test("supervisor rechecks the newest reset in the recovery-to-launch gap", async () => {
+    const lifecycle = new CodexFrontendLifecycleQueue();
+    const terminal = terminalControl();
+    const launches: string[][] = [];
+    const originalAccept = lifecycle.acceptRecovery.bind(lifecycle);
+    let injectedNewestReset = false;
+    lifecycle.acceptRecovery = (event) => {
+      const accepted = originalAccept(event);
+      if (accepted && !injectedNewestReset) {
+        injectedNewestReset = true;
+        lifecycle.reset({ disconnectedGeneration: 2, threadId: event.threadId });
+        lifecycle.recovered({
+          disposition: "resume",
+          threadId: "thread-newest",
+          generation: 3,
+        });
+      }
+      return accepted;
+    };
+    const result = superviseCodexTui({
+      channel: "dev",
+      codexBinary: "codex",
+      socketPath: "/tmp/codex.sock",
+      cwd: "/workspace",
+      env: {},
+      lifecycle,
+      proxy: { quiesceFrontend: () => true },
+      launchTui: (_binary, args) => {
+        launches.push(args);
+        return controlledBridgeChild();
+      },
+      terminalRun: terminal.run,
+      terminalNow: terminal.now,
+      terminationGraceMs: 0,
+      killWaitMs: 0,
+      log: () => {},
+    });
+
+    await waitFor(() => launches.length === 1, "initial TUI was not launched");
+    lifecycle.reset({ disconnectedGeneration: 1, threadId: "thread-stale" });
+    lifecycle.recovered({
+      disposition: "resume",
+      threadId: "thread-stale",
+      generation: 2,
+    });
+    await waitFor(() => launches.length === 2, "newest replacement was not launched");
+    expect(launches).toHaveLength(2);
+    expect(launches[1]!.at(-1)).toBe("thread-newest");
+    expect(launches[1]).not.toContain("thread-stale");
+
+    terminal.finish({ source: "delivery", code: 0 });
+    expect(await result).toBe(0);
+  });
+
+  test("supervisor never launches after delivery or signal is already terminal", async () => {
+    for (const terminalResult of [
+      { source: "delivery" as const, code: 7 },
+      { source: "signal" as const, code: 130 },
+    ]) {
+      const lifecycle = new CodexFrontendLifecycleQueue();
+      const terminal = terminalControl();
+      let launches = 0;
+      terminal.finish(terminalResult);
+      const result = await superviseCodexTui({
+        channel: "dev",
+        codexBinary: "codex",
+        socketPath: "/tmp/codex.sock",
+        cwd: "/workspace",
+        env: {},
+        lifecycle,
+        proxy: { quiesceFrontend: () => true },
+        launchTui: () => {
+          launches += 1;
+          return controlledBridgeChild();
+        },
+        terminalRun: terminal.run,
+        terminalNow: terminal.now,
+        terminationGraceMs: 0,
+        killWaitMs: 0,
+        log: () => {},
+      });
+      expect(result).toBe(terminalResult.code);
+      expect(launches).toBe(0);
+    }
+  });
+
+  test("supervisor replays initial argv only for a proven-not-written start", async () => {
+    const lifecycle = new CodexFrontendLifecycleQueue();
+    const terminal = terminalControl();
+    const launches: string[][] = [];
+    const codexArgs = ["--model", "gpt-5.4", "--image", "/tmp/input.png", "initial prompt"];
+    const result = superviseCodexTui({
+      channel: "dev",
+      codexBinary: "codex",
+      codexArgs,
+      socketPath: "/tmp/codex.sock",
+      cwd: "/workspace",
+      env: {},
+      lifecycle,
+      proxy: { quiesceFrontend: () => true },
+      launchTui: (_binary, args) => {
+        launches.push(args);
+        return controlledBridgeChild();
+      },
+      terminalRun: terminal.run,
+      terminalNow: terminal.now,
+      terminationGraceMs: 0,
+      killWaitMs: 0,
+      log: () => {},
+    });
+
+    await waitFor(() => launches.length === 1, "initial TUI was not launched");
+    lifecycle.reset({ disconnectedGeneration: 1, threadId: null });
+    lifecycle.recovered({
+      disposition: "restart",
+      threadId: null,
+      generation: 2,
+    });
+    await waitFor(() => launches.length === 2, "safe initial restart was not launched");
+    expect(launches[1]).toEqual(buildCodexTuiArgs("/tmp/codex.sock", codexArgs));
+
+    terminal.finish({ source: "delivery", code: 0 });
+    expect(await result).toBe(0);
+  });
+
+  test("supervisor resumes the created thread with the exact proven-not-written prompt", async () => {
+    const lifecycle = new CodexFrontendLifecycleQueue();
+    const terminal = terminalControl();
+    const launches: string[][] = [];
+    const result = superviseCodexTui({
+      channel: "dev",
+      codexBinary: "codex",
+      codexArgs: ["--model", "gpt-5.4", "original positional prompt"],
+      socketPath: "/tmp/codex.sock",
+      cwd: "/workspace",
+      env: {},
+      lifecycle,
+      proxy: { quiesceFrontend: () => true },
+      launchTui: (_binary, args) => {
+        launches.push(args);
+        return controlledBridgeChild();
+      },
+      terminalRun: terminal.run,
+      terminalNow: terminal.now,
+      terminationGraceMs: 0,
+      killWaitMs: 0,
+      log: () => {},
+    });
+
+    await waitFor(() => launches.length === 1, "initial TUI was not launched");
+    lifecycle.reset({ disconnectedGeneration: 1, threadId: "thread-bootstrap" });
+    lifecycle.recovered({
+      disposition: "restart_thread_with_prompt",
+      threadId: "thread-bootstrap",
+      generation: 2,
+      initialInput: [{
+        type: "text",
+        text: "WIRE_PROMPT_746",
+        text_elements: [],
+      }],
+    });
+    await waitFor(() => launches.length === 2, "prompt resume was not launched");
+    expect(launches[1]).toEqual([
+      "resume",
+      "--remote",
+      "unix:///tmp/codex.sock",
+      "--model",
+      "gpt-5.4",
+      "thread-bootstrap",
+      "WIRE_PROMPT_746",
+    ]);
+
+    terminal.finish({ source: "delivery", code: 0 });
+    expect(await result).toBe(0);
+  });
+
+  test("supervisor fails closed on an after-write initial start and on unsafe detach", async () => {
+    {
+      const lifecycle = new CodexFrontendLifecycleQueue();
+      const terminal = terminalControl();
+      let launches = 0;
+      const result = superviseCodexTui({
+        channel: "dev",
+        codexBinary: "codex",
+        codexArgs: ["initial prompt"],
+        socketPath: "/tmp/codex.sock",
+        cwd: "/workspace",
+        env: {},
+        lifecycle,
+        proxy: { quiesceFrontend: () => true },
+        launchTui: () => {
+          launches += 1;
+          return controlledBridgeChild();
+        },
+        terminalRun: terminal.run,
+        terminalNow: terminal.now,
+        terminationGraceMs: 0,
+        killWaitMs: 0,
+        log: () => {},
+      });
+      await waitFor(() => launches === 1, "initial TUI was not launched");
+      lifecycle.reset({ disconnectedGeneration: 1, threadId: null });
+      lifecycle.recovered({
+        disposition: "unknown",
+        threadId: null,
+        generation: 2,
+        reason: "thread/start crossed the transport write boundary",
+      });
+      expect(await result).toBe(1);
+      expect(launches).toBe(1);
+    }
+
+    {
+      const lifecycle = new CodexFrontendLifecycleQueue();
+      const terminal = terminalControl();
+      let launches = 0;
+      const result = superviseCodexTui({
+        channel: "dev",
+        codexBinary: "codex",
+        socketPath: "/tmp/codex.sock",
+        cwd: "/workspace",
+        env: {},
+        lifecycle,
+        proxy: { quiesceFrontend: () => true },
+        launchTui: () => {
+          launches += 1;
+          return controlledBridgeChild({ exitOnSignal: false });
+        },
+        terminalRun: terminal.run,
+        terminalNow: terminal.now,
+        terminationGraceMs: 0,
+        killWaitMs: 0,
+        log: () => {},
+      });
+      await waitFor(() => launches === 1, "initial TUI was not launched");
+      lifecycle.reset({ disconnectedGeneration: 1, threadId: "thread-one" });
+      lifecycle.recovered({
+        disposition: "resume",
+        threadId: "thread-one",
+        generation: 2,
+      });
+      expect(await result).toBe(1);
+      expect(launches).toBe(1);
+    }
+  });
+});

--- a/cli/test/codex-bridge-command.test.ts
+++ b/cli/test/codex-bridge-command.test.ts
@@ -10,10 +10,11 @@ import {
   writeFileSync,
 } from "node:fs";
 import { homedir, tmpdir } from "node:os";
-import { delimiter as pathDelimiter, join } from "node:path";
+import { delimiter as pathDelimiter, dirname, join } from "node:path";
 import type { Connection } from "../src/client";
 import {
   buildCodexChildEnv,
+  executableCommandNames,
   parseCodexVersion,
   resolveCodexBinary,
   resolveCodexLaunch,
@@ -455,6 +456,142 @@ describe("party bridge codex capability and argv boundary", () => {
     ]));
   });
 
+  test("resolves the native codex.exe through Windows PATHEXT semantics", () => {
+    const root = tempDir();
+    const bin = join(root, "bin");
+    mkdirSync(bin);
+    const codex = join(bin, "codex.exe");
+    writeFileSync(codex, "native codex fixture", { mode: 0o755 });
+
+    expect(
+      executableCommandNames("codex", {
+        PATHEXT: ".CMD;.EXE;.BAT;.COM",
+      }, "win32"),
+    ).toEqual(["codex.exe", "codex.com"]);
+    expect(
+      resolveCodexBinary(undefined, {
+        PATH: "bin",
+        PATHEXT: ".CMD;.EXE;.BAT;.COM",
+      }, root, { platform: "win32" }),
+    ).toBe(realpathSync(codex));
+  });
+
+  test("adapts the official Windows npm codex.cmd shim into a direct node invocation", () => {
+    const root = tempDir();
+    const bin = join(root, "bin");
+    const shim = join(bin, "codex.cmd");
+    const posixShim = join(bin, "codex");
+    const node = join(bin, "node.exe");
+    const entrypoint = join(bin, "node_modules", "@openai", "codex", "bin", "codex.js");
+    mkdirSync(dirname(entrypoint), { recursive: true });
+    writeFileSync(shim, "@echo off\r\n", { mode: 0o755 });
+    // npm's cmd-shim package also emits this POSIX wrapper on Windows. It is
+    // not a CreateProcess-compatible executable and must not mask codex.cmd.
+    writeFileSync(posixShim, "#!/bin/sh\n", { mode: 0o755 });
+    writeFileSync(node, "native node fixture", { mode: 0o755 });
+    writeFileSync(entrypoint, "console.log('codex')\n");
+
+    const launch = resolveCodexLaunch(shim, {
+      PATH: "bin",
+      PATHEXT: ".CMD;.EXE;.BAT;.COM",
+    }, root, { platform: "win32" });
+
+    expect(launch).toMatchObject({
+      ok: true,
+      codexBinary: realpathSync(node),
+      codexArgsPrefix: [realpathSync(entrypoint)],
+    });
+  });
+
+  test("prefers native codex.exe over the Windows npm cmd shim", () => {
+    const root = tempDir();
+    const bin = join(root, "bin");
+    mkdirSync(bin);
+    const native = join(bin, "codex.exe");
+    const shim = join(bin, "codex.cmd");
+    writeFileSync(native, "native codex fixture", { mode: 0o755 });
+    writeFileSync(shim, "@echo off\r\n", { mode: 0o755 });
+
+    const launch = resolveCodexLaunch(undefined, {
+      PATH: "bin",
+      PATHEXT: ".CMD;.EXE;.BAT;.COM",
+    }, root, { platform: "win32" });
+
+    expect(launch).toMatchObject({
+      ok: true,
+      codexBinary: realpathSync(native),
+      codexArgsPrefix: [],
+    });
+  });
+
+  test("rejects an explicit Windows cmd shim that is not the Codex npm package", () => {
+    const root = tempDir();
+    const shim = join(root, "codex.cmd");
+    writeFileSync(shim, "@echo off\r\n", { mode: 0o755 });
+
+    const launch = resolveCodexLaunch(shim, { PATH: "" }, root, { platform: "win32" });
+
+    expect(launch).toMatchObject({
+      ok: false,
+      error: expect.stringContaining("expected @openai/codex entrypoint"),
+    });
+  });
+
+  test("does not replace a missing explicit Windows cmd binding with a PATH shim", () => {
+    const root = tempDir();
+    const bin = join(root, "bin");
+    const shim = join(bin, "codex.cmd");
+    const node = join(bin, "node.exe");
+    const entrypoint = join(bin, "node_modules", "@openai", "codex", "bin", "codex.js");
+    mkdirSync(dirname(entrypoint), { recursive: true });
+    writeFileSync(shim, "@echo off\r\n", { mode: 0o755 });
+    writeFileSync(node, "native node fixture", { mode: 0o755 });
+    writeFileSync(entrypoint, "console.log('codex')\n");
+
+    const launch = resolveCodexLaunch(join(root, "missing", "codex.cmd"), {
+      PATH: "bin",
+      PATHEXT: ".CMD;.EXE",
+    }, root, { platform: "win32" });
+
+    expect(launch).toMatchObject({
+      ok: false,
+      error: expect.stringContaining("could not find an executable Codex CLI"),
+    });
+  });
+
+  test("rejects an explicit Windows bat wrapper instead of handing it to direct spawn", () => {
+    const root = tempDir();
+    const wrapper = join(root, "codex.bat");
+    writeFileSync(wrapper, "@echo off\r\n", { mode: 0o755 });
+
+    const launch = resolveCodexLaunch(wrapper, { PATH: "" }, root, { platform: "win32" });
+
+    expect(launch).toMatchObject({
+      ok: false,
+      error: expect.stringContaining("cannot be launched safely without a shell"),
+    });
+  });
+
+  test("rejects the Windows npm shim when node.exe is absent from the child PATH", () => {
+    const root = tempDir();
+    const bin = join(root, "bin");
+    const shim = join(bin, "codex.cmd");
+    const entrypoint = join(bin, "node_modules", "@openai", "codex", "bin", "codex.js");
+    mkdirSync(dirname(entrypoint), { recursive: true });
+    writeFileSync(shim, "@echo off\r\n", { mode: 0o755 });
+    writeFileSync(entrypoint, "console.log('codex')\n");
+
+    const launch = resolveCodexLaunch(shim, {
+      PATH: "bin",
+      PATHEXT: ".CMD;.EXE",
+    }, root, { platform: "win32" });
+
+    expect(launch).toMatchObject({
+      ok: false,
+      error: expect.stringContaining("requires node.exe on PATH"),
+    });
+  });
+
   test("honors AGENTPARTY_CODEX_BIN under a minimized GUI/launchd PATH", () => {
     const root = tempDir();
     const bin = join(root, "private-bin");
@@ -567,12 +704,14 @@ describe("party bridge codex process lifecycle", () => {
         }));
       }
       const launches: string[][] = [];
+      const appServerPrefixes: string[][] = [];
       let requestsAtConnect: string[] = [];
       let appServerSpawns = 0;
       const result = await runCodexSessionBridge(
         {
           channel: "dev",
           codexBinary: process.execPath,
+          codexArgsPrefix: ["/npm/@openai/codex/bin/codex.js"],
           codexArgs: [
             "--model",
             "gpt-5.4",
@@ -591,8 +730,9 @@ describe("party bridge codex process lifecycle", () => {
             config: { kind: "none", path: null },
             account: { present: false, path: join(root, "account.json") },
           }),
-          spawnAppServer: () => {
+          spawnAppServer: ({ codexArgsPrefix }) => {
             appServerSpawns += 1;
+            appServerPrefixes.push(codexArgsPrefix);
             return spawn(process.execPath, ["run", mockCodexFixture], {
               stdio: ["pipe", "pipe", "pipe"],
               env: { ...process.env, MOCK_CODEX_STATE_PATH: statePath },
@@ -624,6 +764,7 @@ describe("party bridge codex process lifecycle", () => {
       );
       return {
         appServerSpawns,
+        appServerPrefixes,
         launches,
         requestsAtConnect,
         result,
@@ -636,7 +777,9 @@ describe("party bridge codex process lifecycle", () => {
       const empty = await runWithThreads([]);
       expect(empty.result).toBe(0);
       expect(empty.appServerSpawns).toBe(1);
+      expect(empty.appServerPrefixes).toEqual([["/npm/@openai/codex/bin/codex.js"]]);
       expect(empty.launches).toEqual([[
+        "/npm/@openai/codex/bin/codex.js",
         "--remote",
         `unix://${join(empty.runtimePath, "codex.sock")}`,
         "--model",
@@ -649,7 +792,9 @@ describe("party bridge codex process lifecycle", () => {
       const exact = await runWithThreads(["thread-journal"]);
       expect(exact.result).toBe(0);
       expect(exact.appServerSpawns).toBe(1);
+      expect(exact.appServerPrefixes).toEqual([["/npm/@openai/codex/bin/codex.js"]]);
       expect(exact.launches).toEqual([[
+        "/npm/@openai/codex/bin/codex.js",
         "resume",
         "--remote",
         `unix://${join(exact.runtimePath, "codex.sock")}`,

--- a/cli/test/codex-delivery-recovery-lane.test.ts
+++ b/cli/test/codex-delivery-recovery-lane.test.ts
@@ -1,0 +1,559 @@
+import { expect, test } from "bun:test";
+import type { ClientFrame, ServerFrame } from "@agentparty/shared";
+import {
+  CodexAgentPartyBridge,
+  CodexSessionController,
+  type CodexRpcPeer,
+  type JsonRpcId,
+  type JsonRpcNotification,
+  type JsonRpcRequest,
+  type JsonRpcResponse,
+} from "../src/codex-app-server-bridge";
+import { DeliveryRecoveryJournal } from "../src/delivery-recovery-journal";
+import { deliveryFrame, welcomeDirectedFrame } from "./mock-server";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+class LaneRpcPeer implements CodexRpcPeer {
+  readonly initializeResult = {};
+  readonly calls: Array<{ method: string; params?: unknown }> = [];
+  startCalls = 0;
+  steerBlock: Promise<void> | null = null;
+  onSteer: (() => void) | null = null;
+  private readonly messages = new Set<
+    (message: JsonRpcRequest | JsonRpcNotification) => void | Promise<void>
+  >();
+  connectionGeneration = 1;
+
+  async start(): Promise<void> {
+    this.startCalls += 1;
+  }
+
+  async request(method: string, params?: unknown): Promise<unknown> {
+    this.calls.push({ method, params });
+    if (method === "thread/start") {
+      return {
+        thread: {
+          id: "thread-lane",
+          status: { type: "idle" },
+          turns: [],
+        },
+      };
+    }
+    if (method === "turn/start") {
+      return {
+        turn: {
+          id: "turn-lane",
+          status: "inProgress",
+          items: [{
+            type: "userMessage",
+            clientId: (params as { clientUserMessageId: string }).clientUserMessageId,
+          }],
+        },
+      };
+    }
+    if (method === "turn/steer") {
+      this.onSteer?.();
+      await this.steerBlock;
+      return {
+        turnId: (params as { expectedTurnId: string }).expectedTurnId,
+      };
+    }
+    if (method === "review/start") return {};
+    throw new Error(`unexpected method ${method}`);
+  }
+
+  async requestConnected(
+    method: string,
+    params?: unknown,
+    expectedGeneration?: number,
+  ): Promise<unknown> {
+    if (
+      expectedGeneration !== undefined &&
+      expectedGeneration !== this.connectionGeneration
+    ) {
+      throw new Error("fake generation changed before request write");
+    }
+    return await this.request(method, params);
+  }
+
+  async notify(): Promise<void> {}
+  respond(_id: JsonRpcId, _result?: unknown, _error?: JsonRpcResponse["error"]): void {}
+  onMessage(
+    listener: (message: JsonRpcRequest | JsonRpcNotification) => void | Promise<void>,
+  ): () => void {
+    this.messages.add(listener);
+    return () => this.messages.delete(listener);
+  }
+  onReconnect(_listener: (generation: number) => void | Promise<void>): () => void {
+    return () => {};
+  }
+
+  async emit(message: JsonRpcRequest | JsonRpcNotification): Promise<void> {
+    await Promise.all([...this.messages].map((listener) => listener(message)));
+  }
+}
+
+function streamingConnection() {
+  let cursor = 0;
+  const sent: ClientFrame[] = [];
+  const queued: ServerFrame[] = [];
+  let ended = false;
+  let wake: (() => void) | null = null;
+  const signal = () => {
+    const resolve = wake;
+    wake = null;
+    resolve?.();
+  };
+  const frames = (async function* (): AsyncGenerator<ServerFrame> {
+    for (;;) {
+      const frame = queued.shift();
+      if (frame) {
+        yield frame;
+        continue;
+      }
+      if (ended) return;
+      await new Promise<void>((resolve) => {
+        wake = resolve;
+      });
+    }
+  })();
+  return {
+    sent,
+    push(frame: ServerFrame) {
+      queued.push(frame);
+      signal();
+    },
+    connection: {
+      frames,
+      send(frame: ClientFrame) {
+        sent.push(frame);
+        return true;
+      },
+      ack(seq: number) {
+        cursor = Math.max(cursor, seq);
+      },
+      close() {
+        ended = true;
+        signal();
+      },
+      get cursor() {
+        return cursor;
+      },
+    },
+  };
+}
+
+async function waitFor(predicate: () => boolean, message: string): Promise<void> {
+  const deadline = Date.now() + 3_000;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error(message);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+test("reconnect fences an in-flight pre-harness claim and replays only after recovery", async () => {
+  const root = mkdtempSync(join(tmpdir(), "ap-codex-recovery-lane-"));
+  try {
+    const rpc = new LaneRpcPeer();
+    const session = new CodexSessionController(rpc);
+    await session.request("thread/start", { cwd: root });
+
+    const stream = streamingConnection();
+    const journal = new DeliveryRecoveryJournal(
+      join(root, "recovery.json"),
+      "dev",
+      "codex",
+    );
+    let releaseRunning!: () => void;
+    const runningGate = new Promise<void>((resolve) => {
+      releaseRunning = resolve;
+    });
+    let runningStarted!: () => void;
+    const enteredRunning = new Promise<void>((resolve) => {
+      runningStarted = resolve;
+    });
+    let firstRunning = true;
+    const bridge = new CodexAgentPartyBridge({
+      channel: "dev",
+      connection: stream.connection,
+      session,
+      recoveryJournal: journal,
+      requireDeliveryRecovery: true,
+      leaseRenewIntervalMs: 60_000,
+      postReply: async () => ({ seq: 1 }),
+      confirmDeliveryUpdate: async (update) => {
+        if (update.state === "running" && firstRunning) {
+          firstRunning = false;
+          runningStarted();
+          await runningGate;
+        }
+        return update.state;
+      },
+      log: () => {},
+    });
+    const run = bridge.run();
+    stream.push(welcomeDirectedFrame(0, "me") as ServerFrame);
+    await waitFor(
+      () => stream.sent.some((frame) => frame.type === "delivery_adapter"),
+      "initial watch registration was not sent",
+    );
+
+    stream.push(deliveryFrame(41, "write exactly once", {
+      id: "delivery-recovery-lane",
+      target_name: "me",
+    }) as ServerFrame);
+    await enteredRunning;
+    expect(journal.get("delivery-recovery-lane")).toMatchObject({ phase: "claimed" });
+
+    // The welcome synchronously invalidates the old generation, then queues
+    // recovery behind the delivery whose running acknowledgement is still in
+    // flight. Releasing that stale ACK must not cross the app-server boundary.
+    stream.push(welcomeDirectedFrame(41, "me") as ServerFrame);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(stream.sent.some((frame) => frame.type === "delivery_recover")).toBe(false);
+
+    releaseRunning();
+    await waitFor(
+      () => stream.sent.some((frame) => frame.type === "delivery_recover"),
+      "recovery did not run after the prior writer lane settled",
+    );
+    const recovery = stream.sent.find(
+      (frame): frame is Extract<ClientFrame, { type: "delivery_recover" }> =>
+        frame.type === "delivery_recover",
+    )!;
+    expect(recovery.replay_safe).toBe(true);
+    expect(journal.get("delivery-recovery-lane")).toMatchObject({
+      phase: "claimed",
+      threadId: "thread-lane",
+    });
+    expect(rpc.calls.filter((call) => call.method === "turn/start")).toHaveLength(0);
+
+    stream.push({
+      type: "delivery_recovery",
+      delivery_id: recovery.delivery_id,
+      request_id: recovery.request_id,
+      result: "recovered",
+      state: "running",
+      attempt: recovery.attempt,
+      lease_epoch: recovery.lease_epoch,
+      lease_token: recovery.next_lease_token,
+      lease_until: Date.now() + 90_000,
+    });
+    await waitFor(
+      () => journal.get("delivery-recovery-lane")?.phase === "harness_accepted",
+      "recovered delivery was not written exactly once",
+    );
+    expect(rpc.calls.filter((call) => call.method === "turn/start")).toHaveLength(1);
+
+    bridge.close();
+    expect(await run).toBe(0);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("transport disconnect fences an autonomously flushed queue until token recovery", async () => {
+  const root = mkdtempSync(join(tmpdir(), "ap-codex-disconnect-lane-"));
+  try {
+    const rpc = new LaneRpcPeer();
+    const session = new CodexSessionController(rpc);
+    await session.request("thread/start", { cwd: root });
+    const stream = streamingConnection();
+    const journal = new DeliveryRecoveryJournal(
+      join(root, "recovery.json"),
+      "dev",
+      "codex",
+    );
+    const bridge = new CodexAgentPartyBridge({
+      channel: "dev",
+      connection: stream.connection,
+      session,
+      recoveryJournal: journal,
+      requireDeliveryRecovery: true,
+      leaseRenewIntervalMs: 60_000,
+      retryDelayMs: 5,
+      postReply: async () => ({ seq: 1 }),
+      confirmDeliveryUpdate: async (update) => update.state,
+      log: () => {},
+    });
+    const run = bridge.run();
+    stream.push(welcomeDirectedFrame(0, "me") as ServerFrame);
+    await waitFor(
+      () => stream.sent.some((frame) => frame.type === "delivery_adapter"),
+      "initial watch registration was not sent",
+    );
+
+    await session.request("review/start", {
+      threadId: "thread-lane",
+      delivery: "inline",
+    });
+    await rpc.emit({
+      method: "turn/started",
+      params: {
+        threadId: "thread-lane",
+        turn: { id: "review-turn", status: "inProgress", items: [] },
+      },
+    });
+    stream.push(deliveryFrame(51, "must wait for recovered ownership", {
+      id: "delivery-disconnect-lane",
+      target_name: "me",
+    }) as ServerFrame);
+    await waitFor(
+      () => journal.get("delivery-disconnect-lane")?.phase === "running_authorized",
+      "delivery did not reach the replay-safe local queue",
+    );
+
+    bridge.handleConnectionStatus("reconnecting");
+    await rpc.emit({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-lane",
+        turn: { id: "review-turn", status: "completed", items: [] },
+      },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    expect(rpc.calls.filter((call) => call.method === "turn/start")).toHaveLength(0);
+    expect(journal.get("delivery-disconnect-lane")).toMatchObject({
+      phase: "running_authorized",
+      threadId: "thread-lane",
+    });
+
+    stream.push(welcomeDirectedFrame(51, "me") as ServerFrame);
+    await waitFor(
+      () => stream.sent.some((frame) =>
+        frame.type === "delivery_recover" &&
+        frame.delivery_id === "delivery-disconnect-lane"
+      ),
+      "disconnect recovery was not requested",
+    );
+    const recovery = stream.sent.find((frame) =>
+      frame.type === "delivery_recover" &&
+      frame.delivery_id === "delivery-disconnect-lane"
+    ) as Extract<ClientFrame, { type: "delivery_recover" }>;
+    expect(recovery.replay_safe).toBe(true);
+    expect(rpc.calls.filter((call) => call.method === "turn/start")).toHaveLength(0);
+
+    stream.push({
+      type: "delivery_recovery",
+      delivery_id: recovery.delivery_id,
+      request_id: recovery.request_id,
+      result: "recovered",
+      state: "running",
+      attempt: recovery.attempt,
+      lease_epoch: recovery.lease_epoch,
+      lease_token: recovery.next_lease_token,
+      lease_until: Date.now() + 90_000,
+    } as ServerFrame);
+    await waitFor(
+      () => rpc.calls.filter((call) => call.method === "turn/start").length === 1,
+      "recovered queued delivery did not flush exactly once",
+    );
+    expect(journal.get("delivery-disconnect-lane")).toMatchObject({
+      phase: "harness_accepted",
+      threadId: "thread-lane",
+    });
+    expect(rpc.calls.filter((call) => call.method === "turn/start")).toHaveLength(1);
+
+    bridge.close();
+    expect(await run).toBe(0);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("final synchronous authorization check closes the WAL-to-transport microtask gap", async () => {
+  const root = mkdtempSync(join(tmpdir(), "ap-codex-final-fence-"));
+  try {
+    const rpc = new LaneRpcPeer();
+    const session = new CodexSessionController(rpc);
+    await session.request("thread/start", { cwd: root });
+    const stream = streamingConnection();
+    const journal = new DeliveryRecoveryJournal(
+      join(root, "recovery.json"),
+      "dev",
+      "codex",
+    );
+    let bridge!: CodexAgentPartyBridge;
+    let disconnectAtHarnessWal = true;
+    const update = journal.update.bind(journal);
+    journal.update = ((deliveryId, patch) => {
+      const result = update(deliveryId, patch);
+      if (patch.phase === "harness_issued" && disconnectAtHarnessWal) {
+        disconnectAtHarnessWal = false;
+        queueMicrotask(() => bridge.handleConnectionStatus("reconnecting"));
+      }
+      return result;
+    }) as typeof journal.update;
+
+    bridge = new CodexAgentPartyBridge({
+      channel: "dev",
+      connection: stream.connection,
+      session,
+      recoveryJournal: journal,
+      requireDeliveryRecovery: true,
+      leaseRenewIntervalMs: 60_000,
+      postReply: async () => ({ seq: 1 }),
+      confirmDeliveryUpdate: async (updateFrame) => updateFrame.state,
+      log: () => {},
+    });
+    const run = bridge.run();
+    stream.push(welcomeDirectedFrame(0, "me") as ServerFrame);
+    await waitFor(
+      () => stream.sent.some((frame) => frame.type === "delivery_adapter"),
+      "initial watch registration was not sent",
+    );
+    stream.push(deliveryFrame(61, "disconnect after WAL, before transport", {
+      id: "delivery-final-fence",
+      target_name: "me",
+    }) as ServerFrame);
+    await waitFor(
+      () => journal.get("delivery-final-fence")?.phase === "running_authorized",
+      "pre-transport generation failure did not roll the WAL back",
+    );
+    expect(rpc.calls.filter((call) => call.method === "turn/start")).toHaveLength(0);
+
+    stream.push(welcomeDirectedFrame(61, "me") as ServerFrame);
+    await waitFor(
+      () => stream.sent.some((frame) =>
+        frame.type === "delivery_recover" &&
+        frame.delivery_id === "delivery-final-fence"
+      ),
+      "rolled-back delivery did not request recovery",
+    );
+    const recovery = stream.sent.find((frame) =>
+      frame.type === "delivery_recover" &&
+      frame.delivery_id === "delivery-final-fence"
+    ) as Extract<ClientFrame, { type: "delivery_recover" }>;
+    expect(recovery.replay_safe).toBe(true);
+    stream.push({
+      type: "delivery_recovery",
+      delivery_id: recovery.delivery_id,
+      request_id: recovery.request_id,
+      result: "recovered",
+      state: "running",
+      attempt: recovery.attempt,
+      lease_epoch: recovery.lease_epoch,
+      lease_token: recovery.next_lease_token,
+      lease_until: Date.now() + 90_000,
+    } as ServerFrame);
+    await waitFor(
+      () => rpc.calls.filter((call) => call.method === "turn/start").length === 1,
+      "recovered delivery did not cross the transport exactly once",
+    );
+    expect(rpc.calls.filter((call) => call.method === "turn/start")).toHaveLength(1);
+    expect(journal.get("delivery-final-fence")?.phase).toBe("harness_accepted");
+
+    bridge.close();
+    expect(await run).toBe(0);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("interactive writer rechecks recovery readiness after waiting for the arbiter lane", async () => {
+  const root = mkdtempSync(join(tmpdir(), "ap-codex-tui-recovery-fence-"));
+  try {
+    const rpc = new LaneRpcPeer();
+    const session = new CodexSessionController(rpc);
+    await session.request("thread/start", { cwd: root });
+    const stream = streamingConnection();
+    const journal = new DeliveryRecoveryJournal(
+      join(root, "recovery.json"),
+      "dev",
+      "codex",
+    );
+    const bridge = new CodexAgentPartyBridge({
+      channel: "dev",
+      connection: stream.connection,
+      session,
+      recoveryJournal: journal,
+      requireDeliveryRecovery: true,
+      leaseRenewIntervalMs: 60_000,
+      postReply: async () => ({ seq: 1 }),
+      confirmDeliveryUpdate: async (update) => update.state,
+      log: () => {},
+    });
+    const run = bridge.run();
+    stream.push(welcomeDirectedFrame(0, "me") as ServerFrame);
+    await waitFor(
+      () => stream.sent.some((frame) => frame.type === "delivery_adapter"),
+      "initial watch registration was not sent",
+    );
+    stream.push(deliveryFrame(71, "keep a durable delivery obligation", {
+      id: "delivery-tui-fence",
+      target_name: "me",
+    }) as ServerFrame);
+    await waitFor(
+      () => journal.get("delivery-tui-fence")?.phase === "harness_accepted",
+      "AgentParty delivery did not establish the active turn",
+    );
+
+    let releaseFirstSteer!: () => void;
+    rpc.steerBlock = new Promise<void>((resolve) => {
+      releaseFirstSteer = resolve;
+    });
+    let firstSteerEntered!: () => void;
+    const firstEntered = new Promise<void>((resolve) => {
+      firstSteerEntered = resolve;
+    });
+    rpc.onSteer = firstSteerEntered;
+    const firstSteer = session.request("turn/steer", {
+      threadId: "thread-lane",
+      expectedTurnId: "turn-lane",
+      input: [{ type: "text", text: "first TUI steer", text_elements: [] }],
+    });
+    await firstEntered;
+
+    const readinessCallsBeforeSecond = rpc.startCalls;
+    const secondSteer = session.request("turn/steer", {
+      threadId: "thread-lane",
+      expectedTurnId: "turn-lane",
+      input: [{ type: "text", text: "second TUI steer", text_elements: [] }],
+    });
+    await waitFor(
+      () => rpc.startCalls > readinessCallsBeforeSecond,
+      "second mutation did not pass the outer readiness check",
+    );
+    bridge.handleConnectionStatus("reconnecting");
+    rpc.steerBlock = null;
+    rpc.onSteer = null;
+    releaseFirstSteer();
+    await firstSteer;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(rpc.calls.filter((call) => call.method === "turn/steer")).toHaveLength(1);
+
+    stream.push(welcomeDirectedFrame(71, "me") as ServerFrame);
+    await waitFor(
+      () => stream.sent.some((frame) =>
+        frame.type === "delivery_recover" &&
+        frame.delivery_id === "delivery-tui-fence"
+      ),
+      "TUI fence did not request durable delivery recovery",
+    );
+    const recovery = stream.sent.find((frame) =>
+      frame.type === "delivery_recover" &&
+      frame.delivery_id === "delivery-tui-fence"
+    ) as Extract<ClientFrame, { type: "delivery_recover" }>;
+    expect(recovery.replay_safe).toBeUndefined();
+    stream.push({
+      type: "delivery_recovery",
+      delivery_id: recovery.delivery_id,
+      request_id: recovery.request_id,
+      result: "recovered",
+      state: "running",
+      attempt: recovery.attempt,
+      lease_epoch: recovery.lease_epoch,
+      lease_token: recovery.next_lease_token,
+      lease_until: Date.now() + 90_000,
+    } as ServerFrame);
+    await secondSteer;
+    expect(rpc.calls.filter((call) => call.method === "turn/steer")).toHaveLength(2);
+
+    bridge.close();
+    expect(await run).toBe(0);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/cli/test/codex-turn-arbiter.test.ts
+++ b/cli/test/codex-turn-arbiter.test.ts
@@ -1,0 +1,1368 @@
+import { describe, expect, test } from "bun:test";
+import {
+  CodexBridgeQueueFullError,
+  CodexInteractiveMutationBlockedError,
+  CodexRetryableBeforeWriteError,
+  CodexTurnArbiter,
+  nonSteerableTurnKind,
+  type CodexDispatch,
+  type CodexTurnStartParams,
+  type CodexTurnSteerParams,
+  type CodexTurnTransport,
+} from "../src/codex-turn-arbiter";
+
+function input(id: string, text = id) {
+  return {
+    text,
+    clientUserMessageId: `agentparty:${id}`,
+    metadata: { delivery_id: id },
+  };
+}
+
+function transport(over: Partial<CodexTurnTransport> = {}) {
+  const starts: CodexTurnStartParams[] = [];
+  const steers: CodexTurnSteerParams[] = [];
+  let next = 1;
+  const value: CodexTurnTransport = {
+    async turnStart(params) {
+      starts.push(params);
+      return { turn: { id: `turn-${next++}` } };
+    },
+    async turnSteer(params) {
+      steers.push(params);
+      return { turnId: params.expectedTurnId };
+    },
+    ...over,
+  };
+  return { value, starts, steers };
+}
+
+function rpcError(data?: unknown): Error & { code: number; data?: unknown } {
+  return Object.assign(new Error("app-server rejected request"), {
+    code: -32_000,
+    ...(data === undefined ? {} : { data }),
+  });
+}
+
+async function waitFor(predicate: () => boolean, message: string): Promise<void> {
+  const deadline = Date.now() + 2_000;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error(message);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+describe("Codex app-server single-writer arbiter", () => {
+  test("idle uses turn/start with exact app-server input shape", async () => {
+    const mock = transport();
+    const arbiter = new CodexTurnArbiter("thread-1", mock.value);
+    await arbiter.observeResume({ thread: { status: { type: "idle" }, turns: [] } });
+
+    const result = await arbiter.submit(input("delivery-1", "hello"));
+    expect(result).toEqual({ kind: "started", turnId: "turn-1" });
+    expect(mock.starts).toEqual([{
+      threadId: "thread-1",
+      clientUserMessageId: "agentparty:delivery-1",
+      input: [{ type: "text", text: "hello", text_elements: [] }],
+      responsesapiClientMetadata: { delivery_id: "delivery-1" },
+    }]);
+    expect(mock.steers).toHaveLength(0);
+  });
+
+  test("running turn always uses turn/steer with expectedTurnId, never turn/start", async () => {
+    const mock = transport();
+    const arbiter = new CodexTurnArbiter("thread-1", mock.value);
+    await arbiter.observeResume({
+      thread: {
+        status: { type: "active" },
+        turns: [{ id: "active-7", status: "inProgress", items: [] }],
+      },
+    });
+
+    const result = await arbiter.submit(input("delivery-2", "new channel input"));
+    expect(result).toEqual({ kind: "steered", turnId: "active-7" });
+    expect(mock.starts).toHaveLength(0);
+    expect(mock.steers).toEqual([{
+      threadId: "thread-1",
+      clientUserMessageId: "agentparty:delivery-2",
+      input: [{ type: "text", text: "new channel input", text_elements: [] }],
+      responsesapiClientMetadata: { delivery_id: "delivery-2" },
+      expectedTurnId: "active-7",
+    }]);
+  });
+
+  test("two simultaneous idle writers serialize to one start followed by steer", async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const starts: CodexTurnStartParams[] = [];
+    const steers: CodexTurnSteerParams[] = [];
+    const arbiter = new CodexTurnArbiter("thread-1", {
+      async turnStart(params) {
+        starts.push(params);
+        await gate;
+        return { turn: { id: "turn-race" } };
+      },
+      async turnSteer(params) {
+        steers.push(params);
+        return { turnId: params.expectedTurnId };
+      },
+    });
+    await arbiter.observeThreadIdle();
+
+    const first = arbiter.submit(input("race-1"));
+    const second = arbiter.submit(input("race-2"));
+    await Promise.resolve();
+    release();
+    await Promise.all([first, second]);
+
+    expect(starts).toHaveLength(1);
+    expect(steers).toHaveLength(1);
+    expect(steers[0]!.expectedTurnId).toBe("turn-race");
+  });
+
+  test("a definitive idle start rejection retries automatically and succeeds once", async () => {
+    let attempts = 0;
+    let rejectedWrites = 0;
+    const mock = transport({
+      async turnStart(params) {
+        attempts += 1;
+        if (attempts === 1) throw rpcError();
+        return { turn: { id: `retry-${params.clientUserMessageId}` } };
+      },
+    });
+    const arbiter = new CodexTurnArbiter("thread-1", mock.value);
+    await arbiter.observeThreadIdle();
+
+    expect(await arbiter.submit({
+      ...input("start-retry"),
+      onWriteRejected: () => {
+        rejectedWrites += 1;
+      },
+    })).toMatchObject({ kind: "queued", reason: "start_rejected" });
+    expect(arbiter.snapshot()).toMatchObject({
+      phase: { type: "idle" },
+      queueDepth: 1,
+    });
+    await waitFor(
+      () => attempts === 2 && arbiter.snapshot().queueDepth === 0,
+      "idle start rejection was never retried",
+    );
+    expect(rejectedWrites).toBe(1);
+    expect(attempts).toBe(2);
+    expect(arbiter.snapshot().phase.type).toBe("normal");
+  });
+
+  test("a queued WAL failure is restored and retried without losing or duplicating input", async () => {
+    let walAttempts = 0;
+    const queuedErrors: unknown[] = [];
+    const mock = transport();
+    const arbiter = new CodexTurnArbiter("thread-1", mock.value, {
+      onQueuedError: ({ error }) => {
+        queuedErrors.push(error);
+      },
+    });
+    await arbiter.enterUnsteerable("review", "review-wal");
+    expect(await arbiter.submit({
+      ...input("queued-wal"),
+      beforeWrite: () => {
+        walAttempts += 1;
+        if (walAttempts === 1) {
+          throw new CodexRetryableBeforeWriteError("journal ENOSPC");
+        }
+      },
+    })).toMatchObject({ kind: "queued", reason: "review" });
+
+    await arbiter.observeTurnCompleted("review-wal");
+    expect(mock.starts).toHaveLength(0);
+    expect(arbiter.snapshot().queueDepth).toBe(1);
+    await waitFor(
+      () => mock.starts.length === 1 && arbiter.snapshot().queueDepth === 0,
+      "queued WAL failure was never retried",
+    );
+    expect(walAttempts).toBe(2);
+    expect(queuedErrors).toHaveLength(1);
+    expect(mock.starts[0]!.clientUserMessageId).toBe("agentparty:queued-wal");
+  });
+
+  test("cancelQueued revokes only a pre-write queue entry", async () => {
+    const mock = transport();
+    const arbiter = new CodexTurnArbiter("thread-1", mock.value);
+    await arbiter.enterUnsteerable("review", "review-cancel");
+    expect(await arbiter.submit(input("cancel-me"))).toMatchObject({ kind: "queued" });
+    expect(await arbiter.cancelQueued("agentparty:cancel-me")).toBe(true);
+    expect(await arbiter.cancelQueued("agentparty:cancel-me")).toBe(false);
+    await arbiter.observeTurnCompleted("review-cancel");
+    expect(mock.starts).toHaveLength(0);
+    expect(arbiter.snapshot().queueDepth).toBe(0);
+  });
+
+  test("rollback debt is durably retried before a rejected idle start is sent again", async () => {
+    const events: string[] = [];
+    let transportAttempts = 0;
+    let rollbackAttempts = 0;
+    const arbiter = new CodexTurnArbiter("thread-1", {
+      async turnStart() {
+        transportAttempts += 1;
+        events.push(`transport-${transportAttempts}`);
+        if (transportAttempts === 1) throw rpcError();
+        return { turn: { id: "after-rollback" } };
+      },
+      async turnSteer() {
+        throw new Error("must not steer");
+      },
+    });
+    await arbiter.observeThreadIdle();
+    expect(await arbiter.submit({
+      ...input("rollback-idle"),
+      beforeWrite: () => {
+        events.push("before-write");
+      },
+      onWriteRejected: () => {
+        rollbackAttempts += 1;
+        events.push(`rollback-${rollbackAttempts}`);
+        if (rollbackAttempts === 1) throw new Error("rollback WAL ENOSPC");
+      },
+    })).toMatchObject({ kind: "queued", reason: "start_rejected" });
+
+    await waitFor(
+      () => transportAttempts === 2 && arbiter.snapshot().queueDepth === 0,
+      "rollback debt never recovered and retried the start",
+    );
+    expect(events).toEqual([
+      "before-write",
+      "transport-1",
+      "rollback-1",
+      "rollback-2",
+      "before-write",
+      "transport-2",
+    ]);
+  });
+
+  test("rollback-only retry runs during review without sending a second transport", async () => {
+    let rollbackAttempts = 0;
+    let steerAttempts = 0;
+    const starts: CodexTurnStartParams[] = [];
+    const arbiter = new CodexTurnArbiter("thread-1", {
+      async turnStart(params) {
+        starts.push(params);
+        return { turn: { id: "after-review-rollback" } };
+      },
+      async turnSteer() {
+        steerAttempts += 1;
+        throw rpcError({
+          codexErrorInfo: { activeTurnNotSteerable: { turnKind: "review" } },
+        });
+      },
+    });
+    await arbiter.observeTurnStarted("review-rejection");
+    expect(await arbiter.submit({
+      ...input("rollback-review"),
+      onWriteRejected: () => {
+        rollbackAttempts += 1;
+        if (rollbackAttempts === 1) throw new Error("rollback WAL ENOSPC");
+      },
+    })).toMatchObject({ kind: "queued", reason: "review" });
+    await waitFor(
+      () => rollbackAttempts === 2,
+      "rollback debt did not retry independently of the review phase",
+    );
+    expect(steerAttempts).toBe(1);
+    expect(starts).toHaveLength(0);
+    expect(arbiter.snapshot().queueDepth).toBe(1);
+
+    await arbiter.observeTurnCompleted("review-rejection");
+    expect(starts).toHaveLength(1);
+    expect(starts[0]!.clientUserMessageId).toBe("agentparty:rollback-review");
+  });
+
+  test("interactive writes cannot cross rollback debt that is still failing", async () => {
+    let startAttempts = 0;
+    let rollbackAttempts = 0;
+    let tuiWrites = 0;
+    const arbiter = new CodexTurnArbiter("thread-1", {
+      async turnStart() {
+        startAttempts += 1;
+        if (startAttempts === 1) throw rpcError();
+        return { turn: { id: "after-global-rollback-fence" } };
+      },
+      async turnSteer() {
+        throw new Error("AgentParty steer was not expected");
+      },
+    });
+    await arbiter.observeThreadIdle();
+    expect(await arbiter.submit({
+      ...input("global-rollback-fence"),
+      onWriteRejected: () => {
+        rollbackAttempts += 1;
+        if (rollbackAttempts <= 2) throw new Error("rollback storage unavailable");
+      },
+    })).toMatchObject({ kind: "queued" });
+
+    await expect(arbiter.runInteractiveMutation(
+      "turn/steer",
+      { threadId: "thread-1", expectedTurnId: "after-global-rollback-fence" },
+      async () => {
+        tuiWrites += 1;
+        return { turnId: "after-global-rollback-fence" };
+      },
+    )).rejects.toBeInstanceOf(CodexRetryableBeforeWriteError);
+    expect(tuiWrites).toBe(0);
+    expect(startAttempts).toBe(1);
+
+    await waitFor(
+      () => startAttempts === 2 && arbiter.snapshot().phase.type === "normal",
+      "rollback debt did not settle before the queued AgentParty retry",
+    );
+    await expect(arbiter.runInteractiveMutation(
+      "turn/steer",
+      { threadId: "thread-1", expectedTurnId: "after-global-rollback-fence" },
+      async () => {
+        tuiWrites += 1;
+        return { turnId: "after-global-rollback-fence" };
+      },
+    )).resolves.toEqual({ turnId: "after-global-rollback-fence" });
+    expect(rollbackAttempts).toBe(3);
+    expect(tuiWrites).toBe(1);
+  });
+
+  test.each(["review", "compact"] as const)(
+    "%s is non-steerable: AgentParty input is bounded-queued until completion",
+    async (kind) => {
+      const mock = transport();
+      const dispatched: string[] = [];
+      const arbiter = new CodexTurnArbiter("thread-1", mock.value, {
+        maxQueue: 2,
+        onQueuedDispatch: ({ input: queued }) => {
+          dispatched.push(queued.clientUserMessageId);
+        },
+      });
+      await arbiter.enterUnsteerable(kind, `${kind}-turn`);
+      expect(await arbiter.submit(input(`${kind}-1`))).toMatchObject({
+        kind: "queued",
+        queuePosition: 1,
+        reason: kind,
+      });
+      expect(await arbiter.submit(input(`${kind}-2`))).toMatchObject({
+        kind: "queued",
+        queuePosition: 2,
+        reason: kind,
+      });
+      await expect(arbiter.submit(input(`${kind}-3`))).rejects.toBeInstanceOf(CodexBridgeQueueFullError);
+      expect(mock.starts).toHaveLength(0);
+      expect(mock.steers).toHaveLength(0);
+
+      await arbiter.observeTurnCompleted(`${kind}-turn`);
+      expect(mock.starts).toHaveLength(1);
+      expect(mock.starts[0]!.clientUserMessageId).toBe(`agentparty:${kind}-1`);
+      expect(dispatched).toEqual([`agentparty:${kind}-1`]);
+      expect(arbiter.snapshot().queueDepth).toBe(1);
+    },
+  );
+
+  test("structured activeTurnNotSteerable error changes phase and queues without blind start", async () => {
+    const starts: CodexTurnStartParams[] = [];
+    const steers: CodexTurnSteerParams[] = [];
+    const error = rpcError({
+      codexErrorInfo: { activeTurnNotSteerable: { turnKind: "review" } },
+    });
+    const arbiter = new CodexTurnArbiter("thread-1", {
+      async turnStart(params) {
+        starts.push(params);
+        return { turn: { id: "after-review" } };
+      },
+      async turnSteer(params) {
+        steers.push(params);
+        throw error;
+      },
+    });
+    await arbiter.observeTurnStarted("review-turn");
+
+    const result = await arbiter.submit(input("during-review"));
+    expect(result).toMatchObject({ kind: "queued", reason: "review" });
+    expect(nonSteerableTurnKind(error)).toBe("review");
+    expect(starts).toHaveLength(0);
+    expect(steers[0]!.expectedTurnId).toBe("review-turn");
+    expect(arbiter.snapshot().phase).toEqual({ type: "review", turnId: "review-turn" });
+
+    await arbiter.observeTurnCompleted("review-turn");
+    expect(starts).toHaveLength(1);
+  });
+
+  test("stale expectedTurnId rejection resyncs and steers the queued input into the new turn", async () => {
+    const steers: CodexTurnSteerParams[] = [];
+    let calls = 0;
+    const arbiter = new CodexTurnArbiter("thread-1", {
+      async turnStart() {
+        throw new Error("must not start");
+      },
+      async turnSteer(params) {
+        steers.push(params);
+        calls += 1;
+        if (calls === 1) throw rpcError();
+        return { turnId: params.expectedTurnId };
+      },
+    });
+    await arbiter.observeTurnStarted("old-turn");
+    expect(await arbiter.submit(input("stale"))).toMatchObject({
+      kind: "queued",
+      reason: "steer_rejected",
+    });
+    expect(arbiter.snapshot().phase.type).toBe("unknown");
+
+    await arbiter.observeResume({
+      thread: {
+        status: { type: "active" },
+        turns: [{ id: "new-turn", status: "inProgress", items: [] }],
+      },
+    });
+    expect(steers.map((entry) => entry.expectedTurnId)).toEqual(["old-turn", "new-turn"]);
+  });
+
+  test("active status without an identifiable turn id fails closed and queues", async () => {
+    const mock = transport();
+    const arbiter = new CodexTurnArbiter("thread-1", mock.value);
+    await arbiter.observeResume({
+      thread: {
+        status: { type: "active" },
+        turns: [],
+      },
+    });
+    expect(await arbiter.submit(input("no-turn-id"))).toMatchObject({
+      kind: "queued",
+      reason: "unknown",
+    });
+    expect(mock.starts).toHaveLength(0);
+    expect(mock.steers).toHaveLength(0);
+
+    await arbiter.observeTurnStarted("recovered-turn");
+    expect(mock.steers).toHaveLength(1);
+    expect(mock.steers[0]!.expectedTurnId).toBe("recovered-turn");
+  });
+
+  test("a stray completed event cannot turn unknown state into an unsafe start", async () => {
+    const mock = transport();
+    const arbiter = new CodexTurnArbiter("thread-1", mock.value);
+    await arbiter.observeResume({
+      thread: { status: { type: "active" }, turns: [] },
+    });
+    await arbiter.submit(input("wait-for-authority"));
+
+    await arbiter.observeTurnCompleted("some-old-turn");
+    expect(mock.starts).toHaveLength(0);
+    expect(arbiter.snapshot()).toMatchObject({
+      phase: { type: "unknown" },
+      queueDepth: 1,
+    });
+
+    await arbiter.observeThreadIdle();
+    expect(mock.starts).toHaveLength(1);
+  });
+
+  test("lost response is uncertain: clientUserMessageId journal prevents duplicate start", async () => {
+    let starts = 0;
+    const arbiter = new CodexTurnArbiter("thread-1", {
+      async turnStart() {
+        starts += 1;
+        // Simulates: app-server accepted the request, but the JSON-RPC response
+        // was lost. A plain Error has no numeric JSON-RPC rejection code.
+        throw new Error("socket closed after write");
+      },
+      async turnSteer() {
+        throw new Error("not reached");
+      },
+    });
+    await arbiter.observeThreadIdle();
+    const delivery = input("unknown-outcome");
+
+    expect(await arbiter.submit(delivery)).toEqual({
+      kind: "uncertain",
+      reason: "unknown_outcome",
+    });
+    expect(await arbiter.submit(delivery)).toEqual({
+      kind: "uncertain",
+      reason: "unknown_outcome",
+    });
+    expect(starts).toBe(1);
+
+    // Authoritative resume/read finds ThreadItem.userMessage.clientId.
+    await arbiter.observeResume({
+      thread: {
+        status: { type: "active" },
+        turns: [{
+          id: "accepted-turn",
+          status: "inProgress",
+          items: [{ type: "userMessage", clientId: "agentparty:unknown-outcome" }],
+        }],
+      },
+    });
+    expect(await arbiter.submit(delivery)).toEqual({ kind: "duplicate" });
+    expect(starts).toBe(1);
+    expect(arbiter.snapshot().uncertainCount).toBe(0);
+  });
+
+  test("interactive TUI start shares the writer lane and queued AgentParty input steers into it", async () => {
+    const mock = transport();
+    const arbiter = new CodexTurnArbiter("thread-1", mock.value);
+    await arbiter.observeThreadIdle();
+
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const tuiStart = arbiter.runInteractiveMutation(
+      "turn/start",
+      { threadId: "thread-1" },
+      async () => {
+        await gate;
+        return { turn: { id: "tui-turn" } };
+      },
+    );
+    const partyInput = arbiter.submit(input("during-tui-start"));
+    await Promise.resolve();
+    expect(mock.starts).toHaveLength(0);
+    expect(mock.steers).toHaveLength(0);
+
+    release();
+    await expect(tuiStart).resolves.toEqual({ turn: { id: "tui-turn" } });
+    await expect(partyInput).resolves.toEqual({ kind: "steered", turnId: "tui-turn" });
+    expect(mock.starts).toHaveLength(0);
+    expect(mock.steers[0]!.expectedTurnId).toBe("tui-turn");
+  });
+
+  test("an active-turn shell command blocks steering until its userShell item completes", async () => {
+    const mock = transport();
+    const queuedDispatches: CodexDispatch[] = [];
+    const arbiter = new CodexTurnArbiter("thread-1", mock.value, {
+      onQueuedDispatch: ({ dispatch }) => {
+        queuedDispatches.push(dispatch);
+      },
+    });
+    await arbiter.observeTurnStarted("active-turn");
+
+    await expect(arbiter.runInteractiveMutation(
+      "thread/shellCommand",
+      { threadId: "thread-1", command: "git status --short" },
+      async () => ({}),
+    )).resolves.toEqual({});
+    expect(arbiter.snapshot().phase).toEqual({ type: "shell", turnId: "active-turn" });
+    expect(await arbiter.submit(input("after-active-shell"))).toMatchObject({
+      kind: "queued",
+      reason: "shell",
+    });
+    expect(mock.steers).toHaveLength(0);
+
+    await arbiter.observeUserShellStarted("active-turn", "active-shell-item");
+    await arbiter.observeUserShellCompleted("active-turn", "active-shell-item");
+    expect(mock.steers).toHaveLength(1);
+    expect(mock.steers[0]!.expectedTurnId).toBe("active-turn");
+    expect(queuedDispatches).toEqual([{ kind: "steered", turnId: "active-turn" }]);
+    expect(arbiter.snapshot().phase).toEqual({ type: "normal", turnId: "active-turn" });
+  });
+
+  test("a mismatched userShell item cannot release the exact shell lifecycle", async () => {
+    const mock = transport();
+    const arbiter = new CodexTurnArbiter("thread-1", mock.value);
+    await arbiter.observeTurnStarted("base-turn");
+    await arbiter.runInteractiveMutation(
+      "thread/shellCommand",
+      { threadId: "thread-1", command: "pwd" },
+      async () => ({}),
+    );
+    await arbiter.submit(input("waits-for-exact-item"));
+
+    await arbiter.observeUserShellStarted("base-turn", "shell-item");
+    await arbiter.observeUserShellCompleted("base-turn", "other-item");
+    await arbiter.observeUserShellCompleted("other-turn", "shell-item");
+    expect(mock.steers).toHaveLength(0);
+    expect(arbiter.snapshot().phase.type).toBe("shell");
+
+    await arbiter.observeUserShellCompleted("base-turn", "shell-item");
+    expect(mock.steers).toHaveLength(1);
+    expect(mock.steers[0]!.expectedTurnId).toBe("base-turn");
+  });
+
+  test("stale idle before a standalone shell starts cannot flush queued input", async () => {
+    const mock = transport();
+    const arbiter = new CodexTurnArbiter("thread-1", mock.value);
+    await arbiter.observeThreadIdle();
+    await arbiter.runInteractiveMutation(
+      "thread/shellCommand",
+      { threadId: "thread-1", command: "pwd" },
+      async () => ({}),
+    );
+    await arbiter.submit(input("after-standalone-shell"));
+
+    await arbiter.observeThreadIdle();
+    expect(mock.starts).toHaveLength(0);
+    await arbiter.observeTurnStarted("standalone-shell-turn");
+    await arbiter.observeUserShellStarted("standalone-shell-turn", "standalone-shell-item");
+    await arbiter.observeTurnCompleted("standalone-shell-turn");
+    expect(mock.starts).toHaveLength(0);
+    await arbiter.observeUserShellCompleted("standalone-shell-turn", "standalone-shell-item");
+    expect(mock.starts).toHaveLength(1);
+    expect(mock.starts[0]!.clientUserMessageId).toBe(
+      "agentparty:after-standalone-shell",
+    );
+  });
+
+  test("after-write shell disconnect plus active resume stays fail-closed", async () => {
+    const mock = transport();
+    const arbiter = new CodexTurnArbiter("thread-1", mock.value);
+    await arbiter.observeTurnStarted("base-turn");
+    await expect(arbiter.runInteractiveMutation(
+      "thread/shellCommand",
+      { threadId: "thread-1", command: "pwd" },
+      async () => {
+        throw new Error("backend disconnected after request write");
+      },
+    )).rejects.toThrow("after request write");
+    expect(await arbiter.submit(input("must-not-steer-after-unknown-shell"))).toMatchObject({
+      kind: "queued",
+      reason: "shell",
+    });
+
+    await arbiter.observeResume({
+      thread: {
+        status: { type: "active" },
+        turns: [{ id: "base-turn", status: "inProgress", items: [] }],
+      },
+    });
+    expect(arbiter.snapshot().phase).toEqual({ type: "shell", turnId: "base-turn" });
+    expect(mock.starts).toHaveLength(0);
+    expect(mock.steers).toHaveLength(0);
+  });
+
+  test("auxiliary shell handles base completion before or after exact item completion", async () => {
+    for (const baseCompletesFirst of [true, false]) {
+      const mock = transport();
+      const arbiter = new CodexTurnArbiter("thread-1", mock.value);
+      await arbiter.observeTurnStarted("base-turn");
+      await arbiter.runInteractiveMutation(
+        "thread/shellCommand",
+        { threadId: "thread-1", command: "pwd" },
+        async () => ({}),
+      );
+      await arbiter.submit(input(`ordered-${baseCompletesFirst}`));
+      await arbiter.observeUserShellStarted("base-turn", "shell-item");
+
+      if (baseCompletesFirst) {
+        await arbiter.observeTurnCompleted("base-turn");
+        expect(mock.starts).toHaveLength(0);
+        expect(mock.steers).toHaveLength(0);
+        await arbiter.observeUserShellCompleted("base-turn", "shell-item");
+        expect(mock.starts).toHaveLength(1);
+      } else {
+        await arbiter.observeUserShellCompleted("base-turn", "shell-item");
+        expect(mock.steers).toHaveLength(1);
+        expect(mock.steers[0]!.expectedTurnId).toBe("base-turn");
+        await arbiter.observeTurnCompleted("base-turn");
+      }
+    }
+  });
+
+  test("proven-not-written shell request restores the prior steerable phase", async () => {
+    const mock = transport();
+    const arbiter = new CodexTurnArbiter("thread-1", mock.value);
+    await arbiter.observeTurnStarted("base-turn");
+    await expect(arbiter.runInteractiveMutation(
+      "thread/shellCommand",
+      { threadId: "thread-1", command: "pwd" },
+      async () => {
+        throw Object.assign(new Error("disconnected before write"), {
+          codexBridgeRequestWritten: false,
+        });
+      },
+    )).rejects.toThrow("before write");
+    expect(arbiter.snapshot().phase).toEqual({ type: "normal", turnId: "base-turn" });
+
+    expect(await arbiter.submit(input("safe-after-no-write"))).toEqual({
+      kind: "steered",
+      turnId: "base-turn",
+    });
+  });
+
+  test.each(["review", "compact"] as const)(
+    "user shell is auxiliary to an active %s phase and restores it exactly",
+    async (kind) => {
+      const mock = transport();
+      const arbiter = new CodexTurnArbiter("thread-1", mock.value);
+      await arbiter.enterUnsteerable(kind, `${kind}-turn`);
+      await arbiter.runInteractiveMutation(
+        "thread/shellCommand",
+        { threadId: "thread-1", command: "pwd" },
+        async () => ({}),
+      );
+      await arbiter.submit(input(`during-${kind}-shell`));
+      await arbiter.observeUserShellStarted(`${kind}-turn`, `${kind}-shell-item`);
+      await arbiter.observeUserShellCompleted(`${kind}-turn`, `${kind}-shell-item`);
+
+      expect(arbiter.snapshot()).toMatchObject({
+        phase: { type: kind, turnId: `${kind}-turn` },
+        queueDepth: 1,
+      });
+      expect(mock.starts).toHaveLength(0);
+      expect(mock.steers).toHaveLength(0);
+      await arbiter.observeTurnCompleted(`${kind}-turn`);
+      expect(mock.starts).toHaveLength(1);
+    },
+  );
+
+  test("resume rehydrates an exact in-progress shell item and later completion releases it", async () => {
+    const mock = transport();
+    const arbiter = new CodexTurnArbiter("thread-1", mock.value);
+    await arbiter.observeResume({
+      thread: {
+        status: { type: "idle" },
+        turns: [{
+          id: "historical-turn",
+          status: "completed",
+          items: [{
+            type: "commandExecution",
+            id: "historical-shell-item",
+            source: "userShell",
+            status: "completed",
+          }],
+        }],
+      },
+    });
+    await arbiter.runInteractiveMutation(
+      "thread/shellCommand",
+      { threadId: "thread-1", command: "pwd" },
+      async () => ({}),
+    );
+    await arbiter.submit(input("after-rehydrated-shell"));
+
+    await arbiter.observeResume({
+      thread: {
+        status: { type: "active" },
+        turns: [
+          {
+            id: "historical-turn",
+            status: "completed",
+            items: [{
+              type: "commandExecution",
+              id: "historical-shell-item",
+              source: "userShell",
+              status: "completed",
+            }],
+          },
+          {
+            id: "live-shell-turn",
+            status: "inProgress",
+            items: [{
+              type: "commandExecution",
+              id: "live-shell-item",
+              source: "userShell",
+              status: "inProgress",
+            }],
+          },
+        ],
+      },
+    });
+    expect(arbiter.snapshot().phase).toEqual({ type: "shell", turnId: "live-shell-turn" });
+    await arbiter.observeUserShellCompleted("live-shell-turn", "historical-shell-item");
+    expect(mock.starts).toHaveLength(0);
+    await arbiter.observeUserShellCompleted("live-shell-turn", "live-shell-item");
+    expect(mock.starts).toHaveLength(0);
+    await arbiter.observeTurnCompleted("live-shell-turn");
+    expect(mock.starts).toHaveLength(1);
+  });
+
+  test("resume rehydrates a fully completed shell without matching prior history", async () => {
+    const mock = transport();
+    const arbiter = new CodexTurnArbiter("thread-1", mock.value);
+    const priorItem = {
+      type: "commandExecution",
+      id: "prior-shell-item",
+      source: "userShell",
+      status: "completed",
+    };
+    await arbiter.observeResume({
+      thread: {
+        status: { type: "idle" },
+        turns: [{ id: "prior-turn", status: "completed", items: [priorItem] }],
+      },
+    });
+    await arbiter.runInteractiveMutation(
+      "thread/shellCommand",
+      { threadId: "thread-1", command: "pwd" },
+      async () => ({}),
+    );
+    await arbiter.submit(input("after-completed-recovery"));
+
+    // Returning only the pre-request item is not evidence that this request
+    // completed and must retain the shell fence.
+    await arbiter.observeResume({
+      thread: {
+        status: { type: "idle" },
+        turns: [{ id: "prior-turn", status: "completed", items: [priorItem] }],
+      },
+    });
+    expect(mock.starts).toHaveLength(0);
+    expect(arbiter.snapshot().phase.type).toBe("shell");
+
+    await arbiter.observeResume({
+      thread: {
+        status: { type: "idle" },
+        turns: [
+          { id: "prior-turn", status: "completed", items: [priorItem] },
+          {
+            id: "completed-shell-turn",
+            status: "completed",
+            items: [{
+              type: "commandExecution",
+              id: "completed-shell-item",
+              source: "userShell",
+              status: "completed",
+            }],
+          },
+        ],
+      },
+    });
+    expect(mock.starts).toHaveLength(1);
+    expect(mock.starts[0]!.clientUserMessageId).toBe(
+      "agentparty:after-completed-recovery",
+    );
+  });
+
+  test("backend-crash recovery aborts a lossy interrupted shell without replaying it", async () => {
+    const mock = transport();
+    const arbiter = new CodexTurnArbiter("thread-1", mock.value);
+    await arbiter.observeThreadIdle();
+    await arbiter.runInteractiveMutation(
+      "thread/shellCommand",
+      { threadId: "thread-1", command: "python -c 'import time; time.sleep(30)'" },
+      async () => ({}),
+    );
+    await arbiter.observeTurnStarted("lossy-shell-turn");
+    await arbiter.observeUserShellStarted("lossy-shell-turn", "lossy-shell-item");
+    await arbiter.submit(input("after-lossy-shell-crash"));
+
+    const interrupted = {
+      thread: {
+        status: { type: "idle" as const },
+        turns: [{
+          id: "lossy-shell-turn",
+          status: "interrupted" as const,
+          // Codex 0.144.4 reports itemsView=full but drops the
+          // commandExecution item after the backend process dies.
+          items: [],
+        }],
+      },
+    };
+    await arbiter.observeResume(interrupted);
+    expect(arbiter.snapshot().phase.type).toBe("shell");
+    expect(mock.starts).toHaveLength(0);
+
+    await arbiter.observeResume(interrupted, { backendRestarted: true });
+    expect(mock.starts).toHaveLength(1);
+    expect(mock.starts[0]!.clientUserMessageId).toBe(
+      "agentparty:after-lossy-shell-crash",
+    );
+  });
+
+  test("cold resume recognizes an active standalone user shell and never steers into it", async () => {
+    const mock = transport();
+    const arbiter = new CodexTurnArbiter("thread-1", mock.value);
+    await arbiter.observeResume({
+      thread: {
+        status: { type: "active" },
+        turns: [{
+          id: "cold-standalone-shell-turn",
+          status: "inProgress",
+          items: [{
+            type: "commandExecution",
+            id: "cold-standalone-shell-item",
+            source: "userShell",
+            status: "inProgress",
+          }],
+        }],
+      },
+    });
+    expect(arbiter.snapshot().phase).toEqual({
+      type: "shell",
+      turnId: "cold-standalone-shell-turn",
+    });
+    expect(await arbiter.submit(input("cold-standalone-waiter"))).toMatchObject({
+      kind: "queued",
+      reason: "shell",
+    });
+    expect(mock.steers).toHaveLength(0);
+
+    await arbiter.observeUserShellCompleted(
+      "cold-standalone-shell-turn",
+      "cold-standalone-shell-item",
+    );
+    expect(mock.starts).toHaveLength(0);
+    await arbiter.observeTurnCompleted("cold-standalone-shell-turn");
+    expect(mock.starts).toHaveLength(1);
+  });
+
+  test("cold resume recognizes an auxiliary user shell and restores its model turn", async () => {
+    const mock = transport();
+    const arbiter = new CodexTurnArbiter("thread-1", mock.value);
+    await arbiter.observeResume({
+      thread: {
+        status: { type: "active" },
+        turns: [{
+          id: "cold-model-turn",
+          status: "inProgress",
+          items: [
+            { type: "userMessage", id: "user-1", clientId: null },
+            {
+              type: "commandExecution",
+              id: "cold-aux-shell-item",
+              source: "userShell",
+              status: "inProgress",
+            },
+          ],
+        }],
+      },
+    });
+    expect(arbiter.snapshot().phase).toEqual({ type: "shell", turnId: "cold-model-turn" });
+    expect(await arbiter.submit(input("cold-aux-waiter"))).toMatchObject({
+      kind: "queued",
+      reason: "shell",
+    });
+    expect(mock.steers).toHaveLength(0);
+
+    await arbiter.observeUserShellCompleted("cold-model-turn", "cold-aux-shell-item");
+    expect(mock.steers).toHaveLength(1);
+    expect(mock.steers[0]!.expectedTurnId).toBe("cold-model-turn");
+  });
+
+  test("cold resume ignores completed shell history and fences the one current shell item", async () => {
+    const mock = transport();
+    const arbiter = new CodexTurnArbiter("thread-1", mock.value);
+    await arbiter.observeResume({
+      thread: {
+        status: { type: "active" },
+        turns: [
+          {
+            id: "old-shell-turn",
+            status: "completed",
+            items: [{
+              type: "commandExecution",
+              id: "old-turn-shell-item",
+              source: "userShell",
+              status: "completed",
+            }],
+          },
+          {
+            id: "long-model-turn",
+            status: "inProgress",
+            items: [
+              { type: "userMessage", id: "user-1", clientId: null },
+              {
+                type: "commandExecution",
+                id: "old-aux-shell-item",
+                source: "userShell",
+                status: "completed",
+              },
+              {
+                type: "commandExecution",
+                id: "current-aux-shell-item",
+                source: "userShell",
+                status: "inProgress",
+              },
+            ],
+          },
+        ],
+      },
+    });
+    expect(arbiter.snapshot().phase).toEqual({ type: "shell", turnId: "long-model-turn" });
+    expect(await arbiter.submit(input("wait-current-aux-shell"))).toMatchObject({
+      kind: "queued",
+      reason: "shell",
+    });
+    expect(mock.steers).toHaveLength(0);
+
+    await arbiter.observeUserShellCompleted("long-model-turn", "old-aux-shell-item");
+    expect(mock.steers).toHaveLength(0);
+    await arbiter.observeUserShellCompleted("long-model-turn", "current-aux-shell-item");
+    expect(mock.steers).toHaveLength(1);
+  });
+
+  test("completed user shell in an old turn does not fence a current ordinary model turn", async () => {
+    const mock = transport();
+    const arbiter = new CodexTurnArbiter("thread-1", mock.value);
+    await arbiter.observeResume({
+      thread: {
+        status: { type: "active" },
+        turns: [
+          {
+            id: "old-shell-turn",
+            status: "completed",
+            items: [{
+              type: "commandExecution",
+              id: "old-shell-item",
+              source: "userShell",
+              status: "completed",
+            }],
+          },
+          {
+            id: "current-model-turn",
+            status: "inProgress",
+            items: [{ type: "userMessage", id: "current-user", clientId: null }],
+          },
+        ],
+      },
+    });
+    expect(arbiter.snapshot().phase).toEqual({
+      type: "normal",
+      turnId: "current-model-turn",
+    });
+    expect(await arbiter.submit(input("steer-current-model"))).toEqual({
+      kind: "steered",
+      turnId: "current-model-turn",
+    });
+  });
+
+  test.each([
+    {
+      kind: "review" as const,
+      items: [{ type: "enteredReviewMode", id: "entered-review" }],
+    },
+    {
+      kind: "compact" as const,
+      items: [{ type: "contextCompaction", id: "compaction" }],
+    },
+  ])("cold resume recognizes an active $kind turn as non-steerable", async ({ kind, items }) => {
+    const mock = transport();
+    const arbiter = new CodexTurnArbiter("thread-1", mock.value);
+    await arbiter.observeResume({
+      thread: {
+        status: { type: "active" },
+        turns: [{
+          id: `cold-${kind}-turn`,
+          status: "inProgress",
+          items: [...items],
+        }],
+      },
+    });
+    expect(arbiter.snapshot().phase).toEqual({
+      type: kind,
+      turnId: `cold-${kind}-turn`,
+    });
+    expect(await arbiter.submit(input(`cold-${kind}-waiter`))).toMatchObject({
+      kind: "queued",
+      reason: kind,
+    });
+    expect(mock.starts).toHaveLength(0);
+    expect(mock.steers).toHaveLength(0);
+  });
+
+  test("interactive TUI turn/start fails closed unless the authoritative phase is idle", async () => {
+    const cases: Array<{
+      expectedPhase: "normal" | "review" | "compact" | "unknown";
+      prepare: (arbiter: CodexTurnArbiter) => Promise<void>;
+    }> = [
+      {
+        expectedPhase: "normal",
+        prepare: async (arbiter) => await arbiter.observeTurnStarted("normal-turn"),
+      },
+      {
+        expectedPhase: "review",
+        prepare: async (arbiter) => await arbiter.enterUnsteerable("review", "review-turn"),
+      },
+      {
+        expectedPhase: "compact",
+        prepare: async (arbiter) => await arbiter.enterUnsteerable("compact", "compact-turn"),
+      },
+      {
+        expectedPhase: "unknown",
+        prepare: async () => {},
+      },
+    ];
+
+    for (const scenario of cases) {
+      const mock = transport();
+      const arbiter = new CodexTurnArbiter("thread-1", mock.value);
+      await scenario.prepare(arbiter);
+      let operationCalls = 0;
+      let thrown: unknown;
+      try {
+        await arbiter.runInteractiveMutation(
+          "turn/start",
+          { threadId: "thread-1" },
+          async () => {
+            operationCalls += 1;
+            return { turn: { id: "must-not-start" } };
+          },
+        );
+      } catch (error) {
+        thrown = error;
+      }
+
+      expect(thrown).toBeInstanceOf(CodexInteractiveMutationBlockedError);
+      expect(thrown).toMatchObject({
+        code: -32_000,
+        data: {
+          codexBridgeInfo: {
+            type: "interactiveMutationBlocked",
+            method: "turn/start",
+            reason: "phase_not_idle",
+            phase: { type: scenario.expectedPhase },
+            uncertainCount: 0,
+          },
+        },
+      });
+      expect(operationCalls).toBe(0);
+      expect(arbiter.snapshot().phase.type).toBe(scenario.expectedPhase);
+    }
+  });
+
+  test("one uncertain journal entry freezes all interactive mutations and queue flushes", async () => {
+    const starts: CodexTurnStartParams[] = [];
+    const steers: CodexTurnSteerParams[] = [];
+    const arbiter = new CodexTurnArbiter("thread-1", {
+      async turnStart(params) {
+        starts.push(params);
+        if (params.clientUserMessageId === "agentparty:uncertain-first") {
+          throw new Error("stdio proxy disconnected after write");
+        }
+        return { turn: { id: "reconciled-turn" } };
+      },
+      async turnSteer(params) {
+        steers.push(params);
+        return { turnId: params.expectedTurnId };
+      },
+    }, { maxQueue: 1 });
+    await arbiter.observeThreadIdle();
+
+    expect(await arbiter.submit(input("uncertain-first"))).toEqual({
+      kind: "uncertain",
+      reason: "unknown_outcome",
+    });
+    await arbiter.observeThreadIdle();
+    expect(await arbiter.submit(input("queued-behind-uncertain"))).toMatchObject({
+      kind: "queued",
+      queuePosition: 1,
+      reason: "unknown_outcome",
+    });
+    await expect(arbiter.submit(input("bounded-overflow"))).rejects.toBeInstanceOf(
+      CodexBridgeQueueFullError,
+    );
+
+    let interactiveCalls = 0;
+    for (
+      const method of [
+        "turn/start",
+        "turn/steer",
+        "turn/interrupt",
+        "review/start",
+        "thread/compact/start",
+        "thread/shellCommand",
+      ] as const
+    ) {
+      await expect(arbiter.runInteractiveMutation(
+        method,
+        {
+          threadId: "thread-1",
+          ...(method === "turn/steer" ? { expectedTurnId: "possibly-running" } : {}),
+          ...(method === "review/start" ? { delivery: "detached" } : {}),
+        },
+        async () => {
+          interactiveCalls += 1;
+          return { turn: { id: "must-not-run" } };
+        },
+      )).rejects.toMatchObject({
+        data: {
+          codexBridgeInfo: {
+            method,
+            reason: "uncertain_outcome",
+            uncertainCount: 1,
+          },
+        },
+      });
+    }
+    expect(interactiveCalls).toBe(0);
+    expect(starts).toHaveLength(1);
+    expect(steers).toHaveLength(0);
+
+    // Only positive clientId evidence clears the uncertainty. The idle phase
+    // observed while frozen then becomes eligible to flush the bounded queue.
+    await arbiter.observeResume({
+      thread: {
+        status: { type: "idle" },
+        turns: [{
+          id: "accepted-earlier",
+          status: "completed",
+          items: [{ type: "userMessage", clientId: "agentparty:uncertain-first" }],
+        }],
+      },
+    });
+    expect(starts.map((entry) => entry.clientUserMessageId)).toEqual([
+      "agentparty:uncertain-first",
+      "agentparty:queued-behind-uncertain",
+    ]);
+    expect(arbiter.snapshot()).toMatchObject({
+      phase: { type: "normal", turnId: "reconciled-turn" },
+      queueDepth: 0,
+      uncertainCount: 0,
+    });
+  });
+
+  test("explicit unknown-outcome resolution unfreezes the current authoritative phase", async () => {
+    const starts: CodexTurnStartParams[] = [];
+    const arbiter = new CodexTurnArbiter("thread-1", {
+      async turnStart(params) {
+        starts.push(params);
+        if (params.clientUserMessageId === "agentparty:resolve-first") {
+          throw new Error("response lost");
+        }
+        return { turn: { id: "after-resolution" } };
+      },
+      async turnSteer(params) {
+        return { turnId: params.expectedTurnId };
+      },
+    });
+    await arbiter.observeThreadIdle();
+    const uncertain = input("resolve-first");
+    expect(await arbiter.submit(uncertain)).toMatchObject({ kind: "uncertain" });
+    await arbiter.observeThreadIdle();
+    expect(await arbiter.submit(input("queued-until-resolution"))).toMatchObject({
+      kind: "queued",
+      reason: "unknown_outcome",
+    });
+    expect(starts).toHaveLength(1);
+
+    expect(await arbiter.resolveUnknownOutcome(uncertain, "accepted")).toEqual({
+      kind: "duplicate",
+    });
+    expect(starts.map((entry) => entry.clientUserMessageId)).toEqual([
+      "agentparty:resolve-first",
+      "agentparty:queued-until-resolution",
+    ]);
+    expect(arbiter.snapshot().uncertainCount).toBe(0);
+  });
+
+  test("abandoned unknown never replays and unfreezes the queued input", async () => {
+    const writes: string[] = [];
+    const arbiter = new CodexTurnArbiter("thread-1", {
+      async turnStart(params) {
+        writes.push(params.clientUserMessageId ?? "missing-client-id");
+        if (params.clientUserMessageId === "agentparty:abandoned-first") {
+          throw new Error("response lost after write");
+        }
+        return { turn: { id: "after-abandonment" } };
+      },
+      async turnSteer(params) {
+        writes.push(params.clientUserMessageId ?? "missing-client-id");
+        return { turnId: params.expectedTurnId };
+      },
+    });
+    await arbiter.observeThreadIdle();
+    const abandoned = input("abandoned-first");
+
+    expect(await arbiter.submit(abandoned)).toMatchObject({ kind: "uncertain" });
+    await arbiter.observeThreadIdle();
+    expect(await arbiter.submit(input("queued-after-abandonment"))).toMatchObject({
+      kind: "queued",
+      reason: "unknown_outcome",
+    });
+
+    expect(await arbiter.resolveUnknownOutcome(abandoned, "abandoned")).toEqual({
+      kind: "duplicate",
+    });
+    expect(arbiter.snapshot()).toEqual({
+      phase: { type: "normal", turnId: "after-abandonment" },
+      queueDepth: 0,
+      uncertainCount: 0,
+    });
+    expect(await arbiter.submit(abandoned)).toEqual({ kind: "duplicate" });
+    expect(writes).toEqual([
+      "agentparty:abandoned-first",
+      "agentparty:queued-after-abandonment",
+    ]);
+  });
+
+  test("unresolved unknown inputs contain only unreconciled defensive snapshots", async () => {
+    const arbiter = new CodexTurnArbiter("thread-1", {
+      async turnStart() {
+        throw new Error("response lost after write");
+      },
+      async turnSteer() {
+        throw new Error("not reached");
+      },
+    });
+    await arbiter.observeThreadIdle();
+    const first = input("snapshot-first", "original text");
+    expect(await arbiter.submit(first)).toMatchObject({ kind: "uncertain" });
+
+    const snapshot = arbiter.unresolvedUnknownInputs();
+    expect(snapshot).toEqual([first]);
+    snapshot[0]!.text = "mutated text";
+    snapshot[0]!.metadata!.delivery_id = "mutated-delivery";
+    snapshot.push(input("invented"));
+    expect(arbiter.unresolvedUnknownInputs()).toEqual([first]);
+
+    await arbiter.observeResume({
+      thread: {
+        status: { type: "idle" },
+        turns: [{
+          id: "positively-reconciled",
+          status: "completed",
+          items: [{ type: "userMessage", clientId: first.clientUserMessageId }],
+        }],
+      },
+    });
+    expect(arbiter.unresolvedUnknownInputs()).toEqual([]);
+
+    const stillUnresolved = input("snapshot-second");
+    expect(await arbiter.submit(stillUnresolved)).toMatchObject({ kind: "uncertain" });
+    expect(arbiter.unresolvedUnknownInputs()).toEqual([stillUnresolved]);
+  });
+
+  test("a rejected interactive steer invalidates the phase instead of restoring a stale turn", async () => {
+    const mock = transport();
+    const arbiter = new CodexTurnArbiter("thread-1", mock.value);
+    await arbiter.observeTurnStarted("stale-turn");
+
+    await expect(arbiter.runInteractiveMutation(
+      "turn/steer",
+      { threadId: "thread-1", expectedTurnId: "stale-turn" },
+      async () => {
+        throw rpcError();
+      },
+    )).rejects.toMatchObject({ code: -32_000 });
+    expect(arbiter.snapshot().phase).toEqual({ type: "unknown", turnId: null });
+    expect(await arbiter.submit(input("after-stale-tui-steer"))).toMatchObject({
+      kind: "queued",
+      reason: "unknown",
+    });
+    expect(mock.starts).toHaveLength(0);
+    expect(mock.steers).toHaveLength(0);
+  });
+
+  test("absence after reconnect stays uncertain because history is not a negative idempotency proof", async () => {
+    const starts: CodexTurnStartParams[] = [];
+    const arbiter = new CodexTurnArbiter("thread-1", {
+      async turnStart(params) {
+        starts.push(params);
+        throw new Error("stdio proxy disconnected after write");
+      },
+      async turnSteer() {
+        throw new Error("not reached");
+      },
+    });
+    await arbiter.observeThreadIdle();
+    expect(await arbiter.submit(input("not-accepted"))).toMatchObject({ kind: "uncertain" });
+
+    await arbiter.observeResume({ thread: { status: { type: "idle" }, turns: [] } });
+    expect(starts).toHaveLength(1);
+    expect(await arbiter.submit(input("not-accepted"))).toEqual({
+      kind: "uncertain",
+      reason: "unknown_outcome",
+    });
+    expect(await arbiter.submit(input("later-input"))).toMatchObject({
+      kind: "queued",
+      reason: "unknown_outcome",
+    });
+    await arbiter.observeThreadIdle();
+    expect(starts).toHaveLength(1);
+    expect(arbiter.snapshot().uncertainCount).toBe(1);
+  });
+});

--- a/cli/test/codex-turn-arbiter.test.ts
+++ b/cli/test/codex-turn-arbiter.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  CodexBridgeJournalOverflowError,
   CodexBridgeQueueFullError,
   CodexInteractiveMutationBlockedError,
   CodexRetryableBeforeWriteError,
@@ -827,6 +828,93 @@ describe("Codex app-server single-writer arbiter", () => {
     );
   });
 
+  test("large shell history uses one stable anchor and still identifies only the new item", async () => {
+    const mock = transport();
+    const arbiter = new CodexTurnArbiter("thread-1", mock.value);
+    const historicalItems = Array.from({ length: 2_000 }, (_, index) => ({
+      type: "commandExecution",
+      id: `historical-shell-${index}`,
+      source: "userShell",
+      status: "completed",
+    }));
+    await arbiter.observeResume({
+      thread: {
+        status: { type: "idle" },
+        turns: [{
+          id: "historical-shell-turn",
+          status: "completed",
+          items: historicalItems,
+        }],
+      },
+    });
+    expect(
+      (arbiter as unknown as { lastObservedUserShellItemId: string | null })
+        .lastObservedUserShellItemId,
+    ).toBe("historical-shell-1999");
+
+    await arbiter.runInteractiveMutation(
+      "thread/shellCommand",
+      { threadId: "thread-1", command: "pwd" },
+      async () => ({}),
+    );
+    expect(
+      (arbiter as unknown as {
+        shellLifecycle: { baselineItemId: string | null } | null;
+      }).shellLifecycle?.baselineItemId,
+    ).toBe("historical-shell-1999");
+    await arbiter.submit(input("after-large-shell-history"));
+
+    // If the baseline anchor disappears, one unrelated terminal item must not
+    // be mistaken for this request's commandExecution item.
+    await arbiter.observeResume({
+      thread: {
+        status: { type: "idle" },
+        turns: [{
+          id: "truncated-shell-turn",
+          status: "completed",
+          items: [{
+            type: "commandExecution",
+            id: "unrelated-shell-item",
+            source: "userShell",
+            status: "completed",
+          }],
+        }],
+      },
+    });
+    expect(arbiter.snapshot().phase.type).toBe("shell");
+    expect(mock.starts).toHaveLength(0);
+
+    await arbiter.observeResume({
+      thread: {
+        status: { type: "idle" },
+        turns: [
+          {
+            id: "historical-shell-turn",
+            status: "completed",
+            items: historicalItems,
+          },
+          {
+            id: "new-shell-turn",
+            status: "completed",
+            items: [{
+              type: "commandExecution",
+              id: "new-shell-item",
+              source: "userShell",
+              status: "completed",
+            }],
+          },
+        ],
+      },
+    });
+    expect(mock.starts.map((entry) => entry.clientUserMessageId)).toEqual([
+      "agentparty:after-large-shell-history",
+    ]);
+    expect(
+      (arbiter as unknown as { lastObservedUserShellItemId: string | null })
+        .lastObservedUserShellItemId,
+    ).toBe("new-shell-item");
+  });
+
   test("backend-crash recovery aborts a lossy interrupted shell without replaying it", async () => {
     const mock = transport();
     const arbiter = new CodexTurnArbiter("thread-1", mock.value);
@@ -861,6 +949,59 @@ describe("Codex app-server single-writer arbiter", () => {
     expect(mock.starts[0]!.clientUserMessageId).toBe(
       "agentparty:after-lossy-shell-crash",
     );
+  });
+
+  test("backend restart releases a shell whose start item was permanently omitted", async () => {
+    const mock = transport();
+    const arbiter = new CodexTurnArbiter("thread-1", mock.value);
+    await arbiter.observeResume({
+      thread: {
+        status: { type: "idle" },
+        turns: [{
+          id: "prior-shell-turn",
+          status: "completed",
+          items: [{
+            type: "commandExecution",
+            id: "prior-shell-item",
+            source: "userShell",
+            status: "completed",
+          }],
+        }],
+      },
+    });
+    await arbiter.runInteractiveMutation(
+      "thread/shellCommand",
+      { threadId: "thread-1", command: "pwd" },
+      async () => ({}),
+    );
+    await arbiter.submit(input("after-omitted-shell-item"));
+
+    const truncatedIdle = {
+      thread: {
+        status: { type: "idle" as const },
+        turns: [{
+          id: "unrelated-terminal-turn",
+          status: "completed" as const,
+          items: [{
+            type: "commandExecution",
+            id: "unrelated-shell-item",
+            source: "userShell",
+            status: "completed",
+          }],
+        }],
+      },
+    };
+    await arbiter.observeResume(truncatedIdle);
+    expect(arbiter.snapshot()).toMatchObject({
+      phase: { type: "shell" },
+      queueDepth: 1,
+    });
+    expect(mock.starts).toHaveLength(0);
+
+    await arbiter.observeResume(truncatedIdle, { backendRestarted: true });
+    expect(mock.starts.map((entry) => entry.clientUserMessageId)).toEqual([
+      "agentparty:after-omitted-shell-item",
+    ]);
   });
 
   test("cold resume recognizes an active standalone user shell and never steers into it", async () => {
@@ -1277,6 +1418,197 @@ describe("Codex app-server single-writer arbiter", () => {
       "agentparty:abandoned-first",
       "agentparty:queued-after-abandonment",
     ]);
+  });
+
+  test("terminal journal is bounded without pruning uncertain or queued correctness state", async () => {
+    const writes: string[] = [];
+    const arbiter = new CodexTurnArbiter("thread-1", {
+      async turnStart(params) {
+        writes.push(params.clientUserMessageId ?? "missing-client-id");
+        return { turn: { id: "long-running-turn" } };
+      },
+      async turnSteer(params) {
+        const clientId = params.clientUserMessageId ?? "missing-client-id";
+        writes.push(clientId);
+        if (clientId === "agentparty:bounded-uncertain") {
+          throw new Error("response lost after write");
+        }
+        return { turnId: params.expectedTurnId };
+      },
+    }, { maxTerminalJournalEntries: 8 });
+    await arbiter.observeTurnStarted("long-running-turn");
+
+    const uncertain = input("bounded-uncertain");
+    expect(await arbiter.submit(uncertain)).toMatchObject({ kind: "uncertain" });
+    expect(await arbiter.submit(input("bounded-queued"))).toMatchObject({
+      kind: "queued",
+      reason: "unknown_outcome",
+    });
+
+    // A full-history reconciliation can contain many old ids. It must retain
+    // only the bounded terminal window, remove an accepted queued input, and
+    // leave the unrelated transport-unknown write fenced.
+    await arbiter.observeResume({
+      thread: {
+        status: { type: "active" },
+        turns: [
+          {
+            id: "completed-history",
+            status: "completed",
+            items: Array.from({ length: 100 }, (_, index) => ({
+              type: "userMessage",
+              clientId: `agentparty:bounded-terminal-${index}`,
+            })),
+          },
+          {
+            id: "long-running-turn",
+            status: "inProgress",
+            items: [
+              { type: "userMessage", clientId: "agentparty:bounded-queued" },
+              { type: "userMessage", clientId: "agentparty:current-turn-recent" },
+            ],
+          },
+        ],
+      },
+    });
+    const internals = arbiter as unknown as {
+      journal: Map<string, string>;
+      terminalJournalOrder: Map<string, undefined>;
+      activeTurnAcceptedClientIds: Set<string>;
+      uncertainInputs: Map<string, unknown>;
+    };
+    expect(internals.terminalJournalOrder.size).toBe(8);
+    expect(internals.activeTurnAcceptedClientIds.size).toBe(2);
+    expect(internals.journal.size).toBe(11);
+    expect(internals.uncertainInputs.size).toBe(1);
+    expect(arbiter.snapshot()).toMatchObject({ queueDepth: 0, uncertainCount: 1 });
+    expect(arbiter.unresolvedUnknownInputs()).toEqual([uncertain]);
+
+    const writesBeforeDuplicate = writes.length;
+    expect(await arbiter.submit(input("current-turn-recent"))).toEqual({ kind: "duplicate" });
+    expect(writes).toHaveLength(writesBeforeDuplicate);
+
+    expect(await arbiter.resolveUnknownOutcome(uncertain, "abandoned")).toEqual({
+      kind: "duplicate",
+    });
+    expect(internals.terminalJournalOrder.size).toBe(8);
+    expect(internals.journal.size).toBe(10);
+    expect(internals.uncertainInputs.size).toBe(0);
+    expect(await arbiter.submit(uncertain)).toEqual({ kind: "duplicate" });
+    expect(writes).toHaveLength(writesBeforeDuplicate);
+  });
+
+  test("active-turn ids stay pinned across terminal churn and backpressure at their own cap", async () => {
+    const mock = transport();
+    const arbiter = new CodexTurnArbiter("thread-1", mock.value, {
+      maxTerminalJournalEntries: 1,
+      maxActiveTurnJournalEntries: 2,
+    });
+    await arbiter.observeTurnStarted("bounded-active-turn");
+
+    expect(await arbiter.submit(input("active-a"))).toMatchObject({ kind: "steered" });
+    expect(await arbiter.submit(input("active-b"))).toMatchObject({ kind: "steered" });
+    expect(await arbiter.submit(input("active-a"))).toEqual({ kind: "duplicate" });
+    expect(mock.steers.map((entry) => entry.clientUserMessageId)).toEqual([
+      "agentparty:active-a",
+      "agentparty:active-b",
+    ]);
+
+    expect(await arbiter.submit(input("active-c"))).toMatchObject({
+      kind: "queued",
+      reason: "steer_rejected",
+    });
+    expect(arbiter.snapshot().queueDepth).toBe(1);
+    await arbiter.observeTurnCompleted("bounded-active-turn");
+    expect(mock.starts.map((entry) => entry.clientUserMessageId)).toEqual([
+      "agentparty:active-c",
+    ]);
+
+    const internals = arbiter as unknown as {
+      journal: Map<string, string>;
+      terminalJournalOrder: Map<string, undefined>;
+      activeTurnAcceptedClientIds: Set<string>;
+    };
+    expect(internals.terminalJournalOrder.size).toBe(1);
+    expect(internals.activeTurnAcceptedClientIds.size).toBe(1);
+    expect(internals.journal.size).toBe(2);
+  });
+
+  test("authoritative active-turn overflow stays fail-closed after the turn completes", async () => {
+    const mock = transport();
+    const arbiter = new CodexTurnArbiter("thread-1", mock.value, {
+      maxTerminalJournalEntries: 1,
+      maxActiveTurnJournalEntries: 2,
+    });
+    await arbiter.observeTurnStarted("overflowed-active-turn", [
+      "agentparty:overflow-a",
+      "agentparty:overflow-b",
+    ]);
+    await arbiter.observeTurnStarted("overflowed-active-turn", [
+      "agentparty:overflow-c",
+    ]);
+    await arbiter.observeTurnStarted("overflowed-active-turn", [
+      "agentparty:overflow-d",
+    ]);
+
+    expect(arbiter.snapshot()).toMatchObject({
+      phase: { type: "normal", turnId: "overflowed-active-turn" },
+      queueDepth: 0,
+      uncertainCount: 1,
+    });
+    await expect(
+      arbiter.submit(input("overflow-c")),
+    ).rejects.toBeInstanceOf(CodexBridgeJournalOverflowError);
+    await arbiter.observeTurnCompleted("overflowed-active-turn");
+    expect(mock.starts).toHaveLength(0);
+    await expect(
+      arbiter.submit(input("fresh-after-overflow")),
+    ).rejects.toBeInstanceOf(CodexBridgeJournalOverflowError);
+
+    const internals = arbiter as unknown as {
+      journal: Map<string, string>;
+      terminalJournalOrder: Map<string, undefined>;
+      activeTurnAcceptedClientIds: Set<string>;
+    };
+    expect(internals.terminalJournalOrder.size).toBe(1);
+    expect(internals.activeTurnAcceptedClientIds.size).toBe(0);
+    expect(internals.journal.size).toBe(1);
+  });
+
+  test("accepted reconciliation removes the queued input and its rollback debt together", async () => {
+    let rollbackAttempts = 0;
+    const arbiter = new CodexTurnArbiter("thread-1", {
+      async turnStart() {
+        throw new Error("must not start");
+      },
+      async turnSteer() {
+        throw rpcError();
+      },
+    });
+    await arbiter.observeTurnStarted("reconciled-turn");
+    const reconciled = {
+      ...input("reconciled-rollback"),
+      onWriteRejected: () => {
+        rollbackAttempts += 1;
+        throw new Error("rollback storage unavailable");
+      },
+    };
+    expect(await arbiter.submit(reconciled)).toMatchObject({
+      kind: "queued",
+      reason: "steer_rejected",
+    });
+    const internals = arbiter as unknown as {
+      rollbackDebts: Map<string, unknown>;
+    };
+    expect(internals.rollbackDebts.size).toBe(1);
+
+    await arbiter.observeTurnStarted("reconciled-turn", [
+      reconciled.clientUserMessageId,
+    ]);
+    expect(arbiter.snapshot().queueDepth).toBe(0);
+    expect(internals.rollbackDebts.size).toBe(0);
+    await new Promise((resolve) => setTimeout(resolve, 125));
+    expect(rollbackAttempts).toBe(1);
   });
 
   test("unresolved unknown inputs contain only unreconciled defensive snapshots", async () => {

--- a/cli/test/codex-unix-proxy.test.ts
+++ b/cli/test/codex-unix-proxy.test.ts
@@ -1,0 +1,768 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { randomBytes } from "node:crypto";
+import { mkdtempSync, rmSync } from "node:fs";
+import { connect, type Socket } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  CODEX_TUI_WEBSOCKET_IDLE_TIMEOUT_SECONDS,
+  CodexSessionController,
+  CodexUnixJsonRpcProxy,
+  type CodexRpcPeer,
+  type JsonRpcId,
+  type JsonRpcNotification,
+  type JsonRpcRequest,
+  type JsonRpcResponse,
+} from "../src/codex-app-server-bridge";
+
+class FakeRpcPeer implements CodexRpcPeer {
+  readonly initializeResult = {
+    userAgent: "fake-codex/0.144.4",
+    codexHome: "/tmp/codex",
+    platformFamily: "unix",
+    platformOs: "test",
+  };
+  readonly calls: Array<{ method: string; params?: unknown }> = [];
+  readonly responses: Array<{ id: JsonRpcId; result?: unknown; error?: JsonRpcResponse["error"] }> = [];
+  private readonly messages = new Set<(message: JsonRpcRequest | JsonRpcNotification) => void | Promise<void>>();
+  private readonly reconnects = new Set<(generation: number) => void | Promise<void>>();
+  connectionGeneration = 1;
+  blockTuiStart: Promise<void> | null = null;
+  blockThreadRead: Promise<void> | null = null;
+
+  async start(): Promise<void> {}
+
+  async request(method: string, params?: unknown): Promise<unknown> {
+    this.calls.push({ method, params });
+    if (method === "thread/start") {
+      return {
+        thread: {
+          id: "thread-uds",
+          status: { type: "idle" },
+          turns: [],
+        },
+      };
+    }
+    if (method === "thread/resume") {
+      return {
+        thread: {
+          id: "thread-uds",
+          status: { type: "active" },
+          turns: [{
+            id: "turn-tui",
+            status: "inProgress",
+            items: [],
+          }],
+        },
+      };
+    }
+    if (method === "turn/start") {
+      await this.blockTuiStart;
+      return {
+        turn: {
+          id: "turn-tui",
+          status: "inProgress",
+          items: [],
+        },
+      };
+    }
+    if (method === "turn/steer") {
+      return {
+        turnId: (params as { expectedTurnId: string }).expectedTurnId,
+      };
+    }
+    if (method === "thread/read") {
+      await this.blockThreadRead;
+      return {};
+    }
+    return {};
+  }
+
+  async requestConnected(
+    method: string,
+    params?: unknown,
+    expectedGeneration?: number,
+  ): Promise<unknown> {
+    if (
+      expectedGeneration !== undefined &&
+      expectedGeneration !== this.connectionGeneration
+    ) {
+      throw new Error("fake generation changed before request write");
+    }
+    return await this.request(method, params);
+  }
+
+  async notify(method: string, params?: unknown): Promise<void> {
+    this.calls.push({ method, params });
+  }
+
+  respond(id: JsonRpcId, result?: unknown, error?: JsonRpcResponse["error"]): void {
+    this.responses.push({ id, result, error });
+  }
+
+  onMessage(
+    listener: (message: JsonRpcRequest | JsonRpcNotification) => void | Promise<void>,
+  ): () => void {
+    this.messages.add(listener);
+    return () => this.messages.delete(listener);
+  }
+
+  onReconnect(listener: (generation: number) => void | Promise<void>): () => void {
+    this.reconnects.add(listener);
+    return () => this.reconnects.delete(listener);
+  }
+
+  async reconnect(): Promise<void> {
+    this.connectionGeneration += 1;
+    for (const listener of this.reconnects) await listener(this.connectionGeneration);
+  }
+
+  emit(message: JsonRpcRequest | JsonRpcNotification): void {
+    for (const listener of this.messages) void listener(message);
+  }
+}
+
+class UnixWebSocketClient {
+  private socket: Socket | null = null;
+  private buffer = Buffer.alloc(0);
+  private frames: string[] = [];
+  private waiters: Array<(value: string) => void> = [];
+
+  async open(path: string): Promise<void> {
+    const socket = connect({ path });
+    this.socket = socket;
+    const key = randomBytes(16).toString("base64");
+    socket.write(
+      "GET /rpc HTTP/1.1\r\n" +
+        "Host: localhost\r\n" +
+        "Upgrade: websocket\r\n" +
+        "Connection: Upgrade\r\n" +
+        `Sec-WebSocket-Key: ${key}\r\n` +
+        "Sec-WebSocket-Version: 13\r\n\r\n",
+    );
+    await new Promise<void>((resolve, reject) => {
+      let handshake = Buffer.alloc(0);
+      const onData = (chunk: Buffer) => {
+        handshake = Buffer.concat([handshake, chunk]);
+        const end = handshake.indexOf("\r\n\r\n");
+        if (end < 0) return;
+        socket.off("data", onData);
+        const header = handshake.subarray(0, end).toString("utf8");
+        if (!header.startsWith("HTTP/1.1 101")) {
+          reject(new Error(`WebSocket upgrade failed: ${header}`));
+          return;
+        }
+        const rest = handshake.subarray(end + 4);
+        socket.on("data", (data) => this.consume(
+          typeof data === "string" ? Buffer.from(data) : data,
+        ));
+        if (rest.length > 0) this.consume(rest);
+        resolve();
+      };
+      socket.on("data", onData);
+      socket.once("error", reject);
+    });
+  }
+
+  private consume(chunk: Buffer): void {
+    this.buffer = Buffer.concat([this.buffer, chunk]);
+    for (;;) {
+      if (this.buffer.length < 2) return;
+      const opcode = this.buffer[0]! & 0x0f;
+      let length = this.buffer[1]! & 0x7f;
+      let offset = 2;
+      if (length === 126) {
+        if (this.buffer.length < 4) return;
+        length = this.buffer.readUInt16BE(2);
+        offset = 4;
+      } else if (length === 127) {
+        if (this.buffer.length < 10) return;
+        const large = Number(this.buffer.readBigUInt64BE(2));
+        if (!Number.isSafeInteger(large)) throw new Error("WebSocket frame is too large");
+        length = large;
+        offset = 10;
+      }
+      if (this.buffer.length < offset + length) return;
+      const payload = this.buffer.subarray(offset, offset + length);
+      this.buffer = this.buffer.subarray(offset + length);
+      if (opcode === 1) {
+        const value = payload.toString("utf8");
+        const waiter = this.waiters.shift();
+        if (waiter) waiter(value);
+        else this.frames.push(value);
+      }
+      if (opcode === 8) return;
+    }
+  }
+
+  send(value: unknown): void {
+    const payload = Buffer.from(JSON.stringify(value));
+    const mask = randomBytes(4);
+    let header: Buffer;
+    if (payload.length < 126) {
+      header = Buffer.from([0x81, 0x80 | payload.length]);
+    } else {
+      header = Buffer.alloc(4);
+      header[0] = 0x81;
+      header[1] = 0x80 | 126;
+      header.writeUInt16BE(payload.length, 2);
+    }
+    const masked = Buffer.alloc(payload.length);
+    for (let index = 0; index < payload.length; index += 1) {
+      masked[index] = payload[index]! ^ mask[index % 4]!;
+    }
+    this.socket!.write(Buffer.concat([header, mask, masked]));
+  }
+
+  async receive(): Promise<unknown> {
+    const line = this.frames.shift() ?? await new Promise<string>((resolve) => {
+      this.waiters.push(resolve);
+    });
+    return JSON.parse(line);
+  }
+
+  close(): void {
+    this.socket?.destroy();
+    this.socket = null;
+  }
+}
+
+let temp: string;
+let proxy: CodexUnixJsonRpcProxy | null;
+let clients: UnixWebSocketClient[];
+
+beforeEach(() => {
+  temp = mkdtempSync(join(tmpdir(), "ap-codex-uds-"));
+  proxy = null;
+  clients = [];
+});
+
+afterEach(async () => {
+  for (const client of clients) client.close();
+  await proxy?.close();
+  rmSync(temp, { recursive: true, force: true });
+});
+
+describe("Codex Unix WebSocket single-writer proxy", () => {
+  test("disables Bun's idle timeout for long-lived quiet Codex sessions", () => {
+    expect(CODEX_TUI_WEBSOCKET_IDLE_TIMEOUT_SECONDS).toBe(0);
+  });
+
+  test("routes the real bootstrap wire shape and serializes TUI start with AgentParty steer", async () => {
+    const rpc = new FakeRpcPeer();
+    const session = new CodexSessionController(rpc);
+    await session.start();
+    proxy = new CodexUnixJsonRpcProxy(session);
+    const socketPath = join(temp, "codex.sock");
+    await proxy.listen(socketPath);
+
+    const tui = new UnixWebSocketClient();
+    clients.push(tui);
+    await tui.open(socketPath);
+    tui.send({
+      id: 1,
+      method: "initialize",
+      params: {
+        clientInfo: { name: "codex-tui", title: "Codex TUI", version: "0.144.4" },
+        capabilities: { experimentalApi: true, requestAttestation: false },
+      },
+    });
+    expect(await tui.receive()).toEqual({
+      id: 1,
+      result: rpc.initializeResult,
+    });
+    tui.send({ method: "initialized" });
+    tui.send({ id: 2, method: "thread/start", params: {} });
+    expect(await tui.receive()).toMatchObject({
+      id: 2,
+      result: { thread: { id: "thread-uds", status: { type: "idle" } } },
+    });
+
+    let release!: () => void;
+    rpc.blockTuiStart = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    tui.send({
+      id: 3,
+      method: "turn/start",
+      params: {
+        threadId: "thread-uds",
+        clientUserMessageId: null,
+        input: [{ type: "text", text: "WIRE_PROMPT_746", text_elements: [] }],
+      },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    const party = session.submit({
+      text: "channel input",
+      clientUserMessageId: "agentparty:delivery-uds",
+    });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(rpc.calls.filter((call) => call.method === "turn/start")).toHaveLength(1);
+    expect(rpc.calls.filter((call) => call.method === "turn/steer")).toHaveLength(0);
+
+    release();
+    expect(await tui.receive()).toMatchObject({
+      id: 3,
+      result: { turn: { id: "turn-tui" } },
+    });
+    expect(await party).toEqual({ kind: "steered", turnId: "turn-tui" });
+    expect(rpc.calls.find((call) => call.method === "turn/steer")?.params).toMatchObject({
+      threadId: "thread-uds",
+      expectedTurnId: "turn-tui",
+      clientUserMessageId: "agentparty:delivery-uds",
+    });
+    tui.send({
+      id: 4,
+      method: "turn/start",
+      params: {
+        threadId: "thread-uds",
+        input: [{ type: "text", text: "must not replace", text_elements: [] }],
+      },
+    });
+    expect(await tui.receive()).toMatchObject({
+      id: 4,
+      error: {
+        code: -32_000,
+        data: {
+          codexBridgeInfo: {
+            method: "turn/start",
+            reason: "phase_not_idle",
+          },
+        },
+      },
+    });
+    expect(rpc.calls.filter((call) => call.method === "turn/start")).toHaveLength(1);
+
+    rpc.emit({
+      id: "approval-7",
+      method: "item/commandExecution/requestApproval",
+      params: { threadId: "thread-uds", turnId: "turn-tui" },
+    });
+    const approval = await tui.receive() as JsonRpcRequest;
+    expect(approval).toMatchObject({
+      method: "item/commandExecution/requestApproval",
+    });
+    expect(approval.id).not.toBe("approval-7");
+    tui.send({ id: approval.id, result: { decision: "accept" } });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(rpc.responses).toContainEqual({
+      id: "approval-7",
+      result: { decision: "accept" },
+      error: undefined,
+    });
+    rpc.emit({
+      id: "approval-8",
+      method: "item/commandExecution/requestApproval",
+      params: { threadId: "thread-uds", turnId: "turn-tui" },
+    });
+    const resolvedApproval = await tui.receive() as JsonRpcRequest;
+    rpc.emit({
+      method: "serverRequest/resolved",
+      params: {
+        threadId: "thread-uds",
+        requestId: "approval-8",
+      },
+    });
+    expect(await tui.receive()).toEqual({
+      method: "serverRequest/resolved",
+      params: {
+        threadId: "thread-uds",
+        requestId: resolvedApproval.id,
+      },
+    });
+    expect(rpc.calls.filter((call) => call.method === "initialize")).toHaveLength(0);
+  }, 10_000);
+
+  test("an accepted initial turn is resumed, not replayed, when its old TUI response is lost", async () => {
+    const rpc = new FakeRpcPeer();
+    const session = new CodexSessionController(rpc);
+    await session.start();
+    proxy = new CodexUnixJsonRpcProxy(session);
+    const socketPath = join(temp, "codex.sock");
+    await proxy.listen(socketPath);
+
+    const first = new UnixWebSocketClient();
+    clients.push(first);
+    await first.open(socketPath);
+    first.send({ id: 1, method: "initialize", params: {} });
+    await first.receive();
+    first.send({ method: "initialized" });
+    first.send({ id: 2, method: "thread/start", params: {} });
+    await first.receive();
+
+    let release!: () => void;
+    rpc.blockTuiStart = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const initialInput = [{
+      type: "text",
+      text: "WIRE_PROMPT_746",
+      text_elements: [],
+    }];
+    first.send({
+      id: 3,
+      method: "turn/start",
+      params: {
+        threadId: "thread-uds",
+        clientUserMessageId: null,
+        input: initialInput,
+      },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    first.close();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    release();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    const replacement = new UnixWebSocketClient();
+    clients.push(replacement);
+    await replacement.open(socketPath);
+    replacement.send({ id: 10, method: "initialize", params: {} });
+    await replacement.receive();
+    replacement.send({ method: "initialized" });
+    replacement.send({
+      id: 11,
+      method: "thread/resume",
+      params: { threadId: "thread-uds" },
+    });
+    expect(await replacement.receive()).toMatchObject({
+      id: 11,
+      result: {
+        thread: {
+          id: "thread-uds",
+          status: { type: "active" },
+        },
+      },
+    });
+
+    expect(rpc.calls.filter((call) => call.method === "thread/start")).toHaveLength(1);
+    expect(rpc.calls.filter((call) => call.method === "turn/start")).toEqual([
+      {
+        method: "turn/start",
+        params: {
+          threadId: "thread-uds",
+          clientUserMessageId: null,
+          input: initialInput,
+        },
+      },
+    ]);
+  }, 10_000);
+
+  test("quiesceFrontend synchronously frees the single frontend slot", async () => {
+    const rpc = new FakeRpcPeer();
+    const session = new CodexSessionController(rpc);
+    proxy = new CodexUnixJsonRpcProxy(session);
+    const socketPath = join(temp, "codex.sock");
+    await proxy.listen(socketPath);
+
+    const first = new UnixWebSocketClient();
+    clients.push(first);
+    await first.open(socketPath);
+    expect(proxy.frontendAttached).toBe(true);
+    expect(proxy.quiesceFrontend("generation changed")).toBe(true);
+    expect(proxy.frontendAttached).toBe(false);
+
+    const replacement = new UnixWebSocketClient();
+    clients.push(replacement);
+    await replacement.open(socketPath);
+    expect(proxy.frontendAttached).toBe(true);
+  });
+
+  test("replays an unanswered server request after the TUI reconnects", async () => {
+    const rpc = new FakeRpcPeer();
+    const session = new CodexSessionController(rpc);
+    await session.start();
+    proxy = new CodexUnixJsonRpcProxy(session);
+    const socketPath = join(temp, "codex.sock");
+    await proxy.listen(socketPath);
+
+    rpc.emit({
+      id: "approval-offline",
+      method: "item/commandExecution/requestApproval",
+      params: { threadId: "thread-uds", turnId: "turn-tui" },
+    });
+
+    const first = new UnixWebSocketClient();
+    clients.push(first);
+    await first.open(socketPath);
+    first.send({ id: 1, method: "initialize", params: {} });
+    expect(await first.receive()).toEqual({ id: 1, result: rpc.initializeResult });
+    first.send({ method: "initialized" });
+    const firstApproval = await first.receive() as JsonRpcRequest;
+    expect(firstApproval).toMatchObject({
+      method: "item/commandExecution/requestApproval",
+    });
+
+    first.close();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    const second = new UnixWebSocketClient();
+    clients.push(second);
+    await second.open(socketPath);
+    second.send({ id: 2, method: "initialize", params: {} });
+    expect(await second.receive()).toEqual({ id: 2, result: rpc.initializeResult });
+    second.send({ method: "initialized" });
+    const secondApproval = await second.receive() as JsonRpcRequest;
+    expect(secondApproval).toMatchObject({
+      method: "item/commandExecution/requestApproval",
+    });
+    expect(secondApproval.id).toBe(firstApproval.id);
+    second.send({ id: secondApproval.id, result: { decision: "accept" } });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(rpc.responses).toEqual([{
+      id: "approval-offline",
+      result: { decision: "accept" },
+      error: undefined,
+    }]);
+  }, 10_000);
+
+  test("ignores an old TUI response when a restarted backend reuses its request id", async () => {
+    const rpc = new FakeRpcPeer();
+    const session = new CodexSessionController(rpc);
+    await session.start();
+    proxy = new CodexUnixJsonRpcProxy(session);
+    const socketPath = join(temp, "codex.sock");
+    await proxy.listen(socketPath);
+
+    const tui = new UnixWebSocketClient();
+    clients.push(tui);
+    await tui.open(socketPath);
+    tui.send({ id: 1, method: "initialize", params: {} });
+    expect(await tui.receive()).toEqual({ id: 1, result: rpc.initializeResult });
+    tui.send({ method: "initialized" });
+
+    rpc.emit({
+      id: 0,
+      method: "item/commandExecution/requestApproval",
+      params: { threadId: "thread-uds", turnId: "turn-old" },
+    });
+    const oldApproval = await tui.receive() as JsonRpcRequest;
+    expect(oldApproval).toMatchObject({
+      method: "item/commandExecution/requestApproval",
+      params: { turnId: "turn-old" },
+    });
+
+    await rpc.reconnect();
+    expect(await tui.receive()).toEqual({
+      method: "serverRequest/resolved",
+      params: {
+        threadId: "thread-uds",
+        requestId: oldApproval.id,
+      },
+    });
+    tui.close();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    const replacement = new UnixWebSocketClient();
+    clients.push(replacement);
+    await replacement.open(socketPath);
+    replacement.send({ id: 2, method: "initialize", params: {} });
+    expect(await replacement.receive()).toEqual({ id: 2, result: rpc.initializeResult });
+    replacement.send({ method: "initialized" });
+
+    rpc.emit({
+      id: 0,
+      method: "item/commandExecution/requestApproval",
+      params: { threadId: "thread-uds", turnId: "turn-new" },
+    });
+    const newApproval = await replacement.receive() as JsonRpcRequest;
+    expect(newApproval).toMatchObject({
+      method: "item/commandExecution/requestApproval",
+      params: { turnId: "turn-new" },
+    });
+    expect(newApproval.id).not.toBe(oldApproval.id);
+
+    replacement.send({ id: oldApproval.id, result: { decision: "accept" } });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(rpc.responses).toEqual([]);
+
+    replacement.send({ id: newApproval.id, result: { decision: "decline" } });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(rpc.responses).toEqual([{
+      id: 0,
+      result: { decision: "decline" },
+      error: undefined,
+    }]);
+  }, 10_000);
+
+  test("does not replay an offline server request that was already resolved", async () => {
+    const rpc = new FakeRpcPeer();
+    const session = new CodexSessionController(rpc);
+    await session.start();
+    proxy = new CodexUnixJsonRpcProxy(session);
+    const socketPath = join(temp, "codex.sock");
+    await proxy.listen(socketPath);
+    rpc.emit({
+      id: "approval-resolved",
+      method: "item/commandExecution/requestApproval",
+      params: { threadId: "thread-uds", turnId: "turn-tui" },
+    });
+    rpc.emit({
+      method: "serverRequest/resolved",
+      params: {
+        threadId: "thread-uds",
+        requestId: "approval-resolved",
+      },
+    });
+
+    const tui = new UnixWebSocketClient();
+    clients.push(tui);
+    await tui.open(socketPath);
+    tui.send({ id: 1, method: "initialize", params: {} });
+    expect(await tui.receive()).toEqual({ id: 1, result: rpc.initializeResult });
+    tui.send({ method: "initialized" });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    rpc.emit({
+      method: "thread/name/updated",
+      params: { threadId: "thread-uds", name: "still live" },
+    });
+    expect(await tui.receive()).toEqual({
+      method: "thread/name/updated",
+      params: { threadId: "thread-uds", name: "still live" },
+    });
+  }, 10_000);
+
+  test("never routes an old TUI request response into a replacement socket", async () => {
+    const rpc = new FakeRpcPeer();
+    const session = new CodexSessionController(rpc);
+    await session.start();
+    proxy = new CodexUnixJsonRpcProxy(session);
+    const socketPath = join(temp, "codex.sock");
+    await proxy.listen(socketPath);
+
+    const first = new UnixWebSocketClient();
+    clients.push(first);
+    await first.open(socketPath);
+    first.send({ id: 1, method: "initialize", params: {} });
+    await first.receive();
+    first.send({ method: "initialized" });
+    let release!: () => void;
+    rpc.blockThreadRead = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    first.send({
+      id: 77,
+      method: "thread/read",
+      params: { threadId: "thread-old", includeTurns: true },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    first.close();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    const second = new UnixWebSocketClient();
+    clients.push(second);
+    await second.open(socketPath);
+    second.send({ id: 2, method: "initialize", params: {} });
+    expect(await second.receive()).toEqual({ id: 2, result: rpc.initializeResult });
+    second.send({ method: "initialized" });
+    release();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    rpc.emit({
+      method: "thread/name/updated",
+      params: { threadId: "thread-uds", name: "new socket" },
+    });
+    expect(await second.receive()).toEqual({
+      method: "thread/name/updated",
+      params: { threadId: "thread-uds", name: "new socket" },
+    });
+  }, 10_000);
+
+  test("a dropped approval frame closes the unhealthy socket and retains it for replay", async () => {
+    const rpc = new FakeRpcPeer();
+    const session = new CodexSessionController(rpc);
+    proxy = new CodexUnixJsonRpcProxy(session, { log: () => {} });
+    const closes: Array<{ code: number; reason: string }> = [];
+    const socket = {
+      data: { connectionId: "dropped" },
+      send: () => 0,
+      close: (code: number, reason: string) => {
+        closes.push({ code, reason });
+      },
+    };
+    const internal = proxy as unknown as {
+      socket: typeof socket | null;
+      frontendReady: boolean;
+      pendingServerRequestsByBackendId: Map<string, unknown>;
+    };
+    internal.socket = socket;
+    internal.frontendReady = true;
+
+    rpc.emit({
+      id: "approval-dropped",
+      method: "item/commandExecution/requestApproval",
+      params: { threadId: "thread-uds", turnId: "turn-dropped" },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(closes).toEqual([{
+      code: 1011,
+      reason: "Codex bridge could not deliver a JSON-RPC frame",
+    }]);
+    expect(internal.frontendReady).toBe(false);
+    expect(internal.pendingServerRequestsByBackendId.size).toBe(1);
+  });
+
+  test("backpressure queues later frames until drain without duplicating the accepted frame", () => {
+    const rpc = new FakeRpcPeer();
+    const session = new CodexSessionController(rpc);
+    proxy = new CodexUnixJsonRpcProxy(session, { log: () => {} });
+    const payloads: string[] = [];
+    const statuses = [-1, 100];
+    const socket = {
+      data: { connectionId: "backpressured" },
+      send: (payload: string) => {
+        payloads.push(payload);
+        return statuses.shift() ?? 100;
+      },
+      close: () => {},
+    };
+    const internal = proxy as unknown as {
+      socket: typeof socket | null;
+      frontendReady: boolean;
+      send: (message: JsonRpcNotification) => void;
+      drain: (target: typeof socket) => void;
+    };
+    internal.socket = socket;
+    internal.frontendReady = true;
+
+    internal.send({ method: "thread/name/updated", params: { name: "first" } });
+    internal.send({ method: "thread/name/updated", params: { name: "second" } });
+    expect(payloads).toHaveLength(1);
+    internal.drain(socket);
+    expect(payloads.map((payload) => JSON.parse(payload).params.name)).toEqual([
+      "first",
+      "second",
+    ]);
+  });
+
+  test("a backpressured TUI cannot grow the proxy outbound queue without bound", () => {
+    const rpc = new FakeRpcPeer();
+    const session = new CodexSessionController(rpc);
+    proxy = new CodexUnixJsonRpcProxy(session, { log: () => {} });
+    const closes: number[] = [];
+    const socket = {
+      data: { connectionId: "bounded-backpressure" },
+      send: () => -1,
+      close: (code: number) => {
+        closes.push(code);
+      },
+    };
+    const internal = proxy as unknown as {
+      socket: typeof socket | null;
+      frontendReady: boolean;
+      send: (message: JsonRpcNotification) => void;
+      outboundQueue: unknown[];
+    };
+    internal.socket = socket;
+    internal.frontendReady = true;
+
+    for (let index = 0; index < 1_026; index += 1) {
+      internal.send({
+        method: "item/agentMessage/delta",
+        params: { delta: `token-${index}` },
+      });
+    }
+    expect(closes).toEqual([1011]);
+    expect(internal.frontendReady).toBe(false);
+    expect(internal.outboundQueue).toHaveLength(0);
+  });
+});

--- a/cli/test/delivery-recovery-journal.test.ts
+++ b/cli/test/delivery-recovery-journal.test.ts
@@ -1,0 +1,232 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import type { DirectedDelivery, MsgFrame } from "@agentparty/shared";
+import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DeliveryRecoveryJournal } from "../src/delivery-recovery-journal";
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function fixture() {
+  const now = Date.now();
+  const delivery: DirectedDelivery = {
+    id: "delivery-recovery-1",
+    message_seq: 41,
+    target_name: "front",
+    cause: "mention",
+    state: "claimed",
+    attempt: 3,
+    lease_epoch: 7,
+    lease_token: "lease-token-old",
+    lease_until: now + 90_000,
+    work_id: "work-1",
+    continuation_ref: "continuation-1",
+    reply_seq: null,
+    last_error: null,
+    created_at: now,
+    updated_at: now,
+  };
+  const message: MsgFrame = {
+    type: "msg",
+    seq: 41,
+    sender: { name: "owner", kind: "human" },
+    kind: "message",
+    body: "@front continue",
+    mentions: ["front"],
+    reply_to: null,
+    state: null,
+    note: null,
+    status: null,
+    ts: now,
+  };
+  return { delivery, message };
+}
+
+describe("DeliveryRecoveryJournal", () => {
+  test("persists claim and next token before recovery so ACK-loss restart is idempotent", () => {
+    const root = mkdtempSync(join(tmpdir(), "ap-delivery-journal-"));
+    roots.push(root);
+    const path = join(root, "journal.json");
+    const { delivery, message } = fixture();
+    const first = new DeliveryRecoveryJournal(path, "dev", "claude");
+    first.recordClaim(delivery, message);
+    const recover = first.prepareRecovery(delivery.id);
+
+    const onDiskBeforeAck = JSON.parse(readFileSync(path, "utf8")) as {
+      entries: Array<{ nextLeaseToken: string }>;
+    };
+    expect(onDiskBeforeAck.entries[0]!.nextLeaseToken).toBe(recover.next_lease_token);
+    expect(statSync(path).mode & 0o777).toBe(0o600);
+
+    const restarted = new DeliveryRecoveryJournal(path, "dev", "claude");
+    const retry = restarted.prepareRecovery(delivery.id);
+    expect(retry.lease_token).toBe(recover.lease_token);
+    expect(retry.next_lease_token).toBe(recover.next_lease_token);
+    restarted.acceptRecovery({
+      type: "delivery_recovery",
+      delivery_id: delivery.id,
+      request_id: retry.request_id,
+      result: "recovered",
+      state: "running",
+      attempt: delivery.attempt,
+      lease_epoch: delivery.lease_epoch!,
+      lease_token: retry.next_lease_token,
+      lease_until: Date.now() + 90_000,
+    });
+
+    const afterAckRestart = new DeliveryRecoveryJournal(path, "dev", "claude");
+    expect(afterAckRestart.get(delivery.id)).toMatchObject({
+      phase: "claimed",
+      nextLeaseToken: null,
+      delivery: {
+        state: "running",
+        lease_token: retry.next_lease_token,
+      },
+    });
+  });
+
+  test("records pre-injection and accepted phases across process restart", () => {
+    const root = mkdtempSync(join(tmpdir(), "ap-delivery-journal-"));
+    roots.push(root);
+    const path = join(root, "journal.json");
+    const { delivery, message } = fixture();
+    const journal = new DeliveryRecoveryJournal(path, "dev", "codex");
+    journal.recordClaim(delivery, message);
+    journal.update(delivery.id, { phase: "running_authorized" });
+    journal.update(delivery.id, { phase: "harness_issued", threadId: "thread-1" });
+
+    const restarted = new DeliveryRecoveryJournal(path, "dev", "codex");
+    expect(restarted.get(delivery.id)).toMatchObject({
+      phase: "harness_issued",
+      threadId: "thread-1",
+    });
+    restarted.update(delivery.id, {
+      phase: "harness_accepted",
+      turnId: "turn-1",
+    });
+    expect(new DeliveryRecoveryJournal(path, "dev", "codex").get(delivery.id)).toMatchObject({
+      phase: "harness_accepted",
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+  });
+
+  test("a failed recovery-token flush rolls back memory and retry commits the same disk-visible token", () => {
+    const root = mkdtempSync(join(tmpdir(), "ap-delivery-journal-"));
+    roots.push(root);
+    const path = join(root, "journal.json");
+    const { delivery, message } = fixture();
+    new DeliveryRecoveryJournal(path, "dev", "claude").recordClaim(delivery, message);
+
+    let failNextCommit = true;
+    const journal = new DeliveryRecoveryJournal(path, "dev", "claude", {
+      persist(commit) {
+        if (failNextCommit) {
+          failNextCommit = false;
+          throw Object.assign(new Error("simulated journal disk full"), { code: "ENOSPC" });
+        }
+        commit();
+      },
+    });
+    expect(() => journal.prepareRecovery(delivery.id)).toThrow("simulated journal disk full");
+    expect(journal.get(delivery.id)?.nextLeaseToken).toBeNull();
+    expect(
+      new DeliveryRecoveryJournal(path, "dev", "claude").get(delivery.id)?.nextLeaseToken,
+    ).toBeNull();
+
+    const retry = journal.prepareRecovery(delivery.id);
+    expect(journal.get(delivery.id)?.nextLeaseToken).toBe(retry.next_lease_token);
+    expect(
+      new DeliveryRecoveryJournal(path, "dev", "claude").get(delivery.id)?.nextLeaseToken,
+    ).toBe(retry.next_lease_token);
+  });
+
+  test("a stale pre-harness snapshot cannot publish replay_safe after the phase advances", () => {
+    const root = mkdtempSync(join(tmpdir(), "ap-delivery-journal-"));
+    roots.push(root);
+    const path = join(root, "journal.json");
+    const { delivery, message } = fixture();
+    const journal = new DeliveryRecoveryJournal(path, "dev", "claude");
+    const before = journal.recordClaim(delivery, message);
+    journal.update(delivery.id, { phase: "harness_accepted" });
+
+    expect(() => journal.prepareRecovery(delivery.id, {
+      replaySafe: true,
+      expected: {
+        phase: before.phase,
+        updatedAt: before.updatedAt,
+        attempt: before.delivery.attempt,
+        leaseEpoch: before.delivery.lease_epoch!,
+        leaseToken: before.delivery.lease_token!,
+      },
+    })).toThrow("changed while recovery was being prepared");
+    expect(journal.get(delivery.id)).toMatchObject({
+      phase: "harness_accepted",
+      nextLeaseToken: null,
+    });
+    expect(
+      new DeliveryRecoveryJournal(path, "dev", "claude").get(delivery.id),
+    ).toMatchObject({
+      phase: "harness_accepted",
+      nextLeaseToken: null,
+    });
+  });
+
+  test("recordClaim rejects identity drift without mutating memory or disk", () => {
+    const root = mkdtempSync(join(tmpdir(), "ap-delivery-journal-identity-"));
+    roots.push(root);
+    const path = join(root, "journal.json");
+    const { delivery, message } = fixture();
+    const journal = new DeliveryRecoveryJournal(path, "dev", "claude");
+    const original = journal.recordClaim(delivery, message);
+    const diskBefore = readFileSync(path, "utf8");
+    const variants: Array<{
+      name: string;
+      delivery: DirectedDelivery;
+      message: MsgFrame;
+    }> = [
+      {
+        name: "message sequence",
+        delivery: { ...delivery, message_seq: delivery.message_seq + 1 },
+        message,
+      },
+      {
+        name: "cause",
+        delivery: { ...delivery, cause: "owner_answer" },
+        message,
+      },
+      {
+        name: "lease token",
+        delivery: { ...delivery, lease_token: "different-token" },
+        message,
+      },
+      {
+        name: "message body",
+        delivery,
+        message: { ...message, body: "@front changed body" },
+      },
+      {
+        name: "work id",
+        delivery: { ...delivery, work_id: "different-work" },
+        message,
+      },
+      {
+        name: "continuation ref",
+        delivery: { ...delivery, continuation_ref: "different-continuation" },
+        message,
+      },
+    ];
+    for (const variant of variants) {
+      expect(
+        () => journal.recordClaim(variant.delivery, variant.message),
+        variant.name,
+      ).toThrow();
+      expect(journal.get(delivery.id), variant.name).toEqual(original);
+      expect(readFileSync(path, "utf8"), variant.name).toBe(diskBefore);
+    }
+  });
+});

--- a/cli/test/fixtures/mock-codex-app-server.ts
+++ b/cli/test/fixtures/mock-codex-app-server.ts
@@ -1,0 +1,161 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { createInterface } from "node:readline";
+
+interface State {
+  threadId: string;
+  turns: Array<{
+    id: string;
+    status: "completed" | "inProgress";
+    items: Array<Record<string, unknown>>;
+  }>;
+  nextTurn: number;
+  generations: number;
+  requests?: string[];
+}
+
+const configuredStatePath = process.env.MOCK_CODEX_STATE_PATH;
+if (!configuredStatePath) throw new Error("MOCK_CODEX_STATE_PATH is required");
+const statePath: string = configuredStatePath;
+
+function load(): State {
+  try {
+    return JSON.parse(readFileSync(statePath, "utf8")) as State;
+  } catch {
+    return {
+      threadId: "thread-mock",
+      turns: [],
+      nextTurn: 1,
+      generations: 0,
+    };
+  }
+}
+
+let state = load();
+state.requests ??= [];
+state.generations += 1;
+writeFileSync(statePath, JSON.stringify(state));
+
+function save(): void {
+  writeFileSync(statePath, JSON.stringify(state));
+}
+
+function send(value: unknown): void {
+  process.stdout.write(`${JSON.stringify(value)}\n`);
+}
+
+function thread() {
+  const active = state.turns.some((turn) => turn.status === "inProgress");
+  return {
+    id: state.threadId,
+    status: { type: active ? "active" : "idle" },
+    turns: state.turns,
+  };
+}
+
+function textFrom(params: Record<string, unknown>): string {
+  if (!Array.isArray(params.input)) return "";
+  const first = params.input[0];
+  return typeof first === "object" && first !== null && "text" in first
+    ? String(first.text)
+    : "";
+}
+
+const input = createInterface({ input: process.stdin });
+input.on("line", (line) => {
+  const frame = JSON.parse(line) as {
+    id?: string | number | null;
+    method: string;
+    params?: Record<string, unknown>;
+  };
+  const params = frame.params ?? {};
+  state.requests!.push(frame.method);
+  save();
+  if (frame.method === "initialized") return;
+  if (frame.method === "initialize") {
+    send({
+      id: frame.id,
+      result: {
+        userAgent: "mock-codex-app-server/0.144.4",
+        codexHome: "/tmp/mock-codex-home",
+        platformFamily: "unix",
+        platformOs: "test",
+      },
+    });
+    return;
+  }
+  if (frame.method === "thread/start" || frame.method === "thread/resume" || frame.method === "thread/read") {
+    send({ id: frame.id, result: { thread: thread() } });
+    return;
+  }
+  if (frame.method === "turn/start") {
+    const id = `turn-${state.nextTurn++}`;
+    const clientId = typeof params.clientUserMessageId === "string" ? params.clientUserMessageId : null;
+    const turn = {
+      id,
+      status: "inProgress" as const,
+      items: [{
+        type: "userMessage",
+        id: `user-${id}`,
+        clientId,
+        content: params.input ?? [],
+      }],
+    };
+    state.turns.push(turn);
+    save();
+    if (textFrom(params).includes("__disconnect_after_accept__")) {
+      process.exit(73);
+    }
+    send({ id: frame.id, result: { turn } });
+    send({ method: "turn/started", params: { threadId: state.threadId, turn } });
+    return;
+  }
+  if (frame.method === "turn/steer") {
+    const turnId = String(params.expectedTurnId);
+    const turn = state.turns.find((entry) => entry.id === turnId);
+    if (turn) {
+      turn.items.push({
+        type: "userMessage",
+        id: `user-${turnId}-${turn.items.length}`,
+        clientId: params.clientUserMessageId ?? null,
+        content: params.input ?? [],
+      });
+      save();
+    }
+    send({ id: frame.id, result: { turnId } });
+    return;
+  }
+  if (frame.method === "mock/complete") {
+    const turn = state.turns.find((entry) => entry.id === params.turnId);
+    if (!turn) {
+      send({ id: frame.id, error: { code: -32_001, message: "unknown turn" } });
+      return;
+    }
+    turn.status = "completed";
+    turn.items.push({
+      type: "agentMessage",
+      id: `agent-${turn.id}`,
+      text: String(params.text ?? "mock final"),
+    });
+    save();
+    send({ id: frame.id, result: {} });
+    send({ method: "turn/completed", params: { threadId: state.threadId, turn } });
+    send({
+      method: "thread/status/changed",
+      params: { threadId: state.threadId, status: { type: "idle" } },
+    });
+    return;
+  }
+  if (frame.method === "mock/serverRequest") {
+    send({ id: frame.id, result: {} });
+    send({
+      id: "server-approval-1",
+      method: "item/commandExecution/requestApproval",
+      params: { threadId: state.threadId, turnId: "turn-1" },
+    });
+    return;
+  }
+  if (frame.method === "mock/disconnect") {
+    process.exit(74);
+  }
+  send({ id: frame.id, result: { echoedMethod: frame.method, params } });
+});

--- a/cli/test/mock-server.ts
+++ b/cli/test/mock-server.ts
@@ -106,7 +106,11 @@ export function welcomeFrame(lastSeq: number, self = "me", readCursors?: Array<{
 // A welcome that advertises directed-delivery v1 — the server routes real agent @-mentions as durable
 // `delivery` frames only after this negotiation (see cli/src/commands/serve.ts + daemon.ts).
 export function welcomeDirectedFrame(lastSeq: number, self = "me") {
-  return { ...welcomeFrame(lastSeq, self), directed_delivery: "v1" };
+  return {
+    ...welcomeFrame(lastSeq, self),
+    directed_delivery: "v1",
+    delivery_recovery: "v1",
+  };
 }
 
 // A durable directed-delivery frame: `{ delivery, message }` where message is the @-mention MsgFrame and
@@ -135,6 +139,8 @@ export function deliveryFrame(
       cause: "mention",
       state: over.state ?? "claimed",
       attempt: 1,
+      lease_epoch: 1,
+      lease_token: `lease-${over.id ?? seq}`,
       lease_until: now + 90_000,
       work_id: over.work_id ?? `work-${seq}`,
       continuation_ref: over.continuation_ref ?? `cont-${seq}`,

--- a/cli/test/serve-runner-command.test.ts
+++ b/cli/test/serve-runner-command.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { builtinRunnerCommand } from "../src/commands/serve";
+import { realpathSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  builtinRunnerCommand,
+  resolveBuiltinCodexLaunch,
+} from "../src/commands/serve";
 
 describe("builtin runner executable binding", () => {
   test("uses the launchd-persisted absolute executable instead of PATH lookup", () => {
@@ -26,5 +31,51 @@ describe("builtin runner executable binding", () => {
     expect(() =>
       builtinRunnerCommand("codex", { AGENTPARTY_RUNNER_BIN: "./codex" })
     ).toThrow("AGENTPARTY_RUNNER_BIN must be absolute");
+  });
+
+  test("Codex preflight preserves flag > Codex env > launchd runner binding priority", () => {
+    const cwd = process.cwd();
+    const missingCodex = resolve(cwd, "missing-codex-env");
+    const missingRunner = resolve(cwd, "missing-runner-binding");
+    const explicit = resolveBuiltinCodexLaunch(process.execPath, {
+      PATH: "",
+      AGENTPARTY_CODEX_BIN: missingCodex,
+      AGENTPARTY_RUNNER_BIN: missingRunner,
+    }, cwd);
+    expect(explicit).toMatchObject({
+      ok: true,
+      codexBinary: realpathSync(process.execPath),
+    });
+
+    const codexEnv = resolveBuiltinCodexLaunch(undefined, {
+      PATH: "",
+      AGENTPARTY_CODEX_BIN: process.execPath,
+      AGENTPARTY_RUNNER_BIN: missingRunner,
+    }, cwd);
+    expect(codexEnv).toMatchObject({
+      ok: true,
+      codexBinary: realpathSync(process.execPath),
+    });
+
+    const launchdBinding = resolveBuiltinCodexLaunch(undefined, {
+      PATH: "",
+      AGENTPARTY_RUNNER_BIN: process.execPath,
+    }, cwd);
+    expect(launchdBinding).toMatchObject({
+      ok: true,
+      codexBinary: realpathSync(process.execPath),
+    });
+  });
+
+  test("Codex preflight fails closed on a malformed launchd runner binding", () => {
+    expect(
+      resolveBuiltinCodexLaunch(undefined, {
+        PATH: "/usr/bin:/bin",
+        AGENTPARTY_RUNNER_BIN: "./custom-codex",
+      }, process.cwd()),
+    ).toMatchObject({
+      ok: false,
+      error: expect.stringContaining("AGENTPARTY_RUNNER_BIN must be absolute"),
+    });
   });
 });

--- a/cli/test/serve.test.ts
+++ b/cli/test/serve.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { existsSync, lstatSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, readlinkSync, rmSync, symlinkSync, unlinkSync, writeFileSync } from "node:fs";
+import { existsSync, lstatSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, readlinkSync, realpathSync, rmSync, symlinkSync, unlinkSync, writeFileSync } from "node:fs";
 import { EXIT_ARCHIVED, type Attachment, type DirectedDelivery, type MsgFrame } from "@agentparty/shared";
 import { tmpdir } from "node:os";
 import { join, sep } from "node:path";
@@ -1369,6 +1369,32 @@ describe("managed front protocol", () => {
 });
 
 describe("builtin runner", () => {
+  test("codex uses one resolved absolute binary instead of trusting the runner PATH", async () => {
+    const { post } = postRecorder();
+    const workdir = tempDir();
+    const calls: string[][] = [];
+    const runProcess: RunnerProcess = async (args) => {
+      calls.push(args);
+      const out = args[args.indexOf("-o") + 1]!;
+      writeFileSync(out, "resolved answer\n");
+      return { code: 0, stdout: `session id: ${uuid(0)}\n`, stderr: "" };
+    };
+
+    await createBuiltinRunner({
+      server: "http://agentparty.test",
+      token: "ap_tok",
+      channel: "dev",
+      harness: "codex",
+      codexBinary: process.execPath,
+      workdir,
+      runProcess,
+      post,
+    })(triggerFrame(700), runnerCtx());
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.slice(0, 2)).toEqual([realpathSync(process.execPath), "exec"]);
+  });
+
   test("codex cold-starts, persists the session id, then resumes it on the next wake", async () => {
     const { post } = postRecorder();
     const workdir = tempDir();
@@ -2231,6 +2257,32 @@ describe("builtin runner", () => {
       console.error = oldError;
     }
     expect(errors.join("\n")).toContain("choose exactly one of --on-mention or --runner");
+  });
+
+  test("--codex-bin is rejected unless the selected resident runner is codex", async () => {
+    const home = tempDir();
+    writeFileSync(join(home, "config.json"), JSON.stringify({ server: "http://127.0.0.1:1", token: "ap_tok" }));
+    const oldHome = process.env.AGENTPARTY_HOME;
+    const errors: string[] = [];
+    const oldError = console.error;
+    process.env.AGENTPARTY_HOME = home;
+    console.error = (line?: unknown) => errors.push(String(line));
+    try {
+      expect(
+        await runServeCommand([
+          "dev",
+          "--runner",
+          "claude",
+          "--codex-bin",
+          process.execPath,
+        ]),
+      ).toBe(1);
+    } finally {
+      if (oldHome === undefined) delete process.env.AGENTPARTY_HOME;
+      else process.env.AGENTPARTY_HOME = oldHome;
+      console.error = oldError;
+    }
+    expect(errors.join("\n")).toContain("--codex-bin requires --runner codex");
   });
 });
 

--- a/cli/test/serve.test.ts
+++ b/cli/test/serve.test.ts
@@ -21,6 +21,7 @@ import {
   runProfileServe,
   runServe,
   RunnerTimeoutError,
+  superviseServe,
   WakeBlockedError,
   writeContextFile,
   type CodexLike,
@@ -1395,6 +1396,135 @@ describe("builtin runner", () => {
     expect(calls[0]!.slice(0, 2)).toEqual([realpathSync(process.execPath), "exec"]);
   });
 
+  test("codex keeps the Windows npm entrypoint prefix before ordinary serve exec", async () => {
+    const { post } = postRecorder();
+    const workdir = tempDir();
+    const calls: string[][] = [];
+    const runProcess: RunnerProcess = async (args) => {
+      calls.push(args);
+      const out = args[args.indexOf("-o") + 1]!;
+      writeFileSync(out, "npm shim answer\n");
+      return { code: 0, stdout: `session id: ${uuid(0)}\n`, stderr: "" };
+    };
+
+    await createBuiltinRunner({
+      server: "http://agentparty.test",
+      token: "ap_tok",
+      channel: "dev",
+      harness: "codex",
+      codexBinary: "C:/Program Files/nodejs/node.exe",
+      codexArgsPrefix: ["C:/Users/test/AppData/Roaming/npm/node_modules/@openai/codex/bin/codex.js"],
+      workdir,
+      runProcess,
+      post,
+    })(triggerFrame(701), runnerCtx());
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.slice(0, 3)).toEqual([
+      "C:/Program Files/nodejs/node.exe",
+      "C:/Users/test/AppData/Roaming/npm/node_modules/@openai/codex/bin/codex.js",
+      "exec",
+    ]);
+  });
+
+  test("codex wake uses the exact preflight launch after PATH changes", async () => {
+    const { post } = postRecorder();
+    const workdir = tempDir();
+    const calls: Array<{ args: string[]; path: string | undefined }> = [];
+    const runProcess: RunnerProcess = async (args, options) => {
+      calls.push({ args, path: options.env.PATH });
+      const out = args[args.indexOf("-o") + 1]!;
+      writeFileSync(out, "pinned preflight answer\n");
+      return { code: 0, stdout: `session id: ${uuid(0)}\n`, stderr: "" };
+    };
+
+    await createBuiltinRunner({
+      server: "http://agentparty.test",
+      token: "ap_tok",
+      channel: "dev",
+      harness: "codex",
+      codexLaunch: {
+        ok: true,
+        codexBinary: "/preflight-a/node.exe",
+        codexArgsPrefix: ["/preflight-a/codex.js"],
+        cwd: "/preflight-a",
+        env: { PATH: "/preflight-a/bin" },
+      },
+      workdir,
+      runProcess,
+      post,
+    })(triggerFrame(702), runnerCtx());
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.args.slice(0, 3)).toEqual([
+      "/preflight-a/node.exe",
+      "/preflight-a/codex.js",
+      "exec",
+    ]);
+    expect(calls[0]!.path).toBe("/preflight-a/bin");
+  });
+
+  test("ordinary serve reuses one preflight launch across supervisor attempts", async () => {
+    const home = tempDir();
+    const oldHome = process.env.AGENTPARTY_HOME;
+    const oldPath = process.env.PATH;
+    process.env.AGENTPARTY_HOME = home;
+    process.env.PATH = "/preflight-a/bin";
+    writeFileSync(join(home, "config.json"), JSON.stringify({
+      server: "http://agentparty.test",
+      token: "ap_tok",
+    }));
+    const launch = {
+      ok: true as const,
+      codexBinary: "/preflight-a/node.exe",
+      codexArgsPrefix: ["/preflight-a/codex.js"],
+      cwd: "/preflight-a",
+      env: { PATH: "/preflight-a/bin" },
+    };
+    const attempts: ServeOptions[] = [];
+    let preflights = 0;
+    try {
+      expect(await runServeCommand(["dev", "--runner", "codex"], {
+        resolveBuiltinCodexLaunch: () => {
+          preflights += 1;
+          process.env.PATH = "/post-preflight-b/bin";
+          return launch;
+        },
+        resolveAvailableUpgrade: async () => null,
+        verifyServeIdentityBoundary: async () => ({
+          ok: true,
+          principal: {
+            server_origin: "http://agentparty.test",
+            name: "me",
+            kind: "agent",
+            owner: null,
+          },
+          namespace: "a".repeat(64),
+        }),
+        runServe: async (options) => {
+          attempts.push(options);
+          return attempts.length === 1 ? 1 : 0;
+        },
+        superviseServe: (options) => superviseServe({
+          ...options,
+          baseDelayMs: 0,
+          maxDelayMs: 0,
+          maxRestarts: 1,
+        }),
+      })).toBe(0);
+    } finally {
+      if (oldHome === undefined) delete process.env.AGENTPARTY_HOME;
+      else process.env.AGENTPARTY_HOME = oldHome;
+      if (oldPath === undefined) delete process.env.PATH;
+      else process.env.PATH = oldPath;
+    }
+
+    expect(preflights).toBe(1);
+    expect(attempts).toHaveLength(2);
+    expect(attempts.every((options) => options.builtinRunner?.codexLaunch === launch)).toBe(true);
+    expect(attempts.every((options) => options.builtinRunner?.codexLaunch?.env.PATH === "/preflight-a/bin")).toBe(true);
+  });
+
   test("codex cold-starts, persists the session id, then resumes it on the next wake", async () => {
     const { post } = postRecorder();
     const workdir = tempDir();
@@ -2287,6 +2417,177 @@ describe("builtin runner", () => {
 });
 
 describe("project profile daemon", () => {
+  test("all Codex profile lanes retain the same preflight launch after PATH changes", async () => {
+    const home = tempDir();
+    const oldHome = process.env.AGENTPARTY_HOME;
+    const oldPath = process.env.PATH;
+    process.env.AGENTPARTY_HOME = home;
+    process.env.PATH = "/preflight-a/bin";
+    const profile = {
+      owner_account: "fan@example.com",
+      handle: "pinned-codex",
+      name: "Pinned Codex",
+      runner: "codex" as const,
+      repo_url: null,
+      workdir: null,
+      base_branch: "main",
+      worktree_strategy: "none" as const,
+      rules: null,
+      invitable_by: "anyone" as const,
+      created_at: 1,
+      updated_at: 1,
+    };
+    const served: ServeOptions[] = [];
+    let preflights = 0;
+    const launch = {
+      ok: true as const,
+      codexBinary: "/preflight-a/node.exe",
+      codexArgsPrefix: ["/preflight-a/codex.js"],
+      cwd: "/preflight-a",
+      env: { PATH: "/preflight-a/bin" },
+    };
+    try {
+      expect(await runProfileServe({
+        server: "http://agentparty.test",
+        humanToken: "acc-human",
+        ownerAccount: profile.owner_account,
+        handle: profile.handle,
+        mentionsOnly: true,
+        once: true,
+        post: async () => ({ seq: 1 }),
+        mintRuntime: async () => ({ token: "ap_profile_runtime", profile }),
+        listInvites: async () => ["alpha", "beta"].map((channel_slug, index) => ({
+          id: index + 1,
+          channel_slug,
+          owner_account: profile.owner_account,
+          profile_handle: profile.handle,
+          invited_by: "owner@example.com",
+          invited_at: index + 1,
+          profile,
+        })),
+        ensureChannelRuntime: async (_server, _token, channel, _owner, _handle, childName) => ({
+          token: `ap_child_${childName}`,
+          name: childName,
+          role: "agent",
+          owner: profile.owner_account,
+          channel_scope: channel,
+          lineage: {
+            parent_agent: profile.handle,
+            root_agent: profile.handle,
+            team_id: profile.handle,
+            depth: 1,
+            expires_at: null,
+          },
+          profile,
+        }),
+        resolveCodexLaunch: () => {
+          preflights += 1;
+          process.env.PATH = "/post-preflight-b/bin";
+          return launch;
+        },
+        runChannelServe: async (options) => {
+          served.push(options);
+          return 0;
+        },
+      })).toBe(0);
+    } finally {
+      if (oldHome === undefined) delete process.env.AGENTPARTY_HOME;
+      else process.env.AGENTPARTY_HOME = oldHome;
+      if (oldPath === undefined) delete process.env.PATH;
+      else process.env.PATH = oldPath;
+    }
+
+    expect(preflights).toBe(1);
+    expect(served).toHaveLength(4);
+    expect(served.every((options) => options.builtinRunner?.codexLaunch === launch)).toBe(true);
+    expect(served.every((options) => options.builtinRunner?.codexLaunch?.env.PATH === "/preflight-a/bin")).toBe(true);
+  });
+
+  test("a failed Codex profile preflight remains offline and is retried without fallback", async () => {
+    const home = tempDir();
+    const oldHome = process.env.AGENTPARTY_HOME;
+    process.env.AGENTPARTY_HOME = home;
+    const profile = {
+      owner_account: "fan@example.com",
+      handle: "missing-codex",
+      name: "Missing Codex",
+      runner: "codex" as const,
+      repo_url: null,
+      workdir: null,
+      base_branch: "main",
+      worktree_strategy: "none" as const,
+      rules: null,
+      invitable_by: "anyone" as const,
+      created_at: 1,
+      updated_at: 1,
+    };
+    let polls = 0;
+    let preflights = 0;
+    let serves = 0;
+    let sleeps = 0;
+    const lines: string[] = [];
+    try {
+      await expect(runProfileServe({
+        server: "http://agentparty.test",
+        humanToken: "acc-human",
+        ownerAccount: profile.owner_account,
+        handle: profile.handle,
+        mentionsOnly: true,
+        pollIntervalMs: 500,
+        out: (line) => lines.push(line),
+        post: async () => ({ seq: 1 }),
+        mintRuntime: async () => ({ token: "ap_profile_runtime", profile }),
+        listInvites: async () => {
+          polls += 1;
+          return [{
+            id: 1,
+            channel_slug: "dev",
+            owner_account: profile.owner_account,
+            profile_handle: profile.handle,
+            invited_by: "owner@example.com",
+            invited_at: 1,
+            profile,
+          }];
+        },
+        ensureChannelRuntime: async (_server, _token, channel, _owner, _handle, childName) => ({
+          token: `ap_child_${childName}`,
+          name: childName,
+          role: "agent",
+          owner: profile.owner_account,
+          channel_scope: channel,
+          lineage: {
+            parent_agent: profile.handle,
+            root_agent: profile.handle,
+            team_id: profile.handle,
+            depth: 1,
+            expires_at: null,
+          },
+          profile,
+        }),
+        resolveCodexLaunch: () => {
+          preflights += 1;
+          return { ok: false, error: "codex preflight A is unavailable" };
+        },
+        runChannelServe: async () => {
+          serves += 1;
+          return 0;
+        },
+        sleep: async () => {
+          sleeps += 1;
+          if (sleeps >= 2) throw new Error("stop after repeated preflight");
+        },
+      })).rejects.toThrow("stop after repeated preflight");
+    } finally {
+      if (oldHome === undefined) delete process.env.AGENTPARTY_HOME;
+      else process.env.AGENTPARTY_HOME = oldHome;
+    }
+
+    expect(polls).toBe(2);
+    expect(preflights).toBe(2);
+    expect(serves).toBe(0);
+    expect(lines.filter((line) => line.includes("failed to attach #dev"))).toHaveLength(2);
+  });
+
   test("profile sessions isolate server, stable profile identity, and authoritative child principal", async () => {
     const home = tempDir();
     const previous = process.env.AGENTPARTY_HOME;

--- a/docs/session-bridge-architecture.html
+++ b/docs/session-bridge-architecture.html
@@ -1,0 +1,309 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>AgentParty #746 · 交互会话桥接架构</title>
+  <style>
+    :root {
+      --fg: #202124;
+      --muted: #667085;
+      --accent: #2457c5;
+      --border: #d8dde6;
+      --soft: #f5f7fa;
+      --code: #edf1f6;
+      --ok: #166534;
+      --warn: #9a3412;
+    }
+    * { box-sizing: border-box; }
+    body {
+      max-width: 1120px;
+      margin: 0 auto;
+      padding: 2rem 1.4rem 5rem;
+      color: var(--fg);
+      font: 16px/1.65 -apple-system, BlinkMacSystemFont, "PingFang SC", "Microsoft YaHei", sans-serif;
+    }
+    header { margin-bottom: 2rem; padding-bottom: 1.2rem; border-bottom: 3px solid var(--accent); }
+    h1 { margin: 0 0 .5rem; font-size: 1.8rem; line-height: 1.25; }
+    h2 { margin-top: 2.4rem; padding-left: .65rem; border-left: 4px solid var(--accent); font-size: 1.25rem; }
+    h3 { margin-top: 1.5rem; font-size: 1.05rem; }
+    p, li { max-width: 94ch; }
+    a { color: var(--accent); }
+    code { padding: .08em .3em; border-radius: 3px; background: var(--code); font: .88em "SFMono-Regular", Menlo, Consolas, monospace; }
+    pre { overflow-x: auto; padding: 1rem; border: 1px solid var(--border); border-radius: 6px; background: var(--code); font-size: .82rem; line-height: 1.55; }
+    pre code { padding: 0; background: transparent; }
+    table { width: 100%; border-collapse: collapse; margin: 1rem 0; font-size: .91rem; }
+    th, td { padding: .58rem .68rem; border: 1px solid var(--border); text-align: left; vertical-align: top; }
+    th { background: var(--soft); }
+    .meta { color: var(--muted); font-size: .9rem; }
+    .good { color: var(--ok); font-weight: 650; }
+    .pending { color: var(--warn); font-weight: 650; }
+    aside { margin: 1rem 0; padding: .8rem 1rem; border-left: 4px solid var(--accent); background: var(--soft); }
+    .flow { display: grid; grid-template-columns: repeat(auto-fit, minmax(9.5rem, 1fr)); gap: .5rem; margin: 1rem 0; }
+    .flow span { padding: .7rem .5rem; border: 1px solid var(--border); background: var(--soft); text-align: center; font-size: .88rem; }
+    .flow span + span::before { content: "→ "; color: var(--accent); font-weight: 700; }
+    footer { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--border); color: var(--muted); font-size: .88rem; }
+    @media (max-width: 800px) {
+      body { padding-inline: .8rem; }
+      table { display: block; overflow-x: auto; }
+      .flow { grid-template-columns: 1fr; }
+      .flow span + span::before { content: "↓ "; }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>交互会话桥接：把频道消息送进当前 Claude / Codex 会话</h1>
+    <p class="meta">Issue #746 · 2026-07-24 · 本机核验 Claude Code 2.1.218 / Codex CLI 0.144.4</p>
+  </header>
+
+  <main>
+    <section aria-labelledby="decision">
+      <h2 id="decision">产品结论</h2>
+      <aside>
+        <strong>#746 是 AgentParty 的核心产品能力，不是“不计划在本仓实现”的上游缺口。</strong>
+        两个 harness 都已有可用原语；AgentParty 必须补齐会话适配、单写仲裁和自己的持久投递账本。
+      </aside>
+      <p class="meta">
+        上游能力依据：
+        <a href="https://code.claude.com/docs/en/channels">Claude Code Channels</a>、
+        <a href="https://code.claude.com/docs/en/channels-reference">Channels reference</a>、
+        <a href="https://github.com/openai/codex/blob/main/codex-rs/app-server/README.md">Codex app-server protocol</a>。
+      </p>
+      <table>
+        <thead>
+          <tr><th>Harness</th><th>同会话主路径</th><th>本仓责任</th><th>当前 slice</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Claude Code ≥ 2.1.80</td>
+            <td>专用 <code>claude/channel</code> capability</td>
+            <td>启动器、Channel MCP adapter、投递租约、linked reply</td>
+            <td class="good">已实现并有单测</td>
+          </tr>
+          <tr>
+            <td>Claude Agent SDK</td>
+            <td>单个 <code>query(AsyncIterable)</code></td>
+            <td>原生 Channel 被版本或组织策略禁用时的自有 runner fallback</td>
+            <td class="pending">后续接线；不冒充 stock TUI 同会话</td>
+          </tr>
+          <tr>
+            <td>Codex app-server</td>
+            <td><code>thread/resume</code> + <code>turn/start</code>/<code>turn/steer</code></td>
+            <td>让 Unix-remote TUI 与频道输入统一经过单写 proxy；稳定 client id 正向对账</td>
+            <td class="good">可运行 proxy、接线与 mock integration 已实现</td>
+          </tr>
+          <tr>
+            <td>PTY / transcript JSONL</td>
+            <td>不采用</td>
+            <td>禁止按键注入、禁止直接改 transcript、禁止并发 resume 进程</td>
+            <td class="good">启动与仲裁均 fail closed</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section aria-labelledby="negative-control">
+      <h2 id="negative-control">普通 MCP notification 是负向对照，不是矛盾结论</h2>
+      <p>
+        <a href="./mcp-notification-idle-wake-spike.html">#553 idle-wake 实验</a>证明的是：
+        普通 logging、resource 和 tool-list notification 在 turn 结束后不会创建新模型 turn。
+        Claude Channels 是 Claude Code 明确定义的另一条 harness 输入协议：
+        server 声明 <code>experimental["claude/channel"]</code>，再发
+        <code>notifications/claude/channel</code>。实现不得把两者混在一起。
+      </p>
+      <p>
+        即使专用 Channel notification 的 transport write 成功，也只代表 claim-only 事件交给客户端
+        队列，不代表正文已释放，更不代表模型已完成工作。因此 AgentParty delivery 继续保持
+        <code>running</code> 并续租，直到当前会话按稳定 receipt 完成 claim → accept，再调用 linked
+        reply tool，且 REST 回帖携带原消息 <code>reply_to</code> 成功。
+      </p>
+    </section>
+
+    <section aria-labelledby="claude">
+      <h2 id="claude">Claude 原生 Channel 链路</h2>
+      <div class="flow" aria-label="Claude Channel 投递时序">
+        <span>频道定向 delivery</span>
+        <span>Worker running + token fencing</span>
+        <span>claim-only Channel notification</span>
+        <span>party_channel_claim 返回 receipt + 正文</span>
+        <span>party_channel_accept 先落 WAL</span>
+        <span>当前会话执行一次</span>
+        <span>party_channel_reply 完成 delivery</span>
+      </div>
+      <pre><code>party bridge claude [channel|--channel C] [-- &lt;claude args...&gt;]
+
+Claude child MCP config:
+  capabilities.experimental["claude/channel"] = {}
+  capabilities.tools = {}
+
+Notification:
+  method = "notifications/claude/channel"
+  params.content = "execution_id=delivery-id; call party_channel_claim"
+  params.meta = { channel, seq, sender, delivery_id, execution_id }
+
+Current-session tools:
+  party_channel_claim(execution_id) → stable claim_receipt + full body
+  party_channel_accept(execution_id, claim_receipt) → durable acceptance
+  party_channel_reply(seq, body) → linked REST reply</code></pre>
+      <h3>边界</h3>
+      <ul>
+        <li>启动前检查 Claude Code 版本；低于 2.1.80 明确失败。</li>
+        <li>组织策略拒绝 development Channels 时，由 Claude 明确报错；AgentParty 不偷偷启用 PTY 或第二个 resume 进程。</li>
+        <li>adapter 与 <code>party serve</code> 共用同身份、同频道实例锁，避免两个消费者双执行。</li>
+        <li>只有服务端认证会员发给当前 target 的 claimed delivery 能进入会话；自己的消息不自唤醒。</li>
+        <li>权限 relay 不在首期开放。后续必须 owner 身份绑定，不能让频道任意发送者批准本机工具。</li>
+      </ul>
+      <h3>持久状态边界</h3>
+      <p>
+        <code>harness_issued</code> 不是跨 adapter 通用的“正文已写入”缩写，必须结合具体 harness 解释。
+        Claude 的 claim-gated 路径先只发送 execution id；Codex 则在唯一 writer 真正调用
+        <code>turn/start</code> 或 <code>turn/steer</code> 前才进入该阶段。
+      </p>
+      <table>
+        <thead><tr><th>Adapter / phase</th><th>正文边界</th><th>崩溃或断线后的规则</th></tr></thead>
+        <tbody>
+          <tr>
+            <td>Claude claim-only <code>harness_issued</code></td>
+            <td>只把 execution id 交给 harness；频道正文仍未释放</td>
+            <td>只有 phase、attempt、lease epoch/token 等 journal 快照精确匹配，且 Worker 明确返回 <code>replay_safe</code>，才可恢复；<code>superseded_safe</code> 只清理旧的 pre-body debt，绝不重新 claim 旧 attempt</td>
+          </tr>
+          <tr>
+            <td>Claude <code>harness_accepted</code></td>
+            <td>正文已经交给当前 Claude 会话</td>
+            <td>不得重放；保留 reply debt，等待同一 execution 的精确晚到回复</td>
+          </tr>
+          <tr>
+            <td>Codex <code>harness_issued</code> / <code>harness_accepted</code></td>
+            <td>已经抵达实际 writer 边界，可能已写入 app-server</td>
+            <td>除非 writer 明确证明尚未写入并安全回滚，否则不得重发；未知结果进入 late-reply-only 对账</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section aria-labelledby="codex">
+      <h2 id="codex">Codex app-server 单写协议</h2>
+      <p>
+        <code>thread/resume</code> 能让多个连接重入同一个 running thread，但“都能读状态”不等于“都能写”。
+        Codex 的 <code>turn/start</code> 会先替换活动 task。AgentParty proxy 必须成为唯一写者，
+        TUI 和频道输入都经过同一个串行仲裁器。
+      </p>
+      <div class="flow" aria-label="Codex 单写代理拓扑">
+        <span>Codex Unix WebSocket TUI</span>
+        <span>AgentParty 单写 proxy</span>
+        <span>仲裁 turn 状态</span>
+        <span>私有 app-server stdio</span>
+        <span>linked channel reply</span>
+      </div>
+      <pre><code>party bridge codex [channel|--channel C] [--codex-bin PATH] [-- &lt;codex args...&gt;]
+
+binary resolution:
+  --codex-bin / AGENTPARTY_CODEX_BIN
+  → child PATH / user-local + Homebrew
+  → Codex.app / ChatGPT.app bundled binary
+
+transport:
+  codex --remote unix://&lt;0600 bridge socket&gt;
+  bridge → codex app-server --stdio
+
+resident runner / desktop:
+  party serve --runner codex [--codex-bin PATH]
+  → same absolute-binary + child-PATH resolver
+  → fail before advertising ready when the executable is unavailable</code></pre>
+      <pre><code>UNKNOWN ── positive clientId reconciliation ──▶ ACCEPTED
+   │
+   └─ cold restart + bounded full read still absent（不是“未执行”证明）
+      └─ delivery = terminal_unknown；保留 durable reply debt / 原 bearer
+         ├─ exact late completion ──▶ linked reply
+         └─ 仅解冻单写仲裁器；原输入永不重放
+
+IDLE ── turn/start ──▶ ACTIVE_NORMAL(turn_id)
+                         │
+                         ├─ turn/steer(expectedTurnId)
+                         └─ Review / Compact：有界排队至 completed</code></pre>
+      <table>
+        <thead><tr><th>观察状态</th><th>频道输入动作</th><th>禁止动作</th></tr></thead>
+        <tbody>
+          <tr><td><code>idle</code></td><td><code>turn/start</code></td><td>并发第二个 start</td></tr>
+          <tr><td>normal active + 已知 turn id</td><td><code>turn/steer(expectedTurnId)</code></td><td>用 start 抢占</td></tr>
+          <tr><td>Review / Compact</td><td>进入有界队列，等待 completed</td><td>steer 失败后降级 start</td></tr>
+          <tr><td>active 但 turn id 不可确认</td><td>fail closed，排队并重新 resume/read</td><td>凭两个客户端各自看到 idle 就 start</td></tr>
+          <tr><td>RPC 响应丢失</td><td>扫描 <code>userMessage.clientId</code> 做正向 accepted 对账；冷重启全量扫描仍缺失时，保留 <code>terminal_unknown</code> reply debt，只解冻单写仲裁器，并继续接受同一 client id 的精确晚到完成</td><td>因历史中缺失 clientId 就推断未执行、重发，或把 delivery 当普通 failed / abandoned 删除</td></tr>
+        </tbody>
+      </table>
+      <p>
+        Review / Compact 依靠 app-server 结构化错误
+        <code>codexErrorInfo.activeTurnNotSteerable.turnKind</code>，不解析英文错误文案。
+        每个 AgentParty delivery 使用稳定的 <code>clientUserMessageId=agentparty:&lt;delivery-id&gt;</code>；
+        本地 journal 自己去重，因为 Codex 只存这个关联字段，并不提供幂等语义。
+        未找到 client id 不能把原输入重发：进程硬崩溃可能落在外部副作用与持久历史之间，
+        所以 absence 不是“未执行”的证明，也不是安全的负向幂等证明。冷重启完成 resume + 有界全量 read
+        后仍缺失时，bridge 可放行仲裁器处理后续独立工作，但必须保留 <code>terminal_unknown</code>
+        journal、原 delivery bearer 和 reply debt；它仍可由同一 client id 的精确晚到 completed history
+        结算一条 linked reply。这个解冻动作不把 delivery 标为普通 <code>failed</code> 或
+        <code>abandoned</code>，也不授权重发原正文。对账完成前，后续 start/steer、interrupt、review、
+        compact 与队列 flush 全部冻结。
+      </p>
+      <p>
+        <code>thread/start</code>、<code>thread/resume</code>、<code>thread/fork</code> 与频道
+        <code>submit</code> 共用 session lane；fork 返回的新 thread 会立即重建 arbiter。
+        未结算 delivery 或 <code>waiting_owner</code> continuation 存在时拒绝切离原 thread。
+        continuation 以 <code>work_id + continuation_ref</code> 绑定原 thread；只有精确匹配的
+        <code>owner_answer</code> 才能重新注入。linked REST reply 以 delivery identity 派生稳定
+        idempotency key，响应丢失时安全重试同一逻辑回复。
+      </p>
+      <p>
+        app-server 发给前端的审批、用户输入和 elicitation 请求会在 TUI 离线时有界保存，并在
+        TUI 重新完成 initialize 后重放。proxy 给每个 backend request 分配跨 generation 唯一的
+        frontend id，并维持双向映射；若 app-server 进程重启，即使原始 request id 从 0 复用，
+        旧 TUI 响应也无法命中新请求。<code>serverRequest/resolved</code> 同样改写回 frontend id。
+        恢复由 <code>thread/resume</code> 重新发出有效请求，完成前设为写屏障。
+      </p>
+    </section>
+
+    <section aria-labelledby="recovery-fencing">
+      <h2 id="recovery-fencing">断线恢复、token fencing 与单活 successor</h2>
+      <p>
+        每次连接恢复都绑定当前 connection generation、delivery attempt、lease epoch 和 lease token。
+        例如 token 依次从 A 旋转为 B、再旋转为 C 时，延迟返回的 A 或 B 恢复结果既不能移除 C 的
+        recovery gate，也不能重新取得当前 delivery 所有权。journal 只有在恢复请求看到的 phase 与租约
+        快照仍然精确一致时，才允许发布 <code>replay_safe</code>；任何阶段推进或 token 变化都使旧请求失效。
+      </p>
+      <p>
+        Worker 保留已轮换 token 的恢复历史，用 <code>superseded_safe</code> 明确关闭旧 attempt，
+        而不是让它再次 claim。对同一逻辑 delivery，任一时刻最多只有一个 <code>claimed</code> /
+        <code>running</code> successor；若旧的 <code>terminal_unknown</code> 获得精确
+        <code>replay_safe</code>，但新的 successor 已在执行，旧项必须先进入 durable queue，
+        等当前 successor 结算后再推进，禁止出现双活正文执行。所有 post-harness 状态都不走此重放路径，
+        只保留精确晚到回复能力。
+      </p>
+    </section>
+
+    <section aria-labelledby="acceptance">
+      <h2 id="acceptance">本 slice 验收与后续</h2>
+      <table>
+        <thead><tr><th>能力</th><th>自动回归</th><th>状态</th></tr></thead>
+        <tbody>
+          <tr><td>Claude 版本边界与启动 argv</td><td>版本解析、最低版本、dev/source 自命令、参数透传</td><td class="good">覆盖</td></tr>
+          <tr><td>Claude durable delivery</td><td>running、稳定 receipt 的 claim → accept 两阶段正文闸门、精确 replay-safe 恢复、post-write unknown 保留 debt、linked reply、REST 失败可重试、plain/directed 去重</td><td class="good">覆盖</td></tr>
+          <tr><td>Codex 单写</td><td>idle start、active steer、同时写入只有一个 start</td><td class="good">覆盖</td></tr>
+          <tr><td>Codex 不可 steer</td><td>Review/Compact 有界排队、stale turn 重同步、未知 turn fail closed</td><td class="good">覆盖</td></tr>
+          <tr><td>Codex unknown outcome</td><td>实际 writer 边界后不重发；正向对账；历史缺失不作负向证明；冷重启保留 terminal_unknown debt 和精确晚到回复，同时解冻后续独立工作</td><td class="good">覆盖</td></tr>
+          <tr><td>Codex thread / continuation 归属</td><td>start/resume/fork 与 submit 串行；waiting_owner 绑定 work/ref/thread；owner_answer 精确恢复</td><td class="good">覆盖</td></tr>
+          <tr><td>Codex linked reply</td><td>delivery 派生固定幂等键；REST 丢响应自动重试；replied / waiting_owner ACK 分流</td><td class="good">覆盖</td></tr>
+          <tr><td>Codex Unix WebSocket + stdio proxy</td><td>真实子进程 JSON-RPC、单 TUI、server request 离线重放、跨 generation request id 隔离、断线恢复屏障、同帧流 Worker running ACK</td><td class="good">自动化覆盖；真实 app-server 初始化探针通过</td></tr>
+          <tr><td>跨连接 delivery recovery</td><td>A→B→C token/generation fencing、旧恢复结果隔离、精确 replay-safe CAS、单活 successor 与 durable 排队</td><td class="good">覆盖</td></tr>
+          <tr><td>GUI / launchd Codex 发现</td><td>精简 PATH、AGENTPARTY_CODEX_BIN、用户目录、Homebrew、Codex.app / ChatGPT.app；bridge、serve、profile 与桌面 sidecar 共用同一 resolver</td><td class="good">自动化覆盖；本机精简 PATH 版本探针通过</td></tr>
+          <tr><td>Codex live dogfood</td><td>真实 TUI 收频道消息、busy steer、Review/Compact 排队、linked reply</td><td class="pending">发布前人工验收</td></tr>
+          <tr><td>Claude SDK streaming fallback</td><td>Channel 禁用场景的独立 runner 验收</td><td class="pending">下一实现 slice</td></tr>
+        </tbody>
+      </table>
+    </section>
+  </main>
+
+  <footer>
+    本文记录产品协议和已落代码边界；“本地单测通过”不等于已发布或真实 harness live dogfood。
+  </footer>
+</body>
+</html>

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -799,6 +799,8 @@ export interface HelloFrame {
    * be selected as the executor for a durable delivery lease.
    */
   directed_delivery?: "v1";
+  /** This connection implements token-fenced delivery recovery v1. */
+  delivery_recovery?: "v1";
   /** CLI package version。可选以兼容旧客户端；服务端会忽略非法值。 */
   client_version?: string;
   /**
@@ -962,11 +964,39 @@ export interface DeliveryUpdateFrame {
   delivery_id: string;
   /** Ephemeral per-update correlation token. It is echoed only on the direct ACK, never persisted. */
   request_id?: string;
+  /** Exact assignment attempt copied from the holder-only delivery frame. */
+  attempt?: number;
+  /** Exact assignment fence copied from the holder-only delivery frame. */
+  lease_epoch?: number;
+  /** Exact reconnect ownership proof copied from the holder-only delivery frame. */
+  lease_token?: string;
   state: "running" | "waiting_owner" | "replied" | "failed";
   work_id?: string;
   continuation_ref?: string;
   reply_seq?: number;
   error?: string;
+}
+
+/**
+ * Rebind unfinished v1 work to a replacement WebSocket. The client generates
+ * and persists `next_lease_token` before sending this CAS. Accepting either the
+ * old or already-rotated token makes ACK-loss retries idempotent while the
+ * rotation fences the previous socket.
+ */
+export interface DeliveryRecoverFrame {
+  type: "delivery_recover";
+  delivery_id: string;
+  request_id: string;
+  attempt: number;
+  lease_epoch: number;
+  lease_token: string;
+  next_lease_token: string;
+  /**
+   * The durable local WAL proves task content was never released to the
+   * harness. Only this pre-harness recovery may explicitly revive an exact
+   * unknown_outcome row; ordinary renew/terminal updates cannot.
+   */
+  replay_safe?: true;
 }
 
 export type ClientFrame =
@@ -977,7 +1007,8 @@ export type ClientFrame =
   | HeartbeatFrame
   | ServeLeaseClaimFrame
   | DeliveryAdapterRegisterFrame
-  | DeliveryUpdateFrame;
+  | DeliveryUpdateFrame
+  | DeliveryRecoverFrame;
 
 // ---- 服务端 → 客户端帧 ----
 
@@ -1014,6 +1045,8 @@ export interface WelcomeFrame {
   read_cursors?: ReadCursor[];
   /** 服务端会把定向 @ 作为独立 delivery 帧重放；新 serve 应以它为唤醒真值，普通 read cursor 仅管阅读。 */
   directed_delivery?: "v1";
+  /** Worker supports token-fenced delivery recovery and authoritative recovery results. */
+  delivery_recovery?: "v1";
   /**
    * 服务端会强制 owner 决策的应答人绑定：owner_decision 携带 expected_decision_responder_owner 时，
    * 只有该 owner 账号本人能应答（在 CAS 里校验）。旧服务端不发这个能力位，会静默丢弃绑定字段——
@@ -1029,6 +1062,10 @@ export interface DirectedDelivery {
   cause: DirectedDeliveryCause;
   state: DirectedDeliveryState;
   attempt: number;
+  /** Monotonic assignment fence; stable across an authenticated reconnect. */
+  lease_epoch?: number;
+  /** Opaque reconnect proof. Never included in public delivery-state frames. */
+  lease_token?: string;
   lease_until: number | null;
   work_id: string | null;
   continuation_ref: string | null;
@@ -1079,6 +1116,21 @@ export interface DeliveryStateFrame {
   delivery: PublicDirectedDelivery;
   /** Present only on the direct ACK for a delivery_update carrying the same token. */
   request_id?: string;
+}
+
+/** Correlated authoritative result for a delivery ownership recovery CAS. */
+export interface DeliveryRecoveryResultFrame {
+  type: "delivery_recovery";
+  delivery_id: string;
+  request_id: string;
+  result: "recovered" | "superseded_safe" | "terminal" | "terminal_unknown";
+  state: DirectedDeliveryState;
+  attempt: number;
+  lease_epoch: number;
+  /** Present only for result=recovered. */
+  lease_token?: string;
+  /** Present only for result=recovered. */
+  lease_until?: number;
 }
 
 export interface ParticipantsFrame {
@@ -1848,4 +1900,5 @@ export type ServerFrame =
   | ServeLeaseFrame
   | DeliveryAdapterRegisteredFrame
   | DirectedDeliveryFrame
-  | DeliveryStateFrame;
+  | DeliveryStateFrame
+  | DeliveryRecoveryResultFrame;

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -64,6 +64,7 @@ import {
   type DecisionState,
   type DirectedDelivery,
   type DirectedDeliveryCause,
+  type DeliveryRecoverFrame,
   type DeliveryUpdateFrame,
   type PublicDirectedDelivery,
   type HostDecision,
@@ -138,6 +139,8 @@ interface ConnState {
   // 只有显式声明能消费 delivery + delivery_update v1 的连接，才可领取 durable work。
   // 旧 serve 仍可观察 raw mention，但不能仅凭 serve_lease claim 被误当成 v1 executor。
   directedDeliveryV1?: boolean;
+  /** Socket negotiated token-fenced delivery recovery. */
+  deliveryRecoveryV1?: boolean;
   /** New sockets do not receive live message frames until hello establishes replay/capabilities. */
   helloPending?: boolean;
   /** Highest message cursor declared by hello on this socket; legacy once may only reserve newer raw work. */
@@ -1364,8 +1367,23 @@ function parseDeliveryUpdateFrame(input: unknown): DeliveryUpdateFrame | null {
   const workId = optionalText(f.work_id, DELIVERY_WORK_ID_LIMIT);
   const continuationRef = optionalText(f.continuation_ref, DELIVERY_CONTINUATION_REF_LIMIT);
   const requestId = optionalText(f.request_id, 128);
+  const leaseToken = optionalText(f.lease_token, 128);
   const error = optionalText(f.error, DECISION_REASON_LIMIT);
-  if (workId === null || continuationRef === null || requestId === null || error === null) return null;
+  if (workId === null || continuationRef === null || requestId === null || leaseToken === null || error === null) {
+    return null;
+  }
+  const leaseEpoch = f.lease_epoch === undefined
+    ? undefined
+    : typeof f.lease_epoch === "number" && Number.isSafeInteger(f.lease_epoch) && f.lease_epoch > 0
+      ? f.lease_epoch
+      : null;
+  if (leaseEpoch === null) return null;
+  const attempt = f.attempt === undefined
+    ? undefined
+    : typeof f.attempt === "number" && Number.isSafeInteger(f.attempt) && f.attempt > 0
+      ? f.attempt
+      : null;
+  if (attempt === null) return null;
   const replySeq =
     f.reply_seq === undefined
       ? undefined
@@ -1380,11 +1398,62 @@ function parseDeliveryUpdateFrame(input: unknown): DeliveryUpdateFrame | null {
     type: "delivery_update",
     delivery_id: f.delivery_id,
     ...(requestId === undefined ? {} : { request_id: requestId }),
+    ...(attempt === undefined ? {} : { attempt }),
+    ...(leaseEpoch === undefined ? {} : { lease_epoch: leaseEpoch }),
+    ...(leaseToken === undefined ? {} : { lease_token: leaseToken }),
     state: f.state,
     ...(workId === undefined ? {} : { work_id: workId }),
     ...(continuationRef === undefined ? {} : { continuation_ref: continuationRef }),
     ...(replySeq === undefined ? {} : { reply_seq: replySeq }),
     ...(error === undefined ? {} : { error }),
+  };
+}
+
+function parseDeliveryRecoverFrame(input: unknown): DeliveryRecoverFrame | null {
+  if (typeof input !== "object" || input === null) return null;
+  const f = input as Record<string, unknown>;
+  if (f.type !== "delivery_recover") return null;
+  const text = (value: unknown, limit = 128): string | null =>
+    typeof value === "string" && value.length > 0 && value.length <= limit ? value : null;
+  const deliveryId = text(f.delivery_id);
+  const requestId = text(f.request_id);
+  const leaseToken = text(f.lease_token);
+  const nextLeaseToken = text(f.next_lease_token);
+  const attempt =
+    typeof f.attempt === "number" && Number.isSafeInteger(f.attempt) && f.attempt > 0
+      ? f.attempt
+      : null;
+  const leaseEpoch =
+    typeof f.lease_epoch === "number" && Number.isSafeInteger(f.lease_epoch) && f.lease_epoch > 0
+      ? f.lease_epoch
+      : null;
+  const replaySafe =
+    f.replay_safe === undefined
+      ? undefined
+      : f.replay_safe === true
+        ? true
+        : null;
+  if (
+    deliveryId === null ||
+    requestId === null ||
+    leaseToken === null ||
+    nextLeaseToken === null ||
+    attempt === null ||
+    leaseEpoch === null ||
+    replaySafe === null ||
+    leaseToken === nextLeaseToken
+  ) {
+    return null;
+  }
+  return {
+    type: "delivery_recover",
+    delivery_id: deliveryId,
+    request_id: requestId,
+    attempt,
+    lease_epoch: leaseEpoch,
+    lease_token: leaseToken,
+    next_lease_token: nextLeaseToken,
+    ...(replaySafe === true ? { replay_safe: true as const } : {}),
   };
 }
 
@@ -1797,9 +1866,15 @@ export class ChannelDO extends Server<Env> {
       cause TEXT NOT NULL,
       state TEXT NOT NULL,
       attempt INTEGER NOT NULL DEFAULT 0,
+      lease_epoch INTEGER NOT NULL DEFAULT 0,
+      lease_token TEXT,
+      previous_lease_epoch INTEGER,
+      previous_lease_attempt INTEGER,
+      previous_lease_token TEXT,
       lease_connection_id TEXT,
       last_lease_connection_id TEXT,
       lease_adapter TEXT,
+      last_lease_adapter TEXT,
       lease_until INTEGER,
       work_id TEXT,
       continuation_ref TEXT,
@@ -1827,6 +1902,11 @@ export class ChannelDO extends Server<Env> {
       // column already exists
     }
     try {
+      sql.exec("ALTER TABLE directed_deliveries ADD COLUMN last_lease_adapter TEXT");
+    } catch {
+      // column already exists
+    }
+    try {
       sql.exec("ALTER TABLE directed_deliveries ADD COLUMN parent_delivery_id TEXT");
     } catch {
       // column already exists
@@ -1835,6 +1915,27 @@ export class ChannelDO extends Server<Env> {
       sql.exec("ALTER TABLE directed_deliveries ADD COLUMN terminal_reason TEXT");
     } catch {
       // column already exists
+    }
+    try {
+      sql.exec("ALTER TABLE directed_deliveries ADD COLUMN lease_epoch INTEGER NOT NULL DEFAULT 0");
+    } catch {
+      // column already exists
+    }
+    try {
+      sql.exec("ALTER TABLE directed_deliveries ADD COLUMN lease_token TEXT");
+    } catch {
+      // column already exists
+    }
+    for (const ddl of [
+      "ALTER TABLE directed_deliveries ADD COLUMN previous_lease_epoch INTEGER",
+      "ALTER TABLE directed_deliveries ADD COLUMN previous_lease_attempt INTEGER",
+      "ALTER TABLE directed_deliveries ADD COLUMN previous_lease_token TEXT",
+    ]) {
+      try {
+        sql.exec(ddl);
+      } catch {
+        // column already exists
+      }
     }
     sql.exec(
       "CREATE INDEX IF NOT EXISTS idx_directed_deliveries_target_state ON directed_deliveries(target_name, state, message_seq)",
@@ -1845,6 +1946,15 @@ export class ChannelDO extends Server<Env> {
     sql.exec(
       "CREATE INDEX IF NOT EXISTS idx_directed_deliveries_lease ON directed_deliveries(state, lease_until)",
     );
+    sql.exec(`CREATE TABLE IF NOT EXISTS directed_delivery_lease_history (
+      delivery_id TEXT NOT NULL,
+      attempt INTEGER NOT NULL,
+      lease_epoch INTEGER NOT NULL,
+      lease_token TEXT NOT NULL,
+      superseded_at INTEGER NOT NULL,
+      PRIMARY KEY (delivery_id, attempt, lease_epoch, lease_token),
+      FOREIGN KEY (delivery_id) REFERENCES directed_deliveries(id) ON DELETE CASCADE
+    )`);
     sql.exec(
       `UPDATE messages
           SET delivery_targets_json = COALESCE((
@@ -2339,6 +2449,7 @@ export class ChannelDO extends Server<Env> {
       last_seq: this.lastSeq(),
       last_rev_seq: this.lastRevSeq(),
       directed_delivery: "v1",
+      delivery_recovery: "v1",
       owner_decision_binding: "v1",
       ...(this.charterRev() > 0 ? { charter_rev: this.charterRev() } : {}),
       presence: this.presenceList(),
@@ -2443,6 +2554,8 @@ export class ChannelDO extends Server<Env> {
       // Capability is sticky for the lifetime of this socket. A later cursor refresh from a caller
       // that omits optional fields must not silently downgrade an already-proven executor.
       const nextDirectedDeliveryV1 = st.directedDeliveryV1 === true || frame.directed_delivery === "v1";
+      const nextDeliveryRecoveryV1 =
+        st.deliveryRecoveryV1 === true || frame.delivery_recovery === "v1";
       const clientVersion = parseClientVersion(frame.client_version);
       const since = typeof frame.since === "number" && frame.since > 0 ? Math.floor(frame.since) : 0;
       if (clientVersion !== null) {
@@ -2463,6 +2576,7 @@ export class ChannelDO extends Server<Env> {
       st = connection.setState({
         ...st,
         directedDeliveryV1: nextDirectedDeliveryV1,
+        deliveryRecoveryV1: nextDeliveryRecoveryV1,
         ...(clientVersion === null ? {} : { clientVersion }),
         helloSince: Math.max(st.helloSince ?? 0, since),
         helloPending: false,
@@ -2565,6 +2679,33 @@ export class ChannelDO extends Server<Env> {
       }
       this.sendFrame(connection, { type: "delivery_adapter", adapter: "watch", registered: true });
       await this.dispatchNextDirectedDelivery(st.name);
+      return;
+    }
+    if (frame.type === "delivery_recover") {
+      const recovery = parseDeliveryRecoverFrame(frame);
+      const outcome = recovery === null
+        ? undefined
+        : this.recoverDirectedDelivery(st, connection.id, recovery, Date.now());
+      if (recovery === null || outcome === undefined) {
+        badRequest();
+      } else {
+        const row = outcome.row;
+        this.sendFrame(connection, {
+          type: "delivery_recovery",
+          delivery_id: String(row.id),
+          request_id: recovery.request_id,
+          result: outcome.result,
+          state: String(row.state) as DirectedDelivery["state"],
+          attempt: Number(row.attempt),
+          lease_epoch: Number(row.lease_epoch),
+          ...(outcome.result === "recovered"
+            ? {
+                lease_token: String(row.lease_token),
+                lease_until: Number(row.lease_until),
+              }
+            : {}),
+        });
+      }
       return;
     }
     if (frame.type === "delivery_update") {
@@ -4111,7 +4252,6 @@ export class ChannelDO extends Server<Env> {
     row: Record<string, unknown>,
     msg: MsgFrame,
   ) {
-    const delivery = this.rowToDirectedDelivery(row);
     if (await this.isParticipantRemoved(hook.name, hook.targetOwner)) {
       this.removeParticipantDeliveryAdapters(hook.name, Date.now());
       return;
@@ -4125,6 +4265,7 @@ export class ChannelDO extends Server<Env> {
       }
       return;
     }
+    const delivery = this.rowToDirectedDelivery(row, false);
     const payload = JSON.stringify({
       ...msg,
       channel: this.name,
@@ -9301,7 +9442,10 @@ export class ChannelDO extends Server<Env> {
 
   // ---- 持久定向投递（issue #551）----
 
-  private rowToDirectedDelivery(row: Record<string, unknown>): DirectedDelivery {
+  private rowToDirectedDelivery(
+    row: Record<string, unknown>,
+    includeRecoveryOwnership = true,
+  ): DirectedDelivery {
     const storedCause = String(row.cause) as DirectedDelivery["cause"];
     const attempt = Number(row.attempt);
     return {
@@ -9311,6 +9455,12 @@ export class ChannelDO extends Server<Env> {
       cause: attempt > 1 && storedCause !== "owner_answer" ? "retry" : storedCause,
       state: String(row.state) as DirectedDelivery["state"],
       attempt,
+      ...(includeRecoveryOwnership
+        ? {
+            lease_epoch: Number(row.lease_epoch ?? 0),
+            lease_token: String(row.lease_token ?? ""),
+          }
+        : {}),
       lease_until: row.lease_until === null || row.lease_until === undefined ? null : Number(row.lease_until),
       work_id: row.work_id === null || row.work_id === undefined ? null : String(row.work_id),
       continuation_ref:
@@ -9846,6 +9996,18 @@ export class ChannelDO extends Server<Env> {
         .toArray()[0];
       if (active !== undefined) return;
       const now = Date.now();
+      if (typeof queued.lease_token === "string" && queued.lease_token.length > 0) {
+        this.ctx.storage.sql.exec(
+          `INSERT OR IGNORE INTO directed_delivery_lease_history (
+             delivery_id, attempt, lease_epoch, lease_token, superseded_at
+           ) VALUES (?, ?, ?, ?, ?)`,
+          String(queued.id),
+          Number(queued.attempt),
+          Number(queued.lease_epoch),
+          String(queued.lease_token),
+          now,
+        );
+      }
       if (
         matchingServe.length === 0 &&
         matchingWatch.length === 0 &&
@@ -9860,6 +10022,10 @@ export class ChannelDO extends Server<Env> {
         const legacyClaim = this.ctx.storage.sql.exec(
           `UPDATE directed_deliveries
               SET state = 'running', attempt = attempt + 1,
+                  previous_lease_epoch = CASE WHEN lease_token IS NULL THEN previous_lease_epoch ELSE lease_epoch END,
+                  previous_lease_attempt = CASE WHEN lease_token IS NULL THEN previous_lease_attempt ELSE attempt END,
+                  previous_lease_token = COALESCE(lease_token, previous_lease_token),
+                  lease_epoch = lease_epoch + 1, lease_token = NULL,
                   lease_connection_id = ?, last_lease_connection_id = ?,
                   lease_adapter = 'legacy_serve', lease_until = ?, last_error = NULL,
                   terminal_reason = NULL, updated_at = ?
@@ -9884,13 +10050,19 @@ export class ChannelDO extends Server<Env> {
       const webhookHolder = adapter === "webhook" ? matchingWebhooks[0] : undefined;
       const holderId = connectionHolder?.id ?? this.webhookHolderId(webhookHolder!.registrationId);
       const leaseUntil = now + (adapter === "webhook" ? DIRECTED_WEBHOOK_LEASE_MS : DIRECTED_DELIVERY_LEASE_MS);
+      const leaseToken = crypto.randomUUID();
       const claim = this.ctx.storage.sql.exec(
         `UPDATE directed_deliveries
             SET state = 'claimed', attempt = attempt + 1,
+                previous_lease_epoch = CASE WHEN lease_token IS NULL THEN previous_lease_epoch ELSE lease_epoch END,
+                previous_lease_attempt = CASE WHEN lease_token IS NULL THEN previous_lease_attempt ELSE attempt END,
+                previous_lease_token = COALESCE(lease_token, previous_lease_token),
+                lease_epoch = lease_epoch + 1, lease_token = ?,
                 lease_connection_id = ?, last_lease_connection_id = ?,
                 lease_adapter = ?, lease_until = ?, last_error = NULL,
                 terminal_reason = NULL, updated_at = ?
           WHERE id = ? AND target_owner = ? AND state = 'queued'`,
+        leaseToken,
         holderId,
         holderId,
         adapter,
@@ -9943,6 +10115,17 @@ export class ChannelDO extends Server<Env> {
     const targets = new Set<string>();
     for (const row of rows) {
       const targetName = String(row.target_name);
+      // A v1 holder received an unforgeable reconnect token before it could
+      // acknowledge `running`. Keep the claim reserved until its fixed lease
+      // deadline so a restarted bridge can CAS-rebind it. Requeueing on socket
+      // close would rotate ownership underneath the durable client journal.
+      if (
+        String(row.state) === "claimed" &&
+        typeof row.lease_token === "string" &&
+        row.lease_token.length > 0
+      ) {
+        continue;
+      }
       targets.add(targetName);
       if (
         String(row.state) === "running" &&
@@ -10141,6 +10324,369 @@ export class ChannelDO extends Server<Env> {
     return this.identityMatchesDeliveryTarget(identity, row) && String(row.state) === "running";
   }
 
+  private fenceRecoveredDeliveryConnection(
+    identity: ConnState,
+    connectionId: string,
+    adapter: string,
+    previousConnectionId: string,
+  ): boolean {
+    if (previousConnectionId !== "" && previousConnectionId !== connectionId) {
+      for (const candidate of this.getConnections<ConnState>()) {
+        if (candidate.id === previousConnectionId) {
+          candidate.close(1012, "delivery ownership recovered by replacement");
+          break;
+        }
+      }
+    }
+    if (adapter === "watch") {
+      for (const candidate of this.getConnections<ConnState>()) {
+        if (candidate.id !== connectionId) continue;
+        const candidateState = candidate.state;
+        if (
+          candidateState?.kind !== "agent" ||
+          candidateState.name !== identity.name ||
+          candidateState.watchCandidate !== true ||
+          this.identityDeliveryPrincipal(candidateState) !== this.identityDeliveryPrincipal(identity)
+        ) {
+          return false;
+        }
+        candidate.setState({
+          ...candidateState,
+          // Zero stays ahead of normal watch registration sequence numbers,
+          // preserving the recovered owner for subsequent queued work.
+          watchClaimSeq: 0,
+        });
+        return true;
+      }
+      return false;
+    }
+    if (adapter !== "serve") return false;
+    let foundRecoveringConnection = false;
+    for (const candidate of this.getConnections<ConnState>()) {
+      const candidateState = candidate.state;
+      if (
+        candidateState?.kind !== "agent" ||
+        candidateState.name !== identity.name ||
+        candidateState.serveCandidate !== true ||
+        this.identityDeliveryPrincipal(candidateState) !== this.identityDeliveryPrincipal(identity)
+      ) {
+        continue;
+      }
+      const held = candidate.id === connectionId;
+      if (held) foundRecoveringConnection = true;
+      const nextState = {
+        ...candidateState,
+        // A recovery token is a stronger fence than soft arrival order.
+        // Zero stays ahead of all normal claim sequence numbers.
+        ...(held ? { serveClaimSeq: 0 } : {}),
+        serveLeaseHeld: held,
+      };
+      candidate.setState(nextState);
+      this.sendFrame(candidate, {
+        type: "serve_lease",
+        name: identity.name,
+        held,
+      });
+    }
+    return foundRecoveringConnection;
+  }
+
+  private recoverDirectedDelivery(
+    identity: ConnState,
+    connectionId: string,
+    recovery: DeliveryRecoverFrame,
+    now: number,
+  ): {
+    result: "recovered" | "superseded_safe" | "terminal" | "terminal_unknown";
+    row: Record<string, unknown>;
+  } | undefined {
+    let row = this.directedDeliveryRow(recovery.delivery_id);
+    if (
+      row === undefined ||
+      identity.kind !== "agent" ||
+      identity.deliveryRecoveryV1 !== true ||
+      !this.identityMatchesDeliveryTarget(identity, row)
+    ) {
+      return undefined;
+    }
+    const state = String(row.state);
+    const adapter = String(row.lease_adapter ?? row.last_lease_adapter ?? "");
+    const leaseUntil = Number(row.lease_until ?? 0);
+    const currentToken = String(row.lease_token ?? "");
+    const previousConnectionId = String(
+      row.lease_connection_id ?? row.last_lease_connection_id ?? "",
+    );
+    const matchesCurrent =
+      Number(row.attempt) === recovery.attempt &&
+      Number(row.lease_epoch) === recovery.lease_epoch &&
+      (currentToken === recovery.lease_token || currentToken === recovery.next_lease_token);
+    const matchesHistory = this.ctx.storage.sql
+      .exec(
+        `SELECT 1 AS found FROM directed_delivery_lease_history
+          WHERE delivery_id = ? AND attempt = ? AND lease_epoch = ?
+            AND lease_token IN (?, ?)
+          LIMIT 1`,
+        recovery.delivery_id,
+        recovery.attempt,
+        recovery.lease_epoch,
+        recovery.lease_token,
+        recovery.next_lease_token,
+      )
+      .toArray()[0] !== undefined;
+    if (!matchesCurrent && !matchesHistory) {
+      return undefined;
+    }
+    // A historical token only proves that this process once owned the same
+    // logical delivery. It must not make an already-settled row look merely
+    // superseded: clients deliberately retain post-harness debt on
+    // superseded_safe, which would otherwise keep a replied/waiting_owner or
+    // policy/retract failure alive forever. Unknown-outcome failures remain
+    // below because the current generation may still revive them with an
+    // exact replay-safe claim.
+    if (
+      state === "replied" ||
+      state === "waiting_owner" ||
+      (state === "failed" && String(row.terminal_reason ?? "") !== "unknown_outcome")
+    ) {
+      return { result: "terminal", row };
+    }
+    if (matchesCurrent && currentToken !== "") {
+      // Every successful current-token rotation becomes durable history before
+      // the row changes. This makes A→B→C reconnects converge: a delayed A
+      // process receives superseded_safe instead of an unauthoritative
+      // bad_request after C owns the same attempt/epoch.
+      this.ctx.storage.sql.exec(
+        `INSERT OR IGNORE INTO directed_delivery_lease_history (
+           delivery_id, attempt, lease_epoch, lease_token, superseded_at
+         ) VALUES (?, ?, ?, ?, ?)`,
+        recovery.delivery_id,
+        recovery.attempt,
+        recovery.lease_epoch,
+        currentToken,
+        now,
+      );
+    }
+    const replaySafeUnknown =
+      recovery.replay_safe === true &&
+      matchesCurrent &&
+      (
+        (state === "running" && leaseUntil <= now) ||
+        (state === "failed" && String(row.terminal_reason ?? "") === "unknown_outcome")
+      );
+    if (replaySafeUnknown) {
+      if (
+        (adapter === "watch" && identity.watchCandidate !== true) ||
+        (adapter === "serve" && identity.serveCandidate !== true) ||
+        (adapter !== "watch" && adapter !== "serve")
+      ) {
+        return undefined;
+      }
+      if (state === "failed") {
+        const successor = this.ctx.storage.sql
+          .exec(
+            `SELECT id FROM directed_deliveries
+              WHERE target_name = ? AND target_owner = ? AND id <> ?
+                AND state IN ('claimed', 'running')
+              ORDER BY message_seq
+              LIMIT 1`,
+            identity.name,
+            this.identityDeliveryPrincipal(identity),
+            recovery.delivery_id,
+          )
+          .toArray()[0];
+        if (successor !== undefined) {
+          // The alarm may already have released a later row. Never revive the
+          // older pre-harness debt as a second active task; place it back in
+          // message order behind the current obligation. Its old journal may
+          // now clear as superseded_safe because Worker delivery is durable.
+          this.ctx.storage.sql.exec(
+            `UPDATE directed_deliveries
+                SET state = 'queued', lease_connection_id = NULL,
+                    lease_adapter = NULL, lease_until = NULL,
+                    last_error = NULL, terminal_reason = NULL, updated_at = ?
+              WHERE id = ? AND state = 'failed'
+                AND terminal_reason = 'unknown_outcome'
+                AND attempt = ? AND lease_epoch = ?
+                AND lease_token IN (?, ?)`,
+            now,
+            recovery.delivery_id,
+            recovery.attempt,
+            recovery.lease_epoch,
+            recovery.lease_token,
+            recovery.next_lease_token,
+          );
+          const deferred = this.directedDeliveryRow(recovery.delivery_id);
+          if (deferred === undefined || String(deferred.state) !== "queued") return undefined;
+          this.broadcastDirectedDelivery(deferred);
+          return { result: "superseded_safe", row: deferred };
+        }
+      }
+      const nextLeaseUntil = now + DIRECTED_DELIVERY_LEASE_MS;
+      this.ctx.storage.sql.exec(
+        `UPDATE directed_deliveries
+            SET state = 'claimed',
+                last_lease_connection_id = COALESCE(lease_connection_id, last_lease_connection_id),
+                last_lease_adapter = COALESCE(lease_adapter, last_lease_adapter),
+                lease_connection_id = ?, lease_adapter = ?, lease_token = ?,
+                lease_until = ?, last_error = NULL, terminal_reason = NULL, updated_at = ?
+          WHERE id = ? AND target_name = ? AND target_owner = ?
+            AND attempt = ? AND lease_epoch = ?
+            AND lease_token IN (?, ?)
+            AND (
+              (state = 'running' AND lease_until <= ?)
+              OR (state = 'failed' AND terminal_reason = 'unknown_outcome')
+            )`,
+        connectionId,
+        adapter,
+        recovery.next_lease_token,
+        nextLeaseUntil,
+        now,
+        recovery.delivery_id,
+        identity.name,
+        this.identityDeliveryPrincipal(identity),
+        recovery.attempt,
+        recovery.lease_epoch,
+        recovery.lease_token,
+        recovery.next_lease_token,
+        now,
+      );
+      const revived = this.directedDeliveryRow(recovery.delivery_id);
+      if (
+        revived === undefined ||
+        String(revived.state) !== "claimed" ||
+        String(revived.lease_connection_id ?? "") !== connectionId ||
+        String(revived.lease_token ?? "") !== recovery.next_lease_token
+      ) {
+        return undefined;
+      }
+      if (!this.fenceRecoveredDeliveryConnection(
+        identity,
+        connectionId,
+        adapter,
+        previousConnectionId,
+      )) {
+        return undefined;
+      }
+      this.broadcastDirectedDelivery(revived);
+      this.broadcastPresenceFor(identity.name);
+      this.ctx.waitUntil(this.ensureAlarmAt(nextLeaseUntil));
+      return { result: "recovered", row: revived };
+    }
+    if ((!matchesCurrent && matchesHistory) || state === "queued" || (state === "claimed" && leaseUntil <= now)) {
+      return { result: "superseded_safe", row };
+    }
+    if (state === "running" && leaseUntil <= now) {
+      if (
+        (adapter === "watch" && identity.watchCandidate !== true) ||
+        (adapter === "serve" && identity.serveCandidate !== true) ||
+        (adapter !== "watch" && adapter !== "serve")
+      ) {
+        return undefined;
+      }
+      // Running proves that the harness was authorized to start. Once that
+      // lease expires, replay is no longer known-safe even if the alarm that
+      // normally performs this transition has not fired yet. Make recovery
+      // itself the authoritative expiry gate so callers never discard a live
+      // reply path based on a misleading superseded_safe result.
+      const terminal = this.transitionDirectedDeliveryTerminal(
+        recovery.delivery_id,
+        "failed",
+        now,
+        {
+          error: "runner ownership lost after task start; outcome unknown, not auto-retried",
+          terminalReason: "unknown_outcome",
+          expectedStates: ["running"],
+          dispatchNext: false,
+        },
+      );
+      row = terminal ?? this.directedDeliveryRow(recovery.delivery_id);
+      if (row === undefined || String(row.state) !== "failed") return undefined;
+      if (
+        (adapter === "watch" || adapter === "serve") &&
+        !this.fenceRecoveredDeliveryConnection(
+          identity,
+          connectionId,
+          adapter,
+          previousConnectionId,
+        )
+      ) {
+        return undefined;
+      }
+      this.dispatchNextDirectedDelivery(identity.name, previousConnectionId || undefined);
+      this.broadcastPresenceFor(identity.name);
+      return { result: "terminal_unknown", row };
+    }
+    if (state === "failed") {
+      return {
+        result: String(row.terminal_reason ?? "") === "unknown_outcome"
+          ? "terminal_unknown"
+          : "terminal",
+        row,
+      };
+    }
+    if (state === "replied" || state === "waiting_owner") {
+      return { result: "terminal", row };
+    }
+    if (state !== "claimed" && state !== "running") return undefined;
+    if (
+      (adapter === "watch" && identity.watchCandidate !== true) ||
+      (adapter === "serve" && identity.serveCandidate !== true) ||
+      (adapter !== "watch" && adapter !== "serve")
+    ) {
+      return undefined;
+    }
+
+    const nextLeaseUntil = now + DIRECTED_DELIVERY_LEASE_MS;
+    this.ctx.storage.sql.exec(
+      `UPDATE directed_deliveries
+          SET last_lease_connection_id = lease_connection_id,
+              lease_connection_id = ?, lease_token = ?, lease_until = ?, updated_at = ?
+        WHERE id = ? AND target_name = ? AND target_owner = ?
+          AND state IN ('claimed', 'running')
+          AND attempt = ? AND lease_epoch = ? AND lease_until > ?
+          AND lease_token IN (?, ?)`,
+      connectionId,
+      recovery.next_lease_token,
+      nextLeaseUntil,
+      now,
+      recovery.delivery_id,
+      identity.name,
+      this.identityDeliveryPrincipal(identity),
+      recovery.attempt,
+      recovery.lease_epoch,
+      now,
+      recovery.lease_token,
+      recovery.next_lease_token,
+    );
+    const recovered = this.directedDeliveryRow(recovery.delivery_id);
+    if (
+      recovered === undefined ||
+      String(recovered.lease_connection_id ?? "") !== connectionId ||
+      String(recovered.lease_token ?? "") !== recovery.next_lease_token ||
+      Number(recovered.lease_epoch) !== recovery.lease_epoch ||
+      Number(recovered.attempt) !== recovery.attempt ||
+      (String(recovered.state) !== "claimed" && String(recovered.state) !== "running")
+    ) {
+      return undefined;
+    }
+
+    // Recovery is stronger than either adapter's soft arrival ordering: the
+    // unforgeable token proves this exact in-flight assignment.
+    if (!this.fenceRecoveredDeliveryConnection(
+      identity,
+      connectionId,
+      adapter,
+      previousConnectionId,
+    )) {
+      return undefined;
+    }
+
+    this.broadcastDirectedDelivery(recovered);
+    this.broadcastPresenceFor(identity.name);
+    this.ctx.waitUntil(this.ensureAlarmAt(nextLeaseUntil));
+    return { result: "recovered", row: recovered };
+  }
+
   private applyDirectedDeliveryUpdate(
     identity: ConnState,
     connectionId: string,
@@ -10151,9 +10697,19 @@ export class ChannelDO extends Server<Env> {
     if (row === undefined || !this.identityMatchesDeliveryTarget(identity, row)) return false;
     if (update.work_id !== undefined && update.work_id !== String(row.work_id ?? "")) return false;
     if (update.continuation_ref !== undefined && update.continuation_ref !== String(row.continuation_ref ?? "")) return false;
+    if (update.attempt !== undefined && update.attempt !== Number(row.attempt)) return false;
+    if (update.lease_epoch !== undefined && update.lease_epoch !== Number(row.lease_epoch)) return false;
+    if (update.lease_token !== undefined && update.lease_token !== String(row.lease_token ?? "")) return false;
     const oldState = String(row.state);
     const ownsCurrentLease = String(row.lease_connection_id ?? "") === connectionId;
     const ownsFormerLease = String(row.last_lease_connection_id ?? "") === connectionId;
+    const ownsLeaseToken =
+      update.lease_token !== undefined &&
+      update.lease_epoch !== undefined &&
+      update.attempt !== undefined &&
+      update.lease_token === String(row.lease_token ?? "") &&
+      update.lease_epoch === Number(row.lease_epoch) &&
+      update.attempt === Number(row.attempt);
     // handleSend can persist the question and detach the lease before the runner's success receipt
     // arrives. ACK a same-principal no-op and return the authoritative waiting_owner row; never let
     // the generic replied receipt erase the human handoff.
@@ -10277,6 +10833,19 @@ export class ChannelDO extends Server<Env> {
   ): Record<string, unknown> | undefined {
     const before = this.directedDeliveryRow(deliveryId);
     if (before === undefined) return undefined;
+    // An owner answer and every waiting_owner ancestor are one logical state transition. Keep the
+    // child terminal update and lineage settlement in the same SQLite commit even when this gate is
+    // reached directly from a websocket receipt, lease expiry, or webhook failure. Callers that
+    // already own an atomic delivery transaction reuse it; otherwise recurse once under capture so
+    // broadcasts and dispatch happen only after the commit succeeds.
+    if (String(before.cause) === "owner_answer" && this.atomicDeliveryEffects === null) {
+      let terminal: Record<string, unknown> | undefined;
+      const effects = this.captureAtomicDeliveryEffects(() => {
+        terminal = this.transitionDirectedDeliveryTerminal(deliveryId, terminalState, now, options);
+      });
+      this.flushAtomicDeliveryEffects(effects);
+      return terminal;
+    }
     const beforeState = String(before.state);
     if (beforeState === "failed" && terminalState === "replied" && !this.isFailedDeliveryRevivable(before)) {
       return undefined;
@@ -10324,6 +10893,7 @@ export class ChannelDO extends Server<Env> {
       `UPDATE directed_deliveries
           SET state = ?,
               last_lease_connection_id = COALESCE(lease_connection_id, last_lease_connection_id),
+              last_lease_adapter = COALESCE(lease_adapter, last_lease_adapter),
               lease_connection_id = NULL, lease_adapter = NULL, lease_until = NULL,
               reply_seq = COALESCE(?, reply_seq), last_error = ?, terminal_reason = ?, updated_at = ?
         WHERE ${clauses.join(" AND ")}`,

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -10050,7 +10050,14 @@ export class ChannelDO extends Server<Env> {
       const webhookHolder = adapter === "webhook" ? matchingWebhooks[0] : undefined;
       const holderId = connectionHolder?.id ?? this.webhookHolderId(webhookHolder!.registrationId);
       const leaseUntil = now + (adapter === "webhook" ? DIRECTED_WEBHOOK_LEASE_MS : DIRECTED_DELIVERY_LEASE_MS);
-      const leaseToken = crypto.randomUUID();
+      // Token-fenced ownership is opt-in per websocket. Older directed-delivery
+      // v1 consumers can execute/ACK a delivery, but cannot recover a claim
+      // after their socket disappears. Giving those consumers a token would
+      // make disconnect cleanup retain an unrecoverable claim for the full
+      // lease window. Webhooks likewise have no websocket recovery handshake.
+      const recoveryCapable =
+        connectionHolder?.state?.deliveryRecoveryV1 === true;
+      const leaseToken = recoveryCapable ? crypto.randomUUID() : null;
       const claim = this.ctx.storage.sql.exec(
         `UPDATE directed_deliveries
             SET state = 'claimed', attempt = attempt + 1,
@@ -10091,7 +10098,7 @@ export class ChannelDO extends Server<Env> {
       if (connectionHolder !== undefined) {
         this.sendFrame(connectionHolder, {
           type: "delivery",
-          delivery: this.rowToDirectedDelivery(claimed),
+          delivery: this.rowToDirectedDelivery(claimed, recoveryCapable),
           message: messageFrame,
         });
       } else {

--- a/worker/test/delivery-atomicity.spec.ts
+++ b/worker/test/delivery-atomicity.spec.ts
@@ -384,6 +384,79 @@ describe("delivery transaction atomicity", () => {
     }
   });
 
+  it.each(["replied", "failed"] as const)(
+    "rolls back owner-answer %s together with its waiting_owner ancestor, then retries once",
+    async (terminalState) => {
+      const context = await setupPendingDecision();
+      try {
+        const resolved = await respond(context.slug, context.owner.token, context.question.seq);
+        expect(resolved.status).toBe(200);
+        const ownerAnswer = await context.serve.nextOfType("delivery");
+        expect(ownerAnswer.delivery.cause).toBe("owner_answer");
+
+        await installTrigger(
+          context.slug,
+          `CREATE TRIGGER fail_owner_answer_ancestor_close
+             BEFORE UPDATE OF state ON directed_deliveries
+             WHEN OLD.state = 'waiting_owner' AND NEW.state IN ('replied', 'failed')
+             BEGIN SELECT RAISE(ABORT, 'injected owner answer ancestor failure'); END`,
+        );
+
+        const transition = async () => {
+          const stub = env.CHANNELS.get(env.CHANNELS.idFromName(context.slug));
+          return runInDurableObject(stub, async (instance: ChannelDO) => {
+            const gate = instance as unknown as {
+              transitionDirectedDeliveryTerminal(
+                id: string,
+                state: "replied" | "failed",
+                now: number,
+                options: {
+                  replySeq?: number;
+                  error?: string;
+                  expectedStates: string[];
+                },
+              ): Record<string, unknown> | undefined;
+            };
+            return gate.transitionDirectedDeliveryTerminal(
+              ownerAnswer.delivery.id,
+              terminalState,
+              Date.now(),
+              {
+                ...(terminalState === "replied"
+                  ? { replySeq: ownerAnswer.delivery.message_seq }
+                  : { error: "injected terminal failure" }),
+                expectedStates: ["claimed"],
+              },
+            );
+          });
+        };
+
+        await expect(transition()).rejects.toThrow("injected owner answer ancestor failure");
+        let deliveries = await deliveryRows(context.slug);
+        expect(deliveries.find((row) => row.id === ownerAnswer.delivery.id)?.state).toBe("claimed");
+        expect(deliveries.find((row) => row.id === context.source.delivery.id)?.state).toBe(
+          "waiting_owner",
+        );
+
+        await dropTrigger(context.slug, "fail_owner_answer_ancestor_close");
+        await expect(transition()).resolves.toMatchObject({
+          id: ownerAnswer.delivery.id,
+          state: terminalState,
+        });
+        deliveries = await deliveryRows(context.slug);
+        expect(deliveries.find((row) => row.id === ownerAnswer.delivery.id)?.state).toBe(
+          terminalState,
+        );
+        expect(deliveries.find((row) => row.id === context.source.delivery.id)?.state).toBe(
+          terminalState,
+        );
+      } finally {
+        await dropTrigger(context.slug, "fail_owner_answer_ancestor_close");
+        context.serve.close();
+      }
+    },
+  );
+
   it("lets only one concurrent decision CAS append the idempotent response", async () => {
     const context = await setupPendingDecision();
     try {

--- a/worker/test/directed-delivery-adapters.spec.ts
+++ b/worker/test/directed-delivery-adapters.spec.ts
@@ -19,6 +19,8 @@ interface DeliveryRow {
   target_owner: string | null;
   state: string;
   attempt: number;
+  lease_epoch: number;
+  lease_token: string | null;
   lease_connection_id: string | null;
   lease_adapter: string | null;
   work_id: string | null;
@@ -76,6 +78,7 @@ async function deliveryRows(slug: string): Promise<DeliveryRow[]> {
     state.storage.sql
       .exec(
         `SELECT id, message_seq, target_name, target_owner, state, attempt,
+                lease_epoch, lease_token,
                 lease_connection_id, lease_adapter, work_id, continuation_ref,
                 reply_seq, last_error
            FROM directed_deliveries
@@ -90,6 +93,8 @@ async function deliveryRows(slug: string): Promise<DeliveryRow[]> {
           row.target_owner === null ? null : String(row.target_owner),
         state: String(row.state),
         attempt: Number(row.attempt),
+        lease_epoch: Number(row.lease_epoch),
+        lease_token: row.lease_token === null ? null : String(row.lease_token),
         lease_connection_id:
           row.lease_connection_id === null
             ? null
@@ -139,7 +144,12 @@ async function replyTo(slug: string, token: string, seq: number, body: string) {
 }
 
 async function registerWatch(ws: WsClient) {
-  ws.send({ type: "hello", since: 0, directed_delivery: "v1" });
+  ws.send({
+    type: "hello",
+    since: 0,
+    directed_delivery: "v1",
+    delivery_recovery: "v1",
+  });
   ws.send({ type: "delivery_adapter", adapter: "watch", op: "register" });
   expect(await ws.nextOfType("delivery_adapter")).toMatchObject({
     adapter: "watch",
@@ -148,7 +158,12 @@ async function registerWatch(ws: WsClient) {
 }
 
 async function claimServe(ws: WsClient) {
-  ws.send({ type: "hello", since: 0, directed_delivery: "v1" });
+  ws.send({
+    type: "hello",
+    since: 0,
+    directed_delivery: "v1",
+    delivery_recovery: "v1",
+  });
   ws.send({ type: "serve_lease", op: "claim" });
   expect(await ws.nextOfType("serve_lease")).toMatchObject({ held: true });
 }
@@ -178,7 +193,7 @@ async function registerWebhook(
 }
 
 describe("unified durable directed-delivery adapters", () => {
-  it("watch 在 running ACK 前断连会立即把同一 work 重派给 standby", async () => {
+  it("watch 在 running ACK 丢失并断连后以 durable token CAS 恢复且不会重复派发", async () => {
     const owner = `${uniq("watch-owner")}@example.com`;
     const sender = await seedToken("human", uniq("sender"), { owner });
     const slug = await createChannel(sender.token);
@@ -222,6 +237,8 @@ describe("unified durable directed-delivery adapters", () => {
         target_name: target.name,
         state: "claimed",
         attempt: 1,
+        lease_epoch: 1,
+        lease_token: expect.any(String),
       },
       message: { seq: posted.seq, body: `@${target.name} watch work` },
     });
@@ -236,27 +253,74 @@ describe("unified durable directed-delivery adapters", () => {
         reply_seq: null,
       },
     ]);
+    const leaseEpoch = full.delivery.lease_epoch;
+    const leaseToken = full.delivery.lease_token;
+    expect(leaseEpoch).toEqual(expect.any(Number));
+    expect(leaseToken).toEqual(expect.any(String));
+    if (leaseEpoch === undefined || leaseToken === undefined) {
+      throw new Error("holder delivery omitted recovery ownership");
+    }
 
-    watch.close();
-    const reassigned = (await standby.nextOfType("delivery")) as DirectedDeliveryFrame;
-    expect(reassigned).toMatchObject({
-      delivery: {
-        id: full.delivery.id,
-        message_seq: posted.seq,
-        target_name: target.name,
-        state: "claimed",
-        attempt: 2,
-        work_id: full.delivery.work_id,
-        continuation_ref: full.delivery.continuation_ref,
-      },
-      message: { seq: posted.seq, body: `@${target.name} watch work` },
+    // Simulate the precise failure window: Worker commits running, while the
+    // direct ACK and the socket disappear before the harness is notified.
+    watch.send({
+      type: "delivery_update",
+      delivery_id: full.delivery.id,
+      request_id: "lost-running-ack",
+      state: "running",
+      attempt: full.delivery.attempt,
+      lease_epoch: leaseEpoch,
+      lease_token: leaseToken,
+      work_id: full.delivery.work_id ?? undefined,
+      continuation_ref: full.delivery.continuation_ref ?? undefined,
     });
+    watch.close();
+    await expect.poll(async () => (await deliveryRows(slug))[0]?.state).toBe("running");
+    await expectNoFullDelivery(standby);
     expect((await deliveryRows(slug))[0]).toMatchObject({
       id: full.delivery.id,
-      state: "claimed",
-      attempt: 2,
+      state: "running",
+      attempt: 1,
       lease_adapter: "watch",
     });
+
+    const nextLeaseToken = crypto.randomUUID();
+    standby.send({
+      type: "delivery_recover",
+      delivery_id: full.delivery.id,
+      request_id: "recover-after-running-ack-loss",
+      attempt: full.delivery.attempt,
+      lease_epoch: leaseEpoch,
+      lease_token: leaseToken,
+      next_lease_token: nextLeaseToken,
+    });
+    expect(await standby.nextOfType("delivery_recovery")).toMatchObject({
+      delivery_id: full.delivery.id,
+      request_id: "recover-after-running-ack-loss",
+      result: "recovered",
+      state: "running",
+      attempt: 1,
+      lease_epoch: leaseEpoch,
+      lease_token: nextLeaseToken,
+    });
+    standby.send({
+      type: "delivery_update",
+      delivery_id: full.delivery.id,
+      request_id: "running-after-recover",
+      state: "running",
+      attempt: full.delivery.attempt,
+      lease_epoch: leaseEpoch,
+      lease_token: nextLeaseToken,
+      work_id: full.delivery.work_id ?? undefined,
+      continuation_ref: full.delivery.continuation_ref ?? undefined,
+    });
+    for (;;) {
+      const state = await standby.nextOfType("delivery_state");
+      if (state.request_id === "running-after-recover") {
+        expect(state.delivery).toMatchObject({ id: full.delivery.id, state: "running" });
+        break;
+      }
+    }
 
     const reply = await replyTo(
       slug,
@@ -267,10 +331,50 @@ describe("unified durable directed-delivery adapters", () => {
     expect((await deliveryRows(slug))[0]).toMatchObject({
       id: full.delivery.id,
       state: "replied",
-      attempt: 2,
+      attempt: 1,
       lease_adapter: null,
       lease_connection_id: null,
       reply_seq: reply.seq,
+    });
+
+    // A replacement process may also lose the terminal ACK. The token can
+    // reconcile that already-terminal receipt, but it must never recover and
+    // reactivate the lease.
+    const terminalReconciler = await WsClient.open(slug, target.token);
+    await terminalReconciler.nextOfType("welcome");
+    await registerWatch(terminalReconciler);
+    terminalReconciler.send({
+      type: "delivery_update",
+      delivery_id: full.delivery.id,
+      request_id: "terminal-ack-reconcile",
+      state: "replied",
+      attempt: full.delivery.attempt,
+      lease_epoch: leaseEpoch,
+      lease_token: nextLeaseToken,
+      work_id: full.delivery.work_id ?? undefined,
+      continuation_ref: full.delivery.continuation_ref ?? undefined,
+      reply_seq: reply.seq,
+    });
+    for (;;) {
+      const state = await terminalReconciler.nextOfType("delivery_state");
+      if (state.request_id === "terminal-ack-reconcile") {
+        expect(state.delivery).toMatchObject({ id: full.delivery.id, state: "replied" });
+        break;
+      }
+    }
+    terminalReconciler.send({
+      type: "delivery_recover",
+      delivery_id: full.delivery.id,
+      request_id: "terminal-must-not-recover",
+      attempt: full.delivery.attempt,
+      lease_epoch: leaseEpoch,
+      lease_token: nextLeaseToken,
+      next_lease_token: crypto.randomUUID(),
+    });
+    expect(await terminalReconciler.nextOfType("delivery_recovery")).toMatchObject({
+      request_id: "terminal-must-not-recover",
+      result: "terminal",
+      state: "replied",
     });
 
     const serve = await WsClient.open(slug, target.token);
@@ -283,10 +387,469 @@ describe("unified durable directed-delivery adapters", () => {
     await expectNoFullDelivery(serve);
     expect((await deliveryRows(slug))[0]).toMatchObject({
       state: "replied",
-      attempt: 2,
+      attempt: 1,
     });
     standby.close();
+    terminalReconciler.close();
     serve.close();
+  });
+
+  it("delivery recovery fences the old socket and rejects wrong principal, token, epoch, and expired lease", async () => {
+    const owner = `${uniq("recover-fence-owner")}@example.com`;
+    const sender = await seedToken("human", uniq("sender"), { owner });
+    const slug = await createChannel(sender.token);
+    const target = await seedToken("agent", uniq("recover-fence-target"), {
+      owner,
+      channelScope: slug,
+    });
+    const other = await seedToken("agent", uniq("recover-fence-other"), {
+      owner,
+      channelScope: slug,
+    });
+    const first = await WsClient.open(slug, target.token);
+    await first.nextOfType("welcome");
+    await registerWatch(first);
+    const posted = await sendMention(slug, sender.token, target.name, "fence old holder");
+    const frame = (await first.nextOfType("delivery")) as DirectedDeliveryFrame;
+    const leaseEpoch = frame.delivery.lease_epoch;
+    const leaseToken = frame.delivery.lease_token;
+    if (leaseEpoch === undefined || leaseToken === undefined) {
+      throw new Error("holder delivery omitted recovery ownership");
+    }
+
+    const impostor = await WsClient.open(slug, other.token);
+    await impostor.nextOfType("welcome");
+    await registerWatch(impostor);
+    impostor.send({
+      type: "delivery_recover",
+      delivery_id: frame.delivery.id,
+      request_id: "wrong-principal",
+      attempt: frame.delivery.attempt,
+      lease_epoch: leaseEpoch,
+      lease_token: leaseToken,
+      next_lease_token: crypto.randomUUID(),
+    });
+    expect(await impostor.nextOfType("error")).toMatchObject({ code: "bad_request" });
+
+    const replacement = await WsClient.open(slug, target.token);
+    await replacement.nextOfType("welcome");
+    await registerWatch(replacement);
+    replacement.send({
+      type: "delivery_recover",
+      delivery_id: frame.delivery.id,
+      request_id: "wrong-token",
+      attempt: frame.delivery.attempt,
+      lease_epoch: leaseEpoch,
+      lease_token: crypto.randomUUID(),
+      next_lease_token: crypto.randomUUID(),
+    });
+    expect(await replacement.nextOfType("error")).toMatchObject({ code: "bad_request" });
+    replacement.send({
+      type: "delivery_recover",
+      delivery_id: frame.delivery.id,
+      request_id: "wrong-epoch",
+      attempt: frame.delivery.attempt,
+      lease_epoch: leaseEpoch + 1,
+      lease_token: leaseToken,
+      next_lease_token: crypto.randomUUID(),
+    });
+    expect(await replacement.nextOfType("error")).toMatchObject({ code: "bad_request" });
+    replacement.send({
+      type: "delivery_recover",
+      delivery_id: frame.delivery.id,
+      request_id: "non-literal-replay-safe",
+      attempt: frame.delivery.attempt,
+      lease_epoch: leaseEpoch,
+      lease_token: leaseToken,
+      next_lease_token: crypto.randomUUID(),
+      replay_safe: "true",
+    } as never);
+    expect(await replacement.nextOfType("error")).toMatchObject({ code: "bad_request" });
+
+    const rotated = crypto.randomUUID();
+    const firstClosed = new Promise<void>((resolve) => {
+      first.ws.addEventListener("close", () => resolve(), { once: true });
+    });
+    replacement.send({
+      type: "delivery_recover",
+      delivery_id: frame.delivery.id,
+      request_id: "valid-recovery",
+      attempt: frame.delivery.attempt,
+      lease_epoch: leaseEpoch,
+      lease_token: leaseToken,
+      next_lease_token: rotated,
+    });
+    expect(await replacement.nextOfType("delivery_recovery")).toMatchObject({
+      request_id: "valid-recovery",
+      result: "recovered",
+      lease_token: rotated,
+      state: "claimed",
+    });
+    await firstClosed;
+
+    // C1 still knows the old secret, but recovery actively evicts the half-open
+    // socket instead of leaving it eligible to win a later watch assignment.
+    expect((await deliveryRows(slug))[0]).toMatchObject({
+      message_seq: posted.seq,
+      state: "claimed",
+      lease_token: rotated,
+    });
+
+    const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+    await runInDurableObject(stub, async (_instance: ChannelDO, state) => {
+      state.storage.sql.exec(
+        "UPDATE directed_deliveries SET lease_until = ? WHERE id = ?",
+        Date.now() - 1,
+        frame.delivery.id,
+      );
+    });
+    const afterExpiry = await WsClient.open(slug, target.token);
+    await afterExpiry.nextOfType("welcome");
+    await registerWatch(afterExpiry);
+    afterExpiry.send({
+      type: "delivery_recover",
+      delivery_id: frame.delivery.id,
+      request_id: "expired-recovery",
+      attempt: frame.delivery.attempt,
+      lease_epoch: leaseEpoch,
+      lease_token: rotated,
+      next_lease_token: crypto.randomUUID(),
+    });
+    expect(await afterExpiry.nextOfType("delivery_recovery")).toMatchObject({
+      request_id: "expired-recovery",
+      result: "superseded_safe",
+    });
+
+    first.close();
+    replacement.close();
+    impostor.close();
+    afterExpiry.close();
+  });
+
+  it("watch recovery evicts the old holder and keeps the recovered socket ahead of an older standby", async () => {
+    const owner = `${uniq("watch-recovery-priority-owner")}@example.com`;
+    const sender = await seedToken("human", uniq("sender"), { owner });
+    const slug = await createChannel(sender.token);
+    const target = await seedToken("agent", uniq("watch-recovery-priority-target"), {
+      owner,
+      channelScope: slug,
+    });
+    const original = await WsClient.open(slug, target.token);
+    await original.nextOfType("welcome");
+    await registerWatch(original);
+    const olderStandby = await WsClient.open(slug, target.token);
+    await olderStandby.nextOfType("welcome");
+    await registerWatch(olderStandby);
+    const recovering = await WsClient.open(slug, target.token);
+    await recovering.nextOfType("welcome");
+    await registerWatch(recovering);
+
+    const firstMessage = await sendMention(
+      slug,
+      sender.token,
+      target.name,
+      "recover then keep watch ownership",
+    );
+    const first = (await original.nextOfType("delivery")) as DirectedDeliveryFrame;
+    if (first.delivery.lease_epoch === undefined || first.delivery.lease_token === undefined) {
+      throw new Error("holder delivery omitted recovery ownership");
+    }
+    const originalClosed = new Promise<void>((resolve) => {
+      original.ws.addEventListener("close", () => resolve(), { once: true });
+    });
+    const rotated = crypto.randomUUID();
+    recovering.send({
+      type: "delivery_recover",
+      delivery_id: first.delivery.id,
+      request_id: "watch-priority-recovery",
+      attempt: first.delivery.attempt,
+      lease_epoch: first.delivery.lease_epoch,
+      lease_token: first.delivery.lease_token,
+      next_lease_token: rotated,
+    });
+    expect(await recovering.nextOfType("delivery_recovery")).toMatchObject({
+      request_id: "watch-priority-recovery",
+      result: "recovered",
+      lease_token: rotated,
+    });
+    await originalClosed;
+    recovering.send({
+      type: "delivery_update",
+      delivery_id: first.delivery.id,
+      request_id: "watch-priority-running",
+      state: "running",
+      attempt: first.delivery.attempt,
+      lease_epoch: first.delivery.lease_epoch,
+      lease_token: rotated,
+      work_id: first.delivery.work_id ?? undefined,
+      continuation_ref: first.delivery.continuation_ref ?? undefined,
+    });
+    for (;;) {
+      const state = await recovering.nextOfType("delivery_state");
+      if (state.request_id === "watch-priority-running") break;
+    }
+    await replyTo(slug, target.token, firstMessage.seq, "first recovered task complete");
+
+    const secondMessage = await sendMention(
+      slug,
+      sender.token,
+      target.name,
+      "second task stays on recovered socket",
+    );
+    const second = (await recovering.nextOfType("delivery")) as DirectedDeliveryFrame;
+    expect(second.delivery).toMatchObject({
+      message_seq: secondMessage.seq,
+      target_name: target.name,
+      state: "claimed",
+    });
+    await expectNoFullDelivery(olderStandby);
+
+    olderStandby.close();
+    recovering.close();
+  });
+
+  it("recovery resolves an old journal safely after more than one claimed supersession", async () => {
+    const owner = `${uniq("recover-history-owner")}@example.com`;
+    const sender = await seedToken("human", uniq("sender"), { owner });
+    const slug = await createChannel(sender.token);
+    const target = await seedToken("agent", uniq("recover-history-target"), {
+      owner,
+      channelScope: slug,
+    });
+    const holders: WsClient[] = [];
+    for (let index = 0; index < 3; index += 1) {
+      const holder = await WsClient.open(slug, target.token);
+      holders.push(holder);
+      await holder.nextOfType("welcome");
+      await registerWatch(holder);
+    }
+    await sendMention(slug, sender.token, target.name, "rotate claim twice");
+    const first = (await holders[0]!.nextOfType("delivery")) as DirectedDeliveryFrame;
+    if (first.delivery.lease_epoch === undefined || first.delivery.lease_token === undefined) {
+      throw new Error("holder delivery omitted recovery ownership");
+    }
+    holders[0]!.close();
+
+    const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+    const expireAndAlarm = async () => {
+      await runInDurableObject(stub, async (instance: ChannelDO, state) => {
+        state.storage.sql.exec(
+          "UPDATE directed_deliveries SET lease_until = ? WHERE id = ?",
+          Date.now() - 1,
+          first.delivery.id,
+        );
+        await instance.onAlarm();
+      });
+    };
+    await expireAndAlarm();
+    const second = (await holders[1]!.nextOfType("delivery")) as DirectedDeliveryFrame;
+    expect(second.delivery).toMatchObject({ id: first.delivery.id, attempt: 2, lease_epoch: 2 });
+    holders[1]!.close();
+    await expireAndAlarm();
+    const third = (await holders[2]!.nextOfType("delivery")) as DirectedDeliveryFrame;
+    expect(third.delivery).toMatchObject({ id: first.delivery.id, attempt: 3, lease_epoch: 3 });
+
+    const restartedOldProcess = await WsClient.open(slug, target.token);
+    await restartedOldProcess.nextOfType("welcome");
+    await registerWatch(restartedOldProcess);
+    restartedOldProcess.send({
+      type: "delivery_recover",
+      delivery_id: first.delivery.id,
+      request_id: "oldest-attempt-recovery",
+      attempt: first.delivery.attempt,
+      lease_epoch: first.delivery.lease_epoch,
+      lease_token: first.delivery.lease_token,
+      next_lease_token: crypto.randomUUID(),
+    });
+    expect(await restartedOldProcess.nextOfType("delivery_recovery")).toMatchObject({
+      request_id: "oldest-attempt-recovery",
+      result: "superseded_safe",
+      state: "claimed",
+      attempt: 3,
+      lease_epoch: 3,
+    });
+
+    holders[2]!.close();
+    restartedOldProcess.close();
+  });
+
+  it("A→B→C token rotations retain every generation so delayed A converges as superseded", async () => {
+    const owner = `${uniq("recover-token-chain-owner")}@example.com`;
+    const sender = await seedToken("human", uniq("sender"), { owner });
+    const slug = await createChannel(sender.token);
+    const target = await seedToken("agent", uniq("recover-token-chain-target"), {
+      owner,
+      channelScope: slug,
+    });
+    const a = await WsClient.open(slug, target.token);
+    await a.nextOfType("welcome");
+    await registerWatch(a);
+    await sendMention(slug, sender.token, target.name, "rotate recovery token A B C");
+    const delivery = (await a.nextOfType("delivery")) as DirectedDeliveryFrame;
+    if (delivery.delivery.lease_epoch === undefined || delivery.delivery.lease_token === undefined) {
+      throw new Error("holder delivery omitted recovery ownership");
+    }
+    const tokenA = delivery.delivery.lease_token;
+    const tokenB = crypto.randomUUID();
+    const b = await WsClient.open(slug, target.token);
+    await b.nextOfType("welcome");
+    await registerWatch(b);
+    b.send({
+      type: "delivery_recover",
+      delivery_id: delivery.delivery.id,
+      request_id: "rotate-a-b",
+      attempt: delivery.delivery.attempt,
+      lease_epoch: delivery.delivery.lease_epoch,
+      lease_token: tokenA,
+      next_lease_token: tokenB,
+    });
+    expect(await b.nextOfType("delivery_recovery")).toMatchObject({
+      request_id: "rotate-a-b",
+      result: "recovered",
+      lease_token: tokenB,
+    });
+
+    const tokenC = crypto.randomUUID();
+    const c = await WsClient.open(slug, target.token);
+    await c.nextOfType("welcome");
+    await registerWatch(c);
+    c.send({
+      type: "delivery_recover",
+      delivery_id: delivery.delivery.id,
+      request_id: "rotate-b-c",
+      attempt: delivery.delivery.attempt,
+      lease_epoch: delivery.delivery.lease_epoch,
+      lease_token: tokenB,
+      next_lease_token: tokenC,
+    });
+    expect(await c.nextOfType("delivery_recovery")).toMatchObject({
+      request_id: "rotate-b-c",
+      result: "recovered",
+      lease_token: tokenC,
+    });
+
+    const delayedA = await WsClient.open(slug, target.token);
+    await delayedA.nextOfType("welcome");
+    await registerWatch(delayedA);
+    delayedA.send({
+      type: "delivery_recover",
+      delivery_id: delivery.delivery.id,
+      request_id: "delayed-a-after-c",
+      attempt: delivery.delivery.attempt,
+      lease_epoch: delivery.delivery.lease_epoch,
+      lease_token: tokenA,
+      next_lease_token: crypto.randomUUID(),
+    });
+    expect(await delayedA.nextOfType("delivery_recovery")).toMatchObject({
+      request_id: "delayed-a-after-c",
+      result: "superseded_safe",
+      state: "claimed",
+      attempt: delivery.delivery.attempt,
+      lease_epoch: delivery.delivery.lease_epoch,
+    });
+    expect((await deliveryRows(slug))[0]).toMatchObject({
+      state: "claimed",
+      lease_token: tokenC,
+    });
+
+    await replyTo(slug, target.token, delivery.delivery.message_seq, "token C completed");
+    delayedA.send({
+      type: "delivery_recover",
+      delivery_id: delivery.delivery.id,
+      request_id: "delayed-a-after-terminal",
+      attempt: delivery.delivery.attempt,
+      lease_epoch: delivery.delivery.lease_epoch,
+      lease_token: tokenA,
+      next_lease_token: crypto.randomUUID(),
+    });
+    expect(await delayedA.nextOfType("delivery_recovery")).toMatchObject({
+      request_id: "delayed-a-after-terminal",
+      result: "terminal",
+      state: "replied",
+    });
+
+    a.close();
+    b.close();
+    c.close();
+    delayedA.close();
+  });
+
+  it("serve token recovery makes the recovering socket holder ahead of an older standby", async () => {
+    const owner = `${uniq("serve-recovery-owner")}@example.com`;
+    const sender = await seedToken("human", uniq("sender"), { owner });
+    const slug = await createChannel(sender.token);
+    const target = await seedToken("agent", uniq("serve-recovery-target"), {
+      owner,
+      channelScope: slug,
+    });
+    const c1 = await WsClient.open(slug, target.token);
+    await c1.nextOfType("welcome");
+    await claimServe(c1);
+    const c3OlderStandby = await WsClient.open(slug, target.token);
+    await c3OlderStandby.nextOfType("welcome");
+    c3OlderStandby.send({
+      type: "hello",
+      since: 0,
+      directed_delivery: "v1",
+      delivery_recovery: "v1",
+    });
+    c3OlderStandby.send({ type: "serve_lease", op: "claim" });
+    expect(await c3OlderStandby.nextOfType("serve_lease")).toMatchObject({ held: false });
+    const c2Recovering = await WsClient.open(slug, target.token);
+    await c2Recovering.nextOfType("welcome");
+    c2Recovering.send({
+      type: "hello",
+      since: 0,
+      directed_delivery: "v1",
+      delivery_recovery: "v1",
+    });
+    c2Recovering.send({ type: "serve_lease", op: "claim" });
+    expect(await c2Recovering.nextOfType("serve_lease")).toMatchObject({ held: false });
+
+    await sendMention(slug, sender.token, target.name, "recover to exact serve");
+    const delivery = (await c1.nextOfType("delivery")) as DirectedDeliveryFrame;
+    if (delivery.delivery.lease_epoch === undefined || delivery.delivery.lease_token === undefined) {
+      throw new Error("holder delivery omitted recovery ownership");
+    }
+    const rotated = crypto.randomUUID();
+    c2Recovering.send({
+      type: "delivery_recover",
+      delivery_id: delivery.delivery.id,
+      request_id: "serve-c2-recovery",
+      attempt: delivery.delivery.attempt,
+      lease_epoch: delivery.delivery.lease_epoch,
+      lease_token: delivery.delivery.lease_token,
+      next_lease_token: rotated,
+    });
+    expect(await c2Recovering.nextOfType("serve_lease")).toMatchObject({ held: true });
+    expect(await c2Recovering.nextOfType("delivery_recovery")).toMatchObject({
+      request_id: "serve-c2-recovery",
+      result: "recovered",
+      lease_token: rotated,
+    });
+    expect(await c3OlderStandby.nextOfType("serve_lease")).toMatchObject({ held: false });
+    c2Recovering.send({
+      type: "delivery_update",
+      delivery_id: delivery.delivery.id,
+      request_id: "serve-c2-running",
+      state: "running",
+      attempt: delivery.delivery.attempt,
+      lease_epoch: delivery.delivery.lease_epoch,
+      lease_token: rotated,
+      work_id: delivery.delivery.work_id ?? undefined,
+      continuation_ref: delivery.delivery.continuation_ref ?? undefined,
+    });
+    for (;;) {
+      const state = await c2Recovering.nextOfType("delivery_state");
+      if (state.request_id === "serve-c2-running") {
+        expect(state.delivery).toMatchObject({ state: "running" });
+        break;
+      }
+    }
+
+    c1.close();
+    c2Recovering.close();
+    c3OlderStandby.close();
   });
 
   it("serve 与 watch 同时在线时由 serve 优先领取，watch 不收到 full delivery", async () => {
@@ -377,13 +940,32 @@ describe("unified durable directed-delivery adapters", () => {
     });
 
     const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
-    await runInDurableObject(stub, async (instance: ChannelDO, state) => {
+    await runInDurableObject(stub, async (_instance: ChannelDO, state) => {
       state.storage.sql.exec(
         "UPDATE directed_deliveries SET lease_until = ? WHERE id = ?",
         Date.now() - 1,
         full.delivery.id,
       );
-      await instance.onAlarm();
+    });
+    const recovery = await WsClient.open(slug, target.token);
+    await recovery.nextOfType("welcome");
+    await registerWatch(recovery);
+    if (full.delivery.lease_epoch === undefined || full.delivery.lease_token === undefined) {
+      throw new Error("holder delivery omitted recovery ownership");
+    }
+    recovery.send({
+      type: "delivery_recover",
+      delivery_id: full.delivery.id,
+      request_id: "running-expired-outcome",
+      attempt: full.delivery.attempt,
+      lease_epoch: full.delivery.lease_epoch,
+      lease_token: full.delivery.lease_token,
+      next_lease_token: crypto.randomUUID(),
+    });
+    expect(await recovery.nextOfType("delivery_recovery")).toMatchObject({
+      request_id: "running-expired-outcome",
+      result: "terminal_unknown",
+      state: "failed",
     });
     expect((await deliveryRows(slug))[0]).toMatchObject({
       state: "failed",
@@ -391,7 +973,121 @@ describe("unified durable directed-delivery adapters", () => {
       lease_adapter: null,
       last_error: "runner ownership lost after task start; outcome unknown, not auto-retried",
     });
+    recovery.close();
     observer.close();
+  });
+
+  it("replay-safe unknown recovery queues old debt behind an active successor and resumes it in order", async () => {
+    const owner = `${uniq("recover-order-owner")}@example.com`;
+    const sender = await seedToken("human", uniq("sender"), { owner });
+    const slug = await createChannel(sender.token);
+    const target = await seedToken("agent", uniq("recover-order-target"), {
+      owner,
+      channelScope: slug,
+    });
+    const firstHolder = await WsClient.open(slug, target.token);
+    await firstHolder.nextOfType("welcome");
+    await registerWatch(firstHolder);
+
+    const firstMessage = await sendMention(
+      slug,
+      sender.token,
+      target.name,
+      "old pre-harness debt",
+    );
+    const first = (await firstHolder.nextOfType("delivery")) as DirectedDeliveryFrame;
+    if (first.delivery.lease_epoch === undefined || first.delivery.lease_token === undefined) {
+      throw new Error("holder delivery omitted recovery ownership");
+    }
+    firstHolder.send({
+      type: "delivery_update",
+      delivery_id: first.delivery.id,
+      request_id: "old-running-before-crash",
+      state: "running",
+      attempt: first.delivery.attempt,
+      lease_epoch: first.delivery.lease_epoch,
+      lease_token: first.delivery.lease_token,
+      work_id: first.delivery.work_id ?? undefined,
+      continuation_ref: first.delivery.continuation_ref ?? undefined,
+    });
+    for (;;) {
+      const state = await firstHolder.nextOfType("delivery_state");
+      if (state.request_id === "old-running-before-crash") break;
+    }
+    const secondMessage = await sendMention(
+      slug,
+      sender.token,
+      target.name,
+      "new successor stays active first",
+    );
+    expect(await deliveryRows(slug)).toMatchObject([
+      { message_seq: firstMessage.seq, state: "running" },
+      { message_seq: secondMessage.seq, state: "queued" },
+    ]);
+
+    firstHolder.close();
+    const successorHolder = await WsClient.open(slug, target.token);
+    await successorHolder.nextOfType("welcome");
+    await registerWatch(successorHolder);
+    const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+    await runInDurableObject(stub, async (instance: ChannelDO, state) => {
+      state.storage.sql.exec(
+        "UPDATE directed_deliveries SET lease_until = ? WHERE id = ?",
+        Date.now() - 1,
+        first.delivery.id,
+      );
+      await instance.onAlarm();
+    });
+    const successor = (await successorHolder.nextOfType("delivery")) as DirectedDeliveryFrame;
+    expect(successor.delivery).toMatchObject({
+      message_seq: secondMessage.seq,
+      state: "claimed",
+    });
+
+    const restartedOld = await WsClient.open(slug, target.token);
+    await restartedOld.nextOfType("welcome");
+    await registerWatch(restartedOld);
+    restartedOld.send({
+      type: "delivery_recover",
+      delivery_id: first.delivery.id,
+      request_id: "revive-old-behind-successor",
+      attempt: first.delivery.attempt,
+      lease_epoch: first.delivery.lease_epoch,
+      lease_token: first.delivery.lease_token,
+      next_lease_token: crypto.randomUUID(),
+      replay_safe: true,
+    });
+    expect(await restartedOld.nextOfType("delivery_recovery")).toMatchObject({
+      request_id: "revive-old-behind-successor",
+      result: "superseded_safe",
+      state: "queued",
+    });
+    expect(await deliveryRows(slug)).toMatchObject([
+      { message_seq: firstMessage.seq, state: "queued", attempt: 1 },
+      { message_seq: secondMessage.seq, state: "claimed", attempt: 1 },
+    ]);
+    await expectNoFullDelivery(restartedOld);
+
+    await replyTo(
+      slug,
+      target.token,
+      secondMessage.seq,
+      "successor completed before old debt",
+    );
+    const resumedOld = (await successorHolder.nextOfType("delivery")) as DirectedDeliveryFrame;
+    expect(resumedOld.delivery).toMatchObject({
+      id: first.delivery.id,
+      message_seq: firstMessage.seq,
+      state: "claimed",
+      attempt: 2,
+    });
+    expect(await deliveryRows(slug)).toMatchObject([
+      { message_seq: firstMessage.seq, state: "claimed", attempt: 2 },
+      { message_seq: secondMessage.seq, state: "replied", attempt: 1 },
+    ]);
+
+    successorHolder.close();
+    restartedOld.close();
   });
 
   it("agent webhook 2xx 持久 accepted/running：payload/请求 ID 稳定，target reply 后 serve 不会重跑", async () => {

--- a/worker/test/directed-delivery.spec.ts
+++ b/worker/test/directed-delivery.spec.ts
@@ -682,7 +682,7 @@ describe("持久定向投递（issue #551）", () => {
     serve.close();
   });
 
-  it("holder 断连后同一 delivery 回到 queued 并由 standby 接管", async () => {
+  it("holder 断连后保留可恢复 claim，到固定租约过期才由 standby 接管", async () => {
     const sender = await seedToken("agent", uniq("sender"));
     const target = await seedToken("agent", uniq("target"));
     const slug = await createChannel(sender.token);
@@ -697,6 +697,25 @@ describe("持久定向投递（issue #551）", () => {
     const firstAttempt = await holder.nextOfType("delivery");
     holder.close();
     expect((await standby.nextOfType("serve_lease")).held).toBe(true);
+
+    // v1 delivery carries an unforgeable recovery token. A socket close alone cannot prove that
+    // the old process failed before persisting/starting it, so the Worker reserves this exact claim
+    // for reconnect instead of immediately creating a second active holder. Once the fixed lease
+    // expires, the ordinary claimed-state retry is safe and the elected standby receives attempt 2.
+    expect((await deliveryRows(slug))[0]).toMatchObject({
+      id: firstAttempt.delivery.id,
+      state: "claimed",
+      attempt: 1,
+    });
+    const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+    await runInDurableObject(stub, async (instance: ChannelDO, state) => {
+      state.storage.sql.exec(
+        "UPDATE directed_deliveries SET lease_until = ? WHERE id = ?",
+        Date.now() - 1,
+        firstAttempt.delivery.id,
+      );
+      await instance.onAlarm();
+    });
     const retry = await standby.nextOfType("delivery");
     expect(retry.delivery).toMatchObject({
       id: firstAttempt.delivery.id,

--- a/worker/test/directed-delivery.spec.ts
+++ b/worker/test/directed-delivery.spec.ts
@@ -19,6 +19,17 @@ async function claim(ws: WsClient) {
   return ws.nextOfType("serve_lease");
 }
 
+async function claimWithRecovery(ws: WsClient) {
+  ws.send({
+    type: "hello",
+    since: 0,
+    directed_delivery: "v1",
+    delivery_recovery: "v1",
+  });
+  ws.send({ type: "serve_lease", op: "claim" });
+  return ws.nextOfType("serve_lease");
+}
+
 async function nextDeliveryState(
   ws: WsClient,
   deliveryId: string,
@@ -37,7 +48,12 @@ async function nextDeliveryState(
 
 async function deliveryRows(
   slug: string,
-): Promise<Array<DirectedDelivery & { lease_connection_id: string | null; lease_adapter: string | null; target_owner: string | null }>> {
+): Promise<Array<Omit<DirectedDelivery, "lease_token"> & {
+  lease_token: string | null;
+  lease_connection_id: string | null;
+  lease_adapter: string | null;
+  target_owner: string | null;
+}>> {
   const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
   return runInDurableObject(stub, async (_instance: ChannelDO, state) =>
     state.storage.sql
@@ -51,6 +67,7 @@ async function deliveryRows(
         cause: String(row.cause) as DirectedDelivery["cause"],
         state: String(row.state) as DirectedDelivery["state"],
         attempt: Number(row.attempt),
+        lease_token: row.lease_token === null ? null : String(row.lease_token),
         lease_until: row.lease_until === null ? null : Number(row.lease_until),
         lease_connection_id: row.lease_connection_id === null ? null : String(row.lease_connection_id),
         lease_adapter: row.lease_adapter === null ? null : String(row.lease_adapter),
@@ -682,7 +699,7 @@ describe("持久定向投递（issue #551）", () => {
     serve.close();
   });
 
-  it("holder 断连后保留可恢复 claim，到固定租约过期才由 standby 接管", async () => {
+  it("未声明 recovery 的 v1 holder 不拿 token，断连后立即 requeue 给 standby", async () => {
     const sender = await seedToken("agent", uniq("sender"));
     const target = await seedToken("agent", uniq("target"));
     const slug = await createChannel(sender.token);
@@ -693,8 +710,49 @@ describe("持久定向投递（issue #551）", () => {
     await standby.nextOfType("welcome");
     expect((await claim(standby)).held).toBe(false);
 
+    const posted = await sendMention(slug, sender.token, target.name, "legacy v1 disconnect");
+    const firstAttempt = await holder.nextOfType("delivery");
+    expect(firstAttempt.delivery.lease_token).toBeUndefined();
+    expect((await deliveryRows(slug))[0]).toMatchObject({
+      id: firstAttempt.delivery.id,
+      state: "claimed",
+      attempt: 1,
+      lease_token: null,
+    });
+
+    holder.close();
+    expect((await standby.nextOfType("serve_lease")).held).toBe(true);
+    const retry = await standby.nextOfType("delivery");
+    expect(retry.delivery).toMatchObject({
+      id: firstAttempt.delivery.id,
+      message_seq: posted.seq,
+      cause: "retry",
+      state: "claimed",
+      attempt: 2,
+    });
+    expect(retry.delivery.lease_token).toBeUndefined();
+    expect((await deliveryRows(slug))[0]).toMatchObject({
+      state: "claimed",
+      attempt: 2,
+      lease_token: null,
+    });
+    standby.close();
+  });
+
+  it("声明 recovery 的 holder 断连后保留 token claim，到固定租约过期才由 standby 接管", async () => {
+    const sender = await seedToken("agent", uniq("sender"));
+    const target = await seedToken("agent", uniq("target"));
+    const slug = await createChannel(sender.token);
+    const holder = await WsClient.open(slug, target.token);
+    await holder.nextOfType("welcome");
+    expect((await claimWithRecovery(holder)).held).toBe(true);
+    const standby = await WsClient.open(slug, target.token);
+    await standby.nextOfType("welcome");
+    expect((await claimWithRecovery(standby)).held).toBe(false);
+
     const posted = await sendMention(slug, sender.token, target.name, "survive disconnect");
     const firstAttempt = await holder.nextOfType("delivery");
+    expect(firstAttempt.delivery.lease_token).toEqual(expect.any(String));
     holder.close();
     expect((await standby.nextOfType("serve_lease")).held).toBe(true);
 
@@ -706,7 +764,11 @@ describe("持久定向投递（issue #551）", () => {
       id: firstAttempt.delivery.id,
       state: "claimed",
       attempt: 1,
+      lease_token: firstAttempt.delivery.lease_token,
     });
+    await expect(standby.nextOfType("delivery", 100)).rejects.toThrow(
+      "timeout waiting for frame",
+    );
     const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
     await runInDurableObject(stub, async (instance: ChannelDO, state) => {
       state.storage.sql.exec(


### PR DESCRIPTION
## 改动说明

- 接入 Claude Code 原生 Channel：claim-only 通知进入当前交互会话，再由 MCP 完成 claim / accept / linked reply；中断投递由持久化 journal 恢复。
- 接入 Codex app-server 单写者桥接：TUI 与 AgentParty 输入共用同一 writer，具备 generation fencing、恢复屏障、WAL 回滚债务与严格 thread snapshot。
- 扩展 Worker directed-delivery recovery v1：lease token、CAS 恢复、原子 owner-answer、终态幂等与权限隔离，同时保持 legacy 客户端兼容。
- 固定普通 serve / profile 的 Codex preflight launch spec；支持 npm `codex.cmd` 安全直连 `node.exe + codex.js`，显式 `.bat` 或失效 shim fail-closed。
- 架构文档：https://htmldock.pwtk-dev.work/d/31

## 合并前检查（review-ack 强制闸——不留结论合不了）

- [x] 我已读 pr-agent / CodeRabbit 的 review，真问题已处理、误报已判明
- [x] 本地门禁通过（tsc / 测试 / build）
- [x] 涉及安全/鉴权/数据的改动已做对抗性验证（租约 fencing、身份漂移、RPC 丢失、TOCTOU、legacy 兼容）

## 验证

- `bun run check` 通过；Worker 758/758
- `serve.test.ts` 88/88；CLI typecheck、`git diff --check` 通过
- 当前 head 的 required CI 全绿：CLI/Worker 全分片、types、web、shared、desktop、dependency audit、full check
- 多轮只读终审：P0/P1/P2 均为 0

Closes #746
