### PR TITLE
fix(worker): 兼容 D1 远端 trigger 迁移

### DIFF
--- a/scripts/deploy-ci.test.ts
+++ b/scripts/deploy-ci.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
 import {
   DEPLOY_TARGETS,
   buildDeployPlan,
@@ -90,5 +91,18 @@ describe("buildDeployPlan", () => {
 
   test("both targets map to distinct public bases", () => {
     expect(DEPLOY_TARGETS.prod.smokeBase).not.toBe(DEPLOY_TARGETS.xdream.smokeBase);
+  });
+});
+
+describe("remote D1 migration compatibility", () => {
+  test("trigger CASE guards are parenthesized so the remote query endpoint keeps the outer END", () => {
+    const migration = readFileSync(
+      new URL("../worker/migrations/0042_channel_decisions.sql", import.meta.url),
+      "utf8",
+    );
+
+    expect(migration).not.toMatch(/\bSELECT\s+CASE\b/i);
+    expect(migration.match(/\bSELECT\s*\(\s*CASE\b/gi)).toHaveLength(7);
+    expect(migration.match(/\bTHEN\s+RAISE\s*\(/gi)).toHaveLength(7);
   });
 });

--- a/scripts/verify-remote-schema-contract.test.ts
+++ b/scripts/verify-remote-schema-contract.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  equivalentTriggerDefinitions,
   extractIndexDefinition,
   extractTriggerDefinition,
   normalizeSqlDefinition,
@@ -60,5 +61,42 @@ CREATE INDEX idx_two ON records(created_at DESC);
       "create trigger guard before insert on records begin select raise(abort, 'nope'); end",
     );
     expect(normalizeSqlDefinition(null)).toBe("");
+  });
+
+  test("accepts only the remote-D1 CASE wrapper as an equivalent trigger definition", () => {
+    const parenthesized = `
+      CREATE TRIGGER guard BEFORE INSERT ON records
+      BEGIN
+        SELECT (CASE
+          WHEN NEW.id IS NULL
+          THEN RAISE(ABORT, 'missing id')
+        END);
+        SELECT (CASE
+          WHEN NEW.owner IS NULL
+          THEN RAISE(ABORT, 'missing owner')
+        END);
+      END;
+    `;
+    const legacyBareCase = `
+      CREATE TRIGGER guard BEFORE INSERT ON records
+      BEGIN
+        SELECT CASE
+          WHEN NEW.id IS NULL
+          THEN RAISE(ABORT, 'missing id')
+        END;
+        SELECT CASE
+          WHEN NEW.owner IS NULL
+          THEN RAISE(ABORT, 'missing owner')
+        END;
+      END;
+    `;
+    const changedGuard = legacyBareCase.replace("NEW.id IS NULL", "NEW.id < 0");
+    const hybridWrapper = parenthesized.replace("SELECT (CASE", "SELECT CASE");
+    const accepted = new Set(equivalentTriggerDefinitions(parenthesized));
+
+    expect(accepted).toContain(normalizeSqlDefinition(parenthesized));
+    expect(accepted).toContain(normalizeSqlDefinition(legacyBareCase));
+    expect(accepted).not.toContain(normalizeSqlDefinition(hybridWrapper));
+    expect(accepted).not.toContain(normalizeSqlDefinition(changedGuard));
   });
 });

--- a/worker/migrations/0042_channel_decisions.sql
+++ b/worker/migrations/0042_channel_decisions.sql
@@ -35,7 +35,7 @@ CREATE TABLE channel_decision_heads (
 CREATE TRIGGER channel_decision_heads_validate_insert
 BEFORE INSERT ON channel_decision_heads
 BEGIN
-  SELECT CASE
+  SELECT (CASE
     WHEN NOT EXISTS (
       SELECT 1
         FROM channel_decisions d
@@ -44,13 +44,13 @@ BEGIN
          AND d.topic COLLATE NOCASE = NEW.topic COLLATE NOCASE
     )
     THEN RAISE(ABORT, 'decision head must match decision channel and topic')
-  END;
+  END);
 END;
 
 CREATE TRIGGER channel_decision_heads_validate_update
 BEFORE UPDATE ON channel_decision_heads
 BEGIN
-  SELECT CASE
+  SELECT (CASE
     WHEN NOT EXISTS (
       SELECT 1
         FROM channel_decisions d
@@ -59,8 +59,8 @@ BEGIN
          AND d.topic COLLATE NOCASE = NEW.topic COLLATE NOCASE
     )
     THEN RAISE(ABORT, 'decision head must match decision channel and topic')
-  END;
-  SELECT CASE
+  END);
+  SELECT (CASE
     WHEN NEW.decision_id != OLD.decision_id AND NOT EXISTS (
       SELECT 1
         FROM channel_decisions d
@@ -68,7 +68,7 @@ BEGIN
          AND d.supersedes_id = OLD.decision_id
     )
     THEN RAISE(ABORT, 'decision head must advance through explicit supersedes lineage')
-  END;
+  END);
 END;
 
 CREATE TRIGGER channel_decision_heads_reject_delete
@@ -98,31 +98,31 @@ END;
 CREATE TRIGGER channel_decisions_validate_insert
 BEFORE INSERT ON channel_decisions
 BEGIN
-  SELECT CASE
+  SELECT (CASE
     WHEN EXISTS (
       SELECT 1 FROM channels c
        WHERE c.slug = NEW.channel_slug
          AND c.archived_at IS NOT NULL
     )
     THEN RAISE(ABORT, 'channel is archived')
-  END;
-  SELECT CASE
+  END);
+  SELECT (CASE
     WHEN NEW.supersedes_id IS NULL AND EXISTS (
       SELECT 1 FROM channel_decision_heads h
        WHERE h.channel_slug = NEW.channel_slug
          AND h.topic = NEW.topic COLLATE NOCASE
     )
     THEN RAISE(ABORT, 'active decision already exists for topic')
-  END;
-  SELECT CASE
+  END);
+  SELECT (CASE
     -- Keep this literal aligned with shared/src/protocol.ts CHANNEL_DECISION_ACTIVE_MAX.
     WHEN NEW.supersedes_id IS NULL AND (
       SELECT COUNT(*) FROM channel_decision_heads h
        WHERE h.channel_slug = NEW.channel_slug
     ) >= 100
     THEN RAISE(ABORT, 'channel active decision limit reached')
-  END;
-  SELECT CASE
+  END);
+  SELECT (CASE
     WHEN NEW.supersedes_id IS NOT NULL AND NOT EXISTS (
       SELECT 1
         FROM channel_decision_heads h
@@ -133,5 +133,5 @@ BEGIN
          AND old.channel_slug = NEW.channel_slug
     )
     THEN RAISE(ABORT, 'supersedes_id must reference the active decision for the same topic')
-  END;
+  END);
 END;

--- a/worker/scripts/schema-contract.d.mts
+++ b/worker/scripts/schema-contract.d.mts
@@ -1,3 +1,4 @@
 export function extractTriggerDefinition(source: string, name: string): string | null;
 export function extractIndexDefinition(source: string, name: string): string | null;
 export function normalizeSqlDefinition(sql: unknown): string;
+export function equivalentTriggerDefinitions(sql: unknown): string[];

--- a/worker/scripts/schema-contract.mjs
+++ b/worker/scripts/schema-contract.mjs
@@ -31,3 +31,16 @@ export function normalizeSqlDefinition(sql) {
     .trim()
     .toLowerCase();
 }
+
+export function equivalentTriggerDefinitions(sql) {
+  const normalized = normalizeSqlDefinition(sql);
+  if (normalized.length === 0) return [];
+
+  const legacyBareCase = normalized.replace(
+    /\bselect\s+\(\s*case\b(.*?)\bend\s*\)\s*;/g,
+    "select case$1end;",
+  );
+  return legacyBareCase === normalized
+    ? [normalized]
+    : [normalized, legacyBareCase];
+}

--- a/worker/scripts/verify-remote-schema.mjs
+++ b/worker/scripts/verify-remote-schema.mjs
@@ -1,6 +1,7 @@
 import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import {
+  equivalentTriggerDefinitions,
   extractIndexDefinition,
   extractTriggerDefinition,
   normalizeSqlDefinition,
@@ -254,7 +255,7 @@ const requiredTriggerDefinitions = Object.fromEntries(
     if (definition === undefined) {
       throw new Error(`could not load expected trigger definition for ${name}`);
     }
-    return [name, normalizeSqlDefinition(definition)];
+    return [name, new Set(equivalentTriggerDefinitions(definition))];
   }),
 );
 
@@ -416,7 +417,7 @@ for (const [table, triggers] of Object.entries(requiredTriggers)) {
   }
   for (const trigger of triggers) {
     const actual = normalizeSqlDefinition(byName.get(trigger));
-    if (actual !== requiredTriggerDefinitions[trigger]) {
+    if (!requiredTriggerDefinitions[trigger].has(actual)) {
       throw new Error(`${trigger} definition does not match the shipped migration`);
     }
   }


### PR DESCRIPTION
## 改动说明

v0.2.150 的 Worker 发布在 prod 应用 `0042_channel_decisions.sql` 时被 D1 远端 `/query` 误分句，报 `incomplete input: SQLITE_ERROR`（[失败流水线](https://github.com/leeguooooo/AgentParty/actions/runs/30113722571)）。根因与 Cloudflare workers-sdk [#4727](https://github.com/cloudflare/workers-sdk/issues/4727) 一致：Trigger 内未括号化的 `CASE ... END` 被误判成 Trigger 外层结束。

本 PR 保留全部数据库边界能力，只做兼容修复：

- 将 0042 的 7 个 `SELECT CASE ... END` 改为 `SELECT (CASE ... END)`；条件、错误信息、Trigger 与迁移顺序均不变。
- 增加静态回归门禁，要求恰有 7 个括号化 CASE 与 7 个对应 `THEN RAISE(...)`，且不允许裸 `SELECT CASE` 回归。
- 为已经成功记账旧 0042 的自托管实例保留升级路径：schema verifier 只把 shipped 全括号定义与严格派生的全 bare-CASE 定义视为等价；hybrid wrapper、条件、RAISE 文本及其他 SQL 漂移仍失败关闭。
- 不移除 Trigger，也不改成应用层补偿，继续保留 append-only、归档拒写、head 线性推进、active 上限等 DB-boundary 不变量。

发布事故后的只读状态确认：prod 已记账 0041，0042/0043 未记账且无 0042 残留对象；xdream 尚未执行 0041/0042/0043。因此重试会从各自未应用迁移继续，不涉及修复已记账迁移。

## 验证

- `bun run check`：通过（含 CLI、shared、Web 1185/1185、Worker 758/758、TypeScript 与 Web production build）。
- 兼容层变更后 `check:scripts`：215/215；迁移与 schema contract 定向测试：16/16；scripts TypeScript：通过。
- 决策定向测试：36/36。
- 隔离远端 D1 实证：0001–0043 全部成功，0042 明确应用，迁移账本中 0042=1，6 个决策 Trigger 均存在。
- 对抗性实证：向归档频道插入决策被精确拒绝为 `channel is archived`，拒绝行计数为 0。
- 旧 0042 已记账兼容复现：3 个 CASE Trigger 的旧定义全部被接受；hybrid/条件/错误文本篡改全部被拒绝。
- 临时远端 D1 数据库已删除，并确认无残留。

## 合并前检查（review-ack 强制闸——不留结论合不了）

> main 分支保护要求：合并前必须读过当前 head 的 pr-agent / CodeRabbit review 并留下 `review-ack:` 结论。

- [x] 我已读 pr-agent / CodeRabbit 的当前 head review，真问题已处理、误报已判明
- [x] 本地门禁通过（tsc / 测试 / build）
- [x] 涉及安全/鉴权/数据的改动已做对抗性验证（隔离远端 D1 迁移 + Trigger 实际拒写 + 旧 schema fail-closed 兼容）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复远程 D1 数据库对触发器中 `CASE` 表达式语法的兼容性问题。
  * 远程 schema 验证现可识别等价的触发器定义，降低因 SQL 表达形式差异导致的验证失败。

* **Tests**
  * 新增迁移脚本兼容性检查，确保相关触发器使用受支持的 SQL 写法。
  * 扩展远程 schema 合同测试，覆盖标准及兼容格式。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
