### PR TITLE
fix(cli): 修复 Codex 会话桥接背压与事件结算

### DIFF
--- a/cli/src/codex-app-server-bridge.ts
+++ b/cli/src/codex-app-server-bridge.ts
@@ -20,6 +20,7 @@ import {
   type ServerFrame,
 } from "@agentparty/shared";
 import type { ServerWebSocket } from "bun";
+import { AsyncLocalStorage } from "node:async_hooks";
 import type { ChildProcessWithoutNullStreams } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { chmodSync } from "node:fs";
@@ -90,6 +91,10 @@ export class CodexRpcDisconnectedError extends Error {
 }
 
 interface PendingRpc {
+  fromMessageDispatch: boolean;
+  responseReceived: boolean;
+  applyStarted: boolean;
+  applyResponse?: (result: unknown) => void | Promise<void>;
   resolve: (result: unknown) => void;
   reject: (error: unknown) => void;
 }
@@ -228,6 +233,9 @@ export class CodexRpcClient {
   private readonly messageListeners = new Set<MessageListener>();
   private readonly reconnectListeners = new Set<ReconnectListener>();
   private readonly disconnectListeners = new Set<DisconnectListener>();
+  private readonly messageDispatchContext = new AsyncLocalStorage<boolean>();
+  private messageDispatchGeneration = 0;
+  private messageDispatchTail: Promise<void> = Promise.resolve();
   private lastDisconnectedGeneration = 0;
   private readonly log: (line: string) => void;
 
@@ -277,10 +285,21 @@ export class CodexRpcClient {
     child.stdin.write(`${JSON.stringify(message)}\n`);
   }
 
-  private rawRequest(method: string, params?: unknown): Promise<unknown> {
+  private rawRequest(
+    method: string,
+    params?: unknown,
+    applyResponse?: (result: unknown) => void | Promise<void>,
+  ): Promise<unknown> {
     const id = `agentparty:${this.generation}:${this.requestSeq++}`;
     return new Promise((resolve, reject) => {
-      this.pending.set(rpcIdKey(id), { resolve, reject });
+      this.pending.set(rpcIdKey(id), {
+        fromMessageDispatch: this.messageDispatchContext.getStore() === true,
+        responseReceived: false,
+        applyStarted: false,
+        ...(applyResponse === undefined ? {} : { applyResponse }),
+        resolve,
+        reject,
+      });
       try {
         this.write({ id, method, ...(params === undefined ? {} : { params }) });
       } catch (error) {
@@ -290,9 +309,51 @@ export class CodexRpcClient {
     });
   }
 
-  private rejectPending(error: Error): void {
-    for (const pending of this.pending.values()) pending.reject(error);
-    this.pending.clear();
+  private rejectPending(
+    error: Error,
+    options: { preserveApplyingResponses?: boolean } = {},
+  ): void {
+    for (const [key, pending] of this.pending) {
+      if (
+        options.preserveApplyingResponses === true &&
+        pending.responseReceived &&
+        pending.applyStarted &&
+        pending.applyResponse !== undefined
+      ) {
+        continue;
+      }
+      this.pending.delete(key);
+      pending.reject(error);
+    }
+  }
+
+  private enqueueMessage(
+    message: JsonRpcRequest | JsonRpcNotification,
+    generation: number,
+  ): void {
+    // Preserve app-server wire order for stateful notifications and requests.
+    // Responses intentionally bypass this lane in handleLine so a listener can
+    // await its own RPC without deadlocking the dispatch queue.
+    const listeners = [...this.messageListeners];
+    const dispatch = async (): Promise<void> => {
+      if (
+        generation !== this.generation ||
+        generation !== this.messageDispatchGeneration
+      ) {
+        return;
+      }
+      await Promise.all(listeners.map(async (listener) => {
+        try {
+          await this.messageDispatchContext.run(
+            true,
+            async () => await listener(message),
+          );
+        } catch (error) {
+          this.log(`codex-bridge: JSON-RPC listener failed: ${errorDetail(error)}`);
+        }
+      }));
+    };
+    this.messageDispatchTail = this.messageDispatchTail.then(dispatch, dispatch);
   }
 
   private handleLine(line: string, generation: number): void {
@@ -312,21 +373,65 @@ export class CodexRpcClient {
       return;
     }
     if (isRpcResponse(message)) {
-      const pending = this.pending.get(rpcIdKey(message.id));
-      if (!pending) return;
-      this.pending.delete(rpcIdKey(message.id));
-      if (message.error) {
-        pending.reject(new CodexRpcError(message.error.code, message.error.message, message.error.data));
+      const key = rpcIdKey(message.id);
+      const pending = this.pending.get(key);
+      if (!pending || pending.responseReceived) return;
+      pending.responseReceived = true;
+      const settle = async (): Promise<void> => {
+        if (this.pending.get(key) !== pending) return;
+        const generationIsCurrent = (): boolean =>
+          generation === this.generation &&
+          generation === this.messageDispatchGeneration &&
+          this.child !== null &&
+          !this.child.stdin.destroyed &&
+          this.child.stdin.writable;
+        if (!generationIsCurrent()) {
+          this.pending.delete(key);
+          pending.reject(new CodexRpcDisconnectedError());
+          return;
+        }
+        if (message.error) {
+          this.pending.delete(key);
+          pending.reject(
+            new CodexRpcError(message.error.code, message.error.message, message.error.data),
+          );
+          return;
+        }
+        try {
+          if (pending.applyResponse) {
+            pending.applyStarted = true;
+            await this.messageDispatchContext.run(
+              true,
+              async () => await pending.applyResponse!(message.result),
+            );
+          }
+          if (this.pending.get(key) !== pending) return;
+          this.pending.delete(key);
+          if (generationIsCurrent()) {
+            pending.resolve(message.result);
+          } else {
+            pending.reject(new CodexRpcDisconnectedError());
+          }
+        } catch (error) {
+          if (this.pending.get(key) !== pending) return;
+          this.pending.delete(key);
+          pending.reject(
+            generationIsCurrent() ? error : new CodexRpcDisconnectedError(),
+          );
+        }
+      };
+      if (pending.applyResponse && !pending.fromMessageDispatch) {
+        // Installing an authoritative thread snapshot is itself a wire-order
+        // dispatch barrier: preceding notifications finish first, and later
+        // notifications cannot run until the snapshot has been applied.
+        const apply = async (): Promise<void> => await settle();
+        this.messageDispatchTail = this.messageDispatchTail.then(apply, apply);
       } else {
-        pending.resolve(message.result);
+        void settle();
       }
       return;
     }
-    for (const listener of this.messageListeners) {
-      void Promise.resolve(listener(message)).catch((error) => {
-        this.log(`codex-bridge: JSON-RPC listener failed: ${errorDetail(error)}`);
-      });
-    }
+    this.enqueueMessage(message, generation);
   }
 
   private scheduleReconnect(): void {
@@ -348,11 +453,15 @@ export class CodexRpcClient {
     if (generation !== this.generation) return;
     if (this.lastDisconnectedGeneration === generation) return;
     this.lastDisconnectedGeneration = generation;
+    this.messageDispatchGeneration = 0;
     this.reader?.close();
     this.reader = null;
     this.child = null;
     this.initializeValue = null;
-    this.rejectPending(new CodexRpcDisconnectedError());
+    this.rejectPending(
+      new CodexRpcDisconnectedError(),
+      { preserveApplyingResponses: true },
+    );
     if (!this.closing) {
       for (const listener of this.disconnectListeners) {
         try {
@@ -369,6 +478,7 @@ export class CodexRpcClient {
   private async connectOnce(): Promise<void> {
     if (this.closing) throw new CodexRpcDisconnectedError("Codex RPC client is closed");
     const generation = ++this.generation;
+    this.messageDispatchGeneration = generation;
     const child = this.options.spawnProxy();
     this.child = child;
     this.reader = createInterface({ input: child.stdout });
@@ -443,6 +553,27 @@ export class CodexRpcClient {
     return this.rawRequest(method, params);
   }
 
+  requestConnectedApplied(
+    method: string,
+    params: unknown,
+    expectedGeneration: number | undefined,
+    applyResponse: (result: unknown) => void | Promise<void>,
+  ): Promise<unknown> {
+    if (
+      !this.child ||
+      this.initializeValue === null ||
+      (expectedGeneration !== undefined && expectedGeneration !== this.generation)
+    ) {
+      return Promise.reject(new CodexRpcDisconnectedError(
+        expectedGeneration !== undefined && expectedGeneration !== this.generation
+          ? `Codex app-server generation changed before ${method} request write`
+          : "Codex app-server control connection closed before request write",
+        { requestWritten: false },
+      ));
+    }
+    return this.rawRequest(method, params, applyResponse);
+  }
+
   async notify(method: string, params?: unknown): Promise<void> {
     await this.start();
     this.write({ method, ...(params === undefined ? {} : { params }) });
@@ -467,6 +598,7 @@ export class CodexRpcClient {
 
   close(): void {
     this.closing = true;
+    this.messageDispatchGeneration = 0;
     if (this.reconnectTimer) clearTimeout(this.reconnectTimer);
     this.reconnectTimer = null;
     this.reader?.close();
@@ -488,6 +620,12 @@ export interface CodexRpcPeer {
     method: string,
     params?: unknown,
     expectedGeneration?: number,
+  ): Promise<unknown>;
+  requestConnectedApplied?(
+    method: string,
+    params: unknown,
+    expectedGeneration: number | undefined,
+    applyResponse: (result: unknown) => void | Promise<void>,
   ): Promise<unknown>;
   notify(method: string, params?: unknown): Promise<void>;
   notifyConnected?(method: string, params?: unknown): void | Promise<void>;
@@ -513,6 +651,15 @@ export interface CodexThread {
   status: { type: "idle" | "active" | "notLoaded" | "systemError" };
   turns: CodexTurn[];
 }
+
+interface AccumulatedAgentMessage {
+  item: CodexThreadItem;
+  text: string;
+  completed: boolean;
+}
+
+const MAX_RETAINED_COMPLETED_TURNS = 256;
+const MAX_RETAINED_COMPLETED_TURN_BYTES = 16 * 1024 * 1024;
 
 type DispatchListener = (input: CodexBridgeInput, dispatch: CodexDispatch) => void | Promise<void>;
 type CompletedTurnListener = (turn: CodexTurn) => void | Promise<void>;
@@ -705,6 +852,8 @@ export class CodexSessionController {
   private readonly unresolvedUnknownListeners = new Set<UnresolvedUnknownListener>();
   private readonly turnByClientId = new Map<string, string>();
   private readonly turns = new Map<string, CodexTurn>();
+  private readonly agentMessagesByTurn =
+    new Map<string, Map<string, AccumulatedAgentMessage>>();
   private readonly log: (line: string) => void;
   private beforeSessionFlushTimer: ReturnType<typeof setTimeout> | null = null;
   private initialThreadStart: InitialThreadStartAttempt | null = null;
@@ -879,12 +1028,277 @@ export class CodexSessionController {
   }
 
   private emitCompleted(turn: CodexTurn): void {
-    this.turns.set(turn.id, turn);
+    const retainedTurn = this.storeTurn(turn);
     for (const listener of this.completedListeners) {
-      void Promise.resolve(listener(turn)).catch((error) => {
+      void Promise.resolve(listener(retainedTurn)).catch((error) => {
         this.log(`codex-bridge: completion listener failed: ${errorDetail(error)}`);
       });
     }
+  }
+
+  private retainedTurnItem(item: CodexThreadItem): CodexThreadItem | null {
+    const id = typeof item.id === "string" ? item.id : null;
+    if (item.type === "userMessage") {
+      const clientId =
+        typeof item.clientId === "string" || item.clientId === null
+          ? item.clientId
+          : undefined;
+      const bootstrapInput =
+        this.bootstrapRecovery?.disposition === "unknown"
+          ? this.bootstrapRecovery.initialInput
+          : undefined;
+      return {
+        type: "userMessage",
+        ...(id === null ? {} : { id }),
+        ...(clientId === undefined ? {} : { clientId }),
+        ...(clientId === null &&
+            bootstrapInput !== undefined &&
+            sameJsonValue(item.content, bootstrapInput)
+          ? { content: item.content }
+          : {}),
+      };
+    }
+    if (item.type === "agentMessage") {
+      return {
+        type: "agentMessage",
+        ...(id === null ? {} : { id }),
+        ...(typeof item.text === "string" ? { text: item.text } : {}),
+        ...(item.phase === "commentary" || item.phase === "final_answer"
+          ? { phase: item.phase }
+          : {}),
+      };
+    }
+    return null;
+  }
+
+  private retainedTurn(turn: CodexTurn): CodexTurn {
+    return {
+      id: turn.id,
+      status: turn.status,
+      ...(turn.items === undefined
+        ? {}
+        : {
+          items: turn.items.flatMap((item) => {
+            const retained = this.retainedTurnItem(item);
+            return retained === null ? [] : [retained];
+          }),
+        }),
+    };
+  }
+
+  private retainedTurnBytes(turn: CodexTurn): number {
+    try {
+      return Buffer.byteLength(JSON.stringify(turn));
+    } catch {
+      return MAX_RETAINED_COMPLETED_TURN_BYTES + 1;
+    }
+  }
+
+  private storeTurn(turn: CodexTurn): CodexTurn {
+    const retained = this.retainedTurn(turn);
+    this.turns.set(retained.id, retained);
+    this.trimRetainedTurns();
+    return retained;
+  }
+
+  private trimRetainedTurns(): void {
+    const completed = [...this.turns.entries()]
+      .filter(([, turn]) => turn.status !== "inProgress")
+      .map(([turnId, turn]) => ({
+        turnId,
+        turn,
+        bytes: this.retainedTurnBytes(turn),
+        bootstrapProof: (turn.items ?? []).some((item) =>
+          item.type === "userMessage" &&
+          item.clientId === null &&
+          Object.prototype.hasOwnProperty.call(item, "content")
+        ),
+      }));
+    let bytes = completed.reduce((total, entry) => total + entry.bytes, 0);
+    let count = completed.length;
+    while (
+      count > MAX_RETAINED_COMPLETED_TURNS ||
+      bytes > MAX_RETAINED_COMPLETED_TURN_BYTES
+    ) {
+      const index = completed.findIndex((entry) => !entry.bootstrapProof);
+      if (index < 0) break;
+      const [evicted] = completed.splice(index, 1);
+      if (!evicted) break;
+      this.turns.delete(evicted.turnId);
+      for (const [clientId, turnId] of this.turnByClientId) {
+        if (turnId === evicted.turnId) {
+          this.turnByClientId.delete(clientId);
+        }
+      }
+      bytes -= evicted.bytes;
+      count -= 1;
+    }
+  }
+
+  private observeAgentMessageItem(
+    turnId: string,
+    item: CodexThreadItem,
+    completed: boolean,
+  ): void {
+    if (
+      item.type !== "agentMessage" ||
+      typeof item.id !== "string"
+    ) {
+      return;
+    }
+    let messages = this.agentMessagesByTurn.get(turnId);
+    if (!messages) {
+      messages = new Map();
+      this.agentMessagesByTurn.set(turnId, messages);
+    }
+    const existing = messages.get(item.id);
+    const itemText = typeof item.text === "string" ? item.text : "";
+    const text =
+      completed
+        ? itemText
+        : existing?.text.length
+          ? existing.text
+          : itemText;
+    const retainedItem = this.retainedTurnItem(item);
+    if (retainedItem === null) return;
+    messages.set(item.id, {
+      item: {
+        ...(existing?.item ?? {}),
+        ...retainedItem,
+        type: "agentMessage",
+        id: item.id,
+        text,
+      },
+      text,
+      completed: completed || existing?.completed === true,
+    });
+  }
+
+  private observeAgentMessageDelta(params: Record<string, unknown>): void {
+    if (
+      typeof params.turnId !== "string" ||
+      typeof params.itemId !== "string" ||
+      typeof params.delta !== "string"
+    ) {
+      return;
+    }
+    let messages = this.agentMessagesByTurn.get(params.turnId);
+    if (!messages) {
+      messages = new Map();
+      this.agentMessagesByTurn.set(params.turnId, messages);
+    }
+    const existing = messages.get(params.itemId);
+    // item/completed is authoritative. Ignore a duplicate/late delta instead
+    // of appending it after the final item text.
+    if (existing?.completed) return;
+    const text = `${existing?.text ?? ""}${params.delta}`;
+    messages.set(params.itemId, {
+      item: {
+        ...(existing?.item ?? {}),
+        type: "agentMessage",
+        id: params.itemId,
+        text,
+      },
+      text,
+      completed: false,
+    });
+  }
+
+  private observeTurnItem(turnId: string, item: CodexThreadItem): void {
+    const retainedItem = this.retainedTurnItem(item);
+    if (retainedItem === null) return;
+    const turn = this.turns.get(turnId) ?? {
+      id: turnId,
+      status: "inProgress",
+      items: [],
+    } satisfies CodexTurn;
+    const items = [...(turn.items ?? [])];
+    const itemId = typeof item.id === "string" ? item.id : null;
+    const existingIndex = itemId === null
+      ? -1
+      : items.findIndex((candidate) => candidate.id === itemId);
+    if (existingIndex >= 0) {
+      items[existingIndex] = {
+        ...items[existingIndex],
+        ...retainedItem,
+      };
+    } else {
+      items.push(retainedItem);
+    }
+    this.storeTurn({ ...turn, items });
+  }
+
+  private observeTurnAgentMessages(turn: CodexTurn, completed: boolean): void {
+    for (const item of turn.items ?? []) {
+      this.observeAgentMessageItem(turn.id, item, completed);
+    }
+  }
+
+  private completedTurnWithAgentText(
+    turn: CodexTurn,
+    previous = this.turns.get(turn.id),
+  ): CodexTurn {
+    const accumulated = this.agentMessagesByTurn.get(turn.id);
+    const canonicalItems = (previous?.items ?? []).filter((item) => {
+      if (item.type !== "agentMessage" || previous?.status !== "inProgress") {
+        return true;
+      }
+      return typeof item.id === "string" &&
+        accumulated?.get(item.id)?.completed === true;
+    });
+    for (const item of turn.items ?? []) {
+      const itemId = typeof item.id === "string" ? item.id : null;
+      const existingIndex = itemId === null
+        ? -1
+        : canonicalItems.findIndex((candidate) => candidate.id === itemId);
+      if (existingIndex >= 0) {
+        canonicalItems[existingIndex] = {
+          ...canonicalItems[existingIndex],
+          ...item,
+        };
+      } else {
+        canonicalItems.push(item);
+      }
+    }
+    const canonicalTurn = canonicalItems.length > 0
+      ? { ...turn, items: canonicalItems }
+      : turn;
+    const snapshotAgents = agentMessageItems(canonicalTurn);
+    if (
+      snapshotAgents.some((item) => item.phase !== "commentary")
+    ) {
+      return canonicalTurn;
+    }
+    const fallback = finalAgentItem(
+      accumulated
+        ? [...accumulated.values()]
+          .filter(({ completed }) => completed)
+          .map(({ item, text }) => ({ ...item, text }))
+        : agentMessageItems(previous),
+    );
+    if (!fallback) return canonicalTurn;
+
+    const items = [...(canonicalTurn.items ?? [])];
+    const fallbackId = typeof fallback.id === "string" ? fallback.id : null;
+    const existingIndex = fallbackId === null
+      ? -1
+      : items.findIndex((item) =>
+        item.type === "agentMessage" && item.id === fallbackId
+      );
+    if (existingIndex >= 0) {
+      const existing = items[existingIndex]!;
+      if (typeof existing.text === "string" && existing.text.trim() !== "") {
+        return canonicalTurn;
+      }
+      items[existingIndex] = {
+        ...fallback,
+        ...existing,
+        text: fallback.text,
+      };
+    } else {
+      items.push(fallback);
+    }
+    return { ...canonicalTurn, items };
   }
 
   private serializeSession<T>(operation: () => Promise<T>): Promise<T> {
@@ -1154,6 +1568,27 @@ export class CodexSessionController {
     );
   }
 
+  private async requestConnectedApplied(
+    method: string,
+    params: unknown,
+    applyResponse: (result: unknown) => void | Promise<void>,
+    expectedGeneration?: number,
+  ): Promise<unknown> {
+    const generation =
+      expectedGeneration ?? this.requestGenerationFence ?? undefined;
+    if (this.rpc.requestConnectedApplied) {
+      return await this.rpc.requestConnectedApplied(
+        method,
+        params,
+        generation,
+        applyResponse,
+      );
+    }
+    const result = await this.rpc.requestConnected(method, params, generation);
+    await applyResponse(result);
+    return result;
+  }
+
   private async notifyConnected(method: string, params?: unknown): Promise<void> {
     if (this.rpc.notifyConnected) {
       await this.rpc.notifyConnected(method, params);
@@ -1182,6 +1617,7 @@ export class CodexSessionController {
     // leave a removed source clientId cached and authorize owner_answer.
     this.turns.clear();
     this.turnByClientId.clear();
+    this.agentMessagesByTurn.clear();
     this.threadId = thread.id;
     this.noThreadRecovery = null;
     if (replacing) {
@@ -1199,15 +1635,22 @@ export class CodexSessionController {
     await this.arbiter!.observeResume({ thread }, options);
 
     for (const turn of thread.turns) {
-      this.turns.set(turn.id, turn);
-      for (const clientId of clientIds(turn)) {
+      this.observeTurnAgentMessages(turn, turn.status !== "inProgress");
+      const observedTurn = turn.status === "inProgress"
+        ? turn
+        : this.completedTurnWithAgentText(turn);
+      const retainedTurn = this.storeTurn(observedTurn);
+      for (const clientId of clientIds(retainedTurn)) {
         this.turnByClientId.set(clientId, turn.id);
         this.emitDispatch(
           { text: "recovered AgentParty input", clientUserMessageId: clientId },
           { kind: "duplicate", turnId: turn.id },
         );
       }
-      if (turn.status !== "inProgress") this.emitCompleted(turn);
+      if (observedTurn.status !== "inProgress") {
+        this.emitCompleted(observedTurn);
+        this.agentMessagesByTurn.delete(observedTurn.id);
+      }
     }
 
     const bootstrapPromptPending =
@@ -1365,21 +1808,26 @@ export class CodexSessionController {
         this.throwIfInitialThreadStartCancelled(attempt);
         attempt.phase = "writing";
         try {
-          const result = await this.requestConnected("thread/start", params);
-          const thread = responseThread(result);
-          if (thread === null) {
-            throw new Error("thread/start returned no valid thread");
-          }
-          await this.attachThread(thread, {
-            deferQueuedInputs: this.options.expectBootstrapPrompt === true,
-          });
-          this.bootstrapThreadId = this.threadId;
-          this.bootstrapRecovery = {
-            disposition: "restart_thread_with_prompt",
-          };
-          if (this.options.expectBootstrapPrompt !== true) {
-            await this.flushBeforeSessionSafely();
-          }
+          const result = await this.requestConnectedApplied(
+            "thread/start",
+            params,
+            async (response) => {
+              const thread = responseThread(response);
+              if (thread === null) {
+                throw new Error("thread/start returned no valid thread");
+              }
+              await this.attachThread(thread, {
+                deferQueuedInputs: this.options.expectBootstrapPrompt === true,
+              });
+              this.bootstrapThreadId = this.threadId;
+              this.bootstrapRecovery = {
+                disposition: "restart_thread_with_prompt",
+              };
+              if (this.options.expectBootstrapPrompt !== true) {
+                await this.flushBeforeSessionSafely();
+              }
+            },
+          );
           attempt.outcome = "resume";
           return result;
         } catch (error) {
@@ -1548,9 +1996,11 @@ export class CodexSessionController {
             }
           }
         }
-        const result = await this.requestConnected(method, params);
-        await this.routeThreadResponse(method, result, record);
-        return result;
+        return await this.requestConnectedApplied(
+          method,
+          params,
+          async (result) => await this.routeThreadResponse(method, result, record),
+        );
       });
     }
 
@@ -1571,11 +2021,14 @@ export class CodexSessionController {
             targetThreadId: requestThreadId,
           });
         }
-        const result = await this.requestConnected(method, params);
         if (method === "thread/rollback") {
-          await this.routeThreadResponse(method, result, record);
+          return await this.requestConnectedApplied(
+            method,
+            params,
+            async (result) => await this.routeThreadResponse(method, result, record),
+          );
         }
-        return result;
+        return await this.requestConnected(method, params);
       });
     }
     if (INTERACTIVE_MUTATIONS.has(method as CodexInteractiveMutation)) {
@@ -1608,12 +2061,17 @@ export class CodexSessionController {
       }
     }
 
-    await this.ensureBackendReady();
-    const result = await this.requestConnected(method, params);
     if ((method === "thread/read" || method === "thread/resume") && requestThreadId === this.threadId) {
-      await this.routeThreadResponse(method, result, record);
+      return await this.withReadySession(async () =>
+        await this.requestConnectedApplied(
+          method,
+          params,
+          async (result) => await this.routeThreadResponse(method, result, record),
+        )
+      );
     }
-    return result;
+    await this.ensureBackendReady();
+    return await this.requestConnected(method, params);
   }
 
   async notify(method: string, params?: unknown): Promise<void> {
@@ -1636,35 +2094,77 @@ export class CodexSessionController {
         if (message.method === "turn/started") {
           const turn = asTurn(params.turn);
           if (turn) {
-            this.turns.set(turn.id, turn);
-            for (const clientId of clientIds(turn)) {
+            const previous = this.turns.get(turn.id);
+            const observedTurn =
+              (turn.items?.length ?? 0) === 0 && (previous?.items?.length ?? 0) > 0
+                ? { ...turn, items: [...previous!.items!] }
+                : turn;
+            this.observeTurnAgentMessages(observedTurn, false);
+            const retainedTurn = this.storeTurn(observedTurn);
+            for (const clientId of clientIds(retainedTurn)) {
               this.turnByClientId.set(clientId, turn.id);
               this.emitDispatch(
                 { text: "observed AgentParty input", clientUserMessageId: clientId },
                 { kind: "duplicate", turnId: turn.id },
               );
             }
-            await this.arbiter.observeTurnStarted(turn.id, clientIds(turn));
+            await this.arbiter.observeTurnStarted(
+              observedTurn.id,
+              clientIds(observedTurn),
+            );
           }
         } else if (message.method === "turn/completed") {
           const turn = asTurn(params.turn);
           if (turn) {
-            for (const clientId of clientIds(turn)) this.turnByClientId.set(clientId, turn.id);
-            this.emitCompleted(turn);
-            await this.arbiter.observeTurnCompleted(turn.id);
+            this.observeTurnAgentMessages(turn, true);
+            const completedTurn = this.completedTurnWithAgentText(turn);
+            for (const clientId of clientIds(completedTurn)) {
+              this.turnByClientId.set(clientId, completedTurn.id);
+            }
+            this.emitCompleted(completedTurn);
+            this.agentMessagesByTurn.delete(completedTurn.id);
+            await this.arbiter.observeTurnCompleted(completedTurn.id);
           }
+        } else if (
+          message.method === "item/agentMessage/delta"
+        ) {
+          this.observeAgentMessageDelta(params);
         } else if (
           (message.method === "item/started" || message.method === "item/completed") &&
           typeof params.turnId === "string" &&
           isObject(params.item) &&
-          typeof params.item.id === "string" &&
-          params.item.type === "commandExecution" &&
-          params.item.source === "userShell"
+          typeof params.item.id === "string"
         ) {
-          if (message.method === "item/started") {
-            await this.arbiter.observeUserShellStarted(params.turnId, params.item.id);
-          } else {
-            await this.arbiter.observeUserShellCompleted(params.turnId, params.item.id);
+          const item = asThreadItem(params.item)[0];
+          if (item) this.observeTurnItem(params.turnId, item);
+          if (item?.type === "userMessage" && typeof item.clientId === "string") {
+            const knownTurnId = this.turnByClientId.get(item.clientId);
+            this.turnByClientId.set(item.clientId, params.turnId);
+            if (knownTurnId !== params.turnId) {
+              this.emitDispatch(
+                {
+                  text: "observed AgentParty input",
+                  clientUserMessageId: item.clientId,
+                },
+                { kind: "duplicate", turnId: params.turnId },
+              );
+              await this.arbiter.observeTurnStarted(params.turnId, [item.clientId]);
+            }
+          } else if (item?.type === "agentMessage") {
+            this.observeAgentMessageItem(
+              params.turnId,
+              item,
+              message.method === "item/completed",
+            );
+          } else if (
+            item?.type === "commandExecution" &&
+            item.source === "userShell"
+          ) {
+            if (message.method === "item/started") {
+              await this.arbiter.observeUserShellStarted(params.turnId, params.item.id);
+            } else {
+              await this.arbiter.observeUserShellCompleted(params.turnId, params.item.id);
+            }
           }
         } else if (
           message.method === "thread/status/changed" &&
@@ -1761,19 +2261,22 @@ export class CodexSessionController {
         );
         this.assertRecoveryCurrent(state);
         requireRecoveryThreadIdentity(resumeResult, threadId, "thread/resume");
-        const result = await this.requestConnected(
+        await this.requestConnectedApplied(
           "thread/read",
           { threadId, includeTurns: true },
+          async (result) => {
+            this.assertRecoveryCurrent(state);
+            const restoredThread = requireRecoveryThreadSnapshot(result, threadId);
+            await this.attachThread(restoredThread, {
+              backendRestarted: true,
+              // A bootstrap prompt that is about to be replayed (or whose outcome
+              // is still unknown) always retains priority over pre-attach delivery.
+              deferQueuedInputs: this.bootstrapThreadId === threadId,
+            });
+            this.assertRecoveryCurrent(state);
+          },
           state.generation,
         );
-        this.assertRecoveryCurrent(state);
-        const restoredThread = requireRecoveryThreadSnapshot(result, threadId);
-        await this.attachThread(restoredThread, {
-          backendRestarted: true,
-          // A bootstrap prompt that is about to be replayed (or whose outcome
-          // is still unknown) always retains priority over pre-attach delivery.
-          deferQueuedInputs: this.bootstrapThreadId === threadId,
-        });
         this.assertRecoveryCurrent(state);
 
         let frontendEvent: CodexFrontendRecovery = {
@@ -1789,6 +2292,10 @@ export class CodexSessionController {
             if (this.recoveredBootstrapInput(bootstrap.initialInput)) {
               this.bootstrapThreadId = null;
               this.bootstrapRecovery = null;
+              for (const turn of [...this.turns.values()]) {
+                this.storeTurn(turn);
+              }
+              this.trimRetainedTurns();
               await this.flushBeforeSessionSafely();
               this.assertRecoveryCurrent(state);
             } else {
@@ -1919,6 +2426,18 @@ interface PendingFrontendServerRequest {
 }
 
 export const CODEX_TUI_WEBSOCKET_IDLE_TIMEOUT_SECONDS = 0;
+// Codex's remote client accepts 128 MiB WebSocket messages. Its app-server
+// legitimately returns multi-megabyte startup/list responses, so the bridge
+// must not impose a smaller wire limit than the client it fronts.
+export const CODEX_TUI_WEBSOCKET_MAX_FRAME_BYTES = 128 * 1_024 * 1_024;
+export const CODEX_TUI_WEBSOCKET_BACKPRESSURE_LIMIT_BYTES =
+  CODEX_TUI_WEBSOCKET_MAX_FRAME_BYTES;
+export const CODEX_TUI_WEBSOCKET_OUTBOUND_QUEUE_MAX_BYTES =
+  CODEX_TUI_WEBSOCKET_MAX_FRAME_BYTES + 1_024 * 1_024;
+// Charge a conservative fixed cost per queued frame as well as its UTF-8
+// payload. This bounds queue object overhead without treating an arbitrary
+// message count as a protocol limit.
+export const CODEX_TUI_WEBSOCKET_OUTBOUND_QUEUE_ENTRY_COST_BYTES = 1_024;
 
 /**
  * Private Unix WebSocket JSON-RPC endpoint used by
@@ -1932,8 +2451,8 @@ export const CODEX_TUI_WEBSOCKET_IDLE_TIMEOUT_SECONDS = 0;
  */
 export class CodexUnixJsonRpcProxy {
   private static readonly MAX_PENDING_SERVER_REQUESTS = 128;
-  private static readonly MAX_OUTBOUND_QUEUE_ENTRIES = 1_024;
-  private static readonly MAX_OUTBOUND_QUEUE_BYTES = 1_048_576;
+  private static readonly MAX_OUTBOUND_QUEUE_BYTES =
+    CODEX_TUI_WEBSOCKET_OUTBOUND_QUEUE_MAX_BYTES;
   private server: ReturnType<typeof Bun.serve> | null = null;
   private socket: ServerWebSocket<{ connectionId: string }> | null = null;
   private frontendReady = false;
@@ -2086,13 +2605,27 @@ export class CodexUnixJsonRpcProxy {
     payload: string,
   ): void {
     if (this.socket !== socket) return;
+    const bytes = Buffer.byteLength(payload);
+    if (bytes > CODEX_TUI_WEBSOCKET_MAX_FRAME_BYTES) {
+      this.failFrontendSocket(
+        socket,
+        `Codex bridge JSON-RPC frame exceeded its ${CODEX_TUI_WEBSOCKET_MAX_FRAME_BYTES}-byte safety limit`,
+      );
+      return;
+    }
     if (this.backpressuredSocket === socket) {
-      const bytes = Buffer.byteLength(payload);
-      if (
-        this.outboundQueue.length >= CodexUnixJsonRpcProxy.MAX_OUTBOUND_QUEUE_ENTRIES ||
-        this.outboundQueueBytes + bytes > CodexUnixJsonRpcProxy.MAX_OUTBOUND_QUEUE_BYTES
-      ) {
-        this.failFrontendSocket(socket, "Codex bridge outbound queue exceeded its safety limit");
+      const estimatedQueueBytes =
+        this.outboundQueueBytes +
+        bytes +
+        (this.outboundQueue.length + 1) *
+          CODEX_TUI_WEBSOCKET_OUTBOUND_QUEUE_ENTRY_COST_BYTES;
+      if (estimatedQueueBytes > CodexUnixJsonRpcProxy.MAX_OUTBOUND_QUEUE_BYTES) {
+        this.failFrontendSocket(
+          socket,
+          `Codex bridge outbound queue exceeded its safety limit ` +
+            `(entries=${this.outboundQueue.length}, bytes=${this.outboundQueueBytes}, ` +
+            `incoming=${bytes}, estimated=${estimatedQueueBytes})`,
+        );
         return;
       }
       this.outboundQueue.push({ socket, payload, bytes });
@@ -2242,6 +2775,13 @@ export class CodexUnixJsonRpcProxy {
         // A session bridge must remain attached while a user or approval is
         // legitimately quiet for longer than Bun's 120-second default.
         idleTimeout: CODEX_TUI_WEBSOCKET_IDLE_TIMEOUT_SECONDS,
+        // Match Codex remote's explicit per-frame ceiling. A legitimate
+        // app-server response can exceed both Bun's smaller defaults and the
+        // proxy's former 1 MiB queue cap; the second bounded queue absorbs a
+        // short burst while drain catches up.
+        maxPayloadLength: CODEX_TUI_WEBSOCKET_MAX_FRAME_BYTES,
+        backpressureLimit: CODEX_TUI_WEBSOCKET_BACKPRESSURE_LIMIT_BYTES,
+        closeOnBackpressureLimit: false,
         open(socket) {
           self.accept(socket);
         },
@@ -2433,12 +2973,30 @@ function continuationKey(delivery: DirectedDelivery): string | null {
   return `${delivery.work_id}\u0000${delivery.continuation_ref}`;
 }
 
-function finalAgentText(turn: CodexTurn): string | null {
-  const agents = (turn.items ?? []).filter((item) =>
-    item.type === "agentMessage" && typeof item.text === "string"
+type AgentMessageItem = CodexThreadItem & { text: string };
+
+function agentMessageItems(turn: CodexTurn | null | undefined): AgentMessageItem[] {
+  return (turn?.items ?? []).filter((item): item is AgentMessageItem =>
+    item.type === "agentMessage" &&
+    typeof item.text === "string" &&
+    item.text.trim() !== ""
   );
-  const text = agents.length > 0 ? String(agents[agents.length - 1]!.text).trim() : "";
-  return text || null;
+}
+
+function finalAgentItem(items: AgentMessageItem[]): AgentMessageItem | null {
+  for (let index = items.length - 1; index >= 0; index -= 1) {
+    const item = items[index]!;
+    if (item.text.trim() !== "" && item.phase === "final_answer") return item;
+  }
+  for (let index = items.length - 1; index >= 0; index -= 1) {
+    const item = items[index]!;
+    if (item.text.trim() !== "" && item.phase !== "commentary") return item;
+  }
+  return null;
+}
+
+function finalAgentText(turn: CodexTurn): string | null {
+  return finalAgentItem(agentMessageItems(turn))?.text.trim() || null;
 }
 
 class CodexDeliveryConnectionReplacedError extends Error {}
@@ -3585,6 +4143,7 @@ export class CodexAgentPartyBridge {
           throw new Error(`delivery state is ${state}, expected failed`);
         }
       }
+      this.log(`codex-bridge: failed seq=${pending.message.seq}: ${error}`);
       // Persist deletion of an owner answer and its parked source binding in
       // one snapshot before dropping the only retryable pending object.
       this.removeSettledJournalEntries(pending);
@@ -3953,11 +4512,28 @@ export class CodexAgentPartyBridge {
         });
         pending.replySeq = posted.seq;
         if (pending.delivery) {
-          this.options.recoveryJournal?.update(pending.delivery.id, {
-            phase: "reply_posted",
-            replyBody: pending.replyBody,
-            replySeq: posted.seq,
-          });
+          try {
+            this.options.recoveryJournal?.update(pending.delivery.id, {
+              phase: "reply_posted",
+              replyBody: pending.replyBody,
+              replySeq: posted.seq,
+            });
+          } catch (error) {
+            // The linked-reply POST can broadcast an unsolicited authoritative
+            // `replied` state before its HTTP response returns. That path
+            // removes the exact pending delivery and WAL entry. Once both
+            // fences confirm that terminal state, the successful POST response
+            // is not an unknown outcome and must not be retried.
+            if (
+              !this.pending.has(pending.clientId) &&
+              this.settledDeliveryIds.has(pending.delivery.id)
+            ) {
+              this.log(`codex-bridge: replied to seq=${pending.message.seq} with seq=${posted.seq}`);
+              return;
+            }
+            pending.replySeq = null;
+            throw error;
+          }
         }
         pending.retryAttempt = 0;
         if (pending.renewTimer) clearInterval(pending.renewTimer);

--- a/cli/src/codex-app-server-bridge.ts
+++ b/cli/src/codex-app-server-bridge.ts
@@ -660,6 +660,8 @@ interface AccumulatedAgentMessage {
   item: CodexThreadItem;
   text: string;
   completed: boolean;
+  hasStarted: boolean;
+  hasDelta: boolean;
 }
 
 const MAX_RETAINED_COMPLETED_TURNS = 256;
@@ -1163,6 +1165,7 @@ export class CodexSessionController {
     turnId: string,
     item: CodexThreadItem,
     completed: boolean,
+    started = false,
   ): void {
     if (
       item.type !== "agentMessage" ||
@@ -1189,7 +1192,12 @@ export class CodexSessionController {
     }
     const text =
       completed
-        ? itemText
+        ? itemText.trim() === "" &&
+            existing?.hasStarted === true &&
+            existing?.hasDelta === true &&
+            existing.text.length > 0
+          ? existing.text
+          : itemText
         : existing?.text.length
           ? existing.text
           : itemText;
@@ -1205,6 +1213,8 @@ export class CodexSessionController {
       },
       text,
       completed: completed || existing?.completed === true,
+      hasStarted: started || existing?.hasStarted === true,
+      hasDelta: existing?.hasDelta === true,
     });
   }
 
@@ -1225,7 +1235,10 @@ export class CodexSessionController {
     // item/completed is authoritative. Ignore a duplicate/late delta instead
     // of appending it after the final item text.
     if (existing?.completed) return;
-    const text = `${existing?.text ?? ""}${params.delta}`;
+    const hadDelta = existing?.hasDelta === true;
+    // item/started text is not streamed output. Seed this buffer only from
+    // actual deltas so an empty delta cannot promote provisional item text.
+    const text = `${hadDelta ? existing.text : ""}${params.delta}`;
     messages.set(params.itemId, {
       item: {
         ...(existing?.item ?? {}),
@@ -1235,6 +1248,8 @@ export class CodexSessionController {
       },
       text,
       completed: false,
+      hasStarted: existing?.hasStarted === true,
+      hasDelta: hadDelta || params.delta.length > 0,
     });
   }
 
@@ -2197,6 +2212,7 @@ export class CodexSessionController {
               params.turnId,
               item,
               message.method === "item/completed",
+              message.method === "item/started",
             );
           } else if (
             item?.type === "commandExecution" &&
@@ -3630,11 +3646,18 @@ export class CodexAgentPartyBridge {
           idempotencyKey: pending.replyIdempotencyKey,
         });
         pending.replySeq = posted.seq;
-        this.options.recoveryJournal?.update(pending.delivery.id, {
-          phase: "reply_posted",
-          replyBody: pending.replyBody,
-          replySeq: posted.seq,
-        });
+        try {
+          this.options.recoveryJournal?.update(pending.delivery.id, {
+            phase: "reply_posted",
+            replyBody: pending.replyBody,
+            replySeq: posted.seq,
+          });
+        } catch (error) {
+          // A stable idempotency key makes the REST result safe to ask for
+          // again, but the in-memory sequence must not outrun durable recovery.
+          pending.replySeq = null;
+          throw error;
+        }
       }
       const replySeq = pending.replySeq;
       if (replySeq === null) throw new Error("recovered reply has no persisted sequence");

--- a/cli/src/codex-app-server-bridge.ts
+++ b/cli/src/codex-app-server-bridge.ts
@@ -40,6 +40,7 @@ import {
   DeliveryRecoveryJournal,
   type DeliveryRecoveryEntry,
 } from "./delivery-recovery-journal";
+import { stripTerminalControls } from "./format";
 
 export type JsonRpcId = string | number | null;
 
@@ -211,6 +212,12 @@ function errorDetail(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+function terminalSafeLogger(
+  sink: (line: string) => void = (line) => console.error(line),
+): (line: string) => void {
+  return (line) => sink(stripTerminalControls(line));
+}
+
 /**
  * Reconnecting JSON-RPC client over `codex app-server proxy --sock …` stdio.
  *
@@ -240,7 +247,7 @@ export class CodexRpcClient {
   private readonly log: (line: string) => void;
 
   constructor(private readonly options: CodexRpcClientOptions) {
-    this.log = options.log ?? ((line) => console.error(line));
+    this.log = terminalSafeLogger(options.log);
     this.reconnectDelay = options.reconnectDelayMs ?? 100;
   }
 
@@ -533,23 +540,30 @@ export class CodexRpcClient {
     return await this.rawRequest(method, params);
   }
 
+  private disconnectedRequestBeforeWrite(
+    method: string,
+    expectedGeneration?: number,
+  ): CodexRpcDisconnectedError | null {
+    const generationChanged =
+      expectedGeneration !== undefined && expectedGeneration !== this.generation;
+    if (this.child && this.initializeValue !== null && !generationChanged) {
+      return null;
+    }
+    return new CodexRpcDisconnectedError(
+      generationChanged
+        ? `Codex app-server generation changed before ${method} request write`
+        : "Codex app-server control connection closed before request write",
+      { requestWritten: false },
+    );
+  }
+
   requestConnected(
     method: string,
     params?: unknown,
     expectedGeneration?: number,
   ): Promise<unknown> {
-    if (
-      !this.child ||
-      this.initializeValue === null ||
-      (expectedGeneration !== undefined && expectedGeneration !== this.generation)
-    ) {
-      return Promise.reject(new CodexRpcDisconnectedError(
-        expectedGeneration !== undefined && expectedGeneration !== this.generation
-          ? `Codex app-server generation changed before ${method} request write`
-          : "Codex app-server control connection closed before request write",
-        { requestWritten: false },
-      ));
-    }
+    const disconnected = this.disconnectedRequestBeforeWrite(method, expectedGeneration);
+    if (disconnected) return Promise.reject(disconnected);
     return this.rawRequest(method, params);
   }
 
@@ -559,18 +573,8 @@ export class CodexRpcClient {
     expectedGeneration: number | undefined,
     applyResponse: (result: unknown) => void | Promise<void>,
   ): Promise<unknown> {
-    if (
-      !this.child ||
-      this.initializeValue === null ||
-      (expectedGeneration !== undefined && expectedGeneration !== this.generation)
-    ) {
-      return Promise.reject(new CodexRpcDisconnectedError(
-        expectedGeneration !== undefined && expectedGeneration !== this.generation
-          ? `Codex app-server generation changed before ${method} request write`
-          : "Codex app-server control connection closed before request write",
-        { requestWritten: false },
-      ));
-    }
+    const disconnected = this.disconnectedRequestBeforeWrite(method, expectedGeneration);
+    if (disconnected) return Promise.reject(disconnected);
     return this.rawRequest(method, params, applyResponse);
   }
 
@@ -852,6 +856,9 @@ export class CodexSessionController {
   private readonly unresolvedUnknownListeners = new Set<UnresolvedUnknownListener>();
   private readonly turnByClientId = new Map<string, string>();
   private readonly turns = new Map<string, CodexTurn>();
+  private readonly retainedTurnBytesById = new Map<string, number>();
+  private retainedCompletedTurnBytes = 0;
+  private retainedCompletedTurnCount = 0;
   private readonly agentMessagesByTurn =
     new Map<string, Map<string, AccumulatedAgentMessage>>();
   private readonly log: (line: string) => void;
@@ -879,7 +886,7 @@ export class CodexSessionController {
       recoveryRetryDelayMs?: number;
     } = {},
   ) {
-    this.log = options.log ?? ((line) => console.error(line));
+    this.log = terminalSafeLogger(options.log);
     rpc.onMessage((message) => this.handleBackendMessage(message));
     const hasDisconnectBoundary = rpc.onDisconnect !== undefined;
     rpc.onDisconnect?.((disconnectedGeneration) => {
@@ -1096,42 +1103,59 @@ export class CodexSessionController {
 
   private storeTurn(turn: CodexTurn): CodexTurn {
     const retained = this.retainedTurn(turn);
+    const previous = this.turns.get(retained.id);
+    if (previous?.status !== undefined && previous.status !== "inProgress") {
+      this.retainedCompletedTurnBytes -=
+        this.retainedTurnBytesById.get(retained.id) ?? 0;
+      this.retainedCompletedTurnCount -= 1;
+    }
+    const retainedBytes = this.retainedTurnBytes(retained);
     this.turns.set(retained.id, retained);
+    this.retainedTurnBytesById.set(retained.id, retainedBytes);
+    if (retained.status !== "inProgress") {
+      this.retainedCompletedTurnBytes += retainedBytes;
+      this.retainedCompletedTurnCount += 1;
+    }
     this.trimRetainedTurns();
     return retained;
   }
 
   private trimRetainedTurns(): void {
+    if (
+      this.retainedCompletedTurnCount <= MAX_RETAINED_COMPLETED_TURNS &&
+      this.retainedCompletedTurnBytes <= MAX_RETAINED_COMPLETED_TURN_BYTES
+    ) {
+      return;
+    }
     const completed = [...this.turns.entries()]
       .filter(([, turn]) => turn.status !== "inProgress")
       .map(([turnId, turn]) => ({
         turnId,
         turn,
-        bytes: this.retainedTurnBytes(turn),
+        bytes: this.retainedTurnBytesById.get(turnId) ?? 0,
         bootstrapProof: (turn.items ?? []).some((item) =>
           item.type === "userMessage" &&
           item.clientId === null &&
           Object.prototype.hasOwnProperty.call(item, "content")
         ),
       }));
-    let bytes = completed.reduce((total, entry) => total + entry.bytes, 0);
-    let count = completed.length;
     while (
-      count > MAX_RETAINED_COMPLETED_TURNS ||
-      bytes > MAX_RETAINED_COMPLETED_TURN_BYTES
+      this.retainedCompletedTurnCount > MAX_RETAINED_COMPLETED_TURNS ||
+      this.retainedCompletedTurnBytes > MAX_RETAINED_COMPLETED_TURN_BYTES
     ) {
       const index = completed.findIndex((entry) => !entry.bootstrapProof);
       if (index < 0) break;
       const [evicted] = completed.splice(index, 1);
       if (!evicted) break;
       this.turns.delete(evicted.turnId);
+      this.retainedTurnBytesById.delete(evicted.turnId);
       for (const [clientId, turnId] of this.turnByClientId) {
         if (turnId === evicted.turnId) {
           this.turnByClientId.delete(clientId);
         }
       }
-      bytes -= evicted.bytes;
-      count -= 1;
+      this.retainedCompletedTurnBytes -= evicted.bytes;
+      this.retainedCompletedTurnCount -= 1;
     }
   }
 
@@ -1153,6 +1177,16 @@ export class CodexSessionController {
     }
     const existing = messages.get(item.id);
     const itemText = typeof item.text === "string" ? item.text : "";
+    if (
+      completed &&
+      existing?.completed === true &&
+      itemText.trim() === ""
+    ) {
+      // item/completed is the authoritative terminal item. A later
+      // turn/completed snapshot can contain only an empty shell for the same
+      // id; do not erase the final text/phase already observed.
+      return;
+    }
     const text =
       completed
         ? itemText
@@ -1269,13 +1303,17 @@ export class CodexSessionController {
     ) {
       return canonicalTurn;
     }
-    const fallback = finalAgentItem(
+    const accumulatedFallback = finalAgentItem(
       accumulated
         ? [...accumulated.values()]
           .filter(({ completed }) => completed)
           .map(({ item, text }) => ({ ...item, text }))
-        : agentMessageItems(previous),
+        : [],
     );
+    const fallback = accumulatedFallback ??
+      (previous?.status !== "inProgress"
+        ? finalAgentItem(agentMessageItems(previous))
+        : null);
     if (!fallback) return canonicalTurn;
 
     const items = [...(canonicalTurn.items ?? [])];
@@ -1294,6 +1332,7 @@ export class CodexSessionController {
         ...fallback,
         ...existing,
         text: fallback.text,
+        phase: fallback.phase,
       };
     } else {
       items.push(fallback);
@@ -1616,6 +1655,9 @@ export class CodexSessionController {
     // Rebuild affinity indexes even for the same thread so rollback cannot
     // leave a removed source clientId cached and authorize owner_answer.
     this.turns.clear();
+    this.retainedTurnBytesById.clear();
+    this.retainedCompletedTurnBytes = 0;
+    this.retainedCompletedTurnCount = 0;
     this.turnByClientId.clear();
     this.agentMessagesByTurn.clear();
     this.threadId = thread.id;
@@ -2438,6 +2480,12 @@ export const CODEX_TUI_WEBSOCKET_OUTBOUND_QUEUE_MAX_BYTES =
 // payload. This bounds queue object overhead without treating an arbitrary
 // message count as a protocol limit.
 export const CODEX_TUI_WEBSOCKET_OUTBOUND_QUEUE_ENTRY_COST_BYTES = 1_024;
+// Bun's backpressure buffer and this bridge queue are independent. In the
+// worst serialized-data case they can retain roughly 257 MiB combined before
+// JavaScript string/object and native framing overhead, so surface a warning
+// before the bridge-owned half reaches its hard limit.
+const CODEX_TUI_WEBSOCKET_OUTBOUND_QUEUE_WARNING_BYTES =
+  Math.floor(CODEX_TUI_WEBSOCKET_OUTBOUND_QUEUE_MAX_BYTES / 2);
 
 /**
  * Private Unix WebSocket JSON-RPC endpoint used by
@@ -2466,6 +2514,7 @@ export class CodexUnixJsonRpcProxy {
     bytes: number;
   }> = [];
   private outboundQueueBytes = 0;
+  private outboundQueueWarningEmitted = false;
   private readonly pendingServerRequestsByBackendId =
     new Map<string, PendingFrontendServerRequest>();
   private readonly pendingServerRequestsByFrontendId =
@@ -2478,7 +2527,7 @@ export class CodexUnixJsonRpcProxy {
     private readonly controller: CodexSessionController,
     options: { log?: (line: string) => void } = {},
   ) {
-    this.log = options.log ?? ((line) => console.error(line));
+    this.log = terminalSafeLogger(options.log);
     this.unsubscribeMessages = controller.onFrontendMessage((message) => {
       let outbound: JsonRpcRequest | JsonRpcNotification = message;
       if ("id" in message) {
@@ -2579,6 +2628,7 @@ export class CodexUnixJsonRpcProxy {
     this.backpressuredSocket = null;
     this.outboundQueue.length = 0;
     this.outboundQueueBytes = 0;
+    this.outboundQueueWarningEmitted = false;
     try {
       socket.close(1012, reason);
     } catch (error) {
@@ -2628,6 +2678,19 @@ export class CodexUnixJsonRpcProxy {
         );
         return;
       }
+      if (
+        !this.outboundQueueWarningEmitted &&
+        estimatedQueueBytes >= CODEX_TUI_WEBSOCKET_OUTBOUND_QUEUE_WARNING_BYTES
+      ) {
+        this.outboundQueueWarningEmitted = true;
+        this.log(
+          `codex-bridge: outbound queue crossed its warning threshold ` +
+            `(entries=${this.outboundQueue.length + 1}, ` +
+            `bytes=${this.outboundQueueBytes + bytes}, ` +
+            `estimated=${estimatedQueueBytes}, ` +
+            `limit=${CodexUnixJsonRpcProxy.MAX_OUTBOUND_QUEUE_BYTES})`,
+        );
+      }
       this.outboundQueue.push({ socket, payload, bytes });
       this.outboundQueueBytes += bytes;
       return;
@@ -2656,6 +2719,7 @@ export class CodexUnixJsonRpcProxy {
     this.backpressuredSocket = null;
     this.outboundQueue.length = 0;
     this.outboundQueueBytes = 0;
+    this.outboundQueueWarningEmitted = false;
     this.log(`codex-bridge: ${reason}; closing the unhealthy TUI socket`);
     socket.close(1011, reason);
   }
@@ -2755,6 +2819,7 @@ export class CodexUnixJsonRpcProxy {
     this.backpressuredSocket = null;
     this.outboundQueue.length = 0;
     this.outboundQueueBytes = 0;
+    this.outboundQueueWarningEmitted = false;
   }
 
   async listen(socketPath: string): Promise<void> {
@@ -2807,6 +2872,7 @@ export class CodexUnixJsonRpcProxy {
           self.backpressuredSocket = null;
           self.outboundQueue.length = 0;
           self.outboundQueueBytes = 0;
+          self.outboundQueueWarningEmitted = false;
           self.log("codex-bridge: TUI disconnected; bridge remains ready for the same session to reattach");
         },
       },
@@ -2825,6 +2891,7 @@ export class CodexUnixJsonRpcProxy {
     this.backpressuredSocket = null;
     this.outboundQueue.length = 0;
     this.outboundQueueBytes = 0;
+    this.outboundQueueWarningEmitted = false;
     const server = this.server;
     this.server = null;
     if (!server) return;
@@ -3044,7 +3111,7 @@ export class CodexAgentPartyBridge {
     if (options.requireDeliveryRecovery === true && options.recoveryJournal === undefined) {
       throw new Error("Codex delivery recovery requires a durable recovery journal");
     }
-    this.log = options.log ?? ((line) => console.error(line));
+    this.log = terminalSafeLogger(options.log);
     this.unsubscribeDispatch = options.session.onDispatch((input, dispatch) => {
       this.observeDispatch(input, dispatch);
     });

--- a/cli/src/commands/codex-bridge.ts
+++ b/cli/src/commands/codex-bridge.ts
@@ -21,6 +21,7 @@ import {
   DeliveryRecoveryJournal,
   deliveryRecoveryJournalPath,
 } from "../delivery-recovery-journal";
+import { stripTerminalControls } from "../format";
 import {
   acquireInstanceLock,
   defaultInstanceLockDir,
@@ -692,7 +693,8 @@ export async function runCodexSessionBridge(
   options: CodexBridgeRuntimeOptions,
   deps: CodexBridgeRuntimeDeps = {},
 ): Promise<number> {
-  const log = deps.log ?? ((line) => console.error(line));
+  const logSink = deps.log ?? ((line: string) => console.error(line));
+  const log = (line: string) => logSink(stripTerminalControls(line));
   const cwd = options.cwd ?? process.cwd();
   const env = options.env ?? process.env;
   let lock: InstanceLock | null = null;

--- a/cli/test/codex-agentparty-bridge.test.ts
+++ b/cli/test/codex-agentparty-bridge.test.ts
@@ -429,17 +429,51 @@ describe("Codex AgentParty delivery integration", () => {
     expect(rpc.calls.filter((call) => call.method === "thread/start")).toHaveLength(1);
 
     rpc.emit({
+      method: "item/started",
+      params: {
+        threadId: "thread-delivery",
+        turnId: "turn-delivery",
+        item: {
+          type: "agentMessage",
+          id: "agent-final",
+          text: "",
+          phase: "final_answer",
+        },
+      },
+    });
+    rpc.emit({
+      method: "item/agentMessage/delta",
+      params: {
+        threadId: "thread-delivery",
+        turnId: "turn-delivery",
+        itemId: "agent-final",
+        delta: "same-session partial",
+      },
+    });
+    rpc.emit({
+      method: "item/completed",
+      params: {
+        threadId: "thread-delivery",
+        turnId: "turn-delivery",
+        item: {
+          type: "agentMessage",
+          id: "agent-final",
+          text: "same-session answer",
+          phase: "final_answer",
+        },
+      },
+    });
+    rpc.emit({
       method: "turn/completed",
       params: {
         threadId: "thread-delivery",
         turn: {
           id: "turn-delivery",
           status: "completed",
-          items: [{
-            type: "agentMessage",
-            id: "agent-final",
-            text: "same-session answer",
-          }],
+          // Codex 0.144.x intentionally leaves lifecycle turn snapshots
+          // unloaded; the authoritative agent item arrived above.
+          items: [],
+          itemsView: "notLoaded",
         },
       },
     });
@@ -459,6 +493,118 @@ describe("Codex AgentParty delivery integration", () => {
     }));
     expect(bridge.pendingCount).toBe(0);
     expect(rpc.calls.filter((call) => call.method === "turn/start")).toHaveLength(1);
+    bridge.close();
+  });
+
+  test("fails closed on an empty completed item or commentary-only output", async () => {
+    const rpc = new DeliveryRpcPeer();
+    rpc.turnIds = ["turn-empty-final", "turn-commentary-only"];
+    const session = new CodexSessionController(rpc);
+    const conn = fakeConnection();
+    const failures: string[] = [];
+    const posts: string[] = [];
+    const bridge = new CodexAgentPartyBridge({
+      channel: "dev",
+      connection: conn.connection,
+      session,
+      leaseRenewIntervalMs: 60_000,
+      confirmDeliveryUpdate: async (update) => {
+        if (update.state === "failed") failures.push(update.error ?? "");
+        return update.state;
+      },
+      postReply: async ({ body }) => {
+        posts.push(body);
+        return { seq: 1 };
+      },
+    });
+
+    await bridge.handleFrame(welcomeDirectedFrame(0, "me") as ServerFrame);
+    await session.request("thread/start", {});
+    await bridge.handleFrame(deliveryFrame(120, "must not post a partial", {
+      id: "delivery-empty-final",
+      target_name: "me",
+      sender: { name: "alice", kind: "human" },
+    }) as ServerFrame);
+    rpc.emit({
+      method: "item/agentMessage/delta",
+      params: {
+        threadId: "thread-delivery",
+        turnId: "turn-empty-final",
+        itemId: "agent-empty-final",
+        delta: "aborted partial output",
+      },
+    });
+    rpc.emit({
+      method: "item/completed",
+      params: {
+        threadId: "thread-delivery",
+        turnId: "turn-empty-final",
+        item: {
+          type: "agentMessage",
+          id: "agent-empty-final",
+          text: "",
+          phase: "final_answer",
+        },
+      },
+    });
+    rpc.emit({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-delivery",
+        turn: {
+          id: "turn-empty-final",
+          status: "completed",
+          items: [],
+          itemsView: "notLoaded",
+        },
+      },
+    });
+    await waitFor(() => failures.length === 1, "empty final item did not fail closed");
+
+    await bridge.handleFrame(deliveryFrame(121, "must not post commentary", {
+      id: "delivery-commentary-only",
+      target_name: "me",
+      sender: { name: "alice", kind: "human" },
+    }) as ServerFrame);
+    rpc.emit({
+      method: "item/completed",
+      params: {
+        threadId: "thread-delivery",
+        turnId: "turn-commentary-only",
+        item: {
+          type: "agentMessage",
+          id: "agent-commentary",
+          text: "progress only",
+          phase: "commentary",
+        },
+      },
+    });
+    rpc.emit({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-delivery",
+        turn: {
+          id: "turn-commentary-only",
+          status: "completed",
+          items: [],
+          itemsView: "notLoaded",
+        },
+      },
+    });
+    await waitFor(
+      () => failures.length === 2,
+      "commentary-only completion did not fail closed",
+    );
+    await waitFor(
+      () => bridge.pendingCount === 0,
+      "fail-closed completions did not clear their delivery ledgers",
+    );
+
+    expect(posts).toEqual([]);
+    expect(failures).toEqual([
+      expect.stringContaining("completed without a final agent message"),
+      expect.stringContaining("completed without a final agent message"),
+    ]);
     bridge.close();
   });
 
@@ -773,6 +919,222 @@ describe("Codex AgentParty delivery integration", () => {
       reply_seq: 91,
     }));
     bridge.close();
+  });
+
+  test("accepts an unsolicited authoritative replied state that wins the POST response race", async () => {
+    const root = mkdtempSync(join(tmpdir(), "ap-codex-reply-race-"));
+    let bridge: CodexAgentPartyBridge | null = null;
+    try {
+      const rpc = new DeliveryRpcPeer();
+      rpc.turnIds = ["turn-reply-race"];
+      const session = new CodexSessionController(rpc);
+      const conn = fakeConnection();
+      const journal = new DeliveryRecoveryJournal(
+        join(root, "journal.json"),
+        "dev",
+        "codex",
+      );
+      const logs: string[] = [];
+      const updates: ClientFrame[] = [];
+      let posts = 0;
+      const incoming = deliveryFrame(127, "reply before the HTTP response returns", {
+        id: "delivery-reply-race",
+        target_name: "me",
+        sender: { name: "alice", kind: "human" },
+      }) as unknown as DirectedDeliveryFrame;
+      bridge = new CodexAgentPartyBridge({
+        channel: "dev",
+        connection: conn.connection,
+        session,
+        recoveryJournal: journal,
+        leaseRenewIntervalMs: 60_000,
+        log: (line) => logs.push(line),
+        confirmDeliveryUpdate: async (update) => {
+          updates.push(update);
+          return update.state;
+        },
+        postReply: async () => {
+          posts += 1;
+          await bridge!.handleFrame({
+            type: "delivery_state",
+            delivery: {
+              ...incoming.delivery,
+              state: "replied",
+              reply_seq: 1_271,
+            },
+          } as ServerFrame);
+          return { seq: 1_271 };
+        },
+      });
+
+      await bridge.handleFrame(welcomeDirectedFrame(0, "me") as ServerFrame);
+      await session.request("thread/start", {});
+      await bridge.handleFrame(incoming as ServerFrame);
+      rpc.emit({
+        method: "item/completed",
+        params: {
+          threadId: "thread-delivery",
+          turnId: "turn-reply-race",
+          item: {
+            type: "agentMessage",
+            id: "agent-reply-race",
+            text: "race-safe reply",
+            phase: "final_answer",
+          },
+        },
+      });
+      rpc.emit({
+        method: "turn/completed",
+        params: {
+          threadId: "thread-delivery",
+          turn: {
+            id: "turn-reply-race",
+            status: "completed",
+            items: [],
+            itemsView: "notLoaded",
+          },
+        },
+      });
+
+      await waitFor(
+        () =>
+          bridge?.pendingCount === 0 &&
+          logs.includes("codex-bridge: replied to seq=127 with seq=1271"),
+        "unsolicited replied state did not settle the delivery",
+      );
+      expect(posts).toBe(1);
+      expect(journal.get(incoming.delivery.id)).toBeNull();
+      expect(updates.filter((update) =>
+        update.type === "delivery_update" && update.state === "replied"
+      )).toHaveLength(0);
+      expect(logs.filter((line) => line.includes("unknown persistence outcome"))).toEqual([]);
+      expect(logs.filter((line) =>
+        line === "codex-bridge: replied to seq=127 with seq=1271"
+      )).toHaveLength(1);
+    } finally {
+      bridge?.close();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("does not swallow a reply journal failure without both authoritative replied fences", async () => {
+    const root = mkdtempSync(join(tmpdir(), "ap-codex-reply-journal-fence-"));
+    let bridge: CodexAgentPartyBridge | null = null;
+    let releaseSecondPost = (): void => {};
+    try {
+      const rpc = new DeliveryRpcPeer();
+      rpc.turnIds = ["turn-reply-journal-fence"];
+      const session = new CodexSessionController(rpc);
+      const conn = fakeConnection();
+      const journal = new DeliveryRecoveryJournal(
+        join(root, "journal.json"),
+        "dev",
+        "codex",
+      );
+      const logs: string[] = [];
+      const postKeys: string[] = [];
+      const updates: ClientFrame[] = [];
+      const secondPostGate = new Promise<void>((resolve) => {
+        releaseSecondPost = resolve;
+      });
+      const originalUpdate = journal.update.bind(journal);
+      let rejectFirstReplyPosted = true;
+      journal.update = (deliveryId, patch) => {
+        if (patch.phase === "reply_posted" && rejectFirstReplyPosted) {
+          rejectFirstReplyPosted = false;
+          throw new Error(`no recovery journal entry for ${deliveryId}`);
+        }
+        return originalUpdate(deliveryId, patch);
+      };
+      const incoming = deliveryFrame(128, "do not broaden the replied race fence", {
+        id: "delivery-reply-journal-fence",
+        target_name: "me",
+        sender: { name: "alice", kind: "human" },
+      }) as unknown as DirectedDeliveryFrame;
+      bridge = new CodexAgentPartyBridge({
+        channel: "dev",
+        connection: conn.connection,
+        session,
+        recoveryJournal: journal,
+        leaseRenewIntervalMs: 60_000,
+        retryDelayMs: 1,
+        log: (line) => logs.push(line),
+        confirmDeliveryUpdate: async (update) => {
+          updates.push(update);
+          return update.state;
+        },
+        postReply: async ({ idempotencyKey }) => {
+          postKeys.push(idempotencyKey);
+          if (postKeys.length > 1) await secondPostGate;
+          return { seq: 1_281 };
+        },
+      });
+
+      await bridge.handleFrame(welcomeDirectedFrame(0, "me") as ServerFrame);
+      await session.request("thread/start", {});
+      await bridge.handleFrame(incoming as ServerFrame);
+      rpc.emit({
+        method: "item/completed",
+        params: {
+          threadId: "thread-delivery",
+          turnId: "turn-reply-journal-fence",
+          item: {
+            type: "agentMessage",
+            id: "agent-reply-journal-fence",
+            text: "retry behind the durable fence",
+            phase: "final_answer",
+          },
+        },
+      });
+      rpc.emit({
+        method: "turn/completed",
+        params: {
+          threadId: "thread-delivery",
+          turn: {
+            id: "turn-reply-journal-fence",
+            status: "completed",
+            items: [],
+            itemsView: "notLoaded",
+          },
+        },
+      });
+
+      await waitFor(
+        () =>
+          postKeys.length === 2 &&
+          logs.some((line) => line.includes("unknown persistence outcome")),
+        "reply journal failure did not enter the stable-key retry path",
+      );
+      expect(bridge.pendingCount).toBe(1);
+      expect(journal.get(incoming.delivery.id)).not.toBeNull();
+      expect(updates.filter((update) =>
+        update.type === "delivery_update" && update.state === "replied"
+      )).toHaveLength(0);
+      expect(new Set(postKeys)).toEqual(
+        new Set(["codex-bridge-reply:delivery-reply-journal-fence"]),
+      );
+
+      releaseSecondPost();
+      await waitFor(
+        () => bridge?.pendingCount === 0,
+        "stable-key retry did not settle after the journal fence recovered",
+      );
+      expect(postKeys).toEqual([
+        "codex-bridge-reply:delivery-reply-journal-fence",
+        "codex-bridge-reply:delivery-reply-journal-fence",
+      ]);
+      expect(updates).toContainEqual(expect.objectContaining({
+        type: "delivery_update",
+        delivery_id: incoming.delivery.id,
+        state: "replied",
+        reply_seq: 1_281,
+      }));
+      expect(journal.get(incoming.delivery.id)).toBeNull();
+    } finally {
+      releaseSecondPost();
+      bridge?.close();
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   test("cold reconnect preserves an absent after-write input for one exact late reply without replay", async () => {

--- a/cli/test/codex-agentparty-bridge.test.ts
+++ b/cli/test/codex-agentparty-bridge.test.ts
@@ -1595,6 +1595,15 @@ describe("Codex AgentParty delivery integration", () => {
       bridgeA = null;
 
       const journalB = new DeliveryRecoveryJournal(path, "dev", "codex");
+      const journalBUpdate = journalB.update.bind(journalB);
+      let rejectFirstRecoveredReplyPosted = true;
+      journalB.update = (deliveryId, patch) => {
+        if (patch.phase === "reply_posted" && rejectFirstRecoveredReplyPosted) {
+          rejectFirstRecoveredReplyPosted = false;
+          throw new Error(`recovered reply_posted WAL is full for ${deliveryId}`);
+        }
+        return journalBUpdate(deliveryId, patch);
+      };
       const rpcB = new DeliveryRpcPeer();
       const sessionB = new CodexSessionController(rpcB);
       await sessionB.request("thread/resume", { threadId: "thread-delivery" });
@@ -1607,6 +1616,7 @@ describe("Codex AgentParty delivery integration", () => {
         requireDeliveryRecovery: true,
         leaseRenewIntervalMs: 60_000,
         deliveryAckTimeoutMs: 1_000,
+        retryDelayMs: 1,
         confirmDeliveryUpdate: async (update) =>
           update.state === "replied" &&
             update.delivery_id === "delivery-response-lost-crash"
@@ -1648,6 +1658,7 @@ describe("Codex AgentParty delivery integration", () => {
         "same-key re-POST did not reconstruct the waiting_owner binding",
       );
       expect(postKeys).toEqual([
+        "codex-bridge-reply:delivery-response-lost-crash",
         "codex-bridge-reply:delivery-response-lost-crash",
         "codex-bridge-reply:delivery-response-lost-crash",
       ]);

--- a/cli/test/codex-app-server-rpc.test.ts
+++ b/cli/test/codex-app-server-rpc.test.ts
@@ -205,6 +205,1262 @@ function idleThread(id: string): {
 }
 
 describe("Codex app-server stdio JSON-RPC and reconnect recovery", () => {
+  test("serializes inbound messages without blocking JSON-RPC responses", async () => {
+    const statePath = join(temp, "state.json");
+    const logs: string[] = [];
+    const rpc = new CodexRpcClient({
+      log: (line) => logs.push(line),
+      spawnProxy: () => spawn("bun", ["run", fixture], {
+        stdio: ["pipe", "pipe", "pipe"],
+        env: { ...process.env, MOCK_CODEX_STATE_PATH: statePath },
+      }),
+    });
+    clients.push(rpc);
+
+    const firstGate = deferred<void>();
+    const firstEntered = deferred<void>();
+    const received: string[] = [];
+    rpc.onMessage(async (message) => {
+      received.push(`slow:${message.method}`);
+      if (message.method === "mock/ordered/first") {
+        firstEntered.resolve(undefined);
+        await firstGate.promise;
+        throw new Error("expected listener failure");
+      }
+    });
+    rpc.onMessage((message) => {
+      received.push(`fast:${message.method}`);
+    });
+
+    await rpc.start();
+    const response = rpc.request("mock/messageOrdering", {});
+    await firstEntered.promise;
+
+    try {
+      expect(received).toEqual([
+        "slow:mock/ordered/first",
+        "fast:mock/ordered/first",
+      ]);
+      await expect(Promise.race([
+        response,
+        new Promise<never>((_, reject) => {
+          setTimeout(
+            () => reject(new Error("JSON-RPC response waited for message listeners")),
+            1_000,
+          );
+        }),
+      ])).resolves.toEqual({ ordered: true });
+      expect(received).toEqual([
+        "slow:mock/ordered/first",
+        "fast:mock/ordered/first",
+      ]);
+    } finally {
+      firstGate.resolve(undefined);
+    }
+
+    await waitFor(
+      () => received.includes("fast:mock/ordered/second"),
+      "second notification was not dispatched after the first listener settled",
+    );
+    expect(received).toEqual([
+      "slow:mock/ordered/first",
+      "fast:mock/ordered/first",
+      "slow:mock/ordered/second",
+      "fast:mock/ordered/second",
+    ]);
+    expect(logs).toContain(
+      "codex-bridge: JSON-RPC listener failed: expected listener failure",
+    );
+  });
+
+  test("fences queued old-generation messages without letting a replacement overtake", async () => {
+    const statePath = join(temp, "state.json");
+    const rpc = new CodexRpcClient({
+      reconnectDelayMs: 60_000,
+      maxReconnectDelayMs: 60_000,
+      spawnProxy: () => spawn("bun", ["run", fixture], {
+        stdio: ["pipe", "pipe", "pipe"],
+        env: { ...process.env, MOCK_CODEX_STATE_PATH: statePath },
+      }),
+    });
+    clients.push(rpc);
+
+    const firstGate = deferred<void>();
+    const firstEntered = deferred<void>();
+    const disconnected = deferred<number>();
+    const received: string[] = [];
+    rpc.onMessage(async (message) => {
+      received.push(message.method);
+      if (message.method === "mock/disconnect/first") {
+        firstEntered.resolve(undefined);
+        await firstGate.promise;
+      }
+    });
+    rpc.onDisconnect((generation) => disconnected.resolve(generation));
+
+    await rpc.start();
+    const lostRequest = rpc.request("mock/messageOrderingDisconnect", {});
+    void lostRequest.catch(() => {});
+    await firstEntered.promise;
+    await expect(disconnected.promise).resolves.toBe(1);
+    await expect(lostRequest).rejects.toBeInstanceOf(CodexRpcDisconnectedError);
+
+    await rpc.start();
+    expect(rpc.connectionGeneration).toBe(2);
+    const replacementResponse = rpc.request("mock/messageOrdering", {});
+    try {
+      await expect(Promise.race([
+        replacementResponse,
+        new Promise<never>((_, reject) => {
+          setTimeout(
+            () => reject(new Error("replacement response waited for the old listener")),
+            1_000,
+          );
+        }),
+      ])).resolves.toEqual({ ordered: true });
+      expect(received).toEqual(["mock/disconnect/first"]);
+    } finally {
+      firstGate.resolve(undefined);
+    }
+
+    await waitFor(
+      () => received.includes("mock/ordered/second"),
+      "replacement generation did not resume ordered message dispatch",
+    );
+    expect(received).toEqual([
+      "mock/disconnect/first",
+      "mock/ordered/first",
+      "mock/ordered/second",
+    ]);
+  });
+
+  test("rejects a disconnected applying snapshot before the next generation can install its snapshot", async () => {
+    let spawnGeneration = 0;
+    const disconnected = deferred<number>();
+    const oldApplyEntered = deferred<void>();
+    const releaseOldApply = deferred<void>();
+    const appliedSnapshots: string[] = [];
+    let installedSnapshot: string | null = null;
+    const currentInstalledSnapshot = (): string | null => installedSnapshot;
+    const rpc = new CodexRpcClient({
+      reconnectDelayMs: 60_000,
+      maxReconnectDelayMs: 60_000,
+      spawnProxy: () => {
+        const generation = ++spawnGeneration;
+        const server = `
+          const { createInterface } = require("node:readline");
+          const input = createInterface({ input: process.stdin });
+          const send = (value) => process.stdout.write(JSON.stringify(value) + "\\n");
+          input.on("line", (line) => {
+            const frame = JSON.parse(line);
+            if (frame.method === "initialized") return;
+            if (frame.method === "initialize") {
+              send({
+                id: frame.id,
+                result: {
+                  userAgent: "disconnect-apply-test/${generation}",
+                  platformFamily: "unix",
+                },
+              });
+              return;
+            }
+            if (frame.method === "thread/read") {
+              send({
+                id: frame.id,
+                result: {
+                  thread: {
+                    id: "snapshot-generation-${generation}",
+                    status: { type: "idle" },
+                    turns: [],
+                  },
+                },
+              });
+              if (${generation} === 1) {
+                setTimeout(() => process.exit(77), 10);
+              }
+              return;
+            }
+            send({ id: frame.id, result: {} });
+          });
+        `;
+        return spawn("bun", ["-e", server], {
+          stdio: ["pipe", "pipe", "pipe"],
+        });
+      },
+    });
+    clients.push(rpc);
+    rpc.onDisconnect((generation) => disconnected.resolve(generation));
+
+    await rpc.start();
+    expect(rpc.connectionGeneration).toBe(1);
+    const oldRequest = rpc.requestConnectedApplied(
+      "thread/read",
+      { threadId: "snapshot-generation-1", includeTurns: true },
+      1,
+      async (result) => {
+        oldApplyEntered.resolve(undefined);
+        await releaseOldApply.promise;
+        const threadId = (result as { thread: { id: string } }).thread.id;
+        appliedSnapshots.push(threadId);
+        installedSnapshot = threadId;
+      },
+    );
+    let oldRequestSettled = false;
+    void oldRequest.then(
+      () => {
+        oldRequestSettled = true;
+      },
+      () => {
+        oldRequestSettled = true;
+      },
+    );
+
+    await oldApplyEntered.promise;
+    await expect(disconnected.promise).resolves.toBe(1);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(oldRequestSettled).toBe(false);
+    expect(currentInstalledSnapshot()).toBeNull();
+
+    await rpc.start();
+    expect(rpc.connectionGeneration).toBe(2);
+    let newApplyEntered = false;
+    const newRequest = rpc.requestConnectedApplied(
+      "thread/read",
+      { threadId: "snapshot-generation-2", includeTurns: true },
+      2,
+      async (result) => {
+        newApplyEntered = true;
+        const threadId = (result as { thread: { id: string } }).thread.id;
+        appliedSnapshots.push(threadId);
+        installedSnapshot = threadId;
+      },
+    );
+    const privateState = rpc as unknown as {
+      pending: Map<string, { responseReceived: boolean }>;
+    };
+    await waitFor(
+      () =>
+        [...privateState.pending.values()].filter(
+          ({ responseReceived }) => responseReceived,
+        ).length === 2,
+      "both generations' snapshot responses were not received",
+    );
+    expect(oldRequestSettled).toBe(false);
+    expect(newApplyEntered).toBe(false);
+    expect(appliedSnapshots).toEqual([]);
+
+    releaseOldApply.resolve(undefined);
+    await expect(oldRequest).rejects.toBeInstanceOf(CodexRpcDisconnectedError);
+    await expect(newRequest).resolves.toMatchObject({
+      thread: { id: "snapshot-generation-2" },
+    });
+    expect(appliedSnapshots).toEqual([
+      "snapshot-generation-1",
+      "snapshot-generation-2",
+    ]);
+    expect(currentInstalledSnapshot()).toBe("snapshot-generation-2");
+    expect(privateState.pending.size).toBe(0);
+  });
+
+  test("rejects a disconnected snapshot queued behind a slow notification without applying it", async () => {
+    const notificationEntered = deferred<void>();
+    const releaseNotification = deferred<void>();
+    const disconnected = deferred<number>();
+    let applyCalls = 0;
+    const server = `
+      const { createInterface } = require("node:readline");
+      const input = createInterface({ input: process.stdin });
+      const send = (value) => process.stdout.write(JSON.stringify(value) + "\\n");
+      input.on("line", (line) => {
+        const frame = JSON.parse(line);
+        if (frame.method === "initialized") return;
+        if (frame.method === "initialize") {
+          send({
+            id: frame.id,
+            result: {
+              userAgent: "queued-disconnect-test/1",
+              platformFamily: "unix",
+            },
+          });
+          return;
+        }
+        if (frame.method === "thread/read") {
+          const frames = [
+            {
+              method: "mock/gated-notification",
+              params: { generation: 1 },
+            },
+            {
+              id: frame.id,
+              result: {
+                thread: {
+                  id: "snapshot-queued-before-disconnect",
+                  status: { type: "idle" },
+                  turns: [],
+                },
+              },
+            },
+          ];
+          process.stdout.write(
+            frames.map((value) => JSON.stringify(value) + "\\n").join(""),
+            () => setTimeout(() => process.exit(78), 100),
+          );
+          return;
+        }
+        send({ id: frame.id, result: {} });
+      });
+    `;
+    const rpc = new CodexRpcClient({
+      reconnectDelayMs: 60_000,
+      maxReconnectDelayMs: 60_000,
+      spawnProxy: () => spawn("bun", ["-e", server], {
+        stdio: ["pipe", "pipe", "pipe"],
+      }),
+    });
+    clients.push(rpc);
+    rpc.onMessage(async (message) => {
+      if (message.method !== "mock/gated-notification") return;
+      notificationEntered.resolve(undefined);
+      await releaseNotification.promise;
+    });
+    rpc.onDisconnect((generation) => disconnected.resolve(generation));
+
+    await rpc.start();
+    const request = rpc.requestConnectedApplied(
+      "thread/read",
+      {
+        threadId: "snapshot-queued-before-disconnect",
+        includeTurns: true,
+      },
+      1,
+      async () => {
+        applyCalls += 1;
+      },
+    );
+    void request.catch(() => {});
+    const privateState = rpc as unknown as {
+      pending: Map<string, {
+        responseReceived: boolean;
+        applyStarted: boolean;
+      }>;
+      messageDispatchTail: Promise<void>;
+    };
+
+    try {
+      await notificationEntered.promise;
+      await waitFor(
+        () =>
+          [...privateState.pending.values()].some(
+            ({ responseReceived, applyStarted }) =>
+              responseReceived && !applyStarted,
+          ),
+        "snapshot response was not queued behind the slow notification",
+      );
+      expect(applyCalls).toBe(0);
+      await expect(disconnected.promise).resolves.toBe(1);
+
+      await expect(Promise.race([
+        request,
+        new Promise<never>((_, reject) => {
+          setTimeout(
+            () => reject(new Error("queued snapshot request did not reject after disconnect")),
+            500,
+          );
+        }),
+      ])).rejects.toBeInstanceOf(CodexRpcDisconnectedError);
+      expect(applyCalls).toBe(0);
+      expect(privateState.pending.size).toBe(0);
+    } finally {
+      releaseNotification.resolve(undefined);
+    }
+
+    await privateState.messageDispatchTail;
+    expect(applyCalls).toBe(0);
+    expect(privateState.pending.size).toBe(0);
+  });
+
+  test("holds a disconnected same-thread snapshot applier ahead of generation-2 recovery and fences its nested write", async () => {
+    const callsPath = join(temp, "snapshot-session-lane-calls.jsonl");
+    let spawnGeneration = 0;
+    const disconnected = deferred<number>();
+    const oldApplyEntered = deferred<void>();
+    const releaseOldApply = deferred<void>();
+    const recovered = deferred<CodexFrontendRecovery>();
+    const rpc = new CodexRpcClient({
+      reconnectDelayMs: 60_000,
+      maxReconnectDelayMs: 60_000,
+      spawnProxy: () => {
+        const generation = ++spawnGeneration;
+        const server = `
+          const { appendFileSync } = require("node:fs");
+          const { createInterface } = require("node:readline");
+          const input = createInterface({ input: process.stdin });
+          const record = (method) => appendFileSync(
+            ${JSON.stringify(callsPath)},
+            JSON.stringify({ generation: ${generation}, method }) + "\\n",
+          );
+          const send = (id, result) =>
+            process.stdout.write(JSON.stringify({ id, result }) + "\\n");
+          const thread = {
+            thread: {
+              id: "thread-session-lane",
+              status: { type: "idle" },
+              turns: [],
+            },
+          };
+          input.on("line", (line) => {
+            const frame = JSON.parse(line);
+            record(frame.method || "<response>");
+            if (frame.method === "initialized") return;
+            if (frame.method === "initialize") {
+              send(frame.id, {
+                userAgent: "session-lane-test/${generation}",
+                platformFamily: "unix",
+              });
+              return;
+            }
+            if (
+              frame.method === "thread/start" ||
+              frame.method === "thread/resume" ||
+              frame.method === "thread/read"
+            ) {
+              send(frame.id, thread);
+              if (${generation} === 1 && frame.method === "thread/read") {
+                setTimeout(() => process.exit(79), 10);
+              }
+              return;
+            }
+            if (frame.method === "turn/start") {
+              send(frame.id, { turn: { id: "unexpected-cross-generation-turn" } });
+              return;
+            }
+            send(frame.id, {});
+          });
+        `;
+        return spawn("bun", ["-e", server], {
+          stdio: ["pipe", "pipe", "pipe"],
+        });
+      },
+    });
+    clients.push(rpc);
+    rpc.onDisconnect((generation) => disconnected.resolve(generation));
+    const session = new CodexSessionController(rpc);
+    session.onFrontendRecovery((event) => {
+      if (event.generation === 2) recovered.resolve(event);
+    });
+
+    await session.start();
+    await session.request("thread/start", {});
+    await session.request("turn/start", {
+      threadId: "thread-session-lane",
+      clientUserMessageId: null,
+      input: [{
+        type: "text",
+        text: "finish the bootstrap before probing snapshot recovery",
+        text_elements: [],
+      }],
+    });
+
+    const privateSession = session as unknown as {
+      routeThreadResponse: (
+        method: string,
+        result: unknown,
+        params: Record<string, unknown>,
+      ) => Promise<void>;
+      requestConnected: (method: string, params?: unknown) => Promise<unknown>;
+    };
+    const originalRouteThreadResponse =
+      privateSession.routeThreadResponse.bind(session);
+    let interceptedOldRead = false;
+    privateSession.routeThreadResponse = async (method, result, params) => {
+      if (method === "thread/read" && !interceptedOldRead) {
+        interceptedOldRead = true;
+        oldApplyEntered.resolve(undefined);
+        await releaseOldApply.promise;
+        // attachThread may flush a queued AgentParty input. Model that nested
+        // write explicitly so this regression proves the old generation fence
+        // survives while the snapshot callback is awaiting.
+        await privateSession.requestConnected("turn/start", {
+          threadId: "thread-session-lane",
+          input: [],
+        });
+        return;
+      }
+      await originalRouteThreadResponse(method, result, params);
+    };
+
+    const oldRead = session.request("thread/read", {
+      threadId: "thread-session-lane",
+      includeTurns: true,
+    });
+    void oldRead.catch(() => {});
+    await oldApplyEntered.promise;
+    await expect(disconnected.promise).resolves.toBe(1);
+
+    await rpc.start();
+    expect(rpc.connectionGeneration).toBe(2);
+    const recordedCalls = (): RpcCall[] => {
+      try {
+        return readFileSync(callsPath, "utf8")
+          .trim()
+          .split("\n")
+          .filter(Boolean)
+          .map((line) => JSON.parse(line) as RpcCall);
+      } catch {
+        return [];
+      }
+    };
+    await waitFor(
+      () =>
+        recordedCalls().some(({ generation, method }) =>
+          generation === 2 && method === "initialized"
+        ),
+      "replacement app-server did not finish its initialize handshake",
+    );
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(
+      recordedCalls()
+        .filter(({ generation }) => generation === 2)
+        .map(({ method }) => method),
+    ).toEqual(["initialize", "initialized"]);
+
+    releaseOldApply.resolve(undefined);
+    await expect(oldRead).rejects.toBeInstanceOf(CodexRpcDisconnectedError);
+    await expect(recovered.promise).resolves.toEqual({
+      disposition: "resume",
+      threadId: "thread-session-lane",
+      generation: 2,
+    });
+    await waitFor(
+      () =>
+        recordedCalls().some(({ generation, method }) =>
+          generation === 2 && method === "thread/read"
+        ),
+      "generation-2 recovery did not complete its authoritative read",
+    );
+    const generationTwoMethods = recordedCalls()
+      .filter(({ generation }) => generation === 2)
+      .map(({ method }) => method);
+    expect(generationTwoMethods).toEqual([
+      "initialize",
+      "initialized",
+      "thread/resume",
+      "thread/read",
+    ]);
+    expect(generationTwoMethods).not.toContain("turn/start");
+  });
+
+  test("orders same-chunk item notifications and read or rollback snapshots in both directions", async () => {
+    for (
+      const [method, order] of [
+        ["thread/read", "notification-first"],
+        ["thread/rollback", "notification-first"],
+        ["thread/read", "response-first"],
+        ["thread/rollback", "response-first"],
+      ] as const
+    ) {
+      const suffix = `${method.replace("/", "-")}-${order}`;
+      const threadId = `thread-wire-barrier-${suffix}`;
+      const turnId = `turn-wire-barrier-${suffix}`;
+      const clientId = `agentparty:wire-barrier-${suffix}`;
+      const server = `
+        const { createInterface } = require("node:readline");
+        const input = createInterface({ input: process.stdin });
+        const send = (value) => process.stdout.write(JSON.stringify(value) + "\\n");
+        const snapshot = {
+          thread: {
+            id: ${JSON.stringify(threadId)},
+            status: { type: "idle" },
+            turns: [],
+          },
+        };
+        input.on("line", (line) => {
+          const frame = JSON.parse(line);
+          const params = frame.params || {};
+          if (frame.method === "initialized") return;
+          if (frame.method === "initialize") {
+            send({
+              id: frame.id,
+              result: {
+                userAgent: "wire-barrier-test/0.144.4",
+                platformFamily: "unix",
+              },
+            });
+            return;
+          }
+          if (frame.method === "thread/start") {
+            send({ id: frame.id, result: snapshot });
+            return;
+          }
+          if (frame.method === "thread/read" && params.listenerProbe === true) {
+            send({ id: frame.id, result: snapshot });
+            return;
+          }
+          if (frame.method === ${JSON.stringify(method)}) {
+            const notification = {
+              method: "item/completed",
+              params: {
+                threadId: ${JSON.stringify(threadId)},
+                turnId: ${JSON.stringify(turnId)},
+                item: {
+                  type: "userMessage",
+                  id: "user-wire-barrier",
+                  clientId: ${JSON.stringify(clientId)},
+                  content: [],
+                },
+              },
+            };
+            const response = { id: frame.id, result: snapshot };
+            const frames = ${JSON.stringify(order)} === "notification-first"
+              ? [notification, response]
+              : [response, notification];
+            process.stdout.write(
+              frames.map((value) => JSON.stringify(value) + "\\n").join(""),
+            );
+            return;
+          }
+          send({ id: frame.id, result: {} });
+        });
+      `;
+      const rpc = new CodexRpcClient({
+        spawnProxy: () => spawn("bun", ["-e", server], {
+          stdio: ["pipe", "pipe", "pipe"],
+        }),
+      });
+      clients.push(rpc);
+
+      const notificationEntered = deferred<void>();
+      const releaseNotification = deferred<void>();
+      const listenerRead = deferred<unknown>();
+      let listenerApplyCount = 0;
+      const delayedPeer: CodexRpcPeer = {
+        get initializeResult() {
+          return rpc.initializeResult;
+        },
+        get connected() {
+          return rpc.connected;
+        },
+        get connectionGeneration() {
+          return rpc.connectionGeneration;
+        },
+        start: () => rpc.start(),
+        request: (rpcMethod, params) => rpc.request(rpcMethod, params),
+        requestConnected: (rpcMethod, params, expectedGeneration) =>
+          rpc.requestConnected(rpcMethod, params, expectedGeneration),
+        requestConnectedApplied: (
+          rpcMethod,
+          params,
+          expectedGeneration,
+          applyResponse,
+        ) => rpc.requestConnectedApplied(
+          rpcMethod,
+          params,
+          expectedGeneration,
+          applyResponse,
+        ),
+        notify: (rpcMethod, params) => rpc.notify(rpcMethod, params),
+        notifyConnected: (rpcMethod, params) => rpc.notifyConnected(rpcMethod, params),
+        respond: (id, result, error) => rpc.respond(id, result, error),
+        onMessage: (listener) =>
+          rpc.onMessage(async (message) => {
+            const params = message.params as Record<string, unknown> | undefined;
+            const item = params?.item as Record<string, unknown> | undefined;
+            if (
+              message.method === "item/completed" &&
+              item?.clientId === clientId
+            ) {
+              notificationEntered.resolve(undefined);
+              await releaseNotification.promise;
+              // Snapshot methods issued from inside the dispatch listener must
+              // bypass their own barrier; otherwise this request waits on the
+              // dispatch that is awaiting it.
+              listenerRead.resolve(await rpc.requestConnectedApplied(
+                "thread/read",
+                {
+                  threadId,
+                  includeTurns: true,
+                  listenerProbe: true,
+                },
+                rpc.connectionGeneration ?? undefined,
+                async () => {
+                  listenerApplyCount += 1;
+                },
+              ));
+            }
+            await listener(message);
+          }),
+        onReconnect: (listener) => rpc.onReconnect(listener),
+        onDisconnect: (listener) => rpc.onDisconnect(listener),
+      };
+      const session = new CodexSessionController(delayedPeer);
+
+      await session.start();
+      await session.request("thread/start", {});
+      const snapshotRequest = session.request(method, {
+        threadId,
+        ...(method === "thread/read" ? { includeTurns: true } : {}),
+      });
+      let snapshotSettled = false;
+      void snapshotRequest.then(
+        () => {
+          snapshotSettled = true;
+        },
+        () => {
+          snapshotSettled = true;
+        },
+      );
+      if (order === "notification-first") {
+        await notificationEntered.promise;
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(snapshotSettled).toBe(false);
+        expect(session.turnForClientId(clientId)).toBeNull();
+      } else {
+        await expect(snapshotRequest).resolves.toMatchObject({
+          thread: { id: threadId, turns: [] },
+        });
+        await notificationEntered.promise;
+        expect(snapshotSettled).toBe(true);
+        expect(session.turnForClientId(clientId)).toBeNull();
+      }
+
+      releaseNotification.resolve(undefined);
+      await expect(Promise.race([
+        listenerRead.promise,
+        new Promise<never>((_, reject) => {
+          setTimeout(
+            () => reject(new Error(`${method} listener RPC deadlocked on its own dispatch`)),
+            2_000,
+          );
+        }),
+      ])).resolves.toEqual({
+        thread: {
+          id: threadId,
+          status: { type: "idle" },
+          turns: [],
+        },
+      });
+      expect(listenerApplyCount).toBe(1);
+      const state = session as unknown as {
+        turns: Map<string, CodexTurn>;
+        turnByClientId: Map<string, string>;
+      };
+      if (order === "notification-first") {
+        await expect(snapshotRequest).resolves.toMatchObject({
+          thread: { id: threadId, turns: [] },
+        });
+        expect(session.turnForClientId(clientId)).toBeNull();
+        expect(state.turns.has(turnId)).toBe(false);
+        expect(state.turnByClientId.has(clientId)).toBe(false);
+      } else {
+        await waitFor(
+          () => session.turnForClientId(clientId) !== null,
+          `${method} response-first item notification was not retained`,
+        );
+        expect(session.turnForClientId(clientId)).toMatchObject({
+          id: turnId,
+          status: "inProgress",
+        });
+        expect(state.turns.has(turnId)).toBe(true);
+        expect(state.turnByClientId.get(clientId)).toBe(turnId);
+      }
+    }
+  });
+
+  test("uses authoritative completed items after reattach and terminal lifecycle duplicates", async () => {
+    const rpc = new ScriptedCodexRpc();
+    rpc.queue("thread/start", idleThread("thread-agent-text"));
+    rpc.queue("thread/read", {
+      thread: {
+        id: "thread-agent-text",
+        status: { type: "active" },
+        turns: [{
+          id: "turn-agent-text",
+          status: "inProgress",
+          items: [],
+        }],
+      },
+    });
+    const session = new CodexSessionController(rpc);
+    const completed: CodexTurn[] = [];
+    session.onTurnCompleted((turn) => {
+      completed.push(turn);
+    });
+
+    await session.start();
+    await session.request("thread/start", {});
+    await rpc.emit({
+      method: "turn/started",
+      params: {
+        threadId: "thread-agent-text",
+        turn: {
+          id: "turn-agent-text",
+          status: "inProgress",
+          items: [],
+          itemsView: "notLoaded",
+        },
+      },
+    });
+    await rpc.emit({
+      method: "item/agentMessage/delta",
+      params: {
+        threadId: "thread-agent-text",
+        turnId: "turn-agent-text",
+        itemId: "agent-final",
+        delta: "streamed partial",
+      },
+    });
+
+    // A thread/read snapshot is authoritative even on the same thread. Do not
+    // let pre-snapshot deltas resurrect items removed by rollback/recovery.
+    await session.request("thread/read", {
+      threadId: "thread-agent-text",
+      includeTurns: true,
+    });
+    expect(
+      (session as unknown as {
+        agentMessagesByTurn: Map<string, unknown>;
+      }).agentMessagesByTurn.size,
+    ).toBe(0);
+    const completedItem = {
+      type: "agentMessage",
+      id: "agent-final",
+      text: "authoritative final",
+      phase: "final_answer",
+    };
+    await rpc.emit({
+      method: "item/completed",
+      params: {
+        threadId: "thread-agent-text",
+        turnId: "turn-agent-text",
+        item: completedItem,
+      },
+    });
+    await rpc.emit({
+      method: "item/completed",
+      params: {
+        threadId: "thread-agent-text",
+        turnId: "turn-agent-text",
+        item: completedItem,
+      },
+    });
+    await rpc.emit({
+      method: "item/agentMessage/delta",
+      params: {
+        threadId: "thread-agent-text",
+        turnId: "turn-agent-text",
+        itemId: "agent-final",
+        delta: " duplicate late delta",
+      },
+    });
+    const unloadedCompletion = {
+      method: "turn/completed",
+      params: {
+        threadId: "thread-agent-text",
+        turn: {
+          id: "turn-agent-text",
+          status: "completed",
+          items: [],
+          itemsView: "notLoaded",
+        },
+      },
+    } satisfies JsonRpcNotification;
+    await rpc.emit(unloadedCompletion);
+    await rpc.emit(unloadedCompletion);
+
+    expect(completed).toHaveLength(2);
+    for (const turn of completed) {
+      expect(turn.items).toContainEqual(expect.objectContaining({
+        type: "agentMessage",
+        id: "agent-final",
+        text: "authoritative final",
+      }));
+    }
+
+    await rpc.emit({
+      method: "item/started",
+      params: {
+        threadId: "thread-agent-text",
+        turnId: "turn-partial-only",
+        item: {
+          type: "agentMessage",
+          id: "agent-partial-only",
+          text: "not terminal",
+          phase: "final_answer",
+        },
+      },
+    });
+    await rpc.emit({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-agent-text",
+        turn: {
+          id: "turn-partial-only",
+          status: "completed",
+          items: [],
+          itemsView: "notLoaded",
+        },
+      },
+    });
+    expect(completed.at(-1)).toMatchObject({
+      id: "turn-partial-only",
+      status: "completed",
+      items: [],
+    });
+
+    // Interleaved terminal turns keep independent item buffers. Their status
+    // remains authoritative, so a delivery layer will still reject either.
+    await rpc.emit({
+      method: "item/agentMessage/delta",
+      params: {
+        threadId: "thread-agent-text",
+        turnId: "turn-interrupted",
+        itemId: "agent-interrupted",
+        delta: "interrupted text",
+      },
+    });
+    await rpc.emit({
+      method: "item/agentMessage/delta",
+      params: {
+        threadId: "thread-agent-text",
+        turnId: "turn-failed",
+        itemId: "agent-failed",
+        delta: "failed text",
+      },
+    });
+    await rpc.emit({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-agent-text",
+        turn: {
+          id: "turn-interrupted",
+          status: "interrupted",
+          items: [],
+          itemsView: "notLoaded",
+        },
+      },
+    });
+    await rpc.emit({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-agent-text",
+        turn: {
+          id: "turn-failed",
+          status: "failed",
+          items: [],
+          itemsView: "notLoaded",
+        },
+      },
+    });
+
+    expect(completed.at(-2)).toMatchObject({
+      id: "turn-interrupted",
+      status: "interrupted",
+      items: [],
+    });
+    expect(completed.at(-1)).toMatchObject({
+      id: "turn-failed",
+      status: "failed",
+      items: [],
+    });
+    expect(
+      (session as unknown as {
+        agentMessagesByTurn: Map<string, unknown>;
+      }).agentMessagesByTurn.size,
+    ).toBe(0);
+  });
+
+  test("associates a client id and canonical items from item lifecycle events", async () => {
+    const rpc = new ScriptedCodexRpc();
+    rpc.queue("thread/start", idleThread("thread-item-lifecycle"));
+    const session = new CodexSessionController(rpc);
+    const dispatches: Array<{
+      clientId: string;
+      turnId: string | null;
+    }> = [];
+    session.onDispatch((input, dispatch) => {
+      dispatches.push({
+        clientId: input.clientUserMessageId,
+        turnId: dispatch.turnId ?? null,
+      });
+    });
+
+    await session.start();
+    await session.request("thread/start", {});
+    await rpc.emit({
+      method: "turn/started",
+      params: {
+        threadId: "thread-item-lifecycle",
+        turn: {
+          id: "turn-item-lifecycle",
+          status: "inProgress",
+          items: [],
+          itemsView: "notLoaded",
+        },
+      },
+    });
+    await rpc.emit({
+      method: "item/completed",
+      params: {
+        threadId: "thread-item-lifecycle",
+        turnId: "turn-item-lifecycle",
+        item: {
+          type: "userMessage",
+          id: "user-item",
+          clientId: "agentparty:late-accepted",
+          content: [],
+        },
+      },
+    });
+    await rpc.emit({
+      method: "item/completed",
+      params: {
+        threadId: "thread-item-lifecycle",
+        turnId: "turn-item-lifecycle",
+        item: {
+          type: "userMessage",
+          id: "user-item",
+          clientId: "agentparty:late-accepted",
+          content: [],
+        },
+      },
+    });
+    await rpc.emit({
+      method: "item/completed",
+      params: {
+        threadId: "thread-item-lifecycle",
+        turnId: "turn-item-lifecycle",
+        item: {
+          type: "agentMessage",
+          id: "agent-item",
+          text: "late authoritative reply",
+          phase: "final_answer",
+        },
+      },
+    });
+    await rpc.emit({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-item-lifecycle",
+        turn: {
+          id: "turn-item-lifecycle",
+          status: "completed",
+          items: [],
+          itemsView: "notLoaded",
+        },
+      },
+    });
+
+    expect(dispatches).toContainEqual({
+      clientId: "agentparty:late-accepted",
+      turnId: "turn-item-lifecycle",
+    });
+    expect(
+      dispatches.filter(({ clientId }) => clientId === "agentparty:late-accepted"),
+    ).toHaveLength(1);
+    expect(session.turnForClientId("agentparty:late-accepted")).toMatchObject({
+      id: "turn-item-lifecycle",
+      status: "completed",
+      items: [
+        expect.objectContaining({
+          type: "userMessage",
+          clientId: "agentparty:late-accepted",
+        }),
+        expect.objectContaining({
+          type: "agentMessage",
+          text: "late authoritative reply",
+        }),
+      ],
+    });
+
+    await rpc.emit({
+      method: "turn/started",
+      params: {
+        threadId: "thread-item-lifecycle",
+        turn: {
+          id: "turn-duplicate-user-lifecycle",
+          status: "inProgress",
+          items: [],
+          itemsView: "notLoaded",
+        },
+      },
+    });
+    const duplicateUserItem = {
+      type: "userMessage",
+      id: "duplicate-user-item",
+      clientId: "agentparty:duplicate-lifecycle",
+      content: [],
+    };
+    await rpc.emit({
+      method: "item/started",
+      params: {
+        threadId: "thread-item-lifecycle",
+        turnId: "turn-duplicate-user-lifecycle",
+        item: duplicateUserItem,
+      },
+    });
+    await rpc.emit({
+      method: "item/completed",
+      params: {
+        threadId: "thread-item-lifecycle",
+        turnId: "turn-duplicate-user-lifecycle",
+        item: duplicateUserItem,
+      },
+    });
+    expect(
+      dispatches.filter(({ clientId }) =>
+        clientId === "agentparty:duplicate-lifecycle"
+      ),
+    ).toHaveLength(1);
+  });
+
+  test("drops multi-megabyte tool lifecycle payloads and bounds completed turn affinity", async () => {
+    const rpc = new ScriptedCodexRpc();
+    rpc.queue("thread/start", idleThread("thread-retention"));
+    const session = new CodexSessionController(rpc);
+    await session.start();
+    await session.request("thread/start", {});
+
+    const heavyTurnId = "turn-heavy-lifecycle";
+    const heavyClientId = "agentparty:heavy-lifecycle";
+    const multiMegabytePayload =
+      `MULTI_MEGABYTE_TOOL_PAYLOAD:${"x".repeat(3 * 1_024 * 1_024)}`;
+    await rpc.emit({
+      method: "turn/started",
+      params: {
+        threadId: "thread-retention",
+        turn: {
+          id: heavyTurnId,
+          status: "inProgress",
+          items: [],
+          itemsView: "notLoaded",
+        },
+      },
+    });
+    await rpc.emit({
+      method: "item/completed",
+      params: {
+        threadId: "thread-retention",
+        turnId: heavyTurnId,
+        item: {
+          type: "userMessage",
+          id: "user-heavy-lifecycle",
+          clientId: heavyClientId,
+          content: [{ type: "text", text: "retain only affinity" }],
+        },
+      },
+    });
+    for (const item of [
+      {
+        type: "commandExecution",
+        id: "command-heavy-lifecycle",
+        command: "/usr/bin/printf payload",
+        aggregatedOutput: multiMegabytePayload,
+        status: "completed",
+      },
+      {
+        type: "mcpToolCall",
+        id: "mcp-heavy-lifecycle",
+        server: "large-fixture",
+        tool: "return_payload",
+        result: { content: multiMegabytePayload },
+        status: "completed",
+      },
+    ]) {
+      await rpc.emit({
+        method: "item/started",
+        params: {
+          threadId: "thread-retention",
+          turnId: heavyTurnId,
+          item,
+        },
+      });
+      await rpc.emit({
+        method: "item/completed",
+        params: {
+          threadId: "thread-retention",
+          turnId: heavyTurnId,
+          item,
+        },
+      });
+    }
+
+    const privateState = session as unknown as {
+      turns: Map<string, CodexTurn>;
+      turnByClientId: Map<string, string>;
+    };
+    expect(privateState.turns.get(heavyTurnId)).toEqual({
+      id: heavyTurnId,
+      status: "inProgress",
+      items: [{
+        type: "userMessage",
+        id: "user-heavy-lifecycle",
+        clientId: heavyClientId,
+      }],
+    });
+    expect(JSON.stringify([...privateState.turns.values()])).not.toContain(
+      "MULTI_MEGABYTE_TOOL_PAYLOAD",
+    );
+
+    await rpc.emit({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-retention",
+        turn: {
+          id: heavyTurnId,
+          status: "completed",
+          items: [],
+          itemsView: "notLoaded",
+        },
+      },
+    });
+    for (let index = 0; index < 260; index += 1) {
+      const turnId = `turn-retained-${index}`;
+      const clientId = `agentparty:retained-${index}`;
+      await rpc.emit({
+        method: "turn/started",
+        params: {
+          threadId: "thread-retention",
+          turn: {
+            id: turnId,
+            status: "inProgress",
+            items: [{
+              type: "userMessage",
+              id: `user-retained-${index}`,
+              clientId,
+              content: [{ type: "text", text: `input ${index}` }],
+            }],
+          },
+        },
+      });
+      await rpc.emit({
+        method: "turn/completed",
+        params: {
+          threadId: "thread-retention",
+          turn: {
+            id: turnId,
+            status: "completed",
+            items: [],
+            itemsView: "notLoaded",
+          },
+        },
+      });
+    }
+
+    // The implementation deliberately keeps at most 256 completed turns and
+    // evicts their clientId affinity in lockstep.
+    expect(privateState.turns.size).toBe(256);
+    expect(privateState.turnByClientId.size).toBe(256);
+    expect(session.turnForClientId(heavyClientId)).toBeNull();
+    expect(session.turnForClientId("agentparty:retained-0")).toBeNull();
+    expect(session.turnForClientId("agentparty:retained-259")).toMatchObject({
+      id: "turn-retained-259",
+      status: "completed",
+    });
+    const retainedJson = JSON.stringify([...privateState.turns.values()]);
+    expect(retainedJson).not.toContain("MULTI_MEGABYTE_TOOL_PAYLOAD");
+    expect(Buffer.byteLength(retainedJson)).toBeLessThan(256 * 1_024);
+  });
+
   for (const method of ["thread/start", "thread/resume"] as const) {
     test(`${method} serializes a concurrent submit behind the thread switch`, async () => {
       const rpc = new ScriptedCodexRpc();
@@ -628,6 +1884,92 @@ describe("Codex app-server stdio JSON-RPC and reconnect recovery", () => {
         }]);
       }
     }
+  });
+
+  test("reprojects accepted unknown bootstrap proof without retaining content beyond the cache cap", async () => {
+    const rpc = new ScriptedCodexRpc();
+    const turnResponse = deferred<unknown>();
+    const recoveries: CodexFrontendRecovery[] = [];
+    const completed: CodexTurn[] = [];
+    const initialInput = [{
+      type: "text",
+      text: `BOOTSTRAP_PROOF_OVER_CAP:${"b".repeat(16 * 1_024 * 1_024)}`,
+      text_elements: [],
+    }];
+    const recoveredTurn = {
+      id: "turn-bootstrap-proof-over-cap",
+      status: "completed" as const,
+      items: [{
+        type: "userMessage",
+        id: "user-bootstrap-proof-over-cap",
+        clientId: null,
+        content: initialInput,
+      }],
+    };
+    rpc.queue("thread/start", idleThread("thread-bootstrap-proof-over-cap"));
+    rpc.queue("turn/start", () => turnResponse.promise);
+    rpc.queue("thread/resume", idleThread("thread-bootstrap-proof-over-cap"));
+    rpc.queue("thread/read", {
+      thread: {
+        id: "thread-bootstrap-proof-over-cap",
+        status: { type: "idle" },
+        turns: [recoveredTurn],
+      },
+    });
+    const session = new CodexSessionController(rpc);
+    session.onFrontendRecovery((event) => {
+      recoveries.push(event);
+    });
+    session.onTurnCompleted((turn) => {
+      completed.push(turn);
+    });
+
+    await session.request("thread/start", {});
+    const starting = session.request("turn/start", {
+      threadId: "thread-bootstrap-proof-over-cap",
+      clientUserMessageId: null,
+      input: initialInput,
+    });
+    await waitFor(
+      () => rpc.calls.some((call) => call.method === "turn/start"),
+      "oversized bootstrap prompt did not cross the scripted transport",
+    );
+    rpc.disconnect();
+    turnResponse.reject(new CodexRpcDisconnectedError("lost after oversized prompt write"));
+    await expect(starting).rejects.toBeInstanceOf(CodexRpcDisconnectedError);
+    await rpc.reconnect();
+
+    expect(recoveries).toEqual([{
+      disposition: "resume",
+      threadId: "thread-bootstrap-proof-over-cap",
+      generation: 2,
+    }]);
+    expect(completed).toHaveLength(1);
+    expect(Buffer.byteLength(JSON.stringify(completed[0]))).toBeGreaterThan(
+      16 * 1_024 * 1_024,
+    );
+    expect(completed[0]?.items?.[0]).toHaveProperty("content", initialInput);
+
+    const state = session as unknown as {
+      turns: Map<string, CodexTurn>;
+      bootstrapRecovery: unknown;
+      bootstrapThreadId: string | null;
+    };
+    expect(state.bootstrapRecovery).toBeNull();
+    expect(state.bootstrapThreadId).toBeNull();
+    expect(state.turns.get(recoveredTurn.id)).toEqual({
+      id: recoveredTurn.id,
+      status: "completed",
+      items: [{
+        type: "userMessage",
+        id: "user-bootstrap-proof-over-cap",
+        clientId: null,
+      }],
+    });
+    const retainedBytes = Buffer.byteLength(
+      JSON.stringify([...state.turns.values()]),
+    );
+    expect(retainedBytes).toBeLessThan(16 * 1_024 * 1_024);
   });
 
   test("an accepted initial turn resumes even if the backend drops before the TUI sees its response", async () => {

--- a/cli/test/codex-app-server-rpc.test.ts
+++ b/cli/test/codex-app-server-rpc.test.ts
@@ -375,9 +375,10 @@ describe("Codex app-server stdio JSON-RPC and reconnect recovery", () => {
                   },
                 },
               });
-              if (${generation} === 1) {
-                setTimeout(() => process.exit(77), 10);
-              }
+              return;
+            }
+            if (frame.method === "mock/exit") {
+              process.exit(77);
               return;
             }
             send({ id: frame.id, result: {} });
@@ -416,6 +417,7 @@ describe("Codex app-server stdio JSON-RPC and reconnect recovery", () => {
     );
 
     await oldApplyEntered.promise;
+    rpc.notifyConnected("mock/exit");
     await expect(disconnected.promise).resolves.toBe(1);
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(oldRequestSettled).toBe(false);
@@ -943,6 +945,9 @@ describe("Codex app-server stdio JSON-RPC and reconnect recovery", () => {
       const state = session as unknown as {
         turns: Map<string, CodexTurn>;
         turnByClientId: Map<string, string>;
+        retainedTurnBytesById: Map<string, number>;
+        retainedCompletedTurnBytes: number;
+        retainedCompletedTurnCount: number;
       };
       if (order === "notification-first") {
         await expect(snapshotRequest).resolves.toMatchObject({
@@ -951,6 +956,9 @@ describe("Codex app-server stdio JSON-RPC and reconnect recovery", () => {
         expect(session.turnForClientId(clientId)).toBeNull();
         expect(state.turns.has(turnId)).toBe(false);
         expect(state.turnByClientId.has(clientId)).toBe(false);
+        expect(state.retainedTurnBytesById.size).toBe(0);
+        expect(state.retainedCompletedTurnBytes).toBe(0);
+        expect(state.retainedCompletedTurnCount).toBe(0);
       } else {
         await waitFor(
           () => session.turnForClientId(clientId) !== null,
@@ -962,6 +970,9 @@ describe("Codex app-server stdio JSON-RPC and reconnect recovery", () => {
         });
         expect(state.turns.has(turnId)).toBe(true);
         expect(state.turnByClientId.get(clientId)).toBe(turnId);
+        expect(state.retainedTurnBytesById.has(turnId)).toBe(true);
+        expect(state.retainedCompletedTurnBytes).toBe(0);
+        expect(state.retainedCompletedTurnCount).toBe(0);
       }
     }
   });
@@ -1073,7 +1084,77 @@ describe("Codex app-server stdio JSON-RPC and reconnect recovery", () => {
         type: "agentMessage",
         id: "agent-final",
         text: "authoritative final",
+        phase: "final_answer",
       }));
+    }
+
+    for (const [suffix, phase] of [
+      ["explicit-final", "final_answer"],
+      ["legacy-final", undefined],
+    ] as const) {
+      const turnId = `turn-${suffix}`;
+      const itemId = `agent-${suffix}`;
+      await rpc.emit({
+        method: "turn/started",
+        params: {
+          threadId: "thread-agent-text",
+          turn: {
+            id: turnId,
+            status: "inProgress",
+            items: [],
+            itemsView: "notLoaded",
+          },
+        },
+      });
+      await rpc.emit({
+        method: "item/completed",
+        params: {
+          threadId: "thread-agent-text",
+          turnId,
+          item: {
+            type: "agentMessage",
+            id: itemId,
+            text: `${suffix} authoritative text`,
+            ...(phase === undefined ? {} : { phase }),
+          },
+        },
+      });
+      // Some app-server snapshots reuse the item id but contain only an empty
+      // commentary shell. Text and phase must both come from the completed
+      // lifecycle item; keeping the shell's phase would hide a valid final.
+      const emptyShellCompletion = {
+        method: "turn/completed",
+        params: {
+          threadId: "thread-agent-text",
+          turn: {
+            id: turnId,
+            status: "completed",
+            items: [{
+              type: "agentMessage",
+              id: itemId,
+              text: "",
+              phase: "commentary",
+            }],
+          },
+        },
+      } satisfies JsonRpcNotification;
+      const completedBefore = completed.length;
+      await rpc.emit(emptyShellCompletion);
+      await rpc.emit(emptyShellCompletion);
+      expect(completed.slice(completedBefore)).toHaveLength(2);
+      for (const completedTurn of completed.slice(completedBefore)) {
+        const finalItem = completedTurn.items?.find((item) => item.id === itemId);
+        expect(finalItem).toMatchObject({
+          type: "agentMessage",
+          id: itemId,
+          text: `${suffix} authoritative text`,
+        });
+        if (phase === undefined) {
+          expect(finalItem?.phase).toBeUndefined();
+        } else {
+          expect(finalItem?.phase).toBe(phase);
+        }
+      }
     }
 
     await rpc.emit({
@@ -1313,6 +1394,72 @@ describe("Codex app-server stdio JSON-RPC and reconnect recovery", () => {
     ).toHaveLength(1);
   });
 
+  test("updates retained turn byte accounting without rescanning completed history", () => {
+    const session = new CodexSessionController(new ScriptedCodexRpc());
+    const internal = session as unknown as {
+      turns: Map<string, CodexTurn>;
+      retainedTurnBytesById: Map<string, number>;
+      retainedCompletedTurnBytes: number;
+      retainedCompletedTurnCount: number;
+      retainedTurnBytes: (turn: CodexTurn) => number;
+      storeTurn: (turn: CodexTurn) => CodexTurn;
+    };
+    const retainedTurnBytes = internal.retainedTurnBytes.bind(session);
+    let serializedTurns = 0;
+    internal.retainedTurnBytes = (turn) => {
+      serializedTurns += 1;
+      return retainedTurnBytes(turn);
+    };
+
+    for (let index = 0; index < 16; index += 1) {
+      internal.storeTurn({
+        id: `completed-${index}`,
+        status: "completed",
+        items: [{
+          type: "agentMessage",
+          id: `final-${index}`,
+          text: `final ${index}`,
+          phase: "final_answer",
+        }],
+      });
+    }
+    const completedBytes = internal.retainedCompletedTurnBytes;
+    serializedTurns = 0;
+
+    internal.storeTurn({ id: "active", status: "inProgress", items: [] });
+    expect(serializedTurns).toBe(1);
+    expect(internal.retainedCompletedTurnCount).toBe(16);
+    expect(internal.retainedCompletedTurnBytes).toBe(completedBytes);
+
+    const replacedBytes = internal.retainedTurnBytesById.get("completed-0")!;
+    internal.storeTurn({ id: "completed-0", status: "inProgress", items: [] });
+    expect(serializedTurns).toBe(2);
+    expect(internal.retainedCompletedTurnCount).toBe(15);
+    expect(internal.retainedCompletedTurnBytes).toBe(completedBytes - replacedBytes);
+
+    internal.storeTurn({
+      id: "completed-0",
+      status: "completed",
+      items: [{
+        type: "agentMessage",
+        id: "replacement-final",
+        text: "replacement final",
+        phase: "final_answer",
+      }],
+    });
+    expect(serializedTurns).toBe(3);
+    expect(internal.retainedCompletedTurnCount).toBe(16);
+    expect(internal.retainedCompletedTurnBytes).toBe(
+      [...internal.turns.entries()]
+        .filter(([, turn]) => turn.status !== "inProgress")
+        .reduce(
+          (total, [turnId]) =>
+            total + (internal.retainedTurnBytesById.get(turnId) ?? 0),
+          0,
+        ),
+    );
+  });
+
   test("drops multi-megabyte tool lifecycle payloads and bounds completed turn affinity", async () => {
     const rpc = new ScriptedCodexRpc();
     rpc.queue("thread/start", idleThread("thread-retention"));
@@ -1387,6 +1534,9 @@ describe("Codex app-server stdio JSON-RPC and reconnect recovery", () => {
     const privateState = session as unknown as {
       turns: Map<string, CodexTurn>;
       turnByClientId: Map<string, string>;
+      retainedTurnBytesById: Map<string, number>;
+      retainedCompletedTurnBytes: number;
+      retainedCompletedTurnCount: number;
     };
     expect(privateState.turns.get(heavyTurnId)).toEqual({
       id: heavyTurnId,
@@ -1450,6 +1600,12 @@ describe("Codex app-server stdio JSON-RPC and reconnect recovery", () => {
     // evicts their clientId affinity in lockstep.
     expect(privateState.turns.size).toBe(256);
     expect(privateState.turnByClientId.size).toBe(256);
+    expect(privateState.retainedTurnBytesById.size).toBe(privateState.turns.size);
+    expect(privateState.retainedCompletedTurnCount).toBe(256);
+    expect(privateState.retainedCompletedTurnBytes).toBe(
+      [...privateState.retainedTurnBytesById.values()]
+        .reduce((total, bytes) => total + bytes, 0),
+    );
     expect(session.turnForClientId(heavyClientId)).toBeNull();
     expect(session.turnForClientId("agentparty:retained-0")).toBeNull();
     expect(session.turnForClientId("agentparty:retained-259")).toMatchObject({

--- a/cli/test/codex-app-server-rpc.test.ts
+++ b/cli/test/codex-app-server-rpc.test.ts
@@ -1158,6 +1158,138 @@ describe("Codex app-server stdio JSON-RPC and reconnect recovery", () => {
     }
 
     await rpc.emit({
+      method: "turn/started",
+      params: {
+        threadId: "thread-agent-text",
+        turn: {
+          id: "turn-delta-final",
+          status: "inProgress",
+          items: [],
+          itemsView: "notLoaded",
+        },
+      },
+    });
+    await rpc.emit({
+      method: "item/started",
+      params: {
+        threadId: "thread-agent-text",
+        turnId: "turn-delta-final",
+        item: {
+          type: "agentMessage",
+          id: "agent-delta-final",
+          text: "",
+          phase: "final_answer",
+        },
+      },
+    });
+    await rpc.emit({
+      method: "item/agentMessage/delta",
+      params: {
+        threadId: "thread-agent-text",
+        turnId: "turn-delta-final",
+        itemId: "agent-delta-final",
+        delta: "final retained from delta",
+      },
+    });
+    await rpc.emit({
+      method: "item/completed",
+      params: {
+        threadId: "thread-agent-text",
+        turnId: "turn-delta-final",
+        item: {
+          type: "agentMessage",
+          id: "agent-delta-final",
+          text: "",
+          phase: "final_answer",
+        },
+      },
+    });
+    await rpc.emit({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-agent-text",
+        turn: {
+          id: "turn-delta-final",
+          status: "completed",
+          items: [],
+          itemsView: "notLoaded",
+        },
+      },
+    });
+    expect(completed.at(-1)?.items).toContainEqual(expect.objectContaining({
+      type: "agentMessage",
+      id: "agent-delta-final",
+      text: "final retained from delta",
+      phase: "final_answer",
+    }));
+
+    await rpc.emit({
+      method: "turn/started",
+      params: {
+        threadId: "thread-agent-text",
+        turn: {
+          id: "turn-empty-delta",
+          status: "inProgress",
+          items: [],
+          itemsView: "notLoaded",
+        },
+      },
+    });
+    await rpc.emit({
+      method: "item/started",
+      params: {
+        threadId: "thread-agent-text",
+        turnId: "turn-empty-delta",
+        item: {
+          type: "agentMessage",
+          id: "agent-empty-delta",
+          text: "non-authoritative started text",
+          phase: "final_answer",
+        },
+      },
+    });
+    await rpc.emit({
+      method: "item/agentMessage/delta",
+      params: {
+        threadId: "thread-agent-text",
+        turnId: "turn-empty-delta",
+        itemId: "agent-empty-delta",
+        delta: "",
+      },
+    });
+    await rpc.emit({
+      method: "item/completed",
+      params: {
+        threadId: "thread-agent-text",
+        turnId: "turn-empty-delta",
+        item: {
+          type: "agentMessage",
+          id: "agent-empty-delta",
+          text: "",
+          phase: "final_answer",
+        },
+      },
+    });
+    await rpc.emit({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-agent-text",
+        turn: {
+          id: "turn-empty-delta",
+          status: "completed",
+          items: [],
+          itemsView: "notLoaded",
+        },
+      },
+    });
+    expect(completed.at(-1)?.items).toContainEqual(expect.objectContaining({
+      type: "agentMessage",
+      id: "agent-empty-delta",
+      text: "",
+      phase: "final_answer",
+    }));
+
+    await rpc.emit({
       method: "item/started",
       params: {
         threadId: "thread-agent-text",

--- a/cli/test/codex-unix-proxy.test.ts
+++ b/cli/test/codex-unix-proxy.test.ts
@@ -824,6 +824,107 @@ describe("Codex Unix WebSocket single-writer proxy", () => {
     expect(internal.frontendReady).toBe(true);
   });
 
+  test("warns once per connection at high-water without logging payloads", () => {
+    const rpc = new FakeRpcPeer();
+    const session = new CodexSessionController(rpc);
+    const logs: string[] = [];
+    proxy = new CodexUnixJsonRpcProxy(session, { log: (line) => logs.push(line) });
+    const socket = {
+      data: { connectionId: "high-water-backpressure" },
+      send: (payload: string) => Buffer.byteLength(payload),
+      close: () => {},
+    };
+    const internal = proxy as unknown as {
+      socket: typeof socket | null;
+      frontendReady: boolean;
+      backpressuredSocket: typeof socket | null;
+      send: (message: JsonRpcNotification) => void;
+      drain: (target: typeof socket) => void;
+      accept: (target: typeof socket) => void;
+      outboundQueue: Array<{
+        socket: typeof socket;
+        payload: string;
+        bytes: number;
+      }>;
+      outboundQueueBytes: number;
+      outboundQueueWarningEmitted: boolean;
+    };
+    internal.socket = socket;
+    internal.frontendReady = true;
+    const nearThreshold =
+      Math.floor(CODEX_TUI_WEBSOCKET_OUTBOUND_QUEUE_MAX_BYTES / 2) -
+      CODEX_TUI_WEBSOCKET_OUTBOUND_QUEUE_ENTRY_COST_BYTES;
+    const seedEpisode = (target = socket) => {
+      internal.backpressuredSocket = target;
+      internal.outboundQueue.push({ socket: target, payload: "{}", bytes: nearThreshold });
+      internal.outboundQueueBytes = nearThreshold;
+    };
+
+    seedEpisode();
+    internal.send({
+      method: "thread/name/updated",
+      params: { name: "SECRET_PAYLOAD_MUST_NOT_BE_LOGGED" },
+    });
+    internal.send({
+      method: "thread/name/updated",
+      params: { name: "SECOND_SECRET_MUST_NOT_BE_LOGGED" },
+    });
+
+    expect(logs.filter((line) => line.includes("warning threshold"))).toHaveLength(1);
+    expect(logs.join("\n")).not.toContain("SECRET");
+    expect(internal.outboundQueueWarningEmitted).toBe(true);
+
+    internal.drain(socket);
+    expect(internal.outboundQueue).toHaveLength(0);
+    expect(internal.outboundQueueBytes).toBe(0);
+    expect(internal.outboundQueueWarningEmitted).toBe(true);
+
+    seedEpisode();
+    internal.send({ method: "thread/name/updated", params: { name: "later episode" } });
+    expect(logs.filter((line) => line.includes("warning threshold"))).toHaveLength(1);
+
+    const replacement = {
+      data: { connectionId: "replacement-high-water" },
+      send: (payload: string) => Buffer.byteLength(payload),
+      close: () => {},
+    };
+    internal.socket = null;
+    internal.accept(replacement);
+    internal.frontendReady = true;
+    seedEpisode(replacement);
+    internal.send({ method: "thread/name/updated", params: { name: "new connection" } });
+    expect(logs.filter((line) => line.includes("warning threshold"))).toHaveLength(2);
+  });
+
+  test("strips terminal controls from bridge diagnostics", () => {
+    const rpc = new FakeRpcPeer();
+    const session = new CodexSessionController(rpc);
+    const logs: string[] = [];
+    proxy = new CodexUnixJsonRpcProxy(session, { log: (line) => logs.push(line) });
+    const socket = {
+      data: { connectionId: "terminal-safe-log" },
+      send: () => 1,
+      close: () => {},
+    };
+    const internal = proxy as unknown as {
+      socket: typeof socket | null;
+      frontendReady: boolean;
+      failFrontendSocket: (target: typeof socket, reason: string) => void;
+    };
+    internal.socket = socket;
+    internal.frontendReady = true;
+
+    internal.failFrontendSocket(
+      socket,
+      "backend \u001B]52;c;clipboard\u0007\r\u001B[31mred\u001B[0m",
+    );
+
+    expect(logs).toEqual([
+      "codex-bridge: backend ]52;c;clipboardred; closing the unhealthy TUI socket",
+    ]);
+    expect(logs[0]).not.toMatch(/[\u0000-\u0008\u000B-\u001F\u007F-\u009F]/);
+  });
+
   test("the aggregate backpressure backlog remains fail-closed at its byte ceiling", () => {
     const rpc = new FakeRpcPeer();
     const session = new CodexSessionController(rpc);

--- a/cli/test/codex-unix-proxy.test.ts
+++ b/cli/test/codex-unix-proxy.test.ts
@@ -5,7 +5,11 @@ import { connect, type Socket } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  CODEX_TUI_WEBSOCKET_BACKPRESSURE_LIMIT_BYTES,
   CODEX_TUI_WEBSOCKET_IDLE_TIMEOUT_SECONDS,
+  CODEX_TUI_WEBSOCKET_MAX_FRAME_BYTES,
+  CODEX_TUI_WEBSOCKET_OUTBOUND_QUEUE_ENTRY_COST_BYTES,
+  CODEX_TUI_WEBSOCKET_OUTBOUND_QUEUE_MAX_BYTES,
   CodexSessionController,
   CodexUnixJsonRpcProxy,
   type CodexRpcPeer,
@@ -246,6 +250,19 @@ afterEach(async () => {
 describe("Codex Unix WebSocket single-writer proxy", () => {
   test("disables Bun's idle timeout for long-lived quiet Codex sessions", () => {
     expect(CODEX_TUI_WEBSOCKET_IDLE_TIMEOUT_SECONDS).toBe(0);
+  });
+
+  test("keeps the WebSocket and proxy backlog limits large enough for bounded multi-megabyte app-server frames", () => {
+    expect(CODEX_TUI_WEBSOCKET_MAX_FRAME_BYTES).toBeGreaterThanOrEqual(
+      128 * 1_024 * 1_024,
+    );
+    expect(CODEX_TUI_WEBSOCKET_BACKPRESSURE_LIMIT_BYTES).toBeGreaterThanOrEqual(
+      CODEX_TUI_WEBSOCKET_MAX_FRAME_BYTES,
+    );
+    expect(CODEX_TUI_WEBSOCKET_OUTBOUND_QUEUE_MAX_BYTES).toBeGreaterThan(
+      CODEX_TUI_WEBSOCKET_MAX_FRAME_BYTES,
+    );
+    expect(CODEX_TUI_WEBSOCKET_OUTBOUND_QUEUE_ENTRY_COST_BYTES).toBeGreaterThan(0);
   });
 
   test("routes the real bootstrap wire shape and serializes TUI start with AgentParty steer", async () => {
@@ -734,7 +751,130 @@ describe("Codex Unix WebSocket single-writer proxy", () => {
     ]);
   });
 
-  test("a backpressured TUI cannot grow the proxy outbound queue without bound", () => {
+  test("preserves one multi-megabyte response behind temporary TUI backpressure", () => {
+    const rpc = new FakeRpcPeer();
+    const session = new CodexSessionController(rpc);
+    proxy = new CodexUnixJsonRpcProxy(session, { log: () => {} });
+    const payloads: string[] = [];
+    const closes: Array<{ code: number; reason: string }> = [];
+    let blocked = true;
+    const socket = {
+      data: { connectionId: "large-bootstrap-response" },
+      send: (payload: string) => {
+        payloads.push(payload);
+        return blocked ? -1 : Buffer.byteLength(payload);
+      },
+      close: (code: number, reason: string) => {
+        closes.push({ code, reason });
+      },
+    };
+    const internal = proxy as unknown as {
+      socket: typeof socket | null;
+      frontendReady: boolean;
+      send: (message: JsonRpcNotification | JsonRpcResponse) => void;
+      drain: (target: typeof socket) => void;
+      outboundQueue: unknown[];
+      outboundQueueBytes: number;
+      backpressuredSocket: typeof socket | null;
+    };
+    internal.socket = socket;
+    internal.frontendReady = true;
+
+    const first = {
+      method: "thread/status/changed",
+      params: { status: { type: "idle" } },
+    } satisfies JsonRpcNotification;
+    internal.send(first);
+    const response = {
+      id: "startup-list-response",
+      result: { catalog: "" },
+    };
+    const emptyPayload = JSON.stringify(response);
+    const targetBytes = 3_199_295;
+    response.result.catalog = "x".repeat(targetBytes - Buffer.byteLength(emptyPayload));
+    const expectedResponsePayload = JSON.stringify(response);
+    expect(Buffer.byteLength(expectedResponsePayload)).toBe(targetBytes);
+    internal.send(response);
+
+    expect(closes).toEqual([]);
+    expect(payloads).toEqual([JSON.stringify(first)]);
+    expect(internal.socket).toBe(socket);
+    expect(internal.backpressuredSocket).toBe(socket);
+    expect(internal.outboundQueue).toHaveLength(1);
+    expect(internal.outboundQueueBytes).toBe(targetBytes);
+    expect(internal.outboundQueueBytes).toBeLessThanOrEqual(
+      CODEX_TUI_WEBSOCKET_OUTBOUND_QUEUE_MAX_BYTES,
+    );
+
+    blocked = false;
+    internal.drain(socket);
+
+    expect(closes).toEqual([]);
+    expect(payloads).toEqual([JSON.stringify(first), expectedResponsePayload]);
+    expect(payloads.filter((payload) => payload === JSON.stringify(first))).toHaveLength(1);
+    expect(
+      payloads.filter((payload) =>
+        (JSON.parse(payload) as { id?: unknown }).id === response.id
+      ),
+    ).toHaveLength(1);
+    expect(internal.socket).toBe(socket);
+    expect(internal.backpressuredSocket).toBeNull();
+    expect(internal.outboundQueue).toHaveLength(0);
+    expect(internal.outboundQueueBytes).toBe(0);
+    expect(internal.frontendReady).toBe(true);
+  });
+
+  test("the aggregate backpressure backlog remains fail-closed at its byte ceiling", () => {
+    const rpc = new FakeRpcPeer();
+    const session = new CodexSessionController(rpc);
+    const logs: string[] = [];
+    proxy = new CodexUnixJsonRpcProxy(session, { log: (line) => logs.push(line) });
+    const closes: Array<{ code: number; reason: string }> = [];
+    const socket = {
+      data: { connectionId: "byte-bounded-backpressure" },
+      send: () => -1,
+      close: (code: number, reason: string) => {
+        closes.push({ code, reason });
+      },
+    };
+    const internal = proxy as unknown as {
+      socket: typeof socket | null;
+      frontendReady: boolean;
+      backpressuredSocket: typeof socket | null;
+      send: (message: JsonRpcNotification) => void;
+      outboundQueue: Array<{
+        socket: typeof socket;
+        payload: string;
+        bytes: number;
+      }>;
+      outboundQueueBytes: number;
+    };
+    internal.socket = socket;
+    internal.frontendReady = true;
+    internal.backpressuredSocket = socket;
+    internal.outboundQueue.push({
+      socket,
+      payload: "{}",
+      bytes: CODEX_TUI_WEBSOCKET_OUTBOUND_QUEUE_MAX_BYTES,
+    });
+    internal.outboundQueueBytes = CODEX_TUI_WEBSOCKET_OUTBOUND_QUEUE_MAX_BYTES;
+
+    internal.send({ method: "thread/name/updated", params: { name: "one too many" } });
+
+    expect(closes).toHaveLength(1);
+    expect(closes[0]).toMatchObject({
+      code: 1011,
+    });
+    expect(closes[0]!.reason).toContain("outbound queue exceeded its safety limit");
+    expect(logs.at(-1)).toContain(
+      `bytes=${CODEX_TUI_WEBSOCKET_OUTBOUND_QUEUE_MAX_BYTES}`,
+    );
+    expect(internal.frontendReady).toBe(false);
+    expect(internal.outboundQueue).toHaveLength(0);
+    expect(internal.outboundQueueBytes).toBe(0);
+  });
+
+  test("does not treat 1,024 small lossless frames as a protocol limit", () => {
     const rpc = new FakeRpcPeer();
     const session = new CodexSessionController(rpc);
     proxy = new CodexUnixJsonRpcProxy(session, { log: () => {} });
@@ -761,8 +901,8 @@ describe("Codex Unix WebSocket single-writer proxy", () => {
         params: { delta: `token-${index}` },
       });
     }
-    expect(closes).toEqual([1011]);
-    expect(internal.frontendReady).toBe(false);
-    expect(internal.outboundQueue).toHaveLength(0);
+    expect(closes).toEqual([]);
+    expect(internal.frontendReady).toBe(true);
+    expect(internal.outboundQueue).toHaveLength(1_025);
   });
 });

--- a/cli/test/fixtures/mock-codex-app-server.ts
+++ b/cli/test/fixtures/mock-codex-app-server.ts
@@ -154,6 +154,23 @@ input.on("line", (line) => {
     });
     return;
   }
+  if (frame.method === "mock/messageOrdering") {
+    send({ method: "mock/ordered/first" });
+    send({ method: "mock/ordered/second" });
+    send({ id: frame.id, result: { ordered: true } });
+    return;
+  }
+  if (frame.method === "mock/messageOrderingDisconnect") {
+    const frames = [
+      { method: "mock/disconnect/first" },
+      { method: "mock/disconnect/second" },
+    ];
+    process.stdout.write(
+      frames.map((value) => `${JSON.stringify(value)}\n`).join(""),
+      () => process.exit(75),
+    );
+    return;
+  }
   if (frame.method === "mock/disconnect") {
     process.exit(74);
   }


### PR DESCRIPTION
## 背景

这是 #746 合并后的真实 Codex app-server 验收修复。v0.2.151 的常驻桥在真实启动、事件结算和回复落库路径上暴露了多处核心竞态，不能作为上游 harness 缺口关闭。

## 修复

- 将 app-server WebSocket 单帧与排队预算对齐官方 128 MiB 协议上限，保留有界内存与 FIFO，不重复发送 Bun 已接收的背压帧。
- 串行化 JSON-RPC 通知与响应快照应用，并为跨 generation、断连、同线程恢复建立明确屏障。
- 以 `item/*` 生命周期作为最终回复权威来源，区分完整 started/delta/completed 与孤立、空增量，过滤 partial、commentary、空 final。
- 收敛 unsolicited `replied` 与 POST response 竞态；恢复回复的 `reply_posted` 落盘失败会回滚内存序号并用同一幂等键重试。
- 压缩并限制已完成 turn 缓存，避免长驻桥保存 command/MCP/file 大载荷。
- 补齐启动背压可观测性、统一断连守卫、终端日志净化和确定性断连测试。

## 验证

- `bun run check:cli`: 1362/1362，0 fail，98 files，5189 assertions。
- 两个最终回归文件：70/70，374 assertions。
- TypeScript 与 `git diff --check` 通过。
- 三轮独立只读审计最终结论：P0=0、P1=0、P2=0。
- 真实 Codex app-server 源码运行：
  - 空闲投递取得 lease，启动新 turn，并形成精确 linked reply。
  - 运行 `/bin/sleep 20` 时投递取得 lease，插入活跃 turn，最终遵循新指令并形成精确 linked reply。
- 真实 Claude Channel（Fable）源码运行：
  - 空闲投递取得 lease，并形成精确 linked reply。
  - 运行 `/bin/sleep 20` 时投递取得 lease，并在同一会话形成精确 linked reply。

Follow-up to #746.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **可靠性改进**
  * 强化断连重连下的 RPC 发放/应用顺序隔离，降低乱序与重复派发风险。
  * 完成回合最终文本规范化去重，优先采用权威最终答案，稳定 `finalAgentText`。
  * 改进回复发布失败闭合与 WAL/结算竞态兜底，避免重复 `replied` 更新并完善 recovery 清理。
* **性能与稳定性**
  * 新增 WebSocket 安全上限与按字节估算的队列约束，超限安全关闭并清理队列；提升大帧回压下的可靠发送。
  * 终端日志输出前清理控制序列。
* **测试**
  * 扩展断连/重连、消息排序、最终回复提取、回复竞态结算与 WebSocket 回压上限端到端覆盖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->