### PR TITLE
fix(web): 补齐 aria-modal 对话框的焦点陷阱 (#637)

### DIFF
--- a/web/src/components/AgentDetailModal.tsx
+++ b/web/src/components/AgentDetailModal.tsx
@@ -3,9 +3,10 @@
 // 在线状态。不建新后端——所有数据来自调用方已经持有的 presence/messages。
 import type { CollaborationRole, MsgFrame, PresenceEntry, Sender, TaskRecord } from "@agentparty/shared";
 import { autoWakeReachable, wakeableState } from "@agentparty/shared";
-import { useEffect } from "react";
+import { useRef } from "react";
 import { fmtRel } from "../lib/time";
 import { useT } from "../i18n/useT";
+import { useModalFocusTrap } from "./useModalFocusTrap";
 import "../i18n/strings/AgentDetailModal";
 
 export type AgentDetailAssignmentSource = "assigned" | "self_reported" | "none";
@@ -373,16 +374,18 @@ export function AgentDetailPanel(props: AgentDetailPanelProps) {
 /** Backward-compatible modal wrapper for existing callers. */
 export function AgentDetailModal({ onClose, ...props }: AgentDetailModalProps) {
   const t = useT();
-  useEffect(() => {
-    const onKey = (event: KeyboardEvent) => {
-      if (event.key === "Escape") onClose();
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [onClose]);
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+  useModalFocusTrap({ active: true, containerRef: dialogRef, onEscape: onClose });
 
   return (
-    <div className="channel-panel-overlay agent-detail-overlay" role="dialog" aria-modal="true" aria-label={t("AgentDetailModal.title", { name: props.display })}>
+    <div
+      ref={dialogRef}
+      className="channel-panel-overlay agent-detail-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-label={t("AgentDetailModal.title", { name: props.display })}
+      tabIndex={-1}
+    >
       <button className="channel-panel-scrim" type="button" aria-label={t("Channel.tools.close")} onClick={onClose} />
       <section className="channel-panel-card agent-detail-card">
         <AgentDetailContent {...props} onClose={onClose} />

--- a/web/src/components/AgentJoin.tsx
+++ b/web/src/components/AgentJoin.tsx
@@ -1,7 +1,7 @@
 // 频道页「＋ 让 agent 加入」：登录人类先给 agent 起个能认出来的名字（默认 <你>-<频道>，
 // 可改成 drawstyle-review 这类），再铸一枚 channel-scoped agent token，弹出可复制的接入脚本。
 // 明文 token 只出现这一次（spec §10）。名字有意义 = 频道里一眼分清谁的哪个项目，不再是随机后缀。
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   AuthError,
   type ChannelCharter,
@@ -26,6 +26,7 @@ function isMacDesktop(): boolean {
 import { apiOrigin } from "../lib/base";
 import { useT } from "../i18n/useT";
 import { useDismissableLayer } from "./useDismissableLayer";
+import { useModalFocusTrap } from "./useModalFocusTrap";
 import "../i18n/strings/AgentJoin";
 
 interface Props {
@@ -113,6 +114,9 @@ export function AgentJoin({ slug, token, namePrefix, inviterName, charter, accou
   const [copied, setCopied] = useState(false);
   // #642：复制失败要给用户明确反馈，别静默——join 命令带着只展示一次的 channel-scoped token。
   const [copyErr, setCopyErr] = useState(false);
+  const composeDialogRef = useRef<HTMLDivElement | null>(null);
+  const doneDialogRef = useRef<HTMLDivElement | null>(null);
+  const nameInputRef = useRef<HTMLInputElement | null>(null);
 
   const open = useCallback(() => {
     onActiveChange?.(true);
@@ -140,7 +144,20 @@ export function AgentJoin({ slug, token, namePrefix, inviterName, charter, accou
   }, [active, phase.kind, reset]);
 
   const dialogOpen = phase.kind === "compose" || phase.kind === "loading" || phase.kind === "done";
-  useDismissableLayer({ active: dialogOpen, onDismiss: close });
+  const composeOpen = phase.kind === "compose" || phase.kind === "loading";
+  useDismissableLayer({ active: dialogOpen, onDismiss: close, dismissOnEscape: false });
+  // compose 与 done 是两个互斥对话框，各自一个 trap——否则 mint 完成后焦点仍留在已卸载的输入框上。
+  useModalFocusTrap({
+    active: composeOpen,
+    containerRef: composeDialogRef,
+    initialFocusRef: nameInputRef,
+    onEscape: close,
+  });
+  useModalFocusTrap({
+    active: phase.kind === "done",
+    containerRef: doneDialogRef,
+    onEscape: close,
+  });
 
   const mint = useCallback(async () => {
     const wanted = name.trim();
@@ -249,8 +266,15 @@ export function AgentJoin({ slug, token, namePrefix, inviterName, charter, accou
         </p>
       )}
 
-      {(phase.kind === "compose" || phase.kind === "loading") && (
-        <div className="agent-join-overlay" role="dialog" aria-modal="true" aria-label={t("AgentJoin.dialogNameLabel")}>
+      {composeOpen && (
+        <div
+          ref={composeDialogRef}
+          className="agent-join-overlay"
+          role="dialog"
+          aria-modal="true"
+          aria-label={t("AgentJoin.dialogNameLabel")}
+          tabIndex={-1}
+        >
           <div className="agent-join-scrim" onClick={close} />
           <div className="d-card agent-join-card">
             <header className="agent-join-card-head">
@@ -267,6 +291,7 @@ export function AgentJoin({ slug, token, namePrefix, inviterName, charter, accou
             <label className="agent-join-namerow">
               <span className="agent-join-namelabel t-mono">{t("AgentJoin.nameFieldLabel")}</span>
               <input
+                ref={nameInputRef}
                 className="t-mono agent-join-nameinput"
                 value={name}
                 autoFocus
@@ -343,7 +368,14 @@ export function AgentJoin({ slug, token, namePrefix, inviterName, charter, accou
       )}
 
       {phase.kind === "done" && (
-        <div className="agent-join-overlay" role="dialog" aria-modal="true" aria-label={t("AgentJoin.doneTitleSuffix")}>
+        <div
+          ref={doneDialogRef}
+          className="agent-join-overlay"
+          role="dialog"
+          aria-modal="true"
+          aria-label={t("AgentJoin.doneTitleSuffix")}
+          tabIndex={-1}
+        >
           <div className="agent-join-scrim" onClick={close} />
           <div className="d-card agent-join-card">
             <header className="agent-join-card-head">

--- a/web/src/components/JoinLink.tsx
+++ b/web/src/components/JoinLink.tsx
@@ -27,6 +27,7 @@ import {
 import { useT, type TFunc } from "../i18n/useT";
 import { apiOrigin } from "../lib/base";
 import { useDismissableLayer } from "./useDismissableLayer";
+import { useModalFocusTrap } from "./useModalFocusTrap";
 import { LarkMemberInvite } from "./LarkMemberInvite";
 import "../i18n/strings/JoinLink";
 
@@ -92,6 +93,8 @@ export function JoinLink({
 }: Props) {
   const t = useT();
   const rootRef = useRef<HTMLDivElement | null>(null);
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const toggleRef = useRef<HTMLButtonElement | null>(null);
   const EXPIRY_OPTIONS = expiryOptions(t);
   const USES_OPTIONS = usesOptions(t);
   const [open, setOpen] = useState(false);
@@ -184,7 +187,19 @@ export function JoinLink({
     onActiveChange?.(true);
   }, [active, close, isOpen, onActiveChange]);
 
-  useDismissableLayer({ active: isOpen && !embedded, onDismiss: close, outsideRef: rootRef });
+  // embedded 是内嵌 region、不是模态：既不抢焦点也不吃 Escape，只有独立弹出时才 trap。
+  useDismissableLayer({
+    active: isOpen && !embedded,
+    onDismiss: close,
+    outsideRef: rootRef,
+    dismissOnEscape: false,
+  });
+  useModalFocusTrap({
+    active: isOpen && !embedded,
+    containerRef: panelRef,
+    returnFocusRef: toggleRef,
+    onEscape: close,
+  });
 
   useEffect(() => {
     if (isOpen && links === null) void refresh();
@@ -335,16 +350,18 @@ export function JoinLink({
   return (
     <div className="joinlink" ref={rootRef}>
       {!embedded && (
-        <button type="button" className="d-btn joinlink-btn" onClick={toggle} aria-expanded={isOpen}>
+        <button ref={toggleRef} type="button" className="d-btn joinlink-btn" onClick={toggle} aria-expanded={isOpen}>
           {t("JoinLink.button")}
         </button>
       )}
       {isOpen && (
         <div
+          ref={panelRef}
           className={`joinlink-panel${embedded ? " joinlink-panel--embedded" : ""}`}
           role={embedded ? "region" : "dialog"}
           aria-modal={embedded ? undefined : true}
           aria-label={t("JoinLink.button")}
+          {...(embedded ? {} : { tabIndex: -1 })}
         >
           <div className="joinlink-mode" role="radiogroup" aria-label={t("JoinLink.modeLabel")}>
             {(["participate", "watch", "external"] as InviteMode[]).map((m) => (

--- a/web/src/components/OnboardingGuide.tsx
+++ b/web/src/components/OnboardingGuide.tsx
@@ -1,8 +1,9 @@
 // 首次进入的 1-2-3-4 引导浮层（#146）。只在浏览器第一次进来时出现，关掉后落一个
 // localStorage 标记（复用 ap_locale 那套持久化模式，不造新机制），之后不再打扰。
 // 范围克制：一张可关闭的四步卡片，讲清「加入频道 → @唤醒 → 认领任务 → 提交」主线。
-import { useCallback, useEffect, useRef, useState, type RefObject } from "react";
+import { useCallback, useRef, useState, type RefObject } from "react";
 import { useT } from "../i18n/useT";
+import { useModalFocusTrap } from "./useModalFocusTrap";
 import "../i18n/strings/Onboarding";
 
 const STORAGE_KEY = "ap_onboarded";
@@ -51,56 +52,13 @@ export function OnboardingGuide({
   }, []);
 
   // 与其它模态一致：显式接管焦点、困住 Tab、Esc 关闭，并在退出后还给来源控件。
-  useEffect(() => {
-    if (!visible) return;
-    const doc = typeof document === "undefined" ? null : document;
-    const previouslyFocused = (doc?.activeElement ?? null) as HTMLElement | null;
-    const focusables = (): HTMLElement[] => {
-      const card = cardRef.current;
-      if (card === null || typeof card.querySelectorAll !== "function") return [];
-      return Array.from(
-        card.querySelectorAll<HTMLElement>(
-          'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
-        ),
-      ).filter((element) => element.tabIndex >= 0);
-    };
-
-    (closeRef.current ?? focusables()[0] ?? cardRef.current)?.focus?.();
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        dismiss();
-        return;
-      }
-      if (e.key !== "Tab") return;
-      const items = focusables();
-      const card = cardRef.current;
-      if (items.length === 0) {
-        e.preventDefault();
-        card?.focus?.();
-        return;
-      }
-      const first = items[0]!;
-      const last = items[items.length - 1]!;
-      const active = (doc?.activeElement ?? null) as HTMLElement | null;
-      if (e.shiftKey && (active === first || active === card)) {
-        e.preventDefault();
-        last.focus();
-      } else if (!e.shiftKey && active === last) {
-        e.preventDefault();
-        first.focus();
-      }
-    };
-    window.addEventListener("keydown", onKey);
-    return () => {
-      window.removeEventListener("keydown", onKey);
-      const explicitTarget = returnFocusRef?.current;
-      if (explicitTarget !== null && explicitTarget !== undefined && explicitTarget.isConnected !== false) {
-        explicitTarget.focus?.();
-      } else if (previouslyFocused?.isConnected !== false) {
-        previouslyFocused?.focus?.();
-      }
-    };
-  }, [dismiss, returnFocusRef, visible]);
+  useModalFocusTrap({
+    active: visible,
+    containerRef: cardRef,
+    initialFocusRef: closeRef,
+    returnFocusRef,
+    onEscape: dismiss,
+  });
 
   if (!visible) return null;
 

--- a/web/src/components/PresenceBar.tsx
+++ b/web/src/components/PresenceBar.tsx
@@ -6,6 +6,7 @@ import { agentHue } from "../lib/agentColor";
 import { fmtRel } from "../lib/time";
 import type { SocketStatus } from "../lib/ws";
 import { useT } from "../i18n/useT";
+import { useModalFocusTrap } from "./useModalFocusTrap";
 import "../i18n/strings/PresenceBar";
 
 interface Props {
@@ -377,6 +378,7 @@ export function PresenceBar({
   const [rosterOpen, setRosterOpen] = useState(false);
   const rosterToggleRef = useRef<HTMLButtonElement | null>(null);
   const rosterCloseRef = useRef<HTMLButtonElement | null>(null);
+  const rosterDialogRef = useRef<HTMLDivElement | null>(null);
 
   // 在线 sender 带 owner；离线/最近 presence 带 account。两者都归到同一账号块。
   const byName = new Map(participants.map((p) => [p.name, p]));
@@ -503,15 +505,13 @@ export function PresenceBar({
   const activePopoverGroup =
     !rosterOpen || hoveredGroup === null ? null : sortedGroups.find((group) => group.key === hoveredGroup.key) ?? null;
 
-  useEffect(() => {
-    if (!rosterOpen) return;
-    rosterCloseRef.current?.focus();
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") closeRoster();
-    };
-    window.addEventListener?.("keydown", onKeyDown);
-    return () => window.removeEventListener?.("keydown", onKeyDown);
-  }, [closeRoster, rosterOpen]);
+  useModalFocusTrap({
+    active: rosterOpen,
+    containerRef: rosterDialogRef,
+    initialFocusRef: rosterCloseRef,
+    returnFocusRef: rosterToggleRef,
+    onEscape: closeRoster,
+  });
 
   function openAgentDetail(name: string) {
     if (onOpenAgentDetail === undefined) return;
@@ -950,7 +950,14 @@ export function PresenceBar({
         </span>
       </div>
       {rosterOpen && (
-        <div className="channel-panel-overlay presence-roster-overlay" role="dialog" aria-modal="true" aria-labelledby="presence-roster-title">
+        <div
+          ref={rosterDialogRef}
+          className="channel-panel-overlay presence-roster-overlay"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="presence-roster-title"
+          tabIndex={-1}
+        >
           <button className="channel-panel-scrim" type="button" aria-label={t("PresenceBar.close")} onClick={closeRoster} />
           <section className="channel-panel-card presence-roster-card">
             <header className="channel-panel-head">

--- a/web/src/components/useDismissableLayer.ts
+++ b/web/src/components/useDismissableLayer.ts
@@ -4,9 +4,16 @@ interface DismissableLayerOptions {
   active: boolean;
   onDismiss(): void;
   outsideRef?: RefObject<HTMLElement | null>;
+  /** Set false when a focus trap on the same layer already owns Escape, so one keypress dismisses once. */
+  dismissOnEscape?: boolean;
 }
 
-export function useDismissableLayer({ active, onDismiss, outsideRef }: DismissableLayerOptions) {
+export function useDismissableLayer({
+  active,
+  onDismiss,
+  outsideRef,
+  dismissOnEscape = true,
+}: DismissableLayerOptions) {
   useEffect(() => {
     if (!active) return;
 
@@ -19,11 +26,11 @@ export function useDismissableLayer({ active, onDismiss, outsideRef }: Dismissab
       onDismiss();
     };
 
-    window.addEventListener("keydown", onKeyDown);
+    if (dismissOnEscape) window.addEventListener("keydown", onKeyDown);
     if (outsideRef !== undefined) document.addEventListener("pointerdown", onPointerDown);
     return () => {
-      window.removeEventListener("keydown", onKeyDown);
+      if (dismissOnEscape) window.removeEventListener("keydown", onKeyDown);
       if (outsideRef !== undefined) document.removeEventListener("pointerdown", onPointerDown);
     };
-  }, [active, onDismiss, outsideRef]);
+  }, [active, dismissOnEscape, onDismiss, outsideRef]);
 }

--- a/web/src/components/useModalFocusTrap.test.tsx
+++ b/web/src/components/useModalFocusTrap.test.tsx
@@ -1,0 +1,179 @@
+// @ts-expect-error Bun executes this test, while the web tsconfig intentionally loads only Vite globals.
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { useRef } from "react";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { useModalFocusTrap } from "./useModalFocusTrap";
+
+class TestEventTarget {
+  private listeners = new Map<string, Set<(event: KeyboardEvent) => void>>();
+
+  addEventListener(type: string, listener: (event: KeyboardEvent) => void) {
+    const listeners = this.listeners.get(type) ?? new Set();
+    listeners.add(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  removeEventListener(type: string, listener: (event: KeyboardEvent) => void) {
+    this.listeners.get(type)?.delete(listener);
+  }
+
+  emit(event: Partial<KeyboardEvent> & { key: string }) {
+    for (const listener of this.listeners.get("keydown") ?? []) listener(event as KeyboardEvent);
+  }
+
+  count() {
+    return this.listeners.get("keydown")?.size ?? 0;
+  }
+}
+
+interface FocusTarget extends Partial<HTMLElement> {
+  id: string;
+  focus(): void;
+}
+
+let renderer: ReactTestRenderer | null = null;
+let events: TestEventTarget;
+let activeElement: FocusTarget | null;
+let focusOrder: string[];
+let focusables: FocusTarget[];
+let container: FocusTarget & Pick<HTMLElement, "contains" | "querySelectorAll">;
+let initial: FocusTarget;
+
+function target(id: string): FocusTarget {
+  const node: FocusTarget = {
+    id,
+    isConnected: true,
+    closest: () => null,
+    focus: () => {
+      activeElement = node;
+      focusOrder.push(id);
+    },
+  };
+  return node;
+}
+
+function Harness({
+  active,
+  onEscape,
+  useInitial = false,
+}: {
+  active: boolean;
+  onEscape(): void;
+  useInitial?: boolean;
+}) {
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+  const initialRef = useRef<HTMLButtonElement | null>(null);
+  useModalFocusTrap({
+    active,
+    containerRef: dialogRef,
+    initialFocusRef: useInitial ? initialRef : undefined,
+    onEscape,
+  });
+
+  if (!active) return null;
+  return (
+    <div ref={dialogRef} className="dialog" tabIndex={-1}>
+      <button ref={initialRef} className="initial" type="button">close</button>
+    </div>
+  );
+}
+
+function renderHarness(props: Parameters<typeof Harness>[0]) {
+  act(() => {
+    renderer = create(<Harness {...props} />, {
+      createNodeMock(element) {
+        const props = element.props as { className?: string };
+        if (props.className === "dialog") return container;
+        if (props.className === "initial") return initial;
+        return {};
+      },
+    });
+  });
+}
+
+beforeEach(() => {
+  Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", { configurable: true, value: true });
+  events = new TestEventTarget();
+  activeElement = null;
+  focusOrder = [];
+  focusables = [target("first"), target("last")];
+  initial = target("initial");
+  container = Object.assign(target("dialog"), {
+    contains: (candidate: Node | null) =>
+      candidate === container || candidate === initial || focusables.includes(candidate as FocusTarget),
+    querySelectorAll: () => focusables,
+  }) as FocusTarget & Pick<HTMLElement, "contains" | "querySelectorAll">;
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      addEventListener: events.addEventListener.bind(events),
+      removeEventListener: events.removeEventListener.bind(events),
+    },
+  });
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: {
+      get activeElement() {
+        return activeElement;
+      },
+    },
+  });
+});
+
+afterEach(() => {
+  act(() => renderer?.unmount());
+  renderer = null;
+  Reflect.deleteProperty(globalThis, "window");
+  Reflect.deleteProperty(globalThis, "document");
+});
+
+describe("useModalFocusTrap", () => {
+  test("moves focus in, wraps Tab in both directions, and restores the launcher", () => {
+    const launcher = target("launcher");
+    activeElement = launcher;
+    renderHarness({ active: true, onEscape: () => {}, useInitial: true });
+
+    expect(activeElement).toBe(initial);
+    expect(focusOrder).toEqual(["initial"]);
+    expect(events.count()).toBe(1);
+
+    activeElement = focusables[1]!;
+    let prevented = 0;
+    act(() => events.emit({ key: "Tab", shiftKey: false, preventDefault: () => { prevented += 1; } }));
+    expect(activeElement).toBe(focusables[0]);
+
+    activeElement = focusables[0]!;
+    act(() => events.emit({ key: "Tab", shiftKey: true, preventDefault: () => { prevented += 1; } }));
+    expect(activeElement).toBe(focusables[1]);
+    expect(prevented).toBe(2);
+
+    act(() => renderer?.update(<Harness active={false} onEscape={() => {}} useInitial />));
+    expect(activeElement).toBe(launcher);
+    expect(events.count()).toBe(0);
+  });
+
+  test("uses the latest Escape callback without re-arming the trap", () => {
+    let first = 0;
+    let second = 0;
+    renderHarness({ active: true, onEscape: () => { first += 1; } });
+    expect(events.count()).toBe(1);
+
+    act(() => renderer?.update(<Harness active onEscape={() => { second += 1; }} />));
+    expect(events.count()).toBe(1);
+    act(() => events.emit({ key: "Escape" }));
+
+    expect(first).toBe(0);
+    expect(second).toBe(1);
+  });
+
+  test("falls back to the dialog when it has no focusable children", () => {
+    focusables = [];
+    renderHarness({ active: true, onEscape: () => {} });
+    expect(activeElement).toBe(container);
+
+    let prevented = 0;
+    act(() => events.emit({ key: "Tab", preventDefault: () => { prevented += 1; } }));
+    expect(prevented).toBe(1);
+    expect(activeElement).toBe(container);
+  });
+});

--- a/web/src/components/useModalFocusTrap.ts
+++ b/web/src/components/useModalFocusTrap.ts
@@ -1,0 +1,99 @@
+import { useEffect, useRef, type RefObject } from "react";
+
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  "[contenteditable=\"true\"]",
+  "[tabindex]:not([tabindex=\"-1\"])",
+].join(", ");
+
+interface ModalFocusTrapOptions {
+  active: boolean;
+  containerRef: RefObject<HTMLElement | null>;
+  initialFocusRef?: RefObject<HTMLElement | null>;
+  returnFocusRef?: RefObject<HTMLElement | null>;
+  onEscape?(): void;
+}
+
+function focusableElements(container: HTMLElement | null): HTMLElement[] {
+  if (container === null || typeof container.querySelectorAll !== "function") return [];
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
+    (element) =>
+      (element.closest?.('[hidden], [aria-hidden="true"]') ?? null) === null &&
+      // jsdom leaves tabIndex undefined on bare stubs; only a negative value means opted out.
+      (element.tabIndex === undefined || element.tabIndex >= 0),
+  );
+}
+
+/**
+ * Gives an aria-modal dialog the keyboard behavior its semantics promise:
+ * focus enters on open, Tab stays inside, Escape dismisses, and close restores
+ * the element that launched it.
+ */
+export function useModalFocusTrap({
+  active,
+  containerRef,
+  initialFocusRef,
+  returnFocusRef,
+  onEscape,
+}: ModalFocusTrapOptions): void {
+  const onEscapeRef = useRef(onEscape);
+  onEscapeRef.current = onEscape;
+
+  useEffect(() => {
+    if (!active) return;
+
+    const doc = typeof document === "undefined" ? null : document;
+    const win = typeof window === "undefined" ? null : window;
+    const previouslyFocused = (doc?.activeElement ?? null) as HTMLElement | null;
+    const container = () => containerRef.current;
+    const items = () => focusableElements(container());
+
+    (initialFocusRef?.current ?? items()[0] ?? container())?.focus?.();
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onEscapeRef.current?.();
+        return;
+      }
+      if (event.key !== "Tab") return;
+
+      const focusables = items();
+      const root = container();
+      if (focusables.length === 0) {
+        event.preventDefault();
+        root?.focus?.();
+        return;
+      }
+
+      const first = focusables[0]!;
+      const last = focusables[focusables.length - 1]!;
+      const current = (doc?.activeElement ?? null) as HTMLElement | null;
+      const focusIsOutside =
+        current === null ||
+        root === null ||
+        typeof root.contains !== "function" ||
+        !root.contains(current);
+      if (event.shiftKey && (current === first || current === root || focusIsOutside)) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && (current === last || focusIsOutside)) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    win?.addEventListener?.("keydown", onKeyDown);
+    return () => {
+      win?.removeEventListener?.("keydown", onKeyDown);
+      // 显式目标若已随卸载消失，退回打开前的焦点，而不是把焦点丢给 body。
+      const explicit = returnFocusRef?.current ?? null;
+      const target = explicit !== null && explicit.isConnected !== false ? explicit : previouslyFocused;
+      if (target?.isConnected === false) return;
+      target?.focus?.();
+    };
+  }, [active, containerRef, initialFocusRef, returnFocusRef]);
+}


### PR DESCRIPTION
## 问题

`#654` 收尾 #637 时修好了 SettingsPanel 与 Onboarding 的焦点行为，但另外几个同样标了 `aria-modal="true"` 的对话框只挂了 `useDismissableLayer`——它只处理 Escape 和外部点击，**Tab 会径直走出对话框落到底层页面**。对键盘和读屏用户来说，`aria-modal` 承诺的语义没有兑现：

| 对话框 | 改前 |
|---|---|
| `AgentDetailModal` | 只有内联 Escape，无初始聚焦、无 Tab 约束、无焦点归还 |
| `AgentJoin`（compose / done 两个） | 仅 `useDismissableLayer` |
| `JoinLink`（非 embedded 时） | 仅 `useDismissableLayer` |
| `PresenceBar` roster | 有初始聚焦与 Escape，缺 Tab 循环 |

## 改动

抽出共享 `useModalFocusTrap`：打开时接管焦点、Tab/Shift+Tab 在对话框内循环、Escape 关闭、关闭后把焦点还给触发控件。两个边界：焦点已在容器外时按方向拉回首/尾元素；容器没有可聚焦子节点时兜底聚焦容器自身。

`useDismissableLayer` 新增 `dismissOnEscape`，让同一层的 Escape 只被处理一次（trap 已经接管时不再重复触发关闭）。

### 与已有内联实现的关系

web 里原本有三处各自实现的焦点陷阱。本次只收编其中语义与新 hook 完全一致的一份：

- `OnboardingGuide` —— **换成共享 hook**（#654 留下的内联版），否则同一套逻辑会有四份拷贝。
- `SectionedDialog` —— **不动**，陷阱与分区（section）导航模型耦合。
- `Channel.tsx` 的 ChannelPanel —— **不动**，额外支持 `autofocus` 属性优先、`shouldRestoreFocus` 归还闸和 `onEscape` 覆盖，比通用 hook 更专。

后续若要统一这两处，应当反过来把它们的能力吸收进 hook，而不是让它们降级——不在本 PR 范围内。

> **rebase 说明**：本 PR 初版还改了 `AgentTokens`。#771 合入后它的弹窗已整体改由 `SectionedDialog` 渲染、自带陷阱，缺口在那边以更好的方式补上了，因此 rebase 时**整体丢弃了对该文件的改动**，不与 #771 争。

## 验证

`bun run check:web` 在 rebase 后重跑仍全绿：全量 web 测试 + `tsc --noEmit` + `vite build`。新增 `useModalFocusTrap.test.tsx` 覆盖焦点进入、双向 Tab 循环、焦点归还、Escape 回调不重挂陷阱、无可聚焦子节点兜底五种情形。

改完后 web 里所有 `aria-modal` 对话框都有陷阱（4 个走新 hook，`SectionedDialog` 与 ChannelPanel 走各自内联实现），无遗漏。

## 来源

这份改动源自一个被遗弃 worktree 里 3 天未提交的 WIP，清理本地 worktree 时发现。原稿基于 7/24 的 main，与之后落地的重构冲突，因此按原意在最新 main 上重做，而非硬解冲突。