### PR TITLE
fix(auth): 显示通用 OIDC 登录者名称 (#773)

### DIFF
--- a/web/src/components/PresenceBar.tsx
+++ b/web/src/components/PresenceBar.tsx
@@ -295,9 +295,10 @@ export function ownerKey(item: Item): string {
 }
 
 function ownerLabel(item: Item): string {
-  // 显示优先级：handle > SSO display name > owner/account（email）> 原始 name。agent 恒无 handle，不受影响。
+  // 人类显示优先级：SSO display name > handle > owner/account（email）> 原始 name。
+  // 这里只决定 UI 文案；@ 路由仍由服务端的唯一性/歧义规则裁决。
+  if (item.kind === "human" && item.displayName !== null && item.displayName !== "") return item.displayName;
   if (item.handle !== null && item.handle !== "") return item.handle;
-  if (item.displayName !== null && item.displayName !== "") return item.displayName;
   if (item.owner !== null && item.owner !== "") return item.owner;
   return item.name;
 }
@@ -405,7 +406,9 @@ export function PresenceBar({
       context: entry?.context ?? null,
       lineage: entry?.lineage ?? sender?.lineage ?? null,
       workflow: entry?.status?.workflow ?? null,
-      display: assigned?.display ?? handle ?? displayName ?? (kind === "human" && owner !== null ? owner : name),
+      display:
+        assigned?.display ??
+        (kind === "human" ? displayName ?? handle ?? owner ?? name : handle ?? displayName ?? name),
       displayName,
       avatarUrl: sender?.avatar_url ?? entry?.avatar_url ?? null,
       avatarThumb: sender?.avatar_thumb ?? entry?.avatar_thumb ?? null,

--- a/web/src/lib/identityDisplay.test.ts
+++ b/web/src/lib/identityDisplay.test.ts
@@ -26,7 +26,7 @@ describe("buildIdentityDisplay", () => {
     expect(map[uuid]).toEqual({ display: "thejacks@163.com", kind: "human", account: "thejacks@163.com" });
   });
 
-  it("prefers a human's handle over owner/email for participants, presence and message senders", () => {
+  it("prefers a human display name over an opaque handle and owner/email", () => {
     const uuid = "61ec302c-6c31-4bca-a1df-88152372f6d9";
     const map = buildIdentityDisplay({
       channelIdentities: [],
@@ -37,18 +37,33 @@ describe("buildIdentityDisplay", () => {
           kind: "message",
           body: "hi",
           ts: 1,
-          sender: { name: uuid, kind: "human", owner: "thejacks@163.com", handle: "leo" },
+          sender: {
+            name: uuid,
+            kind: "human",
+            owner: "thejacks@163.com",
+            handle: "oidc-a1b2c3d4e5f60708",
+            display_name: "Jane Zhang",
+          },
           mentions: [],
           reply_to: null,
         } as MsgFrame,
       ],
-      participants: [{ name: uuid, kind: "human", owner: "thejacks@163.com", handle: "leo" }],
+      participants: [
+        {
+          name: uuid,
+          kind: "human",
+          owner: "thejacks@163.com",
+          handle: "oidc-a1b2c3d4e5f60708",
+          display_name: "Jane Zhang",
+        },
+      ],
       presence: {
         [uuid]: {
           name: uuid,
           kind: "human",
           account: "thejacks@163.com",
-          handle: "leo",
+          handle: "oidc-a1b2c3d4e5f60708",
+          display_name: "Jane Zhang",
           state: "working",
           note: null,
           ts: 1,
@@ -56,6 +71,6 @@ describe("buildIdentityDisplay", () => {
       },
     });
 
-    expect(map[uuid]).toEqual({ display: "leo", kind: "human", account: "thejacks@163.com" });
+    expect(map[uuid]).toEqual({ display: "Jane Zhang", kind: "human", account: "thejacks@163.com" });
   });
 });

--- a/web/src/lib/identityDisplay.ts
+++ b/web/src/lib/identityDisplay.ts
@@ -44,16 +44,16 @@ export function displayForIdentity(name: string, identities: IdentityDisplayMap 
   return identities?.[name]?.display ?? name;
 }
 
-// 显示优先级：人类 handle（可 @ 昵称）> owner（人类专属，email）> 常规 identity 回退。
+// 显示优先级：人类 display_name > handle（可 @ 昵称）> owner（email）> 常规 identity 回退。
 // 消息头的 senderLabel 与引用预览块里"被引用者"的名字共用同一份逻辑，保证两处一致。
 export function resolveSenderLabel(sender: Sender, identities: IdentityDisplayMap | undefined): string {
-  return sender.handle
-    ? sender.handle
-    : sender.kind === "human" && sender.display_name
-      ? sender.display_name
-    : sender.kind === "human" && sender.owner
-      ? sender.owner
-      : displayForIdentity(sender.name, identities);
+  return sender.kind === "human" && sender.display_name
+    ? sender.display_name
+    : sender.handle
+      ? sender.handle
+      : sender.kind === "human" && sender.owner
+        ? sender.owner
+        : displayForIdentity(sender.name, identities);
 }
 
 export function buildIdentityDisplay(input: {
@@ -65,20 +65,20 @@ export function buildIdentityDisplay(input: {
 }): IdentityDisplayMap {
   const map: IdentityDisplayMap = {};
 
-  // 显示优先级：handle（人类=account handle，agent=自设昵称 #165）> SSO display name > owner/account（email）> 原始 name。
-  // agent 有昵称就显示昵称，没有则天然回退 name。map 的 key 仍是原始 name/UUID，不受此优先级影响。
+  // 人类显示优先级：SSO display name > account handle > owner/account（email）> 原始 name。
+  // agent 仍是昵称 > 原始 name。map 的 key 始终是可路由 identity，不用展示名做 key。
   for (const sender of input.participants) {
     addIdentity(map, sender.name, {
       kind: sender.kind,
       account: sender.owner,
-      display: sender.handle || (sender.kind === "human" ? sender.display_name || sender.owner : undefined) || sender.name,
+      display: (sender.kind === "human" ? sender.display_name || sender.handle || sender.owner : sender.handle) || sender.name,
     });
   }
   for (const entry of Object.values(input.presence)) {
     addIdentity(map, entry.name, {
       kind: entry.kind,
       account: entry.account,
-      display: entry.handle || (entry.kind === "human" ? entry.display_name || entry.account : undefined) || entry.name,
+      display: (entry.kind === "human" ? entry.display_name || entry.handle || entry.account : entry.handle) || entry.name,
     });
   }
   for (const message of input.messages) {
@@ -86,8 +86,9 @@ export function buildIdentityDisplay(input: {
       kind: message.sender.kind,
       account: message.sender.owner,
       display:
-        message.sender.handle ||
-        (message.sender.kind === "human" ? message.sender.display_name || message.sender.owner : undefined) ||
+        (message.sender.kind === "human"
+          ? message.sender.display_name || message.sender.handle || message.sender.owner
+          : message.sender.handle) ||
         message.sender.name,
     });
   }

--- a/worker/src/auth.ts
+++ b/worker/src/auth.ts
@@ -9,6 +9,8 @@ export interface TokenIdentity {
   hash: string;
   // OIDC 人类 token 携带 email；ap_ token 无此字段
   email?: string;
+  // OIDC 展示名。绝不参与账号锚点或 ACL；消息侧是否允许 display alias 由频道既有路由规则决定。
+  displayName?: string;
   // 所属人：机器 ap_ token 取 tokens.owner 列；人类 OIDC token 取 email（退回 sub）。无则省略
   owner?: string;
   // principal.account（账号模型 spec §5.1）：ACL 的唯一身份锚点。
@@ -255,6 +257,24 @@ interface OidcClaims {
   sub?: string;
   email?: string;
   name?: string;
+  preferred_username?: string;
+}
+
+function oidcDisplayName(claims: OidcClaims): string | undefined {
+  for (const value of [claims.name, claims.preferred_username]) {
+    if (typeof value !== "string") continue;
+    const safe = [...value.trim()]
+      .map((char) => {
+        const codePoint = char.codePointAt(0)!;
+        if (char.length === 1 && codePoint >= 0xd800 && codePoint <= 0xdfff) return "\ufffd";
+        if (codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f)) return "";
+        return char;
+      })
+      .join("")
+      .trim();
+    if (safe.length > 0) return [...safe].slice(0, 128).join("");
+  }
+  return undefined;
 }
 
 async function verifyOidcToken(token: string, oidc: OidcConfig): Promise<TokenIdentity | null> {
@@ -288,9 +308,11 @@ async function verifyOidcToken(token: string, oidc: OidcConfig): Promise<TokenId
   // email_verified 缺失或为 false → 忽略 email，回退到 sub（sub 由 IdP 保证唯一且不可伪造）。
   const emailVerified = claims.email_verified === true || claims.email_verified === "true";
   const email = emailVerified && typeof claims.email === "string" ? claims.email : undefined;
+  const displayName = oidcDisplayName(claims);
   return {
     name: claims.sub,
     email,
+    ...(displayName === undefined ? {} : { displayName }),
     role: "human",
     kind: "human",
     hash: `oidc:${claims.sub}`,

--- a/worker/src/auth.ts
+++ b/worker/src/auth.ts
@@ -263,7 +263,7 @@ interface OidcClaims {
 function oidcDisplayName(claims: OidcClaims): string | undefined {
   for (const value of [claims.name, claims.preferred_username]) {
     if (typeof value !== "string") continue;
-    const safe = [...value.trim()]
+    const safe = [...value.slice(0, 512).trim()]
       .map((char) => {
         const codePoint = char.codePointAt(0)!;
         if (char.length === 1 && codePoint >= 0xd800 && codePoint <= 0xdfff) return "\ufffd";

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -2638,10 +2638,15 @@ export async function handleHeader(db: D1Database, identity: TokenIdentity): Pro
   )
     .bind(identity.account)
     .first<{ handle: string | null; display_name: string | null; avatar_url: string | null; avatar_thumb: string | null }>();
-  if (!row) return {};
+  if (!row) {
+    return identity.displayName
+      ? { "x-ap-display-name": encodeURIComponent(identity.displayName) }
+      : {};
+  }
+  const displayName = row.display_name ?? identity.displayName;
   return {
     ...(row.handle ? { "x-ap-handle": encodeURIComponent(row.handle) } : {}),
-    ...(row.display_name ? { "x-ap-display-name": encodeURIComponent(row.display_name) } : {}),
+    ...(displayName ? { "x-ap-display-name": encodeURIComponent(displayName) } : {}),
     ...(row.avatar_url ? { "x-ap-avatar-url": row.avatar_url } : {}),
     ...(row.avatar_thumb ? { "x-ap-avatar-thumb": row.avatar_thumb } : {}),
   };
@@ -3024,7 +3029,7 @@ app.get("/api/me", requireBearer, async (c) => {
     channel_scope: id.channel_scope ?? null,
     lineage: id.lineage ?? null,
     handle: profile?.handle ?? agentNickname,
-    display_name: profile?.display_name ?? null,
+    display_name: profile?.display_name ?? id.displayName ?? null,
     avatar_url: profile?.avatar_url ?? null,
     avatar_thumb: profile?.avatar_thumb ?? null,
     provider: profile?.provider ?? null,
@@ -5820,9 +5825,19 @@ app.post("/api/instance/invites/:code/redeem", requireBearer, async (c) => {
     if (conflict === null) {
       try {
         await c.env.DB.prepare(
-          `INSERT INTO account_profiles (account, handle, created_at, updated_at) VALUES (?, ?, ?, ?)`,
+          `INSERT INTO account_profiles (
+             account, handle, display_name, provider, provider_user_id, created_at, updated_at
+           ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
         )
-          .bind(account, invite.preset_handle, now, now)
+          .bind(
+            account,
+            invite.preset_handle,
+            identity.displayName ?? null,
+            identity.displayName === undefined ? null : "oidc",
+            identity.displayName === undefined ? null : identity.name,
+            now,
+            now,
+          )
           .run();
         handleSet = true;
       } catch (e) {
@@ -6780,7 +6795,7 @@ app.get("/api/channels/:slug/identities", async (c) => {
       .bind(account)
       .first<{ handle: string | null; display_name: string | null }>();
     const handle = profile?.handle || null;
-    const display = handle || profile?.display_name || null;
+    const display = profile?.display_name || handle || null;
     if (display === null) continue;
     for (const identity of identities.values()) {
       if (identity.kind === "human" && identity.account === account) add({ ...identity, display, handle });

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -5833,8 +5833,8 @@ app.post("/api/instance/invites/:code/redeem", requireBearer, async (c) => {
             account,
             invite.preset_handle,
             identity.displayName ?? null,
-            identity.displayName === undefined ? null : "oidc",
-            identity.displayName === undefined ? null : identity.name,
+            identity.hash.startsWith("oidc:") ? "oidc" : null,
+            identity.hash.startsWith("oidc:") ? identity.name : null,
             now,
             now,
           )

--- a/worker/test/channels.spec.ts
+++ b/worker/test/channels.spec.ts
@@ -299,7 +299,7 @@ describe("channels", () => {
     expect((await api(`/api/channels/${slug}/identities`, outsider.token)).status).toBe(403);
   });
 
-  it("identity map prefers human profile handles over opaque provider account ids", async () => {
+  it("identity map prefers human display names over handles and opaque provider account ids", async () => {
     const ownerName = "lark-ad72b3f9749e";
     const ownerAccount = "lark:on_22608d74bd2d7f39f6dc67d0da248fa5";
     const owner = await seedToken("human", ownerName, { owner: ownerAccount });
@@ -321,7 +321,7 @@ describe("channels", () => {
     }).identities;
 
     expect(identities).toContainEqual(
-      expect.objectContaining({ name: ownerName, display: handle, handle, kind: "human", account: ownerAccount }),
+      expect.objectContaining({ name: ownerName, display: "Leo", handle, kind: "human", account: ownerAccount }),
     );
   });
 });

--- a/worker/test/oidc.spec.ts
+++ b/worker/test/oidc.spec.ts
@@ -3,7 +3,7 @@ import { SELF, env } from "cloudflare:test";
 import { fetchMock } from "./fetch-mock";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { lookupToken, oidcConfigFromEnv } from "../src/auth";
-import { createChannel, uniq } from "./helpers";
+import { api, createChannel, seedToken, uniq } from "./helpers";
 
 const CLIENT_ID = "ap-web";
 const CONFIGURED_ISSUER = "https://oidc.test"; // 与 vitest.config 的静态绑定一致
@@ -100,6 +100,49 @@ describe("lookupToken OIDC verification", () => {
       // 账号锚点（spec §5.1）：OIDC 人类 account = email ?? sub
       account: "u@leeguoo.com",
     });
+  });
+
+  it("reads name as a display-only claim and falls back to preferred_username", async () => {
+    const namedIssuer = freshIssuer();
+    mockJwks(namedIssuer);
+    const named = await lookupToken(
+      env.DB,
+      await signJwt(claims(namedIssuer, { name: "  Jane Zhang  ", preferred_username: "jzhang" })),
+      oidc(namedIssuer),
+    );
+    expect(named).toMatchObject({
+      name: "user-abc",
+      account: "u@leeguoo.com",
+      displayName: "Jane Zhang",
+    });
+
+    const preferredIssuer = freshIssuer();
+    mockJwks(preferredIssuer);
+    const preferred = await lookupToken(
+      env.DB,
+      await signJwt(claims(preferredIssuer, { name: "   ", preferred_username: "jzhang" })),
+      oidc(preferredIssuer),
+    );
+    expect(preferred?.displayName).toBe("jzhang");
+
+    const emptyIssuer = freshIssuer();
+    mockJwks(emptyIssuer);
+    const empty = await lookupToken(
+      env.DB,
+      await signJwt(claims(emptyIssuer, { name: " ", preferred_username: "" })),
+      oidc(emptyIssuer),
+    );
+    expect(empty?.displayName).toBeUndefined();
+
+    const sanitizedIssuer = freshIssuer();
+    mockJwks(sanitizedIssuer);
+    const sanitized = await lookupToken(
+      env.DB,
+      await signJwt(claims(sanitizedIssuer, { name: `\u0000Jane\ud800${"界".repeat(140)}` })),
+      oidc(sanitizedIssuer),
+    );
+    expect(sanitized?.displayName).toBe(`Jane\ufffd${"界".repeat(123)}`);
+    expect([...(sanitized?.displayName ?? "")]).toHaveLength(128);
   });
 
   it("falls back owner to sub when the JWT has no email", async () => {
@@ -215,7 +258,7 @@ describe("oidc end-to-end via SELF.fetch", () => {
 
   it("accepts an OIDC human end-to-end: list, create channel, post message", async () => {
     mockJwks(CONFIGURED_ISSUER); // 首次验签拉一次 JWKS，其后命中缓存
-    const jwt = await signJwt(claims(CONFIGURED_ISSUER));
+    const jwt = await signJwt(claims(CONFIGURED_ISSUER, { name: "OIDCUser" }));
     const auth = { authorization: `Bearer ${jwt}`, "content-type": "application/json" };
 
     const list = await SELF.fetch("http://ap.test/api/channels", { headers: auth });
@@ -233,7 +276,7 @@ describe("oidc end-to-end via SELF.fetch", () => {
       channel_scope: null,
       lineage: null,
       handle: null,
-      display_name: null,
+      display_name: "OIDCUser",
       avatar_url: null,
       avatar_thumb: null,
       provider: null,
@@ -244,6 +287,10 @@ describe("oidc end-to-end via SELF.fetch", () => {
       // OIDC 人类：非 readonly 能发/建频道；有 account 能自助铸 agent；无 scope；spawn 只给 scoped parent agent
       caps: { send: true, create_channel: true, mint_agents: true, spawn_children: false, scoped_to: null },
     });
+    const profileBeforeInvite = await env.DB.prepare("SELECT handle FROM account_profiles WHERE account = ?")
+      .bind("u@leeguoo.com")
+      .first<{ handle: string }>();
+    expect(profileBeforeInvite).toBeNull();
 
     const cliAudJwt = await signJwt(
       claims(CONFIGURED_ISSUER, { aud: "agentparty-cli", sub: "cli-user", email: "cli@leeguoo.com" }),
@@ -266,6 +313,79 @@ describe("oidc end-to-end via SELF.fetch", () => {
     });
     expect(post.status).toBe(200);
     expect((await post.json()) as { seq: number }).toMatchObject({ seq: 1 });
+    const history = await SELF.fetch(`http://ap.test/api/channels/${slug}/messages`, { headers: auth });
+    expect(history.status).toBe(200);
+    const historyBody = (await history.json()) as {
+      messages: { sender: { owner?: string; handle?: string; display_name?: string } }[];
+    };
+    expect(historyBody.messages[0]?.sender).toMatchObject({
+      owner: "u@leeguoo.com",
+      display_name: "OIDCUser",
+    });
+    expect(historyBody.messages[0]?.sender.handle).toBeUndefined();
+
+    // 真正兑换外部邀请时才创建资料，并保留邀请预设的唯一 handle 与 OIDC 展示名。
+    const owner = await seedToken("human", uniq("invite-owner"), { owner: "invite-owner@example.com" });
+    const inviteSlug = await createChannel(owner.token);
+    const presetHandle = uniq("oidcguest").replaceAll("-", "");
+    const inviteResponse = await api(`/api/channels/${inviteSlug}/external-invites`, owner.token, {
+      method: "POST",
+      body: JSON.stringify({ handle: presetHandle }),
+    });
+    expect(inviteResponse.status).toBe(201);
+    const invite = (await inviteResponse.json()) as { code: string };
+    const inviteJwt = await signJwt(
+      claims(CONFIGURED_ISSUER, {
+        sub: "invited-user",
+        email: "invited@example.com",
+        name: "Invited User",
+      }),
+    );
+    const redeem = await SELF.fetch(`http://ap.test/api/instance/invites/${invite.code}/redeem`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${inviteJwt}` },
+    });
+    expect(redeem.status).toBe(200);
+    expect(await redeem.json()).toMatchObject({ channel_slug: inviteSlug, handle: presetHandle });
+    expect(
+      await env.DB.prepare(
+        "SELECT handle, display_name, provider, provider_user_id FROM account_profiles WHERE account = ?",
+      )
+        .bind("invited@example.com")
+        .first(),
+    ).toMatchObject({
+      handle: presetHandle,
+      display_name: "Invited User",
+      provider: "oidc",
+      provider_user_id: "invited-user",
+    });
+
+    // 邀请预设的唯一 handle 可路由。
+    const handleMention = await SELF.fetch(`http://ap.test/api/channels/${inviteSlug}/messages`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${inviteJwt}`, "content-type": "application/json" },
+      body: JSON.stringify({ kind: "message", body: "handle works", mentions: [presetHandle], reply_to: null }),
+    });
+    expect(handleMention.status).toBe(200);
+
+    // 无效邀请不能因为 token 带 name 就留下 account_profiles 副作用。
+    const invalidJwt = await signJwt(
+      claims(CONFIGURED_ISSUER, {
+        sub: "invalid-invite-user",
+        email: "invalid-invite@example.com",
+        name: "Invalid Invite User",
+      }),
+    );
+    const invalidRedeem = await SELF.fetch("http://ap.test/api/instance/invites/not-a-real-code/redeem", {
+      method: "POST",
+      headers: { authorization: `Bearer ${invalidJwt}` },
+    });
+    expect(invalidRedeem.status).toBe(404);
+    expect(
+      await env.DB.prepare("SELECT handle FROM account_profiles WHERE account = ?")
+        .bind("invalid-invite@example.com")
+        .first(),
+    ).toBeNull();
   });
 
 });

--- a/worker/test/oidc.spec.ts
+++ b/worker/test/oidc.spec.ts
@@ -143,6 +143,15 @@ describe("lookupToken OIDC verification", () => {
     );
     expect(sanitized?.displayName).toBe(`Jane\ufffd${"界".repeat(123)}`);
     expect([...(sanitized?.displayName ?? "")]).toHaveLength(128);
+
+    const boundedIssuer = freshIssuer();
+    mockJwks(boundedIssuer);
+    const bounded = await lookupToken(
+      env.DB,
+      await signJwt(claims(boundedIssuer, { name: "界".repeat(10_000) })),
+      oidc(boundedIssuer),
+    );
+    expect(bounded?.displayName).toBe("界".repeat(128));
   });
 
   it("falls back owner to sub when the JWT has no email", async () => {
@@ -367,6 +376,37 @@ describe("oidc end-to-end via SELF.fetch", () => {
       body: JSON.stringify({ kind: "message", body: "handle works", mentions: [presetHandle], reply_to: null }),
     });
     expect(handleMention.status).toBe(200);
+
+    // OIDC 身份来源不能依赖可选的展示名；无 name/preferred_username 也要保留 provider 锚点。
+    const noNameHandle = uniq("oidcnoname").replaceAll("-", "");
+    const noNameInviteResponse = await api(`/api/channels/${inviteSlug}/external-invites`, owner.token, {
+      method: "POST",
+      body: JSON.stringify({ handle: noNameHandle }),
+    });
+    expect(noNameInviteResponse.status).toBe(201);
+    const noNameInvite = (await noNameInviteResponse.json()) as { code: string };
+    const noNameJwt = await signJwt(
+      claims(CONFIGURED_ISSUER, {
+        sub: "invited-no-name",
+        email: "invited-no-name@example.com",
+      }),
+    );
+    const noNameRedeem = await SELF.fetch(
+      `http://ap.test/api/instance/invites/${noNameInvite.code}/redeem`,
+      { method: "POST", headers: { authorization: `Bearer ${noNameJwt}` } },
+    );
+    expect(noNameRedeem.status).toBe(200);
+    expect(
+      await env.DB.prepare(
+        "SELECT display_name, provider, provider_user_id FROM account_profiles WHERE account = ?",
+      )
+        .bind("invited-no-name@example.com")
+        .first(),
+    ).toMatchObject({
+      display_name: null,
+      provider: "oidc",
+      provider_user_id: "invited-no-name",
+    });
 
     // 无效邀请不能因为 token 带 name 就留下 account_profiles 副作用。
     const invalidJwt = await signJwt(


### PR DESCRIPTION
## 问题

通用 OIDC 已声明 `name`，但鉴权结果没有读取它，导致 `/api/me`、消息发送者、频道身份与在线成员只能退回 email、handle 或不透明的 `sub`。这正是 #773 的根因。

## 改动

- 读取并规范化 `name`，空值时回退 `preferred_username`；清除控制字符并限制为 128 个 Unicode code point
- 把 OIDC 展示名贯通到 `/api/me`、消息/Presence header 与频道身份 API
- 统一 Web 的人类身份显示优先级为：`display_name > handle > owner/email > name`
- 仅在有效外部邀请兑换时随 preset handle 持久化 OIDC 资料；普通登录和无效邀请不会隐式创建 `account_profiles`
- 保留频道既有唯一 display alias / 歧义降级路由契约，不把展示名用于账号锚点或 ACL

## 用户影响

通用 OIDC 登录者会显示 IdP 提供的人类可读名称；已有人工资料里的 `display_name` 仍优先，handle、email 和 sub 继续作为稳定回退。不会因一次登录产生隐式资料写入。

## 验证

- `bun run check`：scripts、CLI、shared、web、worker 全量通过
- CLI：1362 passed
- Web：1215 passed，TypeScript 与 Vite production build 通过
- Worker：759 passed，TypeScript 通过
- OIDC / channel identity / mention routing 定向回归：72 passed
- `git diff --check` 通过

## 发布关联

本 PR 合并后发布 v0.2.155。该版本也会带上已在 v0.2.154 合入的 #746 常驻会话桥接实现；#746 的 Codex 与 Claude 官方站真实链路验收证据会单独回填到 issue。

Closes #773

## 合并前检查（review-ack 强制闸）

- [ ] 我已读当前 head 的 pr-agent / CodeRabbit review，真问题已处理、误报已判明
- [x] 本地全量门禁通过
- [x] 鉴权与持久化边界已有正向和无副作用测试


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 支持从 OIDC 登录信息中获取并展示用户的可读姓名。
  - 用户资料、在线状态、参与者列表及消息发送者显示名现在优先使用“显示名称”，其次使用账号 handle。
  - 外部邀请兑换时可自动保存用户显示名称及相关身份信息。

- **改进**
  - 显示名称会自动清理异常字符、去除多余空白并限制长度，提升展示一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->