### PR TITLE
fix(desktop): 让常驻日志直达最新状态

### DIFF
--- a/web/src/components/LocalAgentsOverview.tsx
+++ b/web/src/components/LocalAgentsOverview.tsx
@@ -22,6 +22,7 @@ import {
   type LocalAgentRow,
 } from "../lib/localAgents";
 import type { DesktopAgentScheduler } from "./DesktopAgentPanel";
+import { useAutoScrollToLatest } from "../lib/useAutoScrollToLatest";
 import "../i18n/strings/LocalAgentsOverview";
 
 const defaultScheduler: DesktopAgentScheduler = {
@@ -85,6 +86,10 @@ export function LocalAgentsOverview({
   // 单调序号——只让「最新一次 refresh」的结果落地，乱序完成的旧结果丢弃。
   const refreshSeqRef = useRef(0);
   const logSeqRef = useRef(0);
+  const logPreRef = useAutoScrollToLatest<HTMLPreElement>(
+    logView?.text,
+    logView?.busy !== true && logView?.error == null,
+  );
 
   useEffect(() => {
     mountedRef.current = true;
@@ -525,7 +530,7 @@ export function LocalAgentsOverview({
                               )}
                               {rowLog?.busy !== true && rowLog?.error == null && (
                                 rowLog?.text?.trim() ? (
-                                  <pre className="t-mono local-agents-log" tabIndex={0}>{rowLog.text}</pre>
+                                  <pre ref={logPreRef} className="t-mono local-agents-log" tabIndex={0}>{rowLog.text}</pre>
                                 ) : (
                                   <p className="local-agents-log-state">{t("LocalAgents.logsEmpty")}</p>
                                 )

--- a/web/src/components/ResidentDutyLogs.test.tsx
+++ b/web/src/components/ResidentDutyLogs.test.tsx
@@ -1,8 +1,9 @@
 // @ts-expect-error Bun executes this test, while the web tsconfig intentionally loads only Vite globals.
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { ReactElement } from "react";
 import { act, create, type ReactTestInstance, type ReactTestRenderer } from "react-test-renderer";
 import { LocaleProvider } from "../i18n/locale";
-import type { DesktopDutyEntry } from "../lib/desktopAgent";
+import type { DesktopAgentConfig, DesktopDutyEntry } from "../lib/desktopAgent";
 
 const { ResidentDutyLogs } = await import("./ResidentDutyLogs");
 
@@ -49,14 +50,20 @@ afterEach(() => {
 });
 
 async function renderPanel(
-  adapter: { dutyList: () => Promise<DesktopDutyEntry[]>; dutyLogRead: (label: string) => Promise<string> },
+  adapter: {
+    dutyList: () => Promise<DesktopDutyEntry[]>;
+    dutyLogRead: (label: string) => Promise<string>;
+    listConfigs?: () => Promise<DesktopAgentConfig[]>;
+  },
   active = true,
+  createNodeMock?: (element: ReactElement) => unknown,
 ): Promise<ReactTestRenderer> {
   await act(async () => {
     renderer = create(
       <LocaleProvider>
         <ResidentDutyLogs t={((k: string) => k) as never} adapter={adapter} active={active} />
       </LocaleProvider>,
+      createNodeMock === undefined ? undefined : { createNodeMock },
     );
   });
   return renderer!;
@@ -78,6 +85,22 @@ describe("ResidentDutyLogs (#725)", () => {
     expect(text).toContain('"dev"');
   });
 
+  test("常驻日志列表显示可信 Agent 名称", async () => {
+    const r = await renderPanel({
+      dutyList: async () => [entry({ instanceId: "abc123:kyc" })],
+      listConfigs: async () => [{
+        configId: "abc123",
+        name: "kyc-reviewer",
+        serverOrigin: "https://agentparty.test",
+        channel: "kyc",
+        kind: "agent",
+        role: "reviewer",
+      }],
+      dutyLogRead: async () => "",
+    });
+    expect(JSON.stringify(r.toJSON())).toContain("kyc-reviewer");
+  });
+
   test("点某个实例 → 读取并展示其日志尾部", async () => {
     const reads: string[] = [];
     const r = await renderPanel({
@@ -88,6 +111,21 @@ describe("ResidentDutyLogs (#725)", () => {
     await act(async () => { await item.props.onClick(); });
     expect(reads).toEqual(["com.agentparty.duty.abc123.kyc"]);
     expect(JSON.stringify(r.toJSON())).toContain("serve: online");
+  });
+
+  test("日志加载后默认定位到最新一行", async () => {
+    const logNode = { scrollTop: 0, scrollHeight: 640 };
+    const r = await renderPanel(
+      {
+        dutyList: async () => [entry()],
+        dutyLogRead: async () => "old failure\nrecovered",
+      },
+      true,
+      (element) => element.type === "pre" ? logNode : {},
+    );
+    const item = buttons(r).find((button) => JSON.stringify(button.props.className).includes("resident-logs-item"))!;
+    await act(async () => { await item.props.onClick(); });
+    expect(logNode.scrollTop).toBe(640);
   });
 
   test("快速切换条目:慢请求不覆盖后点击的日志(#734 排序保护)", async () => {

--- a/web/src/components/ResidentDutyLogs.tsx
+++ b/web/src/components/ResidentDutyLogs.tsx
@@ -2,12 +2,21 @@
 // 方便排查「设了常驻、@ 没反应」这类问题(日志里能看到 ▶ wake / serve: / runner 报错)。
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { TFunc } from "../i18n/useT";
-import { desktopAgentAdapter, type DesktopAgentAdapter, type DesktopDutyEntry } from "../lib/desktopAgent";
+import {
+  desktopAgentAdapter,
+  type DesktopAgentAdapter,
+  type DesktopAgentConfig,
+  type DesktopDutyEntry,
+} from "../lib/desktopAgent";
+import { useAutoScrollToLatest } from "../lib/useAutoScrollToLatest";
 import "../i18n/strings/ResidentDutyLogs";
+
+type ResidentDutyAdapter = Pick<DesktopAgentAdapter, "dutyList" | "dutyLogRead"> &
+  Partial<Pick<DesktopAgentAdapter, "listConfigs">>;
 
 interface Props {
   t: TFunc;
-  adapter?: Pick<DesktopAgentAdapter, "dutyList" | "dutyLogRead">;
+  adapter?: ResidentDutyAdapter;
   active?: boolean;
 }
 
@@ -17,8 +26,18 @@ function channelOf(entry: DesktopDutyEntry): string {
   return idx >= 0 ? entry.instanceId.slice(idx + 1) : entry.instanceId;
 }
 
+function configIdOf(entry: DesktopDutyEntry): string {
+  const idx = entry.instanceId.indexOf(":");
+  return idx >= 0 ? entry.instanceId.slice(0, idx) : entry.instanceId;
+}
+
+function configNames(configs: readonly DesktopAgentConfig[]): Map<string, string> {
+  return new Map(configs.map((config) => [config.configId, config.name]));
+}
+
 export function ResidentDutyLogs({ t, adapter = desktopAgentAdapter, active = true }: Props) {
   const [entries, setEntries] = useState<DesktopDutyEntry[] | null>(null);
+  const [namesByConfigId, setNamesByConfigId] = useState<Map<string, string>>(() => new Map());
   const [listError, setListError] = useState<string | null>(null);
   const [selected, setSelected] = useState<string | null>(null); // 选中的 label
   const [log, setLog] = useState<string>("");
@@ -28,14 +47,18 @@ export function ResidentDutyLogs({ t, adapter = desktopAgentAdapter, active = tr
   const loadSeqRef = useRef(0);
   const listSeqRef = useRef(0);
   const listActiveRef = useRef(active);
+  const logPreRef = useAutoScrollToLatest<HTMLPreElement>(log, !logBusy && logError === null);
 
   const refreshList = useCallback(async () => {
     const seq = ++listSeqRef.current;
     setListError(null);
     try {
-      const list = await adapter.dutyList();
+      const configsRequest = adapter.listConfigs?.().catch(() => [] as DesktopAgentConfig[]) ??
+        Promise.resolve([] as DesktopAgentConfig[]);
+      const [list, configs] = await Promise.all([adapter.dutyList(), configsRequest]);
       if (!listActiveRef.current || seq !== listSeqRef.current) return;
       setEntries(list);
+      setNamesByConfigId(configNames(configs));
       // 选中项若已消失，清掉日志。
       setSelected((current) => (current !== null && list.some((e) => e.label === current) ? current : null));
     } catch (err) {
@@ -80,6 +103,13 @@ export function ResidentDutyLogs({ t, adapter = desktopAgentAdapter, active = tr
     };
   }, [active, refreshList]);
 
+  const agentNameOf = (entry: DesktopDutyEntry): string => {
+    const configId = configIdOf(entry);
+    return namesByConfigId.get(configId) ?? configId;
+  };
+
+  const selectedEntry = entries?.find((entry) => entry.label === selected) ?? null;
+
   return (
     <div className="resident-logs">
       <div className="resident-logs-head">
@@ -104,6 +134,7 @@ export function ResidentDutyLogs({ t, adapter = desktopAgentAdapter, active = tr
                 onClick={() => void loadLog(entry.label)}
               >
                 <span className="resident-logs-chan">#{channelOf(entry)}</span>
+                <span className="resident-logs-agent">{agentNameOf(entry)}</span>
                 <span className={`resident-logs-dot${entry.loaded ? " resident-logs-dot--on" : ""}`} aria-hidden="true">
                   ●
                 </span>
@@ -119,7 +150,10 @@ export function ResidentDutyLogs({ t, adapter = desktopAgentAdapter, active = tr
       {selected !== null && (
         <div className="resident-logs-view">
           <div className="resident-logs-view-head">
-            <span className="t-mono resident-logs-label">{selected}</span>
+            <span className="resident-logs-selection">
+              {selectedEntry !== null && <strong>{agentNameOf(selectedEntry)}</strong>}
+              <span className="t-mono resident-logs-label">{selected}</span>
+            </span>
             <button type="button" className="d-btn resident-logs-reload" disabled={logBusy} onClick={() => void loadLog(selected)}>
               {logBusy ? t("ResidentDutyLogs.loading") : t("ResidentDutyLogs.reload")}
             </button>
@@ -129,7 +163,7 @@ export function ResidentDutyLogs({ t, adapter = desktopAgentAdapter, active = tr
             (log.trim() === "" ? (
               <p className="resident-logs-empty">{t("ResidentDutyLogs.noLog")}</p>
             ) : (
-              <pre className="t-mono resident-logs-pre">{log}</pre>
+              <pre ref={logPreRef} className="t-mono resident-logs-pre">{log}</pre>
             ))}
         </div>
       )}

--- a/web/src/lib/useAutoScrollToLatest.ts
+++ b/web/src/lib/useAutoScrollToLatest.ts
@@ -1,0 +1,20 @@
+import { useLayoutEffect, useRef, type RefObject } from "react";
+
+/**
+ * Log panes show a tail of a file, so the useful default is the newest line.
+ * Keep this behavior shared between the overview and the dedicated duty-log view.
+ */
+export function useAutoScrollToLatest<T extends HTMLElement>(
+  content: string | null | undefined,
+  active = true,
+): RefObject<T | null> {
+  const ref = useRef<T>(null);
+
+  useLayoutEffect(() => {
+    const element = ref.current;
+    if (!active || element === null || content?.trim() === "") return;
+    element.scrollTop = element.scrollHeight;
+  }, [active, content]);
+
+  return ref;
+}

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -283,10 +283,13 @@
 .resident-logs-item { display: flex; align-items: center; gap: 8px; width: 100%; justify-content: flex-start; text-align: left; }
 .resident-logs-item--active { border-color: var(--d-blue); color: var(--d-blue); }
 .resident-logs-chan { font-weight: 600; }
+.resident-logs-agent { min-width: 0; overflow: hidden; color: var(--t-text); font-size: 11px; text-overflow: ellipsis; white-space: nowrap; }
 .resident-logs-dot { color: var(--t-faint); font-size: 10px; }
 .resident-logs-dot--on { color: var(--d-green); }
 .resident-logs-state { font-size: 11px; color: var(--t-dim); }
 .resident-logs-view-head { display: flex; align-items: center; justify-content: space-between; gap: 10px; margin-bottom: 6px; }
+.resident-logs-selection { display: flex; min-width: 0; flex-direction: column; gap: 2px; }
+.resident-logs-selection > strong { font-size: 11px; }
 .resident-logs-label { font-size: 11px; color: var(--t-dim); word-break: break-all; }
 .resident-logs-pre { max-height: 320px; overflow: auto; margin: 0; padding: 8px; font-size: 11px; line-height: 1.5; background: var(--t-faint); border-radius: 4px; white-space: pre-wrap; overflow-wrap: anywhere; }
 


### PR DESCRIPTION
## 改动说明

- 常驻日志列表显示可信 Agent 名称，不再只给频道和配置哈希。
- 运行概览与专用常驻日志加载后自动定位到最新一行，避免历史重试误导为当前故障。
- 抽取共享日志滚动 hook，保持两处行为一致。

## 合并前检查（review-ack 强制闸——不留结论合不了）

- [x] 我已读 pr-agent / CodeRabbit 的 review，真问题已处理、误报已判明
- [x] 本地门禁通过（tsc / 测试 / build）
- [x] 涉及安全/鉴权/数据的改动已做对抗性验证（本 PR 不改安全、鉴权或数据链路；日志滚动由 createNodeMock 断言）

### Review 结论

- pr-agent 的 `logView` 空指针提示为误报：调用使用 `logView?.text`、`logView?.busy`、`logView?.error`，在空值时安全返回 `undefined`。
- CodeRabbit 的 React 副版本提示与当前锁定状态不符：实际安装及 `bun.lock` 中 `react`、`react-dom`、`react-test-renderer` 均为 `19.2.7`，不存在运行时/测试渲染器副版本混用。本次新增用例和全量 1227 项 Web 测试均通过。测试渲染器迁移是全仓既有技术债，不在此功能补丁中伪装成局部修复。

### 验证

- `cd web && bun test src`：1227 pass
- `cd web && bun run typecheck`
- `cd web && bun run build`
- PR CI：CLI、Worker、Web、Desktop、shared、scripts、dependency audit 全部通过

### 发布

合并后发布 v0.2.158，并在官方站与 Desktop 实机复验。
