### PR TITLE
fix(worker): seq 操作对不存在的 seq 返 404 而非 500+泄露 stack (#785)

### DIFF
--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -1862,7 +1862,7 @@ export class ChannelDO extends Server<Env> {
       if (!(await this.isTokenActive(identity.tokenHash))) {
         return Response.json({ error: { code: "unauthorized", message: "invalid or revoked token" } }, { status: 401 });
       }
-      const row = this.ctx.storage.sql.exec("SELECT * FROM messages WHERE seq = ?", seq).one();
+      const row = this.ctx.storage.sql.exec("SELECT * FROM messages WHERE seq = ?", seq).toArray()[0];
       if (!row) {
         return Response.json({ error: { code: "not_found", message: `message seq ${seq} not found` } }, { status: 404 });
       }
@@ -2010,7 +2010,7 @@ export class ChannelDO extends Server<Env> {
       if (byteLength(reason) > REVIEW_REASON_LIMIT) {
         return Response.json({ error: { code: "too_large", message: `reason exceeds ${REVIEW_REASON_LIMIT} bytes` } }, { status: 413 });
       }
-      const row = this.ctx.storage.sql.exec("SELECT * FROM messages WHERE seq = ?", seq).one();
+      const row = this.ctx.storage.sql.exec("SELECT * FROM messages WHERE seq = ?", seq).toArray()[0];
       if (!row) {
         return Response.json({ error: { code: "not_found", message: `message seq ${seq} not found` } }, { status: 404 });
       }
@@ -2454,7 +2454,7 @@ export class ChannelDO extends Server<Env> {
         ? frame.replaces
         : undefined;
     if (replacesSeq !== undefined) {
-      const replacedRow = sql.exec("SELECT * FROM messages WHERE seq = ?", replacesSeq).one();
+      const replacedRow = sql.exec("SELECT * FROM messages WHERE seq = ?", replacesSeq).toArray()[0];
       if (!replacedRow) {
         return { ok: false, code: "bad_request", message: `replacement target seq ${replacesSeq} not found` };
       }

--- a/worker/test/missing-seq.spec.ts
+++ b/worker/test/missing-seq.spec.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { api, createChannel, postMessage, seedToken, uniq } from "./helpers";
+
+// #785: revision/review endpoints looked up the target message with `.one()`,
+// which throws on an empty result set. For a non-existent seq this surfaced as
+// a 500 that leaked the internal SQL error + stack to the client, instead of a
+// clean 404 (the dead `if (!row)` guard could never run). These tests pin the
+// intended behaviour: a missing seq is a client 404, never a 500, and the body
+// never carries an internal stack.
+
+const MISSING_SEQ = 999999;
+
+async function scopedFixture() {
+  const acct = `${uniq("acct")}@leeguoo.com`;
+  const owner = await seedToken("agent", uniq("owner"), { owner: acct });
+  const slug = await createChannel(owner.token);
+  const writer = await seedToken("agent", uniq("writer"), { owner: acct, channelScope: slug });
+  return { slug, owner, writer };
+}
+
+async function expectNotFound(res: Response) {
+  expect(res.status).toBe(404);
+  const raw = await res.text();
+  const parsed = JSON.parse(raw) as { error?: { code?: string } };
+  expect(parsed.error?.code).toBe("not_found");
+  // Must not leak internal implementation details (bundle path / SQL / stack).
+  expect(raw).not.toMatch(/index\.js|\bat \w+.*\(|SqlStorage|SQLITE/i);
+}
+
+describe("missing seq returns 404 not 500 (#785)", () => {
+  it("retract of a non-existent seq → 404", async () => {
+    const { slug, writer } = await scopedFixture();
+    const res = await api(`/api/channels/${slug}/messages/${MISSING_SEQ}/retract`, writer.token, { method: "POST" });
+    await expectNotFound(res);
+  });
+
+  it("edit of a non-existent seq → 404", async () => {
+    const { slug, writer } = await scopedFixture();
+    const res = await api(`/api/channels/${slug}/messages/${MISSING_SEQ}/edit`, writer.token, {
+      method: "POST",
+      body: JSON.stringify({ body: "does not matter" }),
+    });
+    await expectNotFound(res);
+  });
+
+  it("supersede of a non-existent seq → 404", async () => {
+    const { slug, writer } = await scopedFixture();
+    const res = await api(`/api/channels/${slug}/messages/${MISSING_SEQ}/supersede`, writer.token, {
+      method: "POST",
+      body: JSON.stringify({ body: "does not matter" }),
+    });
+    await expectNotFound(res);
+  });
+
+  it("review of a non-existent seq → 404", async () => {
+    const { slug, writer } = await scopedFixture();
+    const res = await api(`/api/channels/${slug}/messages/${MISSING_SEQ}/review`, writer.token, {
+      method: "POST",
+      body: JSON.stringify({ action: "approve" }),
+    });
+    await expectNotFound(res);
+  });
+
+  it("completion send that replaces a non-existent seq → 400 (not 500)", async () => {
+    const acct = `${uniq("acct")}@leeguoo.com`;
+    const owner = await seedToken("agent", uniq("owner"), { owner: acct });
+    const slug = await createChannel(owner.token);
+    const writer = await seedToken("agent", uniq("writer"), { owner: acct, channelScope: slug });
+    const gate = await api(`/api/channels/${slug}/completion-gate`, owner.token, {
+      method: "PUT",
+      body: JSON.stringify({ gate: "reviewer", policy: "sender" }),
+    });
+    expect(gate.status).toBe(200);
+    const kickoff = await postMessage(slug, writer.token, "please do the work");
+    const kickoffSeq = ((await kickoff.json()) as { seq: number }).seq;
+
+    const res = await api(`/api/channels/${slug}/messages`, writer.token, {
+      method: "POST",
+      body: JSON.stringify({
+        kind: "message",
+        body: "final synthesis",
+        mentions: [],
+        reply_to: kickoffSeq,
+        completion_artifact: {
+          kind: "final_synthesis",
+          kickoff_seq: kickoffSeq,
+          replies_count: 1,
+          timeout: false,
+          related_issues: [],
+          related_prs: [],
+        },
+        replaces: MISSING_SEQ,
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    const raw = await res.text();
+    expect(raw).not.toMatch(/index\.js|\bat \w+.*\(|SqlStorage|SQLITE/i);
+  });
+});

--- a/worker/test/missing-seq.spec.ts
+++ b/worker/test/missing-seq.spec.ts
@@ -95,6 +95,8 @@ describe("missing seq returns 404 not 500 (#785)", () => {
 
     expect(res.status).toBe(400);
     const raw = await res.text();
+    const parsed = JSON.parse(raw) as { error?: { code?: string } };
+    expect(parsed.error?.code).toBe("bad_request");
     expect(raw).not.toMatch(/index\.js|\bat \w+.*\(|SqlStorage|SQLITE/i);
   });
 });


### PR DESCRIPTION
## 改动说明
修复 #785（安全相关）：`retract` / `edit` / `supersede` / `review` 以及 completion 的 `replaces` 校验，在查目标消息时用了 `storage.sql.exec(...).one()`。`.one()` 在结果集不是恰好一行时会抛异常——对不存在的 seq（零行）直接抛未捕获异常，冒泡成 **500**，并把内部 SQL 错误与打包文件行号（`index.js:8869/9182`）泄露给任意客户端。紧随其后的 `if (!row)` 404 守卫因此永远执行不到，是死代码。

双重问题：
1. **信息泄露**（安全）：内部实现/打包文件名行号暴露给任意客户端；
2. **错误码语义**：本应 404 `not_found` 却返 500，客户端无法区分「消息不存在」与「服务端故障」，会误重试。

改法（最小对症）：三处目标消息查询 `.one()` → `.toArray()[0]`，空结果返回 `undefined`，让既有的守卫真正生效：
- `worker/src/do.ts` edit/retract/supersede → 404 `not_found`
- `worker/src/do.ts` review → 404 `not_found`
- `worker/src/do.ts` completion send-with-replaces（**顺带发现的同类洞，issue 未列举**）→ 400 `bad_request`

> 更彻底的「顶层错误响应统一剥离 stack」（防未来所有泄露）改动面大、需碰全局错误中间件，建议另开 PR，不在本 PR 范围。

## 验证
- 新增 `worker/test/missing-seq.spec.ts`（5 条）：覆盖 5 个端点对不存在 seq 的返回码，并断言响应体**不含** `index.js` / stack / SQL 内部标记。
- 先复现：改前 5 条全部返 500（红）→ 改后全绿。
- `cd worker && npm run typecheck`：0 错。
- `cd worker && npx vitest run`：**38 文件 / 268 tests 全过**。

## 合并前检查（review-ack 强制闸——不留结论合不了）
- [x] 我已读 pr-agent / CodeRabbit 的 review，真问题已处理、误报已判明
- [x] 本地门禁通过（typecheck / 全量测试）
- [x] 涉及安全/鉴权/数据的改动已做对抗性验证（本 PR 修信息泄露；测试显式断言响应体不泄露 stack/内部路径，改前后对照坐实）

Closes #785


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复了对不存在消息序号进行撤回、编辑、补发或审核时的错误处理。
  * 相关请求现在会返回明确的 `404 not_found` 响应。
  * 修复了完成消息替换目标不存在时的响应，现返回 `400`。
  * 防止向客户端泄露数据库错误、堆栈或内部路径等实现细节。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->