### PR TITLE
fix(web): 恢复正文提及并支持按归属搜索 Agent

### DIFF
--- a/web/src/components/Composer.escape.test.tsx
+++ b/web/src/components/Composer.escape.test.tsx
@@ -54,6 +54,51 @@ function keyEvent(key: string, isComposing = false) {
 }
 
 describe("Composer Escape handling (#357)", () => {
+  test("searching a human shows the readable owner group and all of that human's agents", () => {
+    const account = "lark:on_luis";
+    const candidates = [
+      {
+        name: "luis",
+        display: "Luis",
+        kind: "human" as const,
+        tier: "online" as const,
+        group: account,
+        account,
+        ownerDisplay: "Luis",
+      },
+      ...Array.from({ length: 10 }, (_, index) => ({
+        name: `agent-${index + 1}`,
+        display: `agent-${index + 1}`,
+        kind: "agent" as const,
+        tier: "recent" as const,
+        group: account,
+        account,
+        ownerDisplay: "Luis",
+      })),
+    ];
+    act(() => {
+      renderer = create(
+        <LocaleProvider>
+          <Composer
+            draft="@luis"
+            setDraft={() => undefined}
+            onSend={() => undefined}
+            ready
+            candidates={candidates}
+            mentionStatuses={[]}
+          />
+        </LocaleProvider>,
+      );
+    });
+
+    const textarea = renderer!.root.findByProps({ className: "composer-input t-mono" });
+    act(() => textarea.props.onClick({ currentTarget: { value: "@luis", selectionStart: 5 } }));
+
+    expect(renderer!.root.findAllByProps({ role: "option" })).toHaveLength(11);
+    expect(renderer!.root.findAllByProps({ className: "mention-group" })[0]?.children).toEqual(["Luis"]);
+    expect(renderer!.root.findAllByProps({ className: "mention-owner t-mono" })).toHaveLength(10);
+  });
+
   test("focuses and reveals the composer when reply mode starts", () => {
     const focus = mock(() => undefined);
     const scrollIntoView = mock(() => undefined);

--- a/web/src/components/Composer.tsx
+++ b/web/src/components/Composer.tsx
@@ -111,11 +111,11 @@ function sameCandidateNames(prev: MentionCandidate[], next: MentionCandidate[]):
   return prev.length === next.length && prev.every((item, index) => item.name === next[index]?.name);
 }
 
-function groupLabel(group: string, t: TFunc): string {
+function groupLabel(group: string, t: TFunc, ownerDisplay?: string): string {
   if (group === "human sessions") return t("Composer.group.humanSessions");
   if (group === "unowned agents") return t("Composer.group.unownedAgents");
   if (group === "squads") return t("Composer.group.squads");
-  return group;
+  return ownerDisplay ?? group;
 }
 
 export function Composer({
@@ -341,7 +341,11 @@ export function Composer({
           {menu.items.map((c, i) => {
             const prev = menu.items[i - 1];
             const showGroup = prev === undefined || prev.group !== c.group;
-            const owner = c.account && c.account !== c.display ? c.account : null;
+            const owner =
+              c.kind !== "agent"
+                ? null
+                : c.ownerDisplay
+                  ?? (c.account && c.account !== c.display ? c.account : null);
             const title = [
               c.display,
               owner ? t("Composer.owner", { account: owner }) : "",
@@ -355,7 +359,7 @@ export function Composer({
               <li key={c.name} className="mention-row">
                 {showGroup && (
                   <div className="mention-group" aria-hidden="true">
-                    {groupLabel(c.group, t)}
+                    {groupLabel(c.group, t, c.ownerDisplay)}
                   </div>
                 )}
                 <div

--- a/web/src/components/MessageCard.details.test.tsx
+++ b/web/src/components/MessageCard.details.test.tsx
@@ -7,7 +7,13 @@ import { ChannelStrings } from "../i18n/strings/Channel";
 import type { IdentityDisplayMap } from "../lib/identityDisplay";
 import type { MentionReceipt } from "../lib/wakeReceipt";
 
-mock.module("../lib/markdown", () => ({ renderMarkdown: (s: string) => s }));
+const markdownCalls: Array<{ display?: (name: string) => string }> = [];
+mock.module("../lib/markdown", () => ({
+  renderMarkdown: (_source: string, _identities: IdentityDisplayMap | undefined, display?: (name: string) => string) => {
+    markdownCalls.push({ display });
+    return "";
+  },
+}));
 const { MessageCard } = await import("./MessageCard");
 
 let renderer: ReactTestRenderer | null = null;
@@ -24,6 +30,7 @@ function textContent(node: { children: Array<string | { children: unknown[] }> }
 }
 
 beforeEach(() => {
+  markdownCalls.length = 0;
   Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", { configurable: true, value: true });
   Object.defineProperty(globalThis, "localStorage", { configurable: true, value: {
     getItem: () => "en", setItem() {}, removeItem() {}, clear() {}, key: () => null, length: 0,
@@ -153,6 +160,8 @@ describe("MessageCard touch and keyboard details (#357)", () => {
     expect(text).toContain("Owned byZHENG TONG");
     expect(text).toContain("Technical IDlark-461bc7018484-apple-signin-revoke");
     expect(text).not.toContain("Identityagent · lark:on_");
+    expect(markdownCalls.at(-1)?.display?.("lark-461bc7018484-apple-signin-revoke"))
+      .toBe("apple-signin-revoke");
   });
 
   test("status full detail expands by click and keyboard", () => {

--- a/web/src/components/MessageCard.tsx
+++ b/web/src/components/MessageCard.tsx
@@ -443,6 +443,12 @@ function MessageCardImpl({
     },
     [identityDisplay, t],
   );
+  // 正文 mention 是句子的一部分，只保留短身份名与 @ 语义；“用户 · Agent”仅用于
+  // 消息头、投递状态和身份卡等独立身份界面，不能塞进“有异常 @angel 我即查”这类正文。
+  const inlineMentionLabel = useCallback(
+    (name: string): string => resolveIdentityPresentation(name, identityDisplay).label,
+    [identityDisplay],
+  );
   const lineage = msg.sender.lineage ?? null;
   const lineageLabel = lineage === null ? null : `child of ${lineage.parent_agent}`;
   const senderTitle = [
@@ -1015,7 +1021,7 @@ function MessageCardImpl({
       ) : msg.retracted ? (
         <p className="msg-retracted">{t("MessageCard.retracted")}</p>
       ) : (
-        <Markdown source={msg.body} identities={identityDisplay} display={identityLabel} />
+        <Markdown source={msg.body} identities={identityDisplay} display={inlineMentionLabel} />
       )}
       {!editing && !msg.retracted && msg.attachments !== undefined && msg.attachments.length > 0 && (
         <AttachmentList attachments={msg.attachments} />

--- a/web/src/lib/mentionMarkup.test.ts
+++ b/web/src/lib/mentionMarkup.test.ts
@@ -48,7 +48,7 @@ function spy(identities: IdentityDisplayMap) {
 describe("mention 美化：真实管线集成（#131）", () => {
   it("prose 里的 @name 变成受控 span", () => {
     expect(R("hi @alice there")).toBe(
-      '<p>hi <span class="ap-mention" title="@alice">Alice</span> there</p>',
+      '<p>hi <span class="ap-mention" title="@alice">@Alice</span> there</p>',
     );
   });
 
@@ -97,29 +97,29 @@ describe("mention 美化：真实管线集成（#131）", () => {
 
   it("句末句号留在 mention span 外", () => {
     expect(R("ask @codex.")).toBe(
-      '<p>ask <span class="ap-mention" title="@codex">Codex</span>.</p>',
+      '<p>ask <span class="ap-mention" title="@codex">@Codex</span>.</p>',
     );
   });
 
   it("中文正文无需空格，且只消费唯一匹配的昵称前缀", () => {
     expect(R("请@小明看一下")).toBe(
-      '<p>请<span class="ap-mention" title="@小明">小明同学</span>看一下</p>',
+      '<p>请<span class="ap-mention" title="@小明">@小明同学</span>看一下</p>',
     );
     expect(R("请，@小明：看一下")).toBe(
-      '<p>请，<span class="ap-mention" title="@小明">小明同学</span>：看一下</p>',
+      '<p>请，<span class="ap-mention" title="@小明">@小明同学</span>：看一下</p>',
     );
   });
 
   it("agent handle 大小写不敏感匹配", () => {
     expect(R("hi @ALICE")).toBe(
-      '<p>hi <span class="ap-mention" title="@alice">Alice</span></p>',
+      '<p>hi <span class="ap-mention" title="@alice">@Alice</span></p>',
     );
   });
 
   it("Unicode alias 不做 locale 大小写折叠", () => {
     const unicode = spy({ Ägent: { display: "Unicode Agent", kind: "agent" } });
     expect(unicode.render("@Ägent @ÄGENT")).toBe(
-      '<p><span class="ap-mention" title="@Ägent">Unicode Agent</span> @ÄGENT</p>',
+      '<p><span class="ap-mention" title="@Ägent">@Unicode Agent</span> @ÄGENT</p>',
     );
     expect(unicode.calls).toEqual([{ name: "Ägent", display: "Unicode Agent" }]);
   });
@@ -128,39 +128,39 @@ describe("mention 美化：真实管线集成（#131）", () => {
     const decomposed = "A\u0308gent";
     const composedIdentity = spy({ Ägent: { display: "Unicode Agent", kind: "agent" } });
     expect(composedIdentity.render(`@${decomposed}看一下`)).toBe(
-      '<p><span class="ap-mention" title="@Ägent">Unicode Agent</span>看一下</p>',
+      '<p><span class="ap-mention" title="@Ägent">@Unicode Agent</span>看一下</p>',
     );
 
     const decomposedIdentity = spy({ [decomposed]: { display: "Decomposed Agent", kind: "agent" } });
     expect(decomposedIdentity.render("@Ägent看一下")).toBe(
-      `<p><span class="ap-mention" title="@${decomposed}">Decomposed Agent</span>看一下</p>`,
+      `<p><span class="ap-mention" title="@${decomposed}">@Decomposed Agent</span>看一下</p>`,
     );
   });
 
   it("可读邮箱 display 作为 span 渲染，路由 @ 只保留在 title", () => {
     const raw = "61ec302c-6c31-4bca-a1df-88152372f6d9";
     expect(R(`@${raw} hello`)).toBe(
-      `<p><span class="ap-mention" title="@${raw}">thejacks@163.com</span> hello</p>`,
+      `<p><span class="ap-mention" title="@${raw}">@thejacks@163.com</span> hello</p>`,
     );
   });
 
-  it("正文 @agent 使用调用方统一提供的归属标签，同时保留真实路由 identity", () => {
+  it("正文 @agent 使用短身份名，不把 owner 标签塞进句子，同时保留真实路由 identity", () => {
     const raw = "lark-461bc7018484-apple-signin-revoke";
     const identities: IdentityDisplayMap = {
       [raw]: { display: raw, kind: "agent", account: "lark:on_owner" },
     };
     expect(
       markdownToHtmlUnsafe(`请 @${raw} 检查`, identities, () =>
-        "ZHENG TONG · apple-signin-revoke",
+        "apple-signin-revoke",
       ).trim(),
     ).toBe(
-      `<p>请 <span class="ap-mention" title="@${raw}">ZHENG TONG · apple-signin-revoke</span> 检查</p>`,
+      `<p>请 <span class="ap-mention" title="@${raw}">@apple-signin-revoke</span> 检查</p>`,
     );
   });
 
   it("注入前转义 display 里的 HTML 特殊字符", () => {
     expect(R("@weird hi")).toBe(
-      '<p><span class="ap-mention" title="@weird">a&lt;&amp;"b</span> hi</p>',
+      '<p><span class="ap-mention" title="@weird">@a&lt;&amp;"b</span> hi</p>',
     );
   });
 
@@ -168,8 +168,10 @@ describe("mention 美化：真实管线集成（#131）", () => {
     expect(R("hi @nobody there")).toBe("<p>hi @nobody there</p>");
   });
 
-  it("display 与 name 相同时不注入", () => {
-    expect(R("hi @self there")).toBe("<p>hi @self there</p>");
+  it("display 与 name 相同时仍保留 @ 并高亮已知 mention", () => {
+    expect(R("hi @self there")).toBe(
+      '<p>hi <span class="ap-mention" title="@self">@self</span> there</p>',
+    );
   });
 
   // #642 安全：用户消息里的裸 HTML 不得借样式伪造 @mention（ap-mention span）或系统 UI（hljs span）。
@@ -189,12 +191,12 @@ describe("mention 美化：真实管线集成（#131）", () => {
   });
 
   it("句首、以及 /、* 等真实边界后的 @name 都识别为 mention", () => {
-    expect(R("@alice")).toBe('<p><span class="ap-mention" title="@alice">Alice</span></p>');
+    expect(R("@alice")).toBe('<p><span class="ap-mention" title="@alice">@Alice</span></p>');
     expect(R("path /@alice/x")).toContain(
-      '/<span class="ap-mention" title="@alice">Alice</span>/x',
+      '/<span class="ap-mention" title="@alice">@Alice</span>/x',
     );
     expect(R("**b**@alice")).toBe(
-      '<p><strong>b</strong><span class="ap-mention" title="@alice">Alice</span></p>',
+      '<p><strong>b</strong><span class="ap-mention" title="@alice">@Alice</span></p>',
     );
   });
 });

--- a/web/src/lib/mentionMarkup.ts
+++ b/web/src/lib/mentionMarkup.ts
@@ -69,8 +69,8 @@ export function mentionExtension(
       if (resolution.status !== "resolved") return undefined;
       const name = resolution.target;
       const display = displayFor?.(name) ?? identities[name]?.display;
-      // 没有映射、或映射回自身，就不接管这个 token：让 @name 以字面文本渲染。
-      if (display === undefined || display === name) return undefined;
+      // 没有映射就不接管；已知目标即使显示名等于路由名，也保留 mention 高亮和 @ 语义。
+      if (display === undefined) return undefined;
 
       // CJK 无空格正文可能被词法层读成 "小明看一下"。只消费实际命中的 alias，
       // 余下 "看一下" 继续交给 marked 渲染，不能吞进 mention span。
@@ -80,7 +80,7 @@ export function mentionExtension(
     },
     renderer(token) {
       const { name, display } = token as MentionToken;
-      return `<span class="ap-mention" title="@${escapeHtmlAttr(name)}">${escapeHtmlText(display)}</span>`;
+      return `<span class="ap-mention" title="@${escapeHtmlAttr(name)}">@${escapeHtmlText(display)}</span>`;
     },
   };
 }

--- a/web/src/lib/mentions.test.ts
+++ b/web/src/lib/mentions.test.ts
@@ -135,6 +135,33 @@ describe("mentionCandidates", () => {
     expect(c.role).toBe("worker");
   });
 
+  test("searching a human display name includes that human and every agent under the same account", () => {
+    const account = "lark:on_luis";
+    const identities = [
+      { name: "human-luis", display: "Luis", kind: "human" as const, account, handle: "luis" },
+      ...Array.from({ length: 10 }, (_, index) => ({
+        name: `agent-${index + 1}`,
+        display: `agent-${index + 1}`,
+        kind: "agent" as const,
+        account,
+      })),
+    ];
+    const candidates = mentionCandidates(
+      [{ name: "human-luis", kind: "human", owner: account, handle: "luis" }],
+      {},
+      null,
+      NOW,
+      identities,
+    );
+    const matches = filterCandidates(candidates, "luis");
+
+    expect(matches).toHaveLength(11);
+    expect(matches.map((candidate) => candidate.name)).toContain("luis");
+    expect(matches.filter((candidate) => candidate.kind === "agent")).toHaveLength(10);
+    expect(matches.every((candidate) => candidate.ownerDisplay === "Luis")).toBe(true);
+    expect(matches.every((candidate) => candidate.group === account)).toBe(true);
+  });
+
   test("identity-only agents stay mentionable even without live presence", () => {
     const c = mentionCandidates([], {}, null, NOW, [
       { name: "LEO-MAIN", display: "LEO-MAIN", kind: "agent", account: "lark:on_owner" },

--- a/web/src/lib/mentions.ts
+++ b/web/src/lib/mentions.ts
@@ -29,6 +29,7 @@ export interface MentionCandidate {
   tier: MentionTier;
   group: string; // UI 分组：账号 / 未归属
   account?: string; // 会话背后的账号（人类 = email）
+  ownerDisplay?: string; // 账号对应的人类显示名；用于按人搜索其名下 agent，不能替代路由 token
   role?: string; // 协作角色/职责（host/worker/reviewer/observer），hover 显示
   responsibility?: string; // 结构化职责说明（频道分工字段）
   note?: string; // 当前 status note
@@ -93,6 +94,40 @@ export function mentionCandidates(
     recentSenderByName.set(message.sender.name, mergeSenderIdentity(previous, message.sender));
     recentMentionNames.add(message.sender.name);
     if (message.sender.handle) recentMentionNames.add(message.sender.handle);
+  }
+  const ownerDisplayByAccount = new Map<string, string>();
+  const rememberOwnerDisplay = (
+    account: string | undefined,
+    display: string | null | undefined,
+  ) => {
+    const readable = display?.trim();
+    if (!account || !readable || readable === account || SYSTEM_HUMAN_SESSION_RE.test(readable)) return;
+    if (ownerDisplayByAccount.has(account)) return;
+    ownerDisplayByAccount.set(account, readable);
+  };
+  for (const identity of identities) {
+    if (identity.kind === "human") rememberOwnerDisplay(identity.account, identity.display || identity.handle);
+  }
+  for (const role of roles) {
+    if (role.kind === "human") rememberOwnerDisplay(role.account, role.display);
+  }
+  for (const participant of participants) {
+    if (participant.kind === "human") {
+      rememberOwnerDisplay(
+        participant.owner,
+        participant.display_name || participant.handle,
+      );
+    }
+  }
+  for (const entry of Object.values(presence)) {
+    if (entry.kind === "human") {
+      rememberOwnerDisplay(entry.account, entry.display_name || entry.handle);
+    }
+  }
+  for (const sender of recentSenderByName.values()) {
+    if (sender.kind === "human") {
+      rememberOwnerDisplay(sender.owner, sender.display_name || sender.handle);
+    }
   }
   const kindOf = new Map<string, "agent" | "human">();
   for (const p of participants) kindOf.set(p.name, p.kind);
@@ -159,6 +194,11 @@ export function mentionCandidates(
             : kind === "human" && account
               ? recentSender?.display_name || account
               : name;
+      const ownerDisplay =
+        account === undefined
+          ? undefined
+          : ownerDisplayByAccount.get(account)
+            ?? (kind === "human" && display !== account ? display : undefined);
       const group = account ?? (kind === "human" ? "human sessions" : "unowned agents");
       return {
         sourceName: name,
@@ -168,6 +208,7 @@ export function mentionCandidates(
         tier: tierFor(name, online, presence, now),
         group,
         account,
+        ownerDisplay,
         role: assigned?.role ?? p?.role,
         responsibility: assigned?.responsibility ?? undefined,
         note: p?.note ?? undefined,
@@ -305,5 +346,20 @@ export function filterCandidates(cands: MentionCandidate[], query: string, limit
     if (n.startsWith(q) || d.startsWith(q)) pref.push(c);
     else if (n.includes(q) || d.includes(q)) sub.push(c);
   }
-  return [...pref, ...sub].slice(0, limit);
+  const direct = [...pref, ...sub];
+  const matchedOwnerGroups = new Set(
+    cands
+      .filter((candidate) => q.length >= 2 && candidate.ownerDisplay?.toLowerCase().includes(q))
+      .map((candidate) => candidate.account ?? `display:${candidate.ownerDisplay!.toLowerCase()}`),
+  );
+  if (matchedOwnerGroups.size === 0) return direct.slice(0, limit);
+
+  // 搜人名时把这个人名下的全部 agent 一起带出。owner 组不受普通 8 条上限截断，
+  // 否则 agent 较多的账号仍会出现“只看到本人、看不到自己的 agent”。
+  const ownerMatches = cands.filter((candidate) =>
+    matchedOwnerGroups.has(candidate.account ?? `display:${candidate.ownerDisplay?.toLowerCase() ?? ""}`),
+  );
+  const ownerNames = new Set(ownerMatches.map((candidate) => candidate.name));
+  const remaining = direct.filter((candidate) => !ownerNames.has(candidate.name));
+  return [...ownerMatches, ...remaining.slice(0, Math.max(0, limit - ownerMatches.length))];
 }


### PR DESCRIPTION
## 变更
- 正文 mention 始终保留 @，并使用短身份名，避免把 `Luis · angel` 塞进句子
- 搜索人名时带出该账号下全部 Agent，不受普通 8 条候选上限截断
- 补全分组和 Agent 归属显示使用可读人名，隐藏 `lark:on_*` 技术账号

## 验证
- `bun run check`
- 新增正文 mention、按 owner 搜索和补全菜单回归测试