### PR TITLE
fix(web): 修复归属搜索混入其他成员

### DIFF
--- a/web/src/components/Composer.escape.test.tsx
+++ b/web/src/components/Composer.escape.test.tsx
@@ -99,6 +99,75 @@ describe("Composer Escape handling (#357)", () => {
     expect(renderer!.root.findAllByProps({ className: "mention-owner t-mono" })).toHaveLength(10);
   });
 
+  test("typing an owner after the full menu cannot retain another owner's duplicate session rows", () => {
+    const luisAccount = "lark:on_luis";
+    const wangAccount = "lark:on_wang";
+    const candidates = [
+      {
+        name: "karl",
+        display: "karl",
+        kind: "human" as const,
+        tier: "recent" as const,
+        group: wangAccount,
+        account: wangAccount,
+        ownerDisplay: "王路",
+      },
+      {
+        name: "karl",
+        display: "karl",
+        kind: "human" as const,
+        tier: "recent" as const,
+        group: wangAccount,
+        account: wangAccount,
+        ownerDisplay: "王路",
+      },
+      {
+        name: "luis",
+        display: "Luis",
+        kind: "human" as const,
+        tier: "online" as const,
+        group: luisAccount,
+        account: luisAccount,
+        ownerDisplay: "Luis",
+      },
+      {
+        name: "奥创",
+        display: "奥创",
+        kind: "agent" as const,
+        tier: "recent" as const,
+        group: luisAccount,
+        account: luisAccount,
+        ownerDisplay: "Luis",
+      },
+    ];
+    act(() => {
+      renderer = create(
+        <LocaleProvider>
+          <Composer
+            draft="@"
+            setDraft={() => undefined}
+            onSend={() => undefined}
+            ready
+            candidates={candidates}
+            mentionStatuses={[]}
+          />
+        </LocaleProvider>,
+      );
+    });
+
+    const textarea = renderer!.root.findByProps({ className: "composer-input t-mono" });
+    act(() => textarea.props.onClick({ currentTarget: { value: "@", selectionStart: 1 } }));
+    expect(renderer!.root.findAllByProps({ role: "option" })).toHaveLength(3);
+
+    act(() => textarea.props.onChange({ target: { value: "@luis", selectionStart: 5 } }));
+    expect(
+      renderer!.root.findAllByProps({ className: "mention-name t-mono" }).map((node) => node.children[0]),
+    ).toEqual(["Luis", "奥创"]);
+    expect(renderer!.root.findAllByProps({ className: "mention-group" }).map((node) => node.children[0])).toEqual([
+      "Luis",
+    ]);
+  });
+
   test("focuses and reveals the composer when reply mode starts", () => {
     const focus = mock(() => undefined);
     const scrollIntoView = mock(() => undefined);

--- a/web/src/lib/mentions.test.ts
+++ b/web/src/lib/mentions.test.ts
@@ -502,6 +502,59 @@ describe("filterCandidates", () => {
   test("empty query returns all (capped)", () => {
     expect(filterCandidates(cands, "").length).toBe(3);
   });
+  test("duplicate human sessions cannot leak stale rows into an owner search", () => {
+    const luisAccount = "lark:on_luis";
+    const wangAccount = "lark:on_wang";
+    const candidates = [
+      {
+        name: "karl",
+        display: "karl",
+        kind: "human" as const,
+        tier: "recent" as const,
+        group: wangAccount,
+        account: wangAccount,
+        ownerDisplay: "王路",
+      },
+      {
+        name: "karl",
+        display: "karl",
+        kind: "human" as const,
+        tier: "recent" as const,
+        group: wangAccount,
+        account: wangAccount,
+        ownerDisplay: "王路",
+      },
+      {
+        name: "luis",
+        display: "Luis",
+        kind: "human" as const,
+        tier: "online" as const,
+        group: luisAccount,
+        account: luisAccount,
+        ownerDisplay: "Luis",
+      },
+      {
+        name: "奥创",
+        display: "奥创",
+        kind: "agent" as const,
+        tier: "recent" as const,
+        group: luisAccount,
+        account: luisAccount,
+        ownerDisplay: "Luis",
+      },
+    ];
+
+    expect(filterCandidates(candidates, "").map((candidate) => candidate.name)).toEqual([
+      "karl",
+      "luis",
+      "奥创",
+    ]);
+    expect(filterCandidates(candidates, "luis").map((candidate) => candidate.name)).toEqual([
+      "luis",
+      "奥创",
+    ]);
+    expect(filterCandidates(candidates, "luis").every((candidate) => candidate.account === luisAccount)).toBe(true);
+  });
 });
 
 // 这个函数不只喂草稿状态条——发送/编辑路径也用它决定真正上报给服务端的 mentions 数组（issue #124），

--- a/web/src/lib/mentions.ts
+++ b/web/src/lib/mentions.ts
@@ -46,6 +46,7 @@ const SYSTEM_HUMAN_SESSION_RE =
   /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|login-verify-.+)$/i;
 // #165：昵称可含 unicode（中文），故放开首字为任意字母/数字（与后端 NICKNAME_RE 对齐）。
 const NAME_TOKEN_RE = /^[\p{L}\p{N}][\p{L}\p{N}._-]{0,63}$/u;
+const CANDIDATE_TIER_RANK: Record<MentionTier, number> = { online: 0, wakeable: 1, recent: 2 };
 
 // 档位：① 在线（当前有 WS 连接） ② 可唤醒（autoWakeReachable 统一口径 #47/#55：
 // serve/watch 需不 stale 且不能是 human_driven，webhook 服务端投递、离线也算） ③ 最近活跃（其余 presence）。
@@ -152,7 +153,6 @@ export function mentionCandidates(
     ...roles.map((role) => role.name),
     ...recentSenderByName.keys(),
   ]);
-  const rank: Record<MentionTier, number> = { online: 0, wakeable: 1, recent: 2 };
   const base = [...names]
     // participant_removed only suppresses live addressing; retained sender
     // snapshots still back historical message labels. When the caller has a
@@ -236,7 +236,11 @@ export function mentionCandidates(
       if (!SYSTEM_HUMAN_SESSION_RE.test(c.name)) return true;
       return c.account !== undefined && c.display !== c.name;
     })
-    .sort((a, b) => a.group.localeCompare(b.group) || rank[a.tier] - rank[b.tier] || a.display.localeCompare(b.display))
+    .sort((a, b) =>
+      a.group.localeCompare(b.group)
+      || CANDIDATE_TIER_RANK[a.tier] - CANDIDATE_TIER_RANK[b.tier]
+      || a.display.localeCompare(b.display)
+    )
     .map(({ sourceName: _sourceName, ...candidate }) => candidate);
   const squadCandidates: MentionCandidate[] = squads
     .filter((squad) => squad.name !== self && squad.name !== "system")
@@ -334,12 +338,26 @@ export function parseDraftMentions(text: string, knownNames: readonly string[] =
 }
 
 export function filterCandidates(cands: MentionCandidate[], query: string, limit = 8): MentionCandidate[] {
+  // 同一个可路由昵称可能来自同一人的多个网页登录会话。菜单必须按最终 @ token 去重：
+  // 否则 React 会收到重复 key，在从「@」继续输入「luis」时把旧的 karl/其他 owner 行复用进新结果。
+  const uniqueByName = new Map<string, MentionCandidate>();
+  for (const candidate of cands) {
+    const key = mentionMatchKey(candidate.name);
+    const current = uniqueByName.get(key);
+    if (
+      current === undefined
+      || CANDIDATE_TIER_RANK[candidate.tier] < CANDIDATE_TIER_RANK[current.tier]
+    ) {
+      uniqueByName.set(key, candidate);
+    }
+  }
+  const uniqueCandidates = [...uniqueByName.values()];
   const q = query.toLowerCase();
-  if (q === "") return cands.slice(0, limit);
+  if (q === "") return uniqueCandidates.slice(0, limit);
   // 前缀命中优先，其次子串命中
   const pref: MentionCandidate[] = [];
   const sub: MentionCandidate[] = [];
-  for (const c of cands) {
+  for (const c of uniqueCandidates) {
     // 名字与可读显示名（人类的 email）都参与匹配——这样能直接搜 @thejacks 找到 UUID 会话
     const n = c.name.toLowerCase();
     const d = c.display.toLowerCase();
@@ -348,7 +366,7 @@ export function filterCandidates(cands: MentionCandidate[], query: string, limit
   }
   const direct = [...pref, ...sub];
   const matchedOwnerGroups = new Set(
-    cands
+    uniqueCandidates
       .filter((candidate) => q.length >= 2 && candidate.ownerDisplay?.toLowerCase().includes(q))
       .map((candidate) => candidate.account ?? `display:${candidate.ownerDisplay!.toLowerCase()}`),
   );
@@ -356,7 +374,7 @@ export function filterCandidates(cands: MentionCandidate[], query: string, limit
 
   // 搜人名时把这个人名下的全部 agent 一起带出。owner 组不受普通 8 条上限截断，
   // 否则 agent 较多的账号仍会出现“只看到本人、看不到自己的 agent”。
-  const ownerMatches = cands.filter((candidate) =>
+  const ownerMatches = uniqueCandidates.filter((candidate) =>
     matchedOwnerGroups.has(candidate.account ?? `display:${candidate.ownerDisplay?.toLowerCase() ?? ""}`),
   );
   const ownerNames = new Set(ownerMatches.map((candidate) => candidate.name));


### PR DESCRIPTION
## 改动说明

在提及菜单先展开完整列表、再输入归属人名（如 `@luis`）时，同一昵称的多个登录会话会产生重复 React key，导致其他归属成员残留在筛选结果中。

- 按最终可路由提及 token 去重候选项
- 重复候选优先保留可达性更高的一项
- 增加从完整菜单输入归属人名的组件回归测试
- 增加重复登录会话的筛选单元测试

## 合并前检查（review-ack 强制闸——不留结论合不了）

- [x] 我已读 pr-agent / CodeRabbit 的 review，真问题已处理、误报已判明
- [x] 本地门禁通过（`bun test src/lib/mentions.test.ts`、`bun test src/components/Composer.escape.test.tsx`、`bun run check:web`）
- [x] 涉及安全/鉴权/数据的改动已做对抗性验证（本 PR 不改安全、鉴权或持久化数据；重复会话及跨 owner 残留已由回归测试覆盖）