### PR TITLE
fix(web): 支持按成员拼音搜索 Agent

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
     },
     "cli": {
       "name": "@agentparty/cli",
-      "version": "0.2.157",
+      "version": "0.2.166",
       "bin": {
         "party": "src/index.ts",
       },
@@ -30,7 +30,7 @@
     },
     "desktop": {
       "name": "@agentparty/desktop",
-      "version": "0.2.157",
+      "version": "0.2.166",
       "devDependencies": {
         "@tauri-apps/cli": "^2.6.2",
       },
@@ -56,6 +56,7 @@
         "dompurify": "^3.4.12",
         "highlight.js": "^11.11.1",
         "marked": "^18.0.7",
+        "pinyin-pro": "^3.28.2",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
       },
@@ -662,6 +663,8 @@
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
+
+    "pinyin-pro": ["pinyin-pro@3.28.2", "", {}, "sha512-jV38yxXHLfidirMC4hrXasLDozLCSq/4DfX88GnHcSEJ2+GpSedG6I9VOiEXJu6iQ5dbJC/RjmzyMuS5h/wH5A=="],
 
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 

--- a/web/package.json
+++ b/web/package.json
@@ -23,6 +23,7 @@
     "dompurify": "^3.4.12",
     "highlight.js": "^11.11.1",
     "marked": "^18.0.7",
+    "pinyin-pro": "^3.28.2",
     "react": "^19.2.8",
     "react-dom": "^19.2.8"
   },

--- a/web/src/lib/mentions.test.ts
+++ b/web/src/lib/mentions.test.ts
@@ -525,6 +525,15 @@ describe("filterCandidates", () => {
         ownerDisplay: "王路",
       },
       {
+        name: "apple-signin-revoke",
+        display: "apple-signin-revoke",
+        kind: "agent" as const,
+        tier: "wakeable" as const,
+        group: wangAccount,
+        account: wangAccount,
+        ownerDisplay: "王路",
+      },
+      {
         name: "luis",
         display: "Luis",
         kind: "human" as const,
@@ -546,6 +555,7 @@ describe("filterCandidates", () => {
 
     expect(filterCandidates(candidates, "").map((candidate) => candidate.name)).toEqual([
       "karl",
+      "apple-signin-revoke",
       "luis",
       "奥创",
     ]);
@@ -554,6 +564,15 @@ describe("filterCandidates", () => {
       "奥创",
     ]);
     expect(filterCandidates(candidates, "luis").every((candidate) => candidate.account === luisAccount)).toBe(true);
+    expect(filterCandidates(candidates, "wang").map((candidate) => candidate.name)).toEqual([
+      "karl",
+      "apple-signin-revoke",
+    ]);
+    expect(filterCandidates(candidates, "wl").map((candidate) => candidate.name)).toEqual([
+      "karl",
+      "apple-signin-revoke",
+    ]);
+    expect(filterCandidates(candidates, "wang").every((candidate) => candidate.account === wangAccount)).toBe(true);
   });
 });
 

--- a/web/src/lib/mentions.ts
+++ b/web/src/lib/mentions.ts
@@ -10,6 +10,7 @@ import {
   resolveMentionToken,
   type MentionAlias,
 } from "@agentparty/shared/mentions";
+import { pinyin } from "pinyin-pro";
 import { MENTION_SENDER_RETENTION_MS, mergeSenderIdentity, type SenderIdentitySnapshot } from "./senderIdentity";
 
 export type MentionTier = "online" | "wakeable" | "recent";
@@ -47,6 +48,18 @@ const SYSTEM_HUMAN_SESSION_RE =
 // #165：昵称可含 unicode（中文），故放开首字为任意字母/数字（与后端 NICKNAME_RE 对齐）。
 const NAME_TOKEN_RE = /^[\p{L}\p{N}][\p{L}\p{N}._-]{0,63}$/u;
 const CANDIDATE_TIER_RANK: Record<MentionTier, number> = { online: 0, wakeable: 1, recent: 2 };
+const HAN_RE = /\p{Script=Han}/u;
+
+function ownerSearchKeys(ownerDisplay: string | undefined): string[] {
+  const readable = ownerDisplay?.trim().toLowerCase();
+  if (!readable) return [];
+  if (!HAN_RE.test(readable)) return [readable];
+  return [
+    readable,
+    pinyin(readable, { toneType: "none", type: "array" }).join("").toLowerCase(),
+    pinyin(readable, { pattern: "first", toneType: "none", type: "array" }).join("").toLowerCase(),
+  ];
+}
 
 // 档位：① 在线（当前有 WS 连接） ② 可唤醒（autoWakeReachable 统一口径 #47/#55：
 // serve/watch 需不 stale 且不能是 human_driven，webhook 服务端投递、离线也算） ③ 最近活跃（其余 presence）。
@@ -367,7 +380,7 @@ export function filterCandidates(cands: MentionCandidate[], query: string, limit
   const direct = [...pref, ...sub];
   const matchedOwnerGroups = new Set(
     uniqueCandidates
-      .filter((candidate) => q.length >= 2 && candidate.ownerDisplay?.toLowerCase().includes(q))
+      .filter((candidate) => q.length >= 2 && ownerSearchKeys(candidate.ownerDisplay).some((key) => key.includes(q)))
       .map((candidate) => candidate.account ?? `display:${candidate.ownerDisplay!.toLowerCase()}`),
   );
   if (matchedOwnerGroups.size === 0) return direct.slice(0, limit);


### PR DESCRIPTION
## 改动说明

- 为中文成员显示名生成全拼和首字母搜索键
- 输入 `@wang` / `@wanglu` / `@wl` 时展开“王路”本人及其全部 Agent
- 搜索别名只参与补全过滤，不改变展示名、插入 token 或消息路由
- 覆盖重复网页登录会话、跨 owner 隔离和 Agent 组完整展开

## 合并前检查（review-ack 强制闸——不留结论合不了）
> main 分支保护要求：合并前必须**读过 review 并留下结论**。做法二选一，否则 `review-ack` check 红、无法合并：
> 等当前 head 的 pr-agent(qwen) / CodeRabbit review 都落地后，再二选一（提前 ack 不会放行）：
> - 在本 PR 提交一次 review（Files → Review changes → Approve/Comment），或
> - 评论一条以 `review-ack:` 开头的结论，说清两份 review 有无**真问题**、哪些是**误报**、哪些**采纳**。

- [ ] 我已读 pr-agent / CodeRabbit 的 review，真问题已处理、误报已判明
- [x] 本地门禁通过（1236 tests / tsc / vite build）
- [x] 不涉及安全、鉴权或数据写入；搜索别名不进入消息路由
