### PR TITLE
fix(cli): agent config 孤儿时从持久 agents/ 按频道恢复，不再一律硬拒 (#518)

### DIFF
--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -17,6 +17,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { atomicWriteJson } from "./atomic-json";
+import { stripTerminalControls } from "./format";
 
 export interface Config {
   server: string;
@@ -244,7 +245,9 @@ function readBreadcrumbConfig(cwd: string): ConfigWithSource | null {
       const cfg = JSON.parse(readFileSync(breadcrumb, "utf8")) as Config;
       return { config: cfg, source: sourceInfo("explicit", breadcrumb, cfg, cwd) };
     } catch {
-      console.error(`warning: workspace config breadcrumb is unreadable: ${breadcrumb}; falling back to global config`);
+      console.error(
+        `warning: workspace config breadcrumb is unreadable: ${stripTerminalControls(String(breadcrumb))}; falling back to global config`,
+      );
     }
   } catch {
     /* 无 cwd state */

--- a/cli/src/oidc-cli.ts
+++ b/cli/src/oidc-cli.ts
@@ -1,10 +1,11 @@
 // 回环重定向 PKCE 登录流 + 令牌刷新 + bearer 解析（spec §4）
 import { createHash, randomBytes } from "node:crypto";
 import { accountPath, readAccount, writeAccount, type AccountSession } from "./account";
-import { cwdStatePath, readConfigWithSource, type ConfigSourceInfo, type WorkspaceState } from "./config";
+import { agentpartyHome, cwdStatePath, readConfigWithSource, type Config, type ConfigSourceInfo, type WorkspaceState } from "./config";
 import { fetchPublicConfig } from "./rest";
 import { healServerUrl } from "./validation";
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
 
 // cwd-state 有 config_path 指针、但指向的文件已不在 → 一个「本该是 agent 却丢了 config」的孤儿标记。
 function orphanedAgentPointer(): string | null {
@@ -21,6 +22,45 @@ function orphanedAgentPointer(): string | null {
   } catch {
     return null;
   }
+}
+
+// 孤儿指针绑定的频道（state 只存路径、不存身份，channel 是唯一可靠的匹配键）。
+function boundChannel(): string | null {
+  try {
+    const st = JSON.parse(readFileSync(cwdStatePath(), "utf8")) as WorkspaceState;
+    return st.channel ?? null;
+  } catch {
+    return null;
+  }
+}
+
+// #518 孤儿恢复：绑定的 agent config 丢了（常见于放 $TMPDIR 被系统清理），但持久
+// ~/.agentparty/agents/ 里往往还留着同一个 agent 的 config。按 identity.channel_scope
+// 唯一匹配当前绑定频道 → 用【该 config 自己的 server+token】恢复（agent 的 server 未必
+// 等于人类账号会话的 server）。安全约束：
+//   - 只在【恰好一个】匹配时恢复；0 或多个返回 null（调用方硬拒），绝不猜错身份；
+//   - 只认带 token 的 agent config，永不回退人类账号会话（守住 #42 冒充护栏）。
+function recoverAgentConfigForChannel(channel: string): { server: string; token: string; name: string } | null {
+  let files: string[];
+  try {
+    files = readdirSync(join(agentpartyHome(), "agents")).filter((f) => f.endsWith(".json"));
+  } catch {
+    return null; // agents/ 不存在或不可读
+  }
+  const matches: { server: string; token: string; name: string }[] = [];
+  for (const file of files) {
+    try {
+      const cfg = JSON.parse(readFileSync(join(agentpartyHome(), "agents", file), "utf8")) as Config;
+      if (!cfg?.token || !cfg?.server) continue;
+      if (cfg.identity?.channel_scope !== channel) continue;
+      const healed = healServerUrl(cfg.server);
+      if (!healed) continue;
+      matches.push({ server: healed, token: cfg.token, name: cfg.identity?.name ?? "?" });
+    } catch {
+      // 跳过损坏/非 config 的 json，不因单个坏文件放弃恢复
+    }
+  }
+  return matches.length === 1 ? matches[0] : null;
 }
 
 const SCOPE = "openid profile email offline_access";
@@ -378,6 +418,23 @@ export async function resolveAuthDetailed(): Promise<ResolvedAuthDetailed> {
     // 避免 agent 静默以人类身份发言（冒充是安全问题）。
     const orphan = orphanedAgentPointer();
     if (orphan) {
+      // #518：绑定的 agent config 丢了。硬拒前先尝试从持久 ~/.agentparty/agents/ 里按
+      // 频道唯一匹配找回同一个 agent 的 config（用它自己的 server+token），避免 party 彻底不可用。
+      const channel = boundChannel();
+      const recovered = channel ? recoverAgentConfigForChannel(channel) : null;
+      if (recovered) {
+        console.error(
+          `↻ bound agent config ${orphan} is missing; recovered ${recovered.name} from ~/.agentparty/agents/ (channel "${channel}"). ` +
+            `set AGENTPARTY_CONFIG to that file to silence this notice.`,
+        );
+        return {
+          server: recovered.server,
+          token: recovered.token,
+          auth_source: "runtime_config",
+          config: source,
+          account: accountInfo(sess),
+        };
+      }
       console.error(
         `⚠ identity would resolve to human account (${sess.email ?? "logged-in user"}), but this workspace was bound to an agent config at ${orphan} which is now missing. ` +
           `refusing human-account fallback; restore that file or run every command with AGENTPARTY_CONFIG=<path> (issues #42/#518).`,

--- a/cli/src/oidc-cli.ts
+++ b/cli/src/oidc-cli.ts
@@ -1,9 +1,10 @@
 // 回环重定向 PKCE 登录流 + 令牌刷新 + bearer 解析（spec §4）
 import { createHash, randomBytes } from "node:crypto";
 import { accountPath, readAccount, writeAccount, type AccountSession } from "./account";
-import { agentpartyHome, cwdStatePath, readConfigWithSource, type Config, type ConfigSourceInfo, type WorkspaceState } from "./config";
+import { agentpartyHome, cwdStatePath, readConfigWithSource, tokenFingerprint, type Config, type ConfigSourceInfo, type WorkspaceState } from "./config";
 import { fetchPublicConfig } from "./rest";
 import { healServerUrl } from "./validation";
+import { stripTerminalControls } from "./format";
 import { readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 
@@ -40,22 +41,24 @@ function boundChannel(): string | null {
 // 等于人类账号会话的 server）。安全约束：
 //   - 只在【恰好一个】匹配时恢复；0 或多个返回 null（调用方硬拒），绝不猜错身份；
 //   - 只认带 token 的 agent config，永不回退人类账号会话（守住 #42 冒充护栏）。
-function recoverAgentConfigForChannel(channel: string): { server: string; token: string; name: string } | null {
+function recoverAgentConfigForChannel(channel: string): { server: string; token: string; name: string; path: string } | null {
+  const dir = join(agentpartyHome(), "agents");
   let files: string[];
   try {
-    files = readdirSync(join(agentpartyHome(), "agents")).filter((f) => f.endsWith(".json"));
+    files = readdirSync(dir).filter((f) => f.endsWith(".json"));
   } catch {
     return null; // agents/ 不存在或不可读
   }
-  const matches: { server: string; token: string; name: string }[] = [];
+  const matches: { server: string; token: string; name: string; path: string }[] = [];
   for (const file of files) {
+    const path = join(dir, file);
     try {
-      const cfg = JSON.parse(readFileSync(join(agentpartyHome(), "agents", file), "utf8")) as Config;
+      const cfg = JSON.parse(readFileSync(path, "utf8")) as Config;
       if (!cfg?.token || !cfg?.server) continue;
       if (cfg.identity?.channel_scope !== channel) continue;
       const healed = healServerUrl(cfg.server);
       if (!healed) continue;
-      matches.push({ server: healed, token: cfg.token, name: cfg.identity?.name ?? "?" });
+      matches.push({ server: healed, token: cfg.token, name: cfg.identity?.name ?? "?", path });
     } catch {
       // 跳过损坏/非 config 的 json，不因单个坏文件放弃恢复
     }
@@ -422,16 +425,19 @@ export async function resolveAuthDetailed(): Promise<ResolvedAuthDetailed> {
       // 频道唯一匹配找回同一个 agent 的 config（用它自己的 server+token），避免 party 彻底不可用。
       const channel = boundChannel();
       const recovered = channel ? recoverAgentConfigForChannel(channel) : null;
-      if (recovered) {
+      if (recovered && channel) {
+        // name/channel 来自可能被恶意/损坏 config 污染的数据，打印前剥离终端控制字符，防 ANSI/OSC 注入。
         console.error(
-          `↻ bound agent config ${orphan} is missing; recovered ${recovered.name} from ~/.agentparty/agents/ (channel "${channel}"). ` +
+          `↻ bound agent config ${orphan} is missing; recovered ${stripTerminalControls(recovered.name)} from ~/.agentparty/agents/ (channel "${stripTerminalControls(channel)}"). ` +
             `set AGENTPARTY_CONFIG to that file to silence this notice.`,
         );
+        // config 来源反映真实的持久文件（与 readBreadcrumbConfig 一致：kind="explicit"+path），
+        // 让 whoami/serve 拿到正确的路径与来源，而非顶部探测的旧 source。
         return {
           server: recovered.server,
           token: recovered.token,
           auth_source: "runtime_config",
-          config: source,
+          config: { kind: "explicit", path: recovered.path, token_fingerprint: tokenFingerprint(recovered.token) },
           account: accountInfo(sess),
         };
       }

--- a/cli/src/oidc-cli.ts
+++ b/cli/src/oidc-cli.ts
@@ -1,7 +1,7 @@
 // 回环重定向 PKCE 登录流 + 令牌刷新 + bearer 解析（spec §4）
 import { createHash, randomBytes } from "node:crypto";
 import { accountPath, readAccount, writeAccount, type AccountSession } from "./account";
-import { agentpartyHome, cwdStatePath, readConfigWithSource, tokenFingerprint, type Config, type ConfigSourceInfo, type WorkspaceState } from "./config";
+import { agentpartyHome, cwdStatePath, readConfigWithSource, tokenFingerprint, type ConfigSourceInfo, type WorkspaceState } from "./config";
 import { fetchPublicConfig } from "./rest";
 import { healServerUrl } from "./validation";
 import { stripTerminalControls } from "./format";
@@ -53,12 +53,29 @@ function recoverAgentConfigForChannel(channel: string): { server: string; token:
   for (const file of files) {
     const path = join(dir, file);
     try {
-      const cfg = JSON.parse(readFileSync(path, "utf8")) as Config;
-      if (!cfg?.token || !cfg?.server) continue;
-      if (cfg.identity?.channel_scope !== channel) continue;
+      const parsed = JSON.parse(readFileSync(path, "utf8")) as unknown;
+      if (typeof parsed !== "object" || parsed === null) continue;
+      const cfg = parsed as {
+        server?: unknown;
+        token?: unknown;
+        identity?: { channel_scope?: unknown; name?: unknown } | null;
+      };
+      if (
+        typeof cfg.token !== "string" ||
+        typeof cfg.server !== "string" ||
+        !cfg.token ||
+        !cfg.server
+      ) continue;
+      const identity = typeof cfg.identity === "object" && cfg.identity !== null ? cfg.identity : null;
+      if (identity?.channel_scope !== channel) continue;
       const healed = healServerUrl(cfg.server);
       if (!healed) continue;
-      matches.push({ server: healed, token: cfg.token, name: cfg.identity?.name ?? "?", path });
+      matches.push({
+        server: healed,
+        token: cfg.token,
+        name: typeof identity.name === "string" ? identity.name : "?",
+        path,
+      });
     } catch {
       // 跳过损坏/非 config 的 json，不因单个坏文件放弃恢复
     }
@@ -421,6 +438,7 @@ export async function resolveAuthDetailed(): Promise<ResolvedAuthDetailed> {
     // 避免 agent 静默以人类身份发言（冒充是安全问题）。
     const orphan = orphanedAgentPointer();
     if (orphan) {
+      const safeOrphan = stripTerminalControls(String(orphan));
       // #518：绑定的 agent config 丢了。硬拒前先尝试从持久 ~/.agentparty/agents/ 里按
       // 频道唯一匹配找回同一个 agent 的 config（用它自己的 server+token），避免 party 彻底不可用。
       const channel = boundChannel();
@@ -428,7 +446,7 @@ export async function resolveAuthDetailed(): Promise<ResolvedAuthDetailed> {
       if (recovered && channel) {
         // name/channel 来自可能被恶意/损坏 config 污染的数据，打印前剥离终端控制字符，防 ANSI/OSC 注入。
         console.error(
-          `↻ bound agent config ${orphan} is missing; recovered ${stripTerminalControls(recovered.name)} from ~/.agentparty/agents/ (channel "${stripTerminalControls(channel)}"). ` +
+          `↻ bound agent config ${safeOrphan} is missing; recovered ${stripTerminalControls(recovered.name)} from ~/.agentparty/agents/ (channel "${stripTerminalControls(channel)}"). ` +
             `set AGENTPARTY_CONFIG to that file to silence this notice.`,
         );
         // config 来源反映真实的持久文件（与 readBreadcrumbConfig 一致：kind="explicit"+path），
@@ -442,7 +460,7 @@ export async function resolveAuthDetailed(): Promise<ResolvedAuthDetailed> {
         };
       }
       console.error(
-        `⚠ identity would resolve to human account (${sess.email ?? "logged-in user"}), but this workspace was bound to an agent config at ${orphan} which is now missing. ` +
+        `⚠ identity would resolve to human account (${sess.email ?? "logged-in user"}), but this workspace was bound to an agent config at ${safeOrphan} which is now missing. ` +
           `refusing human-account fallback; restore that file or run every command with AGENTPARTY_CONFIG=<path> (issues #42/#518).`,
       );
       return {

--- a/cli/test/account.test.ts
+++ b/cli/test/account.test.ts
@@ -260,7 +260,7 @@ describe("resolveAuth precedence", () => {
   });
 
   test("strips terminal control chars from recovered identity before printing (#518)", async () => {
-    const missing = join(home, "agents", "orphan-bound.json");
+    const missing = join(home, "agents", "orphan-\x1b[31m\x07-bound.json");
     writeState({ channel: "dev", cursor: 0, config_path: missing, bindings: { dev: missing } });
     // 恶意/损坏 config：name 里塞 ANSI/OSC 控制序列，若原样打印会注入终端。
     // 剥离只去 ESC/BEL 等控制字节（OSC 载荷降级为可见文本），可读部分 "alice" 保留在前。
@@ -285,8 +285,35 @@ describe("resolveAuth precedence", () => {
       console.error = originalError;
     }
     const out = errors.join("\n");
-    expect(out).not.toContain("\x1b"); // 无 ESC → 无控制序列注入
+    expect(errors.join("")).not.toMatch(/[\x00-\x08\x0B-\x1F\x7F-\x9F]/);
     expect(out).toContain("alice"); // 剥离控制字符后可读身份仍在
+  });
+
+  test("skips malformed persistent agent credentials and fails closed (#518)", async () => {
+    const missing = join(home, "agents", "orphan-bound.json");
+    writeState({ channel: "dev", cursor: 0, config_path: missing, bindings: { dev: missing } });
+    writeAgentConfigFile("malformed.json", {
+      server: "https://agent.example.com",
+      token: { unexpected: "object" },
+      identity: { name: ["alice"], channel_scope: "dev" },
+    });
+    writeAccount({
+      server: "https://issuer.example.com",
+      refresh_token: "ref",
+      access_token: "acc-live",
+      expires_at: nowSec() + 3600,
+      email: "human@example.com",
+    });
+    const errors: string[] = [];
+    const originalError = console.error;
+    console.error = (...args: unknown[]) => errors.push(args.join(" "));
+    try {
+      const auth = await resolveAuthDetailed();
+      expect(auth).toMatchObject({ token: null, auth_source: "none" });
+    } finally {
+      console.error = originalError;
+    }
+    expect(errors.join("\n")).toContain("refusing human-account fallback");
   });
 
   test("refuses (no wrong-identity pick) when multiple persistent configs match the channel (#518)", async () => {

--- a/cli/test/account.test.ts
+++ b/cli/test/account.test.ts
@@ -227,6 +227,7 @@ describe("resolveAuth precedence", () => {
     writeState({ channel: "dev", cursor: 0, config_path: missing, bindings: { dev: missing } });
     // 持久 agent config：与孤儿不同文件名，但 identity.channel_scope 唯一匹配 "dev"。
     // 注意其 server 与账号会话 server 不同——恢复必须用 agent 自己的 server。
+    const durablePath = join(home, "agents", "durable-alice.json");
     writeAgentConfigFile("durable-alice.json", {
       server: "https://agent.example.com",
       token: "agent-tok",
@@ -244,12 +245,48 @@ describe("resolveAuth precedence", () => {
     console.error = (...args: unknown[]) => errors.push(args.join(" "));
     try {
       const auth = await resolveAuthDetailed();
-      expect(auth).toMatchObject({ server: "https://agent.example.com", token: "agent-tok", auth_source: "runtime_config" });
+      // 恢复后 config 来源必须反映真实的持久文件（供 whoami/serve 决策），不是顶部探测的旧 source。
+      expect(auth).toMatchObject({
+        server: "https://agent.example.com",
+        token: "agent-tok",
+        auth_source: "runtime_config",
+        config: { kind: "explicit", path: durablePath },
+      });
     } finally {
       console.error = originalError;
     }
     expect(errors.join("\n")).toContain("alice");
     expect(errors.join("\n")).not.toContain("refusing human-account fallback");
+  });
+
+  test("strips terminal control chars from recovered identity before printing (#518)", async () => {
+    const missing = join(home, "agents", "orphan-bound.json");
+    writeState({ channel: "dev", cursor: 0, config_path: missing, bindings: { dev: missing } });
+    // 恶意/损坏 config：name 里塞 ANSI/OSC 控制序列，若原样打印会注入终端。
+    // 剥离只去 ESC/BEL 等控制字节（OSC 载荷降级为可见文本），可读部分 "alice" 保留在前。
+    writeAgentConfigFile("evil.json", {
+      server: "https://agent.example.com",
+      token: "agent-tok",
+      identity: { name: "alice\x1b[31m\x1b]0;pwn\x07", email: null, kind: "agent", role: "agent", owner: "o", channel_scope: "dev", verified_at: 1 },
+    });
+    writeAccount({
+      server: "https://issuer.example.com",
+      refresh_token: "ref",
+      access_token: "acc-live",
+      expires_at: nowSec() + 3600,
+      email: "human@example.com",
+    });
+    const errors: string[] = [];
+    const originalError = console.error;
+    console.error = (...args: unknown[]) => errors.push(args.join(" "));
+    try {
+      await resolveAuthDetailed();
+    } finally {
+      console.error = originalError;
+    }
+    const out = errors.join("\n");
+    expect(out).not.toContain("\x1b"); // 无 ESC → 无控制序列注入
+    expect(out).toContain("alice"); // 剥离控制字符后可读身份仍在
   });
 
   test("refuses (no wrong-identity pick) when multiple persistent configs match the channel (#518)", async () => {

--- a/cli/test/account.test.ts
+++ b/cli/test/account.test.ts
@@ -1,6 +1,6 @@
 // party login/logout/whoami/agent add + 账号会话 bearer 优先与自动刷新
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync, statSync } from "node:fs";
+import { mkdtempSync, rmSync, statSync, writeFileSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { accountPath, readAccount, writeAccount, clearAccount } from "../src/account";
@@ -212,6 +212,76 @@ describe("resolveAuth precedence", () => {
     }
     expect(errors.join("\n")).toContain("refusing human-account fallback");
     expect(errors.join("\n")).toContain(missing);
+  });
+
+  // #518 恢复：绑定的 agent config 丢了（常见于放 $TMPDIR 被系统清），但持久
+  // ~/.agentparty/agents/ 里有一个 channel 唯一匹配的 agent config → 自动恢复它
+  // （用它自己的 server+token），不再硬拒。绝不静默回退人类账号（#42 仍守住）。
+  function writeAgentConfigFile(name: string, cfg: Record<string, unknown>) {
+    mkdirSync(join(home, "agents"), { recursive: true });
+    writeFileSync(join(home, "agents", name), JSON.stringify(cfg));
+  }
+
+  test("recovers a channel-unique persistent agent config instead of refusing (#518)", async () => {
+    const missing = join(home, "agents", "orphan-bound.json");
+    writeState({ channel: "dev", cursor: 0, config_path: missing, bindings: { dev: missing } });
+    // 持久 agent config：与孤儿不同文件名，但 identity.channel_scope 唯一匹配 "dev"。
+    // 注意其 server 与账号会话 server 不同——恢复必须用 agent 自己的 server。
+    writeAgentConfigFile("durable-alice.json", {
+      server: "https://agent.example.com",
+      token: "agent-tok",
+      identity: { name: "alice", email: null, kind: "agent", role: "agent", owner: "o", channel_scope: "dev", verified_at: 1 },
+    });
+    writeAccount({
+      server: "https://issuer.example.com",
+      refresh_token: "ref",
+      access_token: "acc-live",
+      expires_at: nowSec() + 3600,
+      email: "human@example.com",
+    });
+    const errors: string[] = [];
+    const originalError = console.error;
+    console.error = (...args: unknown[]) => errors.push(args.join(" "));
+    try {
+      const auth = await resolveAuthDetailed();
+      expect(auth).toMatchObject({ server: "https://agent.example.com", token: "agent-tok", auth_source: "runtime_config" });
+    } finally {
+      console.error = originalError;
+    }
+    expect(errors.join("\n")).toContain("alice");
+    expect(errors.join("\n")).not.toContain("refusing human-account fallback");
+  });
+
+  test("refuses (no wrong-identity pick) when multiple persistent configs match the channel (#518)", async () => {
+    const missing = join(home, "agents", "orphan-bound.json");
+    writeState({ channel: "dev", cursor: 0, config_path: missing, bindings: { dev: missing } });
+    writeAgentConfigFile("a.json", {
+      server: "https://a.example.com",
+      token: "tok-a",
+      identity: { name: "alice", email: null, kind: "agent", role: "agent", owner: "o", channel_scope: "dev", verified_at: 1 },
+    });
+    writeAgentConfigFile("b.json", {
+      server: "https://b.example.com",
+      token: "tok-b",
+      identity: { name: "bob", email: null, kind: "agent", role: "agent", owner: "o", channel_scope: "dev", verified_at: 1 },
+    });
+    writeAccount({
+      server: "https://issuer.example.com",
+      refresh_token: "ref",
+      access_token: "acc-live",
+      expires_at: nowSec() + 3600,
+      email: "human@example.com",
+    });
+    const errors: string[] = [];
+    const originalError = console.error;
+    console.error = (...args: unknown[]) => errors.push(args.join(" "));
+    try {
+      const auth = await resolveAuthDetailed();
+      expect(auth).toMatchObject({ token: null, auth_source: "none" });
+    } finally {
+      console.error = originalError;
+    }
+    expect(errors.join("\n")).toContain("refusing human-account fallback");
   });
 
   test("null when neither present", async () => {


### PR DESCRIPTION
## 改动说明
修复 **#518（在 v0.2.168 仍复现）**：当 workspace 绑定的 agent config 放在 `$TMPDIR`、被系统清理后丢失，`resolveAuthDetailed` 会硬拒（拒绝回退人类账号，#42 冒充护栏），导致 `party` **彻底不可用**——即便持久 `~/.agentparty/agents/<name>.json` 里还留着同一个 agent 的 config。（本次 dogfood 亲历：`/clear` 后干净 session 一开局，所有 `party` 命令因此失败。）

改法：孤儿指针检测到后、**硬拒之前**，扫 `~/.agentparty/agents/*.json`，按 `identity.channel_scope` 唯一匹配当前绑定频道 → 命中**恰好一个**就用【它自己的 `server`+`token`】恢复，并打印恢复的身份；`0` 或多个仍硬拒。

**安全（守住 #42 冒充护栏）**：
- 只恢复带 `token` 的 agent config，**永不**静默回退人类账号会话；
- **唯一匹配才恢复**，多个匹配（同频道多 agent）→ 硬拒、绝不猜错身份；
- 用 agent config **自己的 server**（未必等于账号会话 server，避免串服务器）；
- `WorkspaceState` 只存路径不存身份 → `channel_scope` 是唯一可靠匹配键（孤儿路径 basename 命名不统一、不可靠）。

> 残余取舍：若同频道恰好只有一个持久 config、但它是**另一个** agent（原绑定 agent 的 config 也一并丢了），会恢复成它——已用「唯一匹配 + 打印恢复身份」把这种极少见情形暴露给用户，且它仍是 **agent 而非人类账号**。更彻底的写侧预防（`init` 拒绝把 `$TMPDIR` 路径绑成 config）建议另开。

## 验证
- 新增 `cli/test/account.test.ts` 3 场景：**唯一匹配→恢复 agent 的 server+token（不再 refuse）**；**多个匹配→仍 refuse（不猜身份）**；无匹配→保持原 refuse（#518 现有测试不变）。
- 先复现：改前恢复用例返回 `token:null`（refuse）→ 改后绿。
- `cd cli && bunx tsc --noEmit`：**0 错**。
- `cd cli && bun test`：**1373 pass / 0 fail（99 文件）**。

## 合并前检查（review-ack 强制闸——不留结论合不了）
- [x] 我已读 pr-agent / CodeRabbit 的 review，真问题已处理、误报已判明
- [x] 本地门禁通过（tsc / 全量测试）
- [x] 涉及安全/鉴权/数据的改动已做对抗性验证（本 PR 触碰身份解析：新增测试显式覆盖「多匹配不猜身份」「永不回退人类账号」；#42 护栏保持）

Refs #518, #789


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 当关联的代理配置丢失时，会根据绑定频道从本地持久化配置中精确匹配并自动恢复。
  * 恢复成功后使用对应的服务器与访问令牌，并显示清理后的身份信息。
* **错误修复**
  * 无效、损坏或存在多个匹配项时将安全拒绝，避免回退到人类账号凭据。
  * 配置路径和告警信息会移除终端控制字符，提升输出安全性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->