### PR TITLE
fix(channel): 显示 Host 候选的所属用户

### DIFF
--- a/web/src/components/HostBoardPanel.test.tsx
+++ b/web/src/components/HostBoardPanel.test.tsx
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { act, create, type ReactTestRenderer } from "react-test-renderer";
 import type { HostBoard, RecommendedAction } from "@agentparty/shared";
 import { LocaleProvider } from "../i18n/locale";
-import { HostBoardPanel } from "./HostBoardPanel";
+import { buildHostCandidate, HostBoardPanel } from "./HostBoardPanel";
 
 let renderer: ReactTestRenderer | null = null;
 
@@ -39,6 +39,28 @@ const board = (recommendedActions: RecommendedAction[]): HostBoard => ({
 });
 
 describe("HostBoardPanel", () => {
+  test("labels a Host candidate with its human owner", () => {
+    expect(buildHostCandidate(
+      {
+        name: "codex-002",
+        display: "codex-002",
+        account: "lark:on_owner",
+      },
+      {
+        "human-session": {
+          display: "leo",
+          kind: "human",
+          account: "lark:on_owner",
+        },
+      },
+      true,
+    )).toEqual({
+      name: "codex-002",
+      label: "leo · codex-002",
+      online: true,
+    });
+  });
+
   test("turns a missing-host warning into a direct assignment flow", async () => {
     const assigned: string[] = [];
     act(() => {

--- a/web/src/components/HostBoardPanel.test.tsx
+++ b/web/src/components/HostBoardPanel.test.tsx
@@ -61,6 +61,21 @@ describe("HostBoardPanel", () => {
     });
   });
 
+  test("keeps an unresolved opaque owner out of the Host candidate label", () => {
+    const candidate = buildHostCandidate(
+      {
+        name: "codex-002",
+        display: "codex-002",
+        account: "lark:on_unknown",
+      },
+      {},
+      false,
+    );
+
+    expect(candidate.label).toBe("codex-002");
+    expect(candidate.label).not.toContain("lark:on_unknown");
+  });
+
   test("turns a missing-host warning into a direct assignment flow", async () => {
     const assigned: string[] = [];
     act(() => {

--- a/web/src/components/HostBoardPanel.tsx
+++ b/web/src/components/HostBoardPanel.tsx
@@ -1,12 +1,32 @@
 import { useEffect, useMemo, useState } from "react";
 import type { HostBoard, RecommendedAction } from "@agentparty/shared";
 import { useT } from "../i18n/useT";
+import {
+  resolveIdentityPresentation,
+  type IdentityDisplayMap,
+} from "../lib/identityDisplay";
 import "../i18n/strings/Channel";
 
 export interface HostCandidate {
   name: string;
   label: string;
   online: boolean;
+}
+
+export function buildHostCandidate(
+  member: { name: string; display: string; account?: string | null },
+  identities: IdentityDisplayMap,
+  online: boolean,
+): HostCandidate {
+  const presentation = resolveIdentityPresentation(member.name, identities, {
+    kind: "agent",
+    owner: member.account ?? null,
+    display: member.display,
+  });
+  const label = presentation.ownerLabel === null
+    ? presentation.label
+    : `${presentation.ownerLabel} · ${presentation.label}`;
+  return { name: member.name, label, online };
 }
 
 const EMPTY_HOST_CANDIDATES: readonly HostCandidate[] = [];

--- a/web/src/pages/Channel.tsx
+++ b/web/src/pages/Channel.tsx
@@ -18,7 +18,11 @@ import { MentionHeaderNotice, type MentionToastItem } from "../components/Mentio
 import { PresenceBar } from "../components/PresenceBar";
 import { ChannelFocusBar } from "../components/ChannelFocusBar";
 import { ChannelFocusPanel } from "../components/ChannelFocusPanel";
-import { HostBoardPanel, type HostCandidate } from "../components/HostBoardPanel";
+import {
+  buildHostCandidate,
+  HostBoardPanel,
+  type HostCandidate,
+} from "../components/HostBoardPanel";
 import { ChannelAdminView, type ChannelAdminMember } from "../components/ChannelAdminView";
 import { computeChannelFocus } from "../lib/channelFocus";
 import {
@@ -5199,14 +5203,12 @@ export function ChannelPage({
   const hostCandidates = useMemo<HostCandidate[]>(
     () => activeChannelAdminMembers
       .filter((member) => member.kind === "agent" && member.name !== "system")
-      .map((member) => ({
-        name: member.name,
-        label: member.display === member.name || member.display.includes(member.name)
-          ? member.display
-          : `${member.display} · ${member.name}`,
-        online: memberOnlineNames.has(member.name),
-      })),
-    [activeChannelAdminMembers, memberOnlineNames],
+      .map((member) => buildHostCandidate(
+        member,
+        identityDisplay,
+        memberOnlineNames.has(member.name),
+      )),
+    [activeChannelAdminMembers, identityDisplay, memberOnlineNames],
   );
   const teamIdentityStats = useMemo(() => {
     const byName = new Map<string, {


### PR DESCRIPTION
## 问题

生产 Chrome 验收发现 Host 候选只显示 Agent 名，例如 `codex-002`，无法判断归属用户。

## 修复

- 复用统一身份解析，将候选展示为 `人名 · Agent 名`
- 保留不可解析 owner 时不泄露 opaque account 的既有规则
- 增加可解析 owner 与未知 opaque owner 两条回归测试

## 验证

- HostBoardPanel: 5 tests passed
- Web: 1252 tests passed
- TypeScript and production build passed

## 合并前检查

- 已读当前 head `1c6b7f3` 的最新 bot review
- CodeRabbit 的有效意见已补回归测试并确认解决
- PR Agent 关于 `presentation.label` 可能为空的提示为误报：身份解析始终使用成员名兜底
- CI 全部通过后再合并
