### PR TITLE
fix(channel): 修复消息身份筛选与展示

### DIFF
--- a/web/src/lib/filters.test.ts
+++ b/web/src/lib/filters.test.ts
@@ -27,6 +27,15 @@ describe("agent filters", () => {
     });
   });
 
+  test("preserves account-backed human identities containing a colon", () => {
+    const identity = "lark:on_22608d74bd2d7f39f6dc67d0da248fa5";
+    const filter = toggleAgent({ mode: "only", agents: [], kind: null }, identity);
+
+    expect(filter.agents).toEqual([identity]);
+    expect(parseAgentFilter(`?${agentFilterSearch(filter)}`)).toEqual(filter);
+    expect(matchesAgentFilter({ name: identity, kind: "human" }, filter)).toBe(true);
+  });
+
   test("parses agentKind from url, ignoring unknown values", () => {
     expect(parseAgentFilter("?agentKind=human")).toEqual({ mode: "only", agents: [], kind: "human" });
     expect(parseAgentFilter("?agentKind=agent")).toEqual({ mode: "only", agents: [], kind: "agent" });

--- a/web/src/lib/filters.ts
+++ b/web/src/lib/filters.ts
@@ -17,7 +17,10 @@ export interface AgentFilter {
   kind: AgentFilterKind | null;
 }
 
-const NAME_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$/;
+// Sender identities are not limited to agent handles. Account-backed human
+// sessions use names such as `lark:on_xxx`; keep those routable identities in
+// deep links while still rejecting path/control characters and oversized input.
+const NAME_RE = /^[a-zA-Z0-9][a-zA-Z0-9._:@-]{0,127}$/;
 
 function cleanAgents(values: string[]): string[] {
   return [...new Set(values.map((v) => v.trim()).filter((v) => NAME_RE.test(v)))].sort((a, b) =>

--- a/web/src/pages/Channel.tsx
+++ b/web/src/pages/Channel.tsx
@@ -74,7 +74,12 @@ import {
 } from "../lib/api";
 import type { AuthProviderConfig } from "../lib/oidc";
 import { agentHue } from "../lib/agentColor";
-import { buildIdentityDisplay, type IdentityDisplayMap } from "../lib/identityDisplay";
+import {
+  buildIdentityDisplay,
+  formatIdentityPresentation,
+  resolveIdentityPresentation,
+  type IdentityDisplayMap,
+} from "../lib/identityDisplay";
 import { mentionCandidates, parseDraftMentions, type DraftMentionStatus } from "../lib/mentions";
 import { buildReceipts, type MentionReceipt } from "../lib/wakeReceipt";
 import { completionMessages } from "../lib/completions";
@@ -1345,6 +1350,7 @@ export function ChannelPanelModal({
 
 function AgentFilterPanel({
   senders,
+  identityDisplay,
   filter,
   visible,
   total,
@@ -1354,6 +1360,7 @@ function AgentFilterPanel({
   onClear,
 }: {
   senders: string[];
+  identityDisplay: IdentityDisplayMap;
   filter: AgentFilter;
   visible: number;
   total: number;
@@ -1416,6 +1423,11 @@ function AgentFilterPanel({
         <div className="agent-filter-chips">
           {senders.map((name) => {
             const selected = filter.agents.includes(name);
+            const presentation = resolveIdentityPresentation(name, identityDisplay);
+            const label = formatIdentityPresentation(
+              presentation,
+              (owner, agent) => `${owner} · ${agent}`,
+            );
             return (
               <button
                 key={name}
@@ -1427,7 +1439,7 @@ function AgentFilterPanel({
                 onClick={() => onToggle(name)}
               >
                 <span className="agent-filter-dot" aria-hidden="true" />
-                <span>{name}</span>
+                <span>{label}</span>
               </button>
             );
           })}
@@ -1517,20 +1529,33 @@ function CatchupPanel({
 
 function SearchHitCard({
   hit,
+  identityDisplay,
   onJump,
   disabled,
 }: {
   hit: SearchHit;
+  identityDisplay: IdentityDisplayMap;
   onJump: (seq: number) => void | Promise<void>;
   disabled: boolean;
 }) {
   const t = useT();
   const hueStyle = { "--ah": agentHue(hit.sender.name) } as CSSProperties;
+  const senderPresentation = resolveIdentityPresentation(hit.sender.name, identityDisplay, {
+    kind: hit.sender.kind,
+    owner: hit.sender.owner,
+    display: hit.sender.kind === "human"
+      ? hit.sender.display_name || hit.sender.handle || hit.sender.owner
+      : hit.sender.handle,
+  });
+  const senderLabel = formatIdentityPresentation(
+    senderPresentation,
+    (owner, agent) => `${owner} · ${agent}`,
+  );
   return (
     <article className="d-card msg-card search-hit-card" style={hueStyle}>
       <header className="d-meta msg-head">
         <span className="msg-avatar" aria-hidden="true" />
-        <span className="msg-sender">{hit.sender.name}</span>
+        <span className="msg-sender">{senderLabel}</span>
         <span className={"msg-kind" + (hit.sender.kind === "human" ? " msg-kind--human" : "")}>
           {hit.sender.kind}
         </span>
@@ -1560,6 +1585,7 @@ export interface ChannelSearchPanelProps {
   searchLimit: string;
   senderListId: string;
   knownSenders: string[];
+  identityDisplay: IdentityDisplayMap;
   searchLoading: boolean;
   searchHits: SearchHit[];
   visibleSearchHits: SearchHit[];
@@ -1583,6 +1609,7 @@ export function ChannelSearchPanel({
   searchLimit,
   senderListId,
   knownSenders,
+  identityDisplay,
   searchLoading,
   searchHits,
   visibleSearchHits,
@@ -1657,9 +1684,14 @@ export function ChannelSearchPanel({
             aria-label={t("Channel.search.fromAria")}
           />
           <datalist id={senderListId}>
-            {knownSenders.map((name) => (
-              <option key={name} value={name} />
-            ))}
+            {knownSenders.map((name) => {
+              const presentation = resolveIdentityPresentation(name, identityDisplay);
+              const label = formatIdentityPresentation(
+                presentation,
+                (owner, agent) => `${owner} · ${agent}`,
+              );
+              return <option key={name} value={name} label={label} />;
+            })}
           </datalist>
           <input
             className="t-mono chan-filter-input"
@@ -1700,7 +1732,13 @@ export function ChannelSearchPanel({
         </p>
       )}
       {query !== "" && !isSeqQuery && visibleSearchHits.map((hit) => (
-        <SearchHitCard key={hit.seq} hit={hit} onJump={selectHit} disabled={jumpingSeq !== null} />
+        <SearchHitCard
+          key={hit.seq}
+          hit={hit}
+          identityDisplay={identityDisplay}
+          onJump={selectHit}
+          disabled={jumpingSeq !== null}
+        />
       ))}
       {query !== "" && !isSeqQuery && !searchLoading && searchHits.length === 0 && searchInputError === null && searchError === null && (
         <p className="d-empty" role="status" aria-live="polite">
@@ -5571,6 +5609,7 @@ export function ChannelPage({
         searchLimit={searchLimit}
         senderListId={senderListId}
         knownSenders={knownSenders}
+        identityDisplay={identityDisplay}
         searchLoading={searchLoading}
         searchHits={searchHits}
         visibleSearchHits={visibleSearchHits}
@@ -5607,6 +5646,7 @@ export function ChannelPage({
       {knownSenders.length > 0 && (
         <AgentFilterPanel
           senders={knownSenders}
+          identityDisplay={identityDisplay}
           filter={agentFilter}
           visible={visibleInView}
           total={totalInView}

--- a/web/src/pages/ChannelSearchPanel.test.tsx
+++ b/web/src/pages/ChannelSearchPanel.test.tsx
@@ -5,6 +5,7 @@ import type { SearchHit } from "@agentparty/shared";
 import { LocaleProvider } from "../i18n/locale";
 import { ChannelStrings } from "../i18n/strings/Channel";
 import { ChannelPanelModal, ChannelSearchPanel, type ChannelSearchPanelProps } from "./Channel";
+import type { IdentityDisplayMap } from "../lib/identityDisplay";
 
 function memoryStorage(): Storage {
   const values = new Map<string, string>();
@@ -32,6 +33,10 @@ const hit: SearchHit = {
 
 const noop = () => {};
 const acceptJump = () => true;
+const identityDisplay: IdentityDisplayMap = {
+  alice: { display: "deployment", kind: "agent", account: "acct-luis" },
+  luis: { display: "Luis", kind: "human", account: "acct-luis" },
+};
 let renderer: ReactTestRenderer | null = null;
 let fakeWindow: EventTarget | null = null;
 
@@ -44,6 +49,7 @@ function baseProps(overrides: Partial<ChannelSearchPanelProps> = {}): ChannelSea
     searchLimit: "100",
     senderListId: "senders-ops",
     knownSenders: ["alice"],
+    identityDisplay,
     searchLoading: false,
     searchHits: [hit],
     visibleSearchHits: [hit],
@@ -128,8 +134,18 @@ describe("Channel search modal (#351)", () => {
     const jump = dialog.findByProps({ title: ChannelStrings.en["Channel.search.jumpTitle"] });
 
     expect(dialog.findByProps({ className: "search-hit-snippet" }).props.children).toBe("deploy completed");
+    expect(dialog.findByProps({ className: "msg-sender" }).props.children).toBe("Luis · deployment");
     await act(async () => { await jump.props.onClick(); });
     expect(events).toEqual(["jump:42", "close"]);
+  });
+
+  test("keeps technical sender values routable while presenting readable owner and agent labels", () => {
+    const root = render(baseProps());
+    const dialog = root.findByProps({ role: "dialog" });
+    const option = dialog.findByType("option");
+
+    expect(option.props.value).toBe("alice");
+    expect(option.props.label).toBe("Luis · deployment");
   });
 
   test("keeps the search dialog open and shows the jump error when navigation fails", async () => {


### PR DESCRIPTION
## 改动说明
- 允许 `lark:on_*` 等账号型身份进入消息筛选，修复筛选芯片点击无效
- 筛选芯片统一显示为可读的「所属用户 · Agent」
- 搜索发送者候选与结果卡片复用同一身份展示逻辑，内部路由名仍保持精确

## 验证
- `bun test web/src/lib/filters.test.ts web/src/pages/ChannelSearchPanel.test.tsx`
- `cd web && bunx tsc --noEmit`
- `bun run check:web`（1255 tests + production build）
- 对抗性覆盖：接受 URL 编码后的 `lark:on_*` 身份往返，继续拒绝 `bad/name` 等路径字符

## 合并前检查（review-ack 强制闸——不留结论合不了）
- [x] 我已读 pr-agent / CodeRabbit 的 review，真问题已处理、误报已判明
- [x] 本地门禁通过（tsc / 测试 / build）
- [x] 涉及安全/鉴权/数据的改动已做对抗性验证（变异测试或等价手段）