### PR TITLE
fix(serve): 启动前校验 runner 并修正配置诊断

### DIFF
--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -36,7 +36,7 @@ import { basename, dirname, isAbsolute, join, relative, sep } from "node:path";
 import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
 import { readAccount } from "../account";
 import { connect } from "../client";
-import { clearStuck, clearStuckForConfig, loadCursor, loadCursorForConfig, loadRevCursor, loadRevCursorForConfig, loadStuck, loadStuckForConfig, resolveChannel, saveCursor, saveCursorForConfig, saveRevCursor, saveRevCursorForConfig, saveStuck, saveStuckForConfig, type StuckWake } from "../config";
+import { clearStuck, clearStuckForConfig, loadCursor, loadCursorForConfig, loadRevCursor, loadRevCursorForConfig, loadStuck, loadStuckForConfig, localAgentConfigsForChannel, readConfigWithSource, resolveChannel, saveCursor, saveCursorForConfig, saveRevCursor, saveRevCursorForConfig, saveStuck, saveStuckForConfig, type StuckWake } from "../config";
 import { acquireInstanceLock, defaultInstanceLockDir, instanceLockTarget, stopOwnInstance } from "../instance-lock";
 import { formatMsg, stripTerminalControls } from "../format";
 import { clearHealthCache, writeHealthCache } from "../health-cache";
@@ -264,6 +264,10 @@ export const EXIT_WAKE_ABANDON_CIRCUIT = 11;
 
 /** 已有 serve 挂在同一 (server identity, channel, machine) 上：拒绝启动，避免重复执行（#99/#465）。 */
 export const EXIT_ALREADY_SERVING = 10;
+/** The selected server/identity does not contain the requested channel. Retrying cannot heal it. */
+export const EXIT_CHANNEL_NOT_FOUND = 12;
+/** A local builtin runner failed its startup authentication/executable preflight. */
+export const EXIT_RUNNER_UNAVAILABLE = 13;
 
 /** Conventional shell exit codes for an explicitly interrupted resident serve. */
 export const EXIT_SIGNAL_INT = 128 + 2;
@@ -636,7 +640,7 @@ interface TerminalDutyDeps {
 }
 
 /**
- * #744:launchd 常驻下,「终局不该重启」的退出(熔断 EXIT_WAKE_ABANDON_CIRCUIT / 撤销 EXIT_AUTH)必须
+ * #744/#802:launchd 常驻下,「终局不该重启」的退出(熔断 / 撤销 / 确定性配置错误)必须
  * 让 launchd 别 KeepAlive 重启——否则熔断的安全停机被绕过、或对着被撤 token 空转,且 launchd 还以为在线。
  * serve 自己 `launchctl bootout` 掉自己那个 job:launchd 移除它 → 不再重启,launchctl print/health/presence
  * 一致显示停机,人工重新「转为常驻」才复活。普通崩溃 / stream-ended **不** bootout,照常由 KeepAlive 自愈。
@@ -654,7 +658,12 @@ export function selfBootoutTerminalDuty(
   if (label === undefined || label === "") return false;
   const platform = deps?.platform ?? process.platform;
   if (platform !== "darwin") return false;
-  if (code !== EXIT_WAKE_ABANDON_CIRCUIT && code !== EXIT_AUTH) return false;
+  if (
+    code !== EXIT_WAKE_ABANDON_CIRCUIT
+    && code !== EXIT_AUTH
+    && code !== EXIT_CHANNEL_NOT_FOUND
+    && code !== EXIT_RUNNER_UNAVAILABLE
+  ) return false;
   // 严格校验注入的 label(@macmini #744 评审):只接受我们自己生成的 duty label(前缀 + launchd 合法字符),
   // 否则拒绝——绝不拿一个猜的/被篡改的 label 去 bootout,免得卸载错的甚至宽泛目标。
   if (!label.startsWith(DUTY_LABEL_PREFIX) || !/^[A-Za-z0-9.-]+$/.test(label)) {
@@ -678,7 +687,13 @@ export function selfBootoutTerminalDuty(
   }
   try {
   const target = `gui/${uid}/${label}`;
-  const reason = code === EXIT_WAKE_ABANDON_CIRCUIT ? "circuit-breaker" : "auth-revoked";
+  const reason = code === EXIT_WAKE_ABANDON_CIRCUIT
+    ? "circuit-breaker"
+    : code === EXIT_AUTH
+      ? "auth-revoked"
+      : code === EXIT_CHANNEL_NOT_FOUND
+        ? "channel-not-found"
+        : "runner-unavailable";
   const plistPath = deps?.plistPath ?? dutyPlistPath(label);
   const ownGeneration = deps?.generation === undefined
     ? process.env.AP_DUTY_GENERATION ?? null
@@ -905,6 +920,10 @@ function sanitizeBlockedError(error: string): string {
   return (compact || "unknown error").slice(0, BLOCKED_ERROR_MAX);
 }
 
+function isChannelNotFoundError(error: unknown): error is RestError {
+  return error instanceof RestError && (error.status === 404 || error.code === "not_found");
+}
+
 // context file 里附带的最近频道消息条数上限（冷起的 runner 不用先跑 history 也有基本上下文）
 const RECENT_MAX = 20;
 const RECENT_BODY_MAX = 400;
@@ -918,6 +937,7 @@ const RUNNER_LOG_FILE = "serve-runner.log";
 const SERVE_LIFECYCLE_LOG_FILE = "serve-lifecycle.log";
 const DEFAULT_SUPERVISOR_RESTART_DELAY_MS = 1_000;
 const MAX_SUPERVISOR_RESTART_DELAY_MS = 30_000;
+const RUNNER_STARTUP_CHECK_TIMEOUT_MS = 15_000;
 const RUNNER_TERMINATION_GRACE_MS = 1_000;
 const RUNNER_TERMINATION_BARRIER_MS = RUNNER_TERMINATION_GRACE_MS + 500;
 const DELIVERY_UPDATE_ACK_TIMEOUT_MS = 5_000;
@@ -1565,6 +1585,8 @@ export interface ServeOptions {
   downloadAttachment?: typeof downloadAttachment;
   // 测试注入点：默认用 sh -c 起子进程
   runCommand?: ServeRunner;
+  /** Local runner readiness gate. It must pass before opening the channel socket or claiming a lease. */
+  startupCheck?: (signal: AbortSignal) => Promise<void>;
   sdkRunner?: SdkRunnerOptions;
   // serve 挂上后声明自己「可被唤醒」的钩子；run() 注入真实实现，测试可省略/替换
   advertise?: (signal?: AbortSignal) => Promise<void>;
@@ -2214,6 +2236,27 @@ export function isRunnerEnvFailure(result: Pick<RunnerProcessResult, "stderr">):
   return RUNNER_ENV_FAILURE_PATTERNS.some((re) => re.test(result.stderr));
 }
 
+export function runnerDiagnosticExcerpt(
+  result: Pick<RunnerProcessResult, "stdout" | "stderr">,
+  harness: RunnerHarness,
+): string {
+  if (harness === "claude") {
+    try {
+      const body = JSON.parse(result.stdout) as Record<string, unknown>;
+      if (body.loggedIn === false) {
+        return "Claude authentication unavailable (loggedIn=false); run `claude login`";
+      }
+      if (body.is_error === true && typeof body.result === "string") {
+        return sanitizeBlockedError(body.result);
+      }
+    } catch {
+      // Fall through to the raw process evidence.
+    }
+  }
+  const raw = result.stderr.trim() || result.stdout.trim();
+  return raw === "" ? "runner exited without diagnostic output" : sanitizeBlockedError(raw);
+}
+
 // #748：claude `-p --output-format json` 命中环境性 auth/api 失败时，结构化错误落在 **stdout 的 JSON**
 // （`is_error:true, terminal_reason:"api_error", result:"...OAuth session expired..."`）而非 stderr，exit 1。
 // isRunnerEnvFailure 只扫 stderr（#693 为躲模型输出误报），会把这类漏判成通用「exit-1 / model may have run」：
@@ -2626,6 +2669,75 @@ async function runHarness(
   if (sid && opts.outputSchema === undefined) return { result, text: result.stdout.trimEnd(), sessionId: sid };
   const parsed = parseClaudeJson(result.stdout);
   return { result, text: parsed.text.trimEnd(), sessionId: sid ?? coldSessionId };
+}
+
+/**
+ * Verify the local harness before a serve socket is opened.
+ *
+ * These commands inspect local authentication only; they do not start a model turn.
+ * The successful result is cached for this process so a transient socket reconnect
+ * does not repeatedly spawn the same check.
+ */
+export function createBuiltinRunnerStartupCheck(
+  opts: BuiltinRunnerOptions,
+): NonNullable<ServeOptions["startupCheck"]> {
+  let ready = false;
+  return async (signal: AbortSignal): Promise<void> => {
+    if (ready) return;
+    mkdirSync(opts.workdir, { recursive: true, mode: 0o700 });
+    const cwd = opts.cwd ?? opts.workdir;
+    let env: Record<string, string | undefined> = opts.harness === "codex"
+      ? prepareCodexHome(opts.workdir, opts.authSourceFile, opts.codexLaunch?.env)
+      : { ...process.env };
+    let args: string[];
+    if (opts.harness === "codex") {
+      const launch = opts.codexLaunch ?? resolveBuiltinCodexLaunch(opts.codexBinary, env, process.cwd());
+      if (!launch.ok) {
+        throw new WakeBlockedError(
+          `builtin codex startup preflight failed: ${launch.error}`,
+          false,
+          { environment: true },
+        );
+      }
+      if (opts.codexLaunch === undefined) env = launch.env;
+      args = [launch.codexBinary, ...launch.codexArgsPrefix, "login", "status"];
+    } else {
+      args = [builtinRunnerCommand("claude", env), "auth", "status", "--json"];
+    }
+    const runProcess = opts.runProcess ?? defaultRunnerProcess;
+    let result: RunnerProcessResult;
+    try {
+      result = await runProcess(args, { cwd, env, signal });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      appendRunnerLog(
+        opts.workdir,
+        `${new Date((opts.now ?? Date.now)()).toISOString()} startup_preflight=true harness=${opts.harness} spawn_failed=true diagnostic=${JSON.stringify(sanitizeBlockedError(message))}`,
+      );
+      throw new WakeBlockedError(
+        `builtin ${opts.harness} startup preflight failed: ${message}`,
+        false,
+        { environment: true },
+      );
+    }
+    if (result.code !== 0) {
+      const diagnostic = runnerDiagnosticExcerpt(result, opts.harness);
+      appendRunnerLog(
+        opts.workdir,
+        `${new Date((opts.now ?? Date.now)()).toISOString()} startup_preflight=true harness=${opts.harness} exit=${result.code} env_failure=true diagnostic=${JSON.stringify(diagnostic)}`,
+      );
+      throw new WakeBlockedError(
+        `builtin ${opts.harness} startup preflight failed: ${diagnostic}`,
+        false,
+        { environment: true },
+      );
+    }
+    ready = true;
+    appendRunnerLog(
+      opts.workdir,
+      `${new Date((opts.now ?? Date.now)()).toISOString()} startup_preflight=true harness=${opts.harness} exit=0 ready=true`,
+    );
+  };
 }
 
 export function createSdkRunner(opts: SdkRunnerOptions): NonNullable<ServeOptions["runCommand"]> {
@@ -3244,12 +3356,15 @@ export function createBuiltinRunner(opts: BuiltinRunnerOptions): NonNullable<Ser
           const envFailure =
             isRunnerEnvFailure(run.result) ||
             (opts.harness === "claude" && claudeJsonEnvFailure(run.result.stdout));
+          const diagnostic = runnerDiagnosticExcerpt(run.result, opts.harness);
           appendRunnerLog(
             opts.workdir,
-            `${new Date(now).toISOString()} seq=${frame.seq} sid=${shortSid(oldSid)} duration_ms=${now - started} exit=${run.result.code}${envFailure ? " env_failure=true" : ""}`,
+            `${new Date(now).toISOString()} seq=${frame.seq} sid=${shortSid(oldSid)} duration_ms=${now - started} exit=${run.result.code}${envFailure ? " env_failure=true" : ""} diagnostic=${JSON.stringify(diagnostic)}`,
           );
           throw new WakeBlockedError(
-            `builtin ${opts.harness} runner blocked: exit code ${run.result.code}${envFailure ? " (runner environment failure: credentials/binary/sandbox — model did not run)" : ""}; log: ${join(opts.workdir, RUNNER_LOG_FILE)}`,
+            `builtin ${opts.harness} runner blocked: exit code ${run.result.code}` +
+              `${envFailure ? ` (runner environment failure: ${diagnostic} — model did not run)` : ` (${diagnostic})`}; ` +
+              `log: ${join(opts.workdir, RUNNER_LOG_FILE)}`,
             false,
             { environment: envFailure },
           );
@@ -4784,6 +4899,16 @@ export async function runServe(o: ServeOptions): Promise<number> {
     );
     return EXIT_ALREADY_SERVING;
   }
+  if (o.startupCheck !== undefined) {
+    try {
+      await o.startupCheck(AbortSignal.timeout(RUNNER_STARTUP_CHECK_TIMEOUT_MS));
+    } catch (error) {
+      const message = sanitizeBlockedError(error instanceof Error ? error.message : String(error));
+      out(`serve: runner 启动预检失败，不连接频道、不领取租约：${message}`);
+      lock?.release?.();
+      return EXIT_RUNNER_UNAVAILABLE;
+    }
+  }
   let conn: ReturnType<typeof connect>;
   try {
     conn = connect(o.server, o.token, o.channel, o.since, {
@@ -4937,17 +5062,20 @@ export async function runServe(o: ServeOptions): Promise<number> {
   // 把已消费但未 ack 的帧按 seq 重排到队首，避免持租者中途退出时静默吞掉在飞 wake（#465）。
   let deferredLeaseSeq: number | null = null;
   let charter: ChannelCharter | null = o.charter ?? null;
-  const refreshCharter = async (reason: string, expectedRev?: number) => {
-    if (!o.fetchCharter) return;
-    if (expectedRev !== undefined && charter !== null && charter.charter_rev >= expectedRev) return;
+  const refreshCharter = async (reason: string, expectedRev?: number): Promise<unknown | null> => {
+    if (!o.fetchCharter) return null;
+    if (expectedRev !== undefined && charter !== null && charter.charter_rev >= expectedRev) return null;
     try {
       charter = await awaitWithAbort(
         o.fetchCharter(lifecycleController.signal),
         lifecycleController.signal,
       );
+      return null;
     } catch (e) {
       if (lifecycleController.signal.aborted) throw lifecycleController.signal.reason;
+      if (reason === "attach" && isChannelNotFoundError(e)) return e;
       out(`  charter 刷新失败（${reason}）: ${e instanceof Error ? e.message : String(e)}`);
+      return e;
     }
   };
   // 触发消息之前的最近频道消息（滚动窗口），随 context file 递给 runner
@@ -4958,14 +5086,10 @@ export async function runServe(o: ServeOptions): Promise<number> {
   try {
     // Initial control-plane work belongs to the same lifecycle as the frame loop. If SIGTERM lands
     // here, the shared finally below must still release the socket, lock, listeners and context dir.
-    await refreshCharter("attach");
-    out(
-      `serving #${o.channel} — 每条${o.mentionsOnly ? " @你 的" : ""}消息触发一次命令（Ctrl-C 停）`,
-    );
-    // #720：没开 --auto-upgrade 的常驻会卡在旧版——权限墙拦 `curl … | sh`、重启又自毁本轮会话。
-    // 提醒一次:加 --auto-upgrade(唤醒间隙自行下载+校验+re-exec,无需人工),或用桌面版 launchd 常驻(默认带)。
-    if (o.autoUpgrade !== true) {
-      out("serve: 未开 --auto-upgrade——本进程不会自升级，落后版本需人工重启。加 --auto-upgrade 让它在唤醒间隙自行换新，或用桌面版「转为常驻」(launchd，默认带)。");
+    const attachCharterError = await refreshCharter("attach");
+    if (isChannelNotFoundError(attachCharterError)) {
+      out(`error: not_found ${attachCharterError.message}`);
+      return EXIT_CHANNEL_NOT_FOUND;
     }
     if (o.statusline === true) {
       heartbeat = setInterval(() => {
@@ -4999,6 +5123,14 @@ export async function runServe(o: ServeOptions): Promise<number> {
         if (!welcomeReported) {
           o.onWelcome?.(frame.last_seq);
           welcomeReported = true;
+          out(
+            `serving #${o.channel} — 每条${o.mentionsOnly ? " @你 的" : ""}消息触发一次命令（Ctrl-C 停）`,
+          );
+          // #720：没开 --auto-upgrade 的常驻会卡在旧版。只有服务端 welcome 已确认频道存在后
+          // 才显示这条与 serving；失败连接不能先宣布“正在服务”再报错。
+          if (o.autoUpgrade !== true) {
+            out("serve: 未开 --auto-upgrade——本进程不会自升级，落后版本需人工重启。加 --auto-upgrade 让它在唤醒间隙自行换新，或用桌面版「转为常驻」(launchd，默认带)。");
+          }
         }
         directedDeliveryMode = frame.directed_delivery === "v1";
         o.onServerCapabilities?.({ ownerDecisionBinding: frame.owner_decision_binding === "v1" });
@@ -5088,7 +5220,9 @@ export async function runServe(o: ServeOptions): Promise<number> {
             ? EXIT_AUTH
             : frame.code === "archived"
               ? EXIT_ARCHIVED
-              : 1;
+              : frame.code === "not_found"
+                ? EXIT_CHANNEL_NOT_FOUND
+                : 1;
         break;
       }
       if (
@@ -5226,6 +5360,7 @@ export async function runServe(o: ServeOptions): Promise<number> {
         // custom/builtin runner 一旦可能已经执行过模型就不会重试；最终通告必须报告真实执行次数，
         // 不能把配置预算 maxAttempts 伪装成实际已跑次数（例如一次 SIGTERM 不能写成 3/3）。
         let attemptsUsed = attemptFloor;
+        let lastFailureEnvironment = false;
         // 身后已缓冲的 wake 深度（#103）：内建 runner 随 working 帧上报，presence 显示「忙 + N 待处理」。
         // 本帧正在处理，故只数它 seq 之后、够格触发唤醒的缓冲帧。
         const queueDepth = pendingWakeDepth(
@@ -5310,8 +5445,13 @@ export async function runServe(o: ServeOptions): Promise<number> {
             attemptFloor = attemptsUsed;
             lastError = errText(error);
             retriable = error instanceof WakeBlockedError && error.retriable;
+            lastFailureEnvironment = error instanceof WakeBlockedError && error.environment;
             if (error instanceof ManagedWorkerUndispatchedError) preflightSilentSkip = true;
-            out(`  runner 预处理失败 (${attemptsUsed}/${maxAttempts})，未发送 running、未启动模型: ${lastError}`);
+            out(
+              lastFailureEnvironment
+                ? `  runner 预处理失败（不重试：环境类错误），未发送 running、未启动模型: ${lastError}`
+                : `  runner 预处理失败 (${attemptsUsed}/${maxAttempts})，未发送 running、未启动模型: ${lastError}`,
+            );
             if (directedDelivery === null) {
               setStuck({ seq: frame.seq, attempts: attemptsUsed, last_error: lastError, retriable });
             }
@@ -5326,7 +5466,10 @@ export async function runServe(o: ServeOptions): Promise<number> {
         if (preflightFailed) {
           const note =
             `wake undelivered before model start, giving up: seq=${frame.seq}; ` +
-            `attempts=${attemptsUsed}/${maxAttempts}; retry_delay_ms=${retryDelayMs}; last error: ${lastError}`;
+            (lastFailureEnvironment
+              ? `attempts=${attemptsUsed}; retry=disabled_environment; `
+              : `attempts=${attemptsUsed}/${maxAttempts}; retry_delay_ms=${retryDelayMs}; `) +
+            `last error: ${lastError}`;
           // 非派工的 managed worker wake 不刷频道 blocked（worker 不是频道参与者，闲聊回复不该刷噪声）；
           // 投递仍在下方 settle，绝不重投。其它预处理失败照常公开宣告放弃。
           if (preflightSilentSkip) {
@@ -5482,12 +5625,17 @@ export async function runServe(o: ServeOptions): Promise<number> {
               // #690：环境性失败（认证/二进制/沙箱）模型确定没跑——别再挂「model may have run」的免责标签，
               // 那会误导 owner 以为副作用可能已发生。说清是环境坏了、修好再 @ 即可（保守：仅明确指纹命中）。
               const envFailure = e instanceof WakeBlockedError && e.environment;
+              lastFailureEnvironment = envFailure;
               if (!retriable) {
                 lastError += envFailure
                   ? " (runner environment failure: model did not run — fix credentials/binary/sandbox, e.g. `claude login`, then re-mention)"
                   : " (not retriable: model may have run)";
               }
-              out(`  命令失败 (${attempt}/${maxAttempts}): ${lastError}`);
+              out(
+                envFailure
+                  ? `  命令失败（不重试：环境类错误）: ${lastError}`
+                  : `  命令失败 (${attempt}/${maxAttempts}): ${lastError}`,
+              );
               // 先落盘再重试：此刻进程崩掉，重启后不会把已经烧掉的次数忘干净
               // Directed work has its own server-side lease/state machine. Mirroring it into the
               // legacy seq debt would make a later ordinary backfill bypass delivery ownership and
@@ -5616,7 +5764,9 @@ export async function runServe(o: ServeOptions): Promise<number> {
           // 没有 CLI flag，所以重试预算与退避必须**在频道里可见**：把常数藏进源码是不诚实的。
           const note =
             `wake undelivered, giving up: seq=${frame.seq}; ` +
-            `attempts=${attemptsUsed}/${maxAttempts}; retry_delay_ms=${retryDelayMs}; ` +
+            (lastFailureEnvironment
+              ? `attempts=${attemptsUsed}; retry=disabled_environment; `
+              : `attempts=${attemptsUsed}/${maxAttempts}; retry_delay_ms=${retryDelayMs}; `) +
             `last error: ${lastError}`;
           out(`  ${note}`);
           try {
@@ -5791,6 +5941,7 @@ export interface ServeSupervisorOptions {
 export function isTerminalServeExit(code: number): boolean {
   return code === 0 || code === EXIT_AUTH || code === EXIT_ARCHIVED || code === EXIT_UPGRADED ||
     code === EXIT_ALREADY_SERVING || code === EXIT_WAKE_ABANDON_CIRCUIT ||
+    code === EXIT_CHANNEL_NOT_FOUND || code === EXIT_RUNNER_UNAVAILABLE ||
     code === EXIT_SIGNAL_INT || code === EXIT_SIGNAL_TERM;
 }
 
@@ -5898,6 +6049,7 @@ export interface ServeCommandDeps {
   verifyServeIdentityBoundary?: typeof verifyServeIdentityBoundary;
   runServe?: typeof runServe;
   superviseServe?: typeof superviseServe;
+  createBuiltinRunnerStartupCheck?: typeof createBuiltinRunnerStartupCheck;
 }
 
 export type ServeIdentityBoundaryResult =
@@ -5991,6 +6143,56 @@ export async function verifyServeIdentityBoundary(
       deliveryPrincipal,
     ]),
   };
+}
+
+function homeRelativePath(path: string): string {
+  const home = homedir();
+  return path === home ? "~" : path.startsWith(`${home}${sep}`) ? `~${path.slice(home.length)}` : path;
+}
+
+export function formatServeProfileHints(input: {
+  channel: string;
+  currentName: string;
+  currentScope: string | null;
+  currentServer: string;
+  runner: RunnerHarness;
+  replayBacklog: boolean;
+  autoUpgrade: boolean;
+  candidates: ReturnType<typeof localAgentConfigsForChannel>;
+}): string[] {
+  if (input.candidates.length === 0) return [];
+  const lines = [
+    `  当前身份 ${input.currentName} (scope=${input.currentScope ?? "未限定"}, server=${input.currentServer})`,
+    `  本机有 ${input.candidates.length} 个 scope=${input.channel} 的候选 Agent 配置：`,
+  ];
+  for (const candidate of input.candidates.slice(0, 8)) {
+    lines.push(
+      `    ${candidate.name} (server=${candidate.server}, config=${homeRelativePath(candidate.path)})`,
+    );
+  }
+  if (input.candidates.length > 8) {
+    lines.push(`    …另有 ${input.candidates.length - 8} 个`);
+  }
+  const first = input.candidates[0]!;
+  const baseArgs = [
+    "party",
+    "serve",
+    input.channel,
+    "--runner",
+    input.runner,
+    ...(input.replayBacklog ? ["--replay-backlog"] : []),
+    ...(input.autoUpgrade ? ["--auto-upgrade"] : []),
+  ];
+  lines.push(
+    `  试试：AGENTPARTY_CONFIG=${shellQuote(first.path)} ${baseArgs.map(shellQuote).join(" ")}`,
+  );
+  if (first.owner !== null) {
+    lines.push(
+      `  若它是 project-agent profile：AGENTPARTY_CONFIG=${shellQuote(first.path)} ` +
+        `${["party", "serve", "--profile", `${first.owner}/${first.name}`].map(shellQuote).join(" ")}`,
+    );
+  }
+  return lines;
 }
 
 export async function run(argv: string[], deps: ServeCommandDeps = {}): Promise<number> {
@@ -6162,6 +6364,7 @@ export async function run(argv: string[], deps: ServeCommandDeps = {}): Promise<
     if (runnerWorkdirPath !== null) appendServeLifecycleLog(runnerWorkdirPath, record);
     console.error(terminalOutput(`serve supervisor: ${record}`));
   };
+  let runnerStartupCheck: NonNullable<ServeOptions["startupCheck"]> | undefined;
   const superviseExit = await superviseForCommand({
     onLifecycle: lifecycle,
     onState: (state) => {
@@ -6195,6 +6398,22 @@ export async function run(argv: string[], deps: ServeCommandDeps = {}): Promise<
       }
       const currentRunnerWorkdir = runnerWorkdirPath ?? defaultRunnerWorkdir(channel, boundary.namespace);
       runnerWorkdirPath = currentRunnerWorkdir;
+      const builtinRunnerOptions: BuiltinRunnerOptions | undefined = harness
+        ? {
+            server: currentServer,
+            token: currentToken,
+            channel,
+            harness,
+            ...(codexLaunch === undefined ? {} : { codexLaunch }),
+            workdir: currentRunnerWorkdir,
+            repo: str(flags.repo),
+          }
+        : undefined;
+      if (builtinRunnerOptions !== undefined && runnerStartupCheck === undefined) {
+        runnerStartupCheck = (deps.createBuiltinRunnerStartupCheck ?? createBuiltinRunnerStartupCheck)(
+          builtinRunnerOptions,
+        );
+      }
       const result = await runServeForCommand({
         server: currentServer,
         token: currentToken,
@@ -6230,17 +6449,8 @@ export async function run(argv: string[], deps: ServeCommandDeps = {}): Promise<
         }),
         statusline: true,
         runnerTimeoutMs,
-        builtinRunner: harness
-          ? {
-              server: currentServer,
-              token: currentToken,
-              channel,
-              harness,
-              ...(codexLaunch === undefined ? {} : { codexLaunch }),
-              workdir: currentRunnerWorkdir,
-              repo: str(flags.repo),
-            }
-          : undefined,
+        builtinRunner: builtinRunnerOptions,
+        startupCheck: runnerStartupCheck,
         sdkRunner: useSdkRunner
           ? {
               server: currentServer,
@@ -6253,6 +6463,20 @@ export async function run(argv: string[], deps: ServeCommandDeps = {}): Promise<
       if (result === EXIT_AUTH && currentAuth.auth_source === "account_session") {
         identityState.rejectedAccountToken = currentToken;
         return EXIT_STREAM_ENDED;
+      }
+      if (result === EXIT_CHANNEL_NOT_FOUND && harness !== undefined) {
+        const currentScope = readConfigWithSource().config?.identity?.channel_scope ?? null;
+        const hints = formatServeProfileHints({
+          channel,
+          currentName: boundary.principal.name,
+          currentScope,
+          currentServer,
+          runner: harness,
+          replayBacklog: flags["replay-backlog"] === true,
+          autoUpgrade: flags["auto-upgrade"] === true,
+          candidates: localAgentConfigsForChannel(channel, currentAuth.config.path),
+        });
+        for (const line of hints) console.error(terminalOutput(line));
       }
       return result;
     },

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -9,12 +9,14 @@ import {
   existsSync,
   mkdirSync,
   openSync,
+  readdirSync,
   readFileSync,
   realpathSync,
   renameSync,
   rmSync,
   statSync,
   writeFileSync,
+  type Dirent,
 } from "node:fs";
 import { atomicWriteJson } from "./atomic-json";
 import { stripTerminalControls } from "./format";
@@ -117,6 +119,73 @@ export interface WorkspaceState {
 
 export function agentpartyHome(): string {
   return process.env.AGENTPARTY_HOME || join(homedir(), ".agentparty");
+}
+
+export interface LocalAgentConfigHint {
+  path: string;
+  server: string;
+  name: string;
+  owner: string | null;
+  channelScope: string;
+}
+
+/**
+ * Find durable local agent identities that are explicitly scoped to a channel.
+ *
+ * This is a diagnostics-only index: never return the token, never follow symlinks,
+ * and ignore malformed/oversized files. A stale cached identity is still useful as
+ * a routing hint, but callers must describe it as a local candidate rather than a
+ * verified live profile.
+ */
+export function localAgentConfigsForChannel(
+  channel: string,
+  currentConfigPath: string | null = null,
+): LocalAgentConfigHint[] {
+  const directory = join(agentpartyHome(), "agents");
+  const current = currentConfigPath === null ? null : canonicalPath(currentConfigPath);
+  let entries: Dirent[];
+  try {
+    entries = readdirSync(directory, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const hints: LocalAgentConfigHint[] = [];
+  for (const entry of entries.slice(0, 500)) {
+    if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
+    const path = join(directory, entry.name);
+    if (current !== null && canonicalPath(path) === current) continue;
+    try {
+      if (statSync(path).size > 1_000_000) continue;
+      const parsed = JSON.parse(readFileSync(path, "utf8")) as Partial<Config>;
+      const identity = parsed.identity;
+      if (
+        typeof parsed.server !== "string"
+        || typeof parsed.token !== "string"
+        || parsed.token === ""
+        || identity === undefined
+        || identity.channel_scope !== channel
+        || typeof identity.name !== "string"
+        || identity.name === ""
+      ) {
+        continue;
+      }
+      hints.push({
+        path,
+        server: parsed.server.replace(/\/+$/, ""),
+        name: identity.name,
+        owner: typeof identity.owner === "string" && identity.owner !== "" ? identity.owner : null,
+        channelScope: channel,
+      });
+    } catch {
+      // One broken local profile must not hide the remaining actionable candidates.
+    }
+  }
+  return hints.sort(
+    (left, right) =>
+      left.server.localeCompare(right.server)
+      || left.name.localeCompare(right.name)
+      || left.path.localeCompare(right.path),
+  );
 }
 
 export function explicitConfigPath(): string | null {

--- a/cli/test/config.test.ts
+++ b/cli/test/config.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createHash } from "node:crypto";
@@ -11,6 +11,7 @@ import {
   globalConfigPath,
   loadCursor,
   loadCursorForConfig,
+  localAgentConfigsForChannel,
   loadRevCursorForConfig,
   loadStuckForConfig,
   readConfig,
@@ -57,6 +58,47 @@ describe("config", () => {
   test("write/read roundtrip", () => {
     writeConfig({ server: "https://ap.example.com", token: "ap_x" });
     expect(readConfig()).toEqual({ server: "https://ap.example.com", token: "ap_x" });
+  });
+
+  test("channel diagnostics list only matching durable agent configs without exposing tokens (#802)", () => {
+    const agents = join(home, "agents");
+    mkdirSync(agents, { recursive: true });
+    const current = join(agents, "current.json");
+    const matching = join(agents, "matching.json");
+    const other = join(agents, "other.json");
+    const outside = join(home, "outside.json");
+    writeFileSync(current, JSON.stringify({
+      server: "https://current.example.com",
+      token: "ap_current_secret",
+      identity: { name: "current", owner: "acct:current", channel_scope: "short-video" },
+    }));
+    writeFileSync(matching, JSON.stringify({
+      server: "https://matching.example.com/",
+      token: "ap_matching_secret",
+      identity: { name: "backend-codex", owner: "lark:on_owner", channel_scope: "short-video" },
+    }));
+    writeFileSync(other, JSON.stringify({
+      server: "https://other.example.com",
+      token: "ap_other_secret",
+      identity: { name: "other", owner: null, channel_scope: "another-channel" },
+    }));
+    writeFileSync(join(agents, "broken.json"), "{not json");
+    writeFileSync(outside, JSON.stringify({
+      server: "https://outside.example.com",
+      token: "ap_outside_secret",
+      identity: { name: "outside", owner: null, channel_scope: "short-video" },
+    }));
+    symlinkSync(outside, join(agents, "linked.json"));
+
+    const hints = localAgentConfigsForChannel("short-video", current);
+    expect(hints).toEqual([{
+      path: matching,
+      server: "https://matching.example.com",
+      name: "backend-codex",
+      owner: "lark:on_owner",
+      channelScope: "short-video",
+    }]);
+    expect(JSON.stringify(hints)).not.toContain("secret");
   });
 
   test("readConfigWithSource reports workspace source and safe fingerprint", () => {

--- a/cli/test/serve-failure-ack.test.ts
+++ b/cli/test/serve-failure-ack.test.ts
@@ -191,12 +191,13 @@ describe("serve wake delivery (#118 / #198)", () => {
 
   // #690：认证过期 / 二进制缺失等环境性失败在模型启动前就崩，别归为「model may have run」。
   test("an auth-failure runner exit is flagged environment=true and says the model did not run (#690)", async () => {
+    const workdir = tempDir();
     const run = createBuiltinRunner({
       server: "http://agentparty.test",
       token: "ap_tok",
       channel: "dev",
       harness: "claude",
-      workdir: tempDir(),
+      workdir,
       // 复刻 #690 现场：`claude -p` 秒退 exit 1，stderr 是 OAuth 过期。
       runProcess: async () => ({
         code: 1,
@@ -217,8 +218,13 @@ describe("serve wake delivery (#118 / #198)", () => {
     expect(err.environment).toBe(true);
     expect(err.retriable).toBe(false); // 认证没修好前立刻重试是白烧
     expect(err.message).toContain("runner environment failure");
+    expect(err.message).toContain("OAuth session expired");
     expect(err.message).toContain("model did not run");
     expect(err.message).not.toContain("model may have run");
+    const log = readFileSync(join(workdir, "serve-runner.log"), "utf8");
+    expect(log).toContain("env_failure=true");
+    expect(log).toContain("OAuth session expired");
+    expect(log).not.toContain("ap_tok");
   });
 
   test("isRunnerEnvFailure matches environment fingerprints and ignores ordinary model failures (#690)", () => {
@@ -725,6 +731,40 @@ describe("重试不得重复模型副作用 (#206 门禁 P1③)", () => {
     const note = String(posts.find((p) => p.state === "blocked")!.note);
     expect(note).toContain("attempts=1/3");
     expect(note).toContain("not retriable");
+  });
+
+  test("environment failure says it will not retry instead of showing a misleading 1/3 budget (#803)", async () => {
+    const s = closeAfterOneMention();
+    const posts: Array<Record<string, unknown>> = [];
+    const o = opts({
+      server: s.url,
+      maxWakeAttempts: 3,
+      post: async (_a, _b, _c, body) => {
+        posts.push(body as Record<string, unknown>);
+        return { seq: 1 };
+      },
+      runCommand: createBuiltinRunner({
+        server: "http://agentparty.test",
+        token: "ap_tok",
+        channel: "dev",
+        harness: "claude",
+        workdir: tempDir(),
+        runProcess: async () => ({
+          code: 1,
+          stdout: "",
+          stderr: "Failed to authenticate: OAuth session expired and could not be refreshed",
+        }),
+        post: async () => ({ seq: 1 }),
+      }),
+    });
+
+    expect(await runServe(o)).toBe(EXIT_ARCHIVED);
+    expect(o.lines.some((line) => line.includes("命令失败（不重试：环境类错误）"))).toBe(true);
+    expect(o.lines.some((line) => line.includes("命令失败 (1/3)"))).toBe(false);
+    const note = String(posts.find((post) => post.state === "blocked")?.note);
+    expect(note).toContain("attempts=1; retry=disabled_environment");
+    expect(note).toContain("OAuth session expired");
+    expect(note).not.toContain("attempts=1/3");
   });
 
   test("runner 根本没起来（spawn 失败）→ 模型没跑过，可以安全重试", async () => {

--- a/cli/test/serve-runner-command.test.ts
+++ b/cli/test/serve-runner-command.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { realpathSync } from "node:fs";
+import { mkdtempSync, readFileSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import {
   builtinRunnerCommand,
+  createBuiltinRunnerStartupCheck,
   resolveBuiltinCodexLaunch,
 } from "../src/commands/serve";
 
@@ -77,5 +79,59 @@ describe("builtin runner executable binding", () => {
       ok: false,
       error: expect.stringContaining("AGENTPARTY_RUNNER_BIN must be absolute"),
     });
+  });
+
+  test("Claude startup preflight keeps the auth evidence in the runner log and stops before service (#803)", async () => {
+    const workdir = mkdtempSync(resolve(tmpdir(), "ap-runner-preflight-"));
+    try {
+      const check = createBuiltinRunnerStartupCheck({
+        server: "https://agentparty.test",
+        token: "ap_test",
+        channel: "dev",
+        harness: "claude",
+        workdir,
+        runProcess: async (args) => {
+          expect(args).toEqual(["claude", "auth", "status", "--json"]);
+          return {
+            code: 1,
+            stdout: JSON.stringify({ loggedIn: false, authMethod: "none" }),
+            stderr: "",
+          };
+        },
+      });
+      await expect(check(AbortSignal.timeout(1_000))).rejects.toThrow(
+        "Claude authentication unavailable (loggedIn=false); run `claude login`",
+      );
+      const log = readFileSync(resolve(workdir, "serve-runner.log"), "utf8");
+      expect(log).toContain("startup_preflight=true");
+      expect(log).toContain("env_failure=true");
+      expect(log).toContain("run `claude login`");
+      expect(log).not.toContain("ap_test");
+    } finally {
+      rmSync(workdir, { recursive: true, force: true });
+    }
+  });
+
+  test("a successful local auth preflight is cached across socket supervisor attempts (#803)", async () => {
+    const workdir = mkdtempSync(resolve(tmpdir(), "ap-runner-preflight-"));
+    let calls = 0;
+    try {
+      const check = createBuiltinRunnerStartupCheck({
+        server: "https://agentparty.test",
+        token: "ap_test",
+        channel: "dev",
+        harness: "claude",
+        workdir,
+        runProcess: async () => {
+          calls += 1;
+          return { code: 0, stdout: JSON.stringify({ loggedIn: true }), stderr: "" };
+        },
+      });
+      await check(AbortSignal.timeout(1_000));
+      await check(AbortSignal.timeout(1_000));
+      expect(calls).toBe(1);
+    } finally {
+      rmSync(workdir, { recursive: true, force: true });
+    }
   });
 });

--- a/cli/test/serve-selfbootout.test.ts
+++ b/cli/test/serve-selfbootout.test.ts
@@ -20,7 +20,10 @@ import {
   dutyLockOwnerIsStale,
   dutyLockPath,
   dutyQuarantinedPlistPath,
+  EXIT_CHANNEL_NOT_FOUND,
+  EXIT_RUNNER_UNAVAILABLE,
   EXIT_WAKE_ABANDON_CIRCUIT,
+  isTerminalServeExit,
   selfBootoutTerminalDuty,
   tryReclaimStaleDutyLock,
 } from "../src/commands/serve";
@@ -49,6 +52,25 @@ describe("selfBootoutTerminalDuty (#744)", () => {
     const did = selfBootoutTerminalDuty(EXIT_WAKE_ABANDON_CIRCUIT, r.out, { ...base(), spawn: r.spawn } as never);
     expect(did).toBe(true);
     expect(r.calls).toEqual([{ cmd: "launchctl", args: ["bootout", `gui/501/${LABEL}`] }]);
+  });
+
+  test("确定性频道与 runner 启动错误会终止 supervisor，并留下准确的 duty 停机原因 (#802/#803)", () => {
+    for (const [code, reason] of [
+      [EXIT_CHANNEL_NOT_FOUND, "channel-not-found"],
+      [EXIT_RUNNER_UNAVAILABLE, "runner-unavailable"],
+    ] as const) {
+      const bodies: string[] = [];
+      const r = recorder();
+      expect(isTerminalServeExit(code)).toBe(true);
+      expect(selfBootoutTerminalDuty(code, r.out, {
+        ...base({
+          writeMarker: (_path: string, body: string) => bodies.push(body),
+        }),
+        spawn: r.spawn,
+      } as never)).toBe(true);
+      expect(JSON.parse(bodies[0]!).reason).toBe(reason);
+      expect(r.calls).toEqual([{ cmd: "launchctl", args: ["bootout", `gui/501/${LABEL}`] }]);
+    }
   });
 
   test("终局先原子留停机标记再 bootout，供 desktop reconcile 避免误复活", () => {

--- a/cli/test/serve-supervisor.test.ts
+++ b/cli/test/serve-supervisor.test.ts
@@ -3,7 +3,10 @@ import { EXIT_ARCHIVED, EXIT_AUTH, EXIT_STREAM_ENDED } from "@agentparty/shared"
 import {
   EXIT_SIGNAL_INT,
   EXIT_SIGNAL_TERM,
+  EXIT_CHANNEL_NOT_FOUND,
+  EXIT_RUNNER_UNAVAILABLE,
   EXIT_WAKE_ABANDON_CIRCUIT,
+  formatServeProfileHints,
   runServe,
   superviseServe,
   verifyServeIdentityBoundary,
@@ -40,6 +43,30 @@ const ownedIdentity = {
 };
 
 describe("serve lifecycle supervisor (#550)", () => {
+  test("profile mismatch hints name the active boundary and give a copyable local config command (#802)", () => {
+    const lines = formatServeProfileHints({
+      channel: "short-video",
+      currentName: "wrong-agent",
+      currentScope: "agentparty",
+      currentServer: "https://wrong.example.com",
+      runner: "claude",
+      replayBacklog: true,
+      autoUpgrade: false,
+      candidates: [{
+        path: "/Users/test/.agentparty/agents/right.json",
+        server: "https://right.example.com",
+        name: "backend-codex",
+        owner: "lark:on_owner",
+        channelScope: "short-video",
+      }],
+    });
+    expect(lines.join("\n")).toContain("当前身份 wrong-agent (scope=agentparty, server=https://wrong.example.com)");
+    expect(lines.join("\n")).toContain("backend-codex (server=https://right.example.com");
+    expect(lines.join("\n")).toContain("AGENTPARTY_CONFIG='/Users/test/.agentparty/agents/right.json'");
+    expect(lines.join("\n")).toContain("'--replay-backlog'");
+    expect(lines.join("\n")).toContain("'--profile' 'lark:on_owner/backend-codex'");
+  });
+
   test("restarts transient exits with bounded exponential backoff", async () => {
     const codes = [EXIT_STREAM_ENDED, 1, 0];
     const sleeps: number[] = [];
@@ -129,6 +156,68 @@ describe("serve lifecycle supervisor (#550)", () => {
     expect(code).toBe(EXIT_AUTH);
     expect(calls).toBe(1);
     expect(sleeps).toEqual([]);
+  });
+
+  test("does not retry deterministic channel/profile or runner startup failures (#802/#803)", async () => {
+    for (const terminalExit of [EXIT_CHANNEL_NOT_FOUND, EXIT_RUNNER_UNAVAILABLE]) {
+      let calls = 0;
+      const sleeps: number[] = [];
+      const code = await superviseServe({
+        runOnce: async () => {
+          calls += 1;
+          return terminalExit;
+        },
+        sleep: async (ms) => { sleeps.push(ms); },
+      });
+      expect(code).toBe(terminalExit);
+      expect(calls).toBe(1);
+      expect(sleeps).toEqual([]);
+    }
+  });
+
+  test("channel not found never prints a serving-success banner (#802)", async () => {
+    const lines: string[] = [];
+    const server = startMockServer((frame, sock) => {
+      if (frame.type !== "hello") return;
+      sock.send({ type: "error", code: "not_found", message: "channel not found: missing" });
+    });
+    try {
+      const code = await runServe({
+        server: server.url,
+        token: "ap_test",
+        channel: "missing",
+        since: 0,
+        cmd: "true",
+        mentionsOnly: true,
+        allowMultiple: true,
+        out: (line) => lines.push(line),
+      });
+      expect(code).toBe(EXIT_CHANNEL_NOT_FOUND);
+      expect(lines.some((line) => line.includes("serving #"))).toBe(false);
+    } finally {
+      server.stop();
+    }
+  });
+
+  test("runner startup preflight fails before a socket or lease exists (#803)", async () => {
+    const lines: string[] = [];
+    const code = await runServe({
+      server: "http://127.0.0.1:1",
+      token: "ap_test",
+      channel: "dev",
+      since: 0,
+      cmd: "",
+      mentionsOnly: true,
+      allowMultiple: true,
+      startupCheck: async () => {
+        throw new Error("Claude authentication unavailable; run `claude login`");
+      },
+      out: (line) => lines.push(line),
+    });
+    expect(code).toBe(EXIT_RUNNER_UNAVAILABLE);
+    expect(lines).toEqual([
+      expect.stringContaining("runner 启动预检失败，不连接频道、不领取租约"),
+    ]);
   });
 
   test("turns thrown transient failures into a logged restart", async () => {


### PR DESCRIPTION
## 变更

- 在建立频道连接和领取租约前校验 Claude/Codex 本地登录态，失败时直接终止且不消耗 wake
- 把 runner 的真实认证/环境诊断写入 `serve-runner.log`，环境错误明确显示“不重试”
- 频道不存在时不再先显示 `serving`，并停止 supervisor/launchd 的无意义重启
- 扫描同频道的本地持久 agent 配置，给出当前身份边界、候选配置和可复制的 `AGENTPARTY_CONFIG` 命令
- 常驻停机标记分别记录 `channel-not-found` 与 `runner-unavailable`

## 验证

- `bun run check`
- 真实本机 `claude auth status --json` 失效态：预检在连接前失败，日志保留 `loggedIn=false` 的可操作诊断
- Chrome 线上验收 v0.2.173 的“你离开期间”折叠/展开状态

Closes #802
Closes #803