### PR TITLE
fix(cli): 等待 Release 资产就绪后再自升级

### DIFF
--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -5,7 +5,16 @@ import { BODY_LIMIT, DECISION_OPTION_LIMIT, DECISION_OPTIONS_MAX, DECISION_PROMP
 import { channelDecisionSnapshotBodyLines } from "@agentparty/shared/onboarding";
 import { createHash, randomUUID } from "node:crypto";
 import { spawnSync } from "node:child_process";
-import { downloadPartyUpgrade, isPartyBinaryPath, maybeReexecUpgrade, serverVersionUpgradeNotice, upgradeNotice, type CliUpgradeNotice, type UpgradeDeps } from "../upgrade";
+import {
+  downloadPartyUpgrade,
+  isPartyBinaryPath,
+  isReleaseAssetPublishing,
+  maybeReexecUpgrade,
+  serverVersionUpgradeNotice,
+  upgradeNotice,
+  type CliUpgradeNotice,
+  type UpgradeDeps,
+} from "../upgrade";
 import {
   clearManagedActions,
   clearManagedExclusiveLocks,
@@ -177,6 +186,10 @@ export async function resolveAvailableUpgrade(
         message: `AgentParty 服务器已发布 party CLI v${notice.available_version}，已下载并校验新版二进制。本轮唤醒结束后 serve 会自动 re-exec 新版。`,
       };
     } catch (error) {
+      if (isReleaseAssetPublishing(error)) {
+        options.out?.(`serve: party v${notice.available_version} 的发布资产仍在生成，稍后会自动重试。`);
+        return null;
+      }
       options.out?.(`serve: 自动下载 party v${notice.available_version} 失败，保留人工升级提示: ${error instanceof Error ? error.message : String(error)}`);
       return notice;
     }

--- a/cli/src/upgrade.ts
+++ b/cli/src/upgrade.ts
@@ -88,6 +88,20 @@ export function detectReleaseTarget(platform: NodeJS.Platform = process.platform
 
 const UPGRADE_NETWORK_TIMEOUT_MS = 60_000;
 
+export class ReleaseAssetDownloadError extends Error {
+  constructor(
+    readonly url: string,
+    readonly status: number,
+  ) {
+    super(`download failed: ${url} (${status})`);
+    this.name = "ReleaseAssetDownloadError";
+  }
+}
+
+export function isReleaseAssetPublishing(error: unknown): boolean {
+  return error instanceof ReleaseAssetDownloadError && error.status === 404;
+}
+
 async function resolveLatestReleaseVersion(fetcher: typeof fetch): Promise<string> {
   const signal = AbortSignal.timeout(UPGRADE_NETWORK_TIMEOUT_MS);
   const api = await fetcher(`https://api.github.com/repos/${OWNER_REPO}/releases/latest`, {
@@ -112,7 +126,7 @@ async function resolveLatestReleaseVersion(fetcher: typeof fetch): Promise<strin
 async function defaultFetchBytes(url: string, signal?: AbortSignal): Promise<Uint8Array> {
   if (url.startsWith("file://")) return new Uint8Array(readFileSync(fileURLToPath(url)));
   const res = await fetch(url, { signal: signal ?? AbortSignal.timeout(UPGRADE_NETWORK_TIMEOUT_MS) });
-  if (!res.ok) throw new Error(`download failed: ${url} (${res.status})`);
+  if (!res.ok) throw new ReleaseAssetDownloadError(url, res.status);
   return new Uint8Array(await res.arrayBuffer());
 }
 

--- a/cli/test/version-negotiation.test.ts
+++ b/cli/test/version-negotiation.test.ts
@@ -124,6 +124,82 @@ describe("CLI↔worker version negotiation (issue #137)", () => {
     });
     expect(installs).toEqual(["/usr/local/bin/party"]);
   });
+
+  test("resolveAvailableUpgrade treats a release asset 404 as publishing and retries successfully later (#805)", async () => {
+    const archive = new TextEncoder().encode("fake tarball");
+    const installs: string[] = [];
+    const output: string[] = [];
+    let assetsReady = false;
+    globalThis.fetch = (async (input: string | URL | Request, _init?: RequestInit) => {
+      const url = String(input);
+      if (url === "https://ap.test/api/version") {
+        return Response.json({ version: "0.2.108", commit: "abc", deployed_at: null });
+      }
+      if (!assetsReady) return new Response("not found", { status: 404 });
+      return url.endsWith(".sha256")
+        ? new Response(`${sha256(archive)}  party-darwin-x64.tar.gz\n`)
+        : new Response(archive);
+    }) as typeof fetch;
+    const options = {
+      autoDownload: true,
+      out: (line: string) => output.push(line),
+      upgradeDeps: {
+        runningVersion: "0.2.107",
+        execPath: "/usr/local/bin/party",
+        platform: "darwin" as const,
+        arch: "x64",
+        extractPartyBinary: async (_archivePath: string, outDir: string) => {
+          const binary = `${outDir}/party`;
+          writeFileSync(binary, "binary");
+          return binary;
+        },
+        installBinary: (_source: string, target: string) => installs.push(target),
+      },
+    };
+
+    expect(await resolveAvailableUpgrade("https://ap.test", null, options)).toBeNull();
+    expect(output).toEqual(["serve: party v0.2.108 的发布资产仍在生成，稍后会自动重试。"]);
+    expect(installs).toHaveLength(0);
+
+    assetsReady = true;
+    expect(await resolveAvailableUpgrade("https://ap.test", null, options)).toMatchObject({
+      available_version: "0.2.108",
+      installed_version: "0.2.108",
+      auto_upgrade: true,
+      action_required: "auto_reexec",
+    });
+    expect(installs).toEqual(["/usr/local/bin/party"]);
+  });
+
+  test("resolveAvailableUpgrade keeps the manual fallback for non-404 download failures (#805)", async () => {
+    const output: string[] = [];
+    globalThis.fetch = (async (input: string | URL | Request, _init?: RequestInit) => {
+      const url = String(input);
+      if (url === "https://ap.test/api/version") {
+        return Response.json({ version: "0.2.108", commit: "abc", deployed_at: null });
+      }
+      return new Response("unavailable", { status: 503 });
+    }) as typeof fetch;
+
+    const notice = await resolveAvailableUpgrade("https://ap.test", null, {
+      autoDownload: true,
+      out: (line) => output.push(line),
+      upgradeDeps: {
+        runningVersion: "0.2.107",
+        execPath: "/usr/local/bin/party",
+        platform: "darwin",
+        arch: "x64",
+      },
+    });
+
+    expect(notice).toMatchObject({
+      available_version: "0.2.108",
+      auto_upgrade: false,
+      action_required: "ask_user",
+    });
+    expect(output[0]).toContain("自动下载 party v0.2.108 失败，保留人工升级提示");
+    expect(output[0]).toContain("(503)");
+  });
 });
 
 describe("upgradeHintForServer（#703：watch 挂载升级提示）", () => {


### PR DESCRIPTION
## 结果

- 把 GitHub Release 资产 404 与真实下载故障区分开
- `serve --auto-upgrade` 在发布窗口内只说明“资产仍在生成，稍后自动重试”，不再向 Agent 注入不可执行的人工升级提示
- 后续既有版本探测会自动重试；资产就绪后照常下载、校验、安装并在安全点 re-exec
- 503、校验失败和安装失败仍保留人工升级提示

## 验证

- `bun test cli/test/version-negotiation.test.ts cli/test/upgrade.test.ts`（19 pass）
- `bunx tsc --noEmit -p cli/tsconfig.json`
- `bun run check`（CLI 1387、Web 1265、Worker 772，全部通过）

Closes #805