### PR TITLE
fix generated image reply attachments

### DIFF
--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -1812,6 +1812,42 @@ function guessAttachmentContentType(filename: string): string {
   return ATTACHMENT_CONTENT_TYPE_BY_EXT[ext] ?? "application/octet-stream";
 }
 
+interface RunnerAttachment {
+  filename: string;
+  bytes: Uint8Array;
+  contentType: string;
+}
+
+function generatedImageAttachments(result: unknown): RunnerAttachment[] {
+  if (!result || typeof result !== "object") return [];
+  const items = (result as Record<string, unknown>).items;
+  if (!Array.isArray(items)) return [];
+
+  const attachments: RunnerAttachment[] = [];
+  for (const item of items) {
+    if (!item || typeof item !== "object" || (item as Record<string, unknown>).type !== "mcp_tool_call") continue;
+    const toolResult = (item as Record<string, unknown>).result;
+    if (!toolResult || typeof toolResult !== "object") continue;
+    const content = (toolResult as Record<string, unknown>).content;
+    if (!Array.isArray(content)) continue;
+    for (const block of content) {
+      if (!block || typeof block !== "object") continue;
+      const image = block as Record<string, unknown>;
+      if (image.type !== "image" || typeof image.data !== "string" || typeof image.mimeType !== "string") continue;
+      const bytes = Buffer.from(image.data, "base64");
+      if (bytes.byteLength === 0) continue;
+      const contentType = image.mimeType.split(";", 1)[0]!.toLowerCase();
+      const extension = contentType === "image/jpeg" ? "jpg" : contentType.split("/")[1] ?? "bin";
+      attachments.push({
+        filename: `generated-image-${attachments.length + 1}.${extension}`,
+        bytes: Uint8Array.from(bytes),
+        contentType,
+      });
+    }
+  }
+  return attachments;
+}
+
 // worker 端 filename 校验：/^[^/\\\x00-\x1f\x7f]{1,255}$/（单段、无控制符）。消毒到合法单段。
 function safeAttachmentFilename(name: string): string {
   const cleaned = name.replace(/[/\\\x00-\x1f\x7f]/g, "_").slice(0, 255);
@@ -1891,6 +1927,7 @@ async function deliverRunnerMessage(opts: {
   expectedDecisionLineage?: RoutedRunnerMessage["expectedDecisionLineage"];
   expectedDecisionResponderOwner?: RoutedRunnerMessage["expectedDecisionResponderOwner"];
   attachmentRoot?: string | null;
+  attachments?: RunnerAttachment[];
   responseSource?: ResponseSource;
 }): Promise<Awaited<ReturnType<typeof postMessage>>> {
   const {
@@ -1907,6 +1944,7 @@ async function deliverRunnerMessage(opts: {
     expectedDecisionLineage,
     expectedDecisionResponderOwner,
     attachmentRoot,
+    attachments = [],
     responseSource,
   } = opts;
   // [attach:/abs/path]：交付物永远走 R2 附件（相对路径在此抛错，与旧行为一致）。
@@ -1917,6 +1955,9 @@ async function deliverRunnerMessage(opts: {
   if (decisionRequest !== undefined && attachPath !== null) {
     throw new Error("managed owner decision cannot be delivered as an attachment");
   }
+  const uploadedAttachments = await Promise.all(
+    attachments.map((attachment) => upload(server, token, channel, attachment.filename, attachment.bytes, attachment.contentType)),
+  );
   if (attachPath !== null) {
     const allowedPath = resolveRunnerAttachmentPath(attachPath, attachmentRoot);
     const bytes = readFileSync(allowedPath); // Buffer：逐字节，不做 utf8 往返，保住 #41 的完整性
@@ -1932,7 +1973,7 @@ async function deliverRunnerMessage(opts: {
       body: clampInlineBody(parts.join("\n")),
       mentions,
       reply_to: replyTo,
-      attachments: [ref],
+      attachments: [ref, ...uploadedAttachments],
       ...(responseSource === undefined ? {} : { response_source: responseSource }),
     });
   }
@@ -1948,7 +1989,7 @@ async function deliverRunnerMessage(opts: {
       body: `[reply body ${inlineBytes} bytes exceeded the ${BODY_LIMIT}-byte inline limit; delivered as attachment ${filename}]`,
       mentions,
       reply_to: replyTo,
-      attachments: [ref],
+      attachments: [ref, ...uploadedAttachments],
       ...(responseSource === undefined ? {} : { response_source: responseSource }),
     });
   }
@@ -1967,6 +2008,7 @@ async function deliverRunnerMessage(opts: {
       ? {}
       : { expected_decision_responder_owner: expectedDecisionResponderOwner }),
     ...(responseSource === undefined ? {} : { response_source: responseSource }),
+    ...(uploadedAttachments.length === 0 ? {} : { attachments: uploadedAttachments }),
   };
   return await post(server, token, channel, payload);
 }
@@ -2003,6 +2045,7 @@ async function deliverRunnerResult(opts: {
   token: string;
   channel: string;
   attachmentRoot?: string | null;
+  attachments?: RunnerAttachment[];
   responseSource?: ResponseSource;
 }): Promise<RunnerDeliveryOutcome> {
   const routed = opts.route === undefined
@@ -2024,6 +2067,7 @@ async function deliverRunnerResult(opts: {
     // A supervisor-owned route is managed. It is fail-closed unless that lane explicitly grants a
     // real workspace root; legacy non-routed runners preserve their historical attachment behavior.
     attachmentRoot: opts.route === undefined ? opts.attachmentRoot : opts.attachmentRoot ?? null,
+    attachments: opts.attachments,
     responseSource: opts.responseSource,
   });
   if (routed.completionSummarySeq !== undefined) {
@@ -3036,6 +3080,7 @@ export function createSdkRunner(opts: SdkRunnerOptions): NonNullable<ServeOption
           frame,
           text: body,
           marker: null,
+          attachments: generatedImageAttachments(result),
           delivery: ctx.delivery ?? null,
           route: opts.resultRoute,
           post,

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -1818,6 +1818,13 @@ interface RunnerAttachment {
   contentType: string;
 }
 
+const GENERATED_IMAGE_FORMATS: Record<string, { extension: string; contentType: string }> = {
+  "image/png": { extension: "png", contentType: "image/png" },
+  "image/jpeg": { extension: "jpg", contentType: "image/jpeg" },
+  "image/gif": { extension: "gif", contentType: "image/gif" },
+  "image/webp": { extension: "webp", contentType: "image/webp" },
+};
+
 function generatedImageAttachments(result: unknown): RunnerAttachment[] {
   if (!result || typeof result !== "object") return [];
   const items = (result as Record<string, unknown>).items;
@@ -1834,14 +1841,14 @@ function generatedImageAttachments(result: unknown): RunnerAttachment[] {
       if (!block || typeof block !== "object") continue;
       const image = block as Record<string, unknown>;
       if (image.type !== "image" || typeof image.data !== "string" || typeof image.mimeType !== "string") continue;
+      const format = GENERATED_IMAGE_FORMATS[image.mimeType.split(";", 1)[0]!.trim().toLowerCase()];
+      if (format === undefined) continue;
       const bytes = Buffer.from(image.data, "base64");
       if (bytes.byteLength === 0) continue;
-      const contentType = image.mimeType.split(";", 1)[0]!.toLowerCase();
-      const extension = contentType === "image/jpeg" ? "jpg" : contentType.split("/")[1] ?? "bin";
       attachments.push({
-        filename: `generated-image-${attachments.length + 1}.${extension}`,
+        filename: `generated-image-${attachments.length + 1}.${format.extension}`,
         bytes: Uint8Array.from(bytes),
-        contentType,
+        contentType: format.contentType,
       });
     }
   }

--- a/cli/test/serve.test.ts
+++ b/cli/test/serve.test.ts
@@ -3300,7 +3300,10 @@ describe("codex-sdk runner", () => {
         items: [{
           type: "mcp_tool_call",
           result: {
-            content: [{ type: "image", data: Buffer.from(imageBytes).toString("base64"), mimeType: "image/png" }],
+            content: [
+              { type: "image", data: Buffer.from(imageBytes).toString("base64"), mimeType: "image/png" },
+              { type: "image", data: Buffer.from("unsafe").toString("base64"), mimeType: "image/p2\u001fdata" },
+            ],
             structured_content: null,
           },
         }],

--- a/cli/test/serve.test.ts
+++ b/cli/test/serve.test.ts
@@ -3289,6 +3289,39 @@ describe("codex-sdk runner", () => {
     });
   });
 
+  test("SDK MCP image results are uploaded as reply attachments", async () => {
+    const { posts, post } = postRecorder();
+    const { uploads, upload } = uploadRecorder();
+    const imageBytes = Uint8Array.from([0x89, 0x50, 0x4e, 0x47]);
+    const thread: ThreadLike = {
+      id: "thread_image_12345678",
+      run: async () => ({
+        finalResponse: "已生成图片",
+        items: [{
+          type: "mcp_tool_call",
+          result: {
+            content: [{ type: "image", data: Buffer.from(imageBytes).toString("base64"), mimeType: "image/png" }],
+            structured_content: null,
+          },
+        }],
+      }),
+    };
+
+    await sdkRunner({
+      workdir: tempDir(),
+      post,
+      uploadAttachment: upload,
+      codexFactory: () => ({ startThread: () => thread, resumeThread: () => thread }),
+    })(triggerFrame(103), runnerCtx());
+
+    expect(uploads).toHaveLength(1);
+    expect(uploads[0]).toMatchObject({ filename: "generated-image-1.png", contentType: "image/png" });
+    expect(uploads[0]!.bytes).toEqual(imageBytes);
+    const message = posts.at(-1)!.body as Extract<MessagePayload, { kind: "message" }>;
+    expect(message.attachments).toHaveLength(1);
+    expect(message.attachments![0]!.filename).toBe("generated-image-1.png");
+  });
+
   test("session reports fall back to workdir when the SDK does not provide cwd", async () => {
     const { post } = postRecorder();
     const workdir = tempDir();


### PR DESCRIPTION
## What changed

- Extract image content blocks from Codex SDK MCP tool results.
- Upload generated image bytes through AgentParty's existing attachment endpoint.
- Include uploaded references on the generated-image reply alongside existing delivery attachments.
- Add an SDK-runner regression test covering the image attachment path.

## Root cause

The SDK runner reduced each `RunResult` to `finalResponse` text before delivery. Generated images are returned in `items[].result.content[]`, so their bytes were discarded and the posted reply contained `attachments: []`.

## Validation

- `cd cli && bun test test/serve.test.ts` — 90 passed
- `cd cli && bunx tsc --noEmit` — passed
- `git diff --check` — passed

## 合并前检查

- [x] 已读 CodeRabbit review；采纳 MIME subtype 信任边界问题，改为固定图片 MIME 白名单
- [x] 本地门禁通过（focused tests / tsc / diff check）
- [x] 安全边界已做变异验证：含控制字符的未知图片 MIME 被跳过，不上传也不进入附件元数据
