### PR TITLE
grant resident Codex full access

### DIFF
--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -1130,8 +1130,8 @@ export interface BuiltinRunnerOptions {
   agentpartyConfigPath?: string;
   /** Prevent the model process from inheriting any usable AgentParty identity. */
   isolateModelPartyAccess?: boolean;
-  /** Front control plane is read-only; execution workers keep workspace-write. */
-  sandbox?: "read-only" | "workspace-write";
+  /** Ordinary residents use full access; managed front/worker lanes explicitly stay constrained. */
+  sandbox?: "read-only" | "workspace-write" | "danger-full-access";
   /** Supervisor-owned routing for managed front/worker results. */
   resultRoute?: RunnerResultRoute;
   /** Harness-enforced final response schema for the managed control plane. */
@@ -2665,7 +2665,7 @@ async function runHarness(
     const flags = [
       "--skip-git-repo-check",
       "--sandbox",
-      opts.sandbox ?? "workspace-write",
+      opts.sandbox ?? "danger-full-access",
       ...schemaArgs,
       ...mcpArgs,
       "-o",

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -1130,7 +1130,7 @@ export interface BuiltinRunnerOptions {
   agentpartyConfigPath?: string;
   /** Prevent the model process from inheriting any usable AgentParty identity. */
   isolateModelPartyAccess?: boolean;
-  /** Ordinary residents use full access; managed front/worker lanes explicitly stay constrained. */
+  /** Resident model lanes default to full host access; callers may still opt into a sandbox explicitly. */
   sandbox?: "read-only" | "workspace-write" | "danger-full-access";
   /** Supervisor-owned routing for managed front/worker results. */
   resultRoute?: RunnerResultRoute;
@@ -4340,21 +4340,18 @@ export async function runProfileServe(opts: ProfileServeOptions): Promise<number
       // #581 managed MCP：lane 清单 + child token config（0600）。这是 #578「child token 纯内存」
       // 边界的有意放宽（issue #581 拍板）：MCP server 进程要持有身份就必须能读到它；模型 env 仍是
       // denied-home，token 不进模型环境。
-      // #647：但它绝不能落在 worker 模型的 workspace-write 沙箱根（channelWorkdir）之内——否则模型能
-      // 读回自己的 token（绕过 denied-home 直接打 REST）并篡改 managed.json（放宽 attachment_root
-      // 越权上传宿主文件）。非 branch 策略下 channelWorkdir === runnerWorkdir，故不能再用 runnerWorkdir/mcp；
-      // 改用 runnerWorkdir 的**同级**目录（.mcp 后缀），在所有策略下都保证落在沙箱之外。MCP server
-      // 子进程（serve 起、非沙箱）照常读得到，被沙箱的只是模型本身。
+      // #647：状态目录仍必须落在 channelWorkdir 之外，避免 child token / managed manifest 被项目侧
+      // git、同步与附件流程被动收集。resident 模型按 owner 的信任边界运行 full access；这里是存储
+      // 卫生与显式能力分层，不把目录位置冒充成对模型保密的安全沙箱。
       const mcpStateDir = `${prepared.runnerWorkdir}.mcp`;
       if (laneProtocol === "mcp") {
-        // 兜底 fail-closed：万一某种策略下路径推导仍落进沙箱，拒绝启动而不是把 token 暴露给模型。
-        // rel === "" 表示 mcpStateDir 与沙箱根**相等**，同样越界（CodeRabbit #651）；rel 不以 .. 开头
-        // 且非绝对路径表示嵌套在沙箱内。两种都拒。
+        // rel === "" 表示 mcpStateDir 与频道工作区相等；rel 不以 .. 开头且非绝对路径表示嵌套。
+        // 两种都拒绝，确保 supervisor 状态不会进入项目工作区。
         const relToWorkspace = relative(prepared.channelWorkdir, mcpStateDir);
         if (!relToWorkspace.startsWith("..") && !isAbsolute(relToWorkspace)) {
           throw new Error(
-            `refusing managed MCP: state dir ${mcpStateDir} is inside the worker sandbox ${prepared.channelWorkdir} ` +
-              "(would leak the child token / manifest to the sandboxed model)",
+            `refusing managed MCP: state dir ${mcpStateDir} is inside the channel workspace ${prepared.channelWorkdir} ` +
+              "(would mix supervisor credentials with project files)",
           );
         }
         writeManagedManifest(mcpStateDir, {
@@ -4481,7 +4478,7 @@ export async function runProfileServe(opts: ProfileServeOptions): Promise<number
               workdir: prepared.runnerWorkdir,
               cwd: prepared.channelWorkdir,
               isolateModelPartyAccess: true,
-              sandbox: role === "front" ? "read-only" : "workspace-write",
+              sandbox: "danger-full-access",
               resultRoute,
               outputSchema: laneProtocol === "mcp" ? undefined : role === "front" ? MANAGED_FRONT_OUTPUT_SCHEMA : undefined,
               attachmentRoot: role === "front" ? null : prepared.channelWorkdir,
@@ -4503,10 +4500,10 @@ export async function runProfileServe(opts: ProfileServeOptions): Promise<number
               workdir: prepared.runnerWorkdir,
               cwd: prepared.channelWorkdir,
               isolateModelPartyAccess: true,
-              // worker 与 builtin lane 一致给 workspace-write，绝不能是 full_access（sdkSandboxMode
-              // 会映射成 danger-full-access = 完全无沙箱）；否则 SDK worker 能读任意主机文件、拷进
-              // channelWorkdir 再 [attach:] 上传，绕过本 PR 对 worker 的主机文件边界。
-              sandbox: role === "front" ? "read_only" : "workspace-write",
+              // Owner-operated resident lanes deliberately avoid Codex's filesystem sandbox.
+              // AgentParty identity isolation, role-cropped MCP tools, result routing, and the
+              // attachment allowlist remain supervisor-enforced boundaries.
+              sandbox: "full_access",
               resultRoute,
               outputSchema: role === "front" ? MANAGED_FRONT_OUTPUT_SCHEMA : undefined,
               attachmentRoot: role === "front" ? null : prepared.channelWorkdir,

--- a/cli/test/serve.test.ts
+++ b/cli/test/serve.test.ts
@@ -2579,10 +2579,12 @@ describe("project profile daemon", () => {
     expect(served).toHaveLength(4);
     expect(served.every((options) => options.builtinRunner?.codexLaunch === launch)).toBe(true);
     expect(served.every((options) => options.builtinRunner?.codexLaunch?.env.PATH === "/preflight-a/bin")).toBe(true);
-    expect(served.filter((options) => options.projectAgent?.runtime_role === "front").every((options) =>
-      options.builtinRunner?.sandbox === "read-only")).toBe(true);
-    expect(served.filter((options) => options.projectAgent?.runtime_role === "worker").every((options) =>
-      options.builtinRunner?.sandbox === "workspace-write")).toBe(true);
+    const fronts = served.filter((options) => options.projectAgent?.runtime_role === "front");
+    const workers = served.filter((options) => options.projectAgent?.runtime_role === "worker");
+    expect(fronts.length).toBeGreaterThan(0);
+    expect(workers.length).toBeGreaterThan(0);
+    expect(fronts.every((options) => options.builtinRunner?.sandbox === "read-only")).toBe(true);
+    expect(workers.every((options) => options.builtinRunner?.sandbox === "workspace-write")).toBe(true);
   });
 
   test("a failed Codex profile preflight remains offline and is retried without fallback", async () => {

--- a/cli/test/serve.test.ts
+++ b/cli/test/serve.test.ts
@@ -1626,6 +1626,7 @@ describe("builtin runner", () => {
     // 先断言 --sandbox 真的存在：indexOf 缺失时返回 -1，只比顺序会放过 sandbox 护栏被删的回归。
     expect(calls[1]!).toContain("--sandbox");
     expect(calls[1]!.indexOf("--sandbox")).toBeLessThan(calls[1]!.indexOf("resume"));
+    expect(calls[1]![calls[1]!.indexOf("--sandbox") + 1]).toBe("danger-full-access");
     const log = readFileSync(join(workdir, "serve-runner.log"), "utf8");
     expect(log).toContain("seq=1 sid=019f35d9");
     expect(log).toContain("seq=2 sid=019f35d9");
@@ -2578,6 +2579,10 @@ describe("project profile daemon", () => {
     expect(served).toHaveLength(4);
     expect(served.every((options) => options.builtinRunner?.codexLaunch === launch)).toBe(true);
     expect(served.every((options) => options.builtinRunner?.codexLaunch?.env.PATH === "/preflight-a/bin")).toBe(true);
+    expect(served.filter((options) => options.projectAgent?.runtime_role === "front").every((options) =>
+      options.builtinRunner?.sandbox === "read-only")).toBe(true);
+    expect(served.filter((options) => options.projectAgent?.runtime_role === "worker").every((options) =>
+      options.builtinRunner?.sandbox === "workspace-write")).toBe(true);
   });
 
   test("a failed Codex profile preflight remains offline and is retried without fallback", async () => {

--- a/cli/test/serve.test.ts
+++ b/cli/test/serve.test.ts
@@ -2583,8 +2583,8 @@ describe("project profile daemon", () => {
     const workers = served.filter((options) => options.projectAgent?.runtime_role === "worker");
     expect(fronts.length).toBeGreaterThan(0);
     expect(workers.length).toBeGreaterThan(0);
-    expect(fronts.every((options) => options.builtinRunner?.sandbox === "read-only")).toBe(true);
-    expect(workers.every((options) => options.builtinRunner?.sandbox === "workspace-write")).toBe(true);
+    expect(fronts.every((options) => options.builtinRunner?.sandbox === "danger-full-access")).toBe(true);
+    expect(workers.every((options) => options.builtinRunner?.sandbox === "danger-full-access")).toBe(true);
   });
 
   test("a failed Codex profile preflight remains offline and is retried without fallback", async () => {
@@ -2922,11 +2922,11 @@ describe("project profile daemon", () => {
     expect(served.filter((o) => o.projectAgent?.runtime_role === "worker")).toHaveLength(3);
     expect(served.filter((o) => o.projectAgent?.runtime_role === "front").every((o) =>
       o.sdkRunner?.outputSchema === MANAGED_FRONT_OUTPUT_SCHEMA &&
-      o.sdkRunner?.sandbox === "read_only" &&
+      o.sdkRunner?.sandbox === "full_access" &&
       o.sdkRunner?.attachmentRoot === null)).toBe(true);
     expect(served.filter((o) => o.projectAgent?.runtime_role === "worker").every((o) =>
       o.sdkRunner?.outputSchema === undefined &&
-      o.sdkRunner?.sandbox === "workspace-write" &&
+      o.sdkRunner?.sandbox === "full_access" &&
       o.sdkRunner?.attachmentRoot === o.projectAgent?.channel_workdir)).toBe(true);
     expect(served.every((o) => o.sdkRunner?.cwd === o.projectAgent?.channel_workdir)).toBe(true);
     expect(JSON.parse(readFileSync(ownerConfig, "utf8"))).toEqual({


### PR DESCRIPTION
## What changed

- Default ordinary resident `--runner codex` executions to Codex `danger-full-access`.
- Run managed project-agent front and worker lanes without the Codex filesystem sandbox as well.
- Keep AgentParty identity isolation, role-cropped MCP tools, supervisor-owned result routing, and attachment allowlists in place.
- Add regression assertions for ordinary, managed CLI, and managed SDK lanes.

## Root cause

The resident reached `codex exec` with the fallback `--sandbox workspace-write`. Real work requiring host capabilities, including starting ADB local `tcp:5037`, failed with `Operation not permitted` even though the agent was otherwise healthy.

Broader read permissions do not solve local networking or host execution. Owner-operated residents need full host access to preserve the expected interactive experience.

## Trust boundary

Resident model lanes are owner-operated and intentionally trusted with full host access. This removes Codex filesystem sandboxing, but does not remove AgentParty control-plane boundaries: model processes still do not inherit a usable AgentParty identity, managed MCP tools remain role-cropped, results remain supervisor-routed, and explicit attachment uploads remain allowlisted.

Supervisor state stays outside the project workspace to prevent credentials or manifests from being accidentally collected by git, sync, or attachment workflows. Its location is storage hygiene, not a secrecy boundary against a full-access model.

## Validation

- `cd cli && bun test test/serve.test.ts test/serve-continuation.test.ts` — 112 passed
- `cd cli && bunx tsc --noEmit` — passed
- `git diff --check` — passed

## 合并前检查

- [x] 本地测试与 TypeScript 门禁通过
- [x] 普通 resident、managed front/worker 均显式验证 full access
- [x] AgentParty 身份、MCP 角色、结果路由、附件边界保持
- [ ] 等待当前 head 的自动 review，并留下 `review-ack` 结论