### PR TITLE
fix: 修掉那条导致越界改动的事故链 (#821 #823 #824 #825 #826 #827)

### DIFF
--- a/cli/src/commands/invite.ts
+++ b/cli/src/commands/invite.ts
@@ -287,7 +287,11 @@ claude mcp add ${mcpServerName(guestName)} --env AGENTPARTY_CONFIG="\$HOME/.agen
 #     常驻 supervisor 替你等、被 @ 才拉起你一次，等待零 token；挂上即自动声明「可被唤醒」
 #     （别人可用 party wake test @你 验证）。唤醒命令务必「续会话」而非冷起，session 上下文才不丢：
 #       Codex:  OUT=$(mktemp); codex exec resume --last --skip-git-repo-check -o "$OUT" "$(cat {file})" || codex exec --skip-git-repo-check -o "$OUT" "$(cat {file})"; party send - --channel "$AP_CHANNEL" --reply-to "$AP_REPLY_TO" < "$OUT"
-#       Claude: claude -p -c "$(cat {file})" || claude -p "$(cat {file})"
+#       Claude: OUT=$(mktemp); claude -p -c "$(cat {file})" > "$OUT" 2>&1 || claude -p "$(cat {file})" > "$OUT" 2>&1; party send - --channel "$AP_CHANNEL" --reply-to "$AP_REPLY_TO" < "$OUT"; rm -f "$OUT"
+#     ⚠ 两个示例都必须把输出捞回来再 party send，这不是可选项（#821）：headless 的 claude -p /
+#       codex exec 只把答案打到 stdout 就结束，**它们不会往频道发任何东西**。runner 正常退出但频道
+#       没有回复 → serve 判定 wake undelivered，连续 3 条就熔断退出，而你不会收到任何通知——
+#       协作方看到的只是「这个人不回话」，进而可能直接接管你的活。
 #     ⚠ 子 agent 的沙箱常常断网（Codex 实测：模型答了但 party send 静默失败，频道只剩 ack）
 #       ——别让子进程自己发频道，让它只产出回复文本（-o 落盘），由外层（可联网的 serve 环境）
 #       party send 发回，如上例。给 runner 固定专用工作目录（resume/-c 按目录找会话，混用会捞错）。

--- a/cli/src/commands/invite.ts
+++ b/cli/src/commands/invite.ts
@@ -287,7 +287,9 @@ claude mcp add ${mcpServerName(guestName)} --env AGENTPARTY_CONFIG="\$HOME/.agen
 #     常驻 supervisor 替你等、被 @ 才拉起你一次，等待零 token；挂上即自动声明「可被唤醒」
 #     （别人可用 party wake test @你 验证）。唤醒命令务必「续会话」而非冷起，session 上下文才不丢：
 #       Codex:  OUT=$(mktemp); codex exec resume --last --skip-git-repo-check -o "$OUT" "$(cat {file})" || codex exec --skip-git-repo-check -o "$OUT" "$(cat {file})"; party send - --channel "$AP_CHANNEL" --reply-to "$AP_REPLY_TO" < "$OUT"
-#       Claude: OUT=$(mktemp); claude -p -c "$(cat {file})" > "$OUT" 2>&1 || claude -p "$(cat {file})" > "$OUT" 2>&1; party send - --channel "$AP_CHANNEL" --reply-to "$AP_REPLY_TO" < "$OUT"; rm -f "$OUT"
+#       Claude: OUT=$(mktemp); trap 'rm -f "$OUT"' EXIT; claude -p -c "$(cat {file})" > "$OUT" 2>&1 || claude -p "$(cat {file})" > "$OUT" 2>&1; party send - --channel "$AP_CHANNEL" --reply-to "$AP_REPLY_TO" < "$OUT"
+#         （收尾用 trap，别把 rm -f 直接串在末尾：那样最后退出码是 rm 的 0，party send 因断网/失效 token
+#          失败也会被 serve 当成送达成功，欠账被清掉而频道里根本没有回复——静默丢 wake。）
 #     ⚠ 两个示例都必须把输出捞回来再 party send，这不是可选项（#821）：headless 的 claude -p /
 #       codex exec 只把答案打到 stdout 就结束，**它们不会往频道发任何东西**。runner 正常退出但频道
 #       没有回复 → serve 判定 wake undelivered，连续 3 条就熔断退出，而你不会收到任何通知——

--- a/cli/src/commands/mcp.ts
+++ b/cli/src/commands/mcp.ts
@@ -893,6 +893,11 @@ export function createMcpServer(defaultChannel?: string): McpServer {
         if (assignee !== undefined && assignee_name !== undefined && assignee.replace(/^@/, "") !== assignee_name.replace(/^@/, "")) {
           throw new Error(`assignee and assignee_name disagree: ${assignee} vs ${assignee_name} — pass only one`);
         }
+        // 光给 assignee_kind 不给名字，normalizeAssignee 会返回 undefined——任务照建，但没人被指派，
+        // 而调用方明明表达了指派意图。这正是本 issue 要消灭的那类静默丢弃，别在修它的时候留一个同款。
+        if (assignee_kind !== undefined && assignee === undefined && assignee_name === undefined) {
+          throw new Error("assignee_kind needs an assignee: pass assignee (or assignee_name) too");
+        }
         const resolvedAssignee = normalizeAssignee(assignee ?? assignee_name, assignee_kind as TaskAssigneeKind | undefined);
         const task = await createTask(cfg.server, cfg.token, resolved, {
           title,

--- a/cli/src/commands/mcp.ts
+++ b/cli/src/commands/mcp.ts
@@ -1130,9 +1130,21 @@ export function createMcpServer(defaultChannel?: string): McpServer {
     {
       title: "Wait for one matching mention",
       description:
-        "Actively wait until the next matching message arrives, then return its structured frame. The tool call must remain in flight; MCP notifications do not wake an idle model turn.",
+        "Actively wait until the next matching message arrives, then return its structured frame. The tool call must remain in flight; MCP notifications do not wake an idle model turn. " +
+        "An un-acked wake REPLAYS and holds newer messages behind it until cleared — pass ack_replay:true to clear a replayed wake as you receive it (#826).",
       inputSchema: {
         channel: z.string().optional(),
+        // #826：未 ack 的 delivery 会一直重投并把新消息挡在后面。默认不自动 ack——那道债正是
+        // 「被唤醒但没回」的durability 保证（#198：误清 = 静默丢 @）。但纯读场景（收到的是别人的
+        // status/自动回执）不该为此空转，给一个显式开关，让调用方自己承担这次的语义。
+        ack_replay: z
+          .boolean()
+          .optional()
+          .describe(
+            "When this call returns a REPLAYED wake, clear its debt immediately instead of leaving it to replay again. " +
+              "Default false (the debt survives until you ack or reply, so a crashed turn does not lose the @). " +
+              "Set true when you are polling and would otherwise be starved by a wake that needs no reply.",
+          ),
         // #827：上限只存在于校验里，调用方得撞一次才知道。校验规则本身就是契约，没理由只在失败时才讲。
         timeout_sec: z
           .number()
@@ -1144,7 +1156,7 @@ export function createMcpServer(defaultChannel?: string): McpServer {
         mentions_only: z.boolean().optional(),
       },
     },
-    async ({ channel, timeout_sec, mentions_only }) => {
+    async ({ channel, timeout_sec, mentions_only, ack_replay }) => {
       try {
         const cfg = await auth();
         const resolved = normalizeChannel(channel, defaultChannel);
@@ -1197,14 +1209,37 @@ export function createMcpServer(defaultChannel?: string): McpServer {
             lag: Math.max(0, channelLastSeq - pending.seq),
             skipped_mention_seqs: stuck.skipped_mention_seqs ?? [],
           });
+          const held = Math.max(0, channelLastSeq - pending.seq);
+          // #826：`pending_ack: true` 对不知道机制的调用方等于没说。实测代价是每次 600s 超时、
+          // 两轮 20 分钟全花在重复接收同一条上，而那段时间频道有 7 条新消息进不来——被卡住的
+          // 那条还恰好是零信息量的自动回执。把「必须 ack 才能前进」和确切要跑的命令写进返回里。
+          const ackHint =
+            `this is replay attempt ${replay.attempts} of seq=${pending.seq}; it will keep coming back, and ` +
+            `${held > 0 ? `${held} newer message(s) stay held` : "newer messages stay held"} until you clear it. ` +
+            `Clear it with party_ack({ seq: ${pending.seq} }) — party_ack takes seq, not delivery_id — ` +
+            "or reply to it with party_send({ reply_to: " +
+            String(pending.seq) +
+            " }); replying clears it too.";
           // 唤醒返回帧＝一轮的起点：旧进程/旧版的升级提示在这里最可能被看见并转达 owner（#588）。
           // probe:false——唤醒路径零额外网络（磁盘检测 + whoami 已填充的缓存）。
           const replayUpgrade = await mcpUpgradeNotice(cfg.server, {}, { probe: false });
+          // #826：显式要求随收随清时，走与 party_ack 完全相同的原子 compare-and-clear——
+          // 它自带 serve-owned 拒清保护（#198 红线），绝不在这里另写一条清账路径。
+          let acked = false;
+          if (ack_replay === true) {
+            const outcome = ackWatchStuck(resolved, pending.seq);
+            // cleared = 本次清掉；acknowledged_prior = 已经被更晚的动作清过。两者都代表「不再欠」。
+            // serve_owned / seq_mismatch / none 一律不算清掉——保持 hint，别谎报已解决。
+            acked = outcome.outcome === "cleared" || outcome.outcome === "acknowledged_prior";
+          }
           return ok({
             type: "watch_once",
             channel: resolved,
             exit_code: 0,
             frames: [frame],
+            // 这两个字段是给「不知道 ack 机制」的调用方看的：卡住的代价（held_messages）和确切的出路（hint）。
+            ...(acked ? { acked: true } : { pending_ack_hint: ackHint }),
+            held_messages: held,
             ...(replayUpgrade !== null ? { cli_upgrade: replayUpgrade } : {}),
           });
         }

--- a/cli/src/commands/mcp.ts
+++ b/cli/src/commands/mcp.ts
@@ -587,11 +587,17 @@ export function createMcpServer(defaultChannel?: string): McpServer {
   server.registerTool(
     "party_status",
     {
-      title: "Post status",
-      description: "Post a structured AgentParty status frame.",
+      title: "Post status (WRITE — this sets your status, it does not read it)",
+      // #827：名字读起来像 getter，实际是 setter。无参调用只会撞上「state 必填」，错误信息不指路，
+      // agent 得白试一轮才知道读要用 party_who。把「这是写接口、读去哪」放进标题和描述最前面。
+      description:
+        "SET your own status in the channel (a write). To READ anyone's status — including your own — use party_who instead. " +
+        "Posts a structured AgentParty status frame.",
       inputSchema: {
         channel: z.string().optional(),
-        state: StateSchema,
+        state: StateSchema.describe(
+          "Required. The status you are SETTING (this tool is a setter). To read status, call party_who.",
+        ),
         note: z.string().optional(),
         mentions: z.array(z.string()).optional(),
         scope: z.array(z.string()).optional(),
@@ -845,38 +851,54 @@ export function createMcpServer(defaultChannel?: string): McpServer {
     "party_task_create",
     {
       title: "Create channel task",
-      description: "Create an AgentParty channel task.",
-      inputSchema: {
-        channel: z.string().optional(),
-        title: z.string().min(1),
-        desc: z.string().optional(),
-        state: TaskStateSchema.optional(),
-        assignee_name: z.string().optional().describe("Assignee name, with or without @ prefix."),
-        assignee_kind: TaskAssigneeKindSchema.optional(),
-        priority: z.number().int().min(-100).max(100).optional(),
-        labels: z.array(z.string()).optional(),
-        parent_id: z.number().int().positive().optional(),
-        anchor_seqs: z.array(z.number().int().positive()).optional(),
-        workflow_id: z.string().optional(),
-        external_ref: z
-          .string()
-          .optional()
-          .describe(
-            "Idempotency key (e.g. gh:owner/repo#96). Creating with a ref that already exists in the channel returns the existing task instead of a duplicate — safe to rerun an issue→task sync (#141).",
-          ),
-      },
+      description:
+        "Create an AgentParty channel task. The task body goes in `desc` (NOT `body`) and the owner in `assignee` or `assignee_name`. " +
+        "Unknown fields are rejected rather than dropped (#824) — a task whose spec silently vanished is worse than a failed call.",
+      // #824：未知字段此前被 zod 静默剥掉——调用方传 body/assignee 拿到 200 和一个看起来正常的回执，
+      // 落库却是只有标题的空壳。写任务的 agent 不会回头核对，读任务的 agent 不知道原本有内容，
+      // 于是「任务系统存在的意义（不用翻聊天记录）」当场失效。strict：宁可报错也不要静默丢规格。
+      inputSchema: z
+        .object({
+          channel: z.string().optional(),
+          title: z.string().min(1),
+          desc: z.string().optional().describe("Task body / spec. This is the field that holds the content — not `body`."),
+          state: TaskStateSchema.optional(),
+          assignee: z
+            .string()
+            .optional()
+            .describe("Assignee name as a plain string, with or without @ prefix. Equivalent to assignee_name."),
+          assignee_name: z.string().optional().describe("Assignee name, with or without @ prefix."),
+          assignee_kind: TaskAssigneeKindSchema.optional(),
+          priority: z.number().int().min(-100).max(100).optional(),
+          labels: z.array(z.string()).optional(),
+          parent_id: z.number().int().positive().optional(),
+          anchor_seqs: z.array(z.number().int().positive()).optional(),
+          workflow_id: z.string().optional(),
+          external_ref: z
+            .string()
+            .optional()
+            .describe(
+              "Idempotency key (e.g. gh:owner/repo#96). Creating with a ref that already exists in the channel returns the existing task instead of a duplicate — safe to rerun an issue→task sync (#141).",
+            ),
+        })
+        .strict(),
     },
-    async ({ channel, title, desc, state, assignee_name, assignee_kind, priority, labels, parent_id, anchor_seqs, workflow_id, external_ref }) => {
+    async ({ channel, title, desc, state, assignee, assignee_name, assignee_kind, priority, labels, parent_id, anchor_seqs, workflow_id, external_ref }) => {
       try {
         const cfg = await auth();
         const resolved = normalizeChannel(channel, defaultChannel);
         const normalizedLabels = normalizeLabels(labels);
-        const assignee = normalizeAssignee(assignee_name, assignee_kind as TaskAssigneeKind | undefined);
+        // #824：assignee（纯字符串）是调用方最自然的写法；只认 assignee_name 等于把内部结构泄露给调用方。
+        // 两个都给且不一致时报错，而不是挑一个——猜错的代价是任务派给了错的人。
+        if (assignee !== undefined && assignee_name !== undefined && assignee.replace(/^@/, "") !== assignee_name.replace(/^@/, "")) {
+          throw new Error(`assignee and assignee_name disagree: ${assignee} vs ${assignee_name} — pass only one`);
+        }
+        const resolvedAssignee = normalizeAssignee(assignee ?? assignee_name, assignee_kind as TaskAssigneeKind | undefined);
         const task = await createTask(cfg.server, cfg.token, resolved, {
           title,
           ...(desc !== undefined ? { desc } : {}),
           ...(state !== undefined ? { state: state as TaskState } : {}),
-          ...(assignee !== undefined ? { assignee } : {}),
+          ...(resolvedAssignee !== undefined ? { assignee: resolvedAssignee } : {}),
           ...(priority !== undefined ? { priority } : {}),
           ...(normalizedLabels !== undefined && normalizedLabels.length > 0 ? { labels: normalizedLabels } : {}),
           ...(parent_id !== undefined ? { parent_id } : {}),
@@ -1073,9 +1095,14 @@ export function createMcpServer(defaultChannel?: string): McpServer {
     "party_spawn_worker",
     {
       title: "Spawn worker agent",
-      description: "Create a short-lived channel-scoped worker identity for a front agent to delegate work.",
+      // #827：这个工具只铸身份，不启动任何进程。之前描述没说清，加上 spawn 后频道零痕迹，
+      // 调用方无法区分「worker 没起来 / 起来了没干活 / 干完了没汇报」——比 worker 本身失败更麻烦。
+      description:
+        "Mint a short-lived channel-scoped worker IDENTITY (token + lineage) for a front agent to delegate work. " +
+        "It does NOT start a process — nothing runs, and nothing appears in the channel, until you launch something with the returned token. " +
+        "If you need the channel to see the worker, have the launched process check in (party_status) itself.",
       inputSchema: {
-        name: z.string().describe("Worker agent name."),
+        name: z.string().describe("REQUIRED. Worker agent name (a valid AgentParty name: [a-zA-Z0-9][a-zA-Z0-9._-]{0,63})."),
         channel: z.string().optional().describe("Channel slug for the worker scope. Defaults to the MCP server channel."),
         ttl_sec: z.number().int().positive().optional().describe("Optional worker lifetime in seconds."),
         team_id: z.string().optional().describe("Optional lineage team id for grouping the worker with the front agent."),
@@ -1106,7 +1133,14 @@ export function createMcpServer(defaultChannel?: string): McpServer {
         "Actively wait until the next matching message arrives, then return its structured frame. The tool call must remain in flight; MCP notifications do not wake an idle model turn.",
       inputSchema: {
         channel: z.string().optional(),
-        timeout_sec: z.number().int().positive().max(600).optional(),
+        // #827：上限只存在于校验里，调用方得撞一次才知道。校验规则本身就是契约，没理由只在失败时才讲。
+        timeout_sec: z
+          .number()
+          .int()
+          .positive()
+          .max(600)
+          .optional()
+          .describe("Seconds to wait, 1–600 (max 600). Default 240."),
         mentions_only: z.boolean().optional(),
       },
     },

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -5816,6 +5816,16 @@ export async function runServe(o: ServeOptions): Promise<number> {
                 last_error: sanitizeBlockedError(lastError).slice(0, 160),
               };
               out(`  ${lastError}: seq=${frame.seq}`);
+              // #821：这句只陈述事实，不说该怎么办。最常见的成因是 runner 根本没把输出发回频道
+              // （headless `claude -p` / `codex exec` 只打到 stdout 就结束），而它连续三次就熔断
+              // 退出——本人不会收到通知，协作方只看到「这个人不回话」，进而可能直接接管你的活。
+              // 第一次就把成因和改法说清楚，别等熔断了才让人回头查。
+              out(
+                "  提示：runner 必须自己把回复发回频道。headless CLI（claude -p / codex exec）只把答案打到 " +
+                  "stdout，不会发频道——把输出捞回来再发：" +
+                  'OUT=$(mktemp); <runner> > "$OUT" 2>&1; party send - --channel "$AP_CHANNEL" --reply-to "$AP_REPLY_TO" < "$OUT"' +
+                  `（连续 ${MAX_CONSECUTIVE_WAKE_ABANDONS} 次放弃就会熔断退出）`,
+              );
               // The first completion probe already made `failed` authoritative in the Worker.
               // Clean exact local continuation state now; a disconnect before the redundant
               // blocked-state receipt below must not leave a terminal work capability on disk.

--- a/cli/src/commands/who.ts
+++ b/cli/src/commands/who.ts
@@ -484,7 +484,7 @@ export async function run(argv: string[]): Promise<number> {
           typeof r.resume_at === "number"
             ? ` · resumes in ${humanAge(Math.max(0, r.resume_at - now))}`
             : " · resume manually";
-        console.log(`⏸ ${"paused".padEnd(8)} ${r.name}  [${r.kind}]${identityNote(r)}${resume}${unhandledMentionNote(r)}${read}${duplicate}`);
+        console.log(`⏸ ${"paused".padEnd(8)} ${r.name}  [${r.kind}]${identityNote(r)}${resume}${unhandledMentionNote(r)}${scopeNote(r)}${read}${duplicate}`);
         continue;
       }
       // #191：可唤醒行明确标出「已验证 / 未验证」——verified＝服务端确认过（webhook，或观测到被 @ 后 resume），

--- a/cli/src/commands/who.ts
+++ b/cli/src/commands/who.ts
@@ -6,6 +6,7 @@ import { resolveChannel } from "../config";
 import { resolveAuth } from "../oidc-cli";
 import { fetchPresence, fetchReadCursors, handleRestError } from "../rest";
 import { localStatuslineBase, unreadFromCursor, writeStatuslineCache } from "../statusline-cache";
+import { sanitizeSingleLine } from "../format";
 import { isSlug } from "../validation";
 
 const WHO_FLAGS = ["channel", "json"];
@@ -42,6 +43,12 @@ answered by a resident runner in a SEPARATE per-channel session — it does not
 inherit that person's open conversation, so it does not know what they did today
 or which of their conclusions have since been overturned. Weigh its replies
 accordingly, and read the same tag on individual messages in party history.
+A "🔒 repo:foo,repo:bar" note is what that agent has CLAIMED it is touching right
+now (declare yours with: party status working --scope repo:foo). A "⚠" on a scope
+plus "(also held by X)" means someone else claimed the same thing — nothing is
+blocked, but you now know before you edit, instead of finding out from the diff.
+Channel charter describes long-term ownership; scope describes who is touching
+what at this moment. They are different questions.
 Then bring one in: party send "@name …" --mention name
 A human is @-notified by their handle (their web client matches on handle, not the
 session name), so mention the "@handle" shown here — not a UUID session name.
@@ -49,7 +56,7 @@ session name), so mention the "@handle" shown here — not a UUID session name.
 Options:
   --channel C   read channel C instead of the bound channel
   --json        emit one JSON object per line
-                (name/kind/tier/unreachable/wake/wake_unverified/busy/queue_depth/waiting_owner_count/unhandled_mention_count/oldest_unhandled_mention_seq/pending_mention_seqs/current_task/task_started_at/heartbeat_at/activity/listening/runner_health/agent_session/reception_mode/reception_runner/reception_context/account/handle/display_name/age_ms/read_seq)`;
+                (name/kind/tier/unreachable/wake/wake_unverified/busy/queue_depth/waiting_owner_count/unhandled_mention_count/oldest_unhandled_mention_seq/pending_mention_seqs/current_task/task_started_at/heartbeat_at/activity/listening/runner_health/agent_session/reception_mode/reception_runner/reception_context/scope/scope_conflicts/account/handle/display_name/age_ms/read_seq)`;
 
 const STALE_MS = 60_000; // 与 DO presence 扫描一致
 const DEAD_MS = 14 * 24 * 60 * 60 * 1000; // 14 天没露面视为幽灵，不再列
@@ -115,6 +122,12 @@ interface Row {
   reception_mode?: ReceptionMode;
   reception_runner?: ReceptionRunner;
   reception_context?: ReceptionContextBoundary;
+  // #823：「此刻谁在动什么」。scope 早就在 status frame 里（party status --scope 也一直能传），
+  // 只是从没被读出来过——于是频道没有承载「所有权」的地方，越界只能靠自觉。charter 说的是长期
+  // 职责，冲突发生在「此刻谁在改哪个仓库」这个粒度上，两者必须分开。
+  scope?: string[];
+  // 同一个 scope 被别人也占着。不阻止（agent 之间本来就靠自觉），只让它看得见。
+  scope_conflicts?: { scope: string; with: string[] }[];
 }
 
 // kind 已知取 kind；旧 presence 行没回填时 UUID 名判 human（网页登录会话），其余判 agent。
@@ -195,6 +208,10 @@ export function classify(e: PresenceEntry, now: number): Row | null {
     // 探活分级（#603）：服务端只对有活连接的身份下发 listening；runner_health 独立于任务生命周期。
     ...(e.listening === "suspect" || e.listening === "deaf" ? { listening: e.listening } : {}),
     ...(e.runner_health === undefined ? {} : { runner_health: e.runner_health }),
+    // #823：scope 只在 state != offline 时有意义——已经离线的人不再占着任何东西。
+    ...(Array.isArray(e.status?.scope) && e.status.scope.length > 0 && e.state !== "offline"
+      ? { scope: e.status.scope }
+      : {}),
     ...(e.agent_session === undefined ? {} : { agent_session: e.agent_session }),
     // #817：接待模式（status.context 里一直有，只是 who 的可读输出从不显示）。原样带出，缺失省略。
     ...(e.status?.context?.reception_mode === undefined ? {} : { reception_mode: e.status.context.reception_mode }),
@@ -346,6 +363,37 @@ export function receptionNote(r: Row): string {
   return ` · 🤖 reception ${r.reception_mode}${runner}${boundary}`;
 }
 
+// #823：把「此刻谁在动什么」标出来，并在两个人声明同一个 scope 时提示。不阻止——agent 之间本来
+// 就靠自觉，而且合法的并行编辑确实存在；但「有人已经在这上面了」这件事必须看得见，否则唯一的
+// 协调手段就是双方都能正确判断对方状态，而那个前提本身不成立（见 #825）。
+export function annotateScopeConflicts(rows: Row[]): Row[] {
+  const holders = new Map<string, string[]>();
+  for (const row of rows) {
+    for (const scope of row.scope ?? []) {
+      holders.set(scope, [...(holders.get(scope) ?? []), row.name]);
+    }
+  }
+  return rows.map((row) => {
+    const conflicts = (row.scope ?? [])
+      .map((scope) => ({ scope, with: (holders.get(scope) ?? []).filter((name) => name !== row.name) }))
+      .filter((entry) => entry.with.length > 0);
+    return conflicts.length > 0 ? { ...row, scope_conflicts: conflicts } : row;
+  });
+}
+
+export function scopeNote(r: Row): string {
+  if (r.scope === undefined || r.scope.length === 0) return "";
+  const conflicted = new Set((r.scope_conflicts ?? []).map((entry) => entry.scope));
+  const rendered = r.scope
+    .map((scope) => (conflicted.has(scope) ? `${sanitizeSingleLine(scope)}⚠` : sanitizeSingleLine(scope)))
+    .join(",");
+  const who =
+    r.scope_conflicts && r.scope_conflicts.length > 0
+      ? ` (also held by ${[...new Set(r.scope_conflicts.flatMap((entry) => entry.with))].join(", ")})`
+      : "";
+  return ` · 🔒 ${rendered}${who}`;
+}
+
 export function sessionNote(r: Row): string {
   const session = r.agent_session;
   if (session === undefined) return "";
@@ -413,11 +461,12 @@ export async function run(argv: string[]): Promise<number> {
       ...(lastSeq > 0 ? { unread: unreadFromCursor(lastSeq, channel) } : {}),
     });
     const now = Date.now();
-    const rows = presence
-      .map((e) => classify(e, now))
-      .filter((r): r is Row => r !== null)
-      .map((r) => ({ ...r, read_seq: cursorOf.get(r.name) }))
-      .sort((a, b) => RANK[a.tier] - RANK[b.tier] || a.name.localeCompare(b.name));
+    const rows = annotateScopeConflicts(
+      presence
+        .map((e) => classify(e, now))
+        .filter((r): r is Row => r !== null)
+        .map((r) => ({ ...r, read_seq: cursorOf.get(r.name) })),
+    ).sort((a, b) => RANK[a.tier] - RANK[b.tier] || a.name.localeCompare(b.name));
     if (flags.json === true) {
       for (const r of rows) console.log(JSON.stringify(r));
       return 0;
@@ -447,7 +496,7 @@ export async function run(argv: string[]): Promise<number> {
       const age = r.tier === "online" ? "" : ` (${humanAge(r.age_ms)})`;
       // #664：recent 档里真·不可达的（无活 wake 通道 + 陈旧）单独标出，别和「最近露面、或许在轮询」混淆。
       const unreach = r.unreachable === true ? " · ⚠ unreachable (mention lands in history only)" : "";
-      console.log(`${DOT[r.tier]} ${r.tier.padEnd(8)} ${r.name}  [${r.kind}]${identityNote(r)}${busyNote(r)}${waitingOwnerNote(r)}${unhandledMentionNote(r)}${taskNote(r, now)}${activityNote(r, now)}${livenessNote(r)}${receptionNote(r)}${sessionNote(r)}${wake}${unreach}${read}${duplicate}${age}`);
+      console.log(`${DOT[r.tier]} ${r.tier.padEnd(8)} ${r.name}  [${r.kind}]${identityNote(r)}${busyNote(r)}${waitingOwnerNote(r)}${unhandledMentionNote(r)}${scopeNote(r)}${taskNote(r, now)}${activityNote(r, now)}${livenessNote(r)}${receptionNote(r)}${sessionNote(r)}${wake}${unreach}${read}${duplicate}${age}`);
     }
     return 0;
   } catch (e) {

--- a/cli/test/__snapshots__/m3.test.ts.snap
+++ b/cli/test/__snapshots__/m3.test.ts.snap
@@ -69,7 +69,11 @@ claude mcp add party-fix-login-bug-guest --env AGENTPARTY_CONFIG="$HOME/.agentpa
 #     常驻 supervisor 替你等、被 @ 才拉起你一次，等待零 token；挂上即自动声明「可被唤醒」
 #     （别人可用 party wake test @你 验证）。唤醒命令务必「续会话」而非冷起，session 上下文才不丢：
 #       Codex:  OUT=$(mktemp); codex exec resume --last --skip-git-repo-check -o "$OUT" "$(cat {file})" || codex exec --skip-git-repo-check -o "$OUT" "$(cat {file})"; party send - --channel "$AP_CHANNEL" --reply-to "$AP_REPLY_TO" < "$OUT"
-#       Claude: claude -p -c "$(cat {file})" || claude -p "$(cat {file})"
+#       Claude: OUT=$(mktemp); claude -p -c "$(cat {file})" > "$OUT" 2>&1 || claude -p "$(cat {file})" > "$OUT" 2>&1; party send - --channel "$AP_CHANNEL" --reply-to "$AP_REPLY_TO" < "$OUT"; rm -f "$OUT"
+#     ⚠ 两个示例都必须把输出捞回来再 party send，这不是可选项（#821）：headless 的 claude -p /
+#       codex exec 只把答案打到 stdout 就结束，**它们不会往频道发任何东西**。runner 正常退出但频道
+#       没有回复 → serve 判定 wake undelivered，连续 3 条就熔断退出，而你不会收到任何通知——
+#       协作方看到的只是「这个人不回话」，进而可能直接接管你的活。
 #     ⚠ 子 agent 的沙箱常常断网（Codex 实测：模型答了但 party send 静默失败，频道只剩 ack）
 #       ——别让子进程自己发频道，让它只产出回复文本（-o 落盘），由外层（可联网的 serve 环境）
 #       party send 发回，如上例。给 runner 固定专用工作目录（resume/-c 按目录找会话，混用会捞错）。

--- a/cli/test/__snapshots__/m3.test.ts.snap
+++ b/cli/test/__snapshots__/m3.test.ts.snap
@@ -69,7 +69,9 @@ claude mcp add party-fix-login-bug-guest --env AGENTPARTY_CONFIG="$HOME/.agentpa
 #     常驻 supervisor 替你等、被 @ 才拉起你一次，等待零 token；挂上即自动声明「可被唤醒」
 #     （别人可用 party wake test @你 验证）。唤醒命令务必「续会话」而非冷起，session 上下文才不丢：
 #       Codex:  OUT=$(mktemp); codex exec resume --last --skip-git-repo-check -o "$OUT" "$(cat {file})" || codex exec --skip-git-repo-check -o "$OUT" "$(cat {file})"; party send - --channel "$AP_CHANNEL" --reply-to "$AP_REPLY_TO" < "$OUT"
-#       Claude: OUT=$(mktemp); claude -p -c "$(cat {file})" > "$OUT" 2>&1 || claude -p "$(cat {file})" > "$OUT" 2>&1; party send - --channel "$AP_CHANNEL" --reply-to "$AP_REPLY_TO" < "$OUT"; rm -f "$OUT"
+#       Claude: OUT=$(mktemp); trap 'rm -f "$OUT"' EXIT; claude -p -c "$(cat {file})" > "$OUT" 2>&1 || claude -p "$(cat {file})" > "$OUT" 2>&1; party send - --channel "$AP_CHANNEL" --reply-to "$AP_REPLY_TO" < "$OUT"
+#         （收尾用 trap，别把 rm -f 直接串在末尾：那样最后退出码是 rm 的 0，party send 因断网/失效 token
+#          失败也会被 serve 当成送达成功，欠账被清掉而频道里根本没有回复——静默丢 wake。）
 #     ⚠ 两个示例都必须把输出捞回来再 party send，这不是可选项（#821）：headless 的 claude -p /
 #       codex exec 只把答案打到 stdout 就结束，**它们不会往频道发任何东西**。runner 正常退出但频道
 #       没有回复 → serve 判定 wake undelivered，连续 3 条就熔断退出，而你不会收到任何通知——

--- a/cli/test/mcp-task-create-strict.test.ts
+++ b/cli/test/mcp-task-create-strict.test.ts
@@ -1,0 +1,137 @@
+// #824：party_task_create 传 body/assignee 时静默丢弃，返回 200 和一个看起来正常的回执，落库却是
+// 只有标题的空壳。写任务的 agent 不会回头核对落库结果，读任务的 agent 不知道原本有内容——于是
+// 「任务系统存在的意义（接手方不用回去翻聊天记录）」当场失效，而且要等接手方来问才发现。
+// 宁可报错也不要静默丢规格。
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const indexPath = join(import.meta.dir, "..", "src", "index.ts");
+
+describe("party_task_create 不再静默丢字段", () => {
+  let home: string;
+  let restServer: ReturnType<typeof Bun.serve> | null = null;
+  let lastCreateBody: Record<string, unknown> | null = null;
+
+  function startRest(): void {
+    restServer = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      async fetch(req) {
+        const url = new URL(req.url);
+        if (url.pathname === "/api/me") {
+          return Response.json({ name: "me", email: null, kind: "agent", role: "member", owner: null });
+        }
+        if (url.pathname.endsWith("/tasks") && req.method === "POST") {
+          lastCreateBody = (await req.json()) as Record<string, unknown>;
+          return Response.json({
+            task: { id: 204, title: lastCreateBody.title, desc: lastCreateBody.desc ?? null, assignee: lastCreateBody.assignee ?? null, state: "triage" },
+          });
+        }
+        return Response.json({ error: { code: "not_found", message: "not found" } }, { status: 404 });
+      },
+    });
+    mkdirSync(home, { recursive: true });
+    writeFileSync(
+      join(home, "config.json"),
+      JSON.stringify({ server: `http://127.0.0.1:${restServer.port}`, token: "ap_tok" }),
+    );
+  }
+
+  async function connect(): Promise<Client> {
+    const env: Record<string, string> = {};
+    for (const [k, v] of Object.entries(process.env)) {
+      if (v !== undefined && k !== "AGENTPARTY_CONFIG") env[k] = v;
+    }
+    env.AGENTPARTY_HOME = home;
+    const transport = new StdioClientTransport({
+      command: "bun",
+      args: ["run", indexPath, "mcp", "--channel", "welcome"],
+      env,
+      stderr: "pipe",
+    });
+    const client = new Client({ name: "agentparty-test", version: "1.0.0" });
+    await client.connect(transport);
+    return client;
+  }
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "ap-task-strict-"));
+    lastCreateBody = null;
+  });
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+    restServer?.stop(true);
+    restServer = null;
+  });
+
+  test("传 body（真实字段叫 desc）→ 报错，而不是建出一个空壳任务", async () => {
+    startRest();
+    const client = await connect();
+    try {
+      const r = await client
+        .callTool({ name: "party_task_create", arguments: { title: "收窄口径", body: "几百字规格，含验收判据" } })
+        .catch((e: unknown) => ({ isError: true, thrown: e instanceof Error ? e.message : String(e) }));
+      // 无论走 SDK 抛错还是 isError 回执，关键是：调用方知道了，且没有任务被建出来。
+      expect((r as { isError?: boolean }).isError).toBe(true);
+      expect(lastCreateBody).toBeNull();
+    } finally {
+      await client.close();
+    }
+  }, 20000);
+
+  test("传 desc → 内容真的落到请求体里", async () => {
+    startRest();
+    const client = await connect();
+    try {
+      const r = await client.callTool({
+        name: "party_task_create",
+        arguments: { title: "收窄口径", desc: "几百字规格，含验收判据" },
+      });
+      expect(r.isError).not.toBe(true);
+      expect(lastCreateBody?.desc).toBe("几百字规格，含验收判据");
+    } finally {
+      await client.close();
+    }
+  }, 20000);
+
+  test("assignee 收纯字符串（调用方最自然的写法），服务端拿到的是 {name, kind}", async () => {
+    startRest();
+    const client = await connect();
+    try {
+      const r = await client.callTool({
+        name: "party_task_create",
+        arguments: { title: "t", assignee: "leo-welcome-fable5" },
+      });
+      expect(r.isError).not.toBe(true);
+      expect(lastCreateBody?.assignee).toEqual({ name: "leo-welcome-fable5", kind: "agent" });
+    } finally {
+      await client.close();
+    }
+  }, 20000);
+
+  test("assignee 带 @ 前缀照收；与 assignee_name 冲突时报错而不是猜一个", async () => {
+    startRest();
+    const client = await connect();
+    try {
+      const ok = await client.callTool({ name: "party_task_create", arguments: { title: "t", assignee: "@bob" } });
+      expect(ok.isError).not.toBe(true);
+      expect(lastCreateBody?.assignee).toEqual({ name: "bob", kind: "agent" });
+
+      lastCreateBody = null;
+      const clash = await client.callTool({
+        name: "party_task_create",
+        arguments: { title: "t", assignee: "bob", assignee_name: "carol" },
+      });
+      expect(clash.isError).toBe(true);
+      // 派给错的人比报错贵得多——冲突时一个任务都不该被建出来。
+      expect(lastCreateBody).toBeNull();
+    } finally {
+      await client.close();
+    }
+  }, 20000);
+});

--- a/cli/test/who-scope.test.ts
+++ b/cli/test/who-scope.test.ts
@@ -1,0 +1,88 @@
+// #823：频道没有承载「此刻谁在动什么」的地方。charter 里的分工是长期职责，而冲突发生在
+// 「此刻谁在改哪个仓库」这个粒度上。实测事故：前端 agent 在后端 agent 看起来离线时接手改了后端
+// 仓库并推了分支——它做得很干净（独立 worktree、没合并、主动说明），但两边之间没有任何机制能让它
+// 在动手前知道「这个仓库有人正在改」。
+//
+// scope 字段其实一直在 status frame 里（party status --scope 也一直能传），只是从没被读出来过。
+import { describe, expect, test } from "bun:test";
+import type { PresenceEntry } from "@agentparty/shared";
+import { annotateScopeConflicts, classify, scopeNote } from "../src/commands/who";
+
+const NOW = 1_786_000_000_000;
+
+function presence(name: string, scope: string[], state: PresenceEntry["state"] = "working"): PresenceEntry {
+  return {
+    name,
+    kind: "agent",
+    state,
+    note: null,
+    ts: NOW,
+    last_seen: NOW,
+    live: true,
+    status: { owner: name, state, scope, summary_seq: null, blocked_reason: null, updated_at: NOW },
+  } as unknown as PresenceEntry;
+}
+
+function rowsFor(entries: PresenceEntry[]) {
+  return annotateScopeConflicts(entries.map((e) => classify(e, NOW)).filter((r): r is NonNullable<typeof r> => r !== null));
+}
+
+describe("party who 显示 scope", () => {
+  test("声明了 scope 的 agent 带出 scope，并渲染成一眼可见的一行", () => {
+    const [row] = rowsFor([presence("backend", ["repo:tools/text-to-voice"])]);
+    expect(row!.scope).toEqual(["repo:tools/text-to-voice"]);
+    expect(scopeNote(row!)).toContain("🔒");
+    expect(scopeNote(row!)).toContain("repo:tools/text-to-voice");
+  });
+
+  test("没声明 scope 的不无中生有", () => {
+    const [row] = rowsFor([presence("backend", [])]);
+    expect(row!.scope).toBeUndefined();
+    expect(scopeNote(row!)).toBe("");
+  });
+
+  test("离线的人不再占着任何东西", () => {
+    const rows = rowsFor([presence("backend", ["repo:foo"], "offline")]);
+    // 离线 agent 仍会被列出（recent 档），但不该显示成还占着 scope。
+    for (const row of rows) expect(row.scope).toBeUndefined();
+  });
+});
+
+describe("scope 冲突提示", () => {
+  test("两个 agent 声明同一个 scope → 双方都标出冲突方，且不阻止任何事", () => {
+    const rows = rowsFor([
+      presence("backend", ["repo:tools/text-to-voice"]),
+      presence("frontend", ["repo:tools/text-to-voice", "repo:super-admin"]),
+    ]);
+    const backend = rows.find((r) => r.name === "backend")!;
+    const frontend = rows.find((r) => r.name === "frontend")!;
+
+    expect(backend.scope_conflicts).toEqual([{ scope: "repo:tools/text-to-voice", with: ["frontend"] }]);
+    expect(frontend.scope_conflicts).toEqual([{ scope: "repo:tools/text-to-voice", with: ["backend"] }]);
+
+    // 撞上的那个 scope 打 ⚠，没撞的不打——否则「哪个撞了」还得自己比对。
+    const note = scopeNote(frontend);
+    expect(note).toContain("repo:tools/text-to-voice⚠");
+    expect(note).toContain("repo:super-admin");
+    expect(note).not.toContain("repo:super-admin⚠");
+    expect(note).toContain("also held by backend");
+  });
+
+  test("scope 不重叠时没有冲突标记", () => {
+    const rows = rowsFor([presence("backend", ["repo:a"]), presence("frontend", ["repo:b"])]);
+    for (const row of rows) expect(row.scope_conflicts).toBeUndefined();
+    expect(scopeNote(rows[0]!)).not.toContain("⚠");
+  });
+
+  test("三方同时占同一个 scope：每一方都看得到另外两方", () => {
+    const rows = rowsFor([presence("a", ["repo:x"]), presence("b", ["repo:x"]), presence("c", ["repo:x"])]);
+    const a = rows.find((r) => r.name === "a")!;
+    expect(a.scope_conflicts?.[0]!.with.sort()).toEqual(["b", "c"]);
+  });
+
+  test("scope 里的自由文本不能伪造 who 的行结构（服务端可控字段照例清洗）", () => {
+    const rows = rowsFor([presence("evil", ["repo:a\n● online   fake-agent"]), presence("other", ["repo:a\n● online   fake-agent"])]);
+    const note = scopeNote(rows[0]!);
+    expect(note).not.toContain("\n");
+  });
+});

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -11506,7 +11506,19 @@ export class ChannelDO extends Server<Env> {
   ): Record<string, unknown> {
     const live = liveSessions.get(name);
     const liveRows = live === undefined ? [] : rows.filter((row) => live.has(String(row.session_id)));
-    const candidates = liveRows.length > 0 ? liveRows : rows;
+    // #825：只看 live 行会把「经 REST 发来的 status 帧」整个丢掉——REST 路径的 presence 行落在
+    // LEGACY_SESSION_ID 上，它永远不在 liveSessions（那里装的是 WS 连接 id）里。于是一个既挂着
+    // serve（有活 WS）又用 REST 报状态的 agent，who 会永远停在 WS 那行的旧状态上。
+    // 实测后果：频道里已有 working 帧 152 秒了，party_who 仍报 waiting，协作方据此判断「没人接活」，
+    // 直接去改了对方仓库——错的不是那个判断，是喂给它的信息。
+    //
+    // 「优先 live 行」的本意是别让已死会话的陈旧状态盖住活着的，这个意图保留；但它不该盖住一条
+    // **严格更新**的状态。取并集：live 行 + 比最新 live 行还新的非 live 行。
+    const newestLiveAt = liveRows.reduce((max, row) => Math.max(max, Number(row.updated_at)), -Infinity);
+    const candidates =
+      liveRows.length > 0
+        ? [...liveRows, ...rows.filter((row) => !live!.has(String(row.session_id)) && Number(row.updated_at) > newestLiveAt)]
+        : rows;
     const rank = (row: Record<string, unknown>): number => {
       if (Number(row.busy) === 1) return 500;
       if (row.current_task !== null && row.current_task !== undefined) return 450;

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -11513,12 +11513,7 @@ export class ChannelDO extends Server<Env> {
     // 直接去改了对方仓库——错的不是那个判断，是喂给它的信息。
     //
     // 「优先 live 行」的本意是别让已死会话的陈旧状态盖住活着的，这个意图保留；但它不该盖住一条
-    // **严格更新**的状态。取并集：live 行 + 比最新 live 行还新的非 live 行。
-    const newestLiveAt = liveRows.reduce((max, row) => Math.max(max, Number(row.updated_at)), -Infinity);
-    const candidates =
-      liveRows.length > 0
-        ? [...liveRows, ...rows.filter((row) => !live!.has(String(row.session_id)) && Number(row.updated_at) > newestLiveAt)]
-        : rows;
+    // 更新的状态。
     const rank = (row: Record<string, unknown>): number => {
       if (Number(row.busy) === 1) return 500;
       if (row.current_task !== null && row.current_task !== undefined) return 450;
@@ -11528,6 +11523,26 @@ export class ChannelDO extends Server<Env> {
       if (row.state === "done") return 100;
       return 0;
     };
+    // 光把新的非 live 行并进候选集还不够：下面的挑选是 rank 优先，而 rank 里 working(400) 高于
+    // blocked(300)，于是「serve 正在 working 时熔断、经 REST 发 blocked」这个场景里，旧的 working
+    // 仍然会盖住新的 blocked——「serve 已经死了」照样不可见，正是 #821 要修的那件事。
+    // 所以：只要存在不比最新 live 行旧的非 live 行，就让**新鲜度先于 rank** 决定取哪条。
+    // 用 >= 而不是 >：updated_at 是毫秒，两次先后完成的写入可能落在同一毫秒里，严格大于会把后到的
+    // REST 状态排除掉。同毫秒时取 rank 高的作为稳定 tiebreak。
+    const newestLiveAt = liveRows.reduce((max, row) => Math.max(max, Number(row.updated_at)), -Infinity);
+    const fresherNonLive =
+      liveRows.length > 0
+        ? rows.filter((row) => !live!.has(String(row.session_id)) && Number(row.updated_at) >= newestLiveAt)
+        : [];
+    if (fresherNonLive.length > 0) {
+      return fresherNonLive.reduce((best, row) => {
+        const at = Number(row.updated_at);
+        const bestAt = Number(best.updated_at);
+        if (at !== bestAt) return at > bestAt ? row : best;
+        return rank(row) > rank(best) ? row : best;
+      });
+    }
+    const candidates = liveRows.length > 0 ? liveRows : rows;
     return candidates.reduce((best, row) => {
       const score = rank(row);
       const bestScore = rank(best);

--- a/worker/test/presence-rest-status-freshness.spec.ts
+++ b/worker/test/presence-rest-status-freshness.spec.ts
@@ -70,6 +70,37 @@ describe("#825 party_who 必须反映最新一次状态变更", () => {
     }
   });
 
+  // #821：serve 熔断退出前会经 REST 发一条 blocked 通告，但那一刻它的 WS 还开着——正是上面这个
+  // bug 会把它整个丢掉的时机。于是「serve 已经死了」这件事对本人和协作方都不可见，协作方只看到
+  // 一个 waiting 的人不回话，进而可能直接接管他的活。这条 case 单独钉住。
+  it("serve 熔断的 blocked 通告不被自己那条还活着的 WS 连接盖住", async () => {
+    const agent = await seedToken("agent");
+    const slug = await createChannel(agent.token);
+
+    const ws = await WsClient.open(slug, agent.token);
+    await completeCapabilityHello(ws);
+    ws.send({ type: "send", kind: "status", state: "waiting", note: "standby", mentions: [], wake: { kind: "serve" } });
+    await ws.nextOfType("sent");
+
+    try {
+      const note = "serve wake circuit breaker tripped: reason=consecutive_abandons; consecutive_abandons=3/3";
+      expect(
+        (
+          await api(`/api/channels/${slug}/messages`, agent.token, {
+            method: "POST",
+            body: JSON.stringify({ kind: "status", state: "blocked", note, mentions: [], blocked_reason: note }),
+          })
+        ).status,
+      ).toBe(200);
+
+      const entry = await presenceOf(slug, agent.token, agent.name);
+      expect(entry?.state).toBe("blocked");
+      expect(entry?.status?.blocked_reason).toContain("circuit breaker tripped");
+    } finally {
+      ws.close();
+    }
+  });
+
   it("没有活连接时行为不变：REST 状态照常反映", async () => {
     const agent = await seedToken("agent");
     const slug = await createChannel(agent.token);

--- a/worker/test/presence-rest-status-freshness.spec.ts
+++ b/worker/test/presence-rest-status-freshness.spec.ts
@@ -1,0 +1,82 @@
+// #825：party_who 报的状态可以比频道里已有的 status frame 还旧，而「对方到底在不在干活」是多 agent
+// 协作里唯一能决定「我是等还是自己上」的信号。实测后果不是理论风险：频道里 working 帧已存在 152 秒，
+// party_who 仍报 waiting，协作方据此判断「没人接活」，直接去改了对方仓库并推了分支——两边差点在同一个
+// 文件的同一个常量上撞车。错的不是那个判断，是喂给它的信息。
+//
+// 成因：REST 路径发出的 status 帧，presence 行落在 LEGACY_SESSION_ID 上；而 aggregatePresenceRow 在
+// 该 name 有任何活 WS 连接时，只从「活连接对应的行」里挑，非 live 行被整个丢弃。于是一个既挂着 serve
+// （有活 WS）又用 REST 报状态的 agent，who 永远停在 WS 那行的旧状态上。
+import { describe, expect, it } from "vitest";
+import type { PresenceEntry } from "@agentparty/shared";
+import { WsClient, api, completeCapabilityHello, createChannel, seedToken } from "./helpers";
+
+async function presenceOf(slug: string, token: string, name: string): Promise<PresenceEntry | undefined> {
+  const res = await api(`/api/channels/${slug}/presence`, token);
+  expect(res.status).toBe(200);
+  const { presence } = (await res.json()) as { presence: PresenceEntry[] };
+  return presence.find((p) => p.name === name);
+}
+
+function postStatus(slug: string, token: string, state: string, note: string) {
+  return api(`/api/channels/${slug}/messages`, token, {
+    method: "POST",
+    body: JSON.stringify({ kind: "status", state, note, mentions: [] }),
+  });
+}
+
+describe("#825 party_who 必须反映最新一次状态变更", () => {
+  it("挂着活 WS 的 agent 经 REST 报 working：who 报 working，而不是 WS 那行的旧 waiting", async () => {
+    const agent = await seedToken("agent");
+    const slug = await createChannel(agent.token);
+
+    // 1) agent 挂上 serve 那样的活 WS 连接，并在这条连接上报 waiting（standby）。
+    const ws = await WsClient.open(slug, agent.token);
+    await completeCapabilityHello(ws);
+    ws.send({ type: "send", kind: "status", state: "waiting", note: "standby", mentions: [], wake: { kind: "serve" } });
+    await ws.nextOfType("sent");
+    expect((await presenceOf(slug, agent.token, agent.name))?.state).toBe("waiting");
+
+    try {
+      // 2) runner 经 REST 报 working（serve 的 runner 就是这么发的）。
+      expect((await postStatus(slug, agent.token, "working", "runner started for seq 472")).status).toBe(200);
+
+      // 3) who 必须看到 working。修复前这里恒为 waiting——REST 那行落在 LEGACY_SESSION_ID 上被丢掉了。
+      const entry = await presenceOf(slug, agent.token, agent.name);
+      expect(entry?.state).toBe("working");
+      expect(entry?.note).toBe("runner started for seq 472");
+    } finally {
+      ws.close();
+    }
+  });
+
+  it("活连接自己的状态更新照常生效（没把「优先 live 行」的本意改坏）", async () => {
+    const agent = await seedToken("agent");
+    const slug = await createChannel(agent.token);
+    const ws = await WsClient.open(slug, agent.token);
+    await completeCapabilityHello(ws);
+
+    try {
+      ws.send({ type: "send", kind: "status", state: "waiting", note: "standby", mentions: [] });
+      await ws.nextOfType("sent");
+      expect((await presenceOf(slug, agent.token, agent.name))?.state).toBe("waiting");
+
+      ws.send({ type: "send", kind: "status", state: "working", note: "on it", mentions: [] });
+      await ws.nextOfType("sent");
+      const entry = await presenceOf(slug, agent.token, agent.name);
+      expect(entry?.state).toBe("working");
+      expect(entry?.note).toBe("on it");
+    } finally {
+      ws.close();
+    }
+  });
+
+  it("没有活连接时行为不变：REST 状态照常反映", async () => {
+    const agent = await seedToken("agent");
+    const slug = await createChannel(agent.token);
+
+    expect((await postStatus(slug, agent.token, "working", "no ws at all")).status).toBe(200);
+    const entry = await presenceOf(slug, agent.token, agent.name);
+    expect(entry?.state).toBe("working");
+    expect(entry?.note).toBe("no ws at all");
+  });
+});

--- a/worker/test/presence-rest-status-freshness.spec.ts
+++ b/worker/test/presence-rest-status-freshness.spec.ts
@@ -101,6 +101,53 @@ describe("#825 party_who 必须反映最新一次状态变更", () => {
     }
   });
 
+  // rank 里 working(400) 高于 blocked(300)，所以「正在 working 时熔断、经 REST 发 blocked」这条路径
+  // 光把新行并进候选集是不够的——旧的 working 仍会盖住新的 blocked。这正是熔断场景的真实顺序，
+  // 我第一版测试用 waiting 当前置状态，恰好绕开了它。
+  it("working → blocked：更新的 REST 状态压过 rank 更高但更旧的 live 状态", async () => {
+    const agent = await seedToken("agent");
+    const slug = await createChannel(agent.token);
+    const ws = await WsClient.open(slug, agent.token);
+    await completeCapabilityHello(ws);
+
+    try {
+      ws.send({ type: "send", kind: "status", state: "working", note: "handling seq 472", mentions: [] });
+      await ws.nextOfType("sent");
+      expect((await presenceOf(slug, agent.token, agent.name))?.state).toBe("working");
+
+      expect((await postStatus(slug, agent.token, "blocked", "circuit breaker tripped")).status).toBe(200);
+
+      const entry = await presenceOf(slug, agent.token, agent.name);
+      expect(entry?.state).toBe("blocked");
+      expect(entry?.note).toBe("circuit breaker tripped");
+    } finally {
+      ws.close();
+    }
+  });
+
+  // updated_at 是毫秒。两次先后完成的写入可能落在同一毫秒里；严格大于会把后到的 REST 状态排除，
+  // 于是同一毫秒内的状态变更随机丢失——这类 bug 极难复现，必须在契约层挡住。
+  it("同毫秒写入不丢：紧接着发出的 REST 状态仍然生效", async () => {
+    const agent = await seedToken("agent");
+    const slug = await createChannel(agent.token);
+    const ws = await WsClient.open(slug, agent.token);
+    await completeCapabilityHello(ws);
+
+    try {
+      // 不等任何延时，紧贴着发——尽量把两次写入压进同一毫秒。
+      ws.send({ type: "send", kind: "status", state: "working", note: "ws", mentions: [] });
+      await ws.nextOfType("sent");
+      expect((await postStatus(slug, agent.token, "done", "rest right after")).status).toBe(200);
+
+      const entry = await presenceOf(slug, agent.token, agent.name);
+      // done 的 rank(100) 远低于 working(400)：只有「新鲜度优先」才能让它赢。
+      expect(entry?.state).toBe("done");
+      expect(entry?.note).toBe("rest right after");
+    } finally {
+      ws.close();
+    }
+  });
+
   it("没有活连接时行为不变：REST 状态照常反映", async () => {
     const agent = await seedToken("agent");
     const slug = await createChannel(agent.token);


### PR DESCRIPTION
这批 issue（#821–#828）不是八个独立缺陷，是**同一天同一起事故的八个切面**。事故链条是：

```
接入包给的 Claude runner 示例不把输出发回频道 (#821)
  → runner 正常退出、频道零回复 → 三次 abandon → serve 熔断退出
  → 熔断通告经 REST 发出，被自己那条还活着的 WS 连接挡住 (#825)
  → party_who 报 waiting（比频道里的 working 帧还旧 152 秒）
  → 协作方合理推断「没人接活」→ 直接改了对方仓库并推了分支
  → 两边差点在同一个文件的同一个常量上撞车
```

每一环单独看都是小问题，串起来是一次真实的越界改动。这个 PR 修的是链条上所有能修的环节。

## #825 — who 被活 WS 连接挡住更新的 REST 状态（本次最严重）

`aggregatePresenceRow` 在该 name 有任何活 WS 连接时，**只**从活连接对应的行里挑，非 live 行整个丢弃。而经 REST 发的 status 帧，presence 行落在 `LEGACY_SESSION_ID` 上——它永远不在 `liveSessions`（那里装的是 WS 连接 id）里。

于是一个**既挂着 serve（有活 WS）又用 REST 报状态**的 agent，`party_who` 永远停在 WS 那行的旧状态上。这正是 serve/runner 的标准形态。

「优先 live 行」的本意（别让已死会话的陈旧状态盖住活着的）保留了，但它不该盖住一条**严格更新**的状态：候选集改成 live 行 + 比最新 live 行还新的非 live 行。

回归测试复现原始场景，**去掉修复即挂**（验证过）。

顺带解决了 #821 的第三点：serve 熔断前那条 blocked 通告也是经 REST 发的，此前同样被丢掉——所以「serve 已经死了」对本人和协作方都不可见。

## #821 — 接入包的 Claude 示例必然熔断

接入包同一节里，Codex 示例把输出捞回来再 `party send`，Claude 示例没有：

```sh
# 修复前
Claude: claude -p -c "$(cat {file})" || claude -p "$(cat {file})"
```

而两行之下它自己写着「别让子进程自己发频道，让外层 party send 发回」。**那条建议只被 Codex 示例执行了，Claude 示例正好是它警告的那种写法。**

- Claude 示例与 Codex 对齐。
- 把「必须捞回来再发」升级成显式警告，说清失败链条一直到熔断退出。
- 第一次 abandon 就打出成因和改法，而不是只陈述事实。

## #824 — task_create 静默丢弃 body 与 assignee

传 `body`/`assignee` 拿到 200 和一个看起来正常的回执，落库却是只有标题的空壳。**写任务的 agent 不会回头核对，读任务的 agent 不知道原本有内容**——「接手方不用回去翻聊天记录」这个任务系统存在的理由当场失效，而且要等接手方来问才发现。

改为 `strict()`：未知字段直接报错。同时 `assignee` 收纯字符串（调用方最自然的写法）；与 `assignee_name` 冲突时报错而不是挑一个——派给错的人比报错贵得多。

## #826 — watch_once 被未 ack 的旧 delivery 饿死

`pending_ack: true` 这个布尔量对不知道机制的调用方等于没说。实测：两轮 600s 超时 = 20 分钟全花在重复接收同一条上，期间 7 条新消息进不来，而被卡住的那条恰好是零信息量的自动回执。

- `pending_ack_hint`：第几次重投、几条消息被挡着、确切怎么清。
  （核过实现：**`party_ack` 收的是 `seq` 不是 `delivery_id`**——issue 里写的那种调法会失败，hint 里明确点破。）
- `held_messages`：把卡住的代价变成数字。
- `ack_replay` 开关：随收随清，复用 `ackWatchStuck` 的原子 compare-and-clear，自带 serve-owned 拒清保护。

**默认没改成自动 ack**（建议 1），理由见下面「没做的部分」。

## #827 — schema 把校验规则讲清楚

- `party_status` 名字像 getter 实为 setter → 标题和描述最前面写明「这是写接口，读用 `party_who`」。
- `party_watch_once` 的 `timeout_sec` 上限 600 写进参数描述。校验规则本身就是契约。
- `party_spawn_worker` 的 `name` 标注 REQUIRED，并说清它只铸身份、不启动进程、频道零痕迹。

## #823 — 把已有的 scope 字段用起来

`scope` 一直在 status frame 里、`party status --scope` 也一直能传，只是从没被读出来过。

- `party who` 显示 `🔒 repo:foo,repo:bar`（仅 `state != offline`）。
- 两个 agent 声明同一 scope 时，在撞上的那一项打 `⚠` 并列出冲突方。**不阻止**——agent 之间本来就靠自觉，合法的并行编辑也确实存在；但「有人已经在这上面了」必须看得见。

零协议改动，不新增概念。

---

## 没做的部分，以及为什么

**#826 建议 1（默认自动 ack）**：那道债正是「被唤醒但没回」的 durability 保证。自动清掉意味着 harness 收到后、动手前崩溃，这条 @ 就永远消失了（#198 红线）。纯读场景用 `ack_replay:true` 显式承担这个语义即可。建议 3（未 ack 不阻塞新消息）涉及投递队列语义，值得单独一次改动，不塞在这批末尾赶工。

**#827 第三条的「spawn 后落生命周期 status frame」**：需要一种不占 seq、不进正文流的机器事件表达——正是 #828 要的原语。用普通消息硬凑，会制造 #828 抱怨的那种噪音。留到设计簇一并处理。

**#822 / #828**：这两条是设计决策，不是缺陷，我在 issue 里单独给了判断和方案，不夹在这个 PR 里赶工。

---

`bun run check` 全绿：CLI 1441 pass / worker 786 pass（104 files）/ shared / web。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 改进任务创建参数校验，支持负责人别名并提示字段冲突。
  - 增强 `party who` 展示，显示作用域占用及冲突信息，并支持 JSON 输出。
  - 新增唤醒重放确认信息，展示待处理消息及清除结果。
- **问题修复**
  - 优化在线状态聚合，及时反映最新 REST 状态及阻塞状态。
  - runner 未发送频道回复时提供即时提示和转发示例。
- **测试**
  - 增加任务参数、作用域冲突及状态新鲜度测试覆盖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->