### PR TITLE
feat(cli): party agents 统一可达性视图（名字即地址）

### DIFF
--- a/cli/src/commands/agents.ts
+++ b/cli/src/commands/agents.ts
@@ -137,7 +137,12 @@ export function memberReach(
   if (e.paused === true) return { reach: "stale", reason: "reception paused" };
   if (live && wakeKind !== undefined && SERVE_LIKE.has(wakeKind)) {
     if (e.runner_health !== undefined && !e.runner_health.ok) {
-      return { reach: "stale", reason: `runner failing x${e.runner_health.consecutive_failures}` };
+      return {
+        reach: "stale",
+        reason: e.runner_health.consecutive_failures > 0
+          ? `runner failing x${e.runner_health.consecutive_failures}`
+          : "runner unhealthy",
+      };
     }
     if (e.listening === "deaf") {
       return { reach: "stale", reason: "deliveries expiring (connected but not consuming)" };

--- a/cli/src/commands/agents.ts
+++ b/cli/src/commands/agents.ts
@@ -1,0 +1,312 @@
+// party agents — 对齐 Claude Code ListAgents 的统一可达性视图（#835）：一条命令列出所有可直达目标，
+// 名字即地址（NAME 可直接 party send --mention）。与 party who 的区别：who 回答「谁在频道里、状态如何」，
+// agents 回答「此刻 @ 谁真的能收到」——REACH 是真实可达性判定，不是最后心跳：
+//   · online(serve)  serve/watch/daemon runner 有活 WS 连接、runner 没连败、delivery 租约没在过期
+//                    （listening != deaf）。对本机自己的 serve 还叠加 health.json 交叉验证：pid 真活着
+//                    且 WS 帧仍新鲜——避免 busy 全绿但 runner 挂死还显示 online（memory: observability-traps）。
+//   · local-direct   本机 Claude cross-session 会话（服务端 runtime topology 比对出的 claude_sessions，
+//                    candidate_ref 非空 = 当前唯一可寻址）。走 Claude 官方 ListAgents/SendMessage 链路。
+//   · wake(webhook)  离线但服务端持有 webhook 端点、自己 POST 投递——服务端可验证的唤醒通道。
+//   · stale          其余一切。包括「连接活着但 runner 连败 / 不吃投喂」——那正是要暴露的假在线。
+import {
+  autoWakeReachable,
+  wakeableState,
+  type PresenceEntry,
+  type RuntimePeerDiscovery,
+  type WakeKind,
+} from "@agentparty/shared";
+import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
+import { resolveChannel } from "../config";
+import { readHealthCache, type HealthCache } from "../health-cache";
+import { resolveAuth } from "../oidc-cli";
+import { fetchPresence, fetchReadCursors, fetchRuntimePeers, handleRestError } from "../rest";
+import { buildRuntimeTopology } from "../runtime-topology";
+import { sanitizeSingleLine } from "../format";
+import { isSlug } from "../validation";
+
+const AGENTS_FLAGS = ["channel", "json"];
+const HELP = `usage: party agents [channel|--channel C] [--json]
+
+Unified reachability view (Claude ListAgents-style): every row is a directly
+addressable target — the NAME is the address (party send "@NAME …" --mention NAME,
+or Claude SendMessage for claude-session rows).
+
+Columns:
+  NAME     the address
+  KIND     channel-member | claude-session | codex
+  REACH    online(serve)  runner truly alive: live WS + runner not failing +
+                          deliveries being consumed (+ local pid/frame cross-check
+                          for this workspace's own serve) — NOT just a heartbeat
+           local-direct   local Claude cross-session peer (official SendMessage path)
+           wake(webhook)  offline but server-delivered webhook wake is verified
+           stale          everything else, including a live socket whose runner is
+                          dead/failing — the honest label for false-online
+  CHANNEL  channel slug, or (bridge) for local claude sessions
+
+Options:
+  --channel C   read channel C instead of the bound channel
+  --json        one JSON object per line
+                (name/kind/reach/channel/reach_reason/wake/busy/read_seq/behind/age_ms)`;
+
+const STALE_MS = 60_000; // 与 DO presence 扫描 / who.ts 一致
+const DEAD_MS = 14 * 24 * 60 * 60 * 1000; // 幽灵线，与 who.ts 一致
+// 本机 health.json 的帧新鲜度阈值：serve 按 ping 心跳（~25s）节奏写 last_frame_at，
+// 超过约 5 个心跳周期没有任何服务端帧 = socket 僵死或进程被 kill 后的残留记录。
+export const LOCAL_FRAME_STALE_MS = 120_000;
+
+export type AgentReach = "online(serve)" | "local-direct" | "wake(webhook)" | "stale";
+export type AgentKind = "channel-member" | "claude-session" | "codex";
+
+export interface AgentRow {
+  name: string;
+  kind: AgentKind;
+  reach: AgentReach;
+  channel: string;
+  /** 为什么不是更高一档——只在 stale 且能说清原因时带出（诚实留白）。 */
+  reach_reason?: string;
+  wake?: WakeKind;
+  busy?: true;
+  read_seq?: number;
+  behind?: number;
+  age_ms?: number;
+}
+
+export interface LocalHealthProbe {
+  cache: HealthCache | null;
+  /** pid 探活注入点（单测可替换）；默认 process.kill(pid, 0)。 */
+  pidAlive?: (pid: number) => boolean;
+  now?: number;
+}
+
+function defaultPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * 本机交叉验证（#254 探针的消费端）：presence 说 online 只证明「服务端看得到一条活连接」，
+ * 不证明 runner 进程还活着。对本 workspace 自己的 serve，读 health.json 再验三件事：
+ * pid 真活着、WS 自报 connected、最近仍在收服务端帧。任一不成立 → 返回失败原因（降级 stale）。
+ * 没有 health 记录（serve 不在本机跑）→ null = 无从交叉验证，不否决。
+ */
+export function localServeFailure(probe: LocalHealthProbe): string | null {
+  const h = probe.cache;
+  if (h === null) return null;
+  const pidAlive = probe.pidAlive ?? defaultPidAlive;
+  const now = probe.now ?? Date.now();
+  if (!pidAlive(h.pid)) return `local runner pid ${h.pid} is dead`;
+  if (!h.ws_connected) return "local runner ws disconnected";
+  if (h.last_frame_at === null || now - h.last_frame_at > LOCAL_FRAME_STALE_MS) {
+    return "local runner ws frames stale";
+  }
+  return null;
+}
+
+const SERVE_LIKE = new Set<WakeKind>(["serve", "watch", "daemon"]);
+
+export function memberKind(e: PresenceEntry): AgentKind {
+  const harness = e.agent_session?.harness;
+  if (harness === "codex" || harness === "codex-sdk") return "codex";
+  if (e.status?.context?.reception_runner === "codex") return "codex";
+  return "channel-member";
+}
+
+/**
+ * 真实可达性判定。取舍（vs 单看最后心跳）：
+ * ① online(serve) 需要活 WS（live=true 或新鲜）+ serve 型 wake layer；
+ * ② 服务端已经看出 runner 不行（runner_health 连败 / listening=deaf 投喂了不吃）→ 直接 stale，
+ *    这正是「busy 全绿但 runner 挂死」的两个服务端信号；
+ * ③ 对本机自己的 serve 叠加 health.json 的 pid/帧交叉验证（localFailure 非 null → stale）——
+ *    kill 掉 runner 不解注册时，presence 的 live 可能要等租约过期才翻转，本地探针立刻翻转；
+ * ④ 读游标落后不否决 online：忙碌 runner 合法落后，落后量作为 behind 字段如实带出，让调用方自己看；
+ * ⑤ webhook 由服务端投递、可服务端验证，离线也算可达；serve/watch 声明而不新鲜的一律 stale。
+ */
+export function memberReach(
+  e: PresenceEntry,
+  now: number,
+  localFailure: string | null = null,
+): { reach: AgentReach; reason?: string } {
+  const seen = e.last_seen ?? e.ts ?? 0;
+  const age = now - seen;
+  const live = e.state !== "offline" && (e.live === true || age < STALE_MS);
+  const wakeKind = e.wake?.kind;
+  if (e.paused === true) return { reach: "stale", reason: "reception paused" };
+  if (live && wakeKind !== undefined && SERVE_LIKE.has(wakeKind)) {
+    if (e.runner_health !== undefined && !e.runner_health.ok) {
+      return { reach: "stale", reason: `runner failing x${e.runner_health.consecutive_failures}` };
+    }
+    if (e.listening === "deaf") {
+      return { reach: "stale", reason: "deliveries expiring (connected but not consuming)" };
+    }
+    if (localFailure !== null) return { reach: "stale", reason: localFailure };
+    return { reach: "online(serve)" };
+  }
+  // webhook：服务端持有端点自己 POST，离线也真能唤醒；不越过幽灵线。
+  if (
+    wakeKind === "webhook" &&
+    age <= DEAD_MS &&
+    autoWakeReachable(e, now, STALE_MS) &&
+    wakeableState(e, now) === "wakeable_verified"
+  ) {
+    return { reach: "wake(webhook)" };
+  }
+  if (live) return { reach: "stale", reason: "live connection but no serve runner" };
+  return { reach: "stale" };
+}
+
+/** 把 presence + 本机 claude 会话发现拼成统一行。导出仅为单测。 */
+export function buildAgentRows(
+  channel: string,
+  presence: PresenceEntry[],
+  now: number,
+  opts: {
+    discovery?: RuntimePeerDiscovery;
+    cursorOf?: Map<string, number>;
+    lastSeq?: number;
+    localHealth?: LocalHealthProbe;
+  } = {},
+): AgentRow[] {
+  const rows: AgentRow[] = [];
+  const localFailure = opts.localHealth === undefined ? null : localServeFailure(opts.localHealth);
+  for (const e of presence) {
+    if (e.name === "system") continue;
+    if (e.kind === "human") continue; // agents 只列可编程直达目标；人类看 party who
+    const seen = e.last_seen ?? e.ts ?? 0;
+    const age = now - seen;
+    if (age > DEAD_MS) continue; // 幽灵不列
+    // 本机交叉验证只适用于「本 workspace 自己的 serve」那一行（discovery.self）；
+    // 别拿本地 health.json 去否决别人机器上的 runner。
+    const isSelf = opts.discovery !== undefined && opts.discovery.self === e.name;
+    const { reach, reason } = memberReach(e, now, isSelf ? localFailure : null);
+    const readSeq = opts.cursorOf?.get(e.name);
+    const behind =
+      readSeq !== undefined && opts.lastSeq !== undefined && opts.lastSeq > readSeq
+        ? opts.lastSeq - readSeq
+        : undefined;
+    rows.push({
+      name: e.name,
+      kind: memberKind(e),
+      reach,
+      channel,
+      ...(reason !== undefined ? { reach_reason: reason } : {}),
+      ...(e.wake?.kind !== undefined && e.wake.kind !== "none" ? { wake: e.wake.kind } : {}),
+      ...(e.busy === true ? { busy: true as const } : {}),
+      ...(readSeq !== undefined ? { read_seq: readSeq } : {}),
+      ...(behind !== undefined ? { behind } : {}),
+      age_ms: age,
+    });
+  }
+  // 本机 Claude cross-session 会话：服务端 runtime topology 比对出的 claude_sessions 提示。
+  // candidate_ref 非空 = 当前唯一可寻址（可走官方 ListAgents/SendMessage 链路）→ local-direct；
+  // 为空 = 不可唯一寻址，如实列为 stale 并说明原因，而不是假装它不存在。
+  for (const peer of opts.discovery?.peers ?? []) {
+    for (const session of peer.claude_sessions) {
+      const addressable = session.candidate_ref !== null;
+      rows.push({
+        name: session.display_name,
+        kind: "claude-session",
+        reach: addressable ? "local-direct" : "stale",
+        channel: "(bridge)",
+        ...(addressable ? {} : { reach_reason: "not uniquely addressable (no candidate_ref)" }),
+      });
+    }
+  }
+  const rank: Record<AgentReach, number> = {
+    "online(serve)": 0,
+    "local-direct": 1,
+    "wake(webhook)": 2,
+    stale: 3,
+  };
+  return rows.sort((a, b) => rank[a.reach] - rank[b.reach] || a.name.localeCompare(b.name));
+}
+
+export function renderAgentTable(rows: AgentRow[]): string[] {
+  const header = ["NAME", "KIND", "REACH", "CHANNEL"];
+  const cells = rows.map((r) => [
+    sanitizeSingleLine(r.name),
+    r.kind,
+    r.reach + (r.busy === true ? " ⏳" : ""),
+    sanitizeSingleLine(r.channel),
+  ]);
+  const widths = header.map((h, i) => Math.max(h.length, ...cells.map((c) => c[i]!.length)));
+  const line = (c: string[]): string => c.map((v, i) => v.padEnd(widths[i]!)).join("  ").trimEnd();
+  return [line(header), ...cells.map((c, idx) => {
+    const reason = rows[idx]!.reach_reason;
+    return line(c) + (reason !== undefined ? `  · ${sanitizeSingleLine(reason)}` : "");
+  })];
+}
+
+export async function run(argv: string[]): Promise<number> {
+  if (isHelpArg(argv, { allowHelpPositional: true })) {
+    console.log(HELP);
+    return 0;
+  }
+  const { positionals, flags } = parseArgs(argv, { booleans: ["json"] });
+  const unknown = unknownFlagError(flags, AGENTS_FLAGS);
+  if (unknown !== null) {
+    console.error(unknown);
+    return 1;
+  }
+  const flagError = valueFlagError(flags, ["channel"]);
+  if (flagError !== null) {
+    console.error(flagError);
+    return 1;
+  }
+  const cfg = await resolveAuth();
+  if (!cfg) {
+    console.error("no config, run: party login or party init --server URL --token T");
+    return 1;
+  }
+  const channel = resolveChannel(str(flags.channel) ?? positionals[0]);
+  if (!channel) {
+    console.error("no channel, pass one or bind with: party init --channel C");
+    return 1;
+  }
+  if (!isSlug(channel)) {
+    console.error("channel must match [a-z0-9][a-z0-9-]{0,63}");
+    return 1;
+  }
+  try {
+    const presence = await fetchPresence(cfg.server, cfg.token, channel);
+    let discovery: RuntimePeerDiscovery | undefined;
+    const topology = buildRuntimeTopology(cfg.server);
+    if (topology !== undefined) {
+      try {
+        discovery = await fetchRuntimePeers(cfg.server, cfg.token, channel, topology, "topology_advisory");
+      } catch {
+        // 老 worker / 可选发现失败：没有 claude-session 行，成员可达性照常。
+      }
+    }
+    let cursorOf = new Map<string, number>();
+    let lastSeq = 0;
+    try {
+      const rc = await fetchReadCursors(cfg.server, cfg.token, channel);
+      lastSeq = rc.last_seq;
+      cursorOf = new Map(rc.cursors.map((c) => [c.name, c.last_seen_seq]));
+    } catch {
+      /* 端点不存在：不标注游标 */
+    }
+    const rows = buildAgentRows(channel, presence, Date.now(), {
+      discovery,
+      cursorOf,
+      lastSeq,
+      localHealth: { cache: readHealthCache(process.cwd(), channel) },
+    });
+    if (flags.json === true) {
+      for (const r of rows) console.log(JSON.stringify(r));
+      return 0;
+    }
+    if (rows.length === 0) {
+      console.log(`no addressable agents in ${channel} yet`);
+      return 0;
+    }
+    for (const line of renderAgentTable(rows)) console.log(line);
+    return 0;
+  } catch (e) {
+    return handleRestError(e);
+  }
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -43,6 +43,7 @@ commands:
   status    [channel|--channel C] working|waiting|blocked|done [-m note] [--mention name]...
   statusline [--channel C] [--refresh] [--no-network]
   who       [channel|--channel C] [--json]                who is online/wakeable/recent — pick who to --mention
+  agents    [channel|--channel C] [--json]                unified reachability view — every NAME is a direct address
   pause     <name> [--channel C] [--resume-at T|--for D]   stop waking an agent (moderator); auto-resume at T / after D
   resume    <name> [--channel C]                           resume a paused agent's reception (moderator)
   wake-budget <name> [--limit N [--window D]|--off]        cap an agent's wakes per window; over-budget @ withheld (#108)
@@ -152,6 +153,8 @@ export async function main(argv: string[]): Promise<number> {
       return (await import("./commands/statusline")).run(rest);
     case "who":
       return (await import("./commands/who")).run(rest);
+    case "agents":
+      return (await import("./commands/agents")).run(rest);
     case "pause":
     case "resume":
       return (await import("./commands/pause")).run(cmd, rest);

--- a/cli/test/agents.test.ts
+++ b/cli/test/agents.test.ts
@@ -1,0 +1,225 @@
+// party agents（#835）：统一可达性视图。REACH 必须是真实可达性判定，不是最后心跳——
+// 重点回归「busy 全绿但 runner 挂死仍显示 online」的假在线（memory: observability-traps）。
+import { describe, expect, test } from "bun:test";
+import type { PresenceEntry, RuntimePeerDiscovery } from "@agentparty/shared";
+import type { HealthCache } from "../src/health-cache";
+import {
+  buildAgentRows,
+  localServeFailure,
+  memberKind,
+  memberReach,
+  renderAgentTable,
+  LOCAL_FRAME_STALE_MS,
+} from "../src/commands/agents";
+
+const NOW = 1_000_000_000;
+
+function p(over: Partial<PresenceEntry> & { name: string }): PresenceEntry {
+  return { state: "waiting", note: null, ts: NOW, last_seen: NOW, ...over };
+}
+
+function health(over: Partial<HealthCache> = {}): HealthCache {
+  return {
+    v: 1,
+    pid: 4242,
+    channel: "pwtk",
+    ws_connected: true,
+    last_frame_at: NOW - 10_000,
+    reconnecting: false,
+    reconnect_count: 0,
+    last_error: null,
+    connected_since: NOW - 60_000,
+    current_task: null,
+    task_started_at: null,
+    heartbeat_at: null,
+    supervisor_state: "running",
+    supervisor_attempt: 1,
+    restart_delay_ms: null,
+    last_exit_code: null,
+    last_exit_at: null,
+    supervisor_error: null,
+    lease_state: "held",
+    serve_standbys: 0,
+    updated_at: NOW,
+    ...over,
+  };
+}
+
+describe("memberReach", () => {
+  test("live serve runner，服务端无异常信号 → online(serve)", () => {
+    const r = memberReach(p({ name: "bot", live: true, wake: { kind: "serve" } }), NOW);
+    expect(r.reach).toBe("online(serve)");
+  });
+
+  test("live 但 runner 连败 → stale（不是 online）——runner 挂死不许显示在线", () => {
+    const r = memberReach(
+      p({ name: "bot", live: true, wake: { kind: "serve" }, runner_health: { ok: false, consecutive_failures: 3 } }),
+      NOW,
+    );
+    expect(r.reach).toBe("stale");
+    expect(r.reason).toContain("runner failing x3");
+  });
+
+  test("live 但 listening=deaf（投喂了不吃）→ stale", () => {
+    const r = memberReach(p({ name: "bot", live: true, wake: { kind: "serve" }, listening: "deaf" }), NOW);
+    expect(r.reach).toBe("stale");
+    expect(r.reason).toContain("not consuming");
+  });
+
+  test("本机交叉验证失败（pid 死了）→ stale，即使 presence 还标着 live", () => {
+    const r = memberReach(p({ name: "bot", live: true, wake: { kind: "serve" } }), NOW, "local runner pid 4242 is dead");
+    expect(r.reach).toBe("stale");
+    expect(r.reason).toBe("local runner pid 4242 is dead");
+  });
+
+  test("offline + webhook（服务端投递，天然 verified）→ wake(webhook)", () => {
+    const r = memberReach(
+      p({ name: "bot", state: "offline", wake: { kind: "webhook" }, last_seen: NOW - 3_600_000 }),
+      NOW,
+    );
+    expect(r.reach).toBe("wake(webhook)");
+  });
+
+  test("offline + 自报 serve（supervisor 已死）→ stale，不谎报可唤醒", () => {
+    const r = memberReach(
+      p({ name: "bot", state: "offline", wake: { kind: "serve" }, last_seen: NOW - 780_000 }),
+      NOW,
+    );
+    expect(r.reach).toBe("stale");
+  });
+
+  test("paused → stale（人主动按了暂停，@ 不唤醒）", () => {
+    const r = memberReach(p({ name: "bot", live: true, wake: { kind: "serve" }, paused: true }), NOW);
+    expect(r.reach).toBe("stale");
+    expect(r.reason).toContain("paused");
+  });
+
+  test("live 但没有 serve 型 wake layer → stale 并说明原因", () => {
+    const r = memberReach(p({ name: "bot", live: true }), NOW);
+    expect(r.reach).toBe("stale");
+    expect(r.reason).toContain("no serve runner");
+  });
+});
+
+describe("localServeFailure", () => {
+  test("pid 死了 → 报 dead", () => {
+    expect(localServeFailure({ cache: health(), pidAlive: () => false, now: NOW })).toContain("dead");
+  });
+
+  test("ws 断开 → 报 disconnected", () => {
+    expect(
+      localServeFailure({ cache: health({ ws_connected: false }), pidAlive: () => true, now: NOW }),
+    ).toContain("disconnected");
+  });
+
+  test("帧陈旧（超过 LOCAL_FRAME_STALE_MS）→ 报 stale", () => {
+    expect(
+      localServeFailure({
+        cache: health({ last_frame_at: NOW - LOCAL_FRAME_STALE_MS - 1 }),
+        pidAlive: () => true,
+        now: NOW,
+      }),
+    ).toContain("stale");
+  });
+
+  test("三件事都成立 → null（不否决）；无记录 → null（无从交叉验证）", () => {
+    expect(localServeFailure({ cache: health(), pidAlive: () => true, now: NOW })).toBeNull();
+    expect(localServeFailure({ cache: null })).toBeNull();
+  });
+});
+
+describe("memberKind", () => {
+  test("agent_session.harness=codex/codex-sdk → codex", () => {
+    expect(memberKind(p({ name: "c", agent_session: { harness: "codex", session_id: "s1", updated_at: NOW } }))).toBe("codex");
+    expect(memberKind(p({ name: "c", agent_session: { harness: "codex-sdk", session_id: "s2", updated_at: NOW } }))).toBe("codex");
+  });
+
+  test("默认 → channel-member", () => {
+    expect(memberKind(p({ name: "a" }))).toBe("channel-member");
+  });
+});
+
+function discovery(over: Partial<RuntimePeerDiscovery> = {}): RuntimePeerDiscovery {
+  return {
+    version: 3,
+    topology_evidence: "client_asserted",
+    comparison: "server_derived",
+    caller_binding: "live_socket",
+    self: "me",
+    peers: [],
+    ...over,
+  };
+}
+
+describe("buildAgentRows", () => {
+  test("成员 + 本机 claude 会话（有 candidate_ref）→ local-direct，CHANNEL=(bridge)；排序 online 在前", () => {
+    const rows = buildAgentRows(
+      "pwtk",
+      [p({ name: "bot", live: true, wake: { kind: "serve" } })],
+      NOW,
+      {
+        discovery: discovery({
+          peers: [{
+            agent: "peer",
+            same_identity: false,
+            relations: [{ relation: "same_workspace", runtime_count: 1 }],
+            claude_sessions: [
+              { display_name: "design-review-x7", relation: "same_workspace", runtime_count: 1, candidate_ref: "candidate_abcdefghijklmnop" },
+              { display_name: "dup-session", relation: "same_workspace", runtime_count: 2, candidate_ref: null },
+            ],
+          }],
+        }),
+      },
+    );
+    expect(rows.map((r) => [r.name, r.kind, r.reach, r.channel])).toEqual([
+      ["bot", "channel-member", "online(serve)", "pwtk"],
+      ["design-review-x7", "claude-session", "local-direct", "(bridge)"],
+      ["dup-session", "claude-session", "stale", "(bridge)"],
+    ]);
+    expect(rows[2]!.reach_reason).toContain("not uniquely addressable");
+  });
+
+  test("本机 health 交叉验证只否决自己（discovery.self），不否决别人的 runner", () => {
+    const presence = [
+      p({ name: "me", live: true, wake: { kind: "serve" } }),
+      p({ name: "other", live: true, wake: { kind: "serve" } }),
+    ];
+    const rows = buildAgentRows("pwtk", presence, NOW, {
+      discovery: discovery({ self: "me" }),
+      localHealth: { cache: health(), pidAlive: () => false, now: NOW },
+    });
+    const byName = new Map(rows.map((r) => [r.name, r]));
+    expect(byName.get("me")!.reach).toBe("stale"); // 杀掉 runner 不解注册 → 必须离开 online
+    expect(byName.get("other")!.reach).toBe("online(serve)");
+  });
+
+  test("human / system / 幽灵不列；游标落后如实带出 behind 但不否决 online", () => {
+    const presence = [
+      p({ name: "system" }),
+      p({ name: "alice", kind: "human", live: true }),
+      p({ name: "ghost", state: "offline", last_seen: NOW - 15 * 24 * 60 * 60 * 1000 }),
+      p({ name: "bot", live: true, wake: { kind: "serve" } }),
+    ];
+    const rows = buildAgentRows("pwtk", presence, NOW, {
+      cursorOf: new Map([["bot", 7]]),
+      lastSeq: 10,
+    });
+    expect(rows.map((r) => r.name)).toEqual(["bot"]);
+    expect(rows[0]!.reach).toBe("online(serve)");
+    expect(rows[0]!.read_seq).toBe(7);
+    expect(rows[0]!.behind).toBe(3);
+  });
+});
+
+describe("renderAgentTable", () => {
+  test("表头 + 对齐列 + stale 原因内联", () => {
+    const lines = renderAgentTable([
+      { name: "bot", kind: "channel-member", reach: "online(serve)", channel: "pwtk", age_ms: 0 },
+      { name: "dead", kind: "channel-member", reach: "stale", channel: "pwtk", reach_reason: "runner failing x3", age_ms: 0 },
+    ]);
+    expect(lines[0]).toMatch(/^NAME\s+KIND\s+REACH\s+CHANNEL$/);
+    expect(lines[1]).toContain("online(serve)");
+    expect(lines[2]).toContain("stale");
+    expect(lines[2]).toContain("· runner failing x3");
+  });
+});


### PR DESCRIPTION
Closes #835

## 内容

新增 `party agents [channel|--channel C] [--json]`：对齐 Claude Code ListAgents 的统一可达性视图，每行一个可直达目标，NAME 即地址。

```
NAME              KIND            REACH          CHANNEL
leo-claude        channel-member  online(serve)  pwtk
design-review-x7  claude-session  local-direct   (bridge)
codex-runner      codex           wake(webhook)  pwtk
dead-runner       channel-member  stale          pwtk  · runner failing x3
```

## REACH 判定（真实可达性，不是最后心跳）

- **online(serve)**：活 WS（live/新鲜）+ serve/watch/daemon wake layer，且服务端两个异常信号都干净——`runner_health.ok`（runner 未连败）、`listening != deaf`（delivery 租约没在过期）。对本 workspace 自己的 serve（discovery.self 匹配）叠加 health.json 本地交叉验证：pid 真活着（`kill(pid,0)`）+ WS 自报 connected + 最近 120s 内收到过服务端帧。**杀掉 runner 不解注册 → 立刻 stale**，不等 presence 租约过期。
- **local-direct**：runtime topology 服务端比对出的本机 Claude cross-session 会话，candidate_ref 非空 = 当前唯一可寻址（官方 ListAgents/SendMessage 链路）；不可寻址的如实列 stale + 原因。
- **wake(webhook)**：服务端持有端点自己 POST，离线也真能唤醒（wakeableState verified）。
- **stale**：其余一切，带 `reach_reason`（runner failing / not consuming / local pid dead / paused / …）。

取舍：读游标落后**不否决** online（忙碌 runner 合法落后），落后量以 `behind` 字段如实带出。

## 测试

- `cli/test/agents.test.ts` 18 用例全过（含「live 但 runner 连败/deaf/本机 pid 死 → stale」回归）
- `bunx tsc --noEmit` 通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增 `party agents` 命令，提供统一的代理可达性视图。
  * 支持表格和逐行 JSON 输出。
  * 展示在线、本机直连、Webhook 唤醒及过期等状态，并提供相关原因。
  * 自动过滤过期幽灵和非代理成员，按可达性排序展示。
  * CLI 帮助信息已加入该命令说明。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->