### PR TITLE
feat(cli): party up 一条幂等命令收敛入门三道门 (#837)

### DIFF
--- a/cli/src/commands/up.ts
+++ b/cli/src/commands/up.ts
@@ -1,0 +1,265 @@
+// party up — 入门三道门（token → init 绑频道 → serve 常驻）收敛成一条幂等命令（#837）。
+// 已就绪的环节跳过、缺的环节补上：可当健康自愈命令反复跑。
+import { mkdirSync, openSync } from "node:fs";
+import { join } from "node:path";
+import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
+import {
+  agentpartyHome,
+  durableConfigPointerPath,
+  explicitConfigPath,
+  readConfig,
+  readState,
+} from "../config";
+import { buildHealthReport } from "./health";
+import { readHealthCache } from "../health-cache";
+import { isPartyBinaryPath } from "../upgrade";
+import { isSlug, normalizeServerUrl } from "../validation";
+
+const UP_FLAGS = ["server", "channel", "runner"];
+const RUNNERS = ["claude", "codex", "codex-sdk"] as const;
+type UpRunner = (typeof RUNNERS)[number];
+// 与 health.ts 一致：> 2x WS 心跳周期
+const STALE_AFTER_MS = 90_000;
+
+const HELP = `usage: party up [channel-url-or-invite-url-or-slug] [--server URL] [--channel C] [--runner claude|codex|codex-sdk]
+
+One idempotent command: token → bind channel (party init) → resident serve runner.
+Each step is checked first and only fixed when missing — safe to re-run as a health self-heal.
+
+Accepts a join/invite URL like https://host/c/<slug>?t=<token>, or a bare channel slug.
+Token sources (in order): URL ?t= → AGENTPARTY_TOKEN env → existing config.
+
+Steps:
+  auth   no usable token → explain how to get one (invite pack / AGENTPARTY_TOKEN)
+  bind   config/channel missing or changed → equivalent of party init
+  serve  runner not healthy → spawn \`party serve <channel> --runner <r> --replay-backlog\`
+         (--replay-backlog drains the offline @-backlog immediately; standby is serve,
+          never watch --once)`;
+
+// ── 纯逻辑（单测覆盖）─────────────────────────────────────────
+
+export interface UpTarget {
+  server: string | null;
+  channel: string | null;
+  token: string | null;
+}
+
+/** 解析位置参数：频道/邀请 URL（https://host/c/slug?t=token）或裸 slug。 */
+export function parseUpTarget(arg: string | undefined): UpTarget | { error: string } {
+  if (arg === undefined || arg === "") return { server: null, channel: null, token: null };
+  if (/^https?:\/\//i.test(arg)) {
+    let url: URL;
+    try {
+      url = new URL(arg);
+    } catch {
+      return { error: `无法解析 URL：${arg}` };
+    }
+    const m = url.pathname.match(/^\/c\/([a-z0-9][a-z0-9-]{0,63})\/?$/);
+    if (!m) return { error: `URL 不是频道链接（期望 /c/<slug>）：${arg}` };
+    const server = normalizeServerUrl(url.origin);
+    if (server === null) return { error: `URL 的 server 部分不合法：${arg}` };
+    const t = url.searchParams.get("t");
+    return { server, channel: m[1]!, token: t !== null && t !== "" ? t : null };
+  }
+  if (isSlug(arg)) return { server: null, channel: arg, token: null };
+  return { error: `既不是频道 URL 也不是合法 slug：${arg}` };
+}
+
+export type UpStep = "auth" | "bind" | "serve";
+
+export interface UpState {
+  hasToken: boolean;
+  needBind: boolean;
+  runnerHealthy: boolean;
+}
+
+/** 幂等分支判定：只列出缺的环节。全就绪 → []。 */
+export function planUp(s: UpState): UpStep[] {
+  const steps: UpStep[] = [];
+  if (!s.hasToken) steps.push("auth");
+  if (s.needBind) steps.push("bind");
+  if (!s.runnerHealthy) steps.push("serve");
+  return steps;
+}
+
+export interface BindInputs {
+  cfgServer: string | undefined;
+  cfgToken: string | undefined;
+  boundChannel: string | undefined;
+  server: string;
+  token: string;
+  channel: string;
+}
+
+/** config/state 与目标一致才算已绑定；token/server/channel 任一漂移都要重新 init。 */
+export function needsBind(i: BindInputs): boolean {
+  return i.cfgServer !== i.server || i.cfgToken !== i.token || i.boundChannel !== i.channel;
+}
+
+// ── 副作用注入（单测里 mock，绝不真起 daemon）──────────────────
+
+export interface UpDeps {
+  readHealth: (channel: string) => { healthy: boolean; pid?: number };
+  runInit: (argv: string[]) => Promise<number>;
+  spawnServe: (channel: string, runner: UpRunner) => number | null;
+}
+
+function defaultSpawnServe(channel: string, runner: UpRunner): number | null {
+  // 编译版二进制：execPath 即 party；dev（bun run）：execPath 是 bun，argv[1] 是入口脚本。
+  const self =
+    isPartyBinaryPath(process.execPath) || process.argv[1] === undefined
+      ? [process.execPath]
+      : [process.execPath, process.argv[1]];
+  const logDir = join(agentpartyHome(), "logs");
+  mkdirSync(logDir, { recursive: true });
+  // 日志落盘而非 ignore：serve 起不来时（token 失效/端口占用）还有现场可查。
+  const log = openSync(join(logDir, `up-serve-${channel}.log`), "a");
+  try {
+    const proc = Bun.spawn(
+      // --replay-backlog：挂上即逐条排空离线积压的 @（cursor-handover 教训：待命用 serve，接管先排空）。
+      [...self, "serve", channel, "--runner", runner, "--replay-backlog"],
+      { cwd: process.cwd(), stdin: "ignore", stdout: log, stderr: log },
+    );
+    proc.unref();
+    return proc.pid;
+  } catch {
+    return null;
+  }
+}
+
+const DEFAULT_DEPS: UpDeps = {
+  readHealth: (channel) => {
+    const r = buildHealthReport(readHealthCache(process.cwd(), channel), { channel, staleAfterMs: STALE_AFTER_MS });
+    return { healthy: r.healthy, pid: r.pid };
+  },
+  runInit: async (argv) => (await import("./init")).run(argv),
+  spawnServe: defaultSpawnServe,
+};
+
+// ── 命令入口 ────────────────────────────────────────────────
+
+export async function run(argv: string[], deps: UpDeps = DEFAULT_DEPS): Promise<number> {
+  if (isHelpArg(argv, { allowHelpPositional: true })) {
+    console.log(HELP);
+    return 0;
+  }
+  const { positionals, flags } = parseArgs(argv);
+  const unknown = unknownFlagError(flags, UP_FLAGS);
+  if (unknown !== null) {
+    console.error(unknown);
+    return 1;
+  }
+  const flagError = valueFlagError(flags, ["server", "channel", "runner"]);
+  if (flagError !== null) {
+    console.error(flagError);
+    return 1;
+  }
+  const runner = (str(flags.runner) ?? "claude") as UpRunner;
+  if (!RUNNERS.includes(runner)) {
+    console.error(`--runner must be one of: ${RUNNERS.join(", ")}`);
+    return 1;
+  }
+  const target = parseUpTarget(positionals[0]);
+  if ("error" in target) {
+    console.error(target.error);
+    return 1;
+  }
+
+  const cfg = readConfig();
+  const st = readState();
+
+  // token：URL ?t= → 环境变量 → 已有 config。都没有 = auth 环节缺失且本命令无法代办。
+  const envToken = process.env.AGENTPARTY_TOKEN?.trim();
+  const token = target.token ?? (envToken !== undefined && envToken !== "" ? envToken : undefined) ?? cfg?.token;
+  if (token === undefined || token === "") {
+    console.error(
+      "没有可用 token（auth 环节缺失）。三种拿法：\n" +
+        "  1) 让邀请人发 join/invite URL：party up 'https://<server>/c/<slug>?t=<token>'\n" +
+        "  2) 拿到 token 后：AGENTPARTY_TOKEN='<token>' party up <slug>\n" +
+        "  3) 人类账号：party login --server <URL> 走浏览器登录",
+    );
+    return 1;
+  }
+  const rawServer = str(flags.server) ?? target.server ?? cfg?.server;
+  if (rawServer === undefined) {
+    console.error("不知道 server：传频道 URL、--server，或先 party init");
+    return 1;
+  }
+  const server = normalizeServerUrl(rawServer);
+  if (server === null) {
+    console.error("server 必须是不带凭据的 http(s) URL");
+    return 1;
+  }
+  const flagChannel = str(flags.channel);
+  if (flagChannel !== undefined && !isSlug(flagChannel)) {
+    console.error("channel must match [a-z0-9][a-z0-9-]{0,63}");
+    return 1;
+  }
+  const channel = flagChannel ?? target.channel ?? st?.channel ?? cfg?.identity?.channel_scope ?? undefined;
+  if (channel === undefined || channel === null) {
+    console.error("不知道要加入哪个频道：传频道 URL、slug 或 --channel");
+    return 1;
+  }
+
+  // TMPDIR 防线（tmpdir-token-loss）：显式 config 落在临时目录时，指出持久镜像路径。
+  // writeConfig 本身已自动镜像到 ~/.agentparty/agents/，这里把暗坑说出声。
+  const explicit = explicitConfigPath();
+  if (explicit !== null) {
+    const durable = durableConfigPointerPath(explicit);
+    if (durable !== explicit) {
+      console.error(
+        `warning: AGENTPARTY_CONFIG 指向临时目录（会被系统清掉）。已同步持久镜像：${durable}\n` +
+          `  建议改用：export AGENTPARTY_CONFIG="${durable}"`,
+      );
+    }
+  }
+
+  const health = deps.readHealth(channel);
+  const steps = planUp({
+    hasToken: true,
+    needBind: needsBind({
+      cfgServer: cfg?.server,
+      cfgToken: cfg?.token,
+      boundChannel: st?.channel,
+      server,
+      token,
+      channel,
+    }),
+    runnerHealthy: health.healthy,
+  });
+
+  if (steps.includes("bind")) {
+    console.log(`up: 绑定频道 #${channel}（等价 party init）`);
+    // token 走环境变量递给 init，不进 argv/ps。
+    const prevEnv = process.env.AGENTPARTY_TOKEN;
+    process.env.AGENTPARTY_TOKEN = token;
+    try {
+      const code = await deps.runInit(["--server", server, "--channel", channel]);
+      if (code !== 0) return code;
+    } finally {
+      if (prevEnv === undefined) delete process.env.AGENTPARTY_TOKEN;
+      else process.env.AGENTPARTY_TOKEN = prevEnv;
+    }
+  } else {
+    console.log(`up: config 已就绪（#${channel} @ ${server}）`);
+  }
+
+  let pid: number | undefined;
+  if (steps.includes("serve")) {
+    const spawned = deps.spawnServe(channel, runner);
+    if (spawned === null) {
+      console.error("up: serve runner 拉起失败——手动跑：party serve " + channel + ` --runner ${runner} --replay-backlog`);
+      return 1;
+    }
+    pid = spawned;
+    console.log(`up: serve runner 已拉起（--runner ${runner} --replay-backlog，积压 @ 会被逐条排空）`);
+  } else {
+    pid = health.pid;
+    console.log("up: serve runner 已在线，跳过");
+  }
+
+  const name = readConfig()?.identity?.name ?? cfg?.identity?.name ?? "(unverified)";
+  console.log(`you are ${name} in ${channel}, reachable via serve (pid ${pid ?? "?"})`);
+  console.log(`别人怎么找到你：party who ${channel} 里的 ${name}，@${name} 即可唤醒`);
+  return 0;
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -18,6 +18,7 @@ commands:
   agent     add <name> [--channel-scope slug] | create <handle> --runner codex|claude|codex-sdk|shell [--invitable-by owner|org|anyone] | list
   spawn     <worker> --channel-scope slug [--ttl 2h] create a short-lived worker from the front agent
   init      --server URL --token T [--channel C]   write config, bind channel (create if missing)
+  up        [channel-url|slug] [--runner claude|codex|codex-sdk]   one idempotent command: token → bind → resident serve (self-heal, #837)
   send      <text|-> [--channel C] [--mention name]... [--reply-to seq]
   complete  <text|-> --kickoff-seq seq [--channel C] [--replies n] [--timeout] [--issue n]... [--pr n]...
   review    approve|reject <seq> [-m reason] [--channel C] [--json]
@@ -94,6 +95,8 @@ export async function main(argv: string[]): Promise<number> {
       return (await import("./commands/spawn")).run(rest);
     case "init":
       return (await import("./commands/init")).run(rest);
+    case "up":
+      return (await import("./commands/up")).run(rest);
     case "send":
       return (await import("./commands/send")).run(rest);
     case "complete":

--- a/cli/test/up.test.ts
+++ b/cli/test/up.test.ts
@@ -1,0 +1,214 @@
+// party up（#837）：幂等分支判定 + 目标解析 + run() 各环节只补缺的部分。
+// serve 拉起全部走 deps 注入的 mock —— 单测绝不真起 daemon。
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { writeConfig, writeState } from "../src/config";
+import { needsBind, parseUpTarget, planUp, run, type UpDeps, type UpStep } from "../src/commands/up";
+
+let home: string;
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "ap-up-test-"));
+  for (const k of ["AGENTPARTY_HOME", "AGENTPARTY_CONFIG", "AGENTPARTY_TOKEN"]) {
+    savedEnv[k] = process.env[k];
+    delete process.env[k];
+  }
+  process.env.AGENTPARTY_HOME = home;
+  process.env.AGENTPARTY_CONFIG = join(home, "agents", "up-test.json");
+});
+
+afterEach(() => {
+  for (const [k, v] of Object.entries(savedEnv)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe("parseUpTarget", () => {
+  test("无参数 → 全 null", () => {
+    expect(parseUpTarget(undefined)).toEqual({ server: null, channel: null, token: null });
+  });
+  test("join URL 带 token", () => {
+    expect(parseUpTarget("https://ap.example.com/c/dev-room?t=ap_secret")).toEqual({
+      server: "https://ap.example.com",
+      channel: "dev-room",
+      token: "ap_secret",
+    });
+  });
+  test("频道 URL 不带 token", () => {
+    expect(parseUpTarget("https://ap.example.com/c/dev-room")).toEqual({
+      server: "https://ap.example.com",
+      channel: "dev-room",
+      token: null,
+    });
+  });
+  test("裸 slug", () => {
+    expect(parseUpTarget("dev-room")).toEqual({ server: null, channel: "dev-room", token: null });
+  });
+  test("非频道 URL → error", () => {
+    expect(parseUpTarget("https://ap.example.com/about")).toHaveProperty("error");
+  });
+  test("非法 slug → error", () => {
+    expect(parseUpTarget("Not A Slug!")).toHaveProperty("error");
+  });
+});
+
+describe("planUp 幂等分支矩阵", () => {
+  const cases: Array<[boolean, boolean, boolean, UpStep[]]> = [
+    // [hasToken, needBind, runnerHealthy] → steps
+    [true, false, true, []],
+    [true, false, false, ["serve"]],
+    [true, true, true, ["bind"]],
+    [true, true, false, ["bind", "serve"]],
+    [false, true, false, ["auth", "bind", "serve"]],
+    [false, false, true, ["auth"]],
+    [false, false, false, ["auth", "serve"]],
+    [false, true, true, ["auth", "bind"]],
+  ];
+  for (const [hasToken, needBind, runnerHealthy, expected] of cases) {
+    test(`token=${hasToken} bind=${needBind} healthy=${runnerHealthy} → [${expected.join(",")}]`, () => {
+      expect(planUp({ hasToken, needBind, runnerHealthy })).toEqual(expected);
+    });
+  }
+});
+
+describe("needsBind", () => {
+  const base = {
+    cfgServer: "https://s",
+    cfgToken: "t1",
+    boundChannel: "c1",
+    server: "https://s",
+    token: "t1",
+    channel: "c1",
+  };
+  test("全一致 → false", () => expect(needsBind(base)).toBe(false));
+  test("token 漂移 → true", () => expect(needsBind({ ...base, token: "t2" })).toBe(true));
+  test("server 漂移 → true", () => expect(needsBind({ ...base, server: "https://s2" })).toBe(true));
+  test("频道未绑 → true", () => expect(needsBind({ ...base, boundChannel: undefined })).toBe(true));
+  test("换频道 → true", () => expect(needsBind({ ...base, channel: "c2" })).toBe(true));
+});
+
+interface CallLog {
+  initArgv: string[][];
+  initEnvToken: Array<string | undefined>;
+  spawned: Array<{ channel: string; runner: string }>;
+}
+
+function mockDeps(opts: { healthy: boolean; pid?: number; initCode?: number; spawnPid?: number | null }): {
+  deps: UpDeps;
+  calls: CallLog;
+} {
+  const calls: CallLog = { initArgv: [], initEnvToken: [], spawned: [] };
+  return {
+    calls,
+    deps: {
+      readHealth: () => ({ healthy: opts.healthy, pid: opts.pid }),
+      runInit: async (argv) => {
+        calls.initArgv.push(argv);
+        calls.initEnvToken.push(process.env.AGENTPARTY_TOKEN);
+        return opts.initCode ?? 0;
+      },
+      spawnServe: (channel, runner) => {
+        calls.spawned.push({ channel, runner });
+        return opts.spawnPid === undefined ? 4242 : opts.spawnPid;
+      },
+    },
+  };
+}
+
+function readyConfig(): void {
+  writeConfig({
+    server: "https://ap.example.com",
+    token: "ap_secret",
+    identity: {
+      name: "leo-claude",
+      email: null,
+      kind: "agent",
+      role: "agent",
+      owner: "leo",
+      owner_handle: null,
+      owner_display_name: null,
+      channel_scope: "dev-room",
+      verified_at: 1,
+    },
+  } as Parameters<typeof writeConfig>[0]);
+  writeState({ channel: "dev-room", cursor: 7 });
+}
+
+describe("run — 幂等只补缺的环节", () => {
+  test("全部就绪：不 init、不 spawn，exit 0", async () => {
+    readyConfig();
+    const { deps, calls } = mockDeps({ healthy: true, pid: 123 });
+    expect(await run([], deps)).toBe(0);
+    expect(calls.initArgv).toEqual([]);
+    expect(calls.spawned).toEqual([]);
+  });
+
+  test("runner 挂了：只重拉 serve，不重新 init", async () => {
+    readyConfig();
+    const { deps, calls } = mockDeps({ healthy: false });
+    expect(await run([], deps)).toBe(0);
+    expect(calls.initArgv).toEqual([]);
+    expect(calls.spawned).toEqual([{ channel: "dev-room", runner: "claude" }]);
+  });
+
+  test("全新机器 + join URL：init（token 走 env 不进 argv）+ 拉 serve", async () => {
+    const { deps, calls } = mockDeps({ healthy: false });
+    expect(await run(["https://ap.example.com/c/dev-room?t=ap_new"], deps)).toBe(0);
+    expect(calls.initArgv).toEqual([["--server", "https://ap.example.com", "--channel", "dev-room"]]);
+    expect(calls.initEnvToken).toEqual(["ap_new"]);
+    // init 期间临时注入的 env token 不泄漏到后续进程环境
+    expect(process.env.AGENTPARTY_TOKEN).toBeUndefined();
+    expect(calls.spawned).toEqual([{ channel: "dev-room", runner: "claude" }]);
+  });
+
+  test("token 漂移（URL 给了新 token）：重新 init", async () => {
+    readyConfig();
+    const { deps, calls } = mockDeps({ healthy: true, pid: 9 });
+    expect(await run(["https://ap.example.com/c/dev-room?t=ap_rotated"], deps)).toBe(0);
+    expect(calls.initArgv.length).toBe(1);
+    expect(calls.initEnvToken).toEqual(["ap_rotated"]);
+    expect(calls.spawned).toEqual([]);
+  });
+
+  test("无 token 任何来源：auth 环节缺失，exit 1，不 init 不 spawn", async () => {
+    const { deps, calls } = mockDeps({ healthy: false });
+    expect(await run(["dev-room", "--server", "https://ap.example.com"], deps)).toBe(1);
+    expect(calls.initArgv).toEqual([]);
+    expect(calls.spawned).toEqual([]);
+  });
+
+  test("不知道频道：exit 1", async () => {
+    const { deps } = mockDeps({ healthy: false });
+    process.env.AGENTPARTY_TOKEN = "ap_x";
+    expect(await run(["--server", "https://ap.example.com"], deps)).toBe(1);
+  });
+
+  test("init 失败：透传退出码，不再拉 serve", async () => {
+    const { deps, calls } = mockDeps({ healthy: false, initCode: 3 });
+    expect(await run(["https://ap.example.com/c/dev-room?t=ap_bad"], deps)).toBe(3);
+    expect(calls.spawned).toEqual([]);
+  });
+
+  test("serve 拉起失败：exit 1", async () => {
+    readyConfig();
+    const { deps } = mockDeps({ healthy: false, spawnPid: null });
+    expect(await run([], deps)).toBe(1);
+  });
+
+  test("--runner codex 透传给 spawnServe", async () => {
+    readyConfig();
+    const { deps, calls } = mockDeps({ healthy: false });
+    expect(await run(["--runner", "codex"], deps)).toBe(0);
+    expect(calls.spawned).toEqual([{ channel: "dev-room", runner: "codex" }]);
+  });
+
+  test("非法 runner：exit 1", async () => {
+    const { deps } = mockDeps({ healthy: true });
+    expect(await run(["--runner", "bash"], deps)).toBe(1);
+  });
+});


### PR DESCRIPTION
Closes #837

## 内容

新增 `party up [channel-url-or-invite|slug]`：把入门三道门（token → `party init` 绑频道 → serve 常驻）收敛成一条幂等命令，兼作健康自愈可反复跑。

- **auth**：token 来源优先级 URL `?t=` → `AGENTPARTY_TOKEN` env → 已有 config；都没有时给出三种拿法（invite URL / env / `party login`），不静默失败。
- **bind**：config/token/server/channel 任一漂移即重新 init（token 走 env 递给 init，不进 argv/ps）。`AGENTPARTY_CONFIG` 落临时目录时警告并指出 `~/.agentparty/agents/` 持久镜像路径（tmpdir-token-loss 防线）。
- **serve**：用本地 health 快照（#254）判定 runner 存活，挂了才重拉；拉起姿势 `party serve <c> --runner claude --replay-backlog`（挂上即逐条排空积压 @，待命用 serve 不用 watch --once），日志落 `~/.agentparty/logs/up-serve-<c>.log`。
- 收尾一行状态：`you are <name> in <channel>, reachable via serve (pid N)` + 怎么被找到。

## 幂等分支矩阵（planUp，单测逐格覆盖）

| hasToken | needBind | runnerHealthy | steps |
|---|---|---|---|
| ✓ | ✗ | ✓ | []（全就绪，纯幂等） |
| ✓ | ✗ | ✗ | [serve] |
| ✓ | ✓ | ✓ | [bind] |
| ✓ | ✓ | ✗ | [bind, serve] |
| ✗ | * | * | 含 auth（run 里直接报路径，exit 1） |

## 测试

- `cli/test/up.test.ts`：29 pass（parseUpTarget / planUp 矩阵 / needsBind / run() 各环节；serve 拉起全走 deps mock，绝不真起 daemon）
- `bun x tsc --noEmit` 通过；`cli.test.ts` + `exit-codes.test.ts` 回归通过