### PR TITLE
feat(cli): 频道回帖成功后追加同机 Cross-session wake-hint (#836)

### DIFF
--- a/cli/src/commands/claude-channel.ts
+++ b/cli/src/commands/claude-channel.ts
@@ -354,6 +354,61 @@ export function confirmClaudeCrossSessionPeer(
   };
 }
 
+const WAKE_HINT_MENTION_RE = /@([A-Za-z0-9][A-Za-z0-9_-]{0,63})/g;
+
+/** Extract advisory @mention targets from a reply body. Server-side mention
+ * resolution stays authoritative; this is only used to decide whether the
+ * same-machine wake hint below is worth appending. */
+export function claudeCrossSessionWakeHintTargets(text: string): string[] {
+  const targets = new Set<string>();
+  for (const match of text.matchAll(WAKE_HINT_MENTION_RE)) {
+    const name = match[1]!;
+    if (isName(name)) targets.add(name);
+  }
+  return [...targets];
+}
+
+/**
+ * Same-machine wake hint (#836). After a channel post succeeds inside an armed
+ * bridge session, nudge the model when a mentioned peer is still listed in the
+ * local Claude Cross-session gate state. The channel stays the single source
+ * of truth: the hint only proposes a ≤512-byte channel+seq notification via
+ * the existing authorization chain, never an alternate transport. Listings
+ * carry a TTL and may be stale, so the wording never asserts liveness.
+ */
+export function claudeCrossSessionWakeHint(
+  targets: readonly string[],
+  peers: ClaudeCrossSessionPeerSummary | undefined,
+  postedSeq: number,
+  armed: () => boolean = isClaudeCrossSessionGateArmed,
+  resolveListedAddress: (
+    agent: string,
+    displayName: string,
+    candidateRef: string,
+  ) => string | null = listedClaudeCrossSessionAddress,
+): string | null {
+  if (peers === undefined || peers.availability !== "ready" || targets.length === 0 || !armed()) {
+    return null;
+  }
+  const wanted = new Set(targets);
+  const listedAgents = [...new Set(peers.peers.flatMap((peer) =>
+    wanted.has(peer.agent) && peer.claude_sessions.some((session) =>
+        session.candidate_ref !== null &&
+        resolveListedAddress(peer.agent, session.display_name, session.candidate_ref) !== null)
+      ? [peer.agent]
+      : []))];
+  if (listedAgents.length === 0) return null;
+  return (
+    `Cross-session wake hint: ${listedAgents.map((agent) => `@${agent}`).join(", ")} may be reachable ` +
+    "locally — a Claude Cross-session listing still matches this mention. Listings expire and can be " +
+    "stale, so this is not proof of a live session. If an earlier local wake would help, follow the " +
+    `full authorization chain first: ${PEERS_TOOL}, then Claude's built-in ListAgents, then ` +
+    `${PEER_CHECK_TOOL}, and only after a confirmed check send one SendMessage of at most 512 UTF-8 ` +
+    `bytes that carries only a channel+seq reference (this channel, seq=${postedSeq}) and no message ` +
+    "body. The AgentParty channel remains the single source of truth; the peer reads the message there."
+  );
+}
+
 const HELP = `usage: party claude-channel [channel|--channel C] [--require-launch-opt-in]
 
 Internal stdio MCP adapter for \`party claude\` and \`party bridge claude\`.
@@ -2217,6 +2272,11 @@ export class ClaudeChannelDeliveryBridge {
     };
   }
 
+  /** Sender of a still-pending channel message; the linked reply mentions it. */
+  pendingSender(seq: number): string | null {
+    return this.pending.get(seq)?.message.sender.name ?? null;
+  }
+
   async reply(seq: number, text: string): Promise<{ seq: number }> {
     if (!Number.isSafeInteger(seq) || seq <= 0) {
       throw new Error("seq must be a positive integer");
@@ -2504,6 +2564,9 @@ export async function run(argv: string[]): Promise<number> {
     },
   });
   let firstEligiblePeersCall = true;
+  // Last topology snapshot handed to the model. The #836 wake hint only reuses
+  // candidates the model already saw; the gate state decides if one is listed.
+  let lastReadyPeersSummary: ClaudeCrossSessionPeerSummary | undefined;
 
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
     tools: [
@@ -2688,6 +2751,7 @@ export async function run(argv: string[]): Promise<number> {
       );
       if (request.params.name === PEERS_TOOL) firstEligiblePeersCall = false;
       const summary = await loadClaudeCrossSessionPeersWithStartupRetry(loadPeers, retryDelays);
+      if (summary.availability === "ready") lastReadyPeersSummary = summary;
       return toolResult(JSON.stringify(request.params.name === PEERS_TOOL
         ? summary
         : confirmClaudeCrossSessionPeer(
@@ -2735,8 +2799,22 @@ export async function run(argv: string[]): Promise<number> {
       return toolResult(`${REPLY_TOOL} requires integer seq and string text`, true);
     }
     try {
+      // Capture the reply's directed mention target before the successful post
+      // clears the pending entry.
+      const replyTarget = bridge.pendingSender(seq);
       const posted = await bridge.reply(seq, text);
-      return toolResult(`AgentParty reply persisted as seq=${posted.seq} (reply_to=${seq}).`);
+      const hint = claudeCrossSessionWakeHint(
+        [...new Set([
+          ...(replyTarget === null ? [] : [replyTarget]),
+          ...claudeCrossSessionWakeHintTargets(text),
+        ])],
+        lastReadyPeersSummary,
+        posted.seq,
+      );
+      return toolResult(
+        `AgentParty reply persisted as seq=${posted.seq} (reply_to=${seq}).` +
+          (hint === null ? "" : `\n${hint}`),
+      );
     } catch (error) {
       return toolResult(error instanceof Error ? error.message : String(error), true);
     }

--- a/cli/test/claude-channel.test.ts
+++ b/cli/test/claude-channel.test.ts
@@ -24,6 +24,8 @@ import {
 import {
   ClaudeChannelDeliveryBridge,
   claudeCrossSessionPeerStartupRetryDelays,
+  claudeCrossSessionWakeHint,
+  claudeCrossSessionWakeHintTargets,
   confirmClaudeCrossSessionPeer,
   loadClaudeCrossSessionPeersWithStartupRetry,
   summarizeClaudeCrossSessionPeers,
@@ -2372,6 +2374,79 @@ describe("Claude Cross-session peer correlation", () => {
     }]));
     expect(confirmClaudeCrossSessionPeer(ambiguous, "peer", "review-session", candidateRef).availability)
       .toBe("stale_or_ambiguous");
+  });
+});
+
+describe("Claude Cross-session wake hint (#836)", () => {
+  const candidateRef = "candidate_1234567890abcdef";
+  const readySummary = () => summarizeClaudeCrossSessionPeers(
+    "dev",
+    "me",
+    [{ name: "peer", kind: "agent", state: "working", note: null, ts: 1, live: true }],
+    {
+      version: 3,
+      topology_evidence: "client_asserted",
+      comparison: "server_derived",
+      caller_binding: "live_socket",
+      self: "me",
+      peers: [{
+        agent: "peer",
+        same_identity: false,
+        relations: [{ relation: "same_worktree", runtime_count: 1 }],
+        claude_sessions: [{
+          display_name: "peer-session",
+          relation: "same_worktree",
+          runtime_count: 1,
+          candidate_ref: candidateRef,
+        }],
+      }],
+    },
+  );
+
+  test("extracts advisory @mention targets from a reply body", () => {
+    expect(claudeCrossSessionWakeHintTargets("@peer please read seq=7, cc @other-agent and @peer again"))
+      .toEqual(["peer", "other-agent"]);
+    expect(claudeCrossSessionWakeHintTargets("no mentions here")).toEqual([]);
+  });
+
+  test("appends the nudge when armed and the mentioned peer is still listed", () => {
+    const resolved: string[] = [];
+    const hint = claudeCrossSessionWakeHint(
+      ["peer"],
+      readySummary(),
+      42,
+      () => true,
+      (agent, displayName, ref) => {
+        resolved.push(`${agent}/${displayName}/${ref}`);
+        return "peer-session [ref-a]";
+      },
+    );
+    expect(resolved).toEqual([`peer/peer-session/${candidateRef}`]);
+    expect(hint).toContain("@peer may be reachable locally");
+    expect(hint).toContain("Listings expire and can be stale");
+    expect(hint).toContain("party_channel_peers");
+    expect(hint).toContain("ListAgents");
+    expect(hint).toContain("party_channel_peer_check");
+    expect(hint).toContain("SendMessage");
+    expect(hint).toContain("512 UTF-8");
+    expect(hint).toContain("seq=42");
+    expect(hint).toContain("no message body");
+    expect(hint).not.toContain("[ref-a]");
+  });
+
+  test("stays silent when armed but no gate listing matches the mention", () => {
+    expect(claudeCrossSessionWakeHint(["peer"], readySummary(), 42, () => true, () => null))
+      .toBeNull();
+    expect(claudeCrossSessionWakeHint(["stranger"], readySummary(), 42, () => true, () => {
+      throw new Error("unmentioned candidates must not be resolved");
+    })).toBeNull();
+  });
+
+  test("stays silent when the local gate is not armed", () => {
+    expect(claudeCrossSessionWakeHint(["peer"], readySummary(), 42, () => false, () => {
+      throw new Error("an unarmed gate must not resolve listings");
+    })).toBeNull();
+    expect(claudeCrossSessionWakeHint(["peer"], undefined, 42, () => true)).toBeNull();
   });
 });
 


### PR DESCRIPTION
Closes #836

这是 **修正版方案**（按 issue 最后一条设计修正评论「重述为同机 wake-hint」实现），不是 issue 原文的直投方案——直投被两条硬阻断否决（shell 里没有 SendMessage 传输；512B/摘要-only 策略禁止正文直投）。

## 实现

- 仅改 `cli/src/commands/claude-channel.ts`：armed 的 bridge 会话内，`party_channel_reply`（频道 post 的 MCP handler）在 post **成功后**，若 `isClaudeCrossSessionGateArmed()` 且回帖目标 mention（reply 的定向 sender + 正文 @token）命中 gate state listings，则在工具结果文本追加 nudge。
- listing 命中判定复用已导出的 `listedClaudeCrossSessionAddress`：对模型已见过的 peers 快照里匹配 mention 的每个 (agent, display_name, candidate_ref) 三元组逐一核对，非空即命中——不新增 gate 导出。
- nudge 措辞：引用完整授权链 party_channel_peers → ListAgents → party_channel_peer_check → SendMessage；注明 ≤512 UTF-8 字节、只携带 channel+seq 引用不带正文；只说 "may be reachable locally"（listing 有 5min TTL 可能陈旧，不断言在线）；频道仍是唯一数据源。
- `gate.ts` / `serve.ts` / CLI `send.ts` 零改动。

## 测试

- 新增单测：armed+listing 命中（有 nudge，并校验措辞要素与不泄漏 send_to 地址）/ armed 但未命中（无 nudge，且不 resolve 未 mention 的候选）/ 未 arm（无 nudge，且不触碰 resolver）。
- `bun test test/claude-channel.test.ts` 101 pass；`claude-channel-mcp` + `claude-cross-session-gate` 26 pass；`tsc --noEmit` 通过。