### PR TITLE
feat(cli): 交互式 Claude 会话本机入册 + 蛰伏 announce 档（#841 P1+P2 切片）

### DIFF
--- a/cli/src/claude-session-registry.ts
+++ b/cli/src/claude-session-registry.ts
@@ -9,8 +9,10 @@
 // 目录校验与 claude-cross-session-gate.ts 的 gateDirectory 同款：拒符号链接、
 // 拒组/他人可读、拒非本 uid。AGENTPARTY_CLAUDE_SESSION_REGISTRY_DIR 可覆盖（测试用）。
 import {
+  closeSync,
   lstatSync,
   mkdirSync,
+  openSync,
   readdirSync,
   readFileSync,
   rmSync,
@@ -30,6 +32,33 @@ const CHANNEL_RE = /^[a-z0-9][a-z0-9-]{0,63}$/;
 const ENTRY_FILE_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.json$/;
 const MAX_ENTRY_BYTES = 4 * 1024;
+const REGISTER_LOCK_FILE = ".register.lock";
+const REGISTER_LOCK_WAIT_MS = 250;
+// 持锁进程死掉会留下孤儿锁；注册只有一次容量检查 + 一次原子写，10s 还没放锁必是尸体。
+const REGISTER_LOCK_STALE_MS = 10_000;
+
+/** O_EXCL 锁 + 有界等待（模式同 claude-cross-session-gate 的 waitForConsumeLock）。 */
+function waitForRegisterLock(lockPath: string): number | null {
+  const deadline = Date.now() + REGISTER_LOCK_WAIT_MS;
+  const sleeper = new Int32Array(new SharedArrayBuffer(4));
+  while (true) {
+    try {
+      return openSync(lockPath, "wx", 0o600);
+    } catch {
+      try {
+        if (Date.now() - lstatSync(lockPath).mtimeMs > REGISTER_LOCK_STALE_MS) {
+          rmSync(lockPath, { force: true });
+          continue;
+        }
+      } catch {
+        // 锁刚被释放：直接重试。
+      }
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) return null;
+      Atomics.wait(sleeper, 0, 0, Math.min(5, remaining));
+    }
+  }
+}
 
 export interface ClaudeSessionRegistryEntry {
   version: 1;
@@ -207,17 +236,25 @@ export function registerClaudeSession(
   const directory = claudeSessionRegistryDirectory(env, true);
   if (directory === null) return false;
   const filename = `${entry.session_id.toLowerCase()}.json`;
-  // listClaudeSessions 顺带剔死行/坏行，让容量判断只数活行。
-  const alive = listClaudeSessions(env);
-  const replacingSelf = alive.some(
-    (existing) => existing.session_id.toLowerCase() === entry.session_id.toLowerCase(),
-  );
-  if (!replacingSelf && alive.length >= CLAUDE_SESSION_REGISTRY_CAPACITY) return false;
+  // 容量检查 + 写入必须互斥：并发 SessionStart hook 是多进程，两个进程同时通过
+  // 「还差一个才满」的检查会超额写入。拿不到锁按拒绝处理（hook 静默，安全侧）。
+  const lockPath = join(directory, REGISTER_LOCK_FILE);
+  const lockFd = waitForRegisterLock(lockPath);
+  if (lockFd === null) return false;
   try {
+    // listClaudeSessions 顺带剔死行/坏行，让容量判断只数活行。
+    const alive = listClaudeSessions(env);
+    const replacingSelf = alive.some(
+      (existing) => existing.session_id.toLowerCase() === entry.session_id.toLowerCase(),
+    );
+    if (!replacingSelf && alive.length >= CLAUDE_SESSION_REGISTRY_CAPACITY) return false;
     atomicWriteJson(join(directory, filename), entry, 0o600);
     return true;
   } catch {
     return false;
+  } finally {
+    closeSync(lockFd);
+    rmSync(lockPath, { force: true });
   }
 }
 

--- a/cli/src/claude-session-registry.ts
+++ b/cli/src/claude-session-registry.ts
@@ -1,0 +1,237 @@
+// 本机 Claude 会话注册表（issue #841 P1）。
+//
+// 目的：人日常开的交互式 `claude`（装了 agentparty 插件）在 SessionStart 时入册、
+// SessionEnd 时出册，让 party 侧（蛰伏 MCP 的 announce 档、后续 serve 唤醒代理）
+// 知道「本机有哪些还活着的交互式 Claude 会话」。注册表只是本机发现提示：
+// 频道仍是唯一数据源，条目永远不构成任何鉴权、路由或投递依据。
+//
+// 落盘：~/.agentparty/claude-sessions/<session_id 小写>.json（目录 0700、文件 0600）。
+// 目录校验与 claude-cross-session-gate.ts 的 gateDirectory 同款：拒符号链接、
+// 拒组/他人可读、拒非本 uid。AGENTPARTY_CLAUDE_SESSION_REGISTRY_DIR 可覆盖（测试用）。
+import {
+  lstatSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+} from "node:fs";
+import { isAbsolute, join } from "node:path";
+import { agentpartyHome } from "./config";
+import { atomicWriteJson } from "./atomic-json";
+
+export const CLAUDE_SESSION_REGISTRY_DIR_ENV = "AGENTPARTY_CLAUDE_SESSION_REGISTRY_DIR";
+/** 容量上限：满了先剔死行，仍满则拒新——绝不覆盖活行。 */
+export const CLAUDE_SESSION_REGISTRY_CAPACITY = 128;
+
+const SESSION_ID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const DISPLAY_NAME_RE = /^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$/;
+const CHANNEL_RE = /^[a-z0-9][a-z0-9-]{0,63}$/;
+const ENTRY_FILE_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.json$/;
+const MAX_ENTRY_BYTES = 4 * 1024;
+
+export interface ClaudeSessionRegistryEntry {
+  version: 1;
+  session_id: string;
+  pid: number;
+  display_name: string | null;
+  channel: string;
+  cwd: string;
+  registered_at: number;
+}
+
+function record(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function isClaudeSessionRegistrySessionId(value: unknown): value is string {
+  return typeof value === "string" && SESSION_ID_RE.test(value);
+}
+
+function validEntry(value: unknown): value is ClaudeSessionRegistryEntry {
+  return record(value) &&
+    value.version === 1 &&
+    isClaudeSessionRegistrySessionId(value.session_id) &&
+    typeof value.pid === "number" &&
+    Number.isInteger(value.pid) &&
+    value.pid > 0 &&
+    (value.display_name === null ||
+      (typeof value.display_name === "string" && DISPLAY_NAME_RE.test(value.display_name))) &&
+    typeof value.channel === "string" &&
+    CHANNEL_RE.test(value.channel) &&
+    typeof value.cwd === "string" &&
+    value.cwd !== "" &&
+    isAbsolute(value.cwd) &&
+    typeof value.registered_at === "number" &&
+    Number.isFinite(value.registered_at);
+}
+
+function validDirectory(path: string): string | null {
+  try {
+    const stat = lstatSync(path);
+    if (
+      !stat.isDirectory() ||
+      stat.isSymbolicLink() ||
+      (stat.mode & 0o077) !== 0 ||
+      (typeof process.getuid === "function" && stat.uid !== process.getuid())
+    ) return null;
+    return path;
+  } catch {
+    return null;
+  }
+}
+
+/** 解析注册表目录；`create` 只对默认路径生效——环境变量覆盖的目录必须已存在且合规。 */
+export function claudeSessionRegistryDirectory(
+  env: NodeJS.ProcessEnv = process.env,
+  create = false,
+): string | null {
+  const override = env[CLAUDE_SESSION_REGISTRY_DIR_ENV];
+  if (typeof override === "string" && override !== "") {
+    return isAbsolute(override) ? validDirectory(override) : null;
+  }
+  const path = join(agentpartyHome(), "claude-sessions");
+  const existing = validDirectory(path);
+  if (existing !== null || !create) return existing;
+  try {
+    mkdirSync(path, { recursive: true, mode: 0o700 });
+  } catch {
+    return null;
+  }
+  return validDirectory(path);
+}
+
+/** kill(pid, 0) 探活：EPERM 也算活（进程在，只是不属于我们——注册表不该出现，但按活处理更保守）。 */
+function pidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+function readEntry(directory: string, filename: string): ClaudeSessionRegistryEntry | null {
+  const path = join(directory, filename);
+  try {
+    const stat = lstatSync(path);
+    if (
+      !stat.isFile() ||
+      stat.isSymbolicLink() ||
+      stat.size > MAX_ENTRY_BYTES ||
+      (stat.mode & 0o077) !== 0 ||
+      (typeof process.getuid === "function" && stat.uid !== process.getuid())
+    ) return null;
+    const value = JSON.parse(readFileSync(path, "utf8")) as unknown;
+    if (!validEntry(value)) return null;
+    // 文件名就是身份：不一致的行按坏行处理，防止一个 session 冒名另一个。
+    if (`${value.session_id.toLowerCase()}.json` !== filename) return null;
+    return value;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 列出仍然存活的入册会话（按 registered_at 升序）。
+ * 死行（pid 不在）与坏行（解析/校验失败）现场清除。
+ */
+export function listClaudeSessions(
+  env: NodeJS.ProcessEnv = process.env,
+): ClaudeSessionRegistryEntry[] {
+  const directory = claudeSessionRegistryDirectory(env);
+  if (directory === null) return [];
+  let filenames: string[];
+  try {
+    filenames = readdirSync(directory);
+  } catch {
+    return [];
+  }
+  const alive: ClaudeSessionRegistryEntry[] = [];
+  for (const filename of filenames) {
+    if (!ENTRY_FILE_RE.test(filename)) continue;
+    const entry = readEntry(directory, filename);
+    if (entry !== null && pidAlive(entry.pid)) {
+      alive.push(entry);
+      continue;
+    }
+    try {
+      rmSync(join(directory, filename), { force: true });
+    } catch {
+      // 清不掉就留给下次；列出结果不受影响。
+    }
+  }
+  return alive.sort((a, b) => a.registered_at - b.registered_at);
+}
+
+export function claudeSessionAlive(
+  sessionId: string,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if (!isClaudeSessionRegistrySessionId(sessionId)) return false;
+  const wanted = sessionId.toLowerCase();
+  return listClaudeSessions(env).some((entry) => entry.session_id.toLowerCase() === wanted);
+}
+
+export interface RegisterClaudeSessionInput {
+  session_id: string;
+  pid: number;
+  display_name: string | null;
+  channel: string;
+  cwd: string;
+  registered_at?: number;
+}
+
+/**
+ * 入册一个交互式 Claude 会话。已入册的同一 session 重复注册（resume/clear）覆盖自身。
+ * 容量满时先剔死行；仍满则拒绝（返回 false），绝不覆盖别人的活行。
+ */
+export function registerClaudeSession(
+  input: RegisterClaudeSessionInput,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  const entry: ClaudeSessionRegistryEntry = {
+    version: 1,
+    session_id: input.session_id,
+    pid: input.pid,
+    display_name:
+      typeof input.display_name === "string" && DISPLAY_NAME_RE.test(input.display_name)
+        ? input.display_name
+        : null,
+    channel: input.channel,
+    cwd: input.cwd,
+    registered_at: input.registered_at ?? Date.now(),
+  };
+  if (!validEntry(entry)) return false;
+  const directory = claudeSessionRegistryDirectory(env, true);
+  if (directory === null) return false;
+  const filename = `${entry.session_id.toLowerCase()}.json`;
+  // listClaudeSessions 顺带剔死行/坏行，让容量判断只数活行。
+  const alive = listClaudeSessions(env);
+  const replacingSelf = alive.some(
+    (existing) => existing.session_id.toLowerCase() === entry.session_id.toLowerCase(),
+  );
+  if (!replacingSelf && alive.length >= CLAUDE_SESSION_REGISTRY_CAPACITY) return false;
+  try {
+    atomicWriteJson(join(directory, filename), entry, 0o600);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function unregisterClaudeSession(
+  sessionId: string,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if (!isClaudeSessionRegistrySessionId(sessionId)) return false;
+  const directory = claudeSessionRegistryDirectory(env);
+  if (directory === null) return false;
+  try {
+    rmSync(join(directory, `${sessionId.toLowerCase()}.json`), { force: true });
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/cli/src/commands/claude-channel.ts
+++ b/cli/src/commands/claude-channel.ts
@@ -33,6 +33,10 @@ import { randomUUID } from "node:crypto";
 import pkg from "../../package.json" with { type: "json" };
 import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
 import { connect, type Connection } from "../client";
+import {
+  listClaudeSessions,
+  type ClaudeSessionRegistryEntry,
+} from "../claude-session-registry";
 import { loadCursor, resolveChannel, saveCursor } from "../config";
 import {
   DeliveryRecoveryJournal,
@@ -424,7 +428,139 @@ export function claudeChannelLaunchOptedIn(
   return env[CLAUDE_CHANNEL_OPT_IN_ENV] === "1";
 }
 
-async function runDormantClaudeChannelMcp(): Promise<number> {
+// ---- 蛰伏 announce 档（issue #841 P2）----
+//
+// 已入册的交互式 Claude 会话（本机会话注册表，#841 P1）在蛰伏 MCP 里加一个
+// announce-only 档位：连 WS 只上报 runtime topology + harness_session，让
+// worker 的 peers 投影天然把它列进 claude_sessions（do.ts 零改动）。
+// 铁律：不 claim delivery（不声明 directedDelivery/deliveryRecovery/
+// advertiseWakeKind 能力）、不取 serve 锁、不持久化游标。活体检测 = 会话进程
+// 退出（注册表探活失败）或 Claude 关掉 MCP → WS 断开即从投影消失，不发明 TTL。
+
+const DORMANT_ANNOUNCE_POLL_MS = 5_000;
+const DORMANT_ANNOUNCE_LIVENESS_MS = 30_000;
+
+/** 注册表没记 display_name（当前 hook payload 拿不到）时的确定性回退名。 */
+export function dormantAnnounceDisplayName(entry: ClaudeSessionRegistryEntry): string {
+  if (entry.display_name !== null) return entry.display_name;
+  return `claude-${entry.session_id.toLowerCase().replace(/-/g, "").slice(0, 12)}`;
+}
+
+/** 选择要宣告的入册会话：同 channel 必须；优先同 cwd；同优先级取最新入册。 */
+export function selectDormantAnnounceEntry(
+  entries: readonly ClaudeSessionRegistryEntry[],
+  channel: string,
+  cwd: string,
+): ClaudeSessionRegistryEntry | null {
+  const matching = entries.filter((entry) => entry.channel === channel);
+  if (matching.length === 0) return null;
+  const pick = (candidates: readonly ClaudeSessionRegistryEntry[]) =>
+    candidates.length === 0
+      ? null
+      : candidates.reduce((a, b) => (b.registered_at >= a.registered_at ? b : a));
+  return pick(matching.filter((entry) => entry.cwd === cwd)) ?? pick(matching);
+}
+
+export interface DormantAnnounceDeps {
+  listSessions: () => ClaudeSessionRegistryEntry[];
+  resolveAuth: () => Promise<{ server?: string | null; token?: string | null }>;
+  connect: typeof connect;
+  buildTopology: typeof buildRuntimeTopology;
+  loadCursor: (channel: string) => number;
+  cwd?: string;
+  pollIntervalMs?: number;
+  livenessIntervalMs?: number;
+}
+
+function abortableSleep(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal.aborted) return resolve();
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+/**
+ * announce-only 主循环：等到注册表里出现本 channel 的活会话（SessionStart hook
+ * 可能晚于 MCP 启动），随后保持一条只带 topology/harness_session 的 WS 连接。
+ * 会话死亡或 signal 中止即断开。任何失败静默退出——蛰伏进程不许打扰 Claude。
+ */
+export async function runDormantClaudeSessionAnnounce(
+  channel: string,
+  signal: AbortSignal,
+  deps: DormantAnnounceDeps,
+): Promise<void> {
+  const cwd = deps.cwd ?? process.cwd();
+  const pollMs = deps.pollIntervalMs ?? DORMANT_ANNOUNCE_POLL_MS;
+  const livenessMs = deps.livenessIntervalMs ?? DORMANT_ANNOUNCE_LIVENESS_MS;
+  if (!isSlug(channel)) return;
+  while (!signal.aborted) {
+    let entry: ClaudeSessionRegistryEntry | null = null;
+    try {
+      entry = selectDormantAnnounceEntry(deps.listSessions(), channel, cwd);
+    } catch {
+      return;
+    }
+    if (entry === null) {
+      await abortableSleep(pollMs, signal);
+      continue;
+    }
+    const auth = await deps.resolveAuth().catch(() => null);
+    if (!auth?.server || !auth.token) return;
+    const topology = deps.buildTopology(auth.server, entry.cwd, {
+      harnessSession: {
+        harness: "claude",
+        display_name: dormantAnnounceDisplayName(entry),
+      },
+    });
+    if (topology === undefined) return;
+    // 只声明 runtimeTopology：无 directedDelivery / deliveryRecovery /
+    // advertiseWakeKind / onCursor——服务端不会给这条连接派任何 delivery，
+    // 消费到的普通消息只本地 ack（防积压），绝不推进持久化游标。
+    const connection = deps.connect(auth.server, auth.token, channel, deps.loadCursor(channel), {
+      runtimeTopology: topology,
+    });
+    const sessionId = entry.session_id;
+    const liveness = setInterval(() => {
+      try {
+        const stillAlive = deps.listSessions().some(
+          (candidate) => candidate.session_id.toLowerCase() === sessionId.toLowerCase(),
+        );
+        if (!stillAlive) connection.close();
+      } catch {
+        connection.close();
+      }
+    }, livenessMs);
+    if (typeof (liveness as { unref?: () => void }).unref === "function") {
+      (liveness as unknown as { unref: () => void }).unref();
+    }
+    const onAbort = () => connection.close();
+    signal.addEventListener("abort", onAbort, { once: true });
+    try {
+      for await (const frame of connection.frames) {
+        if (frame.type === "msg" || frame.type === "status") connection.ack(frame.seq);
+        if (frame.type === "error") return;
+      }
+    } catch {
+      return;
+    } finally {
+      clearInterval(liveness);
+      signal.removeEventListener("abort", onAbort);
+      connection.close();
+    }
+    // 帧流结束：会话死了就回到等待档（换会话可再宣告），否则稍候重试。
+    await abortableSleep(pollMs, signal);
+  }
+}
+
+async function runDormantClaudeChannelMcp(channel: string | null): Promise<number> {
   const server = new Server<Request, Notification, Result>(
     { name: "agentparty-channel-dormant", version: pkg.version },
     { capabilities: {} },
@@ -433,17 +569,32 @@ async function runDormantClaudeChannelMcp(): Promise<number> {
   const closed = new Promise<void>((resolve) => {
     markClosed = resolve;
   });
-  server.onclose = markClosed;
+  const abort = new AbortController();
+  server.onclose = () => {
+    abort.abort();
+    markClosed();
+  };
+  const announce = channel === null
+    ? Promise.resolve()
+    : runDormantClaudeSessionAnnounce(channel, abort.signal, {
+        listSessions: listClaudeSessions,
+        resolveAuth: resolveAuthDetailed,
+        connect,
+        buildTopology: buildRuntimeTopology,
+        loadCursor,
+      }).catch(() => {});
   try {
     await server.connect(new StdioServerTransport());
     await closed;
     return 0;
   } finally {
+    abort.abort();
     try {
       await server.close();
     } catch {
       // The stdio transport normally closes first when Claude exits.
     }
+    await announce;
   }
 }
 
@@ -2439,9 +2590,11 @@ export async function run(argv: string[]): Promise<number> {
 
   if (flags["require-launch-opt-in"] === true && !claudeChannelLaunchOptedIn()) {
     // Enabled plugins are initialized in every Claude session, even when this
-    // server is absent from --channels. Stay protocol-valid but do not resolve
-    // auth, connect AgentParty, claim delivery, or acquire the serve lock.
-    return runDormantClaudeChannelMcp();
+    // server is absent from --channels. Stay protocol-valid and never claim
+    // delivery or acquire the serve lock. #841 P2: when this machine's session
+    // registry lists a live interactive session for the bound channel, keep an
+    // announce-only WS up so the peers projection can list it.
+    return runDormantClaudeChannelMcp(resolveChannel(str(flags.channel) ?? positionals[0]));
   }
 
   const auth = await resolveAuthDetailed();

--- a/cli/src/commands/claude-channel.ts
+++ b/cli/src/commands/claude-channel.ts
@@ -514,6 +514,8 @@ export async function runDormantClaudeSessionAnnounce(
     }
     const auth = await deps.resolveAuth().catch(() => null);
     if (!auth?.server || !auth.token) return;
+    // resolveAuth 是本循环里唯一的长 await：期间收到 abort 就绝不再建连。
+    if (signal.aborted) return;
     const topology = deps.buildTopology(auth.server, entry.cwd, {
       harnessSession: {
         harness: "claude",
@@ -528,21 +530,30 @@ export async function runDormantClaudeSessionAnnounce(
       runtimeTopology: topology,
     });
     const sessionId = entry.session_id;
+    let connectionClosed = false;
+    const closeConnection = () => {
+      connectionClosed = true;
+      connection.close();
+    };
     const liveness = setInterval(() => {
+      if (connectionClosed) return;
       try {
         const stillAlive = deps.listSessions().some(
           (candidate) => candidate.session_id.toLowerCase() === sessionId.toLowerCase(),
         );
-        if (!stillAlive) connection.close();
+        if (!stillAlive) closeConnection();
       } catch {
-        connection.close();
+        closeConnection();
       }
     }, livenessMs);
     if (typeof (liveness as { unref?: () => void }).unref === "function") {
       (liveness as unknown as { unref: () => void }).unref();
     }
-    const onAbort = () => connection.close();
+    const onAbort = () => closeConnection();
     signal.addEventListener("abort", onAbort, { once: true });
+    // abort 恰好落在建连之后、监听注册之前：已 abort 的 signal 不会再派发事件，
+    // 这里立即补一次 close，防止连接泄漏。
+    if (signal.aborted) closeConnection();
     try {
       for await (const frame of connection.frames) {
         if (frame.type === "msg" || frame.type === "status") connection.ack(frame.seq);
@@ -553,7 +564,7 @@ export async function runDormantClaudeSessionAnnounce(
     } finally {
       clearInterval(liveness);
       signal.removeEventListener("abort", onAbort);
-      connection.close();
+      closeConnection();
     }
     // 帧流结束：会话死了就回到等待档（换会话可再宣告），否则稍候重试。
     await abortableSleep(pollMs, signal);

--- a/cli/src/commands/hook.ts
+++ b/cli/src/commands/hook.ts
@@ -25,6 +25,11 @@ import {
   type DeliveryRecoveryEntry,
 } from "../delivery-recovery-journal";
 import { atomicWriteJson, atomicWriteText } from "../atomic-json";
+import {
+  isClaudeSessionRegistrySessionId,
+  registerClaudeSession,
+  unregisterClaudeSession,
+} from "../claude-session-registry";
 import { isHelpArg } from "../args";
 import { isPartyBinaryPath } from "../upgrade";
 import { CLAUDE_LIFECYCLE_OPT_IN_ENV } from "./claude-launch";
@@ -449,6 +454,54 @@ export function shouldForceActivityPush(
   );
 }
 
+/** SessionStart hook payload 里可能带的展示名字段（当前 Claude 实测都不发；拿不到记 null）。 */
+export function claudeSessionDisplayNameFromHookPayload(
+  record: Record<string, unknown>,
+): string | null {
+  for (const key of ["display_name", "session_name", "agent_name"]) {
+    const value = record[key];
+    if (typeof value === "string" && /^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$/.test(value)) return value;
+  }
+  return null;
+}
+
+/**
+ * 本机会话注册表接线（issue #841 P1）：SessionStart 入册、SessionEnd 出册。
+ * 严守 hook 铁律：stdout 恒空、任何失败静默、不等网络。serve 托管 lane
+ * （AP_ACTIVITY_FILE 有值）不入册——那是被管理的 runner 会话，不是交互式会话。
+ * 频道解析与 maybeSpawnPush 同款：AGENTPARTY_CHANNEL ?? readState(cwd)?.channel，
+ * 无频道不入册。pid 记 process.ppid（hook 子进程的父进程即 Claude 本体）。
+ */
+export function recordClaudeSessionLifecycle(
+  record: Record<string, unknown>,
+  env: NodeJS.ProcessEnv = process.env,
+  pid: number = process.ppid,
+): void {
+  try {
+    const event = record.hook_event_name;
+    if (event !== "SessionStart" && event !== "SessionEnd") return;
+    const sessionId = record.session_id;
+    if (!isClaudeSessionRegistrySessionId(sessionId)) return;
+    if (event === "SessionEnd") {
+      unregisterClaudeSession(sessionId, env);
+      return;
+    }
+    if (env.AP_ACTIVITY_FILE) return;
+    const cwd = typeof record.cwd === "string" && record.cwd.length > 0 ? record.cwd : process.cwd();
+    const channel = env.AGENTPARTY_CHANNEL ?? readState(cwd)?.channel;
+    if (!channel) return;
+    registerClaudeSession({
+      session_id: sessionId,
+      pid,
+      display_name: claudeSessionDisplayNameFromHookPayload(record),
+      channel,
+      cwd,
+    }, env);
+  } catch {
+    // hook 铁律：注册表任何失败都不配影响模型。
+  }
+}
+
 function reportHookPayload(
   record: Record<string, unknown>,
   overridePhase?: AgentActivity["phase"],
@@ -502,6 +555,7 @@ async function runHookInput(blockStop: boolean): Promise<number> {
     const payload = JSON.parse(raw) as unknown;
     if (typeof payload !== "object" || payload === null || Array.isArray(payload)) return 0;
     const record = payload as Record<string, unknown>;
+    recordClaudeSessionLifecycle(record);
     if (!blockStop || record.hook_event_name !== "Stop" || record.stop_hook_active !== false) {
       reportHookPayload(record);
       return 0;

--- a/cli/test/claude-channel-dormant-announce.test.ts
+++ b/cli/test/claude-channel-dormant-announce.test.ts
@@ -164,6 +164,18 @@ describe("runDormantClaudeSessionAnnounce (#841 P2)", () => {
     expect(connections[0]!.closed).toBe(true);
   });
 
+  test("an abort during resolveAuth never opens a connection", async () => {
+    const abort = new AbortController();
+    const { deps, connections } = makeDeps({
+      resolveAuth: async () => {
+        abort.abort();
+        return { server: "https://party.example", token: "tok" };
+      },
+    });
+    await runDormantClaudeSessionAnnounce("dev", abort.signal, deps);
+    expect(connections).toHaveLength(0);
+  });
+
   test("stays fully dormant without auth", async () => {
     const { deps, connections } = makeDeps({
       resolveAuth: async () => ({ server: null, token: null }),

--- a/cli/test/claude-channel-dormant-announce.test.ts
+++ b/cli/test/claude-channel-dormant-announce.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, test } from "bun:test";
+import type { ServerFrame } from "@agentparty/shared";
+import type { ClaudeSessionRegistryEntry } from "../src/claude-session-registry";
+import {
+  dormantAnnounceDisplayName,
+  runDormantClaudeSessionAnnounce,
+  selectDormantAnnounceEntry,
+  type DormantAnnounceDeps,
+} from "../src/commands/claude-channel";
+
+function entry(overrides: Partial<ClaudeSessionRegistryEntry> = {}): ClaudeSessionRegistryEntry {
+  return {
+    version: 1,
+    session_id: "11111111-1111-4111-8111-111111111111",
+    pid: process.pid,
+    display_name: null,
+    channel: "dev",
+    cwd: "/tmp/project",
+    registered_at: 1_000,
+    ...overrides,
+  };
+}
+
+class FakeConnection {
+  connectArgs: { server: string; token: string; slug: string; since: number; opts: Record<string, unknown> };
+  sent: unknown[] = [];
+  acked: number[] = [];
+  closed = false;
+  cursor = 0;
+  revCursor = 0;
+  private queue: ServerFrame[] = [];
+  private waiter: (() => void) | null = null;
+
+  constructor(args: FakeConnection["connectArgs"]) {
+    this.connectArgs = args;
+  }
+
+  push(frame: ServerFrame): void {
+    this.queue.push(frame);
+    this.waiter?.();
+  }
+
+  frames = (async function* (self: FakeConnection) {
+    while (true) {
+      if (self.queue.length > 0) {
+        yield self.queue.shift()!;
+        continue;
+      }
+      if (self.closed) return;
+      await new Promise<void>((resolve) => {
+        self.waiter = resolve;
+      });
+      self.waiter = null;
+    }
+  })(this);
+
+  send(frame: unknown): boolean {
+    this.sent.push(frame);
+    return true;
+  }
+
+  ack(seq: number): void {
+    this.acked.push(seq);
+  }
+
+  close(): void {
+    this.closed = true;
+    this.waiter?.();
+  }
+
+  pendingFrames(): ServerFrame[] {
+    return [];
+  }
+
+  replayUnacked(): number {
+    return 0;
+  }
+}
+
+function makeDeps(overrides: Partial<DormantAnnounceDeps> = {}): {
+  deps: DormantAnnounceDeps;
+  connections: FakeConnection[];
+} {
+  const connections: FakeConnection[] = [];
+  const deps: DormantAnnounceDeps = {
+    listSessions: () => [entry()],
+    resolveAuth: async () => ({ server: "https://party.example", token: "tok" }),
+    connect: ((server: string, token: string, slug: string, since: number, opts = {}) => {
+      const connection = new FakeConnection({ server, token, slug, since, opts: opts as Record<string, unknown> });
+      connections.push(connection);
+      return connection;
+    }) as DormantAnnounceDeps["connect"],
+    buildTopology: (server, _cwd, buildDeps) => ({
+      version: 1,
+      node_ref: "node_x",
+      runtime_ref: "runtime_x",
+      workspace_ref: "workspace_x",
+      worktree_ref: "worktree_x",
+      peer_scope: "local_installation",
+      evidence: "client_asserted",
+      ...(buildDeps?.harnessSession === undefined ? {} : { harness_session: buildDeps.harnessSession }),
+    }),
+    loadCursor: () => 42,
+    cwd: "/tmp/project",
+    pollIntervalMs: 5,
+    livenessIntervalMs: 5,
+    ...overrides,
+  };
+  return { deps, connections };
+}
+
+async function tick(ms = 20): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe("dormantAnnounceDisplayName", () => {
+  test("prefers the registered name and falls back to a deterministic session-derived name", () => {
+    expect(dormantAnnounceDisplayName(entry({ display_name: "my-claude" }))).toBe("my-claude");
+    expect(dormantAnnounceDisplayName(entry())).toBe("claude-111111111111");
+  });
+});
+
+describe("selectDormantAnnounceEntry", () => {
+  test("requires the channel, prefers same cwd, then newest registration", () => {
+    const other = entry({ session_id: "22222222-2222-4222-8222-222222222222", channel: "prod" });
+    expect(selectDormantAnnounceEntry([other], "dev", "/tmp/project")).toBeNull();
+    const away = entry({ session_id: "33333333-3333-4333-8333-333333333333", cwd: "/elsewhere", registered_at: 9_000 });
+    const here = entry({ registered_at: 1_000 });
+    expect(selectDormantAnnounceEntry([away, here], "dev", "/tmp/project")).toBe(here);
+    expect(selectDormantAnnounceEntry([away], "dev", "/tmp/project")).toBe(away);
+    const newer = entry({ session_id: "44444444-4444-4444-8444-444444444444", registered_at: 5_000 });
+    expect(selectDormantAnnounceEntry([here, newer], "dev", "/tmp/project")).toBe(newer);
+  });
+});
+
+describe("runDormantClaudeSessionAnnounce (#841 P2)", () => {
+  test("announces topology + harness_session only and never claims delivery", async () => {
+    const { deps, connections } = makeDeps();
+    const abort = new AbortController();
+    const done = runDormantClaudeSessionAnnounce("dev", abort.signal, deps);
+    await tick();
+    expect(connections).toHaveLength(1);
+    const { connectArgs } = connections[0]!;
+    expect(connectArgs.server).toBe("https://party.example");
+    expect(connectArgs.slug).toBe("dev");
+    expect(connectArgs.since).toBe(42);
+    const opts = connectArgs.opts;
+    // announce 档不认领 delivery：不声明任何 delivery/wake 能力，也不持久化游标。
+    expect(opts.directedDelivery).toBeUndefined();
+    expect(opts.deliveryRecovery).toBeUndefined();
+    expect(opts.advertiseWakeKind).toBeUndefined();
+    expect(opts.onCursor).toBeUndefined();
+    expect((opts.runtimeTopology as { harness_session?: unknown }).harness_session).toEqual({
+      harness: "claude",
+      display_name: "claude-111111111111",
+    });
+    // 收到普通消息只本地 ack，绝不发送任何客户端帧。
+    connections[0]!.push({ type: "msg", seq: 7, from: "a", body: "x", ts: 1 } as unknown as ServerFrame);
+    await tick();
+    expect(connections[0]!.acked).toEqual([7]);
+    expect(connections[0]!.sent).toHaveLength(0);
+    abort.abort();
+    await done;
+    expect(connections[0]!.closed).toBe(true);
+  });
+
+  test("stays fully dormant without auth", async () => {
+    const { deps, connections } = makeDeps({
+      resolveAuth: async () => ({ server: null, token: null }),
+    });
+    const abort = new AbortController();
+    await runDormantClaudeSessionAnnounce("dev", abort.signal, deps);
+    expect(connections).toHaveLength(0);
+  });
+
+  test("waits for a registry entry to appear, then closes when the session dies", async () => {
+    let sessions: ClaudeSessionRegistryEntry[] = [];
+    const { deps, connections } = makeDeps({ listSessions: () => sessions });
+    const abort = new AbortController();
+    const done = runDormantClaudeSessionAnnounce("dev", abort.signal, deps);
+    await tick();
+    expect(connections).toHaveLength(0);
+    sessions = [entry()];
+    await tick();
+    expect(connections).toHaveLength(1);
+    // 会话死亡（注册表探活失败）→ 活体检测断开 WS。
+    sessions = [];
+    await tick(30);
+    expect(connections[0]!.closed).toBe(true);
+    abort.abort();
+    await done;
+  });
+
+  test("rejects an invalid channel slug without connecting", async () => {
+    const { deps, connections } = makeDeps();
+    const abort = new AbortController();
+    await runDormantClaudeSessionAnnounce("Bad_Channel!", abort.signal, deps);
+    expect(connections).toHaveLength(0);
+  });
+});

--- a/cli/test/claude-session-registry.test.ts
+++ b/cli/test/claude-session-registry.test.ts
@@ -1,0 +1,233 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { chmodSync, mkdtempSync, readdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  CLAUDE_SESSION_REGISTRY_CAPACITY,
+  CLAUDE_SESSION_REGISTRY_DIR_ENV,
+  claudeSessionAlive,
+  claudeSessionRegistryDirectory,
+  listClaudeSessions,
+  registerClaudeSession,
+  unregisterClaudeSession,
+} from "../src/claude-session-registry";
+import {
+  claudeSessionDisplayNameFromHookPayload,
+  recordClaudeSessionLifecycle,
+} from "../src/commands/hook";
+
+const SESSION_ID = "11111111-1111-4111-8111-111111111111";
+
+function sessionId(n: number): string {
+  return `11111111-1111-4111-8111-${String(n).padStart(12, "0")}`;
+}
+
+async function deadPid(): Promise<number> {
+  const proc = Bun.spawn(["sleep", "0"], { stdout: "ignore", stderr: "ignore" });
+  await proc.exited;
+  return proc.pid;
+}
+
+function baseEntry(overrides: Record<string, unknown> = {}) {
+  return {
+    session_id: SESSION_ID,
+    pid: process.pid,
+    display_name: null,
+    channel: "dev",
+    cwd: "/tmp/project",
+    registered_at: 1_000,
+    ...overrides,
+  };
+}
+
+let directory: string;
+let env: NodeJS.ProcessEnv;
+
+beforeEach(() => {
+  directory = mkdtempSync(join(tmpdir(), "agentparty-claude-session-registry-"));
+  chmodSync(directory, 0o700);
+  env = { [CLAUDE_SESSION_REGISTRY_DIR_ENV]: directory };
+});
+
+afterEach(() => {
+  rmSync(directory, { recursive: true, force: true });
+});
+
+describe("claude session registry", () => {
+  test("register / list / unregister round-trip", () => {
+    expect(registerClaudeSession(baseEntry(), env)).toBe(true);
+    const listed = listClaudeSessions(env);
+    expect(listed).toHaveLength(1);
+    expect(listed[0]).toMatchObject({
+      version: 1,
+      session_id: SESSION_ID,
+      pid: process.pid,
+      display_name: null,
+      channel: "dev",
+      cwd: "/tmp/project",
+      registered_at: 1_000,
+    });
+    expect(claudeSessionAlive(SESSION_ID, env)).toBe(true);
+    expect(unregisterClaudeSession(SESSION_ID, env)).toBe(true);
+    expect(listClaudeSessions(env)).toHaveLength(0);
+    expect(claudeSessionAlive(SESSION_ID, env)).toBe(false);
+  });
+
+  test("rejects malformed inputs", () => {
+    expect(registerClaudeSession(baseEntry({ session_id: "../../etc/passwd" }), env)).toBe(false);
+    expect(registerClaudeSession(baseEntry({ session_id: "not-a-uuid" }), env)).toBe(false);
+    expect(registerClaudeSession(baseEntry({ channel: "Bad_Channel!" }), env)).toBe(false);
+    expect(registerClaudeSession(baseEntry({ cwd: "relative/path" }), env)).toBe(false);
+    expect(registerClaudeSession(baseEntry({ pid: 0 }), env)).toBe(false);
+    expect(unregisterClaudeSession("not-a-uuid", env)).toBe(false);
+    expect(listClaudeSessions(env)).toHaveLength(0);
+  });
+
+  test("invalid display_name is stored as null, valid one is kept", () => {
+    expect(registerClaudeSession(baseEntry({ display_name: "bad name!" }), env)).toBe(true);
+    expect(listClaudeSessions(env)[0]!.display_name).toBeNull();
+    expect(registerClaudeSession(baseEntry({ display_name: "my-session_1" }), env)).toBe(true);
+    expect(listClaudeSessions(env)[0]!.display_name).toBe("my-session_1");
+  });
+
+  test("directory permission checks: group-readable and symlink directories are rejected", () => {
+    chmodSync(directory, 0o750);
+    expect(claudeSessionRegistryDirectory(env)).toBeNull();
+    expect(registerClaudeSession(baseEntry(), env)).toBe(false);
+    expect(listClaudeSessions(env)).toHaveLength(0);
+    chmodSync(directory, 0o700);
+
+    const outer = mkdtempSync(join(tmpdir(), "agentparty-claude-session-link-"));
+    try {
+      const link = join(outer, "link");
+      symlinkSync(directory, link);
+      expect(claudeSessionRegistryDirectory({
+        [CLAUDE_SESSION_REGISTRY_DIR_ENV]: link,
+      })).toBeNull();
+    } finally {
+      rmSync(outer, { recursive: true, force: true });
+    }
+    expect(claudeSessionRegistryDirectory({
+      [CLAUDE_SESSION_REGISTRY_DIR_ENV]: "relative/dir",
+    })).toBeNull();
+  });
+
+  test("group-readable entry files are ignored and pruned", () => {
+    expect(registerClaudeSession(baseEntry(), env)).toBe(true);
+    chmodSync(join(directory, `${SESSION_ID}.json`), 0o644);
+    expect(listClaudeSessions(env)).toHaveLength(0);
+    expect(readdirSync(directory)).toHaveLength(0);
+  });
+
+  test("dead and corrupt rows are pruned on list", async () => {
+    expect(registerClaudeSession(baseEntry(), env)).toBe(true);
+    expect(registerClaudeSession(baseEntry({
+      session_id: sessionId(2),
+      pid: await deadPid(),
+    }), env)).toBe(true);
+    writeFileSync(join(directory, `${sessionId(3)}.json`), "{not json", { mode: 0o600 });
+    // 文件名与内容 session_id 不一致 = 坏行
+    writeFileSync(
+      join(directory, `${sessionId(4)}.json`),
+      JSON.stringify(baseEntry({ version: 1, session_id: sessionId(5) })),
+      { mode: 0o600 },
+    );
+    const listed = listClaudeSessions(env);
+    expect(listed).toHaveLength(1);
+    expect(listed[0]!.session_id).toBe(SESSION_ID);
+    expect(readdirSync(directory).sort()).toEqual([`${SESSION_ID}.json`]);
+  });
+
+  test("list sorts by registered_at ascending", () => {
+    expect(registerClaudeSession(baseEntry({ session_id: sessionId(2), registered_at: 3_000 }), env)).toBe(true);
+    expect(registerClaudeSession(baseEntry({ registered_at: 1_000 }), env)).toBe(true);
+    expect(listClaudeSessions(env).map((entry) => entry.registered_at)).toEqual([1_000, 3_000]);
+  });
+
+  test("capacity: prunes dead rows first, refuses when full of live rows, allows self-overwrite", async () => {
+    for (let index = 1; index <= CLAUDE_SESSION_REGISTRY_CAPACITY; index += 1) {
+      expect(registerClaudeSession(baseEntry({ session_id: sessionId(index) }), env)).toBe(true);
+    }
+    // 全是活行且已满：拒新，绝不覆盖活行。
+    expect(registerClaudeSession(baseEntry({ session_id: sessionId(999) }), env)).toBe(false);
+    // 同一 session 重复注册（resume）不受容量限制。
+    expect(registerClaudeSession(baseEntry({ session_id: sessionId(1), registered_at: 9_000 }), env)).toBe(true);
+    // 一行死了：新行顶上。
+    writeFileSync(
+      join(directory, `${sessionId(2)}.json`),
+      JSON.stringify(baseEntry({ version: 1, session_id: sessionId(2), pid: await deadPid() })),
+      { mode: 0o600 },
+    );
+    expect(registerClaudeSession(baseEntry({ session_id: sessionId(999) }), env)).toBe(true);
+    expect(listClaudeSessions(env)).toHaveLength(CLAUDE_SESSION_REGISTRY_CAPACITY);
+  });
+});
+
+describe("hook lifecycle wiring (#841 P1)", () => {
+  test("SessionStart registers and SessionEnd unregisters", () => {
+    const hookEnv = { ...env, AGENTPARTY_CHANNEL: "dev" };
+    recordClaudeSessionLifecycle({
+      hook_event_name: "SessionStart",
+      session_id: SESSION_ID,
+      cwd: "/tmp/project",
+    }, hookEnv, process.pid);
+    const listed = listClaudeSessions(env);
+    expect(listed).toHaveLength(1);
+    expect(listed[0]).toMatchObject({
+      session_id: SESSION_ID,
+      pid: process.pid,
+      channel: "dev",
+      cwd: "/tmp/project",
+      display_name: null,
+    });
+    recordClaudeSessionLifecycle({
+      hook_event_name: "SessionEnd",
+      session_id: SESSION_ID,
+    }, hookEnv, process.pid);
+    expect(listClaudeSessions(env)).toHaveLength(0);
+  });
+
+  test("serve-managed lanes and channel-less sessions are not registered", () => {
+    recordClaudeSessionLifecycle({
+      hook_event_name: "SessionStart",
+      session_id: SESSION_ID,
+      cwd: "/tmp/project",
+    }, { ...env, AGENTPARTY_CHANNEL: "dev", AP_ACTIVITY_FILE: "/tmp/activity.json" }, process.pid);
+    expect(listClaudeSessions(env)).toHaveLength(0);
+    recordClaudeSessionLifecycle({
+      hook_event_name: "SessionStart",
+      session_id: SESSION_ID,
+      cwd: join(tmpdir(), "agentparty-definitely-no-state"),
+    }, env, process.pid);
+    expect(listClaudeSessions(env)).toHaveLength(0);
+  });
+
+  test("other events and invalid session ids are ignored, failures stay silent", () => {
+    const hookEnv = { ...env, AGENTPARTY_CHANNEL: "dev" };
+    recordClaudeSessionLifecycle({
+      hook_event_name: "PreToolUse",
+      session_id: SESSION_ID,
+    }, hookEnv, process.pid);
+    recordClaudeSessionLifecycle({
+      hook_event_name: "SessionStart",
+      session_id: "../evil",
+      cwd: "/tmp/project",
+    }, hookEnv, process.pid);
+    expect(listClaudeSessions(env)).toHaveLength(0);
+    // 注册表目录不可用也不许抛（hook 铁律）。
+    chmodSync(directory, 0o750);
+    expect(() => recordClaudeSessionLifecycle({
+      hook_event_name: "SessionStart",
+      session_id: SESSION_ID,
+      cwd: "/tmp/project",
+    }, hookEnv, process.pid)).not.toThrow();
+    chmodSync(directory, 0o700);
+  });
+
+  test("display_name is taken from the payload only when present and valid", () => {
+    expect(claudeSessionDisplayNameFromHookPayload({ display_name: "nice-name" })).toBe("nice-name");
+    expect(claudeSessionDisplayNameFromHookPayload({ session_name: "s1" })).toBe("s1");
+    expect(claudeSessionDisplayNameFromHookPayload({ display_name: "bad name!" })).toBeNull();
+    expect(claudeSessionDisplayNameFromHookPayload({})).toBeNull();
+  });
+});

--- a/cli/test/claude-session-registry.test.ts
+++ b/cli/test/claude-session-registry.test.ts
@@ -1,5 +1,13 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { chmodSync, mkdtempSync, readdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -160,6 +168,21 @@ describe("claude session registry", () => {
     );
     expect(registerClaudeSession(baseEntry({ session_id: sessionId(999) }), env)).toBe(true);
     expect(listClaudeSessions(env)).toHaveLength(CLAUDE_SESSION_REGISTRY_CAPACITY);
+  });
+
+  test("register lock: a concurrently held lock refuses registration; a stale lock is reclaimed", () => {
+    const lockPath = join(directory, ".register.lock");
+    // 另一进程正持锁：有界等待后拒绝（安全侧），绝不绕开容量互斥。
+    writeFileSync(lockPath, "", { mode: 0o600 });
+    expect(registerClaudeSession(baseEntry(), env)).toBe(false);
+    expect(listClaudeSessions(env)).toHaveLength(0);
+    // 持锁进程死掉留下的孤儿锁（mtime 超过陈旧阈值）：回收后正常注册。
+    const stale = new Date(Date.now() - 60_000);
+    utimesSync(lockPath, stale, stale);
+    expect(registerClaudeSession(baseEntry(), env)).toBe(true);
+    expect(listClaudeSessions(env)).toHaveLength(1);
+    // 注册完成后锁已释放。
+    expect(readdirSync(directory)).toEqual([`${SESSION_ID}.json`]);
   });
 });
 


### PR DESCRIPTION
#841 的 P1+P2 切片（不含 P3 serve 远程唤醒代理，故不写 Closes）。

## P1 本机会话注册表
- 新模块 `cli/src/claude-session-registry.ts`：条目 `{version, session_id, pid, display_name, channel, cwd, registered_at}`，落 `~/.agentparty/claude-sessions/<session_id>.json`（目录 0700、文件 0600；校验模式抄 cross-session gate 的 gateDirectory：拒符号链接/组他人可读/非本 uid；`AGENTPARTY_CLAUDE_SESSION_REGISTRY_DIR` 可覆盖便于测试）。
- `listClaudeSessions` 用 `kill(pid,0)` 探活（EPERM 算活），死行/坏行现场清除，按 registered_at 排序；容量 128，满时先剔死行、仍满拒新，绝不覆盖活行；写入用现成 `atomicWriteJson`。
- 接线 `party hook report`：SessionStart 入册、SessionEnd 出册。严守 hook 铁律（stdout 恒空、失败静默 exit 0、不等网络）；serve 托管 lane（AP_ACTIVITY_FILE）不入册；channel 解析同 maybeSpawnPush（AGENTPARTY_CHANNEL ?? readState(cwd)?.channel），无频道不入册；pid 记 `process.ppid`（hook 子进程的父进程即 Claude 本体）。
- **display_name 可得性**：Claude 的 SessionStart hook payload 里没有任何展示名字段，实测拿不到 → 记 null；P2 用确定性回退名 `claude-<session_id 前 12 hex>`。

## P2 蛰伏 announce 档
- `claude-channel.ts` 的蛰伏分支（`--require-launch-opt-in` 未 opt-in → `runDormantClaudeChannelMcp`）新增 announce-only 档：注册表里有本 channel 的活会话时，连一条只带 `runtimeTopology`（含 `harness_session`）的 WS——不声明 directedDelivery/deliveryRecovery/advertiseWakeKind、不取 serve 锁、不持久化游标；worker/DO 零改动（peers 投影天然列出 claude_sessions）。
- 活体检测 = WS 断开即消失（会话进程退出由注册表探活触发 close），不发明 TTL。
- 三条不变量保持：不碰 Claude inbox socket；频道是唯一数据源；SendMessage 结果不推进 AgentParty 状态。

## 与设计摘要的偏差
- 设计摘要称蛰伏分支在 `:2380`、广播路径在 `:2430`；实际蛰伏分支在 run() 的 opt-in 检查处（原 :2440），`runDormantClaudeChannelMcp` 定义在 :427，topology 广播路径（buildRuntimeTopology + connect 的 runtimeTopology 选项）在 :2485-2496。机制与摘要一致，仅行号不同。
- 蛰伏 MCP 拿不到自己所属 Claude 会话的 session_id（stdio MCP 无会话上下文），宣告对象取注册表中「同 channel、优先同 cwd、最新入册」的活会话，并轮询等待 SessionStart hook 晚于 MCP 启动的竞态。

## 测试
- `cli/test/claude-session-registry.test.ts`：注册表增删、权限校验（组可读/符号链接/相对路径/坏权限文件）、死行坏行清理、容量上限、hook 两事件接线、display_name 提取。
- `cli/test/claude-channel-dormant-announce.test.ts`：announce 档只报 topology/harness_session、不认领 delivery（无任何 delivery/wake 能力声明、零客户端帧）、无 auth 保持纯蛰伏、会话死亡断开、坏 slug 拒连。
- `bun test`（新增 2 文件 + hook/claude-channel/cross-session 相关 4 套既有套件）全绿，`bunx tsc --noEmit`（cli）通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增本机 Claude 会话注册与状态管理，可自动记录、查询和清理已结束的会话。
  * 休眠模式现在可发现匹配频道和工作目录的活动会话，并公告其运行状态。
  * 会话结束后会自动停止公告，避免展示失效会话。
  * 新增会话名称显示与选择规则，优先使用自定义名称及最近活动会话。

* **安全性**
  * 会话记录受到严格权限保护，并限制存储容量。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->