### PR TITLE
feat(cli): serve 兼任本机唤醒代理骨架——转投判定+降级回退（#841 P3）

### DIFF
--- a/cli/src/claude-session-registry.ts
+++ b/cli/src/claude-session-registry.ts
@@ -194,6 +194,15 @@ export function listClaudeSessions(
   return alive.sort((a, b) => a.registered_at - b.registered_at);
 }
 
+/**
+ * 入册会话在 party 侧的宣告名（#841 P2/P3 共用同一权威定义，防词表漂移）：
+ * 有 display_name 用 display_name，否则回退 `claude-<session_id 前 12 个 hex>`。
+ */
+export function claudeSessionAnnounceName(entry: ClaudeSessionRegistryEntry): string {
+  if (entry.display_name !== null) return entry.display_name;
+  return `claude-${entry.session_id.toLowerCase().replace(/-/g, "").slice(0, 12)}`;
+}
+
 export function claudeSessionAlive(
   sessionId: string,
   env: NodeJS.ProcessEnv = process.env,

--- a/cli/src/commands/claude-channel.ts
+++ b/cli/src/commands/claude-channel.ts
@@ -34,6 +34,7 @@ import pkg from "../../package.json" with { type: "json" };
 import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
 import { connect, type Connection } from "../client";
 import {
+  claudeSessionAnnounceName,
   listClaudeSessions,
   type ClaudeSessionRegistryEntry,
 } from "../claude-session-registry";
@@ -440,10 +441,10 @@ export function claudeChannelLaunchOptedIn(
 const DORMANT_ANNOUNCE_POLL_MS = 5_000;
 const DORMANT_ANNOUNCE_LIVENESS_MS = 30_000;
 
-/** 注册表没记 display_name（当前 hook payload 拿不到）时的确定性回退名。 */
+/** 注册表没记 display_name（当前 hook payload 拿不到）时的确定性回退名。
+ * 权威定义在 claude-session-registry.claudeSessionAnnounceName（P3 唤醒代理同用）。 */
 export function dormantAnnounceDisplayName(entry: ClaudeSessionRegistryEntry): string {
-  if (entry.display_name !== null) return entry.display_name;
-  return `claude-${entry.session_id.toLowerCase().replace(/-/g, "").slice(0, 12)}`;
+  return claudeSessionAnnounceName(entry);
 }
 
 /** 选择要宣告的入册会话：同 channel 必须；优先同 cwd；同优先级取最新入册。 */

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -61,6 +61,7 @@ import {
 } from "../statusline-cache";
 import { downloadAttachment, ensureProjectAgentChannelRuntime, fetchChannelCharter, fetchMe, fetchMessages, fetchServerVersion, listProjectAgentInvites, mintProjectAgentRuntimeToken, postMessage, RestError, uploadAttachment, type ChannelCharter, type ChannelProjectAgentInvite, type Identity, type ProjectAgentChannelRuntime, type ProjectAgentProfile } from "../rest";
 import { isName, isSlug } from "../validation";
+import { attemptWakeProxy, type WakeProxyDeps } from "../serve-wake-proxy";
 import { buildRuntimeTopology } from "../runtime-topology";
 import { buildContext } from "./status";
 import {
@@ -1649,6 +1650,8 @@ export interface ServeOptions {
   upgradeProbeIntervalMs?: number;
   out?: (line: string) => void;
   statusline?: boolean;
+  /** #841 P3 本机唤醒代理注入点（注册表/转投载体）；默认真实注册表 + 无载体骨架。 */
+  wakeProxy?: Omit<WakeProxyDeps, "log">;
   /** 每任务心跳间隔（#228）。默认 DEFAULT_TASK_HEARTBEAT_MS；测试注入更短值。 */
   heartbeatIntervalMs?: number;
   /** 时钟注入（#228）：任务开始时刻与每次心跳时刻走它，便于测试断言心跳在推进。默认 Date.now。 */
@@ -5457,6 +5460,16 @@ export async function runServe(o: ServeOptions): Promise<number> {
       // deferredLeaseSeq 只会在 !hasLease 时设置，held=true 分支会先清空再 replay；因此持租处理
       // 与 standby 冻结区互斥。不要在这里额外跳过，否则一旦状态漂移反而会把欠账永久冻住。
       const qualifies = wouldWake && !selfPaused && hasLease;
+      // #841 P3：本机唤醒代理。@ 目标命中本机入册的 idle 交互式 Claude 会话（注册表
+      // kill(pid,0) 探活，死会话已剔除）时尝试转投一条 ≤512B 的 channel+seq 指针通知。
+      // 纯增量：转投与否都不改变下方 runner/ack 现行为（「照常继续自己的职责」），
+      // attemptWakeProxy 绝不抛错，任何失败降级为现行为——消息绝不因代理而丢失。
+      if (fresh && !fromSelf && hasLease && !selfPaused && frame.mentions.length > 0) {
+        await attemptWakeProxy(frame.mentions, self, { channel: o.channel, seq: frame.seq }, {
+          ...(o.wakeProxy ?? {}),
+          log: out,
+        });
+      }
       let stopAfterFrame = false;
       if (qualifies) {
         out(`▶ ${formatMsg(frame)}`);

--- a/cli/src/serve-wake-proxy.ts
+++ b/cli/src/serve-wake-proxy.ts
@@ -1,0 +1,140 @@
+// serve 本机唤醒代理（issue #841 P3）。
+//
+// 目标：频道消息 @ 到「本机已入册、当前 idle（无自己的 delivery 连接）」的交互式
+// Claude 会话时，serve 不自己起新会话处理，而是给原会话转投一条 ≤512B 的唤醒
+// 通知（只带 channel+seq 指针，被唤醒会话自己回频道读正文），随后照常继续自己
+// 的职责。
+//
+// 载体调研结论（开放问题 B，2026-08 复核）：serve 进程今天**没有**可用的最小
+// 转投载体——
+//   - Claude 的跨会话 SendMessage 是模型专属工具：claude-cross-session-gate 只放
+//     行「armed Claude 会话内、走完 peers→ListAgents→peer_check 授权链的一次
+//     模型调用」，serve 不是 Claude 会话，伪造这条链等于绕过 gate。
+//   - Claude inbox socket 是三不变量之一，绝不直连（shell 直投已在 #836 前置
+//     调研中证伪：无公开传输，且摘要面 ≤512B-only）。
+//   - 起一次性 `claude -p` 转投会产生新会话 + 每条 @ 一次模型调用成本，且新会
+//     话仍要走完整授权链，不满足「最小可行」。
+//   - 真正对味的未来载体是蛰伏 announce MCP（#841 P2）自己：它已持有目标会话
+//     的 stdio 通道并消费频道帧，补上 claude/channel 通知注入即可让「频道本身」
+//     充当唯一传输——那是独立切片，不属于 serve 侧。
+// 因此本模块落的是「转投判定 + 记录 + 降级为现行为」的骨架：判定与降级路径为
+// 一等实现并被单测覆盖，转投函数可注入（未来载体接上即生效），默认载体恒返回
+// false（未转投），serve 行为与现状一致——消息绝不因代理而丢失。
+import { Buffer } from "node:buffer";
+import {
+  claudeSessionAnnounceName,
+  listClaudeSessions,
+  type ClaudeSessionRegistryEntry,
+} from "./claude-session-registry";
+
+/** 三不变量之一：唤醒通知只带 channel+seq 指针，且总长 ≤512 UTF-8 字节。 */
+export const WAKE_PROXY_NOTE_MAX_BYTES = 512;
+
+export interface WakeProxyRef {
+  channel: string;
+  seq: number;
+}
+
+/**
+ * 未来载体要发的通知正文：只含 channel+seq 指针，不含消息正文。
+ * 超出 512B 属于程序错误（channel ≤64 字符 + seq 数字，正常永远不会触发）。
+ */
+export function wakeProxyNote(ref: WakeProxyRef): string {
+  const note =
+    `AgentParty wake: you were mentioned in #${ref.channel} at seq=${ref.seq}. ` +
+    "Read the channel (party history) for the message body; the channel is the single source of truth.";
+  if (Buffer.byteLength(note, "utf8") > WAKE_PROXY_NOTE_MAX_BYTES) {
+    throw new Error("wake proxy note exceeds 512 bytes");
+  }
+  return note;
+}
+
+/**
+ * 转投判定：在本频道的入册活会话里找被 @ 的目标。
+ * - 宣告名（display_name 或回退 `claude-<12hex>`）必须出现在 mentions 里；
+ * - 排除 serve 自己的身份（自己的 @ 走 runner，不转投）；
+ * - 只认绑定同一 channel 的条目；
+ * - 多个候选取最新入册（与蛰伏 announce 的选择一致）。
+ * 死会话由 listClaudeSessions 的 kill(pid,0) 探活现场剔除（开放问题 C）：
+ * 进程已退出的条目根本不会出现在这里，消息自然回落到现行为。
+ */
+export function selectWakeProxyTarget(
+  mentions: readonly string[],
+  self: string,
+  channel: string,
+  sessions: readonly ClaudeSessionRegistryEntry[],
+): ClaudeSessionRegistryEntry | null {
+  const wanted = new Set(mentions.filter((name) => name !== self));
+  if (wanted.size === 0) return null;
+  let best: ClaudeSessionRegistryEntry | null = null;
+  for (const entry of sessions) {
+    if (entry.channel !== channel) continue;
+    if (!wanted.has(claudeSessionAnnounceName(entry))) continue;
+    if (best === null || entry.registered_at >= best.registered_at) best = entry;
+  }
+  return best;
+}
+
+/** 可注入的转投载体：true=已转投成功；false/抛错=未转投（降级为现行为）。 */
+export type WakeProxyForwarder = (
+  target: ClaudeSessionRegistryEntry,
+  ref: WakeProxyRef,
+) => Promise<boolean>;
+
+/**
+ * 默认载体：无传输（见文件头调研结论），恒返回 false。
+ * 未来载体落地后从这里替换，判定/降级骨架与测试不变。
+ */
+export const noWakeProxyForwarder: WakeProxyForwarder = async () => false;
+
+export interface WakeProxyAttempt {
+  /** true 仅当载体确认转投成功；此时被唤醒会话自己去频道读 seq。 */
+  forwarded: boolean;
+  /** 命中的目标宣告名；null = 无本机入册目标（含死会话已被剔除的情形）。 */
+  target: string | null;
+}
+
+export interface WakeProxyDeps {
+  listSessions?: () => ClaudeSessionRegistryEntry[];
+  forward?: WakeProxyForwarder;
+  log?: (line: string) => void;
+}
+
+/**
+ * serve 帧循环里的转投入口。任何一步失败（注册表读取、载体抛错、载体返回
+ * false）都降级为 {forwarded:false}：serve 照常按现行为处理，消息绝不丢失。
+ * 本函数绝不抛错。
+ */
+export async function attemptWakeProxy(
+  mentions: readonly string[],
+  self: string,
+  ref: WakeProxyRef,
+  deps: WakeProxyDeps = {},
+): Promise<WakeProxyAttempt> {
+  const log = deps.log ?? (() => {});
+  let target: ClaudeSessionRegistryEntry | null = null;
+  try {
+    target = selectWakeProxyTarget(
+      mentions,
+      self,
+      ref.channel,
+      (deps.listSessions ?? listClaudeSessions)(),
+    );
+  } catch {
+    return { forwarded: false, target: null };
+  }
+  if (target === null) return { forwarded: false, target: null };
+  const name = claudeSessionAnnounceName(target);
+  try {
+    const forwarded = await (deps.forward ?? noWakeProxyForwarder)(target, ref);
+    log(
+      forwarded
+        ? `serve: 唤醒代理已转投 @${name}（channel=${ref.channel} seq=${ref.seq}，≤512B 指针，正文在频道）`
+        : `serve: @${name} 命中本机入册的 idle Claude 会话，但当前无可用转投载体——降级为现行为（见 #841 P3）`,
+    );
+    return { forwarded, target: name };
+  } catch (error) {
+    log(`serve: 唤醒代理转投 @${name} 失败（${String(error)}）——降级为现行为，消息不丢`);
+    return { forwarded: false, target: name };
+  }
+}

--- a/cli/test/serve-wake-proxy.test.ts
+++ b/cli/test/serve-wake-proxy.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from "bun:test";
+import { Buffer } from "node:buffer";
+import type { ClaudeSessionRegistryEntry } from "../src/claude-session-registry";
+import { claudeSessionAnnounceName } from "../src/claude-session-registry";
+import {
+  attemptWakeProxy,
+  noWakeProxyForwarder,
+  selectWakeProxyTarget,
+  WAKE_PROXY_NOTE_MAX_BYTES,
+  wakeProxyNote,
+} from "../src/serve-wake-proxy";
+
+function entry(overrides: Partial<ClaudeSessionRegistryEntry> = {}): ClaudeSessionRegistryEntry {
+  return {
+    version: 1,
+    session_id: "11111111-1111-4111-8111-111111111111",
+    pid: process.pid,
+    display_name: null,
+    channel: "dev",
+    cwd: "/tmp/project",
+    registered_at: 1000,
+    ...overrides,
+  };
+}
+
+describe("claudeSessionAnnounceName", () => {
+  test("display_name 优先，缺省回退 claude-<12hex>", () => {
+    expect(claudeSessionAnnounceName(entry({ display_name: "my-claude" }))).toBe("my-claude");
+    expect(claudeSessionAnnounceName(entry())).toBe("claude-111111111111");
+  });
+});
+
+describe("wakeProxyNote", () => {
+  test("只带 channel+seq 指针且 ≤512B（含最长 channel）", () => {
+    const note = wakeProxyNote({ channel: "a".repeat(64), seq: Number.MAX_SAFE_INTEGER });
+    expect(Buffer.byteLength(note, "utf8")).toBeLessThanOrEqual(WAKE_PROXY_NOTE_MAX_BYTES);
+    expect(note).toContain(`#${"a".repeat(64)}`);
+    expect(note).toContain(`seq=${Number.MAX_SAFE_INTEGER}`);
+  });
+});
+
+describe("selectWakeProxyTarget", () => {
+  test("回退名命中 → 选中；serve 自己的名字不算转投目标", () => {
+    const sessions = [entry()];
+    expect(selectWakeProxyTarget(["claude-111111111111"], "me", "dev", sessions)?.session_id)
+      .toBe(sessions[0]!.session_id);
+    expect(selectWakeProxyTarget(["claude-111111111111"], "claude-111111111111", "dev", sessions))
+      .toBeNull();
+  });
+
+  test("display_name 命中；channel 不匹配的条目排除", () => {
+    const named = entry({ display_name: "pair-claude" });
+    expect(selectWakeProxyTarget(["pair-claude"], "me", "dev", [named])).toBe(named);
+    expect(selectWakeProxyTarget(["pair-claude"], "me", "other", [named])).toBeNull();
+  });
+
+  test("多候选取最新入册", () => {
+    const older = entry({ registered_at: 1 });
+    const newer = entry({
+      session_id: "22222222-2222-4222-8222-222222222222",
+      display_name: null,
+      registered_at: 2,
+    });
+    const picked = selectWakeProxyTarget(
+      ["claude-111111111111", "claude-222222222222"],
+      "me",
+      "dev",
+      [older, newer],
+    );
+    expect(picked).toBe(newer);
+  });
+
+  test("无 mentions 或全是 self → null", () => {
+    expect(selectWakeProxyTarget([], "me", "dev", [entry()])).toBeNull();
+  });
+});
+
+describe("attemptWakeProxy", () => {
+  test("默认载体（无传输）：命中目标但 forwarded=false，降级为现行为", async () => {
+    const lines: string[] = [];
+    const result = await attemptWakeProxy(["claude-111111111111"], "me", { channel: "dev", seq: 7 }, {
+      listSessions: () => [entry()],
+      log: (line) => lines.push(line),
+    });
+    expect(result).toEqual({ forwarded: false, target: "claude-111111111111" });
+    expect(lines.some((line) => line.includes("降级为现行为"))).toBe(true);
+  });
+
+  test("死会话已被注册表剔除（列表为空）→ 无目标，回落现行为", async () => {
+    const result = await attemptWakeProxy(["claude-111111111111"], "me", { channel: "dev", seq: 7 }, {
+      listSessions: () => [],
+    });
+    expect(result).toEqual({ forwarded: false, target: null });
+  });
+
+  test("载体成功 → forwarded=true 且拿到 ≤512B 指针", async () => {
+    let sent = "";
+    const result = await attemptWakeProxy(["claude-111111111111"], "me", { channel: "dev", seq: 42 }, {
+      listSessions: () => [entry()],
+      forward: async (_target, ref) => {
+        sent = wakeProxyNote(ref);
+        return true;
+      },
+    });
+    expect(result.forwarded).toBe(true);
+    expect(sent).toContain("seq=42");
+    expect(Buffer.byteLength(sent, "utf8")).toBeLessThanOrEqual(WAKE_PROXY_NOTE_MAX_BYTES);
+  });
+
+  test("载体抛错 → 绝不上抛，降级为现行为", async () => {
+    const lines: string[] = [];
+    const result = await attemptWakeProxy(["claude-111111111111"], "me", { channel: "dev", seq: 7 }, {
+      listSessions: () => [entry()],
+      forward: async () => {
+        throw new Error("transport boom");
+      },
+      log: (line) => lines.push(line),
+    });
+    expect(result).toEqual({ forwarded: false, target: "claude-111111111111" });
+    expect(lines.some((line) => line.includes("失败") && line.includes("不丢"))).toBe(true);
+  });
+
+  test("注册表读取抛错 → 降级为现行为", async () => {
+    const result = await attemptWakeProxy(["claude-111111111111"], "me", { channel: "dev", seq: 7 }, {
+      listSessions: () => {
+        throw new Error("registry boom");
+      },
+    });
+    expect(result).toEqual({ forwarded: false, target: null });
+  });
+
+  test("noWakeProxyForwarder 恒 false", async () => {
+    expect(await noWakeProxyForwarder(entry(), { channel: "dev", seq: 1 })).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #841

## 做了什么（P3 收尾切片）

serve runner 兼任本机唤醒代理：@ 目标命中本机已入册、当前 idle 的交互式 Claude 会话（#841 P1 注册表，kill(pid,0) 探活）时，serve 尝试转投一条 ≤512B 的 channel+seq 指针通知（不带正文，被唤醒会话自己回频道读），随后照常继续自己的职责——纯增量，不改变现有 runner/ack 行为。

- `cli/src/claude-session-registry.ts`：新增 `claudeSessionAnnounceName` 作为宣告名权威定义（display_name 或回退 `claude-<12hex>`），P2 蛰伏 announce 档改为委托，防词表漂移。
- `cli/src/serve-wake-proxy.ts`（新）：判定 `selectWakeProxyTarget`（同 channel、排除 self、多候选取最新入册）、`wakeProxyNote`（≤512B 硬校验）、`attemptWakeProxy`（绝不抛错；注册表读取失败/无目标/载体抛错或返回 false 一律降级为现行为，消息绝不丢失）。载体为可注入依赖。
- `cli/src/commands/serve.ts`：帧循环里持租、fresh、非 self 且有 mentions 时调用唤醒代理；`ServeOptions.wakeProxy` 测试注入点。

## 开放问题 B（转投载体）调研结论

serve 进程今天没有可用的最小转投载体，本切片按 issue 约定落「判定 + 记录 + 降级」骨架：

- Claude 跨会话 SendMessage 是 gate（peers→ListAgents→peer_check）后的**模型专属**工具，serve 不是 Claude 会话，伪造授权链等于绕过 gate；
- Claude inbox socket 是三不变量之一，不碰；shell 直投此前已证伪；
- 一次性 `claude -p` 转投 = 新会话 + 每条 @ 一次模型调用，且仍要走完整授权链，不满足「最小可行」；
- 真正对味的未来载体是 P2 蛰伏 announce MCP 自己：它已持有目标会话的 stdio 通道并消费频道帧，补上 `claude/channel` 通知注入即可让频道本身充当唯一传输——独立切片，另开 issue 跟进。

## 开放问题 C（会话已死）

注册表 `listClaudeSessions` 探活失败现场剔行 → 判定拿不到目标 → 自然回落现行为（runner 自己处理），有单测覆盖。

## 三不变量

不碰 Claude inbox socket；频道仍是唯一数据源；唤醒通知 ≤512B 只带 channel+seq 指针（`wakeProxyNote` 超限直接抛错，单测含 64 字符 channel 上界）。

## 测试

- `bun test` serve-wake-proxy（12 例：命中/排除 self/channel 隔离/最新入册/死会话回退/载体成功/载体抛错降级/注册表抛错降级/≤512B）+ claude-session-registry + claude-channel-dormant-announce + serve-directed-delivery + serve-failure-ack 全绿
- `bunx tsc --noEmit`（cli）通过