### PR TITLE
feat(onboarding): 行为契约三层持久化（#845 层 1+2+3）

### DIFF
--- a/cli/src/commands/charter.ts
+++ b/cli/src/commands/charter.ts
@@ -1,6 +1,6 @@
 // party charter — read/update the channel "用前必读" pointer document.
 import { readFileSync } from "node:fs";
-import { channelDecisionSnapshotBodyLines } from "@agentparty/shared/onboarding";
+import { BEHAVIOR_CONTRACT_SUMMARY, channelDecisionSnapshotBodyLines } from "@agentparty/shared/onboarding";
 import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
 import { resolveChannel } from "../config";
 import { stripTerminalControls } from "../format";
@@ -52,6 +52,8 @@ function printCharter(slug: string, body: Awaited<ReturnType<typeof fetchChannel
     return;
   }
   const decisionLines = channelDecisionSnapshotBodyLines(body.active_decisions ?? []);
+  // #845 唤醒补针：wake 路径被拉起的 agent 第一步读 charter，头部固定带一行行为契约摘要。
+  console.log(`# ${BEHAVIOR_CONTRACT_SUMMARY}`);
   if (!body.charter && decisionLines.length === 0) {
     console.log(`# ${slug} charter not set (rev ${body.charter_rev})`);
     return;

--- a/cli/src/commands/digest.ts
+++ b/cli/src/commands/digest.ts
@@ -1,5 +1,6 @@
 // party digest — structured catch-up over recent history, separating mention/wake/resume.
 import type { MsgFrame, StatusState, WakeDelivery } from "@agentparty/shared";
+import { BEHAVIOR_CONTRACT_SUMMARY } from "@agentparty/shared/onboarding";
 import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
 import { loadCursor, resolveChannel } from "../config";
 import { jsonFrame, nowTs } from "../json";
@@ -180,6 +181,8 @@ function printHuman(input: {
   respondedMentions: RespondedMentionDigest[];
   wokenMentions: WokenMentionDigest[];
 }) {
+  // #845 唤醒补针：catch-up 头部固定一行行为契约摘要（shared 同源常量），不喧宾夺主。
+  console.log(`# ${BEHAVIOR_CONTRACT_SUMMARY}`);
   console.log(`digest ${input.channel} #${input.since + 1}..#${input.lastSeq} (${input.total} messages)`);
   console.log(`viewer: ${input.viewer ?? "unknown"}`);
   console.log("wake: delivery ledger is separate from linked fresh ack/status");

--- a/cli/src/commands/mcp.ts
+++ b/cli/src/commands/mcp.ts
@@ -2,7 +2,7 @@
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import type { ChannelDecisionRecord, MsgFrame, StatusState, TaskAssigneeKind, TaskState } from "@agentparty/shared";
 import { MAX_ALSO_RESOLVES } from "@agentparty/shared";
-import { channelDecisionSnapshotBodyLines } from "@agentparty/shared/onboarding";
+import { BEHAVIOR_CONTRACT_SUMMARY, channelDecisionSnapshotBodyLines } from "@agentparty/shared/onboarding";
 import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
@@ -476,7 +476,8 @@ export function createMcpServer(defaultChannel?: string): McpServer {
     "party_send",
     {
       title: "Send message",
-      description: "Send a message to an AgentParty channel.",
+      // #845：行为契约进最常用工具的描述——每轮进上下文、免疫压缩。文本来自 shared，别在这改。
+      description: `Send a message to an AgentParty channel. ${BEHAVIOR_CONTRACT_SUMMARY}`,
       inputSchema: {
         channel: z.string().optional().describe("Channel slug. Defaults to the workspace-bound channel."),
         body: z.string().optional().describe("Message body. May be empty only when attaching."),
@@ -593,7 +594,9 @@ export function createMcpServer(defaultChannel?: string): McpServer {
       // agent 得白试一轮才知道读要用 party_who。把「这是写接口、读去哪」放进标题和描述最前面。
       description:
         "SET your own status in the channel (a write). To READ anyone's status — including your own — use party_who instead. " +
-        "Posts a structured AgentParty status frame.",
+        "Posts a structured AgentParty status frame. " +
+        // #845：行为契约（shared 同源常量），每轮随描述进上下文。
+        BEHAVIOR_CONTRACT_SUMMARY,
       inputSchema: {
         channel: z.string().optional(),
         state: StateSchema.describe(
@@ -1137,7 +1140,9 @@ export function createMcpServer(defaultChannel?: string): McpServer {
       title: "Wait for one matching mention",
       description:
         "Actively wait until the next matching message arrives, then return its structured frame. The tool call must remain in flight; MCP notifications do not wake an idle model turn. " +
-        "An un-acked wake REPLAYS and holds newer messages behind it until cleared — pass ack_replay:true to clear a replayed wake as you receive it (#826).",
+        "An un-acked wake REPLAYS and holds newer messages behind it until cleared — pass ack_replay:true to clear a replayed wake as you receive it (#826). " +
+        // #845：行为契约（shared 同源常量），每轮随描述进上下文。
+        BEHAVIOR_CONTRACT_SUMMARY,
       inputSchema: {
         channel: z.string().optional(),
         // #826：未 ack 的 delivery 会一直重投并把新消息挡在后面。默认不自动 ack——那道债正是

--- a/cli/test/behavior-contract.test.ts
+++ b/cli/test/behavior-contract.test.ts
@@ -1,0 +1,117 @@
+// #845 层 1+3：行为契约的持久化——MCP 工具描述（每轮必达）与 charter 输出头部（唤醒补针）
+// 都必须携带 shared 的同一份契约文本，杜绝各处复刻漂移。
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { BEHAVIOR_CONTRACT_BODY_LINES, BEHAVIOR_CONTRACT_SUMMARY } from "@agentparty/shared/onboarding";
+
+const indexPath = join(import.meta.dir, "..", "src", "index.ts");
+
+describe("行为契约常量（shared 单一来源）", () => {
+  test("单行版非空且无换行（要进工具描述/输出头部）", () => {
+    expect(BEHAVIOR_CONTRACT_SUMMARY.length).toBeGreaterThan(0);
+    expect(BEHAVIOR_CONTRACT_SUMMARY).not.toContain("\n");
+    // 契约四要点齐全
+    expect(BEHAVIOR_CONTRACT_SUMMARY).toContain("reply_to");
+    expect(BEHAVIOR_CONTRACT_SUMMARY).toContain("waiting");
+    expect(BEHAVIOR_CONTRACT_SUMMARY).toContain("唯一数据源");
+  });
+
+  test("多行版非空、含重读指引、不含控制字节", () => {
+    expect(BEHAVIOR_CONTRACT_BODY_LINES.length).toBeGreaterThan(0);
+    const joined = BEHAVIOR_CONTRACT_BODY_LINES.join("\n");
+    expect(joined).toContain("重读本文件");
+    expect(joined).not.toMatch(/[\x00-\x08\x0B-\x1F\x7F]/);
+    // heredoc delimiter 不许出现在正文里，否则落盘会提前截断
+    expect(joined).not.toContain("AGENTPARTY_RULES_EOF");
+  });
+});
+
+describe("行为契约进 MCP 工具描述与 charter 输出（#845）", () => {
+  let home: string;
+  let restServer: ReturnType<typeof Bun.serve> | null = null;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "ap-behavior-contract-"));
+  });
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+    restServer?.stop(true);
+    restServer = null;
+  });
+
+  function startRest(): void {
+    restServer = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch(req) {
+        const url = new URL(req.url);
+        if (url.pathname === "/api/channels/dev/charter" && req.method === "GET") {
+          return Response.json({ charter: "Scope: dev things.", charter_rev: 3, updated_at: null, updated_by: null });
+        }
+        if (url.pathname === "/api/me") {
+          return Response.json({ name: "me", email: null, kind: "agent", role: "member", owner: null });
+        }
+        return Response.json({ error: { code: "not_found", message: "not found" } }, { status: 404 });
+      },
+    });
+    mkdirSync(home, { recursive: true });
+    writeFileSync(
+      join(home, "config.json"),
+      JSON.stringify({ server: `http://127.0.0.1:${restServer.port}`, token: "ap_tok" }),
+    );
+  }
+
+  test("party_send / party_watch_once / party_status 的 description 含契约单行版", async () => {
+    startRest();
+    const env: Record<string, string> = {};
+    for (const [k, v] of Object.entries(process.env)) {
+      if (v !== undefined && k !== "AGENTPARTY_CONFIG") env[k] = v;
+    }
+    env.AGENTPARTY_HOME = home;
+    const transport = new StdioClientTransport({
+      command: "bun",
+      args: ["run", indexPath, "mcp", "--channel", "dev"],
+      env,
+      stderr: "pipe",
+    });
+    const client = new Client({ name: "agentparty-test", version: "1.0.0" });
+    await client.connect(transport);
+    try {
+      const tools = await client.listTools();
+      for (const name of ["party_send", "party_watch_once", "party_status"]) {
+        const tool = tools.tools.find((t) => t.name === name);
+        expect(tool).toBeDefined();
+        expect(tool?.description ?? "").toContain(BEHAVIOR_CONTRACT_SUMMARY);
+      }
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("party charter 文本输出头部固定带一行契约摘要", async () => {
+    startRest();
+    const { run } = await import("../src/commands/charter");
+    const prevHome = process.env.AGENTPARTY_HOME;
+    process.env.AGENTPARTY_HOME = home;
+    const lines: string[] = [];
+    const origLog = console.log;
+    console.log = (...args: unknown[]) => {
+      lines.push(args.join(" "));
+    };
+    try {
+      const code = await run(["dev"]);
+      expect(code).toBe(0);
+    } finally {
+      console.log = origLog;
+      if (prevHome === undefined) delete process.env.AGENTPARTY_HOME;
+      else process.env.AGENTPARTY_HOME = prevHome;
+    }
+    expect(lines[0]).toBe(`# ${BEHAVIOR_CONTRACT_SUMMARY}`);
+    expect(lines.join("\n")).toContain("Scope: dev things.");
+  });
+});

--- a/shared/src/onboarding.ts
+++ b/shared/src/onboarding.ts
@@ -43,6 +43,27 @@ export function channelDecisionSnapshotBodyLines(decisions: readonly ChannelDeci
   ];
 }
 
+// ── 行为契约（#845）──────────────────────────────────────────────────────────
+// 接入包是一次性贴进对话的瞬态文本，上下文被压缩后礼仪约束会蒸发。契约按持久性
+// 分三层复述：MCP 工具描述（每轮必达）、落盘 rules 文件（joinPack 写盘）、charter/digest
+// 输出头部（唤醒补针）。三层全部引用这里的同一份文本，杜绝漂移。全部是静态常量，
+// 不含任何用户/管理员可控输入（charter 注入面的注释化约束见上，别把动态内容混进来）。
+
+/** 单行版：进 MCP 工具描述与 charter/digest 头部。每轮进模型上下文，必须极短、无换行。 */
+export const BEHAVIOR_CONTRACT_SUMMARY =
+  "行为契约：只在被 @ 或确有话说时发言，回复带 reply_to；blocked/歧义时留频道可见的 waiting 状态；频道是唯一数据源。";
+
+/** 多行版：落盘到 ~/.agentparty/agents/<name>-<slug>.rules.md 的正文。 */
+export const BEHAVIOR_CONTRACT_BODY_LINES: readonly string[] = [
+  "# AgentParty 行为契约 / Behavior contract",
+  "",
+  "上下文被压缩或丢失后，先重读本文件再行动。",
+  "",
+  "- 只在被 @ 或确有话说时发言，别刷屏；回复带 reply_to 指向所答消息。",
+  "- blocked 或需求有歧义时，用 party status 留下频道可见的 waiting 状态和问题，别沉默等待。",
+  "- 频道是唯一数据源与共识账本：结论、认领、交接都发进频道，不留在本地。",
+];
+
 /** agent/成员名的合法形状（与 cli/src/validation.ts 的 NAME_RE 同一约束）。 */
 export const AGENT_NAME_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$/;
 

--- a/web/src/i18n/strings/AgentJoin.ts
+++ b/web/src/i18n/strings/AgentJoin.ts
@@ -79,6 +79,8 @@ export const AgentJoinStrings: LocaleDict = {
     "AgentJoin.cmd.episodic2": "#      declare it: party status {slug} waiting -m \"<what you own>\" --residency episodic   (collaborators then read delay as per-turn wakeup, not as offline)",
     "AgentJoin.cmd.episodic3": "#      got an @ you can't handle this turn: party receipt <seq>   (party_receipt tool) — metadata on that message: no seq, no message flow, no delivery, no ack. NEVER hand-roll a receipt with party send: hand-rolled ones have shipped with an empty seq, and being ordinary messages they crowd out real ones.",
     "AgentJoin.cmd.etiquette": "# Etiquette: only speak when @-mentioned or you actually have something to say — don't flood; in party mode, if the loop guard or a real ambiguity stops you, leave a channel-visible waiting status and question.",
+    "AgentJoin.cmd.rulesNote": "# Persist the behavior contract to disk (this pack is transient text — the rules survive context compaction there):",
+    "AgentJoin.cmd.rulesReread": "# After context compaction or loss, re-read $HOME/.agentparty/agents/agentparty-{agentName}-{slug}.rules.md BEFORE acting.",
 
     // 无人值守值守包（#612）：给人跑的 serve --runner 一键预设
     "AgentJoin.modeLabel": "join mode",
@@ -186,6 +188,8 @@ export const AgentJoinStrings: LocaleDict = {
     "AgentJoin.cmd.episodic2": "#      声明：party status {slug} waiting -m \"<你负责什么>\" --residency episodic   （同事据此把延迟读成「按轮唤醒」，而不是掉线）",
     "AgentJoin.cmd.episodic3": "#      收到 @ 但这轮处理不了：party receipt <seq>（party_receipt 工具）——它是那条消息的元数据：不占 seq、不进正文流、不触发 delivery、不需要 ack。绝不要用 party send 手搓回执：手搓版发出过空 seq，而且它作为普通消息会挤占真消息。",
     "AgentJoin.cmd.etiquette": "# 礼仪：只在被 @ 或确有话说时发言，别刷屏；party 模式里 loop guard 或真实歧义让你停下时，要留下频道可见的 waiting 状态和问题。",
+    "AgentJoin.cmd.rulesNote": "# 把行为契约落盘（本接入包是瞬态文本——上下文被压缩后，规则以这个文件为准）：",
+    "AgentJoin.cmd.rulesReread": "# 上下文被压缩/丢失后，先重读 $HOME/.agentparty/agents/agentparty-{agentName}-{slug}.rules.md 再行动。",
 
     // 无人值守值守包（#612）：给人跑的 serve --runner 一键预设
     "AgentJoin.modeLabel": "接入方式",

--- a/web/src/lib/joinPack.test.ts
+++ b/web/src/lib/joinPack.test.ts
@@ -1,0 +1,58 @@
+// #845 层 2：接入包把行为契约落盘成 rules 文件——heredoc 全静态、delimiter 带引号防变量展开，
+// 包尾带「上下文丢失后先重读」指引。契约正文与 cli 层同源（shared 常量），此处只验落盘段形状。
+import { describe, expect, test } from "bun:test";
+import { BEHAVIOR_CONTRACT_BODY_LINES } from "@agentparty/shared/onboarding";
+import { lookup } from "../i18n/dict";
+import type { TFunc } from "../i18n/useT";
+import { buildFullJoinPack } from "./joinPack";
+
+const t: TFunc = (key, vars) => {
+  const raw = lookup("zh", key) ?? lookup("en", key) ?? key;
+  if (vars === undefined) return raw;
+  return raw.replace(/\{(\w+)\}/g, (m, name: string) => (name in vars ? String(vars[name]) : m));
+};
+
+function pack(): string {
+  return buildFullJoinPack({
+    slug: "dev",
+    agentName: "bot",
+    agentToken: "ap_tok",
+    server: "https://party.example",
+    inviterName: "leo",
+    charter: null,
+    t,
+  });
+}
+
+describe("joinPack 行为契约落盘（#845）", () => {
+  test("含 rules 落盘 heredoc 段，delimiter 带引号防变量展开", () => {
+    const text = pack();
+    expect(text).toContain(
+      `cat > "$HOME/.agentparty/agents/agentparty-bot-dev.rules.md" <<'AGENTPARTY_RULES_EOF'`,
+    );
+    // heredoc 完整闭合，正文逐行在包内
+    const lines = text.split("\n");
+    const open = lines.findIndex((l) => l.includes("<<'AGENTPARTY_RULES_EOF'"));
+    const close = lines.indexOf("AGENTPARTY_RULES_EOF", open + 1);
+    expect(open).toBeGreaterThan(-1);
+    expect(close).toBeGreaterThan(open);
+    expect(lines.slice(open + 1, close)).toEqual([...BEHAVIOR_CONTRACT_BODY_LINES]);
+  });
+
+  test("heredoc 正文全静态：不含 token/charter 等动态输入", () => {
+    const text = pack();
+    const lines = text.split("\n");
+    const open = lines.findIndex((l) => l.includes("<<'AGENTPARTY_RULES_EOF'"));
+    const close = lines.indexOf("AGENTPARTY_RULES_EOF", open + 1);
+    const body = lines.slice(open + 1, close).join("\n");
+    expect(body).not.toContain("ap_tok");
+    expect(body).not.toContain("$");
+  });
+
+  test("包尾带「上下文丢失后先重读 rules 文件」指引", () => {
+    const text = pack();
+    const tail = text.split("\n").at(-1) ?? "";
+    expect(tail.startsWith("#")).toBe(true);
+    expect(tail).toContain("agentparty-bot-dev.rules.md");
+  });
+});

--- a/web/src/lib/joinPack.ts
+++ b/web/src/lib/joinPack.ts
@@ -2,7 +2,7 @@
 // （AgentTokens）都调这一份，两个入口的产物从结构上逐字节同构，杜绝再漂移（#584 复盘）。
 // 独立成模块而不放 agentTokenVault：AgentJoin 的测试整体 mock 了 vault 模块，
 // builder 放那边会让组件测试拿到假实现。
-import { AGENT_NAME_RE, channelDecisionSnapshotBodyLines, charterSnapshotBodyLines, mcpServerName } from "@agentparty/shared/onboarding";
+import { AGENT_NAME_RE, BEHAVIOR_CONTRACT_BODY_LINES, channelDecisionSnapshotBodyLines, charterSnapshotBodyLines, mcpServerName } from "@agentparty/shared/onboarding";
 import type { ChannelCharter } from "./api";
 import type { DesktopAgentRunner } from "./desktopAgent";
 import type { TFunc } from "../i18n/useT";
@@ -96,6 +96,14 @@ export function buildFullJoinPack(input: FullJoinPackInput): string {
     t("AgentJoin.cmd.turnWarn3"),
     t("AgentJoin.cmd.turnWarn4", { agentName, slug }),
     ``,
+    // #845 层 2：行为契约落盘成 rules 文件（与 AGENTPARTY_CONFIG 同目录同命名风格），
+    // 上下文被压缩/丢失后可重读。正文是 shared 的静态常量（BEHAVIOR_CONTRACT_BODY_LINES），
+    // 绝不掺 charter 等管理员可控文本（那有注释化防 RCE 的约束）；heredoc delimiter 带引号防变量展开。
+    t("AgentJoin.cmd.rulesNote"),
+    `cat > "$HOME/.agentparty/agents/agentparty-${agentName}-${slug}.rules.md" <<'AGENTPARTY_RULES_EOF'`,
+    ...BEHAVIOR_CONTRACT_BODY_LINES,
+    `AGENTPARTY_RULES_EOF`,
+    ``,
     t("AgentJoin.cmd.step3"),
     // #676：token 走 AGENTPARTY_TOKEN 环境变量传入，不写进 argv——同机任意用户 `ps -axww` 看不到它，
     // 也不触发 party init 自身「--token 会进 argv/history」的告警（最严格可改 `--token -` 从 stdin 读）。
@@ -141,6 +149,8 @@ export function buildFullJoinPack(input: FullJoinPackInput): string {
     t("AgentJoin.cmd.episodic2", { slug }),
     t("AgentJoin.cmd.episodic3"),
     t("AgentJoin.cmd.etiquette"),
+    // #845：包尾提醒——本包是瞬态文本，规则的持久拷贝在上面落盘的 rules 文件里。
+    t("AgentJoin.cmd.rulesReread", { agentName, slug }),
   ].join("\n");
 }
 


### PR DESCRIPTION
#845 的 1+2+3 层切片，拆包（第 4 点按 harness 拆包）与第 5 点留给后续切片。

## 内容
- **层 1（每轮必达）**: shared 新增 `BEHAVIOR_CONTRACT_SUMMARY` / `BEHAVIOR_CONTRACT_BODY_LINES` 单一来源；party_send / party_watch_once / party_status 的 MCP description 尾部追加契约单行版。
- **层 2（落盘）**: joinPack 在 step2 后用带引号 heredoc（`<<'AGENTPARTY_RULES_EOF'` 防变量展开）把契约写到 `~/.agentparty/agents/agentparty-<name>-<slug>.rules.md`；正文全静态常量，不掺 charter 等管理员可控文本；包尾注明「上下文被压缩/丢失后先重读此文件」；i18n 中英双语。两入口共用 builder，同构性质保持。
- **层 3（唤醒补针）**: `party charter` / `party digest` 文本输出头部固定一行契约摘要。

## 测试
- `cli/test/behavior-contract.test.ts`: 常量形状（非空/无换行/无 delimiter 冲突）、MCP listTools 描述含契约、charter 输出首行含契约。
- `web/src/lib/joinPack.test.ts`: heredoc 落盘段逐行等于 shared 常量、正文无动态输入、包尾重读指引。
- cli/web `bunx tsc --noEmit` 通过；相关既有测试（mcp-charter / onboarding-charter / m3 / charter / AgentJoin / AgentTokens.copypack / i18n）全绿。