### PR TITLE
feat(web): 接入包按目标 harness 拆分——Claude Code/Codex/其他三档 (#845 第 4 点)

### DIFF
--- a/web/src/components/AgentJoin.tsx
+++ b/web/src/components/AgentJoin.tsx
@@ -11,7 +11,7 @@ import {
   ValidationError,
 } from "../lib/api";
 import { copyText, saveAgentToken } from "../lib/agentTokenVault";
-import { buildJoinPack, DEFAULT_JOIN_RUNNER, type JoinPackMode } from "../lib/joinPack";
+import { buildJoinPack, DEFAULT_JOIN_RUNNER, type JoinPackHarness, type JoinPackMode } from "../lib/joinPack";
 import { desktopAgentAdapter, type DesktopAgentAdapter, type DesktopAgentRunner } from "../lib/desktopAgent";
 import { isDesktopRuntime, pickDirectory as pickDirectoryDefault } from "../lib/desktopRuntime";
 import { DesktopInstallButton } from "./DesktopInstall";
@@ -103,6 +103,9 @@ export function AgentJoin({ slug, token, namePrefix, inviterName, charter, accou
   // #749：无人值守常驻用哪个 runner——曾写死 claude,用户选 codex 被静默忽略。默认 codex,
   // 与桌面「转为常驻」面板(DesktopAgentPanel)的 picker 默认一致。仅 unattended 模式用到。
   const [runner, setRunner] = useState<DesktopAgentRunner>(DEFAULT_JOIN_RUNNER);
+  // #845 第 4 点：interactive 包的目标 harness——只渲染对应分支把包砍薄。默认 "other"＝全量
+  // （兜底，不选择时行为与旧版逐字节一致）。仅 interactive 模式用到。
+  const [harness, setHarness] = useState<JoinPackHarness>("other");
   // #616 phase 4：桌面 webview 内的无人值守一键接管状态
   const [adoptState, setAdoptState] = useState<"idle" | "busy" | "done" | "error">("idle");
   const [adoptError, setAdoptError] = useState<string | null>(null);
@@ -120,6 +123,7 @@ export function AgentJoin({ slug, token, namePrefix, inviterName, charter, accou
     onActiveChange?.(true);
     setName(suggestName(namePrefix, slug));
     setMode("interactive");
+    setHarness("other");
     setNameErr(null);
     setPhase({ kind: "compose" });
   }, [namePrefix, onActiveChange, slug]);
@@ -179,6 +183,7 @@ export function AgentJoin({ slug, token, namePrefix, inviterName, charter, accou
         inviterName,
         charter,
         runner,
+        harness,
         t,
       });
       saveAgentToken({
@@ -189,6 +194,7 @@ export function AgentJoin({ slug, token, namePrefix, inviterName, charter, accou
         command,
         mode,
         runner,
+        harness,
         savedAt: Date.now(),
       });
       setCopied(false);
@@ -214,7 +220,7 @@ export function AgentJoin({ slug, token, namePrefix, inviterName, charter, accou
               : t("AgentJoin.errGeneric");
       setPhase({ kind: "error", message });
     }
-  }, [accountKey, charter, inviterName, mode, name, runner, slug, token, t]);
+  }, [accountKey, charter, harness, inviterName, mode, name, runner, slug, token, t]);
 
   // 无人值守直接运行：选工作目录（不手填、不复制接入包）→ dutyAdopt 就地落成 launchd 常驻。
   const adopt = useCallback(async () => {
@@ -330,6 +336,35 @@ export function AgentJoin({ slug, token, namePrefix, inviterName, charter, accou
                 </label>
               ))}
             </fieldset>
+
+            {/* #845 第 4 点：interactive 包的目标 harness 三选——只渲染对应分支。仅 interactive 显示。 */}
+            {mode === "interactive" && (
+              <fieldset className="agent-join-mode agent-join-harness">
+                <legend className="agent-join-namelabel t-mono">{t("AgentJoin.harnessLabel")}</legend>
+                {(["claude", "codex", "other"] as const).map((value) => (
+                  <label key={value} className="agent-join-mode-option">
+                    <input
+                      type="radio"
+                      name="agent-join-harness"
+                      value={value}
+                      checked={harness === value}
+                      onChange={() => setHarness(value)}
+                      disabled={phase.kind === "loading"}
+                    />
+                    <span className="t-mono">
+                      {t(
+                        value === "claude"
+                          ? "AgentJoin.harnessClaude"
+                          : value === "codex"
+                            ? "AgentJoin.harnessCodex"
+                            : "AgentJoin.harnessOther",
+                      )}
+                    </span>
+                  </label>
+                ))}
+                <p className="agent-join-hint t-mono">{t("AgentJoin.harnessHint")}</p>
+              </fieldset>
+            )}
 
             {/* #749：无人值守常驻的 runner 选择——曾写死 claude,用户选 codex 被忽略。仅 unattended 显示。 */}
             {mode === "unattended" && (

--- a/web/src/components/AgentTokens.tsx
+++ b/web/src/components/AgentTokens.tsx
@@ -30,7 +30,7 @@ import { apiOrigin } from "../lib/base";
 import { desktopAgentAdapter, type DesktopAgentAdapter, type DesktopAgentRunner } from "../lib/desktopAgent";
 import { isDesktopRuntime, pickDirectory as pickDirectoryDefault } from "../lib/desktopRuntime";
 import { LocalAgentsOverview } from "./LocalAgentsOverview";
-import { buildJoinPack, type JoinPackMode } from "../lib/joinPack";
+import { buildJoinPack, type JoinPackHarness, type JoinPackMode } from "../lib/joinPack";
 import { useT } from "../i18n/useT";
 import { SectionedDialog, type SectionedDialogSection } from "./SectionedDialog";
 import "../i18n/strings/AgentTokens";
@@ -277,7 +277,8 @@ export function AgentTokens({
   // 重建走 buildFullJoinPack——与「＋ 让 agent 加入」同一份 builder，产物逐字节同构，
   // 含 charter 快照与待命/唤醒指引（只发最小包的话，新 agent 报到完就不知道怎么挂 watch/serve）。
   // #612：unattended 记录重建同款无人值守包（serve --runner claude），别把值守机脚本换成交互包。
-  function freshCommand(record: { name: string; token: string; mode?: JoinPackMode; runner?: DesktopAgentRunner }): string {
+  // #845 第 4 点：interactive 记录按生成时选的目标 harness 重建同款拆薄包；旧记录无此字段 → builder 内落 other 全量。
+  function freshCommand(record: { name: string; token: string; mode?: JoinPackMode; runner?: DesktopAgentRunner; harness?: JoinPackHarness }): string {
     return buildJoinPack(record.mode ?? "interactive", {
       slug,
       agentName: record.name,
@@ -288,6 +289,7 @@ export function AgentTokens({
       charter,
       // #749：按生成时选的 runner 重建 unattended 脚本；旧记录无此字段 → buildJoinPack 内落 codex 默认。
       runner: record.runner,
+      harness: record.harness,
       t,
     });
   }
@@ -347,6 +349,8 @@ export function AgentTokens({
       mode: findSavedAgentToken(accountKey, slug, name)?.mode,
       // #749：轮换 token 也要保留已选 runner,否则已选 claude 的 unattended 记录轮换后复制包会回退 codex。
       runner: findSavedAgentToken(accountKey, slug, name)?.runner,
+      // #845：轮换 token 也保留已选目标 harness，「复制接入包」仍是同款拆薄包。
+      harness: findSavedAgentToken(accountKey, slug, name)?.harness,
       savedAt: Date.now(),
     });
     return next.token;

--- a/web/src/i18n/strings/AgentJoin.ts
+++ b/web/src/i18n/strings/AgentJoin.ts
@@ -82,6 +82,13 @@ export const AgentJoinStrings: LocaleDict = {
     "AgentJoin.cmd.rulesNote": "# Persist the behavior contract to disk (this pack is transient text — the rules survive context compaction there):",
     "AgentJoin.cmd.rulesReread": "# After context compaction or loss, re-read $HOME/.agentparty/agents/agentparty-{agentName}-{slug}.rules.md BEFORE acting.",
 
+    // #845 第 4 点：interactive 包的目标 harness 三选——只渲染对应分支，把包砍薄
+    "AgentJoin.harnessLabel": "target harness",
+    "AgentJoin.harnessClaude": "Claude Code",
+    "AgentJoin.harnessCodex": "Codex",
+    "AgentJoin.harnessOther": "other / generic (full pack)",
+    "AgentJoin.harnessHint": "renders only that harness's branches (MCP registration / wake templates); \"other\" keeps the full pack.",
+
     // 无人值守值守包（#612）：给人跑的 serve --runner 一键预设
     "AgentJoin.modeLabel": "join mode",
     "AgentJoin.runnerLabel": "runner",
@@ -190,6 +197,13 @@ export const AgentJoinStrings: LocaleDict = {
     "AgentJoin.cmd.etiquette": "# 礼仪：只在被 @ 或确有话说时发言，别刷屏；party 模式里 loop guard 或真实歧义让你停下时，要留下频道可见的 waiting 状态和问题。",
     "AgentJoin.cmd.rulesNote": "# 把行为契约落盘（本接入包是瞬态文本——上下文被压缩后，规则以这个文件为准）：",
     "AgentJoin.cmd.rulesReread": "# 上下文被压缩/丢失后，先重读 $HOME/.agentparty/agents/agentparty-{agentName}-{slug}.rules.md 再行动。",
+
+    // #845 第 4 点：interactive 包的目标 harness 三选——只渲染对应分支，把包砍薄
+    "AgentJoin.harnessLabel": "目标 harness",
+    "AgentJoin.harnessClaude": "Claude Code",
+    "AgentJoin.harnessCodex": "Codex",
+    "AgentJoin.harnessOther": "其他 / 通用（全量）",
+    "AgentJoin.harnessHint": "只渲染该 harness 的分支（MCP 注册 / 唤醒模板）；选「其他」保持全量包。",
 
     // 无人值守值守包（#612）：给人跑的 serve --runner 一键预设
     "AgentJoin.modeLabel": "接入方式",

--- a/web/src/lib/agentTokenVault.ts
+++ b/web/src/lib/agentTokenVault.ts
@@ -1,6 +1,6 @@
 import { AGENT_NAME_RE, mcpServerName } from "@agentparty/shared/onboarding";
 import type { DesktopAgentRunner } from "./desktopAgent";
-import { type JoinPackMode, MIN_CLI, VERSION_GE_SNIPPET } from "./joinPack";
+import { type JoinPackHarness, type JoinPackMode, MIN_CLI, VERSION_GE_SNIPPET } from "./joinPack";
 
 const RUNNERS: readonly DesktopAgentRunner[] = ["codex", "claude", "codex-sdk"];
 
@@ -16,6 +16,8 @@ export interface AgentTokenRecord {
   mode?: JoinPackMode;
   /** #749：unattended 生成时选的 runner；「复制接入包」按它重建同款。缺省（旧记录）按 codex。 */
   runner?: DesktopAgentRunner;
+  /** #845 第 4 点：interactive 生成时选的目标 harness；「复制接入包」按它重建同款。缺省（旧记录）按 other＝全量。 */
+  harness?: JoinPackHarness;
   savedAt: number;
 }
 
@@ -41,7 +43,8 @@ function isRecord(value: unknown): value is AgentTokenRecord {
     typeof rec.command === "string" &&
     typeof rec.savedAt === "number" &&
     (rec.mode === undefined || rec.mode === "interactive" || rec.mode === "unattended") &&
-    (rec.runner === undefined || RUNNERS.includes(rec.runner as DesktopAgentRunner))
+    (rec.runner === undefined || RUNNERS.includes(rec.runner as DesktopAgentRunner)) &&
+    (rec.harness === undefined || rec.harness === "claude" || rec.harness === "codex" || rec.harness === "other")
   );
 }
 

--- a/web/src/lib/joinPack.test.ts
+++ b/web/src/lib/joinPack.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, test } from "bun:test";
 import { BEHAVIOR_CONTRACT_BODY_LINES } from "@agentparty/shared/onboarding";
 import { lookup } from "../i18n/dict";
 import type { TFunc } from "../i18n/useT";
-import { buildFullJoinPack } from "./joinPack";
+import { buildFullJoinPack, type JoinPackHarness } from "./joinPack";
 
 const t: TFunc = (key, vars) => {
   const raw = lookup("zh", key) ?? lookup("en", key) ?? key;
@@ -12,7 +12,7 @@ const t: TFunc = (key, vars) => {
   return raw.replace(/\{(\w+)\}/g, (m, name: string) => (name in vars ? String(vars[name]) : m));
 };
 
-function pack(): string {
+function pack(harness?: JoinPackHarness): string {
   return buildFullJoinPack({
     slug: "dev",
     agentName: "bot",
@@ -20,6 +20,7 @@ function pack(): string {
     server: "https://party.example",
     inviterName: "leo",
     charter: null,
+    ...(harness === undefined ? {} : { harness }),
     t,
   });
 }
@@ -54,5 +55,92 @@ describe("joinPack 行为契约落盘（#845）", () => {
     const tail = text.split("\n").at(-1) ?? "";
     expect(tail.startsWith("#")).toBe(true);
     expect(tail).toContain("agentparty-bot-dev.rules.md");
+  });
+});
+
+// #845 第 4 点：interactive 包按目标 harness 拆分——目标 agent 只走一条分支，其余是噪音。
+describe("joinPack 按 harness 拆分（#845 第 4 点）", () => {
+  // claude mcp add 命令行 / claudeMode 指引 / claude -p 唤醒模板的指纹
+  const CLAUDE_MCP_ADD = "claude mcp add ";
+  const CLAUDE_WAKE = `claude -p -c "$(cat {file})"`;
+  const CLAUDE_MODE_FP = "watch --once";
+  // codex mcp add 指引 / codex exec 唤醒模板 / serve supervisor（otherMode）的指纹
+  const CODEX_MCP_ADD = "codex mcp add ";
+  const CODEX_WAKE = "codex exec resume --last";
+  const OTHER_MODE_FP = "party serve dev --on-mention";
+
+  test("other 档（含缺省不传）与旧全量逐字节一致", () => {
+    expect(pack("other")).toBe(pack());
+    const full = pack("other");
+    for (const fp of [CLAUDE_MCP_ADD, CLAUDE_WAKE, CLAUDE_MODE_FP, CODEX_MCP_ADD, CODEX_WAKE, OTHER_MODE_FP]) {
+      expect(full).toContain(fp);
+    }
+  });
+
+  test("claude 档：保留 claude mcp add + claudeMode + Claude 唤醒模板，无 codex 行", () => {
+    const text = pack("claude");
+    expect(text).toContain(CLAUDE_MCP_ADD);
+    expect(text).toContain(CLAUDE_MODE_FP);
+    expect(text).toContain(CLAUDE_WAKE);
+    expect(text).not.toContain(CODEX_MCP_ADD);
+    expect(text).not.toContain(CODEX_WAKE);
+    // otherMode 四行（serve supervisor 指引）也去掉
+    expect(text).not.toContain(OTHER_MODE_FP);
+  });
+
+  test("codex 档：保留 codex mcp add + Codex 唤醒模板 + serve 指引，无 claude 行", () => {
+    const text = pack("codex");
+    expect(text).toContain(CODEX_MCP_ADD);
+    expect(text).toContain(CODEX_WAKE);
+    expect(text).toContain(OTHER_MODE_FP);
+    expect(text).not.toContain(CLAUDE_MCP_ADD);
+    expect(text).not.toContain(CLAUDE_WAKE);
+    expect(text).not.toContain(CLAUDE_MODE_FP);
+  });
+
+  test("安全硬行三档全在：PATH 先于版本闸 / token 环境变量 / rules.md 落盘 / turnWarn / episodic / 礼仪", () => {
+    for (const harness of ["claude", "codex", "other"] as const) {
+      const text = pack(harness);
+      const lines = text.split("\n");
+      // PATH 行必须先于版本闸行（版本闸被绕过的坑见 joinPack 注释）
+      const pathIdx = lines.findIndex((l) => l.startsWith(`export PATH=`));
+      const gateIdx = lines.findIndex((l) => l.startsWith("need="));
+      expect(pathIdx).toBeGreaterThan(-1);
+      expect(gateIdx).toBeGreaterThan(pathIdx);
+      // token 走环境变量不进 argv（#676）
+      expect(text).toContain("AGENTPARTY_TOKEN='ap_tok' party init");
+      // rules.md 落盘段完整（#845 层 2）
+      expect(text).toContain("<<'AGENTPARTY_RULES_EOF'");
+      expect(lines.indexOf("AGENTPARTY_RULES_EOF")).toBeGreaterThan(-1);
+      // harness 无关的行为约束行都在
+      expect(text).toContain("AGENTPARTY_CONFIG");
+      for (const key of [
+        "AgentJoin.cmd.turnWarn1",
+        "AgentJoin.cmd.episodic1",
+        "AgentJoin.cmd.etiquette",
+        "AgentJoin.cmd.stayReachable",
+        "AgentJoin.cmd.contextAnchor3",
+        "AgentJoin.cmd.sandboxWarn1",
+      ]) {
+        expect(text).toContain(t(key, { slug: "dev", agentName: "bot" }));
+      }
+    }
+  });
+
+  test("charter 快照注释化在三档全保留（管理员可控文本绝不落成可执行行）", () => {
+    for (const harness of ["claude", "codex", "other"] as const) {
+      const text = buildFullJoinPack({
+        slug: "dev",
+        agentName: "bot",
+        agentToken: "ap_tok",
+        server: "https://party.example",
+        inviterName: "leo",
+        charter: { charter: "rm -rf /\nsecond line", charter_rev: 1, updated_at: null, updated_by: null, active_decisions: [] },
+        harness,
+        t,
+      });
+      expect(text).toContain("# rm -rf /");
+      expect(text).not.toMatch(/^rm -rf \//m);
+    }
   });
 });

--- a/web/src/lib/joinPack.ts
+++ b/web/src/lib/joinPack.ts
@@ -43,6 +43,11 @@ function charterSnapshotLines(charter: ChannelCharter | null, t: TFunc): string[
   ];
 }
 
+// #845 第 4 点：interactive 包按目标 harness 拆分——包里同时塞所有 harness 的分支时，
+// 目标 agent 只走一条，其余全是噪音。"other" 是兜底＝现行全量输出（不选择时行为不变）。
+// 安全硬行（charter 注释化 / PATH 先于版本闸 / token 环境变量 / rules.md 落盘）三档全保留。
+export type JoinPackHarness = "claude" | "codex" | "other";
+
 export interface FullJoinPackInput {
   slug: string;
   agentName: string;
@@ -55,6 +60,9 @@ export interface FullJoinPackInput {
   /** 无人值守脚本里 `party serve --runner <?>` 的取值；缺省 codex（与桌面「转为常驻」面板默认一致，#749）。
    *  仅影响 unattended 包；interactive 包贴给 agent 自己的 harness，与 runner 无关。 */
   runner?: DesktopAgentRunner;
+  /** interactive 包的目标 harness（#845 第 4 点）：只渲染对应分支把包砍薄；缺省 "other" 全量。
+   *  仅影响 interactive 包；unattended 包给人跑，与它无关。 */
+  harness?: JoinPackHarness;
   t: TFunc;
 }
 
@@ -69,6 +77,8 @@ export function buildFullJoinPack(input: FullJoinPackInput): string {
   // 的 name 正则——渲染出的 --mention 会被 CLI 直接拒绝，新 agent 第一条报到就报错。
   // 校验不过就整体降级为不 @：报到照发，blocked 指引改教它用 party who 反查 handle。
   const inviterName = AGENT_NAME_RE.test(input.inviterName) ? input.inviterName : null;
+  // #845 第 4 点：按目标 harness 只渲染对应分支。"other" 恒全量（兜底＝旧行为逐字节不变）。
+  const harness = input.harness ?? "other";
   return [
     t("AgentJoin.cmd.header", { slug }),
     t("AgentJoin.cmd.intro1"),
@@ -114,8 +124,14 @@ export function buildFullJoinPack(input: FullJoinPackInput): string {
       : `party send "${t("AgentJoin.cmd.checkinMessage", { agentName })}" --channel ${slug} --mention ${inviterName}`,
     ``,
     t("AgentJoin.cmd.step4"),
-    `claude mcp add ${mcpServerName(agentName)} --env AGENTPARTY_CONFIG="$HOME/.agentparty/agents/agentparty-${agentName}-${slug}.json" -- party mcp --channel ${slug}`,
-    t("AgentJoin.cmd.step4codex", { mcpName: mcpServerName(agentName), agentName, slug }),
+    // claude mcp add 是 Claude Code 专属注册命令；codex 档去掉，免得 codex 机器上直接执行报错。
+    ...(harness !== "codex"
+      ? [`claude mcp add ${mcpServerName(agentName)} --env AGENTPARTY_CONFIG="$HOME/.agentparty/agents/agentparty-${agentName}-${slug}.json" -- party mcp --channel ${slug}`]
+      : []),
+    // step4codex 是 codex mcp add 指引；claude 档去掉（目标 harness 只走一条，其余是噪音）。
+    ...(harness !== "claude"
+      ? [t("AgentJoin.cmd.step4codex", { mcpName: mcpServerName(agentName), agentName, slug })]
+      : []),
     t("AgentJoin.cmd.step4fallback"),
     ``,
     t("AgentJoin.cmd.step5"),
@@ -130,15 +146,26 @@ export function buildFullJoinPack(input: FullJoinPackInput): string {
       : t("AgentJoin.cmd.blocked2", { slug, inviterName }),
     t("AgentJoin.cmd.stayReachable"),
     t("AgentJoin.cmd.mcpWakeNote"),
-    t("AgentJoin.cmd.claudeMode1"),
-    t("AgentJoin.cmd.claudeMode2", { slug }),
-    t("AgentJoin.cmd.claudeMode3"),
-    t("AgentJoin.cmd.otherMode1"),
-    t("AgentJoin.cmd.otherMode2"),
-    t("AgentJoin.cmd.otherMode3", { slug }),
-    t("AgentJoin.cmd.otherMode4"),
-    `#        Codex:  OUT=$(mktemp); codex exec resume --last --skip-git-repo-check -o "$OUT" "$(cat {file})" || codex exec --skip-git-repo-check -o "$OUT" "$(cat {file})"; party send - --channel "$AP_CHANNEL" --reply-to "$AP_REPLY_TO" < "$OUT"`,
-    `#        Claude: claude -p -c "$(cat {file})" || claude -p "$(cat {file})"`,
+    // claudeMode 三行是 Claude Code 的 watch --once 待命指引；codex 档去掉。
+    ...(harness !== "codex"
+      ? [t("AgentJoin.cmd.claudeMode1"), t("AgentJoin.cmd.claudeMode2", { slug }), t("AgentJoin.cmd.claudeMode3")]
+      : []),
+    // otherMode 四行是常驻 serve supervisor 指引（Codex 唤醒模板挂在它下面）；claude 档去掉。
+    ...(harness !== "claude"
+      ? [
+          t("AgentJoin.cmd.otherMode1"),
+          t("AgentJoin.cmd.otherMode2"),
+          t("AgentJoin.cmd.otherMode3", { slug }),
+          t("AgentJoin.cmd.otherMode4"),
+        ]
+      : []),
+    // 唤醒命令模板按 harness 各留各的：claude 档不需要 codex exec，codex 档不需要 claude -p。
+    ...(harness !== "claude"
+      ? [
+          `#        Codex:  OUT=$(mktemp); codex exec resume --last --skip-git-repo-check -o "$OUT" "$(cat {file})" || codex exec --skip-git-repo-check -o "$OUT" "$(cat {file})"; party send - --channel "$AP_CHANNEL" --reply-to "$AP_REPLY_TO" < "$OUT"`,
+        ]
+      : []),
+    ...(harness !== "codex" ? [`#        Claude: claude -p -c "$(cat {file})" || claude -p "$(cat {file})"`] : []),
     t("AgentJoin.cmd.sandboxWarn1"),
     t("AgentJoin.cmd.sandboxWarn2"),
     t("AgentJoin.cmd.sandboxWarn3"),


### PR DESCRIPTION
#845 第 4 点切片；第 5 点（#844 后 stayReachable 清理）仍后置。

## 改动
- `joinPack.ts`：`FullJoinPackInput` 加 `harness?: "claude" | "codex" | "other"`（缺省 other＝旧全量逐字节不变）；`buildFullJoinPack` 按档只渲染对应分支：
  - **claude 档**：保留 `claude mcp add` + claudeMode 三行 + Claude 唤醒模板；去掉 step4codex、otherMode 四行、Codex 唤醒模板
  - **codex 档**：保留 step4codex + otherMode 四行 + Codex 唤醒模板；去掉 `claude mcp add`、claudeMode 三行、Claude 唤醒模板
  - **安全硬行三档全保留**：charter 注释化、PATH 先于版本闸、token 环境变量、rules.md 落盘、turnWarn/scope/contextAnchor/blocked/stayReachable/episodic/sandbox/礼仪
  - unattended 包不动（给人跑，与 harness 无关）
- UI：AgentJoin interactive 档加三选钮（跟随现有 mode fieldset 样式），i18n 中英双语
- vault 记录存 `harness`，AgentTokens「复制接入包」按它重建同款、轮换 token 保留——两入口仍共用同一 builder（#584 同构不破）

## 三档产物对比（zh，charter=null）
| 档 | 行数 | 字符 |
|---|---|---|
| other（全量） | 75 | 5187 |
| claude | 69 | 4611 |
| codex | 70 | 4748 |

## 测试
- joinPack.test.ts 新增四组断言：other 与缺省逐字节一致且含全部指纹、claude 档无 codex 行、codex 档无 claude 行、安全硬行+charter 注释化三档全在
- `bun test`（web 全量 1280 pass）+ `bunx tsc --noEmit` 通过