### PR TITLE
feat(context): agent 上报 repo/branch 并在频道显眼展示 (#853)

### DIFF
--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -2,6 +2,7 @@
 // 用外部 supervisor 唤醒（wake GOAL 的 session 型那半；有入站 URL 的 runtime 走 webhook）。
 // 复用 client.connect 的自动重连帧流，真正常驻；命令串行执行（一条处理完再下一条，不并发抢跑）。
 import { BODY_LIMIT, DECISION_OPTION_LIMIT, DECISION_OPTIONS_MAX, DECISION_PROMPT_LIMIT, EXIT_ARCHIVED, EXIT_AUTH, EXIT_STREAM_ENDED, EXIT_UPGRADED, type AgentSessionInfo, type Attachment, type DeliveryUpdateFrame, type DirectedDelivery, type MsgFrame, type PublicDirectedDelivery, type ResponseSource, type SendDecisionRequest, type ServerFrame } from "@agentparty/shared";
+import { safeBranchContextLabel, safeRepoContextLabel } from "@agentparty/shared";
 import { channelDecisionSnapshotBodyLines } from "@agentparty/shared/onboarding";
 import { createHash, randomUUID } from "node:crypto";
 import { spawnSync } from "node:child_process";
@@ -45,7 +46,7 @@ import { basename, dirname, isAbsolute, join, relative, sep } from "node:path";
 import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
 import { readAccount } from "../account";
 import { connect } from "../client";
-import { clearStuck, clearStuckForConfig, loadCursor, loadCursorForConfig, loadRevCursor, loadRevCursorForConfig, loadStuck, loadStuckForConfig, localAgentConfigsForChannel, readConfigWithSource, refreshConfigInPlace, resolveChannel, saveCursor, saveCursorForConfig, saveRevCursor, saveRevCursorForConfig, saveStuck, saveStuckForConfig, type StuckWake } from "../config";
+import { clearStuck, clearStuckForConfig, loadCursor, loadCursorForConfig, loadRevCursor, loadRevCursorForConfig, loadStuck, loadStuckForConfig, localAgentConfigsForChannel, branchLabel, repoLabel, readConfigWithSource, refreshConfigInPlace, resolveChannel, saveCursor, saveCursorForConfig, saveRevCursor, saveRevCursorForConfig, saveStuck, saveStuckForConfig, type StuckWake } from "../config";
 import { acquireInstanceLock, claimRunnerCwd, defaultInstanceLockDir, instanceLockTarget, stopOwnInstance } from "../instance-lock";
 import { formatMsg, stripTerminalControls } from "../format";
 import { clearHealthCache, writeHealthCache } from "../health-cache";
@@ -4455,6 +4456,13 @@ export async function runProfileServe(opts: ProfileServeOptions): Promise<number
           : opts.runnerTimeoutMs,
         signal: channelSignal,
         advertise: async (signal) => {
+          // #853：profile 车道的 repo/branch 从频道工作副本推导（advertise 时 checkout 已就绪）。
+          const laneRepo = safeRepoContextLabel(repoLabel(prepared.channelWorkdir));
+          const laneBranch = safeBranchContextLabel(branchLabel(prepared.channelWorkdir));
+          const laneGitContext = {
+            ...(laneRepo !== undefined ? { repo: laneRepo } : {}),
+            ...(laneBranch !== undefined ? { branch: laneBranch } : {}),
+          };
           if (role === "front") {
             const note = projectAgentReadyNote(profile, channel, prepared);
             const { role_warning: roleWarning } = await post(opts.server, principal.token, channel, {
@@ -4468,6 +4476,7 @@ export async function runProfileServe(opts: ProfileServeOptions): Promise<number
               context: {
                 workspace_label: `${profile.owner_account}/${profile.handle}`,
                 worktree_label: `${principal.name}:${profile.worktree_strategy}:${profile.base_branch}`,
+                ...laneGitContext,
                 reception_mode: "model",
                 reception_runner: profile.runner === "shell" ? "custom" : profile.runner,
                 reception_context: "isolated_channel_session",
@@ -4493,6 +4502,7 @@ export async function runProfileServe(opts: ProfileServeOptions): Promise<number
             context: {
               workspace_label: `${profile.owner_account}/${profile.handle}`,
               worktree_label: `${principal.name}:${profile.worktree_strategy}:${profile.base_branch}`,
+              ...laneGitContext,
               reception_mode: "model",
               reception_runner: profile.runner === "shell" ? "custom" : profile.runner,
               reception_context: "isolated_channel_session",

--- a/cli/src/commands/status.ts
+++ b/cli/src/commands/status.ts
@@ -11,8 +11,9 @@ import type {
   WakeKind,
   WorkflowKind,
 } from "@agentparty/shared";
+import { safeBranchContextLabel, safeRepoContextLabel } from "@agentparty/shared";
 import { isHelpArg, parseArgs, str, strArray, unknownFlagError, valueFlagError } from "../args";
-import { advanceCursorPastOwnMessage, resolveChannel, workspaceId, workspaceLabel, worktreeLabel } from "../config";
+import { advanceCursorPastOwnMessage, branchLabel, repoLabel, resolveChannel, workspaceId, workspaceLabel, worktreeLabel } from "../config";
 import { stripTerminalControls } from "../format";
 import { formatAuthDebugLine, resolveAuthDetailed } from "../oidc-cli";
 import { fetchMe, handleRestError, postMessage, taskStateFromReportedStatus, updateTask } from "../rest";
@@ -100,12 +101,17 @@ Options:
 
 export function buildContext(auth: Awaited<ReturnType<typeof resolveAuthDetailed>>): AgentContext {
   const wt = worktreeLabel();
+  // repo/branch 纯 advisory 展示（#853）：先过 shared 白名单，非法值静默丢弃而非污染整个 context。
+  const repo = safeRepoContextLabel(repoLabel());
+  const branch = safeBranchContextLabel(branchLabel());
   return {
     config_kind: auth.config.kind,
     ...(auth.config.token_fingerprint !== undefined ? { config_fingerprint: auth.config.token_fingerprint } : {}),
     workspace_id: workspaceId(),
     workspace_label: workspaceLabel(),
     ...(wt !== undefined ? { worktree_label: wt } : {}),
+    ...(repo !== undefined ? { repo } : {}),
+    ...(branch !== undefined ? { branch } : {}),
   };
 }
 

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -467,6 +467,39 @@ function gitOutput(cwd: string, args: string[]): string | null {
   }
 }
 
+/**
+ * 从 origin remote URL 解析仓库展示标签（#853）。
+ * github.com → `owner/repo`；其他 host → `host:owner/repo`；解析不出 → undefined（静默降级）。
+ */
+export function parseRepoLabel(url: string): string | undefined {
+  const trimmed = url.trim();
+  // ssh scp 形式：git@host:owner/repo(.git)
+  let m = /^[\w.-]+@([\w.-]+):(.+?)(?:\.git)?\/?$/.exec(trimmed);
+  // URL 形式：https://host/owner/repo(.git)、ssh://git@host/owner/repo(.git)
+  if (m === null) m = /^(?:https?|ssh|git):\/\/(?:[\w.-]+@)?([\w.-]+)(?::\d+)?\/(.+?)(?:\.git)?\/?$/.exec(trimmed);
+  if (m === null) return undefined;
+  const host = m[1].toLowerCase();
+  const path = m[2].replace(/^\/+/, "");
+  const segments = path.split("/").filter((s) => s !== "");
+  if (segments.length < 2) return undefined;
+  const ownerRepo = segments.slice(-2).join("/");
+  return host === "github.com" ? ownerRepo : `${host}:${ownerRepo}`;
+}
+
+export function repoLabel(cwd: string = process.cwd()): string | undefined {
+  const url = gitOutput(cwd, ["remote", "get-url", "origin"]);
+  if (url === null) return undefined;
+  return parseRepoLabel(url);
+}
+
+export function branchLabel(cwd: string = process.cwd()): string | undefined {
+  const branch = gitOutput(cwd, ["rev-parse", "--abbrev-ref", "HEAD"]);
+  if (branch === null) return undefined;
+  if (branch !== "HEAD") return branch;
+  // detached HEAD：退回短 SHA
+  return gitOutput(cwd, ["rev-parse", "--short", "HEAD"]) ?? undefined;
+}
+
 export function worktreeLabel(cwd: string = process.cwd()): string | undefined {
   const root = gitOutput(cwd, ["rev-parse", "--show-toplevel"]);
   if (root === null) return undefined;

--- a/cli/src/format.ts
+++ b/cli/src/format.ts
@@ -40,6 +40,8 @@ function formatSender(m: MsgFrame): string {
 function formatContext(ctx: AgentContext | undefined): string[] {
   if (ctx === undefined) return [];
   return [
+    ctx.repo ? `repo=${ctx.repo}` : null,
+    ctx.branch ? `branch=${ctx.branch}` : null,
     ctx.worktree_label ? `worktree=${ctx.worktree_label}` : null,
     ctx.workspace_label ? `workspace=${ctx.workspace_label}` : null,
     ctx.config_kind ? `config=${ctx.config_kind}` : null,

--- a/cli/test/config.test.ts
+++ b/cli/test/config.test.ts
@@ -457,3 +457,85 @@ describe("workspace state", () => {
     expect(warnings[0]).toContain("falling back");
   });
 });
+
+// #853：repo/branch 展示标签。git 集成测试建真实临时仓库；URL 解析纯函数直测。
+import { branchLabel, parseRepoLabel, repoLabel } from "../src/config";
+import { safeBranchContextLabel, safeRepoContextLabel } from "@agentparty/shared";
+import { execSync } from "node:child_process";
+
+describe("parseRepoLabel", () => {
+  test("ssh scp form with .git", () => {
+    expect(parseRepoLabel("git@github.com:leeguooooo/AgentParty.git")).toBe("leeguooooo/AgentParty");
+  });
+  test("https form without .git", () => {
+    expect(parseRepoLabel("https://github.com/leeguooooo/AgentParty")).toBe("leeguooooo/AgentParty");
+  });
+  test("https form with .git and trailing slash", () => {
+    expect(parseRepoLabel("https://github.com/owner/repo.git/")).toBe("owner/repo");
+  });
+  test("ssh url form", () => {
+    expect(parseRepoLabel("ssh://git@github.com/owner/repo.git")).toBe("owner/repo");
+  });
+  test("non-github host keeps host prefix", () => {
+    expect(parseRepoLabel("git@gitlab.example.com:team/proj.git")).toBe("gitlab.example.com:team/proj");
+    expect(parseRepoLabel("https://gitea.internal/org/tool")).toBe("gitea.internal:org/tool");
+  });
+  test("nested group path keeps last two segments", () => {
+    expect(parseRepoLabel("https://gitlab.com/group/sub/proj.git")).toBe("gitlab.com:sub/proj");
+  });
+  test("unparseable returns undefined", () => {
+    expect(parseRepoLabel("/local/path/repo")).toBeUndefined();
+    expect(parseRepoLabel("git@host:justrepo.git")).toBeUndefined();
+    expect(parseRepoLabel("")).toBeUndefined();
+  });
+});
+
+describe("shared context label whitelist", () => {
+  test("accepts whitelisted repo/branch", () => {
+    expect(safeRepoContextLabel("leeguooooo/AgentParty")).toBe("leeguooooo/AgentParty");
+    expect(safeRepoContextLabel("gitlab.example.com:team/proj")).toBe("gitlab.example.com:team/proj");
+    expect(safeBranchContextLabel("feat/853-repo-branch#1@wip")).toBe("feat/853-repo-branch#1@wip");
+  });
+  test("rejects non-whitelist chars, oversize, and non-strings", () => {
+    expect(safeRepoContextLabel("owner/repo<script>")).toBeUndefined();
+    expect(safeRepoContextLabel("a".repeat(121))).toBeUndefined();
+    expect(safeRepoContextLabel(42)).toBeUndefined();
+    expect(safeBranchContextLabel("bad branch name")).toBeUndefined();
+    expect(safeBranchContextLabel("")).toBeUndefined();
+  });
+});
+
+describe("repoLabel/branchLabel (git integration)", () => {
+  let gitDir: string;
+  beforeEach(() => {
+    gitDir = mkdtempSync(join(tmpdir(), "ap-gitctx-"));
+    execSync("git init -q -b main", { cwd: gitDir });
+    execSync("git -c user.email=t@t -c user.name=t commit -q --allow-empty -m init", { cwd: gitDir });
+  });
+  afterEach(() => rmSync(gitDir, { recursive: true, force: true }));
+
+  test("no origin remote → repoLabel undefined", () => {
+    expect(repoLabel(gitDir)).toBeUndefined();
+  });
+  test("github origin → owner/repo", () => {
+    execSync("git remote add origin git@github.com:owner/repo.git", { cwd: gitDir });
+    expect(repoLabel(gitDir)).toBe("owner/repo");
+  });
+  test("branchLabel returns current branch", () => {
+    expect(branchLabel(gitDir)).toBe("main");
+  });
+  test("detached HEAD → short sha", () => {
+    execSync("git checkout -q --detach HEAD", { cwd: gitDir });
+    const sha = execSync("git rev-parse --short HEAD", { cwd: gitDir, encoding: "utf8" }).trim();
+    expect(branchLabel(gitDir)).toBe(sha);
+  });
+  test("non-git dir → both undefined", () => {
+    const plain = mkdtempSync(join(tmpdir(), "ap-plain-"));
+    try {
+      expect(repoLabel(plain)).toBeUndefined();
+      expect(branchLabel(plain)).toBeUndefined();
+    } finally {
+      rmSync(plain, { recursive: true, force: true });
+    }
+  });
+});

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -304,12 +304,37 @@ export type ReceptionMode = "model" | "custom";
 export type ReceptionRunner = "codex" | "claude" | "codex-sdk" | "custom";
 export type ReceptionContextBoundary = "isolated_channel_session" | "fresh_process";
 
+/** repo/branch 展示标签上限（#853）：纯 advisory，超长或含白名单外字符直接丢弃。 */
+export const CONTEXT_GIT_LABEL_MAX = 120;
+const CONTEXT_REPO_RE = /^[A-Za-z0-9._/:-]+$/;
+const CONTEXT_BRANCH_RE = /^[A-Za-z0-9._/@#-]+$/;
+
+/** 校验 `owner/repo`（或 `host:owner/repo`）展示标签；非法返回 undefined（静默降级，不 fail 整个 context）。 */
+export function safeRepoContextLabel(input: unknown): string | undefined {
+  if (typeof input !== "string") return undefined;
+  const trimmed = input.trim();
+  if (trimmed === "" || trimmed.length > CONTEXT_GIT_LABEL_MAX) return undefined;
+  return CONTEXT_REPO_RE.test(trimmed) ? trimmed : undefined;
+}
+
+/** 校验分支/短 SHA 展示标签；白名单额外允许 `#`/`@`（issue 号分支、fork 引用惯例）。 */
+export function safeBranchContextLabel(input: unknown): string | undefined {
+  if (typeof input !== "string") return undefined;
+  const trimmed = input.trim();
+  if (trimmed === "" || trimmed.length > CONTEXT_GIT_LABEL_MAX) return undefined;
+  return CONTEXT_BRANCH_RE.test(trimmed) ? trimmed : undefined;
+}
+
 export interface AgentContext {
   config_kind?: ConfigSourceKind;
   config_fingerprint?: string;
   workspace_id?: string;
   workspace_label?: string;
   worktree_label?: string;
+  /** GitHub 仓库标签 `owner/repo`（非 github 远端为 `host:owner/repo`）。纯展示，不进授权判定（#853）。 */
+  repo?: string;
+  /** 当前分支名；detached HEAD 时为短 SHA。纯展示（#853）。 */
+  branch?: string;
   /** How an unattended @-mention is handled by this resident agent. */
   reception_mode?: ReceptionMode;
   reception_runner?: ReceptionRunner;

--- a/web/src/components/MessageCard.details.test.tsx
+++ b/web/src/components/MessageCard.details.test.tsx
@@ -289,3 +289,50 @@ describe("MessageCard touch and keyboard details (#357)", () => {
     expect(pill.findByProps({ className: "msg-status-name-state" }).children.join("")).toBe("replied");
   });
 });
+
+// #853：消息头 repo ⎇ branch · worktree chip。普通消息回落到发送者 presence 的 context。
+describe("MessageCard git context chip (#853)", () => {
+  function renderWithPresence(context?: Record<string, string>): ReturnType<ReactTestRenderer["root"]["findByProps"]> {
+    const msg = {
+      type: "msg", seq: 20, sender: { name: "builder", kind: "agent", owner: "team@example.com" }, kind: "message",
+      body: "done", mentions: [], reply_to: null, state: null, note: null, status: null,
+      ts: 1_700_000_000_000,
+    } as unknown as MsgFrame;
+    const presence = context === undefined
+      ? undefined
+      : { builder: { name: "builder", kind: "agent", state: "working", note: null, ts: 1, context } };
+    act(() => {
+      renderer = create(<LocaleProvider><MessageCard
+        msg={msg} self={null} quotedMessage={null} canModerate={false} onReply={noop} onEdit={noop}
+        presence={presence as never}
+        onRetract={noop} canCreateTask={false} onCreateTask={noop} editing={false} editDraft=""
+        editSaving={false} actionError={null} busy={false} onEditDraftChange={noop} onEditCancel={noop} onEditSave={noop}
+      /></LocaleProvider>);
+    });
+    return renderer!.root;
+  }
+
+  test("renders repo \u2387 branch \u00b7 worktree beside header metadata", () => {
+    const root = renderWithPresence({
+      repo: "leeguooooo/AgentParty",
+      branch: "feat/853-x",
+      worktree_label: "agentparty:feat/853-x",
+    });
+    const chip = root.findByProps({ className: "t-mono msg-git-context" });
+    expect(textContent(chip)).toBe("leeguooooo/AgentParty \u2387 feat/853-x \u00b7 agentparty:feat/853-x");
+    expect(chip.props.title).toBe("leeguooooo/AgentParty \u2387 feat/853-x \u00b7 agentparty:feat/853-x");
+  });
+
+  test("omits worktree tail when absent, and no chip without repo/branch", () => {
+    const withRepo = renderWithPresence({ repo: "owner/repo", branch: "main" });
+    expect(textContent(withRepo.findByProps({ className: "t-mono msg-git-context" }))).toBe("owner/repo \u2387 main");
+    act(() => renderer?.unmount());
+    renderer = null;
+    const without = renderWithPresence({ worktree_label: "agentparty:main" });
+    expect(without.findAllByProps({ className: "t-mono msg-git-context" })).toHaveLength(0);
+    act(() => renderer?.unmount());
+    renderer = null;
+    const noPresence = renderWithPresence(undefined);
+    expect(noPresence.findAllByProps({ className: "t-mono msg-git-context" })).toHaveLength(0);
+  });
+});

--- a/web/src/components/MessageCard.tsx
+++ b/web/src/components/MessageCard.tsx
@@ -5,6 +5,7 @@ import { memo, useCallback, useEffect, useLayoutEffect, useRef, useState } from 
 import type { CSSProperties } from "react";
 import { agentHue } from "../lib/agentColor";
 import { isClientVersionOutdated, useMinClientVersion } from "../lib/clientVersion";
+import { gitContextChip } from "../lib/gitContext";
 import {
   formatIdentityPresentation,
   resolveAgentOwnerLabel,
@@ -70,6 +71,8 @@ interface Props {
 function contextBits(ctx: AgentContext | undefined): string[] {
   if (ctx === undefined) return [];
   return [
+    ctx.repo ? `repo:${ctx.repo}` : null,
+    ctx.branch ? `⎇ ${ctx.branch}` : null,
     ctx.worktree_label ? `wt:${ctx.worktree_label}` : null,
     ctx.workspace_label ? `ws:${ctx.workspace_label}` : null,
     ctx.config_kind ? `cfg:${ctx.config_kind}` : null,
@@ -571,6 +574,8 @@ function MessageCardImpl({
     const statusWorkflowBits = workflowBits(msg);
     const statusTitle = [
       senderTitle,
+      context?.repo ? `repo: ${context.repo}` : null,
+      context?.branch ? `branch: ${context.branch}` : null,
       context?.worktree_label ? `worktree: ${context.worktree_label}` : null,
       context?.workspace_id ? `workspace id: ${context.workspace_id}` : null,
       context?.workspace_label ? `workspace: ${context.workspace_label}` : null,
@@ -658,6 +663,8 @@ function MessageCardImpl({
           artifact.related_issues.length > 0 ? `issues ${artifact.related_issues.map((n) => `#${n}`).join(", ")}` : null,
           artifact.related_prs.length > 0 ? `PRs ${artifact.related_prs.map((n) => `#${n}`).join(", ")}` : null,
         ].filter((part): part is string => part !== null);
+  // #853：消息头 `repo ⎇ branch · worktree` chip。status 帧自带 context；普通消息回落到发送者当前 presence。
+  const gitChip = gitContextChip(msg.status?.context ?? presence?.[msg.sender.name]?.context);
   return (
     <article
       id={`msg-${msg.seq}`}
@@ -716,6 +723,11 @@ function MessageCardImpl({
                   {" "}⚠
                 </span>
               )}
+            </span>
+          )}
+          {gitChip !== null && (
+            <span className="t-mono msg-git-context" title={gitChip}>
+              {gitChip}
             </span>
           )}
           {msg.response_source !== undefined && (

--- a/web/src/components/PresenceBar.test.ts
+++ b/web/src/components/PresenceBar.test.ts
@@ -901,3 +901,31 @@ describe("presence 未监听/不可唤醒可见性 (#666)", () => {
     expect(nodesWithClass(zh, "presence-unreachable").some((n) => n.children.join("") === "⚠ 未监听")).toBe(true);
   });
 });
+
+// #853：repo ⎇ branch · worktree chip 提级到常规行（非 full 也显示）。
+describe("presence git context chip (#853)", () => {
+  test("renders repo ⎇ branch · worktree in the regular row without expanding", () => {
+    const r = renderPresence({
+      ...presenceEntry(),
+      context: { repo: "leeguooooo/AgentParty", branch: "feat/853-x", worktree_label: "agentparty:feat/853-x" },
+    }, true);
+    const chips = nodesWithClass(r, "presence-git-context");
+    expect(chips).toHaveLength(1);
+    expect(chips[0]?.children.join("")).toBe("leeguooooo/AgentParty \u2387 feat/853-x \u00b7 agentparty:feat/853-x");
+    expect(chips[0]?.props.title).toBe("leeguooooo/AgentParty \u2387 feat/853-x \u00b7 agentparty:feat/853-x");
+  });
+
+  test("omits worktree tail when worktree_label is absent", () => {
+    const r = renderPresence({
+      ...presenceEntry(),
+      context: { repo: "owner/repo", branch: "main" },
+    }, true);
+    const chips = nodesWithClass(r, "presence-git-context");
+    expect(chips[0]?.children.join("")).toBe("owner/repo \u2387 main");
+  });
+
+  test("no chip when context lacks repo and branch", () => {
+    const r = renderPresence({ ...presenceEntry(), context: { worktree_label: "agentparty:main" } }, true);
+    expect(nodesWithClass(r, "presence-git-context")).toHaveLength(0);
+  });
+});

--- a/web/src/components/PresenceBar.tsx
+++ b/web/src/components/PresenceBar.tsx
@@ -3,6 +3,7 @@
 import { autoWakeReachable, evaluateHostLease, PRESENCE_TIMEOUT_MS, wakeableState, type ChannelRoleAssignment, type PresenceEntry, type PresenceState, type Sender } from "@agentparty/shared";
 import { useCallback, useEffect, useRef, useState, type CSSProperties, type ReactElement } from "react";
 import { agentHue } from "../lib/agentColor";
+import { gitContextChip } from "../lib/gitContext";
 import { fmtRel } from "../lib/time";
 import type { SocketStatus } from "../lib/ws";
 import { useT } from "../i18n/useT";
@@ -603,6 +604,8 @@ export function PresenceBar({
       it.context?.workspace_id !== undefined ? `workspace id: ${it.context.workspace_id}` : null,
       it.context?.workspace_label !== undefined ? `workspace: ${it.context.workspace_label}` : null,
       it.context?.worktree_label !== undefined ? `worktree: ${it.context.worktree_label}` : null,
+      it.context?.repo !== undefined ? `repo: ${it.context.repo}` : null,
+      it.context?.branch !== undefined ? `branch: ${it.context.branch}` : null,
       it.lineage !== null ? `parent: ${it.lineage.parent_agent}` : null,
       it.lineage !== null ? `root: ${it.lineage.root_agent}` : null,
       it.lineage !== null ? `team: ${it.lineage.team_id}` : null,
@@ -618,6 +621,7 @@ export function PresenceBar({
       it.note !== null && it.note !== "" ? `note: ${it.note}` : null,
       it.lastSeen !== null ? `last seen: ${fmtRel(it.lastSeen)}` : null,
     ].filter((part): part is string => part !== null);
+    const gitChip = gitContextChip(it.context);
     return (
       <span
         key={it.name}
@@ -716,7 +720,11 @@ export function PresenceBar({
             {t(unreachable.key)}
           </span>
         )}
-        {full && it.context?.worktree_label !== undefined && (
+        {/* #853：repo ⎇ branch · worktree 提级到常规行（不再只在深展开）；title 悬浮全文。 */}
+        {gitChip !== null && (
+          <span className="t-mono presence-context presence-git-context" title={gitChip}>{gitChip}</span>
+        )}
+        {full && gitChip === null && it.context?.worktree_label !== undefined && (
           <span className="t-mono presence-context">{it.context.worktree_label}</span>
         )}
         {full && it.context?.config_kind !== undefined && (
@@ -867,6 +875,8 @@ export function PresenceBar({
               const agentTask = taskLabel(agent, now);
               const agentUnreachable = unreachableBadge(agent, now);
               const agentUnhandledMention = unhandledMentionLabel(agent);
+              // #853：repo ⎇ branch · worktree 提级到常规行的 agent chip（不再只在深展开）。
+              const agentGitChip = gitContextChip(agent.context);
               return (
               <span
                 key={agent.name}
@@ -916,6 +926,11 @@ export function PresenceBar({
                 )}
                 {agent.clientVersion !== null && (
                   <span className="t-mono presence-client-version">cli v{agent.clientVersion}</span>
+                )}
+                {agentGitChip !== null && (
+                  <span className="t-mono presence-context presence-git-context" title={agentGitChip}>
+                    {agentGitChip}
+                  </span>
                 )}
                 {agent.connectionCount > 1 && <span className="t-mono presence-agent-duplicate">x{agent.connectionCount}</span>}
                 {roleBadge(agent, now) !== null && <span className="t-mono presence-agent-role">{roleBadge(agent, now)}</span>}

--- a/web/src/lib/gitContext.test.ts
+++ b/web/src/lib/gitContext.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+import { gitContextChip } from "./gitContext";
+
+// #853：chip 文案拼接。
+describe("gitContextChip", () => {
+  test("repo + branch + worktree", () => {
+    expect(gitContextChip({ repo: "a/b", branch: "main", worktree_label: "b:main" })).toBe("a/b ⎇ main · b:main");
+  });
+  test("repo + branch without worktree", () => {
+    expect(gitContextChip({ repo: "a/b", branch: "main" })).toBe("a/b ⎇ main");
+  });
+  test("repo only / branch only", () => {
+    expect(gitContextChip({ repo: "a/b" })).toBe("a/b");
+    expect(gitContextChip({ branch: "main" })).toBe("⎇ main");
+  });
+  test("null without repo and branch", () => {
+    expect(gitContextChip({ worktree_label: "b:main" })).toBeNull();
+    expect(gitContextChip(undefined)).toBeNull();
+    expect(gitContextChip(null)).toBeNull();
+  });
+});

--- a/web/src/lib/gitContext.ts
+++ b/web/src/lib/gitContext.ts
@@ -1,0 +1,21 @@
+// #853：`repo ⎇ branch · worktree` 上下文 chip 文案。MessageCard 消息头与 PresenceBar 常规行共用。
+// 纯 advisory 展示：字段由服务端白名单校验过，这里只负责拼接，不做授权判定。
+import type { AgentContext } from "@agentparty/shared";
+
+/**
+ * 返回单行 chip 文案；repo 与 branch 都缺席时返回 null（不渲染）。
+ * worktree 段有才拼在尾部；CSS 端到端 ellipsis 截断时它最先被截，保住 repo+branch。
+ */
+export function gitContextChip(ctx: AgentContext | undefined | null): string | null {
+  if (ctx === undefined || ctx === null) return null;
+  const repo = ctx.repo;
+  const branch = ctx.branch;
+  if (repo === undefined && branch === undefined) return null;
+  const head = repo !== undefined && branch !== undefined
+    ? `${repo} ⎇ ${branch}`
+    : repo !== undefined
+      ? repo
+      : `⎇ ${branch}`;
+  const worktree = ctx.worktree_label;
+  return worktree !== undefined && worktree !== "" ? `${head} · ${worktree}` : head;
+}

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -2155,6 +2155,11 @@ button.org-person-name {
   color: var(--t-dim);
   background: var(--t-panel2);
 }
+/* #853：常规行的 repo ⎇ branch · worktree chip，允许比其他 context chip 略宽。 */
+.presence-git-context {
+  max-width: min(240px, 38vw);
+  font-weight: 400;
+}
 .presence-lineage {
   max-width: min(170px, 32vw);
   overflow: hidden;
@@ -3741,6 +3746,20 @@ button.org-person-name {
   font-weight: 600;
 }
 .msg-client-version-warn { color: var(--d-amber); }
+/* #853：消息头 `repo ⎇ branch · worktree` 上下文 chip。单色等宽、单行 ellipsis 截断（尾部 worktree 段先截），title 悬浮全文。 */
+.msg-git-context {
+  display: inline-block;
+  max-width: min(260px, 42vw);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding: 1px 6px;
+  border: 1.4px solid var(--t-faint);
+  border-radius: 0;
+  background: var(--t-panel2);
+  color: var(--t-dim);
+  font-size: 10px;
+  white-space: nowrap;
+}
 .msg-reception-source {
   padding: 1px 6px;
   border: 1.4px solid var(--d-blue);

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -56,6 +56,8 @@ import {
   type Attachment,
   type ErrorCode,
   type AgentContext,
+  safeBranchContextLabel,
+  safeRepoContextLabel,
   type CollaborationRole,
   type CollaborationRoleSource,
   type CompletionArtifact,
@@ -1175,6 +1177,9 @@ function parseAgentContext(input: unknown): AgentContext | undefined | null {
   const workspaceId = safeContextString(raw.workspace_id, 128);
   const workspaceLabel = safeContextString(raw.workspace_label, 80);
   const worktreeLabel = safeContextString(raw.worktree_label, 120);
+  // #853：repo/branch 纯 advisory 展示。白名单校验失败只丢字段，不否决整个 context（旧字段仍有价值）。
+  const repo = safeRepoContextLabel(raw.repo);
+  const branch = safeBranchContextLabel(raw.branch);
   const receptionMode = raw.reception_mode;
   const receptionRunner = raw.reception_runner;
   const receptionContext = raw.reception_context;
@@ -1200,6 +1205,8 @@ function parseAgentContext(input: unknown): AgentContext | undefined | null {
     ...(workspaceId === undefined ? {} : { workspace_id: workspaceId }),
     ...(workspaceLabel === undefined ? {} : { workspace_label: workspaceLabel }),
     ...(worktreeLabel === undefined ? {} : { worktree_label: worktreeLabel }),
+    ...(repo === undefined ? {} : { repo }),
+    ...(branch === undefined ? {} : { branch }),
     ...(receptionMode === undefined
       ? {}
       : { reception_mode: String(receptionMode) as AgentContext["reception_mode"] }),

--- a/worker/src/openapi.ts
+++ b/worker/src/openapi.ts
@@ -870,6 +870,8 @@ export const openapiDocument = {
                           workspace_id: { type: "string" },
                           workspace_label: { type: "string" },
                           worktree_label: { type: "string" },
+                          repo: { type: "string", example: "leeguooooo/AgentParty" },
+                          branch: { type: "string", example: "feat/853-repo-branch-context" },
                         },
                       },
                     },

--- a/worker/test/ws.spec.ts
+++ b/worker/test/ws.spec.ts
@@ -370,6 +370,9 @@ describe("websocket", () => {
         workspace_id: "agentparty-deadbeef",
         workspace_label: "agentparty",
         worktree_label: "agentparty:main",
+        // #853：repo/branch 纯 advisory；非法值（白名单外字符）只丢字段不否决整个 context。
+        repo: "leeguooooo/AgentParty",
+        branch: "feat/853-repo-branch-context",
       },
       scope: ["worker/src/do.ts", "shared/src/protocol.ts"],
       blocked_reason: "waiting for schema review",
@@ -412,6 +415,8 @@ describe("websocket", () => {
           config_fingerprint: "sha256:abc123",
           workspace_label: "agentparty",
           worktree_label: "agentparty:main",
+          repo: "leeguooooo/AgentParty",
+          branch: "feat/853-repo-branch-context",
         },
         decision: {
           kind: "handoff",
@@ -468,6 +473,8 @@ describe("websocket", () => {
         workspace_id: "agentparty-deadbeef",
         workspace_label: "agentparty",
         worktree_label: "agentparty:main",
+        repo: "leeguooooo/AgentParty",
+        branch: "feat/853-repo-branch-context",
       },
     });
     expect(presence.wake).not.toHaveProperty("verified_at");


### PR DESCRIPTION
Closes #853

## 变更
- **shared**: `AgentContext` 新增可选 `repo`/`branch`，附 `safeRepoContextLabel`/`safeBranchContextLabel` 白名单校验（≤120 字符；repo 允许 `[A-Za-z0-9._/:-]`，branch 额外允许 `#@`）
- **cli**: `repoLabel()`（origin remote 解析 ssh scp / https / ssh:// 三种；github.com → `owner/repo`，其他 host → `host:owner/repo`）与 `branchLabel()`（detached HEAD 退回短 SHA），复用 gitOutput 1s 超时静默降级；`buildContext` 统一填充 → status/watch/mcp/serve 心跳全部生效；serve profile 车道从 `prepared.channelWorkdir` 推导
- **worker**: `parseAgentContext` 白名单接收新字段（非法值只丢字段不否决整个 context）；openapi schema 补充
- **web**: MessageCard 消息头（cli 版本旁）与 PresenceBar 常规行 agent chip 渲染 `repo ⎇ branch · worktree` 单色等宽 chip；ellipsis 截断保 repo+branch（worktree 尾段先截）、title 悬浮全文；worktree 追加需求（owner 2026-08-20）一并落地
- 纯 advisory 展示，不进授权判定；不动 runtime-topology 隐私哈希；旧客户端忽略新字段

## 测试
- cli `bun test` 1702 pass；web `bun test` 1291 pass；worker vitest 808 pass；四包 `tsc --noEmit` 全绿