### PR TITLE
feat(cli): announce MCP 收帧即 socket 注入宿主会话——本机零常驻也能被频道唤醒

### DIFF
--- a/cli/src/claude-inbox-inject.ts
+++ b/cli/src/claude-inbox-inject.ts
@@ -187,6 +187,55 @@ export function resolveSessionSocket(
 }
 
 /**
+ * 按 pid 寻址（#857 实测修正）：registry entry 的 `pid` 与 `~/.claude/sessions/<pid>.json`
+ * 同源，直接读那一份文件取 messagingSocketPath。
+ *
+ * **为什么不能按名字寻址**：`claudeSessionAnnounceName(entry)` 是 party 侧的宣告名
+ * （hook 拿不到 display_name 时恒为 `claude-<12hex>`），而这里的 `name` 是 Claude 原生
+ * 会话名（`agentparty-d4`、`portwind-kyc-10`）。两个命名空间永不相等 → 恒 no-match。
+ *
+ * **防 pid 复用**：本机实测 `<pid>.json` 的 `sessionId` 与 registry 的 `session_id` 逐字
+ * 相等，所以传 expectSessionId 时做严格比对——比 procStart 时间戳更硬（pid 被复用后
+ * sessionId 必然不同）。拿不到/不相等一律拒投，降级即可，绝不写错会话的 socket。
+ */
+export function resolveSessionSocketByPid(
+  pid: number,
+  options: { expectSessionId?: string | null; env?: NodeJS.ProcessEnv } = {},
+): ResolveResult {
+  const env = options.env ?? process.env;
+  const dir = nativeSessionsDir(env);
+  if (dir === null) return { ok: false, reason: "unavailable" };
+  if (!Number.isInteger(pid) || pid <= 0) return { ok: false, reason: "no-match" };
+  const session = readNativeSession(dir, `${pid}.json`);
+  if (session === null) return { ok: false, reason: "no-match" };
+  if (!pidAlive(session.pid)) return { ok: false, reason: "no-match" };
+  const expected = options.expectSessionId;
+  if (typeof expected === "string" && expected !== "") {
+    // sessionId 不匹配 ＝ 这个 pid 已经是别的会话（复用/换会话）→ 绝不投。
+    if (session.sessionId === null || session.sessionId.toLowerCase() !== expected.toLowerCase()) {
+      return { ok: false, reason: "no-match" };
+    }
+  }
+  return { ok: true, session };
+}
+
+/**
+ * 机会性读取 Claude 原生会话名（`~/.claude/sessions/<pid>.json` 的 `name`，形如
+ * `agentparty-d4`）。用于 SessionStart 入册时把 registry 的 display_name 从
+ * `claude-<12hex>` 升级成人能读的名字。文件尚未生成/权限不足/sessionId 不匹配一律
+ * 返回 null——调用方保持 null 即可，绝不重试等待（hook 铁律：静默、不阻塞）。
+ */
+export function nativeSessionName(
+  pid: number,
+  options: { expectSessionId?: string | null; env?: NodeJS.ProcessEnv } = {},
+): string | null {
+  const resolved = resolveSessionSocketByPid(pid, options);
+  if (!resolved.ok) return null;
+  const name = resolved.session.name;
+  return typeof name === "string" && name !== "" ? name : null;
+}
+
+/**
  * 读 peerToken：`~/.claude/sessions/<pid>.<sha256(socket path)>.key`（native `USd`）。
  * 读不到（非 Windows optional）返回 null，写入时就不带 auth 行。
  */
@@ -335,8 +384,17 @@ export type InjectResult =
   | { ok: false; reason: InjectFailureReason; detail?: string };
 
 export interface InjectChannelMessageInput {
-  /** 目标会话在 Claude 原生注册里的 `name`（＝我方宣告名）。 */
+  /**
+   * 目标会话名。**只有在它确实是 Claude 原生会话名时才用得上**——party 侧的宣告名
+   * （`claude-<12hex>`）与原生 name 是两个命名空间，恒不相等（#857 实测）。因此调用方
+   * 只要手上有 registry entry，就应该同时传 `pid`（+ `sessionId`）走 pid 寻址；`name`
+   * 退化为纯展示/回退用途。
+   */
   name: string;
+  /** 目标会话 pid（registry entry.pid）。给了就优先按 pid 寻址——权威路径。 */
+  pid?: number;
+  /** 目标会话 id（registry entry.session_id）：pid 寻址时做防复用比对。 */
+  sessionId?: string | null;
   /** 频道指针/摘要（≤512B），会被 cross-session-message 包装。 */
   body: string;
   /** 频道昵称（"Message from <fromName>"）。 */
@@ -366,7 +424,12 @@ export async function injectChannelMessage(
   if (!FROM_MODES.has(fromMode)) {
     return { ok: false, reason: "write-failed", detail: "invalid from-mode" };
   }
-  const resolved = resolveSessionSocket(input.name, env);
+  // 寻址优先级：pid（权威，registry 与原生 sessions 目录同源）→ name（仅当调用方手上
+  // 只有一个原生会话名时的回退）。pid 命中失败**不再**回落到 name：宣告名恒不等于原生
+  // name，回落只会白跑一趟；而若某天名字恰好撞上别的会话，回落反而会投错人。
+  const resolved = input.pid === undefined
+    ? resolveSessionSocket(input.name, env)
+    : resolveSessionSocketByPid(input.pid, { expectSessionId: input.sessionId, env });
   if (!resolved.ok) return { ok: false, reason: resolved.reason };
   const { session } = resolved;
 

--- a/cli/src/commands/claude-channel.ts
+++ b/cli/src/commands/claude-channel.ts
@@ -579,7 +579,12 @@ export async function runDormantClaudeSessionAnnounce(
           injectedSeqs.delete(oldest.value);
         }
         await inject({
-          // 自我保护：目标恒为本轮绑定的宿主会话宣告名，不接受任何外部传入的名字。
+          // 自我保护：目标恒为本轮绑定的宿主会话，不接受任何外部传入的身份。
+          // 寻址走 pid（registry 与 ~/.claude/sessions 同源）——宣告名与 Claude 原生
+          // 会话名是两个命名空间，按名字寻址恒 no-match（#857 实测）。sessionId 一并
+          // 传下去做防 pid 复用比对。
+          pid: entry.pid,
+          sessionId: entry.session_id,
           name: hostAnnounceName,
           body: wakeProxyNote({ channel, seq }),
           // from-name＝真实发信人的友好名 + 技术 ID（接收端面板只显示这一处，

--- a/cli/src/commands/claude-channel.ts
+++ b/cli/src/commands/claude-channel.ts
@@ -41,7 +41,7 @@ import {
 } from "../claude-session-registry";
 import { injectChannelMessage } from "../claude-inbox-inject";
 import { senderInjectFromName, wakeProxyNote } from "../serve-wake-proxy";
-import { loadCursor, resolveChannel, saveCursor } from "../config";
+import { loadCursor, readConfig, resolveChannel, saveCursor } from "../config";
 import {
   DeliveryRecoveryJournal,
   deliveryRecoveryJournalPath,
@@ -49,7 +49,7 @@ import {
 } from "../delivery-recovery-journal";
 import { acquireInstanceLock, defaultInstanceLockDir, instanceLockTarget } from "../instance-lock";
 import { resolveAuthDetailed } from "../oidc-cli";
-import { fetchMessages, fetchPresence, fetchRuntimePeers, postMessage } from "../rest";
+import { fetchMe, fetchMessages, fetchPresence, fetchRuntimePeers, postMessage } from "../rest";
 import { isName, isSlug } from "../validation";
 import { buildRuntimeTopology } from "../runtime-topology";
 import {
@@ -476,18 +476,69 @@ export interface DormantAnnounceDeps {
   livenessIntervalMs?: number;
   /** socket 注入实现（测试注入点）；默认真实 injectChannelMessage。 */
   inject?: typeof injectChannelMessage;
+  /**
+   * 解析「我这条连接所用的频道身份」——注入的**触发条件**按它匹配（见
+   * dormantAnnounceMentionHit 的注释）。默认 resolveAnnounceChannelIdentity。
+   */
+  resolveSelfName?: (auth: { server: string; token: string }) => Promise<string | null>;
+}
+
+/**
+ * ─────────── 三个命名空间，别再混（#857 两次实测教训） ───────────
+ * 1. **匹配用频道身份**：msg 帧的 `mentions` 里只会出现频道 handle（如
+ *    `lark-ad72b3f97491-agentparty`），服务端 mention 校验也只认它。这是判「这条消息
+ *    是不是在叫我」的唯一依据。
+ * 2. **寻址用 pid**：写哪个 socket 由 registry entry 的 pid（+ session_id 防复用）决定，
+ *    对应 `~/.claude/sessions/<pid>.json`。
+ * 3. **展示用宣告名**：`claudeSessionAnnounceName(entry)`（`agentparty-21` /
+ *    `claude-<12hex>`）属于 cross-session peers 命名空间，只用于 peers 投影展示。
+ *    它既不是频道 handle（服务端 @ 它会 mention_not_found），也不是 socket 寻址键。
+ * ────────────────────────────────────────────────────────────────
+ */
+
+/** 本机频道身份：优先 config 缓存（channel_scope 匹配才认），否则问一次 /api/me。 */
+export async function resolveAnnounceChannelIdentity(
+  channel: string,
+  auth: { server: string; token: string },
+): Promise<string | null> {
+  try {
+    const cached = readConfig()?.identity;
+    if (
+      cached !== undefined &&
+      typeof cached.name === "string" &&
+      cached.name !== "" &&
+      (cached.channel_scope === null || cached.channel_scope === channel)
+    ) {
+      return cached.name;
+    }
+  } catch {
+    // 读配置失败 → 退到网络那条。
+  }
+  try {
+    const me = await fetchMe(auth.server, auth.token);
+    return typeof me.name === "string" && me.name !== "" ? me.name : null;
+  } catch {
+    return null;
+  }
 }
 
 /** 注入去重表容量上限：只留最近 N 个 seq，防长跑进程内存无界。 */
 export const DORMANT_ANNOUNCE_SEEN_LIMIT = 512;
 
-/** msg 帧的 mentions 是否命中宿主会话的宣告名（大小写/规范化按 mentionMatchKey）。 */
+/**
+ * msg 帧是不是在叫「我」。
+ *
+ * 比对键是**频道身份**（announce 这条 WS 连接所用的 agent handle），不是宿主会话的
+ * 宣告名——mentions 里只会出现频道 handle，宣告名根本不在这个命名空间里（实测：
+ * `--mention agentparty-21` 会被服务端直接拒成 mention_not_found）。用宣告名比对时
+ * 本函数恒 false，注入永不触发。归一化沿用 mentionMatchKey。
+ */
 export function dormantAnnounceMentionHit(
   mentions: readonly string[] | undefined,
-  announceName: string,
+  channelIdentity: string | null,
 ): boolean {
-  if (mentions === undefined) return false;
-  const wanted = mentionMatchKey(announceName);
+  if (mentions === undefined || channelIdentity === null || channelIdentity === "") return false;
+  const wanted = mentionMatchKey(channelIdentity);
   return mentions.some((mention) => mentionMatchKey(mention) === wanted);
 }
 
@@ -556,8 +607,18 @@ export async function runDormantClaudeSessionAnnounce(
     const connection = deps.connect(auth.server, auth.token, channel, deps.loadCursor(channel), {
       runtimeTopology: topology,
     });
+    // 「叫我」的判据＝本机频道身份（不是宣告名，见上方三命名空间注释）。解析失败
+    // （无缓存且 /api/me 不通）→ selfName=null → 恒不注入，静默降级为改动前行为。
+    const selfName = await (deps.resolveSelfName ?? ((a) => resolveAnnounceChannelIdentity(channel, a)))({
+      server: auth.server,
+      token: auth.token,
+    }).catch(() => null);
+    if (signal.aborted) {
+      connection.close();
+      return;
+    }
     const sessionId = entry.session_id;
-    // 本轮绑定的宿主会话宣告名。注入目标恒为它——announce 进程是宿主会话的子进程，
+    // 本轮绑定的宿主会话宣告名——**只用于展示/回退**，寻址走 pid。注入目标恒为它——announce 进程是宿主会话的子进程，
     // 只许唤醒自己的宿主，绝不代投本机其他会话（那是 serve wake proxy 的职责）。
     const hostAnnounceName = claudeSessionAnnounceName(entry);
     /**
@@ -570,7 +631,7 @@ export async function runDormantClaudeSessionAnnounce(
       sender: MsgFrame["sender"] | undefined,
     ) => {
       try {
-        if (!dormantAnnounceMentionHit(mentions, hostAnnounceName)) return;
+        if (!dormantAnnounceMentionHit(mentions, selfName)) return;
         if (injectedSeqs.has(seq)) return;
         injectedSeqs.add(seq);
         while (injectedSeqs.size > DORMANT_ANNOUNCE_SEEN_LIMIT) {

--- a/cli/src/commands/claude-channel.ts
+++ b/cli/src/commands/claude-channel.ts
@@ -15,6 +15,7 @@ import {
   type DeliveryRecoverFrame,
   type DeliveryRecoveryResultFrame,
   type DirectedDelivery,
+  mentionMatchKey,
   type MsgFrame,
   type PresenceEntry,
   type RuntimePeerDiscovery,
@@ -38,6 +39,8 @@ import {
   listClaudeSessions,
   type ClaudeSessionRegistryEntry,
 } from "../claude-session-registry";
+import { injectChannelMessage } from "../claude-inbox-inject";
+import { senderInjectFromName, wakeProxyNote } from "../serve-wake-proxy";
 import { loadCursor, resolveChannel, saveCursor } from "../config";
 import {
   DeliveryRecoveryJournal,
@@ -471,6 +474,21 @@ export interface DormantAnnounceDeps {
   cwd?: string;
   pollIntervalMs?: number;
   livenessIntervalMs?: number;
+  /** socket 注入实现（测试注入点）；默认真实 injectChannelMessage。 */
+  inject?: typeof injectChannelMessage;
+}
+
+/** 注入去重表容量上限：只留最近 N 个 seq，防长跑进程内存无界。 */
+export const DORMANT_ANNOUNCE_SEEN_LIMIT = 512;
+
+/** msg 帧的 mentions 是否命中宿主会话的宣告名（大小写/规范化按 mentionMatchKey）。 */
+export function dormantAnnounceMentionHit(
+  mentions: readonly string[] | undefined,
+  announceName: string,
+): boolean {
+  if (mentions === undefined) return false;
+  const wanted = mentionMatchKey(announceName);
+  return mentions.some((mention) => mentionMatchKey(mention) === wanted);
 }
 
 function abortableSleep(ms: number, signal: AbortSignal): Promise<void> {
@@ -502,6 +520,14 @@ export async function runDormantClaudeSessionAnnounce(
   const pollMs = deps.pollIntervalMs ?? DORMANT_ANNOUNCE_POLL_MS;
   const livenessMs = deps.livenessIntervalMs ?? DORMANT_ANNOUNCE_LIVENESS_MS;
   if (!isSlug(channel)) return;
+  const inject = deps.inject ?? injectChannelMessage;
+  // 进程内注入去重（按 seq）：WS 重连会重放未 ack 的帧，没有它同一条 @ 会反复唤醒
+  // 宿主会话。跨重连保留，故声明在 while 之外；用插入序 Set + 容量上限防内存无界。
+  //
+  // 已知重叠（#856/#857）：本机若同时跑着 serve，serve 侧的 wake proxy 也会为同一条
+  // @ 注入一次。两条路径各有自己的进程内 seen，本切片**不做跨进程去重**——最终由
+  // Claude 收件箱侧的 msg_id/队列去重与人工感知兜底；重复唤醒的代价远小于叫不醒。
+  const injectedSeqs = new Set<number>();
   while (!signal.aborted) {
     let entry: ClaudeSessionRegistryEntry | null = null;
     try {
@@ -531,6 +557,40 @@ export async function runDormantClaudeSessionAnnounce(
       runtimeTopology: topology,
     });
     const sessionId = entry.session_id;
+    // 本轮绑定的宿主会话宣告名。注入目标恒为它——announce 进程是宿主会话的子进程，
+    // 只许唤醒自己的宿主，绝不代投本机其他会话（那是 serve wake proxy 的职责）。
+    const hostAnnounceName = claudeSessionAnnounceName(entry);
+    /**
+     * 命中 @ 宿主会话 → socket 注入一条 ≤512B 的频道指针（channel+seq，正文留在频道）。
+     * 任何失败都静默降级为「只 ack」的现行为：不抛错、不中断收帧循环。
+     */
+    const maybeInject = async (
+      seq: number,
+      mentions: readonly string[] | undefined,
+      sender: MsgFrame["sender"] | undefined,
+    ) => {
+      try {
+        if (!dormantAnnounceMentionHit(mentions, hostAnnounceName)) return;
+        if (injectedSeqs.has(seq)) return;
+        injectedSeqs.add(seq);
+        while (injectedSeqs.size > DORMANT_ANNOUNCE_SEEN_LIMIT) {
+          const oldest = injectedSeqs.values().next();
+          if (oldest.done === true) break;
+          injectedSeqs.delete(oldest.value);
+        }
+        await inject({
+          // 自我保护：目标恒为本轮绑定的宿主会话宣告名，不接受任何外部传入的名字。
+          name: hostAnnounceName,
+          body: wakeProxyNote({ channel, seq }),
+          // from-name＝真实发信人的友好名 + 技术 ID（接收端面板只显示这一处，
+          // 技术 ID 丢了就分不清两个同名 agent）。
+          fromName: senderInjectFromName(sender, channel),
+          // announce 进程没有自己的回执 socket——绝不冒用别人的 sock 当 from。
+        });
+      } catch {
+        // 静默降级：注入不可用时行为等同改动前（只 ack）。
+      }
+    };
     let connectionClosed = false;
     const closeConnection = () => {
       connectionClosed = true;
@@ -557,7 +617,12 @@ export async function runDormantClaudeSessionAnnounce(
     if (signal.aborted) closeConnection();
     try {
       for await (const frame of connection.frames) {
-        if (frame.type === "msg" || frame.type === "status") connection.ack(frame.seq);
+        if (frame.type === "msg" || frame.type === "status") {
+          connection.ack(frame.seq);
+          // 注意顺序：先 ack 再注入。ack 只是本地防积压（绝不推进持久化游标、绝不
+          // claim delivery，见上方 P2 不变式），注入失败也不该影响 ack。
+          if (frame.type === "msg") await maybeInject(frame.seq, frame.mentions, frame.sender);
+        }
         if (frame.type === "error") return;
       }
     } catch {

--- a/cli/src/commands/hook.ts
+++ b/cli/src/commands/hook.ts
@@ -30,6 +30,7 @@ import {
   registerClaudeSession,
   unregisterClaudeSession,
 } from "../claude-session-registry";
+import { nativeSessionName } from "../claude-inbox-inject";
 import { isHelpArg } from "../args";
 import { isPartyBinaryPath } from "../upgrade";
 import { CLAUDE_LIFECYCLE_OPT_IN_ENV } from "./claude-launch";
@@ -493,7 +494,13 @@ export function recordClaudeSessionLifecycle(
     registerClaudeSession({
       session_id: sessionId,
       pid,
-      display_name: claudeSessionDisplayNameFromHookPayload(record),
+      // hook payload 目前不带展示名（实测），退而求其次机会性读 Claude 原生会话名
+      // （`~/.claude/sessions/<pid>.json` 的 name，如 `agentparty-d4`）：宣告名从
+      // `claude-<12hex>` 变成人能读的名字，频道 peers 列表也更可读。SessionStart 时
+      // 该文件可能还没写出来 → 读不到就保持 null，绝不重试等待（hook 铁律）。
+      display_name:
+        claudeSessionDisplayNameFromHookPayload(record) ??
+        nativeSessionName(pid, { expectSessionId: sessionId, env }),
       channel,
       cwd,
     }, env);

--- a/cli/src/serve-wake-proxy.ts
+++ b/cli/src/serve-wake-proxy.ts
@@ -27,6 +27,8 @@ import {
   type ClaudeSessionRegistryEntry,
 } from "./claude-session-registry";
 import { injectChannelMessage } from "./claude-inbox-inject";
+import { friendlyAgentLabel } from "@agentparty/shared/identity";
+import { readConfig, type CachedIdentity } from "./config";
 
 /** 三不变量之一：唤醒通知只带 channel+seq 指针，且总长 ≤512 UTF-8 字节。 */
 export const WAKE_PROXY_NOTE_MAX_BYTES = 512;
@@ -76,6 +78,75 @@ export function selectWakeProxyTarget(
   return best;
 }
 
+/**
+ * 注入面板上的「谁发来的」。接收端把它原样显示成
+ * `from uds:<sock> (peer claims name: <fromName>)`（#844 实测面板文本），**面板不另外
+ * 显示我们的技术 identity**——所以 fromName 必须自带技术 ID，否则两个仅哈希段不同的
+ * 身份（`lark-ad72b3f97491-agentparty` / `lark-ad72b3f9749e-agentparty`）会显示成同一个
+ * `leo · agentparty`，界面上无法分辨。
+ *
+ * 形态：`<所属人> · <角色> (<技术 identity>)`——友好前半对齐 web 的 identityDisplay
+ * （规则同源于 shared/src/identity.ts），括号里给完整技术 ID 保证唯一可辨（选 A 不选
+ * 尾 5 位短码：短码仍会碰撞，而 from-name 没有长度硬限，只禁 `"` 与 `\r\n<>`）。
+ * 读不到本机 identity（未登录/旧配置）→ 回退 `agentparty#<channel>`。
+ */
+export function injectFromName(
+  channel: string,
+  identity: CachedIdentity | null | undefined = resolveLocalIdentity(),
+): string {
+  if (identity === null || identity === undefined || typeof identity.name !== "string" || identity.name === "") {
+    return `agentparty#${channel}`;
+  }
+  const friendly = friendlyAgentLabel(identity);
+  return sanitizeFromName(
+    friendly === identity.name ? identity.name : `${friendly} (${identity.name})`,
+    channel,
+  );
+}
+
+/**
+ * announce 注入（#857）用的 from-name：那条路径知道**真实发信人**（频道 msg 帧的 sender），
+ * 显示发信人比显示中转身份有用得多。规则同 injectFromName——友好名 + 括号里的技术 ID：
+ * - 人类：`<display_name || handle || owner>`（本身就可读，技术 name 同值时不重复加括号）；
+ * - agent：`<所属人> · <角色> (<技术 identity>)`。
+ * sender 缺失/不可读时回退 `agentparty#<channel>`。
+ */
+export function senderInjectFromName(
+  sender: { name?: string; kind?: string; owner?: string | null; handle?: string | null; display_name?: string | null } | null | undefined,
+  channel: string,
+): string {
+  const name = typeof sender?.name === "string" ? sender.name.trim() : "";
+  if (name === "") return `agentparty#${channel}`;
+  const friendly = sender?.kind === "human"
+    ? (sender.display_name?.trim() || sender.handle?.trim() || sender.owner?.trim() || name)
+    : friendlyAgentLabel({
+        name,
+        owner: sender?.owner ?? null,
+        owner_handle: null,
+        owner_display_name: null,
+      });
+  return sanitizeFromName(friendly === name ? name : `${friendly} (${name})`, channel);
+}
+
+/**
+ * from-name 净化：injectChannelMessage 会硬拒含 `"` / `\r\n<>` 的 from-name（会破坏接收端
+ * 的完整性自校验）。频道昵称是用户可控数据，这里把非法字符换成 `_`，别让一个昵称把整条
+ * 唤醒路径打成静默失败。
+ */
+function sanitizeFromName(value: string, channel: string): string {
+  const cleaned = value.replace(/["\r\n<>]/g, "_").trim();
+  return cleaned === "" ? `agentparty#${channel}` : cleaned;
+}
+
+/** 本机缓存身份；任何读取失败都当「没有」（注入 fromName 回退频道名）。 */
+export function resolveLocalIdentity(cwd?: string): CachedIdentity | null {
+  try {
+    return readConfig(cwd)?.identity ?? null;
+  } catch {
+    return null;
+  }
+}
+
 /** 可注入的转投载体：true=已转投成功；false/抛错=未转投（降级为现行为）。 */
 export type WakeProxyForwarder = (
   target: ClaudeSessionRegistryEntry,
@@ -119,7 +190,8 @@ export function socketWakeProxyForwarder(
   options: SocketWakeProxyForwarderOptions = {},
 ): WakeProxyForwarder {
   const inject = options.inject ?? injectChannelMessage;
-  const fromName = options.fromName ?? ((ref: WakeProxyRef) => ref.channel);
+  // 默认 from-name＝友好名 + 技术 ID（owner 2026-08-20：技术 ID 是身份本身，不能丢）。
+  const fromName = options.fromName ?? ((ref: WakeProxyRef) => injectFromName(ref.channel));
   return async (target, ref) => {
     const result = await inject({
       name: claudeSessionAnnounceName(target),

--- a/cli/src/serve-wake-proxy.ts
+++ b/cli/src/serve-wake-proxy.ts
@@ -60,6 +60,14 @@ export function wakeProxyNote(ref: WakeProxyRef): string {
  * - 多个候选取最新入册（与蛰伏 announce 的选择一致）。
  * 死会话由 listClaudeSessions 的 kill(pid,0) 探活现场剔除（开放问题 C）：
  * 进程已退出的条目根本不会出现在这里，消息自然回落到现行为。
+ *
+ * ⚠️ 已知局限（#857 实测记录，**本次刻意不改**）：mentions 里只会出现频道 handle，
+ * 而这里比对的是宣告名（peers 命名空间），两者恒不相等 → 本函数今天实际上永远返回
+ * null，serve 侧的唤醒代理是一条不触发的路径。改成按频道身份比对会翻转语义：本机
+ * 交互式会话与 serve 共用同一个 agent config，「@ 我」的那个 handle 恰好就是被
+ * `self` 排除掉的自己——放开它等于同一条 @ 既跑 serve runner 又注入交互式会话（双处理），
+ * 会动到 serve 的 wake/欠账记账。#857 的 announce 腿已经在正确的命名空间上覆盖了这个
+ * 场景（且不需要 serve 在跑），所以这里保持现状，是否合并两条腿留给单独切片决策。
  */
 export function selectWakeProxyTarget(
   mentions: readonly string[],
@@ -97,11 +105,7 @@ export function injectFromName(
   if (identity === null || identity === undefined || typeof identity.name !== "string" || identity.name === "") {
     return `agentparty#${channel}`;
   }
-  const friendly = friendlyAgentLabel(identity);
-  return sanitizeFromName(
-    friendly === identity.name ? identity.name : `${friendly} (${identity.name})`,
-    channel,
-  );
+  return sanitizeFromName(withTechnicalId(friendlyAgentLabel(identity), identity.name), channel);
 }
 
 /**
@@ -125,7 +129,15 @@ export function senderInjectFromName(
         owner_handle: null,
         owner_display_name: null,
       });
-  return sanitizeFromName(friendly === name ? name : `${friendly} (${name})`, channel);
+  return sanitizeFromName(withTechnicalId(friendly, name), channel);
+}
+
+/**
+ * 友好名后缀技术 ID——但友好名里**已经含有**技术 name 时不重复（真机实测踩到：
+ * 非哈希前缀的 name 提不出角色，会渲染成 `x · foo-agent (foo-agent)`）。
+ */
+function withTechnicalId(friendly: string, name: string): string {
+  return friendly.includes(name) ? friendly : `${friendly} (${name})`;
 }
 
 /**

--- a/cli/src/serve-wake-proxy.ts
+++ b/cli/src/serve-wake-proxy.ts
@@ -194,6 +194,10 @@ export function socketWakeProxyForwarder(
   const fromName = options.fromName ?? ((ref: WakeProxyRef) => injectFromName(ref.channel));
   return async (target, ref) => {
     const result = await inject({
+      // 同 #857：按 pid 寻址（registry entry.pid 与 ~/.claude/sessions/<pid>.json 同源），
+      // sessionId 防 pid 复用。宣告名只作展示/回退，绝不用来寻址。
+      pid: target.pid,
+      sessionId: target.session_id,
       name: claudeSessionAnnounceName(target),
       body: wakeProxyNote(ref),
       fromName: fromName(ref),

--- a/cli/test/announce-channel-identity.test.ts
+++ b/cli/test/announce-channel-identity.test.ts
@@ -1,0 +1,72 @@
+// #857 第二个阻断缺陷的回归：announce 的触发条件必须按**频道身份**匹配。
+// mentions 里只会出现频道 handle；宣告名（`agentparty-21` / `claude-<12hex>`）属于
+// cross-session peers 命名空间，服务端 @ 它会直接 mention_not_found。
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveAnnounceChannelIdentity } from "../src/commands/claude-channel";
+
+const previous = process.env.AGENTPARTY_CONFIG;
+
+afterEach(() => {
+  if (previous === undefined) delete process.env.AGENTPARTY_CONFIG;
+  else process.env.AGENTPARTY_CONFIG = previous;
+});
+
+function writeConfigFile(identity: Record<string, unknown> | undefined): string {
+  const dir = mkdtempSync(join(tmpdir(), "ap-announce-identity-"));
+  const path = join(dir, "config.json");
+  writeFileSync(
+    path,
+    JSON.stringify({
+      server: "https://party.invalid",
+      token: "tok",
+      ...(identity === undefined ? {} : { identity }),
+    }),
+    { mode: 0o600 },
+  );
+  return path;
+}
+
+describe("resolveAnnounceChannelIdentity", () => {
+  test("uses the cached channel identity when its scope matches", async () => {
+    const path = writeConfigFile({
+      name: "leeguooooo-codex2-agentparty",
+      kind: "agent",
+      role: "agent",
+      owner: "leo@example.com",
+      channel_scope: "agentparty",
+      verified_at: 1,
+    });
+    process.env.AGENTPARTY_CONFIG = path;
+    try {
+      expect(
+        await resolveAnnounceChannelIdentity("agentparty", { server: "https://party.invalid", token: "tok" }),
+      ).toBe("leeguooooo-codex2-agentparty");
+    } finally {
+      rmSync(path, { force: true });
+    }
+  });
+
+  test("a scope mismatch or a missing identity never guesses — falls through to null when /api/me is unreachable", async () => {
+    const path = writeConfigFile({
+      name: "other-channel-agent",
+      kind: "agent",
+      role: "agent",
+      owner: null,
+      // 绑在别的频道上：绝不能拿来当本频道的「我」。
+      channel_scope: "other",
+      verified_at: 1,
+    });
+    process.env.AGENTPARTY_CONFIG = path;
+    try {
+      // server 不可达 → fetchMe 抛错 → null（静默降级为不注入）。
+      expect(
+        await resolveAnnounceChannelIdentity("agentparty", { server: "https://127.0.0.1:1", token: "tok" }),
+      ).toBeNull();
+    } finally {
+      rmSync(path, { force: true });
+    }
+  });
+});

--- a/cli/test/claude-channel-dormant-announce.test.ts
+++ b/cli/test/claude-channel-dormant-announce.test.ts
@@ -102,6 +102,8 @@ function makeDeps(overrides: Partial<DormantAnnounceDeps> = {}): {
       ...(buildDeps?.harnessSession === undefined ? {} : { harness_session: buildDeps.harnessSession }),
     }),
     loadCursor: () => 42,
+    // 默认给一个确定的频道身份：绝不让测试去读真实 config / 打 /api/me。
+    resolveSelfName: async () => "lark-ad72b3f97491-agentparty",
     cwd: "/tmp/project",
     pollIntervalMs: 5,
     livenessIntervalMs: 5,
@@ -228,12 +230,18 @@ function msg(seq: number, mentions: string[]): ServerFrame {
   } as unknown as ServerFrame;
 }
 
+const SELF = "lark-ad72b3f97491-agentparty";
+
 describe("dormantAnnounceMentionHit", () => {
-  test("matches the host announce name case-insensitively and ignores others", () => {
-    expect(dormantAnnounceMentionHit(["Claude-111111111111"], "claude-111111111111")).toBe(true);
-    expect(dormantAnnounceMentionHit(["someone-else"], "claude-111111111111")).toBe(false);
-    expect(dormantAnnounceMentionHit(undefined, "claude-111111111111")).toBe(false);
-    expect(dormantAnnounceMentionHit([], "claude-111111111111")).toBe(false);
+  test("matches the channel identity case-insensitively and ignores everything else", () => {
+    expect(dormantAnnounceMentionHit([SELF.toUpperCase()], SELF)).toBe(true);
+    expect(dormantAnnounceMentionHit(["lark-ad72b3f9749e-agentparty"], SELF)).toBe(false);
+    expect(dormantAnnounceMentionHit(undefined, SELF)).toBe(false);
+    expect(dormantAnnounceMentionHit([], SELF)).toBe(false);
+    // 频道身份解析不出来 → 恒不触发（静默降级）。
+    expect(dormantAnnounceMentionHit([SELF], null)).toBe(false);
+    // 宣告名不在 mentions 命名空间里：拿它当比对键恒 false（这正是第二个阻断缺陷）。
+    expect(dormantAnnounceMentionHit(["claude-111111111111"], SELF)).toBe(false);
   });
 });
 
@@ -262,10 +270,16 @@ describe("runDormantClaudeSessionAnnounce socket inject (#857)", () => {
     const abort = new AbortController();
     const done = runDormantClaudeSessionAnnounce("dev", abort.signal, deps);
     await tick();
-    connections[0]!.push(msg(11, ["someone-else"]));
+    // 别人的频道身份 → 不触发。
+    connections[0]!.push(msg(11, ["lark-ad72b3f9749e-agentparty"]));
     await tick();
     expect(calls).toHaveLength(0);
+    // 宿主会话的宣告名（peers 命名空间）→ 不触发；它根本不是 @ 得到的东西。
     connections[0]!.push(msg(12, ["claude-111111111111"]));
+    await tick();
+    expect(calls).toHaveLength(0);
+    // 自己的频道身份 → 触发。
+    connections[0]!.push(msg(13, [SELF]));
     await tick();
     expect(calls).toHaveLength(1);
     // 寻址走 pid + sessionId（宣告名与 Claude 原生会话名是两个命名空间，#857）。
@@ -274,10 +288,10 @@ describe("runDormantClaudeSessionAnnounce socket inject (#857)", () => {
     expect(calls[0]!.name).toBe("claude-111111111111");
     // from-name＝友好名 + 技术 ID（接收端面板只显示这一处）。
     expect(calls[0]!.fromName).toBe("leo@example.com · agentparty (lark-ad72b3f97491-agentparty)");
-    expect(calls[0]!.body).toContain("seq=12");
+    expect(calls[0]!.body).toContain("seq=13");
     expect(Buffer.byteLength(calls[0]!.body, "utf8")).toBeLessThanOrEqual(512);
     // 注入路径不改变 P2 不变式：只本地 ack，绝不发客户端帧、绝不推进持久化游标。
-    expect(connections[0]!.acked).toEqual([11, 12]);
+    expect(connections[0]!.acked).toEqual([11, 12, 13]);
     expect(connections[0]!.sent).toHaveLength(0);
     expect(connections[0]!.connectArgs.opts.onCursor).toBeUndefined();
     abort.abort();
@@ -289,8 +303,8 @@ describe("runDormantClaudeSessionAnnounce socket inject (#857)", () => {
     const abort = new AbortController();
     const done = runDormantClaudeSessionAnnounce("dev", abort.signal, deps);
     await tick();
-    connections[0]!.push(msg(20, ["claude-111111111111"]));
-    connections[0]!.push(msg(20, ["claude-111111111111"]));
+    connections[0]!.push(msg(20, [SELF]));
+    connections[0]!.push(msg(20, [SELF]));
     await tick();
     expect(calls).toHaveLength(1);
     abort.abort();
@@ -304,9 +318,9 @@ describe("runDormantClaudeSessionAnnounce socket inject (#857)", () => {
     const abort = new AbortController();
     const done = runDormantClaudeSessionAnnounce("dev", abort.signal, deps);
     await tick();
-    connections[0]!.push(msg(30, ["claude-111111111111"]));
+    connections[0]!.push(msg(30, [SELF]));
     await tick();
-    connections[0]!.push(msg(31, ["claude-111111111111"]));
+    connections[0]!.push(msg(31, [SELF]));
     await tick();
     expect(calls).toHaveLength(2);
     expect(connections[0]!.acked).toEqual([30, 31]);

--- a/cli/test/claude-channel-dormant-announce.test.ts
+++ b/cli/test/claude-channel-dormant-announce.test.ts
@@ -241,9 +241,15 @@ describe("runDormantClaudeSessionAnnounce socket inject (#857)", () => {
   function injectingDeps(
     impl?: (input: { name: string; body: string; fromName: string }) => Promise<unknown>,
   ) {
-    const calls: { name: string; body: string; fromName: string }[] = [];
-    const inject = (async (input: { name: string; body: string; fromName: string }) => {
-      calls.push({ name: input.name, body: input.body, fromName: input.fromName });
+    const calls: { name: string; body: string; fromName: string; pid?: number; sessionId?: string | null }[] = [];
+    const inject = (async (input: { name: string; body: string; fromName: string; pid?: number; sessionId?: string | null }) => {
+      calls.push({
+        name: input.name,
+        body: input.body,
+        fromName: input.fromName,
+        pid: input.pid,
+        sessionId: input.sessionId,
+      });
       if (impl !== undefined) return await impl(input);
       return { ok: true, socketPath: "/tmp/x.sock", usedAuth: false, target: input.name };
     }) as DormantAnnounceDeps["inject"];
@@ -262,6 +268,9 @@ describe("runDormantClaudeSessionAnnounce socket inject (#857)", () => {
     connections[0]!.push(msg(12, ["claude-111111111111"]));
     await tick();
     expect(calls).toHaveLength(1);
+    // 寻址走 pid + sessionId（宣告名与 Claude 原生会话名是两个命名空间，#857）。
+    expect(calls[0]!.pid).toBe(process.pid);
+    expect(calls[0]!.sessionId).toBe("11111111-1111-4111-8111-111111111111");
     expect(calls[0]!.name).toBe("claude-111111111111");
     // from-name＝友好名 + 技术 ID（接收端面板只显示这一处）。
     expect(calls[0]!.fromName).toBe("leo@example.com · agentparty (lark-ad72b3f97491-agentparty)");

--- a/cli/test/claude-channel-dormant-announce.test.ts
+++ b/cli/test/claude-channel-dormant-announce.test.ts
@@ -3,6 +3,7 @@ import type { ServerFrame } from "@agentparty/shared";
 import type { ClaudeSessionRegistryEntry } from "../src/claude-session-registry";
 import {
   dormantAnnounceDisplayName,
+  dormantAnnounceMentionHit,
   runDormantClaudeSessionAnnounce,
   selectDormantAnnounceEntry,
   type DormantAnnounceDeps,
@@ -208,5 +209,99 @@ describe("runDormantClaudeSessionAnnounce (#841 P2)", () => {
     const abort = new AbortController();
     await runDormantClaudeSessionAnnounce("Bad_Channel!", abort.signal, deps);
     expect(connections).toHaveLength(0);
+  });
+});
+
+function msg(seq: number, mentions: string[]): ServerFrame {
+  return {
+    type: "msg",
+    seq,
+    sender: { name: "lark-ad72b3f97491-agentparty", kind: "agent", owner: "leo@example.com" },
+    kind: "text",
+    body: "hello",
+    mentions,
+    reply_to: null,
+    state: null,
+    note: null,
+    status: null,
+    ts: 1,
+  } as unknown as ServerFrame;
+}
+
+describe("dormantAnnounceMentionHit", () => {
+  test("matches the host announce name case-insensitively and ignores others", () => {
+    expect(dormantAnnounceMentionHit(["Claude-111111111111"], "claude-111111111111")).toBe(true);
+    expect(dormantAnnounceMentionHit(["someone-else"], "claude-111111111111")).toBe(false);
+    expect(dormantAnnounceMentionHit(undefined, "claude-111111111111")).toBe(false);
+    expect(dormantAnnounceMentionHit([], "claude-111111111111")).toBe(false);
+  });
+});
+
+describe("runDormantClaudeSessionAnnounce socket inject (#857)", () => {
+  function injectingDeps(
+    impl?: (input: { name: string; body: string; fromName: string }) => Promise<unknown>,
+  ) {
+    const calls: { name: string; body: string; fromName: string }[] = [];
+    const inject = (async (input: { name: string; body: string; fromName: string }) => {
+      calls.push({ name: input.name, body: input.body, fromName: input.fromName });
+      if (impl !== undefined) return await impl(input);
+      return { ok: true, socketPath: "/tmp/x.sock", usedAuth: false, target: input.name };
+    }) as DormantAnnounceDeps["inject"];
+    const made = makeDeps({ inject });
+    return { ...made, calls };
+  }
+
+  test("injects only when the host session is mentioned, targeting the host session", async () => {
+    const { deps, connections, calls } = injectingDeps();
+    const abort = new AbortController();
+    const done = runDormantClaudeSessionAnnounce("dev", abort.signal, deps);
+    await tick();
+    connections[0]!.push(msg(11, ["someone-else"]));
+    await tick();
+    expect(calls).toHaveLength(0);
+    connections[0]!.push(msg(12, ["claude-111111111111"]));
+    await tick();
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.name).toBe("claude-111111111111");
+    // from-name＝友好名 + 技术 ID（接收端面板只显示这一处）。
+    expect(calls[0]!.fromName).toBe("leo@example.com · agentparty (lark-ad72b3f97491-agentparty)");
+    expect(calls[0]!.body).toContain("seq=12");
+    expect(Buffer.byteLength(calls[0]!.body, "utf8")).toBeLessThanOrEqual(512);
+    // 注入路径不改变 P2 不变式：只本地 ack，绝不发客户端帧、绝不推进持久化游标。
+    expect(connections[0]!.acked).toEqual([11, 12]);
+    expect(connections[0]!.sent).toHaveLength(0);
+    expect(connections[0]!.connectArgs.opts.onCursor).toBeUndefined();
+    abort.abort();
+    await done;
+  });
+
+  test("injects a given seq at most once even if the frame is replayed", async () => {
+    const { deps, connections, calls } = injectingDeps();
+    const abort = new AbortController();
+    const done = runDormantClaudeSessionAnnounce("dev", abort.signal, deps);
+    await tick();
+    connections[0]!.push(msg(20, ["claude-111111111111"]));
+    connections[0]!.push(msg(20, ["claude-111111111111"]));
+    await tick();
+    expect(calls).toHaveLength(1);
+    abort.abort();
+    await done;
+  });
+
+  test("a failing inject degrades silently: acks continue and the loop survives", async () => {
+    const { deps, connections, calls } = injectingDeps(async () => {
+      throw new Error("socket gone");
+    });
+    const abort = new AbortController();
+    const done = runDormantClaudeSessionAnnounce("dev", abort.signal, deps);
+    await tick();
+    connections[0]!.push(msg(30, ["claude-111111111111"]));
+    await tick();
+    connections[0]!.push(msg(31, ["claude-111111111111"]));
+    await tick();
+    expect(calls).toHaveLength(2);
+    expect(connections[0]!.acked).toEqual([30, 31]);
+    abort.abort();
+    await done;
   });
 });

--- a/cli/test/claude-inbox-inject-by-pid.test.ts
+++ b/cli/test/claude-inbox-inject-by-pid.test.ts
@@ -1,0 +1,151 @@
+// 真实寻址层的端到端回归（#857）：registry entry → pid → `~/.claude/sessions/<pid>.json`
+// → 真实 Unix socket → 写帧成功。上一版把 inject 整个 mock 掉，寻址那层没被覆盖，结果
+// 「宣告名 ≠ Claude 原生会话名」的致命错配一路漏到线上（6/6 no-match）。
+// 用临时 sessions 目录（AGENTPARTY_CLAUDE_NATIVE_SESSIONS_DIR）+ 临时 socket，绝不碰真实
+// `~/.claude/sessions` 或 `/tmp/cc-socks/`。
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createServer, type Server } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  CLAUDE_NATIVE_SESSIONS_DIR_ENV,
+  injectChannelMessage,
+  nativeSessionName,
+  resolveSessionSocket,
+  resolveSessionSocketByPid,
+} from "../src/claude-inbox-inject";
+import {
+  claudeSessionAnnounceName,
+  type ClaudeSessionRegistryEntry,
+} from "../src/claude-session-registry";
+
+const SESSION_ID = "11111111-1111-4111-8111-111111111111";
+
+/** 与真实 registry 一致的 entry：display_name 为 null → 宣告名恒 `claude-<12hex>`。 */
+function registryEntry(overrides: Partial<ClaudeSessionRegistryEntry> = {}): ClaudeSessionRegistryEntry {
+  return {
+    version: 1,
+    session_id: SESSION_ID,
+    pid: process.pid,
+    display_name: null,
+    channel: "dev",
+    cwd: "/tmp/project",
+    registered_at: 1_000,
+    ...overrides,
+  };
+}
+
+let dir: string;
+let sockPath: string;
+let server: Server;
+let received: string[];
+
+function env(): NodeJS.ProcessEnv {
+  return { ...process.env, [CLAUDE_NATIVE_SESSIONS_DIR_ENV]: dir };
+}
+
+function writeNativeSession(fields: Record<string, unknown> = {}): void {
+  const pid = (fields.pid as number | undefined) ?? process.pid;
+  writeFileSync(
+    join(dir, `${pid}.json`),
+    JSON.stringify({
+      pid,
+      sessionId: SESSION_ID,
+      // Claude 原生会话名——与 party 宣告名 `claude-111111111111` 是两个命名空间。
+      name: "agentparty-d4",
+      status: "idle",
+      kind: "interactive",
+      messagingSocketPath: sockPath,
+      procStart: "Thu Aug 20 04:43:49 2026",
+      ...fields,
+    }),
+    { mode: 0o600 },
+  );
+}
+
+beforeEach(async () => {
+  dir = mkdtempSync(join(tmpdir(), "ap-native-sessions-"));
+  sockPath = join(dir, "inbox.sock");
+  received = [];
+  server = createServer((socket) => {
+    socket.on("data", (chunk) => received.push(chunk.toString("utf8")));
+  });
+  await new Promise<void>((resolve) => server.listen(sockPath, resolve));
+});
+
+afterEach(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("按 pid 寻址（#857 真实寻址层）", () => {
+  test("宣告名按 name 寻址恒 no-match，按 pid 寻址命中——这正是线上失效的根因", () => {
+    writeNativeSession();
+    const entry = registryEntry();
+    const announceName = claudeSessionAnnounceName(entry);
+    expect(announceName).toBe("claude-111111111111");
+    // 两个命名空间：宣告名与原生 name 永不相等。
+    expect(resolveSessionSocket(announceName, env())).toEqual({ ok: false, reason: "no-match" });
+    const byPid = resolveSessionSocketByPid(entry.pid, { expectSessionId: entry.session_id, env: env() });
+    expect(byPid.ok).toBe(true);
+    expect(byPid.ok && byPid.session.messagingSocketPath).toBe(sockPath);
+    expect(byPid.ok && byPid.session.name).toBe("agentparty-d4");
+  });
+
+  test("端到端：registry entry → pid → socket → 真的写进帧（宣告名与原生名不同也成功）", async () => {
+    writeNativeSession();
+    const entry = registryEntry();
+    const result = await injectChannelMessage({
+      pid: entry.pid,
+      sessionId: entry.session_id,
+      name: claudeSessionAnnounceName(entry),
+      body: "AgentParty wake: #dev seq=42",
+      fromName: "leo · agentparty (lark-ad72b3f97491-agentparty)",
+      env: env(),
+    });
+    expect(result).toMatchObject({ ok: true, socketPath: sockPath });
+    // 让 socket 数据回调跑完。
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    const payload = received.join("");
+    expect(payload.endsWith("\n")).toBe(true);
+    const frame = JSON.parse(payload.trim().split("\n").at(-1)!) as {
+      type: string;
+      message: { content: string };
+    };
+    expect(frame.type).toBe("user");
+    expect(frame.message.content).toContain("AgentParty wake: #dev seq=42");
+    expect(frame.message.content).toContain('from-name="leo · agentparty (lark-ad72b3f97491-agentparty)"');
+  });
+
+  test("sessionId 不匹配（pid 被复用/换了会话）→ 拒投，绝不写错会话", () => {
+    writeNativeSession({ sessionId: "22222222-2222-4222-8222-222222222222" });
+    expect(
+      resolveSessionSocketByPid(process.pid, { expectSessionId: SESSION_ID, env: env() }),
+    ).toEqual({ ok: false, reason: "no-match" });
+  });
+
+  test("pid 没有对应的原生会话文件 / pid 已死 → no-match（静默降级）", () => {
+    expect(resolveSessionSocketByPid(process.pid, { env: env() })).toEqual({
+      ok: false,
+      reason: "no-match",
+    });
+    writeNativeSession({ pid: 999_999_999 });
+    expect(resolveSessionSocketByPid(999_999_999, { env: env() })).toEqual({
+      ok: false,
+      reason: "no-match",
+    });
+  });
+
+  test("nativeSessionName 供 SessionStart 入册升级 display_name；读不到就 null", () => {
+    expect(nativeSessionName(process.pid, { env: env() })).toBeNull();
+    writeNativeSession();
+    expect(nativeSessionName(process.pid, { expectSessionId: SESSION_ID, env: env() })).toBe(
+      "agentparty-d4",
+    );
+    // 入册后宣告名即变成原生名。
+    expect(claudeSessionAnnounceName(registryEntry({ display_name: "agentparty-d4" }))).toBe(
+      "agentparty-d4",
+    );
+  });
+});

--- a/cli/test/claude-session-registry.test.ts
+++ b/cli/test/claude-session-registry.test.ts
@@ -14,6 +14,7 @@ import {
   CLAUDE_SESSION_REGISTRY_CAPACITY,
   CLAUDE_SESSION_REGISTRY_DIR_ENV,
   claudeSessionAlive,
+  claudeSessionAnnounceName,
   claudeSessionRegistryDirectory,
   listClaudeSessions,
   registerClaudeSession,
@@ -188,7 +189,12 @@ describe("claude session registry", () => {
 
 describe("hook lifecycle wiring (#841 P1)", () => {
   test("SessionStart registers and SessionEnd unregisters", () => {
-    const hookEnv = { ...env, AGENTPARTY_CHANNEL: "dev" };
+    // 原生会话目录指向一个空临时目录：display_name 升级路径读不到东西，保持 null。
+    const hookEnv = {
+      ...env,
+      AGENTPARTY_CHANNEL: "dev",
+      AGENTPARTY_CLAUDE_NATIVE_SESSIONS_DIR: directory,
+    };
     recordClaudeSessionLifecycle({
       hook_event_name: "SessionStart",
       session_id: SESSION_ID,
@@ -208,6 +214,45 @@ describe("hook lifecycle wiring (#841 P1)", () => {
       session_id: SESSION_ID,
     }, hookEnv, process.pid);
     expect(listClaudeSessions(env)).toHaveLength(0);
+  });
+
+  test("SessionStart 机会性把 display_name 升级成 Claude 原生会话名（读不到就保持 null）", () => {
+    const nativeDir = mkdtempSync(join(tmpdir(), "ap-native-sessions-hook-"));
+    try {
+      const hookEnv = {
+        ...env,
+        AGENTPARTY_CHANNEL: "dev",
+        AGENTPARTY_CLAUDE_NATIVE_SESSIONS_DIR: nativeDir,
+      };
+      const payload = { hook_event_name: "SessionStart", session_id: SESSION_ID, cwd: "/tmp/project" };
+      // 文件还没写出来（SessionStart 可能早于原生注册）→ null，不重试不阻塞。
+      recordClaudeSessionLifecycle(payload, hookEnv, process.pid);
+      expect(listClaudeSessions(env)[0]!.display_name).toBeNull();
+      writeFileSync(
+        join(nativeDir, `${process.pid}.json`),
+        JSON.stringify({
+          pid: process.pid,
+          sessionId: SESSION_ID,
+          name: "agentparty-d4",
+          messagingSocketPath: "/tmp/cc-socks-fake/1.sock",
+        }),
+        { mode: 0o600 },
+      );
+      recordClaudeSessionLifecycle(payload, hookEnv, process.pid);
+      const listed = listClaudeSessions(env);
+      expect(listed[0]!.display_name).toBe("agentparty-d4");
+      expect(claudeSessionAnnounceName(listed[0]!)).toBe("agentparty-d4");
+      // sessionId 对不上（pid 复用）→ 不认，保持 null。
+      recordClaudeSessionLifecycle(
+        { ...payload, session_id: sessionId(2) },
+        hookEnv,
+        process.pid,
+      );
+      const other = listClaudeSessions(env).find((e) => e.session_id === sessionId(2))!;
+      expect(other.display_name).toBeNull();
+    } finally {
+      rmSync(nativeDir, { recursive: true, force: true });
+    }
   });
 
   test("serve-managed lanes and channel-less sessions are not registered", () => {

--- a/cli/test/inject-from-name.test.ts
+++ b/cli/test/inject-from-name.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+import { friendlyAgentLabel, generatedAgentRole } from "@agentparty/shared/identity";
+import { wrapCrossSessionMessage } from "../src/claude-inbox-inject";
+import { injectFromName, senderInjectFromName } from "../src/serve-wake-proxy";
+import type { CachedIdentity } from "../src/config";
+
+function identity(overrides: Partial<CachedIdentity> = {}): CachedIdentity {
+  return {
+    name: "lark-ad72b3f97491-agentparty",
+    email: null,
+    kind: "agent",
+    role: "agent",
+    owner: null,
+    channel_scope: "dev",
+    verified_at: 0,
+    ...overrides,
+  };
+}
+
+describe("friendlyAgentLabel (shared, web 同源)", () => {
+  test("prefers owner_display_name, then handle, then owner", () => {
+    expect(friendlyAgentLabel({ name: "lark-ad72b3f97491-agentparty", owner_display_name: "leo" })).toBe(
+      "leo · agentparty",
+    );
+    expect(friendlyAgentLabel({ name: "lark-ad72b3f97491-agentparty", owner_handle: "leo-h" })).toBe(
+      "leo-h · agentparty",
+    );
+    expect(friendlyAgentLabel({ name: "lark-ad72b3f97491-agentparty", owner: "leo@example.com" })).toBe(
+      "leo@example.com · agentparty",
+    );
+  });
+
+  test("degrades to the bare role without a readable owner, and to the raw name without a role", () => {
+    expect(friendlyAgentLabel({ name: "lark-ad72b3f97491-agentparty" })).toBe("agentparty");
+    expect(friendlyAgentLabel({ name: "lark-ad72b3f97491-agentparty", owner: "oidc:abc" })).toBe("agentparty");
+    expect(friendlyAgentLabel({ name: "plain-agent", owner_display_name: "leo" })).toBe("leo · plain-agent");
+    expect(friendlyAgentLabel({ name: "plain-agent" })).toBe("plain-agent");
+    // 非 lark 前缀但同样是生成名的形态也能提出角色。
+    expect(generatedAgentRole("ad72b3f97491-agentparty")).toBe("agentparty");
+  });
+});
+
+describe("injectFromName / senderInjectFromName", () => {
+  test("keeps both the friendly label and the technical id", () => {
+    expect(injectFromName("dev", identity({ owner_display_name: "leo" }))).toBe(
+      "leo · agentparty (lark-ad72b3f97491-agentparty)",
+    );
+  });
+
+  test("two identities differing only in the hash segment stay distinguishable", () => {
+    const a = injectFromName("dev", identity({ owner_display_name: "leo" }));
+    const b = injectFromName(
+      "dev",
+      identity({ name: "lark-ad72b3f9749e-agentparty", owner_display_name: "leo" }),
+    );
+    expect(a).not.toBe(b);
+    expect(b).toContain("lark-ad72b3f9749e-agentparty");
+  });
+
+  test("falls back to the channel when no identity is cached", () => {
+    expect(injectFromName("dev", null)).toBe("agentparty#dev");
+    expect(senderInjectFromName(undefined, "dev")).toBe("agentparty#dev");
+  });
+
+  test("humans show their readable name; agents keep owner · role (id)", () => {
+    expect(
+      senderInjectFromName({ name: "leo", kind: "human", display_name: "郭立lee" }, "dev"),
+    ).toBe("郭立lee (leo)");
+    expect(
+      senderInjectFromName(
+        { name: "lark-ad72b3f97491-agentparty", kind: "agent", owner: "leo@example.com" },
+        "dev",
+      ),
+    ).toBe("leo@example.com · agentparty (lark-ad72b3f97491-agentparty)");
+  });
+
+  test("sanitizes characters that would break the receiver's integrity self-check", () => {
+    const name = senderInjectFromName({ name: 'we"ird<x>', kind: "agent" }, "dev");
+    expect(name).not.toContain('"');
+    expect(name).not.toContain("<");
+  });
+
+  test("the wrapped from-name survives an attribute round-trip", () => {
+    const fromName = injectFromName("dev", identity({ owner_display_name: "leo" }));
+    const wrapped = wrapCrossSessionMessage({ fromName, fromMode: "prompting", body: "hi" });
+    const match = /^<cross-session-message((?:\s+[a-z-]+="[^"]*")*)>\n([\s\S]*)\n<\/cross-session-message>$/.exec(
+      wrapped,
+    );
+    expect(match).not.toBeNull();
+    expect(match![1]).toContain(`from-name="${fromName}"`);
+    expect(match![2]).toBe("hi");
+  });
+});

--- a/cli/test/inject-from-name.test.ts
+++ b/cli/test/inject-from-name.test.ts
@@ -57,6 +57,13 @@ describe("injectFromName / senderInjectFromName", () => {
     expect(b).toContain("lark-ad72b3f9749e-agentparty");
   });
 
+  test("不给友好名重复追加已经含在里面的技术 ID（真机实测踩到）", () => {
+    // 非哈希前缀的 name 提不出角色 → 友好名里已经是完整 name，不该再括号重复一次。
+    expect(injectFromName("dev", identity({ name: "leeguooooo-codex2-agentparty", owner: "leo@example.com" })))
+      .toBe("leo@example.com · leeguooooo-codex2-agentparty");
+    expect(senderInjectFromName({ name: "plain-agent", kind: "agent" }, "dev")).toBe("plain-agent");
+  });
+
   test("falls back to the channel when no identity is cached", () => {
     expect(injectFromName("dev", null)).toBe("agentparty#dev");
     expect(senderInjectFromName(undefined, "dev")).toBe("agentparty#dev");

--- a/cli/test/serve-wake-proxy.test.ts
+++ b/cli/test/serve-wake-proxy.test.ts
@@ -6,6 +6,7 @@ import {
   attemptWakeProxy,
   noWakeProxyForwarder,
   selectWakeProxyTarget,
+  injectFromName,
   socketWakeProxyForwarder,
   WAKE_PROXY_NOTE_MAX_BYTES,
   wakeProxyNote,
@@ -136,18 +137,29 @@ describe("attemptWakeProxy", () => {
 });
 
 describe("socketWakeProxyForwarder（#844 socket 优先载体）", () => {
-  test("注入成功 → true；用宣告名寻址、频道昵称默认取 channel、正文≤512B 指针", async () => {
+  test("注入成功 → true；用宣告名寻址、from-name 带友好名+技术 ID、正文≤512B 指针", async () => {
     let seen: { name: string; body: string; fromName: string } | null = null;
     const forward = socketWakeProxyForwarder({
       inject: async ({ name, body, fromName }) => {
         seen = { name, body, fromName };
         return { ok: true, socketPath: "/tmp/x.sock", usedAuth: false, target: name };
       },
+      // 默认 from-name 走 injectFromName（读本机 identity）；测试固定成确定值保持隔离。
+      fromName: (ref) => injectFromName(ref.channel, {
+        name: "lark-ad72b3f97491-agentparty",
+        email: null,
+        kind: "agent",
+        role: "agent",
+        owner: null,
+        owner_display_name: "leo",
+        channel_scope: "pwtk",
+        verified_at: 0,
+      }),
     });
     const ok = await forward(entry({ display_name: "pair-claude" }), { channel: "pwtk", seq: 42 });
     expect(ok).toBe(true);
     expect(seen!.name).toBe("pair-claude");
-    expect(seen!.fromName).toBe("pwtk");
+    expect(seen!.fromName).toBe("leo · agentparty (lark-ad72b3f97491-agentparty)");
     expect(seen!.body).toContain("seq=42");
     expect(Buffer.byteLength(seen!.body, "utf8")).toBeLessThanOrEqual(WAKE_PROXY_NOTE_MAX_BYTES);
   });

--- a/cli/test/serve-wake-proxy.test.ts
+++ b/cli/test/serve-wake-proxy.test.ts
@@ -138,10 +138,10 @@ describe("attemptWakeProxy", () => {
 
 describe("socketWakeProxyForwarder（#844 socket 优先载体）", () => {
   test("注入成功 → true；用宣告名寻址、from-name 带友好名+技术 ID、正文≤512B 指针", async () => {
-    let seen: { name: string; body: string; fromName: string } | null = null;
+    let seen: { name: string; body: string; fromName: string; pid?: number; sessionId?: string | null } | null = null;
     const forward = socketWakeProxyForwarder({
-      inject: async ({ name, body, fromName }) => {
-        seen = { name, body, fromName };
+      inject: async ({ name, body, fromName, pid, sessionId }) => {
+        seen = { name, body, fromName, pid, sessionId };
         return { ok: true, socketPath: "/tmp/x.sock", usedAuth: false, target: name };
       },
       // 默认 from-name 走 injectFromName（读本机 identity）；测试固定成确定值保持隔离。
@@ -159,6 +159,9 @@ describe("socketWakeProxyForwarder（#844 socket 优先载体）", () => {
     const ok = await forward(entry({ display_name: "pair-claude" }), { channel: "pwtk", seq: 42 });
     expect(ok).toBe(true);
     expect(seen!.name).toBe("pair-claude");
+    // 寻址走 pid + sessionId（宣告名恒不等于 Claude 原生会话名，#857）。
+    expect(seen!.pid).toBe(entry().pid);
+    expect(seen!.sessionId).toBe(entry().session_id);
     expect(seen!.fromName).toBe("leo · agentparty (lark-ad72b3f97491-agentparty)");
     expect(seen!.body).toContain("seq=42");
     expect(Buffer.byteLength(seen!.body, "utf8")).toBeLessThanOrEqual(WAKE_PROXY_NOTE_MAX_BYTES);

--- a/shared/src/identity.ts
+++ b/shared/src/identity.ts
@@ -1,7 +1,11 @@
-// 身份区分码（#858）：同一个 owner 下同角色后缀的 agent（如 lark-ad72b3f97491-agentparty 与
-// lark-ad72b3f9749e-agentparty）渲染出的友好名完全一样，界面上分不出谁是谁。
-// 这里统一给「撞名组」里的每个技术 name 算一段最短且组内唯一的区分码，
-// web（消息头 / presence / 引用预览）与 cli 的 cross-session fromName 注入（#857）共用同一实现，防止规则漂移。
+// 身份展示规则的单一来源：web 的消息头 / presence / 引用预览，与 cli 的 cross-session
+// 注入面板（#857 的 fromName）必须显示同一个「谁是谁」。规则只放这一份，别在 web/cli
+// 各自复刻（同 onboarding.ts 的做法）。
+//
+// 两组导出互补，一起用：
+//   1. 友好名（generatedAgentRole / friendlyAgentLabel）——把技术 name 渲染成人能读的名字；
+//   2. 撞名区分码（identityDisambiguatorSource / assignIdentityDisambiguators，#858）——
+//      友好名撞车时给出组内唯一的最短技术区分码。
 
 const HASH_PREFIX = /^(?:[a-z][a-z0-9]*-)?([0-9a-f]{8,})(?:-|$)/i;
 
@@ -39,4 +43,51 @@ export function assignIdentityDisambiguators(names: readonly string[]): Map<stri
   // 哈希段完全相同（或来源无法区分）：退到完整技术 name，保证「一定能分辨」这个硬要求。
   for (const name of unique) out.set(name, name);
   return out;
+}
+
+/**
+ * 自动生成的 agent 名形如 `lark-ad72b3f97491-agentparty` / `ad72b3f97491-agentparty`：
+ * 前缀是不可读的技术 ID，尾巴才是人给的角色名。提出角色名，提不出返回 null。
+ */
+export function generatedAgentRole(value: string): string | null {
+  const match = value.match(/^(?:lark-)?[0-9a-f]{12,}-(.+)$/i);
+  return match?.[1]?.trim() || null;
+}
+
+/** 不可读的账号标识（SSO subject 等），不适合直接当所属人展示名。 */
+export function isOpaqueAccount(value: string): boolean {
+  return /^(?:(?:lark|oidc|apple|github):|oidc-)/i.test(value);
+}
+
+export interface FriendlyAgentIdentity {
+  /** 技术 identity（可路由名）。 */
+  name: string;
+  owner?: string | null;
+  owner_handle?: string | null;
+  owner_display_name?: string | null;
+}
+
+/**
+ * 友好展示名，对齐 web 的 `<ownerLabel> · <label>`：
+ * - 角色名取 generatedAgentRole(name)，提不出就用原 name；
+ * - 所属人取 owner_display_name > owner_handle > owner（不可读账号忽略）；
+ * - 无可读所属人时降级为纯角色名。
+ * 例：`lark-ad72b3f97491-agentparty` + owner_display_name=leo → `leo · agentparty`。
+ *
+ * 注意：友好名会撞车（同 owner 同角色，只有哈希段不同）——需要「一定能分辨」的场合
+ * （web 列表用 assignIdentityDisambiguators；cli 注入面板 fromName 直接带完整技术 ID）。
+ */
+export function friendlyAgentLabel(identity: FriendlyAgentIdentity): string {
+  const role = generatedAgentRole(identity.name) ?? identity.name;
+  const ownerCandidates = [
+    identity.owner_display_name,
+    identity.owner_handle,
+    identity.owner,
+  ];
+  for (const candidate of ownerCandidates) {
+    const owner = typeof candidate === "string" ? candidate.trim() : "";
+    if (owner === "" || isOpaqueAccount(owner)) continue;
+    return `${owner} · ${role}`;
+  }
+  return role;
 }

--- a/web/src/lib/identityDisplay.ts
+++ b/web/src/lib/identityDisplay.ts
@@ -1,5 +1,9 @@
 import type { MsgFrame, PresenceEntry, Sender } from "@agentparty/shared";
-import { assignIdentityDisambiguators } from "@agentparty/shared/identity";
+import {
+  assignIdentityDisambiguators,
+  generatedAgentRole,
+  isOpaqueAccount,
+} from "@agentparty/shared/identity";
 import type { ChannelIdentity } from "./api";
 import type { MentionCandidate } from "./mentions";
 
@@ -13,14 +17,8 @@ export interface IdentityDisplay {
 
 export type IdentityDisplayMap = Record<string, IdentityDisplay>;
 
-function isOpaqueAccount(value: string): boolean {
-  return /^(?:(?:lark|oidc|apple|github):|oidc-)/i.test(value);
-}
-
-function generatedAgentRole(value: string): string | null {
-  const match = value.match(/^(?:lark-)?[0-9a-f]{12,}-(.+)$/i);
-  return match?.[1]?.trim() || null;
-}
+// 角色提取/账号可读性判定的权威实现在 shared/src/identity.ts——cli 的 cross-session
+// 注入面板复用同一份，别在这里另写一份正则（会与注入面板显示的名字漂移）。
 
 export interface IdentityPresentation {
   label: string;


### PR DESCRIPTION
Closes #857

## 背景（A/B 唤醒实验）
2026-08-20 的对照实验：本机零常驻（watch 已 kill、无 serve）时，
- A 臂 纯频道 @（seq=1845）→ ❌ 静默 90s 零反应；
- B 臂 Claude 原生 cross-session 直投 → ✅ 送达。

频道是拉模型，服务端要推到本机就必须有活着的进程在收。#856 把 socket 注入挂在 **serve** 上，本机零进程仍不通。

## 本切片
让 **announce MCP 自己**当那条常驻的腿：它是插件随会话启动的 MCP server（会话 idle 时仍活着）、已持有频道 WS、知道宿主会话的宣告名。收帧循环从「只 ack」升级为「命中 @ 宿主会话即 socket 注入」。

**效果**：装了插件的交互式会话，不需要 serve / watcher / 额外 daemon，本机零常驻也能被跨机频道消息唤醒。

### 触发条件
msg 帧的 `mentions` 命中宿主会话宣告名（`claudeSessionAnnounceName(entry)`，按 `mentionMatchKey` 归一化比较）→ 注入 `wakeProxyNote({channel, seq})`（≤512B 指针，正文留在频道）。非命中帧维持只 ack。

### 不变式与安全
- 注入目标恒为本轮 `selectDormantAnnounceEntry` 绑定的宿主会话，不接受外部传入的名字——绝不代投本机其他会话（那是 serve wake proxy 的职责）；
- 保持 P2 不变式：只本地 ack 防积压，**不推进持久化游标、不 claim delivery**；
- 注入失败静默降级为改动前行为（只 ack），不抛错、不中断收帧循环；
- 进程内 seq 去重（上限 512，跨重连保留）防 WS 重放导致重复唤醒。

### 与 serve 路径的重叠（已知）
本机若同时跑 serve，serve 的 wake proxy 会为同一条 @ 各注入一次。两条路径各有自己的进程内 seen，本切片**不做跨进程去重**，由 Claude 收件箱侧的 msg_id / 队列与人工感知兜底——重复唤醒的代价远小于叫不醒。代码里有注释说明。

## 附带：注入面板的发送者名（owner 追加需求）
面板显示的是 `from uds:<sock> (peer claims name: <from-name>)`（#844 实测面板文本），**没有另一处独立显示技术 identity**，所以 from-name 必须自带技术 ID。最终形态（方案 A，完整技术 ID）：

```
leo · agentparty (lark-ad72b3f97491-agentparty)
```

不选尾 5 位短码：短码仍会碰撞，而 from-name 没有长度硬限（只禁 `"` 和 `\r\n<>`）。`lark-ad72b3f97491-agentparty` 与 `lark-ad72b3f9749e-agentparty` 的友好名完全相同，只有完整 ID 能区分。

- 角色提取正则 + 所属人可读性判定挪进 `shared/src/identity.ts` 作单一来源，web 的 `identityDisplay.ts` 改为引用（并留注释指向 shared），防两份漂移；
- announce 路径的 from-name 用**真实发信人**（msg 帧 sender）的友好名 + 技术 ID；serve 的 `socketWakeProxyForwarder` 默认用本机 identity 的同款格式；
- from-name 里的非法字符（用户可控昵称）就地净化成 `_`，别让一个昵称把唤醒路径打成静默失败。

## 测试
`cli/test/claude-channel-dormant-announce.test.ts` 补：命中才注入、非命中不注入、目标是宿主会话、同 seq 只注入一次、注入失败仍继续 ack 且循环存活、不推进游标；新增 `cli/test/inject-from-name.test.ts` 覆盖 friendlyAgentLabel 各分支、仅哈希段不同的两个身份产生不同 from-name、`wrapCrossSessionMessage` 属性 round-trip。全部走 mock 注入依赖，**不碰真实 `/tmp/cc-socks/`**。

`bun test`（cli 1737 pass / web 1295 pass）+ `bunx tsc --noEmit`（cli、web）全绿。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 支持按进程 ID 和会话 ID 精确定位 Claude 会话，避免进程复用导致消息误投。
  * 休眠频道会话可根据频道身份和消息提及自动唤醒并注入消息。
  * 支持读取并展示 Claude 原生会话名称。
  * 优化消息来源名称，展示更友好的身份信息并清理特殊字符。
  * 增强代理与发送者身份展示规则。

* **错误修复**
  * 修复会话名称不匹配、身份不明确或目标失效时的错误注入问题。
  * 消息确认、去重及失败降级行为更加稳定。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->