### PR TITLE
fix(web): 撞名身份显示技术区分码，同 owner 同角色的 agent 可分辨

### DIFF
--- a/shared/package.json
+++ b/shared/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "exports": {
     ".": "./src/protocol.ts",
+    "./identity": "./src/identity.ts",
     "./mentions": "./src/mentions.ts",
     "./onboarding": "./src/onboarding.ts"
   }

--- a/shared/src/identity.ts
+++ b/shared/src/identity.ts
@@ -1,0 +1,42 @@
+// 身份区分码（#858）：同一个 owner 下同角色后缀的 agent（如 lark-ad72b3f97491-agentparty 与
+// lark-ad72b3f9749e-agentparty）渲染出的友好名完全一样，界面上分不出谁是谁。
+// 这里统一给「撞名组」里的每个技术 name 算一段最短且组内唯一的区分码，
+// web（消息头 / presence / 引用预览）与 cli 的 cross-session fromName 注入（#857）共用同一实现，防止规则漂移。
+
+const HASH_PREFIX = /^(?:[a-z][a-z0-9]*-)?([0-9a-f]{8,})(?:-|$)/i;
+
+/**
+ * 取一个 name 里最适合当区分码的「哈希段」。
+ * - `lark-ad72b3f97491-agentparty` → `ad72b3f97491`（前缀词 + 十六进制段）
+ * - `61ec302c-6c31-4bca-a1df-88152372f6d9` → `61ec302c`（UUID 首段也是十六进制段）
+ * - 其他形态（人起的名字、纯英文 slug）没有哈希段，降级用整个 name 当来源。
+ */
+export function identityDisambiguatorSource(name: string): string {
+  return name.match(HASH_PREFIX)?.[1] ?? name;
+}
+
+const MIN_DISAMBIGUATOR_LENGTH = 5;
+
+/**
+ * 给一组「渲染后显示名相同」的技术 name 分配组内唯一的区分码。
+ * 从 5 位尾部片段起步，仍有冲突就逐位加长；来源段本身相同（加长也无解）时降级用完整 name。
+ * 单个 name 的组不产生区分码——不撞名的身份显示必须保持原样。
+ */
+export function assignIdentityDisambiguators(names: readonly string[]): Map<string, string> {
+  const out = new Map<string, string>();
+  const unique = [...new Set(names)];
+  if (unique.length < 2) return out;
+
+  const sources = new Map(unique.map((name) => [name, identityDisambiguatorSource(name)]));
+  const maxLength = Math.max(...[...sources.values()].map((source) => source.length));
+
+  for (let length = MIN_DISAMBIGUATOR_LENGTH; length <= maxLength; length++) {
+    const candidates = new Map(unique.map((name) => [name, sources.get(name)!.slice(-length)]));
+    const distinct = new Set(candidates.values());
+    if (distinct.size === unique.length) return candidates;
+  }
+
+  // 哈希段完全相同（或来源无法区分）：退到完整技术 name，保证「一定能分辨」这个硬要求。
+  for (const name of unique) out.set(name, name);
+  return out;
+}

--- a/web/src/components/IdentityDisambiguator.tsx
+++ b/web/src/components/IdentityDisambiguator.tsx
@@ -1,0 +1,10 @@
+// #858：同 owner 同角色的 agent 显示名撞车时，在名字后补一段技术区分码。
+// 只有撞名身份才有 code；不撞名时组件渲染 null，界面完全不变（不给所有身份加尾巴）。
+export function IdentityDisambiguator({ code }: { code: string | null | undefined }) {
+  if (code === null || code === undefined || code === "") return null;
+  return (
+    <span className="t-mono identity-disambiguator" title={code}>
+      ·{code}
+    </span>
+  );
+}

--- a/web/src/components/MessageCard.disambiguator.test.tsx
+++ b/web/src/components/MessageCard.disambiguator.test.tsx
@@ -1,0 +1,128 @@
+// #858：同 owner 同角色的两个 agent 显示名撞车时，消息头要带上技术区分码；
+// 不撞名的身份显示必须完全不变（不给所有人加尾巴）。
+// @ts-expect-error Bun executes this test, while the web tsconfig intentionally loads only Vite globals.
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { act, create, type ReactTestInstance, type ReactTestRenderer } from "react-test-renderer";
+import type { MsgFrame } from "@agentparty/shared";
+import { LocaleProvider } from "../i18n/locale";
+import { buildIdentityDisplay } from "../lib/identityDisplay";
+
+mock.module("../lib/markdown", () => ({ renderMarkdown: (s: string) => s }));
+const { MessageCard } = await import("./MessageCard");
+
+let renderer: ReactTestRenderer | null = null;
+const noop = () => undefined;
+
+function memoryStorage(): Storage {
+  const values = new Map<string, string>();
+  return {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => { values.set(key, value); },
+    removeItem: (key) => { values.delete(key); },
+    clear: () => values.clear(),
+    key: (index) => [...values.keys()][index] ?? null,
+    get length() { return values.size; },
+  };
+}
+
+class TestEventTarget {
+  innerWidth = 1024;
+  addEventListener() {}
+  removeEventListener() {}
+}
+
+beforeEach(() => {
+  Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", { configurable: true, value: true });
+  Object.defineProperty(globalThis, "localStorage", { configurable: true, value: memoryStorage() });
+  Object.defineProperty(globalThis, "window", { configurable: true, value: new TestEventTarget() });
+  Object.defineProperty(globalThis, "document", { configurable: true, value: new TestEventTarget() });
+});
+
+afterEach(() => {
+  act(() => renderer?.unmount());
+  renderer = null;
+  Reflect.deleteProperty(globalThis, "window");
+  Reflect.deleteProperty(globalThis, "document");
+});
+
+const OWNER = "lark:on_b81feb6f84d5225a462349bb36499262";
+
+function msg(senderName: string): MsgFrame {
+  return {
+    type: "msg",
+    seq: 7,
+    sender: { name: senderName, kind: "agent", owner: OWNER },
+    kind: "message",
+    body: "hi",
+    mentions: [],
+    reply_to: null,
+    state: null,
+    note: null,
+    status: null,
+    ts: 1_700_000_000_000,
+  } as MsgFrame;
+}
+
+function identities(...names: string[]) {
+  return buildIdentityDisplay({
+    channelIdentities: [
+      { name: "human-session", display: "leo", kind: "human", account: OWNER },
+      ...names.map((name) => ({ name, display: name, kind: "agent" as const, account: OWNER })),
+    ],
+    mentionOptions: [],
+    messages: [],
+    participants: [],
+    presence: {},
+  });
+}
+
+function render(frame: MsgFrame, identityDisplay: ReturnType<typeof identities>) {
+  act(() => {
+    renderer = create(
+      <LocaleProvider>
+        <MessageCard
+          msg={frame}
+          self={null}
+          quotedMessage={null}
+          identityDisplay={identityDisplay}
+          canModerate={false}
+          onReply={noop}
+          onEdit={noop}
+          onRetract={noop}
+          canCreateTask={false}
+          onCreateTask={noop}
+          editing={false}
+          editDraft={frame.body}
+          editSaving={false}
+          actionError={null}
+          busy={false}
+          onEditDraftChange={noop}
+          onEditCancel={noop}
+          onEditSave={noop}
+        />
+      </LocaleProvider>,
+      { createNodeMock: () => ({ blur: noop, getBoundingClientRect: () => ({ left: 120 }), contains: () => false }) },
+    );
+  });
+  return renderer!.root;
+}
+
+function codes(root: ReactTestInstance): string[] {
+  return root
+    .findAll((n) => String((n.props as { className?: string }).className ?? "").includes("identity-disambiguator"))
+    .map((n) => n.children.map((c) => (typeof c === "string" ? c : "")).join(""));
+}
+
+describe("MessageCard 身份区分码（#858）", () => {
+  test("撞名时消息头带上哈希尾部区分码", () => {
+    const map = identities("lark-ad72b3f97491-agentparty", "lark-ad72b3f9749e-agentparty");
+    const root = render(msg("lark-ad72b3f97491-agentparty"), map);
+    expect(codes(root)).toContain("·97491");
+  });
+
+  test("不撞名时消息头不出现任何区分码", () => {
+    const map = identities("lark-ad72b3f97491-agentparty");
+    const root = render(msg("lark-ad72b3f97491-agentparty"), map);
+    expect(codes(root)).toEqual([]);
+  });
+});

--- a/web/src/components/MessageCard.tsx
+++ b/web/src/components/MessageCard.tsx
@@ -4,9 +4,11 @@ import type { AgentContext, ChannelRoleAssignment, MsgFrame, PresenceEntry, Publ
 import { memo, useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import type { CSSProperties } from "react";
 import { agentHue } from "../lib/agentColor";
+import { IdentityDisambiguator } from "./IdentityDisambiguator";
 import { isClientVersionOutdated, useMinClientVersion } from "../lib/clientVersion";
 import { gitContextChip } from "../lib/gitContext";
 import {
+  disambiguatorForIdentity,
   formatIdentityPresentation,
   resolveAgentOwnerLabel,
   resolveIdentityPresentation,
@@ -426,6 +428,8 @@ function MessageCardImpl({
         : msg.sender.handle,
   });
   const senderLabel = senderPresentation.label;
+  // #858：只有跟别人撞名的身份才带技术区分码；不撞名时 disambiguator 为 undefined，显示完全不变。
+  const senderDisambiguator = senderPresentation.disambiguator ?? null;
   const senderOwnedLabel = formatIdentityPresentation(senderPresentation, (ownerName, agentName) =>
     t("MessageCard.agent.ownedLabel", { owner: ownerName, name: agentName }),
   );
@@ -509,6 +513,8 @@ function MessageCardImpl({
           display: resolveSenderLabel(quotedMessage.sender, identityDisplay),
         })
       : null;
+  const quotedSenderDisambiguator =
+    quotedMessage !== null ? disambiguatorForIdentity(quotedMessage.sender.name, identityDisplay) : null;
   const quotedPreviewText =
     quotedMessage !== null
       ? quotedMessage.retracted
@@ -625,6 +631,7 @@ function MessageCardImpl({
           style={{ cursor: "pointer" }}
         >
           <span className="msg-sender" title={senderTitle}>{senderOwnedLabel}</span>
+          <IdentityDisambiguator code={senderDisambiguator} />
           {" "}
           → {msg.state}
           {statusBits.length > 0 ? ` · ${statusBits.join(" · ")}` : ""} · {fmtTime(msg.ts)}
@@ -699,6 +706,7 @@ function MessageCardImpl({
             recentMessages={recentMessages}
             triggerClassName="msg-sender"
           />
+          <IdentityDisambiguator code={senderDisambiguator} />
           {/* 技术身份保留在悬浮卡片中；消息头用「人 · agent」直接表达归属。 */}
           {lineageLabel !== null && (
             <span className="t-mono msg-lineage" title={senderTitle}>
@@ -857,6 +865,7 @@ function MessageCardImpl({
         >
           <span className="msg-quote-icon" aria-hidden="true">↩</span>
           <span className="msg-quote-sender">{quotedSenderLabel}</span>
+          <IdentityDisambiguator code={quotedSenderDisambiguator} />
           <span className="msg-quote-text">{quotedPreviewText}</span>
         </button>
       )}

--- a/web/src/components/PresenceBar.tsx
+++ b/web/src/components/PresenceBar.tsx
@@ -3,6 +3,8 @@
 import { autoWakeReachable, evaluateHostLease, PRESENCE_TIMEOUT_MS, wakeableState, type ChannelRoleAssignment, type PresenceEntry, type PresenceState, type Sender } from "@agentparty/shared";
 import { useCallback, useEffect, useRef, useState, type CSSProperties, type ReactElement } from "react";
 import { agentHue } from "../lib/agentColor";
+import { disambiguatorForIdentity, type IdentityDisplayMap } from "../lib/identityDisplay";
+import { IdentityDisambiguator } from "./IdentityDisambiguator";
 import { gitContextChip } from "../lib/gitContext";
 import { fmtRel } from "../lib/time";
 import type { SocketStatus } from "../lib/ws";
@@ -30,6 +32,8 @@ interface Props {
   focus?: ReactElement | null;
   // issue #272（审计重开）：点 presence roster 里的某个人/agent，打开它的单 Agent 详情弹窗。
   onOpenAgentDetail?: (name: string) => void;
+  // #858：撞名身份的技术区分码来源；缺省即不显示区分码（老调用方行为不变）。
+  identities?: IdentityDisplayMap;
 }
 
 // 暂停时长预设（#180）：值 → 相对 now 的恢复时刻（epoch ms），"indefinite" 返回 null（手动恢复）。
@@ -75,6 +79,8 @@ export interface Item {
   avatarUrl: string | null;
   avatarThumb: string | null;
   display: string;
+  // #858：同 owner 同角色 agent 撞名时才有值；不撞名恒为 null，presence 行显示不变。
+  disambiguator: string | null;
   responsibility: string | null;
   connectionCount: number;
   clientVersion: string | null;
@@ -378,6 +384,7 @@ export function PresenceBar({
   headerControls,
   focus,
   onOpenAgentDetail,
+  identities,
 }: Props) {
   const t = useT();
   const localizeWaitingOwner = (item: Item): string | null => {
@@ -427,6 +434,7 @@ export function PresenceBar({
         assigned?.display ??
         (kind === "human" ? displayName ?? handle ?? owner ?? name : handle ?? displayName ?? name),
       displayName,
+      disambiguator: disambiguatorForIdentity(name, identities),
       avatarUrl: sender?.avatar_url ?? entry?.avatar_url ?? null,
       avatarThumb: sender?.avatar_thumb ?? entry?.avatar_thumb ?? null,
       responsibility: assigned?.responsibility ?? null,
@@ -655,6 +663,7 @@ export function PresenceBar({
           className={`d-dot d-dot--${it.state}${it.paused ? " d-dot--paused" : ""}${unreachable !== null ? " d-dot--unreachable" : ""}`}
         />
         <span className="presence-name">{it.display}</span>
+        <IdentityDisambiguator code={it.disambiguator} />
         <span className={`t-mono presence-kind presence-kind--${it.kind}`}>{it.kind}</span>
         {it.paused && (
           <span
@@ -907,6 +916,7 @@ export function PresenceBar({
                   className={`d-dot d-dot--${agent.state}${agent.paused ? " d-dot--paused" : ""}${agentUnreachable !== null ? " d-dot--unreachable" : ""}`}
                 />
                 <span>{agent.display}</span>
+                <IdentityDisambiguator code={agent.disambiguator} />
                 <span className={`t-mono presence-agent-kind presence-kind--${agent.kind}`}>{agent.kind}</span>
                 {agent.paused && (
                   <span

--- a/web/src/lib/identityDisplay.test.ts
+++ b/web/src/lib/identityDisplay.test.ts
@@ -191,3 +191,86 @@ describe("resolveIdentityPresentation", () => {
     ).toBe("ZHENG TONG · 小火龙");
   });
 });
+
+describe("identity disambiguation (#858)", () => {
+  const owner = "lark:on_b81feb6f84d5225a462349bb36499262";
+  const human = {
+    name: "human-session",
+    display: "leo",
+    kind: "human" as const,
+    account: owner,
+  };
+
+  function agents(...names: string[]) {
+    return buildIdentityDisplay({
+      channelIdentities: [
+        human,
+        ...names.map((name) => ({ name, display: name, kind: "agent" as const, account: owner })),
+      ],
+      mentionOptions: [],
+      messages: [],
+      participants: [],
+      presence: {},
+    });
+  }
+
+  it("gives two agents that only differ in their hash segment distinct disambiguators", () => {
+    const map = agents("lark-ad72b3f97491-agentparty", "lark-ad72b3f9749e-agentparty");
+    const a = resolveIdentityPresentation("lark-ad72b3f97491-agentparty", map);
+    const b = resolveIdentityPresentation("lark-ad72b3f9749e-agentparty", map);
+
+    expect(a.label).toBe("agentparty");
+    expect(b.label).toBe("agentparty");
+    expect(a.ownerLabel).toBe("leo");
+    expect(a.disambiguator).toBe("97491");
+    expect(b.disambiguator).toBe("9749e");
+  });
+
+  it("leaves a lone identity untouched", () => {
+    const map = agents("lark-ad72b3f97491-agentparty");
+    expect(map["lark-ad72b3f97491-agentparty"]?.disambiguator).toBeUndefined();
+    expect(
+      resolveIdentityPresentation("lark-ad72b3f97491-agentparty", map).disambiguator,
+    ).toBeUndefined();
+  });
+
+  it("does not disambiguate agents whose rendered names already differ", () => {
+    const map = agents("lark-ad72b3f97491-agentparty", "lark-ad72b3f9749e-release");
+    expect(map["lark-ad72b3f97491-agentparty"]?.disambiguator).toBeUndefined();
+    expect(map["lark-ad72b3f9749e-release"]?.disambiguator).toBeUndefined();
+  });
+
+  it("keeps every member of a three-way collision unique", () => {
+    const names = [
+      "lark-ad72b3f97491-agentparty",
+      "lark-ad72b3f9749e-agentparty",
+      "lark-ad72b3f974a0-agentparty",
+    ];
+    const map = agents(...names);
+    const codes = names.map((name) => map[name]?.disambiguator);
+    expect(codes.every((code) => typeof code === "string")).toBe(true);
+    expect(new Set(codes).size).toBe(3);
+  });
+
+  it("grows the disambiguator past 5 chars when 5 is not enough", () => {
+    const map = agents("lark-ad72b3f1aaaaa-agentparty", "lark-ad72b3f2aaaaa-agentparty");
+    expect(map["lark-ad72b3f1aaaaa-agentparty"]?.disambiguator).toBe("1aaaaa");
+    expect(map["lark-ad72b3f2aaaaa-agentparty"]?.disambiguator).toBe("2aaaaa");
+  });
+
+  it("degrades to the tail of the raw name when there is no hash segment", () => {
+    const map = buildIdentityDisplay({
+      channelIdentities: [
+        human,
+        { name: "worker-one", display: "小火龙", kind: "agent", account: owner },
+        { name: "worker-two", display: "小火龙", kind: "agent", account: owner },
+      ],
+      mentionOptions: [],
+      messages: [],
+      participants: [],
+      presence: {},
+    });
+    expect(map["worker-one"]?.disambiguator).toBe("r-one");
+    expect(map["worker-two"]?.disambiguator).toBe("r-two");
+  });
+});

--- a/web/src/lib/identityDisplay.ts
+++ b/web/src/lib/identityDisplay.ts
@@ -1,4 +1,5 @@
 import type { MsgFrame, PresenceEntry, Sender } from "@agentparty/shared";
+import { assignIdentityDisambiguators } from "@agentparty/shared/identity";
 import type { ChannelIdentity } from "./api";
 import type { MentionCandidate } from "./mentions";
 
@@ -6,6 +7,8 @@ export interface IdentityDisplay {
   display: string;
   kind?: "agent" | "human";
   account?: string;
+  // #858：同 owner 同角色的 agent 渲染出的显示名会完全一样；撞名时才带上这段技术区分码。
+  disambiguator?: string;
 }
 
 export type IdentityDisplayMap = Record<string, IdentityDisplay>;
@@ -25,6 +28,8 @@ export interface IdentityPresentation {
   technicalName: string;
   generated: boolean;
   kind?: "agent" | "human";
+  // 仅撞名身份有值；渲染成 `owner · role·<code>`，不撞名的身份显示保持原样。
+  disambiguator?: string;
 }
 
 export function formatIdentityPresentation(
@@ -66,6 +71,14 @@ function addIdentity(
   };
 }
 
+// 撞名区分码查询（#858）：渲染点只需要「有没有」，不必重算 presentation。
+export function disambiguatorForIdentity(
+  name: string,
+  identities: IdentityDisplayMap | undefined,
+): string | null {
+  return identities?.[name]?.disambiguator ?? null;
+}
+
 export function displayForIdentity(name: string, identities: IdentityDisplayMap | undefined): string {
   return identities?.[name]?.display ?? name;
 }
@@ -101,6 +114,7 @@ export function resolveIdentityPresentation(
     technicalName: name,
     generated,
     ...(kind === undefined ? {} : { kind }),
+    ...(identity?.disambiguator === undefined ? {} : { disambiguator: identity.disambiguator }),
   };
 }
 
@@ -183,5 +197,25 @@ export function buildIdentityDisplay(input: {
   }
   for (const identity of input.channelIdentities) addIdentity(map, identity.name, identity, true);
 
+  return withDisambiguators(map);
+}
+
+// #858：全量 map 构建完成后统一扫一遍撞名——按最终渲染出的 `ownerLabel · label` 分组，
+// 同组多于一个技术 name 就给每个成员打一段组内唯一的区分码（规则在 shared/identity，与 #857 共用）。
+function withDisambiguators(map: IdentityDisplayMap): IdentityDisplayMap {
+  const groups = new Map<string, string[]>();
+  for (const name of Object.keys(map)) {
+    const presentation = resolveIdentityPresentation(name, map);
+    const key = `${presentation.kind ?? "unknown"}\u0000${presentation.ownerLabel ?? ""}\u0000${presentation.label}`;
+    const bucket = groups.get(key);
+    if (bucket === undefined) groups.set(key, [name]);
+    else bucket.push(name);
+  }
+  for (const names of groups.values()) {
+    if (names.length < 2) continue;
+    for (const [name, disambiguator] of assignIdentityDisambiguators(names)) {
+      map[name] = { ...map[name]!, disambiguator };
+    }
+  }
   return map;
 }

--- a/web/src/pages/Channel.tsx
+++ b/web/src/pages/Channel.tsx
@@ -5604,6 +5604,7 @@ export function ChannelPage({
         {messageNavigationAnnouncement}
       </span>
       <PresenceBar
+        identities={identityDisplay}
         presence={state.presence}
         participants={state.participants}
         status={state.status}

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -5076,6 +5076,8 @@ button.org-person-name {
   flex-wrap: wrap;
 }
 .agent-detail-alias { color: var(--t-dim); }
+/* #858 撞名区分码：等宽 + 弱化色，跟身份卡 alias 同一视觉层级。 */
+.identity-disambiguator { color: var(--t-dim); font-size: 0.85em; margin-left: 2px; }
 .agent-detail-online-badge {
   font-weight: 700;
 }


### PR DESCRIPTION
## 问题
同 owner + 同角色后缀的 agent 显示名完全一样：`lark-ad72b3f97491-agentparty` 与 `lark-ad72b3f9749e-agentparty` 都渲染成 `leo · agentparty`，消息头 / presence 行 / 引用预览都分不出谁是谁。

## 改动
- `shared/src/identity.ts`（新增，导出 `@agentparty/shared/identity`）
  - `identityDisambiguatorSource(name)`：取 name 里的哈希段（`lark-ad72b3f97491-agentparty` → `ad72b3f97491`；UUID 取首段）；无哈希段则降级用完整 name。
  - `assignIdentityDisambiguators(names)`：给一组撞名的技术 name 分配组内唯一区分码——从哈希段**尾部 5 位**起，仍冲突就逐位加长；来源段完全相同时退到完整技术 name。单元素组不产生区分码。
- `web/src/lib/identityDisplay.ts`
  - `buildIdentityDisplay` 构建完 map 后做冲突扫描：按最终渲染的 `kind + ownerLabel + label` 分组，组内 >1 个 name 才打 `disambiguator`。
  - `IdentityDisplay` / `IdentityPresentation` 新增可选 `disambiguator`；`resolveIdentityPresentation` 有值才返回；新增 `disambiguatorForIdentity()` 便于渲染点直查。
- 渲染：新组件 `IdentityDisambiguator`（等宽 + `--t-dim` 弱化色，与 `AgentDetailModal` 的 alias 同一视觉层级），接在
  - 消息头 sender（`MessageCard`，含 status 行分支）
  - 引用预览的被引用者（`msg-quote-sender`）
  - presence 行与 owner 分组内的 agent 行（`PresenceBar`，新增可选 `identities` prop，由 `Channel.tsx` 传入）
- `.identity-disambiguator` 样式加在 `app.css`。

## 渲染样例
- 撞名：`leo · agentparty·97491` / `leo · agentparty·9749e`
- 不撞名：`leo · agentparty`（**逐字不变**，不给所有身份加尾巴——有测试守住）

## 与 #857 的共用
规则放在 `shared/`（`@agentparty/shared/identity`），cli 侧 cross-session 注入 fromName 直接 import 同一个 `assignIdentityDisambiguators` / `identityDisambiguatorSource` 即可，不会出现两套「取几位哈希」的规则漂移。本 PR 不改 cli，避免与 #857 抢同一批文件。

## 测试
- `web/src/lib/identityDisplay.test.ts` 新增 6 例：两身份仅哈希段不同各拿到不同码、单身份无码、渲染名本就不同不打码、三方撞名全唯一、5 位不够自动加长（`1aaaaa`/`2aaaaa`）、无哈希段形态降级。
- `web/src/components/MessageCard.disambiguator.test.tsx`：消息头有 / 无区分码两态。
- `bun test web` → 1303 pass，剩余 fail 均为改动前既有（`cloudflare:test` 无法在 bun 下解析、RELEASE_CLI_VERSION 版本对齐）。
- `web` 下 `bunx tsc --noEmit` 干净。

Closes #858
