### PR TITLE
fix(web): 接入包 node 分支不再销毁用户 settings.json

### DIFF
--- a/web/src/lib/joinPack.settings.test.ts
+++ b/web/src/lib/joinPack.settings.test.ts
@@ -6,7 +6,7 @@
 // 在设计上就不可能被看见。这里在 fake HOME + 受控 PATH 下实际执行生成的片段。
 import { describe, expect, it } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, existsSync, symlinkSync, readdirSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, existsSync, symlinkSync, readdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { lookup } from "../i18n/dict";
@@ -43,6 +43,11 @@ function settingsShell(): string {
     .join("\n");
 }
 
+// shell 片段本身需要的基础命令。PATH 只暴露它们 + 被测工具，
+// 这样「无可用工具」才是真隔离：Linux CI 上 /bin 常软链到 /usr/bin（自带 python3），
+// 把 /bin 放进 PATH 会让隔离失效——本地 macOS 通过、CI 失败就是这么来的。
+const BASE_TOOLS = ["mkdir", "cp", "rm", "mv", "cat"] as const;
+
 /** 只让指定工具在 PATH 中可见，用来单独驱动 jq / node / python3 三个分支。 */
 function runWithTools(settingsContent: string | null, tools: string[]): {
   home: string;
@@ -53,25 +58,34 @@ function runWithTools(settingsContent: string | null, tools: string[]): {
   const home = mkdtempSync(join(tmpdir(), "ap-settings-"));
   const bin = join(home, "bin");
   mkdirSync(bin);
-  for (const tool of tools) {
+  for (const tool of [...BASE_TOOLS, ...tools]) {
     const real = spawnSync("sh", ["-c", `command -v ${tool}`], { encoding: "utf8" }).stdout.trim();
-    if (real !== "") symlinkSync(real, join(bin, tool));
+    if (real !== "" && !existsSync(join(bin, tool))) symlinkSync(real, join(bin, tool));
   }
   mkdirSync(join(home, ".claude"), { recursive: true });
   const settingsPath = join(home, ".claude", "settings.json");
   if (settingsContent !== null) writeFileSync(settingsPath, settingsContent);
 
-  spawnSync("sh", ["-c", settingsShell()], {
-    env: { HOME: home, PATH: `${bin}:/bin` },
+  // 必须用绝对路径起 shell：PATH 被收窄成只有 bin 之后，Node 会用同一个 PATH 去找
+  // "sh" 本身而找不到，进程根本不启动——那样「损坏输入原文不变」会变成假阳性
+  // （什么都没执行，文件当然没变）。起不来直接抛，不让测试静默失效。
+  const run = spawnSync("/bin/sh", ["-c", settingsShell()], {
+    env: { HOME: home, PATH: bin },
     encoding: "utf8",
   });
+  if (run.error !== undefined) throw run.error;
 
-  return {
-    home,
-    settingsPath,
-    after: existsSync(settingsPath) ? readFileSync(settingsPath, "utf8") : null,
-    leftovers: readdirSync(join(home, ".claude")).filter((f) => f.includes(".tmp")),
-  };
+  try {
+    return {
+      home,
+      settingsPath,
+      after: existsSync(settingsPath) ? readFileSync(settingsPath, "utf8") : null,
+      leftovers: readdirSync(join(home, ".claude")).filter((f) => f.includes(".tmp")),
+    };
+  } finally {
+    // 每个用例都建一个 fake HOME，不清理会堆成 GB 级垃圾（本机实测把盘写满过）。
+    rmSync(home, { recursive: true, force: true });
+  }
 }
 
 const BROKEN = '{"model":"opus","permissions":{"allow":["Bash"]}';

--- a/web/src/lib/joinPack.settings.test.ts
+++ b/web/src/lib/joinPack.settings.test.ts
@@ -1,0 +1,123 @@
+// 接入包写 ~/.claude/settings.json 那段 shell 的**执行级**测试。
+//
+// 为什么必须真跑 shell：joinPack.test.ts 里的 `toContain("crossSessionInbound")` 之类断言，
+// 会被中英文 i18n 注释文案独自满足——把三个写入分支整段删掉，那些断言照样全绿。
+// 于是「node 分支解析失败会把用户整份 settings.json 覆盖掉」这种数据销毁，
+// 在设计上就不可能被看见。这里在 fake HOME + 受控 PATH 下实际执行生成的片段。
+import { describe, expect, it } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, existsSync, symlinkSync, readdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { lookup } from "../i18n/dict";
+import type { TFunc } from "../i18n/useT";
+import { buildJoinPack } from "./joinPack";
+
+const t: TFunc = (key, vars) => {
+  const raw = lookup("zh", key) ?? lookup("en", key) ?? key;
+  if (vars === undefined) return raw;
+  return raw.replace(/\{(\w+)\}/g, (m, name: string) => (name in vars ? String(vars[name]) : m));
+};
+
+/** 从完整接入包里切出设置 crossSessionInbound 的那段 shell（含备份与三分支）。 */
+function settingsShell(): string {
+  const pack = buildJoinPack("interactive", {
+    slug: "demo",
+    agentName: "tester",
+    agentToken: "tok",
+    server: "https://example.invalid",
+    inviterName: "inviter",
+    charter: null,
+    harness: "claude",
+    t,
+  });
+  const lines = pack.split("\n");
+  const start = lines.findIndex((l) => l.includes("AGENTPARTY_CC_SETTINGS="));
+  const end = lines.findIndex((l, i) => i > start && l.trim() === "fi");
+  expect(start).toBeGreaterThan(-1);
+  expect(end).toBeGreaterThan(start);
+  // 只保留可执行行（去掉 # 注释），避免注释里的字样干扰。
+  return lines
+    .slice(start, end + 1)
+    .filter((l) => !l.trimStart().startsWith("#"))
+    .join("\n");
+}
+
+/** 只让指定工具在 PATH 中可见，用来单独驱动 jq / node / python3 三个分支。 */
+function runWithTools(settingsContent: string | null, tools: string[]): {
+  home: string;
+  settingsPath: string;
+  after: string | null;
+  leftovers: string[];
+} {
+  const home = mkdtempSync(join(tmpdir(), "ap-settings-"));
+  const bin = join(home, "bin");
+  mkdirSync(bin);
+  for (const tool of tools) {
+    const real = spawnSync("sh", ["-c", `command -v ${tool}`], { encoding: "utf8" }).stdout.trim();
+    if (real !== "") symlinkSync(real, join(bin, tool));
+  }
+  mkdirSync(join(home, ".claude"), { recursive: true });
+  const settingsPath = join(home, ".claude", "settings.json");
+  if (settingsContent !== null) writeFileSync(settingsPath, settingsContent);
+
+  spawnSync("sh", ["-c", settingsShell()], {
+    env: { HOME: home, PATH: `${bin}:/bin` },
+    encoding: "utf8",
+  });
+
+  return {
+    home,
+    settingsPath,
+    after: existsSync(settingsPath) ? readFileSync(settingsPath, "utf8") : null,
+    leftovers: readdirSync(join(home, ".claude")).filter((f) => f.includes(".tmp")),
+  };
+}
+
+const BROKEN = '{"model":"opus","permissions":{"allow":["Bash"]}';
+const VALID = JSON.stringify({ model: "opus", permissions: { allow: ["Bash"] } }, null, 2);
+
+for (const tool of ["jq", "node", "python3"] as const) {
+  const available = spawnSync("sh", ["-c", `command -v ${tool}`]).status === 0;
+  const maybe = available ? describe : describe.skip;
+
+  maybe(`settings 写入分支：${tool}`, () => {
+    it("合法配置：写入 accept 且不动其他键", () => {
+      const { after } = runWithTools(VALID, [tool]);
+      const parsed = JSON.parse(after ?? "{}");
+      expect(parsed.crossSessionInbound).toBe("accept");
+      // 用户既有设置必须原样保留。
+      expect(parsed.model).toBe("opus");
+      expect(parsed.permissions).toEqual({ allow: ["Bash"] });
+    });
+
+    it("损坏配置：保持原文不动，绝不覆盖用户数据", () => {
+      const { after } = runWithTools(BROKEN, [tool]);
+      // 这是本文件存在的理由：node 分支曾在解析失败时把整份配置写成
+      // {"crossSessionInbound":"accept"}，用户的 model/permissions 全部消失。
+      expect(after).toBe(BROKEN);
+    });
+
+    it("文件不存在：初始化后写入 accept", () => {
+      const { after } = runWithTools(null, [tool]);
+      expect(JSON.parse(after ?? "{}").crossSessionInbound).toBe("accept");
+    });
+
+    it("空文件：不崩坏——要么留空要么是合法 JSON", () => {
+      const { after } = runWithTools("", [tool]);
+      if ((after ?? "").trim() !== "") expect(() => JSON.parse(after ?? "")).not.toThrow();
+    });
+
+    it("不留 .tmp 残留（成功与失败两种输入）", () => {
+      expect(runWithTools(VALID, [tool]).leftovers).toEqual([]);
+      expect(runWithTools(BROKEN, [tool]).leftovers).toEqual([]);
+    });
+  });
+}
+
+describe("settings 写入分支：无可用工具", () => {
+  it("整步跳过，不创建也不破坏配置", () => {
+    const { after } = runWithTools(VALID, []);
+    expect(after).toBe(VALID);
+  });
+});

--- a/web/src/lib/joinPack.ts
+++ b/web/src/lib/joinPack.ts
@@ -153,9 +153,9 @@ export function buildFullJoinPack(input: FullJoinPackInput): string {
           // 否则真正的原始设置就永远找不回来了。
           `[ -f "$AGENTPARTY_CC_SETTINGS.agentparty.bak" ] || cp "$AGENTPARTY_CC_SETTINGS" "$AGENTPARTY_CC_SETTINGS.agentparty.bak" || true`,
           `if command -v jq >/dev/null 2>&1; then`,
-          `  jq '.crossSessionInbound = "accept"' "$AGENTPARTY_CC_SETTINGS" > "$AGENTPARTY_CC_SETTINGS.agentparty.tmp" && mv "$AGENTPARTY_CC_SETTINGS.agentparty.tmp" "$AGENTPARTY_CC_SETTINGS" || true`,
+          `  jq '.crossSessionInbound = "accept"' "$AGENTPARTY_CC_SETTINGS" > "$AGENTPARTY_CC_SETTINGS.agentparty.tmp" && mv "$AGENTPARTY_CC_SETTINGS.agentparty.tmp" "$AGENTPARTY_CC_SETTINGS" || rm -f "$AGENTPARTY_CC_SETTINGS.agentparty.tmp"`,
           `elif command -v node >/dev/null 2>&1; then`,
-          `  node -e 'const fs=require("fs"),f=process.argv[1];let j={};try{j=JSON.parse(fs.readFileSync(f,"utf8"))||{}}catch(e){j={}};j.crossSessionInbound="accept";fs.writeFileSync(f,JSON.stringify(j,null,2)+"\\n")' "$AGENTPARTY_CC_SETTINGS" || true`,
+          `  node -e 'const fs=require("fs"),f=process.argv[1];const raw=fs.readFileSync(f,"utf8");const j=raw.trim()===""?{}:JSON.parse(raw);if(typeof j!=="object"||j===null||Array.isArray(j))process.exit(1);j.crossSessionInbound="accept";fs.writeFileSync(f,JSON.stringify(j,null,2)+"\\n")' "$AGENTPARTY_CC_SETTINGS" || true`,
           `elif command -v python3 >/dev/null 2>&1; then`,
           `  python3 -c 'import json,sys;f=sys.argv[1];d=json.load(open(f)) if open(f).read().strip() else {};d["crossSessionInbound"]="accept";json.dump(d,open(f,"w"),indent=2)' "$AGENTPARTY_CC_SETTINGS" || true`,
           `fi`,


### PR DESCRIPTION
## 严重度：高（已随 v0.2.190 发布到线上）

#856 的接入包三级兜底里，**只有 node 分支有破坏性**：

```js
let j={};try{j=JSON.parse(fs.readFileSync(f,"utf8"))||{}}catch(e){j={}};
j.crossSessionInbound="accept";fs.writeFileSync(f,...)   // ← 解析失败也照写
```

同一份损坏输入 `{"model":"opus","permissions":{"allow":["Bash"]}` 的三分支实测：

| 分支 | 文件结果 |
|---|---|
| jq | 原文保留（`&&` 短路，mv 不执行） |
| **node** | **`{"crossSessionInbound":"accept"}`——model/permissions 全丢** |
| python3 | 原文保留（json.load 抛异常） |

**为什么危险**：接入包是每个新 agent 上线必跑的东西、写的是真实 $HOME 配置、`|| true` 吞掉唯一失败信号、备份 `[ -f bak ] || cp` 首次写入即定（用户几个月后再跑时 bak 已是过期快照）。静默且不可恢复。

## 修复
- node 分支去 try/catch，解析失败自然非零退出、原文件不动；顶层非对象也拒绝。
- jq 分支失败清理 `.agentparty.tmp` 残留。

## 测试（这次补的是真正的缺口）
原 `joinPack.test.ts` 的 `toContain("crossSessionInbound")` 等断言**由中英文 i18n 注释文案独自满足**——把三个写入分支整段删掉，那些断言照样全绿，所以这类数据销毁在设计上就不可能被看见。

新增 `joinPack.settings.test.ts` 在 fake HOME + 受控 PATH 下**实际执行生成的 shell**：jq/node/python3/无工具 × 合法/损坏/空/不存在，断言「损坏输入必须原文不动」「合法输入保留 model/permissions」「无 .tmp 残留」。16 pass。

发现者：另一 Claude 会话的门禁 review（事后审计，#856 已合并）。