### PR TITLE
fix(cli): announce 连接改从频道最新 seq 起，不再重放整个历史才唤醒（#869 第 1 层）

### DIFF
--- a/cli/src/commands/claude-channel.ts
+++ b/cli/src/commands/claude-channel.ts
@@ -49,7 +49,14 @@ import {
 } from "../delivery-recovery-journal";
 import { acquireInstanceLock, defaultInstanceLockDir, instanceLockTarget } from "../instance-lock";
 import { resolveAuthDetailed } from "../oidc-cli";
-import { fetchMe, fetchMessages, fetchPresence, fetchRuntimePeers, postMessage } from "../rest";
+import {
+  fetchMe,
+  fetchMessages,
+  fetchPresence,
+  fetchRecentMessages,
+  fetchRuntimePeers,
+  postMessage,
+} from "../rest";
 import { isName, isSlug } from "../validation";
 import { buildRuntimeTopology } from "../runtime-topology";
 import {
@@ -470,7 +477,17 @@ export interface DormantAnnounceDeps {
   resolveAuth: () => Promise<{ server?: string | null; token?: string | null }>;
   connect: typeof connect;
   buildTopology: typeof buildRuntimeTopology;
-  loadCursor: (channel: string) => number;
+  /**
+   * announce 连接的**起始游标**（#869）。announce 只关心「连上之后的新消息」，
+   * 所以它必须是频道当前最新 seq，绝不能是持久化游标（新身份恒为 0 → 连上要把
+   * 整个频道历史重放完才够得着 live 帧，唤醒功能形同虚设，且失败是静默的）。
+   * 返回 null＝这一轮拿不到起点，本轮不建连（宁可不宣告，也不退回 0）。
+   * 默认 announceStartCursor。
+   */
+  resolveStartCursor?: (
+    channel: string,
+    auth: { server: string; token: string },
+  ) => Promise<number | null>;
   cwd?: string;
   pollIntervalMs?: number;
   livenessIntervalMs?: number;
@@ -520,6 +537,47 @@ export async function resolveAnnounceChannelIdentity(
   } catch {
     return null;
   }
+}
+
+/**
+ * announce 连接的起始游标（#869）：频道当前最新 seq，即「从现在起的新消息」。
+ *
+ * 为什么不是 loadCursor：announce 是 announce-only 连接，它既不推进也不消费持久化
+ * 游标；新接入身份的持久化游标恒为 0，用它建连＝要求服务端重放整个频道历史（实测
+ * 1884 条，30 秒只爬到 seq 16），live 的 @ 根本够不着。
+ *
+ * 为什么不用 Number.MAX_SAFE_INTEGER 这类「只要 live」哨兵：hello.since 在客户端
+ * 同时被当作初始 cursor，`seq <= cursor` 的帧一律丢弃——哨兵会把真正的 live 帧也丢光。
+ * 服务端 hello 协议目前也没有 live-only 语义（worker 只做 `since > 0 ? floor : 0`）。
+ *
+ * 代价是启动时一次 limit=1 的 REST 尾拉，与本就存在的身份解析同量级，不引入可感延迟。
+ * 附带好处：helloSince 落在最新 seq 上，announce 这条无 directedDelivery 的连接不会被
+ * 服务端当成 legacy delivery 消费方去认领历史欠账（P2 不变式）。
+ */
+export async function announceStartCursor(
+  channel: string,
+  auth: { server: string; token: string },
+): Promise<number | null> {
+  try {
+    const tail = await fetchRecentMessages(auth.server, auth.token, channel, 1);
+    const last = tail.at(-1);
+    // 空频道 → 0 就是正确起点（没有历史可重放）。
+    return typeof last?.seq === "number" ? last.seq : 0;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 服务端补拉/重放帧的判据（#869 第 2 层的判定钩子）。
+ *
+ * TODO(#861/#869 第 2 层)：#861 正在给服务端的补拉帧加 `replay` 标记（重放帧与 live 帧
+ * 目前在 wire 上逐字节相同，客户端无从分辨）。标记落地后本函数即刻生效——重连窗口内难免
+ * 收到的重放帧一律不注入，避免老身份重连时历史里的每条 @ 都触发一次唤醒。协议类型由 #861
+ * 在 shared/src/protocol.ts 里补，本切片只做结构化读取，不抢改协议文件。
+ */
+export function dormantAnnounceIsReplayFrame(frame: unknown): boolean {
+  return (frame as { replay?: unknown } | null)?.replay === true;
 }
 
 /** 注入去重表容量上限：只留最近 N 个 seq，防长跑进程内存无界。 */
@@ -601,10 +659,21 @@ export async function runDormantClaudeSessionAnnounce(
       },
     });
     if (topology === undefined) return;
+    // 起点＝频道当前最新 seq（#869）。拿不到就本轮不建连，稍候重试——绝不退回持久化
+    // 游标/0，那等于把唤醒埋进一整段历史重放里静默失效。
+    const startCursor = await (deps.resolveStartCursor ?? announceStartCursor)(channel, {
+      server: auth.server,
+      token: auth.token,
+    }).catch(() => null);
+    if (signal.aborted) return;
+    if (startCursor === null) {
+      await abortableSleep(pollMs, signal);
+      continue;
+    }
     // 只声明 runtimeTopology：无 directedDelivery / deliveryRecovery /
     // advertiseWakeKind / onCursor——服务端不会给这条连接派任何 delivery，
     // 消费到的普通消息只本地 ack（防积压），绝不推进持久化游标。
-    const connection = deps.connect(auth.server, auth.token, channel, deps.loadCursor(channel), {
+    const connection = deps.connect(auth.server, auth.token, channel, startCursor, {
       runtimeTopology: topology,
     });
     // 「叫我」的判据＝本机频道身份（不是宣告名，见上方三命名空间注释）。解析失败
@@ -629,8 +698,12 @@ export async function runDormantClaudeSessionAnnounce(
       seq: number,
       mentions: readonly string[] | undefined,
       sender: MsgFrame["sender"] | undefined,
+      frame: unknown,
     ) => {
       try {
+        // 重放帧一律不注入（#869 第 2 层；标记由 #861 在服务端补上，见
+        // dormantAnnounceIsReplayFrame）。放在最前面：重放的历史 @ 连去重表都不该占。
+        if (dormantAnnounceIsReplayFrame(frame)) return;
         if (!dormantAnnounceMentionHit(mentions, selfName)) return;
         if (injectedSeqs.has(seq)) return;
         injectedSeqs.add(seq);
@@ -687,7 +760,7 @@ export async function runDormantClaudeSessionAnnounce(
           connection.ack(frame.seq);
           // 注意顺序：先 ack 再注入。ack 只是本地防积压（绝不推进持久化游标、绝不
           // claim delivery，见上方 P2 不变式），注入失败也不该影响 ack。
-          if (frame.type === "msg") await maybeInject(frame.seq, frame.mentions, frame.sender);
+          if (frame.type === "msg") await maybeInject(frame.seq, frame.mentions, frame.sender, frame);
         }
         if (frame.type === "error") return;
       }
@@ -724,7 +797,6 @@ async function runDormantClaudeChannelMcp(channel: string | null): Promise<numbe
         resolveAuth: resolveAuthDetailed,
         connect,
         buildTopology: buildRuntimeTopology,
-        loadCursor,
       }).catch(() => {});
   try {
     await server.connect(new StdioServerTransport());

--- a/cli/test/claude-channel-dormant-announce.test.ts
+++ b/cli/test/claude-channel-dormant-announce.test.ts
@@ -4,6 +4,7 @@ import type { ClaudeSessionRegistryEntry } from "../src/claude-session-registry"
 import {
   dormantAnnounceDisplayName,
   dormantAnnounceMentionHit,
+  dormantAnnounceIsReplayFrame,
   runDormantClaudeSessionAnnounce,
   selectDormantAnnounceEntry,
   type DormantAnnounceDeps,
@@ -101,7 +102,8 @@ function makeDeps(overrides: Partial<DormantAnnounceDeps> = {}): {
       evidence: "client_asserted",
       ...(buildDeps?.harnessSession === undefined ? {} : { harness_session: buildDeps.harnessSession }),
     }),
-    loadCursor: () => 42,
+    // #869：起点＝频道当前最新 seq（不是持久化游标、更不是 0）。
+    resolveStartCursor: async () => 1884,
     // 默认给一个确定的频道身份：绝不让测试去读真实 config / 打 /api/me。
     resolveSelfName: async () => "lark-ad72b3f97491-agentparty",
     cwd: "/tmp/project",
@@ -146,7 +148,8 @@ describe("runDormantClaudeSessionAnnounce (#841 P2)", () => {
     const { connectArgs } = connections[0]!;
     expect(connectArgs.server).toBe("https://party.example");
     expect(connectArgs.slug).toBe("dev");
-    expect(connectArgs.since).toBe(42);
+    // #869：起始游标＝频道当前最新 seq，announce 只收「连上之后」的消息。
+    expect(connectArgs.since).toBe(1884);
     const opts = connectArgs.opts;
     // announce 档不认领 delivery：不声明任何 delivery/wake 能力，也不持久化游标。
     expect(opts.directedDelivery).toBeUndefined();
@@ -232,6 +235,59 @@ function msg(seq: number, mentions: string[]): ServerFrame {
 
 const SELF = "lark-ad72b3f97491-agentparty";
 
+describe("announce 起始游标 (#869)", () => {
+  test("按频道当前最新 seq 起，绝不是 0、也不来自持久化游标", async () => {
+    const persisted = 0; // 新接入身份的持久化游标恒为 0——正是本 bug 的现场。
+    const { deps, connections } = makeDeps({ resolveStartCursor: async () => 1884 });
+    // announce 档根本不该有「读持久化游标」这条依赖。
+    expect("loadCursor" in (deps as unknown as Record<string, unknown>)).toBe(false);
+    const abort = new AbortController();
+    const done = runDormantClaudeSessionAnnounce("dev", abort.signal, deps);
+    await tick();
+    expect(connections).toHaveLength(1);
+    const { since, opts } = {
+      since: connections[0]!.connectArgs.since,
+      opts: connections[0]!.connectArgs.opts,
+    };
+    expect(since).not.toBe(0);
+    expect(since).not.toBe(persisted);
+    expect(since).toBe(1884);
+    // 起点已是最新 seq → 历史帧（seq <= since）被客户端丢弃，live 帧立刻可达。
+    connections[0]!.push(msg(1885, [SELF]));
+    await tick();
+    expect(connections[0]!.acked).toEqual([1885]);
+    // P2 不变式不因此破坏：不推进/不持久化游标、不 claim delivery、不发任何客户端帧。
+    expect(opts.onCursor).toBeUndefined();
+    expect(opts.directedDelivery).toBeUndefined();
+    expect(opts.deliveryRecovery).toBeUndefined();
+    expect(opts.advertiseWakeKind).toBeUndefined();
+    expect(connections[0]!.sent).toHaveLength(0);
+    abort.abort();
+    await done;
+  });
+
+  test("拿不到起点就不建连，稍候重试（绝不退回 0）", async () => {
+    let cursor: number | null = null;
+    const { deps, connections } = makeDeps({ resolveStartCursor: async () => cursor });
+    const abort = new AbortController();
+    const done = runDormantClaudeSessionAnnounce("dev", abort.signal, deps);
+    await tick();
+    expect(connections).toHaveLength(0);
+    cursor = 7;
+    await tick();
+    expect(connections).toHaveLength(1);
+    expect(connections[0]!.connectArgs.since).toBe(7);
+    abort.abort();
+    await done;
+  });
+
+  test("重放帧不注入（#869 第 2 层，标记由 #861 补）", async () => {
+    expect(dormantAnnounceIsReplayFrame({ type: "msg", seq: 1, replay: true })).toBe(true);
+    expect(dormantAnnounceIsReplayFrame({ type: "msg", seq: 1 })).toBe(false);
+    expect(dormantAnnounceIsReplayFrame(null)).toBe(false);
+  });
+});
+
 describe("dormantAnnounceMentionHit", () => {
   test("matches the channel identity case-insensitively and ignores everything else", () => {
     expect(dormantAnnounceMentionHit([SELF.toUpperCase()], SELF)).toBe(true);
@@ -294,6 +350,22 @@ describe("runDormantClaudeSessionAnnounce socket inject (#857)", () => {
     expect(connections[0]!.acked).toEqual([11, 12, 13]);
     expect(connections[0]!.sent).toHaveLength(0);
     expect(connections[0]!.connectArgs.opts.onCursor).toBeUndefined();
+    abort.abort();
+    await done;
+  });
+
+  test("带 replay 标记的历史帧不注入（#869 第 2 层）", async () => {
+    const { deps, connections, calls } = injectingDeps();
+    const abort = new AbortController();
+    const done = runDormantClaudeSessionAnnounce("dev", abort.signal, deps);
+    await tick();
+    connections[0]!.push({ ...(msg(40, [SELF]) as object), replay: true } as unknown as ServerFrame);
+    await tick();
+    expect(calls).toHaveLength(0);
+    // 同一条 seq 后续以 live 帧到达仍应注入（重放不该污染去重表）。
+    connections[0]!.push(msg(40, [SELF]));
+    await tick();
+    expect(calls).toHaveLength(1);
     abort.abort();
     await done;
   });


### PR DESCRIPTION
#869 **第 1 层（起始游标）**。第 2 层（重放帧不注入的实际生效）依赖 #861 给服务端补 `replay` 标记，随后跟进。

## 问题
`runDormantClaudeSessionAnnounce` 用 `deps.loadCursor(channel)` 建连接。新接入身份的持久化游标恒为 **0**，announce 连上后要把整个频道历史重放完才够得着 live 帧（实测 1884 条频道，30 秒只爬到 seq 16）——唤醒功能形同虚设，且失败是静默的。

## 改动
- announce 的起始游标改为**频道当前最新 seq**：新增 `announceStartCursor()`（一次 `limit=1` 的尾拉 REST），可经 `deps.resolveStartCursor` 注入。
- `DormantAnnounceDeps.loadCursor` **整条依赖删除**（call site 一并去掉）——announce 档不该有「读持久化游标」这个能力，删掉才不会再被误用。
- 拿不到起点 → 本轮**不建连**，`pollMs` 后重试；绝不退回 0/持久化游标（宁可短暂不宣告，也不把唤醒埋进一整段历史重放里静默失效）。
- P2 不变式原样保持：不声明 `directedDelivery` / `deliveryRecovery` / `advertiseWakeKind` / `onCursor`，不调 `saveCursor`，不发任何客户端帧，msg 仍只本地 ack。
- 第 2 层钩子：新增 `dormantAnnounceIsReplayFrame(frame)`，在 `maybeInject` 最前面短路（重放帧连去重表都不占）。TODO 注释指向 #861/#869 第 2 层；本切片**不碰** `worker/` 和 `shared/src/protocol.ts`。

### 为什么不用「只要 live」哨兵
读码确认：服务端 hello 没有 live-only 语义（`since = frame.since > 0 ? floor : 0`，补拉即 `seq > since`）；客户端 `connect()` 把 `since` 同时当初始 `cursor`，`seq <= cursor` 的帧一律丢弃——所以 `Number.MAX_SAFE_INTEGER` 之类哨兵会把真正的 live 帧也丢光。welcome 的 `last_seq` 到得太晚（hello 已发出、补拉已排好）。故取「一次 limit=1 尾拉」，与本就存在的身份解析同量级，无可感启动延迟。
附带收益：`helloSince` 落在最新 seq 上，announce 这条无 `directedDelivery` 的连接不会被服务端 `matchingLegacy`（`st.helloSince < message_seq`）当成 legacy delivery 消费方去认领历史欠账——`helloSince=0` 时反而有这个风险。

## 变异验证（按要求做了，确认新断言真会红）
1. 把 `connect(..., startCursor, ...)` 改回 `0` → **3 fail**：`since` 不为 0 的断言、`since === 1884`、以及「拿不到起点就不建连」用例（收到 0 而非 7）。
2. 删掉 `if (dormantAnnounceIsReplayFrame(frame)) return;` → **1 fail**：「带 replay 标记的历史帧不注入」。
两处都还原后 15 pass / 0 fail。

## 测试
`bun test test/claude-channel-dormant-announce.test.ts` → 15 pass, 0 fail, 64 expect。新增 4 个用例（起始游标非 0/非持久化游标 + P2 不变式、拿不到起点不建连、replay 帧不注入端到端、`dormantAnnounceIsReplayFrame` 单测）。`bunx tsc --noEmit` 干净；cli 全量 `bun test` 见 CI。

## 本机复验
零 serve/watch，装了插件的 idle 会话，从另一身份 @ 它 → 应**秒级**注入唤醒（不再等历史爬完）。
