### PR TITLE
fix(web,worker): 补拉帧不再冒充 live 帧弹通知，游标不回退到 0 (#861)

### DIFF
--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -246,7 +246,10 @@ function isMessageFrame(value: unknown): boolean {
     (value.retracted_by === undefined || typeof value.retracted_by === "string") &&
     (value.supersedes === undefined || isPositiveInteger(value.supersedes)) &&
     (value.superseded_by === undefined || isPositiveInteger(value.superseded_by)) &&
-    (value.rev_seq === undefined || isPositiveInteger(value.rev_seq));
+    (value.rev_seq === undefined || isPositiveInteger(value.rev_seq)) &&
+    // #861 hello 补拉标记。必须逐字镜像 shared/src/protocol.ts 的 MsgFrame.replay，
+    // 否则服务端一上线这个字段，CLI 就会把所有补拉帧判为非法而静默丢帧（#622 的教训）。
+    (value.replay === undefined || value.replay === true);
 }
 
 function isDirectedDelivery(value: unknown): boolean {

--- a/cli/test/replay-frame-allowlist.test.ts
+++ b/cli/test/replay-frame-allowlist.test.ts
@@ -1,0 +1,91 @@
+// #861 + #622：服务端给 hello 补拉帧加了 MsgFrame.replay。cli/src/client.ts 的 isMessageFrame
+// 是一份**手抄**的字段校验表——protocol.ts 加了字段而这里没跟上，CLI 不会报错，而是把整帧
+// 静默丢掉（#622 的教训，回执 #828 就走这条通道）。这里两头都守：
+//   ① 行为：带 replay:true 的补拉帧必须被投递给消费方，且字段保留；
+//   ② 镜像：protocol.ts 的 MsgFrame 每个字段名都必须在 client.ts 的校验器里出现。
+import { afterEach, describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import type { ServerFrame } from "@agentparty/shared";
+import { connect, type Connection } from "../src/client";
+import { msgFrame, startMockServer, welcomeFrame, type MockServer } from "./mock-server";
+
+let server: MockServer | null = null;
+let conn: Connection | null = null;
+
+afterEach(() => {
+  conn?.close();
+  conn = null;
+  server?.stop();
+  server = null;
+});
+
+async function collect(c: Connection, n: number, timeoutMs = 3000): Promise<ServerFrame[]> {
+  const frames: ServerFrame[] = [];
+  const timer = setTimeout(() => c.close(), timeoutMs);
+  for await (const f of c.frames) {
+    frames.push(f);
+    if (f.type === "msg") c.ack(f.seq);
+    if (frames.length >= n) break;
+  }
+  clearTimeout(timer);
+  return frames;
+}
+
+describe("#861 replay 字段 wire 兼容", () => {
+  test("带 replay:true 的补拉帧不被静默丢弃，字段原样透出", async () => {
+    server = startMockServer((frame, sock) => {
+      if (frame.type !== "hello") return;
+      sock.send(welcomeFrame(2));
+      sock.send({ ...msgFrame(1, "老的 @ 重放"), replay: true });
+      sock.send(msgFrame(2, "真的新消息"));
+    });
+    conn = connect(server.url, "ap_tok", "dev", 0, { backoffBaseMs: 20 });
+    const frames = await collect(conn, 3);
+    const msgs = frames.filter((f) => f.type === "msg") as Array<{ seq: number; body: string; replay?: true }>;
+    expect(msgs.map((m) => m.seq)).toEqual([1, 2]);
+    expect(msgs[0]!.replay).toBe(true);
+    expect(msgs[1]!.replay).toBeUndefined();
+  });
+
+  test("replay 只接受 true —— 任意其它取值判为非法帧", async () => {
+    server = startMockServer((frame, sock) => {
+      if (frame.type !== "hello") return;
+      sock.send(welcomeFrame(2));
+      sock.send({ ...msgFrame(1, "坏帧"), replay: "yes" });
+      sock.send(msgFrame(2, "好帧"));
+    });
+    conn = connect(server.url, "ap_tok", "dev", 0, { backoffBaseMs: 20 });
+    const frames = await collect(conn, 2);
+    const msgs = frames.filter((f) => f.type === "msg") as Array<{ seq: number }>;
+    expect(msgs.map((m) => m.seq)).toEqual([2]);
+  });
+});
+
+describe("#622 allow-list 逐字镜像守卫", () => {
+  test("protocol.ts 的 MsgFrame 每个字段名都出现在 cli 的 isMessageFrame 校验器里", () => {
+    const protocolSrc = readFileSync(new URL("../../shared/src/protocol.ts", import.meta.url), "utf8");
+    const clientSrc = readFileSync(new URL("../src/client.ts", import.meta.url), "utf8");
+
+    const start = protocolSrc.indexOf("export interface MsgFrame {");
+    expect(start).toBeGreaterThan(-1);
+    const end = protocolSrc.indexOf("\n}", start);
+    const block = protocolSrc.slice(start, end);
+    const fields = [...block.matchAll(/^\s{2}(\w+)\??:/gm)].map((m) => m[1]!);
+    expect(fields).toContain("replay");
+    expect(fields).toContain("rev_seq");
+
+    const validatorStart = clientSrc.indexOf("function isMessageFrame(");
+    expect(validatorStart).toBeGreaterThan(-1);
+    const validator = clientSrc.slice(validatorStart, clientSrc.indexOf("\n}", validatorStart));
+
+    // 已知的「结构化子对象」字段：校验器不逐字段展开它们（与现状一致），豁免但显式列出，
+    // 新增字段默认必须被镜像，逼着改 protocol.ts 的人一起改 client.ts。
+    const structured = new Set([
+      "workflow_ref", "role", "role_source", "completion_artifact", "completion_review",
+      "decision_request", "decision_resolution", "decision_response", "attachments",
+      "response_source", "receipts", "revision",
+    ]);
+    const missing = fields.filter((f) => !structured.has(f) && !validator.includes(`value.${f}`));
+    expect(missing).toEqual([]);
+  });
+});

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -1650,6 +1650,14 @@ export interface MsgFrame {
   superseded_by?: number;
   /** 该消息最近一次修订的单调序号；客户端据此推进修订游标（hello.since_rev） */
   rev_seq?: number;
+  /**
+   * hello 补拉（历史重放）标记（#861）。服务端只在 hello.since/since_rev 补拉循环里打上，
+   * live 广播永不携带。客户端据此把「重放的老消息」与「真的新消息」区分开——否则重连时
+   * 一条 10 天前的 @ 会以 live 帧身份触发系统通知。
+   * 可选字段：旧客户端忽略即可正常工作；新客户端见 undefined 时按 live 处理（旧服务端语义）。
+   * 注意：`cli/src/client.ts` 的 isMessageFrame 校验必须逐字镜像本字段（#622 教训）。
+   */
+  replay?: true;
   revision?: {
     original_body: string | null;
   };

--- a/web/src/components/MentionToast.tsx
+++ b/web/src/components/MentionToast.tsx
@@ -8,6 +8,7 @@ import {
   resolveSenderLabel,
   type IdentityDisplayMap,
 } from "../lib/identityDisplay";
+import { fmtTime } from "../lib/time";
 import { useT } from "../i18n/useT";
 import "../i18n/strings/Channel";
 import "../i18n/strings/MessageCard";
@@ -17,6 +18,7 @@ export interface MentionToastItem {
   sender: Sender; // 原始发送者，渲染时经 resolveSenderLabel 解析显示名，保证与消息卡一致
   body: string;   // 已截断的正文预览
   fullBody?: string; // #280：完整正文，挂到 title 上供悬停看全文（缺省回退到 body）
+  ts?: number; // #861：消息**自身**的时间。提醒里必须打出来，否则「通知时间 ≠ @ 时间」无从发现
 }
 
 interface Props {
@@ -65,6 +67,7 @@ function ToastCard({
         <span className="mention-toast-title">
           <span className="ap-sprite ap-sprite--bell-on" aria-hidden="true" />
           <span>{t("Channel.toast.title", { sender: senderLabel, channel })}</span>
+          {item.ts !== undefined && <time className="t-mono mention-toast-time">{fmtTime(item.ts)}</time>}
         </span>
         <button
           type="button"
@@ -120,6 +123,7 @@ export function MentionHeaderNotice({ items, channel, identityDisplay, onJump, o
       >
         <span className="ap-sprite ap-sprite--bell-on" aria-hidden="true" />
         <span className="mention-header-title">{t("Channel.toast.title", { sender: senderLabel, channel })}</span>
+        {item.ts !== undefined && <time className="t-mono mention-header-time">{fmtTime(item.ts)}</time>}
         {items.length > 1 && <span className="t-mono mention-header-count">+{items.length - 1}</span>}
       </button>
       <button

--- a/web/src/i18n/strings/Channel.loading.source.test.ts
+++ b/web/src/i18n/strings/Channel.loading.source.test.ts
@@ -93,7 +93,11 @@ describe("Channel loading and recovery surfaces (#344 #345 #346 #354)", () => {
     expect(channelSource).toContain("const loadInitialPage = useCallback");
     expect(channelSource).toContain("onClick={loadInitialPage}");
     expect(channelSource).toContain("hasMoreRef.current = true");
-    expect(channelSource).toContain("initialCursorRef.current = 0");
+    // #861：游标**不再**被重置成 0。这条曾断言 `initialCursorRef.current = 0`，而那正是缺陷本身——
+    // token 静默续期时 ws effect 会读到清 0 的 ref，以 since=0 建 socket，服务端把整段历史当 live
+    // 帧重放。分页 ref 的复位由 hasMoreRef/olderStatus 承担，游标只单调前进。
+    expect(channelSource).not.toMatch(/initialCursorRef\.current\s*=\s*0\s*;/);
+    expect(channelSource).toContain('setOlderStatus("idle")');
     expect(channelSource).toContain('t("Channel.history.retry")');
     expect(channelSource).toContain('tRef.current("Channel.history.loadFailed")');
   });

--- a/web/src/lib/notify.replay.test.ts
+++ b/web/src/lib/notify.replay.test.ts
@@ -1,0 +1,197 @@
+// #861 回归：8 月 6 日弹出 7 月 27 日的老 @。socket 重建时游标被重新播种成 0，
+// 服务端把整段历史当 live 帧重放，客户端弹窗判据又不做任何新鲜度检查。
+//
+// 这个文件把 issue 里那条「可直接写成断言」的失败场景逐字复刻：真的 ChannelSocket
+// （initialCursor: 0）+ 真的服务端补拉帧 + 真的 shouldNotify/shouldToast/nextMentionBadgeCount，
+// 断言 seq 143 一次通知都不产生，而真正的 live 新帧照弹。
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import type { MsgFrame, ServerFrame } from "@agentparty/shared";
+import { ChannelSocket } from "./ws";
+import {
+  MENTION_ALERT_MAX_AGE_MS,
+  isFreshDelivery,
+  nextMentionBadgeCount,
+  shouldNotify,
+  shouldToast,
+} from "./notify";
+
+// ── issue 里的真实数据 ───────────────────────────────────────────────
+const SEQ_143_TS = 1785134587385; // 2026-07-27 15:43:07
+const NOW = 1785999999999; // 2026-08-06，比 seq 143 晚 10 天
+const SELF_HANDLE = "Evan";
+
+function historyFrame(seq: number, over: Partial<MsgFrame> = {}): MsgFrame {
+  return {
+    type: "msg",
+    seq,
+    sender: { name: "lark-b8d1411d3513", kind: "human" },
+    kind: "message",
+    body: `m${seq}`,
+    mentions: [],
+    reply_to: null,
+    state: null,
+    note: null,
+    status: null,
+    ts: SEQ_143_TS,
+    ...over,
+  } as MsgFrame;
+}
+
+const seq143 = (over: Partial<MsgFrame> = {}): MsgFrame =>
+  historyFrame(143, { mentions: [SELF_HANDLE], body: "@Evan 接口报错验证失败…", ...over });
+
+// ── 最小 WebSocket 桩 ────────────────────────────────────────────────
+class FakeSocket {
+  static instances: FakeSocket[] = [];
+  static OPEN = 1;
+  readyState = 0;
+  onopen: (() => void) | null = null;
+  onmessage: ((ev: { data: unknown }) => void) | null = null;
+  onclose: ((ev: { code: number; reason: string }) => void) | null = null;
+  sent: string[] = [];
+  constructor(public url: string, public protocols?: string[]) {
+    FakeSocket.instances.push(this);
+  }
+  send(data: string) { this.sent.push(data); }
+  close() { this.readyState = 3; }
+  open() { this.readyState = FakeSocket.OPEN; this.onopen?.(); }
+  deliver(frame: ServerFrame) { this.onmessage?.({ data: JSON.stringify(frame) }); }
+  hello(): { type: string; since: number; since_rev?: number } {
+    const raw = this.sent.map((s) => JSON.parse(s) as { type: string });
+    const h = raw.find((f) => f.type === "hello");
+    if (h === undefined) throw new Error("no hello sent");
+    return h as { type: string; since: number };
+  }
+}
+
+const originalWebSocket = Object.getOwnPropertyDescriptor(globalThis, "WebSocket");
+const originalWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+const originalLocation = Object.getOwnPropertyDescriptor(globalThis, "location");
+
+beforeEach(() => {
+  FakeSocket.instances = [];
+  Object.defineProperty(globalThis, "WebSocket", { configurable: true, writable: true, value: FakeSocket });
+  Object.defineProperty(globalThis, "location", {
+    configurable: true, writable: true,
+    value: { protocol: "https:", host: "party.example", origin: "https://party.example" },
+  });
+  Object.defineProperty(globalThis, "window", {
+    configurable: true, writable: true,
+    value: { setInterval: () => 0, clearInterval: () => {}, setTimeout: () => 0, clearTimeout: () => {}, location: globalThis.location },
+  });
+});
+afterEach(() => {
+  for (const [key, desc] of [["WebSocket", originalWebSocket], ["window", originalWindow], ["location", originalLocation]] as const) {
+    if (desc === undefined) Reflect.deleteProperty(globalThis, key);
+    else Object.defineProperty(globalThis, key, desc);
+  }
+});
+
+/**
+ * 驱动一条真实 ChannelSocket，把服务端投来的每一帧过一遍真实的三个提醒判据。
+ * 返回 issue 场景下的通知/toast/角标计数。
+ */
+function driveSocket(opts: {
+  initialCursor: number;
+  frames: ServerFrame[];
+  documentHidden: boolean;
+  now: number;
+}): { notified: number[]; toasted: number[]; badge: number; helloSince: number } {
+  const notified: number[] = [];
+  const toasted: number[] = [];
+  let badge = 0;
+  const sock = new ChannelSocket("seamail", "tok", {
+    onFrame: (frame) => {
+      if (frame.type !== "msg") return;
+      if (shouldNotify(frame, SELF_HANDLE, opts.documentHidden, true, null, opts.now)) notified.push(frame.seq);
+      if (shouldToast(frame, SELF_HANDLE, opts.documentHidden, true, null, opts.now)) toasted.push(frame.seq);
+      badge = nextMentionBadgeCount(badge, frame, SELF_HANDLE, opts.documentHidden, null, opts.now);
+    },
+    onStatus: () => {},
+    onFatal: () => {},
+  }, { initialCursor: opts.initialCursor });
+  sock.connect();
+  const ws = FakeSocket.instances[FakeSocket.instances.length - 1]!;
+  ws.open();
+  ws.deliver({ type: "welcome", participants: [], last_rev_seq: 0 } as unknown as ServerFrame);
+  const helloSince = ws.hello().since;
+  for (const frame of opts.frames) ws.deliver(frame);
+  sock.dispose();
+  return { notified, toasted, badge, helloSince };
+}
+
+// ── issue 的核心失败场景 ────────────────────────────────────────────
+test("#861: socket 以 initialCursor 0 重建、服务端回放含 seq 143 的历史 → 不弹通知/toast/角标", () => {
+  // 已加载窗口 seq 141..190；服务端对 hello{since:0} 回放全量历史（带 replay 标记）
+  const replayed: ServerFrame[] = [];
+  for (let seq = 100; seq <= 190; seq++) {
+    replayed.push(seq === 143 ? seq143({ replay: true }) : historyFrame(seq, { replay: true }));
+  }
+  const hidden = driveSocket({ initialCursor: 0, frames: replayed, documentHidden: true, now: NOW });
+  expect(hidden.notified).toEqual([]);
+  expect(hidden.badge).toBe(0);
+
+  // 标签页聚焦时的页内 toast 走同一判据，同样不该弹
+  const focused = driveSocket({ initialCursor: 0, frames: replayed, documentHidden: false, now: NOW });
+  expect(focused.toasted).toEqual([]);
+});
+
+test("#861 兜底：服务端还没上线 replay 标记时，光凭帧自身 ts 也不弹 10 天前的老 @", () => {
+  const legacyReplay = [seq143()]; // 没有 replay 字段，逐字节等同 live 帧
+  const out = driveSocket({ initialCursor: 0, frames: legacyReplay, documentHidden: true, now: NOW });
+  expect(out.notified).toEqual([]);
+  expect(out.badge).toBe(0);
+});
+
+// ── 对照：真的新消息必须照常弹 ──────────────────────────────────────
+test("对照：真正的 live 新帧仍然正常弹通知 / toast / 角标", () => {
+  const liveMention = seq143({ seq: 241, ts: NOW - 1_000 }); // 无 replay、刚发出
+  const hidden = driveSocket({ initialCursor: 190, frames: [liveMention], documentHidden: true, now: NOW });
+  expect(hidden.notified).toEqual([241]);
+  expect(hidden.badge).toBe(1);
+
+  const focused = driveSocket({ initialCursor: 190, frames: [liveMention], documentHidden: false, now: NOW });
+  expect(focused.toasted).toEqual([241]);
+});
+
+test("对照：短暂掉线后补投的 live 帧（阈值内）照弹——重连退避上限只有 30s，5 分钟窗口留足余量", () => {
+  const nearlyFresh = seq143({ seq: 242, ts: NOW - (MENTION_ALERT_MAX_AGE_MS - 1_000) });
+  const out = driveSocket({ initialCursor: 190, frames: [nearlyFresh], documentHidden: true, now: NOW });
+  expect(out.notified).toEqual([242]);
+});
+
+// ── 游标不回退 ──────────────────────────────────────────────────────
+test("#861: 重建 socket 时带着已见水位重连，hello.since 不是 0", () => {
+  // 初始页停在 190、live 推进到 220 后重建 → hello.since 必须是 220
+  const out = driveSocket({ initialCursor: 220, frames: [], documentHidden: true, now: NOW });
+  expect(out.helloSince).toBe(220);
+});
+
+// 隔离第 A 层（服务端 replay 标记）：帧本身很新，只有 replay 标记能挡住它。
+// 场景：断线 1 分钟后重连，服务端把断线窗口里那条 @ 补拉回来——它已经在 live 广播时被
+// 处理过，补拉不该再打扰一次。
+test("#861: 补拉帧即使 ts 很新也不弹——只靠新鲜度兜底是不够的", () => {
+  const freshReplay = seq143({ seq: 191, ts: NOW - 60_000, replay: true });
+  const hidden = driveSocket({ initialCursor: 0, frames: [freshReplay], documentHidden: true, now: NOW });
+  expect(hidden.notified).toEqual([]);
+  expect(hidden.badge).toBe(0);
+
+  const focused = driveSocket({ initialCursor: 0, frames: [freshReplay], documentHidden: false, now: NOW });
+  expect(focused.toasted).toEqual([]);
+
+  // 同一条帧去掉 replay 标记就是 live 新消息，必须弹——证明上面的 false 来自标记本身，
+  // 而不是判据被整体劣化。
+  const asLive = seq143({ seq: 191, ts: NOW - 60_000 });
+  expect(driveSocket({ initialCursor: 0, frames: [asLive], documentHidden: true, now: NOW }).notified).toEqual([191]);
+});
+
+// ── 新鲜度判据本身 ─────────────────────────────────────────────────
+test("isFreshDelivery: replay 帧永不新鲜；ts 超阈值不新鲜；边界含等号；ts 缺失按新鲜（旧服务端）", () => {
+  expect(isFreshDelivery(seq143({ replay: true, ts: NOW }), NOW)).toBe(false);
+  expect(isFreshDelivery(seq143({ ts: NOW - MENTION_ALERT_MAX_AGE_MS }), NOW)).toBe(true);
+  expect(isFreshDelivery(seq143({ ts: NOW - MENTION_ALERT_MAX_AGE_MS - 1 }), NOW)).toBe(false);
+  expect(isFreshDelivery(seq143({ ts: SEQ_143_TS }), NOW)).toBe(false);
+  expect(isFreshDelivery(seq143({ ts: undefined as unknown as number }), NOW)).toBe(true);
+  // 服务端时钟略快于客户端（ts 在未来）不该被判旧
+  expect(isFreshDelivery(seq143({ ts: NOW + 30_000 }), NOW)).toBe(true);
+});

--- a/web/src/lib/notify.test.ts
+++ b/web/src/lib/notify.test.ts
@@ -1,7 +1,7 @@
 import { test, expect } from "bun:test";
 import { nextMentionBadgeCount, shouldMarkSeen, shouldNotify, shouldToast } from "./notify";
 const base = (over = {}) => ({ type:"msg", kind:"message", seq:5, mentions:["leo"], retracted:undefined,
-  sender:{name:"bob",kind:"agent"}, body:"hi @leo", ...over } as any);
+  sender:{name:"bob",kind:"agent"}, body:"hi @leo", ts: Date.now(), ...over } as any);
 
 test("被@ + 隐藏 + 已授权 → true", () => {
   expect(shouldNotify(base(), "leo", true, true)).toBe(true);

--- a/web/src/lib/notify.ts
+++ b/web/src/lib/notify.ts
@@ -8,10 +8,35 @@ export function isOwnMention(msg: MsgFrame, myHandle: string | null, myName: str
   return msg.mentions.some((mention) => identities.has(mention));
 }
 
+/**
+ * 提醒新鲜度上限（#861）。超过这个年龄的帧一律不弹通知/toast/角标。
+ *
+ * 取 5 分钟的理由：live 帧从服务端 ts 到客户端 onFrame 之间只有网络往返 + 时钟偏差；
+ * 唯一合法的滞后来自断线重连，而 ws.ts 的退避上限是 30s（BACKOFF_MAX_MS），
+ * 加上握手探测最坏也只有几十秒。5 分钟给了 ~10× 余量——短暂掉线期间真正错过的 @
+ * 仍然照弹（用户想要），但比本 issue 里那条 10 天前的老 @ 小三个数量级，
+ * 足以把「历史重放冒充 live」整类问题挡在门外，且不依赖服务端是否已上线 replay 标记。
+ */
+export const MENTION_ALERT_MAX_AGE_MS = 5 * 60_000;
+
+/**
+ * 这一帧是否值得当作「刚发生的事」去打扰用户（#861）。两道判据：
+ * ① 服务端 hello 补拉标记 replay:true 的帧一律不提醒——那是重放的历史，不是新消息；
+ * ② 新鲜度兜底：帧自身 ts 太旧就不提醒，覆盖「服务端还没上线 replay 标记」「客户端游标被
+ *    重新播种成 0 导致全量重放」等所有让老帧走 live 通路的情况。
+ * ts 缺失/非有限值时按新鲜处理，避免旧服务端的帧被整体静音。
+ */
+export function isFreshDelivery(msg: MsgFrame, now: number = Date.now(), maxAgeMs = MENTION_ALERT_MAX_AGE_MS): boolean {
+  if (msg.replay === true) return false;
+  if (!Number.isFinite(msg.ts)) return true;
+  return now - msg.ts <= maxAgeMs;
+}
+
 export function shouldNotify(
   msg: MsgFrame, myHandle: string | null, documentHidden: boolean, permissionGranted: boolean, myName: string | null = null,
+  now: number = Date.now(),
 ): boolean {
-  return permissionGranted && documentHidden && isOwnMention(msg, myHandle, myName);
+  return permissionGranted && documentHidden && isFreshDelivery(msg, now) && isOwnMention(msg, myHandle, myName);
 }
 
 // 页内 toast 判定（Task R5-toast）：与 shouldNotify 互补。
@@ -20,8 +45,9 @@ export function shouldNotify(
 // 其余判定（message 类型 / 未撤回 / 非自己发 / 命中 mentions）与 shouldNotify 一致。
 export function shouldToast(
   msg: MsgFrame, myHandle: string | null, documentHidden: boolean, optin: boolean, myName: string | null = null,
+  now: number = Date.now(),
 ): boolean {
-  return optin && !documentHidden && isOwnMention(msg, myHandle, myName);
+  return optin && !documentHidden && isFreshDelivery(msg, now) && isOwnMention(msg, myHandle, myName);
 }
 
 export function nextMentionBadgeCount(
@@ -30,8 +56,9 @@ export function nextMentionBadgeCount(
   myHandle: string | null,
   documentHidden: boolean,
   myName: string | null = null,
+  now: number = Date.now(),
 ): number {
-  return documentHidden && isOwnMention(msg, myHandle, myName) ? current + 1 : current;
+  return documentHidden && isFreshDelivery(msg, now) && isOwnMention(msg, myHandle, myName) ? current + 1 : current;
 }
 
 export function shouldMarkSeen(documentHidden: boolean, stickBottom: boolean): boolean {

--- a/web/src/pages/Channel.replayNotify.source.test.ts
+++ b/web/src/pages/Channel.replayNotify.source.test.ts
@@ -1,0 +1,73 @@
+// @ts-expect-error Bun executes this test, while the web tsconfig intentionally loads only Vite globals.
+import { describe, expect, test } from "bun:test";
+// @ts-expect-error Bun provides node:fs for this source-level contract test.
+import { readFileSync } from "node:fs";
+
+// #861 的根因是 Channel.tsx 里几处**源码形状**上的定时炸弹：游标被同步清 0、初始页失败退回
+// since=0、提醒判据不看重放标记、弹窗不打时间。这些跨 effect 的时序在单测里无法完整搭起来，
+// 所以用源码契约把它们钉死——任何一条被改回去，这里立刻变红。
+const source: string = readFileSync(new URL("./Channel.tsx", import.meta.url), "utf8");
+
+// loadInitialPage 的函数体（到 `}, [slug, token]);` 为止）
+function loadInitialPageBody(): string {
+  const start = source.indexOf("const loadInitialPage = useCallback(");
+  expect(start).toBeGreaterThan(-1);
+  const end = source.indexOf("}, [slug, token]);", start);
+  expect(end).toBeGreaterThan(start);
+  return source.slice(start, end);
+}
+
+describe("#861 游标不回退", () => {
+  test("loadInitialPage 绝不把 ws 游标同步清 0（token 静默续期会让 ws effect 拿 0 建 socket）", () => {
+    expect(loadInitialPageBody()).not.toMatch(/initialCursorRef\.current\s*=\s*0\s*;/);
+  });
+
+  test("初始页成功时游标单调前进，不被页尾拽回", () => {
+    // 接受任一等价写法：Math.max、显式 > 守卫，或任何以自身为下界的赋值。
+    const body = loadInitialPageBody();
+    expect(body).toMatch(
+      /initialCursorRef\.current = Math\.max\(initialCursorRef\.current,|> initialCursorRef\.current\)?\s*\{?\s*\n?\s*initialCursorRef\.current =/,
+    );
+  });
+
+  test("每条消息帧都推进游标，重建 socket 才能带着已见水位重连", () => {
+    // 等价写法同样放行：> 守卫赋值 或 Math.max。
+    expect(source).toMatch(
+      /frame\.seq > initialCursorRef\.current[\s\S]{0,80}initialCursorRef\.current = frame\.seq|initialCursorRef\.current = Math\.max\(initialCursorRef\.current, frame\.seq\)/,
+    );
+  });
+
+  test("ws hello 起始游标仍取自这个 ref", () => {
+    expect(source).toContain("initialCursor: initialCursorRef.current");
+  });
+});
+
+describe("#861 初始页失败期间不弹历史", () => {
+  test("失败分支显式标记本次降级不可信，成功分支复位", () => {
+    const body = loadInitialPageBody();
+    expect(body).toContain("replayUntrustedRef.current = true;");
+    expect(body).toContain("replayUntrustedRef.current = false;");
+  });
+
+  test("系统通知 / 桌面角标 / 页内 toast 三个出口都被这面闸挡住", () => {
+    const guards = source.match(/!replayUntrustedRef\.current/g) ?? [];
+    expect(guards.length).toBeGreaterThanOrEqual(3);
+    // 三个出口各自的判据表达式里都必须出现这面闸（不约束它排在第几个合取项）。
+    // 通知：notifiedSeqRef 去重那一段
+    expect(source).toMatch(/notifiedSeqRef\.current\.has\(frame\.seq\)[\s\S]{0,200}?!replayUntrustedRef\.current/);
+    // 角标：nextMentionBadgeCount 调用之前
+    expect(source).toMatch(/!replayUntrustedRef\.current[\s\S]{0,200}?nextMentionBadgeCount\(/);
+    // toast：toastedSeqRef 去重那一段
+    expect(source).toMatch(/toastedSeqRef\.current\.has\(frame\.seq\)[\s\S]{0,200}?!replayUntrustedRef\.current/);
+  });
+});
+
+describe("#861 提醒带上消息自身时间", () => {
+  test("系统通知正文打出 frame.ts", () => {
+    expect(source).toMatch(/fmtTime\(frame\.ts[,)]/);
+  });
+
+  test("页内 toast 携带 ts 供渲染", () => {
+    expect(source).toMatch(/ts: frame\.ts[,\s]/);
+  });
+});

--- a/web/src/pages/Channel.tsx
+++ b/web/src/pages/Channel.tsx
@@ -3382,7 +3382,12 @@ export function ChannelPage({
   const hasMoreRef = useRef(true); // 还有更早的历史可上翻
   const loadingOlderRef = useRef(false); // 上翻请求进行中（去抖）
   const [olderStatus, setOlderStatus] = useState<"idle" | "loading" | "error" | "end">("idle");
-  const initialCursorRef = useRef(0); // ws hello 的起始游标 = 初始页最后一条 seq
+  // ws hello 的起始游标。初始 seed = 初始页最后一条 seq，之后随每条 live/补拉帧单调前进（#861）——
+  // socket 重建（token 静默续期）时必须带着已见水位重连，绝不退回 0 让服务端全量重放。
+  const initialCursorRef = useRef(0);
+  // #861：初始页加载失败期间，本连接收到的帧一律不提醒（窗口为空 ⇒ 下界防御失效，
+  // 服务端会把全部历史 @ 当 live 帧重放）。初始页成功后复位。
+  const replayUntrustedRef = useRef(false);
   const initialHistoryRequestRef = useRef(0);
   const pendingAnchorRef = useRef<{ height: number; top: number } | null>(null); // prepend 前的滚动锚
   const oldestSeqRef = useRef(0);
@@ -3899,7 +3904,9 @@ export function ChannelPage({
   const loadInitialPage = useCallback(() => {
     const request = ++initialHistoryRequestRef.current;
     hasMoreRef.current = true;
-    initialCursorRef.current = 0;
+    // #861：**绝不**在这里把游标清 0。token 静默续期（App.tsx setToken）会让本 effect 与
+    // ws effect 在同一次 commit 里重跑，ws effect 读到清 0 的 ref 就会以 since=0 建 socket，
+    // 服务端把整段历史当 live 帧重放，10 天前的老 @ 当场弹通知。游标只单调前进。
     setOlderStatus("idle");
     setHistoryError(null);
     fetchMessagesWithRetry(token, slug, { before: Number.MAX_SAFE_INTEGER, limit: PAGE_SIZE })
@@ -3909,7 +3916,10 @@ export function ChannelPage({
         for (const m of msgs) dispatch({ type: "frame", frame: m }); // 按 seq 去重，与 ws 交叠无害
         hasMoreRef.current = msgs.length >= PAGE_SIZE;
         if (!hasMoreRef.current) setOlderStatus("end");
-        initialCursorRef.current = msgs.length > 0 ? msgs[msgs.length - 1]!.seq : 0;
+        // 单调前进：live 帧已把游标推得比这页页尾更远时（重建 socket 场景）不许回退。
+        const pageTail = msgs.length > 0 ? msgs[msgs.length - 1]!.seq : 0;
+        initialCursorRef.current = Math.max(initialCursorRef.current, pageTail);
+        replayUntrustedRef.current = false; // 历史已可信，恢复提醒
         setBootstrapped(true);
       })
       .catch((err: unknown) => {
@@ -3922,9 +3932,12 @@ export function ChannelPage({
           dispatch({ type: "fatal", reason: "forbidden" });
           return;
         }
-        // 初始页失败：退回 ws 全量重放（since=0），页面仍可用
+        // 初始页失败：退回 ws 全量重放（since=0 —— 只在游标本就是 0 时成立），页面仍可用。
+        // #861：此时 state.messages 为空 ⇒ 下界防御（floor > 0）整体失效，服务端会把频道里
+        // 所有历史 @ 当 live 帧重放。显式标记「本次降级期间的帧一律不提醒」，直到某次初始页
+        // 加载成功、历史重新可信为止。游标同样不清 0（已加载过就保住已见水位）。
         setHistoryError(tRef.current("Channel.history.loadFailed"));
-        initialCursorRef.current = 0;
+        replayUntrustedRef.current = true;
         hasMoreRef.current = false;
         setOlderStatus("end");
         setBootstrapped(true);
@@ -4021,6 +4034,10 @@ export function ChannelPage({
           // 窗口下界防御（review P1 双保险）：低于已加载窗口的旧消息/旧修订不进窗口——
           // 插进去会把上翻分页的 before 起点拽到远古 seq，中段历史被永久跳过。
           // 上翻时 REST 本来就返回当前正文，丢掉这些帧无信息损失。
+          // #861：游标随每条消息帧单调前进，socket 重建时才能带着已见水位重连（hello.since）。
+          if ((frame.type === "msg" || frame.type === "status") && frame.seq > initialCursorRef.current) {
+            initialCursorRef.current = frame.seq;
+          }
           const floor = oldestSeqRef.current;
           if (floor > 0) {
             if ((frame.type === "msg" || frame.type === "status") && frame.seq < floor) return;
@@ -4031,11 +4048,14 @@ export function ChannelPage({
           if (
             frame.type === "msg" &&
             !notifiedSeqRef.current.has(frame.seq) &&
+            !replayUntrustedRef.current &&
             shouldNotify(frame, selfHandleRef.current, document.hidden, optinRef.current, selfNameRef.current)
           ) {
             notifiedSeqRef.current.add(frame.seq);
             const title = tRef.current("Channel.notify.title", { channel: slug });
-            const body = summarizeReplyPreview(frame.body);
+            // #861：带上消息**自身**的时间。弹窗从来只打频道名+正文，用户无从发现
+            // 「通知时间 ≠ @ 时间」——这次让它一眼可见。
+            const body = `${fmtTime(frame.ts)} · ${summarizeReplyPreview(frame.body)}`;
             if (isDesktopRuntime()) {
               void sendMentionNotification({ title, body, slug, seq: frame.seq });
             } else if (typeof Notification !== "undefined" && Notification.permission === "granted") {
@@ -4047,7 +4067,7 @@ export function ChannelPage({
               };
             }
           }
-          if (frame.type === "msg") {
+          if (frame.type === "msg" && !replayUntrustedRef.current) {
             const nextBadge = nextMentionBadgeCount(
               desktopMentionBadgeRef.current,
               frame,
@@ -4064,6 +4084,7 @@ export function ChannelPage({
           if (
             frame.type === "msg" &&
             !toastedSeqRef.current.has(frame.seq) &&
+            !replayUntrustedRef.current &&
             shouldToast(frame, selfHandleRef.current, document.hidden, optinRef.current, selfNameRef.current)
           ) {
             toastedSeqRef.current.add(frame.seq);
@@ -4075,6 +4096,7 @@ export function ChannelPage({
                   sender: frame.sender, // 存原始 sender，渲染时用 resolveSenderLabel 解析，与消息卡显示保持一致
                   body: summarizeReplyPreview(frame.body),
                   fullBody: frame.body, // #280：完整正文，供 toast 悬停看全文
+                  ts: frame.ts, // #861：消息自身时间，提醒里直接打出来
                 },
               ].slice(-3),
             );

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -4219,6 +4219,13 @@ button.org-person-name {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+/* #861：提醒里打出消息自身时间，让「通知时间 ≠ @ 时间」一眼可见 */
+.mention-header-time,
+.mention-toast-time {
+  flex: none;
+  opacity: 0.75;
+  font-size: 10px;
+}
 .mention-header-count {
   flex: none;
   padding: 0 4px;

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -2817,7 +2817,11 @@ export class ChannelDO extends Server<Env> {
                 .exec(backfillQuery, since, pageCursor, HELLO_BACKFILL_PAGE_SIZE)
                 .toArray();
         for (const row of rows) {
-          if (!this.sendPublicFrame(connection, publicMsgFrame(this.rowToFrame(row)), true)) return;
+          // #861：补拉帧在 wire 上带 replay:true，与 live 广播区分开。客户端据此不把
+          // 重放的老消息当新消息弹系统通知/toast/角标。live 路径（broadcast → sendPublicFrame(_, false)）
+          // 永不打这个标记。
+          const replayFrame: MsgFrame = { ...publicMsgFrame(this.rowToFrame(row)), replay: true };
+          if (!this.sendPublicFrame(connection, replayFrame, true)) return;
         }
         if (rows.length < HELLO_BACKFILL_PAGE_SIZE) break;
         // 游标推进到本页最后一行的 seq；seq 唯一且升序，下一页严格取更大的 seq，保证前进、不重不漏。

--- a/worker/test/hello-backfill-replay-marker.spec.ts
+++ b/worker/test/hello-backfill-replay-marker.spec.ts
@@ -1,0 +1,55 @@
+// #861 回归：hello 补拉出去的帧必须在 wire 上带 replay:true，live 广播必须**不带**。
+// 客户端（web/desktop）据此把「重放的历史」与「真的新消息」分开——否则 socket 重建时
+// 服务端把整段历史当 live 帧重放，10 天前的老 @ 会当场弹系统通知。
+import { describe, expect, it } from "vitest";
+import { WsClient, completeCapabilityHello, createChannel, seedToken } from "./helpers";
+
+describe("hello backfill replay marker (#861)", () => {
+  it("marks since=0 backfilled frames with replay:true", async () => {
+    const { token } = await seedToken("agent");
+    const slug = await createChannel(token);
+
+    const writer = await WsClient.open(slug, token);
+    await completeCapabilityHello(writer);
+    writer.send({ type: "send", kind: "message", body: "@Evan 接口报错验证失败", mentions: [] });
+    const live = await writer.nextOfType("msg", 8000);
+    // live 广播不带标记（这条断言若失守，客户端会把所有新消息当历史静音）
+    expect(live.replay).toBeUndefined();
+    writer.close();
+
+    // 全新连接以 since=0 重连：同一条消息这次是补拉来的，必须带标记
+    const reader = await WsClient.open(slug, token);
+    await completeCapabilityHello(reader);
+    const replayed = await reader.nextOfType("msg", 8000);
+    reader.close();
+
+    expect(replayed.seq).toBe(live.seq);
+    expect(replayed.body).toBe(live.body);
+    expect(replayed.replay).toBe(true);
+  });
+
+  it("keeps live frames unmarked on a socket that already finished its backfill", async () => {
+    const { token } = await seedToken("agent");
+    const slug = await createChannel(token);
+
+    const writer = await WsClient.open(slug, token);
+    await completeCapabilityHello(writer);
+    writer.send({ type: "send", kind: "message", body: "first", mentions: [] });
+    const first = await writer.nextOfType("msg", 8000);
+    expect(first.replay).toBeUndefined();
+
+    // 第二个观察者补拉到 first（带标记），随后收到的 live second 不带标记
+    const reader = await WsClient.open(slug, token);
+    await completeCapabilityHello(reader);
+    const backfilled = await reader.nextOfType("msg", 8000);
+    expect(backfilled.replay).toBe(true);
+
+    writer.send({ type: "send", kind: "message", body: "second", mentions: [] });
+    const second = await reader.nextOfType("msg", 8000);
+    expect(second.body).toBe("second");
+    expect(second.replay).toBeUndefined();
+
+    writer.close();
+    reader.close();
+  });
+});


### PR DESCRIPTION
Closes #861

用户 8 月 6 日收到 7 月 27 日（seq 143）的老 @ 弹窗。issue 已把五层根因钉死，这里按纵深防御修**两层**——任一层单独修都不够稳。

## A. 服务端让补拉帧可分辨（`worker/src/do.ts`、`shared/src/protocol.ts`、`cli/src/client.ts`）

- `MsgFrame` 新增**可选**字段 `replay?: true`。hello 补拉循环（`do.ts:2786-2820`，`rev_seq` 分支同理）逐帧打上；live 广播路径（`broadcast → sendPublicFrame(_, false)`）永不携带。
- 协议兼容：字段可选，旧客户端忽略即可正常工作；新客户端见 `undefined` 时按 live 处理（旧服务端语义）。
- **#622 教训**：`cli/src/client.ts` 的 `isMessageFrame` 是手抄的字段校验表，protocol.ts 加字段而它没跟上会**静默丢整帧**。已同步加上 `(value.replay === undefined || value.replay === true)`，并新增一条**镜像守卫测试**：解析 protocol.ts 的 `MsgFrame` 字段名，逐个要求出现在 client.ts 的校验器里（结构化子对象字段显式豁免并列出）。以后再加字段忘了镜像，这条直接变红。

## B. 客户端不拿补拉帧弹通知（`web/src/`）

1. **游标不回退**（`Channel.tsx` loadInitialPage / ws effect）
   - 删掉函数体里同步的 `initialCursorRef.current = 0`——这是缺陷本身：`token` 静默续期（`App.tsx:651` 等三处 `setToken`）时初始页 effect 先跑清 0，ws effect 随后拿 0 建 socket。
   - 初始页成功时 `Math.max(current, pageTail)` 单调前进；**onFrame 里每条 msg/status 帧继续推进游标**，重建 socket 时带着真实已见水位重连。
2. **初始页失败不再退回 `since=0`**：`state.messages` 为空时下界防御（`floor > 0`）整体失效，服务端会把频道里所有历史 @ 重放一遍。改为显式标记 `replayUntrustedRef`——本次降级期间的帧**一律不提醒**（通知 / 桌面角标 / 页内 toast 三个出口都挡），直到某次初始页加载成功、历史重新可信。
3. **判据加新鲜度**（`web/src/lib/notify.ts`）：新增 `isFreshDelivery`，`shouldNotify` / `shouldToast` / `nextMentionBadgeCount` 三个函数统一走它。补拉帧不通知 + 帧自身 ts 过旧不通知。
4. **提醒带上消息自身时间**：系统通知正文前缀 `fmtTime(frame.ts)`，页内 toast / header notice 渲染 `<time>`。这正是用户字面感受到的那点——以后「通知时间 ≠ @ 时间」一眼可见。

### 阈值 `MENTION_ALERT_MAX_AGE_MS = 5 分钟` 的理由

live 帧从服务端 `ts` 到客户端 `onFrame` 之间只有网络往返 + 时钟偏差；唯一合法的滞后来自断线重连，而 `ws.ts` 的退避上限是 `BACKOFF_MAX_MS = 30s`，加上握手探测最坏也只有几十秒。5 分钟给了约 10× 余量：**短暂掉线期间真正错过的 @ 仍然照弹**（用户想要），但比本 issue 那条 10 天前的老 @ 小三个数量级，足以把「历史重放冒充 live」整类问题挡在门外，且**不依赖服务端是否已上线 replay 标记**（灰度期、旧实例同样受保护）。测试里边界含等号，服务端时钟略快（ts 在未来）不判旧。

## 测试

按 issue 给的失败场景逐字写：

- `web/src/lib/notify.replay.test.ts`（7 个）——真的 `ChannelSocket`（`initialCursor: 0`）+ 真的 `shouldNotify/shouldToast/nextMentionBadgeCount`，复刻 slug=seamail / self "Evan" / optin / granted / hidden / 窗口 141..190 / 服务端回放含 seq 143（ts=1785134587385）：**断言零通知、零 toast、角标不动**。对照组：真 live 新帧照弹；阈值内的补投照弹；`hello.since` 不是 0；补拉帧即使 ts 很新也不弹（隔离 A 层）；服务端没上线标记时光凭 ts 也不弹（隔离新鲜度兜底）。
- `web/src/pages/Channel.replayNotify.source.test.ts`（8 个）——跨 effect 的时序单测搭不起来，用源码契约钉死：不清 0、单调前进、live 推进、三出口闸、通知带 ts。断言写成**容忍等价写法**的正则（`Math.max` 与 `>` 守卫都放行）。
- `worker/test/hello-backfill-replay-marker.spec.ts`（2 个）——since=0 补拉帧带 `replay:true`；live 帧不带；补拉完成后的 live 帧仍不带。
- `cli/test/replay-frame-allowlist.test.ts`（3 个）——带 `replay:true` 的帧不被丢弃且字段透出；`replay` 只接受 `true`；protocol↔client allow-list 镜像守卫。
- 修正 `web/src/i18n/strings/Channel.loading.source.test.ts`：它原本断言 `initialCursorRef.current = 0` 存在——**那正是缺陷本身**，已反转为断言其不存在。

统计：web `1334 pass / 0 fail`、cli `1749 pass / 0 fail`、worker `810 pass / 107 files / 0 fail`；shared/cli/worker/web 四包 `tsc --noEmit` 全干净。

## 变异验证

逐个拆掉修复，确认对应断言**真的变红**：

| # | 拆掉的修复 | 结果 |
|---|---|---|
| M1 | 服务端补拉不打 `replay` 标记 | worker 2 red |
| M2 | cli allow-list 不镜像 `replay` | cli 2 red（含镜像守卫） |
| M3 | `isFreshDelivery` 去掉 replay 判据 | web 2 red（含「ts 很新的补拉帧」隔离用例） |
| M4 | `isFreshDelivery` 去掉 ts 新鲜度兜底 | web 2 red |
| M5 | 恢复 `initialCursorRef.current = 0` | web 2 red（新用例 + 被反转的旧用例） |
| M6 | 成功分支改回非单调赋值 | web 1 red |
| M7 | 删掉 onFrame 的游标推进 | web 1 red |
| M8 | 删掉降级期抑制闸（三出口） | web 2 red |
| M9 | 通知/toast 去掉时间 | web 2 red |

**等价实现替换**（防误红）：把 `Math.max(cur, pageTail)` 换成 `if (pageTail > cur) cur = pageTail`、把 `> cur` 守卫换成 `Math.max(cur, frame.seq)`、把模板字符串换成 `fmtTime(frame.ts, Date.now()) + " · " + …`——**8 pass / 0 fail，全部保持绿**。随后把变异重新打回，容忍化后的断言依旧全部变红（4 red），确认宽松化没有把守卫放空。
