### PR TITLE
fix(cli): 唤醒代理同 seq 只转投一次，失败原因透出并校验目标 socket 属主

### DIFF
--- a/cli/src/claude-inbox-inject.ts
+++ b/cli/src/claude-inbox-inject.ts
@@ -370,12 +370,47 @@ export type InjectFailureReason =
   | "ambiguous"
   | "unavailable"
   | "probe-failed"
+  | "socket-untrusted"
   | "body-too-large"
   | "write-failed";
 
+/**
+ * 目标 socket 属主校验（#867 ②）。本模块另外三处 `lstatSync`（会话目录、`<pid>.json`、
+ * `.key`）都做了「非符号链接 + 属主匹配」，唯独**要写入的 socket 本身**从来没验过——
+ * 那份安全完全继承自 Claude 首次建 `/tmp/cc-socks` 时的 0700，本模块自己一条都没查。
+ *
+ * socket 路径可预测（`/tmp/cc-socks/<pid>.sock`，pid 空间小且可枚举，父目录在 world-writable
+ * 的 `/tmp` 下）。多用户机器上若攻击者抢在 Claude 首次运行前建好 `cc-socks`，我们会把
+ * peerToken（auth 行）+ 频道 channel/seq 指针直接写给他。校验很便宜，与另外三处对齐：
+ * 必须是真 socket、非符号链接、属本 uid。
+ *
+ * 返回 null ＝通过；返回字符串 ＝拒投理由（进 InjectResult.detail）。
+ * 注意 `lstatSync` 不跟随符号链接：指向他人 socket 的软链会同时命中 isSymbolicLink 与
+ * !isSocket 两条，任一条都足以拒投。
+ */
+export function socketOwnershipFailure(sockPath: string): string | null {
+  let stat: ReturnType<typeof lstatSync>;
+  try {
+    stat = lstatSync(sockPath);
+  } catch (error) {
+    return `lstat failed: ${String(error)}`;
+  }
+  if (stat.isSymbolicLink()) return "socket path is a symlink";
+  if (!stat.isSocket()) return "path is not a socket";
+  if (typeof process.getuid === "function" && stat.uid !== process.getuid()) {
+    return `socket owned by uid ${stat.uid}, expected ${process.getuid()}`;
+  }
+  return null;
+}
+
 export type InjectResult =
   /**
-   * ok:true ＝**帧已写入收件箱 socket**，不代表已进对方对话流。接收端的
+   * ok:true 的语义，写死在这里（#867 ①附带）：**字节已交给内核**。
+   * `writeFramesToSocket` 走 `socket.end(payload, cb)`，回调只在数据 flush 之后触发——
+   * 不代表对端读了、更不代表对端解析了。本模块从不读任何响应、也不订阅
+   * `peer_message_status`，所以**连 auth 行被拒都感知不到**。
+   *
+   * 也就是说 ok:true ＝**帧已写入收件箱 socket**，不代表已进对方对话流。接收端的
    * crossSessionInbound 闸门决定归宿：accept 才入队唤醒；默认 hold 会进待审队列并在
    * 5 分钟无人处理后被 drop；refuse 直接丢。接收端不回错，我们无从区分。
    * **调用方绝不可据此清频道侧的 @ 欠账/wake 记账**——真正送达以对方回话/ack 为准。
@@ -432,6 +467,11 @@ export async function injectChannelMessage(
     : resolveSessionSocketByPid(input.pid, { expectSessionId: input.sessionId, env });
   if (!resolved.ok) return { ok: false, reason: resolved.reason };
   const { session } = resolved;
+
+  // #867 ②：**连之前**先验目标 socket 的属主/类型。放在探活之前——探活也是一次
+  // connect，不该连一个不属于我们的路径。
+  const untrusted = socketOwnershipFailure(session.messagingSocketPath);
+  if (untrusted !== null) return { ok: false, reason: "socket-untrusted", detail: untrusted };
 
   const alive = await probeSocketAlive(session.messagingSocketPath);
   if (!alive) return { ok: false, reason: "probe-failed" };

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -5474,7 +5474,14 @@ export async function runServe(o: ServeOptions): Promise<number> {
       // kill(pid,0) 探活，死会话已剔除）时尝试转投一条 ≤512B 的 channel+seq 指针通知。
       // 纯增量：转投与否都不改变下方 runner/ack 现行为（「照常继续自己的职责」），
       // attemptWakeProxy 绝不抛错，任何失败降级为现行为——消息绝不因代理而丢失。
-      if (fresh && !fromSelf && hasLease && !selfPaused && frame.mentions.length > 0) {
+      // #866：`!mentionOwnedByDelivery` 是**必须**的去重守卫。directed-delivery 模式下，
+      // 一条同时 @ 自己和另一个本机会话的消息会两次流经这里：先是普通 `msg` 帧
+      // （directedDelivery===null），随后是同一 seq 的权威 `delivery` 帧。没有这条守卫
+      // 就转投两次 → 目标会话对同一条消息开两个 turn，双倍模型成本。
+      // 语义与下方 passesFilter 里的同名条件一致：「这条 @ 归属于稍后到来的 delivery 帧」
+      // → 让那一帧去转投，普通 msg 帧这次跳过。只 @ 别人不 @ 自己时该值为 false，
+      // 不会有 delivery 帧跟上，仍旧在 msg 帧这里转投一次（对照组不受影响）。
+      if (fresh && !fromSelf && hasLease && !selfPaused && !mentionOwnedByDelivery && frame.mentions.length > 0) {
         const wakeProxyDeps = o.wakeProxy ?? {};
         await attemptWakeProxy(frame.mentions, self, { channel: o.channel, seq: frame.seq }, {
           ...wakeProxyDeps,

--- a/cli/src/serve-wake-proxy.ts
+++ b/cli/src/serve-wake-proxy.ts
@@ -5,8 +5,13 @@
 // 通知（只带 channel+seq 指针，被唤醒会话自己回频道读正文），随后照常继续自己
 // 的职责。
 //
-// 载体调研结论（开放问题 B，2026-08 复核）：serve 进程今天**没有**可用的最小
-// 转投载体——
+// ⚠️ 载体现状（#856 起）：默认载体是**真载体** `socketWakeProxyForwarder`（serve.ts 的
+// `?? socketWakeProxyForwarder()`），走本机 UDS 收件箱注入。下面那段「今天没有可用载体」
+// 是 #841 时代的结论，保留作历史背景——但**不要**再据它写「无可用转投载体」这类日志：
+// 今天 forwarded=false 的含义是「socket 注入以某个已知原因失败了」，原因必须打出来（#867 ①）。
+//
+// 载体调研结论（开放问题 B，2026-08 复核；已被 #844/#856 推翻，存档）：serve 进程当时
+// **没有**可用的最小转投载体——
 //   - Claude 的跨会话 SendMessage 是模型专属工具：claude-cross-session-gate 只放
 //     行「armed Claude 会话内、走完 peers→ListAgents→peer_check 授权链的一次
 //     模型调用」，serve 不是 Claude 会话，伪造这条链等于绕过 gate。
@@ -159,16 +164,40 @@ export function resolveLocalIdentity(cwd?: string): CachedIdentity | null {
   }
 }
 
-/** 可注入的转投载体：true=已转投成功；false/抛错=未转投（降级为现行为）。 */
+/**
+ * 载体的结构化结果（#867 ①）：失败时带上真实原因，供降级日志打印。
+ * 载体也可以直接返回裸 boolean（老形态，测试/骨架载体在用）——此时没有原因可报，
+ * 日志会明说「载体未上报原因」，而不是编一个。
+ */
+export interface WakeProxyForwardResult {
+  ok: boolean;
+  /** 失败原因（injectChannelMessage 的 InjectFailureReason，或载体自定义）。 */
+  reason?: string;
+  /** 细节（如 write-failed 的具体错误、socket-untrusted 的判据）。 */
+  detail?: string;
+}
+
+/** 可注入的转投载体：ok=true 已转投；ok=false/抛错=未转投（降级为现行为）。 */
 export type WakeProxyForwarder = (
   target: ClaudeSessionRegistryEntry,
   ref: WakeProxyRef,
-) => Promise<boolean>;
+) => Promise<boolean | WakeProxyForwardResult>;
+
+/** 裸 boolean 与结构化结果的归一化。 */
+function normalizeForwardResult(value: boolean | WakeProxyForwardResult): WakeProxyForwardResult {
+  return typeof value === "boolean" ? { ok: value } : value;
+}
 
 /**
  * 骨架载体：无传输，恒返回 false（降级为现行为）。保留给不接 socket 面的场景/测试。
+ * 这条是**真的**「无可用转投载体」——serve 的默认载体早已不是它（见 serve.ts 的
+ * `?? socketWakeProxyForwarder()`）。
  */
-export const noWakeProxyForwarder: WakeProxyForwarder = async () => false;
+export const noWakeProxyForwarder: WakeProxyForwarder = async (): Promise<WakeProxyForwardResult> => ({
+  ok: false,
+  reason: "no-carrier",
+  detail: "noWakeProxyForwarder：本载体无传输",
+});
 
 export interface SocketWakeProxyForwarderOptions {
   /** 自己的回执 socket（`from:uds:<...>`）。serve 无回执 sock → 省略，接收端记 unknown。 */
@@ -216,7 +245,10 @@ export function socketWakeProxyForwarder(
       fromSock: options.fromSock,
       env: options.env,
     });
-    return result.ok;
+    // #867 ①：结构化失败原因**必须**透出。以前这里是 `return result.ok;`，
+    // injectChannelMessage 精心构造的 6 种 {reason, detail} 全被丢掉，
+    // 「目标会话已死 / socket 陈旧残留 / 同名多会话」在日志里长得一模一样。
+    return result.ok ? { ok: true } : { ok: false, reason: result.reason, detail: result.detail };
   };
 }
 
@@ -225,6 +257,10 @@ export interface WakeProxyAttempt {
   forwarded: boolean;
   /** 命中的目标宣告名；null = 无本机入册目标（含死会话已被剔除的情形）。 */
   target: string | null;
+  /** forwarded=false 时的真实失败原因；载体没上报则为 null（#867 ①）。 */
+  reason?: string | null;
+  /** 失败细节；无则 null。 */
+  detail?: string | null;
 }
 
 export interface WakeProxyDeps {
@@ -259,15 +295,28 @@ export async function attemptWakeProxy(
   if (target === null) return { forwarded: false, target: null };
   const name = claudeSessionAnnounceName(target);
   try {
-    const forwarded = await (deps.forward ?? noWakeProxyForwarder)(target, ref);
+    const result = normalizeForwardResult(await (deps.forward ?? noWakeProxyForwarder)(target, ref));
+    if (result.ok) {
+      log(`serve: 唤醒代理已转投 @${name}（channel=${ref.channel} seq=${ref.seq}，≤512B 指针，正文在频道）`);
+      return { forwarded: true, target: name, reason: null, detail: null };
+    }
+    // #867 ①：这行以前恒打「当前无可用转投载体」——那是 #841 时代的实话（默认载体
+    // 是 noWakeProxyForwarder），#856 把默认载体换成真载体后就变成了**反话**：真实失败
+    // 是 no-match / probe-failed / ambiguous / socket-untrusted 之一，日志却告诉运维
+    // 「没有载体」，排障面被封死。现在打真实原因。
+    const reason = result.reason ?? null;
+    const detail = result.detail ?? null;
     log(
-      forwarded
-        ? `serve: 唤醒代理已转投 @${name}（channel=${ref.channel} seq=${ref.seq}，≤512B 指针，正文在频道）`
-        : `serve: @${name} 命中本机入册的 idle Claude 会话，但当前无可用转投载体——降级为现行为（见 #841 P3）`,
+      `serve: @${name} 命中本机入册的 idle Claude 会话，但转投未成功（channel=${ref.channel} seq=${ref.seq}` +
+        ` reason=${reason ?? "unreported"}${detail === null ? "" : ` detail=${detail}`}）` +
+        "——降级为现行为，消息不丢",
     );
-    return { forwarded, target: name };
+    return { forwarded: false, target: name, reason, detail };
   } catch (error) {
-    log(`serve: 唤醒代理转投 @${name} 失败（${String(error)}）——降级为现行为，消息不丢`);
-    return { forwarded: false, target: name };
+    log(
+      `serve: 唤醒代理转投 @${name} 失败（channel=${ref.channel} seq=${ref.seq}` +
+        ` reason=threw detail=${String(error)}）——降级为现行为，消息不丢`,
+    );
+    return { forwarded: false, target: name, reason: "threw", detail: String(error) };
   }
 }

--- a/cli/test/claude-inbox-inject-by-pid.test.ts
+++ b/cli/test/claude-inbox-inject-by-pid.test.ts
@@ -4,7 +4,7 @@
 // 用临时 sessions 目录（AGENTPARTY_CLAUDE_NATIVE_SESSIONS_DIR）+ 临时 socket，绝不碰真实
 // `~/.claude/sessions` 或 `/tmp/cc-socks/`。
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { createServer, type Server } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -14,6 +14,7 @@ import {
   nativeSessionName,
   resolveSessionSocket,
   resolveSessionSocketByPid,
+  socketOwnershipFailure,
 } from "../src/claude-inbox-inject";
 import {
   claudeSessionAnnounceName,
@@ -147,5 +148,74 @@ describe("按 pid 寻址（#857 真实寻址层）", () => {
     expect(claudeSessionAnnounceName(registryEntry({ display_name: "agentparty-d4" }))).toBe(
       "agentparty-d4",
     );
+  });
+});
+
+// #867 ②：目标 socket 写入前的属主/类型校验。模块里另外三处 lstatSync（会话目录、
+// `<pid>.json`、`.key`）都做了这件事，唯独要写入的 socket 本身以前一次都没验过——
+// 那份安全完全继承自 Claude 建 `/tmp/cc-socks` 时的 0700。这里用临时 socket 构造
+// 不符合条件的情形，绝不碰真实 `/tmp/cc-socks/`。
+describe("#867 ②：目标 socket 属主校验", () => {
+  test("正常的自有 socket 通过校验（不误伤现行路径）", () => {
+    expect(socketOwnershipFailure(sockPath)).toBeNull();
+  });
+
+  test("路径是普通文件而非 socket → 拒投 socket-untrusted，一个字节都不写", async () => {
+    const decoy = join(dir, "decoy.notasock");
+    writeFileSync(decoy, "", { mode: 0o600 });
+    expect(socketOwnershipFailure(decoy)).toBe("path is not a socket");
+
+    writeNativeSession({ messagingSocketPath: decoy });
+    const result = await injectChannelMessage({
+      pid: process.pid,
+      sessionId: SESSION_ID,
+      name: "claude-111111111111",
+      body: "AgentParty wake: #dev seq=1",
+      fromName: "leo",
+      env: env(),
+    });
+    expect(result).toEqual({ ok: false, reason: "socket-untrusted", detail: "path is not a socket" });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(received.join("")).toBe("");
+  });
+
+  test("符号链接指向真 socket → 拒投，绝不顺着软链把 peerToken 写出去", async () => {
+    const link = join(dir, "link.sock");
+    symlinkSync(sockPath, link);
+    // lstat 不跟随符号链接：isSymbolicLink 命中，先于 isSocket 拒掉。
+    expect(socketOwnershipFailure(link)).toBe("socket path is a symlink");
+
+    writeNativeSession({ messagingSocketPath: link });
+    const result = await injectChannelMessage({
+      pid: process.pid,
+      sessionId: SESSION_ID,
+      name: "claude-111111111111",
+      body: "AgentParty wake: #dev seq=2",
+      fromName: "leo",
+      env: env(),
+    });
+    expect(result).toMatchObject({ ok: false, reason: "socket-untrusted" });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    // 软链后面就是那个真 listener——校验若失效，这里会收到帧。
+    expect(received.join("")).toBe("");
+  });
+
+  test("路径根本不存在 → lstat 失败即拒投（早于任何 connect）", () => {
+    const failure = socketOwnershipFailure(join(dir, "nope.sock"));
+    expect(failure).toContain("lstat failed");
+  });
+
+  test("socket 属于别的 uid → 拒投并报出实际 uid", () => {
+    const realGetuid = process.getuid;
+    // 本机构造不出别人的 socket（不 sudo），改用 getuid 偏移等价地翻转比较结果。
+    (process as { getuid?: () => number }).getuid = () => (realGetuid!() + 1) % 60_000;
+    try {
+      const failure = socketOwnershipFailure(sockPath);
+      expect(failure).toContain("socket owned by uid");
+      expect(failure).toContain(String(realGetuid!()));
+    } finally {
+      (process as { getuid?: () => number }).getuid = realGetuid;
+    }
+    expect(socketOwnershipFailure(sockPath)).toBeNull();
   });
 });

--- a/cli/test/claude-inbox-inject.test.ts
+++ b/cli/test/claude-inbox-inject.test.ts
@@ -302,13 +302,17 @@ describe("injectChannelMessage", () => {
     expect(result).toEqual({ ok: false, reason: "no-match" });
   });
 
-  test("探活失败（socket 文件不存在）→ probe-failed", async () => {
+  // #867 ②：socket 文件根本不存在这一档，现在被**更早**的属主校验以更精确的原因拒掉
+  // （socket-untrusted + lstat ENOENT 细节），不再打成含糊的 probe-failed。
+  // probe-failed 仍保留给「文件在、是自己的真 socket、但无人 listen」的陈旧残留。
+  test("socket 文件不存在 → socket-untrusted（lstat 失败），且带出可诊断 detail", async () => {
     writeSessionFile(sessionsDir, process.pid, {
       name: "stale",
       messagingSocketPath: join(sessionsDir, "gone.sock"),
     });
     const result = await injectChannelMessage({ name: "stale", body: "x", fromName: "c", env: env() });
-    expect(result).toEqual({ ok: false, reason: "probe-failed" });
+    expect(result).toMatchObject({ ok: false, reason: "socket-untrusted" });
+    expect((result as { detail?: string }).detail).toContain("lstat failed");
   });
 
   test("from-name 含引号（会破坏完整性自校验）→ 写入前置失败", async () => {

--- a/cli/test/serve-directed-delivery.test.ts
+++ b/cli/test/serve-directed-delivery.test.ts
@@ -20,6 +20,7 @@ import {
 import { writeConfig, writeState } from "../src/config";
 import { msgFrame, startMockServer, welcomeFrame, type MockServer } from "./mock-server";
 import { startRestMock } from "./rest-mock";
+import type { ClaudeSessionRegistryEntry } from "../src/claude-session-registry";
 
 let server: MockServer | null = null;
 
@@ -908,4 +909,91 @@ describe("serve durable directed delivery (#551)", () => {
     expect(runnerCalls).toBe(0);
     expect(lines.some((line) => line.includes("启动确认失败，未启动 runner"))).toBe(true);
   }, 10_000);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #866：唤醒代理的**接线点**回归。此前全仓库没有任何 serve*.test.ts 提到 wakeProxy——
+// #856 只测了 socketWakeProxyForwarder 这个纯函数壳，接线点一条断言都没有，结果
+// 「同一 seq 转投两次」不加修复也是全绿。这里按 seq 计数把接线钉死。
+// ─────────────────────────────────────────────────────────────────────────────
+describe("serve 唤醒代理转投去重（#866）", () => {
+  /** 本机入册的另一个 Claude 会话，宣告名 = peer-claude。 */
+  function peerSession(): ClaudeSessionRegistryEntry {
+    return {
+      version: 1,
+      session_id: "22222222-2222-4222-8222-222222222222",
+      pid: process.pid,
+      display_name: "peer-claude",
+      channel: "dev",
+      cwd: "/tmp/project",
+      registered_at: 1_000,
+    };
+  }
+
+  /**
+   * 跑一轮 directed-delivery 模式的 serve，统计唤醒代理被调用了几次、分别是哪个 seq。
+   * withDelivery=true 时服务端在普通 msg 帧之后再补发同一 seq 的权威 delivery 帧
+   * （＝ @ 到自己时的真实线上时序）。
+   */
+  async function countForwards(
+    mentions: string[],
+    withDelivery: boolean,
+  ): Promise<Array<{ target: string; seq: number }>> {
+    const forwards: Array<{ target: string; seq: number }> = [];
+    const message = msgFrame(7, "@me @peer-claude 看看这个", {
+      sender: { name: "bob", kind: "human", owner: "bob@example.com" },
+      mentions,
+    }) as unknown as MsgFrame;
+    const work = delivery(7);
+    server = startMockServer((frame, sock) => {
+      if (frame.type === "hello") {
+        sock.send({ ...welcomeFrame(0, "me"), directed_delivery: "v1" });
+      } else if (frame.type === "serve_lease") {
+        sock.send({ type: "serve_lease", name: "me", held: true });
+        // 1) 普通 msg 帧先到。
+        sock.send(message as unknown as ServerFrame);
+        if (withDelivery) {
+          // 2) 同一 seq 的权威 delivery 帧随后到 —— 修复前这里会触发第二次转投。
+          sock.send({ type: "delivery", delivery: work, message });
+        } else {
+          sock.send({ type: "error", code: "archived", message: "done" });
+        }
+      } else if (frame.type === "delivery_update") {
+        sock.send({
+          type: "delivery_state",
+          request_id: frame.request_id,
+          delivery: { ...work, state: frame.state, updated_at: Date.now() },
+        });
+        if (frame.state === "replied" || frame.state === "failed") {
+          sock.send({ type: "error", code: "archived", message: "done" });
+        }
+      }
+    });
+
+    await runServe(opts({
+      server: server.url,
+      runCommand: async () => {},
+      wakeProxy: {
+        listSessions: () => [peerSession()],
+        forward: async (target, ref) => {
+          forwards.push({ target: target.display_name!, seq: ref.seq });
+          return true;
+        },
+      },
+    }));
+    return forwards;
+  }
+
+  test("同时 @ 自己和本机另一会话：msg 帧 + delivery 帧同 seq，只转投一次", async () => {
+    const forwards = await countForwards(["me", "peer-claude"], true);
+    // 修复前这里是 2（同一 seq 两条，目标会话对一条消息开两个 turn，双倍模型成本）。
+    expect(forwards).toEqual([{ target: "peer-claude", seq: 7 }]);
+    // 按 seq 去重是这条断言的重点：同一 seq 绝不出现两次。
+    expect(new Set(forwards.map((f) => f.seq)).size).toBe(forwards.length);
+  });
+
+  test("对照组：只 @ 本机另一会话、不 @ 自己 → 没有 delivery 帧跟上，仍转投一次", async () => {
+    const forwards = await countForwards(["peer-claude"], false);
+    expect(forwards).toEqual([{ target: "peer-claude", seq: 7 }]);
+  });
 });

--- a/cli/test/serve-wake-proxy.test.ts
+++ b/cli/test/serve-wake-proxy.test.ts
@@ -84,15 +84,17 @@ describe("attemptWakeProxy", () => {
       listSessions: () => [entry()],
       log: (line) => lines.push(line),
     });
-    expect(result).toEqual({ forwarded: false, target: "claude-111111111111" });
+    expect(result).toMatchObject({ forwarded: false, target: "claude-111111111111", reason: "no-carrier" });
     expect(lines.some((line) => line.includes("降级为现行为"))).toBe(true);
+    // #867 ①：这句 #841 时代的文案必须已经消失——今天它是反话。
+    expect(lines.some((line) => line.includes("当前无可用转投载体"))).toBe(false);
   });
 
   test("死会话已被注册表剔除（列表为空）→ 无目标，回落现行为", async () => {
     const result = await attemptWakeProxy(["claude-111111111111"], "me", { channel: "dev", seq: 7 }, {
       listSessions: () => [],
     });
-    expect(result).toEqual({ forwarded: false, target: null });
+    expect(result).toMatchObject({ forwarded: false, target: null });
   });
 
   test("载体成功 → forwarded=true 且拿到 ≤512B 指针", async () => {
@@ -118,7 +120,8 @@ describe("attemptWakeProxy", () => {
       },
       log: (line) => lines.push(line),
     });
-    expect(result).toEqual({ forwarded: false, target: "claude-111111111111" });
+    expect(result).toMatchObject({ forwarded: false, target: "claude-111111111111", reason: "threw" });
+    expect(result.detail).toContain("transport boom");
     expect(lines.some((line) => line.includes("失败") && line.includes("不丢"))).toBe(true);
   });
 
@@ -128,11 +131,14 @@ describe("attemptWakeProxy", () => {
         throw new Error("registry boom");
       },
     });
-    expect(result).toEqual({ forwarded: false, target: null });
+    expect(result).toMatchObject({ forwarded: false, target: null });
   });
 
-  test("noWakeProxyForwarder 恒 false", async () => {
-    expect(await noWakeProxyForwarder(entry(), { channel: "dev", seq: 1 })).toBe(false);
+  test("noWakeProxyForwarder 恒 false（且这条才是真正的「无载体」）", async () => {
+    expect(await noWakeProxyForwarder(entry(), { channel: "dev", seq: 1 })).toMatchObject({
+      ok: false,
+      reason: "no-carrier",
+    });
   });
 });
 
@@ -157,7 +163,7 @@ describe("socketWakeProxyForwarder（#844 socket 优先载体）", () => {
       }),
     });
     const ok = await forward(entry({ display_name: "pair-claude" }), { channel: "pwtk", seq: 42 });
-    expect(ok).toBe(true);
+    expect(ok).toMatchObject({ ok: true });
     expect(seen!.name).toBe("pair-claude");
     // 寻址走 pid + sessionId（宣告名恒不等于 Claude 原生会话名，#857）。
     expect(seen!.pid).toBe(entry().pid);
@@ -171,6 +177,77 @@ describe("socketWakeProxyForwarder（#844 socket 优先载体）", () => {
     const forward = socketWakeProxyForwarder({
       inject: async () => ({ ok: false, reason: "no-match" }),
     });
-    expect(await forward(entry(), { channel: "dev", seq: 1 })).toBe(false);
+    expect(await forward(entry(), { channel: "dev", seq: 1 })).toMatchObject({ ok: false, reason: "no-match" });
+  });
+});
+
+describe("#867 ①：结构化失败原因必须一路透出到降级日志", () => {
+  // injectChannelMessage 构造的全部失败原因。以前 socketWakeProxyForwarder 一句
+  // `return result.ok;` 把它们全丢了，「目标会话已死 / socket 陈旧残留 / 同名多会话」
+  // 在日志里长得一模一样，而且打的是**错误的**原因（「当前无可用转投载体」）。
+  const reasons = [
+    ["no-match", "目标会话已死或 pid 复用"],
+    ["ambiguous", "同名多会话"],
+    ["unavailable", "寻址目录不可用"],
+    ["probe-failed", "socket 陈旧残留（ECONNREFUSED）"],
+    ["socket-untrusted", "socket path is a symlink"],
+    ["body-too-large", "单行超 1MiB"],
+    ["write-failed", "Error: socket write timeout"],
+  ] as const;
+
+  for (const [reason, detail] of reasons) {
+    test(`reason=${reason} 透出到 forwarder、attempt 与日志`, async () => {
+      const forward = socketWakeProxyForwarder({
+        inject: async () => ({ ok: false, reason, detail }),
+      });
+      expect(await forward(entry(), { channel: "dev", seq: 5 })).toEqual({ ok: false, reason, detail });
+
+      const lines: string[] = [];
+      const result = await attemptWakeProxy(["claude-111111111111"], "me", { channel: "dev", seq: 5 }, {
+        listSessions: () => [entry()],
+        forward,
+        log: (line) => lines.push(line),
+      });
+      expect(result).toMatchObject({ forwarded: false, target: "claude-111111111111", reason, detail });
+      const line = lines.find((l) => l.includes("claude-111111111111"));
+      expect(line).toBeDefined();
+      expect(line!).toContain(`reason=${reason}`);
+      expect(line!).toContain(`detail=${detail}`);
+      // 过时文案已删除：日志绝不能再说「没有载体」——真载体在，只是这次失败了。
+      expect(line!).not.toContain("当前无可用转投载体");
+      expect(line!).not.toContain("#841 P3");
+    });
+  }
+
+  test("两种不同失败打出的是两条不同的日志（以前恒同一句）", async () => {
+    const lines: string[] = [];
+    for (const reason of ["no-match", "probe-failed"] as const) {
+      await attemptWakeProxy(["claude-111111111111"], "me", { channel: "dev", seq: 5 }, {
+        listSessions: () => [entry()],
+        forward: socketWakeProxyForwarder({ inject: async () => ({ ok: false, reason }) }),
+        log: (line) => lines.push(line),
+      });
+    }
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).not.toBe(lines[1]);
+  });
+
+  test("载体只返回裸 boolean false → 明说「未上报原因」，绝不编一个", async () => {
+    const lines: string[] = [];
+    const result = await attemptWakeProxy(["claude-111111111111"], "me", { channel: "dev", seq: 5 }, {
+      listSessions: () => [entry()],
+      forward: async () => false,
+      log: (line) => lines.push(line),
+    });
+    expect(result).toMatchObject({ forwarded: false, reason: null });
+    expect(lines[0]).toContain("reason=unreported");
+  });
+
+  test("成功路径不带 reason/detail", async () => {
+    const result = await attemptWakeProxy(["claude-111111111111"], "me", { channel: "dev", seq: 5 }, {
+      listSessions: () => [entry()],
+      forward: async () => true,
+    });
+    expect(result).toMatchObject({ forwarded: true, reason: null, detail: null });
   });
 });


### PR DESCRIPTION
Closes #866
Closes #867

两个 issue 都在 `serve-wake-proxy` / `claude-inbox-inject` 这一对模块里，性质相邻，一并修。

## #866 重复注入：同一 seq 转投两次

`cli/src/commands/serve.ts` 的转投闸门缺去重守卫：

```diff
-if (fresh && !fromSelf && hasLease && !selfPaused && frame.mentions.length > 0) {
+if (fresh && !fromSelf && hasLease && !selfPaused && !mentionOwnedByDelivery && frame.mentions.length > 0) {
```

issue 里叫它 `awaitingOwnDirectedDelivery`；仓库里**已经有**一个语义完全相同的变量
`mentionOwnedByDelivery`（`directedDeliveryMode && directedDelivery === null && frame.mentions.includes(self)`，
下方 `passesFilter` 在用），所以直接复用它而不是新造一个同义词。

- @ 自己 + @ 本机另一会话：msg 帧归属于稍后到来的 delivery 帧 → 这次跳过，由 delivery 帧转投一次。
- 只 @ 别人不 @ 自己：`mentionOwnedByDelivery=false`，不会有 delivery 帧跟上，仍在 msg 帧转投一次（对照组不受影响）。

## #867 ① 失败原因被丢弃 + 降级日志说反话

`socketWakeProxyForwarder` 的 `return result.ok;` 把 `injectChannelMessage` 构造的 6 种
`{reason, detail}` 全丢了，降级日志固定打「当前无可用转投载体」——#841 时代那是实话
（默认载体是 `noWakeProxyForwarder`），#856 换成真载体后就成了反话。

- `WakeProxyForwarder` 返回类型放宽成 `boolean | WakeProxyForwardResult`（`{ok, reason?, detail?}`），
  裸 boolean 仍可用，内部 `normalizeForwardResult` 归一化——现有测试载体和骨架载体零改动。
- `socketWakeProxyForwarder` 透出 `reason`/`detail`；`attemptWakeProxy` 把它们放进 `WakeProxyAttempt`，
  降级日志改成 `reason=<真实原因> detail=<细节>`，**删掉**「当前无可用转投载体」与「见 #841 P3」。
- 载体没上报原因时打 `reason=unreported`，绝不编一个。抛错路径打 `reason=threw`。
- `noWakeProxyForwarder` 现在自报 `reason=no-carrier`——它才是**真的**「无载体」那条。
- 保持 hook/serve 静默铁律：仍然只走 `out`，不新增任何用户可见的打扰，只是把原来那句错话换成可诊断的真话。
- 附带：`InjectResult.ok:true` 的语义在注释里写死为「**字节已交给内核**」（`socket.end(payload, cb)`
  的回调只在 flush 后触发，不读响应、不订阅 `peer_message_status`，连 auth 行被拒都感知不到）。

## #867 ② 目标 socket 属主校验

模块里三处 `lstatSync` 校验了会话目录 / `<pid>.json` / `.key`，唯独要写入的 socket 一次都没验过——
那份安全完全继承自 Claude 建 `/tmp/cc-socks` 时的 0700。新增：

```ts
export function socketOwnershipFailure(sockPath: string): string | null
// isSymbolicLink() → 拒；!isSocket() → 拒；uid !== getuid() → 拒；lstat 抛错 → 拒
```

在 `injectChannelMessage` 里**探活 connect 之前**调用（探活也是一次 connect，不该连不属于我们的路径），
不符即 `{ok:false, reason:"socket-untrusted", detail:<判据>}`。

一处行为变化：socket 文件**根本不存在**这一档，以前打含糊的 `probe-failed`，现在被更早的属主校验以
`socket-untrusted` + `lstat failed: ENOENT` 细节拒掉，更精确。`probe-failed` 仍保留给「文件在、是自己的
真 socket、但无人 listen」的陈旧残留。相应更新了 `claude-inbox-inject.test.ts` 里那条既有断言。

## 变异验证（必须写进 PR body）

这条线上已连续三次「测试被 mock 掩盖、真机才暴露」，所以逐个拆掉修复确认断言真的变红：

| # | 拆掉的修复 | 结果 |
|---|---|---|
| 1 | serve.ts 去掉 `!mentionOwnedByDelivery` | **red** — `#866` 去重用例 fail（forwards 变成 2 条同 seq），对照组仍 pass |
| 2 | `socketWakeProxyForwarder` 恢复 `return result.ok;` | **red** — `serve-wake-proxy.test.ts` 14 pass / **10 fail** |
| 3 | `injectChannelMessage` 里不调 `socketOwnershipFailure` | **red** — 28 pass / **3 fail**（普通文件、符号链接、不存在路径三条） |
| 4 | `socketOwnershipFailure` 去掉 uid 比对分支 | **red** — 9 pass / **1 fail**（uid 用例） |

其中变异 2/3 的红是**多条**用例同时红，不是单点断言，说明覆盖不是靠一条巧合的断言撑着。
符号链接那条特别做了「一个字节都不写」的取证（软链后面是真 listener，校验若失效会收到帧）。

## 测试统计

- `bun test cli/test`：**1763 pass / 0 fail**（1763 across 122 files；修复前基线 1725 → 新增 38 条）
- `bunx tsc --noEmit`：cli/shared 11 条错误，与 main 基线逐条一致，全部在 `cli/scripts/*probe.ts`、
  `cli/src/rest.ts`、`cli/test/rest-mock.ts`、`cli/test/watch-single-instance.test.ts`——**没有一条**在本 PR 触碰的文件里。

## 并发说明

改动只落在 `cli/src/serve-wake-proxy.ts`、`cli/src/claude-inbox-inject.ts`、`cli/src/commands/serve.ts`
和 4 个 cli 测试文件。**没有碰** `cli/src/commands/claude-channel.ts`（#869）、`worker/`、`shared/src/protocol.ts`（#861）。
