### PR TITLE
fix(cli): party ack 只写本地账本——文案不再教人用它清 pending_mention_seqs；ack <seq>/重复 --seq 不再静默 (#859 #860)

### DIFF
--- a/cli/src/commands/ack.ts
+++ b/cli/src/commands/ack.ts
@@ -11,7 +11,18 @@ import { fetchRecentMessages, handleRestError } from "../rest";
 import { isSlug, parseNonNegativeIntFlag, parsePositiveIntFlag } from "../validation";
 
 const FLAGS = ["channel", "seq", "all", "through", "before"];
-const HELP = `usage: party ack [--channel C] [--seq N | --all | --through N | --before N]
+// #860①：同族命令（receipt/revise/capture/decision）的位置参数都是 seq，只有 ack 是频道 slug，
+// 而 SLUG_RE 收下纯数字串 → `party ack 1841` 曾静默读一个不存在的频道并 exit 0（用户以为债清了）。
+export const NUMERIC_POSITIONAL_ERROR =
+  "party ack takes a CHANNEL as its positional argument, not a seq — " +
+  "`party ack <seq>` would silently read a channel named after that number. " +
+  "Did you mean: party ack --seq N (or: party ack --channel C)?";
+// #860②：--seq 从来不是 repeatable（本地 watch 债本身就是单值的），旧行为是后者覆盖前者，
+// 于是 `--seq 5 --seq 7` 静默只 ack 7。宁可报错，也不静默丢一条。
+export const REPEATED_SEQ_ERROR =
+  "--seq may be given only once: party ack clears a single local watch wake debt, " +
+  "so `--seq A --seq B` would silently drop A. Use `party ack --through B` to clear everything up to B.";
+const HELP = `usage: party ack [channel|--channel C] [--seq N | --all | --through N | --before N]
 
 Acknowledge the pending watch wake debt without posting a message. Use it after
 a watch --once delivered a frame that warrants no reply (someone else's status,
@@ -26,30 +37,60 @@ messages from there.
 Only watch-sourced debt can be acked. Debt owned by party serve is never touched
 here: serve replays it durably and clearing it by hand would silently drop an @.
 
+LOCAL ONLY — this does NOT clear \`pending_mention_seqs\` (#859). There are two
+separate ledgers and this command writes only the first:
+  · LOCAL watch replay state (a file next to your config) — what \`party ack\` clears.
+    Clearing it stops YOUR watch from replaying that frame.
+  · SERVER-side @ delivery debt — what \`party who --json\` reports as
+    unhandled_mention_count / pending_mention_seqs. \`party ack\` sends no request
+    to the server and can never change it.
+To settle the server ledger you must answer the @: \`party send "…" --reply-to N\`
+(list several when one reply settles them all: \`--reply-to A,B\`). An @ you ack
+locally but never reply to stays owed server-side until its delivery lease expires,
+and is then recorded as a FAILED delivery with terminal_reason=unknown_outcome —
+so for an @ that deserves a one-liner, send the one-liner with --reply-to.
+
 Options:
   --channel C   channel to ack in (defaults to the bound channel)
   --seq N       acknowledge through exactly N; a newer pending wake is preserved
+                (single-valued: repeating --seq is an error, not a merge)
   --all         drain: advance cursor to channel head + clear all pending watch debt
   --through N   drain everything up to and including seq N (advance cursor to N)
   --before N    drain everything strictly before seq N (advance cursor to N-1)
 
 A successful later \`party send\` or status update acknowledges an earlier watch wake.
-Use \`party ack --seq N\` when no channel message is warranted.`;
+Use \`party ack --seq N\` when no channel message is warranted (and remember: that
+leaves the server-side @ debt for seq N standing — see LOCAL ONLY above).`;
 
 export async function run(argv: string[]): Promise<number> {
   if (isHelpArg(argv, { allowHelpPositional: true })) {
     console.log(HELP);
     return 0;
   }
-  const { positionals, flags } = parseArgs(argv, { booleans: ["all"] });
+  // #860②：把 --seq 收成数组只为「重复给了几次」可见——重复即报错，绝不静默取最后一个。
+  const { positionals, flags } = parseArgs(argv, { booleans: ["all"], repeatable: ["seq"] });
   const unknown = unknownFlagError(flags, FLAGS);
   if (unknown !== null) {
     console.error(unknown);
     return 1;
   }
+  const seqValues = Array.isArray(flags.seq) ? flags.seq : flags.seq === undefined ? [] : [flags.seq];
+  if (seqValues.length > 1) {
+    console.error(REPEATED_SEQ_ERROR);
+    return 1;
+  }
+  // 归一回单值，后续（互斥判定、parsePositiveIntFlag）保持原语义。
+  if (seqValues.length === 1) flags.seq = seqValues[0]!;
+  else delete flags.seq;
   const flagError = valueFlagError(flags, ["channel", "seq", "through", "before"]);
   if (flagError !== null) {
     console.error(flagError);
+    return 1;
+  }
+  // #860①：纯数字位置参数几乎一定是 seq 被当成频道名了——静默 no-op + exit 0 是最坏的结果。
+  const positional = positionals[0];
+  if (positional !== undefined && /^[0-9]+$/.test(positional)) {
+    console.error(NUMERIC_POSITIONAL_ERROR);
     return 1;
   }
   // --seq / --all / --through / --before 互斥：混用语义含糊，直接拒绝。

--- a/cli/src/commands/watch.ts
+++ b/cli/src/commands/watch.ts
@@ -142,8 +142,12 @@ export const ONCE_REARM_ADVISORY =
   // 还得先辨认是不是重放。查得到欠哪几条，才谈得上一次清准。
   "When one reply settles several, list them: `party send --reply-to 396,398`. " +
   "See exactly which seqs you owe right now: `party who --json` → pending_mention_seqs. " +
-  "For an @ you won't reply to, clear it with `party ack` (or `party ack --all`/`--through N`) " +
-  "instead of posting filler. " +
+  // #859：pending_mention_seqs 是服务端账本，`party ack` 只写本地文件——照旧文案操作清不掉它，
+  // 反而让那条 @ 挂到租约过期、被记成 failed/unknown_outcome。两本账必须分开说。
+  "That field is the SERVER's ledger and only a reply settles it — `party ack` writes local " +
+  "watch state only and can never clear it. For an @ that needs no substantive answer, send a " +
+  "one-line `party send \"noted\" --reply-to N` (this is what clears pending_mention_seqs); use " +
+  "`party ack` (or `--all`/`--through N`) only to stop your own watch from replaying a frame. " +
   // #708：Claude Code 会话内 watch --once / serve 都会被 turn 边界杀，无法可靠在线。真正的持久待命是
   // 「会话外」的第一方常驻——party daemon（持 WS、被 @ 就地跑 SDK、不依赖 turn 边界；桌面端可用 launchd 托管）。
   "For persistent presence that survives harness turn boundaries, run the first-party resident runner " +

--- a/cli/src/commands/who.ts
+++ b/cli/src/commands/who.ts
@@ -36,9 +36,12 @@ agent on serve / watch --follow) has read. No note = not a line-by-line reader.
 An "⚠ N unhandled @ #S1 #S2 …" note is durable reception debt: the agent still
 owes a terminal reply/failure for those mentions, and each replays until cleared.
 The debt is tracked PER DELIVERY, so clear it per seq — one reply that answers
-three @s still leaves the other two owed. Clear them explicitly:
-  party ack --seq S1 --seq S2      (or --through S to clear everything up to S)
+three @s still leaves the other two owed. This debt (and the JSON field
+pending_mention_seqs) is the SERVER's ledger, and only a reply settles it:
   party send "…" --reply-to S1,S2  (a reply may settle several at once)
+"party ack" does NOT clear it (#859): ack writes only local watch replay state, it
+sends no request to the server. Use ack to stop your own watch from replaying a
+frame — never as a way to make pending_mention_seqs go away.
 A "🤖 reception model:claude isolated" note means unattended @s to that name are
 answered by a resident runner in a SEPARATE per-channel session — it does not
 inherit that person's open conversation, so it does not know what they did today
@@ -66,7 +69,10 @@ session name), so mention the "@handle" shown here — not a UUID session name.
 Options:
   --channel C   read channel C instead of the bound channel
   --json        emit one JSON object per line
-                (name/kind/tier/unreachable/wake/wake_unverified/busy/queue_depth/waiting_owner_count/unhandled_mention_count/oldest_unhandled_mention_seq/pending_mention_seqs/last_receipt_seq/not_in_turn_since/current_task/task_started_at/heartbeat_at/activity/listening/runner_health/agent_session/topology_conflicts/reception_mode/reception_runner/reception_context/scope/scope_conflicts/account/handle/display_name/age_ms/read_seq)`;
+                (name/kind/tier/live/residency/unreachable/wake/wake_unverified/busy/queue_depth/waiting_owner_count/unhandled_mention_count/oldest_unhandled_mention_seq/pending_mention_seqs/last_receipt_seq/not_in_turn_since/current_task/task_started_at/heartbeat_at/activity/listening/runner_health/agent_session/topology_conflicts/reception_mode/reception_runner/reception_context/scope/scope_conflicts/account/handle/display_name/age_ms/read_seq)`;
+
+// 导出仅供单测断言 help 文案与真实行为一致（#859/#860：文档漂移过一次，用断言钉住）。
+export const HELP_TEXT = HELP;
 
 const STALE_MS = 60_000; // 与 DO presence 扫描一致
 const DEAD_MS = 14 * 24 * 60 * 60 * 1000; // 14 天没露面视为幽灵，不再列
@@ -92,6 +98,11 @@ interface Row {
   // （offline + 无 wake layer / 适配器陈旧）+ 已陈旧（>STALE_MS）。判定同 send 侧 unreachableOf、
   // 走 autoWakeReachable 权威口径。仅 recent 档、命中时带出；JSON 追加字段（向后兼容，不改旧字段）。
   unreachable?: true;
+  // #859 附：presence 明明下发了 live / residency，who 的 JSON 投影却把它们丢掉（live 只用于算
+  // tier 后即弃），于是 `party who --json | jq .live` 恒 null，与服务端状态无关——用 CLI 审计在线
+  // 状态会得出与服务端相反的结论。原样带出（缺失省略，不无中生有）。
+  live?: boolean;
+  residency?: PresenceEntry["residency"];
   // 人为暂停接待（#180）：与 offline 视觉区分——不是「掉线丢了」，是「人主动按下暂停」。
   // 暂停期该 agent 被 @ 也不唤醒（webhook 不投、serve/watch 自我抑制），消息仍进历史。
   paused?: true;
@@ -188,6 +199,8 @@ export function classify(e: PresenceEntry, now: number): Row | null {
     name: e.name,
     kind,
     tier,
+    ...(typeof e.live === "boolean" ? { live: e.live } : {}),
+    ...(e.residency === undefined ? {} : { residency: e.residency }),
     ...(unreachable ? { unreachable: true as const } : {}),
     ...(paused ? { paused: true as const, ...(typeof e.resume_at === "number" ? { resume_at: e.resume_at } : {}) } : {}),
     ...(wake === undefined ? {} : { wake }),

--- a/cli/test/ack-ledger-semantics.test.ts
+++ b/cli/test/ack-ledger-semantics.test.ts
@@ -1,0 +1,165 @@
+// #859 / #860：`party ack` 只写本地文件，碰不到服务端的 @ 投递账本（pending_mention_seqs）。
+// 这里守住三件事：(1) 文案不再教人用 ack 去清服务端账本；(2) ack 全程不联网，物理上不可能清它；
+// (3) `ack <seq>` / 重复 `--seq` 不再静默 no-op / 静默丢参数。
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { PresenceEntry } from "@agentparty/shared";
+import { NUMERIC_POSITIONAL_ERROR, REPEATED_SEQ_ERROR, run as runAck } from "../src/commands/ack";
+import { ONCE_REARM_ADVISORY } from "../src/commands/watch";
+import { classify, HELP_TEXT as WHO_HELP } from "../src/commands/who";
+import { loadStuck, saveWatchStuck } from "../src/config";
+
+let home: string;
+let cwd: string;
+let originalCwd: string;
+const oldEnv: Record<string, string | undefined> = {};
+
+function capture(): { lines: string[]; restore: () => void } {
+  const lines: string[] = [];
+  const log = console.log;
+  const err = console.error;
+  console.log = (...a: unknown[]) => void lines.push(a.join(" "));
+  console.error = (...a: unknown[]) => void lines.push(a.join(" "));
+  return {
+    lines,
+    restore: () => {
+      console.log = log;
+      console.error = err;
+    },
+  };
+}
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "ap-ack-ledger-home-"));
+  cwd = mkdtempSync(join(tmpdir(), "ap-ack-ledger-cwd-"));
+  for (const key of ["AGENTPARTY_HOME", "AGENTPARTY_CONFIG", "AGENTPARTY_CHANNEL"]) {
+    oldEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+  process.env.AGENTPARTY_HOME = home;
+  originalCwd = process.cwd();
+  process.chdir(cwd);
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  for (const [key, value] of Object.entries(oldEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  rmSync(home, { recursive: true, force: true });
+  rmSync(cwd, { recursive: true, force: true });
+});
+
+const watchDebt = (seq: number) => ({ seq, wake_ts: 1, attempts: 1, source: "watch" as const });
+
+describe("#859 两本账不能混为一谈", () => {
+  test("ack --help 明说本地账本，且不谎称能清 pending_mention_seqs", async () => {
+    const cap = capture();
+    expect(await runAck(["--help"])).toBe(0);
+    cap.restore();
+    const help = cap.lines.join("\n");
+    expect(help).toContain("pending_mention_seqs");
+    expect(help).toMatch(/LOCAL ONLY/);
+    expect(help).toContain("--reply-to");
+    // 不能出现「用 ack 清 pending_mention_seqs」这类同句并列。
+    expect(help).toMatch(/does NOT clear|can never change it/);
+  });
+
+  test("watch --once 的重挂提示不再把 ack 说成清 pending_mention_seqs 的手段", () => {
+    expect(ONCE_REARM_ADVISORY).toContain("pending_mention_seqs");
+    expect(ONCE_REARM_ADVISORY).toMatch(/SERVER's ledger and only a reply settles it/);
+    expect(ONCE_REARM_ADVISORY).toContain("--reply-to N");
+  });
+
+  test("who --help 不再把 ack 列为清 unhandled @ 的手段", () => {
+    expect(WHO_HELP).toContain("pending_mention_seqs");
+    expect(WHO_HELP).toContain("--reply-to S1,S2");
+    expect(WHO_HELP).toMatch(/"party ack" does NOT clear it/);
+  });
+
+  test("端到端：ack 清掉本地债，但全程零网络请求——服务端账本不可能被它改动", async () => {
+    expect(saveWatchStuck("dev", watchDebt(1841))).toBe(true);
+    const realFetch = globalThis.fetch;
+    let calls = 0;
+    globalThis.fetch = (async (...args: unknown[]) => {
+      calls++;
+      throw new Error(`party ack must not talk to the server: ${String(args[0])}`);
+    }) as unknown as typeof fetch;
+    try {
+      const cap = capture();
+      expect(await runAck(["--channel", "dev", "--seq", "1841"])).toBe(0);
+      cap.restore();
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+    // 本地债清了……
+    expect(loadStuck("dev")).toBeNull();
+    // ……服务端那本一次都没被访问过：所以「按提示 ack 后 pending_mention_seqs 会变」在物理上不成立，
+    // 提示只能指向真正有效的操作（--reply-to）。
+    expect(calls).toBe(0);
+  });
+});
+
+describe("#860 参数缺陷", () => {
+  test("① ack <seq> 不再静默 no-op：非零退出并指向 --seq", async () => {
+    expect(saveWatchStuck("dev", watchDebt(1841))).toBe(true);
+    process.env.AGENTPARTY_CHANNEL = "dev";
+    const cap = capture();
+    const code = await runAck(["1841"]);
+    cap.restore();
+    delete process.env.AGENTPARTY_CHANNEL;
+    expect(code).toBe(1);
+    expect(cap.lines.join("\n")).toBe(NUMERIC_POSITIONAL_ERROR);
+    // 债一条都没动。
+    expect(loadStuck("dev")?.seq).toBe(1841);
+  });
+
+  test("① 正常频道位置参数仍然工作", async () => {
+    expect(saveWatchStuck("dev", watchDebt(19))).toBe(true);
+    expect(await runAck(["dev"])).toBe(0);
+    expect(loadStuck("dev")).toBeNull();
+  });
+
+  test("② 重复 --seq 报错，不再静默丢弃第一个", async () => {
+    expect(saveWatchStuck("dev", watchDebt(5))).toBe(true);
+    const cap = capture();
+    const code = await runAck(["--channel", "dev", "--seq", "5", "--seq", "7"]);
+    cap.restore();
+    expect(code).toBe(1);
+    expect(cap.lines.join("\n")).toBe(REPEATED_SEQ_ERROR);
+    expect(loadStuck("dev")?.seq).toBe(5);
+  });
+
+  test("② 单个 --seq 不受影响", async () => {
+    expect(saveWatchStuck("dev", watchDebt(5))).toBe(true);
+    expect(await runAck(["--channel", "dev", "--seq", "5"])).toBe(0);
+    expect(loadStuck("dev")).toBeNull();
+  });
+});
+
+describe("#859 附：who --json 不再丢掉服务端下发的 live / residency", () => {
+  const NOW = 1_000_000_000;
+  const p = (over: Partial<PresenceEntry> & { name: string }): PresenceEntry => ({
+    state: "waiting",
+    note: null,
+    ts: NOW,
+    last_seen: NOW,
+    kind: "agent",
+    ...over,
+  });
+
+  test("live=true / residency 原样投影", () => {
+    const row = classify(p({ name: "bot", live: true, residency: "supervised" }), NOW);
+    expect(row?.live).toBe(true);
+    expect(row?.residency).toBe("supervised");
+  });
+
+  test("服务端没给就省略，不无中生有", () => {
+    const row = classify(p({ name: "bot" }), NOW);
+    expect(row?.live).toBeUndefined();
+    expect(row?.residency).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #860

#859 只做了「把话说对」那一半（issue 里的建议 2）+ 附带的 who --json 字段修复；**建议 1（服务端终态）没做，故不写 Closes #859**，详见下文「#859 剩余部分」。

## #859 的语义判断

两本账，`party ack` 物理上碰不到服务端那本：

| | `pending_mention_seqs` | `party ack` |
|---|---|---|
| 存哪 | 服务端 DO `directed_deliveries` | 本地 `<config>.json.state/state.json` |
| 谁能清 | `send --reply-to N`（含 `--reply-to A,B`）、status 帧 `summary_seq`、持租连接的终态 `delivery_update`、租约过期、保留期裁剪 | `ackWatchStuck` / `drainWatchStuck` |

`ack` 除 `--all` 求一次 head 外不发任何请求，所以**不是提示指向的操作没生效，而是提示本身在教错的东西**。真正有效、且今天就存在的操作只有一个：`party send "…" --reply-to N`。

判定：**先修文案，不动 worker**。三处不再把「用 `pending_mention_seqs` 核对」和「用 `party ack` 清账」并列，改成明确写出两本账的分界，并把「已读不回」的正确做法指向一行 `--reply-to` 回复：

- `cli/src/commands/ack.ts` HELP：新增 LOCAL ONLY 段，写明 ack 不发请求、永远改不了服务端账本，以及不回复的后果（租约过期 → failed / `terminal_reason=unknown_outcome`）。
- `cli/src/commands/watch.ts` `ONCE_REARM_ADVISORY`（#859 复现里那段原文）：改为 “That field is the SERVER's ledger and only a reply settles it”，把 `party ack` 降级为「只阻止你自己的 watch 重放」。
- `cli/src/commands/who.ts` HELP：删掉把 ack 列为清 unhandled @ 手段的写法。

顺带修 issue 附录：`who --json` 之前把服务端下发的 `live` / `residency` 整个丢掉（`live` 只用于算 tier 后即弃），导致 `jq .live` 恒 `null`、用 CLI 审计在线状态会得出与服务端相反的结论。现按「有才带出」原样投影。

### #859 剩余部分（需要服务端配合，本 PR 未做）

issue 建议 1：给「已读不回」一个真的服务端终态（如 REST `POST /api/channels/:slug/deliveries/:id/ack` + `terminal_reason=acknowledged_no_reply`），并为「同 principal 的显式 ack」在 `transitionDirectedDeliveryTerminal` 的 `expectedLeaseConnectionId` 闸上开口子。这属于 `worker/` + `shared/src/protocol.ts`，与并发进行中的 #861 撞面，未在本 PR 触碰。落地前，「已读不回」仍会被记成 `unknown_outcome`——现在至少文案把这个代价讲清楚了。

## #860

**① `party ack <seq>` 静默 no-op + exit 0** → 纯数字位置参数直接报错、退出码 1，并指向 `--seq N` / `--channel C`。没选「解释成 seq」，因为 ack 的位置参数一直是频道、9 个同族命令共用同一解析，静默改语义比报错更危险；报错把踩坑变成一行可读诊断。

**② `who --help` 教的 `--seq S1 --seq S2` 静默丢弃 S1** → 两头都修：`ack` 的 `--seq` 现在按 repeatable 解析、给多次即报错（本地 watch 债本来就是单值的，"多 seq ack" 从不存在），`who --help` 里那行用法删掉。

## 变异验证（逐个拆掉修复，确认断言变红）

| 变异 | 结果 |
|---|---|
| 删掉纯数字位置参数守卫 | ✗ `① ack <seq> 不再静默 no-op` |
| `repeatable: ["seq"]` 去掉 | ✗ `② 重复 --seq 报错，不再静默丢弃第一个` |
| 删掉 ack HELP 的 LOCAL ONLY 段 | ✗ `ack --help 明说本地账本…` |
| who HELP 改回「party ack also helps here」 | ✗ `who --help 不再把 ack 列为清 unhandled @ 的手段` |
| 删掉 watch advisory 里的 SERVER's ledger 句 | ✗ `watch --once 的重挂提示…` |
| 删掉 who classify 的 live/residency 投影 | ✗ `live=true / residency 原样投影` |

6/6 变异全部被抓。（另注：只把 "LOCAL ONLY" 改成 "LOCAL" 这类弱变异一开始没变红——因为同段落别处还留着该串；已确认改用整段删除的强变异复验。）

## 测试

`bun test cli/` 1756 pass / 0 fail；`bunx tsc --noEmit` 无新增 cli/shared 错误（仓库既有的 worker/test `cloudflare:test`、scripts `findLast` 报错为存量）。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - `party ack` 支持使用频道位置参数，并在 `party who --json` 中展示 `live` 与 `residency` 信息。
  - 帮助信息明确区分本地 watch 状态与服务端待处理 mention 的清理方式，并提供确认回复示例。

- **错误修复**
  - 拒绝纯数字频道参数，避免误认为序号。
  - 重复使用 `--seq` 时返回错误，防止参数被覆盖。
  - 更新 mention 清理说明，避免将 `ack` 误认为服务端清理方式。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->