### PR TITLE
fix(worker): announce-only 连接不再被当投递消费方拒绝 (#872)

### DIFF
--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -163,6 +163,11 @@ interface ConnState {
   directedDeliveryV1?: boolean;
   /** Socket negotiated token-fenced delivery recovery. */
   deliveryRecoveryV1?: boolean;
+  /**
+   * #872：本 socket 曾在 hello 里声明过 wake_kind（watch/daemon），即它自称有唤醒层。
+   * announce-only 判据的否定项之一——announce 腿从不声明 wake_kind。sticky：一旦声明过就永久为真。
+   */
+  wakeKindAdvertised?: boolean;
   /** New sockets do not receive live message frames until hello establishes replay/capabilities. */
   helloPending?: boolean;
   /** Highest message cursor declared by hello on this socket; legacy once may only reserve newer raw work. */
@@ -2753,11 +2758,14 @@ export class ChannelDO extends Server<Env> {
       // #675/#688：带内唤醒声明。取代原先挂载往时间线发 waiting 状态消息（刷屏 + 推高 seq）。
       // 只 agent 连接可声明可唤醒；wake_kind 断连由 markOffline 撤销。'watch'（residency=supervised）与
       // 'daemon'（residency=daemon，内嵌 SDK 的第一方常驻）合法，其余忽略。
+      let nextWakeKindAdvertised = st.wakeKindAdvertised === true;
       if (st.kind === "agent") {
         if (frame.wake_kind === "watch") {
           this.advertiseWatchWakePresence(st.name, connection.id, Date.now());
+          nextWakeKindAdvertised = true;
         } else if (frame.wake_kind === "daemon") {
           this.advertiseDaemonWakePresence(st.name, connection.id, Date.now());
+          nextWakeKindAdvertised = true;
         }
       }
       // Finish capability identity before replay. Live broadcasts were withheld while helloPending;
@@ -2766,6 +2774,7 @@ export class ChannelDO extends Server<Env> {
         ...st,
         directedDeliveryV1: nextDirectedDeliveryV1,
         deliveryRecoveryV1: nextDeliveryRecoveryV1,
+        wakeKindAdvertised: nextWakeKindAdvertised,
         ...(clientVersion === null ? {} : { clientVersion }),
         // Topology is a live snapshot, not a sticky capability. A later hello
         // that omits or corrupts it must clear the previous assertion.
@@ -9355,6 +9364,15 @@ export class ChannelDO extends Server<Env> {
         )
         .toArray()[0];
       if (row !== undefined) {
+        // #872：announce-only 连接不是投递消费方——不要求它升级 directed_delivery，也不把欠账
+        // 帧塞给它。live 广播照发（唤醒正是它的唯一职责），补拉出来的历史欠账一律抑制。
+        // 本分支纯读，绝不触碰 directed_deliveries 账本：欠账既不标记已投递也不清除，
+        // 仍等真正的消费方（serve/watch/webhook）来领。
+        if (this.isAnnounceOnlyConnection(st)) {
+          if (replay) return true;
+          this.sendFrame(connection, frame);
+          return true;
+        }
         const isExactLiveLegacyServeHandoff =
           !replay &&
           frame.type === "msg" &&
@@ -9375,6 +9393,23 @@ export class ChannelDO extends Server<Env> {
     }
     this.sendFrame(connection, frame);
     return true;
+  }
+
+  /**
+   * #872：announce-only 连接＝只声明 runtime_topology 的宣告腿（#841 P2 不变式：不 claim delivery、
+   * 不推进游标、不认领欠账）。判据保守且全为否定项，逐条读活状态而非握手瞬间的快照，
+   * 所以同一 socket 后来升级成消费方（第二次 hello 带 directed_delivery / serve_lease claim /
+   * delivery_adapter watch register）立刻失去豁免。
+   */
+  private isAnnounceOnlyConnection(st: ConnState | null | undefined): boolean {
+    return st?.kind === "agent" &&
+      st.helloPending !== true &&
+      st.runtimeTopology !== undefined &&
+      st.directedDeliveryV1 !== true &&
+      st.deliveryRecoveryV1 !== true &&
+      st.wakeKindAdvertised !== true &&
+      st.serveCandidate !== true &&
+      st.watchCandidate !== true;
   }
 
   private closeUpgradeRequired(connection: Connection<ConnState>, detail: string) {

--- a/worker/test/directed-delivery.spec.ts
+++ b/worker/test/directed-delivery.spec.ts
@@ -1,4 +1,9 @@
-import type { DirectedDelivery, DirectedDeliveryFrame, PublicDirectedDelivery } from "@agentparty/shared";
+import type {
+  DirectedDelivery,
+  DirectedDeliveryFrame,
+  PublicDirectedDelivery,
+  ServerFrame,
+} from "@agentparty/shared";
 import { env, runInDurableObject } from "cloudflare:test";
 import { describe, expect, it } from "vitest";
 import { type ChannelDO, DIRECTED_DELIVERY_QUEUED_TIMEOUT_MS } from "../src/do";
@@ -1313,5 +1318,214 @@ describe("排队超时收敛为终态（issue #667）", () => {
     expect((await deliveryRows(slug))[0]).toMatchObject({ id: work.delivery.id, state: "replied" });
     expect(await terminalReason(slug, work.delivery.id)).toBeNull();
     holder.close();
+  });
+});
+
+/**
+ * #872：announce-only 连接（#841 P2 的宣告腿）只声明 runtime_topology，从不 claim delivery。
+ * 服务端必须把它当**非投递消费方**：不要求 directed_delivery v1、不投欠账帧、只给 live 广播，
+ * 且该身份的 delivery 账本在整个 announce 连接生命周期内一字不改。
+ */
+describe("announce-only 连接不是投递消费方（issue #872）", () => {
+  const ANNOUNCE_TOPOLOGY = {
+    version: 1 as const,
+    node_ref: "node_announcebox",
+    runtime_ref: "runtime_announceone",
+    workspace_ref: "workspace_announce",
+    worktree_ref: "worktree_announce",
+    peer_scope: "local_installation" as const,
+    evidence: "client_asserted" as const,
+    harness_session: { harness: "claude" as const, display_name: "dormant-session" },
+  };
+
+  async function openAnnounce(slug: string, token: string, since = 0) {
+    const ws = await WsClient.open(slug, token);
+    await ws.nextOfType("welcome");
+    ws.send({
+      type: "hello",
+      since,
+      client_version: "0.2.191",
+      runtime_topology: ANNOUNCE_TOPOLOGY,
+    });
+    // 装饰过的 ping 走每连接队列，它的 pong 证明上面的 hello（含补拉）已处理完。
+    // 必须自己逐帧读到 pong 为止并把中间帧留证——nextOfType 会静默丢弃途中帧，
+    // 用它就会把「不该发的欠账帧」一起吃掉，断言随之失效。
+    ws.send({ type: "ping", barrier: "announce_hello" });
+    const handshake: ServerFrame[] = [];
+    for (;;) {
+      const frame = await ws.next();
+      if (frame.type === "pong") break;
+      handshake.push(frame);
+    }
+    return { ws, handshake };
+  }
+
+  it("有欠账的身份跑 announce：无 upgrade_required、无欠账帧、live 帧照收，账本零改动", async () => {
+    const sender = await seedToken("agent", uniq("sender"));
+    const target = await seedToken("agent", uniq("dormant"));
+    const slug = await createChannel(sender.token);
+
+    // 先制造 durable 欠账：目标离线时被 @，delivery 落 queued。
+    const owed = await sendMention(slug, sender.token, target.name, "owed while offline");
+    const before = await deliveryRows(slug);
+    expect(before).toMatchObject([{ message_seq: owed.seq, state: "queued", attempt: 0 }]);
+
+    const { ws: announce, handshake } = await openAnnounce(slug, target.token);
+    // 握手 + 补拉窗口里既没有 upgrade_required，也没有那条欠账消息。
+    expect(handshake.filter((frame) => frame.type === "error")).toEqual([]);
+    expect(handshake.filter((frame) => frame.type === "msg" && frame.seq === owed.seq)).toEqual([]);
+    // 账本在 announce 建连 + 补拉之后原封不动。
+    expect(await deliveryRows(slug)).toEqual(before);
+
+    // live 广播必须照收——这正是 announce 存在的理由。补拉阶段若真发了欠账帧或 error，
+    // 它们已在缓冲里排在 live 帧之前，这个循环必然先撞上。
+    const live = await sendMention(slug, sender.token, target.name, "live wake");
+    for (;;) {
+      const frame = await announce.next();
+      if (frame.type === "error") {
+        throw new Error(`announce-only socket was rejected: ${JSON.stringify(frame)}`);
+      }
+      if (frame.type === "msg" && frame.seq === owed.seq) {
+        throw new Error("announce-only socket received a backlog debt frame");
+      }
+      if (frame.type === "msg" && frame.seq === live.seq) {
+        expect(frame.replay).toBeUndefined();
+        break;
+      }
+    }
+
+    // live @ 也只是新增一条 queued 欠账，两条都没被 announce 消费。
+    expect(await deliveryRows(slug)).toMatchObject([
+      { message_seq: owed.seq, state: "queued", attempt: 0, lease_adapter: null, lease_connection_id: null },
+      { message_seq: live.seq, state: "queued", attempt: 0, lease_adapter: null, lease_connection_id: null },
+    ]);
+    const beforeClose = await deliveryRows(slug);
+
+    announce.close();
+    // 断开也不得改动账本（没有租约可回收、没有终态可写）。
+    expect(await deliveryRows(slug)).toEqual(beforeClose);
+  });
+
+  it("announce 与正常消费方并存：欠账只被 v1 serve 领走，announce 不插手", async () => {
+    const sender = await seedToken("agent", uniq("sender"));
+    const target = await seedToken("agent", uniq("both"));
+    const slug = await createChannel(sender.token);
+
+    const { ws: announce } = await openAnnounce(slug, target.token);
+    const capable = await WsClient.open(slug, target.token);
+    await capable.nextOfType("welcome");
+    expect((await claim(capable)).held).toBe(true);
+
+    const posted = await sendMention(slug, sender.token, target.name, "both legs online");
+    const delivery = await capable.nextOfType("delivery");
+    expect(delivery.delivery).toMatchObject({ message_seq: posted.seq, state: "claimed", attempt: 1 });
+    expect((await deliveryRows(slug))[0]).toMatchObject({ lease_adapter: "serve" });
+
+    // announce 收到的是 live 广播，绝不是 delivery。
+    for (;;) {
+      const frame = await announce.next();
+      if (frame.type === "delivery") throw new Error("announce-only socket was handed durable work");
+      if (frame.type === "error") throw new Error(`announce-only socket was rejected: ${JSON.stringify(frame)}`);
+      if (frame.type === "msg" && frame.seq === posted.seq) break;
+    }
+
+    announce.close();
+    capable.close();
+  });
+
+  it("回归：带 topology 但声明 directed_delivery 的 socket 仍是消费方；legacy 仍被 upgrade_required", async () => {
+    const sender = await seedToken("agent", uniq("sender"));
+    const target = await seedToken("agent", uniq("consumer"));
+    const slug = await createChannel(sender.token);
+
+    // 带 topology 但同时声明 directed_delivery v1 → 不是 announce-only，照常领 durable work。
+    const consumer = await WsClient.open(slug, target.token);
+    await consumer.nextOfType("welcome");
+    consumer.send({
+      type: "hello",
+      since: 0,
+      client_version: "0.2.191",
+      directed_delivery: "v1",
+      runtime_topology: ANNOUNCE_TOPOLOGY,
+    });
+    consumer.send({ type: "serve_lease", op: "claim" });
+    expect((await consumer.nextOfType("serve_lease")).held).toBe(true);
+    const posted = await sendMention(slug, sender.token, target.name, "still a consumer");
+    expect((await consumer.nextOfType("delivery")).delivery).toMatchObject({
+      message_seq: posted.seq,
+      state: "claimed",
+    });
+    consumer.close();
+
+    // 旧 CLI（无 topology、无能力声明）行为逐字不变。
+    const legacyTarget = await seedToken("agent", uniq("legacy"));
+    const legacySlug = await createChannel(sender.token);
+    const legacy = await WsClient.open(legacySlug, legacyTarget.token);
+    await legacy.nextOfType("welcome");
+    legacy.send({ type: "hello", since: 0, client_version: "0.2.117" });
+    legacy.raw('{"type":"ping"}');
+    await legacy.nextOfType("pong");
+    const legacyPosted = await sendMention(legacySlug, sender.token, legacyTarget.name, "legacy unchanged");
+    await expectUpgradeRequiredWithoutRaw(legacy, legacyPosted.seq);
+    expect((await deliveryRows(legacySlug))[0]).toMatchObject({ state: "queued", attempt: 0 });
+  });
+
+  it("回归：claim 过 serve 的 legacy socket 即便带 topology 也不是 announce，仍被 upgrade_required", async () => {
+    const sender = await seedToken("agent", uniq("sender"));
+    const target = await seedToken("agent", uniq("legacyserve"));
+    const slug = await createChannel(sender.token);
+    const capable = await WsClient.open(slug, target.token);
+    await capable.nextOfType("welcome");
+    expect((await claim(capable)).held).toBe(true);
+
+    const legacy = await WsClient.open(slug, target.token);
+    await legacy.nextOfType("welcome");
+    legacy.send({
+      type: "hello",
+      since: 0,
+      client_version: "0.2.117",
+      runtime_topology: ANNOUNCE_TOPOLOGY,
+    });
+    legacy.send({ type: "serve_lease", op: "claim" });
+    // claim 闸（v1 holder 已在）与 announce 豁免无关，必须原样拒绝带 topology 的 legacy serve。
+    await expectUpgradeRequiredWithoutRaw(legacy);
+    capable.close();
+  });
+
+  it("回归：注册了 watch 适配器的 v1-less socket 即便带 topology 也仍被 upgrade_required、raw 被抑制", async () => {
+    const sender = await seedToken("agent", uniq("sender"));
+    const target = await seedToken("agent", uniq("watchtopo"));
+    const slug = await createChannel(sender.token);
+    const watcher = await WsClient.open(slug, target.token);
+    await watcher.nextOfType("welcome");
+    watcher.send({
+      type: "hello",
+      since: 0,
+      client_version: "0.2.117",
+      runtime_topology: ANNOUNCE_TOPOLOGY,
+    });
+    watcher.send({ type: "delivery_adapter", adapter: "watch", op: "register" });
+    await watcher.nextOfType("delivery_adapter");
+
+    const posted = await sendMention(slug, sender.token, target.name, "watch adapter with topology");
+    await expectUpgradeRequiredWithoutRaw(watcher, posted.seq);
+  });
+
+  it("同一 socket 后续升级成 serve 消费方即失去 announce 豁免", async () => {
+    const sender = await seedToken("agent", uniq("sender"));
+    const target = await seedToken("agent", uniq("upgrader"));
+    const slug = await createChannel(sender.token);
+    const owed = await sendMention(slug, sender.token, target.name, "owed before upgrade");
+
+    const { ws } = await openAnnounce(slug, target.token);
+    expect((await deliveryRows(slug))[0]).toMatchObject({ state: "queued", attempt: 0 });
+
+    // 二次 hello 声明能力 + claim serve：这条 socket 现在是真消费方，欠账该被派给它。
+    ws.send({ type: "hello", since: 0, client_version: "0.2.191", directed_delivery: "v1" });
+    ws.send({ type: "serve_lease", op: "claim" });
+    expect((await ws.nextOfType("serve_lease")).held).toBe(true);
+    const delivery = await ws.nextOfType("delivery");
+    expect(delivery.delivery).toMatchObject({ message_seq: owed.seq, state: "claimed" });
+    ws.close();
   });
 });


### PR DESCRIPTION
Closes #872

## 问题

有 delivery 欠账的身份跑 announce-only 连接时，服务端先推若干历史欠账帧，再以
`{"type":"error","code":"unavailable","message":"upgrade_required: durable @X delivery requires directed_delivery v1"}`
关掉连接。`runDormantClaudeSessionAnnounce` 里 `if (frame.type === "error") return;` 收到即退出 →
announce 从未进入稳定收帧状态 → #857/#862/#869/#870 在有欠账的身份上全部无效。

## 方案（owner 决策的方向 1）

服务端把 announce-only 连接识别为**非投递消费方**：不做 `directed_delivery` 升级要求、不投欠账帧、只给 live 广播。
不采用「声明能力但不消费」，避免欠账被错误标记为已投递而吞消息。

### 识别 announce-only 的确切判据

`ChannelDO.isAnnounceOnlyConnection(st)`（`worker/src/do.ts`），全为否定项、逐条读**活状态**而非握手瞬间快照：

| 条件 | 字段 | 来源 |
|---|---|---|
| 是 agent 连接 | `st.kind === "agent"` | 鉴权 |
| hello 已完成 | `st.helloPending !== true` | hello |
| 声明了拓扑 | `st.runtimeTopology !== undefined` | hello `runtime_topology` |
| 未声明定向投递 | `st.directedDeliveryV1 !== true` | hello `directed_delivery: "v1"` |
| 未声明投递恢复 | `st.deliveryRecoveryV1 !== true` | hello `delivery_recovery: "v1"` |
| 未声明唤醒层 | `st.wakeKindAdvertised !== true` | hello `wake_kind`（本 PR 新增的 sticky state 字段） |
| 未 claim serve | `st.serveCandidate !== true` | `serve_lease` op=claim |
| 未注册 watch 适配器 | `st.watchCandidate !== true` | `delivery_adapter` adapter=watch op=register |

因为逐条读活状态，同一 socket 后来升级成消费方（第二次 hello 带 `directed_delivery`、或 `serve_lease` claim）
立刻失去豁免，欠账照常派给它。

### 欠账账本不受影响的证明

1. **代码层**：豁免分支位于 `sendPublicFrame`，纯读路径——只 `SELECT` 一次 `directed_deliveries` 判定，
   随后 `return true`（replay）或 `sendFrame`（live）。整条分支没有任何 SQL 写，也不调用
   `closeUpgradeRequired`（那只改连接状态）。announce 连接既不是 serve/watch 候选，
   `dispatchNextDirectedDelivery` 的候选口径根本不选它；断开时 `requeueDirectedDeliveriesForConnection`
   也查不到以它为 `lease_connection_id` 的行。
2. **测试层**：`deliveryRows(slug)` 全字段快照，在 announce 建连+补拉后 `toEqual(before)`，
   收完 live 帧后再断言两条欠账仍是 `queued/attempt 0/lease_adapter null/lease_connection_id null`，
   announce 断开后再 `toEqual` 一次断开前的快照。

## 测试（`worker/test/directed-delivery.spec.ts`，新增 describe「announce-only 连接不是投递消费方（issue #872）」）

1. 有欠账的身份跑 announce → 无 `upgrade_required`、无欠账帧、live 帧照收（`replay` 未标记）、账本前后零改动。
2. announce 与 v1 serve 并存 → 欠账只被 serve 领走（`lease_adapter: "serve"`），announce 只收 live `msg`、绝不收 `delivery`。
3. 回归：带 topology 但声明 `directed_delivery: "v1"` 的 socket 仍是消费方，照常领 durable work；
   旧 CLI（无 topology、无能力声明）仍被 `upgrade_required` 且 raw 被抑制。
4. 回归：v1 holder 在场时，带 topology 的 legacy serve claim 仍在 claim 闸被 `upgrade_required`（豁免不泄漏到那道闸）。
5. 回归：注册了 watch 适配器的 v1-less socket 即便带 topology 也仍被 `upgrade_required`、raw 被抑制。
6. 同一 socket 二次 hello 声明 `directed_delivery: "v1"` + claim serve → 立刻失去豁免，欠账派给它。

**测试踩坑记录**：`WsClient.nextOfType` 会静默丢弃途中帧。第一版用它做 hello 屏障，把「不该发的欠账帧」
一起吃掉，导致断言假绿（变异验证时才暴露）。改成自己逐帧读到 `pong` 并把中间帧留证再断言。

## 变异验证

| 变异 | 结果 |
|---|---|
| 豁免分支整体短路（`if (false && ...)`） | 用例 1/2/6 变红（3 failed / 33 passed） |
| 豁免不区分 replay（欠账帧照发给 announce） | 用例 1 变红（1 failed / 35 passed）——**第一版测试对此假绿，正是它暴露了 nextOfType 吞帧** |
| 判据放宽（去掉 `serveCandidate`/`watchCandidate` 两条） | 用例 5 变红（1 failed / 37 passed） |
| 等价实现替换（把 helper 调用拆成两条同义分支） | 38 passed，对照/回归组不误红 |

## 测试统计

- `worker`：directed-delivery.spec.ts 38 passed（新增 6）；全量 `vitest run` 816 passed（一次 listening-streak 用例的已知偶发抖动，重跑全绿，与本改动无关，CLI 未改动）
- `cli`：`bun test` 1753 passed / 0 fail
- `tsc --noEmit`：worker / cli / shared 均通过

## 本机复验

1. 挑一个**有 delivery 欠账**的身份（有人 @ 过你、serve/watch 还没消费掉那条）。
2. 部署这条分支的 worker 后，用该身份跑 announce（`party claude channel` 的蛰伏宣告腿，或直接用 `runtime_topology`-only 的 hello 建连）。
3. 期望：连接稳定，不再出现 `upgrade_required` error 帧，也不再收到 seq 远小于 since 的历史欠账帧；
   随后在频道里 @ 你，announce 腿应收到 live 帧并注入唤醒宿主会话。
4. 同时用 REST 查该身份的 delivery：欠账仍在（未被 announce 消费或标记），等 serve/watch 上线照常领走。
