### PR TITLE
feat(cli): codex 会话入册 + 协议放行 codex harness (#851 P1+P2)

### DIFF
--- a/cli/src/claude-session-registry.ts
+++ b/cli/src/claude-session-registry.ts
@@ -1,13 +1,20 @@
-// 本机 Claude 会话注册表（issue #841 P1）。
+// 本机交互式会话注册表（issue #841 P1、#851 P2）。
 //
-// 目的：人日常开的交互式 `claude`（装了 agentparty 插件）在 SessionStart 时入册、
-// SessionEnd 时出册，让 party 侧（蛰伏 MCP 的 announce 档、后续 serve 唤醒代理）
-// 知道「本机有哪些还活着的交互式 Claude 会话」。注册表只是本机发现提示：
+// 目的：人日常开的交互式 `claude`（装了 agentparty 插件）/ `codex`（装了 codex hooks）
+// 在 SessionStart 时入册，让 party 侧（蛰伏 MCP 的 announce 档、后续 serve 唤醒代理）
+// 知道「本机有哪些还活着的交互式会话」。注册表只是本机发现提示：
 // 频道仍是唯一数据源，条目永远不构成任何鉴权、路由或投递依据。
 //
-// 落盘：~/.agentparty/claude-sessions/<session_id 小写>.json（目录 0700、文件 0600）。
+// 落盘：~/.agentparty/<harness>-sessions/<session_id 小写>.json（目录 0700、文件 0600）。
+// **每个 harness 一个独立目录**，这是 #851 的硬安全边界：`listClaudeSessions()` 只读
+// claude 目录，所以 claude 专用的 PID 寻址（claude-inbox-inject 的
+// resolveSessionSocketByPid / nativeSessionName，都假定目标进程有 cc-socks 收件箱）
+// 在结构上就拿不到 codex 条目——codex 没有那套 UDS，误用会把消息投到不存在的地方。
+// 条目里额外记 `harness` 字段做二道防线：目录与字段不符的行按坏行丢弃。
+// 旧条目（#841 时期写的、没有 harness 字段）视为 claude，读写完全兼容。
+//
 // 目录校验与 claude-cross-session-gate.ts 的 gateDirectory 同款：拒符号链接、
-// 拒组/他人可读、拒非本 uid。AGENTPARTY_CLAUDE_SESSION_REGISTRY_DIR 可覆盖（测试用）。
+// 拒组/他人可读、拒非本 uid。AGENTPARTY_{CLAUDE,CODEX}_SESSION_REGISTRY_DIR 可覆盖（测试用）。
 import {
   closeSync,
   lstatSync,
@@ -21,8 +28,22 @@ import { isAbsolute, join } from "node:path";
 import { agentpartyHome } from "./config";
 import { atomicWriteJson } from "./atomic-json";
 
+/** 注册表覆盖的 harness 维度（#851 P2）。每个值对应一个独立目录。 */
+export type SessionRegistryHarness = "claude" | "codex";
+
 export const CLAUDE_SESSION_REGISTRY_DIR_ENV = "AGENTPARTY_CLAUDE_SESSION_REGISTRY_DIR";
-/** 容量上限：满了先剔死行，仍满则拒新——绝不覆盖活行。 */
+export const CODEX_SESSION_REGISTRY_DIR_ENV = "AGENTPARTY_CODEX_SESSION_REGISTRY_DIR";
+
+const REGISTRY_DIR_ENV: Record<SessionRegistryHarness, string> = {
+  claude: CLAUDE_SESSION_REGISTRY_DIR_ENV,
+  codex: CODEX_SESSION_REGISTRY_DIR_ENV,
+};
+const REGISTRY_DIR_NAME: Record<SessionRegistryHarness, string> = {
+  claude: "claude-sessions",
+  codex: "codex-sessions",
+};
+
+/** 容量上限：满了先剔死行，仍满则拒新——绝不覆盖活行。每个 harness 目录各自计数。 */
 export const CLAUDE_SESSION_REGISTRY_CAPACITY = 128;
 
 const SESSION_ID_RE =
@@ -68,6 +89,16 @@ export interface ClaudeSessionRegistryEntry {
   channel: string;
   cwd: string;
   registered_at: number;
+  /**
+   * 条目所属 harness（#851 P2）。#841 时期写的旧条目没有这个字段 → 读作 "claude"。
+   * 目录才是权威身份；这个字段只是「目录与内容不符即丢弃」的二道防线。
+   */
+  harness?: SessionRegistryHarness;
+}
+
+/** 旧条目（无 harness 字段）视为 claude。 */
+export function sessionEntryHarness(entry: ClaudeSessionRegistryEntry): SessionRegistryHarness {
+  return entry.harness ?? "claude";
 }
 
 function record(value: unknown): value is Record<string, unknown> {
@@ -93,7 +124,8 @@ function validEntry(value: unknown): value is ClaudeSessionRegistryEntry {
     value.cwd !== "" &&
     isAbsolute(value.cwd) &&
     typeof value.registered_at === "number" &&
-    Number.isFinite(value.registered_at);
+    Number.isFinite(value.registered_at) &&
+    (value.harness === undefined || value.harness === "claude" || value.harness === "codex");
 }
 
 function validDirectory(path: string): string | null {
@@ -112,15 +144,16 @@ function validDirectory(path: string): string | null {
 }
 
 /** 解析注册表目录；`create` 只对默认路径生效——环境变量覆盖的目录必须已存在且合规。 */
-export function claudeSessionRegistryDirectory(
+export function sessionRegistryDirectory(
+  harness: SessionRegistryHarness,
   env: NodeJS.ProcessEnv = process.env,
   create = false,
 ): string | null {
-  const override = env[CLAUDE_SESSION_REGISTRY_DIR_ENV];
+  const override = env[REGISTRY_DIR_ENV[harness]];
   if (typeof override === "string" && override !== "") {
     return isAbsolute(override) ? validDirectory(override) : null;
   }
-  const path = join(agentpartyHome(), "claude-sessions");
+  const path = join(agentpartyHome(), REGISTRY_DIR_NAME[harness]);
   const existing = validDirectory(path);
   if (existing !== null || !create) return existing;
   try {
@@ -129,6 +162,14 @@ export function claudeSessionRegistryDirectory(
     return null;
   }
   return validDirectory(path);
+}
+
+/** @deprecated 保留 #841 的名字；等价于 `sessionRegistryDirectory("claude", …)`。 */
+export function claudeSessionRegistryDirectory(
+  env: NodeJS.ProcessEnv = process.env,
+  create = false,
+): string | null {
+  return sessionRegistryDirectory("claude", env, create);
 }
 
 /** kill(pid, 0) 探活：EPERM 也算活（进程在，只是不属于我们——注册表不该出现，但按活处理更保守）。 */
@@ -141,7 +182,11 @@ function pidAlive(pid: number): boolean {
   }
 }
 
-function readEntry(directory: string, filename: string): ClaudeSessionRegistryEntry | null {
+function readEntry(
+  directory: string,
+  filename: string,
+  harness: SessionRegistryHarness,
+): ClaudeSessionRegistryEntry | null {
   const path = join(directory, filename);
   try {
     const stat = lstatSync(path);
@@ -156,6 +201,9 @@ function readEntry(directory: string, filename: string): ClaudeSessionRegistryEn
     if (!validEntry(value)) return null;
     // 文件名就是身份：不一致的行按坏行处理，防止一个 session 冒名另一个。
     if (`${value.session_id.toLowerCase()}.json` !== filename) return null;
+    // 二道防线（#851）：目录是权威 harness 身份。内容自称另一个 harness 的行按坏行丢弃——
+    // 否则一个写进 claude-sessions/ 的 codex 条目会被 claude 专用的 PID/UDS 寻址捡走。
+    if (sessionEntryHarness(value) !== harness) return null;
     return value;
   } catch {
     return null;
@@ -166,10 +214,11 @@ function readEntry(directory: string, filename: string): ClaudeSessionRegistryEn
  * 列出仍然存活的入册会话（按 registered_at 升序）。
  * 死行（pid 不在）与坏行（解析/校验失败）现场清除。
  */
-export function listClaudeSessions(
+export function listSessions(
+  harness: SessionRegistryHarness,
   env: NodeJS.ProcessEnv = process.env,
 ): ClaudeSessionRegistryEntry[] {
-  const directory = claudeSessionRegistryDirectory(env);
+  const directory = sessionRegistryDirectory(harness, env);
   if (directory === null) return [];
   let filenames: string[];
   try {
@@ -180,7 +229,7 @@ export function listClaudeSessions(
   const alive: ClaudeSessionRegistryEntry[] = [];
   for (const filename of filenames) {
     if (!ENTRY_FILE_RE.test(filename)) continue;
-    const entry = readEntry(directory, filename);
+    const entry = readEntry(directory, filename, harness);
     if (entry !== null && pidAlive(entry.pid)) {
       alive.push(entry);
       continue;
@@ -195,13 +244,36 @@ export function listClaudeSessions(
 }
 
 /**
- * 入册会话在 party 侧的宣告名（#841 P2/P3 共用同一权威定义，防词表漂移）：
- * 有 display_name 用 display_name，否则回退 `claude-<session_id 前 12 个 hex>`。
+ * **只读 claude 目录**（#851 硬约束②）：调用方（serve-wake-proxy 的唤醒代理、
+ * claude-channel 的蛰伏 announce 档）随后都会走 claude 专用的 PID→cc-socks UDS 寻址。
+ * codex 会话没有那套收件箱，必须永远出现不了在这个列表里——所以按目录隔离，而不是
+ * 「一个目录 + 过滤」，漏一次过滤就是投错。codex 用 `listCodexSessions()`。
  */
-export function claudeSessionAnnounceName(entry: ClaudeSessionRegistryEntry): string {
-  if (entry.display_name !== null) return entry.display_name;
-  return `claude-${entry.session_id.toLowerCase().replace(/-/g, "").slice(0, 12)}`;
+export function listClaudeSessions(
+  env: NodeJS.ProcessEnv = process.env,
+): ClaudeSessionRegistryEntry[] {
+  return listSessions("claude", env);
 }
+
+/** 列出仍然存活的入册 codex 会话（#851 P2）。绝不喂给 claude 的 UDS 寻址。 */
+export function listCodexSessions(
+  env: NodeJS.ProcessEnv = process.env,
+): ClaudeSessionRegistryEntry[] {
+  return listSessions("codex", env);
+}
+
+/**
+ * 入册会话在 party 侧的宣告名（#841 P2/P3、#851 共用同一权威定义，防词表漂移）：
+ * 有 display_name 用 display_name，否则回退 `<harness>-<session_id 前 12 个 hex>`。
+ */
+export function sessionAnnounceName(entry: ClaudeSessionRegistryEntry): string {
+  if (entry.display_name !== null) return entry.display_name;
+  const prefix = sessionEntryHarness(entry);
+  return `${prefix}-${entry.session_id.toLowerCase().replace(/-/g, "").slice(0, 12)}`;
+}
+
+/** @deprecated #841 的名字；等价于 `sessionAnnounceName`（claude 条目行为逐字不变）。 */
+export const claudeSessionAnnounceName = sessionAnnounceName;
 
 export function claudeSessionAlive(
   sessionId: string,
@@ -219,18 +291,23 @@ export interface RegisterClaudeSessionInput {
   channel: string;
   cwd: string;
   registered_at?: number;
+  /** 省略即 claude（保持 #841 调用点逐字不变）。 */
+  harness?: SessionRegistryHarness;
 }
 
 /**
- * 入册一个交互式 Claude 会话。已入册的同一 session 重复注册（resume/clear）覆盖自身。
+ * 入册一个交互式会话。已入册的同一 session 重复注册（resume/clear）覆盖自身。
  * 容量满时先剔死行；仍满则拒绝（返回 false），绝不覆盖别人的活行。
+ * 容量与锁都按 harness 目录各自独立——codex 会话刷满不会挤掉 claude 会话。
  */
-export function registerClaudeSession(
+export function registerSession(
   input: RegisterClaudeSessionInput,
   env: NodeJS.ProcessEnv = process.env,
 ): boolean {
+  const harness: SessionRegistryHarness = input.harness ?? "claude";
   const entry: ClaudeSessionRegistryEntry = {
     version: 1,
+    harness,
     session_id: input.session_id,
     pid: input.pid,
     display_name:
@@ -242,7 +319,7 @@ export function registerClaudeSession(
     registered_at: input.registered_at ?? Date.now(),
   };
   if (!validEntry(entry)) return false;
-  const directory = claudeSessionRegistryDirectory(env, true);
+  const directory = sessionRegistryDirectory(harness, env, true);
   if (directory === null) return false;
   const filename = `${entry.session_id.toLowerCase()}.json`;
   // 容量检查 + 写入必须互斥：并发 SessionStart hook 是多进程，两个进程同时通过
@@ -251,8 +328,8 @@ export function registerClaudeSession(
   const lockFd = waitForRegisterLock(lockPath);
   if (lockFd === null) return false;
   try {
-    // listClaudeSessions 顺带剔死行/坏行，让容量判断只数活行。
-    const alive = listClaudeSessions(env);
+    // listSessions 顺带剔死行/坏行，让容量判断只数活行。
+    const alive = listSessions(harness, env);
     const replacingSelf = alive.some(
       (existing) => existing.session_id.toLowerCase() === entry.session_id.toLowerCase(),
     );
@@ -267,12 +344,24 @@ export function registerClaudeSession(
   }
 }
 
-export function unregisterClaudeSession(
+/** @deprecated #841 的名字；等价于 `registerSession`（默认 harness=claude）。 */
+export const registerClaudeSession = registerSession;
+
+/** 入册一个交互式 codex 会话（#851 P2）。 */
+export function registerCodexSession(
+  input: Omit<RegisterClaudeSessionInput, "harness">,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return registerSession({ ...input, harness: "codex" }, env);
+}
+
+export function unregisterSession(
+  harness: SessionRegistryHarness,
   sessionId: string,
   env: NodeJS.ProcessEnv = process.env,
 ): boolean {
   if (!isClaudeSessionRegistrySessionId(sessionId)) return false;
-  const directory = claudeSessionRegistryDirectory(env);
+  const directory = sessionRegistryDirectory(harness, env);
   if (directory === null) return false;
   try {
     rmSync(join(directory, `${sessionId.toLowerCase()}.json`), { force: true });
@@ -280,4 +369,28 @@ export function unregisterClaudeSession(
   } catch {
     return false;
   }
+}
+
+/** @deprecated #841 的名字；等价于 `unregisterSession("claude", …)`。 */
+export function unregisterClaudeSession(
+  sessionId: string,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return unregisterSession("claude", sessionId, env);
+}
+
+/**
+ * 出册一个 codex 会话（#851 P2）。
+ *
+ * 注意：codex 0.145 **没有 SessionEnd/SessionStop 这类会话结束 hook**（实测其内嵌
+ * JSON schema 只有 pre/post-tool-use、permission-request、pre/post-compact、
+ * session-start、subagent-start/stop、user-prompt-submit、stop 十种）。所以正常退出
+ * 路径上没人调用这个函数——codex 条目靠 `listSessions` 的 kill(pid,0) 探活现场剔除。
+ * 这里保留显式出册入口给测试与将来 codex 补上结束事件时接线。
+ */
+export function unregisterCodexSession(
+  sessionId: string,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return unregisterSession("codex", sessionId, env);
 }

--- a/cli/src/commands/hook.ts
+++ b/cli/src/commands/hook.ts
@@ -28,6 +28,7 @@ import { atomicWriteJson, atomicWriteText } from "../atomic-json";
 import {
   isClaudeSessionRegistrySessionId,
   registerClaudeSession,
+  registerCodexSession,
   unregisterClaudeSession,
 } from "../claude-session-registry";
 import { nativeSessionName } from "../claude-inbox-inject";
@@ -35,7 +36,7 @@ import { isHelpArg } from "../args";
 import { isPartyBinaryPath } from "../upgrade";
 import { CLAUDE_LIFECYCLE_OPT_IN_ENV } from "./claude-launch";
 
-const HELP = `usage: party hook <report|stop-guard|push|install|uninstall|status>
+const HELP = `usage: party hook <report|codex-report|stop-guard|push|install|uninstall|status>
 
 Claude Code hook adapter (issues #602/#615): report what the model session is
 actually doing (running a tool / waiting on permission / compacting / idle)
@@ -47,8 +48,15 @@ into channel presence, so \`party who\` and the web can see it.
                        This is a legacy/manual compatibility path: ordinary
                        Claude sessions remain local-only. Presence uplink needs
                        party claude, party bridge claude, or a managed serve lane.
-  uninstall [--user]   remove exactly the entries install added
-  status [--user]      show whether the hooks are installed
+                       --codex: write the codex SessionStart hook into
+                        ~/.codex/hooks.json instead (#851). Existing content is
+                        preserved; a parse failure aborts without writing.
+  uninstall [--user|--codex]   remove exactly the entries install added
+  status [--user|--codex]      show whether the hooks are installed
+  codex-report         (wired by \`install --codex\`) read one codex hook event
+                       from stdin and register an interactive codex session into
+                       ~/.agentparty/codex-sessions/ so party can discover it.
+                       Registry only — never presence, never network.
   report               (wired by install / party serve) read one hook event from
                        stdin, record the local activity snapshot. Under a managed
                        \`party serve\` runner the serve heartbeat uplinks it; in an
@@ -263,7 +271,7 @@ async function runPush(argv: string[]): Promise<number> {
 
 // ---- hooks 安装（#615）----
 
-const HOOK_COMMAND_MARKERS = ["hook report", "hook stop-guard"] as const;
+const HOOK_COMMAND_MARKERS = ["hook report", "hook stop-guard", "hook codex-report"] as const;
 
 interface HookEntry {
   matcher?: string;
@@ -294,10 +302,31 @@ function stripOurCommands(entries: unknown[]): unknown[] {
     .filter((entry): entry is NonNullable<typeof entry> => entry !== null);
 }
 
-export function settingsPath(scope: "project" | "user", cwd: string = process.cwd()): string {
+export type HookScope = "project" | "user" | "codex";
+
+export function settingsPath(scope: HookScope, cwd: string = process.cwd()): string {
+  if (scope === "codex") return join(homedir(), ".codex", "hooks.json");
   return scope === "user"
     ? join(homedir(), ".claude", "settings.json")
     : join(cwd, ".claude", "settings.local.json");
+}
+
+/**
+ * codex 的 hooks 片段（#851 P2）。~/.codex/hooks.json 的顶层就是 `{ "hooks": { … } }`，
+ * 条目形状（`{ hooks: [{ type: "command", command, timeout? }] }`）与 Claude settings
+ * 的 hooks 完全同形，所以 mergeHookSettings/removeHookSettings 原样复用——包括它
+ * 「只增删自己的命令、解析失败即抛错拒写」的保护。
+ *
+ * codex 只有 SessionStart 可用于入册：其内嵌 schema 没有任何会话结束事件。
+ */
+export function codexHookSettingsJson(execPath: string = process.execPath): string {
+  const partyBin = isPartyBinaryPath(execPath) ? execPath : "party";
+  const command = `${partyBin === "party" ? partyBin : JSON.stringify(partyBin)} hook codex-report`;
+  return JSON.stringify({
+    hooks: {
+      SessionStart: [{ hooks: [{ type: "command", command, timeout: 10 }] }],
+    },
+  });
 }
 
 /**
@@ -347,11 +376,25 @@ export function removeHookSettings(source: string): string {
   return `${JSON.stringify(settings, null, 2)}\n`;
 }
 
-function hookScope(argv: string[]): "project" | "user" {
-  // 只认 `--` 终止符之前的 --user；`hook install -- --user` 保持 project 作用域。
+export function hookScope(argv: string[]): HookScope {
+  // 只认 `--` 终止符之前的旗标；`hook install -- --user` 保持 project 作用域。
   const boundary = argv.indexOf("--");
   const flags = boundary === -1 ? argv : argv.slice(0, boundary);
+  if (flags.includes("--codex")) return "codex";
   return flags.includes("--user") ? "user" : "project";
+}
+
+/**
+ * 写前备份（#864 教训：接入包曾整份覆盖用户 settings.json，销毁数据）。
+ * merge/remove 本身解析失败即抛错、调用方直接中止不写；备份是第二层保险，
+ * 让「写了但结果不对」也能人工回退。备份失败不阻断（原文件仍在，且写是原子的）。
+ */
+function backupBeforeWrite(path: string, source: string): void {
+  try {
+    atomicWriteText(`${path}.agentparty.bak`, source);
+  } catch {
+    // best effort
+  }
 }
 
 // 终端输出的动态部分（路径/异常消息）统一剥控制字符——路径可能来自不受信的 repo 目录名。
@@ -366,19 +409,25 @@ async function runInstall(argv: string[]): Promise<number> {
   const source = existsSync(path) ? readFileSync(path, "utf8") : null;
   // serve 用同一份 hooks 配置生成器（#602），装出来的行为与托管 lane 完全一致。
   const { claudeHookSettingsJson } = await import("./serve");
+  const fragment = scope === "codex" ? codexHookSettingsJson() : claudeHookSettingsJson();
   let next: string;
   try {
-    next = mergeHookSettings(source, claudeHookSettingsJson());
+    next = mergeHookSettings(source, fragment);
   } catch (e) {
+    // 解析失败即中止不写（#864）：宁可让人手工修，也绝不覆盖看不懂的用户内容。
     console.error(`无法解析 ${termText(path)}（${termText(e instanceof Error ? e.message : String(e))}）；请先手工修复该文件`);
     return 1;
   }
+  if (source !== null) backupBeforeWrite(path, source);
   // 进程死在写中途会留半截 JSON——毁掉的正是 merge 拼命保护的用户手写配置（#617 评审）。
   atomicWriteText(path, next);
   console.log(`hooks installed -> ${termText(path)}`);
   console.log(
-    "普通 Claude session 只写本地 activity；频道 presence 上行仍需 party claude、" +
-      "party bridge claude 或托管 serve lane。",
+    scope === "codex"
+      ? "codex 交互式会话现在会在 SessionStart 入册到 ~/.agentparty/codex-sessions/；" +
+        "codex 无会话结束事件，出册靠进程探活。唤醒仍走 party bridge codex。"
+      : "普通 Claude session 只写本地 activity；频道 presence 上行仍需 party claude、" +
+        "party bridge claude 或托管 serve lane。",
   );
   return 0;
 }
@@ -390,13 +439,15 @@ async function runUninstall(argv: string[]): Promise<number> {
     console.log(`nothing to remove（${termText(path)} 不存在）`);
     return 0;
   }
+  const source = readFileSync(path, "utf8");
   let next: string;
   try {
-    next = removeHookSettings(readFileSync(path, "utf8"));
+    next = removeHookSettings(source);
   } catch (e) {
     console.error(`无法解析 ${termText(path)}（${termText(e instanceof Error ? e.message : String(e))}）；请先手工修复该文件`);
     return 1;
   }
+  backupBeforeWrite(path, source);
   atomicWriteText(path, next);
   console.log(`hooks removed <- ${termText(path)}`);
   return 0;
@@ -507,6 +558,62 @@ export function recordClaudeSessionLifecycle(
   } catch {
     // hook 铁律：注册表任何失败都不配影响模型。
   }
+}
+
+/**
+ * codex 会话入册（issue #851 P2）——`party hook codex-report` 的全部职责。
+ *
+ * 为什么不复用 `hook report`：codex 的 SessionStart payload 与 Claude 的**同形**
+ * （都带 hook_event_name/session_id/cwd），单看 payload 分不出 harness。同一个入口
+ * 会把 codex 会话写进 claude 注册表，进而被 claude 专用的 PID→cc-socks UDS 寻址捡走
+ * 投递到不存在的收件箱。harness 只能由「装在谁的 hooks 里」决定，所以给 codex 一个
+ * 独立子命令，写独立目录。
+ *
+ * codex 0.145 实测 SessionStart payload（取自二进制内嵌的 session-start.command.input
+ * JSON schema，required 全在）：
+ *   { cwd, hook_event_name: "SessionStart", model, permission_mode, session_id,
+ *     source: "startup"|"resume"|"clear"|"compact", transcript_path: string|null }
+ * 没有 pid（同 Claude），所以记 process.ppid；没有任何展示名字段，display_name 恒 null，
+ * 宣告名回退 `codex-<12hex>`。codex 也没有 SessionEnd——出册靠 kill(pid,0) 探活剔除。
+ *
+ * 铁律同 report：stdout 恒空、任何失败静默 exit 0、不等网络。
+ */
+export function recordCodexSessionLifecycle(
+  record: Record<string, unknown>,
+  env: NodeJS.ProcessEnv = process.env,
+  pid: number = process.ppid,
+): void {
+  try {
+    if (record.hook_event_name !== "SessionStart") return;
+    const sessionId = record.session_id;
+    if (!isClaudeSessionRegistrySessionId(sessionId)) return;
+    // serve 托管 lane 是被管理的 runner 会话，不是人开的交互式会话——同 Claude 档不入册。
+    if (env.AP_ACTIVITY_FILE) return;
+    const cwd = typeof record.cwd === "string" && record.cwd.length > 0 ? record.cwd : process.cwd();
+    const channel = env.AGENTPARTY_CHANNEL ?? readState(cwd)?.channel;
+    if (!channel) return;
+    registerCodexSession({
+      session_id: sessionId,
+      pid,
+      display_name: claudeSessionDisplayNameFromHookPayload(record),
+      channel,
+      cwd,
+    }, env);
+  } catch {
+    // hook 铁律：注册表任何失败都不配影响模型。
+  }
+}
+
+/** `party hook codex-report`：读一条 codex hook 事件，只做入册。stdout 恒空。 */
+async function runCodexHookInput(): Promise<number> {
+  try {
+    const payload = JSON.parse(await readStdin(MAX_STDIN_BYTES)) as unknown;
+    if (typeof payload !== "object" || payload === null || Array.isArray(payload)) return 0;
+    recordCodexSessionLifecycle(payload as Record<string, unknown>);
+  } catch {
+    // 坏 JSON / 写盘失败都不配阻断 codex。
+  }
+  return 0;
 }
 
 function reportHookPayload(
@@ -622,6 +729,7 @@ export async function run(argv: string[]): Promise<number> {
   if (sub === "uninstall") return runUninstall(rest);
   if (sub === "status") return runStatus(rest);
   if (sub === "push") return runPush(rest);
+  if (sub === "codex-report") return runCodexHookInput();
   if (sub !== "report" && sub !== "stop-guard") {
     // 会写 stderr 的分支只剩人在终端敲错子命令。真 hook 调用恒为 `hook report`，不受影响。
     console.error(HELP);

--- a/cli/test/codex-session-registry.test.ts
+++ b/cli/test/codex-session-registry.test.ts
@@ -1,0 +1,298 @@
+// #851 P2：codex 会话入册。
+//
+// 这里的核心不是「codex 能写进去」，而是三条隔离不变量：
+//   ① codex 条目永远不出现在 listClaudeSessions()——那是 claude 专用 PID→cc-socks
+//      UDS 寻址（resolveSessionSocketByPid / nativeSessionName）的输入，codex 没有
+//      那套收件箱，混进去就是把消息投到不存在的地方；
+//   ② claude 条目同样不出现在 listCodexSessions()；
+//   ③ 旧条目（#841 写的、无 harness 字段）仍按 claude 读得出来。
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { chmodSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  CLAUDE_SESSION_REGISTRY_CAPACITY,
+  CLAUDE_SESSION_REGISTRY_DIR_ENV,
+  CODEX_SESSION_REGISTRY_DIR_ENV,
+  claudeSessionAlive,
+  listClaudeSessions,
+  listCodexSessions,
+  registerClaudeSession,
+  registerCodexSession,
+  sessionAnnounceName,
+  sessionEntryHarness,
+  unregisterCodexSession,
+} from "../src/claude-session-registry";
+import { recordCodexSessionLifecycle } from "../src/commands/hook";
+import { resolveSessionSocketByPid } from "../src/claude-inbox-inject";
+
+// 本机实测的 codex session id 形如 019f95e8-2c0b-7903-8779-cd102c5ecd4c（UUIDv7）。
+const CODEX_SESSION_ID = "019f95e8-2c0b-7903-8779-cd102c5ecd4c";
+const CLAUDE_SESSION_ID = "11111111-1111-4111-8111-111111111111";
+
+/** codex 0.145 的真实 SessionStart payload（字段取自二进制内嵌 JSON schema 的 required）。 */
+function codexSessionStartPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    cwd: "/tmp/project",
+    hook_event_name: "SessionStart",
+    model: "gpt-5.1-codex",
+    permission_mode: "default",
+    session_id: CODEX_SESSION_ID,
+    source: "startup",
+    transcript_path: null,
+    ...overrides,
+  };
+}
+
+let claudeDir: string;
+let codexDir: string;
+let env: NodeJS.ProcessEnv;
+
+beforeEach(() => {
+  claudeDir = mkdtempSync(join(tmpdir(), "agentparty-claude-sessions-"));
+  codexDir = mkdtempSync(join(tmpdir(), "agentparty-codex-sessions-"));
+  chmodSync(claudeDir, 0o700);
+  chmodSync(codexDir, 0o700);
+  env = {
+    [CLAUDE_SESSION_REGISTRY_DIR_ENV]: claudeDir,
+    [CODEX_SESSION_REGISTRY_DIR_ENV]: codexDir,
+  };
+});
+
+afterEach(() => {
+  rmSync(claudeDir, { recursive: true, force: true });
+  rmSync(codexDir, { recursive: true, force: true });
+});
+
+describe("codex session registry", () => {
+  test("register / list / unregister round-trip，harness 落盘为 codex", () => {
+    expect(registerCodexSession({
+      session_id: CODEX_SESSION_ID,
+      pid: process.pid,
+      display_name: null,
+      channel: "dev",
+      cwd: "/tmp/project",
+      registered_at: 1_000,
+    }, env)).toBe(true);
+    const listed = listCodexSessions(env);
+    expect(listed).toHaveLength(1);
+    expect(listed[0]).toMatchObject({
+      version: 1,
+      harness: "codex",
+      session_id: CODEX_SESSION_ID,
+      pid: process.pid,
+      channel: "dev",
+    });
+    // 落进 codex 目录，claude 目录里一个文件都没有。
+    expect(readdirSync(codexDir)).toContain(`${CODEX_SESSION_ID}.json`);
+    expect(readdirSync(claudeDir)).toHaveLength(0);
+    expect(unregisterCodexSession(CODEX_SESSION_ID, env)).toBe(true);
+    expect(listCodexSessions(env)).toHaveLength(0);
+  });
+
+  test("不变量①②：两个 harness 的条目互不可见，claudeSessionAlive 也不认 codex", () => {
+    expect(registerCodexSession({
+      session_id: CODEX_SESSION_ID,
+      pid: process.pid,
+      display_name: null,
+      channel: "dev",
+      cwd: "/tmp/project",
+    }, env)).toBe(true);
+    expect(registerClaudeSession({
+      session_id: CLAUDE_SESSION_ID,
+      pid: process.pid,
+      display_name: null,
+      channel: "dev",
+      cwd: "/tmp/project",
+    }, env)).toBe(true);
+
+    expect(listClaudeSessions(env).map((e) => e.session_id)).toEqual([CLAUDE_SESSION_ID]);
+    expect(listCodexSessions(env).map((e) => e.session_id)).toEqual([CODEX_SESSION_ID]);
+    // claudeSessionAlive 是 claude 侧寻址前的存在性闸门——它对 codex session 必须为 false。
+    expect(claudeSessionAlive(CODEX_SESSION_ID, env)).toBe(false);
+    expect(claudeSessionAlive(CLAUDE_SESSION_ID, env)).toBe(true);
+  });
+
+  test("不变量①（防误用取证）：codex 条目喂不进 claude 的 PID→UDS 寻址", () => {
+    expect(registerCodexSession({
+      session_id: CODEX_SESSION_ID,
+      pid: process.pid,
+      display_name: null,
+      channel: "dev",
+      cwd: "/tmp/project",
+    }, env)).toBe(true);
+    // claude 侧唤醒代理的取数只有这一条路径。它拿不到 codex 条目，
+    // 所以根本不会有人把一个 codex pid 交给 resolveSessionSocketByPid。
+    const claudePids = listClaudeSessions(env).map((entry) => entry.pid);
+    expect(claudePids).toHaveLength(0);
+    // 二道防线：即便有人硬把 codex 条目塞进 claude 目录，读取也按坏行丢弃。
+    writeFileSync(
+      join(claudeDir, `${CODEX_SESSION_ID}.json`),
+      JSON.stringify({
+        version: 1,
+        harness: "codex",
+        session_id: CODEX_SESSION_ID,
+        pid: process.pid,
+        display_name: null,
+        channel: "dev",
+        cwd: "/tmp/project",
+        registered_at: 1_000,
+      }),
+      { mode: 0o600 },
+    );
+    expect(listClaudeSessions(env)).toHaveLength(0);
+    // 坏行被现场清除，不留残渣。
+    expect(readdirSync(claudeDir)).toHaveLength(0);
+    // 反向同理：claude 条目塞进 codex 目录也不认。
+    writeFileSync(
+      join(codexDir, `${CLAUDE_SESSION_ID}.json`),
+      JSON.stringify({
+        version: 1,
+        harness: "claude",
+        session_id: CLAUDE_SESSION_ID,
+        pid: process.pid,
+        display_name: null,
+        channel: "dev",
+        cwd: "/tmp/project",
+        registered_at: 1_000,
+      }),
+      { mode: 0o600 },
+    );
+    expect(listCodexSessions(env).map((e) => e.session_id)).toEqual([CODEX_SESSION_ID]);
+    // resolveSessionSocketByPid 本身仍是 claude 专用寻址：给一个没有 cc-socks 的
+    // pid（本进程）必须解析不出收件箱。
+    expect(resolveSessionSocketByPid(process.pid, { env: { HOME: codexDir } }))
+      .toMatchObject({ ok: false });
+  });
+
+  test("不变量③：#841 时期的旧条目（无 harness 字段）仍按 claude 读得出来", () => {
+    writeFileSync(
+      join(claudeDir, `${CLAUDE_SESSION_ID}.json`),
+      JSON.stringify({
+        version: 1,
+        session_id: CLAUDE_SESSION_ID,
+        pid: process.pid,
+        display_name: null,
+        channel: "dev",
+        cwd: "/tmp/project",
+        registered_at: 1_000,
+      }),
+      { mode: 0o600 },
+    );
+    const listed = listClaudeSessions(env);
+    expect(listed).toHaveLength(1);
+    expect(sessionEntryHarness(listed[0]!)).toBe("claude");
+    // 旧条目的宣告名逐字不变（#841 契约）。
+    expect(sessionAnnounceName(listed[0]!)).toBe("claude-111111111111");
+  });
+
+  test("宣告名：codex 条目回退 codex-<12hex>，display_name 优先", () => {
+    expect(sessionAnnounceName({
+      version: 1,
+      harness: "codex",
+      session_id: CODEX_SESSION_ID,
+      pid: 1,
+      display_name: null,
+      channel: "dev",
+      cwd: "/tmp",
+      registered_at: 0,
+    })).toBe("codex-019f95e82c0b");
+    expect(sessionAnnounceName({
+      version: 1,
+      harness: "codex",
+      session_id: CODEX_SESSION_ID,
+      pid: 1,
+      display_name: "my-codex",
+      channel: "dev",
+      cwd: "/tmp",
+      registered_at: 0,
+    })).toBe("my-codex");
+  });
+
+  test("容量按 harness 目录各自独立：codex 刷满挤不掉 claude", () => {
+    for (let n = 0; n < CLAUDE_SESSION_REGISTRY_CAPACITY; n += 1) {
+      expect(registerCodexSession({
+        session_id: `019f95e8-2c0b-7903-8779-${String(n).padStart(12, "0")}`,
+        pid: process.pid,
+        display_name: null,
+        channel: "dev",
+        cwd: "/tmp/project",
+      }, env)).toBe(true);
+    }
+    // codex 满了，新的 codex 会话被拒。
+    expect(registerCodexSession({
+      session_id: CODEX_SESSION_ID,
+      pid: process.pid,
+      display_name: null,
+      channel: "dev",
+      cwd: "/tmp/project",
+    }, env)).toBe(false);
+    // claude 目录不受影响。
+    expect(registerClaudeSession({
+      session_id: CLAUDE_SESSION_ID,
+      pid: process.pid,
+      display_name: null,
+      channel: "dev",
+      cwd: "/tmp/project",
+    }, env)).toBe(true);
+  });
+});
+
+describe("codex hook lifecycle wiring", () => {
+  test("真实 SessionStart payload 入册；payload 无展示名 → display_name 恒 null", () => {
+    const hookEnv = { ...env, AGENTPARTY_CHANNEL: "dev" };
+    recordCodexSessionLifecycle(codexSessionStartPayload(), hookEnv, process.pid);
+    const listed = listCodexSessions(env);
+    expect(listed).toHaveLength(1);
+    expect(listed[0]).toMatchObject({
+      harness: "codex",
+      session_id: CODEX_SESSION_ID,
+      pid: process.pid,
+      display_name: null,
+      channel: "dev",
+      cwd: "/tmp/project",
+    });
+    expect(sessionAnnounceName(listed[0]!)).toBe("codex-019f95e82c0b");
+    // 入册永远只碰 codex 目录。
+    expect(readdirSync(claudeDir)).toHaveLength(0);
+  });
+
+  test("resume/clear/compact 覆盖自身而不是新增", () => {
+    const hookEnv = { ...env, AGENTPARTY_CHANNEL: "dev" };
+    for (const source of ["startup", "resume", "clear", "compact"]) {
+      recordCodexSessionLifecycle(codexSessionStartPayload({ source }), hookEnv, process.pid);
+    }
+    expect(listCodexSessions(env)).toHaveLength(1);
+  });
+
+  test("无频道 / serve 托管 lane / 非 SessionStart 事件都不入册", () => {
+    // 无频道（cwd 不是任何已绑定频道的项目，且没有 AGENTPARTY_CHANNEL）。
+    recordCodexSessionLifecycle(codexSessionStartPayload({ cwd: codexDir }), env, process.pid);
+    expect(listCodexSessions(env)).toHaveLength(0);
+    // serve 托管 lane 是被管理的 runner，不是人开的交互式会话。
+    recordCodexSessionLifecycle(
+      codexSessionStartPayload(),
+      { ...env, AGENTPARTY_CHANNEL: "dev", AP_ACTIVITY_FILE: "/tmp/a.json" },
+      process.pid,
+    );
+    expect(listCodexSessions(env)).toHaveLength(0);
+    // codex 的其它事件与坏 session_id。
+    const hookEnv = { ...env, AGENTPARTY_CHANNEL: "dev" };
+    recordCodexSessionLifecycle(
+      codexSessionStartPayload({ hook_event_name: "PreToolUse" }), hookEnv, process.pid,
+    );
+    recordCodexSessionLifecycle(
+      codexSessionStartPayload({ session_id: "../evil" }), hookEnv, process.pid,
+    );
+    expect(listCodexSessions(env)).toHaveLength(0);
+  });
+
+  test("hook 铁律：注册表不可用也绝不抛", () => {
+    const hookEnv = { ...env, AGENTPARTY_CHANNEL: "dev" };
+    chmodSync(codexDir, 0o750);
+    expect(() => recordCodexSessionLifecycle(codexSessionStartPayload(), hookEnv, process.pid))
+      .not.toThrow();
+    expect(listCodexSessions(env)).toHaveLength(0);
+    chmodSync(codexDir, 0o700);
+  });
+});

--- a/cli/test/hook-install.test.ts
+++ b/cli/test/hook-install.test.ts
@@ -1,6 +1,6 @@
 // #615：hook install 的幂等合并 / 交互 lane 直报的节流与 push 端到端。
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { writeActivityFile } from "../src/activity";
@@ -324,6 +324,97 @@ describe("party hook install end-to-end (project scope)", () => {
     expect((await runIn("uninstall")).code).toBe(0);
     expect((await runIn("status")).code).toBe(1);
     rmSync(project, { recursive: true, force: true });
+  });
+});
+
+describe("party hook install --codex (#851 P2)", () => {
+  // 本机 ~/.codex/hooks.json 的真实形状（otty / vibe-island / superset 三方共存），
+  // 结构原样保留、内容缩短。#864 事故的同类错误绝不许再犯：安装必须只增自己那条。
+  const REAL_WORLD_CODEX_HOOKS = {
+    hooks: {
+      SessionStart: [
+        { hooks: [{ type: "command", command: "SUPERSET_AGENT_ID=codex \"/Users/x/.superset/hooks/notify.sh\"" }] },
+        { _otty: true, hooks: [{ type: "command", command: "'/Applications/Otty.app/.../otty-hook.sh' idle \"$PPID\"" }] },
+      ],
+      PostToolUse: [
+        { matcher: "", hooks: [{ type: "command", command: "'/Users/x/.vibe-island/bin/vibe-island-bridge' --source codex", timeout: 5 }] },
+      ],
+    },
+  };
+
+  async function runCodex(fakeHome: string, ...args: string[]) {
+    const proc = Bun.spawn(["bun", "run", indexPath, "hook", ...args, "--codex"], {
+      cwd: fakeHome,
+      env: { ...process.env, HOME: fakeHome, AGENTPARTY_HOME: home },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [code, stdout, stderr] = await Promise.all([
+      proc.exited,
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+    ]);
+    return { code, stdout, stderr };
+  }
+
+  test("装进 ~/.codex/hooks.json，既有第三方 hooks 一条不少；status/uninstall 往返", async () => {
+    const fakeHome = mkdtempSync(join(tmpdir(), "ap-codexhome-"));
+    const hooksPath = join(fakeHome, ".codex", "hooks.json");
+    mkdirSync(join(fakeHome, ".codex"), { recursive: true });
+    const before = JSON.stringify(REAL_WORLD_CODEX_HOOKS, null, 2);
+    writeFileSync(hooksPath, before);
+
+    expect((await runCodex(fakeHome, "status")).code).toBe(1);
+    const installed = await runCodex(fakeHome, "install");
+    expect(installed.code).toBe(0);
+    expect(installed.stdout).toContain("codex-sessions");
+
+    const after = JSON.parse(readFileSync(hooksPath, "utf8")) as typeof REAL_WORLD_CODEX_HOOKS;
+    // 别人的条目逐字保留（含 _otty 私有字段、matcher、timeout）。
+    expect(after.hooks.PostToolUse).toEqual(REAL_WORLD_CODEX_HOOKS.hooks.PostToolUse);
+    expect(after.hooks.SessionStart.slice(0, 2)).toEqual(REAL_WORLD_CODEX_HOOKS.hooks.SessionStart);
+    // 只多了我们这一条。
+    expect(after.hooks.SessionStart).toHaveLength(3);
+    expect(JSON.stringify(after.hooks.SessionStart[2])).toContain("hook codex-report");
+    // 写前备份留在旁边，人工可回退（#864）。
+    expect(readFileSync(`${hooksPath}.agentparty.bak`, "utf8")).toBe(before);
+
+    // 幂等：再装一次不重复追加。
+    expect((await runCodex(fakeHome, "install")).code).toBe(0);
+    expect((JSON.parse(readFileSync(hooksPath, "utf8")) as typeof REAL_WORLD_CODEX_HOOKS)
+      .hooks.SessionStart).toHaveLength(3);
+
+    expect((await runCodex(fakeHome, "status")).code).toBe(0);
+    expect((await runCodex(fakeHome, "uninstall")).code).toBe(0);
+    // 卸载后恢复成用户原样。
+    expect(JSON.parse(readFileSync(hooksPath, "utf8"))).toEqual(REAL_WORLD_CODEX_HOOKS);
+    expect((await runCodex(fakeHome, "status")).code).toBe(1);
+    rmSync(fakeHome, { recursive: true, force: true });
+  });
+
+  test("hooks.json 解析失败即中止不写——绝不覆盖看不懂的用户内容（#864）", async () => {
+    const fakeHome = mkdtempSync(join(tmpdir(), "ap-codexhome-bad-"));
+    const hooksPath = join(fakeHome, ".codex", "hooks.json");
+    mkdirSync(join(fakeHome, ".codex"), { recursive: true });
+    const broken = '{ "hooks": { "SessionStart": [ }';
+    writeFileSync(hooksPath, broken);
+    const result = await runCodex(fakeHome, "install");
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain("请先手工修复该文件");
+    // 原文件一个字节都没动，也没留备份（根本没走到写）。
+    expect(readFileSync(hooksPath, "utf8")).toBe(broken);
+    expect(existsSync(`${hooksPath}.agentparty.bak`)).toBe(false);
+    rmSync(fakeHome, { recursive: true, force: true });
+  });
+
+  test("hooks 键写坏成数组时同样拒写", async () => {
+    const fakeHome = mkdtempSync(join(tmpdir(), "ap-codexhome-arr-"));
+    const hooksPath = join(fakeHome, ".codex", "hooks.json");
+    mkdirSync(join(fakeHome, ".codex"), { recursive: true });
+    writeFileSync(hooksPath, '{"hooks": ["oops"]}');
+    expect((await runCodex(fakeHome, "install")).code).toBe(1);
+    expect(readFileSync(hooksPath, "utf8")).toBe('{"hooks": ["oops"]}');
+    rmSync(fakeHome, { recursive: true, force: true });
   });
 });
 

--- a/cli/test/runtime-topology.test.ts
+++ b/cli/test/runtime-topology.test.ts
@@ -153,6 +153,35 @@ describe("runtime topology identity", () => {
       harness_session: { harness: "claude", display_name: "unsafe.dot" },
     })).toBeUndefined();
   });
+
+  test("#851 P1: harness_session 放行 codex，且只放行词表内的值", () => {
+    const topology = buildRuntimeTopology("https://party.example", "/repo", {
+      secret: "33".repeat(32),
+      runtimeId: "runtimeaaaaaaaa",
+      git: () => null,
+    })!;
+    // codex 必须原样通过——而不是被静默改写成 claude（那会让 codex 会话冒充可
+    // ListAgents 寻址的 Claude 会话）。
+    expect(parseRuntimeTopology({
+      ...topology,
+      harness_session: { harness: "codex", display_name: "codex-019f95e82c0b" },
+    })?.harness_session).toEqual({
+      harness: "codex",
+      display_name: "codex-019f95e82c0b",
+    });
+    // 词表外的 harness 仍然整帧拒收。
+    for (const harness of ["gemini", "", "CLAUDE", 1, null, undefined]) {
+      expect(parseRuntimeTopology({
+        ...topology,
+        harness_session: { harness, display_name: "some-session" },
+      })).toBeUndefined();
+    }
+    // display_name 白名单对 codex 一样生效。
+    expect(parseRuntimeTopology({
+      ...topology,
+      harness_session: { harness: "codex", display_name: "unsafe name" },
+    })).toBeUndefined();
+  });
 });
 
 describe("runtime peer discovery parser", () => {

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -558,9 +558,17 @@ export interface RuntimeTopology {
   worktree_ref: string;
   peer_scope: "local_installation";
   evidence: "client_asserted";
-  /** Optional safe display hint for a live harness session on this runtime. */
+  /**
+   * Optional safe display hint for a live harness session on this runtime.
+   *
+   * `harness` names which interactive CLI the session belongs to (#851 P1). It is
+   * a display/kind hint only — never an addressing contract. In particular the
+   * server's `claude_sessions` projection deliberately admits `"claude"` only,
+   * because every consumer of that array resolves the hint through Claude's own
+   * ListAgents/SendMessage surface, which cannot reach a codex session.
+   */
   harness_session?: {
-    harness: "claude";
+    harness: "claude" | "codex";
     display_name: string;
   };
 }
@@ -744,6 +752,16 @@ const TOPOLOGY_REF_RE = /^(?:node|runtime|workspace|worktree)_[A-Za-z0-9_-]{8,64
 const TOPOLOGY_SESSION_NAME_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
 const CLAUDE_SESSION_NAME_RE = /^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$/;
 
+/** #851 P1：harness_session.harness 的权威词表。新增 harness 只改这里。 */
+export const HARNESS_SESSION_HARNESSES = ["claude", "codex"] as const;
+
+export function isHarnessSessionHarness(
+  value: unknown,
+): value is NonNullable<RuntimeTopology["harness_session"]>["harness"] {
+  return typeof value === "string" &&
+    (HARNESS_SESSION_HARNESSES as readonly string[]).includes(value);
+}
+
 export function parseRuntimeTopology(input: unknown): RuntimeTopology | undefined {
   if (typeof input !== "object" || input === null || Array.isArray(input)) return undefined;
   const value = input as Record<string, unknown>;
@@ -767,7 +785,7 @@ export function parseRuntimeTopology(input: unknown): RuntimeTopology | undefine
       typeof value.harness_session !== "object" ||
       value.harness_session === null ||
       Array.isArray(value.harness_session) ||
-      (value.harness_session as Record<string, unknown>).harness !== "claude" ||
+      !isHarnessSessionHarness((value.harness_session as Record<string, unknown>).harness) ||
       typeof (value.harness_session as Record<string, unknown>).display_name !== "string" ||
       !CLAUDE_SESSION_NAME_RE.test(
         (value.harness_session as Record<string, unknown>).display_name as string,
@@ -788,7 +806,8 @@ export function parseRuntimeTopology(input: unknown): RuntimeTopology | undefine
       ? {}
       : {
           harness_session: {
-            harness: "claude" as const,
+            harness: (value.harness_session as Record<string, unknown>)
+              .harness as NonNullable<RuntimeTopology["harness_session"]>["harness"],
             display_name: (value.harness_session as Record<string, unknown>).display_name as string,
           },
         }),


### PR DESCRIPTION
#851 P1+P2 切片，P3 待 #872。

## P1 协议放行 codex

`RuntimeTopology.harness_session.harness` 由写死 `"claude"` 扩为 `"claude" | "codex"`；词表集中在 `HARNESS_SESSION_HARNESSES`，`parseRuntimeTopology` 的运行时校验改用 `isHarnessSessionHarness`，并把解析出的值原样带出（而不是硬编码回 `"claude"`）。

- **client.ts 镜像**：查过了，`cli/src/client.ts` 对 `runtime_topology` 没有任何字段 allow-list（第 656 行整体透传），#622 那类逐字镜像要求不适用于本改动。#871 的自动镜像守卫（`cli/test/replay-frame-allowlist.test.ts`）仍然全绿。
- **worker peers 投影：不是「零改动可复用」，issue 的判断需要修正。** `worker/src/do.ts:11897` 的 `claude_sessions` 明确只收 `harness === "claude"`。这**不该改**，而且我没改：`claude_sessions` 是一个寻址契约，它的每个下游消费者（`claude-cross-session-gate` 的 ListAgents 相关、`agents.ts` 的 local-direct、`bridge.ts` 给模型的指令）都会把 hint 拿去 Claude 自己的 ListAgents/SendMessage 解析——把 codex 塞进去等于让 codex 会话冒充一个可 ListAgents 寻址的 Claude 会话。
  - 实际效果：codex 的 topology 现在能被服务端接收并参与 relations 比对（`same_worktree` 等），**但不会出现在 `claude_sessions` 里**。P3 若要让 codex 也按名字被发现，需要一个独立的投影字段，不能复用这个数组。也因此本 PR 没有碰 `do.ts` 一行。

## P2 注册表泛化方案与理由

**选了「按 harness 分独立目录」，不是「一个目录 + harness 字段过滤」。**

理由就是本 issue 的硬约束②。`resolveSessionSocketByPid` / `nativeSessionName` 那套 Claude 专用寻址假定目标进程挂着 cc-socks UDS 收件箱；codex 没有。这套寻址的**唯一取数入口**是 `listClaudeSessions()`。做成一个目录 + 过滤的话，安全性取决于「每个调用点都记得过滤」——漏一次就是把消息投到不存在的地方，而且是静默的。分目录之后 `listClaudeSessions()` 只 readdir claude 目录，codex 条目在结构上就取不到。

条目里仍然加了 `harness` 字段，但它只是**二道防线**：目录才是权威身份，`readEntry` 发现内容自称另一个 harness 就按坏行丢弃并清除。旧条目（#841 时期写的、无 harness 字段）读作 `"claude"`，读写完全兼容——`listClaudeSessions` / `registerClaudeSession` / `claudeSessionAnnounceName` 等 #841 的导出名全部保留为薄封装，行为逐字不变。容量与注册锁也各自独立：codex 刷满 128 条挤不掉任何 claude 条目。

## codex hooks 的真实 payload 结构

取自 codex-cli 0.145.0 二进制内嵌的 `session-start.command.input` JSON schema（不是推断），required 字段全在：

```json
{
  "cwd": "string",
  "hook_event_name": "SessionStart",
  "model": "string",
  "permission_mode": "default|acceptEdits|plan|dontAsk|bypassPermissions",
  "session_id": "string",
  "source": "startup|resume|clear|compact",
  "transcript_path": "string|null"
}
```

三个要点：

1. **没有 pid**（同 Claude）→ 记 `process.ppid`。
2. **没有任何展示名字段** → `display_name` 恒 `null`，宣告名回退 `codex-<12hex>`。Claude 档那个「机会性读 `~/.claude/sessions/<pid>.json`」的兜底对 codex 无对应物。
3. **codex 根本没有会话结束事件**。它内嵌的 hook input schema 只有十种：`pre-tool-use`、`permission-request`、`post-tool-use`、`pre-compact`、`post-compact`、`session-start`、`subagent-start`、`subagent-stop`、`user-prompt-submit`、`stop`。没有 `SessionEnd`。所以出册没有正常触发路径——codex 条目靠 `listSessions` 的 `kill(pid, 0)` 探活现场剔除（这条机制 #841 本来就有）。`unregisterCodexSession` 保留为显式入口，给测试和将来 codex 补上结束事件时接线。

session_id 是 UUIDv7（实测 `019f95e8-2c0b-7903-…`），现有 `SESSION_ID_RE` 的 `[1-8]` 版本位天然放行，无需放宽。

## 防「codex 条目被 Claude 寻址误用」的做法

四层，从结构到断言：

1. **目录隔离**（主防线）：`listClaudeSessions()` 只读 `claude-sessions/`。
2. **读时 harness 校验**（二道防线）：`readEntry` 拿目录的 harness 和条目内容比对，不符即丢弃 + 清除。
3. **独立 hook 子命令**：codex 的 SessionStart payload 与 Claude 同形，同一个 `hook report` 入口分不出 harness，会把 codex 会话写进 claude 注册表。所以给 codex 独立的 `party hook codex-report`，harness 由「装在谁的 hooks 里」决定，而不是猜 payload。
4. **`claudeSessionAlive()` 对 codex session id 恒 false**（它是 claude 侧寻址前的存在性闸门），有断言覆盖。

## 安装方式

`party hook install --codex` → `~/.codex/hooks.json`。codex hooks.json 的顶层就是 `{"hooks": {...}}`，条目形状与 Claude settings 的 hooks 完全同形，所以直接复用 `mergeHookSettings` / `removeHookSettings`——连带复用它「只增删自己 command 含标记的条目、`hooks` 键写坏即抛错拒写」的保护。另外按 #864 的教训加了**写前备份** `<path>.agentparty.bak`（install 与 uninstall 都加），解析失败即中止不写、连备份都不留。

## 变异验证（4/4 真变红）

| 拆掉的修复 | 结果 |
|---|---|
| protocol 校验退回 `harness !== "claude"` | `#851 P1: harness_session 放行 codex…` fail |
| `readEntry` 去掉 harness 与目录的一致性校验 | `不变量①（防误用取证）` fail |
| codex 目录映射改回 `claude-sessions`（模拟「共用目录」方案） | 5 个测试 fail，含入册、互不可见、防误用、hook 接线 |
| codex install 改成整份覆盖而非 merge（模拟 #864） | 3 个 `install --codex` 测试全 fail |

## 真机验证

在本机真实 codex 0.145 会话上跑通（用 scratchpad 里的注册表目录，没污染 `~/.agentparty/`）：

1. `party hook install --codex` 写进真实 `~/.codex/hooks.json`。逐事件比对确认：`PermissionRequest`/`PostToolUse`/`Stop`/`UserPromptSubmit` 条数与内容不变，`SessionStart` 从 3 条变 4 条且前 3 条逐字相同——otty 的 `_otty` 私有字段、vibe-island 的 `timeout`、superset 的条目全部原样保留。
2. `codex exec …` 真跑一轮，条目落盘：
   ```json
   { "version": 1, "harness": "codex",
     "session_id": "01a01e15-fe0f-77a2-81ee-acd62c90deca",
     "pid": 57395, "display_name": null, "channel": "pwtk", "cwd": "…" }
   ```
   harness 标记正确，`~/.agentparty/claude-sessions/` 未被触碰。
3. `party hook uninstall --codex` 后，`~/.codex/hooks.json` 与安装前的备份**语义完全一致**（JSON 深比对 IDENTICAL）。真实 hooks.json 已恢复原状，测试残留的 `.agentparty.bak` 已清除。

## 测试与检查

`cli` 全量 1794 pass / 0 fail、`worker` 810 pass / 0 fail，`shared`/`cli`/`worker` 三处 `tsc --noEmit` 全清。

## 并发提示

本 PR 动了 `shared/src/protocol.ts`，但**只集中在 `harness_session` 那几行 + 文件末尾新增的词表导出**，没碰 `do.ts`、没碰任何连接判定逻辑。#872（announce-only 连接放行）若先合并，**可能需要 rebase**，冲突面应该很小。
