### PR TITLE
fix: announce-only 补拉帧真正抑制 + 会话注册表加 server 维度 (#878 #865)

### DIFF
--- a/cli/src/claude-session-registry.ts
+++ b/cli/src/claude-session-registry.ts
@@ -87,6 +87,16 @@ export interface ClaudeSessionRegistryEntry {
   pid: number;
   display_name: string | null;
   channel: string;
+  /**
+   * 条目所属实例的规范化 origin（#865）。频道 slug 全局不唯一——两台生产实例上都有
+   * `agentparty`——只比 slug 会把 A 实例的 @ 注入到只属于 B 实例的会话（实机撞见）。
+   * 入册时由该会话绑定的 config 解析。
+   *
+   * 可选**只为兼容旧盘上的条目**：#865 之前写的条目没有这个字段，一律视为**不可匹配**
+   * （安全侧，见 sessionEntryMatchesServer），由下次 SessionStart 自然升级。绝不为兼容
+   * 而放宽匹配。
+   */
+  server?: string;
   cwd: string;
   registered_at: number;
   /**
@@ -94,6 +104,40 @@ export interface ClaudeSessionRegistryEntry {
    * 目录才是权威身份；这个字段只是「目录与内容不符即丢弃」的二道防线。
    */
   harness?: SessionRegistryHarness;
+}
+
+/**
+ * 规范化 server 为可比对的 origin（#865）：小写 host、显式端口保留、去 path/query/尾斜杠。
+ * 缺协议头的手写 config（"agentparty.example.com"）由 healServerUrl 补 https://。
+ * 不可解析 → null（＝不可匹配）。
+ */
+export function normalizeSessionRegistryServer(value: unknown): string | null {
+  if (typeof value !== "string" || value === "") return null;
+  // 只在**完全没有 scheme** 时补 https://。不能直接复用 healServerUrl 的
+  // 「失败就拼 https:// 再试」：那会把 `ftp://a.example.com` 变成
+  // `https://ftp://a.example.com` → origin `https://ftp`，两个毫不相干的实例塌成同一个 key。
+  const candidate = /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(value) ? value : `https://${value}`;
+  try {
+    const url = new URL(candidate);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+    if (url.username !== "" || url.password !== "") return null;
+    return url.origin;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 条目是否属于给定实例（#865）。任一侧解析不出 origin —— 含**旧条目没有 server 字段**
+ * —— 一律 false：宁可这一轮叫不醒（下次 SessionStart 就补上），也不跨实例误投。
+ */
+export function sessionEntryMatchesServer(
+  entry: ClaudeSessionRegistryEntry,
+  server: string | null | undefined,
+): boolean {
+  const wanted = normalizeSessionRegistryServer(server);
+  if (wanted === null) return false;
+  return normalizeSessionRegistryServer(entry.server) === wanted;
 }
 
 /** 旧条目（无 harness 字段）视为 claude。 */
@@ -120,6 +164,11 @@ function validEntry(value: unknown): value is ClaudeSessionRegistryEntry {
       (typeof value.display_name === "string" && DISPLAY_NAME_RE.test(value.display_name))) &&
     typeof value.channel === "string" &&
     CHANNEL_RE.test(value.channel) &&
+    // server 缺席合法（旧条目）；在场则必须已是规范化 origin，坏值按坏行丢弃而不是当成
+    // 「无 server」——否则一条被写坏的 server 会静默退化成旧条目的宽松语义。
+    (value.server === undefined ||
+      (typeof value.server === "string" &&
+        normalizeSessionRegistryServer(value.server) === value.server)) &&
     typeof value.cwd === "string" &&
     value.cwd !== "" &&
     isAbsolute(value.cwd) &&
@@ -289,6 +338,8 @@ export interface RegisterClaudeSessionInput {
   pid: number;
   display_name: string | null;
   channel: string;
+  /** 该会话绑定的实例 URL（#865）。解析不出 origin 的值不写入——条目随之不可匹配（安全侧）。 */
+  server?: string | null;
   cwd: string;
   registered_at?: number;
   /** 省略即 claude（保持 #841 调用点逐字不变）。 */
@@ -315,6 +366,9 @@ export function registerSession(
         ? input.display_name
         : null,
     channel: input.channel,
+    ...(normalizeSessionRegistryServer(input.server) === null
+      ? {}
+      : { server: normalizeSessionRegistryServer(input.server)! }),
     cwd: input.cwd,
     registered_at: input.registered_at ?? Date.now(),
   };

--- a/cli/src/commands/claude-channel.ts
+++ b/cli/src/commands/claude-channel.ts
@@ -37,6 +37,7 @@ import { connect, type Connection } from "../client";
 import {
   claudeSessionAnnounceName,
   listClaudeSessions,
+  sessionEntryMatchesServer,
   type ClaudeSessionRegistryEntry,
 } from "../claude-session-registry";
 import { injectChannelMessage } from "../claude-inbox-inject";
@@ -457,13 +458,22 @@ export function dormantAnnounceDisplayName(entry: ClaudeSessionRegistryEntry): s
   return claudeSessionAnnounceName(entry);
 }
 
-/** 选择要宣告的入册会话：同 channel 必须；优先同 cwd；同优先级取最新入册。 */
+/**
+ * 选择要宣告的入册会话：同 **server + channel** 必须；优先同 cwd；同优先级取最新入册。
+ *
+ * #865：频道 slug 跨实例不唯一（两台生产实例上都有 `agentparty`），只比 slug 会让本机
+ * 连着 A 实例的 announce 腿把 @ 注入到只属于 B 实例的会话——实机撞见过。旧条目（无
+ * server 字段）恒不匹配，属安全侧，由下次 SessionStart 自然升级。
+ */
 export function selectDormantAnnounceEntry(
   entries: readonly ClaudeSessionRegistryEntry[],
   channel: string,
   cwd: string,
+  server?: string | null,
 ): ClaudeSessionRegistryEntry | null {
-  const matching = entries.filter((entry) => entry.channel === channel);
+  const matching = entries.filter(
+    (entry) => entry.channel === channel && sessionEntryMatchesServer(entry, server),
+  );
   if (matching.length === 0) return null;
   const pick = (candidates: readonly ClaudeSessionRegistryEntry[]) =>
     candidates.length === 0
@@ -638,9 +648,15 @@ export async function runDormantClaudeSessionAnnounce(
   // Claude 收件箱侧的 msg_id/队列去重与人工感知兜底；重复唤醒的代价远小于叫不醒。
   const injectedSeqs = new Set<number>();
   while (!signal.aborted) {
+    // #865：先解析 auth——选目标要按 server 过滤，拿不到实例身份就一个条目都不该匹配。
+    const auth = await deps.resolveAuth().catch(() => null);
+    if (!auth?.server || !auth.token) return;
+    // resolveAuth 是本循环里唯一的长 await：期间收到 abort 就绝不再建连。
+    if (signal.aborted) return;
+    const authServer = auth.server;
     let entry: ClaudeSessionRegistryEntry | null = null;
     try {
-      entry = selectDormantAnnounceEntry(deps.listSessions(), channel, cwd);
+      entry = selectDormantAnnounceEntry(deps.listSessions(), channel, cwd, authServer);
     } catch {
       return;
     }
@@ -648,10 +664,6 @@ export async function runDormantClaudeSessionAnnounce(
       await abortableSleep(pollMs, signal);
       continue;
     }
-    const auth = await deps.resolveAuth().catch(() => null);
-    if (!auth?.server || !auth.token) return;
-    // resolveAuth 是本循环里唯一的长 await：期间收到 abort 就绝不再建连。
-    if (signal.aborted) return;
     const topology = deps.buildTopology(auth.server, entry.cwd, {
       harnessSession: {
         harness: "claude",
@@ -720,7 +732,7 @@ export async function runDormantClaudeSessionAnnounce(
           pid: entry.pid,
           sessionId: entry.session_id,
           name: hostAnnounceName,
-          body: wakeProxyNote({ channel, seq }),
+          body: wakeProxyNote({ channel, server: authServer, seq }),
           // from-name＝真实发信人的友好名 + 技术 ID（接收端面板只显示这一处，
           // 技术 ID 丢了就分不清两个同名 agent）。
           fromName: senderInjectFromName(sender, channel),

--- a/cli/src/commands/hook.ts
+++ b/cli/src/commands/hook.ts
@@ -18,7 +18,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { AGENT_ACTIVITY_TTL_MS, type AgentActivity } from "@agentparty/shared";
 import { activityFromHookEvent, readActivityFile, writeActivityFile } from "../activity";
-import { agentpartyHome, readState } from "../config";
+import { agentpartyHome, readConfig, readState } from "../config";
 import {
   DeliveryRecoveryJournal,
   deliveryRecoveryJournalPath,
@@ -553,6 +553,10 @@ export function recordClaudeSessionLifecycle(
         claudeSessionDisplayNameFromHookPayload(record) ??
         nativeSessionName(pid, { expectSessionId: sessionId, env }),
       channel,
+      // #865：条目必须带实例维度——频道 slug 跨实例不唯一（两台生产实例上都有
+      // `agentparty`）。取该会话绑定 config 的 server；解析不出就不写，条目随之
+      // 不可匹配（宁可这一轮叫不醒，也不跨实例误投）。
+      server: readConfig(cwd)?.server ?? null,
       cwd,
     }, env);
   } catch {
@@ -597,6 +601,8 @@ export function recordCodexSessionLifecycle(
       pid,
       display_name: claudeSessionDisplayNameFromHookPayload(record),
       channel,
+      // #865：同 claude 档——实例维度是匹配的一部分。
+      server: readConfig(cwd)?.server ?? null,
       cwd,
     }, env);
   } catch {

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -5483,7 +5483,7 @@ export async function runServe(o: ServeOptions): Promise<number> {
       // 不会有 delivery 帧跟上，仍旧在 msg 帧这里转投一次（对照组不受影响）。
       if (fresh && !fromSelf && hasLease && !selfPaused && !mentionOwnedByDelivery && frame.mentions.length > 0) {
         const wakeProxyDeps = o.wakeProxy ?? {};
-        await attemptWakeProxy(frame.mentions, self, { channel: o.channel, seq: frame.seq }, {
+        await attemptWakeProxy(frame.mentions, self, { channel: o.channel, server: o.server, seq: frame.seq }, {
           ...wakeProxyDeps,
           // #844：默认接 socket 优先载体（本机 UDS 收件箱注入，原生「Message from X」UX）；
           // 失败降级为现行为。测试注入的 forward 仍优先。

--- a/cli/src/serve-wake-proxy.ts
+++ b/cli/src/serve-wake-proxy.ts
@@ -29,6 +29,7 @@ import { Buffer } from "node:buffer";
 import {
   claudeSessionAnnounceName,
   listClaudeSessions,
+  sessionEntryMatchesServer,
   type ClaudeSessionRegistryEntry,
 } from "./claude-session-registry";
 import { injectChannelMessage } from "./claude-inbox-inject";
@@ -40,6 +41,8 @@ export const WAKE_PROXY_NOTE_MAX_BYTES = 512;
 
 export interface WakeProxyRef {
   channel: string;
+  /** serve 这条连接所连的实例 URL（#865）。频道 slug 跨实例不唯一，选目标必须同时比对它。 */
+  server: string;
   seq: number;
 }
 
@@ -61,7 +64,9 @@ export function wakeProxyNote(ref: WakeProxyRef): string {
  * 转投判定：在本频道的入册活会话里找被 @ 的目标。
  * - 宣告名（display_name 或回退 `claude-<12hex>`）必须出现在 mentions 里；
  * - 排除 serve 自己的身份（自己的 @ 走 runner，不转投）；
- * - 只认绑定同一 channel 的条目；
+ * - 只认绑定同一 **server + channel** 的条目（#865：slug 跨实例不唯一，两台生产实例上
+ *   都有 `agentparty`，只比 slug 会把 A 实例的 @ 注入到只属于 B 实例的会话——实机撞见）；
+ *   旧条目（无 server 字段）恒不匹配，下次 SessionStart 自然升级；
  * - 多个候选取最新入册（与蛰伏 announce 的选择一致）。
  * 死会话由 listClaudeSessions 的 kill(pid,0) 探活现场剔除（开放问题 C）：
  * 进程已退出的条目根本不会出现在这里，消息自然回落到现行为。
@@ -79,12 +84,14 @@ export function selectWakeProxyTarget(
   self: string,
   channel: string,
   sessions: readonly ClaudeSessionRegistryEntry[],
+  server?: string | null,
 ): ClaudeSessionRegistryEntry | null {
   const wanted = new Set(mentions.filter((name) => name !== self));
   if (wanted.size === 0) return null;
   let best: ClaudeSessionRegistryEntry | null = null;
   for (const entry of sessions) {
     if (entry.channel !== channel) continue;
+    if (!sessionEntryMatchesServer(entry, server)) continue;
     if (!wanted.has(claudeSessionAnnounceName(entry))) continue;
     if (best === null || entry.registered_at >= best.registered_at) best = entry;
   }
@@ -288,6 +295,7 @@ export async function attemptWakeProxy(
       self,
       ref.channel,
       (deps.listSessions ?? listClaudeSessions)(),
+      ref.server,
     );
   } catch {
     return { forwarded: false, target: null };

--- a/cli/test/claude-channel-dormant-announce.test.ts
+++ b/cli/test/claude-channel-dormant-announce.test.ts
@@ -10,6 +10,9 @@ import {
   type DormantAnnounceDeps,
 } from "../src/commands/claude-channel";
 
+const SERVER = "https://party.example";
+const OTHER_SERVER = "https://other.example";
+
 function entry(overrides: Partial<ClaudeSessionRegistryEntry> = {}): ClaudeSessionRegistryEntry {
   return {
     version: 1,
@@ -17,6 +20,7 @@ function entry(overrides: Partial<ClaudeSessionRegistryEntry> = {}): ClaudeSessi
     pid: process.pid,
     display_name: null,
     channel: "dev",
+    server: SERVER,
     cwd: "/tmp/project",
     registered_at: 1_000,
     ...overrides,
@@ -128,13 +132,45 @@ describe("dormantAnnounceDisplayName", () => {
 describe("selectDormantAnnounceEntry", () => {
   test("requires the channel, prefers same cwd, then newest registration", () => {
     const other = entry({ session_id: "22222222-2222-4222-8222-222222222222", channel: "prod" });
-    expect(selectDormantAnnounceEntry([other], "dev", "/tmp/project")).toBeNull();
+    expect(selectDormantAnnounceEntry([other], "dev", "/tmp/project", SERVER)).toBeNull();
     const away = entry({ session_id: "33333333-3333-4333-8333-333333333333", cwd: "/elsewhere", registered_at: 9_000 });
     const here = entry({ registered_at: 1_000 });
-    expect(selectDormantAnnounceEntry([away, here], "dev", "/tmp/project")).toBe(here);
-    expect(selectDormantAnnounceEntry([away], "dev", "/tmp/project")).toBe(away);
+    expect(selectDormantAnnounceEntry([away, here], "dev", "/tmp/project", SERVER)).toBe(here);
+    expect(selectDormantAnnounceEntry([away], "dev", "/tmp/project", SERVER)).toBe(away);
     const newer = entry({ session_id: "44444444-4444-4444-8444-444444444444", registered_at: 5_000 });
-    expect(selectDormantAnnounceEntry([here, newer], "dev", "/tmp/project")).toBe(newer);
+    expect(selectDormantAnnounceEntry([here, newer], "dev", "/tmp/project", SERVER)).toBe(newer);
+  });
+});
+
+describe("selectDormantAnnounceEntry 的 server 维度（issue #865）", () => {
+  test("同 slug 不同 server 不命中；同 slug 同 server 才命中", () => {
+    const here = entry();
+    expect(selectDormantAnnounceEntry([here], "dev", "/tmp/project", SERVER)).toBe(here);
+    expect(selectDormantAnnounceEntry([here], "dev", "/tmp/project", OTHER_SERVER)).toBeNull();
+  });
+
+  test("旧条目（无 server 字段）恒不命中，等下次 SessionStart 升级", () => {
+    const legacy = entry({ server: undefined });
+    expect(selectDormantAnnounceEntry([legacy], "dev", "/tmp/project", SERVER)).toBeNull();
+    // 同一批里的新条目照常命中——旧条目只是被跳过，不会拖垮整批。
+    const fresh = entry({ session_id: "55555555-5555-4555-8555-555555555555", registered_at: 9_000 });
+    expect(selectDormantAnnounceEntry([legacy, fresh], "dev", "/tmp/project", SERVER)).toBe(fresh);
+  });
+
+  test("解析不出实例身份（null/undefined/坏 URL）时一个都不命中", () => {
+    const here = entry();
+    for (const server of [null, undefined, "", "not a url"]) {
+      expect(selectDormantAnnounceEntry([here], "dev", "/tmp/project", server)).toBeNull();
+    }
+  });
+
+  test("按 origin 规范化比对：尾斜杠 / host 大小写 / 缺协议头都等价，端口不同即不同实例", () => {
+    const here = entry();
+    for (const variant of ["https://party.example/", "https://Party.Example", "party.example"]) {
+      expect(selectDormantAnnounceEntry([here], "dev", "/tmp/project", variant)).toBe(here);
+    }
+    expect(selectDormantAnnounceEntry([here], "dev", "/tmp/project", "https://party.example:8443"))
+      .toBeNull();
   });
 });
 

--- a/cli/test/claude-session-registry.test.ts
+++ b/cli/test/claude-session-registry.test.ts
@@ -18,6 +18,9 @@ import {
   claudeSessionRegistryDirectory,
   listClaudeSessions,
   registerClaudeSession,
+  normalizeSessionRegistryServer,
+  registerSession,
+  sessionEntryMatchesServer,
   unregisterClaudeSession,
 } from "../src/claude-session-registry";
 import {
@@ -297,5 +300,55 @@ describe("hook lifecycle wiring (#841 P1)", () => {
     expect(claudeSessionDisplayNameFromHookPayload({ session_name: "s1" })).toBe("s1");
     expect(claudeSessionDisplayNameFromHookPayload({ display_name: "bad name!" })).toBeNull();
     expect(claudeSessionDisplayNameFromHookPayload({})).toBeNull();
+  });
+});
+
+/**
+ * #865：条目的实例维度。频道 slug 全局不唯一（两台生产实例上都有 `agentparty`），
+ * 注册表少了 server 就会把 A 实例的 @ 注入到只属于 B 实例的会话。
+ */
+describe("会话注册表的 server 维度（issue #865）", () => {
+  test("normalizeSessionRegistryServer 归一化到 origin，坏值给 null", () => {
+    expect(normalizeSessionRegistryServer("https://a.example.com/")).toBe("https://a.example.com");
+    expect(normalizeSessionRegistryServer("https://A.Example.COM/api/x?y=1")).toBe("https://a.example.com");
+    // 缺协议头的手写 config 补 https://（healServerUrl 同款自愈）。
+    expect(normalizeSessionRegistryServer("a.example.com")).toBe("https://a.example.com");
+    expect(normalizeSessionRegistryServer("https://a.example.com:8443")).toBe("https://a.example.com:8443");
+    for (const bad of ["", null, undefined, 42, "not a url", "ftp://a.example.com"]) {
+      expect(normalizeSessionRegistryServer(bad)).toBeNull();
+    }
+  });
+
+  test("入册写入规范化 origin，读回后同 server 命中、异 server 不命中", () => {
+    expect(registerSession(baseEntry({ server: "https://a.example.com/" }), env)).toBe(true);
+    const [entry] = listClaudeSessions(env);
+    expect(entry!.server).toBe("https://a.example.com");
+    expect(sessionEntryMatchesServer(entry!, "https://a.example.com")).toBe(true);
+    expect(sessionEntryMatchesServer(entry!, "https://b.example.com")).toBe(false);
+  });
+
+  test("旧条目（无 server 字段）仍能读出，但恒不可匹配", () => {
+    writeFileSync(
+      join(directory, `${SESSION_ID}.json`),
+      JSON.stringify({ version: 1, ...baseEntry(), harness: "claude" }),
+      { mode: 0o600 },
+    );
+    const [entry] = listClaudeSessions(env);
+    expect(entry!.server).toBeUndefined();
+    expect(sessionEntryMatchesServer(entry!, "https://a.example.com")).toBe(false);
+  });
+
+  test("server 解析不出时不写该字段（条目随之不可匹配，安全侧）", () => {
+    expect(registerSession(baseEntry({ server: "not a url" }), env)).toBe(true);
+    expect(listClaudeSessions(env)[0]!.server).toBeUndefined();
+  });
+
+  test("盘上写着未规范化 server 的条目按坏行丢弃，绝不退化成旧条目的宽松语义", () => {
+    writeFileSync(
+      join(directory, `${SESSION_ID}.json`),
+      JSON.stringify({ version: 1, ...baseEntry({ server: "https://a.example.com/" }), harness: "claude" }),
+      { mode: 0o600 },
+    );
+    expect(listClaudeSessions(env)).toHaveLength(0);
   });
 });

--- a/cli/test/serve-directed-delivery.test.ts
+++ b/cli/test/serve-directed-delivery.test.ts
@@ -918,13 +918,15 @@ describe("serve durable directed delivery (#551)", () => {
 // ─────────────────────────────────────────────────────────────────────────────
 describe("serve 唤醒代理转投去重（#866）", () => {
   /** 本机入册的另一个 Claude 会话，宣告名 = peer-claude。 */
-  function peerSession(): ClaudeSessionRegistryEntry {
+  function peerSession(entryServer: string): ClaudeSessionRegistryEntry {
     return {
       version: 1,
       session_id: "22222222-2222-4222-8222-222222222222",
       pid: process.pid,
       display_name: "peer-claude",
       channel: "dev",
+      // #865：条目必须带实例维度——slug 跨实例不唯一，选目标同时比对 server。
+      server: entryServer,
       cwd: "/tmp/project",
       registered_at: 1_000,
     };
@@ -938,6 +940,8 @@ describe("serve 唤醒代理转投去重（#866）", () => {
   async function countForwards(
     mentions: string[],
     withDelivery: boolean,
+    /** 入册条目所属实例；不传＝与 serve 所连实例相同。传别的实例即模拟 #865 的跨实例场景。 */
+    entryServer?: string,
   ): Promise<Array<{ target: string; seq: number }>> {
     const forwards: Array<{ target: string; seq: number }> = [];
     const message = msgFrame(7, "@me @peer-claude 看看这个", {
@@ -970,11 +974,12 @@ describe("serve 唤醒代理转投去重（#866）", () => {
       }
     });
 
+    const sessionServer = server.url;
     await runServe(opts({
-      server: server.url,
+      server: sessionServer,
       runCommand: async () => {},
       wakeProxy: {
-        listSessions: () => [peerSession()],
+        listSessions: () => [peerSession(entryServer ?? sessionServer)],
         forward: async (target, ref) => {
           forwards.push({ target: target.display_name!, seq: ref.seq });
           return true;
@@ -995,5 +1000,45 @@ describe("serve 唤醒代理转投去重（#866）", () => {
   test("对照组：只 @ 本机另一会话、不 @ 自己 → 没有 delivery 帧跟上，仍转投一次", async () => {
     const forwards = await countForwards(["peer-claude"], false);
     expect(forwards).toEqual([{ target: "peer-claude", seq: 7 }]);
+  });
+
+  /**
+   * #865 接线点回归：同名频道跨实例。入册条目属于**另一台**实例，slug 与宣告名都对得上，
+   * 只有 server 不同 —— 必须一次都不转投（实机上这条口子把 A 实例的 @ 注进了 B 实例的会话）。
+   */
+  test("#865：入册条目属于另一实例（同 slug 同宣告名）→ 一次都不转投", async () => {
+    expect(await countForwards(["peer-claude"], false, "https://other.example.com")).toEqual([]);
+  });
+
+  /** #865：旧条目（无 server 字段）视为不可匹配，安全侧降级为不转投。 */
+  test("#865：旧条目（无 server）不转投，等下次 SessionStart 升级", async () => {
+    const forwards: Array<{ target: string; seq: number }> = [];
+    const message = msgFrame(7, "@peer-claude 看看这个", {
+      sender: { name: "bob", kind: "human", owner: "bob@example.com" },
+      mentions: ["peer-claude"],
+    }) as unknown as MsgFrame;
+    server = startMockServer((frame, sock) => {
+      if (frame.type === "hello") {
+        sock.send({ ...welcomeFrame(0, "me"), directed_delivery: "v1" });
+      } else if (frame.type === "serve_lease") {
+        sock.send({ type: "serve_lease", name: "me", held: true });
+        sock.send(message as unknown as ServerFrame);
+        sock.send({ type: "error", code: "archived", message: "done" });
+      }
+    });
+    const legacy = peerSession(server.url);
+    delete (legacy as { server?: string }).server;
+    await runServe(opts({
+      server: server.url,
+      runCommand: async () => {},
+      wakeProxy: {
+        listSessions: () => [legacy],
+        forward: async (target, ref) => {
+          forwards.push({ target: target.display_name!, seq: ref.seq });
+          return true;
+        },
+      },
+    }));
+    expect(forwards).toEqual([]);
   });
 });

--- a/cli/test/serve-wake-proxy.test.ts
+++ b/cli/test/serve-wake-proxy.test.ts
@@ -19,11 +19,15 @@ function entry(overrides: Partial<ClaudeSessionRegistryEntry> = {}): ClaudeSessi
     pid: process.pid,
     display_name: null,
     channel: "dev",
+    server: SERVER_A,
     cwd: "/tmp/project",
     registered_at: 1000,
     ...overrides,
   };
 }
+
+const SERVER_A = "https://a.example.com";
+const SERVER_B = "https://b.example.com";
 
 describe("claudeSessionAnnounceName", () => {
   test("display_name 优先，缺省回退 claude-<12hex>", () => {
@@ -34,7 +38,7 @@ describe("claudeSessionAnnounceName", () => {
 
 describe("wakeProxyNote", () => {
   test("只带 channel+seq 指针且 ≤512B（含最长 channel）", () => {
-    const note = wakeProxyNote({ channel: "a".repeat(64), seq: Number.MAX_SAFE_INTEGER });
+    const note = wakeProxyNote({ channel: "a".repeat(64), server: SERVER_A, seq: Number.MAX_SAFE_INTEGER });
     expect(Buffer.byteLength(note, "utf8")).toBeLessThanOrEqual(WAKE_PROXY_NOTE_MAX_BYTES);
     expect(note).toContain(`#${"a".repeat(64)}`);
     expect(note).toContain(`seq=${Number.MAX_SAFE_INTEGER}`);
@@ -44,16 +48,16 @@ describe("wakeProxyNote", () => {
 describe("selectWakeProxyTarget", () => {
   test("回退名命中 → 选中；serve 自己的名字不算转投目标", () => {
     const sessions = [entry()];
-    expect(selectWakeProxyTarget(["claude-111111111111"], "me", "dev", sessions)?.session_id)
+    expect(selectWakeProxyTarget(["claude-111111111111"], "me", "dev", sessions, SERVER_A)?.session_id)
       .toBe(sessions[0]!.session_id);
-    expect(selectWakeProxyTarget(["claude-111111111111"], "claude-111111111111", "dev", sessions))
+    expect(selectWakeProxyTarget(["claude-111111111111"], "claude-111111111111", "dev", sessions, SERVER_A))
       .toBeNull();
   });
 
   test("display_name 命中；channel 不匹配的条目排除", () => {
     const named = entry({ display_name: "pair-claude" });
-    expect(selectWakeProxyTarget(["pair-claude"], "me", "dev", [named])).toBe(named);
-    expect(selectWakeProxyTarget(["pair-claude"], "me", "other", [named])).toBeNull();
+    expect(selectWakeProxyTarget(["pair-claude"], "me", "dev", [named], SERVER_A)).toBe(named);
+    expect(selectWakeProxyTarget(["pair-claude"], "me", "other", [named], SERVER_A)).toBeNull();
   });
 
   test("多候选取最新入册", () => {
@@ -68,19 +72,45 @@ describe("selectWakeProxyTarget", () => {
       "me",
       "dev",
       [older, newer],
+      SERVER_A,
     );
     expect(picked).toBe(newer);
   });
 
+  /** #865：频道 slug 跨实例不唯一（两台生产实例上都有 `agentparty`）。 */
+  test("#865：同 slug 不同 server 不命中；同 slug 同 server 才命中", () => {
+    const onA = entry({ display_name: "pair-claude", server: SERVER_A });
+    expect(selectWakeProxyTarget(["pair-claude"], "me", "dev", [onA], SERVER_A)).toBe(onA);
+    expect(selectWakeProxyTarget(["pair-claude"], "me", "dev", [onA], SERVER_B)).toBeNull();
+  });
+
+  test("#865：旧条目（无 server 字段）恒不命中；server 未知时同样不命中", () => {
+    const legacy = entry({ display_name: "pair-claude", server: undefined });
+    expect(selectWakeProxyTarget(["pair-claude"], "me", "dev", [legacy], SERVER_A)).toBeNull();
+    const known = entry({ display_name: "pair-claude", server: SERVER_A });
+    expect(selectWakeProxyTarget(["pair-claude"], "me", "dev", [known], null)).toBeNull();
+    expect(selectWakeProxyTarget(["pair-claude"], "me", "dev", [known], undefined)).toBeNull();
+  });
+
+  test("#865：server 按 origin 规范化比对（尾斜杠/大小写 host/缺协议头都等价）", () => {
+    const onA = entry({ display_name: "pair-claude", server: SERVER_A });
+    for (const variant of ["https://a.example.com/", "https://A.Example.com", "a.example.com"]) {
+      expect(selectWakeProxyTarget(["pair-claude"], "me", "dev", [onA], variant)).toBe(onA);
+    }
+    // 端口不同＝不同实例。
+    expect(selectWakeProxyTarget(["pair-claude"], "me", "dev", [onA], "https://a.example.com:8443"))
+      .toBeNull();
+  });
+
   test("无 mentions 或全是 self → null", () => {
-    expect(selectWakeProxyTarget([], "me", "dev", [entry()])).toBeNull();
+    expect(selectWakeProxyTarget([], "me", "dev", [entry()], SERVER_A)).toBeNull();
   });
 });
 
 describe("attemptWakeProxy", () => {
   test("默认载体（无传输）：命中目标但 forwarded=false，降级为现行为", async () => {
     const lines: string[] = [];
-    const result = await attemptWakeProxy(["claude-111111111111"], "me", { channel: "dev", seq: 7 }, {
+    const result = await attemptWakeProxy(["claude-111111111111"], "me", { channel: "dev", server: SERVER_A, seq: 7 }, {
       listSessions: () => [entry()],
       log: (line) => lines.push(line),
     });
@@ -91,7 +121,7 @@ describe("attemptWakeProxy", () => {
   });
 
   test("死会话已被注册表剔除（列表为空）→ 无目标，回落现行为", async () => {
-    const result = await attemptWakeProxy(["claude-111111111111"], "me", { channel: "dev", seq: 7 }, {
+    const result = await attemptWakeProxy(["claude-111111111111"], "me", { channel: "dev", server: SERVER_A, seq: 7 }, {
       listSessions: () => [],
     });
     expect(result).toMatchObject({ forwarded: false, target: null });
@@ -99,7 +129,7 @@ describe("attemptWakeProxy", () => {
 
   test("载体成功 → forwarded=true 且拿到 ≤512B 指针", async () => {
     let sent = "";
-    const result = await attemptWakeProxy(["claude-111111111111"], "me", { channel: "dev", seq: 42 }, {
+    const result = await attemptWakeProxy(["claude-111111111111"], "me", { channel: "dev", server: SERVER_A, seq: 42 }, {
       listSessions: () => [entry()],
       forward: async (_target, ref) => {
         sent = wakeProxyNote(ref);
@@ -113,7 +143,7 @@ describe("attemptWakeProxy", () => {
 
   test("载体抛错 → 绝不上抛，降级为现行为", async () => {
     const lines: string[] = [];
-    const result = await attemptWakeProxy(["claude-111111111111"], "me", { channel: "dev", seq: 7 }, {
+    const result = await attemptWakeProxy(["claude-111111111111"], "me", { channel: "dev", server: SERVER_A, seq: 7 }, {
       listSessions: () => [entry()],
       forward: async () => {
         throw new Error("transport boom");
@@ -126,7 +156,7 @@ describe("attemptWakeProxy", () => {
   });
 
   test("注册表读取抛错 → 降级为现行为", async () => {
-    const result = await attemptWakeProxy(["claude-111111111111"], "me", { channel: "dev", seq: 7 }, {
+    const result = await attemptWakeProxy(["claude-111111111111"], "me", { channel: "dev", server: SERVER_A, seq: 7 }, {
       listSessions: () => {
         throw new Error("registry boom");
       },
@@ -135,7 +165,7 @@ describe("attemptWakeProxy", () => {
   });
 
   test("noWakeProxyForwarder 恒 false（且这条才是真正的「无载体」）", async () => {
-    expect(await noWakeProxyForwarder(entry(), { channel: "dev", seq: 1 })).toMatchObject({
+    expect(await noWakeProxyForwarder(entry(), { channel: "dev", server: SERVER_A, seq: 1 })).toMatchObject({
       ok: false,
       reason: "no-carrier",
     });
@@ -162,7 +192,7 @@ describe("socketWakeProxyForwarder（#844 socket 优先载体）", () => {
         verified_at: 0,
       }),
     });
-    const ok = await forward(entry({ display_name: "pair-claude" }), { channel: "pwtk", seq: 42 });
+    const ok = await forward(entry({ display_name: "pair-claude" }), { channel: "pwtk", server: SERVER_A, seq: 42 });
     expect(ok).toMatchObject({ ok: true });
     expect(seen!.name).toBe("pair-claude");
     // 寻址走 pid + sessionId（宣告名恒不等于 Claude 原生会话名，#857）。
@@ -177,7 +207,7 @@ describe("socketWakeProxyForwarder（#844 socket 优先载体）", () => {
     const forward = socketWakeProxyForwarder({
       inject: async () => ({ ok: false, reason: "no-match" }),
     });
-    expect(await forward(entry(), { channel: "dev", seq: 1 })).toMatchObject({ ok: false, reason: "no-match" });
+    expect(await forward(entry(), { channel: "dev", server: SERVER_A, seq: 1 })).toMatchObject({ ok: false, reason: "no-match" });
   });
 });
 
@@ -200,10 +230,10 @@ describe("#867 ①：结构化失败原因必须一路透出到降级日志", ()
       const forward = socketWakeProxyForwarder({
         inject: async () => ({ ok: false, reason, detail }),
       });
-      expect(await forward(entry(), { channel: "dev", seq: 5 })).toEqual({ ok: false, reason, detail });
+      expect(await forward(entry(), { channel: "dev", server: SERVER_A, seq: 5 })).toEqual({ ok: false, reason, detail });
 
       const lines: string[] = [];
-      const result = await attemptWakeProxy(["claude-111111111111"], "me", { channel: "dev", seq: 5 }, {
+      const result = await attemptWakeProxy(["claude-111111111111"], "me", { channel: "dev", server: SERVER_A, seq: 5 }, {
         listSessions: () => [entry()],
         forward,
         log: (line) => lines.push(line),
@@ -222,7 +252,7 @@ describe("#867 ①：结构化失败原因必须一路透出到降级日志", ()
   test("两种不同失败打出的是两条不同的日志（以前恒同一句）", async () => {
     const lines: string[] = [];
     for (const reason of ["no-match", "probe-failed"] as const) {
-      await attemptWakeProxy(["claude-111111111111"], "me", { channel: "dev", seq: 5 }, {
+      await attemptWakeProxy(["claude-111111111111"], "me", { channel: "dev", server: SERVER_A, seq: 5 }, {
         listSessions: () => [entry()],
         forward: socketWakeProxyForwarder({ inject: async () => ({ ok: false, reason }) }),
         log: (line) => lines.push(line),
@@ -234,7 +264,7 @@ describe("#867 ①：结构化失败原因必须一路透出到降级日志", ()
 
   test("载体只返回裸 boolean false → 明说「未上报原因」，绝不编一个", async () => {
     const lines: string[] = [];
-    const result = await attemptWakeProxy(["claude-111111111111"], "me", { channel: "dev", seq: 5 }, {
+    const result = await attemptWakeProxy(["claude-111111111111"], "me", { channel: "dev", server: SERVER_A, seq: 5 }, {
       listSessions: () => [entry()],
       forward: async () => false,
       log: (line) => lines.push(line),
@@ -244,7 +274,7 @@ describe("#867 ①：结构化失败原因必须一路透出到降级日志", ()
   });
 
   test("成功路径不带 reason/detail", async () => {
-    const result = await attemptWakeProxy(["claude-111111111111"], "me", { channel: "dev", seq: 5 }, {
+    const result = await attemptWakeProxy(["claude-111111111111"], "me", { channel: "dev", server: SERVER_A, seq: 5 }, {
       listSessions: () => [entry()],
       forward: async () => true,
     });

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -9344,6 +9344,14 @@ export class ChannelDO extends Server<Env> {
       : frame.type === "message_update"
         ? frame.message
         : null;
+    // #878：announce-only 连接一条补拉帧都不该收。#876 把这条抑制写在了下面的
+    // 「legacy 欠账」分支里——那条分支要先命中 directed_deliveries 里 (seq, 本身份)
+    // 的行才会走到，于是真机上占绝大多数的补拉帧（无 mention、或 @ 的是别人）
+    // 全都从 row === undefined 掉了下去照发。抑制必须在任何行查询之前、对所有
+    // replay 帧无条件生效。
+    //
+    // 纯早退：不查表、不写表，欠账账本一字不改，仍等真正的消费方来领。
+    if (replay && this.isAnnounceOnlyConnection(st)) return true;
     if (
       st?.kind === "agent" &&
       // Hibernated pre-rollout states have no helloPending field. Their clientVersion proves an
@@ -9369,7 +9377,7 @@ export class ChannelDO extends Server<Env> {
         // 本分支纯读，绝不触碰 directed_deliveries 账本：欠账既不标记已投递也不清除，
         // 仍等真正的消费方（serve/watch/webhook）来领。
         if (this.isAnnounceOnlyConnection(st)) {
-          if (replay) return true;
+          // 走到这里必是 live（replay 已在函数入口无条件早退，见 #878）。
           this.sendFrame(connection, frame);
           return true;
         }

--- a/worker/test/directed-delivery.spec.ts
+++ b/worker/test/directed-delivery.spec.ts
@@ -1406,6 +1406,98 @@ describe("announce-only 连接不是投递消费方（issue #872）", () => {
     expect(await deliveryRows(slug)).toEqual(beforeClose);
   });
 
+  /**
+   * #878 真机口径回归。#876 的抑制写在「legacy 欠账」分支里，只有当 directed_deliveries
+   * 存在 (seq, 本身份) 的行时才走得到；而真机 announce 用 since=频道最新 seq 建连，补拉出来的
+   * 是 edited/retracted/superseded 那几条**与本身份无关**的老消息（mentions 为空或 @ 的是别人），
+   * row === undefined 直接掉下去照发。旧测试只造了一条「@ 自己」的欠账，永远撞不上这条路径。
+   *
+   * 这里按真机造型：announce 的 since = 频道最新 seq，历史里放无关消息 + @ 别人 + @ 自己，
+   * 并把它们编辑/撤回以命中 backfill 的 edited_at/retracted_at 分支。验收＝0 条 replay 帧。
+   */
+  it("#878：since=最新 seq 的 announce 一条 replay 帧都收不到（无关/他人/自己 @ 全覆盖）", async () => {
+    const sender = await seedToken("agent", uniq("sender"));
+    const target = await seedToken("agent", uniq("dormant"));
+    const other = await seedToken("agent", uniq("other"));
+    const slug = await createChannel(sender.token);
+
+    const post = async (body: string, mentions: string[] = []) => {
+      const res = await api(`/api/channels/${slug}/messages`, sender.token, {
+        method: "POST",
+        body: JSON.stringify({ kind: "message", body, mentions, reply_to: null }),
+      });
+      expect(res.status).toBe(200);
+      return (await res.json()) as { seq: number };
+    };
+    const edit = async (seq: number, body: string) => {
+      const res = await api(`/api/channels/${slug}/messages/${seq}/edit`, sender.token, {
+        method: "POST",
+        body: JSON.stringify({ body }),
+      });
+      expect(res.status).toBe(200);
+    };
+
+    // 历史：无关消息（mentions 为空）、@ 别人、@ 自己（产生欠账）。
+    const plain = await post("plain history, nobody mentioned");
+    const atOther = await post(`@${other.name} for someone else`, [other.name]);
+    const owed = await sendMention(slug, sender.token, target.name, "owed while offline");
+    // 编辑让前两条带上 edited_at —— 真机上正是这类行让 since 拦不住补拉。
+    await edit(plain.seq, "plain history, edited");
+    await edit(atOther.seq, `@${other.name} edited`);
+
+    const before = await deliveryRows(slug);
+    expect(before).toMatchObject([
+      { message_seq: atOther.seq, target_name: other.name, state: "queued", attempt: 0 },
+      { message_seq: owed.seq, target_name: target.name, state: "queued", attempt: 0 },
+    ]);
+
+    // 真机造型：since = 频道当前最新 seq（#869 的 announceStartCursor）。
+    const latest = owed.seq;
+    const { ws: announce, handshake } = await openAnnounce(slug, target.token, latest);
+
+    // 验收：0 条 replay 帧、0 条 error。
+    expect(handshake.filter((frame) => frame.type === "error")).toEqual([]);
+    expect(
+      handshake.filter(
+        (frame) =>
+          (frame.type === "msg" || frame.type === "status") && frame.replay === true,
+      ),
+    ).toEqual([]);
+    expect(handshake.filter((frame) => frame.type === "message_update")).toEqual([]);
+    // 逐条点名，防止上面的过滤器口径被将来改宽后静默失效。
+    for (const seq of [plain.seq, atOther.seq, owed.seq]) {
+      expect(handshake.filter((frame) => frame.type === "msg" && frame.seq === seq)).toEqual([]);
+    }
+
+    // 欠账账本一字不改（#876 的性质保持）。
+    expect(await deliveryRows(slug)).toEqual(before);
+
+    // live 广播照收，且不带 replay 标记。
+    const live = await sendMention(slug, sender.token, target.name, "live wake");
+    for (;;) {
+      const frame = await announce.next();
+      if (frame.type === "error") {
+        throw new Error(`announce-only socket was rejected: ${JSON.stringify(frame)}`);
+      }
+      if ((frame.type === "msg" || frame.type === "status") && frame.replay === true) {
+        throw new Error(`announce-only socket received a replay frame: ${JSON.stringify(frame)}`);
+      }
+      if (frame.type === "msg" && frame.seq === live.seq) {
+        expect(frame.replay).toBeUndefined();
+        break;
+      }
+    }
+
+    expect(await deliveryRows(slug)).toMatchObject([
+      { message_seq: atOther.seq, target_name: other.name, state: "queued", attempt: 0 },
+      { message_seq: owed.seq, target_name: target.name, state: "queued", attempt: 0 },
+      { message_seq: live.seq, target_name: target.name, state: "queued", attempt: 0 },
+    ]);
+    const beforeClose = await deliveryRows(slug);
+    announce.close();
+    expect(await deliveryRows(slug)).toEqual(beforeClose);
+  });
+
   it("announce 与正常消费方并存：欠账只被 v1 serve 领走，announce 不插手", async () => {
     const sender = await seedToken("agent", uniq("sender"));
     const target = await seedToken("agent", uniq("both"));


### PR DESCRIPTION
Closes #878
Closes #865

## #878 — announce-only 仍收到 replay 帧的真实成因

#876 把抑制写进了 `sendPublicFrame` 里的**「legacy 欠账」分支**。那条分支的进入条件是：

```
st.kind === "agent" && st.directedDeliveryV1 !== true && clientVersion 非空 && message.kind === "message"
  → 再查 directed_deliveries WHERE message_seq = ? AND target_name = ?
  → row !== undefined 时才走到 isAnnounceOnlyConnection(st) → if (replay) return true
```

真机 announce 腿用 `since = 频道当前最新 seq`（#869）建连，补拉出来的是 hello backfill 里
`edited_at / retracted_at / supersedes / superseded_by / completion_review_*` 非空的那些**老消息** ——
issue 里那 4 条正是它们，`mentions` 为空或 @ 的是别人。这类帧在 `directed_deliveries` 里
根本没有 `(seq, 本身份)` 的行，`row === undefined` 直接从分支底下掉出去照发。
判据（`isAnnounceOnlyConnection`）本身没问题——所以连接没被 `upgrade_required` 踹掉——
问题是抑制根本没被执行到。

**修法**：抑制上提到 `sendPublicFrame` 入口，在任何行查询之前，对**所有** replay 帧无条件生效：

```ts
if (replay && this.isAnnounceOnlyConnection(st)) return true;
```

纯早退：不查表、不写表，`directed_deliveries` 账本一字不改，欠账仍等真正的消费方
（serve / watch / webhook）来领——#876 用三次快照比对证明的性质原样保持，新测试继续断言它。
分支里原来那句 `if (replay) return true;` 随之成为死码，已删并留注释说明 replay 已在入口早退。

### 测试口径为什么之前是假绿

旧的 #872/#876 测试只造了**一条「@ 自己」的欠账消息**，而且 `since=0` —— 那条消息必然有
delivery 行，必然走进 legacy 分支，于是抑制"看起来"生效。真机上占绝大多数的
**「无 mention / @ 别人」的补拉帧**，测试里一条都没有。

新增 `#878：since=最新 seq 的 announce 一条 replay 帧都收不到` 按真机造型：
- announce 的 `since = 频道最新 seq`（不是 0）；
- 历史里放：无关消息（mentions 空）、@ 别人、@ 自己；
- 把前两条**编辑过**，让它们命中 backfill 的 `edited_at IS NOT NULL` 分支（真机上正是这类行能穿透 since）；
- 验收：握手窗口内 **0 条 replay 帧**、0 条 error、逐条点名三个 seq 都不出现；欠账账本与建连前**逐字段相等**；
- live 帧照收且不带 `replay`；断连后账本仍不变。

握手窗口的读法沿用 #876 的 `ping/pong` 屏障 + **逐帧 `ws.next()` 循环**，不用
`nextOfType` —— 后者会静默吃掉途中的帧，正是 #876 假绿的那个坑。live 阶段的循环
同样是逐帧读，任何 `replay === true` 的帧直接 throw。

## #865 — server 规范化方式

新增 `normalizeSessionRegistryServer(value) → string | null`：

- 只在**完全没有 scheme** 时补 `https://`（`agentparty.example.com` → `https://agentparty.example.com`）；
- 然后 `new URL(...).origin`：host 小写、去 path/query/尾斜杠、**显式端口保留**（不同端口＝不同实例）；
- 只接受 `http:` / `https:`，带 userinfo 的一律 null；解析失败 null。

**刻意不复用 `healServerUrl`**：它的策略是「先试原值，失败就拼 `https://` 再试一遍」，
于是 `ftp://a.example.com` 会变成 `https://ftp://a.example.com`，origin 塌成 `https://ftp` ——
两个毫不相干的实例映射到同一个 key。这个洞是写单测时当场撞出来的（测试先红，才改的实现）。

条目侧：`ClaudeSessionRegistryEntry.server?: string`（写盘时已是规范化 origin；`validEntry`
要求在场的 `server` **必须等于自身的规范化结果**，写坏的值按坏行丢弃，绝不静默退化成
「旧条目」的宽松语义）。入册在 `hook.ts` 两处（claude / codex）取
`readConfig(cwd)?.server` —— 即该会话绑定 config 解析出的实例。

匹配侧 `sessionEntryMatchesServer(entry, server)`：任一侧规范化不出 origin —— 含
**旧条目没有 server 字段** —— 一律 `false`。`selectDormantAnnounceEntry` 与
`selectWakeProxyTarget` 都加上这一条；`WakeProxyRef` 加了**必填** `server`，让所有调用点被
类型系统强制交代实例身份（announce 循环里的 `resolveAuth` 因此上移到选目标之前）。
不为兼容放宽，旧条目由下次 SessionStart 自然升级。

## 变异验证

每处修复拆掉都确认断言真的变红；等价实现替换确认不误红。

### worker（`test/directed-delivery.spec.ts`，39 tests）

| 变异 | 结果 |
|---|---|
| 基线 | 39 pass |
| W1：整句删掉入口抑制 | **2 failed** ✅ |
| W2：只在「存在 (seq, 本身份) 欠账行」时抑制（＝#876 的实际行为） | **1 failed** ✅（正是新测试；旧测试全绿——这条就是"测试口径与真机不一致"的直接证据） |
| W3：等价实现——改在 hello backfill 循环里 `continue` 掉 announce-only | 39 pass ✅ 不误红 |

### cli（`serve-wake-proxy` / `claude-channel-dormant-announce` / `claude-session-registry`，65 tests）

| 变异 | 结果 |
|---|---|
| 基线 | 65 pass |
| M1：`selectDormantAnnounceEntry` 去掉 server 比对 | **4 failed** ✅ |
| M2：`selectWakeProxyTarget` 去掉 server 比对 | **3 failed** ✅ |
| M3：为兼容放宽——旧条目（无 server）视为匹配 | **3 failed** ✅ |
| M4：等价实现——两侧各自归一化后比，不早退 | 65 pass ✅ 不误红 |

## 测试统计

- `cli`：**1808 pass / 0 fail**（125 files，179s）。新增 11 条（注册表 server 维度 5、announce 选目标 4、serve 接线点跨实例 + 旧条目 2），并更新了所有携带注册表条目的既有 fixture。
- `worker`：`test/directed-delivery.spec.ts` **39 pass / 0 fail**；全量 `vitest run` 816 pass，1 个
  `session-presence-isolation.spec.ts` 在**并发全量**下偶发失败——单跑该文件 13/13 全绿，
  与本 PR 无关（本 PR 只动 `sendPublicFrame`，不碰 presence/agent_session 路径），属既有 flaky。
- typecheck：`cli` / `worker` / `web` 全部 `tsc --noEmit` 通过。
