### PR TITLE
feat: 迟到投递补 superseded 标记 + 「已读不回」真终态 (#881 #875)

### DIFF
--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -225,6 +225,16 @@ function isReadCursor(value: unknown): boolean {
     isFiniteNumber(value.updated_at);
 }
 
+// #881 superseded 标记。必须逐字镜像 shared/src/protocol.ts 的 SupersededMark，否则服务端
+// 一上线这个字段，CLI 就把带标记的整帧判为非法而静默丢掉（#622 的教训）。
+const SUPERSEDED_REASONS = new Set(["revision", "reply_correction"]);
+
+function isSupersededMark(value: unknown): boolean {
+  return isRecord(value) &&
+    isPositiveInteger(value.by_seq) &&
+    SUPERSEDED_REASONS.has(String(value.reason));
+}
+
 function isMessageFrame(value: unknown): boolean {
   return isRecord(value) &&
     (value.type === "msg" || value.type === "status") &&
@@ -249,7 +259,9 @@ function isMessageFrame(value: unknown): boolean {
     (value.rev_seq === undefined || isPositiveInteger(value.rev_seq)) &&
     // #861 hello 补拉标记。必须逐字镜像 shared/src/protocol.ts 的 MsgFrame.replay，
     // 否则服务端一上线这个字段，CLI 就会把所有补拉帧判为非法而静默丢帧（#622 的教训）。
-    (value.replay === undefined || value.replay === true);
+    (value.replay === undefined || value.replay === true) &&
+    // #881「这条内容已过期」。与 replay 正交，可同时为真：replay=补拉的历史帧，superseded=内容已被取代。
+    (value.superseded === undefined || isSupersededMark(value.superseded));
 }
 
 function isDirectedDelivery(value: unknown): boolean {
@@ -281,7 +293,12 @@ function isPublicDirectedDelivery(value: unknown): boolean {
     isFiniteNumber(value.created_at) &&
     isFiniteNumber(value.updated_at) &&
     // #667: optional coarse "undelivered" flag on a terminal `failed`; older servers omit it.
-    (value.undelivered === undefined || typeof value.undelivered === "boolean");
+    (value.undelivered === undefined || typeof value.undelivered === "boolean") &&
+    // #875: 「已读不回」终态的审计元数据；旧 worker 省略。
+    (value.acknowledged_no_reply === undefined ||
+      (isRecord(value.acknowledged_no_reply) &&
+        typeof value.acknowledged_no_reply.by === "string" &&
+        isFiniteNumber(value.acknowledged_no_reply.at)));
 }
 
 function asServerFrame(value: Record<string, unknown>): ServerFrame {

--- a/cli/src/commands/ack.ts
+++ b/cli/src/commands/ack.ts
@@ -7,10 +7,15 @@
 import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
 import { ackWatchStuck, drainWatchStuck, resolveChannel } from "../config";
 import { resolveAuthDetailed } from "../oidc-cli";
-import { fetchRecentMessages, handleRestError } from "../rest";
+import { ackDelivery, fetchRecentMessages, handleRestError } from "../rest";
 import { isSlug, parseNonNegativeIntFlag, parsePositiveIntFlag } from "../validation";
 
-const FLAGS = ["channel", "seq", "all", "through", "before"];
+const FLAGS = ["channel", "seq", "all", "through", "before", "no-reply"];
+// #875：只有 --seq 指得出「哪一条 @」。--all/--through/--before 是本地游标批量排空，
+// 服务端账本必须逐条结清（每条 @ 是一条独立的 durable delivery），所以不给批量 ack 服务端的口子。
+export const NO_REPLY_REQUIRES_SEQ_ERROR =
+  "--no-reply settles ONE server-side @ and needs to know which one: pass --seq N " +
+  "(see party who --json → pending_mention_seqs). It is not combinable with --all/--through/--before.";
 // #860①：同族命令（receipt/revise/capture/decision）的位置参数都是 seq，只有 ack 是频道 slug，
 // 而 SLUG_RE 收下纯数字串 → `party ack 1841` 曾静默读一个不存在的频道并 exit 0（用户以为债清了）。
 export const NUMERIC_POSITIONAL_ERROR =
@@ -37,21 +42,29 @@ messages from there.
 Only watch-sourced debt can be acked. Debt owned by party serve is never touched
 here: serve replays it durably and clearing it by hand would silently drop an @.
 
-LOCAL ONLY — this does NOT clear \`pending_mention_seqs\` (#859). There are two
-separate ledgers and this command writes only the first:
-  · LOCAL watch replay state (a file next to your config) — what \`party ack\` clears.
-    Clearing it stops YOUR watch from replaying that frame.
+TWO LEDGERS (#859/#875). By default this command writes only the first:
+  · LOCAL watch replay state (a file next to your config) — what plain \`party ack\`
+    clears. Clearing it stops YOUR watch from replaying that frame. No request is
+    sent to the server, so it can never change the server ledger.
   · SERVER-side @ delivery debt — what \`party who --json\` reports as
-    unhandled_mention_count / pending_mention_seqs. \`party ack\` sends no request
-    to the server and can never change it.
-To settle the server ledger you must answer the @: \`party send "…" --reply-to N\`
-(list several when one reply settles them all: \`--reply-to A,B\`). An @ you ack
-locally but never reply to stays owed server-side until its delivery lease expires,
-and is then recorded as a FAILED delivery with terminal_reason=unknown_outcome —
-so for an @ that deserves a one-liner, send the one-liner with --reply-to.
+    unhandled_mention_count / pending_mention_seqs. Only two things settle it:
+    answering the @ (\`party send "…" --reply-to N\`, list several with \`--reply-to A,B\`),
+    or \`party ack --seq N --no-reply\` (see below).
+
+--no-reply is the "I read it, it warrants no reply" exit (#875). It POSTs to the
+server and closes that one @ with terminal_reason=acknowledged_no_reply — a real
+settlement, explicitly NOT failed/unknown_outcome. It is auditable: the ledger
+records who acked and when, and the whole channel can see it. Use it honestly; an
+@ that deserves a one-liner deserves the one-liner (\`send --reply-to N\`).
+
+Without --no-reply, an @ you ack only locally stays owed server-side until its
+delivery lease expires, and is then recorded as a FAILED delivery with
+terminal_reason=unknown_outcome.
 
 Options:
   --channel C   channel to ack in (defaults to the bound channel)
+  --no-reply    ALSO settle the server-side @ debt for --seq N as
+                acknowledged_no_reply ("seen, no reply needed"). Requires --seq.
   --seq N       acknowledge through exactly N; a newer pending wake is preserved
                 (single-valued: repeating --seq is an error, not a merge)
   --all         drain: advance cursor to channel head + clear all pending watch debt
@@ -60,7 +73,8 @@ Options:
 
 A successful later \`party send\` or status update acknowledges an earlier watch wake.
 Use \`party ack --seq N\` when no channel message is warranted (and remember: that
-leaves the server-side @ debt for seq N standing — see LOCAL ONLY above).`;
+leaves the server-side @ debt for seq N standing unless you add --no-reply —
+see TWO LEDGERS above).`;
 
 export async function run(argv: string[]): Promise<number> {
   if (isHelpArg(argv, { allowHelpPositional: true })) {
@@ -68,7 +82,7 @@ export async function run(argv: string[]): Promise<number> {
     return 0;
   }
   // #860②：把 --seq 收成数组只为「重复给了几次」可见——重复即报错，绝不静默取最后一个。
-  const { positionals, flags } = parseArgs(argv, { booleans: ["all"], repeatable: ["seq"] });
+  const { positionals, flags } = parseArgs(argv, { booleans: ["all", "no-reply"], repeatable: ["seq"] });
   const unknown = unknownFlagError(flags, FLAGS);
   if (unknown !== null) {
     console.error(unknown);
@@ -129,6 +143,12 @@ export async function run(argv: string[]): Promise<number> {
     return 1;
   }
 
+  // #875：--no-reply 结清的是**服务端**账本上的某一条 @，必须指名道姓。
+  if (flags["no-reply"] === true && seqFlag === undefined) {
+    console.error(NO_REPLY_REQUIRES_SEQ_ERROR);
+    return 1;
+  }
+
   // --all / --through / --before：批量排空（#668/#674）。
   if (flags.all === true || throughFlag !== undefined || beforeFlag !== undefined) {
     let throughSeq: number;
@@ -167,13 +187,39 @@ export async function run(argv: string[]): Promise<number> {
     return 0;
   }
 
+  // #875：先结服务端账，再动本地债。顺序不能反——本地债清掉了而服务端 POST 失败，
+  // 用户会以为两本账都平了，可那条 @ 仍在服务端欠着，最后照样被记成 unknown_outcome。
+  if (flags["no-reply"] === true) {
+    const auth = await resolveAuthDetailed();
+    if (!auth.server || !auth.token) {
+      console.error("no config, run: party login or party init --server URL --token T");
+      return 1;
+    }
+    try {
+      const result = await ackDelivery(auth.server, auth.token, channel, seqFlag as number);
+      console.log(
+        result.deduped === true
+          ? `server-side @ seq=${seqFlag} in #${channel} was already settled as acknowledged_no_reply`
+          : `settled server-side @ seq=${seqFlag} in #${channel} as acknowledged_no_reply ` +
+            "(seen, no reply needed — visible in the channel ledger)",
+      );
+    } catch (e) {
+      return handleRestError(e);
+    }
+  }
+
   // 单条 ack（默认）：校验与清除同处一个跨进程临界区（ackWatchStuck）：读后清会误吞窗口内新落的债（#599 评审）。
   const acked = ackWatchStuck(channel, seqFlag);
+  const settledServer = flags["no-reply"] === true;
   switch (acked.outcome) {
     case "none":
+      if (settledServer) return 0;
       console.log(`no pending wake debt in #${channel}`);
       return 0;
     case "serve_owned":
+      // 服务端那条 @ 已经被 --no-reply 结清了，serve 不会再重放它——此时再喊「会静默丢掉那个 @」
+      // 就是 #874 刚修掉的那类误导。本地 serve 债留给 serve 闭环自己收，照样不碰。
+      if (settledServer) return 0;
       console.error(
         `refusing to ack: pending debt at seq=${acked.seq} is owned by party serve (source=${acked.source}); ` +
           "serve replays it durably — clearing it by hand would silently drop that @",

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -1360,6 +1360,18 @@ function buildWakeContext(
           cause: delivery.cause,
           attempt: delivery.attempt,
         },
+    // #881：这条触发消息已被后续消息取代。**必须降级处理**——可以当背景读，但不得当作最新
+    // 指令执行；照旧执行就是「拿旧前提行动」，和被假授权骗是同一类失效。判定依据是 seq（频道全局
+    // 单调），不是 ts。superseded/replay 正交，可同时为真。
+    superseded: frame.superseded ?? null,
+    ...(frame.superseded === undefined
+      ? {}
+      : {
+          superseded_notice:
+            `这条消息（seq ${frame.seq}）已被 seq ${frame.superseded.by_seq} 取代` +
+            `（reason=${frame.superseded.reason}）。不要把它当成最新指令执行；` +
+            `先读 seq ${frame.superseded.by_seq}（party history --channel ${channel}），按那条为准。`,
+        }),
     decision_request: frame.decision_request ?? null,
     decision_response: frame.decision_response ?? null,
     charter: boundedCharter,

--- a/cli/src/format.ts
+++ b/cli/src/format.ts
@@ -94,6 +94,8 @@ export interface MsgHeader {
   edited?: boolean;
   /** #817：这条是隔离接待 runner 代发的，不是本人在其完整上下文里说的。 */
   response_source?: MsgFrame["response_source"];
+  /** #881：这条内容已被后续消息取代；消费方应降级，不当最新指令执行。 */
+  superseded?: MsgFrame["superseded"];
 }
 
 // 正文的单行摘要：status 帧取 note（正文常为空），普通消息取 body 首行起的前 N 字符。
@@ -123,6 +125,9 @@ export function msgHeader(m: MsgFrame, previewChars = DEFAULT_HEADER_PREVIEW): M
     ...(m.attachments && m.attachments.length > 0 ? { attachments: m.attachments.length } : {}),
     ...(m.retracted ? { retracted: true } : {}),
     ...(m.edited ? { edited: true } : {}),
+    // #881：headers 模式下也必须看得见「这条已过期」。扫 header 挑活干的 agent 若只在展开
+    // 全文时才发现，判断早就先入为主了——和 response_source 同理。
+    ...(m.superseded === undefined ? {} : { superseded: m.superseded }),
     // 扫 header 时就得看见「这条是代答的」——否则挑出来展开全文才发现，判断已经先入为主了。
     ...(m.response_source === undefined ? {} : { response_source: m.response_source }),
   };
@@ -162,6 +167,11 @@ function formatMsgRaw(m: MsgFrame): string {
     m.retracted ? "retracted" : null,
     m.supersedes !== undefined ? `supersedes #${m.supersedes}` : null,
     m.superseded_by !== undefined ? `superseded by #${m.superseded_by}` : null,
+    // #881：内容已过期的显式标记。读到它就该降级——别把这条当最新指令执行。显式 supersede 链
+    // 上面那个 badge 已经说了，不重复；这里只报 reply_correction 这类隐式判定。
+    m.superseded !== undefined && m.superseded_by === undefined
+      ? `SUPERSEDED by #${m.superseded.by_seq} (${m.superseded.reason}) — not the latest instruction`
+      : null,
     // 回执（#828）：进 badge 而不是正文——「已收到」是这条消息的元数据，不是频道里的一次发言。
     // 手搓版当年正是因为长得像本人发言才误导了协作方。
     formatReceipts(m.receipts),

--- a/cli/src/rest.ts
+++ b/cli/src/rest.ts
@@ -26,6 +26,7 @@ import {
   parseRuntimePeerDiscovery,
   type MsgFrame,
   type PresenceEntry,
+  type PublicDirectedDelivery,
   type ReadCursor,
   type RuntimePeerDiscovery,
   type RuntimePeerPurpose,
@@ -974,6 +975,26 @@ export async function postReceipt(
     headers: bearerJson(token),
     body: JSON.stringify(body),
   })) as { message: MsgFrame };
+}
+
+/**
+ * 「已读不回」的服务端终态（#875）：结清一条 @ 而不发消息，记为
+ * `terminal_reason=acknowledged_no_reply`——**不是** failed / unknown_outcome。
+ *
+ * ref 传 delivery id 或那条 @ 消息的 seq（服务端把纯数字解析成「我在那条消息上的那条 @」，
+ * 因为调用方手上通常只有 `who --json` 报的 pending_mention_seqs）。
+ */
+export async function ackDelivery(
+  server: string,
+  token: string,
+  slug: string,
+  ref: string | number,
+): Promise<{ ok: true; delivery: PublicDirectedDelivery; deduped?: boolean }> {
+  return (await req(
+    server,
+    `/api/channels/${encodeURIComponent(slug)}/deliveries/${encodeURIComponent(String(ref))}/ack`,
+    { method: "POST", headers: bearerJson(token) },
+  )) as { ok: true; delivery: PublicDirectedDelivery; deduped?: boolean };
 }
 
 // 人类决策回应（#284）：人类/moderator 对某条 decision_request 点选项/审批。

--- a/cli/test/ack-ledger-semantics.test.ts
+++ b/cli/test/ack-ledger-semantics.test.ts
@@ -62,10 +62,13 @@ describe("#859 两本账不能混为一谈", () => {
     cap.restore();
     const help = cap.lines.join("\n");
     expect(help).toContain("pending_mention_seqs");
-    expect(help).toMatch(/LOCAL ONLY/);
+    // #875 起两本账仍然是两本，但服务端那本多了一个合法出口（--no-reply）。文案必须两者都说清，
+    // 且默认路径（不带 --no-reply）依旧明说自己碰不到服务端账本。
+    expect(help).toMatch(/TWO LEDGERS/);
     expect(help).toContain("--reply-to");
-    // 不能出现「用 ack 清 pending_mention_seqs」这类同句并列。
-    expect(help).toMatch(/does NOT clear|can never change it/);
+    expect(help).toMatch(/can never change the server ledger/);
+    expect(help).toContain("--no-reply");
+    expect(help).toContain("acknowledged_no_reply");
   });
 
   test("watch --once 的重挂提示不再把 ack 说成清 pending_mention_seqs 的手段", () => {

--- a/cli/test/ack-no-reply-and-superseded.test.ts
+++ b/cli/test/ack-no-reply-and-superseded.test.ts
@@ -1,0 +1,217 @@
+// #875：`party ack` 从纯本地升级为可真正结清服务端账本（--no-reply → acknowledged_no_reply）。
+// #881：superseded 标记必须逐字镜像进 client.ts 的帧校验（#622：漏字段会静默丢整帧），
+//       并且在消费侧看得见——扫 header 的 agent 不能等展开全文才发现「这条已过期」。
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { MsgFrame, ServerFrame } from "@agentparty/shared";
+import { NO_REPLY_REQUIRES_SEQ_ERROR, run as runAck } from "../src/commands/ack";
+import { loadStuck, saveWatchStuck } from "../src/config";
+import { connect, type Connection } from "../src/client";
+import { formatMsg, msgHeader } from "../src/format";
+import { msgFrame, startMockServer, welcomeFrame, type MockServer } from "./mock-server";
+
+let home: string;
+let cwd: string;
+let originalCwd: string;
+const oldEnv: Record<string, string | undefined> = {};
+
+function capture(): { lines: string[]; restore: () => void } {
+  const lines: string[] = [];
+  const log = console.log;
+  const err = console.error;
+  console.log = (...a: unknown[]) => void lines.push(a.join(" "));
+  console.error = (...a: unknown[]) => void lines.push(a.join(" "));
+  return {
+    lines,
+    restore: () => {
+      console.log = log;
+      console.error = err;
+    },
+  };
+}
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "ap-ack-noreply-home-"));
+  cwd = mkdtempSync(join(tmpdir(), "ap-ack-noreply-cwd-"));
+  for (const key of ["AGENTPARTY_HOME", "AGENTPARTY_CONFIG", "AGENTPARTY_CHANNEL"]) {
+    oldEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+  process.env.AGENTPARTY_HOME = home;
+  writeFileSync(join(home, "config.json"), JSON.stringify({ server: "http://ap.test", token: "ap_t" }));
+  originalCwd = process.cwd();
+  process.chdir(cwd);
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  for (const [key, value] of Object.entries(oldEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  rmSync(home, { recursive: true, force: true });
+  rmSync(cwd, { recursive: true, force: true });
+});
+
+const watchDebt = (seq: number) => ({ seq, wake_ts: 1, attempts: 1, source: "watch" as const });
+
+describe("#875 party ack --no-reply 结清服务端账本", () => {
+  test("POST 到 deliveries/:id/ack，本地债一并清掉", async () => {
+    expect(saveWatchStuck("dev", watchDebt(1841))).toBe(true);
+    const realFetch = globalThis.fetch;
+    const urls: string[] = [];
+    const methods: string[] = [];
+    globalThis.fetch = (async (input: unknown, init?: { method?: string }) => {
+      urls.push(String((input as { url?: string })?.url ?? input));
+      methods.push(init?.method ?? "GET");
+      return new Response(
+        JSON.stringify({ ok: true, delivery: { id: "d1", state: "replied", reply_seq: null } }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as unknown as typeof fetch;
+    let lines: string[];
+    try {
+      const cap = capture();
+      expect(await runAck(["--channel", "dev", "--seq", "1841", "--no-reply"])).toBe(0);
+      cap.restore();
+      lines = cap.lines;
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+    expect(urls.some((u) => u.includes("/api/channels/dev/deliveries/1841/ack"))).toBe(true);
+    expect(methods).toContain("POST");
+    expect(lines.join("\n")).toContain("acknowledged_no_reply");
+    expect(loadStuck("dev")).toBeNull();
+  });
+
+  test("服务端失败时不清本地债：不能让人以为两本账都平了", async () => {
+    expect(saveWatchStuck("dev", watchDebt(1841))).toBe(true);
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ error: { code: "conflict", message: "already terminal" } }), {
+        status: 409,
+        headers: { "content-type": "application/json" },
+      })) as unknown as typeof fetch;
+    try {
+      const cap = capture();
+      expect(await runAck(["--channel", "dev", "--seq", "1841", "--no-reply"])).not.toBe(0);
+      cap.restore();
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+    // 服务端那条 @ 还欠着，本地债就必须留着——它是用户下一次还看得见这条 @ 的唯一凭据。
+    expect(loadStuck("dev")?.seq).toBe(1841);
+  });
+
+  test("--no-reply 必须指名道姓：没有 --seq 直接报错，且一次网络请求都不发", async () => {
+    expect(saveWatchStuck("dev", watchDebt(1841))).toBe(true);
+    const realFetch = globalThis.fetch;
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls++;
+      throw new Error("must not talk to the server");
+    }) as unknown as typeof fetch;
+    let lines: string[];
+    try {
+      const cap = capture();
+      expect(await runAck(["--channel", "dev", "--no-reply"])).toBe(1);
+      cap.restore();
+      lines = cap.lines;
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+    expect(lines.join("\n")).toBe(NO_REPLY_REQUIRES_SEQ_ERROR);
+    expect(calls).toBe(0);
+    expect(loadStuck("dev")?.seq).toBe(1841);
+  });
+
+  test("不带 --no-reply 仍然全程零网络：默认行为没被 #875 改变", async () => {
+    expect(saveWatchStuck("dev", watchDebt(7))).toBe(true);
+    const realFetch = globalThis.fetch;
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls++;
+      throw new Error("party ack must not talk to the server");
+    }) as unknown as typeof fetch;
+    try {
+      const cap = capture();
+      expect(await runAck(["--channel", "dev", "--seq", "7"])).toBe(0);
+      cap.restore();
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+    expect(calls).toBe(0);
+  });
+});
+
+async function collect(c: Connection, n: number, timeoutMs = 3000): Promise<ServerFrame[]> {
+  const frames: ServerFrame[] = [];
+  const timer = setTimeout(() => c.close(), timeoutMs);
+  for await (const f of c.frames) {
+    frames.push(f);
+    if (f.type === "msg") c.ack(f.seq);
+    if (frames.length >= n) break;
+  }
+  clearTimeout(timer);
+  return frames;
+}
+
+describe("#881 superseded 的 wire 兼容与可见性", () => {
+  let server: MockServer | null = null;
+  let conn: Connection | null = null;
+
+  afterEach(() => {
+    conn?.close();
+    conn = null;
+    server?.stop();
+    server = null;
+  });
+
+  test("带 superseded 的帧不被静默丢弃；与 replay 可同时为真", async () => {
+    server = startMockServer((frame, sock) => {
+      if (frame.type !== "hello") return;
+      sock.send(welcomeFrame(2));
+      sock.send({
+        ...msgFrame(1, "部署到 prod"),
+        replay: true,
+        superseded: { by_seq: 2, reason: "reply_correction" },
+      });
+      sock.send(msgFrame(2, "改口：先别部署"));
+    });
+    conn = connect(server.url, "ap_tok", "dev", 0, { backoffBaseMs: 20 });
+    const frames = await collect(conn, 3);
+    const msgs = frames.filter((f) => f.type === "msg") as MsgFrame[];
+    expect(msgs.map((m) => m.seq)).toEqual([1, 2]);
+    // 两个标记正交：一条帧同时是「补拉的历史帧」和「内容已过期」。
+    expect(msgs[0]!.replay).toBe(true);
+    expect(msgs[0]!.superseded).toEqual({ by_seq: 2, reason: "reply_correction" });
+    expect(msgs[1]!.superseded).toBeUndefined();
+  });
+
+  test("形状不对的 superseded 判为非法帧（by_seq 必须是正整数、reason 必须在词表里）", async () => {
+    server = startMockServer((frame, sock) => {
+      if (frame.type !== "hello") return;
+      sock.send(welcomeFrame(3));
+      sock.send({ ...msgFrame(1, "坏帧"), superseded: { by_seq: 0, reason: "reply_correction" } });
+      sock.send({ ...msgFrame(2, "坏帧"), superseded: { by_seq: 3, reason: "whatever" } });
+      sock.send(msgFrame(3, "好帧"));
+    });
+    conn = connect(server.url, "ap_tok", "dev", 0, { backoffBaseMs: 20 });
+    const frames = await collect(conn, 2);
+    const msgs = frames.filter((f) => f.type === "msg") as MsgFrame[];
+    expect(msgs.map((m) => m.seq)).toEqual([3]);
+  });
+
+  test("消费侧看得见：header 摘要与全文渲染都报「这条不是最新指令」", () => {
+    const frame = {
+      ...(msgFrame(1, "部署到 prod") as unknown as MsgFrame),
+      superseded: { by_seq: 9, reason: "reply_correction" as const },
+    };
+    expect(msgHeader(frame).superseded).toEqual({ by_seq: 9, reason: "reply_correction" });
+    const rendered = formatMsg(frame);
+    expect(rendered).toContain("SUPERSEDED by #9");
+    expect(rendered).toContain("not the latest instruction");
+  });
+});

--- a/cli/test/replay-frame-allowlist.test.ts
+++ b/cli/test/replay-frame-allowlist.test.ts
@@ -73,6 +73,7 @@ describe("#622 allow-list 逐字镜像守卫", () => {
     const fields = [...block.matchAll(/^\s{2}(\w+)\??:/gm)].map((m) => m[1]!);
     expect(fields).toContain("replay");
     expect(fields).toContain("rev_seq");
+    expect(fields).toContain("superseded");
 
     const validatorStart = clientSrc.indexOf("function isMessageFrame(");
     expect(validatorStart).toBeGreaterThan(-1);
@@ -85,7 +86,12 @@ describe("#622 allow-list 逐字镜像守卫", () => {
       "decision_request", "decision_resolution", "decision_response", "attachments",
       "response_source", "receipts", "revision",
     ]);
-    const missing = fields.filter((f) => !structured.has(f) && !validator.includes(`value.${f}`));
+    // 必须按标识符边界匹配，不能用 includes：`value.superseded_by` 的存在会让 `superseded`
+    // 这个字段名「看起来已镜像」，守卫就对整类前缀重叠的新字段失效（实测：删掉 superseded 的
+    // 校验后本守卫仍然全绿）。前缀重叠在这份协议里不是个例——supersedes/superseded/superseded_by、
+    // edited/edited_at/edited_by、retracted/retracted_at 都是。
+    const mirrored = (field: string) => new RegExp(`value\\.${field}(?![A-Za-z0-9_])`).test(validator);
+    const missing = fields.filter((f) => !structured.has(f) && !mirrored(f));
     expect(missing).toEqual([]);
   });
 });

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -1495,6 +1495,15 @@ export interface PublicDirectedDelivery {
    * 细节，可安全跨组织下发。旧客户端不认识该字段会忽略，仍按普通 `failed` 展示——不影响正确性。
    */
   undelivered?: boolean;
+  /**
+   * 「已读不回」的真终态（#875）。目标身份显式 ack 了这条 @——看到了、判断不需要回复——
+   * 于是它以 `replied` 结清，但 reply_seq 为 null。**不是** failed / unknown_outcome：
+   * 后者是投递失败，把「已读不回」记成失败会让欠账账本失真。
+   *
+   * 刻意可审计且频道侧可见：by 是执行 ack 的身份名，at 是服务端落库时刻——ack 不能成为
+   * 「悄悄吞掉一条 @」的手段，谁在什么时候把它结清了必须查得到。旧 worker 不下发该字段。
+   */
+  acknowledged_no_reply?: { by: string; at: number };
 }
 
 /** 只发给目标身份当前持有 serve lease 的连接；message 正文仍引用原 messages 行，不复制存储。 */
@@ -1677,9 +1686,38 @@ export interface MsgFrame {
    * 注意：`cli/src/client.ts` 的 isMessageFrame 校验必须逐字镜像本字段（#622 教训）。
    */
   replay?: true;
+  /**
+   * 「这条内容已被后续消息取代」的显式标记（#881）。与 `replay` **正交**，可同时为真：
+   * replay 说的是「这是补拉的历史帧」（传输事实），superseded 说的是「这条正文已过期」（内容事实）。
+   *
+   * 定序依据仍然**只有 seq**（频道全局单调）。刻意不按 `ts` 排序或判定新旧：ts 是发送端本地时钟，
+   * 同机多 runner / 跨机漂移下比 seq 更不可信，按它定序会引入新的错序（#881 明确否掉了这个方案）。
+   * 因此 by_seq 一定 > 本帧 seq，消费侧比较的是 seq 而不是时间。
+   *
+   * 消费侧（serve runner / watch / bridge）见到本字段应降级处理：可以读作背景，但不得当成最新指令执行。
+   * 可选字段：旧客户端忽略即可正常工作；旧服务端不下发时按「未知是否被取代」处理（即旧语义）。
+   * 注意：`cli/src/client.ts` 的 isMessageFrame 校验必须逐字镜像本字段（#622 教训）。
+   */
+  superseded?: SupersededMark;
   revision?: {
     original_body: string | null;
   };
+}
+
+/**
+ * 「被取代」的判定口径（#881）。刻意只收**可证明后一条针对的就是前一条**的两种关系，
+ * 不含「同 sender 同 @ 目标的任意后续消息」——那会把「做 X」「再做 Y」两条独立的 @ 里的
+ * 前一条误标成过期，把有效指令降级掉，比不标更危险。
+ *  - `revision`：显式 supersede 链（`supersedes` / `superseded_by`），发送者自己声明的替代关系；
+ *  - `reply_correction`：同一 sender 用 `--reply-to` 回到这条消息、且再次 @ 了同一目标，
+ *    且这条对该目标的 directed delivery 当时**仍未结清**——即「我改口了，别按上一条做」。
+ */
+export type SupersededReason = "revision" | "reply_correction";
+
+export interface SupersededMark {
+  /** 取代它的那条消息的 seq；恒大于被标记帧的 seq。定序依据是 seq，不是 ts。 */
+  by_seq: number;
+  reason: SupersededReason;
 }
 
 /** One bounded page of data attributable to an identity in a channel. */

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -239,7 +239,10 @@ type DeliveryTerminalReason =
   | "source_retention_expired"
   | "delivery_expired"
   | "undelivered_timeout"
-  | "orphaned_waiting_owner";
+  | "orphaned_waiting_owner"
+  // #875：「看到了、明确不需要回复」。唯一一个挂在 state='replied' 上的 reason——它是结清，
+  // 不是失败。绝不能和 failed/unknown_outcome 混为一谈，否则欠账账本把「已读不回」记成投递失败。
+  | "acknowledged_no_reply";
 
 const REVIVABLE_DELIVERY_FAILURES = new Set<DeliveryTerminalReason>(["unknown_outcome"]);
 
@@ -1807,6 +1810,10 @@ export class ChannelDO extends Server<Env> {
       "ALTER TABLE messages ADD COLUMN retracted_by TEXT",
       "ALTER TABLE messages ADD COLUMN supersedes INTEGER",
       "ALTER TABLE messages ADD COLUMN superseded_by INTEGER",
+      // 隐式「被取代」（#881）：同一 sender 用 --reply-to 回到本条、并再次 @ 了同一目标，
+      // 且本条对该目标的 delivery 当时仍未结清。与显式 supersede 链（superseded_by）分列存储，
+      // 因为两者判定口径不同、frame 上要报不同的 reason。
+      "ALTER TABLE messages ADD COLUMN superseded_seq INTEGER",
       // Compact exactly-once tombstone. Delivery rows may be pruned after their bounded audit
       // window, but editing the retained source must never recreate work for an old target.
       "ALTER TABLE messages ADD COLUMN delivery_targets_json TEXT NOT NULL DEFAULT '[]'",
@@ -2120,6 +2127,10 @@ export class ChannelDO extends Server<Env> {
       "ALTER TABLE directed_deliveries ADD COLUMN previous_lease_epoch INTEGER",
       "ALTER TABLE directed_deliveries ADD COLUMN previous_lease_attempt INTEGER",
       "ALTER TABLE directed_deliveries ADD COLUMN previous_lease_token TEXT",
+      // 「已读不回」终态的审计列（#875）：ack 必须查得到是谁、什么时候结清的，否则它就成了
+      // 悄悄吞一条 @ 的手段。终态本身走 state='replied' + terminal_reason='acknowledged_no_reply'。
+      "ALTER TABLE directed_deliveries ADD COLUMN acknowledged_by TEXT",
+      "ALTER TABLE directed_deliveries ADD COLUMN acknowledged_at INTEGER",
     ]) {
       try {
         sql.exec(ddl);
@@ -6257,6 +6268,86 @@ export class ChannelDO extends Server<Env> {
     //  - 不占 seq / 不进正文流 / 不需要 ack，所以既不会淹没信噪比，也不可能像 #826 那样把七条真消息
     //    挡在一条零信息量回执后面。
     // 只 bump rev_seq：重连客户端按 rev_seq 补拉时会重收这条消息（带上回执），无需额外重放通道。
+    // #875「已读不回」的真终态。今天唯一能结清一条 @ 的动作是 `send --reply-to N`，于是「看到了、
+    // 判断不需要回复」这种极常见情况没有合法出口，只能挂到租约过期被记成 failed/unknown_outcome——
+    // 把「已读不回」污染成「投递失败」，欠账账本随之失真。这里给它一个自己的终态。
+    const deliveryAckMatch = url.pathname.match(/^\/internal\/deliveries\/([^/]+)\/ack$/);
+    if (deliveryAckMatch && request.method === "POST") {
+      this.cacheChannelMeta(request.headers, request.headers.get("x-ap-host"));
+      const deliveryId = decodeURIComponent(deliveryAckMatch[1]!);
+      const name = request.headers.get("x-ap-name") ?? "";
+      const owner = request.headers.get("x-ap-owner") ?? undefined;
+      const tokenHash = request.headers.get("x-ap-token-hash") ?? "";
+      if (name === "") {
+        return Response.json(
+          { error: { code: "forbidden", message: "ack requires an identified sender" } },
+          { status: 403 },
+        );
+      }
+      // 调用方手上通常只有 seq（`who --json` 的 pending_mention_seqs 报的就是 seq，没有任何接口
+      // 下发 delivery id），所以纯数字 id 按「我在那条消息上的那条 @」解析。落到同一条授权路径上。
+      const row = /^[1-9]\d*$/.test(deliveryId)
+        ? this.ctx.storage.sql
+            .exec(
+              "SELECT * FROM directed_deliveries WHERE message_seq = ? AND target_name = ? LIMIT 1",
+              Number(deliveryId),
+              name,
+            )
+            .toArray()[0]
+        : this.directedDeliveryRow(deliveryId);
+      if (row === undefined) {
+        return Response.json({ error: { code: "not_found", message: "delivery not found" } }, { status: 404 });
+      }
+      // 只有被 @ 的那个身份本人能宣告「我读了、不回」。principal 按建单时的 target_owner 比对：
+      // 同名不同账号（名字被回收后由别人注册）绝不放行。
+      if (!this.identityMatchesDeliveryTarget({ name, owner, tokenHash }, row)) {
+        return Response.json(
+          { error: { code: "forbidden", message: "only the delivery target can acknowledge it" } },
+          { status: 403 },
+        );
+      }
+      const state = String(row.state);
+      // 幂等：重复 ack 同一条返回既有终态，不报错也不改写审计列。
+      if (state === "replied" && String(row.terminal_reason ?? "") === "acknowledged_no_reply") {
+        return Response.json({ ok: true, delivery: this.rowToPublicDirectedDelivery(row, true), deduped: true });
+      }
+      if (state === "replied" || state === "failed") {
+        return Response.json(
+          {
+            error: {
+              code: "conflict",
+              message: `delivery already terminal (state=${state}); ack cannot re-open or re-settle it`,
+            },
+          },
+          { status: 409 },
+        );
+      }
+      // waiting_owner 不开放：那是服务端持有的、等人类决策的工作状态，不是「一条你读了的 @」。
+      if (state !== "queued" && state !== "claimed" && state !== "running") {
+        return Response.json(
+          { error: { code: "conflict", message: `delivery in state=${state} cannot be acknowledged` } },
+          { status: 409 },
+        );
+      }
+      const now = Date.now();
+      const terminal = this.transitionDirectedDeliveryTerminal(String(row.id), "replied", now, {
+        replySeq: null,
+        terminalReason: "acknowledged_no_reply",
+        expectedStates: [state],
+        // 显式 ack 常发生在原 lease 连接之外（换了会话、从别的终端补 ack），所以不传
+        // expectedLeaseConnectionId；改由 principal 闸把关，且只放行同 principal。
+        explicitAckPrincipal: this.identityDeliveryPrincipal({ owner, tokenHash }),
+        acknowledgedBy: name,
+      });
+      if (terminal === undefined) {
+        return Response.json(
+          { error: { code: "conflict", message: "delivery changed state concurrently; re-read and retry" } },
+          { status: 409 },
+        );
+      }
+      return Response.json({ ok: true, delivery: this.rowToPublicDirectedDelivery(terminal, true) });
+    }
+
     const receiptMatch = url.pathname.match(/^\/internal\/messages\/([1-9]\d*)\/receipt$/);
     if (receiptMatch && request.method === "POST") {
       this.cacheChannelMeta(request.headers, request.headers.get("x-ap-host"));
@@ -10026,6 +10117,16 @@ export class ChannelDO extends Server<Env> {
     // #667：把「排队超时/无唤醒通道」这一粗粒度失因下发，让 UI 把它和「跑了但失败」区分成「未送达」。
     // 只在终态 failed 且 terminal_reason=undelivered_timeout 时置 true，不泄露任何 runner/session 细节。
     const undelivered = state === "failed" && String(row.terminal_reason ?? "") === "undelivered_timeout";
+    // #875：「已读不回」的真终态。频道侧无条件可见（不看 detailedState）——ack 若只有 acker 自己
+    // 看得到，它就成了悄悄吞 @ 的手段；谁在什么时候结清了这条 @，任何观察者都该查得到。
+    const acknowledgedNoReply =
+      String(row.terminal_reason ?? "") === "acknowledged_no_reply" &&
+      typeof row.acknowledged_by === "string" &&
+      row.acknowledged_by.length > 0 &&
+      row.acknowledged_at !== null &&
+      row.acknowledged_at !== undefined
+        ? { by: String(row.acknowledged_by), at: Number(row.acknowledged_at) }
+        : null;
     return {
       id: delivery.id,
       message_seq: delivery.message_seq,
@@ -10036,6 +10137,7 @@ export class ChannelDO extends Server<Env> {
       updated_at: delivery.updated_at,
       preview: preview !== undefined ? preview : this.deliveryMessagePreview(delivery.message_seq),
       ...(undelivered ? { undelivered: true } : {}),
+      ...(acknowledgedNoReply === null ? {} : { acknowledged_no_reply: acknowledgedNoReply }),
     };
   }
 
@@ -10320,6 +10422,66 @@ export class ChannelDO extends Server<Env> {
     return "mention";
   }
 
+  /**
+   * #881「这条已被后续消息取代」的显式标记。**判定口径刻意保守**：只在能证明「后一条针对的就是
+   * 前一条」时才打——同一 sender 用 `--reply-to` 回到那条消息、并再次 @ 了同一个目标，且那条对该
+   * 目标的 delivery 此刻仍未结清（queued/claimed/running/waiting_owner）。
+   *
+   * 刻意**不**采用「同 sender 同 @ 目标的任意后续消息」：「做 X」「再做 Y」是两条独立的 @，把前
+   * 一条标成过期会让 worker 降级掉一条仍然有效的指令——那比不标更危险。也刻意不看 ts：定序依据
+   * 只有 seq（频道全局单调），ts 是本地时钟，同机多 runner / 跨机漂移下比 seq 更不可信。
+   *
+   * 显式 supersede 链（superseded_by）优先，已有关系的不覆盖；已标记过的不重复标记（幂等）。
+   */
+  private markSupersededByReplyCorrection(msg: MsgFrame, targets: string[], now: number) {
+    const replyTo = msg.reply_to;
+    if (replyTo === null || replyTo === undefined) return;
+    const original = this.ctx.storage.sql
+      .exec(
+        "SELECT seq, sender_name, retracted_at, superseded_by, superseded_seq FROM messages WHERE seq = ?",
+        replyTo,
+      )
+      .toArray()[0];
+    if (original === undefined) return;
+    // 只有原发起者能给自己那条指令「改口」；别人回复同一条 @ 不构成取代关系。
+    if (String(original.sender_name) !== msg.sender.name) return;
+    if (original.retracted_at !== null && original.retracted_at !== undefined) return;
+    if (original.superseded_by !== null && original.superseded_by !== undefined) return;
+    if (original.superseded_seq !== null && original.superseded_seq !== undefined) return;
+    const placeholders = targets.map(() => "?").join(", ");
+    const stillOpen = this.ctx.storage.sql
+      .exec(
+        `SELECT 1 FROM directed_deliveries
+          WHERE message_seq = ? AND target_name IN (${placeholders})
+            AND state IN ('queued', 'claimed', 'running', 'waiting_owner')
+          LIMIT 1`,
+        replyTo,
+        ...targets,
+      )
+      .toArray()[0];
+    // 已经结清的 @ 不需要「过期」信号：它不会再被谁当成最新指令执行。
+    if (stillOpen === undefined) return;
+    const rev = this.nextRevSeq();
+    this.ctx.storage.sql.exec(
+      "UPDATE messages SET superseded_seq = ?, rev_seq = ? WHERE seq = ?",
+      msg.seq,
+      rev,
+      replyTo,
+    );
+    const row = this.ctx.storage.sql.exec("SELECT * FROM messages WHERE seq = ?", replyTo).toArray()[0];
+    if (row === undefined) return;
+    // 复用既有的 supersede 动作词：message_update 的 action 联合是 CLI 手抄镜像的（#622），
+    // 新增一个词会让所有未升级客户端把这类修订整帧静默丢掉。语义上这就是一次 supersede。
+    this.broadcastFrame({
+      type: "message_update",
+      target_seq: replyTo,
+      action: "supersede",
+      actor: msg.sender,
+      ts: now,
+      message: this.rowToFrame(row),
+    });
+  }
+
   private ensureDirectedDeliveries(
     msg: MsgFrame,
     classifiedTargets: string[],
@@ -10335,6 +10497,7 @@ export class ChannelDO extends Server<Env> {
     const targets = [...new Set(classifiedTargets)].filter((targetName) => targetName !== msg.sender.name);
     if (targets.length === 0) return Promise.resolve();
     const now = Date.now();
+    this.markSupersededByReplyCorrection(msg, targets, now);
     for (const targetName of targets) {
       const existing = this.ctx.storage.sql
         .exec("SELECT * FROM directed_deliveries WHERE message_seq = ? AND target_name = ?", msg.seq, targetName)
@@ -11358,6 +11521,15 @@ export class ChannelDO extends Server<Env> {
       expectedStates: string[];
       expectedLeaseAdapter?: string;
       expectedLeaseConnectionId?: string;
+      /**
+       * #875「已读不回」的显式 ack 通道。一个显式 ack 很可能发生在原 lease 连接之外（会话换了、
+       * 从别的终端补 ack），拿 lease_connection_id 卡它等于让这条 @ 永远只能靠回复或超时收场。
+       * 所以这里给连接身份闸开一个**窄**口子：口子只对「principal 与建单时 target_owner 完全一致」
+       * 的调用方开放，绝不放宽成任意调用方——principal 不匹配直接拒，比连接闸更严。
+       */
+      explicitAckPrincipal?: string;
+      /** 落审计列 acknowledged_by/at 的身份名；仅显式 ack 传。 */
+      acknowledgedBy?: string;
       dispatchNext?: boolean;
     },
   ): Record<string, unknown> | undefined {
@@ -11393,6 +11565,15 @@ export class ChannelDO extends Server<Env> {
       return before;
     }
     if (!options.expectedStates.includes(beforeState)) return undefined;
+    // 显式 ack 的 principal 闸（#875）。放在连接闸之前：它替代连接身份，但只在 principal 完全相等
+    // 时放行。建单时的 target_owner 缺失（历史行）一律拒绝——宁可让这条 @ 走原来的回复/超时路径，
+    // 也不能凭一个无法归属的 principal 把别人的 @ 结清掉。
+    if (options.explicitAckPrincipal !== undefined) {
+      const principal = typeof before.target_owner === "string" && before.target_owner.length > 0
+        ? before.target_owner
+        : null;
+      if (principal === null || principal !== options.explicitAckPrincipal) return undefined;
+    }
     if (
       options.expectedLeaseAdapter !== undefined &&
       String(before.lease_adapter ?? "") !== options.expectedLeaseAdapter
@@ -11416,21 +11597,29 @@ export class ChannelDO extends Server<Env> {
     const error = terminalState === "failed"
       ? (options.error ?? "delivery failed").slice(0, DECISION_REASON_LIMIT)
       : null;
+    // replied 通常无 reason（普通回复结清）；#875 的显式 ack 是唯一携带 reason 的 replied——
+    // 「已读不回」必须在账本里留下自己的名字，否则它和一条真回复无法区分。
     const terminalReason: DeliveryTerminalReason | null = terminalState === "failed"
       ? options.terminalReason ?? "delivery_failed"
-      : null;
+      : options.terminalReason ?? null;
+    const acknowledgedBy = options.acknowledgedBy ?? null;
     this.ctx.storage.sql.exec(
       `UPDATE directed_deliveries
           SET state = ?,
               last_lease_connection_id = COALESCE(lease_connection_id, last_lease_connection_id),
               last_lease_adapter = COALESCE(lease_adapter, last_lease_adapter),
               lease_connection_id = NULL, lease_adapter = NULL, lease_until = NULL,
-              reply_seq = COALESCE(?, reply_seq), last_error = ?, terminal_reason = ?, updated_at = ?
+              reply_seq = COALESCE(?, reply_seq), last_error = ?, terminal_reason = ?,
+              acknowledged_by = COALESCE(?, acknowledged_by),
+              acknowledged_at = COALESCE(?, acknowledged_at),
+              updated_at = ?
         WHERE ${clauses.join(" AND ")}`,
       terminalState,
       replySeq,
       error,
       terminalReason,
+      acknowledgedBy,
+      acknowledgedBy === null ? null : now,
       now,
       ...whereArgs,
     );
@@ -12392,6 +12581,13 @@ export class ChannelDO extends Server<Env> {
     }
     if (r.supersedes !== null && r.supersedes !== undefined) frame.supersedes = Number(r.supersedes);
     if (r.superseded_by !== null && r.superseded_by !== undefined) frame.superseded_by = Number(r.superseded_by);
+    // #881「这条内容已过期」的显式标记。显式 supersede 链优先（发送者自己声明的替代关系最强），
+    // 其次才是 reply_correction。定序依据仍只有 seq——这里报的 by_seq 恒大于本帧 seq，不涉及 ts。
+    if (r.superseded_by !== null && r.superseded_by !== undefined) {
+      frame.superseded = { by_seq: Number(r.superseded_by), reason: "revision" };
+    } else if (r.superseded_seq !== null && r.superseded_seq !== undefined) {
+      frame.superseded = { by_seq: Number(r.superseded_seq), reason: "reply_correction" };
+    }
     if (r.rev_seq !== null && r.rev_seq !== undefined) frame.rev_seq = Number(r.rev_seq);
     if (!retracted && r.original_body !== null && r.original_body !== undefined) {
       frame.revision = { original_body: String(r.original_body) };

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -8098,6 +8098,48 @@ app.put("/api/channels/:slug/retention", async (c) => {
 
 // 回执（#828）：「收到了，但我现在不在轮次里」。挂在目标消息上的元数据——不占 seq、不进正文流、
 // 不触发 delivery。必须注册在 :action 泛匹配之前，否则被吞。
+// 「已读不回」的真终态（#875）：结清一条 @ 而不发消息。与 failed / unknown_outcome 明确区分——
+// 后者是投递失败。授权在 DO 侧按建单时的 target_owner 逐条判：只有被 @ 的那个 principal 本人能 ack。
+app.post("/api/channels/:slug/deliveries/:id/ack", async (c) => {
+  const slug = c.req.param("slug");
+  const channel = await loadChannel(c.env.DB, slug);
+  if (!channel) return c.json(errorBody("not_found", "channel not found"), 404);
+  const identity = c.get("identity");
+  // ack 写的是服务端持久账本，只读会话不得结清任何人的 @。
+  if (identity.role === "readonly") {
+    return c.json(errorBody("forbidden", "readonly sessions cannot acknowledge deliveries"), 403);
+  }
+  if (!(await canAccessLoadedChannel(c.env.DB, identity, channel))) {
+    return c.json(errorBody("forbidden", "not allowed in this channel"), 403);
+  }
+  if (channel.archived_at !== null) {
+    return c.json(errorBody("archived", "channel is archived"), 410);
+  }
+  const deliveryId = c.req.param("id");
+  if (typeof deliveryId !== "string" || deliveryId.length === 0 || deliveryId.length > 128) {
+    return c.json(errorBody("bad_request", "delivery id required"), 400);
+  }
+  return mutableFetchResponse(
+    await fetchChannelDO(
+      c.env,
+      slug,
+      new Request(`https://do/internal/deliveries/${encodeURIComponent(deliveryId)}/ack`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-partykit-room": slug,
+          "x-ap-name": identity.name,
+          "x-ap-kind": identity.kind,
+          "x-ap-role": identity.role,
+          ...(identity.owner ? { "x-ap-owner": identity.owner } : {}),
+          "x-ap-token-hash": identity.hash,
+          ...channelHeaders(channel, c.req.url),
+        },
+      }),
+    ),
+  );
+});
+
 app.post("/api/channels/:slug/messages/:seq/receipt", async (c) => {
   const slug = c.req.param("slug");
   const channel = await loadChannel(c.env.DB, slug);

--- a/worker/test/delivery-ack-no-reply.spec.ts
+++ b/worker/test/delivery-ack-no-reply.spec.ts
@@ -1,0 +1,241 @@
+// #875「已读不回」的真终态。今天唯一能结清一条 @ 的动作是 `send --reply-to N`，于是
+// 「看到了、判断不需要回复」这种极常见情况只能挂到租约过期，被记成 failed/unknown_outcome——
+// 把「已读不回」污染成「投递失败」。这里守四件事：
+//   ① 显式 ack 写入 state=replied + terminal_reason=acknowledged_no_reply（不是 failed）；
+//   ② 授权只放行**同 principal**——同名不同账号、别人、无归属历史行一律拒；
+//   ③ 连接闸开口子是给「不在原 lease 连接上的显式 ack」的，不是放宽成任意调用方；
+//   ④ 终态可审计（谁 ack、何时）且频道侧可见——ack 不能成为悄悄吞 @ 的手段。
+import type { PublicDirectedDelivery } from "@agentparty/shared";
+import { env, runInDurableObject } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import type { ChannelDO } from "../src/do";
+import { WsClient, api, createChannel, seedToken, uniq } from "./helpers";
+
+async function sendMention(slug: string, token: string, target: string) {
+  const res = await api(`/api/channels/${slug}/messages`, token, {
+    method: "POST",
+    body: JSON.stringify({ kind: "message", body: `@${target} FYI`, mentions: [target], reply_to: null }),
+  });
+  expect(res.status).toBe(200);
+  return (await res.json()) as { seq: number };
+}
+
+async function deliveryRow(slug: string) {
+  const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+  return runInDurableObject(stub, async (_instance: ChannelDO, state) => {
+    const row = state.storage.sql.exec("SELECT * FROM directed_deliveries LIMIT 1").toArray()[0];
+    return row === undefined
+      ? null
+      : {
+          id: String(row.id),
+          state: String(row.state),
+          terminal_reason: row.terminal_reason === null ? null : String(row.terminal_reason),
+          reply_seq: row.reply_seq === null ? null : Number(row.reply_seq),
+          last_error: row.last_error === null ? null : String(row.last_error),
+          acknowledged_by: row.acknowledged_by === null ? null : String(row.acknowledged_by),
+          acknowledged_at: row.acknowledged_at === null ? null : Number(row.acknowledged_at),
+          target_owner: row.target_owner === null ? null : String(row.target_owner),
+        };
+  });
+}
+
+async function setup() {
+  const owner = `${uniq("owner")}@example.com`;
+  const sender = await seedToken("agent", uniq("sender"), { owner });
+  const target = await seedToken("agent", uniq("target"), { owner });
+  const slug = await createChannel(sender.token);
+  const posted = await sendMention(slug, sender.token, target.name);
+  const delivery = await deliveryRow(slug);
+  expect(delivery?.state).toBe("queued");
+  return { owner, sender, target, slug, posted, deliveryId: delivery!.id };
+}
+
+describe("#875 已读不回：acknowledged_no_reply 终态", () => {
+  it("目标身份显式 ack 后落 replied + acknowledged_no_reply，而不是 failed/unknown_outcome", async () => {
+    const { slug, target, deliveryId } = await setup();
+
+    const res = await api(`/api/channels/${slug}/deliveries/${deliveryId}/ack`, target.token, { method: "POST" });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: true; delivery: PublicDirectedDelivery };
+    expect(body.ok).toBe(true);
+    expect(body.delivery.state).toBe("replied");
+    expect(body.delivery.reply_seq).toBeNull();
+
+    const row = await deliveryRow(slug);
+    expect(row?.state).toBe("replied");
+    expect(row?.terminal_reason).toBe("acknowledged_no_reply");
+    // 「已读不回」不是失败：它绝不能带上 failed 那条路径的任何痕迹。
+    expect(row?.last_error).toBeNull();
+    expect(row?.reply_seq).toBeNull();
+  });
+
+  it("终态可审计：记下是谁 ack、什么时候，且频道侧（非 acker 的连接）也看得到", async () => {
+    const { slug, sender, target, deliveryId } = await setup();
+    const before = Date.now();
+
+    const res = await api(`/api/channels/${slug}/deliveries/${deliveryId}/ack`, target.token, { method: "POST" });
+    expect(res.status).toBe(200);
+
+    const row = await deliveryRow(slug);
+    expect(row?.acknowledged_by).toBe(target.name);
+    expect(row?.acknowledged_at).toBeGreaterThanOrEqual(before);
+
+    // 频道侧可见性：用**发送者**（不是 acker）的连接补拉 delivery_state，逐帧读，
+    // 不用 nextOfType 当屏障——它会静默丢掉途中帧，从而掩盖「其实根本没下发」。
+    const ws = await WsClient.open(slug, sender.token);
+    await ws.next();
+    ws.send({ type: "hello", since: 0, directed_delivery: "v1" });
+    let seen: PublicDirectedDelivery | null = null;
+    for (let i = 0; i < 40 && seen === null; i += 1) {
+      const frame = await ws.next();
+      if (frame.type === "delivery_state" && frame.delivery.id === deliveryId) seen = frame.delivery;
+    }
+    ws.close();
+    expect(seen).not.toBeNull();
+    expect(seen!.acknowledged_no_reply).toEqual({ by: target.name, at: row!.acknowledged_at! });
+  });
+
+  it("只放行同 principal：别人（含同 owner 的另一个身份）不能替目标 ack", async () => {
+    const { slug, owner, sender, deliveryId } = await setup();
+    const sibling = await seedToken("agent", uniq("sibling"), { owner });
+
+    for (const token of [sender.token, sibling.token]) {
+      const res = await api(`/api/channels/${slug}/deliveries/${deliveryId}/ack`, token, { method: "POST" });
+      expect(res.status).toBe(403);
+    }
+    const row = await deliveryRow(slug);
+    expect(row?.state).toBe("queued");
+    expect(row?.terminal_reason).toBeNull();
+  });
+
+  // 名字全局唯一，「同名不同账号」只能在名字被回收/重注册后出现——那正是建单时快照的
+  // target_owner 与当前持名者不一致的状态。直接把库里的 target_owner 改掉来复现它。
+  it("同名不同 principal 不放行：建单时的 target_owner 才是权威，不按当前名字推断", async () => {
+    const { slug, target, deliveryId } = await setup();
+    const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+    await runInDurableObject(stub, async (_instance: ChannelDO, state) => {
+      state.storage.sql.exec(
+        "UPDATE directed_deliveries SET target_owner = ? WHERE id = ?",
+        `${uniq("other")}@example.com`,
+        deliveryId,
+      );
+    });
+
+    const res = await api(`/api/channels/${slug}/deliveries/${deliveryId}/ack`, target.token, { method: "POST" });
+    expect(res.status).toBe(403);
+    expect((await deliveryRow(slug))?.state).toBe("queued");
+  });
+
+  it("无归属的历史行（target_owner 为空）一律拒：无法归属的 principal 不能结清别人的 @", async () => {
+    const { slug, target, deliveryId } = await setup();
+    const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+    await runInDurableObject(stub, async (_instance: ChannelDO, state) => {
+      state.storage.sql.exec("UPDATE directed_deliveries SET target_owner = NULL WHERE id = ?", deliveryId);
+    });
+
+    const res = await api(`/api/channels/${slug}/deliveries/${deliveryId}/ack`, target.token, { method: "POST" });
+    expect(res.status).toBe(403);
+    expect((await deliveryRow(slug))?.state).toBe("queued");
+  });
+
+  // 上面几条走的是 REST 入口，那里另有一道 identityMatchesDeliveryTarget。但「为显式 ack 开的
+  // 连接身份闸口子」本身也必须只放行同 principal——它是 transitionDirectedDeliveryTerminal 上
+  // 的一道独立闸，将来任何调用方（webhook/alarm/别的内部路径）传 explicitAckPrincipal 都得被它挡住。
+  // 所以这里直接打这道闸，不经过 REST 入口。
+  it("闸本身只放行同 principal：principal 不符 / 为空时拒绝转终态", async () => {
+    const { slug, deliveryId } = await setup();
+    const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+    const outcomes = await runInDurableObject(stub, async (instance: ChannelDO) => {
+      const gate = (
+        instance as unknown as {
+          transitionDirectedDeliveryTerminal: (
+            id: string,
+            state: "replied" | "failed",
+            now: number,
+            opts: Record<string, unknown>,
+          ) => Record<string, unknown> | undefined;
+        }
+      ).transitionDirectedDeliveryTerminal.bind(instance);
+      const attempt = (principal: string) =>
+        gate(deliveryId, "replied", Date.now(), {
+          replySeq: null,
+          terminalReason: "acknowledged_no_reply",
+          expectedStates: ["queued"],
+          explicitAckPrincipal: principal,
+          acknowledgedBy: "whoever",
+        });
+      return {
+        foreign: attempt("someone-else@example.com") === undefined,
+        empty: attempt("") === undefined,
+      };
+    });
+    expect(outcomes).toEqual({ foreign: true, empty: true });
+    expect((await deliveryRow(slug))?.state).toBe("queued");
+  });
+
+  it("显式 ack 不被原 lease 连接卡死：换一个连接（乃至没有连接）也能结清", async () => {
+    const { slug, target, deliveryId } = await setup();
+    // 先让目标拿到 serve 租约（delivery 进 claimed/running 且 lease_connection_id 绑在这条 ws 上），
+    // 再从**另一条**连接之外的纯 REST 调用 ack——这正是「会话换了、从别的终端补 ack」的场景。
+    const ws = await WsClient.open(slug, target.token);
+    await ws.next();
+    ws.send({ type: "hello", since: 0, directed_delivery: "v1" });
+    ws.send({ type: "serve_lease", op: "claim" });
+    for (let i = 0; i < 40; i += 1) {
+      const frame = await ws.next();
+      if (frame.type === "delivery" && frame.delivery.id === deliveryId) break;
+    }
+    const leased = await deliveryRow(slug);
+    expect(leased?.state === "claimed" || leased?.state === "running").toBe(true);
+
+    const res = await api(`/api/channels/${slug}/deliveries/${deliveryId}/ack`, target.token, { method: "POST" });
+    ws.close();
+    expect(res.status).toBe(200);
+    const row = await deliveryRow(slug);
+    expect(row?.state).toBe("replied");
+    expect(row?.terminal_reason).toBe("acknowledged_no_reply");
+  });
+
+  it("按 @ 消息的 seq 也能 ack（调用方手上通常只有 pending_mention_seqs）", async () => {
+    const { slug, target, posted } = await setup();
+    const res = await api(`/api/channels/${slug}/deliveries/${posted.seq}/ack`, target.token, { method: "POST" });
+    expect(res.status).toBe(200);
+    expect((await deliveryRow(slug))?.terminal_reason).toBe("acknowledged_no_reply");
+  });
+
+  it("幂等：重复 ack 返回既有终态，不改写审计列", async () => {
+    const { slug, target, deliveryId } = await setup();
+    expect((await api(`/api/channels/${slug}/deliveries/${deliveryId}/ack`, target.token, { method: "POST" })).status)
+      .toBe(200);
+    const first = await deliveryRow(slug);
+
+    const again = await api(`/api/channels/${slug}/deliveries/${deliveryId}/ack`, target.token, { method: "POST" });
+    expect(again.status).toBe(200);
+    expect(((await again.json()) as { deduped?: boolean }).deduped).toBe(true);
+    expect(await deliveryRow(slug)).toEqual(first);
+  });
+
+  it("已经真回复过的 @ 不能被 ack 覆盖成「已读不回」", async () => {
+    const { slug, sender, target, posted, deliveryId } = await setup();
+    const replied = await api(`/api/channels/${slug}/messages`, target.token, {
+      method: "POST",
+      body: JSON.stringify({ kind: "message", body: "on it", mentions: [sender.name], reply_to: posted.seq }),
+    });
+    expect(replied.status).toBe(200);
+
+    const res = await api(`/api/channels/${slug}/deliveries/${deliveryId}/ack`, target.token, { method: "POST" });
+    expect(res.status).toBe(409);
+    const row = await deliveryRow(slug);
+    expect(row?.state).toBe("replied");
+    expect(row?.terminal_reason).toBeNull();
+    expect(row?.reply_seq).not.toBeNull();
+  });
+
+  it("只读会话不得结清任何人的 @", async () => {
+    const { slug, deliveryId } = await setup();
+    const readonly = await seedToken("readonly", uniq("ro"));
+    const res = await api(`/api/channels/${slug}/deliveries/${deliveryId}/ack`, readonly.token, { method: "POST" });
+    expect(res.status).toBe(403);
+    expect((await deliveryRow(slug))?.state).toBe("queued");
+  });
+});

--- a/worker/test/message-superseded.spec.ts
+++ b/worker/test/message-superseded.spec.ts
@@ -1,0 +1,146 @@
+// #881 迟到投递的定序：worker 可能拿旧前提行动。修法**不是**按 ts 定序（ts 是本地时钟，
+// 同机多 runner / 跨机漂移下比 seq 更不可信，按它排序反而引入新的错序），而是保留 seq 作为
+// 唯一定序依据，另外补 superseded 显式标记让消费者识别「这条已被后续消息取代」。
+//
+// 判定口径刻意保守——只认「同一 sender 用 --reply-to 回到那条、并再次 @ 同一目标、且那条对该
+// 目标的 delivery 仍未结清」。这里连过度标记的反例一起守：两条独立的 @ 绝不能互相标过期。
+import type { MsgFrame } from "@agentparty/shared";
+import { env, runInDurableObject } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import type { ChannelDO } from "../src/do";
+import { WsClient, api, createChannel, seedToken, uniq } from "./helpers";
+
+async function send(
+  slug: string,
+  token: string,
+  body: string,
+  mentions: string[],
+  replyTo: number | null = null,
+) {
+  const res = await api(`/api/channels/${slug}/messages`, token, {
+    method: "POST",
+    body: JSON.stringify({ kind: "message", body, mentions, reply_to: replyTo }),
+  });
+  expect(res.status).toBe(200);
+  return (await res.json()) as { seq: number };
+}
+
+async function frameAt(slug: string, token: string, seq: number): Promise<MsgFrame> {
+  const res = await api(`/api/channels/${slug}/messages?limit=50`, token);
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as { messages: MsgFrame[] };
+  const found = body.messages.find((m) => m.seq === seq);
+  expect(found).toBeDefined();
+  return found!;
+}
+
+async function setup() {
+  const owner = `${uniq("owner")}@example.com`;
+  const sender = await seedToken("agent", uniq("sender"), { owner });
+  const target = await seedToken("agent", uniq("target"), { owner });
+  const slug = await createChannel(sender.token);
+  return { owner, sender, target, slug };
+}
+
+describe("#881 superseded 显式标记", () => {
+  it("同 sender 用 --reply-to 改口、并再次 @ 同一目标 → 前一条标 superseded，by_seq 指向后一条", async () => {
+    const { slug, sender, target } = await setup();
+    const first = await send(slug, sender.token, `@${target.name} 部署到 prod`, [target.name]);
+    const second = await send(slug, sender.token, `@${target.name} 改口：先别部署`, [target.name], first.seq);
+
+    const stale = await frameAt(slug, sender.token, first.seq);
+    expect(stale.superseded).toEqual({ by_seq: second.seq, reason: "reply_correction" });
+    // 定序依据只有 seq：标记指向的一定是**更大的 seq**，与任何 ts 无关。
+    expect(stale.superseded!.by_seq).toBeGreaterThan(stale.seq);
+    // 取代它的那条自己不是过期的。
+    expect((await frameAt(slug, sender.token, second.seq)).superseded).toBeUndefined();
+  });
+
+  it("不过度标记：同 sender 同目标的两条独立 @（无 reply-to）互不标过期", async () => {
+    const { slug, sender, target } = await setup();
+    const first = await send(slug, sender.token, `@${target.name} 做 X`, [target.name]);
+    await send(slug, sender.token, `@${target.name} 再做 Y`, [target.name]);
+
+    // 「做 X」仍然是有效指令。把它降级掉比不标更危险——这正是本切片否掉「同目标后续消息」口径的原因。
+    expect((await frameAt(slug, sender.token, first.seq)).superseded).toBeUndefined();
+  });
+
+  it("不过度标记：别人回复同一条 @ 不构成取代关系（只有原发起者能改口）", async () => {
+    const { slug, owner, sender, target } = await setup();
+    const other = await seedToken("agent", uniq("other"), { owner });
+    const first = await send(slug, sender.token, `@${target.name} 做 X`, [target.name]);
+    await send(slug, other.token, `@${target.name} 我插一句`, [target.name], first.seq);
+
+    expect((await frameAt(slug, sender.token, first.seq)).superseded).toBeUndefined();
+  });
+
+  it("已结清的 @ 不标：它不会再被谁当成最新指令执行", async () => {
+    const { slug, sender, target } = await setup();
+    const first = await send(slug, sender.token, `@${target.name} 做 X`, [target.name]);
+    // 目标已经回复过这条，delivery 进终态。
+    await send(slug, target.token, "done", [sender.name], first.seq);
+    await send(slug, sender.token, `@${target.name} 改口`, [target.name], first.seq);
+
+    expect((await frameAt(slug, sender.token, first.seq)).superseded).toBeUndefined();
+  });
+
+  it("与 replay 正交：补拉的历史帧可以同时带 replay 与 superseded", async () => {
+    const { slug, sender, target } = await setup();
+    const first = await send(slug, sender.token, `@${target.name} 部署到 prod`, [target.name]);
+    const second = await send(slug, sender.token, `@${target.name} 别部署`, [target.name], first.seq);
+
+    // 逐帧读，不用 nextOfType 当屏障——它会静默丢弃途中帧，可能把该出现的帧一起吃掉造成假绿。
+    const ws = await WsClient.open(slug, target.token);
+    await ws.next();
+    ws.send({ type: "hello", since: 0, directed_delivery: "v1" });
+    let replayed: MsgFrame | null = null;
+    for (let i = 0; i < 60 && replayed === null; i += 1) {
+      const frame = await ws.next();
+      if (frame.type === "msg" && frame.seq === first.seq) replayed = frame;
+    }
+    ws.close();
+    expect(replayed).not.toBeNull();
+    expect(replayed!.replay).toBe(true);
+    expect(replayed!.superseded).toEqual({ by_seq: second.seq, reason: "reply_correction" });
+  });
+
+  it("显式 supersede 链优先，reason 报 revision", async () => {
+    const { slug, sender, target } = await setup();
+    const first = await send(slug, sender.token, `@${target.name} 老结论`, [target.name]);
+    const res = await api(`/api/channels/${slug}/messages/${first.seq}/supersede`, sender.token, {
+      method: "POST",
+      body: JSON.stringify({ body: "新结论", mentions: [target.name] }),
+    });
+    expect(res.status).toBe(200);
+    const superseded = await frameAt(slug, sender.token, first.seq);
+    expect(superseded.superseded?.reason).toBe("revision");
+    expect(superseded.superseded?.by_seq).toBe(superseded.superseded_by);
+  });
+
+  it("幂等：再来一条改口不覆盖已有标记（by_seq 仍指第一次取代它的那条）", async () => {
+    const { slug, sender, target } = await setup();
+    const first = await send(slug, sender.token, `@${target.name} 做 X`, [target.name]);
+    const second = await send(slug, sender.token, `@${target.name} 改口一`, [target.name], first.seq);
+    await send(slug, sender.token, `@${target.name} 改口二`, [target.name], first.seq);
+
+    expect((await frameAt(slug, sender.token, first.seq)).superseded).toEqual({
+      by_seq: second.seq,
+      reason: "reply_correction",
+    });
+  });
+
+  it("标记会 bump rev_seq，重连按 since_rev 补拉的客户端能收到这次修订", async () => {
+    const { slug, sender, target } = await setup();
+    const first = await send(slug, sender.token, `@${target.name} 做 X`, [target.name]);
+    const second = await send(slug, sender.token, `@${target.name} 改口`, [target.name], first.seq);
+
+    const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+    const revSeq = await runInDurableObject(stub, async (_instance: ChannelDO, state) => {
+      const row = state.storage.sql.exec("SELECT rev_seq FROM messages WHERE seq = ?", first.seq).toArray()[0];
+      return row?.rev_seq === null || row?.rev_seq === undefined ? null : Number(row.rev_seq);
+    });
+    expect(revSeq).not.toBeNull();
+    expect(revSeq!).toBeGreaterThan(0);
+    expect(second.seq).toBeGreaterThan(first.seq);
+  });
+});


### PR DESCRIPTION
Closes #881
Closes #875

两项都是 #834「让 worker 有可查证的事实来源」这条线上的：#881 是别拿过期消息当最新指令，#875 是别把「已读不回」记成投递失败。都动 `shared/src/protocol.ts` + `worker/`，所以合在一个切片里做。

---

## #881 迟到投递的定序

**没有采用原 issue 建议的「按 ts 定序」。** `ts` 是发送端本地时钟，同机多 runner / 跨机漂移下比 seq 更不可信，按它排序会引入新的错序。定序依据保持不变：**seq 是唯一依据**（频道全局单调）。新增的只是一个「是否已被取代」的显式信号。

### superseded 判定口径（以及为什么这么定）

新增 `MsgFrame.superseded = { by_seq, reason }`，`by_seq` 恒大于本帧 seq。只在**能证明「后一条针对的就是前一条」**时才打：

| reason | 判定 |
|---|---|
| `revision` | 已有的显式 supersede 链（`superseded_by`）——发送者自己声明的替代关系，最强证据 |
| `reply_correction` | 同一 sender 用 `--reply-to` 回到那条消息、**并再次 @ 了同一目标**，且那条对该目标的 delivery 当时**仍未结清**（queued/claimed/running/waiting_owner） |

**刻意不采用「同 sender 同 @ 目标的任意后续消息」。** 「@bob 做 X」「@bob 再做 Y」是两条独立的 @，按那个口径前一条会被标成过期，worker 于是降级掉一条**仍然有效**的指令——那比不标更危险。已结清的 @ 也不标：它不会再被谁当成最新指令执行。标记幂等，显式链优先，不覆盖已有关系。

与 #861 的 `replay` **正交**，可同时为真：replay 说「这是补拉的历史帧」（传输事实），superseded 说「这条正文已过期」（内容事实）。分成两个字段，不合并。

### 消费侧降级
- serve 的 wake context 带 `superseded` + `superseded_notice`（明确写「不要当成最新指令执行，先读 seq N」）；
- `formatMsg` 全文渲染打 `SUPERSEDED by #N (reason) — not the latest instruction` badge；
- `msgHeader` 也带上——扫 header 挑活干的 agent 不能等展开全文才发现（和 `response_source` 同理）。

---

## #875 「已读不回」的真终态

`POST /api/channels/:slug/deliveries/:id/ack` → `state='replied'` + `terminal_reason='acknowledged_no_reply'`、`reply_seq=null`、`last_error=null`。它是**结清**，不是失败，与 `failed` / `unknown_outcome` 明确区分。（`:id` 收 delivery id，也收纯数字的消息 seq——调用方手上通常只有 `who --json` 报的 `pending_mention_seqs`，没有任何接口下发 delivery id。两种形式落到同一条授权路径。）

### 同 principal 放行怎么实现的
`transitionDirectedDeliveryTerminal` 新增 `explicitAckPrincipal` 选项。显式 ack **不传** `expectedLeaseConnectionId`（显式 ack 本就可能发生在原 lease 连接之外：会话换了、从别的终端补 ack），改由这道闸把关：

```ts
if (options.explicitAckPrincipal !== undefined) {
  const principal = 建单时快照的 target_owner（空则 null）;
  if (principal === null || principal !== options.explicitAckPrincipal) return undefined;
}
```

比连接闸更严，不是放宽：principal 必须与建单时的 `target_owner` **完全相等**；无归属的历史行（`target_owner` 为空）一律拒——宁可让那条 @ 走原来的回复/超时路径，也不能凭一个无法归属的 principal 结清别人的 @。REST 入口另有一道 `identityMatchesDeliveryTarget`，两道是独立的纵深防御，各有测试。

### 审计方式
新增 `acknowledged_by` / `acknowledged_at` 两列，随终态一次写入。`PublicDirectedDelivery.acknowledged_no_reply = { by, at }` **无条件下发**（不看 `detailedState`）——ack 若只有 acker 自己看得见，它就成了悄悄吞 @ 的手段。频道里任何连接补拉 `delivery_state` 都能看到是谁、什么时候结清的。已经真回复过的 @ 不能被 ack 覆盖（409）；重复 ack 幂等，不改写审计列。

### CLI
`party ack --seq N --no-reply`：**先结服务端账，再动本地债**（顺序不能反——本地清了而 POST 失败，用户会以为两本账都平了）。`--no-reply` 必须配 `--seq`（服务端账本按条结清，不给批量口子）。不带 `--no-reply` 时行为完全不变，仍是零网络。help 把两本账的关系重写成 TWO LEDGERS，接住 #874 刚修掉的误导。

---

## 协议兼容
新增字段全部可选，旧客户端忽略即可正常工作；旧 worker 不下发时按旧语义处理。`cli/src/client.ts` 的 `isMessageFrame` / `isPublicDirectedDelivery` 已逐字镜像。

**顺带修了 #871 镜像守卫的一个假阴性**：守卫用 `validator.includes("value.<field>")`，而 `value.superseded_by` 的存在让 `superseded` 看起来「已镜像」——实测把 `superseded` 的校验整段删掉，守卫仍然全绿。改成标识符边界匹配。前缀重叠在这份协议里不是个例（supersedes/superseded/superseded_by、edited/edited_at/edited_by、retracted/retracted_at）。

---

## 变异验证

每处修复都整段删除级别地拆掉，确认对应断言真变红；再做等价实现替换确认不误红。

| # | 变异 | 结果 |
|---|---|---|
| 1 | client.ts 删掉 `superseded` 校验 | 🔴 形状测试红（坏帧被放行）；**同时暴露 #871 守卫假阴性——见上，已修，修后同一变异 🔴** |
| 2 | 删掉 `explicitAckPrincipal` 整个 principal 闸 | 🔴 直打闸的测试红（**第一版测试全绿——REST 入口那道检查遮住了它，因此补了一条绕开 REST 直接打闸的用例**） |
| 3 | replied 分支不再带 `terminalReason`（回到 `: null`） | 🔴 5 条红 |
| 4 | UPDATE 里删掉 `acknowledged_by/at` 两列 | 🔴 审计测试红 |
| 5 | 删掉 `acknowledged_no_reply` 的公开投影 | 🔴 频道可见性测试红 |
| 6 | 删掉 `markSupersededByReplyCorrection` 调用 | 🔴 4 条红 |
| 7 | 删掉「已结清就不标」的 `stillOpen` 闸 | 🔴 过度标记测试红 |
| 8 | 删掉「只有原发起者能改口」的 sender 比对 | 🔴 过度标记测试红 |
| 9 | 删掉 `rowToFrame` 的 `superseded` 投影 | 🔴 4 条红 |
| 10 | 删掉 CLI 的 `--no-reply` 服务端调用整段 | 🔴 2 条红 |
| 11 | 删掉 format.ts 的两处可见性 | 🔴 消费侧可见性测试红 |
| E1 | principal 闸改写成等价的逐条 early-return | 🟢 不误红 |
| E2 | `superseded` 投影改写成 `?? null` + 变量形式 | 🟢 不误红 |

避开了本仓踩过的坑：测试里**不用 `WsClient.nextOfType` 当屏障**（它静默丢弃途中帧，会把不该出现的帧一起吃掉造成假绿），补拉与频道可见性两处都逐帧 `ws.next()` 扫；身份覆盖到边界状态（有 delivery 欠账、有 lease 在别的连接上、target_owner 被改写/清空）。

## 测试

| 包 | 结果 |
|---|---|
| worker `vitest run` | 109 files / **838 passed**（新增 `delivery-ack-no-reply.spec.ts` 11 条、`message-superseded.spec.ts` 8 条） |
| cli `bun test` | 127 files / **1830 passed**（新增 `ack-no-reply-and-superseded.test.ts` 7 条） |
| `tsc --noEmit` | shared / worker / cli / web 全绿 |
