### PR TITLE
fix(cli): 同一身份多执行体并发时强制单活跃任务租约 (#834 第 3 项)

### DIFF
--- a/cli/src/commands/mcp.ts
+++ b/cli/src/commands/mcp.ts
@@ -48,6 +48,14 @@ import { AUTHZ_PROSE_WARNING, checkAuthz, isValidAuthzAction } from "../authz";
 import { askDecision } from "./decision";
 import { uploadAttachmentPaths } from "./send";
 import { buildContext } from "./status";
+import {
+  acquireTaskLease,
+  describeDeniedLease,
+  processScopedExecutorId,
+  releaseTaskLease,
+  taskLeaseDir,
+  taskLeaseKey,
+} from "../task-lease";
 import { EXIT_ALREADY_WATCHING, runWatch } from "./watch";
 
 const HELP = `usage: party mcp
@@ -662,6 +670,32 @@ export function createMcpServer(defaultChannel?: string): McpServer {
         const normalizedMentions = normalizeMentions(mentions);
         const taskScope = task_id === undefined ? [] : [`task:${task_id}`];
         const effectiveScope = [...(scope ?? []), ...taskScope];
+        // #834 第 3 项：MCP 是 harness 会话那条腿的认领入口。这里不落同一把闸,enforcement 就只
+        // 盖住了 CLI 那半——事故里两条腿恰好一条是 serve runner、一条是 harness。
+        const leaseKeyValue = task_id === undefined
+          ? null
+          : taskLeaseKey(authInfo.server, authInfo.token, resolved, task_id);
+        const executorId = processScopedExecutorId();
+        if (leaseKeyValue !== null && task_id !== undefined && (state === "working" || state === "waiting")) {
+          const lease = acquireTaskLease({
+            key: leaseKeyValue,
+            channel: resolved,
+            taskId: task_id,
+            executorId,
+            dir: taskLeaseDir(),
+          });
+          if (lease.state === "denied" && lease.holder !== undefined) {
+            // 拒绝 ≠ 吞任务:这里 return 之前没有发过任何帧,服务端 task 状态原封不动。
+            return fail(describeDeniedLease(lease.holder, resolved, task_id, Date.now()), {
+              type: "task_lease_held",
+              published: false,
+              task_untouched: true,
+              channel: resolved,
+              task_id,
+              holder: lease.holder,
+            });
+          }
+        }
         const { seq } = await postMessage(authInfo.server, authInfo.token, resolved, {
           kind: "status",
           state: state as StatusState,
@@ -676,6 +710,10 @@ export function createMcpServer(defaultChannel?: string): McpServer {
           // #737:worker 报自己那端 blocked 不再拉黑父任务全局 state(见 taskStateFromReportedStatus)。
           const taskState = taskStateFromReportedStatus(state);
           if (taskState !== null) task = await updateTask(authInfo.server, authInfo.token, resolved, task_id, { state: taskState });
+        }
+        // 帧已发出后再交还,别在「已放手、状态还没落地」之间留一个谁都不持有的窗口。
+        if (leaseKeyValue !== null && (state === "done" || state === "blocked")) {
+          releaseTaskLease(leaseKeyValue, executorId, taskLeaseDir());
         }
         advanceCursorPastOwnMessage(resolved, seq);
         return ok({ type: "status", channel: resolved, seq, state, ...(task !== undefined ? { task } : {}) });

--- a/cli/src/commands/status.ts
+++ b/cli/src/commands/status.ts
@@ -11,7 +11,17 @@ import type {
   WakeKind,
   WorkflowKind,
 } from "@agentparty/shared";
-import { safeBranchContextLabel, safeRepoContextLabel } from "@agentparty/shared";
+import { EXIT_TASK_LEASE_HELD, safeBranchContextLabel, safeRepoContextLabel } from "@agentparty/shared";
+import {
+  acquireTaskLease,
+  describeDeniedLease,
+  DEFAULT_TASK_LEASE_TTL_MS,
+  releaseTaskLease,
+  resolveExecutorId,
+  taskLeaseDir,
+  taskLeaseKey,
+  type TaskLeaseResult,
+} from "../task-lease";
 import { isHelpArg, parseArgs, str, strArray, unknownFlagError, valueFlagError } from "../args";
 import { advanceCursorPastOwnMessage, branchLabel, repoLabel, resolveChannel, workspaceId, workspaceLabel, worktreeLabel } from "../config";
 import { stripTerminalControls } from "../format";
@@ -55,6 +65,10 @@ const STATUS_FLAGS = [
   "workflow-parent-summary-seq",
   "task",
   "debug-auth",
+  "force-lease",
+  "executor-id",
+  "lease-ttl-ms",
+  "json",
 ];
 const HELP = `usage: party status [channel|--channel C] working|waiting|blocked|done [-m note] [--mention name]... [--debug-auth]
 
@@ -97,7 +111,17 @@ Options:
   --workflow-parent-summary-seq N
                    parent summary/status seq this workflow status refines
   --task N         link this status to a channel task and update its task state
-  --debug-auth     print resolved auth/config source to stderr`;
+  --force-lease    take over the task lease from another execution runtime of
+                   this identity (only when you know that runtime is gone)
+  --executor-id id override the execution-runtime identity used for the lease
+  --lease-ttl-ms N task lease duration (default: ${DEFAULT_TASK_LEASE_TTL_MS})
+  --json           print a machine-readable result (includes the lease verdict)
+  --debug-auth     print resolved auth/config source to stderr
+
+Task lease (#834): \`working\`/\`waiting --task N\` claims a single-active-executor
+lease for (identity, channel, task). A second runtime of the same identity is
+refused with exit ${EXIT_TASK_LEASE_HELD} and publishes nothing — the task stays claimable by the
+holder. \`done\`/\`blocked --task N\` releases the lease.`;
 
 export function buildContext(auth: Awaited<ReturnType<typeof resolveAuthDetailed>>): AgentContext {
   const wt = worktreeLabel();
@@ -126,7 +150,7 @@ export async function run(argv: string[]): Promise<number> {
   }
   const { positionals, flags } = parseArgs(argv, {
     aliases: { m: "note" },
-    booleans: ["debug-auth"],
+    booleans: ["debug-auth", "force-lease", "json"],
     repeatable: ["mention", "scope"],
   });
   const auth = await resolveAuthDetailed();
@@ -167,6 +191,8 @@ export async function run(argv: string[]): Promise<number> {
       "workflow-step",
       "workflow-parent-summary-seq",
       "task",
+      "executor-id",
+      "lease-ttl-ms",
     ],
     ["mention", "scope"],
   );
@@ -351,6 +377,63 @@ export async function run(argv: string[]): Promise<number> {
           ...(workflowStep !== undefined ? { step_id: workflowStep } : {}),
           ...(workflowParentSummarySeq !== undefined ? { parent_summary_seq: workflowParentSummarySeq } : {}),
         };
+  // ---- #834 第 3 项：认领时刻的单活跃执行体闸门 ----
+  //
+  // 下手点刻意选在**认领**（`status working --task N`）而不是 wake 路径：wake 时拦截太晚，
+  // 活已经开始了；只有认领这一刻的写入是「我要开始动这件事」的第一个可观测点。
+  const leaseTtl = parsePositiveIntFlag(str(flags["lease-ttl-ms"]), "lease-ttl-ms");
+  if (typeof leaseTtl === "string") {
+    console.error(leaseTtl);
+    return 1;
+  }
+  const executorId = resolveExecutorId(process.env, {
+    ...(str(flags["executor-id"]) === undefined ? {} : { executorId: str(flags["executor-id"])! }),
+    ...(sessionHarness === undefined ? {} : { sessionHarness }),
+    ...(sessionId === undefined ? {} : { sessionId }),
+  });
+  const asJson = flags.json === true;
+  const leaseNow = Date.now();
+  let lease: TaskLeaseResult | null = null;
+  const leaseKeyValue = taskId === undefined ? null : taskLeaseKey(auth.server, auth.token, channel, taskId);
+  // working/waiting = 「这件事归我，我还在上面」→ 取/续租约。
+  // done/blocked = 「我不在上面了」→ 立刻交还，别让一个卡住的执行体把任务扣满一个 TTL。
+  const claims = taskId !== undefined && (state === "working" || state === "waiting");
+  if (claims && leaseKeyValue !== null && taskId !== undefined) {
+    lease = acquireTaskLease({
+      key: leaseKeyValue,
+      channel,
+      taskId,
+      executorId,
+      dir: taskLeaseDir(),
+      now: leaseNow,
+      ...(leaseTtl === undefined ? {} : { ttlMs: leaseTtl }),
+      force: flags["force-lease"] === true,
+    });
+    if (lease.state === "denied" && lease.holder !== undefined) {
+      // 红线：拒绝 ≠ 吞任务。这里**不发帧、不改服务端 task state**，任务原样留在频道里，
+      // 持租约的那个执行体照常干；本执行体降级为只读。
+      if (asJson) {
+        console.log(JSON.stringify({
+          ok: false,
+          published: false,
+          task_untouched: true,
+          exit_code: EXIT_TASK_LEASE_HELD,
+          lease: { state: lease.state, reason: lease.reason, holder: lease.holder },
+        }));
+      }
+      console.error(describeDeniedLease(lease.holder, channel, taskId, leaseNow));
+      return EXIT_TASK_LEASE_HELD;
+    }
+    if (lease.state === "unenforced") {
+      console.error(
+        "warn: task lease not enforced — this process has no stable execution-runtime identity. " +
+          "Set AGENTPARTY_EXECUTOR_ID (or pass --executor-id) so a second runtime of this identity can be refused (#834).",
+      );
+    }
+    if (lease.state === "forced" && lease.holder?.taken_over_from !== undefined) {
+      console.error(`warn: took over the task lease from ${lease.holder.taken_over_from} (--force-lease)`);
+    }
+  }
   try {
     if (flags["debug-auth"] === true || process.env.AGENTPARTY_DEBUG_AUTH === "1") {
       try {
@@ -384,8 +467,25 @@ export async function run(argv: string[]): Promise<number> {
       const taskState = taskStateFromReportedStatus(state);
       if (taskState !== null) await updateTask(auth.server, auth.token, channel, taskId, { state: taskState });
     }
+    // 交还租约必须在**帧已发出之后**：先发帧再放手,任务才不会在「已放手、状态还没落地」之间
+    // 出现一个谁都不持有、状态也没更新的窗口。
+    if (leaseKeyValue !== null && (state === "done" || state === "blocked")) {
+      releaseTaskLease(leaseKeyValue, executorId, taskLeaseDir());
+    }
     advanceCursorPastOwnMessage(channel, seq);
-    console.log(`status seq=${seq}`);
+    if (asJson) {
+      console.log(JSON.stringify({
+        ok: true,
+        published: true,
+        seq,
+        ...(taskId === undefined ? {} : { task: taskId }),
+        ...(lease === null
+          ? {}
+          : { lease: { state: lease.state, ...(lease.reason === undefined ? {} : { reason: lease.reason }), holder: lease.holder } }),
+      }));
+    } else {
+      console.log(`status seq=${seq}`);
+    }
     return 0;
   } catch (e) {
     return handleRestError(e);

--- a/cli/src/commands/who.ts
+++ b/cli/src/commands/who.ts
@@ -148,10 +148,16 @@ interface Row {
   runner_health?: RunnerHealth;
   // runner 自报、worker 持久化的模型会话句柄（#522）；不是 websocket session。
   agent_session?: PresenceEntry["agent_session"];
+  // #834 第 3 项：以前这里只有 kind/with/runtime_count——「同一身份跑着两个执行体」和「隔壁
+  // agent 恰好装在同一台机器上」在 JSON 里长得一模一样,读的人无从判定该不该停手。补两个字段
+  // 让它可**程序化判定**:same_identity 说明这是不是自己的另一个执行体,severity=blocking 就是
+  // 「同一身份多执行体并发」这个真会出事的形态(实测:两个实例互相强杀对方的模拟器)。
   topology_conflicts?: Array<{
     kind: "same_identity_worktree" | "same_worktree" | "same_workspace" | "same_local_installation";
     with: string[];
     runtime_count?: number;
+    same_identity?: boolean;
+    severity?: "blocking" | "advisory";
   }>;
   // #817：无人值守时这个身份怎么接待 @——model runner 代答，还是 custom 命令。隔离接待意味着
   // 答话的会话不继承本人当前上下文，协作方在 @ 之前就该看见这一点。
@@ -518,13 +524,18 @@ export function annotateTopologyConflicts(
   return rows.map((row) => {
     const peer = byAgent.get(row.name);
     if (peer === undefined) return row;
-    const conflicts: NonNullable<Row["topology_conflicts"]> = peer.relations.map((item) => ({
-      kind: peer.same_identity && item.relation === "same_worktree"
-        ? "same_identity_worktree"
-        : item.relation,
-      with: peer.same_identity ? [] : [discovery.self],
-      runtime_count: item.runtime_count,
-    }));
+    const conflicts: NonNullable<Row["topology_conflicts"]> = peer.relations.map((item) => {
+      // 同一身份 + 不止一个活着的 runtime = 单活跃执行体被破坏(#834)。runtime_count 缺省算 1,
+      // 但 same_identity 的关系本身就意味着「除了我还有一个」——所以只要 same_identity 就够严重。
+      const sameIdentity = peer.same_identity === true;
+      return {
+        kind: sameIdentity && item.relation === "same_worktree" ? "same_identity_worktree" : item.relation,
+        with: sameIdentity ? [] : [discovery.self],
+        runtime_count: item.runtime_count,
+        same_identity: sameIdentity,
+        severity: sameIdentity ? ("blocking" as const) : ("advisory" as const),
+      };
+    });
     return conflicts.length === 0 ? row : { ...row, topology_conflicts: conflicts };
   });
 }
@@ -533,8 +544,12 @@ export function topologyNote(r: Row): string {
   const conflicts = r.topology_conflicts ?? [];
   if (conflicts.length === 0) return "";
   return conflicts.map((conflict) => {
-    if (conflict.kind === "same_identity_worktree") {
-      return ` · ⚠ ${conflict.runtime_count ?? 1} other live runtime(s) of this identity share one worktree`;
+    // #834:同身份的另一个执行体。人读那行必须说清「会出事」,否则又只是打印一条中性事实——
+    // 事故当天 `party who` 打的正是一条中性的 same_local_installation。
+    if (conflict.severity === "blocking") {
+      const where = conflict.kind === "same_identity_worktree" ? " share one worktree" : ` (${conflict.kind})`;
+      return ` · ⚠ ${conflict.runtime_count ?? 1} other live runtime(s) of this identity${where}` +
+        " — concurrent claims on one task are refused";
     }
     const label = conflict.kind === "same_worktree"
       ? "⚠ same worktree as"

--- a/cli/src/task-lease.ts
+++ b/cli/src/task-lease.ts
@@ -1,0 +1,248 @@
+// 同一身份多执行体的任务租约（#834 第 3 项）。
+//
+// 事故实录：同一个 `king-claude` 身份同时跑着两个执行体——一个交互式 harness 会话，一个由
+// `party serve` 拉起的 reception runner。两个都在认领同一件事、都在动同一台模拟器，互相强杀
+// 对方的进程；其中一个基于假前提派出了消耗真实资产的 worker，另一个据此做了验收。`party who`
+// 当时只打印 `topology_conflicts: [{kind: same_local_installation, runtime_count: 1}]`，**零 enforcement**。
+//
+// instance-lock 那把锁按 (身份, 频道) 互斥，管的是「同一个频道别被 serve/watch 服务两次」。
+// 它挡不住这一类：两个**不同来源**的执行体（一个是 serve runner，一个是人在 harness 里手敲）
+// 各自去认领**同一个 task**。粒度不同，锁也就不同：这里按 (身份, 频道, task) 发租约。
+//
+// 为什么不能复用 pid 锁：`party status working --task N` 是一次性进程，认领完立刻退出。
+// pid 存活探测在这里毫无意义（写完就死）。所以租约靠两样东西成立：
+//   1. **执行体身份**（executor id）——跨多次 `party status` 调用稳定，且两个执行体必须不同；
+//   2. **TTL**——执行体崩了/被 kill 了，租约必须能自然过期被接手，绝不能把 task 永久锁死。
+//
+// 红线：被拒的那个执行体**不许把任务吞掉**。拒绝路径不碰服务端 task 状态、不发 working 帧，
+// 任务原样留在频道里，正确的执行体照常认领。拒绝 ≠ 任务消失。
+import { createHash } from "node:crypto";
+import { mkdirSync, readFileSync, readdirSync, unlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { agentpartyHome } from "./config";
+
+/** 默认租期。与 serve 的 DEFAULT_RUNNER_TIMEOUT_MS（30min）对齐：一个 runner 最多能占这么久。 */
+export const DEFAULT_TASK_LEASE_TTL_MS = 30 * 60_000;
+
+const EXECUTOR_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._:@-]{0,127}$/;
+
+export interface TaskLeaseHolder {
+  executor_id: string;
+  channel: string;
+  task_id: number;
+  acquired_at: number;
+  renewed_at: number;
+  expires_at: number;
+  /** 由 --force-lease 抢占时，记下被抢的那个执行体，便于事后对账。 */
+  taken_over_from?: string;
+}
+
+export type TaskLeaseState =
+  /** 首次拿到（含接手已过期的租约）。 */
+  | "acquired"
+  /** 本执行体自己的租约续期。 */
+  | "renewed"
+  /** 另一个执行体持有且未过期——拒绝，降级为只读。 */
+  | "denied"
+  /** --force-lease 显式抢占。 */
+  | "forced"
+  /** 无法识别本执行体身份，不做判定（既不放行也不冒充放行结论）。 */
+  | "unenforced";
+
+export interface TaskLeaseResult {
+  state: TaskLeaseState;
+  /** denied 时是对方的租约；acquired/renewed/forced 时是本执行体自己的租约。 */
+  holder?: TaskLeaseHolder;
+  /** 被抢占/被接手/无法判定的原因，供 --json 与人读输出复用。 */
+  reason?: "no_executor_identity" | "expired" | "taken_over" | "held_by_other";
+}
+
+export function taskLeaseDir(home: string = agentpartyHome()): string {
+  return join(home, "task-leases");
+}
+
+/** token 只参与不可逆摘要，不落盘；不同 server/身份互不阻塞。 */
+export function taskLeaseKey(server: string, token: string, channel: string, taskId: number): string {
+  const identity = createHash("sha256").update(server).update("\0").update(token).digest("hex").slice(0, 24);
+  return `${identity}-${channel.replace(/[^a-z0-9-]/g, "_")}-task-${taskId}`;
+}
+
+function leasePath(dir: string, key: string): string {
+  return join(dir, `${key}.json`);
+}
+
+function readLease(path: string): TaskLeaseHolder | null {
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as Partial<TaskLeaseHolder>;
+    if (typeof parsed.executor_id !== "string" || !EXECUTOR_ID_RE.test(parsed.executor_id)) return null;
+    if (typeof parsed.expires_at !== "number" || !Number.isFinite(parsed.expires_at)) return null;
+    if (typeof parsed.task_id !== "number" || !Number.isFinite(parsed.task_id)) return null;
+    return parsed as TaskLeaseHolder;
+  } catch {
+    return null;
+  }
+}
+
+export interface ResolveExecutorEnv {
+  [key: string]: string | undefined;
+}
+
+/**
+ * 解析「当前执行体」的稳定身份。
+ *
+ * 顺序刻意从最显式排到最隐式。**最后没有兜底**：识别不出来就返回 null，调用方按 unenforced
+ * 处理。宁可明说「这一刀没落下」，也不要靠一个不稳定的推断（比如 ppid——Claude Code 每次
+ * Bash 调用的父进程都不同，会让同一个 harness 会话把自己上一次的租约当成别人的而自锁）去
+ * 制造一个看着像 enforcement 的假象。
+ */
+export function resolveExecutorId(
+  env: ResolveExecutorEnv = process.env,
+  explicit?: { executorId?: string; sessionHarness?: string; sessionId?: string },
+): string | null {
+  const candidates: (string | undefined)[] = [
+    explicit?.executorId,
+    env.AGENTPARTY_EXECUTOR_ID,
+    // serve 内建 runner 已经在给子进程注入这两个（见 serve.ts 的 AP_RUNNER_* 块）。
+    // session id 每次 resume 会换，workdir 不换——所以 workdir 才是「哪个 runner」的稳定标识。
+    env.AP_RUNNER_WORKDIR === undefined || env.AP_RUNNER_WORKDIR === ""
+      ? undefined
+      : `runner:${env.AP_RUNNER_HARNESS ?? "unknown"}:${createHash("sha256").update(env.AP_RUNNER_WORKDIR).digest("hex").slice(0, 16)}`,
+    explicit?.sessionId === undefined || explicit.sessionHarness === undefined
+      ? undefined
+      : `session:${explicit.sessionHarness}:${explicit.sessionId}`,
+    env.CLAUDE_SESSION_ID === undefined || env.CLAUDE_SESSION_ID === "" ? undefined : `session:claude:${env.CLAUDE_SESSION_ID}`,
+    env.CODEX_THREAD_ID === undefined || env.CODEX_THREAD_ID === "" ? undefined : `session:codex:${env.CODEX_THREAD_ID}`,
+  ];
+  for (const candidate of candidates) {
+    if (candidate === undefined || candidate === "") continue;
+    const trimmed = candidate.slice(0, 128);
+    if (EXECUTOR_ID_RE.test(trimmed)) return trimmed;
+  }
+  return null;
+}
+
+/**
+ * 长驻进程（MCP server、daemon）自己的执行体身份。
+ *
+ * 一次性 CLI 不能用 pid 当身份（写完就死，下一次调用就成了「另一个执行体」而自锁）；但一个
+ * 跟着 harness 会话活一整场的 MCP server 进程，pid 恰恰就是最诚实的「这个会话的执行体」标识。
+ * 仍然优先让环境里的显式声明覆盖它。
+ */
+export function processScopedExecutorId(env: ResolveExecutorEnv = process.env, pid: number = process.pid): string {
+  return resolveExecutorId(env) ?? `mcp:${pid}`;
+}
+
+export interface AcquireTaskLeaseOptions {
+  key: string;
+  channel: string;
+  taskId: number;
+  executorId: string | null;
+  dir?: string;
+  ttlMs?: number;
+  now?: number;
+  force?: boolean;
+}
+
+/**
+ * 认领时刻的那一刀。返回 denied 时调用方必须**什么都不发**——不发 working 帧、不改服务端
+ * task state，让任务原样留着。
+ */
+export function acquireTaskLease(options: AcquireTaskLeaseOptions): TaskLeaseResult {
+  const { key, channel, taskId, executorId, force = false } = options;
+  if (executorId === null) return { state: "unenforced", reason: "no_executor_identity" };
+  const dir = options.dir ?? taskLeaseDir();
+  const now = options.now ?? Date.now();
+  const ttlMs = options.ttlMs ?? DEFAULT_TASK_LEASE_TTL_MS;
+  const path = leasePath(dir, key);
+  const existing = readLease(path);
+  const mine = existing !== null && existing.executor_id === executorId;
+  const live = existing !== null && existing.expires_at > now;
+
+  if (existing !== null && live && !mine && !force) {
+    return { state: "denied", holder: existing, reason: "held_by_other" };
+  }
+
+  const state: TaskLeaseState = mine ? "renewed" : existing !== null && live ? "forced" : "acquired";
+  const reason: TaskLeaseResult["reason"] | undefined = state === "forced"
+    ? "taken_over"
+    : state === "acquired" && existing !== null
+      ? "expired"
+      : undefined;
+  const holder: TaskLeaseHolder = {
+    executor_id: executorId,
+    channel,
+    task_id: taskId,
+    acquired_at: mine ? existing.acquired_at : now,
+    renewed_at: now,
+    expires_at: now + ttlMs,
+    ...(state === "forced" && existing !== null ? { taken_over_from: existing.executor_id } : {}),
+  };
+  try {
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+    writeFileSync(path, JSON.stringify(holder), { mode: 0o600 });
+  } catch {
+    // 落盘失败只损失 enforcement 能力，绝不该让一次正常认领失败。
+    return { state: "unenforced", reason: "no_executor_identity" };
+  }
+  return { state, holder, ...(reason === undefined ? {} : { reason }) };
+}
+
+/**
+ * 交还租约。只删自己的那张——别人已经接手（过期后被合法接管）时绝不动它，否则一个迟到的
+ * `status done` 会把新执行体的租约抹掉。
+ */
+export function releaseTaskLease(key: string, executorId: string | null, dir: string = taskLeaseDir()): boolean {
+  if (executorId === null) return false;
+  const path = leasePath(dir, key);
+  const existing = readLease(path);
+  if (existing === null || existing.executor_id !== executorId) return false;
+  try {
+    unlinkSync(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** 只读查询，供 `--json` 与诊断使用。过期的租约按「没有」返回。 */
+export function readTaskLease(key: string, dir: string = taskLeaseDir(), now: number = Date.now()): TaskLeaseHolder | null {
+  const existing = readLease(leasePath(dir, key));
+  return existing === null || existing.expires_at <= now ? null : existing;
+}
+
+/** 顺手清掉早已过期的租约文件，避免目录无限增长。失败无所谓——过期租约本来就不挡人。 */
+export function pruneExpiredTaskLeases(dir: string = taskLeaseDir(), now: number = Date.now()): number {
+  let removed = 0;
+  let entries: string[] = [];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return 0;
+  }
+  for (const entry of entries) {
+    if (!entry.endsWith(".json")) continue;
+    const path = join(dir, entry);
+    const holder = readLease(path);
+    if (holder !== null && holder.expires_at > now) continue;
+    try {
+      unlinkSync(path);
+      removed += 1;
+    } catch {
+      /* 另一个进程已经清掉了。 */
+    }
+  }
+  return removed;
+}
+
+/** 人读的拒绝说明。刻意把「任务没丢」和「怎么合法接手」写在同一句里。 */
+export function describeDeniedLease(holder: TaskLeaseHolder, channel: string, taskId: number, now: number): string {
+  const remainingS = Math.max(0, Math.ceil((holder.expires_at - now) / 1000));
+  return [
+    `refused: task ${taskId} on #${channel} is already held by another execution runtime of this identity`,
+    `  holder=${holder.executor_id} expires_in=${remainingS}s`,
+    "  this claim was NOT published: the task is untouched and the current holder keeps working on it.",
+    "  read-only is still available (party task list / party history); do not start side-effecting work.",
+    "  if you are certain the holder is gone, take over explicitly: party status working --task " +
+      `${taskId} --force-lease`,
+  ].join("\n");
+}

--- a/cli/test/mcp-task-lease.test.ts
+++ b/cli/test/mcp-task-lease.test.ts
@@ -1,0 +1,120 @@
+// #834 第 3 项：事故里的两条腿一条是 `party serve` 拉起的 reception runner、一条是 harness 会话,
+// 而 harness 那条腿是走 MCP 认领的。只在 CLI 那半落闸 = enforcement 只盖住一半,两个实例照样并发。
+//
+// 这里用两个各自独立的 MCP server 进程（共享同一个 AGENTPARTY_HOME = 同一身份）复现那个形状。
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const indexPath = join(import.meta.dir, "..", "src", "index.ts");
+
+describe("party_status 的任务租约（MCP 腿）", () => {
+  let home: string;
+  let restServer: ReturnType<typeof Bun.serve> | null = null;
+  let posted: { path: string; method: string }[] = [];
+  const clients: Client[] = [];
+
+  function startRest(): void {
+    restServer = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      async fetch(req) {
+        const url = new URL(req.url);
+        if (url.pathname === "/api/me") {
+          return Response.json({ name: "king-claude", email: null, kind: "agent", role: "member", owner: null });
+        }
+        if (url.pathname.endsWith("/messages") && req.method === "POST") {
+          posted.push({ path: url.pathname, method: req.method });
+          return Response.json({ seq: 11 });
+        }
+        if (/\/tasks\/\d+$/.test(url.pathname) && req.method === "PATCH") {
+          posted.push({ path: url.pathname, method: req.method });
+          return Response.json({ id: 9, title: "t", state: "in_progress" });
+        }
+        return Response.json({ error: { code: "not_found", message: "not found" } }, { status: 404 });
+      },
+    });
+    mkdirSync(home, { recursive: true });
+    writeFileSync(
+      join(home, "config.json"),
+      JSON.stringify({ server: `http://127.0.0.1:${restServer.port}`, token: "ap_tok" }),
+    );
+  }
+
+  async function connect(executorId: string): Promise<Client> {
+    const env: Record<string, string> = {};
+    for (const [k, v] of Object.entries(process.env)) {
+      if (v !== undefined && k !== "AGENTPARTY_CONFIG") env[k] = v;
+    }
+    env.AGENTPARTY_HOME = home;
+    env.AGENTPARTY_EXECUTOR_ID = executorId;
+    const transport = new StdioClientTransport({
+      command: "bun",
+      args: ["run", indexPath, "mcp", "--channel", "king"],
+      env,
+      stderr: "pipe",
+    });
+    const client = new Client({ name: "agentparty-test", version: "1.0.0" });
+    await client.connect(transport);
+    clients.push(client);
+    return client;
+  }
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "ap-mcp-lease-"));
+    posted = [];
+    startRest();
+  });
+
+  afterEach(async () => {
+    for (const client of clients.splice(0)) await client.close().catch(() => {});
+    rmSync(home, { recursive: true, force: true });
+    restServer?.stop(true);
+    restServer = null;
+  });
+
+  test("第二个执行体经 MCP 认领同一个 task 被拒，且一条帧都没发", async () => {
+    const first = await connect("runner:claude:reception");
+    const granted = await first.callTool({
+      name: "party_status",
+      arguments: { state: "working", task_id: 9, note: "on it" },
+    });
+    expect(granted.isError).toBeFalsy();
+    const afterFirst = posted.length;
+    expect(afterFirst).toBeGreaterThan(0);
+
+    const second = await connect("session:claude:harness");
+    const denied = await second.callTool({
+      name: "party_status",
+      arguments: { state: "working", task_id: 9, note: "also on it" },
+    });
+    expect(denied.isError).toBe(true);
+    const text = (denied.content as { text: string }[])[0]!.text;
+    expect(text).toMatch(/refused/);
+    expect(text).toMatch(/task is untouched/);
+    expect(text).toMatch(/runner:claude:reception/);
+    // 红线:被拒 ≠ 吞任务。没有新的 POST messages、没有新的 PATCH task。
+    expect(posted.length).toBe(afterFirst);
+    expect((denied.structuredContent as { task_untouched?: boolean }).task_untouched).toBe(true);
+  }, 30_000);
+
+  test("不同 task 不受影响", async () => {
+    const first = await connect("runner:claude:reception");
+    await first.callTool({ name: "party_status", arguments: { state: "working", task_id: 9 } });
+    const second = await connect("session:claude:harness");
+    const other = await second.callTool({ name: "party_status", arguments: { state: "working", task_id: 10 } });
+    expect(other.isError).toBeFalsy();
+  }, 30_000);
+
+  test("持有者报 done 后交还租约，另一个执行体可以正常接手", async () => {
+    const first = await connect("runner:claude:reception");
+    await first.callTool({ name: "party_status", arguments: { state: "working", task_id: 9 } });
+    await first.callTool({ name: "party_status", arguments: { state: "done", task_id: 9 } });
+    const second = await connect("session:claude:harness");
+    const taken = await second.callTool({ name: "party_status", arguments: { state: "working", task_id: 9 } });
+    expect(taken.isError).toBeFalsy();
+  }, 30_000);
+});

--- a/cli/test/oidc-mock.ts
+++ b/cli/test/oidc-mock.ts
@@ -252,6 +252,11 @@ export function startOidcMock(opts: MockOptions = {}): OidcMock {
       if (req.method === "POST" && /^\/api\/channels\/[^/]+\/messages$/.test(u.pathname)) {
         return Response.json({ seq: 7 });
       }
+      if (req.method === "PATCH" && /^\/api\/channels\/[^/]+\/tasks\/\d+$/.test(u.pathname)) {
+        const id = Number(u.pathname.split("/").pop());
+        const b = rec.body as { state?: string } | null;
+        return Response.json({ id, title: "t", state: b?.state ?? "in_progress" });
+      }
       return Response.json({ error: { code: "not_found", message: "not found" } }, { status: 404 });
     },
   });

--- a/cli/test/status-task-lease.test.ts
+++ b/cli/test/status-task-lease.test.ts
@@ -1,0 +1,160 @@
+// #834 第 3 项：`party status working --task N` 是认领时刻,也是唯一该落刀的地方。
+// wake 路径上拦截太晚——活已经开始了。
+//
+// 这一层测的是**端到端后果**,不是租约模块的内部返回值:被拒的那次必须一个字节都没发出去
+// (没有 POST messages、没有 PATCH task),否则「拒绝第二个 runner」就变成了「把任务吞掉」。
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { EXIT_TASK_LEASE_HELD } from "@agentparty/shared";
+import { writeConfig, writeState } from "../src/config";
+import { run as statusRun } from "../src/commands/status";
+import { startOidcMock, type OidcMock } from "./oidc-mock";
+
+let home: string;
+let mock: OidcMock | null = null;
+let logs: string[];
+let errs: string[];
+const origLog = console.log;
+const origErr = console.error;
+const SAVED_ENV = { ...process.env };
+
+function setExecutor(id: string) {
+  process.env.AGENTPARTY_EXECUTOR_ID = id;
+}
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "ap-status-lease-"));
+  process.env.AGENTPARTY_HOME = home;
+  logs = [];
+  errs = [];
+  console.log = (...a: unknown[]) => logs.push(a.map(String).join(" "));
+  console.error = (...a: unknown[]) => errs.push(a.map(String).join(" "));
+  mock = startOidcMock();
+  writeConfig({ server: mock.url, token: "ap_runtime" });
+  writeState({ channel: "king", cursor: 0 });
+});
+
+afterEach(() => {
+  console.log = origLog;
+  console.error = origErr;
+  for (const key of Object.keys(process.env)) if (!(key in SAVED_ENV)) delete process.env[key];
+  Object.assign(process.env, SAVED_ENV);
+  delete process.env.AGENTPARTY_HOME;
+  rmSync(home, { recursive: true, force: true });
+  mock?.stop();
+  mock = null;
+});
+
+function posts(): number {
+  return mock!.requests.filter((r) => r.method === "POST" && r.path === "/api/channels/king/messages").length;
+}
+function taskPatches(): number {
+  return mock!.requests.filter((r) => r.method === "PATCH" && r.path.startsWith("/api/channels/king/tasks/")).length;
+}
+
+test("同一 (identity, task) 的第二个执行体认领被拒，且什么都没发出去", async () => {
+  setExecutor("runner:claude:reception");
+  expect(await statusRun(["working", "--task", "9", "-m", "on it"])).toBe(0);
+  expect(posts()).toBe(1);
+  expect(taskPatches()).toBe(1);
+
+  setExecutor("session:claude:harness");
+  const code = await statusRun(["working", "--task", "9", "-m", "also on it"]);
+  expect(code).toBe(EXIT_TASK_LEASE_HELD);
+  // 被拒的那次:一条帧都没发,task state 也没被改写——任务原样留给持租约的那个执行体。
+  expect(posts()).toBe(1);
+  expect(taskPatches()).toBe(1);
+  expect(errs.join("\n")).toMatch(/refused/);
+  expect(errs.join("\n")).toMatch(/task is untouched/);
+});
+
+test("被拒后任务仍可被正确的执行体接手（不丢）", async () => {
+  setExecutor("runner:claude:reception");
+  await statusRun(["working", "--task", "9"]);
+  setExecutor("session:claude:harness");
+  await statusRun(["working", "--task", "9"]);
+  // 原持有者回来继续推进:照常发帧、照常更新 task。
+  setExecutor("runner:claude:reception");
+  expect(await statusRun(["working", "--task", "9", "-m", "still mine"])).toBe(0);
+  expect(posts()).toBe(2);
+  expect(await statusRun(["done", "--task", "9"])).toBe(0);
+  // 交还后,原本被拒的那个执行体现在可以合法接手。
+  setExecutor("session:claude:harness");
+  expect(await statusRun(["working", "--task", "9"])).toBe(0);
+  expect(posts()).toBe(4);
+});
+
+test("不同 task 不受影响", async () => {
+  setExecutor("runner:claude:reception");
+  await statusRun(["working", "--task", "9"]);
+  setExecutor("session:claude:harness");
+  expect(await statusRun(["working", "--task", "10"])).toBe(0);
+  expect(posts()).toBe(2);
+});
+
+test("不带 --task 的 status 完全不参与租约", async () => {
+  setExecutor("runner:claude:reception");
+  expect(await statusRun(["working", "-m", "no task"])).toBe(0);
+  setExecutor("session:claude:harness");
+  expect(await statusRun(["working", "-m", "no task either"])).toBe(0);
+  expect(posts()).toBe(2);
+});
+
+test("--json 让 agent 程序化读到租约结论", async () => {
+  setExecutor("runner:claude:reception");
+  await statusRun(["working", "--task", "9", "--json"]);
+  const granted = JSON.parse(logs.at(-1)!);
+  expect(granted.ok).toBe(true);
+  expect(granted.lease.state).toBe("acquired");
+
+  logs.length = 0;
+  setExecutor("session:claude:harness");
+  const code = await statusRun(["working", "--task", "9", "--json"]);
+  expect(code).toBe(EXIT_TASK_LEASE_HELD);
+  const denied = JSON.parse(logs.at(-1)!);
+  expect(denied).toMatchObject({
+    ok: false,
+    published: false,
+    task_untouched: true,
+    exit_code: EXIT_TASK_LEASE_HELD,
+    lease: { state: "denied", reason: "held_by_other", holder: { executor_id: "runner:claude:reception" } },
+  });
+});
+
+test("--force-lease 显式抢占：owner 判定对方已死时的逃生口", async () => {
+  setExecutor("runner:claude:reception");
+  await statusRun(["working", "--task", "9"]);
+  setExecutor("session:claude:harness");
+  expect(await statusRun(["working", "--task", "9", "--force-lease"])).toBe(0);
+  expect(errs.join("\n")).toMatch(/took over the task lease from runner:claude:reception/);
+  expect(posts()).toBe(2);
+});
+
+test("blocked --task 交还租约：卡住的执行体不许把任务扣满整个 TTL", async () => {
+  setExecutor("runner:claude:reception");
+  await statusRun(["working", "--task", "9"]);
+  expect(await statusRun(["blocked", "--task", "9", "-m", "stuck"])).toBe(0);
+  setExecutor("session:claude:harness");
+  expect(await statusRun(["working", "--task", "9"])).toBe(0);
+});
+
+test("--lease-ttl-ms 到期后另一个执行体可以接手，任务不会被永久锁死", async () => {
+  setExecutor("runner:claude:reception");
+  expect(await statusRun(["working", "--task", "9", "--lease-ttl-ms", "1"])).toBe(0);
+  await Bun.sleep(5);
+  setExecutor("session:claude:harness");
+  expect(await statusRun(["working", "--task", "9"])).toBe(0);
+  expect(posts()).toBe(2);
+});
+
+test("无法识别执行体身份时明说没落刀，而不是假装拦住了", async () => {
+  delete process.env.AGENTPARTY_EXECUTOR_ID;
+  delete process.env.AP_RUNNER_WORKDIR;
+  delete process.env.CLAUDE_SESSION_ID;
+  delete process.env.CODEX_THREAD_ID;
+  expect(await statusRun(["working", "--task", "9"])).toBe(0);
+  expect(errs.join("\n")).toMatch(/task lease not enforced/);
+  expect(errs.join("\n")).toMatch(/AGENTPARTY_EXECUTOR_ID/);
+});

--- a/cli/test/task-lease.test.ts
+++ b/cli/test/task-lease.test.ts
@@ -1,0 +1,185 @@
+// #834 第 3 项：同一身份多 runner 并发,零 enforcement。
+//
+// 实测事故:一个 `king-claude` 身份同时跑着 harness 会话与 `party serve` 拉起的 reception
+// runner,两个都在认领同一件事、互相强杀对方的模拟器;其中一个基于假前提派出了消耗真实资产的
+// worker。当时 `party who` 只打印 topology_conflicts,没有任何一刀落下来。
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  acquireTaskLease,
+  describeDeniedLease,
+  processScopedExecutorId,
+  pruneExpiredTaskLeases,
+  readTaskLease,
+  releaseTaskLease,
+  resolveExecutorId,
+  taskLeaseKey,
+} from "../src/task-lease";
+
+const NOW = 1_786_000_000_000;
+const TTL = 60_000;
+
+function dir(): string {
+  return mkdtempSync(join(tmpdir(), "ap-task-lease-"));
+}
+
+function claim(d: string, executorId: string | null, taskId = 7, now = NOW, force = false) {
+  return acquireTaskLease({
+    key: taskLeaseKey("https://s", "tok", "king", taskId),
+    channel: "king",
+    taskId,
+    executorId,
+    dir: d,
+    ttlMs: TTL,
+    now,
+    force,
+  });
+}
+
+describe("单活跃执行体：同一 (identity, task) 只有一个执行体能认领", () => {
+  test("第二个执行体认领同一个 task 被拒", () => {
+    const d = dir();
+    expect(claim(d, "runner:claude:aaa").state).toBe("acquired");
+    const second = claim(d, "session:claude:harness-1");
+    expect(second.state).toBe("denied");
+    expect(second.reason).toBe("held_by_other");
+    expect(second.holder?.executor_id).toBe("runner:claude:aaa");
+  });
+
+  test("被拒后任务不丢：租约仍属原持有者，原执行体可以继续续租", () => {
+    const d = dir();
+    claim(d, "runner:claude:aaa");
+    claim(d, "session:claude:harness-1"); // 被拒
+    // 被拒的那次不许改写租约文件——否则原持有者续租时会看到别人的 id 而被自己的 task 拒之门外。
+    const renewed = claim(d, "runner:claude:aaa", 7, NOW + 1_000);
+    expect(renewed.state).toBe("renewed");
+    expect(renewed.holder?.acquired_at).toBe(NOW);
+    expect(readTaskLease(taskLeaseKey("https://s", "tok", "king", 7), d, NOW + 1_000)?.executor_id)
+      .toBe("runner:claude:aaa");
+  });
+
+  test("同一执行体重复认领是续租而不是自锁", () => {
+    const d = dir();
+    claim(d, "runner:claude:aaa");
+    const again = claim(d, "runner:claude:aaa", 7, NOW + 5_000);
+    expect(again.state).toBe("renewed");
+    expect(again.holder?.expires_at).toBe(NOW + 5_000 + TTL);
+  });
+
+  test("不同 task 互不影响", () => {
+    const d = dir();
+    expect(claim(d, "runner:claude:aaa", 7).state).toBe("acquired");
+    expect(claim(d, "session:claude:harness-1", 8).state).toBe("acquired");
+  });
+
+  test("不同身份（server+token）在同一 task 号上不互斥", () => {
+    expect(taskLeaseKey("https://s", "tok-a", "king", 7)).not.toBe(taskLeaseKey("https://s", "tok-b", "king", 7));
+    expect(taskLeaseKey("https://s", "tok", "king", 7)).not.toBe(taskLeaseKey("https://other", "tok", "king", 7));
+  });
+});
+
+describe("绝不把任务永久锁死", () => {
+  test("租约到期后另一个执行体可以接手", () => {
+    const d = dir();
+    claim(d, "runner:claude:aaa");
+    const late = claim(d, "session:claude:harness-1", 7, NOW + TTL + 1);
+    expect(late.state).toBe("acquired");
+    expect(late.reason).toBe("expired");
+  });
+
+  test("--force-lease 显式抢占并留下被抢者的记录", () => {
+    const d = dir();
+    claim(d, "runner:claude:aaa");
+    const forced = claim(d, "session:claude:harness-1", 7, NOW + 10, true);
+    expect(forced.state).toBe("forced");
+    expect(forced.holder?.taken_over_from).toBe("runner:claude:aaa");
+  });
+
+  test("release 只删自己的租约：被合法接手后的迟到 done 不许抹掉新持有者", () => {
+    const d = dir();
+    const key = taskLeaseKey("https://s", "tok", "king", 7);
+    claim(d, "runner:claude:aaa");
+    claim(d, "session:claude:harness-1", 7, NOW + TTL + 1); // 过期接手
+    expect(releaseTaskLease(key, "runner:claude:aaa", d)).toBe(false);
+    expect(readTaskLease(key, d, NOW + TTL + 2)?.executor_id).toBe("session:claude:harness-1");
+    expect(releaseTaskLease(key, "session:claude:harness-1", d)).toBe(true);
+    expect(readTaskLease(key, d, NOW + TTL + 3)).toBeNull();
+  });
+
+  test("损坏的租约文件不锁死任务", () => {
+    const d = dir();
+    const key = taskLeaseKey("https://s", "tok", "king", 7);
+    writeFileSync(join(d, `${key}.json`), "{ not json");
+    expect(claim(d, "runner:claude:aaa").state).toBe("acquired");
+  });
+
+  test("过期租约会被清理，目录不会无限增长", () => {
+    const d = dir();
+    claim(d, "runner:claude:aaa", 7);
+    claim(d, "runner:claude:bbb", 8, NOW + TTL * 5);
+    expect(pruneExpiredTaskLeases(d, NOW + TTL + 1)).toBe(1);
+    expect(readdirSync(d).length).toBe(1);
+  });
+});
+
+describe("执行体身份识别", () => {
+  test("serve 内建 runner 与 harness 会话解析出不同的执行体 id", () => {
+    const runner = resolveExecutorId({ AP_RUNNER_WORKDIR: "/home/u/.agentparty/runners/king", AP_RUNNER_HARNESS: "claude" });
+    const harness = resolveExecutorId({ CLAUDE_SESSION_ID: "sess-42" });
+    expect(runner).not.toBeNull();
+    expect(harness).toBe("session:claude:sess-42");
+    expect(runner).not.toBe(harness);
+  });
+
+  test("同一个 serve runner 换 session（resume）后执行体 id 不变", () => {
+    const a = resolveExecutorId({ AP_RUNNER_WORKDIR: "/w", AP_RUNNER_HARNESS: "claude", AP_RUNNER_SESSION_ID: "s1" });
+    const b = resolveExecutorId({ AP_RUNNER_WORKDIR: "/w", AP_RUNNER_HARNESS: "claude", AP_RUNNER_SESSION_ID: "s2" });
+    expect(a).toBe(b!);
+  });
+
+  test("显式覆盖优先于环境推断", () => {
+    expect(resolveExecutorId({ AP_RUNNER_WORKDIR: "/w" }, { executorId: "op:manual" })).toBe("op:manual");
+  });
+
+  test("识别不出执行体时不做判定，而不是假装放行", () => {
+    expect(resolveExecutorId({})).toBeNull();
+    expect(claim(dir(), null).state).toBe("unenforced");
+  });
+
+  test("长驻进程（MCP）用 pid 兜底，但显式声明优先", () => {
+    expect(processScopedExecutorId({}, 4242)).toBe("mcp:4242");
+    expect(processScopedExecutorId({}, 4243)).not.toBe(processScopedExecutorId({}, 4242));
+    expect(processScopedExecutorId({ AGENTPARTY_EXECUTOR_ID: "op:manual" }, 4242)).toBe("op:manual");
+  });
+
+  test("非法的执行体 id 不被采信", () => {
+    expect(resolveExecutorId({ AGENTPARTY_EXECUTOR_ID: "bad id with spaces" })).toBeNull();
+    expect(resolveExecutorId({ AGENTPARTY_EXECUTOR_ID: "../../escape" })).toBeNull();
+  });
+});
+
+describe("拒绝文案必须说清任务没丢", () => {
+  test("包含 refused / 任务未被改动 / 合法接手方式", () => {
+    const d = dir();
+    claim(d, "runner:claude:aaa");
+    const denied = claim(d, "session:claude:harness-1");
+    const text = describeDeniedLease(denied.holder!, "king", 7, NOW);
+    expect(text).toMatch(/refused/);
+    expect(text).toMatch(/task is untouched/);
+    expect(text).toMatch(/--force-lease/);
+    expect(text).toMatch(/runner:claude:aaa/);
+  });
+});
+
+describe("落盘内容", () => {
+  test("租约文件不含 token", () => {
+    const d = dir();
+    claim(d, "runner:claude:aaa");
+    const file = readdirSync(d)[0]!;
+    const body = readFileSync(join(d, file), "utf8");
+    expect(body).not.toMatch(/tok/);
+    expect(file).not.toMatch(/tok/);
+  });
+});

--- a/cli/test/who-scope.test.ts
+++ b/cli/test/who-scope.test.ts
@@ -101,7 +101,9 @@ describe("live runtime topology 提示", () => {
       claude_sessions: [],
     }]);
     const row = rows.find((candidate) => candidate.name === "a")!;
-    expect(row.topology_conflicts).toEqual([{ kind: "same_worktree", with: ["caller"], runtime_count: 1 }]);
+    expect(row.topology_conflicts).toEqual([
+      { kind: "same_worktree", with: ["caller"], runtime_count: 1, same_identity: false, severity: "advisory" },
+    ]);
     expect(topologyNote(row)).toContain("⚠ same worktree as caller");
   });
 
@@ -113,11 +115,11 @@ describe("live runtime topology 提示", () => {
     const workspace = rows.find((candidate) => candidate.name === "b")!;
     const installation = rows.find((candidate) => candidate.name === "c")!;
     expect(workspace.topology_conflicts).toEqual([
-      { kind: "same_workspace", with: ["caller"], runtime_count: 1 },
+      { kind: "same_workspace", with: ["caller"], runtime_count: 1, same_identity: false, severity: "advisory" },
     ]);
     expect(topologyNote(workspace)).toContain("same workspace as caller");
     expect(installation.topology_conflicts).toEqual([
-      { kind: "same_local_installation", with: ["caller"], runtime_count: 1 },
+      { kind: "same_local_installation", with: ["caller"], runtime_count: 1, same_identity: false, severity: "advisory" },
     ]);
     expect(topologyNote(installation)).toContain("same local installation as caller");
     expect(JSON.stringify(installation)).not.toContain("same_node");
@@ -131,8 +133,32 @@ describe("live runtime topology 提示", () => {
       claude_sessions: [],
     }])[0]!;
     expect(row.topology_conflicts).toEqual([
-      { kind: "same_identity_worktree", with: [], runtime_count: 2 },
+      { kind: "same_identity_worktree", with: [], runtime_count: 2, same_identity: true, severity: "blocking" },
     ]);
     expect(topologyNote(row)).toContain("2 other live runtime(s) of this identity share one worktree");
+  });
+
+  // #834 第 3 项：事故当天 `party who` 打的正是 `same_local_installation, runtime_count: 1`,
+  // 与「隔壁 agent 恰好装在同一台机器上」在 JSON 里长得一模一样,读的人无从判定该不该停手。
+  test("同一身份的另一个执行体（仅同 installation）也必须判定为 blocking", () => {
+    const row = topologyRows([presence("king-claude", [])], [{
+      agent: "king-claude",
+      same_identity: true,
+      relations: [{ relation: "same_local_installation", runtime_count: 1 }],
+      claude_sessions: [],
+    }])[0]!;
+    const conflict = row.topology_conflicts![0]!;
+    expect(conflict.same_identity).toBe(true);
+    expect(conflict.severity).toBe("blocking");
+    expect(topologyNote(row)).toContain("⚠");
+    expect(topologyNote(row)).toContain("concurrent claims on one task are refused");
+    // 别人的 runtime 仍然只是 advisory——不能把「同机装了别的 agent」也升级成停手信号。
+    const other = topologyRows([presence("other", [])], [{
+      agent: "other",
+      same_identity: false,
+      relations: [{ relation: "same_local_installation", runtime_count: 1 }],
+      claude_sessions: [],
+    }])[0]!;
+    expect(other.topology_conflicts![0]!.severity).toBe("advisory");
   });
 });

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -179,6 +179,11 @@ export const EXIT_RATE_LIMITED = 9;
 // 也无活的 wake 通道（离线 + 无 wake layer / 适配器陈旧），@ 只落进历史、不会唤醒任何人。严格模式下
 // 用独立非零码让调用方能编程判定「派发未落地」，而不是把成功发送误当完全失败（消息确实发出去了）。
 export const EXIT_UNREACHABLE = 10;
+// 任务租约冲突（issue #834 第 3 项）：同一身份的**另一个执行体**（典型：`party serve` 拉起的
+// reception runner vs 交互式 harness 会话）已经持有这个 task 的租约。本次认领**没有发出去**——
+// 服务端 task 状态原封不动，任务不会因此丢失。拿到这个码的执行体应当降级为只读（可以看、可以
+// 汇报，别开始有副作用的活），而不是换个措辞重试。
+export const EXIT_TASK_LEASE_HELD = 11;
 
 // ---- 基础类型 ----
 


### PR DESCRIPTION
实现 #834 的**第 3 项【高】：同一身份多 runner 并发，零 enforcement**。（#834 还留着第 5/6 项，故不写 Closes。）

## 事故回放

同一个 `king-claude` 身份同时跑着两个执行体（harness 会话 + `party serve` 拉起的 reception runner）：
- seq133 一个实例基于假前提派出了消耗真实资产的 worker，seq138 另一个据此做了验收，seq142 现场复验整条因果链不成立；
- 两个实例互相强杀对方正在操作的模拟器；
- reception runner 报 `runner timed out after 1800000ms` 之后仍在动设备，最终靠人类 owner 亲自下令 kill 才收敛。

当时 `party who` 打印的是 `topology_conflicts: [{kind: same_local_installation, runtime_count: 1}]` —— 全仓**只有构造与展示，零 enforcement**。

## 做了什么

### 1. 租约粒度与实现位置

新增 `cli/src/task-lease.ts`，按 **(身份, 频道, task)** 发租约，落在 `~/.agentparty/task-leases/<sha(server+token)>-<channel>-task-<id>.json`（token 只参与不可逆摘要，不落盘）。

与既有 `cli/src/instance-lock.ts` 的关系：那把锁按 **(身份, 频道)** 互斥，管的是「同一个频道别被 serve/watch 服务两次」；它挡不住两个**不同来源**的执行体（一个 serve runner、一个人在 harness 里手敲）各自去认领**同一个 task**。粒度不同，锁也就不同。

**为什么不能复用 pid 锁**：`party status working --task N` 是一次性进程，认领完立刻退出，pid 存活探测毫无意义。租约靠两样东西成立：
1. **执行体身份**（executor id）——跨多次调用稳定，且两条腿必须不同。解析链：`AGENTPARTY_EXECUTOR_ID` / `--executor-id` → serve 已注入的 `AP_RUNNER_WORKDIR`(+`AP_RUNNER_HARNESS`，resume 换 session id 也不变) → `--session-id/--session-harness` → `CLAUDE_SESSION_ID` / `CODEX_THREAD_ID`。**最后没有兜底**：识别不出就返回 `unenforced` 并在 stderr 明说「这一刀没落下、请设 `AGENTPARTY_EXECUTOR_ID`」。宁可承认没拦，也不用不稳定的推断（ppid——Claude Code 每次 Bash 调用父进程都不同，会让 harness 把自己上一次的租约当成别人的而自锁）制造一个看着像 enforcement 的假象。长驻的 MCP server 进程可以合法用 pid 兜底（`processScopedExecutorId`），因为它跟着 harness 会话活一整场。
2. **TTL**（默认 30min，对齐 `DEFAULT_RUNNER_TIMEOUT_MS`，`--lease-ttl-ms` 可调）——执行体崩了/被 kill 了，租约必须能自然过期被接手，绝不能把 task 永久锁死。

### 2. 下手点：认领时刻，两条腿都落闸

- `cli/src/commands/status.ts`：`party status working|waiting --task N`
- `cli/src/commands/mcp.ts` 的 `party_status`（**harness 那条腿走的是 MCP**；只在 CLI 落闸等于 enforcement 只盖住一半，事故里恰好是一腿一个）

不在 wake 路径——wake 时拦截太晚，活已经开始了。

### 3. 被拒 runner 的降级语义（红线：拒绝 ≠ 吞任务）

被拒时：**一条帧都不发、不 PATCH 服务端 task state**，任务原样留在频道里由持租约者继续推进；被拒方降级为**只读**（可以 `party task list` / `party history` / 汇报，别开始有副作用的活）。

- CLI：新增 `EXIT_TASK_LEASE_HELD = 11`（shared），stderr 明写 `the task is untouched and the current holder keeps working on it`，并给出合法接手方式；`--json` 输出 `{ok:false, published:false, task_untouched:true, lease:{state:"denied", reason:"held_by_other", holder}}`。
- MCP：`isError` + 同一段文案 + `structuredContent.task_untouched`。

逃生口一并给全（避免把「叫不醒」换成「锁死」）：TTL 到期可接手 / `--force-lease` 显式抢占并记录 `taken_over_from` / `done`|`blocked --task` 交还租约（`blocked` 也放手：卡住的执行体不该把任务扣满整个 TTL）/ `release` 只删自己那张（迟到的 `done` 不许抹掉合法接手者）/ 损坏的租约文件不锁死任务。

### 4. `topology_conflicts` 从只打印升级为可判定

`cli/src/commands/who.ts`：每条 conflict 补 `same_identity` 与 `severity: "blocking"|"advisory"`。同身份的另一个执行体 = `blocking`（事故当天那条 `same_local_installation, runtime_count: 1` 正是这一类，而它在 JSON 里和「隔壁 agent 恰好装在同一台机器上」长得一模一样）；人读那行也从中性事实改成 `⚠ … — concurrent claims on one task are refused`。别人的 runtime 仍是 `advisory`，不把同机装了别的 agent 升级成停手信号。

### 5. 超时收束：现状与本切片的边界

读码结论：serve 侧的超时**已经**有实质收束，不只是记状态（`runWithRunnerTimeout` 的 `RUNNER_TERMINATION_BARRIER_MS` 屏障 + `RunnerTimeoutError.terminationConfirmed`，以及 `runner_termination_unconfirmed` 触发的 serve wake 熔断，见 serve.ts:4880-4887 / 5778 / 5982，已有 #550 测试覆盖）。也就是说「超时后还在动设备」的**唤醒侧**已经被熔断挡住了——party 无法强杀一个已经 detach 的模型子进程，这是能力边界，不是本切片能补的洞。

本切片对这件事的贡献是**并发侧**：一个终止未确认的 runner **仍然持有它的租约**（这正是想要的——不能让第二个执行体在一个可能还在动设备的进程背后开始干同一件事），而 TTL 给了有界的自动解除。真正的「杀掉 detached 子进程」另开切片更合适。

## 变异验证

每处修复都做了**整段删除级**变异（不是弱改词），确认断言真变红；再做等价实现替换，确认不误红。

| # | 变异 | 结果 |
|---|---|---|
| M1 | 删掉 `acquireTaskLease` 里整个 denied 分支 | 🔴 6 fail |
| M2 | 删掉 status.ts 里整个 denied 早退块（照常发帧） | 🔴 3 fail |
| M3 | 删掉 `releaseTaskLease` 的持有者校验（`executor_id !== executorId`） | 🔴 1 fail |
| M4 | 让 `live` 恒真（忽略 TTL 过期） | 🔴 3 fail |
| M5 | 删掉 who.ts 的 `same_identity`/`severity` 字段与 blocking 分支 | 🔴 4 fail |
| M6 | 删掉 mcp.ts 里整个租约闸门 | 🔴 1 fail |
| M7 | 删掉 mcp.ts 的租约交还 | 🔴 1 fail |
| E1 | 等价重写 denied 条件（`!force && !mine && existing !== null && now < existing.expires_at`） | 🟢 37 pass，不误红 |
| E2 | 等价重写 who.ts 的 `same_identity`/`severity` 计算 | 🟢 11 pass，不误红 |

测试没有用 `WsClient.nextOfType`（本切片不涉 WS 帧流）；MCP 那层用两个**真实独立的 MCP server 进程**共享同一个 `AGENTPARTY_HOME` 复现事故形状，断言的是「后果」（没有新的 POST messages / PATCH task），不是模块内部返回值。

## 验证

- `bun test cli/test`：**1867 pass / 0 fail**（新增 31 条）
- `tsc --noEmit`：shared / cli / worker / web 全绿

## 并发提醒

**没有被迫碰 worker/**。`shared/src/protocol.ts` 只加了一个常量 `EXIT_TASK_LEASE_HELD = 11`（纯 additive，紧跟 `EXIT_UNREACHABLE` 之后，不改任何既有类型），与正在做 #881+#875 的 directed delivery 语义改动不重叠；若那边先合，这里 rebase 应当只是一处 context 冲突。`cli/test/oidc-mock.ts` 加了一条 PATCH task 路由（additive）。
