### PR TITLE
feat(cli): bridge codex 暴露 --resume/--resume-last/--list-sessions

### DIFF
--- a/cli/src/codex-sessions.ts
+++ b/cli/src/codex-sessions.ts
@@ -1,0 +1,253 @@
+// Discover Codex rollout sessions so `party bridge codex --resume/--resume-last`
+// can re-enter a thread the user is already looking at.
+//
+// Codex writes one JSONL rollout per session under
+// $CODEX_HOME/sessions/YYYY/MM/DD/rollout-<local-ts>-<uuid>.jsonl. The UUID in
+// the file name is the thread id accepted by `codex resume <threadId>`; the
+// first line is a `session_meta` record carrying cwd/originator/source/git, and
+// the first `event_msg` of type `user_message` is the earliest human-readable
+// label for the session.
+import { closeSync, openSync, readdirSync, readSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import { sanitizeSingleLine } from "./format";
+
+/** Bytes of each rollout read while building a listing. */
+export const CODEX_ROLLOUT_HEAD_BYTES = 512 * 1024;
+
+const ROLLOUT_NAME_RE =
+  /^rollout-(\d{4})-(\d{2})-(\d{2})T(\d{2})-(\d{2})-(\d{2})-([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.jsonl$/i;
+
+const THREAD_ID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export interface CodexSessionSummary {
+  threadId: string;
+  path: string;
+  /** Local wall-clock start encoded in the file name, as epoch ms. */
+  startedAt: number;
+  /** `2026-08-20T18-13-35` exactly as the file name spells it. */
+  startedAtLabel: string;
+  cwd: string | null;
+  originator: string | null;
+  source: string | null;
+  branch: string | null;
+  /** First human turn of the session, collapsed to one short line. */
+  summary: string | null;
+}
+
+export function isCodexThreadId(value: string): boolean {
+  return THREAD_ID_RE.test(value);
+}
+
+/** `$CODEX_HOME/sessions`, else `~/.codex/sessions`. */
+export function codexSessionsRoot(
+  env: NodeJS.ProcessEnv = process.env,
+  home: string = homedir(),
+): string {
+  const codexHome = env.CODEX_HOME?.trim();
+  return codexHome
+    ? resolve(codexHome, "sessions")
+    : resolve(home, ".codex", "sessions");
+}
+
+export function parseCodexRolloutFileName(
+  name: string,
+): { threadId: string; startedAt: number; startedAtLabel: string } | null {
+  const match = ROLLOUT_NAME_RE.exec(name);
+  if (!match) return null;
+  const [, year, month, day, hour, minute, second, threadId] = match;
+  // The file-name stamp is local wall-clock, so build a local Date. Only the
+  // relative order matters for "most recent", and every rollout on one machine
+  // shares the same clock.
+  const startedAt = new Date(
+    Number(year),
+    Number(month) - 1,
+    Number(day),
+    Number(hour),
+    Number(minute),
+    Number(second),
+  ).getTime();
+  if (!Number.isFinite(startedAt)) return null;
+  return {
+    threadId: threadId!.toLowerCase(),
+    startedAt,
+    startedAtLabel: `${year}-${month}-${day}T${hour}-${minute}-${second}`,
+  };
+}
+
+function readdirOrEmpty(path: string): string[] {
+  try {
+    return readdirSync(path);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Enumerate rollout files newest-first without reading any of them. The layout
+ * is a fixed YYYY/MM/DD tree, so only numeric directory levels are descended.
+ */
+export function listCodexRolloutFiles(
+  root: string,
+): Array<{ path: string } & NonNullable<ReturnType<typeof parseCodexRolloutFileName>>> {
+  const found: Array<{ path: string } & NonNullable<ReturnType<typeof parseCodexRolloutFileName>>> = [];
+  for (const year of readdirOrEmpty(root)) {
+    if (!/^\d{4}$/.test(year)) continue;
+    const yearPath = join(root, year);
+    for (const month of readdirOrEmpty(yearPath)) {
+      if (!/^\d{2}$/.test(month)) continue;
+      const monthPath = join(yearPath, month);
+      for (const day of readdirOrEmpty(monthPath)) {
+        if (!/^\d{2}$/.test(day)) continue;
+        const dayPath = join(monthPath, day);
+        for (const name of readdirOrEmpty(dayPath)) {
+          const parsed = parseCodexRolloutFileName(name);
+          if (!parsed) continue;
+          found.push({ path: join(dayPath, name), ...parsed });
+        }
+      }
+    }
+  }
+  found.sort((a, b) =>
+    b.startedAt - a.startedAt || b.startedAtLabel.localeCompare(a.startedAtLabel)
+  );
+  return found;
+}
+
+function readHead(path: string, bytes: number): string {
+  const fd = openSync(path, "r");
+  try {
+    const buffer = Buffer.alloc(bytes);
+    const read = readSync(fd, buffer, 0, bytes, 0);
+    return buffer.subarray(0, read).toString("utf8");
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function oneLine(value: string, limit = 96): string | null {
+  const collapsed = sanitizeSingleLine(value).replace(/\s+/g, " ").trim();
+  if (collapsed === "") return null;
+  return collapsed.length > limit ? `${collapsed.slice(0, limit - 1)}…` : collapsed;
+}
+
+function stringOrNull(value: unknown): string | null {
+  return typeof value === "string" && value !== "" ? value : null;
+}
+
+/**
+ * Extract the identifying fields from a rollout prefix. Truncated input is
+ * expected: the caller only reads a bounded head of a possibly huge file, so
+ * the trailing partial line is dropped and unparsable lines are skipped.
+ */
+export function summarizeCodexRolloutHead(head: string): {
+  cwd: string | null;
+  originator: string | null;
+  source: string | null;
+  branch: string | null;
+  summary: string | null;
+} {
+  const result = {
+    cwd: null as string | null,
+    originator: null as string | null,
+    source: null as string | null,
+    branch: null as string | null,
+    summary: null as string | null,
+  };
+  // A head cut mid-line is never valid JSON, so the trailing partial record is
+  // skipped by the parse guard below rather than needing its own special case.
+  for (const line of head.split("\n")) {
+    if (line.trim() === "") continue;
+    let record: unknown;
+    try {
+      record = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (typeof record !== "object" || record === null) continue;
+    const { type, payload } = record as { type?: unknown; payload?: unknown };
+    if (typeof payload !== "object" || payload === null) continue;
+    const fields = payload as Record<string, unknown>;
+    if (type === "session_meta") {
+      result.cwd = stringOrNull(fields.cwd);
+      result.originator = stringOrNull(fields.originator);
+      result.source = stringOrNull(fields.source);
+      const git = fields.git;
+      if (typeof git === "object" && git !== null) {
+        result.branch = stringOrNull((git as Record<string, unknown>).branch);
+      }
+      continue;
+    }
+    if (
+      result.summary === null &&
+      type === "event_msg" &&
+      fields.type === "user_message" &&
+      typeof fields.message === "string"
+    ) {
+      result.summary = oneLine(fields.message);
+    }
+  }
+  return result;
+}
+
+export interface ListCodexSessionsOptions {
+  limit?: number;
+  /** Only sessions whose recorded cwd is exactly this path. */
+  cwd?: string;
+  headBytes?: number;
+}
+
+export function listCodexSessions(
+  root: string,
+  options: ListCodexSessionsOptions = {},
+): CodexSessionSummary[] {
+  const limit = options.limit ?? 20;
+  const headBytes = options.headBytes ?? CODEX_ROLLOUT_HEAD_BYTES;
+  const sessions: CodexSessionSummary[] = [];
+  for (const file of listCodexRolloutFiles(root)) {
+    if (sessions.length >= limit) break;
+    let details: ReturnType<typeof summarizeCodexRolloutHead>;
+    try {
+      details = summarizeCodexRolloutHead(readHead(file.path, headBytes));
+    } catch {
+      // An unreadable rollout is not a listing failure; it simply cannot be
+      // described. Its thread id is still valid, so keep the row.
+      details = { cwd: null, originator: null, source: null, branch: null, summary: null };
+    }
+    if (options.cwd !== undefined && details.cwd !== options.cwd) continue;
+    sessions.push({
+      threadId: file.threadId,
+      path: file.path,
+      startedAt: file.startedAt,
+      startedAtLabel: file.startedAtLabel,
+      ...details,
+    });
+  }
+  return sessions;
+}
+
+export function latestCodexSession(
+  root: string,
+  options: Omit<ListCodexSessionsOptions, "limit"> = {},
+): CodexSessionSummary | null {
+  return listCodexSessions(root, { ...options, limit: 1 })[0] ?? null;
+}
+
+export function formatCodexSessionLine(session: CodexSessionSummary): string {
+  const when = session.startedAtLabel.replace("T", " ").replace(
+    /-(\d{2})-(\d{2})$/,
+    ":$1:$2",
+  );
+  const origin = [session.originator, session.source]
+    .filter((value): value is string => value !== null)
+    .join("/");
+  const parts = [
+    session.threadId,
+    when,
+    session.cwd ?? "unknown cwd",
+    ...(session.branch === null ? [] : [`@${session.branch}`]),
+    ...(origin === "" ? [] : [`(${origin})`]),
+  ];
+  return `${parts.join("  ")}${session.summary === null ? "" : `\n    ${session.summary}`}`;
+}

--- a/cli/src/commands/bridge.ts
+++ b/cli/src/commands/bridge.ts
@@ -50,6 +50,14 @@ import {
   type ClaudePluginShellInspection,
 } from "./doctor";
 import { runCodexSessionBridge, type CodexBridgeRuntimeOptions } from "./codex-bridge";
+import {
+  codexSessionsRoot,
+  formatCodexSessionLine,
+  isCodexThreadId,
+  latestCodexSession,
+  listCodexSessions,
+  type CodexSessionSummary,
+} from "../codex-sessions";
 
 const CLAUDE_CHANNEL_MIN_VERSION = [2, 1, 80] as const;
 const CLAUDE_CROSS_SESSION_MIN_VERSION = [2, 1, 224] as const;
@@ -153,7 +161,8 @@ const HELP = `usage: party bridge <claude|codex> [channel] [options] [-- <harnes
 forms:
   party bridge claude [channel|--channel C] [--cross-session auto|off|required] [--cross-session-inbound accept|hold|refuse] [--check [--json]] [-- <claude args...>]
   party bridge claude --verify --channel C --receiver-config PATH --sender-config PATH [--receiver-cwd DIR] [--sender-cwd DIR] [--preflight-only] [--keep-artifacts]
-  party bridge codex  [channel|--channel C] [--codex-bin PATH] [-- <codex args...>]
+  party bridge codex  [channel|--channel C] [--codex-bin PATH] [--resume THREAD_ID|--resume-last] [-- <codex args...>]
+  party bridge codex  --list-sessions
 
 Attach AgentParty to the same interactive harness session:
   claude  native Claude Channel input and linked reply tool
@@ -179,6 +188,17 @@ examples:
   party bridge codex dev
   party bridge codex --channel dev -- --model gpt-5.4
   party bridge codex dev --codex-bin /opt/homebrew/bin/codex
+  party bridge codex --list-sessions
+  party bridge codex dev --resume-last
+  party bridge codex dev --resume 01a01e72-8187-7d63-8e4d-9a1a9daa5451
+
+Without --resume/--resume-last the bridge opens a NEW Codex thread, so a session
+you are already watching will not receive the wake. --resume-last re-enters the
+most recent rollout under $CODEX_HOME/sessions (default ~/.codex/sessions);
+--list-sessions prints thread ids with their start time, cwd, branch, and first
+user turn. Codex allows one writer per thread, so a session still open in the
+Codex desktop app cannot be resumed until it is closed there; the resumed turn
+then runs in this terminal's Codex TUI.
 
 Tokens after -- are passed to the selected interactive CLI. The bridge never
 uses PTY input injection and never starts a second writer against a live turn.
@@ -1706,6 +1726,65 @@ async function defaultLaunch(
   return await proc.exited;
 }
 
+/**
+ * Measured on Codex CLI 0.148.0-alpha.15 against the Codex desktop app: while
+ * the GUI has a thread open it holds that thread's only writer, and
+ * `thread/resume` on it fails with `already has an active writer`. The same
+ * thread resumes normally once the owning process releases it, and the resumed
+ * turn then runs in the bridge's own Codex TUI.
+ */
+export const CODEX_RESUME_VISIBILITY_NOTICE =
+  "Codex allows one writer per thread: a session still open in the Codex desktop app " +
+  "cannot be resumed — close it there first. The resumed turn runs in this terminal's Codex TUI.";
+
+export function printCodexSessions(
+  env: NodeJS.ProcessEnv,
+  list: typeof listCodexSessions = listCodexSessions,
+): number {
+  const root = codexSessionsRoot(env);
+  const sessions = list(root, { limit: 20 });
+  if (sessions.length === 0) {
+    console.error(`no Codex sessions found under ${root}`);
+    return 1;
+  }
+  console.log(`Codex sessions under ${root} (newest first):`);
+  for (const session of sessions) console.log(formatCodexSessionLine(session));
+  console.log("");
+  console.log("Resume one with: party bridge codex <channel> --resume <thread-id>");
+  console.log(CODEX_RESUME_VISIBILITY_NOTICE);
+  return 0;
+}
+
+export type CodexResumeSelection =
+  | { ok: true; threadId: string | null; session?: CodexSessionSummary }
+  | { ok: false; error: string };
+
+/** Turn `--resume`/`--resume-last` into one concrete Codex thread id. */
+export function selectCodexResumeThread(
+  options: { resume?: string; resumeLast?: boolean; env: NodeJS.ProcessEnv },
+  latest: typeof latestCodexSession = latestCodexSession,
+): CodexResumeSelection {
+  if (options.resume !== undefined) {
+    if (!isCodexThreadId(options.resume)) {
+      return {
+        ok: false,
+        error:
+          `--resume expects a Codex thread id (the UUID in rollout-<ts>-<uuid>.jsonl), got ${
+            sanitizeSingleLine(options.resume).slice(0, 80)
+          }. List them with: party bridge codex --list-sessions`,
+      };
+    }
+    return { ok: true, threadId: options.resume.toLowerCase() };
+  }
+  if (options.resumeLast !== true) return { ok: true, threadId: null };
+  const root = codexSessionsRoot(options.env);
+  const session = latest(root, {});
+  if (session === null) {
+    return { ok: false, error: `--resume-last found no Codex sessions under ${root}` };
+  }
+  return { ok: true, threadId: session.threadId, session };
+}
+
 export async function run(argv: string[], deps: BridgeDeps = {}): Promise<number> {
   if (isHelpArg(argv, { allowHelpPositional: true })) {
     console.log(HELP);
@@ -1717,16 +1796,19 @@ export async function run(argv: string[], deps: BridgeDeps = {}): Promise<number
   const delimiter = argv.indexOf("--");
   const bridgeArgs = delimiter < 0 ? argv : argv.slice(0, delimiter);
   const harnessArgs = delimiter < 0 ? [] : argv.slice(delimiter + 1);
-  const { positionals, flags } = parseArgs(bridgeArgs, { booleans: ["check", "json"] });
+  const { positionals, flags } = parseArgs(bridgeArgs, {
+    booleans: ["check", "json", "resume-last", "list-sessions"],
+  });
   const unknown = unknownFlagError(flags, [
     "channel", "codex-bin", "cross-session", "cross-session-inbound", "check", "json",
+    "resume", "resume-last", "list-sessions",
   ]);
   if (unknown !== null) {
     console.error(`${unknown}; put harness flags after --`);
     return 1;
   }
   const flagError = valueFlagError(flags, [
-    "channel", "codex-bin", "cross-session", "cross-session-inbound",
+    "channel", "codex-bin", "cross-session", "cross-session-inbound", "resume",
   ]);
   if (flagError !== null) {
     console.error(flagError);
@@ -1744,6 +1826,30 @@ export async function run(argv: string[], deps: BridgeDeps = {}): Promise<number
   if (harness === "claude" && flags["codex-bin"] !== undefined) {
     console.error("--codex-bin is only valid with party bridge codex");
     return 1;
+  }
+  for (const codexOnly of ["resume", "resume-last", "list-sessions"] as const) {
+    if (harness === "claude" && flags[codexOnly] !== undefined) {
+      console.error(`--${codexOnly} is only valid with party bridge codex`);
+      return 1;
+    }
+  }
+  if (flags.resume !== undefined && flags["resume-last"] === true) {
+    console.error("--resume and --resume-last select different threads; pass only one");
+    return 1;
+  }
+  if (
+    flags["list-sessions"] === true &&
+    (flags.resume !== undefined || flags["resume-last"] === true)
+  ) {
+    console.error("--list-sessions only prints sessions; it cannot be combined with --resume/--resume-last");
+    return 1;
+  }
+  if (flags["list-sessions"] === true && harnessArgs.length > 0) {
+    console.error("--list-sessions does not launch Codex, so it does not accept Codex arguments after --");
+    return 1;
+  }
+  if (harness === "codex" && flags["list-sessions"] === true) {
+    return printCodexSessions(deps.env ?? process.env);
   }
   if (harness === "codex" && flags["cross-session"] !== undefined) {
     console.error("--cross-session is only valid with party bridge claude");
@@ -1808,6 +1914,15 @@ export async function run(argv: string[], deps: BridgeDeps = {}): Promise<number
       );
       return 1;
     }
+    const resumeSelection = selectCodexResumeThread({
+      ...(str(flags.resume) === undefined ? {} : { resume: str(flags.resume)! }),
+      resumeLast: flags["resume-last"] === true,
+      env: deps.env ?? process.env,
+    });
+    if (!resumeSelection.ok) {
+      console.error(`party bridge codex ${resumeSelection.error}`);
+      return 1;
+    }
     const cwd = deps.cwd ?? process.cwd();
     const launch = resolveCodexLaunch(
       str(flags["codex-bin"]) ?? deps.codexBinary,
@@ -1840,11 +1955,22 @@ export async function run(argv: string[], deps: BridgeDeps = {}): Promise<number
       );
       return 1;
     }
+    if (resumeSelection.threadId !== null) {
+      const chosen = resumeSelection.session;
+      console.error(
+        `party bridge codex: resuming Codex thread ${resumeSelection.threadId}` +
+          (chosen === undefined
+            ? ""
+            : ` (started ${chosen.startedAtLabel}, cwd ${chosen.cwd ?? "unknown"})`) +
+          `. ${CODEX_RESUME_VISIBILITY_NOTICE}`,
+      );
+    }
     return await (deps.runCodexBridge ?? ((options) => runCodexSessionBridge(options)))({
       channel,
       codexBinary: launch.codexBinary,
       codexArgsPrefix: launch.codexArgsPrefix,
       codexArgs: harnessArgs,
+      initialThreadId: resumeSelection.threadId,
       cwd: launch.cwd,
       env: launch.env,
     });

--- a/cli/src/commands/codex-bridge.ts
+++ b/cli/src/commands/codex-bridge.ts
@@ -38,6 +38,11 @@ export interface CodexBridgeRuntimeOptions {
   /** Fixed argv before Codex subcommands (used by the Windows npm adapter). */
   codexArgsPrefix?: string[];
   codexArgs?: string[];
+  /**
+   * Re-enter this existing Codex thread instead of opening a new one. Supplied
+   * by `party bridge codex --resume/--resume-last`.
+   */
+  initialThreadId?: string | null;
   cwd?: string;
   env?: NodeJS.ProcessEnv;
 }
@@ -270,6 +275,26 @@ export function buildCodexTuiResumeWithPromptArgs(
     threadId,
     ...(initial.prompt === null ? [] : [initial.prompt]),
   ];
+}
+
+/**
+ * Codex keeps one active writer per thread. Measured on Codex CLI
+ * 0.148.0-alpha.15: while the Codex desktop GUI has a thread open,
+ * `thread/resume` on it is rejected with
+ * `thread-store conflict: thread <id> already has an active writer`, and the
+ * same thread resumes normally once the owning process lets it go.
+ */
+export function isCodexActiveWriterConflict(detail: string): boolean {
+  return detail.includes("already has an active writer") ||
+    detail.includes("thread-store conflict");
+}
+
+export function codexActiveWriterConflictMessage(threadId: string): string {
+  return (
+    `codex-bridge: Codex thread ${threadId} already has an active writer, so this bridge ` +
+    "cannot attach to it. Codex allows only one writer per thread: close that thread in the " +
+    "Codex desktop app (or stop the other codex process) and run the same command again."
+  );
 }
 
 export function resolveCodexRecoveryThreadId(
@@ -756,6 +781,20 @@ export async function runCodexSessionBridge(
       log(`codex-bridge: ${error instanceof Error ? error.message : String(error)}`);
       return 1;
     }
+    const requestedThreadId = options.initialThreadId ?? null;
+    if (requestedThreadId !== null) {
+      // Outstanding recovery debt is owed by exactly one thread. Silently
+      // resuming a different one would strand that debt, so refuse instead of
+      // choosing on the operator's behalf.
+      if (initialThreadId !== null && initialThreadId !== requestedThreadId) {
+        log(
+          `codex-bridge: #${options.channel} has unfinished delivery recovery on thread ` +
+            `${initialThreadId}; refusing to resume ${requestedThreadId} instead`,
+        );
+        return 1;
+      }
+      initialThreadId = requestedThreadId;
+    }
     throwIfTerminated();
     lock = acquireInstanceLock(
       "serve",
@@ -809,9 +848,19 @@ export async function runCodexSessionBridge(
     });
     await awaitStartup(session.start());
     if (initialThreadId !== null) {
-      await awaitStartup(session.request("thread/resume", {
-        threadId: initialThreadId,
-      }));
+      try {
+        await awaitStartup(session.request("thread/resume", {
+          threadId: initialThreadId,
+        }));
+      } catch (error) {
+        if (error instanceof CodexBridgeTerminated) throw error;
+        const detail = error instanceof Error ? error.message : String(error);
+        if (isCodexActiveWriterConflict(detail)) {
+          log(codexActiveWriterConflictMessage(initialThreadId));
+          return 1;
+        }
+        throw error;
+      }
       if (session.activeThreadId !== initialThreadId) {
         throw new Error(
           `Codex app-server resumed ${session.activeThreadId ?? "no thread"} instead of ` +

--- a/cli/test/codex-bridge-resume.test.ts
+++ b/cli/test/codex-bridge-resume.test.ts
@@ -1,0 +1,297 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import type { DirectedDelivery, MsgFrame } from "@agentparty/shared";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  CODEX_RESUME_VISIBILITY_NOTICE,
+  printCodexSessions,
+  run as runBridge,
+  selectCodexResumeThread,
+  type CodexCapabilityProbe,
+} from "../src/commands/bridge";
+import {
+  codexActiveWriterConflictMessage,
+  isCodexActiveWriterConflict,
+  runCodexSessionBridge,
+  type CodexBridgeRuntimeOptions,
+} from "../src/commands/codex-bridge";
+import {
+  DeliveryRecoveryJournal,
+  deliveryRecoveryJournalPath,
+} from "../src/delivery-recovery-journal";
+
+const supported: CodexCapabilityProbe = {
+  version: "codex-cli 0.148.0",
+  rootHelp: "--remote <ADDR> ws://host unix://PATH",
+  appServerHelp: "--listen <URL> --stdio",
+};
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const path of tempDirs.splice(0)) rmSync(path, { recursive: true, force: true });
+});
+
+function tempDir(): string {
+  const path = mkdtempSync(join(tmpdir(), "agentparty-codex-resume-"));
+  tempDirs.push(path);
+  return path;
+}
+
+function recordCodexRecoveryDebt(journal: DeliveryRecoveryJournal, threadId: string): void {
+  const now = Date.now();
+  const delivery: DirectedDelivery = {
+    id: "delivery-resume-0",
+    message_seq: 700,
+    target_name: "front",
+    cause: "mention",
+    state: "claimed",
+    attempt: 1,
+    lease_epoch: 1,
+    lease_token: "lease-0",
+    lease_until: now + 90_000,
+    work_id: "work-0",
+    continuation_ref: "continuation-0",
+    reply_seq: null,
+    last_error: null,
+    created_at: now,
+    updated_at: now,
+  };
+  const message: MsgFrame = {
+    type: "msg",
+    seq: delivery.message_seq,
+    sender: { name: "owner", kind: "human" },
+    kind: "message",
+    body: "@front recover",
+    mentions: ["front"],
+    reply_to: null,
+    state: null,
+    note: null,
+    status: null,
+    ts: now,
+  };
+  journal.recordClaim(delivery, message);
+  journal.update(delivery.id, {
+    phase: "harness_issued",
+    threadId,
+    delivery: { ...delivery, state: "running" },
+  });
+}
+
+describe("party bridge codex --resume selects an existing thread", () => {
+  const gui = "01a01e78-a24b-7c61-80e4-a78a0f52a152";
+  const older = "01a01e72-8187-7d63-8e4d-9a1a9daa5451";
+
+  /** A $CODEX_HOME whose sessions tree mirrors a real Codex install. */
+  function codexHome(): string {
+    const home = tempDir();
+    const day = join(home, "sessions", "2026", "08", "20");
+    mkdirSync(day, { recursive: true });
+    const rollout = (stamp: string, threadId: string, cwd: string, prompt: string) => {
+      writeFileSync(
+        join(day, `rollout-${stamp}-${threadId}.jsonl`),
+        `${[
+          JSON.stringify({
+            type: "session_meta",
+            payload: {
+              session_id: threadId,
+              cwd,
+              originator: "Codex Desktop",
+              source: "vscode",
+              git: { branch: "main" },
+            },
+          }),
+          JSON.stringify({
+            type: "event_msg",
+            payload: { type: "user_message", message: prompt },
+          }),
+        ].join("\n")}\n`,
+      );
+    };
+    rollout("2026-08-20T18-13-35", older, "/workspace/old", "an older session");
+    rollout("2026-08-20T18-20-17", gui, "/workspace/watched", "the session the owner is watching");
+    return home;
+  }
+
+  async function runCodexBridgeArgv(argv: string[], env: NodeJS.ProcessEnv): Promise<{
+    code: number;
+    calls: CodexBridgeRuntimeOptions[];
+  }> {
+    const calls: CodexBridgeRuntimeOptions[] = [];
+    const code = await runBridge(argv, {
+      probeCodexCapabilities: async () => supported,
+      codexBinary: process.execPath,
+      cwd: "/workspace",
+      env,
+      runCodexBridge: async (options) => {
+        calls.push(options);
+        return 0;
+      },
+    });
+    return { code, calls };
+  }
+
+  test("--resume passes the exact thread id through with the Codex args after --", async () => {
+    const { code, calls } = await runCodexBridgeArgv(
+      ["codex", "dev", "--resume", gui, "--", "--model", "gpt-5.4"],
+      { PATH: "/bin", CODEX_HOME: codexHome() },
+    );
+    expect(code).toBe(0);
+    expect(calls[0]).toMatchObject({
+      channel: "dev",
+      initialThreadId: gui,
+      codexArgs: ["--model", "gpt-5.4"],
+    });
+  });
+
+  test("--resume-last resolves the newest rollout under $CODEX_HOME", async () => {
+    const { code, calls } = await runCodexBridgeArgv(
+      ["codex", "dev", "--resume-last"],
+      { PATH: "/bin", CODEX_HOME: codexHome() },
+    );
+    expect(code).toBe(0);
+    expect(calls[0]?.initialThreadId).toBe(gui);
+  });
+
+  test("without a resume flag the bridge still opens a new thread", async () => {
+    const { code, calls } = await runCodexBridgeArgv(
+      ["codex", "dev", "--", "--model", "gpt-5.4"],
+      { PATH: "/bin", CODEX_HOME: codexHome() },
+    );
+    expect(code).toBe(0);
+    expect(calls[0]?.initialThreadId).toBeNull();
+    expect(calls[0]?.codexArgs).toEqual(["--model", "gpt-5.4"]);
+  });
+
+  test("resume selection rejects malformed ids and an empty session store", () => {
+    const home = codexHome();
+    expect(selectCodexResumeThread({ resume: gui, env: {} })).toEqual({ ok: true, threadId: gui });
+    expect(selectCodexResumeThread({ resume: "../../etc/passwd", env: {} }))
+      .toMatchObject({ ok: false });
+    expect(selectCodexResumeThread({ resumeLast: true, env: { CODEX_HOME: home } }))
+      .toMatchObject({ ok: true, threadId: gui });
+    expect(selectCodexResumeThread({ resumeLast: true, env: { CODEX_HOME: tempDir() } }))
+      .toMatchObject({ ok: false });
+    expect(selectCodexResumeThread({ env: {} })).toEqual({ ok: true, threadId: null });
+  });
+
+  test("--resume and --resume-last cannot both select a thread", async () => {
+    expect(await runBridge(["codex", "dev", "--resume", gui, "--resume-last"], {
+      runCodexBridge: async () => {
+        throw new Error("bridge must not start on an ambiguous resume selection");
+      },
+    })).toBe(1);
+  });
+
+  test("resume flags are rejected for the Claude harness", async () => {
+    for (const argv of [
+      ["claude", "dev", "--resume", gui],
+      ["claude", "dev", "--resume-last"],
+      ["claude", "dev", "--list-sessions"],
+    ]) {
+      expect(await runBridge(argv, {
+        probeClaudeVersion: async () => {
+          throw new Error("claude must not be probed for a codex-only flag");
+        },
+      })).toBe(1);
+    }
+  });
+
+  test("--list-sessions prints resumable thread ids and never launches Codex", async () => {
+    const printed: string[] = [];
+    const restore = console.log;
+    console.log = (line: string) => printed.push(line);
+    try {
+      expect(printCodexSessions({ CODEX_HOME: codexHome() })).toBe(0);
+      expect(printCodexSessions({ CODEX_HOME: tempDir() })).toBe(1);
+    } finally {
+      console.log = restore;
+    }
+    const output = printed.join("\n");
+    expect(output).toContain("/workspace/watched");
+    expect(output).toContain("the session the owner is watching");
+    expect(output).toContain(CODEX_RESUME_VISIBILITY_NOTICE);
+    const ids = printed.flatMap((line) => {
+      const id = line.trim().split(/\s+/)[0] ?? "";
+      return /^[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$/.test(id) ? [id] : [];
+    });
+    expect(ids).toEqual([gui, older]);
+
+    expect(await runBridge(["codex", "dev", "--list-sessions", "--", "--model", "x"], {
+      runCodexBridge: async () => {
+        throw new Error("--list-sessions must not launch Codex");
+      },
+    })).toBe(1);
+  });
+
+  test("an explicit resume never strands recovery debt owed by another thread", async () => {
+    const previousAgentPartyHome = process.env.AGENTPARTY_HOME;
+    const root = tempDir();
+    process.env.AGENTPARTY_HOME = root;
+    try {
+      const server = "https://runtime-resume.example";
+      const token = "ap_runtime_resume";
+      const journal = new DeliveryRecoveryJournal(
+        deliveryRecoveryJournalPath("codex", server, token, "dev"),
+        "dev",
+        "codex",
+      );
+      recordCodexRecoveryDebt(journal, "thread-journal");
+      const logs: string[] = [];
+      const result = await runCodexSessionBridge(
+        {
+          channel: "dev",
+          codexBinary: process.execPath,
+          initialThreadId: gui,
+          cwd: root,
+          env: { ...process.env },
+        },
+        {
+          resolveAuth: async () => ({
+            server,
+            token,
+            auth_source: "runtime_config",
+            config: { kind: "none", path: null },
+            account: { present: false, path: join(root, "account.json") },
+          }),
+          spawnAppServer: () => {
+            throw new Error("app-server must not start when the resume target conflicts");
+          },
+          runtimeDir: () => {
+            throw new Error("runtime directory must not be created when the resume conflicts");
+          },
+          installSignalHandlers: () => () => {},
+          terminationGraceMs: 0,
+          killWaitMs: 0,
+          log: (line) => logs.push(line),
+        },
+      );
+      expect(result).toBe(1);
+      expect(logs.join("\n")).toContain("thread-journal");
+      expect(logs.join("\n")).toContain(gui);
+    } finally {
+      if (previousAgentPartyHome === undefined) {
+        delete process.env.AGENTPARTY_HOME;
+      } else {
+        process.env.AGENTPARTY_HOME = previousAgentPartyHome;
+      }
+    }
+  });
+
+  test("a thread another process still writes is reported as a closable conflict", () => {
+    // Observed verbatim from Codex CLI 0.148.0-alpha.15 while the Codex desktop
+    // app had this thread open.
+    expect(isCodexActiveWriterConflict(
+      `thread/resume: thread/resume failed: thread ${gui} already has an active writer (code -32600)`,
+    )).toBe(true);
+    expect(isCodexActiveWriterConflict(
+      `thread-store conflict: thread ${gui} already has an active writer`,
+    )).toBe(true);
+    expect(isCodexActiveWriterConflict("thread/resume failed: no such thread")).toBe(false);
+    const message = codexActiveWriterConflictMessage(gui);
+    expect(message).toContain(gui);
+    expect(message).toContain("Codex desktop app");
+    expect(message).toContain("one writer per thread");
+  });
+});

--- a/cli/test/codex-sessions.test.ts
+++ b/cli/test/codex-sessions.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  codexSessionsRoot,
+  formatCodexSessionLine,
+  isCodexThreadId,
+  latestCodexSession,
+  listCodexRolloutFiles,
+  listCodexSessions,
+  parseCodexRolloutFileName,
+  summarizeCodexRolloutHead,
+} from "../src/codex-sessions";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const path of tempDirs.splice(0)) rmSync(path, { recursive: true, force: true });
+});
+
+function tempDir(): string {
+  const path = mkdtempSync(join(tmpdir(), "agentparty-codex-sessions-"));
+  tempDirs.push(path);
+  return path;
+}
+
+interface RolloutFixture {
+  stamp: string;
+  threadId: string;
+  cwd?: string;
+  originator?: string;
+  source?: unknown;
+  branch?: string;
+  userMessage?: string;
+  trailing?: string;
+}
+
+/** Write one rollout in the exact `YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl` shape. */
+function writeRollout(root: string, fixture: RolloutFixture): string {
+  const [date, time] = fixture.stamp.split("T") as [string, string];
+  const [year, month, day] = date.split("-") as [string, string, string];
+  const directory = join(root, year, month, day);
+  mkdirSync(directory, { recursive: true });
+  const path = join(directory, `rollout-${date}T${time}-${fixture.threadId}.jsonl`);
+  const lines = [
+    JSON.stringify({
+      timestamp: `${date}T${time.replace(/-/g, ":")}Z`,
+      type: "session_meta",
+      payload: {
+        session_id: fixture.threadId,
+        cwd: fixture.cwd ?? "/workspace",
+        originator: fixture.originator ?? "Codex Desktop",
+        source: fixture.source ?? "vscode",
+        git: { branch: fixture.branch ?? "main" },
+      },
+    }),
+    JSON.stringify({
+      type: "response_item",
+      payload: { type: "message", role: "developer", content: [] },
+    }),
+    ...(fixture.userMessage === undefined ? [] : [
+      JSON.stringify({
+        type: "event_msg",
+        payload: { type: "user_message", message: fixture.userMessage },
+      }),
+      JSON.stringify({
+        type: "event_msg",
+        payload: { type: "user_message", message: "a later turn that must not win" },
+      }),
+    ]),
+  ];
+  writeFileSync(path, `${lines.join("\n")}\n${fixture.trailing ?? ""}`);
+  return path;
+}
+
+describe("codex rollout session discovery", () => {
+  test("the thread id is the UUID in the rollout file name", () => {
+    expect(
+      parseCodexRolloutFileName(
+        "rollout-2026-08-20T18-13-35-01a01e72-8187-7d63-8e4d-9a1a9daa5451.jsonl",
+      ),
+    ).toEqual({
+      threadId: "01a01e72-8187-7d63-8e4d-9a1a9daa5451",
+      startedAt: new Date(2026, 7, 20, 18, 13, 35).getTime(),
+      startedAtLabel: "2026-08-20T18-13-35",
+    });
+    expect(parseCodexRolloutFileName("rollout-2026-08-20T18-13-35-not-a-uuid.jsonl")).toBeNull();
+    expect(parseCodexRolloutFileName("notes.jsonl")).toBeNull();
+    expect(isCodexThreadId("01a01e72-8187-7d63-8e4d-9a1a9daa5451")).toBe(true);
+    expect(isCodexThreadId("01a01e72")).toBe(false);
+    expect(isCodexThreadId("../../etc/passwd")).toBe(false);
+  });
+
+  test("$CODEX_HOME selects the sessions root", () => {
+    expect(codexSessionsRoot({ CODEX_HOME: "/opt/codex" }, "/home/leo"))
+      .toBe("/opt/codex/sessions");
+    expect(codexSessionsRoot({}, "/home/leo")).toBe("/home/leo/.codex/sessions");
+  });
+
+  test("rollouts are enumerated newest-first across the date tree", () => {
+    const root = tempDir();
+    writeRollout(root, { stamp: "2026-08-19T09-00-00", threadId: "aaaaaaaa-0000-4000-8000-000000000001" });
+    writeRollout(root, { stamp: "2026-08-20T18-13-35", threadId: "aaaaaaaa-0000-4000-8000-000000000002" });
+    writeRollout(root, { stamp: "2026-07-01T23-59-59", threadId: "aaaaaaaa-0000-4000-8000-000000000003" });
+    mkdirSync(join(root, "notes"), { recursive: true });
+    expect(listCodexRolloutFiles(root).map((file) => file.threadId)).toEqual([
+      "aaaaaaaa-0000-4000-8000-000000000002",
+      "aaaaaaaa-0000-4000-8000-000000000001",
+      "aaaaaaaa-0000-4000-8000-000000000003",
+    ]);
+    expect(listCodexRolloutFiles(join(root, "missing"))).toEqual([]);
+  });
+
+  test("the head yields cwd, originator, branch, and the first human turn", () => {
+    const root = tempDir();
+    writeRollout(root, {
+      stamp: "2026-08-20T18-13-35",
+      threadId: "bbbbbbbb-0000-4000-8000-000000000001",
+      cwd: "/Users/leo/github.com/agentparty",
+      originator: "Codex Desktop",
+      source: "vscode",
+      branch: "feat/887",
+      userMessage: "wake the session I am looking at",
+    });
+    const [session] = listCodexSessions(root);
+    expect(session).toMatchObject({
+      threadId: "bbbbbbbb-0000-4000-8000-000000000001",
+      cwd: "/Users/leo/github.com/agentparty",
+      originator: "Codex Desktop",
+      source: "vscode",
+      branch: "feat/887",
+      summary: "wake the session I am looking at",
+    });
+    expect(formatCodexSessionLine(session!)).toContain("bbbbbbbb-0000-4000-8000-000000000001");
+    expect(formatCodexSessionLine(session!)).toContain("2026-08-20 18:13:35");
+    expect(formatCodexSessionLine(session!)).toContain("@feat/887");
+    expect(formatCodexSessionLine(session!)).toContain("wake the session I am looking at");
+  });
+
+  test("a subagent source object is not rendered as a description", () => {
+    const root = tempDir();
+    writeRollout(root, {
+      stamp: "2026-08-20T18-13-35",
+      threadId: "bbbbbbbb-0000-4000-8000-000000000002",
+      source: { subagent: "review" },
+    });
+    expect(listCodexSessions(root)[0]?.source).toBeNull();
+  });
+
+  test("a head cut mid-line is tolerated and never yields a partial record", () => {
+    const head = `${JSON.stringify({
+      type: "session_meta",
+      payload: { cwd: "/workspace", originator: "Codex Desktop", source: "vscode" },
+    })}\n{"type":"event_msg","payload":{"type":"user_m`;
+    expect(summarizeCodexRolloutHead(head)).toEqual({
+      cwd: "/workspace",
+      originator: "Codex Desktop",
+      source: "vscode",
+      branch: null,
+      summary: null,
+    });
+  });
+
+  test("a rollout whose head is larger than the read window still lists", () => {
+    const root = tempDir();
+    writeRollout(root, {
+      stamp: "2026-08-20T18-13-35",
+      threadId: "cccccccc-0000-4000-8000-000000000001",
+      userMessage: "visible turn",
+      trailing: `${JSON.stringify({ type: "event_msg", payload: { type: "token_count", pad: "x".repeat(4096) } })}\n`,
+    });
+    const [session] = listCodexSessions(root, { headBytes: 64 });
+    expect(session?.threadId).toBe("cccccccc-0000-4000-8000-000000000001");
+    expect(session?.summary).toBeNull();
+    expect(listCodexSessions(root)[0]?.summary).toBe("visible turn");
+  });
+
+  test("--resume-last picks the newest rollout and honours a cwd filter", () => {
+    const root = tempDir();
+    writeRollout(root, {
+      stamp: "2026-08-20T10-00-00",
+      threadId: "dddddddd-0000-4000-8000-000000000001",
+      cwd: "/other",
+    });
+    writeRollout(root, {
+      stamp: "2026-08-20T18-13-35",
+      threadId: "dddddddd-0000-4000-8000-000000000002",
+      cwd: "/workspace",
+    });
+    expect(latestCodexSession(root)?.threadId).toBe("dddddddd-0000-4000-8000-000000000002");
+    expect(latestCodexSession(root, { cwd: "/other" })?.threadId)
+      .toBe("dddddddd-0000-4000-8000-000000000001");
+    expect(latestCodexSession(tempDir())).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #887

## 问题

`party bridge codex` 每次都 `buildCodexTuiArgs`（新开线程），而 owner 关心的是他在 Codex GUI 里正盯着的那个会话。resume 能力（`buildCodexTuiResumeArgs` :147、`superviseCodexTui` 的 `initialThreadId` 分叉 :521）早就在代码里，只是 CLI 没有任何参数能把 threadId 传进去。

## 最终参数形态

```
party bridge codex [channel|--channel C] [--codex-bin PATH] [--resume THREAD_ID|--resume-last] [-- <codex args...>]
party bridge codex --list-sessions
```

- `--resume <threadId>` → 接已有的 `initialThreadId` 分叉；先校验成 UUID 形态才下传
- `--resume-last` → 取 `$CODEX_HOME/sessions`（默认 `~/.codex/sessions`）下最近一条 rollout
- `--list-sessions` → 不需要 channel、不启动 Codex，列出可 resume 的线程
- 三个都只对 `codex` 生效；`--resume` 与 `--resume-last` 互斥；`--list-sessions` 不接受 `--` 后的 Codex 参数

`--resume` 与 `--codex-bin`、`-- <codex args>` 的组合按原样传递：resume 分支仍走既有的 `replayableCodexArgs` 过滤（`-i/--image` 与位置 prompt 不重放），未改动那段逻辑。

## threadId 的发现方式

以真实文件结构为准（读了本机若干 rollout 确认，未推断）：会话落在 `~/.codex/sessions/YYYY/MM/DD/rollout-<local-ts>-<uuid>.jsonl`，文件名里的 UUID 即 thread id。首行 `session_meta.payload` 带 `session_id / cwd / originator / source / git.branch`；首条 `event_msg` 且 `payload.type === "user_message"` 是最早的人类发言。`--list-sessions` 就用这几项：

```
$ party bridge codex --list-sessions
Codex sessions under /Users/leo/.codex/sessions (newest first):
01a01e7a-f778-7413-beac-c0bb5fa174f9  2026-08-20 18:22:50  /Users/leo/github.com/agentparty  @codex/claude-cross-session-topology  (codex_exec/exec)
    Reply with exactly GUIVIS-887 and nothing else.
01a01e78-a24b-7c61-80e4-a78a0f52a152  2026-08-20 18:20:17  /Users/leo/github.com/agentparty  @codex/claude-cross-session-topology  (Codex Desktop/vscode)
    ReplywithexactlySEED-887andnothingelse.
```

注意 `source` 有时是对象（subagent 场景），已按非字符串处理成 null，不会把 JSON 塞进输出。

## GUI 侧可见性 —— 真机实测结论（不是推断）

在本机 Codex 桌面端（ChatGPT.app / Codex，CLI 0.148.0-alpha.15）新建了一个会话 `01a01e78-a24b-7c61-80e4-a78a0f52a152`（GUI 里发出 `SEED-887`，rollout 已确认落盘），然后从 CLI resume 它：

```
$ codex exec resume 01a01e78-a24b-7c61-80e4-a78a0f52a152 "..."
ERROR failed to initialize thread persistence: thread-store conflict:
  thread 01a01e78-... already has an active writer
Error: thread/resume: thread/resume failed: thread 01a01e78-... already has an active writer (code -32600)
```

对照组：resume 一个进程已退出的旧线程（`019ff484-...`）**成功**，模型正常回了 `MARKER-887-CLI`。

**结论：GUI 侧能不能实时刷新这个问题不成立——Codex 每个线程只允许一个 active writer，GUI 开着那个线程时根本 resume 不进去。** 在 GUI 里切到「新对话」后重试仍然被拒（那个窗口还持有线程），必须关掉持有它的窗口/进程。所以 owner 场景的正确操作是：先在 Codex 桌面端关掉那个会话，再 `party bridge codex <channel> --resume <id>`；resume 后的这一轮跑在 bridge 自己的终端 TUI 里。

这条被写进了三处输出，用户不会再盯着界面空等：
- `bridge --help` 的 codex 段
- `--list-sessions` 结尾与 `--resume` 启动时打印的 `CODEX_RESUME_VISIBILITY_NOTICE`
- `thread/resume` 真撞上 writer 冲突时的 `codexActiveWriterConflictMessage`（原来只会抛裸 RPC 错误）

「GUI 重新打开该线程后能否看到 bridge 写的轮次」没有实测通过，因此代码与文档里**没有**做这个断言。

## 额外的安全阀

显式 `--resume` 与恢复日志里未结清的欠账线程不一致时，拒绝启动（返回 1），而不是静默把欠账搁浅在另一个线程上。

## 变异验证

先拆掉每处修复确认断言真变红，再做等价实现替换确认不误红。用的是整段删除级变异，不是改词。

| # | 变异（整段删除/置换） | 结果 |
|---|---|---|
| M1 | 删掉 `bridge.ts` 里传给 runCodexBridge 的 `initialThreadId:` 整行 | 🔴 3 fail（`--resume` / `--resume-last` / 新开回归） |
| M2 | 删掉 `superviseCodexTui` 的 `initialThreadId` 三元分支，恒 `buildCodexTuiArgs` | 🔴 2 fail（含既有的 journal 精确线程亲和测试） |
| M3 | 删掉显式 resume 与恢复欠账的冲突守卫整段 | 🔴 1 fail（欠账搁浅测试） |
| M4 | 删掉 `listCodexRolloutFiles` 的 newest-first 排序整段 | 🔴 1 fail（跨日期树的排序测试） |
| M5 | **守卫变异**：`isCodexThreadId` 置为 `value.length > 0`（校验形同虚设） | 🔴 2 fail |
| M6a | **守卫变异**：`isCodexActiveWriterConflict` → `return false`（漏检） | 🔴 1 fail |
| M6b | **守卫变异**：→ `return true`（误检） | 🔴 1 fail |
| M6c | **守卫变异**：→ 只匹配 `"active writer conflict"`，故意错过真实报文（这正是 #884 的子串假阴性形态） | 🔴 1 fail |
| E1 | 等价替换：`isCodexThreadId` 改成按 `-` 分段逐段校验长度+hex；排序改成纯字典序比较；冲突判定改成单个正则 | 🟢 43 pass / 0 fail |

顺带删掉了一行无法被变异覆盖的冗余防御（`summarizeCodexRolloutHead` 里显式 pop 截断行）——截断行本来就不是合法 JSON，会被 parse guard 跳过，留着只是无法验证的死重复。

## 测试

- 新增 `cli/test/codex-sessions.test.ts`（8 tests）：文件名→thread id、`$CODEX_HOME` 解析、跨日期树 newest-first、head 字段抽取、subagent `source` 对象不外泄、head 读窗口截断容错、`--resume-last` + cwd 过滤。fixture 全部用临时目录构造，不依赖本机真实会话。
- 新增 `cli/test/codex-bridge-resume.test.ts`（9 tests）：`--resume` 与 `-- <codex args>` 组合传参、`--resume-last` 解析、无参数走新开分支（回归）、非法/空输入拒绝、互斥、claude 侧拒绝三个 codex-only flag、`--list-sessions` 输出可解析且不启动 Codex、欠账冲突拒启、writer 冲突判定与提示文案。
- `cd cli && bun test`：**1891 pass / 0 fail**（132 files）
- `cd cli && bunx tsc --noEmit`：clean

未触碰 announce/注入链；未对「codex 零常驻唤醒」做任何承诺。
