### PR TITLE
feat(codex): 用 Stop hook 在用户眼前那个会话里唤醒（#899）

### DIFF
--- a/cli/src/codex-stop-wake.ts
+++ b/cli/src/codex-stop-wake.ts
@@ -1,0 +1,191 @@
+// codex 前台唤醒层（issue #899）——在**用户眼前那个会话**里唤醒，不是后台新 runner。
+//
+// 为什么要有这一层（#897 的方向纠正）：#893 的自动唤醒层确实能把 @ 接住，但它拉起的是
+// `party serve --runner codex` 下的一个**新 runner 会话**。owner 原话：「从头到尾没出现过
+// 我们的通讯记录」——消息没丢，但他在自己的界面里什么也看不见。
+//
+// 突破口：codex 的 Stop hook 可以 block 并让会话**继续跑一轮**。turn 结束时判断该身份在
+// 频道上有没有还没处理的 @，有就 block，把一条 ≤512B 的 channel+seq 指针交回给会话——
+// 正文仍然去频道读，「频道是唯一数据源」不因这条提示而破。
+//
+// ⚠️ 契约以本机 codex 0.145.0 **实测**为准，不是从二进制字符串反推的（#899 issue 正文里
+// 那份反推契约有两处是错的，照抄会静默失效）：
+//
+//   ① `stop.command.output` 的 JSON Schema 是 `additionalProperties: false`，字段只有
+//      `continue / decision / reason / stopReason / suppressOutput / systemMessage`——
+//      **没有 `prompt`**。实测多带一个 `prompt` 字段，codex 直接判 `hook: Stop Failed`，
+//      整个输出被丢弃、block 不生效、会话照常停止。注入用的 prompt 就是 `reason` 本身。
+//   ② `stop.command.input` 的字段是
+//      `cwd / hook_event_name / last_assistant_message / model / permission_mode /
+//       session_id / stop_hook_active / transcript_path / turn_id`——
+//      没有 `agent_id / agent_type / agent_transcript_path / reason`（那几个是 SubagentStop）。
+//
+// 实测确认的两条行为（决定了下面的防循环设计）：
+//   - `{"decision":"block","reason":"…"}` 让会话继续跑一轮，模型把 `reason` 当 prompt 执行；
+//   - **codex 自己不封顶**：连续 4 次无条件 block，它就老老实实跑了 4 轮。
+//     `stop_hook_active` 从第 2 次起恒为 true，但 codex **不会**因此拒绝 block。
+//     ⇒ 防循环 100% 是我们的责任，漏一层就是「会话永远停不下来」。
+//
+// 三道防循环闸（任意一道成立就放行，放行＝不 block、让会话正常停止）：
+//   1. `stop_hook_active === true` → 放行。这把每个用户 turn 的注入次数硬顶在 1 次。
+//   2. 同一 seq 只注入一次，seen 集合**落盘**——Stop hook 每轮是一个全新进程，内存集合等于没有。
+//   3. 任何一步取不到信号/抛异常 → 放行。hook 铁律优先于唤醒。
+//
+// 预算（本机 hooks.json 实测 timeout=10）：本模块**全程零网络**，只做同步读盘。
+// 唯一的信号源是 serve/watch 已经落在本地的欠账（StuckWake），网络那一跳早就由它们付过了。
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { atomicWriteJson } from "./atomic-json";
+import type { StuckWake } from "./config";
+
+/** seen 集合的落盘目录，与 #893 的 marker 目录并列。 */
+export const CODEX_STOP_WAKE_SEEN_DIR = "codex-stop-wake";
+/** 每个身份+频道最多记住多少个已注入过的 seq。有界，绝不无限长。 */
+export const CODEX_STOP_WAKE_SEEN_CAPACITY = 64;
+/** 注入正文的硬上限——和 #841 的唤醒通知同一预算。 */
+export const CODEX_STOP_WAKE_REASON_MAX_BYTES = 512;
+/**
+ * 超过这个岁数的欠账不再叫醒任何人（与 watch 的 WATCH_WAKE_DEBT_MAX_AGE_MS 同义）：
+ * 几天前早就在别处处理过的 @，不该在用户今天的会话里跳出来。
+ */
+export const CODEX_STOP_WAKE_DEBT_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+/** 交回给会话的指针：只有 channel+seq，正文永远去频道读。 */
+export interface CodexStopWakePointer {
+  channel: string;
+  seq: number;
+}
+
+export function codexStopWakeSeenPath(home: string, target: string): string {
+  return join(home, CODEX_STOP_WAKE_SEEN_DIR, `${target.replace(/[^a-zA-Z0-9._-]/g, "_")}.json`);
+}
+
+/** 读已注入过的 seq 集合。文件坏了/不存在都当空集——读不到只会多注入一次，不会卡死会话。 */
+export function readCodexStopWakeSeen(path: string): number[] {
+  try {
+    const value = JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
+    if (typeof value !== "object" || value === null || Array.isArray(value)) return [];
+    const seqs = value.seqs;
+    if (!Array.isArray(seqs)) return [];
+    return seqs.filter((seq): seq is number =>
+      typeof seq === "number" && Number.isFinite(seq) && seq > 0
+    );
+  } catch {
+    return [];
+  }
+}
+
+export function hasCodexStopWakeSeen(seen: readonly number[], seq: number): boolean {
+  return seen.includes(seq);
+}
+
+/** 追加一个已注入的 seq 并截断到容量上限（保留最新的 N 个）。纯函数，便于单测。 */
+export function appendCodexStopWakeSeen(
+  seen: readonly number[],
+  seq: number,
+  capacity: number = CODEX_STOP_WAKE_SEEN_CAPACITY,
+): number[] {
+  const next = seen.includes(seq) ? [...seen] : [...seen, seq];
+  return next.length <= capacity ? next : next.slice(next.length - capacity);
+}
+
+/**
+ * 落盘「这条 seq 我注入过了」。**必须在打印 block 之前调用**：
+ * 先打印再落盘的话，中间崩一次就会对同一条 @ 反复注入。
+ */
+export function recordCodexStopWakeSeen(
+  path: string,
+  seq: number,
+  capacity: number = CODEX_STOP_WAKE_SEEN_CAPACITY,
+): void {
+  atomicWriteJson(path, {
+    version: 1,
+    seqs: appendCodexStopWakeSeen(readCodexStopWakeSeen(path), seq, capacity),
+  });
+}
+
+function clampUtf8(text: string, maxBytes: number): string {
+  if (Buffer.byteLength(text, "utf8") <= maxBytes) return text;
+  let out = text;
+  while (out.length > 0 && Buffer.byteLength(out, "utf8") > maxBytes) {
+    out = out.slice(0, -1);
+  }
+  return out;
+}
+
+/**
+ * block 时交回会话的 `reason`——它同时是给用户看的说明**和**注入给模型的 prompt
+ * （契约只有这一个字段，见文件头 ①）。所以措辞要同时满足两件事：
+ *   - 用户一眼看出是 AgentParty 在唤醒他，而不是模型自己不肯停；
+ *   - 模型知道正文要去频道读，不许照着这条提示编内容。
+ */
+export function codexStopWakeReason(pointer: CodexStopWakePointer): string {
+  return clampUtf8(
+    `[AgentParty] 频道 #${pointer.channel} 有一条 @ 你的消息还没处理（seq ${pointer.seq}）。` +
+      `请先执行 \`party history ${pointer.channel} --since ${Math.max(0, pointer.seq - 1)}\` 读到正文，` +
+      `再按正文内容处理并用 \`party send\` 回到该频道。` +
+      `频道是唯一数据源：这条提示只给了指针，不要凭它猜测消息内容。处理完正常结束本轮即可。`,
+    CODEX_STOP_WAKE_REASON_MAX_BYTES,
+  );
+}
+
+export type CodexStopWakeSkip =
+  | "not_stop"
+  | "continuation"
+  | "disabled"
+  | "no_channel"
+  | "no_pending"
+  | "stale_debt"
+  | "already_woken";
+
+export type CodexStopWakeDecision =
+  | { wake: false; skip: CodexStopWakeSkip }
+  | { wake: true; pointer: CodexStopWakePointer };
+
+export interface CodexStopWakeInput {
+  /** codex 递进来的原始 Stop payload。 */
+  payload: Record<string, unknown>;
+  /** 本 cwd 绑定的频道；没绑定为 null。 */
+  channel: string | null;
+  /** #893 的开关：显式 off 时前台这层也一起关（同一个「别自动打扰我」的意思）。 */
+  enabled: boolean;
+  /** serve/watch 落在本地的欠账；没有为 null。 */
+  stuck: Pick<StuckWake, "seq" | "first_wake_ts"> | null;
+  /** 本频道游标：说到哪条为止已经了结了。 */
+  cursor: number;
+  /** 已注入过的 seq 集合。 */
+  seen: readonly number[];
+  now: number;
+}
+
+/**
+ * 纯判定：这一次 Stop 该不该 block。
+ *
+ * 顺序即优先级——最便宜、最致命的闸放在最前面。`stop_hook_active` 尤其不能后移：
+ * 它是唯一能保证「一个用户 turn 最多注入一次」的硬顶（实测 codex 自己不封顶）。
+ */
+export function decideCodexStopWake(input: CodexStopWakeInput): CodexStopWakeDecision {
+  const { payload } = input;
+  if (payload.hook_event_name !== "Stop") return { wake: false, skip: "not_stop" };
+  // 防循环第 1 闸。注意只认严格的 `false`：字段缺失/类型不对一律当「可能是续跑」放行，
+  // 宁可漏叫一次，也绝不冒「会话永远停不下来」的险。
+  if (payload.stop_hook_active !== false) return { wake: false, skip: "continuation" };
+  if (!input.enabled) return { wake: false, skip: "disabled" };
+  if (input.channel === null || input.channel === "") return { wake: false, skip: "no_channel" };
+  const stuck = input.stuck;
+  if (stuck === null || !Number.isFinite(stuck.seq) || stuck.seq <= 0) {
+    return { wake: false, skip: "no_pending" };
+  }
+  // 游标说「这条我已经了结了」——了结过的不再叫。
+  if (stuck.seq <= input.cursor) return { wake: false, skip: "no_pending" };
+  if (
+    typeof stuck.first_wake_ts === "number" &&
+    Number.isFinite(stuck.first_wake_ts) &&
+    input.now - stuck.first_wake_ts > CODEX_STOP_WAKE_DEBT_MAX_AGE_MS
+  ) {
+    return { wake: false, skip: "stale_debt" };
+  }
+  // 防循环第 2 闸：同一条 @ 只注入一次。seen 是落盘的，跨进程有效。
+  if (hasCodexStopWakeSeen(input.seen, stuck.seq)) return { wake: false, skip: "already_woken" };
+  return { wake: true, pointer: { channel: input.channel, seq: stuck.seq } };
+}

--- a/cli/src/commands/hook.ts
+++ b/cli/src/commands/hook.ts
@@ -18,7 +18,14 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { AGENT_ACTIVITY_TTL_MS, type AgentActivity } from "@agentparty/shared";
 import { activityFromHookEvent, readActivityFile, writeActivityFile } from "../activity";
-import { agentpartyHome, readConfig, readState } from "../config";
+import { agentpartyHome, loadCursor, loadStuck, readConfig, readState, type StuckWake } from "../config";
+import {
+  codexStopWakeReason,
+  codexStopWakeSeenPath,
+  decideCodexStopWake,
+  readCodexStopWakeSeen,
+  recordCodexStopWakeSeen,
+} from "../codex-stop-wake";
 import {
   DeliveryRecoveryJournal,
   deliveryRecoveryJournalPath,
@@ -60,7 +67,7 @@ import { isPartyBinaryPath } from "../upgrade";
 import { CLAUDE_LIFECYCLE_OPT_IN_ENV } from "./claude-launch";
 import type { ServeSupervisorOptions } from "./serve";
 
-const HELP = `usage: party hook <report|codex-report|codex-autowake|stop-guard|push|install|uninstall|status>
+const HELP = `usage: party hook <report|codex-report|codex-stop|codex-autowake|stop-guard|push|install|uninstall|status>
 
 Claude Code hook adapter (issues #602/#615): report what the model session is
 actually doing (running a tool / waiting on permission / compacting / idle)
@@ -82,6 +89,17 @@ into channel presence, so \`party who\` and the web can see it.
                        ~/.agentparty/codex-sessions/ so party can discover it.
                        Registry only — never presence, never network. It also
                        starts the wake layer unless auto-wake is turned off (#893).
+  codex-stop           (wired by \`install --codex\`) codex Stop hook (#899): at the
+                       end of a turn, if this identity still has an unhandled @ on
+                       its channel, block that one stop and hand the session a
+                       ≤512B channel+seq pointer, so the wake happens **in the
+                       session the user is looking at** instead of a new background
+                       runner (#893). The channel stays the only source of truth:
+                       the pointer carries no message body.
+                       Loop safety is entirely ours — codex honours repeated blocks
+                       without any cap of its own. Three gates, any one of which
+                       lets the stop through: stop_hook_active, a persisted
+                       per-seq seen set, and fail-open on every error.
   codex-autowake [status|on|off]
                        codex has no MCP sampling and declines idle elicitation
                        (#893), so it can only be reached by a local wake layer.
@@ -311,7 +329,12 @@ async function runPush(argv: string[]): Promise<number> {
 
 // ---- hooks 安装（#615）----
 
-const HOOK_COMMAND_MARKERS = ["hook report", "hook stop-guard", "hook codex-report"] as const;
+const HOOK_COMMAND_MARKERS = [
+  "hook report",
+  "hook stop-guard",
+  "hook codex-report",
+  "hook codex-stop",
+] as const;
 
 interface HookEntry {
   matcher?: string;
@@ -358,13 +381,25 @@ export function settingsPath(scope: HookScope, cwd: string = process.cwd()): str
  * 「只增删自己的命令、解析失败即抛错拒写」的保护。
  *
  * codex 只有 SessionStart 可用于入册：其内嵌 schema 没有任何会话结束事件。
+ * （#899 复核：二进制里那 10 个 hook 事件 `pre-tool-use / permission-request /
+ * post-tool-use / pre-compact / post-compact / session-start / user-prompt-submit /
+ * subagent-start / subagent-stop / stop` 确实不含 SessionEnd——#877 的结论是对的。
+ * 二进制里另有的 `SessionEnd` 字符串属于 realtime 会话 API，不是 hook 事件。）
+ *
+ * Stop 则用于前台唤醒（#899）：turn 结束时把还没处理的 @ 以 channel+seq 指针的形式
+ * block 回**用户眼前那个会话**，而不是像 #893 那样另起一个后台 runner。
  */
 export function codexHookSettingsJson(execPath: string = process.execPath): string {
   const partyBin = isPartyBinaryPath(execPath) ? execPath : "party";
-  const command = `${partyBin === "party" ? partyBin : JSON.stringify(partyBin)} hook codex-report`;
+  const bin = partyBin === "party" ? partyBin : JSON.stringify(partyBin);
   return JSON.stringify({
     hooks: {
-      SessionStart: [{ hooks: [{ type: "command", command, timeout: 10 }] }],
+      SessionStart: [{
+        hooks: [{ type: "command", command: `${bin} hook codex-report`, timeout: 10 }],
+      }],
+      Stop: [{
+        hooks: [{ type: "command", command: `${bin} hook codex-stop`, timeout: 10 }],
+      }],
     },
   });
 }
@@ -794,6 +829,111 @@ export function handleCodexHookRecord(
   }
 }
 
+/** `party hook codex-stop` 的可注入依赖——全部同步读盘，测试直接塞假值，不碰真盘也不碰网。 */
+export interface CodexStopWakeDeps {
+  /** 本 cwd 绑定的频道。 */
+  channel: (cwd: string) => string | null;
+  /** 前台唤醒是否启用（沿用 #893 的 codex-autowake 开关）。 */
+  enabled: () => boolean;
+  /** serve/watch 落在本地的欠账。 */
+  stuck: (channel: string, cwd: string) => Pick<StuckWake, "seq" | "first_wake_ts"> | null;
+  cursor: (channel: string, cwd: string) => number;
+  /** 已注入过的 seq 集合的落盘路径；拿不到身份时返回 null（→ 无法去重，必须放行）。 */
+  seenPath: (channel: string, cwd: string) => string | null;
+  readSeen: (path: string) => number[];
+  recordSeen: (path: string, seq: number) => void;
+  emit: (line: string) => void;
+  log: (line: string) => void;
+  now: () => number;
+}
+
+export function defaultCodexStopWakeDeps(env: NodeJS.ProcessEnv = process.env): CodexStopWakeDeps {
+  const home = agentpartyHome(env);
+  const target = (channel: string, cwd: string): string | null => {
+    const auth = codexAutoWakeAuth(readConfig(cwd));
+    return auth === null ? null : codexAutoWakeTarget(auth, channel);
+  };
+  return {
+    channel: (cwd) => env.AGENTPARTY_CHANNEL ?? readState(cwd)?.channel ?? null,
+    enabled: () => resolveCodexAutoWakeMode(env, home).mode !== "off",
+    stuck: (channel, cwd) => loadStuck(channel, cwd),
+    cursor: (channel, cwd) => loadCursor(channel, cwd),
+    seenPath: (channel, cwd) => {
+      const resolved = target(channel, cwd);
+      return resolved === null ? null : codexStopWakeSeenPath(home, resolved);
+    },
+    readSeen: readCodexStopWakeSeen,
+    recordSeen: recordCodexStopWakeSeen,
+    emit: (line) => console.log(line),
+    log: (line) => appendCodexAutoWakeLog(home, line),
+    now: () => Date.now(),
+  };
+}
+
+/**
+ * 一条 codex Stop 事件的全部处理（#899）。
+ *
+ * 唯一允许写 stdout 的路径就是最后那一行 block JSON——契约要求 `decision:"block"` 必须
+ * 配一个非空 `reason`，而 `reason` 同时就是注入给模型的 prompt（**没有 `prompt` 字段**，
+ * 多带一个会让 codex 整份输出作废，见 codex-stop-wake.ts 文件头）。
+ *
+ * 放行（不写任何 stdout）是所有异常路径的统一归宿：拿不到身份、读盘炸了、判定说不该叫——
+ * 一律安静让会话正常停止。宁可漏叫一次，也绝不把用户的会话卡在无限续跑里。
+ */
+export function handleCodexStopRecord(
+  record: Record<string, unknown>,
+  env: NodeJS.ProcessEnv = process.env,
+  injected?: CodexStopWakeDeps,
+): void {
+  const deps = injected ?? defaultCodexStopWakeDeps(env);
+  // serve 托管 lane 是被管理的 runner 会话，不是用户眼前那个终端会话——前台唤醒对它没有意义，
+  // 而且它自己就是 #893 那条后台通道，在这里再 block 一次等于同一条 @ 被两边各处理一次。
+  if (env.AP_ACTIVITY_FILE) return;
+  if (record.hook_event_name !== "Stop") return;
+  const cwd = typeof record.cwd === "string" && record.cwd.length > 0 ? record.cwd : process.cwd();
+  const channel = deps.channel(cwd);
+  const decision = decideCodexStopWake({
+    payload: record,
+    channel,
+    enabled: deps.enabled(),
+    stuck: channel === null ? null : deps.stuck(channel, cwd),
+    cursor: channel === null ? 0 : deps.cursor(channel, cwd),
+    seen: channel === null ? [] : (() => {
+      const path = deps.seenPath(channel, cwd);
+      return path === null ? [] : deps.readSeen(path);
+    })(),
+    now: deps.now(),
+  });
+  if (!decision.wake) return;
+  const seenPath = deps.seenPath(decision.pointer.channel, cwd);
+  // 去不了重就绝不注入：没有落盘的 seen 集合，同一条 @ 会在每个 turn 结束时反复 block。
+  if (seenPath === null) {
+    deps.log("codex-stop: 拿不到身份（config 里没有 agent token），无法去重，本次放行不注入");
+    return;
+  }
+  // 先落盘再打印。反过来的话，打印后崩一次就会对同一条 @ 反复注入。
+  deps.recordSeen(seenPath, decision.pointer.seq);
+  deps.emit(JSON.stringify({
+    decision: "block",
+    reason: codexStopWakeReason(decision.pointer),
+  }));
+  deps.log(
+    `codex-stop: 在当前 codex 会话里注入了 #${decision.pointer.channel} seq ${decision.pointer.seq} 的指针`,
+  );
+}
+
+/** `party hook codex-stop`：读一条 codex Stop 事件，必要时 block 一次让会话继续跑一轮。 */
+async function runCodexStopHookInput(): Promise<number> {
+  try {
+    const payload = JSON.parse(await readStdin(MAX_STDIN_BYTES)) as unknown;
+    if (typeof payload !== "object" || payload === null || Array.isArray(payload)) return 0;
+    handleCodexStopRecord(payload as Record<string, unknown>);
+  } catch {
+    // hook 铁律高于唤醒：坏 JSON / 读盘失败 / 任何意外，一律安静放行让会话正常停止。
+  }
+  return 0;
+}
+
 /** `party hook codex-report`：读一条 codex hook 事件，入册 + 按配置拉起唤醒层。stdout 恒空。 */
 async function runCodexHookInput(): Promise<number> {
   try {
@@ -1082,6 +1222,7 @@ export async function run(argv: string[]): Promise<number> {
   if (sub === "status") return runStatus(rest);
   if (sub === "push") return runPush(rest);
   if (sub === "codex-report") return runCodexHookInput();
+  if (sub === "codex-stop") return runCodexStopHookInput();
   if (sub === "codex-autowake") return runCodexAutoWakeCommand(rest);
   if (sub !== "report" && sub !== "stop-guard") {
     // 会写 stderr 的分支只剩人在终端敲错子命令。真 hook 调用恒为 `hook report`，不受影响。

--- a/cli/test/codex-stop-wake.test.ts
+++ b/cli/test/codex-stop-wake.test.ts
@@ -1,0 +1,451 @@
+// #899：codex Stop hook 前台唤醒——在用户眼前那个会话里 block 一轮，不是后台新 runner。
+//
+// 样本形态取自本机 codex 0.145.0 的**真机** Stop payload（`codex exec` + 临时 CODEX_HOME
+// 注册 Stop hook 抓下来的原样 JSON），而不是从二进制反推的字段表。真机字段只有：
+//   cwd / hook_event_name / last_assistant_message / model / permission_mode /
+//   session_id / stop_hook_active / transcript_path / turn_id
+// 注意没有 agent_id / agent_type / prompt——反推版把 SubagentStop 的字段混了进来。
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  CODEX_STOP_WAKE_DEBT_MAX_AGE_MS,
+  CODEX_STOP_WAKE_REASON_MAX_BYTES,
+  appendCodexStopWakeSeen,
+  codexStopWakeReason,
+  codexStopWakeSeenPath,
+  decideCodexStopWake,
+  hasCodexStopWakeSeen,
+  readCodexStopWakeSeen,
+  recordCodexStopWakeSeen,
+  type CodexStopWakeInput,
+} from "../src/codex-stop-wake";
+import {
+  codexHookSettingsJson,
+  handleCodexStopRecord,
+  mergeHookSettings,
+  removeHookSettings,
+  type CodexStopWakeDeps,
+} from "../src/commands/hook";
+
+const NOW = 1_700_000_000_000;
+
+/** 真机 Stop payload（字段与顺序原样保留）。 */
+function stopPayload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    cwd: "/tmp/work",
+    hook_event_name: "Stop",
+    last_assistant_message: "HELLO-ONE",
+    model: "gpt-5.6-sol",
+    permission_mode: "default",
+    session_id: "01a021f5-aed7-7802-bea3-6165e5dba553",
+    stop_hook_active: false,
+    transcript_path: "/tmp/rollout.jsonl",
+    turn_id: "01a021f5-c1d5-7cb0-b1f7-61eba78f9af6",
+    ...overrides,
+  };
+}
+
+function decideInput(overrides: Partial<CodexStopWakeInput> = {}): CodexStopWakeInput {
+  return {
+    payload: stopPayload(),
+    channel: "pwtk",
+    enabled: true,
+    stuck: { seq: 42, first_wake_ts: NOW - 1_000 },
+    cursor: 7,
+    seen: [],
+    now: NOW,
+    ...overrides,
+  };
+}
+
+describe("decideCodexStopWake", () => {
+  test("有未处理的 @ → block，指针带 channel+seq", () => {
+    expect(decideCodexStopWake(decideInput())).toEqual({
+      wake: true,
+      pointer: { channel: "pwtk", seq: 42 },
+    });
+  });
+
+  test("没有欠账 → 放行", () => {
+    expect(decideCodexStopWake(decideInput({ stuck: null }))).toEqual({
+      wake: false,
+      skip: "no_pending",
+    });
+  });
+
+  // 防循环第 1 闸。codex 实测不会自己封顶：连续 4 次无条件 block 它就跑了 4 轮，
+  // 所以这一条挂了就是「会话永远停不下来」。
+  test("stop_hook_active 为真（续跑轮）→ 放行", () => {
+    expect(
+      decideCodexStopWake(decideInput({ payload: stopPayload({ stop_hook_active: true }) })),
+    ).toEqual({ wake: false, skip: "continuation" });
+  });
+
+  test("stop_hook_active 缺失或类型不对 → 一律当续跑放行（宁可漏叫，不冒死循环）", () => {
+    for (const value of [undefined, null, "false", 0, 1]) {
+      const payload = stopPayload();
+      if (value === undefined) delete payload.stop_hook_active;
+      else payload.stop_hook_active = value;
+      expect(decideCodexStopWake(decideInput({ payload }))).toEqual({
+        wake: false,
+        skip: "continuation",
+      });
+    }
+  });
+
+  // 防循环第 2 闸：同一条 seq 只注入一次。
+  test("同一 seq 已注入过 → 放行", () => {
+    expect(decideCodexStopWake(decideInput({ seen: [42] }))).toEqual({
+      wake: false,
+      skip: "already_woken",
+    });
+  });
+
+  test("seen 里是别的 seq → 照常 block", () => {
+    expect(decideCodexStopWake(decideInput({ seen: [1, 2, 41, 43] })).wake).toBe(true);
+  });
+
+  test("游标已越过该 seq（早就了结了）→ 放行", () => {
+    expect(decideCodexStopWake(decideInput({ cursor: 42 })).wake).toBe(false);
+    expect(decideCodexStopWake(decideInput({ cursor: 99 }))).toEqual({
+      wake: false,
+      skip: "no_pending",
+    });
+    // 边界：游标差一条时仍然要叫。
+    expect(decideCodexStopWake(decideInput({ cursor: 41 })).wake).toBe(true);
+  });
+
+  test("非 Stop 事件 → 放行", () => {
+    expect(
+      decideCodexStopWake(decideInput({ payload: stopPayload({ hook_event_name: "SubagentStop" }) })),
+    ).toEqual({ wake: false, skip: "not_stop" });
+  });
+
+  test("开关 off → 放行", () => {
+    expect(decideCodexStopWake(decideInput({ enabled: false }))).toEqual({
+      wake: false,
+      skip: "disabled",
+    });
+  });
+
+  test("没绑定频道 → 放行", () => {
+    expect(decideCodexStopWake(decideInput({ channel: null })).wake).toBe(false);
+    expect(decideCodexStopWake(decideInput({ channel: "" }))).toEqual({
+      wake: false,
+      skip: "no_channel",
+    });
+  });
+
+  test("欠账过期（几天前的 @）→ 放行", () => {
+    expect(
+      decideCodexStopWake(
+        decideInput({
+          stuck: { seq: 42, first_wake_ts: NOW - CODEX_STOP_WAKE_DEBT_MAX_AGE_MS - 1 },
+        }),
+      ),
+    ).toEqual({ wake: false, skip: "stale_debt" });
+    // 刚好没到期 → 仍然叫。
+    expect(
+      decideCodexStopWake(
+        decideInput({
+          stuck: { seq: 42, first_wake_ts: NOW - CODEX_STOP_WAKE_DEBT_MAX_AGE_MS },
+        }),
+      ).wake,
+    ).toBe(true);
+    // 没有 first_wake_ts 的旧欠账不该被误判成过期。
+    expect(decideCodexStopWake(decideInput({ stuck: { seq: 42 } })).wake).toBe(true);
+  });
+
+  test("seq 非法 → 放行", () => {
+    for (const seq of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(decideCodexStopWake(decideInput({ stuck: { seq } })).wake).toBe(false);
+    }
+  });
+});
+
+describe("codexStopWakeReason", () => {
+  test("非空、带频道与 seq、点明是 AgentParty 在唤醒", () => {
+    const reason = codexStopWakeReason({ channel: "pwtk", seq: 42 });
+    expect(reason.length).toBeGreaterThan(0);
+    expect(reason).toContain("AgentParty");
+    expect(reason).toContain("pwtk");
+    expect(reason).toContain("42");
+  });
+
+  test("守住 ≤512B 预算（含长频道名）", () => {
+    for (const channel of ["a", "pwtk", "x".repeat(200), "频道".repeat(100)]) {
+      const reason = codexStopWakeReason({ channel, seq: 999_999 });
+      expect(Buffer.byteLength(reason, "utf8")).toBeLessThanOrEqual(
+        CODEX_STOP_WAKE_REASON_MAX_BYTES,
+      );
+      // 截断也绝不许截成空串——契约要求 reason 非空，空了 codex 会忽略整个 block。
+      expect(reason.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("只给指针，不给正文（频道是唯一数据源）", () => {
+    expect(codexStopWakeReason({ channel: "pwtk", seq: 42 })).toContain("party history");
+  });
+});
+
+describe("seen 集合落盘", () => {
+  let home: string;
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "ap-899-"));
+  });
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  test("写入后跨进程可读（Stop hook 每轮都是新进程，内存集合等于没有）", () => {
+    const path = codexStopWakeSeenPath(home, "srv|pwtk");
+    expect(readCodexStopWakeSeen(path)).toEqual([]);
+    recordCodexStopWakeSeen(path, 42);
+    expect(readCodexStopWakeSeen(path)).toEqual([42]);
+    recordCodexStopWakeSeen(path, 43);
+    expect(readCodexStopWakeSeen(path)).toEqual([42, 43]);
+    // 重复写同一条不该让集合增长。
+    recordCodexStopWakeSeen(path, 43);
+    expect(readCodexStopWakeSeen(path)).toEqual([42, 43]);
+  });
+
+  // 身份串里含 `/` 和 `..`，转义后必须仍是 home 下的**单个文件名**，不能变成路径。
+  test("路径把身份里的分隔符转义掉，不穿越目录", () => {
+    const dir = join(home, "codex-stop-wake");
+    const path = codexStopWakeSeenPath(home, "https://a/b|../../etc");
+    expect(path.startsWith(`${dir}/`)).toBe(true);
+    const name = path.slice(dir.length + 1);
+    expect(name).not.toContain("/");
+    expect(name).toBe("https___a_b_.._.._etc.json");
+    expect(join(dir, name)).toBe(path);
+  });
+
+  test("有界：超容量丢最旧的，保留最新的", () => {
+    expect(appendCodexStopWakeSeen([1, 2, 3], 4, 3)).toEqual([2, 3, 4]);
+    expect(appendCodexStopWakeSeen([1, 2, 3], 3, 3)).toEqual([1, 2, 3]);
+    expect(appendCodexStopWakeSeen([], 1, 3)).toEqual([1]);
+  });
+
+  test("文件坏了/不存在 → 当空集，绝不抛", () => {
+    const path = join(home, "codex-stop-wake", "broken.json");
+    expect(readCodexStopWakeSeen(path)).toEqual([]);
+    recordCodexStopWakeSeen(path, 1);
+    require("node:fs").writeFileSync(path, "{ not json");
+    expect(readCodexStopWakeSeen(path)).toEqual([]);
+    for (const bad of ["[]", "null", '{"seqs":"x"}', '{"seqs":[null,"a",-1,0,5]}']) {
+      require("node:fs").writeFileSync(path, bad);
+      expect(readCodexStopWakeSeen(path)).toEqual(bad.includes("5") ? [5] : []);
+    }
+  });
+
+  test("hasCodexStopWakeSeen", () => {
+    expect(hasCodexStopWakeSeen([1, 2], 2)).toBe(true);
+    expect(hasCodexStopWakeSeen([1, 2], 3)).toBe(false);
+    expect(hasCodexStopWakeSeen([], 1)).toBe(false);
+  });
+});
+
+describe("handleCodexStopRecord", () => {
+  let home: string;
+  let emitted: string[];
+  let logged: string[];
+  let seenStore: Map<string, number[]>;
+
+  function deps(overrides: Partial<CodexStopWakeDeps> = {}): CodexStopWakeDeps {
+    return {
+      channel: () => "pwtk",
+      enabled: () => true,
+      stuck: () => ({ seq: 42, first_wake_ts: NOW - 1_000 }),
+      cursor: () => 7,
+      seenPath: () => join(home, "seen.json"),
+      readSeen: (path) => seenStore.get(path) ?? [],
+      recordSeen: (path, seq) => {
+        seenStore.set(path, [...(seenStore.get(path) ?? []), seq]);
+      },
+      emit: (line) => emitted.push(line),
+      log: (line) => logged.push(line),
+      now: () => NOW,
+      ...overrides,
+    };
+  }
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "ap-899h-"));
+    emitted = [];
+    logged = [];
+    seenStore = new Map();
+  });
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  test("有未处理的 @ → 恰好一行 block JSON，契约字段齐全", () => {
+    handleCodexStopRecord(stopPayload(), {}, deps());
+    expect(emitted).toHaveLength(1);
+    const output = JSON.parse(emitted[0]!) as Record<string, unknown>;
+    expect(output.decision).toBe("block");
+    expect(typeof output.reason).toBe("string");
+    expect((output.reason as string).length).toBeGreaterThan(0);
+    // 实测：多带一个 `prompt` 字段会让 codex 判 `Stop Failed`、整份输出作废。
+    // stop.command.output 是 additionalProperties:false，只有这两个键是我们该发的。
+    expect(Object.keys(output).sort()).toEqual(["decision", "reason"]);
+  });
+
+  test("没有未处理的 @ → 放行，stdout 一个字都不写", () => {
+    handleCodexStopRecord(stopPayload(), {}, deps({ stuck: () => null }));
+    expect(emitted).toEqual([]);
+  });
+
+  test("续跑轮（stop_hook_active 为真）→ 放行", () => {
+    handleCodexStopRecord(stopPayload({ stop_hook_active: true }), {}, deps());
+    expect(emitted).toEqual([]);
+  });
+
+  test("同一 seq 第二次 → 放行（seen 已落盘）", () => {
+    const d = deps();
+    handleCodexStopRecord(stopPayload(), {}, d);
+    expect(emitted).toHaveLength(1);
+    handleCodexStopRecord(stopPayload(), {}, d);
+    expect(emitted).toHaveLength(1);
+  });
+
+  test("先落 seen 再打印——顺序反了，中间崩一次就会反复注入", () => {
+    const order: string[] = [];
+    handleCodexStopRecord(stopPayload(), {}, deps({
+      recordSeen: () => order.push("seen"),
+      emit: () => order.push("emit"),
+    }));
+    expect(order).toEqual(["seen", "emit"]);
+  });
+
+  test("拿不到身份（去不了重）→ 放行，绝不注入", () => {
+    handleCodexStopRecord(stopPayload(), {}, deps({ seenPath: () => null }));
+    expect(emitted).toEqual([]);
+    expect(logged.join("\n")).toContain("去重");
+  });
+
+  test("serve 托管 lane（AP_ACTIVITY_FILE）→ 放行，避免与 #893 后台通道重复处理同一条 @", () => {
+    handleCodexStopRecord(stopPayload(), { AP_ACTIVITY_FILE: "/tmp/a.json" }, deps());
+    expect(emitted).toEqual([]);
+  });
+
+  test("本地信号读取抛异常 → 不吞掉异常契约由调用方兜，但绝不写出半条 stdout", () => {
+    expect(() =>
+      handleCodexStopRecord(stopPayload(), {}, deps({
+        stuck: () => {
+          throw new Error("disk on fire");
+        },
+      })),
+    ).toThrow();
+    expect(emitted).toEqual([]);
+  });
+
+  test("非 Stop 事件 → 放行", () => {
+    handleCodexStopRecord(stopPayload({ hook_event_name: "SessionStart" }), {}, deps());
+    expect(emitted).toEqual([]);
+  });
+
+  test("payload 里的 cwd 被用来解析频道", () => {
+    const seen: string[] = [];
+    handleCodexStopRecord(stopPayload({ cwd: "/tmp/elsewhere" }), {}, deps({
+      channel: (cwd) => {
+        seen.push(cwd);
+        return "pwtk";
+      },
+    }));
+    expect(seen).toEqual(["/tmp/elsewhere"]);
+  });
+});
+
+describe("codexHookSettingsJson", () => {
+  test("同时装 SessionStart（入册/#893）与 Stop（前台唤醒/#899），都带 10s 超时", () => {
+    const settings = JSON.parse(codexHookSettingsJson("/usr/local/bin/party")) as {
+      hooks: Record<string, Array<{ hooks: Array<{ command: string; timeout: number }> }>>;
+    };
+    expect(Object.keys(settings.hooks).sort()).toEqual(["SessionStart", "Stop"]);
+    const stop = settings.hooks.Stop![0]!.hooks[0]!;
+    expect(stop.command).toContain("hook codex-stop");
+    expect(stop.timeout).toBe(10);
+    expect(settings.hooks.SessionStart![0]!.hooks[0]!.command).toContain("hook codex-report");
+  });
+
+  // 真机上 ~/.codex/hooks.json 的 Stop 已经挂着别人的东西（otty / vibe-island / superset）。
+  // 合并绝不能动它们，卸载也只许摘我们自己那条。
+  test("与用户已有的 Stop hook 共存：合并幂等、卸载只摘自己那条", () => {
+    const fragment = codexHookSettingsJson("/usr/local/bin/party");
+    const mine = JSON.stringify({
+      hooks: { Stop: [{ hooks: [{ type: "command", command: "my-own-thing" }] }] },
+    });
+    const merged = mergeHookSettings(mine, fragment);
+    expect(merged).toContain("my-own-thing");
+    expect(merged).toContain("hook codex-stop");
+    expect(mergeHookSettings(merged, fragment)).toBe(merged);
+    const removed = JSON.parse(removeHookSettings(merged)) as {
+      hooks: { Stop: Array<{ hooks: Array<{ command: string }> }>; SessionStart?: unknown };
+    };
+    expect(removed.hooks.Stop).toHaveLength(1);
+    expect(removed.hooks.Stop[0]!.hooks[0]!.command).toBe("my-own-thing");
+    expect(removed.hooks.SessionStart).toBeUndefined();
+  });
+});
+
+describe("party hook codex-stop 端到端（子进程）", () => {
+  const indexPath = join(import.meta.dir, "..", "src", "index.ts");
+
+  async function runHook(input: string, env: NodeJS.ProcessEnv) {
+    const proc = Bun.spawn(["bun", "run", indexPath, "hook", "codex-stop"], {
+      env,
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    proc.stdin.write(input);
+    proc.stdin.end();
+    const [stdout, stderr, code] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    return { stdout, stderr, code };
+  }
+
+  let home: string;
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "ap-899e-"));
+  });
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  test("没有任何本地信号 → exit 0、stdout 恒空（hook 铁律）", async () => {
+    const result = await runHook(JSON.stringify(stopPayload()), {
+      ...process.env,
+      AGENTPARTY_HOME: home,
+      AGENTPARTY_CHANNEL: "pwtk",
+    });
+    expect(result.code).toBe(0);
+    expect(result.stdout).toBe("");
+  });
+
+  test("坏 JSON → exit 0、stdout 恒空，绝不阻断会话", async () => {
+    const result = await runHook("{ not json", { ...process.env, AGENTPARTY_HOME: home });
+    expect(result.code).toBe(0);
+    expect(result.stdout).toBe("");
+  });
+
+  test("空 stdin → exit 0、stdout 恒空", async () => {
+    const result = await runHook("", { ...process.env, AGENTPARTY_HOME: home });
+    expect(result.code).toBe(0);
+    expect(result.stdout).toBe("");
+  });
+
+  test("非对象 payload → exit 0、stdout 恒空", async () => {
+    for (const raw of ["[]", '"x"', "null", "3"]) {
+      const result = await runHook(raw, { ...process.env, AGENTPARTY_HOME: home });
+      expect(result.code).toBe(0);
+      expect(result.stdout).toBe("");
+    }
+  });
+});


### PR DESCRIPTION
Closes #899

owner 的痛点是「**我正在用的这个 codex 收到消息**」。#893 的后台唤醒层能接住 @，但唤醒的是后台新 runner，owner 在自己界面里「从头到尾没出现过我们的通讯记录」（#897）。这个 PR 让唤醒发生在**用户眼前那个会话**里。

## ⚠️ 先说结论：issue 正文里那份反推契约有两处是错的，照抄会静默失效

我按要求先做了真机实测（临时 `CODEX_HOME` + `codex exec`，**没碰** owner 的 `~/.codex/hooks.json` 与 `config.toml`），再动手。实测推翻了两点：

### ① `prompt` 字段不存在——多带一个，整份输出作废

二进制里的 `stop.command.output` schema 是 `additionalProperties: false`，字段只有：
`continue / decision / reason / stopReason / suppressOutput / systemMessage`。**没有 `prompt`**，也没有 `hookSpecificOutput` / `additionalContext`（那些是别的事件的输出 schema，issue 把十个事件的字段并集当成了 Stop 的）。

实测对照：

| 返回 | 结果 |
|---|---|
| `{"decision":"block","reason":"…"}` | `hook: Stop Blocked` → **会话继续跑一轮**，模型把 `reason` 当 prompt 执行 |
| `{"decision":"block","reason":"…","prompt":"…"}` | `hook: Stop **Failed**` → 整份输出被丢弃，block 不生效，会话照常停止 |

⇒ **注入用的 prompt 就是 `reason` 本身**，一个字段身兼「给用户看的说明」和「给模型的指令」。所以措辞要同时满足两件事，实现里对此有注释。

### ② 输入字段也不是反推的那份

真机 Stop payload 只有：
`cwd / hook_event_name / last_assistant_message / model / permission_mode / session_id / stop_hook_active / transcript_path / turn_id`

没有 `agent_id / agent_type / agent_transcript_path / reason`——那四个是 **SubagentStop** 的输入。测试样本用的是真机原样 JSON，不是反推字段表。

### ③ 最要命的一条：codex 自己完全不封顶

连续 4 次无条件 block，它就老老实实跑了 4 轮：

```
codex E2E-START → Stop Blocked → COUNT-1 → Stop Blocked → COUNT-2
                → Stop Blocked → COUNT-3 → Stop Blocked → COUNT-4 → Stop Completed
```

`stop_hook_active` 从第 2 次起恒为 `true`，但 **codex 并不因此拒绝 block**，它只是把这个事实告诉你。`turn_id` 在整条续跑链上**保持不变**（所以 turn_id 不能用来判断「新一轮」）。

⇒ **防循环 100% 是我们的责任**，漏一层就是「会话永远停不下来」。

## 防循环方案（三道闸，任一成立即放行）

放行＝不 block，让会话正常停止。

1. **`stop_hook_active === true` → 放行。** 把每个用户 turn 的注入次数硬顶在 1 次。注意只认严格的 `false`：字段缺失/类型不对一律当续跑放行——宁可漏叫一次，绝不冒死循环的险。
2. **同一 seq 只注入一次，seen 集合落盘。** Stop hook 每轮起一个全新进程，内存集合等于没有（#862 的 seen 是内存态，这里不能照搬）。落在 `~/.agentparty/codex-stop-wake/<identity+channel>.json`，有界 64 条。**先落盘再打印**——反过来的话中间崩一次就会反复注入（有专门的顺序断言）。
3. **全路径 fail-open。** 拿不到身份（去不了重）、读盘炸了、判定说不该叫，一律安静放行。hook 铁律高于唤醒。

外加游标闸（已了结的不再叫）与过期闸（>7 天的欠账不再叫醒任何人，与 watch 的 `WATCH_WAKE_DEBT_MAX_AGE_MS` 同义）。

## 10 秒预算

**全程零网络**，只做同步读盘。信号源是 serve/watch 已经落在本地的欠账（`StuckWake`）——网络那一跳早就由它们付过了。没有新增任何需要等网络的路径。

## 与 #893 的协调：同一条 @ 不会被两边各处理一次

读码后的结论是，两条通道**天然不重叠**，靠的是语义差异而不是抢锁：

- **#893 后台通道是「执行者」**：它消费 directed delivery，起 runner 真的把活干了，去重由 delivery_id / 实例锁负责。
- **本 PR 前台通道是「通知者」**：它**不消费任何 delivery**，只把 channel+seq 指针交回给用户眼前的会话。它读的是 `StuckWake` 欠账——按定义就是「送达失败、从没进过模型的 @」，也就是后台通道**没能**处理的那些。

所以不存在「同一条 @ 被执行两次」的危险：前台这条路根本不执行，只是让用户看见。最坏情况是用户看见一条他的后台 runner 也答过的消息——而按 #897，这正是他要的可见性。

另有一道硬闸：`AP_ACTIVITY_FILE` 有值（serve 托管 lane）时直接放行。那本身就是 #893 那条后台通道的 runner 会话，在它身上再 block 一次才是真的重复处理。有测试覆盖。

**后续切片（本 PR 不做）**：更彻底的做法是让 serve 的 wake proxy（`serve-wake-proxy.ts`，#841/#856）在发现本机有活着的入册 codex 会话时，把 ≤512B 指针**停泊**到一个本地收件箱交给 Stop hook 取，而自己不起后台 runner——即「前台在场时前台优先认领」。那要改 serve 侧投递路径，属于 #893/#841 的地盘，不在这一刀里顺手动。本 PR 的模块边界已经为它留好了位置。

## SessionEnd 核实：#877 是对的，issue 的「附带纠正」才是错的

二进制里的 hook 事件枚举是完整的十个：

```
pre-tool-use / permission-request / post-tool-use / pre-compact / post-compact /
session-start / user-prompt-submit / subagent-start / subagent-stop / stop
```

**没有 session-end。** 二进制里确实有 `SessionEnd` 字符串，但它属于 **realtime 会话 API**（邻接的是 `realtimeSessionId / transport / voice / ConversationSpeechParams`），不是 hook 事件。

⇒ **#893 的生命周期不能改成 SessionEnd 精确收尾**，现有的「pid 探活 + TTL」就是唯一可行解。`codex-auto-wake.ts` 里那条注释是准确的，我在 `codexHookSettingsJson` 上补了这次复核的记录。

## 端到端真机验证

不只是单测——用真 codex 二进制 + 真 `party hook codex-stop` 跑通了整条链：

```
codex E2E-START
hook: Stop → Stop Blocked
exec  party history pwtk --since 41      ← 模型真的照着注入的指针去频道读了
hook: Stop → Stop Completed              ← 第二次没有再 block，会话干净结束
```

（`party history` 连不上是因为 fixture 里的 server 是 `example.invalid`，与本功能无关。）
第二次 Stop 没有再 block，正是落盘 seen 集合在跨进程生效——**没有死循环**。

## 变异验证

14 个「整段删除」级变异全部把断言打红，1 个等价实现替换保持绿：

| 变异 | 结果 |
|---|---|
| baseline | 35 pass / 0 fail |
| M1 整段删除 `stop_hook_active` 闸（防循环第 1 闸） | **3 fail** |
| M2 `!== false` 放宽成 `=== true`（缺字段就不再放行） | **1 fail** |
| M3 整段删除 seen 去重闸（防循环第 2 闸） | **2 fail** |
| M4 整段删除游标闸 | **1 fail** |
| M5 整段删除过期闸 | **1 fail** |
| M6 整段删除 enabled 闸 | **1 fail** |
| M7 整段删除 not_stop 闸 | **1 fail** |
| M8 拿掉 reason 的 512B 截断 | **1 fail** |
| M9 seen 集合不再有界 | **1 fail** |
| M10 先打印后落盘（崩溃即反复注入） | **1 fail** |
| M11 输出多带一个 `prompt` 字段（照抄反推契约） | **1 fail** |
| M12 拿不到身份时照样注入 | **1 fail** |
| M13 删掉 `AP_ACTIVITY_FILE` 闸 | **1 fail** |
| M14 Stop hook 不再写进 codex hooks.json | **1 fail** |
| M15 **等价实现替换**（`hasCodexStopWakeSeen` → `some`、`includes` → `indexOf`） | 35 pass / 0 fail（不误红）✅ |

守卫本身（M2/M12/M13）也做了变异，不只是主路径。

## 测试与检查

- `cli/test/codex-stop-wake.test.ts`：36 条，覆盖纯判定的每道闸 + 落盘 seen 的跨进程语义 + `handleCodexStopRecord` 的 DI 单测 + 子进程端到端（坏 JSON / 空 stdin / 非对象 payload 一律 exit 0 且 stdout 恒空）+ 与用户已有 Stop hook 的共存/幂等/卸载。
- `cd cli && bun test`：**1961 pass / 0 fail**
- `cd cli && bunx tsc --noEmit`：干净
- `bun scripts/sync-agentparty-plugin.ts --check`：同步

## 环境纪律

没用 AppleScript；没碰 owner 正在用的会话与桌面端；没改他的 `~/.codex/hooks.json` 与 `config.toml`（所有实测都在临时 `CODEX_HOME` 里，只读过 `auth.json`）。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增 Codex Stop Hook，支持在检测到未处理频道消息时自动唤醒当前会话继续执行。
  - 安装 Hook 时同时注册会话启动与停止事件，并新增 `codex-stop` 命令。
  - 唤醒原因包含频道和消息序号指针，支持重复处理防护及过期判断。

- **稳定性改进**
  - 异常、无效信号、托管会话或不满足条件时会安全放行，不影响会话正常停止。
  - 优化状态持久化、容量限制与输入容错处理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->