### PR TITLE
fix(cli): Stop hook 自己判断有没有未处理的 @，不再依赖 serve 欠账（#903 #904）

### DIFF
--- a/cli/src/codex-stop-wake.ts
+++ b/cli/src/codex-stop-wake.ts
@@ -31,8 +31,14 @@
 //   2. 同一 seq 只注入一次，seen 集合**落盘**——Stop hook 每轮是一个全新进程，内存集合等于没有。
 //   3. 任何一步取不到信号/抛异常 → 放行。hook 铁律优先于唤醒。
 //
-// 预算（本机 hooks.json 实测 timeout=10）：本模块**全程零网络**，只做同步读盘。
-// 唯一的信号源是 serve/watch 已经落在本地的欠账（StuckWake），网络那一跳早就由它们付过了。
+// 信号来源（#903 纠正）：早先这里写死「全程零网络、唯一信号源是 serve/watch 落盘的欠账」，
+// 结果是自咬尾巴——**本 hook 存在的意义正是「用户没挂 serve/bridge」，却要靠 serve 写的欠账
+// 才知道有 @**，于是在目标场景下恒不触发。现在的分工：
+//   - 本地欠账（StuckWake）降级为**可选快路径**：有就用，省掉这次网络；
+//   - 没有就自己问一次 `GET /api/channels/:slug/next-mention?since=<cursor>`——只问 seq、
+//     不拉正文，正文仍旧由会话去 `party history` 读，「频道是唯一数据源」不破。
+// 预算（本机 hooks.json 实测 timeout=10s）：那一跳独立超时 CODEX_STOP_WAKE_QUERY_TIMEOUT_MS，
+// 绝不吃满预算；失败/超时/任何异常一律放行——fail-open 铁律高于唤醒。
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { atomicWriteJson } from "./atomic-json";
@@ -49,6 +55,15 @@ export const CODEX_STOP_WAKE_REASON_MAX_BYTES = 512;
  * 几天前早就在别处处理过的 @，不该在用户今天的会话里跳出来。
  */
 export const CODEX_STOP_WAKE_DEBT_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+/**
+ * 问「有没有未处理的 @」那一跳的独立超时（#903）。
+ * codex 给整个 Stop hook 的预算是 10s；这里取 3s，剩下的 7s 留给读盘、落盘和进程启动，
+ * 网络再慢也只是这一次不叫醒（下一轮 Stop 会再问），绝不把用户的会话卡住。
+ *
+ * 为什么不是更短：真机实测热路径 ~0.25–0.6s，但 DO 冷启动那一次量到过 2.1s——
+ * 2s 级的超时会把「今天第一次被 @」这种最该叫醒的场景恰好卡掉。
+ */
+export const CODEX_STOP_WAKE_QUERY_TIMEOUT_MS = 3_000;
 
 /** 交回给会话的指针：只有 channel+seq，正文永远去频道读。 */
 export interface CodexStopWakePointer {
@@ -142,15 +157,40 @@ export type CodexStopWakeDecision =
   | { wake: false; skip: CodexStopWakeSkip }
   | { wake: true; pointer: CodexStopWakePointer };
 
-export interface CodexStopWakeInput {
+/** 便宜闸门的入参：这三样都不用花一次网络就能拿到。 */
+export interface CodexStopWakeGateInput {
   /** codex 递进来的原始 Stop payload。 */
   payload: Record<string, unknown>;
   /** 本 cwd 绑定的频道；没绑定为 null。 */
   channel: string | null;
   /** #893 的开关：显式 off 时前台这层也一起关（同一个「别自动打扰我」的意思）。 */
   enabled: boolean;
-  /** serve/watch 落在本地的欠账；没有为 null。 */
-  stuck: Pick<StuckWake, "seq" | "first_wake_ts"> | null;
+}
+
+export type CodexStopWakeGate = { ok: true } | { ok: false; skip: CodexStopWakeSkip };
+
+/**
+ * 先于任何信号获取的三道便宜闸（#903 把它单独拆出来，就是为了**先过闸再花网络**：
+ * 不是 Stop、是续跑、被关掉、没绑频道——这四种情况一次网络都不该发）。
+ */
+export function codexStopWakeGate(input: CodexStopWakeGateInput): CodexStopWakeGate {
+  const { payload } = input;
+  if (payload.hook_event_name !== "Stop") return { ok: false, skip: "not_stop" };
+  // 防循环第 1 闸。注意只认严格的 `false`：字段缺失/类型不对一律当「可能是续跑」放行，
+  // 宁可漏叫一次，也绝不冒「会话永远停不下来」的险。
+  if (payload.stop_hook_active !== false) return { ok: false, skip: "continuation" };
+  if (!input.enabled) return { ok: false, skip: "disabled" };
+  if (input.channel === null || input.channel === "") return { ok: false, skip: "no_channel" };
+  return { ok: true };
+}
+
+export interface CodexStopWakeInput extends CodexStopWakeGateInput {
+  /**
+   * 「本身份有一条还没处理的 @，seq 是它」——**信号来源不限**（#903）：
+   * 可以是 serve/watch 落在本地的欠账（快路径），也可以是本 hook 自己问服务端问来的。
+   * 早先这里写死只认本地欠账，而 Stop hook 存在的场景恰恰是「没人挂 serve」⇒ 恒不触发。
+   */
+  pending: Pick<StuckWake, "seq" | "first_wake_ts"> | null;
   /** 本频道游标：说到哪条为止已经了结了。 */
   cursor: number;
   /** 已注入过的 seq 集合。 */
@@ -165,27 +205,22 @@ export interface CodexStopWakeInput {
  * 它是唯一能保证「一个用户 turn 最多注入一次」的硬顶（实测 codex 自己不封顶）。
  */
 export function decideCodexStopWake(input: CodexStopWakeInput): CodexStopWakeDecision {
-  const { payload } = input;
-  if (payload.hook_event_name !== "Stop") return { wake: false, skip: "not_stop" };
-  // 防循环第 1 闸。注意只认严格的 `false`：字段缺失/类型不对一律当「可能是续跑」放行，
-  // 宁可漏叫一次，也绝不冒「会话永远停不下来」的险。
-  if (payload.stop_hook_active !== false) return { wake: false, skip: "continuation" };
-  if (!input.enabled) return { wake: false, skip: "disabled" };
-  if (input.channel === null || input.channel === "") return { wake: false, skip: "no_channel" };
-  const stuck = input.stuck;
-  if (stuck === null || !Number.isFinite(stuck.seq) || stuck.seq <= 0) {
+  const gate = codexStopWakeGate(input);
+  if (!gate.ok) return { wake: false, skip: gate.skip };
+  const pending = input.pending;
+  if (pending === null || !Number.isFinite(pending.seq) || pending.seq <= 0) {
     return { wake: false, skip: "no_pending" };
   }
   // 游标说「这条我已经了结了」——了结过的不再叫。
-  if (stuck.seq <= input.cursor) return { wake: false, skip: "no_pending" };
+  if (pending.seq <= input.cursor) return { wake: false, skip: "no_pending" };
   if (
-    typeof stuck.first_wake_ts === "number" &&
-    Number.isFinite(stuck.first_wake_ts) &&
-    input.now - stuck.first_wake_ts > CODEX_STOP_WAKE_DEBT_MAX_AGE_MS
+    typeof pending.first_wake_ts === "number" &&
+    Number.isFinite(pending.first_wake_ts) &&
+    input.now - pending.first_wake_ts > CODEX_STOP_WAKE_DEBT_MAX_AGE_MS
   ) {
     return { wake: false, skip: "stale_debt" };
   }
   // 防循环第 2 闸：同一条 @ 只注入一次。seen 是落盘的，跨进程有效。
-  if (hasCodexStopWakeSeen(input.seen, stuck.seq)) return { wake: false, skip: "already_woken" };
-  return { wake: true, pointer: { channel: input.channel, seq: stuck.seq } };
+  if (hasCodexStopWakeSeen(input.seen, pending.seq)) return { wake: false, skip: "already_woken" };
+  return { wake: true, pointer: { channel: input.channel as string, seq: pending.seq } };
 }

--- a/cli/src/commands/hook.ts
+++ b/cli/src/commands/hook.ts
@@ -20,6 +20,8 @@ import { AGENT_ACTIVITY_TTL_MS, type AgentActivity } from "@agentparty/shared";
 import { activityFromHookEvent, readActivityFile, writeActivityFile } from "../activity";
 import { agentpartyHome, loadCursor, loadStuck, readConfig, readState, type StuckWake } from "../config";
 import {
+  CODEX_STOP_WAKE_QUERY_TIMEOUT_MS,
+  codexStopWakeGate,
   codexStopWakeReason,
   codexStopWakeSeenPath,
   decideCodexStopWake,
@@ -83,7 +85,9 @@ into channel presence, so \`party who\` and the web can see it.
                         ~/.codex/hooks.json instead (#851). Existing content is
                         preserved; a parse failure aborts without writing.
   uninstall [--user|--codex]   remove exactly the entries install added
-  status [--user|--codex]      show whether the hooks are installed
+  status [--user|--codex]      show whether the hooks are installed. With no scope flag it
+                       reports BOTH the claude scope and the codex scope, each with the file
+                       it actually checked and the hook events found there (#904).
   codex-report         (wired by \`install --codex\`) read one codex hook event
                        from stdin and register an interactive codex session into
                        ~/.agentparty/codex-sessions/ so party can discover it.
@@ -532,22 +536,60 @@ async function runUninstall(argv: string[]): Promise<number> {
   return 0;
 }
 
-function runStatus(argv: string[]): number {
-  const scope = hookScope(argv);
-  const path = settingsPath(scope);
-  const source = existsSync(path) ? readFileSync(path, "utf8") : null;
-  let installed = false;
-  if (source !== null) {
-    try {
-      const hooks = (JSON.parse(source) as { hooks?: Record<string, unknown[]> }).hooks ?? {};
-      installed = Object.values(hooks).some((entries) => Array.isArray(entries) && entries.some(isOurEntry));
-    } catch {
-      console.error(`无法解析 ${termText(path)}`);
-      return 1;
-    }
+/** 一档 hooks 文件的检查结果（#904）。events 是**实际检出**的事件名，不是我们期望装的。 */
+export interface HookScopeStatus {
+  scope: HookScope;
+  path: string;
+  installed: boolean;
+  /** 装着我们条目的 hook 事件名，按文件里的顺序。 */
+  events: string[];
+  /** 文件存在但解析不了。 */
+  unreadable: boolean;
+}
+
+export function inspectHookScope(scope: HookScope, path: string, source: string | null): HookScopeStatus {
+  if (source === null) return { scope, path, installed: false, events: [], unreadable: false };
+  let hooks: Record<string, unknown>;
+  try {
+    hooks = (JSON.parse(source) as { hooks?: Record<string, unknown> }).hooks ?? {};
+  } catch {
+    return { scope, path, installed: false, events: [], unreadable: true };
   }
-  console.log(`${installed ? "installed" : "not installed"} (${termText(path)})`);
-  return installed ? 0 : 1;
+  const events = Object.keys(hooks).filter(
+    (event) => Array.isArray(hooks[event]) && (hooks[event] as unknown[]).some(isOurEntry),
+  );
+  return { scope, path, installed: events.length > 0, events, unreadable: false };
+}
+
+export function formatHookScopeStatus(status: HookScopeStatus): string {
+  const where = `${status.scope} scope: ${termText(status.path)}`;
+  if (status.unreadable) return `unreadable — ${where}`;
+  if (!status.installed) return `not installed — ${where}`;
+  return `installed — ${where} [${status.events.map(termText).join(", ")}]`;
+}
+
+/**
+ * `party hook status`（#904）。
+ *
+ * 不带 scope 参数时**两档都报**：只报 claude 那档会在「codex hook 明明装好了」时给出与事实
+ * 相反的结论——实测中它把一轮排查引向了错路。带 `--codex` / `--user` 则只报那一档。
+ */
+function runStatus(argv: string[]): number {
+  const explicit = argv.some((arg) => arg === "--codex" || arg === "--user" || arg === "--project");
+  const scopes: HookScope[] = explicit ? [hookScope(argv)] : ["project", "codex"];
+  const results = scopes.map((scope) => {
+    const path = settingsPath(scope);
+    return inspectHookScope(scope, path, existsSync(path) ? readFileSync(path, "utf8") : null);
+  });
+  for (const result of results) console.log(formatHookScopeStatus(result));
+  if (results.some((r) => r.unreadable)) return 1;
+  if (results.some((r) => r.installed)) return 0;
+  console.log(
+    scopes.length > 1
+      ? "两档都没装。claude 侧用 `party hook install`（或 --user），codex 侧用 `party hook install --codex`。"
+      : "这一档没装；另一档没查，用 `party hook status` 不带参数可两档都看。",
+  );
+  return 1;
 }
 
 const STOP_GUARD_PHASES = new Set<DeliveryRecoveryEntry["phase"]>([
@@ -829,14 +871,19 @@ export function handleCodexHookRecord(
   }
 }
 
-/** `party hook codex-stop` 的可注入依赖——全部同步读盘，测试直接塞假值，不碰真盘也不碰网。 */
+/** `party hook codex-stop` 的可注入依赖——测试直接塞假值，不碰真盘也不碰网。 */
 export interface CodexStopWakeDeps {
   /** 本 cwd 绑定的频道。 */
   channel: (cwd: string) => string | null;
   /** 前台唤醒是否启用（沿用 #893 的 codex-autowake 开关）。 */
   enabled: () => boolean;
-  /** serve/watch 落在本地的欠账。 */
+  /** serve/watch 落在本地的欠账——**可选快路径**，没有也照样能判（#903）。 */
   stuck: (channel: string, cwd: string) => Pick<StuckWake, "seq" | "first_wake_ts"> | null;
+  /**
+   * 问服务端「> since 的第一条 @ 我的消息是第几条」（#903）。只回 seq，不拉正文。
+   * 实现必须自带独立超时并吞掉一切异常：拿不到就返回 null（= 本次放行）。
+   */
+  nextMention: (channel: string, cwd: string, since: number) => Promise<number | null>;
   cursor: (channel: string, cwd: string) => number;
   /** 已注入过的 seq 集合的落盘路径；拿不到身份时返回 null（→ 无法去重，必须放行）。 */
   seenPath: (channel: string, cwd: string) => string | null;
@@ -857,6 +904,23 @@ export function defaultCodexStopWakeDeps(env: NodeJS.ProcessEnv = process.env): 
     channel: (cwd) => env.AGENTPARTY_CHANNEL ?? readState(cwd)?.channel ?? null,
     enabled: () => resolveCodexAutoWakeMode(env, home).mode !== "off",
     stuck: (channel, cwd) => loadStuck(channel, cwd),
+    nextMention: async (channel, cwd, since) => {
+      const auth = codexAutoWakeAuth(readConfig(cwd));
+      if (auth === null) return null;
+      try {
+        const { fetchNextMention } = await import("../rest");
+        return await fetchNextMention(
+          auth.server,
+          auth.token,
+          channel,
+          since,
+          AbortSignal.timeout(CODEX_STOP_WAKE_QUERY_TIMEOUT_MS),
+        );
+      } catch {
+        // 超时 / 401 / 断网 / 服务端还没这个端点（旧实例回 404）——一律当「不知道」，放行。
+        return null;
+      }
+    },
     cursor: (channel, cwd) => loadCursor(channel, cwd),
     seenPath: (channel, cwd) => {
       const resolved = target(channel, cwd);
@@ -880,11 +944,11 @@ export function defaultCodexStopWakeDeps(env: NodeJS.ProcessEnv = process.env): 
  * 放行（不写任何 stdout）是所有异常路径的统一归宿：拿不到身份、读盘炸了、判定说不该叫——
  * 一律安静让会话正常停止。宁可漏叫一次，也绝不把用户的会话卡在无限续跑里。
  */
-export function handleCodexStopRecord(
+export async function handleCodexStopRecord(
   record: Record<string, unknown>,
   env: NodeJS.ProcessEnv = process.env,
   injected?: CodexStopWakeDeps,
-): void {
+): Promise<void> {
   const deps = injected ?? defaultCodexStopWakeDeps(env);
   // serve 托管 lane 是被管理的 runner 会话，不是用户眼前那个终端会话——前台唤醒对它没有意义，
   // 而且它自己就是 #893 那条后台通道，在这里再 block 一次等于同一条 @ 被两边各处理一次。
@@ -892,14 +956,32 @@ export function handleCodexStopRecord(
   if (record.hook_event_name !== "Stop") return;
   const cwd = typeof record.cwd === "string" && record.cwd.length > 0 ? record.cwd : process.cwd();
   const channel = deps.channel(cwd);
+  // 先过便宜闸再花网络：不是 Stop / 是续跑 / 被关掉 / 没绑频道，一次请求都不发（#903）。
+  if (!codexStopWakeGate({ payload: record, channel, enabled: deps.enabled() }).ok) return;
+  const boundChannel = channel as string;
+  const cursor = deps.cursor(boundChannel, cwd);
+  // 快路径：serve/watch 恰好留了欠账就直接用，省掉这次网络。
+  const stuck = deps.stuck(boundChannel, cwd);
+  let pending: { seq: number; first_wake_ts?: number } | null =
+    stuck !== null && Number.isFinite(stuck.seq) && stuck.seq > cursor ? stuck : null;
+  if (pending === null) {
+    // 慢路径也是**主路径**：本 hook 的目标场景恰恰是「没人挂 serve」，那时本地永远没有欠账。
+    const startedAt = deps.now();
+    const seq = await deps.nextMention(boundChannel, cwd, cursor);
+    deps.log(
+      `codex-stop: next-mention 查询耗时 ${deps.now() - startedAt}ms，结果 ${seq === null ? "无/不可用" : `seq ${seq}`}`,
+    );
+    // 服务端问来的是「此刻仍未处理」，天然不可能是陈年欠账，故 first_wake_ts 取现在。
+    pending = seq === null ? null : { seq, first_wake_ts: deps.now() };
+  }
   const decision = decideCodexStopWake({
     payload: record,
-    channel,
-    enabled: deps.enabled(),
-    stuck: channel === null ? null : deps.stuck(channel, cwd),
-    cursor: channel === null ? 0 : deps.cursor(channel, cwd),
-    seen: channel === null ? [] : (() => {
-      const path = deps.seenPath(channel, cwd);
+    channel: boundChannel,
+    enabled: true,
+    pending,
+    cursor,
+    seen: (() => {
+      const path = deps.seenPath(boundChannel, cwd);
       return path === null ? [] : deps.readSeen(path);
     })(),
     now: deps.now(),
@@ -927,7 +1009,7 @@ async function runCodexStopHookInput(): Promise<number> {
   try {
     const payload = JSON.parse(await readStdin(MAX_STDIN_BYTES)) as unknown;
     if (typeof payload !== "object" || payload === null || Array.isArray(payload)) return 0;
-    handleCodexStopRecord(payload as Record<string, unknown>);
+    await handleCodexStopRecord(payload as Record<string, unknown>);
   } catch {
     // hook 铁律高于唤醒：坏 JSON / 读盘失败 / 任何意外，一律安静放行让会话正常停止。
   }

--- a/cli/src/rest.ts
+++ b/cli/src/rest.ts
@@ -1075,6 +1075,29 @@ export async function fetchWakeDeliveries(
   return Array.isArray(deliveries) ? (deliveries as WakeDelivery[]) : [];
 }
 
+/**
+ * 「> since 的消息里，第一条 @ 到我的是第几条」——只回 seq，不拉正文（#903）。
+ *
+ * 为 codex Stop hook 而生：它没有 serve/watch 落下的本地欠账可读（它存在的意义正是顶替
+ * 那条通道），又只有 ~10s 预算，所以需要一次尽可能便宜、可独立设超时的问询。正文仍旧
+ * 由会话自己去 `party history` 读。
+ */
+export async function fetchNextMention(
+  server: string,
+  token: string,
+  slug: string,
+  since: number,
+  signal?: AbortSignal,
+): Promise<number | null> {
+  const body = await req(
+    server,
+    `/api/channels/${encodeURIComponent(slug)}/next-mention?since=${encodeURIComponent(String(Math.max(0, Math.trunc(since))))}`,
+    { headers: bearerJson(token), ...(signal === undefined ? {} : { signal }) },
+  );
+  const seq = (body as Record<string, unknown> | null)?.seq;
+  return typeof seq === "number" && Number.isFinite(seq) && seq > 0 ? seq : null;
+}
+
 export async function createCapture(
   server: string,
   token: string,

--- a/cli/test/codex-stop-wake.test.ts
+++ b/cli/test/codex-stop-wake.test.ts
@@ -52,7 +52,7 @@ function decideInput(overrides: Partial<CodexStopWakeInput> = {}): CodexStopWake
     payload: stopPayload(),
     channel: "pwtk",
     enabled: true,
-    stuck: { seq: 42, first_wake_ts: NOW - 1_000 },
+    pending: { seq: 42, first_wake_ts: NOW - 1_000 },
     cursor: 7,
     seen: [],
     now: NOW,
@@ -69,7 +69,7 @@ describe("decideCodexStopWake", () => {
   });
 
   test("没有欠账 → 放行", () => {
-    expect(decideCodexStopWake(decideInput({ stuck: null }))).toEqual({
+    expect(decideCodexStopWake(decideInput({ pending: null }))).toEqual({
       wake: false,
       skip: "no_pending",
     });
@@ -117,7 +117,7 @@ describe("decideCodexStopWake", () => {
     expect(decideCodexStopWake(decideInput({ cursor: 41 })).wake).toBe(true);
   });
 
-  test("非 Stop 事件 → 放行", () => {
+  test("非 Stop 事件 → 放行", async () => {
     expect(
       decideCodexStopWake(decideInput({ payload: stopPayload({ hook_event_name: "SubagentStop" }) })),
     ).toEqual({ wake: false, skip: "not_stop" });
@@ -142,7 +142,7 @@ describe("decideCodexStopWake", () => {
     expect(
       decideCodexStopWake(
         decideInput({
-          stuck: { seq: 42, first_wake_ts: NOW - CODEX_STOP_WAKE_DEBT_MAX_AGE_MS - 1 },
+          pending: { seq: 42, first_wake_ts: NOW - CODEX_STOP_WAKE_DEBT_MAX_AGE_MS - 1 },
         }),
       ),
     ).toEqual({ wake: false, skip: "stale_debt" });
@@ -150,17 +150,17 @@ describe("decideCodexStopWake", () => {
     expect(
       decideCodexStopWake(
         decideInput({
-          stuck: { seq: 42, first_wake_ts: NOW - CODEX_STOP_WAKE_DEBT_MAX_AGE_MS },
+          pending: { seq: 42, first_wake_ts: NOW - CODEX_STOP_WAKE_DEBT_MAX_AGE_MS },
         }),
       ).wake,
     ).toBe(true);
     // 没有 first_wake_ts 的旧欠账不该被误判成过期。
-    expect(decideCodexStopWake(decideInput({ stuck: { seq: 42 } })).wake).toBe(true);
+    expect(decideCodexStopWake(decideInput({ pending: { seq: 42 } })).wake).toBe(true);
   });
 
   test("seq 非法 → 放行", () => {
     for (const seq of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
-      expect(decideCodexStopWake(decideInput({ stuck: { seq } })).wake).toBe(false);
+      expect(decideCodexStopWake(decideInput({ pending: { seq } })).wake).toBe(false);
     }
   });
 });
@@ -258,6 +258,7 @@ describe("handleCodexStopRecord", () => {
       channel: () => "pwtk",
       enabled: () => true,
       stuck: () => ({ seq: 42, first_wake_ts: NOW - 1_000 }),
+      nextMention: async () => null,
       cursor: () => 7,
       seenPath: () => join(home, "seen.json"),
       readSeen: (path) => seenStore.get(path) ?? [],
@@ -281,8 +282,8 @@ describe("handleCodexStopRecord", () => {
     rmSync(home, { recursive: true, force: true });
   });
 
-  test("有未处理的 @ → 恰好一行 block JSON，契约字段齐全", () => {
-    handleCodexStopRecord(stopPayload(), {}, deps());
+  test("有未处理的 @ → 恰好一行 block JSON，契约字段齐全", async () => {
+    await handleCodexStopRecord(stopPayload(), {}, deps());
     expect(emitted).toHaveLength(1);
     const output = JSON.parse(emitted[0]!) as Record<string, unknown>;
     expect(output.decision).toBe("block");
@@ -293,69 +294,167 @@ describe("handleCodexStopRecord", () => {
     expect(Object.keys(output).sort()).toEqual(["decision", "reason"]);
   });
 
-  test("没有未处理的 @ → 放行，stdout 一个字都不写", () => {
-    handleCodexStopRecord(stopPayload(), {}, deps({ stuck: () => null }));
+  test("没有未处理的 @ → 放行，stdout 一个字都不写", async () => {
+    await handleCodexStopRecord(stopPayload(), {}, deps({ stuck: () => null }));
     expect(emitted).toEqual([]);
   });
 
-  test("续跑轮（stop_hook_active 为真）→ 放行", () => {
-    handleCodexStopRecord(stopPayload({ stop_hook_active: true }), {}, deps());
+  test("续跑轮（stop_hook_active 为真）→ 放行", async () => {
+    await handleCodexStopRecord(stopPayload({ stop_hook_active: true }), {}, deps());
     expect(emitted).toEqual([]);
   });
 
-  test("同一 seq 第二次 → 放行（seen 已落盘）", () => {
+  test("同一 seq 第二次 → 放行（seen 已落盘）", async () => {
     const d = deps();
-    handleCodexStopRecord(stopPayload(), {}, d);
+    await handleCodexStopRecord(stopPayload(), {}, d);
     expect(emitted).toHaveLength(1);
-    handleCodexStopRecord(stopPayload(), {}, d);
+    await handleCodexStopRecord(stopPayload(), {}, d);
     expect(emitted).toHaveLength(1);
   });
 
-  test("先落 seen 再打印——顺序反了，中间崩一次就会反复注入", () => {
+  test("先落 seen 再打印——顺序反了，中间崩一次就会反复注入", async () => {
     const order: string[] = [];
-    handleCodexStopRecord(stopPayload(), {}, deps({
+    await handleCodexStopRecord(stopPayload(), {}, deps({
       recordSeen: () => order.push("seen"),
       emit: () => order.push("emit"),
     }));
     expect(order).toEqual(["seen", "emit"]);
   });
 
-  test("拿不到身份（去不了重）→ 放行，绝不注入", () => {
-    handleCodexStopRecord(stopPayload(), {}, deps({ seenPath: () => null }));
+  test("拿不到身份（去不了重）→ 放行，绝不注入", async () => {
+    await handleCodexStopRecord(stopPayload(), {}, deps({ seenPath: () => null }));
     expect(emitted).toEqual([]);
     expect(logged.join("\n")).toContain("去重");
   });
 
-  test("serve 托管 lane（AP_ACTIVITY_FILE）→ 放行，避免与 #893 后台通道重复处理同一条 @", () => {
-    handleCodexStopRecord(stopPayload(), { AP_ACTIVITY_FILE: "/tmp/a.json" }, deps());
+  test("serve 托管 lane（AP_ACTIVITY_FILE）→ 放行，避免与 #893 后台通道重复处理同一条 @", async () => {
+    await handleCodexStopRecord(stopPayload(), { AP_ACTIVITY_FILE: "/tmp/a.json" }, deps());
     expect(emitted).toEqual([]);
   });
 
-  test("本地信号读取抛异常 → 不吞掉异常契约由调用方兜，但绝不写出半条 stdout", () => {
-    expect(() =>
+  test("本地信号读取抛异常 → 不吞掉异常契约由调用方兜，但绝不写出半条 stdout", async () => {
+    await expect(
       handleCodexStopRecord(stopPayload(), {}, deps({
         stuck: () => {
           throw new Error("disk on fire");
         },
       })),
-    ).toThrow();
+    ).rejects.toThrow();
     expect(emitted).toEqual([]);
   });
 
-  test("非 Stop 事件 → 放行", () => {
-    handleCodexStopRecord(stopPayload({ hook_event_name: "SessionStart" }), {}, deps());
+  test("非 Stop 事件 → 放行", async () => {
+    await handleCodexStopRecord(stopPayload({ hook_event_name: "SessionStart" }), {}, deps());
     expect(emitted).toEqual([]);
   });
 
-  test("payload 里的 cwd 被用来解析频道", () => {
+  test("payload 里的 cwd 被用来解析频道", async () => {
     const seen: string[] = [];
-    handleCodexStopRecord(stopPayload({ cwd: "/tmp/elsewhere" }), {}, deps({
+    await handleCodexStopRecord(stopPayload({ cwd: "/tmp/elsewhere" }), {}, deps({
       channel: (cwd) => {
         seen.push(cwd);
         return "pwtk";
       },
     }));
     expect(seen).toEqual(["/tmp/elsewhere"]);
+  });
+
+  // ⚠️ 这一条钉住 #903 的盲区，删了等于这个 bug 没修。
+  //
+  // v0.2.203 的实现里，唯一的信号源是 serve/watch 落盘的欠账，而**全仓只有 serve 会写欠账**。
+  // 于是本 hook 在它唯一存在的场景（用户没挂 serve/bridge）里恒不触发：本地永远没有欠账，
+  // 判定永远走 no_pending。单测当时全绿，因为每条用例都自己喂了一个 stuck。
+  test("本地没有欠账（没人挂 serve）→ 仍能问出未处理的 @ 并 block", async () => {
+    const asked: Array<{ channel: string; since: number }> = [];
+    await handleCodexStopRecord(stopPayload(), {}, deps({
+      stuck: () => null,
+      cursor: () => 1899,
+      nextMention: async (channel, _cwd, since) => {
+        asked.push({ channel, since });
+        return 1910;
+      },
+    }));
+    // 问的是「> 我的游标之后的第一条 @」，不是随便问问。
+    expect(asked).toEqual([{ channel: "pwtk", since: 1899 }]);
+    expect(emitted).toHaveLength(1);
+    const output = JSON.parse(emitted[0]!) as Record<string, unknown>;
+    expect(output.decision).toBe("block");
+    expect(output.reason).toContain("1910");
+    expect(Object.keys(output).sort()).toEqual(["decision", "reason"]);
+    // 网络路径同样必须「先落盘 seen 再打印」，否则同一条 @ 每轮都会被重新问出来、反复注入。
+    expect(seenStore.get(join(home, "seen.json"))).toEqual([1910]);
+  });
+
+  test("网络问来的 seq 同样受 seen 去重约束（不会每轮反复注入）", async () => {
+    const d = deps({ stuck: () => null, cursor: () => 1899, nextMention: async () => 1910 });
+    await handleCodexStopRecord(stopPayload(), {}, d);
+    await handleCodexStopRecord(stopPayload(), {}, d);
+    expect(emitted).toHaveLength(1);
+  });
+
+  test("有本地欠账时走快路径，一次网络都不发", async () => {
+    let calls = 0;
+    await handleCodexStopRecord(stopPayload(), {}, deps({
+      nextMention: async () => {
+        calls += 1;
+        return null;
+      },
+    }));
+    expect(calls).toBe(0);
+    expect(emitted).toHaveLength(1);
+  });
+
+  test("本地欠账已被游标越过 → 不当快路径用，仍去问服务端", async () => {
+    let calls = 0;
+    await handleCodexStopRecord(stopPayload(), {}, deps({
+      stuck: () => ({ seq: 5, first_wake_ts: NOW - 1_000 }),
+      cursor: () => 7,
+      nextMention: async () => {
+        calls += 1;
+        return 9;
+      },
+    }));
+    expect(calls).toBe(1);
+    expect(emitted).toHaveLength(1);
+    expect(JSON.parse(emitted[0]!).reason).toContain("9");
+  });
+
+  test("查询超时/失败（返回 null）→ 放行，stdout 一个字都不写", async () => {
+    await handleCodexStopRecord(stopPayload(), {}, deps({ stuck: () => null, nextMention: async () => null }));
+    expect(emitted).toEqual([]);
+  });
+
+  // 便宜闸必须挡在网络前面：不是 Stop / 续跑轮 / 被关掉 / 没绑频道，一次请求都不该发。
+  test.each([
+    ["非 Stop 事件", stopPayload({ hook_event_name: "SessionStart" }), {} as Partial<CodexStopWakeDeps>],
+    ["续跑轮", stopPayload({ stop_hook_active: true }), {}],
+    ["开关关掉", stopPayload(), { enabled: () => false }],
+    ["没绑频道", stopPayload(), { channel: () => null }],
+  ])("%s → 连网络都不发", async (_label, payload, extra) => {
+    let calls = 0;
+    await handleCodexStopRecord(payload, {}, deps({
+      stuck: () => null,
+      nextMention: async () => {
+        calls += 1;
+        return 1910;
+      },
+      ...extra,
+    }));
+    expect(calls).toBe(0);
+    expect(emitted).toEqual([]);
+  });
+
+  test("serve 托管 lane（AP_ACTIVITY_FILE）→ 连网络都不发", async () => {
+    let calls = 0;
+    await handleCodexStopRecord(stopPayload(), { AP_ACTIVITY_FILE: "/tmp/a.json" }, deps({
+      stuck: () => null,
+      nextMention: async () => {
+        calls += 1;
+        return 1910;
+      },
+    }));
+    expect(calls).toBe(0);
+    expect(emitted).toEqual([]);
   });
 });
 

--- a/cli/test/hook-install.test.ts
+++ b/cli/test/hook-install.test.ts
@@ -308,13 +308,14 @@ describe("party hook install end-to-end (project scope)", () => {
       return { code, stdout };
     };
 
-    expect((await runIn("status")).code).toBe(1); // 未装
+    // #904 之后 status 不带 scope 会两档都报；这条是 project 档的往返，显式限定作用域。
+    expect((await runIn("status", "--project")).code).toBe(1); // 未装
     expect((await runIn("install")).code).toBe(0);
     const settings = JSON.parse(readFileSync(join(project, ".claude", "settings.local.json"), "utf8")) as {
       hooks: Record<string, unknown[]>;
     };
     expect(Object.keys(settings.hooks).length).toBe(14);
-    const status = await runIn("status");
+    const status = await runIn("status", "--project");
     expect(status.code).toBe(0);
     expect(status.stdout).toContain("installed");
     const installAgain = await runIn("install");
@@ -322,7 +323,7 @@ describe("party hook install end-to-end (project scope)", () => {
     expect(installAgain.stdout).toContain("party claude");
     expect(installAgain.stdout).not.toContain("任何在此生效范围内");
     expect((await runIn("uninstall")).code).toBe(0);
-    expect((await runIn("status")).code).toBe(1);
+    expect((await runIn("status", "--project")).code).toBe(1);
     rmSync(project, { recursive: true, force: true });
   });
 });
@@ -389,6 +390,43 @@ describe("party hook install --codex (#851 P2)", () => {
     // 卸载后恢复成用户原样。
     expect(JSON.parse(readFileSync(hooksPath, "utf8"))).toEqual(REAL_WORLD_CODEX_HOOKS);
     expect((await runCodex(fakeHome, "status")).code).toBe(1);
+    rmSync(fakeHome, { recursive: true, force: true });
+  });
+
+  // #904：装好了 codex hook，`party hook status` 却报 not installed——它只看 claude 那一档，
+  // 给出与事实相反的结论，实测中把一轮排查引向了「hook 没装」这条错路。
+  test("status 不带 scope 时两档都报，codex 档装了就必须报 installed（#904）", async () => {
+    const fakeHome = mkdtempSync(join(tmpdir(), "ap-codexstatus-"));
+    mkdirSync(join(fakeHome, ".codex"), { recursive: true });
+    const run = async (...args: string[]) => {
+      const proc = Bun.spawn(["bun", "run", indexPath, "hook", ...args], {
+        cwd: fakeHome,
+        env: { ...process.env, HOME: fakeHome, AGENTPARTY_HOME: home },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [code, stdout] = await Promise.all([proc.exited, new Response(proc.stdout).text()]);
+      return { code, stdout };
+    };
+
+    const none = await run("status");
+    expect(none.code).toBe(1);
+    // 两档都报，各自打印自己实际检查的文件路径。
+    expect(none.stdout).toContain("project scope:");
+    expect(none.stdout).toContain(join(fakeHome, ".codex", "hooks.json"));
+    expect(none.stdout).toContain("两档都没装");
+
+    expect((await run("install", "--codex")).code).toBe(0);
+    const after = await run("status");
+    expect(after.code).toBe(0);
+    // codex 那行必须是 installed，并列出实际检出的事件（SessionStart + Stop）。
+    const codexLine = after.stdout.split("\n").find((line) => line.includes("codex scope:"))!;
+    expect(codexLine).toContain("installed —");
+    expect(codexLine).not.toContain("not installed");
+    expect(codexLine).toContain("SessionStart");
+    expect(codexLine).toContain("Stop");
+    // claude 那档没装，仍然如实说没装——两档要能区分。
+    expect(after.stdout.split("\n").find((line) => line.includes("project scope:"))).toContain("not installed");
     rmSync(fakeHome, { recursive: true, force: true });
   });
 

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -350,6 +350,12 @@ const MENTION_TOKEN_RE = /^[\p{L}\p{N}][\p{L}\p{N}._-]{0,63}$/u;
 const WORKFLOW_ID_RE = /^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,127}$/;
 const CLIENT_VERSION_RE = /^[0-9A-Za-z][0-9A-Za-z.+-]{0,63}$/;
 const MAX_MENTIONS = 50;
+/**
+ * `/internal/next-mention` 一次最多核查多少条候选行（#903）。
+ * 候选已被 LIKE 预筛过，正常频道里 @ 某个身份的消息远少于这个数；封顶只是保证这条
+ * 「hook 预算内必须返回」的查询不会因为某个身份被 @ 了上万次而变慢。
+ */
+const NEXT_MENTION_SCAN_LIMIT = 200;
 const MENTIONS_JSON_LIMIT = 4096;
 const MAX_STATUS_SCOPE = 50;
 const STATUS_SCOPE_JSON_LIMIT = 4096;
@@ -6921,6 +6927,46 @@ export class ChannelDO extends Server<Env> {
     if (url.pathname === "/internal/read-cursors" && request.method === "GET") {
       // 已读游标快照 + 频道最新 seq，供 `party who` 标注每个身份读到第几条 / 落后多少（Phase 2 · CLI）。
       return Response.json({ cursors: this.readCursors(), last_seq: this.lastSeq() });
+    }
+    if (url.pathname === "/internal/next-mention" && request.method === "GET") {
+      // #903：一次「有没有还没处理的 @」的极轻量问询——只回 seq，不回正文。
+      // 存在的理由：codex Stop hook 没有 serve/watch 落下的本地欠账可读（那正是它要顶替的东西），
+      // 又只有 ~10s 预算，不能拉一页正文回来自己筛。正文仍旧去 `party history` 读，
+      // 「频道是唯一数据源」不因这个指针端点而破。
+      const since = Math.max(toInt(url.searchParams.get("since"), 0), 0);
+      const name = url.searchParams.get("name") ?? "";
+      if (name === "") return Response.json({ seq: null });
+      const key = mentionMatchKey(name);
+      // LIKE 只是预筛（SQLite 的 ASCII LIKE 不分大小写、`_`/`%` 只会放宽匹配，绝不会漏），
+      // 真正的判定在下面用 mentionMatchKey 逐行核。撤回/擦除的消息 mentions 已清空，天然被排除。
+      const like = `%${name}%`;
+      const rows = this.ctx.storage.sql
+        .exec(
+          `SELECT seq, mentions_json, delivery_targets_json
+             FROM messages
+            WHERE seq > ?
+              AND sender_name <> ?
+              AND (mentions_json LIKE ? OR delivery_targets_json LIKE ?)
+            ORDER BY seq LIMIT ?`,
+          since,
+          name,
+          like,
+          like,
+          NEXT_MENTION_SCAN_LIMIT,
+        )
+        .toArray();
+      for (const row of rows) {
+        let names: string[];
+        try {
+          names = [...parseStoredMentions(row.mentions_json), ...parseStoredTargetNames(row.delivery_targets_json)];
+        } catch {
+          continue;
+        }
+        if (names.some((value) => mentionMatchKey(value) === key)) {
+          return Response.json({ seq: Number(row.seq) });
+        }
+      }
+      return Response.json({ seq: null });
     }
     // GDPR 按身份数据出口/擦除（#421）。授权在 worker 层做（moderator 门），DO 只按 name 读/删本频道数据。
     const identityDataMatch = url.pathname.match(/^\/internal\/identity\/([^/]+)\/data$/);

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -6983,6 +6983,31 @@ app.get("/api/channels/:slug/read-cursors", async (c) => {
   );
 });
 
+/**
+ * #903：「> since 的消息里，第一条 @ 到我的是第几条」——只回一个 seq，不回正文。
+ *
+ * 调用者恒定是**自己**：`name` 一律取 bearer 身份，不接受客户端指定，所以这个端点不会
+ * 变成「探测别人被 @ 了什么」的侧信道。正文仍旧走 /messages，本端点只交指针。
+ */
+app.get("/api/channels/:slug/next-mention", async (c) => {
+  const slug = c.req.param("slug");
+  const channel = await loadChannel(c.env.DB, slug);
+  if (!channel) return c.json(errorBody("not_found", "channel not found"), 404);
+  const identity = c.get("identity");
+  if (!(await canAccessLoadedChannel(c.env.DB, identity, channel))) {
+    return c.json(errorBody("forbidden", "not allowed in this channel"), 403);
+  }
+  const since = new URL(c.req.url).searchParams.get("since") ?? "0";
+  const query = new URLSearchParams({ since, name: identity.name });
+  return fetchMutableChannelDO(
+    c.env,
+    slug,
+    new Request(`https://do/internal/next-mention?${query.toString()}`, {
+      headers: { "x-partykit-room": slug },
+    }),
+  );
+});
+
 app.get("/api/channels/:slug/squads", async (c) => {
   const slug = c.req.param("slug");
   const channel = await loadChannel(c.env.DB, slug);

--- a/worker/test/next-mention.spec.ts
+++ b/worker/test/next-mention.spec.ts
@@ -1,0 +1,94 @@
+// #903：`GET /api/channels/:slug/next-mention?since=N` —— 「> N 的消息里，第一条 @ 我的是第几条」。
+//
+// 存在的理由在 CLI 那侧：codex 的 Stop hook 只有 ~10s 预算，又没有 serve/watch 落下的本地欠账
+// 可读（它存在的意义正是顶替那条通道）。所以它需要一次极便宜、只回指针的问询；正文仍旧走
+// /messages，本端点一个字的正文都不回。
+import { describe, expect, it } from "vitest";
+import { api, createChannel, seedToken } from "./helpers";
+
+async function send(
+  slug: string,
+  token: string,
+  body: string,
+  mentions: string[] = [],
+): Promise<number> {
+  const res = await api(`/api/channels/${slug}/messages`, token, {
+    method: "POST",
+    body: JSON.stringify({ kind: "message", body, mentions, reply_to: null }),
+  });
+  expect(res.status).toBe(200);
+  return ((await res.json()) as { seq: number }).seq;
+}
+
+async function nextMention(slug: string, token: string, since: number): Promise<number | null> {
+  const res = await api(`/api/channels/${slug}/next-mention?since=${since}`, token);
+  expect(res.status).toBe(200);
+  return ((await res.json()) as { seq: number | null }).seq;
+}
+
+describe("next-mention (#903)", () => {
+  it("回第一条 @ 我的 seq；游标越过后回 null；不含正文", async () => {
+    const human = await seedToken("human");
+    const agent = await seedToken("agent");
+    const slug = await createChannel(human.token);
+
+    await send(slug, human.token, "闲聊一句，没 @ 任何人");
+    const mention = await send(slug, human.token, `@${agent.name} 看一下这个`, [agent.name]);
+    const second = await send(slug, human.token, `@${agent.name} 还有这个`, [agent.name]);
+
+    expect(await nextMention(slug, agent.token, 0)).toBe(mention);
+    // 「最小的那个」——不是最后一条，也不是随便一条。
+    expect(mention).toBeLessThan(second);
+    expect(await nextMention(slug, agent.token, mention)).toBe(second);
+    expect(await nextMention(slug, agent.token, second)).toBeNull();
+
+    // 只回指针：响应体里除了 seq 什么都没有，正文一个字都不出现。
+    const res = await api(`/api/channels/${slug}/next-mention?since=0`, agent.token);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(Object.keys(body)).toEqual(["seq"]);
+    expect(JSON.stringify(body)).not.toContain("看一下");
+  });
+
+  it("没被 @ 的身份恒得到 null（别人的 @ 不会被误报成自己的）", async () => {
+    const human = await seedToken("human");
+    const mentioned = await seedToken("agent");
+    const bystander = await seedToken("agent");
+    const slug = await createChannel(human.token);
+
+    await send(slug, human.token, `@${mentioned.name} 你的活`, [mentioned.name]);
+
+    expect(await nextMention(slug, mentioned.token, 0)).not.toBeNull();
+    expect(await nextMention(slug, bystander.token, 0)).toBeNull();
+  });
+
+  it("自己 @ 自己不算未处理的 @（否则 hook 会被自己的消息唤醒，自激成死循环）", async () => {
+    const human = await seedToken("human");
+    const agent = await seedToken("agent");
+    const slug = await createChannel(human.token);
+    await send(slug, human.token, "开场白");
+
+    await send(slug, agent.token, `@${agent.name} 自言自语`, [agent.name]);
+    expect(await nextMention(slug, agent.token, 0)).toBeNull();
+  });
+
+  it("name 一律取 bearer 身份，客户端指定的 name 被忽略（不能拿来探测别人）", async () => {
+    const human = await seedToken("human");
+    const mentioned = await seedToken("agent");
+    const bystander = await seedToken("agent");
+    const slug = await createChannel(human.token);
+    await send(slug, human.token, `@${mentioned.name} 你的活`, [mentioned.name]);
+
+    const res = await api(
+      `/api/channels/${slug}/next-mention?since=0&name=${encodeURIComponent(mentioned.name)}`,
+      bystander.token,
+    );
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as { seq: number | null }).seq).toBeNull();
+  });
+
+  it("频道不存在 → 404", async () => {
+    const agent = await seedToken("agent");
+    const res = await api("/api/channels/no-such-channel-903/next-mention?since=0", agent.token);
+    expect(res.status).toBe(404);
+  });
+});


### PR DESCRIPTION
Closes #903
Closes #904

## #903 根因（issue 里已取证，这里只说改法）

#901 的 Stop hook 唯一信号源是 `deps.stuck = loadStuck(channel, cwd)`，而全仓只有 `cli/src/commands/serve.ts` 会写 `saveStuck`。自咬尾巴：**这个 hook 存在的意义正是「用户没挂 serve/bridge」，它却要靠 serve 写的欠账才知道有 @**，在目标场景下恒不触发。这是 #899 派单里写死「全程零网络」的约束错了，不是实现方的问题。

## 改了什么

1. **新端点** `GET /api/channels/:slug/next-mention?since=N` → `{"seq": number|null}`：「> N 的消息里，第一条 @ 我的是第几条」。只回指针，不回正文——正文仍由会话自己 `party history` 读，「频道是唯一数据源」不破。`name` 一律取 bearer 身份，客户端传的 `name` 被忽略，不能拿来探测别人被 @ 了什么。DO 侧 LIKE 预筛 + `mentionMatchKey` 逐行核，扫描上限 200 行；自己发的消息不算（否则 hook 会被自己的消息自激唤醒）。
2. **本地欠账降级为可选快路径**：有且 `> cursor` 就直接用、省掉网络；没有（= 目标场景）才查。查询独立超时 **3s**，失败/超时/任何异常一律返回 null → 放行。
3. **便宜闸拆成 `codexStopWakeGate` 先跑**：不是 Stop / 续跑轮 / 开关关掉 / 没绑频道 / `AP_ACTIVITY_FILE` 有值 —— 一次网络都不发（有用例逐项钉住）。
4. **三道防循环闸一条没松**：`stop_hook_active` 严格只认 `false`；per-seq seen 落盘去重；全路径 fail-open。**新增的网络路径同样「先落盘 seen 再打印 block」**。
5. **输出契约不动**：只有 `{"decision":"block","reason":"…"}`，没有 `prompt`。
6. 与 #893 分工不变：本 hook 只交回 channel+seq 指针，不消费 delivery。

**#904**：`party hook status` 不带 scope 时两档都报，各自打印实际检查的文件路径与检出的 hook 事件；`--codex` / `--user` / `--project` 仍只报一档；两档都没装时明确说「两档都没装」并给出两条安装命令。

## 真机端到端（硬要求，已做）

一台**没有任何 serve / watch / bridge 在跑**的机器（`ps` 确认为空），一次性 codex 0.145.0 **交互式 TUI** 会话，跑在临时 `CODEX_HOME`（**没有碰 owner 的 `~/.codex/hooks.json` 与 `config.toml`**，没有用 AppleScript 敲任何键盘）：

```
• Stop hook (blocked)
  feedback: [AgentParty] 频道 #e2e903 有一条 @ 你的消息还没处理（seq 1）。请先执行
  `party history e2e903 --since 0` 读到正文，…

• Ran command -v party && party --version && party history e2e903 --since 0
  └ [1] leo-h(human): @codex-e2e 请把这句话原样回给我：903-真机验证通过
    [2] leo-h(human): @codex-e2e 请用 party send 在本频道回复一句：903-e2e-ok
```

频道里随后出现 `seq 3 codex-e2e: 903-e2e-ok` 与 `seq 4 codex-e2e: 903-真机验证通过`。**指针在用户眼前的会话里弹出来了，模型自己去频道读了正文并回了话** —— 本地 `stuck` 全程为空（v0.2.203 在这里恒走 `skip: no_pending`，什么都不弹）。

一个用户 turn 只注入一次：落盘的 seen 里只有一条 `seq 1`，第二次 Stop 被 `stop_hook_active === true` 挡住。

顺带发现（值得记一笔）：**codex 0.145 新装/改动的 hook 默认是不信任状态，要在 TUI 里 Trust 一次才会运行**（"Hooks need review — 1 hook is new or changed"）。`party hook install --codex` 之后如果没做这一步，hook 一次都不会跑——排查 codex 唤醒问题时值得先看这个。

## 网络那一跳实测耗时

| 场景 | 耗时 |
|---|---|
| 本地 wrangler dev，DO 冷启动第一次 | 2165 ms |
| 本地 wrangler dev，热路径 ×5 | 6–33 ms |
| 生产 pwtk 同形 DO 端点往返 ×5（presence 基线） | 246 / 290 / 304 / 397 / 618 ms |
| 真机 codex 会话里实测的那一跳 | **548 ms** |

超时取 3s（issue 允许 2–3s）：热路径远低于它，而 2s 级的超时会把「今天第一次被 @」这种 DO 冷启动场景恰好卡掉。10s 总预算还剩 7s 给读盘/落盘/进程启动。

## 变异验证（整段删除 + 等价替换）

| 变异 | 结果 |
|---|---|
| 删掉 handleCodexStopRecord 里整段网络回退（= 退回 v0.2.203 只认本地欠账） | **红**：「本地没有欠账（没人挂 serve）→ 仍能问出未处理的 @ 并 block」等 3 条挂掉 —— 这正是 #903 本身，这条用例在，bug 就回不来 |
| 把 `recordSeen` / `emit` 顺序对调 | **红**：「先落 seen 再打印」挂掉 |
| DO 查询去掉 `sender_name <> ?` | **红**：「自己 @ 自己不算未处理的 @」挂掉 |
| worker 路由改成信任客户端传的 `name` | **红**：「name 一律取 bearer 身份」挂掉 |
| 等价替换：快路径条件改写成取反形式 | **绿**（不误红） |
| 等价替换：DO 查询去掉 LIKE 预筛、纯 JS 核（语义相同、实现不同） | **绿**（不误红） |

没有用 `nextOfType` 之类「读到某类帧就停」的辅助当屏障。

## 检查

- `bun run check:cli` 全 6 shard 绿（2003 tests）+ tsc
- `bun run check:worker` 绿（110 files / 843 tests）+ tsc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - Stop 唤醒现在支持查询服务端未处理的提及，及时恢复需要继续处理的会话。
  - 新增提及查询接口，仅返回序号指针并执行访问控制，不返回消息正文。
  - Hook 状态检查默认展示项目级 Claude 与 Codex 的安装状态、路径及事件信息。
- **稳定性改进**
  - 增加快速门禁、去重和独立超时；查询失败或超时会安全放行，不阻塞流程。
- **测试**
  - 补充服务端查询、权限、游标、安装状态及异常场景覆盖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->