### PR TITLE
fix(who): 可达性判据不再错位，拉取式唤醒通道单列一档

### DIFF
--- a/cli/src/commands/who.ts
+++ b/cli/src/commands/who.ts
@@ -8,6 +8,7 @@ import { fetchPresence, fetchReadCursors, fetchRuntimePeers, handleRestError } f
 import { buildRuntimeTopology } from "../runtime-topology";
 import { localStatuslineBase, unreadFromCursor, writeStatuslineCache } from "../statusline-cache";
 import { sanitizeSingleLine } from "../format";
+import { buildPullWakeLookup, type PullWakeHint, type PullWakeLookup } from "../pull-wake";
 import { isSlug } from "../validation";
 
 const WHO_FLAGS = ["channel", "json"];
@@ -23,15 +24,27 @@ List who is in a channel, tiered by how you can reach them:
                 · wakeable unverified  self-declared serve/watch the server has NOT
                                        verified — may or may not actually wake up
   ○ recent    seen lately, no wake layer; mention delivers, wake not guaranteed.
-              A "⚠ unreachable" tag flags the genuinely-dead subset: no live wake
-              channel AND stale — the mention only lands in history and will wake
-              no one (JSON: "unreachable":true). Prove otherwise: party wake test @name
-              Such a row also carries a "↳ fix:" hint telling you how to give that
-              identity a wake layer, branched by harness (JSON: "wake_guidance" with
-              reason/harness/harness_source/remedy). A codex session has NO per-session
-              inbox: it is wakeable only while party bridge codex / party serve
-              --runner codex holds its app-server connection — installing a plugin does
-              not make a codex session wakeable on its own.
+              A "⚠ no live wake layer" tag flags the subset with no live wake channel
+              AND stale (JSON: "unreachable":true): nothing is listening right now, so
+              the @ waits as that identity's durable reception debt until it next runs.
+              Prove otherwise: party wake test @name
+  ⇢ deferred  a PULL-based wake channel — the codex Stop hook (#899/#901). The server
+              cannot see it: such a session registers no presence and comes to fetch its
+              own debt at the end of a turn. So it is neither "online" nor "unreachable";
+              the honest statement is "the user gets it next time they use it".
+              Shown only from THIS machine's point of view — this machine has the codex
+              Stop hook installed AND a local config for that identity (JSON: "pull_wake"
+              with scope:"local"/harness/evidence). Another machine's hooks are invisible
+              here, and so is whether the user will open that session again.
+              A "↳ fix:" hint appears only when the harness is actually known from
+              evidence present on THAT row (JSON: "wake_guidance" with
+              reason/harness/harness_source/remedy). When it cannot be known, who says
+              nothing: a wrong remedy is worse than none (#891). No remedy ever tells you
+              to start party serve — serve hands the @ to a background runner, which is
+              exactly the behaviour #897 rejected. A codex session has NO per-session
+              inbox: give it the Stop hook (party hook install --codex) so the @ surfaces
+              in the session you are looking at, or hold its app-server connection with
+              party bridge codex — installing a Claude plugin does nothing for codex.
 A "⏳ busy" tag means the target is serially handling a wake (e.g. a long run): it
 is reachable but a reply will be slow — an ask that times out means "busy", not
 "offline", so do not re-@ it. "N queued" shows how many wakes are already waiting.
@@ -75,7 +88,7 @@ session name), so mention the "@handle" shown here — not a UUID session name.
 Options:
   --channel C   read channel C instead of the bound channel
   --json        emit one JSON object per line
-                (name/kind/tier/live/residency/unreachable/wake_guidance/wake/wake_unverified/busy/queue_depth/waiting_owner_count/unhandled_mention_count/oldest_unhandled_mention_seq/pending_mention_seqs/last_receipt_seq/not_in_turn_since/current_task/task_started_at/heartbeat_at/activity/listening/runner_health/agent_session/topology_conflicts/reception_mode/reception_runner/reception_context/scope/scope_conflicts/account/handle/display_name/age_ms/read_seq)`;
+                (name/kind/tier/live/residency/unreachable/pull_wake/wake_guidance/wake/wake_unverified/busy/queue_depth/waiting_owner_count/unhandled_mention_count/oldest_unhandled_mention_seq/pending_mention_seqs/last_receipt_seq/not_in_turn_since/current_task/task_started_at/heartbeat_at/activity/listening/runner_health/agent_session/topology_conflicts/reception_mode/reception_runner/reception_context/scope/scope_conflicts/account/handle/display_name/age_ms/read_seq)`;
 
 // 导出仅供单测断言 help 文案与真实行为一致（#859/#860：文档漂移过一次，用断言钉住）。
 export const HELP_TEXT = HELP;
@@ -174,20 +187,40 @@ interface Row {
   // Claude 那样的 per-session socket 收件箱，只有在某个进程持有它的 app-server 连接时才可被唤醒；
   // Claude Code 的交互式会话装了插件本身就可被唤醒。把这条判据结构化下发，agent 也能程序化判读。
   wake_guidance?: WakeGuidance;
+  // #905：拉取式唤醒通道（codex Stop hook）的本机线索。它不是服务端事实——服务端对拉取式通道
+  // 一无所知，这正是 #905 的成因。仅在本机同时满足「装了 codex Stop hook」+「有该身份该服务器
+  // 的 config」时带出，scope 恒为 "local"，展示与 JSON 都必须保留这个「本机视角」限定。
+  pull_wake?: PullWakeHint;
 }
 
-/** #879：没有唤醒层时的可操作补救建议。harness=unknown 表示 presence 没给出可信的 harness 维度。 */
+/**
+ * #879：没有唤醒层时的可操作补救建议。
+ *
+ * #891 的教训钉在这里：harness 不再有 "unknown" 这一档。原来的三分支里，unknown 档是唯一
+ * 会在真机点亮的那一支——因为判据字段（agent_session / reception_runner）只在**活跃**身份的
+ * presence 上有，而这条提示只对**离线**身份显示，判据与展示场景在时间上互斥。于是「兜底」
+ * 变成了常态，全频道每一行都挂着同一句并列两条命令、且在 #897 之后**有害**的建议。
+ *
+ * 新规矩：判据取不到就不给建议（返回 undefined）。错误的修复建议比没有建议更糟。
+ */
 export interface WakeGuidance {
   reason: "no_wake_layer";
-  harness: "codex" | "claude" | "unknown";
-  /** 判据来源：agent_session.harness（runner 自报的模型会话句柄）或 reception_runner（接待配置）。 */
-  harness_source?: "agent_session" | "reception_runner";
+  harness: "codex" | "claude";
+  /**
+   * 判据来源。前两个来自 presence（仅活跃身份有）；local_codex_stop_hook 来自本机文件系统
+   * （#905），是唯一一个对**离线**身份仍然可得的来源——也正因为它只是本机视角，用它推出的
+   * 建议措辞里必须保留这个限定。
+   */
+  harness_source: "agent_session" | "reception_runner" | "local_codex_stop_hook";
   /** 可直接执行的补救命令（已带上真实频道名）。 */
   remedy: string[];
 }
 
-// harness 维度只取 presence 里真实存在的两个字段，不硬造。codex-sdk 与 codex 同族（都靠 app-server）。
-export function wakeHarnessOf(r: Row): { harness: WakeGuidance["harness"]; source?: WakeGuidance["harness_source"] } {
+// harness 维度只取真实存在的判据，不硬造，也不再从名字启发式猜（`*-codex` 后缀不构成证据）。
+// codex-sdk 与 codex 同族（都靠 app-server）。判不出就返回 undefined。
+export function wakeHarnessOf(
+  r: Row,
+): { harness: WakeGuidance["harness"]; source: WakeGuidance["harness_source"] } | undefined {
   const fromSession = r.agent_session?.harness;
   if (fromSession === "codex" || fromSession === "codex-sdk") return { harness: "codex", source: "agent_session" };
   if (fromSession === "claude") return { harness: "claude", source: "agent_session" };
@@ -196,24 +229,35 @@ export function wakeHarnessOf(r: Row): { harness: WakeGuidance["harness"]; sourc
     return { harness: "codex", source: "reception_runner" };
   }
   if (fromReception === "claude") return { harness: "claude", source: "reception_runner" };
-  return { harness: "unknown" };
+  // #905：本机装了 codex Stop hook 且本机持有这个身份的 config——离线也成立的唯一一条判据。
+  if (r.pull_wake !== undefined) return { harness: r.pull_wake.harness, source: "local_codex_stop_hook" };
+  return undefined;
 }
 
 /**
- * #879：只对「确实没有唤醒层」的 agent 身份给补救建议——即 who 已判定 unreachable 的那批
- * （不在线 + 无活 wake 通道 + 陈旧）。在线/wakeable/刚断线的身份不加噪音；人类不靠 bridge/serve 唤醒。
+ * 只对「确实没有唤醒层」的 agent 身份给补救建议。人类不靠 bridge/hook 唤醒。
+ *
+ * #891：不再要求 unreachable——那个条件恰恰过滤掉了判据仍在场的那批行。改成「没有 wake 层」
+ * （unreachable 或 wake=none/缺失的 recent 行），判据在场就给，不在场就闭嘴。
+ *
+ * #897/#905：补救命令里**不再出现 `party serve`**。serve 把消息交给后台新 runner，用户在
+ * 自己眼前的会话里什么也看不见——owner 原话「从头到尾没出现过我们的通讯记录」。前台唤醒的
+ * 正确答案是 codex 的 Stop hook 与 Claude 的插件。
  */
 export function wakeGuidanceOf(r: Row, channel: string): WakeGuidance | undefined {
-  if (r.unreachable !== true || r.kind !== "agent") return undefined;
-  const { harness, source } = wakeHarnessOf(r);
+  if (r.kind !== "agent") return undefined;
+  const noWakeLayer = r.unreachable === true || (r.tier === "recent" && (r.wake === undefined || r.wake === "none"));
+  if (!noWakeLayer) return undefined;
+  // 已经有本机拉取通道的身份不需要「怎么装」——它装过了。deferredNote 会另行说明它的状态。
+  if (r.pull_wake !== undefined) return undefined;
+  const found = wakeHarnessOf(r);
+  if (found === undefined) return undefined;
   const ch = sanitizeSingleLine(channel);
   const remedy =
-    harness === "codex"
-      ? [`party bridge codex ${ch}`, `party serve ${ch} --runner codex`]
-      : harness === "claude"
-        ? [`claude plugin install agentparty@agentparty`, `party serve ${ch} --runner claude`]
-        : [`party serve ${ch} --runner codex`, `party serve ${ch} --runner claude`];
-  return { reason: "no_wake_layer", harness, ...(source === undefined ? {} : { harness_source: source }), remedy };
+    found.harness === "codex"
+      ? [`party hook install --codex`, `party bridge codex ${ch}`]
+      : [`claude plugin install agentparty@agentparty`];
+  return { reason: "no_wake_layer", harness: found.harness, harness_source: found.source, remedy };
 }
 
 // 终端可读版：把结构化建议渲染成一句「怎么修」。codex 档绝不说「装插件即可」——那是 Claude 专属，
@@ -221,12 +265,25 @@ export function wakeGuidanceOf(r: Row, channel: string): WakeGuidance | undefine
 export function wakeGuidanceNote(g: WakeGuidance | undefined): string {
   if (g === undefined) return "";
   if (g.harness === "codex") {
-    return ` · ↳ fix: a codex session has no per-session inbox — it is wakeable only while a process holds its app-server connection: run ${g.remedy[0]} (interactive) or ${g.remedy[1]} (unattended)`;
+    return ` · ↳ fix: a codex session has no per-session inbox — give it the Stop hook so the @ surfaces in the session you are looking at: run ${g.remedy[0]} (then it picks pending @s up at the end of a turn), or ${g.remedy[1]} to hold its app-server connection right now`;
   }
-  if (g.harness === "claude") {
-    return ` · ↳ fix: an interactive Claude Code session is wakeable once the agentparty plugin is installed — run ${g.remedy[0]} and rejoin the channel, or ${g.remedy[1]} (unattended)`;
-  }
-  return ` · ↳ fix: no wake layer and harness unknown — start an unattended resident: ${g.remedy[0]} or ${g.remedy[1]}`;
+  return ` · ↳ fix: an interactive Claude Code session is wakeable once the agentparty plugin is installed — run ${g.remedy[0]} and rejoin the channel`;
+}
+
+/**
+ * #905：拉取式通道的可达性措辞。
+ *
+ * 这类身份既不是「在线」也不是「不可达」，而是「**用户下次用它时会收到**」——服务端看不见
+ * 它，是因为它根本不注册 presence，不是因为它死了。所以既不能标 ⚠ unreachable（结论错），
+ * 也不能标 ● online（同样错，此刻确实没人在听）。单列一档 `⇢ deferred`。
+ *
+ * 限定词一个都不能省，而且措辞必须是**条件式**的：本机装的是 codex 的全局 Stop hook，它在
+ * 「某个 codex turn 绑到这个身份」时才会去取。本机不知道用户会不会再开那个会话，也不知道这个
+ * 身份平时跑的是不是 codex——所以只说「本机上一个绑到它的 codex turn 会取走」，不说「它可达」。
+ */
+export function deferredNote(r: Row): string {
+  if (r.pull_wake === undefined) return "";
+  return ` · ⇢ deferred (local view: a codex turn under this identity on this machine picks the @ up via the Stop hook)`;
 }
 
 // kind 已知取 kind；旧 presence 行没回填时 UUID 名判 human（网页登录会话），其余判 agent。
@@ -597,7 +654,13 @@ function humanAge(ms: number): string {
  */
 export function buildRows(
   presence: PresenceEntry[],
-  ctx: { now: number; channel: string; cursorOf?: Map<string, number>; runtimePeers?: RuntimePeerDiscovery },
+  ctx: {
+    now: number;
+    channel: string;
+    cursorOf?: Map<string, number>;
+    runtimePeers?: RuntimePeerDiscovery;
+    pullWake?: PullWakeLookup;
+  },
 ): Row[] {
   const { now, channel } = ctx;
   return annotateTopologyConflicts(
@@ -606,7 +669,14 @@ export function buildRows(
         .map((e) => classify(e, now))
         .filter((r): r is Row => r !== null)
         .map((r) => ({ ...r, read_seq: ctx.cursorOf?.get(r.name) }))
-        // #879：unreachable 的身份补一条「怎么修」——按 harness 分叉，JSON 也带结构化判据。
+        // #905：拉取式唤醒线索必须在 wakeGuidanceOf 之前贴上——它既是「别再给装 hook 的建议」
+        // 的依据，也是离线身份唯一可得的 harness 判据。顺序颠倒就会对已装 hook 的身份重复劝装。
+        .map((r) => {
+          if (r.kind !== "agent") return r;
+          const hint = ctx.pullWake?.hintFor(r.name);
+          return hint === undefined ? r : { ...r, pull_wake: hint };
+        })
+        // #879/#891：没有唤醒层、且 harness 判据确实在场的身份补一条「怎么修」。判不出就不给。
         .map((r) => {
           const guidance = wakeGuidanceOf(r, channel);
           return guidance === undefined ? r : { ...r, wake_guidance: guidance };
@@ -636,7 +706,15 @@ export function renderRow(r: Row, now: number, lastSeq: number): string {
       : "";
   const age = r.tier === "online" ? "" : ` (${humanAge(r.age_ms)})`;
   // #664：recent 档里真·不可达的（无活 wake 通道 + 陈旧）单独标出，别和「最近露面、或许在轮询」混淆。
-  const unreach = r.unreachable === true ? " · ⚠ unreachable (mention lands in history only)" : "";
+  // #905：措辞改了两处。其一，装了拉取式通道（codex Stop hook）的身份走 deferredNote，不再被
+  // 断言成 unreachable——结论本来就是错的。其二，「mention lands in history only」也是过度断言：
+  // @ 是持久 directed delivery，会挂成该身份的接待欠账等它下次跑起来，不是掉进历史就没了。
+  const unreach =
+    r.pull_wake !== undefined
+      ? deferredNote(r)
+      : r.unreachable === true
+        ? " · ⚠ no live wake layer (the @ waits as this identity's reception debt until it next runs)"
+        : "";
   return `${DOT[r.tier]} ${r.tier.padEnd(8)} ${r.name}  [${r.kind}]${identityNote(r)}${busyNote(r)}${waitingOwnerNote(r)}${unhandledMentionNote(r)}${receiptNote(r, now)}${scopeNote(r)}${topologyNote(r)}${taskNote(r, now)}${activityNote(r, now)}${livenessNote(r)}${receptionNote(r)}${sessionNote(r)}${wake}${unreach}${wakeGuidanceNote(r.wake_guidance)}${read}${duplicate}${age}`;
 }
 
@@ -704,7 +782,14 @@ export async function run(argv: string[]): Promise<number> {
       ...(lastSeq > 0 ? { unread: unreadFromCursor(lastSeq, channel) } : {}),
     });
     const now = Date.now();
-    const rows = buildRows(presence, { now, channel, cursorOf, runtimePeers });
+    // #905：本机拉取式唤醒线索。纯本地读盘，扫一次目录，失败即当作「没有」（不影响其余输出）。
+    let pullWake: PullWakeLookup | undefined;
+    try {
+      pullWake = buildPullWakeLookup(channel, cfg.server);
+    } catch {
+      pullWake = undefined;
+    }
+    const rows = buildRows(presence, { now, channel, cursorOf, runtimePeers, pullWake });
     if (flags.json === true) {
       for (const r of rows) console.log(JSON.stringify(r));
       return 0;

--- a/cli/src/pull-wake.ts
+++ b/cli/src/pull-wake.ts
@@ -1,0 +1,113 @@
+// 拉取式唤醒通道的可达性（issue #905）。
+//
+// 背景：#899/#901 的 codex Stop hook 是一条**拉取式**唤醒通道——会话在自己 turn 结束时
+// 主动来取欠账，服务端从头到尾不知道它存在，也没有任何 presence 注册。于是 `who` 那套
+// 「有没有活连接 / 有没有通知订阅」的可达性判据永远看不见它，把实际可达的身份判成
+// unreachable，还顺手建议去挂 `party serve`——恰恰是 #897 里 owner 明确不要的后台 runner。
+//
+// 为什么不做「hook 上报能力位」：Stop hook 眼下是**全程零网络**的同步读盘路径（见
+// codex-stop-wake.ts 文件头的预算说明），而 #903 正在改这条路径。往里塞一次能力位上报，
+// 既要抢 #903 正在动的文件，又要给一条以「零网络」为设计前提的 hook 加上网络依赖。
+// 更根本的是：上报一次就得考虑它什么时候失效——hook 被卸载、身份换机器、config 被删，
+// 服务端都无从知晓，于是能力位会变成一个**永不过期的谎**，比现在的误判更难发现。
+//
+// 所以这里退而求其次，并且**如实标注这只是本机视角**：
+//   - 本机 ~/.codex/hooks.json 里确实挂着 `party hook codex-stop`；
+//   - 本机 ~/.agentparty/agents 里确实有这个身份、这个频道、这台服务器的 config。
+// 两条都成立时，这条 @ 会在该身份下次在**本机**跑 codex 时被它自己取走。别的机器有没有装、
+// 用户还会不会再开那个会话，本机一概不知道——所以措辞只说「本机可拉取」，绝不说「可达」。
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { localAgentConfigsForChannel } from "./config";
+
+/** codex Stop hook 的命令指纹。与 hook.ts 的 codexHookSettingsJson 写入的命令一致。 */
+export const CODEX_STOP_HOOK_COMMAND = "hook codex-stop";
+
+/**
+ * 一个身份的「拉取式唤醒」线索。
+ *
+ * scope 恒为 "local"：这是本机文件系统的观察结果，不是服务端事实。任何消费方（终端行、
+ * JSON、未来的 web）都必须把它当作本机视角展示，不许升格成服务端可达性。
+ */
+export interface PullWakeHint {
+  scope: "local";
+  /** 这条拉取通道属于哪个 harness。目前只有 codex Stop hook 一种。 */
+  harness: "codex";
+  /** 判据清单，便于调用方解释「凭什么这么说」。 */
+  evidence: ["codex_stop_hook", "local_agent_config"];
+}
+
+/** ~/.codex/hooks.json 的位置。注入 userHome 仅为单测。 */
+export function codexHooksPath(userHome: string = homedir()): string {
+  return join(userHome, ".codex", "hooks.json");
+}
+
+/**
+ * 本机是否挂着 codex Stop hook。
+ *
+ * 只认 `hooks.Stop[*].hooks[*].command` 里含指纹的条目：文件不存在、JSON 坏了、形状不对
+ * 一律返回 false。**读不到就当没有**——多标一个 unreachable 只是少给一条提示，
+ * 错标一个「可拉取」却会让人以为消息有人接。
+ */
+export function hasCodexStopHook(path: string = codexHooksPath()): boolean {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return false;
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return false;
+  const hooks = (parsed as Record<string, unknown>).hooks;
+  if (typeof hooks !== "object" || hooks === null || Array.isArray(hooks)) return false;
+  const stop = (hooks as Record<string, unknown>).Stop;
+  if (!Array.isArray(stop)) return false;
+  for (const group of stop) {
+    if (typeof group !== "object" || group === null || Array.isArray(group)) continue;
+    const inner = (group as Record<string, unknown>).hooks;
+    if (!Array.isArray(inner)) continue;
+    for (const entry of inner) {
+      if (typeof entry !== "object" || entry === null || Array.isArray(entry)) continue;
+      const command = (entry as Record<string, unknown>).command;
+      if (typeof command === "string" && command.includes(CODEX_STOP_HOOK_COMMAND)) return true;
+    }
+  }
+  return false;
+}
+
+/** 本机为该频道 + 该服务器持有 config 的身份名集合。 */
+export function locallyConfiguredNames(channel: string, server: string): Set<string> {
+  const names = new Set<string>();
+  // currentConfigPath=null：当前身份自己也要算进来——它同样会被本机的 Stop hook 取走欠账。
+  for (const hint of localAgentConfigsForChannel(channel, null)) {
+    // #865：本机两台生产实例都有同名频道。不比服务器就会把隔壁实例的同名身份认成本机可拉取。
+    if (hint.server !== server) continue;
+    names.add(hint.name);
+  }
+  return names;
+}
+
+export interface PullWakeLookup {
+  /** 该身份在本机是否有拉取式唤醒通道。 */
+  hintFor: (name: string) => PullWakeHint | undefined;
+}
+
+/**
+ * 建一次索引，供整张 who 表复用——每行各自读盘会把 who 变成 N 次目录扫描。
+ * 没装 hook 时直接返回恒空的查询器，连 agents 目录都不扫。
+ */
+export function buildPullWakeLookup(
+  channel: string,
+  server: string,
+  deps: { hasHook?: () => boolean; names?: (channel: string, server: string) => Set<string> } = {},
+): PullWakeLookup {
+  const hasHook = deps.hasHook ?? (() => hasCodexStopHook());
+  if (!hasHook()) return { hintFor: () => undefined };
+  const names = (deps.names ?? locallyConfiguredNames)(channel, server);
+  return {
+    hintFor: (name: string) =>
+      names.has(name)
+        ? { scope: "local", harness: "codex", evidence: ["codex_stop_hook", "local_agent_config"] }
+        : undefined,
+  };
+}

--- a/cli/test/who.test.ts
+++ b/cli/test/who.test.ts
@@ -16,7 +16,12 @@ import {
   waitingOwnerNote,
   wakeGuidanceNote,
   wakeGuidanceOf,
+  wakeHarnessOf,
 } from "../src/commands/who";
+import { buildPullWakeLookup, hasCodexStopHook, locallyConfiguredNames, type PullWakeLookup } from "../src/pull-wake";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 const NOW = 1_000_000_000;
 
@@ -473,10 +478,13 @@ describe("who liveness tiers (#603)", () => {
 });
 
 
-// #879：unreachable 只说了「叫不醒」，没说「怎么修」。修法按 harness 分叉——codex 会话没有默认的
-// per-session socket 收件箱（实测：app-server 的 unix:// 是 socket activation，不自建监听），
-// 所以只有 bridge / serve 持有它的 app-server 连接时才可达；Claude Code 交互式会话装了插件即可达。
-describe("who wake guidance（#879 方向 2：没有唤醒层时给可操作提示）", () => {
+// #879/#891：unreachable 只说了「叫不醒」，没说「怎么修」；#879 按 harness 分叉给建议，但它选的
+// 两个判据字段（agent_session / reception_runner）**只有活跃身份的 presence 才有**，而提示只对
+// **离线**身份显示——判据与展示场景在时间上互斥，于是真机上 10 个身份里 7 个全落 unknown 兜底。
+//
+// 本 describe 的核心不是「字段在场时分叉正确」（#879 已测过，也确实全绿），而是把 #891 的真机形态
+// **变成第一等测试样本**：离线身份**没有**这些字段。那种形态下正确行为是闭嘴，不是兜底。
+describe("who wake guidance（#879/#891：判据在场才给建议，判不出就闭嘴）", () => {
   const STALE = { state: "offline" as const, wake: { kind: "none" as const }, last_seen: NOW - 88 * 60 * 60 * 1000 };
   function row(over: Partial<PresenceEntry> & { name: string }) {
     const r = classify(p({ ...STALE, ...over }), NOW);
@@ -484,7 +492,7 @@ describe("who wake guidance（#879 方向 2：没有唤醒层时给可操作提�
     return r as NonNullable<ReturnType<typeof classify>>;
   }
 
-  test("codex 身份（agent_session.harness）→ 结构化建议指向 bridge/serve", () => {
+  test("codex 身份（agent_session.harness）→ 建议装 Stop hook / bridge，不含 serve", () => {
     const g = wakeGuidanceOf(
       row({ name: "lark-agentparty-codex", agent_session: { harness: "codex", session_id: "s1", updated_at: NOW } }),
       "pwtk",
@@ -493,7 +501,7 @@ describe("who wake guidance（#879 方向 2：没有唤醒层时给可操作提�
       reason: "no_wake_layer",
       harness: "codex",
       harness_source: "agent_session",
-      remedy: ["party bridge codex pwtk", "party serve pwtk --runner codex"],
+      remedy: ["party hook install --codex", "party bridge codex pwtk"],
     });
   });
 
@@ -510,7 +518,7 @@ describe("who wake guidance（#879 方向 2：没有唤醒层时给可操作提�
     expect(viaReception?.harness_source).toBe("reception_runner");
   });
 
-  test("claude 身份 → 建议装插件 / serve --runner claude，绝不出现 codex 专属命令", () => {
+  test("claude 身份 → 建议装插件，绝不出现 codex 专属命令", () => {
     const g = wakeGuidanceOf(
       row({ name: "kyc-claude", agent_session: { harness: "claude", session_id: "s1", updated_at: NOW } }),
       "pwtk",
@@ -519,15 +527,25 @@ describe("who wake guidance（#879 方向 2：没有唤醒层时给可操作提�
       reason: "no_wake_layer",
       harness: "claude",
       harness_source: "agent_session",
-      remedy: ["claude plugin install agentparty@agentparty", "party serve pwtk --runner claude"],
+      remedy: ["claude plugin install agentparty@agentparty"],
     });
   });
 
-  test("harness 未知 → 不硬造，给通用的无人值守建议", () => {
-    const g = wakeGuidanceOf(row({ name: "mystery" }), "pwtk");
-    expect(g?.harness).toBe("unknown");
-    expect(g?.harness_source).toBeUndefined();
-    expect(g?.remedy).toEqual(["party serve pwtk --runner codex", "party serve pwtk --runner claude"]);
+  // ★ #891 的真机形态：这正是 `party who agentparty` 上 7/10 行的样子——离线、陈旧、
+  //   agent_session 和 reception_runner 双双缺席。#879 的单测样本从没覆盖过它。
+  test("#891 真机形态（离线身份缺判据字段）→ 完全不给建议，而不是兜底并列两条命令", () => {
+    for (const name of ["claude-statebar-codex", "lark-ad72b3f9749e-agentparty-codex1", "leo-claude"]) {
+      const r = row({ name });
+      expect(r.unreachable).toBe(true);
+      expect(r.agent_session).toBeUndefined();
+      expect(r.reception_runner).toBeUndefined();
+      expect(wakeGuidanceOf(r, "agentparty")).toBeUndefined();
+    }
+  });
+
+  test("#891：名字带 -codex/-claude 后缀不构成 harness 证据，绝不据此断言", () => {
+    expect(wakeHarnessOf(row({ name: "lark-ad72b3f9749e-agentparty-codex" }))).toBeUndefined();
+    expect(wakeHarnessOf(row({ name: "leo-claude" }))).toBeUndefined();
   });
 
   test("有唤醒层的身份不给建议（online / wakeable / 刚断线都不加噪音）", () => {
@@ -538,39 +556,40 @@ describe("who wake guidance（#879 方向 2：没有唤醒层时给可操作提�
     expect(
       wakeGuidanceOf(row({ name: "srv", wake: { kind: "serve" }, last_seen: NOW, agent_session: session }), "c"),
     ).toBeUndefined();
-    expect(
-      wakeGuidanceOf(row({ name: "fresh", last_seen: NOW - 30_000, agent_session: session }), "c"),
-    ).toBeUndefined();
   });
 
-  test("人类不靠 bridge/serve 唤醒，不给建议", () => {
+  test("人类不靠 bridge/hook 唤醒，不给建议", () => {
     const human = classify(p({ ...STALE, name: "leo", kind: "human", paused: true }), NOW);
     expect(human?.kind).toBe("human");
     expect(wakeGuidanceOf(human as NonNullable<typeof human>, "c")).toBeUndefined();
   });
 
-  test("codex 提示整段文案：含 bridge/serve，且不含「装插件即可」这类 Claude 专属说法", () => {
+  test("codex 提示整段文案：指向 Stop hook / bridge，且既不含「装插件」也不含 serve", () => {
     const note = wakeGuidanceNote({
       reason: "no_wake_layer",
       harness: "codex",
-      remedy: ["party bridge codex pwtk", "party serve pwtk --runner codex"],
+      harness_source: "agent_session",
+      remedy: ["party hook install --codex", "party bridge codex pwtk"],
     });
     expect(note).toBe(
-      " · ↳ fix: a codex session has no per-session inbox — it is wakeable only while a process holds its app-server connection: run party bridge codex pwtk (interactive) or party serve pwtk --runner codex (unattended)",
+      " · ↳ fix: a codex session has no per-session inbox — give it the Stop hook so the @ surfaces in the session you are looking at: run party hook install --codex (then it picks pending @s up at the end of a turn), or party bridge codex pwtk to hold its app-server connection right now",
     );
     expect(note).not.toContain("plugin");
+    expect(note).not.toContain("party serve");
   });
 
-  test("claude 提示整段文案：不含任何 codex 专属命令", () => {
+  test("claude 提示整段文案：不含任何 codex 专属命令，也不含 serve", () => {
     const note = wakeGuidanceNote({
       reason: "no_wake_layer",
       harness: "claude",
-      remedy: ["claude plugin install agentparty@agentparty", "party serve pwtk --runner claude"],
+      harness_source: "agent_session",
+      remedy: ["claude plugin install agentparty@agentparty"],
     });
     expect(note).toBe(
-      " · ↳ fix: an interactive Claude Code session is wakeable once the agentparty plugin is installed — run claude plugin install agentparty@agentparty and rejoin the channel, or party serve pwtk --runner claude (unattended)",
+      " · ↳ fix: an interactive Claude Code session is wakeable once the agentparty plugin is installed — run claude plugin install agentparty@agentparty and rejoin the channel",
     );
     expect(note).not.toContain("codex");
+    expect(note).not.toContain("party serve");
   });
 
   test("没有建议时不输出任何提示（不给全员加噪音）", () => {
@@ -579,19 +598,147 @@ describe("who wake guidance（#879 方向 2：没有唤醒层时给可操作提�
 
   test("help 文案钉住 codex 无 per-session 收件箱这条硬事实与 JSON 字段名", () => {
     expect(HELP_TEXT).toContain("wake_guidance");
+    expect(HELP_TEXT).toContain("pull_wake");
     expect(HELP_TEXT).toContain("A codex session has NO per-session");
     expect(HELP_TEXT).toContain("party bridge codex");
+    expect(HELP_TEXT).toContain("party hook install --codex");
   });
 });
 
-// #879 装配层：note 函数单测全绿、真机什么都不显示，是本仓反复出现的失败模式。这里断言的是
-// presence → 行 → 终端字符串这条链本身：wake_guidance 真的挂到了行上，也真的渲染进了那一行。
-describe("who 唤醒建议的装配（#879：presence → 行 → 终端一行）", () => {
+// #905：拉取式唤醒通道（codex Stop hook）的可达性表达。
+describe("who pull-based reachability（#905：既不是在线，也不是不可达）", () => {
+  const CH = "agentparty";
+  const stale = (over: Partial<PresenceEntry> & { name: string }): PresenceEntry =>
+    p({ state: "offline", wake: { kind: "none" }, last_seen: NOW - 88 * 60 * 60 * 1000, ...over });
+  const lookup = (names: string[]): PullWakeLookup =>
+    buildPullWakeLookup(CH, "https://s", { hasHook: () => true, names: () => new Set(names) });
+
+  test("装了 Stop hook 的身份：不再断言 unreachable，改说「下次跑起来时会取到」", () => {
+    const rows = buildRows([stale({ name: "lark-codex1" })], {
+      now: NOW,
+      channel: CH,
+      pullWake: lookup(["lark-codex1"]),
+    });
+    const r = rows[0] as NonNullable<(typeof rows)[number]>;
+    expect(r.pull_wake).toEqual({
+      scope: "local",
+      harness: "codex",
+      evidence: ["codex_stop_hook", "local_agent_config"],
+    });
+    const line = renderRow(r, NOW, 0);
+    expect(line).toContain("⇢ deferred");
+    expect(line).toContain("picks the @ up via the Stop hook");
+    expect(line).not.toContain("⚠ no live wake layer");
+    expect(line).not.toContain("unreachable");
+    // 已经装过 hook 的身份不该再被劝装一遍。
+    expect(line).not.toContain("↳ fix");
+  });
+
+  test("措辞保留「本机视角」限定——绝不把本机观察升格成服务端可达性", () => {
+    const rows = buildRows([stale({ name: "x" })], { now: NOW, channel: CH, pullWake: lookup(["x"]) });
+    expect(renderRow(rows[0] as NonNullable<(typeof rows)[number]>, NOW, 0)).toContain("local view:");
+  });
+
+  test("本机没这个身份的 config → 不点亮，行仍走无唤醒层措辞", () => {
+    const rows = buildRows([stale({ name: "someone-else" })], {
+      now: NOW,
+      channel: CH,
+      pullWake: lookup(["not-them"]),
+    });
+    expect(rows[0]?.pull_wake).toBeUndefined();
+    expect(renderRow(rows[0] as NonNullable<(typeof rows)[number]>, NOW, 0)).toContain("⚠ no live wake layer");
+  });
+
+  test("本机没装 Stop hook → 一个身份都不点亮（连 agents 目录都不扫）", () => {
+    let scanned = false;
+    const l = buildPullWakeLookup(CH, "https://s", {
+      hasHook: () => false,
+      names: () => {
+        scanned = true;
+        return new Set(["a"]);
+      },
+    });
+    expect(l.hintFor("a")).toBeUndefined();
+    expect(scanned).toBe(false);
+  });
+
+  test("人类身份不走拉取式通道（Stop hook 是 agent 会话的东西）", () => {
+    const rows = buildRows([p({ name: "leo", kind: "human", live: true })], {
+      now: NOW,
+      channel: CH,
+      pullWake: lookup(["leo"]),
+    });
+    expect(rows[0]?.pull_wake).toBeUndefined();
+  });
+
+  // #865：本机两台生产实例都有同名频道 #agentparty。不比服务器就会把隔壁实例上的同名身份
+  // 认成「本机可拉取」——那条 @ 根本不在同一台服务器上，永远等不到人取。
+  test("locallyConfiguredNames：同频道但不同 server 的本机 config 不算数（#865）", () => {
+    const home = mkdtempSync(join(tmpdir(), "who-agents-home-"));
+    mkdirSync(join(home, "agents"), { recursive: true });
+    const put = (file: string, name: string, server: string) =>
+      writeFileSync(
+        join(home, "agents", file),
+        JSON.stringify({ server, token: "ap_x", identity: { name, kind: "agent", channel_scope: "agentparty" } }),
+      );
+    put("here.json", "codex-002", "https://agentparty.pwtk-dev.work");
+    put("there.json", "codex-002-elsewhere", "https://agentparty.leeguoo.com");
+    put("other-channel.json", "unrelated", "https://agentparty.pwtk-dev.work");
+    writeFileSync(
+      join(home, "agents", "other-channel.json"),
+      JSON.stringify({
+        server: "https://agentparty.pwtk-dev.work",
+        token: "ap_x",
+        identity: { name: "unrelated", kind: "agent", channel_scope: "pwtk" },
+      }),
+    );
+    const prev = process.env.AGENTPARTY_HOME;
+    process.env.AGENTPARTY_HOME = home;
+    try {
+      const names = locallyConfiguredNames("agentparty", "https://agentparty.pwtk-dev.work");
+      expect(names.has("codex-002")).toBe(true);
+      expect(names.has("codex-002-elsewhere")).toBe(false); // 隔壁实例
+      expect(names.has("unrelated")).toBe(false); // 隔壁频道
+    } finally {
+      if (prev === undefined) delete process.env.AGENTPARTY_HOME;
+      else process.env.AGENTPARTY_HOME = prev;
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  test("hasCodexStopHook：只认 Stop 事件里带我们指纹的 command，坏文件一律 false", () => {
+    const dir = mkdtempSync(join(tmpdir(), "who-pullwake-"));
+    const write = (body: string) => {
+      const f = join(dir, `${Math.random().toString(36).slice(2)}.json`);
+      writeFileSync(f, body);
+      return f;
+    };
+    expect(hasCodexStopHook(write(JSON.stringify({
+      hooks: { Stop: [{ hooks: [{ type: "command", command: '"/x/party" hook codex-stop' }] }] },
+    })))).toBe(true);
+    // SessionStart 的 codex-report 不算——它不是唤醒通道。
+    expect(hasCodexStopHook(write(JSON.stringify({
+      hooks: { SessionStart: [{ hooks: [{ type: "command", command: "party hook codex-report" }] }] },
+    })))).toBe(false);
+    // 别人的 Stop hook 不算。
+    expect(hasCodexStopHook(write(JSON.stringify({
+      hooks: { Stop: [{ hooks: [{ type: "command", command: "/usr/local/bin/other-tool" }] }] },
+    })))).toBe(false);
+    expect(hasCodexStopHook(write("not json"))).toBe(false);
+    expect(hasCodexStopHook(write(JSON.stringify({ hooks: { Stop: "oops" } })))).toBe(false);
+    expect(hasCodexStopHook(join(dir, "missing.json"))).toBe(false);
+    rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+// #879/#891 装配层：note 函数单测全绿、真机什么都不显示（或反过来：真机全是兜底噪音），是本仓
+// 反复出现的失败模式。这里断言的是 presence → 行 → 终端字符串这条链本身。
+describe("who 唤醒建议的装配（presence → 行 → 终端一行）", () => {
   const CH = "pwtk";
   const stale = (over: Partial<PresenceEntry> & { name: string }): PresenceEntry =>
     p({ state: "offline", wake: { kind: "none" }, last_seen: NOW - 88 * 60 * 60 * 1000, ...over });
 
-  test("codex unreachable 行既带结构化 wake_guidance，也把 fix 提示渲染进终端那一行", () => {
+  test("codex 行既带结构化 wake_guidance，也把 fix 提示渲染进终端那一行", () => {
     const rows = buildRows(
       [stale({ name: "lark-codex", agent_session: { harness: "codex", session_id: "s", updated_at: NOW } })],
       { now: NOW, channel: CH },
@@ -600,26 +747,47 @@ describe("who 唤醒建议的装配（#879：presence → 行 → 终端一行�
       reason: "no_wake_layer",
       harness: "codex",
       harness_source: "agent_session",
-      remedy: ["party bridge codex pwtk", "party serve pwtk --runner codex"],
+      remedy: ["party hook install --codex", "party bridge codex pwtk"],
     });
     const line = renderRow(rows[0] as NonNullable<(typeof rows)[number]>, NOW, 0);
-    expect(line).toContain("⚠ unreachable (mention lands in history only)");
-    expect(line).toContain(
-      "↳ fix: a codex session has no per-session inbox — it is wakeable only while a process holds its app-server connection: run party bridge codex pwtk (interactive) or party serve pwtk --runner codex (unattended)",
-    );
+    expect(line).toContain("⚠ no live wake layer");
+    expect(line).toContain("party hook install --codex");
   });
 
-  test("claude unreachable 行渲染 Claude 专属修法，且整行不含 codex 命令", () => {
+  test("claude 行渲染 Claude 专属修法，且整行不含 codex 命令", () => {
     const rows = buildRows(
       [stale({ name: "kyc-claude", agent_session: { harness: "claude", session_id: "s", updated_at: NOW } })],
       { now: NOW, channel: CH },
     );
     const line = renderRow(rows[0] as NonNullable<(typeof rows)[number]>, NOW, 0);
     expect(line).toContain(
-      "↳ fix: an interactive Claude Code session is wakeable once the agentparty plugin is installed — run claude plugin install agentparty@agentparty and rejoin the channel, or party serve pwtk --runner claude (unattended)",
+      "↳ fix: an interactive Claude Code session is wakeable once the agentparty plugin is installed — run claude plugin install agentparty@agentparty and rejoin the channel",
     );
     expect(line).not.toContain("party bridge codex");
     expect(line).not.toContain("--runner codex");
+  });
+
+  // ★ #905 的验收线：整张表里不许再有一行叫人去挂 serve 来解决前台唤醒。
+  test("#897/#905：真机形态的整张表里，没有任何一行建议 party serve", () => {
+    const rows = buildRows(
+      [
+        stale({ name: "claude-statebar-codex", residency: "daemon" }),
+        stale({ name: "lark-ad72b3f9749e-agentparty", residency: "supervised" }),
+        stale({ name: "lark-ad72b3f9749e-agentparty-codex", residency: "episodic" }),
+        stale({ name: "leo-claude" }),
+        stale({ name: "super-admin-bug-7744", last_seen: NOW - 3 * 24 * 60 * 60 * 1000 }),
+        stale({ name: "kyc-claude", agent_session: { harness: "claude", session_id: "s", updated_at: NOW } }),
+      ],
+      { now: NOW, channel: "agentparty" },
+    );
+    const lines = rows.map((r) => renderRow(r, NOW, 0));
+    expect(lines.length).toBe(6);
+    for (const line of lines) {
+      expect(line).not.toContain("party serve");
+      expect(line).not.toContain("harness unknown");
+    }
+    // 五个没有判据的身份一条 fix 都不给；唯一有判据的那个才给。
+    expect(lines.filter((line) => line.includes("↳ fix")).length).toBe(1);
   });
 
   test("可唤醒的身份行里没有任何 fix 提示（不给全频道加噪音）", () => {


### PR DESCRIPTION
Closes #891
Closes #905

## 问题：`party who` 这一行几乎全是噪音

真机 `party who agentparty`，10 个身份里 7 个长得一模一样。三个独立缺陷叠在同一行。

## 真机前后对照（本机 pwtk 实例，`AGENTPARTY_CONFIG=~/.agentparty/agents/agentparty-codex-002-agentparty.json`）

**Before**
```
● online   lark-ad72b3f97491-agentparty  [agent] · same workspace as codex-002
● online   lark:on_22608d74bd2d7f39f6dc67d0da248fa5  [human] (@leo · leo · …) · read ✓
● online   macmini  [agent]
○ recent   claude-statebar-codex  [agent] · ⚠ unreachable (mention lands in history only) · ↳ fix: no wake layer and harness unknown — start an unattended resident: party serve agentparty --runner codex or party serve agentparty --runner claude (19h)
○ recent   lark-ad72b3f9749e-agentparty  [agent] · ⚠ unreachable (mention lands in history only) · ↳ fix: no wake layer and harness unknown — start an unattended resident: party serve agentparty --runner codex or party serve agentparty --runner claude (19h)
○ recent   lark-ad72b3f9749e-agentparty-codex  [agent] (…) · ⚠ unreachable (mention lands in history only) · ↳ fix: no wake layer and harness unknown — … (22h)
○ recent   lark-ad72b3f9749e-agentparty-codex1  [agent] (…) · ⚠ unreachable (mention lands in history only) · ↳ fix: no wake layer and harness unknown — … (3h)
○ recent   leo-claude  [agent] (…) · ⚠ unreachable (mention lands in history only) · ↳ fix: no wake layer and harness unknown — … (1d)
○ recent   super-admin-bug-7744  [agent] · ⚠ unreachable (mention lands in history only) · ↳ fix: no wake layer and harness unknown — … (3d)
```
7/7 离线身份全落 `harness unknown`，7/7 都在劝人去挂 `party serve`。

**After**
```
● online   lark:on_22608d74bd2d7f39f6dc67d0da248fa5  [human] (@leo · leo · …) · read ✓
● online   macmini  [agent]
○ recent   claude-statebar-codex  [agent] · ⇢ deferred (local view: a codex turn under this identity on this machine picks the @ up via the Stop hook) (19h)
○ recent   lark-ad72b3f97491-agentparty  [agent] · ⇢ deferred (local view: a codex turn under this identity on this machine picks the @ up via the Stop hook) (11m)
○ recent   lark-ad72b3f9749e-agentparty  [agent] · ⇢ deferred (local view: …) (19h)
○ recent   lark-ad72b3f9749e-agentparty-codex  [agent] (…) · ⇢ deferred (local view: …) (23h)
○ recent   lark-ad72b3f9749e-agentparty-codex1  [agent] (…) · ⇢ deferred (local view: …) (3h)
○ recent   leo-claude  [agent] (…) · ⇢ deferred (local view: …) (1d)
○ recent   super-admin-bug-7744  [agent] · ⚠ no live wake layer (the @ waits as this identity's reception debt until it next runs) (3d)
```
- 恒 unknown 的 harness：**没有了**（这一档被删掉，判不出就闭嘴）
- 装了 Stop hook 的身份不再被标 `unreachable`
- **`party who agentparty --json | grep -c "party serve"` → 0**，整张表没有任何一行建议去挂 serve

`super-admin-bug-7744` 是唯一本机没有 config 的身份，如实保留「无唤醒层」——它也没有拿到编造的 fix 建议。

## 拉取式可达性最终采用的表达方式与理由

新增一档 **`⇢ deferred`**，JSON 里是 `pull_wake: {scope:"local", harness:"codex", evidence:[…]}`。

理由：Stop hook 的会话既不是「在线」（此刻确实没人在听）也不是「不可达」（结论是错的），
它是「用户下次用它时会收到」。服务端看不见它不是因为它死了，而是因为**它根本不注册 presence**——
这正是 #905 的成因，所以任何基于在线连接/通知订阅的判据都不可能修好它。单独一档才说得清。

**判据为什么走本机、而不是 hook 上报能力位**（第 2 点的可行性评估结论）：

1. Stop hook 眼下是**全程零网络**的同步读盘路径（`codex-stop-wake.ts` 文件头有明确预算说明），
   而 **#903 正在改这条路径**给它加轻量网络查询。往里塞能力位上报会直接抢 `codex-stop-wake.ts` /
   `hook.ts`。
2. 更根本的问题不是撞车而是语义：上报一次之后**没人能让它失效**——hook 被卸载、身份换机器、
   config 被删，服务端一概不知道。能力位会变成一个**永不过期的谎**，比现在的误判更难发现。
   持续 presence 又把「拉取式」的成本优势整个抵消掉，也不符合它的语义。

所以按任务里的退路做：本机检测（`~/.codex/hooks.json` 里有我们的 `hook codex-stop` **且**
`~/.agentparty/agents/` 里有该身份 + 该频道 + **该服务器**的 config），措辞保留 `local view` 限定，
并且是**条件式**的——只说「本机上一个绑到它的 codex turn 会取走」，不说「它可达」。别的机器装没装、
用户还会不会再开那个会话，本机一概不知道。

## #891：判据错位怎么修

`WakeGuidance.harness` **删掉 `unknown` 这一档**。原来的三分支里 unknown 是唯一会在真机点亮的那支，
因为判据字段只对活跃身份存在、提示只对离线身份显示。现在判据取不到就 `return undefined`，一个字不说。
名字里的 `-codex` / `-claude` 后缀**不构成证据**，不据此断言（有专门的测试钉住）。
唯一新增的、对离线身份仍然可得的判据是上面那条本机拉取线索，它推出的措辞里必须保留本机限定。

同时把 `wakeGuidanceOf` 的触发条件从 `unreachable` 放宽到「没有唤醒层」，让判据仍在场的那批行不被过滤掉。

顺带修掉另一处过度断言：`mention lands in history only` 也是错的——@ 是持久 directed delivery，
会挂成该身份的接待欠账等它下次跑起来，不是掉进历史就没了。

## 与 #903 的协调点

**没有接口依赖，两边可独立合并。** 本 PR 一行没碰 `cli/src/codex-stop-wake.ts` 和
`cli/src/commands/hook.ts`（`git status` 只有 `who.ts` / `who.test.ts` / 新文件 `pull-wake.ts`）。

唯一的耦合是一个**常量指纹**：`pull-wake.ts` 里的 `CODEX_STOP_HOOK_COMMAND = "hook codex-stop"`，
必须与 `hook.ts` 的 `codexHookSettingsJson()` 写进 `~/.codex/hooks.json` 的命令保持一致。
**如果 #903 改了那条命令的子命令名，`who` 的 deferred 一档会静默失效**（表现为退回「无唤醒层」，
不会误报成可达，方向是安全的）。真要改名请顺手改这个常量。

将来若 #903 或后续 issue 决定让 hook 真的上报一次能力位，`pull_wake` 的形状（`scope` 字段）已经
预留了升级路径：服务端来源只需把 `scope` 从 `"local"` 换成服务端档位，展示层的限定词随之解除。

## 自检：变异验证（10 个变异，10 个全红）

整段删除级 + 等价实现替换 + **守卫自身变异**（#884：守卫会假阴性）：

| # | 变异 | 结果 |
|---|---|---|
| M1 | `deferredNote` 整段删除（恒空） | 🔴 killed |
| M2 | `buildRows` 不再把 `pull_wake` 贴到行上 | 🔴 killed |
| M3 | 回退 #891：harness 判不出时也硬给建议 | 🔴 killed |
| M4 | remedy 里把 `party serve` 塞回来（#897 的有害建议） | 🔴 killed |
| M5 | unreachable 文案回退成「mention lands in history only」 | 🔴 killed |
| M6 | 等价替换：deferred / unreachable 两个分支优先级对调 | 🔴 killed |
| M7 | **守卫变异**：`hasCodexStopHook` 恒 true（没装 hook 的机器也标可拉取） | 🔴 killed |
| M8 | **守卫变异**：`locallyConfiguredNames` 不过滤 server（#865 跨实例误认） | 🟢→🔴 |
| M9 | **守卫变异**：`hintFor` 恒给（不查本机 config） | 🔴 killed |
| M10 | 人类身份也贴 `pull_wake` | 🔴 killed |

**M8 第一轮活下来了**，是真发现：我的 deferred 测试注入了 `names`，于是 `#865` 那条
「同频道不同 server 不算数」的服务器过滤**完全没被覆盖**。补了一个走真实 `AGENTPARTY_HOME` 目录
的测试（同频道隔壁实例 + 隔壁频道两个反例）后重跑，M8 转红。

## 测试样本覆盖真机形态

本仓这条链上已连续八次「测试全绿真机是坏的」，#891 本身就是其中一次。所以新测试里把
**「离线身份缺判据字段」这个恰恰是故障成因的形态**列为一等样本：

- `#891 真机形态（离线身份缺判据字段）→ 完全不给建议` —— 直接用真机上那三个身份名构造
- `#891：名字带 -codex/-claude 后缀不构成 harness 证据`
- `#897/#905：真机形态的整张表里，没有任何一行建议 party serve` —— 用真机那 6 行的完整形态过一遍装配链，
  断言 5 个无判据身份一条 fix 都不给、只有唯一有判据的那个才给

## 验证

- `bun run check:cli` ✅ 349 pass / 0 fail + `tsc --noEmit` 干净（未动 worker，未跑 `check:worker`）
- 真机 `party who agentparty` 与 `--json` 已实跑，输出见上
