### PR TITLE
fix(cli): Claude 唤醒注入按频道身份匹配，杜绝同机跨身份误投 (#906)

### DIFF
--- a/cli/src/claude-session-registry.ts
+++ b/cli/src/claude-session-registry.ts
@@ -25,7 +25,7 @@ import {
   rmSync,
 } from "node:fs";
 import { isAbsolute, join } from "node:path";
-import { agentpartyHome } from "./config";
+import { agentpartyHome, readConfig } from "./config";
 import { atomicWriteJson } from "./atomic-json";
 
 /** 注册表覆盖的 harness 维度（#851 P2）。每个值对应一个独立目录。 */
@@ -97,6 +97,19 @@ export interface ClaudeSessionRegistryEntry {
    * 而放宽匹配。
    */
   server?: string;
+  /**
+   * 该会话绑定的**频道身份**（#906）——`config.identity.name`，也就是 msg 帧 `mentions`
+   * 里会出现的那个 handle（`lark-ad72b3f97491-agentparty`）。不是 display_name、不是
+   * 宣告名（#862 三命名空间纪律：匹配用频道身份、寻址用 pid、展示用宣告名）。
+   *
+   * 为什么必须存：选注入目标此前只按 channel + server 过滤，同一 worktree 里跑着两个
+   * 绑不同身份的会话时，@ 身份 A 的消息会被注入进身份 B 的会话——内容/频道/seq 全是真的，
+   * 收信方毫无破绽（同 #865 一类的静默误投）。
+   *
+   * 可选**只为兼容旧盘上的条目**：#906 之前写的条目没有这个字段，一律视为**不可匹配**
+   * （见 sessionEntryMatchesIdentity），由下次 SessionStart 自然升级。绝不为兼容放宽匹配。
+   */
+  identity?: string;
   cwd: string;
   registered_at: number;
   /**
@@ -140,6 +153,32 @@ export function sessionEntryMatchesServer(
   return normalizeSessionRegistryServer(entry.server) === wanted;
 }
 
+/**
+ * 频道身份的可比对形态（#906）：语义与 shared 的 mentionMatchKey 逐字对齐
+ * （NFC 归一；纯 ASCII handle 才小写，其余保持原样）——两边判「是不是同一个身份」
+ * 必须用同一把尺子，否则「命中 @」与「选中会话」会在边界字符上劈叉。
+ * 非字符串/空串/超长 → null（＝不可匹配）。
+ */
+export function normalizeSessionRegistryIdentity(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.normalize("NFC");
+  if (normalized === "" || normalized.length > 128) return null;
+  return /^[A-Za-z0-9._-]+$/.test(normalized) ? normalized.toLowerCase() : normalized;
+}
+
+/**
+ * 条目是否属于给定频道身份（#906）。任一侧解析不出身份——含**旧条目没有 identity
+ * 字段**——一律 false：宁可这一轮叫不醒（下次 SessionStart 就补上），也不同机跨身份误投。
+ */
+export function sessionEntryMatchesIdentity(
+  entry: ClaudeSessionRegistryEntry,
+  identity: string | null | undefined,
+): boolean {
+  const wanted = normalizeSessionRegistryIdentity(identity);
+  if (wanted === null) return false;
+  return normalizeSessionRegistryIdentity(entry.identity) === wanted;
+}
+
 /** 旧条目（无 harness 字段）视为 claude。 */
 export function sessionEntryHarness(entry: ClaudeSessionRegistryEntry): SessionRegistryHarness {
   return entry.harness ?? "claude";
@@ -169,6 +208,11 @@ function validEntry(value: unknown): value is ClaudeSessionRegistryEntry {
     (value.server === undefined ||
       (typeof value.server === "string" &&
         normalizeSessionRegistryServer(value.server) === value.server)) &&
+    // identity 缺席合法（#906 之前的旧条目）；在场则必须已是规范化形态，坏值按坏行
+    // 丢弃而不是当成「无 identity」——否则一条写坏的 identity 会静默退化成旧条目语义。
+    (value.identity === undefined ||
+      (typeof value.identity === "string" &&
+        normalizeSessionRegistryIdentity(value.identity) === value.identity)) &&
     typeof value.cwd === "string" &&
     value.cwd !== "" &&
     isAbsolute(value.cwd) &&
@@ -340,6 +384,12 @@ export interface RegisterClaudeSessionInput {
   channel: string;
   /** 该会话绑定的实例 URL（#865）。解析不出 origin 的值不写入——条目随之不可匹配（安全侧）。 */
   server?: string | null;
+  /**
+   * 该会话绑定的频道身份（#906）。**省略**＝让注册表自己从该会话的 config 解析
+   * （见 resolveSessionRegistryIdentity）——入册点（hook）与 config 同进程同环境，
+   * 这里读到的就是这个会话真正在用的身份。显式传 null＝不写身份（条目不可匹配）。
+   */
+  identity?: string | null;
   cwd: string;
   registered_at?: number;
   /** 省略即 claude（保持 #841 调用点逐字不变）。 */
@@ -351,11 +401,32 @@ export interface RegisterClaudeSessionInput {
  * 容量满时先剔死行；仍满则拒绝（返回 false），绝不覆盖别人的活行。
  * 容量与锁都按 harness 目录各自独立——codex 会话刷满不会挤掉 claude 会话。
  */
+/**
+ * 从该会话绑定的 config 里解析频道身份（#906）。channel_scope 与入册频道不符的缓存身份
+ * 不认（那是另一个频道的 handle），解析不出就返回 null——条目随之不可匹配，宁可漏叫。
+ */
+export function resolveSessionRegistryIdentity(cwd: string, channel: string): string | null {
+  try {
+    const identity = readConfig(cwd)?.identity;
+    if (identity === undefined || identity === null) return null;
+    if (identity.channel_scope !== null && identity.channel_scope !== undefined &&
+        identity.channel_scope !== channel) {
+      return null;
+    }
+    return normalizeSessionRegistryIdentity(identity.name);
+  } catch {
+    return null;
+  }
+}
+
 export function registerSession(
   input: RegisterClaudeSessionInput,
   env: NodeJS.ProcessEnv = process.env,
 ): boolean {
   const harness: SessionRegistryHarness = input.harness ?? "claude";
+  const identity = input.identity === undefined
+    ? resolveSessionRegistryIdentity(input.cwd, input.channel)
+    : normalizeSessionRegistryIdentity(input.identity);
   const entry: ClaudeSessionRegistryEntry = {
     version: 1,
     harness,
@@ -369,6 +440,7 @@ export function registerSession(
     ...(normalizeSessionRegistryServer(input.server) === null
       ? {}
       : { server: normalizeSessionRegistryServer(input.server)! }),
+    ...(identity === null ? {} : { identity }),
     cwd: input.cwd,
     registered_at: input.registered_at ?? Date.now(),
   };

--- a/cli/src/commands/claude-channel.ts
+++ b/cli/src/commands/claude-channel.ts
@@ -37,6 +37,7 @@ import { connect, type Connection } from "../client";
 import {
   claudeSessionAnnounceName,
   listClaudeSessions,
+  sessionEntryMatchesIdentity,
   sessionEntryMatchesServer,
   type ClaudeSessionRegistryEntry,
 } from "../claude-session-registry";
@@ -459,27 +460,37 @@ export function dormantAnnounceDisplayName(entry: ClaudeSessionRegistryEntry): s
 }
 
 /**
- * 选择要宣告的入册会话：同 **server + channel** 必须；优先同 cwd；同优先级取最新入册。
+ * 选择要宣告（并被注入）的入册会话：**server + channel + 频道身份 + cwd 全等**必须，
+ * 同优先级取最新入册。任何一维对不上就返回 null——宁可漏叫，绝不误投。
  *
  * #865：频道 slug 跨实例不唯一（两台生产实例上都有 `agentparty`），只比 slug 会让本机
  * 连着 A 实例的 announce 腿把 @ 注入到只属于 B 实例的会话——实机撞见过。旧条目（无
  * server 字段）恒不匹配，属安全侧，由下次 SessionStart 自然升级。
+ *
+ * #906：**身份维必须在场**。此前只按 channel + server 过滤、优先同 cwd、再 `?? pick(matching)`
+ * 兜底成「该频道里任意一个会话」——同一个 worktree 里跑着两个绑不同身份的会话时，@ 身份 A
+ * 的消息恒落到 registered_at 更新的那个（实机撞见）。消息内容/频道/seq 全是真的，收信方
+ * 毫无破绽，被 @ 的一方一无所知。所以：
+ * - 身份不等一律不选（旧条目无 identity 字段 ⇒ 恒不匹配，下次 SessionStart 自然升级）；
+ * - 删掉跨 cwd 兜底——「频道里随便挑一个」在有身份概念之后不成立，同身份跨 worktree 的
+ *   另一个会话同样是错的宿主（announce 进程只许唤醒自己所在 cwd 的宿主会话）。
  */
 export function selectDormantAnnounceEntry(
   entries: readonly ClaudeSessionRegistryEntry[],
   channel: string,
   cwd: string,
   server?: string | null,
+  identity?: string | null,
 ): ClaudeSessionRegistryEntry | null {
   const matching = entries.filter(
-    (entry) => entry.channel === channel && sessionEntryMatchesServer(entry, server),
+    (entry) =>
+      entry.channel === channel &&
+      sessionEntryMatchesServer(entry, server) &&
+      sessionEntryMatchesIdentity(entry, identity) &&
+      entry.cwd === cwd,
   );
   if (matching.length === 0) return null;
-  const pick = (candidates: readonly ClaudeSessionRegistryEntry[]) =>
-    candidates.length === 0
-      ? null
-      : candidates.reduce((a, b) => (b.registered_at >= a.registered_at ? b : a));
-  return pick(matching.filter((entry) => entry.cwd === cwd)) ?? pick(matching);
+  return matching.reduce((a, b) => (b.registered_at >= a.registered_at ? b : a));
 }
 
 export interface DormantAnnounceDeps {
@@ -508,6 +519,12 @@ export interface DormantAnnounceDeps {
    * dormantAnnounceMentionHit 的注释）。默认 resolveAnnounceChannelIdentity。
    */
   resolveSelfName?: (auth: { server: string; token: string }) => Promise<string | null>;
+  /**
+   * 漏叫留痕（#906）：身份维一收紧，「本机没有该身份的会话」就成了常态化的可观测事件，
+   * 绝不许静默——否则排障的人只能看到「@ 了没反应」。默认写 stderr（stdout 是 MCP
+   * 的 stdio 通道，绝不能碰）。同一句连续重复只打一次，5s 轮询不刷屏。
+   */
+  log?: (line: string) => void;
 }
 
 /**
@@ -647,6 +664,18 @@ export async function runDormantClaudeSessionAnnounce(
   // @ 注入一次。两条路径各有自己的进程内 seen，本切片**不做跨进程去重**——最终由
   // Claude 收件箱侧的 msg_id/队列去重与人工感知兜底；重复唤醒的代价远小于叫不醒。
   const injectedSeqs = new Set<number>();
+  // 漏叫留痕（#906）：同一句连续重复只打一次（5s 轮询否则刷屏）。
+  const rawLog = deps.log ?? ((line: string) => console.error(line));
+  let lastLogged: string | null = null;
+  const logOnce = (line: string) => {
+    if (line === lastLogged) return;
+    lastLogged = line;
+    try {
+      rawLog(line);
+    } catch {
+      // 日志失败绝不影响 announce 主流程。
+    }
+  };
   while (!signal.aborted) {
     // #865：先解析 auth——选目标要按 server 过滤，拿不到实例身份就一个条目都不该匹配。
     const auth = await deps.resolveAuth().catch(() => null);
@@ -654,16 +683,42 @@ export async function runDormantClaudeSessionAnnounce(
     // resolveAuth 是本循环里唯一的长 await：期间收到 abort 就绝不再建连。
     if (signal.aborted) return;
     const authServer = auth.server;
+    // 「叫我」的判据＝本机频道身份（不是宣告名，见上方三命名空间注释）。#906 起它同时
+    // 是**选注入目标**的判据，所以必须先于选目标解析：解析失败（无缓存且 /api/me 不通）
+    // ⇒ 一个条目都不该匹配，本轮不建连。
+    const selfName = await (deps.resolveSelfName ?? ((a: { server: string; token: string }) =>
+      resolveAnnounceChannelIdentity(channel, a)))({
+      server: auth.server,
+      token: auth.token,
+    }).catch(() => null);
+    if (signal.aborted) return;
+    if (selfName === null || selfName === "") {
+      logOnce(
+        `claude-channel: 解析不出本机频道身份（channel=${channel} server=${authServer}），` +
+          "本轮不宣告也不注入——绝不退回「频道里随便挑一个会话」（#906）",
+      );
+      await abortableSleep(pollMs, signal);
+      continue;
+    }
     let entry: ClaudeSessionRegistryEntry | null = null;
     try {
-      entry = selectDormantAnnounceEntry(deps.listSessions(), channel, cwd, authServer);
+      entry = selectDormantAnnounceEntry(deps.listSessions(), channel, cwd, authServer, selfName);
     } catch {
       return;
     }
     if (entry === null) {
+      logOnce(
+        `claude-channel: 本机没有身份 ${selfName} 的入册会话（channel=${channel} ` +
+          `server=${authServer} cwd=${cwd}），未宣告、未注入。旧条目（无 identity 字段）` +
+          "不参与匹配，重开一次会话即自动补上（#906）",
+      );
       await abortableSleep(pollMs, signal);
       continue;
     }
+    logOnce(
+      `claude-channel: announce 绑定会话 ${entry.session_id}（身份 ${selfName} ` +
+        `channel=${channel} cwd=${cwd}）`,
+    );
     const topology = deps.buildTopology(auth.server, entry.cwd, {
       harnessSession: {
         harness: "claude",
@@ -688,12 +743,8 @@ export async function runDormantClaudeSessionAnnounce(
     const connection = deps.connect(auth.server, auth.token, channel, startCursor, {
       runtimeTopology: topology,
     });
-    // 「叫我」的判据＝本机频道身份（不是宣告名，见上方三命名空间注释）。解析失败
-    // （无缓存且 /api/me 不通）→ selfName=null → 恒不注入，静默降级为改动前行为。
-    const selfName = await (deps.resolveSelfName ?? ((a) => resolveAnnounceChannelIdentity(channel, a)))({
-      server: auth.server,
-      token: auth.token,
-    }).catch(() => null);
+    // selfName（本机频道身份）已在选目标之前解析：注入的**触发条件**与**目标选择**
+    // 现在共用同一个值，两者绝不可能分别指向不同身份（#906）。
     if (signal.aborted) {
       connection.close();
       return;

--- a/cli/test/claude-channel-dormant-announce.test.ts
+++ b/cli/test/claude-channel-dormant-announce.test.ts
@@ -12,6 +12,9 @@ import {
 
 const SERVER = "https://party.example";
 const OTHER_SERVER = "https://other.example";
+/** 本机 announce 腿所用的频道身份（#906）；另一身份用来钉住同机跨身份误投。 */
+const SELF_IDENTITY = "lark-ad72b3f97491-agentparty";
+const OTHER_IDENTITY = "lark-ad72b3f9749e-agentparty";
 
 function entry(overrides: Partial<ClaudeSessionRegistryEntry> = {}): ClaudeSessionRegistryEntry {
   return {
@@ -21,6 +24,7 @@ function entry(overrides: Partial<ClaudeSessionRegistryEntry> = {}): ClaudeSessi
     display_name: null,
     channel: "dev",
     server: SERVER,
+    identity: SELF_IDENTITY,
     cwd: "/tmp/project",
     registered_at: 1_000,
     ...overrides,
@@ -130,46 +134,97 @@ describe("dormantAnnounceDisplayName", () => {
 });
 
 describe("selectDormantAnnounceEntry", () => {
-  test("requires the channel, prefers same cwd, then newest registration", () => {
+  test("requires the channel and the same cwd, then newest registration", () => {
     const other = entry({ session_id: "22222222-2222-4222-8222-222222222222", channel: "prod" });
-    expect(selectDormantAnnounceEntry([other], "dev", "/tmp/project", SERVER)).toBeNull();
+    expect(selectDormantAnnounceEntry([other], "dev", "/tmp/project", SERVER, SELF_IDENTITY)).toBeNull();
     const away = entry({ session_id: "33333333-3333-4333-8333-333333333333", cwd: "/elsewhere", registered_at: 9_000 });
     const here = entry({ registered_at: 1_000 });
-    expect(selectDormantAnnounceEntry([away, here], "dev", "/tmp/project", SERVER)).toBe(here);
-    expect(selectDormantAnnounceEntry([away], "dev", "/tmp/project", SERVER)).toBe(away);
+    expect(selectDormantAnnounceEntry([away, here], "dev", "/tmp/project", SERVER, SELF_IDENTITY)).toBe(here);
+    // #906：跨 cwd 兜底已删——同身份但在别的 worktree 的会话同样是错的宿主。
+    expect(selectDormantAnnounceEntry([away], "dev", "/tmp/project", SERVER, SELF_IDENTITY)).toBeNull();
     const newer = entry({ session_id: "44444444-4444-4444-8444-444444444444", registered_at: 5_000 });
-    expect(selectDormantAnnounceEntry([here, newer], "dev", "/tmp/project", SERVER)).toBe(newer);
+    expect(selectDormantAnnounceEntry([here, newer], "dev", "/tmp/project", SERVER, SELF_IDENTITY)).toBe(newer);
+  });
+});
+
+describe("selectDormantAnnounceEntry 的身份维度（issue #906）", () => {
+  // 本次故障形态的直接钉子：同 cwd、同频道、同 server，只有身份不同。
+  test("同 cwd 同频道两个不同身份：选中的必须是该身份那条，与 registered_at 新旧无关", () => {
+    const mine = entry({
+      session_id: "66666666-6666-4666-8666-666666666666",
+      identity: SELF_IDENTITY,
+      registered_at: 1_000,
+    });
+    const theirs = entry({
+      session_id: "77777777-7777-4777-8777-777777777777",
+      identity: OTHER_IDENTITY,
+      // 故意更新——旧实现「取最新入册」会选中它，那正是实机误投的那条。
+      registered_at: 9_000,
+    });
+    expect(selectDormantAnnounceEntry([mine, theirs], "dev", "/tmp/project", SERVER, SELF_IDENTITY))
+      .toBe(mine);
+    expect(selectDormantAnnounceEntry([mine, theirs], "dev", "/tmp/project", SERVER, OTHER_IDENTITY))
+      .toBe(theirs);
+    // 顺序反转也一样（防「靠数组序侥幸通过」）。
+    expect(selectDormantAnnounceEntry([theirs, mine], "dev", "/tmp/project", SERVER, SELF_IDENTITY))
+      .toBe(mine);
+  });
+
+  test("本机没有该身份的会话 ⇒ 一个都不选（绝不退回频道里随便挑一个）", () => {
+    const theirs = entry({ identity: OTHER_IDENTITY, registered_at: 9_000 });
+    expect(selectDormantAnnounceEntry([theirs], "dev", "/tmp/project", SERVER, SELF_IDENTITY)).toBeNull();
+  });
+
+  test("旧条目（无 identity 字段）恒不命中，等下次 SessionStart 升级", () => {
+    const legacy = entry({ identity: undefined });
+    expect(selectDormantAnnounceEntry([legacy], "dev", "/tmp/project", SERVER, SELF_IDENTITY)).toBeNull();
+    const fresh = entry({ session_id: "88888888-8888-4888-8888-888888888888", registered_at: 9_000 });
+    expect(selectDormantAnnounceEntry([legacy, fresh], "dev", "/tmp/project", SERVER, SELF_IDENTITY))
+      .toBe(fresh);
+  });
+
+  test("解析不出本机身份（null/undefined/空串）时一个都不命中", () => {
+    const here = entry();
+    for (const identity of [null, undefined, ""]) {
+      expect(selectDormantAnnounceEntry([here], "dev", "/tmp/project", SERVER, identity)).toBeNull();
+    }
+  });
+
+  test("身份比对与 mention 同一把尺子：ASCII handle 大小写等价", () => {
+    const here = entry();
+    expect(selectDormantAnnounceEntry([here], "dev", "/tmp/project", SERVER, SELF_IDENTITY.toUpperCase()))
+      .toBe(here);
   });
 });
 
 describe("selectDormantAnnounceEntry 的 server 维度（issue #865）", () => {
   test("同 slug 不同 server 不命中；同 slug 同 server 才命中", () => {
     const here = entry();
-    expect(selectDormantAnnounceEntry([here], "dev", "/tmp/project", SERVER)).toBe(here);
-    expect(selectDormantAnnounceEntry([here], "dev", "/tmp/project", OTHER_SERVER)).toBeNull();
+    expect(selectDormantAnnounceEntry([here], "dev", "/tmp/project", SERVER, SELF_IDENTITY)).toBe(here);
+    expect(selectDormantAnnounceEntry([here], "dev", "/tmp/project", OTHER_SERVER, SELF_IDENTITY)).toBeNull();
   });
 
   test("旧条目（无 server 字段）恒不命中，等下次 SessionStart 升级", () => {
     const legacy = entry({ server: undefined });
-    expect(selectDormantAnnounceEntry([legacy], "dev", "/tmp/project", SERVER)).toBeNull();
+    expect(selectDormantAnnounceEntry([legacy], "dev", "/tmp/project", SERVER, SELF_IDENTITY)).toBeNull();
     // 同一批里的新条目照常命中——旧条目只是被跳过，不会拖垮整批。
     const fresh = entry({ session_id: "55555555-5555-4555-8555-555555555555", registered_at: 9_000 });
-    expect(selectDormantAnnounceEntry([legacy, fresh], "dev", "/tmp/project", SERVER)).toBe(fresh);
+    expect(selectDormantAnnounceEntry([legacy, fresh], "dev", "/tmp/project", SERVER, SELF_IDENTITY)).toBe(fresh);
   });
 
   test("解析不出实例身份（null/undefined/坏 URL）时一个都不命中", () => {
     const here = entry();
     for (const server of [null, undefined, "", "not a url"]) {
-      expect(selectDormantAnnounceEntry([here], "dev", "/tmp/project", server)).toBeNull();
+      expect(selectDormantAnnounceEntry([here], "dev", "/tmp/project", server, SELF_IDENTITY)).toBeNull();
     }
   });
 
   test("按 origin 规范化比对：尾斜杠 / host 大小写 / 缺协议头都等价，端口不同即不同实例", () => {
     const here = entry();
     for (const variant of ["https://party.example/", "https://Party.Example", "party.example"]) {
-      expect(selectDormantAnnounceEntry([here], "dev", "/tmp/project", variant)).toBe(here);
+      expect(selectDormantAnnounceEntry([here], "dev", "/tmp/project", variant, SELF_IDENTITY)).toBe(here);
     }
-    expect(selectDormantAnnounceEntry([here], "dev", "/tmp/project", "https://party.example:8443"))
+    expect(selectDormantAnnounceEntry([here], "dev", "/tmp/project", "https://party.example:8443", SELF_IDENTITY))
       .toBeNull();
   });
 });
@@ -269,7 +324,7 @@ function msg(seq: number, mentions: string[]): ServerFrame {
   } as unknown as ServerFrame;
 }
 
-const SELF = "lark-ad72b3f97491-agentparty";
+const SELF = SELF_IDENTITY;
 
 describe("announce 起始游标 (#869)", () => {
   test("按频道当前最新 seq 起，绝不是 0、也不来自持久化游标", async () => {
@@ -432,6 +487,83 @@ describe("runDormantClaudeSessionAnnounce socket inject (#857)", () => {
     await tick();
     expect(calls).toHaveLength(2);
     expect(connections[0]!.acked).toEqual([30, 31]);
+    abort.abort();
+    await done;
+  });
+});
+
+describe("announce 注入的身份闸（issue #906）", () => {
+  function identityDeps(overrides: Partial<DormantAnnounceDeps> = {}) {
+    const calls: { pid?: number; sessionId?: string | null }[] = [];
+    const logs: string[] = [];
+    const inject = (async (input: { pid?: number; sessionId?: string | null; name: string }) => {
+      calls.push({ pid: input.pid, sessionId: input.sessionId });
+      return { ok: true, socketPath: "/tmp/x.sock", usedAuth: false, target: input.name };
+    }) as DormantAnnounceDeps["inject"];
+    const made = makeDeps({ inject, log: (line) => logs.push(line), ...overrides });
+    return { ...made, calls, logs };
+  }
+
+  // 故障形态本体：同 cwd、同频道、两个不同身份的活会话。
+  const MINE = entry({
+    session_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    pid: 111,
+    identity: SELF_IDENTITY,
+    registered_at: 1_000,
+  });
+  const THEIRS = entry({
+    session_id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+    pid: 222,
+    identity: OTHER_IDENTITY,
+    registered_at: 9_000, // 更新：旧实现恒选它 ⇒ 误投。
+  });
+
+  test("@ 我 ⇒ 只注入我这条会话，绝不落到同 cwd 的另一身份会话", async () => {
+    const { deps, connections, calls } = identityDeps({ listSessions: () => [MINE, THEIRS] });
+    const abort = new AbortController();
+    const done = runDormantClaudeSessionAnnounce("dev", abort.signal, deps);
+    await tick();
+    expect(connections).toHaveLength(1);
+    connections[0]!.push(msg(50, [SELF]));
+    await tick();
+    expect(calls).toEqual([{ pid: 111, sessionId: MINE.session_id }]);
+    abort.abort();
+    await done;
+  });
+
+  test("本机没有该身份的会话 ⇒ 不建连、不注入任何人，且留下日志（不静默）", async () => {
+    const { deps, connections, calls, logs } = identityDeps({ listSessions: () => [THEIRS] });
+    const abort = new AbortController();
+    const done = runDormantClaudeSessionAnnounce("dev", abort.signal, deps);
+    await tick();
+    expect(connections).toHaveLength(0);
+    expect(calls).toHaveLength(0);
+    expect(logs.some((line) => line.includes(SELF_IDENTITY) && line.includes("未注入"))).toBe(true);
+    abort.abort();
+    await done;
+  });
+
+  test("解析不出本机身份 ⇒ 不建连、不注入，且留下日志", async () => {
+    const { deps, connections, calls, logs } = identityDeps({
+      listSessions: () => [MINE, THEIRS],
+      resolveSelfName: async () => null,
+    });
+    const abort = new AbortController();
+    const done = runDormantClaudeSessionAnnounce("dev", abort.signal, deps);
+    await tick();
+    expect(connections).toHaveLength(0);
+    expect(calls).toHaveLength(0);
+    expect(logs.some((line) => line.includes("解析不出本机频道身份"))).toBe(true);
+    abort.abort();
+    await done;
+  });
+
+  test("漏叫日志不刷屏：同一句连续轮询只打一次", async () => {
+    const { deps, logs } = identityDeps({ listSessions: () => [THEIRS] });
+    const abort = new AbortController();
+    const done = runDormantClaudeSessionAnnounce("dev", abort.signal, deps);
+    await tick(40); // pollIntervalMs=5 → 至少轮了好几圈。
+    expect(logs.filter((line) => line.includes("未注入"))).toHaveLength(1);
     abort.abort();
     await done;
   });

--- a/cli/test/claude-session-registry.test.ts
+++ b/cli/test/claude-session-registry.test.ts
@@ -18,8 +18,11 @@ import {
   claudeSessionRegistryDirectory,
   listClaudeSessions,
   registerClaudeSession,
+  normalizeSessionRegistryIdentity,
   normalizeSessionRegistryServer,
   registerSession,
+  resolveSessionRegistryIdentity,
+  sessionEntryMatchesIdentity,
   sessionEntryMatchesServer,
   unregisterClaudeSession,
 } from "../src/claude-session-registry";
@@ -350,5 +353,76 @@ describe("会话注册表的 server 维度（issue #865）", () => {
       { mode: 0o600 },
     );
     expect(listClaudeSessions(env)).toHaveLength(0);
+  });
+});
+
+describe("注册表的身份维度（issue #906）", () => {
+  const IDENTITY = "lark-ad72b3f97491-agentparty";
+
+  test("显式传入的身份落盘并可比对", () => {
+    expect(registerSession(baseEntry({ identity: IDENTITY }), env)).toBe(true);
+    const [entry] = listClaudeSessions(env);
+    expect(entry!.identity).toBe(IDENTITY);
+    expect(sessionEntryMatchesIdentity(entry!, IDENTITY)).toBe(true);
+    expect(sessionEntryMatchesIdentity(entry!, IDENTITY.toUpperCase())).toBe(true);
+    expect(sessionEntryMatchesIdentity(entry!, "lark-ad72b3f9749e-agentparty")).toBe(false);
+  });
+
+  test("旧条目（无 identity 字段）仍能读出，但恒不可匹配——宁可漏叫", () => {
+    writeFileSync(
+      join(directory, `${SESSION_ID}.json`),
+      JSON.stringify({ version: 1, ...baseEntry(), harness: "claude" }),
+      { mode: 0o600 },
+    );
+    const [entry] = listClaudeSessions(env);
+    expect(entry!.identity).toBeUndefined();
+    expect(sessionEntryMatchesIdentity(entry!, IDENTITY)).toBe(false);
+  });
+
+  test("显式 null / 解析不出的身份不写该字段（条目随之不可匹配）", () => {
+    expect(registerSession(baseEntry({ identity: null }), env)).toBe(true);
+    expect(listClaudeSessions(env)[0]!.identity).toBeUndefined();
+  });
+
+  test("盘上写着未规范化 identity 的条目按坏行丢弃，绝不退化成旧条目的宽松语义", () => {
+    writeFileSync(
+      join(directory, `${SESSION_ID}.json`),
+      JSON.stringify({ version: 1, ...baseEntry({ identity: IDENTITY.toUpperCase() }), harness: "claude" }),
+      { mode: 0o600 },
+    );
+    expect(listClaudeSessions(env)).toHaveLength(0);
+  });
+
+  test("身份归一化与 mentionMatchKey 同尺：ASCII 小写化、空/超长/非串 → null", () => {
+    expect(normalizeSessionRegistryIdentity("Lark-AD72B3F97491-Agentparty")).toBe(IDENTITY);
+    expect(normalizeSessionRegistryIdentity("张三")).toBe("张三");
+    expect(normalizeSessionRegistryIdentity("")).toBeNull();
+    expect(normalizeSessionRegistryIdentity(null)).toBeNull();
+    expect(normalizeSessionRegistryIdentity("x".repeat(129))).toBeNull();
+  });
+
+  test("省略 identity 时从该会话绑定的 config 解析；channel_scope 不符不认", () => {
+    const configPath = join(directory, "config.json");
+    const previous = process.env.AGENTPARTY_CONFIG;
+    process.env.AGENTPARTY_CONFIG = configPath;
+    try {
+      writeFileSync(
+        configPath,
+        JSON.stringify({
+          server: "https://a.example.com",
+          token: "t",
+          identity: { name: IDENTITY, channel_scope: "dev" },
+        }),
+        { mode: 0o600 },
+      );
+      expect(resolveSessionRegistryIdentity("/tmp/project", "dev")).toBe(IDENTITY);
+      // 另一个频道的缓存身份不认（那是别的频道的 handle）。
+      expect(resolveSessionRegistryIdentity("/tmp/project", "prod")).toBeNull();
+      expect(registerSession(baseEntry(), env)).toBe(true);
+      expect(listClaudeSessions(env)[0]!.identity).toBe(IDENTITY);
+    } finally {
+      if (previous === undefined) delete process.env.AGENTPARTY_CONFIG;
+      else process.env.AGENTPARTY_CONFIG = previous;
+    }
   });
 });


### PR DESCRIPTION
Closes #906

## 问题

`selectDormantAnnounceEntry` 只按 channel + server 过滤，优先同 cwd，最后 `?? pick(matching)` 兜底成「该频道里任意一个会话」；`ClaudeSessionRegistryEntry` 根本不存身份，想校验也无从校验。于是同一个 worktree 下两个绑不同身份的会话会互相串号：@ 身份 A 的消息恒落到 `registered_at` 更新的那条（实机撞见）。内容/频道/seq 全是真的，收信方毫无破绽——与 #865 同类的静默误投。

## 改动

1. **注册表补身份字段** `identity`：入册时由 `registerSession` 从该会话绑定的 config 解析（`config.identity.name`，即 mentions 里的频道 handle；`channel_scope` 与入册频道不符的缓存身份不认）。归一化 `normalizeSessionRegistryIdentity` 与 shared 的 `mentionMatchKey` 逐字同尺，避免「命中 @」与「选中会话」在边界字符上劈叉。
   - 入册点（`commands/hook.ts`）**未改动**（另一 agent 正在改该文件）：身份在 `registerSession` 内部解析，hook 与 config 同进程同环境，读到的就是这个会话真正在用的身份。
2. **`selectDormantAnnounceEntry` 加身份相等判定**，身份对不上一律不选。
3. **删掉 `?? pick(matching)` 跨 cwd 兜底**——同身份但在别的 worktree 的会话同样是错的宿主。现在要求 server + channel + identity + cwd 全等。
4. **身份先于选目标解析**：注入的触发条件（mention hit）与目标选择共用同一个 selfName，两者不可能分别指向不同身份；解析不出身份则本轮不建连。
5. **漏叫留痕**：`本机没有身份 X 的入册会话（… ），未宣告、未注入` 写 stderr（stdout 是 MCP 通道，不碰），同一句连续轮询只打一次。

**向后兼容（保守）**：旧条目无 `identity` 字段 ⇒ 恒不匹配（宁可漏叫不误投）；盘上写着未规范化 identity 的条目按坏行丢弃，绝不退化成旧条目的宽松语义。**实际影响**：本机现存条目大多是旧格式，会暂时不参与匹配——重开一次会话（SessionStart）即自动补上，日志里已写明这句。

## 端到端验证（不是只有单测）

隔离环境**照抄故障场景本身**：临时注册表目录 + 临时 native sessions 目录 + 临时 config + 两个真进程与两个真 UDS 收件箱，**同 cwd `/tmp/shared-worktree`、同频道 `dev`、同 server，两个不同身份**（B 的 `registered_at` 更新）。唯一替身是 WS 连接（不联网），注入走**真实 `injectChannelMessage`**（真 pid 寻址 + 真 socket 写入）。绝未触碰 owner 的任何会话。

先在 `origin/main` 的代码上跑同一个脚本复现故障：

| 轮次 | 本机身份 | A 收到 | B 收到 |
|---|---|---|---|
| @ A | A | **0** | **1（误投）** |
| @ B | B | 0 | 1 |
| @ 本机没有的身份 | — | 0 | **1（误投）** |

同一脚本在本 PR 的代码上：

| 轮次 | A 收到 | B 收到 | 日志 |
|---|---|---|---|
| @ A | **1** | 0 | 绑定会话 aaaa…（身份 A） |
| @ B | 0 | **1** | 绑定会话 bbbb…（身份 B） |
| @ 本机没有的身份 | 0 | 0 | `本机没有身份 … 未宣告、未注入` |

另加一条**旧格式条目**（无 identity、`registered_at` 最新、pid 指向 A 的进程）同时在盘上：修复后它从不被选中，三轮结果不变。

## 变异自检

| 变异 | 结果 |
|---|---|
| 整段删除 `sessionEntryMatchesIdentity(entry, identity) &&` | 7 条断言变红（含钉住本次故障形态的那条） |
| 恢复 `?? pick(matching)` 跨 cwd/身份兜底 | 6 条变红 |
| **守卫自身**变异：`sessionEntryMatchesIdentity` 恒 `true`（#884 教训） | 9 条变红（跨注册表与 announce 两个测试文件） |
| 等价实现替换：`reduce` 取最新 → `sort().at(-1)` | 全绿（不误红） |

钉住本次故障形态的用例：「同 cwd、同频道、两个不同身份的条目，@ 其中一个 ⇒ 选中的必须是该身份那条，**且与 `registered_at` 新旧无关**」（含数组顺序反转，防靠序侥幸通过）。

## 检查

- `bun run check:cli`：480 pass / 1 fail —— 失败的是 `serve-failure-ack.test.ts` 的硬超时耗时断言（`Expected: < 2000, Received: 2448`），并发负载下的时序 flake，单跑该文件 37 pass / 0 fail，与本改动无关。
- `tsc --noEmit`：干净。
- `bun test cli/test`：2007 pass / 0 fail。
