### PR TITLE
fix(cli): 长驻子进程绑定宿主存活，孤儿不再假在线并劫持 @ (#908)

### DIFF
--- a/cli/src/commands/claude-channel.ts
+++ b/cli/src/commands/claude-channel.ts
@@ -49,6 +49,7 @@ import {
   type DeliveryRecoveryEntry,
 } from "../delivery-recovery-journal";
 import { acquireInstanceLock, defaultInstanceLockDir, instanceLockTarget } from "../instance-lock";
+import { watchParentLiveness } from "../parent-liveness";
 import { resolveAuthDetailed } from "../oidc-cli";
 import {
   fetchMe,
@@ -2814,6 +2815,12 @@ export async function run(argv: string[]): Promise<number> {
     console.error("usage: party claude-channel [channel|--channel C]");
     return 1;
   }
+
+  // #908：本命令永远是 harness 通过 stdio 拉起的子进程，不存在合法的「宿主没了还该活着」形态。
+  // 宿主 Claude 死掉后它曾被 init 收养并继续跑（实测一个孤儿跑了 21 小时），持有 WS ＝ 假在线，
+  // 且继续接该身份的 @ 并注入到别的会话去（#906 那次误投的实际来源）。全部逻辑在 parent-liveness，
+  // 这里只挂一行；两个档（蛰伏 announce / armed）共用同一道闸。
+  watchParentLiveness({ label: "party claude-channel" });
 
   if (flags["require-launch-opt-in"] === true && !claudeChannelLaunchOptedIn()) {
     // Enabled plugins are initialized in every Claude session, even when this

--- a/cli/src/commands/mcp.ts
+++ b/cli/src/commands/mcp.ts
@@ -22,6 +22,7 @@ import {
 } from "../config";
 import { jsonFrame } from "../json";
 import { applyMcpProcessTitle, parseMcpServerArgv } from "../mcp-registry";
+import { watchParentLiveness } from "../parent-liveness";
 import { resolveAuth, resolveAuthDetailed } from "../oidc-cli";
 import {
   createTask,
@@ -1620,5 +1621,9 @@ export async function run(argv: string[]): Promise<number> {
   return new Promise<number>((resolve) => {
     process.stdin.on("close", () => resolve(0));
     process.stdin.on("end", () => resolve(0));
+    // #908 第二道闸：stdin EOF 是 harness 正常收尾时的信号，但宿主被 kill -9 / 崩溃时
+    // 那个 pipe 不一定会关（claude-channel 那边实测就没关，孤儿跑了 21 小时）。父进程
+    // 存活探测不依赖任何 fd 状态，宿主一死就收口。
+    watchParentLiveness({ label: "party mcp", terminate: () => resolve(0) });
   });
 }

--- a/cli/src/commands/orphans.ts
+++ b/cli/src/commands/orphans.ts
@@ -1,0 +1,177 @@
+// party orphans —— 列出并（显式确认后）清理孤儿 party 进程 + 回收死掉的会话注册条目（#908）。
+//
+// 判据全在 ../orphan-scan（纯函数，可单测）；这里只负责读 ps、发信号、扫注册表。
+// 默认 dry-run，和 `party mcp prune` 一条策略：--yes 才真动手。
+import { spawnSync } from "node:child_process";
+import {
+  classifyOrphanProcess,
+  parsePsOutput,
+  partyLane,
+  type OrphanVerdict,
+  type ScannedProcess,
+} from "../orphan-scan";
+import { listClaudeSessions, listCodexSessions } from "../claude-session-registry";
+
+const HELP = `usage: party orphans [--yes] [--json]
+
+List AgentParty child processes that outlived the harness session that started
+them (orphaned announce / mcp servers) and, with --yes, shut them down.
+
+Why: a \`party claude-channel\` whose Claude session died keeps its websocket up.
+It shows as online in \`party who\` and keeps receiving that identity's @ — one
+such orphan was the actual source of the cross-identity misdelivery in #906.
+
+Safety:
+  - only processes whose command is the party binary are considered; every other
+    process on this machine is left untouched
+  - only provably orphaned session children (re-parented to init) are shut down;
+    deliberately daemonized lanes (\`party serve\`, \`party watch\`) are listed for
+    you to decide, never signalled
+  - --yes is required to signal anything; SIGTERM only, never SIGKILL
+
+Options:
+  --yes    actually shut down the processes reported as orphaned
+  --json   machine-readable report
+`;
+
+export interface OrphanEntry {
+  proc: ScannedProcess;
+  lane: string | null;
+  verdict: OrphanVerdict;
+}
+
+export interface OrphanPlan {
+  totalProcesses: number;
+  entries: OrphanEntry[];
+  /** 非 party 进程数——纯展示，证明它们被看见了且没被动过。 */
+  untouched: number;
+}
+
+export type PsFn = () => string;
+
+const defaultPs: PsFn = () => {
+  const res = spawnSync("ps", ["-axo", "pid=,ppid=,command="], { encoding: "utf8", maxBuffer: 32 * 1024 * 1024 });
+  return res.status === 0 && typeof res.stdout === "string" ? res.stdout : "";
+};
+
+/** 自己 + 整条祖先链：任何情况下都不许出现在清理列表里。 */
+export function ancestorPids(self: number, procs: readonly ScannedProcess[]): Set<number> {
+  const byPid = new Map(procs.map((p) => [p.pid, p]));
+  const out = new Set<number>([self]);
+  let cursor = byPid.get(self)?.ppid;
+  while (cursor !== undefined && cursor > 1 && !out.has(cursor)) {
+    out.add(cursor);
+    cursor = byPid.get(cursor)?.ppid;
+  }
+  return out;
+}
+
+export function planOrphans(opts: { ps?: PsFn; selfPid?: number } = {}): OrphanPlan {
+  const procs = parsePsOutput((opts.ps ?? defaultPs)());
+  const protectedPids = ancestorPids(opts.selfPid ?? process.pid, procs);
+  const entries: OrphanEntry[] = [];
+  let untouched = 0;
+  for (const proc of procs) {
+    const verdict = classifyOrphanProcess({ proc, protectedPids });
+    if (verdict.reason === "not an AgentParty process — never touched") {
+      untouched += 1;
+      continue;
+    }
+    entries.push({ proc, lane: partyLane(proc.command), verdict });
+  }
+  return { totalProcesses: procs.length, entries, untouched };
+}
+
+export type SignalFn = (pid: number) => { ok: boolean; detail: string };
+
+const defaultSignal: SignalFn = (pid) => {
+  try {
+    process.kill(pid, "SIGTERM");
+    return { ok: true, detail: "SIGTERM sent" };
+  } catch (error) {
+    return { ok: false, detail: (error as Error).message };
+  }
+};
+
+export interface RunOrphansOptions {
+  ps?: PsFn;
+  selfPid?: number;
+  yes?: boolean;
+  json?: boolean;
+  signal?: SignalFn;
+  /** 扫一遍会话注册表；listSessions 顺带把 pid 已死的条目就地删掉。返回剩余活行数。 */
+  sweepRegistry?: () => number;
+  log?: (line: string) => void;
+}
+
+function defaultSweepRegistry(): number {
+  // listSessions 读的时候就会 rmSync 掉 pid 已死的行与坏行——这正是我们要的回收动作，
+  // 不必再复制一遍删除逻辑（也就不会和 #906 正在改的选择逻辑打架）。
+  return listClaudeSessions().length + listCodexSessions().length;
+}
+
+export async function runOrphans(opts: RunOrphansOptions = {}): Promise<number> {
+  const log = opts.log ?? ((line: string) => console.log(line));
+  const plan = planOrphans({ ...(opts.ps === undefined ? {} : { ps: opts.ps }), ...(opts.selfPid === undefined ? {} : { selfPid: opts.selfPid }) });
+  const stale = plan.entries.filter((e) => e.verdict.action === "stale");
+  const review = plan.entries.filter((e) => e.verdict.action === "review");
+
+  const signalled: number[] = [];
+  const failed: { pid: number; detail: string }[] = [];
+  if (opts.yes === true) {
+    const signal = opts.signal ?? defaultSignal;
+    for (const entry of stale) {
+      // 再核一次：发信号路径上只允许出现被判定为 stale 的 party 进程。分类函数是唯一入口，
+      // 这里重跑一遍是为了让「绕过分类直接发信号」在结构上不可能发生。
+      if (classifyOrphanProcess({ proc: entry.proc }).action !== "stale") continue;
+      const res = signal(entry.proc.pid);
+      if (res.ok) signalled.push(entry.proc.pid);
+      else failed.push({ pid: entry.proc.pid, detail: res.detail });
+    }
+  }
+
+  const remainingSessions = (opts.sweepRegistry ?? defaultSweepRegistry)();
+
+  if (opts.json === true) {
+    log(JSON.stringify({
+      total_processes: plan.totalProcesses,
+      untouched_non_party: plan.untouched,
+      dry_run: opts.yes !== true,
+      orphans: stale.map((e) => ({ pid: e.proc.pid, lane: e.lane, command: e.proc.command, reason: e.verdict.reason })),
+      review: review.map((e) => ({ pid: e.proc.pid, lane: e.lane, command: e.proc.command, reason: e.verdict.reason })),
+      signalled,
+      failed,
+      live_session_registrations: remainingSessions,
+    }, null, 2));
+    return failed.length > 0 ? 1 : 0;
+  }
+
+  log(`scanned ${String(plan.totalProcesses)} processes; ${String(plan.untouched)} belong to other tools and were not inspected`);
+  if (stale.length === 0) log("no orphaned AgentParty processes found");
+  for (const e of stale) log(`  [orphan] pid ${String(e.proc.pid)}  ${e.proc.command}\n             ${e.verdict.reason}`);
+  for (const e of review) log(`  [review] pid ${String(e.proc.pid)}  ${e.proc.command}\n             ${e.verdict.reason}`);
+  if (opts.yes !== true && stale.length > 0) {
+    log("");
+    log(`dry run: nothing was signalled. Re-run with --yes to SIGTERM the ${String(stale.length)} orphan(s) above.`);
+  }
+  for (const pid of signalled) log(`SIGTERM sent to pid ${String(pid)}`);
+  for (const f of failed) log(`failed to signal pid ${String(f.pid)}: ${f.detail}`);
+  log(`session registry swept: ${String(remainingSessions)} live registration(s) remain (dead ones were reclaimed)`);
+  return failed.length > 0 ? 1 : 0;
+}
+
+export async function run(argv: string[]): Promise<number> {
+  if (argv.includes("--help") || argv.includes("-h")) {
+    console.log(HELP);
+    return 0;
+  }
+  const known = new Set(["--yes", "--json"]);
+  for (const a of argv) {
+    if (!known.has(a)) {
+      console.error(`unknown option: ${a}`);
+      console.error(HELP);
+      return 1;
+    }
+  }
+  return runOrphans({ yes: argv.includes("--yes"), json: argv.includes("--json") });
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -50,6 +50,7 @@ commands:
   wake-budget <name> [--limit N [--window D]|--off]        cap an agent's wakes per window; over-budget @ withheld (#108)
   health    [--json] [--channel C] [--stale-after ms]      local serve WS health probe (pid alive != ws alive, #254)
   doctor    [claude-plugin [--channel C] [--json]]          version check or no-model Marketplace/Channel/listener audit
+  orphans   [--yes] [--json]                               list party children that outlived their harness session; --yes SIGTERMs them (#908)
   hook      install|uninstall|status [--user] | report      manage legacy Hook settings; presence uplink remains launcher/serve-scoped (#602/#615)
   upgrade   [--version X.Y.Z] [--check]                    download release binary, verify sha256, atomically replace party
   charter   [slug] [--json] | set [slug] -f file.md|-m text|- | template
@@ -194,6 +195,8 @@ export async function main(argv: string[]): Promise<number> {
       return (await import("./commands/gdpr")).run(rest);
     case "doctor":
       return (await import("./commands/doctor")).run(rest);
+    case "orphans":
+      return (await import("./commands/orphans")).run(rest);
     case "health":
       return (await import("./commands/health")).run(rest);
     case "hook":

--- a/cli/src/mcp-registry.ts
+++ b/cli/src/mcp-registry.ts
@@ -54,7 +54,9 @@ function collectScope(out: McpRegistration[], scope: string, servers: unknown): 
 // 「这是不是我们自己的 party mcp 注册」必须由**命令本体**判定，不能由名字判定：
 // 本机同时装着 discord-use / iphone-use-mcp 等别人的 server，误删是灾难，而名字是用户可改的。
 // 反过来也不能放宽：`npx party`、`sh -c "... party mcp"` 这类间接形态一律不认（＝不碰）。
-const PARTY_COMMAND_BASENAMES = new Set(["party", "agentparty-runtime"]);
+// 导出给 orphan-scan.ts 复用（#908）：孤儿进程清理面对的是同一条硬约束，词表必须只有一份，
+// 复制一份出去就会漂移（#622 教训）。
+export const PARTY_COMMAND_BASENAMES = new Set(["party", "agentparty-runtime"]);
 
 /** 严格判定：命令 basename 必须正好是 party 可执行文件，且第一个参数正好是 `mcp`。 */
 export function isPartyMcpRegistration(reg: McpRegistration): boolean {

--- a/cli/src/orphan-scan.ts
+++ b/cli/src/orphan-scan.ts
@@ -1,0 +1,159 @@
+// 存量孤儿进程盘点（issue #908 第 3 件）。
+//
+// #908 给运行中的进程装了宿主存活探测，但**已经在跑的老进程没有那段代码**——owner 机器上
+// 那 18 个 announce 里的孤儿不会自己消失。这里提供一次性的盘点/清理判据。
+//
+// 硬约束（逐条都有单测，其中「绝不碰非 party 进程」这条另有专门的变异用例）：
+//  1. 只按**命令本体**判定是不是我们的进程，绝不看进程名——名字可以被任何人改成 `party`；
+//     词表从 mcp-registry 复用同一份（#898 的 isPartyMcpRegistration 同款严格度）。
+//  2. 只把**确证的孤儿**判成 stale：宿主已被 init 收养（ppid=1）**且**属于「只该随会话活着」
+//     的子进程档（claude-channel / mcp server）。判不准一律 review（列出、不动）。
+//  3. 人有意 daemonize 的进程（nohup 的 `party serve`、`party watch`）永远不是孤儿——
+//     它们的 ppid=1 是**设计如此**，杀掉就是弄坏用户正在用的东西。
+//
+// 纯函数模块：读一份 `ps` 输出 → 分类。副作用（发信号）留在命令层。
+import { basename } from "node:path";
+import { PARTY_COMMAND_BASENAMES } from "./mcp-registry";
+
+export interface ScannedProcess {
+  pid: number;
+  ppid: number;
+  /** ps 给出的完整命令行（argv 以空格连接）。 */
+  command: string;
+}
+
+/** 解析 `ps -axo pid=,ppid=,command=` 的输出。形状不对的行直接跳过——宁可少认。 */
+export function parsePsOutput(stdout: string): ScannedProcess[] {
+  const out: ScannedProcess[] = [];
+  for (const line of stdout.split("\n")) {
+    const m = /^\s*(\d+)\s+(\d+)\s+(\S.*)$/.exec(line);
+    if (m === null) continue;
+    const pid = Number(m[1]);
+    const ppid = Number(m[2]);
+    if (!Number.isInteger(pid) || pid <= 0 || !Number.isInteger(ppid) || ppid < 0) continue;
+    out.push({ pid, ppid, command: m[3]! });
+  }
+  return out;
+}
+
+/**
+ * 命令行 → argv。ps 不会把带空格的路径还原成可解析的形态，所以这里就是朴素切分：
+ * 一个装在带空格目录里的 party 会切出对不上的 basename → 认不出来 → **不碰**（安全侧）。
+ */
+export function commandArgv(command: string): string[] {
+  return command.trim().split(/\s+/).filter((part) => part !== "");
+}
+
+/**
+ * 严格判定「这是不是我们自己的 party 进程」。只看 argv[0] 的 basename。
+ * `npx party` / `sh -c "... party ..."` / `bun run index.ts claude-channel` 这类间接形态
+ * 一律不认（＝永远不会被清理）——与 isPartyMcpRegistration 完全同一策略。
+ */
+export function isPartyProcess(command: string): boolean {
+  const argv = commandArgv(command);
+  const head = argv[0];
+  if (head === undefined || head === "") return false;
+  const base = basename(head).replace(/\.(exe|cmd|bat)$/i, "");
+  return PARTY_COMMAND_BASENAMES.has(base);
+}
+
+/**
+ * 带值的 flag。必须显式列出：只按「跳过所有 `-` 开头的 token」会把 `--channel dev` 的 `dev`
+ * 当成子命令（单测第一次跑就抓到了这个），而无脑「flag 后面那个一律跳过」又会把
+ * `--require-launch-opt-in claude-channel` 里真正的子命令吃掉。名单外的 flag 一律当 boolean。
+ */
+const VALUE_FLAGS = new Set([
+  "--channel", "-c", "--identity", "--claude-session-name", "--runner",
+  "--attempt-id", "--version", "--limit", "--window", "--for", "--resume-at",
+]);
+
+/** party 进程 argv[0] 之后的位置参数（已跳过 flag 及其取值）。 */
+export function partyPositionals(command: string): string[] {
+  const out: string[] = [];
+  const argv = commandArgv(command).slice(1);
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]!;
+    if (arg.startsWith("-")) {
+      // `--channel=dev` 自带取值，不吃下一个 token。
+      if (VALUE_FLAGS.has(arg) && !arg.includes("=")) i += 1;
+      continue;
+    }
+    out.push(arg);
+  }
+  return out;
+}
+
+/** party 进程的子命令；不是 party 进程或没有子命令 → null。 */
+export function partySubcommand(command: string): string | null {
+  if (!isPartyProcess(command)) return null;
+  return partyPositionals(command)[0] ?? null;
+}
+
+/**
+ * 进程档（lane）：
+ *  - `session-child`：只由 harness 通过 stdio 拉起，**不存在**合法的 ppid=1 形态。
+ *  - `daemon`：人可以有意 daemonize，ppid=1 属正常。
+ *  - `oneshot` / null：短命命令或认不出来的，不参与清理。
+ */
+export type PartyLane = "session-child" | "daemon" | "oneshot" | null;
+
+const SESSION_CHILD_SUBCOMMANDS = new Set(["claude-channel"]);
+const DAEMON_SUBCOMMANDS = new Set(["serve", "watch", "daemon", "hook", "bridge"]);
+
+export function partyLane(command: string): PartyLane {
+  const sub = partySubcommand(command);
+  if (sub === null) return null;
+  if (sub === "mcp") {
+    // `party mcp prune` 等子命令是短命 CLI，不是常驻 server——别把一次正在跑的清理当孤儿。
+    return partyPositionals(command)[1] === undefined ? "session-child" : "oneshot";
+  }
+  if (SESSION_CHILD_SUBCOMMANDS.has(sub)) return "session-child";
+  if (DAEMON_SUBCOMMANDS.has(sub)) return "daemon";
+  return "oneshot";
+}
+
+export type OrphanAction = "stale" | "review" | "keep";
+
+export interface OrphanVerdict {
+  action: OrphanAction;
+  reason: string;
+}
+
+export interface ClassifyOrphanInput {
+  proc: ScannedProcess;
+  /** 绝不能碰的 pid（自己、自己的祖先链、用户显式保护的）。 */
+  protectedPids?: ReadonlySet<number>;
+}
+
+/**
+ * 判定一个进程。默认 keep——每一条 stale 都必须由一条明确的规则写出来。
+ */
+export function classifyOrphanProcess(input: ClassifyOrphanInput): OrphanVerdict {
+  const { proc } = input;
+  // ①「绝不碰非 party 进程」：这是第一道也是唯一一道决定性闸门，任何后续分支都到不了
+  // 非 party 进程头上。误杀别人的 mcp server / 编辑器 / 数据库是灾难。
+  if (!isPartyProcess(proc.command)) {
+    return { action: "keep", reason: "not an AgentParty process — never touched" };
+  }
+  if (input.protectedPids?.has(proc.pid) === true) {
+    return { action: "keep", reason: "protected pid (this process or one of its ancestors)" };
+  }
+  const lane = partyLane(proc.command);
+  if (lane === null || lane === "oneshot") {
+    return { action: "keep", reason: "not a long-lived session-bound process" };
+  }
+  if (proc.ppid !== 1) {
+    return { action: "keep", reason: `parent pid ${String(proc.ppid)} is still alive` };
+  }
+  if (lane === "daemon") {
+    // ppid=1 的 serve/watch 绝大多数是人手工 nohup 起来的，是**正常形态**。
+    return {
+      action: "review",
+      reason: "re-parented to init, but this lane is legitimately daemonized — left running, your call",
+    };
+  }
+  return {
+    action: "stale",
+    reason: "orphaned: its harness session is gone (re-parented to init) and this lane only ever runs as a session child",
+  };
+}

--- a/cli/src/parent-liveness.ts
+++ b/cli/src/parent-liveness.ts
@@ -1,0 +1,122 @@
+// 宿主进程存活检测（issue #908）。
+//
+// 背景：`party claude-channel`（announce 档）、`party mcp` 都是 harness 通过 stdio 拉起的
+// **子进程**——它们没有自己的生命周期，只该活到宿主会话活着为止。实测宿主 Claude 会话死掉后
+// 这些子进程被 init 收养（ppid=1）继续活着：持有 WS 连接 → `party who` 里假在线；继续收该
+// 身份的 @ → 按 channel+cwd 注入进**另一个身份**的会话（#906 那次跨身份误投的实际来源，就是
+// 一个跑了 21 小时的孤儿 announce）。全仓此前只有 instance-lock.ts 读过一次 process.ppid，
+// 没有任何长驻进程用它做**运行期**的生命周期判定。
+//
+// 本模块不新造轮子，把仓里已有的两块拼起来：
+//  - 父进程身份：instance-lock 的 `captureParentProcessOwner()`（#755 为 `watch --once` 写的）。
+//    它已经处理了本模块最容易写错的三件事——僵尸进程、pid 复用（比对出生时间）、ps 不可用时
+//    保守判活。自己再写一遍 kill(pid,0) 一定会漏掉其中某一条。
+//  - 收尾动作：#893 codex 唤醒层那套「打一行 `reaping:` 日志 + 自发 SIGTERM 复用已有的优雅
+//    收口路径」（见 codex-auto-wake / hook.ts 的 runCodexAutoWakeSupervise），不另起看护进程。
+//
+// 判定只认**确证死亡**（与 `party mcp prune` 同一策略）：拿不准一律当宿主还活着。宁可多留一个
+// 进程，也不能在宿主还活着的时候把它眼前的 announce 关掉。
+import { captureParentProcessOwner, type ProcessOwner } from "./instance-lock";
+
+/**
+ * 默认探测周期。宿主死后本进程最多多活这么久。
+ * 开销：一次 `kill(pid,0)` + 一次 `ps -o lstart= -o stat= -p <pid>`（instance-lock 内部，1s
+ * 超时）。按 30s 一次算，单个进程 ≈ 每天 2880 次短命 ps，实测不可测量；与 #893 唤醒层的
+ * CODEX_AUTO_WAKE_POLL_MS 取同一个数量级，方便一起调。
+ */
+export const PARENT_LIVENESS_POLL_MS = 30_000;
+
+/** 探测周期覆盖，只给验收/测试用（真机端到端验收不该等 30s）。非法值一律回落默认。 */
+export const PARENT_LIVENESS_POLL_MS_ENV = "AGENTPARTY_PARENT_LIVENESS_POLL_MS";
+
+export function parentLivenessPollMs(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = env[PARENT_LIVENESS_POLL_MS_ENV];
+  if (typeof raw !== "string" || raw === "") return PARENT_LIVENESS_POLL_MS;
+  const parsed = Number(raw);
+  // 下限 50ms：别让一个手滑的 0 把探测变成忙等。
+  if (!Number.isFinite(parsed) || parsed < 50) return PARENT_LIVENESS_POLL_MS;
+  return Math.floor(parsed);
+}
+
+export interface ParentLivenessHandle {
+  /** 停止探测（正常退出路径上调用；重复调用安全）。 */
+  stop: () => void;
+  /** 本次绑定的宿主 pid；≤1 表示启动时就没有可辨认的宿主，探测未启用。 */
+  hostPid: number;
+  /** 探测是否真的挂上了。 */
+  armed: boolean;
+}
+
+export interface WatchParentLivenessOptions {
+  /** 进程标签，只进日志（`claude-channel` / `mcp` …）。 */
+  label: string;
+  /** 覆盖宿主身份（测试用）；默认取启动时的父进程。 */
+  owner?: ProcessOwner;
+  pollMs?: number;
+  /** 收尾：默认给自己发 SIGTERM，复用各命令已有的优雅收口路径（#893 同款）。 */
+  terminate?: () => void;
+  log?: (line: string) => void;
+  /** 覆盖定时器（测试用）。 */
+  schedule?: (fn: () => void, ms: number) => { stop: () => void };
+}
+
+function defaultSchedule(fn: () => void, ms: number): { stop: () => void } {
+  const timer = setInterval(fn, ms);
+  // 探测本身绝不该成为进程活着的理由。
+  if (typeof (timer as { unref?: () => void }).unref === "function") {
+    (timer as unknown as { unref: () => void }).unref();
+  }
+  return { stop: () => clearInterval(timer) };
+}
+
+/**
+ * 启动时就已经是孤儿吗。`captureParentProcessOwner()` 在 pid≤1 时 alive() 恒 false，所以
+ * 「没有可辨认的宿主」和「宿主已死」在这一层是同一个信号；调用方按 armed=false 处理前者。
+ */
+export function hasIdentifiableHost(owner: ProcessOwner): boolean {
+  return Number.isInteger(owner.pid) && owner.pid > 1;
+}
+
+/**
+ * 挂上宿主存活探测。命中即打一行**说明为什么退**的日志，然后调用 terminate() 干净退出。
+ *
+ * 刻意不做的事：不在这里关连接、不在这里删注册条目。各命令自己的 SIGTERM / transport-close
+ * 路径已经会做这些（serve 放实例锁、claude-channel 关 WS、SessionEnd hook 出册），这里再来
+ * 一遍只会写出两套互相打架的收尾逻辑。
+ */
+export function watchParentLiveness(opts: WatchParentLivenessOptions): ParentLivenessHandle {
+  const owner = opts.owner ?? captureParentProcessOwner();
+  if (!hasIdentifiableHost(owner)) {
+    // 启动时就没有宿主（进程被人有意 daemonize，或平台不给 ppid）：不接管它的生命周期。
+    return { stop: () => undefined, hostPid: owner.pid, armed: false };
+  }
+  const log = opts.log ?? ((line: string) => console.error(line));
+  const terminate = opts.terminate ?? (() => {
+    try {
+      process.kill(process.pid, "SIGTERM");
+    } catch {
+      /* 已经在退了 */
+    }
+  });
+  const schedule = opts.schedule ?? defaultSchedule;
+  let stopped = false;
+  const handle = schedule(() => {
+    if (stopped) return;
+    if (owner.alive()) return;
+    stopped = true;
+    handle.stop();
+    log(
+      `reaping: ${opts.label} 的宿主会话（pid=${String(owner.pid)}）已退出，` +
+        `本进程随之退场——不再持有连接、不再接收该身份的 @（#908）`,
+    );
+    terminate();
+  }, opts.pollMs ?? parentLivenessPollMs());
+  return {
+    stop: () => {
+      stopped = true;
+      handle.stop();
+    },
+    hostPid: owner.pid,
+    armed: true,
+  };
+}

--- a/cli/test/orphan-lifecycle-e2e.test.ts
+++ b/cli/test/orphan-lifecycle-e2e.test.ts
@@ -1,0 +1,155 @@
+// #908 端到端：真起进程、真 kill 宿主，钉住本次故障形态。
+//
+// 「测试全绿真机是坏的」在这条链上已经连续八次（#884/#898/#906…），所以这个文件不 mock
+// 任何东西：真的 spawn 一个宿主，真的让宿主拉起 `party claude-channel`，真的 kill 宿主，
+// 然后断言子进程自己没了、注册条目被回收。
+import { afterEach, describe, expect, test } from "bun:test";
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { registerClaudeSession, listClaudeSessions, CLAUDE_SESSION_REGISTRY_DIR_ENV } from "../src/claude-session-registry";
+
+const INDEX = join(import.meta.dir, "..", "src", "index.ts");
+const POLL_MS = 200;
+
+const cleanup: (() => void)[] = [];
+afterEach(() => {
+  for (const fn of cleanup.splice(0)) {
+    try { fn(); } catch { /* 尽力而为 */ }
+  }
+});
+
+function alive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+async function waitFor(label: string, predicate: () => boolean, timeoutMs = 20_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await Bun.sleep(50);
+  }
+  throw new Error(`timed out waiting for: ${label}`);
+}
+
+/** 从 ps 里找出命令行里带某个标记的进程 pid。 */
+function findPids(marker: string, extra = ""): number[] {
+  const res = spawnSync("ps", ["-axo", "pid=,command="], { encoding: "utf8", maxBuffer: 32 * 1024 * 1024 });
+  const out: number[] = [];
+  for (const line of (res.stdout ?? "").split("\n")) {
+    const m = /^\s*(\d+)\s+(\S.*)$/.exec(line);
+    if (m === null) continue;
+    if (m[2]!.includes(marker) && m[2]!.includes(extra)) out.push(Number(m[1]));
+  }
+  return out;
+}
+
+/**
+ * 收尾杀进程**必须先复核身份**：pid 一旦退出就可能被系统立刻复用，照着记下来的 pid 无脑
+ * SIGKILL 会打到同一轮测试里别的进程头上（实测把同 shard 的 watch 用例打成了
+ * 「parent process is gone」）。只杀命令行里仍然带着本用例唯一标记的那个。
+ */
+function killIfStillOurs(pid: number, marker: string): void {
+  if (!findPids(marker).includes(pid)) return;
+  try { process.kill(pid, "SIGKILL"); } catch { /* 刚好没了 */ }
+}
+
+describe("#908 宿主死亡 ⇒ 子进程退场（端到端）", () => {
+  test("宿主 pid 被 kill 后，party claude-channel 子进程自行退出", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "ap-orphan-e2e-"));
+    cleanup.push(() => rmSync(dir, { recursive: true, force: true }));
+    // 唯一标记必须落在**命令行**上（ps 看得到的只有 command，看不到环境变量），否则
+    // 「ps 里已经没有它了」这条断言会永远空转成真。这里借频道名当标记：它本来就要出现在 argv 里。
+    const marker = `e2e-orphan-${String(process.pid)}-${String(Date.now())}`;
+    const hostScript = join(dir, "host.ts");
+    writeFileSync(
+      hostScript,
+      // 宿主：拉起 announce 子进程后就一直活着，等着被我们 kill。子进程 stdio 全部丢弃，
+      // 这样「宿主死了 ⇒ 子进程退出」只可能来自父进程存活探测，不可能是 stdin EOF 的功劳。
+      `import { spawn } from "node:child_process";\n` +
+      `const child = spawn(process.execPath, ["run", ${JSON.stringify(INDEX)}, "claude-channel", "--require-launch-opt-in", "--channel", ${JSON.stringify(marker)}], {\n` +
+      `  stdio: "ignore",\n` +
+      `});\n` +
+      `console.log("child " + String(child.pid));\n` +
+      `setInterval(() => {}, 1000);\n`,
+      "utf8",
+    );
+
+    let hostOut = "";
+    const host: ChildProcess = spawn(process.execPath, ["run", hostScript], {
+      stdio: ["ignore", "pipe", "ignore"],
+      env: {
+        ...process.env,
+        // 端到端要在秒级内看到结果，不能等默认的 30s。
+        AGENTPARTY_PARENT_LIVENESS_POLL_MS: String(POLL_MS),
+      },
+    });
+    host.stdout?.on("data", (chunk: Buffer) => { hostOut += chunk.toString(); });
+    const hostPid = host.pid!;
+    cleanup.push(() => killIfStillOurs(hostPid, hostScript));
+
+    await waitFor("host reports its child pid", () => /child \d+/.test(hostOut));
+    const childPid = Number(/child (\d+)/.exec(hostOut)![1]);
+    cleanup.push(() => killIfStillOurs(childPid, marker));
+    // 必须先在 ps 里看到它（证明标记确实落在命令行上，后面那条「ps 里没有了」才有意义）。
+    await waitFor("announce child is visible in ps", () => findPids(marker).includes(childPid));
+
+    // 前置断言：宿主活着的时候，子进程绝不能自己退——否则这条闸门是「恒杀」，
+    // 后面那条断言就毫无意义了（#884 的教训：守卫自己会假阴性）。
+    await Bun.sleep(POLL_MS * 5);
+    expect(alive(childPid)).toBe(true);
+
+    // 故障形态本身：宿主会话被 kill（-9，不给它任何清理机会，就像真的崩了）。
+    process.kill(hostPid, "SIGKILL");
+    await waitFor("host is gone", () => !alive(hostPid));
+
+    await waitFor("orphaned announce child exits by itself", () => !alive(childPid), 30_000);
+    expect(alive(childPid)).toBe(false);
+    // ps 里也不该再有它。
+    expect(findPids(marker)).toEqual([]);
+  }, 60_000);
+
+  test("宿主 pid 已死的注册条目会被回收", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ap-orphan-reg-"));
+    cleanup.push(() => rmSync(dir, { recursive: true, force: true }));
+    const registry = join(dir, "claude-sessions");
+    mkdirSync(registry, { mode: 0o700 });
+    const env = { ...process.env, [CLAUDE_SESSION_REGISTRY_DIR_ENV]: registry };
+
+    // 一条活行（本进程）+ 一条死行（一个刚退出的真实进程的 pid）。
+    // spawnSync 返回时这个进程已经退出且被收尸，它的 pid 就是一个确证已死的 pid。
+    const dead = spawnSync("sh", ["-c", "exit 0"]);
+    const deadPid = dead.pid!;
+    expect(deadPid).toBeGreaterThan(1);
+    expect(alive(deadPid)).toBe(false);
+
+    expect(registerClaudeSession({
+      session_id: "11111111-1111-4111-8111-111111111111",
+      pid: process.pid,
+      display_name: "alive-one",
+      channel: "e2e-orphan",
+      server: "https://example.test",
+      cwd: process.cwd(),
+    }, env)).toBe(true);
+    expect(registerClaudeSession({
+      session_id: "22222222-2222-4222-8222-222222222222",
+      pid: deadPid,
+      display_name: "dead-one",
+      channel: "e2e-orphan",
+      server: "https://example.test",
+      cwd: process.cwd(),
+    }, env)).toBe(true);
+    expect(readdirSync(registry).filter((f) => f.endsWith(".json"))).toHaveLength(2);
+
+    const live = listClaudeSessions(env);
+    expect(live.map((e) => e.display_name)).toEqual(["alive-one"]);
+    // 回收是**落盘**的，不只是过滤掉：死条目继续留在盘上会一直污染 #906 的选择逻辑。
+    expect(readdirSync(registry).filter((f) => f.endsWith(".json"))).toHaveLength(1);
+  });
+});

--- a/cli/test/orphan-scan.test.ts
+++ b/cli/test/orphan-scan.test.ts
@@ -1,0 +1,232 @@
+// #908 孤儿进程判据的单测。重点在两条硬约束：
+//  (a) 「绝不碰非 party 进程」——有专门的变异用例（#884 教训：守卫自己会假阴性）；
+//  (b) 「人有意 daemonize 的 lane 永远不判 stale」。
+import { describe, expect, test } from "bun:test";
+import {
+  classifyOrphanProcess,
+  commandArgv,
+  isPartyProcess,
+  parsePsOutput,
+  partyLane,
+  partySubcommand,
+  type ScannedProcess,
+} from "../src/orphan-scan";
+import { ancestorPids, planOrphans, runOrphans } from "../src/commands/orphans";
+
+function proc(pid: number, ppid: number, command: string): ScannedProcess {
+  return { pid, ppid, command };
+}
+
+describe("parsePsOutput", () => {
+  test("解析 pid/ppid/command 三列，跳过形状不对的行", () => {
+    const out = parsePsOutput(
+      [
+        "  41114     1 /Users/leo/.local/bin/party claude-channel --require-launch-opt-in",
+        "  10672 10600 /usr/local/bin/claude",
+        "garbage line",
+        "",
+        "   77            ", // 没有 command
+      ].join("\n"),
+    );
+    expect(out).toEqual([
+      proc(41114, 1, "/Users/leo/.local/bin/party claude-channel --require-launch-opt-in"),
+      proc(10672, 10600, "/usr/local/bin/claude"),
+    ]);
+  });
+
+  test("命令里的空格与参数原样保留", () => {
+    const out = parsePsOutput("  5 1 /bin/party mcp --channel dev --identity bot\n");
+    expect(out[0]!.command).toBe("/bin/party mcp --channel dev --identity bot");
+    expect(commandArgv(out[0]!.command)).toEqual(["/bin/party", "mcp", "--channel", "dev", "--identity", "bot"]);
+  });
+});
+
+describe("isPartyProcess —— 只按命令本体判定", () => {
+  test("认得两个官方 basename（含 Windows 后缀）", () => {
+    expect(isPartyProcess("/Users/leo/.local/bin/party claude-channel")).toBe(true);
+    expect(isPartyProcess("/x/plugins/agentparty/bin/agentparty-runtime mcp")).toBe(true);
+    // 后缀剥离与 isPartyMcpRegistration 保持同款；路径分隔符只按 POSIX 处理——
+    // 这条链的输入是 `ps`，Windows 上根本没有它。
+    expect(isPartyProcess("party.exe mcp")).toBe(true);
+  });
+
+  test("不认间接形态与任何冒名者", () => {
+    for (const command of [
+      "npx party claude-channel",
+      "sh -c 'party claude-channel'",
+      "bun run cli/src/index.ts claude-channel",
+      "/opt/other/partyd claude-channel",
+      "/opt/other/my-party mcp",
+      "/usr/bin/node /x/party.js mcp",
+      "",
+      "   ",
+    ]) {
+      expect(isPartyProcess(command)).toBe(false);
+    }
+  });
+
+  test("变异守卫：进程名/参数里出现 party 字样绝不足以让它被认成我们的进程", () => {
+    // 这些是别人的进程，只是命令行里恰好带着 party / claude-channel 字样。
+    // 若把判定从「argv[0] 的 basename」放宽成任何形式的子串/包含匹配，这里必挂。
+    const impostors = [
+      proc(900, 1, "/Applications/Discord.app/Contents/MacOS/Discord --party-mode"),
+      proc(901, 1, "/usr/local/bin/iphone-use-mcp --server party claude-channel"),
+      proc(902, 1, "/usr/bin/python3 party_worker.py claude-channel"),
+      proc(903, 1, "/usr/bin/tail -f /var/log/party-claude-channel.log"),
+    ];
+    for (const p of impostors) {
+      expect(isPartyProcess(p.command)).toBe(false);
+      const verdict = classifyOrphanProcess({ proc: p });
+      expect(verdict.action).toBe("keep");
+      expect(verdict.reason).toBe("not an AgentParty process — never touched");
+    }
+  });
+});
+
+describe("partySubcommand / partyLane", () => {
+  test("子命令＝第一个非 flag 参数", () => {
+    expect(partySubcommand("/bin/party --channel dev claude-channel")).toBe("claude-channel");
+    expect(partySubcommand("/bin/party claude-channel --require-launch-opt-in")).toBe("claude-channel");
+    expect(partySubcommand("/bin/party")).toBeNull();
+    expect(partySubcommand("/bin/node index.js serve")).toBeNull();
+  });
+
+  test("lane 分档", () => {
+    expect(partyLane("/bin/party claude-channel --require-launch-opt-in")).toBe("session-child");
+    expect(partyLane("/bin/party mcp --channel dev")).toBe("session-child");
+    // `party mcp prune` 是短命 CLI，不是常驻 server——正在跑的清理不该被当成孤儿。
+    expect(partyLane("/bin/party mcp prune --yes")).toBe("oneshot");
+    expect(partyLane("/bin/party serve dev --runner claude")).toBe("daemon");
+    expect(partyLane("/bin/party watch dev --once")).toBe("daemon");
+    expect(partyLane("/bin/party hook codex-autowake --supervise --channel dev")).toBe("daemon");
+    expect(partyLane("/bin/party send hi")).toBe("oneshot");
+  });
+});
+
+describe("classifyOrphanProcess", () => {
+  test("本次故障形态：宿主已死的 announce 被 init 收养 ⇒ stale", () => {
+    const v = classifyOrphanProcess({
+      proc: proc(41114, 1, "/Users/leo/.local/bin/party claude-channel --require-launch-opt-in"),
+    });
+    expect(v.action).toBe("stale");
+    expect(v.reason).toContain("orphaned");
+  });
+
+  test("父进程还在 ⇒ 一律 keep（宿主活着的 announce 绝不能被碰）", () => {
+    const v = classifyOrphanProcess({
+      proc: proc(41114, 10672, "/bin/party claude-channel --require-launch-opt-in"),
+    });
+    expect(v.action).toBe("keep");
+  });
+
+  test("人有意 daemonize 的 lane 即使 ppid=1 也只 review，绝不 stale", () => {
+    for (const command of [
+      "/bin/party serve dev --runner claude",
+      "/bin/party watch dev --once",
+      "/bin/party hook codex-autowake --supervise --channel dev",
+    ]) {
+      const v = classifyOrphanProcess({ proc: proc(500, 1, command) });
+      expect(v.action).toBe("review");
+    }
+  });
+
+  test("受保护的 pid（自己/祖先）永不进入清理列表", () => {
+    const v = classifyOrphanProcess({
+      proc: proc(10672, 1, "/bin/party claude-channel"),
+      protectedPids: new Set([10672]),
+    });
+    expect(v.action).toBe("keep");
+  });
+
+  test("短命 party 命令即便 ppid=1 也不动", () => {
+    expect(classifyOrphanProcess({ proc: proc(7, 1, "/bin/party send hi") }).action).toBe("keep");
+    expect(classifyOrphanProcess({ proc: proc(8, 1, "/bin/party mcp prune") }).action).toBe("keep");
+  });
+});
+
+describe("ancestorPids", () => {
+  test("自己 + 整条祖先链", () => {
+    const procs = [proc(10, 20, "a"), proc(20, 30, "b"), proc(30, 1, "c"), proc(99, 1, "d")];
+    expect([...ancestorPids(10, procs)].sort((x, y) => x - y)).toEqual([10, 20, 30]);
+  });
+
+  test("环形 ppid 不死循环", () => {
+    const procs = [proc(10, 20, "a"), proc(20, 10, "b")];
+    expect([...ancestorPids(10, procs)].sort((x, y) => x - y)).toEqual([10, 20]);
+  });
+});
+
+const PS_FIXTURE = [
+  "  10672 10600 /usr/local/bin/claude",
+  "  41114     1 /Users/leo/.local/bin/party claude-channel --require-launch-opt-in",
+  "  41115 10672 /Users/leo/.local/bin/party claude-channel --require-launch-opt-in",
+  "  52207     1 /usr/local/bin/party serve dev --runner claude",
+  "  60000     1 /usr/local/bin/iphone-use-mcp --party",
+  "  60001     1 /Applications/Slack.app/Contents/MacOS/Slack",
+].join("\n");
+
+describe("party orphans 命令", () => {
+  test("dry-run 是默认值：列出孤儿但一个信号都不发", async () => {
+    const lines: string[] = [];
+    const signalled: number[] = [];
+    const code = await runOrphans({
+      ps: () => PS_FIXTURE,
+      selfPid: 10672,
+      json: true,
+      signal: (pid) => { signalled.push(pid); return { ok: true, detail: "" }; },
+      sweepRegistry: () => 3,
+      log: (l) => lines.push(l),
+    });
+    expect(code).toBe(0);
+    expect(signalled).toEqual([]);
+    const report = JSON.parse(lines.join("\n")) as {
+      dry_run: boolean;
+      orphans: { pid: number }[];
+      review: { pid: number }[];
+      untouched_non_party: number;
+      live_session_registrations: number;
+    };
+    expect(report.dry_run).toBe(true);
+    expect(report.orphans.map((o) => o.pid)).toEqual([41114]);
+    expect(report.review.map((o) => o.pid)).toEqual([52207]);
+    // claude 本体 + iphone-use-mcp + Slack：三个非 party 进程，看见了、没碰。
+    expect(report.untouched_non_party).toBe(3);
+    expect(report.live_session_registrations).toBe(3);
+  });
+
+  test("--yes 只对确证的孤儿发 SIGTERM，别的进程一个都不碰", async () => {
+    const signalled: number[] = [];
+    await runOrphans({
+      ps: () => PS_FIXTURE,
+      selfPid: 10672,
+      yes: true,
+      json: true,
+      signal: (pid) => { signalled.push(pid); return { ok: true, detail: "" }; },
+      sweepRegistry: () => 0,
+      log: () => undefined,
+    });
+    expect(signalled).toEqual([41114]);
+    // 宿主还活着的那个 announce（41115）、人手工起的 serve（52207）、别人的 mcp（60000）都没被动。
+    expect(signalled).not.toContain(41115);
+    expect(signalled).not.toContain(52207);
+    expect(signalled).not.toContain(60000);
+  });
+
+  test("命令层扫描不会把自己列进去", () => {
+    const plan = planOrphans({ ps: () => "  4242     1 /bin/party claude-channel\n", selfPid: 4242 });
+    expect(plan.entries[0]!.verdict.action).toBe("keep");
+  });
+
+  test("发信号失败会被报告且退出码非 0", async () => {
+    const code = await runOrphans({
+      ps: () => PS_FIXTURE,
+      selfPid: 10672,
+      yes: true,
+      json: true,
+      signal: () => ({ ok: false, detail: "ESRCH" }),
+      sweepRegistry: () => 0,
+      log: () => undefined,
+    });
+    expect(code).toBe(1);
+  });
+});

--- a/cli/test/parent-liveness.test.ts
+++ b/cli/test/parent-liveness.test.ts
@@ -1,0 +1,127 @@
+// #908 宿主存活探测的单测。
+import { describe, expect, test } from "bun:test";
+import type { ProcessOwner } from "../src/instance-lock";
+import { hasIdentifiableHost, watchParentLiveness } from "../src/parent-liveness";
+
+/** 手动驱动的定时器，让每个用例能精确控制「跑了几个 tick」。 */
+function manualSchedule() {
+  const ticks: (() => void)[] = [];
+  let stopped = 0;
+  return {
+    schedule: (fn: () => void) => {
+      ticks.push(fn);
+      return { stop: () => { stopped += 1; } };
+    },
+    tick: () => { for (const fn of [...ticks]) fn(); },
+    stops: () => stopped,
+  };
+}
+
+function owner(pid: number, alive: () => boolean): ProcessOwner {
+  return { pid, alive };
+}
+
+describe("watchParentLiveness (#908)", () => {
+  test("宿主还活着时什么都不做", () => {
+    const clock = manualSchedule();
+    const logs: string[] = [];
+    let terminated = 0;
+    const handle = watchParentLiveness({
+      label: "party claude-channel",
+      owner: owner(4242, () => true),
+      schedule: clock.schedule,
+      log: (l) => logs.push(l),
+      terminate: () => { terminated += 1; },
+    });
+    expect(handle.armed).toBe(true);
+    expect(handle.hostPid).toBe(4242);
+    clock.tick();
+    clock.tick();
+    expect(terminated).toBe(0);
+    expect(logs).toEqual([]);
+  });
+
+  test("宿主死掉 ⇒ 打一行说明原因的日志并收尾", () => {
+    const clock = manualSchedule();
+    const logs: string[] = [];
+    let terminated = 0;
+    let alive = true;
+    watchParentLiveness({
+      label: "party claude-channel",
+      owner: owner(4242, () => alive),
+      schedule: clock.schedule,
+      log: (l) => logs.push(l),
+      terminate: () => { terminated += 1; },
+    });
+    clock.tick();
+    expect(terminated).toBe(0);
+    alive = false;
+    clock.tick();
+    expect(terminated).toBe(1);
+    expect(logs).toHaveLength(1);
+    // 「留一行日志说明为什么退」是 #908 明写的要求：光退不说话没法排查。
+    expect(logs[0]).toContain("reaping");
+    expect(logs[0]).toContain("4242");
+    expect(logs[0]).toContain("party claude-channel");
+  });
+
+  test("只收尾一次，之后不再重复发信号", () => {
+    const clock = manualSchedule();
+    let terminated = 0;
+    watchParentLiveness({
+      label: "x",
+      owner: owner(9, () => false),
+      schedule: clock.schedule,
+      log: () => undefined,
+      terminate: () => { terminated += 1; },
+    });
+    clock.tick();
+    clock.tick();
+    clock.tick();
+    expect(terminated).toBe(1);
+  });
+
+  test("stop() 之后宿主再死也不收尾（正常退出路径不会自伤）", () => {
+    const clock = manualSchedule();
+    let terminated = 0;
+    let alive = true;
+    const handle = watchParentLiveness({
+      label: "x",
+      owner: owner(9, () => alive),
+      schedule: clock.schedule,
+      log: () => undefined,
+      terminate: () => { terminated += 1; },
+    });
+    handle.stop();
+    alive = false;
+    clock.tick();
+    expect(terminated).toBe(0);
+    expect(clock.stops()).toBe(1);
+  });
+
+  test("启动时就没有可辨认的宿主（ppid≤1，例如被有意 daemonize）⇒ 不接管其生命周期", () => {
+    const clock = manualSchedule();
+    let terminated = 0;
+    for (const pid of [1, 0, -1]) {
+      const handle = watchParentLiveness({
+        label: "x",
+        // alive() 恒 false：若闸门写错，这里会立刻误杀一个人手工起的 daemon。
+        owner: owner(pid, () => false),
+        schedule: clock.schedule,
+        log: () => undefined,
+        terminate: () => { terminated += 1; },
+      });
+      expect(handle.armed).toBe(false);
+    }
+    clock.tick();
+    expect(terminated).toBe(0);
+  });
+
+  test("hasIdentifiableHost 只认 >1 的整数 pid", () => {
+    expect(hasIdentifiableHost(owner(2, () => true))).toBe(true);
+    expect(hasIdentifiableHost(owner(1, () => true))).toBe(false);
+    expect(hasIdentifiableHost(owner(0, () => true))).toBe(false);
+    expect(hasIdentifiableHost(owner(1.5, () => true))).toBe(false);
+    expect(hasIdentifiableHost(owner(Number.NaN, () => true))).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #908

## 问题

`party claude-channel`（announce）和 `party mcp` 都是 harness 通过 stdio 拉起的子进程，**此前没有任何父进程存活检测**。全仓 `process.ppid` 只在 `instance-lock.ts` 出现过一次，没有任何长驻进程用它做运行期生命周期判定。

宿主会话死掉后它们被 init 收养继续活着，三重后果全部静默：假在线（`party who` 里 `● online` 背后没有会话）、**劫持 @**（继续收该身份的消息并按 channel+cwd 注入进另一个身份的会话 —— #906 那次跨身份误投的实际来源就是一个孤儿 announce）、进程膨胀（叠加在 #898/#907 上）。

## 盘出来的长驻进程清单及生命周期归属

| 进程 | 谁拉起 | detached | 原有收尾 | 本 PR |
|---|---|---|---|---|
| `party claude-channel --require-launch-opt-in`（蛰伏 announce + armed 两档） | Claude Code 自己（`plugins/agentparty/claude-mcp.json` 的 MCP stdio server） | 否，stdio pipe | armed 档靠 transport close；蛰伏档只有**按 session_id 关 WS** 的探测，进程本身永不退 | **挂上宿主存活探测** ← 本次故障主体 |
| `party mcp` / `party mcp --managed` | 同上（MCP stdio server） | 否 | `process.stdin` 的 close/end | **加第二道闸**：宿主被 kill -9 时 pipe 不一定关，父进程探测不依赖 fd |
| `party hook codex-autowake --supervise --channel C` | codex SessionStart hook | **是**（`detached: true` + `unref`，有意脱离 codex 进程组） | 已有 #893 的按频道收尾（`reaping: … 已无存活的交互式 codex 会话，唤醒层退场`）+ 放弃预算 | **不改**，它的 ppid=1 是设计如此；本 PR 沿用它的收尾模式 |
| `party hook push …` | Claude 每次 lifecycle hook | `unref`，不 detached | 短命（一次 REST + 有界重试），且有 marker 节流 | 不需要 |
| `party serve`（`party up` 拉起 / 人手工 nohup）、`party watch --once` | 用户显式发起 | serve 有 `unref`；watch 前台 | serve 靠实例锁；watch 已有 #755 的 `captureParentProcessOwner` + parentGuard | 不改；清理命令里这两档**只 review 不动** |

## 做法

**复用已有模式，没有另起一套**：
- 父进程身份直接用 `instance-lock.ts` 的 `captureParentProcessOwner()`（#755 为 `watch --once` 写的）。它已经处理了僵尸进程、pid 复用（比对出生时间）、`ps` 不可用时保守判活 —— 自己重写一遍 `kill(pid,0)` 必然漏其中一条。
- 收尾动作沿用 #893：打一行说明原因的 `reaping:` 日志 + 自发 SIGTERM，复用各命令**已有的**优雅收口路径（关 WS / 放实例锁），不新增看护进程，也不在探测里重复写一套关连接/删条目的逻辑（那会变成两套互相打架的收尾）。

新文件 `cli/src/parent-liveness.ts`、`cli/src/orphan-scan.ts`、`cli/src/commands/orphans.ts`。

**检测周期与开销**：默认 30s（与 `CODEX_AUTO_WAKE_POLL_MS` 同数量级，方便一起调）。单次开销 = 一次 `kill(pid,0)` + 一次 1s 超时的 `ps -o lstart= -o stat= -p <pid>`，单进程约每天 2880 次短命 ps，实测不可测量。定时器 `unref()`，探测本身绝不构成进程活着的理由。`AGENTPARTY_PARENT_LIVENESS_POLL_MS` 可覆盖（验收/测试用，下限 50ms）。

## 清理命令的安全默认值

`party orphans [--yes] [--json]`

- **默认 dry-run**，`--yes` 才发信号；**只发 SIGTERM，永不 SIGKILL**。
- **只按命令本体判定**是不是 party 进程（argv[0] 的 basename 必须正好是 `party`/`agentparty-runtime`），词表从 `mcp-registry.ts` 复用**同一份**而不是复制（#622 漂移教训）。`npx party` / `sh -c "party …"` / `bun run index.ts claude-channel` 这类间接形态一律不认 = 永远不碰。
- 只有 **session-child 档（claude-channel / mcp server）+ 已被 init 收养** 才判 stale。人有意 daemonize 的 `serve`/`watch`/`hook autowake` 即使 ppid=1 也只 review。`party mcp prune` 这类短命 CLI 不参与。
- 自己和整条祖先链在受保护名单里，永不进入清理列表。
- 顺带扫一遍 `~/.agentparty/{claude,codex}-sessions/`：`listSessions()` 读的时候就会把 pid 已死的条目就地删掉，直接复用它而不是复制一份删除逻辑（也就不会和 #906 正在改的选择逻辑打架）。

## 与 #906 的协调点

`fix/906-claude-inject-identity-check` 正在改 `claude-channel.ts` 与 `claude-session-registry.ts`，我也需要碰这两处，所以逻辑**全部放在新文件里**，对他文件的改动压到最小、**没有重写他正在改的任何函数**：

- `cli/src/commands/claude-channel.ts`：**+7 行** —— 一句 import，和 `run()` 里 `--require-launch-opt-in` 分支**之前**的一行 `watchParentLiveness({ label: "party claude-channel" })`（带注释）。两个档共用这一道闸。合并冲突面只有这一处。
- `cli/src/claude-session-registry.ts`：**完全没动**。注册表回收走它已有的 `listSessions()` 读时清理。
- `cli/src/mcp-registry.ts`：**+1 行改动**（`const` → `export const PARTY_COMMAND_BASENAMES`）。#907 若也动这个文件，是一行的冲突。

## 自检（变异 + 等价替换）

整段删除级变异，逐条确认被测试抓住：

| 变异 | 结果 |
|---|---|
| M0 删掉 `claude-channel.ts` 里的 `watchParentLiveness(...)` 调用 | **端到端用例失败**（孤儿撑满 30s 超时）—— 钉住本次故障形态的那条用例确实在测这个改动 |
| M1 `isPartyProcess` 从「argv[0] basename 精确匹配」放宽成子串包含 | 3 fail（冒名进程用例） |
| M2 删掉 `classifyOrphanProcess` 里「非 party 进程一律 keep」的闸门 | 2 fail |
| M3 daemon 档也判 stale | 3 fail（手工 nohup 的 serve/watch 被误判） |
| M4 去掉 `ppid≤1 ⇒ 不接管生命周期` 的早退 | 1 fail |
| M5 去掉收尾的幂等（`stopped` 标志） | 2 fail |
| **E1 等价替换**：`isPartyProcess` 改用 regex 取路径尾段，不走 `path.basename` | 18 pass —— 测的是行为不是实现 |

「绝不碰非 party 进程」这道守卫另有**专门的变异用例**（#884 教训：守卫自己会假阴性）：四个命令行里带 `party`/`claude-channel` 字样但 argv[0] 完全无关的冒名进程（Discord、iphone-use-mcp、`python3 party_worker.py`、`tail -f party-claude-channel.log`），任何形式的放宽匹配都会让它挂。M1 就是这条的对照实验。

**写测试过程中被抓到的两个真 bug**（都不是测试问题）：
1. `partySubcommand` 会把 `--channel dev` 的 `dev` 当成子命令 —— 已改成显式的带值 flag 名单。
2. 端到端用例的收尾按记下来的 pid 无脑 SIGKILL，pid 复用时会打到同一轮测试里别的进程头上（实测把同 shard 的 watch 用例打成了「parent process is gone」，`check:cli` 连挂两次而 baseline 通过）。已改成**先复核命令行标记再杀**。顺带发现原来的「ps 里已经没有它了」断言是空转的（唯一标记落在 env 上，而 ps 只看得到 command），已把标记挪到 argv。

## 验收（不是只有单测）

用 `bun build --compile` 出的**真二进制**在本机构造真实场景：

1. 起「宿主 + `party claude-channel --require-launch-opt-in`」，`kill -9` 宿主 → 子进程在一个探测周期内**自行退场**，`ps` 里干净。
2. 同一形态下（探测周期调到 10 分钟，让孤儿留在原地）跑 `party orphans`：**只列出这一个孤儿**，本机另外 65 个 party 进程和 750 个非 party 进程一个没碰；`--yes` 收掉，确认消失。
3. 宿主还活着时先断言子进程**不会**自己退（否则这道闸是「恒杀」，第 1 条就毫无意义）。
4. 注册表：pid 已死的条目在 `listSessions()` 后**从盘上消失**（不只是被过滤掉）。

`bun run check:cli`（6 shard + tsc）与 `bun run check:scripts` 全绿，check:cli 连跑两次稳定。
