### PR TITLE
fix(cli): codex hook 按会话真实身份判定，不再按 cwd 猜身份 (#917)

### DIFF
--- a/cli/src/codex-session-identity.ts
+++ b/cli/src/codex-session-identity.ts
@@ -1,0 +1,342 @@
+// codex hook 的会话身份解析（issue #917）。
+//
+// 为什么要有这一层：codex 的 hook payload 只带 `cwd` / `session_id`，此前 SessionStart 入册
+// 与 Stop 前台唤醒都用 `readConfig(cwd)` 当身份——那是**按目录猜**。真机上同一个 worktree
+// 会绑着十几个身份（#907），而且分属两台生产实例（#865），于是：
+//   - 唤醒查询用了另一个身份的 token、另一台服务器 ⇒ 恒查不到，静默失效（#917 现场）；
+//   - 更坏的一侧：万一那个身份恰好有待处理的 @，就会把别人的 @ 注入进本会话——
+//     频道、seq、正文全是真的，收信方毫无破绽（#906/#865 反复证明过的静默误投）。
+//
+// 因此这里的铁律是：**宁可不叫，也绝不猜。** 解析不出唯一身份就返回 refusal，
+// 调用方放行并把原因写进日志。判定始终带上 server 维度（#865）。
+//
+// 解析优先级（越靠前越硬）：
+//   1. `env`              —— 会话进程自己带着 `AGENTPARTY_CONFIG`（hook 是 codex 的子进程，
+//                            天然继承）。这是唯一「会话自己说了算」的信号，最硬。
+//   2. `session-registry` —— 按 `session_id` 回查本机 codex 会话注册表条目里记下的
+//                            identity + server（#906 在 claude 侧同款），再映射回本地 config。
+//   3. `mcp-registration` —— 该 codex 进程下挂着的 agentparty MCP 子进程的 `AGENTPARTY_CONFIG`。
+//                            接入包正是把身份写进 MCP 注册的 env（`codex mcp add --env …`），
+//                            所以这条能把「照接入包装好、但没在 shell 里 export」的常见形态救回来。
+//                            该进程下有两个以上不同身份 ⇒ 歧义 ⇒ 放弃（owner 的 ChatGPT.app
+//                            app-server 就是这样多路复用的，真机实测）。
+//   4. `cwd-unique`       —— 退到 cwd 绑定的 config，但**只在本机该频道不存在第二个身份时**
+//                            才算数。单身份机器（绝大多数）行为逐字不变；多身份机器一律放弃。
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import {
+  agentpartyHome,
+  explicitConfigPath,
+  localAgentConfigsForChannel,
+  readConfig,
+  type Config,
+  type LocalAgentConfigHint,
+} from "./config";
+import {
+  listCodexSessions,
+  normalizeSessionRegistryIdentity,
+  normalizeSessionRegistryServer,
+  type ClaudeSessionRegistryEntry,
+} from "./claude-session-registry";
+import { healServerUrl } from "./validation";
+
+export type CodexHookIdentitySource =
+  | "env"
+  | "session-registry"
+  | "mcp-registration"
+  | "cwd-unique";
+
+export interface CodexHookIdentity {
+  source: CodexHookIdentitySource;
+  /** 解析到的 config 文件路径；cwd 档可能为 null（历史行为不依赖路径）。 */
+  configPath: string | null;
+  /** 已 heal 过的实例 URL。判定必须带上它（#865）。 */
+  server: string;
+  token: string;
+  /** 频道身份（`config.identity.name`）；人类账号 config 没有则 null。 */
+  name: string | null;
+  /**
+   * cursor / 欠账是否该按 config 作用域读（`loadCursorForConfig`）。
+   * env 档由 `process.env.AGENTPARTY_CONFIG` 天然作用域化，cwd 档保持历史的 cwd 作用域，
+   * 其余两档解析出的是**本进程 env 之外**的身份，只有 config 作用域才是它真正的游标。
+   */
+  configScopedState: boolean;
+}
+
+export type CodexHookIdentityRefusal =
+  | "no-channel"
+  | "env-config-unusable"
+  | "registry-identity-unresolvable"
+  | "ambiguous"
+  | "no-identity";
+
+export type CodexHookIdentityResolution =
+  | { ok: true; identity: CodexHookIdentity }
+  | { ok: false; reason: CodexHookIdentityRefusal; detail: string };
+
+export interface CodexHookIdentityDeps {
+  /** 本进程显式指定的 config 路径（＝会话自己带的 `AGENTPARTY_CONFIG`）。 */
+  explicitConfigPath: () => string | null;
+  readConfigFile: (path: string) => Config | null;
+  readCwdConfig: (cwd: string) => Config | null;
+  /** 本机绑定该频道的所有 agent config（诊断索引，不含 token 之外的判断）。 */
+  candidates: (channel: string) => LocalAgentConfigHint[];
+  codexSessions: () => ClaudeSessionRegistryEntry[];
+  /** 给定 codex 进程下可见的 agentparty MCP 注册所用的 config 路径（已去重）。 */
+  mcpConfigPaths: (pid: number) => string[];
+  /** codex 本体的 pid——hook 是它的子进程，故取 `process.ppid`。 */
+  pid: number;
+}
+
+export interface CodexHookIdentityInput {
+  cwd: string;
+  channel: string | null;
+  sessionId: string | null;
+  deps: CodexHookIdentityDeps;
+}
+
+function readConfigFileSync(path: string): Config | null {
+  try {
+    return JSON.parse(readFileSync(path, "utf8")) as Config;
+  } catch {
+    return null;
+  }
+}
+
+export function defaultCodexHookIdentityDeps(
+  env: NodeJS.ProcessEnv = process.env,
+  pid: number = process.ppid,
+): CodexHookIdentityDeps {
+  return {
+    explicitConfigPath,
+    readConfigFile: readConfigFileSync,
+    readCwdConfig: (cwd) => readConfig(cwd),
+    candidates: (channel) => localAgentConfigsForChannel(channel, null, agentpartyHome(env)),
+    codexSessions: () => listCodexSessions(env),
+    mcpConfigPaths: (target) => codexMcpConfigPaths(target),
+    pid,
+  };
+}
+
+/** 判定用的身份键：server + 频道身份。少一半都不算同一个身份（#865 + #906）。 */
+function identityKey(server: string, name: string | null): string {
+  return `${normalizeSessionRegistryServer(server) ?? server} ${normalizeSessionRegistryIdentity(name) ?? ""}`;
+}
+
+/**
+ * 一份 config 能不能用作「本会话在该频道上的身份」。
+ * token 必须在（人类账号没有 agent token 时唤醒本就无从谈起），server 必须能 heal，
+ * 缓存身份若绑了另一个频道 ⇒ 不认（那是别的频道的 handle）。
+ */
+function usableConfig(config: Config | null, channel: string): { server: string; token: string; name: string | null } | null {
+  if (config === null) return null;
+  const { server, token, identity } = config;
+  if (typeof server !== "string" || typeof token !== "string" || token === "") return null;
+  const healed = healServerUrl(server);
+  if (healed === null) return null;
+  const scope = identity?.channel_scope;
+  if (typeof scope === "string" && scope !== channel) return null;
+  const name = typeof identity?.name === "string" && identity.name !== "" ? identity.name : null;
+  return { server: healed, token, name };
+}
+
+function distinctCandidateKeys(candidates: LocalAgentConfigHint[]): Map<string, LocalAgentConfigHint> {
+  const map = new Map<string, LocalAgentConfigHint>();
+  for (const hint of candidates) {
+    const healed = healServerUrl(hint.server);
+    if (healed === null) continue;
+    const key = identityKey(healed, hint.name);
+    if (!map.has(key)) map.set(key, hint);
+  }
+  return map;
+}
+
+/**
+ * 解析「本 codex 会话到底是哪个身份」。任何一步只要不唯一就返回 refusal——**绝不降级去猜**。
+ */
+export function resolveCodexHookIdentity(input: CodexHookIdentityInput): CodexHookIdentityResolution {
+  const { cwd, channel, sessionId, deps } = input;
+  if (channel === null || channel === "") {
+    return { ok: false, reason: "no-channel", detail: "本 cwd 没绑频道，无从判定身份" };
+  }
+
+  // ① 会话自己带的 AGENTPARTY_CONFIG——唯一「会话说了算」的信号。
+  const explicit = deps.explicitConfigPath();
+  if (explicit !== null && explicit !== "") {
+    const usable = usableConfig(deps.readConfigFile(explicit), channel);
+    if (usable !== null) {
+      return {
+        ok: true,
+        identity: { source: "env", configPath: explicit, ...usable, configScopedState: false },
+      };
+    }
+    // 显式选择了身份却读不出/绑着别的频道：失败关闭。绝不悄悄换一个身份顶上。
+    return {
+      ok: false,
+      reason: "env-config-unusable",
+      detail: `AGENTPARTY_CONFIG=${explicit} 读不出可用于 #${channel} 的身份，本次放弃`,
+    };
+  }
+
+  // ② session_id → 注册表条目（identity + server 都是 SessionStart 时按本表同一套规则记的）。
+  if (sessionId !== null && sessionId !== "") {
+    const wanted = sessionId.toLowerCase();
+    const entry = deps.codexSessions().find((row) => row.session_id.toLowerCase() === wanted) ?? null;
+    if (entry !== null && entry.channel === channel) {
+      const name = normalizeSessionRegistryIdentity(entry.identity);
+      const server = normalizeSessionRegistryServer(entry.server);
+      if (name !== null && server !== null) {
+        const key = identityKey(server, name);
+        const matches = deps.candidates(channel).filter((hint) => {
+          const healed = healServerUrl(hint.server);
+          return healed !== null && identityKey(healed, hint.name) === key;
+        });
+        if (matches.length === 1) {
+          const usable = usableConfig(deps.readConfigFile(matches[0]!.path), channel);
+          if (usable !== null) {
+            return {
+              ok: true,
+              identity: {
+                source: "session-registry",
+                configPath: matches[0]!.path,
+                ...usable,
+                configScopedState: true,
+              },
+            };
+          }
+        }
+        // 条目记着身份，却映射不回唯一一份本地 config：只能放弃。回落到 cwd 猜＝正是本 issue。
+        return {
+          ok: false,
+          reason: "registry-identity-unresolvable",
+          detail:
+            `注册表条目记的身份 ${name}@${server} 在本机找不到唯一对应的 config` +
+            `（命中 ${matches.length} 份），本次放弃`,
+        };
+      }
+    }
+  }
+
+  // ③ 该 codex 进程下挂着的 agentparty MCP 注册——接入包写进 env 的那份身份。
+  const mcpPaths = deps.mcpConfigPaths(deps.pid);
+  if (mcpPaths.length > 0) {
+    const found = new Map<string, { path: string; server: string; token: string; name: string | null }>();
+    for (const path of mcpPaths) {
+      const usable = usableConfig(deps.readConfigFile(path), channel);
+      if (usable === null) continue;
+      const key = identityKey(usable.server, usable.name);
+      if (!found.has(key)) found.set(key, { path, ...usable });
+    }
+    if (found.size === 1) {
+      const only = [...found.values()][0]!;
+      return {
+        ok: true,
+        identity: {
+          source: "mcp-registration",
+          configPath: only.path,
+          server: only.server,
+          token: only.token,
+          name: only.name,
+          configScopedState: true,
+        },
+      };
+    }
+    if (found.size > 1) {
+      return {
+        ok: false,
+        reason: "ambiguous",
+        detail:
+          `codex 进程 ${deps.pid} 下同时挂着 ${found.size} 个绑 #${channel} 的身份` +
+          `（${[...found.values()].map((row) => `${row.name ?? "?"}@${row.server}`).join(", ")}）` +
+          `——分不清本会话是哪一个，放弃。给这个会话显式设 AGENTPARTY_CONFIG 即可解决`,
+      };
+    }
+  }
+
+  // ④ cwd 绑定的 config——只有本机该频道不存在第二个身份时才算数。
+  const cwdUsable = usableConfig(deps.readCwdConfig(cwd), channel);
+  const distinct = distinctCandidateKeys(deps.candidates(channel));
+  if (cwdUsable !== null) {
+    const key = identityKey(cwdUsable.server, cwdUsable.name);
+    const others = [...distinct.keys()].filter((candidate) => candidate !== key);
+    if (others.length === 0) {
+      return {
+        ok: true,
+        identity: { source: "cwd-unique", configPath: null, ...cwdUsable, configScopedState: false },
+      };
+    }
+    return {
+      ok: false,
+      reason: "ambiguous",
+      detail:
+        `本机绑 #${channel} 的身份有 ${distinct.has(key) ? distinct.size : distinct.size + 1} 个，` +
+        `cwd(${cwd}) 只能猜出其中一个（${cwdUsable.name ?? "?"}@${cwdUsable.server}）——按 cwd 猜必然误投，放弃。` +
+        `给这个会话显式设 AGENTPARTY_CONFIG，或让接入包把身份写进该会话的 MCP 注册 env`,
+    };
+  }
+  return {
+    ok: false,
+    reason: "no-identity",
+    detail: `#${channel} 上解析不出本会话的身份（cwd=${cwd}），本次放弃`,
+  };
+}
+
+/** 一次 `ps` 调用的上限，绝不吃满 hook 预算。 */
+const PS_TIMEOUT_MS = 1_500;
+const PS_MAX_CHILDREN = 16;
+
+type SpawnLike = typeof spawnSync;
+
+function psLines(args: string[], spawn: SpawnLike): string[] {
+  try {
+    const result = spawn("ps", args, {
+      encoding: "utf8",
+      timeout: PS_TIMEOUT_MS,
+      maxBuffer: 8 * 1024 * 1024,
+    });
+    if (result.status !== 0 || typeof result.stdout !== "string") return [];
+    return result.stdout.split("\n").filter((line) => line.trim() !== "");
+  } catch {
+    return [];
+  }
+}
+
+/** 一行 `party mcp …` 才算数：既要是我们的二进制，也要真的是 mcp 子命令。 */
+export function looksLikePartyMcpCommand(command: string): boolean {
+  const tokens = command.trim().split(/\s+/);
+  const first = tokens[0];
+  if (first === undefined) return false;
+  const binary = first.split("/").pop() ?? first;
+  const mcpAt = tokens.indexOf("mcp");
+  // dev 形态是 `bun /path/cli/src/index.ts mcp`：只要参数里出现 party 入口即可。
+  const ours = binary === "party" || tokens.some((token) => /(?:^|\/)party(?:\.js|\.ts)?$/.test(token));
+  return ours && mcpAt > 0;
+}
+
+/**
+ * 读出给定 codex 进程下所有 agentparty MCP 子进程注册时用的 `AGENTPARTY_CONFIG`（去重）。
+ *
+ * macOS/Linux 的 `ps eww` 会连环境变量一起打印，且只对本 uid 的进程可读——正好够用。
+ * 任何失败一律返回空数组（＝这条线索不可用，调用方继续往下走或放弃）。
+ */
+export function codexMcpConfigPaths(pid: number, spawn: SpawnLike = spawnSync): string[] {
+  if (!Number.isInteger(pid) || pid <= 1) return [];
+  if (process.platform === "win32") return [];
+  const children: number[] = [];
+  for (const line of psLines(["-axo", "pid=,ppid=,args="], spawn)) {
+    const match = /^\s*(\d+)\s+(\d+)\s+(.*)$/.exec(line);
+    if (match === null) continue;
+    if (Number(match[2]) !== pid) continue;
+    if (!looksLikePartyMcpCommand(match[3]!)) continue;
+    children.push(Number(match[1]));
+    if (children.length >= PS_MAX_CHILDREN) break;
+  }
+  if (children.length === 0) return [];
+  const paths: string[] = [];
+  for (const line of psLines(["eww", "-o", "command=", "-p", children.join(",")], spawn)) {
+    const found = /(?:^|\s)AGENTPARTY_CONFIG=(\S+)/.exec(line);
+    if (found === null) continue;
+    if (!paths.includes(found[1]!)) paths.push(found[1]!);
+  }
+  return paths;
+}

--- a/cli/src/codex-session-identity.ts
+++ b/cli/src/codex-session-identity.ts
@@ -307,10 +307,17 @@ export function looksLikePartyMcpCommand(command: string): boolean {
   const first = tokens[0];
   if (first === undefined) return false;
   const binary = first.split("/").pop() ?? first;
-  const mcpAt = tokens.indexOf("mcp");
   // dev 形态是 `bun /path/cli/src/index.ts mcp`：只要参数里出现 party 入口即可。
-  const ours = binary === "party" || tokens.some((token) => /(?:^|\/)party(?:\.js|\.ts)?$/.test(token));
-  return ours && mcpAt > 0;
+  const entryAt = tokens.findIndex((token) => /(?:^|\/)party(?:\.js|\.ts)?$/.test(token));
+  const ours = binary === "party" || entryAt >= 0;
+  if (!ours) return false;
+  // `mcp` 必须是**入口之后的第一个非 flag 参数**，不能是命令行里任意位置出现的同名 token——
+  // 否则 `party send "x" --channel mcp`、`party serve x --on-mention mcp` 会被误判成 MCP 注册
+  // 进程，进而从一个毫不相干的进程里读出 AGENTPARTY_CONFIG，把 @ 判给错的身份。
+  // 这正是 #917 要根除的那类「猜身份」，判据本身更不能松。
+  const afterEntry = tokens.slice(Math.max(entryAt, 0) + 1);
+  const sub = afterEntry.find((token) => !token.startsWith("-"));
+  return sub === "mcp";
 }
 
 /**

--- a/cli/src/commands/hook.ts
+++ b/cli/src/commands/hook.ts
@@ -18,7 +18,22 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { AGENT_ACTIVITY_TTL_MS, type AgentActivity } from "@agentparty/shared";
 import { activityFromHookEvent, readActivityFile, writeActivityFile } from "../activity";
-import { agentpartyHome, loadCursor, loadStuck, readConfig, readState, type StuckWake } from "../config";
+import {
+  agentpartyHome,
+  loadCursor,
+  loadCursorForConfig,
+  loadStuck,
+  loadStuckForConfig,
+  readConfig,
+  readState,
+  type StuckWake,
+} from "../config";
+import {
+  defaultCodexHookIdentityDeps,
+  resolveCodexHookIdentity,
+  type CodexHookIdentity,
+  type CodexHookIdentityResolution,
+} from "../codex-session-identity";
 import {
   CODEX_STOP_WAKE_QUERY_TIMEOUT_MS,
   codexStopWakeGate,
@@ -717,13 +732,30 @@ export function recordCodexSessionLifecycle(
     const cwd = typeof record.cwd === "string" && record.cwd.length > 0 ? record.cwd : process.cwd();
     const channel = env.AGENTPARTY_CHANNEL ?? readState(cwd)?.channel;
     if (!channel) return;
+    // #917：身份/实例都由会话身份解析器给（env → MCP 注册 → 本机唯一），**绝不按 cwd 猜**。
+    // 解析不出就两个字段都不写——条目随之不可匹配（#906/#865 的安全侧），也让 Stop hook
+    // 的「按 session_id 回查」明确失败，而不是拿到一个猜错的身份。
+    const resolved = resolveCodexHookIdentity({
+      cwd,
+      channel,
+      sessionId,
+      deps: defaultCodexHookIdentityDeps(env, pid),
+    });
+    if (!resolved.ok) {
+      appendCodexAutoWakeLog(
+        agentpartyHome(env),
+        `codex-report: 入册时解析不出会话身份（${resolved.reason}）：${resolved.detail}`,
+      );
+    }
     registerCodexSession({
       session_id: sessionId,
       pid,
       display_name: claudeSessionDisplayNameFromHookPayload(record),
       channel,
       // #865：同 claude 档——实例维度是匹配的一部分。
-      server: readConfig(cwd)?.server ?? null,
+      server: resolved.ok ? resolved.identity.server : null,
+      // #906：显式传（含 null），绝不让注册表回落到 readConfig(cwd) 的猜测。
+      identity: resolved.ok ? resolved.identity.name : null,
       cwd,
     }, env);
   } catch {
@@ -754,7 +786,23 @@ function defaultCodexAutoWakeDeps(env: NodeJS.ProcessEnv = process.env): CodexAu
     home,
     env,
     lockDir: defaultInstanceLockDir(),
-    readConfigAt: (cwd) => readConfig(cwd),
+    // #917：后台唤醒层同样不许按 cwd 猜身份——猜错就是替另一个身份拉起 serve、
+    // 用别人的 token 接别人的 @。解析不出唯一身份就当「没有 agent token」跳过拉起。
+    readConfigAt: (cwd) => {
+      const channel = env.AGENTPARTY_CHANNEL ?? readState(cwd)?.channel ?? null;
+      const resolved = resolveCodexHookIdentity({
+        cwd,
+        channel,
+        sessionId: null,
+        deps: defaultCodexHookIdentityDeps(env),
+      });
+      if (resolved.ok) return { server: resolved.identity.server, token: resolved.identity.token };
+      appendCodexAutoWakeLog(
+        home,
+        `codex-report: 唤醒层解析不出会话身份（${resolved.reason}）：${resolved.detail}——不拉起`,
+      );
+      return null;
+    },
     channelAt: (cwd) => env.AGENTPARTY_CHANNEL ?? readState(cwd)?.channel ?? null,
     spawn: (args, cwd, childEnv) => {
       // 编译版二进制：execPath 即 party；dev（bun run）：execPath 是 bun，argv[1] 是入口脚本。
@@ -894,18 +942,61 @@ export interface CodexStopWakeDeps {
   now: () => number;
 }
 
-export function defaultCodexStopWakeDeps(env: NodeJS.ProcessEnv = process.env): CodexStopWakeDeps {
+export function defaultCodexStopWakeDeps(
+  env: NodeJS.ProcessEnv = process.env,
+  sessionId: string | null = null,
+  pid: number = process.ppid,
+): CodexStopWakeDeps {
   const home = agentpartyHome(env);
+  // #917：身份只解析一次，全部下游（查询用的 token/实例、游标作用域、seen 集合）都用它。
+  // 此前这里每处各调一次 `readConfig(cwd)`——按 cwd 猜，真机上猜到了同目录下另一个身份、
+  // 还跨了实例，于是查询恒空、唤醒静默失效（#917 现场）。解析不出就统一返回 null ＝ 放行。
+  let cached: { key: string; resolution: CodexHookIdentityResolution } | null = null;
+  let logged = false;
+  const identity = (channel: string, cwd: string): CodexHookIdentity | null => {
+    const key = `${channel} ${cwd}`;
+    if (cached === null || cached.key !== key) {
+      cached = {
+        key,
+        resolution: resolveCodexHookIdentity({
+          cwd,
+          channel,
+          sessionId,
+          deps: defaultCodexHookIdentityDeps(env, pid),
+        }),
+      };
+    }
+    if (cached.resolution.ok) return cached.resolution.identity;
+    if (!logged) {
+      logged = true;
+      appendCodexAutoWakeLog(
+        home,
+        `codex-stop: 解析不出本会话身份（${cached.resolution.reason}）：` +
+          `${cached.resolution.detail}——本次放行不注入`,
+      );
+    }
+    return null;
+  };
   const target = (channel: string, cwd: string): string | null => {
-    const auth = codexAutoWakeAuth(readConfig(cwd));
+    const resolved = identity(channel, cwd);
+    if (resolved === null) return null;
+    const auth = codexAutoWakeAuth(resolved);
     return auth === null ? null : codexAutoWakeTarget(auth, channel);
   };
   return {
     channel: (cwd) => env.AGENTPARTY_CHANNEL ?? readState(cwd)?.channel ?? null,
     enabled: () => resolveCodexAutoWakeMode(env, home).mode !== "off",
-    stuck: (channel, cwd) => loadStuck(channel, cwd),
+    // 游标/欠账必须落在**解析出来那个身份**的作用域里：拿另一个身份的游标当 since，
+    // 查询要么恒空（漏叫）要么把老 @ 翻出来。env / cwd 两档的作用域与历史逐字一致。
+    stuck: (channel, cwd) => {
+      const resolved = identity(channel, cwd);
+      return resolved !== null && resolved.configScopedState && resolved.configPath !== null
+        ? loadStuckForConfig(channel, resolved.configPath)
+        : loadStuck(channel, cwd);
+    },
     nextMention: async (channel, cwd, since) => {
-      const auth = codexAutoWakeAuth(readConfig(cwd));
+      const resolved = identity(channel, cwd);
+      const auth = resolved === null ? null : codexAutoWakeAuth(resolved);
       if (auth === null) return null;
       try {
         const { fetchNextMention } = await import("../rest");
@@ -921,7 +1012,12 @@ export function defaultCodexStopWakeDeps(env: NodeJS.ProcessEnv = process.env): 
         return null;
       }
     },
-    cursor: (channel, cwd) => loadCursor(channel, cwd),
+    cursor: (channel, cwd) => {
+      const resolved = identity(channel, cwd);
+      return resolved !== null && resolved.configScopedState && resolved.configPath !== null
+        ? loadCursorForConfig(channel, resolved.configPath)
+        : loadCursor(channel, cwd);
+    },
     seenPath: (channel, cwd) => {
       const resolved = target(channel, cwd);
       return resolved === null ? null : codexStopWakeSeenPath(home, resolved);
@@ -949,7 +1045,11 @@ export async function handleCodexStopRecord(
   env: NodeJS.ProcessEnv = process.env,
   injected?: CodexStopWakeDeps,
 ): Promise<void> {
-  const deps = injected ?? defaultCodexStopWakeDeps(env);
+  // #917：session_id 是「按会话回查身份」的钥匙，必须在建 deps 之前从 payload 里取出来。
+  const deps = injected ?? defaultCodexStopWakeDeps(
+    env,
+    typeof record.session_id === "string" ? record.session_id : null,
+  );
   // serve 托管 lane 是被管理的 runner 会话，不是用户眼前那个终端会话——前台唤醒对它没有意义，
   // 而且它自己就是 #893 那条后台通道，在这里再 block 一次等于同一条 @ 被两边各处理一次。
   if (env.AP_ACTIVITY_FILE) return;
@@ -990,7 +1090,7 @@ export async function handleCodexStopRecord(
   const seenPath = deps.seenPath(decision.pointer.channel, cwd);
   // 去不了重就绝不注入：没有落盘的 seen 集合，同一条 @ 会在每个 turn 结束时反复 block。
   if (seenPath === null) {
-    deps.log("codex-stop: 拿不到身份（config 里没有 agent token），无法去重，本次放行不注入");
+    deps.log("codex-stop: 拿不到本会话的唯一身份（见上一条解析日志），无法去重，本次放行不注入");
     return;
   }
   // 先落盘再打印。反过来的话，打印后崩一次就会对同一条 @ 反复注入。

--- a/cli/src/commands/invite.ts
+++ b/cli/src/commands/invite.ts
@@ -262,6 +262,10 @@ ${checkinLines}
 claude mcp get ${mcpServerName(guestName)} >/dev/null 2>&1 && echo "# already registered: ${mcpServerName(guestName)} (skipped; run: party mcp prune)" || claude mcp add ${mcpServerName(guestName)} --env AGENTPARTY_CONFIG="\$HOME/.agentparty/agents/agentparty-${guestName}-${slug}.json" -- party mcp --channel ${slug} --identity ${mcpServerName(guestName)}
 # Codex：codex mcp add ${mcpServerName(guestName)} --env AGENTPARTY_CONFIG="\$HOME/.agentparty/agents/agentparty-${guestName}-${slug}.json" -- party mcp --channel ${slug}
 # 非 MCP 的 harness：跳过这步，继续用 party CLI 并每条命令带 AGENTPARTY_CONFIG 前缀。
+# Codex 前台唤醒（turn 结束时提示还没处理的 @）要认出「本会话是哪个身份」。
+# 同一台机器、同一个目录挂着多个身份时，**在启动 codex 的那个 shell 里 export 上面这行
+# AGENTPARTY_CONFIG**（或让本会话的 MCP 注册里只有这一个身份）——否则 hook 分不清是谁，
+# 会明确放弃提示（宁可不叫也不误投，原因写在 ~/.agentparty/logs/codex-auto-wake.log）。
 # 注意：注册的工具通常下个会话才出现——本次会话先用下面的 CLI 命令。
 
 # 5) 之后怎么参与（优先 party_* 工具；CLI 命令是非 MCP harness 的兜底，读懂再决定怎么待命）：

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -151,8 +151,9 @@ export interface LocalAgentConfigHint {
 export function localAgentConfigsForChannel(
   channel: string,
   currentConfigPath: string | null = null,
+  home: string = agentpartyHome(),
 ): LocalAgentConfigHint[] {
-  const directory = join(agentpartyHome(), "agents");
+  const directory = join(home, "agents");
   const current = currentConfigPath === null ? null : canonicalPath(currentConfigPath);
   let entries: Dirent[];
   try {

--- a/cli/test/__snapshots__/m3.test.ts.snap
+++ b/cli/test/__snapshots__/m3.test.ts.snap
@@ -44,6 +44,10 @@ party send "👋 fix-login-bug-guest 报到，来参与协作" --channel fix-log
 claude mcp get party-fix-login-bug-guest >/dev/null 2>&1 && echo "# already registered: party-fix-login-bug-guest (skipped; run: party mcp prune)" || claude mcp add party-fix-login-bug-guest --env AGENTPARTY_CONFIG="$HOME/.agentparty/agents/agentparty-fix-login-bug-guest-fix-login-bug.json" -- party mcp --channel fix-login-bug --identity party-fix-login-bug-guest
 # Codex：codex mcp add party-fix-login-bug-guest --env AGENTPARTY_CONFIG="$HOME/.agentparty/agents/agentparty-fix-login-bug-guest-fix-login-bug.json" -- party mcp --channel fix-login-bug
 # 非 MCP 的 harness：跳过这步，继续用 party CLI 并每条命令带 AGENTPARTY_CONFIG 前缀。
+# Codex 前台唤醒（turn 结束时提示还没处理的 @）要认出「本会话是哪个身份」。
+# 同一台机器、同一个目录挂着多个身份时，**在启动 codex 的那个 shell 里 export 上面这行
+# AGENTPARTY_CONFIG**（或让本会话的 MCP 注册里只有这一个身份）——否则 hook 分不清是谁，
+# 会明确放弃提示（宁可不叫也不误投，原因写在 ~/.agentparty/logs/codex-auto-wake.log）。
 # 注意：注册的工具通常下个会话才出现——本次会话先用下面的 CLI 命令。
 
 # 5) 之后怎么参与（优先 party_* 工具；CLI 命令是非 MCP harness 的兜底，读懂再决定怎么待命）：

--- a/cli/test/codex-session-identity.test.ts
+++ b/cli/test/codex-session-identity.test.ts
@@ -267,6 +267,13 @@ describe("MCP 子进程扫描", () => {
     expect(looksLikePartyMcpCommand("mcp party")).toBe(false);
     expect(looksLikePartyMcpCommand("some-other-mcp mcp")).toBe(false);
     expect(looksLikePartyMcpCommand("")).toBe(false);
+    // `mcp` 出现在参数值里不算数：这些是别的子命令，从它们身上读 AGENTPARTY_CONFIG
+    // 会把 @ 判给毫不相干的身份——正是 #917 要根除的那类猜测。
+    expect(looksLikePartyMcpCommand('party send "hi" --channel mcp')).toBe(false);
+    expect(looksLikePartyMcpCommand("party serve x --on-mention mcp")).toBe(false);
+    expect(looksLikePartyMcpCommand("party history mcp")).toBe(false);
+    // flag 挡在子命令前面仍要认得出来。
+    expect(looksLikePartyMcpCommand("party --verbose mcp --channel x")).toBe(true);
   });
 
   test("从 `ps eww` 里读出子进程注册时用的 AGENTPARTY_CONFIG（去重）", () => {

--- a/cli/test/codex-session-identity.test.ts
+++ b/cli/test/codex-session-identity.test.ts
@@ -1,0 +1,309 @@
+// #917：codex hook 的会话身份解析——按 cwd 猜身份会猜到同目录下的另一个身份、还跨实例。
+//
+// 本文件的**钉子**是 `pins #917` 那一组：cwd 解析出的身份 ≠ 会话真实身份、且两者在不同
+// 服务器上时，查询必须用会话真实身份。真机故障形态逐字照抄：
+//   cwd → leeguooooo-codex2-agentparty @ https://agentparty.leeguoo.com
+//   会话 → lark-ad72b3f9749e-agentparty-codex1 @ https://agentparty.pwtk-dev.work
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  saveCursorForConfig,
+  writeState,
+  writeWorkspaceConfigOnly,
+  type Config,
+} from "../src/config";
+import { registerCodexSession } from "../src/claude-session-registry";
+import {
+  codexMcpConfigPaths,
+  defaultCodexHookIdentityDeps,
+  looksLikePartyMcpCommand,
+  resolveCodexHookIdentity,
+} from "../src/codex-session-identity";
+import { codexAutoWakeAuth, codexAutoWakeTarget } from "../src/codex-auto-wake";
+import { codexStopWakeSeenPath } from "../src/codex-stop-wake";
+import { defaultCodexStopWakeDeps } from "../src/commands/hook";
+
+const CHANNEL = "agentparty";
+const CWD_SERVER = "https://agentparty.leeguoo.com";
+const CWD_NAME = "leeguooooo-codex2-agentparty";
+const SESSION_SERVER = "https://agentparty.pwtk-dev.work";
+const SESSION_NAME = "lark-ad72b3f9749e-agentparty-codex1";
+const SESSION_ID = "01a021f5-aed7-7802-bea3-6165e5dba553";
+
+let home: string;
+let cwd: string;
+let savedEnv: Record<string, string | undefined>;
+
+function agentConfig(name: string, server: string, token: string, channel: string | null = CHANNEL): Config {
+  return {
+    server,
+    token,
+    identity: {
+      name,
+      email: null,
+      kind: "agent",
+      role: "member",
+      owner: null,
+      channel_scope: channel,
+      verified_at: 1_700_000_000_000,
+    },
+  };
+}
+
+/** 把一份身份写进 ~/.agentparty/agents（＝本机候选身份索引的唯一来源）。 */
+function writeAgentConfig(filename: string, config: Config): string {
+  const directory = join(home, "agents");
+  mkdirSync(directory, { recursive: true, mode: 0o700 });
+  const path = join(directory, filename);
+  writeFileSync(path, JSON.stringify(config), { mode: 0o600 });
+  return path;
+}
+
+function deps(overrides: Partial<ReturnType<typeof defaultCodexHookIdentityDeps>> = {}) {
+  return { ...defaultCodexHookIdentityDeps(process.env, 4242), mcpConfigPaths: () => [], ...overrides };
+}
+
+function resolve(overrides: Parameters<typeof deps>[0] = {}, sessionId: string | null = SESSION_ID) {
+  return resolveCodexHookIdentity({ cwd, channel: CHANNEL, sessionId, deps: deps(overrides) });
+}
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "agentparty-codex-identity-home-"));
+  cwd = mkdtempSync(join(tmpdir(), "agentparty-codex-identity-cwd-"));
+  savedEnv = {
+    AGENTPARTY_HOME: process.env.AGENTPARTY_HOME,
+    AGENTPARTY_CONFIG: process.env.AGENTPARTY_CONFIG,
+    AGENTPARTY_CHANNEL: process.env.AGENTPARTY_CHANNEL,
+  };
+  process.env.AGENTPARTY_HOME = home;
+  delete process.env.AGENTPARTY_CONFIG;
+  process.env.AGENTPARTY_CHANNEL = CHANNEL;
+});
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  rmSync(home, { recursive: true, force: true });
+  rmSync(cwd, { recursive: true, force: true });
+});
+
+describe("pins #917：cwd 猜出的身份 ≠ 会话真实身份（且跨实例）", () => {
+  /** 真机故障现场：同一 cwd 上绑着 codex2@leeguoo，真实会话身份是 codex1@pwtk-dev。 */
+  function stageRealWorldCollision(): { codex1: string; codex2: string } {
+    const codex2 = agentConfig(CWD_NAME, CWD_SERVER, "token-codex2");
+    const codex1 = agentConfig(SESSION_NAME, SESSION_SERVER, "token-codex1");
+    const codex2Path = writeAgentConfig("agentparty-leeguooooo-codex2-agentparty.json", codex2);
+    const codex1Path = writeAgentConfig("agentparty-lark-codex1-agentparty.json", codex1);
+    // cwd 绑的是 codex2——`readConfig(cwd)` 只会解出它。
+    writeWorkspaceConfigOnly(codex2, cwd);
+    writeState({ channel: CHANNEL, cursor: 900 }, cwd);
+    // 会话真实身份由 SessionStart 入册时记下（本进程 pid 保证条目存活）。
+    registerCodexSession({
+      session_id: SESSION_ID,
+      pid: process.pid,
+      display_name: null,
+      channel: CHANNEL,
+      server: SESSION_SERVER,
+      identity: SESSION_NAME,
+      cwd,
+    }, process.env);
+    return { codex1: codex1Path, codex2: codex2Path };
+  }
+
+  test("解析出的是会话真实身份，不是 cwd 猜出来的那个", () => {
+    stageRealWorldCollision();
+    const result = resolve();
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.identity.name).toBe(SESSION_NAME);
+    expect(result.identity.server).toBe(SESSION_SERVER);
+    expect(result.identity.token).toBe("token-codex1");
+    expect(result.identity.source).toBe("session-registry");
+  });
+
+  test("Stop hook 的真实接线（token / 实例 / seen 集合 / 游标）全部落在会话真实身份上", () => {
+    const paths = stageRealWorldCollision();
+    // 会话真实身份的游标（config 作用域）是 1921；cwd 那份是 900——用错就会把 since 搞错。
+    saveCursorForConfig(CHANNEL, 1921, paths.codex1);
+    const wake = defaultCodexStopWakeDeps(process.env, SESSION_ID, 4242);
+
+    const expected = codexStopWakeSeenPath(
+      home,
+      codexAutoWakeTarget(codexAutoWakeAuth({ server: SESSION_SERVER, token: "token-codex1" })!, CHANNEL),
+    );
+    const wrong = codexStopWakeSeenPath(
+      home,
+      codexAutoWakeTarget(codexAutoWakeAuth({ server: CWD_SERVER, token: "token-codex2" })!, CHANNEL),
+    );
+    expect(wake.seenPath(CHANNEL, cwd)).toBe(expected);
+    expect(wake.seenPath(CHANNEL, cwd)).not.toBe(wrong);
+    expect(wake.cursor(CHANNEL, cwd)).toBe(1921);
+  });
+
+  test("注册表条目没记身份（#906 之前的旧条目）时宁可不叫，绝不回落到 cwd 猜", () => {
+    stageRealWorldCollision();
+    registerCodexSession({
+      session_id: SESSION_ID,
+      pid: process.pid,
+      display_name: null,
+      channel: CHANNEL,
+      server: null,
+      identity: null,
+      cwd,
+    }, process.env);
+    const result = resolve();
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("ambiguous");
+  });
+});
+
+describe("解析优先级", () => {
+  test("会话自己带的 AGENTPARTY_CONFIG 最硬，压过 cwd 与注册表", () => {
+    const path = writeAgentConfig("explicit.json", agentConfig(SESSION_NAME, SESSION_SERVER, "token-explicit"));
+    writeWorkspaceConfigOnly(agentConfig(CWD_NAME, CWD_SERVER, "token-codex2"), cwd);
+    process.env.AGENTPARTY_CONFIG = path;
+    const result = resolve();
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.identity.source).toBe("env");
+    expect(result.identity.token).toBe("token-explicit");
+    // env 档的游标由 process.env 天然作用域化，不该再套一层 config 作用域。
+    expect(result.identity.configScopedState).toBe(false);
+  });
+
+  test("显式 AGENTPARTY_CONFIG 指向另一个频道的身份 ⇒ 失败关闭，不换人顶上", () => {
+    const path = writeAgentConfig("other.json", agentConfig("someone-else", SESSION_SERVER, "t", "another-channel"));
+    writeAgentConfig("only.json", agentConfig(SESSION_NAME, SESSION_SERVER, "token-codex1"));
+    process.env.AGENTPARTY_CONFIG = path;
+    const result = resolve();
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("env-config-unusable");
+  });
+
+  test("MCP 注册反查：该 codex 进程下唯一一个绑本频道的身份就是它", () => {
+    const path = writeAgentConfig("mcp.json", agentConfig(SESSION_NAME, SESSION_SERVER, "token-codex1"));
+    writeAgentConfig("elsewhere.json", agentConfig("someone-else", CWD_SERVER, "token-other"));
+    writeWorkspaceConfigOnly(agentConfig(CWD_NAME, CWD_SERVER, "token-codex2"), cwd);
+    const result = resolve({ mcpConfigPaths: () => [path] }, null);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.identity.source).toBe("mcp-registration");
+    expect(result.identity.token).toBe("token-codex1");
+    expect(result.identity.configScopedState).toBe(true);
+  });
+
+  test("MCP 注册反查：同一 codex 进程下挂着两个身份 ⇒ 歧义，放弃", () => {
+    const a = writeAgentConfig("a.json", agentConfig(SESSION_NAME, SESSION_SERVER, "token-codex1"));
+    const b = writeAgentConfig("b.json", agentConfig(CWD_NAME, CWD_SERVER, "token-codex2"));
+    const result = resolve({ mcpConfigPaths: () => [a, b] }, null);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("ambiguous");
+    expect(result.detail).toContain(SESSION_NAME);
+    expect(result.detail).toContain(CWD_NAME);
+  });
+
+  test("单身份机器：cwd 档照旧可用（行为不变）", () => {
+    const config = agentConfig(SESSION_NAME, SESSION_SERVER, "token-codex1");
+    writeAgentConfig("only.json", config);
+    writeWorkspaceConfigOnly(config, cwd);
+    const result = resolve({}, null);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.identity.source).toBe("cwd-unique");
+    expect(result.identity.configScopedState).toBe(false);
+  });
+
+  test("本机该频道有第二个身份 ⇒ cwd 档立刻失效", () => {
+    const config = agentConfig(SESSION_NAME, SESSION_SERVER, "token-codex1");
+    writeAgentConfig("one.json", config);
+    writeAgentConfig("two.json", agentConfig(CWD_NAME, CWD_SERVER, "token-codex2"));
+    writeWorkspaceConfigOnly(config, cwd);
+    const result = resolve({}, null);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("ambiguous");
+  });
+
+  test("同名身份分属两台实例也算两个身份（#865：server 必须参与判定）", () => {
+    const config = agentConfig(SESSION_NAME, SESSION_SERVER, "token-a");
+    writeAgentConfig("one.json", config);
+    writeAgentConfig("two.json", agentConfig(SESSION_NAME, CWD_SERVER, "token-b"));
+    writeWorkspaceConfigOnly(config, cwd);
+    const result = resolve({}, null);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("ambiguous");
+  });
+
+  test("没绑频道 ⇒ 直接放弃", () => {
+    writeWorkspaceConfigOnly(agentConfig(SESSION_NAME, SESSION_SERVER, "t"), cwd);
+    const result = resolveCodexHookIdentity({ cwd, channel: null, sessionId: null, deps: deps() });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("no-channel");
+  });
+
+  test("一份身份都没有 ⇒ 放弃（不是崩，也不是猜）", () => {
+    const result = resolve({}, null);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("no-identity");
+  });
+});
+
+describe("MCP 子进程扫描", () => {
+  test("只认真正的 `party … mcp` 命令行", () => {
+    expect(looksLikePartyMcpCommand("party mcp --channel agentparty")).toBe(true);
+    expect(looksLikePartyMcpCommand("/Users/leo/.local/bin/party mcp")).toBe(true);
+    expect(looksLikePartyMcpCommand("bun /repo/cli/src/party.ts mcp --channel x")).toBe(true);
+    expect(looksLikePartyMcpCommand("party serve agentparty --runner codex")).toBe(false);
+    expect(looksLikePartyMcpCommand("mcp party")).toBe(false);
+    expect(looksLikePartyMcpCommand("some-other-mcp mcp")).toBe(false);
+    expect(looksLikePartyMcpCommand("")).toBe(false);
+  });
+
+  test("从 `ps eww` 里读出子进程注册时用的 AGENTPARTY_CONFIG（去重）", () => {
+    const calls: string[][] = [];
+    const spawn = ((_bin: string, args: string[]) => {
+      calls.push(args);
+      if (args[0] === "-axo") {
+        return {
+          status: 0,
+          stdout: [
+            " 3002 69445 party mcp --channel agentparty",
+            " 3005 69445 party mcp --channel agentparty",
+            " 3009 69445 party serve agentparty --runner codex",
+            " 4001    12 party mcp --channel agentparty",
+          ].join("\n"),
+        };
+      }
+      expect(args).toEqual(["eww", "-o", "command=", "-p", "3002,3005"]);
+      return {
+        status: 0,
+        stdout: [
+          "party mcp --channel agentparty AGENTPARTY_CONFIG=/agents/codex.json TERM=xterm",
+          "party mcp --channel agentparty AGENTPARTY_CONFIG=/agents/codex1.json",
+          "party mcp --channel agentparty AGENTPARTY_CONFIG=/agents/codex1.json",
+        ].join("\n"),
+      };
+    }) as unknown as typeof import("node:child_process").spawnSync;
+    expect(codexMcpConfigPaths(69445, spawn)).toEqual(["/agents/codex.json", "/agents/codex1.json"]);
+    expect(calls).toHaveLength(2);
+  });
+
+  test("ps 挂了 / pid 不合法 ⇒ 空数组（这条线索不可用，绝不抛）", () => {
+    const dead = (() => {
+      throw new Error("ps: command not found");
+    }) as unknown as typeof import("node:child_process").spawnSync;
+    expect(codexMcpConfigPaths(69445, dead)).toEqual([]);
+    expect(codexMcpConfigPaths(1, dead)).toEqual([]);
+    expect(codexMcpConfigPaths(-1, dead)).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #917

## 根因与修法

hook payload 只有 `cwd` / `session_id`，此前 Stop 唤醒与 SessionStart 入册都用 `readConfig(cwd)` 当身份——**按目录猜**。真机上 `/Users/leo/github.com/agentparty` 猜出的是 `leeguooooo-codex2-agentparty`@`agentparty.leeguoo.com`，而会话真实身份是 `lark-ad72b3f9749e-agentparty-codex1`@`agentparty.pwtk-dev.work`：连服务器都是错的，查询恒空 ⇒ 静默失效。

新增 `cli/src/codex-session-identity.ts`，按「硬度」排序解析，**任何一步不唯一就放弃并留日志**（宁可不叫，绝不猜），判定全程带 server 维度（#865）：

| 优先级 | 来源 | 依据 |
|---|---|---|
| ① | `env` | 会话进程自己带的 `AGENTPARTY_CONFIG`（hook 是 codex 的子进程，天然继承）。唯一「会话自己说了算」的信号。显式指了却读不出/绑着别的频道 ⇒ **失败关闭**，绝不换人顶上 |
| ② | `session-registry` | 按 `session_id` 回查本机 codex 注册表条目里的 identity + server，再映射回唯一一份本地 config。**前提是入册那步先记对**——所以入册也改成显式写解析结果（复用 #906 在 claude 侧的 `identity` 字段与匹配纪律） |
| ③ | `mcp-registration` | 该 codex 进程下挂着的 `party mcp` 子进程的 `AGENTPARTY_CONFIG`（`ps eww`）。接入包本来就把身份写进 MCP 注册的 env，这条把「照接入包装好、但没在 shell 里 export」的常见形态救回来。同一进程下 ≥2 个身份 ⇒ 歧义 ⇒ 放弃 |
| ④ | `cwd-unique` | 退到 cwd config，但**只在本机该频道不存在第二个身份时**才算数。单身份机器行为逐字不变；多身份机器一律放弃 |

顺带修掉的同源问题：
- 游标/欠账改为落在**解析出的身份**的作用域（`loadCursorForConfig`）——拿别人的游标当 `since`，要么恒空要么翻旧账；
- 后台唤醒层（#893）的 `readConfigAt` 同样不再按 cwd 猜——猜错就是替另一个身份拉起 serve、用别人的 token 接别人的 @；
- 入册解析不出身份时 identity/server 都不写（条目不可匹配），并写日志。

**Stop hook 铁律一条没松**：`stop_hook_active` 严格只认 `false`、per-seq 落盘去重、全路径 fail-open、先落盘再打印、网络独立超时 3s、输出契约只有 `decision`+`reason`（没有 `prompt`）。

## 歧义时的行为

不 block、不写 stdout，会话正常停止；`~/.agentparty/logs/codex-auto-wake.log` 写明原因与解法，例如真机实测的那条：

```
codex-stop: 解析不出本会话身份（ambiguous）：本机绑 #agentparty 的身份有 14 个，
cwd(/Users/leo/github.com/agentparty) 只能猜出其中一个（leeguooooo-codex2-agentparty@https://agentparty.leeguoo.com）
——按 cwd 猜必然误投，放弃。给这个会话显式设 AGENTPARTY_CONFIG，或让接入包把身份写进该会话的 MCP 注册 env——本次放行不注入
```

## 真机验证（不是只有单测）

环境**照抄故障场景本身**，没有自选更容易过的：cwd = `/Users/leo/github.com/agentparty`（`party whoami` 实测解析为 `leeguooooo-codex2-agentparty`@`leeguoo.com`），本机 `~/.agentparty/agents` 下绑 `#agentparty` 的身份 14 个，真实会话身份在**另一台实例** `pwtk-dev.work`。owner 的 `~/.codex` / `~/.claude` / agents 配置一个字节没改：注册表写进临时 `AGENTPARTY_CODEX_SESSION_REGISTRY_DIR`，codex 用临时 `CODEX_HOME`，验证会写到的 seen 集合验完原样还原。

| 步骤 | 结果 |
|---|---|
| A. SessionStart 入册（会话带 `AGENTPARTY_CONFIG`=codex1） | 条目记 `identity: lark-ad72b3f9749e-agentparty-codex1` / `server: https://agentparty.pwtk-dev.work`（修前记的是 cwd 猜出的 leeguoo.com，且没有 identity） |
| B. Stop，**不带** `AGENTPARTY_CONFIG`（＝ #917 现场那次真实调用） | 按 session_id 回查命中 codex1 ⇒ `next-mention` 返回 **seq 1902**（修前这里恒「无/不可用」）。因该 seq 早前已人工注入过，去重闸正确挡住 |
| B2. 同上，先清 seen | `{"decision":"block","reason":"[AgentParty] 频道 #agentparty 有一条 @ 你的消息还没处理（seq 1902）…"}` ✅ |
| C. 陌生 session_id + 不带 env（歧义） | 无任何输出（放行），日志写明 14 个候选、为何放弃 ✅ |
| F. 身份 B（`codex-002`，同一台机、同一 cwd） | 解析为 codex-002 自己、查自己的实例、无待处理 ⇒ 无输出；**绝不出现 codex1 的 1902** ✅ |
| G. 一次性真 codex 会话（临时 `CODEX_HOME`，跑在故障 cwd 上，`codex exec`） | codex 报 `hook: Stop Completed`（输出契约没破），hook 在会话内跑起来并查到 **seq 1902**（正确实例）。故意保留 seen ⇒ 本次判定不该注入，不让无人看管的会话去回别人的 @ ✅ |
| E. 真机 MCP 反查 | 对 ChatGPT.app 的 codex app-server（pid 69445）实跑 `ps` 扫描，读出 6 份注册 config，其中 `#agentparty` 占两个身份（codex / codex1）⇒ 该进程按设计判歧义放弃 ✅ |

## 自检（变异 + 等价实现）

| 变异 | 结果 |
|---|---|
| 整段删除解析器的 `session-registry` 档 | pins #917 那两条**失败** ✅ |
| `seenPath` 退回 `codexAutoWakeAuth(readConfig(cwd))`（＝修前那行） | 接线钉子**失败** ✅ |
| `identityKey` 丢掉 server 维度 | 「同名身份分属两台实例」**失败** ✅（#865 守卫有效） |
| cwd 档取消歧义检查（`others` 恒空） | 3 条**失败** ✅ |
| 注册表档 `configScopedState: true → false`（游标作用域） | 接线钉子**失败** ✅ |
| **等价实现替换**：注册表档改用 `distinctCandidateKeys` 查表（与 mcp 档同款写法） | 全绿 ✅（测试没有过拟合实现细节） |

钉住本次故障形态的用例：`pins #917 > Stop hook 的真实接线（token / 实例 / seen 集合 / 游标）全部落在会话真实身份上` —— 直接跑**真实的** `defaultCodexStopWakeDeps`，断言 seenPath 落在 codex1@pwtk 的 target 上、且 `not.toBe` cwd 猜出的 codex2@leeguoo 的 target，游标读的是 codex1 的 1921 而不是 cwd 的 900。

`bun run check:cli` 全绿（453 tests + tsc）。worker 未改动。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 改进 Codex 会话身份识别，支持通过环境配置、会话注册和 MCP 注册信息准确匹配身份。
  * 身份无法唯一确认时将停止发送唤醒提示，避免跨频道、服务器或身份误投。
  * Codex 前台唤醒新增配置说明，帮助确保会话正确关联。

* **错误修复**
  * 修复 Codex Stop 唤醒可能根据工作目录误判身份的问题。
  * 优化多身份、配置缺失及进程扫描失败时的安全处理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->