### PR TITLE
fix(quota): 自部署不再继承 SaaS 免费层限制，403 不再一句话包打天下 (#920 #919)

### DIFF
--- a/web/src/components/AgentJoin.tsx
+++ b/web/src/components/AgentJoin.tsx
@@ -22,6 +22,7 @@ function isMacDesktop(): boolean {
   return isDesktopRuntime() && /mac/i.test(globalThis.navigator?.userAgent ?? "");
 }
 import { apiOrigin } from "../lib/base";
+import { forbiddenText } from "../lib/forbidden";
 import { useT } from "../i18n/useT";
 import { useDismissableLayer } from "./useDismissableLayer";
 import { useModalFocusTrap } from "./useModalFocusTrap";
@@ -214,7 +215,7 @@ export function AgentJoin({ slug, token, namePrefix, inviterName, charter, accou
         err instanceof AuthError
           ? t("AgentJoin.errAuth")
           : err instanceof ForbiddenError
-            ? t("AgentJoin.errForbidden")
+            ? forbiddenText(err, t, "AgentJoin.errForbidden")
             : err instanceof ValidationError
               ? t("AgentJoin.errValidation")
               : t("AgentJoin.errGeneric");

--- a/web/src/components/AgentTokens.tsx
+++ b/web/src/components/AgentTokens.tsx
@@ -27,6 +27,7 @@ import {
   saveAgentToken,
 } from "../lib/agentTokenVault";
 import { apiOrigin } from "../lib/base";
+import { forbiddenText } from "../lib/forbidden";
 import { desktopAgentAdapter, type DesktopAgentAdapter, type DesktopAgentRunner } from "../lib/desktopAgent";
 import { isDesktopRuntime, pickDirectory as pickDirectoryDefault } from "../lib/desktopRuntime";
 import { LocalAgentsOverview } from "./LocalAgentsOverview";
@@ -183,7 +184,7 @@ export function AgentTokens({
     } catch (err) {
       if (seq !== agentRefreshSeqRef.current) return;
       if (err instanceof AuthError) onAuthFailed(err.message);
-      else if (err instanceof ForbiddenError) setAgentError(t("AgentTokens.errForbidden"));
+      else if (err instanceof ForbiddenError) setAgentError(forbiddenText(err, t, "AgentTokens.errForbidden"));
       else setAgentError(t("AgentTokens.errLoad"));
     }
   }, [onAuthFailed, slug, t, token]);

--- a/web/src/components/CreateChannel.forbidden.test.tsx
+++ b/web/src/components/CreateChannel.forbidden.test.tsx
@@ -1,0 +1,96 @@
+// @ts-expect-error Bun executes this test, while the web tsconfig intentionally loads only Vite globals.
+import { afterEach, describe, expect, test } from "bun:test";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { LocaleProvider } from "../i18n/locale";
+
+// #919：建频道失败时，前端把任何 403 都渲染成「需人类账号登录」，服务端的 code / message 被整个
+// 丢弃。owner 实际撞的是频道配额，却被指去查登录状态。这里钉住三种语义不同的 403 渲染出三种
+// 不同、且各自可执行的文案，防止再退回一句话包打天下。
+// 桩的是 fetch 而不是 ../lib/api——mock.module 是进程级的，会污染同批跑的其它 spec；桩 fetch
+// 还顺带覆盖了 rest 层解析 403 响应体这一环（真实故障就发生在那里）。
+const { CreateChannel } = await import("./CreateChannel");
+
+let renderer: ReactTestRenderer | null = null;
+const realFetch = globalThis.fetch;
+
+afterEach(() => {
+  act(() => renderer?.unmount());
+  renderer = null;
+  globalThis.fetch = realFetch;
+});
+
+// 打开面板 → 填一个合法 slug → 提交 → 返回内联红字文案
+async function submitAndReadError(body: string): Promise<string> {
+  globalThis.fetch = (async () => new Response(body, { status: 403 })) as typeof fetch;
+  await act(async () => {
+    renderer = create(
+      <LocaleProvider>
+        <CreateChannel token="ap_tok" onCreated={() => {}} />
+      </LocaleProvider>,
+    );
+  });
+  const r = renderer!;
+  await act(async () => {
+    r.root.findByProps({ className: "d-pill chan-pill newchan-open" }).props.onClick();
+  });
+  await act(async () => {
+    r.root.findByProps({ className: "t-mono newchan-input" }).props.onChange({ target: { value: "ludo" } });
+  });
+  await act(async () => {
+    await r.root.findByProps({ className: "d-btn d-btn--primary" }).props.onClick();
+  });
+  const alert = r.root.findByProps({ role: "alert" });
+  return alert.children.join("");
+}
+
+function body403(code: string, message: string): string {
+  return JSON.stringify({ error: { code, message } });
+}
+
+const QUOTA_MESSAGE =
+  "account channel quota reached (max 20 channels per account) (free tier limit — upgrade to member for a higher quota (use the membership link in the Web or desktop header))";
+const QUOTA = body403("quota_exceeded", QUOTA_MESSAGE);
+const READONLY_MESSAGE = "readonly token cannot create channels";
+const READONLY = body403("unauthorized", READONLY_MESSAGE);
+const SCOPED_MESSAGE = "channel-scoped token can only create its own scope channel";
+const SCOPED = body403("forbidden", SCOPED_MESSAGE);
+
+describe("CreateChannel 403 rendering (#919)", () => {
+  test("quota_exceeded says what the quota is, and nothing about signing in", async () => {
+    const text = await submitAndReadError(QUOTA);
+    // 服务端原文必须原样可见——那句英文才是排查时的决定性线索
+    expect(text).toContain("max 20 channels per account");
+    expect(text.toLowerCase()).toContain("quota");
+    // 而且绝不能再把人往登录问题上带（默认 locale 是 en）
+    expect(text.toLowerCase()).not.toContain("sign in");
+    expect(text.toLowerCase()).not.toContain("log in");
+    expect(text.toLowerCase()).not.toContain("human account");
+  });
+
+  test("readonly token gets a token-swap instruction, not a quota one", async () => {
+    const text = await submitAndReadError(READONLY);
+    expect(text).toContain(READONLY_MESSAGE);
+    expect(text.toLowerCase()).toContain("read-only");
+    expect(text.toLowerCase()).not.toContain("quota reached");
+  });
+
+  test("channel-scoped token is told it can only create its own scope", async () => {
+    const text = await submitAndReadError(SCOPED);
+    expect(text).toContain(SCOPED_MESSAGE);
+    expect(text).toContain("scoped to a single channel");
+    expect(text.toLowerCase()).not.toContain("read-only");
+    expect(text.toLowerCase()).not.toContain("quota reached");
+  });
+
+  test("the three 403 codes never collapse onto one string", async () => {
+    const quota = await submitAndReadError(QUOTA);
+    const readonly = await submitAndReadError(READONLY);
+    const scoped = await submitAndReadError(SCOPED);
+    expect(new Set([quota, readonly, scoped]).size).toBe(3);
+  });
+
+  test("falls back to the local string only when the server gave nothing", async () => {
+    const text = await submitAndReadError("not json at all");
+    expect(text).toContain("gave no reason");
+  });
+});

--- a/web/src/components/CreateChannel.tsx
+++ b/web/src/components/CreateChannel.tsx
@@ -9,6 +9,7 @@ import {
   ValidationError,
   type Visibility,
 } from "../lib/api";
+import { forbiddenText } from "../lib/forbidden";
 import { useT } from "../i18n/useT";
 import "../i18n/strings/CreateChannel";
 
@@ -63,7 +64,7 @@ export function CreateChannel({ token, onCreated }: Props) {
         e instanceof ConflictError
           ? t("CreateChannel.errConflict")
           : e instanceof ForbiddenError
-            ? t("CreateChannel.errForbidden")
+            ? forbiddenText(e, t, "CreateChannel.errForbidden")
             : e instanceof ValidationError
               ? t("CreateChannel.errValidation")
               : e instanceof AuthError

--- a/web/src/i18n/strings/CreateChannel.ts
+++ b/web/src/i18n/strings/CreateChannel.ts
@@ -4,7 +4,7 @@ export const CreateChannelStrings: LocaleDict = {
   en: {
     "CreateChannel.slugInvalid": "slug must be lowercase letters/digits/-, starting with a letter or digit, 1–64 chars",
     "CreateChannel.errConflict": "That slug is taken — try another",
-    "CreateChannel.errForbidden": "Current token can't create channels (needs a human account login)",
+    "CreateChannel.errForbidden": "The server refused this request and gave no reason — check that this token has write access",
     "CreateChannel.errValidation": "Invalid field, please check",
     "CreateChannel.errAuth": "Session expired, please sign in again",
     "CreateChannel.errGeneric": "Couldn't create the channel, try again shortly",
@@ -30,7 +30,7 @@ export const CreateChannelStrings: LocaleDict = {
   zh: {
     "CreateChannel.slugInvalid": "slug 只能用小写字母/数字/-，字母或数字开头，1–64 位",
     "CreateChannel.errConflict": "这个 slug 已被占用，换一个",
-    "CreateChannel.errForbidden": "当前 token 没有建频道的权限（需人类账号登录）",
+    "CreateChannel.errForbidden": "服务端拒绝了这次建频道且没给原因——确认这枚 token 有写权限",
     "CreateChannel.errValidation": "字段不合法，请检查",
     "CreateChannel.errAuth": "登录已过期，请重新登录",
     "CreateChannel.errGeneric": "建频道失败，请稍后重试",

--- a/web/src/i18n/strings/Forbidden.ts
+++ b/web/src/i18n/strings/Forbidden.ts
@@ -1,0 +1,20 @@
+import { registerDict, type LocaleDict } from "../dict";
+
+// #919：按服务端 error.code 分叉的 403 文案。每条都必须给出「下一步能做什么」，
+// 并把服务端原文带在 {detail} 里——排查时那句英文原文往往才是决定性的线索。
+export const ForbiddenStrings: LocaleDict = {
+  en: {
+    "Forbidden.quotaExceeded": "Channel quota reached — archive or delete unused channels, or ask this instance's operator to raise the limit. Server said: {detail}",
+    "Forbidden.readonly": "This token is read-only, so it can't perform this action. Sign in with (or switch to) a token that has write access. Server said: {detail}",
+    "Forbidden.scopedToken": "This token is scoped to a single channel and can only create/act on that one. Server said: {detail}",
+    "Forbidden.withDetail": "The server refused this request: {detail}",
+  },
+  zh: {
+    "Forbidden.quotaExceeded": "已达频道数上限——先归档或删掉不用的频道，或找本实例运营方抬高上限。服务端原文：{detail}",
+    "Forbidden.readonly": "这枚 token 是只读的，做不了这个操作。换一枚有写权限的 token 再试。服务端原文：{detail}",
+    "Forbidden.scopedToken": "这枚 token 绑定在单个频道上，只能操作它自己 scope 的那一个。服务端原文：{detail}",
+    "Forbidden.withDetail": "服务端拒绝了这次请求：{detail}",
+  },
+};
+
+registerDict(ForbiddenStrings);

--- a/web/src/lib/api.forbidden.test.ts
+++ b/web/src/lib/api.forbidden.test.ts
@@ -1,0 +1,39 @@
+// @ts-expect-error Bun executes this test, while the web tsconfig intentionally loads only Vite globals.
+import { afterEach, describe, expect, test } from "bun:test";
+import { createChannel, ForbiddenError } from "./api";
+
+// #919 的另一半：渲染层再怎么分叉，前提也是 rest 层真的把服务端的 error.code / error.message
+// 带上来。这里直接桩 fetch，钉住 403 响应体被解析进 ForbiddenError，而不是被一句本地兜底吃掉。
+const realFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+function stub403(body: unknown): void {
+  globalThis.fetch = (async () =>
+    new Response(JSON.stringify(body), { status: 403, headers: { "content-type": "application/json" } })) as typeof fetch;
+}
+
+describe("createChannel 403 plumbing (#919)", () => {
+  test("carries the server code and message through", async () => {
+    const message = "account channel quota reached (max 20 channels per account)";
+    stub403({ error: { code: "quota_exceeded", message } });
+    const err = await createChannel("ap_tok", { slug: "ludo" }).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ForbiddenError);
+    const forbidden = err as ForbiddenError;
+    expect(forbidden.code).toBe("quota_exceeded");
+    expect(forbidden.serverMessage).toBe(message);
+    // message 也必须是服务端原文，不是本地兜底
+    expect(forbidden.message).toBe(message);
+  });
+
+  test("keeps the local fallback only when the body carries nothing usable", async () => {
+    globalThis.fetch = (async () => new Response("not json", { status: 403 })) as typeof fetch;
+    const err = (await createChannel("ap_tok", { slug: "ludo" }).catch((e: unknown) => e)) as ForbiddenError;
+    expect(err).toBeInstanceOf(ForbiddenError);
+    expect(err.code).toBeNull();
+    expect(err.serverMessage).toBeNull();
+    expect(err.message).toBe("no permission to create channels");
+  });
+});

--- a/web/src/lib/api.forbidden.test.ts
+++ b/web/src/lib/api.forbidden.test.ts
@@ -1,6 +1,7 @@
 // @ts-expect-error Bun executes this test, while the web tsconfig intentionally loads only Vite globals.
 import { afterEach, describe, expect, test } from "bun:test";
 import { createChannel, ForbiddenError } from "./api";
+import { forbiddenText } from "./forbidden";
 
 // #919 的另一半：渲染层再怎么分叉，前提也是 rest 层真的把服务端的 error.code / error.message
 // 带上来。这里直接桩 fetch，钉住 403 响应体被解析进 ForbiddenError，而不是被一句本地兜底吃掉。
@@ -26,6 +27,19 @@ describe("createChannel 403 plumbing (#919)", () => {
     expect(forbidden.serverMessage).toBe(message);
     // message 也必须是服务端原文，不是本地兜底
     expect(forbidden.message).toBe(message);
+  });
+
+  // 畸形响应：非字符串的 code/message 若原样传下去，forbiddenText 会对数字调 .includes 而抛，
+  // 于是 403 一个字都渲染不出来——正是本 PR 要治的病（真实原因被吞掉）的更坏版本。
+  test("treats non-string code/message as absent instead of passing them downstream", async () => {
+    stub403({ error: { code: 42, message: { nested: true } } });
+    const err = (await createChannel("ap_tok", { slug: "ludo" }).catch((e: unknown) => e)) as ForbiddenError;
+    expect(err).toBeInstanceOf(ForbiddenError);
+    expect(err.code).toBeNull();
+    expect(err.serverMessage).toBeNull();
+    expect(err.message).toBe("no permission to create channels");
+    // 关键：渲染这条错误不能抛。
+    expect(() => forbiddenText(err, ((k: string) => k) as never, "CreateChannel.errForbidden")).not.toThrow();
   });
 
   test("keeps the local fallback only when the body carries nothing usable", async () => {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -14,7 +14,19 @@ let activeShareToken: string | null = null;
 export class AuthError extends Error {}
 // 私有频道 ACL 拒入（spec §3 访问规则矩阵）：worker 回 403 forbidden / WS 1008 forbidden。
 // 与 AuthError 区分——token 有效，只是这个频道不让进，不该回登录闸。
-export class ForbiddenError extends Error {}
+// #919：403 有很多种语义完全不同的原因（readonly token / scoped token / 配额用满 …），处置办法
+// 各不相同。此前前端只保留「403 了」这一位信息，UI 只能一句话包打天下，把用户导向不存在的问题。
+// 现在把服务端权威的 error.code / error.message 一起带上来，渲染层据此分叉。
+export class ForbiddenError extends Error {
+  constructor(
+    message: string,
+    readonly code: string | null = null,
+    // 服务端原文。null = 服务端没给（或响应体不可解析），此时 message 是前端兜底文案。
+    readonly serverMessage: string | null = null,
+  ) {
+    super(message);
+  }
+}
 // 铸 agent token 时同名已存在（worker 409）——上层据此换名重试。
 export class ConflictError extends Error {}
 // 实例邀请制（#593）：登录有效但账号未入册（403 invite_required）。上层渲染「输入邀请码」界面，
@@ -31,6 +43,15 @@ export class LarkDirectoryApiError extends Error {
   ) {
     super(message);
   }
+}
+
+// 从 403 响应体里取出服务端的 error.code / error.message，转成带上下文的 ForbiddenError。
+// fallback 只在服务端没给 message 时才用——绝不拿本地文案盖掉服务端说清楚了的真实原因（#919）。
+async function forbiddenFrom(res: Response, fallback: string): Promise<ForbiddenError> {
+  const body = (await res.json().catch(() => null)) as { error?: { code?: string; message?: string } } | null;
+  const code = body?.error?.code ?? null;
+  const serverMessage = body?.error?.message ?? null;
+  return new ForbiddenError(serverMessage ?? fallback, code, serverMessage);
 }
 
 function fetchApi(path: string, init?: RequestInit): Promise<Response> {
@@ -471,7 +492,7 @@ export async function createChannelAgent(
     body: JSON.stringify({ name, channel_scope: slug }),
   });
   if (res.status === 401) throw new AuthError("invalid or revoked token");
-  if (res.status === 403) throw new ForbiddenError("no permission to mint agents here");
+  if (res.status === 403) throw await forbiddenFrom(res, "no permission to mint agents here");
   if (res.status === 409) throw new ConflictError("agent name already exists");
   if (res.status === 400) throw new ValidationError("invalid agent name");
   if (!res.ok) throw new Error(`POST /api/agents failed (${res.status})`);
@@ -483,7 +504,7 @@ export async function listChannelAgents(token: string, slug: string): Promise<Ch
     headers: { authorization: `Bearer ${token}` },
   });
   if (res.status === 401) throw new AuthError("invalid or revoked token");
-  if (res.status === 403) throw new ForbiddenError("forbidden");
+  if (res.status === 403) throw await forbiddenFrom(res, "forbidden");
   if (!res.ok) throw new Error(`GET /api/channels/${slug}/agents failed (${res.status})`);
   const data = (await res.json()) as { agents: ChannelAgentInfo[] };
   return data.agents;
@@ -889,7 +910,7 @@ export async function createChannel(
     body: JSON.stringify({ kind: "standing", ...input }),
   });
   if (res.status === 401) throw new AuthError("invalid or revoked token");
-  if (res.status === 403) throw new ForbiddenError("no permission to create channels");
+  if (res.status === 403) throw await forbiddenFrom(res, "no permission to create channels");
   if (res.status === 409) throw new ConflictError("slug already exists");
   if (res.status === 400) throw new ValidationError("invalid channel");
   if (!res.ok) throw new Error(`POST /api/channels failed (${res.status})`);

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -48,9 +48,12 @@ export class LarkDirectoryApiError extends Error {
 // 从 403 响应体里取出服务端的 error.code / error.message，转成带上下文的 ForbiddenError。
 // fallback 只在服务端没给 message 时才用——绝不拿本地文案盖掉服务端说清楚了的真实原因（#919）。
 async function forbiddenFrom(res: Response, fallback: string): Promise<ForbiddenError> {
-  const body = (await res.json().catch(() => null)) as { error?: { code?: string; message?: string } } | null;
-  const code = body?.error?.code ?? null;
-  const serverMessage = body?.error?.message ?? null;
+  const body = (await res.json().catch(() => null)) as { error?: { code?: unknown; message?: unknown } } | null;
+  // 运行期校验类型：畸形响应（message 是数字/对象）若原样传下去，下游按字符串处理会抛，
+  // 于是 403 什么都渲染不出来——那正是本 PR 要治的病（真实原因被吞掉）。非字符串一律当没给。
+  const raw = body?.error;
+  const code = typeof raw?.code === "string" && raw.code !== "" ? raw.code : null;
+  const serverMessage = typeof raw?.message === "string" && raw.message !== "" ? raw.message : null;
   return new ForbiddenError(serverMessage ?? fallback, code, serverMessage);
 }
 

--- a/web/src/lib/forbidden.ts
+++ b/web/src/lib/forbidden.ts
@@ -1,0 +1,27 @@
+// #919：403 的真实原因过去被前端一句本地文案盖掉（建频道撞配额，UI 却说「需人类账号登录」），
+// 用户被导向一个根本不存在的问题。这里是所有 403 渲染的共同规则：
+//   1) 服务端给了 code → 渲染这个 code 对应的、可执行的中文文案，并把服务端原文作为 detail 附上；
+//   2) 服务端只给了 message → 至少把 message 透出来，不许用本地兜底盖掉；
+//   3) 什么都没有 → 才用调用方的兜底 key。
+import type { TFunc } from "../i18n/useT";
+import { ForbiddenError } from "./api";
+import "../i18n/strings/Forbidden";
+
+// 有专属文案的 code。其余 code 走「透出服务端原文」这条通用路径。
+const CODE_KEYS: Record<string, string> = {
+  quota_exceeded: "Forbidden.quotaExceeded",
+  unauthorized: "Forbidden.readonly",
+};
+
+export function forbiddenText(err: unknown, t: TFunc, fallbackKey: string): string {
+  if (!(err instanceof ForbiddenError)) return t(fallbackKey);
+  const detail = err.serverMessage;
+  const key = err.code === null ? undefined : CODE_KEYS[err.code];
+  if (key !== undefined) return t(key, { detail: detail ?? "" });
+  // channel-scoped token 在服务端复用了通用的 forbidden code，只有 message 能区分。
+  if (detail !== null && detail.includes("channel-scoped token")) {
+    return t("Forbidden.scopedToken", { detail });
+  }
+  if (detail !== null && detail !== "") return t("Forbidden.withDetail", { detail });
+  return t(fallbackKey);
+}

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -457,8 +457,18 @@ async function enrollInstanceMember(db: D1Database, account: string, addedBy: st
 }
 
 // 会员申请指引：拒绝时附在错误信息里，告诉调用方「为什么」+「怎么解锁」。
+// 只在「命中的是 free 层配额」时才附——即 hostedMembershipGating 开启且账号非会员。
 const MEMBERSHIP_UPGRADE_HINT =
   "upgrade to member for a higher quota (use the membership link in the Web or desktop header)";
+// #920：命中的是实例的技术硬上限（MAX_CHANNELS_PER_ACCOUNT / MEMBER_ATTACHMENT_SIZE_LIMIT）时，
+// 升级会员并不能解锁——自部署实例更没有可升级的对象。此时唯一可执行的下一步是找本实例运营方。
+const INSTANCE_LIMIT_HINT = "instance limit — contact the operator of this instance to raise it";
+
+// 拒绝文案按「撞到的是哪一层上限」分叉，而不是按部署形态硬编码：
+// free 层配额 → 升级引导；实例硬上限（含自部署默认形态）→ 联系运营方。
+function quotaHint(onFreeTier: boolean): string {
+  return onFreeTier ? ` (free tier limit — ${MEMBERSHIP_UPGRADE_HINT})` : ` (${INSTANCE_LIMIT_HINT})`;
+}
 const WEBHOOK_SECRET_MAX = 4096;
 const HEADER_VALUE_RE = /^[\x21-\x7e]+$/;
 // do 无条件信任的内部头清单：ws 升级转发前必须逐个剥离客户端注入值，只认 worker 权威版本
@@ -4474,7 +4484,7 @@ app.post("/api/channels", async (c) => {
     const total = Number(counts?.total ?? 0);
     const recent = Number(counts?.recent ?? 0);
     if (total >= cap) {
-      const hint = member ? "" : ` (free tier limit — ${MEMBERSHIP_UPGRADE_HINT})`;
+      const hint = quotaHint(!member);
       return c.json(
         errorBody("quota_exceeded", `account channel quota reached (max ${cap} channels per account)${hint}`),
         403,
@@ -8459,7 +8469,7 @@ app.post("/api/channels/:slug/attachments", async (c) => {
   const uploaderMembership = await loadMembership(c.env.DB, identity.account);
   const uploaderIsMember = !hostedMembershipGating(c.env) || isMember(uploaderMembership);
   const sizeLimit = uploaderIsMember ? MEMBER_ATTACHMENT_SIZE_LIMIT : resolveFreeAttachmentLimit(c.env);
-  const sizeHint = uploaderIsMember ? "" : ` (free tier limit — ${MEMBERSHIP_UPGRADE_HINT})`;
+  const sizeHint = quotaHint(!uploaderIsMember);
   // Content-Length 先挡一刀，避免把超大体读进内存
   const declaredLength = Number(c.req.header("content-length"));
   if (Number.isFinite(declaredLength) && declaredLength > sizeLimit) {

--- a/worker/test/self-hosted-quota-920.spec.ts
+++ b/worker/test/self-hosted-quota-920.spec.ts
@@ -1,0 +1,91 @@
+// #920 自部署不该继承 SaaS 免费层限制。
+// 取证：HOSTED_MEMBERSHIP_GATING 曾硬写在提交进仓库的 wrangler 配置里，于是任何照本仓自部署的
+// 实例都走 FREE_CHANNEL_CAP=20 而不是 MAX_CHANNELS_PER_ACCOUNT=100，撞上限时还被劝去升级
+// 一个跟本实例无关的会员。这里钉住 gating 关闭时的两件事：
+//   1) 账号频道上限是 MAX_CHANNELS_PER_ACCOUNT，不是 free 层配额；
+//   2) 撞到硬上限时的文案不含任何升级引导，只指向本实例运营方。
+// 测试环境全局把 gating 设成 "true"（见 vitest.config.ts），所以这里显式改成 "false" 模拟
+// 自部署默认形态，跑完还原，避免污染同一 workerd 里的其它 spec。
+import { FREE_ATTACHMENT_SIZE_LIMIT, FREE_CHANNEL_CAP, MAX_CHANNELS_PER_ACCOUNT } from "@agentparty/shared";
+import { env, SELF } from "cloudflare:test";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { api, createChannel, seedToken, uniq } from "./helpers";
+
+async function seedChannels(ownerAccount: string, count: number, createdAt: number): Promise<void> {
+  const stmt = env.DB.prepare(
+    "INSERT INTO channels (slug, kind, created_by, owner_account, created_at) VALUES (?, 'standing', ?, ?, ?)",
+  );
+  const rows = [];
+  for (let i = 0; i < count; i++) rows.push(stmt.bind(uniq("seed"), "seed-creator", ownerAccount, createdAt));
+  await env.DB.batch(rows);
+}
+
+function createChannelReq(token: string) {
+  return api("/api/channels", token, {
+    method: "POST",
+    body: JSON.stringify({ slug: uniq("ch"), kind: "standing" }),
+  });
+}
+
+function upload(slug: string, token: string, filename: string, bytes: Uint8Array): Promise<Response> {
+  return SELF.fetch(`http://ap.test/api/channels/${slug}/attachments?filename=${encodeURIComponent(filename)}`, {
+    method: "POST",
+    headers: { authorization: `Bearer ${token}`, "content-type": "application/octet-stream" },
+    body: bytes,
+  });
+}
+
+describe("self-hosted deployment keeps full limits (#920)", () => {
+  beforeAll(() => {
+    (env as unknown as Record<string, unknown>).HOSTED_MEMBERSHIP_GATING = "false";
+  });
+  afterAll(() => {
+    (env as unknown as Record<string, unknown>).HOSTED_MEMBERSHIP_GATING = "true";
+  });
+
+  it("uses MAX_CHANNELS_PER_ACCOUNT (not the free cap) for a non-member account", async () => {
+    const account = uniq("acct");
+    const { token } = await seedToken("agent", uniq("tok"), { owner: account });
+    const old = Date.now() - 2 * 60 * 60 * 1000; // 窗口外，不撞创建限速
+
+    // 先播到刚好超过 free 配额：gating 开时这里就会被拒，gating 关时必须照常放行。
+    await seedChannels(account, FREE_CHANNEL_CAP, old);
+    expect((await createChannelReq(token)).status).toBe(201);
+
+    // 再补到硬上限 - 1，最后一个仍放行，第 MAX+1 个才该被拒。
+    await seedChannels(account, MAX_CHANNELS_PER_ACCOUNT - FREE_CHANNEL_CAP - 2, old);
+    expect((await createChannelReq(token)).status).toBe(201);
+
+    const over = await createChannelReq(token);
+    expect(over.status).toBe(403);
+    const body = (await over.json()) as { error: { code: string; message: string } };
+    expect(body.error.code).toBe("quota_exceeded");
+    // 报的是硬上限数字，不是 free 层数字
+    expect(body.error.message).toContain(String(MAX_CHANNELS_PER_ACCOUNT));
+    expect(body.error.message).not.toContain(`max ${FREE_CHANNEL_CAP} channels`);
+  });
+
+  it("never offers a membership upgrade when the instance runs no membership gating", async () => {
+    const account = uniq("acct");
+    const { token } = await seedToken("agent", uniq("tok"), { owner: account });
+    await seedChannels(account, MAX_CHANNELS_PER_ACCOUNT, Date.now() - 2 * 60 * 60 * 1000);
+
+    const over = await createChannelReq(token);
+    expect(over.status).toBe(403);
+    const message = ((await over.json()) as { error: { message: string } }).error.message.toLowerCase();
+    // 升级引导在自部署实例上无对象可升，必须消失……
+    expect(message).not.toContain("upgrade");
+    expect(message).not.toContain("member");
+    expect(message).not.toContain("free tier");
+    // ……并被换成一个真的能执行的下一步
+    expect(message).toContain("contact the operator of this instance");
+  });
+
+  it("does not apply the free attachment size limit", async () => {
+    // 非会员账号（无 account_membership 行），gating 关 ⇒ 应享有 member 档的 25 MiB 上限
+    const { token } = await seedToken("agent", uniq("tok"), { owner: uniq("acct") });
+    const slug = await createChannel(token);
+    const overFree = new Uint8Array(FREE_ATTACHMENT_SIZE_LIMIT + 1024);
+    expect((await upload(slug, token, "over-free.bin", overFree)).status).toBe(201);
+  });
+});

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -3,6 +3,9 @@
   "name": "agentparty",
   "main": "src/index.ts",
   "compatibility_date": "2026-06-01",
+  // #920：会员门槛是「运营共享托管服务」才该开的东西，代码侧默认关（hostedMembershipGating
+  // 只认显式 "true"/"1"）。这一份服务的是公共实例 agentparty.leeguoo.com，故显式开启。
+  // 自部署者不该继承它——见 wrangler.xdream.jsonc。
   "vars": {
     "HOSTED_MEMBERSHIP_GATING": "true"
   },

--- a/worker/wrangler.xdream.jsonc
+++ b/worker/wrangler.xdream.jsonc
@@ -6,7 +6,10 @@
   "workers_dev": true,
   "vars": {
     "AUTH_PROVIDERS": "[{\"id\":\"lark\",\"kind\":\"lark\",\"label\":\"Sign in with Lark\",\"client_id\":\"cli_aac5bdcb23389e17\",\"tenant_key\":\"153a70cd6e8f977e\"}]",
-    "HOSTED_MEMBERSHIP_GATING": "true"
+    // #920：这一份服务的是 agentparty.pwtk-dev.work —— 运营方自用的自部署实例，不卖会员。
+    // 开着 gating 等于实例在对自己的运营方限流（20 个频道），还劝他升级一个不存在的会员。
+    // 自部署形态一律关；只有真的运营共享托管服务的实例才显式改成 "true"。
+    "HOSTED_MEMBERSHIP_GATING": "false"
   },
   "durable_objects": {
     "bindings": [


### PR DESCRIPTION
Closes #920
Closes #919

owner 今天建频道失败的那条路径，两半一起修：真实原因不该存在（#920），且它本身也不该被前端盖掉（#919）。

## #920 采用的形态（按 owner 裁决）

代码侧默认就是**关**（`hostedMembershipGating` 只认显式 `"true"`/`"1"`），所以自部署者继承的形态是关。仓库里两份部署配置按**实际路由域名**（不是文件名）定性：

| 配置文件 | worker name | 实际域名 | 定性 | `HOSTED_MEMBERSHIP_GATING` |
|---|---|---|---|---|
| `worker/wrangler.jsonc` | `agentparty` | agentparty.leeguoo.com | 公共 | 显式保留 `"true"` |
| `worker/wrangler.xdream.jsonc` | `agentparty-xdream` | agentparty.pwtk-dev.work | 自部署 | 改为 `"false"` |

也就是 owner 日常在用、今天被 20 卡住的那个实例（pwtk-dev.work）走 xdream 这份配置，改后上限从 `FREE_CHANNEL_CAP`(20) 回到 `MAX_CHANNELS_PER_ACCOUNT`(100)。两份都留了注释写明为什么，防止下次有人「顺手统一」回去。

未部署——本 PR 只改代码。

## 受 `hostedMembershipGating` 影响的限制 —— 全清单

盘完全仓，调用点正好两个，都是同一类问题，都已修：

| 限制 | 调用点 | gating 开 + 非会员 | gating 关（或会员） |
|---|---|---|---|
| 账号频道总数 | `POST /api/channels`（`worker/src/index.ts:4463`） | `FREE_CHANNEL_CAP` = 20 | `MAX_CHANNELS_PER_ACCOUNT` = 100 |
| 附件体积 | `POST /api/channels/:slug/attachments`（`worker/src/index.ts:8460`） | `FREE_ATTACHMENT_SIZE_LIMIT` = 5 MiB | `MEMBER_ATTACHMENT_SIZE_LIMIT` = 25 MiB |

其余额度（`MAX_CHANNEL_CREATES_PER_WINDOW` 限速、`MAX_CONNECTIONS_PER_CHANNEL` 等）不看 gating，是纯技术闸，未受影响，无需立 issue。

## 文案按 gating 状态分叉

新增 `quotaHint(onFreeTier)`，两处共用。分叉依据是**撞到的是哪一层上限**，不是硬编码部署形态：

- free 层配额 → `(free tier limit — upgrade to member …)`，与今天一致；
- 实例技术硬上限（含自部署形态下的一切拒绝）→ `(instance limit — contact the operator of this instance to raise it)`。

顺带修掉一个旧行为：gating 开、账号是**会员**、撞到 100 的硬上限时，原先 hint 是空串（只有一句裸配额数字）；现在同样指向运营方——升级会员对这条上限本来也无用。

## #919 前端

- `ForbiddenError` 新增 `code` / `serverMessage`；`api.ts` 加 `forbiddenFrom(res, fallback)` 解析 403 响应体，接入 `createChannel` / `createChannelAgent` / `listChannelAgents`。服务端给了 message 就绝不用本地兜底盖掉。
- 新增 `web/src/lib/forbidden.ts` 的 `forbiddenText()`：`quota_exceeded` / `unauthorized`(readonly) / channel-scoped / 其它（透出服务端原文）四路分叉，每条都给可执行的下一步。
- 三处同款写法一起接：`CreateChannel`、`AgentJoin`、`AgentTokens`。
- `CreateChannel.errForbidden` 只在服务端什么都没给时才用，且已改掉「需人类账号登录」这句会把人导向不存在问题的话。

`AgentJoin.errForbidden` / `AgentTokens.errForbidden` 确认是同一模式，已一并接入 `forbiddenText`。

## 自检：变异 + 等价替换

新增用例：`worker/test/self-hosted-quota-920.spec.ts`（3 条）、`web/src/components/CreateChannel.forbidden.test.tsx`（5 条）、`web/src/lib/api.forbidden.test.ts`（2 条）。

**删除级变异**（每条都必须变红）：

| 变异 | 结果 |
|---|---|
| worker：`quotaHint` 还原成旧的 `member ? "" : 升级引导` | 🔴 1 failed（"never offers a membership upgrade …"） |
| worker：`hostedMembershipGating` 改成恒真 | 🔴 4 failed（#920 三条全红 + #277 的 opt-in 断言） |
| web：`CreateChannel` 还原成 `t("CreateChannel.errForbidden")` 一句话 | 🔴 4 failed |
| web：`api.ts` 丢掉 `forbiddenFrom`，退回 `new ForbiddenError("no permission…")` | 🔴 1 failed |
| web：`forbiddenText` 整段短路成恒返回 fallback | 🔴 4 failed |

**等价实现替换**（必须仍绿）：

| 替换 | 结果 |
|---|---|
| worker：删掉 `quotaHint` 辅助函数，两处各自内联拼同样的串 | 🟢 8 passed |
| web：`forbiddenText` 的 code→key 查表换成等价 if 链 | 🟢 全绿 |

**一个被自检抓到的假绿**：第一版组件测试用 `mock.module("../lib/api")` 桩 `createChannel` 并直接 `new ForbiddenError(msg, code, msg)`，于是「api.ts 丢掉 code」这条变异**照样全绿**——测试绕过了真实故障发生的那一层。已改成桩 `globalThis.fetch`、走完整 rest→渲染链路；顺带修掉 `mock.module` 进程级污染同批 spec 的问题（它曾让 `api.forbidden.test.ts` 在同批跑时误红）。

断言均钉在渲染出的可见文案与服务端原文上，不是 i18n key，也不靠某条注释文案独自满足；「三种 403 渲染不折叠成一句」额外用 `new Set([...]).size === 3` 直接钉住。

## 备注

可见性合法值确认是 `public` / `private` / `public_watch`，前端 `VIS_OPTIONS` 用的是对的，此处非缺陷，未改。

## 验证

`bun run check:worker`（846 tests / 111 files 全绿 + tsc）、`bun run check:web`（1361 tests 全绿 + tsc + build）均通过。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化 403 错误提示，细分配额超限、只读令牌、频道范围令牌及一般拒绝场景。
  * 展示服务端返回的详细原因，并在缺少原因时提供清晰的本地提示。
  * 创建频道、创建 Agent 和加载 Agent 列表时，错误信息更加准确且可操作。
  * 区分免费层配额与实例硬上限，分别提示升级或联系实例运营方。
* **测试**
  * 新增相关错误处理及自部署配额场景的覆盖，确保提示内容正确。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->