### PR TITLE
fix(cli): 唤醒背景上下文不再喂旧前提，MCP 补齐清账与唤醒判别式 (#834 第 4/5/6 项)

### DIFF
--- a/cli/src/commands/mcp.ts
+++ b/cli/src/commands/mcp.ts
@@ -11,6 +11,7 @@ import pkg from "../../package.json" with { type: "json" };
 import {
   ackWatchStuck,
   advanceCursorPastOwnMessage,
+  drainWatchStuck,
   loadCursor,
   loadRevCursor,
   loadStuck,
@@ -25,6 +26,7 @@ import { applyMcpProcessTitle, parseMcpServerArgv } from "../mcp-registry";
 import { watchParentLiveness } from "../parent-liveness";
 import { resolveAuth, resolveAuthDetailed } from "../oidc-cli";
 import {
+  ackDelivery,
   createTask,
   fetchChannelCharter,
   fetchMe,
@@ -128,6 +130,14 @@ Tools:
 Resources:
   party://charter               charter for the bound channel (--channel or cwd binding, 用前必读)
   party://{channel}/charter     charter for any channel by slug`;
+
+// #834 第 5 项：错误信息必须落在**调用方够得到的那个操作面**上。旧的 party_ack 在 seq 不匹配时
+// 叫人去跑 `party ack --through`——一个 MCP-only 的 agent 根本敲不了 CLI。所以这里刻意不复用
+// ack.ts 的 NO_REPLY_REQUIRES_SEQ_ERROR（它写的是 --seq/--all/--through 这套 CLI 旗标），
+// 而用工具参数名重写一份；两份措辞由 mcp-ack-parity.test.ts 钉住，不许互相串入对方的旗标。
+export const MCP_NO_REPLY_REQUIRES_SEQ_ERROR =
+  "no_reply settles ONE server-side @ and needs to know which one: pass an exact seq " +
+  "(see party_who → pending_mention_seqs). It is not combinable with all/through/before.";
 
 const StateSchema = z.enum(["working", "waiting", "blocked", "done"]);
 const TaskStateSchema = z.enum(["triage", "backlog", "assigned", "in_progress", "needs_review", "done", "blocked"]);
@@ -1424,20 +1434,92 @@ export function createMcpServer(defaultChannel?: string): McpServer {
     {
       title: "Acknowledge a watch wake that needs no reply",
       description:
-        "Clear the pending watch wake debt without posting a message (#594). Use after party_watch_once delivered a frame that warrants no reply — replying with empty acks burns the loop guard; leaving the debt makes every later watch replay the same frame. Serve-owned debt is never touched.",
+        "Clear the pending watch wake debt without posting a message (#594). Use after party_watch_once delivered a frame that warrants no reply — replying with empty acks burns the loop guard; leaving the debt makes every later watch replay the same frame. Serve-owned debt is never touched. " +
+        "TWO LEDGERS: by default this writes only the LOCAL watch replay state. The server-side @ debt that party_who reports as pending_mention_seqs is settled either by answering the @ or by passing no_reply with an exact seq.",
       inputSchema: {
         channel: z.string().optional().describe("Channel slug. Defaults to the workspace-bound channel."),
         seq: z.number().int().positive().optional().describe(
           "Acknowledge through this exact seq; a newer pending watch wake is preserved and reported.",
         ),
+        // #834 第 5 项：这些在 CLI 上早就有了，MCP 侧一直没有——而 agent 大多只有 MCP。
+        // 旧实现的 seq_mismatch 错误还直接叫调用方去跑 `party ack --through`，那是它够不到的命令。
+        through: z.number().int().positive().optional().describe(
+          "Batch drain: advance the read cursor to this seq and clear all pending watch debt up through it. Mutually exclusive with seq/all/before.",
+        ),
+        all: z.boolean().optional().describe(
+          "Batch drain everything up to the channel head — 'from now on only new messages'. Mutually exclusive with seq/through/before.",
+        ),
+        before: z.number().int().nonnegative().optional().describe(
+          "Batch drain everything strictly before this seq. Mutually exclusive with seq/through/all.",
+        ),
+        no_reply: z.boolean().optional().describe(
+          "Also settle the SERVER-side @ at `seq` as terminal_reason=acknowledged_no_reply (#875). Requires an exact seq — it names one delivery, so it is not combinable with through/all/before.",
+        ),
       },
     },
-    async ({ channel, seq }) => {
+    async ({ channel, seq, through, all, before, no_reply }) => {
       try {
         const resolved = normalizeChannel(channel, defaultChannel);
+        const selectors = [
+          all === true ? "all" : null,
+          through === undefined ? null : "through",
+          before === undefined ? null : "before",
+          seq === undefined ? null : "seq",
+        ].filter((name): name is string => name !== null);
+        if (selectors.length > 1) {
+          return fail(`mutually exclusive selectors: ${selectors.join(", ")} — pass at most one`);
+        }
+        // #875：no_reply 结清的是服务端账本上的**某一条** @，必须指名道姓；批量选择器指不出来。
+        if (no_reply === true && seq === undefined) {
+          return fail(MCP_NO_REPLY_REQUIRES_SEQ_ERROR);
+        }
+        if (all === true || through !== undefined || before !== undefined) {
+          let throughSeq: number;
+          if (all === true) {
+            const cfg = await auth();
+            const tail = await fetchRecentMessages(cfg.server, cfg.token, resolved, 1);
+            throughSeq = tail.at(-1)?.seq ?? 0;
+          } else if (through !== undefined) {
+            throughSeq = through;
+          } else {
+            throughSeq = Math.max(0, (before as number) - 1);
+          }
+          const drained = drainWatchStuck(resolved, throughSeq);
+          if (drained.outcome === "serve_owned") {
+            // serve 债绝不代清（误清 = 静默丢一条 @，#198 红线）：只推进游标，如实回报。
+            return ok({
+              type: "ack",
+              channel: resolved,
+              drained: true,
+              cursor: drained.cursor,
+              cleared_seq: null,
+              serve_owned_seq: drained.seq,
+              serve_owned_source: drained.source,
+              note: `pending debt at seq=${drained.seq} is owned by party serve (source=${drained.source}) — preserved, not cleared`,
+            });
+          }
+          return ok({
+            type: "ack",
+            channel: resolved,
+            drained: true,
+            cursor: drained.cursor,
+            cleared_seq: drained.clearedSeq,
+          });
+        }
+        // #875：先结服务端账再动本地债。顺序反了就会出现「本地平了、服务端仍欠着」，
+        // 调用方以为两本账都平了。
+        let serverSettled: { settled: true; deduped: boolean } | null = null;
+        if (no_reply === true) {
+          const cfg = await auth();
+          const result = await ackDelivery(cfg.server, cfg.token, resolved, seq as number);
+          serverSettled = { settled: true, deduped: result.deduped === true };
+        }
         // 与 CLI party ack 共用原子 compare-and-clear（#599 评审）：读后清会误吞窗口内新债。
         const acked = ackWatchStuck(resolved, seq);
-        if (acked.outcome === "none") return ok({ type: "ack", channel: resolved, acked: false, note: "no pending wake debt" });
+        const settled = serverSettled === null ? {} : { server_settled: true, server_deduped: serverSettled.deduped };
+        if (acked.outcome === "none") {
+          return ok({ type: "ack", channel: resolved, acked: false, ...settled, note: "no pending wake debt" });
+        }
         if (acked.outcome === "serve_owned") {
           return fail(
             `refusing to ack: pending debt at seq=${acked.seq} is owned by party serve (source=${acked.source}); ` +
@@ -1447,7 +1529,7 @@ export function createMcpServer(defaultChannel?: string): McpServer {
         if (acked.outcome === "seq_mismatch") {
           return fail(
             `refusing to ack seq=${seq}: older pending watch debt seq=${acked.seq} must be handled first` +
-              " (or explicitly drained with party ack --through)",
+              ` (or explicitly drained: call this tool again with through=${acked.seq})`,
           );
         }
         if (acked.outcome === "acknowledged_prior") {
@@ -1456,11 +1538,12 @@ export function createMcpServer(defaultChannel?: string): McpServer {
             channel: resolved,
             acked: true,
             seq: acked.seq,
+            ...settled,
             pending_preserved: true,
             pending_seq: acked.pendingSeq,
           });
         }
-        return ok({ type: "ack", channel: resolved, acked: true, seq: acked.seq });
+        return ok({ type: "ack", channel: resolved, acked: true, seq: acked.seq, ...settled });
       } catch (e) {
         return fail(e instanceof Error ? e.message : String(e));
       }

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -1275,6 +1275,28 @@ function truncateCodePointsWithNotice(
 // 也让 runner 能一次拿全 channel/seq/sender/body/reply_to/recent/protocol_reminder（评审建议）。
 // recent = 触发消息之前、serve 在线期间看到的最近频道消息（含自己/未 @ 的闲聊，正文截断），
 // 让冷起的 runner 开箱有上下文；完整脉络仍以 party history 为准。
+/**
+ * #834 第 4 项 / #881：把 `message_update("supersede")` 落到 serve 的 recent 缓冲上。
+ *
+ * recent 是**收帧当时**的快照。一条消息进缓冲之后才被后续消息取代——而 supersede 恰恰只发生在
+ * 「之后」——那份快照就永远停在没有 superseded 标记的样子上。于是下一次唤醒把它当成仍然有效的
+ * 背景喂给模型，正是 issue 里「按已被推翻的旧前提改道」的那条路径。
+ *
+ * 只认服务端广播过来的权威快照（`update.message`），不自己拼标记；找不到目标 seq（早被 RECENT_MAX
+ * 挤出去了）就什么都不做。返回是否命中，供日志与用例断言。
+ */
+export function applySupersedeToRecent(
+  recent: MsgFrame[],
+  targetSeq: number,
+  message: MsgFrame,
+): boolean {
+  if (message.superseded === undefined) return false;
+  const index = recent.findIndex((entry) => entry.seq === targetSeq);
+  if (index < 0) return false;
+  recent[index] = { ...recent[index]!, superseded: message.superseded };
+  return true;
+}
+
 function buildWakeContext(
   frame: MsgFrame,
   channel: string,
@@ -1318,6 +1340,7 @@ function buildWakeContext(
     body: string;
     attachments: ReturnType<typeof attachmentContextMetadata>[];
     ts: number;
+    superseded?: NonNullable<MsgFrame["superseded"]>;
   }> = [];
   // 最近的消息最有用：从尾部向前装预算，最后再恢复时间顺序。
   for (let i = recent.length - 1; i >= 0 && recentBudget > 0; i--) {
@@ -1336,9 +1359,16 @@ function buildWakeContext(
       body: boundedBody,
       attachments: message.attachments?.map(attachmentContextMetadata) ?? [],
       ts: message.ts,
+      // #834 第 4 项的真正落点：被「重放旧 seq」的正是 recent[]，触发帧只有一条。
+      // 触发帧早就带 superseded 了，recent[] 却一直把它丢掉——于是模型读到的背景上下文里，
+      // 一条已被推翻的旧指令与仍然有效的指令长得一模一样。这就是「拿旧前提行动」的入口。
+      ...(message.superseded === undefined ? {} : { superseded: message.superseded }),
     });
   }
   boundedRecent.reverse();
+  const recentSupersededSeqs = boundedRecent
+    .filter((entry) => entry.superseded !== undefined)
+    .map((entry) => entry.seq);
   recentBodyTruncated ||= boundedRecent.length < recent.length;
   return {
     channel,
@@ -1371,6 +1401,16 @@ function buildWakeContext(
             `这条消息（seq ${frame.seq}）已被 seq ${frame.superseded.by_seq} 取代` +
             `（reason=${frame.superseded.reason}）。不要把它当成最新指令执行；` +
             `先读 seq ${frame.superseded.by_seq}（party history --channel ${channel}），按那条为准。`,
+        }),
+    // #834 第 4 项：背景上下文里也有被取代的条目。单独一条 notice，不与触发帧那条互相遮蔽——
+    // 两者可以同时出现，也可以只出现一条。
+    ...(recentSupersededSeqs.length === 0
+      ? {}
+      : {
+          recent_superseded_seqs: recentSupersededSeqs,
+          recent_superseded_notice:
+            `下方 recent 里的 seq ${recentSupersededSeqs.join("、")} 已被后续消息取代，` +
+            `它们只是背景，不得当作仍然有效的指令或前提；每条的 superseded.by_seq 才是现行版本。`,
         }),
     decision_request: frame.decision_request ?? null,
     decision_response: frame.decision_response ?? null,
@@ -5428,6 +5468,14 @@ export async function runServe(o: ServeOptions): Promise<number> {
           lease_state: hasLease ? "held" : "standby",
         }));
         if (hasLease) reportPendingPersistedSession();
+        continue;
+      }
+      // #834 第 4 项：supersede 是**事后**才广播的修订帧，而 recent 里躺的是收帧当时的快照。
+      // 不在这里接住它，缓冲里那条旧指令就永远不带标记，下一次唤醒照旧把它当有效前提喂进模型。
+      if (frame.type === "message_update" && frame.action === "supersede") {
+        if (applySupersedeToRecent(recent, frame.target_seq, frame.message)) {
+          out(`serve: seq ${frame.target_seq} 已被 seq ${frame.message.superseded?.by_seq} 取代——后续唤醒的背景上下文会标注它`);
+        }
         continue;
       }
       if (frame.type !== "msg") continue;

--- a/cli/src/commands/wake.ts
+++ b/cli/src/commands/wake.ts
@@ -34,6 +34,22 @@ Options:
 // 的明确信号，不该误报失败。wake_pending = 唤醒确凿、最终回复待定（介于 healthy 与 timeout 之间的成功态）。
 type WakeResult = "not_auto_wakeable" | "healthy" | "wake_pending" | "timeout" | "self_target" | "not_listening" | "runner_failing";
 type AckEvidence = "reply_to" | "status.summary_seq";
+// #834 第 6 项：`wake_invoked.ok` 是三态布尔（true/false/null），而 null 的真实含义是「已投递、
+// 尚未确认消费」——一个**成功中间态**。可人读的那半早就靠 evidence 说清了（#107），但机器读的
+// 那半没有：`if (!phases.wake_invoked.ok)` 会把一次健康的 broadcast 判成失败。
+// 补一个自述其名的判别式，`ok` 原样保留（它是 JSON 输出契约，见 test/fixtures/json-contract）。
+//   invoked           = 唤醒确凿（ok:true）
+//   not_invoked       = 确凿没唤起（ok:false）
+//   broadcast_pending = 已广播给拉客户端、等 resume 确认消费（ok:null，但**不是**失败）
+//   not_audited       = 账本没有这条的行，判不了（ok:null）
+export type WakeInvokedStatus = "invoked" | "not_invoked" | "broadcast_pending" | "not_audited";
+
+export interface WakeInvokedPhase {
+  ok: boolean | null;
+  status: WakeInvokedStatus;
+  adapter: string | null;
+  evidence: string;
+}
 
 interface WakePresence {
   state: string | null;
@@ -58,7 +74,7 @@ interface WakeTestFrame extends Record<string, unknown> {
   presence: WakePresence;
   phases: {
     mention_delivered: { ok: boolean; seq: number | null; evidence: string };
-    wake_invoked: { ok: boolean | null; adapter: string | null; evidence: string };
+    wake_invoked: WakeInvokedPhase;
     agent_resumed: { ok: boolean; seq: number | null; evidence: AckEvidence | null };
   };
   reason: string | null;
@@ -130,10 +146,11 @@ function ackFromWakeDelivery(delivery: WakeDelivery | null): { seq: number; evid
   return null;
 }
 
-function summarizeWakeDelivery(delivery: WakeDelivery | null, adapter: string | null): { ok: boolean | null; adapter: string | null; evidence: string } {
+function summarizeWakeDelivery(delivery: WakeDelivery | null, adapter: string | null): WakeInvokedPhase {
   if (delivery === null) {
     return {
       ok: null,
+      status: "not_audited",
       adapter,
       evidence: "adapter delivery is not audited by the worker yet; only linked resume is conclusive",
     };
@@ -142,6 +159,7 @@ function summarizeWakeDelivery(delivery: WakeDelivery | null, adapter: string | 
     const status = delivery.http_status === null ? "" : ` status=${delivery.http_status}`;
     return {
       ok: true,
+      status: "invoked",
       adapter,
       evidence: `webhook delivery attempt ${delivery.attempt}${status} for mention #${delivery.mention_seq}`,
     };
@@ -150,6 +168,7 @@ function summarizeWakeDelivery(delivery: WakeDelivery | null, adapter: string | 
   const error = delivery.error ? ` error=${delivery.error}` : "";
   return {
     ok: false,
+    status: "not_invoked",
     adapter,
     evidence: `webhook delivery attempt ${delivery.attempt} failed${status}${error} for mention #${delivery.mention_seq}`,
   };
@@ -160,10 +179,11 @@ function summarizeWakeDelivery(delivery: WakeDelivery | null, adapter: string | 
 //  - null delivery         → ok:null，标注「尚未审计」（沿用旧语义，仅在 ledger 缺行/端点不支持时）。
 //  - result='broadcast'    → ok:null，但给出真实审计证据（已广播、待 resume 确认消费），而不是笼统的「未审计」。
 //  - result='consumed'     → ok:true，唤醒闭环（resume 已引用这条 @）。
-function summarizeServeWatchDelivery(delivery: WakeDelivery | null, adapter: string | null): { ok: boolean | null; adapter: string | null; evidence: string } {
+function summarizeServeWatchDelivery(delivery: WakeDelivery | null, adapter: string | null): WakeInvokedPhase {
   if (delivery === null) {
     return {
       ok: null,
+      status: "not_audited",
       adapter,
       evidence: "serve/watch broadcast is not audited by the worker yet; only linked resume is conclusive",
     };
@@ -173,6 +193,7 @@ function summarizeServeWatchDelivery(delivery: WakeDelivery | null, adapter: str
     const via = delivery.ack_seq !== null ? `reply #${delivery.ack_seq}` : delivery.resume_seq !== null ? `status #${delivery.resume_seq}` : "linked resume";
     return {
       ok: true,
+      status: "invoked",
       adapter,
       evidence: `${kind} client consumed the broadcast for mention #${delivery.mention_seq} (${via})`,
     };
@@ -180,6 +201,7 @@ function summarizeServeWatchDelivery(delivery: WakeDelivery | null, adapter: str
   // result='broadcast'：服务端已把这条 @ 广播给可唤醒的拉客户端，但尚未观测到引用它的 resume。
   return {
     ok: null,
+    status: "broadcast_pending",
     adapter,
     evidence: `${kind} broadcast delivered for mention #${delivery.mention_seq}; awaiting linked resume to confirm consumption`,
   };
@@ -232,15 +254,17 @@ function printHuman(frame: WakeTestFrame) {
   // #107：ok===null 时别一律印死板的「not audited」——serve/watch 的 broadcast 行已是真实审计结果，
   // 直接摊出 evidence（broadcast 已投递/待 resume 确认），只有 ledger 真无行时 evidence 才是「未审计」。
   console.log(
+    // #834 第 6 项：人读这行改由 status 判别式驱动（与旧的 ok 三态分支等价），
+    // 让这个字段成为受力字段——写错了这里就印错，而不是悄悄躺在 JSON 里发霉。
     `wake invoked: ${
-      frame.phases.wake_invoked.ok === null
-        ? frame.phases.wake_invoked.evidence
-        : frame.phases.wake_invoked.ok
-          ? // #689：唤起确凿但最终回复未到（headless runner 数分钟）——明说 reply pending，别让读者误当彻底成功或失败。
-            frame.result === "wake_pending"
-            ? "yes (reply pending)"
-            : "yes"
-          : "no"
+      frame.phases.wake_invoked.status === "invoked"
+        ? // #689：唤起确凿但最终回复未到（headless runner 数分钟）——明说 reply pending，别让读者误当彻底成功或失败。
+          frame.result === "wake_pending"
+          ? "yes (reply pending)"
+          : "yes"
+        : frame.phases.wake_invoked.status === "not_invoked"
+          ? "no"
+          : frame.phases.wake_invoked.evidence
     }`,
   );
   console.log(
@@ -326,7 +350,7 @@ export async function run(argv: string[]): Promise<number> {
         presence: summarizePresence(null),
         phases: {
           mention_delivered: { ok: false, seq: null, evidence: "not sent because target is the caller's own identity" },
-          wake_invoked: { ok: false, adapter: null, evidence: reason },
+          wake_invoked: { ok: false, status: "not_invoked", adapter: null, evidence: reason },
           agent_resumed: { ok: false, seq: null, evidence: null },
         },
         reason,
@@ -355,7 +379,7 @@ export async function run(argv: string[]): Promise<number> {
         presence: summarizePresence(presence),
         phases: {
           mention_delivered: { ok: false, seq: null, evidence: "not sent because target is not auto-wakeable" },
-          wake_invoked: { ok: false, adapter, evidence: gate.block },
+          wake_invoked: { ok: false, status: "not_invoked", adapter, evidence: gate.block },
           agent_resumed: { ok: false, seq: null, evidence: null },
         },
         reason: gate.block,
@@ -452,11 +476,12 @@ export async function run(argv: string[]): Promise<number> {
       result === "wake_pending"
         ? {
             ok: true as const,
+            status: "invoked" as const,
             adapter,
             evidence: `target's runner is processing mention #${seq} (presence.current_task) — wake invoked; final reply pending`,
           }
         : gate.advisory !== null && wakeDelivery === null
-          ? { ok: false as const, adapter, evidence: gate.advisory }
+          ? { ok: false as const, status: "not_invoked" as const, adapter, evidence: gate.advisory }
           : adapter === "serve" || adapter === "watch"
             ? summarizeServeWatchDelivery(wakeDelivery, adapter)
             : summarizeWakeDelivery(wakeDelivery, adapter);

--- a/cli/test/fixtures/json-contract/wake-test.json
+++ b/cli/test/fixtures/json-contract/wake-test.json
@@ -21,6 +21,7 @@
     },
     "wake_invoked": {
       "ok": false,
+      "status": "not_invoked",
       "adapter": "none",
       "evidence": "target is human-driven; mention is inbox only"
     },

--- a/cli/test/mcp-ack-parity.test.ts
+++ b/cli/test/mcp-ack-parity.test.ts
@@ -1,0 +1,155 @@
+// #834 第 5 项：turn-based harness 的清账体验。
+//
+// CLI 上 `party ack --all/--through/--before/--no-reply` 早就有了，但 agent 大多**只有 MCP**，
+// 而 party_ack 的入参一直只有 {channel, seq}：深积压只能一条一条 ack，服务端那本账根本够不到。
+// 更糟的是 seq 不匹配时它回的错误直接叫人去跑 `party ack --through` —— 一个 MCP-only 的调用方
+// 敲不了 CLI，这条提示等于把人指到墙上。
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { NO_REPLY_REQUIRES_SEQ_ERROR } from "../src/commands/ack";
+import { MCP_NO_REPLY_REQUIRES_SEQ_ERROR } from "../src/commands/mcp";
+
+const indexPath = join(import.meta.dir, "..", "src", "index.ts");
+
+interface ToolResult {
+  isError?: boolean;
+  content: { text: string }[];
+  structuredContent?: Record<string, unknown>;
+}
+
+describe("party_ack 的 MCP/CLI 对等（#834 第 5 项）", () => {
+  let home: string;
+  let rest: ReturnType<typeof Bun.serve> | null = null;
+  let acked: string[] = [];
+  const clients: Client[] = [];
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "ap-mcp-ack-"));
+    acked = [];
+    rest = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch(req) {
+        const url = new URL(req.url);
+        if (url.pathname === "/api/me") {
+          return Response.json({ name: "alice", email: null, kind: "agent", role: "member", owner: null });
+        }
+        // party ack --all / all:true 用它探频道 head。
+        if (url.pathname.endsWith("/messages")) {
+          return Response.json({ messages: [{ seq: 77 }] });
+        }
+        const ack = url.pathname.match(/\/deliveries\/([^/]+)\/ack$/);
+        if (ack !== null && req.method === "POST") {
+          acked.push(ack[1]!);
+          return Response.json({ ok: true, delivery: { id: "d1", state: "acknowledged" } });
+        }
+        return Response.json({ error: { code: "not_found", message: "not found" } }, { status: 404 });
+      },
+    });
+    mkdirSync(home, { recursive: true });
+    writeFileSync(
+      join(home, "config.json"),
+      JSON.stringify({ server: `http://127.0.0.1:${rest.port}`, token: "ap_tok" }),
+    );
+  });
+
+  afterEach(async () => {
+    for (const client of clients.splice(0)) await client.close().catch(() => {});
+    rmSync(home, { recursive: true, force: true });
+    rest?.stop(true);
+    rest = null;
+  });
+
+  async function connect(): Promise<Client> {
+    const env: Record<string, string> = {};
+    for (const [k, v] of Object.entries(process.env)) {
+      if (v !== undefined && k !== "AGENTPARTY_CONFIG") env[k] = v;
+    }
+    env.AGENTPARTY_HOME = home;
+    const transport = new StdioClientTransport({
+      command: "bun",
+      args: ["run", indexPath, "mcp", "--channel", "dev"],
+      env,
+      stderr: "pipe",
+    });
+    const client = new Client({ name: "agentparty-test", version: "1.0.0" });
+    await client.connect(transport);
+    clients.push(client);
+    return client;
+  }
+
+  test("批量排空真的落盘：through=42 之后 through=10 不会把游标退回去", async () => {
+    const client = await connect();
+    const first = (await client.callTool({ name: "party_ack", arguments: { through: 42 } })) as ToolResult;
+    expect(first.isError).toBeFalsy();
+    expect(first.structuredContent).toMatchObject({ drained: true, cursor: 42, cleared_seq: null });
+
+    // 第二次刻意传一个更小的 through。若第一次只是把入参回显出来（没真写），这里会得到 10。
+    const second = (await client.callTool({ name: "party_ack", arguments: { through: 10 } })) as ToolResult;
+    expect(second.structuredContent).toMatchObject({ drained: true, cursor: 42 });
+  }, 30_000);
+
+  test("all:true 走服务端 head，不再需要调用方自己知道 head 在哪", async () => {
+    const client = await connect();
+    const result = (await client.callTool({ name: "party_ack", arguments: { all: true } })) as ToolResult;
+    expect(result.isError).toBeFalsy();
+    expect(result.structuredContent).toMatchObject({ drained: true, cursor: 77 });
+  }, 30_000);
+
+  test("before:N 排空严格早于 N 的部分（游标停在 N-1，不吞掉 N 本身）", async () => {
+    const client = await connect();
+    const result = (await client.callTool({ name: "party_ack", arguments: { before: 20 } })) as ToolResult;
+    expect(result.structuredContent).toMatchObject({ drained: true, cursor: 19 });
+  }, 30_000);
+
+  test("no_reply 结清服务端那本账，并如实报告 server_settled", async () => {
+    const client = await connect();
+    const result = (await client.callTool({ name: "party_ack", arguments: { seq: 7, no_reply: true } })) as ToolResult;
+    expect(result.isError).toBeFalsy();
+    // 真的打到了服务端 delivery ack 端点——不是只动了本地那本账。
+    expect(acked).toEqual(["7"]);
+    expect(result.structuredContent).toMatchObject({ server_settled: true });
+  }, 30_000);
+
+  test("no_reply 不带 seq 被拒，且错误只提 MCP 参数名、不把 CLI 旗标甩给够不到 CLI 的调用方", async () => {
+    const client = await connect();
+    const result = (await client.callTool({ name: "party_ack", arguments: { no_reply: true } })) as ToolResult;
+    expect(result.isError).toBe(true);
+    const text = result.content[0]!.text;
+    expect(text).toContain(MCP_NO_REPLY_REQUIRES_SEQ_ERROR);
+    expect(text).not.toContain("--seq");
+    expect(text).not.toContain("--through");
+    // 服务端一次都没被打——参数校验必须在网络调用之前。
+    expect(acked).toEqual([]);
+  }, 30_000);
+
+  test("选择器互斥：through 与 seq 同时给出直接拒绝，不猜意图", async () => {
+    const client = await connect();
+    const result = (await client.callTool({ name: "party_ack", arguments: { seq: 3, through: 9 } })) as ToolResult;
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain("mutually exclusive");
+    expect(acked).toEqual([]);
+  }, 30_000);
+
+  test("工具 schema 暴露四个新参数——够不到的能力等于不存在", async () => {
+    const client = await connect();
+    const tools = await client.listTools();
+    const ack = tools.tools.find((tool) => tool.name === "party_ack");
+    expect(ack).toBeDefined();
+    const props = Object.keys((ack!.inputSchema as { properties?: Record<string, unknown> }).properties ?? {});
+    expect(props).toContain("through");
+    expect(props).toContain("all");
+    expect(props).toContain("before");
+    expect(props).toContain("no_reply");
+  }, 30_000);
+
+  test("两套措辞各说各的操作面，不互相串旗标", () => {
+    expect(NO_REPLY_REQUIRES_SEQ_ERROR).toContain("--seq");
+    expect(MCP_NO_REPLY_REQUIRES_SEQ_ERROR).not.toContain("--");
+    expect(MCP_NO_REPLY_REQUIRES_SEQ_ERROR).toContain("no_reply");
+  });
+});

--- a/cli/test/wake-context-superseded.test.ts
+++ b/cli/test/wake-context-superseded.test.ts
@@ -1,0 +1,169 @@
+// #834 第 4 项：唤醒上下文里的**背景消息**必须带上「已被取代」。
+//
+// #881 把 superseded 一路做通到了触发帧，但 issue 抱怨的那件事说的是「wake-context 会重放旧
+// seq，携带已被后续消息推翻的旧前提」——被重放的正是 `recent[]`（触发帧只有一条）。recent[]
+// 此前只落 seq/sender/kind/body/attachments/ts，标记整个丢掉：模型看到的背景里，一条已被推翻
+// 的旧指令与仍然有效的指令长得一模一样。
+//
+// 而且 recent 是**收帧当时**的快照，supersede 只发生在「之后」——不接住服务端的
+// message_update("supersede") 广播，缓冲里那条永远不会带上标记。两件事必须都做，缺一条这
+// 条路径就仍然是通的。
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { type MsgFrame } from "@agentparty/shared";
+import {
+  applySupersedeToRecent,
+  createWakeContextDir,
+  runServe,
+  writeContextFile,
+  type ServeOptions,
+} from "../src/commands/serve";
+import { msgFrame, startMockServer, welcomeFrame, type MockServer } from "./mock-server";
+
+const dirs: string[] = [];
+let server: MockServer | null = null;
+afterEach(() => {
+  server?.stop();
+  server = null;
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+
+function ctxDir(): string {
+  const d = createWakeContextDir();
+  dirs.push(d);
+  return d;
+}
+
+function frame(seq: number, body: string, superseded?: { by_seq: number; reason: "revision" | "reply_correction" }): MsgFrame {
+  const base = msgFrame(seq, body) as unknown as MsgFrame;
+  return superseded === undefined ? base : { ...base, superseded };
+}
+
+function contextOf(trigger: MsgFrame, recent: MsgFrame[]): Record<string, unknown> {
+  const path = writeContextFile(ctxDir(), trigger, "dev", "alice", recent);
+  return JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
+}
+
+describe("#834 第 4 项：recent[] 里的旧前提必须自带 superseded", () => {
+  // 反假绿：**触发帧刻意不带 superseded**。触发帧那条分支早就实现了，让它同时满足条件就会把
+  // 被测的这道闸整个遮住——退回旧实现照样全绿。这里唯一能产生标记的来源只有 recent[]。
+  test("触发帧未被取代，但背景里的旧指令被取代 → recent 条目与 notice 都要报出来", () => {
+    const ctx = contextOf(frame(9, "@alice 现在处理这个"), [
+      frame(3, "部署到 prod", { by_seq: 5, reason: "reply_correction" }),
+      frame(5, "改口：先别部署"),
+    ]);
+
+    expect(ctx.superseded).toBeNull();
+    expect(ctx.superseded_notice).toBeUndefined();
+
+    const recent = ctx.recent as Array<Record<string, unknown>>;
+    expect(recent.map((entry) => entry.seq)).toEqual([3, 5]);
+    expect(recent[0]!.superseded).toEqual({ by_seq: 5, reason: "reply_correction" });
+    expect(recent[1]!.superseded).toBeUndefined();
+
+    expect(ctx.recent_superseded_seqs).toEqual([3]);
+    expect(String(ctx.recent_superseded_notice)).toContain("seq 3");
+    expect(String(ctx.recent_superseded_notice)).toContain("不得当作仍然有效的指令");
+  });
+
+  test("背景全是有效消息 → 不凭空插 notice（免得每次唤醒都喊狼来了）", () => {
+    const ctx = contextOf(frame(9, "@alice 干活"), [frame(3, "早"), frame(5, "好")]);
+    expect(ctx.recent_superseded_seqs).toBeUndefined();
+    expect(ctx.recent_superseded_notice).toBeUndefined();
+    for (const entry of ctx.recent as Array<Record<string, unknown>>) {
+      expect(entry.superseded).toBeUndefined();
+    }
+  });
+
+  test("触发帧与背景各自被取代时两条 notice 并存，互不遮蔽", () => {
+    const ctx = contextOf(frame(9, "@alice 按老方案来", { by_seq: 11, reason: "revision" }), [
+      frame(3, "部署到 prod", { by_seq: 5, reason: "reply_correction" }),
+    ]);
+    expect(ctx.superseded).toEqual({ by_seq: 11, reason: "revision" });
+    expect(String(ctx.superseded_notice)).toContain("seq 11");
+    expect(ctx.recent_superseded_seqs).toEqual([3]);
+    expect(String(ctx.recent_superseded_notice)).toContain("seq 3");
+  });
+});
+
+describe("#834 第 4 项：supersede 广播必须落到 serve 的 recent 缓冲", () => {
+  // 这条是上面那条的**前置**：recent 存的是收帧当时的快照，标记只可能后到。没有这一步，
+  // 上面新增的字段在真实 serve 里永远是空的（只有重连补拉的帧才自带标记）。
+  test("message_update(supersede) 命中缓冲里的旧帧 → 之后落盘的上下文带标记", () => {
+    const recent: MsgFrame[] = [frame(3, "部署到 prod"), frame(5, "改口：先别部署")];
+    const authoritative = frame(3, "部署到 prod", { by_seq: 5, reason: "reply_correction" });
+
+    expect(applySupersedeToRecent(recent, 3, authoritative)).toBe(true);
+    expect(recent[0]!.superseded).toEqual({ by_seq: 5, reason: "reply_correction" });
+
+    const ctx = contextOf(frame(9, "@alice 继续"), recent);
+    expect(ctx.recent_superseded_seqs).toEqual([3]);
+  });
+
+  test("目标 seq 已被挤出缓冲 → 什么都不动，不凭空造一条", () => {
+    const recent: MsgFrame[] = [frame(5, "改口：先别部署")];
+    expect(applySupersedeToRecent(recent, 3, frame(3, "部署到 prod", { by_seq: 5, reason: "reply_correction" }))).toBe(false);
+    expect(recent).toHaveLength(1);
+    expect(recent[0]!.superseded).toBeUndefined();
+  });
+
+  test("权威快照没带 superseded → 不当成取代（标记只认服务端下发的，不自己拼）", () => {
+    const recent: MsgFrame[] = [frame(3, "部署到 prod")];
+    expect(applySupersedeToRecent(recent, 3, frame(3, "部署到 prod"))).toBe(false);
+    expect(recent[0]!.superseded).toBeUndefined();
+  });
+
+  test("不篡改缓冲里的其它字段，也不动别的条目", () => {
+    const recent: MsgFrame[] = [frame(3, "部署到 prod"), frame(5, "改口")];
+    applySupersedeToRecent(recent, 3, frame(3, "被服务端改写过的正文", { by_seq: 5, reason: "reply_correction" }));
+    expect(recent[0]!.body).toBe("部署到 prod");
+    expect(recent[0]!.seq).toBe(3);
+    expect(recent[1]!.superseded).toBeUndefined();
+  });
+});
+
+describe("#834 第 4 项：serve 主循环必须接住 supersede 广播（端到端）", () => {
+  // 上面两组都在函数级：把 message_update 那块处理整个从 runServe 的帧循环里删掉，它们照样全绿。
+  // 这条走真实的 runServe 循环，唯一能让 ctx.recent[0] 带上标记的路径就是那块处理。
+  test("旧指令进缓冲 → 服务端广播取代 → 下一次唤醒拿到的 recent 已带标记", async () => {
+    const lockDir = mkdtempSync(join(tmpdir(), "ap-lock-"));
+    dirs.push(lockDir);
+    const superseded = { by_seq: 5, reason: "reply_correction" as const };
+    server = startMockServer((clientFrame, sock) => {
+      if (clientFrame.type !== "hello") return;
+      sock.send(welcomeFrame(0, "me"));
+      setTimeout(() => sock.send(msgFrame(3, "部署到 prod")), 20);
+      setTimeout(() => sock.send(msgFrame(5, "改口：先别部署")), 40);
+      setTimeout(() => sock.send({
+        type: "message_update",
+        target_seq: 3,
+        action: "supersede",
+        actor: { name: "bob", kind: "agent" },
+        ts: Date.now(),
+        message: msgFrame(3, "部署到 prod", { superseded }),
+      }), 60);
+      setTimeout(() => sock.send(msgFrame(9, "@me 继续", { mentions: ["me"] })), 80);
+      setTimeout(() => sock.send({ type: "error", code: "archived", message: "done" }), 160);
+    });
+    let seen: MsgFrame[] | null = null;
+    const options: ServeOptions = {
+      server: server.url,
+      token: "ap_tok",
+      channel: "dev",
+      since: 0,
+      cmd: "true",
+      mentionsOnly: true,
+      lockDir,
+      out: () => {},
+      runCommand: async (_frame, ctx) => { seen = ctx.recent.slice(); },
+    };
+    await runServe(options);
+    const recent: MsgFrame[] | null = seen;
+    expect(recent).not.toBeNull();
+    expect(recent!.map((entry) => entry.seq)).toEqual([3, 5]);
+    expect(recent![0]!.superseded).toEqual(superseded);
+    expect(recent![1]!.superseded).toBeUndefined();
+  });
+});

--- a/cli/test/wake.test.ts
+++ b/cli/test/wake.test.ts
@@ -123,7 +123,8 @@ describe("wake test falsifiability (#181)", () => {
       result: "not_auto_wakeable",
       phases: {
         mention_delivered: { ok: true, seq: 7 },
-        wake_invoked: { ok: false },
+        // #834 第 6 项：status 是自述其名的判别式，ok 是保留下来的旧三态布尔。
+        wake_invoked: { ok: false, status: "not_invoked" },
         agent_resumed: { ok: false, seq: null },
       },
     });
@@ -192,7 +193,7 @@ describe("wake test wake_pending when runner is actively processing the probe (#
       result: "wake_pending",
       phases: {
         mention_delivered: { ok: true, seq: 91 },
-        wake_invoked: { ok: true },
+        wake_invoked: { ok: true, status: "invoked" },
         agent_resumed: { ok: false, seq: null },
       },
     });
@@ -399,7 +400,9 @@ describe("wake test audits serve/watch ledger (#107)", () => {
       result: "timeout",
       phases: {
         mention_delivered: { ok: true, seq: 50 },
-        wake_invoked: { ok: null, adapter: "serve" },
+        // #834 第 6 项：ok:null 在这里的真实含义是「已广播、待确认消费」——一个成功中间态。
+        // 机器读的那半必须能与「账本无行、判不了」区分开，否则 `if (!ok)` 会把它误判成失败。
+        wake_invoked: { ok: null, status: "broadcast_pending", adapter: "serve" },
         agent_resumed: { ok: false, seq: null },
       },
     });
@@ -457,7 +460,7 @@ describe("wake test audits serve/watch ledger (#107)", () => {
       result: "healthy",
       phases: {
         mention_delivered: { ok: true, seq: 60 },
-        wake_invoked: { ok: true, adapter: "serve" },
+        wake_invoked: { ok: true, status: "invoked", adapter: "serve" },
         agent_resumed: { ok: true, seq: 61, evidence: "reply_to" },
       },
     });
@@ -520,7 +523,7 @@ describe("wake test audits serve/watch ledger (#107)", () => {
       type: "wake_test",
       result: "timeout",
       phases: {
-        wake_invoked: { ok: null, adapter: "watch" },
+        wake_invoked: { ok: null, status: "broadcast_pending", adapter: "watch" },
         agent_resumed: { ok: false, seq: null },
       },
     });

--- a/plugins/agentparty/skills/agentparty/SKILL.md
+++ b/plugins/agentparty/skills/agentparty/SKILL.md
@@ -145,6 +145,15 @@ stop and ask the owner; the owner or an assigned host records the grant with
 `party authz grant "<action>" -m "<scope and limits>"`. Never re-assert someone else's
 authorization claim to a downstream worker — pass them the check, not the claim.
 
+**A superseded message is background, not an instruction (#834).** History and wake context
+replay old seqs, and one of them may already have been overtaken — the sender corrected
+themselves two messages later. A frame carrying `superseded` (rendered as
+`SUPERSEDED by #N`, and listed in a wake context's `recent_superseded_seqs`) MUST NOT be
+executed as the current instruction: read `superseded.by_seq` and act on that one instead.
+Ordering is by `seq`, never by timestamp — clocks are local and several runtimes may share
+one machine. Acting on an overtaken premise is the same class of failure as trusting a
+relayed authorization: you end up working from something that is no longer true.
+
 The Marketplace plugin packages this skill with two thin platform shells. Codex receives the
 generic `party mcp` entry. Claude also receives lifecycle hooks plus a declared
 `agentparty-channel` server backed by `party claude-channel`. Start a fresh Claude session with
@@ -573,6 +582,7 @@ surface it to the owner instead of ignoring it.
 | Read past messages / catch up on context | `party history <slug> [--limit <n>]` — defaults to the **most recent** `--limit` messages; use `--since 0` to read from the very beginning, `--before <seq>` to page further back |
 | Catch up **every turn** without burning the context window | `party history <slug> --headers [--exclude-status]` — one line per message (seq/sender/kind/@/reply/length + preview) instead of full bodies; expand the ones that matter with `party history <slug> --seq <n>`. MCP: `party_history { mode: "headers" }` then `party_history { seq: n }` |
 | Verify an authorization before an irreversible action | `party authz check "<action>"` (exit 3 = no credential, safe to gate on) · `party authz list` · owner/host grants with `party authz grant "<action>" -m "<scope>"` · revoke with `party authz revoke "<action>"` |
+| Clear wake debt without posting a message | `party ack --seq N` (local replay state) · `party ack --seq N --no-reply` (also settles the SERVER-side @ as acknowledged_no_reply) · `party ack --all\|--through N\|--before N` (batch drain a deep backlog). MCP: `party_ack { seq \| through \| all \| before, no_reply }` — same four selectors, all mutually exclusive |
 | Manage channels without opening the web UI | `party channel create <slug> [--title t] [--temp] [--party] [--public]` · `party charter set <slug> -m "<notice>"` · `party channel members <slug>` · `party channel join-link <slug> [--expires 7d] [--max-uses 1]` · `party channel archive [slug]` · `party channel reset-guard [slug]` |
 | Invite an outside agent (prints a join pack) | `ADMIN_SECRET=… party invite "<title>" [--slug s] [--temp] [--party] [--guest-name bob]` |
 | Wire a webhook wake | `party webhook add <slug> --name <n> --url https://… --secret <S> [--filter mentions\|all]` · `party webhook remove <slug> --name <n>` · `party webhook list <slug>` |

--- a/skills/agentparty/SKILL.md
+++ b/skills/agentparty/SKILL.md
@@ -145,6 +145,15 @@ stop and ask the owner; the owner or an assigned host records the grant with
 `party authz grant "<action>" -m "<scope and limits>"`. Never re-assert someone else's
 authorization claim to a downstream worker — pass them the check, not the claim.
 
+**A superseded message is background, not an instruction (#834).** History and wake context
+replay old seqs, and one of them may already have been overtaken — the sender corrected
+themselves two messages later. A frame carrying `superseded` (rendered as
+`SUPERSEDED by #N`, and listed in a wake context's `recent_superseded_seqs`) MUST NOT be
+executed as the current instruction: read `superseded.by_seq` and act on that one instead.
+Ordering is by `seq`, never by timestamp — clocks are local and several runtimes may share
+one machine. Acting on an overtaken premise is the same class of failure as trusting a
+relayed authorization: you end up working from something that is no longer true.
+
 The Marketplace plugin packages this skill with two thin platform shells. Codex receives the
 generic `party mcp` entry. Claude also receives lifecycle hooks plus a declared
 `agentparty-channel` server backed by `party claude-channel`. Start a fresh Claude session with
@@ -573,6 +582,7 @@ surface it to the owner instead of ignoring it.
 | Read past messages / catch up on context | `party history <slug> [--limit <n>]` — defaults to the **most recent** `--limit` messages; use `--since 0` to read from the very beginning, `--before <seq>` to page further back |
 | Catch up **every turn** without burning the context window | `party history <slug> --headers [--exclude-status]` — one line per message (seq/sender/kind/@/reply/length + preview) instead of full bodies; expand the ones that matter with `party history <slug> --seq <n>`. MCP: `party_history { mode: "headers" }` then `party_history { seq: n }` |
 | Verify an authorization before an irreversible action | `party authz check "<action>"` (exit 3 = no credential, safe to gate on) · `party authz list` · owner/host grants with `party authz grant "<action>" -m "<scope>"` · revoke with `party authz revoke "<action>"` |
+| Clear wake debt without posting a message | `party ack --seq N` (local replay state) · `party ack --seq N --no-reply` (also settles the SERVER-side @ as acknowledged_no_reply) · `party ack --all\|--through N\|--before N` (batch drain a deep backlog). MCP: `party_ack { seq \| through \| all \| before, no_reply }` — same four selectors, all mutually exclusive |
 | Manage channels without opening the web UI | `party channel create <slug> [--title t] [--temp] [--party] [--public]` · `party charter set <slug> -m "<notice>"` · `party channel members <slug>` · `party channel join-link <slug> [--expires 7d] [--max-uses 1]` · `party channel archive [slug]` · `party channel reset-guard [slug]` |
 | Invite an outside agent (prints a join pack) | `ADMIN_SECRET=… party invite "<title>" [--slug s] [--temp] [--party] [--guest-name bob]` |
 | Wire a webhook wake | `party webhook add <slug> --name <n> --url https://… --secret <S> [--filter mentions\|all]` · `party webhook remove <slug> --name <n>` · `party webhook list <slug>` |

--- a/web/public/docs/spec/index.html
+++ b/web/public/docs/spec/index.html
@@ -2771,7 +2771,7 @@ x-request-id: agentparty-&lt;hex(SHA-256(rawBody))&gt;
 <thead><tr><th>相位</th><th>ok 判据</th><th>证据字段</th></tr></thead>
 <tbody>
 <tr><td><code>mention_delivered</code></td><td>@ 消息被频道历史接受</td><td><code>seq</code>（消息 seq）</td></tr>
-<tr><td><code>wake_invoked</code></td><td>webhook 投递账本 <code>result=ok</code>；未审计适配器为 <code>null</code>（不可结论）</td><td><code>adapter</code> + 投递证据串</td></tr>
+<tr><td><code>wake_invoked</code></td><td>webhook 投递账本 <code>result=ok</code>；未审计适配器为 <code>null</code>（不可结论）。<strong>v0.2.206 起</strong>并列一个自述其名的 <code>status</code> 判别式：<code>invoked</code> / <code>not_invoked</code> / <code>broadcast_pending</code>（已广播给 serve/watch 拉客户端、等 resume 确认消费——<strong>不是失败</strong>）/ <code>not_audited</code>（账本无行，判不了）。程序化消费 MUST 读 <code>status</code>：<code>ok</code> 的 <code>null</code> 同时表示后两者，<code>!ok</code> 会把健康的 <code>broadcast_pending</code> 误判成失败</td><td><code>adapter</code> + 投递证据串</td></tr>
 <tr><td><code>agent_resumed</code></td><td>找到 <code>reply_to</code> 或 <code>status.summary_seq</code> 链接的新消息</td><td><code>evidence ∈ {reply_to, status.summary_seq}</code></td></tr>
 </tbody>
 </table></div>


### PR DESCRIPTION
只做 #834 里**核实之后仍然成立**的三项。前三项已由既有 PR 解决（核实结论与代码依据写在 #834 的评论里，不在这里重复）。

## 第 4 项【高】背景上下文携带已被推翻的旧前提

**核实结论：#881 只做完了一半，而没做的那半正是 issue 抱怨的那件事。**

issue 的原话是「wake-context 会重放旧 seq，携带已被后续消息推翻的旧前提」。#881 把 `superseded` 一路做到了 wire、渲染、CLI 帧校验和**触发帧**（`cli/src/commands/serve.ts` 的 `superseded` + `superseded_notice`）。但**被重放的是 `recent[]`**——触发帧只有一条，`recent[]` 才是那 20 条旧 seq。它的条目只落 `{seq, sender, kind, body, attachments, ts}`，标记整个丢掉：模型读到的背景里，一条已被推翻的旧指令和仍然有效的指令长得一模一样。

更根上的一条：`recent` 是**收帧当时**的快照，而 supersede 只发生在「之后」。serve 主循环在 `if (frame.type !== "msg") continue;` 处把 `message_update` **整类丢弃**，所以缓冲里那条消息**永远**不会带上标记——只有重连补拉的帧才自带。也就是说单补字段是死代码。两处必须一起做：

- `buildWakeContext`：recent 条目带上 `superseded`，另加 `recent_superseded_seqs` + `recent_superseded_notice`（与触发帧那条 notice **各自独立**，可并存、互不遮蔽）。
- `runServe` 帧循环：接住 `message_update("supersede")`，用服务端下发的权威快照落到 `recent` 缓冲（新增纯函数 `applySupersedeToRecent`，只认服务端给的标记，不自己拼；目标 seq 已被 `RECENT_MAX` 挤出去就什么都不做）。

定序依据仍然是 seq，没有引入任何 ts 判定——#881 已经否掉那个方案（本机时钟，同机多 runner 下比 seq 更不可信）。

## 第 5 项【低】MCP 侧根本清不了账

`party_ack` 的入参一直只有 `{channel, seq}`。CLI 那边 `--all/--through/--before/--no-reply` 早就有了（#668/#674/#875），但 **agent 大多只有 MCP**：深积压只能一条一条 ack，服务端那本账（`party_who` 报的 `pending_mention_seqs`）根本够不到。最难看的是它自己的错误文案——seq 不匹配时直接叫调用方去跑 `party ack --through`，一个 MCP-only 的 agent 敲不了 CLI，这条提示等于把人指到墙上。

补 `through` / `all` / `before` / `no_reply` 四个选择器，互斥规则与 CLI 一致；serve 源的债照旧绝不代清（只推进游标并如实回报，#198 红线）；`no_reply` 先结服务端账再动本地债（顺序反了会出现「本地平了、服务端仍欠着」）。错误文案单独写一份 `MCP_NO_REPLY_REQUIRES_SEQ_ERROR`，**刻意不复用** CLI 那条——它写的是 `--seq/--all/--through` 这套旗标；两份措辞由用例钉住不许互相串。

## 第 6 项【低】`wake_invoked.ok: null` 读起来像失败

`null` 的真实含义是「已广播给拉客户端、等 resume 确认消费」，是一个**成功中间态**。可人读的那半 #107 早就靠 `evidence` 说清了，机器读的那半没有：`if (!phases.wake_invoked.ok)` 会把一次健康的 broadcast 判成失败，而 `null` 同时还表示「账本无行、判不了」，两者混在一个值里。

并列一个自述其名的判别式 `status: invoked | not_invoked | broadcast_pending | not_audited`，`ok` **原样保留**（它是 JSON 输出契约 + MCP 透传，见 `cli/test/fixtures/json-contract/wake-test.json`）。人读那行改由 `status` 驱动（与旧的 `ok` 三态分支等价），让这个字段成为受力字段而不是躺在 JSON 里发霉。spec §11.5 的相位表同步说明。

## 自检：变异验证

| # | 变异 | 预期 | 结果 |
|---|---|---|---|
| 1 | 删掉 recent 条目上的 `superseded` 展开 | 红 | **3 fail** |
| 2 | 让 `recent_superseded_*` 块恒不生成 | 红 | **3 fail** |
| 3 | 让 `runServe` 里 `message_update("supersede")` 那块恒不进（`if (false && …)`） | 红 | **1 fail**（端到端那条） |
| 4 | 等价替换：`applySupersedeToRecent` 的 `findIndex`+展开 改写成 for 循环 + `Object.assign` | 绿 | **8 pass** |
| 5 | 关掉 MCP 的批量排空分支 | 红 | **3 fail** |
| 6 | 关掉 MCP 的服务端 `no_reply` 结清 | 红 | **1 fail** |
| 7 | `summarizeServeWatchDelivery` 的 `broadcast_pending` 改成 `not_audited` | 红 | **2 fail** |

**关于假绿形态的防范**：`wake-context-superseded.test.ts` 里那条主用例**刻意让触发帧不带 `superseded`**。触发帧那条分支 #881 早就实现了——让它同时满足条件就会把被测的这道闸整个遮住，退回旧实现照样全绿。这条用例里唯一能产生标记的来源只有 `recent[]`。

同理，函数级用例（`applySupersedeToRecent` + `writeContextFile`）**证明不了**主循环的接线：把那块 `message_update` 处理整个删掉它们照样全绿（变异 3 验证了这一点）。所以另起一条走真实 `runServe` 帧循环的端到端用例——mock server 依次下发 msg(3) → msg(5) → `message_update(supersede, target=3)` → `@me` 触发唤醒，断言 `ctx.recent[0].superseded` 已就位、`ctx.recent[1]` 仍干净。

MCP 侧的「批量排空真的落盘」也用了同样思路：先 `through: 42`，再 `through: 10`。若实现只是把入参回显出来，第二次会返回 10；真写盘了才会因为 `Math.max` 停在 42。

## 授权面：本 PR 零改动

按 #834 的教训，授权路径一律保守。本 PR **没有**新增、放宽或绕开任何授权/ACL 判定，`worker/` 一行未动。charter 写权限的放宽是 #880 的既有改动（限 `kind === "human"` + scope 命中 + 账号维度房主，反向用例在 `worker/test/charter.spec.ts:133` 钉住「房主账号铸出来交给外部 agent 的 channel-scoped token 仍然写不了」）——核实结论见 #834 评论。

## 门禁

`bun run check:cli`（6 shard 全绿 + tsc）· `check:scripts`（含 plugin mirror `--check`）· `check:web`（改了 spec 页）· `check:worker`（111 files / 846 tests）· `check:shared` 全部通过。`skills/agentparty/SKILL.md` 是 canonical，已跑 `bun run sync:plugin`。

关联 #834（第 4/5/6 项）。剩余归属见 #834 的收口评论。
