### PR TITLE
fix(worker,cli): next-mention 走 @ 倒排索引，codex skill 加载失败不再吞 @ (#913 #892)

### DIFF
--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -231,12 +231,35 @@ export class WakeBlockedError extends Error {
    * 让 owner 从 `party who` / `party wake test` 看得见），修好后由下一条 @ 或重连自愈。
    */
   readonly environment: boolean;
-  constructor(message: string, retriable = false, opts?: { environment?: boolean }) {
+  /**
+   * #892：runner 的**配置/输入**坏了——不是凭据、不是二进制、不是沙箱，而是一份 harness 在启动模型
+   * 之前就要读、且读不动的本地文件（当前只有一类：codex 递归发现到的畸形 `SKILL.md`）。
+   * 与 environment 的区别只在**处置**：认证过期那类修好之前重试都是白烧、且旧凭据可能已经换人，
+   * 所以 #690 把它判终局；这类是「用户把某个文件改回去就能跑」的确定性错误，模型一步都没起，
+   * 把这条 @ 结算掉纯属白丢。带上它的 wake 不结算、不推游标，serve 终局停机等人修（见 EXIT_RUNNER_UNAVAILABLE）。
+   */
+  readonly configuration: RunnerConfigFailure | null;
+  constructor(
+    message: string,
+    retriable = false,
+    opts?: { environment?: boolean; configuration?: RunnerConfigFailure },
+  ) {
     super(message);
     this.name = "WakeBlockedError";
     this.retriable = retriable;
     this.environment = opts?.environment ?? false;
+    this.configuration = opts?.configuration ?? null;
   }
+}
+
+/** #892：一处会在模型启动前把 runner 打死、且用户改一个文件就能修好的配置错。 */
+export interface RunnerConfigFailure {
+  /** 稳定的机器可读类别，落进日志/通告，便于以后再加别的 harness 的同类错。 */
+  kind: "codex_skill_load";
+  /** 出问题的文件绝对路径——诊断里最有用的一条信息，绝不能被摘要吃掉。 */
+  path: string;
+  /** harness 自己给的原因原文（例：missing YAML frontmatter delimited by ---）。 */
+  reason: string;
 }
 
 /** runner 占用超过硬上限；模型可能已经执行过，所以绝不能自动重跑。 */
@@ -2382,6 +2405,43 @@ export function isRunnerEnvFailure(result: Pick<RunnerProcessResult, "stderr">):
   return RUNNER_ENV_FAILURE_PATTERNS.some((re) => re.test(result.stderr));
 }
 
+/**
+ * #892：**判定成立的那一行**是什么。
+ *
+ * 存在的理由是一个真实误诊：诊断摘要一直取 stderr 的**开头**，而环境失败的指纹往往在**结尾**
+ * （codex 先吐 skill/启动噪声，401 之类的真因排在后面）。于是 #892 的报告里出现了
+ * `env_failure=true` 配一段「failed to load skill ... missing YAML frontmatter」——那段文字
+ * 与 RUNNER_ENV_FAILURE_PATTERNS 的任何一条都不匹配，也就是说：**通告里展示的原因，根本不是
+ * 触发判定的那一条**。报的人照着改 SKILL.md，改不好也不奇怪。
+ *
+ * 所以判定命中时，诊断必须交出命中的那一行。所有指纹都是行内模式（没有跨行的），
+ * 逐行扫与整串扫命中集合一致，不会出现「整串命中而逐行找不到」。
+ */
+export function runnerEnvFailureEvidence(stderr: string): string | null {
+  for (const line of stderr.split("\n")) {
+    const text = line.trim();
+    if (text === "") continue;
+    if (RUNNER_ENV_FAILURE_PATTERNS.some((re) => re.test(text))) return text;
+  }
+  return null;
+}
+
+// #892：codex 在**模型启动之前**递归发现并加载 skills；碰到一份没有 YAML frontmatter 的
+// 嵌套 SKILL.md 会打印这行。它既不是凭据错也不是二进制缺失——RUNNER_ENV_FAILURE_PATTERNS
+// 一条都不匹配——所以在此之前它落进「exit-1，模型可能跑过」那一档，被终局结算，@ 就此沉掉。
+// 而实情是模型一步都没起，且用户把那个文件删掉/补上 frontmatter 就好。单独成档。
+const CODEX_SKILL_LOAD_FAILURE_RE = /failed to load skill\s+([^\s][^\n]*?):\s*([^\n]+)/i;
+
+/** stderr 里若有 codex 的 skill 加载失败，交出出问题的路径与原文理由。 */
+export function codexSkillLoadFailure(stderr: string): RunnerConfigFailure | null {
+  const match = CODEX_SKILL_LOAD_FAILURE_RE.exec(stderr);
+  if (match === null) return null;
+  const path = match[1]!.trim();
+  const reason = match[2]!.trim();
+  if (path === "" || reason === "") return null;
+  return { kind: "codex_skill_load", path, reason };
+}
+
 export function runnerDiagnosticExcerpt(
   result: Pick<RunnerProcessResult, "stdout" | "stderr">,
   harness: RunnerHarness,
@@ -2399,6 +2459,12 @@ export function runnerDiagnosticExcerpt(
       // Fall through to the raw process evidence.
     }
   }
+  // #892：环境失败判定命中时，交出**命中的那一行**而不是 stderr 的开头。见 runnerEnvFailureEvidence。
+  const evidence = runnerEnvFailureEvidence(result.stderr);
+  if (evidence !== null) return sanitizeBlockedError(evidence);
+  // #892：配置类失败同理——把出问题的文件路径顶到最前，别让它被前面的启动噪声挤出摘要。
+  const config = codexSkillLoadFailure(result.stderr);
+  if (config !== null) return sanitizeBlockedError(`failed to load skill ${config.path}: ${config.reason}`);
   const raw = result.stderr.trim() || result.stdout.trim();
   return raw === "" ? "runner exited without diagnostic output" : sanitizeBlockedError(raw);
 }
@@ -2831,6 +2897,20 @@ async function runHarness(
  * These commands inspect local authentication only; they do not start a model turn.
  * The successful result is cached for this process so a transient socket reconnect
  * does not repeatedly spawn the same check.
+ *
+ * #892：**它通过不等于 runner 能跑**，日志也就不能写 `ready=true`。报告里的形态正是
+ * `startup_preflight=true ... ready=true` 之后第一条真 @ 直接崩在 codex 的 skill 加载上。
+ * 想让 preflight 覆盖那条路径需要一个「加载完配置与 skills 但不起模型」的命令；在 codex-cli
+ * 0.145.0 上逐个验过，没有：
+ *   - `codex login status`：只看凭据，畸形 SKILL.md 对它完全不可见；
+ *   - `codex doctor --json`：18 项检查（auth/config/network/sandbox/state/...），**没有 skills 这一项**，
+ *     畸形文件在场时 overallStatus 仍不报它；
+ *   - `codex debug prompt-input`：确实走 skill 发现（输出里能看到已加载的 skill 列表），但对畸形文件
+ *     只是静默跳过——exit 0、stderr 空，RUST_LOG=error/info 都不吐那行 ERROR；
+ *   - 只有 `codex exec` 会打印 `failed to load skill ...`，而它就是要起模型的那条命令。
+ * 结论：这里只能诚实地报「验了什么、没验什么」，真实的第一手证据留给第一次 wake，由
+ * codexSkillLoadFailure 那一档负责不把它结算掉。哪天 codex 提供了免模型的校验模式，
+ * 把它加进来并把 unverified 缩小即可。
  */
 export function createBuiltinRunnerStartupCheck(
   opts: BuiltinRunnerOptions,
@@ -2887,9 +2967,10 @@ export function createBuiltinRunnerStartupCheck(
       );
     }
     ready = true;
+    // #892：只写「验过什么、没验什么」。`ready=true` 是一句这条检查没有资格下的结论。
     appendRunnerLog(
       opts.workdir,
-      `${new Date((opts.now ?? Date.now)()).toISOString()} startup_preflight=true harness=${opts.harness} exit=0 ready=true`,
+      `${new Date((opts.now ?? Date.now)()).toISOString()} startup_preflight=true harness=${opts.harness} exit=0 verified=auth,binary unverified=config,skills`,
     );
   };
 }
@@ -3511,11 +3592,28 @@ export function createBuiltinRunner(opts: BuiltinRunnerOptions): NonNullable<Ser
           const envFailure =
             isRunnerEnvFailure(run.result) ||
             (opts.harness === "claude" && claudeJsonEnvFailure(run.result.stdout));
+          // #892：codex 的 skill 加载失败单独成档，但**排在环境失败之后**——凭据过期那类的处置
+          // （#690/#748 已确立的终局语义）不能被一条恰好同时出现的 skill 噪声改写。只有在没有任何
+          // 环境指纹命中时，skill 加载失败才是这次非零退出最好的解释。
+          const configFailure =
+            !envFailure && opts.harness === "codex" ? codexSkillLoadFailure(run.result.stderr) : null;
           const diagnostic = runnerDiagnosticExcerpt(run.result, opts.harness);
           appendRunnerLog(
             opts.workdir,
-            `${new Date(now).toISOString()} seq=${frame.seq} sid=${shortSid(oldSid)} duration_ms=${now - started} exit=${run.result.code}${envFailure ? " env_failure=true" : ""} diagnostic=${JSON.stringify(diagnostic)}`,
+            `${new Date(now).toISOString()} seq=${frame.seq} sid=${shortSid(oldSid)} duration_ms=${now - started} exit=${run.result.code}${envFailure ? " env_failure=true" : ""}${configFailure === null ? "" : ` config_failure=${configFailure.kind} config_path=${JSON.stringify(configFailure.path)}`} diagnostic=${JSON.stringify(diagnostic)}`,
           );
+          if (configFailure !== null) {
+            throw new WakeBlockedError(
+              `builtin codex runner blocked: exit code ${run.result.code} ` +
+                `(codex skill/config load failure: ${configFailure.path}: ${configFailure.reason} — model did not run); ` +
+                `修好或移除该文件后重启 serve；这条 @ 不会被结算。log: ${join(opts.workdir, RUNNER_LOG_FILE)}`,
+              // 模型确定没跑过 ⇒ 重跑是安全的（这正是 retriable 的定义）。立刻重试没意义——文件不会
+              // 在几毫秒里自己变好——所以调用方看到 configuration 就跳出重试循环，而不是靠 retriable=false
+              // 把它伪装成「不安全重跑」。持久化的欠账因此保留 retriable=true，人修好重启后能真的重放。
+              true,
+              { environment: true, configuration: configFailure },
+            );
+          }
           throw new WakeBlockedError(
             `builtin ${opts.harness} runner blocked: exit code ${run.result.code}` +
               `${envFailure ? ` (runner environment failure: ${diagnostic} — model did not run)` : ` (${diagnostic})`}; ` +
@@ -5576,6 +5674,9 @@ export async function runServe(o: ServeOptions): Promise<number> {
         // 不能把配置预算 maxAttempts 伪装成实际已跑次数（例如一次 SIGTERM 不能写成 3/3）。
         let attemptsUsed = attemptFloor;
         let lastFailureEnvironment = false;
+        // #892：本帧撞上的 runner 配置错（畸形 SKILL.md 之类）。非 null ⇒ 这条 @ 不结算、不推游标，
+        // serve 终局停机等人修好——把一条模型从未看到的 @ 结算掉，等于替用户丢消息。
+        let heldConfigFailure: RunnerConfigFailure | null = null;
         // 身后已缓冲的 wake 深度（#103）：内建 runner 随 working 帧上报，presence 显示「忙 + N 待处理」。
         // 本帧正在处理，故只数它 seq 之后、够格触发唤醒的缓冲帧。
         const queueDepth = pendingWakeDepth(
@@ -5843,6 +5944,10 @@ export async function runServe(o: ServeOptions): Promise<number> {
               // 那会误导 owner 以为副作用可能已发生。说清是环境坏了、修好再 @ 即可（保守：仅明确指纹命中）。
               const envFailure = e instanceof WakeBlockedError && e.environment;
               lastFailureEnvironment = envFailure;
+              // #892：runner 配置坏了（当前只有 codex 畸形 SKILL.md 一类）。模型一步没起，
+              // 而且文件不会在重试间隔里自己变好——立刻重跑只是把同一份诊断再打一遍。
+              const configFailure = e instanceof WakeBlockedError ? e.configuration : null;
+              if (configFailure !== null) heldConfigFailure = configFailure;
               if (!retriable) {
                 lastError += envFailure
                   ? " (runner environment failure: model did not run — fix credentials/binary/sandbox, e.g. `claude login`, then re-mention)"
@@ -5866,6 +5971,10 @@ export async function runServe(o: ServeOptions): Promise<number> {
                   ...(runnerTerminationUnconfirmed ? { termination_unconfirmed: true } : {}),
                 });
               }
+              // #892：配置类失败到此为止。retriable 仍是 true（模型确实没跑，重放是安全的，
+              // 落盘的欠账也就带着 retriable=true，人修好重启后能真的重放），但重试留给「人改完文件」
+              // 那一刻，不在这里空转烧预算。
+              if (heldConfigFailure !== null) break;
               if (retriable && attempt < maxAttempts && retryDelayMs > 0) {
                 await delayWithAbort(retryDelayMs, lifecycleController.signal);
               }
@@ -5986,6 +6095,33 @@ export async function runServe(o: ServeOptions): Promise<number> {
           // 不删，理由写在这里。
           if (deliveryConfirmed && stuck !== null && stuck.seq === frame.seq) setStuck(null);
           await clearBusyIfDrained(`idle: ${self} finished wake seq=${frame.seq}, waiting for next @`);
+        } else if (heldConfigFailure !== null) {
+          // #892：runner 的配置/输入坏了，模型一步都没起。这不是「这条 @ 处理失败」，是「这台
+          // serve 现在没有执行能力」——把它当失败结算掉，等于用户改好一个文件之后还得回去求发送方
+          // 重发一遍。所以：响亮宣告 + **不结算**（不发 delivery failed）+ **不推游标**（不 ack）
+          // + 终局停机。留在服务端的那条 @ 由租约过期/重连重放交给修好后的 serve。
+          const note =
+            `wake held, runner configuration is broken: seq=${frame.seq}; ` +
+            `reason=${heldConfigFailure.kind}; path=${heldConfigFailure.path}; detail=${heldConfigFailure.reason}; ` +
+            `model did not run; this @ was not consumed — fix or remove that file and restart serve`;
+          out(`  ${note}`);
+          try {
+            await (o.post ?? postMessage)(o.server, o.token, o.channel, {
+              kind: "status",
+              state: "blocked",
+              note,
+              mentions: [],
+              blocked_reason: note,
+              // 停机退出，队列不会再被排空——强制清 busy，别留一个「永远在忙」的幽灵。
+              ...takeBusyClearIfDrained(true),
+            }, lifecycleController.signal);
+          } catch (e) {
+            out(`  配置错误通告发送失败，欠账保留、游标不动、退出: ${errText(e)}`);
+            code = EXIT_WAKE_UNANNOUNCED;
+            break;
+          }
+          code = EXIT_RUNNER_UNAVAILABLE;
+          break;
         } else {
           // 有界重放到顶：显式放弃，但必须响亮留痕——静默丢弃正是 #118 要修的东西。
           // 没有 CLI flag，所以重试预算与退避必须**在频道里可见**：把常数藏进源码是不诚实的。

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -2411,8 +2411,8 @@ export function isRunnerEnvFailure(result: Pick<RunnerProcessResult, "stderr">):
  * 存在的理由是一个真实误诊：诊断摘要一直取 stderr 的**开头**，而环境失败的指纹往往在**结尾**
  * （codex 先吐 skill/启动噪声，401 之类的真因排在后面）。于是 #892 的报告里出现了
  * `env_failure=true` 配一段「failed to load skill ... missing YAML frontmatter」——那段文字
- * 与 RUNNER_ENV_FAILURE_PATTERNS 的任何一条都不匹配，也就是说：**通告里展示的原因，根本不是
- * 触发判定的那一条**。报的人照着改 SKILL.md，改不好也不奇怪。
+ * 与 RUNNER_ENV_FAILURE_PATTERNS 的任何一条都不匹配（`missing YAML frontmatter` 那个形态），
+ * 也就是说：**通告里展示的原因，根本不是触发判定的那一条**。报的人照着改 SKILL.md，改不好也不奇怪。
  *
  * 所以判定命中时，诊断必须交出命中的那一行。所有指纹都是行内模式（没有跨行的），
  * 逐行扫与整串扫命中集合一致，不会出现「整串命中而逐行找不到」。
@@ -2426,10 +2426,16 @@ export function runnerEnvFailureEvidence(stderr: string): string | null {
   return null;
 }
 
-// #892：codex 在**模型启动之前**递归发现并加载 skills；碰到一份没有 YAML frontmatter 的
-// 嵌套 SKILL.md 会打印这行。它既不是凭据错也不是二进制缺失——RUNNER_ENV_FAILURE_PATTERNS
-// 一条都不匹配——所以在此之前它落进「exit-1，模型可能跑过」那一档，被终局结算，@ 就此沉掉。
-// 而实情是模型一步都没起，且用户把那个文件删掉/补上 frontmatter 就好。单独成档。
+// #892：codex 在**模型启动之前**递归发现并加载 skills；读不动某个 SKILL.md 时会打印这行。
+// 它既不是凭据错也不是二进制缺失，此前落进「exit-1，模型可能跑过」那一档被终局结算，@ 就此沉掉；
+// 而实情是模型一步都没起，且用户把那个文件删掉/补好就行。单独成档。
+//
+// 两种形态、两条歧路，都要挡住：
+//   - `missing YAML frontmatter delimited by ---`：RUNNER_ENV_FAILURE_PATTERNS 一条都不匹配
+//     ⇒ 旧实现判它「模型可能跑过」，挂着免责标签终局结算；
+//   - `No such file or directory`（断掉的 skill 符号链接，正是 #892 报告里的布局）：**恰好**命中
+//     ENOENT「二进制缺失」指纹 ⇒ 旧实现判它环境失败，同样终局结算，还显示错的修法。
+// 所以判环境之前必须先摘掉这几行，见 withoutSkillLoadLines。
 const CODEX_SKILL_LOAD_FAILURE_RE = /failed to load skill\s+([^\s][^\n]*?):\s*([^\n]+)/i;
 
 /** stderr 里若有 codex 的 skill 加载失败，交出出问题的路径与原文理由。 */

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -2442,6 +2442,24 @@ export function codexSkillLoadFailure(stderr: string): RunnerConfigFailure | nul
   return { kind: "codex_skill_load", path, reason };
 }
 
+/**
+ * 判别环境失败时，先把 skill 加载失败那几行摘掉（CodeRabbit on #892）。
+ *
+ * 理由是一个会真实发生的串档：#892 报告里的全局 skills 目录含一个指向共享 skill 树的**符号链接**，
+ * 断链时 codex 打的正是 `failed to load skill <path>: No such file or directory`——而
+ * `no such file or directory` 恰好是 RUNNER_ENV_FAILURE_PATTERNS 里「二进制缺失」的指纹。
+ * 不摘掉的话，这条最该落进「配置坏了、改个文件就好」那一档的错，会被判成环境失败终局结算，
+ * 并且对着用户显示 credentials/binary/sandbox 的通用修法。
+ *
+ * 只摘 skill 加载失败自己那一行：其它行里的认证/二进制错照旧优先（#690/#748 的判据不动）。
+ */
+function withoutSkillLoadLines(stderr: string): string {
+  return stderr
+    .split("\n")
+    .filter((line) => !/failed to load skill\s/i.test(line))
+    .join("\n");
+}
+
 export function runnerDiagnosticExcerpt(
   result: Pick<RunnerProcessResult, "stdout" | "stderr">,
   harness: RunnerHarness,
@@ -2460,7 +2478,9 @@ export function runnerDiagnosticExcerpt(
     }
   }
   // #892：环境失败判定命中时，交出**命中的那一行**而不是 stderr 的开头。见 runnerEnvFailureEvidence。
-  const evidence = runnerEnvFailureEvidence(result.stderr);
+  // 同样先摘掉 skill 加载失败那几行，否则断链 skill 的「No such file or directory」会冒充环境证据，
+  // 把真正该显示的路径挤掉——判定与展示必须用同一份输入，不然又是一次「展示的原因不是触发的原因」。
+  const evidence = runnerEnvFailureEvidence(withoutSkillLoadLines(result.stderr));
   if (evidence !== null) return sanitizeBlockedError(evidence);
   // #892：配置类失败同理——把出问题的文件路径顶到最前，别让它被前面的启动噪声挤出摘要。
   const config = codexSkillLoadFailure(result.stderr);
@@ -3589,12 +3609,14 @@ export function createBuiltinRunner(opts: BuiltinRunnerOptions): NonNullable<Ser
         if (run.result.code !== 0) {
           // #690：认证过期 / 二进制缺失 / 沙箱拒权等环境性失败在模型启动前就崩，别归为「model may have run」。
           // #748：claude 的 auth/api 失败落在 stdout 的结构化 JSON（非 stderr），补一条只吃结构化字段的判定。
-          const envFailure =
-            isRunnerEnvFailure(run.result) ||
-            (opts.harness === "claude" && claudeJsonEnvFailure(run.result.stdout));
           // #892：codex 的 skill 加载失败单独成档，但**排在环境失败之后**——凭据过期那类的处置
           // （#690/#748 已确立的终局语义）不能被一条恰好同时出现的 skill 噪声改写。只有在没有任何
           // 环境指纹命中时，skill 加载失败才是这次非零退出最好的解释。
+          // 判环境时先摘掉 skill 加载失败那几行（断掉的 skill 符号链接会打出「No such file or
+          // directory」，恰好撞上「二进制缺失」的指纹）——见 withoutSkillLoadLines。
+          const envFailure =
+            isRunnerEnvFailure({ stderr: withoutSkillLoadLines(run.result.stderr) }) ||
+            (opts.harness === "claude" && claudeJsonEnvFailure(run.result.stdout));
           const configFailure =
             !envFailure && opts.harness === "codex" ? codexSkillLoadFailure(run.result.stderr) : null;
           const diagnostic = runnerDiagnosticExcerpt(run.result, opts.harness);

--- a/cli/test/serve-failure-ack.test.ts
+++ b/cli/test/serve-failure-ack.test.ts
@@ -1047,6 +1047,52 @@ describe("codex skill/config 加载失败自成一档 (#892)", () => {
     expect(diagnostic).not.toContain("missing YAML frontmatter");
   });
 
+  // CodeRabbit on #932：skill 加载失败**自己那一行**就可能含 `No such file or directory`
+  // （#892 报告里的全局 skills 目录挂着一个指向共享 skill 树的符号链接，断链就是这个形态），
+  // 而它恰好命中「二进制缺失」的 ENOENT 指纹。不把这行摘掉的话，新加的这一档在「文件缺失」
+  // 这个最常见形态下恒不生效——@ 照样被终局结算，还对着用户显示 credentials/binary/sandbox 的修法。
+  const CODEX_DANGLING_SYMLINK_STDERR = [
+    "Reading additional input from stdin...",
+    "2026-08-23T17:21:23.637254Z ERROR codex_core::session::session: failed to load skill " +
+      "/Users/dev/.agents/skills/shared/SKILL.md: No such file or directory (os error 2)",
+    "OpenAI Codex v0.145.0",
+  ].join("\n");
+
+  test("断链 skill 的 ENOENT 不冒充环境失败：仍落配置档，不结算、不推游标", async () => {
+    // 这一行**确实**命中 ENOENT 环境指纹——正因如此才需要先摘掉它再判环境。
+    expect(isRunnerEnvFailure({ stderr: CODEX_DANGLING_SYMLINK_STDERR })).toBe(true);
+    expect(codexSkillLoadFailure(CODEX_DANGLING_SYMLINK_STDERR)?.reason).toContain("No such file or directory");
+
+    const s = closeAfterOneMention();
+    const posts: Array<Record<string, unknown>> = [];
+    const cursors: number[] = [];
+    const o = opts({
+      server: s.url,
+      maxWakeAttempts: 3,
+      onCursor: (c) => cursors.push(c),
+      post: async (_a, _b, _c, body) => {
+        posts.push(body as Record<string, unknown>);
+        return { seq: 1 };
+      },
+      runCommand: createBuiltinRunner({
+        server: "http://agentparty.test",
+        token: "ap_tok",
+        channel: "dev",
+        harness: "codex",
+        workdir: tempDir(),
+        runProcess: async () => ({ code: 1, stdout: "", stderr: CODEX_DANGLING_SYMLINK_STDERR }),
+        post: async () => ({ seq: 1 }),
+      }),
+    });
+
+    expect(await runServe(o)).toBe(13);
+    expect(cursors).toEqual([]);
+    const note = String(posts.find((p) => p.state === "blocked")?.note);
+    expect(note).toContain("codex_skill_load");
+    expect(note).toContain("/Users/dev/.agents/skills/shared/SKILL.md");
+    expect(note).not.toContain("retry=disabled_environment");
+  });
+
   test("环境指纹优先：同时出现 auth 失败时仍走 #690/#748 的终局语义，不被本档改写", async () => {
     const s = closeAfterOneMention();
     const posts: Array<Record<string, unknown>> = [];

--- a/cli/test/serve-failure-ack.test.ts
+++ b/cli/test/serve-failure-ack.test.ts
@@ -6,7 +6,7 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { EXIT_ARCHIVED, type MsgFrame } from "@agentparty/shared";
-import { claudeJsonEnvFailure, createBuiltinRunner, createSdkRunner, EXIT_WAKE_ABANDON_CIRCUIT, isRunnerEnvFailure, profileChildServeOptions, runServe, WakeBlockedError, type BuiltinRunnerOptions, type RunnerProcess, type ServeOptions } from "../src/commands/serve";
+import { claudeJsonEnvFailure, codexSkillLoadFailure, createBuiltinRunner, createBuiltinRunnerStartupCheck, createSdkRunner, EXIT_WAKE_ABANDON_CIRCUIT, isRunnerEnvFailure, profileChildServeOptions, runnerDiagnosticExcerpt, runnerEnvFailureEvidence, runServe, WakeBlockedError, type BuiltinRunnerOptions, type RunnerProcess, type ServeOptions } from "../src/commands/serve";
 import type { StuckWake } from "../src/config";
 import { msgFrame, startMockServer, welcomeFrame, type MockServer } from "./mock-server";
 
@@ -996,5 +996,191 @@ describe("profile 子 serve 继承 --replay-backlog (#206 门禁 P2)", () => {
       mentionsOnly: true,
     });
     expect(opts.skipBacklog).not.toBe(false);
+  });
+});
+
+// #892：`party serve --runner codex` 报了 preflight 通过，第一条真 @ 却因为 codex 递归发现到一份
+// 没有 YAML frontmatter 的嵌套 SKILL.md 在模型启动前退出，而 AgentParty 把这次唤醒**终局结算**掉了。
+// codex 侧的输入错不归我们管，但「假阳性 preflight」和「把一条模型从没看见的 @ 结算掉」是我们的。
+//
+// 真机取证（codex-cli 0.145.0，隔离 HOME/CODEX_HOME，嵌套 knowledge-base/SKILL.md 无 frontmatter）：
+//   codex exec  → stderr 出现 `ERROR ... failed to load skill <path>: missing YAML frontmatter delimited by ---`
+//   codex login status / codex doctor --json / codex debug prompt-input → 三者都看不见这个文件
+// 也就是说：免模型的检查覆盖不到这条路径，preflight 没有资格说 ready。
+const CODEX_SKILL_STDERR = [
+  "Reading additional input from stdin...",
+  "2026-08-23T17:21:23.637254Z ERROR codex_core::session::session: failed to load skill " +
+    "/Users/dev/ai-workspace/shared-skills/ima-skill/knowledge-base/SKILL.md: missing YAML frontmatter delimited by ---",
+  "OpenAI Codex v0.145.0",
+].join("\n");
+
+describe("codex skill/config 加载失败自成一档 (#892)", () => {
+  test("codexSkillLoadFailure 交出出问题的路径与原文理由", () => {
+    const failure = codexSkillLoadFailure(CODEX_SKILL_STDERR);
+    expect(failure).not.toBeNull();
+    expect(failure!.kind).toBe("codex_skill_load");
+    expect(failure!.path).toBe("/Users/dev/ai-workspace/shared-skills/ima-skill/knowledge-base/SKILL.md");
+    expect(failure!.reason).toBe("missing YAML frontmatter delimited by ---");
+    // 普通的模型失败不该被这一档吃掉。
+    expect(codexSkillLoadFailure("model ran, then failed")).toBeNull();
+    expect(codexSkillLoadFailure("")).toBeNull();
+  });
+
+  test("这段 stderr 不匹配任何环境指纹——正是它此前落进「模型可能跑过」那一档的原因", () => {
+    // 反过来说明这一档为什么必须新增：既有的 isRunnerEnvFailure 对它一个字都不认。
+    expect(isRunnerEnvFailure({ stderr: CODEX_SKILL_STDERR })).toBe(false);
+  });
+
+  test("诊断摘要交出**命中判定的那一行**，而不是 stderr 的开头 (#892 误诊根因)", () => {
+    // 报告里的形态：env_failure=true，可展示的诊断却是一段与所有环境指纹都不匹配的 skill 噪声。
+    // 因为摘要一直取 stderr 开头，而真因（401）排在后面——照着展示的原因去改，永远改不好。
+    const stderr = [
+      "Reading additional input from stdin...",
+      "2026-08-23T17:21:23Z ERROR codex_core::session::session: failed to load skill /tmp/x/SKILL.md: missing YAML frontmatter delimited by ---",
+      "OpenAI Codex v0.145.0",
+      "2026-08-23T17:21:25Z ERROR codex_api: failed to connect to websocket: HTTP error: 401 Unauthorized, url: wss://api.openai.com/v1/responses",
+    ].join("\n");
+    expect(isRunnerEnvFailure({ stderr })).toBe(true);
+    expect(runnerEnvFailureEvidence(stderr)).toContain("401 Unauthorized");
+    const diagnostic = runnerDiagnosticExcerpt({ stdout: "", stderr }, "codex");
+    expect(diagnostic).toContain("401 Unauthorized");
+    expect(diagnostic).not.toContain("missing YAML frontmatter");
+  });
+
+  test("环境指纹优先：同时出现 auth 失败时仍走 #690/#748 的终局语义，不被本档改写", async () => {
+    const s = closeAfterOneMention();
+    const posts: Array<Record<string, unknown>> = [];
+    const cursors: number[] = [];
+    const o = opts({
+      server: s.url,
+      maxWakeAttempts: 3,
+      onCursor: (c) => cursors.push(c),
+      post: async (_a, _b, _c, body) => {
+        posts.push(body as Record<string, unknown>);
+        return { seq: 1 };
+      },
+      runCommand: createBuiltinRunner({
+        server: "http://agentparty.test",
+        token: "ap_tok",
+        channel: "dev",
+        harness: "codex",
+        workdir: tempDir(),
+        runProcess: async () => ({
+          code: 1,
+          stdout: "",
+          stderr: `${CODEX_SKILL_STDERR}\nERROR: Failed to authenticate: OAuth session expired`,
+        }),
+        post: async () => ({ seq: 1 }),
+      }),
+    });
+
+    expect(await runServe(o)).toBe(EXIT_ARCHIVED);
+    // 终局结算：宣告放弃、推进游标——与本 PR 之前一致。
+    expect(cursors).toEqual([1]);
+    const note = String(posts.find((p) => p.state === "blocked")?.note);
+    expect(note).toContain("retry=disabled_environment");
+    expect(note).not.toContain("wake held");
+  });
+
+  test("只有 skill 加载失败时：不结算、不推游标、终局停机，通告里带路径与修法", async () => {
+    const s = closeAfterOneMention();
+    const posts: Array<Record<string, unknown>> = [];
+    const cursors: number[] = [];
+    const stucks: Array<StuckWake | null> = [];
+    let calls = 0;
+    const o = opts({
+      server: s.url,
+      maxWakeAttempts: 3,
+      onCursor: (c) => cursors.push(c),
+      onStuck: (st: StuckWake | null) => stucks.push(st),
+      post: async (_a, _b, _c, body) => {
+        posts.push(body as Record<string, unknown>);
+        return { seq: 1 };
+      },
+      runCommand: createBuiltinRunner({
+        server: "http://agentparty.test",
+        token: "ap_tok",
+        channel: "dev",
+        harness: "codex",
+        workdir: tempDir(),
+        runProcess: async () => {
+          calls++;
+          return { code: 1, stdout: "", stderr: CODEX_SKILL_STDERR };
+        },
+        post: async () => ({ seq: 1 }),
+      }),
+    });
+
+    // 停机退出（EXIT_RUNNER_UNAVAILABLE=13），不是跑到频道 archived 才结束。
+    expect(await runServe(o)).toBe(13);
+    // 文件不会在重试间隔里自己变好——一次就够，别把预算烧在同一份诊断上。
+    expect(calls).toBe(1);
+    // 最要紧的一条：这条 @ 没有被消费。游标一步没动。
+    expect(cursors).toEqual([]);
+    // 欠账落盘且标着「重放是安全的」——人修好文件重启后，它会真的被重放而不是直接判死。
+    expect(stucks.at(-1)).toMatchObject({ seq: 1, retriable: true });
+    const note = String(posts.find((p) => p.state === "blocked")?.note);
+    expect(note).toContain("wake held");
+    expect(note).toContain("codex_skill_load");
+    expect(note).toContain("/Users/dev/ai-workspace/shared-skills/ima-skill/knowledge-base/SKILL.md");
+    expect(note).toContain("missing YAML frontmatter");
+    expect(note).toContain("model did not run");
+    expect(note).toContain("not consumed");
+    // 不能再说「放弃」——那正是把 @ 丢掉的说法。
+    expect(note).not.toContain("giving up");
+    expect(note).not.toContain("retry=disabled_environment");
+  });
+
+  test("对照组：同一夹具、同一条 @，stderr 换成普通模型失败就照旧结算并推游标", async () => {
+    // 这条是上一测试的正控。没有它，「游标没动」也可能只是因为这条 @ 压根没被唤醒过——
+    // 那样即便退回旧实现，断言照样绿。夹具唯一的变量是 stderr 里有没有那行 skill 加载失败。
+    const s = closeAfterOneMention();
+    const cursors: number[] = [];
+    const posts: Array<Record<string, unknown>> = [];
+    const o = opts({
+      server: s.url,
+      maxWakeAttempts: 3,
+      onCursor: (c) => cursors.push(c),
+      post: async (_a, _b, _c, body) => {
+        posts.push(body as Record<string, unknown>);
+        return { seq: 1 };
+      },
+      runCommand: createBuiltinRunner({
+        server: "http://agentparty.test",
+        token: "ap_tok",
+        channel: "dev",
+        harness: "codex",
+        workdir: tempDir(),
+        runProcess: async () => ({ code: 1, stdout: "", stderr: "model ran, then failed" }),
+        post: async () => ({ seq: 1 }),
+      }),
+    });
+
+    expect(await runServe(o)).toBe(EXIT_ARCHIVED);
+    expect(cursors).toEqual([1]);
+    expect(String(posts.find((p) => p.state === "blocked")?.note)).toContain("giving up");
+  });
+
+  test("startup preflight 不再声称 ready——它只验了 auth/binary", async () => {
+    const workdir = tempDir();
+    const check = createBuiltinRunnerStartupCheck({
+      server: "http://agentparty.test",
+      token: "ap_tok",
+      channel: "dev",
+      harness: "codex",
+      workdir,
+      codexLaunch: { ok: true, codexBinary: "codex", codexArgsPrefix: [], env: {} },
+      runProcess: async () => ({ code: 0, stdout: "Logged in", stderr: "" }),
+      post: async () => ({ seq: 1 }),
+    } as unknown as BuiltinRunnerOptions);
+    await check(new AbortController().signal);
+
+    const log = readFileSync(join(workdir, "serve-runner.log"), "utf8");
+    expect(log).toContain("startup_preflight=true");
+    expect(log).toContain("verified=auth,binary");
+    expect(log).toContain("unverified=config,skills");
+    // 这条检查跑的是 `codex login status`，它对畸形 SKILL.md 完全不可见（真机验过）。
+    // 说 ready=true 就是替它下一个它下不了的结论——正是 #892 报告里被 quote 的那一行。
+    expect(log).not.toContain("ready=true");
   });
 });

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -356,6 +356,10 @@ const MAX_MENTIONS = 50;
  * 「hook 预算内必须返回」的查询不会因为某个身份被 @ 了上万次而变慢。
  */
 const NEXT_MENTION_SCAN_LIMIT = 200;
+/** #913：@ 倒排索引回填完成的 meta 标记。见 onStart 里建表处的说明。 */
+const MENTION_INDEX_BACKFILL_META = "mention_index_v1";
+/** 回填分页大小：单次查询恒有界，长频道也不会把整表 toArray 进内存。 */
+const MENTION_INDEX_BACKFILL_PAGE_SIZE = 1000;
 const MENTIONS_JSON_LIMIT = 4096;
 const MAX_STATUS_SCOPE = 50;
 const STATUS_SCOPE_JSON_LIMIT = 4096;
@@ -1723,6 +1727,8 @@ export class ChannelDO extends Server<Env> {
   // frame is awaiting I/O. Preserve wire order explicitly: hello must finish token validation and
   // capability setup before an immediately-following serve lease / adapter / send frame runs.
   private readonly wsMessageTails = new Map<string, Promise<void>>();
+  /** #913：上一次 `/internal/next-mention` 查询真实读到的行数。见该处理器里的说明。 */
+  nextMentionRowsRead = 0;
   private participantAuthorityRefreshedAt = 0;
   // Authorization checks make dispatch asynchronous. Serialize each target so
   // two wakeups cannot select the same queued row before either claim commits.
@@ -2455,6 +2461,49 @@ export class ChannelDO extends Server<Env> {
       // column already exists
     }
     this.migrateReadCursorSessionSchema();
+    // #913：@ 倒排索引。`/internal/next-mention` 是 codex Stop hook **每轮结束都要调**的信号源，
+    // 原实现按 `seq > since AND (mentions_json LIKE ? OR delivery_targets_json LIKE ?)` 扫 messages：
+    // LIMIT 封的是命中行数不是扫描行数，零命中时 SQLite 必须扫完 since 之后的每一行才能确定「没有」。
+    // 游标新鲜时窗口只有几条，游标陈旧时（新身份 cursor=0，正是 #870 的形态）代价与频道长度同阶。
+    // 这张表把「谁被 @ 过」翻成 (match_key, seq) 主键，零命中查询退化成一次 B 树探针，不再随频道增长。
+    //
+    // 索引只保证是**超集**：命中候选仍旧回 messages 行逐条核验（撤回/擦除/编辑掉的 @ 在那里被滤掉），
+    // 所以「删 @」的路径漏同步只会多读一行，永远不会误报；只有「加 @」的路径必须同步，那只有
+    // storeMessage 的 INSERT 与 edit 两处，两处都走 indexMessageMentions。
+    sql.exec(`CREATE TABLE IF NOT EXISTS message_mentions (
+      match_key TEXT NOT NULL,
+      seq INTEGER NOT NULL,
+      PRIMARY KEY (match_key, seq)
+    )`);
+    if (this.getMeta(MENTION_INDEX_BACKFILL_META) === null) {
+      // 一次性回填存量消息。放在 onStart 末尾——前面那些一次性迁移（legacy delivery_targets_json 补写、
+      // retract_scrub_*）会改写 mentions/targets，必须等它们定型后再建索引，否则索引会漏掉补写出来的目标。
+      // 事务内完成：中途抛异常则整体回滚、meta 不落，下次 hydrate 重来，绝不留半张索引。
+      this.ctx.storage.transactionSync(() => {
+        let after = -1;
+        for (;;) {
+          const rows = sql
+            .exec(
+              `SELECT seq, mentions_json, delivery_targets_json FROM messages
+                WHERE seq > ? ORDER BY seq LIMIT ?`,
+              after,
+              MENTION_INDEX_BACKFILL_PAGE_SIZE,
+            )
+            .toArray();
+          if (rows.length === 0) break;
+          for (const row of rows) {
+            after = Number(row.seq);
+            this.indexMessageMentions(
+              after,
+              parseStoredMentions(row.mentions_json),
+              parseStoredTargetNames(row.delivery_targets_json),
+            );
+          }
+          if (rows.length < MENTION_INDEX_BACKFILL_PAGE_SIZE) break;
+        }
+        this.setMeta(MENTION_INDEX_BACKFILL_META, "1");
+      });
+    }
     this.ctx.setWebSocketAutoResponse(
       new WebSocketRequestResponsePair('{"type":"ping"}', '{"type":"pong"}'),
     );
@@ -2463,6 +2512,40 @@ export class ChannelDO extends Server<Env> {
     // real clock guarantee rather than something that only runs if unrelated traffic wakes the DO.
     this.scheduleDirectedDeliveryRetentionAlarm();
     this.scheduleParticipantRemovalMetaRetentionAlarm();
+  }
+
+  /**
+   * #913：把一条消息的 @ 目标写进倒排索引。**只加不删**——索引是超集，读路径回 messages 逐条核验，
+   * 所以重复调用、以及「这条 @ 后来被撤回/编辑掉了」都无害。反过来说，任何**新增** @ 的写路径都
+   * 必须调它，漏一处就是漏一次唤醒。当前只有两处：storeMessage 的 INSERT 与 edit 的 UPDATE。
+   */
+  private indexMessageMentions(seq: number, ...nameLists: readonly (readonly string[])[]): void {
+    const keys = new Set<string>();
+    for (const names of nameLists) {
+      for (const name of names) keys.add(mentionMatchKey(name));
+    }
+    for (const key of keys) {
+      this.ctx.storage.sql.exec(
+        "INSERT OR IGNORE INTO message_mentions (match_key, seq) VALUES (?, ?)",
+        key,
+        seq,
+      );
+    }
+  }
+
+  /**
+   * 索引行的卫生清理：消息被撤回/擦除/裁剪后，它的索引行已无意义。删不掉也只是多读一行
+   * （核验会滤掉），所以这里是省钱不是保正确——正确性由读路径的核验保证。
+   */
+  private dropMentionIndex(seq: number): void {
+    this.ctx.storage.sql.exec("DELETE FROM message_mentions WHERE seq = ?", seq);
+  }
+
+  /** 裁剪掉一批消息之后，把索引里指向已消失消息的行一并清掉。 */
+  private dropOrphanMentionIndex(): void {
+    this.ctx.storage.sql.exec(
+      "DELETE FROM message_mentions WHERE seq NOT IN (SELECT seq FROM messages)",
+    );
   }
 
   private hasCompositeSessionPrimaryKey(table: "presence" | "read_cursor"): boolean {
@@ -3245,6 +3328,7 @@ export class ChannelDO extends Server<Env> {
             `DELETE FROM messages AS m WHERE m.ts <= ?`,
             cutoff,
           );
+          this.dropOrphanMentionIndex();
         });
         await this.flushAtomicDeliveryEffects(atomicEffects);
         this.broadcastInvalidatedDecisions(invalidatedDecisionSeqs, now);
@@ -6125,6 +6209,14 @@ export class ChannelDO extends Server<Env> {
             seq,
           );
           const updated = this.ctx.storage.sql.exec("SELECT * FROM messages WHERE seq = ?", seq).one();
+          // #913：编辑可以**新增** @（删除已路由目标会在上面被拒），新增的必须进倒排索引，
+          // 否则被 @ 的人这次唤醒就查不到。索引只加不删，编辑掉的非路由 @ 由读路径核验滤掉。
+          // 取的是**刚落库的那一行**而不是入参：索引与存储读同一个事实，不可能各说各话。
+          this.indexMessageMentions(
+            seq,
+            parseStoredMentions(updated.mentions_json),
+            parseStoredTargetNames(updated.delivery_targets_json),
+          );
           editState.frame = this.rowToFrame(updated);
           this.ensureDirectedDeliveries(
             editState.frame,
@@ -6186,6 +6278,8 @@ export class ChannelDO extends Server<Env> {
             this.nextRevSeq(),
             seq,
           );
+          // #913：撤回已把 mentions 清空，索引行留着只会让读路径白核验一行。顺手清掉。
+          this.dropMentionIndex(seq);
 
           // A queued/dead webhook payload is an immutable copy of the original frame. Scrubbing the
           // messages row alone would leave a retract bypass: alarm retry or moderator redeliver could
@@ -6937,24 +7031,29 @@ export class ChannelDO extends Server<Env> {
       const name = url.searchParams.get("name") ?? "";
       if (name === "") return Response.json({ seq: null });
       const key = mentionMatchKey(name);
-      // LIKE 只是预筛（SQLite 的 ASCII LIKE 不分大小写、`_`/`%` 只会放宽匹配，绝不会漏），
-      // 真正的判定在下面用 mentionMatchKey 逐行核。撤回/擦除的消息 mentions 已清空，天然被排除。
-      const like = `%${name}%`;
-      const rows = this.ctx.storage.sql
-        .exec(
-          `SELECT seq, mentions_json, delivery_targets_json
-             FROM messages
-            WHERE seq > ?
-              AND sender_name <> ?
-              AND (mentions_json LIKE ? OR delivery_targets_json LIKE ?)
-            ORDER BY seq LIMIT ?`,
-          since,
-          name,
-          like,
-          like,
-          NEXT_MENTION_SCAN_LIMIT,
-        )
-        .toArray();
+      // #913：预筛走 message_mentions 倒排索引，不再对 messages 做 `seq > since` 的全窗口 LIKE 扫描。
+      // 关键差别在**零命中**：LIKE 版必须扫完 since 之后每一行才能确定「没有」，代价与频道长度同阶
+      // （新身份 cursor=0 + 1900 条消息 = 每轮 turn 扫 1900 行）；索引版是一次 (match_key, seq) 的 B 树
+      // 探针，从没被 @ 过的身份直接读到 0 行。命中时仍旧回 messages 逐行核验——索引只保证是超集，
+      // 撤回/擦除/编辑掉的 @ 在这里被滤掉，判定口径与改动前逐字一致。LIMIT 同样封候选行数。
+      const cursor = this.ctx.storage.sql.exec(
+        `SELECT m.seq AS seq, m.mentions_json AS mentions_json, m.delivery_targets_json AS delivery_targets_json
+           FROM message_mentions AS idx
+           JOIN messages AS m ON m.seq = idx.seq
+          WHERE idx.match_key = ?
+            AND idx.seq > ?
+            AND m.sender_name <> ?
+          ORDER BY idx.seq LIMIT ?`,
+        key,
+        since,
+        name,
+        NEXT_MENTION_SCAN_LIMIT,
+      );
+      const rows = cursor.toArray();
+      // 成本护栏的观测点（#913）：这个端点唯一的存在前提是「便宜到每轮 turn 都能问一次」，
+      // 而「便宜」只能用真实读到的行数证明——响应体里看不出扫了 1900 行还是 0 行。
+      // 留在实例上供守卫测试断言：零命中查询的读行数不随频道长度增长。
+      this.nextMentionRowsRead = cursor.rowsRead;
       for (const row of rows) {
         let names: string[];
         try {
@@ -8836,6 +8935,8 @@ export class ChannelDO extends Server<Env> {
         : null,
       now,
     );
+    // #913：与 INSERT 同一事务里补 @ 倒排索引，让 next-mention 不必再全表 LIKE。
+    this.indexMessageMentions(seq, msg.mentions, deliveryTargets);
     this.ensureDirectedDeliveries(msg, deliveryTargets, deliveryTargetOwners);
     let waitingOwnerDelivery: Record<string, unknown> | undefined;
     let waitingOwnerPresence: PresenceEntry | null = null;
@@ -8937,6 +9038,7 @@ export class ChannelDO extends Server<Env> {
             )`,
         seq - RETAIN_N,
       );
+      this.dropOrphanMentionIndex();
     }
 
     const frames: ServerFrame[] = replacedUpdate === undefined ? [msg] : [msg, replacedUpdate];
@@ -9856,6 +9958,8 @@ export class ChannelDO extends Server<Env> {
         revSeq,
         seq,
       );
+        // #913：擦除同撤回，mentions 已清空，索引行一并清掉。
+        this.dropMentionIndex(seq);
       }
       audit_deleted = countOne(
         `SELECT COUNT(*) AS n FROM message_audit

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -5279,6 +5279,8 @@ export class ChannelDO extends Server<Env> {
       options.workflow === undefined ? null : JSON.stringify(options.workflow),
       now,
     );
+    // #913：系统状态帧也能 @ 人（workflow/审阅提醒），同样要进 @ 倒排索引。
+    this.indexMessageMentions(seq, options.mentions ?? []);
     const frame: MsgFrame = {
       type: "status",
       seq,
@@ -5322,6 +5324,8 @@ export class ChannelDO extends Server<Env> {
       roleSource ?? null,
       now,
     );
+    // #913：审阅回复会 @ 提交人，这条 @ 必须能被 next-mention 查到。
+    this.indexMessageMentions(seq, mentions);
     const row = this.ctx.storage.sql.exec("SELECT * FROM messages WHERE seq = ?", seq).one();
     const frame = this.rowToFrame(row);
     this.linkWakeResume(identity, frame, now);
@@ -5361,6 +5365,8 @@ export class ChannelDO extends Server<Env> {
       JSON.stringify(response),
       now,
     );
+    // #913：决策回应同样反指提问方并 @ 它，同样要进 @ 倒排索引。
+    this.indexMessageMentions(seq, mentions);
     const row = this.ctx.storage.sql.exec("SELECT * FROM messages WHERE seq = ?", seq).one();
     const frame = this.rowToFrame(row);
     this.linkWakeResume(identity, frame, now);
@@ -6210,8 +6216,14 @@ export class ChannelDO extends Server<Env> {
           );
           const updated = this.ctx.storage.sql.exec("SELECT * FROM messages WHERE seq = ?", seq).one();
           // #913：编辑可以**新增** @（删除已路由目标会在上面被拒），新增的必须进倒排索引，
-          // 否则被 @ 的人这次唤醒就查不到。索引只加不删，编辑掉的非路由 @ 由读路径核验滤掉。
-          // 取的是**刚落库的那一行**而不是入参：索引与存储读同一个事实，不可能各说各话。
+          // 否则被 @ 的人这次唤醒就查不到。取的是**刚落库的那一行**而不是入参：索引与存储读同一个
+          // 事实，不可能各说各话。
+          //
+          // 先删后建，而不是只追加：编辑是唯一会**移除** @ 的常规路径，只追加的话陈旧行会一直攒。
+          // 核验虽然会把它们滤掉、不会误报，但候选是有 LIMIT 的——同一个 key 攒够
+          // NEXT_MENTION_SCAN_LIMIT 条陈旧行，就能把它们后面一条真 @ 挤出候选窗口，变成漏唤醒。
+          // 删掉它们，索引就对每条消息都是精确的（撤回/擦除/裁剪已各自清理）。
+          this.dropMentionIndex(seq);
           this.indexMessageMentions(
             seq,
             parseStoredMentions(updated.mentions_json),

--- a/worker/test/env.d.ts
+++ b/worker/test/env.d.ts
@@ -8,3 +8,10 @@ declare namespace Cloudflare {
     OIDC_CLIENT_ID?: string;
   }
 }
+
+// vite 的 `?raw` 后缀导入：把文件文本在构建期嵌进来。workers 运行时读不到宿主文件系统，
+// 源码级守卫（next-mention.spec.ts 里那条「所有 INSERT 都同步了 @ 索引」）只能靠它拿到源码。
+declare module "*?raw" {
+  const content: string;
+  export default content;
+}

--- a/worker/test/next-mention.spec.ts
+++ b/worker/test/next-mention.spec.ts
@@ -6,7 +6,12 @@
 import { env, runInDurableObject } from "cloudflare:test";
 import { describe, expect, it } from "vitest";
 import type { ChannelDO } from "../src/do";
-import { api, createChannel, seedToken } from "./helpers";
+// 源码文本（vite ?raw）：workers 运行时读不到宿主文件系统，源码守卫只能靠构建期把文本嵌进来。
+import doSource from "../src/do.ts?raw";
+import { api, createChannel, seedToken, uniq } from "./helpers";
+
+/** 与 worker/src/do.ts 的 NEXT_MENTION_SCAN_LIMIT 对齐：一次问询最多核查多少条候选。 */
+const NEXT_MENTION_SCAN_LIMIT = 200;
 
 async function send(
   slug: string,
@@ -192,6 +197,78 @@ describe("next-mention 扫描代价 (#913)", () => {
     expect(await nextMention(slug, agent.token, 0)).toBe(mention);
   });
 
+  // 索引化把「查得到」从**全表扫描**换成**索引探针**，代价是：任何写 messages.mentions_json 的路径
+  // 漏同步，那条 @ 就从此查不到——而改动前 LIKE 全扫是找得到的，也就是说漏一处即是**漏唤醒回归**。
+  // do.ts 里有四处 `INSERT INTO messages`，靠人眼数是靠不住的（第一版就漏了三处，CodeRabbit 逮到）。
+  // 这条守卫按源码钉死：每一处 INSERT 只要写 mentions_json，其后必须紧跟 indexMessageMentions。
+  // 将来任何人新增第五处直写路径，这里会立刻红，而不是等某个 agent 神秘地叫不醒。
+  it("所有直写 messages.mentions_json 的 INSERT 都同步了 @ 索引（源码守卫）", async () => {
+    const source = doSource;
+    const inserts = [...source.matchAll(/INSERT INTO messages \(/g)];
+    // 数量本身也钉一下：新增写路径必须来这里过一遍，而不是悄悄多一处。
+    expect(inserts.length).toBe(4);
+    for (const insert of inserts) {
+      const block = source.slice(insert.index!, insert.index! + 4000);
+      if (!block.slice(0, 1200).includes("mentions_json")) continue;
+      const statementEnd = block.indexOf("\n    );");
+      const after = block.slice(statementEnd === -1 ? 0 : statementEnd, statementEnd === -1 ? 4000 : statementEnd + 600);
+      expect(after).toContain("indexMessageMentions");
+    }
+  });
+
+  // 上一条是源码守卫；这一条是行为守卫，走真实端点证明「审阅驳回 @ 原作者」这一类的 @ 查得到。
+  // 挑驳回回复是因为它最要命：作者正等着被叫醒去改，查不到就等于驳回通知石沉大海。
+  it("审阅驳回回复里的 @ 能被 next-mention 查到（非 handleSend 的写路径）", async () => {
+    const acct = `${uniq("acct")}@leeguoo.com`;
+    const owner = await seedToken("agent", uniq("owner"), { owner: acct });
+    const slug = await createChannel(owner.token);
+    const writer = await seedToken("agent", uniq("writer"), { owner: acct, channelScope: slug });
+    const reviewer = await seedToken("agent", uniq("reviewer"), {
+      owner: `${uniq("reviewer")}@example.com`,
+      channelScope: slug,
+    });
+    const gate = await api(`/api/channels/${slug}/completion-gate`, owner.token, {
+      method: "PUT",
+      body: JSON.stringify({ gate: "reviewer", policy: "sender" }),
+    });
+    expect(gate.status).toBe(200);
+
+    const kickoff = await send(slug, writer.token, "please do the work");
+    const completion = await api(`/api/channels/${slug}/messages`, writer.token, {
+      method: "POST",
+      body: JSON.stringify({
+        kind: "message",
+        body: "final synthesis",
+        mentions: [],
+        reply_to: kickoff,
+        completion_artifact: {
+          kind: "final_synthesis",
+          kickoff_seq: kickoff,
+          replies_count: 1,
+          timeout: false,
+          related_issues: [],
+          related_prs: [],
+        },
+      }),
+    });
+    expect(completion.status).toBe(200);
+    const completionSeq = ((await completion.json()) as { seq: number }).seq;
+    // 驳回之前 writer 没有任何待处理的 @（它自己发的不算）——把闸前的状态先钉死，
+    // 免得下面的「查得到」是别的东西凑出来的。
+    expect(await nextMention(slug, writer.token, 0)).toBeNull();
+
+    const rejected = await api(`/api/channels/${slug}/messages/${completionSeq}/review`, reviewer.token, {
+      method: "POST",
+      body: JSON.stringify({ action: "reject", reason: "missing test evidence" }),
+    });
+    expect(rejected.status).toBe(200);
+    const replySeq = ((await rejected.json()) as { reply: { seq: number; mentions: string[] } }).reply;
+    expect(replySeq.mentions).toEqual([writer.name]);
+
+    // 这就是 codex Stop hook 会问的那一句：作者查得到「有人 @ 我了」。
+    expect(await nextMention(slug, writer.token, 0)).toBe(replySeq.seq);
+  });
+
   // 编辑是除 INSERT 之外唯一能**新增** @ 的路径。漏同步它 = 被新 @ 到的人这次唤醒直接查不到。
   it("编辑新增的 @ 立刻可查", async () => {
     const human = await seedToken("human");
@@ -208,4 +285,40 @@ describe("next-mention 扫描代价 (#913)", () => {
 
     expect(await nextMention(slug, agent.token, 0)).toBe(seq);
   });
+
+  // CodeRabbit on #932 推翻了本 PR 初版的安全论证：「索引是超集 + 回表核验 ⇒ 永不误报」只在**不设上限**
+  // 时成立。候选是有上限的（NEXT_MENTION_SCAN_LIMIT），而编辑是唯一会**移除** @ 的常规路径；只追加不
+  // 替换的话，被编辑掉的 @ 会在索引里留下陈旧行，攒够上限就能把排在它们后面的**真** @ 挤出候选窗口
+  // ⇒ 漏唤醒。这是本 PR 会引入的回归，不是既有缺陷。修法是编辑路径先删后建。
+  it("编辑移除 @ 后，排在陈旧行之后的真 @ 仍然查得到（候选上限不会被陈旧行吃光）", async () => {
+    const human = await seedToken("human");
+    // 被 @ 的是人类：agent 的 @ 会落成 directed delivery，而已路由的目标**不允许**被编辑掉
+    // （必须撤回/supersede）。所以能制造陈旧索引行的只有非路由 @，这里用人类目标来构造。
+    const target = await seedToken("human");
+    const slug = await createChannel(human.token);
+    const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+    const clearRate = () =>
+      runInDurableObject(stub, (_instance: ChannelDO, state) => {
+        state.storage.sql.exec("DELETE FROM rate");
+      });
+
+    // 攒满整整一个候选窗口的「曾经 @ 过、后来被编辑掉」的消息。
+    for (let i = 0; i < NEXT_MENTION_SCAN_LIMIT; i += 1) {
+      if (i > 0 && i % 20 === 0) await clearRate();
+      const seq = await send(slug, human.token, `@${target.name} 第 ${i} 条`, [target.name]);
+      const edit = await api(`/api/channels/${slug}/messages/${seq}/edit`, human.token, {
+        method: "POST",
+        body: JSON.stringify({ body: `第 ${i} 条（改口，不 @ 了）` }),
+      });
+      expect(edit.status).toBe(200);
+    }
+    await clearRate();
+    // 编辑真的把 @ 拿掉了——否则下面的「查得到」只是因为陈旧行本身还是有效命中，闸被遮住。
+    expect(await nextMention(slug, target.token, 0)).toBeNull();
+
+    const real = await send(slug, human.token, `@${target.name} 这条是真的`, [target.name]);
+    expect(await nextMention(slug, target.token, 0)).toBe(real);
+    // 200 条消息 + 200 次编辑，比默认 20s 预算慢；这是这条守卫的固有成本——想证明「陈旧行吃光候选窗口」
+    // 就必须真的把窗口填满，凑不满的夹具证明不了任何事。
+  }, 120_000);
 });

--- a/worker/test/next-mention.spec.ts
+++ b/worker/test/next-mention.spec.ts
@@ -3,7 +3,9 @@
 // 存在的理由在 CLI 那侧：codex 的 Stop hook 只有 ~10s 预算，又没有 serve/watch 落下的本地欠账
 // 可读（它存在的意义正是顶替那条通道）。所以它需要一次极便宜、只回指针的问询；正文仍旧走
 // /messages，本端点一个字的正文都不回。
+import { env, runInDurableObject } from "cloudflare:test";
 import { describe, expect, it } from "vitest";
+import type { ChannelDO } from "../src/do";
 import { api, createChannel, seedToken } from "./helpers";
 
 async function send(
@@ -90,5 +92,120 @@ describe("next-mention (#903)", () => {
     const agent = await seedToken("agent");
     const res = await api("/api/channels/no-such-channel-903/next-mention?since=0", agent.token);
     expect(res.status).toBe(404);
+  });
+});
+
+// #913：这个端点的存在前提是「便宜到 codex Stop hook 每轮结束都能问一次」。原实现用
+// `seq > since AND (mentions_json LIKE ? OR delivery_targets_json LIKE ?)` 扫 messages——LIMIT 封的是
+// 命中行数不是扫描行数，**零命中时必须扫完 since 之后每一行**才能确定「没有」。游标新鲜时窗口只有
+// 几条，游标陈旧时（新身份 cursor=0，正是 #870 的形态）代价与频道长度同阶。
+//
+// 响应体里看不出扫了 1900 行还是 0 行，所以这里断言的是 DO 记下的真实读行数：同一场景把频道拉长
+// 一个数量级，读行数不许跟着涨。退回 LIKE 全扫实现，长频道那次会读满整段，本用例立刻红。
+describe("next-mention 扫描代价 (#913)", () => {
+  // 造「长频道 + 零命中」：频道里全是 @ 别人的消息（索引非空、LIKE 也有得扫），
+  // 问的人自己一次都没被 @ 过，since=0 —— 陈旧游标的极端形态。
+  async function seedNoisyChannel(length: number) {
+    const human = await seedToken("human");
+    const noisy = await seedToken("agent");
+    const bystander = await seedToken("agent");
+    const slug = await createChannel(human.token);
+    const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+    for (let i = 0; i < length; i += 1) {
+      // 造长频道要绕开每分钟 30 条的发送限速——清的是限速账本，消息本身仍旧走真实的
+      // POST /messages → storeMessage 路径（索引也就必须是那条路径自己维护出来的）。
+      if (i > 0 && i % 20 === 0) {
+        await runInDurableObject(stub, (_instance: ChannelDO, state) => {
+          state.storage.sql.exec("DELETE FROM rate");
+        });
+      }
+      await send(slug, human.token, `@${noisy.name} 第 ${i} 条`, [noisy.name]);
+    }
+    return { slug, human, noisy, bystander };
+  }
+
+  function rowsRead(slug: string): Promise<number> {
+    const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+    return runInDurableObject(stub, (instance: ChannelDO) => instance.nextMentionRowsRead);
+  }
+
+  it("零命中 + since=0：读行数不随频道长度增长", async () => {
+    const short = await seedNoisyChannel(20);
+    const long = await seedNoisyChannel(200);
+
+    // 正控：消息真的存进去了、那些 @ 也真的查得到——否则「读行数小」可能只是因为频道是空的，
+    // 被测的那道闸根本没被考到。
+    expect(await nextMention(short.slug, short.noisy.token, 0)).toBe(1);
+    expect(await nextMention(long.slug, long.noisy.token, 0)).toBe(1);
+    const history = await api(`/api/channels/${long.slug}/messages?limit=1000`, long.human.token);
+    expect(((await history.json()) as { messages: unknown[] }).messages.length).toBe(200);
+
+    expect(await nextMention(short.slug, short.bystander.token, 0)).toBeNull();
+    const shortRows = await rowsRead(short.slug);
+    expect(await nextMention(long.slug, long.bystander.token, 0)).toBeNull();
+    const longRows = await rowsRead(long.slug);
+
+    // 频道长了 10 倍，读行数不许跟着长。全扫实现这里会是 20 vs 200。
+    expect(longRows).toBeLessThanOrEqual(shortRows + 2);
+    // 且绝对值必须是常数级，不是「涨得慢一点」。
+    expect(longRows).toBeLessThanOrEqual(4);
+  });
+
+  it("命中时的读行数只跟命中位置有关，不跟 since 到命中点的距离有关", async () => {
+    const { slug, human, noisy, bystander } = await seedNoisyChannel(200);
+    const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+    await runInDurableObject(stub, (_instance: ChannelDO, state) => {
+      state.storage.sql.exec("DELETE FROM rate");
+    });
+    // 在长频道最末尾补一条 @ bystander 的：命中点在 201，since=0 的距离是满的。
+    const target = await send(slug, human.token, `@${bystander.name} 轮到你`, [bystander.name]);
+    expect(target).toBe(201);
+
+    expect(await nextMention(slug, bystander.token, 0)).toBe(target);
+    // 索引直接定位到那一条；全扫实现要走完前面 200 行才够得到它。
+    expect(await rowsRead(slug)).toBeLessThanOrEqual(4);
+    // 同一频道里被 @ 了 200 次的那位，仍旧拿到最早的那条（LIMIT 语义没被换掉）。
+    expect(await nextMention(slug, noisy.token, 0)).toBe(1);
+  });
+
+  // 索引是查询的唯一预筛，所以**存量频道**必须被回填——线上那些早于本次发布的消息一条都不能查不到。
+  // 这里把索引连同回填标记一起抹掉（模拟「升级前就存在的频道」），再重跑 onStart。
+  it("存量消息由 onStart 回填进索引，升级前发的 @ 一样查得到", async () => {
+    const human = await seedToken("human");
+    const agent = await seedToken("agent");
+    const slug = await createChannel(human.token);
+    await send(slug, human.token, "开场白");
+    const mention = await send(slug, human.token, `@${agent.name} 老消息里的 @`, [agent.name]);
+
+    const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+    await runInDurableObject(stub, (_instance: ChannelDO, state) => {
+      state.storage.sql.exec("DELETE FROM message_mentions");
+      state.storage.sql.exec("DELETE FROM meta WHERE key = 'mention_index_v1'");
+    });
+    // 没有索引就查不到——这正是回填要补的洞，先把洞晾出来，免得后面的绿是白来的。
+    expect(await nextMention(slug, agent.token, 0)).toBeNull();
+
+    await runInDurableObject(stub, (instance: ChannelDO) => instance.onStart());
+    expect(await nextMention(slug, agent.token, 0)).toBe(mention);
+    // 回填是一次性的：标记落了，重复 hydrate 不再扫全表，也不会把索引扫坏。
+    await runInDurableObject(stub, (instance: ChannelDO) => instance.onStart());
+    expect(await nextMention(slug, agent.token, 0)).toBe(mention);
+  });
+
+  // 编辑是除 INSERT 之外唯一能**新增** @ 的路径。漏同步它 = 被新 @ 到的人这次唤醒直接查不到。
+  it("编辑新增的 @ 立刻可查", async () => {
+    const human = await seedToken("human");
+    const agent = await seedToken("agent");
+    const slug = await createChannel(human.token);
+    const seq = await send(slug, human.token, "先不 @ 任何人");
+    expect(await nextMention(slug, agent.token, 0)).toBeNull();
+
+    const res = await api(`/api/channels/${slug}/messages/${seq}/edit`, human.token, {
+      method: "POST",
+      body: JSON.stringify({ body: `@${agent.name} 补 @ 你一下` }),
+    });
+    expect(res.status).toBe(200);
+
+    expect(await nextMention(slug, agent.token, 0)).toBe(seq);
   });
 });


### PR DESCRIPTION
Closes #913
Closes #892

两个互不相干的修复。共同点是「看起来没事」——一个是每轮 turn 都在付的隐性代价，一个是通过的 preflight 加一条被吞掉的 @。

---

## #913：next-mention 在游标陈旧时全量扫描

`GET /api/channels/:slug/next-mention?since=N` 是 codex Stop hook **每次 turn 结束都要调**的信号源。原实现：

```sql
SELECT seq, mentions_json, delivery_targets_json FROM messages
 WHERE seq > ? AND sender_name <> ?
   AND (mentions_json LIKE ? OR delivery_targets_json LIKE ?)
 ORDER BY seq LIMIT 200
```

`LIMIT 200` 封的是**命中行数**，不是扫描行数。零命中时 SQLite 仍要扫完 `since` 之后的每一行才能确定「没有」。游标新鲜时窗口只有几条；游标陈旧时（新身份 cursor=0，正是 #870 的形态）代价与频道长度同阶。

### 做法

DO 内建 SQLite 新增一张 @ 倒排表（**不需要 `worker/migrations/` 迁移文件**——`messages` 一族都在 `ctx.storage.sql` 里，同 `idempotency_key` 等列的既有做法，用 `CREATE TABLE IF NOT EXISTS` + meta 标记回填）：

```sql
CREATE TABLE IF NOT EXISTS message_mentions (
  match_key TEXT NOT NULL,
  seq INTEGER NOT NULL,
  PRIMARY KEY (match_key, seq)
)
```

读路径改成 `match_key = ? AND seq > ?` 的索引探针 + 回 `messages` 逐行核验。

**索引对每条消息都是精确的**（初版这里写的是「只保证是超集 + 回表核验 ⇒ 永不误报」，被 CodeRabbit 推翻——超集只在**不设上限**时才等价于安全，更正论证见下方 Round 2 第 2 条），这是这版设计的关键：命中候选仍旧回 `messages` 用 `mentionMatchKey` 逐条核，但核验只是防御性的第二道闸，不是承重墙。四处写路径全部同步：四个 `INSERT INTO messages`（`handleSend` / `insertSystemStatus` / `insertReviewerReply` / `insertDecisionResponse`）各自入索引；edit **先删后建**（取的是**刚落库的那一行**而不是入参，索引与存储读同一个事实）；撤回/擦除删该 seq 的行；裁剪删孤儿行。另有一条**源码守卫**钉死「写 mentions_json 的 INSERT 后必须紧跟 indexMessageMentions」，杜绝下一处直写路径再漏。

存量频道由 `onStart` 一次性回填（分页 + `transactionSync`，中途抛异常整体回滚、meta 不落、下次 hydrate 重来）。回填**放在 onStart 末尾**：前面那些一次性迁移（legacy `delivery_targets_json` 补写、`retract_scrub_*`）会改写 mentions/targets，必须等它们定型。

结果语义与 limit 行为不变。唯一的差别是变**更正确**了：LIKE 预筛的 200 条候选可能全是假阳性（名字作为子串命中别人的 mentions），旧实现那时会漏掉第 201 条真 @；索引预筛没有这个洞。

### 扫描量前后对照（`worker/test/next-mention.spec.ts`，`SqlStorageCursor.rowsRead` 实测）

| 场景 | 改动前 | 改动后 |
|---|---|---|
| 零命中，20 条消息的频道，since=0 | 20 | **1** |
| 零命中，200 条消息的频道，since=0 | 200 | **1** |
| 命中在第 201 条，since=0 | 201 | **2** |

改动前的数字来自把查询整段换回 LIKE 版跑同一组用例（见下方变异验证）。按报告里 ~1900 条消息的频道推算，零命中一轮从扫 1900 行 + 两列 JSON LIKE 降到一次 B 树探针。

### 顺带评估：要不要加 TTL 缓存 / 按身份记「上次扫到哪」

**都不要。**

- 短 TTL 缓存：代价换来的是新鲜度。这条链上缓存住一个 `null`，就是让一条已经到达的 @ 在 TTL 内叫不醒人——正好是 #870/#922 反复在修的那类静默失败。索引化之后零命中已经是一次探针，缓存省不下什么，却把「可能漏唤醒」重新引进来。
- 按身份记「上次扫到哪」：那是把游标复制一份放在服务端，两份游标一旦漂移就是同一类漏唤醒；而且 #922 刚把调用侧的 `since` 改成「跳过已注入过的 seq」，服务端再自作主张记一个水位会直接和它打架。

### 观测点

`ChannelDO.nextMentionRowsRead` 记下上一次查询真实读到的行数。这个端点唯一的存在前提是「便宜到每轮 turn 都能问一次」，而响应体里看不出扫了 1900 行还是 0 行——护栏用例断言的就是它。

---

## #892：preflight 报成功，首次唤醒却被判终局失败

三处修正。**结论先说：`codex_skill_load` 落在一个新档——「模型确定没跑 + 用户改个文件就能修好」——不结算、不推游标、终局停机等人修；`#690/#748` 的判据与终局语义一个字没动。**

### 1（最要紧的）诊断摘要交出的不是触发判定的那一行

报告里的 runner log 是 `env_failure=true`，展示的诊断却是：

```
Reading additional input from stdin... ERROR ... failed to load skill <path>: missing YAML frontmatter ...
```

这段文字与 `RUNNER_ENV_FAILURE_PATTERNS` 里的**任何一条都不匹配**（逐条比过：oauth/expired/authenticate/401/unauthorized/command not found/ENOENT/permission denied，一条都不沾）。也就是说：**触发 `env_failure=true` 的那条指纹，根本不在展示出来的诊断里**——因为 `runnerDiagnosticExcerpt` 一直取 stderr 的**开头**，而 codex 先吐 skill/启动噪声，真因排在后面。报的人照着展示的原因去改 SKILL.md，当然改不好。

现在：判定命中时，诊断交出**命中的那一行**。所有指纹都是行内模式，逐行扫与整串扫命中集合一致。

### 2 codex skill/config 加载失败单独成档

在此之前它落进「exit-1，模型可能跑过」那一档，通告挂着 `not retriable: model may have run` 的免责标签被终局结算——而实情是模型一步都没起，且用户把那个文件删掉/补上 frontmatter 就好。

新档的处置：**响亮宣告 + 不结算 delivery + 不推游标 + 终局停机（`EXIT_RUNNER_UNAVAILABLE`）**。理由是「把一条模型从没看见的 @ 结算掉，等于用户改好文件之后还得回去求发送方重发一遍」。留在服务端的那条 @ 由租约过期/重连重放交给修好后的 serve；落盘的欠账带 `retriable: true`（模型确实没跑，重放是安全的），人修好重启后会真的被重放而不是直接判死。终局退出而不是原地空转，也顺带堵掉「supervisor 自动重启 → 撞同一堵墙 → 再重启」的循环。

**取舍写清楚：**
- **判定顺序：环境指纹优先。** 只有在没有任何环境指纹命中时，skill 加载失败才是这次非零退出最好的解释。一条恰好同时出现的 skill 噪声不能改写凭据过期那类的处置（有用例钉住）。
- **为什么不把整个 environment 档都改成不结算。** #690 把它判终局是有理由的：凭据过期在修好之前重试都是白烧，而且旧凭据可能已经换了人。这次只新增一档窄的，不动既有判据。
- **误判方向是安全的。** 万一 codex 因别的原因退出而 stderr 里恰好带一行 skill 加载失败，后果是这条 @ 不被消费 + serve 响亮停机——消息保住、人看得见，而不是静默丢。
- **为什么不加本地 SKILL.md 体检当启动闸。** 实测 codex 0.145.0 对畸形嵌套 SKILL.md 是**跳过并继续**的。自己复刻一套发现规则去拦，等于用假阳性把一套本来能跑的环境挡在门外，比病本身更糟。

### 3 preflight 不再声称 ready

issue 说「要么覆盖到会导致失败的同一条路径，要么别声称 ready」。**真机逐个验过（codex-cli 0.145.0，隔离 HOME + CODEX_HOME，嵌套 `knowledge-base/SKILL.md` 无 frontmatter，照抄报告里的 `~/.agents/skills` 布局）：没有免模型的路径能覆盖它。**

| 命令 | 结果 |
|---|---|
| `codex login status` | 只看凭据，畸形 SKILL.md 完全不可见 |
| `codex doctor --json` | 18 项检查（auth/config/network/sandbox/state/…），**没有 skills 这一项**；畸形文件在场时也不报它 |
| `codex debug prompt-input` | 确实走 skill 发现（输出里能看到已加载的 skill 列表），但对畸形文件静默跳过——exit 0、stderr 空，`RUST_LOG=error`/`info` 都不吐那行 ERROR |
| `codex exec` | 唯一会打印 `failed to load skill ...` 的，而它就是要起模型的那条命令 |

所以只能诚实报账：runner log 从 `exit=0 ready=true` 改成 `exit=0 verified=auth,binary unverified=config,skills`。`ready=true` 是这条检查没有资格下的结论——它正是报告里被 quote 的那一行。哪天 codex 提供免模型校验模式，把它加进来、把 `unverified` 缩小即可（判据写在代码注释里，省得下一个人重做一遍调研）。

真机验证遵守 CONTRIBUTING「真机验证纪律」：临时 HOME/CODEX_HOME + 一次性 shell 脚本，不碰 owner 的 `~/.codex`、`~/.agents/skills` 与任何在跑的会话，全程无 GUI 模拟输入。

---

## 变异验证

每处修复都做了**整段删除级变异**（确认对应断言真变红）与**等价实现替换**（确认不误红）。

### #913

| 变异 | 结果 |
|---|---|
| 查询整段换回 LIKE 全扫 | 🔴 `expected 200 to be less than or equal to 22` / `expected 201 to be less than or equal to 8`（原有 5 条语义用例仍绿——说明代价护栏钉的确实是代价，不是语义） |
| 删掉 INSERT 路径的索引同步 | 🔴 4 条红（含原有的 #903 语义用例） |
| 删掉 edit 路径的索引同步 | 🔴「编辑新增的 @ 立刻可查」 |
| 删掉 onStart 回填整段 | 🔴「存量消息由 onStart 回填进索引」 |
| 等价替换：JOIN 改写成 `seq IN (SELECT …)` 子查询 | 🟢 9/9 |

### #892

| 变异 | 结果 |
|---|---|
| 删掉 `configFailure` 抛出整段 | 🔴「只有 skill 加载失败时：不结算、不推游标、终局停机」 |
| 删掉 wake 循环里的 hold 分支整段 | 🔴 同上 |
| 删掉诊断里的 evidence 查找 | 🔴「诊断摘要交出命中判定的那一行」 |
| preflight 日志退回 `ready=true` | 🔴「startup preflight 不再声称 ready」 |
| 等价替换：`runnerEnvFailureEvidence` 用 `find` 重写 | 🟢 44/44 |
| 等价替换：hold 闸条件改成直接看 `e.configuration` | 🟢 44/44 |

### 给守卫自己做的变异

提醒过的假绿形态是「fixture 让另一个分支单独满足条件，把被测的闸整个遮住」。两处都配了**正控**，确保只有被测的闸能决定结果：

- **#913 代价护栏**：断言「读行数小」之前先证明频道**不是空的**——两个频道各自的被 @ 者都能查到第 1 条，长频道 history 恰好 200 条。没有这条，「读行数小」可能只是因为没消息可扫，退回 LIKE 实现照样绿。
- **#892 hold 用例**：配一条对照组，**同一夹具、同一条 @**，只把 stderr 从带 skill 加载失败换成普通模型失败 → 照旧结算、游标推到 1、通告说 `giving up`。没有这条，「游标没动」可能只是因为这条 @ 压根没被唤醒过。

没有用 `nextOfType` 之类「读到某类帧就停」的辅助做屏障。

## 检查

- `bun run check:worker`：111 files / 850 tests 全绿 + `tsc --noEmit`
- `bun run check:cli`：6 shard 全绿（401 tests）+ `tsc --noEmit`
- 基于 `origin/main` 47baa55（含 #925 #927 #928）rebase 后重跑

---

# Round 2：CodeRabbit 三条 finding，**全部属实**，两条是本 PR 引入的漏唤醒回归

漏唤醒是这条链上最危险的方向，逐条给结论 + 依据。

## 1️⃣ 其它直写 `messages` 的路径没维护索引 —— 属实，**回归**

`worker/src/do.ts` 有 **4 处** `INSERT INTO messages`，初版只在 `handleSend`（:8939）接了 `indexMessageMentions`。另外三处都写 `mentions_json`：

| 位置 | 写的是什么 | 谁会因此叫不醒 |
|---|---|---|
| `insertSystemStatus` | `options.mentions ?? []` | workflow guard 熔断时被 @ 的发起人 / host |
| `insertReviewerReply` | `mentions`（签名里就带） | **审阅驳回时被 @ 的原作者**——他正等着去改 |
| `insertDecisionResponse` | `mentions` | 决策回应反指的提问方 |

改成索引探针之后这三类里的 @ **从此查不到**；改之前 LIKE 全扫是找得到的。**是本 PR 引入的回归。**

**修**：三处各补一行 `indexMessageMentions`。

**并且加了一条源码守卫**——靠人眼数 INSERT 是靠不住的（初版就漏了三处）：遍历 `do.ts` 里全部 `INSERT INTO messages`，只要该语句写了 `mentions_json`，其后必须紧跟 `indexMessageMentions`；INSERT 总数也一并钉死。将来任何人新增第五处直写路径，这里立刻红，而不是等某个 agent 神秘地叫不醒。（workers 运行时读不到宿主文件系统，源码文本走 vite `?raw` 在构建期嵌入。）

**漏唤醒方向的行为用例**：走真实端点做一次审阅驳回，断言 `next-mention` 查得到那条 `@原作者` 的回复。驳回**之前**先断言原作者「无待处理 @」——把闸前状态钉死，免得那句「查得到」是别的东西凑出来的。

## 2️⃣ 编辑移除 @ 留下陈旧索引行 + 候选上限 ⇒ 挤掉真 @ —— 属实，**回归**

这条直接推翻了初版 PR body 里的安全论证。**更正如下：**

> ~~索引只保证是超集，回表核验 ⇒ 漏同步只会多读一行，永远不会误报一次唤醒~~
>
> **「超集 + 回表核验」只在「候选不设上限」时才等价于安全。** 候选是有上限的（`NEXT_MENTION_SCAN_LIMIT = 200`），陈旧行会**吃掉候选预算**：同一个 key 攒够 200 条陈旧行，排在它们后面的真 @ 就落在候选窗口外，核验根本轮不到它 ⇒ 漏唤醒。
>
> **修正后的不变式：索引必须对每条消息都是精确的（不是超集）。** 四条产生陈旧行的路径全部堵死：编辑 → 先删该 seq 的旧行再按落库后的行重建；撤回/擦除 → 删该 seq 的行；裁剪 → 删孤儿行。核验保留，但它的职责降级为「防御同一事务外的异常」，不再是安全论证的承重墙。

**漏唤醒方向的用例**：造满**整整一个候选窗口**（200 条）「曾经 @ 过、后来被编辑掉」的消息，再发一条真的 @，断言查得到。凑不满窗口的夹具证明不了任何事，所以这条用例的 120s 预算是它的固有成本。夹具里被 @ 的是**人类**——agent 的 @ 会落成 directed delivery，而已路由的目标按设计**不允许**被编辑掉（必须撤回/supersede），只有非路由 @ 才能制造陈旧行。填满窗口后先断言 `null`（证明编辑真的把 @ 拿掉了），再发真 @——不然「查得到」可能只是因为陈旧行本身仍是有效命中，被测的闸被遮住。

## 3️⃣ skill 加载错误行里的 ENOENT 被判成环境失败 —— 属实

`RUNNER_ENV_FAILURE_PATTERNS` 含 `/no such file or directory/i`（「二进制缺失」指纹）。而 #892 报告里的全局 skills 目录挂着一个**指向共享 skill 树的符号链接**——断链时 codex 打的正是：

```
ERROR codex_core::session::session: failed to load skill /Users/dev/.agents/skills/shared/SKILL.md: No such file or directory (os error 2)
```

这一行自己就命中 ENOENT ⇒ `envFailure=true` ⇒ 新加的配置档在**「文件缺失」这个最常见形态下恒不生效**，@ 照样被终局结算，还对着用户显示 credentials/binary/sandbox 的通用修法。判定顺序「环境优先」本身没错，错的是**判定用的输入**。

**修**：判环境（以及取展示证据）之前，先摘掉 `failed to load skill` 那几行。只摘这几行——其它行里的认证/二进制错照旧优先，`#690/#748` 的判据一个字没动。展示与判定用**同一份输入**，否则又是一次「展示的原因不是触发的原因」（正是本 PR 修的第 1 类问题）。

**用例**：先断言这行**确实**命中 ENOENT 指纹（这正是需要摘行的理由），再断言整条 wake 落配置档——不结算、游标不动、退出 13、通告带路径。

---

## Round 2 变异验证

| 变异 | 结果 |
|---|---|
| 整段删除 `insertReviewerReply` 的索引同步 | 🔴「审阅驳回回复里的 @ 能被 next-mention 查到」 |
| 整段删除 `insertDecisionResponse` 的索引同步 | 🔴 源码守卫 |
| 整段删除 `insertSystemStatus` 的索引同步 | 🔴 源码守卫 |
| 整段删除编辑路径的先删后建（退回只追加） | 🔴「编辑移除 @ 后，排在陈旧行之后的真 @ 仍然查得到」 |
| 整段删除「判环境前摘掉 skill 行」 | 🔴 CLI 45 条里 1 条红 |
| 等价替换：摘行改成正则整体替换 | 🟢 45/45 |
| 等价替换：源码守卫的 INSERT 匹配换写法 | 🟢 |

## Round 2 检查

- `bun run check:worker`：111 files / **853** tests 全绿 + `tsc --noEmit`
- `bun run check:cli`：6 shard 全绿 + `tsc --noEmit`
