### PR TITLE
fix(cli): 任务租约认得出 harness 那条腿，没落闸时不再静默 (#931)

### DIFF
--- a/cli/src/commands/doctor.ts
+++ b/cli/src/commands/doctor.ts
@@ -10,6 +10,14 @@ import { fetchMe, fetchPresence, fetchRuntimePeers, type Identity } from "../res
 import { buildRuntimeTopology } from "../runtime-topology";
 import { INSTALL_LINE, OWNER_REPO, RUNNING_VERSION, compareVersions, pendingUpgrade } from "../upgrade";
 import { diagnoseCodexWake, formatCodexWakeDiagnosis } from "../wake-diagnosis";
+import {
+  diagnoseTaskLeaseEnforcement,
+  formatTaskLeaseEnforcement,
+  localExecutorEvidence,
+  shouldSurfaceTaskLeaseEnforcement,
+  type LocalExecutorEvidence,
+  type TaskLeaseEnforcement,
+} from "../task-lease-diagnosis";
 
 const CLAUDE_PLUGIN_ID = "agentparty@agentparty";
 const CLAUDE_PLUGIN_SCHEMA = "agentparty.claude-plugin-doctor.v1";
@@ -477,6 +485,44 @@ async function latestVersion(): Promise<string | null> {
   }
 }
 
+/**
+ * 任务租约那一段（#931）。**纯本地、不发网络**：doctor 在断网/没登录时也必须能跑。
+ *
+ * 「存在多执行体拓扑」的判据取本机可核实的证据（活着的 serve/watch 实例锁、别的执行体持着的
+ * 未过期任务租约），而不是服务端的 topology_conflicts——后者要网络与鉴权，doctor 拿不到就
+ * 只能沉默，那又回到了本 issue 要根除的静默。代价是：另一条腿在**另一台机器**上时本机看不见，
+ * 那正是 #931 的跨机缺口，输出里的「边界」那行会把它说出来。
+ */
+export async function taskLeaseDoctorLines(
+  deps: {
+    auth?: () => Promise<{ server?: string; token?: string }>;
+    channel?: () => string | null;
+    enforcement?: TaskLeaseEnforcement;
+    evidence?: LocalExecutorEvidence;
+  } = {},
+): Promise<string[]> {
+  try {
+    const enforcement = deps.enforcement ?? diagnoseTaskLeaseEnforcement();
+    let evidence = deps.evidence;
+    if (evidence === undefined) {
+      const auth = await (deps.auth ?? resolveAuthDetailed)();
+      const channel = (deps.channel ?? (() => resolveChannel(undefined)))();
+      if (!auth.server || !auth.token || channel === null || channel === undefined || channel === "") return [];
+      evidence = localExecutorEvidence({
+        server: auth.server,
+        token: auth.token,
+        channel,
+        executorId: enforcement.executor_id,
+      });
+    }
+    if (!shouldSurfaceTaskLeaseEnforcement(enforcement, evidence.present)) return [];
+    return formatTaskLeaseEnforcement(enforcement, { evidence });
+  } catch {
+    // 诊断是附赠信息，绝不能把 doctor 本身弄挂。
+    return [];
+  }
+}
+
 async function runVersionDoctor(argv: string[]): Promise<number> {
   if (argv.length > 0) {
     console.error(HELP);
@@ -485,6 +531,9 @@ async function runVersionDoctor(argv: string[]): Promise<number> {
   // #924：先说「这台机器上被 @ 叫得醒吗」。版本信息永远查得到，而唤醒断了才是用户真正
   // 遇到的那个问题——此前它只在日志里留一行，等于静默。放最前面，一眼可见。
   for (const line of formatCodexWakeDiagnosis(diagnoseCodexWake())) console.log(line);
+  // #931：同理，「同一身份的第二个执行体会不会被拦住」也曾只在 stderr 有一行 warn。
+  // 只在**真有第二个执行体**时报（无冲突不报，避免每次 doctor 都多一条无关噪音）。
+  for (const line of await taskLeaseDoctorLines()) console.log(line);
   console.log("");
   console.log(`running:   ${RUNNING_VERSION}`);
   const pending = pendingUpgrade();

--- a/cli/src/commands/status.ts
+++ b/cli/src/commands/status.ts
@@ -17,11 +17,11 @@ import {
   describeDeniedLease,
   DEFAULT_TASK_LEASE_TTL_MS,
   releaseTaskLease,
-  resolveExecutorId,
   taskLeaseDir,
   taskLeaseKey,
   type TaskLeaseResult,
 } from "../task-lease";
+import { diagnoseTaskLeaseEnforcement, formatTaskLeaseEnforcement } from "../task-lease-diagnosis";
 import { isHelpArg, parseArgs, str, strArray, unknownFlagError, valueFlagError } from "../args";
 import { advanceCursorPastOwnMessage, branchLabel, repoLabel, resolveChannel, workspaceId, workspaceLabel, worktreeLabel } from "../config";
 import { stripTerminalControls } from "../format";
@@ -386,11 +386,13 @@ export async function run(argv: string[]): Promise<number> {
     console.error(leaseTtl);
     return 1;
   }
-  const executorId = resolveExecutorId(process.env, {
+  const explicitExecutor = {
     ...(str(flags["executor-id"]) === undefined ? {} : { executorId: str(flags["executor-id"])! }),
     ...(sessionHarness === undefined ? {} : { sessionHarness }),
     ...(sessionId === undefined ? {} : { sessionId }),
-  });
+  };
+  const enforcement = diagnoseTaskLeaseEnforcement(process.env, { explicit: explicitExecutor });
+  const executorId = enforcement.executor_id;
   const asJson = flags.json === true;
   const leaseNow = Date.now();
   let lease: TaskLeaseResult | null = null;
@@ -418,17 +420,25 @@ export async function run(argv: string[]): Promise<number> {
           published: false,
           task_untouched: true,
           exit_code: EXIT_TASK_LEASE_HELD,
-          lease: { state: lease.state, reason: lease.reason, holder: lease.holder },
+          lease: { state: lease.state, reason: lease.reason, holder: lease.holder, enforced: true, scope: "local_home" },
         }));
       }
       console.error(describeDeniedLease(lease.holder, channel, taskId, leaseNow));
       return EXIT_TASK_LEASE_HELD;
     }
     if (lease.state === "unenforced") {
-      console.error(
-        "warn: task lease not enforced — this process has no stable execution-runtime identity. " +
-          "Set AGENTPARTY_EXECUTOR_ID (or pass --executor-id) so a second runtime of this identity can be refused (#834).",
-      );
+      // #931：这里原本只有一行 warn，在刷屏的 serve 日志里等于不存在——闸看着装了，最需要它的
+      // 那条腿从来没被拦过，而且没人被告知。改成和 wake-diagnosis 同一口径：为什么 + 会怎样 +
+      // 一条能粘贴的命令，并说清「本机互斥 ≠ 跨机互斥」。
+      console.error("warn: task lease not enforced (#834 #931)");
+      const detail = lease.reason === "lease_store_unwritable"
+        ? [
+            `  为什么: 租约目录写不进去（${taskLeaseDir()}）——认得出执行体也落不了盘`,
+            `  会怎样: ${enforcement.consequence}`,
+            "  怎么修: 检查该目录的权限/磁盘（本命令照常执行，只是这一刀没落下）",
+          ]
+        : formatTaskLeaseEnforcement(enforcement).slice(1);
+      for (const line of detail) console.error(line);
     }
     if (lease.state === "forced" && lease.holder?.taken_over_from !== undefined) {
       console.error(`warn: took over the task lease from ${lease.holder.taken_over_from} (--force-lease)`);
@@ -481,7 +491,18 @@ export async function run(argv: string[]): Promise<number> {
         ...(taskId === undefined ? {} : { task: taskId }),
         ...(lease === null
           ? {}
-          : { lease: { state: lease.state, ...(lease.reason === undefined ? {} : { reason: lease.reason }), holder: lease.holder } }),
+          : {
+              lease: {
+                state: lease.state,
+                ...(lease.reason === undefined ? {} : { reason: lease.reason }),
+                holder: lease.holder,
+                // #931：「这一刀有没有落下」必须能被程序读到，而不是只在 stderr 打一行。
+                // 同时带上互斥边界——跨机同身份不在射程内，别让调用方把它当全局互斥。
+                enforced: lease.state !== "unenforced",
+                scope: "local_home",
+                ...(lease.state === "unenforced" ? { fix: enforcement.fix, detail: enforcement.detail } : {}),
+              },
+            }),
       }));
     } else {
       console.log(`status seq=${seq}`);

--- a/cli/src/commands/who.ts
+++ b/cli/src/commands/who.ts
@@ -4,6 +4,12 @@ import { autoWakeReachable, type AgentActivity, type ListeningVerdict, type Pres
 import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
 import { resolveChannel } from "../config";
 import { diagnoseCodexWake, formatCodexWakeDiagnosis, shouldSurfaceCodexWakeDiagnosis } from "../wake-diagnosis";
+import {
+  diagnoseTaskLeaseEnforcement,
+  formatTaskLeaseEnforcement,
+  shouldSurfaceTaskLeaseEnforcement,
+  type TaskLeaseEnforcement,
+} from "../task-lease-diagnosis";
 import { resolveAuth } from "../oidc-cli";
 import { fetchPresence, fetchReadCursors, fetchRuntimePeers, handleRestError } from "../rest";
 import { buildRuntimeTopology } from "../runtime-topology";
@@ -89,7 +95,7 @@ session name), so mention the "@handle" shown here — not a UUID session name.
 Options:
   --channel C   read channel C instead of the bound channel
   --json        emit one JSON object per line
-                (name/kind/tier/live/residency/unreachable/pull_wake/wake_guidance/wake/wake_unverified/busy/queue_depth/waiting_owner_count/unhandled_mention_count/oldest_unhandled_mention_seq/pending_mention_seqs/last_receipt_seq/not_in_turn_since/current_task/task_started_at/heartbeat_at/activity/listening/runner_health/agent_session/topology_conflicts/reception_mode/reception_runner/reception_context/scope/scope_conflicts/account/handle/display_name/age_ms/read_seq)`;
+                (name/kind/tier/live/residency/unreachable/pull_wake/wake_guidance/wake/wake_unverified/busy/queue_depth/waiting_owner_count/unhandled_mention_count/oldest_unhandled_mention_seq/pending_mention_seqs/last_receipt_seq/not_in_turn_since/current_task/task_started_at/heartbeat_at/activity/listening/runner_health/agent_session/topology_conflicts/task_lease/reception_mode/reception_runner/reception_context/scope/scope_conflicts/account/handle/display_name/age_ms/read_seq)`;
 
 // 导出仅供单测断言 help 文案与真实行为一致（#859/#860：文档漂移过一次，用断言钉住）。
 export const HELP_TEXT = HELP;
@@ -101,7 +107,7 @@ const SYSTEM_HUMAN_SESSION_RE =
   /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|login-verify-.+)$/i;
 
 type Tier = "online" | "wakeable" | "recent";
-interface Row {
+export interface Row {
   name: string;
   kind: SenderKind;
   tier: Tier;
@@ -173,6 +179,18 @@ interface Row {
     same_identity?: boolean;
     severity?: "blocking" | "advisory";
   }>;
+  // #931：只在 blocking 冲突（=自己这个身份还有别的执行体）的那一行上出现。判定说「并发认领会被
+  // 拒」是有前提的——那把闸只在**本机**、且**认得出执行体标识**时才落得下来。认不出时它是开的，
+  // 而此前唯一的告知是 `party status` 往 stderr 打的一行 warn（刷屏的 serve 日志里等于不存在）。
+  // 所以「这一刀有没有落下」必须和冲突本身出现在同一处，且可程序化判定。
+  task_lease?: {
+    enforced: boolean;
+    /** 互斥边界。跨机（含同机不同 AGENTPARTY_HOME）的同一身份挡不住——#931 缺口 1。 */
+    scope: "local_home";
+    executor_id?: string;
+    reason?: "no_signal" | "malformed";
+    fix?: string;
+  };
   // #817：无人值守时这个身份怎么接待 @——model runner 代答，还是 custom 命令。隔离接待意味着
   // 答话的会话不继承本人当前上下文，协作方在 @ 之前就该看见这一点。
   reception_mode?: ReceptionMode;
@@ -598,6 +616,34 @@ export function annotateTopologyConflicts(
   });
 }
 
+/**
+ * 把「本机这条腿的任务租约落没落闸」贴到**有 blocking 冲突的那些行**上（#931）。
+ *
+ * 只贴 blocking 行是刻意的：blocking ⇔ same_identity ⇔ 这一行说的就是「我自己还有别的执行体」。
+ * 别的行贴上去既没有意义，也会把噪音铺满整个 who。
+ */
+/** 这一行是不是「我自己还有别的执行体」——blocking ⇔ same_identity（#885）。 */
+export function hasBlockingConflict(row: Row): boolean {
+  return (row.topology_conflicts ?? []).some((conflict) => conflict.severity === "blocking");
+}
+
+export function annotateTaskLeaseEnforcement(rows: Row[], enforcement?: TaskLeaseEnforcement): Row[] {
+  if (enforcement === undefined) return rows;
+  return rows.map((row) => {
+    if (!hasBlockingConflict(row)) return row;
+    return {
+      ...row,
+      task_lease: {
+        enforced: enforcement.enforced,
+        scope: enforcement.scope,
+        ...(enforcement.executor_id === null ? {} : { executor_id: enforcement.executor_id }),
+        ...(enforcement.reason === null ? {} : { reason: enforcement.reason }),
+        ...(enforcement.fix === null ? {} : { fix: enforcement.fix }),
+      },
+    };
+  });
+}
+
 export function topologyNote(r: Row): string {
   const conflicts = r.topology_conflicts ?? [];
   if (conflicts.length === 0) return "";
@@ -606,8 +652,12 @@ export function topologyNote(r: Row): string {
     // 事故当天 `party who` 打的正是一条中性的 same_local_installation。
     if (conflict.severity === "blocking") {
       const where = conflict.kind === "same_identity_worktree" ? " share one worktree" : ` (${conflict.kind})`;
-      return ` · ⚠ ${conflict.runtime_count ?? 1} other live runtime(s) of this identity${where}` +
-        " — concurrent claims on one task are refused";
+      // #931:「会被拒」是有前提的。本机认不出执行体标识时那把闸根本没落下,这里再说「are refused」
+      // 就是在骗人——读的人以为有东西拦着,于是放心地让两个执行体一起干。判定不确定就别断言。
+      const verdict = r.task_lease?.enforced === false
+        ? " — ⚠ concurrent claims are NOT refused here: no execution-runtime identity on this machine (party doctor)"
+        : " — concurrent claims on one task are refused";
+      return ` · ⚠ ${conflict.runtime_count ?? 1} other live runtime(s) of this identity${where}${verdict}`;
     }
     const label = conflict.kind === "same_worktree"
       ? "⚠ same worktree as"
@@ -661,10 +711,12 @@ export function buildRows(
     cursorOf?: Map<string, number>;
     runtimePeers?: RuntimePeerDiscovery;
     pullWake?: PullWakeLookup;
+    /** #931：本机这条腿的任务租约判定。缺省＝不标注（老调用方行为不变）。 */
+    taskLease?: TaskLeaseEnforcement;
   },
 ): Row[] {
   const { now, channel } = ctx;
-  return annotateTopologyConflicts(
+  return annotateTaskLeaseEnforcement(annotateTopologyConflicts(
     annotateScopeConflicts(
       presence
         .map((e) => classify(e, now))
@@ -684,7 +736,7 @@ export function buildRows(
         }),
     ),
     ctx.runtimePeers,
-  ).sort((a, b) => RANK[a.tier] - RANK[b.tier] || a.name.localeCompare(b.name));
+  ), ctx.taskLease).sort((a, b) => RANK[a.tier] - RANK[b.tier] || a.name.localeCompare(b.name));
 }
 
 /** 单行终端渲染。抽出来让「哪些标注真的出现在行里」可断言（#879 之前只有 note 函数被单测覆盖）。 */
@@ -790,7 +842,14 @@ export async function run(argv: string[]): Promise<number> {
     } catch {
       pullWake = undefined;
     }
-    const rows = buildRows(presence, { now, channel, cursorOf, runtimePeers, pullWake });
+    // #931：本机这条腿的任务租约判定。纯本地、不发网络；失败即当作「不标注」，绝不弄挂 who。
+    let taskLease: TaskLeaseEnforcement | undefined;
+    try {
+      taskLease = diagnoseTaskLeaseEnforcement();
+    } catch {
+      taskLease = undefined;
+    }
+    const rows = buildRows(presence, { now, channel, cursorOf, runtimePeers, pullWake, ...(taskLease === undefined ? {} : { taskLease }) });
     if (flags.json === true) {
       for (const r of rows) console.log(JSON.stringify(r));
       return 0;
@@ -800,6 +859,12 @@ export async function run(argv: string[]): Promise<number> {
       return 0;
     }
     for (const r of rows) console.log(renderRow(r, now, lastSeq));
+    // #931：who 里出现了「这个身份还有别的执行体」，而本机那把闸没落下——这两件事必须放在一起
+    // 说出来。此前它只在 `party status` 的 stderr 里有一行 warn，而 who 那行还在断言「会被拒」。
+    if (taskLease !== undefined && shouldSurfaceTaskLeaseEnforcement(taskLease, rows.some(hasBlockingConflict))) {
+      console.log("");
+      for (const line of formatTaskLeaseEnforcement(taskLease)) console.log(line);
+    }
     // #924：谁在场是一回事，「@ 我叫不叫得醒我」是另一回事。此前后者只在日志里留一行，
     // 于是用户看到自己在 who 里好好地列着、却怎么都醒不过来。断了就在这里说出来。
     try {

--- a/cli/src/task-lease-diagnosis.ts
+++ b/cli/src/task-lease-diagnosis.ts
@@ -1,0 +1,224 @@
+// 「这台机器上这个身份的任务租约到底落没落闸」——issue #931。
+//
+// #885 给「同一身份多执行体并发」装了一道闸（认领时刻的单活跃执行体租约）。但那道闸有两个
+// 边界，实机上都会被踩到：
+//   1. 它只在**本机文件级**成立（`taskLeaseDir()` 在 `$AGENTPARTY_HOME` 下）。跨机同身份、
+//      甚至同机不同 AGENTPARTY_HOME，都挡不住。
+//   2. 认不出执行体标识时**静默降级**成 unenforced，只往 stderr 打一行 warn；而事故里的
+//      harness 那条腿恰恰最容易落进这一档（根因见 `resolveExecutorIdentity` 的注释）。
+// 于是「闸看起来装了，最需要它的场景下却是开的，而且没人被告知」——本仓反复出现的那个形态。
+//
+// 本模块只负责第 2 条的**可见性**：把判定结果做成可主动查询的东西（`party who` / `party doctor`
+// / `party status --json`），呈现口径照抄 #925/#926 的 wake-diagnosis：
+//   一行结论 → 为什么 → 会怎样 → 一条能直接粘贴的命令。
+// 第 1 条（跨机）不在本模块射程内，但**必须在输出里说出边界**，否则「本机互斥」会被读成
+// 「全局互斥」——那比没有闸更危险。
+//
+// 与 wake-diagnosis 同一条纪律：判定跑的是和真实行为**完全同一份**实现
+// （`resolveExecutorIdentity`），绝不写第二套「诊断专用」的解析逻辑，否则诊断说好、真跑起来坏。
+// 本模块纯读本地盘 + 至多几次进程存活探测，不发网络、不写任何东西。
+import {
+  EXECUTOR_ID_ENV_LADDER,
+  resolveExecutorIdentity,
+  taskLeaseDir,
+  taskLeaseIdentityPrefix,
+  type ExecutorIdRefusal,
+  type ExecutorIdSource,
+  type ResolveExecutorEnv,
+} from "./task-lease";
+import { agentpartyHome } from "./config";
+import { instanceLockHolderPid, instanceLockTarget, defaultInstanceLockDir } from "./instance-lock";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+export interface TaskLeaseEnforcement {
+  /** 这台机器上这条腿的认领能不能被租约判定。false = 第二个执行体不会被拒。 */
+  enforced: boolean;
+  executor_id: string | null;
+  source: ExecutorIdSource | null;
+  reason: ExecutorIdRefusal | null;
+  /** 为什么（人读）。 */
+  detail: string;
+  /** 会怎样（人读）。诊断只说事实没用，得说出后果，否则读的人不知道该不该停手。 */
+  consequence: string;
+  /** 一条能直接粘贴执行的命令；已落闸时为 null。 */
+  fix: string | null;
+  /** 互斥边界。跨机（含同机不同 AGENTPARTY_HOME）不在射程内——#931 缺口 1，尚未做服务端租约。 */
+  scope: "local_home";
+  home: string;
+}
+
+const SOURCE_LABEL: Record<ExecutorIdSource, string> = {
+  flag: "--executor-id",
+  env: "AGENTPARTY_EXECUTOR_ID",
+  runner: "AP_RUNNER_WORKDIR（serve 拉起的 runner）",
+  harness_session: "调用方传入的 harness 会话",
+  claude_session: "CLAUDE_CODE_SESSION_ID / CLAUDE_SESSION_ID",
+  codex_session: "CODEX_THREAD_ID",
+};
+
+/** 修法给的是**一条可粘贴的命令**，不是「请设置某某变量」这种无从执行的建议。 */
+export const TASK_LEASE_FIX_COMMAND =
+  'export AGENTPARTY_EXECUTOR_ID="harness:$(hostname -s):1"   # 每个执行体一个稳定且互不相同的值';
+
+export function diagnoseTaskLeaseEnforcement(
+  env: ResolveExecutorEnv = process.env,
+  opts: {
+    home?: string;
+    explicit?: { executorId?: string; sessionHarness?: string; sessionId?: string };
+  } = {},
+): TaskLeaseEnforcement {
+  const identity = resolveExecutorIdentity(env, opts.explicit);
+  const home = opts.home ?? agentpartyHome(env as NodeJS.ProcessEnv);
+  if (identity.id !== null && identity.source !== null) {
+    return {
+      enforced: true,
+      executor_id: identity.id,
+      source: identity.source,
+      reason: null,
+      detail: `执行体标识来自 ${SOURCE_LABEL[identity.source]}`,
+      consequence: "同一身份的第二个执行体认领同一个 task 会被拒（任务不动，降级只读）",
+      fix: null,
+      scope: "local_home",
+      home,
+    };
+  }
+  const detail = identity.refusal === "malformed"
+    ? `${identity.rejected.map((source) => SOURCE_LABEL[source]).join(" / ")} 设了，但值不合法` +
+      "（只允许 [A-Za-z0-9][A-Za-z0-9._:@-]{0,127}），丢弃后没有别的可用标识"
+    : `没有任何稳定标识在场（${EXECUTOR_ID_ENV_LADDER.join(" / ")} 一个都没设）`;
+  return {
+    enforced: false,
+    executor_id: null,
+    source: null,
+    reason: identity.refusal,
+    detail,
+    consequence:
+      "同一身份的第二个执行体认领同一个 task 时【不会被拒】——两个都会开工（#834 那次事故的形状）",
+    fix: TASK_LEASE_FIX_COMMAND,
+    scope: "local_home",
+    home,
+  };
+}
+
+/** 本机能看见的「另一个执行体」证据。纯本地，不发网络。 */
+export interface LocalExecutorEvidence {
+  /** 本机存在另一个执行体在服务这条 (server, token, channel)。 */
+  present: boolean;
+  /** 证据来源，供人读输出说清「凭什么这么判」。 */
+  kinds: ("serve" | "watch" | "task_lease")[];
+}
+
+function liveLeaseHolders(dir: string, prefix: string, now: number): string[] {
+  let entries: string[] = [];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return [];
+  }
+  const holders: string[] = [];
+  for (const entry of entries) {
+    if (!entry.startsWith(`${prefix}-`) || !entry.endsWith(".json")) continue;
+    try {
+      const parsed = JSON.parse(readFileSync(join(dir, entry), "utf8")) as {
+        executor_id?: unknown;
+        expires_at?: unknown;
+      };
+      if (typeof parsed.executor_id !== "string") continue;
+      if (typeof parsed.expires_at !== "number" || parsed.expires_at <= now) continue;
+      holders.push(parsed.executor_id);
+    } catch {
+      /* 半写/手改的租约文件不作为证据。 */
+    }
+  }
+  return holders;
+}
+
+/**
+ * 本机是否还有**另一个**执行体在这条 (server, token, channel) 上活着。
+ *
+ * 判定带 server 维度：`instanceLockTarget` / `taskLeaseIdentityPrefix` 都把 server 摁进摘要，
+ * 本机同时连两台生产实例、两边同名频道时不会互相误判（#865）。
+ *
+ * 证据本身是保守的：`instanceLockHolderPid` 只在**正向确认**持有者进程还活着（且 pid 没被
+ * 复用）时才返回 pid，租约只认未过期的那些。拿不准一律当作「没有」——诊断宁可少说一句，
+ * 也不能凭一个陈旧的锁文件把用户吓停手（#908 的教训）。
+ */
+export function localExecutorEvidence(opts: {
+  server: string;
+  token: string;
+  channel: string;
+  /** 本执行体自己的标识；同名的租约不算「另一个」。null（认不出）时任何活租约都算证据。 */
+  executorId: string | null;
+  lockDir?: string;
+  leaseDir?: string;
+  now?: number;
+  selfPid?: number;
+}): LocalExecutorEvidence {
+  const target = instanceLockTarget(opts.server, opts.token, opts.channel);
+  const lockDir = opts.lockDir ?? defaultInstanceLockDir();
+  const selfPid = opts.selfPid ?? process.pid;
+  const kinds: LocalExecutorEvidence["kinds"] = [];
+  for (const kind of ["serve", "watch"] as const) {
+    let pid: number | null = null;
+    try {
+      pid = instanceLockHolderPid(kind, target, lockDir);
+    } catch {
+      pid = null;
+    }
+    if (pid !== null && pid !== selfPid) kinds.push(kind);
+  }
+  const holders = liveLeaseHolders(
+    opts.leaseDir ?? taskLeaseDir(),
+    taskLeaseIdentityPrefix(opts.server, opts.token),
+    opts.now ?? Date.now(),
+  );
+  if (holders.some((holder) => holder !== opts.executorId)) kinds.push("task_lease");
+  return { present: kinds.length > 0, kinds };
+}
+
+/**
+ * 该不该主动把这段说出来。
+ *
+ * 判据是「**没落闸** 且 本机确实存在另一个执行体」——两个条件缺一不可：
+ *  - 落了闸就不用喊（enforced 时 who 仍可显示，但不作为问题上报）；
+ *  - 没有第二个执行体时喊，就是给每一次 `party doctor` 加一条与当下无关的噪音，
+ *    噪音多了真问题就被淹没——那是另一种静默。
+ */
+export function shouldSurfaceTaskLeaseEnforcement(
+  d: TaskLeaseEnforcement,
+  otherExecutorPresent: boolean,
+): boolean {
+  return !d.enforced && otherExecutorPresent;
+}
+
+/**
+ * 渲染成给人看的几行。照抄 wake-diagnosis 的口径：一行结论、为什么、会怎样、一条可执行命令。
+ * 最后一行永远说清**边界**——本机互斥不是全局互斥，别让人读成「跨机也拦得住」。
+ */
+export function formatTaskLeaseEnforcement(
+  d: TaskLeaseEnforcement,
+  ctx: { evidence?: LocalExecutorEvidence } = {},
+): string[] {
+  const out: string[] = [];
+  if (d.enforced) {
+    out.push(`task-lease: 这台机器上这个身份的任务认领【已落闸】（执行体 ${d.executor_id ?? ""}）`);
+    out.push(`  依据: ${d.detail}`);
+  } else {
+    out.push("task-lease: 这台机器上这个身份的任务认领【没落闸】");
+    out.push(`  为什么: ${d.detail}`);
+    out.push(`  会怎样: ${d.consequence}`);
+    out.push(`  怎么修: ${d.fix ?? ""}`);
+  }
+  const kinds = ctx.evidence?.kinds ?? [];
+  if (kinds.length > 0) {
+    const label = kinds
+      .map((kind) => (kind === "task_lease" ? "本机另有执行体持着这个身份的任务租约" : `本机有一个 party ${kind} 在跑`))
+      .join("；");
+    out.push(`  证据: ${label}——这个身份此刻确实不止一个执行体`);
+  }
+  out.push(
+    `  边界: 这把闸只在本机 ${d.home} 内互斥；另一台机器（或另一个 AGENTPARTY_HOME）上的同一身份仍挡不住（#931 跨机缺口，需服务端租约）`,
+  );
+  return out;
+}

--- a/cli/src/task-lease.ts
+++ b/cli/src/task-lease.ts
@@ -54,17 +54,30 @@ export interface TaskLeaseResult {
   /** denied 时是对方的租约；acquired/renewed/forced 时是本执行体自己的租约。 */
   holder?: TaskLeaseHolder;
   /** 被抢占/被接手/无法判定的原因，供 --json 与人读输出复用。 */
-  reason?: "no_executor_identity" | "expired" | "taken_over" | "held_by_other";
+  reason?:
+    | "no_executor_identity"
+    | "expired"
+    | "taken_over"
+    | "held_by_other"
+    /** 认得出执行体，但租约目录写不下去（只读盘 / 权限）——和「认不出」是两回事，别混报。 */
+    | "lease_store_unwritable";
 }
 
 export function taskLeaseDir(home: string = agentpartyHome()): string {
   return join(home, "task-leases");
 }
 
+/**
+ * (server, token) 的不可逆摘要。**必须带 server 维度**：同一台机器上可以连着两台生产实例，
+ * 两边都有同名频道（#865），只按 token 或只按频道去分租约会让两台实例互相阻塞或互相看不见。
+ */
+export function taskLeaseIdentityPrefix(server: string, token: string): string {
+  return createHash("sha256").update(server).update("\0").update(token).digest("hex").slice(0, 24);
+}
+
 /** token 只参与不可逆摘要，不落盘；不同 server/身份互不阻塞。 */
 export function taskLeaseKey(server: string, token: string, channel: string, taskId: number): string {
-  const identity = createHash("sha256").update(server).update("\0").update(token).digest("hex").slice(0, 24);
-  return `${identity}-${channel.replace(/[^a-z0-9-]/g, "_")}-task-${taskId}`;
+  return `${taskLeaseIdentityPrefix(server, token)}-${channel.replace(/[^a-z0-9-]/g, "_")}-task-${taskId}`;
 }
 
 function leasePath(dir: string, key: string): string {
@@ -87,38 +100,113 @@ export interface ResolveExecutorEnv {
   [key: string]: string | undefined;
 }
 
+/** 执行体标识的来源。诊断要能说出「凭什么认得出/为什么认不出」，所以来源必须是结构化的。 */
+export type ExecutorIdSource =
+  /** --executor-id */
+  | "flag"
+  /** AGENTPARTY_EXECUTOR_ID */
+  | "env"
+  /** AP_RUNNER_WORKDIR（serve 内建 runner 注入） */
+  | "runner"
+  /** 调用方显式传入的 harness 会话（--agent-session 等） */
+  | "harness_session"
+  /** CLAUDE_CODE_SESSION_ID / CLAUDE_SESSION_ID */
+  | "claude_session"
+  /** CODEX_THREAD_ID */
+  | "codex_session";
+
+/** 认不出执行体时的原因码。「一个都没有」和「设了但设错了」得分开说，修法完全不同。 */
+export type ExecutorIdRefusal = "no_signal" | "malformed";
+
+export interface ExecutorIdentity {
+  /** 认得出时的稳定标识；认不出为 null。 */
+  id: string | null;
+  source: ExecutorIdSource | null;
+  refusal: ExecutorIdRefusal | null;
+  /** 在场但被判非法、因此被丢弃的来源。用来说「你设了 X，但值不合法」。 */
+  rejected: ExecutorIdSource[];
+}
+
+/** 诊断文案里要逐字列出的环境变量名。写在一处，免得实现改了、提示还在教旧变量名。 */
+export const EXECUTOR_ID_ENV_LADDER = [
+  "AGENTPARTY_EXECUTOR_ID",
+  "AP_RUNNER_WORKDIR",
+  "CLAUDE_CODE_SESSION_ID",
+  "CLAUDE_SESSION_ID",
+  "CODEX_THREAD_ID",
+] as const;
+
 /**
- * 解析「当前执行体」的稳定身份。
+ * 解析「当前执行体」的稳定身份，并**说得出**结论是怎么来的。
  *
- * 顺序刻意从最显式排到最隐式。**最后没有兜底**：识别不出来就返回 null，调用方按 unenforced
+ * 顺序刻意从最显式排到最隐式。**最后没有兜底**：识别不出来就 id=null，调用方按 unenforced
  * 处理。宁可明说「这一刀没落下」，也不要靠一个不稳定的推断（比如 ppid——Claude Code 每次
  * Bash 调用的父进程都不同，会让同一个 harness 会话把自己上一次的租约当成别人的而自锁）去
  * 制造一个看着像 enforcement 的假象。
+ *
+ * #931 的根因就在这条梯子上：真实的 Claude Code（2.1.x 实测）注入的是 **`CLAUDE_CODE_SESSION_ID`**，
+ * 而这里原本只读 `CLAUDE_SESSION_ID`——一个 Claude Code 从不设置的名字。于是事故里那条 harness
+ * 腿每一次都掉到梯子底部，恒定 unenforced：闸看着装了，最需要它的那条腿从来没被拦过。
+ * 两个名字都留着：`CLAUDE_SESSION_ID` 仍是 serve/包装脚本可能注入的形态，去掉它等于砍掉一条
+ * 已经在用的识别路径。
  */
+export function resolveExecutorIdentity(
+  env: ResolveExecutorEnv = process.env,
+  explicit?: { executorId?: string; sessionHarness?: string; sessionId?: string },
+): ExecutorIdentity {
+  const candidates: { source: ExecutorIdSource; value: string | undefined }[] = [
+    { source: "flag", value: explicit?.executorId },
+    { source: "env", value: env.AGENTPARTY_EXECUTOR_ID },
+    // serve 内建 runner 已经在给子进程注入这两个（见 serve.ts 的 AP_RUNNER_* 块）。
+    // session id 每次 resume 会换，workdir 不换——所以 workdir 才是「哪个 runner」的稳定标识。
+    {
+      source: "runner",
+      value: env.AP_RUNNER_WORKDIR === undefined || env.AP_RUNNER_WORKDIR === ""
+        ? undefined
+        : `runner:${env.AP_RUNNER_HARNESS ?? "unknown"}:${createHash("sha256").update(env.AP_RUNNER_WORKDIR).digest("hex").slice(0, 16)}`,
+    },
+    {
+      source: "harness_session",
+      value: explicit?.sessionId === undefined || explicit.sessionHarness === undefined
+        ? undefined
+        : `session:${explicit.sessionHarness}:${explicit.sessionId}`,
+    },
+    // 真实 Claude Code 注入的名字。放在旧名之前：两个都在时以真实来源为准。
+    {
+      source: "claude_session",
+      value: env.CLAUDE_CODE_SESSION_ID === undefined || env.CLAUDE_CODE_SESSION_ID === ""
+        ? undefined
+        : `session:claude:${env.CLAUDE_CODE_SESSION_ID}`,
+    },
+    {
+      source: "claude_session",
+      value: env.CLAUDE_SESSION_ID === undefined || env.CLAUDE_SESSION_ID === ""
+        ? undefined
+        : `session:claude:${env.CLAUDE_SESSION_ID}`,
+    },
+    {
+      source: "codex_session",
+      value: env.CODEX_THREAD_ID === undefined || env.CODEX_THREAD_ID === ""
+        ? undefined
+        : `session:codex:${env.CODEX_THREAD_ID}`,
+    },
+  ];
+  const rejected: ExecutorIdSource[] = [];
+  for (const candidate of candidates) {
+    if (candidate.value === undefined || candidate.value === "") continue;
+    const trimmed = candidate.value.slice(0, 128);
+    if (EXECUTOR_ID_RE.test(trimmed)) return { id: trimmed, source: candidate.source, refusal: null, rejected };
+    if (!rejected.includes(candidate.source)) rejected.push(candidate.source);
+  }
+  return { id: null, source: null, refusal: rejected.length > 0 ? "malformed" : "no_signal", rejected };
+}
+
+/** 只要结论不要来源时的薄封装。判定逻辑只有 `resolveExecutorIdentity` 一份实现。 */
 export function resolveExecutorId(
   env: ResolveExecutorEnv = process.env,
   explicit?: { executorId?: string; sessionHarness?: string; sessionId?: string },
 ): string | null {
-  const candidates: (string | undefined)[] = [
-    explicit?.executorId,
-    env.AGENTPARTY_EXECUTOR_ID,
-    // serve 内建 runner 已经在给子进程注入这两个（见 serve.ts 的 AP_RUNNER_* 块）。
-    // session id 每次 resume 会换，workdir 不换——所以 workdir 才是「哪个 runner」的稳定标识。
-    env.AP_RUNNER_WORKDIR === undefined || env.AP_RUNNER_WORKDIR === ""
-      ? undefined
-      : `runner:${env.AP_RUNNER_HARNESS ?? "unknown"}:${createHash("sha256").update(env.AP_RUNNER_WORKDIR).digest("hex").slice(0, 16)}`,
-    explicit?.sessionId === undefined || explicit.sessionHarness === undefined
-      ? undefined
-      : `session:${explicit.sessionHarness}:${explicit.sessionId}`,
-    env.CLAUDE_SESSION_ID === undefined || env.CLAUDE_SESSION_ID === "" ? undefined : `session:claude:${env.CLAUDE_SESSION_ID}`,
-    env.CODEX_THREAD_ID === undefined || env.CODEX_THREAD_ID === "" ? undefined : `session:codex:${env.CODEX_THREAD_ID}`,
-  ];
-  for (const candidate of candidates) {
-    if (candidate === undefined || candidate === "") continue;
-    const trimmed = candidate.slice(0, 128);
-    if (EXECUTOR_ID_RE.test(trimmed)) return trimmed;
-  }
-  return null;
+  return resolveExecutorIdentity(env, explicit).id;
 }
 
 /**
@@ -181,8 +269,16 @@ export function acquireTaskLease(options: AcquireTaskLeaseOptions): TaskLeaseRes
     mkdirSync(dir, { recursive: true, mode: 0o700 });
     writeFileSync(path, JSON.stringify(holder), { mode: 0o600 });
   } catch {
-    // 落盘失败只损失 enforcement 能力，绝不该让一次正常认领失败。
-    return { state: "unenforced", reason: "no_executor_identity" };
+    // 落盘失败只损失 enforcement 能力，绝不该让一次正常认领失败。原因必须与「认不出执行体」
+    // 分开：那一档的修法是设 AGENTPARTY_EXECUTOR_ID，这一档设了也没用（盘写不进去）。
+    return { state: "unenforced", reason: "lease_store_unwritable" };
+  }
+  // 自愈（#908 同款保守收尾）：顺手清掉早已过期的租约文件。放在写之后，免得把「接手了一张
+  // 过期租约」这个事实（reason=expired）在读到之前就抹掉。清理失败无所谓——过期租约本来就不挡人。
+  try {
+    pruneExpiredTaskLeases(dir, now);
+  } catch {
+    /* 目录不可读/并发删除：租约判定不依赖它。 */
   }
   return { state, holder, ...(reason === undefined ? {} : { reason }) };
 }

--- a/cli/test/status-task-lease.test.ts
+++ b/cli/test/status-task-lease.test.ts
@@ -149,12 +149,66 @@ test("--lease-ttl-ms 到期后另一个执行体可以接手，任务不会被�
   expect(posts()).toBe(2);
 });
 
+/** 把梯子上每一级都清干净——少删一个（比如 #931 之前漏掉的 CLAUDE_CODE_SESSION_ID），
+ *  测试就会在真实 harness 里悄悄走到「认得出」那条分支，把被测的闸整个遮住。 */
+function clearExecutorEnv(): void {
+  for (const key of ["AGENTPARTY_EXECUTOR_ID", "AP_RUNNER_WORKDIR", "CLAUDE_CODE_SESSION_ID", "CLAUDE_SESSION_ID", "CODEX_THREAD_ID"]) {
+    delete process.env[key];
+  }
+}
+
 test("无法识别执行体身份时明说没落刀，而不是假装拦住了", async () => {
-  delete process.env.AGENTPARTY_EXECUTOR_ID;
-  delete process.env.AP_RUNNER_WORKDIR;
-  delete process.env.CLAUDE_SESSION_ID;
-  delete process.env.CODEX_THREAD_ID;
+  clearExecutorEnv();
   expect(await statusRun(["working", "--task", "9"])).toBe(0);
   expect(errs.join("\n")).toMatch(/task lease not enforced/);
   expect(errs.join("\n")).toMatch(/AGENTPARTY_EXECUTOR_ID/);
+});
+
+// #931：一行 stderr warn 在刷屏的 serve 日志里等于不存在。「没落闸」必须说出后果、给出修法，
+// 并说清边界——本机互斥不是全局互斥。
+test("没落闸时说清：为什么 / 会怎样 / 怎么修 / 只在本机成立", async () => {
+  clearExecutorEnv();
+  expect(await statusRun(["working", "--task", "9"])).toBe(0);
+  const text = errs.join("\n");
+  expect(text).toMatch(/为什么:/);
+  expect(text).toMatch(/会怎样:.*不会被拒/);
+  expect(text).toMatch(/怎么修:.*AGENTPARTY_EXECUTOR_ID/);
+  expect(text).toMatch(/边界:.*跨机/);
+});
+
+// 「这一刀有没有落下」必须能被**程序**读到,不能只有人眼可见的一行 stderr。
+test("--json 让调用方读到 enforced=false 与互斥边界", async () => {
+  clearExecutorEnv();
+  expect(await statusRun(["working", "--task", "9", "--json"])).toBe(0);
+  const out = JSON.parse(logs.at(-1)!);
+  expect(out.lease.state).toBe("unenforced");
+  expect(out.lease.enforced).toBe(false);
+  expect(out.lease.scope).toBe("local_home");
+  expect(out.lease.fix).toMatch(/AGENTPARTY_EXECUTOR_ID/);
+
+  // 认得出执行体时同一个字段必须翻面——否则这条断言用一个恒 false 的常量也能过。
+  logs.length = 0;
+  setExecutor("runner:claude:reception");
+  expect(await statusRun(["working", "--task", "10", "--json"])).toBe(0);
+  const enforced = JSON.parse(logs.at(-1)!);
+  expect(enforced.lease.enforced).toBe(true);
+  expect(enforced.lease.fix).toBeUndefined();
+});
+
+// #931 根因的端到端形状：事故里 harness 那条腿走的就是这个环境（Claude Code 注入
+// CLAUDE_CODE_SESSION_ID，用户不会去设 AGENTPARTY_EXECUTOR_ID）。修好之前它恒定 unenforced，
+// 于是 serve runner 已经持租的 task 照样能被它认领——两个执行体一起干。
+test("Claude Code 的 harness 腿（只有 CLAUDE_CODE_SESSION_ID）现在会被真的拦住", async () => {
+  setExecutor("runner:claude:reception");
+  expect(await statusRun(["working", "--task", "9"])).toBe(0);
+  expect(posts()).toBe(1);
+
+  clearExecutorEnv();
+  process.env.CLAUDE_CODE_SESSION_ID = "f54570ae-db1b-4939-af3f-86cf8e5845d4";
+  const code = await statusRun(["working", "--task", "9", "-m", "harness also on it"]);
+  expect(code).toBe(EXIT_TASK_LEASE_HELD);
+  expect(errs.join("\n")).toMatch(/refused/);
+  // 红线不变：被拒 ≠ 吞任务。
+  expect(posts()).toBe(1);
+  expect(taskPatches()).toBe(1);
 });

--- a/cli/test/task-lease-visibility.test.ts
+++ b/cli/test/task-lease-visibility.test.ts
@@ -1,0 +1,262 @@
+// #931：闸装了 ≠ 闸会落下。
+//
+// #885 的租约有两个自己写在注释里的边界，实机上都会被踩到：认不出执行体标识时**静默**降级成
+// unenforced（只有一行 stderr warn），以及互斥只在本机文件级成立。本文件钉住的是「这件事必须
+// 可被看见」——`party who` 那行不许再断言「会被拒」、`party doctor` 要在真有第二个执行体时把它
+// 报为问题、JSON 里要能程序化读到。跨机那半仍是缺口，最后一组用例把缺口本身钉住。
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { taskLeaseDoctorLines } from "../src/commands/doctor";
+import { annotateTaskLeaseEnforcement, topologyNote, type Row } from "../src/commands/who";
+import {
+  diagnoseTaskLeaseEnforcement,
+  formatTaskLeaseEnforcement,
+  localExecutorEvidence,
+  shouldSurfaceTaskLeaseEnforcement,
+} from "../src/task-lease-diagnosis";
+import { acquireTaskLease, taskLeaseDir, taskLeaseKey } from "../src/task-lease";
+import { processStartedAt } from "../src/instance-lock";
+
+const NOW = 1_786_000_000_000;
+const SERVER = "https://party.example";
+const TOKEN = "ap_tok";
+const SAVED_ENV = { ...process.env };
+let home: string;
+
+/** 梯子上每一级都清干净：漏一个（#931 前漏的正是 CLAUDE_CODE_SESSION_ID）就会在真实 harness
+ *  里悄悄走到「认得出」那条分支，把被测的闸整个遮住，退回旧实现照样全绿。 */
+function clearExecutorEnv(): void {
+  for (const key of ["AGENTPARTY_EXECUTOR_ID", "AP_RUNNER_WORKDIR", "CLAUDE_CODE_SESSION_ID", "CLAUDE_SESSION_ID", "CODEX_THREAD_ID"]) {
+    delete process.env[key];
+  }
+}
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "ap-lease-vis-"));
+  process.env.AGENTPARTY_HOME = home;
+  clearExecutorEnv();
+});
+
+afterEach(() => {
+  for (const key of Object.keys(process.env)) if (!(key in SAVED_ENV)) delete process.env[key];
+  Object.assign(process.env, SAVED_ENV);
+  rmSync(home, { recursive: true, force: true });
+});
+
+function otherExecutorHoldsLease(taskId = 9, holder = "runner:claude:reception"): void {
+  const dir = taskLeaseDir(home);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, `${taskLeaseKey(SERVER, TOKEN, "king", taskId)}.json`),
+    JSON.stringify({
+      executor_id: holder,
+      channel: "king",
+      task_id: taskId,
+      acquired_at: Date.now(),
+      renewed_at: Date.now(),
+      expires_at: Date.now() + 600_000,
+    }),
+  );
+}
+
+describe("认不出执行体这件事必须可见（不只是 stderr 一行 warn）", () => {
+  test("说得出结论、为什么、会怎样、一条可执行命令，并且说清只在本机成立", () => {
+    const d = diagnoseTaskLeaseEnforcement({});
+    expect(d.enforced).toBe(false);
+    expect(d.reason).toBe("no_signal");
+    const text = formatTaskLeaseEnforcement(d).join("\n");
+    expect(text).toContain("没落闸");
+    expect(text).toMatch(/为什么:/);
+    expect(text).toMatch(/会怎样:.*不会被拒/);
+    expect(text).toMatch(/怎么修:.*AGENTPARTY_EXECUTOR_ID/);
+    // 边界那行是硬要求：「本机互斥」被读成「全局互斥」比没有闸更危险。
+    expect(text).toMatch(/边界:.*跨机缺口/);
+  });
+
+  test("设了但值不合法与一个都没设，给的是不同的原因（修法不同）", () => {
+    expect(diagnoseTaskLeaseEnforcement({ AGENTPARTY_EXECUTOR_ID: "bad id" }).reason).toBe("malformed");
+    expect(formatTaskLeaseEnforcement(diagnoseTaskLeaseEnforcement({ AGENTPARTY_EXECUTOR_ID: "bad id" })).join("\n"))
+      .toMatch(/值不合法/);
+    expect(diagnoseTaskLeaseEnforcement({}).reason).toBe("no_signal");
+  });
+
+  test("认得出时不喊狼来了，且说得出凭什么认得出", () => {
+    const d = diagnoseTaskLeaseEnforcement({ CLAUDE_CODE_SESSION_ID: "sess-1" });
+    expect(d.enforced).toBe(true);
+    expect(d.source).toBe("claude_session");
+    expect(formatTaskLeaseEnforcement(d).join("\n")).toContain("已落闸");
+    expect(shouldSurfaceTaskLeaseEnforcement(d, true)).toBe(false);
+  });
+});
+
+describe("party who：不许再断言「会被拒」", () => {
+  const blockingRow = (): Row => ({
+    name: "king-claude",
+    kind: "agent",
+    tier: "online",
+    topology_conflicts: [
+      { kind: "same_local_installation", with: [], runtime_count: 1, same_identity: true, severity: "blocking" },
+    ],
+  } as unknown as Row);
+  const advisoryRow = (): Row => ({
+    name: "other",
+    kind: "agent",
+    tier: "online",
+    topology_conflicts: [
+      { kind: "same_local_installation", with: ["caller"], runtime_count: 1, same_identity: false, severity: "advisory" },
+    ],
+  } as unknown as Row);
+
+  // 同一个 fixture、同一行冲突，只有 enforcement 一个变量在动——这样「refused / NOT refused」
+  // 只可能由被测的那道闸决定，不会有别的分支替它满足条件。
+  test("没落闸时那行说的是 NOT refused，落了闸才是 refused", () => {
+    const unenforced = annotateTaskLeaseEnforcement([blockingRow()], diagnoseTaskLeaseEnforcement({}))[0]!;
+    expect(unenforced.task_lease).toMatchObject({ enforced: false, scope: "local_home", reason: "no_signal" });
+    expect(topologyNote(unenforced)).toContain("NOT refused");
+    expect(topologyNote(unenforced)).not.toMatch(/claims on one task are refused/);
+
+    const enforced = annotateTaskLeaseEnforcement(
+      [blockingRow()],
+      diagnoseTaskLeaseEnforcement({ AGENTPARTY_EXECUTOR_ID: "runner:claude:reception" }),
+    )[0]!;
+    expect(enforced.task_lease).toMatchObject({ enforced: true, executor_id: "runner:claude:reception" });
+    expect(topologyNote(enforced)).toContain("concurrent claims on one task are refused");
+    expect(topologyNote(enforced)).not.toContain("NOT refused");
+  });
+
+  test("只贴在 blocking 的那些行上：别人家的 runtime 不背这口锅", () => {
+    const rows = annotateTaskLeaseEnforcement([blockingRow(), advisoryRow()], diagnoseTaskLeaseEnforcement({}));
+    expect(rows[0]!.task_lease).toBeDefined();
+    expect(rows[1]!.task_lease).toBeUndefined();
+    expect(topologyNote(rows[1]!)).not.toContain("NOT refused");
+  });
+
+  test("拿不到判定时行为不变（老调用方不受影响）", () => {
+    const rows = annotateTaskLeaseEnforcement([blockingRow()], undefined);
+    expect(rows[0]!.task_lease).toBeUndefined();
+    expect(topologyNote(rows[0]!)).toContain("concurrent claims on one task are refused");
+  });
+});
+
+describe("本机「另一个执行体」的证据（带 server 维度，#865）", () => {
+  test("别的执行体持着这个身份的活租约 = 有证据", () => {
+    otherExecutorHoldsLease();
+    const evidence = localExecutorEvidence({ server: SERVER, token: TOKEN, channel: "king", executorId: null });
+    expect(evidence.present).toBe(true);
+    expect(evidence.kinds).toContain("task_lease");
+  });
+
+  test("只有自己那张租约不算「另一个」", () => {
+    otherExecutorHoldsLease(9, "runner:claude:me");
+    const evidence = localExecutorEvidence({ server: SERVER, token: TOKEN, channel: "king", executorId: "runner:claude:me" });
+    expect(evidence.present).toBe(false);
+  });
+
+  test("过期的租约不作数（陈旧文件不许把用户吓停手）", () => {
+    const dir = taskLeaseDir(home);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, `${taskLeaseKey(SERVER, TOKEN, "king", 9)}.json`),
+      JSON.stringify({ executor_id: "runner:claude:dead", channel: "king", task_id: 9, acquired_at: 1, renewed_at: 1, expires_at: NOW }),
+    );
+    expect(localExecutorEvidence({ server: SERVER, token: TOKEN, channel: "king", executorId: null, now: NOW + 1 }).present)
+      .toBe(false);
+  });
+
+  test("另一台 server 上的同名频道不算数（本机两台生产实例）", () => {
+    otherExecutorHoldsLease();
+    const evidence = localExecutorEvidence({
+      server: "https://other.example",
+      token: TOKEN,
+      channel: "king",
+      executorId: null,
+    });
+    expect(evidence.present).toBe(false);
+  });
+
+  test("活着的 serve 实例锁也是证据", async () => {
+    const child = Bun.spawn(["sleep", "5"], { stdout: "ignore", stderr: "ignore" });
+    try {
+      const lockDir = mkdtempSync(join(tmpdir(), "ap-lock-"));
+      const startedAt = processStartedAt(child.pid);
+      expect(startedAt).toBeDefined();
+      const { instanceLockTarget } = await import("../src/instance-lock");
+      writeFileSync(
+        join(lockDir, `serve-${instanceLockTarget(SERVER, TOKEN, "king")}.lock`),
+        JSON.stringify({ pid: child.pid, id: "x", started_at: startedAt, kind: "serve", channel: "king" }),
+      );
+      const evidence = localExecutorEvidence({ server: SERVER, token: TOKEN, channel: "king", executorId: null, lockDir });
+      expect(evidence.kinds).toContain("serve");
+      rmSync(lockDir, { recursive: true, force: true });
+    } finally {
+      child.kill();
+    }
+  });
+});
+
+describe("party doctor：真有第二个执行体时报为问题，没有时不制造噪音", () => {
+  const auth = async () => ({ server: SERVER, token: TOKEN });
+  const channel = () => "king";
+
+  test("没落闸 + 本机确有另一个执行体 → 报出来，并给一条可执行命令", async () => {
+    otherExecutorHoldsLease();
+    const lines = await taskLeaseDoctorLines({ auth, channel });
+    expect(lines.join("\n")).toContain("没落闸");
+    expect(lines.join("\n")).toMatch(/怎么修:.*AGENTPARTY_EXECUTOR_ID/);
+    expect(lines.join("\n")).toMatch(/证据:/);
+  });
+
+  // 下面两条各只翻转 AND 门的一侧。任一侧单独满足就输出，等于闸失效。
+  test("没落闸但本机只有自己 → 不报（无冲突不制造噪音）", async () => {
+    const lines = await taskLeaseDoctorLines({ auth, channel });
+    expect(lines).toEqual([]);
+  });
+
+  test("有另一个执行体但已落闸 → 不报（闸落下来了就不是问题）", async () => {
+    otherExecutorHoldsLease();
+    process.env.AGENTPARTY_EXECUTOR_ID = "session:claude:harness";
+    const lines = await taskLeaseDoctorLines({ auth, channel });
+    expect(lines).toEqual([]);
+  });
+
+  test("没登录 / 没绑频道时 doctor 照常跑，不抛不报", async () => {
+    otherExecutorHoldsLease();
+    expect(await taskLeaseDoctorLines({ auth: async () => ({}), channel })).toEqual([]);
+    expect(await taskLeaseDoctorLines({ auth, channel: () => null })).toEqual([]);
+  });
+});
+
+describe("跨机缺口（#931 缺口 1）——尚未做服务端租约，这里钉住现状", () => {
+  // ⚠️ 这不是「期望的行为」，是**已知缺口的现状**。服务端 (identity, channel, task) 租约落地后，
+  // 这条用例必须翻红并改成「第二个被拒」——它存在的意义就是不让人误以为跨机已经拦得住。
+  test("两个 AGENTPARTY_HOME 的同一身份都能认领同一个 task（本机文件锁挡不住）", () => {
+    const other = mkdtempSync(join(tmpdir(), "ap-lease-other-home-"));
+    try {
+      const key = taskLeaseKey(SERVER, TOKEN, "king", 9);
+      const first = acquireTaskLease({ key, channel: "king", taskId: 9, executorId: "runner:claude:a", dir: taskLeaseDir(home) });
+      const second = acquireTaskLease({ key, channel: "king", taskId: 9, executorId: "session:claude:b", dir: taskLeaseDir(other) });
+      expect(first.state).toBe("acquired");
+      expect(second.state).toBe("acquired"); // ← 缺口：互斥只在同一个 home 内成立
+      // 缺口不许被静默：任何一次「没落闸/落闸」的呈现都必须带上这句边界。
+      expect(formatTaskLeaseEnforcement(diagnoseTaskLeaseEnforcement({})).join("\n")).toMatch(/另一台机器.*仍挡不住/);
+    } finally {
+      rmSync(other, { recursive: true, force: true });
+    }
+  });
+
+  test("同一个 home 内，反向用例照旧：不同 task、不同身份都不许被拒", () => {
+    const dir = taskLeaseDir(home);
+    acquireTaskLease({ key: taskLeaseKey(SERVER, TOKEN, "king", 9), channel: "king", taskId: 9, executorId: "runner:a", dir });
+    // 不同 task
+    expect(acquireTaskLease({ key: taskLeaseKey(SERVER, TOKEN, "king", 10), channel: "king", taskId: 10, executorId: "session:b", dir }).state)
+      .toBe("acquired");
+    // 不同身份（token 不同）
+    expect(acquireTaskLease({ key: taskLeaseKey(SERVER, "ap_other", "king", 9), channel: "king", taskId: 9, executorId: "session:b", dir }).state)
+      .toBe("acquired");
+    // 不同 server 上的同名频道 + 同 task 号（#865：本机两台生产实例）
+    expect(acquireTaskLease({ key: taskLeaseKey("https://other.example", TOKEN, "king", 9), channel: "king", taskId: 9, executorId: "session:b", dir }).state)
+      .toBe("acquired");
+  });
+});

--- a/cli/test/task-lease.test.ts
+++ b/cli/test/task-lease.test.ts
@@ -15,6 +15,7 @@ import {
   readTaskLease,
   releaseTaskLease,
   resolveExecutorId,
+  resolveExecutorIdentity,
   taskLeaseKey,
 } from "../src/task-lease";
 
@@ -117,10 +118,31 @@ describe("绝不把任务永久锁死", () => {
 
   test("过期租约会被清理，目录不会无限增长", () => {
     const d = dir();
-    claim(d, "runner:claude:aaa", 7);
+    writeFileSync(
+      join(d, `${taskLeaseKey("https://s", "tok", "king", 7)}.json`),
+      JSON.stringify({ executor_id: "runner:claude:aaa", channel: "king", task_id: 7, acquired_at: NOW, renewed_at: NOW, expires_at: NOW + TTL }),
+    );
     claim(d, "runner:claude:bbb", 8, NOW + TTL * 5);
-    expect(pruneExpiredTaskLeases(d, NOW + TTL + 1)).toBe(1);
+    expect(pruneExpiredTaskLeases(d, NOW + TTL + 1)).toBe(0); // 认领时已自愈清掉
     expect(readdirSync(d).length).toBe(1);
+  });
+
+  // #931/#908：残留租约不能靠「下次有人想起来跑一次 prune」——那次调用全仓根本不存在（本模块
+  // 之外零调用点）。认领这一刀顺手自愈，才是唯一每次都会跑到的地方。
+  test("认领时顺手清掉过期租约（自愈不依赖任何外部调用）", () => {
+    const d = dir();
+    const stale = join(d, `${taskLeaseKey("https://s", "tok", "king", 7)}.json`);
+    writeFileSync(stale, JSON.stringify({ executor_id: "runner:claude:dead", channel: "king", task_id: 7, acquired_at: NOW, renewed_at: NOW, expires_at: NOW + 1 }));
+    claim(d, "runner:claude:bbb", 8, NOW + TTL * 5);
+    expect(readdirSync(d)).toEqual([`${taskLeaseKey("https://s", "tok", "king", 8)}.json`]);
+    // 但**没过期**的别人家租约绝不能被顺手清掉——那会把 enforcement 直接清成 0。
+    const live = join(d, `${taskLeaseKey("https://s", "tok", "king", 9)}.json`);
+    writeFileSync(live, JSON.stringify({ executor_id: "runner:claude:live", channel: "king", task_id: 9, acquired_at: NOW, renewed_at: NOW, expires_at: NOW + TTL * 100 }));
+    claim(d, "runner:claude:bbb", 8, NOW + TTL * 6);
+    expect(readdirSync(d).sort()).toEqual([
+      `${taskLeaseKey("https://s", "tok", "king", 8)}.json`,
+      `${taskLeaseKey("https://s", "tok", "king", 9)}.json`,
+    ].sort());
   });
 });
 
@@ -157,6 +179,43 @@ describe("执行体身份识别", () => {
   test("非法的执行体 id 不被采信", () => {
     expect(resolveExecutorId({ AGENTPARTY_EXECUTOR_ID: "bad id with spaces" })).toBeNull();
     expect(resolveExecutorId({ AGENTPARTY_EXECUTOR_ID: "../../escape" })).toBeNull();
+  });
+
+  // #931 根因：真实 Claude Code（实测 2.1.239）注入的是 CLAUDE_CODE_SESSION_ID，而梯子上写的是
+  // 一个它从不设置的名字 CLAUDE_SESSION_ID。于是事故里那条 harness 腿**每一次**都掉到梯子底部、
+  // 恒定 unenforced——闸装了，最需要它的那条腿从来没被拦过。
+  test("Claude Code 真实注入的 CLAUDE_CODE_SESSION_ID 能识别出 harness 那条腿", () => {
+    const harness = resolveExecutorIdentity({ CLAUDE_CODE_SESSION_ID: "f54570ae-db1b-4939-af3f-86cf8e5845d4" });
+    expect(harness.id).toBe("session:claude:f54570ae-db1b-4939-af3f-86cf8e5845d4");
+    expect(harness.source).toBe("claude_session");
+    // 与 serve runner 那条腿必须是**不同**的执行体，否则闸落下来也拦不住事故里的那个形状。
+    const runner = resolveExecutorIdentity({
+      AP_RUNNER_WORKDIR: "/home/u/.agentparty/runners/king",
+      AP_RUNNER_HARNESS: "claude",
+      CLAUDE_CODE_SESSION_ID: "f54570ae-db1b-4939-af3f-86cf8e5845d4",
+    });
+    expect(runner.source).toBe("runner");
+    expect(runner.id).not.toBe(harness.id);
+  });
+
+  test("认不出时说得出为什么：一个都没设 vs 设了但值不合法", () => {
+    const none = resolveExecutorIdentity({});
+    expect(none.id).toBeNull();
+    expect(none.refusal).toBe("no_signal");
+    expect(none.rejected).toEqual([]);
+    const bad = resolveExecutorIdentity({ AGENTPARTY_EXECUTOR_ID: "bad id with spaces" });
+    expect(bad.id).toBeNull();
+    expect(bad.refusal).toBe("malformed");
+    expect(bad.rejected).toEqual(["env"]);
+  });
+
+  test("非法值不会挡住梯子上后面那个合法的来源", () => {
+    const resolved = resolveExecutorIdentity({
+      AGENTPARTY_EXECUTOR_ID: "bad id with spaces",
+      CLAUDE_CODE_SESSION_ID: "sess-42",
+    });
+    expect(resolved.id).toBe("session:claude:sess-42");
+    expect(resolved.rejected).toEqual(["env"]);
   });
 });
 


### PR DESCRIPTION
Closes #931

## 一句话

闸装了 ≠ 闸会落下。#885 的租约在事故那条 harness 腿上**恒定不生效**，而且没人被告知——本 PR 修掉恒不生效的根因，并把「有没有落闸」做成可主动查询、可程序化判定的东西。跨机那半是缺口，只说清边界、不硬凑半吊子实现。

## 1. 根因：`resolveExecutorId` 读的是一个不存在的变量名

梯子最后两级是 `CLAUDE_SESSION_ID` / `CODEX_THREAD_ID`。**真实的 Claude Code 从不设置 `CLAUDE_SESSION_ID`**——本机实测（Claude Code 2.1.239，本 PR 就是在这个环境里写的）：

```
CLAUDE_CODE_SESSION_ID=f54570ae-db1b-4939-af3f-86cf8e5845d4
CLAUDE_PID=2330
CLAUDECODE=1
# 没有 CLAUDE_SESSION_ID
```

仓里别处用的也是 `CLAUDE_CODE_SESSION_ID`（`cli/test/claude-channel-mcp.test.ts`、`watch.ts` 的 `isCodexRuntimeEnv` 用例），只有 `task-lease.ts` 与 `decision.ts` 用了那个不存在的旧名。

于是那条 harness 腿的判定过程是：`--executor-id` 没传 → `AGENTPARTY_EXECUTOR_ID` 没人会去 export → `AP_RUNNER_WORKDIR` 只有 serve 拉起的子进程才有 → `CLAUDE_SESSION_ID` **永远不存在** → 掉到梯子底部返回 null → `unenforced`。**这一档不是偶发，是必然**：只要认领发生在 Claude Code 的 Bash 里，就 100% 落进来。事故里的两条腿一条是 serve runner（有 `AP_RUNNER_WORKDIR`，判得出）、一条是 harness（判不出），闸永远只有一边有身份，`denied` 分支根本不可能进。

修法：梯子补上 `CLAUDE_CODE_SESSION_ID`（放在旧名之前），旧名保留——serve / 包装脚本仍可能注入它，删掉等于砍一条在用的识别路径。

顺带修的两处「说不清」：
- `resolveExecutorIdentity()` 返回 `{id, source, refusal, rejected}`。`refusal` 分 `no_signal`（一个都没设）与 `malformed`（设了但值不合法，比如 `AGENTPARTY_EXECUTOR_ID="my id"` 带空格被静默丢弃）——两者修法完全不同，此前都归到同一个 null。`resolveExecutorId()` 保留为薄封装，解析逻辑只有一份实现（wake-diagnosis 同款纪律：诊断与真实行为不许两套）。
- 落盘失败此前也报 `reason: "no_executor_identity"`，是错的（认得出执行体，只是盘写不进去），改报 `lease_store_unwritable`。

## 2. 别再静默降级：让「没落闸」可见

呈现口径**复用 #925/#926 的 `wake-diagnosis`**（一行结论 → 为什么 → 会怎样 → 一条可粘贴命令），不另造一套。实现落在新模块 `cli/src/task-lease-diagnosis.ts`，**没有改 #926 的任何文件**。

| 面 | 变化 |
|---|---|
| `party status` | unenforced 从一行 warn 变成：为什么 / 会怎样 / 怎么修 / 边界 |
| `party status --json` | `lease` 补 `enforced`、`scope:"local_home"`、unenforced 时带 `fix`/`detail` |
| `party who --json` | blocking 冲突行补 `task_lease: {enforced, scope, executor_id?, reason?, fix?}` |
| `party who` 人读 | **那行不再骗人**：本机认不出执行体时，`— concurrent claims on one task are refused` 改成 `— ⚠ concurrent claims are NOT refused here: no execution-runtime identity on this machine`；并在列表后追加完整诊断段 |
| `party doctor` | 新增一段，紧跟 wake 诊断 |

`party who` 那句是本 PR 最该改的一处：**它此前在无条件断言一件本机根本没做的事**。读的人以为有东西拦着，于是放心让两个执行体一起干——比没有提示更糟。

`party doctor` 的门是 **AND**：`没落闸 且 本机确有另一个执行体`。第二个条件取**本地可核实的证据**（活着的 serve/watch 实例锁、别的执行体持着的未过期任务租约），而不是服务端 `topology_conflicts`——后者要网络与鉴权，doctor 拿不到就只能沉默，那又回到本 issue 要根除的静默。代价（另一条腿在别的机器上时本机看不见）由输出里的「边界」那行说出来。判定带 server 维度（`instanceLockTarget` / `taskLeaseIdentityPrefix` 都把 server 摁进摘要），本机同时连两台生产实例、两边同名频道时不会互相误判（#865）。

## 3. 跨机缺口：本切片不做，取舍如下

**结论：不做服务端租约，缺口留下并单开 issue。**

- 真做需要动 `worker/src/do.ts`（新表 + TTL/epoch + REST/WS 面）。而 `(identity, channel, task)` 粒度的关键在于**同一身份的两个执行体要能被区分**——服务端手上只有 token，看不出执行体，所以必须让客户端把 executor id 送上去，这是**协议变更**（`shared/src/protocol.ts` + 版本协商 + 老客户端降级）。这不是「顺手加个表」，够一个独立切片。
- 眼下 `worker/src/do.ts` 同时被 `fix/913-892-scan-and-preflight`（next-mention 段）与 `fix/929-decision-ledger`（decision 段）改着，此刻塞一张新表纯属制造冲突。
- 半吊子跨机实现（比如把租约目录钉死在 `~/.agentparty` 而无视 `AGENTPARTY_HOME`）会直接破坏真机验证纪律里「用临时 HOME」的做法，且仍挡不住真正的跨机——净负值。

所以本 PR 做的是：**把缺口说出来，并钉住它的现状**。任何一次落闸/没落闸的呈现都必带边界行；`task-lease-visibility.test.ts` 最后一组用例断言「两个 `AGENTPARTY_HOME` 的同一身份都能认领同一个 task」，注释写明这是**已知缺口现状、不是期望行为**，服务端租约落地后必须翻红改成「第二个被拒」。

建议单开 issue：**服务端 (identity, channel, task) 租约**，形状对齐 #99 的 `serve_lease`，含协议字段与老服务端降级路径。（本次未开，按需由 owner 拍板；#931 关闭时可在 issue 里留链。）

## 4. 不吞任务 / 不死锁（#885、#908 的红线）

- 拒绝路径一字未动：不发帧、不改服务端 task state。原有用例全部保留并跑绿，真机也复核了（见下）。
- 新增自愈：`acquireTaskLease` 成功写盘后顺手 `pruneExpiredTaskLeases`。**`pruneExpiredTaskLeases` 此前全仓零调用点**（只有模块自己和测试引用）——也就是说残留租约靠的是「以后有人想起来跑一次」，而那次调用不存在。放在认领之后是刻意的：放在读之前会把「接手了一张过期租约」（`reason: "expired"`）这个事实在读到之前就抹掉；未过期的别人家租约绝不清（有用例钉住，清掉就等于把 enforcement 归零）。
- 加宽识别范围的死锁风险评估：同一 Claude 会话里的多个子 agent 会共享 `CLAUDE_CODE_SESSION_ID` → 判为同一执行体 → `renewed`，方向偏**放行**而不是误拒，与今天的 unenforced 等价，不会新造死锁；会话 resume 换 id 后旧租约走 TTL 过期，本来就有 `--force-lease` 逃生口。

## 5. 变异自检（12 组，全部转红）

每组只改一处，跑 `task-lease` / `status-task-lease` / `task-lease-visibility` / `who-scope`：

| # | 变异 | 结果 |
|---|---|---|
| M1 | 删掉 `CLAUDE_CODE_SESSION_ID` 那一级（回到 #931 之前的梯子） | ✅ 转红（4 条，含端到端那条） |
| M2 | `topologyNote` 无条件宣称 `are refused` | ✅ 转红 |
| M3 | `shouldSurface` 丢掉「真有第二个执行体」这一侧 | ✅ 转红（噪音用例） |
| M4 | `shouldSurface` 丢掉「没落闸」这一侧 | ✅ 转红 |
| M5 | 等价替换：`annotate` 贴到所有行而不只 blocking 行 | ✅ 转红 |
| M6 | 删掉认领时的过期租约自愈 | ✅ 转红（2 条） |
| M7 | `status --json` 不再暴露 `enforced`/`scope`/`fix` | ✅ 转红 |
| M8 | 证据判定忽略租约过期时间 | ✅ 转红 |
| M9 | 证据判定丢掉 server 维度（#865） | ✅ 转红（2 条） |
| M10 | unenforced 退回「只打一行 warn」 | ✅ 转红 |
| M11 | 整段删除级：`denied` 分支恒不进（`if (false && …)`） | ✅ 转红（8 条，含 MCP 腿） |
| M12 | `diagnose` 恒报「已落闸」 | ✅ 转红（4 条） |

**给守卫自己做的变异**（针对「fixture 让另一个分支单独满足条件」这个假绿形态）：
- who 的两条断言用**同一个 fixture 行**，只有 enforcement 一个变量在动 —— `refused` / `NOT refused` 只可能由被测的那道闸决定；M2/M5 证明它没被别的分支遮住。
- doctor 的 AND 门左右两侧各有一条只翻转单侧的用例（M3/M4 分别打中其中一条）。
- `clearExecutorEnv()` 逐个删梯子上的每一级 —— **旧用例只删了 4 个中的 3 个，漏的正是 `CLAUDE_CODE_SESSION_ID`**；本 PR 之后如果不补删，测试会在真实 harness 里悄悄走到「认得出」分支，把被测的闸整个遮住（M1 之所以能红，靠的就是这个）。

## 6. 真机验证（CONTRIBUTING「真机验证纪律」）

CLI + 临时 `AGENTPARTY_HOME` + 一次性本地 mock，**零 GUI、零 AppleScript、不碰任何在跑的会话与用户级配置**（验证目录已删除）。场景照抄事故：同一身份，serve runner（`AP_RUNNER_*`）先持租 task 9，harness 腿（**真实 Claude Code 环境**，没有 `AGENTPARTY_EXECUTOR_ID`）再认领同一个 task。

```
$ 本进程执行体解析 → {"id":"session:claude:f54570ae-…","source":"claude_session"}

runner 腿:  status seq=11        exit=0
harness 腿: refused: task 9 on #king is already held by another execution runtime…
            holder=runner:claude:c72daa7e39bee03f expires_in=1800s
            this claim was NOT published: the task is untouched…
            exit=11 (EXIT_TASK_LEASE_HELD)
mock 收到:   ["POST …/messages","PATCH …/tasks/9"]     ← 只有 runner 那一次，被拒的没发任何东西
```

对照组（`env -u CLAUDE_CODE_SESSION_ID` = #931 之前那条梯子在真实 Claude Code 里的处境）：

```
warn: task lease not enforced (#834 #931)
  为什么/会怎样/怎么修/边界 …
status seq=11    exit=0
mock 收到: [POST, PATCH, POST, PATCH]   ← 两条腿都认领成功 = 事故本体
```

`party doctor` 真机（同一临时 HOME，种一张 `runner:claude:reception` 的活租约）：

```
task-lease: 这台机器上这个身份的任务认领【没落闸】
  为什么: 没有任何稳定标识在场（AGENTPARTY_EXECUTOR_ID / AP_RUNNER_WORKDIR / CLAUDE_CODE_SESSION_ID / … 一个都没设）
  会怎样: 同一身份的第二个执行体认领同一个 task 时【不会被拒】——两个都会开工（#834 那次事故的形状）
  怎么修: export AGENTPARTY_EXECUTOR_ID="harness:$(hostname -s):1"
  证据: 本机另有执行体持着这个身份的任务租约——这个身份此刻确实不止一个执行体
  边界: 这把闸只在本机 … 内互斥；另一台机器（或另一个 AGENTPARTY_HOME）上的同一身份仍挡不住（#931 跨机缺口）
```

同一条命令在**执行体认得出**时静默（无噪音），在**没有第二个执行体**时也静默——两侧都真机核过。

## 7. 检查与并行协调

- `bun run check:cli`（6 shard 全绿 + `tsc --noEmit` 干净）。未动 worker，`check:worker` 不涉及。
- 未改 `cli/src/wake-diagnosis.ts` / `pull-wake.ts` / MCP 启动路径 / 接入包生成器 / presence 上报（`feat/926-reachability-visible` 的地盘），只**复用其呈现风格**，新展示全在 `cli/src/task-lease-diagnosis.ts`。与 #926 的协调点：两者都往 `party who` 列表末尾追加诊断段、都往 `party doctor` 顶部追加一段——顺序上 wake 在前、task-lease 在后；若 #926 也动 `who.ts`/`doctor.ts` 的同一处，合并时按「wake 诊断在前」保留两段即可。
- 未改 `worker/src/do.ts` / `worker/src/index.ts`（`fix/913-892`、`fix/929` 的地盘）。
- `cli/src/commands/decision.ts` 里 `runnerSessionFromEnv` 也读着同一个不存在的 `CLAUDE_SESSION_ID`（错误信息还教用户去设它）。它有 `AP_RUNNER_SESSION_ID` 兜底，故障面不同，**本 PR 不碰**——留作独立小修，避免跨切片改动。
