### PR TITLE
fix(cli): decision.ts 读真实的 CLAUDE_CODE_SESSION_ID (#937)

### DIFF
--- a/cli/src/commands/decision.ts
+++ b/cli/src/commands/decision.ts
@@ -102,9 +102,12 @@ function runnerSessionFromEnv(
 ): string | null {
   const explicit = nonEmpty(env.AP_RUNNER_SESSION_ID);
   if (explicit !== null) return explicit;
-  return harness === "claude"
-    ? nonEmpty(env.CLAUDE_SESSION_ID)
-    : nonEmpty(env.CODEX_THREAD_ID);
+  if (harness !== "claude") return nonEmpty(env.CODEX_THREAD_ID);
+  // 真实 Claude Code 注入的是 CLAUDE_CODE_SESSION_ID（本机 2.1.239 实测）；
+  // `CLAUDE_SESSION_ID` 是仓里扩散开的一个错名，harness 里**从不存在**——只读它就等于这一级恒空
+  // （#931 里同一个错名让任务租约对 harness 那条腿 100% 不落闸）。旧名保留：serve 与包装脚本
+  // 仍可能注入它，去掉会缩小兼容面。
+  return nonEmpty(env.CLAUDE_CODE_SESSION_ID) ?? nonEmpty(env.CLAUDE_SESSION_ID);
 }
 
 /**
@@ -149,7 +152,8 @@ export function prepareDecisionContinuation(
   }
   const sessionId = runnerSessionFromEnv(harnessRaw, env);
   if (sessionId === null) {
-    const expected = harnessRaw === "claude" ? "CLAUDE_SESSION_ID" : "CODEX_THREAD_ID";
+    // 别再把错名教给用户：claude 档要报真实存在的那个变量名。
+    const expected = harnessRaw === "claude" ? "CLAUDE_CODE_SESSION_ID" : "CODEX_THREAD_ID";
     throw new Error(
       `runner continuation has no live session id; expected AP_RUNNER_SESSION_ID or ${expected}`,
     );

--- a/cli/test/decision.test.ts
+++ b/cli/test/decision.test.ts
@@ -26,6 +26,9 @@ const CONTINUATION_ENV = [
   "AP_RUNNER_SESSION_ID",
   "CODEX_THREAD_ID",
   "CLAUDE_SESSION_ID",
+  // 真实 Claude Code 会注入它（本机 2.1.239 实测）。不清掉的话，跑测试的那台机器
+  // 自己的会话 id 会泄进来，让「解析不出 session」这类用例永远走不到该走的分支（#931 同款假绿）。
+  "CLAUDE_CODE_SESSION_ID",
 ] as const;
 
 function clearContinuationEnv(): void {
@@ -323,6 +326,43 @@ describe("party decision ask", () => {
     expect(errs.join("\n")).toContain("decision ask refused before POST");
     expect(errs.join("\n")).toContain("CODEX_THREAD_ID");
     expect(mock!.requests.some((request) => request.method === "POST" && request.path.endsWith("/messages"))).toBe(false);
+  });
+
+  // #937：仓里扩散过一个错名 `CLAUDE_SESSION_ID`，而真实 Claude Code 注入的是
+  // `CLAUDE_CODE_SESSION_ID`。只读错名等于这一级恒空——#931 里同一个错名让任务租约对
+  // harness 那条腿 100% 不落闸。这条钉住「真实 harness 的形态能被解析出来」。
+  test("只设真实的 CLAUDE_CODE_SESSION_ID（harness 的实际形态）也能解析出 runner session", async () => {
+    const workdir = join(home, "runner");
+    process.env.AP_DELIVERY_ID = "local-delivery";
+    process.env.AP_WORK_ID = "local-work";
+    process.env.AP_CONTINUATION_REF = "local-ref";
+    process.env.AP_RUNNER_WORKDIR = workdir;
+    process.env.AP_RUNNER_HARNESS = "claude";
+    // 刻意**不设**旧的 CLAUDE_SESSION_ID：否则那一级单独就能满足条件，把被测的这一级遮住。
+    process.env.CLAUDE_CODE_SESSION_ID = "claude-real-session";
+
+    await decisionRun(["ask", "mismatched question"]);
+
+    expect(readRunnerContinuation(continuationPath(workdir, "local-ref"))).toMatchObject({
+      harness: "claude",
+      session_id: "claude-real-session",
+    });
+  });
+
+  // 错误信息不能把不存在的变量名教给用户——照着 export 一个 harness 从不设置的名字，
+  // 等于绕开真正的信号源。
+  test("解析不出 session 时，报的是真实存在的变量名", async () => {
+    const workdir = join(home, "runner");
+    process.env.AP_DELIVERY_ID = "local-delivery";
+    process.env.AP_WORK_ID = "local-work";
+    process.env.AP_CONTINUATION_REF = "local-ref";
+    process.env.AP_RUNNER_WORKDIR = workdir;
+    process.env.AP_RUNNER_HARNESS = "claude";
+
+    await decisionRun(["ask", "mismatched question"]);
+
+    const text = errs.join("\n");
+    expect(text).toContain("CLAUDE_CODE_SESSION_ID");
   });
 
   test("server rejects a model-session lineage mismatch before creating a decision", async () => {


### PR DESCRIPTION
## 问题

`cli/src/commands/decision.ts` 的 `runnerSessionFromEnv` 读 `env.CLAUDE_SESSION_ID` —— **Claude Code 从不设置这个变量**，真名是 `CLAUDE_CODE_SESSION_ID`。

本会话自身就跑在 Claude Code 里，实测（2.1.239）：

```
$ env | grep -iE "^CLAUDE.*SESSION"
CLAUDE_CODE_SESSION_ID=f54570ae-db1b-4939-af3f-86cf8e5845d4
CLAUDE_CODE_CHILD_SESSION=1
```

更糟的是解析失败时的错误信息把这个**不存在的名字教给用户**：

```ts
const expected = harnessRaw === "claude" ? "CLAUDE_SESSION_ID" : "CODEX_THREAD_ID";
```

用户照着 export 一个 harness 从不设置的名字，等于绕开真正的信号源。

## 与 #931 的关系

同一个错名在 `cli/src/task-lease.ts` 里造成过更严重的后果：任务租约对 harness 那条腿 **100% 不落闸**（`denied` 分支根本进不去），#931 / PR #935 已修那一处。

`decision.ts` 这一处有 `AP_RUNNER_SESSION_ID` 兜底，**故障面不同**，所以单独修。

## 改动

1. 读取梯子改为 `CLAUDE_CODE_SESSION_ID ?? CLAUDE_SESSION_ID` —— **旧名保留**，serve 与包装脚本仍可能注入它，去掉会缩小兼容面；
2. 错误信息里的 `expected` 改成真实变量名；
3. 全仓扫过一遍 `CLAUDE_SESSION_ID`：`task-lease.ts` 已由 #935 修好（两名并存），`serve.ts:3371` 只是注释，无其它待修点。

## 测试环境清理列表补 `CLAUDE_CODE_SESSION_ID`

`decision.test.ts` 的 `CONTINUATION_ENV` 里没有它 —— 不清掉的话，**跑测试那台机器自己的会话 id 会泄进来**，让「解析不出 session」这类用例永远走不到该走的分支。这正是 #931 里那个假绿的同款成因（旧测试的 `clearExecutorEnv` 也漏删了它）。

## 变异验证

| 变异 | 结果 |
|---|---|
| 读取梯子退回只读 `CLAUDE_SESSION_ID` + 错误信息退回错名 | **2 fail**（两条新用例都红） |
| **守卫自身**：同时去掉 `CLAUDE_CODE_SESSION_ID` 的环境清理 + 退回错名 | **1 fail**（仍红——用例不靠"测试机恰好没设这个变量"运气） |

新用例刻意**不设**旧的 `CLAUDE_SESSION_ID`，否则那一级单独就能满足条件、把被测的这一级遮住。

`bun run check:cli` 全绿（357 tests + tsc）。

Closes #937