### PR TITLE
feat(worker,cli,shared): 任务认领租约抬到服务端，跨机同身份并发终于挡得住 (#936)

### DIFF
--- a/cli/src/commands/mcp.ts
+++ b/cli/src/commands/mcp.ts
@@ -54,13 +54,12 @@ import { askDecision } from "./decision";
 import { uploadAttachmentPaths } from "./send";
 import { buildContext } from "./status";
 import {
-  acquireTaskLease,
   describeDeniedLease,
   processScopedExecutorId,
-  releaseTaskLease,
   taskLeaseDir,
   taskLeaseKey,
 } from "../task-lease";
+import { acquireTaskLeaseAcrossMachines, releaseTaskLeaseAcrossMachines } from "../task-lease-remote";
 import { EXIT_ALREADY_WATCHING, runWatch } from "./watch";
 
 const HELP = `usage: party mcp [--channel <slug>] [--identity <label>]
@@ -710,22 +709,32 @@ export function createMcpServer(defaultChannel?: string): McpServer {
           : taskLeaseKey(authInfo.server, authInfo.token, resolved, task_id);
         const executorId = processScopedExecutorId();
         if (leaseKeyValue !== null && task_id !== undefined && (state === "working" || state === "waiting")) {
-          const lease = acquireTaskLease({
+          // #936:跨机那半也走同一条判定。MCP 恰好是 harness 那条腿的认领入口——事故里两条腿
+          // 一条是 serve runner、一条是人在 harness 里手敲,只给 CLI 装闸等于只盖住一半。
+          const lease = await acquireTaskLeaseAcrossMachines({
+            server: authInfo.server,
+            token: authInfo.token,
             key: leaseKeyValue,
             channel: resolved,
             taskId: task_id,
             executorId,
             dir: taskLeaseDir(),
           });
-          if (lease.state === "denied" && lease.holder !== undefined) {
+          // 判据只看 state:holder 只是补充信息,读不出 holder 的拒绝仍然是拒绝。
+          if (lease.state === "denied") {
             // 拒绝 ≠ 吞任务:这里 return 之前没有发过任何帧,服务端 task 状态原封不动。
-            return fail(describeDeniedLease(lease.holder, resolved, task_id, Date.now()), {
+            const message = lease.holder === undefined
+              ? `refused: task ${task_id} on #${resolved} is held by another execution runtime of this identity; ` +
+                "this claim was NOT published and the task is untouched"
+              : describeDeniedLease(lease.holder, resolved, task_id, Date.now(), lease.scope);
+            return fail(message, {
               type: "task_lease_held",
               published: false,
               task_untouched: true,
               channel: resolved,
               task_id,
-              holder: lease.holder,
+              scope: lease.scope,
+              ...(lease.holder === undefined ? {} : { holder: lease.holder }),
             });
           }
         }
@@ -745,8 +754,16 @@ export function createMcpServer(defaultChannel?: string): McpServer {
           if (taskState !== null) task = await updateTask(authInfo.server, authInfo.token, resolved, task_id, { state: taskState });
         }
         // 帧已发出后再交还,别在「已放手、状态还没落地」之间留一个谁都不持有的窗口。
-        if (leaseKeyValue !== null && (state === "done" || state === "blocked")) {
-          releaseTaskLease(leaseKeyValue, executorId, taskLeaseDir());
+        if (leaseKeyValue !== null && task_id !== undefined && (state === "done" || state === "blocked")) {
+          await releaseTaskLeaseAcrossMachines({
+            server: authInfo.server,
+            token: authInfo.token,
+            key: leaseKeyValue,
+            channel: resolved,
+            taskId: task_id,
+            executorId,
+            dir: taskLeaseDir(),
+          });
         }
         advanceCursorPastOwnMessage(resolved, seq);
         return ok({ type: "status", channel: resolved, seq, state, ...(task !== undefined ? { task } : {}) });

--- a/cli/src/commands/status.ts
+++ b/cli/src/commands/status.ts
@@ -13,14 +13,16 @@ import type {
 } from "@agentparty/shared";
 import { EXIT_TASK_LEASE_HELD, safeBranchContextLabel, safeRepoContextLabel } from "@agentparty/shared";
 import {
-  acquireTaskLease,
   describeDeniedLease,
   DEFAULT_TASK_LEASE_TTL_MS,
-  releaseTaskLease,
   taskLeaseDir,
   taskLeaseKey,
-  type TaskLeaseResult,
 } from "../task-lease";
+import {
+  acquireTaskLeaseAcrossMachines,
+  releaseTaskLeaseAcrossMachines,
+  type RemoteTaskLeaseResult,
+} from "../task-lease-remote";
 import { diagnoseTaskLeaseEnforcement, formatTaskLeaseEnforcement } from "../task-lease-diagnosis";
 import { isHelpArg, parseArgs, str, strArray, unknownFlagError, valueFlagError } from "../args";
 import { advanceCursorPastOwnMessage, branchLabel, repoLabel, resolveChannel, workspaceId, workspaceLabel, worktreeLabel } from "../config";
@@ -395,13 +397,17 @@ export async function run(argv: string[]): Promise<number> {
   const executorId = enforcement.executor_id;
   const asJson = flags.json === true;
   const leaseNow = Date.now();
-  let lease: TaskLeaseResult | null = null;
+  let lease: RemoteTaskLeaseResult | null = null;
   const leaseKeyValue = taskId === undefined ? null : taskLeaseKey(auth.server, auth.token, channel, taskId);
   // working/waiting = 「这件事归我，我还在上面」→ 取/续租约。
   // done/blocked = 「我不在上面了」→ 立刻交还，别让一个卡住的执行体把任务扣满一个 TTL。
   const claims = taskId !== undefined && (state === "working" || state === "waiting");
   if (claims && leaseKeyValue !== null && taskId !== undefined) {
-    lease = acquireTaskLease({
+    // #936：先本机、后服务端。服务端那半才是跨机互斥；老服务端没有这条路由时退回本机租约
+    // （**不是**放行——放行比现在更糟，现在至少同一个 HOME 内还挡得住）。
+    lease = await acquireTaskLeaseAcrossMachines({
+      server: auth.server,
+      token: auth.token,
       key: leaseKeyValue,
       channel,
       taskId,
@@ -411,7 +417,10 @@ export async function run(argv: string[]): Promise<number> {
       ...(leaseTtl === undefined ? {} : { ttlMs: leaseTtl }),
       force: flags["force-lease"] === true,
     });
-    if (lease.state === "denied" && lease.holder !== undefined) {
+    // 判据只看 state，**绝不附加 `holder !== undefined`**：holder 只是给人读的补充信息，
+    // 一个读不出 holder 的拒绝仍然是拒绝。把它写进判据，等于「服务端拒了但回执被截断」时
+    // 直接放行——正好是本 issue 要修的那件事，只不过换了个触发条件。
+    if (lease.state === "denied") {
       // 红线：拒绝 ≠ 吞任务。这里**不发帧、不改服务端 task state**，任务原样留在频道里，
       // 持租约的那个执行体照常干；本执行体降级为只读。
       if (asJson) {
@@ -420,11 +429,31 @@ export async function run(argv: string[]): Promise<number> {
           published: false,
           task_untouched: true,
           exit_code: EXIT_TASK_LEASE_HELD,
-          lease: { state: lease.state, reason: lease.reason, holder: lease.holder, enforced: true, scope: "local_home" },
+          lease: {
+            state: lease.state,
+            reason: lease.reason,
+            holder: lease.holder,
+            enforced: true,
+            scope: lease.scope,
+            ...(lease.degraded === undefined ? {} : { degraded: lease.degraded }),
+          },
         }));
       }
-      console.error(describeDeniedLease(lease.holder, channel, taskId, leaseNow));
+      console.error(
+        lease.holder === undefined
+          ? `refused: task ${taskId} on #${channel} is held by another execution runtime of this identity\n` +
+            "  this claim was NOT published: the task is untouched and the current holder keeps working on it."
+          : describeDeniedLease(lease.holder, channel, taskId, leaseNow, lease.scope),
+      );
       return EXIT_TASK_LEASE_HELD;
+    }
+    // 退回本机租约时必须**说出来**：调用方读到 scope=local_home 才知道这一刀只挡得住这个 HOME。
+    if (lease.degraded !== undefined) {
+      console.error(
+        lease.degraded === "server_unsupported"
+          ? "warn: this server has no task-lease endpoint (#936) — falling back to the local-home lease; another machine running this identity is NOT blocked"
+          : "warn: server task lease unavailable this time — falling back to the local-home lease; another machine running this identity is NOT blocked",
+      );
     }
     if (lease.state === "unenforced") {
       // #931：这里原本只有一行 warn，在刷屏的 serve 日志里等于不存在——闸看着装了，最需要它的
@@ -479,8 +508,16 @@ export async function run(argv: string[]): Promise<number> {
     }
     // 交还租约必须在**帧已发出之后**：先发帧再放手,任务才不会在「已放手、状态还没落地」之间
     // 出现一个谁都不持有、状态也没更新的窗口。
-    if (leaseKeyValue !== null && (state === "done" || state === "blocked")) {
-      releaseTaskLease(leaseKeyValue, executorId, taskLeaseDir());
+    if (leaseKeyValue !== null && taskId !== undefined && (state === "done" || state === "blocked")) {
+      await releaseTaskLeaseAcrossMachines({
+        server: auth.server,
+        token: auth.token,
+        key: leaseKeyValue,
+        channel,
+        taskId,
+        executorId,
+        dir: taskLeaseDir(),
+      });
     }
     advanceCursorPastOwnMessage(channel, seq);
     if (asJson) {
@@ -499,7 +536,8 @@ export async function run(argv: string[]): Promise<number> {
                 // #931：「这一刀有没有落下」必须能被程序读到，而不是只在 stderr 打一行。
                 // 同时带上互斥边界——跨机同身份不在射程内，别让调用方把它当全局互斥。
                 enforced: lease.state !== "unenforced",
-                scope: "local_home",
+                scope: lease.scope,
+                ...(lease.degraded === undefined ? {} : { degraded: lease.degraded }),
                 ...(lease.state === "unenforced" ? { fix: enforcement.fix, detail: enforcement.detail } : {}),
               },
             }),

--- a/cli/src/commands/who.ts
+++ b/cli/src/commands/who.ts
@@ -1,6 +1,6 @@
 // party who — 从终端看频道里谁在线/可唤醒/最近，便于接着 party send --mention 把人拉进来/唤醒。
 // Claude Code 原生 @ 只认本地文件/技能，塞不进远程动态列表；本命令就是那个「动态在线列表」。
-import { autoWakeReachable, type AgentActivity, type ListeningVerdict, type PresenceEntry, type ReceptionContextBoundary, type ReceptionMode, type ReceptionRunner, type RunnerHealth, type RuntimePeerDiscovery, type SenderKind, type WakeKind, wakeableState } from "@agentparty/shared";
+import { autoWakeReachable, type AgentActivity, type ListeningVerdict, type PresenceEntry, type ReceptionContextBoundary, type ReceptionMode, type ReceptionRunner, type RunnerHealth, type RuntimePeerDiscovery, type SenderKind, type TaskLeaseScope, type WakeKind, wakeableState } from "@agentparty/shared";
 import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
 import { resolveChannel } from "../config";
 import { diagnoseCodexWake, formatCodexWakeDiagnosis, shouldSurfaceCodexWakeDiagnosis } from "../wake-diagnosis";
@@ -194,8 +194,9 @@ export interface Row {
   // 所以「这一刀有没有落下」必须和冲突本身出现在同一处，且可程序化判定。
   task_lease?: {
     enforced: boolean;
-    /** 互斥边界。跨机（含同机不同 AGENTPARTY_HOME）的同一身份挡不住——#931 缺口 1。 */
-    scope: "local_home";
+    /** 这条腿够得到的最强那一层（#936）：`server` = 认领时会取服务端租约，跨机同身份也拦得住；
+     *  `local_home` = 认不出执行体，连本机都不落闸。语义见 TaskLeaseEnforcement.scope。 */
+    scope: TaskLeaseScope;
     executor_id?: string;
     reason?: "no_signal" | "malformed";
     fix?: string;

--- a/cli/src/rest.ts
+++ b/cli/src/rest.ts
@@ -35,6 +35,8 @@ import {
   type SendMessageFrame,
   type SendStatusFrame,
   type TaskAssigneeKind,
+  type TaskLeaseGrantedResponse,
+  type TaskLeaseReleasedResponse,
   type TaskRecord,
   type TaskState,
   type TokenRole,
@@ -60,6 +62,12 @@ export class RestError extends Error {
     public status: number,
     public code: string | null,
     message: string,
+    /**
+     * 已解析的响应体（非 JSON 响应为 null）。结构化错误常带 message 之外的可执行信息——
+     * 任务租约冲突要告诉被拒方「谁持有、何时过期」（#936），把它塌缩成一句 message
+     * 就只剩「你不被允许」，调用方既不知道等多久也不知道该不该 force。
+     */
+    public body: unknown = null,
   ) {
     super(message);
   }
@@ -209,7 +217,7 @@ function extractError(status: number, body: unknown, raw: string): RestError {
     else if (typeof b.error === "string") message = b.error;
   }
   if (!code && status === 401) code = "unauthorized";
-  return new RestError(status, code, message);
+  return new RestError(status, code, message, body);
 }
 
 // 所有 REST 调用的默认超时（#116）。没有它，一次 TCP 半开就让 serve 永久挂在 await 上：
@@ -752,6 +760,39 @@ export async function updateTask(
     headers: bearerJson(token),
     body: JSON.stringify(body),
   })) as TaskRecord;
+}
+
+/**
+ * 服务端任务租约（#936）。老服务端没有这条路由，`req` 会抛 404——调用方**必须**据此退回本机
+ * 租约，而不是当成「没人持租」直接放行（放行比现在更糟：现在至少本机还挡得住）。
+ * 判据见 `cli/src/task-lease-remote.ts` 的 `serverLeaseUnsupported`。
+ */
+export async function claimServerTaskLease(
+  server: string,
+  token: string,
+  slug: string,
+  id: number,
+  body: { executor_id: string; ttl_ms?: number; force?: boolean },
+): Promise<TaskLeaseGrantedResponse> {
+  return (await req(server, `/api/channels/${encodeURIComponent(slug)}/tasks/${id}/lease`, {
+    method: "POST",
+    headers: bearerJson(token),
+    body: JSON.stringify({ op: "claim", ...body }),
+  })) as TaskLeaseGrantedResponse;
+}
+
+export async function releaseServerTaskLease(
+  server: string,
+  token: string,
+  slug: string,
+  id: number,
+  executorId: string,
+): Promise<TaskLeaseReleasedResponse> {
+  return (await req(server, `/api/channels/${encodeURIComponent(slug)}/tasks/${id}/lease`, {
+    method: "POST",
+    headers: bearerJson(token),
+    body: JSON.stringify({ op: "release", executor_id: executorId }),
+  })) as TaskLeaseReleasedResponse;
 }
 
 export async function listSquads(server: string, token: string, slug: string): Promise<ChannelSquad[]> {

--- a/cli/src/task-lease-diagnosis.ts
+++ b/cli/src/task-lease-diagnosis.ts
@@ -3,7 +3,8 @@
 // #885 给「同一身份多执行体并发」装了一道闸（认领时刻的单活跃执行体租约）。但那道闸有两个
 // 边界，实机上都会被踩到：
 //   1. 它只在**本机文件级**成立（`taskLeaseDir()` 在 `$AGENTPARTY_HOME` 下）。跨机同身份、
-//      甚至同机不同 AGENTPARTY_HOME，都挡不住。
+//      甚至同机不同 AGENTPARTY_HOME，都挡不住。（#936 已补上服务端租约；但那半要靠**认得出
+//      执行体**才送得上去，所以第 2 条没修好时，第 1 条照样是开的。）
 //   2. 认不出执行体标识时**静默降级**成 unenforced，只往 stderr 打一行 warn；而事故里的
 //      harness 那条腿恰恰最容易落进这一档（根因见 `resolveExecutorIdentity` 的注释）。
 // 于是「闸看起来装了，最需要它的场景下却是开的，而且没人被告知」——本仓反复出现的那个形态。
@@ -11,8 +12,8 @@
 // 本模块只负责第 2 条的**可见性**：把判定结果做成可主动查询的东西（`party who` / `party doctor`
 // / `party status --json`），呈现口径照抄 #925/#926 的 wake-diagnosis：
 //   一行结论 → 为什么 → 会怎样 → 一条能直接粘贴的命令。
-// 第 1 条（跨机）不在本模块射程内，但**必须在输出里说出边界**，否则「本机互斥」会被读成
-// 「全局互斥」——那比没有闸更危险。
+// 第 1 条（跨机）的实现不在本模块射程内（见 task-lease-remote.ts），但**必须在输出里说出边界**，
+// 否则「本机互斥」会被读成「全局互斥」——那比没有闸更危险。
 //
 // 与 wake-diagnosis 同一条纪律：判定跑的是和真实行为**完全同一份**实现
 // （`resolveExecutorIdentity`），绝不写第二套「诊断专用」的解析逻辑，否则诊断说好、真跑起来坏。
@@ -26,6 +27,7 @@ import {
   type ExecutorIdSource,
   type ResolveExecutorEnv,
 } from "./task-lease";
+import type { TaskLeaseScope } from "@agentparty/shared";
 import { agentpartyHome } from "./config";
 import { instanceLockHolderPid, instanceLockTarget, defaultInstanceLockDir } from "./instance-lock";
 import { readdirSync, readFileSync } from "node:fs";
@@ -43,8 +45,15 @@ export interface TaskLeaseEnforcement {
   consequence: string;
   /** 一条能直接粘贴执行的命令；已落闸时为 null。 */
   fix: string | null;
-  /** 互斥边界。跨机（含同机不同 AGENTPARTY_HOME）不在射程内——#931 缺口 1，尚未做服务端租约。 */
-  scope: "local_home";
+  /**
+   * 这条腿够得到的最强那一层。
+   *  - `server`：认得出执行体 ⇒ 认领时会把 executor_id 上送，服务端 (identity, channel, task)
+   *    租约生效，跨机同身份也拦得住（#936）。老服务端没有这条路由时客户端会退回本机——那不是
+   *    本地诊断能预知的（本模块不发网络），认领时会明说。
+   *  - `local_home`：认不出执行体 ⇒ 既落不了本机的闸，也没有可上送的标识，跨机更无从谈起。
+   *    这两件事是**同一个根因**，所以修法也只有一条（设一个稳定的 AGENTPARTY_EXECUTOR_ID）。
+   */
+  scope: TaskLeaseScope;
   home: string;
 }
 
@@ -79,7 +88,7 @@ export function diagnoseTaskLeaseEnforcement(
       detail: `执行体标识来自 ${SOURCE_LABEL[identity.source]}`,
       consequence: "同一身份的第二个执行体认领同一个 task 会被拒（任务不动，降级只读）",
       fix: null,
-      scope: "local_home",
+      scope: "server",
       home,
     };
   }
@@ -217,8 +226,12 @@ export function formatTaskLeaseEnforcement(
       .join("；");
     out.push(`  证据: ${label}——这个身份此刻确实不止一个执行体`);
   }
+  // 边界永远说出来，但要说**当下这条腿真实的**边界，别把两种情形塌缩成一句。
   out.push(
-    `  边界: 这把闸只在本机 ${d.home} 内互斥；另一台机器（或另一个 AGENTPARTY_HOME）上的同一身份仍挡不住（#931 跨机缺口，需服务端租约）`,
+    d.scope === "server"
+      ? `  边界: 本机 ${d.home} 内互斥，认领时还会向服务端取 (identity, channel, task) 租约（#936）——跨机同身份也拦得住；` +
+        "老服务端没有这条路由时会退回本机租约，认领那一刻会明说（scope=local_home）"
+      : `  边界: 认不出执行体 ⇒ 连本机 ${d.home} 内都不落闸，也没有可上送给服务端的标识；另一台机器（或另一个 AGENTPARTY_HOME）上的同一身份仍挡不住`,
   );
   return out;
 }

--- a/cli/src/task-lease-remote.ts
+++ b/cli/src/task-lease-remote.ts
@@ -1,0 +1,177 @@
+// 跨机任务租约（#936）：把 #885 的本机文件锁与服务端 (identity, channel, task) 租约串成一条判定。
+//
+// #885 在认领时刻装了闸，#931 修好了它在本机恒不落闸的根因，但闸本身只在 `$AGENTPARTY_HOME/task-leases`
+// 这一个目录里成立——同一身份在两台机器上并发认领同一个 task，两边都会成功。服务端要区分同一
+// 身份的两个执行体，手上只有 token（两条腿的 token 完全一样），所以只能由客户端把执行体标识送上去。
+//
+// 顺序刻意是「先本机、后服务端」：
+//   1. 本机能直接答「被拒」的时候不必发网络请求（同机双执行体是最常见的那一种）；
+//   2. 拿到服务端拒绝时，本机那张刚取的租约要立刻还回去，不留一张自己不用却挡着别人的租约。
+// 反过来（先服务端后本机）会在「服务端给了、本机拒了」时留下一张孤儿服务端租约，要靠 TTL 才
+// 收得回——正好是 #908 那类锁残留。
+//
+// 降级路径是本模块的另一半。老服务端没有这条路由，此时**退回本机租约**，绝不是直接放行：
+// 放行等于比现在更糟（现在至少同一个 HOME 内还挡得住）。降级的原因会一路带到调用方，让
+// `--json` 与人读输出都能说清「这一刀落在哪一层」。
+import type { TaskLeaseScope } from "@agentparty/shared";
+import { RestError, claimServerTaskLease, releaseServerTaskLease } from "./rest";
+import {
+  acquireTaskLease,
+  releaseTaskLease,
+  taskLeaseDir,
+  type TaskLeaseHolder,
+  type TaskLeaseResult,
+  type TaskLeaseState,
+} from "./task-lease";
+
+/** 退回本机租约的原因。两档的修法完全不同，绝不能塌缩成一个 boolean。 */
+export type TaskLeaseDegradation =
+  /** 服务端没有这条路由（老服务端）——升级服务端才有跨机互斥。 */
+  | "server_unsupported"
+  /** 服务端在，但这次没答上来（网络/超时/5xx/参数被拒）——本次退回本机，下次照常再试。 */
+  | "server_unavailable";
+
+export interface RemoteTaskLeaseResult extends TaskLeaseResult {
+  /** 这一刀最终落在哪一层。`server` = 跨机互斥成立；`local_home` = 只挡得住同一个 HOME。 */
+  scope: TaskLeaseScope;
+  degraded?: TaskLeaseDegradation;
+}
+
+export interface AcquireAcrossMachinesOptions {
+  server: string;
+  token: string;
+  /** 本机租约 key（`taskLeaseKey(server, token, channel, taskId)`）。 */
+  key: string;
+  channel: string;
+  taskId: number;
+  executorId: string | null;
+  dir?: string;
+  ttlMs?: number;
+  now?: number;
+  force?: boolean;
+  /** 注入点，只给测试用；默认走真实 REST。 */
+  claim?: typeof claimServerTaskLease;
+  release?: typeof releaseServerTaskLease;
+}
+
+/**
+ * 「老服务端不认这个字段」的判据。
+ *
+ * 未命中路由时 Hono 回的是**裸 404**（纯文本，没有 `error.code`）；本仓所有真实的 404 都走
+ * `errorBody("not_found", …)`，一定带 code。两者形状不同，所以「路由不存在」与「频道/任务不存在」
+ * 分得开——后者不该被当成老服务端，它说明服务端认得这条路由、只是这次的对象不在。
+ */
+export function serverLeaseUnsupported(error: unknown): boolean {
+  if (!(error instanceof RestError)) return false;
+  if (error.status === 405 || error.status === 501) return true;
+  return error.status === 404 && error.code === null;
+}
+
+function isServerDenial(error: unknown): error is RestError {
+  return error instanceof RestError && error.status === 409 && error.code === "task_lease_held";
+}
+
+function coerceHolder(raw: unknown, channel: string, taskId: number): TaskLeaseHolder | null {
+  if (typeof raw !== "object" || raw === null) return null;
+  const holder = (raw as { holder?: unknown }).holder;
+  if (typeof holder !== "object" || holder === null) return null;
+  const h = holder as Record<string, unknown>;
+  if (typeof h.executor_id !== "string") return null;
+  const num = (value: unknown, fallback: number): number =>
+    typeof value === "number" && Number.isFinite(value) ? value : fallback;
+  return {
+    executor_id: h.executor_id,
+    channel: typeof h.channel === "string" ? h.channel : channel,
+    task_id: num(h.task_id, taskId),
+    acquired_at: num(h.acquired_at, 0),
+    renewed_at: num(h.renewed_at, 0),
+    expires_at: num(h.expires_at, 0),
+    ...(typeof h.taken_over_from === "string" ? { taken_over_from: h.taken_over_from } : {}),
+  };
+}
+
+/**
+ * 取一次「跨机也成立」的任务租约。
+ *
+ * 返回 denied 时调用方必须**什么都不发**——不发 status 帧、不改服务端 task state，任务原样留着
+ * （#885 立的红线，服务端租约同样守）。
+ */
+export async function acquireTaskLeaseAcrossMachines(
+  options: AcquireAcrossMachinesOptions,
+): Promise<RemoteTaskLeaseResult> {
+  const dir = options.dir ?? taskLeaseDir();
+  const local = acquireTaskLease({
+    key: options.key,
+    channel: options.channel,
+    taskId: options.taskId,
+    executorId: options.executorId,
+    dir,
+    ...(options.ttlMs === undefined ? {} : { ttlMs: options.ttlMs }),
+    ...(options.now === undefined ? {} : { now: options.now }),
+    ...(options.force === undefined ? {} : { force: options.force }),
+  });
+  // 本机就能答「被拒」：不必再发网络请求，结论也不会变（服务端最多同样拒）。
+  if (local.state === "denied") return { ...local, scope: "local_home" };
+  // 认不出执行体 / 租约目录写不进去：没有可上送的标识，服务端那一半无从谈起。
+  if (options.executorId === null) return { ...local, scope: "local_home" };
+
+  const claim = options.claim ?? claimServerTaskLease;
+  try {
+    const granted = await claim(options.server, options.token, options.channel, options.taskId, {
+      executor_id: options.executorId,
+      ...(options.ttlMs === undefined ? {} : { ttl_ms: options.ttlMs }),
+      ...(options.force === true ? { force: true } : {}),
+    });
+    const state: TaskLeaseState = granted.state;
+    return {
+      state,
+      scope: "server",
+      holder: granted.holder,
+      ...(granted.reason === undefined ? {} : { reason: granted.reason }),
+    };
+  } catch (error) {
+    if (isServerDenial(error)) {
+      // 服务端说这个 task 归另一台机器上的执行体。本机那张刚取的租约立刻还回去——我们并不会
+      // 去干这件事，不该占着它挡住别人（还只删自己的那张，别人合法接手的碰都不碰）。
+      releaseTaskLease(options.key, options.executorId, dir);
+      const holder = coerceHolder(error.body, options.channel, options.taskId);
+      return {
+        state: "denied",
+        scope: "server",
+        reason: "held_by_other",
+        ...(holder === null ? {} : { holder }),
+      };
+    }
+    // 降级：退回本机租约（已经在上面取到了），**不是**放行。
+    return {
+      ...local,
+      scope: "local_home",
+      degraded: serverLeaseUnsupported(error) ? "server_unsupported" : "server_unavailable",
+    };
+  }
+}
+
+/**
+ * 交还租约。本机那张一定要还；服务端那张尽力而为——还不上也只是等它自然过期，绝不因此让
+ * 一次正常的 `status done` 失败。
+ */
+export async function releaseTaskLeaseAcrossMachines(options: {
+  server: string;
+  token: string;
+  key: string;
+  channel: string;
+  taskId: number;
+  executorId: string | null;
+  dir?: string;
+  release?: typeof releaseServerTaskLease;
+}): Promise<void> {
+  const dir = options.dir ?? taskLeaseDir();
+  releaseTaskLease(options.key, options.executorId, dir);
+  if (options.executorId === null) return;
+  const release = options.release ?? releaseServerTaskLease;
+  try {
+    await release(options.server, options.token, options.channel, options.taskId, options.executorId);
+  } catch {
+    /* 老服务端没有这条路由 / 网络抖动：租约会按 TTL 自然过期，不阻塞收尾。 */
+  }
+}

--- a/cli/src/task-lease.ts
+++ b/cli/src/task-lease.ts
@@ -19,12 +19,15 @@
 import { createHash } from "node:crypto";
 import { mkdirSync, readFileSync, readdirSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { isExecutorId, TASK_LEASE_DEFAULT_TTL_MS, type TaskLeaseScope } from "@agentparty/shared";
 import { agentpartyHome } from "./config";
 
 /** 默认租期。与 serve 的 DEFAULT_RUNNER_TIMEOUT_MS（30min）对齐：一个 runner 最多能占这么久。 */
-export const DEFAULT_TASK_LEASE_TTL_MS = 30 * 60_000;
+export const DEFAULT_TASK_LEASE_TTL_MS = TASK_LEASE_DEFAULT_TTL_MS;
 
-const EXECUTOR_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._:@-]{0,127}$/;
+// 字符集判据只有 shared 一份实现（#936）：本机租约与服务端租约用同一个 executor_id，两边各写
+// 一个正则就会出现「本机认得出、服务端 400」的静默分叉（#622 那次 allow-list 镜像漂移同款）。
+const EXECUTOR_ID_RE = { test: (value: string): boolean => isExecutorId(value) };
 
 export interface TaskLeaseHolder {
   executor_id: string;
@@ -331,11 +334,20 @@ export function pruneExpiredTaskLeases(dir: string = taskLeaseDir(), now: number
 }
 
 /** 人读的拒绝说明。刻意把「任务没丢」和「怎么合法接手」写在同一句里。 */
-export function describeDeniedLease(holder: TaskLeaseHolder, channel: string, taskId: number, now: number): string {
+export function describeDeniedLease(
+  holder: TaskLeaseHolder,
+  channel: string,
+  taskId: number,
+  now: number,
+  /** 这一刀落在哪一层。被拒方要能分清「另一台机器上的执行体」和「本机另一条腿」——两者的
+   *  排查动作完全不同（#936）。 */
+  scope: TaskLeaseScope = "local_home",
+): string {
   const remainingS = Math.max(0, Math.ceil((holder.expires_at - now) / 1000));
   return [
     `refused: task ${taskId} on #${channel} is already held by another execution runtime of this identity`,
-    `  holder=${holder.executor_id} expires_in=${remainingS}s`,
+    `  holder=${holder.executor_id} expires_in=${remainingS}s scope=${scope}` +
+      (scope === "server" ? " (server lease: the holder may be on another machine)" : " (this machine only)"),
     "  this claim was NOT published: the task is untouched and the current holder keeps working on it.",
     "  read-only is still available (party task list / party history); do not start side-effecting work.",
     "  if you are certain the holder is gone, take over explicitly: party status working --task " +

--- a/cli/test/oidc-mock.ts
+++ b/cli/test/oidc-mock.ts
@@ -21,6 +21,8 @@ export function makeJwt(payload: Record<string, unknown>): string {
 
 export interface MockOptions {
   cliClientId?: string | null; // null → 不返回 cli_client_id（模拟老 worker，回落 web client_id）
+  /** false → 没有 /tasks/:id/lease 路由（老服务端，#936 前）：回**裸 404**，与真实 Hono 未命中路由同形。 */
+  taskLease?: boolean;
   // 覆盖 /token 响应；默认按 grant_type 给确定性 token
   tokenResponse?: (params: Record<string, string>) => Record<string, unknown>;
 }
@@ -31,6 +33,17 @@ export function startOidcMock(opts: MockOptions = {}): OidcMock {
   const profiles: Record<string, unknown>[] = [];
   const invites: Record<string, unknown>[] = [];
   const wakeBudgets = new Map<string, { limit: number; window_ms: number }>();
+  // 服务端任务租约台账（#936）。按 (token, 频道, task) 分格——同一个 mock 被两个
+  // AGENTPARTY_HOME 共用时，它就代表「两台机器连的是同一台服务端」。
+  const taskLeases = new Map<string, {
+    executor_id: string;
+    channel: string;
+    task_id: number;
+    acquired_at: number;
+    renewed_at: number;
+    expires_at: number;
+    taken_over_from?: string;
+  }>();
   let retention = { message_retention_ms: null as number | null, audit_retention_ms: null as number | null };
   let base = "";
 
@@ -251,6 +264,69 @@ export function startOidcMock(opts: MockOptions = {}): OidcMock {
       }
       if (req.method === "POST" && /^\/api\/channels\/[^/]+\/messages$/.test(u.pathname)) {
         return Response.json({ seq: 7 });
+      }
+      if (req.method === "POST" && /^\/api\/channels\/[^/]+\/tasks\/\d+\/lease$/.test(u.pathname)) {
+        // 老服务端：路由压根不存在 → Hono 的默认 404 是**纯文本**，没有 error.code。
+        // 客户端正是靠这个形状把「老服务端」与「频道/任务不存在」分开的，所以这里必须逐字同形。
+        if (opts.taskLease === false) return new Response("404 Not Found", { status: 404 });
+        const parts = u.pathname.split("/");
+        const channel = parts[3]!;
+        const taskId = Number(parts[5]);
+        const b = rec.body as { op?: string; executor_id?: string; ttl_ms?: number; force?: boolean } | null;
+        const executorId = b?.executor_id;
+        if (typeof executorId !== "string" || !/^[A-Za-z0-9][A-Za-z0-9._:@-]{0,127}$/.test(executorId)) {
+          return Response.json({ error: { code: "bad_request", message: "executor_id" } }, { status: 400 });
+        }
+        const key = `${auth ?? ""}|${channel}|${taskId}`;
+        const now = Date.now();
+        const existing = taskLeases.get(key);
+        if (b?.op === "release") {
+          if (existing !== undefined && existing.executor_id === executorId) taskLeases.delete(key);
+          return Response.json({
+            type: "task_lease",
+            state: "released",
+            scope: "server",
+            released: existing?.executor_id === executorId,
+          });
+        }
+        const mine = existing !== undefined && existing.executor_id === executorId;
+        const live = existing !== undefined && existing.expires_at > now;
+        if (existing !== undefined && live && !mine && b?.force !== true) {
+          return Response.json(
+            {
+              error: { code: "task_lease_held", message: `held by ${existing.executor_id}` },
+              type: "task_lease",
+              state: "denied",
+              scope: "server",
+              reason: "held_by_other",
+              holder: existing,
+              task_untouched: true,
+              server_time: now,
+            },
+            { status: 409 },
+          );
+        }
+        const state = mine ? "renewed" : existing !== undefined && live ? "forced" : "acquired";
+        const ttl = Math.min(60 * 60_000, Math.max(1, b?.ttl_ms ?? 30 * 60_000));
+        const holder = {
+          executor_id: executorId,
+          channel,
+          task_id: taskId,
+          acquired_at: mine && existing !== undefined ? existing.acquired_at : now,
+          renewed_at: now,
+          expires_at: now + ttl,
+          ...(state === "forced" && existing !== undefined ? { taken_over_from: existing.executor_id } : {}),
+        };
+        taskLeases.set(key, holder);
+        return Response.json({
+          type: "task_lease",
+          state,
+          scope: "server",
+          holder,
+          ...(state === "forced" ? { reason: "taken_over" } : {}),
+          ttl_ms: ttl,
+          server_time: now,
+        });
       }
       if (req.method === "PATCH" && /^\/api\/channels\/[^/]+\/tasks\/\d+$/.test(u.pathname)) {
         const id = Number(u.pathname.split("/").pop());

--- a/cli/test/status-task-lease.test.ts
+++ b/cli/test/status-task-lease.test.ts
@@ -173,7 +173,7 @@ test("没落闸时说清：为什么 / 会怎样 / 怎么修 / 只在本机成�
   expect(text).toMatch(/为什么:/);
   expect(text).toMatch(/会怎样:.*不会被拒/);
   expect(text).toMatch(/怎么修:.*AGENTPARTY_EXECUTOR_ID/);
-  expect(text).toMatch(/边界:.*跨机/);
+  expect(text).toMatch(/边界:.*另一台机器.*仍挡不住/);
 });
 
 // 「这一刀有没有落下」必须能被**程序**读到,不能只有人眼可见的一行 stderr。
@@ -211,4 +211,142 @@ test("Claude Code 的 harness 腿（只有 CLAUDE_CODE_SESSION_ID）现在会被
   // 红线不变：被拒 ≠ 吞任务。
   expect(posts()).toBe(1);
   expect(taskPatches()).toBe(1);
+});
+
+// ---- #936：跨机（两个 AGENTPARTY_HOME，一台服务端） ----
+//
+// #885 的闸只在 `$AGENTPARTY_HOME/task-leases` 里成立，所以「另一台机器」在测试里就是
+// **另一个 HOME**——它和真正的第二台机器对本机租约而言是同一件事（两个互不可见的租约目录），
+// 而服务端仍是同一台。下面这组用例走的是 `party status` 的完整路径，不是租约模块的返回值。
+
+/** 切到「另一台机器」：换 HOME，并让它连同一台服务端、用同一个 token（同一身份）。 */
+function switchMachine(dir: string): void {
+  process.env.AGENTPARTY_HOME = dir;
+  writeConfig({ server: mock!.url, token: "ap_runtime" });
+  writeState({ channel: "king", cursor: 0 });
+}
+
+test("两台机器上的同一身份：第二台被服务端租约拒掉，且一个字节都没发出去", async () => {
+  const machineB = mkdtempSync(join(tmpdir(), "ap-status-lease-b-"));
+  try {
+    setExecutor("runner:claude:reception");
+    expect(await statusRun(["working", "--task", "9", "-m", "on it"])).toBe(0);
+    expect(posts()).toBe(1);
+
+    switchMachine(machineB);
+    setExecutor("session:claude:harness");
+    const code = await statusRun(["working", "--task", "9", "-m", "also on it"]);
+    expect(code).toBe(EXIT_TASK_LEASE_HELD);
+    // 红线：拒绝 ≠ 吞任务。第二台什么都没发，task 状态也没被改写。
+    expect(posts()).toBe(1);
+    expect(taskPatches()).toBe(1);
+    // 被拒方必须知道「谁持有、何时过期」，以及这是**跨机**的那一层。
+    const text = errs.join("\n");
+    expect(text).toMatch(/holder=runner:claude:reception/);
+    expect(text).toMatch(/scope=server/);
+    expect(text).toMatch(/another machine/);
+    expect(text).toMatch(/task is untouched/);
+  } finally {
+    rmSync(machineB, { recursive: true, force: true });
+  }
+});
+
+test("被服务端拒掉的那台不许留下一张自己不用却挡着别人的本机租约", async () => {
+  const machineB = mkdtempSync(join(tmpdir(), "ap-status-lease-b2-"));
+  try {
+    setExecutor("runner:claude:reception");
+    await statusRun(["working", "--task", "9"]);
+
+    switchMachine(machineB);
+    setExecutor("session:claude:harness");
+    expect(await statusRun(["working", "--task", "9"])).toBe(EXIT_TASK_LEASE_HELD);
+    // B 机上的第三个执行体不该被 B 自己刚才那张作废的租约挡住（那会是 #908 那类锁残留）——
+    // 它应当继续被**服务端**拒，而不是被本机一张孤儿租约拒。
+    errs.length = 0;
+    setExecutor("session:claude:third");
+    expect(await statusRun(["working", "--task", "9"])).toBe(EXIT_TASK_LEASE_HELD);
+    expect(errs.join("\n")).toMatch(/holder=runner:claude:reception/);
+    expect(errs.join("\n")).toMatch(/scope=server/);
+  } finally {
+    rmSync(machineB, { recursive: true, force: true });
+  }
+});
+
+test("--json：拿到租约时 scope=server；被跨机拒绝时 scope=server + holder", async () => {
+  const machineB = mkdtempSync(join(tmpdir(), "ap-status-lease-b3-"));
+  try {
+    setExecutor("runner:claude:reception");
+    expect(await statusRun(["working", "--task", "9", "--json"])).toBe(0);
+    expect(JSON.parse(logs.at(-1)!).lease).toMatchObject({ state: "acquired", scope: "server", enforced: true });
+
+    switchMachine(machineB);
+    setExecutor("session:claude:harness");
+    logs.length = 0;
+    expect(await statusRun(["working", "--task", "9", "--json"])).toBe(EXIT_TASK_LEASE_HELD);
+    const denied = JSON.parse(logs.at(-1)!);
+    expect(denied.published).toBe(false);
+    expect(denied.task_untouched).toBe(true);
+    expect(denied.lease).toMatchObject({ state: "denied", scope: "server" });
+    expect(denied.lease.holder.executor_id).toBe("runner:claude:reception");
+  } finally {
+    rmSync(machineB, { recursive: true, force: true });
+  }
+});
+
+test("交还后另一台机器立刻能接手（done 会把服务端那张也还回去）", async () => {
+  const machineB = mkdtempSync(join(tmpdir(), "ap-status-lease-b4-"));
+  try {
+    setExecutor("runner:claude:reception");
+    await statusRun(["working", "--task", "9"]);
+    switchMachine(machineB);
+    setExecutor("session:claude:harness");
+    expect(await statusRun(["working", "--task", "9"])).toBe(EXIT_TASK_LEASE_HELD);
+
+    process.env.AGENTPARTY_HOME = home;
+    setExecutor("runner:claude:reception");
+    expect(await statusRun(["done", "--task", "9"])).toBe(0);
+
+    switchMachine(machineB);
+    setExecutor("session:claude:harness");
+    expect(await statusRun(["working", "--task", "9"])).toBe(0);
+  } finally {
+    rmSync(machineB, { recursive: true, force: true });
+  }
+});
+
+// 降级路径。老服务端（#936 之前）没有这条路由，客户端必须**退回本机租约**——不是放行。
+// 放行比现在更糟：现在至少同一个 HOME 内还挡得住。
+test("老服务端：退回本机租约，同一个 HOME 内照样被拒，并明说跨机没拦住", async () => {
+  mock?.stop();
+  mock = startOidcMock({ taskLease: false });
+  const machineB = mkdtempSync(join(tmpdir(), "ap-status-lease-legacy-"));
+  try {
+    switchMachine(home);
+    setExecutor("runner:claude:reception");
+    expect(await statusRun(["working", "--task", "9"])).toBe(0);
+    expect(errs.join("\n")).toMatch(/no task-lease endpoint/);
+    expect(errs.join("\n")).toMatch(/another machine running this identity is NOT blocked/);
+
+    // 退回本机 ≠ 放行：同一个 HOME 的第二个执行体照样被拒，一个字节都没发。
+    const postsBefore = posts();
+    setExecutor("session:claude:harness");
+    expect(await statusRun(["working", "--task", "9"])).toBe(EXIT_TASK_LEASE_HELD);
+    expect(posts()).toBe(postsBefore);
+
+    // 另一个 HOME 仍挡不住——老服务端下这是**已知且被说出来**的边界，不是静默缺口。
+    switchMachine(machineB);
+    setExecutor("session:claude:harness");
+    expect(await statusRun(["working", "--task", "9", "--json"])).toBe(0);
+    expect(JSON.parse(logs.at(-1)!).lease).toMatchObject({ scope: "local_home", degraded: "server_unsupported" });
+  } finally {
+    rmSync(machineB, { recursive: true, force: true });
+  }
+});
+
+// 老客户端连新服务端：从不调用租约端点，也从不被拒——不能因为不送字段就被挡住。
+// 这一半在服务端（worker/test/task-lease.spec.ts）钉死；这里钉住客户端不认领时不发那次请求。
+test("不带 --task 的 status 不碰租约端点（没有认领就没有租约）", async () => {
+  setExecutor("runner:claude:reception");
+  expect(await statusRun(["working", "-m", "no task"])).toBe(0);
+  expect(mock!.requests.some((r) => r.path.endsWith("/lease"))).toBe(false);
 });

--- a/cli/test/task-lease-visibility.test.ts
+++ b/cli/test/task-lease-visibility.test.ts
@@ -16,7 +16,14 @@ import {
   localExecutorEvidence,
   shouldSurfaceTaskLeaseEnforcement,
 } from "../src/task-lease-diagnosis";
-import { acquireTaskLease, taskLeaseDir, taskLeaseKey } from "../src/task-lease";
+import { acquireTaskLease, readTaskLease, taskLeaseDir, taskLeaseKey } from "../src/task-lease";
+import {
+  acquireTaskLeaseAcrossMachines,
+  releaseTaskLeaseAcrossMachines,
+  serverLeaseUnsupported,
+  type AcquireAcrossMachinesOptions,
+} from "../src/task-lease-remote";
+import { RestError } from "../src/rest";
 import { processStartedAt } from "../src/instance-lock";
 
 const NOW = 1_786_000_000_000;
@@ -72,7 +79,21 @@ describe("认不出执行体这件事必须可见（不只是 stderr 一行 warn
     expect(text).toMatch(/会怎样:.*不会被拒/);
     expect(text).toMatch(/怎么修:.*AGENTPARTY_EXECUTOR_ID/);
     // 边界那行是硬要求：「本机互斥」被读成「全局互斥」比没有闸更危险。
-    expect(text).toMatch(/边界:.*跨机缺口/);
+    // 认不出执行体时连服务端租约都送不上去（#936），所以边界仍然是「另一台机器仍挡不住」。
+    expect(text).toMatch(/边界:.*另一台机器.*仍挡不住/);
+    expect(d.scope).toBe("local_home");
+  });
+
+  test("认得出执行体时，边界那行改说服务端租约（#936），不再谎报也不再吓人", () => {
+    const d = diagnoseTaskLeaseEnforcement({ AGENTPARTY_EXECUTOR_ID: "harness:mac:1" });
+    expect(d.enforced).toBe(true);
+    expect(d.scope).toBe("server");
+    const text = formatTaskLeaseEnforcement(d).join("\n");
+    // 两侧各断一次：认得出 ⇒ 说服务端租约；不许再输出「仍挡不住」那句（否则等于没修）。
+    expect(text).toMatch(/边界:.*服务端.*租约/);
+    expect(text).not.toMatch(/另一台机器.*仍挡不住/);
+    // 老服务端会退回本机这件事必须仍然说得出来——别让人以为升级客户端就万事大吉。
+    expect(text).toMatch(/老服务端.*退回本机/);
   });
 
   test("设了但值不合法与一个都没设，给的是不同的原因（修法不同）", () => {
@@ -228,19 +249,235 @@ describe("party doctor：真有第二个执行体时报为问题，没有时不�
   });
 });
 
-describe("跨机缺口（#931 缺口 1）——尚未做服务端租约，这里钉住现状", () => {
-  // ⚠️ 这不是「期望的行为」，是**已知缺口的现状**。服务端 (identity, channel, task) 租约落地后，
-  // 这条用例必须翻红并改成「第二个被拒」——它存在的意义就是不让人误以为跨机已经拦得住。
-  test("两个 AGENTPARTY_HOME 的同一身份都能认领同一个 task（本机文件锁挡不住）", () => {
+describe("跨机互斥（#936）——服务端 (identity, channel, task) 租约", () => {
+  // 这一组的前身是 #935 里那条「钉住缺口」的用例：两个 AGENTPARTY_HOME 下的同一身份都能认领
+  // 同一个 task，注释写明「服务端租约落地后此用例必须翻红」。现在它翻红了，改成断言相反的事实。
+  //
+  // 服务端那半用一个**共享的租约台账**代表「两台机器看到的是同一台服务端」。台账逐字实现
+  // worker 那条 upsert 的判据（同 executor 续期 / 过期可接手 / force 抢占 / 否则拒），
+  // 真实服务端行为由 worker/test/task-lease.spec.ts 在真 workerd + 真 D1 上覆盖。
+  interface ServerLease {
+    executor_id: string;
+    acquired_at: number;
+    renewed_at: number;
+    expires_at: number;
+    taken_over_from?: string;
+  }
+
+  function makeServer() {
+    const ledger = new Map<string, ServerLease>();
+    const calls: { executor_id: string; force: boolean }[] = [];
+    const claim: NonNullable<AcquireAcrossMachinesOptions["claim"]> = async (_server, _token, slug, id, body) => {
+      calls.push({ executor_id: body.executor_id, force: body.force === true });
+      const key = `${slug}#${id}`;
+      const now = Date.now();
+      const existing = ledger.get(key);
+      const mine = existing !== undefined && existing.executor_id === body.executor_id;
+      const live = existing !== undefined && existing.expires_at > now;
+      if (existing !== undefined && live && !mine && body.force !== true) {
+        throw new RestError(409, "task_lease_held", "held", {
+          error: { code: "task_lease_held", message: "held" },
+          state: "denied",
+          scope: "server",
+          reason: "held_by_other",
+          holder: { ...existing, channel: slug, task_id: id },
+          task_untouched: true,
+          server_time: now,
+        });
+      }
+      const state = mine ? "renewed" : existing !== undefined && live ? "forced" : "acquired";
+      const next: ServerLease = {
+        executor_id: body.executor_id,
+        acquired_at: mine && existing !== undefined ? existing.acquired_at : now,
+        renewed_at: now,
+        expires_at: now + (body.ttl_ms ?? 600_000),
+        ...(state === "forced" && existing !== undefined ? { taken_over_from: existing.executor_id } : {}),
+      };
+      ledger.set(key, next);
+      return {
+        type: "task_lease",
+        state,
+        scope: "server",
+        holder: { ...next, channel: slug, task_id: id },
+        ttl_ms: body.ttl_ms ?? 600_000,
+        server_time: now,
+      };
+    };
+    return { claim, ledger, calls };
+  }
+
+  function machine(homeDir: string, executorId: string, srv: ReturnType<typeof makeServer>): AcquireAcrossMachinesOptions {
+    return {
+      key: taskLeaseKey(SERVER, TOKEN, "king", 9),
+      channel: "king",
+      taskId: 9,
+      executorId,
+      server: SERVER,
+      token: TOKEN,
+      dir: taskLeaseDir(homeDir),
+      claim: srv.claim,
+    };
+  }
+
+  test("两台机器（两个 AGENTPARTY_HOME）的同一身份：第二台被拒，且说得出谁持有", async () => {
     const other = mkdtempSync(join(tmpdir(), "ap-lease-other-home-"));
+    const srv = makeServer();
     try {
-      const key = taskLeaseKey(SERVER, TOKEN, "king", 9);
-      const first = acquireTaskLease({ key, channel: "king", taskId: 9, executorId: "runner:claude:a", dir: taskLeaseDir(home) });
-      const second = acquireTaskLease({ key, channel: "king", taskId: 9, executorId: "session:claude:b", dir: taskLeaseDir(other) });
+      const first = await acquireTaskLeaseAcrossMachines(machine(home, "runner:claude:a", srv));
+      const second = await acquireTaskLeaseAcrossMachines(machine(other, "session:claude:b", srv));
       expect(first.state).toBe("acquired");
-      expect(second.state).toBe("acquired"); // ← 缺口：互斥只在同一个 home 内成立
-      // 缺口不许被静默：任何一次「没落闸/落闸」的呈现都必须带上这句边界。
-      expect(formatTaskLeaseEnforcement(diagnoseTaskLeaseEnforcement({})).join("\n")).toMatch(/另一台机器.*仍挡不住/);
+      expect(first.scope).toBe("server");
+      // ← 这一行就是 #935 钉住的那个缺口，现在必须是 denied。
+      expect(second.state).toBe("denied");
+      expect(second.scope).toBe("server");
+      expect(second.holder?.executor_id).toBe("runner:claude:a");
+      // 拒绝不能吞任务：被拒方要能知道等多久（#885 红线的可执行那一半）。
+      expect(second.holder?.expires_at).toBeGreaterThan(Date.now());
+      // 被拒的一方不许在本机留下一张自己不用、却挡着别人的租约（#908 那类锁残留）。
+      expect(readTaskLease(taskLeaseKey(SERVER, TOKEN, "king", 9), taskLeaseDir(other))).toBeNull();
+    } finally {
+      rmSync(other, { recursive: true, force: true });
+    }
+  });
+
+  test("降级：老服务端不认这条路由 ⇒ 退回本机租约，**不放行**", async () => {
+    const other = mkdtempSync(join(tmpdir(), "ap-lease-legacy-"));
+    // 老服务端 = 路由没命中，Hono 回裸 404（没有 error.code）。
+    const legacy: NonNullable<AcquireAcrossMachinesOptions["claim"]> = async () => {
+      throw new RestError(404, null, "404 Not Found", null);
+    };
+    try {
+      const opts: AcquireAcrossMachinesOptions = { ...machine(home, "runner:claude:a", makeServer()), claim: legacy };
+      const first = await acquireTaskLeaseAcrossMachines(opts);
+      expect(first.state).toBe("acquired");
+      // 退回本机，并且**说出来**——scope 必须是 local_home，否则调用方会误读成跨机已互斥。
+      expect(first.scope).toBe("local_home");
+      expect(first.degraded).toBe("server_unsupported");
+
+      // 「退回本机」≠「放行」：同一个 HOME 内的第二个执行体照样被拒。
+      const sameHome = await acquireTaskLeaseAcrossMachines({ ...opts, executorId: "session:claude:b" });
+      expect(sameHome.state).toBe("denied");
+      expect(sameHome.scope).toBe("local_home");
+      expect(sameHome.holder?.executor_id).toBe("runner:claude:a");
+
+      // 另一个 HOME 仍挡不住——这是老服务端下**已知且被说出来**的边界，不是静默缺口。
+      const otherHome = await acquireTaskLeaseAcrossMachines({
+        ...opts,
+        dir: taskLeaseDir(other),
+        executorId: "session:claude:b",
+      });
+      expect(otherHome.state).toBe("acquired");
+      expect(otherHome.degraded).toBe("server_unsupported");
+
+      // 降级带回来的必须是**本机那次判定的真实结果**，不是一个「反正放行」的常量。
+      // 逐项翻一遍本机能给出的每一种非拒绝结论：
+      const renewed = await acquireTaskLeaseAcrossMachines(opts);
+      expect(renewed.state).toBe("renewed");
+      expect(renewed.holder?.executor_id).toBe("runner:claude:a");
+      const forced = await acquireTaskLeaseAcrossMachines({ ...opts, executorId: "session:claude:b", force: true });
+      expect(forced.state).toBe("forced");
+      expect(forced.holder?.taken_over_from).toBe("runner:claude:a");
+      // 认不出执行体时降级不许被粉饰成「拿到了」——那正是 #931 修掉的那种假象。
+      const unenforced = await acquireTaskLeaseAcrossMachines({ ...opts, executorId: null });
+      expect(unenforced.state).toBe("unenforced");
+      expect(unenforced.reason).toBe("no_executor_identity");
+    } finally {
+      rmSync(other, { recursive: true, force: true });
+    }
+  });
+
+  test("服务端在但这次没答上来（网络抖动/5xx）：同样退回本机，原因与老服务端分开", async () => {
+    const flaky: NonNullable<AcquireAcrossMachinesOptions["claim"]> = async () => {
+      throw new RestError(503, "unavailable", "upstream down", { error: { code: "unavailable" } });
+    };
+    const res = await acquireTaskLeaseAcrossMachines({
+      ...machine(home, "runner:claude:a", makeServer()),
+      claim: flaky,
+    });
+    expect(res.state).toBe("acquired");
+    expect(res.scope).toBe("local_home");
+    // 两档的修法完全不同：一个是升级服务端，一个是重试。塌缩成一个 boolean 就说不清了。
+    expect(res.degraded).toBe("server_unavailable");
+  });
+
+  test("真 404（频道/任务不存在，带 error.code）不算「老服务端」", async () => {
+    const missing: NonNullable<AcquireAcrossMachinesOptions["claim"]> = async () => {
+      throw new RestError(404, "not_found", "task not found", { error: { code: "not_found" } });
+    };
+    const res = await acquireTaskLeaseAcrossMachines({
+      ...machine(home, "runner:claude:a", makeServer()),
+      claim: missing,
+    });
+    expect(res.degraded).toBe("server_unavailable");
+    expect(serverLeaseUnsupported(new RestError(404, "not_found", "x", null))).toBe(false);
+    expect(serverLeaseUnsupported(new RestError(404, null, "404 Not Found", null))).toBe(true);
+  });
+
+  test("认不出执行体：不给服务端发任何请求（没有可上送的标识），并如实报 unenforced", async () => {
+    const srv = makeServer();
+    const res = await acquireTaskLeaseAcrossMachines({ ...machine(home, "x", srv), executorId: null });
+    expect(res.state).toBe("unenforced");
+    expect(res.scope).toBe("local_home");
+    expect(srv.calls).toEqual([]);
+  });
+
+  test("本机就能答「被拒」时不发网络请求（结论不会因为问服务端而改变）", async () => {
+    const srv = makeServer();
+    // 本机先由另一个执行体持租——注意这里**没有**经过服务端，模拟一个老 CLI 留下的本机租约。
+    acquireTaskLease({
+      key: taskLeaseKey(SERVER, TOKEN, "king", 9),
+      channel: "king",
+      taskId: 9,
+      executorId: "runner:legacy",
+      dir: taskLeaseDir(home),
+    });
+    const res = await acquireTaskLeaseAcrossMachines(machine(home, "session:new", srv));
+    expect(res.state).toBe("denied");
+    expect(res.scope).toBe("local_home");
+    expect(srv.calls).toEqual([]);
+  });
+
+  test("--force-lease 一路传到服务端；被抢的那个记进 taken_over_from", async () => {
+    const other = mkdtempSync(join(tmpdir(), "ap-lease-force-"));
+    const srv = makeServer();
+    try {
+      await acquireTaskLeaseAcrossMachines(machine(home, "runner:incumbent", srv));
+      const forced = await acquireTaskLeaseAcrossMachines({
+        ...machine(other, "runner:taker", srv),
+        force: true,
+      });
+      expect(forced.state).toBe("forced");
+      expect(forced.scope).toBe("server");
+      expect(forced.holder?.taken_over_from).toBe("runner:incumbent");
+      expect(srv.calls.at(-1)).toEqual({ executor_id: "runner:taker", force: true });
+    } finally {
+      rmSync(other, { recursive: true, force: true });
+    }
+  });
+
+  test("交还后另一台机器立刻能接手（不必等 TTL）", async () => {
+    const other = mkdtempSync(join(tmpdir(), "ap-lease-release-"));
+    const srv = makeServer();
+    const releasedFor: string[] = [];
+    try {
+      await acquireTaskLeaseAcrossMachines(machine(home, "runner:a", srv));
+      expect((await acquireTaskLeaseAcrossMachines(machine(other, "runner:b", srv))).state).toBe("denied");
+      await releaseTaskLeaseAcrossMachines({
+        server: SERVER,
+        token: TOKEN,
+        key: taskLeaseKey(SERVER, TOKEN, "king", 9),
+        channel: "king",
+        taskId: 9,
+        executorId: "runner:a",
+        dir: taskLeaseDir(home),
+        release: async (_s, _t, slug, id, executorId) => {
+          releasedFor.push(executorId);
+          srv.ledger.delete(`${slug}#${id}`);
+          return { type: "task_lease", state: "released", scope: "server", released: true };
+        },
+      });
+      expect(releasedFor).toEqual(["runner:a"]);
+      expect((await acquireTaskLeaseAcrossMachines(machine(other, "runner:b", srv))).state).toBe("acquired");
     } finally {
       rmSync(other, { recursive: true, force: true });
     }

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -415,6 +415,115 @@ export interface TaskRecord {
   completed_at: number | null;
 }
 
+// ---- 任务租约（#936）：把 #885 的本机文件锁抬到服务端 ----
+//
+// #885 在**认领时刻**装了一道「同一身份只允许一个执行体动这件事」的闸，但它只在本机文件级
+// 成立（`$AGENTPARTY_HOME/task-leases`）。同一身份在两台机器（或同机两个 AGENTPARTY_HOME）
+// 上并发认领同一个 task，两边都会成功——闸装了，最需要它的跨机场景恒是开的。
+//
+// 服务端要区分同一身份的两个执行体，手上只有 token（两条腿的 token 完全相同），所以**必须由
+// 客户端把执行体标识送上去**。这就是这里这组线上类型存在的理由，也是它天然的边界：
+//
+//   executor_id 是客户端自报的，因此它**只用来区分同一身份的不同执行体，绝不参与任何鉴权**。
+//   租约行的主键三要素（channel / task / identity）全部由服务端从 bearer token 推出，
+//   请求体里的 executor_id 只是那一行**内部**的值。换一个 executor_id 能改变的只有「我算不算
+//   当前持租的那个执行体」，永远越不出「同一 token 同一频道同一 task」这一格。
+//
+// 形状对齐 #99 的 serve_lease：同一身份多个候选里选唯一持租者、断线/超时后租约回收改选、
+// 明确告诉每个候选自己此刻持不持租。差别只在载体——serve_lease 挂在长连接上（断连即隐式释放），
+// 任务认领是一次性 HTTP 调用（写完即退），没有连接可挂，所以租约必须落库并靠 TTL 过期自愈。
+
+/** 服务端 `/api/version` 的能力清单里，「支持任务租约端点」的名字。 */
+export const TASK_LEASE_FEATURE = "task_lease";
+
+/** 租约到底在哪一层成立。`local_home` = 只挡得住同一个 AGENTPARTY_HOME；`server` = 跨机。 */
+export type TaskLeaseScope = "server" | "local_home";
+
+/** 默认租期。与 serve 的 runner 超时（30min）对齐：一个执行体最多能占这么久。 */
+export const TASK_LEASE_DEFAULT_TTL_MS = 30 * 60_000;
+/**
+ * 服务端对租期的钳制。
+ *
+ * **上限**是防死锁的关键：租期和 executor_id 一样由客户端自报，不钳死上限，一个手滑（或恶意）
+ * 的 ttl_ms 就能把一个 task 锁到天荒地老，而服务端没有任何探活手段能救它。钳住之后最坏情况
+ * 有确定上界：别人最多等这么久就能合法接手。
+ *
+ * **下限**只用来挡住 0/负数，刻意不设一个「像样的」地板：短租期只会让持租方更早放手，
+ * 伤不到任何别人；反而是给它设地板会让 `--lease-ttl-ms` 在本机与服务端两层给出不同答案。
+ */
+export const TASK_LEASE_MIN_TTL_MS = 1;
+export const TASK_LEASE_MAX_TTL_MS = 60 * 60_000;
+
+/**
+ * 执行体标识的合法字符集。**客户端与服务端必须用同一份**——两边各写一个正则，就会出现
+ * 「本机认得出、服务端 400」或反过来的静默分叉（#622 那次 allow-list 镜像漂移的同款形态）。
+ */
+export const EXECUTOR_ID_MAX_LENGTH = 128;
+export function isExecutorId(value: unknown): value is string {
+  return typeof value === "string" && /^[A-Za-z0-9][A-Za-z0-9._:@-]{0,127}$/.test(value);
+}
+
+export interface TaskLeaseHolderInfo {
+  executor_id: string;
+  channel: string;
+  task_id: number;
+  acquired_at: number;
+  renewed_at: number;
+  expires_at: number;
+  /** 被 force 抢占时记下被抢的那个执行体，便于事后对账。 */
+  taken_over_from?: string;
+}
+
+/** 首次拿到（含接手已过期的租约） / 本执行体续期 / 显式抢占 / 被拒。 */
+export type TaskLeaseGrantState = "acquired" | "renewed" | "forced";
+export type TaskLeaseWireState = TaskLeaseGrantState | "denied";
+
+/** POST /api/channels/:slug/tasks/:id/lease 的请求体。op 与 serve_lease 的 op 同名同义。 */
+export interface TaskLeaseRequest {
+  op?: "claim" | "release";
+  /** 客户端自报的执行体标识。不合法 → 400；**不参与任何鉴权判定**。 */
+  executor_id: string;
+  ttl_ms?: number;
+  /** 显式抢占当前持租者（对应 CLI 的 --force-lease）。 */
+  force?: boolean;
+}
+
+export interface TaskLeaseGrantedResponse {
+  type: "task_lease";
+  state: TaskLeaseGrantState;
+  scope: "server";
+  holder: TaskLeaseHolderInfo;
+  /** acquired 时说明是不是接手了一张过期租约；forced 时说明是抢来的。 */
+  reason?: "expired" | "taken_over";
+  ttl_ms: number;
+  server_time: number;
+}
+
+/**
+ * 被拒的回执。红线（#885 已确立，服务端租约同样要守）：**拒绝不能吞任务**。
+ * 服务端在这条路径上不碰 channel_tasks 一个字节，并且必须把「谁持有、何时过期」摆出来，
+ * 而不是一句 403——被拒的一方要能判断该等多久、该不该 force，而不是只知道自己不被允许。
+ */
+export interface TaskLeaseDeniedResponse {
+  error: { code: "task_lease_held"; message: string };
+  type: "task_lease";
+  state: "denied";
+  scope: "server";
+  reason: "held_by_other";
+  holder: TaskLeaseHolderInfo;
+  /** 任务原样留着——这个字段是给程序读的那半句话。 */
+  task_untouched: true;
+  server_time: number;
+}
+
+export interface TaskLeaseReleasedResponse {
+  type: "task_lease";
+  state: "released";
+  scope: "server";
+  /** false = 当前租约不是本执行体的（已被合法接手），什么都没删。 */
+  released: boolean;
+}
+
 /**
  * 频道级「当前已定稿」账本（#736）。每次变更都 append 新行；supersedes_id 显式指向
  * 被替代的旧结论，服务端通过独立 head 指针投影 status / superseded_by_id。
@@ -523,6 +632,9 @@ export type ErrorCode =
 export type RestErrorCode =
   | ErrorCode
   | "conflict"
+  // 任务租约冲突（#936）：同一身份的另一个执行体持有该 task 的服务端租约。刻意与 forbidden
+  // 分开——它不是「你没权限」，而是「此刻轮不到你，等 N 秒或显式接手」，语义完全不同。
+  | "task_lease_held"
   | "unavailable"
   | "forbidden"
   | "participant_removed"

--- a/worker/migrations/0044_channel_task_leases.sql
+++ b/worker/migrations/0044_channel_task_leases.sql
@@ -1,0 +1,46 @@
+-- Server-side (identity, channel, task) claim lease — issue #936.
+--
+-- #885 put the gate at the claim moment, but only as a file lock under
+-- $AGENTPARTY_HOME/task-leases: the same identity on two machines both won.
+-- This table is that same lease, moved to the one place both machines can see.
+--
+-- Shape follows #99's serve_lease: among several execution runtimes of ONE
+-- identity, exactly one holds; the others are told who holds and until when.
+-- The difference is the carrier — serve_lease hangs off a live WebSocket (a
+-- disconnect implicitly releases it), while a task claim is a one-shot HTTP call
+-- that exits immediately. With no connection to hang on, the lease must be
+-- durable and must expire on its own, or a dead executor would pin the task
+-- forever (#908 already paid for one orphan-lock deadlock).
+--
+-- Identity is the SERVER's notion of identity, never anything the client says:
+--   identity_name      = the token's agent/human name
+--   identity_principal = owner account, or token-sha256:<hash> for legacy tokens
+-- (identical to do.ts identityDeliveryPrincipal, so a revoked-and-reminted token
+-- under a new owner never inherits the old owner's lease).
+--
+-- executor_id is the ONLY client-supplied part, and it lives strictly INSIDE a
+-- row already scoped by the three server-derived columns. It can distinguish two
+-- runtimes of one identity; it can never reach another identity's row.
+--
+-- The server dimension (#865: one machine talking to two production instances
+-- that both have a #agentparty) is structural here — each deployment has its own
+-- D1, so two instances cannot collide by construction.
+CREATE TABLE IF NOT EXISTS channel_task_leases (
+  channel_slug TEXT NOT NULL,
+  task_id INTEGER NOT NULL,
+  identity_name TEXT NOT NULL,
+  identity_principal TEXT NOT NULL,
+  executor_id TEXT NOT NULL,
+  acquired_at INTEGER NOT NULL,
+  renewed_at INTEGER NOT NULL,
+  expires_at INTEGER NOT NULL,
+  taken_over_from TEXT,
+  PRIMARY KEY (channel_slug, task_id, identity_name, identity_principal),
+  FOREIGN KEY (channel_slug) REFERENCES channels(slug) ON DELETE CASCADE
+);
+
+-- Opportunistic reclaim sweep: "everything in this channel that has already
+-- lapsed". Expiry is the only self-healing path, so it must stay cheap enough to
+-- run on every claim.
+CREATE INDEX IF NOT EXISTS idx_channel_task_leases_expiry
+  ON channel_task_leases(channel_slug, expires_at);

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -8,7 +8,9 @@ import {
   DEFAULT_MEMBERSHIP,
   FREE_ATTACHMENT_SIZE_LIMIT,
   FREE_CHANNEL_CAP,
+  isExecutorId,
   isMember,
+  EXECUTOR_ID_MAX_LENGTH,
   LOOP_GUARD_N,
   LOOP_GUARD_PARTY_N,
   MAX_CHANNELS_PER_ACCOUNT,
@@ -18,6 +20,10 @@ import {
   parseRuntimeTopology,
   RESERVED_NAMES,
   ROLE_RESPONSIBILITY_LIMIT,
+  TASK_LEASE_DEFAULT_TTL_MS,
+  TASK_LEASE_FEATURE,
+  TASK_LEASE_MAX_TTL_MS,
+  TASK_LEASE_MIN_TTL_MS,
 } from "@agentparty/shared";
 import type {
   AgentLineage,
@@ -39,6 +45,11 @@ import type {
   ParticipantRemovedFrame,
   RestErrorCode,
   TaskAssigneeKind,
+  TaskLeaseDeniedResponse,
+  TaskLeaseGrantState,
+  TaskLeaseGrantedResponse,
+  TaskLeaseHolderInfo,
+  TaskLeaseReleasedResponse,
   TaskRecord,
   TaskSummary,
   StatusState,
@@ -2891,6 +2902,10 @@ app.get("/api/version", (c) => {
     ...DEPLOYMENT_METADATA,
     min_client_version: resolveMinClientVersion(c.env.MIN_CLIENT_VERSION),
     min_client_enforced: isEnforced(c.env.MIN_CLIENT_ENFORCE),
+    // 能力清单（#936）：协议新增的端点在这里显式声明，诊断/doctor 据此说清「这台服务端的
+    // 任务租约是跨机的还是只到本机」。认领热路径不查它（多一次 RTT、多一个失败面），走的是
+    // 「未命中路由的 404 没有 error.code」这个形状判定——两条信号指向同一个结论。
+    features: [TASK_LEASE_FEATURE],
   });
 });
 
@@ -7571,6 +7586,203 @@ app.patch("/api/channels/:slug/tasks/:id", async (c) => {
   const row = await loadTaskRow(c.env.DB, slug, id);
   await insertSystemStatus(c.env, slug, `task #${id} ${state}`, statusStateForTask(state)).catch(() => false);
   return c.json(taskRowToRecord(row!));
+});
+
+// ---- 任务租约（#936）：把 #885 的本机文件锁抬到服务端 ----
+//
+// 为什么是一个**独立端点**而不是给 PATCH /tasks/:id 加一个 executor_id 字段：
+//   1. 老客户端不送字段也必须照常改任务状态（不能因为不送字段就被拒）。独立端点天然满足——
+//      老客户端只是从不调用它，PATCH 路径一个字节都没变。
+//   2. 认领这一刻要「先判定、再动任何东西」。塞进 PATCH 里就成了「先改再判」，被拒时任务
+//      已经被动过了——正好违反 #885 立下的红线：拒绝不能吞任务。
+//
+// 与 #99 serve_lease 的对齐点：同一身份的多个候选里选唯一持租者；持租者消失后租约回收改选；
+// 每个候选都被明确告知自己此刻持不持租、以及谁在持。差别只在载体：serve_lease 挂在长连接上
+// （断连即隐式释放，presence 扫描兜底），任务认领是一次性 HTTP（写完即退），没有连接可挂，
+// 所以这里靠 TTL 过期自愈，并把上限钉死（见 clampTaskLeaseTtl）。
+
+function taskLeasePrincipal(identity: TokenIdentity): string {
+  // 与 do.ts identityDeliveryPrincipal 同一份判据：token 被撤销后同名复用给另一个 owner 时，
+  // 新 owner 不该继承旧 owner 的租约，也不该被旧 owner 的残留租约压住。
+  return typeof identity.owner === "string" && identity.owner.length > 0
+    ? identity.owner
+    : `token-sha256:${identity.hash}`;
+}
+
+// 租期钳制是**防死锁的关键一环**：executor_id 由客户端自报，租期也一样。不钳死上限，一个
+// 手滑（或恶意）的 ttl_ms 就能把一个 task 锁到天荒地老，而服务端没有任何探活手段能救它。
+// 钳住之后最坏情况有确定上界：别人最多等 TASK_LEASE_MAX_TTL_MS 就能合法接手。
+function clampTaskLeaseTtl(raw: unknown): number | null {
+  if (raw === undefined || raw === null) return TASK_LEASE_DEFAULT_TTL_MS;
+  if (typeof raw !== "number" || !Number.isFinite(raw) || !Number.isInteger(raw) || raw <= 0) return null;
+  return Math.min(TASK_LEASE_MAX_TTL_MS, Math.max(TASK_LEASE_MIN_TTL_MS, raw));
+}
+
+interface TaskLeaseRow {
+  executor_id: string;
+  channel_slug: string;
+  task_id: number;
+  acquired_at: number;
+  renewed_at: number;
+  expires_at: number;
+  taken_over_from: string | null;
+}
+
+function taskLeaseHolder(row: TaskLeaseRow): TaskLeaseHolderInfo {
+  return {
+    executor_id: row.executor_id,
+    channel: row.channel_slug,
+    task_id: row.task_id,
+    acquired_at: row.acquired_at,
+    renewed_at: row.renewed_at,
+    expires_at: row.expires_at,
+    ...(row.taken_over_from === null ? {} : { taken_over_from: row.taken_over_from }),
+  };
+}
+
+app.post("/api/channels/:slug/tasks/:id/lease", async (c) => {
+  const slug = c.req.param("slug");
+  const channel = await loadChannel(c.env.DB, slug);
+  if (!channel) return c.json(errorBody("not_found", "channel not found"), 404);
+  const identity = c.get("identity");
+  // 鉴权全部在租约逻辑**之前**跑完，且只看 bearer token。请求体里的 executor_id 到这里还没被
+  // 读过一眼——它永远不可能让一个够不着这个频道的调用方够着它。
+  if (!(await canAccessLoadedChannel(c.env.DB, identity, channel))) {
+    return c.json(errorBody("forbidden", "not allowed in this channel"), 403);
+  }
+  if (identity.role === "readonly") {
+    return c.json(errorBody("forbidden", "readonly token cannot claim tasks"), 403);
+  }
+  if (channel.archived_at !== null) return c.json(errorBody("archived", "channel is archived"), 410);
+  const id = positiveInt(Number(c.req.param("id")));
+  if (id === null) return c.json(errorBody("bad_request", "id must be a positive integer"), 400);
+  if (!(await loadTaskRow(c.env.DB, slug, id))) return c.json(errorBody("not_found", "task not found"), 404);
+  const body = (await c.req.json().catch(() => null)) as Record<string, unknown> | null;
+  if (!body) return c.json(errorBody("bad_request", "json body required"), 400);
+  const op = body.op === undefined ? "claim" : body.op;
+  if (op !== "claim" && op !== "release") {
+    return c.json(errorBody("bad_request", "op must be claim|release"), 400);
+  }
+  // 客户端与服务端共用 shared 的 isExecutorId，两边各写一个正则就会静默分叉（#622 同款）。
+  if (!isExecutorId(body.executor_id)) {
+    return c.json(
+      errorBody("bad_request", `executor_id must match [A-Za-z0-9][A-Za-z0-9._:@-]{0,${EXECUTOR_ID_MAX_LENGTH - 1}}`),
+      400,
+    );
+  }
+  const executorId = body.executor_id;
+  const principal = taskLeasePrincipal(identity);
+  const now = Date.now();
+
+  if (op === "release") {
+    // 只删自己的那张。别人已经在过期后合法接手时绝不动它，否则一个迟到的 `status done` 会
+    // 把新执行体的租约抹掉。
+    const released = await c.env.DB.prepare(
+      `DELETE FROM channel_task_leases
+        WHERE channel_slug = ? AND task_id = ? AND identity_name = ? AND identity_principal = ?
+          AND executor_id = ?`,
+    )
+      .bind(slug, id, identity.name, principal, executorId)
+      .run();
+    const releasedBody: TaskLeaseReleasedResponse = {
+      type: "task_lease",
+      state: "released",
+      scope: "server",
+      // false = 当前租约不是本执行体的（已被合法接手 / 早已过期清掉），什么都没删。
+      released: (released.meta?.changes ?? 0) > 0,
+    };
+    return c.json(releasedBody);
+  }
+
+  const ttlMs = clampTaskLeaseTtl(body.ttl_ms);
+  if (ttlMs === null) return c.json(errorBody("bad_request", "ttl_ms must be a positive integer"), 400);
+  const force = body.force === true;
+  const expiresAt = now + ttlMs;
+
+  // 判定与写入必须是**同一条语句**。先 SELECT 再 INSERT 会让两个执行体各自读到「没人持租」
+  // 然后双双写入——那正是本 issue 要修的那个形状，只不过挪到了服务端。upsert 的 WHERE 让
+  // SQLite 在同一次写里裁决：条件不满足则一行都不改，RETURNING 空即「被拒」。
+  const upsert = await c.env.DB.prepare(
+    `INSERT INTO channel_task_leases
+       (channel_slug, task_id, identity_name, identity_principal, executor_id,
+        acquired_at, renewed_at, expires_at, taken_over_from)
+     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?6, ?7, NULL)
+     ON CONFLICT(channel_slug, task_id, identity_name, identity_principal) DO UPDATE SET
+       executor_id = excluded.executor_id,
+       acquired_at = CASE WHEN channel_task_leases.executor_id = excluded.executor_id
+                          THEN channel_task_leases.acquired_at ELSE excluded.acquired_at END,
+       renewed_at = excluded.renewed_at,
+       expires_at = excluded.expires_at,
+       taken_over_from = CASE
+         WHEN channel_task_leases.executor_id = excluded.executor_id THEN NULL
+         WHEN channel_task_leases.expires_at > excluded.renewed_at THEN channel_task_leases.executor_id
+         ELSE NULL END
+     WHERE channel_task_leases.executor_id = excluded.executor_id
+        OR channel_task_leases.expires_at <= excluded.renewed_at
+        OR ?8 = 1
+     RETURNING *`,
+  )
+    .bind(slug, id, identity.name, principal, executorId, now, expiresAt, force ? 1 : 0)
+    .all<TaskLeaseRow>();
+  const granted = (upsert.results ?? [])[0];
+
+  if (granted === undefined) {
+    // 被拒。红线：**这条路径一个字节都不碰 channel_tasks**，任务原样留在频道里，持租的执行体
+    // 照常干。回执必须说出「谁持有、何时过期」——一句 403 会让被拒方既不知道等多久，也不知道
+    // 该不该 force，只能改个措辞重试，那和吞掉任务没有区别。
+    const current = await c.env.DB.prepare(
+      `SELECT * FROM channel_task_leases
+        WHERE channel_slug = ? AND task_id = ? AND identity_name = ? AND identity_principal = ?`,
+    )
+      .bind(slug, id, identity.name, principal)
+      .first<TaskLeaseRow>();
+    if (current === null) {
+      // 只可能是两条并发请求之间对方刚好释放了。让调用方立刻重试一次，而不是把它误报成冲突。
+      return c.json(errorBody("conflict", "task lease changed concurrently; retry"), 409);
+    }
+    const holder = taskLeaseHolder(current);
+    const denied: TaskLeaseDeniedResponse = {
+      error: {
+        code: "task_lease_held",
+        message:
+          `task ${id} on #${slug} is held by another execution runtime of this identity ` +
+          `(holder=${holder.executor_id}, expires_in=${Math.max(0, Math.ceil((holder.expires_at - now) / 1000))}s); ` +
+          "the task was not touched",
+      },
+      type: "task_lease",
+      state: "denied",
+      scope: "server",
+      reason: "held_by_other",
+      holder,
+      task_untouched: true,
+      server_time: now,
+    };
+    return c.json(denied, 409);
+  }
+
+  // 自愈（#908 同款保守收尾）：顺手清掉本频道里早已过期的租约行。刚写的这张没过期，扫不到它。
+  // 服务端**不做任何存活推断**——它看不见对端进程，猜「那个执行体大概死了」只会把一个还活着的
+  // 执行体踢掉。唯一的回收依据是租期真的走完，拿不准一律当持租者还活着（parent-liveness 同款）。
+  await c.env.DB.prepare(
+    "DELETE FROM channel_task_leases WHERE channel_slug = ? AND expires_at <= ?",
+  )
+    .bind(slug, now)
+    .run()
+    .catch(() => undefined);
+
+  const holder = taskLeaseHolder(granted);
+  const state: TaskLeaseGrantState =
+    holder.taken_over_from !== undefined ? "forced" : holder.acquired_at === now ? "acquired" : "renewed";
+  const ok: TaskLeaseGrantedResponse = {
+    type: "task_lease",
+    state,
+    scope: "server",
+    holder,
+    ...(state === "forced" ? { reason: "taken_over" as const } : {}),
+    ttl_ms: ttlMs,
+    server_time: now,
+  };
+  return c.json(ok);
 });
 
 app.get("/api/channels/:slug/captures", async (c) => {

--- a/worker/src/openapi.ts
+++ b/worker/src/openapi.ts
@@ -1305,6 +1305,54 @@ export const openapiDocument = {
         },
       },
     },
+    "/api/channels/{slug}/tasks/{id}/lease": {
+      post: {
+        summary:
+          "claim or release the (identity, channel, task) claim lease (#936). Identity comes from the bearer token; " +
+          "executor_id only distinguishes execution runtimes OF THAT SAME identity and never widens access. " +
+          "A denial NEVER touches the task - the body names the current holder and its expiry so the caller can " +
+          "decide whether to wait or take over explicitly.",
+        security: [{ bearer: [] }],
+        parameters: [
+          { name: "slug", in: "path", required: true, schema: { type: "string" } },
+          { name: "id", in: "path", required: true, schema: { type: "integer", minimum: 1 } },
+        ],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                required: ["executor_id"],
+                properties: {
+                  op: { type: "string", enum: ["claim", "release"], default: "claim" },
+                  executor_id: {
+                    type: "string",
+                    maxLength: 128,
+                    pattern: "^[A-Za-z0-9][A-Za-z0-9._:@-]{0,127}$",
+                    description: "client-reported execution-runtime id; scoped to the token's identity, never an authz input",
+                  },
+                  ttl_ms: {
+                    type: "integer",
+                    minimum: 1,
+                    description: "clamped server-side to at most 3600000 so a self-reported ttl can never pin a task indefinitely",
+                  },
+                  force: { type: "boolean", description: "explicitly take over a live lease (CLI --force-lease)" },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          "200": { description: "{type:'task_lease',state:acquired|renewed|forced|released,scope:'server',holder,ttl_ms}" },
+          "400": { description: "invalid op / executor_id / ttl_ms" },
+          "403": { description: "readonly token or not allowed in this channel" },
+          "404": { description: "channel or task not found" },
+          "409": { description: "task_lease_held - another execution runtime of this identity holds it; task_untouched:true" },
+          "410": { description: "channel archived" },
+        },
+      },
+    },
     "/api/channels/{slug}/search": {
       get: {
         summary: "server-side retained history search",

--- a/worker/test/task-lease.spec.ts
+++ b/worker/test/task-lease.spec.ts
@@ -1,0 +1,339 @@
+// 服务端 (identity, channel, task) 租约 —— issue #936。
+//
+// 被测的是「同一身份的第二个执行体拿不到这个 task」这一件事，以及它的三条边界：
+//   1. 拒绝不能吞任务（#885 立的红线）——被拒时 channel_tasks 必须一个字节没动；
+//   2. 必须能自愈——租期走完就能被合法接手，服务端绝不靠猜存活（#908）；
+//   3. executor_id 是客户端自报的，只能用来区分同一身份的不同执行体，**绝不放大权限**。
+//
+// 反向用例刻意逐条翻转判定的每一个维度（task / name / principal / 频道可达性 / 角色），
+// 确保「被拒」只可能由被测的那道闸产生，而不是被别的分支顺手挡掉。
+import { env } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import { api, createChannel, seedToken, uniq } from "./helpers";
+
+async function createTask(slug: string, token: string, title = "claimable"): Promise<number> {
+  const res = await api(`/api/channels/${slug}/tasks`, token, {
+    method: "POST",
+    body: JSON.stringify({ title }),
+  });
+  if (res.status !== 201) throw new Error(`create task failed: ${res.status} ${await res.text()}`);
+  return ((await res.json()) as { id: number }).id;
+}
+
+function claim(
+  slug: string,
+  id: number,
+  token: string,
+  body: Record<string, unknown>,
+): Promise<Response> {
+  return api(`/api/channels/${slug}/tasks/${id}/lease`, token, {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+async function readTask(slug: string, id: number, token: string) {
+  const res = await api(`/api/channels/${slug}/tasks/${id}`, token);
+  return (await res.json()) as { state: string; updated_at: number; title: string };
+}
+
+/** 把租约行的到期时刻推到过去。只造「租期已走完」这个前提，判定仍走真实的认领路径。 */
+async function expireLease(slug: string, id: number): Promise<void> {
+  const res = await env.DB.prepare(
+    "UPDATE channel_task_leases SET expires_at = ? WHERE channel_slug = ? AND task_id = ?",
+  )
+    .bind(1, slug, id)
+    .run();
+  if ((res.meta?.changes ?? 0) === 0) throw new Error("expireLease matched no row — fixture is wrong");
+}
+
+describe("server task lease (#936)", () => {
+  it("同一身份的第二个执行体被拒，且拿到「谁持有、何时过期」", async () => {
+    const owner = `${uniq("owner")}@example.com`;
+    const agent = await seedToken("agent", uniq("agent"), { owner });
+    const slug = await createChannel(agent.token);
+    const task = await createTask(slug, agent.token);
+
+    const first = await claim(slug, task, agent.token, { executor_id: "runner:claude:a" });
+    expect(first.status).toBe(200);
+    expect(await first.json()).toMatchObject({
+      type: "task_lease",
+      state: "acquired",
+      scope: "server",
+      holder: { executor_id: "runner:claude:a", task_id: task, channel: slug },
+    });
+
+    // 同一个 token（同一身份），另一个执行体。
+    const second = await claim(slug, task, agent.token, { executor_id: "session:claude:b" });
+    expect(second.status).toBe(409);
+    const denied = (await second.json()) as Record<string, unknown>;
+    expect(denied).toMatchObject({
+      error: { code: "task_lease_held" },
+      state: "denied",
+      scope: "server",
+      reason: "held_by_other",
+      task_untouched: true,
+      holder: { executor_id: "runner:claude:a" },
+    });
+    // 一句 403 说不出「等多久 / 该不该 force」。持有者与到期时刻必须在回执里。
+    const holder = denied.holder as { expires_at: number };
+    expect(holder.expires_at).toBeGreaterThan(Date.now());
+    expect(String((denied.error as { message: string }).message)).toContain("runner:claude:a");
+  });
+
+  it("拒绝 ≠ 吞任务：被拒那次没碰 channel_tasks 一个字节", async () => {
+    const owner = `${uniq("owner")}@example.com`;
+    const agent = await seedToken("agent", uniq("agent"), { owner });
+    const slug = await createChannel(agent.token);
+    const task = await createTask(slug, agent.token);
+    await claim(slug, task, agent.token, { executor_id: "runner:a" });
+
+    const before = await readTask(slug, task, agent.token);
+    const denied = await claim(slug, task, agent.token, { executor_id: "runner:b" });
+    expect(denied.status).toBe(409);
+    const after = await readTask(slug, task, agent.token);
+    expect(after).toEqual(before);
+    // 持租者仍然照常干活：它的认领路径没有被这次拒绝影响。
+    const patched = await api(`/api/channels/${slug}/tasks/${task}`, agent.token, {
+      method: "PATCH",
+      body: JSON.stringify({ state: "in_progress" }),
+    });
+    expect(patched.status).toBe(200);
+  });
+
+  it("持租者续期：acquired_at 不变、到期时刻前移，state=renewed", async () => {
+    const owner = `${uniq("owner")}@example.com`;
+    const agent = await seedToken("agent", uniq("agent"), { owner });
+    const slug = await createChannel(agent.token);
+    const task = await createTask(slug, agent.token);
+
+    const first = (await (await claim(slug, task, agent.token, { executor_id: "runner:a" })).json()) as {
+      holder: { acquired_at: number; expires_at: number };
+    };
+    await new Promise((r) => setTimeout(r, 5));
+    const again = await claim(slug, task, agent.token, { executor_id: "runner:a" });
+    expect(again.status).toBe(200);
+    const renewed = (await again.json()) as { state: string; holder: { acquired_at: number; expires_at: number } };
+    expect(renewed.state).toBe("renewed");
+    expect(renewed.holder.acquired_at).toBe(first.holder.acquired_at);
+    expect(renewed.holder.expires_at).toBeGreaterThan(first.holder.expires_at);
+  });
+
+  it("自愈：租期走完后另一个执行体能合法接手（不需要任何人来解锁）", async () => {
+    const owner = `${uniq("owner")}@example.com`;
+    const agent = await seedToken("agent", uniq("agent"), { owner });
+    const slug = await createChannel(agent.token);
+    const task = await createTask(slug, agent.token);
+    await claim(slug, task, agent.token, { executor_id: "runner:dead" });
+
+    // 先确认闸真的是落着的——否则下面的「接手成功」可能只是闸从来没落下。
+    expect((await claim(slug, task, agent.token, { executor_id: "runner:next" })).status).toBe(409);
+
+    await expireLease(slug, task);
+    const taken = await claim(slug, task, agent.token, { executor_id: "runner:next" });
+    expect(taken.status).toBe(200);
+    expect(await taken.json()).toMatchObject({ state: "acquired", holder: { executor_id: "runner:next" } });
+  });
+
+  it("force 显式抢占活租约，并把被抢的那个记进 taken_over_from", async () => {
+    const owner = `${uniq("owner")}@example.com`;
+    const agent = await seedToken("agent", uniq("agent"), { owner });
+    const slug = await createChannel(agent.token);
+    const task = await createTask(slug, agent.token);
+    await claim(slug, task, agent.token, { executor_id: "runner:incumbent" });
+
+    const forced = await claim(slug, task, agent.token, { executor_id: "runner:taker", force: true });
+    expect(forced.status).toBe(200);
+    expect(await forced.json()).toMatchObject({
+      state: "forced",
+      reason: "taken_over",
+      holder: { executor_id: "runner:taker", taken_over_from: "runner:incumbent" },
+    });
+  });
+
+  it("release 只删自己的那张；别人的租约动不了", async () => {
+    const owner = `${uniq("owner")}@example.com`;
+    const agent = await seedToken("agent", uniq("agent"), { owner });
+    const slug = await createChannel(agent.token);
+    const task = await createTask(slug, agent.token);
+    await claim(slug, task, agent.token, { executor_id: "runner:holder" });
+
+    const foreign = await claim(slug, task, agent.token, { op: "release", executor_id: "runner:other" });
+    expect(foreign.status).toBe(200);
+    expect(await foreign.json()).toMatchObject({ state: "released", released: false });
+    // 没被删掉：闸还落着。
+    expect((await claim(slug, task, agent.token, { executor_id: "runner:other" })).status).toBe(409);
+
+    const own = await claim(slug, task, agent.token, { op: "release", executor_id: "runner:holder" });
+    expect(await own.json()).toMatchObject({ state: "released", released: true });
+    expect((await claim(slug, task, agent.token, { executor_id: "runner:other" })).status).toBe(200);
+  });
+
+  it("租期被服务端钳到上限：自报的 ttl 挡不出一个无限期死锁", async () => {
+    const owner = `${uniq("owner")}@example.com`;
+    const agent = await seedToken("agent", uniq("agent"), { owner });
+    const slug = await createChannel(agent.token);
+    const task = await createTask(slug, agent.token);
+
+    const res = await claim(slug, task, agent.token, { executor_id: "runner:greedy", ttl_ms: 365 * 24 * 3600_000 });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ttl_ms: number; holder: { expires_at: number } };
+    expect(body.ttl_ms).toBe(60 * 60_000);
+    expect(body.holder.expires_at).toBeLessThanOrEqual(Date.now() + 60 * 60_000);
+  });
+
+  describe("反向用例：闸只该在 (identity, channel, task) 全部相同时落下", () => {
+    it("不同 task 不互相阻塞", async () => {
+      const owner = `${uniq("owner")}@example.com`;
+      const agent = await seedToken("agent", uniq("agent"), { owner });
+      const slug = await createChannel(agent.token);
+      const a = await createTask(slug, agent.token, "a");
+      const b = await createTask(slug, agent.token, "b");
+      await claim(slug, a, agent.token, { executor_id: "runner:1" });
+      expect((await claim(slug, b, agent.token, { executor_id: "runner:2" })).status).toBe(200);
+    });
+
+    it("不同频道的同号 task 不互相阻塞", async () => {
+      const owner = `${uniq("owner")}@example.com`;
+      const agent = await seedToken("agent", uniq("agent"), { owner });
+      const one = await createChannel(agent.token);
+      const two = await createChannel(agent.token);
+      const t1 = await createTask(one, agent.token);
+      const t2 = await createTask(two, agent.token);
+      await claim(one, t1, agent.token, { executor_id: "runner:1" });
+      expect((await claim(two, t2, agent.token, { executor_id: "runner:2" })).status).toBe(200);
+    });
+
+    it("不同身份不互相阻塞（两个 agent 各自认领同一个 task）", async () => {
+      const owner = `${uniq("owner")}@example.com`;
+      const a = await seedToken("agent", uniq("agent-a"), { owner });
+      const b = await seedToken("agent", uniq("agent-b"), { owner });
+      const slug = await createChannel(a.token);
+      const task = await createTask(slug, a.token);
+      await claim(slug, task, a.token, { executor_id: "runner:same" });
+      // 同名 executor_id 也不该串——判定的三要素里 identity_name 不同。
+      expect((await claim(slug, task, b.token, { executor_id: "runner:same" })).status).toBe(200);
+    });
+
+    it("同名不同 principal 不互相阻塞（token 撤销后同名重铸给另一个 owner）", async () => {
+      // 真实形状：老 token 被撤销、同一个 name 重新铸给另一个账号。新 owner 不该继承旧 owner
+      // 的租约，也不该被旧 owner 留下的租约压住——判定的第三个维度是 principal，不只是 name。
+      const host = await seedToken("human", uniq("host"), { owner: `${uniq("host")}@example.com` });
+      const slug = uniq("ch");
+      const created = await api("/api/channels", host.token, {
+        method: "POST",
+        body: JSON.stringify({ slug, kind: "standing", visibility: "public" }),
+      });
+      expect(created.status).toBe(201);
+      const task = await createTask(slug, host.token);
+
+      const name = uniq("reminted");
+      const first = await seedToken("agent", name, { owner: `${uniq("o1")}@example.com` });
+      expect((await claim(slug, task, first.token, { executor_id: "runner:old-owner" })).status).toBe(200);
+
+      await env.DB.prepare("DELETE FROM tokens WHERE name = ?").bind(name).run();
+      const second = await seedToken("agent", name, { owner: `${uniq("o2")}@example.com` });
+      expect((await claim(slug, task, second.token, { executor_id: "runner:new-owner" })).status).toBe(200);
+      // 旧 owner 那张租约仍在（没被新 owner 顺手抹掉），只是不再挡任何人。
+      const rows = await env.DB.prepare(
+        "SELECT executor_id FROM channel_task_leases WHERE channel_slug = ? AND task_id = ?",
+      )
+        .bind(slug, task)
+        .all<{ executor_id: string }>();
+      expect((rows.results ?? []).map((r) => r.executor_id).sort()).toEqual(["runner:new-owner", "runner:old-owner"]);
+    });
+  });
+
+  describe("executor_id 不可成为伪造点", () => {
+    it("换 executor_id 够不着一个本来就够不着的频道（鉴权在租约之前）", async () => {
+      const insider = await seedToken("agent", uniq("insider"), { owner: `${uniq("in")}@example.com` });
+      const outsider = await seedToken("agent", uniq("outsider"), { owner: `${uniq("out")}@example.com` });
+      const slug = await createChannel(insider.token);
+      const task = await createTask(slug, insider.token);
+      await claim(slug, task, insider.token, { executor_id: "runner:insider" });
+
+      // 冒充持租者的 executor_id 也一样：403，且不是 409——它连冲突判定都没走到。
+      const res = await claim(slug, task, outsider.token, { executor_id: "runner:insider" });
+      expect(res.status).toBe(403);
+      expect(await res.json()).toMatchObject({ error: { code: "forbidden" } });
+    });
+
+    it("readonly token 换任何 executor_id 都拿不到租约", async () => {
+      // 频道刻意设成 public：readonly 这一刀必须是**唯一**决定结果的那道闸。若沿用私有频道，
+      // canAccessLoadedChannel 会先把它挡掉，403 照样出现，而 readonly 判定被整个遮住——
+      // 删掉那行代码测试也全绿（实测：这条用例的第一版正是这个形状）。
+      const host = await seedToken("human", uniq("host"), { owner: `${uniq("host")}@example.com` });
+      const slug = uniq("ch");
+      expect(
+        (await api("/api/channels", host.token, {
+          method: "POST",
+          body: JSON.stringify({ slug, kind: "standing", visibility: "public" }),
+        })).status,
+      ).toBe(201);
+      const task = await createTask(slug, host.token);
+
+      const ro = await seedToken("readonly", uniq("ro"), { owner: `${uniq("ro")}@example.com` });
+      // 先证明这个 readonly token 确实够得着这个频道（读得到任务）——否则下面的 403 说明不了问题。
+      expect((await api(`/api/channels/${slug}/tasks/${task}`, ro.token)).status).toBe(200);
+      const res = await claim(slug, task, ro.token, { executor_id: "runner:sneaky" });
+      expect(res.status).toBe(403);
+      expect(await res.json()).toMatchObject({ error: { code: "forbidden", message: expect.stringContaining("readonly") } });
+    });
+
+    it("租约端点从不改任务状态——伪造 executor_id 也推不动 channel_tasks", async () => {
+      const owner = `${uniq("owner")}@example.com`;
+      const agent = await seedToken("agent", uniq("agent"), { owner });
+      const slug = await createChannel(agent.token);
+      const task = await createTask(slug, agent.token);
+      const before = await readTask(slug, task, agent.token);
+      await claim(slug, task, agent.token, { executor_id: "runner:a" });
+      await claim(slug, task, agent.token, { executor_id: "runner:a", force: true });
+      await claim(slug, task, agent.token, { op: "release", executor_id: "runner:a" });
+      expect(await readTask(slug, task, agent.token)).toEqual(before);
+    });
+
+    it("非法 executor_id 一律 400（客户端与服务端共用 shared 的同一份判据）", async () => {
+      const owner = `${uniq("owner")}@example.com`;
+      const agent = await seedToken("agent", uniq("agent"), { owner });
+      const slug = await createChannel(agent.token);
+      const task = await createTask(slug, agent.token);
+      for (const bad of ["", "-leading-dash", "with space", "x".repeat(129), 42, null]) {
+        const res = await claim(slug, task, agent.token, { executor_id: bad });
+        expect(res.status, `executor_id=${JSON.stringify(bad)}`).toBe(400);
+      }
+    });
+  });
+
+  describe("新旧兼容", () => {
+    it("老客户端不送 executor_id 也照改任务状态——PATCH 从不要求租约", async () => {
+      const owner = `${uniq("owner")}@example.com`;
+      const agent = await seedToken("agent", uniq("agent"), { owner });
+      const slug = await createChannel(agent.token);
+      const task = await createTask(slug, agent.token);
+      await claim(slug, task, agent.token, { executor_id: "runner:holder" });
+
+      // 老客户端（从不调用租约端点）在别人持租时仍能推进任务：不能因为不送字段就被拒。
+      const patched = await api(`/api/channels/${slug}/tasks/${task}`, agent.token, {
+        method: "PATCH",
+        body: JSON.stringify({ state: "in_progress" }),
+      });
+      expect(patched.status).toBe(200);
+      expect((await patched.json()) as { state: string }).toMatchObject({ state: "in_progress" });
+    });
+
+    it("/api/version 声明 task_lease 能力", async () => {
+      const res = await api("/api/version", "unused");
+      expect(res.status).toBe(200);
+      expect(((await res.json()) as { features: string[] }).features).toContain("task_lease");
+    });
+
+    it("不存在的 task 报 not_found（带 error.code），与老服务端「路由没命中」的裸 404 形状不同", async () => {
+      const owner = `${uniq("owner")}@example.com`;
+      const agent = await seedToken("agent", uniq("agent"), { owner });
+      const slug = await createChannel(agent.token);
+      const res = await claim(slug, 987654, agent.token, { executor_id: "runner:a" });
+      expect(res.status).toBe(404);
+      expect(await res.json()).toMatchObject({ error: { code: "not_found" } });
+    });
+  });
+});

--- a/worker/test/version-negotiation.spec.ts
+++ b/worker/test/version-negotiation.spec.ts
@@ -77,6 +77,9 @@ describe("version endpoint and advisory guardrail (issue #137)", () => {
       deployed_at: null,
       min_client_version: DEFAULT_MIN_CLIENT_VERSION,
       min_client_enforced: false,
+      // 能力清单（#936）：协议新增的端点在这里显式声明，客户端/诊断据此说清「这台服务端的
+      // 任务租约是跨机的还是只到本机」。toEqual 是刻意的——加字段必须来这里改一次。
+      features: ["task_lease"],
     });
   });
 


### PR DESCRIPTION
Closes #936

#885 在**认领时刻**装了闸，#931（PR #935）修好了它在本机恒不落闸的根因。但闸本身只在 `$AGENTPARTY_HOME/task-leases` 这一个目录里成立——**同一身份在两台机器上并发认领同一个 task，两边都会成功**。

PR #935 里有一条用例把这个缺口的现状钉住了（注释写明「服务端租约落地后此用例必须翻红」）。本 PR 让它翻红，并改成断言相反的事实。

---

## 与 #99 `serve_lease` 的对齐点与差异

**对齐（刻意复用同一套语义，没另起一套）**

| 语义 | `serve_lease`（#99） | 本 PR 的任务租约 |
|---|---|---|
| 分组维度 | 同一 `name` + `identityDeliveryPrincipal`（owner，legacy token 回落 `token-sha256:<hash>`） | 同一 `identity_name` + `identity_principal`，**逐字复用同一份 principal 判据** |
| 唯一持租者 | 同组候选里恰好一个 held | 同组恰好一行，恰好一个 `executor_id` |
| 告知 | 回 `serve_lease{name,held}` 让每个候选知道自己持不持租 | 回 `{state,holder,expires_at}`，被拒方知道**谁持有、何时过期** |
| 回收改选 | 持租者断连 / 心跳超时（presence 60s 扫描）后转给下一个 standby | 租期走完后下一个 claim 直接接手（`state=acquired, reason=expired`） |
| 显式操作字 | `op: "claim"` | `op: "claim" \| "release"`（同名同义） |

**差异（只有一处，且是被迫的）——载体不同**

`serve_lease` 挂在长连接上：断连即隐式释放，DO 里的 `ConnState.serveLeaseHeld` 是内存态，`onClose`/`scanPresence` 兜底。任务认领是**一次性 HTTP 调用**（`party status working --task N` 写完立刻退出），没有连接可挂、没有 pid 可探（#885 注释里已论证过 pid 锁在这里无意义）。

所以：

1. 租约必须**落库**（D1 `channel_task_leases`），不能是内存/连接态；
2. 回收只能靠 **TTL 过期**，不能靠断连信号；
3. 因为回收只有 TTL 这一条路，租期上限必须由服务端钳死（见下）。

同样因为是 HTTP 而非 WS，客户端侧的 op 走 REST 而不是帧；`shared/src/protocol.ts` 里新增的是这条 REST 的线上类型，不是 `ClientFrame`/`ServerFrame` 成员。

---

## 协议变更与兼容矩阵

新端点：`POST /api/channels/:slug/tasks/:id/lease`，body `{op?, executor_id, ttl_ms?, force?}`。

**为什么是独立端点，而不是给 `PATCH /tasks/:id` 加一个 `executor_id` 字段**——两条理由，缺一都会踩到 issue 里点名的红线：

1. 老客户端不送字段也必须照常改任务状态。独立端点天然满足：老客户端只是从不调用它，PATCH 路径一个字节没变。
2. 认领要「先判定、再动任何东西」。塞进 PATCH 就成了「先改再判」，被拒时任务已经被动过——正好违反 #885 的红线。

| | 老服务端（无此路由） | 新服务端 |
|---|---|---|
| **老客户端**（从不调用租约端点） | 现状不变：只有本机 `$AGENTPARTY_HOME` 内互斥 | **照常工作**，PATCH 不要求租约、绝不因为不送字段被拒。代价：它不参与租约，可以踩到新客户端持有的租约——这是无法给不参与者追加 enforcement 的固有边界，写在这里而不是留给人踩 |
| **新客户端** | 收到**裸 404**（Hono 未命中路由，无 `error.code`）⇒ **退回本机租约，不放行**，并往 stderr 明说 + `--json` 带 `scope:"local_home", degraded:"server_unsupported"` | 跨机互斥成立，`scope:"server"` |

降级判据的形状之所以可靠：本仓所有真实 404 都走 `errorBody("not_found", …)`（一定带 `error.code`），未命中路由是 Hono 默认的纯文本 404（无 code）。两者分得开——「频道/任务不存在」不会被误判成「老服务端」，有正反两条用例钉住（真机也实测了这两种 404 的原始报文，见下）。

网络抖动 / 5xx / 参数被拒 ⇒ 同样退回本机，但原因码是 `server_unavailable`——两档修法完全不同（升级服务端 vs 重试），刻意不塌缩成一个 boolean。

`/api/version` 增加 `features: ["task_lease"]`，供诊断/doctor 说清这台服务端的租约是跨机的还是只到本机。认领热路径**不**查它（多一次 RTT、多一个失败面），走 404 形状判定。

---

## executor_id 不可伪造性

`executor_id` 由客户端自报。**它只用来区分同一身份的不同执行体，不参与任何鉴权判定。**

论证（每一条都有反向用例）：

1. **判定三要素全部由服务端从 bearer token 推出**：`channel_slug`（URL + 频道加载）、`identity_name`、`identity_principal`。`executor_id` 只是一行**内部**的值，那一行的位置早已被服务端锁死。换 executor_id 能改变的只有「我算不算当前持租的那个」，永远越不出「同一 token 同一频道同一 task」这一格。
   - 反向用例：`不同身份不互相阻塞（两个 agent 各自认领同一个 task）`——刻意用**同一个** executor_id，仍各得各的行。
   - 反向用例：`同名不同 principal 不互相阻塞（token 撤销后同名重铸给另一个 owner）`——新 owner 不继承、也不被旧 owner 的租约压住。
2. **鉴权在租约逻辑之前跑完，且只看 token**：`canAccessLoadedChannel` → `role === "readonly"` → 频道归档 → task 存在性，全部在读 `body.executor_id` 之前。
   - 反向用例：`换 executor_id 够不着一个本来就够不着的频道`——外部 token 冒充持租者的 executor_id，得到 **403**（不是 409：它连冲突判定都没走到）。
   - 反向用例：`readonly token 换任何 executor_id 都拿不到租约`——**fixture 用 public 频道**，并先断言该 token 确实读得到这个 task，确保 readonly 那道闸是唯一决定结果的（第一版用私有频道，`canAccessLoadedChannel` 先挡掉，删掉 readonly 判定测试照样全绿；变异跑出来后改掉的，见下）。
3. **租约端点从不写 `channel_tasks`**：claim / force / release 三条路径跑完，任务的每一个字段（含 `updated_at`）逐字不变。
   - 反向用例：`租约端点从不改任务状态`。
4. **字符集与长度由服务端强制**（与客户端共用 shared 的 `isExecutorId`，两边不再各写一份正则）：非法值 400。
5. **租期由服务端钳制**（≤1h）。这条是防死锁的关键：ttl 和 executor_id 一样是自报的，不钳上限，一个手滑或恶意的 `ttl_ms` 就能把 task 锁到天荒地老，而服务端没有任何探活手段能救它。钳住之后最坏情况有确定上界。下限只挡 0/负数，刻意不设「像样的地板」——短租期只会让持租方更早放手，伤不到别人，设地板反而会让 `--lease-ttl-ms` 在本机与服务端两层给出不同答案。

**唯一剩下的、我不打算假装解决的**：持有 token 的人可以自报 = 当前持有者的 executor_id，从而不留 `taken_over_from` 审计痕迹地续期/释放那张租约。但他手上已经有 `force: true` 这条同样可用、且会落审计的路——所以伪造 executor_id **不增加任何能力**，只是少留一条痕迹。这是「同一 token 内部」的事，不构成权限放大。写在这里而不是藏着。

---

## 自愈 / 不制造新死锁（#908）

- **服务端不做任何存活推断**。它看不见对端进程，猜「那个执行体大概死了」只会把还活着的执行体踢掉。唯一的回收依据是租期真的走完——拿不准一律当持租者还活着，与 `cli/src/parent-liveness.ts` 的保守判定同款。
- 过期行的清扫是纯 housekeeping，**判定不依赖它**（删掉清扫那段是等价变异，用例应当仍全绿——已验证，见下）。
- `done`/`blocked` 立刻交还本机 + 服务端两张，不必等满一个 TTL。
- `--force-lease` 是显式逃生口，一路传到服务端。
- **服务端不可达时退回本机租约而不是阻塞**：新增的这一层不会制造任何「连不上就干不了活」的新死锁。
- 客户端被服务端拒绝时，把刚取的本机租约立刻还回去——不留一张自己不用却挡着别人的锁（真机与单测都钉住了）。

## server 维度（#865）

服务端侧是**结构性**的：每个部署有自己的 D1，本机同时连两台生产实例时两边不可能串。客户端本机租约那半仍按 `taskLeaseIdentityPrefix(server, token)` 分格，原有用例保留。

---

## 自检：变异 + 等价替换

每条变异都必须让某条用例翻红。全绿 = 那道闸没有被任何用例决定。

| 变异 | 结果 |
|---|---|
| M1 整段删除服务端那半调用（永远只走本机） | **11 red** |
| M2 granted 的 `scope` 谎报 `local_home` | **3 red** |
| M3 被服务端拒后不还本机租约（孤儿锁） | **2 red** |
| M4 `serverLeaseUnsupported` 放宽成「任何 404」 | **1 red** |
| M5 降级时直接放行（不退回本机判定） | **1 red**（见下） |
| M6 status.ts 拒绝分支短路 | **9 red** |
| W1 upsert 的 WHERE 整条删掉（永远放行） | **4 red** |
| W2 去掉「过期可接手」 | **1 red** |
| W3 去掉 force 抢占 | **11 red** |
| W4 principal 塌缩成常量 | **1 red** |
| W5 去掉租期上限钳制 | **1 red** |
| W6 去掉 readonly 闸 | **1 red**（见下） |
| W7 executor_id 只校验类型不校验字符集 | **1 red** |
| W8 去掉频道可达性闸 | **1 red** |
| W9 release 不校验 executor_id（能删别人的租约） | **1 red** |
| W10 续期时刷新 `acquired_at` | **1 red** |
| **W11 删掉过期行清扫（等价实现替换）** | **全绿 — 预期如此**：清扫是 housekeeping，判定由 upsert 的 WHERE 做（W2 已单独钉住） |

**给守卫自己做的变异，抓到了两条假绿**（第一轮 M5 / W6 双双存活）：

- **W6 `readonly` 闸**：fixture 用的是私有频道，`canAccessLoadedChannel` 会先把 readonly token 挡掉 → 403 照样出现，readonly 判定被整个遮住，删掉那行代码测试全绿。改成 **public 频道 + 先断言该 token 读得到这个 task**，让 readonly 成为唯一能决定结果的那道闸，W6 才翻红。这正是派单里点名的形态：断言写对了，但另一个分支单独满足条件把被测的闸遮住。
- **M5 降级放行**：本机 `denied` 会提前 return，永远走不到降级分支，所以「降级时只回 acquired」几乎不可观测。补了三条断言逐项翻过本机能给出的每一种非拒绝结论（`renewed` 且 holder 正确 / `forced` 且 `taken_over_from` 正确 / `unenforced` 且 `reason=no_executor_identity`），M5 才翻红。

另外，**没有**用「读到某类帧就停」的辅助做屏障——全是逐调用消费、逐行断言（`server.calls` 逐次记录，含「本机能答被拒时一次网络请求都不发」这条）。

---

## 真机验证

**环境照抄故障场景**：两个隔离的 `AGENTPARTY_HOME`（= 两台机器）+ **一台真服务端**（`wrangler dev --local`：真 workerd + 真 D1 + 完整迁移链跑到 0044）+ 真实的 `party` CLI（不是被测函数）。不碰 owner 的 `~/.agentparty`，不用 AppleScript/GUI，临时目录用完即删。

实测结果：

1. **机器 A 认领** → `{"state":"acquired","scope":"server"}`，exit 0。
2. **机器 B（另一个 HOME、同一 token/身份/频道/task）认领** → exit **11**，
   `{"published":false,"task_untouched":true,"lease":{"state":"denied","scope":"server","holder":{"executor_id":"machineA:runner",…}}}`，
   stderr 逐字给出 `holder=machineA:runner expires_in=1800s scope=server (server lease: the holder may be on another machine)` + 怎么合法接手。
3. **拒绝 ≠ 吞任务**：频道消息账本里 B 那次一条都没有（A 的 `working` 之后直接是 A 的 `done`），task state 未被改写。
4. **A `done` 后 B 立刻能接手**（不必等 TTL）。
5. **自愈**：`--lease-ttl-ms 1500`，B 立刻认领 → exit 11；等 2s 后 → exit 0，`state=acquired`。
6. **反向**：另一个 task 不被挡。
7. **executor_id 伪造**：另一个身份（另一个 token）用**同一个** `machineA:runner` 认领同一个 task → 得到**自己那一行**，D1 里 `verify-agent` 的 task 4 租约仍是 `machineA:runner`、`taken_over_from=NULL`，没被夺走。
8. **老客户端连新服务端**：裸 curl（从不送 executor_id）在另一执行体持租时 `PATCH .../tasks/:id` → **200**，任务照改。
9. **`--force-lease` 跨机接手** → `state=forced`、`taken_over_from=machineA:runner` 落账。
10. **404 两种形状实测**：`{"error":{"code":"not_found",…}}`（task 不存在） vs 纯文本 `404 Not Found`（未命中路由）——降级判据成立。

## 全量检查

`check:worker`（896 passed）、`check:cli`（6 shard 全绿 + tsc）、`check:shared`、`check:scripts`（含 `check-migration-numbering`）、`check:web` 全部通过。

`worker/test/version-negotiation.spec.ts` 对 `/api/version` 用的是 `toEqual`（刻意的：加字段必须来这里改一次），已随 `features` 一并更新。
