### PR TITLE
fix(cli): 蛰伏宣告按宿主 pid 精确寻址，消费锁回收不再放两个 Hook 进临界区

### DIFF
--- a/cli/src/claude-cross-session-gate.ts
+++ b/cli/src/claude-cross-session-gate.ts
@@ -20,6 +20,9 @@ const STATE_FILE = "state.json";
 const ARM_FILE = "armed.json";
 const CONSUME_LOCK_FILE = "consume.lock";
 const CONSUME_LOCK_WAIT_MS = 250;
+// Hook 临界区全是同步小文件操作，正常持锁远小于 10s。进程若在 finally 前崩溃，
+// O_EXCL 锁文件会留在每次 launch 的私有目录里；不回收就会让整个 bridge 永久 fail-closed。
+const CONSUME_LOCK_STALE_MS = 10_000;
 const MAX_CANDIDATES = 64;
 const MAX_TOOL_RESULT_DEPTH = 64;
 const MAX_TOOL_RESULT_NODES = 4_096;
@@ -548,10 +551,62 @@ function waitForConsumeLock(lockPath: string): number | null {
     try {
       return openSync(lockPath, "wx", 0o600);
     } catch {
+      if (reclaimStaleConsumeLock(lockPath)) continue;
       const remaining = deadline - Date.now();
       if (remaining <= 0) return null;
       Atomics.wait(sleeper, 0, 0, Math.min(5, remaining));
     }
+  }
+}
+
+// 回收崩溃 Hook 留下的陈旧锁。lstat→rm→open 三步不是原子的：两个 Hook 同时判定
+// 同一把锁过期时，后手的 rm 会删掉先手刚建好的新锁，两边一起进临界区——恰好毁掉
+// 这把锁存在的意义。所以先用一把回收锁把回收动作串起来，拿到回收锁之后再重新
+// lstat，确认这一刻锁仍然是过期的（而不是别人刚建的新锁），才真正删。
+// 返回 true 表示调用方应立刻重试 O_EXCL。
+function reclaimStaleConsumeLock(lockPath: string): boolean {
+  const reclaimPath = `${lockPath}.reclaim`;
+  let reclaimFd: number;
+  try {
+    reclaimFd = openSync(reclaimPath, "wx", 0o600);
+  } catch {
+    // 别的 Hook 正在回收，等它删完再竞争。回收锁只跨几个同步 syscall，正常持锁
+    // 时间远小于阈值；只有在回收过程中崩溃才会残留，按同样的过期阈值兜底清掉。
+    dropStaleLockFile(reclaimPath);
+    return false;
+  }
+  try {
+    const stat = lstatSync(lockPath);
+    if (
+      !stat.isFile() ||
+      stat.isSymbolicLink() ||
+      Date.now() - stat.mtimeMs <= CONSUME_LOCK_STALE_MS
+    ) {
+      return false;
+    }
+    rmSync(lockPath, { force: true });
+    return true;
+  } catch {
+    // 锁刚被别的 Hook 正常释放：直接重试 O_EXCL。
+    return true;
+  } finally {
+    closeSync(reclaimFd);
+    rmSync(reclaimPath, { force: true });
+  }
+}
+
+function dropStaleLockFile(path: string): void {
+  try {
+    const stat = lstatSync(path);
+    if (
+      stat.isFile() &&
+      !stat.isSymbolicLink() &&
+      Date.now() - stat.mtimeMs > CONSUME_LOCK_STALE_MS
+    ) {
+      rmSync(path, { force: true });
+    }
+  } catch {
+    // 已经没了，正常。
   }
 }
 

--- a/cli/src/commands/claude-channel.ts
+++ b/cli/src/commands/claude-channel.ts
@@ -461,8 +461,8 @@ export function dormantAnnounceDisplayName(entry: ClaudeSessionRegistryEntry): s
 }
 
 /**
- * 选择要宣告（并被注入）的入册会话：**server + channel + 频道身份 + cwd 全等**必须，
- * 同优先级取最新入册。任何一维对不上就返回 null——宁可漏叫，绝不误投。
+ * 选择要宣告（并被注入）的入册会话：**host pid + server + channel + 频道身份 + cwd
+ * 全等**必须。任何一维对不上就返回 null——宁可漏叫，绝不误投。
  *
  * #865：频道 slug 跨实例不唯一（两台生产实例上都有 `agentparty`），只比 slug 会让本机
  * 连着 A 实例的 announce 腿把 @ 注入到只属于 B 实例的会话——实机撞见过。旧条目（无
@@ -474,7 +474,10 @@ export function dormantAnnounceDisplayName(entry: ClaudeSessionRegistryEntry): s
  * 毫无破绽，被 @ 的一方一无所知。所以：
  * - 身份不等一律不选（旧条目无 identity 字段 ⇒ 恒不匹配，下次 SessionStart 自然升级）；
  * - 删掉跨 cwd 兜底——「频道里随便挑一个」在有身份概念之后不成立，同身份跨 worktree 的
- *   另一个会话同样是错的宿主（announce 进程只许唤醒自己所在 cwd 的宿主会话）。
+ *   另一个会话同样是错的宿主。
+ * - cwd/identity 仍不足以标识会话：同一仓库同一身份同时开两个 Claude 时，每个蛰伏 MCP
+ *   都是各自 Claude 的直接子进程。因此必须用 process.ppid 精确命中自己的注册项，不能取
+ *   registered_at 最新的兄弟会话。
  */
 export function selectDormantAnnounceEntry(
   entries: readonly ClaudeSessionRegistryEntry[],
@@ -482,15 +485,20 @@ export function selectDormantAnnounceEntry(
   cwd: string,
   server?: string | null,
   identity?: string | null,
+  hostPid: number = process.ppid,
 ): ClaudeSessionRegistryEntry | null {
+  if (!Number.isInteger(hostPid) || hostPid <= 0) return null;
   const matching = entries.filter(
     (entry) =>
+      entry.pid === hostPid &&
       entry.channel === channel &&
       sessionEntryMatchesServer(entry, server) &&
       sessionEntryMatchesIdentity(entry, identity) &&
       entry.cwd === cwd,
   );
   if (matching.length === 0) return null;
+  // /clear / resume 可能让同一 Claude pid 短暂保留多个 session_id；只在已经精确
+  // 命中宿主 pid 之后才用时间选该进程最新的一条。
   return matching.reduce((a, b) => (b.registered_at >= a.registered_at ? b : a));
 }
 
@@ -511,8 +519,12 @@ export interface DormantAnnounceDeps {
     auth: { server: string; token: string },
   ) => Promise<number | null>;
   cwd?: string;
+  /** 当前 dormant MCP 的宿主 Claude pid；生产默认 process.ppid，测试可覆盖。 */
+  hostPid?: number;
   pollIntervalMs?: number;
   livenessIntervalMs?: number;
+  /** socket 注入失败后的有界重试间隔；生产默认 250ms。 */
+  injectRetryDelayMs?: number;
   /** socket 注入实现（测试注入点）；默认真实 injectChannelMessage。 */
   inject?: typeof injectChannelMessage;
   /**
@@ -646,7 +658,8 @@ function abortableSleep(ms: number, signal: AbortSignal): Promise<void> {
 /**
  * announce-only 主循环：等到注册表里出现本 channel 的活会话（SessionStart hook
  * 可能晚于 MCP 启动），随后保持一条只带 topology/harness_session 的 WS 连接。
- * 会话死亡或 signal 中止即断开。任何失败静默退出——蛰伏进程不许打扰 Claude。
+ * 会话死亡或 signal 中止即断开。瞬时网络/服务端故障按 poll 间隔重连；失败只写本地
+ * 诊断，绝不把噪音写进 Claude 的 MCP stdout。
  */
 export async function runDormantClaudeSessionAnnounce(
   channel: string,
@@ -654,8 +667,10 @@ export async function runDormantClaudeSessionAnnounce(
   deps: DormantAnnounceDeps,
 ): Promise<void> {
   const cwd = deps.cwd ?? process.cwd();
+  const hostPid = deps.hostPid ?? process.ppid;
   const pollMs = deps.pollIntervalMs ?? DORMANT_ANNOUNCE_POLL_MS;
   const livenessMs = deps.livenessIntervalMs ?? DORMANT_ANNOUNCE_LIVENESS_MS;
+  const injectRetryDelayMs = Math.max(0, deps.injectRetryDelayMs ?? 250);
   if (!isSlug(channel)) return;
   const inject = deps.inject ?? injectChannelMessage;
   // 进程内注入去重（按 seq）：WS 重连会重放未 ack 的帧，没有它同一条 @ 会反复唤醒
@@ -703,14 +718,22 @@ export async function runDormantClaudeSessionAnnounce(
     }
     let entry: ClaudeSessionRegistryEntry | null = null;
     try {
-      entry = selectDormantAnnounceEntry(deps.listSessions(), channel, cwd, authServer, selfName);
+      entry = selectDormantAnnounceEntry(
+        deps.listSessions(),
+        channel,
+        cwd,
+        authServer,
+        selfName,
+        hostPid,
+      );
     } catch {
       return;
     }
     if (entry === null) {
       logOnce(
         `claude-channel: 本机没有身份 ${selfName} 的入册会话（channel=${channel} ` +
-          `server=${authServer} cwd=${cwd}），未宣告、未注入。旧条目（无 identity 字段）` +
+        `server=${authServer} cwd=${cwd} host_pid=${hostPid}），未宣告、未注入。` +
+          `旧条目（无 identity 字段）` +
           "不参与匹配，重开一次会话即自动补上（#906）",
       );
       await abortableSleep(pollMs, signal);
@@ -770,26 +793,45 @@ export async function runDormantClaudeSessionAnnounce(
         if (dormantAnnounceIsReplayFrame(frame)) return;
         if (!dormantAnnounceMentionHit(mentions, selfName)) return;
         if (injectedSeqs.has(seq)) return;
-        injectedSeqs.add(seq);
-        while (injectedSeqs.size > DORMANT_ANNOUNCE_SEEN_LIMIT) {
-          const oldest = injectedSeqs.values().next();
-          if (oldest.done === true) break;
-          injectedSeqs.delete(oldest.value);
+        for (let attempt = 1; attempt <= 3 && !signal.aborted; attempt += 1) {
+          let result: Awaited<ReturnType<typeof inject>> | null = null;
+          try {
+            result = await inject({
+              // 自我保护：目标恒为本轮绑定的宿主会话，不接受任何外部传入的身份。
+              // 寻址走 pid（registry 与 ~/.claude/sessions 同源）——宣告名与 Claude 原生
+              // 会话名是两个命名空间，按名字寻址恒 no-match（#857 实测）。sessionId 一并
+              // 传下去做防 pid 复用比对。
+              pid: entry.pid,
+              sessionId: entry.session_id,
+              name: hostAnnounceName,
+              body: wakeProxyNote({ channel, server: authServer, seq }),
+              // from-name＝真实发信人的友好名 + 技术 ID（接收端面板只显示这一处，
+              // 技术 ID 丢了就分不清两个同名 agent）。
+              fromName: senderInjectFromName(sender, channel),
+              // announce 进程没有自己的回执 socket——绝不冒用别人的 sock 当 from。
+            });
+          } catch {
+            // 与结构化 ok:false 统一走有界重试。
+          }
+          if (result?.ok === true) {
+            // 只有字节真正写进 socket 后才去重。失败前就记 seen 会让临时故障
+            // 把这条 @ 永久变成「已注入」的假成功。
+            injectedSeqs.add(seq);
+            while (injectedSeqs.size > DORMANT_ANNOUNCE_SEEN_LIMIT) {
+              const oldest = injectedSeqs.values().next();
+              if (oldest.done === true) break;
+              injectedSeqs.delete(oldest.value);
+            }
+            return;
+          }
+          if (attempt < 3) await abortableSleep(injectRetryDelayMs, signal);
         }
-        await inject({
-          // 自我保护：目标恒为本轮绑定的宿主会话，不接受任何外部传入的身份。
-          // 寻址走 pid（registry 与 ~/.claude/sessions 同源）——宣告名与 Claude 原生
-          // 会话名是两个命名空间，按名字寻址恒 no-match（#857 实测）。sessionId 一并
-          // 传下去做防 pid 复用比对。
-          pid: entry.pid,
-          sessionId: entry.session_id,
-          name: hostAnnounceName,
-          body: wakeProxyNote({ channel, server: authServer, seq }),
-          // from-name＝真实发信人的友好名 + 技术 ID（接收端面板只显示这一处，
-          // 技术 ID 丢了就分不清两个同名 agent）。
-          fromName: senderInjectFromName(sender, channel),
-          // announce 进程没有自己的回执 socket——绝不冒用别人的 sock 当 from。
-        });
+        if (!signal.aborted) {
+          logOnce(
+            `claude-channel: socket 注入连续 3 次未成功（channel=${channel} seq=${seq} ` +
+              `session=${entry.session_id}），未记入去重表`,
+          );
+        }
       } catch {
         // 静默降级：注入不可用时行为等同改动前（只 ack）。
       }
@@ -826,10 +868,21 @@ export async function runDormantClaudeSessionAnnounce(
           // claim delivery，见上方 P2 不变式），注入失败也不该影响 ack。
           if (frame.type === "msg") await maybeInject(frame.seq, frame.mentions, frame.sender, frame);
         }
-        if (frame.type === "error") return;
+        if (frame.type === "error") {
+          // 只有明确的瞬时服务端故障才重连。鉴权/归档/协议错误重试也不会自愈，
+          // 保持原有终止语义，避免每 5s 空转。
+          if (frame.code !== "unavailable" && frame.code !== "rate_limited") return;
+          logOnce(
+            `claude-channel: announce 收到可重试错误 ${frame.code}（channel=${channel}），` +
+              `将在 ${pollMs}ms 后重连`,
+          );
+          break;
+        }
       }
     } catch {
-      return;
+      if (!signal.aborted) {
+        logOnce(`claude-channel: announce 帧流异常（channel=${channel}），将在 ${pollMs}ms 后重连`);
+      }
     } finally {
       clearInterval(liveness);
       signal.removeEventListener("abort", onAbort);

--- a/cli/test/claude-channel-dormant-announce.test.ts
+++ b/cli/test/claude-channel-dormant-announce.test.ts
@@ -20,7 +20,7 @@ function entry(overrides: Partial<ClaudeSessionRegistryEntry> = {}): ClaudeSessi
   return {
     version: 1,
     session_id: "11111111-1111-4111-8111-111111111111",
-    pid: process.pid,
+    pid: process.ppid,
     display_name: null,
     channel: "dev",
     server: SERVER,
@@ -115,8 +115,10 @@ function makeDeps(overrides: Partial<DormantAnnounceDeps> = {}): {
     // 默认给一个确定的频道身份：绝不让测试去读真实 config / 打 /api/me。
     resolveSelfName: async () => "lark-ad72b3f97491-agentparty",
     cwd: "/tmp/project",
+    hostPid: process.ppid,
     pollIntervalMs: 5,
     livenessIntervalMs: 5,
+    injectRetryDelayMs: 1,
     ...overrides,
   };
   return { deps, connections };
@@ -144,6 +146,23 @@ describe("selectDormantAnnounceEntry", () => {
     expect(selectDormantAnnounceEntry([away], "dev", "/tmp/project", SERVER, SELF_IDENTITY)).toBeNull();
     const newer = entry({ session_id: "44444444-4444-4444-8444-444444444444", registered_at: 5_000 });
     expect(selectDormantAnnounceEntry([here, newer], "dev", "/tmp/project", SERVER, SELF_IDENTITY)).toBe(newer);
+  });
+
+  test("same cwd and identity still bind to this MCP's parent Claude pid", () => {
+    const mine = entry({ registered_at: 1_000 });
+    const newerSibling = entry({
+      session_id: "99999999-9999-4999-8999-999999999999",
+      pid: process.ppid + 1,
+      registered_at: 9_000,
+    });
+    expect(selectDormantAnnounceEntry(
+      [mine, newerSibling],
+      "dev",
+      "/tmp/project",
+      SERVER,
+      SELF_IDENTITY,
+      process.ppid,
+    )).toBe(mine);
   });
 });
 
@@ -300,6 +319,24 @@ describe("runDormantClaudeSessionAnnounce (#841 P2)", () => {
     await done;
   });
 
+  test("reconnects after a retryable channel error instead of killing announce", async () => {
+    const { deps, connections } = makeDeps();
+    const abort = new AbortController();
+    const done = runDormantClaudeSessionAnnounce("dev", abort.signal, deps);
+    await tick();
+    expect(connections).toHaveLength(1);
+    connections[0]!.push({
+      type: "error",
+      code: "unavailable",
+      message: "temporary outage",
+    } as ServerFrame);
+    await tick(30);
+    expect(connections).toHaveLength(2);
+    expect(connections[0]!.closed).toBe(true);
+    abort.abort();
+    await done;
+  });
+
   test("rejects an invalid channel slug without connecting", async () => {
     const { deps, connections } = makeDeps();
     const abort = new AbortController();
@@ -430,7 +467,7 @@ describe("runDormantClaudeSessionAnnounce socket inject (#857)", () => {
     await tick();
     expect(calls).toHaveLength(1);
     // 寻址走 pid + sessionId（宣告名与 Claude 原生会话名是两个命名空间，#857）。
-    expect(calls[0]!.pid).toBe(process.pid);
+    expect(calls[0]!.pid).toBe(process.ppid);
     expect(calls[0]!.sessionId).toBe("11111111-1111-4111-8111-111111111111");
     expect(calls[0]!.name).toBe("claude-111111111111");
     // from-name＝友好名 + 技术 ID（接收端面板只显示这一处）。
@@ -485,8 +522,31 @@ describe("runDormantClaudeSessionAnnounce socket inject (#857)", () => {
     await tick();
     connections[0]!.push(msg(31, [SELF]));
     await tick();
-    expect(calls).toHaveLength(2);
+    // 每条都做 3 次有界重试，但不阻断后续帧。
+    expect(calls).toHaveLength(6);
     expect(connections[0]!.acked).toEqual([30, 31]);
+    abort.abort();
+    await done;
+  });
+
+  test("records dedupe only after inject succeeds", async () => {
+    let attempt = 0;
+    const { deps, connections, calls } = injectingDeps(async (input) => {
+      attempt += 1;
+      return attempt === 1
+        ? { ok: false, reason: "probe-failed" }
+        : { ok: true, socketPath: "/tmp/x.sock", usedAuth: false, target: input.name };
+    });
+    const abort = new AbortController();
+    const done = runDormantClaudeSessionAnnounce("dev", abort.signal, deps);
+    await tick();
+    connections[0]!.push(msg(32, [SELF]));
+    await tick();
+    expect(calls).toHaveLength(2);
+    // 成功后才进 seen：同 seq 再来不会重复写 socket。
+    connections[0]!.push(msg(32, [SELF]));
+    await tick();
+    expect(calls).toHaveLength(2);
     abort.abort();
     await done;
   });
@@ -500,7 +560,7 @@ describe("announce 注入的身份闸（issue #906）", () => {
       calls.push({ pid: input.pid, sessionId: input.sessionId });
       return { ok: true, socketPath: "/tmp/x.sock", usedAuth: false, target: input.name };
     }) as DormantAnnounceDeps["inject"];
-    const made = makeDeps({ inject, log: (line) => logs.push(line), ...overrides });
+    const made = makeDeps({ hostPid: 111, inject, log: (line) => logs.push(line), ...overrides });
     return { ...made, calls, logs };
   }
 

--- a/cli/test/claude-cross-session-hook-command.test.ts
+++ b/cli/test/claude-cross-session-hook-command.test.ts
@@ -7,6 +7,7 @@ import {
   openSync,
   readFileSync,
   rmSync,
+  utimesSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -183,6 +184,100 @@ describe("hidden Claude Cross-session hook command", () => {
       expect(result.stdout).toContain("state is busy");
     } finally {
       if (lockFd !== null) closeSync(lockFd);
+      rmSync(gate, { recursive: true, force: true });
+    }
+  });
+
+  test("reclaims a consume lock abandoned by a crashed Hook process", async () => {
+    const gate = mkdtempSync(join(tmpdir(), "agentparty-hook-stale-lock-test-"));
+    chmodSync(gate, 0o700);
+    const sessionId = "67676767-6767-4767-8767-676767676767";
+    const hookArgs = ["--gate-directory", gate];
+    try {
+      expect((await runHook(JSON.stringify({
+        hook_event_name: "SessionStart",
+        session_id: sessionId,
+      }), process.env, hookArgs)).code).toBe(0);
+      const lockPath = join(gate, "consume.lock");
+      closeSync(openSync(lockPath, "wx", 0o600));
+      utimesSync(lockPath, new Date(0), new Date(0));
+
+      const result = await runHook(JSON.stringify({
+        hook_event_name: "PreToolUse",
+        session_id: sessionId,
+        tool_name: "SendMessage",
+        tool_input: { to: "researcher", message: "status" },
+      }), process.env, hookArgs);
+
+      expect(result).toEqual({ code: 0, stdout: "", stderr: "" });
+      expect(await Bun.file(lockPath).exists()).toBe(false);
+    } finally {
+      rmSync(gate, { recursive: true, force: true });
+    }
+  });
+
+  test("a stale consume lock is not reclaimed while another Hook is already reclaiming it", async () => {
+    const gate = mkdtempSync(join(tmpdir(), "agentparty-hook-reclaim-race-test-"));
+    chmodSync(gate, 0o700);
+    const sessionId = "68686868-6868-4868-8868-686868686868";
+    const hookArgs = ["--gate-directory", gate];
+    let reclaimFd: number | null = null;
+    try {
+      expect((await runHook(JSON.stringify({
+        hook_event_name: "SessionStart",
+        session_id: sessionId,
+      }), process.env, hookArgs)).code).toBe(0);
+      const lockPath = join(gate, "consume.lock");
+      closeSync(openSync(lockPath, "wx", 0o600));
+      utimesSync(lockPath, new Date(0), new Date(0));
+      // 另一个 Hook 已经拿着回收锁，正处在 lstat→rm→open 之间。此时本进程必须
+      // 完全不碰 consume.lock：直接删会把对方回收后新建的锁删掉，两边一起进临界区。
+      reclaimFd = openSync(`${lockPath}.reclaim`, "wx", 0o600);
+
+      const result = await runHook(JSON.stringify({
+        hook_event_name: "PreToolUse",
+        session_id: sessionId,
+        tool_name: "SendMessage",
+        tool_input: { to: "researcher", message: "status" },
+      }), process.env, hookArgs);
+
+      expect(result.code).toBe(2);
+      expect(result.stdout).toContain("state is busy");
+      expect(await Bun.file(lockPath).exists()).toBe(true);
+    } finally {
+      if (reclaimFd !== null) closeSync(reclaimFd);
+      rmSync(gate, { recursive: true, force: true });
+    }
+  });
+
+  test("a reclaim lock abandoned by a crashed Hook does not wedge stale-lock recovery", async () => {
+    const gate = mkdtempSync(join(tmpdir(), "agentparty-hook-reclaim-stale-test-"));
+    chmodSync(gate, 0o700);
+    const sessionId = "69696969-6969-4969-8969-696969696969";
+    const hookArgs = ["--gate-directory", gate];
+    try {
+      expect((await runHook(JSON.stringify({
+        hook_event_name: "SessionStart",
+        session_id: sessionId,
+      }), process.env, hookArgs)).code).toBe(0);
+      const lockPath = join(gate, "consume.lock");
+      const reclaimPath = `${lockPath}.reclaim`;
+      for (const path of [lockPath, reclaimPath]) {
+        closeSync(openSync(path, "wx", 0o600));
+        utimesSync(path, new Date(0), new Date(0));
+      }
+
+      const result = await runHook(JSON.stringify({
+        hook_event_name: "PreToolUse",
+        session_id: sessionId,
+        tool_name: "SendMessage",
+        tool_input: { to: "researcher", message: "status" },
+      }), process.env, hookArgs);
+
+      expect(result).toEqual({ code: 0, stdout: "", stderr: "" });
+      expect(await Bun.file(lockPath).exists()).toBe(false);
+      expect(await Bun.file(reclaimPath).exists()).toBe(false);
+    } finally {
       rmSync(gate, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
## 背景

跨会话链路上的三处可靠性缺陷 + 一条 ultrareview 查出的锁竞态。

## 改动

### 蛰伏宣告（`cli/src/commands/claude-channel.ts`）

- `selectDormantAnnounceEntry` 加上 **host pid** 维度。同一仓库同一身份并开两个 Claude 时，`cwd + identity` 已不足以标识会话，取 `registered_at` 最新的那条会把 @ 投给兄弟会话。蛰伏 MCP 是各自 Claude 的直接子进程，用 `process.ppid` 才能精确命中自己的注册项。
- socket 注入失败改为**有界重试**，并且只在字节真正写进 socket 之后才记 `seen`。先记 seen 会让一次瞬时故障把这条 @ 永久变成「已注入」的假成功。
- 断线按 poll 间隔重连，失败只写本地诊断，不把噪音写进 MCP stdout。

### 消费锁陈旧回收（`cli/src/claude-cross-session-gate.ts`）

`waitForConsumeLock` 的陈旧锁回收原先是 `lstat → 判过期 → rmSync(force) → openSync(wx)` 四个独立 syscall，且 `rmSync` 按路径删、不校验 inode。崩溃残留一把过期锁后两个 Hook 一起撞进回收路径：

1. A、B 都 lstat 到同一把过期锁，都过了 mtime 判断
2. A rm 掉、`openSync(wx)` 成功，装上一把全新的锁
3. B 拿着自己那份陈旧 stat 继续走，rm 掉的是 **A 刚建的新锁**，然后自己 `openSync(wx)` 也成功

两边同时进临界区，而这个临界区守的正是 permit 消费和 send barrier 的装/拆——败方 send 会把胜方刚写的 `send_barrier_expires_at` 抹成 null，同批次兄弟工具直接绕过 barrier。回收机制本来是为崩溃后恢复加的，结果恢复动作自己把互斥丢了。

改为先取一把**回收锁**把回收动作串起来，拿到之后**重新 lstat** 确认此刻仍然过期才真正删；回收锁自身只跨几个同步 syscall，万一崩溃残留按同一阈值兜底清理，不会反过来卡死回收。

## 测试

- 新增：回收锁被别人持有时，陈旧锁必须原封不动，Hook 报 `state is busy` 退出 2
- 新增：回收锁自己陈旧时，不能卡死陈旧锁的回收
- 蛰伏宣告侧的 host pid / 重试 / 去重时机用例
- `bunx tsc --noEmit --project cli/tsconfig.json` 通过