### PR TITLE
fix(scripts): 回滚前重新确认仓库状态，远端未知时一个字节都不改

### DIFF
--- a/scripts/release-version.test.ts
+++ b/scripts/release-version.test.ts
@@ -105,7 +105,7 @@ function runGit(directory: string, args: string[]) {
   execFileSync("git", args, { cwd: directory, stdio: "pipe" });
 }
 
-type ReleaseHarnessScenario = "view-error" | "ci-failure" | "snapshot-copy-failure" | "push-not-landed" | "push-failed";
+type ReleaseHarnessScenario = "view-error" | "ci-failure" | "snapshot-copy-failure" | "push-not-landed" | "push-failed" | "push-failed-dirty" | "push-failed-head-moved" | "fetch-failed-after-push";
 
 function writeExecutable(path: string, body: string) {
   writeFileSync(path, `#!/usr/bin/env bash\nset -euo pipefail\n${body}`);
@@ -144,9 +144,22 @@ function runReleaseHarness(scenario: ReleaseHarnessScenario) {
     join(fakeBin, "git"),
     `printf 'git %s\\n' "$*" >> "$MOCK_COMMAND_LOG"
 case "\${1:-}" in
-  status) exit 0 ;;
+  fetch)
+    # 预检那次 fetch 必须成功；只有推送之后的核实 fetch 才挂。
+    if [[ "$MOCK_SCENARIO" == "fetch-failed-after-push" ]] && grep -q 'refs/heads/main' "$MOCK_COMMAND_LOG"; then
+      echo "simulated fetch outage" >&2
+      exit 1
+    fi
+    exit 0 ;;
+  status)
+    # 入口的干净树校验必须放行；只有推送失败后的那次复查才报脏，用来验证
+    # 「状态变了就不自动回滚」。
+    if [[ "$MOCK_SCENARIO" == "push-failed-dirty" ]] && grep -q 'refs/heads/main' "$MOCK_COMMAND_LOG"; then
+      printf ' M cli/src/somebody-elses-wip.ts\\n'
+    fi
+    exit 0 ;;
   push)
-    if [[ "$MOCK_SCENARIO" == "push-failed" && "$*" == *"refs/heads/main"* ]]; then
+    if [[ "$MOCK_SCENARIO" == push-failed* && "$*" == *"refs/heads/main"* ]]; then
       echo "simulated push rejection" >&2
       exit 1
     fi
@@ -156,7 +169,13 @@ case "\${1:-}" in
     # tag 已发过。push-not-landed 场景下推完之后让 origin/main 停在别处，用来
     # 验证「静默空推」确实会被拦住。
     case "\${2:-}" in
-      HEAD) printf '%s\\n' "$MOCK_HEAD_SHA"; exit 0 ;;
+      HEAD)
+        if [[ "$MOCK_SCENARIO" == "push-failed-head-moved" ]] && grep -q 'refs/heads/main' "$MOCK_COMMAND_LOG"; then
+          printf '%s\\n' "$MOCK_OTHER_SHA"
+        else
+          printf '%s\\n' "$MOCK_HEAD_SHA"
+        fi
+        exit 0 ;;
       FETCH_HEAD)
         if [[ "$MOCK_SCENARIO" == "push-not-landed" ]] && grep -q 'refs/heads/main' "$MOCK_COMMAND_LOG"; then
           printf '%s\\n' "$MOCK_OTHER_SHA"
@@ -628,8 +647,40 @@ describe("release main 推送落地", () => {
     expect(result.commands).not.toContain("git push origin v0.2.83");
     // 不回滚的话「重跑」根本走不通：基线校验会挡下 HEAD ≠ origin/main，
     // 就算手工对齐，版本文件已经是新版号、bump 无 diff，commit 会空提交失败。
-    expect(result.commands).toContain("git reset --hard 1111111111111111111111111111111111111111");
+    expect(result.commands).toContain("git reset --keep 1111111111111111111111111111111111111111");
     expect(result.stderr).toContain("可直接重跑");
+  });
+
+  // 脚本从入口校验跑到这里要好几分钟，而本仓常有多个 agent 会话共用同一棵工作树。
+  // 期间别人动过文件的话，照着几分钟前的假设 reset 就会吃掉别人的改动。
+  test("推送失败后工作树已被别人改脏时，一步都不碰", () => {
+    const result = runReleaseHarness("push-failed-dirty");
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.commands).not.toContain("git reset");
+    expect(result.stderr).toContain("不自动回滚");
+    expect(result.stderr).toContain("git push origin");
+  });
+
+  test("推送失败后 HEAD 已经被别人推进过时，一步都不碰", () => {
+    const result = runReleaseHarness("push-failed-head-moved");
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.commands).not.toContain("git reset");
+    expect(result.stderr).toContain("不自动回滚");
+  });
+
+  // push 成功、只是 fetch 挂了：远端到底落没落地是未知的。未知状态下回滚会让本地
+  // 与已经落地的远端劈叉，所以这条分支必须一个字节都不改。
+  test("推送后 fetch 失败时不回滚，只给出确认远端的命令", () => {
+    const result = runReleaseHarness("fetch-failed-after-push");
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.commands).not.toContain("git reset");
+    expect(result.stderr).toContain("本地不做任何回滚");
+    expect(result.stderr).toContain("git ls-remote origin refs/heads/main");
+    expect(result.commands).not.toContain("git tag v0.2.83");
+    expect(result.commands).not.toContain("gh run list");
   });
 
   test("origin/main 没指向发布提交时停住，且不留悬空 tag", () => {
@@ -638,7 +689,7 @@ describe("release main 推送落地", () => {
     expect(result.exitCode).not.toBe(0);
     expect(result.commands).toContain("git push origin HEAD:refs/heads/main");
     expect(result.stderr).toContain("版本提交没进 main");
-    expect(result.commands).toContain("git reset --hard 1111111111111111111111111111111111111111");
+    expect(result.commands).toContain("git reset --keep 1111111111111111111111111111111111111111");
     expect(result.commands).not.toContain("git tag v0.2.83");
     expect(result.commands).not.toContain("git push origin v0.2.83");
     expect(result.commands).not.toContain("gh run list");

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -244,16 +244,33 @@ remove_release_temp_files() {
 # 基线对齐，release-version.ts 也已无 diff 可 bump，`git commit` 会因为没有暂存内容
 # 失败。也就是说不回滚的话，「重跑」这条路根本走不通。
 #
-# 所以默认把本地那条发布提交回滚掉——它完全是脚本自己刚打的，工作树在入口处已经
-# 校验过干净——让「重跑」重新成为一条真的能走的路。回滚失败就把手工命令原样给出。
+# 所以默认把本地那条发布提交回滚掉，让「重跑」重新成为一条真的能走的路。
+#
+# 但回滚是破坏性动作，而这套脚本从入口校验到这里要跑好几分钟（完整门禁 + 推送），
+# 期间仓库可能已经不是脚本以为的样子了——本仓常有多个 agent 会话共用同一棵工作树，
+# 别人随时可能在里面改文件甚至提交。所以回滚前必须重新确认状态，而不是照着几分钟
+# 前的假设动手：HEAD 必须仍然正好是脚本自己打的那条提交，工作树必须仍然干净。
+# 任何一条对不上就一步都不碰，只打印手工恢复命令。
+#
+# 即便两项都满足，也走 `git reset --keep` 而不是 `--hard`：前者在发现会覆盖本地
+# 修改时会自己拒绝执行，等于多一道 git 自己把关的保险。
 abort_unpushed_release() {
   local base_sha="$1" release_sha="$2" version="$3"
-  if [[ -n "$base_sha" ]] && git reset --hard "$base_sha" >/dev/null 2>&1; then
-    echo "   已回滚本地发布提交 ${release_sha}，工作树复位到 ${base_sha}。" >&2
+  local head_now tree_state
+  head_now=$(git rev-parse HEAD 2>/dev/null || true)
+  tree_state=$(git status --porcelain 2>/dev/null || echo "?")
+  if [[ -n "$base_sha" && "$head_now" == "$release_sha" && -z "$tree_state" ]] &&
+    git reset --keep "$base_sha" >/dev/null 2>&1; then
+    echo "   已回滚本地发布提交 ${release_sha}，工作树复位到 ${base_sha}（git reflog 可找回）。" >&2
     echo "   修好后可直接重跑： scripts/release.sh ${version}" >&2
     return 0
   fi
-  echo "   自动回滚失败，本地仍停在 ${release_sha}（版本文件已是 ${version}）。" >&2
+  if [[ "$head_now" != "$release_sha" || -n "$tree_state" ]]; then
+    echo "   仓库状态已变（HEAD=${head_now:-未知}，工作树${tree_state:+不干净}${tree_state:-干净}），不自动回滚。" >&2
+  else
+    echo "   自动回滚未成功。" >&2
+  fi
+  echo "   本地仍停在 ${release_sha}（版本文件已是 ${version}）。" >&2
   echo "   二选一：" >&2
   echo "     1) 手工补推： git push origin ${release_sha}:refs/heads/main" >&2
   echo "        然后手工补 tag： git tag v${version} ${release_sha} && git push origin v${version}" >&2
@@ -360,9 +377,13 @@ main() {
   fi
   # 推完必须核实远端确实指向这条提交——上面那条静默失败就是这么漏过去的。
   if ! git fetch origin main --quiet; then
-    echo "!! 推送后 fetch origin main 失败，无法核实是否落地。tag 未推。" >&2
-    echo "   先自行确认 origin/main 是否已是 ${RELEASE_SHA}：已是则只需补打 tag，未是则按下面回滚。" >&2
-    abort_unpushed_release "$BASE_SHA" "$RELEASE_SHA" "$VER"
+    # 这里 push 已经返回成功、只是 fetch 挂了：远端到底落没落地是**未知**的。
+    # 未知状态下自动回滚是错的——万一已经落地，本地一回滚就与远端劈叉，而操作者
+    # 还以为什么都没发生。所以这条分支只报状态、给两条命令，一个字节都不改。
+    echo "!! 推送后 fetch origin main 失败，无法核实是否落地。tag 未推，本地不做任何回滚。" >&2
+    echo "   先确认远端： git ls-remote origin refs/heads/main" >&2
+    echo "   已是 ${RELEASE_SHA} → 只需补 tag： git tag v${VER} ${RELEASE_SHA} && git push origin v${VER}" >&2
+    echo "   还不是 → 丢弃本地这条提交后重跑： git reset --keep ${BASE_SHA} && scripts/release.sh ${VER}" >&2
     return 1
   fi
   [[ "$(git rev-parse FETCH_HEAD)" == "$RELEASE_SHA" ]] || {


### PR DESCRIPTION
#946 的后续。那版加的自动回滚不够安全，codex stop-gate 审出来的，属实。

## 问题

`release.sh` 从入口的干净树校验跑到推送失败，中间要经过完整门禁和推送，好几分钟。到了失败分支再 `git reset --hard "$BASE_SHA"`，用的还是几分钟前那份假设。

本仓常有多个 agent 会话共用同一棵工作树（今天就撞了不止一次），期间别人完全可能改文件、甚至提交。照着过期假设做破坏性 reset，会把别人的改动一起吃掉。

第二个问题更微妙：push 已经返回成功、只是核实用的 `fetch` 挂了 —— 此时**远端到底落没落地是未知的**。原代码一边打印「先自行确认 origin/main 是否已是这条提交」，一边立刻回滚，自相矛盾；万一远端其实已经落地，本地一回滚就与远端劈叉，而操作者还以为什么都没发生。

## 改动

- **回滚前重新确认状态**：`HEAD` 必须仍然正好是脚本自己打的那条提交，工作树必须仍然干净。任一条对不上就一步都不碰，只打印手工恢复命令。
- **`reset --keep` 取代 `--hard`**：发现会覆盖本地修改时 git 自己会拒绝执行，多一道由 git 把关的保险。提示里点明 reflog 可找回。
- **远端未知时不回滚**：fetch 失败分支改为只报状态，给出 `git ls-remote origin refs/heads/main` 与两条分支恢复路径（已落地 → 只补 tag；未落地 → `reset --keep` 后重跑）。

## 测试

原来的 harness mock 恒返回干净状态、HEAD 恒不动、fetch 恒成功，这三条路径全是盲区。新增三个场景，都断言**没有执行任何 `git reset`**：

| 场景 | 断言 |
|---|---|
| `push-failed-dirty` | 推送失败后工作树被别人改脏 → 不回滚，提示状态已变 |
| `push-failed-head-moved` | 推送失败后 HEAD 已被推进过 → 不回滚 |
| `fetch-failed-after-push` | 推送后 fetch 挂掉 → 不回滚，给出 `git ls-remote` 确认命令 |

`check:scripts` 363 条全绿。