### PR TITLE
fix(scripts): 落地判定改用祖先关系，远端未知时不回滚

### DIFF
--- a/scripts/release-push-target.test.ts
+++ b/scripts/release-push-target.test.ts
@@ -18,10 +18,13 @@ describe("release.sh 推送目标", () => {
     expect(releaseScript).toContain('git push origin "HEAD:refs/heads/main"');
   });
 
-  test("推完核实 origin/main 真的指向这条发布提交", () => {
+  test("推完核实发布提交真的进了 origin/main 的历史", () => {
     const verify = releaseScript.slice(releaseScript.indexOf('git push origin "HEAD:refs/heads/main"'));
     expect(verify).toContain("git fetch origin main --quiet");
-    expect(verify).toMatch(/\[\[ "\$\(git rev-parse FETCH_HEAD\)" == "\$RELEASE_SHA" \]\]/);
+    // 必须是祖先判定而不是 tip 相等：别人紧接着又推一笔时 tip 不是我们的提交，
+    // 但发布提交确实已经在 main 的历史里，判成「没落地」会误回滚。
+    expect(verify).toContain('git merge-base --is-ancestor "$RELEASE_SHA" FETCH_HEAD');
+    expect(verify).not.toMatch(/\$\(git rev-parse FETCH_HEAD\)" == "\$RELEASE_SHA/);
   });
 
   test("tag 在 main 落地之后才打——main 没推成就不留悬空 tag", () => {

--- a/scripts/release-version.test.ts
+++ b/scripts/release-version.test.ts
@@ -105,7 +105,7 @@ function runGit(directory: string, args: string[]) {
   execFileSync("git", args, { cwd: directory, stdio: "pipe" });
 }
 
-type ReleaseHarnessScenario = "view-error" | "ci-failure" | "snapshot-copy-failure" | "push-not-landed" | "push-failed" | "push-failed-dirty" | "push-failed-head-moved" | "fetch-failed-after-push";
+type ReleaseHarnessScenario = "view-error" | "ci-failure" | "snapshot-copy-failure" | "push-not-landed" | "push-failed" | "push-failed-dirty" | "push-failed-head-moved" | "fetch-failed-after-push" | "push-failed-but-landed";
 
 function writeExecutable(path: string, body: string) {
   writeFileSync(path, `#!/usr/bin/env bash\nset -euo pipefail\n${body}`);
@@ -144,6 +144,18 @@ function runReleaseHarness(scenario: ReleaseHarnessScenario) {
     join(fakeBin, "git"),
     `printf 'git %s\\n' "$*" >> "$MOCK_COMMAND_LOG"
 case "\${1:-}" in
+  ls-remote)
+    # push/fetch 失败后脚本靠这条把「未知」变成「已知」。
+    if [[ "$MOCK_SCENARIO" == "fetch-failed-after-push" ]]; then
+      echo "simulated ls-remote outage" >&2
+      exit 1
+    fi
+    if [[ "$MOCK_SCENARIO" == "push-failed-but-landed" ]]; then
+      printf '%s\\trefs/heads/main\\n' "$MOCK_HEAD_SHA"
+    else
+      printf '%s\\trefs/heads/main\\n' "$MOCK_OTHER_SHA"
+    fi
+    exit 0 ;;
   fetch)
     # 预检那次 fetch 必须成功；只有推送之后的核实 fetch 才挂。
     if [[ "$MOCK_SCENARIO" == "fetch-failed-after-push" ]] && grep -q 'refs/heads/main' "$MOCK_COMMAND_LOG"; then
@@ -647,6 +659,7 @@ describe("release main 推送落地", () => {
     expect(result.commands).not.toContain("git push origin v0.2.83");
     // 不回滚的话「重跑」根本走不通：基线校验会挡下 HEAD ≠ origin/main，
     // 就算手工对齐，版本文件已经是新版号、bump 无 diff，commit 会空提交失败。
+    expect(result.stderr).toContain("确实没落地");
     expect(result.commands).toContain("git reset --keep 1111111111111111111111111111111111111111");
     expect(result.stderr).toContain("可直接重跑");
   });
@@ -670,17 +683,29 @@ describe("release main 推送落地", () => {
     expect(result.stderr).toContain("不自动回滚");
   });
 
-  // push 成功、只是 fetch 挂了：远端到底落没落地是未知的。未知状态下回滚会让本地
-  // 与已经落地的远端劈叉，所以这条分支必须一个字节都不改。
-  test("推送后 fetch 失败时不回滚，只给出确认远端的命令", () => {
+  // push 成功、只是 fetch 挂了，连 ls-remote 也拿不到：落地与否未知。未知状态下
+  // 回滚会让本地与可能已经落地的远端劈叉，所以必须一个字节都不改。
+  test("远端状态拿不到时不回滚", () => {
     const result = runReleaseHarness("fetch-failed-after-push");
 
     expect(result.exitCode).not.toBe(0);
     expect(result.commands).not.toContain("git reset");
-    expect(result.stderr).toContain("本地不做任何回滚");
+    expect(result.stderr).toContain("落地与否未知");
     expect(result.stderr).toContain("git ls-remote origin refs/heads/main");
     expect(result.commands).not.toContain("git tag v0.2.83");
     expect(result.commands).not.toContain("gh run list");
+  });
+
+  // git push 返回非 0 不等于远端没落地：服务端可能已经更新了 ref，只是客户端在
+  // 拿到响应前断了。这种情况下回滚会把已经发布出去的提交从本地抹掉。
+  test("推送报错但远端其实已落地时不回滚，只提示补 tag", () => {
+    const result = runReleaseHarness("push-failed-but-landed");
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.commands).not.toContain("git reset");
+    expect(result.stderr).toContain("推送已生效");
+    expect(result.stderr).toContain("只需补 tag");
+    expect(result.commands).not.toContain("git tag v0.2.83");
   });
 
   test("origin/main 没指向发布提交时停住，且不留悬空 tag", () => {

--- a/scripts/release-version.test.ts
+++ b/scripts/release-version.test.ts
@@ -105,7 +105,7 @@ function runGit(directory: string, args: string[]) {
   execFileSync("git", args, { cwd: directory, stdio: "pipe" });
 }
 
-type ReleaseHarnessScenario = "view-error" | "ci-failure" | "snapshot-copy-failure" | "push-not-landed" | "push-failed" | "push-failed-dirty" | "push-failed-head-moved" | "fetch-failed-after-push" | "push-failed-but-landed";
+type ReleaseHarnessScenario = "view-error" | "ci-failure" | "snapshot-copy-failure" | "push-not-landed" | "push-failed" | "push-failed-dirty" | "push-failed-head-moved" | "fetch-failed-after-push" | "push-failed-but-landed" | "push-failed-advanced" | "push-landed-not-tip";
 
 function writeExecutable(path: string, body: string) {
   writeFileSync(path, `#!/usr/bin/env bash\nset -euo pipefail\n${body}`);
@@ -143,22 +143,25 @@ function runReleaseHarness(scenario: ReleaseHarnessScenario) {
   writeExecutable(
     join(fakeBin, "git"),
     `printf 'git %s\\n' "$*" >> "$MOCK_COMMAND_LOG"
+pushed() { grep -q 'refs/heads/main' "$MOCK_COMMAND_LOG"; }
+committed() { grep -q '^git commit' "$MOCK_COMMAND_LOG"; }
 case "\${1:-}" in
   ls-remote)
-    # push/fetch 失败后脚本靠这条把「未知」变成「已知」。
-    if [[ "$MOCK_SCENARIO" == "fetch-failed-after-push" ]]; then
-      echo "simulated ls-remote outage" >&2
-      exit 1
-    fi
-    if [[ "$MOCK_SCENARIO" == "push-failed-but-landed" ]]; then
-      printf '%s\\trefs/heads/main\\n' "$MOCK_HEAD_SHA"
-    else
-      printf '%s\\trefs/heads/main\\n' "$MOCK_OTHER_SHA"
-    fi
+    # push / 核实 fetch 失败后，脚本靠这条把「未知」尽量变成「已知」。
+    case "$MOCK_SCENARIO" in
+      fetch-failed-after-push) echo "simulated ls-remote outage" >&2; exit 1 ;;
+      push-failed-but-landed) printf '%s\\trefs/heads/main\\n' "$MOCK_RELEASE_SHA" ;;
+      push-failed-advanced)   printf '%s\\trefs/heads/main\\n' "$MOCK_OTHER_SHA" ;;
+      *)                      printf '%s\\trefs/heads/main\\n' "$MOCK_BASE_SHA" ;;
+    esac
     exit 0 ;;
+  merge-base)
+    # --is-ancestor：发布提交在不在远端历史里。
+    [[ "$MOCK_SCENARIO" != "push-not-landed" ]]
+    exit $? ;;
   fetch)
     # 预检那次 fetch 必须成功；只有推送之后的核实 fetch 才挂。
-    if [[ "$MOCK_SCENARIO" == "fetch-failed-after-push" ]] && grep -q 'refs/heads/main' "$MOCK_COMMAND_LOG"; then
+    if [[ "$MOCK_SCENARIO" == "fetch-failed-after-push" ]] && pushed; then
       echo "simulated fetch outage" >&2
       exit 1
     fi
@@ -166,7 +169,7 @@ case "\${1:-}" in
   status)
     # 入口的干净树校验必须放行；只有推送失败后的那次复查才报脏，用来验证
     # 「状态变了就不自动回滚」。
-    if [[ "$MOCK_SCENARIO" == "push-failed-dirty" ]] && grep -q 'refs/heads/main' "$MOCK_COMMAND_LOG"; then
+    if [[ "$MOCK_SCENARIO" == "push-failed-dirty" ]] && pushed; then
       printf ' M cli/src/somebody-elses-wip.ts\\n'
     fi
     exit 0 ;;
@@ -177,22 +180,26 @@ case "\${1:-}" in
     fi
     exit 0 ;;
   rev-parse)
-    # 发布基线与推送核实都读 SHA；只有 tag 名要报「不存在」，否则脚本会以为
-    # tag 已发过。push-not-landed 场景下推完之后让 origin/main 停在别处，用来
-    # 验证「静默空推」确实会被拦住。
+    # tag 名要报「不存在」，否则脚本会以为这一版已经发过。
     case "\${2:-}" in
       HEAD)
-        if [[ "$MOCK_SCENARIO" == "push-failed-head-moved" ]] && grep -q 'refs/heads/main' "$MOCK_COMMAND_LOG"; then
+        # 发布提交打出来之前 HEAD 是基线，之后是发布提交——mock 必须分得清这两者，
+        # 否则「回滚到基线」「HEAD 有没有被别人推进过」这些判断全测不出来。
+        if [[ "$MOCK_SCENARIO" == "push-failed-head-moved" ]] && pushed; then
           printf '%s\\n' "$MOCK_OTHER_SHA"
+        elif committed; then
+          printf '%s\\n' "$MOCK_RELEASE_SHA"
         else
-          printf '%s\\n' "$MOCK_HEAD_SHA"
+          printf '%s\\n' "$MOCK_BASE_SHA"
         fi
         exit 0 ;;
       FETCH_HEAD)
-        if [[ "$MOCK_SCENARIO" == "push-not-landed" ]] && grep -q 'refs/heads/main' "$MOCK_COMMAND_LOG"; then
+        if ! pushed; then
+          printf '%s\\n' "$MOCK_BASE_SHA"
+        elif [[ "$MOCK_SCENARIO" == "push-not-landed" || "$MOCK_SCENARIO" == "push-landed-not-tip" ]]; then
           printf '%s\\n' "$MOCK_OTHER_SHA"
         else
-          printf '%s\\n' "$MOCK_HEAD_SHA"
+          printf '%s\\n' "$MOCK_RELEASE_SHA"
         fi
         exit 0 ;;
       *) exit 1 ;;
@@ -263,8 +270,9 @@ exec /bin/cp "$@"
       MOCK_COMMAND_LOG: commandLog,
       MOCK_COPY_COUNT: copyCount,
       MOCK_SCENARIO: scenario,
-      MOCK_HEAD_SHA: "1111111111111111111111111111111111111111",
+      MOCK_BASE_SHA: "1111111111111111111111111111111111111111",
       MOCK_OTHER_SHA: "2222222222222222222222222222222222222222",
+      MOCK_RELEASE_SHA: "3333333333333333333333333333333333333333",
       RELEASE_GH_RETRY_DELAY: "0",
       RELEASE_GH_RETRY_ATTEMPTS: "2",
       RELEASE_RUN_LOOKUP_ATTEMPTS: "2",
@@ -690,7 +698,7 @@ describe("release main 推送落地", () => {
 
     expect(result.exitCode).not.toBe(0);
     expect(result.commands).not.toContain("git reset");
-    expect(result.stderr).toContain("落地与否未知");
+    expect(result.stderr).toContain("拿不准远端到底落没落地");
     expect(result.stderr).toContain("git ls-remote origin refs/heads/main");
     expect(result.commands).not.toContain("git tag v0.2.83");
     expect(result.commands).not.toContain("gh run list");
@@ -703,9 +711,29 @@ describe("release main 推送落地", () => {
 
     expect(result.exitCode).not.toBe(0);
     expect(result.commands).not.toContain("git reset");
-    expect(result.stderr).toContain("推送已生效");
+    expect(result.stderr).toContain("推送其实生效了");
     expect(result.stderr).toContain("只需补 tag");
     expect(result.commands).not.toContain("git tag v0.2.83");
+  });
+
+  // 只比远端 tip 是不够的：别人在我们推上去之后紧接着又推一笔，tip 就不是我们的
+  // 提交了，但它确实已经在 main 的历史里。判成「没落地」去回滚，等于把已经发布出去
+  // 的提交从本地抹掉。
+  test("推送报错、tip 已被别人推进但发布提交在历史里时不回滚", () => {
+    const result = runReleaseHarness("push-failed-advanced");
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.commands).not.toContain("git reset");
+    expect(result.stderr).toContain("推送其实生效了");
+  });
+
+  test("推送成功、tip 已被别人推进但发布提交在历史里时照常打 tag", () => {
+    const result = runReleaseHarness("push-landed-not-tip");
+
+    expect(result.commands).not.toContain("git reset");
+    expect(result.commands).toContain("git tag v0.2.83");
+    expect(result.commands).toContain("git push origin v0.2.83");
+    expect(result.stderr).not.toContain("没进 main");
   });
 
   test("origin/main 没指向发布提交时停住，且不留悬空 tag", () => {

--- a/scripts/release-version.test.ts
+++ b/scripts/release-version.test.ts
@@ -700,6 +700,10 @@ describe("release main 推送落地", () => {
     expect(result.commands).not.toContain("git reset");
     expect(result.stderr).toContain("拿不准远端到底落没落地");
     expect(result.stderr).toContain("git ls-remote origin refs/heads/main");
+    // 未知态下三条路都要写清楚：已落地只差 tag、没落地先补推、不想继续就回滚重跑。
+    expect(result.stderr).toContain("只差 tag");
+    expect(result.stderr).toContain("先补推");
+    expect(result.stderr).toContain("不想继续这一版");
     expect(result.commands).not.toContain("git tag v0.2.83");
     expect(result.commands).not.toContain("gh run list");
   });

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -300,21 +300,53 @@ remote_main_sha() {
 # 确认没落地才允许回滚，仍然拿不准就一个字节都不改。
 settle_unlanded_release() {
   local base_sha="$1" release_sha="$2" version="$3"
-  local remote
-  remote=$(remote_main_sha)
-  if [[ -n "$remote" && "$remote" == "$release_sha" ]]; then
-    echo "   远端 origin/main 其实已经是 ${release_sha}（推送已生效，只是客户端没拿到响应），不回滚。" >&2
-    echo "   只需补 tag： git tag v${version} ${release_sha} && git push origin v${version}" >&2
+  case "$(release_landing_state "$base_sha" "$release_sha")" in
+    landed)
+      echo "   远端 origin/main 的历史里已经有 ${release_sha}（推送其实生效了），不回滚。" >&2
+      echo "   只需补 tag： git tag v${version} ${release_sha} && git push origin v${version}" >&2
+      ;;
+    missing)
+      echo "   已向远端确认这条提交确实没落地。" >&2
+      abort_unpushed_release "$base_sha" "$release_sha" "$version"
+      ;;
+    *)
+      echo "   拿不准远端到底落没落地，不自动回滚。" >&2
+      echo "   恢复前先确认远端： git ls-remote origin refs/heads/main" >&2
+      print_release_manual_recovery "$base_sha" "$release_sha" "$version"
+      ;;
+  esac
+}
+
+# 这条发布提交到底进没进 origin/main：landed / missing / unknown。
+#
+# 只比远端 tip 是不够的。别人完全可能在我们推上去之后紧接着又推一笔，此时 tip 不是
+# 我们的提交，但我们的提交确实已经在 main 的历史里。把这种情况判成「没落地」去回滚，
+# 等于把已经发布出去的提交从本地抹掉；重跑还会为同一个版本号造出第二条 bump 提交，
+# tag 最终指向的东西和 main 里的那条对不上。
+#
+# 所以：tip 正好是它 ⇒ landed；tip 还停在发布前的基线 ⇒ 确实 missing；tip 是第三个
+# 值 ⇒ 必须把远端历史取下来做祖先判定才能分清，取不下来就老实说 unknown。
+release_landing_state() {
+  local base_sha="$1" release_sha="$2"
+  local tip
+  tip=$(remote_main_sha)
+  if [[ -n "$tip" && "$tip" == "$release_sha" ]]; then
+    printf 'landed'
     return 0
   fi
-  if [[ -z "$remote" ]]; then
-    echo "   git ls-remote 也拿不到远端状态，落地与否未知，不自动回滚。" >&2
-    echo "   恢复前先确认远端： git ls-remote origin refs/heads/main" >&2
-    print_release_manual_recovery "$base_sha" "$release_sha" "$version"
+  if [[ -n "$tip" && -n "$base_sha" && "$tip" == "$base_sha" ]]; then
+    printf 'missing'
     return 0
   fi
-  echo "   已向远端确认 origin/main = ${remote}，这条提交确实没落地。" >&2
-  abort_unpushed_release "$base_sha" "$release_sha" "$version"
+  if git fetch origin main --quiet 2>/dev/null; then
+    if git merge-base --is-ancestor "$release_sha" FETCH_HEAD 2>/dev/null; then
+      printf 'landed'
+    else
+      printf 'missing'
+    fi
+    return 0
+  fi
+  printf 'unknown'
 }
 
 cleanup_release_version() {
@@ -421,8 +453,10 @@ main() {
     settle_unlanded_release "$BASE_SHA" "$RELEASE_SHA" "$VER"
     return 1
   fi
-  [[ "$(git rev-parse FETCH_HEAD)" == "$RELEASE_SHA" ]] || {
-    echo "!! origin/main 未指向 ${RELEASE_SHA}，版本提交没进 main。tag 未推。" >&2
+  # 用祖先判定而不是 tip 相等：别人在我们之后又推一笔时 tip 会不是我们的提交，
+  # 但发布提交确实已经在 main 的历史里，那种情况直接继续打 tag 就对了。
+  git merge-base --is-ancestor "$RELEASE_SHA" FETCH_HEAD || {
+    echo "!! origin/main 的历史里没有 ${RELEASE_SHA}，版本提交没进 main。tag 未推。" >&2
     echo "   origin/main = $(git rev-parse FETCH_HEAD)" >&2
     # 这条分支是**已经核实过**远端没落地，可以直接走带状态门的回滚。
     abort_unpushed_release "$BASE_SHA" "$RELEASE_SHA" "$VER"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -270,12 +270,51 @@ abort_unpushed_release() {
   else
     echo "   自动回滚未成功。" >&2
   fi
+  print_release_manual_recovery "$base_sha" "$release_sha" "$version"
+  return 0
+}
+
+print_release_manual_recovery() {
+  local base_sha="$1" release_sha="$2" version="$3"
   echo "   本地仍停在 ${release_sha}（版本文件已是 ${version}）。" >&2
   echo "   二选一：" >&2
   echo "     1) 手工补推： git push origin ${release_sha}:refs/heads/main" >&2
   echo "        然后手工补 tag： git tag v${version} ${release_sha} && git push origin v${version}" >&2
-  echo "     2) 丢弃这条提交后重跑： git reset --hard ${base_sha:-<发布前的 SHA>} && scripts/release.sh ${version}" >&2
-  return 0
+  echo "     2) 丢弃这条提交后重跑： git reset --keep ${base_sha:-<发布前的 SHA>} && scripts/release.sh ${version}" >&2
+}
+
+# 远端 main 现在指向哪。拿不到就回空——空字符串代表「未知」，不代表「没落地」。
+remote_main_sha() {
+  local line
+  line=$(git ls-remote origin refs/heads/main 2>/dev/null) || return 0
+  printf '%s' "${line%%[[:space:]]*}"
+}
+
+# push 失败、或推送后的核实 fetch 失败之后的收尾。
+#
+# 关键：`git push` 返回非 0 **不等于**远端没落地——服务端完全可能已经更新了 ref，
+# 只是客户端在拿到响应之前断了。fetch 失败同理，只说明「没能核实」。在落地与否未知
+# 的时候回滚本地提交，会让本地与可能已经落地的远端劈叉，而操作者以为什么都没发生。
+#
+# 所以先用 ls-remote 把「未知」尽量变成「已知」：确认已落地就别回滚（只差补 tag），
+# 确认没落地才允许回滚，仍然拿不准就一个字节都不改。
+settle_unlanded_release() {
+  local base_sha="$1" release_sha="$2" version="$3"
+  local remote
+  remote=$(remote_main_sha)
+  if [[ -n "$remote" && "$remote" == "$release_sha" ]]; then
+    echo "   远端 origin/main 其实已经是 ${release_sha}（推送已生效，只是客户端没拿到响应），不回滚。" >&2
+    echo "   只需补 tag： git tag v${version} ${release_sha} && git push origin v${version}" >&2
+    return 0
+  fi
+  if [[ -z "$remote" ]]; then
+    echo "   git ls-remote 也拿不到远端状态，落地与否未知，不自动回滚。" >&2
+    echo "   恢复前先确认远端： git ls-remote origin refs/heads/main" >&2
+    print_release_manual_recovery "$base_sha" "$release_sha" "$version"
+    return 0
+  fi
+  echo "   已向远端确认 origin/main = ${remote}，这条提交确实没落地。" >&2
+  abort_unpushed_release "$base_sha" "$release_sha" "$version"
 }
 
 cleanup_release_version() {
@@ -371,24 +410,21 @@ main() {
   # main 引用（还停在 bump 之前），git 会打印 "Everything up-to-date" 当作成功，
   # 于是 tag 上去了、版本提交没进 main，线上 /api/version 与 tag 对不上。
   if ! git push origin "HEAD:refs/heads/main"; then
+    # 注意：push 非 0 不代表远端没落地，交给 settle 去向远端确认。
     echo "!! 推送 origin/main 失败（网络或权限）。tag 未推。" >&2
-    abort_unpushed_release "$BASE_SHA" "$RELEASE_SHA" "$VER"
+    settle_unlanded_release "$BASE_SHA" "$RELEASE_SHA" "$VER"
     return 1
   fi
   # 推完必须核实远端确实指向这条提交——上面那条静默失败就是这么漏过去的。
   if ! git fetch origin main --quiet; then
-    # 这里 push 已经返回成功、只是 fetch 挂了：远端到底落没落地是**未知**的。
-    # 未知状态下自动回滚是错的——万一已经落地，本地一回滚就与远端劈叉，而操作者
-    # 还以为什么都没发生。所以这条分支只报状态、给两条命令，一个字节都不改。
-    echo "!! 推送后 fetch origin main 失败，无法核实是否落地。tag 未推，本地不做任何回滚。" >&2
-    echo "   先确认远端： git ls-remote origin refs/heads/main" >&2
-    echo "   已是 ${RELEASE_SHA} → 只需补 tag： git tag v${VER} ${RELEASE_SHA} && git push origin v${VER}" >&2
-    echo "   还不是 → 丢弃本地这条提交后重跑： git reset --keep ${BASE_SHA} && scripts/release.sh ${VER}" >&2
+    echo "!! 推送后 fetch origin main 失败，无法用本地引用核实。tag 未推。" >&2
+    settle_unlanded_release "$BASE_SHA" "$RELEASE_SHA" "$VER"
     return 1
   fi
   [[ "$(git rev-parse FETCH_HEAD)" == "$RELEASE_SHA" ]] || {
     echo "!! origin/main 未指向 ${RELEASE_SHA}，版本提交没进 main。tag 未推。" >&2
     echo "   origin/main = $(git rev-parse FETCH_HEAD)" >&2
+    # 这条分支是**已经核实过**远端没落地，可以直接走带状态门的回滚。
     abort_unpushed_release "$BASE_SHA" "$RELEASE_SHA" "$VER"
     return 1
   }

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -310,9 +310,13 @@ settle_unlanded_release() {
       abort_unpushed_release "$base_sha" "$release_sha" "$version"
       ;;
     *)
-      echo "   拿不准远端到底落没落地，不自动回滚。" >&2
-      echo "   恢复前先确认远端： git ls-remote origin refs/heads/main" >&2
-      print_release_manual_recovery "$base_sha" "$release_sha" "$version"
+      # 未知态下操作者最容易懵：既不知道该补推还是该补 tag，也不知道能不能重跑。
+      # 所以这里不给「二选一」，而是先给确认命令，再按确认结果分三条路写清楚。
+      echo "   拿不准远端到底落没落地，不自动回滚。本地仍停在 ${release_sha}（版本文件已是 ${version}）。" >&2
+      echo "   先确认远端： git ls-remote origin refs/heads/main" >&2
+      echo "     远端已含 ${release_sha} → 只差 tag： git tag v${version} ${release_sha} && git push origin v${version}" >&2
+      echo "     远端还没有 → 先补推： git push origin ${release_sha}:refs/heads/main，落地后再按上一条补 tag" >&2
+      echo "     不想继续这一版 → git reset --keep ${base_sha:-<发布前的 SHA>} && scripts/release.sh ${version}" >&2
       ;;
   esac
 }


### PR DESCRIPTION
#947 的续。**#947 被合并时我还在往那个分支上推**，后两笔（`d120ed7`、`c74f4fd`）没进 squash —— 往已合并 PR 推送是静默无效的。核 main 上的 `scripts/release.sh`：`merge-base --is-ancestor` 0 处、`release_landing_state` 0 处，确认缺的就是这两笔。本 PR 把它们重新落到当前 main 上。

两笔都来自 codex stop-gate 的连续审查，都属实。

## 一：`git push` 报错 ≠ 远端没落地

#947 只在 fetch 失败那支承认"远端状态未知"，push 失败那支仍然直接回滚。但 `git push` 返回非 0 同样不代表远端没落地 —— 服务端完全可能已经更新了 ref，只是客户端在拿到响应之前断了。此时回滚等于把已经发布出去的提交从本地抹掉，本地与远端就此劈叉，而操作者以为什么都没发生。

改为先用 `git ls-remote` 把"未知"尽量变成"已知"，只有确认**没**落地才允许回滚。

## 二：`tip ≠ 这条提交` ≠ 没落地

上一条的实现拿远端 tip 相等做判据，同样不成立：别人可能在我们推上去之后紧接着又推一笔，tip 就不是我们的提交了，但它确实已经在 main 的历史里。判成没落地去回滚，除了抹掉已发布的提交，重跑还会为同一个版本号造出第二条 bump 提交，tag 最终指向的东西和 main 里那条对不上。

`release_landing_state` 三态化：

| 远端状态 | 判定 | 动作 |
|---|---|---|
| tip 正好是这条提交 | landed | 不回滚，提示补 tag |
| tip 还停在发布前的基线 | missing | 走带状态门的回滚 |
| tip 是第三个值 | 取历史做 `merge-base --is-ancestor` 判定 | 判不出就 unknown，**一律不回滚** |

推送后的核实也从 `FETCH_HEAD == RELEASE_SHA` 换成祖先判定 —— 别人在我们之后又推一笔时，发布照常继续打 tag，而不是误判成失败。

## harness 的根本问题

原来的 git mock 对 `rev-parse HEAD` 在**提交前后返回同一个 SHA**，所以"回滚到基线""HEAD 有没有被别人推进过"这些断言恒真，看着在测其实什么都没测。改成基线 / 发布 / 第三方三个不同 SHA，按有没有 `commit`、有没有 `push` 过来分辨阶段。

新增场景：推送报错但 tip 已被推进（不回滚）、推送成功但 tip 已被推进（照常打 tag）、ls-remote 也拿不到（不回滚）。

变异自检：砍掉祖先判定退回旧行为 → 两条用例挂；短路"已落地"判断 → 对应用例挂。42 条相关用例全绿。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改进**
  - 优化发布流程的远端提交状态判断，可区分提交已落地、未落地或状态未知。
  - 推送后远端产生新提交时，仍可正确确认发布提交已包含在远端历史中。
  - 推送失败或状态无法确认时，保留现有提交并提供人工恢复指引，避免误回滚或重复打标签。
  - 回滚操作更加安全，减少对本地未提交内容的影响。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->