### PR TITLE
fix(scripts): tag 推送失败时说清「只差补 tag」，绝不回滚

### DIFF
--- a/scripts/release-version.test.ts
+++ b/scripts/release-version.test.ts
@@ -105,7 +105,7 @@ function runGit(directory: string, args: string[]) {
   execFileSync("git", args, { cwd: directory, stdio: "pipe" });
 }
 
-type ReleaseHarnessScenario = "view-error" | "ci-failure" | "snapshot-copy-failure" | "push-not-landed" | "push-failed" | "push-failed-dirty" | "push-failed-head-moved" | "fetch-failed-after-push" | "push-failed-but-landed" | "push-failed-advanced" | "push-landed-not-tip" | "tag-push-failed" | "tag-push-failed-but-created";
+type ReleaseHarnessScenario = "view-error" | "ci-failure" | "snapshot-copy-failure" | "push-not-landed" | "push-failed" | "push-failed-dirty" | "push-failed-head-moved" | "fetch-failed-after-push" | "push-failed-but-landed" | "push-failed-advanced" | "push-landed-not-tip" | "tag-push-failed" | "tag-push-failed-but-created" | "tag-push-failed-lookup-down";
 
 function writeExecutable(path: string, body: string) {
   writeFileSync(path, `#!/usr/bin/env bash\nset -euo pipefail\n${body}`);
@@ -149,6 +149,10 @@ case "\${1:-}" in
   ls-remote)
     if [[ "$*" == *"refs/tags/"* ]]; then
       # tag 推送失败后用来分辨「其实已经建上了」和「真没建上」。
+      if [[ "$MOCK_SCENARIO" == "tag-push-failed-lookup-down" ]]; then
+        echo "simulated ls-remote outage" >&2
+        exit 1
+      fi
       if [[ "$MOCK_SCENARIO" == "tag-push-failed-but-created" ]]; then
         printf '%s\\trefs/tags/v0.2.83\\n' "$MOCK_RELEASE_SHA"
       fi
@@ -774,6 +778,18 @@ describe("release main 推送落地", () => {
     expect(result.commands).not.toContain("git reset");
     expect(result.stderr).toContain("发布流程实际已经完成");
     expect(result.stderr).not.toContain("不要重跑");
+  });
+
+  // 「远端没有这个 tag」和「没问出来」是两回事。把后者当前者，就会用肯定语气说一件
+  // 没核实过的事——这条线上正是在治这个。
+  test("连远端 tag 状态都问不到时，不冒充「确实没有」", () => {
+    const result = runReleaseHarness("tag-push-failed-lookup-down");
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.commands).not.toContain("git reset");
+    expect(result.stderr).toContain("也没问出来");
+    expect(result.stderr).toContain("git ls-remote origin refs/tags/v0.2.83");
+    expect(result.stderr).toContain("不要回滚");
   });
 
   test("origin/main 没指向发布提交时停住，且不留悬空 tag", () => {

--- a/scripts/release-version.test.ts
+++ b/scripts/release-version.test.ts
@@ -105,7 +105,7 @@ function runGit(directory: string, args: string[]) {
   execFileSync("git", args, { cwd: directory, stdio: "pipe" });
 }
 
-type ReleaseHarnessScenario = "view-error" | "ci-failure" | "snapshot-copy-failure" | "push-not-landed" | "push-failed" | "push-failed-dirty" | "push-failed-head-moved" | "fetch-failed-after-push" | "push-failed-but-landed" | "push-failed-advanced" | "push-landed-not-tip";
+type ReleaseHarnessScenario = "view-error" | "ci-failure" | "snapshot-copy-failure" | "push-not-landed" | "push-failed" | "push-failed-dirty" | "push-failed-head-moved" | "fetch-failed-after-push" | "push-failed-but-landed" | "push-failed-advanced" | "push-landed-not-tip" | "tag-push-failed" | "tag-push-failed-but-created";
 
 function writeExecutable(path: string, body: string) {
   writeFileSync(path, `#!/usr/bin/env bash\nset -euo pipefail\n${body}`);
@@ -147,6 +147,13 @@ pushed() { grep -q 'refs/heads/main' "$MOCK_COMMAND_LOG"; }
 committed() { grep -q '^git commit' "$MOCK_COMMAND_LOG"; }
 case "\${1:-}" in
   ls-remote)
+    if [[ "$*" == *"refs/tags/"* ]]; then
+      # tag 推送失败后用来分辨「其实已经建上了」和「真没建上」。
+      if [[ "$MOCK_SCENARIO" == "tag-push-failed-but-created" ]]; then
+        printf '%s\\trefs/tags/v0.2.83\\n' "$MOCK_RELEASE_SHA"
+      fi
+      exit 0
+    fi
     # push / 核实 fetch 失败后，脚本靠这条把「未知」尽量变成「已知」。
     case "$MOCK_SCENARIO" in
       fetch-failed-after-push) echo "simulated ls-remote outage" >&2; exit 1 ;;
@@ -176,6 +183,10 @@ case "\${1:-}" in
   push)
     if [[ "$MOCK_SCENARIO" == push-failed* && "$*" == *"refs/heads/main"* ]]; then
       echo "simulated push rejection" >&2
+      exit 1
+    fi
+    if [[ "$MOCK_SCENARIO" == tag-push-failed* && "$*" == *"v0.2.83"* ]]; then
+      echo "remote: - Cannot create ref due to creations being restricted." >&2
       exit 1
     fi
     exit 0 ;;
@@ -738,6 +749,31 @@ describe("release main 推送落地", () => {
     expect(result.commands).toContain("git tag v0.2.83");
     expect(result.commands).toContain("git push origin v0.2.83");
     expect(result.stderr).not.toContain("没进 main");
+  });
+
+  // 分支保护会限制 ref creation，只有带 bypass 权限的凭据能建 tag。CI runner 或
+  // 别人的凭据推到这里就会失败，落在「main 已落地、tag 未创建」这个中间态——它和
+  // 「版本提交没进 main」正好相反，绝不能回滚。
+  test("tag 推送失败时不回滚，并说清只差补 tag", () => {
+    const result = runReleaseHarness("tag-push-failed");
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.commands).not.toContain("git reset");
+    expect(result.stderr).toContain("版本提交已经在 main");
+    expect(result.stderr).toContain("不要回滚");
+    expect(result.stderr).toContain("git push origin v0.2.83");
+    // 重跑是死路：会被「tag 已存在」挡下，删掉本地 tag 又会卡在 bump 无 diff。
+    expect(result.stderr).toContain("不要重跑");
+    expect(result.commands).not.toContain("gh run list");
+  });
+
+  test("tag 其实已经建上时说明发布已完成，而不是让人重推", () => {
+    const result = runReleaseHarness("tag-push-failed-but-created");
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.commands).not.toContain("git reset");
+    expect(result.stderr).toContain("发布流程实际已经完成");
+    expect(result.stderr).not.toContain("不要重跑");
   });
 
   test("origin/main 没指向发布提交时停住，且不留悬空 tag", () => {

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -321,10 +321,13 @@ settle_unlanded_release() {
   esac
 }
 
-# 远端那个 tag 现在指向哪。拿不到就回空。
+# 远端那个 tag 现在指向哪。
+# 退出码 0 = 问到了（stdout 为空表示远端确实没有这个 tag）；非 0 = 没问成，状态未知。
+# 「远端没有」和「没问出来」必须分开——把后者当成前者，就会用肯定语气说一件没核实过
+# 的事，这条线上正是在治这个。
 remote_tag_sha() {
   local line
-  line=$(git ls-remote origin "refs/tags/$1" 2>/dev/null) || return 0
+  line=$(git ls-remote origin "refs/tags/$1" 2>/dev/null) || return 1
   printf '%s' "${line%%[[:space:]]*}"
 }
 
@@ -339,8 +342,14 @@ remote_tag_sha() {
 # tag 单独补上去。
 settle_unpushed_tag() {
   local tag="$1" release_sha="$2" version="$3"
-  local remote_tag
-  remote_tag=$(remote_tag_sha "$tag")
+  local remote_tag lookup_ok=1
+  remote_tag=$(remote_tag_sha "$tag") || lookup_ok=0
+  if [[ "$lookup_ok" == "0" ]]; then
+    echo "   连远端 tag 状态也没问出来（git ls-remote 失败），先确认： git ls-remote origin refs/tags/${tag}" >&2
+    echo "   远端已有且指向 ${release_sha} ⇒ 发布其实已完成；没有 ⇒ 重推： git push origin ${tag}" >&2
+    echo "   无论哪种都不要回滚，也不要重跑 scripts/release.sh。" >&2
+    return 0
+  fi
   if [[ -n "$remote_tag" && "$remote_tag" == "$release_sha" ]]; then
     echo "   远端其实已经有 ${tag} 且指向 ${release_sha}（推送已生效，只是客户端没拿到响应）。" >&2
     echo "   发布流程实际已经完成，直接去看 CI： gh run list --workflow=release.yml --branch ${tag}" >&2

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -321,6 +321,42 @@ settle_unlanded_release() {
   esac
 }
 
+# 远端那个 tag 现在指向哪。拿不到就回空。
+remote_tag_sha() {
+  local line
+  line=$(git ls-remote origin "refs/tags/$1" 2>/dev/null) || return 0
+  printf '%s' "${line%%[[:space:]]*}"
+}
+
+# tag 没能推上去时的收尾。
+#
+# 此刻 main 已经落地，处境和「版本提交没进 main」正好相反：绝不能回滚，缺的只是一个
+# tag。这个中间态是真实可达的——分支保护会限制 ref creation，只有带 bypass 权限的
+# 凭据能建 tag，CI runner 或别人的凭据推到这里就会失败。
+#
+# 也不要建议重跑 release.sh：重跑先被「tag 已存在」挡下；就算删掉本地 tag，版本文件
+# 已经是新版号，bump 无 diff，commit 会因为没有暂存内容失败。唯一正确的恢复方式是把
+# tag 单独补上去。
+settle_unpushed_tag() {
+  local tag="$1" release_sha="$2" version="$3"
+  local remote_tag
+  remote_tag=$(remote_tag_sha "$tag")
+  if [[ -n "$remote_tag" && "$remote_tag" == "$release_sha" ]]; then
+    echo "   远端其实已经有 ${tag} 且指向 ${release_sha}（推送已生效，只是客户端没拿到响应）。" >&2
+    echo "   发布流程实际已经完成，直接去看 CI： gh run list --workflow=release.yml --branch ${tag}" >&2
+    return 0
+  fi
+  if [[ -n "$remote_tag" ]]; then
+    echo "   ⚠ 远端已存在 ${tag}，却指向 ${remote_tag}，与本次发布提交对不上。" >&2
+    echo "   先查清那个 tag 是谁建的，不要贸然覆盖。" >&2
+    return 0
+  fi
+  echo "   重试： git push origin ${tag}" >&2
+  echo "   若是凭据没有创建 tag 的权限（分支保护限制 ref creation），换有权限的凭据再推。" >&2
+  echo "   不要重跑 scripts/release.sh：会被「tag ${tag} 已存在」挡下，删掉本地 tag 也只会卡在" >&2
+  echo "   「版本文件已是 ${version}、bump 无 diff、commit 空提交」上。缺的只是这一个 tag。" >&2
+}
+
 # 这条发布提交到底进没进 origin/main：landed / missing / unknown。
 #
 # 只比远端 tip 是不够的。别人完全可能在我们推上去之后紧接着又推一笔，此时 tip 不是
@@ -468,7 +504,12 @@ main() {
   }
   # tag 放在 main 落地之后：main 没推成就绝不留下一个指向本地提交的 tag。
   git tag "$TAG"
-  git push origin "$TAG"
+  if ! git push origin "$TAG"; then
+    echo "!! tag $TAG 推送失败。版本提交已经在 main（${RELEASE_SHA}），缺的只是这个 tag。" >&2
+    echo "   **不要回滚**——回滚会把已经发布出去的提交从本地抹掉。" >&2
+    settle_unpushed_tag "$TAG" "$RELEASE_SHA" "$VER"
+    return 1
+  fi
 
   # 3) 轮询 tag 的 CI；任何失败都保留 tag，交由操作者诊断。
   if watch_tag_run; then


### PR DESCRIPTION
承 #949。发版真机跑通后，从 v0.2.211 的 stderr 里读出一个之前完全没处置的中间态。

## 这个态是真实可达的

v0.2.211 的发版输出里有这么两行：

```
remote: Bypassed rule violations for refs/tags/v0.2.211:
remote: - Cannot create ref due to creations being restricted.
```

分支保护对 tag 创建做了限制，只是发版者的凭据带 bypass 权限，所以被放行。**换一个没有 bypass 权限的凭据——CI runner、或别的操作者——这里就是真失败。**

失败点落在「**main 已经落地、tag 还没创建**」。

## 之前完全没处置

```sh
git tag "$TAG"
git push origin "$TAG"     # 裸的，失败就靠 set -e 静默中止
```

没有诊断、没有恢复路径。而且这个态和这条线上之前修的所有情况**正好相反**：版本提交已经发布出去了，**绝不能回滚**。

更麻烦的是重跑也走不通：`release.sh` 开头会被「tag 已存在」挡下；就算删掉本地 tag，版本文件已经是新版号，bump 无 diff，`git commit` 会因为没有暂存内容失败。和之前那个「排查后重跑」是同一类死胡同。

## 改动

`settle_unpushed_tag`：先用 `git ls-remote origin refs/tags/<tag>` 把状态问清楚，再决定说什么。

| 远端 tag 状态 | 结论 |
|---|---|
| 已存在且指向本次发布提交 | 推送其实生效了（客户端没拿到响应），发布已完成，直接去看 CI |
| 已存在但指向别处 | 报警，先查清是谁建的，不贸然覆盖 |
| 确实没有 | 给 `git push origin <tag>` 重推命令，点明凭据权限这一常见成因 |

并明确写出**不要重跑 `release.sh`**，以及为什么重跑走不通——缺的只是这一个 tag。

## 测试

| 场景 | 断言 |
|---|---|
| `tag-push-failed` | 不回滚、给补 tag 命令、明说不要重跑、不进 CI 轮询 |
| `tag-push-failed-but-created` | 说明发布已完成，而不是让人重推 |

变异自检：把处置删回裸 `git push origin "$TAG"` → 两条用例挂。`check:scripts` 368 条全绿。