### PR TITLE
test(cli): 拿真 claude 二进制核「原生还认不认我们的 cross-session 格式」(#953)

### DIFF
--- a/cli/src/claude-native-format.ts
+++ b/cli/src/claude-native-format.ts
@@ -35,9 +35,21 @@ export function locateClaudeBinary(env: NodeJS.ProcessEnv = process.env): string
   // 优先 versions 目录下最新的那个：`which claude` 常指向一个 shim/软链，strings 抠不到东西。
   const versions = join(env.HOME ?? homedir(), ".local", "share", "claude", "versions");
   try {
-    const entries = readdirSync(versions).sort();
+    // 按**语义序**挑最新，不能用字典序：`2.1.9` 字典序排在 `2.1.246` 之后，会挑到旧版本，
+    // 于是守卫拿一个过时二进制的格式去核对——比不核还糟（它会给出肯定但过时的结论）。
+    const entries = readdirSync(versions)
+      .map((name) => ({ name, parts: name.split(".").map((n) => Number.parseInt(n, 10)) }))
+      .filter((e) => e.parts.every((n) => Number.isFinite(n)) && e.parts.length > 0)
+      .sort((a, b) => {
+        const len = Math.max(a.parts.length, b.parts.length);
+        for (let i = 0; i < len; i += 1) {
+          const d = (a.parts[i] ?? 0) - (b.parts[i] ?? 0);
+          if (d !== 0) return d;
+        }
+        return 0;
+      });
     for (let i = entries.length - 1; i >= 0; i -= 1) {
-      const p = join(versions, entries[i]!);
+      const p = join(versions, entries[i]!.name);
       if (existsSync(p)) return p;
     }
   } catch {
@@ -80,8 +92,15 @@ export function readClaudeNativeCrossSessionFormat(
   // 而「这串字符集」和「这个取值列表」本身是稳定的。
   const charset = lines.find((l) => /^[A-Za-z0-9%:_/.\\-]+$/.test(l) && l.includes("A-Za-z0-9%")) ?? null;
 
-  const modesLine = lines.find((l) => l.includes('"bypass","prompting"'));
-  const modes = modesLine === undefined ? null : ["bypass", "prompting"];
+  // 真的把取值抠出来，不要"确认含某串之后返回硬编码列表"——那样原生新增一个 mode
+  // （例如变成 ["bypass","prompting","silent"]）时，我们仍然报告旧列表，守卫就瞎了。
+  const modesLine = lines.find((l) => /\[\s*"bypass"\s*,\s*"prompting"[^\]]*\]/.test(l));
+  const modesRaw = modesLine === undefined
+    ? null
+    : /\[\s*("bypass"\s*,\s*"prompting"[^\]]*)\]/.exec(modesLine)?.[1] ?? null;
+  const modes = modesRaw === null
+    ? null
+    : modesRaw.split(",").map((v) => v.trim().replace(/^"|"$/g, "")).filter((v) => v !== "");
 
   return { strictSource: strict, fromCharset: charset, fromModes: modes, binaryPath };
 }

--- a/cli/src/claude-native-format.ts
+++ b/cli/src/claude-native-format.ts
@@ -1,0 +1,120 @@
+// 从**装着的 claude 二进制**里抠出原生 cross-session-message 的接收侧正则（issue #953）。
+//
+// 为什么需要它：我们发出去的那条消息格式是**逆向**出来的，而原生接收侧是一条
+// **顺序固定的严格正则**——调一次属性顺序、加一个必选属性、换一个字符集，我们发的整条
+// 消息就匹配不上。而失败表现是**接收方什么都不会发生，也不会报错**（socket 写成功、
+// 对方一个字都收不到、两侧零告警）。
+//
+// 仓里原有的守卫钉的是**我们自己的输出**，防的是我们改坏自己；Claude 那边改了格式它照样
+// 全绿。用「我们的输出没变」代替「原生还认不认」，正是拿便宜信号替真实判据。这个模块把
+// 真实判据取回来：直接问二进制。
+//
+// 拿不到就 **skip 不红**：CI 上没装 claude 是常态，为此常红会让人把守卫关掉，那就白做了。
+// 要抓的是「装了 claude 的开发机上原生格式已经变了」。
+import { spawnSync } from "node:child_process";
+import { existsSync, readdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/** 原生严格解析器里那段可复核的事实。抠不出任何一项就返回 null（调用方 skip）。 */
+export interface ClaudeNativeCrossSessionFormat {
+  /** 接收侧那条严格正则的原文（属性顺序就固化在它里面）。 */
+  strictSource: string;
+  /** `from` 属性允许的字符集，例如 `A-Za-z0-9%:_/.\-`。 */
+  fromCharset: string | null;
+  /** `from-mode` 的合法取值。 */
+  fromModes: string[] | null;
+  /** 抠到的二进制路径，报错时打印出来好复核。 */
+  binaryPath: string;
+}
+
+/** 找到本机 claude 二进制。找不到返回 null。 */
+export function locateClaudeBinary(env: NodeJS.ProcessEnv = process.env): string | null {
+  const explicit = env.AGENTPARTY_CLAUDE_BINARY;
+  if (explicit !== undefined && explicit !== "" && existsSync(explicit)) return explicit;
+  // 优先 versions 目录下最新的那个：`which claude` 常指向一个 shim/软链，strings 抠不到东西。
+  const versions = join(env.HOME ?? homedir(), ".local", "share", "claude", "versions");
+  try {
+    const entries = readdirSync(versions).sort();
+    for (let i = entries.length - 1; i >= 0; i -= 1) {
+      const p = join(versions, entries[i]!);
+      if (existsSync(p)) return p;
+    }
+  } catch {
+    /* 目录不在，继续走 PATH */
+  }
+  // 显式指了路径却不存在 ⇒ 调用方是在**要求用这一个**（测试/定向诊断），不要偷偷回落到
+  // PATH 上另一个 claude —— 那会让"降级路径"的行为取决于跑测试的机器装没装 claude。
+  if (explicit !== undefined && explicit !== "") return null;
+  const which = spawnSync("sh", ["-c", "command -v claude"], { encoding: "utf8", timeout: 5_000 });
+  const path = (which.stdout ?? "").trim();
+  return path !== "" && existsSync(path) ? path : null;
+}
+
+/**
+ * 从二进制里读出原生格式。
+ *
+ * 锚点选的是接收侧那条严格正则里**独一无二**的片段（`from-session="(` 紧跟在
+ * `cross-session-message` 之后的那一段）——用它定位，比按行号或偏移量稳。
+ */
+export function readClaudeNativeCrossSessionFormat(
+  binaryPath: string,
+): ClaudeNativeCrossSessionFormat | null {
+  const res = spawnSync("strings", ["-a", binaryPath], {
+    encoding: "utf8",
+    timeout: 60_000,
+    maxBuffer: 512 * 1024 * 1024,
+  });
+  if (res.status !== 0 || typeof res.stdout !== "string") return null;
+  const lines = res.stdout.split("\n");
+
+  // 锚点只能用 `from-session="(` ——严格正则那行里标签是模板占位符 `${f}`，**不含**
+  // 字面量 `cross-session-message`；要求两者同时出现会永远匹配不上（这一条是实测踩出来的）。
+  // 再要求它同时含 hop-chain 与 from-mode，把它与别处零散的 from-session 提及区分开。
+  const strict = lines.find((l) =>
+    l.includes('from-session="(') && l.includes('hop-chain="(') && l.includes('from-mode="('),
+  );
+  if (strict === undefined) return null;
+
+  // 按**内容特征**找，不按变量名：压缩过的产物里变量名（m / y）随构建变化，
+  // 而「这串字符集」和「这个取值列表」本身是稳定的。
+  const charset = lines.find((l) => /^[A-Za-z0-9%:_/.\\-]+$/.test(l) && l.includes("A-Za-z0-9%")) ?? null;
+
+  const modesLine = lines.find((l) => l.includes('"bypass","prompting"'));
+  const modes = modesLine === undefined ? null : ["bypass", "prompting"];
+
+  return { strictSource: strict, fromCharset: charset, fromModes: modes, binaryPath };
+}
+
+/**
+ * 把抠到的严格正则还原成可执行的 RegExp。
+ *
+ * 二进制里那段是**模板字符串**（`${f}` `${m}` `${n}` …），要把占位符替回真值才能用。
+ * 任何一处还原不出就返回 null —— 宁可 skip，也不要拿一条半成品正则去判「原生不认」，
+ * 那会变成一条骗人的红灯。
+ */
+export function buildNativeStrictRegex(fmt: ClaudeNativeCrossSessionFormat): RegExp | null {
+  const start = fmt.strictSource.indexOf("^<");
+  if (start === -1) return null;
+  const end = fmt.strictSource.indexOf("$`", start);
+  if (end === -1) return null;
+  let src = fmt.strictSource.slice(start, end + 1);
+  if (fmt.fromCharset === null || fmt.fromModes === null) return null;
+  src = src
+    .replace(/\$\{f\}/g, "cross-session-message")
+    .replace(/\$\{m\}/g, fmt.fromCharset.replace(/\\\\/g, "\\"))
+    // from-session / hop-chain 的取值形状我们不复现，用宽松占位——本守卫要抓的是
+    // **属性顺序与框架**变没变，不是去复刻它们各自的内部格式。
+    .replace(/\$\{n\}/g, "[^\"]*")
+    .replace(/\$\{r\}/g, "[^\"]*")
+    .replace(/\$\{y\.join\("\|"\)\}/g, fmt.fromModes.join("|"));
+  if (src.includes("${")) return null;
+  try {
+    // 二进制里那段是**源码文本**：正则里的 `\s` 在源码里写作 `\\s`。逐个还原会漏
+    // （第一版只还原了 \n / \r，漏了 \s / \S，导致 body 段匹配不上、守卫误报"原生不认"）。
+    // 统一把双反斜杠折成单反斜杠。
+    return new RegExp(src.replace(/\\\\/g, "\\"));
+  } catch {
+    return null;
+  }
+}

--- a/cli/test/claude-native-format-guard.test.ts
+++ b/cli/test/claude-native-format-guard.test.ts
@@ -1,0 +1,83 @@
+// #953：拿**真 claude 二进制**去核「原生还认不认我们发的格式」。
+//
+// 仓里原有的守卫（claude-inbox-inject.test.ts 的「attr 顺序固定…逐字精确」）钉的是
+// **我们自己的输出**，防的是我们改坏自己；**Claude 那边改了格式它照样全绿**。
+// 用「我们的输出没变」代替「原生还认不认」，是拿便宜信号替真实判据。这条把真实判据取回来。
+//
+// 失败为什么危险：原生接收侧是**顺序固定的严格正则**，匹配不上时的表现是
+// **接收方什么都不会发生、也不会报错**（socket 写成功、对方一个字都收不到、两侧零告警）。
+//
+// 拿不到二进制/抠不出正则一律 **skip 不红**：CI 上没装 claude 是常态，为此常红会让人
+// 把守卫关掉，那就白做了。要抓的是「装了 claude 的开发机上原生格式已经变了」。
+import { describe, expect, test } from "bun:test";
+import {
+  buildNativeStrictRegex,
+  locateClaudeBinary,
+  readClaudeNativeCrossSessionFormat,
+} from "../src/claude-native-format";
+import { wrapCrossSessionMessage } from "../src/claude-inbox-inject";
+
+// **惰性**取，不在模块加载时扫二进制：`strings -a` 要跑 1 秒并把 58MB 字符串读进内存，
+// 放在顶层会卡在同目录所有 spec 之前，把重 subprocess 的用例挤过 5 秒超时线（实测把
+// worktree / cli 那几条挤红了，而它们跟本改动毫无关系）。
+let cached: { fmt: ReturnType<typeof readClaudeNativeCrossSessionFormat>; native: RegExp | null } | undefined;
+function nativeFormat() {
+  if (cached === undefined) {
+    const binary = locateClaudeBinary();
+    const fmt = binary === null ? null : readClaudeNativeCrossSessionFormat(binary);
+    cached = { fmt, native: fmt === null ? null : buildNativeStrictRegex(fmt) };
+  }
+  return cached;
+}
+
+describe("原生 cross-session 格式漂移守卫（#953）", () => {
+  test("原生严格正则认我们 wrap 出来的消息（无 claude 则跳过）", () => {
+    const { fmt, native } = nativeFormat();
+    if (native === null || fmt === null) return;
+    const samples = [
+      wrapCrossSessionMessage({
+        from: "uds:/tmp/cc-socks/1.sock",
+        fromName: "pwtk",
+        fromMode: "prompting",
+        body: "channel=pwtk seq=42",
+      }),
+      // 多行正文：body 段用的是 [\s\S]*，换行必须能过。
+      wrapCrossSessionMessage({
+        from: "uds:/tmp/cc-socks/2.sock",
+        fromName: "a-b_c",
+        fromMode: "bypass",
+        body: "line1\nline2",
+      }),
+      // 全属性齐活——顺序就固化在原生那条正则里，多一个属性也得排在对的位置。
+      wrapCrossSessionMessage({
+        from: "uds:/tmp/cc-socks/3.sock",
+        fromSession: "abc123",
+        hopChain: "a,b",
+        fromName: "n",
+        fromMode: "bypass",
+        body: "x",
+      }),
+    ];
+    for (const s of samples) {
+      expect({
+        sample: s.split("\n")[0],
+        accepted: native.test(s),
+        binary: fmt.binaryPath,
+      }).toEqual({ sample: s.split("\n")[0], accepted: true, binary: fmt.binaryPath });
+    }
+  });
+
+  test("从二进制读到的字符集与取值集，与我们的常量一致（无 claude 则跳过）", () => {
+    const { fmt } = nativeFormat();
+    if (fmt === null) return;
+    // 这两个也是逆向来的，一起盯住。
+    expect(fmt.fromCharset?.replace(/\\\\/g, "\\")).toBe("A-Za-z0-9%:_/.\\-");
+    expect(fmt.fromModes).toEqual(["bypass", "prompting"]);
+  });
+
+  test("抠不出来时 skip 而不是红（无 claude 的 CI 上不许常红）", () => {
+    // 这条恒跑：它断言的是"降级路径存在且是 skip"，不依赖本机有没有 claude。
+    expect(locateClaudeBinary({ AGENTPARTY_CLAUDE_BINARY: "/nonexistent/claude", HOME: "/nonexistent" })).toBe(null);
+    expect(readClaudeNativeCrossSessionFormat("/nonexistent/claude")).toBe(null);
+  });
+});

--- a/cli/test/claude-native-format-guard.test.ts
+++ b/cli/test/claude-native-format-guard.test.ts
@@ -20,6 +20,11 @@ import { wrapCrossSessionMessage } from "../src/claude-inbox-inject";
 // **惰性**取，不在模块加载时扫二进制：`strings -a` 要跑 1 秒并把 58MB 字符串读进内存，
 // 放在顶层会卡在同目录所有 spec 之前，把重 subprocess 的用例挤过 5 秒超时线（实测把
 // worktree / cli 那几条挤红了，而它们跟本改动毫无关系）。
+// skipIf 的条件只做**廉价**判断（二进制在不在），扫描本身仍然惰性——
+// 不能在用例体里 `return` 来"跳过"：bun 不把 return 当 skip，它算 **pass**，
+// 于是没装 claude 的机器上这条守卫会显示为通过。那正是「绿灯代替验证」。
+const NO_CLAUDE = locateClaudeBinary() === null;
+
 let cached: { fmt: ReturnType<typeof readClaudeNativeCrossSessionFormat>; native: RegExp | null } | undefined;
 function nativeFormat() {
   if (cached === undefined) {
@@ -31,9 +36,12 @@ function nativeFormat() {
 }
 
 describe("原生 cross-session 格式漂移守卫（#953）", () => {
-  test("原生严格正则认我们 wrap 出来的消息（无 claude 则跳过）", () => {
+  test.skipIf(NO_CLAUDE)("原生严格正则认我们 wrap 出来的消息", () => {
     const { fmt, native } = nativeFormat();
-    if (native === null || fmt === null) return;
+    // 抠不出正则 ⇒ 显式失败，不是静默通过：这时我们对"原生认不认"一无所知，
+    // 而一条"不知道"被记成 pass，就是拿沉默冒充确认。
+    expect({ gotRegex: native !== null, binary: fmt?.binaryPath ?? null })
+      .toEqual({ gotRegex: true, binary: fmt?.binaryPath ?? null });
     const samples = [
       wrapCrossSessionMessage({
         from: "uds:/tmp/cc-socks/1.sock",
@@ -67,9 +75,29 @@ describe("原生 cross-session 格式漂移守卫（#953）", () => {
     }
   });
 
-  test("从二进制读到的字符集与取值集，与我们的常量一致（无 claude 则跳过）", () => {
+  // 只断言"原生认我们的输出"证明不了还原后的正则**保留了顺序约束**——一条被我还原坏、
+  // 变得过分宽松的正则同样会让上面那条全绿。这条从反面钉住：顺序错了必须被拒。
+  test.skipIf(NO_CLAUDE)("还原后的正则确实保留顺序约束：属性换序必须被拒", () => {
+    const { native } = nativeFormat();
+    if (native === null) throw new Error("抠不出原生正则");
+    const swapped = [
+      // from-name / from-mode 互换
+      '<cross-session-message from="uds:/a.sock" from-mode="bypass" from-name="n">\nx\n</cross-session-message>',
+      // from-session / hop-chain 互换
+      '<cross-session-message from="uds:/a.sock" hop-chain="a,b" from-session="s" from-name="n">\nx\n</cross-session-message>',
+      // from 挪到最后
+      '<cross-session-message from-name="n" from="uds:/a.sock">\nx\n</cross-session-message>',
+    ];
+    for (const s of swapped) {
+      expect({ head: s.split("\n")[0], accepted: native.test(s) })
+        .toEqual({ head: s.split("\n")[0], accepted: false });
+    }
+  });
+
+  test.skipIf(NO_CLAUDE)("从二进制读到的字符集与取值集，与我们的常量一致", () => {
     const { fmt } = nativeFormat();
-    if (fmt === null) return;
+    expect(fmt).not.toBe(null);
+    if (fmt === null) throw new Error("unreachable");
     // 这两个也是逆向来的，一起盯住。
     expect(fmt.fromCharset?.replace(/\\\\/g, "\\")).toBe("A-Za-z0-9%:_/.\\-");
     expect(fmt.fromModes).toEqual(["bypass", "prompting"]);

--- a/cli/test/claude-native-format-guard.test.ts
+++ b/cli/test/claude-native-format-guard.test.ts
@@ -42,6 +42,7 @@ describe("原生 cross-session 格式漂移守卫（#953）", () => {
     // 而一条"不知道"被记成 pass，就是拿沉默冒充确认。
     expect({ gotRegex: native !== null, binary: fmt?.binaryPath ?? null })
       .toEqual({ gotRegex: true, binary: fmt?.binaryPath ?? null });
+    if (native === null || fmt === null) throw new Error("unreachable: 上面那条断言已保证非 null");
     const samples = [
       wrapCrossSessionMessage({
         from: "uds:/tmp/cc-socks/1.sock",


### PR DESCRIPTION
Closes #953

## 问题：守卫钉的是我们自己，不是原生

我们发出去的 cross-session 消息格式是**逆向**出来的。仓里原有那条 `attr 顺序固定…逐字精确`（`claude-inbox-inject.test.ts`）钉的是**我们的输出**，防的是我们改坏自己 —— **Claude 那边改了格式，它照样全绿**。

用「我们的输出没变」代替「原生还认不认」，正是拿便宜信号替真实判据。

而原生接收侧是一条**顺序固定的严格正则**（从 `2.1.246` 二进制抠出）：

```
^<cross-session-message(?: from="([m]+)")?(?: from-session="(n)")?(?: hop-chain="(r)")?
 (?: from-name="([^"<>\n\r]+)")?(?: from-mode="(bypass|prompting)")?>\n([\s\S]*)\n</cross-session-message>$
```

调一次属性顺序、加一个必选属性、换一个字符集，我们发的整条消息就匹配不上 —— **而失败表现是接收方什么都不会发生、也不会报错**（socket 写成功、对方一个字都收不到、两侧零告警）。**触发条件不在我们手里：Claude 升级就可能触发。**

## 做法

`cli/src/claude-native-format.ts`：定位本机 claude 二进制 → `strings -a` 抠出那条严格正则 → 把模板占位符（`${f}` `${m}` `${y.join("|")}`）替回真值还原成可执行 RegExp → 用它匹配 `wrapCrossSessionMessage` 的实际输出。顺带核对从二进制读到的 `from` 字符集与 `from-mode` 取值集与我们的常量一致（这两个也是逆向来的）。

**降级是 skip 不是红**：找不到二进制 / 抠不出正则一律跳过。CI 上没装 claude 是常态，为此常红会让人把守卫关掉，那就白做了 —— 要抓的是「装了 claude 的开发机上原生格式已经变了」。另有一条**恒跑**的用例断言降级路径本身存在（不依赖本机有没有 claude）。

## 排查中修掉的三处（都是我自己写出来的坑）

1. **锚点选错**：不能同时要求 `from-session="(` 与字面量 `cross-session-message` —— 严格正则那行里标签是模板占位符 `${f}`，**不含字面量**，会永远匹配不上。
2. **还原时漏折转义**：只折 `\n` / `\r` 会漏 `\s` / `\S`，导致 body 段匹配不上、守卫**误报「原生不认」**。改成统一把双反斜杠折成单反斜杠。
3. **降级路径受本机 PATH 影响**：`locateClaudeBinary` 显式指了路径却不存在时会偷偷回落到 `command -v claude`，使「降级」的行为取决于跑测试的机器装没装 claude。改成显式路径优先且不回落。

第 2 条尤其值得记：**一条还原得不完整的正则会变成骗人的红灯** —— 它会让人以为原生真的改了格式。所以还原不出任何一处就返回 `null` 走 skip，宁可不判也不误判。

## 一处性能问题（差点误伤同批用例）

扫二进制原本放在**模块加载时**：`strings -a` 要跑 1 秒并把 58MB 字符串读进内存，卡在同目录所有 spec 之前，把 `worktree` / `cli` 那几条重 subprocess 用例**挤过 5 秒超时线**。改成惰性 + 缓存后，`worktree.test.ts` 从 `16 pass 2 fail` 恢复到 `18 pass 0 fail`。

排查这一步本身也有教训：我一度用「暂存改动前后各跑一次」下结论，但两次之间本机 load average 从 120 掉到 57，**负载变化混进了对照**，差点把真问题当成 flake 放过。后来改用同一时间窗口的干净 main worktree 做对照才定位准。

## 验证

- **变异**：把 `from-name` / `from-mode` 顺序调换 ⇒ 守卫变红。
- 守卫自身 3 pass；`tsc --noEmit` 干净。
- 剩余 `cli.test.ts` 里 1 条 5s 超时：**单独跑该用例通过**，且**没有任何生产代码 import 这个新模块**（只被测试文件引用），与本改动无因果 —— 该文件本身是 subprocess 密集型，本机今日 load 一度到 202。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 增加对本机 Claude 原生跨会话消息格式的自动识别与兼容校验。
  * 支持从 Claude 原生格式提取严格校验规则，并验证消息格式是否匹配。

* **测试**
  * 新增单行、多行及完整属性消息的格式兼容性检查。
  * 在无法找到或读取 Claude 程序时自动跳过相关检查，避免影响测试结果。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->