### PR TITLE
fix(cli): join 的 ✅ 改按唤醒层本身判——claude 档补 plugin update + 壳检查，codex 档主动拉起并探活 (#957 #961)

### DIFF
--- a/cli/src/commands/doctor.ts
+++ b/cli/src/commands/doctor.ts
@@ -452,23 +452,50 @@ async function runClaudePluginDoctor(
     console.log(`  topology: ${report.channel.topology_visibility}`);
     if (report.blockers.length > 0) console.log(`  blockers: ${report.blockers.join(", ")}`);
     if (report.warnings.length > 0) console.log(`  warnings: ${report.warnings.join(", ")}`);
-    if (report.blockers.includes("plugin_missing")) {
-      console.log("  fix: claude plugin install agentparty@agentparty && claude plugin enable agentparty@agentparty");
-    } else if (report.blockers.includes("plugin_disabled")) {
-      console.log("  fix: claude plugin enable agentparty@agentparty");
-    }
-    if (report.blockers.includes("claude_version_unsupported")) {
-      console.log(`  fix: update Claude Code to >= ${CLAUDE_PLUGIN_MIN_VERSION.join(".")}`);
-    }
-    if (report.blockers.includes("channel_unbound")) console.log("  fix: party init --channel <channel>");
-    if (report.blockers.includes("identity_not_agent")) {
-      console.log("  fix: bind an agent token with party init --token <agent-token> --channel <channel>");
-    }
-    if (report.blockers.includes("listener_not_observed")) {
-      console.log("  fix: start a fresh channel session with party claude <channel>");
-    }
+    for (const line of claudePluginDoctorFixLines(report)) console.log(line);
   }
   return report.status === "ready" ? 0 : 1;
+}
+
+/**
+ * Per-blocker fix lines. Pure so the wording is testable.
+ *
+ * `plugin_version_mismatch` must point at `plugin update` (#961): `claude plugin install` on an
+ * already-installed plugin only prints "already installed" and never upgrades, so telling the
+ * user to install again leaves them exactly where they are.
+ */
+export function claudePluginDoctorFixLines(
+  report: Pick<ClaudePluginDoctorReport, "blockers" | "plugin" | "runtime_version">,
+): string[] {
+  const lines: string[] = [];
+  if (report.blockers.includes("plugin_missing")) {
+    lines.push("  fix: claude plugin install agentparty@agentparty && claude plugin enable agentparty@agentparty");
+  } else if (report.blockers.includes("plugin_disabled")) {
+    lines.push("  fix: claude plugin enable agentparty@agentparty");
+  }
+  if (report.blockers.includes("plugin_version_mismatch")) {
+    const installed = report.plugin.version ?? "?";
+    const pluginNewer = report.plugin.version !== undefined &&
+      compareVersions(report.plugin.version, report.runtime_version) > 0;
+    lines.push(
+      pluginNewer
+        ? `  fix: party upgrade (installed plugin ${installed} is newer than runtime ${report.runtime_version}; upgrade the CLI, do not downgrade the plugin)`
+        : `  fix: claude plugin update agentparty@agentparty (installed ${installed}, runtime ${report.runtime_version}; \`plugin install\` only reports "already installed" and never upgrades), then restart Claude Code`,
+    );
+  } else if (report.blockers.includes("plugin_bundle_invalid")) {
+    lines.push("  fix: claude plugin update agentparty@agentparty, then restart Claude Code");
+  }
+  if (report.blockers.includes("claude_version_unsupported")) {
+    lines.push(`  fix: update Claude Code to >= ${CLAUDE_PLUGIN_MIN_VERSION.join(".")}`);
+  }
+  if (report.blockers.includes("channel_unbound")) lines.push("  fix: party init --channel <channel>");
+  if (report.blockers.includes("identity_not_agent")) {
+    lines.push("  fix: bind an agent token with party init --token <agent-token> --channel <channel>");
+  }
+  if (report.blockers.includes("listener_not_observed")) {
+    lines.push("  fix: start a fresh channel session with party claude <channel>");
+  }
+  return lines;
 }
 
 // Latest release: follow the releases/latest redirect, matching install.sh.

--- a/cli/src/commands/hook.ts
+++ b/cli/src/commands/hook.ts
@@ -952,7 +952,7 @@ export interface CodexAutoWakeSpawnDeps {
   recordPid: (markerPath: string, channel: string, pid: number, now: number) => void;
 }
 
-function defaultCodexAutoWakeDeps(env: NodeJS.ProcessEnv = process.env): CodexAutoWakeSpawnDeps {
+export function defaultCodexAutoWakeDeps(env: NodeJS.ProcessEnv = process.env): CodexAutoWakeSpawnDeps {
   const home = agentpartyHome(env);
   return {
     home,

--- a/cli/src/commands/join.ts
+++ b/cli/src/commands/join.ts
@@ -14,6 +14,10 @@
 //  - **失败要能看见，且是 #926 的口径**：哪一步没成、为什么、一条可执行的下一步。收尾自检从
 //    **本地盘的真实状态**重新判定（不是信步骤返回码），任一步没落地都如实报「还差哪一步」。
 //  - **幂等**：重复跑不叠加副作用（判重、先探后加、绑定替换本身都幂等，join 只负责正确编排）。
+//  - **「前置条件齐了」≠「唤醒真的会发生」（#957/#961）**：收尾那句 ✅ 承诺的是「@ 一下就叫得醒」，
+//    所以它的判据必须是唤醒层本身——claude 档是插件装到位且版本与 CLI 一致（doctor 的 shell 检查，
+//    版本不一致时 SessionStart 根本没布上）；codex 档是唤醒层**进程真的在**（join 收尾主动拉起，
+//    再探活）。任一没成就不印 ✅，照实说本会话此刻能被怎么叫到。
 import { spawnSync } from "node:child_process";
 import { copyFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
@@ -31,6 +35,24 @@ import {
 import { isSlug, normalizeServerUrl } from "../validation";
 import { buildWakeChecklist, type WakeChecklist } from "../wake-checklist";
 import { diagnoseCodexWake } from "../wake-diagnosis";
+import { RUNNING_VERSION, compareVersions } from "../upgrade";
+import {
+  activeCodexAutoWakePid,
+  codexAutoWakeAuth,
+  codexAutoWakeMarkerPath,
+  codexAutoWakeTarget,
+  runningServePid,
+} from "../codex-auto-wake";
+import { defaultInstanceLockDir, isSameLiveProcess } from "../instance-lock";
+import { listCodexSessions, registerCodexSession } from "../claude-session-registry";
+import { findHarnessAncestor } from "../join-binding";
+import {
+  CLAUDE_PLUGIN_MIN_VERSION,
+  inspectClaudePluginShell,
+  parseClaudePluginList,
+  type ClaudePluginShellInspection,
+} from "./doctor";
+import type { CodexAutoWakeOutcome } from "./hook";
 
 const JOIN_FLAGS = ["server", "channel", "as", "harness", "mention"];
 const HELP = `usage: AGENTPARTY_TOKEN='<token>' party join --server URL --channel SLUG --as NAME [--harness codex|claude|other] [--mention name] [--yes] [--coexist]
@@ -71,6 +93,22 @@ interface GateStep {
   label: string;
   evidence: string;
   remedy?: string;
+  /** 做 remedy 之前必须知道的话（版本错配、要重开会话……），不是第二件待办。 */
+  notes?: string[];
+}
+
+/** codex 唤醒层的存活证据（#957）：判据是**进程真的在**，不是开关是否 default-on。 */
+export interface CodexWakeLayerLiveness {
+  pid: number;
+  /** serve 已抢到实例锁（连上服务端了）；或只在启动标记里（刚拉起、还在连）。 */
+  source: "serve-lock" | "starting-marker";
+}
+
+interface CodexWakeLayerState {
+  outcome: CodexAutoWakeOutcome;
+  live: CodexWakeLayerLiveness | null;
+  /** 跑 join 的这个 codex 会话没能在注册表里挂到本频道时的说明（唤醒层会因此提前退场）。 */
+  adoptionNote: string | null;
 }
 
 /** 注入点：测试喂假 spawn（不碰真机的 claude/codex 二进制），其余走真实 init/hook/send。 */
@@ -89,6 +127,21 @@ export interface JoinDeps {
    * 但 hook 步骤的 ok/fail 仍由 diagnoseCodexWake 读**真实盘状态**决定，探测只影响 remedy 文案。
    */
   codexWakeChecklist: () => WakeChecklist;
+  /**
+   * claude 档收尾自检（#961）：插件生命周期壳——装没装、启没启用、版本是否与 CLI 一致、包是否完整。
+   * 复用 doctor 的 inspectClaudePluginShell（`party bridge claude --check` 的 lifecycle 就是它），
+   * 不 shell 出去再解析文本。缺省实现会 spawn 真机 claude，测试换成桩。
+   */
+  claudePluginShell: () => ClaudePluginShellInspection;
+  /**
+   * codex 档收尾（#957）：主动拉起唤醒层。缺省＝hook.ts 的 maybeStartCodexAutoWake（与 SessionStart
+   * 同一条路径，同一套去重/标记），join 只是多给它一次机会——它此刻已有身份和 token，不必等下次会话。
+   */
+  startCodexWakeLayer: () => Promise<CodexAutoWakeOutcome>;
+  /** codex 档收尾自检（#957）：唤醒层进程真的在吗。缺省＝probeCodexWakeLayer（锁 + 启动标记 + 探活）。 */
+  codexWakeLayerLive: () => Promise<CodexWakeLayerLiveness | null>;
+  /** 跑 join 的那个 codex 进程 pid（进程祖先链）；找不到 null。用于把本会话在注册表里挂到本频道。 */
+  codexAncestorPid: () => number | null;
 }
 
 export interface JoinOptions {
@@ -155,32 +208,98 @@ function registerCodexMcp(deps: JoinDeps, name: string, configPath: string, slug
   return { level: "ok", msg: `MCP 已注册：${name}` };
 }
 
-/** 装 harness 插件（marketplace）——best-effort：装不上不阻断，只提示。 */
-function installHarnessPlugin(deps: JoinDeps, harness: "claude" | "codex"): StepOutcome {
-  const bin = harness;
-  const steps: string[][] =
-    harness === "claude"
-      ? [
-          ["plugin", "marketplace", "add", "leeguooooo/AgentParty"],
-          ["plugin", "install", "agentparty@agentparty"],
-          ["plugin", "enable", "agentparty@agentparty"],
-        ]
-      : [
-          ["plugin", "marketplace", "add", "leeguooooo/AgentParty"],
-          ["plugin", "add", "agentparty@agentparty"],
-        ];
-  const first = deps.spawn(bin, steps[0]!, { encoding: "utf8", timeout: 60_000 });
+const CLAUDE_PLUGIN = "agentparty@agentparty";
+const MARKETPLACE = "leeguooooo/AgentParty";
+
+/**
+ * 本机已装的 agentparty 插件版本。`undefined`＝读不出（claude 不可用 / 输出解析不了）；`null`＝没装。
+ * 走的是 doctor 同一个解析器（parseClaudePluginList），判据不另写一份。
+ */
+function installedClaudePluginVersion(deps: JoinDeps): string | null | undefined {
+  const r = deps.spawn("claude", ["plugin", "list", "--json"], { encoding: "utf8", timeout: 30_000 });
+  if (r.error !== undefined || r.status !== 0 || typeof r.stdout !== "string") return undefined;
+  const list = parseClaudePluginList(r.stdout);
+  if (list === null) return undefined;
+  return list.find((p) => p.id === CLAUDE_PLUGIN)?.version ?? null;
+}
+
+/**
+ * 装 claude 插件（marketplace）——best-effort：装不上不阻断，只提示；能不能唤醒由收尾自检判。
+ *
+ * #961：`claude plugin install` 对已装的只回一句 "already installed"（exit 0），**永远不会升级**。
+ * 于是本机插件停在旧版、CLI 已经是新版，doctor 判 plugin_version_mismatch，SessionStart 唤醒根本
+ * 没布上。所以 install 之后读一次已装版本，≠ 当前 CLI 就跟一步 `plugin update`。
+ *
+ * 装了 / 更新了都要**重开 Claude 会话**才生效（当前会话还挂着旧插件）——这句必须进结论，
+ * 不能埋在 warn 里，所以用 restartNeeded 带出去。
+ */
+function installClaudePlugin(deps: JoinDeps): StepOutcome & { restartNeeded: boolean } {
+  const first = deps.spawn("claude", ["plugin", "marketplace", "add", MARKETPLACE], { encoding: "utf8", timeout: 60_000 });
   if (first.error !== undefined) {
-    return { level: "skip", msg: `${bin} 二进制不可用，跳过插件安装（不影响 CLI 协作）` };
+    return { level: "skip", msg: "claude 二进制不可用，跳过插件安装（不影响 CLI 协作）", restartNeeded: false };
+  }
+  const before = installedClaudePluginVersion(deps);
+  let anyFail = first.status !== 0;
+  for (const args of [["plugin", "install", CLAUDE_PLUGIN], ["plugin", "enable", CLAUDE_PLUGIN]]) {
+    const r = deps.spawn("claude", args, { encoding: "utf8", timeout: 60_000 });
+    if (r.error !== undefined || r.status !== 0) anyFail = true;
+  }
+  let updated = false;
+  if (before !== undefined && before !== null && before !== RUNNING_VERSION) {
+    const r = deps.spawn("claude", ["plugin", "update", CLAUDE_PLUGIN], { encoding: "utf8", timeout: 60_000 });
+    if (r.error !== undefined || r.status !== 0) anyFail = true;
+    else updated = true;
+  }
+  const after = installedClaudePluginVersion(deps);
+  // 装上了（之前没有）或换了版本 ⇒ 当前会话还挂着旧的，必须重开。
+  const restartNeeded = before !== after && after !== undefined;
+  if (anyFail) {
+    // 修法要对症：已装旧版就是 update（install 原地踏步），没装才是 install。
+    const fix = after === null || after === undefined
+      ? `claude plugin install ${CLAUDE_PLUGIN}`
+      : `claude plugin update ${CLAUDE_PLUGIN}`;
+    return {
+      level: "warn",
+      msg: `claude 插件未完全装上（best-effort，不阻断；手动 ${fix}，然后重开会话）——能不能被唤醒见下方自检`,
+      remedy: fix,
+      restartNeeded,
+    };
+  }
+  if (after !== undefined && after !== null && after !== RUNNING_VERSION) {
+    const fix = compareVersions(after, RUNNING_VERSION) > 0 ? "party upgrade" : `claude plugin update ${CLAUDE_PLUGIN}`;
+    return {
+      level: "warn",
+      msg: `claude 插件是 ${after}，CLI 是 ${RUNNING_VERSION}，版本不一致时 SessionStart 唤醒不会布上——手动 ${fix}`,
+      remedy: fix,
+      restartNeeded,
+    };
+  }
+  const msg = updated
+    ? `claude 插件已从 ${before} 更新到 ${after}（需重开 Claude 会话才生效）`
+    : before === null
+      ? `claude 插件已安装（${after}；需重开 Claude 会话才生效）`
+      : `claude 插件已是 ${after ?? RUNNING_VERSION}（跳过）`;
+  return { level: "ok", msg, restartNeeded };
+}
+
+/** 装 codex 插件（marketplace）——best-effort：装不上不阻断，只提示。 */
+function installCodexPlugin(deps: JoinDeps): StepOutcome {
+  const steps: string[][] = [
+    ["plugin", "marketplace", "add", MARKETPLACE],
+    ["plugin", "add", CLAUDE_PLUGIN],
+  ];
+  const first = deps.spawn("codex", steps[0]!, { encoding: "utf8", timeout: 60_000 });
+  if (first.error !== undefined) {
+    return { level: "skip", msg: "codex 二进制不可用，跳过插件安装（不影响 CLI 协作）" };
   }
   let anyFail = first.status !== 0;
   for (const args of steps.slice(1)) {
-    const r = deps.spawn(bin, args, { encoding: "utf8", timeout: 60_000 });
+    const r = deps.spawn("codex", args, { encoding: "utf8", timeout: 60_000 });
     if (r.error !== undefined || r.status !== 0) anyFail = true;
   }
   return anyFail
-    ? { level: "warn", msg: `${bin} 插件未完全装上（best-effort，不阻断；重开会话或手动 ${bin} plugin install agentparty@agentparty）` }
-    : { level: "ok", msg: `${bin} 插件已安装` };
+    ? { level: "warn", msg: `codex 插件未完全装上（best-effort，不阻断；重开会话或手动 codex plugin add ${CLAUDE_PLUGIN}）` }
+    : { level: "ok", msg: "codex 插件已安装" };
 }
 
 /**
@@ -222,6 +341,156 @@ function setClaudeInboxAccept(deps: JoinDeps): StepOutcome {
   }
 }
 
+/**
+ * claude 插件壳每种 blocker 对应的那一条修法（#961）。**版本不一致的修法是 update，不是 install**——
+ * install 对已装的只回 already installed。插件比 CLI 还新时反过来升 CLI。
+ */
+function claudePluginRemedy(shell: ClaudePluginShellInspection): { do: string; notes: string[] } {
+  const restart = "做完【重开一个 Claude 会话】才生效——当前会话还挂着旧插件";
+  switch (shell.status) {
+    case "ready":
+      return { do: "", notes: [] };
+    case "plugin_version_mismatch": {
+      const v = shell.plugin.version ?? "?";
+      if (shell.plugin.version !== undefined && compareVersions(shell.plugin.version, RUNNING_VERSION) > 0) {
+        return { do: "party upgrade", notes: [`本机插件 ${v} 比 CLI ${RUNNING_VERSION} 新：升 CLI，不是降插件`] };
+      }
+      return {
+        do: `claude plugin update ${CLAUDE_PLUGIN}`,
+        notes: [
+          `本机插件 ${v}，CLI ${RUNNING_VERSION}——\`claude plugin install\` 对已装的只回 already installed、不会升级，要 update`,
+          restart,
+        ],
+      };
+    }
+    case "plugin_missing":
+      return {
+        do: `claude plugin marketplace add ${MARKETPLACE} && claude plugin install ${CLAUDE_PLUGIN} && claude plugin enable ${CLAUDE_PLUGIN}`,
+        notes: [restart],
+      };
+    case "plugin_disabled":
+      return { do: `claude plugin enable ${CLAUDE_PLUGIN}`, notes: [restart] };
+    case "plugin_bundle_invalid":
+      return {
+        do: `claude plugin update ${CLAUDE_PLUGIN}`,
+        notes: ["本机插件包与这个版本的 CLI 对不上（缺 launcher / hooks 接线）", restart],
+      };
+    case "claude_unavailable":
+      return { do: "把 claude 放到 PATH 上（或先装 Claude Code），然后重跑 party join", notes: [] };
+    case "claude_version_unsupported":
+      return { do: `把 Claude Code 升到 >= ${CLAUDE_PLUGIN_MIN_VERSION.join(".")}，然后重跑 party join`, notes: [] };
+    case "plugin_state_unavailable":
+      return { do: "claude plugin list --json   看它为什么读不出插件状态，修好后重跑 party join", notes: [] };
+  }
+}
+
+/**
+ * 唤醒层进程探活（#957）——`party hook codex-autowake status` 用的同一把锁，再加启动标记：
+ * serve 连上服务端才抢实例锁，刚拉起那几秒只有标记里的 pid。两处都用 isSameLiveProcess
+ * 判「进程真的在」（pid + 出生时间），不是看开关、也不是信 spawn 返回值。
+ *
+ * 等一小会儿（waitMs）让 serve 有机会拿到锁：拿到＝已连上服务端，证据更硬；没拿到但进程活着
+ * ＝刚拉起、还在连，也算在。进程不在（或压根没拉）⇒ null。
+ */
+export async function probeCodexWakeLayer(input: {
+  home: string;
+  lockDir: string;
+  config: { server?: unknown; token?: unknown } | null;
+  channel: string;
+  alive?: (pid: number, startedAt?: number) => boolean;
+  waitMs?: number;
+  sleep?: (ms: number) => Promise<void>;
+  now?: () => number;
+}): Promise<CodexWakeLayerLiveness | null> {
+  const auth = codexAutoWakeAuth(input.config);
+  if (auth === null) return null;
+  const alive = input.alive ?? isSameLiveProcess;
+  const now = input.now ?? (() => Date.now());
+  const sleep = input.sleep ?? ((ms: number) => Bun.sleep(ms));
+  const deadline = now() + (input.waitMs ?? 3_000);
+  const marker = codexAutoWakeMarkerPath(input.home, codexAutoWakeTarget(auth, input.channel));
+  for (;;) {
+    const locked = runningServePid(auth, input.channel, input.lockDir);
+    if (locked !== null) return { pid: locked, source: "serve-lock" };
+    // 0 ＝ 只占了位还没回填 pid（还不算「进程在」）；null ＝ 没标记或标记里的进程已死。
+    const starting = activeCodexAutoWakePid(marker, now(), alive);
+    if (starting === null) return null;
+    if (now() >= deadline) return starting > 0 ? { pid: starting, source: "starting-marker" } : null;
+    await sleep(250);
+  }
+}
+
+/**
+ * 把跑 join 的这个 codex 会话在注册表里挂到本频道（#957）。
+ *
+ * 唤醒层的回收判据是「频道上还有没有活着的入册 codex 会话」（hook.ts 的 supervise）。本会话
+ * SessionStart 时往往还没绑频道（或解析不出身份），注册表里要么没有它、要么挂在别的频道——
+ * 那样 join 刚拉起的唤醒层会在宽限期一过被自己判成孤儿退场。这里只**更新已有条目**：
+ * session_id 由 codex 给，没有条目就没法凭空造一个（绝不伪造），只能如实说。
+ */
+function adoptCodexSessionForChannel(
+  deps: JoinDeps,
+  slug: string,
+  identity: string | null,
+  server: string | null,
+): string | null {
+  try {
+    const pid = deps.codexAncestorPid();
+    if (pid === null) {
+      return "找不到跑 join 的 codex 进程（不在 codex 会话里跑？）——唤醒层在没有入册 codex 会话时会自动退场";
+    }
+    const entry = listCodexSessions().find((e) => e.pid === pid);
+    if (entry === undefined) {
+      return "本会话没入册（SessionStart 时还没绑频道）——唤醒层约 60s 后会判无人使用而退场；新开一个 codex 会话即可长期挂着";
+    }
+    if (entry.channel === slug && (entry.identity ?? null) === identity) return null;
+    const ok = registerCodexSession({
+      session_id: entry.session_id,
+      pid: entry.pid,
+      display_name: entry.display_name,
+      channel: slug,
+      identity,
+      server,
+      cwd: entry.cwd,
+    });
+    return ok ? null : "会话注册表更新失败——唤醒层可能约 60s 后退场；新开一个 codex 会话即可";
+  } catch (e) {
+    return `会话注册表更新失败：${e instanceof Error ? e.message : String(e)}`;
+  }
+}
+
+/** codex 档收尾：先认领本会话、再主动拉起唤醒层、再探活。三步各自失败都不抛，全部进证据。 */
+async function bringUpCodexWakeLayer(
+  deps: JoinDeps,
+  slug: string,
+  record: (name: string, outcome: StepOutcome) => void,
+): Promise<CodexWakeLayerState> {
+  const cfg = readConfig();
+  const adoptionNote = adoptCodexSessionForChannel(deps, slug, cfg?.identity?.name ?? null, cfg?.server ?? null);
+  let outcome: CodexAutoWakeOutcome;
+  try {
+    outcome = await deps.startCodexWakeLayer();
+  } catch (e) {
+    outcome = { action: "start-failed", channel: slug, detail: e instanceof Error ? e.message : String(e) };
+  }
+  let live: CodexWakeLayerLiveness | null = null;
+  try {
+    live = await deps.codexWakeLayerLive();
+  } catch {
+    live = null;
+  }
+  if (outcome.action === "start") {
+    record("拉起唤醒层", live === null
+      ? { level: "warn", msg: `已尝试拉起 party serve ${slug} --runner codex，但探不到它的进程——见下方自检` }
+      : { level: "ok", msg: `已拉起 party serve ${slug} --runner codex（pid ${live.pid}）` });
+  } else if (outcome.action === "skip" && outcome.reason === "already-serving") {
+    record("拉起唤醒层", { level: "ok", msg: `已有唤醒层在跑（${outcome.detail}）` });
+  } else {
+    record("拉起唤醒层", { level: "warn", msg: `没拉起：${outcome.detail}` });
+  }
+  return { outcome, live, adoptionNote };
+}
+
 function symbol(level: StepLevel): string {
   return level === "ok" ? "✓" : level === "skip" ? "·" : level === "warn" ? "!" : "✗";
 }
@@ -232,6 +501,7 @@ function buildJoinGate(
   slug: string,
   checkinOk: boolean,
   deps: JoinDeps,
+  codexWake: CodexWakeLayerState | null,
 ): { steps: GateStep[]; remaining: number; next: { do: string; notes: string[] } | null } {
   const cfg = readConfig();
   const identity = cfg?.identity?.name ?? null;
@@ -265,6 +535,24 @@ function buildJoinGate(
       }
     }
   }
+  // claude 档（#961）：唤醒层就是 Marketplace 插件的 SessionStart hook。装没装、启没启用、版本是否
+  // 与 CLI 一致、包是否完整——doctor 的 shell 检查（bridge claude --check 的 lifecycle）说了算。
+  // 版本不一致时插件的 hooks 与本版 CLI 对不上，SessionStart 根本没布上，✅ 就是假的。
+  if (harness === "claude") {
+    const shell = deps.claudePluginShell();
+    const ok = shell.status === "ready";
+    const remedy = claudePluginRemedy(shell);
+    steps.push({
+      id: "plugin_lifecycle_ready",
+      ok,
+      label: "claude 插件装到位、已启用、版本与 CLI 一致（SessionStart 唤醒靠它）",
+      evidence: ok
+        ? `${CLAUDE_PLUGIN} ${shell.plugin.version ?? RUNNING_VERSION}`
+        : `blocker: ${shell.blockers.join(", ")}${shell.plugin.version === undefined ? "" : `（本机插件 ${shell.plugin.version}，CLI ${RUNNING_VERSION}）`}`,
+      remedy: remedy.do,
+      notes: remedy.notes,
+    });
+  }
   steps.push({
     id: "checkin_sent",
     ok: checkinOk,
@@ -272,6 +560,25 @@ function buildJoinGate(
     evidence: checkinOk ? "已发送" : "",
     remedy: `party send "👋 <你> 报到" --channel ${slug}`,
   });
+  // codex 档（#957）：四项静态前置条件齐了 ≠ 唤醒真的会发生。唤醒层是 `party serve --runner codex`
+  // 这个进程；它在不在，判据只有一个——进程探活。放在最后：前面任一步没过，这一步的修法都没意义。
+  if (harness === "codex" && codexWake !== null) {
+    const live = codexWake.live;
+    const why = codexWake.outcome.action === "skip" || codexWake.outcome.action === "start-failed"
+      ? codexWake.outcome.detail
+      : "拉起了但探不到进程（可能刚退出：看 ~/.agentparty/logs/codex-auto-wake.log）";
+    steps.push({
+      id: "wake_layer_live",
+      ok: live !== null,
+      label: "唤醒层进程在跑（无人值守时被 @ 也能拉起 codex runner）",
+      evidence: live === null
+        ? ""
+        : `pid ${live.pid} · ${live.source === "serve-lock" ? "serve 已持锁（连上服务端了）" : "刚拉起，正在连服务端"}` +
+          (codexWake.adoptionNote === null ? "" : `    ⚠ ${codexWake.adoptionNote}`),
+      remedy: `新开一个 codex 会话（SessionStart 会重新拉起唤醒层），或手动：party serve ${slug} --runner codex`,
+      notes: [why],
+    });
+  }
   const failed = steps.find((s) => !s.ok);
   let next: { do: string; notes: string[] } | null = null;
   if (failed !== undefined) {
@@ -279,7 +586,7 @@ function buildJoinGate(
     if (failed.id === "hook_installed" || failed.id === "hook_trusted") {
       next = codexWakeNext;
     } else {
-      next = { do: failed.remedy ?? "重跑 party join", notes: [] };
+      next = { do: failed.remedy ?? "重跑 party join", notes: failed.notes ?? [] };
     }
   }
   return { steps, remaining: steps.filter((s) => !s.ok).length, next };
@@ -343,8 +650,13 @@ export async function runJoin(opts: JoinOptions, deps: JoinDeps): Promise<number
 
   // 4) 装 harness 插件（best-effort）。claude 插件承载 SessionStart/End→会话注册表+可发现+跨会话（#848）；
   //    codex 插件同理（#850）。other 档不装（不知道装哪个）。
-  if (harness === "claude") record("装 claude 插件", installHarnessPlugin(deps, "claude"));
-  if (harness === "codex") record("装 codex 插件", installHarnessPlugin(deps, "codex"));
+  let claudePluginRestart = false;
+  if (harness === "claude") {
+    const outcome = installClaudePlugin(deps);
+    claudePluginRestart = outcome.restartNeeded;
+    record("装 claude 插件", outcome);
+  }
+  if (harness === "codex") record("装 codex 插件", installCodexPlugin(deps));
 
   // 5a) claude 档：crossSessionInbound=accept（#844），否则跨会话 @ 默认 hold 会被 drop。
   if (harness === "claude") record("开启跨会话 @ 接收", setClaudeInboxAccept(deps));
@@ -374,8 +686,13 @@ export async function runJoin(opts: JoinOptions, deps: JoinDeps): Promise<number
     checkinOk ? { level: "ok", msg: "已在频道报到" } : { level: "fail", msg: `报到失败（退出码 ${sendCode}）` },
   );
 
+  // 6b) codex 档（#957）：主动拉起唤醒层。跑 join 的这个会话的 SessionStart 早过去了（那会儿还没身份），
+  //     不拉它就从生到死没有唤醒层——只有用户下次发言、回合结束时 Stop hook 才把 @ 交给他。
+  let codexWake: CodexWakeLayerState | null = null;
+  if (harness === "codex") codexWake = await bringUpCodexWakeLayer(deps, slug, record);
+
   // 7) 收尾自检（#926）：这是包的末尾，用户看到的就这一句结论。从本地盘真实状态重判，不信步骤返回码。
-  const gate = buildJoinGate(harness, slug, checkinOk, deps);
+  const gate = buildJoinGate(harness, slug, checkinOk, deps, codexWake);
   deps.log("");
   deps.log(`接入自检 · #${slug}`);
   for (const s of gate.steps) {
@@ -383,8 +700,27 @@ export async function runJoin(opts: JoinOptions, deps: JoinDeps): Promise<number
   }
   deps.log("");
   if (gate.remaining === 0) {
+    if (harness === "claude" && claudePluginRestart) {
+      // #961：插件刚装/刚更新，当前这个会话还挂着旧的——「要重开」是结论的一部分，不能埋在 warn 里。
+      deps.log(
+        `✅ 全部就绪，差一次重开：claude 插件已是 ${RUNNING_VERSION}，【新开一个 Claude 会话】后 @ ${agentName} 就能唤醒它；` +
+          `当前这个会话还挂着旧插件，不会被唤醒。`,
+      );
+      return 0;
+    }
     deps.log(`✅ 全部就绪：现在 @ ${agentName}，这台机器上的 ${harness} 会话就能被唤醒来协作。`);
     return 0;
+  }
+  const failed = gate.steps.find((s) => !s.ok);
+  if (failed?.id === "wake_layer_live") {
+    // #957：前置条件全齐、唯独唤醒层没起来。此刻的真实能力是 Stop hook 兜底——照实说，绝不说「就能被唤醒」。
+    deps.log(`⚠ 接入完成，但唤醒层没起来：${gate.next?.notes[0] ?? "原因不明"}`);
+    deps.log(
+      `本会话只能在你下次发言、回合结束时收到 @（Stop hook 会把积压的 @ 交给你）；` +
+        `要无人值守被唤醒，请新开一个 codex 会话。`,
+    );
+    deps.log(`  或手动拉起：party serve ${slug} --runner codex`);
+    return 1;
   }
   deps.log(`还差 ${gate.remaining} 步。现在只做这一件事：`);
   if (gate.next !== null) {
@@ -467,6 +803,27 @@ export async function run(argv: string[]): Promise<number> {
     errlog: (line) => console.error(line),
     home: process.env.HOME ?? homedir(),
     codexWakeChecklist: () => buildWakeChecklist(diagnoseCodexWake()),
+    claudePluginShell: () => inspectClaudePluginShell(),
+    startCodexWakeLayer: async () => {
+      const hook = await import("./hook");
+      // 与 SessionStart 完全同一条路径（同一套开关 / 去重 / 标记 / 日志），只是由 join 触发。
+      // 身份靠 AGENTPARTY_CONFIG（上面已设）走 env 档解析，绝不按 cwd 猜（#917）。
+      return hook.maybeStartCodexAutoWake(
+        { hook_event_name: "SessionStart", source: "party-join", cwd: process.cwd() },
+        hook.defaultCodexAutoWakeDeps(process.env),
+      );
+    },
+    codexWakeLayerLive: () =>
+      probeCodexWakeLayer({
+        home: agentpartyHome(),
+        lockDir: defaultInstanceLockDir(),
+        config: readConfig(),
+        channel: slug,
+      }),
+    codexAncestorPid: () => {
+      const found = findHarnessAncestor(process.ppid);
+      return found !== null && found.harness === "codex" ? found.pid : null;
+    },
   };
   return runJoin(
     { server, channel: slug, agentName, harnessFlag, mention, yes: flags.yes === true, coexist: flags.coexist === true, token },

--- a/cli/src/commands/who.ts
+++ b/cli/src/commands/who.ts
@@ -282,10 +282,12 @@ export function wakeGuidanceOf(r: Row, channel: string): WakeGuidance | undefine
   const found = wakeHarnessOf(r);
   if (found === undefined) return undefined;
   const ch = sanitizeSingleLine(channel);
+  // #961：claude 档给两条——install 对已装的只回 already installed、**永远不会升级**，而版本落后于
+  // CLI 时插件的 SessionStart 唤醒根本没布上。所以 install 之后必须跟一步 update。
   const remedy =
     found.harness === "codex"
       ? [`party hook install --codex`, `party bridge codex ${ch}`]
-      : [`claude plugin install agentparty@agentparty`];
+      : [`claude plugin install agentparty@agentparty`, `claude plugin update agentparty@agentparty`];
   return { reason: "no_wake_layer", harness: found.harness, harness_source: found.source, remedy };
 }
 
@@ -296,7 +298,8 @@ export function wakeGuidanceNote(g: WakeGuidance | undefined): string {
   if (g.harness === "codex") {
     return ` · ↳ fix: a codex session has no per-session inbox — give it the Stop hook so the @ surfaces in the session you are looking at: run ${g.remedy[0]} (then it picks pending @s up at the end of a turn), or ${g.remedy[1]} to hold its app-server connection right now`;
   }
-  return ` · ↳ fix: an interactive Claude Code session is wakeable once the agentparty plugin is installed — run ${g.remedy[0]} and rejoin the channel`;
+  // 已装旧版时第一条只会回 already installed（不升级），所以第二条 update 不是可选项。
+  return ` · ↳ fix: an interactive Claude Code session is wakeable once the agentparty plugin is installed and matches the party CLI version — run ${g.remedy[0]}, then ${g.remedy[1] ?? "claude plugin update agentparty@agentparty"} (install never upgrades an already-installed plugin), restart Claude Code and rejoin the channel`;
 }
 
 /**

--- a/cli/src/join-binding.ts
+++ b/cli/src/join-binding.ts
@@ -253,6 +253,17 @@ export function detectHarnessFromAncestry(
   startPid: number,
   spawn: SpawnLike = spawnSync,
 ): BindingHarness | null {
+  return findHarnessAncestor(startPid, spawn)?.harness ?? null;
+}
+
+/**
+ * 同上，但连那个 harness 进程的 pid 一起给（#957：join 要拿它去注册表里认领「跑 join 的这个
+ * codex 会话」）。找不到返回 null，绝不猜。
+ */
+export function findHarnessAncestor(
+  startPid: number,
+  spawn: SpawnLike = spawnSync,
+): { harness: BindingHarness; pid: number } | null {
   if (!Number.isInteger(startPid) || startPid <= 1) return null;
   if (process.platform === "win32") return null;
   const table = readProcessTable(spawn);
@@ -262,7 +273,7 @@ export function detectHarnessFromAncestry(
     const row = table.get(pid);
     if (row === undefined) return null;
     const harness = harnessFromCommand(row.args);
-    if (harness !== null) return harness;
+    if (harness !== null) return { harness, pid };
     if (row.ppid <= 1 || row.ppid === pid) return null;
     pid = row.ppid;
   }

--- a/cli/test/doctor-plugin.test.ts
+++ b/cli/test/doctor-plugin.test.ts
@@ -4,6 +4,7 @@ import { resolve } from "node:path";
 import type { PresenceEntry } from "@agentparty/shared";
 import type { Identity } from "../src/rest";
 import {
+  claudePluginDoctorFixLines,
   inspectClaudePluginBundle,
   inspectClaudePluginReadiness,
   inspectClaudePluginShell,
@@ -164,6 +165,34 @@ describe("party doctor claude-plugin", () => {
     expect(inspectClaudePluginShell(dependencies({
       claudeVersion: () => "2.1.80 (Claude Code)",
     })).blockers).toEqual(["claude_version_unsupported"]);
+  });
+
+  // #961: `plugin install` on an installed plugin only says "already installed" and never upgrades,
+  // so the version-mismatch fix must be `plugin update` (or `party upgrade` when the plugin is newer).
+  test("version mismatch fix line says plugin update, never plugin install", () => {
+    const stale = claudePluginDoctorFixLines({
+      blockers: ["plugin_version_mismatch"],
+      plugin: { installed: true, enabled: true, version: "0.2.203", bundle_valid: true, launcher_executable: true },
+      runtime_version: "0.2.212",
+    });
+    expect(stale).toHaveLength(1);
+    expect(stale[0]).toContain("claude plugin update agentparty@agentparty");
+    expect(stale[0]).toContain("0.2.203");
+    expect(stale[0]).toContain("restart Claude Code");
+    expect(stale[0]).not.toContain("fix: claude plugin install");
+    const newer = claudePluginDoctorFixLines({
+      blockers: ["plugin_version_mismatch"],
+      plugin: { installed: true, enabled: true, version: "0.2.300", bundle_valid: true, launcher_executable: true },
+      runtime_version: "0.2.212",
+    });
+    expect(newer[0]).toContain("party upgrade");
+    // Missing plugin is still an install.
+    const missing = claudePluginDoctorFixLines({
+      blockers: ["plugin_missing"],
+      plugin: { installed: false, enabled: false, bundle_valid: false, launcher_executable: false },
+      runtime_version: "0.2.212",
+    });
+    expect(missing[0]).toContain("claude plugin install agentparty@agentparty");
   });
 
   test("reports ready only when plugin, auth, channel, and a healthy durable listener are observed", async () => {

--- a/cli/test/join.test.ts
+++ b/cli/test/join.test.ts
@@ -9,21 +9,39 @@ import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { BEHAVIOR_CONTRACT_BODY_LINES } from "@agentparty/shared/onboarding";
-import { runJoin, type JoinDeps, type JoinOptions } from "../src/commands/join";
+import { probeCodexWakeLayer, runJoin, type JoinDeps, type JoinOptions } from "../src/commands/join";
 import { run as initRun } from "../src/commands/init";
 import { run as hookRun } from "../src/commands/hook";
 import { run as sendRun } from "../src/commands/send";
+import { inspectClaudePluginShell, parseClaudePluginList } from "../src/commands/doctor";
 import { buildWakeChecklist } from "../src/wake-checklist";
 import { diagnoseCodexWake } from "../src/wake-diagnosis";
+import { RUNNING_VERSION } from "../src/upgrade";
+import { codexAutoWakeAuth, codexAutoWakeMarkerPath, codexAutoWakeTarget, writeCodexAutoWakeMarker } from "../src/codex-auto-wake";
+import { currentProcessStartedAt, instanceLockTarget } from "../src/instance-lock";
+import { listCodexSessions, registerCodexSession } from "../src/claude-session-registry";
 import { startRestMock, type RestMock } from "./rest-mock";
 
-// 只读 .error / .status 的最小 spawnSync 桩。record 记下每次调用，便于断言 MCP 注册确实发生。
+const PLUGIN = "agentparty@agentparty";
+
+// 只读 .error / .status（插件相关再读 .stdout）的最小 spawnSync 桩。record 记下每次调用，便于断言
+// MCP 注册 / 插件 update 确实发生。
 interface SpawnBehavior {
   noBinary?: boolean; // 二进制不存在（ENOENT）
   mcpAlreadyRegistered?: boolean; // mcp get 返回 0（已注册）
   failMcpAdd?: boolean; // mcp add 返回非 0
+  /**
+   * 本机已装的 claude 插件版本（#961）：省略＝与 CLI 同版；null＝没装；"0.2.203" 这类＝旧版。
+   * 桩是**有状态**的，照真机行为走：`plugin install` 对已装的只回 already installed（**不升级**），
+   * 只有 `plugin update` 才把版本换成当前 CLI 的。
+   */
+  installedPluginVersion?: string | null;
+  failPluginUpdate?: boolean; // plugin update 返回非 0
 }
-function fakeSpawn(record: string[][], behavior: SpawnBehavior = {}) {
+interface PluginState {
+  installed: string | null;
+}
+function fakeSpawn(record: string[][], behavior: SpawnBehavior, state: PluginState) {
   return ((cmd: string, args: readonly string[]) => {
     record.push([cmd, ...args]);
     const base = { pid: 0, output: [], stdout: "", stderr: "", signal: null } as Record<string, unknown>;
@@ -33,6 +51,23 @@ function fakeSpawn(record: string[][], behavior: SpawnBehavior = {}) {
     }
     if (args[0] === "mcp" && args[1] === "add") {
       return { ...base, status: behavior.failMcpAdd ? 1 : 0 };
+    }
+    if (cmd === "claude" && args[0] === "--version") return { ...base, status: 0, stdout: "2.1.200 (Claude Code)\n" };
+    if (cmd === "claude" && args[0] === "plugin" && args[1] === "list") {
+      const rows = state.installed === null
+        ? []
+        : [{ id: PLUGIN, version: state.installed, enabled: true, installPath: "/nowhere/agentparty" }];
+      return { ...base, status: 0, stdout: `${JSON.stringify(rows)}\n` };
+    }
+    if (cmd === "claude" && args[0] === "plugin" && args[1] === "install") {
+      // 真机行为：已装就只回 "already installed"，版本原地不动。
+      if (state.installed === null) state.installed = RUNNING_VERSION;
+      return { ...base, status: 0 };
+    }
+    if (cmd === "claude" && args[0] === "plugin" && args[1] === "update") {
+      if (behavior.failPluginUpdate) return { ...base, status: 1 };
+      state.installed = RUNNING_VERSION;
+      return { ...base, status: 0 };
     }
     return { ...base, status: 0 };
   }) as unknown as JoinDeps["spawn"];
@@ -66,8 +101,12 @@ afterEach(() => {
 });
 
 function deps(record: string[][], behavior: SpawnBehavior, logs: string[]): JoinDeps {
+  const state: PluginState = {
+    installed: behavior.installedPluginVersion === undefined ? RUNNING_VERSION : behavior.installedPluginVersion,
+  };
+  const spawn = fakeSpawn(record, behavior, state);
   return {
-    spawn: fakeSpawn(record, behavior),
+    spawn,
     initRun,
     hookRun,
     sendRun,
@@ -83,7 +122,30 @@ function deps(record: string[][], behavior: SpawnBehavior, logs: string[]): Join
         () => ({ onPath: null, candidates: [], gated: [], desktop: null }),
         () => null,
       ),
+    // claude 插件壳检查（#961）：走**真的** inspectClaudePluginShell（版本比对逻辑不另写一份），
+    // 只把 claude 二进制换成上面那个有状态桩、把读盘的包检查换成恒 valid。
+    claudePluginShell: () =>
+      inspectClaudePluginShell({
+        claudeVersion: () => {
+          const r = spawn("claude", ["--version"], { encoding: "utf8" });
+          return r.error === undefined && r.status === 0 ? String(r.stdout).trim() : null;
+        },
+        claudePlugins: () => {
+          const r = spawn("claude", ["plugin", "list", "--json"], { encoding: "utf8" });
+          return r.error === undefined && r.status === 0 ? parseClaudePluginList(String(r.stdout)) : null;
+        },
+        inspectBundle: () => ({ valid: true, launcherExecutable: true }),
+      }),
+    // codex 唤醒层（#957）：默认假装拉起成功且进程在（happy path）；失败用例逐个覆盖。
+    startCodexWakeLayer: async () => ({ action: "start", channel: "dev", cwd: process.cwd(), args: [] }),
+    codexWakeLayerLive: async () => ({ pid: 4242, source: "serve-lock" }),
+    codexAncestorPid: () => null,
   };
+}
+/** 「现在只做这一件事：」后面那一行——自检给出的唯一修法。 */
+function nextActionLine(logs: string[]): string | undefined {
+  const i = logs.findIndex((l) => l.includes("现在只做这一件事"));
+  return i === -1 ? undefined : logs[i + 1]?.trim();
 }
 function baseOpts(over: Partial<JoinOptions>): JoinOptions {
   return {
@@ -149,6 +211,68 @@ describe("party join —— 一条命令跑完整段接入（#944）", () => {
     // claude 档附带：crossSessionInbound=accept 写进 ~/.claude/settings.json（#844）。
     const settings = JSON.parse(readFileSync(join(tmp, ".claude", "settings.json"), "utf8")) as { crossSessionInbound: string };
     expect(settings.crossSessionInbound).toBe("accept");
+
+    // 插件已是当前版本：不跑 update，自检里插件那一步 ✓，结论不要求重开会话。
+    expect(record.some((r) => r[0] === "claude" && r[1] === "plugin" && r[2] === "update")).toBe(false);
+    expect(out).toContain("版本与 CLI 一致");
+    expect(out).not.toContain("重开");
+  });
+
+  // ★ #961 事故场景：本机插件 0.2.203、CLI 0.2.212。旧 join 只 install（回 already installed，不升级）
+  //   就印 ✅，而 doctor 判 plugin_version_mismatch、SessionStart 唤醒根本没布上。
+  test("#961：已装旧版插件时 join 会跑 plugin update，结论明说「要重开会话」而不是埋在 warn 里", async () => {
+    mock = startRestMock();
+    const record: string[][] = [];
+    const logs: string[] = [];
+    const code = await runJoin(baseOpts({ harnessFlag: "claude" }), deps(record, { installedPluginVersion: "0.2.203" }, logs));
+    const out = logs.join("\n");
+
+    // install 之后跟了 update（install 对已装的原地踏步）。
+    const install = record.findIndex((r) => r[0] === "claude" && r[1] === "plugin" && r[2] === "install");
+    const update = record.findIndex((r) => r[0] === "claude" && r[1] === "plugin" && r[2] === "update" && r[3] === PLUGIN);
+    expect(install).toBeGreaterThan(-1);
+    expect(update).toBeGreaterThan(install);
+    // 更新到位 → 就绪，但**当前会话还挂着旧插件**——「重开」是结论句的一部分。
+    expect(code).toBe(0);
+    expect(out).toContain(`已从 0.2.203 更新到 ${RUNNING_VERSION}`);
+    const verdict = logs.find((l) => l.startsWith("✅"));
+    expect(verdict).toBeDefined();
+    expect(verdict).toContain("重开");
+    expect(verdict).toContain("当前这个会话还挂着旧插件");
+  });
+
+  test("#961：update 没成、插件仍是旧版 ⇒ 自检报 plugin_version_mismatch、不印 ✅，修法是 update 不是 install", async () => {
+    mock = startRestMock();
+    const record: string[][] = [];
+    const logs: string[] = [];
+    const code = await runJoin(
+      baseOpts({ harnessFlag: "claude" }),
+      deps(record, { installedPluginVersion: "0.2.203", failPluginUpdate: true }, logs),
+    );
+    const out = logs.join("\n");
+
+    // 隔离：config / 身份 / 报到全成，唯独插件版本落后——这正是事故当天的形态。
+    expect(existsSync(configPath())).toBe(true);
+    expect(code).toBe(1);
+    expect(out).not.toContain("全部就绪");
+    expect(out).toContain("plugin_version_mismatch");
+    expect(out).toContain(`本机插件 0.2.203，CLI ${RUNNING_VERSION}`);
+    // 唯一那条修法必须是 update：照旧教 install 等于原地踏步。
+    expect(nextActionLine(logs)).toBe(`claude plugin update ${PLUGIN}`);
+    // 做完要重开会话——写在修法旁边，不是埋在 warn 里。
+    expect(out).toContain("重开一个 Claude 会话");
+  });
+
+  test("#961：没装过插件 → install 装上（不跑 update），结论同样明说要重开会话", async () => {
+    mock = startRestMock();
+    const record: string[][] = [];
+    const logs: string[] = [];
+    const code = await runJoin(baseOpts({ harnessFlag: "claude" }), deps(record, { installedPluginVersion: null }, logs));
+    expect(code).toBe(0);
+    expect(record.some((r) => r[0] === "claude" && r[2] === "install")).toBe(true);
+    expect(record.some((r) => r[0] === "claude" && r[2] === "update")).toBe(false);
+    const verdict = logs.find((l) => l.startsWith("✅"));
+    expect(verdict).toContain("重开");
   });
 
   test("失败可见：报到被服务端 500 打回时，自检如实报「还差」并给出可执行下一步，不是静默成功", async () => {
@@ -192,9 +316,111 @@ describe("party join —— 一条命令跑完整段接入（#944）", () => {
     expect(record.some((r) => r[0] === "codex" && r[1] === "mcp" && r[2] === "add")).toBe(true);
     expect(record.some((r) => r[0] === "claude")).toBe(false);
 
-    // 无 config.toml（老版本 codex / 无信任闸）→ hook 判 ok → 自检「全部就绪」。
+    // 无 config.toml（老版本 codex / 无信任闸）→ hook 判 ok；唤醒层进程在（pid 4242）→ 自检「全部就绪」。
     expect(code).toBe(0);
     expect(out).toContain("全部就绪");
+    expect(out).toContain("唤醒层进程在跑");
+    expect(out).toContain("pid 4242");
+  });
+
+  // ★ #957 事故场景：四项静态前置条件全绿、唤醒层进程根本不在，旧 join 照印「就能被唤醒」，
+  //   owner @ 了 25 分钟纹丝不动。
+  test("#957：唤醒层拉不起来 ⇒ 结论是降级文案（Stop hook 兜底 / 新开会话），绝不说「就能被唤醒」", async () => {
+    mock = startRestMock();
+    const record: string[][] = [];
+    const logs: string[] = [];
+    const d = deps(record, {}, logs);
+    d.startCodexWakeLayer = async () => ({
+      action: "start-failed",
+      channel: "dev",
+      detail: "拉 `party serve dev --runner codex` 失败（spawn 没返回 pid）",
+    });
+    d.codexWakeLayerLive = async () => null;
+    const code = await runJoin(baseOpts({ harnessFlag: "codex" }), d);
+    const out = logs.join("\n");
+
+    // 隔离：config / 身份 / hook / 报到全成，唯独唤醒层进程不在。
+    expect(existsSync(configPath())).toBe(true);
+    expect(code).toBe(1);
+    expect(out).not.toContain("就能被唤醒");
+    expect(out).not.toContain("全部就绪");
+    // 自检里那一格是 ✗，且带原因。
+    expect(out).toContain("✗ 唤醒层进程在跑");
+    expect(out).toContain("spawn 没返回 pid");
+    // 降级文案：照实说此刻能被怎么叫到。
+    expect(out).toContain("本会话只能在你下次发言、回合结束时收到 @");
+    expect(out).toContain("新开一个 codex 会话");
+    expect(out).toContain("party serve dev --runner codex");
+  });
+
+  test("#957：用户显式关了 auto-wake（skip: disabled）同样不印 ✅，原因照实带出来", async () => {
+    mock = startRestMock();
+    const record: string[][] = [];
+    const logs: string[] = [];
+    const d = deps(record, {}, logs);
+    d.startCodexWakeLayer = async () => ({ action: "skip", reason: "disabled", detail: "codex auto-wake 被显式关掉了（默认是开的）" });
+    d.codexWakeLayerLive = async () => null;
+    const code = await runJoin(baseOpts({ harnessFlag: "codex" }), d);
+    const out = logs.join("\n");
+    expect(code).toBe(1);
+    expect(out).not.toContain("就能被唤醒");
+    expect(out).toContain("被显式关掉了");
+    expect(out).toContain("本会话只能在你下次发言、回合结束时收到 @");
+  });
+
+  test("#957：已有唤醒层在跑（skip: already-serving）且探活得到 pid ⇒ 就绪，不再拉第二个", async () => {
+    mock = startRestMock();
+    const record: string[][] = [];
+    const logs: string[] = [];
+    const d = deps(record, {}, logs);
+    d.startCodexWakeLayer = async () => ({ action: "skip", reason: "already-serving", detail: "#dev 上本身份已有 serve 在跑（pid 777）" });
+    d.codexWakeLayerLive = async () => ({ pid: 777, source: "serve-lock" });
+    const code = await runJoin(baseOpts({ harnessFlag: "codex" }), d);
+    const out = logs.join("\n");
+    expect(code).toBe(0);
+    expect(out).toContain("已有唤醒层在跑");
+    expect(out).toContain("pid 777");
+    expect(out).toContain("全部就绪");
+  });
+
+  test("#957：跑 join 的 codex 会话在注册表里挂到本频道（否则唤醒层宽限期一过就判无人使用退场）", async () => {
+    mock = startRestMock();
+    const record: string[][] = [];
+    const logs: string[] = [];
+    // 预置：本会话 SessionStart 时绑的是别的频道、身份没解析出来——事故当天注册表里就是这样。
+    const sessionId = "019f95e8-2c0b-7903-8779-cd102c5ecd4c";
+    expect(registerCodexSession({
+      session_id: sessionId,
+      pid: process.pid,
+      display_name: null,
+      channel: "elsewhere",
+      identity: null,
+      server: null,
+      cwd: process.cwd(),
+    })).toBe(true);
+    const d = deps(record, {}, logs);
+    d.codexAncestorPid = () => process.pid;
+    const code = await runJoin(baseOpts({ harnessFlag: "codex" }), d);
+    expect(code).toBe(0);
+    const entry = listCodexSessions().find((e) => e.session_id === sessionId);
+    expect(entry).toBeDefined();
+    expect(entry!.channel).toBe("dev");
+    expect(entry!.identity).toBe("agent"); // mock /api/me 的身份
+    expect(entry!.server).toBe(new URL(mock.url).origin);
+    // 挂上了就不该再有「没入册」的警告。
+    expect(logs.join("\n")).not.toContain("没入册");
+  });
+
+  test("#957：找不到本会话的注册表条目时不伪造，如实提示唤醒层会提前退场", async () => {
+    mock = startRestMock();
+    const record: string[][] = [];
+    const logs: string[] = [];
+    const d = deps(record, {}, logs);
+    d.codexAncestorPid = () => process.pid; // 有 codex 进程，但注册表里没它
+    const code = await runJoin(baseOpts({ harnessFlag: "codex" }), d);
+    expect(code).toBe(0);
+    expect(logs.join("\n")).toContain("没入册");
+    expect(listCodexSessions().length).toBe(0);
   });
 
   test("失败可见（owner 场景）：codex hook 已装但信任闸 disabled、非交互不批准时，自检报「还差」hook 那一步", async () => {
@@ -249,20 +475,23 @@ describe("party join —— 一条命令跑完整段接入（#944）", () => {
   // 下面三条覆盖 SpawnBehavior 的三个分支。它们不是补覆盖率——这三条正是本切片声称
   // 「失败要能看见」的路径：桩写了却没人用，那个声称就没被验证过（CodeRabbit 逮到）。
 
-  test("目标机器没装 claude CLI：注册这一步 warn 而不是崩，且不影响「就绪」结论", async () => {
+  test("目标机器没装 claude CLI：注册/装插件 warn 而不是崩，配置照样落地；但唤醒层核实不了就不印 ✅", async () => {
     mock = startRestMock();
     const record: string[][] = [];
     const logs: string[] = [];
     const code = await runJoin(baseOpts({ harnessFlag: "claude" }), deps(record, { noBinary: true }, logs));
     const out = logs.join("\n");
 
-    // MCP 注册是 best-effort：装不上不该把整段接入判成失败——config / 绑定 / 报到都成了。
-    expect(code).toBe(0);
-    expect(out).toContain("全部就绪");
-    // 但必须**看得见**：这一步的结果不能被静默吞掉。
+    // MCP 注册 / 装插件是 best-effort：不崩、不静默——这一步的结果必须**看得见**。
     expect(out).toMatch(/mcp[\s\S]{0,80}(未|没|失败|跳过|not|skip)/i);
-    // 配置与报到仍然落地（best-effort 步骤不该拖垮 gate 步骤）。
+    // 配置与报到仍然落地（best-effort 步骤不该拖垮前面的步骤）。
     expect(existsSync(configPath())).toBe(true);
+    // #961：claude 档的唤醒层就是插件；claude 都不在 PATH 上，插件装没装、版本对不对一概核实不了——
+    // 这时说「就能被唤醒」是拿前置条件顶替判据。自检如实报 claude_unavailable，给一条修法。
+    expect(code).toBe(1);
+    expect(out).not.toContain("全部就绪");
+    expect(out).toContain("claude_unavailable");
+    expect(nextActionLine(logs)).toContain("PATH");
   });
 
   test("重复接入：mcp get 命中已注册 ⇒ 跳过 add，不再叠一个常驻进程（#898）", async () => {
@@ -303,5 +532,62 @@ describe("party join —— 一条命令跑完整段接入（#944）", () => {
     expect(logs.some((l) => l.includes("ap_secret_xyz"))).toBe(false);
     // 但它确实经环境变量到了 init 手里——config 里落了这个 token。
     expect((JSON.parse(readFileSync(configPath(), "utf8")) as { token: string }).token).toBe("ap_secret_xyz");
+  });
+});
+
+// #957 的判据本身：wake_layer_live 来自**进程探活**（serve 实例锁 / 启动标记里的 pid 是否还活着），
+// 不是 auto-wake 开关是不是 default-on。开关默认就是开的——按开关判永远是绿的，那正是事故。
+describe("probeCodexWakeLayer —— 唤醒层进程探活（#957）", () => {
+  const config = { server: "https://party.example.com", token: "agent-token" };
+  const auth = () => codexAutoWakeAuth(config)!;
+  let home: string;
+  let lockDir: string;
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "party-join-wake-home-"));
+    lockDir = mkdtempSync(join(tmpdir(), "party-join-wake-locks-"));
+  });
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(lockDir, { recursive: true, force: true });
+  });
+  /** 假时钟：每问一次前进 1s，waitMs=2s ⇒ 两轮就到期，sleep 不真睡。 */
+  function clock() {
+    let t = 1_000;
+    return { now: () => (t += 1_000), sleep: async () => {}, waitMs: 2_000 };
+  }
+
+  test("什么都没有（开关默认开着也一样）→ null：没有进程就是没有唤醒层", async () => {
+    expect(await probeCodexWakeLayer({ home, lockDir, config, channel: "dev", ...clock() })).toBeNull();
+  });
+
+  test("config 没有 agent token → null（人类账号会话没有唤醒层可言）", async () => {
+    expect(await probeCodexWakeLayer({ home, lockDir, config: { server: config.server }, channel: "dev", ...clock() })).toBeNull();
+  });
+
+  test("serve 已持实例锁（进程活着）→ pid 来自锁，source=serve-lock", async () => {
+    const target = instanceLockTarget(auth().server, auth().token, "dev");
+    writeFileSync(join(lockDir, `serve-${target}.lock`), JSON.stringify({ pid: process.pid, id: "t", started_at: currentProcessStartedAt() }));
+    expect(await probeCodexWakeLayer({ home, lockDir, config, channel: "dev", ...clock() })).toEqual({ pid: process.pid, source: "serve-lock" });
+  });
+
+  test("只有启动标记、进程活着 → 等到期后按标记算在（刚拉起、还在连服务端）", async () => {
+    const marker = codexAutoWakeMarkerPath(home, codexAutoWakeTarget(auth(), "dev"));
+    writeCodexAutoWakeMarker(marker, { pid: 31337, started_at: null, claimed_at: 0, channel: "dev" });
+    const alive = (pid: number) => pid === 31337;
+    expect(await probeCodexWakeLayer({ home, lockDir, config, channel: "dev", alive, ...clock() })).toEqual({ pid: 31337, source: "starting-marker" });
+  });
+
+  test("启动标记里的进程已经死了 → null：spawn 成功过不算数，此刻不在就是不在", async () => {
+    const marker = codexAutoWakeMarkerPath(home, codexAutoWakeTarget(auth(), "dev"));
+    writeCodexAutoWakeMarker(marker, { pid: 31337, started_at: null, claimed_at: 0, channel: "dev" });
+    const alive = () => false;
+    expect(await probeCodexWakeLayer({ home, lockDir, config, channel: "dev", alive, ...clock() })).toBeNull();
+  });
+
+  test("标记只占了位、还没回填 pid → 等到期仍没进程就 null（占位不是进程）", async () => {
+    const marker = codexAutoWakeMarkerPath(home, codexAutoWakeTarget(auth(), "dev"));
+    const c = clock();
+    writeCodexAutoWakeMarker(marker, { pid: null, started_at: null, claimed_at: 2_000, channel: "dev" });
+    expect(await probeCodexWakeLayer({ home, lockDir, config, channel: "dev", alive: () => true, ...c })).toBeNull();
   });
 });

--- a/cli/test/who.test.ts
+++ b/cli/test/who.test.ts
@@ -528,7 +528,7 @@ describe("who wake guidance（#879/#891：判据在场才给建议，判不出�
       reason: "no_wake_layer",
       harness: "claude",
       harness_source: "agent_session",
-      remedy: ["claude plugin install agentparty@agentparty"],
+      remedy: ["claude plugin install agentparty@agentparty", "claude plugin update agentparty@agentparty"],
     });
   });
 
@@ -584,10 +584,11 @@ describe("who wake guidance（#879/#891：判据在场才给建议，判不出�
       reason: "no_wake_layer",
       harness: "claude",
       harness_source: "agent_session",
-      remedy: ["claude plugin install agentparty@agentparty"],
+      remedy: ["claude plugin install agentparty@agentparty", "claude plugin update agentparty@agentparty"],
     });
+    // #961：install 对已装的只回 already installed、不升级——修法必须带上 update，且说明要重开。
     expect(note).toBe(
-      " · ↳ fix: an interactive Claude Code session is wakeable once the agentparty plugin is installed — run claude plugin install agentparty@agentparty and rejoin the channel",
+      " · ↳ fix: an interactive Claude Code session is wakeable once the agentparty plugin is installed and matches the party CLI version — run claude plugin install agentparty@agentparty, then claude plugin update agentparty@agentparty (install never upgrades an already-installed plugin), restart Claude Code and rejoin the channel",
     );
     expect(note).not.toContain("codex");
     expect(note).not.toContain("party serve");
@@ -814,7 +815,7 @@ describe("who 唤醒建议的装配（presence → 行 → 终端一行）", () 
     );
     const line = renderRow(rows[0] as NonNullable<(typeof rows)[number]>, NOW, 0);
     expect(line).toContain(
-      "↳ fix: an interactive Claude Code session is wakeable once the agentparty plugin is installed — run claude plugin install agentparty@agentparty and rejoin the channel",
+      "↳ fix: an interactive Claude Code session is wakeable once the agentparty plugin is installed and matches the party CLI version — run claude plugin install agentparty@agentparty, then claude plugin update agentparty@agentparty (install never upgrades an already-installed plugin), restart Claude Code and rejoin the channel",
     );
     expect(line).not.toContain("party bridge codex");
     expect(line).not.toContain("--runner codex");


### PR DESCRIPTION
## 根因

#957 和 #961 是同一个形状：`party join` 收尾那句「✅ 全部就绪：现在 @ X，这台机器上的 <harness> 会话就能被唤醒」，判据全是**静态前置条件**（config 写了、身份解析了、hook 装了/批了、报到了），而「唤醒真的会发生」这个真正的判据一次都没查。

- **claude 档（#961）**：`installHarnessPlugin` 是 marketplace add → `plugin install` → `plugin enable`。`plugin install` 对已装的只回 "already installed"（exit 0），**永远不升级**。于是本机插件 0.2.203、CLI 0.2.212，`party bridge claude --check` 报 `plugin_version_mismatch` blocker，SessionStart 唤醒根本没布上，join 照样印 ✅；而 join / doctor / who 三处教的修法还是 `plugin install`——照做原地踏步。
- **codex 档（#957）**：唤醒层（`party serve --runner codex`）只在 `codex-report` 的 SessionStart 里拉起。跑 join 的那个会话 SessionStart 早过去了（那会儿还没身份），所以它从生到死没有唤醒层；`buildJoinGate` 的四项 `channel_bound / identity_resolved / hook_installed / hook_trusted` 全绿就印「就能被唤醒」，实际只有用户下次发言、回合结束时 Stop hook 才把 @ 交给他。

## 修法

### claude 档
1. **install 之后读已装版本，≠ CLI 就 `claude plugin update`**（`cli/src/commands/join.ts` `installClaudePlugin`）。版本读取走 doctor 同一个 `parseClaudePluginList`，判据不另写一份。插件比 CLI 还新时提示 `party upgrade` 而不是降插件。
2. **收尾自检新增 `plugin_lifecycle_ready`**：直接调 doctor 的 `inspectClaudePluginShell()`（`party bridge claude --check` 的 lifecycle 就是它），不 shell 出去再解析文本。有 blocker 就不印 ✅，把 blocker + 对症修法印出来。`plugin_version_mismatch` 的修法是 **update**（join.ts / doctor.ts `claudePluginDoctorFixLines` / who.ts `wakeGuidanceOf` 三处一起改）。
3. **「需重开会话」进结论句**：装了或更新了插件后印 `✅ 全部就绪，差一次重开：claude 插件已是 X，【新开一个 Claude 会话】后 @ name 就能唤醒它；当前这个会话还挂着旧插件，不会被唤醒。`

### codex 档
1. **收尾主动拉起唤醒层**：调 `hook.ts` 现有的 `maybeStartCodexAutoWake(record, defaultCodexAutoWakeDeps())`——与 SessionStart 完全同一条路径（同一套开关 / 去重 / 标记 / 日志）。身份靠 join 已设的 `AGENTPARTY_CONFIG` 走 env 档解析（#917 不按 cwd 猜）。
2. **自检新增 `wake_layer_live`**，判据是**进程真的在**：`probeCodexWakeLayer` 先看 serve 实例锁（`runningServePid`，与 `codex-autowake status` 同一把锁），再看启动标记里的 pid（`activeCodexAutoWakePid` → `isSameLiveProcess`）；等最多 3s 让 serve 有机会持锁。不看开关是否 default-on。
3. **拉不起来时结论降级**：`⚠ 接入完成，但唤醒层没起来：<原因>` + `本会话只能在你下次发言、回合结束时收到 @（Stop hook 会把积压的 @ 交给你）；要无人值守被唤醒，请新开一个 codex 会话。` + 手动兜底命令。绝不出现「就能被唤醒」。exit 1。
4. **顺手堵一个会让 ✅ 在 60s 后变假的坑**：唤醒层的回收判据是「频道上还有没有活着的入册 codex 会话」。跑 join 的会话在 SessionStart 时往往没绑频道 / 挂在别的频道，注册表里对不上，唤醒层宽限期一过就判「无人使用」退场——issue 里那条 `reaping` 日志就是这么来的。join 现在通过进程祖先链找到跑它的 codex pid，**只更新已有条目**的 channel/identity/server（绝不伪造 session_id）；找不到条目就在证据里如实提示。

### 附带
- `join-binding.ts`：`detectHarnessFromAncestry` 抽成 `findHarnessAncestor`（多返回 pid），原函数语义不变。
- **`hook.ts` 只改一处**：`defaultCodexAutoWakeDeps` 加 `export`，函数体一字未动。与 #959/#960 正在改的 `maybeStartCodexAutoWake / decideCodexAutoWake` 内部逻辑无重叠；如果那边给 join 的这次调用（record 带 `source: "party-join"`）判成 skip，join 会走降级结论并把 skip 原因印出来，不会误报 ✅。
- 一条行为变更请 review 时留意：claude 档在 **claude 不在 PATH 上**时以前也印 ✅（旧测试「不影响就绪结论」）。现在 `claude_unavailable` 同样是 blocker——插件是 claude 档唯一的唤醒层，连 claude 都找不到就核实不了，按 #961 的口径「有 blocker 就别印 ✅」处理，修法指向把 claude 放到 PATH。对应测试改成断言这一点。

## 测试证据

`cd cli && bunx tsc --noEmit` 干净。

`bun test test/join.test.ts test/who.test.ts test/doctor-plugin.test.ts test/join-binding.test.ts test/codex-auto-wake.test.ts`：
```
 23 pass / 0 fail   (join.test.ts, 新增 12 条)
 136 pass / 0 fail  (其余 4 个文件)
```
全量 `bun test`：2364 pass / 2 fail——那 2 条是 `claude-native-format-guard.test.ts`（#953，从本机真 claude 二进制 2.1.250 抠原生正则，抠不出），与本 PR 改动无关（它只 import 未改动的 `claude-inbox-inject`，失败点是本机 claude 版本的二进制格式），未在 main 上单独复跑。

新增用例覆盖事故场景本身：
- (a) 已装 0.2.203 → 跑了 `plugin update`（且在 install 之后），结论含「重开」「当前这个会话还挂着旧插件」
- (b) update 失败仍是旧版 → exit 1、无「全部就绪」、自检印 `plugin_version_mismatch`，「现在只做这一件事」下面那行**恰好是** `claude plugin update agentparty@agentparty`
- (c) 唤醒层 start-failed / skip(disabled) → 无「就能被唤醒」，有降级文案；already-serving + pid 探到 → ✅
- (d) `probeCodexWakeLayer`：无进程 → null（开关默认开也一样）；标记里进程已死 → null；占位无 pid → null；锁 / 标记 pid 活 → 对应 source
- 注册表认领：预置挂在别频道的条目 → 改到本频道 + identity + server；没条目 → 不伪造、提示「没入册」
- doctor：`claudePluginDoctorFixLines` 版本不一致给 update / 插件更新给 party upgrade / 缺失仍 install
- who：claude 档 remedy 变成 install + update，文案说明 install 不升级

**变异自检**（每个修复单独弄坏 → 对应用例变红 → 恢复后全绿）：
| 变异 | 变红的用例 |
|---|---|
| 不跑 plugin update | (a) |
| 插件壳检查恒 ok | (b) + 无 claude 那条 |
| 版本不一致修法退回 install | (b) |
| 「重开」不进结论句 | (a) + 首次安装那条 |
| wake_layer_live 恒 ok | (c) 两条 |
| 降级文案分支去掉 | (c) 两条 |
| 探活不看进程存活 | (d) 两条 |
| 不更新注册表 | 认领那条 |

Closes #957
Closes #961

https://claude.ai/code/session_01Az8CnUpayZzqpi1sh32Ssi
