### PR TITLE
fix(cli): 原生格式守卫按角色还原占位符，不再把压缩变量名写死 (#969)

### DIFF
--- a/cli/src/claude-native-format.ts
+++ b/cli/src/claude-native-format.ts
@@ -108,10 +108,18 @@ export function readClaudeNativeCrossSessionFormat(
 /**
  * 把抠到的严格正则还原成可执行的 RegExp。
  *
- * 二进制里那段是**模板字符串**（`${f}` `${m}` `${n}` …），要把占位符替回真值才能用。
+ * 二进制里那段是**模板字符串**（`${vj}` `${ea}` `${t}` …），要把占位符替回真值才能用。
  * 任何一处还原不出就返回 null —— 宁可 skip，也不要拿一条半成品正则去判「原生不认」，
  * 那会变成一条骗人的红灯。
+ *
+ * #969：占位符**按角色**替，不按变量名。压缩产物里的变量名随构建变化（2.1.24x 之前是
+ * `f/m/n/r/y`，之后成了 `vj/ea/t/r/ZP`），第一版按名替换在 2.1.247+ 上全部落空、守卫恒红——
+ * 而属性顺序与框架一字未变。角色由占位符**所处的位置**决定：`^<${X}` / `</${X}>` 是标签名，
+ * `[${X}]` 是 from 的字符集，`from-mode="(${X.join("|")})"` 是取值集，其余 `="(${X})"` 是
+ * from-session / hop-chain 的内部格式（我们不复现，宽松占位）。
  */
+const TEMPLATE_IDENT = String.raw`\$\{[A-Za-z_$][\w$]*\}`;
+
 export function buildNativeStrictRegex(fmt: ClaudeNativeCrossSessionFormat): RegExp | null {
   const start = fmt.strictSource.indexOf("^<");
   if (start === -1) return null;
@@ -120,18 +128,21 @@ export function buildNativeStrictRegex(fmt: ClaudeNativeCrossSessionFormat): Reg
   let src = fmt.strictSource.slice(start, end + 1);
   if (fmt.fromCharset === null || fmt.fromModes === null) return null;
   src = src
-    .replace(/\$\{f\}/g, "cross-session-message")
-    .replace(/\$\{m\}/g, fmt.fromCharset.replace(/\\\\/g, "\\"))
+    .replace(new RegExp(String.raw`^\^<${TEMPLATE_IDENT}`), "^<cross-session-message")
+    .replace(new RegExp(String.raw`</${TEMPLATE_IDENT}>`, "g"), "</cross-session-message>")
+    .replace(new RegExp(String.raw`\[${TEMPLATE_IDENT}\]`, "g"), `[${fmt.fromCharset}]`)
+    .replace(
+      new RegExp(String.raw`from-mode="\(\$\{[A-Za-z_$][\w$]*\.join\("\|"\)\}\)"`, "g"),
+      `from-mode="(${fmt.fromModes.join("|")})"`,
+    )
     // from-session / hop-chain 的取值形状我们不复现，用宽松占位——本守卫要抓的是
     // **属性顺序与框架**变没变，不是去复刻它们各自的内部格式。
-    .replace(/\$\{n\}/g, "[^\"]*")
-    .replace(/\$\{r\}/g, "[^\"]*")
-    .replace(/\$\{y\.join\("\|"\)\}/g, fmt.fromModes.join("|"));
+    .replace(new RegExp(String.raw`="\(${TEMPLATE_IDENT}\)"`, "g"), '="([^"]*)"');
   if (src.includes("${")) return null;
   try {
     // 二进制里那段是**源码文本**：正则里的 `\s` 在源码里写作 `\\s`。逐个还原会漏
     // （第一版只还原了 \n / \r，漏了 \s / \S，导致 body 段匹配不上、守卫误报"原生不认"）。
-    // 统一把双反斜杠折成单反斜杠。
+    // 统一把双反斜杠折成单反斜杠（抠到的 charset 同样是源码文本，一并折）。
     return new RegExp(src.replace(/\\\\/g, "\\"));
   } catch {
     return null;

--- a/cli/test/claude-native-format-guard.test.ts
+++ b/cli/test/claude-native-format-guard.test.ts
@@ -104,6 +104,27 @@ describe("原生 cross-session 格式漂移守卫（#953）", () => {
     expect(fmt.fromModes).toEqual(["bypass", "prompting"]);
   });
 
+  // #969：压缩产物的变量名随构建变化（f/m/n/r/y → vj/ea/t/r/ZP），第一版按变量名替换在
+  // 2.1.247+ 上全部落空，守卫在装了 claude 的机器上恒红。这条用当前二进制里那行的**真实形态**、
+  // 再把变量名全换成别的，钉住「按角色还原，不认变量名」。恒跑，不依赖本机有没有 claude。
+  test("还原不认变量名：占位符换名后仍还原出同一条严格正则（#969）", () => {
+    const line = (tag: string, cs: string, sess: string, hop: string, modes: string) =>
+      'tM=new RegExp(`^<${' + tag + '}(?: from="([${' + cs + '}]+)")?(?: from-session="(${' + sess + '})")?' +
+      '(?: hop-chain="(${' + hop + '})")?(?: from-name="([^"<>\\\\n\\\\r]+)")?(?: from-mode="(${' + modes +
+      '.join("|")})")?>\\\\n([\\\\s\\\\S]*)\\\\n</${' + tag + '}>$`)';
+    const build = (strictSource: string) =>
+      buildNativeStrictRegex({ strictSource, fromCharset: "A-Za-z0-9%:_/.\\\\-", fromModes: ["bypass", "prompting"], binaryPath: "x" });
+    const variants = [line("f", "m", "n", "r", "y"), line("vj", "ea", "t", "r", "ZP"), line("$a1", "_b", "c_", "d$", "E9")];
+    const sources = variants.map((v) => build(v)?.source ?? null);
+    expect(sources.map((x) => x !== null)).toEqual([true, true, true]);
+    expect(new Set(sources).size).toBe(1);
+    const native = build(variants[1]!)!;
+    const ok = wrapCrossSessionMessage({ from: "uds:/tmp/cc-socks/3.sock", fromSession: "abc", hopChain: "a,b", fromName: "n", fromMode: "bypass", body: "l1\nl2" });
+    expect({ accepted: native.test(ok) }).toEqual({ accepted: true });
+    const swapped = '<cross-session-message from="uds:/a.sock" from-mode="bypass" from-name="n">\nx\n</cross-session-message>';
+    expect({ accepted: native.test(swapped) }).toEqual({ accepted: false });
+  });
+
   test("抠不出来时 skip 而不是红（无 claude 的 CI 上不许常红）", () => {
     // 这条恒跑：它断言的是"降级路径存在且是 skip"，不依赖本机有没有 claude。
     expect(locateClaudeBinary({ AGENTPARTY_CLAUDE_BINARY: "/nonexistent/claude", HOME: "/nonexistent" })).toBe(null);


### PR DESCRIPTION
## 根因
`buildNativeStrictRegex` 把压缩产物里的模板变量名 `${f}/${m}/${n}/${r}/${y.join}` 写死；claude 2.1.247+ 变成 `${vj}/${ea}/${t}/${r}/${ZP.join}`，替换全部落空 → `src.includes("${")` → null → `gotRegex:false`。装了 claude 的开发机上守卫恒红，`scripts/release.sh` 的本地 `bun run check` 因此过不去；CI 无 claude 会 skip 所以看不到。**属性顺序与框架一字未变，格式没有漂移。**

## 修法
占位符按**角色**（所处位置）替换：`^<${X}` / `</${X}>` 标签名、`[${X}]` charset、`from-mode="(${X.join("|")})"` modes、其余 `="(${X})"` 宽松占位。任何合法标识符都吃。

## 测试证据
- 本机 claude 2.1.250 真二进制：`bun test test/claude-native-format-guard.test.ts` → **5 pass / 0 fail**（修前 2 fail）。
- 新增恒跑用例：同一行分别用 `f/m/n/r/y`、`vj/ea/t/r/ZP`、`$a1/_b/c_/d$/E9` 三套变量名，还原出的 `source` 完全相同；接受 `wrapCrossSessionMessage` 全属性样本、拒绝属性换序样本。
- 变异自检：把 `TEMPLATE_IDENT` 改回只认 `[fmnry]` → 3 fail（新用例 + 两条真二进制用例），恢复后 5 pass。
- `bunx tsc --noEmit` 通过。

Closes #969

https://claude.ai/code/session_01Az8CnUpayZzqpi1sh32Ssi