### PR TITLE
fix(cli): codex 身份解析先按 harness 过滤候选，claude 绑定不再造成 ambiguous（#971）

### DIFF
--- a/cli/src/codex-auto-wake.ts
+++ b/cli/src/codex-auto-wake.ts
@@ -319,6 +319,7 @@ export type CodexAutoWakeSkipReason =
   | "no-channel"
   | "non-interactive"
   | "harness-mismatch"
+  | "no-codex-binding"
   | "no-agent-token"
   | "already-serving"
   | "already-starting"
@@ -346,8 +347,11 @@ export interface CodexAutoWakeDecisionInput {
    * 拉唤醒层：它 60 秒后必被回收，留下的只有一条零信息的 waiting 帧。缺省 / unknown = 按交互式处理。
    */
   sessionKind?: CodexSessionKindLike | null;
-  /** 身份解析被「绑给别的 harness」拒掉时的说明（#960）；null = 没这回事。 */
-  harnessMismatch?: string | null;
+  /**
+   * 身份解析被「绑给别的 harness」拒掉（#960 harness-mismatch）或候选按 harness 过滤后一个不剩
+   * （#971 no-codex-binding）时的原因；null = 没这回事。两者都以自己的名字进日志，绝不混进 no-agent-token。
+   */
+  identityRefusal?: { reason: "harness-mismatch" | "no-codex-binding"; detail: string } | null;
   /** 同 (身份, 频道) 刚被回收过的证据（#959 退避）；null = 没有。 */
   flapping?: CodexAutoWakeFlap | null;
   /** 决策时刻；只用于把退避说明里的「多久前」算出来。缺省 Date.now()。 */
@@ -390,8 +394,8 @@ export function decideCodexAutoWake(input: CodexAutoWakeDecisionInput): CodexAut
         `（拉了也会在 60 秒后被回收，只给 #${channel} 留一条零信息的 waiting 帧）`,
     };
   }
-  if (typeof input.harnessMismatch === "string" && input.harnessMismatch !== "") {
-    return { action: "skip", reason: "harness-mismatch", detail: input.harnessMismatch };
+  if (input.identityRefusal !== null && input.identityRefusal !== undefined) {
+    return { action: "skip", reason: input.identityRefusal.reason, detail: input.identityRefusal.detail };
   }
   if (!input.hasAgentToken) {
     return {

--- a/cli/src/codex-session-identity.ts
+++ b/cli/src/codex-session-identity.ts
@@ -31,6 +31,10 @@
 //                            app-server 就是这样多路复用的，真机实测）。
 //   5. `cwd-unique`       —— 退到 cwd 绑定的 config，但**只在本机该频道不存在第二个身份时**
 //                            才算数。单身份机器（绝大多数）行为逐字不变；多身份机器一律放弃。
+//
+// 反推各档（③④⑤）的候选集都**先按 harness 过滤**（#960/#971）：绑定文件里明确写着属于别的 harness
+// （且没有同身份 codex 绑定）的身份不是 codex 的候选——过滤后 0 个 ⇒ `no-codex-binding`（这台机
+// 就没打算让 codex 接本频道，安静退出）；恰 1 个 ⇒ 认领；≥2 个才是歧义。没有绑定记录的老配置保留。
 import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import {
@@ -88,6 +92,7 @@ export type CodexHookIdentityRefusal =
   | "env-config-unusable"
   | "ambiguous-binding"
   | "harness-mismatch"
+  | "no-codex-binding"
   | "registry-identity-unresolvable"
   | "ambiguous"
   | "no-identity";
@@ -293,6 +298,15 @@ export function resolveCodexHookIdentity(input: CodexHookIdentityInput): CodexHo
       `#${channel} 上的身份 ${identity.name ?? "?"}@${identity.server} 是用 --harness ${owner.harness} 加入的` +
       `（join-bindings 如实记着），codex hook 不认领它——要让 codex 也接这个身份，用 codex 的接入包重新加入`,
   });
+  // #971：候选按 harness 过滤后一个都不剩＝这台机就没打算让 codex 接本频道。这是预期状态，
+  // 不是故障：安静退出，绝不写成 ambiguous 那段引人重跑 codex 接入包的长文。
+  const noCodexBinding = (what: string): CodexHookIdentityResolution => ({
+    ok: false,
+    reason: "no-codex-binding",
+    detail: `${what}，codex 不接 #${channel}（要让 codex 也接是可选的，用 codex 的接入包 join 一次即可）`,
+  });
+  const describe = (rows: readonly { name: string | null; server: string }[]): string =>
+    rows.map((row) => `${row.name ?? "?"}@${row.server}`).join(", ");
 
   // ③ session_id → 注册表条目（identity + server 都是 SessionStart 时按本表同一套规则记的）。
   if (sessionId !== null && sessionId !== "") {
@@ -355,26 +369,73 @@ export function resolveCodexHookIdentity(input: CodexHookIdentityInput): CodexHo
       };
     }
     if (found.size > 1) {
+      // #971：歧义只在 **codex 可认领的** 候选之间算。绑给别的 harness 的身份先剔掉。
+      const rows = [...found.values()].filter((row) =>
+        boundElsewhere({ server: row.server, name: row.name, configPath: row.path }) === null);
+      if (rows.length === 1) {
+        const only = rows[0]!;
+        return {
+          ok: true,
+          identity: {
+            source: "mcp-registration",
+            configPath: only.path,
+            server: only.server,
+            token: only.token,
+            name: only.name,
+            configScopedState: true,
+          },
+        };
+      }
+      if (rows.length === 0) {
+        return noCodexBinding(
+          `codex 进程 ${deps.pid} 下挂着的 ${found.size} 个绑 #${channel} 的身份` +
+            `（${describe([...found.values()])}）全是用别的 harness 加入的`,
+        );
+      }
       return {
         ok: false,
         reason: "ambiguous",
         detail:
-          `codex 进程 ${deps.pid} 下同时挂着 ${found.size} 个绑 #${channel} 的身份` +
-          `（${[...found.values()].map((row) => `${row.name ?? "?"}@${row.server}`).join(", ")}）` +
+          `codex 进程 ${deps.pid} 下同时挂着 ${rows.length} 个绑 #${channel} 的身份` +
+          `（${describe(rows)}）` +
           `——分不清本会话是哪一个，放弃。重新跑一遍接入包即可（加入即绑定会记下本次身份）`,
       };
     }
   }
 
-  // ⑤ cwd 绑定的 config——只有本机该频道不存在第二个身份时才算数。
+  // ⑤ cwd 绑定的 config——只有本机该频道不存在第二个 **codex 可认领的** 身份时才算数。
+  //
+  // #971：候选集先按 harness 过滤，再谈唯一/歧义。绑定文件里明确写着 `harness: claude`（且没有
+  // 同身份 codex 绑定）的身份根本不是 codex 的候选——piggo 现场同 cwd 堆着一旧一新两个 claude
+  // 绑定、零个 codex 绑定，此前这里把两个都算进候选、判成 ambiguous，每个 codex SessionStart 都
+  // 刷一遍长文，修法还引人「重跑 codex 接入包」，与这台机「codex 不接 #C」的意图正相反。
+  // 没有绑定记录的老配置照旧留在候选里（它们没被任何 harness 认领）。
   const cwdUsable = usableConfig(deps.readCwdConfig(cwd), channel);
   const distinct = distinctCandidateKeys(deps.candidates(channel));
+  const claimedByOtherHarness = (hint: LocalAgentConfigHint): boolean => {
+    const healed = healServerUrl(hint.server);
+    return healed !== null && boundElsewhere({ server: healed, name: hint.name, configPath: hint.path }) !== null;
+  };
+  const eligible = new Map([...distinct].filter(([, hint]) => !claimedByOtherHarness(hint)));
+  const foreignNames = [...distinct.values()]
+    .filter((hint) => claimedByOtherHarness(hint))
+    .map((hint) => hint.name ?? "?");
   if (cwdUsable !== null) {
     const key = identityKey(cwdUsable.server, cwdUsable.name);
-    const others = [...distinct.keys()].filter((candidate) => candidate !== key);
+    const others = [...eligible.keys()].filter((candidate) => candidate !== key);
+    const cwdOwner = boundElsewhere({ ...cwdUsable, configPath: null });
+    if (cwdOwner !== null) {
+      // cwd 指向的身份是别的 harness 的。本机该频道就它一个身份 ⇒ harness-mismatch（#960 原样）；
+      // 连同它在内绑该频道的身份全是别的 harness 的、且不止一个 ⇒ no-codex-binding（#971 现场）；
+      // 还剩没人认领的老配置 ⇒ 那也不是 cwd 指的这个，绝不改猜它——仍按 mismatch 拒。
+      const foreignCount = foreignNames.length + (distinct.has(key) ? 0 : 1);
+      if (others.length === 0 && foreignCount > 1) {
+        const names = distinct.has(key) ? foreignNames : [cwdUsable.name ?? "?", ...foreignNames];
+        return noCodexBinding(`本目录绑 #${channel} 的 ${names.length} 个身份（${names.join(", ")}）全是用别的 harness 加入的`);
+      }
+      return harnessMismatch(cwdOwner, cwdUsable);
+    }
     if (others.length === 0) {
-      const owner = boundElsewhere({ ...cwdUsable, configPath: null });
-      if (owner !== null) return harnessMismatch(owner, cwdUsable);
       return {
         ok: true,
         identity: { source: "cwd-unique", configPath: null, ...cwdUsable, configScopedState: false },
@@ -384,10 +445,13 @@ export function resolveCodexHookIdentity(input: CodexHookIdentityInput): CodexHo
       ok: false,
       reason: "ambiguous",
       detail:
-        `本机绑 #${channel} 的身份有 ${distinct.has(key) ? distinct.size : distinct.size + 1} 个，` +
+        `本机绑 #${channel} 的身份有 ${eligible.has(key) ? eligible.size : eligible.size + 1} 个，` +
         `cwd(${cwd}) 只能猜出其中一个（${cwdUsable.name ?? "?"}@${cwdUsable.server}）——按 cwd 猜必然误投，放弃。` +
         `重新跑一遍该身份的接入包即可（加入即绑定会把「这个 harness 的这个频道 = 这个身份」记下来）`,
     };
+  }
+  if (distinct.size > 0 && eligible.size === 0) {
+    return noCodexBinding(`本机绑 #${channel} 的 ${distinct.size} 个身份（${foreignNames.join(", ")}）全是用别的 harness 加入的`);
   }
   return {
     ok: false,
@@ -421,6 +485,10 @@ export function codexHookIdentityFix(
       // 身份是绑给别的 harness 的：codex 不抢。想让 codex 也接它，就用 codex 的接入包（party invite）
       // 再 join 一次——别拿 party init 手搓，半截 join 看着正常、被 @ 时静默不醒（#955）。
       return `AGENTPARTY_TOKEN='<T>' party join --channel ${channel}${serverFlag} --as <name> --harness codex --yes    # 这个身份是用别的 harness 加入的，codex 不认领；要让 codex 接它，用 codex 的接入包重新 join`;
+    case "no-codex-binding":
+      // #971：本目录绑该频道的身份全是别的 harness（claude）的，codex 不接是这台机的**预期状态**，
+      // 不是故障。命令只是「想让 codex 也接」时的可选路径——同样走接入包 join，不是 party init（#955）。
+      return `AGENTPARTY_TOKEN='<T>' party join --channel ${channel}${serverFlag} --as <name> --harness codex --yes    # 可选：本目录绑 #${channel} 的身份都是 claude 加入的，codex 不接是预期行为；只有想让 codex 也接这个频道时才用 codex 的接入包 join 一次`;
     case "ambiguous-binding":
     case "ambiguous":
     case "registry-identity-unresolvable":

--- a/cli/src/commands/hook.ts
+++ b/cli/src/commands/hook.ts
@@ -922,7 +922,9 @@ export function recordCodexSessionLifecycle(
       sessionId,
       deps: defaultCodexHookIdentityDeps(env, pid),
     });
-    if (!resolved.ok) {
+    // #971：候选全是别的 harness 的＝这台机就没打算让 codex 接本频道，是预期状态：不刷日志
+    // （唤醒层决策会以一条 skip(no-codex-binding) 留痕，够定位）。其余解析失败照旧记。
+    if (!resolved.ok && resolved.reason !== "no-codex-binding") {
       appendCodexAutoWakeLog(
         agentpartyHome(env),
         `codex-report: 入册时解析不出会话身份（${resolved.reason}）：${resolved.detail}`,
@@ -992,8 +994,9 @@ export function defaultCodexAutoWakeDeps(
         deps: defaultCodexHookIdentityDeps(env, pid),
       });
       if (resolved.ok) return { server: resolved.identity.server, token: resolved.identity.token };
-      // #960：绑给别的 harness 的身份由决策层以 skip(harness-mismatch) 留痕，这里不重复记。
-      if (resolved.reason !== "harness-mismatch") {
+      // #960/#971：绑给别的 harness 的身份由决策层以 skip(harness-mismatch) / skip(no-codex-binding)
+      // 留痕，这里不重复记。
+      if (resolved.reason !== "harness-mismatch" && resolved.reason !== "no-codex-binding") {
         appendCodexAutoWakeLog(
           home,
           `codex-report: 唤醒层解析不出会话身份（${resolved.reason}）：${resolved.detail}——不拉起`,
@@ -1066,7 +1069,9 @@ export function maybeStartCodexAutoWake(
     cwd,
     now,
     sessionKind,
-    harnessMismatch: refused?.refused === "harness-mismatch" ? refused.detail : null,
+    identityRefusal: refused !== null && (refused.refused === "harness-mismatch" || refused.refused === "no-codex-binding")
+      ? { reason: refused.refused, detail: refused.detail }
+      : null,
     hasAgentToken: auth !== null,
     // 已有 serve（不管是用户手挂的还是上一次自动拉的）就绝不拉第二个：一条 @ 触发两次
     // 完整 runner ＝ 双份回帖、git push 类副作用跑两遍。
@@ -1181,7 +1186,8 @@ export function defaultCodexStopWakeDeps(
       };
     }
     if (cached.resolution.ok) return cached.resolution.identity;
-    if (!logged) {
+    // #971：本目录的身份全是别的 harness 的＝codex 不接本频道是预期状态，每个 Stop 都记一行只是噪音。
+    if (!logged && cached.resolution.reason !== "no-codex-binding") {
       logged = true;
       appendCodexAutoWakeLog(
         home,

--- a/cli/src/wake-diagnosis.ts
+++ b/cli/src/wake-diagnosis.ts
@@ -273,7 +273,8 @@ export function formatCodexWakeDiagnosis(d: CodexWakeDiagnosis): string[] {
     out.push("  另外: hook 装了但还没被 codex 信任 —— 未获批准的 hook 会被【静默跳过】");
     out.push("  怎么修: party wake check   （它会说出该在【哪个 codex 二进制】里批准——直接跑 `codex` 未必是对的）");
   }
-  if (d.bindings.length === 0 && d.identity === null) {
+  // #971：no-codex-binding 是「这台机没打算让 codex 接」，fix 里已说明可选；再劝「重跑接入包」就是反向引导。
+  if (d.bindings.length === 0 && d.identity === null && d.reason !== "no-codex-binding") {
     out.push("  提示: 本机还没有为 codex 记下任何加入绑定——重跑一遍该身份的接入包即可（加入即绑定，#924）");
   }
   return out;

--- a/cli/test/codex-auto-wake.test.ts
+++ b/cli/test/codex-auto-wake.test.ts
@@ -735,6 +735,29 @@ describe("pins #960：codex hook 不认领绑给 claude 的身份", () => {
     expect(log).not.toContain("no-agent-token");
   });
 
+  test("#971 piggo 现场：同 cwd 一旧一新两个 claude 绑定、零个 codex 绑定 ⇒ 一条 skip(no-codex-binding)，没有 ambiguous 长文", () => {
+    // 旧身份：老版本记的绑定没有 owner，自成一组、不被新绑定替换；config 按设计保留。
+    const oldPath = joinAs("leo-server", "tok-old", "claude", false);
+    writeJoinBinding(joinBindingsPath(home), {
+      harness: "claude", server: SERVER, channel: CHANNEL, owner: null, identity: "leo-server", config_path: oldPath, cwd, created_at: 1,
+    });
+    joinAs("server", "tok-new", "claude");
+    const d = realDeps();
+    const outcome = maybeStartCodexAutoWake(sessionStart({ cwd }), d);
+    expect(outcome).toMatchObject({ action: "skip", reason: "no-codex-binding" });
+    expect(d.calls).toHaveLength(0);
+    const skips = d.lines.filter((line) => line.startsWith("skip("));
+    expect(skips).toHaveLength(1);
+    expect(skips[0]).toContain("skip(no-codex-binding)");
+    const log = d.lines.join("\n");
+    expect(log).not.toContain("ambiguous");
+    expect(log).not.toContain("只能猜出其中一个");
+    expect(log).not.toContain("重新跑一遍");
+    expect(log).not.toContain("no-agent-token");
+    // 唤醒层自己的「解析不出会话身份」那行也不该再出现——预期状态只留决策层这一条痕。
+    expect(log).not.toContain("解析不出会话身份");
+  });
+
   test("同一个身份也用 codex 接入包加入过 ⇒ codex 可以认领，照拉", () => {
     joinAs("leo-server", "tok-shared", "claude");
     joinAs("leo-server", "tok-shared", "codex");

--- a/cli/test/codex-session-identity.test.ts
+++ b/cli/test/codex-session-identity.test.ts
@@ -434,6 +434,7 @@ describe("pins #924：同 harness 同频道堆了一串历史身份，加入后�
       "env-config-unusable",
       "ambiguous-binding",
       "harness-mismatch",
+      "no-codex-binding",
       "registry-identity-unresolvable",
       "ambiguous",
       "no-identity",
@@ -532,5 +533,153 @@ describe("pins #960：反推各档解析出的身份若绑给了别的 harness �
     expect(fix).toMatch(/^AGENTPARTY_TOKEN=\S+ party join\b/);
     expect(fix).toContain("--harness codex");
     expect(fix).not.toMatch(/(^|\s)party init\b/);
+  });
+});
+
+// #971：候选集必须**先按 harness 过滤**再谈唯一/歧义。piggo 真机：#ludo 上堆着一旧一新两个 claude
+// 绑定（leo-server 已移出频道、token 已撤但 config 按设计保留；server 是新的 `--harness claude`），
+// 零个 codex 绑定。此前 cwd 档把两个都算进候选 ⇒ 「ambiguous……放弃」每个 codex SessionStart 刷一遍，
+// 修法还叫人「重跑 codex 接入包」——与这台机「codex 不接 #ludo」的意图正相反。
+describe("pins #971：claude 绑定不是 codex 的候选——过滤后再判唯一/歧义", () => {
+  const SERVER = SESSION_SERVER;
+  const OLD = "leo-server";
+  const NEW = "server";
+
+  function bindTo(harness: BindingHarness, configPath: string, identity: string, owner: string | null = "leo") {
+    writeJoinBinding(joinBindingsPath(home), {
+      harness, server: SERVER, channel: CHANNEL, owner, identity, config_path: configPath, cwd, created_at: 1_700_000_000_000,
+    }, { replace: false });
+  }
+
+  test("(a) piggo 现场：同 cwd 两个 claude 绑定 + 0 个 codex 绑定 ⇒ no-codex-binding，绝不是 ambiguous", () => {
+    const oldPath = writeAgentConfig("agentparty-leo-server.json", agentConfig(OLD, SERVER, "tok-old"));
+    const newPath = writeAgentConfig("agentparty-server.json", agentConfig(NEW, SERVER, "tok-new"));
+    bindTo("claude", oldPath, OLD, null);
+    bindTo("claude", newPath, NEW);
+    writeWorkspaceConfigOnly(agentConfig(NEW, SERVER, "tok-new"), cwd);
+    const result = resolve({}, null);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("no-codex-binding");
+    expect(result.detail).not.toContain("ambiguous");
+    expect(result.detail).not.toContain("只能猜出其中一个");
+    expect(result.detail).not.toContain("重新跑一遍");
+    expect(result.detail).toContain(OLD);
+    expect(result.detail).toContain(NEW);
+    expect(result.detail).toContain("可选");
+  });
+
+  test("(a′) 老绑定已被替换、只剩 config 残留：cwd 指向 claude 的身份 ⇒ 仍拒绝，且绝不改猜那份残留 config", () => {
+    // 同 owner 的 claude 绑定会被后加入的替换（join-binding 的默认语义），于是 leo-server 只剩 config、没有绑定。
+    writeAgentConfig("agentparty-leo-server.json", agentConfig(OLD, SERVER, "tok-revoked"));
+    const newPath = writeAgentConfig("agentparty-server.json", agentConfig(NEW, SERVER, "tok-new"));
+    bindTo("claude", newPath, NEW);
+    writeWorkspaceConfigOnly(agentConfig(NEW, SERVER, "tok-new"), cwd);
+    const result = resolve({}, null);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    // cwd 指的那个是 claude 的——这是 mismatch；残留的 leo-server 不是 cwd 指的，绝不认领它。
+    expect(result.reason).toBe("harness-mismatch");
+    expect(result.detail).not.toContain("ambiguous");
+    expect(result.detail).toContain(NEW);
+  });
+
+  test("(b) 一 claude 一 codex：认领 codex 那个，哪怕 claude 的更新、且绑在 cwd 上", () => {
+    const codexPath = writeAgentConfig("agentparty-leo-codex.json", agentConfig("leo-codex", SERVER, "tok-codex"));
+    const claudePath = writeAgentConfig("agentparty-server.json", agentConfig(NEW, SERVER, "tok-new"));
+    bindTo("codex", codexPath, "leo-codex");
+    bindTo("claude", claudePath, NEW);
+    writeWorkspaceConfigOnly(agentConfig(NEW, SERVER, "tok-new"), cwd);
+    const result = resolve({}, null);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.identity.name).toBe("leo-codex");
+    expect(result.identity.token).toBe("tok-codex");
+    expect(result.identity.source).toBe("join-binding");
+  });
+
+  test("(b′) MCP 注册档：进程下挂着 claude 的与没人认领的两个身份 ⇒ 过滤掉 claude 的，认领剩下那一个", () => {
+    const claudePath = writeAgentConfig("agentparty-server.json", agentConfig(NEW, SERVER, "tok-new"));
+    const freePath = writeAgentConfig("agentparty-free.json", agentConfig("free", SERVER, "tok-free"));
+    bindTo("claude", claudePath, NEW);
+    const result = resolve({ mcpConfigPaths: () => [claudePath, freePath] }, null);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.identity.name).toBe("free");
+    expect(result.identity.source).toBe("mcp-registration");
+  });
+
+  test("(c) 两个 codex 绑定 ⇒ 才是 ambiguous（-binding），不因为旁边还有 claude 绑定而变味", () => {
+    const one = writeAgentConfig("agentparty-codex-one.json", agentConfig("codex-one", SERVER, "tok-1"));
+    const two = writeAgentConfig("agentparty-codex-two.json", agentConfig("codex-two", SERVER, "tok-2"));
+    const claudePath = writeAgentConfig("agentparty-server.json", agentConfig(NEW, SERVER, "tok-new"));
+    bindTo("codex", one, "codex-one", "alice");
+    bindTo("codex", two, "codex-two", "bob");
+    bindTo("claude", claudePath, NEW);
+    // 两条 codex 绑定都不是在本 cwd 加入的：cwd 收窄不出唯一。
+    const result = resolveCodexHookIdentity({ cwd: join(cwd, "elsewhere"), channel: CHANNEL, sessionId: null, deps: deps() });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("ambiguous-binding");
+    expect(result.detail).toContain("codex-one");
+    expect(result.detail).toContain("codex-two");
+    expect(result.detail).not.toContain(NEW);
+  });
+
+  test("(c′) cwd 档：没有绑定的老配置照旧是候选——两份没人认领的 + 一份 claude 的 ⇒ 歧义只在前两者之间", () => {
+    writeAgentConfig("agentparty-old-a.json", agentConfig("old-a", SERVER, "tok-a"));
+    writeAgentConfig("agentparty-old-b.json", agentConfig("old-b", SERVER, "tok-b"));
+    const claudePath = writeAgentConfig("agentparty-server.json", agentConfig(NEW, SERVER, "tok-new"));
+    bindTo("claude", claudePath, NEW);
+    writeWorkspaceConfigOnly(agentConfig("old-a", SERVER, "tok-a"), cwd);
+    const result = resolve({}, null);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("ambiguous");
+    expect(result.detail).toContain("身份有 2 个");
+  });
+
+  test("cwd 档：claude 的身份旁边只剩一份没人认领的老配置、且 cwd 指向它 ⇒ 过滤后唯一，正常认领（行为与单身份机器一致）", () => {
+    writeAgentConfig("agentparty-old-a.json", agentConfig("old-a", SERVER, "tok-a"));
+    const claudePath = writeAgentConfig("agentparty-server.json", agentConfig(NEW, SERVER, "tok-new"));
+    bindTo("claude", claudePath, NEW);
+    writeWorkspaceConfigOnly(agentConfig("old-a", SERVER, "tok-a"), cwd);
+    const result = resolve({}, null);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.identity.name).toBe("old-a");
+    expect(result.identity.source).toBe("cwd-unique");
+  });
+
+  test("cwd 没绑 config、本机该频道的身份全是 claude 的 ⇒ no-codex-binding（不是含糊的 no-identity）", () => {
+    const oldPath = writeAgentConfig("agentparty-leo-server.json", agentConfig(OLD, SERVER, "tok-old"));
+    bindTo("claude", oldPath, OLD);
+    const result = resolve({}, null);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("no-codex-binding");
+  });
+
+  test("现有 harness-mismatch 路径原样保留：单身份机器、cwd 指向 claude 的身份 ⇒ 仍是 harness-mismatch", () => {
+    const path = writeAgentConfig("agentparty-leo-server.json", agentConfig(OLD, SERVER, "tok"));
+    writeWorkspaceConfigOnly(agentConfig(OLD, SERVER, "tok"), cwd);
+    bindTo("claude", path, OLD);
+    const result = resolve({}, null);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("harness-mismatch");
+  });
+
+  test("(d) no-codex-binding 的修法：party join --harness codex（不是 party init，#955），且明说是可选的", () => {
+    const fix = codexHookIdentityFix("no-codex-binding", { channel: CHANNEL, server: SERVER });
+    expect(fix).toMatch(/^AGENTPARTY_TOKEN='<T>' party join\b/);
+    expect(fix).toContain(`--channel ${CHANNEL}`);
+    expect(fix).toContain(`--server ${SERVER}`);
+    expect(fix).toContain("--harness codex");
+    expect(fix).toContain("--yes");
+    expect(fix).not.toMatch(/(^|\s)party init\b/);
+    expect(fix).toContain("可选");
+    expect(fix).toContain("claude");
+    expect(fix).not.toContain("重跑");
   });
 });


### PR DESCRIPTION
## 根因

#966 的 `harness-mismatch` 判在「解析出唯一身份之后」；解析阶段（`resolveCodexHookIdentity` 的 cwd 档 ⑤ 与 MCP 注册档 ④）仍把 `harness: claude` 的 join-binding 当作 codex 候选。piggo 机上 #ludo 有一旧一新两个 claude 绑定、零个 codex 绑定 ⇒ 候选数 2 ⇒ 每个 codex SessionStart 都记「ambiguous……放弃」，修法文案还叫人「重跑该身份的 codex 接入包」——与这台机「codex 不接 #ludo」的意图正相反（照做等于把 #960 加回来）。

## 修法

- `cli/src/codex-session-identity.ts`
  - ④/⑤ 档候选集**先按 harness 过滤**：绑定文件里明确属于别的 harness（且无同身份 codex 绑定）的身份剔除；无绑定记录的老配置保留。剔除后 0 个 ⇒ 新拒绝理由 `no-codex-binding`；恰 1 个 ⇒ 认领；≥2 个才 `ambiguous`。
  - `codexHookIdentityFix("no-codex-binding")`：`AGENTPARTY_TOKEN='<T>' party join --channel C --server S --as <name> --harness codex --yes`，注释明说本目录绑该频道的身份都是 claude 的、codex 不接是预期行为、只有想让 codex 也接时才用（不是 `party init`，#955）。
  - 现有 `harness-mismatch` 路径原样保留：单身份 cwd / 注册表档 / MCP 档指向 claude 身份仍是 mismatch；cwd 指向 claude 身份、旁边只剩一份残留的无绑定 config 时也仍拒绝（绝不改猜残留那份——它在 piggo 上正是 token 已撤的 leo-server）。
- `cli/src/commands/hook.ts`：`no-codex-binding` 安静退出——SessionStart 入册与 Stop hook 都不再记「解析不出会话身份」；唤醒层 `readConfigAt` 也不重复记，只由决策层留一条 `skip(no-codex-binding)`。
- `cli/src/codex-auto-wake.ts`：`CodexAutoWakeSkipReason` 增 `no-codex-binding`；`harnessMismatch` 入参泛化为 `identityRefusal: { reason, detail }`。
- `cli/src/wake-diagnosis.ts`：`no-codex-binding` 时不再追加「本机还没有为 codex 记下任何加入绑定——重跑接入包」提示（那句正是反向引导）。

## 测试证据

`cli/test/codex-session-identity.test.ts` 新增 `pins #971` 组（11 条），`cli/test/codex-auto-wake.test.ts` 新增 piggo 现场端到端 1 条：

- (a) 同 cwd 两个 claude 绑定 + 0 codex ⇒ `no-codex-binding`，detail 不含 ambiguous / 「只能猜出其中一个」/ 「重新跑一遍」
- (a′) 老绑定已被替换、只剩 config 残留 ⇒ `harness-mismatch`，不含 ambiguous，不认领残留
- (b) 一 claude 一 codex ⇒ 认领 codex 那个（join-binding 档）；(b′) MCP 档两身份一 claude 一无主 ⇒ 认领无主那个
- (c) 两个 codex 绑定 ⇒ `ambiguous-binding`；(c′) 两份无绑定老配置 + 一份 claude ⇒ `ambiguous` 且只数 2 个
- (d) 修法文案 `party join --harness codex --yes`，含「可选」，不含 `party init` / 「重跑」
- 唤醒层：piggo 现场 ⇒ 恰一条 `skip(no-codex-binding)`，日志不含 ambiguous / no-agent-token / 「解析不出会话身份」

```
cd cli && bunx tsc --noEmit                                              # 通过
bun test test/codex-session-identity.test.ts test/codex-auto-wake.test.ts  # 91 pass / 0 fail
bun test test/hook-install.test.ts test/join.test.ts test/join-binding.test.ts \
         test/codex-stop-wake.test.ts test/wake-diagnosis.test.ts test/doctor-plugin.test.ts  # 全绿
```

变异自检：把 ⑤ 档的 harness 过滤短路成恒 false ⇒ (a)、(c′)、cwd 唯一认领、无 cwd 全 claude、唤醒层 piggo 共 5 条红；恢复后全绿。

Closes #971

https://claude.ai/code/session_01Az8CnUpayZzqpi1sh32Ssi


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改进**
  - 优化 Codex 身份识别，会优先筛选属于 Codex 的有效绑定，减少与其他工具绑定冲突导致的误判。
  - 在设备未配置 Codex 绑定时，自动唤醒会安静跳过，不再误报身份歧义或引导重复接入。
  - 唤醒诊断信息更加准确，仅在确实需要时提示重新执行接入流程。
  - 完善了多种绑定场景下的自动唤醒与身份解析验证，提升稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->