### PR TITLE
feat(cli): party claude 支持本机持久化默认启动参数，opt-in 一次不用每次手敲 -- 参数

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ the plugin, then use the AgentParty launcher for a fresh Claude session with liv
 
 ```sh
 party claude <channel>
+# extra Claude flags go after --; set machine-local defaults once so you stop retyping them:
+party claude --default-args -- --dangerously-skip-permissions   # opt-in, printed at every launch
 ```
 
 The Claude shell bundles the Skill, generic MCP tools, a durable channel MCP, and lifecycle hooks

--- a/cli/src/claude-default-args.ts
+++ b/cli/src/claude-default-args.ts
@@ -1,0 +1,130 @@
+// `party claude` 的本机默认启动参数（#978）。
+//
+// 背景：owner 这台机所有 Claude 都是 `claude --dangerously-skip-permissions` 起的；改用
+// `party claude <chan>` 起会话后，每次都得手敲 `-- --dangerously-skip-permissions`，漏一次
+// 就是一个卡在权限确认上的会话。要的是「配一次，之后一条命令就带上」。
+//
+// 硬约束：
+// - `--dangerously-skip-permissions` 是高危 flag，这里**绝不**把任何参数硬编码成无条件默认。
+//   默认参数只来自用户显式写下的配置（opt-in 一次），文案说清这是「本机默认」。
+// - 显式 `-- <args>` 仍然生效：默认在前、显式在后（Claude CLI 后者覆盖）；同名 flag 不重复插。
+// - 存储沿用现有本机偏好机制：和 `codex-auto-wake.json` 放在同一层（`$AGENTPARTY_HOME/`），
+//   同样的 atomicWriteJson、同样用 `home` 注入做测试。
+// - 优先级：配置文件 > 环境变量 `AGENTPARTY_CLAUDE_DEFAULT_ARGS`（兜底）> 无。
+//   和 codex auto-wake 相反（那边 env 优先是为了给子进程递 `off`）；这里文件是用户主动写的
+//   显式意图，不该被一个可能是很久以前 export 在 shell rc 里的变量盖掉。
+
+import { readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { atomicWriteJson } from "./atomic-json";
+
+export const CLAUDE_DEFAULT_ARGS_FILE = "claude-default-args.json";
+export const CLAUDE_DEFAULT_ARGS_ENV = "AGENTPARTY_CLAUDE_DEFAULT_ARGS";
+/** 需要在文案里单独点名的高危 flag：配了它就等于本机所有 `party claude` 会话都跳权限。 */
+export const CLAUDE_DANGEROUS_FLAGS = ["--dangerously-skip-permissions"] as const;
+
+export type ClaudeDefaultArgsSource = "config" | "env" | "none";
+
+export interface ClaudeDefaultArgsResolution {
+  args: string[];
+  source: ClaudeDefaultArgsSource;
+  /** 来源的人类可读描述：配置文件路径，或环境变量名；`none` 时是「没配置时该写哪个文件」。 */
+  origin: string;
+}
+
+export function claudeDefaultArgsPath(home: string): string {
+  return join(home, CLAUDE_DEFAULT_ARGS_FILE);
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
+/** 读配置文件里的默认参数；文件不存在 / 不是合法形状 → null（当没设过）。空数组视为「显式清空」。 */
+export function readClaudeDefaultArgs(home: string): string[] | null {
+  try {
+    const value = JSON.parse(readFileSync(claudeDefaultArgsPath(home), "utf8")) as unknown;
+    if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+    const args = (value as { args?: unknown }).args;
+    return isStringArray(args) ? [...args] : null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeClaudeDefaultArgs(home: string, args: string[]): void {
+  atomicWriteJson(claudeDefaultArgsPath(home), { version: 1, args: [...args] });
+}
+
+/** 清空 = 删文件，而不是写空数组：这样才是「恢复原样」（含环境变量兜底重新生效）。 */
+export function clearClaudeDefaultArgs(home: string): void {
+  rmSync(claudeDefaultArgsPath(home), { force: true });
+}
+
+/** 环境变量按空白切分；不支持引号——需要带空格的值请写配置文件。空串 → null。 */
+export function parseClaudeDefaultArgsEnv(value: unknown): string[] | null {
+  if (typeof value !== "string") return null;
+  const parts = value.trim().split(/\s+/).filter((part) => part !== "");
+  return parts.length === 0 ? null : parts;
+}
+
+export function resolveClaudeDefaultArgs(
+  env: NodeJS.ProcessEnv,
+  home: string,
+): ClaudeDefaultArgsResolution {
+  const path = claudeDefaultArgsPath(home);
+  const fromConfig = readClaudeDefaultArgs(home);
+  if (fromConfig !== null) return { args: fromConfig, source: "config", origin: path };
+  const fromEnv = parseClaudeDefaultArgsEnv(env[CLAUDE_DEFAULT_ARGS_ENV]);
+  if (fromEnv !== null) {
+    return { args: fromEnv, source: "env", origin: `环境变量 ${CLAUDE_DEFAULT_ARGS_ENV}` };
+  }
+  return { args: [], source: "none", origin: path };
+}
+
+/** `--model=sonnet` → `--model`；非 flag 返回 null。 */
+function flagName(token: string): string | null {
+  if (!token.startsWith("-") || token === "-" || token === "--") return null;
+  const eq = token.indexOf("=");
+  return eq === -1 ? token : token.slice(0, eq);
+}
+
+/**
+ * 把参数切成「一个 flag + 它后面紧跟的非 flag 值」的组；开头的裸位置参数自成一组。
+ * 这样 `--model sonnet` 作为整体被去重，而不是只删掉 `--model` 留下一个孤零零的 `sonnet`。
+ */
+function groupArgs(args: string[]): string[][] {
+  const groups: string[][] = [];
+  for (const token of args) {
+    const last = groups[groups.length - 1];
+    if (flagName(token) !== null || last === undefined || flagName(last[0]!) === null) {
+      groups.push([token]);
+    } else {
+      last.push(token);
+    }
+  }
+  return groups;
+}
+
+/**
+ * 默认参数在前、显式参数在后。显式里已经出现过同名 flag 的默认组整组丢掉——
+ * 既避免 `--dangerously-skip-permissions --dangerously-skip-permissions` 这种重复，
+ * 也让 `--model opus` 显式覆盖默认的 `--model sonnet` 时不留下残值。
+ */
+export function mergeClaudeArgs(defaultArgs: string[], explicitArgs: string[]): string[] {
+  if (defaultArgs.length === 0) return [...explicitArgs];
+  const explicitFlags = new Set(
+    explicitArgs.map(flagName).filter((name): name is string => name !== null),
+  );
+  const kept = groupArgs(defaultArgs)
+    .filter((group) => {
+      const name = flagName(group[0]!);
+      return name === null || !explicitFlags.has(name);
+    })
+    .flat();
+  return [...kept, ...explicitArgs];
+}
+
+export function hasDangerousClaudeFlag(args: string[]): boolean {
+  return args.some((arg) => (CLAUDE_DANGEROUS_FLAGS as readonly string[]).includes(arg));
+}

--- a/cli/src/commands/claude-launch.ts
+++ b/cli/src/commands/claude-launch.ts
@@ -1,5 +1,15 @@
 import { spawnSync } from "node:child_process";
 import { isHelpArg } from "../args";
+import {
+  CLAUDE_DEFAULT_ARGS_ENV,
+  claudeDefaultArgsPath,
+  clearClaudeDefaultArgs,
+  hasDangerousClaudeFlag,
+  mergeClaudeArgs,
+  resolveClaudeDefaultArgs,
+  writeClaudeDefaultArgs,
+} from "../claude-default-args";
+import { agentpartyHome } from "../config";
 import { isSlug } from "../validation";
 import {
   inspectClaudePluginReadiness,
@@ -17,12 +27,22 @@ export const CLAUDE_CHANNEL_OPT_IN_ENV = "AGENTPARTY_CLAUDE_CHANNEL_OPT_IN";
  */
 export const CLAUDE_LIFECYCLE_OPT_IN_ENV = "AGENTPARTY_CLAUDE_LIFECYCLE_OPT_IN";
 
+const USAGE = "usage: party claude [channel] [-- <claude args...>] | --default-args -- [<claude args...>] | --show-default-args";
+
 const HELP = `usage: party claude [channel] [-- <claude args...>]
+       party claude --default-args -- <claude args...>   # 设为本机默认启动参数（配一次）
+       party claude --default-args --                    # 清空本机默认
+       party claude --show-default-args                  # 查看本机默认及其来源
 
 Start Claude Code with the AgentParty Marketplace Channel explicitly armed.
 Before launch, require the enabled plugin, an agent token, channel access, and
 no existing durable listener. Claude Cross-session uses party bridge claude
-instead; do not stack the two launch paths.`;
+instead; do not stack the two launch paths.
+
+Default launch args are opt-in per machine and never hard-coded: only what you
+wrote with --default-args (file: $AGENTPARTY_HOME/claude-default-args.json;
+fallback env ${CLAUDE_DEFAULT_ARGS_ENV}, lower priority) is prepended before your
+explicit -- args. The launcher prints the defaults and their source every time.`;
 
 export interface ClaudeLaunchResult {
   status: number | null;
@@ -35,6 +55,9 @@ export interface ClaudeLaunchDependencies {
     listener: ClaudePluginDoctorReport["channel"]["listener"];
   }>;
   launch(args: string[], env: NodeJS.ProcessEnv): ClaudeLaunchResult;
+  /** 本机偏好根（默认 `agentpartyHome(env)`）；测试用临时目录注入。 */
+  home?: string;
+  env?: NodeJS.ProcessEnv;
 }
 
 const defaultDependencies: ClaudeLaunchDependencies = {
@@ -49,9 +72,10 @@ export function claudeLaunchPlan(
   channel: string | undefined,
   claudeArgs: string[],
   env: NodeJS.ProcessEnv = process.env,
+  defaultArgs: string[] = [],
 ): { args: string[]; env: NodeJS.ProcessEnv } {
   return {
-    args: ["--channels", CLAUDE_CHANNEL_PLUGIN, ...claudeArgs],
+    args: ["--channels", CLAUDE_CHANNEL_PLUGIN, ...mergeClaudeArgs(defaultArgs, claudeArgs)],
     env: {
       ...env,
       [CLAUDE_CHANNEL_OPT_IN_ENV]: "1",
@@ -59,6 +83,48 @@ export function claudeLaunchPlan(
       ...(channel === undefined ? {} : { AGENTPARTY_CHANNEL: channel }),
     },
   };
+}
+
+function dangerousFlagNotice(args: string[]): string | null {
+  if (!hasDangerousClaudeFlag(args)) return null;
+  return "注意：--dangerously-skip-permissions 会让 Claude 跳过所有权限确认。这是你在本机显式配置的默认，AgentParty 从不替你打开它；不想要了就 `party claude --default-args --` 清空。";
+}
+
+function runSetDefaultArgs(home: string, args: string[]): number {
+  const path = claudeDefaultArgsPath(home);
+  if (args.length === 0) {
+    clearClaudeDefaultArgs(home);
+    console.log(`已清空本机 \`party claude\` 的默认启动参数（删除 ${path}）；之后只带你显式写在 -- 后面的参数。`);
+    return 0;
+  }
+  writeClaudeDefaultArgs(home, args);
+  console.log(
+    `已把以下参数设为本机 \`party claude\` 的默认启动参数（由你显式配置，写在 ${path}）：\n` +
+      `  ${args.join(" ")}\n` +
+      "之后每次 `party claude <channel>` 都会自动带上；显式 `-- <args>` 追加在默认之后（同名 flag 以显式为准）。\n" +
+      "清空：`party claude --default-args --`；查看：`party claude --show-default-args`。",
+  );
+  const notice = dangerousFlagNotice(args);
+  if (notice !== null) console.log(notice);
+  return 0;
+}
+
+function runShowDefaultArgs(env: NodeJS.ProcessEnv, home: string): number {
+  const resolution = resolveClaudeDefaultArgs(env, home);
+  if (resolution.source === "none") {
+    console.log(`未配置本机默认启动参数（文件 ${resolution.origin} 不存在，环境变量 ${CLAUDE_DEFAULT_ARGS_ENV} 未设）。`);
+    console.log("设置：`party claude --default-args -- <claude args...>`");
+    return 0;
+  }
+  console.log(`默认参数：${resolution.args.join(" ")}（来自 ${resolution.origin}）`);
+  console.log(
+    resolution.source === "config"
+      ? "这是本机显式配置的默认；清空：`party claude --default-args --`"
+      : `这是环境变量兜底；写配置文件会覆盖它：\`party claude --default-args -- <claude args...>\``,
+  );
+  const notice = dangerousFlagNotice(resolution.args);
+  if (notice !== null) console.log(notice);
+  return 0;
 }
 
 export async function run(
@@ -69,11 +135,23 @@ export async function run(
     console.log(HELP);
     return 0;
   }
+  const env = deps.env ?? process.env;
+  const home = deps.home ?? agentpartyHome(env);
   const separator = argv.indexOf("--");
   const ownArgs = separator === -1 ? argv : argv.slice(0, separator);
   const claudeArgs = separator === -1 ? [] : argv.slice(separator + 1);
+  if (ownArgs.length === 1 && ownArgs[0] === "--default-args") {
+    if (separator === -1) {
+      console.error("party claude --default-args 需要 `--`：`--default-args -- <claude args...>` 设置，`--default-args --` 清空");
+      return 1;
+    }
+    return runSetDefaultArgs(home, claudeArgs);
+  }
+  if (ownArgs.length === 1 && ownArgs[0] === "--show-default-args" && separator === -1) {
+    return runShowDefaultArgs(env, home);
+  }
   if (ownArgs.length > 1 || ownArgs.some((arg) => arg.startsWith("-"))) {
-    console.error("usage: party claude [channel] [-- <claude args...>]");
+    console.error(USAGE);
     return 1;
   }
   const channel = ownArgs[0];
@@ -99,7 +177,14 @@ export async function run(
     console.error(`AgentParty Channel is not launch-ready (${detail}); run: party doctor claude-plugin --json`);
     return 1;
   }
-  const plan = claudeLaunchPlan(channel, claudeArgs);
+  const defaults = resolveClaudeDefaultArgs(env, home);
+  if (defaults.args.length > 0) {
+    // 让人一眼知道这个会话带了什么默认（尤其是跳权限），以及它是从哪来的。
+    console.log(`默认参数：${defaults.args.join(" ")}（来自 ${defaults.origin}）`);
+    const notice = dangerousFlagNotice(defaults.args);
+    if (notice !== null) console.log(notice);
+  }
+  const plan = claudeLaunchPlan(channel, claudeArgs, env, defaults.args);
   const result = deps.launch(plan.args, plan.env);
   if (result.error !== undefined) {
     console.error(`could not start Claude Code: ${result.error.message}`);

--- a/cli/test/claude-launch-default-args.test.ts
+++ b/cli/test/claude-launch-default-args.test.ts
@@ -1,0 +1,264 @@
+// #978：`party claude` 的本机默认启动参数（opt-in 一次）。
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  CLAUDE_DEFAULT_ARGS_ENV,
+  claudeDefaultArgsPath,
+  clearClaudeDefaultArgs,
+  mergeClaudeArgs,
+  readClaudeDefaultArgs,
+  resolveClaudeDefaultArgs,
+  writeClaudeDefaultArgs,
+} from "../src/claude-default-args";
+import {
+  CLAUDE_CHANNEL_PLUGIN,
+  claudeLaunchPlan,
+  run,
+  type ClaudeLaunchDependencies,
+} from "../src/commands/claude-launch";
+
+const SKIP = "--dangerously-skip-permissions";
+
+let home: string;
+let logs: string[];
+let errors: string[];
+const originalLog = console.log;
+const originalError = console.error;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "agentparty-claude-defaults-"));
+  logs = [];
+  errors = [];
+  console.log = (...args: unknown[]) => logs.push(args.map(String).join(" "));
+  console.error = (...args: unknown[]) => errors.push(args.map(String).join(" "));
+});
+
+afterEach(() => {
+  console.log = originalLog;
+  console.error = originalError;
+  rmSync(home, { recursive: true, force: true });
+});
+
+function launcher(env: NodeJS.ProcessEnv = {}) {
+  const calls: Array<{ args: string[]; env: NodeJS.ProcessEnv }> = [];
+  const deps: ClaudeLaunchDependencies = {
+    preflight: async () => ({ blockers: ["listener_not_observed"], listener: "not_observed" }),
+    launch(args, launchEnv) {
+      calls.push({ args, env: launchEnv });
+      return { status: 0 };
+    },
+    home,
+    env,
+  };
+  return { deps, calls };
+}
+
+describe("claude default args storage", () => {
+  test("lives next to codex-auto-wake.json under the agentparty home and is opt-in only", () => {
+    expect(claudeDefaultArgsPath(home)).toBe(join(home, "claude-default-args.json"));
+    expect(existsSync(claudeDefaultArgsPath(home))).toBe(false);
+    expect(readClaudeDefaultArgs(home)).toBeNull();
+    // 无配置、无环境变量 ⇒ 空；绝不给高危 flag 一个硬编码默认。
+    expect(resolveClaudeDefaultArgs({}, home)).toEqual({
+      args: [],
+      source: "none",
+      origin: claudeDefaultArgsPath(home),
+    });
+  });
+
+  test("round-trips through the config file and reports the file as the source", () => {
+    writeClaudeDefaultArgs(home, [SKIP, "--model", "sonnet"]);
+    const raw = JSON.parse(readFileSync(claudeDefaultArgsPath(home), "utf8")) as unknown;
+    expect(raw).toEqual({ version: 1, args: [SKIP, "--model", "sonnet"] });
+    expect(resolveClaudeDefaultArgs({}, home)).toEqual({
+      args: [SKIP, "--model", "sonnet"],
+      source: "config",
+      origin: claudeDefaultArgsPath(home),
+    });
+  });
+
+  test("env var is a fallback with lower priority than the file", () => {
+    const env = { [CLAUDE_DEFAULT_ARGS_ENV]: `${SKIP} --model opus` };
+    expect(resolveClaudeDefaultArgs(env, home)).toMatchObject({
+      args: [SKIP, "--model", "opus"],
+      source: "env",
+    });
+    writeClaudeDefaultArgs(home, ["--model", "sonnet"]);
+    expect(resolveClaudeDefaultArgs(env, home)).toMatchObject({
+      args: ["--model", "sonnet"],
+      source: "config",
+    });
+  });
+
+  test("clearing removes the file so the machine is back to its original state", () => {
+    writeClaudeDefaultArgs(home, [SKIP]);
+    clearClaudeDefaultArgs(home);
+    expect(existsSync(claudeDefaultArgsPath(home))).toBe(false);
+    expect(resolveClaudeDefaultArgs({}, home).args).toEqual([]);
+    // 再清一次不报错
+    clearClaudeDefaultArgs(home);
+  });
+
+  test("a corrupt or malformed file is treated as unset, never as arbitrary args", () => {
+    writeFileSync(claudeDefaultArgsPath(home), "{ not json");
+    expect(readClaudeDefaultArgs(home)).toBeNull();
+    writeFileSync(claudeDefaultArgsPath(home), JSON.stringify({ version: 1, args: [SKIP, 3] }));
+    expect(readClaudeDefaultArgs(home)).toBeNull();
+    writeFileSync(claudeDefaultArgsPath(home), JSON.stringify([SKIP]));
+    expect(readClaudeDefaultArgs(home)).toBeNull();
+  });
+});
+
+describe("mergeClaudeArgs", () => {
+  test("defaults first, explicit after; nothing to merge leaves explicit untouched", () => {
+    expect(mergeClaudeArgs([], ["--model", "sonnet"])).toEqual(["--model", "sonnet"]);
+    expect(mergeClaudeArgs([SKIP], ["--model", "sonnet"])).toEqual([SKIP, "--model", "sonnet"]);
+  });
+
+  test("a default flag already given explicitly is not inserted twice", () => {
+    expect(mergeClaudeArgs([SKIP], [SKIP])).toEqual([SKIP]);
+    expect(mergeClaudeArgs([SKIP, "--verbose"], ["--model", "opus", SKIP])).toEqual([
+      "--verbose",
+      "--model",
+      "opus",
+      SKIP,
+    ]);
+  });
+
+  test("an explicit valued flag drops the whole default group, not just the flag token", () => {
+    expect(mergeClaudeArgs(["--model", "sonnet", SKIP], ["--model", "opus"])).toEqual([
+      SKIP,
+      "--model",
+      "opus",
+    ]);
+    expect(mergeClaudeArgs(["--model", "sonnet"], ["--model=opus"])).toEqual(["--model=opus"]);
+  });
+});
+
+describe("party claude launch with defaults", () => {
+  test("no config ⇒ args unchanged and no defaults line printed", async () => {
+    const { deps, calls } = launcher();
+    expect(await run(["dev", "--", "--model", "sonnet"], deps)).toBe(0);
+    expect(calls[0]!.args).toEqual(["--channels", CLAUDE_CHANNEL_PLUGIN, "--model", "sonnet"]);
+    expect(logs.some((line) => line.includes("默认参数"))).toBe(false);
+  });
+
+  test("configured defaults go after --channels <plugin> and before explicit -- args", async () => {
+    writeClaudeDefaultArgs(home, [SKIP]);
+    const { deps, calls } = launcher();
+    expect(await run(["dev", "--", "--model", "sonnet"], deps)).toBe(0);
+    expect(calls[0]!.args).toEqual([
+      "--channels",
+      CLAUDE_CHANNEL_PLUGIN,
+      SKIP,
+      "--model",
+      "sonnet",
+    ]);
+    expect(calls[0]!.env.AGENTPARTY_CHANNEL).toBe("dev");
+  });
+
+  test("bare `party claude <chan>` picks up the defaults — the whole point of #978", async () => {
+    writeClaudeDefaultArgs(home, [SKIP]);
+    const { deps, calls } = launcher();
+    expect(await run(["ludo"], deps)).toBe(0);
+    expect(calls[0]!.args).toEqual(["--channels", CLAUDE_CHANNEL_PLUGIN, SKIP]);
+  });
+
+  test("explicit arg duplicating a default is not inserted twice", async () => {
+    writeClaudeDefaultArgs(home, [SKIP]);
+    const { deps, calls } = launcher();
+    expect(await run(["dev", "--", SKIP, "--model", "sonnet"], deps)).toBe(0);
+    expect(calls[0]!.args).toEqual([
+      "--channels",
+      CLAUDE_CHANNEL_PLUGIN,
+      SKIP,
+      "--model",
+      "sonnet",
+    ]);
+    expect(calls[0]!.args.filter((arg) => arg === SKIP)).toHaveLength(1);
+  });
+
+  test("launch output names the defaults, their source file, and the skip-permissions warning", async () => {
+    writeClaudeDefaultArgs(home, [SKIP]);
+    const { deps } = launcher();
+    await run(["dev"], deps);
+    const line = logs.find((entry) => entry.startsWith("默认参数："));
+    expect(line).toBe(`默认参数：${SKIP}（来自 ${claudeDefaultArgsPath(home)}）`);
+    expect(logs.some((entry) => entry.includes("跳过所有权限确认") && entry.includes("本机显式配置的默认"))).toBe(true);
+  });
+
+  test("env fallback applies when no file exists and is reported as the env source", async () => {
+    const { deps, calls } = launcher({ [CLAUDE_DEFAULT_ARGS_ENV]: "--model haiku" });
+    await run(["dev"], deps);
+    expect(calls[0]!.args).toEqual(["--channels", CLAUDE_CHANNEL_PLUGIN, "--model", "haiku"]);
+    expect(logs.find((entry) => entry.startsWith("默认参数："))).toBe(
+      `默认参数：--model haiku（来自 环境变量 ${CLAUDE_DEFAULT_ARGS_ENV}）`,
+    );
+  });
+
+  test("claudeLaunchPlan without defaults keeps the original shape", () => {
+    expect(claudeLaunchPlan("dev", ["--model", "sonnet"], {}).args).toEqual([
+      "--channels",
+      CLAUDE_CHANNEL_PLUGIN,
+      "--model",
+      "sonnet",
+    ]);
+    expect(claudeLaunchPlan(undefined, [], {}, [SKIP]).args).toEqual(["--channels", CLAUDE_CHANNEL_PLUGIN, SKIP]);
+  });
+});
+
+describe("party claude --default-args / --show-default-args", () => {
+  test("--default-args -- <args> writes the file, says it is a machine-local default, and does not launch", async () => {
+    const { deps, calls } = launcher();
+    expect(await run(["--default-args", "--", SKIP], deps)).toBe(0);
+    expect(calls).toHaveLength(0);
+    expect(readClaudeDefaultArgs(home)).toEqual([SKIP]);
+    expect(logs.join("\n")).toContain("本机 `party claude` 的默认启动参数");
+    expect(logs.join("\n")).toContain("由你显式配置");
+    expect(logs.join("\n")).toContain(claudeDefaultArgsPath(home));
+    expect(logs.join("\n")).toContain("跳过所有权限确认");
+  });
+
+  test("--default-args -- clears and a later launch is back to the original args", async () => {
+    writeClaudeDefaultArgs(home, [SKIP]);
+    const { deps, calls } = launcher();
+    expect(await run(["--default-args", "--"], deps)).toBe(0);
+    expect(existsSync(claudeDefaultArgsPath(home))).toBe(false);
+    expect(logs.join("\n")).toContain("已清空");
+
+    logs = [];
+    expect(await run(["dev", "--", "--model", "sonnet"], deps)).toBe(0);
+    expect(calls[0]!.args).toEqual(["--channels", CLAUDE_CHANNEL_PLUGIN, "--model", "sonnet"]);
+    expect(logs.some((line) => line.includes("默认参数"))).toBe(false);
+  });
+
+  test("--default-args without -- is a usage error and writes nothing", async () => {
+    const { deps, calls } = launcher();
+    expect(await run(["--default-args"], deps)).toBe(1);
+    expect(await run(["--default-args", SKIP], deps)).toBe(1);
+    expect(calls).toHaveLength(0);
+    expect(existsSync(claudeDefaultArgsPath(home))).toBe(false);
+    expect(errors.some((line) => line.includes("--default-args"))).toBe(true);
+  });
+
+  test("--show-default-args reports unset, then the configured args with their file", async () => {
+    const { deps, calls } = launcher();
+    expect(await run(["--show-default-args"], deps)).toBe(0);
+    expect(logs.join("\n")).toContain("未配置本机默认启动参数");
+
+    logs = [];
+    writeClaudeDefaultArgs(home, [SKIP, "--model", "sonnet"]);
+    expect(await run(["--show-default-args"], deps)).toBe(0);
+    expect(logs[0]).toBe(`默认参数：${SKIP} --model sonnet（来自 ${claudeDefaultArgsPath(home)}）`);
+    expect(calls).toHaveLength(0);
+  });
+
+  test("--show-default-args with a channel or -- is still rejected as ambiguous", async () => {
+    const { deps, calls } = launcher();
+    expect(await run(["dev", "--show-default-args"], deps)).toBe(1);
+    expect(await run(["--show-default-args", "--"], deps)).toBe(1);
+    expect(calls).toHaveLength(0);
+  });
+});

--- a/cli/test/claude-launch.test.ts
+++ b/cli/test/claude-launch.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   CLAUDE_CHANNEL_OPT_IN_ENV,
   CLAUDE_CHANNEL_PLUGIN,
@@ -11,12 +14,16 @@ import {
 describe("party claude launcher", () => {
   test("arms exactly one Marketplace Channel launch and forwards Claude args", async () => {
     const calls: Array<{ args: string[]; env: NodeJS.ProcessEnv }> = [];
+    // 隔离本机偏好：这台机可能配过 `party claude --default-args`（#978），不能影响这里的精确断言。
+    const home = mkdtempSync(join(tmpdir(), "agentparty-claude-launch-"));
     const deps: ClaudeLaunchDependencies = {
       preflight: async () => ({ blockers: ["listener_not_observed"], listener: "not_observed" }),
       launch(args, env) {
         calls.push({ args, env });
         return { status: 7 };
       },
+      home,
+      env: {},
     };
 
     expect(await run(["dev", "--", "--model", "sonnet"], deps)).toBe(7);

--- a/plugins/agentparty/skills/agentparty/SKILL.md
+++ b/plugins/agentparty/skills/agentparty/SKILL.md
@@ -197,7 +197,13 @@ The Marketplace plugin packages this skill with two thin platform shells. Codex 
 generic `party mcp` entry. Claude also receives lifecycle hooks plus a declared
 `agentparty-channel` server backed by `party claude-channel`. Start a fresh Claude session with
 `party claude <channel>` to let durable channel events enter the open
-main session without waiting for the model to poll. The plugin still requires the `party` release
+main session without waiting for the model to poll. Extra Claude flags go after `--`
+(`party claude <channel> -- --model sonnet`); to stop retyping them, set machine-local defaults once
+with `party claude --default-args -- <claude args...>` (stored in
+`$AGENTPARTY_HOME/claude-default-args.json`, prepended before explicit `--` args, printed with
+their source at every launch; `--default-args --` clears, `--show-default-args` inspects). Nothing
+is defaulted unless you wrote it there — `--dangerously-skip-permissions` in particular is only ever
+a default you opted into yourself. The plugin still requires the `party` release
 binary: it is the install/discovery and lifecycle shell, not a second implementation of auth,
 config, transport, topology, or process supervision. Claude installs it disabled because enabling
 it opens an external service connection; configure `party` before enabling it.

--- a/skills/agentparty/SKILL.md
+++ b/skills/agentparty/SKILL.md
@@ -197,7 +197,13 @@ The Marketplace plugin packages this skill with two thin platform shells. Codex 
 generic `party mcp` entry. Claude also receives lifecycle hooks plus a declared
 `agentparty-channel` server backed by `party claude-channel`. Start a fresh Claude session with
 `party claude <channel>` to let durable channel events enter the open
-main session without waiting for the model to poll. The plugin still requires the `party` release
+main session without waiting for the model to poll. Extra Claude flags go after `--`
+(`party claude <channel> -- --model sonnet`); to stop retyping them, set machine-local defaults once
+with `party claude --default-args -- <claude args...>` (stored in
+`$AGENTPARTY_HOME/claude-default-args.json`, prepended before explicit `--` args, printed with
+their source at every launch; `--default-args --` clears, `--show-default-args` inspects). Nothing
+is defaulted unless you wrote it there — `--dangerously-skip-permissions` in particular is only ever
+a default you opted into yourself. The plugin still requires the `party` release
 binary: it is the install/discovery and lifecycle shell, not a second implementation of auth,
 config, transport, topology, or process supervision. Claude installs it disabled because enabling
 it opens an external service connection; configure `party` before enabling it.


### PR DESCRIPTION
## 诉求

owner 这台机所有 Claude 都是 `claude --dangerously-skip-permissions` 起的；改用 `party claude <chan>` 后每次都得手敲 `-- --dangerously-skip-permissions`，漏一次就是一个卡在权限确认上的会话。要的是**配一次，之后一条命令就带上**。

## 设计

| 命令 | 作用 |
|---|---|
| `party claude --default-args -- <claude args...>` | 写入本机默认（文案明说：由你显式配置的本机默认；含 `--dangerously-skip-permissions` 时额外警告） |
| `party claude --default-args --` | 清空 = 删文件，恢复原样 |
| `party claude --show-default-args` | 查看默认参数与来源 |
| `party claude <chan> [-- <args>]` | `["--channels", PLUGIN, ...默认, ...显式]`，每次启动打印 `默认参数：…（来自 <文件>）` |

- **存储**沿用 `party hook codex-autowake` 同一套本机偏好机制：`$AGENTPARTY_HOME/claude-default-args.json`（`{version:1,args:[...]}`，`atomicWriteJson` 0600，与 `codex-auto-wake.json` 同层），`home` 注入可测。新模块 `cli/src/claude-default-args.ts`。
- **绝不硬编码任何默认**：无文件、无环境变量 ⇒ args 与改动前一字不差。
- **优先级**：配置文件 > 环境变量 `AGENTPARTY_CLAUDE_DEFAULT_ARGS`（兜底，空白切分）> 无。和 codex-autowake 相反（那边 env 优先是给子进程递 `off`）；这里文件是用户主动写的显式意图，不该被 shell rc 里陈年变量盖掉。
- **合并**：默认在前、显式在后；显式里已有同名 flag 的默认组**整组**丢掉（`--model sonnet` 被 `--model opus` 覆盖时不留下孤零零的 `sonnet`；`--model=opus` 形式也识别）。
- `--default-args` 不带 `--` ⇒ usage 错、一字不写；`--show-default-args` 混入 channel 或 `--` ⇒ 仍按歧义拒绝。
- 坏文件 / 形状不对（非 string 数组、顶层是数组）⇒ 视为未设置，绝不当参数用。

## 测试

`cd cli && bun test test/claude-launch.test.ts test/claude-launch-default-args.test.ts` → 25 pass / 0 fail；`bun test test/cli.test.ts` 一并 54 pass。`bunx tsc --noEmit` 通过。`bun run sync:plugin` 后镜像已同步。

覆盖 issue 列的全部用例：无配置 args 不变；有配置插在 `--channels <plugin>` 之后、显式 `--` 之前；裸 `party claude <chan>` 也带上；显式与默认重复不重复插入；`--default-args --` 清空后启动恢复原样且不再打印提示；启动输出含 `默认参数：--dangerously-skip-permissions（来自 <路径>）` 与跳权限警告；env 兜底与优先级；坏文件；`--default-args` 缺 `--` 拒绝；`--show-default-args` 未设/已设两态。

**变异自检**：把 `claudeLaunchPlan` 里的 `...mergeClaudeArgs(defaultArgs, claudeArgs)` 改回 `...claudeArgs` ⇒ 4 个用例红（含「裸 `party claude <chan>` 带上默认」）；恢复后全绿。

原有 `claude-launch.test.ts` 的精确断言改为注入临时 `home` + 空 env，避免这台机真配了默认参数后测试被污染。

## 文档

`skills/agentparty/SKILL.md` 的 `party claude` 段补了默认参数用法（已 `sync:plugin`），README 启动片段补一行。

Closes #978

https://claude.ai/code/session_01Az8CnUpayZzqpi1sh32Ssi
