### PR TITLE
fix(cli): join claude 档收尾加武装监听闸，只有蛰伏档时不印 ✅，who 说清为什么不在线 (#979)

### DIFF
--- a/cli/src/claude-armed-listener.ts
+++ b/cli/src/claude-armed-listener.ts
@@ -1,0 +1,248 @@
+// claude 档「武装监听」探活（issue #979）。
+//
+// 普通 `claude` 起的会话按 #615 设计是 local-only：插件在每个会话里都会拉起
+// `party claude-channel --require-launch-opt-in`，但没有 AGENTPARTY_CLAUDE_CHANNEL_OPT_IN=1 它就走
+// 蛰伏档——只宣告在线、绝不认领投递、**不抢 serve 锁**。真正会接 @ 的只有三种进程：
+//   - `party claude <chan>` 起的会话（设了 opt-in，claude-channel 走 armed 档）；
+//   - `party bridge claude <chan>` 起的会话（自带 claude-channel，不带 --require-launch-opt-in）；
+//   - `party serve <chan> --runner claude` 常驻。
+// 三者**都会抢同一把 "serve" 实例锁**（claude-channel.ts 的注释：serve 与 live-session adapter 是同一
+// 身份/频道的两个投递消费者，绝不能并存）。所以「本机有没有会接 @ 的 Claude 监听」的判据就是
+// 这把锁有没有活着的持有者——进程事实，不是开关，与 #957 的 probeCodexWakeLayer 同一形状。
+// 锁持有者的命令行（ps）只用来**说清是谁**（pid / 起法），不参与判定。
+//
+// 蛰伏档留下的唯一本机痕迹是会话注册表（claude-sessions/，SessionStart 入册）。它只用来把
+// 「为什么不在线」说清楚：本机明明有 N 个 claude 会话在这个频道入册，但全是蛰伏档。
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import {
+  listClaudeSessions,
+  normalizeSessionRegistryIdentity,
+  sessionEntryMatchesIdentity,
+  sessionEntryMatchesServer,
+  type ClaudeSessionRegistryEntry,
+} from "./claude-session-registry";
+import { localAgentConfigsForChannel } from "./config";
+import { defaultInstanceLockDir, instanceLockHolderPid, instanceLockTarget } from "./instance-lock";
+import { healServerUrl } from "./validation";
+
+/** 武装监听是谁起的：`party claude`/`bridge claude` 的 claude-channel、`party serve` 常驻、或认不出。 */
+export type ClaudeArmedListenerLaunch = "claude-channel" | "serve" | "unknown";
+
+export interface ClaudeArmedListenerLiveness {
+  pid: number;
+  launch: ClaudeArmedListenerLaunch;
+}
+
+export interface ClaudeArmedListenerProbe {
+  /** 持有 serve 锁的活进程；null ＝ 本机此刻没有任何会接 @ 的 Claude 监听。 */
+  live: ClaudeArmedListenerLiveness | null;
+  /** 本机在该频道、该实例、该身份下入册且还活着的 claude 会话数。live===null 时它们全是蛰伏档。 */
+  sessions: number;
+}
+
+/** 两条修法命令——结论句里必须原样印出（#979）。 */
+export function claudeArmCommand(channel: string): string {
+  return `party claude ${channel}`;
+}
+export function claudeServeCommand(channel: string): string {
+  return `party serve ${channel} --runner claude`;
+}
+
+/** 读某 pid 的完整命令行；读不到（Windows / ps 不可用 / 进程没了）→ null。 */
+export function processCommandLine(pid: number): string | null {
+  if (process.platform === "win32") return null;
+  try {
+    const r = spawnSync("ps", ["-o", "command=", "-p", String(pid)], { encoding: "utf8", timeout: 1_000 });
+    if (r.error !== undefined || r.status !== 0) return null;
+    const line = r.stdout.trim();
+    return line === "" ? null : line;
+  } catch {
+    return null;
+  }
+}
+
+/** 从命令行认出起法。只认我们自己的两个子命令名；认不出就 unknown，绝不猜。 */
+export function classifyListenerCommand(command: string | null): ClaudeArmedListenerLaunch {
+  if (command === null) return "unknown";
+  if (/\bclaude-channel\b/.test(command)) return "claude-channel";
+  if (/\bserve\b/.test(command)) return "serve";
+  return "unknown";
+}
+
+interface ProbeConfig {
+  server?: unknown;
+  token?: unknown;
+  identity?: { name?: unknown } | null;
+}
+
+function lockTargetOf(config: ProbeConfig | null, channel: string): string | null {
+  if (config === null) return null;
+  const { server, token } = config;
+  if (typeof server !== "string" || typeof token !== "string" || token === "") return null;
+  const healed = healServerUrl(server);
+  return healed === null ? null : instanceLockTarget(healed, token, channel);
+}
+
+function countSessions(
+  entries: ClaudeSessionRegistryEntry[],
+  channel: string,
+  server: unknown,
+  identity: unknown,
+): number {
+  const serverStr = typeof server === "string" ? server : null;
+  const identityStr = typeof identity === "string" ? identity : null;
+  return entries.filter((e) =>
+    e.channel === channel && sessionEntryMatchesServer(e, serverStr) && sessionEntryMatchesIdentity(e, identityStr)
+  ).length;
+}
+
+/**
+ * 本机该 (server, token, channel) 有没有会接 @ 的 Claude 监听——serve 锁的活持有者（#979）。
+ * 与 probeCodexWakeLayer 对等：判据是进程真的在（pid + 出生时间，instanceLockHolderPid 内部核对），
+ * 不是插件装没装、不是 opt-in 开关。config 没有 agent token ⇒ 谈不上监听 ⇒ null。
+ */
+export function probeClaudeArmedListener(input: {
+  lockDir?: string;
+  config: ProbeConfig | null;
+  channel: string;
+  /** 注入点：锁持有者 pid（测试不写真锁时用）。缺省读锁文件 + 探活。 */
+  lockHolder?: (target: string, lockDir: string) => number | null;
+  /** 注入点：pid → 命令行。缺省 ps。 */
+  commandOf?: (pid: number) => string | null;
+  /** 注入点：会话注册表。缺省 listClaudeSessions()。 */
+  sessions?: () => ClaudeSessionRegistryEntry[];
+}): ClaudeArmedListenerProbe {
+  const lockDir = input.lockDir ?? defaultInstanceLockDir();
+  const target = lockTargetOf(input.config, input.channel);
+  let sessions = 0;
+  try {
+    sessions = countSessions(
+      (input.sessions ?? listClaudeSessions)(),
+      input.channel,
+      input.config?.server,
+      input.config?.identity?.name,
+    );
+  } catch {
+    sessions = 0;
+  }
+  if (target === null) return { live: null, sessions };
+  const holder = (input.lockHolder ?? ((t, d) => instanceLockHolderPid("serve", t, d)))(target, lockDir);
+  if (holder === null) return { live: null, sessions };
+  const launch = classifyListenerCommand((input.commandOf ?? processCommandLine)(holder));
+  return { live: { pid: holder, launch }, sessions };
+}
+
+/** ✅ 句里「就能被唤醒」指的是谁——按 pid / 起法说清（#979 修法 3）。 */
+export function describeClaudeArmedListener(live: ClaudeArmedListenerLiveness, channel: string): string {
+  switch (live.launch) {
+    case "claude-channel":
+      return `由 party claude / party bridge claude 起的 Claude 会话（武装监听 party claude-channel，pid ${live.pid}）`;
+    case "serve":
+      return `常驻的 party serve ${channel} --runner claude（pid ${live.pid}）`;
+    case "unknown":
+      return `持有 #${channel} 监听锁的进程（pid ${live.pid}）`;
+  }
+}
+
+/** 没有武装监听时对「本机有哪些 claude 会话」的一句说明。 */
+export function describeDormantClaudeSessions(sessions: number, channel: string): string {
+  return sessions > 0
+    ? `本机在 #${channel} 入册的 ${sessions} 个 claude 会话全是蛰伏档（普通 claude 起的，不接频道消息）`
+    : `本机没有任何 claude 会话在 #${channel} 入册`;
+}
+
+/** 降级结论（#979 修法 2）：不印 ✅，两条命令原样印出。 */
+export function claudeNoArmedListenerLines(identity: string, channel: string, sessions: number): string[] {
+  return [
+    `⚠ 已绑定身份 ${identity}，但这台机现在没有会接 @ 的 Claude 会话。`,
+    `普通 \`claude\` 起的会话不接频道消息（local-only）；要能被 @ 唤醒，用 ${claudeArmCommand(channel)} 起一个会话` +
+      `（或 ${claudeServeCommand(channel)} 常驻）。`,
+    `  ${claudeArmCommand(channel)}`,
+    `  ${claudeServeCommand(channel)}`,
+    `  ${describeDormantClaudeSessions(sessions, channel)}`,
+  ];
+}
+
+// ── party who 那一侧（#979 修法 4）────────────────────────────────────────────
+
+export interface ClaudeDormantDiagnosis {
+  channel: string;
+  /** 频道身份（config.identity.name 原样）。 */
+  identity: string;
+  /** 本机在该频道入册、属于这个身份的存活 claude 会话数（全是蛰伏档）。 */
+  sessions: number;
+}
+
+/**
+ * 本机在 #channel 有蛰伏档 claude 会话、却没有武装监听的身份列表。纯本地：扫 agents/ 下
+ * 绑到该频道的 config → 每个身份看注册表里有没有活会话、serve 锁有没有活持有者。
+ * 有锁持有者（`party claude` / serve 在跑）的身份不列——它不是「只有蛰伏档」。
+ */
+export function diagnoseClaudeDormantSessions(
+  channel: string,
+  server: string,
+  deps: {
+    home?: string;
+    lockDir?: string;
+    sessions?: () => ClaudeSessionRegistryEntry[];
+    lockHolder?: (target: string, lockDir: string) => number | null;
+    readToken?: (path: string) => string | null;
+  } = {},
+): ClaudeDormantDiagnosis[] {
+  const wantedServer = healServerUrl(server);
+  const entries = (deps.sessions ?? listClaudeSessions)();
+  if (entries.length === 0) return [];
+  const readToken = deps.readToken ?? ((path: string) => {
+    try {
+      const parsed = JSON.parse(readFileSync(path, "utf8")) as { token?: unknown };
+      return typeof parsed.token === "string" && parsed.token !== "" ? parsed.token : null;
+    } catch {
+      return null;
+    }
+  });
+  const out: ClaudeDormantDiagnosis[] = [];
+  const seen = new Set<string>();
+  for (const hint of localAgentConfigsForChannel(channel, null, deps.home)) {
+    if (healServerUrl(hint.server) !== wantedServer) continue;
+    const key = normalizeSessionRegistryIdentity(hint.name);
+    if (key === null || seen.has(key)) continue;
+    seen.add(key);
+    const token = readToken(hint.path);
+    const probe = probeClaudeArmedListener({
+      ...(deps.lockDir === undefined ? {} : { lockDir: deps.lockDir }),
+      config: { server: hint.server, token, identity: { name: hint.name } },
+      channel,
+      ...(deps.lockHolder === undefined ? {} : { lockHolder: deps.lockHolder }),
+      sessions: () => entries,
+    });
+    if (probe.live !== null || probe.sessions === 0) continue;
+    out.push({ channel, identity: hint.name, sessions: probe.sessions });
+  }
+  return out;
+}
+
+/** who 的行里已经在线 / 可唤醒的身份不用再解释——只对「不在线」的那些说为什么。 */
+export function claudeDormantToSurface(
+  diags: ClaudeDormantDiagnosis[],
+  rows: { name: string; tier: string }[],
+): ClaudeDormantDiagnosis[] {
+  const reachable = new Set<string>();
+  for (const r of rows) {
+    if (r.tier !== "online" && r.tier !== "wakeable") continue;
+    const key = normalizeSessionRegistryIdentity(r.name);
+    if (key !== null) reachable.add(key);
+  }
+  return diags.filter((d) => {
+    const key = normalizeSessionRegistryIdentity(d.identity);
+    return key === null || !reachable.has(key);
+  });
+}
+
+export function formatClaudeDormantDiagnosis(d: ClaudeDormantDiagnosis): string[] {
+  return [
+    `wake (claude): #${d.channel} 上 ${d.identity} 不在线——${describeDormantClaudeSessions(d.sessions, d.channel)}，` +
+      "普通 `claude` 起的会话不接频道消息（local-only）",
+    `  要能被 @ 唤醒: ${claudeArmCommand(d.channel)}   （或常驻: ${claudeServeCommand(d.channel)}）`,
+  ];
+}

--- a/cli/src/commands/join.ts
+++ b/cli/src/commands/join.ts
@@ -16,8 +16,10 @@
 //  - **幂等**：重复跑不叠加副作用（判重、先探后加、绑定替换本身都幂等，join 只负责正确编排）。
 //  - **「前置条件齐了」≠「唤醒真的会发生」（#957/#961）**：收尾那句 ✅ 承诺的是「@ 一下就叫得醒」，
 //    所以它的判据必须是唤醒层本身——claude 档是插件装到位且版本与 CLI 一致（doctor 的 shell 检查，
-//    版本不一致时 SessionStart 根本没布上）；codex 档是唤醒层**进程真的在**（join 收尾主动拉起，
-//    再探活）。任一没成就不印 ✅，照实说本会话此刻能被怎么叫到。
+//    版本不一致时 SessionStart 根本没布上）**且本机有会接 @ 的武装监听进程**（#979：普通 `claude`
+//    起的会话按 #615 是 local-only 蛰伏档，只有 `party claude` / `bridge claude` / `party serve
+//    --runner claude` 会抢 serve 锁接 @——判据是锁的活持有者，不是开关）；codex 档是唤醒层
+//    **进程真的在**（join 收尾主动拉起，再探活）。任一没成就不印 ✅，照实说本会话此刻能被怎么叫到。
 import { spawnSync } from "node:child_process";
 import { copyFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
@@ -45,6 +47,15 @@ import {
 } from "../codex-auto-wake";
 import { defaultInstanceLockDir, isSameLiveProcess } from "../instance-lock";
 import { listCodexSessions, registerCodexSession } from "../claude-session-registry";
+import {
+  claudeArmCommand,
+  claudeNoArmedListenerLines,
+  claudeServeCommand,
+  describeClaudeArmedListener,
+  describeDormantClaudeSessions,
+  probeClaudeArmedListener,
+  type ClaudeArmedListenerProbe,
+} from "../claude-armed-listener";
 import { findHarnessAncestor } from "../join-binding";
 import {
   CLAUDE_PLUGIN_MIN_VERSION,
@@ -53,6 +64,9 @@ import {
   type ClaudePluginShellInspection,
 } from "./doctor";
 import type { CodexAutoWakeOutcome } from "./hook";
+
+// 与 probeCodexWakeLayer 并排导出：两档的「唤醒层进程探活」都从这里拿（#957 / #979）。
+export { probeClaudeArmedListener };
 
 const JOIN_FLAGS = ["server", "channel", "as", "harness", "mention"];
 const HELP = `usage: AGENTPARTY_TOKEN='<token>' party join --server URL --channel SLUG --as NAME [--harness codex|claude|other] [--mention name] [--yes] [--coexist]
@@ -133,6 +147,12 @@ export interface JoinDeps {
    * 不 shell 出去再解析文本。缺省实现会 spawn 真机 claude，测试换成桩。
    */
   claudePluginShell: () => ClaudePluginShellInspection;
+  /**
+   * claude 档收尾自检（#979）：本机有没有会接 @ 的武装监听——`party claude` / `bridge claude` 起的
+   * claude-channel（非 --require-launch-opt-in 蛰伏档）或 `party serve --runner claude`，三者都持
+   * 同一把 serve 锁。缺省＝probeClaudeArmedListener（锁持有者探活 + ps 认起法 + 注册表数蛰伏档）。
+   */
+  claudeArmedListener: () => ClaudeArmedListenerProbe;
   /**
    * codex 档收尾（#957）：主动拉起唤醒层。缺省＝hook.ts 的 maybeStartCodexAutoWake（与 SessionStart
    * 同一条路径，同一套去重/标记），join 只是多给它一次机会——它此刻已有身份和 token，不必等下次会话。
@@ -502,6 +522,7 @@ function buildJoinGate(
   checkinOk: boolean,
   deps: JoinDeps,
   codexWake: CodexWakeLayerState | null,
+  claudeListener: ClaudeArmedListenerProbe | null,
 ): { steps: GateStep[]; remaining: number; next: { do: string; notes: string[] } | null } {
   const cfg = readConfig();
   const identity = cfg?.identity?.name ?? null;
@@ -577,6 +598,23 @@ function buildJoinGate(
           (codexWake.adoptionNote === null ? "" : `    ⚠ ${codexWake.adoptionNote}`),
       remedy: `新开一个 codex 会话（SessionStart 会重新拉起唤醒层），或手动：party serve ${slug} --runner codex`,
       notes: [why],
+    });
+  }
+  // claude 档（#979）：插件装到位 ≠ 有人接 @。普通 `claude` 起的会话是蛰伏档（#615 local-only），
+  // 只有 `party claude` / `bridge claude` 起的会话或 `party serve --runner claude` 会抢 serve 锁接 @。
+  // 判据是锁的活持有者（进程事实），不是 opt-in 开关。放在最后，同 codex 档的 wake_layer_live。
+  if (harness === "claude" && claudeListener !== null) {
+    const live = claudeListener.live;
+    steps.push({
+      id: "armed_listener_live",
+      ok: live !== null,
+      label: "本机有会接 @ 的 Claude 武装监听（普通 claude 会话是蛰伏档，不接频道消息）",
+      evidence: live === null ? "" : describeClaudeArmedListener(live, slug),
+      remedy: claudeArmCommand(slug),
+      notes: [
+        describeDormantClaudeSessions(claudeListener.sessions, slug),
+        `或常驻：${claudeServeCommand(slug)}`,
+      ],
     });
   }
   const failed = steps.find((s) => !s.ok);
@@ -691,8 +729,19 @@ export async function runJoin(opts: JoinOptions, deps: JoinDeps): Promise<number
   let codexWake: CodexWakeLayerState | null = null;
   if (harness === "codex") codexWake = await bringUpCodexWakeLayer(deps, slug, record);
 
+  // 6c) claude 档（#979）：本机有没有会接 @ 的武装监听。探活失败按「没有」算——不会因此把 join 弄挂，
+  //     但也绝不因探不到就假定有。
+  let claudeListener: ClaudeArmedListenerProbe | null = null;
+  if (harness === "claude") {
+    try {
+      claudeListener = deps.claudeArmedListener();
+    } catch {
+      claudeListener = { live: null, sessions: 0 };
+    }
+  }
+
   // 7) 收尾自检（#926）：这是包的末尾，用户看到的就这一句结论。从本地盘真实状态重判，不信步骤返回码。
-  const gate = buildJoinGate(harness, slug, checkinOk, deps, codexWake);
+  const gate = buildJoinGate(harness, slug, checkinOk, deps, codexWake, claudeListener);
   deps.log("");
   deps.log(`接入自检 · #${slug}`);
   for (const s of gate.steps) {
@@ -702,9 +751,17 @@ export async function runJoin(opts: JoinOptions, deps: JoinDeps): Promise<number
   if (gate.remaining === 0) {
     if (harness === "claude" && claudePluginRestart) {
       // #961：插件刚装/刚更新，当前这个会话还挂着旧的——「要重开」是结论的一部分，不能埋在 warn 里。
+      // #979：重开也得用 party claude 起，普通 claude 起的会话是蛰伏档。
       deps.log(
-        `✅ 全部就绪，差一次重开：claude 插件已是 ${RUNNING_VERSION}，【新开一个 Claude 会话】后 @ ${agentName} 就能唤醒它；` +
+        `✅ 全部就绪，差一次重开：claude 插件已是 ${RUNNING_VERSION}，【用 ${claudeArmCommand(slug)} 新开一个 Claude 会话】后 @ ${agentName} 就能唤醒它；` +
           `当前这个会话还挂着旧插件，不会被唤醒。`,
+      );
+      return 0;
+    }
+    if (harness === "claude" && claudeListener?.live) {
+      // #979 修法 3：✅ 句写明「就能被唤醒」指的是谁（pid / 起法），别让人以为是眼前这个普通会话。
+      deps.log(
+        `✅ 全部就绪：现在 @ ${agentName}，这台机器上${describeClaudeArmedListener(claudeListener.live, slug)}就能被唤醒来协作。`,
       );
       return 0;
     }
@@ -712,6 +769,15 @@ export async function runJoin(opts: JoinOptions, deps: JoinDeps): Promise<number
     return 0;
   }
   const failed = gate.steps.find((s) => !s.ok);
+  if (failed?.id === "armed_listener_live") {
+    // #979：前置条件全齐、唯独本机没有会接 @ 的 Claude 会话。此刻的真实能力是「谁也叫不醒」——
+    // 照实说，把两条命令原样印出来，绝不说「就能被唤醒」。
+    const identity = readConfig()?.identity?.name ?? agentName;
+    for (const line of claudeNoArmedListenerLines(identity, slug, claudeListener?.sessions ?? 0)) deps.log(line);
+    deps.log("");
+    deps.log("在这一步完成之前：@ 你可能不会有任何反应，而且不会有任何报错——别人只会以为你在忙。");
+    return 1;
+  }
   if (failed?.id === "wake_layer_live") {
     // #957：前置条件全齐、唯独唤醒层没起来。此刻的真实能力是 Stop hook 兜底——照实说，绝不说「就能被唤醒」。
     deps.log(`⚠ 接入完成，但唤醒层没起来：${gate.next?.notes[0] ?? "原因不明"}`);
@@ -804,6 +870,8 @@ export async function run(argv: string[]): Promise<number> {
     home: process.env.HOME ?? homedir(),
     codexWakeChecklist: () => buildWakeChecklist(diagnoseCodexWake()),
     claudePluginShell: () => inspectClaudePluginShell(),
+    claudeArmedListener: () =>
+      probeClaudeArmedListener({ lockDir: defaultInstanceLockDir(), config: readConfig(), channel: slug }),
     startCodexWakeLayer: async () => {
       const hook = await import("./hook");
       // 与 SessionStart 完全同一条路径（同一套开关 / 去重 / 标记 / 日志），只是由 join 触发。

--- a/cli/src/commands/who.ts
+++ b/cli/src/commands/who.ts
@@ -4,6 +4,7 @@ import { autoWakeReachable, type AgentActivity, type ListeningVerdict, type Pres
 import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
 import { resolveChannel } from "../config";
 import { diagnoseCodexWake, formatCodexWakeDiagnosis, shouldSurfaceCodexWakeDiagnosis } from "../wake-diagnosis";
+import { claudeDormantToSurface, diagnoseClaudeDormantSessions, formatClaudeDormantDiagnosis } from "../claude-armed-listener";
 import {
   diagnoseTaskLeaseEnforcement,
   formatTaskLeaseEnforcement,
@@ -929,6 +930,18 @@ export async function run(argv: string[]): Promise<number> {
       }
     } catch {
       // 诊断是附赠信息，绝不能把 who 本身弄挂。
+    }
+    // #979：某个身份「不在线」，而本机明明有它的 claude 会话在这个频道入册——那些全是普通 `claude`
+    // 起的蛰伏档（#615 local-only），没有一个会接 @。此前 who 只显示「不在线」，没告诉人为什么；
+    // 这里把原因和两条命令说出来。纯本地读盘（注册表 + agents/ config + serve 锁），失败即闭嘴。
+    try {
+      const dormant = claudeDormantToSurface(diagnoseClaudeDormantSessions(channel, cfg.server), rows);
+      if (dormant.length > 0) {
+        console.log("");
+        for (const d of dormant) for (const line of formatClaudeDormantDiagnosis(d)) console.log(line);
+      }
+    } catch {
+      // 同上：附赠信息。
     }
     return 0;
   } catch (e) {

--- a/cli/test/join.test.ts
+++ b/cli/test/join.test.ts
@@ -9,7 +9,9 @@ import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { BEHAVIOR_CONTRACT_BODY_LINES } from "@agentparty/shared/onboarding";
-import { probeCodexWakeLayer, runJoin, type JoinDeps, type JoinOptions } from "../src/commands/join";
+import { probeClaudeArmedListener, probeCodexWakeLayer, runJoin, type JoinDeps, type JoinOptions } from "../src/commands/join";
+import { classifyListenerCommand } from "../src/claude-armed-listener";
+import { healServerUrl } from "../src/validation";
 import { run as initRun } from "../src/commands/init";
 import { run as hookRun } from "../src/commands/hook";
 import { run as sendRun } from "../src/commands/send";
@@ -19,7 +21,7 @@ import { diagnoseCodexWake } from "../src/wake-diagnosis";
 import { RUNNING_VERSION } from "../src/upgrade";
 import { codexAutoWakeAuth, codexAutoWakeMarkerPath, codexAutoWakeTarget, writeCodexAutoWakeMarker } from "../src/codex-auto-wake";
 import { currentProcessStartedAt, instanceLockTarget } from "../src/instance-lock";
-import { listCodexSessions, registerCodexSession } from "../src/claude-session-registry";
+import { listCodexSessions, registerClaudeSession, registerCodexSession } from "../src/claude-session-registry";
 import { startRestMock, type RestMock } from "./rest-mock";
 
 const PLUGIN = "agentparty@agentparty";
@@ -136,6 +138,8 @@ function deps(record: string[][], behavior: SpawnBehavior, logs: string[]): Join
         },
         inspectBundle: () => ({ valid: true, launcherExecutable: true }),
       }),
+    // claude 武装监听（#979）：默认假装本机有 party claude 起的会话在接 @（happy path）；蛰伏档用例逐个覆盖。
+    claudeArmedListener: () => ({ live: { pid: 5150, launch: "claude-channel" }, sessions: 1 }),
     // codex 唤醒层（#957）：默认假装拉起成功且进程在（happy path）；失败用例逐个覆盖。
     startCodexWakeLayer: async () => ({ action: "start", channel: "dev", cwd: process.cwd(), args: [] }),
     codexWakeLayerLive: async () => ({ pid: 4242, source: "serve-lock" }),
@@ -216,6 +220,12 @@ describe("party join —— 一条命令跑完整段接入（#944）", () => {
     expect(record.some((r) => r[0] === "claude" && r[1] === "plugin" && r[2] === "update")).toBe(false);
     expect(out).toContain("版本与 CLI 一致");
     expect(out).not.toContain("重开");
+
+    // #979：✅ 句写明「就能被唤醒」指的是谁——本机那个 party claude 起的武装监听（pid），不是眼前这个会话。
+    const verdict = logs.find((l) => l.startsWith("✅"));
+    expect(verdict).toContain("pid 5150");
+    expect(verdict).toContain("party claude-channel");
+    expect(out).toContain("✓ 本机有会接 @ 的 Claude 武装监听");
   });
 
   // ★ #961 事故场景：本机插件 0.2.203、CLI 0.2.212。旧 join 只 install（回 already installed，不升级）
@@ -589,5 +599,261 @@ describe("probeCodexWakeLayer —— 唤醒层进程探活（#957）", () => {
     const c = clock();
     writeCodexAutoWakeMarker(marker, { pid: null, started_at: null, claimed_at: 2_000, channel: "dev" });
     expect(await probeCodexWakeLayer({ home, lockDir, config, channel: "dev", alive: () => true, ...c })).toBeNull();
+  });
+});
+
+// ★ #979 事故场景：piggo 机上 14 个 `party claude-channel --require-launch-opt-in` 全是蛰伏档（普通 claude
+//   起的，#615 local-only），插件装好、版本一致、报到成功——旧 join 照印「✅ 就能被唤醒」，@ 了 5 分钟 0 pong。
+//   判据必须是「本机有没有会接 @ 的进程」：serve 锁的活持有者，不是插件状态、不是 opt-in 开关。
+describe("party join claude 档 —— 武装监听闸（#979）", () => {
+  /** 用真锁目录跑真探活（不注入 lockHolder），只把 ps 换成桩；注册表走 AGENTPARTY_HOME 下的真目录。 */
+  function realProbe(lockDir: string, commandOf: (pid: number) => string | null): JoinDeps["claudeArmedListener"] {
+    return () => {
+      // 与生产同一来源：AGENTPARTY_CONFIG 已由 runJoin 指向 join 刚写的 config。
+      const raw = JSON.parse(readFileSync(configPath(), "utf8")) as { server: string; token: string; identity?: { name: string } };
+      return probeClaudeArmedListener({ lockDir, config: raw, channel: "dev", commandOf });
+    };
+  }
+  /** 预置一个普通 claude 会话（SessionStart 入册的形态）：pid 是本进程，所以「活着」。 */
+  function registerDormantSession(sessionId: string, server: string): void {
+    expect(registerClaudeSession({
+      session_id: sessionId,
+      pid: process.pid,
+      display_name: null,
+      channel: "dev",
+      identity: "agent", // mock /api/me 的身份
+      server,
+      cwd: process.cwd(),
+    })).toBe(true);
+  }
+  function lockFileFor(lockDir: string, server: string, token: string): string {
+    return join(lockDir, `serve-${instanceLockTarget(healServerUrl(server)!, token, "dev")}.lock`);
+  }
+
+  test("只有蛰伏档 claude-channel 进程 ⇒ 不印 ✅、不说「就能被唤醒」，两条命令原样印出，并说清本机 N 个会话全是蛰伏档", async () => {
+    mock = startRestMock();
+    const lockDir = mkdtempSync(join(tmpdir(), "party-join-claude-locks-"));
+    registerDormantSession("019f95e8-2c0b-7903-8779-cd102c5ecd4d", mock.url);
+    const record: string[][] = [];
+    const logs: string[] = [];
+    const d = deps(record, {}, logs);
+    // 真探活：锁目录是空的（蛰伏档从不抢 serve 锁）；ps 桩不该被问到（没有持有者）。
+    d.claudeArmedListener = realProbe(lockDir, () => "party claude-channel --require-launch-opt-in");
+    const code = await runJoin(baseOpts({ harnessFlag: "claude" }), d);
+    const out = logs.join("\n");
+    rmSync(lockDir, { recursive: true, force: true });
+
+    // 隔离：config / 身份 / 插件（同版）/ 报到全成，唯独没有武装监听——事故当天就是这个形态。
+    expect(existsSync(configPath())).toBe(true);
+    expect(out).toContain("版本与 CLI 一致");
+    expect(code).toBe(1);
+    expect(out).not.toContain("就能被唤醒");
+    expect(out).not.toContain("全部就绪");
+    expect(out).not.toContain("✅");
+    // 自检那一格是 ✗。
+    expect(out).toContain("✗ 本机有会接 @ 的 Claude 武装监听");
+    // 降级文案：身份已绑、为什么叫不醒、两条命令**原样**印出。
+    expect(out).toContain("已绑定身份 agent，但这台机现在没有会接 @ 的 Claude 会话");
+    expect(out).toContain("local-only");
+    expect(out).toContain("party claude dev");
+    expect(out).toContain("party serve dev --runner claude");
+    // 本机那个普通 claude 会话被数出来了，且说明它是蛰伏档。
+    expect(out).toContain("1 个 claude 会话全是蛰伏档");
+    // 这类失败没有报错——必须明说。
+    expect(out).toContain("别人只会以为你在忙");
+  });
+
+  test("有 party claude 起的武装进程（持 serve 锁的 claude-channel）⇒ ✅ 且指出 pid 与起法", async () => {
+    mock = startRestMock();
+    const lockDir = mkdtempSync(join(tmpdir(), "party-join-claude-locks-"));
+    const record: string[][] = [];
+    const logs: string[] = [];
+    const d = deps(record, {}, logs);
+    const asked: number[] = [];
+    d.claudeArmedListener = () => {
+      // 锁由「本进程」持有（pid + 出生时间都对得上）——这就是 party claude 起的 claude-channel 的形态。
+      const raw = JSON.parse(readFileSync(configPath(), "utf8")) as { server: string; token: string };
+      writeFileSync(lockFileFor(lockDir, raw.server, raw.token), JSON.stringify({ pid: process.pid, id: "t", started_at: currentProcessStartedAt() }));
+      return realProbe(lockDir, (pid) => {
+        asked.push(pid);
+        return "party claude-channel --channel dev";
+      })();
+    };
+    const code = await runJoin(baseOpts({ harnessFlag: "claude" }), d);
+    const out = logs.join("\n");
+    rmSync(lockDir, { recursive: true, force: true });
+
+    expect(code).toBe(0);
+    expect(asked).toEqual([process.pid]);
+    const verdict = logs.find((l) => l.startsWith("✅"));
+    expect(verdict).toBeDefined();
+    expect(verdict).toContain("就能被唤醒");
+    expect(verdict).toContain(`pid ${process.pid}`);
+    expect(verdict).toContain("party claude-channel");
+    expect(out).toContain("✓ 本机有会接 @ 的 Claude 武装监听");
+    expect(out).toContain(`由 party claude / party bridge claude 起的 Claude 会话（武装监听 party claude-channel，pid ${process.pid}）`);
+    expect(out).not.toContain("蛰伏档（普通 claude 起的，不接频道消息）");
+  });
+
+  test("有 serve 锁（party serve --runner claude 常驻）⇒ ✅ 且写明是 serve", async () => {
+    mock = startRestMock();
+    const record: string[][] = [];
+    const logs: string[] = [];
+    const d = deps(record, {}, logs);
+    d.claudeArmedListener = () => ({ live: { pid: 777, launch: "serve" }, sessions: 0 });
+    const code = await runJoin(baseOpts({ harnessFlag: "claude" }), d);
+    expect(code).toBe(0);
+    const verdict = logs.find((l) => l.startsWith("✅"));
+    expect(verdict).toContain("party serve dev --runner claude（pid 777）");
+    expect(verdict).toContain("就能被唤醒");
+  });
+
+  test("锁持有者认不出起法 ⇒ 仍算武装监听（进程事实优先），只是描述退回「持锁进程 pid」", async () => {
+    mock = startRestMock();
+    const record: string[][] = [];
+    const logs: string[] = [];
+    const d = deps(record, {}, logs);
+    d.claudeArmedListener = () => ({ live: { pid: 888, launch: "unknown" }, sessions: 2 });
+    const code = await runJoin(baseOpts({ harnessFlag: "claude" }), d);
+    expect(code).toBe(0);
+    expect(logs.find((l) => l.startsWith("✅"))).toContain("持有 #dev 监听锁的进程（pid 888）");
+  });
+
+  test("探活本身抛异常 ⇒ 按「没有武装监听」处理（绝不因探不到就假定有），结论是降级文案", async () => {
+    mock = startRestMock();
+    const record: string[][] = [];
+    const logs: string[] = [];
+    const d = deps(record, {}, logs);
+    d.claudeArmedListener = () => {
+      throw new Error("ps exploded");
+    };
+    const code = await runJoin(baseOpts({ harnessFlag: "claude" }), d);
+    const out = logs.join("\n");
+    expect(code).toBe(1);
+    expect(out).not.toContain("✅");
+    expect(out).toContain("party claude dev");
+  });
+
+  test("插件旧版且 update 失败 + 无武装监听 ⇒ 第一条修法仍是 plugin update（监听闸放最后，前面没过它的修法没意义）", async () => {
+    mock = startRestMock();
+    const record: string[][] = [];
+    const logs: string[] = [];
+    const d = deps(record, { installedPluginVersion: "0.2.203", failPluginUpdate: true }, logs);
+    d.claudeArmedListener = () => ({ live: null, sessions: 0 });
+    const code = await runJoin(baseOpts({ harnessFlag: "claude" }), d);
+    const out = logs.join("\n");
+    expect(code).toBe(1);
+    expect(nextActionLine(logs)).toBe(`claude plugin update ${PLUGIN}`);
+    // 监听那一格照样 ✗ 列出来，只是不做第一条修法。
+    expect(out).toContain("✗ 本机有会接 @ 的 Claude 武装监听");
+  });
+
+  test("#961 重开文案（#979 修订）：重开要用 party claude 起，不是裸 claude", async () => {
+    mock = startRestMock();
+    const record: string[][] = [];
+    const logs: string[] = [];
+    const code = await runJoin(baseOpts({ harnessFlag: "claude" }), deps(record, { installedPluginVersion: "0.2.203" }, logs));
+    expect(code).toBe(0);
+    const verdict = logs.find((l) => l.startsWith("✅"));
+    expect(verdict).toContain("用 party claude dev 新开一个 Claude 会话");
+  });
+
+  test("codex 档不受影响：不查 claude 武装监听、不印 claude 的降级文案", async () => {
+    mock = startRestMock();
+    const record: string[][] = [];
+    const logs: string[] = [];
+    const d = deps(record, {}, logs);
+    let asked = false;
+    d.claudeArmedListener = () => {
+      asked = true;
+      return { live: null, sessions: 0 };
+    };
+    const code = await runJoin(baseOpts({ harnessFlag: "codex" }), d);
+    expect(code).toBe(0);
+    expect(asked).toBe(false);
+    expect(logs.join("\n")).not.toContain("武装监听");
+  });
+});
+
+// #979 的判据本身：armed_listener_live 来自 serve 锁的**活持有者**（pid + 出生时间），不是插件状态、
+// 不是 AGENTPARTY_CLAUDE_CHANNEL_OPT_IN 开关。蛰伏档从不抢锁，所以「只有蛰伏档」⇒ 锁目录为空 ⇒ null。
+describe("probeClaudeArmedListener —— 武装监听探活（#979）", () => {
+  const config = { server: "https://party.example.com", token: "agent-token", identity: { name: "server" } };
+  const target = () => instanceLockTarget(config.server, config.token, "dev");
+  let lockDir: string;
+  beforeEach(() => {
+    lockDir = mkdtempSync(join(tmpdir(), "party-join-claude-locks-"));
+  });
+  afterEach(() => {
+    rmSync(lockDir, { recursive: true, force: true });
+  });
+  const dormantEntry = (id: string, identity = "server") => ({
+    version: 1 as const,
+    session_id: id,
+    pid: process.pid,
+    display_name: null,
+    channel: "dev",
+    server: "https://party.example.com",
+    identity,
+    cwd: process.cwd(),
+    registered_at: 1,
+    harness: "claude" as const,
+  });
+
+  test("没有锁（只有蛰伏档入册）→ live=null，蛰伏会话按 (channel, server, identity) 数出来", () => {
+    const sessions = () => [
+      dormantEntry("019f95e8-2c0b-7903-8779-cd102c5ecd41"),
+      dormantEntry("019f95e8-2c0b-7903-8779-cd102c5ecd42"),
+      dormantEntry("019f95e8-2c0b-7903-8779-cd102c5ecd43", "someone-else"), // 别的身份不算
+      { ...dormantEntry("019f95e8-2c0b-7903-8779-cd102c5ecd44"), channel: "other" }, // 别的频道不算
+    ];
+    const asked: number[] = [];
+    const r = probeClaudeArmedListener({ lockDir, config, channel: "dev", sessions, commandOf: (pid) => (asked.push(pid), null) });
+    expect(r).toEqual({ live: null, sessions: 2 });
+    expect(asked).toEqual([]); // 没有持有者就不问 ps
+  });
+
+  test("serve 锁被活进程持有 → live=pid，起法由命令行认出（claude-channel）", () => {
+    writeFileSync(join(lockDir, `serve-${target()}.lock`), JSON.stringify({ pid: process.pid, id: "t", started_at: currentProcessStartedAt() }));
+    const r = probeClaudeArmedListener({
+      lockDir,
+      config,
+      channel: "dev",
+      sessions: () => [dormantEntry("019f95e8-2c0b-7903-8779-cd102c5ecd41")],
+      commandOf: (pid) => (pid === process.pid ? "party claude-channel --channel dev" : null),
+    });
+    expect(r).toEqual({ live: { pid: process.pid, launch: "claude-channel" }, sessions: 1 });
+  });
+
+  test("serve 锁被活进程持有、命令行是 serve → launch=serve", () => {
+    writeFileSync(join(lockDir, `serve-${target()}.lock`), JSON.stringify({ pid: process.pid, id: "t", started_at: currentProcessStartedAt() }));
+    const r = probeClaudeArmedListener({ lockDir, config, channel: "dev", sessions: () => [], commandOf: () => "party serve dev --runner claude" });
+    expect(r.live).toEqual({ pid: process.pid, launch: "serve" });
+  });
+
+  test("锁文件在、持有者进程已死 → null：锁文件不是进程", () => {
+    // 出生时间对不上 ⇒ instanceLockHolderPid 判「不是原持有者」（PID 复用防线），等价于死了。
+    writeFileSync(join(lockDir, `serve-${target()}.lock`), JSON.stringify({ pid: process.pid, id: "t", started_at: currentProcessStartedAt() - 3_600_000 }));
+    const r = probeClaudeArmedListener({ lockDir, config, channel: "dev", sessions: () => [], commandOf: () => "party claude-channel" });
+    expect(r.live).toBeNull();
+  });
+
+  test("config 没有 token（人类账号 / 没绑）→ null，不去碰锁", () => {
+    writeFileSync(join(lockDir, `serve-${target()}.lock`), JSON.stringify({ pid: process.pid, id: "t", started_at: currentProcessStartedAt() }));
+    const r = probeClaudeArmedListener({ lockDir, config: { server: config.server }, channel: "dev", sessions: () => [] });
+    expect(r.live).toBeNull();
+  });
+
+  test("锁属于另一个身份/实例（token 不同）→ 不算本身份的监听", () => {
+    writeFileSync(join(lockDir, `serve-${instanceLockTarget(config.server, "other-token", "dev")}.lock`), JSON.stringify({ pid: process.pid, id: "t", started_at: currentProcessStartedAt() }));
+    const r = probeClaudeArmedListener({ lockDir, config, channel: "dev", sessions: () => [], commandOf: () => "party claude-channel" });
+    expect(r.live).toBeNull();
+  });
+
+  test("classifyListenerCommand：只认 claude-channel / serve 两个子命令名，其余 unknown", () => {
+    expect(classifyListenerCommand("/usr/local/bin/party claude-channel --channel dev")).toBe("claude-channel");
+    expect(classifyListenerCommand("bun /x/cli/src/index.ts serve dev --runner claude")).toBe("serve");
+    expect(classifyListenerCommand("node something-else")).toBe("unknown");
+    expect(classifyListenerCommand(null)).toBe("unknown");
   });
 });

--- a/cli/test/who.test.ts
+++ b/cli/test/who.test.ts
@@ -916,3 +916,102 @@ describe("who deferred 行的队列深度（#958）", () => {
     expect(line).not.toContain("queued ≈");
   });
 });
+
+// ── #979：身份「不在线」时说清为什么——本机只有普通 claude 起的蛰伏档，没有会接 @ 的武装监听 ──
+import { afterEach, beforeEach } from "bun:test";
+import { claudeDormantToSurface, diagnoseClaudeDormantSessions, formatClaudeDormantDiagnosis } from "../src/claude-armed-listener";
+import { registerClaudeSession } from "../src/claude-session-registry";
+import { currentProcessStartedAt, instanceLockTarget } from "../src/instance-lock";
+
+describe("who claude 蛰伏档说明（#979）", () => {
+  const SERVER = "https://party.example.com";
+  let home: string;
+  let lockDir: string;
+  let savedHome: string | undefined;
+  beforeEach(() => {
+    savedHome = process.env.AGENTPARTY_HOME;
+    home = mkdtempSync(join(tmpdir(), "party-who-979-home-"));
+    lockDir = mkdtempSync(join(tmpdir(), "party-who-979-locks-"));
+    process.env.AGENTPARTY_HOME = home;
+    mkdirSync(join(home, "agents"), { recursive: true });
+  });
+  afterEach(() => {
+    if (savedHome === undefined) delete process.env.AGENTPARTY_HOME;
+    else process.env.AGENTPARTY_HOME = savedHome;
+    rmSync(home, { recursive: true, force: true });
+    rmSync(lockDir, { recursive: true, force: true });
+  });
+  /** 本机为某身份绑到 #ludo 的 config（party join 写的那种）。 */
+  function writeAgentConfig(name: string, token: string): void {
+    writeFileSync(
+      join(home, "agents", `agentparty-${name}-ludo.json`),
+      JSON.stringify({ server: SERVER, token, identity: { name, channel_scope: "ludo" } }),
+    );
+  }
+  /** 普通 claude 会话 SessionStart 入册的形态：pid 是本进程（活着），身份/实例都对上。 */
+  function registerDormant(id: string, identity: string): void {
+    expect(registerClaudeSession({
+      session_id: id,
+      pid: process.pid,
+      display_name: null,
+      channel: "ludo",
+      identity,
+      server: SERVER,
+      cwd: process.cwd(),
+    })).toBe(true);
+  }
+
+  test("只有蛰伏档 ⇒ 列出该身份并数出会话数；渲染含「不在线」原因、local-only、两条命令原样", () => {
+    writeAgentConfig("server", "tok-server");
+    registerDormant("019f95e8-2c0b-7903-8779-cd102c5ecd51", "server");
+    registerDormant("019f95e8-2c0b-7903-8779-cd102c5ecd52", "server");
+    const diags = diagnoseClaudeDormantSessions("ludo", SERVER, { lockDir });
+    expect(diags).toEqual([{ channel: "ludo", identity: "server", sessions: 2 }]);
+    const lines = formatClaudeDormantDiagnosis(diags[0]!);
+    expect(lines[0]).toContain("#ludo 上 server 不在线");
+    expect(lines[0]).toContain("2 个 claude 会话全是蛰伏档");
+    expect(lines[0]).toContain("local-only");
+    expect(lines[1]).toContain("party claude ludo");
+    expect(lines[1]).toContain("party serve ludo --runner claude");
+  });
+
+  test("该身份的 serve 锁有活持有者（party claude / serve 在跑）⇒ 不列：它不是「只有蛰伏档」", () => {
+    writeAgentConfig("server", "tok-server");
+    registerDormant("019f95e8-2c0b-7903-8779-cd102c5ecd51", "server");
+    writeFileSync(
+      join(lockDir, `serve-${instanceLockTarget(SERVER, "tok-server", "ludo")}.lock`),
+      JSON.stringify({ pid: process.pid, id: "t", started_at: currentProcessStartedAt() }),
+    );
+    expect(diagnoseClaudeDormantSessions("ludo", SERVER, { lockDir })).toEqual([]);
+  });
+
+  test("注册表里没有该身份的活会话 ⇒ 不列（没会话谈不上蛰伏）；别的实例的会话也不算（#865）", () => {
+    writeAgentConfig("server", "tok-server");
+    expect(diagnoseClaudeDormantSessions("ludo", SERVER, { lockDir })).toEqual([]);
+    expect(registerClaudeSession({
+      session_id: "019f95e8-2c0b-7903-8779-cd102c5ecd53",
+      pid: process.pid,
+      display_name: null,
+      channel: "ludo",
+      identity: "server",
+      server: "https://other.example.com",
+      cwd: process.cwd(),
+    })).toBe(true);
+    expect(diagnoseClaudeDormantSessions("ludo", SERVER, { lockDir })).toEqual([]);
+  });
+
+  test("身份在 who 里已 online / wakeable ⇒ 不再解释；recent 或压根没那一行 ⇒ 说出来", () => {
+    const diags = [
+      { channel: "ludo", identity: "server", sessions: 1 },
+      { channel: "ludo", identity: "Alpha", sessions: 1 },
+      { channel: "ludo", identity: "ghost", sessions: 3 },
+    ];
+    const rows = [
+      { name: "server", tier: "online" },
+      { name: "alpha", tier: "wakeable" }, // 身份比对与 mentionMatchKey 同尺子：ASCII 不分大小写
+      { name: "ghost", tier: "recent" },
+    ];
+    expect(claudeDormantToSurface(diags, rows).map((d) => d.identity)).toEqual(["ghost"]);
+    expect(claudeDormantToSurface(diags, []).map((d) => d.identity)).toEqual(["server", "Alpha", "ghost"]);
+  });
+});

--- a/plugins/agentparty/skills/agentparty/SKILL.md
+++ b/plugins/agentparty/skills/agentparty/SKILL.md
@@ -604,7 +604,7 @@ surface it to the owner instead of ignoring it.
 | Preflight or verify durable Channel reception while Claude is busy | `party claude --verify --channel <slug> --receiver-config PATH --sender-config PATH [--receiver-cwd DIR] --preflight-only`; replace it with `--live` only for an authorized one-model run whose test messages may remain in Channel history/audit |
 | Preflight or run the real two-Claude round-trip verifier | `party bridge claude --verify --channel <slug> --receiver-config PATH --sender-config PATH [--receiver-cwd DIR] [--sender-cwd DIR] --preflight-only`; remove `--preflight-only` only for an authorized live model run |
 | Attach the current live Claude session, with safe Cross-session auto-degradation | `party bridge claude <slug>`; use `--cross-session required` only when full capability is mandatory |
-| Join a channel | `AGENTPARTY_TOKEN='<T>' party join --server <URL> --channel <slug> --as <name> --harness codex\|claude --yes` — one command: config + rules, dedupe, bind, register MCP, install+approve the codex wake hook, check in, verdict. **Never hand-roll this from `party init`**: `join` does six things `init` does not, and a partial join looks fine while `@` silently never reaches you. |
+| Join a channel | `AGENTPARTY_TOKEN='<T>' party join --server <URL> --channel <slug> --as <name> --harness codex\|claude --yes` — one command: config + rules, dedupe, bind, register MCP, install+approve the codex wake hook, check in, verdict. **Never hand-roll this from `party init`**: `join` does six things `init` does not, and a partial join looks fine while `@` silently never reaches you. For `--harness claude` the final ✅ also requires an **armed listener on this machine** (a session started by `party claude <slug>` / `party bridge claude <slug>`, or `party serve <slug> --runner claude`) — an ordinary `claude` session is local-only and never receives `@` (#615/#979), so `join` run from one prints the degraded verdict with those two commands instead of ✅; run `party claude <slug>` next. |
 | Make this interactive Claude session's activity visible in the channel (#615) | Install and enable the Marketplace plugin, then launch with `party claude <slug>` or `party bridge claude <slug>`; ordinary Claude sessions stay local-only and cannot overwrite the active listener's state |
 | See who to mention (online/wakeable/recent) | `party who <slug> [--json]` — run this BEFORE mentioning so you pick a real, reachable name |
 | Send a message | `party send "<text>" --channel <slug> [--mention <name>]... [--reply-to <seq>]` |
@@ -739,7 +739,12 @@ a copy-paste pack that is a short behavior contract plus **two commands**: insta
 if missing) and one `party join`. `party join` does the whole join in one shot — write config +
 rules, dedupe same-channel identities, bind identity, register the MCP server (probe-then-add),
 install and approve the codex wake hook, check in, and print one final verdict ("全部就绪" or
-"还差第 N 步: <one command>"). Send that pack to the teammate; do not ask them to open `/c/<slug>`.
+"还差第 N 步: <one command>"). The verdict is gated on the wake layer itself, not on static
+prerequisites: for claude it also checks that an armed listener process exists on this machine
+(`party claude <slug>` / `party bridge claude <slug>` session, or `party serve <slug> --runner
+claude`) — a plain `claude` session is a local-only dormant listener that never receives `@`, so
+`join` then prints the degraded verdict with those two commands rather than ✅ (#979). Send that
+pack to the teammate; do not ask them to open `/c/<slug>`.
 
 Self-service path when you are already logged in as a channel moderator:
 

--- a/skills/agentparty/SKILL.md
+++ b/skills/agentparty/SKILL.md
@@ -604,7 +604,7 @@ surface it to the owner instead of ignoring it.
 | Preflight or verify durable Channel reception while Claude is busy | `party claude --verify --channel <slug> --receiver-config PATH --sender-config PATH [--receiver-cwd DIR] --preflight-only`; replace it with `--live` only for an authorized one-model run whose test messages may remain in Channel history/audit |
 | Preflight or run the real two-Claude round-trip verifier | `party bridge claude --verify --channel <slug> --receiver-config PATH --sender-config PATH [--receiver-cwd DIR] [--sender-cwd DIR] --preflight-only`; remove `--preflight-only` only for an authorized live model run |
 | Attach the current live Claude session, with safe Cross-session auto-degradation | `party bridge claude <slug>`; use `--cross-session required` only when full capability is mandatory |
-| Join a channel | `AGENTPARTY_TOKEN='<T>' party join --server <URL> --channel <slug> --as <name> --harness codex\|claude --yes` — one command: config + rules, dedupe, bind, register MCP, install+approve the codex wake hook, check in, verdict. **Never hand-roll this from `party init`**: `join` does six things `init` does not, and a partial join looks fine while `@` silently never reaches you. |
+| Join a channel | `AGENTPARTY_TOKEN='<T>' party join --server <URL> --channel <slug> --as <name> --harness codex\|claude --yes` — one command: config + rules, dedupe, bind, register MCP, install+approve the codex wake hook, check in, verdict. **Never hand-roll this from `party init`**: `join` does six things `init` does not, and a partial join looks fine while `@` silently never reaches you. For `--harness claude` the final ✅ also requires an **armed listener on this machine** (a session started by `party claude <slug>` / `party bridge claude <slug>`, or `party serve <slug> --runner claude`) — an ordinary `claude` session is local-only and never receives `@` (#615/#979), so `join` run from one prints the degraded verdict with those two commands instead of ✅; run `party claude <slug>` next. |
 | Make this interactive Claude session's activity visible in the channel (#615) | Install and enable the Marketplace plugin, then launch with `party claude <slug>` or `party bridge claude <slug>`; ordinary Claude sessions stay local-only and cannot overwrite the active listener's state |
 | See who to mention (online/wakeable/recent) | `party who <slug> [--json]` — run this BEFORE mentioning so you pick a real, reachable name |
 | Send a message | `party send "<text>" --channel <slug> [--mention <name>]... [--reply-to <seq>]` |
@@ -739,7 +739,12 @@ a copy-paste pack that is a short behavior contract plus **two commands**: insta
 if missing) and one `party join`. `party join` does the whole join in one shot — write config +
 rules, dedupe same-channel identities, bind identity, register the MCP server (probe-then-add),
 install and approve the codex wake hook, check in, and print one final verdict ("全部就绪" or
-"还差第 N 步: <one command>"). Send that pack to the teammate; do not ask them to open `/c/<slug>`.
+"还差第 N 步: <one command>"). The verdict is gated on the wake layer itself, not on static
+prerequisites: for claude it also checks that an armed listener process exists on this machine
+(`party claude <slug>` / `party bridge claude <slug>` session, or `party serve <slug> --runner
+claude`) — a plain `claude` session is a local-only dormant listener that never receives `@`, so
+`join` then prints the degraded verdict with those two commands rather than ✅ (#979). Send that
+pack to the teammate; do not ask them to open `/c/<slug>`.
 
 Self-service path when you are already logged in as a channel moderator:
 


### PR DESCRIPTION
## 根因

`party join --harness claude` 收尾印「✅ 现在 @ server，这台机器上的 claude 会话就能被唤醒」，但 piggo 机上 14 个 `party claude-channel` 全是 `--require-launch-opt-in` 的**蛰伏档**——裸 `claude` 起的会话按 #615 是 local-only：只宣告在线、不认领投递、**不抢 serve 锁**。真正会接 @ 的只有 `party claude <chan>` / `party bridge claude <chan>` 起的会话（armed claude-channel）或 `party serve <chan> --runner claude`。#967 加的 `plugin_lifecycle_ready` 查的是插件装没装、版本对不对，没有一项是「此刻有没有会接 @ 的进程」——#957/#961 同一形状的第三次。

## 修法

- **`cli/src/claude-armed-listener.ts`（新）**：`probeClaudeArmedListener`，与 #957 的 `probeCodexWakeLayer` 对等。
  - 判据来源：**serve 实例锁的活持有者**（`instanceLockHolderPid("serve", instanceLockTarget(server, token, channel))`，pid + 出生时间核对）。`claude-channel.ts` 的 armed 档、`serve.ts` 都抢这同一把锁（"serve 与 live-session adapter 是同一身份/频道的两个投递消费者"），蛰伏档从不抢——所以「锁有活持有者」⇔「本机有会接 @ 的 Claude 监听」。进程事实，不是 opt-in 开关。
  - 锁持有者的命令行（`ps -o command=`）只用来说清**是谁**（`claude-channel` / `serve` / unknown），不参与判定。
  - 会话注册表（`claude-sessions/`，按 channel + server + identity 过滤）只用来数「本机有 N 个蛰伏档」。
- **`join.ts`**：收尾自检新增 `armed_listener_live`（放最后，同 codex 的 `wake_layer_live`）。
  - 没有武装监听 ⇒ 不印 ✅，结论：「⚠ 已绑定身份 X，但这台机现在没有会接 @ 的 Claude 会话。普通 `claude` 起的会话不接频道消息（local-only）……」，`party claude <chan>` 与 `party serve <chan> --runner claude` 两条命令原样印出，并说明本机 N 个会话全是蛰伏档；退出码 1。
  - 有武装监听 ⇒ ✅ 句写明是哪个：「由 party claude / party bridge claude 起的 Claude 会话（武装监听 party claude-channel，pid N）」或「常驻的 party serve <chan> --runner claude（pid N）」。
  - #961 的「差一次重开」文案改为「用 `party claude <chan>` 新开一个 Claude 会话」。
  - 探活抛异常按「没有」处理（绝不因探不到就假定有）。
- **`who.ts`**：某身份不在线（行缺失或 recent）、而本机注册表里有它在该频道的活 claude 会话且 serve 锁无活持有者 ⇒ 尾部补 `wake (claude): #chan 上 X 不在线——本机在 #chan 入册的 N 个 claude 会话全是蛰伏档……` 加两条命令。纯本地读盘，失败即闭嘴。
- **SKILL.md**（canonical + `bun run sync:plugin` 镜像）写明 claude 档 ✅ 的新判据。

未改 `claude-launch.ts`（#978/#980 在动它，只读）。

## 测试证据

- `cd cli && bunx tsc --noEmit` ✅
- `bun test test/join.test.ts test/who.test.ts test/who-scope.test.ts test/join-binding.test.ts` → 145 pass / 0 fail
- `bun test test/claude-channel.test.ts` → 103 pass；`test/claude-channel-dormant-announce.test.ts` → 38 pass；`test/claude-channel-mcp.test.ts` 随批次通过（三个文件与 join 并行跑时 stdio 桩会超时 flaky，单跑全绿，与本 PR 无关）
- 新增用例（issue 列的全部）：
  - 只有蛰伏档（真注册表条目 + 空锁目录 + 真探活）⇒ 无 ✅、不含「就能被唤醒」、含 `party claude dev` 与 `party serve dev --runner claude`、「1 个 claude 会话全是蛰伏档」
  - 真锁（本进程 pid + 出生时间）+ ps 桩回 claude-channel ⇒ ✅ 带 `pid <本进程>` 与「party claude-channel」
  - serve 锁 ⇒ ✅ 写明 `party serve dev --runner claude（pid 777）`
  - 探活抛异常 ⇒ 降级文案；插件旧版 + 无监听 ⇒ 第一条修法仍是 `plugin update`（闸放最后）；codex 档不查、不印
  - `probeClaudeArmedListener`：无锁→null 且按 (channel, server, identity) 数蛰伏档；活锁→pid+launch；出生时间对不上→null；无 token→null；别的 token 的锁→null；`classifyListenerCommand`
  - who：只有蛰伏档 ⇒ 列出并渲染两条命令；有锁持有者 ⇒ 不列；注册表空/别的实例 ⇒ 不列；online/wakeable 行过滤、recent/缺行保留
- **变异自检**：把 `armed_listener_live` 的 `ok` 恒 true ⇒ 「只有蛰伏档」那条第一个红（另两条随之红）；恢复后全绿。

Closes #979

https://claude.ai/code/session_01Az8CnUpayZzqpi1sh32Ssi
