### PR TITLE
fix(cli): codex-stop 在解析身份之前先走 #976 的 rollout 头判定，一次性 codex 一行放行

### DIFF
--- a/cli/src/commands/hook.ts
+++ b/cli/src/commands/hook.ts
@@ -1162,6 +1162,11 @@ export interface CodexStopWakeDeps {
   channel: (cwd: string) => string | null;
   /** 前台唤醒是否启用（沿用 #893 的 codex-autowake 开关）。 */
   enabled: () => boolean;
+  /**
+   * 触发本次 Stop 的 codex 是不是人在用的会话（#982，与 codex-report 同一道判定）。
+   * `non-interactive` ⇒ 放行不注入、不解析身份；`interactive` / `unknown` / 缺省 ⇒ 原路径。
+   */
+  sessionKind?: () => CodexSessionKindProbe;
   /** serve/watch 落在本地的欠账——**可选快路径**，没有也照样能判（#903）。 */
   stuck: (channel: string, cwd: string) => Pick<StuckWake, "seq" | "first_wake_ts"> | null;
   /**
@@ -1225,6 +1230,8 @@ export function defaultCodexStopWakeDeps(
   return {
     channel: (cwd) => env.AGENTPARTY_CHANNEL ?? readState(cwd)?.channel ?? null,
     enabled: () => resolveCodexAutoWakeMode(env, home).mode !== "off",
+    // #982：与 SessionStart 同一道探测——先读本会话的 rollout 头（#976），读不到再看进程形态。
+    sessionKind: () => probeCodexSessionKind({ hookParentPid: pid, sessionId, env }),
     // 游标/欠账必须落在**解析出来那个身份**的作用域里：拿另一个身份的游标当 since，
     // 查询要么恒空（漏叫）要么把老 @ 翻出来。env / cwd 两档的作用域与历史逐字一致。
     stuck: (channel, cwd) => {
@@ -1298,6 +1305,15 @@ export async function handleCodexStopRecord(
   // 先过便宜闸再花网络：不是 Stop / 是续跑 / 被关掉 / 没绑频道，一次请求都不发（#903）。
   if (!codexStopWakeGate({ payload: record, channel, enabled: deps.enabled() }).ok) return;
   const boundChannel = channel as string;
+  // #982：身份解析之前先判会话形态——被 Claude 委托的一次性 codex 每回合都触发 Stop，此前每回合
+  // 都走一遍身份解析、打一条 harness-mismatch / 解析不出的长文，与 SessionStart（codex-report）
+  // 的 skip(non-interactive) 一行不一致。non-interactive ⇒ 放行，一行留痕即止；interactive /
+  // unknown ⇒ 原路径（Stop 不拉唤醒层，unknown 在这里没有更贵的一侧）。探测炸了也按原路径。
+  const sessionKind = probeCodexStopSessionKind(deps);
+  if (sessionKind?.kind === "non-interactive") {
+    deps.log(`codex-stop: skip(non-interactive) ${codexSessionKindLogTag(sessionKind)}`);
+    return;
+  }
   const cursor = deps.cursor(boundChannel, cwd);
   const seenPath = deps.seenPath(boundChannel, cwd);
   const seenEntries = seenPath === null ? [] : deps.readSeen(seenPath);
@@ -1352,6 +1368,16 @@ export async function handleCodexStopRecord(
     `codex-stop: 在当前 codex 会话里注入了 #${decision.pointer.channel} seq ${decision.pointer.seq} 的指针` +
       (depth === undefined ? "" : `（第 1/${depth.remaining + 1}${depth.exact ? "" : "+"} 条，提示里已给出排空命令）`),
   );
+}
+
+/** #982：Stop 路径的形态探测；没注入 / 探测抛异常都当「没结论」，走原路径。 */
+function probeCodexStopSessionKind(deps: CodexStopWakeDeps): CodexSessionKindProbe | null {
+  if (deps.sessionKind === undefined) return null;
+  try {
+    return deps.sessionKind();
+  } catch {
+    return null;
+  }
 }
 
 /**

--- a/cli/test/codex-stop-wake.test.ts
+++ b/cli/test/codex-stop-wake.test.ts
@@ -6,7 +6,7 @@
 //   session_id / stop_hook_active / transcript_path / turn_id
 // 注意没有 agent_id / agent_type / prompt——反推版把 SubagentStop 的字段混了进来。
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -28,11 +28,14 @@ import {
 import {
   codexHookSettingsJson,
   codexStopWakeBacklog,
+  defaultCodexStopWakeDeps,
   handleCodexStopRecord,
   mergeHookSettings,
   removeHookSettings,
   type CodexStopWakeDeps,
 } from "../src/commands/hook";
+import { codexAutoWakeLogPath } from "../src/codex-auto-wake";
+import { resetCodexRolloutMetaCache, type CodexSessionKindProbe } from "../src/codex-session-kind";
 import type { NextMention } from "../src/rest";
 
 const NOW = 1_700_000_000_000;
@@ -835,6 +838,182 @@ describe("codex Stop hook 积压可见性（#958）", () => {
       expect(output.reason).toContain("seq 1935");
       expect(output.reason).not.toContain("1/1");
       expect(output.reason).toContain("party history pwtk --since 1934");
+    });
+  });
+});
+
+
+// ── #982 的钉子 ─────────────────────────────────────────────────────────────
+// piggo 机 2026-08-28 06:42Z：同一批被 Claude 委托的一次性 codex，SessionStart 已按 #976 记成
+// `skip(non-interactive) … rollout 头：originator=Claude Code source=vscode`，它们的 Stop hook
+// 却仍每回合走身份解析、打 `harness-mismatch` 长行。修法：Stop 路径在解析身份之前跑同一道探测。
+describe("codex-stop 先走 rollout 头判定（#982）", () => {
+  const DIRECT_ID = "01a046e8-89f6-7ba2-a792-4d0342522e7f";
+  const ROLLOUT_DETAIL = "rollout 头：originator=Claude Code source=vscode";
+  let home: string;
+  let emitted: string[];
+  let logged: string[];
+
+  /** 身份解析的每一个下游入口都装成地雷：non-interactive 短路后一个都不许碰。 */
+  function deps(overrides: Partial<CodexStopWakeDeps> = {}): CodexStopWakeDeps {
+    const mine = (name: string) => () => { throw new Error(`${name} must not run for a non-interactive codex`); };
+    return {
+      channel: () => "pwtk",
+      enabled: () => true,
+      stuck: mine("stuck"),
+      nextMention: async () => { throw new Error("nextMention must not run for a non-interactive codex"); },
+      cursor: mine("cursor"),
+      seenPath: mine("seenPath"),
+      readSeen: () => [],
+      recordSeen: () => {},
+      emit: (line) => emitted.push(line),
+      log: (line) => logged.push(line),
+      now: () => NOW,
+      ...overrides,
+    };
+  }
+
+  /** interactive / unknown 时要走的**原路径**：与 handleCodexStopRecord 主用例同一份假值。 */
+  function interactivePath(kind: CodexSessionKindProbe | (() => never)): CodexStopWakeDeps {
+    const seenStore = new Map<string, { seq: number; ts: number }[]>();
+    return deps({
+      sessionKind: typeof kind === "function" ? kind : () => kind,
+      stuck: () => ({ seq: 42, first_wake_ts: NOW - 1_000 }),
+      cursor: () => 7,
+      seenPath: () => join(home, "seen.json"),
+      readSeen: (path) => seenStore.get(path) ?? [],
+      recordSeen: (path, seq, at) => {
+        seenStore.set(path, [...(seenStore.get(path) ?? []), { seq, ts: at }]);
+      },
+    });
+  }
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "ap-982-"));
+    emitted = [];
+    logged = [];
+    resetCodexRolloutMetaCache();
+  });
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+    resetCodexRolloutMetaCache();
+  });
+
+  test("rollout 头 originator=Claude Code ⇒ 不注入、日志恰一行 non-interactive、身份解析一步不走", async () => {
+    await handleCodexStopRecord(stopPayload(), {}, deps({
+      sessionKind: () => ({ kind: "non-interactive", detail: ROLLOUT_DETAIL }),
+    }));
+    expect(emitted).toEqual([]);
+    expect(logged).toHaveLength(1);
+    expect(logged[0]).toBe(`codex-stop: skip(non-interactive) kind=non-interactive detail=${ROLLOUT_DETAIL}`);
+    expect(logged[0]).not.toContain("harness-mismatch");
+    expect(logged[0]).not.toContain("解析不出");
+  });
+
+  test("便宜闸在探测之前：没绑频道 / 被关掉 / 续跑中，探测一次都不跑", async () => {
+    const probe = () => { throw new Error("sessionKind must not run before the cheap gate"); };
+    await handleCodexStopRecord(stopPayload(), {}, deps({ sessionKind: probe, channel: () => null }));
+    await handleCodexStopRecord(stopPayload(), {}, deps({ sessionKind: probe, enabled: () => false }));
+    await handleCodexStopRecord(stopPayload({ stop_hook_active: true }), {}, deps({ sessionKind: probe }));
+    expect(emitted).toEqual([]);
+    expect(logged).toEqual([]);
+  });
+
+  test("interactive（无 rollout 结论、ps 判交互式）⇒ 原路径不变：照常注入，日志不多一行", async () => {
+    await handleCodexStopRecord(stopPayload(), {}, interactivePath({
+      kind: "interactive",
+      detail: "父进程 codex（tty 上）；rollout 头 originator=codex_cli_rs source=cli 无结论，按进程形态判",
+    }));
+    expect(emitted).toHaveLength(1);
+    expect(JSON.parse(emitted[0]!)).toMatchObject({ decision: "block" });
+    expect(logged.some((line) => line.includes("non-interactive"))).toBe(false);
+  });
+
+  test("unknown（探测没结论）⇒ 原路径不变：Stop 不拉唤醒层，unknown 在这里不做保守侧", async () => {
+    await handleCodexStopRecord(stopPayload(), {}, interactivePath({ kind: "unknown", detail: "父进程 pid 不合法" }));
+    expect(emitted).toHaveLength(1);
+    expect(JSON.parse(emitted[0]!)).toMatchObject({ decision: "block" });
+    expect(logged.some((line) => line.includes("non-interactive"))).toBe(false);
+  });
+
+  test("探测抛异常 ⇒ 当没结论，原路径不变（绝不因为探测坏了漏叫）", async () => {
+    await handleCodexStopRecord(stopPayload(), {}, interactivePath(() => { throw new Error("ps exploded"); }));
+    expect(emitted).toHaveLength(1);
+    expect(JSON.parse(emitted[0]!)).toMatchObject({ decision: "block" });
+  });
+
+  test("没注入 sessionKind（老调用方）⇒ 原路径不变", async () => {
+    const d = interactivePath({ kind: "interactive", detail: "" });
+    delete d.sessionKind;
+    await handleCodexStopRecord(stopPayload(), {}, d);
+    expect(emitted).toHaveLength(1);
+  });
+
+  describe("真实接线：defaultCodexStopWakeDeps 从 $CODEX_HOME 的 rollout 头判出 non-interactive", () => {
+    let codexHome: string;
+    let env: NodeJS.ProcessEnv;
+
+    /** piggo 机 codex 0.149.1 实抓的直接会话头（base_instructions 换成占位）。 */
+    function writeRolloutHead(uuid: string): void {
+      const day = join(codexHome, "sessions", "2026", "08", "28");
+      mkdirSync(day, { recursive: true });
+      writeFileSync(join(day, `rollout-2026-08-28T14-47-19-${uuid}.jsonl`), `${JSON.stringify({
+        timestamp: "2026-08-28T05:47:19.944Z",
+        type: "session_meta",
+        payload: {
+          session_id: uuid, id: uuid, timestamp: "2026-08-28T05:47:19.944Z", cwd: "/Users/leo/tk.com/piggo",
+          originator: "Claude Code", cli_version: "0.149.1", source: "vscode", model_provider: "openai",
+          base_instructions: "<long text that must never reach the log>",
+        },
+      })}\n`);
+    }
+
+    beforeEach(() => {
+      codexHome = mkdtempSync(join(tmpdir(), "codex-home-982-"));
+      // 不继承 process.env：AP_ACTIVITY_FILE / AGENTPARTY_CONFIG 之类会改走向。
+      env = {
+        PATH: process.env.PATH,
+        AGENTPARTY_HOME: home,
+        AGENTPARTY_CHANNEL: "pwtk",
+        AGENTPARTY_CODEX_AUTO_WAKE: "serve",
+        CODEX_HOME: codexHome,
+      };
+    });
+    afterEach(() => {
+      rmSync(codexHome, { recursive: true, force: true });
+    });
+
+    function logLines(): string[] {
+      const path = codexAutoWakeLogPath(home);
+      return existsSync(path) ? readFileSync(path, "utf8").split("\n").filter((line) => line.length > 0) : [];
+    }
+
+    test("sessionKind 接的是 #976 的探测：按 Stop 载荷的 session_id 命中 rollout 头", () => {
+      writeRolloutHead(DIRECT_ID);
+      const wake = defaultCodexStopWakeDeps(env, DIRECT_ID, 4242);
+      const probe = wake.sessionKind!();
+      expect(probe.kind).toBe("non-interactive");
+      expect(probe.detail).toContain("rollout");
+      expect(probe.detail).toContain("originator=Claude Code");
+      expect(probe.detail).not.toContain("long text");
+    });
+
+    test("端到端：一次性 codex 的 Stop ⇒ stdout 空、日志恰一行 skip(non-interactive)，无 harness-mismatch / 解析不出", async () => {
+      writeRolloutHead(DIRECT_ID);
+      const wake = defaultCodexStopWakeDeps(env, DIRECT_ID, 4242);
+      const printed: string[] = [];
+      await handleCodexStopRecord(
+        stopPayload({ session_id: DIRECT_ID, cwd: home }),
+        env,
+        { ...wake, emit: (line) => printed.push(line) },
+      );
+      expect(printed).toEqual([]);
+      const lines = logLines();
+      expect(lines).toHaveLength(1);
+      expect(lines[0]).toContain("codex-stop: skip(non-interactive) kind=non-interactive detail=rollout 头：originator=Claude Code source=vscode");
+      expect(lines[0]).not.toContain("harness-mismatch");
+      expect(lines[0]).not.toContain("解析不出");
+      expect(lines[0]).not.toContain("long text");
     });
   });
 });


### PR DESCRIPTION
Closes #982

## 根因

被 Claude 委托的一次性 codex 每回合都触发 Stop。SessionStart（`codex-report`）已按 #976 用 `probeCodexSessionKind({hookParentPid, sessionId})` 读 rollout 头，一行 `skip(non-interactive) … kind=non-interactive detail=rollout 头：originator=Claude Code source=vscode` 跳过；但 `codex-stop` 路径（`cli/src/commands/hook.ts` 的 `defaultCodexStopWakeDeps` / `handleCodexStopRecord`）没这一步，第一次触碰 `cursor` / `seenPath` 就进 `resolveCodexHookIdentity`，每回合打一条 `harness-mismatch` / `解析不出本会话身份` 的长文。同一个会话两条 hook 两种判定文案。

## 修法

- `CodexStopWakeDeps` 新增可选 `sessionKind?: () => CodexSessionKindProbe`；`defaultCodexStopWakeDeps(env, sessionId, pid)` 接 `probeCodexSessionKind({ hookParentPid: pid, sessionId, env })`——`session_id` 就是 `handleCodexStopRecord` 从 Stop 载荷里取的那个（#917 已经在传）。
- `handleCodexStopRecord`：过完便宜闸（Stop / 非续跑 / 开着 / 绑了频道）之后、**第一次触碰身份之前**探测：
  - `non-interactive` ⇒ 直接放行，日志恰一行 `codex-stop: skip(non-interactive) kind=… detail=…`（复用 `codexSessionKindLogTag`，detail 已剥终端控制字符、不含 rollout 正文）；
  - `interactive` / `unknown` / 未注入 / 探测抛异常 ⇒ 原路径一字不改（#965 的积压与深度逻辑不动；Stop 路径本来就不拉唤醒层，unknown 在这里没有更贵的一侧，所以不像 SessionStart 那样做保守侧）。
- 探测放在便宜闸之后：没绑频道 / 被关掉 / 续跑中一次 rollout 读取都不做。
- 没碰 `join.ts` / `who.ts`（#979 在改）。

## 测试证据

`cli/test/codex-stop-wake.test.ts` 新增 `codex-stop 先走 rollout 头判定（#982）` 8 例：

- rollout 头 originator=Claude Code ⇒ 不注入、日志恰一行 `codex-stop: skip(non-interactive) kind=non-interactive detail=rollout 头：originator=Claude Code source=vscode`、不含 `harness-mismatch` / `解析不出`；`stuck` / `cursor` / `seenPath` / `nextMention` 全装成地雷（被调用即抛）证明身份解析一步不走。
- 便宜闸在探测之前：没绑频道 / 关掉 / `stop_hook_active` ⇒ 探测不跑。
- `interactive`（无 rollout 结论、ps 判交互式）⇒ 照常注入 block、日志不多一行；`unknown` ⇒ 同；探测抛异常 ⇒ 同；老调用方不注入 `sessionKind` ⇒ 同。
- 真实接线：临时 `CODEX_HOME` 里写 piggo 机实抓的头 A，`defaultCodexStopWakeDeps(env, DIRECT_ID, 4242).sessionKind()` ⇒ `non-interactive`、detail 含 `originator=Claude Code`、不含 `base_instructions` 正文；端到端跑 `handleCodexStopRecord` ⇒ stdout 空、`codex-auto-wake.log` 恰一行 `skip(non-interactive)`，无 `harness-mismatch` / `解析不出`。

```
cd cli && bunx tsc --noEmit                                                      # 通过
bun test test/codex-session-kind.test.ts test/codex-auto-wake.test.ts \
  test/codex-session-identity.test.ts                                             # 134 pass, 0 fail
bun test test/codex-stop-wake.test.ts                                             # 72 pass, 0 fail
```

`hook-install.test.ts` / `codex-stop-wake.test.ts` 里的**子进程** e2e 用例（`bun run src/index.ts hook …`，5s 超时）在本机 load avg ~146 时间歇超时（exit 143），单独计时同一条命令冷启 3–8s；超时的用例包括与本改动无关的 `hook push` / `Stop guard`，非本 PR 引入。

变异自检：把 Stop 路径的探测短路成 `null`（恢复前）⇒ 恰好 2 例红：「rollout 头 originator=Claude Code ⇒ 不注入…」与「端到端：一次性 codex 的 Stop ⇒ … 恰一行 skip(non-interactive)」（后者日志变成 `解析不出本会话身份（no-identity）`）；其余 70 例仍绿。恢复后 72 全绿。

## 未做

- 本机实测 Stop 路径的探测在 rollout 无结论时会多跑一次 `ps`（与 SessionStart 相同；身份解析本来就有一次 `ps eww`），没做跨进程缓存——hook 是一次性进程，与 #977 的取舍一致。
- 没给 `interactive` / `unknown` 加日志行：Stop 每回合触发，逐次记 kind 会刷成噪音；需要时从 SessionStart 那条看。

https://claude.ai/code/session_01Az8CnUpayZzqpi1sh32Ssi


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能改进**
  - 优化停止钩子的会话识别流程。
  - 对非交互式会话直接跳过唤醒处理，减少不必要的身份解析和网络查询。
  - 非交互式会话仅记录一条跳过日志，避免产生误报。

- **错误修复**
  - 当会话信息缺失或探测失败时，自动沿用原有处理路径，确保兼容性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->