### PR TITLE
fix(cli): party upgrade 顺手把 Claude 插件对齐到新 CLI 版本，并提示重开会话（#985）

### DIFF
--- a/cli/src/claude-plugin-sync.ts
+++ b/cli/src/claude-plugin-sync.ts
@@ -1,0 +1,135 @@
+// claude 插件版本对齐（#961 / #967 / #985）：`party join --harness claude` 和 `party upgrade` 都要
+// 把本机装的 agentparty 插件拉到和 CLI 同版，判据、动作、修法只写这一份。
+//
+// 为什么非对齐不可：插件版本 ≠ CLI 版本时 doctor 判 plugin_version_mismatch，SessionStart 唤醒
+// 根本不布上（#961）。而 `claude plugin install` 对已装的只回 "already installed"（exit 0），
+// **永远不会升级**，只有 `claude plugin update` 才换版本。
+import type { spawnSync } from "node:child_process";
+import { parseClaudePluginList } from "./commands/doctor";
+import { compareVersions } from "./upgrade";
+
+export const CLAUDE_PLUGIN = "agentparty@agentparty";
+export const CLAUDE_PLUGIN_MARKETPLACE = "leeguooooo/AgentParty";
+export const CLAUDE_PLUGIN_UPDATE_COMMAND = `claude plugin update ${CLAUDE_PLUGIN}`;
+
+export type PluginSpawn = typeof spawnSync;
+
+/** `claude plugin list --json` 的探测结果：先分「claude 起不起得来」，再分「读没读出版本」。 */
+export type ClaudePluginProbe =
+  | { available: false }
+  /** version：`undefined`＝清单读不出 / 解析不了；`null`＝没装；字符串＝已装版本。 */
+  | { available: true; version: string | null | undefined };
+
+/**
+ * 读本机已装的 agentparty 插件版本。走的是 doctor 同一个解析器（parseClaudePluginList），
+ * 判据不另写一份。
+ */
+export function probeInstalledClaudePlugin(spawn: PluginSpawn): ClaudePluginProbe {
+  const r = spawn("claude", ["plugin", "list", "--json"], { encoding: "utf8", timeout: 30_000 });
+  if (r.error !== undefined) return { available: false };
+  if (r.status !== 0 || typeof r.stdout !== "string") return { available: true, version: undefined };
+  const list = parseClaudePluginList(r.stdout);
+  if (list === null) return { available: true, version: undefined };
+  return { available: true, version: list.find((p) => p.id === CLAUDE_PLUGIN)?.version ?? null };
+}
+
+/** 同 probeInstalledClaudePlugin，但把「claude 不可用」和「读不出」都折成 `undefined`。 */
+export function installedClaudePluginVersion(spawn: PluginSpawn): string | null | undefined {
+  const probe = probeInstalledClaudePlugin(spawn);
+  return probe.available ? probe.version : undefined;
+}
+
+/** 跑一次 `claude plugin update agentparty@agentparty`。true＝exit 0。 */
+export function runClaudePluginUpdate(spawn: PluginSpawn): boolean {
+  const r = spawn("claude", ["plugin", "update", CLAUDE_PLUGIN], { encoding: "utf8", timeout: 60_000 });
+  return r.error === undefined && r.status === 0;
+}
+
+/**
+ * 插件与 CLI 版本不一致时的对症修法：插件比 CLI 新 ⇒ 升 CLI（不是降插件）；插件旧 ⇒ update
+ * （install 原地踏步）。
+ */
+export function claudePluginMismatchFix(pluginVersion: string, cliVersion: string): string {
+  return compareVersions(pluginVersion, cliVersion) > 0 ? "party upgrade" : CLAUDE_PLUGIN_UPDATE_COMMAND;
+}
+
+export type ClaudePluginSyncKind =
+  /** `claude plugin list` 起不来（二进制不在 PATH）。 */
+  | "claude_unavailable"
+  /** claude 在，但插件清单读不出 / 解析不了。 */
+  | "unreadable"
+  /** 没装 agentparty 插件——不替人做主装；join 才装。 */
+  | "not_installed"
+  /** 已经和 CLI 同版，什么都没做。 */
+  | "current"
+  /** 跑了 update 且之后读到的版本 == CLI。 */
+  | "updated"
+  /** update 命令退出非 0。 */
+  | "update_failed"
+  /** update 命令退出 0，但之后读到的版本仍 ≠ CLI（marketplace 还没拿到新 tag、缓存……）。 */
+  | "still_mismatched";
+
+export interface ClaudePluginSyncResult {
+  kind: ClaudePluginSyncKind;
+  /** 对齐前读到的版本（语义同 installedClaudePluginVersion）。 */
+  before: string | null | undefined;
+  /** 对齐后读到的版本；没跑 update 时等于 before。 */
+  after: string | null | undefined;
+  /** 还需要人手做的那一条命令；已对齐 / 无需对齐时为 undefined。 */
+  fix?: string;
+}
+
+/**
+ * 把本机 claude 插件对齐到 `cliVersion`：读已装版本，≠ cliVersion 就跑 `claude plugin update`，
+ * 再读一次核实。**只对齐已装的**，没装不装（那是 join 的事）。任何一步失败都不抛——调用方按
+ * kind 决定怎么说，CLI 自身的升级 / 加入不因插件而失败。
+ *
+ * `cliVersion` 由调用方给：join 传 RUNNING_VERSION；upgrade 传刚装上的目标版本——upgrade 进程
+ * 本身还是旧二进制，RUNNING_VERSION 是旧的，拿它比对会把插件对齐到旧版。
+ */
+export function syncClaudePluginToCli(spawn: PluginSpawn, cliVersion: string): ClaudePluginSyncResult {
+  const probe = probeInstalledClaudePlugin(spawn);
+  if (!probe.available) return { kind: "claude_unavailable", before: undefined, after: undefined };
+  const before = probe.version;
+  if (before === undefined) return { kind: "unreadable", before, after: before };
+  if (before === null) return { kind: "not_installed", before, after: before };
+  if (before === cliVersion) return { kind: "current", before, after: before };
+  if (!runClaudePluginUpdate(spawn)) {
+    return { kind: "update_failed", before, after: before, fix: claudePluginMismatchFix(before, cliVersion) };
+  }
+  const after = installedClaudePluginVersion(spawn);
+  if (after === cliVersion) return { kind: "updated", before, after };
+  return {
+    kind: "still_mismatched",
+    before,
+    after,
+    fix: typeof after === "string" ? claudePluginMismatchFix(after, cliVersion) : CLAUDE_PLUGIN_UPDATE_COMMAND,
+  };
+}
+
+/**
+ * `party upgrade` 收尾时给人看的那几行（#985）。CLI 已经装好了，这里只是「顺手」——所以每个分支
+ * 都是说明，不是错误；调用方退出码不受它影响。
+ */
+export function describeClaudePluginSync(result: ClaudePluginSyncResult, cliVersion: string): string[] {
+  switch (result.kind) {
+    case "claude_unavailable":
+      return ["claude 不在 PATH，跳过 Claude 插件对齐（不影响 CLI）"];
+    case "unreadable":
+      return [`读不出 Claude 插件清单，跳过插件对齐；确认方式：claude plugin list --json，需要时手动 ${CLAUDE_PLUGIN_UPDATE_COMMAND}`];
+    case "not_installed":
+      return ["未安装 Claude 插件，跳过插件对齐（要用 Claude 唤醒层时跑 party join --harness claude）"];
+    case "current":
+      return [`Claude 插件已是 ${cliVersion}，无需更新`];
+    case "updated":
+      return [`Claude 插件 ${result.before} → ${result.after}，需重开 Claude 会话生效（当前会话仍挂着旧插件）`];
+    case "update_failed":
+      return [
+        `Claude 插件仍是 ${result.before}（CLI ${cliVersion}），update 失败——唤醒层会报 plugin_version_mismatch，手动：${result.fix}`,
+      ];
+    case "still_mismatched":
+      return [
+        `Claude 插件 update 跑完仍是 ${result.after ?? "读不出"}（CLI ${cliVersion}）——可能 marketplace 还没拿到新版，稍后手动：${result.fix}`,
+      ];
+  }
+}

--- a/cli/src/commands/join.ts
+++ b/cli/src/commands/join.ts
@@ -39,6 +39,14 @@ import { buildWakeChecklist, type WakeChecklist } from "../wake-checklist";
 import { diagnoseCodexWake } from "../wake-diagnosis";
 import { RUNNING_VERSION, compareVersions } from "../upgrade";
 import {
+  CLAUDE_PLUGIN as SHARED_CLAUDE_PLUGIN,
+  CLAUDE_PLUGIN_MARKETPLACE,
+  CLAUDE_PLUGIN_UPDATE_COMMAND,
+  claudePluginMismatchFix,
+  installedClaudePluginVersion,
+  syncClaudePluginToCli,
+} from "../claude-plugin-sync";
+import {
   activeCodexAutoWakePid,
   codexAutoWakeAuth,
   codexAutoWakeMarkerPath,
@@ -60,7 +68,6 @@ import { findHarnessAncestor } from "../join-binding";
 import {
   CLAUDE_PLUGIN_MIN_VERSION,
   inspectClaudePluginShell,
-  parseClaudePluginList,
   type ClaudePluginShellInspection,
 } from "./doctor";
 import type { CodexAutoWakeOutcome } from "./hook";
@@ -228,27 +235,16 @@ function registerCodexMcp(deps: JoinDeps, name: string, configPath: string, slug
   return { level: "ok", msg: `MCP 已注册：${name}` };
 }
 
-const CLAUDE_PLUGIN = "agentparty@agentparty";
-const MARKETPLACE = "leeguooooo/AgentParty";
-
-/**
- * 本机已装的 agentparty 插件版本。`undefined`＝读不出（claude 不可用 / 输出解析不了）；`null`＝没装。
- * 走的是 doctor 同一个解析器（parseClaudePluginList），判据不另写一份。
- */
-function installedClaudePluginVersion(deps: JoinDeps): string | null | undefined {
-  const r = deps.spawn("claude", ["plugin", "list", "--json"], { encoding: "utf8", timeout: 30_000 });
-  if (r.error !== undefined || r.status !== 0 || typeof r.stdout !== "string") return undefined;
-  const list = parseClaudePluginList(r.stdout);
-  if (list === null) return undefined;
-  return list.find((p) => p.id === CLAUDE_PLUGIN)?.version ?? null;
-}
+const CLAUDE_PLUGIN = SHARED_CLAUDE_PLUGIN;
+const MARKETPLACE = CLAUDE_PLUGIN_MARKETPLACE;
 
 /**
  * 装 claude 插件（marketplace）——best-effort：装不上不阻断，只提示；能不能唤醒由收尾自检判。
  *
  * #961：`claude plugin install` 对已装的只回一句 "already installed"（exit 0），**永远不会升级**。
  * 于是本机插件停在旧版、CLI 已经是新版，doctor 判 plugin_version_mismatch，SessionStart 唤醒根本
- * 没布上。所以 install 之后读一次已装版本，≠ 当前 CLI 就跟一步 `plugin update`。
+ * 没布上。所以 install 之后交给 syncClaudePluginToCli（与 `party upgrade` 共用，#985）：读已装版本，
+ * ≠ 当前 CLI 就跟一步 `plugin update`，再读一次核实。
  *
  * 装了 / 更新了都要**重开 Claude 会话**才生效（当前会话还挂着旧插件）——这句必须进结论，
  * 不能埋在 warn 里，所以用 restartNeeded 带出去。
@@ -258,26 +254,23 @@ function installClaudePlugin(deps: JoinDeps): StepOutcome & { restartNeeded: boo
   if (first.error !== undefined) {
     return { level: "skip", msg: "claude 二进制不可用，跳过插件安装（不影响 CLI 协作）", restartNeeded: false };
   }
-  const before = installedClaudePluginVersion(deps);
+  const before = installedClaudePluginVersion(deps.spawn);
   let anyFail = first.status !== 0;
   for (const args of [["plugin", "install", CLAUDE_PLUGIN], ["plugin", "enable", CLAUDE_PLUGIN]]) {
     const r = deps.spawn("claude", args, { encoding: "utf8", timeout: 60_000 });
     if (r.error !== undefined || r.status !== 0) anyFail = true;
   }
-  let updated = false;
-  if (before !== undefined && before !== null && before !== RUNNING_VERSION) {
-    const r = deps.spawn("claude", ["plugin", "update", CLAUDE_PLUGIN], { encoding: "utf8", timeout: 60_000 });
-    if (r.error !== undefined || r.status !== 0) anyFail = true;
-    else updated = true;
-  }
-  const after = installedClaudePluginVersion(deps);
+  const sync = syncClaudePluginToCli(deps.spawn, RUNNING_VERSION);
+  if (sync.kind === "update_failed") anyFail = true;
+  const updated = sync.kind === "updated";
+  const after = sync.after;
   // 装上了（之前没有）或换了版本 ⇒ 当前会话还挂着旧的，必须重开。
   const restartNeeded = before !== after && after !== undefined;
   if (anyFail) {
     // 修法要对症：已装旧版就是 update（install 原地踏步），没装才是 install。
     const fix = after === null || after === undefined
       ? `claude plugin install ${CLAUDE_PLUGIN}`
-      : `claude plugin update ${CLAUDE_PLUGIN}`;
+      : CLAUDE_PLUGIN_UPDATE_COMMAND;
     return {
       level: "warn",
       msg: `claude 插件未完全装上（best-effort，不阻断；手动 ${fix}，然后重开会话）——能不能被唤醒见下方自检`,
@@ -286,7 +279,7 @@ function installClaudePlugin(deps: JoinDeps): StepOutcome & { restartNeeded: boo
     };
   }
   if (after !== undefined && after !== null && after !== RUNNING_VERSION) {
-    const fix = compareVersions(after, RUNNING_VERSION) > 0 ? "party upgrade" : `claude plugin update ${CLAUDE_PLUGIN}`;
+    const fix = claudePluginMismatchFix(after, RUNNING_VERSION);
     return {
       level: "warn",
       msg: `claude 插件是 ${after}，CLI 是 ${RUNNING_VERSION}，版本不一致时 SessionStart 唤醒不会布上——手动 ${fix}`,

--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -1,4 +1,6 @@
-import { INSTALL_LINE, compareVersions, downloadPartyUpgrade } from "../upgrade";
+import { spawnSync } from "node:child_process";
+import { INSTALL_LINE, compareVersions, downloadPartyUpgrade, type PartyUpgradeOptions, type PartyUpgradeResult } from "../upgrade";
+import { describeClaudePluginSync, syncClaudePluginToCli, type PluginSpawn } from "../claude-plugin-sync";
 
 function help(): string {
   return [
@@ -6,16 +8,42 @@ function help(): string {
     "",
     "Download the GitHub Release binary, verify sha256, and atomically replace the running party binary.",
     "Falls back to the installer when the current executable is not a compiled party binary.",
+    "After the CLI lands, an installed Claude plugin (agentparty@agentparty) is updated to the same version.",
   ].join("\n");
 }
 
-export async function run(argv: string[]): Promise<number> {
+/** 注入点：测试喂假下载 / 假 spawn（不碰网络、不碰真机 claude）。 */
+export interface UpgradeCommandDeps {
+  download: (options: PartyUpgradeOptions) => Promise<PartyUpgradeResult>;
+  spawn: PluginSpawn;
+  log: (line: string) => void;
+  errlog: (line: string) => void;
+}
+
+const defaultDeps: UpgradeCommandDeps = {
+  download: (options) => downloadPartyUpgrade(options),
+  spawn: spawnSync,
+  log: (line) => console.log(line),
+  errlog: (line) => console.error(line),
+};
+
+/**
+ * CLI 落地后顺手把 Claude 插件对齐到同一版本（#985）——否则 `party claude` 立刻 plugin_version_mismatch，
+ * 每次升级都把插件甩在后面。对齐目标是**刚装上的版本**，不是 RUNNING_VERSION（本进程还是旧二进制）。
+ * 只是「顺手」：任何分支都不改 upgrade 的退出码，CLI 已经升好了。
+ */
+function syncClaudePluginAfterUpgrade(deps: UpgradeCommandDeps, cliVersion: string): void {
+  const result = syncClaudePluginToCli(deps.spawn, cliVersion);
+  for (const line of describeClaudePluginSync(result, cliVersion)) deps.log(line);
+}
+
+export async function run(argv: string[], deps: UpgradeCommandDeps = defaultDeps): Promise<number> {
   let version = "latest";
   let checkOnly = false;
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i]!;
     if (arg === "--help" || arg === "-h") {
-      console.log(help());
+      deps.log(help());
       return 0;
     }
     if (arg === "--check") {
@@ -25,39 +53,43 @@ export async function run(argv: string[]): Promise<number> {
     if (arg === "--version") {
       const next = argv[++i];
       if (next === undefined || next.startsWith("-")) {
-        console.error("--version requires X.Y.Z");
+        deps.errlog("--version requires X.Y.Z");
         return 1;
       }
       version = next;
       continue;
     }
-    console.error(`unknown option: ${arg}`);
-    console.log(help());
+    deps.errlog(`unknown option: ${arg}`);
+    deps.log(help());
     return 1;
   }
 
+  let result: PartyUpgradeResult;
   try {
-    const result = await downloadPartyUpgrade({ version, checkOnly });
-    if (checkOnly) {
-      console.log(`running: ${result.running_version}`);
-      console.log(`target:  ${result.target_version} (${result.target})`);
-      if (compareVersions(result.target_version, result.running_version) > 0) {
-        console.log(`upgrade available: ${result.asset_url}`);
-      } else {
-        console.log("already current");
-      }
-      return 0;
-    }
-    if (result.reason === "already_current") {
-      console.log(`party is already current: v${result.running_version}`);
-      return 0;
-    }
-    console.log(`installed party v${result.target_version} -> ${result.install_path}`);
-    console.log("restart running serve/watch processes to use the new binary; serve --auto-upgrade will re-exec at the next safe point.");
-    return 0;
+    result = await deps.download({ version, checkOnly });
   } catch (error) {
-    console.error(`party upgrade failed: ${error instanceof Error ? error.message : String(error)}`);
-    console.error(`fallback: ${INSTALL_LINE}`);
+    deps.errlog(`party upgrade failed: ${error instanceof Error ? error.message : String(error)}`);
+    deps.errlog(`fallback: ${INSTALL_LINE}`);
     return 1;
   }
+  if (checkOnly) {
+    deps.log(`running: ${result.running_version}`);
+    deps.log(`target:  ${result.target_version} (${result.target})`);
+    if (compareVersions(result.target_version, result.running_version) > 0) {
+      deps.log(`upgrade available: ${result.asset_url}`);
+    } else {
+      deps.log("already current");
+    }
+    return 0;
+  }
+  if (result.reason === "already_current") {
+    deps.log(`party is already current: v${result.running_version}`);
+    // CLI 没动，插件仍可能落后（上次升级时 claude 不在 / update 没成）——同样顺手对齐到当前版本。
+    syncClaudePluginAfterUpgrade(deps, result.running_version);
+    return 0;
+  }
+  deps.log(`installed party v${result.target_version} -> ${result.install_path}`);
+  deps.log("restart running serve/watch processes to use the new binary; serve --auto-upgrade will re-exec at the next safe point.");
+  syncClaudePluginAfterUpgrade(deps, result.target_version);
+  return 0;
 }

--- a/cli/test/upgrade.test.ts
+++ b/cli/test/upgrade.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { writeFileSync } from "node:fs";
 import { compareVersions, downloadPartyUpgrade, maybeReexecUpgrade, pendingUpgrade } from "../src/upgrade";
+import { run as runUpgrade, type UpgradeCommandDeps } from "../src/commands/upgrade";
 
 function sha256(bytes: Uint8Array): string {
   const hash = new Bun.CryptoHasher("sha256");
@@ -121,5 +122,146 @@ describe("upgrade", () => {
       installBinary: () => { throw new Error("must not install"); },
     });
     expect(result).toMatchObject({ installed: false, target: "linux-arm64", target_version: "0.2.60" });
+  });
+});
+
+// #985：`party upgrade` 只升 CLI 不升 Claude 插件，升完立刻 plugin_version_mismatch。
+// 桩照真机行为：`plugin update` 才换版本；对齐目标必须是**刚装上的**版本（本进程还是旧二进制）。
+describe("party upgrade syncs the claude plugin (#985)", () => {
+  const PLUGIN = "agentparty@agentparty";
+
+  interface PluginBehavior {
+    noClaude?: boolean;
+    installed: string | null;
+    failUpdate?: boolean;
+    /** update 退出 0 但版本不动（marketplace 还没拿到新 tag）。 */
+    updateNoop?: boolean;
+  }
+
+  function harness(behavior: PluginBehavior, target = "0.2.215", running = "0.2.214") {
+    const record: string[][] = [];
+    const logs: string[] = [];
+    const errs: string[] = [];
+    const state = { installed: behavior.installed };
+    const spawn = ((cmd: string, args: readonly string[]) => {
+      record.push([cmd, ...args]);
+      const base = { pid: 0, output: [], stdout: "", stderr: "", signal: null };
+      if (behavior.noClaude) return { ...base, status: null, error: new Error("spawn ENOENT") };
+      if (cmd === "claude" && args[0] === "plugin" && args[1] === "list") {
+        const rows = state.installed === null
+          ? []
+          : [{ id: PLUGIN, version: state.installed, enabled: true, installPath: "/nowhere/agentparty" }];
+        return { ...base, status: 0, stdout: `${JSON.stringify(rows)}\n` };
+      }
+      if (cmd === "claude" && args[0] === "plugin" && args[1] === "update") {
+        if (behavior.failUpdate) return { ...base, status: 1 };
+        if (!behavior.updateNoop) state.installed = target;
+        return { ...base, status: 0 };
+      }
+      return { ...base, status: 0 };
+    }) as unknown as UpgradeCommandDeps["spawn"];
+    const deps: UpgradeCommandDeps = {
+      download: async () => ({
+        running_version: running,
+        target_version: target,
+        target: "darwin-arm64",
+        asset_url: `https://example.invalid/v${target}/party-darwin-arm64.tar.gz`,
+        installed: target !== running,
+        install_path: "/usr/local/bin/party",
+        ...(target === running ? { reason: "already_current" as const } : {}),
+      }),
+      spawn,
+      log: (line) => logs.push(line),
+      errlog: (line) => errs.push(line),
+    };
+    return { deps, record, logs, errs, state };
+  }
+
+  const updateCalls = (record: string[][]) =>
+    record.filter((r) => r[0] === "claude" && r[1] === "plugin" && r[2] === "update" && r[3] === PLUGIN);
+
+  test("装了旧版插件 ⇒ upgrade 后跑 plugin update，结论行「插件 X → Y，需重开 Claude 会话生效」", async () => {
+    const h = harness({ installed: "0.2.214" });
+    expect(await runUpgrade([], h.deps)).toBe(0);
+    expect(updateCalls(h.record)).toHaveLength(1);
+    expect(h.state.installed).toBe("0.2.215");
+    const line = h.logs.find((l) => l.includes("0.2.214 → 0.2.215"));
+    expect(line).toBeDefined();
+    expect(line).toContain("需重开 Claude 会话");
+    // CLI 自己那行照旧在前面。
+    expect(h.logs[0]).toContain("installed party v0.2.215");
+  });
+
+  test("插件已与新 CLI 同版 ⇒ 不跑 update，只说明无需更新", async () => {
+    const h = harness({ installed: "0.2.215" });
+    expect(await runUpgrade([], h.deps)).toBe(0);
+    expect(updateCalls(h.record)).toHaveLength(0);
+    expect(h.logs.some((l) => l.includes("Claude 插件已是 0.2.215"))).toBe(true);
+    expect(h.logs.some((l) => l.includes("重开"))).toBe(false);
+  });
+
+  test("对齐目标是刚装上的版本，不是本进程的旧版：插件==旧 CLI 版也要 update", async () => {
+    // 真机场景（owner 2026-08-28）：CLI 0.2.214→0.2.215，插件 0.2.214。RUNNING_VERSION 还是 0.2.214，
+    // 若拿它比对会判「已一致」、把插件甩在后面。
+    const h = harness({ installed: "0.2.214" }, "0.2.215", "0.2.214");
+    await runUpgrade([], h.deps);
+    expect(updateCalls(h.record)).toHaveLength(1);
+    expect(h.state.installed).toBe("0.2.215");
+  });
+
+  test("claude 不在 PATH ⇒ 一行说明跳过，不报错，退出码 0", async () => {
+    const h = harness({ noClaude: true, installed: null });
+    expect(await runUpgrade([], h.deps)).toBe(0);
+    expect(updateCalls(h.record)).toHaveLength(0);
+    expect(h.errs).toEqual([]);
+    expect(h.logs.some((l) => l.includes("claude 不在 PATH") && l.includes("跳过"))).toBe(true);
+  });
+
+  test("claude 在但插件没装 ⇒ 不替人装，一行说明跳过", async () => {
+    const h = harness({ installed: null });
+    expect(await runUpgrade([], h.deps)).toBe(0);
+    expect(h.record.some((r) => r[0] === "claude" && r[1] === "plugin" && r[2] === "install")).toBe(false);
+    expect(updateCalls(h.record)).toHaveLength(0);
+    expect(h.logs.some((l) => l.includes("未安装 Claude 插件") && l.includes("跳过"))).toBe(true);
+  });
+
+  test("update 失败 ⇒ 印 `claude plugin update agentparty@agentparty`，upgrade 退出码仍为 0", async () => {
+    const h = harness({ installed: "0.2.214", failUpdate: true });
+    expect(await runUpgrade([], h.deps)).toBe(0);
+    expect(updateCalls(h.record)).toHaveLength(1);
+    expect(h.logs.some((l) => l.includes(`claude plugin update ${PLUGIN}`))).toBe(true);
+    expect(h.logs.some((l) => l.includes("仍是 0.2.214"))).toBe(true);
+    expect(h.logs.some((l) => l.includes("→"))).toBe(false);
+  });
+
+  test("update 退出 0 但版本没动 ⇒ 如实说仍不一致并印修法，不假报「已更新」", async () => {
+    const h = harness({ installed: "0.2.214", updateNoop: true });
+    expect(await runUpgrade([], h.deps)).toBe(0);
+    expect(h.logs.some((l) => l.includes("→"))).toBe(false);
+    expect(h.logs.some((l) => l.includes("仍是 0.2.214") && l.includes(`claude plugin update ${PLUGIN}`))).toBe(true);
+  });
+
+  test("CLI 已是最新（already_current）时插件落后同样顺手对齐到当前版本", async () => {
+    const h = harness({ installed: "0.2.214" }, "0.2.215", "0.2.215");
+    expect(await runUpgrade([], h.deps)).toBe(0);
+    expect(h.logs[0]).toContain("already current");
+    expect(updateCalls(h.record)).toHaveLength(1);
+    expect(h.logs.some((l) => l.includes("0.2.214 → 0.2.215") && l.includes("重开"))).toBe(true);
+  });
+
+  test("--check 只看不装，也不碰插件", async () => {
+    const h = harness({ installed: "0.2.214" });
+    expect(await runUpgrade(["--check"], h.deps)).toBe(0);
+    expect(h.record).toEqual([]);
+    expect(h.logs.some((l) => l.startsWith("upgrade available:"))).toBe(true);
+  });
+
+  test("下载失败 ⇒ 退出 1、印 fallback，不碰插件", async () => {
+    const h = harness({ installed: "0.2.214" });
+    h.deps.download = async () => { throw new Error("boom"); };
+    expect(await runUpgrade([], h.deps)).toBe(1);
+    expect(h.record).toEqual([]);
+    expect(h.errs[0]).toContain("party upgrade failed: boom");
+    expect(h.errs[1]).toContain("fallback:");
   });
 });


### PR DESCRIPTION
## 根因

`party upgrade` 只换 CLI 二进制。本机 `agentparty@agentparty` 插件停在旧版，随后 `party claude` preflight / doctor 立刻 `plugin_version_mismatch`，唤醒层不可用，要手动 `claude plugin update agentparty@agentparty` 再重开会话。#961/#967 只在 `party join --harness claude` 里做了「install 后读版本 ≠ CLI 就 update」，upgrade 这条更常走的路没做，每次升级都把插件甩在后面。

## 修法

- **新增 `cli/src/claude-plugin-sync.ts`**（join 与 upgrade 共用，不复制）：
  - `probeInstalledClaudePlugin` / `installedClaudePluginVersion`：读已装版本，复用 doctor 的 `parseClaudePluginList`；区分「claude 不可用」「读不出」「没装」「已装 X」。
  - `syncClaudePluginToCli(spawn, cliVersion)`：≠ cliVersion 就跑 `claude plugin update`，再读一次核实；返回 `current | updated | update_failed | still_mismatched | not_installed | unreadable | claude_unavailable`，任何分支不抛。
  - `claudePluginMismatchFix`：插件比 CLI 新 ⇒ `party upgrade`，旧 ⇒ `claude plugin update …`（原 join 里的判据搬过来）。
  - `describeClaudePluginSync`：upgrade 收尾给人看的那一行。
- **`cli/src/commands/upgrade.ts`**：CLI 落地后（`installed` 与 `already_current` 两条路都做）对齐插件到**刚装上的目标版本**，而不是 `RUNNING_VERSION`——upgrade 进程本身还是旧二进制，拿 RUNNING_VERSION 比对会判「已一致」（这正是 owner 真机 0.2.214→0.2.215 的场景）。
  - 结论行：`Claude 插件 0.2.214 → 0.2.215，需重开 Claude 会话生效（当前会话仍挂着旧插件）`
  - claude 不在 PATH / 插件没装 / 清单读不出 ⇒ 一行说明跳过，不进 stderr
  - update 失败或跑完版本仍不动 ⇒ 印 `claude plugin update agentparty@agentparty`，退出码仍为 0（CLI 已升）
  - `--check` 与下载失败路径不碰插件
  - `run(argv, deps)` 加注入点（download / spawn / log / errlog）便于测试，默认行为不变
- **`cli/src/commands/join.ts`**：`installClaudePlugin` 改调共享模块（常量、读版本、update、修法判据全部从 `claude-plugin-sync` 来），只做抽函数的最小改动；未碰 `claude-launch.ts`。

### codex 插件

join 的 codex 档只有 `codex plugin marketplace add` + `codex plugin add agentparty@agentparty`，代码里没有任何「读已装版本 / 版本比对 / update」路径，doctor 也不检查 codex 插件版本；`codex plugin` 子命令目前没有对应的 `list --json` 判据可复用。没有同样的版本对齐路径，本 PR 不做，避免凭空造一条没有判据的命令。

## 测试证据

```
bunx tsc --noEmit -p cli/tsconfig.json            # 无输出（通过）
bun test cli/test/upgrade.test.ts cli/test/join.test.ts cli/test/doctor-plugin.test.ts
 70 pass / 0 fail / 305 expect() calls
```

`cli/test/upgrade.test.ts` 新增 `party upgrade syncs the claude plugin (#985)`，桩照真机行为（只有 `plugin update` 才换版本）：

1. 装了旧版插件 ⇒ 跑 update 一次，结论含 `0.2.214 → 0.2.215` 与 `需重开 Claude 会话`
2. 插件已与新 CLI 同版 ⇒ 不跑 update
3. 对齐目标是刚装上的版本：插件 == 旧 CLI 版（RUNNING_VERSION）也要 update
4. claude 不在 PATH ⇒ 一行「跳过」，stderr 为空，退出 0
5. claude 在但插件没装 ⇒ 不替人 install，一行「跳过」
6. update 失败 ⇒ 印 `claude plugin update agentparty@agentparty`，退出码 0，不印 `→`
7. update 退出 0 但版本没动 ⇒ 如实说仍不一致 + 修法，不假报已更新
8. `already_current` 时插件落后同样对齐
9. `--check` / 下载失败不碰插件

join 现有 `#961` 用例（旧版→update、没装→install 不 update、update 失败→修法是 update）原样通过。

### 变异自检

- 去掉版本比对、恒判「已一致」（不跑 update）⇒ **7 红**：第一条「装了旧版插件 ⇒ 跑 update」红，另有 join 的两条 #961 用例红。
- 去掉等版短路（恒跑 update）⇒ **3 红**：「同版不跑 update」红，join 的「没装→install 不跑 update」红。
- 恢复后 70/70 绿。

Closes #985

https://claude.ai/code/session_01Az8CnUpayZzqpi1sh32Ssi
