### PR TITLE
fix(cli): party claude 改用 --dangerously-load-development-channels 加载插件频道，与 bridge 同一个函数拼参数 (#984)

### DIFF
--- a/cli/src/commands/bridge.ts
+++ b/cli/src/commands/bridge.ts
@@ -42,6 +42,7 @@ import { isName, isSlug } from "../validation";
 import {
   CLAUDE_CHANNEL_OPT_IN_ENV,
   CLAUDE_LIFECYCLE_OPT_IN_ENV,
+  claudeChannelLoadArgs,
 } from "./claude-launch";
 import {
   defaultClaudePluginDoctorDependencies,
@@ -887,8 +888,8 @@ export function buildClaudeBridgeLaunch(options: {
     args: [
       "--mcp-config",
       JSON.stringify(mcpConfig),
-      "--dangerously-load-development-channels",
-      `server:${CHANNEL_SERVER_NAME}`,
+      // 与 `party claude` 同一个函数拼频道加载参数（#984）：两条入口不许再漂移。
+      ...claudeChannelLoadArgs(`server:${CHANNEL_SERVER_NAME}`),
       ...(crossSessionReady
         ? [
             "--append-system-prompt",

--- a/cli/src/commands/claude-launch.ts
+++ b/cli/src/commands/claude-launch.ts
@@ -12,12 +12,39 @@ import {
 import { agentpartyHome } from "../config";
 import { isSlug } from "../validation";
 import {
+  claudePluginDoctorFixLines,
   inspectClaudePluginReadiness,
   type ClaudePluginDoctorBlocker,
   type ClaudePluginDoctorReport,
 } from "./doctor";
 
 export const CLAUDE_CHANNEL_PLUGIN = "plugin:agentparty@agentparty";
+/**
+ * Claude 加载频道服务器的唯一入口（#984）。
+ *
+ * `--channels <entry>` 受 Claude 的 `allowedChannelPlugins` 门控：那是 managed-only 设置
+ * （与 allowedMcpServers / availableModels 同组，"highest source owns it whole"），个人账号在
+ * 自己的 settings.json 里改不了；默认名单来自 Anthropic 远端的 `tengu_harbor_ledger`，只有
+ * telegram/discord/imessage 那几个官方插件。所以插件频道在个人账号上永远 "not on the approved
+ * channels allowlist"，只能走 `--dangerously-load-development-channels <entry>`（启动时弹一次
+ * "Loading development channels" 确认框）。
+ *
+ * 用真二进制（claude 2.1.250）核过的两个事实，决定了这里**只**传 dev flag、**不**同时传
+ * `--channels`：
+ * 1. 两个 flag 的值同一个解析器，形态一样：`plugin:<name>@<marketplace>` 或 `server:<name>`，
+ *    不带标签直接报 "entries must be tagged"。
+ * 2. `--channels` 的条目先进 allowedChannels，dev 条目在确认框之后**追加**在后面；注册门
+ *    `findChannelEntry` 用 Array.find 取**第一个**同名条目——同时传两者时命中的是 `--channels`
+ *    那个非 dev 条目，照样走 allowlist 判定、照样被拒（实测："Channel notifications skipped:
+ *    … not on the approved channels allowlist"）；只传 dev flag 才 "Channel notifications
+ *    registered"。`party bridge claude` 一直只传 dev flag，所以起得来。
+ *
+ * `party claude` 与 `party bridge claude` 都必须经这个函数拼参数，测试钉住两处不再漂移。
+ */
+export const CLAUDE_DEV_CHANNELS_FLAG = "--dangerously-load-development-channels";
+export function claudeChannelLoadArgs(entry: string): string[] {
+  return [CLAUDE_DEV_CHANNELS_FLAG, entry];
+}
 export const CLAUDE_CHANNEL_OPT_IN_ENV = "AGENTPARTY_CLAUDE_CHANNEL_OPT_IN";
 /**
  * Authorizes the Marketplace lifecycle hooks to publish activity and guard a
@@ -39,6 +66,13 @@ Before launch, require the enabled plugin, an agent token, channel access, and
 no existing durable listener. Claude Cross-session uses party bridge claude
 instead; do not stack the two launch paths.
 
+The plugin channel is loaded with ${CLAUDE_DEV_CHANNELS_FLAG} ${CLAUDE_CHANNEL_PLUGIN}
+(Claude's allowedChannelPlugins allowlist is managed-only and cannot be edited on a
+personal account), so Claude shows one "Loading development channels" confirmation
+at startup; pick "I am using this for local development". Do not add
+--channels ${CLAUDE_CHANNEL_PLUGIN} yourself: that entry shadows the development
+one and the channel is refused again.
+
 Default launch args are opt-in per machine and never hard-coded: only what you
 wrote with --default-args (file: $AGENTPARTY_HOME/claude-default-args.json;
 fallback env ${CLAUDE_DEFAULT_ARGS_ENV}, lower priority) is prepended before your
@@ -53,6 +87,8 @@ export interface ClaudeLaunchDependencies {
   preflight(channel: string | undefined): Promise<{
     blockers: ClaudePluginDoctorBlocker[];
     listener: ClaudePluginDoctorReport["channel"]["listener"];
+    /** doctor 的逐项修法（#984：拒绝启动时直接印出来，不再只丢一句「去跑 doctor」）。 */
+    fix_lines?: string[];
   }>;
   launch(args: string[], env: NodeJS.ProcessEnv): ClaudeLaunchResult;
   /** 本机偏好根（默认 `agentpartyHome(env)`）；测试用临时目录注入。 */
@@ -63,7 +99,11 @@ export interface ClaudeLaunchDependencies {
 const defaultDependencies: ClaudeLaunchDependencies = {
   preflight: async (channel) => {
     const report = await inspectClaudePluginReadiness(channel);
-    return { blockers: report.blockers, listener: report.channel.listener };
+    return {
+      blockers: report.blockers,
+      listener: report.channel.listener,
+      fix_lines: claudePluginDoctorFixLines(report),
+    };
   },
   launch: (args, env) => spawnSync("claude", args, { stdio: "inherit", env }),
 };
@@ -74,8 +114,12 @@ export function claudeLaunchPlan(
   env: NodeJS.ProcessEnv = process.env,
   defaultArgs: string[] = [],
 ): { args: string[]; env: NodeJS.ProcessEnv } {
+  // 频道加载参数是启动必需项，不是用户偏好：永远由启动器拼，不走 #978 的默认参数机制。
+  // 但沿用 mergeClaudeArgs 的同名判定——用户在默认参数或显式 `--` 里自己写了
+  // --dangerously-load-development-channels，就以用户的为准、不重复拼（run() 会提醒必须自带插件条目）。
+  const userArgs = mergeClaudeArgs(defaultArgs, claudeArgs);
   return {
-    args: ["--channels", CLAUDE_CHANNEL_PLUGIN, ...mergeClaudeArgs(defaultArgs, claudeArgs)],
+    args: mergeClaudeArgs(claudeChannelLoadArgs(CLAUDE_CHANNEL_PLUGIN), userArgs),
     env: {
       ...env,
       [CLAUDE_CHANNEL_OPT_IN_ENV]: "1",
@@ -83,6 +127,34 @@ export function claudeLaunchPlan(
       ...(channel === undefined ? {} : { AGENTPARTY_CHANNEL: channel }),
     },
   };
+}
+
+function hasFlag(args: string[], flag: string): boolean {
+  return args.some((arg) => arg === flag || arg.startsWith(`${flag}=`));
+}
+
+/**
+ * 启动前关于频道加载方式的提示（纯函数，可测）。`userArgs` 是默认参数与显式 `--` 合并后的用户参数。
+ * 第一条永远打印：让人知道为什么会弹确认框、该选哪个；后两条只在用户自己碰了这两个 flag 时出现。
+ */
+export function claudeChannelLaunchNotices(userArgs: string[]): string[] {
+  const lines = [
+    `频道加载：${CLAUDE_DEV_CHANNELS_FLAG} ${CLAUDE_CHANNEL_PLUGIN}` +
+      "（Claude 的 allowedChannelPlugins 名单是 managed-only，个人账号改不了，插件频道只能按 development channel 加载）；" +
+      "Claude 启动会弹一次「Loading development channels」确认框，选「I am using this for local development」即可。",
+  ];
+  if (hasFlag(userArgs, CLAUDE_DEV_CHANNELS_FLAG)) {
+    lines.push(
+      `注意：你自己给了 ${CLAUDE_DEV_CHANNELS_FLAG}，启动器不再替你补；它的值里必须包含 ${CLAUDE_CHANNEL_PLUGIN}，否则频道不会武装。`,
+    );
+  }
+  if (hasFlag(userArgs, "--channels")) {
+    lines.push(
+      `注意：--channels 的条目会遮住同名的 development 条目（Claude 取第一个匹配），` +
+        `带上 --channels ${CLAUDE_CHANNEL_PLUGIN} 会让频道再次被 allowlist 拒掉；请去掉它。`,
+    );
+  }
+  return lines;
 }
 
 function dangerousFlagNotice(args: string[]): string | null {
@@ -174,7 +246,17 @@ export async function run(
     const detail = launchBlockers.length > 0
       ? launchBlockers.join(", ")
       : `listener_${readiness.listener}`;
-    console.error(`AgentParty Channel is not launch-ready (${detail}); run: party doctor claude-plugin --json`);
+    console.error(`AgentParty Channel is not launch-ready (${detail})`);
+    for (const line of readiness.fix_lines ?? []) console.error(line);
+    if (launchBlockers.includes("plugin_state_unavailable")) {
+      // 读不到插件状态 ≠ 插件坏了：`claude plugin list --json` 没在 10s 内返回（Claude 慢、正在自更新、
+      // 登录过期都会这样）。别让人去改插件，先重试。
+      console.error(
+        "  hint: `claude plugin list --json` did not answer within 10s (Claude slow, self-updating, or logged out); retry, then: party doctor claude-plugin --json",
+      );
+    } else {
+      console.error("  details: party doctor claude-plugin --json");
+    }
     return 1;
   }
   const defaults = resolveClaudeDefaultArgs(env, home);
@@ -184,6 +266,7 @@ export async function run(
     const notice = dangerousFlagNotice(defaults.args);
     if (notice !== null) console.log(notice);
   }
+  for (const line of claudeChannelLaunchNotices(mergeClaudeArgs(defaults.args, claudeArgs))) console.log(line);
   const plan = claudeLaunchPlan(channel, claudeArgs, env, defaults.args);
   const result = deps.launch(plan.args, plan.env);
   if (result.error !== undefined) {

--- a/cli/src/commands/doctor.ts
+++ b/cli/src/commands/doctor.ts
@@ -492,8 +492,17 @@ export function claudePluginDoctorFixLines(
   if (report.blockers.includes("identity_not_agent")) {
     lines.push("  fix: bind an agent token with party init --token <agent-token> --channel <channel>");
   }
+  if (report.blockers.includes("plugin_state_unavailable")) {
+    lines.push(
+      "  fix: `claude plugin list --json` did not answer within 10s (Claude slow, self-updating, or logged out); retry, then check `claude plugin list`",
+    );
+  }
   if (report.blockers.includes("listener_not_observed")) {
-    lines.push("  fix: start a fresh channel session with party claude <channel>");
+    // #984：doctor 看不到 Claude 的频道 allowlist（它是 Anthropic 远端下发的 ledger，个人账号改不了），
+    // 所以直接把「怎么加载、会弹什么」写进结论，而不是让人撞上 "not on the approved channels allowlist" 再回来。
+    lines.push(
+      "  fix: start a fresh channel session with party claude <channel> (it loads the plugin channel with --dangerously-load-development-channels because the allowedChannelPlugins allowlist is managed-only; Claude shows one \"Loading development channels\" confirmation at startup)",
+    );
   }
   return lines;
 }

--- a/cli/test/claude-launch-default-args.test.ts
+++ b/cli/test/claude-launch-default-args.test.ts
@@ -13,13 +13,14 @@ import {
   writeClaudeDefaultArgs,
 } from "../src/claude-default-args";
 import {
-  CLAUDE_CHANNEL_PLUGIN,
   claudeLaunchPlan,
   run,
   type ClaudeLaunchDependencies,
 } from "../src/commands/claude-launch";
 
 const SKIP = "--dangerously-skip-permissions";
+// #984：频道按 development channel 加载（字面量，故意不引用 claudeChannelLoadArgs——去掉 flag 必须红）。
+const CHANNEL_LOAD = ["--dangerously-load-development-channels", "plugin:agentparty@agentparty"];
 
 let home: string;
 let logs: string[];
@@ -141,17 +142,16 @@ describe("party claude launch with defaults", () => {
   test("no config ⇒ args unchanged and no defaults line printed", async () => {
     const { deps, calls } = launcher();
     expect(await run(["dev", "--", "--model", "sonnet"], deps)).toBe(0);
-    expect(calls[0]!.args).toEqual(["--channels", CLAUDE_CHANNEL_PLUGIN, "--model", "sonnet"]);
+    expect(calls[0]!.args).toEqual([...CHANNEL_LOAD, "--model", "sonnet"]);
     expect(logs.some((line) => line.includes("默认参数"))).toBe(false);
   });
 
-  test("configured defaults go after --channels <plugin> and before explicit -- args", async () => {
+  test("configured defaults go after the channel-load args and before explicit -- args", async () => {
     writeClaudeDefaultArgs(home, [SKIP]);
     const { deps, calls } = launcher();
     expect(await run(["dev", "--", "--model", "sonnet"], deps)).toBe(0);
     expect(calls[0]!.args).toEqual([
-      "--channels",
-      CLAUDE_CHANNEL_PLUGIN,
+      ...CHANNEL_LOAD,
       SKIP,
       "--model",
       "sonnet",
@@ -163,7 +163,7 @@ describe("party claude launch with defaults", () => {
     writeClaudeDefaultArgs(home, [SKIP]);
     const { deps, calls } = launcher();
     expect(await run(["ludo"], deps)).toBe(0);
-    expect(calls[0]!.args).toEqual(["--channels", CLAUDE_CHANNEL_PLUGIN, SKIP]);
+    expect(calls[0]!.args).toEqual([...CHANNEL_LOAD, SKIP]);
   });
 
   test("explicit arg duplicating a default is not inserted twice", async () => {
@@ -171,8 +171,7 @@ describe("party claude launch with defaults", () => {
     const { deps, calls } = launcher();
     expect(await run(["dev", "--", SKIP, "--model", "sonnet"], deps)).toBe(0);
     expect(calls[0]!.args).toEqual([
-      "--channels",
-      CLAUDE_CHANNEL_PLUGIN,
+      ...CHANNEL_LOAD,
       SKIP,
       "--model",
       "sonnet",
@@ -192,7 +191,7 @@ describe("party claude launch with defaults", () => {
   test("env fallback applies when no file exists and is reported as the env source", async () => {
     const { deps, calls } = launcher({ [CLAUDE_DEFAULT_ARGS_ENV]: "--model haiku" });
     await run(["dev"], deps);
-    expect(calls[0]!.args).toEqual(["--channels", CLAUDE_CHANNEL_PLUGIN, "--model", "haiku"]);
+    expect(calls[0]!.args).toEqual([...CHANNEL_LOAD, "--model", "haiku"]);
     expect(logs.find((entry) => entry.startsWith("默认参数："))).toBe(
       `默认参数：--model haiku（来自 环境变量 ${CLAUDE_DEFAULT_ARGS_ENV}）`,
     );
@@ -200,12 +199,11 @@ describe("party claude launch with defaults", () => {
 
   test("claudeLaunchPlan without defaults keeps the original shape", () => {
     expect(claudeLaunchPlan("dev", ["--model", "sonnet"], {}).args).toEqual([
-      "--channels",
-      CLAUDE_CHANNEL_PLUGIN,
+      ...CHANNEL_LOAD,
       "--model",
       "sonnet",
     ]);
-    expect(claudeLaunchPlan(undefined, [], {}, [SKIP]).args).toEqual(["--channels", CLAUDE_CHANNEL_PLUGIN, SKIP]);
+    expect(claudeLaunchPlan(undefined, [], {}, [SKIP]).args).toEqual([...CHANNEL_LOAD, SKIP]);
   });
 });
 
@@ -230,7 +228,7 @@ describe("party claude --default-args / --show-default-args", () => {
 
     logs = [];
     expect(await run(["dev", "--", "--model", "sonnet"], deps)).toBe(0);
-    expect(calls[0]!.args).toEqual(["--channels", CLAUDE_CHANNEL_PLUGIN, "--model", "sonnet"]);
+    expect(calls[0]!.args).toEqual([...CHANNEL_LOAD, "--model", "sonnet"]);
     expect(logs.some((line) => line.includes("默认参数"))).toBe(false);
   });
 

--- a/cli/test/claude-launch.test.ts
+++ b/cli/test/claude-launch.test.ts
@@ -5,11 +5,19 @@ import { join } from "node:path";
 import {
   CLAUDE_CHANNEL_OPT_IN_ENV,
   CLAUDE_CHANNEL_PLUGIN,
+  CLAUDE_DEV_CHANNELS_FLAG,
   CLAUDE_LIFECYCLE_OPT_IN_ENV,
+  claudeChannelLaunchNotices,
+  claudeChannelLoadArgs,
   claudeLaunchPlan,
   run,
   type ClaudeLaunchDependencies,
 } from "../src/commands/claude-launch";
+import { buildClaudeBridgeLaunch } from "../src/commands/bridge";
+
+// #984：插件频道只能按 development channel 加载（allowedChannelPlugins 是 managed-only）。
+// 字面量、不引用 claudeChannelLoadArgs：去掉 flag 或改回 --channels，这里必须红。
+const CHANNEL_LOAD = ["--dangerously-load-development-channels", "plugin:agentparty@agentparty"];
 
 describe("party claude launcher", () => {
   test("arms exactly one Marketplace Channel launch and forwards Claude args", async () => {
@@ -29,11 +37,11 @@ describe("party claude launcher", () => {
     expect(await run(["dev", "--", "--model", "sonnet"], deps)).toBe(7);
     expect(calls).toHaveLength(1);
     expect(calls[0]!.args).toEqual([
-      "--channels",
-      CLAUDE_CHANNEL_PLUGIN,
+      ...CHANNEL_LOAD,
       "--model",
       "sonnet",
     ]);
+    expect(calls[0]!.args).not.toContain("--channels");
     expect(calls[0]!.env[CLAUDE_CHANNEL_OPT_IN_ENV]).toBe("1");
     expect(calls[0]!.env[CLAUDE_LIFECYCLE_OPT_IN_ENV]).toBe("1");
     expect(calls[0]!.env.AGENTPARTY_CHANNEL).toBe("dev");
@@ -41,7 +49,7 @@ describe("party claude launcher", () => {
 
   test("does not invent a channel when the bound channel should be used", () => {
     const plan = claudeLaunchPlan(undefined, [], { KEEP: "yes" });
-    expect(plan.args).toEqual(["--channels", CLAUDE_CHANNEL_PLUGIN]);
+    expect(plan.args).toEqual([...CHANNEL_LOAD]);
     expect(plan.env).toMatchObject({
       KEEP: "yes",
       [CLAUDE_CHANNEL_OPT_IN_ENV]: "1",
@@ -87,5 +95,104 @@ describe("party claude launcher", () => {
     });
     expect(code).toBe(1);
     expect(launched).toBe(false);
+  });
+
+  test("an explicit --dangerously-load-development-channels replaces the launcher's, never duplicates it", () => {
+    const explicit = [CLAUDE_DEV_CHANNELS_FLAG, "plugin:agentparty@agentparty", "--model", "sonnet"];
+    expect(claudeLaunchPlan("dev", explicit, {}).args).toEqual(explicit);
+    // 用户在本机默认参数里写了它也一样（默认参数也是用户显式写下的意图）。
+    expect(claudeLaunchPlan("dev", [], {}, [CLAUDE_DEV_CHANNELS_FLAG, "server:mine"]).args).toEqual([
+      CLAUDE_DEV_CHANNELS_FLAG,
+      "server:mine",
+    ]);
+    expect(
+      claudeLaunchPlan("dev", ["--model", "sonnet"], {}, ["--dangerously-skip-permissions"]).args,
+    ).toEqual([...CHANNEL_LOAD, "--dangerously-skip-permissions", "--model", "sonnet"]);
+  });
+
+  test("launch notices explain the confirmation dialog and warn when the user touches the two channel flags", async () => {
+    const plain = claudeChannelLaunchNotices(["--model", "sonnet"]);
+    expect(plain).toHaveLength(1);
+    expect(plain[0]).toContain(CLAUDE_DEV_CHANNELS_FLAG);
+    expect(plain[0]).toContain("Loading development channels");
+    expect(plain[0]).toContain("I am using this for local development");
+
+    const own = claudeChannelLaunchNotices([CLAUDE_DEV_CHANNELS_FLAG, "server:mine"]);
+    expect(own).toHaveLength(2);
+    expect(own[1]).toContain(CLAUDE_CHANNEL_PLUGIN);
+
+    // `--channels plugin:agentparty@agentparty` 会遮住 development 条目（真二进制实测），必须点名。
+    const shadow = claudeChannelLaunchNotices(["--channels", CLAUDE_CHANNEL_PLUGIN]);
+    expect(shadow).toHaveLength(2);
+    expect(shadow[1]).toContain("--channels");
+    expect(claudeChannelLaunchNotices([`--channels=${CLAUDE_CHANNEL_PLUGIN}`])).toHaveLength(2);
+
+    const logs: string[] = [];
+    const original = console.log;
+    console.log = (...args: unknown[]) => logs.push(args.map(String).join(" "));
+    try {
+      const home = mkdtempSync(join(tmpdir(), "agentparty-claude-launch-"));
+      const code = await run(["dev"], {
+        preflight: async () => ({ blockers: ["listener_not_observed"], listener: "not_observed" }),
+        launch: () => ({ status: 0 }),
+        home,
+        env: {},
+      });
+      expect(code).toBe(0);
+    } finally {
+      console.log = original;
+    }
+    expect(logs.some((line) => line.startsWith("频道加载：") && line.includes("Loading development channels"))).toBe(true);
+  });
+
+  test("a refused launch prints doctor's fix lines instead of only pointing at doctor", async () => {
+    const errors: string[] = [];
+    const original = console.error;
+    console.error = (...args: unknown[]) => errors.push(args.map(String).join(" "));
+    try {
+      const code = await run(["dev"], {
+        preflight: async () => ({
+          blockers: ["plugin_state_unavailable", "listener_not_observed"],
+          listener: "not_observed",
+          fix_lines: ["  fix: something concrete"],
+        }),
+        launch: () => ({ status: 0 }),
+      });
+      expect(code).toBe(1);
+    } finally {
+      console.error = original;
+    }
+    expect(errors[0]).toBe("AgentParty Channel is not launch-ready (plugin_state_unavailable)");
+    expect(errors).toContain("  fix: something concrete");
+    expect(errors.some((line) => line.includes("claude plugin list --json") && line.includes("retry"))).toBe(true);
+  });
+});
+
+describe("channel loading is one shape on both Claude launch paths (#984)", () => {
+  // 守卫：`party claude` 与 `party bridge claude` 的频道加载参数必须出自同一个函数。
+  // Claude 对 --channels 与 --dangerously-load-development-channels 用同一个解析器，值同形态
+  // （plugin:<name>@<marketplace> / server:<name>）；两条入口只传 dev flag、都不传 --channels。
+  const subsequence = (haystack: string[], needle: string[]): boolean =>
+    haystack.some((_, i) => needle.every((token, j) => haystack[i + j] === token));
+
+  test("party claude loads the plugin entry through claudeChannelLoadArgs and nothing else", () => {
+    expect(claudeChannelLoadArgs(CLAUDE_CHANNEL_PLUGIN)).toEqual(CHANNEL_LOAD);
+    const plan = claudeLaunchPlan("dev", ["--model", "sonnet"], {});
+    expect(plan.args.slice(0, 2)).toEqual(claudeChannelLoadArgs(CLAUDE_CHANNEL_PLUGIN));
+    expect(plan.args).not.toContain("--channels");
+    expect(plan.args.filter((arg) => arg === CLAUDE_DEV_CHANNELS_FLAG)).toHaveLength(1);
+  });
+
+  test("party bridge claude loads its server entry through the same function", () => {
+    const launch = buildClaudeBridgeLaunch({
+      channel: "dev",
+      claudeArgs: ["--model", "opus"],
+      execPath: "/opt/homebrew/bin/bun",
+      processArgv: ["/opt/homebrew/bin/bun", "/repo/cli/src/index.ts", "bridge", "claude"],
+    });
+    expect(subsequence(launch.args, claudeChannelLoadArgs("server:agentparty-channel"))).toBe(true);
+    expect(subsequence(launch.args, ["--dangerously-load-development-channels", "server:agentparty-channel"])).toBe(true);
+    expect(launch.args).not.toContain("--channels");
+    expect(launch.args.filter((arg) => arg === CLAUDE_DEV_CHANNELS_FLAG)).toHaveLength(1);
   });
 });

--- a/plugins/agentparty/skills/agentparty/SKILL.md
+++ b/plugins/agentparty/skills/agentparty/SKILL.md
@@ -197,7 +197,12 @@ The Marketplace plugin packages this skill with two thin platform shells. Codex 
 generic `party mcp` entry. Claude also receives lifecycle hooks plus a declared
 `agentparty-channel` server backed by `party claude-channel`. Start a fresh Claude session with
 `party claude <channel>` to let durable channel events enter the open
-main session without waiting for the model to poll. Extra Claude flags go after `--`
+main session without waiting for the model to poll. It loads the plugin channel with
+`--dangerously-load-development-channels plugin:agentparty@agentparty` (Claude's
+`allowedChannelPlugins` allowlist is managed-only and cannot be edited on a personal account), so
+Claude shows one "Loading development channels" confirmation at startup; pick "I am using this for
+local development". Never add `--channels plugin:agentparty@agentparty` yourself: that entry shadows
+the development one and the channel is refused again. Extra Claude flags go after `--`
 (`party claude <channel> -- --model sonnet`); to stop retyping them, set machine-local defaults once
 with `party claude --default-args -- <claude args...>` (stored in
 `$AGENTPARTY_HOME/claude-default-args.json`, prepended before explicit `--` args, printed with

--- a/skills/agentparty/SKILL.md
+++ b/skills/agentparty/SKILL.md
@@ -197,7 +197,12 @@ The Marketplace plugin packages this skill with two thin platform shells. Codex 
 generic `party mcp` entry. Claude also receives lifecycle hooks plus a declared
 `agentparty-channel` server backed by `party claude-channel`. Start a fresh Claude session with
 `party claude <channel>` to let durable channel events enter the open
-main session without waiting for the model to poll. Extra Claude flags go after `--`
+main session without waiting for the model to poll. It loads the plugin channel with
+`--dangerously-load-development-channels plugin:agentparty@agentparty` (Claude's
+`allowedChannelPlugins` allowlist is managed-only and cannot be edited on a personal account), so
+Claude shows one "Loading development channels" confirmation at startup; pick "I am using this for
+local development". Never add `--channels plugin:agentparty@agentparty` yourself: that entry shadows
+the development one and the channel is refused again. Extra Claude flags go after `--`
 (`party claude <channel> -- --model sonnet`); to stop retyping them, set machine-local defaults once
 with `party claude --default-args -- <claude args...>` (stored in
 `$AGENTPARTY_HOME/claude-default-args.json`, prepended before explicit `--` args, printed with


### PR DESCRIPTION
## 根因

- `--channels <entry>` 受 Claude 的 `allowedChannelPlugins` 门控。它是 managed-only 设置（与 `allowedMcpServers` / `availableModels` / `strictKnownMarketplaces` 同组，"the highest source that sets one owns it whole"），个人账号在自己的 settings.json 里改不了；没有 org 值时名单来自 Anthropic 远端下发的 `tengu_harbor_ledger`（GrowthBook），默认只有官方的 telegram/discord/imessage/fakechat。插件频道在个人账号上永远 `not on the approved channels allowlist`。
- `party bridge claude` 一直传 `--dangerously-load-development-channels server:agentparty-channel`（`bridge.ts`），`party claude` 的 `claudeLaunchPlan` 只传 `--channels plugin:agentparty@agentparty`——两条本应等价的入口不一致，bridge 起得来、`party claude` 起不来。

## 用 claude 2.1.250 真二进制核实的结论（flag 值形态 + 拼法）

两个 flag 都是 `.hideHelp()`，`--help` 里看不到；用 `strings -a` 读解析逻辑，再用一个只声明 `experimental["claude/channel"]` 的假 stdio MCP + `--debug-file` 在真交互式 claude 里实测三种拼法：

1. **值同形态**：`--channels` 与 `--dangerously-load-development-channels` 共用同一个解析函数，条目必须是 `plugin:<name>@<marketplace>` 或 `server:<name>`，否则直接报 `entries must be tagged`。所以 `party claude` 用 `plugin:agentparty@agentparty`、bridge 用 `server:agentparty-channel`，各自正确。
2. **不能两个都传**：`--channels` 条目先进 allowedChannels；dev 条目要在「Loading development channels」确认框接受后才 `[...allowedChannels, ...dev(dev:true)]` **追加在后面**。注册门 `findChannelEntry` 用 `Array.find` 取**第一个**同名条目——两个都传时命中的是 `--channels` 那条非 dev 条目，照样走 allowlist 判定、照样被拒。实测日志：

   | 拼法 | `--debug-file` 结果 |
   |---|---|
   | `--channels server:x` | `Channel notifications skipped: server x is not on the approved channels allowlist (use --dangerously-load-development-channels for local dev)` |
   | `--channels server:x --dangerously-load-development-channels server:x`（确认框已接受） | 同上，**skipped** |
   | `--dangerously-load-development-channels server:x` | `Channel notifications registered` |

   `plugin:` 与 `server:` 走同一条 `findChannelEntry` + 追加逻辑（plugin 只多一道 marketplace 相符判定），所以结论对 `plugin:agentparty@agentparty` 同样成立。这也意味着 issue 里 owner 的临时绕过 `party claude ludo -- --dangerously-load-development-channels plugin:agentparty@agentparty` 在旧代码下其实仍会被 `--channels` 那条遮住；`party bridge claude` 的绕过才是真起作用的那个。

因此 `party claude` **只传** `--dangerously-load-development-channels plugin:agentparty@agentparty`，**不再传** `--channels`（issue 里「紧跟在 `--channels` 之后」的测试期望据此改为「没有 `--channels`」）。

## 修法

- `cli/src/commands/claude-launch.ts`
  - 新增 `CLAUDE_DEV_CHANNELS_FLAG` 与 `claudeChannelLoadArgs(entry)`，注释写明上面两条核实事实。
  - `claudeLaunchPlan`：`mergeClaudeArgs(claudeChannelLoadArgs(CLAUDE_CHANNEL_PLUGIN), mergeClaudeArgs(defaultArgs, claudeArgs))`——复用 #978 的同名判定：用户在显式 `--` 或本机默认参数里自己给了 `--dangerously-load-development-channels` 就以用户的为准、不重复拼；flag 本身不进默认参数机制。
  - 启动前打印 `频道加载：… 会弹一次「Loading development channels」确认框，选「I am using this for local development」`；用户自己带了 `--channels`（会遮住 dev 条目）或 dev flag（必须自带插件条目）时点名提醒（`claudeChannelLaunchNotices`，纯函数）。
  - 拒绝启动时直接打印 doctor 的 fix 行（preflight 结果新增可选 `fix_lines`），`plugin_state_unavailable` 单独说明是 `claude plugin list --json` 10s 没回（Claude 慢/自更新/登录过期），先重试——不再只丢一句「去跑 doctor」。
- `cli/src/commands/bridge.ts`：改为 `...claudeChannelLoadArgs(\`server:${CHANNEL_SERVER_NAME}\`)`，两条入口出自同一个函数。
- `cli/src/commands/doctor.ts`：`listener_not_observed` 的 fix 行写明「按 development channel 加载 + 会弹一次确认框」（doctor 看不到远端 ledger，只能把事实写进结论）；新增 `plugin_state_unavailable` 的 fix 行。
- `skills/agentparty/SKILL.md`（+ `bun run sync:plugin` 同步 `plugins/` 镜像）：`party claude` 段补「会弹一次频道确认框」与「别自己加 `--channels plugin:agentparty@agentparty`」。
- 未碰 `cli/src/commands/upgrade.ts`（#985 另有人改）。

## 测试

- `cli/test/claude-launch.test.ts`、`cli/test/claude-launch-default-args.test.ts`：所有精确 args 断言同步改为字面量 `["--dangerously-load-development-channels", "plugin:agentparty@agentparty", …]`（故意不引用 `claudeChannelLoadArgs`），并断言不含 `--channels`。
- 新增：显式/默认参数里已给同名 flag 时不重复拼；`claudeChannelLaunchNotices` 三种提示；拒绝启动时打印 fix 行 + `plugin_state_unavailable` 提示。
- 守卫（`channel loading is one shape on both Claude launch paths (#984)`）：`party claude` 的 args 以 `claudeChannelLoadArgs(CLAUDE_CHANNEL_PLUGIN)` 开头、`buildClaudeBridgeLaunch` 的 args 含连续子序列 `claudeChannelLoadArgs("server:agentparty-channel")`，两边都恰好一个该 flag、都不含 `--channels`。
- 变异自检：
  - `claudeChannelLoadArgs` 改回 `["--channels", entry]` ⇒ 13 red（两个 launch 测试文件 + claude-channel 的 bridge 测试），恢复后全绿。
  - bridge 改回手写 `"--channels", \`server:…\`` ⇒ 守卫 1 red，恢复后全绿。
- `cd cli && bunx tsc --noEmit` 通过；`bun test test/claude-launch.test.ts test/claude-launch-default-args.test.ts test/doctor-plugin.test.ts test/claude-channel.test.ts` 147 pass；整个 cli 套件 2578 pass / 1 fail（`cursor-persistence` 的 5s barrier 计时在全量并发下偶发，单跑 12/12 通过，与本改动无关）。

Closes #984

https://claude.ai/code/session_01Az8CnUpayZzqpi1sh32Ssi
