### PR TITLE
feat(cli): 接入引导第 4 步——party wake verify 真发一条 @ 验证往返，超时说清哪一层没通

### DIFF
--- a/cli/src/commands/claude-channel.ts
+++ b/cli/src/commands/claude-channel.ts
@@ -15,6 +15,7 @@ import {
   type DeliveryRecoverFrame,
   type DeliveryRecoveryResultFrame,
   type DirectedDelivery,
+  isWakeVerifyFrame,
   mentionMatchKey,
   type MsgFrame,
   type PresenceEntry,
@@ -651,6 +652,19 @@ export function dormantAnnounceIsReplayFrame(frame: unknown): boolean {
   return (frame as { replay?: unknown } | null)?.replay === true;
 }
 
+/** #990：这条 msg 帧是不是接入验证帧（自 @ 的唯一放行例外）。字段缺/型别不对一律 false。 */
+export function dormantAnnounceIsWakeVerifyFrame(frame: unknown): boolean {
+  const f = frame as Partial<Pick<MsgFrame, "kind" | "body" | "mentions" | "sender">> | null;
+  if (f === null || typeof f !== "object") return false;
+  if (typeof f.sender?.name !== "string" || (f.kind !== "message" && f.kind !== "status")) return false;
+  return isWakeVerifyFrame({
+    kind: f.kind,
+    body: typeof f.body === "string" ? f.body : null,
+    mentions: Array.isArray(f.mentions) ? f.mentions.filter((m): m is string => typeof m === "string") : null,
+    sender: { name: f.sender.name },
+  });
+}
+
 /** 注入去重表容量上限：只留最近 N 个 seq，防长跑进程内存无界。 */
 export const DORMANT_ANNOUNCE_SEEN_LIMIT = 512;
 
@@ -839,7 +853,8 @@ export async function runDormantClaudeSessionAnnounce(
         if (!dormantAnnounceMentionHit(mentions, selfName)) return;
         // #963：发信人就是我这个身份——那是对话里提到自己（「@leo-server 这次醒了」），不是召唤。
         // 尤其带 reply_to 的回帖。同身份 13 个 runtime 各醒一次就是这么来的第二、三轮。
-        if (selfAuthoredMention(sender?.name, selfName)) return;
+        // #990：接入验证帧（`[wake-verify]` + 只 @ 自己）是唯一例外——它就是自己对自己的显式召唤。
+        if (selfAuthoredMention(sender?.name, selfName) && !dormantAnnounceIsWakeVerifyFrame(frame)) return;
         if (injectedSeqs.has(seq)) return;
         // #963：本机已有 live bridge / serve 持锁 ⇒ 这条 @ 由它经 directed delivery 权威处理（服务端
         // 只让一个 adapter 认领），蛰伏腿不再叠加一次注入。锁没人持才轮到蛰伏腿之间抢认领。
@@ -2604,10 +2619,12 @@ export class ClaudeChannelDeliveryBridge {
       // Server-side membership and target routing are the trust boundary. The
       // adapter additionally fails closed on a mismatched target/state and
       // never lets the current session wake itself.
+      // #990：接入验证帧（只 @ 自己）是唯一放行的自发 delivery——服务端为它建了 directed delivery，
+      // 这里若还按 #963 丢掉，验证只会卡在 claimed 直到租约过期。
       if (
         delivery.target_name !== this.self ||
         delivery.state !== "claimed" ||
-        message.sender.name === this.self ||
+        (message.sender.name === this.self && !isWakeVerifyFrame(message)) ||
         this.settledDeliveryIds.has(delivery.id)
       ) {
         return;
@@ -2625,7 +2642,7 @@ export class ClaudeChannelDeliveryBridge {
     if (
       !fresh ||
       !mentioned ||
-      message.sender.name === this.self ||
+      (message.sender.name === this.self && !isWakeVerifyFrame(message)) ||
       this.seenPlainSeqs.has(message.seq)
     ) {
       if (fresh) this.options.connection.ack(message.seq);

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -1,7 +1,7 @@
 // party serve — 常驻监听频道，每条 @你 的消息触发一次本地命令，把「跑完就停的 session agent」
 // 用外部 supervisor 唤醒（wake GOAL 的 session 型那半；有入站 URL 的 runtime 走 webhook）。
 // 复用 client.connect 的自动重连帧流，真正常驻；命令串行执行（一条处理完再下一条，不并发抢跑）。
-import { BODY_LIMIT, DECISION_OPTION_LIMIT, DECISION_OPTIONS_MAX, DECISION_PROMPT_LIMIT, EXIT_ARCHIVED, EXIT_AUTH, EXIT_STREAM_ENDED, EXIT_UPGRADED, type AgentSessionInfo, type Attachment, type DeliveryUpdateFrame, type DirectedDelivery, type MsgFrame, type PublicDirectedDelivery, type ResponseSource, type SendDecisionRequest, type ServerFrame } from "@agentparty/shared";
+import { BODY_LIMIT, DECISION_OPTION_LIMIT, DECISION_OPTIONS_MAX, DECISION_PROMPT_LIMIT, EXIT_ARCHIVED, EXIT_AUTH, EXIT_STREAM_ENDED, EXIT_UPGRADED, isWakeVerifyFrame, type AgentSessionInfo, type Attachment, type DeliveryUpdateFrame, type DirectedDelivery, type MsgFrame, type PublicDirectedDelivery, type ResponseSource, type SendDecisionRequest, type ServerFrame } from "@agentparty/shared";
 import { safeBranchContextLabel, safeRepoContextLabel } from "@agentparty/shared";
 import { channelDecisionSnapshotBodyLines } from "@agentparty/shared/onboarding";
 import { createHash, randomUUID } from "node:crypto";
@@ -5760,7 +5760,8 @@ export async function runServe(o: ServeOptions): Promise<number> {
         out(`serve: ignored invalid delivery ${directedDelivery.id} for target=${directedDelivery.target_name} state=${directedDelivery.state}`);
         continue;
       }
-      const fromSelf = frame.sender.name === self;
+      // #990：接入验证帧（`[wake-verify]` + 只 @ 自己）是自己对自己的显式召唤，唯一放行的自发消息。
+      const fromSelf = frame.sender.name === self && !isWakeVerifyFrame(frame);
       // fresh = 游标之上的新消息。历史修订快照会穿透去重被重放（seq 早已消费过），
       // 它们不是新唤醒——不 fresh 就绝不触发 runner（否则旧 @ 被编辑一次，每次重连都重跑一遍）
       // delivery 是独立 work cursor：即使普通 read cursor 已越过 message_seq，也必须执行。

--- a/cli/src/commands/wake.ts
+++ b/cli/src/commands/wake.ts
@@ -1,10 +1,11 @@
 // party wake test — prove mention/wake/resume as separate phases.
 import { autoWakeReachable, EXIT_TIMEOUT, type MsgFrame, type PresenceEntry, type WakeDelivery, type WakeKind } from "@agentparty/shared";
 import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
-import { readConfig, resolveChannel } from "../config";
+import { agentpartyHome, readConfig, resolveChannel } from "../config";
+import { joinBindingsPath, readJoinBindings } from "../join-binding";
 import { jsonFrame, nowTs } from "../json";
 import { resolveAuth } from "../oidc-cli";
-import { RestError, fetchMessages, fetchPresence, fetchWakeDeliveries, handleRestError, postMessage } from "../rest";
+import { RestError, fetchMe, fetchMessages, fetchPresence, fetchWakeDeliveries, handleRestError, postMessage } from "../rest";
 import { MAX_TIMEOUT_SEC, isName, isSlug, parsePositiveIntFlag } from "../validation";
 import { diagnoseCodexWake } from "../wake-diagnosis";
 import { buildWakeChecklist, formatWakeChecklist } from "../wake-checklist";
@@ -14,6 +15,14 @@ const DEFAULT_TIMEOUT_SEC = 30;
 const STALE_MS = 60_000; // keep serve/watch wakeability aligned with `party who` and mention receipts
 const HELP = `usage: party wake test @agent [channel|--channel C] [--timeout N] [--json]
        party wake check [--json]
+       party wake verify [channel|--channel C] [--timeout N] [--json]
+
+verify is onboarding step 4 (#990): it sends ONE verify frame as YOUR OWN identity
+(\`[wake-verify] @you ping\`, the only self-mention the server and the local listeners
+treat as a real summons), waits for the reply, and on timeout names the layer that
+did not deliver — server_delivery / local_listener / model_reply — with one fix.
+The frame is never counted against the loop guard. Exit code 0 only on a real
+round trip.
 
 check answers one question about THIS machine, with no network at all: "if someone
 @s me right now, will anything happen?" It prints how many steps are still missing
@@ -73,7 +82,7 @@ interface WakePresence {
   current_task?: PresenceEntry["current_task"];
 }
 
-interface WakeTestFrame extends Record<string, unknown> {
+export interface WakeTestFrame extends Record<string, unknown> {
   type: "wake_test";
   channel: string;
   target: string;
@@ -231,9 +240,10 @@ async function fetchLatestLedgerDelivery(
   target: string,
   mentionSeq: number,
   kinds: readonly WakeKind[],
+  fetcher: typeof fetchWakeDeliveries = fetchWakeDeliveries,
 ): Promise<WakeDelivery | null> {
   try {
-    const deliveries = await fetchWakeDeliveries(server, token, channel, { since: mentionSeq, target, limit: 20 });
+    const deliveries = await fetcher(server, token, channel, { since: mentionSeq, target, limit: 20 });
     return deliveries
       .filter((d) => d.mention_seq === mentionSeq && kinds.includes(d.adapter_kind))
       .at(-1) ?? null;
@@ -241,6 +251,178 @@ async function fetchLatestLedgerDelivery(
     if (e instanceof RestError && (e.status === 404 || e.status === 501)) return null;
     throw e;
   }
+}
+
+/**
+ * wake test 的往返本体（#990 抽出来供接入引导第 4 步复用）：读 presence 过闸 → 发探针 → 轮询
+ * ledger / 回帖 → 按 presence 探活分级定论。只返回结构化的 wake_test 帧，不打印、不定退出码。
+ * 网络与时钟全部可注入（deps），缺省是真实 REST。
+ */
+export interface WakeProbeDeps {
+  fetchPresence: typeof fetchPresence;
+  postMessage: typeof postMessage;
+  fetchMessages: typeof fetchMessages;
+  fetchWakeDeliveries: typeof fetchWakeDeliveries;
+  sleep: (ms: number) => Promise<void>;
+  now: () => number;
+}
+
+export interface WakeProbeOptions {
+  server: string;
+  token: string;
+  channel: string;
+  target: string;
+  timeoutSec: number;
+  /** 探针正文；缺省是 wake test 那句。验证帧（#990）用它带上 WAKE_VERIFY_PREFIX。 */
+  body?: string;
+  deps?: Partial<WakeProbeDeps>;
+}
+
+export async function runWakeProbe(opts: WakeProbeOptions): Promise<WakeTestFrame> {
+  const { server, token, channel, target, timeoutSec } = opts;
+  const deps: WakeProbeDeps = {
+    fetchPresence,
+    postMessage,
+    fetchMessages,
+    fetchWakeDeliveries,
+    sleep,
+    now: () => Date.now(),
+    ...opts.deps,
+  };
+  const presenceList = await deps.fetchPresence(server, token, channel);
+  const presence = presenceList.find((p) => p.name === target) ?? null;
+  const generatedAt = nowTs();
+  const gate = wakeProbeGate(presence, generatedAt);
+  const adapter = presence?.wake?.kind ?? null;
+  if (gate.block !== null) {
+    return {
+      type: "wake_test",
+      channel,
+      target,
+      result: "not_auto_wakeable",
+      generated_at: generatedAt,
+      timeout_sec: timeoutSec,
+      presence: summarizePresence(presence),
+      phases: {
+        mention_delivered: { ok: false, seq: null, evidence: "not sent because target is not auto-wakeable" },
+        wake_invoked: { ok: false, status: "not_invoked", adapter, evidence: gate.block },
+        agent_resumed: { ok: false, seq: null, evidence: null },
+      },
+      reason: gate.block,
+    };
+  }
+
+  const { seq } = await deps.postMessage(server, token, channel, {
+    kind: "message",
+    body: opts.body ?? `@${target} wake test: please reply to this message or post a status linked with summary_seq`,
+    mentions: [target],
+    reply_to: null,
+  });
+  const deadline = deps.now() + timeoutSec * 1000;
+  const ledgerKinds = ledgerKindsFor(adapter);
+  let ack: { seq: number; evidence: AckEvidence } | null = null;
+  let wakeDelivery: WakeDelivery | null = null;
+  do {
+    if (ledgerKinds !== null) {
+      wakeDelivery = await fetchLatestLedgerDelivery(server, token, channel, target, seq, ledgerKinds, deps.fetchWakeDeliveries);
+      ack = ackFromWakeDelivery(wakeDelivery);
+      if (ack !== null) break;
+    }
+    ack = findLinkedAck(await deps.fetchMessages(server, token, channel, seq, 100), target, seq);
+    if (ack !== null) break;
+    await deps.sleep(Math.min(1000, Math.max(100, deadline - deps.now())));
+  } while (deps.now() < deadline);
+  if (ledgerKinds !== null && wakeDelivery === null) {
+    wakeDelivery = await fetchLatestLedgerDelivery(server, token, channel, target, seq, ledgerKinds, deps.fetchWakeDeliveries);
+  }
+
+  // serve/watch are local supervisors reading the channel stream; they filter out the
+  // sender's own messages to avoid self-trigger loops. So a self-test (mentioning your own
+  // agent) always times out even when the supervisor is healthy — spell that out so the next
+  // person doesn't burn a debugging session on it (as happened with serve+bare self-tests).
+  const selfTestProne = adapter === "serve" || adapter === "watch";
+  const timeoutReason = selfTestProne
+    ? "timed out waiting for linked reply_to/status.summary_seq (serve/watch ignore the sender's own messages — if @" +
+      target +
+      " is your own identity, retry from a different one)"
+    : "timed out waiting for linked reply_to/status.summary_seq";
+  // #181: 探针已投递，按观测定论。收到 ack → healthy（哪怕它没声明任何 wake 适配器，
+  // 只要它真的答复了就是可达的）。没 ack 时，若 heartbeat 视角本就负面（没声明适配器），
+  // 结论仍是 not_auto_wakeable 但标注「探针已投递、未答复、未确认」——把 heartbeat 判定
+  // 和投递判定摊开，而不是当初那句不可证伪的 mention: not sent。
+  let result: WakeResult = ack !== null ? "healthy" : gate.advisory !== null ? "not_auto_wakeable" : "timeout";
+  let frameReason =
+    ack !== null
+      ? null
+      : gate.advisory !== null
+        ? `${gate.advisory} (unconfirmed — probe delivered #${seq}, no reply within ${timeoutSec}s)`
+        : timeoutReason;
+  // 探活分级（#603/#689）：没收到最终回复不再一锅端。重取一次 presence——若服务端/自报已给出证据，
+  // 细分为可处置的结论。优先级（先真、再故障、后不消费）：
+  //   ① current_task==本探针 seq → runner 已唤起、正在处理这条 @：wake_pending（唤醒确凿，reply pending）。
+  //      #689：headless runner 跑一条要数分钟，30s 内没有最终回复是正常的，绝不能误报「no wake adapter」/失败。
+  //      这条对「没声明适配器」(advisory) 与「timeout」两条路径都适用——current_task 是活体执行的直接证据，
+  //      不依赖 presence 是否同步了 wake 适配器声明。
+  //   ② runner_health 报连败 → runner_failing（修 runner 环境，优先于不消费——「唤醒了起不来」更接近根因）。
+  //   ③ listening=deaf/suspect → not_listening（重启 supervisor）。
+  let finalPresence = presence;
+  if (ack === null) {
+    try {
+      finalPresence = (await deps.fetchPresence(server, token, channel)).find((p) => p.name === target) ?? presence;
+    } catch {
+      /* 刷新失败就用探针前的快照定级 */
+    }
+    if (finalPresence?.current_task === seq) {
+      result = "wake_pending";
+      frameReason =
+        `probe delivered #${seq}; target's runner is actively processing it (presence.current_task=#${seq}) — ` +
+        "wake invoked, final reply pending (a headless builtin runner may take minutes to reply)";
+    } else if (result === "timeout") {
+      const health = finalPresence?.runner_health;
+      if (health !== undefined && !health.ok) {
+        result = "runner_failing";
+        frameReason =
+          `probe delivered #${seq} but the target's runner keeps failing (x${health.consecutive_failures}` +
+          `${health.last_error !== undefined ? `: ${health.last_error}` : ""}) — fix the runner environment ` +
+          "(binary/credentials/sandbox) instead of re-mentioning";
+      } else if (finalPresence?.listening === "deaf" || finalPresence?.listening === "suspect") {
+        result = "not_listening";
+        frameReason =
+          `probe delivered #${seq} but the target's live connection is not consuming deliveries ` +
+          `(listening=${finalPresence.listening}) — restart its serve/watch supervisor instead of re-mentioning`;
+      }
+    }
+  }
+  // #689：runner 正在处理本探针（current_task 命中）是唤醒确凿的最强证据——盖过「没声明适配器」的负面 heartbeat
+  // 视角与 ledger 未审计。此时 wake_invoked 直接判 yes、reply pending。
+  const wakeInvoked =
+    result === "wake_pending"
+      ? {
+          ok: true as const,
+          status: "invoked" as const,
+          adapter,
+          evidence: `target's runner is processing mention #${seq} (presence.current_task) — wake invoked; final reply pending`,
+        }
+      : gate.advisory !== null && wakeDelivery === null
+        ? { ok: false as const, status: "not_invoked" as const, adapter, evidence: gate.advisory }
+        : adapter === "serve" || adapter === "watch"
+          ? summarizeServeWatchDelivery(wakeDelivery, adapter)
+          : summarizeWakeDelivery(wakeDelivery, adapter);
+  return {
+    type: "wake_test",
+    channel,
+    target,
+    result,
+    generated_at: nowTs(),
+    timeout_sec: timeoutSec,
+    presence: summarizePresence(finalPresence),
+    phases: {
+      mention_delivered: { ok: true, seq, evidence: "message accepted by channel history" },
+      wake_invoked: wakeInvoked,
+      agent_resumed: { ok: ack !== null, seq: ack?.seq ?? null, evidence: ack?.evidence ?? null },
+    },
+    reason: frameReason,
+  };
 }
 
 function printHuman(frame: WakeTestFrame) {
@@ -302,6 +484,73 @@ function runCheck(json: boolean): number {
   return checklist.remaining === 0 ? 0 : 1;
 }
 
+/**
+ * `party wake verify`（#990）：接入引导第 4 步，以本身份真发一条 @ 验证往返。
+ * 身份取本地缓存的 config.identity，没有就问 /api/me；harness 从加入绑定里认（修法命令按档给）。
+ */
+async function runVerify(channelPositional: string | undefined, flags: ReturnType<typeof parseArgs>["flags"]): Promise<number> {
+  const unknown = unknownFlagError(flags, WAKE_FLAGS);
+  if (unknown !== null) {
+    console.error(unknown);
+    return 1;
+  }
+  const flagError = valueFlagError(flags, ["channel", "timeout"]);
+  if (flagError !== null) {
+    console.error(flagError);
+    return 1;
+  }
+  const channel = resolveChannel(str(flags.channel) ?? channelPositional);
+  if (!channel) {
+    console.error("no channel, pass one or bind with: party init --channel C");
+    return 1;
+  }
+  if (!isSlug(channel)) {
+    console.error("channel must match [a-z0-9][a-z0-9-]{0,63}");
+    return 1;
+  }
+  const timeout = parsePositiveIntFlag(str(flags.timeout), "timeout", MAX_TIMEOUT_SEC);
+  if (typeof timeout === "string") {
+    console.error(timeout);
+    return 1;
+  }
+  const cfg = await resolveAuth();
+  if (!cfg) {
+    console.error("no config, run: party login or party init --server URL --token T");
+    return 1;
+  }
+  const { verifyWakeRoundTrip, formatWakeVerifyStep, DEFAULT_WAKE_VERIFY_TIMEOUT_MS } = await import("../onboarding/verify-wake");
+  try {
+    let identity = readConfig()?.identity?.name ?? null;
+    if (identity === null || identity === "") identity = (await fetchMe(cfg.server, cfg.token)).name;
+    const bindings = readJoinBindings(joinBindingsPath(agentpartyHome()));
+    const bound = bindings.find((b) => b.channel === channel && b.identity === identity && b.harness !== "other");
+    const harness = bound?.harness ?? "other";
+    const timeoutMs = timeout === undefined ? DEFAULT_WAKE_VERIFY_TIMEOUT_MS : timeout * 1000;
+    const result = await verifyWakeRoundTrip({ server: cfg.server, token: cfg.token, channel, identity, timeoutMs, harness });
+    if (flags.json === true) {
+      console.log(JSON.stringify(jsonFrame({
+        type: "wake_verify",
+        channel,
+        identity,
+        harness,
+        ok: result.ok,
+        elapsed_ms: result.elapsedMs,
+        layer: result.layer ?? null,
+        detail: result.detail,
+        fix: result.fix ?? null,
+        seq: result.seq,
+        probe: result.probe,
+        local: result.local,
+      })));
+    } else {
+      for (const line of formatWakeVerifyStep(result)) console.log(line);
+    }
+    return result.ok ? 0 : EXIT_TIMEOUT;
+  } catch (e) {
+    return handleRestError(e);
+  }
+}
+
 export async function run(argv: string[]): Promise<number> {
   if (isHelpArg(argv, { allowHelpPositional: true })) {
     console.log(HELP);
@@ -318,8 +567,18 @@ export async function run(argv: string[]): Promise<number> {
     }
     return runCheck(parsed.flags.json === true);
   }
+  if (subcmd === "verify") {
+    if (extra.length > 0 || channelArg !== undefined) {
+      console.error("usage: party wake verify [channel|--channel C] [--timeout N] [--json]");
+      return 1;
+    }
+    return runVerify(targetArg, parsed.flags);
+  }
   if (subcmd !== "test" || extra.length > 0) {
-    console.error("usage: party wake test @agent [channel|--channel C] [--timeout N] [--json]\n       party wake check [--json]");
+    console.error(
+      "usage: party wake test @agent [channel|--channel C] [--timeout N] [--json]\n" +
+        "       party wake check [--json]\n       party wake verify [channel|--channel C] [--timeout N] [--json]",
+    );
     return 1;
   }
   const { flags } = parsed;
@@ -392,147 +651,11 @@ export async function run(argv: string[]): Promise<number> {
   }
 
   try {
-    const presenceList = await fetchPresence(cfg.server, cfg.token, channel);
-    const presence = presenceList.find((p) => p.name === target) ?? null;
-    const generatedAt = nowTs();
-    const gate = wakeProbeGate(presence, generatedAt);
-    const adapter = presence?.wake?.kind ?? null;
-    if (gate.block !== null) {
-      const frame: WakeTestFrame = {
-        type: "wake_test",
-        channel,
-        target,
-        result: "not_auto_wakeable",
-        generated_at: generatedAt,
-        timeout_sec: timeoutSec,
-        presence: summarizePresence(presence),
-        phases: {
-          mention_delivered: { ok: false, seq: null, evidence: "not sent because target is not auto-wakeable" },
-          wake_invoked: { ok: false, status: "not_invoked", adapter, evidence: gate.block },
-          agent_resumed: { ok: false, seq: null, evidence: null },
-        },
-        reason: gate.block,
-      };
-      if (flags.json === true) console.log(JSON.stringify(jsonFrame(frame)));
-      else printHuman(frame);
-      return EXIT_TIMEOUT;
-    }
-
-    const { seq } = await postMessage(cfg.server, cfg.token, channel, {
-      kind: "message",
-      body: `@${target} wake test: please reply to this message or post a status linked with summary_seq`,
-      mentions: [target],
-      reply_to: null,
-    });
-    const deadline = Date.now() + timeoutSec * 1000;
-    const ledgerKinds = ledgerKindsFor(adapter);
-    let ack: { seq: number; evidence: AckEvidence } | null = null;
-    let wakeDelivery: WakeDelivery | null = null;
-    do {
-      if (ledgerKinds !== null) {
-        wakeDelivery = await fetchLatestLedgerDelivery(cfg.server, cfg.token, channel, target, seq, ledgerKinds);
-        ack = ackFromWakeDelivery(wakeDelivery);
-        if (ack !== null) break;
-      }
-      ack = findLinkedAck(await fetchMessages(cfg.server, cfg.token, channel, seq, 100), target, seq);
-      if (ack !== null) break;
-      await sleep(Math.min(1000, Math.max(100, deadline - Date.now())));
-    } while (Date.now() < deadline);
-    if (ledgerKinds !== null && wakeDelivery === null) {
-      wakeDelivery = await fetchLatestLedgerDelivery(cfg.server, cfg.token, channel, target, seq, ledgerKinds);
-    }
-
-    // serve/watch are local supervisors reading the channel stream; they filter out the
-    // sender's own messages to avoid self-trigger loops. So a self-test (mentioning your own
-    // agent) always times out even when the supervisor is healthy — spell that out so the next
-    // person doesn't burn a debugging session on it (as happened with serve+bare self-tests).
-    const selfTestProne = adapter === "serve" || adapter === "watch";
-    const timeoutReason = selfTestProne
-      ? "timed out waiting for linked reply_to/status.summary_seq (serve/watch ignore the sender's own messages — if @" +
-        target +
-        " is your own identity, retry from a different one)"
-      : "timed out waiting for linked reply_to/status.summary_seq";
-    // #181: 探针已投递，按观测定论。收到 ack → healthy（哪怕它没声明任何 wake 适配器，
-    // 只要它真的答复了就是可达的）。没 ack 时，若 heartbeat 视角本就负面（没声明适配器），
-    // 结论仍是 not_auto_wakeable 但标注「探针已投递、未答复、未确认」——把 heartbeat 判定
-    // 和投递判定摊开，而不是当初那句不可证伪的 mention: not sent。
-    let result: WakeResult = ack !== null ? "healthy" : gate.advisory !== null ? "not_auto_wakeable" : "timeout";
-    let frameReason =
-      ack !== null
-        ? null
-        : gate.advisory !== null
-          ? `${gate.advisory} (unconfirmed — probe delivered #${seq}, no reply within ${timeoutSec}s)`
-          : timeoutReason;
-    // 探活分级（#603/#689）：没收到最终回复不再一锅端。重取一次 presence——若服务端/自报已给出证据，
-    // 细分为可处置的结论。优先级（先真、再故障、后不消费）：
-    //   ① current_task==本探针 seq → runner 已唤起、正在处理这条 @：wake_pending（唤醒确凿，reply pending）。
-    //      #689：headless runner 跑一条要数分钟，30s 内没有最终回复是正常的，绝不能误报「no wake adapter」/失败。
-    //      这条对「没声明适配器」(advisory) 与「timeout」两条路径都适用——current_task 是活体执行的直接证据，
-    //      不依赖 presence 是否同步了 wake 适配器声明。
-    //   ② runner_health 报连败 → runner_failing（修 runner 环境，优先于不消费——「唤醒了起不来」更接近根因）。
-    //   ③ listening=deaf/suspect → not_listening（重启 supervisor）。
-    let finalPresence = presence;
-    if (ack === null) {
-      try {
-        finalPresence = (await fetchPresence(cfg.server, cfg.token, channel)).find((p) => p.name === target) ?? presence;
-      } catch {
-        /* 刷新失败就用探针前的快照定级 */
-      }
-      if (finalPresence?.current_task === seq) {
-        result = "wake_pending";
-        frameReason =
-          `probe delivered #${seq}; target's runner is actively processing it (presence.current_task=#${seq}) — ` +
-          "wake invoked, final reply pending (a headless builtin runner may take minutes to reply)";
-      } else if (result === "timeout") {
-        const health = finalPresence?.runner_health;
-        if (health !== undefined && !health.ok) {
-          result = "runner_failing";
-          frameReason =
-            `probe delivered #${seq} but the target's runner keeps failing (x${health.consecutive_failures}` +
-            `${health.last_error !== undefined ? `: ${health.last_error}` : ""}) — fix the runner environment ` +
-            "(binary/credentials/sandbox) instead of re-mentioning";
-        } else if (finalPresence?.listening === "deaf" || finalPresence?.listening === "suspect") {
-          result = "not_listening";
-          frameReason =
-            `probe delivered #${seq} but the target's live connection is not consuming deliveries ` +
-            `(listening=${finalPresence.listening}) — restart its serve/watch supervisor instead of re-mentioning`;
-        }
-      }
-    }
-    // #689：runner 正在处理本探针（current_task 命中）是唤醒确凿的最强证据——盖过「没声明适配器」的负面 heartbeat
-    // 视角与 ledger 未审计。此时 wake_invoked 直接判 yes、reply pending。
-    const wakeInvoked =
-      result === "wake_pending"
-        ? {
-            ok: true as const,
-            status: "invoked" as const,
-            adapter,
-            evidence: `target's runner is processing mention #${seq} (presence.current_task) — wake invoked; final reply pending`,
-          }
-        : gate.advisory !== null && wakeDelivery === null
-          ? { ok: false as const, status: "not_invoked" as const, adapter, evidence: gate.advisory }
-          : adapter === "serve" || adapter === "watch"
-            ? summarizeServeWatchDelivery(wakeDelivery, adapter)
-            : summarizeWakeDelivery(wakeDelivery, adapter);
-    const frame: WakeTestFrame = {
-      type: "wake_test",
-      channel,
-      target,
-      result,
-      generated_at: nowTs(),
-      timeout_sec: timeoutSec,
-      presence: summarizePresence(finalPresence),
-      phases: {
-        mention_delivered: { ok: true, seq, evidence: "message accepted by channel history" },
-        wake_invoked: wakeInvoked,
-        agent_resumed: { ok: ack !== null, seq: ack?.seq ?? null, evidence: ack?.evidence ?? null },
-      },
-      reason: frameReason,
-    };
+    const frame = await runWakeProbe({ server: cfg.server, token: cfg.token, channel, target, timeoutSec });
     if (flags.json === true) console.log(JSON.stringify(jsonFrame(frame)));
     else printHuman(frame);
     // #689：wake_pending（唤醒确凿、reply pending）与 healthy 同为成功——不再退 EXIT_TIMEOUT 误报失败。
-    return ack !== null || result === "wake_pending" ? 0 : EXIT_TIMEOUT;
+    return frame.phases.agent_resumed.ok || frame.result === "wake_pending" ? 0 : EXIT_TIMEOUT;
   } catch (e) {
     return handleRestError(e);
   }

--- a/cli/src/commands/watch.ts
+++ b/cli/src/commands/watch.ts
@@ -5,6 +5,7 @@ import {
   EXIT_LOOP_GUARD,
   EXIT_STREAM_ENDED,
   EXIT_TIMEOUT,
+  isWakeVerifyFrame,
   type DirectedDelivery,
   type MsgFrame,
 } from "@agentparty/shared";
@@ -707,7 +708,8 @@ export async function runWatch(o: WatchOptions): Promise<number> {
       const msg = frame.type === "message_update" ? frame.message : frame;
       if (msg.type !== "msg" && msg.type !== "status") continue;
       lastSeq = Math.max(lastSeq, msg.seq);
-      const fromSelf = msg.sender.name === self;
+      // #990：接入验证帧（`[wake-verify]` + 只 @ 自己）是自己对自己的显式召唤，唯一放行的自发消息。
+      const fromSelf = msg.sender.name === self && !isWakeVerifyFrame(msg);
       const qualifies = !fromSelf && (!o.mentionsOnly || msg.mentions.includes(self));
       // fresh = 游标之上的新消息。重放的历史修订快照（seq 早已消费过）会穿透去重进来
       // ——它们可以照常打印（展示编辑是 feature），但绝不能算「唤醒」（曾把 --once 假唤醒）

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -61,7 +61,7 @@ commands:
   digest    [channel|--channel C] [--since seq|last-seen] [--json]
   host      board [channel|--channel C] [--since seq] [--limit n] [--json]
   capture   <seq>|list [channel|--channel C] --as decision|requirement|bug|action-item [-m note] [--json] [--issue-body]
-  wake      test @agent [channel|--channel C] [--timeout N] [--json]
+  wake      test @agent [channel|--channel C] [--timeout N] [--json] | check [--json] | verify [channel|--channel C] [--timeout N] [--json]   verify = onboarding step 4: real @-yourself round trip, names the failing layer (#990)
   channel   create <slug> [--title t] [--temp] [--party] [--public] | list | archive [slug] | guard unlimited|off|<limit> [slug] | workflow-guard off|<limit> [slug] | reset-guard [slug] | reset-workflow-guard <workflow_id> [slug] | kick <name> [slug] | invite-agent <owner>/<handle> [slug] | remove-agent <owner>/<handle> [slug] | join-link <slug> | role list|set|unset
   invite    "<title>" [--slug s] [--temp] [--party] [--public] [--guest-name bob] [--owner label]   (ADMIN_SECRET env)
   webhook   add <channel> --name n --url URL --secret S [--filter mentions|status|needs-human|all] | remove <channel> --name n | list <channel>

--- a/cli/src/onboarding/verify-wake.ts
+++ b/cli/src/onboarding/verify-wake.ts
@@ -1,0 +1,298 @@
+// 接入引导第 4 步：真发一条 @ 验证往返（issue #990，epic #987）。
+//
+// 接入的最终判据是**真实唤醒**，不是「插件装了 / 锁有人持」这类间接证据（#957/#961/#979 全是间接证据
+// 打 ✅、真机叫不醒）。这里以本身份发一条验证帧（`[wake-verify]` + 只 @ 自己，见 shared 的
+// isWakeVerifyFrame——服务端与本机监听把它当成自 @ 的唯一放行例外），然后**复用** `party wake test`
+// 的往返本体（runWakeProbe：presence 过闸 → 发探针 → 轮询 ledger/回帖 → 探活分级），不另写一套。
+//
+// 超时时按层定位——三层各自的证据来源不同，文案与修法也不同：
+//   server_delivery  服务端没投递：presence 没登记可唤醒 / ledger 没有这条 @ 的行 / webhook 投递失败
+//   local_listener   服务端已投递，本机监听没收到：没有认领文件、bridge 恢复日志、serve 任务痕迹，
+//                    或 presence.listening 报 deaf/suspect，或本机根本没有武装监听
+//   model_reply      本机监听已收到（有上述痕迹），模型在超时内没有回帖（或 runner 连败）
+// 判层是纯函数（classifyWakeVerify），输入是往返帧 + 本机证据，方便被测、也方便 #988 的步骤机直接接。
+import { WAKE_VERIFY_PREFIX } from "@agentparty/shared";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { probeClaudeArmedListener, type ClaudeArmedListenerProbe } from "../claude-armed-listener";
+import { deliveryRecoveryJournalPath } from "../delivery-recovery-journal";
+import { readHealthCache } from "../health-cache";
+import { mentionWakeClaimDir, mentionWakeClaimKey } from "../mention-wake-claim";
+import { runWakeProbe, type WakeProbeOptions, type WakeTestFrame } from "../commands/wake";
+
+export type WakeVerifyLayer = "server_delivery" | "local_listener" | "model_reply";
+export type WakeVerifyHarness = "claude" | "codex" | "other";
+
+export const DEFAULT_WAKE_VERIFY_TIMEOUT_MS = 30_000;
+
+export interface VerifyWakeRoundTripOptions {
+  server: string;
+  token: string;
+  channel: string;
+  /** 本身份的频道 handle（mentions 里出现的那个名字）。 */
+  identity: string;
+  /** 等回执/回帖的上限；缺省 30s。 */
+  timeoutMs?: number;
+  /** 修法命令按 harness 给：claude 档给 `party claude <chan>`，其余给 `party wake check`。 */
+  harness?: WakeVerifyHarness;
+}
+
+/** 本机监听留下的痕迹——每一项都是「收到了这条 seq」的直接证据，任何一项为真即本机已收到。 */
+export interface WakeLocalEvidence {
+  /** 本机 serve 锁的活持有者（probeClaudeArmedListener）：谁在接 @、有几个蛰伏会话。 */
+  listener: ClaudeArmedListenerProbe;
+  /** #963 认领文件：本机某个 runtime 已为这条 seq 认领唤醒（claude-channel 蛰伏腿）。 */
+  claimed: boolean;
+  /** claude bridge 的 delivery 恢复日志里有这条 seq（武装 bridge 已收到 directed delivery）。 */
+  journaled: boolean;
+  /** serve 健康缓存记录 current_task == seq（serve 已把它交给 runner）。 */
+  runnerTask: boolean;
+}
+
+export interface VerifyWakeRoundTripResult {
+  ok: boolean;
+  elapsedMs: number;
+  /** ok=false 时哪一层没通；发送本身失败（网络/loop guard）时也没有层——那是「探针没发出去」。 */
+  layer?: WakeVerifyLayer;
+  /** 一句人话结论（不含「第 4 步」前缀，由 formatWakeVerifyStep 拼）。 */
+  detail: string;
+  /** ok=false 时的一条修法命令。 */
+  fix?: string;
+  /** 验证帧的 seq；探针没发出去为 null。 */
+  seq: number | null;
+  /** 原始往返帧（wake_test），--json 时原样带出。 */
+  probe: WakeTestFrame | null;
+  /** 超时时读到的本机证据；ok 或探针没发出去时为 null。 */
+  local: WakeLocalEvidence | null;
+}
+
+export interface VerifyWakeDeps {
+  probe: (opts: WakeProbeOptions) => Promise<WakeTestFrame>;
+  localEvidence: (input: { server: string; token: string; channel: string; identity: string; seq: number }) => WakeLocalEvidence;
+  now: () => number;
+}
+
+/** 验证帧正文：前缀是判据（isWakeVerifyFrame），其余是给被唤醒的模型看的一句话。 */
+export function verifyWakeBody(identity: string): string {
+  return `${WAKE_VERIFY_PREFIX} @${identity} ping · 接入引导第 4 步的唤醒验证——收到请用 party send "pong" --reply-to <这条的 seq> 回一句`;
+}
+
+function readJson(path: string): unknown {
+  try {
+    return JSON.parse(readFileSync(path, "utf8")) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+/** 本机证据的真实读法：只读盘 + 一次 ps，任何一项读不出都按「没有」算（宁可判监听没收到，也不伪造收到）。 */
+export function readWakeLocalEvidence(input: {
+  server: string;
+  token: string;
+  channel: string;
+  identity: string;
+  seq: number;
+  cwd?: string;
+}): WakeLocalEvidence {
+  const { server, token, channel, identity, seq } = input;
+  let listener: ClaudeArmedListenerProbe;
+  try {
+    listener = probeClaudeArmedListener({ config: { server, token, identity: { name: identity } }, channel });
+  } catch {
+    listener = { live: null, sessions: 0 };
+  }
+  let claimed = false;
+  try {
+    claimed = existsSync(join(mentionWakeClaimDir(), `${mentionWakeClaimKey({ server, identity, channel, seq })}.json`));
+  } catch {
+    claimed = false;
+  }
+  let journaled = false;
+  try {
+    const journal = readJson(deliveryRecoveryJournalPath("claude", server, token, channel)) as
+      | { entries?: Array<{ message?: { seq?: unknown } }> }
+      | null;
+    journaled = Array.isArray(journal?.entries) && journal.entries.some((e) => e?.message?.seq === seq);
+  } catch {
+    journaled = false;
+  }
+  let runnerTask = false;
+  try {
+    runnerTask = readHealthCache(input.cwd ?? process.cwd(), channel)?.current_task === seq;
+  } catch {
+    runnerTask = false;
+  }
+  return { listener, claimed, journaled, runnerTask };
+}
+
+function fixFor(harness: WakeVerifyHarness, channel: string, layer: WakeVerifyLayer): string {
+  if (layer === "model_reply") {
+    return harness === "claude"
+      ? `看那个会话是不是卡住/在等权限；常驻档看 runner 日志：party health ${channel}`
+      : `party health ${channel}   （看 runner 为什么没回；codex 档看 ~/.agentparty/logs/codex-auto-wake.log）`;
+  }
+  if (layer === "local_listener") {
+    return harness === "claude"
+      ? `party claude ${channel}   （重新起一个武装监听；常驻：party serve ${channel} --runner claude）`
+      : `party wake check   （codex 档：唤醒层进程/hook 信任闸逐项核）`;
+  }
+  return harness === "claude"
+    ? `party claude ${channel}   （起武装监听后服务端才会把你登记成可唤醒）`
+    : `party wake check`;
+}
+
+function fmtSec(ms: number): string {
+  const sec = ms / 1000;
+  return sec >= 10 ? `${Math.round(sec)}s` : `${sec.toFixed(1)}s`;
+}
+
+function localTrace(local: WakeLocalEvidence): string | null {
+  if (local.runnerTask) return "serve 已把它交给 runner";
+  if (local.journaled) return "bridge 恢复日志已记下这条 delivery";
+  if (local.claimed) return "本机 runtime 已认领这条唤醒";
+  return null;
+}
+
+/**
+ * 判层（纯函数）。ok 的两种：healthy（收到回帖/linked status）与 wake_pending（runner 正在处理，#689）。
+ * 其余按「服务端投了没 → 本机收到没 → 模型回了没」的顺序落到第一层没通的地方。
+ */
+export function classifyWakeVerify(
+  frame: WakeTestFrame,
+  local: WakeLocalEvidence,
+  input: { identity: string; channel: string; elapsedMs: number; timeoutMs: number; harness: WakeVerifyHarness },
+): { ok: boolean; layer?: WakeVerifyLayer; detail: string; fix?: string } {
+  const { identity, channel, elapsedMs, timeoutMs, harness } = input;
+  const resumed = frame.phases.agent_resumed;
+  if (resumed.ok) {
+    const via = resumed.evidence === "status.summary_seq" ? "linked status" : "回帖";
+    return { ok: true, detail: `@${identity} ping → ${fmtSec(elapsedMs)} 收到回执 ✓（${via} #${resumed.seq}）` };
+  }
+  if (frame.result === "wake_pending") {
+    return {
+      ok: true,
+      detail:
+        `@${identity} ping → ${fmtSec(elapsedMs)} 收到回执 ✓（runner 已接手 #${frame.phases.mention_delivered.seq}，` +
+        "回帖待定——headless runner 处理一条要数分钟）",
+    };
+  }
+  const head = `✗ ${fmtSec(timeoutMs)} 未收到`;
+  const invoked = frame.phases.wake_invoked;
+  // ① 服务端这层：探针根本没发（presence 过闸失败）/ 没有唤醒层 / ledger 没行 / webhook 投递失败。
+  if (!frame.phases.mention_delivered.ok) {
+    const layer: WakeVerifyLayer = "server_delivery";
+    return {
+      ok: false,
+      layer,
+      detail: `${head}：服务端没把 @${identity} 当成可唤醒目标（${frame.reason ?? invoked.evidence}），验证帧没发`,
+      fix: fixFor(harness, channel, layer),
+    };
+  }
+  if (invoked.status === "not_invoked" || invoked.status === "not_audited") {
+    const layer: WakeVerifyLayer = "server_delivery";
+    const why =
+      invoked.status === "not_audited"
+        ? `服务端账本没有这条 @ 的投递记录（登记的唤醒层：${invoked.adapter ?? "无"}）——可能被暂停接待，或服务端版本过旧不认验证帧`
+        : invoked.evidence;
+    return {
+      ok: false,
+      layer,
+      detail: `${head}：验证帧已发（#${frame.phases.mention_delivered.seq}），服务端未投递 → ${why}`,
+      fix: fixFor(harness, channel, layer),
+    };
+  }
+  // ② 服务端已投递（broadcast/claimed/webhook ok）。本机有没有收到的直接痕迹？
+  const trace = localTrace(local);
+  if (trace !== null || frame.result === "runner_failing") {
+    const layer: WakeVerifyLayer = "model_reply";
+    const health = frame.presence.runner_health;
+    const why =
+      frame.result === "runner_failing" && health !== undefined && !health.ok
+        ? `runner 连败 x${health.consecutive_failures}${health.last_error !== undefined ? `（${health.last_error}）` : ""}`
+        : `${trace}，模型没有在 ${fmtSec(timeoutMs)} 内回帖`;
+    return {
+      ok: false,
+      layer,
+      detail: `${head}：服务端已投递、本机监听已收到，模型未回 → ${why}`,
+      fix: fixFor(harness, channel, layer),
+    };
+  }
+  const layer: WakeVerifyLayer = "local_listener";
+  const why =
+    frame.result === "not_listening"
+      ? `本机连接没在消费投递（服务端判 listening=${frame.presence.listening ?? "suspect"}）`
+      : local.listener.live === null
+        ? `本机没有武装监听${local.listener.sessions > 0 ? `（有 ${local.listener.sessions} 个蛰伏会话，普通 claude 起的会话不接 @）` : ""}`
+        : `本机监听 pid ${local.listener.live.pid}（${local.listener.live.launch}）没留下收到这条 @ 的痕迹`;
+  return {
+    ok: false,
+    layer,
+    detail: `${head}：服务端已投递、本机监听未收到 → ${why}`,
+    fix: fixFor(harness, channel, layer),
+  };
+}
+
+export const defaultVerifyWakeDeps: VerifyWakeDeps = {
+  probe: runWakeProbe,
+  localEvidence: readWakeLocalEvidence,
+  now: () => Date.now(),
+};
+
+/**
+ * 真发一条 @ 验证往返。发送失败（网络 / 频道 loop guard 熔断）不抛：ok=false、无 layer、detail 说清
+ * 「探针没发出去」——那不是三层里的任何一层，是频道现在根本发不了消息。
+ */
+export async function verifyWakeRoundTrip(
+  opts: VerifyWakeRoundTripOptions,
+  deps: VerifyWakeDeps = defaultVerifyWakeDeps,
+): Promise<VerifyWakeRoundTripResult> {
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_WAKE_VERIFY_TIMEOUT_MS;
+  const harness = opts.harness ?? "other";
+  const startedAt = deps.now();
+  let frame: WakeTestFrame;
+  try {
+    frame = await deps.probe({
+      server: opts.server,
+      token: opts.token,
+      channel: opts.channel,
+      target: opts.identity,
+      timeoutSec: Math.max(1, Math.ceil(timeoutMs / 1000)),
+      body: verifyWakeBody(opts.identity),
+    });
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    return {
+      ok: false,
+      elapsedMs: deps.now() - startedAt,
+      detail: `✗ 验证帧没发出去：${message}`,
+      fix: /loop.guard/i.test(message) ? `party channel reset-guard ${opts.channel}   （频道已熔断，@ 现在到不了任何 agent）` : "party doctor",
+      seq: null,
+      probe: null,
+      local: null,
+    };
+  }
+  const elapsedMs = deps.now() - startedAt;
+  const seq = frame.phases.mention_delivered.seq;
+  const local =
+    seq === null
+      ? { listener: { live: null, sessions: 0 }, claimed: false, journaled: false, runnerTask: false }
+      : deps.localEvidence({ server: opts.server, token: opts.token, channel: opts.channel, identity: opts.identity, seq });
+  const verdict = classifyWakeVerify(frame, local, { identity: opts.identity, channel: opts.channel, elapsedMs, timeoutMs, harness });
+  return {
+    ok: verdict.ok,
+    elapsedMs,
+    ...(verdict.layer === undefined ? {} : { layer: verdict.layer }),
+    detail: verdict.detail,
+    ...(verdict.fix === undefined ? {} : { fix: verdict.fix }),
+    seq,
+    probe: frame,
+    local: verdict.ok ? null : local,
+  };
+}
+
+/** epic #987 里第 4 步那一行（加修法一行）。 */
+export function formatWakeVerifyStep(result: VerifyWakeRoundTripResult): string[] {
+  const lines = [`第 4 步  真发一条 @ 验证 · ${result.detail}`];
+  if (!result.ok && result.fix !== undefined) lines.push(`         → 修法：${result.fix}`);
+  return lines;
+}

--- a/cli/test/claude-channel-dormant-announce.test.ts
+++ b/cli/test/claude-channel-dormant-announce.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { ServerFrame } from "@agentparty/shared";
+import { WAKE_VERIFY_PREFIX, type ServerFrame } from "@agentparty/shared";
 import type { ClaudeSessionRegistryEntry } from "../src/claude-session-registry";
 import {
   dormantAnnounceDisplayName,
@@ -716,6 +716,33 @@ describe("同身份多 runtime 的 @ 唤醒（issue #963）", () => {
     for (const runtime of runtimes) expect(runtime.connections[0]!.acked).toEqual([46, 47]);
     // 对照：别人发的 @ 照常唤醒（自 @ 过滤没有把正常召唤一起挡掉）。
     for (const runtime of runtimes) runtime.connections[0]!.push(msg(48, [SELF]));
+    await tick(40);
+    expect(calls).toHaveLength(1);
+    abort.abort();
+    await Promise.all(done);
+  });
+
+  test("#990：自发的验证帧（[wake-verify] + 只 @ 自己）是自 @ 的唯一例外——照常唤醒，且仍只唤醒一次", async () => {
+    const { runtimes, calls } = siblingRuntimes(3);
+    const abort = new AbortController();
+    const done = runtimes.map((runtime) => runDormantClaudeSessionAnnounce("dev", abort.signal, runtime.deps));
+    await tick();
+    const verify = {
+      ...(msg(60, [SELF], { sender: { name: SELF, kind: "agent", owner: "leo@example.com" } }) as unknown as Record<string, unknown>),
+      // 本文件的 msg() 夹具写的 kind 是 "text"（线上帧恒为 "message"）；验证帧判据认的是真实 wire 值。
+      kind: "message",
+      body: `${WAKE_VERIFY_PREFIX} @${SELF} ping · 接入引导第 4 步`,
+    } as unknown as ServerFrame;
+    for (const runtime of runtimes) runtime.connections[0]!.push(verify);
+    await tick(40);
+    expect(calls).toHaveLength(1);
+    // 对照：前缀对了但还 @ 了别人 ⇒ 不是验证帧，仍按自 @ 忽略。
+    const notVerify = {
+      ...(msg(61, [SELF, "peer"], { sender: { name: SELF, kind: "agent" } }) as unknown as Record<string, unknown>),
+      kind: "message",
+      body: `${WAKE_VERIFY_PREFIX} @peer 看 @${SELF}`,
+    } as unknown as ServerFrame;
+    for (const runtime of runtimes) runtime.connections[0]!.push(notVerify);
     await tick(40);
     expect(calls).toHaveLength(1);
     abort.abort();

--- a/cli/test/verify-wake.test.ts
+++ b/cli/test/verify-wake.test.ts
@@ -1,0 +1,399 @@
+// #990：接入引导第 4 步——真发一条 @ 验证往返，超时说清哪一层没通。
+//
+// 钉三件事：① 往返成功 ⇒ 第 4 步过（healthy / wake_pending 都算）；② 三种超时各落到**不同的层**、给不同的
+// 文案与修法（把判层短路成常量，这里至少两条会红）；③ 本机证据的真实读法（认领文件 / bridge 恢复日志）与
+// #959 的 waiting 帧去重互不干扰（验证帧是 message，去重只看 status）。
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { WAKE_VERIFY_PREFIX, isWakeVerifyFrame, type MsgFrame } from "@agentparty/shared";
+import { deliveryRecoveryJournalPath } from "../src/delivery-recovery-journal";
+import { mentionWakeClaimDir, mentionWakeClaimKey } from "../src/mention-wake-claim";
+import {
+  classifyWakeVerify,
+  formatWakeVerifyStep,
+  readWakeLocalEvidence,
+  verifyWakeBody,
+  verifyWakeRoundTrip,
+  type VerifyWakeDeps,
+  type WakeLocalEvidence,
+} from "../src/onboarding/verify-wake";
+import { serveWakeAlreadyAdvertised, serveWakeNote } from "../src/commands/serve";
+import type { WakeTestFrame } from "../src/commands/wake";
+import type { ResolvedAuthDetailed } from "../src/oidc-cli";
+import { msgFrame } from "./mock-server";
+import { startRestMock, type RestMock, type RestRequest } from "./rest-mock";
+
+const SERVER = "https://party.example.com";
+const TOKEN = "ap_tok";
+const CHANNEL = "ludo";
+const ME = "server";
+
+function frame(over: Omit<Partial<WakeTestFrame>, "phases"> & { phases?: Partial<WakeTestFrame["phases"]> } = {}): WakeTestFrame {
+  const base: WakeTestFrame = {
+    type: "wake_test",
+    channel: CHANNEL,
+    target: ME,
+    result: "timeout",
+    generated_at: 1,
+    timeout_sec: 30,
+    presence: { state: "waiting", residency: "supervised", wake_kind: "serve", wake_verified_at: null, last_seen: 1 },
+    phases: {
+      mention_delivered: { ok: true, seq: 42, evidence: "message accepted by channel history" },
+      wake_invoked: { ok: null, status: "broadcast_pending", adapter: "serve", evidence: "serve broadcast delivered for mention #42; awaiting linked resume to confirm consumption" },
+      agent_resumed: { ok: false, seq: null, evidence: null },
+    },
+    reason: "timed out waiting for linked reply_to/status.summary_seq",
+  };
+  return { ...base, ...over, phases: { ...base.phases, ...(over.phases ?? {}) } } as WakeTestFrame;
+}
+
+const noLocal: WakeLocalEvidence = { listener: { live: null, sessions: 0 }, claimed: false, journaled: false, runnerTask: false };
+const armedLocal: WakeLocalEvidence = { listener: { live: { pid: 41233, launch: "claude-channel" }, sessions: 1 }, claimed: false, journaled: false, runnerTask: false };
+
+function deps(probe: WakeTestFrame | Error, local: WakeLocalEvidence = noLocal): VerifyWakeDeps & { probed: unknown[]; asked: number[] } {
+  const probed: unknown[] = [];
+  const asked: number[] = [];
+  let t = 1_000;
+  return {
+    probed,
+    asked,
+    probe: async (opts) => {
+      probed.push(opts);
+      t += 3_200;
+      if (probe instanceof Error) throw probe;
+      return probe;
+    },
+    localEvidence: ({ seq }) => {
+      asked.push(seq);
+      return local;
+    },
+    now: () => t,
+  };
+}
+
+const classify = (f: WakeTestFrame, local: WakeLocalEvidence, harness: "claude" | "codex" | "other" = "claude") =>
+  classifyWakeVerify(f, local, { identity: ME, channel: CHANNEL, elapsedMs: 3_200, timeoutMs: 30_000, harness });
+
+describe("验证帧本体（#990）", () => {
+  test("正文以 [wake-verify] 开头、只 @ 自己：服务端与本机监听都认它是验证帧", () => {
+    const body = verifyWakeBody(ME);
+    expect(body.startsWith(WAKE_VERIFY_PREFIX)).toBe(true);
+    expect(body).toContain(`@${ME}`);
+    expect(isWakeVerifyFrame({ kind: "message", body, mentions: [ME], sender: { name: ME } })).toBe(true);
+  });
+
+  test("往返探针复用 wake test 的本体：目标＝自己、正文＝验证帧、超时按秒上取整", async () => {
+    const d = deps(frame({ result: "healthy", phases: { agent_resumed: { ok: true, seq: 43, evidence: "reply_to" } } }));
+    const r = await verifyWakeRoundTrip({ server: SERVER, token: TOKEN, channel: CHANNEL, identity: ME, timeoutMs: 2_500 }, d);
+    expect(d.probed).toEqual([{ server: SERVER, token: TOKEN, channel: CHANNEL, target: ME, timeoutSec: 3, body: verifyWakeBody(ME) }]);
+    expect(r.ok).toBe(true);
+    expect(r.seq).toBe(42);
+    expect(r.probe?.type).toBe("wake_test");
+  });
+});
+
+describe("往返成功 ⇒ 第 4 步过（#990）", () => {
+  test("收到回帖：ok、带耗时与回帖 seq，无 layer，不读本机证据也不留 local", async () => {
+    const d = deps(frame({ result: "healthy", phases: { agent_resumed: { ok: true, seq: 43, evidence: "reply_to" } } }));
+    const r = await verifyWakeRoundTrip({ server: SERVER, token: TOKEN, channel: CHANNEL, identity: ME }, d);
+    expect(r).toMatchObject({ ok: true, elapsedMs: 3_200, seq: 42, local: null });
+    expect(r.layer).toBeUndefined();
+    expect(r.fix).toBeUndefined();
+    expect(formatWakeVerifyStep(r)).toEqual([`第 4 步  真发一条 @ 验证 · @${ME} ping → 3.2s 收到回执 ✓（回帖 #43）`]);
+  });
+
+  test("runner 已接手（wake_pending，#689）同样算过——headless runner 数分钟才回帖", async () => {
+    const d = deps(frame({ result: "wake_pending", phases: { wake_invoked: { ok: true, status: "invoked", adapter: "serve", evidence: "processing" } } }));
+    const r = await verifyWakeRoundTrip({ server: SERVER, token: TOKEN, channel: CHANNEL, identity: ME }, d);
+    expect(r.ok).toBe(true);
+    expect(r.detail).toContain("收到回执 ✓");
+    expect(r.detail).toContain("runner 已接手 #42");
+  });
+});
+
+describe("三种超时各落不同的层（#990）", () => {
+  test("服务端未投递：presence 没登记可唤醒 ⇒ server_delivery，验证帧没发", () => {
+    const v = classify(
+      frame({
+        result: "not_auto_wakeable",
+        reason: "no presence for target",
+        phases: {
+          mention_delivered: { ok: false, seq: null, evidence: "not sent because target is not auto-wakeable" },
+          wake_invoked: { ok: false, status: "not_invoked", adapter: null, evidence: "no presence for target" },
+        },
+      }),
+      noLocal,
+    );
+    expect(v.ok).toBe(false);
+    expect(v.layer).toBe("server_delivery");
+    expect(v.detail).toContain("✗ 30s 未收到");
+    expect(v.detail).toContain("服务端没把 @server 当成可唤醒目标");
+    expect(v.detail).toContain("no presence for target");
+    expect(v.fix).toContain(`party claude ${CHANNEL}`);
+  });
+
+  test("服务端未投递：帧发了但账本没有这条 @ 的行 ⇒ server_delivery", () => {
+    const v = classify(
+      frame({ phases: { wake_invoked: { ok: null, status: "not_audited", adapter: "serve", evidence: "not audited" } } }),
+      armedLocal,
+    );
+    expect(v.layer).toBe("server_delivery");
+    expect(v.detail).toContain("服务端未投递");
+    expect(v.detail).toContain("账本没有这条 @ 的投递记录");
+  });
+
+  test("本机未收到：服务端已广播、本机没有任何收到痕迹且没有武装监听 ⇒ local_listener", () => {
+    const v = classify(frame(), { ...noLocal, listener: { live: null, sessions: 2 } });
+    expect(v.layer).toBe("local_listener");
+    expect(v.detail).toContain("服务端已投递、本机监听未收到");
+    expect(v.detail).toContain("本机没有武装监听");
+    expect(v.detail).toContain("2 个蛰伏会话");
+    expect(v.fix).toContain(`party claude ${CHANNEL}`);
+  });
+
+  test("本机未收到：服务端判 listening=deaf ⇒ local_listener，说清是连接没在消费", () => {
+    const v = classify(
+      frame({ result: "not_listening", presence: { state: "waiting", residency: "supervised", wake_kind: "serve", wake_verified_at: null, last_seen: 1, listening: "deaf" } }),
+      armedLocal,
+    );
+    expect(v.layer).toBe("local_listener");
+    expect(v.detail).toContain("listening=deaf");
+  });
+
+  test("模型未回：本机 runtime 已认领这条唤醒，30s 内没回帖 ⇒ model_reply", () => {
+    const v = classify(frame(), { ...armedLocal, claimed: true });
+    expect(v.layer).toBe("model_reply");
+    expect(v.detail).toContain("服务端已投递、本机监听已收到，模型未回");
+    expect(v.detail).toContain("已认领这条唤醒");
+    expect(v.fix).toContain("卡住");
+  });
+
+  test("模型未回：runner 连败（#603）⇒ model_reply，带失败次数与最后错误", () => {
+    const v = classify(
+      frame({
+        result: "runner_failing",
+        presence: { state: "waiting", residency: "supervised", wake_kind: "serve", wake_verified_at: null, last_seen: 1, runner_health: { ok: false, consecutive_failures: 3, last_error: "claude: not logged in" } },
+      }),
+      armedLocal,
+      "codex",
+    );
+    expect(v.layer).toBe("model_reply");
+    expect(v.detail).toContain("runner 连败 x3");
+    expect(v.detail).toContain("not logged in");
+    expect(v.fix).toContain("party health");
+  });
+
+  test("三层互斥：同一份服务端帧，只改本机证据就换层（判层不是常量）", () => {
+    const f = frame();
+    expect(classify(f, noLocal).layer).toBe("local_listener");
+    expect(classify(f, { ...noLocal, journaled: true }).layer).toBe("model_reply");
+    expect(classify(f, { ...noLocal, runnerTask: true }).layer).toBe("model_reply");
+    expect(
+      classify(frame({ phases: { wake_invoked: { ok: false, status: "not_invoked", adapter: "webhook", evidence: "webhook delivery attempt 1 failed status=502" } } }), noLocal).layer,
+    ).toBe("server_delivery");
+  });
+
+  test("超时时读一次本机证据（按这条 seq），结果里带 layer/fix/local，退出形态是 ✗ 一行 + 修法一行", async () => {
+    const d = deps(frame(), noLocal);
+    const r = await verifyWakeRoundTrip({ server: SERVER, token: TOKEN, channel: CHANNEL, identity: ME, harness: "claude" }, d);
+    expect(d.asked).toEqual([42]);
+    expect(r).toMatchObject({ ok: false, layer: "local_listener", seq: 42, local: noLocal });
+    const lines = formatWakeVerifyStep(r);
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toStartWith("第 4 步  真发一条 @ 验证 · ✗ 30s 未收到：服务端已投递、本机监听未收到 → ");
+    expect(lines[1]).toBe(`         → 修法：party claude ${CHANNEL}   （重新起一个武装监听；常驻：party serve ${CHANNEL} --runner claude）`);
+  });
+
+  test("验证帧发不出去（频道熔断）：不是三层里的任何一层，修法指向 reset-guard", async () => {
+    const d = deps(new Error("loop_guard: 30 consecutive agent messages, waiting for a human"));
+    const r = await verifyWakeRoundTrip({ server: SERVER, token: TOKEN, channel: CHANNEL, identity: ME }, d);
+    expect(r.ok).toBe(false);
+    expect(r.layer).toBeUndefined();
+    expect(r.seq).toBeNull();
+    expect(r.detail).toContain("验证帧没发出去");
+    expect(r.fix).toContain(`party channel reset-guard ${CHANNEL}`);
+    expect(d.asked).toEqual([]);
+  });
+});
+
+describe("本机证据的真实读法（#990）", () => {
+  let home: string;
+  let saved: string | undefined;
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "ap-990-home-"));
+    saved = process.env.AGENTPARTY_HOME;
+    process.env.AGENTPARTY_HOME = home;
+  });
+  afterEach(() => {
+    if (saved === undefined) delete process.env.AGENTPARTY_HOME;
+    else process.env.AGENTPARTY_HOME = saved;
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  test("空 home：没有监听、没有任何痕迹", () => {
+    const e = readWakeLocalEvidence({ server: SERVER, token: TOKEN, channel: CHANNEL, identity: ME, seq: 42, cwd: home });
+    expect(e).toEqual({ listener: { live: null, sessions: 0 }, claimed: false, journaled: false, runnerTask: false });
+  });
+
+  test("#963 认领文件（同 server/身份/频道/seq）⇒ claimed；别的 seq 不算", () => {
+    const dir = mentionWakeClaimDir(home);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, `${mentionWakeClaimKey({ server: SERVER, identity: ME, channel: CHANNEL, seq: 42 })}.json`), "{}");
+    expect(readWakeLocalEvidence({ server: SERVER, token: TOKEN, channel: CHANNEL, identity: ME, seq: 42, cwd: home }).claimed).toBe(true);
+    expect(readWakeLocalEvidence({ server: SERVER, token: TOKEN, channel: CHANNEL, identity: ME, seq: 43, cwd: home }).claimed).toBe(false);
+  });
+
+  test("claude bridge 的 delivery 恢复日志里有这条 seq ⇒ journaled；坏 JSON 按没有算", () => {
+    const path = deliveryRecoveryJournalPath("claude", SERVER, TOKEN, CHANNEL);
+    mkdirSync(join(path, ".."), { recursive: true });
+    writeFileSync(path, JSON.stringify({ version: 1, channel: CHANNEL, bridge: "claude", entries: [{ message: { seq: 42 } }] }));
+    expect(readWakeLocalEvidence({ server: SERVER, token: TOKEN, channel: CHANNEL, identity: ME, seq: 42, cwd: home }).journaled).toBe(true);
+    expect(readWakeLocalEvidence({ server: SERVER, token: TOKEN, channel: CHANNEL, identity: ME, seq: 41, cwd: home }).journaled).toBe(false);
+    writeFileSync(path, "{not json");
+    expect(readWakeLocalEvidence({ server: SERVER, token: TOKEN, channel: CHANNEL, identity: ME, seq: 42, cwd: home }).journaled).toBe(false);
+  });
+});
+
+describe("与 #959 的 waiting 帧去重互不干扰", () => {
+  const auth: ResolvedAuthDetailed = {
+    server: SERVER,
+    token: TOKEN,
+    auth_source: "runtime_config",
+    config: { present: true, kind: "workspace", path: "/tmp/x.json" } as never,
+    account: { present: false, path: "/tmp/account.json" } as never,
+  };
+  const note = serveWakeNote("claude");
+  const status = (seq: number, n: string) =>
+    msgFrame(seq, "", { sender: { name: ME, kind: "agent" }, kind: "status", state: "waiting", note: n }) as unknown as MsgFrame;
+  const verify = (seq: number) =>
+    msgFrame(seq, verifyWakeBody(ME), { sender: { name: ME, kind: "agent" }, mentions: [ME] }) as unknown as MsgFrame;
+
+  test("验证帧不是状态帧：它夹在中间不会让去重把上线帧误判成「已发过」，也不会被去重吃掉", async () => {
+    // 上一条状态帧是别的 note，中间有验证帧 ⇒ 去重不命中（照发上线帧）。
+    expect(await serveWakeAlreadyAdvertised(auth, CHANNEL, note, { self: ME, recent: (async () => [status(1, "别的"), verify(2)]) as never })).toBe(false);
+    // 上一条状态帧一字不差，验证帧在它之后 ⇒ 去重照常命中（验证帧不干扰去重判定）。
+    expect(await serveWakeAlreadyAdvertised(auth, CHANNEL, note, { self: ME, recent: (async () => [status(1, note), verify(2)]) as never })).toBe(true);
+    // 验证帧本身永远不是 waiting 状态帧——去重的判据碰不到它。
+    expect(verify(2).kind).toBe("message");
+    expect(isWakeVerifyFrame(verify(2))).toBe(true);
+  });
+});
+
+// ── CLI 入口：party wake verify（走 REST mock，与 wake.test.ts 同一套） ──
+describe("party wake verify（#990）", () => {
+  const indexPath = join(import.meta.dir, "..", "src", "index.ts");
+  let home: string;
+  let mock: RestMock | null = null;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "ap-wake-verify-"));
+  });
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+    mock?.stop();
+    mock = null;
+  });
+
+  async function runCli(args: string[]): Promise<{ code: number; stdout: string; stderr: string }> {
+    const proc = Bun.spawn(["bun", "run", indexPath, ...args], {
+      env: { ...process.env, AGENTPARTY_HOME: home, ADMIN_SECRET: undefined },
+      stdout: "pipe",
+      stderr: "pipe",
+      cwd: home,
+    });
+    const [stdout, stderr, code] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    return { code, stdout, stderr };
+  }
+
+  function writeCfg(server: string) {
+    mkdirSync(home, { recursive: true });
+    writeFileSync(join(home, "config.json"), JSON.stringify({
+      server,
+      token: TOKEN,
+      identity: { name: ME, email: null, kind: "agent", role: "agent", owner: null, channel_scope: null, verified_at: 0 },
+    }));
+  }
+
+  const presence = () => Response.json({
+    presence: [{ name: ME, state: "waiting", note: null, ts: Date.now(), last_seen: Date.now(), residency: "supervised", wake: { kind: "serve" } }],
+  });
+  const reqsOf = (m: RestMock, method: string, path: string): RestRequest[] => m.requests.filter((r) => r.method === method && r.path === path);
+
+  test("往返成功：以本身份发验证帧（[wake-verify] + 只 @ 自己），收到回帖 ⇒ exit 0，印第 4 步那一行", async () => {
+    mock = startRestMock((req) => {
+      if (req.method === "GET" && req.path === `/api/channels/${CHANNEL}/presence`) return presence();
+      if (req.method === "POST" && req.path === `/api/channels/${CHANNEL}/messages`) return Response.json({ seq: 5 });
+      if (req.method === "GET" && req.path === `/api/channels/${CHANNEL}/wake-deliveries`) {
+        return Response.json({ deliveries: [{ mention_seq: 5, target_name: ME, webhook_name: "", adapter_kind: "serve", attempt: 1, result: "broadcast", http_status: null, error: null, attempted_at: 1, ack_seq: null, resume_seq: null }] });
+      }
+      if (req.method === "GET" && req.path === `/api/channels/${CHANNEL}/messages`) {
+        return Response.json({ messages: [{ type: "message", seq: 6, sender: { name: ME, kind: "agent" }, kind: "message", body: "pong", mentions: [], reply_to: 5, ts: 1 }] });
+      }
+      return undefined;
+    });
+    writeCfg(mock.url);
+    const r = await runCli(["wake", "verify", CHANNEL, "--timeout", "2"]);
+    expect(r.stderr).toBe("");
+    expect(r.code).toBe(0);
+    const posts = reqsOf(mock, "POST", `/api/channels/${CHANNEL}/messages`);
+    expect(posts).toHaveLength(1);
+    const body = posts[0]!.body as { kind: string; body: string; mentions: string[] };
+    expect(body.kind).toBe("message");
+    expect(body.body.startsWith(WAKE_VERIFY_PREFIX)).toBe(true);
+    expect(body.mentions).toEqual([ME]);
+    expect(r.stdout).toMatch(/^第 4 步 {2}真发一条 @ 验证 · @server ping → \d+(\.\d)?s 收到回执 ✓（回帖 #6）\n$/);
+  });
+
+  test("超时：服务端已广播、这台机器没有武装监听 ⇒ exit 2，✗ 行说清 local_listener 与修法；--json 带 layer", async () => {
+    mock = startRestMock((req) => {
+      if (req.method === "GET" && req.path === `/api/channels/${CHANNEL}/presence`) return presence();
+      if (req.method === "POST" && req.path === `/api/channels/${CHANNEL}/messages`) return Response.json({ seq: 7 });
+      if (req.method === "GET" && req.path === `/api/channels/${CHANNEL}/wake-deliveries`) {
+        return Response.json({ deliveries: [{ mention_seq: 7, target_name: ME, webhook_name: "", adapter_kind: "serve", attempt: 1, result: "broadcast", http_status: null, error: null, attempted_at: 1, ack_seq: null, resume_seq: null }] });
+      }
+      if (req.method === "GET" && req.path === `/api/channels/${CHANNEL}/messages`) return Response.json({ messages: [] });
+      return undefined;
+    });
+    writeCfg(mock.url);
+    const human = await runCli(["wake", "verify", "--channel", CHANNEL, "--timeout", "1"]);
+    expect(human.code).toBe(2);
+    expect(human.stdout).toContain("第 4 步  真发一条 @ 验证 · ✗ 1.0s 未收到：服务端已投递、本机监听未收到 → 本机没有武装监听");
+    expect(human.stdout).toContain("→ 修法：party wake check");
+
+    const json = await runCli(["wake", "verify", CHANNEL, "--timeout", "1", "--json"]);
+    expect(json.code).toBe(2);
+    const out = JSON.parse(json.stdout.trim());
+    expect(out).toMatchObject({ type: "wake_verify", channel: CHANNEL, identity: ME, ok: false, layer: "local_listener", seq: 7 });
+    expect(out.probe.type).toBe("wake_test");
+    expect(out.local.listener.live).toBeNull();
+  });
+
+  test("超时：服务端账本没有这条 @ 的行 ⇒ server_delivery（与本机层文案不同）", async () => {
+    mock = startRestMock((req) => {
+      if (req.method === "GET" && req.path === `/api/channels/${CHANNEL}/presence`) return presence();
+      if (req.method === "POST" && req.path === `/api/channels/${CHANNEL}/messages`) return Response.json({ seq: 8 });
+      if (req.method === "GET" && req.path === `/api/channels/${CHANNEL}/wake-deliveries`) return Response.json({ deliveries: [] });
+      if (req.method === "GET" && req.path === `/api/channels/${CHANNEL}/messages`) return Response.json({ messages: [] });
+      return undefined;
+    });
+    writeCfg(mock.url);
+    const r = await runCli(["wake", "verify", CHANNEL, "--timeout", "1", "--json"]);
+    expect(r.code).toBe(2);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.layer).toBe("server_delivery");
+    expect(out.detail).toContain("服务端未投递");
+  });
+
+  test("用法错误：verify 不收目标位置参数", async () => {
+    writeCfg("https://party.example.com");
+    const r = await runCli(["wake", "verify", CHANNEL, "extra"]);
+    expect(r.code).toBe(1);
+    expect(r.stderr).toContain("usage: party wake verify");
+  });
+});

--- a/cli/test/wake-verify-listeners.test.ts
+++ b/cli/test/wake-verify-listeners.test.ts
@@ -1,0 +1,168 @@
+// #990：验证帧是「自发消息」过滤的唯一例外——serve / watch / claude-channel bridge 三个本机监听都要认。
+//
+// #963 起监听一律忽略发信人是自己的帧（对话里提到自己不是召唤）。验证帧（`[wake-verify]` + 只 @ 自己）
+// 正是要让本身份不借别人的手走一遍真实唤醒链，所以它必须穿过这道过滤；而普通自 @（哪怕正文里有前缀
+// 但还 @ 了别人）继续被忽略——这里每个监听都配一条对照。
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { EXIT_ARCHIVED, WAKE_VERIFY_PREFIX, type ClientFrame, type MsgFrame, type ServerFrame } from "@agentparty/shared";
+import { ClaudeChannelDeliveryBridge, type ChannelNotification } from "../src/commands/claude-channel";
+import { runServe, type ServeOptions } from "../src/commands/serve";
+import { runWatch, type WatchOptions } from "../src/commands/watch";
+import { deliveryFrame, msgFrame, startMockServer, welcomeDirectedFrame, welcomeFrame, type MockServer } from "./mock-server";
+
+const VERIFY = `${WAKE_VERIFY_PREFIX} @me ping · 接入验证`;
+const self = { name: "me", kind: "agent" };
+
+let server: MockServer | null = null;
+afterEach(() => {
+  server?.stop();
+  server = null;
+});
+
+describe("serve：自发验证帧触发 runner，普通自 @ 不触发（#990）", () => {
+  test("mentions-only 下：自 @ 忽略；验证帧唤醒；前缀对了但还 @ 了别人的自发帧仍忽略", async () => {
+    server = startMockServer((frame, sock) => {
+      if (frame.type !== "hello") return;
+      sock.send(welcomeFrame(0, "me"));
+      setTimeout(() => sock.send(msgFrame(1, "@me 这次醒了", { sender: self, mentions: ["me"] })), 10);
+      setTimeout(() => sock.send(msgFrame(2, `${WAKE_VERIFY_PREFIX} @bob 看 @me`, { sender: self, mentions: ["bob", "me"] })), 25);
+      setTimeout(() => sock.send(msgFrame(3, VERIFY, { sender: self, mentions: ["me"] })), 40);
+      setTimeout(() => sock.send({ type: "error", code: "archived", message: "done" }), 90);
+    });
+    const woke: number[] = [];
+    const lines: string[] = [];
+    const o: ServeOptions = {
+      server: server.url,
+      token: "ap_tok",
+      channel: "dev",
+      since: 0,
+      cmd: "true",
+      mentionsOnly: true,
+      out: (line) => lines.push(line),
+      lockDir: mkdtempSync(join(tmpdir(), "ap-lock-")),
+      runCommand: async (frame: MsgFrame) => {
+        woke.push(frame.seq);
+      },
+    };
+    expect(await runServe(o)).toBe(EXIT_ARCHIVED);
+    expect(woke).toEqual([3]);
+  });
+});
+
+describe("watch：自发验证帧算数，普通自发帧照旧跳过（#990）", () => {
+  test("--mentions-only --once：自 @ 跳过、验证帧打印并退出", async () => {
+    server = startMockServer((frame, sock) => {
+      if (frame.type === "hello") {
+        sock.send(welcomeFrame(0, "me"));
+        setTimeout(() => sock.send(msgFrame(1, "@me echo", { sender: self, mentions: ["me"] })), 20);
+        setTimeout(() => sock.send(msgFrame(2, VERIFY, { sender: self, mentions: ["me"] })), 60);
+      }
+    });
+    const lines: string[] = [];
+    const o: WatchOptions = {
+      server: server.url,
+      token: "ap_tok",
+      channel: "dev",
+      since: 0,
+      once: true,
+      follow: false,
+      mentionsOnly: true,
+      timeoutSec: 2,
+      out: (line) => lines.push(line),
+      lockDir: mkdtempSync(join(tmpdir(), "ap-lock-")),
+    };
+    expect(await runWatch(o)).toBe(0);
+    expect(lines[0]).toBe(`[2] me(agent): ${VERIFY}`);
+    // seq 1 的自 @ 没有被打印（--once 在第一条匹配帧后就退出，匹配的是 2 不是 1）。
+    expect(lines.some((line) => line.startsWith("[1]"))).toBe(false);
+  });
+});
+
+describe("claude-channel bridge：自发验证帧的 directed delivery 被认领并注入，普通自发 delivery 仍不处理（#990）", () => {
+  function streaming() {
+    let cursor = 0;
+    const sent: ClientFrame[] = [];
+    const queued: ServerFrame[] = [];
+    let ended = false;
+    let wake: (() => void) | null = null;
+    const signal = () => {
+      const resolve = wake;
+      wake = null;
+      resolve?.();
+    };
+    const frames = (async function* (): AsyncGenerator<ServerFrame> {
+      for (;;) {
+        const frame = queued.shift();
+        if (frame) {
+          yield frame;
+          continue;
+        }
+        if (ended) return;
+        await new Promise<void>((resolve) => {
+          wake = resolve;
+        });
+      }
+    })();
+    return {
+      sent,
+      push(frame: ServerFrame) {
+        queued.push(frame);
+        signal();
+      },
+      connection: {
+        frames,
+        send(frame: ClientFrame) {
+          sent.push(frame);
+          return true;
+        },
+        ack(seq: number) {
+          cursor = Math.max(cursor, seq);
+        },
+        close() {
+          ended = true;
+          signal();
+        },
+        get cursor() {
+          return cursor;
+        },
+      },
+    };
+  }
+
+  async function settle(ms = 60): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  test("自发普通 delivery：不发 delivery_update；自发验证帧 delivery：发 running 更新（认领链启动）", async () => {
+    const stream = streaming();
+    const notifications: ChannelNotification[] = [];
+    const bridge = new ClaudeChannelDeliveryBridge({
+      channel: "dev",
+      connection: stream.connection,
+      notify: async (notification) => {
+        notifications.push(notification);
+      },
+      postReply: async () => ({ seq: 1 }),
+      deliveryAckTimeoutMs: 1_000,
+      out: () => {},
+    });
+    const run = bridge.run();
+    stream.push(welcomeDirectedFrame(0, "me") as ServerFrame);
+    // 对照：#963 的自 @——哪怕服务端（老版本）发来了 delivery，bridge 也不处理。
+    stream.push(deliveryFrame(5, "@me 这次醒了", { id: "del-5", target_name: "me", sender: self, mentions: ["me"] }) as ServerFrame);
+    await settle();
+    expect(stream.sent.filter((f) => f.type === "delivery_update")).toHaveLength(0);
+    // 验证帧：与别人 @ 我完全同一条路径——先向 Worker 报 running。
+    stream.push(deliveryFrame(6, VERIFY, { id: "del-6", target_name: "me", sender: self, mentions: ["me"] }) as ServerFrame);
+    await settle();
+    const updates = stream.sent.filter((f) => f.type === "delivery_update") as Array<Extract<ClientFrame, { type: "delivery_update" }>>;
+    expect(updates).toHaveLength(1);
+    expect(updates[0]!.delivery_id).toBe("del-6");
+    expect(updates[0]!.state).toBe("running");
+    bridge.close();
+    await expect(run).resolves.toBe(0);
+  });
+});

--- a/plugins/agentparty/skills/agentparty/SKILL.md
+++ b/plugins/agentparty/skills/agentparty/SKILL.md
@@ -614,6 +614,7 @@ surface it to the owner instead of ignoring it.
 | Codex / unknown wake | `party serve <slug> --on-mention '<runner using {file}>'` — run under tmux/launchctl/supervisor if the shell is ephemeral |
 | Tail/debug only | `party watch <slug> --mentions-only --follow [--timeout N]` — prints messages but does not wake an agent by itself |
 | Verify a wake path actually resumes an agent | `party wake test @name [--channel <slug>] [--json]` — run from a DIFFERENT identity than the target; `party who` marks self-declared watch wake as `watch (unverified)` |
+| Prove YOUR OWN identity is really wakeable (onboarding step 4, #990) | `party wake verify [<slug>] [--timeout N] [--json]` — sends one `[wake-verify] @you ping` frame as yourself (the only self-mention the server and local listeners treat as a real summons; never counted against the loop guard), waits for the reply, and on timeout names the layer that failed — `server_delivery` / `local_listener` / `model_reply` — with one fix command. Exit 0 only on a real round trip |
 | Let Lark wake a human when the channel @mentions them | `party lark notify on --channel <slug>` — requires `party login` with Lark/Feishu and a profile handle; use `notify off` to disable |
 | Create a short-lived worker for an agent team | CLI: `party spawn <worker> --channel-scope <slug> [--ttl 2h] [--team-id id]`; MCP: `party_spawn_worker` |
 | Manage channel tasks | CLI: `party task create|from|list|assign|claim|status|block|done`; MCP: `party_task_list/create/from_message/update` |

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -415,6 +415,34 @@ export interface TaskRecord {
   completed_at: number | null;
 }
 
+// ---- 接入验证帧（#990）----
+/**
+ * 接入引导第 4 步「真发一条 @ 验证」的帧标记。
+ *
+ * 验证帧 = 本身份对**自己**的显式召唤：kind=message、正文以 WAKE_VERIFY_PREFIX 开头、mentions 只含发信人自己。
+ * #963 把「自 @」统一判成「对话里提到自己」而不是召唤（服务端不建 delivery、不落 broadcast ledger、监听不唤醒）；
+ * 验证帧是唯一例外——它存在的理由就是让本身份不借别人的手走一遍真实唤醒链（服务端投递 → 本机监听 → 模型回帖）。
+ * 判据三样缺一不可，所以一条普通回帖里顺口提到自己永远不会被误当成验证帧。
+ * 服务端不把它计入 loop guard 的 streak / fair-share（它是探针、不是对话），但频道已熔断时照样拒——
+ * 那时 @ 本来就到不了你，验证失败是真话。
+ */
+export const WAKE_VERIFY_PREFIX = "[wake-verify]";
+
+export function isWakeVerifyFrame(frame: {
+  kind: MessageKind;
+  body?: string | null;
+  mentions?: readonly string[] | null;
+  sender: { name: string };
+}): boolean {
+  if (frame.kind !== "message") return false;
+  if (typeof frame.body !== "string" || !frame.body.startsWith(WAKE_VERIFY_PREFIX)) return false;
+  const mentions = frame.mentions ?? [];
+  if (mentions.length === 0) return false;
+  const self = mentionKey(frame.sender.name);
+  if (self === "") return false;
+  return mentions.every((name) => mentionKey(name) === self);
+}
+
 // ---- 任务租约（#936）：把 #885 的本机文件锁抬到服务端 ----
 //
 // #885 在**认领时刻**装了一道「同一身份只允许一个执行体动这件事」的闸，但它只在本机文件级

--- a/skills/agentparty/SKILL.md
+++ b/skills/agentparty/SKILL.md
@@ -614,6 +614,7 @@ surface it to the owner instead of ignoring it.
 | Codex / unknown wake | `party serve <slug> --on-mention '<runner using {file}>'` — run under tmux/launchctl/supervisor if the shell is ephemeral |
 | Tail/debug only | `party watch <slug> --mentions-only --follow [--timeout N]` — prints messages but does not wake an agent by itself |
 | Verify a wake path actually resumes an agent | `party wake test @name [--channel <slug>] [--json]` — run from a DIFFERENT identity than the target; `party who` marks self-declared watch wake as `watch (unverified)` |
+| Prove YOUR OWN identity is really wakeable (onboarding step 4, #990) | `party wake verify [<slug>] [--timeout N] [--json]` — sends one `[wake-verify] @you ping` frame as yourself (the only self-mention the server and local listeners treat as a real summons; never counted against the loop guard), waits for the reply, and on timeout names the layer that failed — `server_delivery` / `local_listener` / `model_reply` — with one fix command. Exit 0 only on a real round trip |
 | Let Lark wake a human when the channel @mentions them | `party lark notify on --channel <slug>` — requires `party login` with Lark/Feishu and a profile handle; use `notify off` to disable |
 | Create a short-lived worker for an agent team | CLI: `party spawn <worker> --channel-scope <slug> [--ttl 2h] [--team-id id]`; MCP: `party_spawn_worker` |
 | Manage channel tasks | CLI: `party task create|from|list|assign|claim|status|block|done`; MCP: `party_task_list/create/from_message/update` |

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -8,6 +8,7 @@ import {
   LOOP_GUARD_AGENT_PARTY_N,
   LOOP_GUARD_N,
   LOOP_GUARD_PARTY_N,
+  isWakeVerifyFrame,
   MAX_ALSO_RESOLVES,
   MAX_WEBHOOKS_PER_CHANNEL,
   MAX_MESSAGE_AUDIT_ROWS,
@@ -83,6 +84,7 @@ import {
   type IdentityEraseSummary,
   type IdentityExportData,
   type MsgFrame,
+  type MessageKind,
   type MessageUpdateFrame,
   type ParticipantRemovedFrame,
   type PresenceEntry,
@@ -4667,7 +4669,7 @@ export class ChannelDO extends Server<Env> {
         return true;
       case "mentions":
         // #963：自 @ 不投 webhook——那是对话里提到自己，不是召唤。
-        return msg.mentions.includes(hookName) && !this.isSelfMention(msg.sender.name, hookName);
+        return msg.mentions.includes(hookName) && !this.isSelfMention(msg.sender.name, hookName, msg);
       case "status":
         return msg.kind === "status";
       case "needs-human":
@@ -4957,8 +4959,18 @@ export class ChannelDO extends Server<Env> {
   // 的回帖）。mentions 数组原样落库/广播（正文里的 @ 仍要高亮、仍要进 history），但服务端**不为它生成
   // 任何唤醒语义**：不建 directed delivery、不落 serve/watch 的 broadcast ledger、不投 mentions 过滤的
   // webhook。同身份 13 个 runtime 各醒一次的第二、三轮就是自 @ 触发的。
-  private isSelfMention(senderName: string, target: string): boolean {
-    return mentionMatchKey(senderName) === mentionMatchKey(target);
+  //
+  // #990：唯一例外是接入验证帧（isWakeVerifyFrame：`[wake-verify]` 前缀 + mentions 只含自己）——它的存在理由
+  // 就是让本身份走一遍真实唤醒链，所以传了 frame 且判定为验证帧时，自 @ **就是**召唤。不传 frame 的调用点
+  // 保持 #963 原判（保守：宁可不唤醒）。
+  private isSelfMention(
+    senderName: string,
+    target: string,
+    frame?: { kind: MessageKind; body?: string | null; mentions?: readonly string[] | null },
+  ): boolean {
+    if (mentionMatchKey(senderName) !== mentionMatchKey(target)) return false;
+    if (frame !== undefined && isWakeVerifyFrame({ ...frame, sender: { name: senderName } })) return false;
+    return true;
   }
 
   // #107：某 name 当前登记的 wake 层（presence.wake_kind）。无 presence / 未登记 = null。
@@ -4979,8 +4991,8 @@ export class ChannelDO extends Server<Env> {
     for (const name of msg.mentions) {
       if (seen.has(name)) continue;
       seen.add(name);
-      // #963：自 @ 不是唤醒，别落一行「已广播唤醒」的假账。
-      if (this.isSelfMention(msg.sender.name, name)) continue;
+      // #963：自 @ 不是唤醒，别落一行「已广播唤醒」的假账（#990 验证帧除外）。
+      if (this.isSelfMention(msg.sender.name, name, msg)) continue;
       const kind = this.wakeKindFor(name);
       if (kind !== "serve" && kind !== "watch") continue;
       // #180：被人为暂停接待的目标，webhook 一律不投；serve/watch 同理不落"已广播唤醒"行，
@@ -8551,7 +8563,7 @@ export class ChannelDO extends Server<Env> {
       // #963：发信人自己不入 deliveryTargets——自 @ 不建 directed delivery，否则每个同身份 runtime
       // 都会把这条「提到自己」的回帖当成一次新召唤。mentions 数组保持原样（正文高亮/历史不受影响）。
       deliveryTargets: candidateDeliveryTargets.filter((target) =>
-        !this.isSelfMention(senderName, target) &&
+        !this.isSelfMention(senderName, target, frame) &&
         Object.prototype.hasOwnProperty.call(ownerLookup, target) &&
         (expectedAutoOwners.get(mentionMatchKey(target)) === undefined || !invalidAutoKeys.has(mentionMatchKey(target)))
       ),
@@ -8754,6 +8766,10 @@ export class ChannelDO extends Server<Env> {
     // status 是 presence/协调状态，不是对话消息：agent 已触发 fair-share guard 后仍必须能声明
     // blocked/waiting，让频道知道它为什么停下。它也不消耗/重置消息 streak（#466）。
     const loopGuard = identity.kind === "agent" && frame.kind === "message" ? this.loopGuardMessage(identity.name) : null;
+    // #990：接入验证帧是探针不是对话——照样过 guard 的闸（频道熔断时 @ 本来就到不了它，拒掉是真话），
+    // 但**不计入** streak / fair-share：一台机器反复跑接入引导不该把频道的名额吃光（#959 同一类教训）。
+    const verifyProbe =
+      frame.kind === "message" && isWakeVerifyFrame({ ...frame, sender: { name: identity.name } });
     if (loopGuard !== null) {
       this.alertLoopGuard(loopGuard);
       return {
@@ -9087,8 +9103,10 @@ export class ChannelDO extends Server<Env> {
     const workflowGuardFrame = this.applyWorkflowGuardAfterSend(identity, msg, workflowGuard, now);
     if (frame.kind === "message") {
       if (identity.kind === "agent") {
-        this.setMeta("agent_streak", String(this.agentStreak() + 1));
-        this.setMeta(this.agentCountKey(identity.name), String(this.agentCount(identity.name) + 1));
+        if (!verifyProbe) {
+          this.setMeta("agent_streak", String(this.agentStreak() + 1));
+          this.setMeta(this.agentCountKey(identity.name), String(this.agentCount(identity.name) + 1));
+        }
       } else {
         this.clearLoopGuardState();
         this.clearWorkflowGuards();
@@ -10560,9 +10578,9 @@ export class ChannelDO extends Server<Env> {
   }
 
   private async agentMentionTargets(msg: MsgFrame): Promise<string[]> {
-    // #963：自 @ 不是唤醒目标（与 routeMentionsForDelivery 同一口径）。
+    // #963：自 @ 不是唤醒目标（与 routeMentionsForDelivery 同一口径，#990 验证帧同样例外）。
     const candidates = [...new Set(
-      msg.mentions.filter((name) => name !== "system" && !this.isSelfMention(msg.sender.name, name)),
+      msg.mentions.filter((name) => name !== "system" && !this.isSelfMention(msg.sender.name, name, msg)),
     )];
     if (candidates.length === 0) return [];
     const authoritative = new Map<string, { name: string; role: string; active: boolean; removed: boolean }>();
@@ -10734,11 +10752,12 @@ export class ChannelDO extends Server<Env> {
   ): Promise<void> {
     // Status/presence frames are coordination metadata, not agent work. Self-mentions likewise must
     // never claim a queue slot the CLI intentionally refuses to run, or one poison row blocks every
-    // later work item for that target until lease expiry.
+    // later work item for that target until lease expiry. #990: the onboarding verify frame is the one
+    // self-mention the CLI listeners deliberately DO run, so it keeps its queue slot (isSelfMention).
     if (msg.kind !== "message") return Promise.resolve();
     // Pause delays dispatch; it must not erase the durable wake debt. The queued row is created even
     // while the target is paused and resumePresence() restarts adapter selection later.
-    const targets = [...new Set(classifiedTargets)].filter((targetName) => targetName !== msg.sender.name);
+    const targets = [...new Set(classifiedTargets)].filter((targetName) => !this.isSelfMention(msg.sender.name, targetName, msg));
     if (targets.length === 0) return Promise.resolve();
     const now = Date.now();
     this.markSupersededByReplyCorrection(msg, targets, now);

--- a/worker/test/wake-verify-frame.spec.ts
+++ b/worker/test/wake-verify-frame.spec.ts
@@ -1,0 +1,173 @@
+// #990：接入引导第 4 步的验证帧——本身份对自己的显式召唤。
+//
+// #963 把「自 @」判成「对话里提到自己」：不建 directed delivery、不落 broadcast ledger、不投 webhook。
+// 验证帧（`[wake-verify]` 前缀 + mentions 只含自己）是唯一例外：它就是要让本身份走一遍真实唤醒链。
+// 同时它是探针不是对话：不计入 loop guard 的 streak / fair-share（反复跑接入引导不该吃光频道名额），
+// 但频道已熔断时照样拒——那时 @ 本来就到不了它，验证失败是真话。
+import { env, runInDurableObject } from "cloudflare:test";
+import { LOOP_GUARD_AGENT_N, LOOP_GUARD_N, WAKE_VERIFY_PREFIX, isWakeVerifyFrame } from "@agentparty/shared";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import type { ChannelDO } from "../src/do";
+import { fetchMock } from "./fetch-mock";
+import { WsClient, api, completeCapabilityHello, createChannel, postMessage, seedToken, uniq } from "./helpers";
+
+beforeAll(() => {
+  fetchMock.activate();
+  fetchMock.disableNetConnect();
+});
+afterEach(() => fetchMock.assertNoPendingInterceptors());
+
+function send(slug: string, token: string, body: string, mentions: string[], replyTo: number | null = null) {
+  return api(`/api/channels/${slug}/messages`, token, {
+    method: "POST",
+    body: JSON.stringify({ kind: "message", body, mentions, reply_to: replyTo }),
+  });
+}
+
+async function deliveryTargets(slug: string): Promise<Array<{ seq: number; target: string }>> {
+  const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+  return runInDurableObject(stub, async (_instance: ChannelDO, state) =>
+    state.storage.sql
+      .exec("SELECT message_seq, target_name FROM directed_deliveries ORDER BY message_seq, target_name")
+      .toArray()
+      .map((row) => ({ seq: Number(row.message_seq), target: String(row.target_name) })),
+  );
+}
+
+async function ledgerRows(slug: string): Promise<Array<{ seq: number; target: string; kind: string; result: string }>> {
+  const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+  return runInDurableObject(stub, async (_instance: ChannelDO, state) =>
+    state.storage.sql
+      .exec("SELECT mention_seq, target_name, adapter_kind, result FROM wake_delivery_ledger ORDER BY id")
+      .toArray()
+      .map((row) => ({
+        seq: Number(row.mention_seq),
+        target: String(row.target_name),
+        kind: String(row.adapter_kind),
+        result: String(row.result),
+      })),
+  );
+}
+
+async function guardCounters(slug: string, agentName: string): Promise<{ streak: number; count: number }> {
+  const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+  return runInDurableObject(stub, async (_instance: ChannelDO, state) => {
+    const read = (key: string) => {
+      const row = state.storage.sql.exec("SELECT value FROM meta WHERE key = ?", key).toArray()[0];
+      return row === undefined ? 0 : Number(row.value);
+    };
+    return { streak: read("agent_streak"), count: read(`agent_count:${agentName}`) };
+  });
+}
+
+async function seedGuardCounters(slug: string, agentName: string, count: number, streak = count) {
+  const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+  await runInDurableObject(stub, async (_instance: ChannelDO, state) => {
+    state.storage.sql.exec(
+      `INSERT INTO meta (key, value) VALUES (?, ?), ('agent_streak', ?)
+       ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+      `agent_count:${agentName}`,
+      String(count),
+      String(streak),
+    );
+  });
+}
+
+async function enableLoopGuard(slug: string, token: string, limit: number): Promise<void> {
+  const res = await api(`/api/channels/${slug}/loop-guard`, token, {
+    method: "PUT",
+    body: JSON.stringify({ enabled: true, limit }),
+  });
+  expect(res.status).toBe(200);
+}
+
+// 用真实 WS status 帧把 agent 登记成 serve（服务端据此盖 presence.wake_kind）。
+async function registerServe(slug: string, token: string): Promise<WsClient> {
+  const ws = await WsClient.open(slug, token);
+  await completeCapabilityHello(ws);
+  ws.send({ type: "send", kind: "status", state: "waiting", note: "standby", mentions: [], residency: "supervised", wake: { kind: "serve" } });
+  await ws.nextOfType("sent");
+  return ws;
+}
+
+describe("isWakeVerifyFrame（共享判据）", () => {
+  it("三样缺一不可：前缀 + kind=message + mentions 只含自己", () => {
+    const base = { kind: "message" as const, body: `${WAKE_VERIFY_PREFIX} @me ping`, mentions: ["me"], sender: { name: "me" } };
+    expect(isWakeVerifyFrame(base)).toBe(true);
+    // ASCII 大小写按 mentionMatchKey 同一把尺子
+    expect(isWakeVerifyFrame({ ...base, mentions: ["ME"] })).toBe(true);
+    expect(isWakeVerifyFrame({ ...base, body: "@me ping" })).toBe(false);
+    expect(isWakeVerifyFrame({ ...base, kind: "status" })).toBe(false);
+    expect(isWakeVerifyFrame({ ...base, mentions: [] })).toBe(false);
+    expect(isWakeVerifyFrame({ ...base, mentions: ["me", "peer"] })).toBe(false);
+    expect(isWakeVerifyFrame({ ...base, mentions: ["peer"] })).toBe(false);
+    expect(isWakeVerifyFrame({ ...base, body: null })).toBe(false);
+    expect(isWakeVerifyFrame({ ...base, mentions: undefined })).toBe(false);
+  });
+});
+
+describe("验证帧是自 @ 的唯一例外（issue #990）", () => {
+  it("验证帧：为自己建 directed delivery、落 serve broadcast ledger；普通自 @ 依旧不建（#963 不回退）", async () => {
+    const owner = `${uniq("owner")}@example.com`;
+    const self = await seedToken("agent", uniq("leo-server"), { owner });
+    const slug = await createChannel(self.token);
+    const ws = await registerServe(slug, self.token);
+
+    // 对照：普通自 @ 没有任何唤醒语义。
+    const plain = await send(slug, self.token, `@${self.name} 这次醒了`, [self.name]);
+    expect(plain.status).toBe(200);
+    expect(await deliveryTargets(slug)).toEqual([]);
+    expect(await ledgerRows(slug)).toEqual([]);
+
+    // 验证帧：与别人 @ 它完全同一条路径。
+    const verify = await send(slug, self.token, `${WAKE_VERIFY_PREFIX} @${self.name} ping`, [self.name]);
+    expect(verify.status).toBe(200);
+    const seq = ((await verify.json()) as { seq: number }).seq;
+    expect(await deliveryTargets(slug)).toEqual([{ seq, target: self.name }]);
+    expect(await ledgerRows(slug)).toEqual([{ seq, target: self.name, kind: "serve", result: "broadcast" }]);
+    ws.close();
+  });
+
+  it("前缀对了但还 @ 了别人：不是验证帧，自己那份照旧不建，只给别人建", async () => {
+    const owner = `${uniq("owner")}@example.com`;
+    const self = await seedToken("agent", uniq("leo-server"), { owner });
+    const peer = await seedToken("agent", uniq("peer"), { owner });
+    const slug = await createChannel(self.token);
+    const res = await send(slug, self.token, `${WAKE_VERIFY_PREFIX} @${peer.name} 看看 @${self.name}`, [peer.name, self.name]);
+    expect(res.status).toBe(200);
+    const seq = ((await res.json()) as { seq: number }).seq;
+    expect(await deliveryTargets(slug)).toEqual([{ seq, target: peer.name }]);
+  });
+});
+
+describe("验证帧不计 loop guard（issue #990）", () => {
+  it("连发验证帧不推 streak / fair-share 计数；普通消息的名额一条不少", async () => {
+    const agent = await seedToken("agent");
+    const slug = await createChannel(agent.token);
+    await enableLoopGuard(slug, agent.token, LOOP_GUARD_N);
+    expect((await postMessage(slug, agent.token, "warm up")).status).toBe(200);
+    await seedGuardCounters(slug, agent.name, LOOP_GUARD_AGENT_N - 1);
+
+    for (let i = 0; i < 3; i += 1) {
+      const res = await send(slug, agent.token, `${WAKE_VERIFY_PREFIX} @${agent.name} ping ${i}`, [agent.name]);
+      expect(res.status).toBe(200);
+    }
+    // 三条验证帧过去了，计数器纹丝不动。
+    expect(await guardCounters(slug, agent.name)).toEqual({ streak: LOOP_GUARD_AGENT_N - 1, count: LOOP_GUARD_AGENT_N - 1 });
+    // 最后一条普通消息的名额还在（若验证帧计了数，这条就已经 409）。
+    expect((await postMessage(slug, agent.token, "at my quota")).status).toBe(200);
+    const over = await postMessage(slug, agent.token, "over my quota");
+    expect(over.status).toBe(409);
+    await expect(over.json()).resolves.toMatchObject({ error: { code: "loop_guard" } });
+  });
+
+  it("频道已熔断时验证帧照样被拒——@ 本来就到不了它，验证失败是真话", async () => {
+    const agent = await seedToken("agent");
+    const slug = await createChannel(agent.token);
+    await enableLoopGuard(slug, agent.token, LOOP_GUARD_N);
+    await seedGuardCounters(slug, agent.name, LOOP_GUARD_AGENT_N);
+    const res = await send(slug, agent.token, `${WAKE_VERIFY_PREFIX} @${agent.name} ping`, [agent.name]);
+    expect(res.status).toBe(409);
+    await expect(res.json()).resolves.toMatchObject({ error: { code: "loop_guard" } });
+  });
+});


### PR DESCRIPTION
## 做了什么

子任务 C（epic #987）：接入的最终判据是**真实唤醒**。新增可独立调用的模块 + 子命令，供 #988 的步骤机直接接入（本 PR **不改** `join.ts` 的收尾逻辑）。

- `cli/src/onboarding/verify-wake.ts`（新）
  - `verifyWakeRoundTrip({ server, token, channel, identity, timeoutMs?, harness? }, deps?)` → `{ ok, elapsedMs, layer?: "server_delivery" | "local_listener" | "model_reply", detail, fix?, seq, probe, local }`
  - `classifyWakeVerify(frame, localEvidence, ctx)` 纯函数判层；`readWakeLocalEvidence()` 读本机痕迹；`formatWakeVerifyStep()` 印 epic 里第 4 步那一行
- `party wake verify [channel|--channel C] [--timeout N] [--json]`（与 `wake test` / `wake check` 同一体系）
  - 过：`第 4 步  真发一条 @ 验证 · @server ping → 3.2s 收到回执 ✓（回帖 #43）`
  - 超时：`第 4 步  真发一条 @ 验证 · ✗ 30s 未收到：服务端已投递、本机监听未收到 → 本机没有武装监听…` + `→ 修法：party claude ludo …`
  - exit 0 只在真往返（healthy / wake_pending #689）；`--json` 出 `wake_verify` 帧（内含原始 `wake_test` 帧与本机证据）

## 设计 / 复用了什么

- **验证帧** = `[wake-verify]` 前缀 + `kind=message` + `mentions` 只含发信人自己（`shared` 的 `isWakeVerifyFrame`，三样缺一不可，普通回帖里顺口提到自己永远不会误判）。
- #963 把「自 @」统一判成「提到自己不是召唤」（服务端不建 delivery / 不落 ledger / 不投 webhook，本机监听全忽略）。验证帧是**唯一例外**，六个点位都认它是真实召唤：
  - worker `do.ts`：`isSelfMention(sender, target, frame?)` 传 frame 的调用点（`routeMentionsForDelivery` / `ensureDirectedDeliveries` / `recordServeWatchWakes` / `shouldDeliverWebhook` / `agentMentionTargets`）
  - cli：`serve.ts` `fromSelf`、`watch.ts` `fromSelf`、`claude-channel.ts` bridge 的两处 `sender === self` 与蛰伏 announce 腿的 `selfAuthoredMention`
- **不计 loop guard**：验证帧不推 `agent_streak` / `agent_count`，但频道已熔断时照样 409（那时 @ 本来就到不了它，验证失败是真话；`verify` 会说「验证帧没发出去 → party channel reset-guard」）。
- **#959 去重**只看 `status` 帧，验证帧是 `message`，互不干扰（有测试钉住）。
- **往返本体复用 `party wake test`**：`wake.ts` 抽出 `runWakeProbe`（presence 过闸 → 发探针 → 轮询 ledger / 回帖 → #603/#689 探活分级），`wake test` 行为与 JSON 契约不变。
- **超时判层**（按「服务端投了没 → 本机收到没 → 模型回了没」落到第一层没通处）：
  - `server_delivery`：presence 没登记可唤醒（探针没发）/ 账本没这条 @ 的行（`not_audited`：可能被 pause 或服务端旧版不认验证帧）/ webhook 投递失败
  - `local_listener`：服务端已广播，但本机没有 #963 认领文件、claude bridge 恢复日志、serve 健康缓存 `current_task` 任一痕迹；或 `listening=deaf/suspect`；或 `probeClaudeArmedListener` 说本机没有武装监听
  - `model_reply`：本机已收到（上述任一痕迹）但超时没回帖；或 runner 连败
  - 修法按加入绑定里的 harness 给（claude → `party claude <chan>`，其余 → `party wake check`）

## 测试证据

- `cd worker && bunx tsc --noEmit && bunx vitest run test/wake-verify-frame.spec.ts test/self-mention-no-wake.spec.ts test/agent-loop-guard.spec.ts test/webhooks.spec.ts test/undeliverable-mentions.spec.ts test/directed-delivery-adapters.spec.ts test/mention-debt-visibility.spec.ts test/guards.spec.ts test/body-mentions.spec.ts` → 9 files / 82 passed
  - 新 spec：验证帧为自己建 directed delivery + serve broadcast ledger，普通自 @ 仍不建（#963 不回退）；前缀对但还 @ 别人不算；连发 3 条验证帧计数器纹丝不动、普通消息名额一条不少；熔断时验证帧仍 409
- `cd cli && bunx tsc --noEmit && bun test test/verify-wake.test.ts test/wake-verify-listeners.test.ts test/claude-channel-dormant-announce.test.ts test/serve-advertise-dedupe.test.ts test/json-contract.test.ts test/cli.test.ts test/exit-codes.test.ts` → 119 pass
  - 往返成功 / wake_pending ⇒ 过；三种超时各给不同 layer + 文案 + 修法；发不出去（loop guard）无 layer；本机证据真实读法（认领文件 / 恢复日志）；与 #959 去重互不干扰；`party wake verify` 走 REST mock 的三条端到端（成功 / local_listener / server_delivery）
  - 监听：serve / watch / bridge / 蛰伏 announce 腿——自发验证帧唤醒、普通自 @ 与「前缀对但 @ 了别人」仍忽略
- 回归：`bun test test/serve.test.ts test/watch.test.ts test/claude-channel.test.ts test/wake.test.ts test/serve-directed-delivery.test.ts test/watch-directed-delivery.test.ts` → 266 pass；另 10 个 serve/watch/join/mcp 相关文件 147 pass
- **变异自检**：把 `classifyWakeVerify` 短路成恒 `local_listener` ⇒ 9 red（三层各自的用例 + 两条 CLI 端到端），还原后全绿

## 没做的

- `join.ts` 收尾不接（#988）；真机验证由 piggo 机负责
- `local_listener` 与 `model_reply` 的分界依赖本机痕迹：claude bridge 走恢复日志、蛰伏腿走认领文件、serve 走健康缓存；codex 一次性 runner 若三者都没留痕，会落到 `local_listener` 并如实说「监听 pid 没留下收到这条 @ 的痕迹」

Closes #990

https://claude.ai/code/session_01Az8CnUpayZzqpi1sh32Ssi
