### PR TITLE
feat(cli): party join 改成分步引导——步骤机 + 每步 check/一条修法/停在该步 + --yes 逐步打印 (#988)

### DIFF
--- a/cli/src/commands/join.ts
+++ b/cli/src/commands/join.ts
@@ -20,6 +20,10 @@
 //    起的会话按 #615 是 local-only 蛰伏档，只有 `party claude` / `bridge claude` / `party serve
 //    --runner claude` 会抢 serve 锁接 @——判据是锁的活持有者，不是开关）；codex 档是唤醒层
 //    **进程真的在**（join 收尾主动拉起，再探活）。任一没成就不印 ✅，照实说本会话此刻能被怎么叫到。
+//  - **分步引导（#988 / epic #987）**：收尾自检不再是一坨格子，而是第 0～4 步顺序跑——版本 → 身份 →
+//    接收方式 → 起一个可唤醒的会话 → 真发一条 @ 验证。每步一条 check、过/不过、不过时恰一条修法并
+//    **停在该步**（退出码非 0）；全部过了才印 ✅。步骤机在 onboarding/steps.ts，这里只按 harness 组装
+//    每一步查什么、修法是哪条。无 TTY / --yes 不交互、逐步打印；有 TTY 第 2 步可选接收方式。
 import { spawnSync } from "node:child_process";
 import { copyFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
@@ -57,13 +61,16 @@ import { defaultInstanceLockDir, isSameLiveProcess } from "../instance-lock";
 import { listCodexSessions, registerCodexSession } from "../claude-session-registry";
 import {
   claudeArmCommand,
-  claudeNoArmedListenerLines,
   claudeServeCommand,
   describeClaudeArmedListener,
   describeDormantClaudeSessions,
   probeClaudeArmedListener,
   type ClaudeArmedListenerProbe,
 } from "../claude-armed-listener";
+import { resolveClaudeDefaultArgs, type ClaudeDefaultArgsResolution } from "../claude-default-args";
+import { claudeLaunchPlan } from "./claude-launch";
+import { runSteps, type Step, type StepResult } from "../onboarding/steps";
+import { verifyWakeRoundTrip, type VerifyWakeDeps } from "../onboarding/verify-wake";
 import { findHarnessAncestor } from "../join-binding";
 import {
   CLAUDE_PLUGIN_MIN_VERSION,
@@ -76,12 +83,24 @@ import type { CodexAutoWakeOutcome } from "./hook";
 export { probeClaudeArmedListener };
 
 const JOIN_FLAGS = ["server", "channel", "as", "harness", "mention"];
+/** 每一步「做完重跑」的那条命令——引导幂等，修好了就再跑同一条。 */
+const RERUN = "party join";
 const HELP = `usage: AGENTPARTY_TOKEN='<token>' party join --server URL --channel SLUG --as NAME [--harness codex|claude|other] [--mention name] [--yes] [--coexist]
 
-One command that does the whole join: write config + rules, dedupe (#907), bind
-identity (#924), register the MCP server (probe-then-add, #898), install and approve
-the codex wake hook (#901/#942/#943), check in, and print one final verdict — either
-"全部就绪" or "还差第 N 步: <one command>". No 108-line paste, no per-line reading.
+One command that does the whole join as guided steps (#987/#988):
+  第 0 步 版本      CLI version; claude plugin installed + aligned to the CLI (#961/#985)
+  第 1 步 身份      write config + rules, dedupe (#907), bind (#924), register the MCP
+                    server (probe-then-add, #898), check in
+  第 2 步 接收方式  claude: interactive session vs resident serve (asked on a TTY; the
+                    default is taken and printed with --yes / no TTY); codex: install +
+                    approve the Stop hook (#901/#942/#943)
+  第 3 步 起一个可唤醒的会话  claude: print the exact \`party claude\` launch and probe for
+                    an armed listener (#979); codex: bring up the wake layer, probe it (#957)
+  第 4 步 真发一条 @ 验证     send one \`[wake-verify]\` @ to yourself and wait for the
+                    receipt; on timeout say which layer failed (#990, party wake verify)
+Each step runs one check; the first failing step prints exactly one fix command and
+join stops there (exit 1). ✅ is printed only when every step passed. Every step is
+idempotent — do the fix, then re-run the same \`party join\`.
 
 The token comes ONLY from the AGENTPARTY_TOKEN env var — never a flag, so it stays out
 of argv / ps / shell history (#676).
@@ -93,7 +112,8 @@ Options:
   --harness H    codex | claude | other. Omit to auto-detect from the process tree;
                  if it cannot be told, join proceeds as "other" and says so.
   --mention NAME @ the inviter in the check-in line (dropped if not a valid name)
-  --yes          approve the codex hook trust flip non-interactively (passed to
+  --yes          non-interactive: never prompt (第 2 步 takes the harness default and
+                 prints it); also approves the codex hook trust flip (passed to
                  \`party hook install --codex --yes\`); never bypasses the gate
   --coexist      keep any identity this harness already had on this channel (passed to
                  \`party init --coexist\`); default is replace`;
@@ -107,15 +127,39 @@ interface StepOutcome {
   remedy?: string;
 }
 
-// 收尾自检的一格。gate 步骤全绿才「全部就绪」；best-effort 步骤只呈现、不决定结论。
-interface GateStep {
-  id: string;
-  ok: boolean;
-  label: string;
-  evidence: string;
-  remedy?: string;
-  /** 做 remedy 之前必须知道的话（版本错配、要重开会话……），不是第二件待办。 */
-  notes?: string[];
+/** 第 2 步 claude 档的接收方式：交互式会话（party claude）或常驻（party serve --runner claude）。 */
+export type ReceiveMode = "interactive" | "serve";
+
+/** 第 4 步的输入：第 3 步探活到的那个会被唤醒的进程（#990 的真实往返验证按它判「谁收到了」）。 */
+export interface WakeVerifyInput {
+  channel: string;
+  identity: string;
+  harness: JoinPackHarness;
+  listener: { pid: number; description: string } | null;
+}
+/**
+ * 第 4 步「真发一条 @ 验证」的可注入实现。缺省＝roundTripWakeVerifier（#990 的 verifyWakeRoundTrip：
+ * 以本身份发一条 `[wake-verify]` @ 自己、等回执，超时按层说清哪一层没通）；测试注入桩。
+ */
+export type WakeVerifier = (input: WakeVerifyInput) => Promise<StepResult> | StepResult;
+
+/**
+ * 把 #990 的往返结果适配成一步：detail 直接当摘要（去掉它自带的 ✓/✗，行尾由步骤机补），fix 就是
+ * 那一条修法。server/token 从 join 刚写的 config 读（AGENTPARTY_CONFIG 已指向它）。
+ */
+export function roundTripWakeVerifier(verifyDeps?: VerifyWakeDeps): WakeVerifier {
+  return async (input) => {
+    const cfg = readConfig();
+    if (cfg === null || typeof cfg.server !== "string" || typeof cfg.token !== "string" || cfg.token === "") {
+      return { ok: false, summary: "config 里没有 server/token，发不了验证帧", fix: { do: RERUN } };
+    }
+    const r = await verifyWakeRoundTrip(
+      { server: cfg.server, token: cfg.token, channel: input.channel, identity: input.identity, harness: input.harness },
+      verifyDeps,
+    );
+    const summary = r.detail.replace(/^✗\s*/, "").replace(/\s*✓/g, "");
+    return r.ok ? { ok: true, summary } : { ok: false, summary, ...(r.fix === undefined ? {} : { fix: { do: r.fix } }) };
+  };
 }
 
 /** codex 唤醒层的存活证据（#957）：判据是**进程真的在**，不是开关是否 default-on。 */
@@ -169,6 +213,15 @@ export interface JoinDeps {
   codexWakeLayerLive: () => Promise<CodexWakeLayerLiveness | null>;
   /** 跑 join 的那个 codex 进程 pid（进程祖先链）；找不到 null。用于把本会话在注册表里挂到本频道。 */
   codexAncestorPid: () => number | null;
+  /**
+   * 第 2 步（claude 档）：有 TTY 且未 --yes 时问用户选接收方式。返回 null ＝ 没法问（无 TTY），
+   * 按 harness 默认走并把所选印出来。--yes 时 runJoin 根本不调它。缺省 readline 一问。
+   */
+  chooseReceiveMode: (channel: string) => Promise<ReceiveMode | null>;
+  /** 第 3 步（claude 档）：本机 `party claude` 的默认启动参数（#978），只用来把最终命令印全。 */
+  claudeDefaultArgs: () => ClaudeDefaultArgsResolution;
+  /** 第 4 步：真发一条 @ 的往返验证。缺省 roundTripWakeVerifier（#990 的 verifyWakeRoundTrip）。 */
+  verifyWake: WakeVerifier;
 }
 
 export interface JoinOptions {
@@ -249,10 +302,23 @@ const MARKETPLACE = CLAUDE_PLUGIN_MARKETPLACE;
  * 装了 / 更新了都要**重开 Claude 会话**才生效（当前会话还挂着旧插件）——这句必须进结论，
  * 不能埋在 warn 里，所以用 restartNeeded 带出去。
  */
-function installClaudePlugin(deps: JoinDeps): StepOutcome & { restartNeeded: boolean } {
+interface ClaudePluginInstallOutcome extends StepOutcome {
+  restartNeeded: boolean;
+  before: string | null | undefined;
+  after: string | null | undefined;
+  updated: boolean;
+}
+function installClaudePlugin(deps: JoinDeps): ClaudePluginInstallOutcome {
   const first = deps.spawn("claude", ["plugin", "marketplace", "add", MARKETPLACE], { encoding: "utf8", timeout: 60_000 });
   if (first.error !== undefined) {
-    return { level: "skip", msg: "claude 二进制不可用，跳过插件安装（不影响 CLI 协作）", restartNeeded: false };
+    return {
+      level: "skip",
+      msg: "claude 二进制不可用，跳过插件安装（不影响 CLI 协作）",
+      restartNeeded: false,
+      before: undefined,
+      after: undefined,
+      updated: false,
+    };
   }
   const before = installedClaudePluginVersion(deps.spawn);
   let anyFail = first.status !== 0;
@@ -273,9 +339,12 @@ function installClaudePlugin(deps: JoinDeps): StepOutcome & { restartNeeded: boo
       : CLAUDE_PLUGIN_UPDATE_COMMAND;
     return {
       level: "warn",
-      msg: `claude 插件未完全装上（best-effort，不阻断；手动 ${fix}，然后重开会话）——能不能被唤醒见下方自检`,
+      msg: `claude 插件未完全装上（best-effort；手动 ${fix}，然后重开会话）`,
       remedy: fix,
       restartNeeded,
+      before,
+      after,
+      updated,
     };
   }
   if (after !== undefined && after !== null && after !== RUNNING_VERSION) {
@@ -285,6 +354,9 @@ function installClaudePlugin(deps: JoinDeps): StepOutcome & { restartNeeded: boo
       msg: `claude 插件是 ${after}，CLI 是 ${RUNNING_VERSION}，版本不一致时 SessionStart 唤醒不会布上——手动 ${fix}`,
       remedy: fix,
       restartNeeded,
+      before,
+      after,
+      updated,
     };
   }
   const msg = updated
@@ -292,7 +364,7 @@ function installClaudePlugin(deps: JoinDeps): StepOutcome & { restartNeeded: boo
     : before === null
       ? `claude 插件已安装（${after}；需重开 Claude 会话才生效）`
       : `claude 插件已是 ${after ?? RUNNING_VERSION}（跳过）`;
-  return { level: "ok", msg, restartNeeded };
+  return { level: "ok", msg, restartNeeded, before, after, updated };
 }
 
 /** 装 codex 插件（marketplace）——best-effort：装不上不阻断，只提示。 */
@@ -472,7 +544,7 @@ function adoptCodexSessionForChannel(
   }
 }
 
-/** codex 档收尾：先认领本会话、再主动拉起唤醒层、再探活。三步各自失败都不抛，全部进证据。 */
+/** codex 档第 3 步：先认领本会话、再主动拉起唤醒层、再探活。三步各自失败都不抛，全部进证据。 */
 async function bringUpCodexWakeLayer(
   deps: JoinDeps,
   slug: string,
@@ -494,7 +566,7 @@ async function bringUpCodexWakeLayer(
   }
   if (outcome.action === "start") {
     record("拉起唤醒层", live === null
-      ? { level: "warn", msg: `已尝试拉起 party serve ${slug} --runner codex，但探不到它的进程——见下方自检` }
+      ? { level: "warn", msg: `已尝试拉起 party serve ${slug} --runner codex，但探不到它的进程` }
       : { level: "ok", msg: `已拉起 party serve ${slug} --runner codex（pid ${live.pid}）` });
   } else if (outcome.action === "skip" && outcome.reason === "already-serving") {
     record("拉起唤醒层", { level: "ok", msg: `已有唤醒层在跑（${outcome.detail}）` });
@@ -508,119 +580,309 @@ function symbol(level: StepLevel): string {
   return level === "ok" ? "✓" : level === "skip" ? "·" : level === "warn" ? "!" : "✗";
 }
 
-/** 收尾自检：从**本地盘的真实状态**重判「就绪 / 还差哪一步」（#926），不信步骤返回码。 */
-function buildJoinGate(
-  harness: JoinPackHarness,
-  slug: string,
-  checkinOk: boolean,
-  deps: JoinDeps,
-  codexWake: CodexWakeLayerState | null,
-  claudeListener: ClaudeArmedListenerProbe | null,
-): { steps: GateStep[]; remaining: number; next: { do: string; notes: string[] } | null } {
-  const cfg = readConfig();
-  const identity = cfg?.identity?.name ?? null;
-  const server = cfg?.server ?? null;
-  const steps: GateStep[] = [
-    {
-      id: "channel_bound",
-      ok: server !== null,
-      label: "写下了本频道的身份配置",
-      evidence: server === null ? "" : `#${slug} @ ${server}`,
-      remedy: "AGENTPARTY_TOKEN='<token>' party join --server <url> --channel <slug> --as <name>",
-    },
-    {
-      id: "identity_resolved",
-      ok: identity !== null,
-      label: "服务端确认了身份",
-      evidence: identity === null ? "" : `${identity}`,
-      remedy: "检查 token 是否有效、server 是否可达，然后重跑 party join",
-    },
-  ];
-  // codex 档：把 #926 的 hook 两步原样并进来（装了 hook、批了信任）——那是 codex 能不能被 @ 唤醒的闸。
-  // 复用同一份 wake 清单：hook 步骤的 ok/fail 由 diagnoseCodexWake 读**真实盘状态**决定，
-  // next.do 的探测式修法（#942）也直接取它的，别自己另写一套判定。
-  let codexWakeNext: { do: string; notes: string[] } | null = null;
-  if (harness === "codex") {
-    const wake = deps.codexWakeChecklist();
-    codexWakeNext = wake.next === null ? null : { do: wake.next.do, notes: wake.next.notes };
-    for (const s of wake.steps) {
-      if (s.id === "hook_installed" || s.id === "hook_trusted") {
-        steps.push({ id: s.id, ok: s.ok, label: s.label, evidence: s.evidence });
+// ── 步骤（#988）────────────────────────────────────────────────────────────────
+//
+// 每一步都是 onboarding/steps.ts 的 Step<JoinCtx>：一条 check、过/不过、不过时恰一条修法。
+// 步骤之间靠 ctx 传状态（第 0 步的「要重开」、第 1 步解析出的身份、第 2 步选的接收方式、
+// 第 3 步探到的进程）。best-effort 的小动作（MCP 注册、装插件、inbox accept）不决定过/不过，
+// 只作为该步的补充行印出来——失败要能看见，但不该把整段接入判死。
+
+interface JoinCtx {
+  opts: JoinOptions;
+  deps: JoinDeps;
+  harness: JoinPackHarness;
+  slug: string;
+  agentName: string;
+  configPath: string;
+  rulesPath: string;
+  mcpName: string;
+  /** 第 0 步：插件刚装 / 刚更新，当前会话还挂着旧的——「要重开」是 ✅ 句的一部分。 */
+  claudePluginRestart: boolean;
+  /** 第 1 步：服务端确认的身份（config.identity.name）。 */
+  identity: string | null;
+  /** 第 2 步：claude 档所选接收方式。 */
+  receiveMode: ReceiveMode;
+  /** 第 3 步：探活到的那个会被唤醒的进程。 */
+  listener: { pid: number; description: string } | null;
+}
+
+/** best-effort 小动作的一行：`✓ 注册 claude MCP: …`，作为步骤的补充行。 */
+function outcomeLine(name: string, outcome: StepOutcome): string {
+  return `${symbol(outcome.level)} ${name}: ${outcome.msg}`;
+}
+
+/** 第 0 步 版本：CLI 版本；claude 档还要插件装到位、已启用、与 CLI 同版（#961/#985）。 */
+function versionStep(): Step<JoinCtx> {
+  return {
+    id: "version",
+    title: "版本",
+    run(ctx) {
+      const { deps, harness } = ctx;
+      const cli = `CLI ${RUNNING_VERSION}`;
+      if (harness === "codex") {
+        return { ok: true, summary: cli, detail: [outcomeLine("装 codex 插件", installCodexPlugin(deps))] };
       }
-    }
+      if (harness !== "claude") return { ok: true, summary: cli };
+      const install = installClaudePlugin(deps);
+      ctx.claudePluginRestart = install.restartNeeded;
+      const detail: string[] = install.level === "ok" || install.level === "skip" ? [] : [outcomeLine("装 claude 插件", install)];
+      // 判据是 doctor 的插件壳检查（与 bridge claude --check 同一份）：版本不一致时 SessionStart 根本没布上。
+      const shell = deps.claudePluginShell();
+      if (shell.status !== "ready") {
+        const remedy = claudePluginRemedy(shell);
+        const versions = shell.plugin.version === undefined ? "" : `（本机插件 ${shell.plugin.version}，CLI ${RUNNING_VERSION}）`;
+        return {
+          ok: false,
+          summary: `${cli} · claude 插件 blocker: ${shell.blockers.join(", ")}${versions}`,
+          detail,
+          fix: { do: remedy.do, notes: remedy.notes },
+        };
+      }
+      const v = shell.plugin.version ?? RUNNING_VERSION;
+      const plugin = install.updated
+        ? `claude 插件 ${install.before} → 已更新到 ${v}（需重开会话）`
+        : install.before === null
+          ? `claude 插件已安装 ${v}（需重开会话）`
+          : `claude 插件 ${v} 版本与 CLI 一致`;
+      return { ok: true, summary: `${cli} · ${plugin}`, detail };
+    },
+  };
+}
+
+/** 第 1 步 身份：rules 落盘、party init（config + 判重 + 绑定）、服务端确认、MCP 注册、报到。 */
+function identityStep(harnessKnown: boolean): Step<JoinCtx> {
+  return {
+    id: "identity",
+    title: "身份",
+    async run(ctx) {
+      const { deps, opts, harness, slug, agentName, configPath, rulesPath, mcpName } = ctx;
+      const detail: string[] = [];
+      // 行为契约的持久拷贝（#845）。正文是 shared 静态常量，绝不掺 charter 等管理员可控文本。
+      try {
+        mkdirSync(pathJoin(rulesPath, ".."), { recursive: true });
+        atomicWriteText(rulesPath, `${BEHAVIOR_CONTRACT_BODY_LINES.join("\n")}\n`);
+        detail.push(outcomeLine("行为契约落盘", { level: "ok", msg: rulesPath }));
+      } catch (e) {
+        detail.push(outcomeLine("行为契约落盘", { level: "warn", msg: `写 rules 文件失败：${e instanceof Error ? e.message : String(e)}` }));
+      }
+      // party init：写 config + 同频道判重（#907）+ 加入即绑定（#924）+ 拉 charter。全部复用 init.ts。
+      // harness 探不出时不传 --harness——让 init 也如实说「不知道是哪个 harness、没写绑定」。
+      const initArgs = ["--server", opts.server, "--channel", slug];
+      if (harnessKnown) initArgs.push("--harness", harness);
+      if (opts.coexist) initArgs.push("--coexist");
+      const initCode = await deps.initRun(initArgs);
+      if (initCode !== 0) {
+        return {
+          ok: false,
+          summary: `party init 失败（退出码 ${initCode}）——token / server 有问题`,
+          detail,
+          fix: { do: `检查 AGENTPARTY_TOKEN 是否有效、--server ${opts.server} 是否可达，然后重跑 ${RERUN}` },
+        };
+      }
+      // 从本地盘的真实状态重判（不信步骤返回码）：config 写了没、服务端确认的身份是谁。
+      const cfg = readConfig();
+      if (cfg?.server === undefined || cfg.server === null) {
+        return {
+          ok: false,
+          summary: "本频道的身份配置没写下来",
+          detail,
+          fix: { do: `AGENTPARTY_TOKEN='<token>' party join --server ${opts.server} --channel ${slug} --as ${agentName}` },
+        };
+      }
+      const identity = cfg.identity?.name ?? null;
+      if (identity === null) {
+        return {
+          ok: false,
+          summary: "服务端没确认身份（config 里没有 identity）",
+          detail,
+          fix: { do: `检查 AGENTPARTY_TOKEN 是否有效、--server ${opts.server} 是否可达，然后重跑 ${RERUN}` },
+        };
+      }
+      ctx.identity = identity;
+      // 注册 MCP（先探后加，#898）。claude/codex 各走各的；other（探不出）两条都试——「不知道就都覆盖」。
+      if (harness === "claude" || harness === "other") detail.push(outcomeLine("注册 claude MCP", registerClaudeMcp(deps, mcpName, configPath, slug)));
+      if (harness === "codex" || harness === "other") detail.push(outcomeLine("注册 codex MCP", registerCodexMcp(deps, mcpName, configPath, slug)));
+      // claude 档：crossSessionInbound=accept（#844），否则跨会话 @ 默认 hold 会被 drop。
+      if (harness === "claude") detail.push(outcomeLine("开启跨会话 @ 接收", setClaudeInboxAccept(deps)));
+      // 报到（#597）。init 只写配置不发言，必须补这一条，否则网页/频道里看不到你。能 @ 邀请人就 @。
+      const sendArgs = [`👋 ${agentName} 报到，来参与协作`, "--channel", slug];
+      if (opts.mention !== null) sendArgs.push("--mention", opts.mention);
+      const sendCode = await deps.sendRun(sendArgs);
+      if (sendCode !== 0) {
+        return {
+          ok: false,
+          summary: `#${slug} 上以 ${identity} 报到失败（退出码 ${sendCode}）——别人看不到你`,
+          detail,
+          fix: { do: `party send "👋 ${agentName} 报到" --channel ${slug}` },
+        };
+      }
+      return { ok: true, summary: `#${slug} 上以 ${identity} 报到`, detail };
+    },
+  };
+}
+
+/**
+ * 第 2 步 接收方式。
+ *  - claude：交互式会话（party claude）还是常驻（party serve --runner claude）。有 TTY 且未 --yes 问一句；
+ *    否则按 claude 档默认（交互式）并把所选印出来。这一步不会不过——它只决定第 3 步印哪条命令。
+ *  - codex：接 @ 的路是 Stop hook + 唤醒层。装 + 当场批准 Stop hook（#901/#942/#943，复用
+ *    party hook install --codex），check 是 #926 wake 清单里的 hook_installed / hook_trusted（读真实盘状态）。
+ *  - other：没有唤醒层，只能用 CLI 收消息。
+ */
+function receiveModeStep(): Step<JoinCtx> {
+  return {
+    id: "receive_mode",
+    title: "接收方式",
+    async run(ctx) {
+      const { deps, opts, harness, slug } = ctx;
+      if (harness === "claude") {
+        const chosen = opts.yes ? null : await deps.chooseReceiveMode(slug);
+        ctx.receiveMode = chosen ?? "interactive";
+        const summary = ctx.receiveMode === "interactive"
+          ? `你选：交互式 Claude 会话（可选：常驻 ${claudeServeCommand(slug)}）`
+          : `你选：常驻 ${claudeServeCommand(slug)}（可选：交互式 ${claudeArmCommand(slug)}）`;
+        const detail = chosen === null ? [`${opts.yes ? "--yes" : "无 TTY"}：不交互，按 claude 档默认选了${ctx.receiveMode === "interactive" ? "交互式会话" : "常驻"}`] : [];
+        return { ok: true, summary, detail };
+      }
+      if (harness === "codex") {
+        const hookArgs = ["install", "--codex"];
+        if (opts.yes) hookArgs.push("--yes");
+        const hookCode = await deps.hookRun(hookArgs);
+        const detail = hookCode === 0 ? [] : [outcomeLine("装 + 批准 codex hook", { level: "warn", msg: `party hook install --codex 退出码 ${hookCode}` })];
+        // hook 的 ok/fail 由 diagnoseCodexWake 读真实盘状态决定；修法走 #942 的探测式（桌面版 / exec 等注记）。
+        const wake = deps.codexWakeChecklist();
+        const failed = wake.steps.find((s) => (s.id === "hook_installed" || s.id === "hook_trusted") && !s.ok);
+        if (failed !== undefined) {
+          return {
+            ok: false,
+            summary: `Stop hook 没到位：${failed.label}`,
+            detail,
+            fix: wake.next === null ? { do: `party hook install --codex` } : { do: wake.next.do, notes: wake.next.notes },
+          };
+        }
+        return { ok: true, summary: "Stop hook 已装、已批准；无人值守时由唤醒层（party serve --runner codex）接 @", detail };
+      }
+      return { ok: true, summary: `CLI 收消息（harness 是 other，没有唤醒层）：party watch ${slug} 或常驻 party serve ${slug}` };
+    },
+  };
+}
+
+/**
+ * 第 3 步 起一个可唤醒的会话。
+ *  - claude（#979）：印出按第 2 步所选拼好的那条命令（party claude 展开成 claudeLaunchPlan 的最终 argv +
+ *    本机默认参数 #978），check 是本机有没有会接 @ 的武装监听——serve 锁的活持有者，不是插件状态、不是开关。
+ *    这一步不替人起会话（那是 #989）；探不到就停在这，修法就是那条命令。
+ *  - codex（#957）：主动拉起唤醒层再探活，判据是进程真的在。
+ */
+function wakeableSessionStep(): Step<JoinCtx> {
+  return {
+    id: "wakeable_session",
+    title: "起一个可唤醒的会话",
+    async run(ctx) {
+      const { deps, harness, slug } = ctx;
+      const identity = ctx.identity ?? ctx.agentName;
+      if (harness === "claude") {
+        const detail: string[] = [];
+        let command: string;
+        if (ctx.receiveMode === "serve") {
+          command = claudeServeCommand(slug);
+          detail.push(`运行：${command}`);
+        } else {
+          command = claudeArmCommand(slug);
+          const defaults = deps.claudeDefaultArgs();
+          const plan = claudeLaunchPlan(slug, [], {}, defaults.args);
+          const defaultsNote = defaults.args.length === 0 ? "无本机默认参数" : `默认参数：${defaults.args.join(" ")}（来自 ${defaults.origin}）`;
+          detail.push(`运行：${command}        （已自动带 dev-channels；${defaultsNote}）`);
+          detail.push(`展开：AGENTPARTY_CHANNEL=${slug} claude ${plan.args.join(" ")}`);
+        }
+        // 探活失败按「没有」算——绝不因探不到就假定有。
+        let probe: ClaudeArmedListenerProbe;
+        try {
+          probe = deps.claudeArmedListener();
+        } catch {
+          probe = { live: null, sessions: 0 };
+        }
+        if (probe.live === null) {
+          return {
+            ok: false,
+            summary: `本机没有会接 @ 的 Claude 会话——${describeDormantClaudeSessions(probe.sessions, slug)}`,
+            detail,
+            fix: {
+              do: command,
+              notes: [
+                `⚠ 已绑定身份 ${identity}，但这台机现在没有会接 @ 的 Claude 会话。`,
+                `普通 \`claude\` 起的会话不接频道消息（local-only）；要能被 @ 唤醒，用 ${claudeArmCommand(slug)} 起一个会话（或 ${claudeServeCommand(slug)} 常驻）。`,
+              ],
+            },
+          };
+        }
+        const description = describeClaudeArmedListener(probe.live, slug);
+        ctx.listener = { pid: probe.live.pid, description };
+        return { ok: true, summary: `${description}在接 @`, detail };
+      }
+      if (harness === "codex") {
+        const detail: string[] = [];
+        const wake = await bringUpCodexWakeLayer(deps, slug, (name, outcome) => detail.push(outcomeLine(name, outcome)));
+        if (wake.adoptionNote !== null) detail.push(`⚠ ${wake.adoptionNote}`);
+        if (wake.live === null) {
+          const why = wake.outcome.action === "skip" || wake.outcome.action === "start-failed"
+            ? wake.outcome.detail
+            : "拉起了但探不到进程（可能刚退出：看 ~/.agentparty/logs/codex-auto-wake.log）";
+          return {
+            ok: false,
+            summary: `唤醒层没起来：${why}`,
+            detail,
+            fix: {
+              do: `party serve ${slug} --runner codex`,
+              notes: [
+                "本会话只能在你下次发言、回合结束时收到 @（Stop hook 会把积压的 @ 交给你）；" +
+                  "要无人值守被唤醒，请新开一个 codex 会话（SessionStart 会重新拉起唤醒层），或手动拉起：",
+              ],
+            },
+          };
+        }
+        const description = `唤醒层 party serve ${slug} --runner codex（pid ${wake.live.pid}）`;
+        ctx.listener = { pid: wake.live.pid, description };
+        const state = wake.live.source === "serve-lock" ? "serve 已持锁（连上服务端了）" : "刚拉起，正在连服务端";
+        return { ok: true, summary: `唤醒层进程在跑 pid ${wake.live.pid} · ${state}`, detail };
+      }
+      return { ok: true, summary: "harness 是 other，没有可唤醒的会话可起（用 CLI 收消息）" };
+    },
+  };
+}
+
+/** 第 4 步 真发一条 @ 验证：以本身份发一条 `[wake-verify]` @ 自己、等回执（#990）；可注入（测试用桩）。 */
+function verifyStep(): Step<JoinCtx> {
+  return {
+    id: "verify",
+    title: "真发一条 @ 验证",
+    run(ctx) {
+      return ctx.deps.verifyWake({
+        channel: ctx.slug,
+        identity: ctx.identity ?? ctx.agentName,
+        harness: ctx.harness,
+        listener: ctx.listener,
+      });
+    },
+  };
+}
+
+/** ✅ 句：写明谁会被唤醒（pid / 起法），别让人以为是眼前这个普通会话（#979 修法 3）。 */
+function completionLine(ctx: JoinCtx): string {
+  const { harness, slug } = ctx;
+  const identity = ctx.identity ?? ctx.agentName;
+  if (harness === "claude" && ctx.claudePluginRestart) {
+    // #961：插件刚装/刚更新，当前这个会话还挂着旧的——「要重开」是结论的一部分，不能埋在补充行里。
+    // #979：重开也得用 party claude 起，普通 claude 起的会话是蛰伏档。
+    return (
+      `✅ 接入完成，差一次重开：claude 插件已是 ${RUNNING_VERSION}，【用 ${claudeArmCommand(slug)} 新开一个 Claude 会话】后 @ ${identity} 就能唤醒它；` +
+      `当前这个会话还挂着旧插件，不会被唤醒。`
+    );
   }
-  // claude 档（#961）：唤醒层就是 Marketplace 插件的 SessionStart hook。装没装、启没启用、版本是否
-  // 与 CLI 一致、包是否完整——doctor 的 shell 检查（bridge claude --check 的 lifecycle）说了算。
-  // 版本不一致时插件的 hooks 与本版 CLI 对不上，SessionStart 根本没布上，✅ 就是假的。
-  if (harness === "claude") {
-    const shell = deps.claudePluginShell();
-    const ok = shell.status === "ready";
-    const remedy = claudePluginRemedy(shell);
-    steps.push({
-      id: "plugin_lifecycle_ready",
-      ok,
-      label: "claude 插件装到位、已启用、版本与 CLI 一致（SessionStart 唤醒靠它）",
-      evidence: ok
-        ? `${CLAUDE_PLUGIN} ${shell.plugin.version ?? RUNNING_VERSION}`
-        : `blocker: ${shell.blockers.join(", ")}${shell.plugin.version === undefined ? "" : `（本机插件 ${shell.plugin.version}，CLI ${RUNNING_VERSION}）`}`,
-      remedy: remedy.do,
-      notes: remedy.notes,
-    });
+  if (ctx.listener !== null) {
+    return `✅ 接入完成：现在 @ ${identity}，这台机器上${ctx.listener.description}就能被唤醒来协作。`;
   }
-  steps.push({
-    id: "checkin_sent",
-    ok: checkinOk,
-    label: "在频道里报到了（否则别人看不到你）",
-    evidence: checkinOk ? "已发送" : "",
-    remedy: `party send "👋 <你> 报到" --channel ${slug}`,
-  });
-  // codex 档（#957）：四项静态前置条件齐了 ≠ 唤醒真的会发生。唤醒层是 `party serve --runner codex`
-  // 这个进程；它在不在，判据只有一个——进程探活。放在最后：前面任一步没过，这一步的修法都没意义。
-  if (harness === "codex" && codexWake !== null) {
-    const live = codexWake.live;
-    const why = codexWake.outcome.action === "skip" || codexWake.outcome.action === "start-failed"
-      ? codexWake.outcome.detail
-      : "拉起了但探不到进程（可能刚退出：看 ~/.agentparty/logs/codex-auto-wake.log）";
-    steps.push({
-      id: "wake_layer_live",
-      ok: live !== null,
-      label: "唤醒层进程在跑（无人值守时被 @ 也能拉起 codex runner）",
-      evidence: live === null
-        ? ""
-        : `pid ${live.pid} · ${live.source === "serve-lock" ? "serve 已持锁（连上服务端了）" : "刚拉起，正在连服务端"}` +
-          (codexWake.adoptionNote === null ? "" : `    ⚠ ${codexWake.adoptionNote}`),
-      remedy: `新开一个 codex 会话（SessionStart 会重新拉起唤醒层），或手动：party serve ${slug} --runner codex`,
-      notes: [why],
-    });
-  }
-  // claude 档（#979）：插件装到位 ≠ 有人接 @。普通 `claude` 起的会话是蛰伏档（#615 local-only），
-  // 只有 `party claude` / `bridge claude` 起的会话或 `party serve --runner claude` 会抢 serve 锁接 @。
-  // 判据是锁的活持有者（进程事实），不是 opt-in 开关。放在最后，同 codex 档的 wake_layer_live。
-  if (harness === "claude" && claudeListener !== null) {
-    const live = claudeListener.live;
-    steps.push({
-      id: "armed_listener_live",
-      ok: live !== null,
-      label: "本机有会接 @ 的 Claude 武装监听（普通 claude 会话是蛰伏档，不接频道消息）",
-      evidence: live === null ? "" : describeClaudeArmedListener(live, slug),
-      remedy: claudeArmCommand(slug),
-      notes: [
-        describeDormantClaudeSessions(claudeListener.sessions, slug),
-        `或常驻：${claudeServeCommand(slug)}`,
-      ],
-    });
-  }
-  const failed = steps.find((s) => !s.ok);
-  let next: { do: string; notes: string[] } | null = null;
-  if (failed !== undefined) {
-    // codex 的 hook 步骤走 #942 的探测式修法（含桌面版/exec 等注记）；其余步骤给自己的一条 remedy。
-    if (failed.id === "hook_installed" || failed.id === "hook_trusted") {
-      next = codexWakeNext;
-    } else {
-      next = { do: failed.remedy ?? "重跑 party join", notes: failed.notes ?? [] };
-    }
-  }
-  return { steps, remaining: steps.filter((s) => !s.ok).length, next };
+  return `✅ 接入完成：${identity} 已绑到 #${slug}（harness 是 ${harness}，没有唤醒层）；收消息用 party watch ${slug} 或常驻 party serve ${slug}。`;
 }
 
 // ── orchestrator ────────────────────────────────────────────────────────────
@@ -630,7 +892,6 @@ export async function runJoin(opts: JoinOptions, deps: JoinDeps): Promise<number
   const agentsDir = pathJoin(home, "agents");
   const configPath = pathJoin(agentsDir, configFileName(agentName, slug));
   const rulesPath = pathJoin(agentsDir, rulesFileName(agentName, slug));
-  const mcpName = mcpServerName(agentName);
 
   // token 只经环境变量往下游传（init/send 从 AGENTPARTY_TOKEN / config 读），绝不进 argv。
   process.env.AGENTPARTY_TOKEN = token;
@@ -641,156 +902,61 @@ export async function runJoin(opts: JoinOptions, deps: JoinDeps): Promise<number
   const harness: JoinPackHarness = opts.harnessFlag ?? detected ?? "other";
   const harnessKnown = opts.harnessFlag !== null || detected !== null;
 
-  const bestEffort: { name: string; outcome: StepOutcome }[] = [];
-  const record = (name: string, outcome: StepOutcome): void => {
-    bestEffort.push({ name, outcome });
-    deps.log(`  ${symbol(outcome.level)} ${name}: ${outcome.msg}`);
+  deps.log(`party join → #${slug} as ${agentName}（harness: ${harness}${harnessKnown ? "" : " · 探测不出，按 other 处理"}，server ${server}）`);
+
+  const ctx: JoinCtx = {
+    opts,
+    deps,
+    harness,
+    slug,
+    agentName,
+    configPath,
+    rulesPath,
+    mcpName: mcpServerName(agentName),
+    claudePluginRestart: false,
+    identity: null,
+    receiveMode: "interactive",
+    listener: null,
   };
-
-  deps.log(`party join → #${slug} as ${agentName}（harness: ${harness}${harnessKnown ? "" : " · 探测不出，按 other 处理"}）`);
-
-  // 1) 落盘 rules 文件——行为契约的持久拷贝（#845）。正文是 shared 静态常量，绝不掺 charter 等
-  //    管理员可控文本（那有注释化防 RCE 的约束）。上下文被压缩/丢失后可重读。
-  try {
-    mkdirSync(agentsDir, { recursive: true });
-    atomicWriteText(rulesPath, `${BEHAVIOR_CONTRACT_BODY_LINES.join("\n")}\n`);
-    record("行为契约落盘", { level: "ok", msg: rulesPath });
-  } catch (e) {
-    record("行为契约落盘", { level: "warn", msg: `写 rules 文件失败：${e instanceof Error ? e.message : String(e)}` });
-  }
-
-  // 2) party init：写 config + 同频道判重（#907）+ 加入即绑定（#924）+ 拉 charter。全部复用 init.ts。
-  //    harness 探不出时不传 --harness——让 init 也如实说「不知道是哪个 harness、没写绑定」（不硬编 other）。
-  const initArgs = ["--server", server, "--channel", slug];
-  if (harnessKnown) initArgs.push("--harness", harness);
-  if (opts.coexist) initArgs.push("--coexist");
-  const initCode = await deps.initRun(initArgs);
-  if (initCode !== 0) {
-    // init 失败是硬失败（config 没写 = 后面全白搭）。如实报，别继续假装成功。
-    deps.errlog(`party init 失败（退出码 ${initCode}）——token / server 有问题。修好后重跑 party join。`);
-    return initCode;
-  }
-
-  // 3) 注册 MCP（先探后加，#898）。claude/codex 各走各的；other（探不出）两条都试——「不知道就都覆盖」。
-  if (harness === "claude" || harness === "other") {
-    record("注册 claude MCP", registerClaudeMcp(deps, mcpName, configPath, slug));
-  }
-  if (harness === "codex" || harness === "other") {
-    record("注册 codex MCP", registerCodexMcp(deps, mcpName, configPath, slug));
-  }
-
-  // 4) 装 harness 插件（best-effort）。claude 插件承载 SessionStart/End→会话注册表+可发现+跨会话（#848）；
-  //    codex 插件同理（#850）。other 档不装（不知道装哪个）。
-  let claudePluginRestart = false;
-  if (harness === "claude") {
-    const outcome = installClaudePlugin(deps);
-    claudePluginRestart = outcome.restartNeeded;
-    record("装 claude 插件", outcome);
-  }
-  if (harness === "codex") record("装 codex 插件", installCodexPlugin(deps));
-
-  // 5a) claude 档：crossSessionInbound=accept（#844），否则跨会话 @ 默认 hold 会被 drop。
-  if (harness === "claude") record("开启跨会话 @ 接收", setClaudeInboxAccept(deps));
-
-  // 5b) codex 档：装 + 当场批准 Stop hook（#901/#942/#943）。复用 party hook install --codex：
-  //     它当场问一句 y/N（--yes 非交互直批），只翻我们自己那两条，绝不用 --dangerously-bypass-hook-trust。
-  if (harness === "codex") {
-    const hookArgs = ["install", "--codex"];
-    if (opts.yes) hookArgs.push("--yes");
-    const hookCode = await deps.hookRun(hookArgs);
-    record(
-      "装 + 批准 codex hook",
-      hookCode === 0
-        ? { level: "ok", msg: "hook 已装（信任状态见下方自检）" }
-        : { level: "warn", msg: `party hook install --codex 退出码 ${hookCode}——信任状态见下方自检` },
-    );
-  }
-
-  // 6) 报到（#597）。init 只写配置不发言，必须补这一条，否则网页/频道里看不到你。能 @ 邀请人就 @。
-  const checkinMsg = `👋 ${agentName} 报到，来参与协作`;
-  const sendArgs = [checkinMsg, "--channel", slug];
-  if (opts.mention !== null) sendArgs.push("--mention", opts.mention);
-  const sendCode = await deps.sendRun(sendArgs);
-  const checkinOk = sendCode === 0;
-  record(
-    "频道报到",
-    checkinOk ? { level: "ok", msg: "已在频道报到" } : { level: "fail", msg: `报到失败（退出码 ${sendCode}）` },
-  );
-
-  // 6b) codex 档（#957）：主动拉起唤醒层。跑 join 的这个会话的 SessionStart 早过去了（那会儿还没身份），
-  //     不拉它就从生到死没有唤醒层——只有用户下次发言、回合结束时 Stop hook 才把 @ 交给他。
-  let codexWake: CodexWakeLayerState | null = null;
-  if (harness === "codex") codexWake = await bringUpCodexWakeLayer(deps, slug, record);
-
-  // 6c) claude 档（#979）：本机有没有会接 @ 的武装监听。探活失败按「没有」算——不会因此把 join 弄挂，
-  //     但也绝不因探不到就假定有。
-  let claudeListener: ClaudeArmedListenerProbe | null = null;
-  if (harness === "claude") {
-    try {
-      claudeListener = deps.claudeArmedListener();
-    } catch {
-      claudeListener = { live: null, sessions: 0 };
-    }
-  }
-
-  // 7) 收尾自检（#926）：这是包的末尾，用户看到的就这一句结论。从本地盘真实状态重判，不信步骤返回码。
-  const gate = buildJoinGate(harness, slug, checkinOk, deps, codexWake, claudeListener);
+  // other 档没有唤醒层：第 3、4 步无物可查，只跑到第 2 步（接收方式＝CLI）。
+  const steps: Step<JoinCtx>[] = harness === "other"
+    ? [versionStep(), identityStep(harnessKnown), receiveModeStep()]
+    : [versionStep(), identityStep(harnessKnown), receiveModeStep(), wakeableSessionStep(), verifyStep()];
+  const outcome = await runSteps({ steps, ctx, log: deps.log, rerun: RERUN });
   deps.log("");
-  deps.log(`接入自检 · #${slug}`);
-  for (const s of gate.steps) {
-    deps.log(`  ${s.ok ? "✓" : "✗"} ${s.label}${s.evidence === "" ? "" : `    ${s.evidence}`}`);
-  }
-  deps.log("");
-  if (gate.remaining === 0) {
-    if (harness === "claude" && claudePluginRestart) {
-      // #961：插件刚装/刚更新，当前这个会话还挂着旧的——「要重开」是结论的一部分，不能埋在 warn 里。
-      // #979：重开也得用 party claude 起，普通 claude 起的会话是蛰伏档。
-      deps.log(
-        `✅ 全部就绪，差一次重开：claude 插件已是 ${RUNNING_VERSION}，【用 ${claudeArmCommand(slug)} 新开一个 Claude 会话】后 @ ${agentName} 就能唤醒它；` +
-          `当前这个会话还挂着旧插件，不会被唤醒。`,
-      );
-      return 0;
-    }
-    if (harness === "claude" && claudeListener?.live) {
-      // #979 修法 3：✅ 句写明「就能被唤醒」指的是谁（pid / 起法），别让人以为是眼前这个普通会话。
-      deps.log(
-        `✅ 全部就绪：现在 @ ${agentName}，这台机器上${describeClaudeArmedListener(claudeListener.live, slug)}就能被唤醒来协作。`,
-      );
-      return 0;
-    }
-    deps.log(`✅ 全部就绪：现在 @ ${agentName}，这台机器上的 ${harness} 会话就能被唤醒来协作。`);
+  if (outcome.ok) {
+    deps.log(completionLine(ctx));
     return 0;
   }
-  const failed = gate.steps.find((s) => !s.ok);
-  if (failed?.id === "armed_listener_live") {
-    // #979：前置条件全齐、唯独本机没有会接 @ 的 Claude 会话。此刻的真实能力是「谁也叫不醒」——
-    // 照实说，把两条命令原样印出来，绝不说「就能被唤醒」。
-    const identity = readConfig()?.identity?.name ?? agentName;
-    for (const line of claudeNoArmedListenerLines(identity, slug, claudeListener?.sessions ?? 0)) deps.log(line);
-    deps.log("");
-    deps.log("在这一步完成之前：@ 你可能不会有任何反应，而且不会有任何报错——别人只会以为你在忙。");
-    return 1;
-  }
-  if (failed?.id === "wake_layer_live") {
-    // #957：前置条件全齐、唯独唤醒层没起来。此刻的真实能力是 Stop hook 兜底——照实说，绝不说「就能被唤醒」。
-    deps.log(`⚠ 接入完成，但唤醒层没起来：${gate.next?.notes[0] ?? "原因不明"}`);
-    deps.log(
-      `本会话只能在你下次发言、回合结束时收到 @（Stop hook 会把积压的 @ 交给你）；` +
-        `要无人值守被唤醒，请新开一个 codex 会话。`,
-    );
-    deps.log(`  或手动拉起：party serve ${slug} --runner codex`);
-    return 1;
-  }
-  deps.log(`还差 ${gate.remaining} 步。现在只做这一件事：`);
-  if (gate.next !== null) {
-    deps.log(`  ${gate.next.do}`);
-    for (const note of gate.next.notes) deps.log(`  ${note}`);
-  }
-  deps.log(`  做完回来再跑一次：party wake check`);
-  deps.log("");
-  // 这句是整段自检存在的理由：这类失败**没有任何报错**，不明说就没人知道自己坏了。
+  deps.log(`接入停在第 ${outcome.stoppedAt.index} 步（${outcome.stoppedAt.title}）——做完上面那一条，重跑同一条 ${RERUN}。`);
+  // 这句是整段引导存在的理由：这类失败**没有任何报错**，不明说就没人知道自己坏了。
   deps.log("在这一步完成之前：@ 你可能不会有任何反应，而且不会有任何报错——别人只会以为你在忙。");
   return 1;
+}
+
+/**
+ * 第 2 步的那一问（有 TTY 才问）。非 TTY 返回 null——沉默不等于选择，按默认走并印出所选。
+ * 只用 node:readline，不引新依赖。
+ */
+async function promptReceiveMode(slug: string): Promise<ReceiveMode | null> {
+  if (process.stdin.isTTY !== true || process.stdout.isTTY !== true) return null;
+  const { createInterface } = await import("node:readline");
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const answer = await new Promise<string>((resolve) => {
+      rl.question(
+        `         1) 交互式 Claude 会话（${claudeArmCommand(slug)}）\n` +
+          `         2) 常驻 ${claudeServeCommand(slug)}\n` +
+          "         选 [1/2]（回车＝1）：",
+        resolve,
+      );
+    });
+    return answer.trim() === "2" ? "serve" : "interactive";
+  } catch {
+    return null;
+  } finally {
+    rl.close();
+  }
 }
 
 export async function run(argv: string[]): Promise<number> {
@@ -885,6 +1051,9 @@ export async function run(argv: string[]): Promise<number> {
       const found = findHarnessAncestor(process.ppid);
       return found !== null && found.harness === "codex" ? found.pid : null;
     },
+    chooseReceiveMode: promptReceiveMode,
+    claudeDefaultArgs: () => resolveClaudeDefaultArgs(process.env, agentpartyHome()),
+    verifyWake: roundTripWakeVerifier(),
   };
   return runJoin(
     { server, channel: slug, agentName, harnessFlag, mention, yes: flags.yes === true, coexist: flags.coexist === true, token },

--- a/cli/src/commands/join.ts
+++ b/cli/src/commands/join.ts
@@ -217,7 +217,8 @@ export interface JoinDeps {
    * 第 2 步（claude 档）：有 TTY 且未 --yes 时问用户选接收方式。返回 null ＝ 没法问（无 TTY），
    * 按 harness 默认走并把所选印出来。--yes 时 runJoin 根本不调它。缺省 readline 一问。
    */
-  chooseReceiveMode: (channel: string) => Promise<ReceiveMode | null>;
+  /** null＝无 TTY（按默认走）；"cancelled"＝用户 Ctrl+C / 关闭了输入（必须停，不许替人选）。 */
+  chooseReceiveMode: (channel: string) => Promise<ReceiveMode | null | "cancelled">;
   /** 第 3 步（claude 档）：本机 `party claude` 的默认启动参数（#978），只用来把最终命令印全。 */
   claudeDefaultArgs: () => ClaudeDefaultArgsResolution;
   /** 第 4 步：真发一条 @ 的往返验证。缺省 roundTripWakeVerifier（#990 的 verifyWakeRoundTrip）。 */
@@ -737,6 +738,15 @@ function receiveModeStep(): Step<JoinCtx> {
       const { deps, opts, harness, slug } = ctx;
       if (harness === "claude") {
         const chosen = opts.yes ? null : await deps.chooseReceiveMode(slug);
+        if (chosen === "cancelled") {
+          // 用户在选择时 Ctrl+C / 关了输入：这是「不要继续」，不是「无 TTY 按默认」。停在本步，
+          // 修法就是重跑（想不交互就带 --yes）。
+          return {
+            ok: false,
+            summary: "已取消（Ctrl+C / 输入已关闭），没有替你选接收方式",
+            fix: { do: "party join … --yes", notes: ["--yes 不交互，按 claude 档默认选交互式会话；想常驻先起 party serve 再重跑"] },
+          };
+        }
         ctx.receiveMode = chosen ?? "interactive";
         const summary = ctx.receiveMode === "interactive"
           ? `你选：交互式 Claude 会话（可选：常驻 ${claudeServeCommand(slug)}）`
@@ -938,12 +948,16 @@ export async function runJoin(opts: JoinOptions, deps: JoinDeps): Promise<number
  * 第 2 步的那一问（有 TTY 才问）。非 TTY 返回 null——沉默不等于选择，按默认走并印出所选。
  * 只用 node:readline，不引新依赖。
  */
-async function promptReceiveMode(slug: string): Promise<ReceiveMode | null> {
+async function promptReceiveMode(slug: string): Promise<ReceiveMode | null | "cancelled"> {
   if (process.stdin.isTTY !== true || process.stdout.isTTY !== true) return null;
   const { createInterface } = await import("node:readline");
   const rl = createInterface({ input: process.stdin, output: process.stdout });
   try {
-    const answer = await new Promise<string>((resolve) => {
+    // Ctrl+C 在 readline 里是 rl 的 "SIGINT" 事件、Ctrl+D 是 "close"：两者都不会 resolve question，
+    // 不接就永远挂在这一步。接住并明确返回 cancelled——不能把「用户要停」当成「无 TTY 按默认」。
+    const answer = await new Promise<string | "cancelled">((resolve) => {
+      rl.once("SIGINT", () => resolve("cancelled"));
+      rl.once("close", () => resolve("cancelled"));
       rl.question(
         `         1) 交互式 Claude 会话（${claudeArmCommand(slug)}）\n` +
           `         2) 常驻 ${claudeServeCommand(slug)}\n` +
@@ -951,9 +965,10 @@ async function promptReceiveMode(slug: string): Promise<ReceiveMode | null> {
         resolve,
       );
     });
+    if (answer === "cancelled") return "cancelled";
     return answer.trim() === "2" ? "serve" : "interactive";
   } catch {
-    return null;
+    return "cancelled";
   } finally {
     rl.close();
   }

--- a/cli/src/onboarding/steps.ts
+++ b/cli/src/onboarding/steps.ts
@@ -1,0 +1,112 @@
+// 接入引导的步骤机（issue #988，epic #987）。
+//
+// 从前 `party join` 收尾是一坨自检：把所有格子一次性判完再挑第一个 ✗ 给修法。分步引导把它改成
+// **顺序执行、逐步打印、不过就停**：
+//
+//   第 0 步  版本 · CLI 0.2.216 ✓ · claude 插件 0.2.214 → 已更新到 0.2.216（需重开会话）
+//   第 1 步  身份 · #ludo 上以 server 报到 ✓
+//   第 2 步  接收方式 · 你选：交互式 Claude 会话（可选：常驻 party serve ludo --runner claude）
+//   第 3 步  起一个可唤醒的会话 · 本机没有会接 @ 的 Claude 会话 ✗
+//            修法（做完重跑同一条 party join）：
+//              party claude ludo
+//
+// 这个文件只管「机器」：一步一条 check、过/不过、不过时**恰一条**修法命令然后停（退出码非 0），
+// 全部过才轮到调用方印 ✅。每一步该查什么、修法是哪条，由调用方（join.ts）按 harness 组装——
+// 这里不认识 claude / codex。
+//
+// 设计约束：
+//  - **只给一条修法**（#926 / wake-checklist 同一纪律）：列三件等于没给，用户会挑最容易的做完就停。
+//    所以 fix.do 是一个字符串，不是数组；notes 是「做这条之前必须知道的话」，不是第二件待办。
+//  - **停在该步**：后面的步骤一概不跑——它们的修法在前一步没过时没有意义（监听闸放最后的老规矩）。
+//  - **幂等**：机器本身无状态；每一步的 run 由调用方保证可重跑（先探后加、替换式绑定……）。
+//  - **不交互**：机器只打印。要问用户的（第 2 步选接收方式）由那一步的 run 自己决定问不问，
+//    `--yes` / 无 TTY 时按默认走并把所选印出来。
+
+/** 一步跑完的结果。 */
+export interface StepResult {
+  ok: boolean;
+  /** 跟在「第 N 步  标题 · 」后面的一句摘要；机器会在末尾补 ✓ / ✗。 */
+  summary: string;
+  /** 摘要之外要给人看的补充行（缩进印在步骤行下方）：所选默认、要跑的命令、原因……过/不过都可有。 */
+  detail?: string[];
+  /** 不过时的修法：do 是**恰一条**可跑的命令；notes 是做它之前必须知道的话。ok=true 时忽略。 */
+  fix?: { do: string; notes?: string[] };
+}
+
+export interface Step<Ctx> {
+  id: string;
+  /** 「第 N 步」后面的标题：版本 / 身份 / 接收方式 / 起一个可唤醒的会话 / 真发一条 @ 验证。 */
+  title: string;
+  run(ctx: Ctx): Promise<StepResult> | StepResult;
+}
+
+export interface StepRecord {
+  index: number;
+  id: string;
+  title: string;
+  result: StepResult;
+}
+
+export type StepsOutcome =
+  | { ok: true; records: StepRecord[] }
+  | { ok: false; records: StepRecord[]; stoppedAt: StepRecord };
+
+/** 步骤行下方补充行的缩进——与「第 N 步  」对齐（两个全角字符宽度按 9 列算，够用即可）。 */
+export const STEP_INDENT = "         ";
+
+/** 「第 N 步  标题 · 摘要 ✓」这一行。 */
+export function formatStepLine(index: number, title: string, result: StepResult): string {
+  return `第 ${index} 步  ${title} · ${result.summary} ${result.ok ? "✓" : "✗"}`;
+}
+
+/**
+ * 一步的完整输出：步骤行 + 补充行 + （不过时）恰一条修法。修法的形态固定：
+ *   `修法（做完重跑同一条 party join）：` 一行，下一行缩进印命令，再下面是 notes。
+ * 测试就靠这个形态数「印了几条修法」。
+ */
+export function formatStep(index: number, title: string, result: StepResult, rerun: string): string[] {
+  const lines = [formatStepLine(index, title, result)];
+  for (const d of result.detail ?? []) lines.push(`${STEP_INDENT}${d}`);
+  if (!result.ok) {
+    const fix = result.fix ?? { do: rerun };
+    for (const n of fix.notes ?? []) lines.push(`${STEP_INDENT}${n}`);
+    lines.push(`${STEP_INDENT}修法（做完重跑同一条 ${rerun}）：`);
+    lines.push(`${STEP_INDENT}  ${fix.do}`);
+  }
+  return lines;
+}
+
+export interface RunStepsInput<Ctx> {
+  steps: Step<Ctx>[];
+  ctx: Ctx;
+  log: (line: string) => void;
+  /** 「做完重跑」时该跑的命令，缺省 `party join`。 */
+  rerun?: string;
+  /** 第一步的编号（epic 从第 0 步「版本」数起）。 */
+  firstIndex?: number;
+}
+
+/**
+ * 顺序跑步骤：每步跑完立刻打印；任一步不过 ⇒ 印修法、**停**（后续步骤不跑）。
+ * run 抛异常按「不过」处理（异常文本进摘要），绝不因探活炸了就假定过了。
+ */
+export async function runSteps<Ctx>(input: RunStepsInput<Ctx>): Promise<StepsOutcome> {
+  const rerun = input.rerun ?? "party join";
+  const first = input.firstIndex ?? 0;
+  const records: StepRecord[] = [];
+  for (let i = 0; i < input.steps.length; i++) {
+    const step = input.steps[i]!;
+    const index = first + i;
+    let result: StepResult;
+    try {
+      result = await step.run(input.ctx);
+    } catch (e) {
+      result = { ok: false, summary: `这一步炸了：${e instanceof Error ? e.message : String(e)}` };
+    }
+    const record: StepRecord = { index, id: step.id, title: step.title, result };
+    records.push(record);
+    for (const line of formatStep(index, step.title, result, rerun)) input.log(line);
+    if (!result.ok) return { ok: false, records, stoppedAt: record };
+  }
+  return { ok: true, records };
+}

--- a/cli/test/join-fixture.ts
+++ b/cli/test/join-fixture.ts
@@ -1,0 +1,181 @@
+// party join 测试共用的桩（join.test.ts / onboarding-steps.test.ts）。
+//
+// 只桩 claude/codex 二进制（spawnSync）与几个探活注入点；init / hook / send 走**真实**实现打到
+// rest-mock，收尾判定读**真实盘状态**——反假绿纪律：桩得越少，测试越接近真机。
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { JoinDeps, JoinOptions } from "../src/commands/join";
+import { run as initRun } from "../src/commands/init";
+import { run as hookRun } from "../src/commands/hook";
+import { run as sendRun } from "../src/commands/send";
+import { inspectClaudePluginShell, parseClaudePluginList } from "../src/commands/doctor";
+import { buildWakeChecklist } from "../src/wake-checklist";
+import { diagnoseCodexWake } from "../src/wake-diagnosis";
+import { RUNNING_VERSION } from "../src/upgrade";
+
+export const PLUGIN = "agentparty@agentparty";
+
+// 只读 .error / .status（插件相关再读 .stdout）的最小 spawnSync 桩。record 记下每次调用，便于断言
+// MCP 注册 / 插件 update 确实发生。
+export interface SpawnBehavior {
+  noBinary?: boolean; // 二进制不存在（ENOENT）
+  mcpAlreadyRegistered?: boolean; // mcp get 返回 0（已注册）
+  failMcpAdd?: boolean; // mcp add 返回非 0
+  /**
+   * 本机已装的 claude 插件版本（#961）：省略＝与 CLI 同版；null＝没装；"0.2.203" 这类＝旧版。
+   * 桩是**有状态**的，照真机行为走：`plugin install` 对已装的只回 already installed（**不升级**），
+   * 只有 `plugin update` 才把版本换成当前 CLI 的。
+   */
+  installedPluginVersion?: string | null;
+  failPluginUpdate?: boolean; // plugin update 返回非 0
+}
+interface PluginState {
+  installed: string | null;
+}
+export function fakeSpawn(record: string[][], behavior: SpawnBehavior, state: PluginState): JoinDeps["spawn"] {
+  return ((cmd: string, args: readonly string[]) => {
+    record.push([cmd, ...args]);
+    const base = { pid: 0, output: [], stdout: "", stderr: "", signal: null } as Record<string, unknown>;
+    if (behavior.noBinary) return { ...base, status: null, error: new Error("spawn ENOENT") };
+    if (args[0] === "mcp" && args[1] === "get") {
+      return { ...base, status: behavior.mcpAlreadyRegistered ? 0 : 1 };
+    }
+    if (args[0] === "mcp" && args[1] === "add") {
+      return { ...base, status: behavior.failMcpAdd ? 1 : 0 };
+    }
+    if (cmd === "claude" && args[0] === "--version") return { ...base, status: 0, stdout: "2.1.200 (Claude Code)\n" };
+    if (cmd === "claude" && args[0] === "plugin" && args[1] === "list") {
+      const rows = state.installed === null
+        ? []
+        : [{ id: PLUGIN, version: state.installed, enabled: true, installPath: "/nowhere/agentparty" }];
+      return { ...base, status: 0, stdout: `${JSON.stringify(rows)}\n` };
+    }
+    if (cmd === "claude" && args[0] === "plugin" && args[1] === "install") {
+      // 真机行为：已装就只回 "already installed"，版本原地不动。
+      if (state.installed === null) state.installed = RUNNING_VERSION;
+      return { ...base, status: 0 };
+    }
+    if (cmd === "claude" && args[0] === "plugin" && args[1] === "update") {
+      if (behavior.failPluginUpdate) return { ...base, status: 1 };
+      state.installed = RUNNING_VERSION;
+      return { ...base, status: 0 };
+    }
+    return { ...base, status: 0 };
+  }) as unknown as JoinDeps["spawn"];
+}
+
+const ENV_KEYS = ["AGENTPARTY_HOME", "AGENTPARTY_CONFIG", "AGENTPARTY_TOKEN", "CODEX_HOME", "HOME"];
+
+/** 每个用例一个干净 HOME：AGENTPARTY_HOME / CODEX_HOME / HOME 全指进临时目录。 */
+export function joinEnv(): { setup: () => string; teardown: () => void } {
+  const saved: Record<string, string | undefined> = {};
+  let tmp = "";
+  return {
+    setup() {
+      for (const k of ENV_KEYS) saved[k] = process.env[k];
+      tmp = mkdtempSync(join(tmpdir(), "party-join-"));
+      process.env.HOME = tmp;
+      process.env.AGENTPARTY_HOME = join(tmp, ".agentparty");
+      process.env.CODEX_HOME = join(tmp, ".codex");
+      delete process.env.AGENTPARTY_CONFIG;
+      delete process.env.AGENTPARTY_TOKEN;
+      return tmp;
+    },
+    teardown() {
+      for (const k of ENV_KEYS) {
+        if (saved[k] === undefined) delete process.env[k];
+        else process.env[k] = saved[k];
+      }
+      try {
+        rmSync(tmp, { recursive: true, force: true });
+      } catch {
+        /* best-effort */
+      }
+    },
+  };
+}
+
+export function joinDeps(tmp: string, record: string[][], behavior: SpawnBehavior, logs: string[]): JoinDeps {
+  const state: PluginState = {
+    installed: behavior.installedPluginVersion === undefined ? RUNNING_VERSION : behavior.installedPluginVersion,
+  };
+  const spawn = fakeSpawn(record, behavior, state);
+  return {
+    spawn,
+    initRun,
+    hookRun,
+    sendRun,
+    log: (l) => logs.push(l),
+    errlog: (l) => logs.push(l),
+    home: tmp,
+    // hook 步骤的 ok/fail 仍由 diagnoseCodexWake 读**真实盘状态**决定；只把「哪个 codex 带信任闸」
+    // 的探测换成快桩，免得默认实现 spawn 真机上的 codex 二进制（慢且不确定）。
+    codexWakeChecklist: () =>
+      buildWakeChecklist(
+        diagnoseCodexWake(),
+        process.env,
+        () => ({ onPath: null, candidates: [], gated: [], desktop: null }),
+        () => null,
+      ),
+    // claude 插件壳检查（#961）：走**真的** inspectClaudePluginShell（版本比对逻辑不另写一份），
+    // 只把 claude 二进制换成上面那个有状态桩、把读盘的包检查换成恒 valid。
+    claudePluginShell: () =>
+      inspectClaudePluginShell({
+        claudeVersion: () => {
+          const r = spawn("claude", ["--version"], { encoding: "utf8" });
+          return r.error === undefined && r.status === 0 ? String(r.stdout).trim() : null;
+        },
+        claudePlugins: () => {
+          const r = spawn("claude", ["plugin", "list", "--json"], { encoding: "utf8" });
+          return r.error === undefined && r.status === 0 ? parseClaudePluginList(String(r.stdout)) : null;
+        },
+        inspectBundle: () => ({ valid: true, launcherExecutable: true }),
+      }),
+    // claude 武装监听（#979）：默认假装本机有 party claude 起的会话在接 @（happy path）；蛰伏档用例逐个覆盖。
+    claudeArmedListener: () => ({ live: { pid: 5150, launch: "claude-channel" }, sessions: 1 }),
+    // codex 唤醒层（#957）：默认假装拉起成功且进程在（happy path）；失败用例逐个覆盖。
+    startCodexWakeLayer: async () => ({ action: "start", channel: "dev", cwd: process.cwd(), args: [] }),
+    codexWakeLayerLive: async () => ({ pid: 4242, source: "serve-lock" }),
+    codexAncestorPid: () => null,
+    // 第 2 步（#988）：默认「没法问」（无 TTY）——按 harness 默认走；交互用例逐个覆盖。
+    chooseReceiveMode: async () => null,
+    // 第 3 步（#988）：本机没配 party claude 默认参数；有默认参数的用例逐个覆盖。
+    claudeDefaultArgs: () => ({ args: [], source: "none", origin: join(tmp, ".agentparty", "claude-default-args.json") }),
+    // 第 4 步（#988）：往返验证桩——真实的 roundTripWakeVerifier（#990）要发真帧、等 30s，单测不跑它；
+    // 适配层（往返结果 → 一步）在 onboarding-steps.test.ts 里单独用假 probe 测。
+    verifyWake: ({ identity }) => ({ ok: true, summary: STUB_WAKE_VERIFY_SUMMARY(identity) }),
+  };
+}
+
+export const STUB_WAKE_VERIFY_SUMMARY = (identity: string) => `@${identity} ping → 0.1s 收到回执（测试桩）`;
+
+/** 「修法（做完重跑同一条 party join）：」下面那一行——引导给出的唯一修法命令。 */
+export function fixLine(logs: string[]): string | undefined {
+  const i = logs.findIndex((l) => l.includes("修法（"));
+  return i === -1 ? undefined : logs[i + 1]?.trim();
+}
+
+/** 输出里印了几条修法（每个停下的步骤恰一条；全部过了是 0）。 */
+export function fixCount(logs: string[]): number {
+  return logs.filter((l) => l.includes("修法（")).length;
+}
+
+/** 「第 N 步」那一行。 */
+export function stepLine(logs: string[], n: number): string | undefined {
+  return logs.find((l) => l.startsWith(`第 ${n} 步`));
+}
+
+export function baseJoinOpts(server: string, over: Partial<JoinOptions>): JoinOptions {
+  return {
+    server,
+    channel: "dev",
+    agentName: "bot",
+    harnessFlag: "claude",
+    mention: "leo",
+    yes: false,
+    coexist: false,
+    token: "ap_bot_secret",
+    ...over,
+  };
+}

--- a/cli/test/join.test.ts
+++ b/cli/test/join.test.ts
@@ -1,8 +1,12 @@
-// party join 端到端（issue #944）——把 108 行接入包收进一条命令，跑完自检报「就绪 / 还差哪一步」。
+// party join 端到端（issue #944）——把 108 行接入包收进一条命令，跑完引导报「接入完成 / 停在第 N 步」。
 //
 // 反假绿纪律（本仓反复踩的坑）：每个失败用例都确保**只有被测的那道闸**决定结果，其余步骤全绿，
-// 免得「另一个分支单独满足条件遮住闸」。收尾自检从**本地盘真实状态**重判，不信步骤返回码——
-// 所以 checkin 真失败（服务端 500）、codex hook 真处于 disabled 时，自检必须如实报「还差」。
+// 免得「另一个分支单独满足条件遮住闸」。每步从**本地盘真实状态**重判，不信步骤返回码——
+// 所以 checkin 真失败（服务端 500）、codex hook 真处于 disabled 时，引导必须如实停在那一步。
+//
+// #988 起 join 是分步引导（第 0～4 步，onboarding/steps.ts）：不过就停在该步、恰一条修法。
+// 输出形态相应变了（`第 N 步  标题 · 摘要 ✓/✗`、`修法（…）：` + 一行命令、`✅ 接入完成`），
+// 断言按新形态等价改写；判据（哪一步过/不过、修法是哪条、退出码）一条没放宽。
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { mkdtempSync } from "node:fs";
@@ -12,157 +16,32 @@ import { BEHAVIOR_CONTRACT_BODY_LINES } from "@agentparty/shared/onboarding";
 import { probeClaudeArmedListener, probeCodexWakeLayer, runJoin, type JoinDeps, type JoinOptions } from "../src/commands/join";
 import { classifyListenerCommand } from "../src/claude-armed-listener";
 import { healServerUrl } from "../src/validation";
-import { run as initRun } from "../src/commands/init";
-import { run as hookRun } from "../src/commands/hook";
-import { run as sendRun } from "../src/commands/send";
-import { inspectClaudePluginShell, parseClaudePluginList } from "../src/commands/doctor";
-import { buildWakeChecklist } from "../src/wake-checklist";
-import { diagnoseCodexWake } from "../src/wake-diagnosis";
 import { RUNNING_VERSION } from "../src/upgrade";
 import { codexAutoWakeAuth, codexAutoWakeMarkerPath, codexAutoWakeTarget, writeCodexAutoWakeMarker } from "../src/codex-auto-wake";
 import { currentProcessStartedAt, instanceLockTarget } from "../src/instance-lock";
 import { listCodexSessions, registerClaudeSession, registerCodexSession } from "../src/claude-session-registry";
 import { startRestMock, type RestMock } from "./rest-mock";
-
-const PLUGIN = "agentparty@agentparty";
-
-// 只读 .error / .status（插件相关再读 .stdout）的最小 spawnSync 桩。record 记下每次调用，便于断言
-// MCP 注册 / 插件 update 确实发生。
-interface SpawnBehavior {
-  noBinary?: boolean; // 二进制不存在（ENOENT）
-  mcpAlreadyRegistered?: boolean; // mcp get 返回 0（已注册）
-  failMcpAdd?: boolean; // mcp add 返回非 0
-  /**
-   * 本机已装的 claude 插件版本（#961）：省略＝与 CLI 同版；null＝没装；"0.2.203" 这类＝旧版。
-   * 桩是**有状态**的，照真机行为走：`plugin install` 对已装的只回 already installed（**不升级**），
-   * 只有 `plugin update` 才把版本换成当前 CLI 的。
-   */
-  installedPluginVersion?: string | null;
-  failPluginUpdate?: boolean; // plugin update 返回非 0
-}
-interface PluginState {
-  installed: string | null;
-}
-function fakeSpawn(record: string[][], behavior: SpawnBehavior, state: PluginState) {
-  return ((cmd: string, args: readonly string[]) => {
-    record.push([cmd, ...args]);
-    const base = { pid: 0, output: [], stdout: "", stderr: "", signal: null } as Record<string, unknown>;
-    if (behavior.noBinary) return { ...base, status: null, error: new Error("spawn ENOENT") };
-    if (args[0] === "mcp" && args[1] === "get") {
-      return { ...base, status: behavior.mcpAlreadyRegistered ? 0 : 1 };
-    }
-    if (args[0] === "mcp" && args[1] === "add") {
-      return { ...base, status: behavior.failMcpAdd ? 1 : 0 };
-    }
-    if (cmd === "claude" && args[0] === "--version") return { ...base, status: 0, stdout: "2.1.200 (Claude Code)\n" };
-    if (cmd === "claude" && args[0] === "plugin" && args[1] === "list") {
-      const rows = state.installed === null
-        ? []
-        : [{ id: PLUGIN, version: state.installed, enabled: true, installPath: "/nowhere/agentparty" }];
-      return { ...base, status: 0, stdout: `${JSON.stringify(rows)}\n` };
-    }
-    if (cmd === "claude" && args[0] === "plugin" && args[1] === "install") {
-      // 真机行为：已装就只回 "already installed"，版本原地不动。
-      if (state.installed === null) state.installed = RUNNING_VERSION;
-      return { ...base, status: 0 };
-    }
-    if (cmd === "claude" && args[0] === "plugin" && args[1] === "update") {
-      if (behavior.failPluginUpdate) return { ...base, status: 1 };
-      state.installed = RUNNING_VERSION;
-      return { ...base, status: 0 };
-    }
-    return { ...base, status: 0 };
-  }) as unknown as JoinDeps["spawn"];
-}
+import { PLUGIN, baseJoinOpts, fixLine, joinDeps, joinEnv, stepLine, type SpawnBehavior } from "./join-fixture";
 
 let tmp: string;
 let mock: RestMock;
-const savedEnv: Record<string, string | undefined> = {};
-const ENV_KEYS = ["AGENTPARTY_HOME", "AGENTPARTY_CONFIG", "AGENTPARTY_TOKEN", "CODEX_HOME", "HOME"];
+const env = joinEnv();
 
 beforeEach(() => {
-  for (const k of ENV_KEYS) savedEnv[k] = process.env[k];
-  tmp = mkdtempSync(join(tmpdir(), "party-join-"));
-  process.env.HOME = tmp;
-  process.env.AGENTPARTY_HOME = join(tmp, ".agentparty");
-  process.env.CODEX_HOME = join(tmp, ".codex");
-  delete process.env.AGENTPARTY_CONFIG;
-  delete process.env.AGENTPARTY_TOKEN;
+  tmp = env.setup();
 });
 afterEach(() => {
   mock?.stop();
-  for (const k of ENV_KEYS) {
-    if (savedEnv[k] === undefined) delete process.env[k];
-    else process.env[k] = savedEnv[k];
-  }
-  try {
-    rmSync(tmp, { recursive: true, force: true });
-  } catch {
-    /* best-effort */
-  }
+  env.teardown();
 });
 
 function deps(record: string[][], behavior: SpawnBehavior, logs: string[]): JoinDeps {
-  const state: PluginState = {
-    installed: behavior.installedPluginVersion === undefined ? RUNNING_VERSION : behavior.installedPluginVersion,
-  };
-  const spawn = fakeSpawn(record, behavior, state);
-  return {
-    spawn,
-    initRun,
-    hookRun,
-    sendRun,
-    log: (l) => logs.push(l),
-    errlog: (l) => logs.push(l),
-    home: tmp,
-    // hook 步骤的 ok/fail 仍由 diagnoseCodexWake 读**真实盘状态**决定；只把「哪个 codex 带信任闸」
-    // 的探测换成快桩，免得默认实现 spawn 真机上的 codex 二进制（慢且不确定）。
-    codexWakeChecklist: () =>
-      buildWakeChecklist(
-        diagnoseCodexWake(),
-        process.env,
-        () => ({ onPath: null, candidates: [], gated: [], desktop: null }),
-        () => null,
-      ),
-    // claude 插件壳检查（#961）：走**真的** inspectClaudePluginShell（版本比对逻辑不另写一份），
-    // 只把 claude 二进制换成上面那个有状态桩、把读盘的包检查换成恒 valid。
-    claudePluginShell: () =>
-      inspectClaudePluginShell({
-        claudeVersion: () => {
-          const r = spawn("claude", ["--version"], { encoding: "utf8" });
-          return r.error === undefined && r.status === 0 ? String(r.stdout).trim() : null;
-        },
-        claudePlugins: () => {
-          const r = spawn("claude", ["plugin", "list", "--json"], { encoding: "utf8" });
-          return r.error === undefined && r.status === 0 ? parseClaudePluginList(String(r.stdout)) : null;
-        },
-        inspectBundle: () => ({ valid: true, launcherExecutable: true }),
-      }),
-    // claude 武装监听（#979）：默认假装本机有 party claude 起的会话在接 @（happy path）；蛰伏档用例逐个覆盖。
-    claudeArmedListener: () => ({ live: { pid: 5150, launch: "claude-channel" }, sessions: 1 }),
-    // codex 唤醒层（#957）：默认假装拉起成功且进程在（happy path）；失败用例逐个覆盖。
-    startCodexWakeLayer: async () => ({ action: "start", channel: "dev", cwd: process.cwd(), args: [] }),
-    codexWakeLayerLive: async () => ({ pid: 4242, source: "serve-lock" }),
-    codexAncestorPid: () => null,
-  };
+  return joinDeps(tmp, record, behavior, logs);
 }
-/** 「现在只做这一件事：」后面那一行——自检给出的唯一修法。 */
-function nextActionLine(logs: string[]): string | undefined {
-  const i = logs.findIndex((l) => l.includes("现在只做这一件事"));
-  return i === -1 ? undefined : logs[i + 1]?.trim();
-}
+/** 引导停下时给出的唯一修法命令（「修法（…）：」下面那一行）。 */
+const nextActionLine = fixLine;
 function baseOpts(over: Partial<JoinOptions>): JoinOptions {
-  return {
-    server: mock.url,
-    channel: "dev",
-    agentName: "bot",
-    harnessFlag: "claude",
-    mention: "leo",
-    yes: false,
-    coexist: false,
-    token: "ap_bot_secret",
-    ...over,
-  };
+  return baseJoinOpts(mock.url, over);
 }
 
 const configPath = () => join(tmp, ".agentparty", "agents", "agentparty-bot-dev.json");
@@ -170,17 +49,17 @@ const rulesPath = () => join(tmp, ".agentparty", "agents", "agentparty-bot-dev.r
 const bindingsPath = () => join(tmp, ".agentparty", "join-bindings.json");
 
 describe("party join —— 一条命令跑完整段接入（#944）", () => {
-  test("claude 档 happy path：config / rules / 绑定 / MCP 注册 / 报到全部落地，自检报「全部就绪」", async () => {
+  test("claude 档 happy path：config / rules / 绑定 / MCP 注册 / 报到全部落地，引导报「✅ 接入完成」", async () => {
     mock = startRestMock();
     const record: string[][] = [];
     const logs: string[] = [];
     const code = await runJoin(baseOpts({ harnessFlag: "claude" }), deps(record, {}, logs));
     const out = logs.join("\n");
 
-    // 返回 0 且自检结论是「全部就绪」——用户看到的最后一句。
+    // 返回 0 且结论是「✅ 接入完成」——用户看到的最后一句；没有任何一步停下。
     expect(code).toBe(0);
-    expect(out).toContain("全部就绪");
-    expect(out).not.toContain("还差");
+    expect(out).toContain("✅ 接入完成");
+    expect(out).not.toContain("接入停在");
 
     // 1) config 落地：token（来自 AGENTPARTY_TOKEN，绝不进 argv）+ 服务端确认的身份都写进去了。
     expect(existsSync(configPath())).toBe(true);
@@ -225,7 +104,10 @@ describe("party join —— 一条命令跑完整段接入（#944）", () => {
     const verdict = logs.find((l) => l.startsWith("✅"));
     expect(verdict).toContain("pid 5150");
     expect(verdict).toContain("party claude-channel");
-    expect(out).toContain("✓ 本机有会接 @ 的 Claude 武装监听");
+    // 第 3 步那一行 ✓，且摘要指向那个武装监听。
+    const step3 = stepLine(logs, 3);
+    expect(step3).toContain("武装监听 party claude-channel，pid 5150）在接 @");
+    expect(step3?.endsWith("✓")).toBe(true);
   });
 
   // ★ #961 事故场景：本机插件 0.2.203、CLI 0.2.212。旧 join 只 install（回 already installed，不升级）
@@ -244,14 +126,14 @@ describe("party join —— 一条命令跑完整段接入（#944）", () => {
     expect(update).toBeGreaterThan(install);
     // 更新到位 → 就绪，但**当前会话还挂着旧插件**——「重开」是结论句的一部分。
     expect(code).toBe(0);
-    expect(out).toContain(`已从 0.2.203 更新到 ${RUNNING_VERSION}`);
+    expect(stepLine(logs, 0)).toContain(`claude 插件 0.2.203 → 已更新到 ${RUNNING_VERSION}`);
     const verdict = logs.find((l) => l.startsWith("✅"));
     expect(verdict).toBeDefined();
     expect(verdict).toContain("重开");
     expect(verdict).toContain("当前这个会话还挂着旧插件");
   });
 
-  test("#961：update 没成、插件仍是旧版 ⇒ 自检报 plugin_version_mismatch、不印 ✅，修法是 update 不是 install", async () => {
+  test("#961：update 没成、插件仍是旧版 ⇒ 第 0 步报 plugin_version_mismatch 并停在那、不印 ✅，修法是 update 不是 install", async () => {
     mock = startRestMock();
     const record: string[][] = [];
     const logs: string[] = [];
@@ -261,10 +143,11 @@ describe("party join —— 一条命令跑完整段接入（#944）", () => {
     );
     const out = logs.join("\n");
 
-    // 隔离：config / 身份 / 报到全成，唯独插件版本落后——这正是事故当天的形态。
-    expect(existsSync(configPath())).toBe(true);
+    // #988：版本是第 0 步，不过就停在这——身份那步（写 config）根本不跑；修好重跑同一条 join 即可。
+    expect(existsSync(configPath())).toBe(false);
+    expect(stepLine(logs, 1)).toBeUndefined();
     expect(code).toBe(1);
-    expect(out).not.toContain("全部就绪");
+    expect(out).not.toContain("✅");
     expect(out).toContain("plugin_version_mismatch");
     expect(out).toContain(`本机插件 0.2.203，CLI ${RUNNING_VERSION}`);
     // 唯一那条修法必须是 update：照旧教 install 等于原地踏步。
@@ -285,7 +168,7 @@ describe("party join —— 一条命令跑完整段接入（#944）", () => {
     expect(verdict).toContain("重开");
   });
 
-  test("失败可见：报到被服务端 500 打回时，自检如实报「还差」并给出可执行下一步，不是静默成功", async () => {
+  test("失败可见：报到被服务端 500 打回时，引导如实停在第 1 步并给出可执行下一步，不是静默成功", async () => {
     // 只让 POST 消息（＝报到）失败，其余端点全 200——隔离「报到闸」，别让别的分支遮住它。
     mock = startRestMock((req) => {
       if (req.method === "POST" && /^\/api\/channels\/[^/]+\/messages$/.test(req.path)) {
@@ -298,19 +181,20 @@ describe("party join —— 一条命令跑完整段接入（#944）", () => {
     const code = await runJoin(baseOpts({ harnessFlag: "claude" }), deps(record, {}, logs));
     const out = logs.join("\n");
 
-    // config / 身份都成功（隔离），唯独报到失败 → 自检必须报「还差」，不能是「全部就绪」。
+    // config / 身份都成功（隔离），唯独报到失败 → 引导必须停在第 1 步，不能是「接入完成」。
     expect(existsSync(configPath())).toBe(true);
     expect(code).toBe(1);
-    expect(out).not.toContain("全部就绪");
-    expect(out).toContain("还差");
+    expect(out).not.toContain("✅");
+    expect(out).toContain("接入停在第 1 步");
+    expect(stepLine(logs, 2)).toBeUndefined();
     // 如实报出是哪一步、给一条可执行的下一步（#926 口径）。
-    expect(out).toContain("报到");
-    expect(out).toContain("party send");
+    expect(stepLine(logs, 1)).toContain("报到失败");
+    expect(nextActionLine(logs)).toContain("party send");
     // 这类失败没有报错——自检必须明说，否则没人知道自己坏了。
     expect(out).toContain("别人只会以为你在忙");
   });
 
-  test("codex 档 happy path：装 hook + codex mcp add，空 CODEX_HOME（无信任闸）下自检「全部就绪」", async () => {
+  test("codex 档 happy path：装 hook + codex mcp add，空 CODEX_HOME（无信任闸）下引导「✅ 接入完成」", async () => {
     mock = startRestMock();
     const record: string[][] = [];
     const logs: string[] = [];
@@ -326,11 +210,11 @@ describe("party join —— 一条命令跑完整段接入（#944）", () => {
     expect(record.some((r) => r[0] === "codex" && r[1] === "mcp" && r[2] === "add")).toBe(true);
     expect(record.some((r) => r[0] === "claude")).toBe(false);
 
-    // 无 config.toml（老版本 codex / 无信任闸）→ hook 判 ok；唤醒层进程在（pid 4242）→ 自检「全部就绪」。
+    // 无 config.toml（老版本 codex / 无信任闸）→ hook 判 ok；唤醒层进程在（pid 4242）→ 「✅ 接入完成」。
     expect(code).toBe(0);
-    expect(out).toContain("全部就绪");
-    expect(out).toContain("唤醒层进程在跑");
-    expect(out).toContain("pid 4242");
+    expect(out).toContain("✅ 接入完成");
+    expect(stepLine(logs, 3)).toContain("唤醒层进程在跑 pid 4242");
+    expect(logs.find((l) => l.startsWith("✅"))).toContain("pid 4242");
   });
 
   // ★ #957 事故场景：四项静态前置条件全绿、唤醒层进程根本不在，旧 join 照印「就能被唤醒」，
@@ -353,10 +237,13 @@ describe("party join —— 一条命令跑完整段接入（#944）", () => {
     expect(existsSync(configPath())).toBe(true);
     expect(code).toBe(1);
     expect(out).not.toContain("就能被唤醒");
-    expect(out).not.toContain("全部就绪");
-    // 自检里那一格是 ✗，且带原因。
-    expect(out).toContain("✗ 唤醒层进程在跑");
-    expect(out).toContain("spawn 没返回 pid");
+    expect(out).not.toContain("✅");
+    // 第 3 步那一行是 ✗，且带原因；停在这，第 4 步不跑。
+    const step3 = stepLine(logs, 3);
+    expect(step3).toContain("唤醒层没起来");
+    expect(step3).toContain("spawn 没返回 pid");
+    expect(step3?.endsWith("✗")).toBe(true);
+    expect(stepLine(logs, 4)).toBeUndefined();
     // 降级文案：照实说此刻能被怎么叫到。
     expect(out).toContain("本会话只能在你下次发言、回合结束时收到 @");
     expect(out).toContain("新开一个 codex 会话");
@@ -390,7 +277,7 @@ describe("party join —— 一条命令跑完整段接入（#944）", () => {
     expect(code).toBe(0);
     expect(out).toContain("已有唤醒层在跑");
     expect(out).toContain("pid 777");
-    expect(out).toContain("全部就绪");
+    expect(out).toContain("✅ 接入完成");
   });
 
   test("#957：跑 join 的 codex 会话在注册表里挂到本频道（否则唤醒层宽限期一过就判无人使用退场）", async () => {
@@ -433,7 +320,7 @@ describe("party join —— 一条命令跑完整段接入（#944）", () => {
     expect(listCodexSessions().length).toBe(0);
   });
 
-  test("失败可见（owner 场景）：codex hook 已装但信任闸 disabled、非交互不批准时，自检报「还差」hook 那一步", async () => {
+  test("失败可见（owner 场景）：codex hook 已装但信任闸 disabled、非交互不批准时，引导停在第 2 步（hook）", async () => {
     mock = startRestMock();
     const codexHome = join(tmp, ".codex");
     mkdirSync(codexHome, { recursive: true });
@@ -459,10 +346,11 @@ describe("party join —— 一条命令跑完整段接入（#944）", () => {
     // 隔离：config/身份/报到都成功，唯独 hook 信任那道闸不过。
     expect(existsSync(configPath())).toBe(true);
     expect(code).toBe(1);
-    expect(out).not.toContain("全部就绪");
-    expect(out).toContain("还差");
-    // 自检明确点出是 hook 那一步（#926 措辞：未获批准的 hook 会被静默跳过）。
-    expect(out).toContain("hook");
+    expect(out).not.toContain("✅");
+    expect(out).toContain("接入停在第 2 步");
+    // 第 2 步那一行明确点出是 hook（#926 措辞：未获批准的 hook 会被静默跳过）；唤醒层那步不跑。
+    expect(stepLine(logs, 2)).toContain("hook");
+    expect(stepLine(logs, 3)).toBeUndefined();
     // 红线：绝不建议绕过信任闸。
     expect(out).not.toContain("dangerously-bypass-hook-trust");
   });
@@ -485,23 +373,23 @@ describe("party join —— 一条命令跑完整段接入（#944）", () => {
   // 下面三条覆盖 SpawnBehavior 的三个分支。它们不是补覆盖率——这三条正是本切片声称
   // 「失败要能看见」的路径：桩写了却没人用，那个声称就没被验证过（CodeRabbit 逮到）。
 
-  test("目标机器没装 claude CLI：注册/装插件 warn 而不是崩，配置照样落地；但唤醒层核实不了就不印 ✅", async () => {
+  test("目标机器没装 claude CLI：第 0 步如实报 claude_unavailable 并停在那，不崩、不印 ✅", async () => {
     mock = startRestMock();
     const record: string[][] = [];
     const logs: string[] = [];
     const code = await runJoin(baseOpts({ harnessFlag: "claude" }), deps(record, { noBinary: true }, logs));
     const out = logs.join("\n");
 
-    // MCP 注册 / 装插件是 best-effort：不崩、不静默——这一步的结果必须**看得见**。
-    expect(out).toMatch(/mcp[\s\S]{0,80}(未|没|失败|跳过|not|skip)/i);
-    // 配置与报到仍然落地（best-effort 步骤不该拖垮前面的步骤）。
-    expect(existsSync(configPath())).toBe(true);
     // #961：claude 档的唤醒层就是插件；claude 都不在 PATH 上，插件装没装、版本对不对一概核实不了——
-    // 这时说「就能被唤醒」是拿前置条件顶替判据。自检如实报 claude_unavailable，给一条修法。
+    // 这时说「就能被唤醒」是拿前置条件顶替判据。第 0 步如实报 claude_unavailable，给一条修法。
+    // #988：版本是第 0 步，停在这——身份那步（写 config / MCP 注册）不跑；装好 claude 重跑同一条 join。
     expect(code).toBe(1);
-    expect(out).not.toContain("全部就绪");
-    expect(out).toContain("claude_unavailable");
+    expect(out).not.toContain("✅");
+    expect(stepLine(logs, 0)).toContain("claude_unavailable");
+    expect(stepLine(logs, 0)?.endsWith("✗")).toBe(true);
     expect(nextActionLine(logs)).toContain("PATH");
+    expect(stepLine(logs, 1)).toBeUndefined();
+    expect(existsSync(configPath())).toBe(false);
   });
 
   test("重复接入：mcp get 命中已注册 ⇒ 跳过 add，不再叠一个常驻进程（#898）", async () => {
@@ -648,10 +536,15 @@ describe("party join claude 档 —— 武装监听闸（#979）", () => {
     expect(out).toContain("版本与 CLI 一致");
     expect(code).toBe(1);
     expect(out).not.toContain("就能被唤醒");
-    expect(out).not.toContain("全部就绪");
+    expect(out).not.toContain("接入完成");
     expect(out).not.toContain("✅");
-    // 自检那一格是 ✗。
-    expect(out).toContain("✗ 本机有会接 @ 的 Claude 武装监听");
+    // 第 3 步那一行是 ✗，停在这（第 4 步不跑）。
+    const step3 = stepLine(logs, 3);
+    expect(step3).toContain("本机没有会接 @ 的 Claude 会话");
+    expect(step3?.endsWith("✗")).toBe(true);
+    expect(stepLine(logs, 4)).toBeUndefined();
+    // 唯一那条修法就是 party claude dev。
+    expect(nextActionLine(logs)).toBe("party claude dev");
     // 降级文案：身份已绑、为什么叫不醒、两条命令**原样**印出。
     expect(out).toContain("已绑定身份 agent，但这台机现在没有会接 @ 的 Claude 会话");
     expect(out).toContain("local-only");
@@ -690,7 +583,9 @@ describe("party join claude 档 —— 武装监听闸（#979）", () => {
     expect(verdict).toContain("就能被唤醒");
     expect(verdict).toContain(`pid ${process.pid}`);
     expect(verdict).toContain("party claude-channel");
-    expect(out).toContain("✓ 本机有会接 @ 的 Claude 武装监听");
+    const step3 = stepLine(logs, 3);
+    expect(step3).toContain(`pid ${process.pid}）在接 @`);
+    expect(step3?.endsWith("✓")).toBe(true);
     expect(out).toContain(`由 party claude / party bridge claude 起的 Claude 会话（武装监听 party claude-channel，pid ${process.pid}）`);
     expect(out).not.toContain("蛰伏档（普通 claude 起的，不接频道消息）");
   });
@@ -734,18 +629,24 @@ describe("party join claude 档 —— 武装监听闸（#979）", () => {
     expect(out).toContain("party claude dev");
   });
 
-  test("插件旧版且 update 失败 + 无武装监听 ⇒ 第一条修法仍是 plugin update（监听闸放最后，前面没过它的修法没意义）", async () => {
+  test("插件旧版且 update 失败 + 无武装监听 ⇒ 唯一修法是 plugin update（版本是第 0 步，停在那；监听那步根本不跑）", async () => {
     mock = startRestMock();
     const record: string[][] = [];
     const logs: string[] = [];
     const d = deps(record, { installedPluginVersion: "0.2.203", failPluginUpdate: true }, logs);
-    d.claudeArmedListener = () => ({ live: null, sessions: 0 });
+    let listenerAsked = false;
+    d.claudeArmedListener = () => {
+      listenerAsked = true;
+      return { live: null, sessions: 0 };
+    };
     const code = await runJoin(baseOpts({ harnessFlag: "claude" }), d);
     const out = logs.join("\n");
     expect(code).toBe(1);
     expect(nextActionLine(logs)).toBe(`claude plugin update ${PLUGIN}`);
-    // 监听那一格照样 ✗ 列出来，只是不做第一条修法。
-    expect(out).toContain("✗ 本机有会接 @ 的 Claude 武装监听");
+    // 停在第 0 步：监听那步不跑、不探活、不给第二条修法（前面没过它的修法没意义）。
+    expect(listenerAsked).toBe(false);
+    expect(stepLine(logs, 3)).toBeUndefined();
+    expect(out).not.toContain("party claude dev");
   });
 
   test("#961 重开文案（#979 修订）：重开要用 party claude 起，不是裸 claude", async () => {

--- a/cli/test/onboarding-steps.test.ts
+++ b/cli/test/onboarding-steps.test.ts
@@ -1,0 +1,452 @@
+// 接入引导步骤机（issue #988，epic #987）。
+//
+// 两层：
+//  1. onboarding/steps.ts 的机器本身——顺序跑、不过就停、恰一条修法、异常算不过、输出形态。
+//  2. party join 装配出来的第 0～4 步——每一步失败都停在该步且只印一条修法；--yes 无 TTY 全流程；
+//     全部过 ⇒ ✅ 且写明 pid / 起法；同一状态重跑输出相同（幂等）。
+//
+// 变异自检（写这份测试时做过）：把 runSteps 的「不过就 return」删掉让它继续跑 ⇒ 下面
+// 「停在该步」「只印一条修法」「后续步骤不跑」全红。
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { formatStep, runSteps, type Step, type StepResult } from "../src/onboarding/steps";
+import { roundTripWakeVerifier, runJoin } from "../src/commands/join";
+import type { VerifyWakeDeps } from "../src/onboarding/verify-wake";
+import type { WakeTestFrame } from "../src/commands/wake";
+import { RUNNING_VERSION } from "../src/upgrade";
+import { startRestMock, type RestMock } from "./rest-mock";
+import { PLUGIN, STUB_WAKE_VERIFY_SUMMARY, baseJoinOpts, fixCount, fixLine, joinDeps, joinEnv, stepLine } from "./join-fixture";
+
+// ── 1. 机器本身 ───────────────────────────────────────────────────────────────
+
+describe("runSteps —— 顺序跑、不过就停、恰一条修法", () => {
+  const ok = (id: string, summary = `${id} 过了`): Step<string[]> => ({
+    id,
+    title: id,
+    run(ran) {
+      ran.push(id);
+      return { ok: true, summary };
+    },
+  });
+  const bad = (id: string, fix?: StepResult["fix"]): Step<string[]> => ({
+    id,
+    title: id,
+    run(ran) {
+      ran.push(id);
+      return { ok: false, summary: `${id} 没过`, fix };
+    },
+  });
+
+  test("全部过 ⇒ ok，每步一行「第 N 步  标题 · 摘要 ✓」，从第 0 步数起，没有修法", async () => {
+    const ran: string[] = [];
+    const logs: string[] = [];
+    const out = await runSteps({ steps: [ok("版本"), ok("身份")], ctx: ran, log: (l) => logs.push(l) });
+    expect(out.ok).toBe(true);
+    expect(ran).toEqual(["版本", "身份"]);
+    expect(logs).toEqual(["第 0 步  版本 · 版本 过了 ✓", "第 1 步  身份 · 身份 过了 ✓"]);
+  });
+
+  test("中间一步不过 ⇒ 停在该步：后面的步骤不跑、只印一条修法、stoppedAt 指向它", async () => {
+    const ran: string[] = [];
+    const logs: string[] = [];
+    const out = await runSteps({
+      steps: [ok("版本"), bad("身份", { do: "party send hi --channel dev", notes: ["先知道这个"] }), ok("接收方式"), bad("验证")],
+      ctx: ran,
+      log: (l) => logs.push(l),
+    });
+    expect(out.ok).toBe(false);
+    if (out.ok) throw new Error("unreachable");
+    expect(out.stoppedAt.index).toBe(1);
+    expect(out.stoppedAt.id).toBe("身份");
+    // 后面的步骤一个都没跑——不是「跑了但没印」。
+    expect(ran).toEqual(["版本", "身份"]);
+    expect(stepLine(logs, 2)).toBeUndefined();
+    expect(stepLine(logs, 3)).toBeUndefined();
+    // 恰一条修法：notes 在前、修法标记、命令一行。
+    expect(fixCount(logs)).toBe(1);
+    expect(fixLine(logs)).toBe("party send hi --channel dev");
+    expect(logs).toEqual([
+      "第 0 步  版本 · 版本 过了 ✓",
+      "第 1 步  身份 · 身份 没过 ✗",
+      "         先知道这个",
+      "         修法（做完重跑同一条 party join）：",
+      "           party send hi --channel dev",
+    ]);
+  });
+
+  test("不过但没给修法 ⇒ 修法退回「重跑」那条命令（rerun 可配）", async () => {
+    const logs: string[] = [];
+    const out = await runSteps({ steps: [bad("身份")], ctx: [], log: (l) => logs.push(l), rerun: "party recover dev" });
+    expect(out.ok).toBe(false);
+    expect(fixCount(logs)).toBe(1);
+    expect(fixLine(logs)).toBe("party recover dev");
+    expect(logs.some((l) => l.includes("重跑同一条 party recover dev"))).toBe(true);
+  });
+
+  test("run 抛异常 ⇒ 按不过处理并停（绝不因探活炸了就假定过了）", async () => {
+    const ran: string[] = [];
+    const logs: string[] = [];
+    const boom: Step<string[]> = {
+      id: "探活",
+      title: "探活",
+      run() {
+        throw new Error("ps exploded");
+      },
+    };
+    const out = await runSteps({ steps: [boom, ok("验证")], ctx: ran, log: (l) => logs.push(l) });
+    expect(out.ok).toBe(false);
+    expect(ran).toEqual([]);
+    expect(stepLine(logs, 0)).toContain("ps exploded");
+    expect(stepLine(logs, 0)?.endsWith("✗")).toBe(true);
+    expect(stepLine(logs, 1)).toBeUndefined();
+  });
+
+  test("firstIndex 可配（recover 之类从第 1 步数起）；detail 行缩进印在步骤行下方，过/不过都印", () => {
+    const lines = formatStep(3, "起一个可唤醒的会话", { ok: true, summary: "武装监听 pid 41233", detail: ["运行：party claude ludo"] }, "party join");
+    expect(lines).toEqual(["第 3 步  起一个可唤醒的会话 · 武装监听 pid 41233 ✓", "         运行：party claude ludo"]);
+    const failed = formatStep(3, "起一个可唤醒的会话", { ok: false, summary: "没监听", detail: ["运行：party claude ludo"], fix: { do: "party claude ludo" } }, "party join");
+    expect(failed[1]).toBe("         运行：party claude ludo");
+    expect(failed.filter((l) => l.includes("修法（")).length).toBe(1);
+  });
+});
+
+// ── 2. party join 装配出来的五步 ───────────────────────────────────────────────
+
+let tmp: string;
+let mock: RestMock;
+const env = joinEnv();
+beforeEach(() => {
+  tmp = env.setup();
+});
+afterEach(() => {
+  mock?.stop();
+  env.teardown();
+});
+const configPath = () => join(tmp, ".agentparty", "agents", "agentparty-bot-dev.json");
+const opts = (over: Parameters<typeof baseJoinOpts>[1] = {}) => baseJoinOpts(mock.url, over);
+
+/** 停在第 n 步的通用断言：退出码 1、无 ✅、第 n 步 ✗、第 n+1 步没印、恰一条修法、收尾提示。 */
+function expectStoppedAt(code: number, logs: string[], n: number): void {
+  const out = logs.join("\n");
+  expect(code).toBe(1);
+  expect(out).not.toContain("✅");
+  expect(stepLine(logs, n)?.endsWith("✗")).toBe(true);
+  expect(stepLine(logs, n + 1)).toBeUndefined();
+  expect(fixCount(logs)).toBe(1);
+  expect(out).toContain(`接入停在第 ${n} 步`);
+  expect(out).toContain("别人只会以为你在忙");
+}
+
+describe("party join 引导 —— 每一步失败都停在该步、只印一条修法（#988）", () => {
+  test("第 0 步 版本：插件旧版且 update 失败 ⇒ 停在第 0 步，修法是 plugin update，身份那步不跑（config 不写）", async () => {
+    mock = startRestMock();
+    const logs: string[] = [];
+    const code = await runJoin(opts({ yes: true }), joinDeps(tmp, [], { installedPluginVersion: "0.2.203", failPluginUpdate: true }, logs));
+    expectStoppedAt(code, logs, 0);
+    expect(stepLine(logs, 0)).toContain("plugin_version_mismatch");
+    expect(fixLine(logs)).toBe(`claude plugin update ${PLUGIN}`);
+    expect(existsSync(configPath())).toBe(false);
+    expect(mock.requests.some((r) => r.method === "POST")).toBe(false);
+  });
+
+  test("第 1 步 身份：服务端不认 token（/api/me 401，身份解析不出）⇒ 停在第 1 步，修法指向 token / server，后面不跑", async () => {
+    mock = startRestMock((req) => (req.path === "/api/me" ? Response.json({ error: { code: "unauthorized", message: "bad token" } }, { status: 401 }) : undefined));
+    const logs: string[] = [];
+    const chosen: string[] = [];
+    const d = joinDeps(tmp, [], {}, logs);
+    d.chooseReceiveMode = async () => {
+      chosen.push("asked");
+      return "interactive";
+    };
+    const code = await runJoin(opts(), d);
+    expectStoppedAt(code, logs, 1);
+    expect(stepLine(logs, 1)).toContain("服务端没确认身份");
+    expect(fixLine(logs)).toContain("AGENTPARTY_TOKEN");
+    expect(chosen).toEqual([]); // 第 2 步没跑到，也就没问
+    // 身份没确认就不报到——别往频道里发一条无名的 👋。
+    expect(mock.requests.some((r) => r.method === "POST" && /\/messages$/.test(r.path))).toBe(false);
+  });
+
+  test("第 1 步 身份：报到 500 ⇒ 停在第 1 步，修法是 party send", async () => {
+    mock = startRestMock((req) => {
+      if (req.method === "POST" && /^\/api\/channels\/[^/]+\/messages$/.test(req.path)) {
+        return Response.json({ error: { code: "boom", message: "boom" } }, { status: 500 });
+      }
+      return undefined;
+    });
+    const logs: string[] = [];
+    const code = await runJoin(opts({ yes: true }), joinDeps(tmp, [], {}, logs));
+    expectStoppedAt(code, logs, 1);
+    expect(fixLine(logs)).toBe('party send "👋 bot 报到" --channel dev');
+  });
+
+  test("第 2 步 接收方式（codex）：hook 信任闸 disabled ⇒ 停在第 2 步，唤醒层那步不拉起", async () => {
+    mock = startRestMock();
+    const codexHome = join(tmp, ".codex");
+    mkdirSync(codexHome, { recursive: true });
+    const hooksJson = join(codexHome, "hooks.json");
+    writeFileSync(hooksJson, JSON.stringify({ hooks: { Stop: [{ hooks: [{ type: "command", command: "party hook codex-stop", timeout: 10 }] }] } }));
+    writeFileSync(`${codexHome}/config.toml`, `[hooks.state."${hooksJson}:stop:0:0"]\ntrusted_hash = "deadbeef"\nenabled = false\n`);
+    const logs: string[] = [];
+    const d = joinDeps(tmp, [], {}, logs);
+    d.hookRun = async () => 0; // 非交互、没批准：信任状态原样留在盘上
+    let started = false;
+    d.startCodexWakeLayer = async () => {
+      started = true;
+      return { action: "start", channel: "dev", cwd: process.cwd(), args: [] };
+    };
+    const code = await runJoin(opts({ harnessFlag: "codex" }), d);
+    expectStoppedAt(code, logs, 2);
+    expect(stepLine(logs, 2)).toContain("Stop hook 没到位");
+    expect(started).toBe(false);
+    expect(logs.join("\n")).not.toContain("dangerously-bypass-hook-trust");
+  });
+
+  test("第 3 步 起会话（claude）：只有蛰伏档 ⇒ 停在第 3 步，修法就是那条 party claude dev，第 4 步不跑", async () => {
+    mock = startRestMock();
+    const logs: string[] = [];
+    const d = joinDeps(tmp, [], {}, logs);
+    d.claudeArmedListener = () => ({ live: null, sessions: 2 });
+    let verified = false;
+    d.verifyWake = () => {
+      verified = true;
+      return { ok: true, summary: "不该跑到" };
+    };
+    const code = await runJoin(opts({ yes: true }), d);
+    expectStoppedAt(code, logs, 3);
+    expect(stepLine(logs, 3)).toContain("2 个 claude 会话全是蛰伏档");
+    expect(fixLine(logs)).toBe("party claude dev");
+    expect(verified).toBe(false);
+    // 要跑的命令印全了：party claude 展开成 claudeLaunchPlan 的最终 argv（#995：dev-channels flag）。
+    expect(logs.join("\n")).toContain("展开：AGENTPARTY_CHANNEL=dev claude --dangerously-load-development-channels plugin:agentparty@agentparty");
+  });
+
+  test("第 3 步 起会话（codex）：唤醒层拉不起 ⇒ 停在第 3 步，修法是 party serve dev --runner codex", async () => {
+    mock = startRestMock();
+    const logs: string[] = [];
+    const d = joinDeps(tmp, [], {}, logs);
+    d.startCodexWakeLayer = async () => ({ action: "start-failed", channel: "dev", detail: "spawn 没返回 pid" });
+    d.codexWakeLayerLive = async () => null;
+    const code = await runJoin(opts({ harnessFlag: "codex", yes: true }), d);
+    expectStoppedAt(code, logs, 3);
+    expect(fixLine(logs)).toBe("party serve dev --runner codex");
+  });
+
+  test("第 4 步 验证：注入的往返验证不过 ⇒ 停在第 4 步，用它给的修法，不印 ✅", async () => {
+    mock = startRestMock();
+    const logs: string[] = [];
+    const d = joinDeps(tmp, [], {}, logs);
+    const seen: unknown[] = [];
+    d.verifyWake = (input) => {
+      seen.push(input);
+      return { ok: false, summary: "@agent ping → 10s 没回执（插件层没通）", fix: { do: "party wake check dev" } };
+    };
+    const code = await runJoin(opts({ yes: true }), d);
+    expectStoppedAt(code, logs, 4);
+    expect(fixLine(logs)).toBe("party wake check dev");
+    // 第 4 步拿到的是第 3 步探到的那个进程（#990 按它判「谁收到了」）。
+    expect(seen).toEqual([{
+      channel: "dev",
+      identity: "agent",
+      harness: "claude",
+      listener: { pid: 5150, description: "由 party claude / party bridge claude 起的 Claude 会话（武装监听 party claude-channel，pid 5150）" },
+    }]);
+  });
+});
+
+describe("party join 引导 —— --yes 无 TTY 全流程（#988）", () => {
+  test("claude 档：五步逐行打印、不交互、✅ 写明 pid 与起法；第 4 步标明真实往返随 #990 接入", async () => {
+    mock = startRestMock();
+    const logs: string[] = [];
+    const d = joinDeps(tmp, [], {}, logs);
+    let asked = false;
+    d.chooseReceiveMode = async () => {
+      asked = true;
+      return "serve";
+    };
+    d.claudeDefaultArgs = () => ({ args: ["--dangerously-skip-permissions"], source: "config", origin: "/x/claude-default-args.json" });
+    const code = await runJoin(opts({ yes: true }), d);
+    const out = logs.join("\n");
+    expect(code).toBe(0);
+    // --yes：压根不问。
+    expect(asked).toBe(false);
+    // 五步按序、全 ✓。
+    const steps = logs.filter((l) => l.startsWith("第 ")).map((l) => l.slice(0, 5));
+    expect(steps).toEqual(["第 0 步", "第 1 步", "第 2 步", "第 3 步", "第 4 步"]);
+    for (const l of logs.filter((x) => x.startsWith("第 "))) expect(l.endsWith("✓")).toBe(true);
+    expect(stepLine(logs, 0)).toContain(`CLI ${RUNNING_VERSION} · claude 插件 ${RUNNING_VERSION} 版本与 CLI 一致`);
+    expect(stepLine(logs, 1)).toContain("#dev 上以 agent 报到");
+    expect(stepLine(logs, 2)).toContain("你选：交互式 Claude 会话");
+    expect(out).toContain("--yes：不交互，按 claude 档默认选了交互式会话");
+    expect(out).toContain("运行：party claude dev        （已自动带 dev-channels；默认参数：--dangerously-skip-permissions（来自 /x/claude-default-args.json））");
+    expect(out).toContain("展开：AGENTPARTY_CHANNEL=dev claude --dangerously-load-development-channels plugin:agentparty@agentparty --dangerously-skip-permissions");
+    expect(stepLine(logs, 3)).toContain("武装监听 party claude-channel，pid 5150）在接 @");
+    expect(stepLine(logs, 4)).toContain(STUB_WAKE_VERIFY_SUMMARY("agent"));
+    expect(fixCount(logs)).toBe(0);
+    const verdict = logs.find((l) => l.startsWith("✅"));
+    expect(verdict).toBe("✅ 接入完成：现在 @ agent，这台机器上由 party claude / party bridge claude 起的 Claude 会话（武装监听 party claude-channel，pid 5150）就能被唤醒来协作。");
+  });
+
+  test("codex 档：✅ 写明唤醒层 pid", async () => {
+    mock = startRestMock();
+    const logs: string[] = [];
+    const code = await runJoin(opts({ harnessFlag: "codex", yes: true }), joinDeps(tmp, [], {}, logs));
+    expect(code).toBe(0);
+    expect(logs.filter((l) => l.startsWith("第 ")).length).toBe(5);
+    expect(stepLine(logs, 2)).toContain("Stop hook 已装、已批准");
+    expect(logs.find((l) => l.startsWith("✅"))).toBe("✅ 接入完成：现在 @ agent，这台机器上唤醒层 party serve dev --runner codex（pid 4242）就能被唤醒来协作。");
+  });
+
+  test("other 档：没有唤醒层，只跑到第 2 步，✅ 说清收消息靠 CLI", async () => {
+    mock = startRestMock();
+    const logs: string[] = [];
+    const code = await runJoin(opts({ harnessFlag: "other", yes: true }), joinDeps(tmp, [], {}, logs));
+    expect(code).toBe(0);
+    expect(logs.filter((l) => l.startsWith("第 ")).length).toBe(3);
+    expect(stepLine(logs, 2)).toContain("party watch dev");
+    expect(logs.find((l) => l.startsWith("✅"))).toContain("没有唤醒层");
+  });
+
+  test("有 TTY 且未 --yes：第 2 步问一句，选常驻 ⇒ 第 3 步印/修法都是 party serve dev --runner claude", async () => {
+    mock = startRestMock();
+    const logs: string[] = [];
+    const d = joinDeps(tmp, [], {}, logs);
+    const askedFor: string[] = [];
+    d.chooseReceiveMode = async (channel) => {
+      askedFor.push(channel);
+      return "serve";
+    };
+    d.claudeArmedListener = () => ({ live: null, sessions: 0 });
+    const code = await runJoin(opts({ yes: false }), d);
+    expect(askedFor).toEqual(["dev"]);
+    expect(stepLine(logs, 2)).toContain("你选：常驻 party serve dev --runner claude");
+    expect(logs.join("\n")).not.toContain("不交互");
+    expectStoppedAt(code, logs, 3);
+    expect(fixLine(logs)).toBe("party serve dev --runner claude");
+    expect(logs.join("\n")).toContain("运行：party serve dev --runner claude");
+  });
+
+  test("无 TTY 且未 --yes：问不了（null）⇒ 按 claude 档默认（交互式）并印出所选", async () => {
+    mock = startRestMock();
+    const logs: string[] = [];
+    const d = joinDeps(tmp, [], {}, logs); // fixture 默认 chooseReceiveMode 返回 null
+    const code = await runJoin(opts({ yes: false }), d);
+    expect(code).toBe(0);
+    expect(stepLine(logs, 2)).toContain("你选：交互式 Claude 会话");
+    expect(logs.join("\n")).toContain("无 TTY：不交互，按 claude 档默认选了交互式会话");
+  });
+});
+
+// 第 4 步的真实实现（#990 的 verifyWakeRoundTrip）→ 一步的适配：往返结果的 detail 当摘要、fix 当修法。
+// 往返本体（判层、修法文案）在 verify-wake.test.ts 里测；这里只测适配层没把信息弄丢、没重复打 ✓/✗。
+describe("roundTripWakeVerifier —— 第 4 步接 #990 的往返（#988）", () => {
+  function frame(over: Partial<WakeTestFrame["phases"]> = {}, result: WakeTestFrame["result"] = "timeout"): WakeTestFrame {
+    return {
+      type: "wake_test",
+      channel: "dev",
+      target: "agent",
+      result,
+      generated_at: 1,
+      timeout_sec: 30,
+      presence: { state: "waiting", residency: "supervised", wake_kind: "serve", wake_verified_at: null, last_seen: 1 },
+      phases: {
+        mention_delivered: { ok: true, seq: 42, evidence: "message accepted by channel history" },
+        wake_invoked: { ok: null, status: "broadcast_pending", adapter: "serve", evidence: "serve broadcast delivered for mention #42" },
+        agent_resumed: { ok: false, seq: null, evidence: null },
+        ...over,
+      },
+      reason: "timed out waiting for linked reply_to/status.summary_seq",
+    } as WakeTestFrame;
+  }
+  function verifyDeps(f: WakeTestFrame, probed: unknown[] = []): VerifyWakeDeps {
+    let t = 1_000;
+    return {
+      probe: async (o) => {
+        probed.push(o);
+        t += 3_200;
+        return f;
+      },
+      localEvidence: () => ({ listener: { live: null, sessions: 1 }, claimed: false, journaled: false, runnerTask: false }),
+      now: () => t,
+    };
+  }
+
+  test("收到回执 ⇒ 第 4 步 ✓，摘要是「@agent ping → 3.2s 收到回执」，探针用的是 join 写的 config 里的 server/token", async () => {
+    mock = startRestMock();
+    const probed: unknown[] = [];
+    const logs: string[] = [];
+    const d = joinDeps(tmp, [], {}, logs);
+    d.verifyWake = roundTripWakeVerifier(verifyDeps(frame({ agent_resumed: { ok: true, seq: 43, evidence: "reply_to" } }, "healthy"), probed));
+    const code = await runJoin(opts({ yes: true }), d);
+    expect(code).toBe(0);
+    expect(stepLine(logs, 4)).toBe("第 4 步  真发一条 @ 验证 · @agent ping → 3.2s 收到回执（回帖 #43） ✓");
+    expect(probed).toHaveLength(1);
+    const o = probed[0] as { server: string; token: string; channel: string; target: string };
+    expect(o.server).toBe(new URL(mock.url).origin);
+    expect(o.token).toBe("ap_bot_secret");
+    expect(o.channel).toBe("dev");
+    expect(o.target).toBe("agent");
+  });
+
+  test("超时（服务端已投递、本机没收到）⇒ 停在第 4 步，摘要说清哪一层没通，修法是 #990 给的那一条", async () => {
+    mock = startRestMock();
+    const logs: string[] = [];
+    const d = joinDeps(tmp, [], {}, logs);
+    d.verifyWake = roundTripWakeVerifier(verifyDeps(frame({ wake_invoked: { ok: true, status: "invoked", adapter: "serve", evidence: "claimed" } })));
+    const code = await runJoin(opts({ yes: true }), d);
+    expectStoppedAt(code, logs, 4);
+    const step4 = stepLine(logs, 4)!;
+    expect(step4).toContain("30s 未收到：服务端已投递、本机监听未收到");
+    // 不重复打 ✗：往返结果自带的「✗ 」被适配层去掉，行尾只有步骤机补的那个。
+    expect(step4.split("✗").length).toBe(2);
+    expect(fixLine(logs)).toContain("party claude dev");
+  });
+});
+
+describe("party join 引导 —— 幂等（#988）", () => {
+  test("同一状态重跑两次输出逐行相同", async () => {
+    mock = startRestMock();
+    // 「同一状态」：MCP 已注册、crossSessionInbound 已是 accept、插件同版——第二次跑时盘上什么都没变。
+    mkdirSync(join(tmp, ".claude"), { recursive: true });
+    writeFileSync(join(tmp, ".claude", "settings.json"), JSON.stringify({ crossSessionInbound: "accept" }));
+    const first: string[] = [];
+    const second: string[] = [];
+    expect(await runJoin(opts({ yes: true }), joinDeps(tmp, [], { mcpAlreadyRegistered: true }, first))).toBe(0);
+    expect(await runJoin(opts({ yes: true }), joinDeps(tmp, [], { mcpAlreadyRegistered: true }, second))).toBe(0);
+    expect(second).toEqual(first);
+    expect(first.filter((l) => l.startsWith("第 ")).length).toBe(5);
+  });
+
+  test("首跑后重跑不叠加副作用（MCP 只 add 一次、插件不重复 update、报到是新的一条而不是报错）", async () => {
+    mock = startRestMock();
+    const record: string[][] = [];
+    const first: string[] = [];
+    const second: string[] = [];
+    // 第一跑：mcp get 探到未注册 → add；第二跑：已注册 → 跳过 add。桩按 mcpAlreadyRegistered 分别配。
+    expect(await runJoin(opts({ yes: true }), joinDeps(tmp, record, {}, first))).toBe(0);
+    expect(await runJoin(opts({ yes: true }), joinDeps(tmp, record, { mcpAlreadyRegistered: true }, second))).toBe(0);
+    expect(second.join("\n")).toContain("跳过重复添加");
+    expect(second.join("\n")).toContain("crossSessionInbound 已是 accept（跳过）");
+    expect(record.filter((r) => r[0] === "claude" && r[1] === "mcp" && r[2] === "add").length).toBe(1);
+    expect(record.some((r) => r[0] === "claude" && r[1] === "plugin" && r[2] === "update")).toBe(false);
+    // 两次都是完整五步、都 ✅。
+    expect(second.filter((l) => l.startsWith("第 ")).length).toBe(5);
+    expect(second.find((l) => l.startsWith("✅"))).toBe(first.find((l) => l.startsWith("✅")));
+  });
+
+  test("停在某一步后修好再跑 ⇒ 同一条 join 从第 0 步重来并走完", async () => {
+    mock = startRestMock();
+    const logs1: string[] = [];
+    const d1 = joinDeps(tmp, [], {}, logs1);
+    d1.claudeArmedListener = () => ({ live: null, sessions: 1 });
+    expect(await runJoin(opts({ yes: true }), d1)).toBe(1);
+    expect(fixLine(logs1)).toBe("party claude dev");
+    // 「做完修法」＝本机起了 party claude dev（锁被持有）。
+    const logs2: string[] = [];
+    const d2 = joinDeps(tmp, [], { mcpAlreadyRegistered: true }, logs2);
+    expect(await runJoin(opts({ yes: true }), d2)).toBe(0);
+    expect(logs2.filter((l) => l.startsWith("第 ")).length).toBe(5);
+    expect(logs2.find((l) => l.startsWith("✅"))).toContain("pid 5150");
+  });
+});

--- a/cli/test/onboarding-steps.test.ts
+++ b/cli/test/onboarding-steps.test.ts
@@ -168,6 +168,27 @@ describe("party join 引导 —— 每一步失败都停在该步、只印一条
     expect(mock.requests.some((r) => r.method === "POST" && /\/messages$/.test(r.path))).toBe(false);
   });
 
+  // pr_agent on #998：TTY 下 Ctrl+C / 关闭输入不能被当成「无 TTY 按默认」继续往下跑——那是用户要停。
+  test("第 2 步 接收方式：用户取消（Ctrl+C / 输入关闭）⇒ 停在第 2 步，不替人选，第 3 步不跑", async () => {
+    mock = startRestMock(() => undefined);
+    const logs: string[] = [];
+    const d = joinDeps(tmp, [], {}, logs);
+    let probed = 0;
+    d.chooseReceiveMode = async () => "cancelled";
+    const origProbe = d.claudeArmedListener;
+    d.claudeArmedListener = () => {
+      probed += 1;
+      return origProbe();
+    };
+    const code = await runJoin(opts(), d);
+    expectStoppedAt(code, logs, 2);
+    expect({ probed, cancelled: stepLine(logs, 2)?.includes("已取消") ?? false, fix: fixLine(logs) ?? "" }).toEqual({
+      probed: 0,
+      cancelled: true,
+      fix: expect.stringContaining("--yes"),
+    });
+  });
+
   test("第 1 步 身份：报到 500 ⇒ 停在第 1 步，修法是 party send", async () => {
     mock = startRestMock((req) => {
       if (req.method === "POST" && /^\/api\/channels\/[^/]+\/messages$/.test(req.path)) {
@@ -450,3 +471,4 @@ describe("party join 引导 —— 幂等（#988）", () => {
     expect(logs2.find((l) => l.startsWith("✅"))).toContain("pid 5150");
   });
 });
+

--- a/plugins/agentparty/skills/agentparty/SKILL.md
+++ b/plugins/agentparty/skills/agentparty/SKILL.md
@@ -609,7 +609,7 @@ surface it to the owner instead of ignoring it.
 | Preflight or verify durable Channel reception while Claude is busy | `party claude --verify --channel <slug> --receiver-config PATH --sender-config PATH [--receiver-cwd DIR] --preflight-only`; replace it with `--live` only for an authorized one-model run whose test messages may remain in Channel history/audit |
 | Preflight or run the real two-Claude round-trip verifier | `party bridge claude --verify --channel <slug> --receiver-config PATH --sender-config PATH [--receiver-cwd DIR] [--sender-cwd DIR] --preflight-only`; remove `--preflight-only` only for an authorized live model run |
 | Attach the current live Claude session, with safe Cross-session auto-degradation | `party bridge claude <slug>`; use `--cross-session required` only when full capability is mandatory |
-| Join a channel | `AGENTPARTY_TOKEN='<T>' party join --server <URL> --channel <slug> --as <name> --harness codex\|claude --yes` — one command: config + rules, dedupe, bind, register MCP, install+approve the codex wake hook, check in, verdict. **Never hand-roll this from `party init`**: `join` does six things `init` does not, and a partial join looks fine while `@` silently never reaches you. For `--harness claude` the final ✅ also requires an **armed listener on this machine** (a session started by `party claude <slug>` / `party bridge claude <slug>`, or `party serve <slug> --runner claude`) — an ordinary `claude` session is local-only and never receives `@` (#615/#979), so `join` run from one prints the degraded verdict with those two commands instead of ✅; run `party claude <slug>` next. |
+| Join a channel | `AGENTPARTY_TOKEN='<T>' party join --server <URL> --channel <slug> --as <name> --harness codex\|claude --yes` — one command that runs the join as guided steps 第 0～4 步 (版本 → 身份 → 接收方式 → 起一个可唤醒的会话 → 真发一条 @ 验证): config + rules, dedupe, bind, register MCP, install+approve the codex wake hook, check in, probe the wake layer. Each step prints `第 N 步  标题 · 摘要 ✓/✗`; the first failing step prints **exactly one** fix command and join stops there (exit 1) — do that one thing, then re-run the same `party join` (idempotent). `--yes` = never prompt (step 2 takes the harness default). **Never hand-roll this from `party init`**: `join` does six things `init` does not, and a partial join looks fine while `@` silently never reaches you. For `--harness claude` the final `✅ 接入完成` also requires an **armed listener on this machine** (a session started by `party claude <slug>` / `party bridge claude <slug>`, or `party serve <slug> --runner claude`) — an ordinary `claude` session is local-only and never receives `@` (#615/#979), so `join` run from one stops at 第 3 步 with `party claude <slug>` as the fix instead of ✅; run it next. |
 | Make this interactive Claude session's activity visible in the channel (#615) | Install and enable the Marketplace plugin, then launch with `party claude <slug>` or `party bridge claude <slug>`; ordinary Claude sessions stay local-only and cannot overwrite the active listener's state |
 | See who to mention (online/wakeable/recent) | `party who <slug> [--json]` — run this BEFORE mentioning so you pick a real, reachable name |
 | Send a message | `party send "<text>" --channel <slug> [--mention <name>]... [--reply-to <seq>]` |
@@ -742,15 +742,18 @@ ADMIN_SECRET=... party invite "ZEGO IM 联调" --slug zego-im --party --guest-na
 
 `party invite` creates or reuses the channel, mints one channel-scoped guest token, and prints
 a copy-paste pack that is a short behavior contract plus **two commands**: install the CLI (only
-if missing) and one `party join`. `party join` does the whole join in one shot — write config +
-rules, dedupe same-channel identities, bind identity, register the MCP server (probe-then-add),
-install and approve the codex wake hook, check in, and print one final verdict ("全部就绪" or
-"还差第 N 步: <one command>"). The verdict is gated on the wake layer itself, not on static
-prerequisites: for claude it also checks that an armed listener process exists on this machine
-(`party claude <slug>` / `party bridge claude <slug>` session, or `party serve <slug> --runner
-claude`) — a plain `claude` session is a local-only dormant listener that never receives `@`, so
-`join` then prints the degraded verdict with those two commands rather than ✅ (#979). Send that
-pack to the teammate; do not ask them to open `/c/<slug>`.
+if missing) and one `party join`. `party join` does the whole join as guided steps (第 0 步 版本 →
+第 1 步 身份 → 第 2 步 接收方式 → 第 3 步 起一个可唤醒的会话 → 第 4 步 真发一条 @ 验证): write
+config + rules, dedupe same-channel identities, bind identity, register the MCP server
+(probe-then-add), install and approve the codex wake hook, check in, probe the wake layer. Each step
+prints `第 N 步  标题 · 摘要 ✓/✗`; the first failing step prints exactly one fix command and join
+stops there ("接入停在第 N 步"), and only when every step passed does it print `✅ 接入完成` naming
+the process that will be woken (pid / how it was started). The verdict is gated on the wake layer
+itself, not on static prerequisites: for claude 第 3 步 checks that an armed listener process
+exists on this machine (`party claude <slug>` / `party bridge claude <slug>` session, or `party
+serve <slug> --runner claude`) — a plain `claude` session is a local-only dormant listener that
+never receives `@`, so `join` then stops at 第 3 步 with `party claude <slug>` as the fix rather
+than ✅ (#979). Send that pack to the teammate; do not ask them to open `/c/<slug>`.
 
 Self-service path when you are already logged in as a channel moderator:
 

--- a/skills/agentparty/SKILL.md
+++ b/skills/agentparty/SKILL.md
@@ -609,7 +609,7 @@ surface it to the owner instead of ignoring it.
 | Preflight or verify durable Channel reception while Claude is busy | `party claude --verify --channel <slug> --receiver-config PATH --sender-config PATH [--receiver-cwd DIR] --preflight-only`; replace it with `--live` only for an authorized one-model run whose test messages may remain in Channel history/audit |
 | Preflight or run the real two-Claude round-trip verifier | `party bridge claude --verify --channel <slug> --receiver-config PATH --sender-config PATH [--receiver-cwd DIR] [--sender-cwd DIR] --preflight-only`; remove `--preflight-only` only for an authorized live model run |
 | Attach the current live Claude session, with safe Cross-session auto-degradation | `party bridge claude <slug>`; use `--cross-session required` only when full capability is mandatory |
-| Join a channel | `AGENTPARTY_TOKEN='<T>' party join --server <URL> --channel <slug> --as <name> --harness codex\|claude --yes` — one command: config + rules, dedupe, bind, register MCP, install+approve the codex wake hook, check in, verdict. **Never hand-roll this from `party init`**: `join` does six things `init` does not, and a partial join looks fine while `@` silently never reaches you. For `--harness claude` the final ✅ also requires an **armed listener on this machine** (a session started by `party claude <slug>` / `party bridge claude <slug>`, or `party serve <slug> --runner claude`) — an ordinary `claude` session is local-only and never receives `@` (#615/#979), so `join` run from one prints the degraded verdict with those two commands instead of ✅; run `party claude <slug>` next. |
+| Join a channel | `AGENTPARTY_TOKEN='<T>' party join --server <URL> --channel <slug> --as <name> --harness codex\|claude --yes` — one command that runs the join as guided steps 第 0～4 步 (版本 → 身份 → 接收方式 → 起一个可唤醒的会话 → 真发一条 @ 验证): config + rules, dedupe, bind, register MCP, install+approve the codex wake hook, check in, probe the wake layer. Each step prints `第 N 步  标题 · 摘要 ✓/✗`; the first failing step prints **exactly one** fix command and join stops there (exit 1) — do that one thing, then re-run the same `party join` (idempotent). `--yes` = never prompt (step 2 takes the harness default). **Never hand-roll this from `party init`**: `join` does six things `init` does not, and a partial join looks fine while `@` silently never reaches you. For `--harness claude` the final `✅ 接入完成` also requires an **armed listener on this machine** (a session started by `party claude <slug>` / `party bridge claude <slug>`, or `party serve <slug> --runner claude`) — an ordinary `claude` session is local-only and never receives `@` (#615/#979), so `join` run from one stops at 第 3 步 with `party claude <slug>` as the fix instead of ✅; run it next. |
 | Make this interactive Claude session's activity visible in the channel (#615) | Install and enable the Marketplace plugin, then launch with `party claude <slug>` or `party bridge claude <slug>`; ordinary Claude sessions stay local-only and cannot overwrite the active listener's state |
 | See who to mention (online/wakeable/recent) | `party who <slug> [--json]` — run this BEFORE mentioning so you pick a real, reachable name |
 | Send a message | `party send "<text>" --channel <slug> [--mention <name>]... [--reply-to <seq>]` |
@@ -742,15 +742,18 @@ ADMIN_SECRET=... party invite "ZEGO IM 联调" --slug zego-im --party --guest-na
 
 `party invite` creates or reuses the channel, mints one channel-scoped guest token, and prints
 a copy-paste pack that is a short behavior contract plus **two commands**: install the CLI (only
-if missing) and one `party join`. `party join` does the whole join in one shot — write config +
-rules, dedupe same-channel identities, bind identity, register the MCP server (probe-then-add),
-install and approve the codex wake hook, check in, and print one final verdict ("全部就绪" or
-"还差第 N 步: <one command>"). The verdict is gated on the wake layer itself, not on static
-prerequisites: for claude it also checks that an armed listener process exists on this machine
-(`party claude <slug>` / `party bridge claude <slug>` session, or `party serve <slug> --runner
-claude`) — a plain `claude` session is a local-only dormant listener that never receives `@`, so
-`join` then prints the degraded verdict with those two commands rather than ✅ (#979). Send that
-pack to the teammate; do not ask them to open `/c/<slug>`.
+if missing) and one `party join`. `party join` does the whole join as guided steps (第 0 步 版本 →
+第 1 步 身份 → 第 2 步 接收方式 → 第 3 步 起一个可唤醒的会话 → 第 4 步 真发一条 @ 验证): write
+config + rules, dedupe same-channel identities, bind identity, register the MCP server
+(probe-then-add), install and approve the codex wake hook, check in, probe the wake layer. Each step
+prints `第 N 步  标题 · 摘要 ✓/✗`; the first failing step prints exactly one fix command and join
+stops there ("接入停在第 N 步"), and only when every step passed does it print `✅ 接入完成` naming
+the process that will be woken (pid / how it was started). The verdict is gated on the wake layer
+itself, not on static prerequisites: for claude 第 3 步 checks that an armed listener process
+exists on this machine (`party claude <slug>` / `party bridge claude <slug>` session, or `party
+serve <slug> --runner claude`) — a plain `claude` session is a local-only dormant listener that
+never receives `@`, so `join` then stops at 第 3 步 with `party claude <slug>` as the fix rather
+than ✅ (#979). Send that pack to the teammate; do not ask them to open `/c/<slug>`.
 
 Self-service path when you are already logged in as a channel moderator:
 


### PR DESCRIPTION
## 做了什么

`party join` 从「收尾一坨自检格子」改成 epic #987 的**分步引导**：第 0～4 步顺序跑、每步一条 check、过/不过、不过时**恰一条**修法命令并停在该步（退出码 1）；全部过了才印 `✅ 接入完成`，写明谁会被唤醒（pid / 起法）。无 TTY / `--yes` 不交互、逐步打印；有 TTY 且未 `--yes` 第 2 步用 `node:readline` 问一句选接收方式。

### 步骤机 `cli/src/onboarding/steps.ts`（新）

```ts
interface StepResult { ok: boolean; summary: string; detail?: string[]; fix?: { do: string; notes?: string[] } }
interface Step<Ctx>  { id: string; title: string; run(ctx: Ctx): Promise<StepResult> | StepResult }
runSteps({ steps, ctx, log, rerun = "party join", firstIndex = 0 }) → { ok: true, records } | { ok: false, records, stoppedAt }
```

- 机器无状态、不认识 harness；`fix.do` 是一个字符串不是数组——「只给一条」是 #926 的老纪律。
- 任一步不过 ⇒ 打印 `第 N 步  标题 · 摘要 ✗` + notes + `修法（做完重跑同一条 party join）：` + 一行命令，然后 **return**（后续步骤的 `run` 一个都不调）。`run` 抛异常按不过处理，绝不因探活炸了就假定过了。
- `firstIndex` / `rerun` 可配，给 #991 `party recover` 复用。

### `party join` 每一步复用了什么（`cli/src/commands/join.ts`）

| 步 | check | 复用 | 不过时的修法 |
|---|---|---|---|
| 0 版本 | `CLI x.y.z`；claude 档插件装到位/启用/与 CLI 同版 | `installClaudePlugin`（内含 #993 `syncClaudePluginToCli`）+ doctor `inspectClaudePluginShell`（原 `plugin_lifecycle_ready`）| `claudePluginRemedy`（#961：update 不是 install；插件比 CLI 新则 `party upgrade`）|
| 1 身份 | `party init` 成功、config 有 server、服务端确认 identity、报到成功 | 现有 rules 落盘 / init / MCP 先探后加 / crossSessionInbound / send（原 `channel_bound`/`identity_resolved`/`checkin_sent`）| `party send "👋 <as> 报到" --channel <c>` 或「检查 AGENTPARTY_TOKEN / --server」|
| 2 接收方式 | claude：交互式 vs 常驻（TTY 问；`--yes`/无 TTY 取默认并印「按 claude 档默认选了…」）；codex：`party hook install --codex [--yes]` 后读 #926 清单的 `hook_installed`/`hook_trusted` | 现有 hook 安装 + `codexWakeChecklist` | codex：#942 探测式修法 `wake.next` |
| 3 起一个可唤醒的会话 | claude：印 `party claude <c>`（`claudeLaunchPlan` 展开成最终 argv，#995 dev-channels + #978 默认参数）+ `probeClaudeArmedListener`（原 `armed_listener_live`）；codex：`bringUpCodexWakeLayer` 主动拉起 + `probeCodexWakeLayer`（原 `wake_layer_live`）| #979 / #957 原逻辑 | claude：`party claude <c>`（选了常驻则 `party serve <c> --runner claude`）；codex：`party serve <c> --runner codex` |
| 4 真发一条 @ 验证 | `roundTripWakeVerifier` → #996 的 `verifyWakeRoundTrip`（发 `[wake-verify]` @ 自己、等回执、超时按层定位）| #990 | #990 给的那一条 |

- `JoinDeps` 新增三个注入点：`chooseReceiveMode`（缺省 readline，非 TTY 返回 null）、`claudeDefaultArgs`、`verifyWake`（缺省真往返；测试注入桩）。
- other 档没有唤醒层，只跑第 0～2 步，✅ 说清收消息靠 `party watch` / `party serve`。
- #957/#961/#979 的降级文案原样挪进对应步骤的 notes / fix；`claudeNoArmedListenerLines` 不再由 join 用（who 侧照旧）。
- 语义变化（有意）：版本是第 0 步——插件 `claude_unavailable` / `plugin_version_mismatch` 时**停在第 0 步，config 不写、MCP 不注册**；修好重跑同一条 join。旧版会先把 config/MCP/报到都做完再在收尾报「还差」。

## 输出样例（`--yes`，无 TTY）

claude 档全部过（本机已有 `party claude dev` 起的会话）：

```
party join → #dev as bot（harness: claude，server https://…）
第 0 步  版本 · CLI 0.2.216 · claude 插件 0.2.216 版本与 CLI 一致 ✓
第 1 步  身份 · #dev 上以 agent 报到 ✓
         ✓ 行为契约落盘: ~/.agentparty/agents/agentparty-bot-dev.rules.md
         ✓ 注册 claude MCP: MCP 已注册：party-bot
         ✓ 开启跨会话 @ 接收: 已把 ~/.claude/settings.json 的 crossSessionInbound 设为 accept（原文件备份在 …）
第 2 步  接收方式 · 你选：交互式 Claude 会话（可选：常驻 party serve dev --runner claude） ✓
         --yes：不交互，按 claude 档默认选了交互式会话
第 3 步  起一个可唤醒的会话 · 由 party claude / party bridge claude 起的 Claude 会话（武装监听 party claude-channel，pid 5150）在接 @ ✓
         运行：party claude dev        （已自动带 dev-channels；默认参数：--dangerously-skip-permissions（来自 ~/.agentparty/claude-default-args.json））
         展开：AGENTPARTY_CHANNEL=dev claude --dangerously-load-development-channels plugin:agentparty@agentparty --dangerously-skip-permissions
第 4 步  真发一条 @ 验证 · @agent ping → 3.2s 收到回执（回帖 #43） ✓

✅ 接入完成：现在 @ agent，这台机器上由 party claude / party bridge claude 起的 Claude 会话（武装监听 party claude-channel，pid 5150）就能被唤醒来协作。
```

从普通 `claude` 会话里跑（只有蛰伏档，#979 事故形态）——停在第 3 步：

```
第 0 步  版本 · CLI 0.2.216 · claude 插件 0.2.216 版本与 CLI 一致 ✓
第 1 步  身份 · #dev 上以 agent 报到 ✓
         …
第 2 步  接收方式 · 你选：交互式 Claude 会话（可选：常驻 party serve dev --runner claude） ✓
         --yes：不交互，按 claude 档默认选了交互式会话
第 3 步  起一个可唤醒的会话 · 本机没有会接 @ 的 Claude 会话——本机在 #dev 入册的 1 个 claude 会话全是蛰伏档（普通 claude 起的，不接频道消息） ✗
         运行：party claude dev        （已自动带 dev-channels；无本机默认参数）
         展开：AGENTPARTY_CHANNEL=dev claude --dangerously-load-development-channels plugin:agentparty@agentparty
         ⚠ 已绑定身份 agent，但这台机现在没有会接 @ 的 Claude 会话。
         普通 `claude` 起的会话不接频道消息（local-only）；要能被 @ 唤醒，用 party claude dev 起一个会话（或 party serve dev --runner claude 常驻）。
         修法（做完重跑同一条 party join）：
           party claude dev

接入停在第 3 步（起一个可唤醒的会话）——做完上面那一条，重跑同一条 party join。
在这一步完成之前：@ 你可能不会有任何反应，而且不会有任何报错——别人只会以为你在忙。
```

插件旧版且 update 失败（#961）——停在第 0 步：

```
第 0 步  版本 · CLI 0.2.216 · claude 插件 blocker: plugin_version_mismatch（本机插件 0.2.203，CLI 0.2.216） ✗
         ! 装 claude 插件: claude 插件未完全装上（best-effort；手动 claude plugin update agentparty@agentparty，然后重开会话）
         本机插件 0.2.203，CLI 0.2.216——`claude plugin install` 对已装的只回 already installed、不会升级，要 update
         做完【重开一个 Claude 会话】才生效——当前会话还挂着旧插件
         修法（做完重跑同一条 party join）：
           claude plugin update agentparty@agentparty

接入停在第 0 步（版本）——做完上面那一条，重跑同一条 party join。
```

codex 档全部过：

```
第 0 步  版本 · CLI 0.2.216 ✓
         ✓ 装 codex 插件: codex 插件已安装
第 1 步  身份 · #dev 上以 agent 报到 ✓
         …
第 2 步  接收方式 · Stop hook 已装、已批准；无人值守时由唤醒层（party serve --runner codex）接 @ ✓
第 3 步  起一个可唤醒的会话 · 唤醒层进程在跑 pid 4242 · serve 已持锁（连上服务端了） ✓
         ✓ 拉起唤醒层: 已拉起 party serve dev --runner codex（pid 4242）
第 4 步  真发一条 @ 验证 · @agent ping → 3.2s 收到回执（回帖 #43） ✓

✅ 接入完成：现在 @ agent，这台机器上唤醒层 party serve dev --runner codex（pid 4242）就能被唤醒来协作。
```

## 测试

- 新 `cli/test/onboarding-steps.test.ts`（21 例）：机器本身（顺序、停在该步、后续 `run` 不调、恰一条修法、异常算不过、输出形态、`firstIndex`/`rerun`）；join 装配的每一步失败都停在该步（第 0 步插件 mismatch ⇒ config 不写、无 POST；第 1 步 401/报到 500；第 2 步 codex hook disabled ⇒ 唤醒层不拉；第 3 步蛰伏档 / codex 拉不起；第 4 步注入不过）；`--yes` 无 TTY 全流程（五步全 ✓、不问、✅ 写明 pid/起法、展开命令含 dev-channels + 默认参数）；TTY 选常驻 ⇒ 第 3 步印/修都是 serve；幂等（同一状态两次输出逐行相同；重跑不叠加 MCP add / plugin update）；`roundTripWakeVerifier` 适配 #996（收到回执 ⇒ ✓ 且探针用 join 写的 config；超时 ⇒ 停在第 4 步、不重复打 ✗、修法是 #990 的）。
- `cli/test/join.test.ts`：38 例全部保留，断言按新输出形态等价改写（`全部就绪`→`✅ 接入完成`、`还差`→`接入停在第 N 步`、格子标签→`第 N 步` 行 + `stepLine()`、`nextActionLine`→`修法（…）：` 下一行）；判据（哪步过/不过、修法是哪条、退出码）没放宽。两处随「版本是第 0 步」的语义变化而改：`plugin_version_mismatch` / `claude_unavailable` 用例改为断言**停在第 0 步、config 不写、第 1 步不跑**。
- 共用桩抽到 `cli/test/join-fixture.ts`。
- 变异自检：把 `runSteps` 的「不过就 return」删掉让它继续跑 ⇒ `onboarding-steps` + `join` 两文件 **21 fail / 37 pass**；恢复后全绿。
- `cd cli && bunx tsc --noEmit` 干净；`bun test`（cli 全量）2644 pass / 0 fail；`scripts/skill-join-row.test.ts` 4 pass；`bun run sync:plugin` 已同步镜像。

## SKILL.md

Intent 表「Join a channel」行与接入包段落改成「分步引导 / 停在第 N 步 / ✅ 接入完成」的口径（#955 守卫仍绿），`plugins/` 镜像已 sync。

## 没做的

- `party recover <chan>`（#991）与 invite 接入包一句话化（#992）不在本 PR；步骤机的 `firstIndex`/`rerun` 已为 recover 留好。
- 第 3 步 claude 档只**打印**命令 + 探活，不替人起会话（#989）。
- 有 TTY 的第 2 步是最简 `1/2` 选择；没加 `--receive` 之类的 flag（非交互想常驻：先 `party serve <c> --runner claude` 再重跑 join，第 3 步会认出 serve）。
- 真机验证由 piggo 机负责。

Closes #988

https://claude.ai/code/session_01Az8CnUpayZzqpi1sh32Ssi
