### PR TITLE
fix(worker): 验证帧按发送者 30s 限频、只认已登记 agent 身份；wake verify 身份以 /api/me 为准

### DIFF
--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -137,6 +137,7 @@ const ERROR_CODES = new Set([
   "too_large",
   "loop_guard",
   "workflow_guard",
+  "wake_verify_rate_limited",
   "archived",
   "quota_exceeded",
   "channel_full",

--- a/cli/src/commands/wake.ts
+++ b/cli/src/commands/wake.ts
@@ -21,8 +21,10 @@ verify is onboarding step 4 (#990): it sends ONE verify frame as YOUR OWN identi
 (\`[wake-verify] @you ping\`, the only self-mention the server and the local listeners
 treat as a real summons), waits for the reply, and on timeout names the layer that
 did not deliver — server_delivery / local_listener / model_reply — with one fix.
-The frame is never counted against the loop guard. Exit code 0 only on a real
-round trip.
+The frame is never counted against the loop guard, but the server accepts at most
+one verify frame per sender per 30s (wake_verify_rate_limited says when to retry).
+Your identity comes from /api/me; the cached config identity is only a fallback.
+Exit code 0 only on a real round trip.
 
 check answers one question about THIS machine, with no network at all: "if someone
 @s me right now, will anything happen?" It prints how many steps are still missing
@@ -486,8 +488,35 @@ function runCheck(json: boolean): number {
 
 /**
  * `party wake verify`（#990）：接入引导第 4 步，以本身份真发一条 @ 验证往返。
- * 身份取本地缓存的 config.identity，没有就问 /api/me；harness 从加入绑定里认（修法命令按档给）。
+ * 身份以 /api/me 的权威答复为准（#997）：本地 config.identity 只是缓存——config 里是旧身份时验证帧会
+ * @ 错人、harness 回退 other、修法命令不准。缓存与权威不一致时打印提示；/api/me 不可达才退回缓存。
+ * harness 从加入绑定里认（修法命令按档给）。
  */
+export async function resolveVerifyIdentity(
+  cfg: { server: string; token: string },
+  deps: { cached: () => string | null; fetchMe: (server: string, token: string) => Promise<{ name: string }>; warn: (line: string) => void } = {
+    cached: () => readConfig()?.identity?.name ?? null,
+    fetchMe: async (server, token) => fetchMe(server, token),
+    warn: (line) => console.error(line),
+  },
+): Promise<{ identity: string; source: "server" | "cache" }> {
+  const cachedRaw = deps.cached();
+  const cached = cachedRaw === null || cachedRaw === "" ? null : cachedRaw;
+  let identity: string;
+  try {
+    identity = (await deps.fetchMe(cfg.server, cfg.token)).name;
+  } catch (e) {
+    if (cached === null) throw e;
+    const message = e instanceof Error ? e.message : String(e);
+    deps.warn(`warn: /api/me 不可达（${message}），暂以本地缓存身份 ${cached} 验证；结果可能不准`);
+    return { identity: cached, source: "cache" };
+  }
+  if (cached !== null && cached !== identity) {
+    deps.warn(`note: 本地 config 缓存的身份 ${cached} 与服务端登记的 ${identity} 不一致，以服务端为准（party whoami 可刷新缓存）`);
+  }
+  return { identity, source: "server" };
+}
+
 async function runVerify(channelPositional: string | undefined, flags: ReturnType<typeof parseArgs>["flags"]): Promise<number> {
   const unknown = unknownFlagError(flags, WAKE_FLAGS);
   if (unknown !== null) {
@@ -520,8 +549,7 @@ async function runVerify(channelPositional: string | undefined, flags: ReturnTyp
   }
   const { verifyWakeRoundTrip, formatWakeVerifyStep, DEFAULT_WAKE_VERIFY_TIMEOUT_MS } = await import("../onboarding/verify-wake");
   try {
-    let identity = readConfig()?.identity?.name ?? null;
-    if (identity === null || identity === "") identity = (await fetchMe(cfg.server, cfg.token)).name;
+    const { identity, source: identitySource } = await resolveVerifyIdentity(cfg);
     const bindings = readJoinBindings(joinBindingsPath(agentpartyHome()));
     const bound = bindings.find((b) => b.channel === channel && b.identity === identity && b.harness !== "other");
     const harness = bound?.harness ?? "other";
@@ -532,6 +560,7 @@ async function runVerify(channelPositional: string | undefined, flags: ReturnTyp
         type: "wake_verify",
         channel,
         identity,
+        identity_source: identitySource,
         harness,
         ok: result.ok,
         elapsed_ms: result.elapsedMs,

--- a/cli/src/commands/wake.ts
+++ b/cli/src/commands/wake.ts
@@ -1,5 +1,6 @@
 // party wake test — prove mention/wake/resume as separate phases.
 import { autoWakeReachable, EXIT_TIMEOUT, type MsgFrame, type PresenceEntry, type WakeDelivery, type WakeKind } from "@agentparty/shared";
+import { stripTerminalControls } from "../format";
 import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
 import { agentpartyHome, readConfig, resolveChannel } from "../config";
 import { joinBindingsPath, readJoinBindings } from "../join-binding";
@@ -508,11 +509,12 @@ export async function resolveVerifyIdentity(
   } catch (e) {
     if (cached === null) throw e;
     const message = e instanceof Error ? e.message : String(e);
-    deps.warn(`warn: /api/me 不可达（${message}），暂以本地缓存身份 ${cached} 验证；结果可能不准`);
+    // 错误消息与身份名来自网络/远端，写终端前剥控制字符（CWE-150）；返回值仍是原始身份，验证帧要用原值。
+    deps.warn(stripTerminalControls(`warn: /api/me 不可达（${message}），暂以本地缓存身份 ${cached} 验证；结果可能不准`));
     return { identity: cached, source: "cache" };
   }
   if (cached !== null && cached !== identity) {
-    deps.warn(`note: 本地 config 缓存的身份 ${cached} 与服务端登记的 ${identity} 不一致，以服务端为准（party whoami 可刷新缓存）`);
+    deps.warn(stripTerminalControls(`note: 本地 config 缓存的身份 ${cached} 与服务端登记的 ${identity} 不一致，以服务端为准（party whoami 可刷新缓存）`));
   }
   return { identity, source: "server" };
 }

--- a/cli/src/onboarding/verify-wake.ts
+++ b/cli/src/onboarding/verify-wake.ts
@@ -19,6 +19,7 @@ import { deliveryRecoveryJournalPath } from "../delivery-recovery-journal";
 import { readHealthCache } from "../health-cache";
 import { mentionWakeClaimDir, mentionWakeClaimKey } from "../mention-wake-claim";
 import { runWakeProbe, type WakeProbeOptions, type WakeTestFrame } from "../commands/wake";
+import { RestError } from "../rest";
 
 export type WakeVerifyLayer = "server_delivery" | "local_listener" | "model_reply";
 export type WakeVerifyHarness = "claude" | "codex" | "other";
@@ -169,10 +170,12 @@ export function classifyWakeVerify(
     return { ok: true, detail: `@${identity} ping → ${fmtSec(elapsedMs)} 收到回执 ✓（${via} #${resumed.seq}）` };
   }
   if (frame.result === "wake_pending") {
+    // #997：wake_pending 理论上必带 seq（探针已发出），但判层是纯函数、输入来自网络帧——seq 为 null 时不拼 "#null"。
+    const pendingSeq = frame.phases.mention_delivered.seq;
     return {
       ok: true,
       detail:
-        `@${identity} ping → ${fmtSec(elapsedMs)} 收到回执 ✓（runner 已接手 #${frame.phases.mention_delivered.seq}，` +
+        `@${identity} ping → ${fmtSec(elapsedMs)} 收到回执 ✓（runner 已接手${pendingSeq === null ? "" : ` #${pendingSeq}`}，` +
         "回帖待定——headless runner 处理一条要数分钟）",
     };
   }
@@ -232,6 +235,15 @@ export function classifyWakeVerify(
   };
 }
 
+/** 限频错误体里的 retry_after_ms → 整秒（向上取整，至少 1s）；体不合形状为 null。 */
+export function wakeVerifyRetryAfterSec(body: unknown): number | null {
+  if (typeof body !== "object" || body === null) return null;
+  const err = (body as { error?: unknown }).error;
+  if (typeof err !== "object" || err === null) return null;
+  const ms = (err as { retry_after_ms?: unknown }).retry_after_ms;
+  return typeof ms === "number" && Number.isFinite(ms) ? Math.max(1, Math.ceil(ms / 1000)) : null;
+}
+
 export const defaultVerifyWakeDeps: VerifyWakeDeps = {
   probe: runWakeProbe,
   localEvidence: readWakeLocalEvidence,
@@ -261,9 +273,23 @@ export async function verifyWakeRoundTrip(
     });
   } catch (e) {
     const message = e instanceof Error ? e.message : String(e);
+    const elapsedMs = deps.now() - startedAt;
+    // #997：服务端按发送者限频验证帧（同一身份 30s 一条）——不是三层里的任何一层，也不是熔断；说清等多久。
+    if (e instanceof RestError && e.code === "wake_verify_rate_limited") {
+      const waitSec = wakeVerifyRetryAfterSec(e.body);
+      return {
+        ok: false,
+        elapsedMs,
+        detail: `✗ 验证帧被服务端限频：同一身份 30s 内只能发一条${waitSec === null ? "" : `，${waitSec}s 后可再发`}`,
+        fix: `${waitSec === null ? "稍等片刻" : `sleep ${waitSec}`} && party wake verify ${opts.channel}`,
+        seq: null,
+        probe: null,
+        local: null,
+      };
+    }
     return {
       ok: false,
-      elapsedMs: deps.now() - startedAt,
+      elapsedMs,
       detail: `✗ 验证帧没发出去：${message}`,
       fix: /loop.guard/i.test(message) ? `party channel reset-guard ${opts.channel}   （频道已熔断，@ 现在到不了任何 agent）` : "party doctor",
       seq: null,

--- a/cli/src/onboarding/verify-wake.ts
+++ b/cli/src/onboarding/verify-wake.ts
@@ -281,7 +281,8 @@ export async function verifyWakeRoundTrip(
         ok: false,
         elapsedMs,
         detail: `✗ 验证帧被服务端限频：同一身份 30s 内只能发一条${waitSec === null ? "" : `，${waitSec}s 后可再发`}`,
-        fix: `${waitSec === null ? "稍等片刻" : `sleep ${waitSec}`} && party wake verify ${opts.channel}`,
+        // 修法必须是能直接跑的命令：没拿到重试时间就只给验证命令本身，别拼一个不存在的「稍等片刻」进 shell。
+        fix: waitSec === null ? `party wake verify ${opts.channel}` : `sleep ${waitSec} && party wake verify ${opts.channel}`,
         seq: null,
         probe: null,
         local: null,

--- a/cli/test/verify-wake.test.ts
+++ b/cli/test/verify-wake.test.ts
@@ -150,7 +150,8 @@ describe("服务端限频（#997）", () => {
     const r = await verifyWakeRoundTrip({ server: SERVER, token: TOKEN, channel: CHANNEL, identity: ME }, deps(e));
     expect(r.ok).toBe(false);
     expect(r.detail).toBe("✗ 验证帧被服务端限频：同一身份 30s 内只能发一条");
-    expect(r.fix).toBe(`稍等片刻 && party wake verify ${CHANNEL}`);
+    // 没有 retry_after 时修法只能是可执行的验证命令本身（coderabbit on #999：`稍等片刻 && …` 进 shell 会先炸）。
+    expect(r.fix).toBe(`party wake verify ${CHANNEL}`);
   });
 
   test("wakeVerifyRetryAfterSec：向上取整、至少 1s、形状不对为 null", () => {
@@ -187,6 +188,19 @@ describe("身份以 /api/me 为准，config 只是缓存（#997）", () => {
     expect(warned[0]).toContain("stale-me");
     expect(warned[0]).toContain(ME);
     expect(warned[0]).toContain("以服务端为准");
+  });
+
+  // coderabbit on #999（CWE-150）：/api/me 的 name 与网络错误消息来自远端，写 stderr 前必须剥终端控制字符；
+  // 但返回给验证帧用的身份值保持原样（那是要精确匹配的原值，不是显示用）。
+  test("远端身份名 / 错误消息含终端控制字符：提示行剥掉，返回值不动", async () => {
+    const evil = "me\u001b]0;pwned\u0007\u001b[31m";
+    const { deps: d, warned } = idDeps("stale-me", evil);
+    await expect(resolveVerifyIdentity(cfg, d)).resolves.toEqual({ identity: evil, source: "server" });
+    expect(warned).toHaveLength(1);
+    expect({ hasEsc: warned[0]!.includes("\u001b"), hasBel: warned[0]!.includes("\u0007") }).toEqual({ hasEsc: false, hasBel: false });
+    const err = idDeps("cached-me", new Error("boom\u001b[2J\u001b]52;c;evil\u0007"));
+    await expect(resolveVerifyIdentity(cfg, err.deps)).resolves.toEqual({ identity: "cached-me", source: "cache" });
+    expect(err.warned[0]!.includes("\u001b")).toBe(false);
   });
 
   test("缓存一致 / 无缓存：取权威身份，不提示", async () => {

--- a/cli/test/verify-wake.test.ts
+++ b/cli/test/verify-wake.test.ts
@@ -16,9 +16,12 @@ import {
   readWakeLocalEvidence,
   verifyWakeBody,
   verifyWakeRoundTrip,
+  wakeVerifyRetryAfterSec,
   type VerifyWakeDeps,
   type WakeLocalEvidence,
 } from "../src/onboarding/verify-wake";
+import { resolveVerifyIdentity } from "../src/commands/wake";
+import { RestError } from "../src/rest";
 import { serveWakeAlreadyAdvertised, serveWakeNote } from "../src/commands/serve";
 import type { WakeTestFrame } from "../src/commands/wake";
 import type { ResolvedAuthDetailed } from "../src/oidc-cli";
@@ -110,6 +113,102 @@ describe("往返成功 ⇒ 第 4 步过（#990）", () => {
     expect(r.ok).toBe(true);
     expect(r.detail).toContain("收到回执 ✓");
     expect(r.detail).toContain("runner 已接手 #42");
+  });
+
+  test("wake_pending 但 seq 为 null（#997 防御）：仍算过，文案不拼 #null / #undefined", () => {
+    const v = classify(
+      frame({
+        result: "wake_pending",
+        phases: {
+          mention_delivered: { ok: true, seq: null, evidence: "accepted" },
+          wake_invoked: { ok: true, status: "invoked", adapter: "serve", evidence: "processing" },
+        },
+      }),
+      noLocal,
+    );
+    expect(v.ok).toBe(true);
+    expect(v.detail).toContain("runner 已接手，");
+    expect(v.detail).not.toMatch(/#(null|undefined)/);
+  });
+});
+
+describe("服务端限频（#997）", () => {
+  test("wake_verify_rate_limited：不是三层里的任何一层，说清等多久，修法带 sleep N", async () => {
+    const e = new RestError(429, "wake_verify_rate_limited", "already sent a wake-verify frame", {
+      error: { code: "wake_verify_rate_limited", message: "x", retry_after_ms: 12_400, retry_at: 1 },
+    });
+    const r = await verifyWakeRoundTrip({ server: SERVER, token: TOKEN, channel: CHANNEL, identity: ME }, deps(e));
+    expect(r.ok).toBe(false);
+    expect(r.layer).toBeUndefined();
+    expect(r.seq).toBeNull();
+    expect(r.detail).toBe("✗ 验证帧被服务端限频：同一身份 30s 内只能发一条，13s 后可再发");
+    expect(r.fix).toBe(`sleep 13 && party wake verify ${CHANNEL}`);
+  });
+
+  test("错误体缺 retry_after_ms：不编秒数", async () => {
+    const e = new RestError(429, "wake_verify_rate_limited", "limited", { error: { code: "wake_verify_rate_limited" } });
+    const r = await verifyWakeRoundTrip({ server: SERVER, token: TOKEN, channel: CHANNEL, identity: ME }, deps(e));
+    expect(r.ok).toBe(false);
+    expect(r.detail).toBe("✗ 验证帧被服务端限频：同一身份 30s 内只能发一条");
+    expect(r.fix).toBe(`稍等片刻 && party wake verify ${CHANNEL}`);
+  });
+
+  test("wakeVerifyRetryAfterSec：向上取整、至少 1s、形状不对为 null", () => {
+    expect(wakeVerifyRetryAfterSec({ error: { retry_after_ms: 12_400 } })).toBe(13);
+    expect(wakeVerifyRetryAfterSec({ error: { retry_after_ms: 200 } })).toBe(1);
+    expect(wakeVerifyRetryAfterSec({ error: { retry_after_ms: "soon" } })).toBeNull();
+    expect(wakeVerifyRetryAfterSec({ error: {} })).toBeNull();
+    expect(wakeVerifyRetryAfterSec(null)).toBeNull();
+    expect(wakeVerifyRetryAfterSec("nope")).toBeNull();
+  });
+});
+
+describe("身份以 /api/me 为准，config 只是缓存（#997）", () => {
+  const cfg = { server: SERVER, token: TOKEN };
+  function idDeps(cached: string | null, me: string | Error) {
+    const warned: string[] = [];
+    return {
+      warned,
+      deps: {
+        cached: () => cached,
+        fetchMe: async () => {
+          if (me instanceof Error) throw me;
+          return { name: me };
+        },
+        warn: (line: string) => warned.push(line),
+      },
+    };
+  }
+
+  test("缓存与权威不一致：取权威身份，打印一条提示", async () => {
+    const { deps: d, warned } = idDeps("stale-me", ME);
+    await expect(resolveVerifyIdentity(cfg, d)).resolves.toEqual({ identity: ME, source: "server" });
+    expect(warned).toHaveLength(1);
+    expect(warned[0]).toContain("stale-me");
+    expect(warned[0]).toContain(ME);
+    expect(warned[0]).toContain("以服务端为准");
+  });
+
+  test("缓存一致 / 无缓存：取权威身份，不提示", async () => {
+    const same = idDeps(ME, ME);
+    await expect(resolveVerifyIdentity(cfg, same.deps)).resolves.toEqual({ identity: ME, source: "server" });
+    expect(same.warned).toEqual([]);
+    const none = idDeps(null, ME);
+    await expect(resolveVerifyIdentity(cfg, none.deps)).resolves.toEqual({ identity: ME, source: "server" });
+    expect(none.warned).toEqual([]);
+    const empty = idDeps("", ME);
+    await expect(resolveVerifyIdentity(cfg, empty.deps)).resolves.toEqual({ identity: ME, source: "server" });
+    expect(empty.warned).toEqual([]);
+  });
+
+  test("/api/me 不可达：有缓存才退回缓存并警告；没缓存就把错误抛出去", async () => {
+    const fallback = idDeps("cached-me", new Error("fetch failed"));
+    await expect(resolveVerifyIdentity(cfg, fallback.deps)).resolves.toEqual({ identity: "cached-me", source: "cache" });
+    expect(fallback.warned).toHaveLength(1);
+    expect(fallback.warned[0]).toContain("fetch failed");
+    expect(fallback.warned[0]).toContain("cached-me");
+    const dead = idDeps(null, new Error("fetch failed"));
+    await expect(resolveVerifyIdentity(cfg, dead.deps)).rejects.toThrow("fetch failed");
   });
 });
 
@@ -311,15 +410,17 @@ describe("party wake verify（#990）", () => {
     return { code, stdout, stderr };
   }
 
-  function writeCfg(server: string) {
+  function writeCfg(server: string, cachedName: string = ME) {
     mkdirSync(home, { recursive: true });
     writeFileSync(join(home, "config.json"), JSON.stringify({
       server,
       token: TOKEN,
-      identity: { name: ME, email: null, kind: "agent", role: "agent", owner: null, channel_scope: null, verified_at: 0 },
+      identity: { name: cachedName, email: null, kind: "agent", role: "agent", owner: null, channel_scope: null, verified_at: 0 },
     }));
   }
 
+  // #997：身份以 /api/me 为准。
+  const me = () => Response.json({ name: ME, email: null, kind: "agent", role: "agent", owner: null, channel_scope: null, verified_at: 0 });
   const presence = () => Response.json({
     presence: [{ name: ME, state: "waiting", note: null, ts: Date.now(), last_seen: Date.now(), residency: "supervised", wake: { kind: "serve" } }],
   });
@@ -327,6 +428,7 @@ describe("party wake verify（#990）", () => {
 
   test("往返成功：以本身份发验证帧（[wake-verify] + 只 @ 自己），收到回帖 ⇒ exit 0，印第 4 步那一行", async () => {
     mock = startRestMock((req) => {
+      if (req.method === "GET" && req.path === "/api/me") return me();
       if (req.method === "GET" && req.path === `/api/channels/${CHANNEL}/presence`) return presence();
       if (req.method === "POST" && req.path === `/api/channels/${CHANNEL}/messages`) return Response.json({ seq: 5 });
       if (req.method === "GET" && req.path === `/api/channels/${CHANNEL}/wake-deliveries`) {
@@ -352,6 +454,7 @@ describe("party wake verify（#990）", () => {
 
   test("超时：服务端已广播、这台机器没有武装监听 ⇒ exit 2，✗ 行说清 local_listener 与修法；--json 带 layer", async () => {
     mock = startRestMock((req) => {
+      if (req.method === "GET" && req.path === "/api/me") return me();
       if (req.method === "GET" && req.path === `/api/channels/${CHANNEL}/presence`) return presence();
       if (req.method === "POST" && req.path === `/api/channels/${CHANNEL}/messages`) return Response.json({ seq: 7 });
       if (req.method === "GET" && req.path === `/api/channels/${CHANNEL}/wake-deliveries`) {
@@ -369,13 +472,14 @@ describe("party wake verify（#990）", () => {
     const json = await runCli(["wake", "verify", CHANNEL, "--timeout", "1", "--json"]);
     expect(json.code).toBe(2);
     const out = JSON.parse(json.stdout.trim());
-    expect(out).toMatchObject({ type: "wake_verify", channel: CHANNEL, identity: ME, ok: false, layer: "local_listener", seq: 7 });
+    expect(out).toMatchObject({ type: "wake_verify", channel: CHANNEL, identity: ME, identity_source: "server", ok: false, layer: "local_listener", seq: 7 });
     expect(out.probe.type).toBe("wake_test");
     expect(out.local.listener.live).toBeNull();
   });
 
   test("超时：服务端账本没有这条 @ 的行 ⇒ server_delivery（与本机层文案不同）", async () => {
     mock = startRestMock((req) => {
+      if (req.method === "GET" && req.path === "/api/me") return me();
       if (req.method === "GET" && req.path === `/api/channels/${CHANNEL}/presence`) return presence();
       if (req.method === "POST" && req.path === `/api/channels/${CHANNEL}/messages`) return Response.json({ seq: 8 });
       if (req.method === "GET" && req.path === `/api/channels/${CHANNEL}/wake-deliveries`) return Response.json({ deliveries: [] });
@@ -388,6 +492,72 @@ describe("party wake verify（#990）", () => {
     const out = JSON.parse(r.stdout.trim());
     expect(out.layer).toBe("server_delivery");
     expect(out.detail).toContain("服务端未投递");
+  });
+
+  test("config 缓存的是旧身份：验证帧仍 @ /api/me 的权威身份，stderr 提示不一致（#997）", async () => {
+    mock = startRestMock((req) => {
+      if (req.method === "GET" && req.path === "/api/me") return me();
+      if (req.method === "GET" && req.path === `/api/channels/${CHANNEL}/presence`) return presence();
+      if (req.method === "POST" && req.path === `/api/channels/${CHANNEL}/messages`) return Response.json({ seq: 9 });
+      if (req.method === "GET" && req.path === `/api/channels/${CHANNEL}/wake-deliveries`) {
+        return Response.json({ deliveries: [{ mention_seq: 9, target_name: ME, webhook_name: "", adapter_kind: "serve", attempt: 1, result: "broadcast", http_status: null, error: null, attempted_at: 1, ack_seq: null, resume_seq: null }] });
+      }
+      if (req.method === "GET" && req.path === `/api/channels/${CHANNEL}/messages`) {
+        return Response.json({ messages: [{ type: "message", seq: 10, sender: { name: ME, kind: "agent" }, kind: "message", body: "pong", mentions: [], reply_to: 9, ts: 1 }] });
+      }
+      return undefined;
+    });
+    writeCfg(mock.url, "stale-me");
+    const r = await runCli(["wake", "verify", CHANNEL, "--timeout", "2", "--json"]);
+    expect(r.code).toBe(0);
+    expect(r.stderr).toContain("stale-me");
+    expect(r.stderr).toContain("以服务端为准");
+    const posts = reqsOf(mock, "POST", `/api/channels/${CHANNEL}/messages`);
+    expect(posts).toHaveLength(1);
+    expect((posts[0]!.body as { mentions: string[] }).mentions).toEqual([ME]);
+    expect((posts[0]!.body as { body: string }).body).toContain(`@${ME} ping`);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out).toMatchObject({ type: "wake_verify", identity: ME, identity_source: "server", ok: true });
+  });
+
+  test("/api/me 不可达：退回 config 缓存身份继续验证，stderr 警告（#997）", async () => {
+    mock = startRestMock((req) => {
+      if (req.method === "GET" && req.path === "/api/me") return Response.json({ error: { code: "unavailable", message: "directory down" } }, { status: 503 });
+      if (req.method === "GET" && req.path === `/api/channels/${CHANNEL}/presence`) return presence();
+      if (req.method === "POST" && req.path === `/api/channels/${CHANNEL}/messages`) return Response.json({ seq: 11 });
+      if (req.method === "GET" && req.path === `/api/channels/${CHANNEL}/wake-deliveries`) {
+        return Response.json({ deliveries: [{ mention_seq: 11, target_name: ME, webhook_name: "", adapter_kind: "serve", attempt: 1, result: "broadcast", http_status: null, error: null, attempted_at: 1, ack_seq: null, resume_seq: null }] });
+      }
+      if (req.method === "GET" && req.path === `/api/channels/${CHANNEL}/messages`) {
+        return Response.json({ messages: [{ type: "message", seq: 12, sender: { name: ME, kind: "agent" }, kind: "message", body: "pong", mentions: [], reply_to: 11, ts: 1 }] });
+      }
+      return undefined;
+    });
+    writeCfg(mock.url);
+    const r = await runCli(["wake", "verify", CHANNEL, "--timeout", "2", "--json"]);
+    expect(r.code).toBe(0);
+    expect(r.stderr).toContain("/api/me 不可达");
+    const out = JSON.parse(r.stdout.trim());
+    expect(out).toMatchObject({ identity: ME, identity_source: "cache", ok: true });
+  });
+
+  test("服务端限频：exit 2，说清等多久与修法（#997）", async () => {
+    mock = startRestMock((req) => {
+      if (req.method === "GET" && req.path === "/api/me") return me();
+      if (req.method === "GET" && req.path === `/api/channels/${CHANNEL}/presence`) return presence();
+      if (req.method === "POST" && req.path === `/api/channels/${CHANNEL}/messages`) {
+        return Response.json(
+          { error: { code: "wake_verify_rate_limited", message: "limited", retry_after_ms: 21_500, retry_at: Date.now() + 21_500 } },
+          { status: 429 },
+        );
+      }
+      return undefined;
+    });
+    writeCfg(mock.url);
+    const r = await runCli(["wake", "verify", CHANNEL, "--timeout", "2"]);
+    expect(r.code).toBe(2);
+    expect(r.stdout).toContain("第 4 步  真发一条 @ 验证 · ✗ 验证帧被服务端限频：同一身份 30s 内只能发一条，22s 后可再发");
+    expect(r.stdout).toContain(`→ 修法：sleep 22 && party wake verify ${CHANNEL}`);
   });
 
   test("用法错误：verify 不收目标位置参数", async () => {

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -428,6 +428,14 @@ export interface TaskRecord {
  */
 export const WAKE_VERIFY_PREFIX = "[wake-verify]";
 
+/**
+ * 验证帧的服务端限频窗口（#997）：同一 (channel, sender) 在这个窗口内最多放行一条验证帧。
+ * 验证帧绕过自 @ 过滤、又不计 loop guard，等于一条不受熔断约束的写入通道（刷历史 / directed delivery /
+ * ledger）——限频是它唯一的闸，独立于 loop guard，熔断中照样拒。超出返回 `wake_verify_rate_limited`，
+ * 并带 retry_after_ms / retry_at 告诉调用方下次可发的时间。
+ */
+export const WAKE_VERIFY_MIN_INTERVAL_MS = 30_000;
+
 export function isWakeVerifyFrame(frame: {
   kind: MessageKind;
   body?: string | null;
@@ -652,6 +660,8 @@ export type ErrorCode =
   | "too_large"
   | "loop_guard"
   | "workflow_guard"
+  // #997：接入验证帧被按发送者限频（WAKE_VERIFY_MIN_INTERVAL_MS）；错误体带 retry_after_ms / retry_at。
+  | "wake_verify_rate_limited"
   | "archived"
   | "quota_exceeded"
   | "channel_full"
@@ -2559,6 +2569,9 @@ export interface ErrorFrame {
   type: "error";
   code: ErrorCode;
   message: string;
+  /** #997：限频类错误（wake_verify_rate_limited）附带的下次可发时间——距现在的毫秒数与绝对时间戳。 */
+  retry_after_ms?: number;
+  retry_at?: number;
 }
 
 export interface PongFrame {

--- a/worker/src/do.ts
+++ b/worker/src/do.ts
@@ -8,6 +8,7 @@ import {
   LOOP_GUARD_AGENT_PARTY_N,
   LOOP_GUARD_N,
   LOOP_GUARD_PARTY_N,
+  WAKE_VERIFY_MIN_INTERVAL_MS,
   isWakeVerifyFrame,
   MAX_ALSO_RESOLVES,
   MAX_WEBHOOKS_PER_CHANNEL,
@@ -275,8 +276,30 @@ type SendSuccessOutcome =
 
 type SendOutcome =
   | SendSuccessOutcome
-  | { ok: false; code: ErrorCode; message: string };
+  | {
+      ok: false;
+      code: ErrorCode;
+      message: string;
+      /** #997：限频类拒绝附带的下次可发时间（距现在毫秒 / 绝对时间戳），REST 与 WS 错误体原样带出。 */
+      retryAfterMs?: number;
+      retryAt?: number;
+    };
 type SendErrorOutcome = Extract<SendOutcome, { ok: false }>;
+
+/** 拒发结果 → 客户端错误体（REST `error` 对象 / WS error 帧字段），限频类带 retry_after_ms / retry_at。 */
+function sendErrorBody(out: SendErrorOutcome): {
+  code: ErrorCode;
+  message: string;
+  retry_after_ms?: number;
+  retry_at?: number;
+} {
+  return {
+    code: out.code,
+    message: out.message,
+    ...(out.retryAfterMs === undefined ? {} : { retry_after_ms: out.retryAfterMs }),
+    ...(out.retryAt === undefined ? {} : { retry_at: out.retryAt }),
+  };
+}
 
 interface ResolvedMentionFrame {
   frame: SendFrame;
@@ -314,6 +337,7 @@ export const ERROR_STATUS: Record<ErrorCode, number> = {
   too_large: 413,
   loop_guard: 409,
   workflow_guard: 409,
+  wake_verify_rate_limited: 429,
   archived: 410,
   quota_exceeded: 403,
   channel_full: 429,
@@ -3104,7 +3128,7 @@ export class ChannelDO extends Server<Env> {
         { countRate: false, sessionId: connection.id },
       );
       if (!out.ok) {
-        this.sendFrame(connection, { type: "error", code: out.code, message: out.message });
+        this.sendFrame(connection, { type: "error", ...sendErrorBody(out) });
         return;
       }
       // 幂等去重命中（#98）：只回 sent（原 seq），不重复广播/唤醒。ws 发送目前不带 key，故常态为 false。
@@ -4963,13 +4987,23 @@ export class ChannelDO extends Server<Env> {
   // #990：唯一例外是接入验证帧（isWakeVerifyFrame：`[wake-verify]` 前缀 + mentions 只含自己）——它的存在理由
   // 就是让本身份走一遍真实唤醒链，所以传了 frame 且判定为验证帧时，自 @ **就是**召唤。不传 frame 的调用点
   // 保持 #963 原判（保守：宁可不唤醒）。
+  //
+  // #997：验证帧只对**已登记的 agent 身份**成立——帧带 sender.kind 时，非 agent（人类 / 只读）发的
+  // `[wake-verify]` 自 @ 仍按普通自 @ 处理；发送时的 owner 绑定核对在 routeMentionsForDelivery（有 D1 目录）。
   private isSelfMention(
     senderName: string,
     target: string,
-    frame?: { kind: MessageKind; body?: string | null; mentions?: readonly string[] | null },
+    frame?: {
+      kind: MessageKind;
+      body?: string | null;
+      mentions?: readonly string[] | null;
+      sender?: { kind?: SenderKind };
+    },
   ): boolean {
     if (mentionMatchKey(senderName) !== mentionMatchKey(target)) return false;
-    if (frame !== undefined && isWakeVerifyFrame({ ...frame, sender: { name: senderName } })) return false;
+    if (frame === undefined) return true;
+    if (frame.sender?.kind !== undefined && frame.sender.kind !== "agent") return true;
+    if (isWakeVerifyFrame({ ...frame, sender: { name: senderName } })) return false;
     return true;
   }
 
@@ -6130,6 +6164,7 @@ export class ChannelDO extends Server<Env> {
               reply_to: row.reply_to === null || row.reply_to === undefined ? null : Number(row.reply_to),
             },
             identity.name,
+            { kind: identity.kind, principal: this.identityDeliveryPrincipal(identity) },
           );
           if ("ok" in routed) {
             return Response.json(
@@ -6378,7 +6413,7 @@ export class ChannelDO extends Server<Env> {
         { countRate: true },
       );
       if (!out.ok) {
-        return Response.json({ error: { code: out.code, message: out.message } }, { status: ERROR_STATUS[out.code] });
+        return Response.json({ error: sendErrorBody(out) }, { status: ERROR_STATUS[out.code] });
       }
       // 同一次超越是一个修订事件：新旧两行共用一个 rev_seq
       const supersedeRev = this.nextRevSeq();
@@ -7202,10 +7237,7 @@ export class ChannelDO extends Server<Env> {
         ...(expectedDecisionResponderOwner === undefined ? {} : { expectedDecisionResponderOwner }),
       });
       if (!out.ok) {
-        return Response.json(
-          { error: { code: out.code, message: out.message } },
-          { status: ERROR_STATUS[out.code] },
-        );
+        return Response.json({ error: sendErrorBody(out) }, { status: ERROR_STATUS[out.code] });
       }
       // 幂等去重命中（#98）：首发时已广播/唤醒过，重发只回原 seq，绝不重复副作用
       if (!out.deduped) {
@@ -8506,6 +8538,12 @@ export class ChannelDO extends Server<Env> {
   private async routeMentionsForDelivery(
     frame: SendFrame,
     senderName: string,
+    /**
+     * #997：发送者的登记身份（kind + 创建时 principal）。验证帧把自己列为投递目标的唯一条件是：
+     * 发送者是 agent，且 D1 目录里该名字当前登记的 principal 就是发送者自己——名字被别的账号占用 /
+     * 登记不上时，验证帧退化为普通自 @（不建 delivery、不免 loop guard）。不传 = 不放行任何自 @。
+     */
+    senderBinding?: { kind: SenderKind; principal: string },
   ): Promise<RoutedMentionFrame | SendErrorOutcome> {
     const mentionResolution = await this.resolveMentions(frame);
     if ("ok" in mentionResolution) return mentionResolution;
@@ -8558,13 +8596,18 @@ export class ChannelDO extends Server<Env> {
         (frame.mentions ?? []).filter((target) => !invalidAutoKeys.has(mentionMatchKey(target))),
       );
     }
+    const senderKey = mentionMatchKey(senderName);
+    const senderFrame = senderBinding === undefined ? frame : { ...frame, sender: { kind: senderBinding.kind } };
     return {
       frame,
       // #963：发信人自己不入 deliveryTargets——自 @ 不建 directed delivery，否则每个同身份 runtime
       // 都会把这条「提到自己」的回帖当成一次新召唤。mentions 数组保持原样（正文高亮/历史不受影响）。
+      // #997：验证帧（唯一放行的自 @）还要求目录登记的 principal 与发送者一致，见 senderBinding。
       deliveryTargets: candidateDeliveryTargets.filter((target) =>
-        !this.isSelfMention(senderName, target, frame) &&
+        !this.isSelfMention(senderName, target, senderFrame) &&
         Object.prototype.hasOwnProperty.call(ownerLookup, target) &&
+        (mentionMatchKey(target) !== senderKey ||
+          (senderBinding !== undefined && ownerLookup[target] === senderBinding.principal)) &&
         (expectedAutoOwners.get(mentionMatchKey(target)) === undefined || !invalidAutoKeys.has(mentionMatchKey(target)))
       ),
       deliveryTargetOwners: ownerLookup,
@@ -8747,7 +8790,10 @@ export class ChannelDO extends Server<Env> {
     if (byteLength(payload) > BODY_LIMIT) {
       return { ok: false, code: "too_large", message: `body exceeds ${BODY_LIMIT} bytes` };
     }
-    const mentionRouting = await this.routeMentionsForDelivery(frame, identity.name);
+    const mentionRouting = await this.routeMentionsForDelivery(frame, identity.name, {
+      kind: identity.kind,
+      principal: this.identityDeliveryPrincipal(identity),
+    });
     if ("ok" in mentionRouting) return mentionRouting;
     frame = mentionRouting.frame;
     const { deliveryTargets, deliveryTargetOwners } = mentionRouting;
@@ -8768,8 +8814,20 @@ export class ChannelDO extends Server<Env> {
     const loopGuard = identity.kind === "agent" && frame.kind === "message" ? this.loopGuardMessage(identity.name) : null;
     // #990：接入验证帧是探针不是对话——照样过 guard 的闸（频道熔断时 @ 本来就到不了它，拒掉是真话），
     // 但**不计入** streak / fair-share：一台机器反复跑接入引导不该把频道的名额吃光（#959 同一类教训）。
+    // #997：「验证帧」的完整判据 = 帧形状（isWakeVerifyFrame）+ 发送者是已登记 agent + mentions 绑定到
+    // 发送者自己的登记身份（routeMentionsForDelivery 已用 D1 目录核过 principal，核不过就不会把自己列入
+    // deliveryTargets）。三者缺一，就按普通自 @ 处理：不免 guard、不限频、不建 delivery。
     const verifyProbe =
-      frame.kind === "message" && isWakeVerifyFrame({ ...frame, sender: { name: identity.name } });
+      frame.kind === "message" &&
+      identity.kind === "agent" &&
+      isWakeVerifyFrame({ ...frame, sender: { name: identity.name } }) &&
+      deliveryTargets.some((target) => mentionMatchKey(target) === mentionMatchKey(identity.name));
+    // #997：验证帧按 (channel, sender) 限频——它绕过自 @ 过滤又不计 loop guard，这是它唯一的闸。
+    // 放在 loop guard 之前、独立判定：熔断中也照拒，且不因熔断而放过刷帧。
+    if (verifyProbe) {
+      const limited = this.wakeVerifyRateLimit(identity.name, Date.now());
+      if (limited !== null) return limited;
+    }
     if (loopGuard !== null) {
       this.alertLoopGuard(loopGuard);
       return {
@@ -9103,7 +9161,10 @@ export class ChannelDO extends Server<Env> {
     const workflowGuardFrame = this.applyWorkflowGuardAfterSend(identity, msg, workflowGuard, now);
     if (frame.kind === "message") {
       if (identity.kind === "agent") {
-        if (!verifyProbe) {
+        if (verifyProbe) {
+          // #997：限频窗口从这条被接受的验证帧起算（被拒的不占窗口——熔断解除后立刻重跑验证不该再等 30s）。
+          this.setMeta(this.wakeVerifyAtKey(identity.name), String(now));
+        } else {
           this.setMeta("agent_streak", String(this.agentStreak() + 1));
           this.setMeta(this.agentCountKey(identity.name), String(this.agentCount(identity.name) + 1));
         }
@@ -10196,6 +10257,34 @@ export class ChannelDO extends Server<Env> {
 
   private agentCountKey(name: string): string {
     return `agent_count:${name}`;
+  }
+
+  // #997：验证帧限频状态——与 streak / fair-share 同一形态，落 DO 的 meta 表（key 按发送者分片），
+  // 值是最近一条**被接受**的验证帧的时间戳。不随 clearLoopGuardState 清：限频独立于 loop guard，
+  // 人类发言 / reset-guard 都不该把它归零。
+  private wakeVerifyAtKey(name: string): string {
+    return `wake_verify_at:${name}`;
+  }
+
+  private wakeVerifyRateLimit(name: string, now: number): SendErrorOutcome | null {
+    const raw = this.getMeta(this.wakeVerifyAtKey(name));
+    if (raw === null) return null;
+    const last = Number(raw);
+    if (!Number.isFinite(last)) return null;
+    const retryAt = last + WAKE_VERIFY_MIN_INTERVAL_MS;
+    const retryAfterMs = retryAt - now;
+    if (retryAfterMs <= 0) return null;
+    const windowSec = Math.round(WAKE_VERIFY_MIN_INTERVAL_MS / 1000);
+    const waitSec = Math.max(1, Math.ceil(retryAfterMs / 1000));
+    return {
+      ok: false,
+      code: "wake_verify_rate_limited",
+      message:
+        `${name} already sent a wake-verify frame in this channel within the last ${windowSec}s ` +
+        `(limit: 1 per ${windowSec}s per sender); retry in ${waitSec}s, at ${new Date(retryAt).toISOString()}`,
+      retryAfterMs,
+      retryAt,
+    };
   }
 
   // 熔断实际生效的阈值：显式配置优先，否则回落 normal/party 默认（便于手工修复旧 DO meta）。

--- a/worker/test/wake-verify-frame.spec.ts
+++ b/worker/test/wake-verify-frame.spec.ts
@@ -77,6 +77,11 @@ async function seedGuardCounters(slug: string, agentName: string, count: number,
 async function expireVerifyWindow(slug: string, agentName: string) {
   const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
   await runInDurableObject(stub, async (_instance: ChannelDO, state) => {
+    // 先确认这一行存在：不存在时 UPDATE 影响 0 行会静默"成功"，把测试自己的 bug 伪装成限频没过期。
+    const raw = state.storage.sql
+      .exec("SELECT value FROM meta WHERE key = ?", `wake_verify_at:${agentName}`)
+      .toArray()[0]?.value ?? null;
+    expect(raw).not.toBeNull();
     state.storage.sql.exec(
       "UPDATE meta SET value = CAST(CAST(value AS INTEGER) - ? AS TEXT) WHERE key = ?",
       WAKE_VERIFY_MIN_INTERVAL_MS,

--- a/worker/test/wake-verify-frame.spec.ts
+++ b/worker/test/wake-verify-frame.spec.ts
@@ -5,7 +5,7 @@
 // 同时它是探针不是对话：不计入 loop guard 的 streak / fair-share（反复跑接入引导不该吃光频道名额），
 // 但频道已熔断时照样拒——那时 @ 本来就到不了它，验证失败是真话。
 import { env, runInDurableObject } from "cloudflare:test";
-import { LOOP_GUARD_AGENT_N, LOOP_GUARD_N, WAKE_VERIFY_PREFIX, isWakeVerifyFrame } from "@agentparty/shared";
+import { LOOP_GUARD_AGENT_N, LOOP_GUARD_N, WAKE_VERIFY_MIN_INTERVAL_MS, WAKE_VERIFY_PREFIX, isWakeVerifyFrame } from "@agentparty/shared";
 import { afterEach, beforeAll, describe, expect, it } from "vitest";
 import type { ChannelDO } from "../src/do";
 import { fetchMock } from "./fetch-mock";
@@ -69,6 +69,18 @@ async function seedGuardCounters(slug: string, agentName: string, count: number,
       `agent_count:${agentName}`,
       String(count),
       String(streak),
+    );
+  });
+}
+
+// #997：把该发送者最近一条被接受的验证帧时间戳拨到窗口之外（模拟 30s 过去，不碰 Date.now）。
+async function expireVerifyWindow(slug: string, agentName: string) {
+  const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+  await runInDurableObject(stub, async (_instance: ChannelDO, state) => {
+    state.storage.sql.exec(
+      "UPDATE meta SET value = CAST(CAST(value AS INTEGER) - ? AS TEXT) WHERE key = ?",
+      WAKE_VERIFY_MIN_INTERVAL_MS,
+      `wake_verify_at:${agentName}`,
     );
   });
 }
@@ -149,6 +161,9 @@ describe("验证帧不计 loop guard（issue #990）", () => {
     await seedGuardCounters(slug, agent.name, LOOP_GUARD_AGENT_N - 1);
 
     for (let i = 0; i < 3; i += 1) {
+      // #997：验证帧按发送者 30s 一条限频（见 wake-verify-rate-limit.spec.ts）；这里把上一条的窗口拨到过期，
+      // 让三条都被接受，专门看 guard 计数。
+      if (i > 0) await expireVerifyWindow(slug, agent.name);
       const res = await send(slug, agent.token, `${WAKE_VERIFY_PREFIX} @${agent.name} ping ${i}`, [agent.name]);
       expect(res.status).toBe(200);
     }

--- a/worker/test/wake-verify-rate-limit.spec.ts
+++ b/worker/test/wake-verify-rate-limit.spec.ts
@@ -1,0 +1,300 @@
+// #997：验证帧加固。
+//
+// #990 的验证帧（`[wake-verify]` + mentions 只含自己）绕过自 @ 过滤、又不计 loop guard，等于一条不受熔断
+// 约束的写入通道。这里钉住它唯一的闸：
+//   • 同一 (channel, sender) 在 WAKE_VERIFY_MIN_INTERVAL_MS 内最多放行一条，超出 429 wake_verify_rate_limited，
+//     错误体带 retry_after_ms / retry_at；窗口过了放行；限频独立于 loop guard，熔断中照拒。
+//   • 「验证帧」只对已登记的 agent 身份成立：非 agent 发的同形状帧、mentions 绑定到的登记身份不是发送者本人，
+//     都按普通自 @ 处理（不建 delivery、不落 ledger、不免 guard、不限频）。
+import { env, runInDurableObject } from "cloudflare:test";
+import { LOOP_GUARD_AGENT_N, LOOP_GUARD_N, WAKE_VERIFY_MIN_INTERVAL_MS, WAKE_VERIFY_PREFIX } from "@agentparty/shared";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import type { ChannelDO } from "../src/do";
+import { fetchMock } from "./fetch-mock";
+import { WsClient, api, completeCapabilityHello, createChannel, postMessage, seedToken, uniq } from "./helpers";
+
+async function sha256Hex(input: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(input));
+  return [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+beforeAll(() => {
+  fetchMock.activate();
+  fetchMock.disableNetConnect();
+});
+afterEach(() => fetchMock.assertNoPendingInterceptors());
+
+function send(slug: string, token: string, body: string, mentions: string[], extra: Record<string, unknown> = {}) {
+  return api(`/api/channels/${slug}/messages`, token, {
+    method: "POST",
+    body: JSON.stringify({ kind: "message", body, mentions, reply_to: null, ...extra }),
+  });
+}
+
+function verify(slug: string, token: string, name: string, tag = "") {
+  return send(slug, token, `${WAKE_VERIFY_PREFIX} @${name} ping${tag}`, [name]);
+}
+
+async function deliveryTargets(slug: string): Promise<Array<{ seq: number; target: string }>> {
+  const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+  return runInDurableObject(stub, async (_instance: ChannelDO, state) =>
+    state.storage.sql
+      .exec("SELECT message_seq, target_name FROM directed_deliveries ORDER BY message_seq, target_name")
+      .toArray()
+      .map((row) => ({ seq: Number(row.message_seq), target: String(row.target_name) })),
+  );
+}
+
+async function ledgerRows(slug: string): Promise<Array<{ seq: number; target: string }>> {
+  const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+  return runInDurableObject(stub, async (_instance: ChannelDO, state) =>
+    state.storage.sql
+      .exec("SELECT mention_seq, target_name FROM wake_delivery_ledger ORDER BY id")
+      .toArray()
+      .map((row) => ({ seq: Number(row.mention_seq), target: String(row.target_name) })),
+  );
+}
+
+async function readMeta(slug: string, key: string): Promise<string | null> {
+  const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+  return runInDurableObject(stub, async (_instance: ChannelDO, state) => {
+    const row = state.storage.sql.exec("SELECT value FROM meta WHERE key = ?", key).toArray()[0];
+    return row === undefined ? null : String(row.value);
+  });
+}
+
+async function writeMeta(slug: string, key: string, value: string): Promise<void> {
+  const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+  await runInDurableObject(stub, async (_instance: ChannelDO, state) => {
+    state.storage.sql.exec(
+      "INSERT INTO meta (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+      key,
+      value,
+    );
+  });
+}
+
+/** 把「上一条被接受的验证帧」的时间戳往前拨 ms 毫秒——模拟时间流逝，不碰 Date.now。 */
+async function ageVerifyWindow(slug: string, name: string, ms: number): Promise<void> {
+  const raw = await readMeta(slug, `wake_verify_at:${name}`);
+  expect(raw).not.toBeNull();
+  await writeMeta(slug, `wake_verify_at:${name}`, String(Number(raw) - ms));
+}
+
+async function guardCounters(slug: string, agentName: string): Promise<{ streak: number; count: number }> {
+  return {
+    streak: Number((await readMeta(slug, "agent_streak")) ?? "0"),
+    count: Number((await readMeta(slug, `agent_count:${agentName}`)) ?? "0"),
+  };
+}
+
+async function enableLoopGuard(slug: string, token: string, limit: number): Promise<void> {
+  const res = await api(`/api/channels/${slug}/loop-guard`, token, {
+    method: "PUT",
+    body: JSON.stringify({ enabled: true, limit }),
+  });
+  expect(res.status).toBe(200);
+}
+
+async function tripLoopGuard(slug: string, agentName: string): Promise<void> {
+  await writeMeta(slug, `agent_count:${agentName}`, String(LOOP_GUARD_AGENT_N));
+  await writeMeta(slug, "agent_streak", String(LOOP_GUARD_AGENT_N));
+}
+
+// 用真实 WS status 帧把 agent 登记成 serve（服务端据此盖 presence.wake_kind）。
+async function registerServe(slug: string, token: string): Promise<WsClient> {
+  const ws = await WsClient.open(slug, token);
+  await completeCapabilityHello(ws);
+  ws.send({ type: "send", kind: "status", state: "waiting", note: "standby", mentions: [], residency: "supervised", wake: { kind: "serve" } });
+  await ws.nextOfType("sent");
+  return ws;
+}
+
+describe("验证帧按 (channel, sender) 限频（issue #997）", () => {
+  it("连续两条：第二条 429 wake_verify_rate_limited，错误体带 retry_after_ms / retry_at 与人话的下次可发时间", async () => {
+    const agent = await seedToken("agent");
+    const slug = await createChannel(agent.token);
+    const before = Date.now();
+    const first = await verify(slug, agent.token, agent.name, " 1");
+    expect(first.status).toBe(200);
+    const firstSeq = ((await first.json()) as { seq: number }).seq;
+
+    const second = await verify(slug, agent.token, agent.name, " 2");
+    expect(second.status).toBe(429);
+    const body = (await second.json()) as {
+      error: { code: string; message: string; retry_after_ms: number; retry_at: number };
+    };
+    expect(body.error.code).toBe("wake_verify_rate_limited");
+    expect(body.error.retry_after_ms).toBeGreaterThan(0);
+    expect(body.error.retry_after_ms).toBeLessThanOrEqual(WAKE_VERIFY_MIN_INTERVAL_MS);
+    expect(body.error.retry_at).toBeGreaterThanOrEqual(before + WAKE_VERIFY_MIN_INTERVAL_MS);
+    expect(body.error.retry_at - Date.now()).toBeLessThanOrEqual(WAKE_VERIFY_MIN_INTERVAL_MS);
+    expect(body.error.message).toContain("wake-verify");
+    expect(body.error.message).toContain(`1 per ${WAKE_VERIFY_MIN_INTERVAL_MS / 1000}s`);
+    expect(body.error.message).toContain(new Date(body.error.retry_at).toISOString());
+    // 被拒的那条没有落库、没有建任何唤醒副作用。
+    expect(await deliveryTargets(slug)).toEqual([{ seq: firstSeq, target: agent.name }]);
+    const history = await api(`/api/channels/${slug}/messages?after=0&limit=50`, agent.token);
+    const messages = ((await history.json()) as { messages: Array<{ seq: number }> }).messages;
+    expect(messages.map((m) => m.seq)).toEqual([firstSeq]);
+  });
+
+  it("WS 发送同样限频：error 帧带 wake_verify_rate_limited 与 retry_after_ms", async () => {
+    const agent = await seedToken("agent");
+    const slug = await createChannel(agent.token);
+    const ws = await WsClient.open(slug, agent.token);
+    await completeCapabilityHello(ws);
+    const frame = { type: "send", kind: "message", body: `${WAKE_VERIFY_PREFIX} @${agent.name} ping`, mentions: [agent.name], reply_to: null };
+    ws.send(frame);
+    await ws.nextOfType("sent");
+    ws.send(frame);
+    const err = (await ws.nextOfType("error")) as { code: string; retry_after_ms?: number; retry_at?: number };
+    expect(err.code).toBe("wake_verify_rate_limited");
+    expect(err.retry_after_ms).toBeGreaterThan(0);
+    expect(typeof err.retry_at).toBe("number");
+    ws.close();
+  });
+
+  it("窗口过了放行；再发又进下一个窗口", async () => {
+    const agent = await seedToken("agent");
+    const slug = await createChannel(agent.token);
+    expect((await verify(slug, agent.token, agent.name, " 1")).status).toBe(200);
+    expect((await verify(slug, agent.token, agent.name, " 2")).status).toBe(429);
+    // 差 1s 到窗口：仍拒。
+    await ageVerifyWindow(slug, agent.name, WAKE_VERIFY_MIN_INTERVAL_MS - 1_000);
+    const early = await verify(slug, agent.token, agent.name, " 3");
+    expect(early.status).toBe(429);
+    const earlyBody = (await early.json()) as { error: { retry_after_ms: number } };
+    expect(earlyBody.error.retry_after_ms).toBeLessThanOrEqual(1_000);
+    // 补足窗口：放行。
+    await ageVerifyWindow(slug, agent.name, 1_000);
+    expect((await verify(slug, agent.token, agent.name, " 4")).status).toBe(200);
+    // 放行那条重新起算窗口。
+    expect((await verify(slug, agent.token, agent.name, " 5")).status).toBe(429);
+  });
+
+  it("限频按发送者分片：另一个 agent 在同频道不受影响；同一 agent 在另一个频道也不受影响", async () => {
+    const owner = `${uniq("owner")}@example.com`;
+    const a = await seedToken("agent", uniq("a"), { owner });
+    const b = await seedToken("agent", uniq("b"), { owner });
+    const slug = await createChannel(a.token);
+    const other = await createChannel(a.token);
+    expect((await verify(slug, a.token, a.name)).status).toBe(200);
+    expect((await verify(slug, a.token, a.name)).status).toBe(429);
+    expect((await verify(slug, b.token, b.name)).status).toBe(200);
+    expect((await verify(other, a.token, a.name)).status).toBe(200);
+  });
+
+  it("独立于 loop guard：熔断中照拒（先撞限频），窗口过了再撞熔断本身；人类发言清熔断也不清限频", async () => {
+    const agent = await seedToken("agent");
+    const human = await seedToken("human", uniq("leo"));
+    const slug = await createChannel(agent.token);
+    await enableLoopGuard(slug, agent.token, LOOP_GUARD_N);
+    expect((await verify(slug, agent.token, agent.name, " 1")).status).toBe(200);
+    await tripLoopGuard(slug, agent.name);
+    // 熔断中：普通消息 409；验证帧在限频窗口内 429（限频先于 guard 判定）。
+    expect((await postMessage(slug, agent.token, "still talking")).status).toBe(409);
+    const limited = await verify(slug, agent.token, agent.name, " 2");
+    expect(limited.status).toBe(429);
+    await expect(limited.json()).resolves.toMatchObject({ error: { code: "wake_verify_rate_limited" } });
+    // 窗口过了、仍在熔断：照拒，这回是 guard 的真话。
+    await ageVerifyWindow(slug, agent.name, WAKE_VERIFY_MIN_INTERVAL_MS);
+    const tripped = await verify(slug, agent.token, agent.name, " 3");
+    expect(tripped.status).toBe(409);
+    await expect(tripped.json()).resolves.toMatchObject({ error: { code: "loop_guard" } });
+    // 被拒的验证帧不占窗口：guard 解除后立刻重跑验证不必再等。
+    expect((await postMessage(slug, human.token, "human here, guard cleared")).status).toBe(200);
+    expect((await verify(slug, agent.token, agent.name, " 4")).status).toBe(200);
+    // 人类发言清了 streak / fair-share，但限频窗口是独立状态：紧接着的第二条仍拒。
+    expect((await postMessage(slug, human.token, "again")).status).toBe(200);
+    expect((await verify(slug, agent.token, agent.name, " 5")).status).toBe(429);
+    expect(await guardCounters(slug, agent.name)).toEqual({ streak: 0, count: 0 });
+  });
+
+  it("幂等重试不算第二条：同 idempotency_key 命中去重回原 seq，不被限频", async () => {
+    const agent = await seedToken("agent");
+    const slug = await createChannel(agent.token);
+    const key = uniq("idem");
+    const first = await send(slug, agent.token, `${WAKE_VERIFY_PREFIX} @${agent.name} ping`, [agent.name], { idempotency_key: key });
+    expect(first.status).toBe(200);
+    const seq = ((await first.json()) as { seq: number }).seq;
+    const retry = await send(slug, agent.token, `${WAKE_VERIFY_PREFIX} @${agent.name} ping`, [agent.name], { idempotency_key: key });
+    expect(retry.status).toBe(200);
+    expect(((await retry.json()) as { seq: number }).seq).toBe(seq);
+  });
+});
+
+describe("验证帧只对已登记的 agent 身份成立（issue #997）", () => {
+  it("非 agent 发的同形状帧：按普通自 @ 处理——不建 delivery、不落 ledger、也不限频", async () => {
+    const human = await seedToken("human", uniq("leo"));
+    const slug = await createChannel(human.token);
+    for (let i = 0; i < 3; i += 1) {
+      const res = await verify(slug, human.token, human.name, ` ${i}`);
+      expect(res.status).toBe(200);
+    }
+    expect(await deliveryTargets(slug)).toEqual([]);
+    expect(await ledgerRows(slug)).toEqual([]);
+    expect(await readMeta(slug, `wake_verify_at:${human.name}`)).toBeNull();
+  });
+
+  it("mentions 绑定到的登记身份不是发送者本人（principal 劈叉）：不是验证帧——不建 delivery、计 loop guard、不限频", async () => {
+    // tokens.name 全局唯一、REST 每次从同一行读身份、WS 的陈旧 principal 又会被 reconcileRemovedConnections
+    // 关掉——入口层已经让「同名不同 principal」进不来。这道闸是 routeMentionsForDelivery 自己的独立判定
+    // （将来任何内部调用方都得被它挡住），所以像 delivery-ack-no-reply.spec 一样直接打 handleSend。
+    const owner = `${uniq("owner")}@example.com`;
+    const agent = await seedToken("agent", uniq("moved"), { owner });
+    const slug = await createChannel(agent.token);
+    await enableLoopGuard(slug, agent.token, LOOP_GUARD_N);
+    const tokenHash = await sha256Hex(agent.token);
+    const stub = env.CHANNELS.get(env.CHANNELS.idFromName(slug));
+    const sendAs = (identityOwner: string) =>
+      runInDurableObject(stub, async (instance: ChannelDO) => {
+        const handleSend = (
+          instance as unknown as {
+            handleSend: (
+              identity: { name: string; kind: "agent"; role: "agent"; owner: string; tokenHash: string },
+              frame: Record<string, unknown>,
+            ) => Promise<{ ok: boolean; code?: string; deliveryTargets?: string[] }>;
+          }
+        ).handleSend.bind(instance);
+        return handleSend(
+          { name: agent.name, kind: "agent", role: "agent", owner: identityOwner, tokenHash },
+          { type: "send", kind: "message", body: `${WAKE_VERIFY_PREFIX} @${agent.name} ping`, mentions: [agent.name], reply_to: null },
+        );
+      });
+
+    // 目录登记的 principal 是 owner，发送身份自称别的账号：同形状帧退化为普通自 @。
+    const foreign = await sendAs(`${uniq("stranger")}@example.com`);
+    expect(foreign.ok).toBe(true);
+    expect(foreign.deliveryTargets).toEqual([]);
+    expect(await deliveryTargets(slug)).toEqual([]);
+    expect(await guardCounters(slug, agent.name)).toEqual({ streak: 1, count: 1 });
+    expect(await readMeta(slug, `wake_verify_at:${agent.name}`)).toBeNull();
+
+    // 对照：同一帧、principal 对上 ⇒ 验证帧成立（自己进 deliveryTargets、开限频窗口、不计 guard）。
+    const genuine = await sendAs(owner);
+    expect(genuine.ok).toBe(true);
+    expect(genuine.deliveryTargets).toEqual([agent.name]);
+    expect(await guardCounters(slug, agent.name)).toEqual({ streak: 1, count: 1 });
+    expect(await readMeta(slug, `wake_verify_at:${agent.name}`)).not.toBeNull();
+    // 第二条真验证帧被限频（与 REST 同一判定）。
+    const again = await sendAs(owner);
+    expect(again).toMatchObject({ ok: false, code: "wake_verify_rate_limited" });
+  });
+
+  it("已登记 agent 的验证帧仍走真实唤醒链（#990 不回退）：建 delivery、落 serve ledger、不计 guard", async () => {
+    const owner = `${uniq("owner")}@example.com`;
+    const self = await seedToken("agent", uniq("leo-server"), { owner });
+    const slug = await createChannel(self.token);
+    await enableLoopGuard(slug, self.token, LOOP_GUARD_N);
+    const ws = await registerServe(slug, self.token);
+    const res = await verify(slug, self.token, self.name);
+    expect(res.status).toBe(200);
+    const seq = ((await res.json()) as { seq: number }).seq;
+    expect(await deliveryTargets(slug)).toEqual([{ seq, target: self.name }]);
+    expect(await ledgerRows(slug)).toEqual([{ seq, target: self.name }]);
+    expect(await guardCounters(slug, self.name)).toEqual({ streak: 0, count: 0 });
+    expect(await readMeta(slug, `wake_verify_at:${self.name}`)).not.toBeNull();
+    ws.close();
+  });
+});


### PR DESCRIPTION
## 根因

#996（#990）的验证帧（`[wake-verify]` + mentions 只含自己）是自 @ 过滤的唯一放行例外，且不计 loop guard 的 streak / fair-share。两点叠加 = 任何持该频道 agent 身份的调用方都能无节流连发验证帧，绕过熔断刷历史 / directed delivery / ledger（pr_agent 在 #996 上指出，合并后评估成立）。另外 `party wake verify` 先取本地 config 的 `identity.name`，为空才问 `/api/me`——config 里是旧身份时验证帧 @ 错人、harness 回退 other、修法命令不准。

## 修法

**服务端（`worker/src/do.ts`）**
- 限频：同一 (channel, sender) 在 `WAKE_VERIFY_MIN_INTERVAL_MS`（30s，`shared/src/protocol.ts` 新常量）内最多放行一条验证帧。超出返回 `wake_verify_rate_limited`（HTTP 429），REST 错误体与 WS `error` 帧都带 `retry_after_ms` / `retry_at`，message 写明「retry in Ns, at <ISO>」。
- 限频状态放 **DO meta 表**，key `wake_verify_at:<sender>`（与 `agent_count:<name>` 同一形态、同一 `setMeta`），值 = 最近一条**被接受**的验证帧时间戳。被拒的不占窗口（熔断解除后立刻重跑不必再等）。
- 独立于 loop guard：判定放在 guard 之前；熔断中先撞限频（429），窗口过了再撞 guard（409）；`clearLoopGuardState`（人类发言 / reset-guard）不清它；幂等重试先命中 #98 去重，不算第二条。
- 身份：「验证帧」的完整判据 = 帧形状（`isWakeVerifyFrame`）+ 发送者 `kind === "agent"` + mentions 绑定到发送者自己在 D1 目录登记的 principal（`routeMentionsForDelivery` 新增 `senderBinding` 参数，用 `ownerLookup[self] === identityDeliveryPrincipal(identity)` 核对；`isSelfMention` 对带 `sender.kind` 的帧要求 agent）。三者缺一按普通自 @ 处理：不建 delivery、不落 ledger、计 guard、不限频。
- `SendOutcome` 错误分支加 `retryAfterMs` / `retryAt`，统一经 `sendErrorBody()` 出 REST / WS；`ERROR_STATUS` 加 `wake_verify_rate_limited: 429`；`shared` `ErrorCode` 与 `ErrorFrame` 同步；`cli/src/client.ts` 的 `ERROR_CODES` allow-list 镜像新码（否则 WS 上这条 error 帧会被静默丢掉）。

**CLI**
- `cli/src/commands/wake.ts`：抽出 `resolveVerifyIdentity()`——以 `fetchMe` 为准，config.identity 只作缓存；不一致时 stderr 打「本地 config 缓存的身份 X 与服务端登记的 Y 不一致，以服务端为准」；`/api/me` 不可达才退回缓存并警告，没缓存就把错误抛出。`--json` 多 `identity_source: "server" | "cache"`。帮助文本补限频与身份来源两句。
- `cli/src/onboarding/verify-wake.ts`：`verifyWakeRoundTrip` 识别 `RestError.code === "wake_verify_rate_limited"`，detail「验证帧被服务端限频：同一身份 30s 内只能发一条，Ns 后可再发」，fix `sleep N && party wake verify <chan>`（新 `wakeVerifyRetryAfterSec` 从错误体取秒数，缺就不编）；`classifyWakeVerify` 对 `wake_pending` 且 seq 为 null 不再拼 `#null`。

## 测试证据

- `cd worker && bunx tsc --noEmit` ✓
- `cd worker && bunx vitest run test/wake-verify-frame.spec.ts test/wake-verify-rate-limit.spec.ts` → 2 files / 14 passed
  - 新 spec `worker/test/wake-verify-rate-limit.spec.ts`（9 例）：连续两条第二条 429 + `retry_after_ms`/`retry_at`/message 含 ISO 时间且被拒那条不落库；WS 同样限频且 error 帧带字段；拨旧 `wake_verify_at` 差 1s 仍拒、补足放行、放行后重新起算；按发送者分片（别的 agent / 别的频道不受影响）；熔断中先 429、窗口过了 409、人类发言清 guard 不清限频；幂等重试不算第二条；人类发同形状帧不建 delivery / 不落 ledger / 不限频；principal 劈叉（直打 `handleSend`，同 delivery-ack-no-reply.spec 的写法）退化为普通自 @ 并计 guard，对照 principal 一致 ⇒ 验证帧成立且第二条被限频；已登记 agent 的验证帧仍走真实唤醒链（#990 不回退）
  - `wake-verify-frame.spec.ts` 的「连发三条不计 guard」改为每条之间把窗口拨过期（新规则下连发本身就会被限频），断言不变
- 回归：`bunx vitest run` 上述两个 + self-mention-no-wake / agent-loop-guard / webhooks / undeliverable-mentions / directed-delivery-adapters / mention-debt-visibility / guards / body-mentions / directed-delivery / idempotency → 12 files / 136 passed
- `cd cli && bunx tsc --noEmit` ✓；`bun test test/verify-wake.test.ts` → 31 pass（新增：`resolveVerifyIdentity` 三组——不一致取权威并提示 / 一致或无缓存不提示 / 不可达退缓存或抛错；限频 detail+fix、缺 `retry_after_ms` 不编秒数、`wakeVerifyRetryAfterSec` 边界；`wake_pending` seq null；三条端到端——config 旧身份仍 @ `/api/me` 身份且 stderr 提示、`/api/me` 503 退缓存、服务端 429 ⇒ exit 2 带修法）
- 回归：`bun test test/wake.test.ts test/wake-verify-listeners.test.ts test/json-contract.test.ts test/cli.test.ts test/exit-codes.test.ts test/client.test.ts` → 104 pass
- **变异自检**：
  - worker：把 `if (limited !== null) return limited;` 改成不返回 ⇒ 新 spec 9 例 **6 红**（含「连续两条第二条被拒」），还原后全绿
  - cli：让 `resolveVerifyIdentity` 有缓存就直接返回缓存（旧行为）⇒ **4 红**（两条单测 + 两条端到端），还原后全绿

## 没做的

- 不碰 `cli/src/commands/join.ts`（另一 agent 在改）；接入步骤机接 `identity_source` 由 #988 决定
- 「同名不同 principal」在入口层本就进不来（`tokens.name` UNIQUE、REST 每次从同一行读身份、WS 的陈旧 principal 会被 `reconcileRemovedConnections` 关掉），这道核对是 `routeMentionsForDelivery` 自己的独立闸，测试因此直打 `handleSend`

Closes #997

https://claude.ai/code/session_01Az8CnUpayZzqpi1sh32Ssi


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 验证帧新增限频机制：同一发送者在 30 秒内最多发送一条。
  - 限频时通过 REST 和 WebSocket 返回重试时间，便于稍后再次操作。
  - 验证身份优先以服务端信息为准，服务不可用时回退至缓存身份，并标注身份来源。

- **错误修复**
  - 正确处理验证限频错误，避免相关错误响应被静默丢弃。
  - 修复验证状态缺少序号时显示异常内容的问题。
  - 收紧验证帧身份校验，降低未登记身份触发验证流程的风险。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->