### PR TITLE
fix(cli): 唤醒注入 from-name 只放友好名，技术 ID 挪到正文 from-id、撞名才加短码

### DIFF
--- a/cli/src/commands/claude-channel.ts
+++ b/cli/src/commands/claude-channel.ts
@@ -53,7 +53,7 @@ import {
   type MentionWakeClaimResult,
   type MentionWakeRef,
 } from "../mention-wake-claim";
-import { senderInjectFromName, wakeProxyNote } from "../serve-wake-proxy";
+import { senderInjectFromName, wakeProxyNote, type InjectSenderLike } from "../serve-wake-proxy";
 import { loadCursor, readConfig, resolveChannel, saveCursor } from "../config";
 import {
   DeliveryRecoveryJournal,
@@ -738,6 +738,28 @@ export async function runDormantClaudeSessionAnnounce(
   // @ 注入一次。两条路径各有自己的进程内 seen，本切片**不做跨进程去重**——最终由
   // Claude 收件箱侧的 msg_id/队列去重与人工感知兜底；重复唤醒的代价远小于叫不醒。
   const injectedSeqs = new Set<number>();
+  // #986：频道里「能看到的成员」名册，供 from-name 同名消歧用——只有存在友好名相同、技术 name
+  // 不同的另一个成员时才给主名加短后缀。来源：participants 帧（入连名册）、presence 帧、
+  // 已见过的 msg sender；跨重连累计，按技术 name 去重，超过上限淘汰最早的。
+  const knownSenders = new Map<string, InjectSenderLike>();
+  const rememberSender = (sender: InjectSenderLike | null | undefined) => {
+    const name = typeof sender?.name === "string" ? sender.name.trim() : "";
+    if (name === "") return;
+    // 新值覆盖旧值（display_name/handle 可能后来才补上），保持插入序以便淘汰最早的。
+    knownSenders.delete(name);
+    knownSenders.set(name, {
+      name,
+      kind: sender?.kind,
+      owner: sender?.owner ?? null,
+      handle: sender?.handle ?? null,
+      display_name: sender?.display_name ?? null,
+    });
+    while (knownSenders.size > DORMANT_ANNOUNCE_SEEN_LIMIT) {
+      const oldest = knownSenders.keys().next();
+      if (oldest.done === true) break;
+      knownSenders.delete(oldest.value);
+    }
+  };
   // 漏叫留痕（#906）：同一句连续重复只打一次（5s 轮询否则刷屏）。
   const rawLog = deps.log ?? ((line: string) => console.error(line));
   let lastLogged: string | null = null;
@@ -849,6 +871,8 @@ export async function runDormantClaudeSessionAnnounce(
       try {
         // 重放帧一律不注入（#869 第 2 层；标记由 #861 在服务端补上，见
         // dormantAnnounceIsReplayFrame）。放在最前面：重放的历史 @ 连去重表都不该占。
+        // #986：发信人先进名册（哪怕是重放帧、哪怕这条不 @ 我）——后面同名的另一个人出现时才分得开。
+        rememberSender(sender);
         if (dormantAnnounceIsReplayFrame(frame)) return;
         if (!dormantAnnounceMentionHit(mentions, selfName)) return;
         // #963：发信人就是我这个身份——那是对话里提到自己（「@leo-server 这次醒了」），不是召唤。
@@ -900,10 +924,11 @@ export async function runDormantClaudeSessionAnnounce(
               pid: entry.pid,
               sessionId: entry.session_id,
               name: hostAnnounceName,
-              body: wakeProxyNote({ channel, server: authServer, seq, siblings }),
-              // from-name＝真实发信人的友好名 + 技术 ID（接收端面板只显示这一处，
-              // 技术 ID 丢了就分不清两个同名 agent）。
-              fromName: senderInjectFromName(sender, channel),
+              // #986：技术 identity 进正文末行 `from-id:`（防冒充字段不丢，可读回）。
+              body: wakeProxyNote({ channel, server: authServer, seq, siblings, fromId: sender?.name ?? null }),
+              // from-name＝真实发信人的**友好名**（`leo`）；只有频道里另有同友好名、不同技术 name 的
+              // 成员时才带短消歧后缀（`leo·9749e`），别再把整段 hash 拼进主名（#986）。
+              fromName: senderInjectFromName(sender, channel, [...knownSenders.values()]),
               // announce 进程没有自己的回执 socket——绝不冒用别人的 sock 当 from。
             });
           } catch {
@@ -960,6 +985,18 @@ export async function runDormantClaudeSessionAnnounce(
     if (signal.aborted) closeConnection();
     try {
       for await (const frame of connection.frames) {
+        // #986：维护频道成员名册（from-name 同名消歧的判定范围）。这些帧不 ack、不注入。
+        if (frame.type === "participants") {
+          for (const participant of frame.participants) rememberSender(participant);
+        } else if (frame.type === "presence") {
+          rememberSender({
+            name: frame.name,
+            kind: frame.kind,
+            owner: frame.account ?? null,
+            handle: frame.handle ?? null,
+            display_name: frame.display_name ?? null,
+          });
+        }
         if (frame.type === "msg" || frame.type === "status") {
           connection.ack(frame.seq);
           // 注意顺序：先 ack 再注入。ack 只是本地防积压（绝不推进持久化游标、绝不

--- a/cli/src/serve-wake-proxy.ts
+++ b/cli/src/serve-wake-proxy.ts
@@ -33,7 +33,7 @@ import {
   type ClaudeSessionRegistryEntry,
 } from "./claude-session-registry";
 import { injectChannelMessage } from "./claude-inbox-inject";
-import { friendlyAgentLabel } from "@agentparty/shared/identity";
+import { assignIdentityDisambiguators, friendlyAgentLabel } from "@agentparty/shared/identity";
 import { readConfig, type CachedIdentity } from "./config";
 
 /** 三不变量之一：唤醒通知只带 channel+seq 指针，且总长 ≤512 UTF-8 字节。 */
@@ -49,24 +49,51 @@ export interface WakeProxyRef {
    * 兄弟已回，再决定要不要开口。省略/≤1 不写进通知。
    */
   siblings?: number;
+  /**
+   * from-name 背后的技术 identity（#986）。from-name 只放友好名（`leo`），技术 ID 不再拼进主名
+   * （拼进去会被 Claude 的 @handle 化压成 `@leo-lark-ad72b3f9749e`），而是落到正文末行的
+   * `from-id:` 元信息里——防冒充字段不丢，仍可用 wakeProxyNoteFromId 读回。省略/空 ⇒ 不写。
+   */
+  fromId?: string | null;
 }
+
+/** 正文末行元信息键（#986）：`from-id: <技术 identity>`。 */
+const WAKE_NOTE_FROM_ID_KEY = "from-id:";
+const WAKE_NOTE_FROM_ID_RE = /^from-id: (\S+)/m;
 
 /**
  * 未来载体要发的通知正文：只含 channel+seq 指针，不含消息正文。
- * 超出 512B 属于程序错误（channel ≤64 字符 + seq 数字，正常永远不会触发）。
+ * 超出 512B 属于程序错误（channel ≤64 字符 + seq 数字 + identity ≤64 字符，正常永远不会触发）。
  */
 export function wakeProxyNote(ref: WakeProxyRef): string {
   const siblings = typeof ref.siblings === "number" && Number.isInteger(ref.siblings) && ref.siblings > 1
     ? ` siblings=${ref.siblings}: ${ref.siblings} live runtimes share your identity; ` +
       "check whether a sibling already replied before you speak."
     : "";
+  const fromId = normalizeFromId(ref.fromId);
+  const fromIdLine = fromId === null
+    ? ""
+    : `\n${WAKE_NOTE_FROM_ID_KEY} ${fromId} (technical identity behind from-name; verify via party history)`;
   const note =
     `AgentParty wake: you were mentioned in #${ref.channel} at seq=${ref.seq}.${siblings} ` +
-    "Read the channel (party history) for the message body; the channel is the single source of truth.";
+    "Read the channel (party history) for the message body; the channel is the single source of truth." +
+    fromIdLine;
   if (Buffer.byteLength(note, "utf8") > WAKE_PROXY_NOTE_MAX_BYTES) {
     throw new Error("wake proxy note exceeds 512 bytes");
   }
   return note;
+}
+
+/** 从通知正文读回 from-id（#986 防冒充字段的读回路径）；没有则 null。 */
+export function wakeProxyNoteFromId(note: string): string | null {
+  return WAKE_NOTE_FROM_ID_RE.exec(note)?.[1] ?? null;
+}
+
+/** 技术 identity 进正文前的净化：只认无空白的单个 token，空/非串一律当没有。 */
+function normalizeFromId(value: string | null | undefined): string | null {
+  if (typeof value !== "string") return null;
+  const cleaned = value.replace(/\s+/g, "").trim();
+  return cleaned === "" ? null : cleaned;
 }
 
 /**
@@ -108,15 +135,13 @@ export function selectWakeProxyTarget(
 }
 
 /**
- * 注入面板上的「谁发来的」。接收端把它原样显示成
- * `from uds:<sock> (peer claims name: <fromName>)`（#844 实测面板文本），**面板不另外
- * 显示我们的技术 identity**——所以 fromName 必须自带技术 ID，否则两个仅哈希段不同的
- * 身份（`lark-ad72b3f97491-agentparty` / `lark-ad72b3f9749e-agentparty`）会显示成同一个
- * `leo · agentparty`，界面上无法分辨。
+ * 注入面板上的「谁发来的」——serve 转投路径用本机 identity（中转身份）。
  *
- * 形态：`<所属人> · <角色> (<技术 identity>)`——友好前半对齐 web 的 identityDisplay
- * （规则同源于 shared/src/identity.ts），括号里给完整技术 ID 保证唯一可辨（选 A 不选
- * 尾 5 位短码：短码仍会碰撞，而 from-name 没有长度硬限，只禁 `"` 与 `\r\n<>`）。
+ * #986 起 from-name **只放友好名**（对齐 web 的 identityDisplay，规则同源于 shared/src/identity.ts）：
+ * 接收端把它显示成 `from uds:<sock> (peer claims name: <fromName>)`，并会把它 @handle 化——
+ * 以前把完整技术 ID 拼进主名，结果是 `@leo-lark-ad72b3f9749e` 这种一段 hash（owner：「很难看」）。
+ * 技术 identity 没有丢：它走 WakeProxyRef.fromId 落到正文末行 `from-id:`（防冒充字段仍可读回）。
+ * 同名消歧见 senderInjectFromName——serve 路径看不到频道成员集合，不做后缀。
  * 读不到本机 identity（未登录/旧配置）→ 回退 `agentparty#<channel>`。
  */
 export function injectFromName(
@@ -126,39 +151,74 @@ export function injectFromName(
   if (identity === null || identity === undefined || typeof identity.name !== "string" || identity.name === "") {
     return `agentparty#${channel}`;
   }
-  return sanitizeFromName(withTechnicalId(friendlyAgentLabel(identity), identity.name), channel);
+  return sanitizeFromName(friendlyAgentLabel(identity), channel);
+}
+
+/** 注入 from-name 用得到的发信人字段（msg 帧 sender / participants / presence 都能凑出）。 */
+export interface InjectSenderLike {
+  name?: string;
+  kind?: string;
+  owner?: string | null;
+  handle?: string | null;
+  display_name?: string | null;
+}
+
+/**
+ * 发信人的友好名（不带技术 ID）：
+ * - 人类：`<display_name || handle || owner || name>`；
+ * - agent：`<所属人> · <角色>`（friendlyAgentLabel，同 web）。
+ * sender 缺失/name 空 ⇒ null。
+ */
+export function senderFriendlyName(sender: InjectSenderLike | null | undefined): string | null {
+  const name = typeof sender?.name === "string" ? sender.name.trim() : "";
+  if (name === "") return null;
+  if (sender?.kind === "human") {
+    return sender.display_name?.trim() || sender.handle?.trim() || sender.owner?.trim() || name;
+  }
+  return friendlyAgentLabel({
+    name,
+    owner: sender?.owner ?? null,
+    owner_handle: null,
+    owner_display_name: null,
+  });
 }
 
 /**
  * announce 注入（#857）用的 from-name：那条路径知道**真实发信人**（频道 msg 帧的 sender），
- * 显示发信人比显示中转身份有用得多。规则同 injectFromName——友好名 + 括号里的技术 ID：
- * - 人类：`<display_name || handle || owner>`（本身就可读，技术 name 同值时不重复加括号）；
- * - agent：`<所属人> · <角色> (<技术 identity>)`。
+ * 显示发信人比显示中转身份有用得多。
+ *
+ * #986：主名只放友好名（`leo`）。技术 identity 走 WakeProxyRef.fromId 进正文 `from-id:`。
+ * 防冒充仍成立、且只在需要时才露出：`peers`（频道里能看到的成员集合——participants /
+ * presence / 已见过的 msg sender）里存在**友好名相同、技术 name 不同**的另一个发信人时，
+ * 才在主名后加组内唯一的短消歧码（`leo·9749e`，规则与 web #858 共用
+ * assignIdentityDisambiguators：哈希段末 5 位起步，仍撞就加长）；否则一个字都不加。
  * sender 缺失/不可读时回退 `agentparty#<channel>`。
  */
 export function senderInjectFromName(
-  sender: { name?: string; kind?: string; owner?: string | null; handle?: string | null; display_name?: string | null } | null | undefined,
+  sender: InjectSenderLike | null | undefined,
   channel: string,
+  peers: readonly InjectSenderLike[] = [],
 ): string {
   const name = typeof sender?.name === "string" ? sender.name.trim() : "";
-  if (name === "") return `agentparty#${channel}`;
-  const friendly = sender?.kind === "human"
-    ? (sender.display_name?.trim() || sender.handle?.trim() || sender.owner?.trim() || name)
-    : friendlyAgentLabel({
-        name,
-        owner: sender?.owner ?? null,
-        owner_handle: null,
-        owner_display_name: null,
-      });
-  return sanitizeFromName(withTechnicalId(friendly, name), channel);
+  const friendly = senderFriendlyName(sender);
+  if (name === "" || friendly === null) return `agentparty#${channel}`;
+  return sanitizeFromName(withDisambiguator(friendly, name, peers), channel);
 }
 
 /**
- * 友好名后缀技术 ID——但友好名里**已经含有**技术 name 时不重复（真机实测踩到：
- * 非哈希前缀的 name 提不出角色，会渲染成 `x · foo-agent (foo-agent)`）。
+ * 同名消歧：peers 里凡是友好名与本发信人相同、技术 name 不同的，一起组成撞名组；
+ * 组内 ≥2 个技术 name 才给本发信人打 `·<短码>` 后缀。单人组恒原样返回。
  */
-function withTechnicalId(friendly: string, name: string): string {
-  return friendly.includes(name) ? friendly : `${friendly} (${name})`;
+function withDisambiguator(friendly: string, name: string, peers: readonly InjectSenderLike[]): string {
+  const group = new Set<string>([name]);
+  for (const peer of peers) {
+    const peerName = typeof peer?.name === "string" ? peer.name.trim() : "";
+    if (peerName === "" || peerName === name) continue;
+    if (senderFriendlyName(peer) === friendly) group.add(peerName);
+  }
+  if (group.size < 2) return friendly;
+  const code = assignIdentityDisambiguators([...group]).get(name) ?? name;
+  return `${friendly}·${code}`;
 }
 
 /**
@@ -218,8 +278,13 @@ export const noWakeProxyForwarder: WakeProxyForwarder = async (): Promise<WakePr
 export interface SocketWakeProxyForwarderOptions {
   /** 自己的回执 socket（`from:uds:<...>`）。serve 无回执 sock → 省略，接收端记 unknown。 */
   fromSock?: string;
-  /** 频道昵称解析（"Message from <fromName>"）；默认用 channel 名。 */
+  /** 频道昵称解析（"Message from <fromName>"）；默认本机 identity 的友好名（injectFromName）。 */
   fromName?: (ref: WakeProxyRef) => string;
+  /**
+   * from-name 背后的技术 identity（#986），进正文末行 `from-id:`；默认本机 identity 的 name。
+   * 返回 null ⇒ 不写该行。
+   */
+  fromId?: (ref: WakeProxyRef) => string | null;
   /** 注入实现注入点（测试用）；默认真实 injectChannelMessage。 */
   inject?: typeof injectChannelMessage;
   env?: NodeJS.ProcessEnv;
@@ -247,17 +312,21 @@ export function socketWakeProxyForwarder(
   options: SocketWakeProxyForwarderOptions = {},
 ): WakeProxyForwarder {
   const inject = options.inject ?? injectChannelMessage;
-  // 默认 from-name＝友好名 + 技术 ID（owner 2026-08-20：技术 ID 是身份本身，不能丢）。
-  const fromName = options.fromName ?? ((ref: WakeProxyRef) => injectFromName(ref.channel));
+  // 默认 from-name＝本机 identity 的友好名；技术 ID（owner 2026-08-20：是身份本身，不能丢）
+  // 不再拼进主名，而是进正文 `from-id:`（#986）。两者默认都读本机 identity，只读一次。
+  const needsIdentity = options.fromName === undefined || options.fromId === undefined;
   return async (target, ref) => {
+    const identity = needsIdentity ? resolveLocalIdentity() : null;
+    const fromName = options.fromName === undefined ? injectFromName(ref.channel, identity) : options.fromName(ref);
+    const fromId = options.fromId === undefined ? (identity?.name ?? null) : options.fromId(ref);
     const result = await inject({
       // 同 #857：按 pid 寻址（registry entry.pid 与 ~/.claude/sessions/<pid>.json 同源），
       // sessionId 防 pid 复用。宣告名只作展示/回退，绝不用来寻址。
       pid: target.pid,
       sessionId: target.session_id,
       name: claudeSessionAnnounceName(target),
-      body: wakeProxyNote(ref),
-      fromName: fromName(ref),
+      body: wakeProxyNote({ ...ref, fromId }),
+      fromName,
       fromSock: options.fromSock,
       env: options.env,
     });

--- a/cli/test/claude-channel-dormant-announce.test.ts
+++ b/cli/test/claude-channel-dormant-announce.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { WAKE_VERIFY_PREFIX, type ServerFrame } from "@agentparty/shared";
 import type { ClaudeSessionRegistryEntry } from "../src/claude-session-registry";
+import { wakeProxyNoteFromId } from "../src/serve-wake-proxy";
 import {
   dormantAnnounceDisplayName,
   dormantAnnounceMentionHit,
@@ -356,7 +357,10 @@ describe("runDormantClaudeSessionAnnounce (#841 P2)", () => {
 function msg(
   seq: number,
   mentions: string[],
-  overrides: { sender?: { name: string; kind: string; owner?: string }; reply_to?: number | null } = {},
+  overrides: {
+    sender?: { name: string; kind: string; owner?: string; display_name?: string; handle?: string };
+    reply_to?: number | null;
+  } = {},
 ): ServerFrame {
   return {
     type: "msg",
@@ -482,14 +486,53 @@ describe("runDormantClaudeSessionAnnounce socket inject (#857)", () => {
     expect(calls[0]!.pid).toBe(process.ppid);
     expect(calls[0]!.sessionId).toBe("11111111-1111-4111-8111-111111111111");
     expect(calls[0]!.name).toBe("claude-111111111111");
-    // from-name＝友好名 + 技术 ID（接收端面板只显示这一处）。
+    // from-name＝友好名（#986 起不再拼技术 ID；默认发信人没有 display_name/handle，友好名回退 owner）。
     expect(calls[0]!.fromName).toBe("leo@example.com");
+    // 技术 ID 挪到正文 from-id 行，仍可读回。
+    expect(wakeProxyNoteFromId(calls[0]!.body)).toBe("leo");
     expect(calls[0]!.body).toContain("seq=13");
     expect(Buffer.byteLength(calls[0]!.body, "utf8")).toBeLessThanOrEqual(512);
     // 注入路径不改变 P2 不变式：只本地 ack，绝不发客户端帧、绝不推进持久化游标。
     expect(connections[0]!.acked).toEqual([11, 12, 13]);
     expect(connections[0]!.sent).toHaveLength(0);
     expect(connections[0]!.connectArgs.opts.onCursor).toBeUndefined();
+    abort.abort();
+    await done;
+  });
+
+  test("#986：from-name 只放友好名 `leo`；频道里出现同名不同 ID 的第二人后才加短后缀且互不相同", async () => {
+    const { deps, connections, calls } = injectingDeps();
+    const abort = new AbortController();
+    const done = runDormantClaudeSessionAnnounce("dev", abort.signal, deps);
+    await tick();
+    const leoA = { name: "lark-ad72b3f9749e", kind: "human", display_name: "leo", owner: "leo@example.com" };
+    const leoB = { name: "lark-ad72b3f97491", kind: "human", display_name: "leo", owner: "leo2@example.com" };
+    // 单发信人 ⇒ 恰为 `leo`，主名里没有技术 ID；技术 ID 在正文 from-id 行。
+    connections[0]!.push(msg(21, [SELF], { sender: leoA }));
+    await tick();
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.fromName).toBe("leo");
+    expect(wakeProxyNoteFromId(calls[0]!.body)).toBe("lark-ad72b3f9749e");
+    // 第二个 leo（技术 ID 不同）出现在名册（participants 帧）后：两人各带短后缀、互不相同。
+    connections[0]!.push({ type: "participants", participants: [leoA, leoB] } as unknown as ServerFrame);
+    connections[0]!.push(msg(22, [SELF], { sender: leoB }));
+    connections[0]!.push(msg(23, [SELF], { sender: leoA }));
+    await tick();
+    expect(calls).toHaveLength(3);
+    const fromB = calls[1]!.fromName;
+    const fromA = calls[2]!.fromName;
+    expect(fromA).not.toBe(fromB);
+    expect(fromA.startsWith("leo·")).toBe(true);
+    expect(fromB.startsWith("leo·")).toBe(true);
+    expect(fromA).not.toContain("lark-ad72b3f9749e");
+    expect(fromB).not.toContain("lark-ad72b3f97491");
+    expect(wakeProxyNoteFromId(calls[1]!.body)).toBe("lark-ad72b3f97491");
+    expect(wakeProxyNoteFromId(calls[2]!.body)).toBe("lark-ad72b3f9749e");
+    // 不同名的人不受影响。
+    connections[0]!.push(msg(24, [SELF], { sender: { name: "lark-0000aaaa1111", kind: "human", display_name: "bob" } }));
+    await tick();
+    expect(calls).toHaveLength(4);
+    expect(calls[3]!.fromName).toBe("bob");
     abort.abort();
     await done;
   });

--- a/cli/test/claude-inbox-inject-by-pid.test.ts
+++ b/cli/test/claude-inbox-inject-by-pid.test.ts
@@ -102,7 +102,7 @@ describe("按 pid 寻址（#857 真实寻址层）", () => {
       sessionId: entry.session_id,
       name: claudeSessionAnnounceName(entry),
       body: "AgentParty wake: #dev seq=42",
-      fromName: "leo · agentparty (lark-ad72b3f97491-agentparty)",
+      fromName: "leo · agentparty",
       env: env(),
     });
     expect(result).toMatchObject({ ok: true, socketPath: sockPath });
@@ -116,7 +116,7 @@ describe("按 pid 寻址（#857 真实寻址层）", () => {
     };
     expect(frame.type).toBe("user");
     expect(frame.message.content).toContain("AgentParty wake: #dev seq=42");
-    expect(frame.message.content).toContain('from-name="leo · agentparty (lark-ad72b3f97491-agentparty)"');
+    expect(frame.message.content).toContain('from-name="leo · agentparty"');
   });
 
   test("sessionId 不匹配（pid 被复用/换了会话）→ 拒投，绝不写错会话", () => {

--- a/cli/test/claude-native-format-guard.test.ts
+++ b/cli/test/claude-native-format-guard.test.ts
@@ -66,6 +66,14 @@ describe("原生 cross-session 格式漂移守卫（#953）", () => {
         fromMode: "bypass",
         body: "x",
       }),
+      // #986：from-name 只放友好名——含空格/中文/消歧点 `·` 的友好名必须过原生 `[^"<>\n\r]+`，
+      // 且正文末行的 `from-id:` 元信息行也要能过 body 段。
+      wrapCrossSessionMessage({
+        from: "uds:/tmp/cc-socks/4.sock",
+        fromName: "郭立 lee · agentparty·9749e",
+        fromMode: "prompting",
+        body: "AgentParty wake: you were mentioned in #pwtk at seq=42.\nfrom-id: lark-ad72b3f9749e (technical identity behind from-name; verify via party history)",
+      }),
     ];
     for (const s of samples) {
       expect({

--- a/cli/test/inject-from-name.test.ts
+++ b/cli/test/inject-from-name.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, test } from "bun:test";
 import { friendlyAgentLabel, generatedAgentRole } from "@agentparty/shared/identity";
 import { wrapCrossSessionMessage } from "../src/claude-inbox-inject";
-import { injectFromName, senderInjectFromName } from "../src/serve-wake-proxy";
+import {
+  injectFromName,
+  senderFriendlyName,
+  senderInjectFromName,
+  wakeProxyNote,
+  wakeProxyNoteFromId,
+} from "../src/serve-wake-proxy";
 import type { CachedIdentity } from "../src/config";
 
 function identity(overrides: Partial<CachedIdentity> = {}): CachedIdentity {
@@ -40,25 +46,58 @@ describe("friendlyAgentLabel (shared, web 同源)", () => {
   });
 });
 
-describe("injectFromName / senderInjectFromName", () => {
-  test("keeps both the friendly label and the technical id", () => {
-    expect(injectFromName("dev", identity({ owner_display_name: "leo" }))).toBe(
-      "leo · agentparty (lark-ad72b3f97491-agentparty)",
-    );
+describe("injectFromName / senderInjectFromName（#986：主名只放友好名）", () => {
+  test("serve 路径：from-name 只放本机 identity 的友好名，不再拼技术 ID", () => {
+    expect(injectFromName("dev", identity({ owner_display_name: "leo" }))).toBe("leo · agentparty");
+    expect(injectFromName("dev", identity({ owner_display_name: "leo" }))).not.toContain("lark-ad72b3f97491");
   });
 
-  test("two identities differing only in the hash segment stay distinguishable", () => {
-    const a = injectFromName("dev", identity({ owner_display_name: "leo" }));
-    const b = injectFromName(
-      "dev",
-      identity({ name: "lark-ad72b3f9749e-agentparty", owner_display_name: "leo" }),
-    );
-    expect(a).not.toBe(b);
-    expect(b).toContain("lark-ad72b3f9749e-agentparty");
+  test("技术 ID 走正文 from-id 元信息行，仍可逐字读回（防冒充字段不丢）", () => {
+    const note = wakeProxyNote({ channel: "dev", server: "https://a.example.com", seq: 7, fromId: "lark-ad72b3f9749e" });
+    expect(wakeProxyNoteFromId(note)).toBe("lark-ad72b3f9749e");
+    // 没给 ⇒ 不写、读回 null；空白/空串同样当没有。
+    expect(wakeProxyNoteFromId(wakeProxyNote({ channel: "dev", server: "x", seq: 7 }))).toBeNull();
+    expect(wakeProxyNoteFromId(wakeProxyNote({ channel: "dev", server: "x", seq: 7, fromId: "  " }))).toBeNull();
+    // 指针正文本身不变：仍是 channel+seq。
+    expect(note).toContain("#dev");
+    expect(note).toContain("seq=7");
   });
 
-  test("不给友好名重复追加已经含在里面的技术 ID（真机实测踩到）", () => {
-    // 非哈希前缀的 name 提不出角色 → 友好名里已经是完整 name，不该再括号重复一次。
+  test("单发信人 ⇒ from-name 恰为 `leo`（owner 真机形态：人类账号技术 ID + display_name）", () => {
+    const leo = { name: "lark-ad72b3f9749e", kind: "human", display_name: "leo", owner: "leo@example.com" };
+    expect(senderInjectFromName(leo, "dev")).toBe("leo");
+    // 名册里只有自己 / 只有不同名的人 ⇒ 同样不加后缀。
+    expect(senderInjectFromName(leo, "dev", [leo])).toBe("leo");
+    expect(senderInjectFromName(leo, "dev", [leo, { name: "lark-0000aaaa1111", kind: "human", display_name: "bob" }]))
+      .toBe("leo");
+  });
+
+  test("两个友好名相同、技术 ID 不同的发信人 ⇒ 各带短消歧后缀且互不相同", () => {
+    const a = { name: "lark-ad72b3f97491", kind: "human", display_name: "leo" };
+    const b = { name: "lark-ad72b3f9749e", kind: "human", display_name: "leo" };
+    const peers = [a, b];
+    const fromA = senderInjectFromName(a, "dev", peers);
+    const fromB = senderInjectFromName(b, "dev", peers);
+    expect(fromA).not.toBe(fromB);
+    expect(fromA).toBe("leo·97491");
+    expect(fromB).toBe("leo·9749e");
+    // 短码，不是整段 hash：主名里绝不再出现完整技术 ID。
+    expect(fromA).not.toContain("lark-ad72b3f97491");
+    expect(fromB).not.toContain("lark-ad72b3f9749e");
+  });
+
+  test("agent 发信人同理：友好名 `owner · role`，只在撞名时带后缀", () => {
+    const a = { name: "lark-ad72b3f97491-agentparty", kind: "agent", owner: "leo@example.com" };
+    const b = { name: "lark-ad72b3f9749e-agentparty", kind: "agent", owner: "leo@example.com" };
+    expect(senderInjectFromName(a, "dev")).toBe("leo@example.com · agentparty");
+    expect(senderInjectFromName(a, "dev", [a, b])).toBe("leo@example.com · agentparty·97491");
+    expect(senderInjectFromName(b, "dev", [a, b])).toBe("leo@example.com · agentparty·9749e");
+    // 同 owner 不同角色 ⇒ 友好名本就不同，不算撞名。
+    const c = { name: "lark-ad72b3f9749e-codex", kind: "agent", owner: "leo@example.com" };
+    expect(senderInjectFromName(a, "dev", [a, c])).toBe("leo@example.com · agentparty");
+  });
+
+  test("非哈希前缀的 name 提不出角色 ⇒ 友好名就是整个 name，不重复", () => {
     expect(injectFromName("dev", identity({ name: "leeguooooo-codex2-agentparty", owner: "leo@example.com" })))
       .toBe("leo@example.com · leeguooooo-codex2-agentparty");
     expect(senderInjectFromName({ name: "plain-agent", kind: "agent" }, "dev")).toBe("plain-agent");
@@ -67,34 +106,44 @@ describe("injectFromName / senderInjectFromName", () => {
   test("falls back to the channel when no identity is cached", () => {
     expect(injectFromName("dev", null)).toBe("agentparty#dev");
     expect(senderInjectFromName(undefined, "dev")).toBe("agentparty#dev");
+    expect(senderFriendlyName(undefined)).toBeNull();
   });
 
-  test("humans show their readable name; agents keep owner · role (id)", () => {
-    expect(
-      senderInjectFromName({ name: "leo", kind: "human", display_name: "郭立lee" }, "dev"),
-    ).toBe("郭立lee (leo)");
-    expect(
-      senderInjectFromName(
-        { name: "lark-ad72b3f97491-agentparty", kind: "agent", owner: "leo@example.com" },
-        "dev",
-      ),
-    ).toBe("leo@example.com · agentparty (lark-ad72b3f97491-agentparty)");
+  test("humans show their readable name (display_name > handle > owner > name)", () => {
+    expect(senderInjectFromName({ name: "leo", kind: "human", display_name: "郭立lee" }, "dev")).toBe("郭立lee");
+    expect(senderInjectFromName({ name: "lark-1", kind: "human", handle: "leo-h", owner: "leo@example.com" }, "dev"))
+      .toBe("leo-h");
+    expect(senderInjectFromName({ name: "lark-1", kind: "human", owner: "leo@example.com" }, "dev"))
+      .toBe("leo@example.com");
   });
 
   test("sanitizes characters that would break the receiver's integrity self-check", () => {
     const name = senderInjectFromName({ name: 'we"ird<x>', kind: "agent" }, "dev");
     expect(name).not.toContain('"');
     expect(name).not.toContain("<");
+    const human = senderInjectFromName({ name: "lark-1", kind: "human", display_name: 'a"b<c>\nd' }, "dev");
+    expect(human).toMatch(/^[^"<>\r\n]+$/);
   });
 
-  test("the wrapped from-name survives an attribute round-trip", () => {
-    const fromName = injectFromName("dev", identity({ owner_display_name: "leo" }));
-    const wrapped = wrapCrossSessionMessage({ fromName, fromMode: "prompting", body: "hi" });
-    const match = /^<cross-session-message((?:\s+[a-z-]+="[^"]*")*)>\n([\s\S]*)\n<\/cross-session-message>$/.exec(
-      wrapped,
-    );
-    expect(match).not.toBeNull();
-    expect(match![1]).toContain(`from-name="${fromName}"`);
-    expect(match![2]).toBe("hi");
+  test("the wrapped from-name survives an attribute round-trip（含空格/中文/消歧点）", () => {
+    for (const fromName of [
+      injectFromName("dev", identity({ owner_display_name: "leo" })),
+      senderInjectFromName({ name: "leo", kind: "human", display_name: "郭立 lee" }, "dev"),
+      senderInjectFromName(
+        { name: "lark-ad72b3f9749e", kind: "human", display_name: "leo" },
+        "dev",
+        [{ name: "lark-ad72b3f97491", kind: "human", display_name: "leo" }],
+      ),
+    ]) {
+      const wrapped = wrapCrossSessionMessage({ fromName, fromMode: "prompting", body: "hi" });
+      const match = /^<cross-session-message((?:\s+[a-z-]+="[^"]*")*)>\n([\s\S]*)\n<\/cross-session-message>$/.exec(
+        wrapped,
+      );
+      expect(match).not.toBeNull();
+      expect(match![1]).toContain(`from-name="${fromName}"`);
+      // 原生接收侧 from-name 字符集 `[^"<>\n\r]+`（#953 守卫同款）。
+      expect(fromName).toMatch(/^[^"<>\n\r]+$/);
+      expect(match![2]).toBe("hi");
+    }
   });
 });

--- a/cli/test/serve-wake-proxy.test.ts
+++ b/cli/test/serve-wake-proxy.test.ts
@@ -10,6 +10,7 @@ import {
   socketWakeProxyForwarder,
   WAKE_PROXY_NOTE_MAX_BYTES,
   wakeProxyNote,
+  wakeProxyNoteFromId,
 } from "../src/serve-wake-proxy";
 
 function entry(overrides: Partial<ClaudeSessionRegistryEntry> = {}): ClaudeSessionRegistryEntry {
@@ -42,6 +43,19 @@ describe("wakeProxyNote", () => {
     expect(Buffer.byteLength(note, "utf8")).toBeLessThanOrEqual(WAKE_PROXY_NOTE_MAX_BYTES);
     expect(note).toContain(`#${"a".repeat(64)}`);
     expect(note).toContain(`seq=${Number.MAX_SAFE_INTEGER}`);
+  });
+
+  test("最长 channel + 最长 identity + siblings 齐上仍 ≤512B，且 from-id 可读回（#986）", () => {
+    const note = wakeProxyNote({
+      channel: "a".repeat(64),
+      server: SERVER_A,
+      seq: Number.MAX_SAFE_INTEGER,
+      siblings: 99,
+      fromId: "b".repeat(64),
+    });
+    expect(Buffer.byteLength(note, "utf8")).toBeLessThanOrEqual(WAKE_PROXY_NOTE_MAX_BYTES);
+    expect(wakeProxyNoteFromId(note)).toBe("b".repeat(64));
+    expect(note).toContain("siblings=99");
   });
 });
 
@@ -173,7 +187,7 @@ describe("attemptWakeProxy", () => {
 });
 
 describe("socketWakeProxyForwarder（#844 socket 优先载体）", () => {
-  test("注入成功 → true；用宣告名寻址、from-name 带友好名+技术 ID、正文≤512B 指针", async () => {
+  test("注入成功 → true；用宣告名寻址、from-name 只带友好名、技术 ID 在正文 from-id、正文≤512B 指针", async () => {
     let seen: { name: string; body: string; fromName: string; pid?: number; sessionId?: string | null } | null = null;
     const forward = socketWakeProxyForwarder({
       inject: async ({ name, body, fromName, pid, sessionId }) => {
@@ -191,6 +205,7 @@ describe("socketWakeProxyForwarder（#844 socket 优先载体）", () => {
         channel_scope: "pwtk",
         verified_at: 0,
       }),
+      fromId: () => "lark-ad72b3f97491-agentparty",
     });
     const ok = await forward(entry({ display_name: "pair-claude" }), { channel: "pwtk", server: SERVER_A, seq: 42 });
     expect(ok).toMatchObject({ ok: true });
@@ -198,7 +213,9 @@ describe("socketWakeProxyForwarder（#844 socket 优先载体）", () => {
     // 寻址走 pid + sessionId（宣告名恒不等于 Claude 原生会话名，#857）。
     expect(seen!.pid).toBe(entry().pid);
     expect(seen!.sessionId).toBe(entry().session_id);
-    expect(seen!.fromName).toBe("leo · agentparty (lark-ad72b3f97491-agentparty)");
+    // #986：主名只放友好名；技术 ID 挪到正文 from-id 行，仍可读回。
+    expect(seen!.fromName).toBe("leo · agentparty");
+    expect(wakeProxyNoteFromId(seen!.body)).toBe("lark-ad72b3f97491-agentparty");
     expect(seen!.body).toContain("seq=42");
     expect(Buffer.byteLength(seen!.body, "utf8")).toBeLessThanOrEqual(WAKE_PROXY_NOTE_MAX_BYTES);
   });

--- a/shared/src/identity.ts
+++ b/shared/src/identity.ts
@@ -75,7 +75,8 @@ export interface FriendlyAgentIdentity {
  * 例：`lark-ad72b3f97491-agentparty` + owner_display_name=leo → `leo · agentparty`。
  *
  * 注意：友好名会撞车（同 owner 同角色，只有哈希段不同）——需要「一定能分辨」的场合
- * （web 列表用 assignIdentityDisambiguators；cli 注入面板 fromName 直接带完整技术 ID）。
+ * 用 assignIdentityDisambiguators（web 列表与 cli 注入面板 fromName 同用；#986 起 cli 也只在
+ * 撞名时加短码，技术 ID 走正文 `from-id:`）。
  */
 export function friendlyAgentLabel(identity: FriendlyAgentIdentity): string {
   const role = generatedAgentRole(identity.name) ?? identity.name;


### PR DESCRIPTION
## 问题（#986，owner 真机 2026-08-28）

被 @ 唤醒的 Claude 会话看到的发信人是 `leo (lark-ad72b3f9749e)`，经 Claude Code 的 cross-session @handle 化后压成 `@leo-lark-ad72b3f9749e`——那串是账号技术 ID，在面向人读的主名位置就是一段 hash（owner 原话「这个名字很难看」）。防冒充的理由成立，但把它拼进**主名**是错的位置。

## 改动前后

| 场景 | 改动前 from-name | 改动后 from-name | 技术 ID 在哪 |
|---|---|---|---|
| owner 一个人 @ 我（display_name=leo，name=lark-ad72b3f9749e） | `leo (lark-ad72b3f9749e)` → `@leo-lark-ad72b3f9749e` | `leo` | 正文末行 `from-id: lark-ad72b3f9749e (…)` |
| 频道里有两个 display_name=leo、技术 ID 不同的人 | `leo (lark-ad72b3f97491)` / `leo (lark-ad72b3f9749e)` | `leo·97491` / `leo·9749e` | 同上，各自的完整 ID |
| agent 发信人 `lark-ad72b3f9749e-agentparty`（owner leo@…） | `leo@example.com · agentparty (lark-ad72b3f9749e-agentparty)` | `leo@example.com · agentparty`（撞名时 `…·9749e`） | 同上 |
| serve 转投路径（本机 identity 中转） | `leo · agentparty (lark-ad72b3f97491-agentparty)` | `leo · agentparty` | 同上（本机 identity name） |

注入后接收端看到的完整消息形态：

```
<cross-session-message from-name="leo" from-mode="prompting">
AgentParty wake: you were mentioned in #pwtk at seq=42. Read the channel (party history) for the message body; the channel is the single source of truth.
from-id: lark-ad72b3f9749e (technical identity behind from-name; verify via party history)
</cross-session-message>
```

## 设计要点

- **技术 ID 放哪**：正文末行 `from-id:` 元信息行（`WakeProxyRef.fromId` → `wakeProxyNote`），新增 `wakeProxyNoteFromId()` 读回。没用原生 `from-session` 属性——它是回执路由语义的会话 id 字段（原生正则对它有内部格式约束），塞技术 ID 既语义不对也有被拒的风险；正文段是 `[\s\S]*`，稳。原生正则的属性顺序一个字没动。
- **消歧范围**：announce 腿维护一份「频道里能看到的成员」名册——`participants` 帧（入连名册）+ `presence` 帧 + 已见过的 msg sender，跨重连累计、按技术 name 去重、超 512 条淘汰最早的。只有名册里存在**友好名相同、技术 name 不同**的另一人时才加短码；短码规则与 web #858 共用 `assignIdentityDisambiguators`（哈希段末 5 位起步，仍撞就加长，哈希段全同退完整 name），所以 web 列表和注入面板给同一个人的区分码一致。
- serve 转投路径（`injectFromName`）看不到成员集合，不做后缀（那条路径今天恒不触发，见 `selectWakeProxyTarget` 注释）；`socketWakeProxyForwarder` 新增 `fromId` 注入点，默认与 `fromName` 共读一次本机 identity。
- from-name 含空格/中文/`·` 都在原生 `[^"<>\n\r]+` 内；`sanitizeFromName` 仍把非法字符换 `_`。

## 测试

```
cd cli && bunx tsc --noEmit                      # 通过
bun test test/inject-from-name.test.ts test/serve-wake-proxy.test.ts \
  test/claude-channel-dormant-announce.test.ts test/claude-native-format-guard.test.ts \
  test/claude-inbox-inject.test.ts test/claude-inbox-inject-by-pid.test.ts
# 116 pass / 0 fail（native-format-guard 5 条全跑，本机有 claude 二进制，未 skip）
bun test test/serve-directed-delivery.test.ts test/claude-channel-mcp.test.ts test/claude-channel.test.ts \
  test/announce-channel-identity.test.ts test/verify-wake.test.ts test/wake-verify-listeners.test.ts
# 150 pass / 0 fail
```

- `inject-from-name.test.ts`：单发信人 ⇒ from-name **恰为** `leo`；两同名不同 ID ⇒ `leo·97491` / `leo·9749e` 互不相同且主名不含完整 ID；agent 同理；`from-id` 逐字读回；含空格/中文/`·` 的 from-name 过 wrap 往返与原生字符集。
- `serve-wake-proxy.test.ts`：最长 channel(64) + 最长 identity(64) + siblings=99 仍 ≤512B 且 from-id 可读回；forwarder 的 from-name 只带友好名、正文带 from-id。
- `claude-channel-dormant-announce.test.ts`：端到端——第一个 leo @ 我 ⇒ `leo`；`participants` 帧带来第二个 leo 后，两人各带短码、互不相同、正文 from-id 各自正确；不同名的 bob 不受影响。
- `claude-native-format-guard.test.ts`：新增用**真 claude 二进制**正则核 `郭立 lee · agentparty·9749e` + 含 `from-id:` 行的正文——通过。
- **变异自检**：把 `withDisambiguator` 改成恒返回友好名 ⇒ 3 条红（unit 两条 + dormant 端到端一条），恢复后全绿。

## 未做

- serve 转投路径不做同名消歧（无成员集合，且该路径今天恒不触发）。
- 接收端 Claude Code 对 `leo·9749e` 的 @handle 化具体长什么样没在真机验证（推测 `@leo-9749e`），但主名里已无整段 hash。

Closes #986

https://claude.ai/code/session_01Az8CnUpayZzqpi1sh32Ssi
