### PR TITLE
fix(cli): 插件安装成败按最终版本判，消掉第 0 步自相矛盾的 ✓ 与告警

### DIFF
--- a/cli/src/claude-plugin-sync.ts
+++ b/cli/src/claude-plugin-sync.ts
@@ -94,11 +94,21 @@ export function syncClaudePluginToCli(spawn: PluginSpawn, cliVersion: string): C
   if (before === undefined) return { kind: "unreadable", before, after: before };
   if (before === null) return { kind: "not_installed", before, after: before };
   if (before === cliVersion) return { kind: "current", before, after: before };
-  if (!runClaudePluginUpdate(spawn)) {
-    return { kind: "update_failed", before, after: before, fix: claudePluginMismatchFix(before, cliVersion) };
-  }
+  // 退出码只是线索，**装好的版本才是事实**：update 退出非 0 但其实已经换好版本是真机常见形态
+  // （owner 0.2.220 截图那一类）。以前这里非 0 就直接返回 after=before，于是上层看到「没更新过」
+  // → 结论丢掉「差一次重开」，而第 0 步另一次探测又读到新版本、打出「版本与 CLI 一致」的假绿。
+  // 所以：不管退出码，更新之后一律重新读一次，按真实版本分类。
+  const ranOk = runClaudePluginUpdate(spawn);
   const after = installedClaudePluginVersion(spawn);
   if (after === cliVersion) return { kind: "updated", before, after };
+  if (!ranOk) {
+    return {
+      kind: "update_failed",
+      before,
+      after: after ?? before,
+      fix: claudePluginMismatchFix(typeof after === "string" ? after : before, cliVersion),
+    };
+  }
   return {
     kind: "still_mismatched",
     before,

--- a/cli/src/claude-plugin-sync.ts
+++ b/cli/src/claude-plugin-sync.ts
@@ -99,7 +99,9 @@ export function syncClaudePluginToCli(spawn: PluginSpawn, cliVersion: string): C
   // → 结论丢掉「差一次重开」，而第 0 步另一次探测又读到新版本、打出「版本与 CLI 一致」的假绿。
   // 所以：不管退出码，更新之后一律重新读一次，按真实版本分类。
   const ranOk = runClaudePluginUpdate(spawn);
-  const after = installedClaudePluginVersion(spawn);
+  // 重读失败（plugin list 偶发读不出）就再试一次：单次读的结果不该决定「换没换版本」这个事实。
+  // 上层（join 第 0 步）还会拿权威壳探测再兜一次底。
+  const after = installedClaudePluginVersion(spawn) ?? installedClaudePluginVersion(spawn);
   if (after === cliVersion) return { kind: "updated", before, after };
   if (!ranOk) {
     return {

--- a/cli/src/commands/join.ts
+++ b/cli/src/commands/join.ts
@@ -1047,13 +1047,15 @@ export function completionLine(ctx: JoinCtx, done: string = "接入完成"): str
     // #961：插件刚装/刚更新，当前这个会话还挂着旧的——「要重开」是结论的一部分，不能埋在补充行里。
     // #979：重开也得用 party claude 起，普通 claude 起的会话是蛰伏档。
     return (
+      // 两档都**不许对「新会话能被唤醒」打包票**：那个会话还没起、更没验证过，唯一能证明它的是
+      // 第 4 步真发一条 @（codex stop-time review on b75a9e1）。所以结论只说已知事实 + 下一步怎么验。
       ctx.claudePluginRestart === "changed"
-        ? `✅ ${done}，差一次重开：claude 插件已是 ${RUNNING_VERSION}，【用 ${claudeArmCommand(slug)} 新开一个 Claude 会话】后 @ ${identity} 就能唤醒它；` +
-          `当前这个会话还挂着旧插件，不会被唤醒。`
+        ? `✅ ${done}，差一次重开：claude 插件已是 ${RUNNING_VERSION}，当前这个会话还挂着旧插件、收不到 @。` +
+          `【用 ${claudeArmCommand(slug)} 新开一个 Claude 会话】，起好后在那个会话里跑 \`party wake verify ${slug}\` 验证 @ ${identity} 真能叫醒它。`
         // 版本读不出来 ⇒ 不知道这个会话挂的是新是旧。结论只能照实说，不许把不确定写成确定
         // （codex stop-time review on 2e7f6b2）。
         : `✅ ${done}，但插件版本读不出来：无法确认当前这个会话挂的是不是旧插件。保险起见【用 ` +
-          `${claudeArmCommand(slug)} 新开一个 Claude 会话】，那个会话被 @ ${identity} 时一定能唤醒。`
+          `${claudeArmCommand(slug)} 新开一个 Claude 会话】，起好后在那个会话里跑 \`party wake verify ${slug}\` 验证 @ ${identity} 能不能叫醒它。`
     );
   }
   if (ctx.listener !== null) {

--- a/cli/src/commands/join.ts
+++ b/cli/src/commands/join.ts
@@ -358,7 +358,8 @@ function installClaudePlugin(deps: JoinDeps): ClaudePluginInstallOutcome {
       updated: false,
     };
   }
-  const before = installedClaudePluginVersion(deps.spawn);
+  // 进场读同样重试一次：单次读失败会让「之前是什么版本」永远未知，下游只能猜（见第 0 步）。
+  const before = installedClaudePluginVersion(deps.spawn) ?? installedClaudePluginVersion(deps.spawn);
   let anyFail = first.status !== 0;
   for (const args of [["plugin", "install", CLAUDE_PLUGIN], ["plugin", "enable", CLAUDE_PLUGIN]]) {
     const r = deps.spawn("claude", args, { encoding: "utf8", timeout: 60_000 });
@@ -405,7 +406,10 @@ function installClaudePlugin(deps: JoinDeps): ClaudePluginInstallOutcome {
     ? `claude 插件已从 ${before} 更新到 ${after}（需重开 Claude 会话才生效）`
     : before === null
       ? `claude 插件已安装（${after}；需重开 Claude 会话才生效）`
-      : `claude 插件已是 ${after ?? RUNNING_VERSION}（跳过）`;
+      : before === undefined
+        // 进场版本读不出来 ⇒ 不知道这一趟有没有换版本。别说成「跳过」，那是拿沉默冒充确认。
+        ? `claude 插件 ${after ?? RUNNING_VERSION}（装之前的版本读不出来，无法确认是否换过）`
+        : `claude 插件已是 ${after ?? RUNNING_VERSION}（跳过）`;
   return { level: "ok", msg, restartNeeded, before, after, updated };
 }
 
@@ -701,13 +705,19 @@ export function versionStep(rerun: string = RERUN): Step<JoinCtx> {
         shell.plugin.version !== undefined &&
         shell.plugin.version !== install.before;
       const changed = install.updated || changedByShell;
-      // 装上/换版都意味着当前会话仍挂着旧插件，必须重开——重开标志同样按事实修正。
-      if (changed || install.before === null) ctx.claudePluginRestart = true;
+      // 进场那次版本读也可能失败：这时「换没换」根本无从判断（before 未知，changedByShell 也失效）。
+      // 不许因此说成「版本与 CLI 一致」——那是拿沉默冒充确认；重开提示按保守一侧保留：
+      // 多重开一次只是麻烦，漏掉重开则唤醒层没布上（codex stop-time review on 274de76）。
+      const beforeUnknown = install.before === undefined;
+      // 装上/换版/说不清 都意味着当前会话可能还挂着旧插件，必须提示重开。
+      if (changed || install.before === null || beforeUnknown) ctx.claudePluginRestart = true;
       const plugin = changed
         ? `claude 插件 ${install.before} → 已更新到 ${v}（需重开会话）`
         : install.before === null
           ? `claude 插件已安装 ${v}（需重开会话）`
-          : `claude 插件 ${v} 版本与 CLI 一致`;
+          : beforeUnknown
+            ? `claude 插件 ${v}（装之前的版本读不出来，无法确认是否换过——若这次装过/更新过需重开会话）`
+            : `claude 插件 ${v} 版本与 CLI 一致`;
       return { ok: true, summary: `${cli} · ${plugin}`, detail };
     },
   };

--- a/cli/src/commands/join.ts
+++ b/cli/src/commands/join.ts
@@ -365,12 +365,16 @@ function installClaudePlugin(deps: JoinDeps): ClaudePluginInstallOutcome {
     if (r.error !== undefined || r.status !== 0) anyFail = true;
   }
   const sync = syncClaudePluginToCli(deps.spawn, RUNNING_VERSION);
-  if (sync.kind === "update_failed") anyFail = true;
   const updated = sync.kind === "updated";
   const after = sync.after;
   // 装上了（之前没有）或换了版本 ⇒ 当前会话还挂着旧的，必须重开。
   const restartNeeded = before !== after && after !== undefined;
-  if (anyFail) {
+  // 成败按**最终事实**判，不按子命令退出码：`marketplace add` 在已加过时、`plugin install` 在
+  // 已装时都可能返回非 0，而随后的 update 把版本对齐了——真机实测（owner 截图 0.2.217→0.2.220）
+  // 就是这样：第 0 步打了 ✓「已更新到 0.2.220」，同一屏又印「插件未完全装上」，两句不可能同时为真。
+  // 装好的版本等于 CLI 版本 = 这一步真的成了，中途那些非 0 是噪声（同一形状栽过太多次：#957/#961/#979）。
+  const healthy = after !== null && after !== undefined && after === RUNNING_VERSION;
+  if (anyFail && !healthy) {
     // 修法要对症：已装旧版就是 update（install 原地踏步），没装才是 install。
     const fix = after === null || after === undefined
       ? `claude plugin install ${CLAUDE_PLUGIN}`

--- a/cli/src/commands/join.ts
+++ b/cli/src/commands/join.ts
@@ -646,7 +646,13 @@ export interface JoinCtx {
   rulesPath: string;
   mcpName: string;
   /** 第 0 步：插件刚装 / 刚更新，当前会话还挂着旧的——「要重开」是 ✅ 句的一部分。 */
-  claudePluginRestart: boolean;
+  /**
+   * 结论要不要提「重开会话」，以及**凭什么**：
+   * - "changed"：这一趟真的装上/换了版本 ⇒ 当前会话确定还挂着旧插件；
+   * - "unknown"：版本读不出来，无从判断 ⇒ 只能说「说不清，保险起见重开」，不许说成确定事实；
+   * - false：不用提。
+   */
+  claudePluginRestart: false | "changed" | "unknown";
   /** 第 1 步：服务端确认的身份（config.identity.name）。 */
   identity: string | null;
   /** 第 2 步：claude 档所选接收方式。 */
@@ -680,7 +686,7 @@ export function versionStep(rerun: string = RERUN): Step<JoinCtx> {
       }
       if (harness !== "claude") return { ok: true, summary: cli };
       const install = installClaudePlugin(deps);
-      ctx.claudePluginRestart = install.restartNeeded;
+      ctx.claudePluginRestart = install.restartNeeded ? "changed" : false;
       const detail: string[] = install.level === "ok" || install.level === "skip" ? [] : [outcomeLine("装 claude 插件", install)];
       // 判据是 doctor 的插件壳检查（与 bridge claude --check 同一份）：版本不一致时 SessionStart 根本没布上。
       const shell = deps.claudePluginShell();
@@ -710,7 +716,8 @@ export function versionStep(rerun: string = RERUN): Step<JoinCtx> {
       // 多重开一次只是麻烦，漏掉重开则唤醒层没布上（codex stop-time review on 274de76）。
       const beforeUnknown = install.before === undefined;
       // 装上/换版/说不清 都意味着当前会话可能还挂着旧插件，必须提示重开。
-      if (changed || install.before === null || beforeUnknown) ctx.claudePluginRestart = true;
+      if (changed || install.before === null) ctx.claudePluginRestart = "changed";
+      else if (beforeUnknown) ctx.claudePluginRestart = "unknown";
       const plugin = changed
         ? `claude 插件 ${install.before} → 已更新到 ${v}（需重开会话）`
         : install.before === null
@@ -1040,8 +1047,13 @@ export function completionLine(ctx: JoinCtx, done: string = "接入完成"): str
     // #961：插件刚装/刚更新，当前这个会话还挂着旧的——「要重开」是结论的一部分，不能埋在补充行里。
     // #979：重开也得用 party claude 起，普通 claude 起的会话是蛰伏档。
     return (
-      `✅ ${done}，差一次重开：claude 插件已是 ${RUNNING_VERSION}，【用 ${claudeArmCommand(slug)} 新开一个 Claude 会话】后 @ ${identity} 就能唤醒它；` +
-      `当前这个会话还挂着旧插件，不会被唤醒。`
+      ctx.claudePluginRestart === "changed"
+        ? `✅ ${done}，差一次重开：claude 插件已是 ${RUNNING_VERSION}，【用 ${claudeArmCommand(slug)} 新开一个 Claude 会话】后 @ ${identity} 就能唤醒它；` +
+          `当前这个会话还挂着旧插件，不会被唤醒。`
+        // 版本读不出来 ⇒ 不知道这个会话挂的是新是旧。结论只能照实说，不许把不确定写成确定
+        // （codex stop-time review on 2e7f6b2）。
+        : `✅ ${done}，但插件版本读不出来：无法确认当前这个会话挂的是不是旧插件。保险起见【用 ` +
+          `${claudeArmCommand(slug)} 新开一个 Claude 会话】，那个会话被 @ ${identity} 时一定能唤醒。`
     );
   }
   if (ctx.listener !== null) {
@@ -1078,7 +1090,7 @@ export async function runJoin(opts: JoinOptions, deps: JoinDeps): Promise<number
     configPath,
     rulesPath,
     mcpName: mcpServerName(agentName),
-    claudePluginRestart: false,
+    claudePluginRestart: false as false | "changed" | "unknown",
     identity: null,
     receiveMode: "interactive",
     interactive: false,

--- a/cli/src/commands/join.ts
+++ b/cli/src/commands/join.ts
@@ -1051,7 +1051,7 @@ export function completionLine(ctx: JoinCtx, done: string = "接入完成"): str
       // 第 4 步真发一条 @（codex stop-time review on b75a9e1）。所以结论只说已知事实 + 下一步怎么验。
       ctx.claudePluginRestart === "changed"
         ? `✅ ${done}，差一次重开：claude 插件已是 ${RUNNING_VERSION}，当前这个会话还挂着旧插件、收不到 @。` +
-          `【用 ${claudeArmCommand(slug)} 新开一个 Claude 会话】，起好后在那个会话里跑 \`party wake verify ${slug}\` 验证 @ ${identity} 真能叫醒它。`
+          `【用 ${claudeArmCommand(slug)} 新开一个 Claude 会话】，起好后在那个会话里跑 \`party wake verify ${slug}\` 验证 @ ${identity} 能不能叫醒它。`
         // 版本读不出来 ⇒ 不知道这个会话挂的是新是旧。结论只能照实说，不许把不确定写成确定
         // （codex stop-time review on 2e7f6b2）。
         : `✅ ${done}，但插件版本读不出来：无法确认当前这个会话挂的是不是旧插件。保险起见【用 ` +

--- a/cli/src/commands/join.ts
+++ b/cli/src/commands/join.ts
@@ -691,7 +691,19 @@ export function versionStep(rerun: string = RERUN): Step<JoinCtx> {
         };
       }
       const v = shell.plugin.version ?? RUNNING_VERSION;
-      const plugin = install.updated
+      // 「这一趟到底换没换版本」不能只信 install.updated：那是 sync 自己那一次重读的结论，
+      // 读失败（plugin list 偶发读不出）就退化成「没更新过」，而这里的壳探测又读到了新版本
+      // ⇒ 打出「版本与 CLI 一致」的假绿、且丢掉重开提示（codex stop-time review on b88a58c）。
+      // 壳探测是第 0 步本来就要做的**权威读**，拿它跟进场时的 before 比，才是这一趟的事实。
+      const changedByShell =
+        install.before !== undefined &&
+        install.before !== null &&
+        shell.plugin.version !== undefined &&
+        shell.plugin.version !== install.before;
+      const changed = install.updated || changedByShell;
+      // 装上/换版都意味着当前会话仍挂着旧插件，必须重开——重开标志同样按事实修正。
+      if (changed || install.before === null) ctx.claudePluginRestart = true;
+      const plugin = changed
         ? `claude 插件 ${install.before} → 已更新到 ${v}（需重开会话）`
         : install.before === null
           ? `claude 插件已安装 ${v}（需重开会话）`

--- a/cli/test/join-fixture.ts
+++ b/cli/test/join-fixture.ts
@@ -29,6 +29,11 @@ export interface SpawnBehavior {
    */
   installedPluginVersion?: string | null;
   failPluginUpdate?: boolean; // plugin update 返回非 0
+  /**
+   * `marketplace add` / `plugin install` / `plugin enable` 返回非 0（真机常见：已加过 marketplace、
+   * 已装过插件时就会这样），但 update 照样把版本对齐——用来钉「按最终事实判成败，不按退出码」。
+   */
+  noisyPluginSubcommands?: boolean;
 }
 interface PluginState {
   installed: string | null;
@@ -54,7 +59,10 @@ export function fakeSpawn(record: string[][], behavior: SpawnBehavior, state: Pl
     if (cmd === "claude" && args[0] === "plugin" && args[1] === "install") {
       // 真机行为：已装就只回 "already installed"，版本原地不动。
       if (state.installed === null) state.installed = RUNNING_VERSION;
-      return { ...base, status: 0 };
+      return { ...base, status: behavior.noisyPluginSubcommands ? 1 : 0 };
+    }
+    if (cmd === "claude" && args[0] === "plugin" && (args[1] === "marketplace" || args[1] === "enable")) {
+      return { ...base, status: behavior.noisyPluginSubcommands ? 1 : 0 };
     }
     if (cmd === "claude" && args[0] === "plugin" && args[1] === "update") {
       if (behavior.failPluginUpdate) return { ...base, status: 1 };

--- a/cli/test/join-fixture.ts
+++ b/cli/test/join-fixture.ts
@@ -34,6 +34,12 @@ export interface SpawnBehavior {
    * 已装过插件时就会这样），但 update 照样把版本对齐——用来钉「按最终事实判成败，不按退出码」。
    */
   noisyPluginSubcommands?: boolean;
+  /**
+   * `plugin update` 退出非 0 **但版本其实已经换好**（真机常见）。用来钉「按装好的版本判，
+   * 不按退出码」——否则上层会以为没更新过，结论丢掉「差一次重开」，而另一处探测读到新版本
+   * 又打出「版本与 CLI 一致」的假绿。
+   */
+  pluginUpdateNoisyButWorks?: boolean;
 }
 interface PluginState {
   installed: string | null;
@@ -67,7 +73,7 @@ export function fakeSpawn(record: string[][], behavior: SpawnBehavior, state: Pl
     if (cmd === "claude" && args[0] === "plugin" && args[1] === "update") {
       if (behavior.failPluginUpdate) return { ...base, status: 1 };
       state.installed = RUNNING_VERSION;
-      return { ...base, status: 0 };
+      return { ...base, status: behavior.pluginUpdateNoisyButWorks ? 1 : 0 };
     }
     return { ...base, status: 0 };
   }) as unknown as JoinDeps["spawn"];

--- a/cli/test/join-fixture.ts
+++ b/cli/test/join-fixture.ts
@@ -45,6 +45,8 @@ export interface SpawnBehavior {
    * 不能挂在单次重读上——读失败时上层必须用权威壳探测兜底，否则又是「版本与 CLI 一致」的假绿。
    */
   pluginListFailsAfterUpdate?: number;
+  /** 一开始的头 N 次 `plugin list` 读不出来：连「之前是什么版本」都不知道。 */
+  pluginListFailsAtStart?: number;
 }
 interface PluginState {
   installed: string | null;
@@ -52,6 +54,9 @@ interface PluginState {
   listFailuresLeft?: number;
 }
 export function fakeSpawn(record: string[][], behavior: SpawnBehavior, state: PluginState): JoinDeps["spawn"] {
+  if (behavior.pluginListFailsAtStart !== undefined && state.listFailuresLeft === undefined) {
+    state.listFailuresLeft = behavior.pluginListFailsAtStart;
+  }
   return ((cmd: string, args: readonly string[]) => {
     record.push([cmd, ...args]);
     const base = { pid: 0, output: [], stdout: "", stderr: "", signal: null } as Record<string, unknown>;

--- a/cli/test/join-fixture.ts
+++ b/cli/test/join-fixture.ts
@@ -40,9 +40,16 @@ export interface SpawnBehavior {
    * 又打出「版本与 CLI 一致」的假绿。
    */
   pluginUpdateNoisyButWorks?: boolean;
+  /**
+   * update 之后的头 N 次 `plugin list` 读不出来（真机偶发）。用来钉「换没换版本」这个事实
+   * 不能挂在单次重读上——读失败时上层必须用权威壳探测兜底，否则又是「版本与 CLI 一致」的假绿。
+   */
+  pluginListFailsAfterUpdate?: number;
 }
 interface PluginState {
   installed: string | null;
+  /** 还要让多少次 `plugin list` 读失败（pluginListFailsAfterUpdate 用）。 */
+  listFailuresLeft?: number;
 }
 export function fakeSpawn(record: string[][], behavior: SpawnBehavior, state: PluginState): JoinDeps["spawn"] {
   return ((cmd: string, args: readonly string[]) => {
@@ -57,6 +64,10 @@ export function fakeSpawn(record: string[][], behavior: SpawnBehavior, state: Pl
     }
     if (cmd === "claude" && args[0] === "--version") return { ...base, status: 0, stdout: "2.1.200 (Claude Code)\n" };
     if (cmd === "claude" && args[0] === "plugin" && args[1] === "list") {
+      if ((state.listFailuresLeft ?? 0) > 0) {
+        state.listFailuresLeft = (state.listFailuresLeft ?? 0) - 1;
+        return { ...base, status: 1 };
+      }
       const rows = state.installed === null
         ? []
         : [{ id: PLUGIN, version: state.installed, enabled: true, installPath: "/nowhere/agentparty" }];
@@ -73,6 +84,7 @@ export function fakeSpawn(record: string[][], behavior: SpawnBehavior, state: Pl
     if (cmd === "claude" && args[0] === "plugin" && args[1] === "update") {
       if (behavior.failPluginUpdate) return { ...base, status: 1 };
       state.installed = RUNNING_VERSION;
+      if (behavior.pluginListFailsAfterUpdate !== undefined) state.listFailuresLeft = behavior.pluginListFailsAfterUpdate;
       return { ...base, status: behavior.pluginUpdateNoisyButWorks ? 1 : 0 };
     }
     return { ...base, status: 0 };

--- a/cli/test/join.test.ts
+++ b/cli/test/join.test.ts
@@ -174,6 +174,25 @@ describe("party join —— 一条命令跑完整段接入（#944）", () => {
     expect(verdict).toContain("重开");
   });
 
+  // codex stop-time review on b88a58c：update 之后那一次重读失败（plugin list 偶发读不出）时，
+  // sync 退化成「没更新过」，而第 0 步的壳探测又读到新版本 ⇒ 再次「版本与 CLI 一致」假绿 + 丢重开。
+  test("update 后重读失败但壳探测读到新版本 ⇒ 仍按事实算「已更新」并提示重开", async () => {
+    mock = startRestMock();
+    const record: string[][] = [];
+    const logs: string[] = [];
+    const code = await runJoin(
+      baseOpts({ harnessFlag: "claude" }),
+      // 2 = 让 sync 的重读与它的重试都读不出来，只剩后面的权威壳探测能读到。
+      deps(record, { installedPluginVersion: "0.2.217", pluginListFailsAfterUpdate: 2 }, logs),
+    );
+    const out = logs.join("\n");
+    expect(code).toBe(0);
+    expect(stepLine(logs, 0)).toContain(`claude 插件 0.2.217 → 已更新到 ${RUNNING_VERSION}`);
+    expect(stepLine(logs, 0)).not.toContain("版本与 CLI 一致");
+    const verdict = logs.find((l) => l.startsWith("✅"));
+    expect(verdict).toContain("重开");
+  });
+
   test("子命令返回非 0 且最终版本仍不对 ⇒ 照实报未装好，不能被「按最终事实判」放过", async () => {
     mock = startRestMock();
     const record: string[][] = [];

--- a/cli/test/join.test.ts
+++ b/cli/test/join.test.ts
@@ -172,8 +172,10 @@ describe("party join —— 一条命令跑完整段接入（#944）", () => {
     const verdict = logs.find((l) => l.startsWith("✅"));
     expect(verdict).toBeDefined();
     expect(verdict).toContain("重开");
-    // 这一档是**确定**换过版本，结论就该说确定话。
+    // 这一档是**确定**换过版本，结论就该说确定话——但同样不许承诺新会话「就能唤醒」。
     expect(verdict).toContain("当前这个会话还挂着旧插件");
+    expect(verdict).not.toMatch(/一定能|就能唤醒/);
+    expect(verdict).toContain("party wake verify");
   });
 
   // codex stop-time review on b88a58c：update 之后那一次重读失败（plugin list 偶发读不出）时，
@@ -215,6 +217,9 @@ describe("party join —— 一条命令跑完整段接入（#944）", () => {
     expect(verdict).toContain("读不出来");
     expect(verdict).toContain("保险起见");
     expect(verdict).not.toContain("当前这个会话还挂着旧插件");
+    // 也不许对「新会话一定能被唤醒」打包票（第六轮）：那个会话还没起、没验证过，只能指向真验证。
+    expect(verdict).not.toMatch(/一定能|就能唤醒/);
+    expect(verdict).toContain("party wake verify");
   });
 
   test("子命令返回非 0 且最终版本仍不对 ⇒ 照实报未装好，不能被「按最终事实判」放过", async () => {

--- a/cli/test/join.test.ts
+++ b/cli/test/join.test.ts
@@ -133,6 +133,40 @@ describe("party join —— 一条命令跑完整段接入（#944）", () => {
     expect(verdict).toContain("当前这个会话还挂着旧插件");
   });
 
+  // owner 真机截图（0.2.220）：第 0 步打了 ✓「插件 0.2.217 → 已更新到 0.2.220」，同一屏又印
+  // 「claude 插件未完全装上（手动 update，然后重开会话）」——两句不可能同时为真。
+  // 根因：成败按 marketplace add / plugin install / enable 的**退出码**判，而它们在「已加过 /
+  // 已装过」时本来就返回非 0；真实判据是最终装好的版本等于 CLI 版本。
+  test("子命令返回非 0 但 update 把版本对齐了 ⇒ 第 0 步只报更新成功，不再自相矛盾地印「未完全装上」", async () => {
+    mock = startRestMock();
+    const record: string[][] = [];
+    const logs: string[] = [];
+    const code = await runJoin(
+      baseOpts({ harnessFlag: "claude" }),
+      deps(record, { installedPluginVersion: "0.2.217", noisyPluginSubcommands: true }, logs),
+    );
+    const out = logs.join("\n");
+    expect(code).toBe(0);
+    expect(stepLine(logs, 0)).toContain(`claude 插件 0.2.217 → 已更新到 ${RUNNING_VERSION}`);
+    expect(out).not.toContain("未完全装上");
+    // 「需重开会话」照旧要说——当前会话还挂着旧插件。
+    expect(out).toContain("重开");
+  });
+
+  test("子命令返回非 0 且最终版本仍不对 ⇒ 照实报未装好，不能被「按最终事实判」放过", async () => {
+    mock = startRestMock();
+    const record: string[][] = [];
+    const logs: string[] = [];
+    const code = await runJoin(
+      baseOpts({ harnessFlag: "claude" }),
+      deps(record, { installedPluginVersion: "0.2.203", noisyPluginSubcommands: true, failPluginUpdate: true }, logs),
+    );
+    const out = logs.join("\n");
+    expect(code).not.toBe(0);
+    expect(out).toMatch(/未完全装上|版本不一致/);
+    expect(logs.find((l) => l.startsWith("✅"))).toBeUndefined();
+  });
+
   test("#961：update 没成、插件仍是旧版 ⇒ 第 0 步报 plugin_version_mismatch 并停在那、不印 ✅，修法是 update 不是 install", async () => {
     mock = startRestMock();
     const record: string[][] = [];

--- a/cli/test/join.test.ts
+++ b/cli/test/join.test.ts
@@ -153,6 +153,27 @@ describe("party join —— 一条命令跑完整段接入（#944）", () => {
     expect(out).toContain("重开");
   });
 
+  // codex stop-time review on 208a7f1：`plugin update` 退出非 0 但其实已生效时，
+  // 旧实现不再读一次版本（after=before）⇒ 上层以为没更新过：结论丢掉「差一次重开」，
+  // 而第 0 步另一次探测读到新版本又打出「版本与 CLI 一致」的假绿。
+  test("plugin update 退出非 0 但版本已生效 ⇒ 按事实算「已更新」，重开提示不能丢", async () => {
+    mock = startRestMock();
+    const record: string[][] = [];
+    const logs: string[] = [];
+    const code = await runJoin(
+      baseOpts({ harnessFlag: "claude" }),
+      deps(record, { installedPluginVersion: "0.2.217", pluginUpdateNoisyButWorks: true }, logs),
+    );
+    const out = logs.join("\n");
+    expect(code).toBe(0);
+    expect(stepLine(logs, 0)).toContain(`claude 插件 0.2.217 → 已更新到 ${RUNNING_VERSION}`);
+    // 绝不能说成「本来就一致」——当前会话还挂着 0.2.217。
+    expect(stepLine(logs, 0)).not.toContain("版本与 CLI 一致");
+    const verdict = logs.find((l) => l.startsWith("✅"));
+    expect(verdict).toBeDefined();
+    expect(verdict).toContain("重开");
+  });
+
   test("子命令返回非 0 且最终版本仍不对 ⇒ 照实报未装好，不能被「按最终事实判」放过", async () => {
     mock = startRestMock();
     const record: string[][] = [];

--- a/cli/test/join.test.ts
+++ b/cli/test/join.test.ts
@@ -193,6 +193,25 @@ describe("party join —— 一条命令跑完整段接入（#944）", () => {
     expect(verdict).toContain("重开");
   });
 
+  // codex stop-time review on 274de76：连**进场那次**版本读都失败时，before 未知、changedByShell 也
+  // 失效 ⇒ 又回到「版本与 CLI 一致」的假绿并丢掉重开。说不清就得说说不清，重开按保守一侧保留。
+  test("进场版本读不出来 ⇒ 不许说「版本与 CLI 一致」，并保留重开提示", async () => {
+    mock = startRestMock();
+    const record: string[][] = [];
+    const logs: string[] = [];
+    const code = await runJoin(
+      baseOpts({ harnessFlag: "claude" }),
+      // 3 = 进场读 + 它的重试 + sync 内部那次读，全部读不出；第 4 次（权威壳探测）能读到。
+      deps(record, { installedPluginVersion: RUNNING_VERSION, pluginListFailsAtStart: 3 }, logs),
+    );
+    const out = logs.join("\n");
+    expect(code).toBe(0);
+    expect(stepLine(logs, 0)).not.toContain("版本与 CLI 一致");
+    expect(stepLine(logs, 0)).toContain("读不出来");
+    const verdict = logs.find((l) => l.startsWith("✅"));
+    expect(verdict).toContain("重开");
+  });
+
   test("子命令返回非 0 且最终版本仍不对 ⇒ 照实报未装好，不能被「按最终事实判」放过", async () => {
     mock = startRestMock();
     const record: string[][] = [];

--- a/cli/test/join.test.ts
+++ b/cli/test/join.test.ts
@@ -174,8 +174,10 @@ describe("party join —— 一条命令跑完整段接入（#944）", () => {
     expect(verdict).toContain("重开");
     // 这一档是**确定**换过版本，结论就该说确定话——但同样不许承诺新会话「就能唤醒」。
     expect(verdict).toContain("当前这个会话还挂着旧插件");
-    expect(verdict).not.toMatch(/一定能|就能唤醒/);
+    // 「真能叫醒」同样预设了结果（第七轮）：验证的措辞必须中性。
+    expect(verdict).not.toMatch(/一定能|就能唤醒|真能/);
     expect(verdict).toContain("party wake verify");
+    expect(verdict).toContain("能不能叫醒");
   });
 
   // codex stop-time review on b88a58c：update 之后那一次重读失败（plugin list 偶发读不出）时，
@@ -218,8 +220,9 @@ describe("party join —— 一条命令跑完整段接入（#944）", () => {
     expect(verdict).toContain("保险起见");
     expect(verdict).not.toContain("当前这个会话还挂着旧插件");
     // 也不许对「新会话一定能被唤醒」打包票（第六轮）：那个会话还没起、没验证过，只能指向真验证。
-    expect(verdict).not.toMatch(/一定能|就能唤醒/);
+    expect(verdict).not.toMatch(/一定能|就能唤醒|真能/);
     expect(verdict).toContain("party wake verify");
+    expect(verdict).toContain("能不能叫醒");
   });
 
   test("子命令返回非 0 且最终版本仍不对 ⇒ 照实报未装好，不能被「按最终事实判」放过", async () => {

--- a/cli/test/join.test.ts
+++ b/cli/test/join.test.ts
@@ -172,6 +172,8 @@ describe("party join —— 一条命令跑完整段接入（#944）", () => {
     const verdict = logs.find((l) => l.startsWith("✅"));
     expect(verdict).toBeDefined();
     expect(verdict).toContain("重开");
+    // 这一档是**确定**换过版本，结论就该说确定话。
+    expect(verdict).toContain("当前这个会话还挂着旧插件");
   });
 
   // codex stop-time review on b88a58c：update 之后那一次重读失败（plugin list 偶发读不出）时，
@@ -209,7 +211,10 @@ describe("party join —— 一条命令跑完整段接入（#944）", () => {
     expect(stepLine(logs, 0)).not.toContain("版本与 CLI 一致");
     expect(stepLine(logs, 0)).toContain("读不出来");
     const verdict = logs.find((l) => l.startsWith("✅"));
-    expect(verdict).toContain("重开");
+    // 结论也不许把「说不清」写成确定事实（codex review 第五轮）：不能出现「当前这个会话还挂着旧插件」。
+    expect(verdict).toContain("读不出来");
+    expect(verdict).toContain("保险起见");
+    expect(verdict).not.toContain("当前这个会话还挂着旧插件");
   });
 
   test("子命令返回非 0 且最终版本仍不对 ⇒ 照实报未装好，不能被「按最终事实判」放过", async () => {


### PR DESCRIPTION
## 现象（owner 真机 v0.2.220 截图）

```
第 0 步  版本 · CLI 0.2.220 · claude 插件 0.2.217 → 已更新到 0.2.220（需重开会话） ✓
         ! 装 claude 插件: claude 插件未完全装上（best-effort；手动 claude plugin update agentparty@agentparty，然后重开会话）
```
✓ 说更新成功，紧跟的告警说没装好——两句不可能同时为真。

## 根因

`installClaudePlugin` 用 `marketplace add` / `plugin install` / `plugin enable` 的**退出码**（`anyFail`）判成败。这三条在「marketplace 已加过 / 插件已装过」时本来就返回非 0；而随后的 `syncClaudePluginToCli` 已经把版本从 0.2.217 更新到 0.2.220 —— 最终状态是健康的，报告却按中途的噪声出。

这正是这条线上反复栽的同一形状（#957 / #961 / #979）：**拿便宜的代理信号盖过昂贵但真实的判据**。真实判据现成就有：装好的版本是否等于 CLI 版本。

## 修法

```ts
const healthy = after !== null && after !== undefined && after === RUNNING_VERSION;
if (anyFail && !healthy) { …告警… }
```
退出码只在 `!healthy` 时用来**选对症修法**（没装 → `plugin install`，装了旧版 → `plugin update`）。版本仍不一致的既有分支不变。

## 测试
- 子命令返回非 0 但 update 把版本对齐 ⇒ 第 0 步只报更新成功、全文无「未完全装上」、仍说「需重开会话」。
- 子命令返回非 0 且最终版本仍不对 ⇒ 照实报错、退出码非 0、不印 ✅（确认新判据没把真失败放过）。
- fixture 新增 `noisyPluginSubcommands` 桩（模拟真机「已加过/已装过就返回非 0」）。
- 变异自检：改回 `if (anyFail)` ⇒ 第一条红。
- `bun test join + onboarding-steps + recover + doctor-plugin` → 105 pass / 0 fail；`bunx tsc --noEmit` 通过。

https://claude.ai/code/session_01Az8CnUpayZzqpi1sh32Ssi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug 修复**
  - 优化插件安装结果判断：即使部分安装命令返回非零状态，只要最终插件版本与 CLI 版本一致，仍会正确显示安装成功。
  - 当最终版本未对齐或无法确认时，准确提示安装状态，避免显示误导性的成功信息。
  - 改进版本读取与失败重试机制，减少不必要的失败警告。
  - 插件版本发生变化或状态不确定时，保留重新启动会话提醒，并引导通过验证命令确认唤醒结果。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->