### PR TITLE
fix(cli): 「装没装上」与「版本对不对」分开判，插件比 CLI 新时不再假报未装上

### DIFF
--- a/cli/src/commands/join.ts
+++ b/cli/src/commands/join.ts
@@ -373,13 +373,14 @@ function installClaudePlugin(deps: JoinDeps): ClaudePluginInstallOutcome {
   // 成败按**最终事实**判，不按子命令退出码：`marketplace add` 在已加过时、`plugin install` 在
   // 已装时都可能返回非 0，而随后的 update 把版本对齐了——真机实测（owner 截图 0.2.217→0.2.220）
   // 就是这样：第 0 步打了 ✓「已更新到 0.2.220」，同一屏又印「插件未完全装上」，两句不可能同时为真。
-  // 装好的版本等于 CLI 版本 = 这一步真的成了，中途那些非 0 是噪声（同一形状栽过太多次：#957/#961/#979）。
-  const healthy = after !== null && after !== undefined && after === RUNNING_VERSION;
-  if (anyFail && !healthy) {
-    // 修法要对症：已装旧版就是 update（install 原地踏步），没装才是 install。
-    const fix = after === null || after === undefined
-      ? `claude plugin install ${CLAUDE_PLUGIN}`
-      : CLAUDE_PLUGIN_UPDATE_COMMAND;
+  // 「装没装上」与「版本对不对」是两件事，别混成一句：
+  //   读得出版本 ⇒ 就是装上了（中途那些非 0 是噪声：marketplace 已加过、plugin install 已装过都会非 0）；
+  //   版本不对由下面那个分支说，它会给对症修法（插件比 CLI 新 ⇒ `party upgrade` 升 CLI，不是降插件）。
+  // owner 截图（CLI 0.2.221 / 插件 0.2.222）里两句同时出现：「未完全装上（手动 plugin update）」
+  // 与「本机插件比 CLI 新：升 CLI，不是降插件」——前者既是假的、修法方向还正好相反。
+  const installed = after !== null && after !== undefined;
+  if (anyFail && !installed) {
+    const fix = `claude plugin install ${CLAUDE_PLUGIN}`;
     return {
       level: "warn",
       msg: `claude 插件未完全装上（best-effort；手动 ${fix}，然后重开会话）`,
@@ -687,7 +688,12 @@ export function versionStep(rerun: string = RERUN): Step<JoinCtx> {
       if (harness !== "claude") return { ok: true, summary: cli };
       const install = installClaudePlugin(deps);
       ctx.claudePluginRestart = install.restartNeeded ? "changed" : false;
-      const detail: string[] = install.level === "ok" || install.level === "skip" ? [] : [outcomeLine("装 claude 插件", install)];
+      // 壳检查（下面）不 ready 时会把版本关系与修法讲清楚；install 那条 warn 若说的是同一件事
+      // （版本不一致），再印一遍只是噪声——owner 截图里就是同屏两句讲一件事。
+      const detail: string[] =
+        install.level === "ok" || install.level === "skip" || install.msg.includes("版本不一致")
+          ? []
+          : [outcomeLine("装 claude 插件", install)];
       // 判据是 doctor 的插件壳检查（与 bridge claude --check 同一份）：版本不一致时 SessionStart 根本没布上。
       const shell = deps.claudePluginShell();
       if (shell.status !== "ready") {

--- a/cli/test/join-fixture.ts
+++ b/cli/test/join-fixture.ts
@@ -34,6 +34,8 @@ export interface SpawnBehavior {
    * 已装过插件时就会这样），但 update 照样把版本对齐——用来钉「按最终事实判成败，不按退出码」。
    */
   noisyPluginSubcommands?: boolean;
+  /** `plugin install` 真的失败：返回非 0 **且没装上**（区别于 noisy 那种「已装过所以非 0」）。 */
+  failPluginInstall?: boolean;
   /**
    * `plugin update` 退出非 0 **但版本其实已经换好**（真机常见）。用来钉「按装好的版本判，
    * 不按退出码」——否则上层会以为没更新过，结论丢掉「差一次重开」，而另一处探测读到新版本
@@ -48,6 +50,17 @@ export interface SpawnBehavior {
   /** 一开始的头 N 次 `plugin list` 读不出来：连「之前是什么版本」都不知道。 */
   pluginListFailsAtStart?: number;
 }
+/** 只比数字段，够桩用（"0.2.222" vs "0.2.221"）。 */
+function compareSemverLoose(a: string, b: string): number {
+  const pa = a.split(".").map((x) => Number.parseInt(x, 10) || 0);
+  const pb = b.split(".").map((x) => Number.parseInt(x, 10) || 0);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i += 1) {
+    const d = (pa[i] ?? 0) - (pb[i] ?? 0);
+    if (d !== 0) return d;
+  }
+  return 0;
+}
+
 interface PluginState {
   installed: string | null;
   /** 还要让多少次 `plugin list` 读失败（pluginListFailsAfterUpdate 用）。 */
@@ -79,6 +92,7 @@ export function fakeSpawn(record: string[][], behavior: SpawnBehavior, state: Pl
       return { ...base, status: 0, stdout: `${JSON.stringify(rows)}\n` };
     }
     if (cmd === "claude" && args[0] === "plugin" && args[1] === "install") {
+      if (behavior.failPluginInstall) return { ...base, status: 1 }; // 真失败：没装上
       // 真机行为：已装就只回 "already installed"，版本原地不动。
       if (state.installed === null) state.installed = RUNNING_VERSION;
       return { ...base, status: behavior.noisyPluginSubcommands ? 1 : 0 };
@@ -88,7 +102,10 @@ export function fakeSpawn(record: string[][], behavior: SpawnBehavior, state: Pl
     }
     if (cmd === "claude" && args[0] === "plugin" && args[1] === "update") {
       if (behavior.failPluginUpdate) return { ...base, status: 1 };
-      state.installed = RUNNING_VERSION;
+      // 真机行为：update 只会把插件带到 marketplace 上的版本，**不会降级**。本机插件比 CLI 新
+      // （CLI 还没升）时跑 update 等于没动，这一档正是 owner 截图那种 0.2.222 插件 / 0.2.221 CLI。
+      const newer = state.installed !== null && compareSemverLoose(state.installed, RUNNING_VERSION) > 0;
+      if (!newer) state.installed = RUNNING_VERSION;
       if (behavior.pluginListFailsAfterUpdate !== undefined) state.listFailuresLeft = behavior.pluginListFailsAfterUpdate;
       return { ...base, status: behavior.pluginUpdateNoisyButWorks ? 1 : 0 };
     }

--- a/cli/test/join-fixture.ts
+++ b/cli/test/join-fixture.ts
@@ -102,9 +102,12 @@ export function fakeSpawn(record: string[][], behavior: SpawnBehavior, state: Pl
     }
     if (cmd === "claude" && args[0] === "plugin" && args[1] === "update") {
       if (behavior.failPluginUpdate) return { ...base, status: 1 };
-      // 真机行为：update 只会把插件带到 marketplace 上的版本，**不会降级**。本机插件比 CLI 新
-      // （CLI 还没升）时跑 update 等于没动，这一档正是 owner 截图那种 0.2.222 插件 / 0.2.221 CLI。
-      const newer = state.installed !== null && compareSemverLoose(state.installed, RUNNING_VERSION) > 0;
+      // 真机行为二则（桩不能比真机宽容，否则会掩盖真缺陷）：
+      //  1) 没装过时 `plugin update` 直接失败，**不会顺手装上**（那是 install 的活）；
+      //  2) update 只把插件带到 marketplace 上的版本，**不会降级**——本机插件比 CLI 新
+      //     （CLI 还没升）时跑它等于没动，正是 owner 截图那种 0.2.222 插件 / 0.2.221 CLI。
+      if (state.installed === null) return { ...base, status: 1 };
+      const newer = compareSemverLoose(state.installed, RUNNING_VERSION) > 0;
       if (!newer) state.installed = RUNNING_VERSION;
       if (behavior.pluginListFailsAfterUpdate !== undefined) state.listFailuresLeft = behavior.pluginListFailsAfterUpdate;
       return { ...base, status: behavior.pluginUpdateNoisyButWorks ? 1 : 0 };

--- a/cli/test/join.test.ts
+++ b/cli/test/join.test.ts
@@ -225,6 +225,41 @@ describe("party join —— 一条命令跑完整段接入（#944）", () => {
     expect(verdict).toContain("能不能叫醒");
   });
 
+  // owner 真机截图（CLI 0.2.221 / 本机插件 0.2.222）：同屏出现「插件未完全装上（手动 plugin update）」
+  // 与「本机插件比 CLI 新：升 CLI，不是降插件」——前者是假的，修法方向还正好相反。
+  // 「装没装上」（读得出版本就是装上了）与「版本对不对」是两件事，不许混成一句。
+  test("插件比 CLI 新 ⇒ 不说「未完全装上」，只说版本不一致并给升 CLI 的修法", async () => {
+    mock = startRestMock();
+    const record: string[][] = [];
+    const logs: string[] = [];
+    const newer = "99.9.9"; // 恒比 RUNNING_VERSION 新
+    const code = await runJoin(
+      baseOpts({ harnessFlag: "claude" }),
+      deps(record, { installedPluginVersion: newer, noisyPluginSubcommands: true }, logs),
+    );
+    const out = logs.join("\n");
+    expect(code).not.toBe(0); // 版本不一致是 blocker，停在版本这一步
+    expect(out).not.toContain("未完全装上");
+    expect(out).toContain(newer);
+    // 修法必须是升 CLI，不是降插件。
+    expect(out).toContain("party upgrade");
+    expect(out).not.toContain(`claude plugin update ${PLUGIN}，然后重开会话`);
+  });
+
+  test("真的没装插件且子命令失败 ⇒ 仍说「未完全装上」，修法是 install", async () => {
+    mock = startRestMock();
+    const record: string[][] = [];
+    const logs: string[] = [];
+    const code = await runJoin(
+      baseOpts({ harnessFlag: "claude" }),
+      // 没装 + install 真失败（返回非 0 且没装上）
+      deps(record, { installedPluginVersion: null, failPluginInstall: true }, logs),
+    );
+    const out = logs.join("\n");
+    expect(out).toContain("未完全装上");
+    expect(out).toContain(`claude plugin install ${PLUGIN}`);
+  });
+
   test("子命令返回非 0 且最终版本仍不对 ⇒ 照实报未装好，不能被「按最终事实判」放过", async () => {
     mock = startRestMock();
     const record: string[][] = [];
@@ -235,7 +270,10 @@ describe("party join —— 一条命令跑完整段接入（#944）", () => {
     );
     const out = logs.join("\n");
     expect(code).not.toBe(0);
-    expect(out).toMatch(/未完全装上|版本不一致/);
+    // 版本仍不对 ⇒ 壳检查报 blocker 并给 update 修法（「未完全装上」只留给真没装上的情况）。
+    expect(out).toContain("plugin_version_mismatch");
+    expect(out).toContain(`claude plugin update ${PLUGIN}`);
+    expect(out).not.toContain("未完全装上");
     expect(logs.find((l) => l.startsWith("✅"))).toBeUndefined();
   });
 


### PR DESCRIPTION
## 现象（owner 真机截图，`party recover ludo`，CLI 0.2.221 / 本机插件 0.2.222）

```
第 2 步  版本 · CLI 0.2.221 · claude 插件 blocker: plugin_version_mismatch（本机插件 0.2.222, CLI 0.2.221） ✗
         ! 装 claude 插件: claude 插件未完全装上（best-effort；手动 claude plugin update agentparty@agentparty，然后重开会话）
         本机插件 0.2.222 比 CLI 0.2.221 新：升 CLI，不是降插件
         修法（做完重跑同一条 party recover ludo）：party upgrade
```
中间那句既是假的（插件装着 0.2.222），**修法方向还正好相反**（它让你 `plugin update`，正确的是 `party upgrade` 升 CLI）。

## 根因

#1008 把成败判据从「子命令退出码」改成了「装好的版本 == CLI 版本」。插件比 CLI **新**时这个等式同样不成立 ⇒ 又落回「未完全装上」那一支，并按「已装旧版」给出 update 修法。

「装没装上」和「版本对不对」是两件事：
- 读得出版本 ⇒ **装上了**（中途那些非 0 是噪声：marketplace 已加过、plugin install 已装过都会非 0）；
- 版本对不对由专门的分支说，它调 `claudePluginMismatchFix`，插件更新时给的就是 `party upgrade`。

## 改动

- `installed = after 读得出`（不再要求等于 CLI 版本）；`未完全装上` 只在**真没装上**且子命令失败时出现，修法固定为 `plugin install`。
- 壳检查不 ready 时已经把版本关系与修法讲清楚，install 那条同义 warn 不再重复印（同屏两句讲一件事）。

## 测试
- 插件比 CLI 新（99.9.9）+ 子命令非 0 ⇒ 全文无「未完全装上」、含新版本号、含 `party upgrade`、**不含**降插件的 update 修法。
- 真没装上（`plugin install` 返回非 0 且没装上）⇒ 仍说「未完全装上」+ `claude plugin install …`。
- 既有「版本仍不对」用例改为钉 `plugin_version_mismatch` + update 修法（detail 已被抑制，断言等价收紧而非放宽）。
- fixture：新增 `failPluginInstall`；`plugin update` 桩不再把「比 CLI 新」的插件降级（贴近真机）。
- 变异自检：`installed` 改回「== CLI 版本」⇒ 2 红。
- `bun test join + onboarding-steps + recover + doctor-plugin + upgrade` → 128 pass / 0 fail；`tsc --noEmit` 通过。

https://claude.ai/code/session_01Az8CnUpayZzqpi1sh32Ssi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化插件安装引导：仅在确认插件未成功安装时提示安装失败。
  * 修复本机插件版本高于 CLI 版本时的误报，不再建议降级插件。
  * 版本不一致时提供升级 CLI 的明确修复建议。
  * 避免重复显示插件版本不匹配相关警告。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->