### PR TITLE
fix(cli): party claude 撞到插件落后自己更新完直接启动，identity_unavailable 分出四档原因

### DIFF
--- a/cli/src/commands/claude-launch.ts
+++ b/cli/src/commands/claude-launch.ts
@@ -117,6 +117,14 @@ export type ClaudeLaunchPreflight = {
  * 三个条件缺一不可：命中 `plugin_version_mismatch`、两边版本都读得出、且插件**严格旧于** CLI。
  * 插件比 CLI 新时跑 update 等于降级（#1011），这里必须返回 false，让 fix_lines 去说 `party upgrade`。
  */
+/**
+ * 这一行修法是不是在讲插件本身（`claude plugin install/enable/update`、`party upgrade`）。
+ * 只有这些会随「刚跑过的那次 update」而失效；其余 blocker 的修法与插件无关。
+ */
+export function isPluginFixLine(line: string): boolean {
+  return /claude plugin (install|enable|update)|party upgrade/.test(line);
+}
+
 /** 版本号带预发行/构建后缀（-beta.1、+build）——数字段比较对它不成立。 */
 export function hasPrerelease(version: string): boolean {
   return /[-+]/.test(version.trim());
@@ -401,13 +409,16 @@ export async function run(
       ? launchBlockers.join(", ")
       : `listener_${readiness.listener}`;
     console.error(`AgentParty Channel is not launch-ready (${detail})`);
+    // 刚动过插件、又没能重新检查时，**只有插件那条**修法可能已经过时（它是按更新前的版本算的）；
+    // auth / channel_unbound / identity 那些跟插件无关的修法照样准确，不该被连坐抹掉
+    // （codex stop-time review on 916778f）。
+    for (const line of readiness.fix_lines ?? []) {
+      if (staleFixAfterSelfHeal && isPluginFixLine(line)) continue;
+      console.error(line);
+    }
     if (staleFixAfterSelfHeal) {
-      // 刚动过插件、又没能重新检查：手里这几行修法是更新**之前**的状态算出来的，可能已经不对。
-      // 与其端出一条可能反向的命令，不如说清楚「现在不知道」，把人指向权威判据。
-      console.error("  注意: 刚尝试过更新插件，但重新检查没成功——更新前算出的修法可能已经不适用，这里不再给它。");
-      console.error("  以当前状态为准: party doctor claude-plugin --json");
-    } else {
-      for (const line of readiness.fix_lines ?? []) console.error(line);
+      console.error("  注意: 刚尝试过更新插件，但重新检查没成功——插件那条修法是更新前算出的，可能已经不适用，这里不给它。");
+      console.error("  插件当前状态以此为准: party doctor claude-plugin --json");
     }
     if (launchBlockers.includes("plugin_state_unavailable")) {
       // 读不到插件状态 ≠ 插件坏了：`claude plugin list --json` 没在 10s 内返回（Claude 慢、正在自更新、

--- a/cli/src/commands/claude-launch.ts
+++ b/cli/src/commands/claude-launch.ts
@@ -117,10 +117,19 @@ export type ClaudeLaunchPreflight = {
  * 三个条件缺一不可：命中 `plugin_version_mismatch`、两边版本都读得出、且插件**严格旧于** CLI。
  * 插件比 CLI 新时跑 update 等于降级（#1011），这里必须返回 false，让 fix_lines 去说 `party upgrade`。
  */
+/** 版本号带预发行/构建后缀（-beta.1、+build）——数字段比较对它不成立。 */
+export function hasPrerelease(version: string): boolean {
+  return /[-+]/.test(version.trim());
+}
+
 export function shouldSelfHealPluginVersion(readiness: ClaudeLaunchPreflight): boolean {
   if (!readiness.blockers.includes("plugin_version_mismatch")) return false;
   const { plugin_version: plugin, runtime_version: runtime } = readiness;
   if (plugin === undefined || runtime === undefined) return false;
+  // 预发行号（0.2.223-beta.1）在 compareVersions 里会被 parseInt 截成 0.2.223，比出来「相等」，
+  // 于是既不自愈也不解释。本仓 release.sh 只发严格 X.Y.Z，但真撞上时要**显式**不自愈：
+  // 版本关系都判不准，就别去动插件（coderabbit on #1014）。
+  if (hasPrerelease(plugin) || hasPrerelease(runtime)) return false;
   return compareVersions(plugin, runtime) < 0;
 }
 
@@ -366,6 +375,15 @@ export async function run(
       }
     } else {
       console.error(notice);
+      // 失败也要重跑 preflight：update 可能把状态换成了另一种不匹配（例如插件反而新于 CLI），
+      // 沿用第一次的 fix_lines 就会给出过时的 `claude plugin update`，而正确修法已经变成
+      // `party upgrade`——又是「陈旧结论盖过当前事实」（coderabbit on #1014）。
+      // 重跑失败就保留原来的 readiness，至少不比现在差。
+      try {
+        readiness = await deps.preflight(channel);
+      } catch {
+        // 保持原 readiness：这一步只为让修法更准，读不到就照旧说。
+      }
     }
   }
   // Before launch, no durable listener is the one expected doctor blocker.

--- a/cli/src/commands/claude-launch.ts
+++ b/cli/src/commands/claude-launch.ts
@@ -357,6 +357,7 @@ export async function run(
   // #1013：插件旧于 CLI 是 `party claude` 自己修得掉的一条——它起的是**新**进程，更新后的插件
   // 本来就会被新会话加载，没有「重启当前会话」这回事。修完必须**重跑一次 preflight**：自愈只
   // 处理版本这一条，identity/listener 等 blocker 一个都不许因此被跳过。
+  let staleFixAfterSelfHeal = false;
   if (autoPluginUpdate && shouldSelfHealPluginVersion(readiness)) {
     const target = readiness.runtime_version ?? RUNNING_VERSION;
     console.log(
@@ -376,13 +377,18 @@ export async function run(
     } else {
       console.error(notice);
       // 失败也要重跑 preflight：update 可能把状态换成了另一种不匹配（例如插件反而新于 CLI），
-      // 沿用第一次的 fix_lines 就会给出过时的 `claude plugin update`，而正确修法已经变成
-      // `party upgrade`——又是「陈旧结论盖过当前事实」（coderabbit on #1014）。
-      // 重跑失败就保留原来的 readiness，至少不比现在差。
+      // 沿用第一次的 fix_lines 就会给出过时的 `claude plugin update`（coderabbit on #1014）。
+      //
+      // 「这次尝试有没有可能真的动过插件」决定了重跑失败时该怎么说：
+      //   update_failed / still_mismatched ⇒ update 命令**真的跑过**，状态可能已变；重跑又没成功，
+      //     那我们就是不知道现在该怎么修——绝不能把更新前的修法当成当前修法端出去
+      //     （codex stop-time review on a21d986）。
+      //   claude_unavailable / unreadable / not_installed ⇒ 一个字节都没动，原修法仍然准确。
+      const mutated = sync.kind === "update_failed" || sync.kind === "still_mismatched";
       try {
         readiness = await deps.preflight(channel);
       } catch {
-        // 保持原 readiness：这一步只为让修法更准，读不到就照旧说。
+        if (mutated) staleFixAfterSelfHeal = true;
       }
     }
   }
@@ -395,7 +401,14 @@ export async function run(
       ? launchBlockers.join(", ")
       : `listener_${readiness.listener}`;
     console.error(`AgentParty Channel is not launch-ready (${detail})`);
-    for (const line of readiness.fix_lines ?? []) console.error(line);
+    if (staleFixAfterSelfHeal) {
+      // 刚动过插件、又没能重新检查：手里这几行修法是更新**之前**的状态算出来的，可能已经不对。
+      // 与其端出一条可能反向的命令，不如说清楚「现在不知道」，把人指向权威判据。
+      console.error("  注意: 刚尝试过更新插件，但重新检查没成功——更新前算出的修法可能已经不适用，这里不再给它。");
+      console.error("  以当前状态为准: party doctor claude-plugin --json");
+    } else {
+      for (const line of readiness.fix_lines ?? []) console.error(line);
+    }
     if (launchBlockers.includes("plugin_state_unavailable")) {
       // 读不到插件状态 ≠ 插件坏了：`claude plugin list --json` 没在 10s 内返回（Claude 慢、正在自更新、
       // 登录过期都会这样）。别让人去改插件，先重试。

--- a/cli/src/commands/claude-launch.ts
+++ b/cli/src/commands/claude-launch.ts
@@ -11,6 +11,12 @@ import {
 } from "../claude-default-args";
 import { agentpartyHome, readConfig, refreshConfigInPlace } from "../config";
 import { normalizeWakeLang } from "../wake-note-i18n";
+import {
+  CLAUDE_PLUGIN_UPDATE_COMMAND,
+  syncClaudePluginToCli,
+  type ClaudePluginSyncResult,
+} from "../claude-plugin-sync";
+import { RUNNING_VERSION, compareVersions } from "../upgrade";
 import { isSlug } from "../validation";
 import {
   claudePluginDoctorFixLines,
@@ -55,9 +61,9 @@ export const CLAUDE_CHANNEL_OPT_IN_ENV = "AGENTPARTY_CLAUDE_CHANNEL_OPT_IN";
  */
 export const CLAUDE_LIFECYCLE_OPT_IN_ENV = "AGENTPARTY_CLAUDE_LIFECYCLE_OPT_IN";
 
-const USAGE = "usage: party claude [channel] [-- <claude args...>] | --default-args -- [<claude args...>] | --show-default-args";
+const USAGE = "usage: party claude [channel] [--lang zh|en] [--no-auto-plugin-update] [-- <claude args...>] | --default-args -- [<claude args...>] | --show-default-args";
 
-const HELP = `usage: party claude [channel] [--lang zh|en] [-- <claude args...>]
+const HELP = `usage: party claude [channel] [--lang zh|en] [--no-auto-plugin-update] [-- <claude args...>]
        party claude --default-args -- <claude args...>   # 设为本机默认启动参数（配一次）
        party claude --default-args --                    # 清空本机默认
        party claude --show-default-args                  # 查看本机默认及其来源
@@ -78,10 +84,66 @@ one and the channel is refused again.
 agent config (#1003) and then launches as usual; omit it to auto-detect from the agent's
 own recent channel messages (fallback: the mentioning message, then LANG, then en).
 
+If the installed Marketplace plugin is older than this CLI, the launcher runs
+\`claude plugin update agentparty@agentparty\` itself and then launches (the new
+Claude process loads the updated plugin; nothing to restart). It prints which
+command it ran and the version it moved the plugin from and to. It never runs
+update when the plugin is *newer* than the CLI — that would be a downgrade;
+upgrade the CLI with \`party upgrade\` instead. --no-auto-plugin-update turns the
+self-heal off and falls back to printing the manual command.
+
 Default launch args are opt-in per machine and never hard-coded: only what you
 wrote with --default-args (file: $AGENTPARTY_HOME/claude-default-args.json;
 fallback env ${CLAUDE_DEFAULT_ARGS_ENV}, lower priority) is prepended before your
 explicit -- args. The launcher prints the defaults and their source every time.`;
+
+/** #1013：自愈只碰「插件版本」这一条 blocker，且只在插件**旧于** CLI 时动手。 */
+export const NO_AUTO_PLUGIN_UPDATE_FLAG = "--no-auto-plugin-update";
+
+export type ClaudeLaunchPreflight = {
+  blockers: ClaudePluginDoctorBlocker[];
+  listener: ClaudePluginDoctorReport["channel"]["listener"];
+  /** doctor 的逐项修法（#984：拒绝启动时直接印出来，不再只丢一句「去跑 doctor」）。 */
+  fix_lines?: string[];
+  /** 本机已装的插件版本（#1013 判「旧于 CLI」用；读不出来时缺席）。 */
+  plugin_version?: string;
+  /** 这个 party 二进制的版本，即插件该对齐到的目标。 */
+  runtime_version?: string;
+};
+
+/**
+ * 插件版本落后是否该由 `party claude` 自己修（#1013）。
+ *
+ * 三个条件缺一不可：命中 `plugin_version_mismatch`、两边版本都读得出、且插件**严格旧于** CLI。
+ * 插件比 CLI 新时跑 update 等于降级（#1011），这里必须返回 false，让 fix_lines 去说 `party upgrade`。
+ */
+export function shouldSelfHealPluginVersion(readiness: ClaudeLaunchPreflight): boolean {
+  if (!readiness.blockers.includes("plugin_version_mismatch")) return false;
+  const { plugin_version: plugin, runtime_version: runtime } = readiness;
+  if (plugin === undefined || runtime === undefined) return false;
+  return compareVersions(plugin, runtime) < 0;
+}
+
+/** 自愈结果的说明文案（纯函数，可测）。第一句永远说明「动了什么」。 */
+export function pluginSelfHealNotice(result: ClaudePluginSyncResult, runtimeVersion: string): string {
+  const from = typeof result.before === "string" ? result.before : "?";
+  switch (result.kind) {
+    case "updated":
+      return `已自动运行 \`${CLAUDE_PLUGIN_UPDATE_COMMAND}\`：插件 ${from} → ${result.after}（与 CLI ${runtimeVersion} 对齐）；这就用新版本启动新的 Claude 会话。`;
+    case "update_failed":
+      return `自动运行 \`${CLAUDE_PLUGIN_UPDATE_COMMAND}\` 失败（命令退出非 0，插件仍是 ${result.after ?? from}）。`;
+    case "still_mismatched":
+      return `自动运行 \`${CLAUDE_PLUGIN_UPDATE_COMMAND}\` 后插件仍是 ${result.after ?? from}，没到 CLI 的 ${runtimeVersion}（marketplace 还没拿到这个 tag，或本机缓存未刷新）。`;
+    case "claude_unavailable":
+      return "无法自动更新插件：`claude` 不在 PATH 上，跑不了 `claude plugin update`。";
+    case "unreadable":
+      return "无法自动更新插件：`claude plugin list --json` 读不出插件清单，不确定动了会变成什么，没有动。";
+    case "not_installed":
+      return "无法自动更新插件：本机没装 agentparty 插件（装插件是 `party join` 的事，启动器不替你做主）。";
+    case "current":
+      return `插件已与 CLI ${runtimeVersion} 同版，无需更新。`;
+  }
+}
 
 export interface ClaudeLaunchResult {
   status: number | null;
@@ -89,12 +151,9 @@ export interface ClaudeLaunchResult {
 }
 
 export interface ClaudeLaunchDependencies {
-  preflight(channel: string | undefined): Promise<{
-    blockers: ClaudePluginDoctorBlocker[];
-    listener: ClaudePluginDoctorReport["channel"]["listener"];
-    /** doctor 的逐项修法（#984：拒绝启动时直接印出来，不再只丢一句「去跑 doctor」）。 */
-    fix_lines?: string[];
-  }>;
+  preflight(channel: string | undefined): Promise<ClaudeLaunchPreflight>;
+  /** #1013：把本机插件对齐到 `cliVersion`（默认 syncClaudePluginToCli）；测试注入。 */
+  syncPlugin?: (cliVersion: string) => ClaudePluginSyncResult;
   launch(args: string[], env: NodeJS.ProcessEnv): ClaudeLaunchResult;
   /** 本机偏好根（默认 `agentpartyHome(env)`）；测试用临时目录注入。 */
   home?: string;
@@ -118,8 +177,11 @@ const defaultDependencies: ClaudeLaunchDependencies = {
       blockers: report.blockers,
       listener: report.channel.listener,
       fix_lines: claudePluginDoctorFixLines(report),
+      ...(report.plugin.version === undefined ? {} : { plugin_version: report.plugin.version }),
+      runtime_version: report.runtime_version,
     };
   },
+  syncPlugin: (cliVersion) => syncClaudePluginToCli(spawnSync, cliVersion),
   launch: (args, env) => spawnSync("claude", args, { stdio: "inherit", env }),
 };
 
@@ -225,7 +287,10 @@ export async function run(
   const env = deps.env ?? process.env;
   const home = deps.home ?? agentpartyHome(env);
   const separator = argv.indexOf("--");
-  const rawOwnArgs = separator === -1 ? argv : argv.slice(0, separator);
+  const rawArgsBeforeSeparator = separator === -1 ? argv : argv.slice(0, separator);
+  // #1013：`--no-auto-plugin-update` 先摘掉（它只关自愈，不进 claude 的参数、也不参与位置参数校验）。
+  const autoPluginUpdate = !rawArgsBeforeSeparator.includes(NO_AUTO_PLUGIN_UPDATE_FLAG);
+  const rawOwnArgs = rawArgsBeforeSeparator.filter((arg) => arg !== NO_AUTO_PLUGIN_UPDATE_FLAG);
   const claudeArgs = separator === -1 ? [] : argv.slice(separator + 1);
   // #1003：`--lang zh|en` 先从自有参数里摘出来（写进 config 后照常启动），其余参数的校验不变。
   const langIndex = rawOwnArgs.findIndex((arg) => arg === "--lang" || arg.startsWith("--lang="));
@@ -273,12 +338,35 @@ export async function run(
     }
     console.log(`唤醒文案语言已写入 config：lang=${lang}`);
   }
-  let readiness: Awaited<ReturnType<ClaudeLaunchDependencies["preflight"]>>;
+  let readiness: ClaudeLaunchPreflight;
   try {
     readiness = await deps.preflight(channel);
   } catch {
     console.error("AgentParty Channel preflight failed; run: party doctor claude-plugin --json");
     return 1;
+  }
+  // #1013：插件旧于 CLI 是 `party claude` 自己修得掉的一条——它起的是**新**进程，更新后的插件
+  // 本来就会被新会话加载，没有「重启当前会话」这回事。修完必须**重跑一次 preflight**：自愈只
+  // 处理版本这一条，identity/listener 等 blocker 一个都不许因此被跳过。
+  if (autoPluginUpdate && shouldSelfHealPluginVersion(readiness)) {
+    const target = readiness.runtime_version ?? RUNNING_VERSION;
+    console.log(
+      `插件 ${readiness.plugin_version} 落后于 CLI ${target}，正在运行 \`${CLAUDE_PLUGIN_UPDATE_COMMAND}\`` +
+        `（不想让启动器动插件：加 ${NO_AUTO_PLUGIN_UPDATE_FLAG}）……`,
+    );
+    const sync = (deps.syncPlugin ?? ((cliVersion: string) => syncClaudePluginToCli(spawnSync, cliVersion)))(target);
+    const notice = pluginSelfHealNotice(sync, target);
+    if (sync.kind === "updated" || sync.kind === "current") {
+      console.log(notice);
+      try {
+        readiness = await deps.preflight(channel);
+      } catch {
+        console.error("AgentParty Channel preflight failed; run: party doctor claude-plugin --json");
+        return 1;
+      }
+    } else {
+      console.error(notice);
+    }
   }
   // Before launch, no durable listener is the one expected doctor blocker.
   // Everything else means Claude would open without the promised Channel, or

--- a/cli/src/commands/doctor.ts
+++ b/cli/src/commands/doctor.ts
@@ -6,7 +6,8 @@ import { spawnSync } from "node:child_process";
 import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
 import { resolveChannel } from "../config";
 import { resolveAuthDetailed } from "../oidc-cli";
-import { fetchMe, fetchPresence, fetchRuntimePeers, type Identity } from "../rest";
+import { fetchMe, fetchPresence, fetchRuntimePeers, RestError, type Identity } from "../rest";
+import { stripTerminalControls } from "../format";
 import { buildRuntimeTopology } from "../runtime-topology";
 import { INSTALL_LINE, OWNER_REPO, RUNNING_VERSION, compareVersions, pendingUpgrade } from "../upgrade";
 import { diagnoseCodexWake, formatCodexWakeDiagnosis } from "../wake-diagnosis";
@@ -62,6 +63,64 @@ export type ClaudePluginDoctorBlocker =
   | "listener_not_observed"
   | "listener_suspect"
   | "listener_deaf";
+/**
+ * `identity_unavailable` 的分档（#1013）。以前 `deps.identity(...)` 抛任何异常都只记一个词，
+ * 而这三种的处置完全相反：超时该重试、401 该重新 join、网络不通该查 server / 代理。
+ * 分不出来的才落 `unknown`——它是兜底，不是默认。
+ */
+export type ClaudeIdentityErrorKind = "timeout" | "unauthorized" | "network" | "unknown";
+
+/** 网络层失败的指纹：fetch 自己只抛一句 "fetch failed"，真正的原因在 cause.code 里。 */
+const NETWORK_ERROR_CODES = [
+  "ENOTFOUND",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EAI_AGAIN",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "EPIPE",
+  "ETIMEDOUT",
+  "CERT_HAS_EXPIRED",
+  "UNABLE_TO_VERIFY_LEAF_SIGNATURE",
+];
+
+function errorCode(err: unknown): string | undefined {
+  if (typeof err !== "object" || err === null) return undefined;
+  const code = (err as { code?: unknown }).code;
+  return typeof code === "string" ? code : undefined;
+}
+
+/**
+ * 把 `/api/me` 的异常分档，并给出一句可进终端的短说明。
+ *
+ * 服务端返回的文字**绝不**原样进终端：先 stripTerminalControls（它可能含 ANSI / 控制字符），
+ * 再截断——诊断要的是「哪一类」，不是把响应体倒出来。
+ */
+export function classifyIdentityError(err: unknown): { kind: ClaudeIdentityErrorKind; message: string } {
+  const kind = ((): ClaudeIdentityErrorKind => {
+    if (err instanceof RestError) {
+      if (err.status === 401 || err.status === 403) return "unauthorized";
+      // 5xx / 502 之类不是「你的 token 不对」，也不是本机的事：按可达性问题处置（重试 + 查 server）。
+      if (err.status >= 500) return "network";
+      return "unknown";
+    }
+    const name = typeof err === "object" && err !== null ? String((err as { name?: unknown }).name ?? "") : "";
+    // AbortSignal.timeout() 抛 DOMException("TimeoutError")；老运行时 / 手动 abort 是 AbortError。
+    if (name === "TimeoutError" || name === "AbortError") return "timeout";
+    const code = errorCode(err);
+    if (code !== undefined && NETWORK_ERROR_CODES.includes(code)) return code === "ETIMEDOUT" ? "timeout" : "network";
+    const causeCode = errorCode(typeof err === "object" && err !== null ? (err as { cause?: unknown }).cause : undefined);
+    if (causeCode !== undefined && NETWORK_ERROR_CODES.includes(causeCode)) {
+      return causeCode === "ETIMEDOUT" ? "timeout" : "network";
+    }
+    if (err instanceof TypeError && /fetch failed|network/i.test(err.message)) return "network";
+    return "unknown";
+  })();
+  const raw = err instanceof Error ? err.message : String(err);
+  const message = stripTerminalControls(raw).replace(/\s+/g, " ").trim().slice(0, 200);
+  return { kind, message: message === "" ? kind : message };
+}
+
 export type ClaudePluginDoctorWarning =
   | "activity_not_observed"
   | "topology_not_observed"
@@ -123,6 +182,10 @@ export interface ClaudePluginDoctorReport {
     configured: boolean;
     source: "runtime_config" | "account_session" | "none";
     identity?: string;
+    /** #1013：identity_unavailable 的分档；没有该 blocker 时缺席（旧字段语义不动，只新增）。 */
+    identity_error?: ClaudeIdentityErrorKind;
+    /** 同上，一句已清洗（stripTerminalControls + 截断）的短说明。 */
+    identity_error_message?: string;
   };
   channel: {
     slug?: string;
@@ -327,6 +390,7 @@ export async function inspectClaudePluginReadiness(
   if (channel === null) blockers.push("channel_unbound");
 
   let identity: Identity | null = null;
+  let identityError: { kind: ClaudeIdentityErrorKind; message: string } | null = null;
   let access: ClaudePluginDoctorReport["channel"]["access"] = "not_checked";
   let listener: ClaudePluginDoctorReport["channel"]["listener"] = "not_checked";
   let activityVisibility: ClaudePluginDoctorReport["channel"]["activity_visibility"] = "not_checked";
@@ -337,7 +401,8 @@ export async function inspectClaudePluginReadiness(
     try {
       identity = await deps.identity(auth.server, auth.token, AbortSignal.timeout(5_000));
       if (identity.kind !== "agent") blockers.push("identity_not_agent");
-    } catch {
+    } catch (err) {
+      identityError = classifyIdentityError(err);
       blockers.push("identity_unavailable");
     }
   }
@@ -411,6 +476,9 @@ export async function inspectClaudePluginReadiness(
       configured: auth.server !== null && auth.token !== null,
       source: auth.auth_source,
       ...(identity === null ? {} : { identity: identity.name }),
+      ...(identityError === null
+        ? {}
+        : { identity_error: identityError.kind, identity_error_message: identityError.message }),
     },
     channel: {
       ...(channel === null ? {} : { slug: channel }),
@@ -465,7 +533,10 @@ async function runClaudePluginDoctor(
  * user to install again leaves them exactly where they are.
  */
 export function claudePluginDoctorFixLines(
-  report: Pick<ClaudePluginDoctorReport, "blockers" | "plugin" | "runtime_version">,
+  report: Pick<ClaudePluginDoctorReport, "blockers" | "plugin" | "runtime_version"> & {
+    /** #1013：identity_unavailable 的分档；旧调用方不传也照旧工作（落 unknown 那条兜底文案）。 */
+    auth?: Partial<ClaudePluginDoctorReport["auth"]>;
+  },
 ): string[] {
   const lines: string[] = [];
   if (report.blockers.includes("plugin_missing")) {
@@ -489,6 +560,30 @@ export function claudePluginDoctorFixLines(
     lines.push(`  fix: update Claude Code to >= ${CLAUDE_PLUGIN_MIN_VERSION.join(".")}`);
   }
   if (report.blockers.includes("channel_unbound")) lines.push("  fix: party init --channel <channel>");
+  if (report.blockers.includes("identity_unavailable")) {
+    // #1013：三种失败的处置完全不同，别再挤成一句「身份读不出来」。
+    const detail = report.auth?.identity_error_message;
+    const suffix = detail === undefined || detail === "" ? "" : ` (${detail})`;
+    switch (report.auth?.identity_error) {
+      case "timeout":
+        lines.push(`  fix: /api/me did not answer within 5s${suffix}; retry, then check the server with party doctor`);
+        break;
+      case "unauthorized":
+        lines.push(
+          `  fix: the server rejected this token${suffix}; re-bind an agent token with party init --token <agent-token> --channel <channel> (or party join <invite>)`,
+        );
+        break;
+      case "network":
+        lines.push(
+          `  fix: could not reach the AgentParty server${suffix}; check network/VPN/proxy and the server URL (party whoami shows which server this config points at)`,
+        );
+        break;
+      default:
+        lines.push(
+          `  fix: could not read this agent identity${suffix}; details: party doctor claude-plugin --json (auth.identity_error)`,
+        );
+    }
+  }
   if (report.blockers.includes("identity_not_agent")) {
     lines.push("  fix: bind an agent token with party init --token <agent-token> --channel <channel>");
   }

--- a/cli/test/claude-launch-plugin-selfheal.test.ts
+++ b/cli/test/claude-launch-plugin-selfheal.test.ts
@@ -302,13 +302,12 @@ describe("自愈失败后的修法要反映当前状态（#1014 review）", () =
     expect(err).not.toContain(MISMATCH_FIX.trim());
   });
 
-  test("重跑 preflight 抛异常 ⇒ 保留原来的修法，不比现在差", async () => {
-    const h = harness([mismatched(OLD_PLUGIN, MISMATCH_FIX)], {
-      kind: "update_failed",
-      before: OLD_PLUGIN,
-      after: OLD_PLUGIN,
-      fix: "claude plugin update agentparty@agentparty",
-    });
+  // codex stop-time review on a21d986：我上一轮写的是「重跑失败就保留原修法」，而那恰恰是把
+  // **更新前**算出的修法当成当前修法端出去。分两种情况：
+  //   update 真跑过（update_failed / still_mismatched）+ 重新检查又失败 ⇒ 现在到底该怎么修是**未知**，
+  //     绝不能给可能反向的命令，只能说清楚并指向权威判据；
+  //   一个字节都没动（claude_unavailable 等）⇒ 原修法仍然准确，照常给。
+  function throwOnSecondPreflight(h: Harness): void {
     let calls = 0;
     const first = h.deps.preflight;
     h.deps.preflight = async (channel) => {
@@ -316,8 +315,35 @@ describe("自愈失败后的修法要反映当前状态（#1014 review）", () =
       if (calls > 1) throw new Error("boom");
       return first(channel);
     };
+  }
+
+  test("update 跑过 + 重新检查失败 ⇒ 不给更新前的修法，改说「现在不知道」并指向 doctor", async () => {
+    const h = harness([mismatched(OLD_PLUGIN, MISMATCH_FIX)], {
+      kind: "update_failed",
+      before: OLD_PLUGIN,
+      after: OLD_PLUGIN,
+      fix: "claude plugin update agentparty@agentparty",
+    });
+    throwOnSecondPreflight(h);
     expect(await capture(h, () => run(["dev"], h.deps))).toBe(1);
-    expect(h.err.join("\n")).toContain(MISMATCH_FIX.trim());
+    const err = h.err.join("\n");
+    expect(err).not.toContain(MISMATCH_FIX.trim());
+    expect(err).toContain("重新检查没成功");
+    expect(err).toContain("party doctor claude-plugin --json");
+    expect(h.launches).toHaveLength(0);
+  });
+
+  test("插件一个字节没动（claude 不在 PATH）+ 重新检查失败 ⇒ 原修法仍准确，照常给", async () => {
+    const h = harness([mismatched(OLD_PLUGIN, MISMATCH_FIX)], {
+      kind: "claude_unavailable",
+      before: undefined,
+      after: undefined,
+    });
+    throwOnSecondPreflight(h);
+    expect(await capture(h, () => run(["dev"], h.deps))).toBe(1);
+    const err = h.err.join("\n");
+    expect(err).toContain(MISMATCH_FIX.trim());
+    expect(err).not.toContain("重新检查没成功");
   });
 
   test("预发行版本号 ⇒ 不自愈（版本关系判不准就别动插件）", () => {

--- a/cli/test/claude-launch-plugin-selfheal.test.ts
+++ b/cli/test/claude-launch-plugin-selfheal.test.ts
@@ -1,0 +1,220 @@
+// #1013：`party claude` 撞到「插件旧于 CLI」应该自己 update 完直接启动，而不是让人手敲命令。
+// 这里钉住四档：旧+成功⇒启动；旧+失败⇒不启动 + 手动命令；新于 CLI⇒绝不 update；开关关掉⇒回到今天。
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  NO_AUTO_PLUGIN_UPDATE_FLAG,
+  run,
+  shouldSelfHealPluginVersion,
+  type ClaudeLaunchDependencies,
+  type ClaudeLaunchPreflight,
+} from "../src/commands/claude-launch";
+import type { ClaudePluginSyncResult } from "../src/claude-plugin-sync";
+
+const CLI = "0.2.223";
+const OLD_PLUGIN = "0.2.222";
+const NEW_PLUGIN = "0.2.224";
+
+const MISMATCH_FIX =
+  `  fix: claude plugin update agentparty@agentparty (installed ${OLD_PLUGIN}, runtime ${CLI})`;
+const UPGRADE_FIX = "  fix: party upgrade (installed plugin is newer than runtime)";
+
+function mismatched(pluginVersion: string, fix: string): ClaudeLaunchPreflight {
+  return {
+    blockers: ["plugin_version_mismatch", "listener_not_observed"],
+    listener: "not_observed",
+    fix_lines: [fix],
+    plugin_version: pluginVersion,
+    runtime_version: CLI,
+  };
+}
+
+const ready: ClaudeLaunchPreflight = {
+  blockers: ["listener_not_observed"],
+  listener: "not_observed",
+  fix_lines: [],
+  plugin_version: CLI,
+  runtime_version: CLI,
+};
+
+interface Harness {
+  deps: ClaudeLaunchDependencies;
+  launches: string[][];
+  syncCalls: string[];
+  preflights: number;
+  out: string[];
+  err: string[];
+}
+
+function harness(
+  preflights: ClaudeLaunchPreflight[],
+  sync: ClaudePluginSyncResult | undefined,
+): Harness {
+  const state: Harness = {
+    launches: [],
+    syncCalls: [],
+    preflights: 0,
+    out: [],
+    err: [],
+    deps: undefined as unknown as ClaudeLaunchDependencies,
+  };
+  state.deps = {
+    preflight: async () => {
+      const next = preflights[Math.min(state.preflights, preflights.length - 1)]!;
+      state.preflights += 1;
+      return next;
+    },
+    ...(sync === undefined
+      ? {}
+      : {
+          syncPlugin: (cliVersion: string) => {
+            state.syncCalls.push(cliVersion);
+            return sync;
+          },
+        }),
+    launch(args) {
+      state.launches.push(args);
+      return { status: 0 };
+    },
+    home: mkdtempSync(join(tmpdir(), "agentparty-selfheal-")),
+    env: {},
+  };
+  return state;
+}
+
+async function capture<T>(h: Harness, fn: () => Promise<T>): Promise<T> {
+  const log = console.log;
+  const error = console.error;
+  console.log = (...args: unknown[]) => void h.out.push(args.map(String).join(" "));
+  console.error = (...args: unknown[]) => void h.err.push(args.map(String).join(" "));
+  try {
+    return await fn();
+  } finally {
+    console.log = log;
+    console.error = error;
+  }
+}
+
+describe("party claude plugin self-heal (#1013)", () => {
+  test("plugin older than CLI + update succeeds: updates, re-checks, and launches", async () => {
+    const h = harness([mismatched(OLD_PLUGIN, MISMATCH_FIX), ready], {
+      kind: "updated",
+      before: OLD_PLUGIN,
+      after: CLI,
+    });
+
+    expect(await capture(h, () => run(["dev"], h.deps))).toBe(0);
+
+    // 自愈跑过一次，目标是 CLI 版本（不是插件版本）。
+    expect(h.syncCalls).toEqual([CLI]);
+    // 修完必须重跑 preflight，别的 blocker 不因自愈被跳过。
+    expect(h.preflights).toBe(2);
+    // 真的启动了——这是本 issue 的要点：不再让用户重跑一次 `party claude`。
+    expect(h.launches).toHaveLength(1);
+    const out = h.out.join("\n");
+    expect(out).toContain("claude plugin update agentparty@agentparty");
+    expect(out).toContain(OLD_PLUGIN);
+    expect(out).toContain(CLI);
+    // 不该再印那条「你自己去敲」的手动修法。
+    expect(h.err.join("\n")).not.toContain(MISMATCH_FIX);
+    expect(h.err.join("\n")).not.toContain("not launch-ready");
+  });
+
+  test("plugin older than CLI + update fails: no launch, manual command plus the reason", async () => {
+    const h = harness([mismatched(OLD_PLUGIN, MISMATCH_FIX)], {
+      kind: "update_failed",
+      before: OLD_PLUGIN,
+      after: OLD_PLUGIN,
+      fix: "claude plugin update agentparty@agentparty",
+    });
+
+    expect(await capture(h, () => run(["dev"], h.deps))).toBe(1);
+
+    expect(h.syncCalls).toEqual([CLI]);
+    expect(h.launches).toHaveLength(0);
+    const err = h.err.join("\n");
+    expect(err).toContain("not launch-ready");
+    expect(err).toContain(MISMATCH_FIX);
+    // 失败原因要说出来，不能只丢一条命令。
+    expect(err).toContain("失败");
+  });
+
+  test("plugin newer than CLI: never runs update, keeps the party upgrade advice", async () => {
+    const h = harness([mismatched(NEW_PLUGIN, UPGRADE_FIX)], {
+      kind: "updated",
+      before: NEW_PLUGIN,
+      after: CLI,
+    });
+
+    expect(await capture(h, () => run(["dev"], h.deps))).toBe(1);
+
+    // #1011：跑 update 就是降级。一次都不许调。
+    expect(h.syncCalls).toEqual([]);
+    expect(h.preflights).toBe(1);
+    expect(h.launches).toHaveLength(0);
+    expect(h.err.join("\n")).toContain("party upgrade");
+  });
+
+  test(`${NO_AUTO_PLUGIN_UPDATE_FLAG} keeps today's behaviour`, async () => {
+    const h = harness([mismatched(OLD_PLUGIN, MISMATCH_FIX)], {
+      kind: "updated",
+      before: OLD_PLUGIN,
+      after: CLI,
+    });
+
+    expect(await capture(h, () => run(["dev", NO_AUTO_PLUGIN_UPDATE_FLAG], h.deps))).toBe(1);
+
+    expect(h.syncCalls).toEqual([]);
+    expect(h.launches).toHaveLength(0);
+    const err = h.err.join("\n");
+    expect(err).toContain("not launch-ready");
+    expect(err).toContain(MISMATCH_FIX);
+  });
+
+  test(`${NO_AUTO_PLUGIN_UPDATE_FLAG} is not forwarded to Claude and does not break the channel arg`, async () => {
+    const h = harness([ready], undefined);
+
+    expect(await capture(h, () => run([NO_AUTO_PLUGIN_UPDATE_FLAG, "dev", "--", "--model", "sonnet"], h.deps))).toBe(0);
+
+    expect(h.launches).toHaveLength(1);
+    expect(h.launches[0]).not.toContain(NO_AUTO_PLUGIN_UPDATE_FLAG);
+    expect(h.launches[0]).toContain("sonnet");
+  });
+
+  test("self-heal does not swallow other blockers found after the update", async () => {
+    const h = harness(
+      [
+        mismatched(OLD_PLUGIN, MISMATCH_FIX),
+        {
+          blockers: ["identity_unavailable", "listener_not_observed"],
+          listener: "not_observed",
+          fix_lines: ["  fix: identity"],
+          plugin_version: CLI,
+          runtime_version: CLI,
+        },
+      ],
+      { kind: "updated", before: OLD_PLUGIN, after: CLI },
+    );
+
+    expect(await capture(h, () => run(["dev"], h.deps))).toBe(1);
+
+    expect(h.launches).toHaveLength(0);
+    expect(h.err.join("\n")).toContain("identity_unavailable");
+  });
+
+  test("shouldSelfHealPluginVersion only fires for a strictly older readable plugin", () => {
+    expect(shouldSelfHealPluginVersion(mismatched(OLD_PLUGIN, MISMATCH_FIX))).toBe(true);
+    expect(shouldSelfHealPluginVersion(mismatched(NEW_PLUGIN, UPGRADE_FIX))).toBe(false);
+    expect(shouldSelfHealPluginVersion(mismatched(CLI, MISMATCH_FIX))).toBe(false);
+    expect(shouldSelfHealPluginVersion(ready)).toBe(false);
+    expect(
+      shouldSelfHealPluginVersion({
+        blockers: ["plugin_version_mismatch"],
+        listener: "not_checked",
+        runtime_version: CLI,
+      }),
+    ).toBe(false);
+  });
+});

--- a/cli/test/claude-launch-plugin-selfheal.test.ts
+++ b/cli/test/claude-launch-plugin-selfheal.test.ts
@@ -1,7 +1,7 @@
 // #1013：`party claude` 撞到「插件旧于 CLI」应该自己 update 完直接启动，而不是让人手敲命令。
 // 这里钉住四档：旧+成功⇒启动；旧+失败⇒不启动 + 手动命令；新于 CLI⇒绝不 update；开关关掉⇒回到今天。
-import { describe, expect, test } from "bun:test";
-import { mkdtempSync } from "node:fs";
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -38,6 +38,17 @@ const ready: ClaudeLaunchPreflight = {
   plugin_version: CLI,
   runtime_version: CLI,
 };
+
+// TMPDIR 是持久路径：每个 harness 建的临时目录都要收回去，别让 agentparty-selfheal-* 越积越多
+// （coderabbit on #1014）。
+const tempDirs: string[] = [];
+function trackTemp(dir: string): string {
+  tempDirs.push(dir);
+  return dir;
+}
+afterEach(() => {
+  while (tempDirs.length > 0) rmSync(tempDirs.pop()!, { recursive: true, force: true });
+});
 
 interface Harness {
   deps: ClaudeLaunchDependencies;
@@ -78,7 +89,7 @@ function harness(
       state.launches.push(args);
       return { status: 0 };
     },
-    home: mkdtempSync(join(tmpdir(), "agentparty-selfheal-")),
+    home: trackTemp(mkdtempSync(join(tmpdir(), "agentparty-selfheal-"))),
     env: {},
   };
   return state;
@@ -270,5 +281,46 @@ describe(`${NO_AUTO_PLUGIN_UPDATE_FLAG} 的位置（#1014 review）`, () => {
     expect(h.syncCalls).toEqual([CLI]); // 开关没被误触发
     expect(h.launches).toHaveLength(1);
     expect(h.launches[0]).toContain(NO_AUTO_PLUGIN_UPDATE_FLAG); // 原样传给 claude
+  });
+});
+
+// coderabbit on #1014：自愈失败后仍打第一次 preflight 的 fix_lines —— 如果这次 update 把状态
+// 换成了另一种不匹配（插件反而新于 CLI），用户会拿到过时的 `claude plugin update`，
+// 而正确修法已经是 `party upgrade`。失败也要重跑 preflight，按当前事实给修法。
+describe("自愈失败后的修法要反映当前状态（#1014 review）", () => {
+  test("update 后状态翻成「插件新于 CLI」⇒ 打的是 party upgrade，不是过时的 plugin update", async () => {
+    const h = harness(
+      [mismatched(OLD_PLUGIN, MISMATCH_FIX), mismatched(NEW_PLUGIN, UPGRADE_FIX)],
+      { kind: "still_mismatched", before: OLD_PLUGIN, after: NEW_PLUGIN },
+    );
+    expect(await capture(h, () => run(["dev"], h.deps))).toBe(1);
+    expect(h.syncCalls).toEqual([CLI]);
+    expect(h.preflights).toBe(2); // 失败也重跑了
+    expect(h.launches).toHaveLength(0);
+    const err = h.err.join("\n");
+    expect(err).toContain(UPGRADE_FIX.trim());
+    expect(err).not.toContain(MISMATCH_FIX.trim());
+  });
+
+  test("重跑 preflight 抛异常 ⇒ 保留原来的修法，不比现在差", async () => {
+    const h = harness([mismatched(OLD_PLUGIN, MISMATCH_FIX)], {
+      kind: "update_failed",
+      before: OLD_PLUGIN,
+      after: OLD_PLUGIN,
+      fix: "claude plugin update agentparty@agentparty",
+    });
+    let calls = 0;
+    const first = h.deps.preflight;
+    h.deps.preflight = async (channel) => {
+      calls += 1;
+      if (calls > 1) throw new Error("boom");
+      return first(channel);
+    };
+    expect(await capture(h, () => run(["dev"], h.deps))).toBe(1);
+    expect(h.err.join("\n")).toContain(MISMATCH_FIX.trim());
+  });
+
+  test("预发行版本号 ⇒ 不自愈（版本关系判不准就别动插件）", () => {
+    expect(shouldSelfHealPluginVersion(mismatched("0.2.223-beta.1", MISMATCH_FIX))).toBe(false);
   });
 });

--- a/cli/test/claude-launch-plugin-selfheal.test.ts
+++ b/cli/test/claude-launch-plugin-selfheal.test.ts
@@ -243,12 +243,25 @@ describe(`${NO_AUTO_PLUGIN_UPDATE_FLAG} 的位置（#1014 review）`, () => {
     expect(h.syncCalls).toEqual([]);
   });
 
-  test("与 --lang 混用不打架", async () => {
+  // codex stop-time review on a1b5d78：这条原来只断言「没有 usage:」+「没调 update」，
+  // 而 run() 在 --lang 落盘失败时会**在 preflight 之前**就 return 1 —— 两条断言照样成立，
+  // 等于因为提前报错而假绿；而且没注入 storeLang 时它会调真的 storeWakeLang()，
+  // 有可能把 lang=zh 写进本机真实的 agent config。两个毛病一起修：注入 storeLang，
+  // 并把判据改成「真的走到了 preflight」这种只有解析成功才可能出现的事实。
+  test("与 --lang 混用不打架：lang 照常落盘、频道照常解析、自愈仍被关掉", async () => {
     const h = harness([mismatched(OLD_PLUGIN, MISMATCH_FIX)], { kind: "updated", before: OLD_PLUGIN, after: CLI });
-    await capture(h, () => run(["--lang", "zh", NO_AUTO_PLUGIN_UPDATE_FLAG, "dev"], h.deps));
-    const err = h.err.join("\n");
-    expect(err).not.toContain("usage:");
-    expect(h.syncCalls).toEqual([]);
+    const stored: string[] = [];
+    h.deps.storeLang = (lang: string) => {
+      stored.push(lang);
+      return true; // 绝不碰真实 config
+    };
+    const code = await capture(h, () => run(["--lang", "zh", NO_AUTO_PLUGIN_UPDATE_FLAG, "dev"], h.deps));
+    expect(stored).toEqual(["zh"]);
+    // 解析成功的硬证据：真的走到了 preflight（flag 没被当成位置参数、也没在 --lang 那步早退）。
+    expect(h.preflights).toBe(1);
+    expect(code).toBe(1); // 版本不一致仍是 blocker，只是不自愈
+    expect(h.syncCalls).toEqual([]); // 开关生效
+    expect(h.err.join("\n")).not.toContain("usage:");
   });
 
   test("放在 `--` 之后属于 claude 的参数：不当开关，自愈照常发生", async () => {

--- a/cli/test/claude-launch-plugin-selfheal.test.ts
+++ b/cli/test/claude-launch-plugin-selfheal.test.ts
@@ -317,6 +317,26 @@ describe("自愈失败后的修法要反映当前状态（#1014 review）", () =
     };
   }
 
+  // codex stop-time review on 916778f：抹修法要**只抹插件那条**。auth / channel_unbound 之类
+  // 与插件无关的修法照样准确，被连坐抹掉等于把「插件状态未知」升级成「什么都不告诉你」。
+  test("只抹插件那条修法：channel_unbound 等无关修法照常给", async () => {
+    const INIT_FIX = "  fix: party init --channel <channel>";
+    const both: ClaudeLaunchPreflight = {
+      blockers: ["plugin_version_mismatch", "channel_unbound", "listener_not_observed"],
+      listener: "not_observed",
+      fix_lines: [MISMATCH_FIX, INIT_FIX],
+      plugin_version: OLD_PLUGIN,
+      runtime_version: CLI,
+    };
+    const h = harness([both], { kind: "update_failed", before: OLD_PLUGIN, after: OLD_PLUGIN });
+    throwOnSecondPreflight(h);
+    expect(await capture(h, () => run(["dev"], h.deps))).toBe(1);
+    const err = h.err.join("\n");
+    expect(err).not.toContain(MISMATCH_FIX.trim()); // 插件那条：可能已过时，抹掉
+    expect(err).toContain(INIT_FIX.trim()); // 与插件无关：照常给
+    expect(err).toContain("party doctor claude-plugin --json");
+  });
+
   test("update 跑过 + 重新检查失败 ⇒ 不给更新前的修法，改说「现在不知道」并指向 doctor", async () => {
     const h = harness([mismatched(OLD_PLUGIN, MISMATCH_FIX)], {
       kind: "update_failed",

--- a/cli/test/claude-launch-plugin-selfheal.test.ts
+++ b/cli/test/claude-launch-plugin-selfheal.test.ts
@@ -218,3 +218,44 @@ describe("party claude plugin self-heal (#1013)", () => {
     ).toBe(false);
   });
 });
+
+// codex stop-time review on #1014 怀疑「`--no-auto-plugin-update` 放在 `--` 之前会被当成频道位置参数」。
+// 实测三种位置都正确（flag 被摘掉、频道照常解析），但当时**一条用例都没钉住位置**——补上，
+// 免得以后有人改参数解析时把它摔回去。
+describe(`${NO_AUTO_PLUGIN_UPDATE_FLAG} 的位置（#1014 review）`, () => {
+  test("跟在频道后面：频道仍是 dev，自愈被关掉", async () => {
+    const h = harness([mismatched(OLD_PLUGIN, MISMATCH_FIX)], { kind: "updated", before: OLD_PLUGIN, after: CLI });
+    expect(await capture(h, () => run(["dev", NO_AUTO_PLUGIN_UPDATE_FLAG], h.deps))).toBe(1);
+    // 关键：没有「channel must match」「usage:」这类解析错——它没被当成位置参数。
+    const err = h.err.join("\n");
+    expect(err).not.toContain("channel must match");
+    expect(err).not.toContain("usage:");
+    expect(h.syncCalls).toEqual([]); // 开关生效：一次 update 都不调
+    expect(h.preflights).toBe(1);
+  });
+
+  test("排在频道前面：一样解析得出频道、一样关掉自愈", async () => {
+    const h = harness([mismatched(OLD_PLUGIN, MISMATCH_FIX)], { kind: "updated", before: OLD_PLUGIN, after: CLI });
+    expect(await capture(h, () => run([NO_AUTO_PLUGIN_UPDATE_FLAG, "dev"], h.deps))).toBe(1);
+    const err = h.err.join("\n");
+    expect(err).not.toContain("channel must match");
+    expect(err).not.toContain("usage:");
+    expect(h.syncCalls).toEqual([]);
+  });
+
+  test("与 --lang 混用不打架", async () => {
+    const h = harness([mismatched(OLD_PLUGIN, MISMATCH_FIX)], { kind: "updated", before: OLD_PLUGIN, after: CLI });
+    await capture(h, () => run(["--lang", "zh", NO_AUTO_PLUGIN_UPDATE_FLAG, "dev"], h.deps));
+    const err = h.err.join("\n");
+    expect(err).not.toContain("usage:");
+    expect(h.syncCalls).toEqual([]);
+  });
+
+  test("放在 `--` 之后属于 claude 的参数：不当开关，自愈照常发生", async () => {
+    const h = harness([mismatched(OLD_PLUGIN, MISMATCH_FIX), ready], { kind: "updated", before: OLD_PLUGIN, after: CLI });
+    expect(await capture(h, () => run(["dev", "--", NO_AUTO_PLUGIN_UPDATE_FLAG], h.deps))).toBe(0);
+    expect(h.syncCalls).toEqual([CLI]); // 开关没被误触发
+    expect(h.launches).toHaveLength(1);
+    expect(h.launches[0]).toContain(NO_AUTO_PLUGIN_UPDATE_FLAG); // 原样传给 claude
+  });
+});

--- a/cli/test/doctor-identity-error.test.ts
+++ b/cli/test/doctor-identity-error.test.ts
@@ -1,0 +1,114 @@
+// #1013：`identity_unavailable` 以前把超时 / 401 / 网络不通挤成一个词，而这三种的处置完全相反。
+// 这里钉住分档本身、报告字段，以及 fix_lines 是否对症。
+import { describe, expect, test } from "bun:test";
+import type { PresenceEntry } from "@agentparty/shared";
+import {
+  classifyIdentityError,
+  claudePluginDoctorFixLines,
+  inspectClaudePluginReadiness,
+  type ClaudePluginDoctorDependencies,
+} from "../src/commands/doctor";
+import { RestError } from "../src/rest";
+
+function deps(identity: () => Promise<never>): ClaudePluginDoctorDependencies {
+  return {
+    claudeVersion: () => "2.1.228 (Claude Code)",
+    claudePlugins: () => null,
+    inspectBundle: () => ({ valid: true, launcherExecutable: true }),
+    resolveAuth: async () => ({
+      server: "https://agentparty.example.com",
+      token: "private-test-token",
+      auth_source: "runtime_config",
+      config: { kind: "workspace", path: "/private/config", workspace_id: "workspace" },
+      account: { present: false, path: "/private/account" },
+    }),
+    channel: () => "dev",
+    identity,
+    presence: async () => [] as PresenceEntry[],
+    runtimeTopology: () => undefined,
+    runtimePeers: async () => ({ self: "nobody", peers: [] }) as never,
+  };
+}
+
+const timeoutError = (): never => {
+  throw new DOMException("The operation timed out.", "TimeoutError");
+};
+const unauthorizedError = (): never => {
+  throw new RestError(401, "unauthorized", "agent token revoked");
+};
+const networkError = (): never => {
+  throw Object.assign(new TypeError("fetch failed"), { cause: Object.assign(new Error("dns"), { code: "ENOTFOUND" }) });
+};
+
+describe("identity_unavailable classification (#1013)", () => {
+  test("classifies timeout, 401, network, and unknown apart", () => {
+    expect(classifyIdentityError(new DOMException("timed out", "TimeoutError")).kind).toBe("timeout");
+    expect(classifyIdentityError(new DOMException("aborted", "AbortError")).kind).toBe("timeout");
+    expect(classifyIdentityError(new RestError(401, "unauthorized", "nope")).kind).toBe("unauthorized");
+    expect(classifyIdentityError(new RestError(403, "forbidden", "nope")).kind).toBe("unauthorized");
+    expect(classifyIdentityError(new RestError(502, null, "bad gateway")).kind).toBe("network");
+    expect(
+      classifyIdentityError(Object.assign(new TypeError("fetch failed"), { cause: { code: "ECONNREFUSED" } })).kind,
+    ).toBe("network");
+    expect(classifyIdentityError(Object.assign(new Error("boom"), { code: "ENOTFOUND" })).kind).toBe("network");
+    expect(classifyIdentityError(new RestError(418, null, "teapot")).kind).toBe("unknown");
+    expect(classifyIdentityError(new Error("something else")).kind).toBe("unknown");
+  });
+
+  test("scrubs terminal control sequences out of the server's own words", () => {
+    const classified = classifyIdentityError(
+      new RestError(401, "unauthorized", "\u001b[31mrevoked\u0007\nby owner"),
+    );
+    expect(classified.kind).toBe("unauthorized");
+    expect(classified.message).not.toContain("\u001b");
+    expect(classified.message).not.toContain("\u0007");
+    expect(classified.message).not.toContain("\n");
+    expect(classified.message).toContain("revoked");
+  });
+
+  test("the report carries the classification per failure mode", async () => {
+    for (const [thrower, expected] of [
+      [timeoutError, "timeout"],
+      [unauthorizedError, "unauthorized"],
+      [networkError, "network"],
+    ] as const) {
+      const report = await inspectClaudePluginReadiness(undefined, deps(async () => thrower()));
+      expect(report.blockers).toContain("identity_unavailable");
+      expect(report.auth.identity_error).toBe(expected);
+      expect(typeof report.auth.identity_error_message).toBe("string");
+    }
+  });
+
+  test("a healthy identity leaves the new fields absent (old schema untouched)", async () => {
+    const report = await inspectClaudePluginReadiness(undefined, {
+      ...deps(async () => timeoutError()),
+      identity: async () => ({ name: "a", email: null, kind: "agent", role: "agent", owner: null }),
+    });
+    expect(report.blockers).not.toContain("identity_unavailable");
+    expect(report.auth.identity_error).toBeUndefined();
+    expect(report.auth.identity_error_message).toBeUndefined();
+  });
+
+  test("fix lines are per-cause, not one generic sentence", () => {
+    const base = {
+      blockers: ["identity_unavailable" as const],
+      plugin: { installed: true, enabled: true, bundle_valid: true, launcher_executable: true },
+      runtime_version: "0.2.223",
+    };
+    const line = (kind: "timeout" | "unauthorized" | "network" | "unknown") =>
+      claudePluginDoctorFixLines({ ...base, auth: { identity_error: kind, identity_error_message: "why" } })
+        .join("\n");
+
+    expect(line("timeout")).toContain("retry");
+    expect(line("unauthorized")).toContain("party init --token");
+    expect(line("network")).toContain("network");
+    expect(line("unknown")).toContain("auth.identity_error");
+
+    // 四档必须互不相同——否则「分档」等于没做。
+    const all = (["timeout", "unauthorized", "network", "unknown"] as const).map(line);
+    expect(new Set(all).size).toBe(4);
+
+    // 老调用方不传 auth 也不能崩，落兜底那条。
+    expect(claudePluginDoctorFixLines(base).join("\n")).toContain("could not read this agent identity");
+  });
+});

--- a/plugins/agentparty/skills/agentparty/SKILL.md
+++ b/plugins/agentparty/skills/agentparty/SKILL.md
@@ -206,7 +206,12 @@ the development one and the channel is refused again. Extra Claude flags go afte
 (`party claude <channel> -- --model sonnet`); to stop retyping them, set machine-local defaults once
 with `party claude --default-args -- <claude args...>` (stored in
 `$AGENTPARTY_HOME/claude-default-args.json`, prepended before explicit `--` args, printed with
-their source at every launch; `--default-args --` clears, `--show-default-args` inspects). Nothing
+their source at every launch; `--default-args --` clears, `--show-default-args` inspects). If the
+installed plugin is older than the `party` CLI, the launcher runs
+`claude plugin update agentparty@agentparty` itself and then launches — it starts a fresh Claude
+process, so the updated plugin is loaded with nothing to restart; it prints the command it ran and
+the versions it moved between. It never updates when the plugin is *newer* than the CLI (that is a
+downgrade — run `party upgrade`), and `--no-auto-plugin-update` turns the self-heal off. Nothing
 is defaulted unless you wrote it there — `--dangerously-skip-permissions` in particular is only ever
 a default you opted into yourself. The plugin still requires the `party` release
 binary: it is the install/discovery and lifecycle shell, not a second implementation of auth,

--- a/skills/agentparty/SKILL.md
+++ b/skills/agentparty/SKILL.md
@@ -206,7 +206,12 @@ the development one and the channel is refused again. Extra Claude flags go afte
 (`party claude <channel> -- --model sonnet`); to stop retyping them, set machine-local defaults once
 with `party claude --default-args -- <claude args...>` (stored in
 `$AGENTPARTY_HOME/claude-default-args.json`, prepended before explicit `--` args, printed with
-their source at every launch; `--default-args --` clears, `--show-default-args` inspects). Nothing
+their source at every launch; `--default-args --` clears, `--show-default-args` inspects). If the
+installed plugin is older than the `party` CLI, the launcher runs
+`claude plugin update agentparty@agentparty` itself and then launches — it starts a fresh Claude
+process, so the updated plugin is loaded with nothing to restart; it prints the command it ran and
+the versions it moved between. It never updates when the plugin is *newer* than the CLI (that is a
+downgrade — run `party upgrade`), and `--no-auto-plugin-update` turns the self-heal off. Nothing
 is defaulted unless you wrote it there — `--dangerously-skip-permissions` in particular is only ever
 a default you opted into yourself. The plugin still requires the `party` release
 binary: it is the install/discovery and lifecycle shell, not a second implementation of auth,


### PR DESCRIPTION
## 根因

**问题 1 — `party claude` 本可以自己修完就启动。**
`claude-launch` 的 preflight 拿到 `plugin_version_mismatch` 就一律拒启动，打印 `claude plugin update agentparty@agentparty` + 「restart Claude Code」让人手敲。但 `party claude` 干的事就是**起一个新的 claude 进程**——插件更新后新会话本来就加载新版本，压根没有「重启当前会话」这回事。而 `syncClaudePluginToCli`（#985/#993，`party upgrade` 用的就是它）早就在仓库里。

**问题 2 — `identity_unavailable` 一个词盖了三种病。**
`cli/src/commands/doctor.ts` 里 `deps.identity(...)` 的 `catch {}` 把超时、401、DNS/网络不通全压成同一个 blocker。这三种的处置完全相反：超时该重试，401 该重新 join，网络不通该查 server / 代理。

## 修法

- `shouldSelfHealPluginVersion()`（纯函数）：命中 `plugin_version_mismatch` **且**两边版本都读得出 **且**插件**严格旧于** CLI 时才自愈。插件比 CLI 新 ⇒ 一次 `update` 都不调（那是降级，#1011），照旧走 `party upgrade` 那条 fix line。
- 自愈成功 ⇒ 打印「跑了哪条命令、把插件从 X 更新到 Y」，然后**重新跑一次 preflight** 再判断能不能启动。自愈只处理版本这一条，`identity_unavailable` / listener 等 blocker 一个都不会因此被跳过（有专门用例钉住）。
- 自愈失败（`update_failed` / `still_mismatched` / `claude_unavailable` / `unreadable` / `not_installed`）⇒ 不启动，退回原来的手动命令，并把失败原因逐档说清。
- `--no-auto-plugin-update` 关掉自愈，行为回到今天；这个 flag 不转发给 claude、也不参与位置参数校验。
- doctor 新增 `auth.identity_error: "timeout" | "unauthorized" | "network" | "unknown"` 与 `auth.identity_error_message`。message 先过 `stripTerminalControls` 再折行、截断到 200 字符——服务端原文不直接进终端。`claudePluginDoctorFixLines` 按档给对症建议；`auth` 是**可选**参数，旧调用方不传照旧工作（落 unknown 兜底那条）。**只新增字段，旧字段语义与 schema 版本不动。**

## 测试证据

新增 `cli/test/claude-launch-plugin-selfheal.test.ts`（7 例）与 `cli/test/doctor-identity-error.test.ts`（5 例），覆盖 issue「测试」全部条目：插件旧+成功⇒不打印手动命令 / 打印「已更新到 X」/ launch 桩被调用一次；旧+失败⇒不启动+手动命令+失败原因；插件新于 CLI⇒`syncPlugin` 零调用；`--no-auto-plugin-update`⇒零调用；identity 三种异常的 `identity_error` 与 fix_lines 分别正确（且四档文案互不相同）。

```
$ cd cli && bunx tsc --noEmit                       # 干净
$ bun test test/claude-launch.test.ts test/claude-launch-default-args.test.ts \
           test/doctor-plugin.test.ts test/claude-launch-plugin-selfheal.test.ts \
           test/doctor-identity-error.test.ts
 58 pass / 0 fail / 260 expect()
```

**变异自检（两条都真红过）**
- 把自愈分支短路掉（`if (false && …)`）⇒ `claude-launch-plugin-selfheal` **3 红**（含第一条「更新成功后继续启动」）。
- `classifyIdentityError` 恒返回 `"unknown"` ⇒ `doctor-identity-error` **3 红**。

`skills/agentparty/SKILL.md` 同步说明了新行为，已跑 `bun run sync:plugin` 更新镜像。

Closes #1013

https://claude.ai/code/session_01Az8CnUpayZzqpi1sh32Ssi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - `party claude` 检测到插件版本过旧时，可自动更新插件并重新检查后启动。
  - 新增 `--no-auto-plugin-update` 选项，可关闭自动更新并显示手动修复命令。
  - `party doctor` 现在区分身份读取失败原因，并提供针对性的修复建议。

- **问题修复**
  - 改进插件启动前检查，更新失败或仍存在其他问题时会阻止启动并说明原因。
  - 优化错误信息展示，避免终端控制字符影响报告可读性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->