### PR TITLE
fix(cli): token 被拒时先找本机同频道验活的身份，别一上来就让人去要新 token

### DIFF
--- a/cli/src/commands/doctor.ts
+++ b/cli/src/commands/doctor.ts
@@ -2,14 +2,13 @@
 import type { PresenceEntry, RuntimePeerDiscovery, RuntimeTopology } from "@agentparty/shared";
 import { lstatSync, readFileSync, realpathSync } from "node:fs";
 import { resolve } from "node:path";
-import { homedir } from "node:os";
-import { sep } from "node:path";
 import { spawnSync } from "node:child_process";
 import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
 import { localAgentConfigsForChannel, resolveChannel } from "../config";
 import { resolveAuthDetailed } from "../oidc-cli";
 import { fetchMe, fetchPresence, fetchRuntimePeers, RestError, type Identity } from "../rest";
 import { stripTerminalControls } from "../format";
+import { shellQuote } from "../codex-trust-gate";
 import { buildRuntimeTopology } from "../runtime-topology";
 import { INSTALL_LINE, OWNER_REPO, RUNNING_VERSION, compareVersions, pendingUpgrade } from "../upgrade";
 import { diagnoseCodexWake, formatCodexWakeDiagnosis } from "../wake-diagnosis";
@@ -91,19 +90,35 @@ export interface ClaudeAlternateIdentity {
 const ALTERNATE_IDENTITY_PROBE_LIMIT = 5;
 const ALTERNATE_IDENTITY_PROBE_TIMEOUT_MS = 5_000;
 
-function homeRelativePath(path: string): string {
-  const home = homedir();
-  return path === home ? "~" : path.startsWith(`${home}${sep}`) ? `~${path.slice(home.length)}` : path;
-}
-
-/** config 文件里读 token 只发生在这里：`localAgentConfigsForChannel` 按设计不返 token，
- *  读出来的 token 只进 fetch 的 Authorization 头，绝不进 argv / 日志 / 报告字段。 */
-function tokenAt(path: string): string | null {
+/**
+ * config 文件里读 token 只发生在这里：`localAgentConfigsForChannel` 按设计不返 token，
+ * 读出来的 token 只进 fetch 的 Authorization 头，绝不进 argv / 日志 / 报告字段。
+ *
+ * server 与 token **一次读出**：分两次读会在文件正被改写时把旧 server 配上新 token，
+ * 等于把新凭据发给上一个地址。
+ */
+function credentialsAt(path: string): { server: string; token: string } | null {
   try {
-    const parsed = JSON.parse(readFileSync(path, "utf8")) as { token?: unknown };
-    return typeof parsed.token === "string" && parsed.token !== "" ? parsed.token : null;
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as { server?: unknown; token?: unknown };
+    if (typeof parsed.server !== "string" || parsed.server === "") return null;
+    if (typeof parsed.token !== "string" || parsed.token === "") return null;
+    return { server: parsed.server.replace(/\/+$/, ""), token: parsed.token };
   } catch {
     return null;
+  }
+}
+
+/**
+ * 探活会把**别的 config 的 token** 主动发出去——这是本机诊断顺手扩大的凭据面，所以只发给 https。
+ * 明文 http 只放行 loopback（本地起 worker 调试的常规姿势）。
+ */
+export function safeProbeTarget(server: string): boolean {
+  try {
+    const url = new URL(server);
+    if (url.protocol === "https:") return true;
+    return url.protocol === "http:" && (url.hostname === "localhost" || url.hostname === "127.0.0.1" || url.hostname === "[::1]" || url.hostname === "::1");
+  } catch {
+    return false;
   }
 }
 
@@ -119,16 +134,16 @@ export async function probeLiveAlternateIdentities(
     : localAgentConfigsForChannel(channel, currentConfigPath, home)
   ).slice(0, ALTERNATE_IDENTITY_PROBE_LIMIT);
   const probed = await Promise.all(hints.map(async (hint): Promise<ClaudeAlternateIdentity[]> => {
-    const token = tokenAt(hint.path);
-    if (token === null) return [];
+    const credentials = credentialsAt(hint.path);
+    if (credentials === null || !safeProbeTarget(credentials.server)) return [];
     try {
       const identity = await fetchIdentity(
-        hint.server,
-        token,
+        credentials.server,
+        credentials.token,
         AbortSignal.timeout(ALTERNATE_IDENTITY_PROBE_TIMEOUT_MS),
       );
       if (identity.kind !== "agent") return [];
-      return [{ name: identity.name, path: hint.path, server: hint.server }];
+      return [{ name: identity.name, path: hint.path, server: credentials.server }];
     } catch {
       return [];
     }
@@ -671,9 +686,11 @@ export function claudePluginDoctorFixLines(
         const channelSlug = report.channel?.slug ?? "<channel>";
         lines.push(`  fix: the server rejected this token${suffix}`);
         for (const alternate of alternates) {
+          // name 是服务端给的字符串、path 来自 readdir：进终端前一律清洗，进命令一律 shell 引用，
+          // 否则一条「可以直接粘」的修法就成了注入面。
           lines.push(
-            `  fix: this machine still has a working #${channelSlug} identity ${alternate.name} — ` +
-              `AGENTPARTY_CONFIG=${homeRelativePath(alternate.path)} party claude ${channelSlug}`,
+            `  fix: this machine still has a working #${channelSlug} identity ${stripTerminalControls(alternate.name)} — ` +
+              `AGENTPARTY_CONFIG=${shellQuote(alternate.path)} party claude ${shellQuote(channelSlug)}`,
           );
         }
         lines.push("  fix: or re-bind a fresh token with party join <invite>");

--- a/cli/src/commands/doctor.ts
+++ b/cli/src/commands/doctor.ts
@@ -2,9 +2,11 @@
 import type { PresenceEntry, RuntimePeerDiscovery, RuntimeTopology } from "@agentparty/shared";
 import { lstatSync, readFileSync, realpathSync } from "node:fs";
 import { resolve } from "node:path";
+import { homedir } from "node:os";
+import { sep } from "node:path";
 import { spawnSync } from "node:child_process";
 import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
-import { resolveChannel } from "../config";
+import { localAgentConfigsForChannel, resolveChannel } from "../config";
 import { resolveAuthDetailed } from "../oidc-cli";
 import { fetchMe, fetchPresence, fetchRuntimePeers, RestError, type Identity } from "../rest";
 import { stripTerminalControls } from "../format";
@@ -69,6 +71,70 @@ export type ClaudePluginDoctorBlocker =
  * 分不出来的才落 `unknown`——它是兜底，不是默认。
  */
 export type ClaudeIdentityErrorKind = "timeout" | "unauthorized" | "network" | "unknown";
+
+/**
+ * 本机同频道、**已验活**的另一份身份（#1015）。
+ *
+ * token 被服务端拒了不等于这台机器没得用：`~/.agentparty/agents/` 里常有同频道的好几份 config
+ * （换过名字、重发过 token、project-agent 与自建各一份）。真机上三份 ludo 身份里两份 401、
+ * 一份 200——只报「有候选」会把人推向那两份死的，所以这里只收**真打过 `/api/me` 且回 200** 的。
+ */
+export interface ClaudeAlternateIdentity {
+  /** /api/me 回的名字（权威），不是 config 里缓存的那个。 */
+  name: string;
+  /** config 路径，直接拼进 AGENTPARTY_CONFIG=… 用。 */
+  path: string;
+  server: string;
+}
+
+/** 至多探几份、每份多久——诊断不该把终端卡住。 */
+const ALTERNATE_IDENTITY_PROBE_LIMIT = 5;
+const ALTERNATE_IDENTITY_PROBE_TIMEOUT_MS = 5_000;
+
+function homeRelativePath(path: string): string {
+  const home = homedir();
+  return path === home ? "~" : path.startsWith(`${home}${sep}`) ? `~${path.slice(home.length)}` : path;
+}
+
+/** config 文件里读 token 只发生在这里：`localAgentConfigsForChannel` 按设计不返 token，
+ *  读出来的 token 只进 fetch 的 Authorization 头，绝不进 argv / 日志 / 报告字段。 */
+function tokenAt(path: string): string | null {
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as { token?: unknown };
+    return typeof parsed.token === "string" && parsed.token !== "" ? parsed.token : null;
+  } catch {
+    return null;
+  }
+}
+
+/** 默认实现：同频道兄弟 config 逐个真问 `/api/me`，只留答 200 的。任何异常都当「这份不活」。 */
+export async function probeLiveAlternateIdentities(
+  channel: string,
+  currentConfigPath: string | null,
+  fetchIdentity: (server: string, token: string, signal: AbortSignal) => Promise<Identity> = fetchMe,
+  home?: string,
+): Promise<ClaudeAlternateIdentity[]> {
+  const hints = (home === undefined
+    ? localAgentConfigsForChannel(channel, currentConfigPath)
+    : localAgentConfigsForChannel(channel, currentConfigPath, home)
+  ).slice(0, ALTERNATE_IDENTITY_PROBE_LIMIT);
+  const probed = await Promise.all(hints.map(async (hint): Promise<ClaudeAlternateIdentity[]> => {
+    const token = tokenAt(hint.path);
+    if (token === null) return [];
+    try {
+      const identity = await fetchIdentity(
+        hint.server,
+        token,
+        AbortSignal.timeout(ALTERNATE_IDENTITY_PROBE_TIMEOUT_MS),
+      );
+      if (identity.kind !== "agent") return [];
+      return [{ name: identity.name, path: hint.path, server: hint.server }];
+    } catch {
+      return [];
+    }
+  }));
+  return probed.flat();
+}
 
 /** 网络层失败的指纹：fetch 自己只抛一句 "fetch failed"，真正的原因在 cause.code 里。 */
 const NETWORK_ERROR_CODES = [
@@ -186,6 +252,11 @@ export interface ClaudePluginDoctorReport {
     identity_error?: ClaudeIdentityErrorKind;
     /** 同上，一句已清洗（stripTerminalControls + 截断）的短说明。 */
     identity_error_message?: string;
+    /**
+     * #1015：token 被拒时，本机同频道**验活过**的其它身份。只在 identity_error==="unauthorized"
+     * 时出现；一份都没验活就是空数组（与「没查」区分不开也无所谓——两种情况修法相同）。
+     */
+    live_alternate_identities?: ClaudeAlternateIdentity[];
   };
   channel: {
     slug?: string;
@@ -205,6 +276,11 @@ export interface ClaudePluginDoctorDependencies {
   resolveAuth(): ReturnType<typeof resolveAuthDetailed>;
   channel(explicit?: string): string | null;
   identity(server: string, token: string, signal: AbortSignal): Promise<Identity>;
+  /**
+   * #1015：token 被拒时找本机同频道还活着的身份。可选——省略即「不查」（返回空），
+   * 这样既有的测试 deps 不必联网，也不会去碰用户真实的 ~/.agentparty。
+   */
+  liveAlternateIdentities?(channel: string, currentConfigPath: string | null): Promise<ClaudeAlternateIdentity[]>;
   presence(server: string, token: string, channel: string, signal: AbortSignal): Promise<PresenceEntry[]>;
   runtimeTopology(server: string): RuntimeTopology | undefined;
   runtimePeers(
@@ -311,6 +387,8 @@ export const defaultClaudePluginDoctorDependencies: ClaudePluginDoctorDependenci
   resolveAuth: resolveAuthDetailed,
   channel: resolveChannel,
   identity: fetchMe,
+  liveAlternateIdentities: (channel, currentConfigPath) =>
+    probeLiveAlternateIdentities(channel, currentConfigPath),
   presence: fetchPresence,
   // `doctor` remains read-only. A live party claude listener has already
   // created the private installation secret; absence is reported, not repaired.
@@ -391,6 +469,7 @@ export async function inspectClaudePluginReadiness(
 
   let identity: Identity | null = null;
   let identityError: { kind: ClaudeIdentityErrorKind; message: string } | null = null;
+  let liveAlternates: ClaudeAlternateIdentity[] = [];
   let access: ClaudePluginDoctorReport["channel"]["access"] = "not_checked";
   let listener: ClaudePluginDoctorReport["channel"]["listener"] = "not_checked";
   let activityVisibility: ClaudePluginDoctorReport["channel"]["activity_visibility"] = "not_checked";
@@ -404,6 +483,15 @@ export async function inspectClaudePluginReadiness(
     } catch (err) {
       identityError = classifyIdentityError(err);
       blockers.push("identity_unavailable");
+    }
+  }
+  // #1015：token 被拒时，先看这台机器上同频道有没有还活着的身份——有的话修法是「切过去」，
+  // 而不是让人去要一个新 token。只收真打过 /api/me 的，未验证的候选一律不报。
+  if (identityError?.kind === "unauthorized" && channel !== null && deps.liveAlternateIdentities !== undefined) {
+    try {
+      liveAlternates = await deps.liveAlternateIdentities(channel, auth.config.path ?? null);
+    } catch {
+      liveAlternates = [];
     }
   }
   if (auth.server && auth.token && identity?.kind === "agent" && channel !== null) {
@@ -479,6 +567,7 @@ export async function inspectClaudePluginReadiness(
       ...(identityError === null
         ? {}
         : { identity_error: identityError.kind, identity_error_message: identityError.message }),
+      ...(liveAlternates.length === 0 ? {} : { live_alternate_identities: liveAlternates }),
     },
     channel: {
       ...(channel === null ? {} : { slug: channel }),
@@ -536,6 +625,8 @@ export function claudePluginDoctorFixLines(
   report: Pick<ClaudePluginDoctorReport, "blockers" | "plugin" | "runtime_version"> & {
     /** #1013：identity_unavailable 的分档；旧调用方不传也照旧工作（落 unknown 那条兜底文案）。 */
     auth?: Partial<ClaudePluginDoctorReport["auth"]>;
+    /** #1015：切身份的修法要把频道名写进命令里；旧调用方不传就退回 `<channel>` 占位。 */
+    channel?: Partial<ClaudePluginDoctorReport["channel"]>;
   },
 ): string[] {
   const lines: string[] = [];
@@ -568,11 +659,26 @@ export function claudePluginDoctorFixLines(
       case "timeout":
         lines.push(`  fix: /api/me did not answer within 5s${suffix}; retry, then check the server with party doctor`);
         break;
-      case "unauthorized":
-        lines.push(
-          `  fix: the server rejected this token${suffix}; re-bind an agent token with party init --token <agent-token> --channel <channel> (or party join <invite>)`,
-        );
+      case "unauthorized": {
+        const alternates = report.auth?.live_alternate_identities ?? [];
+        if (alternates.length === 0) {
+          lines.push(
+            `  fix: the server rejected this token${suffix}; re-bind an agent token with party init --token <agent-token> --channel <channel> (or party join <invite>)`,
+          );
+          break;
+        }
+        // 这台机器上已经有验活的同频道身份：先给「切过去」，那是零等待的修法。
+        const channelSlug = report.channel?.slug ?? "<channel>";
+        lines.push(`  fix: the server rejected this token${suffix}`);
+        for (const alternate of alternates) {
+          lines.push(
+            `  fix: this machine still has a working #${channelSlug} identity ${alternate.name} — ` +
+              `AGENTPARTY_CONFIG=${homeRelativePath(alternate.path)} party claude ${channelSlug}`,
+          );
+        }
+        lines.push("  fix: or re-bind a fresh token with party join <invite>");
         break;
+      }
       case "network":
         lines.push(
           `  fix: could not reach the AgentParty server${suffix}; check network/VPN/proxy and the server URL (party whoami shows which server this config points at)`,

--- a/cli/test/doctor-live-alternate-identity.test.ts
+++ b/cli/test/doctor-live-alternate-identity.test.ts
@@ -1,0 +1,174 @@
+// #1015：token 被服务端拒了，不等于这台机器没得用。~/.agentparty/agents/ 常有同频道的好几份 config
+// （真机 ludo：三份里两份 401、一份 200），旧修法却只有「去要个新 token」。
+//
+// 这里钉住的核心是**只报验活过的**：列未验证的候选比不列更坏——三份里猜一份，准会把人推向死的那份。
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { PresenceEntry } from "@agentparty/shared";
+import {
+  claudePluginDoctorFixLines,
+  inspectClaudePluginReadiness,
+  probeLiveAlternateIdentities,
+  type ClaudeAlternateIdentity,
+  type ClaudePluginDoctorDependencies,
+} from "../src/commands/doctor";
+import { RestError, type Identity } from "../src/rest";
+
+const agent = (name: string): Identity => ({ name, email: null, kind: "agent", role: "agent", owner: null });
+
+/** 一个只在临时目录里的 ~/.agentparty——绝不碰用户真实 config。 */
+function fakeHome(configs: { file: string; name: string; channel: string; token: string }[]): string {
+  const home = mkdtempSync(join(tmpdir(), "agentparty-1015-"));
+  mkdirSync(join(home, "agents"));
+  for (const config of configs) {
+    writeFileSync(
+      join(home, "agents", config.file),
+      JSON.stringify({
+        server: "https://agentparty.example.com",
+        token: config.token,
+        identity: { name: config.name, kind: "agent", role: "agent", channel_scope: config.channel },
+      }),
+    );
+  }
+  return home;
+}
+
+function deps(
+  identity: () => Promise<never>,
+  liveAlternateIdentities?: ClaudePluginDoctorDependencies["liveAlternateIdentities"],
+): ClaudePluginDoctorDependencies {
+  return {
+    claudeVersion: () => "2.1.228 (Claude Code)",
+    claudePlugins: () => null,
+    inspectBundle: () => ({ valid: true, launcherExecutable: true }),
+    resolveAuth: async () => ({
+      server: "https://agentparty.example.com",
+      token: "private-test-token",
+      auth_source: "runtime_config",
+      config: { kind: "workspace", path: "/private/config", workspace_id: "workspace" },
+      account: { present: false, path: "/private/account" },
+    }),
+    channel: () => "ludo",
+    identity,
+    ...(liveAlternateIdentities === undefined ? {} : { liveAlternateIdentities }),
+    presence: async () => [] as PresenceEntry[],
+    runtimeTopology: () => undefined,
+    runtimePeers: async () => ({ self: "nobody", peers: [] }) as never,
+  };
+}
+
+const revoked = (): never => {
+  throw new RestError(401, "unauthorized", "invalid or revoked token");
+};
+
+describe("live alternate identity probe (#1015)", () => {
+  test("only the config whose /api/me actually answers 200 is reported", async () => {
+    const home = fakeHome([
+      { file: "dead-one.json", name: "lark-ad72b3f9749e-ludo", channel: "ludo", token: "dead-1" },
+      { file: "dead-two.json", name: "leo-server", channel: "ludo", token: "dead-2" },
+      { file: "live.json", name: "server", channel: "ludo", token: "live-1" },
+      { file: "other-channel.json", name: "elsewhere", channel: "piggygo", token: "live-2" },
+    ]);
+    const asked: string[] = [];
+    const alternates = await probeLiveAlternateIdentities(
+      "ludo",
+      null,
+      async (_server, token) => {
+        asked.push(token);
+        if (token !== "live-1") throw new RestError(401, "unauthorized", "invalid or revoked token");
+        return agent("server");
+      },
+      home,
+    );
+
+    expect(alternates.map((entry) => entry.name)).toEqual(["server"]);
+    expect(alternates[0]!.path).toBe(join(home, "agents", "live.json"));
+    // 每一份都真问过服务端——「有 config 就当它活着」正是要修的毛病。
+    expect(asked.sort()).toEqual(["dead-1", "dead-2", "live-1"]);
+    // 别的频道的身份不算数，哪怕它 token 是好的。
+    expect(asked).not.toContain("live-2");
+  });
+
+  test("a human token on the same channel is not offered as an agent identity", async () => {
+    const home = fakeHome([{ file: "human.json", name: "leo", channel: "ludo", token: "human-1" }]);
+    const alternates = await probeLiveAlternateIdentities(
+      "ludo",
+      null,
+      async () => ({ name: "leo", email: null, kind: "human", role: "member", owner: null }),
+      home,
+    );
+    expect(alternates).toEqual([]);
+  });
+
+  test("the current config is not offered back to itself", async () => {
+    const home = fakeHome([{ file: "self.json", name: "server", channel: "ludo", token: "self-1" }]);
+    const alternates = await probeLiveAlternateIdentities(
+      "ludo",
+      join(home, "agents", "self.json"),
+      async () => agent("server"),
+      home,
+    );
+    expect(alternates).toEqual([]);
+  });
+
+  test("the report carries verified alternates only under a 401", async () => {
+    const probe = async (): Promise<ClaudeAlternateIdentity[]> => [
+      { name: "server", path: "/home/leo/.agentparty/agents/live.json", server: "https://agentparty.example.com" },
+    ];
+    const report = await inspectClaudePluginReadiness(undefined, deps(async () => revoked(), probe));
+    expect(report.auth.identity_error).toBe("unauthorized");
+    expect(report.auth.live_alternate_identities?.map((entry) => entry.name)).toEqual(["server"]);
+
+    // 超时不是「token 不对」，不该去问兄弟 config。
+    const timedOut = await inspectClaudePluginReadiness(
+      undefined,
+      deps(async () => {
+        throw new DOMException("timed out", "TimeoutError");
+      }, probe),
+    );
+    expect(timedOut.auth.live_alternate_identities).toBeUndefined();
+  });
+
+  test("a probe that blows up degrades to today's behaviour instead of failing the audit", async () => {
+    const report = await inspectClaudePluginReadiness(
+      undefined,
+      deps(async () => revoked(), async () => {
+        throw new Error("disk on fire");
+      }),
+    );
+    expect(report.auth.identity_error).toBe("unauthorized");
+    expect(report.auth.live_alternate_identities).toBeUndefined();
+  });
+
+  test("the fix line hands over the exact switch command, and stays unchanged with no live sibling", () => {
+    const base = {
+      blockers: ["identity_unavailable" as const],
+      plugin: { installed: true, enabled: true, bundle_valid: true, launcher_executable: true },
+      runtime_version: "0.2.224",
+      channel: { slug: "ludo" },
+    };
+    const withAlternate = claudePluginDoctorFixLines({
+      ...base,
+      auth: {
+        identity_error: "unauthorized",
+        identity_error_message: "invalid or revoked token",
+        live_alternate_identities: [
+          { name: "server", path: `${process.env.HOME}/.agentparty/agents/live.json`, server: "https://x" },
+        ],
+      },
+    }).join("\n");
+    expect(withAlternate).toContain("server");
+    expect(withAlternate).toContain("AGENTPARTY_CONFIG=~/.agentparty/agents/live.json party claude ludo");
+    expect(withAlternate).toContain("party join <invite>");
+
+    const withoutAlternate = claudePluginDoctorFixLines({
+      ...base,
+      auth: { identity_error: "unauthorized", identity_error_message: "invalid or revoked token" },
+    }).join("\n");
+    // 一份都没验活时逐字不动——今天的行为是基线。
+    expect(withoutAlternate).toContain("party init --token <agent-token> --channel <channel>");
+    expect(withoutAlternate).not.toContain("AGENTPARTY_CONFIG=");
+  });
+});

--- a/cli/test/doctor-live-alternate-identity.test.ts
+++ b/cli/test/doctor-live-alternate-identity.test.ts
@@ -9,6 +9,7 @@ import { join } from "node:path";
 import type { PresenceEntry } from "@agentparty/shared";
 import {
   claudePluginDoctorFixLines,
+  safeProbeTarget,
   inspectClaudePluginReadiness,
   probeLiveAlternateIdentities,
   type ClaudeAlternateIdentity,
@@ -19,14 +20,14 @@ import { RestError, type Identity } from "../src/rest";
 const agent = (name: string): Identity => ({ name, email: null, kind: "agent", role: "agent", owner: null });
 
 /** 一个只在临时目录里的 ~/.agentparty——绝不碰用户真实 config。 */
-function fakeHome(configs: { file: string; name: string; channel: string; token: string }[]): string {
+function fakeHome(configs: { file: string; name: string; channel: string; token: string; server?: string }[]): string {
   const home = mkdtempSync(join(tmpdir(), "agentparty-1015-"));
   mkdirSync(join(home, "agents"));
   for (const config of configs) {
     writeFileSync(
       join(home, "agents", config.file),
       JSON.stringify({
-        server: "https://agentparty.example.com",
+        server: config.server ?? "https://agentparty.example.com",
         token: config.token,
         identity: { name: config.name, kind: "agent", role: "agent", channel_scope: config.channel },
       }),
@@ -155,12 +156,12 @@ describe("live alternate identity probe (#1015)", () => {
         identity_error: "unauthorized",
         identity_error_message: "invalid or revoked token",
         live_alternate_identities: [
-          { name: "server", path: `${process.env.HOME}/.agentparty/agents/live.json`, server: "https://x" },
+          { name: "server", path: "/home/leo/.agentparty/agents/live.json", server: "https://x" },
         ],
       },
     }).join("\n");
     expect(withAlternate).toContain("server");
-    expect(withAlternate).toContain("AGENTPARTY_CONFIG=~/.agentparty/agents/live.json party claude ludo");
+    expect(withAlternate).toContain("AGENTPARTY_CONFIG=/home/leo/.agentparty/agents/live.json party claude ludo");
     expect(withAlternate).toContain("party join <invite>");
 
     const withoutAlternate = claudePluginDoctorFixLines({
@@ -170,5 +171,49 @@ describe("live alternate identity probe (#1015)", () => {
     // 一份都没验活时逐字不动——今天的行为是基线。
     expect(withoutAlternate).toContain("party init --token <agent-token> --channel <channel>");
     expect(withoutAlternate).not.toContain("AGENTPARTY_CONFIG=");
+  });
+
+  test("a plaintext-http sibling never receives its token (loopback excepted)", async () => {
+    const home = fakeHome([
+      { file: "plain.json", name: "plain", channel: "ludo", token: "plain-1", server: "http://agentparty.example.com" },
+      { file: "loopback.json", name: "loopback", channel: "ludo", token: "loopback-1", server: "http://localhost:8787" },
+    ]);
+    const asked: string[] = [];
+    const alternates = await probeLiveAlternateIdentities(
+      "ludo",
+      null,
+      async (server, token) => {
+        asked.push(token);
+        return agent(server.includes("localhost") ? "loopback" : "plain");
+      },
+      home,
+    );
+    // 探活是本机诊断顺手把**别的 config 的 token** 发出去，明文 http 一律不发。
+    expect(asked).not.toContain("plain-1");
+    expect(asked).toEqual(["loopback-1"]);
+    expect(alternates.map((entry) => entry.name)).toEqual(["loopback"]);
+
+    expect(safeProbeTarget("https://agentparty.example.com")).toBe(true);
+    expect(safeProbeTarget("http://agentparty.example.com")).toBe(false);
+    expect(safeProbeTarget("http://127.0.0.1:8787")).toBe(true);
+    expect(safeProbeTarget("not a url")).toBe(false);
+  });
+
+  test("a hostile config path cannot break out of the copy-pasteable command", () => {
+    const lines = claudePluginDoctorFixLines({
+      blockers: ["identity_unavailable"],
+      plugin: { installed: true, enabled: true, bundle_valid: true, launcher_executable: true },
+      runtime_version: "0.2.224",
+      channel: { slug: "ludo" },
+      auth: {
+        identity_error: "unauthorized",
+        live_alternate_identities: [
+          { name: "srv\u001b[31mred", path: "/home/leo/x'; rm -rf ~; echo '.json", server: "https://x" },
+        ],
+      },
+    }).join("\n");
+    // 注入片段必须整段落在引号里，且服务端给的名字不带控制字符进终端。
+    expect(lines).toContain("AGENTPARTY_CONFIG='/home/leo/x'\\''; rm -rf ~; echo '\\''.json'");
+    expect(lines).not.toContain("\u001b");
   });
 });


### PR DESCRIPTION
Closes #1015

## 问题

真机 v0.2.224，插件自愈跑通后停在：

```
AgentParty Channel is not launch-ready (identity_unavailable)
  fix: the server rejected this token (invalid or revoked token); re-bind an agent token with
       party init --token <agent-token> --channel <channel> (or party join <invite>)
```

分档是对的（确实 401）。但同一台机器 `~/.agentparty/agents/` 里 scope=ludo 有三份 config，实测 `/api/me`：`lark-ad72b3f9749e-ludo` 401、`leo-server` 401、`server` **200**。选中的被撤了，旁边那份还活着——人却被指去找 owner 要新 token。

## 改法

`doctor` 在 `identity_error === "unauthorized"` 时扫同频道其它 config，**逐个真打 `/api/me`**，只收回 200 且 `kind==="agent"` 的，写进 `auth.live_alternate_identities`，修法给出可直接粘的切换命令。

真机跑（拿那份被撤的 token）：

```
  fix: the server rejected this token (invalid or revoked token)
  fix: this machine still has a working #ludo identity server — AGENTPARTY_CONFIG=~/.agentparty/agents/agentparty-server-ludo.json party claude ludo
  fix: or re-bind a fresh token with party join <invite>
```

## 约束

- **只报验活过的**。列未验证的候选比不列更坏——三份里两份是死的，猜一份准坏一份。
- 至多探 5 份、每份 5s、并发；`localAgentConfigsForChannel` 按设计不返 token，读 token 的代码只在 doctor 内部，token 只进 Authorization 头，不进 argv / 日志 / 报告字段。
- 超时 / 网络 / unknown 三档不触发探测（它们不是「token 不对」）。
- 探测抛异常、或一份都没验活 ⇒ 输出与今天逐字相同。
- `liveAlternateIdentities` 在 deps 里是**可选**的：既有测试省略它即「不查」，不联网也不碰用户真实 `~/.agentparty`。

## 验证

- 新增 `cli/test/doctor-live-alternate-identity.test.ts` 6 例（临时 home，绝不碰真实 config）：只报验活的 / 每份都真问过 / 别的频道不算 / human token 不算 / 当前 config 不自荐 / 401 之外不探 / 探测崩了降级 / 无兄弟时逐字不变。
- **变异自检**：① 把「只留 200」改成「全列」→ 2 红；② 把 401 闸放开成「任何 identity 错误都探」→ 1 红。恢复后全绿。
- `bunx tsc --noEmit -p cli` 干净；`bun test cli/test` 2808 pass / 0 fail。
- 真机复现场景实跑，输出如上。

https://claude.ai/code/session_01Az8CnUpayZzqpi1sh32Ssi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * `party doctor` 现在可检测同频道中已验证可用的备用身份。
  * 遇到未授权问题时，如存在可用备用身份，将提供直接切换配置的修复命令。
  * 仅报告实际验证成功、属于代理身份且不属于当前配置的候选项。

* **错误修复**
  * 优化未授权场景下的诊断与修复建议，避免推荐不可用或不相关的身份。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->