### PR TITLE
fix(cli): 备用身份探活要按 /api/me 的权威 scope 判频道，别信本地缓存

### DIFF
--- a/cli/src/commands/doctor.ts
+++ b/cli/src/commands/doctor.ts
@@ -143,6 +143,13 @@ export async function probeLiveAlternateIdentities(
         AbortSignal.timeout(ALTERNATE_IDENTITY_PROBE_TIMEOUT_MS),
       );
       if (identity.kind !== "agent") return [];
+      // 频道以 /api/me 的权威答复为准，不认本地 config 里那份缓存（#997 同一教训）：token 还活着
+      // 不代表它还属于这个频道——被改过 scope / 重新绑到别的频道，缓存都不会变。报错频道的身份
+      // 等于给一条注定失败的命令，比不报更坏。
+      //
+      // scope 为 null（不限频道的 agent）也不收：/api/me 证明不了它是这个频道的成员，
+      // 而这里的断言正是「这是一份能用在 #<channel> 的身份」。漏报只损失一条提示，退回今天的行为。
+      if (identity.channel_scope !== channel) return [];
       return [{ name: identity.name, path: hint.path, server: credentials.server }];
     } catch {
       return [];

--- a/cli/test/doctor-live-alternate-identity.test.ts
+++ b/cli/test/doctor-live-alternate-identity.test.ts
@@ -17,7 +17,14 @@ import {
 } from "../src/commands/doctor";
 import { RestError, type Identity } from "../src/rest";
 
-const agent = (name: string): Identity => ({ name, email: null, kind: "agent", role: "agent", owner: null });
+const agent = (name: string, channelScope: string | null = "ludo"): Identity => ({
+  name,
+  email: null,
+  kind: "agent",
+  role: "agent",
+  owner: null,
+  channel_scope: channelScope,
+});
 
 /** 一个只在临时目录里的 ~/.agentparty——绝不碰用户真实 config。 */
 function fakeHome(configs: { file: string; name: string; channel: string; token: string; server?: string }[]): string {
@@ -97,7 +104,7 @@ describe("live alternate identity probe (#1015)", () => {
     const alternates = await probeLiveAlternateIdentities(
       "ludo",
       null,
-      async () => ({ name: "leo", email: null, kind: "human", role: "member", owner: null }),
+      async () => ({ name: "leo", email: null, kind: "human", role: "member", owner: null, channel_scope: "ludo" }),
       home,
     );
     expect(alternates).toEqual([]);
@@ -171,6 +178,27 @@ describe("live alternate identity probe (#1015)", () => {
     // 一份都没验活时逐字不动——今天的行为是基线。
     expect(withoutAlternate).toContain("party init --token <agent-token> --channel <channel>");
     expect(withoutAlternate).not.toContain("AGENTPARTY_CONFIG=");
+  });
+
+  test("a token that is alive but no longer scoped to this channel is not offered", async () => {
+    const home = fakeHome([
+      { file: "moved.json", name: "server", channel: "ludo", token: "moved-1" },
+      { file: "unscoped.json", name: "roamer", channel: "ludo", token: "unscoped-1" },
+      { file: "still-here.json", name: "keeper", channel: "ludo", token: "keeper-1" },
+    ]);
+    const alternates = await probeLiveAlternateIdentities(
+      "ludo",
+      null,
+      // 三个 token 都活着，但服务端说的 scope 各不相同——本地 config 里那份 scope 是缓存，不算数。
+      async (_server, token) =>
+        token === "moved-1"
+          ? agent("server", "piggygo")
+          : token === "unscoped-1"
+            ? agent("roamer", null)
+            : agent("keeper", "ludo"),
+      home,
+    );
+    expect(alternates.map((entry) => entry.name)).toEqual(["keeper"]);
   });
 
   test("a plaintext-http sibling never receives its token (loopback excepted)", async () => {


### PR DESCRIPTION
codex stop-time review 抓到 #1016 的漏洞：探活只验了「token 活着 + kind===agent」，没验它**现在**属于哪个频道。

本地 config 里的 `identity.channel_scope` 只是缓存（#997 同一教训）：token 还活着不代表还属于这个频道——被改过 scope、重新绑到别的频道，缓存都不会变。那样会报出一个错频道的身份，并给出一条注定失败的切换命令——比不报更坏。

改成以 `/api/me` 回的 `channel_scope` 为准，必须 `=== channel` 才收。`channel_scope === null`（不限频道的 agent）也不收：`/api/me` 证明不了它是这个频道的成员，而这里的断言正是「这是一份能用在 #<channel> 的身份」；漏报只损失一条提示，退回今天的行为。

验证：
- 新增用例——三个 token 全活，服务端说的 scope 分别是别的频道 / null / 本频道，只有最后一个被收。
- 变异自检：去掉该闸 → 1 红。
- 真机复跑（那份被撤的 ludo token）输出不变：`server` 的权威 scope 确实是 ludo。

https://claude.ai/code/session_01Az8CnUpayZzqpi1sh32Ssi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
  - 改进备用身份检测：仅当身份明确属于目标频道时，才会将其列为可用备用身份。
  - 对频道范围为空或与本地缓存不一致的身份进行过滤，避免提供不匹配的备用身份。
  - 扩展相关验证，确保身份状态和频道归属判断更加准确。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->