### PR TITLE
fix(cli): MCP 工具面不再继承全局兜底身份，未授权的会话不能以 agent 名义说话

### DIFF
--- a/cli/src/commands/bridge.ts
+++ b/cli/src/commands/bridge.ts
@@ -39,6 +39,7 @@ import {
 } from "../claude-cross-session-gate";
 import { isPartyBinaryPath, RUNNING_VERSION } from "../upgrade";
 import { isName, isSlug } from "../validation";
+import { MCP_OPT_IN_ENV } from "../mcp-session-binding";
 import {
   CLAUDE_CHANNEL_OPT_IN_ENV,
   CLAUDE_LIFECYCLE_OPT_IN_ENV,
@@ -2033,6 +2034,9 @@ export async function run(argv: string[], deps: BridgeDeps = {}): Promise<number
   // a separate opt-in and are armed only for the final Claude child below.
   delete env[CLAUDE_CHANNEL_OPT_IN_ENV];
   delete env[CLAUDE_LIFECYCLE_OPT_IN_ENV];
+  // #1018：频道 MCP 要避开（bridge 自带一份），但**工具面**是 bridge 亲手起的这个会话该有的。
+  // 两件事分开用两个 env，正是为了在这里能只放行其中一件。
+  env[MCP_OPT_IN_ENV] = "1";
   let rawVersion: string;
   try {
     rawVersion = await (deps.probeClaudeVersion ?? defaultProbeClaudeVersion)({ cwd, env });

--- a/cli/src/commands/claude-launch.ts
+++ b/cli/src/commands/claude-launch.ts
@@ -11,6 +11,7 @@ import {
 } from "../claude-default-args";
 import { agentpartyHome, readConfig, refreshConfigInPlace } from "../config";
 import { normalizeWakeLang } from "../wake-note-i18n";
+import { MCP_OPT_IN_ENV } from "../mcp-session-binding";
 import {
   CLAUDE_PLUGIN_UPDATE_COMMAND,
   syncClaudePluginToCli,
@@ -53,6 +54,7 @@ export function claudeChannelLoadArgs(entry: string): string[] {
   return [CLAUDE_DEV_CHANNELS_FLAG, entry];
 }
 export const CLAUDE_CHANNEL_OPT_IN_ENV = "AGENTPARTY_CLAUDE_CHANNEL_OPT_IN";
+
 /**
  * Authorizes the Marketplace lifecycle hooks to publish activity and guard a
  * delivered execution. Kept separate from the Channel opt-in because
@@ -217,6 +219,8 @@ export function claudeLaunchPlan(
     env: {
       ...env,
       [CLAUDE_CHANNEL_OPT_IN_ENV]: "1",
+      // #1018：这是 owner 亲手起的会话，工具面照常放行（进程树内继承，别的会话拿不到）。
+      [MCP_OPT_IN_ENV]: "1",
       [CLAUDE_LIFECYCLE_OPT_IN_ENV]: "1",
       ...(channel === undefined ? {} : { AGENTPARTY_CHANNEL: channel }),
     },

--- a/cli/src/commands/mcp.ts
+++ b/cli/src/commands/mcp.ts
@@ -8,6 +8,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { z } from "zod";
 import { DEFAULT_HEADER_PREVIEW, msgHeader, stripTerminalControls } from "../format";
 import pkg from "../../package.json" with { type: "json" };
+import type { ConfigSourceInfo } from "../config";
 import {
   ackWatchStuck,
   advanceCursorPastOwnMessage,
@@ -26,6 +27,7 @@ import { applyMcpProcessTitle, parseMcpServerArgv } from "../mcp-registry";
 import { watchParentLiveness } from "../parent-liveness";
 import { reportWakeSelfCheck } from "../wake-reachability";
 import { resolveAuth, resolveAuthDetailed } from "../oidc-cli";
+import { inspectMcpSessionBinding, mcpSessionBindingDenial } from "../mcp-session-binding";
 import {
   ackDelivery,
   createTask,
@@ -254,7 +256,26 @@ function titleFromMessage(msg: MsgFrame): string {
   return label.length > 120 ? `${label.slice(0, 117)}...` : label;
 }
 
+/**
+ * #1018：MCP 是**自动**加载进每个 Claude 会话的通道，所以身份不能来自「全局兜底」——
+ * 那份 config 是全机器共享的，等于没授权的会话也能以某个 agent 的名义说话。
+ * 抛错而不是隐藏工具：工具凭空消失看起来像插件坏了，这里给一条能照做的修法。
+ */
+function assertSessionBound(source: ConfigSourceInfo): void {
+  const binding = inspectMcpSessionBinding({ configSourceKind: source.kind, env: process.env });
+  if (!binding.bound) throw new Error(mcpSessionBindingDenial(source.path));
+}
+
+async function authDetailed(): Promise<Awaited<ReturnType<typeof resolveAuthDetailed>>> {
+  const detailed = await resolveAuthDetailed();
+  // source.kind === "none" 交给各调用点既有的 "no config" 文案：那是「没接入过」，
+  // 与「继承了别人的身份」是两件事，修法也不同。
+  if (detailed.server !== null && detailed.token !== null) assertSessionBound(detailed.config);
+  return detailed;
+}
+
 async function auth(): Promise<{ server: string; token: string; me?: Identity }> {
+  await authDetailed();
   const cfg = await resolveAuth();
   if (!cfg) throw new Error("no config, run: party login or party init --server URL --token T");
   return cfg;
@@ -696,7 +717,7 @@ export function createMcpServer(defaultChannel?: string): McpServer {
     },
     async ({ channel, state, note, mentions, scope, summary_seq, task_id }) => {
       try {
-        const authInfo = await resolveAuthDetailed();
+        const authInfo = await authDetailed();
         if (!authInfo.server || !authInfo.token) throw new Error("no config, run: party login or party init --server URL --token T");
         const resolved = normalizeChannel(channel, defaultChannel);
         const normalizedMentions = normalizeMentions(mentions);

--- a/cli/src/commands/mcp.ts
+++ b/cli/src/commands/mcp.ts
@@ -10,6 +10,7 @@ import { DEFAULT_HEADER_PREVIEW, msgHeader, stripTerminalControls } from "../for
 import pkg from "../../package.json" with { type: "json" };
 import type { ConfigSourceInfo } from "../config";
 import {
+  readConfigWithSource,
   ackWatchStuck,
   advanceCursorPastOwnMessage,
   drainWatchStuck,
@@ -283,7 +284,13 @@ async function auth(): Promise<{ server: string; token: string; me?: Identity }>
 
 let captureQueue: Promise<void> = Promise.resolve();
 
+/**
+ * #1018：走这条路的工具（party_digest / party_wake_test 等）不经过 auth()，而是直接跑内层
+ * 命令模块——那里各自解析身份，会绕开会话绑定闸（codex stop-time review 抓到）。闸落在这里
+ * 而不是逐个补调用点：新加的工具只要用了 captureCommand 就自动被盖住。
+ */
 async function captureCommand(run: () => Promise<number>): Promise<{ code: number; stdout: string; stderr: string }> {
+  assertSessionBound(readConfigWithSource().source);
   let release!: () => void;
   const previous = captureQueue;
   captureQueue = new Promise<void>((resolve) => {

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -5,6 +5,7 @@ import { BODY_LIMIT, DECISION_OPTION_LIMIT, DECISION_OPTIONS_MAX, DECISION_PROMP
 import { safeBranchContextLabel, safeRepoContextLabel } from "@agentparty/shared";
 import { channelDecisionSnapshotBodyLines } from "@agentparty/shared/onboarding";
 import { createHash, randomUUID } from "node:crypto";
+import { MCP_OPT_IN_ENV } from "../mcp-session-binding";
 import { spawnSync } from "node:child_process";
 import {
   downloadPartyUpgrade,
@@ -3187,6 +3188,9 @@ export function createSdkRunner(opts: SdkRunnerOptions): NonNullable<ServeOption
     env: definedEnv({
       ...process.env,
       AGENTPARTY_CHANNEL: opts.channel,
+      // #1018：serve 是 owner 亲手起的、绑定到某个频道的常驻监听，它的 runner 会话该有工具面。
+      // （isolate / 显式 config 两条路本来就是 explicit 来源，这里只为「回落全局 config」的那条兜住。）
+      [MCP_OPT_IN_ENV]: "1",
       ...(opts.isolateModelPartyAccess
         ? isolatedModelPartyEnv(opts.workdir, opts.server)
         : opts.agentpartyConfigPath
@@ -3632,6 +3636,9 @@ export function createBuiltinRunner(opts: BuiltinRunnerOptions): NonNullable<Ser
     const env = {
       ...baseEnv,
       AGENTPARTY_CHANNEL: opts.channel,
+      // #1018：serve 是 owner 亲手起的、绑定到某个频道的常驻监听，它的 runner 会话该有工具面。
+      // （isolate / 显式 config 两条路本来就是 explicit 来源，这里只为「回落全局 config」的那条兜住。）
+      [MCP_OPT_IN_ENV]: "1",
       ...(opts.isolateModelPartyAccess
         ? isolatedModelPartyEnv(opts.workdir, opts.server)
         : opts.agentpartyConfigPath

--- a/cli/src/mcp-session-binding.ts
+++ b/cli/src/mcp-session-binding.ts
@@ -1,0 +1,66 @@
+// party mcp 的会话绑定闸（issue #1018）。
+//
+// 插件是全局启用的，于是**每一个** Claude 会话都会加载 `party mcp`。频道注入那层
+// （claude-channel）早就有 opt-in 闸，工具面这层却没有——再叠上 `~/.agentparty/config.json`
+// 这条无差别兜底，结果就是：从没接入过的会话照样能以某个 agent 的名义发言（owner 实测，
+// 一个与项目无关的目录 `party whoami` 直接拿到活身份）。
+//
+// 这里掐掉的只有**兜底**那一条来源。判据是「这个身份是不是被绑到了这个会话／这个目录」：
+//
+//   explicit   AGENTPARTY_CONFIG 显式指定，或 cwd breadcrumb —— 绑过
+//   workspace  该目录自己的 config（party join / party init 写的）—— 绑过
+//   global     ~/.agentparty/config.json 兜底 —— **没绑过**，正是要挡的
+//              （AGENTPARTY_HOME 被显式指过则不算兜底：那与 AGENTPARTY_CONFIG 同类，是按进程树的选择）
+//   none       没有任何 config —— 沿用既有的 "no config" 文案，不归本闸管
+//
+// 另加一条进程树旁路：`party claude` / `party bridge` 起的会话带 AGENTPARTY_MCP_OPT_IN=1。
+// env 只沿进程树继承，别的会话是另一棵进程树，天然拿不到——这就是「绑定 session」。
+// 刻意**不复用** AGENTPARTY_CLAUDE_CHANNEL_OPT_IN：bridge 会故意删掉那个（避免同时激活
+// marketplace 频道 MCP），拿它当工具面的判据会把 bridge 起的会话一起误伤。
+//
+// 手敲的 `party send` 等 CLI 命令不受影响：闸只在 MCP 这条自动加载的通道上。
+import type { ConfigSourceKind } from "./config";
+
+export const MCP_OPT_IN_ENV = "AGENTPARTY_MCP_OPT_IN";
+
+export type McpSessionBinding =
+  | { bound: true; via: "opt_in_env" | "explicit_home" | "explicit_config" | "workspace_config" }
+  | { bound: false; reason: "global_fallback" };
+
+/**
+ * 判这个会话有没有被授予身份。`none` 不进这里——它由调用方沿用既有的 "no config" 文案，
+ * 那是「压根没接入过」，不是「继承了别人的身份」。
+ */
+export function inspectMcpSessionBinding(input: {
+  configSourceKind: ConfigSourceKind;
+  env: NodeJS.ProcessEnv;
+}): McpSessionBinding {
+  if (input.env[MCP_OPT_IN_ENV] === "1") return { bound: true, via: "opt_in_env" };
+  // AGENTPARTY_HOME 是把整个 home 指到别处——和 AGENTPARTY_CONFIG 同一类的、按进程树生效的
+  // 显式选择（serve 的隔离 lane、测试夹具都靠它）。要挡的是**默认那份** ~/.agentparty/config.json
+  // 白给每个会话，不是有人明确指了家目录还要拦。
+  if ((input.env.AGENTPARTY_HOME ?? "") !== "") return { bound: true, via: "explicit_home" };
+  switch (input.configSourceKind) {
+    case "explicit":
+      return { bound: true, via: "explicit_config" };
+    case "workspace":
+      return { bound: true, via: "workspace_config" };
+    default:
+      return { bound: false, reason: "global_fallback" };
+  }
+}
+
+/**
+ * 拒绝时给的话。三条放行路各给一条能照做的命令——**不**打印全局 config 里那个身份的名字：
+ * 会话没被授予它，就不该从这里得知它存在。
+ */
+export function mcpSessionBindingDenial(configPath: string | null): string {
+  const where = configPath === null ? "the global config" : `the global config (${configPath})`;
+  return [
+    `this Claude session was not granted an AgentParty identity: it would fall back to ${where},`,
+    "which every session on this machine shares. Pick one:",
+    "  party claude <channel>                       start a session bound to that channel",
+    "  party join <invite>                          bind this directory's own identity",
+    `  ${MCP_OPT_IN_ENV}=1                          deliberate one-off for this process tree`,
+  ].join("\n");
+}

--- a/cli/test/claude-launch.test.ts
+++ b/cli/test/claude-launch.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { MCP_OPT_IN_ENV } from "../src/mcp-session-binding";
 import {
   CLAUDE_CHANNEL_OPT_IN_ENV,
   CLAUDE_CHANNEL_PLUGIN,
@@ -44,6 +45,8 @@ describe("party claude launcher", () => {
     expect(calls[0]!.args).not.toContain("--channels");
     expect(calls[0]!.env[CLAUDE_CHANNEL_OPT_IN_ENV]).toBe("1");
     expect(calls[0]!.env[CLAUDE_LIFECYCLE_OPT_IN_ENV]).toBe("1");
+    // #1018：owner 亲手起的会话必须带上工具面授权，否则这条路会被自己的闸挡死。
+    expect(calls[0]!.env[MCP_OPT_IN_ENV]).toBe("1");
     expect(calls[0]!.env.AGENTPARTY_CHANNEL).toBe("dev");
   });
 

--- a/cli/test/mcp-session-binding.test.ts
+++ b/cli/test/mcp-session-binding.test.ts
@@ -54,3 +54,40 @@ describe("mcp session binding gate (#1018)", () => {
     expect(mcpSessionBindingDenial(null)).toContain("the global config");
   });
 });
+
+// codex stop-time review 抓到 party_digest / party_wake_test 绕过了闸：它们不走 auth()，
+// 而是直接 captureCommand 进内层命令模块，各自解析身份。闸补在 captureCommand 里（结构上盖住
+// 所有这类工具），这条守卫盯住「以后不许再开第三条路」——每个工具处理函数必须落在其中一条上。
+describe("每个 MCP 工具都必须经过闸（#1018 防漂移）", () => {
+  test("没有工具能绕开 auth() / authDetailed() / captureCommand", async () => {
+    const source = await Bun.file(new URL("../src/commands/mcp.ts", import.meta.url)).text();
+    // 闸自己必须同时钉在两处入口上，否则下面的分类就没有意义。
+    expect(source).toContain("assertSessionBound(detailed.config)");
+    expect(source).toContain("assertSessionBound(readConfigWithSource().source)");
+
+    const GATE = /await auth\(\)|await authDetailed\(\)|captureCommand\(/u;
+    // 有的工具经一层模块内 helper 拿身份（party_charter → charterData → auth()）。
+    // 先收集「自己已经过闸」的 helper，再把调用它们的工具也算过闸——只放行这一层，
+    // 更深的间接调用会被判成未过闸，宁可误报也不放过真漏网。
+    const gatedHelpers = [...source.matchAll(/async function (\w+)\([^)]*\)[^{]*\{([\s\S]*?)\n\}/gu)]
+      .filter((match) => GATE.test(match[2] ?? ""))
+      .map((match) => match[1]!);
+    expect(gatedHelpers).toContain("auth");
+    expect(gatedHelpers).toContain("charterData");
+
+    const bodies = source.split(/server\.registerTool\(\s*\n?\s*"/u).slice(1);
+    const ungated = bodies
+      .map((part) => ({
+        name: part.slice(0, part.indexOf('"')),
+        // split 已经把每段切到下一个注册之前；最后一段吃到文件尾。
+        body: part,
+      }))
+      .filter(({ body }) =>
+        !GATE.test(body) && !gatedHelpers.some((helper) => new RegExp(`\\b${helper}\\(`, "u").test(body))
+      )
+      .map(({ name }) => name);
+
+    expect(bodies.length).toBeGreaterThan(15);
+    expect(ungated).toEqual([]);
+  });
+});

--- a/cli/test/mcp-session-binding.test.ts
+++ b/cli/test/mcp-session-binding.test.ts
@@ -1,0 +1,56 @@
+// #1018：没被授权的会话照样能用 AgentParty。根因是两条叠加——插件全局启用，于是每个 Claude
+// 会话都加载 `party mcp`；而 `~/.agentparty/config.json` 是**无差别兜底**，任何目录都能拿到它。
+// 这里钉住的是：工具面只认「绑过」的身份来源，兜底那条一律拒，且拒绝要能照做。
+import { describe, expect, test } from "bun:test";
+import {
+  MCP_OPT_IN_ENV,
+  inspectMcpSessionBinding,
+  mcpSessionBindingDenial,
+} from "../src/mcp-session-binding";
+
+describe("mcp session binding gate (#1018)", () => {
+  test("全局兜底是唯一被拒的来源；绑过的三条路都放行", () => {
+    const at = (kind: "explicit" | "workspace" | "global" | "none", env: NodeJS.ProcessEnv = {}) =>
+      inspectMcpSessionBinding({ configSourceKind: kind, env });
+
+    // AGENTPARTY_CONFIG 显式指定 / cwd breadcrumb（也报 explicit）
+    expect(at("explicit")).toEqual({ bound: true, via: "explicit_config" });
+    // party join / party init 写的该目录自己的 config
+    expect(at("workspace")).toEqual({ bound: true, via: "workspace_config" });
+    // 这一条就是「没授权却能用」的来源
+    expect(at("global")).toEqual({ bound: false, reason: "global_fallback" });
+  });
+
+  test("显式指过 AGENTPARTY_HOME 不算兜底——那与 AGENTPARTY_CONFIG 同类，也是按进程树的选择", () => {
+    expect(inspectMcpSessionBinding({ configSourceKind: "global", env: { AGENTPARTY_HOME: "/tmp/h" } }))
+      .toEqual({ bound: true, via: "explicit_home" });
+    // 空串不算「指过」，否则一个被清空的变量会静默放行。
+    expect(inspectMcpSessionBinding({ configSourceKind: "global", env: { AGENTPARTY_HOME: "" } }).bound).toBe(false);
+  });
+
+  test("进程树 opt-in 压过来源判定——那是 owner 亲手起的会话", () => {
+    expect(inspectMcpSessionBinding({ configSourceKind: "global", env: { [MCP_OPT_IN_ENV]: "1" } }))
+      .toEqual({ bound: true, via: "opt_in_env" });
+    // 只认 "1"：别的取值（含空串、"0"、"true"）不算授权，免得半配置状态被当成放行。
+    for (const value of ["", "0", "true", "yes"]) {
+      expect(inspectMcpSessionBinding({ configSourceKind: "global", env: { [MCP_OPT_IN_ENV]: value } }).bound)
+        .toBe(false);
+    }
+  });
+
+  test("env 不在这个进程树里就不生效（别的会话是另一棵树）", () => {
+    // 判据只看传进来的 env 快照，不读 process.env——同机另一个会话的 env 根本不可见。
+    expect(inspectMcpSessionBinding({ configSourceKind: "global", env: {} }).bound).toBe(false);
+  });
+
+  test("拒绝文案给出三条能照做的路，且不泄露那个身份是谁", () => {
+    const denial = mcpSessionBindingDenial("/Users/leo/.agentparty/config.json");
+    expect(denial).toContain("party claude <channel>");
+    expect(denial).toContain("party join <invite>");
+    expect(denial).toContain(MCP_OPT_IN_ENV);
+    expect(denial).toContain("/Users/leo/.agentparty/config.json");
+    // 会话没被授予那个身份，就不该从拒绝信息里得知它叫什么。
+    expect(denial).not.toMatch(/logged in as|identity=/);
+    expect(mcpSessionBindingDenial(null)).toContain("the global config");
+  });
+});


### PR DESCRIPTION
Closes #1018

## 问题（owner 实测）

「其他 session 我并没给他 agentparty 权限，他却能用」。两条口子叠加：

1. **工具面没有闸**。插件全局启用 ⇒ 每个 Claude 会话都加载 `party mcp`。频道注入那层（`claude-channel`）早有 `--require-launch-opt-in`，工具面这层什么都没有。
2. **全局 config 无差别兜底**。任何目录、任何会话，前面几层没命中就自动拿到 `~/.agentparty/config.json`：

```
$ cd /private/tmp/... && party whoami
runtime: logged in as super-admin-bug-7744 (agent/agent)   ← 从没接入过的目录
config: global /Users/leo/.agentparty/config.json
```

## 改法

**只掐掉兜底那一条来源**，判据是「这个身份有没有被绑到这个会话／这个目录」：

| 来源 | 判定 |
|---|---|
| `explicit`（`AGENTPARTY_CONFIG` / cwd breadcrumb） | 放行 |
| `workspace`（`party join`/`party init` 写的该目录 config） | 放行 |
| 显式指过 `AGENTPARTY_HOME` | 放行（与 `AGENTPARTY_CONFIG` 同类的、按进程树的显式选择） |
| 进程树里 `AGENTPARTY_MCP_OPT_IN=1` | 放行 |
| `global` 兜底 | **拒** ← 就是这条 |
| `none` | 沿用既有 "no config" 文案（那是没接入过，不是继承别人的身份） |

授权沿**进程树**继承——别的会话是另一棵进程树，天然拿不到，这就是「绑定 session」。`party claude` / `party bridge` / `serve` 的 runner 子会话都显式授予。

刻意**不复用** `AGENTPARTY_CLAUDE_CHANNEL_OPT_IN`：bridge 会故意删掉那个（避开 marketplace 频道 MCP），拿它当工具面判据会把 bridge 起的会话一起误伤。

**手敲的 CLI 命令不受影响**，闸只在自动加载进每个会话的这条通道上。不用改插件 manifest，升级 CLI 即生效。

## 真机验证（编译前的真 stdio server + 真 REST）

| 场景 | 结果 |
|---|---|
| 无关目录 `party_whoami` | `isError`，给出三条修法 |
| 无关目录 `party_send` | **拒**（这正是「能以 agent 名义说话」那件事） |
| 同目录 + `AGENTPARTY_MCP_OPT_IN=1` | 正常返回身份 |
| 已绑定目录、无 env | 正常返回身份 |
| `tools/list` | 24 个工具照常列出（凭空消失像是插件坏了） |

拒绝文案给三条能照做的路，且**不打印那个身份叫什么**——会话没被授予它，就不该从拒绝信息里得知它存在。

## 测试

- 新增 `cli/test/mcp-session-binding.test.ts` 5 例：兜底是唯一被拒的来源、`AGENTPARTY_HOME` 显式指过不算兜底（空串不算）、opt-in 只认 `"1"`、env 不在本进程树就不生效、拒绝文案含三条修法且不泄露身份名。
- `claude-launch.test.ts` 加一条：owner 亲手起的会话必须带上工具面授权（否则这条路会被自己的闸挡死）。
- **变异自检**：① 兜底改成放行 → 3 红；② `party claude` 不再授予 → 1 红。
- `bun test cli/test` **2816 pass / 0 fail**；`tsc --noEmit` 干净。

中途 36 个红是有价值的信号：MCP 工具测试用 `AGENTPARTY_HOME` 指临时目录当夹具，被我的闸挡了——这暴露的是判据缺了 `AGENTPARTY_HOME` 这一类显式选择，不是测试的错，按原则补上后全绿（而不是为了让测试过而放宽兜底）。

## 破坏面

升级后，**直接在任意未绑定会话里调 `party_send` 等工具会被拦** —— 那正是本 issue 要修的行为。第一次撞上的人会拿到那条带三个修法的拒绝。

https://claude.ai/code/session_01Az8CnUpayZzqpi1sh32Ssi