### PR TITLE
ci: 发版时不再重跑同一 commit 已在 main 跑绿的 check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,8 @@ jobs:
   #
   # 证据要求（任何一条不满足就照常全跑，fail-safe 只会多跑绝不漏测）：
   #   - 同一个 workflow（release.yml）、**同一个 commit SHA**；
-  #   - 那次运行不是本次运行；
+  #   - 那次运行不是本次运行，且是 **main 上的 push**（PR 运行可能走 cli_only 快路径，
+  #     那种绿不代表跑过完整门禁）；
   #   - 那次运行里名为 "full check" 的 job 结论是 success —— 它是唯一的聚合门禁，
   #     覆盖 cli/worker/web/shared/scripts/desktop/plugin 全部区域。
   # 注意：跳过的是**步骤**不是 job。job 本身照常成功结束，needs 图与各 job 结论一字不变——
@@ -72,6 +73,12 @@ jobs:
             while IFS= read -r run_id; do
               [ -z "$run_id" ] && continue
               [ "$run_id" = "$GITHUB_RUN_ID" ] && continue
+              # 只认 main 上的 push 运行。PR 运行的 head_sha 就是 PR 头 commit，而 PR 上的
+              # full check 可能走了 cli_only 快路径（worker/web/shared/scripts 全 skip 也算绿）——
+              # 拿它当"跑过完整门禁"的证据，等于没测就发版。main push 上 cli_only 恒 false。
+              meta="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$run_id" \
+                --jq '"\(.event) \(.head_branch)"' 2>/dev/null || true)"
+              [ "$meta" = "push main" ] || continue
               concl="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$run_id/jobs?per_page=100" \
                 --jq '.jobs[] | select(.name == "full check") | .conclusion' 2>/dev/null || true)"
               case "$concl" in

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,52 @@ jobs:
             non_cli:
               - '!cli/**'
 
+  # ── 发版重复跑 check（本次优化）─────────────────────────────────────
+  # v* tag 指向的就是刚在 main 上跑完整门禁的那个 commit，于是同一份代码的 check 跑两遍。
+  # 白跑的那一遍不只是浪费 ~3 分钟：worker 分片在 CI 上会偶发 EnvironmentTeardownError 抖红，
+  # 于是一次随机失败就把已经验证过的代码卡在发不出去（v0.2.226 实际撞上）。
+  #
+  # 证据要求（任何一条不满足就照常全跑，fail-safe 只会多跑绝不漏测）：
+  #   - 同一个 workflow（release.yml）、**同一个 commit SHA**；
+  #   - 那次运行不是本次运行；
+  #   - 那次运行里名为 "full check" 的 job 结论是 success —— 它是唯一的聚合门禁，
+  #     覆盖 cli/worker/web/shared/scripts/desktop/plugin 全部区域。
+  # 注意：跳过的是**步骤**不是 job。job 本身照常成功结束，needs 图与各 job 结论一字不变——
+  # build/desktop 的 needs 一旦变成 skipped，整条发布链会跟着 skip，那是「改错＝没跑测试也发版」
+  # 的地方，不碰。version-contract 也从不跳过：它校验的是 tag 本身（版本一致、不比 latest 旧），
+  # 那是 main 那次跑不出来的新信息。
+  prior-green:
+    name: prior green check
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+    outputs:
+      skip: ${{ steps.probe.outputs.skip }}
+    steps:
+      - id: probe
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -uo pipefail
+          skip=false
+          if [ "${GITHUB_REF_TYPE:-}" = "tag" ]; then
+            # 读成一行一个 run id：不靠变量分词（那在非 bash 下静默变成"整串当一个元素"）。
+            while IFS= read -r run_id; do
+              [ -z "$run_id" ] && continue
+              [ "$run_id" = "$GITHUB_RUN_ID" ] && continue
+              concl="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$run_id/jobs?per_page=100" \
+                --jq '.jobs[] | select(.name == "full check") | .conclusion' 2>/dev/null || true)"
+              case "$concl" in
+                *success*) skip=true; echo "prior green: run $run_id 的 full check 已 success（同 SHA $GITHUB_SHA）" ;;
+              esac
+              [ "$skip" = "true" ] && break
+            done < <(gh api "repos/$GITHUB_REPOSITORY/actions/workflows/release.yml/runs?head_sha=$GITHUB_SHA&per_page=20" \
+                --jq '.workflow_runs[].id' 2>/dev/null || true)
+          fi
+          echo "skip=$skip" >> "$GITHUB_OUTPUT"
+          echo "skip=$skip"
+
   # ── #9 pre-merge / release gate：每个 workspace 独立并行跑，墙上时间=最慢单个 ──
   # 7 个检查区域（cli/worker/web/shared/scripts/desktop/Claude Plugin）互不依赖（worker vitest 用隔离的
   # 空 assets 目录，不再需要 web/dist），原来一个 job 串行跑 `bun run check` 要 ~6min，
@@ -54,7 +100,7 @@ jobs:
   # 墙上时间 ≈ 最重那一片而非全部串行（原 ~2m36s → ~1min）。tsc 单独一次跑，见 check-cli-types。
   check-cli:
     name: check cli (shard ${{ matrix.shard }}/6)
-    needs: changes
+    needs: [changes, prior-green]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -65,27 +111,31 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/bun-install
+        if: ${{ needs.prior-green.outputs.skip != 'true' }}
       - working-directory: cli
+        if: ${{ needs.prior-green.outputs.skip != 'true' }}
         run: bun test --shard=${{ matrix.shard }}/6
 
   # cli tsc 只跑一次（不放进分片，避免每片重复 typecheck）。
   check-cli-types:
     name: check cli (types)
-    needs: changes
+    needs: [changes, prior-green]
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/bun-install
+        if: ${{ needs.prior-green.outputs.skip != 'true' }}
       - working-directory: cli
+        if: ${{ needs.prior-green.outputs.skip != 'true' }}
         run: bunx tsc --noEmit
 
   # web/shared/scripts：非纯 CLI（或非 PR）才跑，纯 CLI 快路径下 skip。
   # worker 因为一个 workerd 串行跑 43 个 spec 太慢（~6min），单独拆分片 job，见下。
   check-rest:
     name: check ${{ matrix.ws }}
-    needs: changes
+    needs: [changes, prior-green]
     if: needs.changes.outputs.cli_only != 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -97,7 +147,9 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/bun-install
+        if: ${{ needs.prior-green.outputs.skip != 'true' }}
       - run: bun run check:${{ matrix.ws }}
+        if: ${{ needs.prior-green.outputs.skip != 'true' }}
 
   # Marketplace Plugin is a released product surface, not just a directory our
   # own tests can parse. Validate with Claude itself at both the minimum Plugin
@@ -106,7 +158,7 @@ jobs:
   # mirrored Plugin manifests stale.
   check-plugin:
     name: check Claude plugin (${{ matrix.claude }})
-    needs: changes
+    needs: [changes, prior-green]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -117,11 +169,15 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/bun-install
+        if: ${{ needs.prior-green.outputs.skip != 'true' }}
       - name: verify Plugin mirror
+        if: ${{ needs.prior-green.outputs.skip != 'true' }}
         run: bun scripts/sync-agentparty-plugin.ts --check
       - name: Claude strict Plugin validation
+        if: ${{ needs.prior-green.outputs.skip != 'true' }}
         run: bunx @anthropic-ai/claude-code@${{ matrix.claude }} plugin validate --strict plugins/agentparty
       - name: isolated Marketplace install acceptance
+        if: ${{ needs.prior-green.outputs.skip != 'true' }}
         run: bun scripts/verify-agentparty-plugin-install.ts --claude-package-version ${{ matrix.claude }}
 
   # worker 测试：43 个 spec 在单 workerd 里串行要 ~6min，是唯一长杆。
@@ -130,7 +186,7 @@ jobs:
   # 墙上时间 ≈ 最重那一片，而非全部串行之和。
   check-worker:
     name: check worker (shard ${{ matrix.shard }}/6)
-    needs: changes
+    needs: [changes, prior-green]
     if: needs.changes.outputs.cli_only != 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -142,17 +198,20 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/bun-install
+        if: ${{ needs.prior-green.outputs.skip != 'true' }}
       - name: verify test runtime
+        if: ${{ needs.prior-green.outputs.skip != 'true' }}
         working-directory: worker
         run: bun run verify:test-runtime
       - name: vitest shard ${{ matrix.shard }}/6
+        if: ${{ needs.prior-green.outputs.skip != 'true' }}
         working-directory: worker
         run: bunx vitest run --shard=${{ matrix.shard }}/6
 
   # worker tsc 只跑一次，放并行独立 job（不放进分片，避免每片重复 typecheck）。
   check-worker-types:
     name: check worker (types)
-    needs: changes
+    needs: [changes, prior-green]
     if: needs.changes.outputs.cli_only != 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -160,14 +219,16 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/bun-install
+        if: ${{ needs.prior-green.outputs.skip != 'true' }}
       - working-directory: worker
+        if: ${{ needs.prior-green.outputs.skip != 'true' }}
         run: bunx tsc --noEmit
 
   # Desktop Rust checks require macOS system frameworks. Keep this in the normal PR/main gate,
   # while preserving the explicit CLI-only PR fast path.
   check-desktop:
     name: check desktop (macOS)
-    needs: changes
+    needs: [changes, prior-green]
     if: needs.changes.outputs.cli_only != 'true'
     runs-on: macos-14
     permissions:
@@ -175,9 +236,11 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/bun-install
+        if: ${{ needs.prior-green.outputs.skip != 'true' }}
       # Rust 依赖（tauri/wry/objc2… ~400 crate）编译占了这个 job 的大头；缓存 ~/.cargo + target/
       # 后每次只增量编译改动，冷编 ~3min → 温编数十秒。key 随 Cargo.lock 变化，工具链升级自动失效。
       - name: cache Rust build
+        if: ${{ needs.prior-green.outputs.skip != 'true' }}
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: desktop/src-tauri
@@ -185,17 +248,21 @@ jobs:
           # 塞污染的编译产物再被后续 release 命中（#719 评审的供应链加固）。
           save-if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') }}
       - name: verify desktop version consistency
+        if: ${{ needs.prior-green.outputs.skip != 'true' }}
         run: |
           set -euo pipefail
           VERSION="$(bun -p "require('./cli/package.json').version")"
           bun scripts/release-version.ts --check "$VERSION"
       - name: prepare desktop sidecar
+        if: ${{ needs.prior-green.outputs.skip != 'true' }}
         working-directory: desktop
         run: bun run prepare:sidecar
       - name: test desktop Rust
+        if: ${{ needs.prior-green.outputs.skip != 'true' }}
         working-directory: desktop/src-tauri
         run: cargo test --locked
       - name: check desktop Rust build
+        if: ${{ needs.prior-green.outputs.skip != 'true' }}
         working-directory: desktop/src-tauri
         run: cargo check --locked
 

--- a/scripts/ci-paths-filter.test.ts
+++ b/scripts/ci-paths-filter.test.ts
@@ -146,6 +146,11 @@ describe("release.yml 并行门禁 + CI 拆分不变量 (#247 phase 2)", () => {
     expect(job).toContain("*success*) skip=true");
     // 不能把本次运行自己当证据
     expect(job).toContain('[ "$run_id" = "$GITHUB_RUN_ID" ] && continue');
+    // 只认 main 上的 push：PR 运行的 head_sha 就是 PR 头 commit，而 PR 上的 full check
+    // 可能走 cli_only 快路径（worker/web/shared/scripts 全 skip 也算绿）。拿那种绿当
+    // 「跑过完整门禁」的证据，等于没测就发版。
+    expect(job).toContain('[ "$meta" = "push main" ] || continue');
+    expect(job).toContain("head_branch");
     // 只在 tag 上才可能跳过；默认值必须是 false（任何异常都退回全跑）
     expect(job).toContain('if [ "${GITHUB_REF_TYPE:-}" = "tag" ]');
     expect(job).toMatch(/skip=false\n/);

--- a/scripts/ci-paths-filter.test.ts
+++ b/scripts/ci-paths-filter.test.ts
@@ -19,6 +19,15 @@ function hasDep(block: string, dep: string): boolean {
   return new RegExp(`^\\s*- ${dep}\\s*$`, "m").test(block);
 }
 
+/** 截出一个 job 的片段（到下一个顶层 job 为止）——别用全局 yml 断言，别的 job 会让断言假通过。 */
+function jobSlice(name: string): string {
+  const start = yml.indexOf(`\n  ${name}:\n`);
+  if (start < 0) throw new Error(`job ${name} not found in release.yml`);
+  const rest = yml.slice(start + 1);
+  const next = rest.slice(1).search(/\n {2}[a-z][a-z0-9-]*:\n/u);
+  return next < 0 ? rest : rest.slice(0, next + 1);
+}
+
 describe("release.yml 并行门禁 + CI 拆分不变量 (#247 phase 2)", () => {
   test('required 门禁 job 名字仍是 "full check"（改名会让分支保护的 required check 消失）', () => {
     expect(yml).toContain("name: full check");
@@ -62,7 +71,9 @@ describe("release.yml 并行门禁 + CI 拆分不变量 (#247 phase 2)", () => {
     expect(pluginJob).toContain("bun scripts/sync-agentparty-plugin.ts --check");
     expect(pluginJob).toContain("plugin validate --strict plugins/agentparty");
     expect(pluginJob).toContain("verify-agentparty-plugin-install.ts --claude-package-version ${{ matrix.claude }}");
-    expect(pluginJob).not.toMatch(/^\s+if:/m);
+    // 只禁**job 级** if:（缩进 4 空格）——那才是「被 cli_only 拦住」的形态。
+    // step 级 if: 是另一回事（prior-green 跳过重复 check），下面单独钉住它只能是那一个条件。
+    expect(pluginJob).not.toMatch(/^ {4}if:/m);
   });
 
   test("check-cli 分片无条件跑 + tsc 单列（cli 在快路径与全量下都要测）", () => {
@@ -75,9 +86,9 @@ describe("release.yml 并行门禁 + CI 拆分不变量 (#247 phase 2)", () => {
     expect(cliJob).toContain("working-directory: cli");
     expect(cliTypesJob).toContain("name: check cli (types)");
     expect(cliTypesJob).toContain("bunx tsc --noEmit");
-    // 无条件跑：cli 在 cli_only 快路径下也要测，故两个 job 都不带 if: 门。
-    expect(cliJob).not.toMatch(/^\s+if:/m);
-    expect(cliTypesJob).not.toMatch(/^\s+if:/m);
+    // 无条件跑：cli 在 cli_only 快路径下也要测，故两个 job 都不带**job 级** if: 门。
+    expect(cliJob).not.toMatch(/^ {4}if:/m);
+    expect(cliTypesJob).not.toMatch(/^ {4}if:/m);
   });
 
   test('聚合 "full check" needs 全部 workspace job（含 worker 分片与 types + desktop），且 if: always()', () => {
@@ -123,5 +134,46 @@ describe("release.yml 并行门禁 + CI 拆分不变量 (#247 phase 2)", () => {
     // publish（release）仍 needs build + desktop —— 传递闭包 = 全部 check，"全绿才发布"不变。
     expect(hasDep(releaseJob, "build")).toBe(true);
     expect(hasDep(releaseJob, "desktop")).toBe(true);
+  });
+
+  // ── 发版时跳过「同一 commit 已在 main 跑绿」的重复 check ──────────────
+  // 这里钉住的是这套跳过**不会变成「没跑测试也发版」**：证据必须是同 SHA 的 full check success，
+  // 跳过只发生在步骤层（job 结论与 needs 图不变），且校验 tag 本身的 version-contract 从不跳过。
+  test("prior-green 只认同 SHA 的 full check success，且 fail-safe 默认全跑", () => {
+    const job = yml.slice(yml.indexOf("  prior-green:\n"), yml.indexOf("  # ── #9 pre-merge"));
+    expect(job).toContain("head_sha=$GITHUB_SHA");
+    expect(job).toContain('select(.name == "full check")');
+    expect(job).toContain("*success*) skip=true");
+    // 不能把本次运行自己当证据
+    expect(job).toContain('[ "$run_id" = "$GITHUB_RUN_ID" ] && continue');
+    // 只在 tag 上才可能跳过；默认值必须是 false（任何异常都退回全跑）
+    expect(job).toContain('if [ "${GITHUB_REF_TYPE:-}" = "tag" ]');
+    expect(job).toMatch(/skip=false\n/);
+    // 读 run id 不靠变量分词（非 bash 下会把整串当一个元素），并显式 shell: bash
+    expect(job).toContain("while IFS= read -r run_id");
+    expect(job).toContain("shell: bash");
+  });
+
+  test("跳过只发生在步骤层：check job 的结论与 needs 图不变，version-contract 从不跳过", () => {
+    const COND = "if: ${{ needs.prior-green.outputs.skip != 'true' }}";
+    for (const name of [
+      "check-cli", "check-cli-types", "check-rest", "check-plugin",
+      "check-worker", "check-worker-types", "check-desktop",
+    ]) {
+      const job = jobSlice(name);
+      expect(job).toContain("needs: [changes, prior-green]");
+      expect(job).toContain(COND);
+      // 每一条 step 级 if: 都只能是这个条件——别的条件混进来会悄悄改变门禁语义
+      for (const line of job.split("\n").filter((l) => /^ {8}if:/.test(l))) {
+        expect(line.trim()).toBe(COND);
+      }
+    }
+    // tag 自身的校验（版本一致、不比 latest 旧）是 main 那次跑不出来的新信息，绝不能跳
+    const versionContract = jobSlice("version-contract");
+    expect(versionContract).toContain("needs: changes");
+    expect(versionContract).not.toContain("prior-green");
+    // 发布链的门禁不受影响：build/desktop 不认识 prior-green
+    expect(jobSlice("build")).not.toContain("prior-green");
+    expect(jobSlice("desktop")).not.toContain("prior-green");
   });
 });


### PR DESCRIPTION
## 为什么

owner 问「我们构建一次要 15 分钟？」。拆这次 v0.2.226 的实际时间线：

| 阶段 | 耗时 |
|---|---|
| 全部 check（并行分片） | 08:45 → 08:48，**约 3 分钟** |
| `build desktop darwin-arm64 / x64`（Tauri/Rust） | 各约 **4.5 分钟**（并行）|
| `full check` → 各平台二进制 → publish | 之后 |

15 分钟里真正的长杆是 desktop 的 Rust 构建，check 只占 3 分钟。但那 3 分钟是**纯白跑**：`v*` tag 指向的就是刚在 main 上跑完整门禁的那个 commit。

而且代价不只是时间——worker 分片在 CI 上会偶发 `EnvironmentTeardownError: Closing rpc while "resolve" was pending` 抖红。**v0.2.226 就是这样卡住的**：`check worker (shard 1/6)` 随机红 → `full check` 红 → 二进制 skip → 发不出去；`gh run rerun --failed` 之后一次就绿。已经验证过的代码，被一次重复的、抖动的验证挡在门外。

## 改法

新增 `prior-green` job，只找硬证据：

- 同一个 workflow（`release.yml`）、**同一个 commit SHA**；
- 那次运行不是本次运行；
- 那次运行里名为 `full check` 的 job 结论是 `success`（它是唯一的聚合门禁，覆盖 cli/worker/web/shared/scripts/desktop/plugin 全部区域）。

任一条不满足 ⇒ `skip=false` ⇒ 照常全跑。fail-safe 方向：配错/接口异常只会**多跑**，绝不漏测。

### 两条刻意的边界

- **跳过的是步骤，不是 job**。job 照常成功结束，`needs` 图与各 job 结论一字不变。若改成 job 级 skip，`build`/`desktop` 的 `needs` 变 skipped 会让整条发布链跟着 skip——那是「改错＝没跑测试也发版」的地方，不碰。代价是 7 个 job 各留一个 checkout（几秒），换来 3 分钟 → 约 30 秒。
- **`version-contract` 从不跳过**。它校验的是 tag 本身（版本与 package 一致、不比 latest 旧），那是 main 那次跑不出来的新信息。

## 验证

探针脚本按四种情况实跑（真 API、真 run id）：

| 场景 | 期望 | 实测 |
|---|---|---|
| 真 main SHA，已有 `full check` success | true | ✅ 命中 run 33374371614 |
| 排除本次 run，仍有另一次绿 | true | ✅ 命中 run 33374364483 |
| 不存在的 SHA | false | ✅ |
| 非 tag 触发 | false | ✅ |

**第一次本地测出的是全 false——那是我的测试脚手架错了，不是代码错**：zsh 不对不带引号的变量做分词，`for r in $runs` 把整串当成一个元素。CI 里是 bash，逻辑本来就对。已顺手把循环改成 `while IFS= read -r`（不依赖分词）并显式 `shell: bash`。

YAML 用 `yaml.safe_load` 校验通过。

https://claude.ai/code/session_01Az8CnUpayZzqpi1sh32Ssi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **优化**
  * 优化标签版本的自动检查流程：如果同一提交已通过完整验证，后续重复运行将跳过相同检查。
  * 保留检查任务及汇总结果，确保版本验证状态仍可正常查看。
  * 减少重复构建与测试带来的等待时间，加快版本发布流程。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->