### PR TITLE
perf(plugin): 没接入 AgentParty 的会话不再为每个 hook 事件启动 party

### DIFF
--- a/plugins/agentparty/bin/agentparty-runtime
+++ b/plugins/agentparty/bin/agentparty-runtime
@@ -6,6 +6,30 @@ fail() {
   exit 127
 }
 
+# #1025：没接入 AgentParty 的会话必须完全无感。
+#
+# 插件一旦启用就会被加载进**每一个** Claude 会话，于是每个 PreToolUse/PostToolUse/Stop…
+# 都要启动一次完整的 party。实测（macOS，Apple Silicon）：那个二进制每次启动恒定烧掉
+# ~130ms CPU，与它接下来干什么无关——`party --version` 同样是 130ms。原因不是二进制有
+# 68MB（同样 63MB 的最小 `bun --compile` 产物 20ms 就起来了），而是打进单文件产物的
+# ~5MB JS 每次启动都要被处理一遍：实测 4MB「从不导入、从不执行」的代码就值 280ms。
+# 多会话并发时这些短进程互相抢 CPU、触发 page-in，墙钟被放大到秒级（#602 的预算是 50ms）。
+#
+# 而这些会话在 #1018 之后连 MCP 工具面都用不了——被挡在功能之外，却照样付全额代价。
+# 所以在 spawn 之前就退出：只有 AgentParty 启动器亲手武装过的会话（party claude /
+# party bridge claude 设 AGENTPARTY_CLAUDE_LIFECYCLE_OPT_IN=1），或 serve 托管 lane
+# （AP_ACTIVITY_FILE 有值），才真的有一个在听的 listener 需要上报活动。
+#
+# 铁律照旧（#602）：stdout 永远为空、永远 exit 0——hook 的 stdout 会被灌进模型上下文，
+# 非零退出会阻断模型的工具调用。这条早退路径只用 sh 内建命令，不碰磁盘、不启动任何进程。
+case "${1:-}" in
+  hook)
+    if [ "${AGENTPARTY_CLAUDE_LIFECYCLE_OPT_IN:-}" != "1" ] && [ -z "${AP_ACTIVITY_FILE:-}" ]; then
+      exit 0
+    fi
+    ;;
+esac
+
 if [ -n "${AGENTPARTY_RUNTIME_BIN:-}" ]; then
   case "$AGENTPARTY_RUNTIME_BIN" in
     /*) : ;;

--- a/scripts/agentparty-plugin.test.ts
+++ b/scripts/agentparty-plugin.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { chmodSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
@@ -133,8 +133,10 @@ describe("AgentParty marketplace plugin", () => {
     writeFileSync(installed, "#!/bin/sh\nprintf '%s\\n' \"$*\"\n");
     chmodSync(installed, 0o755);
     try {
+      // #1025 起 hook 在未接入的会话里会在 spawn 之前退出，所以这条「不靠 PATH 也能找到
+      // party」的用例带上 launcher 武装过的 opt-in，才真的会走到 exec。
       const result = spawnSync(runtimeLauncher, ["hook", "report"], {
-        env: { HOME: home, PATH: "/usr/bin:/bin" },
+        env: { HOME: home, PATH: "/usr/bin:/bin", AGENTPARTY_CLAUDE_LIFECYCLE_OPT_IN: "1" },
         encoding: "utf8",
       });
       expect(result.status).toBe(0);
@@ -143,6 +145,92 @@ describe("AgentParty marketplace plugin", () => {
     } finally {
       rmSync(home, { recursive: true, force: true });
     }
+  });
+
+  // #1025：插件一旦启用就被加载进**每一个** Claude 会话，于是每个生命周期事件都要启动一次
+  // 完整的 party——实测每次恒定 ~130ms CPU（与它接下来干什么无关，`party --version` 同样如此）。
+  // 而这些会话在 #1018 之后连 MCP 工具面都用不了。这里钉住：没被 AgentParty 启动器武装过的
+  // 会话，hook 必须在 spawn 之前就结束，且仍然遵守 #602 铁律（stdout 空、exit 0）。
+  describe("hook fast exit for sessions that never joined (#1025)", () => {
+    /** 一个会「留下痕迹」的假 party：被 exec 到就写文件，用来证明到底有没有 spawn。 */
+    function stubHome(): { home: string; marker: string } {
+      const home = mkdtempSync(join(tmpdir(), "agentparty-hook-fastexit-"));
+      const marker = join(home, "spawned.txt");
+      const installed = resolve(home, ".local/bin/party");
+      mkdirSync(resolve(home, ".local/bin"), { recursive: true });
+      writeFileSync(installed, `#!/bin/sh\nprintf '%s' spawned > ${marker}\nprintf '%s\\n' "$*"\n`);
+      chmodSync(installed, 0o755);
+      return { home, marker };
+    }
+
+    test("未接入的会话：不启动 party，stdout 为空，exit 0", () => {
+      const { home, marker } = stubHome();
+      try {
+        const result = spawnSync(runtimeLauncher, ["hook", "report"], {
+          env: { HOME: home, PATH: "/usr/bin:/bin" },
+          input: '{"hook_event_name":"PreToolUse","tool_name":"Bash"}',
+          encoding: "utf8",
+        });
+        expect(existsSync(marker)).toBe(false);   // 真正要证的：进程根本没起
+        expect(result.status).toBe(0);            // #602：永远 exit 0
+        expect(result.stdout).toBe("");           // #602：stdout 会进模型上下文，必须为空
+        expect(result.stderr).toBe("");
+      } finally {
+        rmSync(home, { recursive: true, force: true });
+      }
+    });
+
+    test("launcher 武装过的会话（AGENTPARTY_CLAUDE_LIFECYCLE_OPT_IN=1）：照常启动", () => {
+      const { home, marker } = stubHome();
+      try {
+        const result = spawnSync(runtimeLauncher, ["hook", "report"], {
+          env: { HOME: home, PATH: "/usr/bin:/bin", AGENTPARTY_CLAUDE_LIFECYCLE_OPT_IN: "1" },
+          encoding: "utf8",
+        });
+        expect(existsSync(marker)).toBe(true);
+        expect(result.stdout).toBe("hook report\n");
+      } finally {
+        rmSync(home, { recursive: true, force: true });
+      }
+    });
+
+    test("serve 托管 lane（AP_ACTIVITY_FILE）：照常启动", () => {
+      const { home, marker } = stubHome();
+      try {
+        spawnSync(runtimeLauncher, ["hook", "report"], {
+          env: { HOME: home, PATH: "/usr/bin:/bin", AP_ACTIVITY_FILE: join(home, "activity.json") },
+          encoding: "utf8",
+        });
+        expect(existsSync(marker)).toBe(true);
+      } finally {
+        rmSync(home, { recursive: true, force: true });
+      }
+    });
+
+    test("opt-in 只认 \"1\"，且早退只作用于 hook——别的子命令一律照常", () => {
+      for (const env of [{ AGENTPARTY_CLAUDE_LIFECYCLE_OPT_IN: "0" }, { AGENTPARTY_CLAUDE_LIFECYCLE_OPT_IN: "" }]) {
+        const { home, marker } = stubHome();
+        try {
+          spawnSync(runtimeLauncher, ["hook", "report"], {
+            env: { HOME: home, PATH: "/usr/bin:/bin", ...env },
+            encoding: "utf8",
+          });
+          expect(existsSync(marker)).toBe(false);
+        } finally {
+          rmSync(home, { recursive: true, force: true });
+        }
+      }
+      // mcp / claude-channel 这些常驻入口不受影响：它们本来就只在被显式启动时才跑。
+      for (const argv of [["mcp"], ["claude-channel", "--require-launch-opt-in"], ["--version"]]) {
+        const { home, marker } = stubHome();
+        try {
+          spawnSync(runtimeLauncher, argv, { env: { HOME: home, PATH: "/usr/bin:/bin" }, encoding: "utf8" });
+          expect(existsSync(marker)).toBe(true);
+        } finally {
+          rmSync(home, { recursive: true, force: true });
+        }
+      }
+    });
   });
 
   test("fails explicitly instead of downloading when a configured runtime is missing", () => {

--- a/scripts/verify-agentparty-plugin-install.ts
+++ b/scripts/verify-agentparty-plugin-install.ts
@@ -221,6 +221,10 @@ export function inspectAgentPartyPluginInstall(
       HOME: configDirectory,
       PATH: "/usr/bin:/bin",
       AGENTPARTY_RUNTIME_BIN: runtimeProbe,
+      // #1025 起，未被 AgentParty 启动器武装过的会话里 hook 会在 spawn 之前退出。
+      // 这里要验的是「缓存副本里的 launcher 能解析到配置的 party」，所以必须走到 exec，
+      // 带上 launcher 自己会设的 opt-in。
+      AGENTPARTY_CLAUDE_LIFECYCLE_OPT_IN: "1",
     },
     encoding: "utf8",
     timeout: 5_000,


### PR DESCRIPTION
针对 #1025 的第一刀，也是 owner 那句话：**没有接入 AgentParty 的 session 应该无感才对**。

## 测量（先把根因定死，别猜）

在 load 152 的真机上逐层对照，用 CPU 时间排除负载噪声：

| | 墙钟（热） | CPU |
|---|---|---|
| `bun -e ''` | 0.01–0.25s | ~0.00s |
| 最小 `bun --compile` 产物（**63MB**） | 0.02–0.12s | ~0.00s |
| **`party --version`** | 0.72–1.72s | **0.12–0.15s** |
| **`party hook report`** | — | **~0.17s** |

三个结论：

1. **不是二进制大**。同样 63MB 的最小编译产物 20ms 就起来了。
2. **不是懒加载失效**。专门做了对照实验：`--compile` 下动态 import 确实还是懒的（触发 0.02s / 不触发 0.00s）。
3. **是 bundle 的启动处理成本**。决定性实验：把 **4MB「从不导入、从不执行」** 的代码打进产物，启动就多烧 **280ms CPU**（该产物 67.8MB，和我们的 68.3MB 同级）。所以 `--version` 和 `hook report` 代价完全相同——**代价与命令做什么无关**。

（也试了 `--bytecode`：能砍约 35%，但二进制翻倍到 132MB，仍远超 50ms，不采纳。）

## 这一刀

插件一旦启用就被加载进**每一个** Claude 会话。而这些会话在 #1018 之后连 MCP 工具面都用不了——**被挡在功能之外，却照样付全额代价**。

所以在 `exec` 之前就退出：只有被 AgentParty 启动器武装过的会话（`party claude` / `party bridge claude` 设 `AGENTPARTY_CLAUDE_LIFECYCLE_OPT_IN=1`）或 serve 托管 lane（`AP_ACTIVITY_FILE`）才真的有 listener 在听、需要上报活动。判断只用 sh 内建命令，不碰磁盘、不启动任何进程。

| | 改前 | 改后 |
|---|---|---|
| **未接入的会话** | wall 0.79–3.01s / CPU **0.16–0.19s** | wall 0.05–0.18s / CPU **0.000s** |
| 已接入的会话 | — | 不变 |

`#602` 铁律照旧：stdout 永远为空、永远 exit 0。早退只作用于 `hook` 子命令，`mcp` / `claude-channel` / `--version` 一律照常。

## 顺带修的生产代码

`verify-agentparty-plugin-install.ts` 探测缓存 launcher 用的正是 `hook report`，现在必须带 opt-in 才会走到 exec——否则那条验收验的就成了早退路径（假绿）。

## 测试

新增 4 条用例，用一个「被 exec 到就写文件」的假 party 证明**进程根本没起**（而不是只看输出）：未接入不 spawn + stdout 空 + exit 0；opt-in 会 spawn；`AP_ACTIVITY_FILE` 会 spawn；opt-in 只认 `"1"`，且别的子命令不受影响。

**变异自检**：① 去掉早退、② 早退扩大到所有子命令、③ opt-in 放宽成「非空即可」——三者各让测试变红。

`bun run check:scripts` 399 pass / 0 fail。

## 明确未解决

**已接入的会话每次 hook 仍是 ~130ms CPU，仍超 #602 的 50ms 预算。** 这一刀只解决「不该付钱的人别付钱」，#1025 保持打开。真正压到预算内需要让 hook 路径不再加载整个 CLI bundle（独立小二进制或等价方案），代价是发布体积，值得单独决策。

https://claude.ai/code/session_01Az8CnUpayZzqpi1sh32Ssi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 未启用 AgentParty 的 Claude 会话触发钩子时将快速退出，避免启动不必要的进程。
  * 已通过启动器启用或由服务托管的会话继续正常运行。
  * 其他命令（如 MCP、频道通信和版本查询）不受影响。

* **测试**
  * 增加了对不同启用方式、命令行为及快速退出逻辑的验证。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->