### PR TITLE
fix(release): 发布产物验收跟上「未武装的会话一点活都不该干」

### DIFF
--- a/scripts/verify-cli-binary.test.ts
+++ b/scripts/verify-cli-binary.test.ts
@@ -62,6 +62,13 @@ function successfulRunner(overrides: Map<string, { status: number; stdout: strin
         expect(input).toBe("{}");
         return { status: 2, stdout: "", stderr: "malformed event envelope\n" };
       case "hook report": {
+        // #1025：出厂时 hook 走的是插件 wrapper，未被 AgentParty 启动器武装过的会话在
+        // exec 之前就退出。桩必须忠实反映这一点——否则它会让「早退被改坏」的代码全绿。
+        // （真产物那一侧由 scripts/verify-cli-binary.ts 对真二进制、真 wrapper 验，
+        // 并做过变异自检：去掉早退 → 验收失败。）
+        if (!unarmedHookSpawns && env.AGENTPARTY_CLAUDE_LIFECYCLE_OPT_IN !== "1" && !env.AP_ACTIVITY_FILE) {
+          return { status: 0, stdout: "", stderr: "" };
+        }
         const payload = JSON.parse(input ?? "") as {
           session_id: string;
           hook_event_name: string;
@@ -114,6 +121,12 @@ afterEach(() => {
     rmSync(directory, { recursive: true, force: true });
   }
 });
+
+/**
+ * #1025 负向用例用：设成 true 就模拟一个「未武装也照样启动 runtime」的坏产物。
+ * 验收必须因此失败——否则那条断言等于没写。
+ */
+let unarmedHookSpawns = false;
 
 describe("CLI binary acceptance", () => {
   test("parses one explicit binary and rejects ambiguous requests", () => {
@@ -181,5 +194,16 @@ describe("CLI binary acceptance", () => {
     expect(() => verifyCliBinary(artifact(), pluginRoot, runner)).toThrow(
       "party claude-cross-session-hook exited 0; expected 2",
     );
+  });
+
+  test("未武装的会话若仍然启动 runtime，验收必须失败（#1025 回归门禁）", () => {
+    // 直接钉住那条断言的**存在**：把它从 verify-cli-binary.ts 里删掉，本用例就会红。
+    unarmedHookSpawns = true;
+    try {
+      expect(() => verifyCliBinary(artifact(), pluginRoot, successfulRunner()))
+        .toThrow(/unarmed plugin lifecycle hook still wrote/);
+    } finally {
+      unarmedHookSpawns = false;
+    }
   });
 });

--- a/scripts/verify-cli-binary.test.ts
+++ b/scripts/verify-cli-binary.test.ts
@@ -94,8 +94,19 @@ function successfulRunner(overrides: Map<string, { status: number; stdout: strin
         return { status: 0, stdout: "", stderr: "" };
       }
       case "hook stop-guard": {
-        const activityFile = env.AP_ACTIVITY_FILE;
-        expect(typeof activityFile).toBe("string");
+        // 同 `hook report`：Stop 也走插件 wrapper，未武装的会话在 exec 之前就退出。
+        // wrapper 的判据是 argv[1]==="hook"，两个子命令共用同一道闸——桩必须两边都模拟，
+        // 否则「只有 report 被挡住、stop-guard 漏了」这种缺陷会全绿。
+        if (!unarmedHookSpawns && env.AGENTPARTY_CLAUDE_LIFECYCLE_OPT_IN !== "1" && !env.AP_ACTIVITY_FILE) {
+          return { status: 0, stdout: "", stderr: "" };
+        }
+        const activityFile = env.AP_ACTIVITY_FILE ?? join(
+          env.AGENTPARTY_HOME!,
+          "state",
+          "activity",
+          `${(JSON.parse(input ?? "{}") as { session_id?: string }).session_id ?? "unknown"}.json`,
+        );
+        mkdirSync(resolve(activityFile, ".."), { recursive: true });
         const payload = JSON.parse(input ?? "") as { stop_hook_active?: boolean };
         const armed = env.AGENTPARTY_CLAUDE_LIFECYCLE_OPT_IN === "1";
         writeFileSync(activityFile!, JSON.stringify({

--- a/scripts/verify-cli-binary.ts
+++ b/scripts/verify-cli-binary.ts
@@ -301,20 +301,31 @@ export function verifyCliBinary(
       AGENTPARTY_CLAUDE_LIFECYCLE_OPT_IN: undefined,
       AP_ACTIVITY_FILE: undefined,
     };
-    runExpected(
-      runner,
-      pluginRuntime,
-      ordinaryHookEnv,
-      pluginHookArguments(requestedPluginRoot, "SessionStart"),
-      0,
-      [],
-      [],
-      JSON.stringify({
-        session_id: ordinarySessionId,
-        hook_event_name: "SessionStart",
-        cwd: process.cwd(),
-      }),
-    );
+    // 覆盖每一类事件，而不是只挑 SessionStart：Stop 在 hooks.json 里映射到的是
+    // `hook stop-guard`（另一个子命令），只验一个事件证明不了整条早退。
+    for (const event of ["SessionStart", "PreToolUse", "Stop"] as const) {
+      const unarmed = runExpected(
+        runner,
+        pluginRuntime,
+        ordinaryHookEnv,
+        pluginHookArguments(requestedPluginRoot, event),
+        0,
+        [],
+        [],
+        JSON.stringify({
+          session_id: ordinarySessionId,
+          hook_event_name: event,
+          cwd: process.cwd(),
+          ...(event === "PreToolUse" ? { tool_name: "Bash" } : {}),
+          ...(event === "Stop" ? { stop_hook_active: false } : {}),
+        }),
+      );
+      // #602 铁律：hook 的 stdout 会被灌进模型上下文，必须逐字为空——
+      // "包含某些内容" 不够，任何多余输出都是违约。
+      if (unarmed.stdout !== "") {
+        throw new Error(`unarmed plugin ${event} hook wrote to stdout`);
+      }
+    }
     // No local snapshot: nothing ran. (The previous contract accepted a private
     // snapshot here; nothing ever read it except that same session's next hook,
     // which now also does not run.)
@@ -351,7 +362,8 @@ export function verifyCliBinary(
     }
     if (
       typeof armedActivity !== "object" || armedActivity === null ||
-      (armedActivity as { phase?: unknown }).phase !== "starting"
+      (armedActivity as { phase?: unknown }).phase !== "starting" ||
+      typeof (armedActivity as { ts?: unknown }).ts !== "number"
     ) {
       throw new Error("armed plugin lifecycle hook wrote the wrong local activity snapshot");
     }

--- a/scripts/verify-cli-binary.ts
+++ b/scripts/verify-cli-binary.ts
@@ -50,6 +50,8 @@ export interface CliBinaryAcceptanceReport {
     claude_cross_session_hook_fail_closed: true;
     plugin_runtime_hook_exec_form: true;
     plugin_activity_unarmed_isolated: true;
+    /** #1025：未武装的会话连 runtime 都不该启动（不只是不写共享 presence）。 */
+    plugin_hook_unarmed_does_not_spawn: true;
     plugin_activity_failed_push_rearms: true;
     plugin_activity_busy_phase: true;
     plugin_activity_waiting_phase: true;
@@ -274,9 +276,16 @@ export function verifyCliBinary(
     }
 
     // Enabled Marketplace hooks are initialized in ordinary Claude sessions
-    // too. Prove that an unarmed session records only its private local
-    // snapshot and does not even create the optimistic REST-push marker that
-    // could overwrite a real listener's shared presence row.
+    // too. The guarantee has always been "an unarmed session must not touch a
+    // real listener's shared presence"; since #1025 it is strictly stronger:
+    // such a session does no work at all. The plugin wrapper returns before it
+    // ever execs the runtime, because loading the CLI costs ~130ms of CPU per
+    // event no matter what the event is, and an unarmed session cannot use
+    // AgentParty anyway (#1018 gates its tools).
+    //
+    // This probe runs against the real release binary through the real cached
+    // wrapper — the unit tests use a stub, so this is the only place the shipped
+    // artifact's per-event cost contract is actually enforced.
     const ordinarySessionId = "release-plugin-hook-ordinary";
     const ordinaryActivityFile = join(
       isolatedHome,
@@ -306,20 +315,45 @@ export function verifyCliBinary(
         cwd: process.cwd(),
       }),
     );
-    let ordinaryActivity: unknown;
-    try {
-      ordinaryActivity = JSON.parse(readFileSync(ordinaryActivityFile, "utf8")) as unknown;
-    } catch {
-      throw new Error("unarmed plugin lifecycle hook did not retain its local activity snapshot");
+    // No local snapshot: nothing ran. (The previous contract accepted a private
+    // snapshot here; nothing ever read it except that same session's next hook,
+    // which now also does not run.)
+    if (existsSync(ordinaryActivityFile)) {
+      throw new Error("unarmed plugin lifecycle hook still wrote a local activity snapshot");
     }
-    if (
-      typeof ordinaryActivity !== "object" || ordinaryActivity === null ||
-      (ordinaryActivity as { phase?: unknown }).phase !== "starting"
-    ) {
-      throw new Error("unarmed plugin lifecycle hook wrote the wrong local activity snapshot");
-    }
+    // The original guarantee, unchanged: never the shared-presence push marker.
     if (existsSync(`${ordinaryActivityFile}.push.json`)) {
       throw new Error("unarmed plugin lifecycle hook attempted to publish shared presence activity");
+    }
+    // And the armed session must still work — otherwise "does nothing" would be
+    // trivially satisfied by a hook that is simply broken.
+    const armedSessionId = "release-plugin-hook-armed";
+    const armedActivityFile = join(isolatedHome, "state", "activity", `${armedSessionId}.json`);
+    runExpected(
+      runner,
+      pluginRuntime,
+      { ...ordinaryHookEnv, AGENTPARTY_CLAUDE_LIFECYCLE_OPT_IN: "1" },
+      pluginHookArguments(requestedPluginRoot, "SessionStart"),
+      0,
+      [],
+      [],
+      JSON.stringify({
+        session_id: armedSessionId,
+        hook_event_name: "SessionStart",
+        cwd: process.cwd(),
+      }),
+    );
+    let armedActivity: unknown;
+    try {
+      armedActivity = JSON.parse(readFileSync(armedActivityFile, "utf8")) as unknown;
+    } catch {
+      throw new Error("armed plugin lifecycle hook did not write its local activity snapshot");
+    }
+    if (
+      typeof armedActivity !== "object" || armedActivity === null ||
+      (armedActivity as { phase?: unknown }).phase !== "starting"
+    ) {
+      throw new Error("armed plugin lifecycle hook wrote the wrong local activity snapshot");
     }
 
     // This is the exact exec-form composition Claude uses for plugin hooks:
@@ -531,6 +565,7 @@ export function verifyCliBinary(
         claude_cross_session_hook_fail_closed: true,
         plugin_runtime_hook_exec_form: true,
         plugin_activity_unarmed_isolated: true,
+        plugin_hook_unarmed_does_not_spawn: true,
         plugin_activity_failed_push_rearms: true,
         plugin_activity_busy_phase: true,
         plugin_activity_waiting_phase: true,


### PR DESCRIPTION
## v0.2.229 发布失败，而且是我判错了

`build bun-linux-x64 / Claude capability binary acceptance` 挂在：

```
verify-cli-binary: unarmed plugin lifecycle hook did not retain its local activity snapshot
```

**这正是 CodeRabbit 在 #1026 上提的第一条，我当时判成「不成立」。** 我只查了 `scripts/verify-cli-binary.test.ts`（用桩、直接调 party、不经 launcher）就下了结论，**没查 `scripts/verify-cli-binary.ts` 这个真验收脚本**——它拿真二进制走真 wrapper。判错了，记在这里。

## 契约怎么改

那条断言护的意图写在它自己的注释里：「未武装的会话**只**写自己的私有快照，绝不碰共享 presence」。#1026 之后它一点都不写——**保证只强不弱**。而那份私有快照的唯一读者是「同一会话的下一次 hook」，那次现在也不跑了，所以对未武装会话它就是纯死重（正是 #1025 要消掉的东西）。

升级成更强的版本，并让它成为 #1025 的回归门禁：

| | 契约 |
|---|---|
| 未武装 | 不写 activity、不写 push marker、stdout 空、exit 0 |
| 武装 | 照常写出正确快照 —— 否则「什么都不干」会被一个单纯坏掉的 hook 轻易满足 |

新增 probe 字段 `plugin_hook_unarmed_does_not_spawn`（additive）。

**这是唯一能验到发布产物的地方**——单测用的是桩。issue #1025 里「验收应覆盖发布产物，不只覆盖 `bun src/index.ts`」说的就是这个缺口。

## 验证

- 真编译一份二进制、跑真验收：`status: passed`，两个 probe 都为 true。
- **变异自检（真产物）**：去掉 launcher 的早退 → 验收报 `unarmed plugin lifecycle hook still wrote a local activity snapshot` 并失败；恢复后 passed。
- **变异自检（单测）**：把新断言从验收脚本里删掉 → 单测红。这条是第二笔 commit 补的——第一次做变异时发现单测**完全没保护那条断言的存在性**（删掉照样绿），于是加了负向用例：用一个可翻转开关造出「未武装也照样启动 runtime」的坏产物，验收必须抛错。
- 桩也跟着忠实模拟了 wrapper 的早退，否则它会让「早退被改坏」的代码全绿。
- `bun run check:scripts` 400 pass / 0 fail。

https://claude.ai/code/session_01Az8CnUpayZzqpi1sh32Ssi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 改进插件会话生命周期验证：未启用生命周期功能时不会启动运行时或写入本地活动记录。
  * 已启用的会话仍会正确生成启动状态记录。
  * 新增验收检查，及时识别未启用时仍启动运行时的问题。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->