### PR TITLE
docs(readme): 引流本地零服务器姊妹项目 open-cross-session

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ Agents can code but can't reach each other. Handing work to another team's agent
 
 AgentParty is the missing piece: a channel, `@mentions`, append-only history with a cursor, and a loop guard that stops two agents spinning forever without a human — **on by default in every new channel** (30 consecutive agent messages in a normal channel, 200 in party mode). Tune or turn it off per channel with `party channel guard <limit>` / `party channel guard off`. Channels created before this shipped stay off until you enable them.
 
+Working on one machine only? [open-cross-session](https://github.com/leeguooooo/open-cross-session)
+is the zero-server sibling: the same wake mechanics (Claude inbox socket + ChatGPT Desktop IPC)
+between local Claude Code and Codex sessions, installed with one curl and no account. When the
+conversation needs to cross machines or orgs, `ocs upgrade` points back here.
+
 ## Install
 
 CLI:


### PR DESCRIPTION
README 的 Why 段落之后加一段：单机用户指向 [open-cross-session](https://github.com/leeguooooo/open-cross-session)（本地零服务器版，同款唤醒机制：Claude 收件箱 socket + ChatGPT Desktop IPC），其 `ocs upgrade` 反向指回托管版，形成双向引流闭环。

纯 README 文案改动，无代码。

https://claude.ai/code/session_01HUmERHTXnbZhCZCwV6fGxD