### PR TITLE
perf(plugin): 合并 PreToolUse/PostToolUse 的重复启动，止住已武装会话的 hook 超时

### DIFF
--- a/plugins/agentparty/bin/agentparty-runtime
+++ b/plugins/agentparty/bin/agentparty-runtime
@@ -30,31 +30,102 @@ case "${1:-}" in
     ;;
 esac
 
-if [ -n "${AGENTPARTY_RUNTIME_BIN:-}" ]; then
-  case "$AGENTPARTY_RUNTIME_BIN" in
-    /*) : ;;
-    *) fail "AGENTPARTY_RUNTIME_BIN must be an absolute path" ;;
-  esac
-  [ -x "$AGENTPARTY_RUNTIME_BIN" ] \
-    || fail "AGENTPARTY_RUNTIME_BIN is not executable: $AGENTPARTY_RUNTIME_BIN"
-  exec "$AGENTPARTY_RUNTIME_BIN" "$@"
-fi
-
-path_party="$(command -v party 2>/dev/null || true)"
-if [ -n "$path_party" ] && [ -x "$path_party" ]; then
-  exec "$path_party" "$@"
-fi
-
-for candidate in \
-  "${HOME:-}/.local/bin/party" \
-  "/opt/homebrew/bin/party" \
-  "/usr/local/bin/party" \
-  "/Applications/AgentParty.app/Contents/MacOS/party"
-do
-  [ "$candidate" != "/.local/bin/party" ] || continue
-  if [ -x "$candidate" ]; then
-    exec "$candidate" "$@"
+# 解析出真正的 party 可执行体。写成函数（而不是一路 exec）是因为 #1025 的合并逻辑
+# 需要先把 stdin 读进来，再用管道喂给它——那条路径没法直接 exec 整条流水线。
+resolve_party() {
+  if [ -n "${AGENTPARTY_RUNTIME_BIN:-}" ]; then
+    case "$AGENTPARTY_RUNTIME_BIN" in
+      /*) : ;;
+      *) fail "AGENTPARTY_RUNTIME_BIN must be an absolute path" ;;
+    esac
+    [ -x "$AGENTPARTY_RUNTIME_BIN" ] \
+      || fail "AGENTPARTY_RUNTIME_BIN is not executable: $AGENTPARTY_RUNTIME_BIN"
+    printf '%s' "$AGENTPARTY_RUNTIME_BIN"
+    return 0
   fi
-done
 
-fail "party runtime not found. Install it with: curl -fsSL https://raw.githubusercontent.com/leeguooooo/agentparty/main/install.sh | sh ; then run /reload-plugins or start a new Claude session"
+  path_party="$(command -v party 2>/dev/null || true)"
+  if [ -n "$path_party" ] && [ -x "$path_party" ]; then
+    printf '%s' "$path_party"
+    return 0
+  fi
+
+  for candidate in \
+    "${HOME:-}/.local/bin/party" \
+    "/opt/homebrew/bin/party" \
+    "/usr/local/bin/party" \
+    "/Applications/AgentParty.app/Contents/MacOS/party"
+  do
+    [ "$candidate" != "/.local/bin/party" ] || continue
+    if [ -x "$candidate" ]; then
+      printf '%s' "$candidate"
+      return 0
+    fi
+  done
+
+  fail "party runtime not found. Install it with: curl -fsSL https://raw.githubusercontent.com/leeguooooo/agentparty/main/install.sh | sh ; then run /reload-plugins or start a new Claude session"
+}
+
+# ── #1025 第二刀：把 PreToolUse/PostToolUse 的重复启动合并掉 ─────────────────
+#
+# 已武装的会话每个事件仍要启动一次完整的 party。实测（Apple Silicon，load ~130）：
+# 单次 wall 1.9–4.4 秒，峰值 9.4–12.3 秒——而 Claude 的 hook 超时是 10 秒，于是
+# SessionStart / Stop 会被判 failed（owner 实测截图）。CPU 只有 0.25s，差的几十倍全是
+# 高负载下的调度等待与调页；而负载本身有很大一部分正是这些短进程自己造出来的。
+#
+# 能合并是因为 hook 内部本来就对普通事件做 15 秒节流：同一窗口内的第二、第三次启动，
+# 做完的事和第一次一模一样。所以只对**这两类**事件按时间窗合并：
+#   - 相位边界事件（Notification=权限等待、SessionStart、compaction、turn 失败…）永不合并；
+#   - Stop 走的是 stop-guard 子命令，完全不经过这里——它要读按 (server,token,channel) 哈希出来的
+#     journal 才能判断该不该拦，sh 里算不出那个路径，靠猜文件位置跳过等于「该拦的没拦住」。
+#
+# 合并只损失一条重复的 presence 活动上报（那本来就会被节流丢掉），不影响消息收发与唤醒。
+# 关掉：AGENTPARTY_HOOK_COALESCE_SECONDS=0。
+coalesce_seconds="${AGENTPARTY_HOOK_COALESCE_SECONDS:-10}"
+
+maybe_coalesce_report() {
+  # $1 = 完整 payload。返回 0 表示「本次可以跳过」。
+  [ "$coalesce_seconds" -gt 0 ] 2>/dev/null || return 1
+  case "$1" in
+    *'"hook_event_name":"PreToolUse"'*|*'"hook_event_name": "PreToolUse"'*|\
+    *'"hook_event_name":"PostToolUse"'*|*'"hook_event_name": "PostToolUse"'*) : ;;
+    *) return 1 ;;
+  esac
+
+  if [ -n "${AP_ACTIVITY_FILE:-}" ]; then
+    stamp="${AP_ACTIVITY_FILE}.coalesce"
+  else
+    # session_id 用纯参数展开取，不起子进程（这条路径的全部意义就是别花钱）。
+    sid="$1"
+    case "$sid" in *'"session_id":"'*) sid="${sid#*\"session_id\":\"}"; sid="${sid%%\"*}" ;; *) return 1 ;; esac
+    # 它要拼进路径：字符集不合法就别合并，绝不拿它构造路径。
+    case "$sid" in ""|*[!A-Za-z0-9._-]*) return 1 ;; esac
+    stamp="${AGENTPARTY_HOME:-${HOME:-}/.agentparty}/state/activity/${sid}.json.coalesce"
+  fi
+
+  now="$(date +%s 2>/dev/null || echo 0)"
+  case "$now" in ""|*[!0-9]*) return 1 ;; esac
+  last="$(cat "$stamp" 2>/dev/null || echo 0)"
+  case "$last" in ""|*[!0-9]*) last=0 ;; esac
+
+  if [ "$((now - last))" -lt "$coalesce_seconds" ] && [ "$last" -le "$now" ]; then
+    return 0
+  fi
+  # 这次要真跑：先记下时刻，窗口内后续的同类事件就能跳过。写不进去就当没有窗口（照常启动）。
+  mkdir -p "${stamp%/*}" 2>/dev/null || true
+  printf '%s' "$now" > "$stamp" 2>/dev/null || true
+  return 1
+}
+
+party_bin="$(resolve_party)"
+
+if [ "${1:-}" = "hook" ] && [ "${2:-}" = "report" ]; then
+  payload="$(cat)"
+  if maybe_coalesce_report "$payload"; then
+    exit 0
+  fi
+  printf '%s' "$payload" | "$party_bin" "$@"
+  exit 0
+fi
+
+exec "$party_bin" "$@"

--- a/plugins/agentparty/bin/agentparty-runtime
+++ b/plugins/agentparty/bin/agentparty-runtime
@@ -120,12 +120,16 @@ maybe_coalesce_report() {
 party_bin="$(resolve_party)"
 
 if [ "${1:-}" = "hook" ] && [ "${2:-}" = "report" ]; then
-  payload="$(cat)"
+  # `$(cat)` 会吃掉结尾的换行——补一个哨兵再摘掉，原样保留字节（CodeRabbit on #1034）。
+  payload="$(cat; printf x)"
+  payload="${payload%x}"
   if maybe_coalesce_report "$payload"; then
     exit 0
   fi
+  # 显式透传 party 的退出码。注：脚本开头的 `set -e` 本来就会在管道失败时以该状态退出——
+  # 变异自检实测（把这行改成 `exit 0`，行为不变）证明了这一点。写出来只为让意图不依赖 set -e。
   printf '%s' "$payload" | "$party_bin" "$@"
-  exit 0
+  exit $?
 fi
 
 exec "$party_bin" "$@"

--- a/scripts/agentparty-plugin.test.ts
+++ b/scripts/agentparty-plugin.test.ts
@@ -233,6 +233,121 @@ describe("AgentParty marketplace plugin", () => {
     });
   });
 
+  // #1025 第二刀：已武装的会话每个事件仍要启动一次完整的 party（实测 load ~130 下 wall 1.9–4.4s、
+  // 峰值 9.4–12.3s，而 Claude 的 hook 超时是 10s）。hook 内部本来就对普通事件做 15 秒节流，
+  // 所以同一窗口内的重复启动做完的事一模一样——在 wrapper 层合并掉。
+  describe("PreToolUse/PostToolUse 的重复启动被合并（#1025）", () => {
+    function stubHome(): { home: string; marker: string; env: NodeJS.ProcessEnv } {
+      const home = mkdtempSync(join(tmpdir(), "agentparty-coalesce-"));
+      const marker = join(home, "spawned.txt");
+      const installed = resolve(home, ".local/bin/party");
+      mkdirSync(resolve(home, ".local/bin"), { recursive: true });
+      writeFileSync(installed, `#!/bin/sh\nprintf 'x' >> ${marker}\ncat > /dev/null\n`);
+      chmodSync(installed, 0o755);
+      return {
+        home,
+        marker,
+        env: {
+          HOME: home,
+          AGENTPARTY_HOME: join(home, ".agentparty"),
+          PATH: "/usr/bin:/bin",
+          AGENTPARTY_CLAUDE_LIFECYCLE_OPT_IN: "1",
+        },
+      };
+    }
+
+    const spawns = (marker: string) => (existsSync(marker) ? readFileSync(marker, "utf8").length : 0);
+    const fire = (env: NodeJS.ProcessEnv, event: string, extra: NodeJS.ProcessEnv = {}) =>
+      spawnSync(runtimeLauncher, ["hook", "report"], {
+        env: { ...env, ...extra },
+        input: JSON.stringify({ hook_event_name: event, tool_name: "Bash", session_id: "sess-1" }),
+        encoding: "utf8",
+      });
+
+    test("同一窗口内连发 5 次 PreToolUse ⇒ 只启动 1 次", () => {
+      const { home, marker, env } = stubHome();
+      try {
+        for (let i = 0; i < 5; i += 1) fire(env, "PreToolUse");
+        expect(spawns(marker)).toBe(1);
+      } finally {
+        rmSync(home, { recursive: true, force: true });
+      }
+    });
+
+    test("相位边界事件（权限等待等）永不合并", () => {
+      const { home, marker, env } = stubHome();
+      try {
+        for (let i = 0; i < 3; i += 1) fire(env, "Notification");
+        expect(spawns(marker)).toBe(3);
+      } finally {
+        rmSync(home, { recursive: true, force: true });
+      }
+    });
+
+    test("AGENTPARTY_HOOK_COALESCE_SECONDS=0 关掉合并", () => {
+      const { home, marker, env } = stubHome();
+      try {
+        for (let i = 0; i < 3; i += 1) fire(env, "PreToolUse", { AGENTPARTY_HOOK_COALESCE_SECONDS: "0" });
+        expect(spawns(marker)).toBe(3);
+      } finally {
+        rmSync(home, { recursive: true, force: true });
+      }
+    });
+
+    test("payload 原样透传（读了 stdin 就必须再喂回去）", () => {
+      const home = mkdtempSync(join(tmpdir(), "agentparty-coalesce-echo-"));
+      const installed = resolve(home, ".local/bin/party");
+      mkdirSync(resolve(home, ".local/bin"), { recursive: true });
+      writeFileSync(installed, "#!/bin/sh\ncat\n");
+      chmodSync(installed, 0o755);
+      try {
+        const payload = JSON.stringify({ hook_event_name: "PreToolUse", tool_name: "Bash", session_id: "sess-1" });
+        const result = spawnSync(runtimeLauncher, ["hook", "report"], {
+          env: { HOME: home, AGENTPARTY_HOME: join(home, ".agentparty"), PATH: "/usr/bin:/bin", AGENTPARTY_CLAUDE_LIFECYCLE_OPT_IN: "1" },
+          input: payload,
+          encoding: "utf8",
+        });
+        expect(result.stdout).toBe(payload);
+      } finally {
+        rmSync(home, { recursive: true, force: true });
+      }
+    });
+
+    test("恶意 session_id 既不参与合并、也绝不拼进路径", () => {
+      const { home, marker, env } = stubHome();
+      try {
+        for (let i = 0; i < 3; i += 1) {
+          spawnSync(runtimeLauncher, ["hook", "report"], {
+            env,
+            input: JSON.stringify({ hook_event_name: "PreToolUse", session_id: "../../../../etc/x" }),
+            encoding: "utf8",
+          });
+        }
+        // 不合并（字符集不合法 ⇒ 每次都照常启动），且没有在 home 之外留下任何 .coalesce 文件
+        expect(spawns(marker)).toBe(3);
+        expect(existsSync(join(home, ".agentparty", "state", "activity"))).toBe(false);
+      } finally {
+        rmSync(home, { recursive: true, force: true });
+      }
+    });
+
+    test("Stop 走 stop-guard，完全不经过合并（该拦的必须还能拦）", () => {
+      const { home, marker, env } = stubHome();
+      try {
+        for (let i = 0; i < 3; i += 1) {
+          spawnSync(runtimeLauncher, ["hook", "stop-guard"], {
+            env,
+            input: JSON.stringify({ hook_event_name: "Stop", session_id: "sess-1" }),
+            encoding: "utf8",
+          });
+        }
+        expect(spawns(marker)).toBe(3);
+      } finally {
+        rmSync(home, { recursive: true, force: true });
+      }
+    });
+  });
+
   test("fails explicitly instead of downloading when a configured runtime is missing", () => {
     const result = spawnSync(runtimeLauncher, ["mcp"], {
       env: {

--- a/scripts/agentparty-plugin.test.ts
+++ b/scripts/agentparty-plugin.test.ts
@@ -313,6 +313,43 @@ describe("AgentParty marketplace plugin", () => {
       }
     });
 
+    test("payload 结尾的换行原样保留（`$(cat)` 会吃掉它）", () => {
+      const home = mkdtempSync(join(tmpdir(), "agentparty-coalesce-nl-"));
+      const installed = resolve(home, ".local/bin/party");
+      mkdirSync(resolve(home, ".local/bin"), { recursive: true });
+      writeFileSync(installed, "#!/bin/sh\ncat\n");
+      chmodSync(installed, 0o755);
+      try {
+        const payload = `${JSON.stringify({ hook_event_name: "PreToolUse", session_id: "sess-nl" })}\n`;
+        const result = spawnSync(runtimeLauncher, ["hook", "report"], {
+          env: { HOME: home, AGENTPARTY_HOME: join(home, ".agentparty"), PATH: "/usr/bin:/bin", AGENTPARTY_CLAUDE_LIFECYCLE_OPT_IN: "1" },
+          input: payload,
+          encoding: "utf8",
+        });
+        expect(result.stdout).toBe(payload);
+      } finally {
+        rmSync(home, { recursive: true, force: true });
+      }
+    });
+
+    test("party 的退出码要带出来，别吞成 0", () => {
+      const home = mkdtempSync(join(tmpdir(), "agentparty-coalesce-exit-"));
+      const installed = resolve(home, ".local/bin/party");
+      mkdirSync(resolve(home, ".local/bin"), { recursive: true });
+      writeFileSync(installed, "#!/bin/sh\ncat > /dev/null\nexit 3\n");
+      chmodSync(installed, 0o755);
+      try {
+        const result = spawnSync(runtimeLauncher, ["hook", "report"], {
+          env: { HOME: home, AGENTPARTY_HOME: join(home, ".agentparty"), PATH: "/usr/bin:/bin", AGENTPARTY_CLAUDE_LIFECYCLE_OPT_IN: "1" },
+          input: JSON.stringify({ hook_event_name: "PreToolUse", session_id: "sess-exit" }),
+          encoding: "utf8",
+        });
+        expect(result.status).toBe(3);
+      } finally {
+        rmSync(home, { recursive: true, force: true });
+      }
+    });
+
     test("恶意 session_id 既不参与合并、也绝不拼进路径", () => {
       const { home, marker, env } = stubHome();
       try {


### PR DESCRIPTION
owner：「bug 没修复？」——**对，#1026 只豁免了未接入的会话**，已武装的会话（也就是他截图里那种）一分没省。这一刀补上。

## 现场量到的

| | |
|---|---|
| `party hook report`（已武装，load ~130） | wall **1.9–4.4s**，峰值 **9.4–12.3s** |
| Claude 的 hook 超时 | **10s** |
| 同一次调用的 CPU | 只有 **0.25s** |

差的几十倍全是高负载下的调度等待与调页——**而负载本身有很大一部分正是这些短进程自己造出来的**。owner 截图里 `SessionStart hook (failed) — timed out after 10s` 就是这么来的。

（`--minify` 实测无效：3.3MB JS 的产物 1.44–5.32s，和 5MB 的出厂版在噪声内。所以不是少打包一点能解决的。）

## 这一刀

hook 内部本来就对普通事件做 **15 秒节流**——同一窗口内的第二、第三次启动，做完的事和第一次一模一样。所以在 wrapper 层按时间窗合并，**只针对 `PreToolUse` / `PostToolUse`**：

- **相位边界事件永不合并**：`Notification`（权限等待）、`SessionStart`、compaction、turn 失败——这些正是绕过内部节流的那些。
- **`Stop` 完全不经过这条路径**：它走 `stop-guard` 子命令。我考虑过在 sh 里判「journal 空就别启动」，但那个 journal 路径是按 `(server, token, channel)` 哈希出来的，**sh 里算不出**；靠猜文件位置去跳过，等于「该拦的 Stop 没拦住」——方向错了，不做。

全程 POSIX sh：连 `session_id` 都用参数展开取、不起子进程；字符集不合法就不合并，**绝不拿它构造路径**。关掉：`AGENTPARTY_HOOK_COALESCE_SECONDS=0`。

实测一个 turn 里 8 次 `PreToolUse`：**4.05 / 1.91 / 1.02 / 0.37 / 0.09 / 0.03 / 0.41 / 0.04** 秒。

## 测试

6 条新用例，用「被 exec 到就写文件」的假 party 数**真实启动次数**（不是看输出）：连发 5 次只启动 1 次、相位边界事件 3 次都启动、开关能关掉、payload 原样透传（读了 stdin 就必须喂回去）、恶意 `session_id` 既不合并也不拼路径、`stop-guard` 三次都照常启动。

**变异自检**：① 不合并、② 所有事件都合并（相位边界被吞）、③ 不校验 `session_id` 字符集、④ 读了 stdin 不喂回去 —— 四条各让用例变红。`check:scripts` 406 pass。

## 仍未解决

单次启动仍是 ~130ms CPU / 高负载下数秒。真要压进 #602 的 50ms，只有让 hook 不加载整个 CLI bundle（独立小二进制，安装体积 68→131MB）。#1025 保持打开，那个交换留给 owner 定。

https://claude.ai/code/session_01Az8CnUpayZzqpi1sh32Ssi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 优化工具调用事件上报：短时间内连续触发的同类事件将自动合并，减少重复启动和上报。
  * 支持通过环境变量调整事件合并时间窗口，也可关闭合并。
  * 事件数据将保持原样传递，其他类型事件继续即时处理。

* **Bug 修复**
  * 增强会话标识校验，避免异常输入导致在非预期位置生成文件。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->