### PR TITLE
fix(cli): hook 路径加 stdout 闸，杜绝 invalid stop hook JSON output

### DIFF
--- a/cli/src/commands/hook.ts
+++ b/cli/src/commands/hook.ts
@@ -1322,7 +1322,7 @@ export function defaultCodexStopWakeDeps(
     },
     readSeen: readCodexStopWakeSeen,
     recordSeen: (path, seq, at) => recordCodexStopWakeSeen(path, seq, at),
-    emit: (line) => console.log(line),
+    emit: (line) => emitHookLine(line),
     log: (line) => appendCodexAutoWakeLog(home, line),
     now: () => Date.now(),
     wakeLang: async (channel, cwd) => {
@@ -1826,7 +1826,8 @@ async function runHookInput(blockStop: boolean): Promise<number> {
     // recent permission/tool/idle push must not mask that the model was kept
     // alive for another continuation.
     reportHookPayload(record, "working", true);
-    console.log(JSON.stringify({
+    // 唯一允许写 stdout 的出口（#1032）：闸内其余 console.log 都被改道去了 stderr。
+    emitHookLine(JSON.stringify({
       decision: "block",
       reason:
         `AgentParty still has ${pendingCount} delivered execution${pendingCount === 1 ? "" : "s"} ` +
@@ -1840,6 +1841,40 @@ async function runHookInput(blockStop: boolean): Promise<number> {
   return 0;
 }
 
+/**
+ * hook 路径的 stdout 闸（#1032）。
+ *
+ * 这些子命令的输出契约是「要么零字节，要么恰好一行 JSON」——codex 拿 stdout 当 Stop hook 的
+ * 决策，Claude 拿 stdout 当模型上下文。可路径上任何一处 `console.log`（我们自己的、还是某个
+ * 被 import 进来的模块的）都会直接落进那条信道并让它变成非法输出。真机实测：一个交互式 codex
+ * 会话轮次结束时报 `hook returned invalid stop hook JSON output`。
+ *
+ * `party mcp` 早就为同一个原因做过这件事（#596：stdio 是 JSON-RPC 信道）。这里照抄：把
+ * console.log 改道到 stderr，只留一条显式通道给真正要写的那行。
+ *
+ * 注意这不是「猜哪里会打印」——它让契约与打印点解耦：以后谁往这条路径上加日志都不会再破坏它。
+ */
+export async function withHookStdoutGuard(body: () => Promise<number>): Promise<number> {
+  const previous = console.log;
+  hookStdoutWrite = (line: string) => previous(line);
+  console.log = (...args: unknown[]) => console.error(...args);
+  try {
+    return await body();
+  } finally {
+    console.log = previous;
+    hookStdoutWrite = null;
+  }
+}
+
+/** 闸打开期间，唯一允许写 stdout 的通道；闸外为 null（照常用 console.log）。 */
+let hookStdoutWrite: ((line: string) => void) | null = null;
+
+/** hook 决策行的唯一出口：闸内走保留下来的真 stdout，闸外退回 console.log。 */
+export function emitHookLine(line: string): void {
+  if (hookStdoutWrite === null) console.log(line);
+  else hookStdoutWrite(line);
+}
+
 export async function run(argv: string[]): Promise<number> {
   if (isHelpArg(argv, { allowHelpPositional: true })) {
     console.log(HELP);
@@ -1850,13 +1885,13 @@ export async function run(argv: string[]): Promise<number> {
   if (sub === "uninstall") return runUninstall(rest);
   if (sub === "status") return runStatus(rest);
   if (sub === "push") return runPush(rest);
-  if (sub === "codex-report") return runCodexHookInput();
-  if (sub === "codex-stop") return runCodexStopHookInput();
+  if (sub === "codex-report") return withHookStdoutGuard(() => runCodexHookInput());
+  if (sub === "codex-stop") return withHookStdoutGuard(() => runCodexStopHookInput());
   if (sub === "codex-autowake") return runCodexAutoWakeCommand(rest);
   if (sub !== "report" && sub !== "stop-guard") {
     // 会写 stderr 的分支只剩人在终端敲错子命令。真 hook 调用恒为 `hook report`，不受影响。
     console.error(HELP);
     return 1;
   }
-  return runHookInput(sub === "stop-guard");
+  return withHookStdoutGuard(() => runHookInput(sub === "stop-guard"));
 }

--- a/cli/test/hook-stdout-guard.test.ts
+++ b/cli/test/hook-stdout-guard.test.ts
@@ -1,0 +1,83 @@
+// #1032：真机上一个交互式 codex 会话轮次结束时报
+//   Stop hook (failed) — hook returned invalid stop hook JSON output
+//
+// 这些子命令的输出契约是「要么零字节，要么恰好一行 JSON」——codex 拿 stdout 当 Stop 决策、
+// Claude 拿 stdout 当模型上下文。而路径上任何一处 console.log（我们自己的、或某个被 import
+// 进来的模块的）都会直接落进那条信道。`party mcp` 早就为同一原因把 console.log 改道（#596）。
+//
+// 这里钉的是「契约与打印点解耦」：以后谁往这条路径上加日志都不该再破坏它。
+import { describe, expect, test } from "bun:test";
+import { emitHookLine, withHookStdoutGuard } from "../src/commands/hook";
+
+describe("hook 的 stdout 闸（#1032）", () => {
+  function capture(): { out: string[]; err: string[]; restore: () => void } {
+    const out: string[] = [];
+    const err: string[] = [];
+    const realLog = console.log;
+    const realErr = console.error;
+    console.log = (...a: unknown[]) => void out.push(a.map(String).join(" "));
+    console.error = (...a: unknown[]) => void err.push(a.map(String).join(" "));
+    return {
+      out,
+      err,
+      restore: () => {
+        console.log = realLog;
+        console.error = realErr;
+      },
+    };
+  }
+
+  test("闸内的 console.log 一律改道 stderr，stdout 保持零字节", async () => {
+    const c = capture();
+    try {
+      await withHookStdoutGuard(async () => {
+        console.log("某个模块顺手打的日志");
+        return 0;
+      });
+    } finally {
+      c.restore();
+    }
+    expect(c.out).toEqual([]);
+    expect(c.err).toContain("某个模块顺手打的日志");
+  });
+
+  test("决策行仍然写进真正的 stdout，且只此一条", async () => {
+    const c = capture();
+    try {
+      await withHookStdoutGuard(async () => {
+        console.log("噪声");
+        emitHookLine('{"decision":"block","reason":"x"}');
+        console.log("更多噪声");
+        return 0;
+      });
+    } finally {
+      c.restore();
+    }
+    expect(c.out).toEqual(['{"decision":"block","reason":"x"}']);
+  });
+
+  test("闸退出后 console.log 恢复原样（抛异常也要恢复）", async () => {
+    const c = capture();
+    try {
+      await expect(
+        withHookStdoutGuard(async () => {
+          throw new Error("boom");
+        }),
+      ).rejects.toThrow("boom");
+      console.log("闸外的日志照常走 stdout");
+    } finally {
+      c.restore();
+    }
+    expect(c.out).toEqual(["闸外的日志照常走 stdout"]);
+  });
+
+  test("闸外调用 emitHookLine 退回 console.log（不吞输出）", () => {
+    const c = capture();
+    try {
+      emitHookLine("plain");
+    } finally {
+      c.restore();
+    }
+    expect(c.out).toEqual(["plain"]);
+  });
+});


### PR DESCRIPTION
Closes #1032

## 现场

owner 截图 + #1032：一个交互式 codex 会话轮次结束时

```
Stop hook (failed)
error: hook returned invalid stop hook JSON output
```

## 根因的形状

`hook codex-stop` / `stop-guard` 的输出契约是「**要么零字节，要么恰好一行 JSON**」——codex 拿 stdout 当 Stop 决策，Claude 拿 stdout 当模型上下文。而这条路径上**任何一处 `console.log`**（我们自己的、或某个被 import 进来的模块的）都会直接落进那条信道，把它变成非法输出。

## 改法：不猜是哪一处打印的

「找出那句 `console.log` 删掉」是治标——下一个往这条路径加日志的人会再坏一次。改成让**契约与打印点解耦**：进 hook 子命令前把 `console.log` 改道到 stderr，只留 `emitHookLine` 一条显式通道写 stdout。

`party mcp` 早就为同一个原因做过这件事（#596：stdio 是 JSON-RPC 信道），这里照抄同一形态。

覆盖 `codex-stop` / `codex-report` / `report` / `stop-guard` 四条；`stop-guard` 的 block 决策行改走 `emitHookLine`。闸退出（**含抛异常**）必须恢复 `console.log`。

## 验证

- 真实调用三条路径（无身份的 codex 会话、未武装的 stop-guard、report）：**stdout 均为零字节，exit 0**。
- 4 条用例：闸内 `console.log` 改道 stderr 且 stdout 零字节 / 决策行仍写真 stdout 且只此一条 / 抛异常后仍恢复 / 闸外 `emitHookLine` 退回 `console.log` 不吞输出。
- **变异自检**：① 不改道、② 退出后不恢复、③ 决策行也走被改道的 `console.log`（决策丢进 stderr）—— 三条各让用例变红。
- `cli` 全量 2835 中 1 条 codex app-server 用例在 load ~58 下抖动，单跑该文件 44 例全过。

https://claude.ai/code/session_01Az8CnUpayZzqpi1sh32Ssi