### PR TITLE
feat(cli): party claude 跑之前先把自己升上去

### DIFF
--- a/cli/src/auto-upgrade.ts
+++ b/cli/src/auto-upgrade.ts
@@ -41,10 +41,18 @@ export type AutoUpgradeOutcome =
   | { kind: "failed" }            // 升级动过手但没成功——不挡本次命令
   | { kind: "upgraded"; from: string; to: string; reexecCode: number | null };
 
-/** `--no-auto-upgrade` 从 argv 里摘掉（它不该流进下游命令的参数校验）。 */
+/**
+ * `--no-auto-upgrade` 从 argv 里摘掉（它不该流进下游命令的参数校验）。
+ *
+ * 只认 `--` **之前**的：`party claude dev -- --no-auto-upgrade` 里那个是给 claude 的参数，
+ * 既不该被当成我们的开关、更不该被摘掉（CodeRabbit on #1036）。终止符本身与其后的一切原样保留。
+ */
 export function stripNoAutoUpgradeFlag(argv: readonly string[]): { argv: string[]; disabled: boolean } {
-  const disabled = argv.includes(NO_AUTO_UPGRADE_FLAG);
-  return { argv: argv.filter((a) => a !== NO_AUTO_UPGRADE_FLAG), disabled };
+  const terminator = argv.indexOf("--");
+  const own = terminator === -1 ? argv : argv.slice(0, terminator);
+  const rest = terminator === -1 ? [] : argv.slice(terminator);
+  const disabled = own.includes(NO_AUTO_UPGRADE_FLAG);
+  return { argv: [...own.filter((a) => a !== NO_AUTO_UPGRADE_FLAG), ...rest], disabled };
 }
 
 export function autoUpgradeDisabled(env: NodeJS.ProcessEnv, flagDisabled: boolean): boolean {

--- a/cli/src/auto-upgrade.ts
+++ b/cli/src/auto-upgrade.ts
@@ -1,0 +1,109 @@
+// 交互式入口的自动升级（issue #1030）。
+//
+// owner：「执行命令时候自动升级」。此前 CLI 发现有新版只打一句提示，等人自己去跑 `party upgrade`
+// ——于是真机上反复出现「照着 web 引导跑命令 → 撞上一个早就修好的 bug → 修法是先升级」。
+// #1014 已经给**插件**做了自愈（party claude 撞到插件落后就自己更新再启动），CLI 自身却没有。
+//
+// 三条硬约束（issue 里写死的）：
+//   1. **绝不进热路径**。`party hook report` 每个模型工具边界都会跑，#602 的预算是 50ms 且明令
+//      不等网络；#1025 那笔「每次启动恒烧 ~130ms CPU」的账还没还完。所以这个模块只被交互式命令
+//      显式调用，hook / mcp / claude-channel 一个都不接——它们的入口里根本没有这次调用。
+//   2. **必须能关**，且每次动手都要在终端说清楚做了什么（照抄 #1014 插件自愈的形态）。
+//   3. **升级失败不挡本次命令**——降级成一句提示继续跑。
+//
+// 版本探测复用既有的 TTL 缓存（默认 6h 一次），不是每条命令都打网络。
+import { RUNNING_VERSION, compareVersions } from "./upgrade";
+import { shouldProbeUpgrade } from "./upgrade-hint-cache";
+
+export const NO_AUTO_UPGRADE_FLAG = "--no-auto-upgrade";
+export const NO_AUTO_UPGRADE_ENV = "AGENTPARTY_NO_AUTO_UPGRADE";
+
+export interface AutoUpgradeDeps {
+  /** 服务端认为的最新 CLI 版本；读不到返回 null（当作「没结论」，不动手）。 */
+  latestVersion: () => Promise<string | null>;
+  /** 真正执行升级；返回 0 表示成功。 */
+  upgrade: () => Promise<number>;
+  /** 升级后用新二进制重跑本次命令；返回它的退出码，null 表示没能重跑。 */
+  reexec: () => number | null;
+  now: () => number;
+  cwd: () => string;
+  log: (line: string) => void;
+  runningVersion?: string;
+  /** 探测节流：缺省走磁盘 TTL 缓存。 */
+  shouldProbe?: (now: number, cwd: string) => boolean;
+}
+
+export type AutoUpgradeOutcome =
+  | { kind: "disabled" }          // 显式关掉
+  | { kind: "throttled" }         // 还在 TTL 窗口内，这次不探
+  | { kind: "current" }           // 已是最新
+  | { kind: "unknown" }           // 探不到版本（网络/服务端），当作没结论
+  | { kind: "failed" }            // 升级动过手但没成功——不挡本次命令
+  | { kind: "upgraded"; from: string; to: string; reexecCode: number | null };
+
+/** `--no-auto-upgrade` 从 argv 里摘掉（它不该流进下游命令的参数校验）。 */
+export function stripNoAutoUpgradeFlag(argv: readonly string[]): { argv: string[]; disabled: boolean } {
+  const disabled = argv.includes(NO_AUTO_UPGRADE_FLAG);
+  return { argv: argv.filter((a) => a !== NO_AUTO_UPGRADE_FLAG), disabled };
+}
+
+export function autoUpgradeDisabled(env: NodeJS.ProcessEnv, flagDisabled: boolean): boolean {
+  return flagDisabled || env[NO_AUTO_UPGRADE_ENV] === "1";
+}
+
+/**
+ * 有新版就先升级、再用新二进制重跑本次命令。
+ *
+ * 任何一步不确定都**什么都不做**：探不到版本、比不出大小、升级失败——一律让本次命令照常执行。
+ * 这个模块唯一有权做的破坏性动作是「替换二进制并重跑」，只在拿到明确的「服务端版本 > 运行版本」时才做。
+ */
+export async function maybeAutoUpgrade(
+  deps: AutoUpgradeDeps,
+  env: NodeJS.ProcessEnv,
+  flagDisabled: boolean,
+): Promise<AutoUpgradeOutcome> {
+  if (autoUpgradeDisabled(env, flagDisabled)) return { kind: "disabled" };
+  const now = deps.now();
+  const probe = deps.shouldProbe ?? ((at: number, cwd: string) => shouldProbeUpgrade("auto-upgrade", cwd, at));
+  if (!probe(now, deps.cwd())) return { kind: "throttled" };
+
+  let latest: string | null;
+  try {
+    latest = await deps.latestVersion();
+  } catch {
+    latest = null;
+  }
+  if (latest === null || latest === "") return { kind: "unknown" };
+
+  const running = deps.runningVersion ?? RUNNING_VERSION;
+  let newer: boolean;
+  try {
+    newer = compareVersions(latest, running) > 0;
+  } catch {
+    return { kind: "unknown" };
+  }
+  if (!newer) return { kind: "current" };
+
+  deps.log(
+    `party ${running} 落后于已发布的 ${latest}，正在自动升级（不想让它自己升：加 ${NO_AUTO_UPGRADE_FLAG}` +
+      ` 或设 ${NO_AUTO_UPGRADE_ENV}=1）……`,
+  );
+  let code: number;
+  try {
+    code = await deps.upgrade();
+  } catch {
+    code = 1;
+  }
+  if (code !== 0) {
+    // 升级失败绝不挡住本次命令：说清楚，然后用当前版本继续。
+    deps.log(`自动升级没成功（exit ${code}），本次继续用 ${running} 跑；手动升级：party upgrade`);
+    return { kind: "failed" };
+  }
+  const reexecCode = deps.reexec();
+  deps.log(
+    reexecCode === null
+      ? `已升级到 ${latest}；本次命令仍在 ${running} 的进程里跑完，下次起就是新版`
+      : `已升级到 ${latest}，正在用新版本重跑本次命令……`,
+  );
+  return { kind: "upgraded", from: running, to: latest, reexecCode };
+}

--- a/cli/src/commands/claude-launch.ts
+++ b/cli/src/commands/claude-launch.ts
@@ -10,6 +10,7 @@ import {
   writeClaudeDefaultArgs,
 } from "../claude-default-args";
 import { agentpartyHome, readConfig, refreshConfigInPlace } from "../config";
+import { maybeAutoUpgrade, stripNoAutoUpgradeFlag, type AutoUpgradeOutcome } from "../auto-upgrade";
 import { stripTerminalControls } from "../format";
 import { fetchMe } from "../rest";
 import { normalizeWakeLang } from "../wake-note-i18n";
@@ -19,7 +20,7 @@ import {
   syncClaudePluginToCli,
   type ClaudePluginSyncResult,
 } from "../claude-plugin-sync";
-import { RUNNING_VERSION, compareVersions } from "../upgrade";
+import { RUNNING_VERSION, compareVersions, serverVersionUpgradeNotice } from "../upgrade";
 import { isSlug } from "../validation";
 import {
   claudePluginDoctorFixLines,
@@ -175,6 +176,8 @@ export interface ClaudeLaunchDependencies {
   preflight(channel: string | undefined): Promise<ClaudeLaunchPreflight>;
   /** #1029：AGENTPARTY_TOKEN 有值时先重绑身份；缺省走 `party init`。 */
   rebindToken?(channel: string | undefined): Promise<number>;
+  /** #1030：自动升级；缺省走真实探测+升级+re-exec。测试注入假的，绝不碰网络。 */
+  autoUpgrade?(env: NodeJS.ProcessEnv, flagDisabled: boolean, argv: readonly string[]): Promise<AutoUpgradeOutcome>;
   /** #1031：重绑前用来判「凭据能不能发往这个地址」的 server；缺省读本地 config。 */
   configServer?(): string | null;
   /** #1031：先验后写——用这个 token 问一次 /api/me；缺省真打网络。 */
@@ -357,6 +360,40 @@ export function safeTokenTarget(server: string): boolean {
   }
 }
 
+/** 默认自动升级：探服务端最新版 → `party upgrade` → 用新二进制重跑本次命令。 */
+async function defaultAutoUpgrade(
+  env: NodeJS.ProcessEnv,
+  flagDisabled: boolean,
+  argv: readonly string[],
+): Promise<AutoUpgradeOutcome> {
+  return maybeAutoUpgrade(
+    {
+      latestVersion: async () => {
+        // 判据复用既有的 serverVersionUpgradeNotice（它已经处理了 prerelease 不算已发布等边界），
+        // 不在这里再写一份版本比较。
+        const { resolveAuthDetailed } = await import("../oidc-cli");
+        const auth = await resolveAuthDetailed();
+        if (auth.server === null) return null;
+        const { fetchServerVersion } = await import("../rest");
+        const info = await fetchServerVersion(auth.server);
+        const notice = serverVersionUpgradeNotice(info.version);
+        return notice === null ? null : notice.available_version;
+      },
+      upgrade: async () => (await import("./upgrade")).run([]),
+      reexec: () => {
+        // 升级已经把新二进制原子替换到同一路径，用它重跑同一条命令。
+        const result = spawnSync(process.execPath, ["claude", ...argv], { stdio: "inherit" });
+        return result.error === undefined ? (result.status ?? 0) : null;
+      },
+      now: () => Date.now(),
+      cwd: () => process.cwd(),
+      log: (line) => console.log(line),
+    },
+    env,
+    flagDisabled,
+  );
+}
+
 export async function run(
   argv: string[],
   deps: ClaudeLaunchDependencies = defaultDependencies,
@@ -367,6 +404,14 @@ export async function run(
   }
   const env = deps.env ?? process.env;
   const home = deps.home ?? agentpartyHome(env);
+  // #1030：有新版就先把自己升上去，再跑本次命令。只在这类交互式入口做——
+  // hook / mcp / claude-channel 的入口里没有这次调用，它们一次网络都不打（#602 / #1025）。
+  {
+    const stripped = stripNoAutoUpgradeFlag(argv);
+    if (stripped.argv.length !== argv.length) argv = stripped.argv;
+    const outcome = await (deps.autoUpgrade ?? defaultAutoUpgrade)(env, stripped.disabled, argv);
+    if (outcome.kind === "upgraded" && outcome.reexecCode !== null) return outcome.reexecCode;
+  }
   const separator = argv.indexOf("--");
   const rawArgsBeforeSeparator = separator === -1 ? argv : argv.slice(0, separator);
   // #1013：`--no-auto-plugin-update` 先摘掉（它只关自愈，不进 claude 的参数、也不参与位置参数校验）。

--- a/cli/src/oidc-cli.ts
+++ b/cli/src/oidc-cli.ts
@@ -418,7 +418,10 @@ export async function resolveAuthDetailed(): Promise<ResolvedAuthDetailed> {
   // 治不了就明确报出来，别让它流进 fetch 变成不可诊断的 "fetch() URL is invalid"
   const server = rawServer ? healServerUrl(rawServer) : undefined;
   if (rawServer && !server) {
-    console.error(`config server url invalid: "${rawServer}" — expected like https://agentparty.example.com`);
+    // server 来自 config **文件**，不是我们写的常量：ANSI / 控制字符能伪造终端输出（#1036 review）。
+    console.error(
+      `config server url invalid: "${stripTerminalControls(String(rawServer))}" — expected like https://agentparty.example.com`,
+    );
   }
   if (!server) {
     return { server: null, token: null, auth_source: "none", config: source, account: accountInfo(sess) };

--- a/cli/test/auto-upgrade.test.ts
+++ b/cli/test/auto-upgrade.test.ts
@@ -1,0 +1,117 @@
+// #1030：owner「执行命令时候自动升级」。此前 CLI 发现有新版只打提示，等人自己去跑 party upgrade
+// ——于是真机上反复出现「照着引导跑命令 → 撞上早就修好的 bug → 修法是先升级」。
+//
+// 这里钉住三条硬约束：能关、失败不挡本次命令、任何「没结论」都不动手。
+// 「热路径不打网络」由另一条用例从入口侧证明（hook/mcp 的 run 里根本没有这次调用）。
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  NO_AUTO_UPGRADE_ENV,
+  NO_AUTO_UPGRADE_FLAG,
+  autoUpgradeDisabled,
+  maybeAutoUpgrade,
+  stripNoAutoUpgradeFlag,
+  type AutoUpgradeDeps,
+} from "../src/auto-upgrade";
+
+function deps(over: Partial<AutoUpgradeDeps> = {}): AutoUpgradeDeps & { logs: string[]; calls: string[] } {
+  const logs: string[] = [];
+  const calls: string[] = [];
+  return {
+    logs,
+    calls,
+    latestVersion: async () => {
+      calls.push("probe");
+      return "9.9.9";
+    },
+    upgrade: async () => {
+      calls.push("upgrade");
+      return 0;
+    },
+    reexec: () => {
+      calls.push("reexec");
+      return 0;
+    },
+    now: () => 1_800_000_000_000,
+    cwd: () => "/tmp/x",
+    log: (line) => void logs.push(line),
+    runningVersion: "0.1.0",
+    shouldProbe: () => true,
+    ...over,
+  };
+}
+
+describe("交互式入口的自动升级（#1030）", () => {
+  test("有新版 ⇒ 升级并用新版本重跑本次命令", async () => {
+    const d = deps();
+    const out = await maybeAutoUpgrade(d, {}, false);
+    expect(out).toMatchObject({ kind: "upgraded", from: "0.1.0", to: "9.9.9", reexecCode: 0 });
+    expect(d.calls).toEqual(["probe", "upgrade", "reexec"]);
+    expect(d.logs.join("\n")).toContain("正在自动升级");
+  });
+
+  test("已是最新 ⇒ 一步不动", async () => {
+    const d = deps({ latestVersion: async () => "0.1.0" });
+    expect(await maybeAutoUpgrade(d, {}, false)).toEqual({ kind: "current" });
+    expect(d.calls).not.toContain("upgrade");
+    expect(d.calls).not.toContain("reexec");
+  });
+
+  test("--no-auto-upgrade / 环境变量 ⇒ 连探测都不做", async () => {
+    const byFlag = deps();
+    expect(await maybeAutoUpgrade(byFlag, {}, true)).toEqual({ kind: "disabled" });
+    expect(byFlag.calls).toEqual([]);
+    const byEnv = deps();
+    expect(await maybeAutoUpgrade(byEnv, { [NO_AUTO_UPGRADE_ENV]: "1" }, false)).toEqual({ kind: "disabled" });
+    expect(byEnv.calls).toEqual([]);
+    expect(autoUpgradeDisabled({ [NO_AUTO_UPGRADE_ENV]: "0" }, false)).toBe(false);
+  });
+
+  test("还在 TTL 窗口内 ⇒ 不打网络（每条命令都探会把延迟压回热路径）", async () => {
+    const d = deps({ shouldProbe: () => false });
+    expect(await maybeAutoUpgrade(d, {}, false)).toEqual({ kind: "throttled" });
+    expect(d.calls).toEqual([]);
+  });
+
+  test("探不到版本 / 探测抛异常 ⇒ 当作没结论，绝不动手", async () => {
+    for (const latest of [async () => null, async () => "", async () => { throw new Error("net"); }]) {
+      const d = deps({ latestVersion: latest as AutoUpgradeDeps["latestVersion"] });
+      expect(await maybeAutoUpgrade(d, {}, false)).toEqual({ kind: "unknown" });
+      expect(d.calls).not.toContain("upgrade");
+      expect(d.calls).not.toContain("reexec");
+    }
+  });
+
+  test("升级失败 ⇒ 说清楚并继续用当前版本跑，绝不挡住本次命令", async () => {
+    for (const upgrade of [async () => 1, async () => { throw new Error("boom"); }]) {
+      const d = deps({ upgrade: upgrade as AutoUpgradeDeps["upgrade"] });
+      expect(await maybeAutoUpgrade(d, {}, false)).toEqual({ kind: "failed" });
+      expect(d.calls).not.toContain("reexec");
+      expect(d.logs.join("\n")).toContain("自动升级没成功");
+    }
+  });
+
+  test("重跑不了 ⇒ 本次仍用旧进程跑完，并说明下次生效", async () => {
+    const d = deps({ reexec: () => null });
+    const out = await maybeAutoUpgrade(d, {}, false);
+    expect(out).toMatchObject({ kind: "upgraded", reexecCode: null });
+    expect(d.logs.join("\n")).toContain("下次起就是新版");
+  });
+
+  test("--no-auto-upgrade 从 argv 里摘干净（不流进下游参数校验）", () => {
+    expect(stripNoAutoUpgradeFlag(["dev", NO_AUTO_UPGRADE_FLAG])).toEqual({ argv: ["dev"], disabled: true });
+    expect(stripNoAutoUpgradeFlag(["dev"])).toEqual({ argv: ["dev"], disabled: false });
+  });
+
+  test("热路径不接这套：hook / mcp / claude-channel 的源码里没有自动升级的调用", () => {
+    // #602 的 50ms 预算 + 明令不等网络；#1025 那笔每次启动 ~130ms 的账还没还完。
+    // 这条断言直接读源码——比任何 mock 都难糊弄。
+    const root = join(import.meta.dir, "..", "src", "commands");
+    for (const file of ["hook.ts", "mcp.ts", "claude-channel.ts"]) {
+      const source = readFileSync(join(root, file), "utf8");
+      expect(source).not.toContain("maybeAutoUpgrade");
+      expect(source).not.toContain("auto-upgrade");
+    }
+  });
+});

--- a/cli/test/auto-upgrade.test.ts
+++ b/cli/test/auto-upgrade.test.ts
@@ -115,3 +115,19 @@ describe("交互式入口的自动升级（#1030）", () => {
     }
   });
 });
+
+// CodeRabbit on #1036：`party claude dev -- --no-auto-upgrade` 里那个是给 claude 的参数，
+// 既不该被当成我们的开关，也不该被摘掉。
+test("`--` 之后的同名参数原样保留，也不算开关", () => {
+  expect(stripNoAutoUpgradeFlag(["dev", "--", NO_AUTO_UPGRADE_FLAG])).toEqual({
+    argv: ["dev", "--", NO_AUTO_UPGRADE_FLAG],
+    disabled: false,
+  });
+  // `--` 之前的才算我们的
+  expect(stripNoAutoUpgradeFlag(["dev", NO_AUTO_UPGRADE_FLAG, "--", "--model", "sonnet"])).toEqual({
+    argv: ["dev", "--", "--model", "sonnet"],
+    disabled: true,
+  });
+  // 终止符本身必须保留：摘掉它会让后面的参数被当成我们的位置参数
+  expect(stripNoAutoUpgradeFlag(["dev", "--"])).toEqual({ argv: ["dev", "--"], disabled: false });
+});

--- a/cli/test/claude-launch.test.ts
+++ b/cli/test/claude-launch.test.ts
@@ -447,3 +447,53 @@ test("明文地址报错时清洗 server 字符串（它来自 config 文件，�
   expect(joined).toContain("拒绝把 AGENTPARTY_TOKEN 发往明文地址");
   expect(joined).not.toContain(String.fromCharCode(27));
 });
+
+// #1030 接线：party claude 必须真的调用自动升级，而且 --no-auto-upgrade 能一路传到它。
+describe("party claude 接上自动升级（#1030）", () => {
+  function harness(over: Record<string, unknown> = {}) {
+    const calls: Array<{ args: string[]; env: NodeJS.ProcessEnv }> = [];
+    const seen: Array<{ flagDisabled: boolean; argv: readonly string[] }> = [];
+    return {
+      calls,
+      seen,
+      deps: {
+        preflight: async () => ({ blockers: ["listener_not_observed"], listener: "not_observed" }),
+        launch(args: string[], env: NodeJS.ProcessEnv) {
+          calls.push({ args, env });
+          return { status: 0 };
+        },
+        home: mkdtempSync(join(tmpdir(), "agentparty-autoupgrade-")),
+        env: {} as NodeJS.ProcessEnv,
+        autoUpgrade: async (_env: NodeJS.ProcessEnv, flagDisabled: boolean, argv: readonly string[]) => {
+          seen.push({ flagDisabled, argv });
+          return { kind: "current" } as const;
+        },
+        ...over,
+      } as unknown as ClaudeLaunchDependencies,
+    };
+  }
+
+  test("启动前先问一次自动升级", async () => {
+    const h = harness();
+    expect(await run(["dev"], h.deps)).toBe(0);
+    expect(h.seen).toHaveLength(1);
+    expect(h.seen[0]!.flagDisabled).toBe(false);
+    expect(h.calls).toHaveLength(1);
+  });
+
+  test("--no-auto-upgrade 传下去，且不流进 claude 的参数", async () => {
+    const h = harness();
+    expect(await run(["dev", "--no-auto-upgrade"], h.deps)).toBe(0);
+    expect(h.seen[0]!.flagDisabled).toBe(true);
+    expect(h.seen[0]!.argv).toEqual(["dev"]);
+    expect(h.calls[0]!.args.join(" ")).not.toContain("--no-auto-upgrade");
+  });
+
+  test("真升级并重跑了 ⇒ 本进程不再启动 claude，直接带出重跑的退出码", async () => {
+    const h = harness({
+      autoUpgrade: async () => ({ kind: "upgraded", from: "0.1.0", to: "9.9.9", reexecCode: 5 }),
+    });
+    expect(await run(["dev"], h.deps)).toBe(5);
+    expect(h.calls).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Closes #1030 —— owner 两条反馈里的第 1 条：「执行命令时候自动升级」。

## 为什么

此前 CLI 发现有新版只**打一句提示**，等人自己去跑 `party upgrade`。于是真机上反复出现同一条路径：照着 web 引导跑命令 → 撞上一个早就修好的 bug → 修法是先升级。#1014 已经给**插件**做了自愈（`party claude` 撞到插件落后就自己更新再启动），CLI 自身却没有。

## 三条硬约束（issue 里写死的，逐条落实）

1. **绝不进热路径。** 这个模块只被交互式入口显式调用——`hook` / `mcp` / `claude-channel` 的 `run` 里**根本没有这次调用**。有一条用例直接读那三份源码断言不含 `maybeAutoUpgrade`，比任何 mock 都难糊弄（`hook report` 每个工具边界都跑，#602 预算 50ms 且明令不等网络；#1025 那笔每次启动 ~130ms 的账还没还完）。
2. **必须能关**：`--no-auto-upgrade` 或 `AGENTPARTY_NO_AUTO_UPGRADE=1`，关掉后**连探测都不做**。每次动手都在终端说清楚做了什么（照抄 #1014 插件自愈的形态）。
3. **升级失败不挡本次命令**：说清楚，然后用当前版本继续跑。

另：版本探测复用既有的 TTL 缓存（默认 6h 一次），不是每条命令都打网络；版本比较复用 `serverVersionUpgradeNotice`（它已经处理了「prerelease 不算已发布」这类边界），不在这里再写一份。

## 「不确定就什么都不做」

这个模块唯一有权做的破坏性动作是「替换二进制并重跑」。所以探不到版本、探测抛异常、比不出大小——**一律当没结论**，本次命令照常执行。

## 测试

12 条用例。**变异自检 6 条**：去掉 disabled 闸 / 去掉 TTL 闸 / 去掉「探不到就不动手」/ 升级失败也继续重跑 / 重跑后仍继续启动 claude（会起两个会话）/ `--no-auto-upgrade` 不从 argv 摘掉 —— 每条各让用例变红。

`bun test cli/test` **2847 pass / 0 fail**。

https://claude.ai/code/session_01Az8CnUpayZzqpi1sh32Ssi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - `party claude` 启动前会自动检查并升级到最新版本，并尝试使用新版本重新执行当前命令。
  - 支持通过 `--no-auto-upgrade` 参数或环境变量关闭自动升级。
  - 使用缓存减少重复版本检查，升级异常不会阻断原命令执行。

- **用户体验**
  - 自动升级、版本检查和失败情况会提供终端提示。
  - 禁用升级参数不会继续传递给 Claude。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->