### PR TITLE
fix(cli): 自动升级不再把 AGENTPARTY_TOKEN 漏给 claude 子进程

### DIFF
--- a/cli/src/claude-plugin-sync.ts
+++ b/cli/src/claude-plugin-sync.ts
@@ -24,8 +24,21 @@ export type ClaudePluginProbe =
  * 读本机已装的 agentparty 插件版本。走的是 doctor 同一个解析器（parseClaudePluginList），
  * 判据不另写一份。
  */
+/**
+ * spawn `claude` 时一律摘掉本机凭据（纵深防御，codex stop-time review on #1036）。
+ *
+ * 调用方（`party claude`）已经在最早时机把 AGENTPARTY_TOKEN 摘出环境，但 `claude` 是我们
+ * 交出去的、还会自己再 spawn 一堆东西的外部进程——凭据没有任何理由跟着它走。这一层保证
+ * 「上游哪天忘了摘，这里也不会漏」。
+ */
+export function claudeSpawnEnv(base: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+  const env = { ...base };
+  delete env.AGENTPARTY_TOKEN;
+  return env;
+}
+
 export function probeInstalledClaudePlugin(spawn: PluginSpawn): ClaudePluginProbe {
-  const r = spawn("claude", ["plugin", "list", "--json"], { encoding: "utf8", timeout: 30_000 });
+  const r = spawn("claude", ["plugin", "list", "--json"], { encoding: "utf8", timeout: 30_000, env: claudeSpawnEnv() });
   if (r.error !== undefined) return { available: false };
   if (r.status !== 0 || typeof r.stdout !== "string") return { available: true, version: undefined };
   const list = parseClaudePluginList(r.stdout);
@@ -41,7 +54,7 @@ export function installedClaudePluginVersion(spawn: PluginSpawn): string | null 
 
 /** 跑一次 `claude plugin update agentparty@agentparty`。true＝exit 0。 */
 export function runClaudePluginUpdate(spawn: PluginSpawn): boolean {
-  const r = spawn("claude", ["plugin", "update", CLAUDE_PLUGIN], { encoding: "utf8", timeout: 60_000 });
+  const r = spawn("claude", ["plugin", "update", CLAUDE_PLUGIN], { encoding: "utf8", timeout: 60_000, env: claudeSpawnEnv() });
   return r.error === undefined && r.status === 0;
 }
 

--- a/cli/src/commands/claude-launch.ts
+++ b/cli/src/commands/claude-launch.ts
@@ -365,6 +365,7 @@ async function defaultAutoUpgrade(
   env: NodeJS.ProcessEnv,
   flagDisabled: boolean,
   argv: readonly string[],
+  envToken?: string,
 ): Promise<AutoUpgradeOutcome> {
   return maybeAutoUpgrade(
     {
@@ -382,7 +383,12 @@ async function defaultAutoUpgrade(
       upgrade: async () => (await import("./upgrade")).run([]),
       reexec: () => {
         // 升级已经把新二进制原子替换到同一路径，用它重跑同一条命令。
-        const result = spawnSync(process.execPath, ["claude", ...argv], { stdio: "inherit" });
+        // 重跑的新进程自己还要用这个 token 去重绑，所以**只**在这一个子进程里交回去
+        // ——升级过程中那些 `claude plugin ...` 子进程一个都拿不到。
+        const result = spawnSync(process.execPath, ["claude", ...argv], {
+          stdio: "inherit",
+          env: envToken === undefined ? process.env : { ...process.env, AGENTPARTY_TOKEN: envToken },
+        });
         return result.error === undefined ? (result.status ?? 0) : null;
       },
       now: () => Date.now(),
@@ -404,12 +410,27 @@ export async function run(
   }
   const env = deps.env ?? process.env;
   const home = deps.home ?? agentpartyHome(env);
+  // 凭据在**任何 spawn 之前**就离开环境（codex stop-time review on #1036）。
+  //
+  // 自动升级排在重绑之前，而 `party upgrade` 会 spawn `claude plugin update` —— 那一刻
+  // AGENTPARTY_TOKEN 还在 process.env 里，直接被 Claude 插件子进程继承。同一条路径上
+  // 还有 join / doctor / mcp-prune 好几处 spawn("claude")，逐个去补一定会漏下一个。
+  // 所以在这里一次性摘走：token 只活在这个函数的局部变量里，需要谁再精确交给谁。
+  const envToken = env.AGENTPARTY_TOKEN;
+  if (envToken !== undefined && envToken !== "") {
+    delete process.env.AGENTPARTY_TOKEN;
+    delete (env as Record<string, string | undefined>).AGENTPARTY_TOKEN;
+  }
   // #1030：有新版就先把自己升上去，再跑本次命令。只在这类交互式入口做——
   // hook / mcp / claude-channel 的入口里没有这次调用，它们一次网络都不打（#602 / #1025）。
   {
     const stripped = stripNoAutoUpgradeFlag(argv);
     if (stripped.argv.length !== argv.length) argv = stripped.argv;
-    const outcome = await (deps.autoUpgrade ?? defaultAutoUpgrade)(env, stripped.disabled, argv);
+    const outcome = await (deps.autoUpgrade ?? ((e, d, a) => defaultAutoUpgrade(e, d, a, envToken)))(
+      env,
+      stripped.disabled,
+      argv,
+    );
     if (outcome.kind === "upgraded" && outcome.reexecCode !== null) return outcome.reexecCode;
   }
   const separator = argv.indexOf("--");
@@ -470,7 +491,6 @@ export async function run(
   // （owner 实测：照着引导跑，撞的正是 identity_unavailable / invalid or revoked token）。
   //
   // token 只走环境变量、绝不进 argv：`ps -axww` 同机任何用户可见，shell history 也留底（#111）。
-  const envToken = env.AGENTPARTY_TOKEN;
   if (envToken !== undefined && envToken !== "") {
     // 明文 http 一律不发凭据（loopback 例外，本地起 worker 调试的常规姿势）。判据与 #1015
     // 的兄弟身份探活同一条：token 一旦上路就收不回来。
@@ -499,7 +519,15 @@ export async function run(
       }
     }
     const rebind = deps.rebindToken ?? defaultRebindToken;
-    const code = await rebind(channel);
+    // `party init` 从 process.env 读 token。只在这一次调用期间放回去，finally 立刻摘走——
+    // 窗口越窄，能顺着环境跑掉的子进程越少。
+    process.env.AGENTPARTY_TOKEN = envToken;
+    let code: number;
+    try {
+      code = await rebind(channel);
+    } finally {
+      delete process.env.AGENTPARTY_TOKEN;
+    }
     if (code !== 0) {
       console.error("AGENTPARTY_TOKEN 重绑失败；单独跑一次看详情：party init --channel <channel>");
       return code;

--- a/cli/test/claude-launch.test.ts
+++ b/cli/test/claude-launch.test.ts
@@ -497,3 +497,69 @@ describe("party claude 接上自动升级（#1030）", () => {
     expect(h.calls).toHaveLength(0);
   });
 });
+
+// codex stop-time review on #1036：自动升级排在重绑之前，而 `party upgrade` 会 spawn
+// `claude plugin update` —— 那一刻 AGENTPARTY_TOKEN 还在 process.env 里，直接被插件子进程继承。
+describe("凭据在任何 spawn 之前就离开环境（#1036 codex review）", () => {
+  test("自动升级跑起来时，process.env 里已经没有 token 了", async () => {
+    let seenDuringUpgrade: string | undefined = "还没跑";
+    const calls: Array<{ args: string[]; env: NodeJS.ProcessEnv }> = [];
+    const deps = {
+      preflight: async () => ({ blockers: ["listener_not_observed"], listener: "not_observed" }),
+      launch(args: string[], env: NodeJS.ProcessEnv) {
+        calls.push({ args, env });
+        return { status: 0 };
+      },
+      home: mkdtempSync(join(tmpdir(), "agentparty-token-scrub-")),
+      env: { AGENTPARTY_TOKEN: "ap_secret" } as NodeJS.ProcessEnv,
+      configServer: () => "https://agentparty.example.com",
+      verifyToken: async () => ({ kind: "agent" }),
+      rebindToken: async () => 0,
+      autoUpgrade: async () => {
+        // 这一刻正是 `party upgrade` 会 spawn `claude plugin update` 的时机
+        seenDuringUpgrade = process.env.AGENTPARTY_TOKEN;
+        return { kind: "current" } as const;
+      },
+    } as unknown as ClaudeLaunchDependencies;
+
+    const before = process.env.AGENTPARTY_TOKEN;
+    process.env.AGENTPARTY_TOKEN = "ap_secret";
+    try {
+      expect(await run(["dev"], deps)).toBe(0);
+    } finally {
+      if (before === undefined) delete process.env.AGENTPARTY_TOKEN;
+      else process.env.AGENTPARTY_TOKEN = before;
+    }
+    expect(seenDuringUpgrade).toBeUndefined();
+    // 子进程 claude 同样拿不到
+    expect(calls[0]!.env.AGENTPARTY_TOKEN).toBeUndefined();
+  });
+
+  test("重绑结束后 token 立刻从环境里摘走（窗口只覆盖那一次调用）", async () => {
+    let seenDuringRebind: string | undefined;
+    const deps = {
+      preflight: async () => ({ blockers: ["listener_not_observed"], listener: "not_observed" }),
+      launch: () => ({ status: 0 }),
+      home: mkdtempSync(join(tmpdir(), "agentparty-token-window-")),
+      env: { AGENTPARTY_TOKEN: "ap_secret" } as NodeJS.ProcessEnv,
+      configServer: () => "https://agentparty.example.com",
+      verifyToken: async () => ({ kind: "agent" }),
+      autoUpgrade: async () => ({ kind: "current" }) as const,
+      rebindToken: async () => {
+        seenDuringRebind = process.env.AGENTPARTY_TOKEN;
+        return 0;
+      },
+    } as unknown as ClaudeLaunchDependencies;
+
+    const before = process.env.AGENTPARTY_TOKEN;
+    process.env.AGENTPARTY_TOKEN = "ap_secret";
+    try {
+      await run(["dev"], deps);
+    } finally {
+      if (before === undefined) delete process.env.AGENTPARTY_TOKEN;
+      else process.env.AGENTPARTY_TOKEN = before;
+    }
+    // init 靠 process.env 读 token，所以重绑期间必须看得见
+    expect(seenDuringRebind).toBe("ap_secret");
+  });
+});

--- a/cli/test/claude-plugin-sync.test.ts
+++ b/cli/test/claude-plugin-sync.test.ts
@@ -1,0 +1,39 @@
+// codex stop-time review on #1036：`claude` 是我们交出去、还会自己再 spawn 一堆东西的外部进程，
+// 本机凭据没有任何理由跟着它走。上游（party claude）已经在最早时机把 AGENTPARTY_TOKEN 摘出环境，
+// 这里是纵深防御：上游哪天忘了摘，这一层也不漏。
+import { describe, expect, test } from "bun:test";
+import {
+  claudeSpawnEnv,
+  probeInstalledClaudePlugin,
+  runClaudePluginUpdate,
+  type PluginSpawn,
+} from "../src/claude-plugin-sync";
+
+describe("spawn claude 时摘掉凭据（纵深防御）", () => {
+  test("claudeSpawnEnv 只删 AGENTPARTY_TOKEN，其余环境原样保留", () => {
+    const env = claudeSpawnEnv({ AGENTPARTY_TOKEN: "ap_secret", PATH: "/usr/bin", HOME: "/h" });
+    expect(env.AGENTPARTY_TOKEN).toBeUndefined();
+    expect(env.PATH).toBe("/usr/bin");
+    expect(env.HOME).toBe("/h");
+  });
+
+  test("plugin list / plugin update 两处 spawn 都拿不到 token", () => {
+    const seen: Array<NodeJS.ProcessEnv | undefined> = [];
+    const spawn = ((_cmd: string, _args: readonly string[], opts: { env?: NodeJS.ProcessEnv }) => {
+      seen.push(opts.env);
+      return { status: 0, stdout: "[]", stderr: "", error: undefined };
+    }) as unknown as PluginSpawn;
+
+    const before = process.env.AGENTPARTY_TOKEN;
+    process.env.AGENTPARTY_TOKEN = "ap_secret";
+    try {
+      probeInstalledClaudePlugin(spawn);
+      runClaudePluginUpdate(spawn);
+    } finally {
+      if (before === undefined) delete process.env.AGENTPARTY_TOKEN;
+      else process.env.AGENTPARTY_TOKEN = before;
+    }
+    expect(seen).toHaveLength(2);
+    for (const env of seen) expect(env?.AGENTPARTY_TOKEN).toBeUndefined();
+  });
+});


### PR DESCRIPTION
codex stop-time review 在 #1036 上抓到的：**自动升级会把重连用的 `AGENTPARTY_TOKEN` 暴露给 Claude 插件子进程。**

## 怎么漏的

#1036 把自动升级排在了 token 重绑**之前**。而 `party upgrade` 会 spawn `claude plugin update` —— 那一刻 `AGENTPARTY_TOKEN` 还在 `process.env` 里，直接被继承。原来的 `delete process.env.AGENTPARTY_TOKEN` 在重绑之后，晚了。

同一条路径上还有 `join` / `doctor` / `mcp-prune` 好几处 `spawn("claude")`——**逐个去补一定会漏下一个**。

## 改法：让凭据在任何 spawn 之前就离开环境

1. `party claude` 进来的**第一件事**就是把 token 从 `process.env` / `deps.env` 摘走，只留在函数的一个局部变量里。此后这个进程 spawn 什么都不会带上它。
2. 需要它的两处**精确交回去**：
   - 重绑：`party init` 从 `process.env` 读，所以只在那一次调用期间放回，`finally` 立刻摘走；
   - 升级后的重跑：新进程自己还要用它重绑，所以**只**在那一个子进程的 env 里给。
3. **纵深防御**：`claude-plugin-sync` 的两处 `spawn("claude")` 自己也摘——上游哪天忘了，这层不漏。

## 测试

- 自动升级跑起来的那一刻 `process.env.AGENTPARTY_TOKEN` 必须已经是 `undefined`（那正是 `claude plugin update` 被 spawn 的时机）；子进程 claude 的 env 里同样没有。
- 重绑期间必须**看得见**（`init` 靠它读），窗口只覆盖那一次调用。
- `claudeSpawnEnv` 只删凭据、其余环境原样；`plugin list` / `plugin update` 两处 spawn 都拿不到。

**变异自检**：① 不在最早时机摘走（＝codex 报的那个泄漏）→ 红；② 重绑时不放回去 → 红；③ 纵深那层不摘 → 2 条红。

`bun test cli/test` **2852 pass / 0 fail**。

## 过程中差点无声丢掉一次改动

做变异自检时我用 `git checkout <file>` 还原，把**尚未提交**的纵深防御那处改动一起抹了（该文件当时全是未提交的新增）。是靠「变异 3 预期该红却是 0 红」才发现的。还原用 `cp` 备份、别用 `git checkout`。

https://claude.ai/code/session_01Az8CnUpayZzqpi1sh32Ssi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **安全性改进**
  * Claude 启动、插件探测和更新过程中不再向子进程传递敏感凭据。
  * 自动升级和初始化重绑仅在必要期间使用凭据，并在操作完成后及时清理。
  * 即使重绑失败，敏感凭据也不会残留在运行环境中。

* **Bug 修复**
  * 修复敏感凭据可能被不必要的 Claude 子进程继承的问题。

* **测试**
  * 增加凭据隔离、清理时机及插件操作安全性的验证。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->