### PR TITLE
fix(cli): 自动升级要把版本读回来再宣布成功，别拿退出码冒充事实

### DIFF
--- a/cli/src/auto-upgrade.ts
+++ b/cli/src/auto-upgrade.ts
@@ -21,8 +21,17 @@ export const NO_AUTO_UPGRADE_ENV = "AGENTPARTY_NO_AUTO_UPGRADE";
 export interface AutoUpgradeDeps {
   /** 服务端认为的最新 CLI 版本；读不到返回 null（当作「没结论」，不动手）。 */
   latestVersion: () => Promise<string | null>;
-  /** 真正执行升级；返回 0 表示成功。 */
+  /** 真正执行升级；返回 0 表示命令本身没报错——**不等于目标版本已装上**。 */
   upgrade: () => Promise<number>;
+  /**
+   * 升级后把盘上二进制的版本**读回来**。
+   *
+   * #1011 已经在插件上吃过这个亏：`claude plugin update` 退出码为 0 不代表版本真的变了。
+   * CLI 这边同样：发布窗口里 GitHub Release 的资产可能还没传完（isReleaseAssetPublishing
+   * 专门为此存在）、"latest" 在中途也可能解析到别的版本。所以「升没升上去」只能由**读回来的
+   * 版本**回答，不能由退出码回答（codex stop-time review）。读不出返回 null。
+   */
+  installedVersion: () => string | null;
   /** 升级后用新二进制重跑本次命令；返回它的退出码，null 表示没能重跑。 */
   reexec: () => number | null;
   now: () => number;
@@ -38,7 +47,7 @@ export type AutoUpgradeOutcome =
   | { kind: "throttled" }         // 还在 TTL 窗口内，这次不探
   | { kind: "current" }           // 已是最新
   | { kind: "unknown" }           // 探不到版本（网络/服务端），当作没结论
-  | { kind: "failed" }            // 升级动过手但没成功——不挡本次命令
+  | { kind: "failed"; installed: string | null } // 动过手但版本没变到目标——不挡本次命令
   | { kind: "upgraded"; from: string; to: string; reexecCode: number | null };
 
 /**
@@ -105,13 +114,25 @@ export async function maybeAutoUpgrade(
   if (code !== 0) {
     // 升级失败绝不挡住本次命令：说清楚，然后用当前版本继续。
     deps.log(`自动升级没成功（exit ${code}），本次继续用 ${running} 跑；手动升级：party upgrade`);
-    return { kind: "failed" };
+    return { kind: "failed", installed: null };
   }
+  // 退出码 0 只说明「命令没报错」。真正装上没装上，只有把盘上的版本**读回来**才知道——
+  // 发布窗口里资产可能还没传完、"latest" 中途也可能解析到别的版本。不读回来就宣布成功，
+  // 就是拿命令的成败冒充事实（#1011 在插件上的同一课）。
+  const installed = deps.installedVersion();
+  if (installed === null || compareVersions(installed, running) <= 0) {
+    deps.log(
+      `自动升级命令跑完了，但盘上仍是 ${installed ?? "读不出版本"}——没升上去（发布窗口里资产可能还没传完）。` +
+        `本次继续用 ${running} 跑；稍后手动重试：party upgrade`,
+    );
+    return { kind: "failed", installed };
+  }
+  // 装上的**可能不是**刚才那个 latest（发布中途 latest 变了）。以读回来的为准报数，别复述期望值。
   const reexecCode = deps.reexec();
   deps.log(
     reexecCode === null
-      ? `已升级到 ${latest}；本次命令仍在 ${running} 的进程里跑完，下次起就是新版`
-      : `已升级到 ${latest}，正在用新版本重跑本次命令……`,
+      ? `已升级到 ${installed}；本次命令仍在 ${running} 的进程里跑完，下次起就是新版`
+      : `已升级到 ${installed}，正在用新版本重跑本次命令……`,
   );
-  return { kind: "upgraded", from: running, to: latest, reexecCode };
+  return { kind: "upgraded", from: running, to: installed, reexecCode };
 }

--- a/cli/src/commands/claude-launch.ts
+++ b/cli/src/commands/claude-launch.ts
@@ -20,7 +20,7 @@ import {
   syncClaudePluginToCli,
   type ClaudePluginSyncResult,
 } from "../claude-plugin-sync";
-import { RUNNING_VERSION, compareVersions, serverVersionUpgradeNotice } from "../upgrade";
+import { RUNNING_VERSION, compareVersions, readInstalledPartyVersion, serverVersionUpgradeNotice } from "../upgrade";
 import { isSlug } from "../validation";
 import {
   claudePluginDoctorFixLines,
@@ -381,6 +381,8 @@ async function defaultAutoUpgrade(
         return notice === null ? null : notice.available_version;
       },
       upgrade: async () => (await import("./upgrade")).run([]),
+      // 读回盘上的版本：升没升上去只能由它回答，不能由退出码回答。
+      installedVersion: () => readInstalledPartyVersion(process.execPath),
       reexec: () => {
         // 升级已经把新二进制原子替换到同一路径，用它重跑同一条命令。
         // 重跑的新进程自己还要用这个 token 去重绑，所以**只**在这一个子进程里交回去

--- a/cli/src/upgrade.ts
+++ b/cli/src/upgrade.ts
@@ -51,7 +51,8 @@ export interface CliUpgradeNotice {
   command: string;
 }
 
-function defaultReadInstalledVersion(execPath: string): string | null {
+/** 读盘上二进制自报的版本；读不出返回 null。导出供自动升级「先读回来再宣布成功」用（#1036 后续）。 */
+export function readInstalledPartyVersion(execPath: string): string | null {
   try {
     const proc = Bun.spawnSync([execPath, "--version"], { stdout: "pipe", stderr: "ignore" });
     if (!proc.success) return null;
@@ -249,7 +250,7 @@ export async function downloadPartyUpgrade(
 export function pendingUpgrade(deps: UpgradeDeps = {}): string | null {
   const running = deps.runningVersion ?? RUNNING_VERSION;
   const execPath = deps.execPath ?? process.execPath;
-  const read = deps.readInstalledVersion ?? defaultReadInstalledVersion;
+  const read = deps.readInstalledVersion ?? readInstalledPartyVersion;
   // 只有 execPath 看起来是 party 二进制（basename 含 party）才比——dev 下 execPath=bun，跳过。
   if (!isPartyBinaryPath(execPath)) return null;
   const installed = read(execPath);

--- a/cli/test/auto-upgrade.test.ts
+++ b/cli/test/auto-upgrade.test.ts
@@ -29,6 +29,7 @@ function deps(over: Partial<AutoUpgradeDeps> = {}): AutoUpgradeDeps & { logs: st
       calls.push("upgrade");
       return 0;
     },
+    installedVersion: () => "9.9.9",
     reexec: () => {
       calls.push("reexec");
       return 0;
@@ -86,7 +87,7 @@ describe("交互式入口的自动升级（#1030）", () => {
   test("升级失败 ⇒ 说清楚并继续用当前版本跑，绝不挡住本次命令", async () => {
     for (const upgrade of [async () => 1, async () => { throw new Error("boom"); }]) {
       const d = deps({ upgrade: upgrade as AutoUpgradeDeps["upgrade"] });
-      expect(await maybeAutoUpgrade(d, {}, false)).toEqual({ kind: "failed" });
+      expect(await maybeAutoUpgrade(d, {}, false)).toEqual({ kind: "failed", installed: null });
       expect(d.calls).not.toContain("reexec");
       expect(d.logs.join("\n")).toContain("自动升级没成功");
     }
@@ -130,4 +131,31 @@ test("`--` 之后的同名参数原样保留，也不算开关", () => {
   });
   // 终止符本身必须保留：摘掉它会让后面的参数被当成我们的位置参数
   expect(stripNoAutoUpgradeFlag(["dev", "--"])).toEqual({ argv: ["dev", "--"], disabled: false });
+});
+
+// codex stop-time review：退出码 0 只说明「命令没报错」。发布窗口里 GitHub Release 的资产可能
+// 还没传完（isReleaseAssetPublishing 专为此存在），"latest" 中途也可能解析到别的版本。
+// 不把盘上的版本读回来就宣布成功，就是拿命令的成败冒充事实（#1011 在插件上的同一课）。
+describe("升没升上去只能由读回来的版本回答", () => {
+  test("命令 exit 0 但盘上版本没变 ⇒ 判失败，不重跑、也不谎报升级", async () => {
+    const d = deps({ installedVersion: () => "0.1.0" });
+    const out = await maybeAutoUpgrade(d, {}, false);
+    expect(out).toEqual({ kind: "failed", installed: "0.1.0" });
+    expect(d.calls).not.toContain("reexec");
+    expect(d.logs.join("\n")).toContain("没升上去");
+  });
+
+  test("读不出盘上版本 ⇒ 同样当失败（读不出不是成功）", async () => {
+    const d = deps({ installedVersion: () => null });
+    expect(await maybeAutoUpgrade(d, {}, false)).toEqual({ kind: "failed", installed: null });
+    expect(d.calls).not.toContain("reexec");
+  });
+
+  test("装上的版本与期望的 latest 不同 ⇒ 按读回来的报数，不复述期望值", async () => {
+    const d = deps({ latestVersion: async () => "9.9.9", installedVersion: () => "9.9.8" });
+    const out = await maybeAutoUpgrade(d, {}, false);
+    expect(out).toMatchObject({ kind: "upgraded", to: "9.9.8" });
+    expect(d.logs.join("\n")).toContain("9.9.8");
+    expect(d.logs.join("\n")).not.toContain("已升级到 9.9.9");
+  });
 });


### PR DESCRIPTION
codex stop-time review：**自动升级会把「命令成功」误判为「目标版本已安装」，在发布窗口造成假升级。**

## 我重犯了 #1011 的错

`party upgrade` 退出码为 0 只说明**命令本身没报错**，不等于目标版本装上了：

- **发布窗口**：GitHub Release 的资产可能还没传完——仓库里 `isReleaseAssetPublishing()` 就是专门为这个 404 存在的；
- `"latest"` 在中途也可能解析到另一个版本。

而我在 #1036 里写的是「exit 0 ⇒ 打印『已升级到 ${latest}』并重跑」。**这正是 #1011 我刚在插件上修过的同一形状**（「装没装上」与「版本对不对」要分开判，且必须把版本**读回来**），转手在 CLI 上又犯一次。

## 改法

升级命令返回后，把盘上二进制的版本**读回来**再决定：

| 读回来的 | 结论 |
|---|---|
| 比运行版新 | 真升上去了 —— **按读回来的那个报数**，不复述期望的 `latest`（发布中途 latest 可能已经变了）|
| 没变 / 读不出 | **判失败** —— 不重跑、不谎报，说清楚「发布窗口里资产可能还没传完」，本次继续用当前版本跑 |

「读不出」也算失败：读不出不是成功。

复用 `upgrade.ts` 里既有的版本读取（把 `defaultReadInstalledVersion` 导出成 `readInstalledPartyVersion`），不另写一份。

## 测试

3 条新用例：exit 0 但版本没变 ⇒ 失败且不重跑；读不出 ⇒ 失败；装上的与期望的 latest 不同 ⇒ 按读回来的报数、日志里不出现期望值。

**变异自检**：① 不读回版本就宣布成功（＝codex 报的那个假升级）→ 2 红；② 报数用期望值而不是读回来的 → 1 红。

`bun test cli/test` **2855 pass / 0 fail**。

https://claude.ai/code/session_01Az8CnUpayZzqpi1sh32Ssi