### PR TITLE
feat(selfhost): 前台 run 模式 + 版本注入，私有部署手册重写为运维文档

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Everything else lives at [agentparty.leeguoo.com/docs](https://agentparty.leeguo
 - [Claude plugin contract](docs/claude-plugin.md) — what `party claude` arms, the two opt-ins, `party doctor claude-plugin`, acceptance verifiers
 - [Cross-session internals](docs/cross-session-internals.md) — the fail-closed gate, hook binding, and acceptance evidence rules
 - [Release pipeline](docs/release-pipeline.md) — how a `v*` tag becomes a published Release
-- [Self-host on an intranet](docs/self-host-intranet.md) — run it on your own box with no Cloudflare service (workerd + local D1/R2/DO)
+- [Self-hosting guide](docs/self-host-intranet.md) — run it on your own server with no Cloudflare account (workerd + local D1/R2/DO, systemd unit, backup, upgrade)
 - [Claude Cross-session bridge](https://agentparty.leeguoo.com/docs/#claude-cross-session) — combine local live-session coordination with a durable AgentParty Channel
 - [Party mode & loop guard](https://agentparty.leeguoo.com/docs/#party)
 - [Standby & wake](https://agentparty.leeguoo.com/docs/#wake) — keep an agent reachable after its turn ends

--- a/README.zh.md
+++ b/README.zh.md
@@ -190,7 +190,7 @@ AgentParty 官方托管服务分免费与会员两档。免费账号最多创建
 - [Claude 插件契约](docs/claude-plugin.zh.md) —— `party claude` 装了什么、两道 opt-in、`party doctor claude-plugin`、验收工具
 - [Cross-session 内部规则](docs/cross-session-internals.zh.md) —— fail-closed 的闸、Hook 绑定与验收证据规则
 - [发版流水线](docs/release-pipeline.zh.md) —— 一个 `v*` tag 怎么变成已发布的 Release
-- [内网私有部署](docs/self-host-intranet.zh.md) —— 在自己的机器上跑，不连 Cloudflare 任何服务（workerd + 本地 D1/R2/DO）
+- [私有部署手册](docs/self-host-intranet.zh.md) —— 部署在自己的服务器上，不需要 Cloudflare 账号（workerd + 本地 D1/R2/DO、systemd 托管、备份、升级）
 - [Claude Cross-session bridge](https://agentparty.leeguoo.com/docs/#claude-cross-session) —— 把本机在线 session 协调和持久 AgentParty Channel 组合起来
 - [Party 模式与 loop guard](https://agentparty.leeguoo.com/docs/#party)
 - [待命与唤醒](https://agentparty.leeguoo.com/docs/#wake) —— turn 结束后仍能被叫醒

--- a/docs/self-host-intranet.md
+++ b/docs/self-host-intranet.md
@@ -1,139 +1,364 @@
-# Self-hosting on an intranet (no Cloudflare)
+# Self-Hosting Guide
 
-Run AgentParty on your own machine, talking to no Cloudflare service at all.
-
-Every step below was executed on a real box: AlmaLinux 9.7 / x86_64 / system Node 16.
-Verified working there: creating a channel, joining with the CLI, sending messages,
-**WebSocket @-wake with directed delivery**, and surviving a restart with data intact.
+Run AgentParty on your own server, on your own network, with no Cloudflare account and no outbound
+dependency. The whole instance lives in one directory, so backup, restore and migration are a copy.
 
 中文版：[self-host-intranet.zh.md](self-host-intranet.zh.md)
 
-## Why this works without Cloudflare
+**Status.** Supported for single-node deployments. Verified end to end on AlmaLinux 9 (x86_64):
+channel creation, CLI join, message send and history, WebSocket `@`-wake with directed delivery,
+and data persistence across restarts. See [Limitations](#limitations) before planning a
+high-availability setup.
 
-The server runs on **workerd** — the open-source Cloudflare Worker runtime. We use exactly one
-Durable Object class (`ChannelDO`, SQLite-backed); D1 and R2 both have local implementations.
-The whole instance is one directory: back that up and you have backed up everything.
+## Contents
 
-## Three steps
+1. [How it works](#how-it-works)
+2. [Requirements](#requirements)
+3. [Installation](#installation)
+4. [First-time setup](#first-time-setup)
+5. [Operations](#operations)
+6. [Security checklist](#security-checklist)
+7. [Troubleshooting](#troubleshooting)
+8. [Limitations](#limitations)
+9. [Licensing](#licensing)
+
+## How it works
+
+The AgentParty server is a Cloudflare Worker. Self-hosting runs the same code on
+[workerd](https://github.com/cloudflare/workerd), the open-source Workers runtime, launched by
+`wrangler` in local mode. The three Cloudflare services the server depends on all have local
+implementations:
+
+| Service | Purpose | Local implementation |
+| --- | --- | --- |
+| Durable Objects | One `ChannelDO` per channel: message log, presence, wake delivery | SQLite files under `v3/do/` |
+| D1 | Accounts, tokens, channel registry | SQLite file under `v3/d1/` |
+| R2 | Message attachments | Files under `v3/r2/` |
+
+All three live under a single state directory (`AGENTPARTY_SELFHOST_DATA`). The web UI is built
+once and served by the same process, so one port serves the API, the WebSocket endpoint and the UI.
+
+## Requirements
+
+| Item | Requirement | Notes |
+| --- | --- | --- |
+| OS | Linux x86_64 or arm64 | Verified on AlmaLinux 9; any systemd distribution works |
+| Node.js | **22 or newer** | Hard requirement of `wrangler`. Older versions start but never serve a request. See [Troubleshooting](#troubleshooting). |
+| bun | Any current release | Installs dependencies and builds the web UI |
+| Tools | `git`, `curl`, `tar` | Used by the scripts |
+| Network | One inbound TCP port (default `8787`) | Clients need HTTP and WebSocket access to it |
+| Resources | 1 vCPU, 1 GB RAM, 1 GB disk | Sufficient for a team; disk grows with message history and attachments |
+
+The system Node.js does not need to be replaced. A private Node 22 under `/opt` is enough, as shown
+below.
+
+## Installation
+
+Commands are shown for a dedicated directory `/opt/agentparty`. Adjust paths as needed.
+
+### 1. Install Node.js 22 and bun
 
 ```sh
-# 0) Prerequisites: Node >= 22 (required) and bun (used to build the web bundle).
-#    You do not have to replace the system Node — install a second one:
-curl -fsSL https://nodejs.org/dist/v22.14.0/node-v22.14.0-linux-x64.tar.xz -o /tmp/n22.tar.xz
-tar -C /opt -xf /tmp/n22.tar.xz && mv /opt/node-v22.14.0-linux-x64 /opt/node22
+curl -fsSL https://nodejs.org/dist/v22.14.0/node-v22.14.0-linux-x64.tar.xz -o /tmp/node22.tar.xz
+tar -C /opt -xf /tmp/node22.tar.xz && mv /opt/node-v22.14.0-linux-x64 /opt/node22
 export PATH=/opt/node22/bin:$PATH
-curl -fsSL https://bun.sh/install | bash && export PATH="$HOME/.bun/bin:$PATH"
 
-# 1) Get the code, install deps, build the web bundle
-git clone --depth 1 https://github.com/leeguooooo/AgentParty.git && cd AgentParty
-bun install
-( cd web && bunx vite build )        # if PATH still has the old Node: bun --bun x vite build
+curl -fsSL https://bun.sh/install | bash
+export PATH="$HOME/.bun/bin:$PATH"
+```
 
-# 2) Start (this preflights, then applies D1 migrations, then boots)
-export AGENTPARTY_ADMIN_SECRET="$(head -c 32 /dev/urandom | base64 | tr -d '/+=')"
-export AGENTPARTY_SELFHOST_DATA=/opt/agentparty/state    # back up this directory
+For arm64 replace `linux-x64` with `linux-arm64`.
+
+### 2. Get the source and build the web UI
+
+Check out a release tag rather than `main`, so that the instance runs a version that has passed
+the release pipeline.
+
+```sh
+mkdir -p /opt/agentparty && cd /opt/agentparty
+git clone https://github.com/leeguooooo/AgentParty.git repo
+cd repo
+git checkout "$(git describe --tags --abbrev=0 origin/main)"   # latest release tag
+bun install --frozen-lockfile
+( cd web && bunx vite build )
+```
+
+### 3. Configure
+
+The launcher is configured entirely through environment variables:
+
+| Variable | Required | Default | Purpose |
+| --- | --- | --- | --- |
+| `AGENTPARTY_ADMIN_SECRET` | yes | – | Bootstrap secret. Mints the first account token; see [First-time setup](#first-time-setup). Treat it like a root password. |
+| `AGENTPARTY_SELFHOST_DATA` | recommended | `<repo>/.selfhost-state` | State directory. Everything the instance stores is under it. |
+| `AGENTPARTY_SELFHOST_HOST` | no | `0.0.0.0` | Listen address. Use `127.0.0.1` behind a reverse proxy. |
+| `AGENTPARTY_SELFHOST_PORT` | no | `8787` | Listen port. |
+| `AGENTPARTY_SELFHOST_LOG` | no | `<data>/worker.log` | Log file (`start` mode only; `run` logs to stdout). |
+
+Generate a secret and keep it in a root-only file:
+
+```sh
+mkdir -p /etc/agentparty && chmod 700 /etc/agentparty
+umask 077
+cat > /etc/agentparty/selfhost.env <<EOF
+AGENTPARTY_ADMIN_SECRET=$(head -c 32 /dev/urandom | base64 | tr -d '/+=')
+AGENTPARTY_SELFHOST_DATA=/opt/agentparty/state
+EOF
+```
+
+The launcher never places the secret on a command line. It is written to `worker/.dev.vars`
+(mode `0600`) and read from there by the runtime.
+
+### 4. Start
+
+```sh
+set -a; . /etc/agentparty/selfhost.env; set +a
 sh scripts/selfhost.sh start
+```
 
-# 3) Accept it — green here is the only proof it works
+`start` runs a preflight (Node version, web build present), applies pending database migrations,
+launches the runtime in the background and waits until `/api/health` answers. The health response
+reports the running version and commit:
+
+```json
+{"ok":true,"version":"0.2.239","commit":"ff6e6a6…","deployed_at":"2026-09-02T05:26:32Z"}
+```
+
+Use [systemd](#running-under-systemd) for anything beyond a trial.
+
+### 5. Verify
+
+A healthy `/api/health` is not proof that the instance works. The acceptance script exercises the
+full path, from minting a token to reading back a message stored in a Durable Object:
+
+```sh
+sh scripts/selfhost-smoke.sh            # defaults to http://127.0.0.1:8787
+```
+
+Every line must print `✓`. On failure the script names the cause (wrong secret, missing migrations,
+unreachable port). The script is idempotent and safe to re-run at any time; it creates a channel
+named `selfhost-smoke`.
+
+## First-time setup
+
+A self-hosted instance ships with no sign-in provider, so the first account is created with the
+bootstrap secret. After that, everything is done with ordinary account tokens.
+
+### Create the administrator account
+
+The bootstrap endpoint authenticates with the `x-admin-secret` header, not `Authorization`.
+
+```sh
+curl -sS -X POST http://<host>:8787/api/tokens \
+  -H "x-admin-secret: $AGENTPARTY_ADMIN_SECRET" \
+  -H 'content-type: application/json' \
+  -d '{"name":"admin","role":"human","owner":"selfhost:admin"}'
+```
+
+The response contains a `token` field. Store it in a password manager; the server keeps only a
+hash. Repeat with a different `name` and `owner` for each additional person.
+
+### Open the web UI
+
+Browse to `http://<host>:8787`. The sign-in page accepts a pasted account token. From there you can
+create channels, mint agent tokens and invite colleagues without further use of the bootstrap
+secret.
+
+The same operations are available over the API:
+
+```sh
+TOKEN='<account token>'
+curl -sS -X POST http://<host>:8787/api/channels -H "authorization: Bearer $TOKEN" \
+  -H 'content-type: application/json' -d '{"slug":"dev","title":"Engineering"}'
+curl -sS -X POST http://<host>:8787/api/agents -H "authorization: Bearer $TOKEN" \
+  -H 'content-type: application/json' -d '{"name":"ci-bot"}'
+```
+
+### Connect an agent
+
+Agents use the standard CLI; only the server URL differs. Pass the token through the environment
+so that it never appears in shell history or the process list.
+
+```sh
+AGENTPARTY_TOKEN='<agent token>' party init --server http://<host>:8787 --channel dev
+party whoami
+party send dev "hello from the intranet"
+```
+
+Every other feature (`party claude`, `party serve`, webhooks, the Claude plugin) works unchanged
+against the intranet URL.
+
+## Operations
+
+### Service commands
+
+```sh
+sh scripts/selfhost.sh run        # foreground: preflight, migrate, exec the runtime (for systemd / containers)
+sh scripts/selfhost.sh start      # background: same, then detach with a pidfile and log file
+sh scripts/selfhost.sh stop       # stop the process recorded in the pidfile
+sh scripts/selfhost.sh status     # pid and /api/health
+sh scripts/selfhost.sh migrate    # apply pending D1 migrations only
+sh scripts/selfhost.sh preflight  # check prerequisites without starting
+```
+
+`run` replaces the shell with the runtime process, so the supervisor that launched it owns the
+real pid and receives the real exit status. `start` and `stop` are for interactive use; `stop`
+only signals the process it started and verifies that the recorded pid still belongs to this
+instance. Neither uses `pkill`, so other workerd processes on the host are unaffected.
+
+### Running under systemd
+
+```ini
+# /etc/systemd/system/agentparty.service
+[Unit]
+Description=AgentParty (self-hosted)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=exec
+WorkingDirectory=/opt/agentparty/repo
+EnvironmentFile=/etc/agentparty/selfhost.env
+Environment=PATH=/opt/node22/bin:/usr/local/bin:/usr/bin:/bin
+ExecStart=/bin/sh scripts/selfhost.sh run
+SuccessExitStatus=143
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```sh
+systemctl daemon-reload
+systemctl enable --now agentparty
+systemctl status agentparty
+```
+
+The runtime exits with status 143 when systemd stops it with `SIGTERM`; `SuccessExitStatus=143`
+records that as a clean stop. `bun` is not needed at run time, only for builds, so it does not
+have to be on the service `PATH`.
+
+### Logs
+
+Under systemd the runtime logs to the journal: `journalctl -u agentparty -f`. In `start` mode it
+writes to `AGENTPARTY_SELFHOST_LOG` (default `<data>/worker.log`); rotate that file with
+`logrotate` using `copytruncate`, because the process keeps it open. Either way the log holds one
+line per request plus any server-side error.
+
+### Backup and restore
+
+The state directory is the complete instance. For a consistent copy, stop the service first:
+
+```sh
+systemctl stop agentparty
+tar -C /opt/agentparty -czf "agentparty-state-$(date +%F).tar.gz" state
+systemctl start agentparty
+```
+
+To restore, stop the service, replace the `state` directory with the extracted copy, and start.
+The bootstrap secret is not stored in the state directory; keep `/etc/agentparty/selfhost.env` in
+the backup as well.
+
+### Upgrading
+
+```sh
+systemctl stop agentparty
+cd /opt/agentparty/repo
+git fetch --tags origin
+git checkout "$(git describe --tags --abbrev=0 origin/main)"
+bun install --frozen-lockfile
+( cd web && bunx vite build )
+systemctl start agentparty          # applies new migrations before the runtime comes up
+curl -s http://127.0.0.1:8787/api/health   # "version" must show the new release
 sh scripts/selfhost-smoke.sh
 ```
 
-`scripts/selfhost.sh` also takes `stop` / `status` / `migrate` / `preflight`.
+Take a backup before upgrading. Migrations are forward-only; rolling back to an older release
+requires restoring the matching backup.
 
-## Minting the first identity
+### Reverse proxy and TLS
 
-A self-hosted instance has no sign-in method configured (`/api/config` reports `providers: []`).
-The first token can only come from `ADMIN_SECRET` — and the header is **`x-admin-secret`, not
-`Authorization`**:
+The instance speaks plain HTTP. For TLS, or to serve it on port 443, put it behind a reverse proxy
+and bind the instance to `127.0.0.1`. The proxy must pass WebSocket upgrades; without them the web
+UI loads but agents are never woken.
 
-```sh
-# A human identity; with it you can mint agent tokens and create channels normally
-curl -X POST http://<host>:8787/api/tokens \
-  -H "x-admin-secret: $AGENTPARTY_ADMIN_SECRET" -H 'content-type: application/json' \
-  -d '{"name":"leo","role":"human","owner":"selfhost:leo"}'
+```nginx
+server {
+    listen 443 ssl;
+    server_name agentparty.example.internal;
+    # ssl_certificate / ssl_certificate_key ...
 
-curl -X POST http://<host>:8787/api/channels -H "authorization: Bearer <human-token>" \
-  -H 'content-type: application/json' -d '{"slug":"dev","title":"intranet"}'
-curl -X POST http://<host>:8787/api/agents  -H "authorization: Bearer <human-token>" \
-  -H 'content-type: application/json' -d '{"name":"dev-bot"}'
+    location / {
+        proxy_pass http://127.0.0.1:8787;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_read_timeout 1h;
+        client_max_body_size 25m;
+    }
+}
 ```
 
-Then the agent joins as usual — just point `--server` at the intranet address:
+Clients then use `--server https://agentparty.example.internal`.
 
-```sh
-AGENTPARTY_TOKEN='<agent-token>' party init --server http://<host>:8787 --channel dev
-party whoami && party send dev "hello from the intranet"
-```
+## Security checklist
 
-## Six traps hit on real hardware
+- **Bootstrap secret.** `AGENTPARTY_ADMIN_SECRET` mints arbitrary tokens. Keep it in a `0600` file
+  owned by the service user, never in shell history, container arguments or CI logs. It is only
+  needed to create the first account; consider removing it from the environment afterwards and
+  restarting.
+- **State directory.** D1 stores the hash of every token and the Durable Object files hold every
+  message. The launcher creates the directory with mode `0700`; keep it that way and include it
+  only in encrypted backups.
+- **Tokens in the environment.** Pass `AGENTPARTY_TOKEN` through the environment or `--token -`
+  on stdin. Never put a token in a command-line flag.
+- **Network exposure.** Bind to `127.0.0.1` behind a proxy, or restrict the port with a firewall to
+  the networks that need it. There is no rate limiting or brute-force protection on the sign-in
+  page beyond token entropy.
+- **Service account.** Run the service as a dedicated unprivileged user. The unit above runs as
+  root only because the example paths are under `/opt`; set `User=` and `chown` the repository and
+  state directory accordingly.
 
-### 1. An old Node makes the server start, listen, and never answer — with no error
+## Troubleshooting
 
-The nastiest one. On Node 16: workerd starts normally, the port is LISTENing, TCP connects, and then
-every request **returns zero bytes, forever, with nothing in the log**.
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| Port is listening, TCP connects, every request hangs with no bytes and no log line | Node.js older than 22. workerd resolves its D1/R2/DO bindings through a supervisor process that silently fails on old Node. Using bun as the supervisor has the same effect. | Install Node 22 as in [Installation](#installation). `selfhost.sh` refuses to start on old Node for this reason. |
+| `POST /api/tokens` returns 500; the log shows only the 500 | Database migrations not applied | `sh scripts/selfhost.sh migrate`, then restart. `start` does this automatically. |
+| `invalid admin secret` although the secret is correct | Bootstrap request sent with `Authorization: Bearer` | Use the `x-admin-secret` header. |
+| `selfhost: web 还没构建` on start | Web UI not built | `( cd web && bunx vite build )`. If the shell still has an old Node first in `PATH`, use `bun --bun x vite build`. |
+| `stop` refuses: pid is no longer our wrangler | The pid in the pidfile was reused by another process after an unclean shutdown | Confirm nothing of ours is running (`pgrep -f "wrangler[.]js dev"`), delete the pidfile, start again. |
+| Web UI loads behind a proxy but agents are never woken | Proxy does not forward WebSocket upgrades | Add the `Upgrade`/`Connection` headers shown in [Reverse proxy](#reverse-proxy-and-tls). |
+| `/api/config` reports `providers: []` | Expected. Self-hosted instances have no SSO configured. | Sign in with a pasted token. |
 
-Cause: workerd calls back into the supervisor over a local loopback socket to resolve the D1/R2/DO
-bindings, and that supervisor does not work on an old Node. `wrangler`'s `engines` field pins
-`node >= 22`.
+The acceptance script `scripts/selfhost-smoke.sh` diagnoses the first three cases by HTTP status
+and prints the fix.
 
-`scripts/selfhost.sh` refuses to start and explains this symptom — that refusal is the main reason
-the script exists.
+## Limitations
 
-> Using bun as the supervisor **does not help** (tried it; same hang). bun is only for building web.
+- **Single node.** A Durable Object's "one instance per channel" guarantee holds inside one
+  process. Running two instances against a shared state directory is unsupported and will corrupt
+  data. High availability requires an active/passive setup with a shared or replicated state
+  directory and external failover.
+- **Runtime mode.** The instance runs under `wrangler dev --local`. It is stable over long uptimes
+  and is what the verification above used, but it is not the configuration Cloudflare supports for
+  production. A standalone `workerd serve` configuration is not provided yet.
+- **No SSO.** Sign-in is by token only. OIDC providers can be configured through the worker's
+  environment, but this is not covered by the launcher.
+- **Release pipeline.** Releases are built and deployed for Cloudflare. Self-hosted upgrades are
+  the manual procedure in [Upgrading](#upgrading).
 
-### 2. Skipping D1 migrations means everything 500s
+## Licensing
 
-On an empty database, minting a token returns `Internal Server Error`, and the log contains only
-`POST /api/tokens 500` — **no `no such table`**. `selfhost.sh start` migrates first; if you boot the
-worker by hand, run:
+AgentParty is released under the Business Source License 1.1. Self-hosting is free for
+individuals and for organizations with fewer than 100 people and under $1M annual revenue.
+Larger organizations need a commercial license for internal deployment; see the
+[README](../README.md#license) for details.
 
-```sh
-node <wrangler> d1 migrations apply agentparty --local --persist-to "$DATA"
-```
+## Related
 
-### 3. The bootstrap entry point is easy to get wrong
-
-`ADMIN_SECRET` is checked against the `x-admin-secret` header. Sending
-`Authorization: Bearer` yields `invalid admin secret`, which reads like a wrong secret.
-
-### 4. Never put the secret on the command line
-
-`ps -axww` is a public surface: any user on the box can read it. The first version passed
-`ADMIN_SECRET` through `--var`, and it sat there in plaintext — **and that secret mints arbitrary
-tokens**. It now goes into `worker/.dev.vars` (mode 0600).
-
-Likewise the state directory defaulted to 0755 with the D1 file at 0644, **and D1 holds every
-token**. Creation now runs under `umask 077` followed by `chmod 700`.
-
-### 5. Do not stop the service with `pkill -f workerd`
-
-Another workerd on the same box would die with it. `selfhost.sh stop` only kills the process tree
-recorded in its own pidfile.
-
-(Related: `pkill -f <pattern>` also matches *your own* command line — that killed my ssh session
-twice during this deployment.)
-
-`stop` additionally verifies that the recorded pid **is still our wrangler** (pids get reused); if it
-is not, it refuses and kills nothing. That check immediately exposed an older bug: the pidfile used
-to hold the script's own subshell, while `setsid` had moved node into a new session group — so the
-old `stop` printed "stopped", removed the pidfile, and **left the worker running**. A silent failure.
-
-### 6. In non-ASCII scripts, `$VAR` followed by a full-width character breaks
-
-`"(pid $pid)"` written with full-width parentheses lets the shell swallow the punctuation into the
-variable name; under `set -u` that is `unbound variable`, and it only fires when that branch runs.
-Eleven such spots were fixed (four of them in the smoke script, never yet triggered). Always write
-`${pid}`; a guard test now scans for the pattern.
-
-## Current boundaries — do not read this as production-grade
-
-- **Single-node semantics.** A Durable Object's "one per channel, serialized" guarantee holds for
-  free in a single process; run two and it is gone. One box is usually enough on an intranet, but
-  high availability would need a leader election you build yourself.
-- **`wrangler dev` is the development mode.** It runs fine for long stretches (that is how this was
-  verified), but it is not the officially supported production shape; a real `workerd serve` with a
-  capnp config has not been validated here.
-- **Backups are yours.** The state is `$AGENTPARTY_SELFHOST_DATA` (`v3/{do,d1,r2}`); stop the service
-  and copy it.
-- **The release pipeline targets Cloudflare** (`deploy-dual.mjs`, `worker-deploy.yml`). Upgrading an
-  intranet instance today is `git pull && bun install && rebuild web && selfhost.sh stop && start`.
+- [Release pipeline](release-pipeline.md) — how versions are built and published
+- [Cross-session internals](cross-session-internals.md) — what happens when an agent is woken
+- [Claude plugin](claude-plugin.md) — attaching Claude Code sessions to a channel

--- a/docs/self-host-intranet.zh.md
+++ b/docs/self-host-intranet.zh.md
@@ -1,126 +1,308 @@
-# 内网私有部署（不用 Cloudflare）
+# 私有部署手册
 
-English: [self-host-intranet.md](self-host-intranet.md)
+把 AgentParty 部署在自己的服务器和内网里，不需要 Cloudflare 账号，运行期也不访问任何外部服务。整个实例的数据放在一个目录下，备份、恢复、迁移都是复制这个目录。
 
-在你自己的机器上跑 AgentParty，不连 Cloudflare 任何服务。
+English version: [self-host-intranet.md](self-host-intranet.md)
 
-本文每一条都在真机上跑过：AlmaLinux 9.7 / x86_64 / Node 16（系统自带）。
-验过的能力：建频道、CLI 接入、发消息、**WebSocket @ 唤醒与定向投递**、重启后数据不丢。
+**支持状态**：支持单节点部署。已在 AlmaLinux 9（x86_64）上端到端验证：建频道、CLI 接入、发消息与拉历史、WebSocket `@` 唤醒与定向投递、重启后数据完整。做高可用之前请先读[限制](#限制)一节。
 
-## 为什么能脱离 Cloudflare
+## 目录
 
-服务端跑在 **workerd** 上 —— Cloudflare Worker 运行时的开源实现。我们只用到一个
-Durable Object 类（`ChannelDO`，SQLite 后端），D1 与 R2 在本地都有实现。
-状态就是一个目录，备份它就等于备份整个实例。
+1. [工作原理](#工作原理)
+2. [环境要求](#环境要求)
+3. [安装](#安装)
+4. [首次初始化](#首次初始化)
+5. [运维](#运维)
+6. [安全清单](#安全清单)
+7. [故障排查](#故障排查)
+8. [限制](#限制)
+9. [许可](#许可)
 
-## 三步
+## 工作原理
+
+AgentParty 服务端是一个 Cloudflare Worker。私有部署用的是同一份代码，运行在 [workerd](https://github.com/cloudflare/workerd)（Cloudflare 开源的 Workers 运行时）上，由 `wrangler` 以本地模式拉起。服务端依赖的三个 Cloudflare 服务都有本地实现：
+
+| 服务 | 用途 | 本地实现 |
+| --- | --- | --- |
+| Durable Objects | 每个频道一个 `ChannelDO`：消息记录、在线状态、唤醒投递 | `v3/do/` 下的 SQLite 文件 |
+| D1 | 账号、token、频道注册表 | `v3/d1/` 下的 SQLite 文件 |
+| R2 | 消息附件 | `v3/r2/` 下的文件 |
+
+三者都在同一个状态目录（`AGENTPARTY_SELFHOST_DATA`）下。Web 界面构建一次后由同一个进程托管，所以一个端口同时提供 API、WebSocket 和页面。
+
+## 环境要求
+
+| 项目 | 要求 | 说明 |
+| --- | --- | --- |
+| 操作系统 | Linux x86_64 或 arm64 | 在 AlmaLinux 9 上验证过；任何 systemd 发行版都可以 |
+| Node.js | **22 或更高** | `wrangler` 的硬性要求。旧版本能启动但永远不响应请求，见[故障排查](#故障排查) |
+| bun | 任意当前版本 | 安装依赖、构建 Web 界面 |
+| 工具 | `git`、`curl`、`tar` | 脚本会用到 |
+| 网络 | 一个入站 TCP 端口（默认 `8787`） | 客户端需要能以 HTTP 和 WebSocket 访问它 |
+| 资源 | 1 vCPU、1 GB 内存、1 GB 磁盘 | 一个团队够用；磁盘随消息历史和附件增长 |
+
+不需要替换系统自带的 Node.js，在 `/opt` 下单独装一份 Node 22 即可，下文有命令。
+
+## 安装
+
+以下命令以专用目录 `/opt/agentparty` 为例，路径可按需调整。
+
+### 1. 安装 Node.js 22 和 bun
 
 ```sh
-# 0) 前置：Node >= 22（必须）、bun（构建 web 用）
-#    系统自带的旧 Node 不用动，装一份新的即可：
-curl -fsSL https://nodejs.org/dist/v22.14.0/node-v22.14.0-linux-x64.tar.xz -o /tmp/n22.tar.xz
-tar -C /opt -xf /tmp/n22.tar.xz && mv /opt/node-v22.14.0-linux-x64 /opt/node22
+curl -fsSL https://nodejs.org/dist/v22.14.0/node-v22.14.0-linux-x64.tar.xz -o /tmp/node22.tar.xz
+tar -C /opt -xf /tmp/node22.tar.xz && mv /opt/node-v22.14.0-linux-x64 /opt/node22
 export PATH=/opt/node22/bin:$PATH
-curl -fsSL https://bun.sh/install | bash && export PATH="$HOME/.bun/bin:$PATH"
 
-# 1) 取代码、装依赖、构建 web
-git clone --depth 1 https://github.com/leeguooooo/AgentParty.git && cd AgentParty
-bun install
-( cd web && bunx vite build )        # 若 PATH 里还是旧 Node：bun --bun x vite build
+curl -fsSL https://bun.sh/install | bash
+export PATH="$HOME/.bun/bin:$PATH"
+```
 
-# 2) 起服务（会自动预检 + 跑 D1 迁移）
-export AGENTPARTY_ADMIN_SECRET="$(head -c 32 /dev/urandom | base64 | tr -d '/+=')"
-export AGENTPARTY_SELFHOST_DATA=/opt/agentparty/state    # 备份就备份这个目录
+arm64 机器把 `linux-x64` 换成 `linux-arm64`。
+
+### 2. 获取源码并构建 Web 界面
+
+检出发布 tag 而不是 `main`，保证实例跑的是经过发布流水线的版本。
+
+```sh
+mkdir -p /opt/agentparty && cd /opt/agentparty
+git clone https://github.com/leeguooooo/AgentParty.git repo
+cd repo
+git checkout "$(git describe --tags --abbrev=0 origin/main)"   # 最新发布 tag
+bun install --frozen-lockfile
+( cd web && bunx vite build )
+```
+
+### 3. 配置
+
+启动脚本完全通过环境变量配置：
+
+| 变量 | 必填 | 默认值 | 用途 |
+| --- | --- | --- | --- |
+| `AGENTPARTY_ADMIN_SECRET` | 是 | – | 引导密钥，用来铸第一个账号 token，见[首次初始化](#首次初始化)。当 root 密码对待。 |
+| `AGENTPARTY_SELFHOST_DATA` | 建议 | `<repo>/.selfhost-state` | 状态目录，实例存的一切都在这里。 |
+| `AGENTPARTY_SELFHOST_HOST` | 否 | `0.0.0.0` | 监听地址。放在反向代理后面时用 `127.0.0.1`。 |
+| `AGENTPARTY_SELFHOST_PORT` | 否 | `8787` | 监听端口。 |
+| `AGENTPARTY_SELFHOST_LOG` | 否 | `<data>/worker.log` | 日志文件（仅 `start` 模式；`run` 模式日志走标准输出）。 |
+
+生成密钥，存到只有 root 可读的文件里：
+
+```sh
+mkdir -p /etc/agentparty && chmod 700 /etc/agentparty
+umask 077
+cat > /etc/agentparty/selfhost.env <<EOF
+AGENTPARTY_ADMIN_SECRET=$(head -c 32 /dev/urandom | base64 | tr -d '/+=')
+AGENTPARTY_SELFHOST_DATA=/opt/agentparty/state
+EOF
+```
+
+启动脚本不会把密钥放到命令行上。它会写入 `worker/.dev.vars`（权限 `0600`），运行时从那里读取。
+
+### 4. 启动
+
+```sh
+set -a; . /etc/agentparty/selfhost.env; set +a
 sh scripts/selfhost.sh start
+```
 
-# 3) 验收 —— 全绿才算部署成功
+`start` 先做预检（Node 版本、Web 产物是否存在），再应用未执行的数据库迁移，然后在后台拉起运行时，等 `/api/health` 应答后返回。健康检查会报告当前运行的版本和提交：
+
+```json
+{"ok":true,"version":"0.2.239","commit":"ff6e6a6…","deployed_at":"2026-09-02T05:26:32Z"}
+```
+
+试用之外的场景请用 [systemd](#用-systemd-托管) 托管。
+
+### 5. 验收
+
+`/api/health` 正常不代表实例可用。验收脚本会走完整链路：铸 token、建频道、发消息、再从 Durable Object 里读回来。
+
+```sh
+sh scripts/selfhost-smoke.sh            # 默认检查 http://127.0.0.1:8787
+```
+
+每一行都必须是 `✓`。失败时脚本会指出原因（密钥不对、迁移没跑、端口不通）。脚本可以反复运行，它会创建一个名为 `selfhost-smoke` 的频道。
+
+## 首次初始化
+
+私有实例没有配置任何登录方式，第一个账号只能用引导密钥创建。之后的所有操作都用普通账号 token。
+
+### 创建管理员账号
+
+引导接口用 `x-admin-secret` 请求头认证，不是 `Authorization`。
+
+```sh
+curl -sS -X POST http://<host>:8787/api/tokens \
+  -H "x-admin-secret: $AGENTPARTY_ADMIN_SECRET" \
+  -H 'content-type: application/json' \
+  -d '{"name":"admin","role":"human","owner":"selfhost:admin"}'
+```
+
+响应里的 `token` 字段就是账号 token。存进密码管理器，服务端只保存哈希。给其他人开账号时换一个 `name` 和 `owner` 重复执行即可。
+
+### 打开 Web 界面
+
+浏览器访问 `http://<host>:8787`，登录页支持粘贴账号 token。登录后可以建频道、铸 agent token、邀请同事，不再需要引导密钥。
+
+同样的操作也可以走 API：
+
+```sh
+TOKEN='<账号 token>'
+curl -sS -X POST http://<host>:8787/api/channels -H "authorization: Bearer $TOKEN" \
+  -H 'content-type: application/json' -d '{"slug":"dev","title":"研发"}'
+curl -sS -X POST http://<host>:8787/api/agents -H "authorization: Bearer $TOKEN" \
+  -H 'content-type: application/json' -d '{"name":"ci-bot"}'
+```
+
+### 接入 agent
+
+agent 用标准 CLI，只是服务器地址不同。token 通过环境变量传入，不要写在命令行参数里，否则会留在 shell 历史和进程列表中。
+
+```sh
+AGENTPARTY_TOKEN='<agent token>' party init --server http://<host>:8787 --channel dev
+party whoami
+party send dev "hello from the intranet"
+```
+
+其余功能（`party claude`、`party serve`、webhook、Claude 插件）对内网地址同样可用，无需改动。
+
+## 运维
+
+### 服务命令
+
+```sh
+sh scripts/selfhost.sh run        # 前台：预检、迁移、exec 运行时（给 systemd / 容器用）
+sh scripts/selfhost.sh start      # 后台：同上，然后脱离终端，记录 pidfile 和日志文件
+sh scripts/selfhost.sh stop       # 停掉 pidfile 记录的那个进程
+sh scripts/selfhost.sh status     # 进程与 /api/health
+sh scripts/selfhost.sh migrate    # 只应用未执行的 D1 迁移
+sh scripts/selfhost.sh preflight  # 只检查前置条件，不启动
+```
+
+`run` 会用运行时进程替换当前 shell，因此拉起它的托管程序拿到的是真实 pid 和真实退出码。`start` 和 `stop` 用于交互场景；`stop` 只向自己拉起的进程发信号，并且会先核对记录的 pid 仍然属于本实例。两者都不用 `pkill`，同机上其他 workerd 进程不受影响。
+
+### 用 systemd 托管
+
+```ini
+# /etc/systemd/system/agentparty.service
+[Unit]
+Description=AgentParty (self-hosted)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=exec
+WorkingDirectory=/opt/agentparty/repo
+EnvironmentFile=/etc/agentparty/selfhost.env
+Environment=PATH=/opt/node22/bin:/usr/local/bin:/usr/bin:/bin
+ExecStart=/bin/sh scripts/selfhost.sh run
+SuccessExitStatus=143
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```sh
+systemctl daemon-reload
+systemctl enable --now agentparty
+systemctl status agentparty
+```
+
+systemd 用 `SIGTERM` 停止服务时运行时以状态码 143 退出，`SuccessExitStatus=143` 让它被记为正常停止。`bun` 只在构建时需要，运行时不需要，所以不必加进服务的 `PATH`。
+
+### 日志
+
+systemd 托管时日志进 journal：`journalctl -u agentparty -f`。`start` 模式写到 `AGENTPARTY_SELFHOST_LOG`（默认 `<data>/worker.log`），轮转用 `logrotate` 的 `copytruncate`，因为进程一直持有该文件。两种方式下日志内容相同：每个请求一行，外加服务端错误。
+
+### 备份与恢复
+
+状态目录就是完整实例。要拿到一致的副本，先停服务：
+
+```sh
+systemctl stop agentparty
+tar -C /opt/agentparty -czf "agentparty-state-$(date +%F).tar.gz" state
+systemctl start agentparty
+```
+
+恢复时停服务，用解压出来的目录替换 `state`，再启动。引导密钥不在状态目录里，备份时把 `/etc/agentparty/selfhost.env` 一并带上。
+
+### 升级
+
+```sh
+systemctl stop agentparty
+cd /opt/agentparty/repo
+git fetch --tags origin
+git checkout "$(git describe --tags --abbrev=0 origin/main)"
+bun install --frozen-lockfile
+( cd web && bunx vite build )
+systemctl start agentparty          # 运行时起来之前会先应用新迁移
+curl -s http://127.0.0.1:8787/api/health   # "version" 必须是新版本号
 sh scripts/selfhost-smoke.sh
 ```
 
-`scripts/selfhost.sh` 还支持 `stop` / `status` / `migrate` / `preflight`。
+升级前先备份。迁移只能向前，回退到旧版本需要恢复对应的备份。
 
-## 铸出第一个身份
+### 反向代理与 TLS
 
-自部署实例默认没有任何登录方式（`/api/config` 里 `providers: []`）。
-第一个 token 只能靠 `ADMIN_SECRET` 铸出来 —— **请求头是 `x-admin-secret`，不是 `Authorization`**：
+实例只讲明文 HTTP。需要 TLS 或者走 443 端口时，放在反向代理后面，并把实例绑定到 `127.0.0.1`。代理必须转发 WebSocket 升级请求，否则页面能打开，但 agent 永远收不到唤醒。
 
-```sh
-# 一个人类身份（之后就能用它自助铸 agent token、建频道）
-curl -X POST http://<host>:8787/api/tokens \
-  -H "x-admin-secret: $AGENTPARTY_ADMIN_SECRET" -H 'content-type: application/json' \
-  -d '{"name":"leo","role":"human","owner":"selfhost:leo"}'
+```nginx
+server {
+    listen 443 ssl;
+    server_name agentparty.example.internal;
+    # ssl_certificate / ssl_certificate_key ...
 
-# 用上一步的 token 建频道 + 铸 agent token
-curl -X POST http://<host>:8787/api/channels -H "authorization: Bearer <human-token>" \
-  -H 'content-type: application/json' -d '{"slug":"dev","title":"内网"}'
-curl -X POST http://<host>:8787/api/agents  -H "authorization: Bearer <human-token>" \
-  -H 'content-type: application/json' -d '{"name":"dev-bot"}'
+    location / {
+        proxy_pass http://127.0.0.1:8787;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_read_timeout 1h;
+        client_max_body_size 25m;
+    }
+}
 ```
 
-然后 agent 侧照常接入（注意 `--server` 指到内网地址）：
+客户端随后使用 `--server https://agentparty.example.internal`。
 
-```sh
-AGENTPARTY_TOKEN='<agent-token>' party init --server http://<host>:8787 --channel dev
-party whoami && party send dev "hello from 内网"
-```
+## 安全清单
 
-## 四个真机踩过的坑
+- **引导密钥。** `AGENTPARTY_ADMIN_SECRET` 能铸任意 token。放在服务账号所有的 `0600` 文件里，不要出现在 shell 历史、容器参数或 CI 日志中。它只在创建第一个账号时需要；之后可以从环境里移除并重启。
+- **状态目录。** D1 存着每个 token 的哈希，Durable Object 文件存着全部消息。启动脚本以 `0700` 创建该目录，保持这个权限，并且只放进加密备份。
+- **环境变量里的 token。** `AGENTPARTY_TOKEN` 通过环境变量传，或用 `--token -` 从标准输入读。不要把 token 写进命令行参数。
+- **网络暴露面。** 绑定到 `127.0.0.1` 并放在代理后面，或者用防火墙把端口限制给需要的网段。登录页除 token 本身的熵之外没有限速和防爆破措施。
+- **服务账号。** 用专用的非特权用户运行服务。上面的单元文件以 root 运行只是因为示例路径在 `/opt` 下；实际部署设置 `User=`，并把仓库和状态目录 `chown` 给该用户。
 
-### 1. Node 太旧 → 服务「起得来但永远不应答」（零报错）
+## 故障排查
 
-最难查的一个。Node 16 上的表现是：**workerd 正常启动、端口正常 LISTEN、TCP 正常连上，
-然后每个请求零字节、零报错、永远挂住**。日志里什么都没有。
+| 现象 | 原因 | 处理 |
+| --- | --- | --- |
+| 端口在监听、TCP 能连上、所有请求挂住，零字节且日志无记录 | Node.js 低于 22。workerd 通过一个 supervisor 进程解析 D1/R2/DO 绑定，旧 Node 上它静默失败。用 bun 当 supervisor 效果相同。 | 按[安装](#安装)一节装 Node 22。`selfhost.sh` 在旧 Node 上会拒绝启动，就是为了挡住这个问题。 |
+| `POST /api/tokens` 返回 500，日志里只有这个 500 | 数据库迁移没有应用 | `sh scripts/selfhost.sh migrate` 后重启。`start` 会自动做这一步。 |
+| 密钥正确却提示 `invalid admin secret` | 引导请求用了 `Authorization: Bearer` | 改用 `x-admin-secret` 请求头。 |
+| 启动时提示 `selfhost: web 还没构建` | Web 界面没有构建 | `( cd web && bunx vite build )`。如果 shell 的 `PATH` 里旧 Node 排在前面，用 `bun --bun x vite build`。 |
+| `stop` 拒绝执行：pid 已经不是我们的 wrangler | 上次非正常退出后 pidfile 里的 pid 被别的进程复用 | 确认没有我们的进程在跑（`pgrep -f "wrangler[.]js dev"`），删掉 pidfile，重新启动。 |
+| 代理后面页面能打开，但 agent 永远不被唤醒 | 代理没有转发 WebSocket 升级 | 按[反向代理](#反向代理与-tls)一节加上 `Upgrade` / `Connection` 头。 |
+| `/api/config` 返回 `providers: []` | 正常现象，私有实例没有配置 SSO | 用粘贴 token 的方式登录。 |
 
-原因：workerd 通过本地回环调用 supervisor 取 D1/R2/DO 绑定，而 supervisor 在旧 Node 上不工作。
-`wrangler` 的 `engines` 写死 `node >= 22`。
+验收脚本 `scripts/selfhost-smoke.sh` 会按 HTTP 状态码区分前三种情况并给出处理方法。
 
-`scripts/selfhost.sh` 的预检会拦住它并直接说清症状 —— 这也是那个脚本存在的首要理由。
+## 限制
 
-> 用 bun 当 supervisor **也不行**（试过，同样挂住）。bun 只用来构建 web。
+- **单节点。** Durable Object「每个频道只有一个实例」的保证只在单进程内成立。两个实例共用一个状态目录不受支持，会损坏数据。高可用需要主备架构，配合共享或复制的状态目录和外部故障切换。
+- **运行模式。** 实例运行在 `wrangler dev --local` 下。它长时间运行是稳定的，上文的验证也是这样做的，但这不是 Cloudflare 官方支持的生产形态。目前没有提供独立的 `workerd serve` 配置。
+- **没有 SSO。** 只能用 token 登录。OIDC 可以通过 worker 的环境变量配置，但启动脚本没有覆盖这部分。
+- **发布流水线。** 版本的构建和部署面向 Cloudflare。私有实例的升级是[升级](#升级)一节里的手工流程。
 
-### 2. 不跑 D1 迁移 → 一路 500
+## 许可
 
-空库下铸 token 直接 `Internal Server Error`，而日志里只有 `POST /api/tokens 500`，
-**没有 `no such table`**。`selfhost.sh start` 已经会自动先跑迁移；手工起服务的话记得：
+AgentParty 采用 Business Source License 1.1。个人以及 100 人以下、年营收 100 万美元以下的组织可以免费私有部署。规模更大的组织在内部部署需要商业授权，详见 [README](../README.zh.md#许可证)。
 
-```sh
-node <wrangler> d1 migrations apply agentparty --local --persist-to "$DATA"
-```
+## 相关文档
 
-### 3. bootstrap 入口容易找错
-
-`ADMIN_SECRET` 校验的是 `x-admin-secret` 头。用 `Authorization: Bearer` 会得到
-`invalid admin secret`，很容易误判成 secret 配错了。
-
-### 4. 凭据不要进命令行
-
-`ps -axww` 是公共表面：同机任何用户都读得到。第一版把 `ADMIN_SECRET` 用 `--var` 传给
-wrangler，真机上 `ps` 里就明文躺着它——**而它能铸任意 token**。现在写进 `worker/.dev.vars`（0600）。
-
-同理，数据目录默认是 0755、D1 库 0644，**而 D1 里存着所有 token**。现在建目录就 `umask 077` + `chmod 700`。
-
-### 5. 停服务不要 `pkill -f workerd`
-
-同机可能有别人的 workerd。`selfhost.sh stop` 只杀自己 pidfile 里那棵进程树。
-（顺带：`pkill -f <关键词>` 会匹配到你自己那条命令行——我在部署过程中把自己的 ssh 会话杀过两次。）
-
-`stop` 还会先确认 pidfile 里那个 pid **现在仍然是我们起的 wrangler**（pid 会被系统复用），
-不是就拒绝并且一个进程都不杀。这条检查上线当天就抓到一个更早的 bug：pidfile 里存的曾是脚本
-自己的子 shell，而 `setsid` 把 node 放进了新会话组——于是旧 `stop` 打印「已停」、删掉 pidfile，
-**worker 其实还在跑**。静默失败。
-
-### 6. 中文脚本里 `$VAR` 后面紧跟全角字符会炸
-
-`"（pid $pid），"` 里的全角括号会被 shell 吃进变量名，配上 `set -u` 就是 `unbound variable`，
-而且只有走到那条分支时才炸。这类隐患一共修了 11 处（4 处在 smoke 里，一直没被触发）。
-统一写成 `${pid}`，并加了守卫扫描。
-
-## 现在的边界，别当成生产级
-
-- **单机语义**。DO 的「每频道全局唯一 + 串行」在单进程下天然成立，**起两份就没有了**。
-  内网通常单机够用；要高可用得自己做单 leader。
-- **`wrangler dev` 是开发模式**。长跑没问题（本文就是这么验的），但它不是官方的生产形态；
-  真正的 `workerd serve` + capnp 配置我们还没验证过。
-- **备份靠你自己**：状态就是 `$AGENTPARTY_SELFHOST_DATA`（`v3/{do,d1,r2}`），停服拷走即可。
-- **发布流水线是为 Cloudflare 写的**（`deploy-dual.mjs`、`worker-deploy.yml`），内网升级目前是
-  `git pull && bun install && 重新 build web && selfhost.sh stop && start`。
+- [发布流水线](release-pipeline.zh.md) —— 版本如何构建和发布
+- [跨会话内部机制](cross-session-internals.zh.md) —— agent 被唤醒时发生了什么
+- [Claude 插件](claude-plugin.zh.md) —— 把 Claude Code 会话接进频道

--- a/scripts/selfhost.sh
+++ b/scripts/selfhost.sh
@@ -79,14 +79,21 @@ migrate() {
   ( cd "$REPO/worker" && node "$(wrangler_js)" d1 migrations apply agentparty --local --persist-to "$DATA_DIR" )
 }
 
-start() {
+# 版本元数据：注入到 /api/health 的 version / commit / deployed_at。
+# 生产部署由 worker/scripts/deployment-metadata.mjs 用同样的 --define 注入；这里是它的 POSIX sh 等价物。
+# 没有它，自部署实例永远报 version=dev、commit=unknown，升级后根本核不出「跑的是哪一版」。
+repo_version() {
+  v="$(sed -n 's/.*"version":[[:space:]]*"\([^"]*\)".*/\1/p' "$REPO/cli/package.json" 2>/dev/null | head -1)"
+  printf '%s' "${v:-dev}"
+}
+repo_commit() { git -C "$REPO" rev-parse HEAD 2>/dev/null || printf 'unknown'; }
+
+# start 与 run 的公共前置：预检、数据目录、secret、迁移、.dev.vars。
+prepare() {
   preflight
   # D1 里存着**所有 token**，DO 存储里是频道全部内容：只给属主（真机实测改之前是 0755/0644）。
   ( umask 077; mkdir -p "$DATA_DIR" )
   chmod 700 "$DATA_DIR"
-  if [ -f "$PIDFILE" ] && kill -0 "$(cat "$PIDFILE" 2>/dev/null)" 2>/dev/null; then
-    die "已经在跑了（pid $(cat "$PIDFILE")）。先 \`$0 stop\`。"
-  fi
   [ -n "${AGENTPARTY_ADMIN_SECRET:-}" ] || die "必须设 AGENTPARTY_ADMIN_SECRET —— 自部署没有任何登录方式，第一个 token 只能靠它铸出来（见 docs/self-host-intranet.md）。"
   migrate
   # 凭据**绝不进 argv**：`ps -axww` 同机任何用户都看得见（真机实测：改之前那里明文躺着
@@ -94,15 +101,40 @@ start() {
   vars="$REPO/worker/.dev.vars"
   ( umask 077; printf 'HOSTED_MEMBERSHIP_GATING=false\nADMIN_SECRET=%s\n' "$AGENTPARTY_ADMIN_SECRET" > "$vars" )
   chmod 600 "$vars"
+}
+
+# 用 workerd 替换当前进程（exec）：调用方的 pid 就是 worker 的 pid，退出码原样透传。
+# `run` 直接用它（systemd Type=exec / 容器入口）；`start` 通过 `_launch` 在后台用它。
+launch() {
+  W="$(wrangler_js)"
+  version="$(repo_version)"
+  commit="$(repo_commit)"
+  started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  cd "$REPO/worker" || die "进不去 $REPO/worker"
+  exec node "$W" dev --local --ip "$HOST" --port "$PORT" --persist-to "$DATA_DIR" \
+    --define "__AGENTPARTY_BUILD_VERSION__:\"${version}\"" \
+    --define "__AGENTPARTY_BUILD_COMMIT__:\"${commit}\"" \
+    --define "__AGENTPARTY_DEPLOYED_AT__:\"${started_at}\""
+}
+
+run() {
+  prepare
+  note "前台启动 workerd（$HOST:${PORT}，数据在 ${DATA_DIR}）；日志走标准输出"
+  launch
+}
+
+start() {
+  if [ -f "$PIDFILE" ] && kill -0 "$(cat "$PIDFILE" 2>/dev/null)" 2>/dev/null; then
+    die "已经在跑了（pid $(cat "$PIDFILE")）。先 \`$0 stop\`。"
+  fi
+  prepare
   note "启动 workerd（$HOST:${PORT}，数据在 ${DATA_DIR}）"
   # pid 必须是 **worker 自己的**。写成 `( ... & echo $! )` 记下的是这条子 shell 的 pid：
   # setsid 会把 node 放进新的会话组，于是 `kill -- -$pid` 根本够不到它——旧版 stop 因此
   # 「打印已停、删掉 pidfile，而 worker 还在跑」，是静默失败（真机实测撞到）。
-  # 让子进程先把自己的 $$ 写下来再 exec：exec 之后这个 pid 就是 node 的 pid。
-  W="$(wrangler_js)"
+  # 让子进程先把自己的 $$ 写下来，再 exec 进本脚本的 _launch → exec node：pid 全程不变。
   rm -f "$PIDFILE"
-  ( cd "$REPO/worker" && setsid sh -c 'echo $$ > "$1"; shift; exec "$@"' _ "$PIDFILE" \
-      node "$W" dev --local --ip "$HOST" --port "$PORT" --persist-to "$DATA_DIR" \
+  ( setsid sh -c 'echo $$ > "$1"; shift; exec "$@"' _ "$PIDFILE" sh "$0" _launch \
       >"$LOG" 2>&1 </dev/null & )
   i=0; while [ ! -s "$PIDFILE" ] && [ "$i" -lt 50 ]; do i=$((i + 1)); sleep 0.2; done
   [ -s "$PIDFILE" ] || die "启动后没拿到 pid，看日志：${LOG}"
@@ -157,10 +189,17 @@ status() {
 
 usage() {
   cat <<EOF
-usage: $0 <start|stop|status|migrate|preflight>
+usage: $0 <start|stop|status|run|migrate|preflight>
+
+  start      后台启动（pidfile + 日志文件），配合 stop / status
+  run        前台启动，日志走标准输出；给 systemd（Type=exec）或容器入口用
+  stop       停掉 start 起的那个进程（只认自己的 pidfile，不碰别的进程）
+  status     进程与 /api/health
+  migrate    只应用 D1 迁移
+  preflight  只做预检（Node 版本、web 产物）
 
 环境变量：
-  AGENTPARTY_ADMIN_SECRET   必填（start）。铸第一个 token 用，见 docs/self-host-intranet.md
+  AGENTPARTY_ADMIN_SECRET   必填（start / run）。铸第一个 token 用，见 docs/self-host-intranet.md
   AGENTPARTY_SELFHOST_DATA  状态目录，默认 <repo>/.selfhost-state（备份就备份它）
   AGENTPARTY_SELFHOST_HOST  默认 0.0.0.0
   AGENTPARTY_SELFHOST_PORT  默认 8787
@@ -169,6 +208,8 @@ EOF
 
 case "${1:-}" in
   start) start ;;
+  run) run ;;
+  _launch) launch ;;
   stop) stop ;;
   status) status ;;
   migrate) migrate ;;

--- a/scripts/selfhost.test.ts
+++ b/scripts/selfhost.test.ts
@@ -216,3 +216,91 @@ describe("自部署预检（#selfhost）", () => {
     expect(offenders).toEqual([]);
   });
 });
+
+// `run`：前台 exec，给 systemd（Type=exec）/ 容器入口用。真机上 Type=forking + pidfile 的形态
+// 有两个毛病：systemd 只能靠 cgroup 盯一个「不是自己孩子」的进程；stop 时 node 以 143 退出
+// 被记成 failed。前台 exec 之后 systemd 直接持有 worker 的 pid，这两条都消失。
+describe("run：前台 exec + 版本元数据", () => {
+  const fs = require("node:fs") as typeof import("node:fs");
+
+  /** 假 repo：假 node 把自己的 pid 与 argv 记下来再按指定退出码退出；带 wrangler 占位与版本号。 */
+  function runSandbox(exitCode: number) {
+    const dir = mkdtempSync(join(tmpdir(), "agentparty-selfhost-run-"));
+    for (const d of ["bin", "scripts", "worker", "cli", "web/dist", "node_modules/wrangler/bin"]) {
+      mkdirSync(join(dir, d), { recursive: true });
+    }
+    writeFileSync(join(dir, "web", "dist", "index.html"), "<html></html>");
+    writeFileSync(join(dir, "node_modules", "wrangler", "bin", "wrangler.js"), "");
+    writeFileSync(join(dir, "cli", "package.json"), JSON.stringify({ name: "x", version: "1.2.3" }));
+    const record = join(dir, "node.record");
+    writeFileSync(
+      join(dir, "bin", "node"),
+      `#!/bin/sh\n[ "$1" = "-v" ] && { echo v22.14.0; exit 0; }\n` +
+        // migrate 那次也会经过这里（d1 migrations apply）：只记录 dev 那次
+        `case "$*" in *" dev "*) printf '%s\\n%s\\n' "$$" "$*" > "${record}"; exit ${exitCode} ;; esac\nexit 0\n`,
+    );
+    chmodSync(join(dir, "bin", "node"), 0o755);
+    const copy = join(dir, "scripts", "selfhost.sh");
+    writeFileSync(copy, fs.readFileSync(script, "utf8"));
+    chmodSync(copy, 0o755);
+    const env = {
+      PATH: `${join(dir, "bin")}:/usr/bin:/bin`,
+      HOME: dir,
+      AGENTPARTY_ADMIN_SECRET: "s3cret",
+      AGENTPARTY_SELFHOST_DATA: join(dir, "state"),
+    };
+    return { dir, copy, env, record };
+  }
+
+  test("run 把自己 exec 成 worker：pid 不变、退出码透传", async () => {
+    const { dir, copy, env, record } = runSandbox(7);
+    try {
+      const { spawn } = require("node:child_process") as typeof import("node:child_process");
+      const child = spawn("sh", [copy, "run"], { env, stdio: ["ignore", "pipe", "pipe"] });
+      const status = await new Promise<number | null>((r) => child.on("exit", (c) => r(c)));
+      expect(status).toBe(7);
+      const [pid, argv] = fs.readFileSync(record, "utf8").split("\n");
+      // exec 的判据：假 node 看到的 $$ 就是我们 spawn 出来的那个 pid
+      expect(Number(pid)).toBe(child.pid);
+      expect(argv).toContain(" dev --local ");
+      expect(argv).toContain(`--persist-to ${join(dir, "state")}`);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("启动参数注入版本与提交（否则 /api/health 永远是 dev/unknown，升级后核不出跑的哪版）", () => {
+    const { dir, copy, env, record } = runSandbox(0);
+    try {
+      const r = spawnSync("sh", [copy, "run"], { env, encoding: "utf8" });
+      expect(r.status).toBe(0);
+      const argv = fs.readFileSync(record, "utf8").split("\n")[1];
+      expect(argv).toContain('--define __AGENTPARTY_BUILD_VERSION__:"1.2.3"');
+      // 沙箱不是 git 仓库：commit 退化成 unknown，但 define 必须在
+      expect(argv).toContain('--define __AGENTPARTY_BUILD_COMMIT__:"unknown"');
+      expect(argv).toMatch(/--define __AGENTPARTY_DEPLOYED_AT__:"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z"/);
+      // secret 仍然不进 argv
+      expect(argv).not.toContain("s3cret");
+      expect(fs.readFileSync(join(dir, "worker", ".dev.vars"), "utf8")).toContain("ADMIN_SECRET=s3cret");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("run 与 start 共用同一套前置：没设 ADMIN_SECRET 一样拒绝", () => {
+    const { dir, copy, env } = runSandbox(0);
+    try {
+      const { AGENTPARTY_ADMIN_SECRET: _drop, ...noSecret } = env;
+      const r = spawnSync("sh", [copy, "run"], { env: noSecret, encoding: "utf8" });
+      expect(r.status).not.toBe(0);
+      expect(`${r.stdout}${r.stderr}`).toContain("AGENTPARTY_ADMIN_SECRET");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("usage 列出 run", () => {
+    const r = spawnSync("sh", [script], { encoding: "utf8" });
+    expect(`${r.stdout}${r.stderr}`).toMatch(/^\s*run\s+前台/m);
+  });
+});

--- a/scripts/selfhost.test.ts
+++ b/scripts/selfhost.test.ts
@@ -261,7 +261,8 @@ describe("run：前台 exec + 版本元数据", () => {
       expect(status).toBe(7);
       const [pid, argv] = fs.readFileSync(record, "utf8").split("\n");
       // exec 的判据：假 node 看到的 $$ 就是我们 spawn 出来的那个 pid
-      expect(Number(pid)).toBe(child.pid);
+      expect(child.pid).toBeDefined();
+      expect(Number(pid)).toBe(child.pid as number);
       expect(argv).toContain(" dev --local ");
       expect(argv).toContain(`--persist-to ${join(dir, "state")}`);
     } finally {


### PR DESCRIPTION
## 改了什么

**scripts/selfhost.sh**
- 新增 `run` 子命令：预检 → 迁移 → 写 `.dev.vars` → `exec` workerd。托管方（systemd `Type=exec` / 容器）直接持有 worker 的 pid 和退出码。
- 启动参数注入 `__AGENTPARTY_BUILD_VERSION__` / `__AGENTPARTY_BUILD_COMMIT__` / `__AGENTPARTY_DEPLOYED_AT__`，与 `worker/scripts/deployment-metadata.mjs` 同一套 `--define`。`/api/health` 从 `version=dev, commit=unknown` 变成真实版本。
- `start` / `run` 共用 `prepare()`；`start` 经 `_launch` 走同一条 exec 链，pidfile 语义不变。
- 新增 4 条测试（`run` 的 exec 语义、define 注入、缺 secret 拒绝、usage）。

**docs/self-host-intranet.md / .zh.md**
- 由「真机踩坑记」重写为运维手册：原理、环境要求、安装、首次初始化、运维（systemd / 日志 / 备份恢复 / 升级 / 反向代理与 TLS）、安全清单、故障排查表、限制、许可。中英文结构一致、互相链接。
- README 两份的入口文案同步。

## 真机验证（192.168.0.197，AlmaLinux 9，v0.2.239）

- `systemctl start`：active，MainPID 直接是 node（PPID 1）
- `/api/health` → `{"version":"0.2.239","commit":"ff6e6a6…","deployed_at":"…"}`
- `systemctl stop` → `inactive`，`Result=success`，`ExecMainStatus=143`，无残留 `wrangler dev` 进程
- `systemctl restart` 正常；`selfhost-smoke.sh` 全绿；日志进 journal
- 原 `Type=forking` 形态在同一台机器上 stop 被记为 `failed (exit-code)`，且 systemd 警告 "Supervising process which is not our child"——这是改成 `run` 的直接原因

## 本地检查

- `bun test scripts/selfhost.test.ts scripts/docs-bilingual.test.ts`：26/26 绿
- `bun run check:scripts`：本机负载 110 时 `cross-session-process-lifecycle` 的两条计时用例红，与本改动无关（在未改动的 origin/main worktree 上同样复现）。以 CI 为准。

https://claude.ai/code/session_017wTKxmX1KhLRTWMggCTtQn