### PR TITLE
fix(selfhost): smoke 按 seq 精确读回 + 运行名带 pid，可无限次反复运行

### DIFF
--- a/scripts/selfhost-smoke.sh
+++ b/scripts/selfhost-smoke.sh
@@ -23,7 +23,7 @@ ok "health"
 
 # 每次跑用唯一名字：smoke 要能反复跑。第一版复用固定名字，第二次就撞重名，
 # 而错误信息却把它归到「迁移没跑」——错因指错方向比不报错更浪费时间。
-RUN="$(date +%s)"
+RUN="$(date +%s)-$$"   # 秒数会在同一秒内两次运行时撞名（409），拼上 pid
 
 # 分诊靠**真实 HTTP 状态**，不靠猜。curl 把状态码附在正文末尾一行。
 post() { # $1=path $2=headers-name $3=header-value $4=json
@@ -67,17 +67,18 @@ ok "agent token"
 #    kind 必须是 "message"（不是 "msg"）：格式以 worker/src/do.ts 的 parseSendFrame 为准，
 #    别照直觉猜——我第一版就猜错了，返回的只是笼统的 invalid send payload。
 r="$(post "/api/channels/$CHANNEL/messages" authorization "Bearer $AT" "{\"kind\":\"message\",\"body\":\"selfhost smoke $RUN\",\"mentions\":[]}")"
-case "$(body_of "$r")" in
-  *'"seq"'*) ok "发消息（穿过 ChannelDO）" ;;
-  *) fail "发消息失败（HTTP $(code_of "$r")）：$(body_of "$r")" ;;
-esac
+SEQ="$(body_of "$r" | sed -n 's/.*"seq":\([0-9][0-9]*\).*/\1/p' | head -1)"
+[ -n "$SEQ" ] || fail "发消息失败（HTTP $(code_of "$r")）：$(body_of "$r")"
+ok "发消息（穿过 ChannelDO，seq ${SEQ}）"
 
-# 6) 读回来 —— 证明它真的落盘了，不只是被接受
-hist="$(curl -fsS --max-time 15 "$BASE/api/channels/$CHANNEL/messages?limit=5" \
+# 6) 读回来 —— 证明它真的落盘了，不只是被接受。
+#    必须按本次的 seq 精确读：`?limit=5` 给的是最旧的 5 条，频道里积累超过 5 条
+#    （smoke 跑到第 6 次）就读不到自己那条，会把「一切正常」误报成失败。
+hist="$(curl -fsS --max-time 15 "$BASE/api/channels/$CHANNEL/messages?since=$((SEQ - 1))&limit=1" \
   -H "authorization: Bearer $AT" 2>/dev/null || true)"
 case "$hist" in
   *"selfhost smoke $RUN"*) ok "读回消息（DO 存储可用）" ;;
-  *) fail "读不回刚发的消息：$hist" ;;
+  *) fail "读不回刚发的消息（seq ${SEQ}）：$hist" ;;
 esac
 
 printf '\nsmoke: 全部通过 —— 这台自部署实例可以用了（%s）\n' "$BASE"

--- a/scripts/selfhost.test.ts
+++ b/scripts/selfhost.test.ts
@@ -317,7 +317,7 @@ describe("selfhost-smoke：可反复运行", () => {
 
   test("读回必须按本次 seq 精确取，不能拿最旧 N 条碰运气", () => {
     expect(smoke).toContain('messages?since=$((SEQ - 1))&limit=1');
-    expect(smoke).not.toMatch(/messages\?limit=\d+"/);
+    expect(smoke).not.toMatch(/messages\?[^&]*limit=\d+/);
   });
 
   test("每次运行的名字要在同一秒内也唯一", () => {

--- a/scripts/selfhost.test.ts
+++ b/scripts/selfhost.test.ts
@@ -305,3 +305,22 @@ describe("run：前台 exec + 版本元数据", () => {
     expect(`${r.stdout}${r.stderr}`).toMatch(/^\s*run\s+前台/m);
   });
 });
+
+// smoke 真机跑到第 6 次才暴露的两个坑：`?limit=5` 返回最旧 5 条（自己那条读不到 ⇒ 误报失败）；
+// `RUN=$(date +%s)` 同一秒内两次运行撞名（409）。守卫钉住修法，别被顺手改回去。
+describe("selfhost-smoke：可反复运行", () => {
+  const smoke = require("node:fs")
+    .readFileSync(resolve(import.meta.dir, "selfhost-smoke.sh"), "utf8")
+    .split("\n")
+    .filter((l: string) => !l.trim().startsWith("#"))
+    .join("\n");
+
+  test("读回必须按本次 seq 精确取，不能拿最旧 N 条碰运气", () => {
+    expect(smoke).toContain('messages?since=$((SEQ - 1))&limit=1');
+    expect(smoke).not.toMatch(/messages\?limit=\d+"/);
+  });
+
+  test("每次运行的名字要在同一秒内也唯一", () => {
+    expect(smoke).toMatch(/^RUN="\$\(date \+%s\)-\$\$"/m);
+  });
+});


### PR DESCRIPTION
真机按手册升级到 v0.2.240 后跑验收，第 6 次运行才暴露两个 smoke 自身的问题：

1. 读回用 `?limit=5`，返回的是**最旧** 5 条；频道累积超过 5 条后本次那条不在其中，把一切正常的实例误报成「读不回消息」。改为取发送响应里的 `seq`，用 `since=seq-1&limit=1` 精确读回（`since` 由 `/api/channels/:slug/messages` 原样透传给 DO）。
2. `RUN=$(date +%s)` 同一秒内连跑两次撞名（`POST /api/tokens` 409）。拼上 `$$`。

真机（192.168.0.197，v0.2.240）连跑三次全绿（seq 8/9/10）。新增两条守卫测试钉住修法；`bun test scripts/selfhost.test.ts` 22/22，scripts tsc 通过。

https://claude.ai/code/session_017wTKxmX1KhLRTWMggCTtQn