### PR TITLE
feat(web): 模块③——侧栏顶部去终端 cosplay，频道/归档/空态改人话

### DIFF
--- a/web/src/components/ChannelList.tsx
+++ b/web/src/components/ChannelList.tsx
@@ -169,7 +169,7 @@ function ScopedChannelList({ channels, active, error, onOpen, onRetry }: ScopedP
         <ChannelPill key={c.slug} c={c} active={active} onOpen={onOpen} />
       ))}
       {live !== null && live.length === 0 && archived.length === 0 && (
-        <p className="side-note t-mono">$ party channel create</p>
+        <p className="side-note t-mono">{t("Home.channelsEmpty")}</p>
       )}
       {category !== "all" && filteredLive !== null && filteredLive.length === 0 && live !== null && live.length > 0 && (
         <p className="side-note t-mono">{t(CATEGORY_EMPTY_KEY[category])}</p>

--- a/web/src/i18n/strings/Home.ts
+++ b/web/src/i18n/strings/Home.ts
@@ -2,10 +2,11 @@ import { registerDict, type LocaleDict } from "../dict";
 
 export const HomeStrings: LocaleDict = {
   en: {
-    "Home.archivedToggle": "$ ls ./archived/ · {count}",
-    "Home.channelsLabel": "$ ls ./channels/",
+    "Home.archivedToggle": "archived · {count}",
+    "Home.channelsLabel": "channels",
     "Home.noParticipants": "no participants yet",
     "Home.loading": "loading…",
+    "Home.channelsEmpty": "No channels yet — create one with the button above.",
     "Home.channelCategoryAll": "All ({count})",
     "Home.channelCategoryCreated": "Created ({count})",
     "Home.channelCategoryJoined": "Joined ({count})",
@@ -13,10 +14,11 @@ export const HomeStrings: LocaleDict = {
     "Home.channelCategoryEmptyJoined": "You haven't joined any channels yet.",
   },
   zh: {
-    "Home.archivedToggle": "$ ls ./archived/ · {count}",
-    "Home.channelsLabel": "$ ls ./channels/",
+    "Home.archivedToggle": "归档 · {count}",
+    "Home.channelsLabel": "频道",
     "Home.noParticipants": "尚无参与者",
     "Home.loading": "加载中…",
+    "Home.channelsEmpty": "还没有频道——用上面的「新建频道」建一个。",
     "Home.channelCategoryAll": "全部 ({count})",
     "Home.channelCategoryCreated": "我创建的 ({count})",
     "Home.channelCategoryJoined": "我加入的 ({count})",

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -7434,8 +7434,7 @@ button.org-person-name {
   font-size: 12px;
   color: var(--t-muted);
 }
-/* 频道项：❯ 前缀 */
-.chan-head::before { content: "❯"; color: var(--t-faint); font-size: 12px; flex: none; }
+/* 模块③（#1049）：频道项不再伪装成终端提示符，去掉 ❯ 前缀 */
 
 /* #1044：presence 行不再伪装成终端（原 `$ who --live` 前缀已去掉）。 */
 


### PR DESCRIPTION
## 模块③：侧栏顶部（承接 #1044 头部、#1048 名单弹窗）

侧栏顶部原本假装成一个终端：`$ ls ./channels/`、`$ ls ./archived/ · 3`、空态写着 `$ party channel create`、每个频道前面还有个 `❯` 提示符。非终端用户看不懂，终端用户也不会真去敲。

### 改动
- `Home.channelsLabel` → `channels` / `频道`；`Home.archivedToggle` → `archived · {count}` / `归档 · {count}`
- 空态由组件内写死的 `$ party channel create` 改为 i18n 键 `Home.channelsEmpty`，文案直接指向上方「新建频道」按钮
- 删除 `.chan-head::before { content: "❯" }`

### 验证
- `bunx tsc --noEmit` 0 错
- `ChannelList.test.tsx` 6/6 通过
- 没有测试钉死这三条旧字符串

### 未动（不属侧栏，记为后续候选）
- `.gate-hint::before "$ "`（频道页入群提示）
- `.role-board-head p::before "$ ls ./roles/ --assigned"`（team blog）

https://claude.ai/code/session_01HE21mDsWhAUwhJ8NnXLqWZ