### PR TITLE
feat(web): 模块⑥——送达提示与唤醒回执把唤醒方式改成人话，不露 serve/watch 实现名

### DIFF
--- a/web/src/components/Composer.escape.test.tsx
+++ b/web/src/components/Composer.escape.test.tsx
@@ -234,6 +234,29 @@ describe("Composer Escape handling (#357)", () => {
     act(() => r!.unmount());
   });
 
+  test("模块⑥：送达提示把 wakeKind=serve 显示成「standing by」，不露实现名", () => {
+    let r: ReactTestRenderer | undefined;
+    act(() => {
+      r = create(
+        <LocaleProvider>
+          <Composer
+            draft="@evan hi"
+            setDraft={() => undefined}
+            onSend={() => undefined}
+            ready
+            candidates={[]}
+            mentionStatuses={[{ name: "evan", display: "evan", tier: "wakeable", wakeKind: "serve" }]}
+          />
+        </LocaleProvider>,
+      );
+    });
+    const labels = r!.root.findAllByProps({ className: "composer-reach-label" }).map((n) => String(n.children.join("")));
+    expect(labels).toHaveLength(1);
+    expect(labels[0]).toContain("standing by");
+    expect(labels[0]).not.toMatch(/\bserve\b/);
+    act(() => r!.unmount());
+  });
+
   test("focuses and reveals the composer when reply mode starts", () => {
     const focus = mock(() => undefined);
     const scrollIntoView = mock(() => undefined);

--- a/web/src/components/Composer.tsx
+++ b/web/src/components/Composer.tsx
@@ -2,6 +2,7 @@
 // readonly / archived 时由页面层直接不渲染本组件（错误内联为条幅）。
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { isOpaqueAccount } from "@agentparty/shared/identity";
+import { wakeKindLabel } from "../lib/wakeKindLabel";
 import type { ChangeEvent, ClipboardEvent, CSSProperties, DragEvent, KeyboardEvent } from "react";
 import type { Attachment } from "@agentparty/shared";
 import { formatSize, isImageAttachment, useAttachmentBlobUrl } from "./AttachmentList";
@@ -155,7 +156,7 @@ export function Composer({
   const reachLabel = (s: DraftMentionStatus): string => {
     const reach = REACH_TIER[s.tier];
     if (reach === "online") return t("WakeReceipt.pre.online");
-    if (reach === "wakeable") return t("WakeReceipt.pre.wakeable", { kind: s.wakeKind ?? "wake" });
+    if (reach === "wakeable") return t("WakeReceipt.pre.wakeable", { kind: wakeKindLabel(s.wakeKind, t) || t("WakeKind.serve") });
     return t("WakeReceipt.pre.offline");
   };
   const taRef = useRef<HTMLTextAreaElement | null>(null);

--- a/web/src/components/MessageStatus.test.tsx
+++ b/web/src/components/MessageStatus.test.tsx
@@ -76,6 +76,38 @@ afterEach(() => {
   }
 });
 
+describe("模块⑥：唤醒方式给用户看时用人话", () => {
+  test("pending_wake 的回执把 serve 显示成「常驻待命」，不露实现名", () => {
+    act(() => {
+      renderer = create(
+        <LocaleProvider>
+          <MessageStatus
+            receipts={[{ name: "evan", state: "pending_wake", detail: "serve", at: null }]}
+            readers={[]}
+            unread={[]}
+            deliveries={[]}
+            display={(name) => name}
+          />
+        </LocaleProvider>,
+      );
+    });
+    act(() => renderer!.root.findByProps({ "aria-label": "展开消息送达详情" }).props.onClick());
+    const texts: string[] = [];
+    const titles: string[] = [];
+    const walk = (node: unknown): void => {
+      if (typeof node === "string") { texts.push(node); return; }
+      if (!node || typeof node !== "object") return;
+      const n = node as { props?: Record<string, unknown>; children?: unknown[] };
+      if (typeof n.props?.title === "string") titles.push(n.props.title);
+      for (const child of n.children ?? []) walk(child);
+    };
+    walk(renderer!.toJSON());
+    const all = texts.join(" ") + " " + titles.join(" ");
+    expect(all).toContain("常驻待命");
+    expect(all).not.toMatch(/\bserve\b/);
+  });
+});
+
 describe("MessageStatus delivery diagnostics (#806)", () => {
   test("collapsed state prioritizes the actionable count without repeating every target", () => {
     const r = renderStatus([

--- a/web/src/components/MessageStatus.tsx
+++ b/web/src/components/MessageStatus.tsx
@@ -4,6 +4,7 @@
 //   · @ 提及送达 = 事件驱动 agent(webhook/watch --once)的唤醒回执——它们不逐条读频道，只被 @ 唤醒
 // 不把事件驱动 agent 混进「已读」假装它逐条读了。
 import type { DirectedDeliveryState, PublicDirectedDelivery } from "@agentparty/shared";
+import { wakeKindLabel } from "../lib/wakeKindLabel";
 import { useMemo, useState } from "react";
 import { useT } from "../i18n/useT";
 import "../i18n/strings/WakeReceipt";
@@ -62,12 +63,15 @@ export function MessageStatus({
   const hasDetails = hasRead || visibleReceipts.length > 0 || deliveries.length > 0;
   if (!hasDetails) return null;
 
+  // pending_wake 的 detail 是唤醒方式（serve/watch…），给用户看要过一遍人话；其余状态的 detail 是 #seq / HTTP 码，原样。
+  const receiptDetail = (r: MentionReceipt): string =>
+    r.state === "pending_wake" ? wakeKindLabel(r.detail, t) : (r.detail ?? "");
   const receiptText = (r: MentionReceipt): string => {
-    const base = t(`WakeReceipt.state.${r.state}`, { detail: r.detail ?? "" });
+    const base = t(`WakeReceipt.state.${r.state}`, { detail: receiptDetail(r) });
     return r.state === "woke" && r.at !== null ? `${base} ${fmtTime(r.at)}` : base;
   };
   const receiptTitle = (r: MentionReceipt): string =>
-    t(`WakeReceipt.title.${r.state}`, { name: display(r.name), detail: r.detail ?? "" });
+    t(`WakeReceipt.title.${r.state}`, { name: display(r.name), detail: receiptDetail(r) });
   // #667：终态 failed 若带 undelivered（排队超时/对端无唤醒通道），用「未送达」独立文案，与「跑了但失败」区分。
   const deliveryStateKey = (delivery: PublicDirectedDelivery): string =>
     delivery.state === "failed" && delivery.undelivered === true ? "undelivered" : delivery.state;

--- a/web/src/i18n/strings/WakeReceipt.ts
+++ b/web/src/i18n/strings/WakeReceipt.ts
@@ -5,7 +5,12 @@ export const WakeReceiptStrings: LocaleDict = {
   en: {
     // 发送前预览：@ 目标当前能不能落地
     "WakeReceipt.pre.online": "online · will see it live",
-    "WakeReceipt.pre.wakeable": "wakeable ({kind}) · @ will wake it",
+    "WakeReceipt.pre.wakeable": "wakeable · {kind} · @ will wake it",
+    "WakeKind.serve": "standing by",
+    "WakeKind.watch": "watching for @",
+    "WakeKind.daemon": "background daemon",
+    "WakeKind.webhook": "webhook",
+    "WakeKind.none": "no wake channel",
     "WakeReceipt.pre.offline": "offline · not wakeable — won't reach until it reconnects",
     "WakeReceipt.pre.label": "reach",
     // 发送后回执
@@ -60,7 +65,12 @@ export const WakeReceiptStrings: LocaleDict = {
   },
   zh: {
     "WakeReceipt.pre.online": "在线 · 会实时看到",
-    "WakeReceipt.pre.wakeable": "可唤醒({kind}) · @ 会拉起",
+    "WakeReceipt.pre.wakeable": "可唤醒 · {kind} · @ 会拉起",
+    "WakeKind.serve": "常驻待命",
+    "WakeKind.watch": "守候 @ 中",
+    "WakeKind.daemon": "后台守护",
+    "WakeKind.webhook": "回调唤醒",
+    "WakeKind.none": "没有唤醒通道",
     "WakeReceipt.pre.offline": "离线·不可唤醒 · 重连前收不到",
     "WakeReceipt.pre.label": "能否送达",
     "WakeReceipt.state.replied": "已回复 {detail}",

--- a/web/src/lib/wakeKindLabel.ts
+++ b/web/src/lib/wakeKindLabel.ts
@@ -1,0 +1,14 @@
+import type { WakeKind } from "@agentparty/shared";
+import type { TFunc } from "../i18n/useT";
+
+const KNOWN: ReadonlySet<string> = new Set(["serve", "watch", "daemon", "webhook", "none"]);
+
+/**
+ * 模块⑥：唤醒方式给用户看时用人话，不露 serve / watch / daemon / webhook 这些实现名。
+ * 数据层（wakeReceipt.detail、DraftMentionStatus.wakeKind）保持原值，只在渲染处过一遍。
+ * 未知值原样返回——宁可露一个陌生词，也别把真实状态吞掉。
+ */
+export function wakeKindLabel(kind: WakeKind | string | null | undefined, t: TFunc): string {
+  if (kind === null || kind === undefined || kind === "") return "";
+  return KNOWN.has(kind) ? t(`WakeKind.${kind as WakeKind}`) : kind;
+}


### PR DESCRIPTION
## 模块⑥：@ 后的送达提示 + 消息唤醒回执（承接 #1044 / #1048 / #1049 / #1050 / #1053）

输入 @ 之后的送达提示写着「可唤醒(serve) · @ 会拉起」，消息回执 hover 写着「声明了可唤醒(serve)」。serve / watch / daemon / webhook 是 CLI 的运行模式名，用户不该需要知道。

### 改动
- 新增 `web/src/lib/wakeKindLabel.ts`：唤醒方式 → 人话；未知值原样返回，不吞状态
  - serve → 常驻待命 / standing by；watch → 守候 @ 中 / watching for @；daemon → 后台守护 / background daemon；webhook → 回调唤醒 / webhook；none → 没有唤醒通道 / no wake channel
- `Composer` 送达提示：`WakeReceipt.pre.wakeable` 改为「可唤醒 · {kind} · @ 会拉起」，kind 走映射
- `MessageStatus` 回执：只有 `pending_wake` 的 detail 是唤醒方式，过映射；`replied/working/woke/wake_failed` 的 detail 是 #seq / HTTP 码，原样
- 数据层 `lib/wakeReceipt.ts`、`lib/mentions.ts` 不动（测试钉着 `detail === "serve"`，那是内部值）

### 验证
- `bunx tsc --noEmit` 0 错
- Composer.escape / MessageStatus / wakeReceipt / mentions 四个文件 89/89（含新增两条：回执与送达提示均不含 `serve` 原词）
- 本机负载高，全量 `check:web` 以 CI 为准

https://claude.ai/code/session_01HE21mDsWhAUwhJ8NnXLqWZ