### PR TITLE
feat(cli): Claude 会话内自动识别身份 + 展示名对齐 Claude 原生会话名（#1052 #2/#6）

### DIFF
--- a/cli/src/claude-inbox-inject.ts
+++ b/cli/src/claude-inbox-inject.ts
@@ -89,6 +89,21 @@ function nativeSessionsDir(env: NodeJS.ProcessEnv = process.env): string | null 
   }
 }
 
+/**
+ * 本机是否存在任何 Claude 原生会话寻址文件（`<pid>.json`）。#1052 #2 的祖先链探测先问这一句：
+ * 目录不存在 / 空目录 ⇒ 这台机器上根本没有 Claude 会话，`party` 不必再花 `ps` 往上爬。
+ * 只 readdir 不解析，任何失败按「没有」处理（调用方随之走既有的 cwd 解析）。
+ */
+export function nativeSessionsAvailable(env: NodeJS.ProcessEnv = process.env): boolean {
+  const dir = nativeSessionsDir(env);
+  if (dir === null) return false;
+  try {
+    return readdirSync(dir).some((filename) => PID_JSON_RE.test(filename));
+  } catch {
+    return false;
+  }
+}
+
 /** 单个 `<pid>.json` 的关切字段（native `B5d` 解析同款）。 */
 export interface NativeClaudeSession {
   pid: number;

--- a/cli/src/claude-native-display-name.ts
+++ b/cli/src/claude-native-display-name.ts
@@ -1,0 +1,85 @@
+// 注册表展示名与 Claude 原生会话名对齐（#1052 #6）。
+//
+// Claude 内置 cross-session 里一个会话只有一个名字（`~/.claude/sessions/<pid>.json` 的 `name`，
+// 形如 `agentparty-83`）。AgentParty 的 SessionStart hook 常常跑在 Claude 写出这个文件之前，
+// 于是注册表 display_name 留 null、宣告名回退成 `claude-<12hex>`——`party who` / peers 列表里
+// 是一串谁也不认识的名字，与 ListAgents 按精确名关联也永远对不上。
+//
+// 这里补两条路：
+//   - hook 后续每一轮（PreToolUse/Stop/…，每轮一个进程）读一次原生名，读到且与条目不同就更新；
+//   - announce 绑定宿主会话时读一次，读不到隔一小段再读一次（每进程一次重试），仍读不到才用回退名。
+// 两条路都只在 pid + sessionId 双双吻合时才认（nativeSessionName 内置的 expectSessionId 校验），
+// 绝不把别的会话的名字写进这条目。任何失败静默——hook 铁律：不抛、不阻塞。
+import { nativeSessionName } from "./claude-inbox-inject";
+import {
+  claudeSessionAnnounceName,
+  isClaudeSessionDisplayName,
+  patchClaudeSessionEntry,
+  type ClaudeSessionRegistryEntry,
+} from "./claude-session-registry";
+
+/** announce 首次读不到原生名时的重试间隔（Claude 通常在启动后百毫秒内写出寻址文件）。 */
+export const ANNOUNCE_NATIVE_NAME_RETRY_MS = 500;
+/** 只对刚入册（SessionStart 不久）的会话重试：老会话还没名字＝Claude 根本没写，等也没用。 */
+export const ANNOUNCE_NATIVE_NAME_RETRY_WINDOW_MS = 60_000;
+
+/**
+ * 读一次原生名；读到、合法且与条目不同 ⇒ 写回注册表并返回新名；否则返回条目现有的 display_name。
+ * 返回值是「此刻应当展示的注册表名」（可能仍为 null＝继续用回退名）。
+ */
+export function syncNativeDisplayName(
+  entry: ClaudeSessionRegistryEntry,
+  env: NodeJS.ProcessEnv = process.env,
+): string | null {
+  try {
+    const name = nativeSessionName(entry.pid, { expectSessionId: entry.session_id, env });
+    if (!isClaudeSessionDisplayName(name)) return entry.display_name;
+    if (name === entry.display_name) return name;
+    patchClaudeSessionEntry(entry.session_id, { display_name: name }, env);
+    return name;
+  } catch {
+    return entry.display_name;
+  }
+}
+
+/**
+ * announce 绑定宿主会话时的宣告名：原生名优先；首次读不到就等 `retryDelayMs` 再读一次
+ * （每进程对同一会话只重试一次），仍读不到才回退 `claude-<12hex>`。
+ */
+const retriedSessions = new Set<string>();
+
+export async function announceDisplayName(
+  entry: ClaudeSessionRegistryEntry,
+  env: NodeJS.ProcessEnv = process.env,
+  options: { retryDelayMs?: number; retryWindowMs?: number; signal?: AbortSignal } = {},
+): Promise<string> {
+  let name = syncNativeDisplayName(entry, env);
+  if (name === null) {
+    const key = entry.session_id.toLowerCase();
+    const fresh = Date.now() - entry.registered_at < (options.retryWindowMs ?? ANNOUNCE_NATIVE_NAME_RETRY_WINDOW_MS);
+    if (fresh && !retriedSessions.has(key)) {
+      retriedSessions.add(key);
+      await abortableDelay(options.retryDelayMs ?? ANNOUNCE_NATIVE_NAME_RETRY_MS, options.signal);
+      name = syncNativeDisplayName(entry, env);
+    }
+  }
+  return name ?? claudeSessionAnnounceName(entry);
+}
+
+/** 测试用：允许同一进程内再次重试。 */
+export function resetAnnounceNativeNameRetries(): void {
+  retriedSessions.clear();
+}
+
+function abortableDelay(ms: number, signal?: AbortSignal): Promise<void> {
+  if (ms <= 0 || signal?.aborted) return Promise.resolve();
+  return new Promise((resolve) => {
+    const timer = setTimeout(done, ms);
+    function done(): void {
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", done);
+      resolve();
+    }
+    signal?.addEventListener("abort", done, { once: true });
+  });
+}

--- a/cli/src/claude-self-session.ts
+++ b/cli/src/claude-self-session.ts
@@ -1,0 +1,164 @@
+// 「我此刻跑在哪个 Claude Code 会话里」（#1052 #2）。
+//
+// Claude 内置 cross-session 发消息自动带上发送方身份；AgentParty 里一个用 per-session config
+// 接入的会话却得在每条 `party` 命令前手写 `AGENTPARTY_CONFIG=<path>`——config 按 cwd 查找，
+// 同目录的两个会话会撞同一个 workspaceId。要让 `party` 自己认出宿主会话，先得知道宿主 pid。
+//
+// 两条路，先快后慢：
+//   ① 环境变量（零 spawn）：Claude Code（本机 2.1.258 实测）给 Bash 子进程放了
+//      `CLAUDE_CODE_SESSION_ID` 与 `CLAUDE_CODE_MESSAGING_SOCKET=/tmp/cc-socks/<pid>.sock`。
+//      从 socket 文件名取 pid，读 `~/.claude/sessions/<pid>.json`，要求文件里的 sessionId、
+//      messagingSocketPath 与环境变量**逐字相等**、且 pid 活着——三者都对才算认出。这是防继承来的
+//      陈旧环境：serve runner、嵌套 shell、`/clear` 之后换了会话，都会让其中一项对不上。
+//   ② 父进程链（变量缺失：旧版 Claude Code、或不在 Bash 工具下）：沿父进程链往上走，第一个在
+//      `~/.claude/sessions/<pid>.json` 里有寻址文件的祖先就是宿主（做法与 open-cross-session 的
+//      src/wake.ts findSelfClaudePid 同款）。**不能只看 process.ppid**：`party` 是在 Claude 的
+//      Bash 工具里经中间 shell 起的（party → zsh → claude），ppid 是那个 shell。
+//
+// 安全边界：
+//   - 只读 sessions 目录（沿用 claude-inbox-inject 的目录/文件校验：非符号链接、属本 uid、
+//     文件名 pid 与内容 pid 一致），绝不写任何 Claude 文件；
+//   - 找不到 / `ps` 不可用 / 任一步出错 ⇒ null，调用方回落既有的 cwd 解析——绝不猜；
+//   - 每个进程只爬一次（结果按 sessions 目录缓存），`party statusline` 这类高频调用不会反复起 `ps`；
+//   - 只在 Claude 的子进程树里才爬：Claude Code 给所有子进程（Bash 工具、hook、MCP server）
+//     设 `CLAUDECODE=1`，没有它就是终端 / serve runner 等场景，一次 `ps` 都不起。这个变量若将来
+//     消失，结果只是退回按 cwd 解析（现状），不会更糟。
+import { spawnSync } from "node:child_process";
+import { basename, isAbsolute } from "node:path";
+import {
+  CLAUDE_NATIVE_SESSIONS_DIR_ENV,
+  nativeSessionsAvailable,
+  resolveSessionSocketByPid,
+  type NativeClaudeSession,
+} from "./claude-inbox-inject";
+
+/** 最多往上走多少层。Bash 工具链通常 2–3 层；10 层足够覆盖 wrapper / 嵌套 shell。 */
+export const SELF_CLAUDE_SESSION_MAX_HOPS = 10;
+/** 单次 `ps` 上限：绝不让一条 `party` 命令因 ps 卡住而挂死。 */
+const PS_TIMEOUT_MS = 1_000;
+
+export interface SelfClaudeSession {
+  /** 宿主 Claude 进程 pid（＝ `<pid>.json` 的文件名，也＝注册表条目的 pid）。 */
+  pid: number;
+  /** 宿主会话的 sessionId（`<pid>.json` 的 `sessionId`）；文件里没写则 null（＝不可匹配）。 */
+  sessionId: string | null;
+  /** Claude 自己的会话名（`<pid>.json` 的 `name`，形如 `agentparty-83`）；没写则 null。 */
+  name: string | null;
+  /** 从起点到宿主走了几层（诊断用）；0＝由环境变量直接认出，没起过 `ps`。 */
+  hops: number;
+}
+
+type SpawnLike = typeof spawnSync;
+
+/** Claude Code 给子进程树打的标记；缺席 ⇒ 不在 Claude 会话里，不爬。 */
+export const CLAUDE_CODE_MARKER_ENV = "CLAUDECODE";
+/** Claude Code 给 Bash 子进程的宿主会话 id（2.1.258 实测）。 */
+export const CLAUDE_CODE_SESSION_ID_ENV = "CLAUDE_CODE_SESSION_ID";
+/** Claude Code 给 Bash 子进程的宿主收件箱 socket 路径（`/tmp/cc-socks/<pid>.sock`）。 */
+export const CLAUDE_CODE_MESSAGING_SOCKET_ENV = "CLAUDE_CODE_MESSAGING_SOCKET";
+const SOCKET_PID_RE = /^(\d+)\.sock$/;
+
+export interface FindSelfClaudeSessionOptions {
+  env?: NodeJS.ProcessEnv;
+  /** 起点 pid；默认 process.pid（第一跳就是 process.ppid）。 */
+  startPid?: number;
+  maxHops?: number;
+  spawn?: SpawnLike;
+}
+
+/** 一跳：`ps -o ppid= -p <pid>`。解析不出 / 失败 ⇒ null。 */
+function parentPid(pid: number, spawn: SpawnLike): number | null {
+  try {
+    const out = spawn("ps", ["-o", "ppid=", "-p", String(pid)], {
+      encoding: "utf8",
+      timeout: PS_TIMEOUT_MS,
+    });
+    if (out.status !== 0 || typeof out.stdout !== "string") return null;
+    const parent = Number(out.stdout.trim());
+    return Number.isInteger(parent) && parent > 0 ? parent : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 路 ①：按环境变量认宿主，零 spawn。变量缺任何一个 ⇒ null（调用方改走父进程链）；变量齐全但与
+ * 寻址文件对不上（陈旧环境）⇒ 同样 null，由父进程链给出真实答案，绝不信环境变量单方面的说法。
+ */
+export function selfClaudeSessionFromEnv(env: NodeJS.ProcessEnv = process.env): SelfClaudeSession | null {
+  const sessionId = env[CLAUDE_CODE_SESSION_ID_ENV];
+  const socket = env[CLAUDE_CODE_MESSAGING_SOCKET_ENV];
+  if (typeof sessionId !== "string" || sessionId === "") return null;
+  if (typeof socket !== "string" || socket === "" || !isAbsolute(socket)) return null;
+  const match = SOCKET_PID_RE.exec(basename(socket));
+  if (match === null) return null;
+  const pid = Number(match[1]);
+  if (!Number.isInteger(pid) || pid <= 0) return null;
+  // resolveSessionSocketByPid 已校验：文件名 pid＝内容 pid、pid 活、sessionId 与期望相等。
+  const resolved = resolveSessionSocketByPid(pid, { expectSessionId: sessionId, env });
+  if (!resolved.ok) return null;
+  if (resolved.session.messagingSocketPath !== socket) return null;
+  return fromNative(resolved.session, 0);
+}
+
+/**
+ * 不带缓存的祖先链探测（路 ②）。返回第一个持有原生寻址文件的祖先；到根（pid ≤ 1）/ 超出跳数 /
+ * `ps` 失败都返回 null。祖先的寻址文件坏掉（校验不过）同样 null——不继续往上猜别的会话。
+ */
+export function walkToSelfClaudeSession(
+  options: FindSelfClaudeSessionOptions = {},
+): SelfClaudeSession | null {
+  const env = options.env ?? process.env;
+  const spawn = options.spawn ?? spawnSync;
+  const maxHops = options.maxHops ?? SELF_CLAUDE_SESSION_MAX_HOPS;
+  let pid = options.startPid ?? process.pid;
+  if (!Number.isInteger(pid) || pid <= 0) return null;
+  if (process.platform === "win32") return null;
+  if ((env[CLAUDE_CODE_MARKER_ENV] ?? "") === "") return null;
+  if (!nativeSessionsAvailable(env)) return null;
+  for (let hop = 1; hop <= maxHops; hop += 1) {
+    const parent = parentPid(pid, spawn);
+    if (parent === null || parent <= 1 || parent === pid) return null;
+    const resolved = resolveSessionSocketByPid(parent, { env });
+    if (resolved.ok) return fromNative(resolved.session, hop);
+    pid = parent;
+  }
+  return null;
+}
+
+function fromNative(session: NativeClaudeSession, hops: number): SelfClaudeSession {
+  return { pid: session.pid, sessionId: session.sessionId, name: session.name, hops };
+}
+
+let cache: { key: string; value: SelfClaudeSession | null } | null = null;
+
+/**
+ * 带进程级缓存的探测：同一进程内按 sessions 目录 + 起点只爬一次。
+ * 缓存 key 含目录覆盖变量，测试在同进程切换夹具目录时不会拿到旧答案。
+ */
+export function findSelfClaudeSession(
+  options: FindSelfClaudeSessionOptions = {},
+): SelfClaudeSession | null {
+  const env = options.env ?? process.env;
+  const key = [
+    env[CLAUDE_CODE_MARKER_ENV] ?? "",
+    env[CLAUDE_CODE_SESSION_ID_ENV] ?? "",
+    env[CLAUDE_CODE_MESSAGING_SOCKET_ENV] ?? "",
+    env[CLAUDE_NATIVE_SESSIONS_DIR_ENV] ?? "",
+    String(options.startPid ?? process.pid),
+  ].join("|");
+  if (cache !== null && cache.key === key) return cache.value;
+  let value: SelfClaudeSession | null = null;
+  try {
+    value = selfClaudeSessionFromEnv(env) ?? walkToSelfClaudeSession(options);
+  } catch {
+    value = null;
+  }
+  cache = { key, value };
+  return value;
+}
+
+/** 测试用：清掉进程级缓存。 */
+export function resetSelfClaudeSessionCache(): void {
+  cache = null;
+}

--- a/cli/src/claude-session-registry.ts
+++ b/cli/src/claude-session-registry.ts
@@ -49,6 +49,11 @@ export const CLAUDE_SESSION_REGISTRY_CAPACITY = 128;
 const SESSION_ID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const DISPLAY_NAME_RE = /^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$/;
+
+/** 注册表接受的展示名形态（与 validEntry 同一把尺子；Claude 原生会话名 `agentparty-83` 天然符合）。 */
+export function isClaudeSessionDisplayName(value: unknown): value is string {
+  return typeof value === "string" && DISPLAY_NAME_RE.test(value);
+}
 const CHANNEL_RE = /^[a-z0-9][a-z0-9-]{0,63}$/;
 const ENTRY_FILE_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.json$/;
@@ -117,6 +122,16 @@ export interface ClaudeSessionRegistryEntry {
    * 目录才是权威身份；这个字段只是「目录与内容不符即丢弃」的二道防线。
    */
   harness?: SessionRegistryHarness;
+  /**
+   * 该会话绑定的 config 文件绝对路径（#1052 #2）。有了它，会话里的 `party` 命令不必再手写
+   * `AGENTPARTY_CONFIG`：config.ts 沿父进程链找到宿主 Claude pid → `<pid>.json` 的 sessionId
+   * → 本条目 → 这里的路径。**只在 pid 与 session_id 双双吻合、且文件里的 server/identity 与
+   * 条目一致时才采用**（见 config.ts readClaudeSessionConfig），任何一项对不上都当没有。
+   *
+   * 可选：旧条目没有；hook 入册时解析不出「绑过的」来源（只有全局兜底）也不写——
+   * 全局兜底不是绑定，记进来会让 #1018 的 MCP 闸把它误当成显式绑定放行。
+   */
+  config_path?: string;
 }
 
 /**
@@ -218,7 +233,12 @@ function validEntry(value: unknown): value is ClaudeSessionRegistryEntry {
     isAbsolute(value.cwd) &&
     typeof value.registered_at === "number" &&
     Number.isFinite(value.registered_at) &&
-    (value.harness === undefined || value.harness === "claude" || value.harness === "codex");
+    (value.harness === undefined || value.harness === "claude" || value.harness === "codex") &&
+    // config_path 缺席合法（旧条目 / 没绑过）；在场必须是非空绝对路径，坏值按坏行丢弃。
+    (value.config_path === undefined ||
+      (typeof value.config_path === "string" &&
+        value.config_path !== "" &&
+        isAbsolute(value.config_path)));
 }
 
 function validDirectory(path: string): string | null {
@@ -356,6 +376,51 @@ export function listCodexSessions(
 }
 
 /**
+ * 按 session_id 读**一条**仍存活的 claude 条目（#1052 #2：config 解析每条命令都要查，不必
+ * 扫整个目录）。不存在 / 坏行 / pid 已死 ⇒ null（死行留给 listSessions 顺手清）。
+ */
+export function readClaudeSessionEntry(
+  sessionId: string,
+  env: NodeJS.ProcessEnv = process.env,
+): ClaudeSessionRegistryEntry | null {
+  if (!isClaudeSessionRegistrySessionId(sessionId)) return null;
+  const directory = sessionRegistryDirectory("claude", env);
+  if (directory === null) return null;
+  const entry = readEntry(directory, `${sessionId.toLowerCase()}.json`, "claude");
+  if (entry === null || !pidAlive(entry.pid)) return null;
+  return entry;
+}
+
+/**
+ * 就地更新一条已入册 claude 会话的 display_name / config_path（#1052 #2/#6）。
+ * 只改已有条目（不存在返回 false，绝不凭空造），其余字段逐字保留；写入走 registerSession
+ * 的同一把锁与校验。传 undefined 的字段不动。
+ */
+export function patchClaudeSessionEntry(
+  sessionId: string,
+  patch: { display_name?: string | null; config_path?: string | null },
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  const entry = readClaudeSessionEntry(sessionId, env);
+  if (entry === null) return false;
+  const displayName = patch.display_name === undefined ? entry.display_name : patch.display_name;
+  const configPath = patch.config_path === undefined ? (entry.config_path ?? null) : patch.config_path;
+  if (displayName === entry.display_name && configPath === (entry.config_path ?? null)) return true;
+  return registerSession({
+    session_id: entry.session_id,
+    pid: entry.pid,
+    display_name: displayName,
+    channel: entry.channel,
+    server: entry.server ?? null,
+    identity: entry.identity ?? null,
+    cwd: entry.cwd,
+    registered_at: entry.registered_at,
+    harness: "claude",
+    config_path: configPath,
+  }, env);
+}
+
+/**
  * 入册会话在 party 侧的宣告名（#841 P2/P3、#851 共用同一权威定义，防词表漂移）：
  * 有 display_name 用 display_name，否则回退 `<harness>-<session_id 前 12 个 hex>`。
  */
@@ -394,6 +459,8 @@ export interface RegisterClaudeSessionInput {
   registered_at?: number;
   /** 省略即 claude（保持 #841 调用点逐字不变）。 */
   harness?: SessionRegistryHarness;
+  /** 该会话绑定的 config 绝对路径（#1052 #2）；省略 / null / 非绝对路径都不写。 */
+  config_path?: string | null;
 }
 
 /**
@@ -443,6 +510,9 @@ export function registerSession(
     ...(identity === null ? {} : { identity }),
     cwd: input.cwd,
     registered_at: input.registered_at ?? Date.now(),
+    ...(typeof input.config_path === "string" && input.config_path !== "" && isAbsolute(input.config_path)
+      ? { config_path: input.config_path }
+      : {}),
   };
   if (!validEntry(entry)) return false;
   const directory = sessionRegistryDirectory(harness, env, true);

--- a/cli/src/commands/claude-channel.ts
+++ b/cli/src/commands/claude-channel.ts
@@ -42,6 +42,7 @@ import {
   sessionEntryMatchesServer,
   type ClaudeSessionRegistryEntry,
 } from "../claude-session-registry";
+import { announceDisplayName } from "../claude-native-display-name";
 import { injectChannelMessage } from "../claude-inbox-inject";
 import {
   claimMentionWake,
@@ -856,7 +857,7 @@ export async function runDormantClaudeSessionAnnounce(
     const topology = deps.buildTopology(auth.server, entry.cwd, {
       harnessSession: {
         harness: "claude",
-        display_name: dormantAnnounceDisplayName(entry),
+        display_name: await announceDisplayName(entry, deps.env ?? process.env, { signal }),
       },
     });
     if (topology === undefined) return;

--- a/cli/src/commands/doctor.ts
+++ b/cli/src/commands/doctor.ts
@@ -4,7 +4,7 @@ import { lstatSync, readFileSync, realpathSync } from "node:fs";
 import { resolve } from "node:path";
 import { spawnSync } from "node:child_process";
 import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
-import { localAgentConfigsForChannel, resolveChannel } from "../config";
+import { configResolutionLabel, localAgentConfigsForChannel, readConfigWithSource, resolveChannel } from "../config";
 import { resolveAuthDetailed } from "../oidc-cli";
 import { fetchMe, fetchPresence, fetchRuntimePeers, RestError, type Identity } from "../rest";
 import { stripTerminalControls } from "../format";
@@ -784,6 +784,16 @@ export async function taskLeaseDoctorLines(
   }
 }
 
+function configResolutionDoctorLines(): string[] {
+  try {
+    const { source } = readConfigWithSource();
+    const path = source.path === null ? "none" : stripTerminalControls(source.path);
+    return [`identity: config=${path} resolved-by=${configResolutionLabel(source)}`];
+  } catch {
+    return [];
+  }
+}
+
 async function runVersionDoctor(argv: string[]): Promise<number> {
   if (argv.length > 0) {
     console.error(HELP);
@@ -795,6 +805,9 @@ async function runVersionDoctor(argv: string[]): Promise<number> {
   // #931：同理，「同一身份的第二个执行体会不会被拦住」也曾只在 stderr 有一行 warn。
   // 只在**真有第二个执行体**时报（无冲突不报，避免每次 doctor 都多一条无关噪音）。
   for (const line of await taskLeaseDoctorLines()) console.log(line);
+  // #1052 #2：身份是从哪一步解析出来的（explicit env / claude session registry / workspace /
+  // breadcrumb / global）。在 Claude 会话里跑，认出宿主会话就会显示 claude session registry。
+  for (const line of configResolutionDoctorLines()) console.log(line);
   console.log("");
   console.log(`running:   ${RUNNING_VERSION}`);
   const pending = pendingUpgrade();

--- a/cli/src/commands/hook.ts
+++ b/cli/src/commands/hook.ts
@@ -26,7 +26,9 @@ import {
   loadStuck,
   loadStuckForConfig,
   readConfig,
+  readConfigWithSource,
   readState,
+  type ConfigSourceInfo,
   type StuckWake,
 } from "../config";
 import {
@@ -63,10 +65,12 @@ import { atomicWriteJson, atomicWriteText } from "../atomic-json";
 import {
   isClaudeSessionRegistrySessionId,
   listCodexSessions,
+  readClaudeSessionEntry,
   registerClaudeSession,
   registerCodexSession,
   unregisterClaudeSession,
 } from "../claude-session-registry";
+import { syncNativeDisplayName } from "../claude-native-display-name";
 import {
   CODEX_AUTO_WAKE_ENV,
   CODEX_AUTO_WAKE_MARKER_ENV,
@@ -845,6 +849,16 @@ export function claudeSessionDisplayNameFromHookPayload(
 }
 
 /**
+ * 入册时记进条目的 config 路径（#1052 #2）：只认「绑过」的来源——显式 AGENTPARTY_CONFIG /
+ * 注册表 / cwd 面包屑（kind=explicit）与本目录 workspace config。全局兜底不是绑定：记进去会让
+ * 后续命令把它当显式绑定用，也会绕过 #1018 的 MCP 闸。
+ */
+export function boundConfigPathForRegistry(source: ConfigSourceInfo): string | null {
+  if (source.path === null) return null;
+  return source.kind === "explicit" || source.kind === "workspace" ? source.path : null;
+}
+
+/**
  * 本机会话注册表接线（issue #841 P1）：SessionStart 入册、SessionEnd 出册。
  * 严守 hook 铁律：stdout 恒空、任何失败静默、不等网络。serve 托管 lane
  * （AP_ACTIVITY_FILE 有值）不入册——那是被管理的 runner 会话，不是交互式会话。
@@ -858,9 +872,16 @@ export function recordClaudeSessionLifecycle(
 ): void {
   try {
     const event = record.hook_event_name;
-    if (event !== "SessionStart" && event !== "SessionEnd") return;
     const sessionId = record.session_id;
     if (!isClaudeSessionRegistrySessionId(sessionId)) return;
+    if (event !== "SessionStart" && event !== "SessionEnd") {
+      // #1052 #6：SessionStart 常早于 Claude 写出 `~/.claude/sessions/<pid>.json`，那一轮拿不到
+      // 原生会话名。后续每一轮 hook（每轮一个新进程）再读一次；pid 与 session_id 都对得上才写回。
+      if (env.AP_ACTIVITY_FILE) return;
+      const entry = readClaudeSessionEntry(sessionId, env);
+      if (entry !== null && entry.pid === pid) syncNativeDisplayName(entry, env);
+      return;
+    }
     if (event === "SessionEnd") {
       unregisterClaudeSession(sessionId, env);
       return;
@@ -869,6 +890,7 @@ export function recordClaudeSessionLifecycle(
     const cwd = typeof record.cwd === "string" && record.cwd.length > 0 ? record.cwd : process.cwd();
     const channel = env.AGENTPARTY_CHANNEL ?? readState(cwd)?.channel;
     if (!channel) return;
+    const bound = readConfigWithSource(cwd);
     registerClaudeSession({
       session_id: sessionId,
       pid,
@@ -883,8 +905,11 @@ export function recordClaudeSessionLifecycle(
       // #865：条目必须带实例维度——频道 slug 跨实例不唯一（两台生产实例上都有
       // `agentparty`）。取该会话绑定 config 的 server；解析不出就不写，条目随之
       // 不可匹配（宁可这一轮叫不醒，也不跨实例误投）。
-      server: readConfig(cwd)?.server ?? null,
+      server: bound.config?.server ?? null,
       cwd,
+      // #1052 #2：记下这个会话绑的 config，后续 `party` 命令沿父进程链认出宿主会话后直接用它，
+      // 不必再手写 AGENTPARTY_CONFIG。
+      config_path: boundConfigPathForRegistry(bound.source),
     }, env);
   } catch {
     // hook 铁律：注册表任何失败都不配影响模型。

--- a/cli/src/commands/join.ts
+++ b/cli/src/commands/join.ts
@@ -59,8 +59,11 @@ import {
 } from "../codex-auto-wake";
 import { defaultInstanceLockDir, isSameLiveProcess } from "../instance-lock";
 import {
+  isClaudeSessionDisplayName,
   isClaudeSessionRegistrySessionId,
   listCodexSessions,
+  readClaudeSessionEntry,
+  registerClaudeSession,
   registerCodexSession,
 } from "../claude-session-registry";
 import {
@@ -77,6 +80,7 @@ import { STEP_INDENT, runSteps, type Step, type StepResult } from "../onboarding
 import { verifyWakeRoundTrip, type VerifyWakeDeps } from "../onboarding/verify-wake";
 import { normalizeWakeLang, resolveWakeLang, type WakeLang } from "../wake-note-i18n";
 import { findHarnessAncestor } from "../join-binding";
+import { findSelfClaudeSession, type SelfClaudeSession } from "../claude-self-session";
 import {
   CLAUDE_PLUGIN_MIN_VERSION,
   inspectClaudePluginShell,
@@ -237,6 +241,11 @@ export interface JoinDeps {
   codexWakeLayerLive: () => Promise<CodexWakeLayerLiveness | null>;
   /** 跑 join 的那个 codex 进程 pid（进程祖先链）；找不到 null。用于把本会话在注册表里挂到本频道。 */
   codexAncestorPid: () => number | null;
+  /**
+   * 跑 join 的这个进程所在的 Claude 会话（#1052 #2）；不在 Claude 里 ⇒ null。可选：测试夹具不给
+   * 就不登记（绝不让单测沿真实进程链写真实注册表）。生产由 defaultJoinDeps 接 findSelfClaudeSession。
+   */
+  claudeSelfSession?: () => SelfClaudeSession | null;
   /**
    * 当前 Codex task/thread id。ChatGPT.app 的多个 task 共用同一个 app-server PID，PID 只能证明
    * 属于这批 task，不能选出眼前这个；缺失时只允许 PID 下恰好一个注册表候选。
@@ -622,6 +631,57 @@ function adoptCodexSessionForChannel(
   }
 }
 
+/**
+ * 把跑 join 的这个 Claude 会话登记到本频道，并记下它绑的 config（#1052 #2）。
+ *
+ * 会话的 SessionStart hook 入册时往往还没绑频道（条目不存在）或绑在别的频道 / 记着同目录里
+ * 上一个身份的 config；join 刚写好 per-session config，此刻是唯一知道「这个会话＝这份 config」
+ * 的时机。登记之后，本会话里的 `party` 命令不必再手写 AGENTPARTY_CONFIG（config.ts 沿父进程链
+ * 认出宿主会话 → 注册表 → config_path）。
+ *
+ * 判据全部来自 Claude 自己的寻址文件（`~/.claude/sessions/<pid>.json` 的 sessionId / name），
+ * 不是猜的；已有条目 pid 不符（pid 复用）就拒绝改写。不在 Claude 会话里 ⇒ null（一个字不说）。
+ */
+function adoptClaudeSessionForChannel(
+  deps: JoinDeps,
+  slug: string,
+  configPath: string,
+  identity: string | null,
+  server: string | null,
+): StepOutcome | null {
+  try {
+    if (deps.claudeSelfSession === undefined || process.env.AP_ACTIVITY_FILE) return null;
+    const self = deps.claudeSelfSession();
+    if (self === null) return null;
+    if (self.sessionId === null || !isClaudeSessionRegistrySessionId(self.sessionId)) {
+      return { level: "warn", msg: `Claude 寻址文件里没有合法的 sessionId（pid ${self.pid}）——没登记；本会话里跑 party 命令请带 AGENTPARTY_CONFIG=${configPath}` };
+    }
+    const existing = readClaudeSessionEntry(self.sessionId);
+    if (existing !== null && existing.pid !== self.pid) {
+      return { level: "warn", msg: `注册表里会话 ${self.sessionId} 记的 pid ${existing.pid} 与当前宿主 ${self.pid} 不符——拒绝改写` };
+    }
+    const displayName = isClaudeSessionDisplayName(self.name) ? self.name : existing?.display_name ?? null;
+    const ok = registerClaudeSession({
+      session_id: self.sessionId,
+      pid: self.pid,
+      display_name: displayName,
+      channel: slug,
+      identity,
+      server,
+      cwd: existing?.cwd ?? process.cwd(),
+      ...(existing === null ? {} : { registered_at: existing.registered_at }),
+      config_path: configPath,
+    });
+    if (!ok) return { level: "warn", msg: "会话注册表写入失败——本会话里跑 party 命令请带 AGENTPARTY_CONFIG" };
+    return {
+      level: "ok",
+      msg: `${displayName ?? `claude pid ${self.pid}`} → ${configPath}（本会话里的 party 命令不用再带 AGENTPARTY_CONFIG）`,
+    };
+  } catch (e) {
+    return { level: "warn", msg: `会话注册表更新失败：${e instanceof Error ? e.message : String(e)}` };
+  }
+}
+
 /** codex 档第 3 步：先认领本会话、再主动拉起唤醒层、再探活。三步各自失败都不抛，全部进证据。 */
 async function bringUpCodexWakeLayer(
   deps: JoinDeps,
@@ -825,6 +885,11 @@ function identityStep(harnessKnown: boolean): Step<JoinCtx> {
       }
       // claude 档：crossSessionInbound=accept（#844），否则跨会话 @ 默认 hold 会被 drop。
       if (harness === "claude") detail.push(outcomeLine("开启跨会话 @ 接收", setClaudeInboxAccept(deps)));
+      // #1052 #2：跑在 Claude 会话里就把这个会话登记到本频道并记下它绑的 config（codex 档另有 #957）。
+      if (harness !== "codex") {
+        const adopted = adoptClaudeSessionForChannel(deps, slug, configPath, identity, cfg.server);
+        if (adopted !== null) detail.push(outcomeLine("登记本会话", adopted));
+      }
       // 报到（#597）。init 只写配置不发言，必须补这一条，否则网页/频道里看不到你。能 @ 邀请人就 @。
       const sendArgs = [`👋 ${agentName} 报到，来参与协作`, "--channel", slug];
       if (opts.mention !== null) sendArgs.push("--mention", opts.mention);
@@ -1338,6 +1403,7 @@ export function defaultJoinDeps(slug: string): JoinDeps {
         config: readConfig(),
         channel: slug,
       }),
+    claudeSelfSession: () => findSelfClaudeSession(),
     codexAncestorPid: () => {
       const found = findHarnessAncestor(process.ppid);
       return found !== null && found.harness === "codex" ? found.pid : null;

--- a/cli/src/commands/whoami.ts
+++ b/cli/src/commands/whoami.ts
@@ -4,7 +4,7 @@ import { isHelpArg, parseArgs, unknownFlagError } from "../args";
 import { handleRestError, fetchMe, RestError } from "../rest";
 import { resolveAuthDetailed } from "../oidc-cli";
 import { jsonFrame, nowTs } from "../json";
-import { readConfig, resolveChannel, refreshConfigInPlace } from "../config";
+import { configResolutionLabel, readConfig, resolveChannel, refreshConfigInPlace } from "../config";
 import { cachedIdentity, statuslineIdentity, writeStatuslineCache } from "../statusline-cache";
 import { healServerUrl } from "../validation";
 import { stripTerminalControls } from "../format";
@@ -73,6 +73,7 @@ export async function run(argv: string[]): Promise<number> {
       console.log(`server: ${auth.server ?? "none (no config server and no account session)"}`);
       console.log(`account: ${auth.account.present ? `${auth.account.email ?? auth.account.sub ?? "present"} present server=${auth.account.server}` : `absent path=${terminalPath(auth.account.path)}`}`);
       console.log(`config: ${auth.config.path ? `${auth.config.kind} ${terminalPath(auth.config.path)}` : "none"}`);
+      console.log(`config-resolved-by: ${configResolutionLabel(auth.config)}`);
       console.log(`auth-source: ${auth.auth_source}`);
     }
     return 0;
@@ -147,6 +148,9 @@ export async function run(argv: string[]): Promise<number> {
         }`,
       );
       console.log(`config: ${auth.config.path ? `${auth.config.kind} ${terminalPath(auth.config.path)} token=${auth.config.token_fingerprint ?? "none"}` : "none"}`);
+      // #1052 #2：说清是哪一步解析出的身份——在 Claude 会话里不带 AGENTPARTY_CONFIG 也能认出宿主
+      // 会话绑的 config（claude session registry），排障时一眼看出用的是不是本会话的身份。
+      console.log(`config-resolved-by: ${configResolutionLabel(auth.config)}`);
       console.log(`auth-source: ${auth.auth_source}`);
       if (rejoin) {
         console.log("rejoin:");

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -20,6 +20,12 @@ import {
 } from "node:fs";
 import { atomicWriteJson } from "./atomic-json";
 import { stripTerminalControls } from "./format";
+import { findSelfClaudeSession } from "./claude-self-session";
+import {
+  readClaudeSessionEntry,
+  sessionEntryMatchesIdentity,
+  sessionEntryMatchesServer,
+} from "./claude-session-registry";
 
 export interface Config {
   server: string;
@@ -47,11 +53,46 @@ export interface CachedIdentity {
 
 export type ConfigSourceKind = "explicit" | "workspace" | "global" | "none";
 
+/**
+ * 具体是哪一步解析出了身份（#1052 #2）。`kind` 是给闸门用的粗分类（explicit/workspace 算「绑过」，
+ * global 是兜底），这里是给人看的细分：`explicit_env`＝AGENTPARTY_CONFIG；
+ * `claude_session_registry`＝沿父进程链认出宿主 Claude 会话、从注册表条目拿到它绑的 config；
+ * `breadcrumb`＝cwd state 里的绑定面包屑（kind 同为 explicit）。
+ */
+export type ConfigResolution =
+  | "explicit_env"
+  | "claude_session_registry"
+  | "workspace"
+  | "breadcrumb"
+  | "global"
+  | "none";
+
 export interface ConfigSourceInfo {
   kind: ConfigSourceKind;
   path: string | null;
   workspace_id?: string;
   token_fingerprint?: string;
+  resolution?: ConfigResolution;
+  /** resolution 为 claude_session_registry 时：认出的宿主会话（诊断用，whoami/doctor 打印）。 */
+  claude_session?: { pid: number; session_id: string };
+}
+
+const CONFIG_RESOLUTION_LABEL: Record<ConfigResolution, string> = {
+  explicit_env: "explicit env",
+  claude_session_registry: "claude session registry",
+  workspace: "workspace",
+  breadcrumb: "breadcrumb",
+  global: "global",
+  none: "none",
+};
+
+/** 人话版的解析步骤名（whoami / doctor 用）：`explicit env` / `claude session registry` / …。 */
+export function configResolutionLabel(source: Pick<ConfigSourceInfo, "kind" | "resolution" | "claude_session">): string {
+  const base = source.resolution === undefined ? source.kind : CONFIG_RESOLUTION_LABEL[source.resolution];
+  if (source.resolution === "claude_session_registry" && source.claude_session !== undefined) {
+    return `${base} (claude pid ${source.claude_session.pid}, session ${source.claude_session.session_id})`;
+  }
+  return base;
 }
 
 export interface ConfigWithSource {
@@ -313,13 +354,57 @@ export function tokenFingerprint(token: string): string {
   return `sha256:${createHash("sha256").update(token).digest("hex").slice(0, 12)}`;
 }
 
-function sourceInfo(kind: ConfigSourceKind, path: string | null, cfg: Config | null, cwd: string): ConfigSourceInfo {
+function sourceInfo(
+  kind: ConfigSourceKind,
+  path: string | null,
+  cfg: Config | null,
+  cwd: string,
+  resolution: ConfigResolution = kind === "explicit" ? "explicit_env" : kind,
+): ConfigSourceInfo {
   return {
     kind,
     path,
     ...(kind === "workspace" ? { workspace_id: workspaceId(cwd) } : {}),
     ...(cfg?.token ? { token_fingerprint: tokenFingerprint(cfg.token) } : {}),
+    resolution,
   };
+}
+
+/**
+ * 宿主 Claude 会话绑定的 config（#1052 #2）——排在「显式 AGENTPARTY_CONFIG」之后、「按 cwd 找
+ * workspace config」之前。链路：父进程链 → 宿主 pid → `~/.claude/sessions/<pid>.json` 的 sessionId
+ * → 注册表条目 → 条目的 config_path。
+ *
+ * 失败即回落（返回 null 走既有步骤），且**绝不拿到别人的 config**：
+ *   - 条目的 pid 必须等于认出的宿主 pid，session_id 必须等于寻址文件里的 sessionId（pid 复用 /
+ *     `/clear` 换会话都会让其中一项对不上）；
+ *   - config 文件里的 server 与 identity.name 必须与条目记的实例 / 频道身份一致（同一目录里
+ *     后来者覆盖了这份文件也会被识破）；
+ *   - 文件必须真有 token。
+ */
+function readClaudeSessionConfig(cwd: string, env: NodeJS.ProcessEnv = process.env): ConfigWithSource | null {
+  try {
+    const self = findSelfClaudeSession({ env });
+    if (self === null || self.sessionId === null) return null;
+    const entry = readClaudeSessionEntry(self.sessionId, env);
+    if (entry === null || entry.pid !== self.pid) return null;
+    if (entry.session_id.toLowerCase() !== self.sessionId.toLowerCase()) return null;
+    const path = entry.config_path;
+    if (path === undefined) return null;
+    const cfg = JSON.parse(readFileSync(path, "utf8")) as Config;
+    if (typeof cfg?.token !== "string" || cfg.token === "") return null;
+    if (!sessionEntryMatchesServer(entry, cfg.server)) return null;
+    if (!sessionEntryMatchesIdentity(entry, cfg.identity?.name)) return null;
+    return {
+      config: cfg,
+      source: {
+        ...sourceInfo("explicit", path, cfg, cwd, "claude_session_registry"),
+        claude_session: { pid: entry.pid, session_id: entry.session_id },
+      },
+    };
+  } catch {
+    return null;
+  }
 }
 
 function readBreadcrumbConfig(cwd: string): ConfigWithSource | null {
@@ -329,7 +414,7 @@ function readBreadcrumbConfig(cwd: string): ConfigWithSource | null {
     if (!breadcrumb) return null;
     try {
       const cfg = JSON.parse(readFileSync(breadcrumb, "utf8")) as Config;
-      return { config: cfg, source: sourceInfo("explicit", breadcrumb, cfg, cwd) };
+      return { config: cfg, source: sourceInfo("explicit", breadcrumb, cfg, cwd, "breadcrumb") };
     } catch {
       console.error(
         `warning: workspace config breadcrumb is unreadable: ${stripTerminalControls(String(breadcrumb))}; falling back to global config`,
@@ -372,7 +457,12 @@ export function readConfigWithSource(cwd: string = process.cwd()): ConfigWithSou
     return { config: null, source: missingExplicit };
   }
 
-  // 走到这里说明没有 AGENTPARTY_CONFIG，按正常 workspace → breadcrumb → global 顺序读取。
+  // 没有 AGENTPARTY_CONFIG：先看自己是不是跑在某个已入册的 Claude 会话里（#1052 #2）——
+  // 那个会话绑的 config 比 cwd 更准（同目录的两个会话各有各的）。认不出就按
+  // workspace → breadcrumb → global 顺序读取。
+  const session = readClaudeSessionConfig(cwd);
+  if (session !== null) return session;
+
   const ws = defaultWorkspaceConfigPath(cwd);
   try {
     const cfg = JSON.parse(readFileSync(ws, "utf8")) as Config;

--- a/cli/test/claude-channel-dormant-announce.test.ts
+++ b/cli/test/claude-channel-dormant-announce.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { mkdtempSync } from "node:fs";
+import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { WAKE_VERIFY_PREFIX, type ServerFrame } from "@agentparty/shared";
 import type { ClaudeSessionRegistryEntry } from "../src/claude-session-registry";
+import { CLAUDE_NATIVE_SESSIONS_DIR_ENV } from "../src/claude-inbox-inject";
 import { wakeProxyNoteFromId } from "../src/serve-wake-proxy";
 import { resetWakeLangCache } from "../src/wake-note-i18n";
 import {
@@ -140,6 +141,47 @@ function makeDeps(overrides: Partial<DormantAnnounceDeps> = {}): {
 async function tick(ms = 20): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, ms));
 }
+
+describe("announce display name = Claude native session name (#1052 #6)", () => {
+  function nativeFixture(name: string | null): NodeJS.ProcessEnv {
+    const dir = mkdtempSync(join(tmpdir(), "announce-native-sessions-"));
+    if (name !== null) {
+      writeFileSync(
+        join(dir, `${process.ppid}.json`),
+        JSON.stringify({ pid: process.ppid, sessionId: entry().session_id, name, messagingSocketPath: join(dir, "inbox.sock") }),
+        { mode: 0o600 },
+      );
+    }
+    return { [CLAUDE_NATIVE_SESSIONS_DIR_ENV]: dir };
+  }
+
+  test("announces Claude's own session name when the sessions file is readable", async () => {
+    const { deps, connections } = makeDeps({ env: nativeFixture("agentparty-83") });
+    const controller = new AbortController();
+    const run = runDormantClaudeSessionAnnounce("dev", controller.signal, deps);
+    await tick();
+    expect(connections).toHaveLength(1);
+    const opts = connections[0]!.connectArgs.opts;
+    expect((opts.runtimeTopology as { harness_session?: unknown }).harness_session).toEqual({
+      harness: "claude",
+      display_name: "agentparty-83",
+    });
+    controller.abort();
+    await run;
+  });
+
+  test("falls back to claude-<12hex> only while the native name is unavailable", async () => {
+    const { deps, connections } = makeDeps({ env: nativeFixture(null) });
+    const controller = new AbortController();
+    const run = runDormantClaudeSessionAnnounce("dev", controller.signal, deps);
+    await tick();
+    expect(connections).toHaveLength(1);
+    expect((connections[0]!.connectArgs.opts.runtimeTopology as { harness_session?: { display_name: string } }).harness_session?.display_name)
+      .toBe("claude-111111111111");
+    controller.abort();
+    await run;
+  });
+});
 
 describe("dormantAnnounceDisplayName", () => {
   test("prefers the registered name and falls back to a deterministic session-derived name", () => {

--- a/cli/test/claude-native-display-name.test.ts
+++ b/cli/test/claude-native-display-name.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { CLAUDE_NATIVE_SESSIONS_DIR_ENV } from "../src/claude-inbox-inject";
+import {
+  announceDisplayName,
+  resetAnnounceNativeNameRetries,
+  syncNativeDisplayName,
+} from "../src/claude-native-display-name";
+import {
+  CLAUDE_SESSION_REGISTRY_DIR_ENV,
+  listClaudeSessions,
+  registerClaudeSession,
+  type ClaudeSessionRegistryEntry,
+} from "../src/claude-session-registry";
+import { recordClaudeSessionLifecycle } from "../src/commands/hook";
+
+const SESSION_ID = "11111111-1111-4111-8111-111111111111";
+const OTHER_SESSION_ID = "11111111-1111-4111-8111-222222222222";
+
+let registryDir: string;
+let nativeDir: string;
+let env: NodeJS.ProcessEnv;
+let savedHome: string | undefined;
+
+beforeEach(() => {
+  registryDir = mkdtempSync(join(tmpdir(), "ap-native-name-registry-"));
+  chmodSync(registryDir, 0o700);
+  nativeDir = mkdtempSync(join(tmpdir(), "ap-native-name-sessions-"));
+  env = {
+    [CLAUDE_SESSION_REGISTRY_DIR_ENV]: registryDir,
+    [CLAUDE_NATIVE_SESSIONS_DIR_ENV]: nativeDir,
+    AGENTPARTY_CHANNEL: "dev",
+  };
+  // hook 的 config 解析走 process.env：指到临时 home，绝不让测试摸到真实 ~/.agentparty / ~/.claude。
+  savedHome = process.env.AGENTPARTY_HOME;
+  process.env.AGENTPARTY_HOME = mkdtempSync(join(tmpdir(), "ap-native-name-home-"));
+  process.env[CLAUDE_NATIVE_SESSIONS_DIR_ENV] = nativeDir;
+  resetAnnounceNativeNameRetries();
+});
+
+afterEach(() => {
+  rmSync(registryDir, { recursive: true, force: true });
+  rmSync(nativeDir, { recursive: true, force: true });
+  rmSync(process.env.AGENTPARTY_HOME!, { recursive: true, force: true });
+  if (savedHome === undefined) delete process.env.AGENTPARTY_HOME;
+  else process.env.AGENTPARTY_HOME = savedHome;
+  delete process.env[CLAUDE_NATIVE_SESSIONS_DIR_ENV];
+  resetAnnounceNativeNameRetries();
+});
+
+function writeNativeSession(name: string, fields: Record<string, unknown> = {}): void {
+  writeFileSync(
+    join(nativeDir, `${process.pid}.json`),
+    JSON.stringify({
+      pid: process.pid,
+      sessionId: SESSION_ID,
+      name,
+      messagingSocketPath: join(nativeDir, "inbox.sock"),
+      ...fields,
+    }),
+    { mode: 0o600 },
+  );
+}
+
+function register(overrides: Partial<ClaudeSessionRegistryEntry> = {}): ClaudeSessionRegistryEntry {
+  expect(registerClaudeSession({
+    session_id: SESSION_ID,
+    pid: process.pid,
+    display_name: null,
+    channel: "dev",
+    server: "https://party.example",
+    identity: "agent-a",
+    cwd: "/tmp/project",
+    registered_at: Date.now(),
+    ...overrides,
+  }, env)).toBe(true);
+  return listClaudeSessions(env)[0]!;
+}
+
+describe("syncNativeDisplayName (#1052 #6)", () => {
+  test("writes Claude's own session name into the registry once it is readable", () => {
+    const entry = register();
+    expect(syncNativeDisplayName(entry, env)).toBeNull();
+    writeNativeSession("agentparty-83");
+    expect(syncNativeDisplayName(entry, env)).toBe("agentparty-83");
+    expect(listClaudeSessions(env)[0]!.display_name).toBe("agentparty-83");
+  });
+
+  test("ignores a sessions file that belongs to another session (pid reuse) or carries an invalid name", () => {
+    const entry = register();
+    writeNativeSession("agentparty-83", { sessionId: OTHER_SESSION_ID });
+    expect(syncNativeDisplayName(entry, env)).toBeNull();
+    writeNativeSession("bad name!");
+    expect(syncNativeDisplayName(entry, env)).toBeNull();
+    expect(listClaudeSessions(env)[0]!.display_name).toBeNull();
+  });
+
+  test("follows a renamed session and leaves an already-correct entry untouched", () => {
+    const entry = register({ display_name: "old-name" });
+    writeNativeSession("new-name");
+    expect(syncNativeDisplayName(entry, env)).toBe("new-name");
+    expect(listClaudeSessions(env)[0]!.display_name).toBe("new-name");
+    const before = listClaudeSessions(env)[0]!;
+    expect(syncNativeDisplayName(before, env)).toBe("new-name");
+    expect(listClaudeSessions(env)[0]).toEqual(before);
+  });
+});
+
+describe("announceDisplayName (#1052 #6)", () => {
+  test("equals the native name when readable, retries once when it appears late, and falls back otherwise", async () => {
+    const entry = register();
+    // 已有：直接用。
+    writeNativeSession("agentparty-83");
+    expect(await announceDisplayName(entry, env, { retryDelayMs: 5 })).toBe("agentparty-83");
+
+    // 晚到：第一次读不到，重试一次后读到。
+    rmSync(join(nativeDir, `${process.pid}.json`));
+    resetAnnounceNativeNameRetries();
+    const fresh = register();
+    setTimeout(() => writeNativeSession("agentparty-84"), 10);
+    expect(await announceDisplayName(fresh, env, { retryDelayMs: 40 })).toBe("agentparty-84");
+    expect(listClaudeSessions(env)[0]!.display_name).toBe("agentparty-84");
+
+    // 一直没有：回退 claude-<12hex>，且每进程对同一会话只重试一次。
+    rmSync(join(nativeDir, `${process.pid}.json`));
+    resetAnnounceNativeNameRetries();
+    const absent = register();
+    const started = Date.now();
+    expect(await announceDisplayName(absent, env, { retryDelayMs: 30 })).toBe("claude-111111111111");
+    expect(Date.now() - started).toBeGreaterThanOrEqual(25);
+    const again = Date.now();
+    expect(await announceDisplayName(absent, env, { retryDelayMs: 30 })).toBe("claude-111111111111");
+    expect(Date.now() - again).toBeLessThan(25);
+  });
+
+  test("does not wait for a session registered long ago (Claude never wrote a name)", async () => {
+    const stale = register({ registered_at: 1_000 });
+    const started = Date.now();
+    expect(await announceDisplayName(stale, env, { retryDelayMs: 200 })).toBe("claude-111111111111");
+    expect(Date.now() - started).toBeLessThan(150);
+  });
+});
+
+describe("hook later rounds (#1052 #6)", () => {
+  test("a PreToolUse/Stop round after the sessions file appears updates display_name", () => {
+    const start = { hook_event_name: "SessionStart", session_id: SESSION_ID, cwd: "/tmp/project" };
+    recordClaudeSessionLifecycle(start, env, process.pid);
+    expect(listClaudeSessions(env)[0]!.display_name).toBeNull();
+    // 文件还没出现：后续轮读不到，保持 null。
+    recordClaudeSessionLifecycle({ hook_event_name: "PreToolUse", session_id: SESSION_ID }, env, process.pid);
+    expect(listClaudeSessions(env)[0]!.display_name).toBeNull();
+    writeNativeSession("agentparty-83");
+    recordClaudeSessionLifecycle({ hook_event_name: "PreToolUse", session_id: SESSION_ID }, env, process.pid);
+    expect(listClaudeSessions(env)[0]!.display_name).toBe("agentparty-83");
+    // Stop 轮同样会跟进改名。
+    writeNativeSession("agentparty-84");
+    recordClaudeSessionLifecycle({ hook_event_name: "Stop", session_id: SESSION_ID }, env, process.pid);
+    expect(listClaudeSessions(env)[0]!.display_name).toBe("agentparty-84");
+  });
+
+  test("a later round from a different pid, a serve-managed lane, or an unregistered session changes nothing", () => {
+    recordClaudeSessionLifecycle({ hook_event_name: "SessionStart", session_id: SESSION_ID, cwd: "/tmp/project" }, env, process.pid);
+    writeNativeSession("agentparty-83");
+    recordClaudeSessionLifecycle({ hook_event_name: "PreToolUse", session_id: SESSION_ID }, env, process.pid + 1);
+    expect(listClaudeSessions(env)[0]!.display_name).toBeNull();
+    recordClaudeSessionLifecycle(
+      { hook_event_name: "PreToolUse", session_id: SESSION_ID },
+      { ...env, AP_ACTIVITY_FILE: "/tmp/activity.json" },
+      process.pid,
+    );
+    expect(listClaudeSessions(env)[0]!.display_name).toBeNull();
+    expect(() => recordClaudeSessionLifecycle(
+      { hook_event_name: "PreToolUse", session_id: OTHER_SESSION_ID },
+      env,
+      process.pid,
+    )).not.toThrow();
+    expect(listClaudeSessions(env)).toHaveLength(1);
+  });
+});

--- a/cli/test/claude-self-session.test.ts
+++ b/cli/test/claude-self-session.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { CLAUDE_NATIVE_SESSIONS_DIR_ENV } from "../src/claude-inbox-inject";
+import {
+  SELF_CLAUDE_SESSION_MAX_HOPS,
+  findSelfClaudeSession,
+  resetSelfClaudeSessionCache,
+  selfClaudeSessionFromEnv,
+  walkToSelfClaudeSession,
+} from "../src/claude-self-session";
+
+const SESSION_ID = "11111111-1111-4111-8111-111111111111";
+
+let dir: string;
+let env: NodeJS.ProcessEnv;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "ap-self-claude-"));
+  env = { [CLAUDE_NATIVE_SESSIONS_DIR_ENV]: dir, CLAUDECODE: "1" };
+  resetSelfClaudeSessionCache();
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+  resetSelfClaudeSessionCache();
+});
+
+function writeNativeSession(pid: number, fields: Record<string, unknown> = {}): void {
+  writeFileSync(
+    join(dir, `${pid}.json`),
+    JSON.stringify({
+      pid,
+      sessionId: SESSION_ID,
+      name: "agentparty-83",
+      messagingSocketPath: join(dir, `${pid}.sock`),
+      ...fields,
+    }),
+    { mode: 0o600 },
+  );
+}
+
+/** 假 `ps -o ppid= -p <pid>`：按给定的 pid→ppid 表作答；不在表里 ⇒ 非 0 退出。 */
+function fakePs(tree: Record<number, number>, calls: number[] = []) {
+  return ((_cmd: string, args: readonly string[]) => {
+    const pid = Number(args[args.length - 1]);
+    calls.push(pid);
+    const parent = tree[pid];
+    if (parent === undefined) return { status: 1, stdout: "", stderr: "" };
+    return { status: 0, stdout: `${parent}\n`, stderr: "" };
+  }) as unknown as typeof import("node:child_process").spawnSync;
+}
+
+describe("walkToSelfClaudeSession (#1052 #2)", () => {
+  test("walks past the intermediate shell to the first ancestor with a native sessions file", () => {
+    // party(100) → zsh(200) → claude(process.pid) → launchd(1)
+    writeNativeSession(process.pid);
+    const calls: number[] = [];
+    const found = walkToSelfClaudeSession({ env, startPid: 100, spawn: fakePs({ 100: 200, 200: process.pid, [process.pid]: 1 }, calls) });
+    expect(found).toEqual({ pid: process.pid, sessionId: SESSION_ID, name: "agentparty-83", hops: 2 });
+    // 第一跳（ppid）没有寻址文件，必须继续往上走——只看 process.ppid 是错的。
+    expect(calls).toEqual([100, 200]);
+  });
+
+  test("returns null at the root, on ps failure, and beyond the hop budget", () => {
+    writeNativeSession(process.pid);
+    expect(walkToSelfClaudeSession({ env, startPid: 100, spawn: fakePs({ 100: 200, 200: 1 }) })).toBeNull();
+    expect(walkToSelfClaudeSession({ env, startPid: 100, spawn: fakePs({}) })).toBeNull();
+    // 宿主在第 11 层：超出预算 ⇒ null（绝不无限往上爬）。
+    const tree: Record<number, number> = {};
+    let pid = 100;
+    for (let hop = 1; hop <= SELF_CLAUDE_SESSION_MAX_HOPS; hop += 1) {
+      tree[pid] = pid + 1;
+      pid += 1;
+    }
+    tree[pid] = process.pid;
+    expect(walkToSelfClaudeSession({ env, startPid: 100, spawn: fakePs(tree) })).toBeNull();
+    expect(walkToSelfClaudeSession({ env, startPid: 100, spawn: fakePs(tree), maxHops: SELF_CLAUDE_SESSION_MAX_HOPS + 1 })?.pid).toBe(process.pid);
+  });
+
+  test("does not spawn ps at all when no native sessions file exists or outside a Claude process tree", () => {
+    const calls: number[] = [];
+    expect(walkToSelfClaudeSession({ env, startPid: 100, spawn: fakePs({ 100: process.pid }, calls) })).toBeNull();
+    expect(calls).toEqual([]);
+    writeNativeSession(process.pid);
+    // 没有 CLAUDECODE 标记＝终端 / serve runner：不爬。
+    expect(walkToSelfClaudeSession({ env: { ...env, CLAUDECODE: undefined }, startPid: 100, spawn: fakePs({ 100: process.pid }, calls) })).toBeNull();
+    expect(calls).toEqual([]);
+  });
+
+  test("a malformed sessions file on the ancestor yields null instead of guessing further up", () => {
+    // 文件名 pid 与内容 pid 不符 → 坏文件；祖父有好文件也不该被认领（那是别的会话）。
+    writeNativeSession(200, { pid: 201 });
+    writeNativeSession(300);
+    expect(walkToSelfClaudeSession({ env, startPid: 100, spawn: fakePs({ 100: 200, 200: 300, 300: 1 }) })).toBeNull();
+  });
+
+  test("findSelfClaudeSession caches per process and never throws", () => {
+    writeNativeSession(process.pid);
+    const calls: number[] = [];
+    const spawn = fakePs({ 100: process.pid, [process.pid]: 1 }, calls);
+    expect(findSelfClaudeSession({ env, startPid: 100, spawn })?.pid).toBe(process.pid);
+    expect(findSelfClaudeSession({ env, startPid: 100, spawn })?.pid).toBe(process.pid);
+    expect(calls).toEqual([100]);
+    const throwing = (() => {
+      throw new Error("boom");
+    }) as unknown as typeof import("node:child_process").spawnSync;
+    resetSelfClaudeSessionCache();
+    expect(findSelfClaudeSession({ env, startPid: 100, spawn: throwing })).toBeNull();
+  });
+
+  test("env fast path: complete and consistent CLAUDE_CODE_* variables resolve the host with zero ps spawns", () => {
+    writeNativeSession(process.pid);
+    const calls: number[] = [];
+    const envWithVars = {
+      ...env,
+      CLAUDE_CODE_SESSION_ID: SESSION_ID,
+      CLAUDE_CODE_MESSAGING_SOCKET: join(dir, `${process.pid}.sock`),
+    };
+    expect(selfClaudeSessionFromEnv(envWithVars)).toEqual({ pid: process.pid, sessionId: SESSION_ID, name: "agentparty-83", hops: 0 });
+    // 走 findSelfClaudeSession：ps 桩绝不能被问到（哪怕它能答）。
+    expect(findSelfClaudeSession({ env: envWithVars, startPid: 100, spawn: fakePs({ 100: process.pid }, calls) })?.hops).toBe(0);
+    expect(calls).toEqual([]);
+  });
+
+  test("env fast path: a stale or inconsistent environment is ignored and the ps walk answers instead", () => {
+    writeNativeSession(process.pid);
+    const socket = join(dir, `${process.pid}.sock`);
+    // sessionId 不一致（/clear 换会话、继承来的旧环境）。
+    expect(selfClaudeSessionFromEnv({ ...env, CLAUDE_CODE_SESSION_ID: "22222222-2222-4222-8222-222222222222", CLAUDE_CODE_MESSAGING_SOCKET: socket })).toBeNull();
+    // socket 路径不一致。
+    expect(selfClaudeSessionFromEnv({ ...env, CLAUDE_CODE_SESSION_ID: SESSION_ID, CLAUDE_CODE_MESSAGING_SOCKET: join(dir, `${process.pid}.other.sock`) })).toBeNull();
+    // socket 文件名不是 <pid>.sock / 相对路径 / 变量缺一个。
+    expect(selfClaudeSessionFromEnv({ ...env, CLAUDE_CODE_SESSION_ID: SESSION_ID, CLAUDE_CODE_MESSAGING_SOCKET: "/tmp/cc-socks/x.sock" })).toBeNull();
+    expect(selfClaudeSessionFromEnv({ ...env, CLAUDE_CODE_SESSION_ID: SESSION_ID, CLAUDE_CODE_MESSAGING_SOCKET: "cc-socks/1.sock" })).toBeNull();
+    expect(selfClaudeSessionFromEnv({ ...env, CLAUDE_CODE_SESSION_ID: SESSION_ID })).toBeNull();
+    expect(selfClaudeSessionFromEnv({ ...env, CLAUDE_CODE_MESSAGING_SOCKET: socket })).toBeNull();
+    // 不一致 ⇒ 回落到 ps 链，由真实祖先给答案（这里父进程链上是 process.pid 持有文件）。
+    const calls: number[] = [];
+    const found = findSelfClaudeSession({
+      env: { ...env, CLAUDE_CODE_SESSION_ID: "22222222-2222-4222-8222-222222222222", CLAUDE_CODE_MESSAGING_SOCKET: socket },
+      startPid: 100,
+      spawn: fakePs({ 100: 200, 200: process.pid }, calls),
+    });
+    expect(found).toEqual({ pid: process.pid, sessionId: SESSION_ID, name: "agentparty-83", hops: 2 });
+    expect(calls).toEqual([100, 200]);
+  });
+
+  test("the real ps walk finds a real ancestor that owns a sessions file", () => {
+    // bun test 自己扮演宿主：从本进程往上走一跳就是它自己的父进程，所以把寻址文件写给 process.pid，
+    // 起点用一个「假想子进程」——startPid=process.pid 的第一跳是 process.ppid，不含自己；
+    // 因此这里以本进程为起点写父进程的文件，验证真 `ps` 能解析出 ppid。
+    writeNativeSession(process.ppid);
+    const found = walkToSelfClaudeSession({ env });
+    expect(found?.pid).toBe(process.ppid);
+    expect(found?.hops).toBe(1);
+  });
+});

--- a/cli/test/claude-session-registry.test.ts
+++ b/cli/test/claude-session-registry.test.ts
@@ -20,6 +20,8 @@ import {
   registerClaudeSession,
   normalizeSessionRegistryIdentity,
   normalizeSessionRegistryServer,
+  patchClaudeSessionEntry,
+  readClaudeSessionEntry,
   registerSession,
   resolveSessionRegistryIdentity,
   sessionEntryMatchesIdentity,
@@ -190,6 +192,66 @@ describe("claude session registry", () => {
     expect(listClaudeSessions(env)).toHaveLength(1);
     // 注册完成后锁已释放。
     expect(readdirSync(directory)).toEqual([`${SESSION_ID}.json`]);
+  });
+});
+
+describe("config_path (#1052 #2)", () => {
+  test("round-trips an absolute config_path and drops rows with a bad one", () => {
+    expect(registerClaudeSession(baseEntry({ config_path: "/tmp/agents/a-dev.json" }), env)).toBe(true);
+    expect(listClaudeSessions(env)[0]!.config_path).toBe("/tmp/agents/a-dev.json");
+    expect(readClaudeSessionEntry(SESSION_ID, env)?.config_path).toBe("/tmp/agents/a-dev.json");
+    // 相对路径 / 空串不写（条目照常入册，只是没有 config_path）。
+    expect(registerClaudeSession(baseEntry({ config_path: "relative.json" }), env)).toBe(true);
+    expect(listClaudeSessions(env)[0]!.config_path).toBeUndefined();
+    // 盘上被写坏的 config_path 按坏行丢弃，不退化成「无 config_path」。
+    writeFileSync(
+      join(directory, `${SESSION_ID}.json`),
+      JSON.stringify({ ...listClaudeSessions(env)[0]!, config_path: "../evil.json" }),
+      { mode: 0o600 },
+    );
+    expect(listClaudeSessions(env)).toHaveLength(0);
+  });
+
+  test("patchClaudeSessionEntry updates only display_name / config_path of an existing entry", () => {
+    expect(patchClaudeSessionEntry(SESSION_ID, { display_name: "x" }, env)).toBe(false);
+    expect(registerClaudeSession(baseEntry({ server: "https://party.example", identity: "agent-a" }), env)).toBe(true);
+    const before = listClaudeSessions(env)[0]!;
+    expect(patchClaudeSessionEntry(SESSION_ID, { config_path: "/tmp/agents/a-dev.json" }, env)).toBe(true);
+    expect(listClaudeSessions(env)[0]).toEqual({ ...before, config_path: "/tmp/agents/a-dev.json" });
+    expect(patchClaudeSessionEntry(SESSION_ID, { display_name: "agentparty-83" }, env)).toBe(true);
+    expect(listClaudeSessions(env)[0]).toEqual({ ...before, config_path: "/tmp/agents/a-dev.json", display_name: "agentparty-83" });
+    expect(patchClaudeSessionEntry(SESSION_ID, { config_path: null }, env)).toBe(true);
+    expect(listClaudeSessions(env)[0]!.config_path).toBeUndefined();
+    expect(readClaudeSessionEntry("../evil", env)).toBeNull();
+  });
+
+  test("SessionStart records the bound config path (explicit env) but never the global fallback", () => {
+    const home = mkdtempSync(join(tmpdir(), "ap-registry-home-"));
+    const savedHome = process.env.AGENTPARTY_HOME;
+    const savedConfig = process.env.AGENTPARTY_CONFIG;
+    const savedNative = process.env.AGENTPARTY_CLAUDE_NATIVE_SESSIONS_DIR;
+    try {
+      process.env.AGENTPARTY_HOME = home;
+      process.env.AGENTPARTY_CLAUDE_NATIVE_SESSIONS_DIR = directory;
+      const hookEnv = { ...env, AGENTPARTY_CHANNEL: "dev", AGENTPARTY_CLAUDE_NATIVE_SESSIONS_DIR: directory };
+      const payload = { hook_event_name: "SessionStart", session_id: SESSION_ID, cwd: "/tmp/project" };
+      // 全局兜底：不记（记了会让后续命令把兜底当显式绑定，也绕过 #1018 的 MCP 闸）。
+      writeFileSync(join(home, "config.json"), JSON.stringify({ server: "https://party.example", token: "t", identity: { name: "agent-g" } }));
+      delete process.env.AGENTPARTY_CONFIG;
+      recordClaudeSessionLifecycle(payload, hookEnv, process.pid);
+      expect(listClaudeSessions(env)[0]!.config_path).toBeUndefined();
+      // 显式 AGENTPARTY_CONFIG：记下来。
+      const explicit = join(home, "agent-a-dev.json");
+      writeFileSync(explicit, JSON.stringify({ server: "https://party.example", token: "t", identity: { name: "agent-a" } }));
+      process.env.AGENTPARTY_CONFIG = explicit;
+      recordClaudeSessionLifecycle(payload, hookEnv, process.pid);
+      expect(listClaudeSessions(env)[0]).toMatchObject({ config_path: explicit, server: "https://party.example", identity: "agent-a" });
+    } finally {
+      if (savedHome === undefined) delete process.env.AGENTPARTY_HOME; else process.env.AGENTPARTY_HOME = savedHome;
+      if (savedConfig === undefined) delete process.env.AGENTPARTY_CONFIG; else process.env.AGENTPARTY_CONFIG = savedConfig;
+      if (savedNative === undefined) delete process.env.AGENTPARTY_CLAUDE_NATIVE_SESSIONS_DIR; else process.env.AGENTPARTY_CLAUDE_NATIVE_SESSIONS_DIR = savedNative;
+      rmSync(home, { recursive: true, force: true });
+    }
   });
 });
 

--- a/cli/test/config-claude-session-identity.test.ts
+++ b/cli/test/config-claude-session-identity.test.ts
@@ -1,0 +1,211 @@
+// #1052 #2：在 Claude 会话里跑 `party` 不必再手写 AGENTPARTY_CONFIG——config 解析沿父进程链认出
+// 宿主会话，从注册表条目拿到它绑的 config。这里用真实子进程验证真实的 pid 爬链：
+//   bun(party) → sh（中间 shell，模拟 Claude 的 Bash 工具）→ sh（扮演 Claude 本体，持有寻址文件）
+// 只看 process.ppid 会停在中间 shell 上（没有寻址文件）——这正是要钉死的错法。
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { CLAUDE_NATIVE_SESSIONS_DIR_ENV } from "../src/claude-inbox-inject";
+import {
+  CLAUDE_SESSION_REGISTRY_DIR_ENV,
+  registerClaudeSession,
+} from "../src/claude-session-registry";
+import { workspaceId } from "../src/config";
+
+const indexPath = join(import.meta.dir, "..", "src", "index.ts");
+const SESSION_A = "11111111-1111-4111-8111-aaaaaaaaaaaa";
+const SESSION_B = "11111111-1111-4111-8111-bbbbbbbbbbbb";
+
+let home: string;
+let registryDir: string;
+let nativeDir: string;
+let cwd: string;
+let rest: ReturnType<typeof Bun.serve>;
+let server: string;
+const tokens = new Map<string, string>();
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "ap-session-identity-home-"));
+  registryDir = join(home, "claude-sessions");
+  mkdirSync(registryDir, { mode: 0o700 });
+  chmodSync(registryDir, 0o700);
+  nativeDir = mkdtempSync(join(tmpdir(), "ap-session-identity-native-"));
+  cwd = mkdtempSync(join(tmpdir(), "ap-session-identity-cwd-"));
+  tokens.clear();
+  // 假服务端：按 bearer token 回答 /api/me，whoami 就能在无网络下证明「用的是哪份 config」。
+  rest = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch(req) {
+      const auth = req.headers.get("authorization") ?? "";
+      const name = tokens.get(auth.replace(/^Bearer\s+/i, ""));
+      if (name === undefined) return Response.json({ error: "unauthorized" }, { status: 401 });
+      return Response.json({ name, email: null, kind: "agent", role: "agent", owner: "owner", channel_scope: "dev" });
+    },
+  });
+  server = `http://127.0.0.1:${rest.port}`;
+});
+
+afterEach(() => {
+  rest.stop(true);
+  for (const dir of [home, nativeDir, cwd]) rmSync(dir, { recursive: true, force: true });
+});
+
+const env = (): Record<string, string | undefined> => ({
+  AGENTPARTY_HOME: home,
+  // Claude 给子进程树打的标记；CI 里 bun test 不在 Claude 下跑，得显式给。
+  CLAUDECODE: "1",
+  [CLAUDE_SESSION_REGISTRY_DIR_ENV]: registryDir,
+  [CLAUDE_NATIVE_SESSIONS_DIR_ENV]: nativeDir,
+});
+
+function writeAgentConfig(name: string, token: string): string {
+  const path = join(home, "agents", `${name}-dev.json`);
+  mkdirSync(join(home, "agents"), { recursive: true });
+  writeFileSync(path, JSON.stringify({ server, token, identity: { name, channel_scope: "dev", owner: "owner" } }), { mode: 0o600 });
+  tokens.set(token, name);
+  return path;
+}
+
+/** 起一个「假 Claude」进程：先睡一会儿让测试写好寻址文件与注册表，再经中间 shell 跑 party。 */
+function spawnFakeClaude(args: string, extraEnv: Record<string, string | undefined> = {}) {
+  const childEnv: Record<string, string | undefined> = {
+    ...process.env,
+    ...env(),
+    AGENTPARTY_CONFIG: undefined,
+    // 本测试钉的是 ps 父进程链；bun test 若在真 Claude 会话下跑，会继承这两个变量（环境变量快路），删掉。
+    CLAUDE_CODE_SESSION_ID: undefined,
+    CLAUDE_CODE_MESSAGING_SOCKET: undefined,
+    ...extraEnv,
+  };
+  for (const key of Object.keys(childEnv)) if (childEnv[key] === undefined) delete childEnv[key];
+  const inner = `bun run '${indexPath}' ${args}; :`;
+  return Bun.spawn(["sh", "-c", `sleep 0.6; sh -c "${inner.replaceAll('"', '\\"')}"; :`], {
+    cwd,
+    env: childEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+}
+
+function writeNativeSession(pid: number, sessionId: string, name: string): void {
+  writeFileSync(
+    join(nativeDir, `${pid}.json`),
+    JSON.stringify({ pid, sessionId, name, messagingSocketPath: join(nativeDir, `${pid}.sock`) }),
+    { mode: 0o600 },
+  );
+}
+
+function registerEntry(pid: number, sessionId: string, identity: string, configPath: string): void {
+  expect(registerClaudeSession({
+    session_id: sessionId,
+    pid,
+    display_name: null,
+    channel: "dev",
+    server,
+    identity,
+    cwd,
+    config_path: configPath,
+  }, { [CLAUDE_SESSION_REGISTRY_DIR_ENV]: registryDir })).toBe(true);
+}
+
+async function finish(proc: ReturnType<typeof Bun.spawn>) {
+  const [code, stdout, stderr] = await Promise.all([
+    proc.exited,
+    new Response(proc.stdout as ReadableStream).text(),
+    new Response(proc.stderr as ReadableStream).text(),
+  ]);
+  const line = stdout.split("\n").find((l) => l.startsWith("{"));
+  return { code, stdout, stderr, json: line === undefined ? null : (JSON.parse(line) as Record<string, any>) };
+}
+
+describe("identity auto-detection inside a Claude session (#1052 #2)", () => {
+  test("a party command whose ancestor chain contains the Claude pid resolves the per-session config with no env var", async () => {
+    // cwd 里放一份 workspace config（另一身份）：注册表那步必须排在「按 cwd 找 workspace」前面。
+    const workspacePath = join(home, "state", workspaceId(cwd), "config.json");
+    mkdirSync(join(workspacePath, ".."), { recursive: true });
+    tokens.set("tok-cwd", "agent-cwd");
+    writeFileSync(workspacePath, JSON.stringify({ server, token: "tok-cwd", identity: { name: "agent-cwd", channel_scope: "dev" } }));
+    const probe = await finish(spawnFakeClaude("whoami --json"));
+    expect(probe.json?.runtime?.name).toBe("agent-cwd");
+    expect(probe.json?.config?.resolution).toBe("workspace");
+
+    const configA = writeAgentConfig("agent-a", "tok-a");
+    const claude = spawnFakeClaude("whoami --json");
+    writeNativeSession(claude.pid, SESSION_A, "agentparty-83");
+    registerEntry(claude.pid, SESSION_A, "agent-a", configA);
+    const result = await finish(claude);
+    expect(result.code).toBe(0);
+    expect(result.json?.runtime?.name).toBe("agent-a");
+    expect(result.json?.config?.resolution).toBe("claude_session_registry");
+    expect(result.json?.config?.path).toBe(configA);
+    // 认出的宿主必须是最外层那个 sh（持有寻址文件的假 Claude），不是中间 shell。
+    expect(result.json?.config?.claude_session).toEqual({ pid: claude.pid, session_id: SESSION_A });
+  }, 20_000);
+
+  test("two sessions in the same cwd resolve to their own configs", async () => {
+    const configA = writeAgentConfig("agent-a", "tok-a");
+    const configB = writeAgentConfig("agent-b", "tok-b");
+    const claudeA = spawnFakeClaude("whoami --json");
+    const claudeB = spawnFakeClaude("whoami --json");
+    writeNativeSession(claudeA.pid, SESSION_A, "agentparty-83");
+    writeNativeSession(claudeB.pid, SESSION_B, "agentparty-84");
+    registerEntry(claudeA.pid, SESSION_A, "agent-a", configA);
+    registerEntry(claudeB.pid, SESSION_B, "agent-b", configB);
+    const [a, b] = await Promise.all([finish(claudeA), finish(claudeB)]);
+    expect(a.json?.runtime?.name).toBe("agent-a");
+    expect(a.json?.config?.path).toBe(configA);
+    expect(b.json?.runtime?.name).toBe("agent-b");
+    expect(b.json?.config?.path).toBe(configB);
+  }, 20_000);
+
+  test("a stale registry entry (sessionId or pid mismatch) is ignored and resolution falls through", async () => {
+    const configA = writeAgentConfig("agent-a", "tok-a");
+    // 寻址文件说这个 pid 现在是会话 B；注册表里 B 没条目、A 的条目记的是同一 pid → 绝不采用 A。
+    const claude = spawnFakeClaude("whoami --json");
+    writeNativeSession(claude.pid, SESSION_B, "agentparty-83");
+    registerEntry(claude.pid, SESSION_A, "agent-a", configA);
+    const result = await finish(claude);
+    expect(result.json?.config?.resolution).not.toBe("claude_session_registry");
+    expect(result.json?.runtime?.name ?? null).not.toBe("agent-a");
+
+    // pid 对不上（条目记的是另一个活着的 pid——这里用 bun test 自己）同样不认。
+    const other = spawnFakeClaude("whoami --json");
+    writeNativeSession(other.pid, SESSION_B, "agentparty-84");
+    registerEntry(process.pid, SESSION_B, "agent-a", configA);
+    const second = await finish(other);
+    expect(second.json?.config?.resolution).not.toBe("claude_session_registry");
+
+    // config 内容被同目录后来者覆盖成另一身份：identity 与条目不符 → 不认。
+    const swapped = spawnFakeClaude("whoami --json");
+    writeNativeSession(swapped.pid, SESSION_A, "agentparty-85");
+    registerEntry(swapped.pid, SESSION_A, "agent-a", configA);
+    tokens.set("tok-b", "agent-b");
+    writeFileSync(configA, JSON.stringify({ server, token: "tok-b", identity: { name: "agent-b", channel_scope: "dev" } }));
+    const third = await finish(swapped);
+    expect(third.json?.config?.resolution).not.toBe("claude_session_registry");
+  }, 30_000);
+
+  test("explicit AGENTPARTY_CONFIG still wins over the registry", async () => {
+    const configA = writeAgentConfig("agent-a", "tok-a");
+    const configExplicit = writeAgentConfig("agent-explicit", "tok-explicit");
+    const claude = spawnFakeClaude("whoami --json", { AGENTPARTY_CONFIG: configExplicit });
+    writeNativeSession(claude.pid, SESSION_A, "agentparty-83");
+    registerEntry(claude.pid, SESSION_A, "agent-a", configA);
+    const result = await finish(claude);
+    expect(result.json?.runtime?.name).toBe("agent-explicit");
+    expect(result.json?.config?.resolution).toBe("explicit_env");
+    expect(result.json?.config?.path).toBe(configExplicit);
+  }, 20_000);
+
+  test("whoami prints the resolution step for humans", async () => {
+    const configA = writeAgentConfig("agent-a", "tok-a");
+    const claude = spawnFakeClaude("whoami");
+    writeNativeSession(claude.pid, SESSION_A, "agentparty-83");
+    registerEntry(claude.pid, SESSION_A, "agent-a", configA);
+    const result = await finish(claude);
+    expect(result.stdout).toContain("runtime: logged in as agent-a");
+    expect(result.stdout).toContain(`config-resolved-by: claude session registry (claude pid ${claude.pid}, session ${SESSION_A})`);
+  }, 20_000);
+});

--- a/cli/test/join.test.ts
+++ b/cli/test/join.test.ts
@@ -26,7 +26,7 @@ import { healServerUrl } from "../src/validation";
 import { RUNNING_VERSION } from "../src/upgrade";
 import { codexAutoWakeAuth, codexAutoWakeMarkerPath, codexAutoWakeTarget, writeCodexAutoWakeMarker } from "../src/codex-auto-wake";
 import { currentProcessStartedAt, instanceLockTarget } from "../src/instance-lock";
-import { listCodexSessions, registerClaudeSession, registerCodexSession } from "../src/claude-session-registry";
+import { listClaudeSessions, listCodexSessions, registerClaudeSession, registerCodexSession } from "../src/claude-session-registry";
 import { startRestMock, type RestMock } from "./rest-mock";
 import { PLUGIN, baseJoinOpts, fixLine, joinDeps, joinEnv, stepLine, type SpawnBehavior } from "./join-fixture";
 
@@ -794,6 +794,53 @@ describe("party join claude 档 —— 武装监听闸（#979）", () => {
   function lockFileFor(lockDir: string, server: string, token: string): string {
     return join(lockDir, `serve-${instanceLockTarget(healServerUrl(server)!, token, "dev")}.lock`);
   }
+
+  test("在 Claude 会话里跑 join ⇒ 本会话登记到频道并记下 config_path（#1052 #2），原生名进 display_name", async () => {
+    mock = startRestMock();
+    const sessionId = "019f95e8-2c0b-7903-8779-cd102c5ecd4e";
+    // SessionStart 时挂在别的频道、没名字、没 config_path——join 之后必须全部对齐到本频道。
+    expect(registerClaudeSession({
+      session_id: sessionId,
+      pid: process.pid,
+      display_name: null,
+      channel: "elsewhere",
+      identity: null,
+      server: mock.url,
+      cwd: process.cwd(),
+      registered_at: 12_345,
+    })).toBe(true);
+    const record: string[][] = [];
+    const logs: string[] = [];
+    const d = deps(record, {}, logs);
+    d.claudeSelfSession = () => ({ pid: process.pid, sessionId, name: "agentparty-83", hops: 2 });
+    await runJoin(baseOpts({ harnessFlag: "claude" }), d);
+    const entry = listClaudeSessions().find((candidate) => candidate.session_id === sessionId);
+    expect(entry).toMatchObject({
+      pid: process.pid,
+      channel: "dev",
+      identity: "agent", // mock /api/me 的身份
+      display_name: "agentparty-83",
+      config_path: configPath(),
+      registered_at: 12_345,
+    });
+    expect(logs.join("\n")).toContain("登记本会话");
+
+    // pid 不符（条目属于别的宿主）⇒ 拒绝改写，条目原样。
+    const before = listClaudeSessions().find((candidate) => candidate.session_id === sessionId)!;
+    const logs2: string[] = [];
+    const d2 = deps([], {}, logs2);
+    d2.claudeSelfSession = () => ({ pid: process.pid + 1, sessionId, name: "agentparty-84", hops: 2 });
+    await runJoin(baseOpts({ harnessFlag: "claude" }), d2);
+    expect(listClaudeSessions().find((candidate) => candidate.session_id === sessionId)).toEqual(before);
+    expect(logs2.join("\n")).toContain("拒绝改写");
+
+    // 不在 Claude 会话里（探测为 null）⇒ 一个字不说，也不动注册表。
+    const logs3: string[] = [];
+    const d3 = deps([], {}, logs3);
+    d3.claudeSelfSession = () => null;
+    await runJoin(baseOpts({ harnessFlag: "claude" }), d3);
+    expect(logs3.join("\n")).not.toContain("登记本会话");
+  });
 
   test("只有蛰伏档 claude-channel 进程 ⇒ 不印 ✅、不说「就能被唤醒」，两条命令原样印出，并说清本机 N 个会话全是蛰伏档", async () => {
     mock = startRestMock();

--- a/docs/cross-session-internals.md
+++ b/docs/cross-session-internals.md
@@ -278,3 +278,38 @@ events are malformed envelopes and also exit 2 instead of falling through as no-
 `PostToolBatch` events from the previous session cannot read, clear, or consume the new session's chain.
 All three state transitions share the consume lock and recheck the armed session while holding it, so a
 re-arm between an optimistic check and lock acquisition cannot revive the previous session's event.
+
+## Identity inside a Claude session
+
+`party` resolves its identity config in this order; `party whoami` prints the winning step as
+`config-resolved-by`, `party doctor` as `resolved-by`, and `whoami --json` as `config.resolution`:
+
+1. `explicit env` — `AGENTPARTY_CONFIG` (or the global `--config` flag). Fail-closed: when that file and
+   its durable mirror are both unreadable, no other source is substituted.
+2. `claude session registry` — only inside a Claude Code process tree (Claude sets `CLAUDECODE` for
+   every child). `party` first reads Claude's own `CLAUDE_CODE_SESSION_ID` and
+   `CLAUDE_CODE_MESSAGING_SOCKET` (`/tmp/cc-socks/<pid>.sock`), takes the pid from the socket name, and
+   accepts it only when `~/.claude/sessions/<pid>.json` carries exactly that `sessionId` and
+   `messagingSocketPath` and the pid is alive — a stale inherited environment (serve runner, nested
+   shell, a session replaced by `/clear`) fails that check. This path spawns nothing. Without those
+   variables (older Claude Code, or not under the Bash tool) it walks its parent-process chain (at most
+   10 hops of `ps -o ppid=`; `process.ppid` alone is the intermediate shell, not Claude) to the first
+   ancestor that owns `~/.claude/sessions/<pid>.json` and reads that file's `sessionId`. Either way it
+   then looks up the local session registry entry for that `sessionId`. The entry's `config_path` is used only when the entry's `pid` equals that
+   ancestor, its `session_id` equals the file's `sessionId`, and the config file's `server` and
+   `identity.name` still match what the entry recorded. Any mismatch or error falls through; this step
+   never selects another session's config. `config_path` is written by the `SessionStart` hook from a
+   bound source (explicit or workspace, never the global fallback) and by `party join` / `party recover`
+   when they run inside the session. The walk runs once per process and never runs outside Claude.
+3. `workspace` — the cwd-keyed config written by `party init` / `party join`.
+4. `breadcrumb` — the cwd state's binding pointer.
+5. `global` — `~/.agentparty/config.json`.
+
+Display names come from Claude's sessions file. A registry entry's `display_name` is Claude's own
+`name` from `~/.claude/sessions/<pid>.json` (for example `agentparty-83`) — the same name Claude's
+`ListAgents` shows, minus the bracketed `[ref]`, which AgentParty cannot derive and does not invent.
+`SessionStart` often runs before Claude writes that file, so every later hook round (`PreToolUse`,
+`Stop`, …) re-reads it once and updates the entry, and the dormant announce re-reads it once (with one
+short retry for a freshly registered session) before publishing `harness_session.display_name`. The
+`claude-<12hex>` fallback appears only while the native name is unavailable. `party who`, `party agents`,
+the `party_channel_peers` `claude_sessions[].display_name` hints, and doctor all render that name.

--- a/docs/cross-session-internals.zh.md
+++ b/docs/cross-session-internals.zh.md
@@ -214,3 +214,34 @@ receiver 的 Claude/MCP 初始化、bridge 启动地址，以及同时匹配该�
 上一条 session 迟到的 `PreToolUse` 或 `PostToolBatch` 不能读取、清空或消费新 session 的许可链。
 三类状态转换共用 consume lock，并在持锁时重查 armed session；旧事件即使先通过乐观检查、后等待锁，
 也不能在重武装后恢复执行。
+
+## Claude 会话内的身份
+
+`party` 按下列顺序解析身份 config；`party whoami` 用 `config-resolved-by` 打印命中的那一步，
+`party doctor` 用 `resolved-by`，`whoami --json` 给 `config.resolution`：
+
+1. `explicit env`——`AGENTPARTY_CONFIG`（或全局 `--config`）。失败关闭：该文件与其持久镜像都读不到时，
+   不拿任何别的来源顶替。
+2. `claude session registry`——只在 Claude Code 的进程树里生效（Claude 给每个子进程设 `CLAUDECODE`）。
+   `party` 先读 Claude 自己给的 `CLAUDE_CODE_SESSION_ID` 与 `CLAUDE_CODE_MESSAGING_SOCKET`
+   （`/tmp/cc-socks/<pid>.sock`），从 socket 文件名取 pid，只有 `~/.claude/sessions/<pid>.json` 里的
+   `sessionId`、`messagingSocketPath` 与变量逐字相等且 pid 活着才认——继承来的陈旧环境（serve runner、
+   嵌套 shell、`/clear` 之后换了会话）过不了这一关。这条路径不起任何子进程。变量缺失（旧版 Claude
+   Code、或不在 Bash 工具下）才沿父进程链往上走（最多 10 跳 `ps -o ppid=`；只看 `process.ppid` 得到的是
+   中间 shell，不是 Claude），找到第一个持有 `~/.claude/sessions/<pid>.json` 的祖先，读该文件的
+   `sessionId`。之后都是查本机会话注册表里对应的条目。只有当条目的 `pid` 等于那个祖先、`session_id` 等于文件里的 `sessionId`、且
+   config 文件里的 `server` 与 `identity.name` 仍与条目所记一致时，才采用条目的 `config_path`。任何一项
+   对不上或出错都往下回落；这一步绝不会选到别的会话的 config。`config_path` 由 `SessionStart` hook 从
+   「绑过」的来源（显式或 workspace，绝不是全局兜底）写入，也由在会话内运行的 `party join` /
+   `party recover` 写入。爬链每进程只做一次，不在 Claude 里根本不爬。
+3. `workspace`——`party init` / `party join` 写的按 cwd 隔离的 config。
+4. `breadcrumb`——cwd state 里的绑定面包屑。
+5. `global`——`~/.agentparty/config.json`。
+
+展示名来自 Claude 自己的 sessions 文件。注册表条目的 `display_name` 就是
+`~/.claude/sessions/<pid>.json` 里 Claude 自己的 `name`（例如 `agentparty-83`）——与 Claude `ListAgents`
+显示的同名，只是没有方括号里的 `[ref]`（AgentParty 推不出它，也不编造）。`SessionStart` 常常跑在
+Claude 写出该文件之前，所以之后每一轮 hook（`PreToolUse`、`Stop`……）都会再读一次并更新条目；蛰伏
+announce 在发布 `harness_session.display_name` 之前也会再读一次（刚入册的会话多一次短暂重试）。
+`claude-<12hex>` 回退名只在原生名不可读时出现。`party who`、`party agents`、`party_channel_peers` 的
+`claude_sessions[].display_name` 提示与 doctor 展示的都是这个名字。


### PR DESCRIPTION
#1052 的 #2 与 #6（对应 open-cross-session#2 / #6）。

## #2 会话内身份自动识别
- 入册时把该会话绑定的 config 路径记进会话注册表条目（`config_path`，可选字段，旧条目不受影响）。
- `readConfigWithSource` 在「显式 AGENTPARTY_CONFIG」之后、「按 cwd 找 workspace」之前多一步：认出宿主 Claude 会话 → 注册表条目 → 它的 config。认宿主的顺序：① `CLAUDE_CODE_SESSION_ID` + `CLAUDE_CODE_MESSAGING_SOCKET` 环境变量（Claude Code 2.1.258 实测存在），与 `~/.claude/sessions/<pid>.json` 三重互验（sessionId、socket 路径、pid 活），零子进程；② 变量缺失才走 `ps` 父进程链（≤10 跳，受 `CLAUDECODE` 门控）。
- 绝不拿到别人的 config：条目 pid/session_id 必须与认出的宿主一致，config 里的 server 与 identity.name 必须与条目一致，否则回落到既有步骤。
- `party whoami` / `party doctor` 打印 `config-resolved-by: explicit env | claude session registry (claude pid …, session …) | workspace | breadcrumb | global`。
- 代价（进程内 cpuUsage，5 次）：环境变量路径均值 1.2ms、无子进程；`ps` 兜底路径均值 7.8ms；无 `CLAUDECODE` 时 0.5ms（与原先一致）。

## #6 展示名对齐 Claude 原生会话名
- 展示名以 Claude 写在 `~/.claude/sessions/<pid>.json` 的 `name`（如 `agentparty-83`）为准；SessionStart 读不到时，后续 hook 回合与 announce 各重试一次并回写注册表；`claude-<12hex>` 只在原生名不可得时用。
- `party who` / peers 摘要 / doctor 显示原生名。方括号 ref 推不出来，不造。

## 测试
新增 claude-self-session（8）、claude-native-display-name（7）、config-claude-session-identity（5，真 spawn `sh → sh → bun` 链）；registry/dormant-announce/join 用例扩展。变异自检：走链只用 ppid、跳过 sessionId 比对、永不重试原生名——各自至少一条测试红。
本机负载 24–34 下 `check:cli` 有 36 条 5s/15s spawn 超时红，关掉本改动（`CLAUDECODE=""`）同样红，以 CI 为准。

真机：本会话内临时 `AGENTPARTY_HOME` 下 `party whoami` 输出 `config-resolved-by: claude session registry (claude pid 28490, session 05bc979a-…)`。

docs/cross-session-internals（中英）新增「Claude 会话内的身份」小节。

https://claude.ai/code/session_017wTKxmX1KhLRTWMggCTtQn