### PR TITLE
fix(web): agent 默认名前缀走可读性阶梯，拒绝 Lark 不透明 id（#1043）

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,6 @@
 // 应用骨架：登录闸 → 头部 + 左侧频道列表 + 右侧（首页 | 频道页）
 import { isMember } from "@agentparty/shared";
+import { agentNameOwnerLabel } from "./lib/agentNameOwner";
 import { isOpaqueAccount } from "@agentparty/shared/identity";
 import { membershipApplyMailto, membershipStatusOf } from "./lib/membership";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -1430,7 +1431,7 @@ export function App() {
               canResetGuard={!isShareMode() && me?.role === "human"}
               // 可见性切换是 owner 专属：服务端算好的 can_moderate 决定渲不渲染（非 owner 不显会 403 的按钮）
               canModerate={channels?.find((c) => c.slug === slug)?.can_moderate === true}
-              agentNamePrefix={(me?.email ?? me?.name ?? slug).split("@")[0] ?? slug}
+              agentNamePrefix={agentNameOwnerLabel(me, slug)}
               accountKey={me?.email ?? me?.owner ?? me?.name ?? null}
               inviterName={me?.name ?? slug}
               selfHandle={me?.handle ?? null}

--- a/web/src/lib/agentNameOwner.test.ts
+++ b/web/src/lib/agentNameOwner.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import { agentNameOwnerLabel } from "./agentNameOwner";
+
+const me = (o: Partial<{ handle: string | null; display_name: string | null; email: string | null; name: string }>) =>
+  ({ handle: null, display_name: null, email: null, name: "", ...o }) as never;
+
+describe("agent 默认名前缀（#1043）", () => {
+  test("有邮箱账号：行为与之前一致，取邮箱本地部分", () => {
+    expect(agentNameOwnerLabel(me({ email: "leo@example.com", name: "lark-3f9a8b7c6d5e" }), "ludo")).toBe("leo");
+  });
+  test("阶梯：handle 优先于 display_name，display_name 优先于邮箱", () => {
+    expect(agentNameOwnerLabel(me({ handle: "leo", display_name: "Leo Guo", email: "x@y.z" }), "ludo")).toBe("leo");
+    expect(agentNameOwnerLabel(me({ display_name: "Leo Guo", email: "x@y.z" }), "ludo")).toBe("Leo Guo");
+  });
+  test("Lark 无邮箱账号：name 是 provider subject 时退回 slug，不产出 lark-/ou_ 前缀", () => {
+    expect(agentNameOwnerLabel(me({ name: "lark-3f9a8b7c6d5e-ludo" }), "ludo")).toBe("ludo");
+    expect(agentNameOwnerLabel(me({ name: "ou_9f8e7d6c5b4a3210" }), "ludo")).toBe("ludo");
+    expect(agentNameOwnerLabel(me({ name: "lark:on_abcdef" }), "ludo")).toBe("ludo");
+  });
+  test("不透明 id 出现在更高一级时跳到下一级，而不是整体放弃", () => {
+    expect(agentNameOwnerLabel(me({ handle: "ou_9f8e7d6c5b4a3210", display_name: "Leo" }), "ludo")).toBe("Leo");
+    expect(agentNameOwnerLabel(me({ display_name: "   ", email: "  ", name: "leo" }), "ludo")).toBe("leo");
+  });
+  test("me 为空时退回 slug", () => {
+    expect(agentNameOwnerLabel(null, "ludo")).toBe("ludo");
+  });
+});

--- a/web/src/lib/agentNameOwner.test.ts
+++ b/web/src/lib/agentNameOwner.test.ts
@@ -24,4 +24,8 @@ describe("agent 默认名前缀（#1043）", () => {
   test("me 为空时退回 slug", () => {
     expect(agentNameOwnerLabel(null, "ludo")).toBe("ludo");
   });
+  test("连 slug 都是不透明 id 时退回中性的 agent", () => {
+    expect(agentNameOwnerLabel(null, "ou_9f8e7d6c5b4a3210")).toBe("agent");
+    expect(agentNameOwnerLabel(me({ name: "lark-3f9a8b7c6d5e" }), "lark-3f9a8b7c6d5e")).toBe("agent");
+  });
 });

--- a/web/src/lib/agentNameOwner.ts
+++ b/web/src/lib/agentNameOwner.ts
@@ -5,6 +5,9 @@ type AgentNameOwner = Pick<MeInfo, "handle" | "display_name" | "email" | "name">
 
 // Lark/Feishu 的 provider subject（lark-<hex>… / ou_…）是身份键，不是给人看的名字（#1043）。
 // 旧账号只把 subject 放在 me.name 时，宁可退回频道名，也不把它塞进 agent 默认名前缀。
+// 连频道 slug 都是不透明 id 时的中性兜底（CodeRabbit #1059）。
+const NEUTRAL_PREFIX = "agent";
+
 const OPAQUE_PROVIDER_ID_RE = /^(?:lark-[a-f0-9]{10,}(?:-|$)|ou_[a-z0-9]{10,}$)/i;
 
 function readable(value: string | null | undefined): string | null {
@@ -13,7 +16,7 @@ function readable(value: string | null | undefined): string | null {
   return OPAQUE_PROVIDER_ID_RE.test(candidate) || isOpaqueAccount(candidate) ? null : candidate;
 }
 
-/** agent 默认名的前缀：handle → display_name → 邮箱本地部分 → name → 频道 slug，每级过可读性守卫。 */
+/** agent 默认名的前缀：handle → display_name → 邮箱本地部分 → name → 频道 slug → "agent"，每级过可读性守卫。 */
 export function agentNameOwnerLabel(me: AgentNameOwner | null | undefined, slug: string): string {
   const emailLocalPart = me?.email?.split("@")[0] ?? null;
   return (
@@ -21,6 +24,7 @@ export function agentNameOwnerLabel(me: AgentNameOwner | null | undefined, slug:
     readable(me?.display_name) ??
     readable(emailLocalPart) ??
     readable(me?.name) ??
-    slug
+    readable(slug) ??
+    NEUTRAL_PREFIX
   );
 }

--- a/web/src/lib/agentNameOwner.ts
+++ b/web/src/lib/agentNameOwner.ts
@@ -1,0 +1,26 @@
+import { isOpaqueAccount } from "@agentparty/shared/identity";
+import type { MeInfo } from "./api";
+
+type AgentNameOwner = Pick<MeInfo, "handle" | "display_name" | "email" | "name">;
+
+// Lark/Feishu 的 provider subject（lark-<hex>… / ou_…）是身份键，不是给人看的名字（#1043）。
+// 旧账号只把 subject 放在 me.name 时，宁可退回频道名，也不把它塞进 agent 默认名前缀。
+const OPAQUE_PROVIDER_ID_RE = /^(?:lark-[a-f0-9]{10,}(?:-|$)|ou_[a-z0-9]{10,}$)/i;
+
+function readable(value: string | null | undefined): string | null {
+  const candidate = value?.trim();
+  if (!candidate) return null;
+  return OPAQUE_PROVIDER_ID_RE.test(candidate) || isOpaqueAccount(candidate) ? null : candidate;
+}
+
+/** agent 默认名的前缀：handle → display_name → 邮箱本地部分 → name → 频道 slug，每级过可读性守卫。 */
+export function agentNameOwnerLabel(me: AgentNameOwner | null | undefined, slug: string): string {
+  const emailLocalPart = me?.email?.split("@")[0] ?? null;
+  return (
+    readable(me?.handle) ??
+    readable(me?.display_name) ??
+    readable(emailLocalPart) ??
+    readable(me?.name) ??
+    slug
+  );
+}


### PR DESCRIPTION
Closes #1043

## 现状
`App.tsx` 给接入向导的默认名前缀是 `(me.email ?? me.name ?? slug).split("@")[0]`。Lark 无邮箱账号的 `me.name` 是 provider subject，默认名变成 `lark-3f9a…-ludo`。

## 改动
- 新增 `web/src/lib/agentNameOwner.ts`：`handle → display_name → 邮箱本地部分 → name → slug`，每级过可读性守卫；守卫同时认 `lark-<hex>…` / `ou_…` 和 `@agentparty/shared/identity` 的 `isOpaqueAccount`
- `App.tsx` 的 `agentNamePrefix` 改用它；有邮箱账号行为与今天一致
- 参考实现取自归档 `archive/fix-agent-name-prefix` 的 lib，未取其基于旧四步布局的 AgentJoin 改动

## 验收（对应 issue）
- Lark 无邮箱：默认名不含 `lark-` / `ou_`，退回 handle / display_name / slug ✅（单测）
- 有邮箱：邮箱本地部分 ✅（单测）
- 单测覆盖阶梯每一级与不透明 id 拒绝 ✅ 5/5

`bunx tsc --noEmit` 0 错。

https://claude.ai/code/session_01HE21mDsWhAUwhJ8NnXLqWZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化频道页中代理名称前缀的生成逻辑，优先使用更易读的用户信息。
  * 自动跳过不可读的邮箱或第三方平台标识，并在缺少有效用户信息时使用频道名称作为回退。

* **测试**
  * 增加多种用户信息优先级、回退场景及不可读标识过滤的测试覆盖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->