### PR TITLE
fix(web): 新建/编辑小队后整页崩溃（squad 写接口响应形状，v0.2.250 回归）

### DIFF
--- a/web/src/lib/api.squads.test.ts
+++ b/web/src/lib/api.squads.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createSquad, updateSquad } from "./api";
+
+const originalFetch = Object.getOwnPropertyDescriptor(globalThis, "fetch");
+afterEach(() => {
+  if (originalFetch === undefined) Reflect.deleteProperty(globalThis, "fetch");
+  else Object.defineProperty(globalThis, "fetch", originalFetch);
+});
+function mockFetch(body: unknown, status = 200) {
+  Object.defineProperty(globalThis, "fetch", {
+    configurable: true,
+    value: async () => new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } }),
+  });
+}
+const squad = { type: "squad", channel: "c", name: "fe", title: null, description: null, leader: null, members: ["a"], created_by: "leo", created_by_kind: "human", created_at: 1, updated_at: 1 };
+
+describe("squad 写接口的响应形状（线上 v0.2.250 崩溃回归）", () => {
+  test("worker 直接返回裸记录（真实形状）", async () => {
+    mockFetch(squad, 201);
+    expect((await createSquad("t", "c", "fe", { members: ["a"] })).name).toBe("fe");
+    mockFetch(squad);
+    expect((await updateSquad("t", "c", "fe", { members: ["a"] })).members).toEqual(["a"]);
+  });
+  test("{ squad } 包装也认", async () => {
+    mockFetch({ squad });
+    expect((await createSquad("t", "c", "fe", { members: ["a"] })).name).toBe("fe");
+  });
+  test("认不出的响应抛错，绝不返回 undefined", async () => {
+    mockFetch({ ok: true });
+    await expect(createSquad("t", "c", "fe", { members: ["a"] })).rejects.toThrow("unexpected body");
+  });
+});

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -699,6 +699,16 @@ async function squadWriteError(res: Response, what: string): Promise<never> {
   throw new Error(`${what} failed (${res.status})`);
 }
 
+// 增改接口的响应既可能是 { squad } 也可能是裸记录；两种都认，认不出就抛错，绝不把 undefined 交给调用方。
+function squadFromResponse(data: unknown, what: string): ChannelSquad {
+  const obj = data as { squad?: ChannelSquad; name?: unknown } | null;
+  const squad = obj?.squad ?? (typeof obj?.name === "string" ? (obj as ChannelSquad) : undefined);
+  if (squad === undefined || typeof squad.name !== "string" || !Array.isArray(squad.members)) {
+    throw new Error(`${what} returned an unexpected body`);
+  }
+  return squad;
+}
+
 // #1060 PR C：squad 的增删改（worker 早有路由，web 之前只读）。members 是整体替换，不是追加。
 export async function createSquad(token: string, slug: string, name: string, body: SquadWriteBody): Promise<ChannelSquad> {
   const res = await fetchApi(`/api/channels/${encodeURIComponent(slug)}/squads`, {
@@ -707,8 +717,7 @@ export async function createSquad(token: string, slug: string, name: string, bod
     body: JSON.stringify({ name, ...body }),
   });
   if (!res.ok) await squadWriteError(res, `POST /api/channels/${slug}/squads`);
-  const data = (await res.json()) as { squad: ChannelSquad };
-  return data.squad;
+  return squadFromResponse(await res.json(), `POST /api/channels/${slug}/squads`);
 }
 
 export async function updateSquad(token: string, slug: string, name: string, body: SquadWriteBody): Promise<ChannelSquad> {
@@ -718,8 +727,7 @@ export async function updateSquad(token: string, slug: string, name: string, bod
     body: JSON.stringify(body),
   });
   if (!res.ok) await squadWriteError(res, `PATCH /api/channels/${slug}/squads/${name}`);
-  const data = (await res.json()) as { squad: ChannelSquad };
-  return data.squad;
+  return squadFromResponse(await res.json(), `PATCH /api/channels/${slug}/squads/${name}`);
 }
 
 export async function deleteSquad(token: string, slug: string, name: string): Promise<void> {

--- a/web/src/lib/mentions.ts
+++ b/web/src/lib/mentions.ts
@@ -271,8 +271,7 @@ export function mentionCandidates(
       || a.display.localeCompare(b.display)
     )
     .map(({ sourceName: _sourceName, ...candidate }) => candidate);
-  const squadCandidates: MentionCandidate[] = squads
-    .filter((squad) => squad.name !== self && squad.name !== "system")
+  const squadCandidates: MentionCandidate[] = squads.filter((squad) => squad != null && squad.name !== self && squad.name !== "system")
     .map((squad) => ({
       name: squad.name,
       display: squad.title && squad.title !== "" ? squad.title : squad.name,

--- a/web/src/pages/Channel.tsx
+++ b/web/src/pages/Channel.tsx
@@ -3822,12 +3822,12 @@ export function ChannelPage({
   const createTeamSquad = useCallback((name: string, draft: TeamSquadDraft) =>
     squadWrite("__new__", async () => {
       const saved = await createSquad(token, slug, name, draft);
-      setChannelSquads((current) => [...current.filter((s) => s.name !== saved.name), saved]);
+      setChannelSquads((current) => [...current.filter((s) => s !== undefined && s.name !== saved.name), saved]);
     }), [squadWrite, token, slug]);
   const updateTeamSquad = useCallback((name: string, draft: TeamSquadDraft) =>
     squadWrite(name, async () => {
       const saved = await updateSquad(token, slug, name, draft);
-      setChannelSquads((current) => current.map((s) => (s.name === saved.name ? saved : s)));
+      setChannelSquads((current) => current.filter((s) => s !== undefined).map((s) => (s.name === saved.name ? saved : s)));
     }), [squadWrite, token, slug]);
   const deleteTeamSquad = useCallback((name: string) =>
     squadWrite(name, async () => {


### PR DESCRIPTION
## 现象
v0.2.250 上线后，在团队看板新建或编辑一个小队 → 整页白屏：`Uncaught TypeError: Cannot read properties of undefined (reading 'name')`，栈在 @ 候选生成（`mentionCandidates`）遍历 squad 列表处。

## 根因
worker 的 `POST/PATCH /squads` 直接返回裸 squad 记录，PR C（#1064）的 `createSquad` / `updateSquad` 按 `{ squad }` 取值拿到 `undefined`，被塞进 `channelSquads`，随后每次渲染都在 `mentionCandidates` 里炸。刷新页面后从 `GET /squads` 重新拉取即恢复，所以只影响当次会话；小队本身已成功写入。

## 修复
- `lib/api.ts`：两种响应形状都认，认不出就抛错，绝不把 `undefined` 交给调用方
- `lib/mentions.ts`：squad 列表里的空洞直接跳过（任何一处坏数据不再拖垮整页）
- `Channel.tsx`：本地列表更新前过滤 `undefined`
- `api.squads.test.ts` 三条回归

## 验证
- `bunx tsc --noEmit` 0 错；api.squads / mentions / TeamSquads 61/61

## 教训
PR C 里我没读 POST/PATCH 的响应代码就假设了包装形状，且组件测试全是 mock 回调、没打到 api 层——这正是记忆里「mock 全绿真机坏」的形状。

https://claude.ai/code/session_01HE21mDsWhAUwhJ8NnXLqWZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 改进 Squad 创建和更新响应的兼容性，支持多种响应格式，并在响应无效时明确报错。
  * 修复频道 Squad 列表中无效条目可能导致的问题。
  * 修复提及候选项处理，避免显示不存在的 Squad。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->