### PR TITLE
fix(web,worker): 离线会话补回身份，同一个人不再分成「在线一行 + 离线一行」（#1067 续）

### DIFF
--- a/web/src/components/PresenceBar.test.ts
+++ b/web/src/components/PresenceBar.test.ts
@@ -712,6 +712,37 @@ function renderWith(entry: PresenceEntry, extra: Record<string, unknown>, open =
 }
 
 // 模块②（#1047）：名单弹窗从分组卡片 + 悬停浮层改成平铺成员表——一人一行、人话状态、一行一个主动作。
+describe("离线行的身份回填（#1067）", () => {
+  test("离线会话用服务端身份表的显示名与账号，从而能与在线会话并成一行", () => {
+    let next!: ReactTestRenderer;
+    void act(() => {
+      next = create(
+        createElement(
+          LocaleProvider,
+          null,
+          createElement(PresenceBar, {
+            presence: {
+              "lark:on_2260": { name: "lark:on_2260", kind: "human", state: "offline", ts: Date.now() - 90_000, last_seen: Date.now() - 90_000 },
+              leo: { name: "leo", kind: "human", state: "online", ts: Date.now(), last_seen: Date.now(), live: true, account: "lark:on_2260", handle: "leo" },
+            },
+            participants: [{ name: "leo", kind: "human", owner: "lark:on_2260", handle: "leo" }],
+            identities: {
+              "lark:on_2260": { display: "leo", kind: "human", account: "lark:on_2260" },
+              leo: { display: "leo", kind: "human", account: "lark:on_2260" },
+            },
+            status: "open",
+            initialRosterOpen: true,
+          } as never),
+        ),
+      );
+    });
+    renderer = next;
+    const rows = next.root.findAll((n) => n.type === "li" && typeof n.props["data-name"] === "string");
+    expect(rows).toHaveLength(1);
+    expect(nodesWithClass(next, "roster-name").map((n) => String(n.children.join("")))).toEqual(["leo"]);
+  });
+});
+
 describe("presence roster flat list (#1047)", () => {
   const NOW = Date.now();
   const agent = (name: string, over: Record<string, unknown> = {}): PresenceEntry =>

--- a/web/src/components/PresenceBar.tsx
+++ b/web/src/components/PresenceBar.tsx
@@ -508,11 +508,13 @@ export function PresenceBar({
         note: null,
         ts: entry?.ts ?? null,
         owner: null,
-        account: owner,
+        // 服务端身份表（identities）带着账号与「人话」显示名：离线行照样可信，
+        // 否则同一个人的离线会话既显示成原始 id、又因缺账号无法与在线会话归并（#1067）。
+        account: owner ?? identities?.[name]?.account ?? null,
         handle: null,
         ...meta,
         displayName: null,
-        display: assigned?.display ?? name,
+        display: assigned?.display ?? identities?.[name]?.display ?? name,
       };
     }
     if (entry && entry.state !== "offline") {

--- a/web/src/lib/personRoster.test.ts
+++ b/web/src/lib/personRoster.test.ts
@@ -54,6 +54,18 @@ describe("名单按人聚合（#1067）", () => {
     expect(rows[0]!.display).toBe("Leo");
   });
 
+  test("一半会话有 handle、一半只有 account 时仍并成一行（离线行拿不到 handle）", () => {
+    const rows = buildPersonRows([
+      s("leo", { handle: "leo", account: "lark:on_2260", state: "online" }),
+      s("lark:on_2260", { account: "lark:on_2260", state: "offline" }),
+      s("someone-else", { account: "lark:on_9999", state: "offline" }),
+    ]);
+    expect(rows).toHaveLength(2);
+    const leo = rows.find((r) => r.anchor === "handle")!;
+    expect(leo.sessions.map((x) => x.name).sort()).toEqual(["lark:on_2260", "leo"]);
+    expect(leo.display).toBe("leo");
+  });
+
   test("显示名永不落到不透明账号串上", () => {
     const rows = buildPersonRows([s("lark:on_acda4d", { account: "lark:on_acda4d", display: "lark:on_acda4d" })]);
     expect(rows[0]!.display).toBe("lark:on_acda4d"); // 无可读名时保留原样，但……

--- a/web/src/lib/personRoster.ts
+++ b/web/src/lib/personRoster.ts
@@ -110,6 +110,25 @@ export function buildPersonRows<T extends PersonLike>(items: T[], options: Build
     else existing.sessions.push(item);
   }
 
+  // 同一个人可能一半会话有 handle、另一半只有 account（离线行拿不到 handle）：
+  // 先把 handle 组占用的账号登记下来，再把只有 account 的组并进去，否则同一个人还是两行。
+  const keyByAccount = new Map<string, string>();
+  for (const [key, group] of groups) {
+    if (group.anchor !== "handle") continue;
+    for (const session of group.sessions) {
+      const account = norm(session.account) ?? norm(session.owner);
+      if (account !== null && !keyByAccount.has(account)) keyByAccount.set(account, key);
+    }
+  }
+  for (const [key, group] of [...groups]) {
+    if (group.anchor !== "account") continue;
+    const account = key.slice("account:".length);
+    const target = keyByAccount.get(account);
+    if (target === undefined || target === key) continue;
+    groups.get(target)!.sessions.push(...group.sessions);
+    groups.delete(key);
+  }
+
   const rows: PersonRow<T>[] = [];
   for (const [key, { anchor, sessions }] of groups) {
     const ordered = [...sessions].sort((a, b) => rank(a) - rank(b));

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -6981,6 +6981,26 @@ app.get("/api/channels/:slug/identities", async (c) => {
     }
   }
 
+  // #1067：桌面端/OIDC 登录的人类会话名就是账号本身（lark:on_…），这类会话没有 tokens 行，
+  // 账号在上面几步都补不上——名字直接就是答案，只要 account_profiles 里确有这个账号。
+  const selfNamedCandidates = [...identities.values()]
+    .filter((entry) => entry.account === undefined && entry.name.includes(":"))
+    .map((entry) => entry.name);
+  if (selfNamedCandidates.length > 0) {
+    const placeholders = selfNamedCandidates.map(() => "?").join(",");
+    const known = await c.env.DB
+      .prepare(`SELECT account FROM account_profiles WHERE account IN (${placeholders})`)
+      .bind(...selfNamedCandidates)
+      .all<{ account: string }>()
+      .catch(() => ({ results: [] as { account: string }[] }));
+    const knownAccounts = new Set(known.results.map((row) => row.account));
+    for (const entry of [...identities.values()]) {
+      if (entry.account === undefined && knownAccounts.has(entry.name)) {
+        add({ ...entry, kind: entry.kind ?? "human", account: entry.name });
+      }
+    }
+  }
+
   const humanAccounts = new Set(
     [...identities.values()]
       .filter((identity) => identity.kind === "human" && identity.account !== undefined)


### PR DESCRIPTION
接 #1067。上线后名单确实开始按人聚合（截图里有一行显示「2 个会话」），但「两个我」还在。

## 查到的事实（生产库 agentparty-xdream）
- `account_profiles` 里其实有这些人的资料：`lark:on_2260…` → handle `leo`/display `leo`；`lark:on_acda…` → `Evan`/`陈文捷`；`lark:on_8cca…` → `向健`
- `lark:on_2260…` 这类**人类会话名就是账号本身**（桌面端/OIDC 路径），它们没有 `tokens` 行，identities 的账号回填全落空 → 账号未知
- web 的离线分支把 `handle`/`display` 一律置空、只回退原始 name → 既显示成 id，又与在线会话归不到一组
- 截图里的「两个 evan」其实是人 Evan 与 agent `Evan_Claude`，不是重复

## 修复
- **worker**：identities 对「账号未知且名字含 `:`」的条目，拿名字去 `account_profiles` 反查；命中即认回账号，后续 profile 回填顺带给出人话显示名
- **web**：离线行用服务端 identities 的 `display`/`account` 兜底
- **personRoster**：加一趟合并——handle 组占用过的账号，会把「只有 account」的组并进来（同一个人一半会话有 handle、一半没有）

## 验证
- web + worker `tsc` 0 错；personRoster / PresenceBar / teamBoard 80/80，含两条新回归

https://claude.ai/code/session_01HE21mDsWhAUwhJ8NnXLqWZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化在线与离线会话的合并逻辑，即使部分会话缺少账号标识，也能将同一人的会话合并为一行。
  * 离线会话优先显示可信的账号和姓名；缺少身份信息时保留原有显示方式。
  * 改进身份识别，支持识别特定格式的自命名会话并补充人员信息。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->