### PR TITLE
fix(selfhost): recover quickly from Wrangler exits

### DIFF
--- a/docs/self-host-intranet.md
+++ b/docs/self-host-intranet.md
@@ -205,16 +205,18 @@ v0.2.242 or newer; an older shell keeps rejecting non-loopback `http://` even af
 ### Service commands
 
 ```sh
-sh scripts/selfhost.sh run        # foreground: preflight, migrate, exec the runtime (for systemd / containers)
-sh scripts/selfhost.sh start      # background: same, then detach with a pidfile and log file
+sh scripts/selfhost.sh run        # foreground: preflight, migrate, exec the runtime (first/manual run)
+sh scripts/selfhost.sh serve      # foreground: preflight, no migration (supervisor restart path)
+sh scripts/selfhost.sh start      # background: preflight, migrate, then detach with a pidfile and log file
 sh scripts/selfhost.sh stop       # stop the process recorded in the pidfile
 sh scripts/selfhost.sh status     # pid and /api/health
 sh scripts/selfhost.sh migrate    # apply pending D1 migrations only
 sh scripts/selfhost.sh preflight  # check prerequisites without starting
 ```
 
-`run` replaces the shell with the runtime process, so the supervisor that launched it owns the
-real pid and receives the real exit status. `start` and `stop` are for interactive use; `stop`
+`run` and `serve` replace the shell with the runtime process, so the supervisor that launched one
+owns the real pid and receives the real exit status. `run` applies migrations first; `serve`
+assumes migrations were already applied during installation or upgrade. `start` and `stop` are for interactive use; `stop`
 only signals the process it started and verifies that the recorded pid still belongs to this
 instance. Neither uses `pkill`, so other workerd processes on the host are unaffected.
 
@@ -232,9 +234,9 @@ Type=exec
 WorkingDirectory=/opt/agentparty/repo
 EnvironmentFile=/etc/agentparty/selfhost.env
 Environment=PATH=/opt/node22/bin:/usr/local/bin:/usr/bin:/bin
-ExecStart=/bin/sh scripts/selfhost.sh run
+ExecStart=/bin/sh scripts/selfhost.sh serve
 SuccessExitStatus=143
-Restart=on-failure
+Restart=always
 RestartSec=5
 
 [Install]
@@ -242,10 +244,20 @@ WantedBy=multi-user.target
 ```
 
 ```sh
+set -a; . /etc/agentparty/selfhost.env; set +a
+sh scripts/selfhost.sh migrate
 systemctl daemon-reload
 systemctl enable --now agentparty
 systemctl status agentparty
 ```
+
+Run `migrate` once before the service's first start and after each code upgrade. The unit deliberately
+uses `serve`, which does not migrate: if Wrangler exits unexpectedly, systemd can restore the HTTP
+service without putting an unchanged schema migration in the recovery path. `Restart=always` is a
+temporary mitigation for [cloudflare/workers-sdk#14926](https://github.com/cloudflare/workers-sdk/issues/14926),
+where a recoverable internal connection loss can still terminate `wrangler dev`. On macOS, the
+equivalent launchd service should use `KeepAlive=true` and invoke `selfhost.sh serve`; run `migrate`
+manually on install and upgrade in the same way.
 
 The runtime exits with status 143 when systemd stops it with `SIGTERM`; `SuccessExitStatus=143`
 records that as a clean stop. `bun` is not needed at run time, only for builds, so it does not
@@ -281,7 +293,9 @@ git fetch --tags origin
 git checkout "$(git describe --tags --abbrev=0 origin/main)"
 bun install --frozen-lockfile
 ( cd web && bunx vite build )
-systemctl start agentparty          # applies new migrations before the runtime comes up
+set -a; . /etc/agentparty/selfhost.env; set +a
+sh scripts/selfhost.sh migrate      # apply this release's migrations exactly once
+systemctl start agentparty          # serve starts without re-running migrations
 curl -s http://127.0.0.1:8787/api/health   # "version" must show the new release
 sh scripts/selfhost-smoke.sh
 ```
@@ -339,6 +353,7 @@ Clients then use `--server https://agentparty.example.internal`.
 | --- | --- | --- |
 | Port is listening, TCP connects, every request hangs with no bytes and no log line | Node.js older than 22. workerd resolves its D1/R2/DO bindings through a supervisor process that silently fails on old Node. Using bun as the supervisor has the same effect. | Install Node 22 as in [Installation](#installation). `selfhost.sh` refuses to start on old Node for this reason. |
 | `POST /api/tokens` returns 500; the log shows only the 500 | Database migrations not applied | `sh scripts/selfhost.sh migrate`, then restart. `start` does this automatically. |
+| Wrangler logs `Error in ProxyController`, `Network connection lost`, then exits; the UI says "Failed to load channel list" | Upstream Wrangler regression [cloudflare/workers-sdk#14926](https://github.com/cloudflare/workers-sdk/issues/14926); persisted data is normally intact but the HTTP process is gone | Run under a supervisor with automatic restart and use `selfhost.sh serve` as shown above. Run `migrate` separately only on install or upgrade. |
 | `invalid admin secret` although the secret is correct | Bootstrap request sent with `Authorization: Bearer` | Use the `x-admin-secret` header. |
 | `selfhost: web 还没构建` on start | Web UI not built | `( cd web && bunx vite build )`. If the shell still has an old Node first in `PATH`, use `bun --bun x vite build`. |
 | `stop` refuses: pid is no longer our wrangler | The pid in the pidfile was reused by another process after an unclean shutdown | Confirm nothing of ours is running (`pgrep -f "wrangler[.]js dev"`), delete the pidfile, start again. |
@@ -354,9 +369,12 @@ and prints the fix.
   process. Running two instances against a shared state directory is unsupported and will corrupt
   data. High availability requires an active/passive setup with a shared or replicated state
   directory and external failover.
-- **Runtime mode.** The instance runs under `wrangler dev --local`. It is stable over long uptimes
-  and is what the verification above used, but it is not the configuration Cloudflare supports for
-  production. A standalone `workerd serve` configuration is not provided yet.
+- **Runtime mode.** The instance runs under `wrangler dev --local`, which is not a Cloudflare-supported
+  production configuration. Wrangler 4.114.0 through the current 4.128.0 have an open crash-recovery
+  regression ([workers-sdk#14926](https://github.com/cloudflare/workers-sdk/issues/14926)), so persistent
+  installations need the supervisor setup above. Once AgentParty ships a Wrangler/Miniflare version
+  containing that fix, remove this temporary restart/migration split from the service setup and use the
+  standard `selfhost.sh run` path again. A standalone `workerd serve` configuration is not provided yet.
 - **No SSO.** Sign-in is by token only. OIDC providers can be configured through the worker's
   environment, but this is not covered by the launcher.
 - **Release pipeline.** Releases are built and deployed for Cloudflare. Self-hosted upgrades are

--- a/docs/self-host-intranet.zh.md
+++ b/docs/self-host-intranet.zh.md
@@ -177,15 +177,16 @@ party send dev "hello from the intranet"
 ### 服务命令
 
 ```sh
-sh scripts/selfhost.sh run        # 前台：预检、迁移、exec 运行时（给 systemd / 容器用）
-sh scripts/selfhost.sh start      # 后台：同上，然后脱离终端，记录 pidfile 和日志文件
+sh scripts/selfhost.sh run        # 前台：预检、迁移、exec 运行时（首次或手工运行）
+sh scripts/selfhost.sh serve      # 前台：预检、不迁移（给 supervisor 自动重启用）
+sh scripts/selfhost.sh start      # 后台：预检、迁移，然后脱离终端，记录 pidfile 和日志文件
 sh scripts/selfhost.sh stop       # 停掉 pidfile 记录的那个进程
 sh scripts/selfhost.sh status     # 进程与 /api/health
 sh scripts/selfhost.sh migrate    # 只应用未执行的 D1 迁移
 sh scripts/selfhost.sh preflight  # 只检查前置条件，不启动
 ```
 
-`run` 会用运行时进程替换当前 shell，因此拉起它的托管程序拿到的是真实 pid 和真实退出码。`start` 和 `stop` 用于交互场景；`stop` 只向自己拉起的进程发信号，并且会先核对记录的 pid 仍然属于本实例。两者都不用 `pkill`，同机上其他 workerd 进程不受影响。
+`run` 和 `serve` 都会用运行时进程替换当前 shell，因此拉起它们的托管程序拿到的是真实 pid 和真实退出码。`run` 会先应用迁移；`serve` 假定迁移已在安装或升级时完成。`start` 和 `stop` 用于交互场景；`stop` 只向自己拉起的进程发信号，并且会先核对记录的 pid 仍然属于本实例。两者都不用 `pkill`，同机上其他 workerd 进程不受影响。
 
 ### 用 systemd 托管
 
@@ -201,9 +202,9 @@ Type=exec
 WorkingDirectory=/opt/agentparty/repo
 EnvironmentFile=/etc/agentparty/selfhost.env
 Environment=PATH=/opt/node22/bin:/usr/local/bin:/usr/bin:/bin
-ExecStart=/bin/sh scripts/selfhost.sh run
+ExecStart=/bin/sh scripts/selfhost.sh serve
 SuccessExitStatus=143
-Restart=on-failure
+Restart=always
 RestartSec=5
 
 [Install]
@@ -211,10 +212,14 @@ WantedBy=multi-user.target
 ```
 
 ```sh
+set -a; . /etc/agentparty/selfhost.env; set +a
+sh scripts/selfhost.sh migrate
 systemctl daemon-reload
 systemctl enable --now agentparty
 systemctl status agentparty
 ```
+
+服务首次启动前及每次升级后只运行一次 `migrate`。unit 刻意使用不执行迁移的 `serve`：Wrangler 意外退出时，systemd 可以直接恢复 HTTP 服务，不把未变化的 schema 迁移放进恢复关键路径。`Restart=always` 是 [cloudflare/workers-sdk#14926](https://github.com/cloudflare/workers-sdk/issues/14926) 的临时缓解；该上游问题会让一次本可恢复的内部连接中断仍然终止 `wrangler dev`。macOS 上的等价 launchd 服务应设置 `KeepAlive=true` 并调用 `selfhost.sh serve`，安装和升级时同样手工运行 `migrate`。
 
 systemd 用 `SIGTERM` 停止服务时运行时以状态码 143 退出，`SuccessExitStatus=143` 让它被记为正常停止。`bun` 只在构建时需要，运行时不需要，所以不必加进服务的 `PATH`。
 
@@ -243,7 +248,9 @@ git fetch --tags origin
 git checkout "$(git describe --tags --abbrev=0 origin/main)"
 bun install --frozen-lockfile
 ( cd web && bunx vite build )
-systemctl start agentparty          # 运行时起来之前会先应用新迁移
+set -a; . /etc/agentparty/selfhost.env; set +a
+sh scripts/selfhost.sh migrate      # 只应用一次本版本的新迁移
+systemctl start agentparty          # serve 启动时不重复迁移
 curl -s http://127.0.0.1:8787/api/health   # "version" 必须是新版本号
 sh scripts/selfhost-smoke.sh
 ```
@@ -288,6 +295,7 @@ server {
 | --- | --- | --- |
 | 端口在监听、TCP 能连上、所有请求挂住，零字节且日志无记录 | Node.js 低于 22。workerd 通过一个 supervisor 进程解析 D1/R2/DO 绑定，旧 Node 上它静默失败。用 bun 当 supervisor 效果相同。 | 按[安装](#安装)一节装 Node 22。`selfhost.sh` 在旧 Node 上会拒绝启动，就是为了挡住这个问题。 |
 | `POST /api/tokens` 返回 500，日志里只有这个 500 | 数据库迁移没有应用 | `sh scripts/selfhost.sh migrate` 后重启。`start` 会自动做这一步。 |
+| Wrangler 记录 `Error in ProxyController`、`Network connection lost` 后退出，页面显示「Failed to load channel list」 | 上游 Wrangler 回归 [cloudflare/workers-sdk#14926](https://github.com/cloudflare/workers-sdk/issues/14926)；持久化数据通常完好，但 HTTP 进程已退出 | 按上文用 supervisor 自动重启，并以 `selfhost.sh serve` 作为启动命令。只在安装或升级时单独运行 `migrate`。 |
 | 密钥正确却提示 `invalid admin secret` | 引导请求用了 `Authorization: Bearer` | 改用 `x-admin-secret` 请求头。 |
 | 启动时提示 `selfhost: web 还没构建` | Web 界面没有构建 | `( cd web && bunx vite build )`。如果 shell 的 `PATH` 里旧 Node 排在前面，用 `bun --bun x vite build`。 |
 | `stop` 拒绝执行：pid 已经不是我们的 wrangler | 上次非正常退出后 pidfile 里的 pid 被别的进程复用 | 确认没有我们的进程在跑（`pgrep -f "wrangler[.]js dev"`），删掉 pidfile，重新启动。 |
@@ -299,7 +307,7 @@ server {
 ## 限制
 
 - **单节点。** Durable Object「每个频道只有一个实例」的保证只在单进程内成立。两个实例共用一个状态目录不受支持，会损坏数据。高可用需要主备架构，配合共享或复制的状态目录和外部故障切换。
-- **运行模式。** 实例运行在 `wrangler dev --local` 下。它长时间运行是稳定的，上文的验证也是这样做的，但这不是 Cloudflare 官方支持的生产形态。目前没有提供独立的 `workerd serve` 配置。
+- **运行模式。** 实例运行在 `wrangler dev --local` 下，这不是 Cloudflare 官方支持的生产形态。Wrangler 4.114.0 到当前 4.128.0 存在一个尚未修复的崩溃恢复回归（[workers-sdk#14926](https://github.com/cloudflare/workers-sdk/issues/14926)），因此持久部署需要采用上面的 supervisor 配置。AgentParty 升级到包含上游修复的 Wrangler/Miniflare 后，应移除这套临时的自动重启/迁移分离方案，恢复标准的 `selfhost.sh run` 路径。目前没有提供独立的 `workerd serve` 配置。
 - **没有 SSO。** 只能用 token 登录。OIDC 可以通过 worker 的环境变量配置，但启动脚本没有覆盖这部分。
 - **发布流水线。** 版本的构建和部署面向 Cloudflare。私有实例的升级是[升级](#升级)一节里的手工流程。
 

--- a/scripts/selfhost.sh
+++ b/scripts/selfhost.sh
@@ -71,12 +71,20 @@ wrangler_js() {
   printf '%s' "$found"
 }
 
-migrate() {
-  preflight
+prepare_data_dir() {
   ( umask 077; mkdir -p "$DATA_DIR" )
   chmod 700 "$DATA_DIR"
+}
+
+apply_migrations() {
   note "应用 D1 迁移到 $DATA_DIR"
   ( cd "$REPO/worker" && node "$(wrangler_js)" d1 migrations apply agentparty --local --persist-to "$DATA_DIR" )
+}
+
+migrate() {
+  preflight
+  prepare_data_dir
+  apply_migrations
 }
 
 # 版本元数据：注入到 /api/health 的 version / commit / deployed_at。
@@ -88,14 +96,14 @@ repo_version() {
 }
 repo_commit() { git -C "$REPO" rev-parse HEAD 2>/dev/null || printf 'unknown'; }
 
-# start 与 run 的公共前置：预检、数据目录、secret、迁移、.dev.vars。
-prepare() {
+# 所有运行模式的公共前置：预检、数据目录、secret、.dev.vars。
+# 迁移刻意不放在这里：受 supervisor 托管的 `serve` 会在 Wrangler 意外退出后频繁重跑，
+# 恢复路径不应重复执行只在安装/升级时需要的 schema 工作（#1061）。
+prepare_runtime() {
   preflight
   # D1 里存着**所有 token**，DO 存储里是频道全部内容：只给属主（真机实测改之前是 0755/0644）。
-  ( umask 077; mkdir -p "$DATA_DIR" )
-  chmod 700 "$DATA_DIR"
+  prepare_data_dir
   [ -n "${AGENTPARTY_ADMIN_SECRET:-}" ] || die "必须设 AGENTPARTY_ADMIN_SECRET —— 自部署没有任何登录方式，第一个 token 只能靠它铸出来（见 docs/self-host-intranet.md）。"
-  migrate
   # 凭据**绝不进 argv**：`ps -axww` 同机任何用户都看得见（真机实测：改之前那里明文躺着
   # ADMIN_SECRET，而它能铸任意 token）。改用 wrangler 的 .dev.vars，0600 只给属主。
   vars="$REPO/worker/.dev.vars"
@@ -103,8 +111,14 @@ prepare() {
   chmod 600 "$vars"
 }
 
+# start 与 run 保持一条命令即可首次启动的兼容行为：准备运行时后应用迁移。
+prepare() {
+  prepare_runtime
+  apply_migrations
+}
+
 # 用 workerd 替换当前进程（exec）：调用方的 pid 就是 worker 的 pid，退出码原样透传。
-# `run` 直接用它（systemd Type=exec / 容器入口）；`start` 通过 `_launch` 在后台用它。
+# `run` / `serve` 直接用它（systemd Type=exec / 容器入口）；`start` 通过 `_launch` 在后台用它。
 launch() {
   W="$(wrangler_js)"
   version="$(repo_version)"
@@ -120,6 +134,14 @@ launch() {
 run() {
   prepare
   note "前台启动 workerd（$HOST:${PORT}，数据在 ${DATA_DIR}）；日志走标准输出"
+  launch
+}
+
+# 给 systemd / launchd / 容器 supervisor 的快速恢复入口。安装或升级时必须先单独 migrate；
+# 意外退出后的自动重启只走这里，不再把 schema 迁移放进每次 crash recovery 的关键路径。
+serve() {
+  prepare_runtime
+  note "前台启动 workerd（不执行迁移，$HOST:${PORT}，数据在 ${DATA_DIR}）；日志走标准输出"
   launch
 }
 
@@ -189,17 +211,18 @@ status() {
 
 usage() {
   cat <<EOF
-usage: $0 <start|stop|status|run|migrate|preflight>
+usage: $0 <start|stop|status|run|serve|migrate|preflight>
 
   start      后台启动（pidfile + 日志文件），配合 stop / status
-  run        前台启动，日志走标准输出；给 systemd（Type=exec）或容器入口用
+  run        前台启动，自动迁移后运行；适合首次启动或手工运行
+  serve      前台启动，不执行迁移；先 migrate，给 supervisor 的自动重启入口用
   stop       停掉 start 起的那个进程（只认自己的 pidfile，不碰别的进程）
   status     进程与 /api/health
   migrate    只应用 D1 迁移
   preflight  只做预检（Node 版本、web 产物）
 
 环境变量：
-  AGENTPARTY_ADMIN_SECRET   必填（start / run）。铸第一个 token 用，见 docs/self-host-intranet.md
+  AGENTPARTY_ADMIN_SECRET   必填（start / run / serve）。铸第一个 token 用，见 docs/self-host-intranet.md
   AGENTPARTY_SELFHOST_DATA  状态目录，默认 <repo>/.selfhost-state（备份就备份它）
   AGENTPARTY_SELFHOST_HOST  默认 0.0.0.0
   AGENTPARTY_SELFHOST_PORT  默认 8787
@@ -209,6 +232,7 @@ EOF
 case "${1:-}" in
   start) start ;;
   run) run ;;
+  serve) serve ;;
   _launch) launch ;;
   stop) stop ;;
   status) status ;;

--- a/scripts/selfhost.sh
+++ b/scripts/selfhost.sh
@@ -20,6 +20,12 @@ MIN_NODE_MAJOR=22
 
 REPO="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
 DATA_DIR="${AGENTPARTY_SELFHOST_DATA:-$REPO/.selfhost-state}"
+# Wrangler 在 launch() 里会 cd 到 worker/。相对状态目录若不在这里固定，预检/迁移和
+# 运行时会悄悄落到两个不同目录（例如调用方的 state 与 worker/state）。
+case "$DATA_DIR" in
+  /*) ;;
+  *) DATA_DIR="$(pwd -P)/$DATA_DIR" ;;
+esac
 HOST="${AGENTPARTY_SELFHOST_HOST:-0.0.0.0}"
 PORT="${AGENTPARTY_SELFHOST_PORT:-8787}"
 LOG="${AGENTPARTY_SELFHOST_LOG:-$DATA_DIR/worker.log}"

--- a/scripts/selfhost.test.ts
+++ b/scripts/selfhost.test.ts
@@ -188,10 +188,15 @@ describe("自部署预检（#selfhost）", () => {
       expect(code()).not.toMatch(/\bpkill\b/);
     });
 
-    test("两处创建数据目录都要收紧权限（少一处就等于漏一条路径）", () => {
+    test("迁移与运行路径共用收紧权限的数据目录准备", () => {
       const src = code();
-      expect(src.split('chmod 700 "$DATA_DIR"').length - 1).toBe(2);
-      expect(src.split('umask 077; mkdir -p "$DATA_DIR"').length - 1).toBe(2);
+      const dataDirFn = src.slice(src.indexOf("prepare_data_dir() {"), src.indexOf("apply_migrations() {"));
+      expect(dataDirFn).toContain('chmod 700 "$DATA_DIR"');
+      expect(dataDirFn).toMatch(/umask 077; mkdir -p "\$DATA_DIR"/);
+      const migrateFn = src.slice(src.indexOf("migrate() {"), src.indexOf("repo_version() {"));
+      const runtimeFn = src.slice(src.indexOf("prepare_runtime() {"), src.indexOf("prepare() {"));
+      expect(migrateFn).toContain("prepare_data_dir");
+      expect(runtimeFn).toContain("prepare_data_dir");
     });
 
     test("pidfile 内容不是 pid ⇒ 拒绝并清掉，绝不拿它去 kill", () => {
@@ -220,7 +225,7 @@ describe("自部署预检（#selfhost）", () => {
 // `run`：前台 exec，给 systemd（Type=exec）/ 容器入口用。真机上 Type=forking + pidfile 的形态
 // 有两个毛病：systemd 只能靠 cgroup 盯一个「不是自己孩子」的进程；stop 时 node 以 143 退出
 // 被记成 failed。前台 exec 之后 systemd 直接持有 worker 的 pid，这两条都消失。
-describe("run：前台 exec + 版本元数据", () => {
+describe("run / serve：前台 exec + 版本元数据", () => {
   const fs = require("node:fs") as typeof import("node:fs");
 
   /** 假 repo：假 node 把自己的 pid 与 argv 记下来再按指定退出码退出；带 wrangler 占位与版本号。 */
@@ -233,9 +238,11 @@ describe("run：前台 exec + 版本元数据", () => {
     writeFileSync(join(dir, "node_modules", "wrangler", "bin", "wrangler.js"), "");
     writeFileSync(join(dir, "cli", "package.json"), JSON.stringify({ name: "x", version: "1.2.3" }));
     const record = join(dir, "node.record");
+    const calls = join(dir, "node.calls");
     writeFileSync(
       join(dir, "bin", "node"),
       `#!/bin/sh\n[ "$1" = "-v" ] && { echo v22.14.0; exit 0; }\n` +
+        `printf '%s\\n' "$*" >> "${calls}"\n` +
         // migrate 那次也会经过这里（d1 migrations apply）：只记录 dev 那次
         `case "$*" in *" dev "*) printf '%s\\n%s\\n' "$$" "$*" > "${record}"; exit ${exitCode} ;; esac\nexit 0\n`,
     );
@@ -249,11 +256,11 @@ describe("run：前台 exec + 版本元数据", () => {
       AGENTPARTY_ADMIN_SECRET: "s3cret",
       AGENTPARTY_SELFHOST_DATA: join(dir, "state"),
     };
-    return { dir, copy, env, record };
+    return { dir, copy, env, record, calls };
   }
 
   test("run 把自己 exec 成 worker：pid 不变、退出码透传", async () => {
-    const { dir, copy, env, record } = runSandbox(7);
+    const { dir, copy, env, record, calls } = runSandbox(7);
     try {
       const { spawn } = require("node:child_process") as typeof import("node:child_process");
       const child = spawn("sh", [copy, "run"], { env, stdio: ["ignore", "pipe", "pipe"] });
@@ -265,6 +272,24 @@ describe("run：前台 exec + 版本元数据", () => {
       expect(Number(pid)).toBe(child.pid as number);
       expect(argv).toContain(" dev --local ");
       expect(argv).toContain(`--persist-to ${join(dir, "state")}`);
+      expect(fs.readFileSync(calls, "utf8")).toContain("d1 migrations apply agentparty --local");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("serve 跳过迁移并 exec worker：给 supervisor 的重启路径不做 schema 工作", async () => {
+    const { dir, copy, env, record, calls } = runSandbox(7);
+    try {
+      const { spawn } = require("node:child_process") as typeof import("node:child_process");
+      const child = spawn("sh", [copy, "serve"], { env, stdio: ["ignore", "pipe", "pipe"] });
+      const status = await new Promise<number | null>((r) => child.on("exit", (c) => r(c)));
+      expect(status).toBe(7);
+      const [pid, argv] = fs.readFileSync(record, "utf8").split("\n");
+      expect(Number(pid)).toBe(child.pid as number);
+      expect(argv).toContain(" dev --local ");
+      expect(fs.readFileSync(calls, "utf8")).not.toContain("d1 migrations apply");
+      expect(fs.readFileSync(join(dir, "worker", ".dev.vars"), "utf8")).toContain("ADMIN_SECRET=s3cret");
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -288,22 +313,39 @@ describe("run：前台 exec + 版本元数据", () => {
     }
   });
 
-  test("run 与 start 共用同一套前置：没设 ADMIN_SECRET 一样拒绝", () => {
+  test("run / serve 与 start 共用同一套前置：没设 ADMIN_SECRET 一样拒绝", () => {
     const { dir, copy, env } = runSandbox(0);
     try {
       const { AGENTPARTY_ADMIN_SECRET: _drop, ...noSecret } = env;
-      const r = spawnSync("sh", [copy, "run"], { env: noSecret, encoding: "utf8" });
-      expect(r.status).not.toBe(0);
-      expect(`${r.stdout}${r.stderr}`).toContain("AGENTPARTY_ADMIN_SECRET");
+      for (const command of ["run", "serve"]) {
+        const r = spawnSync("sh", [copy, command], { env: noSecret, encoding: "utf8" });
+        expect(r.status).not.toBe(0);
+        expect(`${r.stdout}${r.stderr}`).toContain("AGENTPARTY_ADMIN_SECRET");
+      }
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
   });
 
-  test("usage 列出 run", () => {
+  test("usage 列出 run 与 serve，并说清迁移边界", () => {
     const r = spawnSync("sh", [script], { encoding: "utf8" });
     expect(`${r.stdout}${r.stderr}`).toMatch(/^\s*run\s+前台/m);
+    expect(`${r.stdout}${r.stderr}`).toMatch(/^\s*serve\s+前台启动，不执行迁移/m);
   });
+});
+
+describe("#1061：supervisor 恢复路径文档", () => {
+  for (const name of ["self-host-intranet.md", "self-host-intranet.zh.md"]) {
+    test(`${name} 用 serve 自动重启，并把迁移留在安装/升级`, () => {
+      const doc = require("node:fs").readFileSync(resolve(import.meta.dir, "..", "docs", name), "utf8") as string;
+      expect(doc).toContain("ExecStart=/bin/sh scripts/selfhost.sh serve");
+      expect(doc).not.toContain("ExecStart=/bin/sh scripts/selfhost.sh run");
+      expect(doc).toContain("Restart=always");
+      expect(doc).toContain("sh scripts/selfhost.sh migrate");
+      expect(doc).toContain("cloudflare/workers-sdk/issues/14926");
+      expect(doc).toContain("4.128.0");
+    });
+  }
 });
 
 // smoke 真机跑到第 6 次才暴露的两个坑：`?limit=5` 返回最旧 5 条（自己那条读不到 ⇒ 误报失败）；

--- a/scripts/selfhost.test.ts
+++ b/scripts/selfhost.test.ts
@@ -295,6 +295,21 @@ describe("run / serve：前台 exec + 版本元数据", () => {
     }
   });
 
+  test("相对状态目录在 cd worker 前固定成绝对路径：准备与运行时不能写到两个地方", () => {
+    const { dir, copy, env, record } = runSandbox(0);
+    try {
+      const relativeEnv = { ...env, AGENTPARTY_SELFHOST_DATA: "state" };
+      const r = spawnSync("sh", [copy, "serve"], { cwd: dir, env: relativeEnv, encoding: "utf8" });
+      expect(r.status).toBe(0);
+      const argv = fs.readFileSync(record, "utf8").split("\n")[1];
+      expect(argv).toContain(`--persist-to ${join(fs.realpathSync(dir), "state")}`);
+      expect(fs.statSync(join(dir, "state")).mode & 0o777).toBe(0o700);
+      expect(fs.existsSync(join(dir, "worker", "state"))).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test("启动参数注入版本与提交（否则 /api/health 永远是 dev/unknown，升级后核不出跑的哪版）", () => {
     const { dir, copy, env, record } = runSandbox(0);
     try {
@@ -317,7 +332,7 @@ describe("run / serve：前台 exec + 版本元数据", () => {
     const { dir, copy, env } = runSandbox(0);
     try {
       const { AGENTPARTY_ADMIN_SECRET: _drop, ...noSecret } = env;
-      for (const command of ["run", "serve"]) {
+      for (const command of ["start", "run", "serve"]) {
         const r = spawnSync("sh", [copy, command], { env: noSecret, encoding: "utf8" });
         expect(r.status).not.toBe(0);
         expect(`${r.stdout}${r.stderr}`).toContain("AGENTPARTY_ADMIN_SECRET");


### PR DESCRIPTION
Closes #1061

## Summary

- add `selfhost.sh serve`, a foreground supervisor entrypoint that keeps preflight, state permissions, secret preparation, real PID/exit propagation, and version metadata but deliberately skips D1 migrations
- keep `run` and `start` backward-compatible by continuing to migrate automatically
- update the English and Chinese runbooks to run migrations once on install/upgrade and use `serve` with `Restart=always` / launchd `KeepAlive=true`
- document the upstream failure signature, persisted-data behavior, and the condition for removing this workaround
- add regression coverage for migration separation, exec semantics, secret handling, permissions, usage text, and both runbooks

## Why

cloudflare/workers-sdk#14926 is still open and Wrangler 4.128.0 does not contain a fix. When the ProxyController loses its internal connection, `wrangler dev --local` can exit even though Miniflare restarts workerd. External supervision restores availability, but the existing `run` command re-applies all migrations on every crash recovery. The new `serve` path keeps schema work out of that recovery loop.

## Verification

- `sh -n scripts/selfhost.sh`
- `bun test scripts/selfhost.test.ts scripts/docs-bilingual.test.ts` — 31 pass
- scripts test stage — 439 pass
- repository TypeScript 7.0.2: `cli/node_modules/.bin/tsc --project scripts/tsconfig.json`
- real local self-host smoke with a fresh temporary state directory: migrated 47 files once, started through `serve` without another migration, then passed health, bootstrap token, channel, agent token, ChannelDO write, and read-back checks

## Removal condition

Once AgentParty upgrades to a Wrangler/Miniflare release that fixes cloudflare/workers-sdk#14926, switch the supervised service back to the standard `selfhost.sh run` path and remove the temporary restart/migration split from the runbook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增 `serve` 前台启动模式，启动及崩溃恢复时不重复执行数据迁移。
  * 自部署流程新增独立的运行时准备步骤，自动处理目录权限、管理员密钥和配置文件。
  * `run` 与 `start` 继续支持自动完成数据迁移。
  * 命令行帮助信息新增 `serve` 用法，并支持通过环境变量配置管理员密钥。

* **测试**
  * 增加对启动流程、迁移行为、运行时配置及 `serve` 模式的覆盖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->