### PR TITLE
feat(cli): party who 不带频道时给出跨频道的「我能到达谁」（#1074）

### DIFF
--- a/cli/src/commands/who-global.ts
+++ b/cli/src/commands/who-global.ts
@@ -1,0 +1,193 @@
+// `party who` 不带频道时的全局视图（#1074）。
+//
+// 此前 who/agents 都是频道内视图：要用它们，你得先知道该进哪个频道。于是「找人」的实际路径
+// 变成了「开网页 → 看频道列表 → 进频道 → 看名单」。这里把「我已加入的所有频道」的 presence
+// 聚合成一份「我能到达谁」，按人去重（同一个人在多个频道出现只占一行），每行给出可达性与
+// 出现在哪些频道，供下一步 `party send --channel <其中之一> --mention <name>`。
+//
+// 没有新增服务端接口：只用现成的 listChannels + fetchPresence。
+import type { PresenceEntry, SenderKind } from "@agentparty/shared";
+import { autoWakeReachable } from "@agentparty/shared";
+import { isOpaqueAccount } from "@agentparty/shared/identity";
+import type { ChannelInfo } from "../rest";
+
+/** 可达性档位，与频道内 who 同序：能立刻说上话的排前面。 */
+export type GlobalReach = "online" | "wakeable" | "recent" | "offline";
+const REACH_ORDER: Record<GlobalReach, number> = { online: 0, wakeable: 1, recent: 2, offline: 3 };
+
+export interface GlobalWhoRow {
+  /** @ 提及用的名字；同一个人的多条会话取可达性最好的那条。 */
+  name: string;
+  kind: SenderKind;
+  reach: GlobalReach;
+  /** 可读的归属人；不透明账号串一律省略。 */
+  owner?: string;
+  /** 这个人出现在哪些频道（已按频道名排序），下一步 --channel 从这里挑。 */
+  channels: string[];
+  /** 同一个人被折叠掉的其它会话名（便于精确寻址时区分）。 */
+  aka?: string[];
+  last_seen?: number;
+  /** 人为暂停接待：被 @ 也不会醒，必须显式标出，否则 online 会骗人。 */
+  paused?: true;
+}
+
+export interface GlobalWhoInput {
+  /** 每个频道一份 presence 快照；顺序不影响结果。 */
+  channels: Array<{ slug: string; presence: PresenceEntry[] }>;
+  /** 自己的名字，输出里排除（找人是找别人）。 */
+  self?: string;
+  now: number;
+  /** 超过这个时长没露面就归为 offline，与频道内 who 的 recent 判据同源。 */
+  staleMs?: number;
+}
+
+const DEFAULT_STALE_MS = 60_000;
+
+function nonBlank(value: string | null | undefined): string | undefined {
+  const v = value?.trim();
+  return v !== undefined && v !== "" ? v : undefined;
+}
+
+function readable(value: string | null | undefined): string | undefined {
+  const v = nonBlank(value);
+  return v !== undefined && !isOpaqueAccount(v) ? v : undefined;
+}
+
+/**
+ * 单条 presence 的可达性。故意比频道内 who 粗一档：全局视图要回答的是「我现在能不能找到他」，
+ * 不承担「为什么叫不醒」的诊断——那仍然是 `party who <channel>` 的职责。
+ */
+export function reachOf(entry: PresenceEntry, now: number, staleMs = DEFAULT_STALE_MS): GlobalReach {
+  const age = now - (entry.last_seen ?? entry.ts ?? 0);
+  // state 是自报的**工作**状态（working/waiting/blocked/done），不是连通性：一个 49 天前
+  // 报过 working 的会话至今仍是 state=working。判「在线」必须同时看 live 或新鲜度，
+  // 口径与频道内 who 的 tier 完全一致，否则全局视图会把一堆死会话标成在线。
+  if (entry.state !== "offline" && (entry.live === true || age < staleMs)) return "online";
+  // 可唤醒同样走权威判定（wake 声明 + 新鲜度 + residency），不只看 wake.kind 存在。
+  if (autoWakeReachable(entry, now, staleMs)) return "wakeable";
+  return age <= staleMs ? "recent" : "offline";
+}
+
+/**
+ * 同一个人的聚合键。与 web 侧名单（#1067）同一套思路：人靠全局昵称跨会话对上，
+ * 其次账号；agent 是独立个体，恒按名字各自成行——同一 owner 名下的两个 agent 不是同一个东西。
+ */
+export function personKeyOf(entry: PresenceEntry): string {
+  if (entry.kind !== "human") return `agent:${entry.name}`;
+  const handle = nonBlank(entry.handle);
+  if (handle !== undefined) return `handle:${handle.toLowerCase()}`;
+  // account 在服务端按原值精确比较，只差大小写是两个主体，不折叠大小写。
+  const account = nonBlank(entry.account);
+  return account !== undefined ? `account:${account}` : `human:${entry.name}`;
+}
+
+function displayOf(entry: PresenceEntry): string {
+  // 人类的会话名常是 UUID / provider subject，直接展示没人认得；昵称与展示名优先。
+  if (entry.kind === "human") {
+    return nonBlank(entry.display_name) ?? nonBlank(entry.handle) ?? readable(entry.account) ?? entry.name;
+  }
+  return nonBlank(entry.handle) ?? entry.name;
+}
+
+export function buildGlobalWho(input: GlobalWhoInput): GlobalWhoRow[] {
+  const { channels, self, now, staleMs = DEFAULT_STALE_MS } = input;
+  const groups = new Map<string, {
+    best: PresenceEntry;
+    bestReach: GlobalReach;
+    names: Set<string>;
+    channels: Set<string>;
+    lastSeen: number;
+    paused: boolean;
+  }>();
+
+  for (const { slug, presence } of channels) {
+    for (const entry of presence) {
+      if (entry.name === "system" || (self !== undefined && entry.name === self)) continue;
+      const key = personKeyOf(entry);
+      const reach = reachOf(entry, now, staleMs);
+      const seen = entry.last_seen ?? entry.ts ?? 0;
+      const existing = groups.get(key);
+      if (existing === undefined) {
+        groups.set(key, {
+          best: entry,
+          bestReach: reach,
+          names: new Set([entry.name]),
+          channels: new Set([slug]),
+          lastSeen: seen,
+          paused: entry.paused === true,
+        });
+        continue;
+      }
+      existing.names.add(entry.name);
+      existing.channels.add(slug);
+      existing.lastSeen = Math.max(existing.lastSeen, seen);
+      // 代表条目取可达性最好的那条；同档时取更近的一次露面。
+      if (
+        REACH_ORDER[reach] < REACH_ORDER[existing.bestReach] ||
+        (REACH_ORDER[reach] === REACH_ORDER[existing.bestReach] && seen > (existing.best.last_seen ?? existing.best.ts ?? 0))
+      ) {
+        existing.best = entry;
+        existing.bestReach = reach;
+      }
+      // 只要有一条会话是被暂停的就标出来：暂停是人主动按下的，@ 不会醒，宁可多提醒。
+      if (entry.paused === true) existing.paused = true;
+    }
+  }
+
+  const rows: GlobalWhoRow[] = [];
+  for (const group of groups.values()) {
+    const name = group.best.name;
+    const aka = [...group.names].filter((other) => other !== name).sort();
+    const owner = readable(group.best.account);
+    rows.push({
+      name,
+      kind: group.best.kind ?? "agent",
+      reach: group.bestReach,
+      ...(owner === undefined ? {} : { owner }),
+      channels: [...group.channels].sort(),
+      ...(aka.length === 0 ? {} : { aka }),
+      ...(group.lastSeen > 0 ? { last_seen: group.lastSeen } : {}),
+      ...(group.paused ? { paused: true as const } : {}),
+    });
+  }
+
+  return rows.sort((a, b) =>
+    REACH_ORDER[a.reach] - REACH_ORDER[b.reach]
+    // 同档内 agent 在前：找人办事时，能直接派活的排前面更顺手。
+    || Number(a.kind === "human") - Number(b.kind === "human")
+    || (b.last_seen ?? 0) - (a.last_seen ?? 0)
+    || a.name.localeCompare(b.name),
+  );
+}
+
+const REACH_MARK: Record<GlobalReach, string> = {
+  online: "●",
+  wakeable: "◐",
+  recent: "○",
+  offline: "·",
+};
+
+export function renderGlobalRow(row: GlobalWhoRow, display: string, now: number): string {
+  const age = row.last_seen === undefined ? "" : ` ${fmtAge(now - row.last_seen)}`;
+  const owner = row.owner === undefined ? "" : ` · ${row.owner}`;
+  const paused = row.paused === true ? " ⏸ paused" : "";
+  const where = row.channels.length === 1 ? `#${row.channels[0]}` : `#${row.channels[0]} +${row.channels.length - 1}`;
+  return `${REACH_MARK[row.reach]} ${display}${owner}  ${row.kind}${paused}  ${where}${age}`;
+}
+
+function fmtAge(ms: number): string {
+  if (ms < 60_000) return "just now";
+  if (ms < 3_600_000) return `${Math.floor(ms / 60_000)}m ago`;
+  if (ms < 86_400_000) return `${Math.floor(ms / 3_600_000)}h ago`;
+  return `${Math.floor(ms / 86_400_000)}d ago`;
+}
+
+/** 供命令层复用：只取未归档频道，避免把死频道的历史成员算进「我能到达谁」。 */
+export function activeChannelSlugs(channels: ChannelInfo[]): string[] {
+  return channels
+    .filter((channel) => channel.archived_at === null || channel.archived_at === undefined)
+    .map((channel) => channel.slug)
+    .sort();
+}
+
+export { displayOf as globalWhoDisplay };

--- a/cli/src/commands/who-global.ts
+++ b/cli/src/commands/who-global.ts
@@ -16,8 +16,15 @@ export type GlobalReach = "online" | "wakeable" | "recent" | "offline";
 const REACH_ORDER: Record<GlobalReach, number> = { online: 0, wakeable: 1, recent: 2, offline: 3 };
 
 export interface GlobalWhoRow {
-  /** @ 提及用的名字；同一个人的多条会话取可达性最好的那条。 */
+  /**
+   * 可直接用于 `party send --mention <name>` 的地址。
+   * 人类的会话名是 UUID / provider subject，**@ 不到**——只有全局昵称 handle 能被服务端解析成
+   * 「被 @」，所以人类优先取 handle；没有 handle 时退回会话名并置 mentionable:false，
+   * 让调用方知道这行不能直接 @（而不是让它发一条永远叫不醒人的消息）。
+   */
   name: string;
+  /** 缺省即可 @；false 表示这一行没有可 @ 的地址。 */
+  mentionable?: false;
   kind: SenderKind;
   reach: GlobalReach;
   /** 可读的归属人；不透明账号串一律省略。 */
@@ -95,6 +102,7 @@ export function buildGlobalWho(input: GlobalWhoInput): GlobalWhoRow[] {
     best: PresenceEntry;
     bestReach: GlobalReach;
     names: Set<string>;
+    entries: PresenceEntry[];
     channels: Set<string>;
     lastSeen: number;
     paused: boolean;
@@ -112,6 +120,7 @@ export function buildGlobalWho(input: GlobalWhoInput): GlobalWhoRow[] {
           best: entry,
           bestReach: reach,
           names: new Set([entry.name]),
+          entries: [entry],
           channels: new Set([slug]),
           lastSeen: seen,
           paused: entry.paused === true,
@@ -119,6 +128,7 @@ export function buildGlobalWho(input: GlobalWhoInput): GlobalWhoRow[] {
         continue;
       }
       existing.names.add(entry.name);
+      existing.entries.push(entry);
       existing.channels.add(slug);
       existing.lastSeen = Math.max(existing.lastSeen, seen);
       // 代表条目取可达性最好的那条；同档时取更近的一次露面。
@@ -134,13 +144,47 @@ export function buildGlobalWho(input: GlobalWhoInput): GlobalWhoRow[] {
     }
   }
 
+  // 同一个人可能一半会话带 handle、一半只有 account（离线行常拿不到 handle）：
+  // 先记下 handle 组占用了哪些账号，再把纯 account 组并进去，否则同一个人会裂成两行。
+  // 与 web 名单（#1067）同一趟二次合并。
+  const keyByAccount = new Map<string, string>();
+  for (const [key, group] of groups) {
+    if (!key.startsWith("handle:")) continue;
+    for (const entry of group.entries) {
+      const account = nonBlank(entry.account);
+      if (account !== undefined && !keyByAccount.has(account)) keyByAccount.set(account, key);
+    }
+  }
+  for (const [key, group] of [...groups]) {
+    if (!key.startsWith("account:")) continue;
+    const target = keyByAccount.get(key.slice("account:".length));
+    if (target === undefined || target === key) continue;
+    const into = groups.get(target)!;
+    for (const entry of group.entries) into.entries.push(entry);
+    for (const name of group.names) into.names.add(name);
+    for (const slug of group.channels) into.channels.add(slug);
+    into.lastSeen = Math.max(into.lastSeen, group.lastSeen);
+    into.paused = into.paused || group.paused;
+    if (REACH_ORDER[group.bestReach] < REACH_ORDER[into.bestReach]) {
+      into.best = group.best;
+      into.bestReach = group.bestReach;
+    }
+    groups.delete(key);
+  }
+
   const rows: GlobalWhoRow[] = [];
   for (const group of groups.values()) {
-    const name = group.best.name;
+    // 人类：任一会话上的 handle 都是同一个全局昵称，取到即用；agent 的 name 本身就是地址。
+    const handle = group.best.kind === "human"
+      ? [...group.entries].map((entry) => nonBlank(entry.handle)).find((value) => value !== undefined)
+      : undefined;
+    const name = handle ?? group.best.name;
+    const mentionable = group.best.kind !== "human" || handle !== undefined;
     const aka = [...group.names].filter((other) => other !== name).sort();
     const owner = readable(group.best.account);
     rows.push({
       name,
+      ...(mentionable ? {} : { mentionable: false as const }),
       kind: group.best.kind ?? "agent",
       reach: group.bestReach,
       ...(owner === undefined ? {} : { owner }),
@@ -171,8 +215,9 @@ export function renderGlobalRow(row: GlobalWhoRow, display: string, now: number)
   const age = row.last_seen === undefined ? "" : ` ${fmtAge(now - row.last_seen)}`;
   const owner = row.owner === undefined ? "" : ` · ${row.owner}`;
   const paused = row.paused === true ? " ⏸ paused" : "";
+  const noMention = row.mentionable === false ? "  ⚠ no @ handle" : "";
   const where = row.channels.length === 1 ? `#${row.channels[0]}` : `#${row.channels[0]} +${row.channels.length - 1}`;
-  return `${REACH_MARK[row.reach]} ${display}${owner}  ${row.kind}${paused}  ${where}${age}`;
+  return `${REACH_MARK[row.reach]} ${display}${owner}  ${row.kind}${paused}  ${where}${age}${noMention}`;
 }
 
 function fmtAge(ms: number): string {

--- a/cli/src/commands/who-global.ts
+++ b/cli/src/commands/who-global.ts
@@ -211,13 +211,27 @@ const REACH_MARK: Record<GlobalReach, string> = {
   offline: "·",
 };
 
-export function renderGlobalRow(row: GlobalWhoRow, display: string, now: number): string {
+/**
+ * 渲染一行。display / owner / 频道名都来自服务端，**必须**先过终端控制序列清洗——
+ * 否则一个恶意昵称就能在别人终端里改写光标与颜色（#629 修过同一类问题，这条路径不能漏）。
+ * aka 也一并展示：折叠掉的会话名是精确寻址时的唯一线索，只藏进 JSON 等于丢了。
+ */
+export function renderGlobalRow(
+  row: GlobalWhoRow,
+  display: string,
+  now: number,
+  sanitize: (value: string) => string = (value) => value,
+): string {
   const age = row.last_seen === undefined ? "" : ` ${fmtAge(now - row.last_seen)}`;
-  const owner = row.owner === undefined ? "" : ` · ${row.owner}`;
+  const owner = row.owner === undefined ? "" : ` · ${sanitize(row.owner)}`;
   const paused = row.paused === true ? " ⏸ paused" : "";
   const noMention = row.mentionable === false ? "  ⚠ no @ handle" : "";
-  const where = row.channels.length === 1 ? `#${row.channels[0]}` : `#${row.channels[0]} +${row.channels.length - 1}`;
-  return `${REACH_MARK[row.reach]} ${display}${owner}  ${row.kind}${paused}  ${where}${age}${noMention}`;
+  const channels = row.channels.map(sanitize);
+  const where = channels.length === 1 ? `#${channels[0]}` : `#${channels[0]} +${channels.length - 1}`;
+  const aka = row.aka === undefined || row.aka.length === 0
+    ? ""
+    : `  aka ${row.aka.slice(0, 2).map(sanitize).join(", ")}${row.aka.length > 2 ? ` +${row.aka.length - 2}` : ""}`;
+  return `${REACH_MARK[row.reach]} ${sanitize(display)}${owner}  ${row.kind}${paused}  ${where}${age}${noMention}${aka}`;
 }
 
 function fmtAge(ms: number): string {

--- a/cli/src/commands/who.ts
+++ b/cli/src/commands/who.ts
@@ -2,6 +2,8 @@
 // Claude Code 原生 @ 只认本地文件/技能，塞不进远程动态列表；本命令就是那个「动态在线列表」。
 import { autoWakeReachable, type AgentActivity, type ListeningVerdict, type PresenceEntry, type ReceptionContextBoundary, type ReceptionMode, type ReceptionRunner, type RunnerHealth, type RuntimePeerDiscovery, type SenderKind, type TaskLeaseScope, type WakeKind, wakeableState } from "@agentparty/shared";
 import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
+import { listChannels } from "../rest";
+import { activeChannelSlugs, buildGlobalWho, globalWhoDisplay, renderGlobalRow } from "./who-global";
 import { resolveChannel } from "../config";
 import { diagnoseCodexWake, formatCodexWakeDiagnosis, shouldSurfaceCodexWakeDiagnosis } from "../wake-diagnosis";
 import { claudeDormantToSurface, diagnoseClaudeDormantSessions, formatClaudeDormantDiagnosis } from "../claude-armed-listener";
@@ -860,8 +862,9 @@ export async function run(argv: string[]): Promise<number> {
   }
   const channel = resolveChannel(str(flags.channel) ?? positionals[0]);
   if (!channel) {
-    console.error("no channel, pass one or bind with: party init --channel C");
-    return 1;
+    // #1074：没有频道时不再报错退出——聚合「我已加入的所有频道」，回答「我能到达谁」。
+    // 频道内 who 的诊断细节（为什么叫不醒）仍需显式给频道，这里只解决「先找到人」。
+    return runGlobalWho(cfg, flags.json === true);
   }
   if (!isSlug(channel)) {
     console.error("channel must match [a-z0-9][a-z0-9-]{0,63}");
@@ -961,4 +964,50 @@ export async function run(argv: string[]): Promise<number> {
   } catch (e) {
     return handleRestError(e);
   }
+}
+
+/**
+ * `party who` 无频道时的全局视图（#1074）。逐频道拉 presence 后按人聚合。
+ * 任一频道拉取失败只跳过它并在末尾如实说明——不能因为一个频道坏掉就让整条命令没输出。
+ */
+async function runGlobalWho(cfg: { server: string; token: string; name?: string }, json: boolean): Promise<number> {
+  let channels;
+  try {
+    channels = activeChannelSlugs(await listChannels(cfg.server, cfg.token));
+  } catch (err: unknown) {
+    return handleRestError(err);
+  }
+  if (channels.length === 0) {
+    console.error("no channels yet — join one first: party join --server URL --channel SLUG --as NAME");
+    return 1;
+  }
+  const snapshots: Array<{ slug: string; presence: PresenceEntry[] }> = [];
+  const failed: string[] = [];
+  for (const slug of channels) {
+    try {
+      snapshots.push({ slug, presence: await fetchPresence(cfg.server, cfg.token, slug) });
+    } catch {
+      failed.push(slug);
+    }
+  }
+  const now = Date.now();
+  const rows = buildGlobalWho({ channels: snapshots, ...(cfg.name === undefined ? {} : { self: cfg.name }), now });
+  if (json) {
+    for (const row of rows) console.log(JSON.stringify(row));
+    if (failed.length > 0) console.error(`could not read presence for: ${failed.join(", ")}`);
+    return 0;
+  }
+  if (rows.length === 0) {
+    console.log(`no one reachable across ${channels.length} channel(s) yet`);
+    return 0;
+  }
+  console.log(`reachable across ${snapshots.length} channel(s) — pass a channel for wake diagnostics:`);
+  for (const row of rows) {
+    const entry = snapshots
+      .flatMap((snapshot) => snapshot.presence)
+      .find((candidate) => candidate.name === row.name);
+    console.log("  " + renderGlobalRow(row, entry === undefined ? row.name : globalWhoDisplay(entry), now));
+  }
+  if (failed.length > 0) console.log(`\ncould not read presence for: ${failed.join(", ")}`);
+  return 0;
 }

--- a/cli/src/commands/who.ts
+++ b/cli/src/commands/who.ts
@@ -1016,7 +1016,7 @@ async function runGlobalWho(cfg: { server: string; token: string; name?: string 
     const entry = snapshots
       .flatMap((snapshot) => snapshot.presence)
       .find((candidate) => candidate.name === row.name);
-    console.log("  " + renderGlobalRow(row, entry === undefined ? row.name : globalWhoDisplay(entry), now));
+    console.log("  " + renderGlobalRow(row, entry === undefined ? row.name : globalWhoDisplay(entry), now, terminalIdentityText));
   }
   if (failed.length > 0) {
     console.log(`\ncould not read presence for: ${failed.join(", ")} — this list is incomplete`);

--- a/cli/src/commands/who.ts
+++ b/cli/src/commands/who.ts
@@ -990,15 +990,25 @@ async function runGlobalWho(cfg: { server: string; token: string; name?: string 
       failed.push(slug);
     }
   }
+  // 一个频道都读不到时，"没人可达" 是错的结论——那是我们没读到，不是没人。
+  if (snapshots.length === 0) {
+    console.error(`could not read presence for any of ${channels.length} channel(s): ${failed.join(", ")}`);
+    return 1;
+  }
   const now = Date.now();
   const rows = buildGlobalWho({ channels: snapshots, ...(cfg.name === undefined ? {} : { self: cfg.name }), now });
   if (json) {
     for (const row of rows) console.log(JSON.stringify(row));
     if (failed.length > 0) console.error(`could not read presence for: ${failed.join(", ")}`);
-    return 0;
+    // 部分频道读不到时结果是不完整的：退出码要反映这一点，否则脚本会把不完整当完整。
+    return failed.length > 0 ? 1 : 0;
   }
   if (rows.length === 0) {
-    console.log(`no one reachable across ${channels.length} channel(s) yet`);
+    console.log(`no one reachable across ${snapshots.length} channel(s) yet`);
+    if (failed.length > 0) {
+      console.log(`could not read presence for: ${failed.join(", ")}`);
+      return 1;
+    }
     return 0;
   }
   console.log(`reachable across ${snapshots.length} channel(s) — pass a channel for wake diagnostics:`);
@@ -1008,6 +1018,9 @@ async function runGlobalWho(cfg: { server: string; token: string; name?: string 
       .find((candidate) => candidate.name === row.name);
     console.log("  " + renderGlobalRow(row, entry === undefined ? row.name : globalWhoDisplay(entry), now));
   }
-  if (failed.length > 0) console.log(`\ncould not read presence for: ${failed.join(", ")}`);
+  if (failed.length > 0) {
+    console.log(`\ncould not read presence for: ${failed.join(", ")} — this list is incomplete`);
+    return 1;
+  }
   return 0;
 }

--- a/cli/test/who-global.test.ts
+++ b/cli/test/who-global.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { PresenceEntry } from "@agentparty/shared";
-import { activeChannelSlugs, buildGlobalWho, personKeyOf, reachOf } from "../src/commands/who-global";
+import { activeChannelSlugs, buildGlobalWho, personKeyOf, reachOf, renderGlobalRow } from "../src/commands/who-global";
 
 const NOW = 1_700_000_000_000;
 
@@ -142,5 +142,39 @@ describe("全局 who 的按人聚合（#1074）", () => {
       { slug: "dead", title: null, archived_at: NOW - 1 } as never,
     ]);
     expect(slugs).toEqual(["live"]);
+  });
+});
+
+describe("全局 who 的终端渲染（#1074）", () => {
+  const sanitize = (v: string) => v.replace(/[\u0000-\u001F\u007F-\u009F]+/g, " ").replace(/\s+/g, " ").trim();
+
+  test("服务端可控字段必须过控制序列清洗（#629 同类注入）", () => {
+    const row = {
+      name: "evil",
+      kind: "agent" as const,
+      reach: "online" as const,
+      owner: "own\u001b[31mer",
+      channels: ["ch\u0007an"],
+      last_seen: NOW - 1_000,
+    };
+    const line = renderGlobalRow(row, "dis\u001b[2Jplay", NOW, sanitize);
+    // 清洗只剥不可见控制字符（ESC/BEL），可见残留如 "[2J" 保留原样——与 terminalIdentityText 同语义
+    expect(line).not.toMatch(/[\u0000-\u001F\u007F-\u009F]/);
+    expect(line).toContain("dis [2Jplay");
+    expect(line).toContain("own [31mer");
+    expect(line).toContain("#ch an");
+  });
+
+  test("折叠掉的会话名要在终端里露出来，不能只藏进 JSON", () => {
+    const row = {
+      name: "leo",
+      kind: "human" as const,
+      reach: "online" as const,
+      channels: ["alpha"],
+      aka: ["sess-1", "sess-2", "sess-3"],
+      last_seen: NOW - 1_000,
+    };
+    const line = renderGlobalRow(row, "Leo", NOW, sanitize);
+    expect(line).toContain("aka sess-1, sess-2 +1");
   });
 });

--- a/cli/test/who-global.test.ts
+++ b/cli/test/who-global.test.ts
@@ -38,10 +38,10 @@ describe("全局 who 的按人聚合（#1074）", () => {
     });
     expect(rows).toHaveLength(1);
     expect(rows[0]!.channels).toEqual(["alpha", "beta"]);
-    // 代表取可达性最好的那条会话
-    expect(rows[0]!.name).toBe("leo-cli");
+    // name 是可 @ 的 handle（不是会话名）；两条会话名都进 aka
+    expect(rows[0]!.name).toBe("leo");
     expect(rows[0]!.reach).toBe("online");
-    expect(rows[0]!.aka).toEqual(["leo-web"]);
+    expect(rows[0]!.aka).toEqual(["leo-cli", "leo-web"]);
   });
 
   test("agent 各自成行，不因同一 owner 被并到一起", () => {
@@ -91,7 +91,49 @@ describe("全局 who 的按人聚合（#1074）", () => {
         ],
       }],
     });
-    expect(rows.map((r) => r.name)).toEqual(["agent-live", "human-live", "offline-bot"]);
+    // 人类那行的 name 取 handle（h1），不是会话名
+    expect(rows.map((r) => r.name)).toEqual(["agent-live", "h1", "offline-bot"]);
+  });
+
+  test("人类行的 name 必须是可 @ 的 handle，而不是 UUID / lark:on_ 会话名", () => {
+    const rows = buildGlobalWho({
+      now: NOW,
+      channels: [{
+        slug: "alpha",
+        presence: [p("lark:on_deadbeefdeadbeef", { kind: "human", handle: "leo", display_name: "Leo", live: true })],
+      }],
+    });
+    expect(rows[0]!.name).toBe("leo");
+    expect(rows[0]!.mentionable).toBeUndefined();
+    expect(rows[0]!.aka).toEqual(["lark:on_deadbeefdeadbeef"]);
+  });
+
+  test("人类没有 handle 时如实标 mentionable:false，不谎称能 @", () => {
+    const rows = buildGlobalWho({
+      now: NOW,
+      channels: [{ slug: "alpha", presence: [p("193af9b8-cb06-4efe-a0f5-f1284bb8303e", { kind: "human", live: true })] }],
+    });
+    expect(rows[0]!.mentionable).toBe(false);
+    expect(rows[0]!.name).toBe("193af9b8-cb06-4efe-a0f5-f1284bb8303e");
+  });
+
+  test("handle 只出现在该人的某一条会话上时也要取到", () => {
+    const rows = buildGlobalWho({
+      now: NOW,
+      channels: [
+        { slug: "alpha", presence: [p("sess-1", { kind: "human", account: "leo@x.com", live: true })] },
+        { slug: "beta", presence: [p("sess-2", { kind: "human", account: "leo@x.com", handle: "leo", state: "offline", last_seen: NOW - 5_000 })] },
+      ],
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.name).toBe("leo");
+    expect(rows[0]!.mentionable).toBeUndefined();
+  });
+
+  test("agent 的 name 本身就是地址，恒可 @", () => {
+    const rows = buildGlobalWho({ now: NOW, channels: [{ slug: "alpha", presence: [p("bot")] }] });
+    expect(rows[0]!.name).toBe("bot");
+    expect(rows[0]!.mentionable).toBeUndefined();
   });
 
   test("归档频道不计入「我能到达谁」", () => {

--- a/cli/test/who-global.test.ts
+++ b/cli/test/who-global.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "bun:test";
+import type { PresenceEntry } from "@agentparty/shared";
+import { activeChannelSlugs, buildGlobalWho, personKeyOf, reachOf } from "../src/commands/who-global";
+
+const NOW = 1_700_000_000_000;
+
+function p(name: string, over: Partial<PresenceEntry> = {}): PresenceEntry {
+  return {
+    type: "presence",
+    name,
+    kind: "agent",
+    state: "waiting",
+    ts: NOW - 1_000,
+    last_seen: NOW - 1_000,
+    ...over,
+  } as PresenceEntry;
+}
+
+describe("全局 who 的可达性分档（#1074）", () => {
+  test("在线 > 可唤醒 > 最近 > 离线", () => {
+    expect(reachOf(p("a", { state: "working", last_seen: NOW - 1_000 }), NOW)).toBe("online");
+    expect(reachOf(p("a", { state: "working", live: true, last_seen: NOW - 86_400_000 }), NOW)).toBe("online");
+    // state 是自报的工作状态，不是连通性：久未露面的 working 不能算在线（实机踩到过）
+    expect(reachOf(p("a", { state: "working", last_seen: NOW - 49 * 86_400_000 }), NOW)).toBe("offline");
+    expect(reachOf(p("a", { state: "offline", last_seen: NOW - 10_000 }), NOW)).toBe("recent");
+    expect(reachOf(p("a", { state: "offline", last_seen: NOW - 3_600_000 }), NOW)).toBe("offline");
+  });
+});
+
+describe("全局 who 的按人聚合（#1074）", () => {
+  test("同一个人在多个频道只占一行，并列出全部频道", () => {
+    const rows = buildGlobalWho({
+      now: NOW,
+      channels: [
+        { slug: "alpha", presence: [p("leo-web", { kind: "human", handle: "leo", state: "offline", last_seen: NOW - 5_000 })] },
+        { slug: "beta", presence: [p("leo-cli", { kind: "human", handle: "leo", live: true })] },
+      ],
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.channels).toEqual(["alpha", "beta"]);
+    // 代表取可达性最好的那条会话
+    expect(rows[0]!.name).toBe("leo-cli");
+    expect(rows[0]!.reach).toBe("online");
+    expect(rows[0]!.aka).toEqual(["leo-web"]);
+  });
+
+  test("agent 各自成行，不因同一 owner 被并到一起", () => {
+    const rows = buildGlobalWho({
+      now: NOW,
+      channels: [{
+        slug: "alpha",
+        presence: [p("bot-a", { account: "leo@x.com" }), p("bot-b", { account: "leo@x.com" })],
+      }],
+    });
+    expect(rows.map((r) => r.name).sort()).toEqual(["bot-a", "bot-b"]);
+  });
+
+  test("只差大小写的账号是两个人；不透明账号不当归属展示", () => {
+    expect(personKeyOf(p("a", { kind: "human", account: "Acct" }))).not.toBe(
+      personKeyOf(p("b", { kind: "human", account: "acct" })),
+    );
+    const rows = buildGlobalWho({
+      now: NOW,
+      channels: [{ slug: "alpha", presence: [p("x", { kind: "human", account: "lark:on_deadbeef" })] }],
+    });
+    expect(rows[0]!.owner).toBeUndefined();
+  });
+
+  test("排除自己与 system；暂停会话必须标出", () => {
+    const rows = buildGlobalWho({
+      now: NOW,
+      self: "me",
+      channels: [{
+        slug: "alpha",
+        presence: [p("me"), p("system"), p("paused-bot", { paused: true })],
+      }],
+    });
+    expect(rows.map((r) => r.name)).toEqual(["paused-bot"]);
+    expect(rows[0]!.paused).toBe(true);
+  });
+
+  test("排序：先按可达性，同档 agent 在前", () => {
+    const rows = buildGlobalWho({
+      now: NOW,
+      channels: [{
+        slug: "alpha",
+        presence: [
+          p("offline-bot", { state: "offline", last_seen: NOW - 86_400_000 }),
+          p("human-live", { kind: "human", live: true, handle: "h1" }),
+          p("agent-live", { live: true }),
+        ],
+      }],
+    });
+    expect(rows.map((r) => r.name)).toEqual(["agent-live", "human-live", "offline-bot"]);
+  });
+
+  test("归档频道不计入「我能到达谁」", () => {
+    const slugs = activeChannelSlugs([
+      { slug: "live", title: null, archived_at: null } as never,
+      { slug: "dead", title: null, archived_at: NOW - 1 } as never,
+    ]);
+    expect(slugs).toEqual(["live"]);
+  });
+});


### PR DESCRIPTION
Closes #1074（拆自 #1073）

## 问题
`who` / `agents` 都是频道内视图——要用它们，你得先知道该进哪个频道。于是「找人」的真实路径是：开网页 → 看频道列表 → 进频道 → 看名单。owner 在 #1073 里的原话是「ocs 可以主动发现，AgentParty 要打开页面，人操作很麻烦」。

## 改动
`party who` 不带频道时，聚合「我已加入的未归档频道」的 presence，按人回答「我能到达谁」：

```
reachable across 13 channel(s) — pass a channel for wake diagnostics:
  ● codex-agentparty  agent  #codex 3h ago
  ● 王路  human  #agentparty +8 26m ago
  · server  agent  #ludo 2d ago
```

- **按人去重**：人靠全局昵称跨会话对上，其次账号；agent 恒各自成行（同一 owner 名下两个 agent 不是同一个东西）。与 web 名单（#1067）同一套聚合思路。
- **每行给出**可达性、归属（不透明账号串不展示）、出现在哪些频道、最近露面；被折叠的其它会话名进 `aka`。
- **`--json`** 逐行输出，字段 `name/kind/reach/owner?/channels[]/aka?/last_seen?/paused?`。
- 单个频道拉取失败只跳过并在末尾说明，不让一个坏频道毁掉整条命令。
- **不新增服务端接口**：只用现成的 `listChannels` + `fetchPresence`。

## 实机验证时抓到的一个真问题
第一版把 `state !== "offline"` 当作在线，结果一堆 **14–52 天没露面、state 仍是 `working`** 的会话被标成 ●在线。`state` 是自报的**工作**状态，不是连通性。已改为复用频道内 who 的权威口径（`state !== offline && (live || 新鲜)`），可唤醒走 `autoWakeReachable`。修正后实机复验，那些会话正确落到离线档。

## 边界
频道内 who 的诊断能力（为什么叫不醒、pull wake、任务租约冲突等）**保持不变**，全局视图只负责「先找到人」，需要诊断仍要显式给频道——输出第一行就是这么提示的。

## 验证
- `bunx tsc --noEmit` 0 错
- 新增 `cli/test/who-global.test.ts` 7 条（分档口径含那条实机踩到的回归、跨频道聚合、agent 不被并、大小写账号、排除自己与 system、暂停标注、归档频道不计入）
- `who` 相关既有测试 89/89
- 实机跑通 `party who` 与 `party who --json`

https://claude.ai/code/session_01HUmERHTXnbZhCZCwV6fGxD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - `party who` 在未指定频道时支持全局视图，汇总用户加入的频道并按人员展示。
  - 同一人员出现在多个频道时合并为一行，同时显示所属频道、别名、最近活跃时间及暂停状态。
  - 提供在线、可唤醒、最近活跃和离线等可达性状态，并排除系统账号和当前用户。
  - 支持终端及 JSON 输出；个别频道读取失败时仍会继续处理其他频道。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->