### PR TITLE
fix(cli): 全局 who 加 --all 入口，绑定频道 404 时退回全局（#1074 补）

### DIFF
--- a/cli/src/commands/who.ts
+++ b/cli/src/commands/who.ts
@@ -14,15 +14,15 @@ import {
   type TaskLeaseEnforcement,
 } from "../task-lease-diagnosis";
 import { resolveAuth } from "../oidc-cli";
-import { fetchPresence, fetchReadCursors, fetchRuntimePeers, handleRestError } from "../rest";
+import { fetchPresence, fetchReadCursors, fetchRuntimePeers, handleRestError, RestError } from "../rest";
 import { buildRuntimeTopology } from "../runtime-topology";
 import { localStatuslineBase, unreadFromCursor, writeStatuslineCache } from "../statusline-cache";
 import { sanitizeSingleLine } from "../format";
 import { buildPullWakeLookup, pullWakeDelivers, type PullWakeHint, type PullWakeLookup } from "../pull-wake";
 import { isSlug } from "../validation";
 
-const WHO_FLAGS = ["channel", "json"];
-const HELP = `usage: party who [channel|--channel C] [--json]
+const WHO_FLAGS = ["channel", "json", "all"];
+const HELP = `usage: party who [channel|--channel C] [--all] [--json]
 
 List who is in a channel, tiered by how you can reach them:
   ● online    connected right now
@@ -103,6 +103,9 @@ A human is @-notified by their handle (their web client matches on handle, not t
 session name), so mention the "@handle" shown here — not a UUID session name.
 
 Options:
+  --all         ignore the bound channel: list everyone you can reach across all
+                your channels, one row per person (#1074). Wake diagnostics still
+                need a channel.
   --channel C   read channel C instead of the bound channel
   --json        emit one JSON object per line
                 (name/kind/tier/live/residency/unreachable/pull_wake/wake_guidance/wake/wake_unverified/busy/queue_depth/waiting_owner_count/unhandled_mention_count/oldest_unhandled_mention_seq/pending_mention_seqs/last_receipt_seq/not_in_turn_since/current_task/task_started_at/heartbeat_at/activity/listening/runner_health/idle_watches/agent_session/topology_conflicts/task_lease/reception_mode/reception_runner/reception_context/scope/scope_conflicts/account/handle/display_name/age_ms/read_seq)`;
@@ -860,7 +863,11 @@ export async function run(argv: string[]): Promise<number> {
     console.error(flagError);
     return 1;
   }
-  const channel = resolveChannel(str(flags.channel) ?? positionals[0]);
+  const channel = flags.all === true ? null : resolveChannel(str(flags.channel) ?? positionals[0]);
+  if (flags.all === true && (str(flags.channel) !== undefined || positionals[0] !== undefined)) {
+    console.error("--all lists everyone across your channels; drop the channel argument");
+    return 1;
+  }
   if (!channel) {
     // #1074：没有频道时不再报错退出——聚合「我已加入的所有频道」，回答「我能到达谁」。
     // 频道内 who 的诊断细节（为什么叫不醒）仍需显式给频道，这里只解决「先找到人」。
@@ -871,7 +878,18 @@ export async function run(argv: string[]): Promise<number> {
     return 1;
   }
   try {
-    const presence = await fetchPresence(cfg.server, cfg.token, channel);
+    let presence;
+    try {
+      presence = await fetchPresence(cfg.server, cfg.token, channel);
+    } catch (err: unknown) {
+      // 绑定的频道可能早就没了（改名/归档/换服务器）。此时报「找不到频道」等于把人堵死，
+      // 而我们完全知道他还能到达谁——退回全局视图，并说明为什么。
+      if (err instanceof RestError && err.status === 404) {
+        console.error(`channel ${channel} not found — showing everyone across your channels instead (party who --all)`);
+        return runGlobalWho(cfg, flags.json === true);
+      }
+      throw err;
+    }
     let runtimePeers: RuntimePeerDiscovery | undefined;
     const runtimeTopology = buildRuntimeTopology(cfg.server);
     if (runtimeTopology !== undefined) {

--- a/cli/test/who-global.test.ts
+++ b/cli/test/who-global.test.ts
@@ -178,3 +178,26 @@ describe("全局 who 的终端渲染（#1074）", () => {
     expect(line).toContain("aka sess-1, sess-2 +1");
   });
 });
+
+// #1074 的入口可达性：绑定频道的目录里 `party who` 仍是频道视图（向后兼容），
+// 全局视图靠 --all 显式进入；绑定频道已不存在（404）时自动退回全局并说明原因。
+// 这两条在 who.ts 的命令层，属于源码守卫：只断言分支存在，不起真网络。
+import { readFileSync } from "node:fs";
+const whoSource = readFileSync(new URL("../src/commands/who.ts", import.meta.url), "utf8");
+
+describe("全局 who 的入口（#1074 补）", () => {
+  test("--all 是显式入口，且与频道参数互斥", () => {
+    expect(whoSource).toContain('"all"');
+    expect(whoSource).toContain("flags.all === true ? null : resolveChannel");
+    expect(whoSource).toContain("--all lists everyone across your channels; drop the channel argument");
+  });
+
+  test("绑定频道 404 时退回全局视图，而不是死在「找不到频道」", () => {
+    expect(whoSource).toContain("err instanceof RestError && err.status === 404");
+    expect(whoSource).toContain("showing everyone across your channels instead");
+  });
+
+  test("帮助文本里写明 --all", () => {
+    expect(whoSource).toContain("[--all]");
+  });
+});


### PR DESCRIPTION
接 #1077（已合并、随 v0.2.258 发布）。**用发布版实测发现这个功能几乎触发不到**，属于我上一轮的疏漏。

## 问题
`party who` 的全局视图只在 `resolveChannel` 返回空时才走。而现实中绝大多数目录都能解析出某个绑定频道，于是：

```
$ party who            # 在已绑定的目录里
error: not_found channel not found     ← 绑定的频道在服务端已不存在，直接失败
```

两个后果：
1. 全局视图对多数用户不可达——功能等于没上；
2. 绑定频道失效时直接报错退出，而我们明明知道这个人还能到达谁。

## 改动
- **`--all`**：显式进入全局视图，无视绑定频道；与频道参数互斥（同时给会明确报错而不是静默忽略）。
- **404 兜底**：绑定频道不存在时自动退回全局视图，stderr 说明原因并指向 `--all`。
- 频道视图的行为与输出**一字未改**，向后兼容。
- 帮助文本补 `--all`，并写明唤醒诊断仍需指定频道。

## 验证
- `bunx tsc --noEmit` 0 错
- 实测：`party who --all` 给出跨 13 个频道的全局视图；`party --config … who` 的频道视图输出与改动前一致
- `who` 相关测试全过，新增 3 条源码守卫锁住 `--all` 分支、404 兜底分支与帮助文本

https://claude.ai/code/session_01HUmERHTXnbZhCZCwV6fGxD