### PR TITLE
feat(cli): 接入引导加颜色、收篇幅（#1073）

### DIFF
--- a/cli/src/commands/hook.ts
+++ b/cli/src/commands/hook.ts
@@ -563,7 +563,9 @@ async function runInstall(argv: string[]): Promise<number> {
   // 并给出恰一条修法——这里再把整份清单和那段来龙去脉印一遍，就成了同一段修复说明连印两遍
   // （用户原话：「这个长篇大论的篇幅，用户都懵了」）。brief 只压掉解说与清单重播，
   // **信任确认那一问照问**（它要人当场敲 y，压掉等于装了个不会跑的 hook）。
-  const brief = argv.includes("--brief");
+  // 与 hookScope 同一纪律：只认 `--` 终止符之前的旗标（`hook install -- --brief` 不算）。
+  const briefBoundary = argv.indexOf("--");
+  const brief = (briefBoundary === -1 ? argv : argv.slice(0, briefBoundary)).includes("--brief");
   const path = settingsPath(scope);
   const source = existsSync(path) ? readFileSync(path, "utf8") : null;
   // serve 用同一份 hooks 配置生成器（#602），装出来的行为与托管 lane 完全一致。

--- a/cli/src/commands/hook.ts
+++ b/cli/src/commands/hook.ts
@@ -559,6 +559,11 @@ function termText(value: string): string {
 
 async function runInstall(argv: string[]): Promise<number> {
   const scope = hookScope(argv);
+  // #1073：`--brief` 给 party join 用。join 装完 hook 后，第 2 步会用**同一份**唤醒清单判过/不过
+  // 并给出恰一条修法——这里再把整份清单和那段来龙去脉印一遍，就成了同一段修复说明连印两遍
+  // （用户原话：「这个长篇大论的篇幅，用户都懵了」）。brief 只压掉解说与清单重播，
+  // **信任确认那一问照问**（它要人当场敲 y，压掉等于装了个不会跑的 hook）。
+  const brief = argv.includes("--brief");
   const path = settingsPath(scope);
   const source = existsSync(path) ? readFileSync(path, "utf8") : null;
   // serve 用同一份 hooks 配置生成器（#602），装出来的行为与托管 lane 完全一致。
@@ -576,7 +581,7 @@ async function runInstall(argv: string[]): Promise<number> {
   // 进程死在写中途会留半截 JSON——毁掉的正是 merge 拼命保护的用户手写配置（#617 评审）。
   atomicWriteText(path, next);
   console.log(`hooks installed -> ${termText(path)}`);
-  console.log(
+  if (!brief) console.log(
     scope === "codex"
       ? "codex 交互式会话现在会在 SessionStart 入册到 ~/.agentparty/codex-sessions/；" +
         "codex 无会话结束事件，出册靠进程探活。\n" +
@@ -598,8 +603,10 @@ async function runInstall(argv: string[]): Promise<number> {
     // 「新的或改动过的」hook 发问，带 trusted_hash 且 enabled=false 的它再也不会问；桌面版连
     // 界面都没有）。所以这一步由我们收集用户的确认：问一句，敲 y 才写。
     await offerCodexHookTrust(argv);
-    console.log("");
-    for (const line of formatWakeChecklist(buildWakeChecklist(diagnoseCodexWake()))) console.log(line);
+    if (!brief) {
+      console.log("");
+      for (const line of formatWakeChecklist(buildWakeChecklist(diagnoseCodexWake()))) console.log(line);
+    }
   }
   return 0;
 }

--- a/cli/src/commands/join.ts
+++ b/cli/src/commands/join.ts
@@ -982,7 +982,8 @@ function receiveModeStep(): Step<JoinCtx> {
         return { ok: true, summary, detail };
       }
       if (harness === "codex") {
-        const hookArgs = ["install", "--codex"];
+        // --brief：装完别再把整份唤醒清单印一遍——紧接着这一步就用同一份清单判过/不过并给一条修法（#1073）。
+        const hookArgs = ["install", "--codex", "--brief"];
         if (opts.yes) hookArgs.push("--yes");
         const hookCode = await deps.hookRun(hookArgs);
         const detail = hookCode === 0 ? [] : [outcomeLine("装 + 批准 codex hook", { level: "warn", msg: `party hook install --codex 退出码 ${hookCode}` })];

--- a/cli/src/commands/join.ts
+++ b/cli/src/commands/join.ts
@@ -77,6 +77,7 @@ import {
 import { resolveClaudeDefaultArgs, type ClaudeDefaultArgsResolution } from "../claude-default-args";
 import { claudeLaunchPlan } from "./claude-launch";
 import { STEP_INDENT, runSteps, type Step, type StepResult } from "../onboarding/steps";
+import { processStyle, styleFor, type Style } from "../onboarding/color";
 import { verifyWakeRoundTrip, type VerifyWakeDeps } from "../onboarding/verify-wake";
 import { normalizeWakeLang, resolveWakeLang, type WakeLang } from "../wake-note-i18n";
 import { findHarnessAncestor } from "../join-binding";
@@ -94,7 +95,7 @@ export { probeClaudeArmedListener };
 const JOIN_FLAGS = ["server", "channel", "as", "harness", "mention", "lang"];
 /** 每一步「做完重跑」的那条命令——引导幂等，修好了就再跑同一条。 */
 const RERUN = "party join";
-const HELP = `usage: AGENTPARTY_TOKEN='<token>' party join --server URL --channel SLUG --as NAME [--harness codex|claude|other] [--mention name] [--lang zh|en] [--yes] [--coexist]
+const HELP = `usage: AGENTPARTY_TOKEN='<token>' party join --server URL --channel SLUG --as NAME [--harness codex|claude|other] [--mention name] [--lang zh|en] [--yes] [--coexist] [--verbose]
 
 One command that does the whole join as guided steps (#987/#988):
   第 0 步 版本      CLI version; claude plugin installed + aligned to the CLI (#961/#985)
@@ -133,7 +134,8 @@ Options:
                  \`party init --coexist\`); default is replace
   --lang zh|en   language of the wake notes injected into this agent's session (stored in
                  config, passed to \`party init --lang\`). Omit to auto-detect from the
-                 agent's own recent channel messages (#1003)`;
+                 agent's own recent channel messages (#1003)
+  --verbose      印出过了的步骤里的每一条子检查；缺省只印异常的那些（没过的步骤永远全印）`;
 
 // 每一步的结果。level 决定它在自检里怎么呈现；gate=true 的步骤决定「就绪 / 还差」。
 type StepLevel = "ok" | "skip" | "warn" | "fail";
@@ -206,6 +208,8 @@ interface CodexWakeLayerState {
 
 /** 注入点：测试喂假 spawn（不碰真机的 claude/codex 二进制），其余走真实 init/hook/send。 */
 export interface JoinDeps {
+  /** 着色器；测试与非 TTY 不给＝不着色（真机由 defaultJoinDeps 按 TTY/NO_COLOR 决定）。 */
+  style?: Style;
   spawn: typeof spawnSync;
   initRun: (argv: string[]) => Promise<number>;
   hookRun: (argv: string[]) => Promise<number>;
@@ -290,6 +294,8 @@ export interface JoinOptions {
   token: string;
   /** #1003：唤醒文案语言的显式覆盖（`--lang zh|en`），交给 party init 写进 config；缺省 null＝自动判定。 */
   lang?: WakeLang | null;
+  /** #1073：`--verbose` 把过了的步骤里的 ✓/· 子项也印出来；缺省只印异常子项。 */
+  verbose?: boolean;
 }
 
 function configFileName(agentName: string, slug: string): string {
@@ -762,6 +768,41 @@ function outcomeLine(name: string, outcome: StepOutcome): string {
   return `${symbol(outcome.level)} ${name}: ${outcome.msg}`;
 }
 
+
+// #1073 收篇幅：join 里跑的子命令（party init / party send）会把自己那套逐行日志直接打到
+// stdout——「created channel / bound channel / config written / runtime / sent seq=1」一次六七行，
+// 而这些都已经被第 1 步那一行摘要概括了。成功就吞掉，**失败或 --verbose 才原样回放**：出问题时
+// 那几行往往是唯一线索，绝不能真丢。
+//
+// 只包 init/send 这两个非交互子命令。hook install 可能要人按键批准，吞它的输出＝让人对着空屏等。
+async function quietSubcommand(
+  run: () => Promise<number>,
+  opts: { verbose: boolean; log: (line: string) => void },
+): Promise<number> {
+  const buffered: string[] = [];
+  const capture = (...args: unknown[]) => {
+    buffered.push(args.map((a) => (typeof a === "string" ? a : String(a))).join(" "));
+  };
+  const realLog = console.log;
+  const realError = console.error;
+  console.log = capture;
+  console.error = capture;
+  let code: number;
+  try {
+    code = await run();
+  } catch (e) {
+    console.log = realLog;
+    console.error = realError;
+    for (const line of buffered) opts.log(`${STEP_INDENT}${line}`);
+    throw e;
+  } finally {
+    console.log = realLog;
+    console.error = realError;
+  }
+  if (code !== 0 || opts.verbose) for (const line of buffered) opts.log(`${STEP_INDENT}${line}`);
+  return code;
+}
+
 /**
  * 第 0 步 版本：CLI 版本；claude 档还要插件装到位、已启用、与 CLI 同版（#961/#985）。
  * rerun 只进修法文案里的「然后重跑 …」（recover 传自己的那条）。
@@ -849,7 +890,7 @@ function identityStep(harnessKnown: boolean): Step<JoinCtx> {
       if (harnessKnown) initArgs.push("--harness", harness);
       if (opts.coexist) initArgs.push("--coexist");
       if (opts.lang !== undefined && opts.lang !== null) initArgs.push("--lang", opts.lang);
-      const initCode = await deps.initRun(initArgs);
+      const initCode = await quietSubcommand(() => deps.initRun(initArgs), { verbose: ctx.opts.verbose === true, log: deps.log });
       if (initCode !== 0) {
         return {
           ok: false,
@@ -893,7 +934,7 @@ function identityStep(harnessKnown: boolean): Step<JoinCtx> {
       // 报到（#597）。init 只写配置不发言，必须补这一条，否则网页/频道里看不到你。能 @ 邀请人就 @。
       const sendArgs = [`👋 ${agentName} 报到，来参与协作`, "--channel", slug];
       if (opts.mention !== null) sendArgs.push("--mention", opts.mention);
-      const sendCode = await deps.sendRun(sendArgs);
+      const sendCode = await quietSubcommand(() => deps.sendRun(sendArgs), { verbose: ctx.opts.verbose === true, log: deps.log });
       if (sendCode !== 0) {
         return {
           ok: false,
@@ -1207,14 +1248,16 @@ export async function runJoin(opts: JoinOptions, deps: JoinDeps): Promise<number
   const steps: Step<JoinCtx>[] = harness === "other"
     ? [versionStep(), identityStep(harnessKnown), receiveModeStep()]
     : [versionStep(), identityStep(harnessKnown), receiveModeStep(), wakeableSessionStep()];
-  let outcome = await runSteps({ steps, ctx, log: deps.log, rerun: RERUN });
+  const style = deps.style ?? styleFor(false);
+  const verbose = opts.verbose === true;
+  let outcome = await runSteps({ steps, ctx, log: deps.log, rerun: RERUN, style, verbose });
   // 第 4 步单独一轮：第 3 步选了「在这个终端起」时它不在 join 里跑（验证挪进新会话，#989），其余照旧接着跑。
   if (outcome.ok && harness !== "other" && !ctx.launchAfterJoin) {
-    outcome = await runSteps({ steps: [verifyStep()], ctx, log: deps.log, rerun: RERUN, firstIndex: 4 });
+    outcome = await runSteps({ steps: [verifyStep()], ctx, log: deps.log, rerun: RERUN, firstIndex: 4, style, verbose });
   }
   deps.log("");
   if (!outcome.ok) {
-    deps.log(`接入停在第 ${outcome.stoppedAt.index} 步（${outcome.stoppedAt.title}）——做完上面那一条，重跑同一条 ${RERUN}。`);
+    deps.log(style.bad(`接入停在第 ${outcome.stoppedAt.index} 步（${outcome.stoppedAt.title}）——做完上面那一条，重跑同一条 ${RERUN}。`));
     // 这句是整段引导存在的理由：这类失败**没有任何报错**，不明说就没人知道自己坏了。
     deps.log("在这一步完成之前：@ 你可能不会有任何反应，而且不会有任何报错——别人只会以为你在忙。");
     return 1;
@@ -1292,8 +1335,8 @@ export async function run(argv: string[]): Promise<number> {
     console.log(HELP);
     return 0;
   }
-  const { flags } = parseArgs(argv, { booleans: ["yes", "coexist"] });
-  const unknown = unknownFlagError(flags, [...JOIN_FLAGS, "yes", "coexist"]);
+  const { flags } = parseArgs(argv, { booleans: ["yes", "coexist", "verbose"] });
+  const unknown = unknownFlagError(flags, [...JOIN_FLAGS, "yes", "coexist", "verbose"]);
   if (unknown !== null) {
     console.error(unknown);
     return 1;
@@ -1356,7 +1399,7 @@ export async function run(argv: string[]): Promise<number> {
   }
 
   return runJoin(
-    { server, channel: slug, agentName, harnessFlag, mention, yes: flags.yes === true, coexist: flags.coexist === true, token, lang },
+    { server, channel: slug, agentName, harnessFlag, mention, yes: flags.yes === true, coexist: flags.coexist === true, token, lang, verbose: flags.verbose === true },
     defaultJoinDeps(slug),
   );
 }
@@ -1376,6 +1419,7 @@ export function codexSessionIdFromEnvironment(env: NodeJS.ProcessEnv): string | 
 
 export function defaultJoinDeps(slug: string): JoinDeps {
   return {
+    style: processStyle(),
     spawn: spawnSync,
     initRun: (a) => import("./init").then((m) => m.run(a)),
     hookRun: (a) => import("./hook").then((m) => m.run(a)),

--- a/cli/src/commands/join.ts
+++ b/cli/src/commands/join.ts
@@ -777,29 +777,36 @@ function outcomeLine(name: string, outcome: StepOutcome): string {
 // 只包 init/send 这两个非交互子命令。hook install 可能要人按键批准，吞它的输出＝让人对着空屏等。
 async function quietSubcommand(
   run: () => Promise<number>,
-  opts: { verbose: boolean; log: (line: string) => void },
+  opts: { verbose: boolean; log: (line: string) => void; errlog: (line: string) => void },
 ): Promise<number> {
-  const buffered: string[] = [];
-  const capture = (...args: unknown[]) => {
-    buffered.push(args.map((a) => (typeof a === "string" ? a : String(a))).join(" "));
+  // 两路分开存：回放时 stderr 仍走 stderr。合成一路会把子命令的报错挪到 stdout，
+  // 让 `party join 2>errors.log` 这类用法再也捞不到失败原因——收篇幅不该改变流的语义。
+  const buffered: { stream: "out" | "err"; line: string }[] = [];
+  const capture = (stream: "out" | "err") => (...args: unknown[]) => {
+    buffered.push({ stream, line: args.map((a) => (typeof a === "string" ? a : String(a))).join(" ") });
   };
   const realLog = console.log;
   const realError = console.error;
-  console.log = capture;
-  console.error = capture;
+  console.log = capture("out");
+  console.error = capture("err");
+  const replay = () => {
+    for (const { stream, line } of buffered) {
+      (stream === "err" ? opts.errlog : opts.log)(`${STEP_INDENT}${line}`);
+    }
+  };
   let code: number;
   try {
     code = await run();
   } catch (e) {
     console.log = realLog;
     console.error = realError;
-    for (const line of buffered) opts.log(`${STEP_INDENT}${line}`);
+    replay();
     throw e;
   } finally {
     console.log = realLog;
     console.error = realError;
   }
-  if (code !== 0 || opts.verbose) for (const line of buffered) opts.log(`${STEP_INDENT}${line}`);
+  if (code !== 0 || opts.verbose) replay();
   return code;
 }
 
@@ -890,7 +897,7 @@ function identityStep(harnessKnown: boolean): Step<JoinCtx> {
       if (harnessKnown) initArgs.push("--harness", harness);
       if (opts.coexist) initArgs.push("--coexist");
       if (opts.lang !== undefined && opts.lang !== null) initArgs.push("--lang", opts.lang);
-      const initCode = await quietSubcommand(() => deps.initRun(initArgs), { verbose: ctx.opts.verbose === true, log: deps.log });
+      const initCode = await quietSubcommand(() => deps.initRun(initArgs), { verbose: ctx.opts.verbose === true, log: deps.log, errlog: deps.errlog });
       if (initCode !== 0) {
         return {
           ok: false,
@@ -934,7 +941,7 @@ function identityStep(harnessKnown: boolean): Step<JoinCtx> {
       // 报到（#597）。init 只写配置不发言，必须补这一条，否则网页/频道里看不到你。能 @ 邀请人就 @。
       const sendArgs = [`👋 ${agentName} 报到，来参与协作`, "--channel", slug];
       if (opts.mention !== null) sendArgs.push("--mention", opts.mention);
-      const sendCode = await quietSubcommand(() => deps.sendRun(sendArgs), { verbose: ctx.opts.verbose === true, log: deps.log });
+      const sendCode = await quietSubcommand(() => deps.sendRun(sendArgs), { verbose: ctx.opts.verbose === true, log: deps.log, errlog: deps.errlog });
       if (sendCode !== 0) {
         return {
           ok: false,

--- a/cli/src/commands/recover.ts
+++ b/cli/src/commands/recover.ts
@@ -26,10 +26,11 @@ import { type JoinPackHarness, mcpServerName } from "@agentparty/shared/onboardi
 import { RestError, fetchMe, type Identity } from "../rest";
 import { isSlug } from "../validation";
 import { runSteps, type Step } from "../onboarding/steps";
+import { processStyle } from "../onboarding/color";
 import { completionLine, defaultJoinDeps, verifyStep, versionStep, wakeableSessionStep, type JoinCtx, type JoinDeps } from "./join";
 
 const RECOVER_FLAGS = ["harness"];
-const HELP = `usage: party recover <channel> [--harness codex|claude|other] [--yes]
+const HELP = `usage: party recover <channel> [--harness codex|claude|other] [--yes] [--verbose]
 
 Recover / reconnect an identity this machine already joined (#991) — no need to remember
 the original \`party join\` line or its token. Guided steps, same engine as \`party join\`:
@@ -65,6 +66,8 @@ export interface RecoverOptions {
   channel: string;
   harnessFlag: JoinPackHarness | null;
   yes: boolean;
+  /** #1073：印出过了的步骤里的每一条子检查；缺省只印异常的那些。 */
+  verbose?: boolean;
 }
 
 /** 第 1 步找回的结果，第 2～4 步靠它组 ctx。 */
@@ -245,13 +248,15 @@ export async function runRecover(opts: RecoverOptions, deps: RecoverDeps): Promi
   };
   // 第 2 步是 join 的第 0 步，第 3/4 步是 join 的第 3/4 步——同一份实现，只换 rerun 文案。
   const steps: Step<RecoverCtx>[] = [recoverIdentityStep(rerun), versionStep(rerun), ...harnessGatedWakeSteps()];
-  const outcome = await runSteps({ steps, ctx, log: deps.log, rerun, firstIndex: 1 });
+  // 与 join 同一套呈现：着色 + 过了的步骤只印异常子项（#1073）。
+  const style = processStyle();
+  const outcome = await runSteps({ steps, ctx, log: deps.log, rerun, firstIndex: 1, style, verbose: opts.verbose === true });
   deps.log("");
   if (outcome.ok) {
     deps.log(completionLine(ctx, "恢复完成"));
     return 0;
   }
-  deps.log(`恢复停在第 ${outcome.stoppedAt.index} 步（${outcome.stoppedAt.title}）——做完上面那一条，重跑同一条 ${rerun}。`);
+  deps.log(style.bad(`恢复停在第 ${outcome.stoppedAt.index} 步（${outcome.stoppedAt.title}）——做完上面那一条，重跑同一条 ${rerun}。`));
   deps.log("在这一步完成之前：@ 你可能不会有任何反应，而且不会有任何报错——别人只会以为你在忙。");
   return 1;
 }
@@ -284,8 +289,8 @@ export async function run(argv: string[]): Promise<number> {
     console.log(HELP);
     return 0;
   }
-  const { flags, positionals } = parseArgs(argv, { booleans: ["yes"] });
-  const unknown = unknownFlagError(flags, [...RECOVER_FLAGS, "yes"]);
+  const { flags, positionals } = parseArgs(argv, { booleans: ["yes", "verbose"] });
+  const unknown = unknownFlagError(flags, [...RECOVER_FLAGS, "yes", "verbose"]);
   if (unknown !== null) {
     console.error(unknown);
     return 1;
@@ -310,7 +315,7 @@ export async function run(argv: string[]): Promise<number> {
     return 1;
   }
   const harnessFlag = (harnessFlagRaw ?? null) as JoinPackHarness | null;
-  return runRecover({ channel: slug, harnessFlag, yes: flags.yes === true }, defaultRecoverDeps(slug));
+  return runRecover({ channel: slug, harnessFlag, yes: flags.yes === true, verbose: flags.verbose === true }, defaultRecoverDeps(slug));
 }
 
 export function defaultRecoverDeps(slug: string): RecoverDeps {

--- a/cli/src/commands/recover.ts
+++ b/cli/src/commands/recover.ts
@@ -48,7 +48,8 @@ No binding / revoked token / renamed identity ⇒ stops at 第 1 步 with the \`
 Options:
   --harness H    pick the binding of this harness when this directory bound the channel under
                  several (codex | claude | other). Omit to auto-detect from the process tree.
-  --yes          accepted for symmetry with \`party join\`; recover never prompts`;
+  --yes          accepted for symmetry with \`party join\`; recover never prompts
+  --verbose      印出过了的步骤里的每一条子检查；缺省只印异常的那些（没过的步骤永远全印）`;
 
 /** 注入点：join 的那一套（步骤 2/3/4 的探活）+ 第 1 步自己的三样。 */
 export interface RecoverDeps extends JoinDeps {

--- a/cli/src/onboarding/color.ts
+++ b/cli/src/onboarding/color.ts
@@ -1,0 +1,59 @@
+// 接入引导的着色（#1073 第 1 点）。
+//
+// 引导输出是一屏纯文本，「哪一步过了、卡在哪、要跑哪条命令」全靠人逐行读。加色不是好看：
+// ✗ 和修法命令要在一眼扫下来时先跳出来。
+//
+// 纪律：**只给本地生成的结构元素上色**——步骤序号、✓/✗/!/· 符号、修法命令。摘要与补充行里
+// 可能混进服务端可控文本（身份、频道名、错误消息），给它们套色码等于把 reset 序列的控制权
+// 交给远端：一个 \x1b[0m 就能提前收色、后面的伪造文本继承我们的样式。那类文本一律不着色。
+// （同理，这里绝不 strip——清洗是 format.ts 的职责，重复实现只会两边漂移。）
+
+/** 一组着色函数；关闭着色时全部是恒等函数。 */
+export interface Style {
+  ok(text: string): string;
+  bad(text: string): string;
+  warn(text: string): string;
+  dim(text: string): string;
+  bold(text: string): string;
+  cmd(text: string): string;
+}
+
+const PLAIN: Style = {
+  ok: (t) => t,
+  bad: (t) => t,
+  warn: (t) => t,
+  dim: (t) => t,
+  bold: (t) => t,
+  cmd: (t) => t,
+};
+
+const wrap = (code: string) => (text: string): string => `\x1b[${code}m${text}\x1b[0m`;
+
+const COLOR: Style = {
+  ok: wrap("32"),
+  bad: wrap("31"),
+  warn: wrap("33"),
+  dim: wrap("2"),
+  bold: wrap("1"),
+  cmd: wrap("36"),
+};
+
+/**
+ * 该不该着色。优先级照通行约定：NO_COLOR（只看有没有设，空串也算设了）> FORCE_COLOR >
+ * TERM=dumb > 输出是不是 TTY。管道重定向到文件默认不带色，所以贴日志给别人看不会一堆乱码。
+ */
+export function colorEnabled(env: Record<string, string | undefined>, isTty: boolean): boolean {
+  if (env.NO_COLOR !== undefined) return false;
+  if (env.FORCE_COLOR !== undefined && env.FORCE_COLOR !== "0") return true;
+  if (env.TERM === "dumb") return false;
+  return isTty;
+}
+
+export function styleFor(enabled: boolean): Style {
+  return enabled ? COLOR : PLAIN;
+}
+
+/** 进程默认：按当前 env 与 stdout 是否 TTY 决定。 */
+export function processStyle(): Style {
+  return styleFor(colorEnabled(process.env, process.stdout.isTTY === true));
+}

--- a/cli/src/onboarding/steps.ts
+++ b/cli/src/onboarding/steps.ts
@@ -23,6 +23,7 @@
 //    `--yes` / 无 TTY 时按默认走并把所选印出来。
 
 import { styleFor, type Style } from "./color";
+import { sanitizeSingleLine } from "../format";
 
 /** 一步跑完的结果。 */
 export interface StepResult {
@@ -57,9 +58,18 @@ export type StepsOutcome =
 export const STEP_INDENT = "         ";
 
 /** 「第 N 步  标题 · 摘要 ✓」这一行。 */
+// 摘要、补充行、修法命令里混着服务端可控文本（身份、频道名、init/send 的错误消息）。它们会被
+// 原样打进终端——#372 那条老纪律照样适用：一条含 ESC 的文本就能注入 OSC52 剪贴板写入、或用光标/
+// 清屏序列伪造整屏输出。而这里每一行都是「一行一条」的结构，残留的换行/TAB 还能伪造出一整个
+// 步骤行。所以出口统一过 sanitizeSingleLine，**清洗在前、着色在后**（顺序反了会把我们自己的
+// 色码一起洗掉）。
+function clean(text: string): string {
+  return sanitizeSingleLine(text);
+}
+
 export function formatStepLine(index: number, title: string, result: StepResult, style: Style = styleFor(false)): string {
   const mark = result.ok ? style.ok("✓") : style.bad("✗");
-  return `${style.dim(`第 ${index} 步`)}  ${style.bold(title)} · ${result.summary} ${mark}`;
+  return `${style.dim(`第 ${index} 步`)}  ${style.bold(clean(title))} · ${clean(result.summary)} ${mark}`;
 }
 
 // 过了的步骤里，`✓ 子项: …` / `· 子项: …` 是「一切正常」的流水账（#1073 第 2 点）：join 一次
@@ -87,12 +97,12 @@ export function formatStep(
 ): string[] {
   const style = opts.style ?? styleFor(false);
   const lines = [formatStepLine(index, title, result, style)];
-  for (const d of visibleDetail(result, opts.verbose === true)) lines.push(`${STEP_INDENT}${d}`);
+  for (const d of visibleDetail(result, opts.verbose === true)) lines.push(`${STEP_INDENT}${clean(d)}`);
   if (!result.ok) {
     const fix = result.fix ?? { do: rerun };
-    for (const n of fix.notes ?? []) lines.push(`${STEP_INDENT}${n}`);
-    lines.push(`${STEP_INDENT}${style.bold(`修法（做完重跑同一条 ${rerun}）：`)}`);
-    lines.push(`${STEP_INDENT}  ${style.cmd(fix.do)}`);
+    for (const n of fix.notes ?? []) lines.push(`${STEP_INDENT}${clean(n)}`);
+    lines.push(`${STEP_INDENT}${style.bold(`修法（做完重跑同一条 ${clean(rerun)}）：`)}`);
+    lines.push(`${STEP_INDENT}  ${style.cmd(clean(fix.do))}`);
   }
   return lines;
 }

--- a/cli/src/onboarding/steps.ts
+++ b/cli/src/onboarding/steps.ts
@@ -22,6 +22,8 @@
 //  - **不交互**：机器只打印。要问用户的（第 2 步选接收方式）由那一步的 run 自己决定问不问，
 //    `--yes` / 无 TTY 时按默认走并把所选印出来。
 
+import { styleFor, type Style } from "./color";
+
 /** 一步跑完的结果。 */
 export interface StepResult {
   ok: boolean;
@@ -55,8 +57,20 @@ export type StepsOutcome =
 export const STEP_INDENT = "         ";
 
 /** 「第 N 步  标题 · 摘要 ✓」这一行。 */
-export function formatStepLine(index: number, title: string, result: StepResult): string {
-  return `第 ${index} 步  ${title} · ${result.summary} ${result.ok ? "✓" : "✗"}`;
+export function formatStepLine(index: number, title: string, result: StepResult, style: Style = styleFor(false)): string {
+  const mark = result.ok ? style.ok("✓") : style.bad("✗");
+  return `${style.dim(`第 ${index} 步`)}  ${style.bold(title)} · ${result.summary} ${mark}`;
+}
+
+// 过了的步骤里，`✓ 子项: …` / `· 子项: …` 是「一切正常」的流水账（#1073 第 2 点）：join 一次
+// 能刷十几行，真正要读的结论反而被推出屏幕。所以**过了的步骤只印异常子项**（! / ✗）与自由文本
+// 补充行（第 2 步「你选了什么」那种，没有前缀符号）。没过的步骤照原样全印——那时每一行都是线索。
+// `--verbose` 恢复全印。
+const ROUTINE_DETAIL = /^[✓·]\s/u;
+function visibleDetail(result: StepResult, verbose: boolean): string[] {
+  const detail = result.detail ?? [];
+  if (verbose || !result.ok) return detail;
+  return detail.filter((line) => !ROUTINE_DETAIL.test(line));
 }
 
 /**
@@ -64,14 +78,21 @@ export function formatStepLine(index: number, title: string, result: StepResult)
  *   `修法（做完重跑同一条 party join）：` 一行，下一行缩进印命令，再下面是 notes。
  * 测试就靠这个形态数「印了几条修法」。
  */
-export function formatStep(index: number, title: string, result: StepResult, rerun: string): string[] {
-  const lines = [formatStepLine(index, title, result)];
-  for (const d of result.detail ?? []) lines.push(`${STEP_INDENT}${d}`);
+export function formatStep(
+  index: number,
+  title: string,
+  result: StepResult,
+  rerun: string,
+  opts: { style?: Style; verbose?: boolean } = {},
+): string[] {
+  const style = opts.style ?? styleFor(false);
+  const lines = [formatStepLine(index, title, result, style)];
+  for (const d of visibleDetail(result, opts.verbose === true)) lines.push(`${STEP_INDENT}${d}`);
   if (!result.ok) {
     const fix = result.fix ?? { do: rerun };
     for (const n of fix.notes ?? []) lines.push(`${STEP_INDENT}${n}`);
-    lines.push(`${STEP_INDENT}修法（做完重跑同一条 ${rerun}）：`);
-    lines.push(`${STEP_INDENT}  ${fix.do}`);
+    lines.push(`${STEP_INDENT}${style.bold(`修法（做完重跑同一条 ${rerun}）：`)}`);
+    lines.push(`${STEP_INDENT}  ${style.cmd(fix.do)}`);
   }
   return lines;
 }
@@ -84,6 +105,10 @@ export interface RunStepsInput<Ctx> {
   rerun?: string;
   /** 第一步的编号（epic 从第 0 步「版本」数起）。 */
   firstIndex?: number;
+  /** 着色；不给＝不着色（测试与管道默认走这条）。 */
+  style?: Style;
+  /** 过了的步骤也把 ✓/· 子项全印出来。 */
+  verbose?: boolean;
 }
 
 /**
@@ -105,7 +130,7 @@ export async function runSteps<Ctx>(input: RunStepsInput<Ctx>): Promise<StepsOut
     }
     const record: StepRecord = { index, id: step.id, title: step.title, result };
     records.push(record);
-    for (const line of formatStep(index, step.title, result, rerun)) input.log(line);
+    for (const line of formatStep(index, step.title, result, rerun, { style: input.style, verbose: input.verbose })) input.log(line);
     if (!result.ok) return { ok: false, records, stoppedAt: record };
   }
   return { ok: true, records };

--- a/cli/test/join.test.ts
+++ b/cli/test/join.test.ts
@@ -433,7 +433,7 @@ describe("party join —— 一条命令跑完整段接入（#944）", () => {
     const d = deps(record, {}, logs);
     d.startCodexWakeLayer = async () => ({ action: "skip", reason: "already-serving", detail: "#dev 上本身份已有 serve 在跑（pid 777）" });
     d.codexWakeLayerLive = async () => ({ pid: 777, source: "serve-lock" });
-    const code = await runJoin(baseOpts({ harnessFlag: "codex" }), d);
+    const code = await runJoin(baseOpts({ harnessFlag: "codex", verbose: true }), d);
     const out = logs.join("\n");
     expect(code).toBe(0);
     expect(out).toContain("已有唤醒层在跑");
@@ -669,11 +669,36 @@ describe("party join —— 一条命令跑完整段接入（#944）", () => {
     expect(existsSync(configPath())).toBe(false);
   });
 
+  // #1073 收篇幅：party init / party send 自己那套逐行日志（created channel / config written /
+  // sent seq=1 …）已被第 1 步的一行摘要概括，成功时不该再刷一屏。但失败时它们往往是唯一线索，
+  // 必须原样回放——吞掉证据比啰嗦严重得多。
+  test("子命令的流水账：成功时吞掉，失败时原样回放", async () => {
+    mock = startRestMock();
+    const logs: string[] = [];
+    const ok = deps([], {}, logs);
+    const realInit = ok.initRun;
+    ok.initRun = async (a) => {
+      console.log("created channel dev");
+      return realInit(a);
+    };
+    expect(await runJoin(baseOpts({ harnessFlag: "claude" }), ok)).toBe(0);
+    expect(logs.join("\n")).not.toContain("created channel dev");
+
+    const logs2: string[] = [];
+    const bad = deps([], {}, logs2);
+    bad.initRun = async () => {
+      console.log("token 被拒：403");
+      return 1;
+    };
+    expect(await runJoin(baseOpts({ harnessFlag: "claude" }), bad)).toBe(1);
+    expect(logs2.join("\n")).toContain("token 被拒：403");
+  });
+
   test("重复接入：mcp get 命中已注册 ⇒ 跳过 add，不再叠一个常驻进程（#898）", async () => {
     mock = startRestMock();
     const record: string[][] = [];
     const logs: string[] = [];
-    const code = await runJoin(baseOpts({ harnessFlag: "claude" }), deps(record, { mcpAlreadyRegistered: true }, logs));
+    const code = await runJoin(baseOpts({ harnessFlag: "claude", verbose: true }), deps(record, { mcpAlreadyRegistered: true }, logs));
 
     expect(code).toBe(0);
     // 探到了（get 跑过），但**没有** add——每个注册在每个会话里都是一个常驻进程。
@@ -813,7 +838,7 @@ describe("party join claude 档 —— 武装监听闸（#979）", () => {
     const logs: string[] = [];
     const d = deps(record, {}, logs);
     d.claudeSelfSession = () => ({ pid: process.pid, sessionId, name: "agentparty-83", hops: 2 });
-    await runJoin(baseOpts({ harnessFlag: "claude" }), d);
+    await runJoin(baseOpts({ harnessFlag: "claude", verbose: true }), d);
     const entry = listClaudeSessions().find((candidate) => candidate.session_id === sessionId);
     expect(entry).toMatchObject({
       pid: process.pid,

--- a/cli/test/join.test.ts
+++ b/cli/test/join.test.ts
@@ -685,13 +685,19 @@ describe("party join —— 一条命令跑完整段接入（#944）", () => {
     expect(logs.join("\n")).not.toContain("created channel dev");
 
     const logs2: string[] = [];
+    const errs2: string[] = [];
     const bad = deps([], {}, logs2);
+    bad.errlog = (line) => void errs2.push(line);
     bad.initRun = async () => {
-      console.log("token 被拒：403");
+      console.log("走 stdout 的那半");
+      console.error("token 被拒：403");
       return 1;
     };
     expect(await runJoin(baseOpts({ harnessFlag: "claude" }), bad)).toBe(1);
-    expect(logs2.join("\n")).toContain("token 被拒：403");
+    // 回放要**保流**：子命令写 stderr 的照旧走 stderr，否则 `party join 2>errors.log` 再也捞不到失败原因。
+    expect(errs2.join("\n")).toContain("token 被拒：403");
+    expect(logs2.join("\n")).not.toContain("token 被拒：403");
+    expect(logs2.join("\n")).toContain("走 stdout 的那半");
   });
 
   test("重复接入：mcp get 命中已注册 ⇒ 跳过 add，不再叠一个常驻进程（#898）", async () => {

--- a/cli/test/onboarding-color.test.ts
+++ b/cli/test/onboarding-color.test.ts
@@ -1,0 +1,76 @@
+// #1073：引导输出的着色与篇幅（第 1、2 点）。
+import { describe, expect, test } from "bun:test";
+import { colorEnabled, styleFor } from "../src/onboarding/color";
+import { formatStep, formatStepLine } from "../src/onboarding/steps";
+
+const ESC = "\x1b";
+
+describe("着色开关", () => {
+  test("NO_COLOR 一票否决，哪怕在 TTY 上、哪怕同时设了 FORCE_COLOR", () => {
+    expect(colorEnabled({ NO_COLOR: "" }, true)).toBe(false);
+    expect(colorEnabled({ NO_COLOR: "1", FORCE_COLOR: "1" }, true)).toBe(false);
+  });
+
+  test("FORCE_COLOR 能在非 TTY（管道 / CI）上开色，FORCE_COLOR=0 不算开", () => {
+    expect(colorEnabled({ FORCE_COLOR: "1" }, false)).toBe(true);
+    expect(colorEnabled({ FORCE_COLOR: "0" }, false)).toBe(false);
+  });
+
+  test("缺省跟着 TTY 走；TERM=dumb 不上色", () => {
+    expect(colorEnabled({}, true)).toBe(true);
+    expect(colorEnabled({}, false)).toBe(false);
+    expect(colorEnabled({ TERM: "dumb" }, true)).toBe(false);
+  });
+});
+
+describe("着色只碰本地生成的结构元素", () => {
+  const style = styleFor(true);
+  // 摘要里可能带服务端可控文本（身份、频道名、错误消息）。给它套色码＝把 reset 序列的控制权交给
+  // 远端：正文里一个 ESC[0m 就能提前收色、后面的伪造文本继承我们的样式。所以摘要一律不着色。
+  test("摘要原样，不被色码包住", () => {
+    const summary = `#dev 上以 evil${ESC}[0m 报到`;
+    const line = formatStepLine(1, "身份", { ok: true, summary }, style);
+    expect(line).toContain(summary);
+    expect(line).not.toContain(`${ESC}[32m#dev`);
+  });
+
+  test("✓ 绿、✗ 红、修法命令上色", () => {
+    expect(formatStepLine(1, "身份", { ok: true, summary: "s" }, style)).toContain(`${ESC}[32m✓${ESC}[0m`);
+    const failed = formatStep(3, "会话", { ok: false, summary: "s", fix: { do: "party claude dev" } }, "party join", { style });
+    expect(failed[0]).toContain(`${ESC}[31m✗${ESC}[0m`);
+    expect(failed.at(-1)).toContain(`${ESC}[36mparty claude dev${ESC}[0m`);
+  });
+
+  test("不给 style ⇒ 一个色码都没有（管道、测试、贴日志给人看）", () => {
+    const lines = formatStep(3, "会话", { ok: false, summary: "s", fix: { do: "party claude dev" } }, "party join");
+    expect(lines.join("\n")).not.toContain(ESC);
+  });
+});
+
+describe("过了的步骤只印异常子项（#1073 收篇幅）", () => {
+  const result = {
+    ok: true,
+    summary: "报到成功",
+    detail: ["✓ 注册 claude MCP: 已加", "· 装 codex 插件: 跳过", "! 行为契约落盘: 写失败", "无 TTY：按默认选了交互式会话"],
+  };
+
+  test("缺省吞掉 ✓ / · 流水账，保留 ! 与自由文本", () => {
+    const out = formatStep(1, "身份", result, "party join").join("\n");
+    expect(out).not.toContain("注册 claude MCP");
+    expect(out).not.toContain("装 codex 插件");
+    expect(out).toContain("行为契约落盘: 写失败");
+    expect(out).toContain("无 TTY：按默认选了交互式会话");
+  });
+
+  test("--verbose 全印回来", () => {
+    const lines = formatStep(1, "身份", result, "party join", { verbose: true });
+    expect(lines).toHaveLength(5);
+    expect(lines.join("\n")).toContain("注册 claude MCP");
+  });
+
+  test("没过的步骤永远全印——那时每一行都是线索", () => {
+    const out = formatStep(1, "身份", { ...result, ok: false, fix: { do: "party join" } }, "party join").join("\n");
+    expect(out).toContain("注册 claude MCP");
+    expect(out).toContain("装 codex 插件");
+  });
+});

--- a/cli/test/onboarding-color.test.ts
+++ b/cli/test/onboarding-color.test.ts
@@ -27,11 +27,32 @@ describe("着色只碰本地生成的结构元素", () => {
   const style = styleFor(true);
   // 摘要里可能带服务端可控文本（身份、频道名、错误消息）。给它套色码＝把 reset 序列的控制权交给
   // 远端：正文里一个 ESC[0m 就能提前收色、后面的伪造文本继承我们的样式。所以摘要一律不着色。
-  test("摘要原样，不被色码包住", () => {
-    const summary = `#dev 上以 evil${ESC}[0m 报到`;
-    const line = formatStepLine(1, "身份", { ok: true, summary }, style);
-    expect(line).toContain(summary);
+  test("摘要不被色码包住，且它自带的 ESC 序列被洗掉（#372 同一纪律）", () => {
+    const line = formatStepLine(1, "身份", { ok: true, summary: `#dev 上以 evil${ESC}[0m 报到` }, style);
+    // 远端可控文本先清洗再拼：一条含 ESC 的摘要不该能提前收色、让后面的伪造文本继承我们的样式。
+    // 整段 CSI 被移除（不是只去 ESC 留下可见的 "[0m"）
+    expect(line).toContain("#dev 上以 evil 报到");
+    expect(line).not.toContain(ESC + "[0m 报到");
     expect(line).not.toContain(`${ESC}[32m#dev`);
+  });
+
+  test("补充行、修法命令、notes 里的控制字符一并洗掉——含能伪造整行的换行/TAB", () => {
+    const lines = formatStep(
+      3,
+      "会话",
+      {
+        ok: false,
+        summary: "s",
+        detail: [`! 写失败：${ESC}]52;c;cGl3bmVk\x07`],
+        fix: { do: `party claude dev\n第 4 步  真发一条 @ 验证 · 伪造的 ✓`, notes: [`先看这个\tTAB`] },
+      },
+      "party join",
+    );
+    const out = lines.join("\n");
+    expect(out).not.toContain(ESC);
+    expect(out).not.toContain("\x07");
+    // 换行被折成空格 ⇒ 伪造的「第 4 步」不再是独立的一行
+    expect(lines.filter((l) => l.startsWith("第 "))).toHaveLength(1);
   });
 
   test("✓ 绿、✗ 红、修法命令上色", () => {
@@ -101,5 +122,23 @@ describe("party hook install --brief（给 join 用）", () => {
     const out = lines.join("\n");
     expect(out).toContain("hooks installed -> ");
     expect(out).not.toContain("普通 Claude session 只写本地 activity");
+  });
+
+  // 与 hookScope 同一纪律：`--` 之后的东西不是旗标。两处判法不一致，日后必然漂移。
+  test("`--` 之后的 --brief 不算数", async () => {
+    const cwd = process.cwd();
+    const sandbox = mkdtempSync(join(tmpdir(), "ap-hook-brief-"));
+    const lines: string[] = [];
+    const real = console.log;
+    console.log = (...a: unknown[]) => void lines.push(a.map(String).join(" "));
+    try {
+      process.chdir(sandbox);
+      await hookRun(["install", "--claude", "--", "--brief"]);
+    } finally {
+      console.log = real;
+      process.chdir(cwd);
+      rmSync(sandbox, { recursive: true, force: true });
+    }
+    expect(lines.join("\n")).toContain("普通 Claude session 只写本地 activity");
   });
 });

--- a/cli/test/onboarding-color.test.ts
+++ b/cli/test/onboarding-color.test.ts
@@ -74,3 +74,32 @@ describe("过了的步骤只印异常子项（#1073 收篇幅）", () => {
     expect(out).toContain("装 codex 插件");
   });
 });
+
+// #1073 第 2 点的另一半：join 装完 codex hook 后，第 2 步会用同一份唤醒清单判过/不过并给恰一条
+// 修法。hook install 自己再把整份清单印一遍＝同一段修复说明连印两遍。join 因此传 --brief。
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { run as hookRun } from "../src/commands/hook";
+
+describe("party hook install --brief（给 join 用）", () => {
+  test("brief 压掉解说与清单重播，但保留「装到哪个文件」这一行", async () => {
+    // hook install 写的是 **cwd** 下的 .claude/settings.local.json——不隔离就会往仓库工作树里落文件。
+    const cwd = process.cwd();
+    const sandbox = mkdtempSync(join(tmpdir(), "ap-hook-brief-"));
+    const lines: string[] = [];
+    const real = console.log;
+    console.log = (...a: unknown[]) => void lines.push(a.map(String).join(" "));
+    try {
+      process.chdir(sandbox);
+      await hookRun(["install", "--claude", "--brief"]);
+    } finally {
+      console.log = real;
+      process.chdir(cwd);
+      rmSync(sandbox, { recursive: true, force: true });
+    }
+    const out = lines.join("\n");
+    expect(out).toContain("hooks installed -> ");
+    expect(out).not.toContain("普通 Claude session 只写本地 activity");
+  });
+});

--- a/cli/test/onboarding-steps.test.ts
+++ b/cli/test/onboarding-steps.test.ts
@@ -628,8 +628,9 @@ describe("party join 引导 —— 幂等（#988）", () => {
     const first: string[] = [];
     const second: string[] = [];
     // 第一跑：mcp get 探到未注册 → add；第二跑：已注册 → 跳过 add。桩按 mcpAlreadyRegistered 分别配。
-    expect(await runJoin(opts({ yes: true }), joinDeps(tmp, record, {}, first))).toBe(0);
-    expect(await runJoin(opts({ yes: true }), joinDeps(tmp, record, { mcpAlreadyRegistered: true }, second))).toBe(0);
+    // verbose：这里断言的是「✓ 跳过重复添加」这类子项本身，缺省已不印（#1073 收篇幅）。
+    expect(await runJoin(opts({ yes: true, verbose: true }), joinDeps(tmp, record, {}, first))).toBe(0);
+    expect(await runJoin(opts({ yes: true, verbose: true }), joinDeps(tmp, record, { mcpAlreadyRegistered: true }, second))).toBe(0);
     expect(second.join("\n")).toContain("跳过重复添加");
     expect(second.join("\n")).toContain("crossSessionInbound 已是 accept（跳过）");
     expect(record.filter((r) => r[0] === "claude" && r[1] === "mcp" && r[2] === "add").length).toBe(1);

--- a/cli/test/recover.test.ts
+++ b/cli/test/recover.test.ts
@@ -323,7 +323,7 @@ describe("party recover —— 第 2～4 步复用 join 的第 0/3/4 步", () =>
     mock = startRestMock();
     seedBinding({ harness: "codex" });
     const logs: string[] = [];
-    const code = await runRecover(opts(), deps(logs));
+    const code = await runRecover(opts({ verbose: true }), deps(logs));
     const out = logs.join("\n");
 
     expect(code).toBe(0);


### PR DESCRIPTION
#1073 的第 1、2 点。第 3 点（少的那一步）在 #1079。

用户原话：**「这个长篇大论的篇幅，用户都懵了」**。`party join` 一次刷一屏纯文本——init/send 自己的六七行日志、每个步骤十来行 `✓ 某某: 已加` 的流水账——真正要读的「卡在哪、要跑哪条命令」被推出屏幕。

## 颜色（新 `cli/src/onboarding/color.ts`）
`✓` 绿、`✗` 红、`!` 黄、修法命令青、步骤号灰、标题粗。

**只给本地生成的结构元素上色。** 摘要与补充行里混着服务端可控文本（身份、频道名、错误消息），给它们套色码＝把 reset 序列的控制权交给远端：正文里一个 `ESC[0m` 就能提前收色、后面的伪造文本继承我们的样式。有测试钉住这条。

开关优先级：`NO_COLOR`（一票否决）> `FORCE_COLOR` > `TERM=dumb` > 是否 TTY。管道重定向默认无色，贴日志给人看不会一堆乱码。

## 篇幅
- **过了的步骤只印异常子项**（`!` / `✗`）和自由文本补充行；`✓ …` / `· …` 的流水账缺省不印。**没过的步骤永远全印**——那时每一行都是线索。
- `party init` / `party send` 自己那套逐行日志（`created channel` / `config written` / `sent seq=1`…）成功时吞掉，**失败或 `--verbose` 原样回放**。吞掉证据比啰嗦严重得多，所以只吞成功那次。`party hook install` 不吞——它可能要人按键批准，吞它等于让人对着空屏等。
- 新增 `--verbose` 全部恢复；`party recover` 同步同一套呈现（也加了 `--verbose`）。

## 验证
- `bunx tsc --noEmit -p cli` 0 错
- **cli 全量 2929 pass / 0 fail**（本机）
- 新增 `test/onboarding-color.test.ts` 9 例：着色开关矩阵、「摘要不被色码包住」、无 style 时一个 ESC 都没有、缺省吞流水账 / `--verbose` 全印 / 失败步骤永远全印
- `test/join.test.ts` 新增「子命令流水账：成功吞掉、失败原样回放」
- 原有 4 个断言在子项上的用例改为传 `verbose: true`——它们测的是子检查本身，仍然覆盖，只是缺省不再印

https://claude.ai/code/session_01HUmERHTXnbZhCZCwV6fGxD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - `party join` 和 `party recover` 新增 `--verbose` 选项，可在成功时查看完整子命令日志。
  - 默认精简成功步骤输出，仅在失败或启用详细模式时展示完整日志。
  - 引导流程新增彩色输出，并根据终端环境自动启用或禁用颜色。
  - Codex Hook 安装支持精简输出，避免重复显示唤醒清单。

- **改进**
  - 失败步骤、错误提示和修复命令获得更清晰的样式区分。
  - 成功步骤保留重要信息，同时减少常规流水账输出。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->