### PR TITLE
perf(cli): 一条 MCP 注册服务所有频道 + 会话关了停止宣称可达 (#1083)

### DIFF
--- a/cli/src/commands/mcp.ts
+++ b/cli/src/commands/mcp.ts
@@ -69,7 +69,7 @@ import { acquireTaskLeaseAcrossMachines, releaseTaskLeaseAcrossMachines } from "
 import { EXIT_ALREADY_WATCHING, runWatch } from "./watch";
 import { settleClaudeDeliveryRecovery } from "../delivery-recovery-journal";
 
-const HELP = `usage: party mcp [--channel <slug>] [--identity <label>]
+const HELP = `usage: party mcp [--channel <slug> | --all-channels] [--identity <label>]
        party mcp prune [--yes] [--check-remote] [--json]
        party mcp identities [--channel C] [--server S] [--keep NAME] [--yes] [--json]
 
@@ -77,6 +77,11 @@ Run an AgentParty stdio MCP server.
 
 Options:
   --channel <slug>   default channel for tools that take an optional channel
+  --all-channels     one registration for every channel on this machine (#1083):
+                     tools take channel (required) / identity / server, and the
+                     identity is resolved per call from ~/.agentparty/agents.
+                     Ambiguous channels (several identities, no recorded default)
+                     are refused with the candidates listed — never guessed.
   --identity <label> cosmetic label carried in argv so 'ps -axww' shows whose
                      server this process is (#898). It never affects which
                      identity is used — that always comes from AGENTPARTY_CONFIG.
@@ -465,6 +470,25 @@ function charterText(data: Record<string, unknown>): string {
  * 让它带着错身份或空身份去调用，只会变成一条以别人名义发出的消息或一句无法诊断的 401。
  */
 function wrapToolsWithPerCallIdentity(server: McpServer, defaultChannel: string | undefined): void {
+  // 资源（party://charter、party://{channel}/charter）不走 registerTool，得单独包：否则聚合档下
+  // 读 charter 会在没有任何身份的进程里发请求，拿到一句无法诊断的 401。频道取自模板变量，
+  // 模板没给（具体的 party://charter）就用启动时绑定的那个。
+  const originalResource = server.registerResource.bind(server);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (server as any).registerResource = (name: string, uriOrTemplate: unknown, meta: unknown, cb: (...a: any[]) => any) =>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    originalResource(name as any, uriOrTemplate as any, meta as any, (async (uri: any, variables: any, ...rest: any[]) => {
+      const rawVar = variables?.channel;
+      const fromTemplate = Array.isArray(rawVar) ? rawVar[0] : rawVar;
+      const channel = typeof fromTemplate === "string" && fromTemplate !== "" ? fromTemplate : defaultChannel;
+      if (channel === undefined || channel === "") {
+        throw new Error("这条 MCP 服务本机所有频道，请读 party://<channel>/charter 指明是哪一个");
+      }
+      const resolved = resolveChannelIdentity({ channel });
+      if (!resolved.ok) throw new Error(resolved.message);
+      return withMcpIdentity(resolved.config.path, () => cb(uri, variables, ...rest));
+    }) as any);
+
   const original = server.registerTool.bind(server);
   // 用 any 是因为 registerTool 的重载签名带一长串泛型，这里只做透传包装，不改变任何一个参数。
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -473,18 +497,23 @@ function wrapToolsWithPerCallIdentity(server: McpServer, defaultChannel: string 
     // 校验入参，没声明的字段会被直接丢掉——handler 再怎么读也读不到（party_whoami 的 schema
     // 本来是空的，实测就是这么丢的）。已经声明过 channel 的工具保持原样，不覆盖它的描述与校验。
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const shape = (spec as any)?.inputSchema;
-    if (shape !== null && typeof shape === "object") {
-      if (shape.channel === undefined) {
-        shape.channel = z
-          .string()
-          .describe("channel slug — 这条 MCP 服务本机所有频道，必须指明是哪一个");
-      }
-      if (shape.identity === undefined) {
-        shape.identity = z
-          .string()
-          .optional()
-          .describe("同一频道在本机有多份身份时，指定用哪一个（party who --all 可查）");
+    const input = (spec as any)?.inputSchema;
+    const extra = {
+      channel: z.string().describe("channel slug — 这条 MCP 服务本机所有频道，必须指明是哪一个"),
+      identity: z.string().optional().describe("同一频道在本机有多份身份时，指定用哪一个（party who --all 可查）"),
+      server: z.string().optional().describe("同名频道分属多个实例时，用实例 URL 限定（party who --all 可查）"),
+    };
+    if (input !== null && typeof input === "object") {
+      if (typeof input.extend === "function" && input.shape !== undefined) {
+        // ZodObject（party_task_create 用的是 .strict()）：往实例上赋属性是空操作，strict 还会把
+        // 没声明的 identity/server 直接拒掉。必须走 .extend()；已声明的字段保留原描述与校验。
+        const present = input.shape as Record<string, unknown>;
+        const missing = Object.fromEntries(Object.entries(extra).filter(([k]) => present[k] === undefined));
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (spec as any).inputSchema = Object.keys(missing).length === 0 ? input : input.extend(missing);
+      } else {
+        // 裸 shape（大多数工具）：直接补键。
+        for (const [k, v] of Object.entries(extra)) if (input[k] === undefined) input[k] = v;
       }
     }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -500,6 +529,7 @@ function wrapToolsWithPerCallIdentity(server: McpServer, defaultChannel: string 
       const resolved = resolveChannelIdentity({
         channel,
         identity: typeof args?.identity === "string" && args.identity !== "" ? args.identity : undefined,
+        server: typeof args?.server === "string" && args.server !== "" ? args.server : undefined,
       });
       if (!resolved.ok) return fail(resolved.message);
       return withMcpIdentity(resolved.config.path, () => handler(args, extra));

--- a/cli/src/commands/mcp.ts
+++ b/cli/src/commands/mcp.ts
@@ -26,6 +26,8 @@ import {
 import { jsonFrame } from "../json";
 import { applyMcpProcessTitle, parseMcpServerArgv } from "../mcp-registry";
 import { watchParentLiveness } from "../parent-liveness";
+import { resolveChannelIdentity } from "../mcp-channel-identity";
+import { withMcpIdentity } from "../mcp-identity-context";
 import { reportWakeSelfCheck } from "../wake-reachability";
 import { resolveAuth, resolveAuthDetailed } from "../oidc-cli";
 import { inspectMcpSessionBinding, mcpSessionBindingDenial } from "../mcp-session-binding";
@@ -455,11 +457,70 @@ function charterText(data: Record<string, unknown>): string {
   return decisions.length === 0 ? base : `${base}\n\n${decisions.join("\n")}`;
 }
 
-export function createMcpServer(defaultChannel?: string): McpServer {
+
+/**
+ * 把每个工具的 handler 包进「按本次调用的 channel 解析出的身份」上下文里（#1083 聚合档）。
+ *
+ * 解析不出来（本机没这个频道 / 多份身份且没登记默认）时**直接把原因回给调用方**，不往下跑：
+ * 让它带着错身份或空身份去调用，只会变成一条以别人名义发出的消息或一句无法诊断的 401。
+ */
+function wrapToolsWithPerCallIdentity(server: McpServer, defaultChannel: string | undefined): void {
+  const original = server.registerTool.bind(server);
+  // 用 any 是因为 registerTool 的重载签名带一长串泛型，这里只做透传包装，不改变任何一个参数。
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (server as any).registerTool = (name: string, spec: unknown, handler: (...args: any[]) => any) => {
+    // 聚合档下 channel / identity 必须出现在**每个**工具的 inputSchema 里：MCP SDK 会按 schema
+    // 校验入参，没声明的字段会被直接丢掉——handler 再怎么读也读不到（party_whoami 的 schema
+    // 本来是空的，实测就是这么丢的）。已经声明过 channel 的工具保持原样，不覆盖它的描述与校验。
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const shape = (spec as any)?.inputSchema;
+    if (shape !== null && typeof shape === "object") {
+      if (shape.channel === undefined) {
+        shape.channel = z
+          .string()
+          .describe("channel slug — 这条 MCP 服务本机所有频道，必须指明是哪一个");
+      }
+      if (shape.identity === undefined) {
+        shape.identity = z
+          .string()
+          .optional()
+          .describe("同一频道在本机有多份身份时，指定用哪一个（party who --all 可查）");
+      }
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return original(name as any, spec as any, (async (args: any, extra: any) => {
+      const channel = typeof args?.channel === "string" && args.channel !== "" ? args.channel : defaultChannel;
+      if (channel === undefined || channel === "") {
+        // 聚合档下频道不是可省的：省了就没有身份，没有身份就没有「我是谁」。
+        return fail(
+          `这条 MCP 服务本机所有频道，请在参数里给出 channel（工具 ${name}）。` +
+            `本机有哪些频道：party who --all`,
+        );
+      }
+      const resolved = resolveChannelIdentity({
+        channel,
+        identity: typeof args?.identity === "string" && args.identity !== "" ? args.identity : undefined,
+      });
+      if (!resolved.ok) return fail(resolved.message);
+      return withMcpIdentity(resolved.config.path, () => handler(args, extra));
+    }) as any);
+  };
+}
+
+export function createMcpServer(defaultChannel?: string, aggregateChannels: boolean = false): McpServer {
   const server = new McpServer({
     name: "agentparty",
     version: pkg.version,
   });
+
+  // #1083 聚合档：一条注册服务本机所有频道，身份按每次调用的 channel 解析。包住 registerTool
+  // 这一处即可——所有工具都从这里进来，22 个 auth() 调用点一处都不用改（它们都走
+  // explicitConfigPath 这个瓶颈）。
+  //
+  // **必须显式开启**（--all-channels）。曾经想用「没设 AGENTPARTY_CONFIG 就算聚合」来自动判定，
+  // 那是错的：很多现存装法本来就不设这个 env（靠 cwd 绑定或全局 config），自动判定会让他们
+  // 突然被要求每次调用都传 channel——一次静默的破坏性变更。默认档行为一字不变。
+  if (aggregateChannels) wrapToolsWithPerCallIdentity(server, defaultChannel);
 
   // 启动时解析一次「我在哪个频道」——flag 优先，否则吃 cwd 绑定（party init --channel）。
   // 工具、concrete resource、whoami 提示三者共用这一个答案，不能各认各的。
@@ -1827,7 +1888,7 @@ export async function run(argv: string[]): Promise<number> {
     agentName: parsed.identity,
     configPath: process.env.AGENTPARTY_CONFIG ?? null,
   });
-  const server = createMcpServer(defaultChannel);
+  const server = createMcpServer(defaultChannel, parsed.allChannels);
   await server.connect(new StdioServerTransport());
   // #926：会话启动时自检一次「这台机器上这个身份叫不醒吗」，把结论挂到 presence 上。
   // MCP 不受 codex hook 信任闸管辖（owner 那台实测：26 条 hook 全 disabled，8 个 party mcp 照跑），

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -1,5 +1,6 @@
 // 全局配置与 workspace 游标状态
 import { homedir, tmpdir } from "node:os";
+import { currentMcpIdentityPath } from "./mcp-identity-context";
 import { basename, dirname, join, resolve, sep } from "node:path";
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
@@ -247,6 +248,12 @@ export function localAgentConfigsForChannel(
 }
 
 export function explicitConfigPath(): string | null {
+  // #1083：单进程多频道时，「用哪份身份」是**每次调用**的属性，不再是进程属性。MCP 在工具
+  // 边界上把它放进 AsyncLocalStorage，这里优先取它——绝不用改 process.env 的办法切身份，
+  // 那在并发调用下会串号（后一个调用读到前一个设的值，以别人的身份发言且不报错）。
+  // 不在上下文里（普通 CLI、单频道 MCP）就照旧走 env，行为一字不变。
+  const perCall = currentMcpIdentityPath();
+  if (perCall !== null) return perCall;
   return process.env.AGENTPARTY_CONFIG || null;
 }
 

--- a/cli/src/mcp-channel-identity.ts
+++ b/cli/src/mcp-channel-identity.ts
@@ -1,0 +1,192 @@
+// 单进程多频道下的身份解析（#1083）。
+//
+// 旧模型是「一个频道一条 MCP 注册」：每条注册在 argv 里绑一个 --channel、在 env 里绑一份
+// AGENTPARTY_CONFIG。于是进程数 = 频道数 × 会话数，而且注册**只进不出**——`party join` 每加入
+// 一个频道就往全局 config 塞一条，没有任何东西会把它删掉。实测这台机器上 5 条注册里只有 1 个
+// 频道还在用，最老的一个 36 天没动过，却仍在每个 codex 会话里各起一个进程、挂 25 小时。
+//
+// 新模型是「一条注册，不绑频道」：频道由每次工具调用传进来，身份按频道解析。这个文件就是那个
+// 解析器，也是整条路上唯一有**串号**风险的地方——解错了不会报错，只会以别人的身份发言。
+//
+// 因此解析顺序是「显式 > 记录 > 失败」，**绝不按时间/字典序猜**：
+//   1. 调用方显式给了身份名 ⇒ 只认它，找不到就报错（绝不退回默认）
+//   2. 该频道有登记的默认身份（party join 绑定时写下）⇒ 用它
+//   3. 该频道在本机只有唯一一份身份 ⇒ 用它
+//   4. 其余（多份且没登记默认）⇒ **失败关闭**，把候选列出来让人选
+//
+// 第 4 条不是保守，是必需：本机 24 个频道里 16 个有多份身份（agentparty 一个频道 15 份），
+// 「挑最近验证的那个」这种启发式在这里等价于随机挑一个身份替用户说话。
+import { readFileSync, readdirSync, writeFileSync, mkdirSync, renameSync } from "node:fs";
+import { join } from "node:path";
+import { agentpartyHome } from "./config";
+
+export interface AgentIdentityConfig {
+  /** config 文件绝对路径——解析结果最终就是它，交给下游当 AGENTPARTY_CONFIG 用。 */
+  path: string;
+  server: string;
+  /** 频道由 identity.channel_scope 给出：身份自带频道归属，不靠文件名猜。 */
+  channel: string;
+  name: string;
+  verifiedAt: number | null;
+}
+
+/** 每频道默认身份的登记表：`<server> <channel>` → config 路径。 */
+export type ChannelDefaults = Record<string, string>;
+
+export function agentsDir(home: string = agentpartyHome()): string {
+  return join(home, "agents");
+}
+
+export function channelDefaultsPath(home: string = agentpartyHome()): string {
+  return join(home, "mcp-channel-defaults.json");
+}
+
+function defaultsKey(server: string, channel: string): string {
+  // JSON 数组当键：不依赖分隔符，server 里出现任何字符都不会撞键，落盘后也仍然可读。
+  return JSON.stringify([server, channel]);
+}
+
+/**
+ * 列出本机所有 agent 身份配置。读坏了的文件一律跳过——一份坏 config 不该让整台机器的 MCP
+ * 起不来；它的频道会退化成「没有这份身份」，走失败关闭那条路，比静默用错身份安全。
+ */
+export function listAgentConfigs(home: string = agentpartyHome()): AgentIdentityConfig[] {
+  let files: string[];
+  try {
+    files = readdirSync(agentsDir(home)).filter((f) => f.endsWith(".json"));
+  } catch {
+    return [];
+  }
+  const out: AgentIdentityConfig[] = [];
+  for (const file of files) {
+    const path = join(agentsDir(home), file);
+    try {
+      const raw = JSON.parse(readFileSync(path, "utf8")) as {
+        server?: unknown;
+        token?: unknown;
+        identity?: { name?: unknown; channel_scope?: unknown; verified_at?: unknown };
+      };
+      const server = typeof raw.server === "string" ? raw.server : null;
+      const channel = typeof raw.identity?.channel_scope === "string" ? raw.identity.channel_scope : null;
+      const name = typeof raw.identity?.name === "string" ? raw.identity.name : null;
+      // 没有 token 的 config 解析出来也不能用于发言，直接当不存在。
+      if (server === null || channel === null || name === null || typeof raw.token !== "string") continue;
+      out.push({
+        path,
+        server,
+        channel,
+        name,
+        verifiedAt: typeof raw.identity?.verified_at === "number" ? raw.identity.verified_at : null,
+      });
+    } catch {
+      continue;
+    }
+  }
+  return out;
+}
+
+export function readChannelDefaults(home: string = agentpartyHome()): ChannelDefaults {
+  try {
+    const raw = JSON.parse(readFileSync(channelDefaultsPath(home), "utf8")) as unknown;
+    if (raw === null || typeof raw !== "object" || Array.isArray(raw)) return {};
+    const out: ChannelDefaults = {};
+    for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
+      if (typeof v === "string") out[k] = v;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * 记下某频道的默认身份（party join 绑定成功后调用）。原子替换：写中途崩溃不会留半截 JSON，
+ * 那会让整台机器的默认表失效、把一堆频道推进失败关闭。
+ */
+export function recordChannelDefault(
+  server: string,
+  channel: string,
+  configPath: string,
+  home: string = agentpartyHome(),
+): void {
+  const current = readChannelDefaults(home);
+  current[defaultsKey(server, channel)] = configPath;
+  const target = channelDefaultsPath(home);
+  const tmp = `${target}.tmp-${process.pid}`;
+  mkdirSync(home, { recursive: true });
+  writeFileSync(tmp, `${JSON.stringify(current, null, 2)}\n`, { mode: 0o600 });
+  renameSync(tmp, target);
+}
+
+export type ChannelIdentityResolution =
+  | { ok: true; config: AgentIdentityConfig; via: "explicit" | "default" | "only" }
+  | { ok: false; reason: "none" | "ambiguous"; candidates: AgentIdentityConfig[]; message: string };
+
+export interface ResolveChannelIdentityInput {
+  channel: string;
+  /** 调用方显式指定的身份名。给了就只认它。 */
+  identity?: string | undefined;
+  /** 限定服务器（一台机器可能同时连 prod 与自建实例，同名频道在两边是两回事）。 */
+  server?: string | undefined;
+  configs?: AgentIdentityConfig[];
+  defaults?: ChannelDefaults;
+}
+
+/** 见文件头的解析顺序：显式 > 登记的默认 > 唯一 > 失败关闭。 */
+export function resolveChannelIdentity(input: ResolveChannelIdentityInput): ChannelIdentityResolution {
+  const configs = input.configs ?? listAgentConfigs();
+  const defaults = input.defaults ?? readChannelDefaults();
+  const matches = configs.filter(
+    (c) => c.channel === input.channel && (input.server === undefined || c.server === input.server),
+  );
+
+  if (input.identity !== undefined) {
+    const hit = matches.filter((c) => c.name === input.identity);
+    if (hit.length === 1) return { ok: true, config: hit[0]!, via: "explicit" };
+    // 显式指定却找不到 / 撞名，绝不退回默认身份——那正是「以为用 A 发言、实际用了 B」。
+    return {
+      ok: false,
+      reason: hit.length === 0 ? "none" : "ambiguous",
+      candidates: matches,
+      message:
+        hit.length === 0
+          ? `#${input.channel} 上没有名为 ${input.identity} 的身份${describeCandidates(matches)}`
+          : `#${input.channel} 上有多份名为 ${input.identity} 的身份，无法确定用哪个——请用 --server 限定`,
+    };
+  }
+
+  if (matches.length === 0) {
+    return {
+      ok: false,
+      reason: "none",
+      candidates: [],
+      message:
+        `本机没有 #${input.channel} 的身份。先加入这个频道：` +
+        `AGENTPARTY_TOKEN='<token>' party join --server <URL> --channel ${input.channel} --as <name>`,
+    };
+  }
+
+  for (const key of matches.map((c) => defaultsKey(c.server, c.channel))) {
+    const recorded = defaults[key];
+    if (recorded === undefined) continue;
+    const hit = matches.find((c) => c.path === recorded);
+    if (hit !== undefined) return { ok: true, config: hit, via: "default" };
+  }
+
+  if (matches.length === 1) return { ok: true, config: matches[0]!, via: "only" };
+
+  return {
+    ok: false,
+    reason: "ambiguous",
+    candidates: matches,
+    // 说清楚「为什么不替你选」+ 两条出路。这里绝不挑一个了事：挑错不会报错，只会以别人的身份发言。
+    message:
+      `#${input.channel} 在本机有 ${matches.length} 份身份，没有登记默认，不替你猜——` +
+      `传 identity 指定，或用 \`party join\` 重新绑定把它记为默认。${describeCandidates(matches)}`,
+  };
+}
+
+function describeCandidates(candidates: AgentIdentityConfig[]): string {
+  if (candidates.length === 0) return "";
+  return `（候选：${candidates.map((c) => c.name).join("、")}）`;
+}

--- a/cli/src/mcp-channel-identity.ts
+++ b/cli/src/mcp-channel-identity.ts
@@ -167,11 +167,22 @@ export function resolveChannelIdentity(input: ResolveChannelIdentityInput): Chan
     };
   }
 
-  for (const key of matches.map((c) => defaultsKey(c.server, c.channel))) {
-    const recorded = defaults[key];
-    if (recorded === undefined) continue;
-    const hit = matches.find((c) => c.path === recorded);
-    if (hit !== undefined) return { ok: true, config: hit, via: "default" };
+  // 把所有登记命中都收齐再判：同一频道在两台实例上各登记了默认时，按枚举顺序取第一个
+  // 等于按文件名排序选身份——正是本文件头上说绝不做的那种「猜」。恰一个命中才算数。
+  const defaultHits = matches.filter((c) => {
+    const recorded = defaults[defaultsKey(c.server, c.channel)];
+    return recorded !== undefined && recorded === c.path;
+  });
+  if (defaultHits.length === 1) return { ok: true, config: defaultHits[0]!, via: "default" };
+  if (defaultHits.length > 1) {
+    return {
+      ok: false,
+      reason: "ambiguous",
+      candidates: defaultHits,
+      message:
+        `#${input.channel} 在 ${defaultHits.length} 个实例上都登记了默认身份，请用 server 限定` +
+        `（候选实例：${[...new Set(defaultHits.map((c) => c.server))].join("、")}）`,
+    };
   }
 
   const distinct = dedupeSameIdentity(matches);

--- a/cli/src/mcp-channel-identity.ts
+++ b/cli/src/mcp-channel-identity.ts
@@ -141,7 +141,7 @@ export function resolveChannelIdentity(input: ResolveChannelIdentityInput): Chan
   );
 
   if (input.identity !== undefined) {
-    const hit = matches.filter((c) => c.name === input.identity);
+    const hit = dedupeSameIdentity(matches.filter((c) => c.name === input.identity));
     if (hit.length === 1) return { ok: true, config: hit[0]!, via: "explicit" };
     // 显式指定却找不到 / 撞名，绝不退回默认身份——那正是「以为用 A 发言、实际用了 B」。
     return {
@@ -151,7 +151,8 @@ export function resolveChannelIdentity(input: ResolveChannelIdentityInput): Chan
       message:
         hit.length === 0
           ? `#${input.channel} 上没有名为 ${input.identity} 的身份${describeCandidates(matches)}`
-          : `#${input.channel} 上有多份名为 ${input.identity} 的身份，无法确定用哪个——请用 --server 限定`,
+          : `#${input.channel} 上有多份名为 ${input.identity} 的身份，分属不同实例，请用 server 限定` +
+            `（候选实例：${[...new Set(hit.map((c) => c.server))].join("、")}）`,
     };
   }
 
@@ -173,17 +174,36 @@ export function resolveChannelIdentity(input: ResolveChannelIdentityInput): Chan
     if (hit !== undefined) return { ok: true, config: hit, via: "default" };
   }
 
-  if (matches.length === 1) return { ok: true, config: matches[0]!, via: "only" };
+  const distinct = dedupeSameIdentity(matches);
+  if (distinct.length === 1) return { ok: true, config: distinct[0]!, via: "only" };
 
   return {
     ok: false,
     reason: "ambiguous",
-    candidates: matches,
+    candidates: distinct,
     // 说清楚「为什么不替你选」+ 两条出路。这里绝不挑一个了事：挑错不会报错，只会以别人的身份发言。
     message:
       `#${input.channel} 在本机有 ${matches.length} 份身份，没有登记默认，不替你猜——` +
       `传 identity 指定，或用 \`party join\` 重新绑定把它记为默认。${describeCandidates(matches)}`,
   };
+}
+
+/**
+ * 同一个 (server, channel, name) 有多份 config 文件时，那是**同一个身份的重复配置**，不是
+ * 身份歧义——挑哪份都不会以别人的名义说话，最坏只是拿到一个旧 token。此时取最近验证过的那份。
+ *
+ * 这个区分是必需的：owner 那台机器上 #agentparty 的 leo-claude 就有两份 config（同 server、
+ * 同名），此前会被判成歧义并提示「请用 --server 限定」——而两份的 server 一模一样，
+ * 那条出路根本走不通。给一条走不通的修法，比不给更糟。
+ */
+function dedupeSameIdentity(configs: AgentIdentityConfig[]): AgentIdentityConfig[] {
+  const best = new Map<string, AgentIdentityConfig>();
+  for (const c of configs) {
+    const key = JSON.stringify([c.server, c.channel, c.name]);
+    const prev = best.get(key);
+    if (prev === undefined || (c.verifiedAt ?? -1) > (prev.verifiedAt ?? -1)) best.set(key, c);
+  }
+  return [...best.values()];
 }
 
 function describeCandidates(candidates: AgentIdentityConfig[]): string {

--- a/cli/src/mcp-identity-context.ts
+++ b/cli/src/mcp-identity-context.ts
@@ -1,0 +1,23 @@
+// 单进程多频道下的「本次调用用哪份身份」（#1083）。
+//
+// 一条注册要服务所有频道，身份就得按每次工具调用解析。最直觉的做法是临时改
+// `process.env.AGENTPARTY_CONFIG` 再改回来——**那是错的**：MCP 的工具调用可以并发，两个
+// 调用交错时后一个会读到前一个设的值，于是以别人的身份发言，而且不会有任何报错。
+// 这正是这条路上最该防的事（同机串号在 #865 已经真实发生过一次）。
+//
+// 所以用 AsyncLocalStorage：每次调用有自己的一份，天然隔离，进程级状态一个字节都不改。
+// 落点选在 `explicitConfigPath()` 这个瓶颈上——auth()、readConfig()、以及 captureCommand
+// 在同进程内跑的那些命令模块，全都从那里取 config 路径，所以 22 个调用点一处都不用改。
+import { AsyncLocalStorage } from "node:async_hooks";
+
+const storage = new AsyncLocalStorage<string>();
+
+/** 在 configPath 这个身份下跑 fn。嵌套时内层覆盖外层。 */
+export function withMcpIdentity<T>(configPath: string, fn: () => T): T {
+  return storage.run(configPath, fn);
+}
+
+/** 当前调用绑定的 config 路径；不在任何身份上下文里就是 null（走原来的 env 那条路）。 */
+export function currentMcpIdentityPath(): string | null {
+  return storage.getStore() ?? null;
+}

--- a/cli/src/mcp-registry.ts
+++ b/cli/src/mcp-registry.ts
@@ -217,10 +217,16 @@ export interface McpServerArgv {
   channel: string | null;
   /** `--identity <label>`：纯展示用，唯一目的是让 `ps -axww` 看出这个进程是谁的。 */
   identity: string | null;
+  /**
+   * `--all-channels`（#1083）：一条注册服务本机所有频道。频道由每次工具调用传入，身份按频道
+   * 解析。**必须显式开启**——旧装法很多本来就不设 AGENTPARTY_CONFIG，自动判定会让它们突然
+   * 被要求每次都传 channel。
+   */
+  allChannels: boolean;
   error: string | null;
 }
 
-const MCP_USAGE = "usage: party mcp [--channel C] [--identity LABEL] | party mcp prune [--yes]";
+const MCP_USAGE = "usage: party mcp [--channel C | --all-channels] [--identity LABEL] | party mcp prune [--yes]";
 
 /**
  * `party mcp` 的参数解析。`--identity` 是 #898 第 3 件的载体：process.title 在 Bun/macOS
@@ -228,9 +234,14 @@ const MCP_USAGE = "usage: party mcp [--channel C] [--identity LABEL] | party mcp
  * 它绝不影响身份解析——身份永远来自 AGENTPARTY_CONFIG，标签写错也只是标签写错。
  */
 export function parseMcpServerArgv(argv: string[]): McpServerArgv {
-  const out: McpServerArgv = { channel: null, identity: null, error: null };
+  const out: McpServerArgv = { channel: null, identity: null, allChannels: false, error: null };
   for (let i = 0; i < argv.length; i += 1) {
     const a = argv[i];
+    // #1083：一条注册服务本机所有频道，频道由每次工具调用传入、身份按频道解析。
+    if (a === "--all-channels") {
+      out.allChannels = true;
+      continue;
+    }
     if (a === "--channel" || a === "--identity") {
       const v = argv[i + 1];
       if (v === undefined || v.startsWith("-")) return { ...out, error: `${a} needs a value\n${MCP_USAGE}` };

--- a/cli/src/pull-wake.ts
+++ b/cli/src/pull-wake.ts
@@ -17,6 +17,7 @@
 // 两条都成立时，这条 @ 会在该身份下次在**本机**跑 codex 时被它自己取走。别的机器有没有装、
 // 用户还会不会再开那个会话，本机一概不知道——所以措辞只说「本机可拉取」，绝不说「可达」。
 import { readFileSync } from "node:fs";
+import { listSessions } from "./claude-session-registry";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { localAgentConfigsForChannel } from "./config";
@@ -46,8 +47,12 @@ export interface PullWakeHint {
    * `missing` 不会走到这里——那时压根不产生 hint。
    */
   hook: Exclude<CodexStopHookStatus, "missing">;
-  /** 判据清单，便于调用方解释「凭什么这么说」。 */
-  evidence: ["codex_stop_hook", "local_agent_config"];
+  /**
+   * 判据清单，便于调用方解释「凭什么这么说」。三条缺一不可：装了 hook、本机有这份身份的
+   * config、**而且本机现在有一个用该身份的活会话**（#1083）。第三条是后补的——前两条都为真
+   * 但会话早就关了的情况，此前会一直宣称可达。
+   */
+  evidence: ["codex_stop_hook", "local_agent_config", "live_codex_session"];
 }
 
 /** 这条拉取通道当下真的会取走 @ 吗。false ⇒ 装了但 codex 不会执行它。 */
@@ -104,6 +109,24 @@ export function locallyConfiguredNames(channel: string, server: string): Set<str
   return names;
 }
 
+/**
+ * 本机**活着**的 codex 会话在该频道用的身份名（#1083）。
+ *
+ * listSessions 已按 pid 过滤死条目；这里再比 channel 与 server。没有记下 identity 的老条目
+ * （#906 之前入册的）一律不计入——**读不到就当没有**：少给一条提示只是少一句话，
+ * 错标一个「可拉取」会让发送方安心去等一个永远不会来的回复。
+ */
+export function liveCodexSessionNames(channel: string, server: string): Set<string> {
+  const names = new Set<string>();
+  for (const entry of listSessions("codex")) {
+    if (entry.channel !== channel) continue;
+    // server 记不下来的条目同样跳过：#865 的同名频道在两台实例上是两回事。
+    if (entry.server !== server) continue;
+    if (typeof entry.identity === "string" && entry.identity !== "") names.add(entry.identity);
+  }
+  return names;
+}
+
 export interface PullWakeLookup {
   /** 该身份在本机是否有拉取式唤醒通道。 */
   hintFor: (name: string) => PullWakeHint | undefined;
@@ -121,6 +144,13 @@ export function buildPullWakeLookup(
     /** hook 会不会被 codex 执行（#926）。缺省走 #925 的四态判定；`missing` 视同没装。 */
     hookStatus?: () => CodexStopHookStatus;
     names?: (channel: string, server: string) => Set<string>;
+    /**
+     * #1083：本机**当前活着**的会话身份。前两道闸只证明「装了 hook」和「本机有这份 config」，
+     * 而 config 文件从不删除——于是一个几天前就关掉的会话，会一直对全频道宣称
+     * 「@ 我，这台机器上的 codex 会通过 Stop hook 接」。实测名单里有 3~11 天前关掉的会话仍在这么说。
+     * Stop hook 只在**有会话在跑**时才会触发，所以「有活会话」才是这个承诺的真正前提。
+     */
+    liveNames?: (channel: string, server: string) => Set<string>;
   } = {},
 ): PullWakeLookup {
   // hasHook 是「文件里有没有」，hookStatus 是「会不会跑」——两件事，两道闸，缺一不可。
@@ -131,10 +161,16 @@ export function buildPullWakeLookup(
   // missing：文件里有指纹但四态判定说没有（例如 hooks.json 刚被改坏）——以「不会跑」为准，闭嘴。
   if (status === "missing") return { hintFor: () => undefined };
   const names = (deps.names ?? locallyConfiguredNames)(channel, server);
+  const live = (deps.liveNames ?? liveCodexSessionNames)(channel, server);
   return {
     hintFor: (name: string) =>
-      names.has(name)
-        ? { scope: "local", harness: "codex", hook: status, evidence: ["codex_stop_hook", "local_agent_config"] }
+      names.has(name) && live.has(name)
+        ? {
+            scope: "local",
+            harness: "codex",
+            hook: status,
+            evidence: ["codex_stop_hook", "local_agent_config", "live_codex_session"],
+          }
         : undefined,
   };
 }

--- a/cli/test/mcp-channel-identity.test.ts
+++ b/cli/test/mcp-channel-identity.test.ts
@@ -1,0 +1,179 @@
+// #1083：单进程多频道下的身份解析。这条路上解错身份**不会报错**，只会以别人的身份发言——
+// 所以用例重点全在「什么时候必须拒绝」，而不是「什么时候能解出来」。
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  listAgentConfigs,
+  readChannelDefaults,
+  recordChannelDefault,
+  resolveChannelIdentity,
+  type AgentIdentityConfig,
+} from "../src/mcp-channel-identity";
+
+function cfg(over: Partial<AgentIdentityConfig>): AgentIdentityConfig {
+  return {
+    path: "/p/a.json",
+    server: "https://s1",
+    channel: "dev",
+    name: "a",
+    verifiedAt: null,
+    ...over,
+  };
+}
+
+function home(): string {
+  return mkdtempSync(join(tmpdir(), "ap-mcp-ident-"));
+}
+
+function writeAgentConfig(h: string, file: string, body: unknown): string {
+  mkdirSync(join(h, "agents"), { recursive: true });
+  const p = join(h, "agents", file);
+  writeFileSync(p, JSON.stringify(body));
+  return p;
+}
+
+describe("列出本机身份", () => {
+  test("频道取自 identity.channel_scope，不靠文件名猜", () => {
+    const h = home();
+    // 文件名故意与频道不符：真相在 channel_scope 里。
+    writeAgentConfig(h, "agentparty-bot-WRONGNAME.json", {
+      server: "https://s1",
+      token: "t",
+      identity: { name: "bot", channel_scope: "real-channel", verified_at: 5 },
+    });
+    const got = listAgentConfigs(h);
+    expect(got).toHaveLength(1);
+    expect(got[0]!.channel).toBe("real-channel");
+    expect(got[0]!.name).toBe("bot");
+    rmSync(h, { recursive: true, force: true });
+  });
+
+  test("坏 JSON / 缺 token / 缺 channel_scope 一律跳过，不让一份坏 config 弄挂整台机器", () => {
+    const h = home();
+    mkdirSync(join(h, "agents"), { recursive: true });
+    writeFileSync(join(h, "agents", "broken.json"), "{ not json");
+    writeAgentConfig(h, "no-token.json", { server: "https://s1", identity: { name: "x", channel_scope: "dev" } });
+    writeAgentConfig(h, "no-scope.json", { server: "https://s1", token: "t", identity: { name: "y" } });
+    writeAgentConfig(h, "good.json", {
+      server: "https://s1",
+      token: "t",
+      identity: { name: "z", channel_scope: "dev" },
+    });
+    expect(listAgentConfigs(h).map((c) => c.name)).toEqual(["z"]);
+    rmSync(h, { recursive: true, force: true });
+  });
+
+  test("agents 目录不存在时返回空，不抛", () => {
+    const h = home();
+    expect(listAgentConfigs(h)).toEqual([]);
+    rmSync(h, { recursive: true, force: true });
+  });
+});
+
+describe("解析顺序：显式 > 登记的默认 > 唯一 > 失败关闭", () => {
+  const only = cfg({ path: "/p/only.json", channel: "solo", name: "solo-bot" });
+  const a = cfg({ path: "/p/a.json", channel: "dev", name: "alice", verifiedAt: 100 });
+  const b = cfg({ path: "/p/b.json", channel: "dev", name: "bob", verifiedAt: 999 });
+
+  test("频道只有一份身份 ⇒ 用它", () => {
+    const r = resolveChannelIdentity({ channel: "solo", configs: [only, a, b], defaults: {} });
+    expect(r.ok && r.via).toBe("only");
+    expect(r.ok && r.config.name).toBe("solo-bot");
+  });
+
+  test("多份 + 没登记默认 ⇒ 失败关闭，把候选都列出来", () => {
+    const r = resolveChannelIdentity({ channel: "dev", configs: [a, b], defaults: {} });
+    expect(r.ok).toBe(false);
+    if (r.ok) throw new Error("unreachable");
+    expect(r.reason).toBe("ambiguous");
+    expect(r.candidates.map((c) => c.name).sort()).toEqual(["alice", "bob"]);
+    expect(r.message).toContain("alice");
+    expect(r.message).toContain("bob");
+  });
+
+  // 这条是本文件存在的理由：任何「挑最近验证的 / 挑第一个」的启发式，都等价于随机挑一个
+  // 身份替用户说话，而且不会有任何报错。
+  test("绝不按 verified_at 或顺序挑一个了事", () => {
+    const r = resolveChannelIdentity({ channel: "dev", configs: [a, b], defaults: {} });
+    expect(r.ok).toBe(false);
+    const reversed = resolveChannelIdentity({ channel: "dev", configs: [b, a], defaults: {} });
+    expect(reversed.ok).toBe(false);
+  });
+
+  test("登记了默认 ⇒ 用登记的那个（而不是最近验证的那个）", () => {
+    const r = resolveChannelIdentity({
+      channel: "dev",
+      configs: [a, b],
+      defaults: { [JSON.stringify(["https://s1", "dev"])]: "/p/a.json" },
+    });
+    expect(r.ok && r.via).toBe("default");
+    expect(r.ok && r.config.name).toBe("alice"); // b 的 verified_at 更新，但登记的是 a
+  });
+
+  test("登记的默认指向一份已经不存在的 config ⇒ 退回歧义判定，不静默换人", () => {
+    const r = resolveChannelIdentity({
+      channel: "dev",
+      configs: [a, b],
+      defaults: { [JSON.stringify(["https://s1", "dev"])]: "/p/deleted.json" },
+    });
+    expect(r.ok).toBe(false);
+  });
+
+  test("显式指定身份 ⇒ 只认它", () => {
+    const r = resolveChannelIdentity({ channel: "dev", identity: "bob", configs: [a, b], defaults: {} });
+    expect(r.ok && r.via).toBe("explicit");
+    expect(r.ok && r.config.name).toBe("bob");
+  });
+
+  test("显式指定了一个不存在的身份 ⇒ 报错，绝不退回登记的默认", () => {
+    const r = resolveChannelIdentity({
+      channel: "dev",
+      identity: "carol",
+      configs: [a, b],
+      defaults: { [JSON.stringify(["https://s1", "dev"])]: "/p/a.json" },
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) throw new Error("unreachable");
+    expect(r.message).toContain("carol");
+  });
+
+  test("本机没有这个频道的身份 ⇒ 报错并给出 party join 的原话", () => {
+    const r = resolveChannelIdentity({ channel: "nope", configs: [a], defaults: {} });
+    expect(r.ok).toBe(false);
+    if (r.ok) throw new Error("unreachable");
+    expect(r.reason).toBe("none");
+    expect(r.message).toContain("party join");
+    expect(r.message).toContain("nope");
+  });
+
+  // 一台机器可能同时连 prod 和自建实例，两边可以有同名频道——那是两个不同的地方。
+  test("同名频道分属两个 server ⇒ 不给 server 时算歧义，给了就解得出", () => {
+    const p = cfg({ path: "/p/p.json", server: "https://prod", channel: "shared", name: "prod-bot" });
+    const x = cfg({ path: "/p/x.json", server: "https://xdream", channel: "shared", name: "x-bot" });
+    expect(resolveChannelIdentity({ channel: "shared", configs: [p, x], defaults: {} }).ok).toBe(false);
+    const r = resolveChannelIdentity({ channel: "shared", server: "https://xdream", configs: [p, x], defaults: {} });
+    expect(r.ok && r.config.name).toBe("x-bot");
+  });
+});
+
+describe("默认身份登记表", () => {
+  test("写了能读回来，同频道再写是替换而不是叠加", () => {
+    const h = home();
+    recordChannelDefault("https://s1", "dev", "/p/a.json", h);
+    expect(readChannelDefaults(h)).toEqual({ [JSON.stringify(["https://s1", "dev"])]: "/p/a.json" });
+    recordChannelDefault("https://s1", "dev", "/p/b.json", h);
+    recordChannelDefault("https://s1", "other", "/p/c.json", h);
+    expect(readChannelDefaults(h)).toEqual({ [JSON.stringify(["https://s1", "dev"])]: "/p/b.json", [JSON.stringify(["https://s1", "other"])]: "/p/c.json" });
+    rmSync(h, { recursive: true, force: true });
+  });
+
+  test("登记表坏了 ⇒ 当作没有登记（退回失败关闭），而不是让 MCP 起不来", () => {
+    const h = home();
+    mkdirSync(h, { recursive: true });
+    writeFileSync(join(h, "mcp-channel-defaults.json"), "{ broken");
+    expect(readChannelDefaults(h)).toEqual({});
+    rmSync(h, { recursive: true, force: true });
+  });
+});

--- a/cli/test/mcp-channel-identity.test.ts
+++ b/cli/test/mcp-channel-identity.test.ts
@@ -11,6 +11,7 @@ import {
   resolveChannelIdentity,
   type AgentIdentityConfig,
 } from "../src/mcp-channel-identity";
+import { parseMcpServerArgv } from "../src/mcp-registry";
 
 function cfg(over: Partial<AgentIdentityConfig>): AgentIdentityConfig {
   return {
@@ -175,5 +176,59 @@ describe("默认身份登记表", () => {
     writeFileSync(join(h, "mcp-channel-defaults.json"), "{ broken");
     expect(readChannelDefaults(h)).toEqual({});
     rmSync(h, { recursive: true, force: true });
+  });
+});
+
+// owner 那台机器上的真实场景：#agentparty 的 leo-claude 有两份 config，同 server、同名，
+// 只是验证时间不同。这不是身份歧义（挑哪份都不会以别人的名义说话），此前却被判成歧义并
+// 提示「请用 --server 限定」——而两份 server 一模一样，那条出路根本走不通。
+describe("同一身份的重复 config 不算歧义", () => {
+  const older = {
+    path: "/p/old.json",
+    server: "https://s1",
+    channel: "dev",
+    name: "same",
+    verifiedAt: 100,
+  };
+  const newer = { ...older, path: "/p/new.json", verifiedAt: 999 };
+
+  test("同 (server, channel, name) 的多份 config ⇒ 取最近验证的那份，不报歧义", () => {
+    const r = resolveChannelIdentity({ channel: "dev", configs: [older, newer], defaults: {} });
+    expect(r.ok && r.via).toBe("only");
+    expect(r.ok && r.config.path).toBe("/p/new.json");
+  });
+
+  test("显式指定该身份同样解得出", () => {
+    const r = resolveChannelIdentity({ channel: "dev", identity: "same", configs: [older, newer], defaults: {} });
+    expect(r.ok && r.config.path).toBe("/p/new.json");
+  });
+
+  test("名字不同才是真歧义——这条线不能被上面的合并冲掉", () => {
+    const other = { ...older, path: "/p/other.json", name: "different" };
+    const r = resolveChannelIdentity({ channel: "dev", configs: [older, newer, other], defaults: {} });
+    expect(r.ok).toBe(false);
+    if (r.ok) throw new Error("unreachable");
+    expect(r.candidates.map((c) => c.name).sort()).toEqual(["different", "same"]);
+  });
+});
+
+// #1083 的一次真实事故：最初用「没设 AGENTPARTY_CONFIG 就算聚合档」自动判定，结果 44 个既有
+// 用例当场变红——很多现存装法本来就不设这个 env（靠 cwd 绑定或全局 config）。自动判定会让
+// 它们突然被要求每次调用都传 channel，是一次静默的破坏性变更。聚合必须是主动选择。
+describe("聚合档必须显式开启（--all-channels）", () => {
+  test("裸 `party mcp` 不进聚合档", () => {
+    expect(parseMcpServerArgv([]).allChannels).toBe(false);
+  });
+
+  test("只给 --channel 的旧注册不进聚合档", () => {
+    expect(parseMcpServerArgv(["--channel", "dev"]).allChannels).toBe(false);
+  });
+
+  test("--all-channels 才进，且能与 --identity 共存", () => {
+    expect(parseMcpServerArgv(["--all-channels"]).allChannels).toBe(true);
+    const both = parseMcpServerArgv(["--all-channels", "--identity", "leo"]);
+    expect(both.allChannels).toBe(true);
+    expect(both.identity).toBe("leo");
+    expect(both.error).toBeNull();
   });
 });

--- a/cli/test/mcp-channel-identity.test.ts
+++ b/cli/test/mcp-channel-identity.test.ts
@@ -232,3 +232,66 @@ describe("聚合档必须显式开启（--all-channels）", () => {
     expect(both.error).toBeNull();
   });
 });
+
+// CodeRabbit on #1084：两台实例各登记了同一频道的默认身份时，按枚举顺序取第一个＝按文件名
+// 排序选身份，正是「绝不猜」要防的。收齐所有命中，恰一个才用。
+describe("多实例各登记了默认身份 ⇒ 歧义，不按顺序挑", () => {
+  const prod = cfg({ path: "/p/prod.json", server: "https://prod", channel: "shared", name: "prod-bot" });
+  const x = cfg({ path: "/p/x.json", server: "https://xdream", channel: "shared", name: "x-bot" });
+  const defaults = {
+    [JSON.stringify(["https://prod", "shared"])]: "/p/prod.json",
+    [JSON.stringify(["https://xdream", "shared"])]: "/p/x.json",
+  };
+
+  test("不给 server ⇒ 拒绝并列出两个实例", () => {
+    const r = resolveChannelIdentity({ channel: "shared", configs: [prod, x], defaults });
+    expect(r.ok).toBe(false);
+    if (r.ok) throw new Error("unreachable");
+    expect(r.message).toContain("https://prod");
+    expect(r.message).toContain("https://xdream");
+  });
+
+  test("给了 server ⇒ 解到那台的默认", () => {
+    const r = resolveChannelIdentity({ channel: "shared", server: "https://xdream", configs: [prod, x], defaults });
+    expect(r.ok && r.via).toBe("default");
+    expect(r.ok && r.config.name).toBe("x-bot");
+  });
+
+  test("枚举顺序反过来结论不变", () => {
+    expect(resolveChannelIdentity({ channel: "shared", configs: [x, prod], defaults }).ok).toBe(false);
+  });
+});
+
+// CodeRabbit on #1084：party_task_create 的 inputSchema 是 .strict() 的 ZodObject。往实例上赋属性
+// 是空操作，strict 还会把没声明的 identity/server 直接拒掉——聚合档下这个工具就没法指定身份。
+describe("聚合档下 strict ZodObject 工具也能收 identity / server", () => {
+  test("party_task_create 的 schema 被 .extend() 出 identity 与 server", async () => {
+    const { createMcpServer } = await import("../src/commands/mcp");
+    const server = createMcpServer(undefined, true);
+    // 私有字段，但这是唯一能不起 stdio 就核对「客户端看到的 schema」的办法。
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const tool = (server as any)._registeredTools["party_task_create"];
+    const schema = tool.inputSchema;
+    const shape = typeof schema.shape === "function" ? schema.shape() : schema.shape;
+    expect(shape.identity).toBeDefined();
+    expect(shape.server).toBeDefined();
+    expect(shape.channel).toBeDefined();
+    // strict 仍在：随便塞个没声明的键要被拒
+    expect(schema.safeParse({ channel: "dev", title: "t", identity: "me", bogus: 1 }).success).toBe(false);
+    expect(schema.safeParse({ channel: "dev", title: "t", identity: "me", server: "https://s" }).success).toBe(true);
+  });
+
+  test("裸 shape 的工具同样补上三个键，已有的 channel 不被覆盖", async () => {
+    const { createMcpServer } = await import("../src/commands/mcp");
+    const server = createMcpServer(undefined, true);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const tools = (server as any)._registeredTools;
+    for (const name of ["party_whoami", "party_send", "party_who"]) {
+      const schema = tools[name].inputSchema;
+      const shape = typeof schema.shape === "function" ? schema.shape() : schema.shape ?? schema;
+      expect(shape.channel, name).toBeDefined();
+      expect(shape.identity, name).toBeDefined();
+      expect(shape.server, name).toBeDefined();
+    }
+  });
+});

--- a/cli/test/mcp-prune.test.ts
+++ b/cli/test/mcp-prune.test.ts
@@ -339,24 +339,27 @@ describe("party mcp 的 argv 解析（--identity，#898）", () => {
     expect(parseMcpServerArgv(["--channel", "dev", "--identity", "party-bot"])).toEqual({
       channel: "dev",
       identity: "party-bot",
+      allChannels: false,
       error: null,
     });
     expect(parseMcpServerArgv(["--identity", "party-bot", "--channel", "dev"])).toEqual({
       channel: "dev",
       identity: "party-bot",
+      allChannels: false,
       error: null,
     });
   });
 
   test("两者都缺席（真机常态：裸 `party mcp`）仍然合法", () => {
-    expect(parseMcpServerArgv([])).toEqual({ channel: null, identity: null, error: null });
+    expect(parseMcpServerArgv([])).toEqual({ channel: null, identity: null, allChannels: false, error: null });
   });
 
   test("只给其中一个也合法（旧注册只有 --channel，绝不能被新解析器拒掉）", () => {
-    expect(parseMcpServerArgv(["--channel", "dev"])).toEqual({ channel: "dev", identity: null, error: null });
+    expect(parseMcpServerArgv(["--channel", "dev"])).toEqual({ channel: "dev", identity: null, allChannels: false, error: null });
     expect(parseMcpServerArgv(["--identity", "party-bot"])).toEqual({
       channel: null,
       identity: "party-bot",
+      allChannels: false,
       error: null,
     });
   });
@@ -370,8 +373,13 @@ describe("party mcp 的 argv 解析（--identity，#898）", () => {
     expect(parseMcpServerArgv(["dev"]).error).toContain("usage: party mcp");
   });
 
-  test("标签只影响展示：解析结果里没有任何可以改写身份来源的字段", () => {
+  test("标签只影响展示：argv 里没有任何字段能**指名**一个身份", () => {
     const parsed = parseMcpServerArgv(["--identity", "party-someone-else"]);
-    expect(Object.keys(parsed).sort()).toEqual(["channel", "error", "identity"]);
+    // #1083 加了 allChannels。它切换的是「身份怎么解析」（按每次调用的 channel 去盘上找），
+    // 而不是「身份是谁」——argv 依然指名不了任何身份，--identity 依然纯展示。守的是同一条线：
+    // 谁都别想靠改注册命令行冒充别人。
+    expect(Object.keys(parsed).sort()).toEqual(["allChannels", "channel", "error", "identity"]);
+    expect(parsed.identity).toBe("party-someone-else");
+    expect(parsed.allChannels).toBe(false);
   });
 });

--- a/cli/test/send-deferred.test.ts
+++ b/cli/test/send-deferred.test.ts
@@ -24,7 +24,13 @@ function stale(over: Partial<PresenceEntry> & { name: string }): PresenceEntry {
 }
 
 const lookup = (names: string[], hook: "ok" | "disabled" = "ok") =>
-  buildPullWakeLookup(CH, "https://s", { hasHook: () => true, hookStatus: () => hook, names: () => new Set(names) });
+  buildPullWakeLookup(CH, "https://s", {
+    hasHook: () => true,
+    hookStatus: () => hook,
+    names: () => new Set(names),
+    // #1083：不注入就会去读这台机器真实的会话注册表，测试随机器状态摇摆。
+    liveNames: () => new Set(names),
+  });
 
 function report(presence: PresenceEntry[], sentSeq: number, pullWake = lookup(["codex1"])) {
   return reachReport({ mentions: ["codex1"], presence, now: NOW, channel: CH, sentSeq, wantLine: false, wantWarn: true, pullWake });

--- a/cli/test/who.test.ts
+++ b/cli/test/who.test.ts
@@ -625,12 +625,31 @@ describe("who pull-based reachability（#905：既不是在线，也不是不可
     p({ state: "offline", wake: { kind: "none" }, last_seen: NOW - 88 * 60 * 60 * 1000, ...over });
   // #926：`hookStatus` 必须显式注入。默认实现会去读**这台机器真实的** ~/.codex/config.toml，
   // 于是单测结果会随跑测试那台机器的 hook 信任闸摇摆（owner 那台就是全 disabled）。
-  const lookup = (names: string[], hook: CodexStopHookStatus = "ok"): PullWakeLookup =>
+  // #1083：liveNames 同样必须显式注入。默认实现读**这台机器真实的**会话注册表，
+  // 单测会随跑测试时机器上开着哪些 codex 会话摇摆。缺省让 names 里的都算「有活会话」，
+  // 保持既有用例语义；「有 config 但会话已关」那档由下面专门的用例覆盖。
+  const lookup = (names: string[], hook: CodexStopHookStatus = "ok", live: string[] = names): PullWakeLookup =>
     buildPullWakeLookup(CH, "https://s", {
       hasHook: () => true,
       hookStatus: () => hook,
       names: () => new Set(names),
+      liveNames: () => new Set(live),
     });
+
+  // #1083：本机有该身份的 config、hook 也装着，但那个会话**早就关了**。此前这两条就足以让
+  // 名单一直宣称「@ 我，这台机器上的 codex 会接」——实测线上名单里有 3~11 天前关掉的会话仍在这么说。
+  // Stop hook 只在有会话在跑时才触发，所以会话关了就必须停止这个承诺：宁可少说一句，
+  // 也不能让发送方安心去等一个永远不会来的回复。
+  test("有 config 但会话已经关了 ⇒ 不再宣称 deferred 可达", () => {
+    const rows = buildRows([stale({ name: "lark-codex1" })], {
+      now: NOW,
+      channel: CH,
+      pullWake: lookup(["lark-codex1"], "ok", []), // config 在，活会话没有
+    });
+    const r = rows[0] as NonNullable<(typeof rows)[number]>;
+    expect(r.pull_wake).toBeUndefined();
+    expect(renderRow(r, NOW, 0)).not.toContain("⇢ deferred");
+  });
 
   test("装了 Stop hook 的身份：不再断言 unreachable，改说「下次跑起来时会取到」", () => {
     const rows = buildRows([stale({ name: "lark-codex1" })], {
@@ -643,7 +662,7 @@ describe("who pull-based reachability（#905：既不是在线，也不是不可
       scope: "local",
       harness: "codex",
       hook: "ok",
-      evidence: ["codex_stop_hook", "local_agent_config"],
+      evidence: ["codex_stop_hook", "local_agent_config", "live_codex_session"],
     });
     const line = renderRow(r, NOW, 0);
     expect(line).toContain("⇢ deferred");
@@ -878,7 +897,13 @@ describe("who deferred 行的队列深度（#958）", () => {
   const stale = (over: Partial<PresenceEntry> & { name: string }): PresenceEntry =>
     p({ state: "offline", wake: { kind: "none" }, last_seen: NOW - 88 * 60 * 60 * 1000, ...over });
   const lookup = (names: string[]): PullWakeLookup =>
-    buildPullWakeLookup(CH, "https://s", { hasHook: () => true, hookStatus: () => "ok", names: () => new Set(names) });
+    buildPullWakeLookup(CH, "https://s", {
+      hasHook: () => true,
+      hookStatus: () => "ok",
+      names: () => new Set(names),
+      // #1083：不注入就会去读这台机器真实的会话注册表，测试随机器状态摇摆。
+      liveNames: () => new Set(names),
+    });
   const render = (entry: PresenceEntry): string => {
     const rows = buildRows([entry], { now: NOW, channel: CH, pullWake: lookup([entry.name]) });
     return renderRow(rows[0] as NonNullable<(typeof rows)[number]>, NOW, 0, CH);
@@ -923,6 +948,7 @@ describe("who deferred 行的队列深度（#958）", () => {
         hasHook: () => true,
         hookStatus: () => "disabled",
         names: () => new Set(["lark-codex1"]),
+        liveNames: () => new Set(["lark-codex1"]),
       }),
     });
     const line = renderRow(rows[0] as NonNullable<(typeof rows)[number]>, NOW, 0, CH);


### PR DESCRIPTION
Fixes #1083（进程膨胀那半），并顺带修掉排查中发现的一个更严重的问题。

## 背景数据
16GB Mac、4 个 Claude Code + 6 个 Codex 并发会话下实测：agentparty **29 个进程 / 298 MB**，占自研 MCP 进程数 37%、内存 55%。对比 iphone-use-mcp 6 个进程 2 MB。

根因是两条叠加，第二条被低估了：

1. **一个 channel 一个进程** —— 进程数 = 频道数 × 会话数。
2. **注册只进不出** —— `party join` 每加入一个频道就往全局 config 塞一条，**没有任何东西会删它**。owner 那台机器上 5 条 codex 注册里只有 1 个频道还在用，最老的 36 天没动过，却仍在每个会话里各起一个进程。这一条让第一条随时间**单调恶化**。

## 改动一：`party mcp --all-channels`
`--channel` 本来就只是默认值（所有工具都收显式 channel 参数），真正把它钉成一进程一频道的是**身份**：每条注册各绑一份 `AGENTPARTY_CONFIG`。所以这版把身份从**进程属性**改成**调用属性**。

- 身份按每次调用的 channel 解析（新 `mcp-channel-identity.ts`），顺序是 **显式 > 登记的默认 > 唯一 > 失败关闭**，绝不按时间或顺序猜——本机 24 个频道里 16 个有多份身份（agentparty 一个频道 15 份），猜一个等于随机挑个人替用户说话，而且不会报错。
- 每次调用的身份走 **AsyncLocalStorage，绝不临时改 `process.env`**。MCP 工具调用可以并发，改 env 再改回来会让后一个调用读到前一个设的值——这正是这条路上最该防的串号。
- 落点选在 `explicitConfigPath()` 这一个瓶颈上，**22 个 `auth()` 调用点一处未改**。

**聚合必须显式开启。** 最初我用「没设 `AGENTPARTY_CONFIG` 就算聚合」自动判定，44 个既有用例当场变红——很多现存装法本来就不设这个 env（靠 cwd 绑定或全局 config），自动判定会让它们突然被要求每次都传 channel，是一次静默的破坏性变更。默认档行为一字未变。

## 改动二：会话关了就别再宣称「@ 我这台机器会接」
排查时发现的，比进程数严重：名单里那句 `⇢ deferred — a codex turn under this identity on this machine picks the @ up via the Stop hook`，判据只有「装了 hook」+「本机有这个身份的 config」，而 **config 文件从来不删**。

owner 的 #agentparty 名单里有 4 个这样的条目——3 / 5 / 7 / 11 天前关掉的会话，今天仍在宣称可达。**别人 @ 过去不会有回应，也不会报错。**

加了第三道闸：本机必须有一个**活着的**、用该身份的会话。判据是现成的（`listSessions` 已按 pid 判活并顺手删死条目），只是没人用它。

顺带澄清，免得日后有人补不需要的机制：会话结束**不需要**「优雅注销」——注册表按 pid 判活，`kill -9` 一样立刻生效，比退出前说再见更可靠；服务端 presence 也本来就按 `last_seen` 衰减。缺的从来只有本地这一句假承诺。

**常驻（`party serve`）完全不受影响**：它走 serve 租约，不看 hook 也不看会话注册表。

## 验证
真机起一个不带任何 `AGENTPARTY_CONFIG` 的进程，走真 JSON-RPC：

| 场景 | 结果 |
|---|---|
| `channel=ocs`（唯一身份） | 自动解析成 `leomacbook`，完成服务端调用 |
| `channel=agentparty`（15 份身份） | 拒绝 + 列候选，绝不猜 |
| `channel=nosuchchannel` | 给出 `party join` 原话 |
| 显式 `identity=leo-claude` | 穿过歧义，解析成功 |

cli 全量 **2970 pass / 0 fail**。

## 未做
- 空闲自退：**建议不做**。MCP 进程本来就随宿主会话退出（#908），合并成 1 条注册后每会话就 1 个进程；此时再加空闲自退等于赌客户端会按需重启，赌输就是 agent 静默失联，收益只剩几 MB。要的话可以做成默认关闭的开关。
- `party mcp prune` 认「陈旧频道」+ 覆盖 codex 注册（目前只删「身份已不存在」的 Claude Code 注册，管不到本次这批）。另开 PR。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增 MCP 聚合频道模式，可通过 `--all-channels` 为不同频道选择并使用对应身份。
  - 支持保存频道默认身份，并在身份不明确时提供失败原因与候选信息。
  - 改进并发调用时的身份隔离，避免不同频道间发生身份混用。

- **改进**
  - 拉取式唤醒现在仅在存在匹配的活跃 Codex 会话时触发，减少误报。

- **测试**
  - 补充多频道身份解析、参数处理及活跃会话判断的测试覆盖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->