### PR TITLE
fix(cli): party who --all 不再对着一屏离线的人说「reachable」（#1074 补）

### DIFF
--- a/cli/src/commands/who-global.ts
+++ b/cli/src/commands/who-global.ts
@@ -260,17 +260,24 @@ export interface GlobalWhoSummary {
 export function summarizeGlobalWho(rows: GlobalWhoRow[], channelCount: number, now: number): GlobalWhoSummary {
   const counts: Record<GlobalReach, number> = { online: 0, wakeable: 0, recent: 0, offline: 0 };
   for (const row of rows) counts[row.reach] += 1;
+  // 暂停中的身份不折：⏸ 是有人**刻意**设的状态（被 @ 也不唤醒），折进计数里等于把这个决定藏掉。
   const stale = (row: GlobalWhoRow): boolean =>
-    row.reach === "offline" && row.last_seen !== undefined && now - row.last_seen > OFFLINE_FOLD_MS;
+    row.reach === "offline" &&
+    row.paused !== true &&
+    row.last_seen !== undefined &&
+    now - row.last_seen > OFFLINE_FOLD_MS;
   const shown = rows.filter((row) => !stale(row));
   const foldedRows = rows.filter(stale);
   const reachable = counts.online + counts.wakeable;
   const parts = (Object.keys(counts) as GlobalReach[])
     .filter((tier) => counts[tier] > 0)
     .map((tier) => `${counts[tier]} ${tier}`);
-  const header = reachable > 0
-    ? `${reachable} reachable across ${channelCount} channel(s) (${parts.join(" · ")}) — pass a channel for wake diagnostics:`
-    : `no one reachable right now across ${channelCount} channel(s) (${parts.join(" · ")}) — pass a channel for wake diagnostics:`;
+  // 空列表也从这里出文案，与非空时同一口径（此前 who.ts 自己写了一句「… yet」，两处措辞打架）。
+  const header = rows.length === 0
+    ? `no one reachable right now across ${channelCount} channel(s)`
+    : reachable > 0
+      ? `${reachable} reachable across ${channelCount} channel(s) (${parts.join(" · ")}) — pass a channel for wake diagnostics:`
+      : `no one reachable right now across ${channelCount} channel(s) (${parts.join(" · ")}) — pass a channel for wake diagnostics:`;
   let foldLine: string | undefined;
   if (foldedRows.length > 0) {
     const ages = foldedRows.map((row) => now - (row.last_seen ?? now));

--- a/cli/src/commands/who-global.ts
+++ b/cli/src/commands/who-global.ts
@@ -234,6 +234,62 @@ export function renderGlobalRow(
   return `${REACH_MARK[row.reach]} ${sanitize(display)}${owner}  ${row.kind}${paused}  ${where}${age}${noMention}${aka}`;
 }
 
+/** 离线行保留多久：与频道内名单「历史会话不上榜」（#1069）同一口径——一周没露面就折叠。 */
+export const OFFLINE_FOLD_MS = 7 * 86_400_000;
+
+export interface GlobalWhoSummary {
+  /** 逐行打印的那些（在线 / 可唤醒 / 最近 / 一周内离线）。 */
+  shown: GlobalWhoRow[];
+  /** 被折进一行的陈旧离线行数。 */
+  folded: number;
+  /** 表头：按档位报计数，**不**说「reachable」——除非真有人在线或可唤醒。 */
+  header: string;
+  /** 折叠行；没折叠就是 undefined。 */
+  foldLine: string | undefined;
+  /** 图例：只在至少一行用到了记号时给。 */
+  legend: string | undefined;
+}
+
+/**
+ * 全局 who 的文本呈现（不含逐行渲染）。
+ *
+ * 此前表头恒写「reachable across N channel(s)」，而列表里可以一个在线的都没有：owner 那台机器
+ * 实测 7 行全是 offline（最老 60 天），全靠一个没有图例的 `·` 区分——系统自信地讲了一件错事。
+ * 表头改成按档位报数；一周以上没露面的离线行折成一行计数（频道内名单同一口径）；记号给图例。
+ */
+export function summarizeGlobalWho(rows: GlobalWhoRow[], channelCount: number, now: number): GlobalWhoSummary {
+  const counts: Record<GlobalReach, number> = { online: 0, wakeable: 0, recent: 0, offline: 0 };
+  for (const row of rows) counts[row.reach] += 1;
+  const stale = (row: GlobalWhoRow): boolean =>
+    row.reach === "offline" && row.last_seen !== undefined && now - row.last_seen > OFFLINE_FOLD_MS;
+  const shown = rows.filter((row) => !stale(row));
+  const foldedRows = rows.filter(stale);
+  const reachable = counts.online + counts.wakeable;
+  const parts = (Object.keys(counts) as GlobalReach[])
+    .filter((tier) => counts[tier] > 0)
+    .map((tier) => `${counts[tier]} ${tier}`);
+  const header = reachable > 0
+    ? `${reachable} reachable across ${channelCount} channel(s) (${parts.join(" · ")}) — pass a channel for wake diagnostics:`
+    : `no one reachable right now across ${channelCount} channel(s) (${parts.join(" · ")}) — pass a channel for wake diagnostics:`;
+  let foldLine: string | undefined;
+  if (foldedRows.length > 0) {
+    const ages = foldedRows.map((row) => now - (row.last_seen ?? now));
+    const newest = fmtAge(Math.min(...ages));
+    const oldest = fmtAge(Math.max(...ages));
+    foldLine =
+      `  · ${foldedRows.length} more offline for over a week (last seen ${newest} – ${oldest}) — ` +
+      `party who <channel> lists them`;
+  }
+  const marks = new Set(shown.map((row) => REACH_MARK[row.reach]));
+  const legend = shown.length === 0
+    ? undefined
+    : "  " + (["online", "wakeable", "recent", "offline"] as GlobalReach[])
+        .filter((tier) => marks.has(REACH_MARK[tier]))
+        .map((tier) => `${REACH_MARK[tier]} ${tier}`)
+        .join("  ");
+  return { shown, folded: foldedRows.length, header, foldLine, legend };
+}
+
 function fmtAge(ms: number): string {
   if (ms < 60_000) return "just now";
   if (ms < 3_600_000) return `${Math.floor(ms / 60_000)}m ago`;

--- a/cli/src/commands/who.ts
+++ b/cli/src/commands/who.ts
@@ -3,7 +3,7 @@
 import { autoWakeReachable, type AgentActivity, type ListeningVerdict, type PresenceEntry, type ReceptionContextBoundary, type ReceptionMode, type ReceptionRunner, type RunnerHealth, type RuntimePeerDiscovery, type SenderKind, type TaskLeaseScope, type WakeKind, wakeableState } from "@agentparty/shared";
 import { isHelpArg, parseArgs, str, unknownFlagError, valueFlagError } from "../args";
 import { listChannels } from "../rest";
-import { activeChannelSlugs, buildGlobalWho, globalWhoDisplay, renderGlobalRow } from "./who-global";
+import { activeChannelSlugs, buildGlobalWho, globalWhoDisplay, renderGlobalRow, summarizeGlobalWho } from "./who-global";
 import { resolveChannel } from "../config";
 import { diagnoseCodexWake, formatCodexWakeDiagnosis, shouldSurfaceCodexWakeDiagnosis } from "../wake-diagnosis";
 import { claudeDormantToSurface, diagnoseClaudeDormantSessions, formatClaudeDormantDiagnosis } from "../claude-armed-listener";
@@ -1029,13 +1029,17 @@ async function runGlobalWho(cfg: { server: string; token: string; name?: string 
     }
     return 0;
   }
-  console.log(`reachable across ${snapshots.length} channel(s) — pass a channel for wake diagnostics:`);
-  for (const row of rows) {
+  // 表头按档位报数、陈旧离线折一行、记号给图例——不再对着一屏离线的人说「reachable」。
+  const summary = summarizeGlobalWho(rows, snapshots.length, now);
+  console.log(summary.header);
+  for (const row of summary.shown) {
     const entry = snapshots
       .flatMap((snapshot) => snapshot.presence)
       .find((candidate) => candidate.name === row.name);
     console.log("  " + renderGlobalRow(row, entry === undefined ? row.name : globalWhoDisplay(entry), now, terminalIdentityText));
   }
+  if (summary.foldLine !== undefined) console.log(summary.foldLine);
+  if (summary.legend !== undefined) console.log(summary.legend);
   if (failed.length > 0) {
     console.log(`\ncould not read presence for: ${failed.join(", ")} — this list is incomplete`);
     return 1;

--- a/cli/src/commands/who.ts
+++ b/cli/src/commands/who.ts
@@ -1022,7 +1022,7 @@ async function runGlobalWho(cfg: { server: string; token: string; name?: string 
     return failed.length > 0 ? 1 : 0;
   }
   if (rows.length === 0) {
-    console.log(`no one reachable across ${snapshots.length} channel(s) yet`);
+    console.log(summarizeGlobalWho(rows, snapshots.length, now).header);
     if (failed.length > 0) {
       console.log(`could not read presence for: ${failed.join(", ")}`);
       return 1;

--- a/cli/test/who-global.test.ts
+++ b/cli/test/who-global.test.ts
@@ -268,4 +268,24 @@ describe("summarizeGlobalWho —— 表头按档位报数、陈旧离线折叠�
     expect(none.shown).toHaveLength(0);
     expect(none.legend).toBeUndefined();
   });
+
+  // CodeRabbit on #1085：⏸ 是有人刻意设的状态，折进「N more offline」里等于把这个决定藏掉。
+  test("暂停中的身份哪怕离线很久也不折叠，且照常显示 ⏸", () => {
+    const rows = [
+      row({ name: "paused-bot", reach: "offline", paused: true, last_seen: NOW - 40 * DAY }),
+      row({ name: "old", reach: "offline", last_seen: NOW - 40 * DAY }),
+    ];
+    const s = summarizeGlobalWho(rows, 1, NOW);
+    expect(s.shown.map((r) => r.name)).toEqual(["paused-bot"]);
+    expect(s.folded).toBe(1);
+    expect(renderGlobalRow(s.shown[0]!, "paused-bot", NOW)).toContain("⏸ paused");
+  });
+
+  test("空列表：表头与非空时同一口径，不再是另一句「… yet」", () => {
+    const s = summarizeGlobalWho([], 2, NOW);
+    expect(s.header).toBe("no one reachable right now across 2 channel(s)");
+    expect(s.shown).toHaveLength(0);
+    expect(s.foldLine).toBeUndefined();
+    expect(s.legend).toBeUndefined();
+  });
 });

--- a/cli/test/who-global.test.ts
+++ b/cli/test/who-global.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { PresenceEntry } from "@agentparty/shared";
-import { activeChannelSlugs, buildGlobalWho, personKeyOf, reachOf, renderGlobalRow } from "../src/commands/who-global";
+import { activeChannelSlugs, buildGlobalWho, personKeyOf, reachOf, renderGlobalRow, summarizeGlobalWho, type GlobalWhoRow, type GlobalReach } from "../src/commands/who-global";
 
 const NOW = 1_700_000_000_000;
 
@@ -199,5 +199,73 @@ describe("全局 who 的入口（#1074 补）", () => {
 
   test("帮助文本里写明 --all", () => {
     expect(whoSource).toContain("[--all]");
+  });
+});
+
+// 真机事故：`party who --all` 表头恒写「reachable across 1 channel(s)」，底下 7 行全是 offline
+// （最老 60 天），全靠一个没有图例的 `·` 区分。判定（reach）是对的，撒谎的是呈现。
+describe("summarizeGlobalWho —— 表头按档位报数、陈旧离线折叠、记号给图例", () => {
+  const NOW = 1_800_000_000_000;
+  const DAY = 86_400_000;
+  const row = (over: Partial<GlobalWhoRow> & { name: string; reach: GlobalReach }): GlobalWhoRow => ({
+    kind: "agent",
+    channels: ["agentparty"],
+    ...over,
+  });
+
+  test("一个在线的都没有 ⇒ 表头不许说 reachable，而是如实报「no one reachable right now」+ 各档计数", () => {
+    const rows = [
+      row({ name: "a", reach: "recent", last_seen: NOW - 12 * 3_600_000 }),
+      row({ name: "b", reach: "offline", last_seen: NOW - 59 * DAY }),
+      row({ name: "c", reach: "offline", last_seen: NOW - 60 * DAY }),
+    ];
+    const s = summarizeGlobalWho(rows, 1, NOW);
+    expect(s.header).toMatch(/^no one reachable right now across 1 channel\(s\)/);
+    expect(s.header).toContain("1 recent");
+    expect(s.header).toContain("2 offline");
+    expect(s.header).not.toMatch(/^\d+ reachable/);
+  });
+
+  test("有人在线或可唤醒 ⇒ 表头报可达人数与各档计数", () => {
+    const rows = [
+      row({ name: "a", reach: "online", last_seen: NOW }),
+      row({ name: "b", reach: "wakeable", last_seen: NOW - DAY }),
+      row({ name: "c", reach: "offline", last_seen: NOW - 2 * DAY }),
+    ];
+    const s = summarizeGlobalWho(rows, 3, NOW);
+    expect(s.header).toMatch(/^2 reachable across 3 channel\(s\) \(1 online · 1 wakeable · 1 offline\)/);
+  });
+
+  test("离线超过一周的行折成一行计数（频道内名单同一口径），一周内的照常逐行印", () => {
+    const rows = [
+      row({ name: "fresh", reach: "offline", last_seen: NOW - 2 * DAY }),
+      row({ name: "old1", reach: "offline", last_seen: NOW - 59 * DAY }),
+      row({ name: "old2", reach: "offline", last_seen: NOW - 60 * DAY }),
+    ];
+    const s = summarizeGlobalWho(rows, 1, NOW);
+    expect(s.shown.map((r) => r.name)).toEqual(["fresh"]);
+    expect(s.folded).toBe(2);
+    expect(s.foldLine).toContain("2 more offline for over a week");
+    expect(s.foldLine).toContain("59d ago – 60d ago");
+    expect(s.foldLine).toContain("party who <channel>");
+  });
+
+  test("没有 last_seen 的离线行不折叠——不知道多久没露面就不能当陈旧", () => {
+    const s = summarizeGlobalWho([row({ name: "x", reach: "offline" })], 1, NOW);
+    expect(s.shown).toHaveLength(1);
+    expect(s.folded).toBe(0);
+    expect(s.foldLine).toBeUndefined();
+  });
+
+  test("图例只列实际用到的记号；一行都没印就没有图例", () => {
+    const s = summarizeGlobalWho(
+      [row({ name: "a", reach: "online", last_seen: NOW }), row({ name: "b", reach: "offline", last_seen: NOW - DAY })],
+      1,
+      NOW,
+    );
+    expect(s.legend).toBe("  ● online  · offline");
+    const none = summarizeGlobalWho([row({ name: "old", reach: "offline", last_seen: NOW - 30 * DAY })], 1, NOW);
+    expect(none.shown).toHaveLength(0);
+    expect(none.legend).toBeUndefined();
   });
 });


### PR DESCRIPTION
这两天代码的审计中在真机上抓到的：`party who --all` 表头恒写「reachable across 1 channel(s)」，底下 7 行**全是 offline**（最老 60 天），全靠一个没有图例的 `·` 区分。`reach` 字段的判定是对的，撒谎的是呈现——而这一行表头此前没有任何测试钉住。

- 表头按档位报数：有人在线/可唤醒才说「N reachable」，否则如实说「no one reachable right now」
- 离线超过一周的行折成一行计数（与频道内名单「历史会话不上榜」#1069 同一口径）；没有 `last_seen` 的不折
- 记号给图例，只列实际用到的

真机改后：`4 reachable across 13 channel(s) (4 online · 66 offline)`。who/send/onboarding 相关 154/0。

https://claude.ai/code/session_01HUmERHTXnbZhCZCwV6fGxD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 优化无频道时的全局 `party who` 输出：按可达状态显示统计信息，并提供相应图例。
  * 将超过一周未出现的离线成员折叠为汇总行，同时保留无最近活动记录的离线成员。
  * 无可达成员时显示明确提示及各状态计数。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->