### PR TITLE
fix(cli): party join 绑定成功后记为该频道的本机默认身份（#1083 尾巴）

### DIFF
--- a/cli/src/commands/join.ts
+++ b/cli/src/commands/join.ts
@@ -78,6 +78,7 @@ import { resolveClaudeDefaultArgs, type ClaudeDefaultArgsResolution } from "../c
 import { claudeLaunchPlan } from "./claude-launch";
 import { STEP_INDENT, runSteps, type Step, type StepResult } from "../onboarding/steps";
 import { processStyle, styleFor, type Style } from "../onboarding/color";
+import { recordChannelDefault } from "../mcp-channel-identity";
 import { verifyWakeRoundTrip, type VerifyWakeDeps } from "../onboarding/verify-wake";
 import { normalizeWakeLang, resolveWakeLang, type WakeLang } from "../wake-note-i18n";
 import { findHarnessAncestor } from "../join-binding";
@@ -926,6 +927,15 @@ function identityStep(harnessKnown: boolean): Step<JoinCtx> {
         };
       }
       ctx.identity = identity;
+      // #1083：把这份身份记为该频道在本机的默认。`party mcp --all-channels` 按频道解析身份时，
+      // 多份身份 + 没登记默认 ⇒ 失败关闭；join 是唯一知道「你刚绑的就是这个」的地方。
+      // 登记失败不阻断接入（只是少一条默认），但要说出来。
+      try {
+        recordChannelDefault(cfg.server, slug, configPath);
+        detail.push(outcomeLine("记为本机默认身份", { level: "ok", msg: `#${slug} 上的 MCP 调用缺省用 ${identity}` }));
+      } catch (e) {
+        detail.push(outcomeLine("记为本机默认身份", { level: "warn", msg: `写登记表失败：${e instanceof Error ? e.message : String(e)}` }));
+      }
       // 注册 MCP（先探后加，#898）。claude/codex 各走各的；other（探不出）两条都试——「不知道就都覆盖」。
       if (harness === "claude" || harness === "other") detail.push(outcomeLine("注册 claude MCP", registerClaudeMcp(deps, mcpName, configPath, slug)));
       if (harness === "codex" || harness === "other") {

--- a/cli/test/join.test.ts
+++ b/cli/test/join.test.ts
@@ -8,6 +8,7 @@
 // 输出形态相应变了（`第 N 步  标题 · 摘要 ✓/✗`、`修法（…）：` + 一行命令、`✅ 接入完成`），
 // 断言按新形态等价改写；判据（哪一步过/不过、修法是哪条、退出码）一条没放宽。
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { readChannelDefaults } from "../src/mcp-channel-identity";
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -698,6 +699,17 @@ describe("party join —— 一条命令跑完整段接入（#944）", () => {
     expect(errs2.join("\n")).toContain("token 被拒：403");
     expect(logs2.join("\n")).not.toContain("token 被拒：403");
     expect(logs2.join("\n")).toContain("走 stdout 的那半");
+  });
+
+  // #1083：`party mcp --all-channels` 按频道解析身份，多份身份 + 没登记默认 ⇒ 失败关闭。
+  // join 是唯一知道「你刚绑的就是这个」的地方，绑定成功必须把它记为该频道的本机默认。
+  test("绑定成功后把这份身份记为该频道的本机默认（供 --all-channels 解析）", async () => {
+    mock = startRestMock();
+    const logs: string[] = [];
+    expect(await runJoin(baseOpts({ harnessFlag: "claude", verbose: true }), deps([], {}, logs))).toBe(0);
+    const defaults = readChannelDefaults(join(tmp, ".agentparty"));
+    expect(defaults[JSON.stringify([mock.url, "dev"])]).toBe(configPath());
+    expect(logs.join("\n")).toContain("记为本机默认身份");
   });
 
   test("重复接入：mcp get 命中已注册 ⇒ 跳过 add，不再叠一个常驻进程（#898）", async () => {


### PR DESCRIPTION
#1084 里写了 `recordChannelDefault`，但 `party join` **从没调用它**——「登记的默认身份」那一档永远填不上，于是 `party mcp --all-channels` 在多份身份的频道上只能永远失败关闭、让用户每次传 identity。这是我自己留的尾巴。

join 是唯一知道「你刚绑的就是这个」的地方：绑定成功（服务端确认身份后）立即记为该频道在本机的默认。登记失败不阻断接入，但作为子项报出来。

测试：join 后读回登记表，键 `[server, channel]` → 该 config 路径。cli 全量 2982/2983，唯一一红是 `party claude launcher` 的 5s 超时（与本改动无关，单独重跑见下）。

https://claude.ai/code/session_01HUmERHTXnbZhCZCwV6fGxD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 成功完成身份确认后，系统会将该身份记录为指定频道的本机默认身份。
  - 默认身份登记失败时仅记录警告，不会阻断后续注册与报到流程。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->