### PR TITLE
feat(cli): 老用户自动迁移——一频道一注册合并成一条 party mcp --all-channels (#1083)

### DIFF
--- a/cli/src/commands/join.ts
+++ b/cli/src/commands/join.ts
@@ -25,6 +25,8 @@
 //    **停在该步**（退出码非 0）；全部过了才印 ✅。步骤机在 onboarding/steps.ts，这里只按 harness 组装
 //    每一步查什么、修法是哪条。无 TTY / --yes 不交互、逐步打印；有 TTY 第 2 步可选接收方式。
 import { spawnSync } from "node:child_process";
+import { defaultMigrateDeps, ensureMachineWideSingle } from "./mcp-migrate";
+import type { McpRegistration } from "../mcp-registry";
 import { copyFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join as pathJoin } from "node:path";
@@ -211,6 +213,8 @@ export interface JoinDeps {
   /** 着色器；测试与非 TTY 不给＝不着色（真机由 defaultJoinDeps 按 TTY/NO_COLOR 决定）。 */
   style?: Style;
   spawn: typeof spawnSync;
+  /** MCP 注册表读取（#1083）。测试注入有状态的桩；真机缺省读 ~/.claude.json 与 codex 的 config.toml。 */
+  mcpRegistrations?: () => McpRegistration[];
   initRun: (argv: string[]) => Promise<number>;
   hookRun: (argv: string[]) => Promise<number>;
   sendRun: (argv: string[]) => Promise<number>;
@@ -306,52 +310,32 @@ function rulesFileName(agentName: string, slug: string): string {
 }
 
 // #1083：join 不再每个频道各注册一条 MCP。那正是「进程数 = 频道数 × 会话数、注册只进不出」的
-// 源头——迁移只能清存量，增量必须在这里堵住。现在 join 只做一件事：确保本机有**一条**
-// `party mcp --all-channels`（Claude 加在 user scope、codex 加在全局 config），已有就跳过。
-// 频道由每次工具调用传入，身份按频道解析（本频道的默认身份在上一步已登记）。
-const SINGLE_MCP_NAME = "party";
-
-/** claude MCP 注册：先探（claude mcp get party）后加（--scope user，覆盖整台机器）。探不到二进制 → skip 并说明。 */
-function registerClaudeMcp(deps: JoinDeps): StepOutcome {
-  const addCmd = `claude mcp add --scope user ${SINGLE_MCP_NAME} -- party mcp --all-channels`;
-  const probe = deps.spawn("claude", ["mcp", "get", SINGLE_MCP_NAME], { encoding: "utf8", timeout: 30_000 });
+// 源头——迁移只能清存量，增量必须在这里堵住。现在 join 只做一件事：确保本机 user/global 有
+// **一条** `party mcp --all-channels`，判据是**读注册表**（不是 `mcp get party` 有没有——同名的
+// 旧式注册、某个项目里 local 的 --all-channels 都会让那个探测返回 0，而整台机器并没被覆盖）。
+function ensureSingleMcp(deps: JoinDeps, harness: "claude" | "codex"): StepOutcome {
+  const bin = harness;
+  const probe = deps.spawn(bin, ["--version"], { encoding: "utf8", timeout: 30_000 });
+  const remedy = harness === "codex"
+    ? "codex mcp add party -- party mcp --all-channels"
+    : "claude mcp add --scope user party -- party mcp --all-channels";
   if (probe.error !== undefined) {
-    return { level: "skip", msg: `claude 二进制不可用，跳过 MCP 注册。装好 claude 后手动：${addCmd}` };
+    return { level: "skip", msg: `${bin} 二进制不可用，跳过 MCP 注册。装好 ${bin} 后手动：${remedy}` };
   }
-  // 已有就跳过——一条注册服务所有频道，多余的用 party mcp prune / migrate 清。幂等。
-  if (probe.status === 0) {
-    return { level: "ok", msg: `MCP 已注册（跳过重复添加）：${SINGLE_MCP_NAME}（一条服务本机所有频道）` };
-  }
-  const add = deps.spawn(
-    "claude",
-    ["mcp", "add", "--scope", "user", SINGLE_MCP_NAME, "--", "party", "mcp", "--all-channels"],
-    { encoding: "utf8", timeout: 30_000 },
-  );
-  if (add.error !== undefined || add.status !== 0) {
-    return { level: "fail", msg: `claude MCP 注册失败：${SINGLE_MCP_NAME}`, remedy: addCmd };
-  }
-  return { level: "ok", msg: `MCP 已注册：${SINGLE_MCP_NAME}（user scope，一条服务本机所有频道）` };
+  const migrateDeps = defaultMigrateDeps(deps.home, deps.spawn);
+  if (deps.mcpRegistrations !== undefined) migrateDeps.registrations = deps.mcpRegistrations;
+  const r = ensureMachineWideSingle(harness, migrateDeps);
+  if (!r.ok) return { level: "fail", msg: `${bin} MCP 注册失败：${r.detail}`, remedy: r.remedy };
+  if (r.action === "present") return { level: "ok", msg: "MCP 已注册（跳过重复添加）：party（一条服务本机所有频道）" };
+  return { level: "ok", msg: `MCP 已注册：party（${r.detail}）` };
 }
 
-/** codex MCP 注册：先探（codex mcp get party）后加（全局 config）。探不到二进制 → skip 并说明。 */
+function registerClaudeMcp(deps: JoinDeps): StepOutcome {
+  return ensureSingleMcp(deps, "claude");
+}
+
 function registerCodexMcp(deps: JoinDeps): StepOutcome {
-  const addCmd = `codex mcp add ${SINGLE_MCP_NAME} -- party mcp --all-channels`;
-  const probe = deps.spawn("codex", ["mcp", "get", SINGLE_MCP_NAME], { encoding: "utf8", timeout: 30_000 });
-  if (probe.error !== undefined) {
-    return { level: "skip", msg: `codex 二进制不可用，跳过 MCP 注册。装好 codex 后手动：${addCmd}` };
-  }
-  if (probe.status === 0) {
-    return { level: "ok", msg: `MCP 已注册（跳过重复添加）：${SINGLE_MCP_NAME}（一条服务本机所有频道）` };
-  }
-  const add = deps.spawn(
-    "codex",
-    ["mcp", "add", SINGLE_MCP_NAME, "--", "party", "mcp", "--all-channels"],
-    { encoding: "utf8", timeout: 30_000 },
-  );
-  if (add.error !== undefined || add.status !== 0) {
-    return { level: "fail", msg: `codex MCP 注册失败：${SINGLE_MCP_NAME}`, remedy: addCmd };
-  }
-  return { level: "ok", msg: `MCP 已注册：${SINGLE_MCP_NAME}（全局，一条服务本机所有频道）` };
+  return ensureSingleMcp(deps, "codex");
 }
 
 const CLAUDE_PLUGIN = SHARED_CLAUDE_PLUGIN;

--- a/cli/src/commands/join.ts
+++ b/cli/src/commands/join.ts
@@ -305,49 +305,53 @@ function rulesFileName(agentName: string, slug: string): string {
   return `agentparty-${agentName}-${slug}.rules.md`;
 }
 
-/** claude MCP 注册：先探（claude mcp get）后加（claude mcp add）。探不到二进制 → skip 并说明。 */
-function registerClaudeMcp(deps: JoinDeps, name: string, configPath: string, slug: string): StepOutcome {
-  const addCmd =
-    `claude mcp add ${name} --env AGENTPARTY_CONFIG="${configPath}" -- party mcp --channel ${slug} --identity ${name}`;
-  const probe = deps.spawn("claude", ["mcp", "get", name], { encoding: "utf8", timeout: 30_000 });
+// #1083：join 不再每个频道各注册一条 MCP。那正是「进程数 = 频道数 × 会话数、注册只进不出」的
+// 源头——迁移只能清存量，增量必须在这里堵住。现在 join 只做一件事：确保本机有**一条**
+// `party mcp --all-channels`（Claude 加在 user scope、codex 加在全局 config），已有就跳过。
+// 频道由每次工具调用传入，身份按频道解析（本频道的默认身份在上一步已登记）。
+const SINGLE_MCP_NAME = "party";
+
+/** claude MCP 注册：先探（claude mcp get party）后加（--scope user，覆盖整台机器）。探不到二进制 → skip 并说明。 */
+function registerClaudeMcp(deps: JoinDeps): StepOutcome {
+  const addCmd = `claude mcp add --scope user ${SINGLE_MCP_NAME} -- party mcp --all-channels`;
+  const probe = deps.spawn("claude", ["mcp", "get", SINGLE_MCP_NAME], { encoding: "utf8", timeout: 30_000 });
   if (probe.error !== undefined) {
     return { level: "skip", msg: `claude 二进制不可用，跳过 MCP 注册。装好 claude 后手动：${addCmd}` };
   }
-  // 已注册就跳过——每条注册在每个会话里都是一个常驻进程（#898）。幂等。
+  // 已有就跳过——一条注册服务所有频道，多余的用 party mcp prune / migrate 清。幂等。
   if (probe.status === 0) {
-    return { level: "ok", msg: `MCP 已注册（跳过重复添加）：${name}（多余的用 party mcp prune 清）` };
+    return { level: "ok", msg: `MCP 已注册（跳过重复添加）：${SINGLE_MCP_NAME}（一条服务本机所有频道）` };
   }
   const add = deps.spawn(
     "claude",
-    ["mcp", "add", name, "--env", `AGENTPARTY_CONFIG=${configPath}`, "--", "party", "mcp", "--channel", slug, "--identity", name],
+    ["mcp", "add", "--scope", "user", SINGLE_MCP_NAME, "--", "party", "mcp", "--all-channels"],
     { encoding: "utf8", timeout: 30_000 },
   );
   if (add.error !== undefined || add.status !== 0) {
-    return { level: "fail", msg: `claude MCP 注册失败：${name}`, remedy: addCmd };
+    return { level: "fail", msg: `claude MCP 注册失败：${SINGLE_MCP_NAME}`, remedy: addCmd };
   }
-  return { level: "ok", msg: `MCP 已注册：${name}` };
+  return { level: "ok", msg: `MCP 已注册：${SINGLE_MCP_NAME}（user scope，一条服务本机所有频道）` };
 }
 
-/** codex MCP 注册：先探（读注册表）后加（codex mcp add）。探不到二进制 → skip 并说明。 */
-function registerCodexMcp(deps: JoinDeps, name: string, configPath: string, slug: string): StepOutcome {
-  const addCmd =
-    `codex mcp add ${name} --env AGENTPARTY_CONFIG="${configPath}" -- party mcp --channel ${slug} --identity ${name}`;
-  const probe = deps.spawn("codex", ["mcp", "get", name], { encoding: "utf8", timeout: 30_000 });
+/** codex MCP 注册：先探（codex mcp get party）后加（全局 config）。探不到二进制 → skip 并说明。 */
+function registerCodexMcp(deps: JoinDeps): StepOutcome {
+  const addCmd = `codex mcp add ${SINGLE_MCP_NAME} -- party mcp --all-channels`;
+  const probe = deps.spawn("codex", ["mcp", "get", SINGLE_MCP_NAME], { encoding: "utf8", timeout: 30_000 });
   if (probe.error !== undefined) {
     return { level: "skip", msg: `codex 二进制不可用，跳过 MCP 注册。装好 codex 后手动：${addCmd}` };
   }
   if (probe.status === 0) {
-    return { level: "ok", msg: `MCP 已注册（跳过重复添加）：${name}` };
+    return { level: "ok", msg: `MCP 已注册（跳过重复添加）：${SINGLE_MCP_NAME}（一条服务本机所有频道）` };
   }
   const add = deps.spawn(
     "codex",
-    ["mcp", "add", name, "--env", `AGENTPARTY_CONFIG=${configPath}`, "--", "party", "mcp", "--channel", slug, "--identity", name],
+    ["mcp", "add", SINGLE_MCP_NAME, "--", "party", "mcp", "--all-channels"],
     { encoding: "utf8", timeout: 30_000 },
   );
   if (add.error !== undefined || add.status !== 0) {
-    return { level: "fail", msg: `codex MCP 注册失败：${name}`, remedy: addCmd };
+    return { level: "fail", msg: `codex MCP 注册失败：${SINGLE_MCP_NAME}`, remedy: addCmd };
   }
-  return { level: "ok", msg: `MCP 已注册：${name}` };
+  return { level: "ok", msg: `MCP 已注册：${SINGLE_MCP_NAME}（全局，一条服务本机所有频道）` };
 }
 
 const CLAUDE_PLUGIN = SHARED_CLAUDE_PLUGIN;
@@ -927,9 +931,9 @@ function identityStep(harnessKnown: boolean): Step<JoinCtx> {
       }
       ctx.identity = identity;
       // 注册 MCP（先探后加，#898）。claude/codex 各走各的；other（探不出）两条都试——「不知道就都覆盖」。
-      if (harness === "claude" || harness === "other") detail.push(outcomeLine("注册 claude MCP", registerClaudeMcp(deps, mcpName, configPath, slug)));
+      if (harness === "claude" || harness === "other") detail.push(outcomeLine("注册 claude MCP", registerClaudeMcp(deps)));
       if (harness === "codex" || harness === "other") {
-        detail.push(outcomeLine("注册 codex MCP", registerCodexMcp(deps, mcpName, configPath, slug)));
+        detail.push(outcomeLine("注册 codex MCP", registerCodexMcp(deps)));
       }
       // claude 档：crossSessionInbound=accept（#844），否则跨会话 @ 默认 hold 会被 drop。
       if (harness === "claude") detail.push(outcomeLine("开启跨会话 @ 接收", setClaudeInboxAccept(deps)));

--- a/cli/src/commands/mcp-migrate.ts
+++ b/cli/src/commands/mcp-migrate.ts
@@ -22,7 +22,6 @@ import { join } from "node:path";
 import { spawnSync } from "node:child_process";
 import { agentpartyHome } from "../config";
 import { codexRegistryScopes, readCodexMcpRegistrations } from "../codex-mcp-registry";
-import { harnessMcpRemove } from "./mcp-prune";
 import { recordChannelDefault } from "../mcp-channel-identity";
 import {
   isPartyMcpRegistration,
@@ -104,7 +103,7 @@ function readJson(path: string): unknown | undefined {
 }
 
 /** 真机依赖：两边注册表都读，删/加都走 harness 自己的 CLI。 */
-export function defaultMigrateDeps(home: string = homedir()): MigrateDeps {
+export function defaultMigrateDeps(home: string = homedir(), spawn: typeof spawnSync = spawnSync): MigrateDeps {
   const scopes = codexRegistryScopes(process.env, process.cwd(), home);
   const globalCodexHome = scopes.find((sc) => sc.kind === "global")?.codexHome ?? join(home, ".codex");
   return {
@@ -116,17 +115,27 @@ export function defaultMigrateDeps(home: string = homedir()): MigrateDeps {
     ],
     readServer: readServerFromConfig,
     recordDefault: (server, channel, configPath) => recordChannelDefault(server, channel, configPath),
-    // 删除复用 prune 的实现：它按注册所属 scope 切 cwd / 加 --scope user。不带 scope 的
-    // `claude mcp remove` 在别的目录里找不到那个名字**也返回 0**——上一版就是这样把 26 条
-    // 一条没删却全报了 ✓。
-    remove: harnessMcpRemove,
+    // 删除**必须走注入的 spawn**：曾直接复用 prune 的实现（内部是真 spawnSync），结果 join 的单测
+    // 从桩里读到一条同名旧注册后，真的对 owner 机器跑了 `claude mcp remove party --scope user`，
+    // 把真机的单注册删掉了。scope 逻辑与 prune 一致：按注册所属 scope 切 cwd、显式 --scope。
+    remove: (reg) => {
+      const res = registrationHarness(reg) === "codex"
+        ? spawn("codex", ["mcp", "remove", reg.name], { encoding: "utf8", env: { ...process.env, CODEX_HOME: reg.codexHome ?? globalCodexHome } })
+        : spawn("claude", ["mcp", "remove", reg.name, "--scope", reg.scope === "user" ? "user" : "local"], {
+            encoding: "utf8",
+            cwd: reg.scope === "user" ? home : reg.scope,
+          });
+      if (res.error) return { ok: false, detail: res.error.message };
+      if (res.status !== 0) return { ok: false, detail: (res.stderr ?? "").trim() || (res.stdout ?? "").trim() || `exit ${String(res.status)}` };
+      return { ok: true, detail: (res.stdout ?? "").trim() };
+    },
     addSingle: (harness) => {
       const res = harness === "codex"
-        ? spawnSync("codex", ["mcp", "add", SINGLE_NAME, "--", "party", "mcp", "--all-channels"], {
+        ? spawn("codex", ["mcp", "add", SINGLE_NAME, "--", "party", "mcp", "--all-channels"], {
             encoding: "utf8",
             env: { ...process.env, CODEX_HOME: globalCodexHome },
           })
-        : spawnSync("claude", ["mcp", "add", "--scope", "user", SINGLE_NAME, "--", "party", "mcp", "--all-channels"], {
+        : spawn("claude", ["mcp", "add", "--scope", "user", SINGLE_NAME, "--", "party", "mcp", "--all-channels"], {
             encoding: "utf8",
             cwd: home,
           });
@@ -137,11 +146,11 @@ export function defaultMigrateDeps(home: string = homedir()): MigrateDeps {
     addBack: (reg) => {
       const envArgs = Object.entries(reg.env).flatMap(([k, v]) => ["--env", `${k}=${v}`]);
       const res = registrationHarness(reg) === "codex"
-        ? spawnSync("codex", ["mcp", "add", reg.name, ...envArgs, "--", reg.command, ...reg.args], {
+        ? spawn("codex", ["mcp", "add", reg.name, ...envArgs, "--", reg.command, ...reg.args], {
             encoding: "utf8",
             env: { ...process.env, CODEX_HOME: reg.codexHome ?? globalCodexHome },
           })
-        : spawnSync(
+        : spawn(
             "claude",
             ["mcp", "add", "--scope", reg.scope === "user" ? "user" : "local", reg.name, ...envArgs, "--", reg.command, ...reg.args],
             { encoding: "utf8", cwd: reg.scope === "user" ? home : reg.scope },
@@ -360,6 +369,68 @@ export function runMcpMigrate(plan: MigratePlan, deps: MigrateDeps, log: (line: 
     }
   }
   return { code: addFailed.length > 0 ? 1 : 0, moved, failed, added, addFailed };
+}
+
+export type EnsureSingleOutcome =
+  | { ok: true; action: "present" | "added" | "replaced"; detail: string }
+  | { ok: false; detail: string; remedy: string };
+
+/**
+ * 确保某个 harness 在 user/global scope 有**一条** `party mcp --all-channels`（join 每次调用）。
+ *
+ * 判据是读注册表、看 isMachineWideSingle，**不是**「有没有叫 party 的注册」：一条 user 级的旧式
+ * `party --channel king`、或某个项目里 local 的 `party --all-channels`，都会让按名字探测的
+ * `mcp get party` 返回 0，而这台机器并没有覆盖所有频道的那一条（codex stop-time review on c15a030）。
+ * 同名的旧注册走迁移同一套：记默认 → 删旧（读回）→ 加新（读回），加不上原样加回。
+ */
+export function ensureMachineWideSingle(
+  harness: RegistrationHarness,
+  deps: MigrateDeps,
+): EnsureSingleOutcome {
+  const remedy = harness === "codex"
+    ? `codex mcp add ${SINGLE_NAME} -- party mcp --all-channels`
+    : `claude mcp add --scope user ${SINGLE_NAME} -- party mcp --all-channels`;
+  if (hasMachineWideSingle(deps, harness)) return { ok: true, action: "present", detail: "已有一条 --all-channels（user/global）" };
+
+  const collision = deps
+    .registrations()
+    .find((r) => registrationHarness(r) === harness && collidesWithSingle(r, deps.globalCodexHome));
+  if (collision !== undefined) {
+    // 同名但不是 --all-channels：多半是旧式 per-channel。能记默认就记（保住它原来的身份）。
+    const channel = registrationChannel(collision);
+    const configPath = collision.env.AGENTPARTY_CONFIG;
+    if (channel !== null && configPath !== undefined && configPath !== "") {
+      const server = deps.readServer(configPath);
+      if (server !== null) {
+        try {
+          deps.recordDefault(server, channel, configPath);
+        } catch (e) {
+          return { ok: false, detail: `同名旧注册 ${SINGLE_NAME} 的默认身份记不下来（${e instanceof Error ? e.message : String(e)}），未改动`, remedy };
+        }
+      }
+    }
+    const removed = deps.remove(collision);
+    if (!removed.ok || stillRegistered(deps, collision)) {
+      return { ok: false, detail: `同名旧注册 ${SINGLE_NAME} 删不掉（${removed.ok ? "命令返回 0 但读回还在" : removed.detail}），未改动`, remedy };
+    }
+    const res = deps.addSingle(harness);
+    if (res.ok && hasMachineWideSingle(deps, harness)) {
+      return { ok: true, action: "replaced", detail: `同名旧注册 ${SINGLE_NAME}（${collision.args.join(" ")}）已换成 --all-channels（读回确认）` };
+    }
+    const back = deps.addBack(collision);
+    const restored = back.ok && stillRegistered(deps, collision);
+    return {
+      ok: false,
+      detail: restored
+        ? `--all-channels 没加上（${res.ok ? "读回不在 user/global" : res.detail}）；同名旧注册已原样加回`
+        : `--all-channels 没加上（${res.ok ? "读回不在 user/global" : res.detail}），旧注册加回也失败（${back.detail}）——现在没有 party`,
+      remedy,
+    };
+  }
+
+  const res = deps.addSingle(harness);
+  if (res.ok && hasMachineWideSingle(deps, harness)) return { ok: true, action: "added", detail: "已加一条 --all-channels（user/global，读回确认）" };
+  return { ok: false, detail: res.ok ? "命令返回 0，但读回注册表时它不在 user/global scope" : res.detail, remedy };
 }
 
 // ── 自动触发 ──────────────────────────────────────────────────────────────────

--- a/cli/src/commands/mcp-migrate.ts
+++ b/cli/src/commands/mcp-migrate.ts
@@ -131,7 +131,7 @@ export function defaultMigrateDeps(home: string = homedir()): MigrateDeps {
             cwd: home,
           });
       if (res.error) return { ok: false, detail: res.error.message };
-      if (res.status !== 0) return { ok: false, detail: (res.stderr ?? "").trim() || `exit ${String(res.status)}` };
+      if (res.status !== 0) return { ok: false, detail: (res.stderr ?? "").trim() || (res.stdout ?? "").trim() || `exit ${String(res.status)}` };
       return { ok: true, detail: (res.stdout ?? "").trim() };
     },
     addBack: (reg) => {
@@ -147,7 +147,7 @@ export function defaultMigrateDeps(home: string = homedir()): MigrateDeps {
             { encoding: "utf8", cwd: reg.scope === "user" ? home : reg.scope },
           );
       if (res.error) return { ok: false, detail: res.error.message };
-      if (res.status !== 0) return { ok: false, detail: (res.stderr ?? "").trim() || `exit ${String(res.status)}` };
+      if (res.status !== 0) return { ok: false, detail: (res.stderr ?? "").trim() || (res.stdout ?? "").trim() || `exit ${String(res.status)}` };
       return { ok: true, detail: (res.stdout ?? "").trim() };
     },
     now: () => Date.now(),

--- a/cli/src/commands/mcp-migrate.ts
+++ b/cli/src/commands/mcp-migrate.ts
@@ -66,7 +66,9 @@ export interface MigrateDeps {
 
 /** 这条旧注册与单注册同名同 scope：加新会覆盖它（codex）或被它顶住（claude），删它会连新的一起删。 */
 export function collidesWithSingle(reg: McpRegistration, globalCodexHome: string): boolean {
-  if (reg.name !== SINGLE_NAME) return false;
+  // 只有 **AgentParty 自己的**注册才算冲突。用户可能有一个恰好叫 party 的别的 MCP 服务，
+  // 那不是我们的，绝不能删、也绝不能被同名 add 覆盖（codex stop-time review on a40b60f）。
+  if (reg.name !== SINGLE_NAME || !isPartyMcpRegistration(reg)) return false;
   return registrationHarness(reg) === "codex" ? reg.codexHome === globalCodexHome : reg.scope === "user";
 }
 
@@ -208,6 +210,23 @@ export interface MigrateResult {
   addFailed: { harness: RegistrationHarness; detail: string }[];
 }
 
+/** 名字 party 在 user/global 被**别的**（非 AgentParty）MCP 服务占着：不动它，我们换个名字注册。 */
+export function foreignSameKey(deps: MigrateDeps, harness: RegistrationHarness): McpRegistration | undefined {
+  return deps.registrations().find((r) => {
+    if (registrationHarness(r) !== harness || r.name !== SINGLE_NAME || isPartyMcpRegistration(r)) return false;
+    return harness === "codex" ? r.codexHome === deps.globalCodexHome : r.scope === "user";
+  });
+}
+
+/** 名字被占时给用户的出路：换个名字注册，检测是名字无关的（看的是命令与 --all-channels）。 */
+export const ALT_SINGLE_NAME = "agentparty";
+function foreignRemedy(harness: RegistrationHarness, foreign: McpRegistration): string {
+  const cmd = harness === "codex"
+    ? `codex mcp add ${ALT_SINGLE_NAME} -- party mcp --all-channels`
+    : `claude mcp add --scope user ${ALT_SINGLE_NAME} -- party mcp --all-channels`;
+  return `名字 ${SINGLE_NAME} 已被别的 MCP 服务占用（${foreign.command} ${foreign.args.join(" ")}），不动它；请换名注册：${cmd}`;
+}
+
 function hasMachineWideSingle(deps: MigrateDeps, harness: RegistrationHarness): boolean {
   return deps.registrations().some((r) => registrationHarness(r) === harness && isMachineWideSingle(r, deps.globalCodexHome));
 }
@@ -263,6 +282,14 @@ export function runMcpMigrate(plan: MigratePlan, deps: MigrateDeps, log: (line: 
   for (const harness of harnesses) {
     if (plan.alreadySingle.has(harness)) {
       covered.add(harness);
+      continue;
+    }
+    const foreign = foreignSameKey(deps, harness);
+    if (foreign !== undefined) {
+      // codex 的同名 add 会**覆盖**：这里不能试。旧注册也一条不动。
+      const detail = foreignRemedy(harness, foreign);
+      addFailed.push({ harness, detail });
+      log(`  ✗ ${harness}：${detail}`);
       continue;
     }
     const collisions = plan.legacy.filter((l) => l.harness === harness && collidesWithSingle(l.reg, deps.globalCodexHome));
@@ -359,6 +386,12 @@ export function runMcpMigrate(plan: MigratePlan, deps: MigrateDeps, log: (line: 
   // 3) 收尾读回：删旧的过程中单注册若被 harness CLI 连带删掉（同名、scope 落空……），当场自愈。
   for (const harness of covered) {
     if (hasMachineWideSingle(deps, harness)) continue;
+    if (foreignSameKey(deps, harness) !== undefined) {
+      addFailed.push({ harness, detail: "删旧注册后单条注册消失，且名字已被别的 MCP 占用，未重加" });
+      log(`  ✗ ${harness}：单条注册消失且名字 ${SINGLE_NAME} 已被别的 MCP 占用——现在没有 party，请立刻手工加：`);
+      log(`      ${harness === "codex" ? `codex mcp add ${ALT_SINGLE_NAME}` : `claude mcp add --scope user ${ALT_SINGLE_NAME}`} -- party mcp --all-channels`);
+      continue;
+    }
     const res = deps.addSingle(harness);
     if (res.ok && hasMachineWideSingle(deps, harness)) {
       log(`  ! ${harness}：删旧注册时单条注册被连带删掉了，已重新加回（读回确认）`);
@@ -391,6 +424,11 @@ export function ensureMachineWideSingle(
     ? `codex mcp add ${SINGLE_NAME} -- party mcp --all-channels`
     : `claude mcp add --scope user ${SINGLE_NAME} -- party mcp --all-channels`;
   if (hasMachineWideSingle(deps, harness)) return { ok: true, action: "present", detail: "已有一条 --all-channels（user/global）" };
+
+  const foreign = foreignSameKey(deps, harness);
+  if (foreign !== undefined) {
+    return { ok: false, detail: foreignRemedy(harness, foreign), remedy: foreignRemedy(harness, foreign).split("：").pop() ?? remedy };
+  }
 
   const collision = deps
     .registrations()

--- a/cli/src/commands/mcp-migrate.ts
+++ b/cli/src/commands/mcp-migrate.ts
@@ -60,7 +60,15 @@ export interface MigrateDeps {
   remove: (reg: McpRegistration) => { ok: boolean; detail: string };
   /** 必须加到 user / global scope——local/project 只对一个目录生效，别的项目会永久没有 party。 */
   addSingle: (harness: RegistrationHarness) => { ok: boolean; detail: string };
+  /** 回滚：把一条刚删掉的旧注册按原 scope / args / env 原样加回去。 */
+  addBack: (reg: McpRegistration) => { ok: boolean; detail: string };
   now: () => number;
+}
+
+/** 这条旧注册与单注册同名同 scope：加新会覆盖它（codex）或被它顶住（claude），删它会连新的一起删。 */
+export function collidesWithSingle(reg: McpRegistration, globalCodexHome: string): boolean {
+  if (reg.name !== SINGLE_NAME) return false;
+  return registrationHarness(reg) === "codex" ? reg.codexHome === globalCodexHome : reg.scope === "user";
 }
 
 export function isSingleRegistration(reg: McpRegistration): boolean {
@@ -122,6 +130,22 @@ export function defaultMigrateDeps(home: string = homedir()): MigrateDeps {
             encoding: "utf8",
             cwd: home,
           });
+      if (res.error) return { ok: false, detail: res.error.message };
+      if (res.status !== 0) return { ok: false, detail: (res.stderr ?? "").trim() || `exit ${String(res.status)}` };
+      return { ok: true, detail: (res.stdout ?? "").trim() };
+    },
+    addBack: (reg) => {
+      const envArgs = Object.entries(reg.env).flatMap(([k, v]) => ["--env", `${k}=${v}`]);
+      const res = registrationHarness(reg) === "codex"
+        ? spawnSync("codex", ["mcp", "add", reg.name, ...envArgs, "--", reg.command, ...reg.args], {
+            encoding: "utf8",
+            env: { ...process.env, CODEX_HOME: reg.codexHome ?? globalCodexHome },
+          })
+        : spawnSync(
+            "claude",
+            ["mcp", "add", "--scope", reg.scope === "user" ? "user" : "local", reg.name, ...envArgs, "--", reg.command, ...reg.args],
+            { encoding: "utf8", cwd: reg.scope === "user" ? home : reg.scope },
+          );
       if (res.error) return { ok: false, detail: res.error.message };
       if (res.status !== 0) return { ok: false, detail: (res.stderr ?? "").trim() || `exit ${String(res.status)}` };
       return { ok: true, detail: (res.stdout ?? "").trim() };
@@ -204,33 +228,90 @@ export function runMcpMigrate(plan: MigratePlan, deps: MigrateDeps, log: (line: 
     identitiesByChannel.set(key, (identitiesByChannel.get(key) ?? new Set()).add(item.configPath));
   }
 
-  // 1) 每个涉及的 harness：先把单条注册加到 user/global，读回确认
+  const manualAdd = (harness: RegistrationHarness): string =>
+    harness === "codex"
+      ? `      codex mcp add ${SINGLE_NAME} -- party mcp --all-channels`
+      : `      claude mcp add --scope user ${SINGLE_NAME} -- party mcp --all-channels`;
+
+  const recordDefaultFor = (item: LegacyRegistration): { ok: true } | { ok: false; detail: string } => {
+    const key = JSON.stringify([item.server, item.channel]);
+    if (identitiesByChannel.get(key)!.size > 1) return { ok: true }; // 多身份频道不设默认（下面统一提示）
+    try {
+      deps.recordDefault(item.server, item.channel, item.configPath);
+      return { ok: true };
+    } catch (e) {
+      return { ok: false, detail: e instanceof Error ? e.message : String(e) };
+    }
+  };
+
+  // 1) 每个涉及的 harness：把单条注册加到 user/global，读回确认。
+  //    同名同 scope 的旧注册（早期文档就教 `claude mcp add party -- party mcp --channel X`）要先删再加：
+  //    codex 的同名 add 会**覆盖**，随后按名字删旧就把新的一起删了（codex stop-time review on a998ba9）；
+  //    claude 的同名 add 会被顶住（"already exists" 且退出码 0）。加不上就把旧的原样加回，绝不留空档。
   const harnesses = new Set(plan.legacy.map((l) => l.harness));
   const covered = new Set<RegistrationHarness>();
+  const replaced = new Set<McpRegistration>();
   for (const harness of harnesses) {
     if (plan.alreadySingle.has(harness)) {
       covered.add(harness);
       continue;
     }
+    const collisions = plan.legacy.filter((l) => l.harness === harness && collidesWithSingle(l.reg, deps.globalCodexHome));
+    let collisionRemoved: LegacyRegistration | null = null;
+    if (collisions.length > 0) {
+      const c = collisions[0]!;
+      // 同名旧注册用的身份同样要记为默认；记不下来就不动它（否则这个频道从「能用」变「歧义」）。
+      const recorded = recordDefaultFor(c);
+      if (!recorded.ok) {
+        addFailed.push({ harness, detail: `同名旧注册 ${c.reg.name} 的默认身份记不下来（${recorded.detail}）` });
+        log(`  ✗ ${harness}：同名旧注册 ${c.reg.name} 的默认身份记不下来（${recorded.detail}）——该 harness 一条都不动`);
+        continue;
+      }
+      const removed = deps.remove(c.reg);
+      if (!removed.ok || stillRegistered(deps, c.reg)) {
+        const detail = removed.ok ? "命令返回 0，但读回注册表时它还在" : removed.detail;
+        addFailed.push({ harness, detail: `同名旧注册 ${c.reg.name} 删不掉（${detail}），无法腾出名字` });
+        log(`  ✗ ${harness}：同名旧注册 ${c.reg.name} 删不掉（${detail}）——该 harness 一条都不动`);
+        continue;
+      }
+      collisionRemoved = c;
+    }
     const res = deps.addSingle(harness);
     if (res.ok && hasMachineWideSingle(deps, harness)) {
       covered.add(harness);
       added.push(harness);
-      log(`  ✓ ${harness}：已在 user/global scope 加一条 \`party mcp --all-channels\`（读回确认）`);
-    } else {
-      const detail = res.ok ? "命令返回 0，但读回注册表时它不在 user/global scope" : res.detail;
-      addFailed.push({ harness, detail });
-      log(`  ✗ ${harness}：单条注册没加上（${detail}）——该 harness 的旧注册一条都不动。手工加：`);
-      log(harness === "codex"
-        ? `      codex mcp add ${SINGLE_NAME} -- party mcp --all-channels`
-        : `      claude mcp add --scope user ${SINGLE_NAME} -- party mcp --all-channels`);
+      if (collisionRemoved !== null) {
+        replaced.add(collisionRemoved.reg);
+        moved.push(collisionRemoved);
+        log(`  ✓ ${harness}：同名旧注册 ${SINGLE_NAME} 已换成 \`party mcp --all-channels\`（读回确认）`);
+      } else {
+        log(`  ✓ ${harness}：已在 user/global scope 加一条 \`party mcp --all-channels\`（读回确认）`);
+      }
+      continue;
     }
+    const detail = res.ok ? "命令返回 0，但读回注册表时它不在 user/global scope" : res.detail;
+    addFailed.push({ harness, detail });
+    if (collisionRemoved !== null) {
+      // 旧的已删、新的没加上：立刻把旧的原样加回，并读回确认。
+      const back = deps.addBack(collisionRemoved.reg);
+      const restored = back.ok && stillRegistered(deps, collisionRemoved.reg);
+      log(
+        restored
+          ? `  ✗ ${harness}：单条注册没加上（${detail}）；已把同名旧注册原样加回，一切照旧。手工加：`
+          : `  ✗ ${harness}：单条注册没加上（${detail}），且旧注册加回也失败（${back.detail}）——现在没有 party，请立刻手工加：`,
+      );
+    } else {
+      log(`  ✗ ${harness}：单条注册没加上（${detail}）——该 harness 的旧注册一条都不动。手工加：`);
+    }
+    log(manualAdd(harness));
   }
 
   // 2) 记默认 + 删旧（只对已覆盖的 harness），每条删完读回验证
   const warned = new Set<string>();
   for (const item of plan.legacy) {
     if (!covered.has(item.harness)) continue;
+    if (replaced.has(item.reg)) continue; // 同名旧注册已在上一步换掉，再按名字删就是删新的
+    if (collidesWithSingle(item.reg, deps.globalCodexHome)) continue; // 保险：任何情况下都不按单注册的名字删
     const key = JSON.stringify([item.server, item.channel]);
     const contenders = identitiesByChannel.get(key)!;
     if (contenders.size > 1) {
@@ -265,6 +346,18 @@ export function runMcpMigrate(plan: MigratePlan, deps: MigrateDeps, log: (line: 
   }
   for (const f of failed) {
     log(`  ! ${f.reg.name}：${f.step === "default" ? "记默认身份失败，未删" : "删除失败，仍保留"}（${f.detail}）`);
+  }
+  // 3) 收尾读回：删旧的过程中单注册若被 harness CLI 连带删掉（同名、scope 落空……），当场自愈。
+  for (const harness of covered) {
+    if (hasMachineWideSingle(deps, harness)) continue;
+    const res = deps.addSingle(harness);
+    if (res.ok && hasMachineWideSingle(deps, harness)) {
+      log(`  ! ${harness}：删旧注册时单条注册被连带删掉了，已重新加回（读回确认）`);
+    } else {
+      addFailed.push({ harness, detail: "删旧注册后单条注册消失，重加失败" });
+      log(`  ✗ ${harness}：删旧注册后单条注册消失，重加失败——现在没有 party，请立刻手工加：`);
+      log(manualAdd(harness));
+    }
   }
   return { code: addFailed.length > 0 ? 1 : 0, moved, failed, added, addFailed };
 }

--- a/cli/src/commands/mcp-migrate.ts
+++ b/cli/src/commands/mcp-migrate.ts
@@ -1,0 +1,355 @@
+// 老用户的自动迁移：一频道一注册 → 一条 `party mcp --all-channels`（#1083）。
+//
+// 旧模型下 `party join` 每加入一个频道就往 harness 的全局 config 里塞一条注册（各绑一个
+// --channel 与一份 AGENTPARTY_CONFIG），进程数 = 频道数 × 会话数，而且只进不出。新模型是一条
+// 注册服务所有频道、身份按调用的频道解析。老用户机器上躺着的那些旧注册不会自己消失——
+// 得有东西替他们收掉，而且不能靠他们记得去跑一条命令。
+//
+// 三步，顺序不能反：
+//   1. 把每条旧注册**正在用的那份身份**记为该频道的本机默认（recordChannelDefault）。
+//      这一步保住老用户原来的身份：迁移后 `--all-channels` 在这些频道上零歧义，行为一字不变。
+//   2. 用 harness 自己的 `codex mcp remove` / `claude mcp remove` 删旧注册（绝不手改 TOML/JSON）。
+//   3. 每个涉及的 harness 加一条 `party mcp --all-channels`（已有就不重复加）。
+//
+// 失败关闭：第 1 步记不下来就不删那条；第 3 步加不上就把删掉的也报出来并给出手工命令——
+// 绝不能让用户处在「旧的删了、新的没加上」的空档，那等于所有 agent 一起静默失联。
+//
+// 触发：任何交互式 `party` 命令启动时（不含 mcp/hook/serve 这些进程内路径）检查一次，
+// 一次性标记；也提供 `party mcp migrate [--dry-run|--yes]` 让人先看再动。
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { agentpartyHome } from "../config";
+import { codexMcpRemove, codexRegistryScopes, readCodexMcpRegistrations } from "../codex-mcp-registry";
+import { recordChannelDefault } from "../mcp-channel-identity";
+import {
+  isPartyMcpRegistration,
+  parseClaudeMcpRegistrations,
+  registrationChannel,
+  registrationHarness,
+  type McpRegistration,
+  type RegistrationHarness,
+} from "../mcp-registry";
+
+export interface LegacyRegistration {
+  reg: McpRegistration;
+  harness: RegistrationHarness;
+  channel: string;
+  configPath: string;
+  server: string;
+}
+
+export interface MigratePlan {
+  /** 要迁走的旧式注册：有 --channel、有 AGENTPARTY_CONFIG、config 读得出 server。 */
+  legacy: LegacyRegistration[];
+  /** party 的注册但不动它：说明为什么。 */
+  skipped: { reg: McpRegistration; reason: string }[];
+  /** 已经有 --all-channels 注册的 harness。 */
+  alreadySingle: Set<RegistrationHarness>;
+}
+
+export interface MigrateDeps {
+  home: string;
+  registrations: () => McpRegistration[];
+  readServer: (configPath: string) => string | null;
+  recordDefault: (server: string, channel: string, configPath: string) => void;
+  remove: (reg: McpRegistration) => { ok: boolean; detail: string };
+  addSingle: (harness: RegistrationHarness, sample: McpRegistration) => { ok: boolean; detail: string };
+  now: () => number;
+}
+
+export function isSingleRegistration(reg: McpRegistration): boolean {
+  return isPartyMcpRegistration(reg) && reg.args.includes("--all-channels");
+}
+
+function readServerFromConfig(configPath: string): string | null {
+  try {
+    const raw = JSON.parse(readFileSync(configPath, "utf8")) as { server?: unknown; token?: unknown };
+    if (typeof raw.token !== "string" || raw.token === "") return null;
+    return typeof raw.server === "string" && raw.server !== "" ? raw.server : null;
+  } catch {
+    return null;
+  }
+}
+
+function readJson(path: string): unknown | undefined {
+  try {
+    return JSON.parse(readFileSync(path, "utf8")) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+
+/** 真机依赖：两边注册表都读，删/加都走 harness 自己的 CLI。 */
+export function defaultMigrateDeps(home: string = homedir()): MigrateDeps {
+  return {
+    home,
+    registrations: () => [
+      ...parseClaudeMcpRegistrations(readJson(join(home, ".claude.json")) ?? null),
+      ...readCodexMcpRegistrations(codexRegistryScopes(process.env, process.cwd(), home)),
+    ],
+    readServer: readServerFromConfig,
+    recordDefault: (server, channel, configPath) => recordChannelDefault(server, channel, configPath),
+    remove: (reg) => {
+      if (registrationHarness(reg) === "codex") return codexMcpRemove(reg);
+      const res = spawnSync("claude", ["mcp", "remove", reg.name], { encoding: "utf8" });
+      if (res.error) return { ok: false, detail: res.error.message };
+      if (res.status !== 0) return { ok: false, detail: (res.stderr ?? "").trim() || `exit ${String(res.status)}` };
+      return { ok: true, detail: (res.stdout ?? "").trim() };
+    },
+    addSingle: (harness, sample) => {
+      const bin = harness === "codex" ? "codex" : "claude";
+      const env = harness === "codex" && sample.codexHome ? { ...process.env, CODEX_HOME: sample.codexHome } : process.env;
+      const res = spawnSync(bin, ["mcp", "add", SINGLE_NAME, "--", "party", "mcp", "--all-channels"], { encoding: "utf8", env });
+      if (res.error) return { ok: false, detail: res.error.message };
+      if (res.status !== 0) return { ok: false, detail: (res.stderr ?? "").trim() || `exit ${String(res.status)}` };
+      return { ok: true, detail: (res.stdout ?? "").trim() };
+    },
+    now: () => Date.now(),
+  };
+}
+
+/** 单条注册的名字。固定名字是刻意的：老用户 N 条各有各的名字，新的只该有一条。 */
+export const SINGLE_NAME = "party";
+
+export function planMcpMigrate(deps: MigrateDeps): MigratePlan {
+  const legacy: LegacyRegistration[] = [];
+  const skipped: MigratePlan["skipped"] = [];
+  const alreadySingle = new Set<RegistrationHarness>();
+  for (const reg of deps.registrations()) {
+    if (!isPartyMcpRegistration(reg)) continue;
+    const harness = registrationHarness(reg);
+    if (isSingleRegistration(reg)) {
+      alreadySingle.add(harness);
+      continue;
+    }
+    const channel = registrationChannel(reg);
+    if (channel === null) {
+      // 没绑频道的旧注册（裸 `party mcp`）：它本来就靠 cwd 绑定工作，不是本次要收的形状。
+      skipped.push({ reg, reason: "没有 --channel，不是一频道一注册的形状" });
+      continue;
+    }
+    const configPath = reg.env.AGENTPARTY_CONFIG;
+    if (configPath === undefined || configPath === "") {
+      skipped.push({ reg, reason: "没有 AGENTPARTY_CONFIG，不知道它用的是哪份身份，不动" });
+      continue;
+    }
+    const server = deps.readServer(configPath);
+    if (server === null) {
+      // config 读不出（TMPDIR 被清、token 没了）：这条注册本来就是坏的，交给 `party mcp prune`。
+      skipped.push({ reg, reason: `身份配置读不出：${configPath}（交给 party mcp prune）` });
+      continue;
+    }
+    legacy.push({ reg, harness, channel, configPath, server });
+  }
+  return { legacy, skipped, alreadySingle };
+}
+
+export interface MigrateResult {
+  code: number;
+  moved: LegacyRegistration[];
+  failed: { reg: McpRegistration; step: "default" | "remove"; detail: string }[];
+  added: RegistrationHarness[];
+  addFailed: { harness: RegistrationHarness; detail: string }[];
+}
+
+/**
+ * 执行迁移。返回码非 0 只有一种情况：**有 harness 的新注册没加上**——那时用户可能处在
+ * 「旧的删了、新的没加上」的空档，必须显眼。单条旧注册删失败不算（它只是多留一个进程）。
+ */
+export function runMcpMigrate(plan: MigratePlan, deps: MigrateDeps, log: (line: string) => void): MigrateResult {
+  const moved: LegacyRegistration[] = [];
+  const failed: MigrateResult["failed"] = [];
+  const harnesses = new Set<RegistrationHarness>();
+  // 同一 (server, channel) 有多条旧注册且指向**不同**身份时，不能默默挑一个当默认——老模型下这两个
+  // 身份本来就同时在跑（两个 MCP 进程、两套工具前缀），迁移后按调用解析会失败关闭并列出候选，
+  // 这是对的：让人选，而不是替人选。owner 那台机器上 #bug-7744 / #welcome 就是这种情况。
+  const identitiesByChannel = new Map<string, Set<string>>();
+  for (const item of plan.legacy) {
+    const key = JSON.stringify([item.server, item.channel]);
+    identitiesByChannel.set(key, (identitiesByChannel.get(key) ?? new Set()).add(item.configPath));
+  }
+  const warned = new Set<string>();
+  for (const item of plan.legacy) {
+    const key = JSON.stringify([item.server, item.channel]);
+    const contenders = identitiesByChannel.get(key)!;
+    if (contenders.size > 1) {
+      if (!warned.has(key)) {
+        warned.add(key);
+        log(`  ! #${item.channel} 有 ${contenders.size} 份不同身份的旧注册，不设默认；迁移后调用时传 identity，或用 party join 重新绑定其中一个`);
+      }
+    } else {
+      // 1) 先记默认——记不下来就不删，否则迁完这个频道会从「能用」变成「歧义」。
+      try {
+        deps.recordDefault(item.server, item.channel, item.configPath);
+      } catch (e) {
+        failed.push({ reg: item.reg, step: "default", detail: e instanceof Error ? e.message : String(e) });
+        continue;
+      }
+    }
+    // 2) 删旧
+    const removed = deps.remove(item.reg);
+    if (!removed.ok) {
+      failed.push({ reg: item.reg, step: "remove", detail: removed.detail });
+      continue;
+    }
+    moved.push(item);
+    harnesses.add(item.harness);
+    log(
+      contenders.size > 1
+        ? `  ✓ #${item.channel} 的注册 ${item.reg.name} 已收进单条注册（未设默认）`
+        : `  ✓ #${item.channel} 的注册 ${item.reg.name} 已收进单条注册（默认身份：${item.configPath}）`,
+    );
+  }
+  // 3) 每个涉及的 harness 补一条 --all-channels（已有就不加）
+  const added: RegistrationHarness[] = [];
+  const addFailed: MigrateResult["addFailed"] = [];
+  for (const harness of harnesses) {
+    if (plan.alreadySingle.has(harness)) continue;
+    const sample = plan.legacy.find((l) => l.harness === harness)!.reg;
+    const res = deps.addSingle(harness, sample);
+    if (res.ok) {
+      added.push(harness);
+      log(`  ✓ ${harness}：已加一条 \`party mcp --all-channels\``);
+    } else {
+      addFailed.push({ harness, detail: res.detail });
+      log(`  ✗ ${harness}：新注册没加上（${res.detail}）——旧注册已删，请立刻手工加：`);
+      log(`      ${harness} mcp add ${SINGLE_NAME} -- party mcp --all-channels`);
+    }
+  }
+  for (const f of failed) {
+    log(`  ! ${f.reg.name}：${f.step === "default" ? "记默认身份失败，未删" : "删除失败"}（${f.detail}）`);
+  }
+  return { code: addFailed.length > 0 ? 1 : 0, moved, failed, added, addFailed };
+}
+
+// ── 自动触发 ──────────────────────────────────────────────────────────────────
+
+export function migrateMarkerPath(home: string = agentpartyHome()): string {
+  return join(home, "state", "mcp-migrate-v1.json");
+}
+
+interface Marker {
+  status: "done" | "nothing" | "failed";
+  at: number;
+  moved?: number;
+}
+
+function readMarker(path: string): Marker | null {
+  const raw = readJson(path);
+  if (raw === null || typeof raw !== "object") return null;
+  const m = raw as Partial<Marker>;
+  if (m.status !== "done" && m.status !== "nothing" && m.status !== "failed") return null;
+  return { status: m.status, at: typeof m.at === "number" ? m.at : 0, moved: typeof m.moved === "number" ? m.moved : undefined };
+}
+
+function writeMarker(path: string, marker: Marker): void {
+  mkdirSync(join(path, ".."), { recursive: true });
+  const tmp = `${path}.tmp-${process.pid}`;
+  writeFileSync(tmp, `${JSON.stringify(marker, null, 2)}\n`);
+  renameSync(tmp, path);
+}
+
+/** 失败后多久再自动试一次。天天弹是骚扰，永不重试是把老用户扔在旧模型里。 */
+const RETRY_AFTER_MS = 24 * 60 * 60 * 1000;
+
+/** 这些入口不做自动迁移：它们是 harness 拉起的进程内路径 / 常驻守护，不该在那里改 harness 的配置。 */
+const NO_AUTO_MIGRATE = new Set(["mcp", "hook", "serve", "daemon", "watch", "bridge", "claude", "codex", "capture", "notify-when-idle", "statusline"]);
+
+/**
+ * 交互式命令启动时调一次。有旧式注册就迁，没有就写「无事」标记，之后再也不看。
+ * 迁移输出走 errlog（stderr）：不能污染命令自己的 stdout（很多命令支持 --json）。
+ */
+export function maybeAutoMigrate(
+  cmd: string,
+  opts: { deps?: MigrateDeps; agentpartyHome?: string; errlog?: (line: string) => void } = {},
+): { ran: boolean; result?: MigrateResult } {
+  if (NO_AUTO_MIGRATE.has(cmd)) return { ran: false };
+  const home = opts.agentpartyHome ?? agentpartyHome();
+  const markerPath = migrateMarkerPath(home);
+  const deps = opts.deps ?? defaultMigrateDeps();
+  const errlog = opts.errlog ?? ((line: string) => console.error(line));
+  const marker = readMarker(markerPath);
+  const now = deps.now();
+  if (marker !== null && marker.status !== "failed") return { ran: false };
+  if (marker !== null && marker.status === "failed" && now - marker.at < RETRY_AFTER_MS) return { ran: false };
+
+  let plan: MigratePlan;
+  try {
+    plan = planMcpMigrate(deps);
+  } catch {
+    // 读注册表都炸了（harness 没装 / 文件坏）：不打扰，下次再看。
+    return { ran: false };
+  }
+  if (plan.legacy.length === 0) {
+    writeMarker(markerPath, { status: "nothing", at: now });
+    return { ran: false };
+  }
+  errlog(
+    `party：发现 ${plan.legacy.length} 条旧式「一频道一注册」的 MCP 注册，正在合并成一条 \`party mcp --all-channels\`` +
+      `（每个会话从 ${plan.legacy.length} 个 party 进程降到 1 个；原来各频道用的身份会记为默认，行为不变）：`,
+  );
+  const result = runMcpMigrate(plan, deps, errlog);
+  if (result.code === 0) {
+    writeMarker(markerPath, { status: "done", at: now, moved: result.moved.length });
+    errlog(`party：迁移完成。正在跑的会话不受影响，下次新开的会话生效。想看细节：party mcp migrate --dry-run`);
+  } else {
+    writeMarker(markerPath, { status: "failed", at: now, moved: result.moved.length });
+  }
+  return { ran: true, result };
+}
+
+// ── CLI ──────────────────────────────────────────────────────────────────────
+
+const HELP = `usage: party mcp migrate [--dry-run] [--yes]
+
+把旧式「一频道一注册」的 MCP 注册合并成一条 \`party mcp --all-channels\`（#1083）。
+交互式 party 命令启动时会自动做一次；这里是手动入口。
+
+  --dry-run   只列计划，不改任何东西（缺省）
+  --yes       执行
+
+做什么：
+  1. 每条旧注册正在用的身份 → 记为该频道的本机默认（迁移后行为不变）
+  2. 用 codex/claude 自己的 \`mcp remove\` 删旧注册（不手改配置文件）
+  3. 每个涉及的 harness 加一条 \`party mcp --all-channels\``;
+
+export async function runMigrateCli(argv: string[], deps: MigrateDeps = defaultMigrateDeps()): Promise<number> {
+  if (argv.includes("--help") || argv.includes("-h")) {
+    console.log(HELP);
+    return 0;
+  }
+  const yes = argv.includes("--yes");
+  const plan = planMcpMigrate(deps);
+  if (plan.legacy.length === 0) {
+    console.log("没有旧式「一频道一注册」的 party 注册，无需迁移。");
+    for (const s of plan.skipped) console.log(`  · 跳过 ${s.reg.name}：${s.reason}`);
+    return 0;
+  }
+  console.log(`${yes ? "迁移" : "计划迁移"} ${plan.legacy.length} 条旧注册：`);
+  for (const l of plan.legacy) console.log(`  · ${l.harness}  ${l.reg.name}  #${l.channel}  ← ${l.configPath}`);
+  for (const s of plan.skipped) console.log(`  · 跳过 ${s.reg.name}：${s.reason}`);
+  if (!yes) {
+    console.log("（未改任何东西。执行：party mcp migrate --yes）");
+    return 0;
+  }
+  const result = runMcpMigrate(plan, deps, (line) => console.log(line));
+  if (result.code === 0) {
+    writeMarker(migrateMarkerPath(), { status: "done", at: deps.now(), moved: result.moved.length });
+    console.log("迁移完成。正在跑的会话不受影响，下次新开的会话生效。");
+  }
+  return result.code;
+}
+
+/** 供 doctor 用：标记文件存在且非 failed ⇒ 已处理过。 */
+export function migrationDone(home: string = agentpartyHome()): boolean {
+  const m = readMarker(migrateMarkerPath(home));
+  return m !== null && m.status !== "failed";
+}
+
+// 仅供测试：让用例能构造一个「已迁移」的家目录。
+export function writeMigrateMarkerForTest(home: string, marker: { status: "done" | "nothing" | "failed"; at: number }): void {
+  writeMarker(migrateMarkerPath(home), marker);
+}
+

--- a/cli/src/commands/mcp-migrate.ts
+++ b/cli/src/commands/mcp-migrate.ts
@@ -21,7 +21,8 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
 import { agentpartyHome } from "../config";
-import { codexMcpRemove, codexRegistryScopes, readCodexMcpRegistrations } from "../codex-mcp-registry";
+import { codexRegistryScopes, readCodexMcpRegistrations } from "../codex-mcp-registry";
+import { harnessMcpRemove } from "./mcp-prune";
 import { recordChannelDefault } from "../mcp-channel-identity";
 import {
   isPartyMcpRegistration,
@@ -51,16 +52,29 @@ export interface MigratePlan {
 
 export interface MigrateDeps {
   home: string;
+  /** codex 的全局注册表所在 home（CODEX_HOME 或 ~/.codex）。单条注册必须加在这里，项目级不算覆盖。 */
+  globalCodexHome: string;
   registrations: () => McpRegistration[];
   readServer: (configPath: string) => string | null;
   recordDefault: (server: string, channel: string, configPath: string) => void;
   remove: (reg: McpRegistration) => { ok: boolean; detail: string };
-  addSingle: (harness: RegistrationHarness, sample: McpRegistration) => { ok: boolean; detail: string };
+  /** 必须加到 user / global scope——local/project 只对一个目录生效，别的项目会永久没有 party。 */
+  addSingle: (harness: RegistrationHarness) => { ok: boolean; detail: string };
   now: () => number;
 }
 
 export function isSingleRegistration(reg: McpRegistration): boolean {
   return isPartyMcpRegistration(reg) && reg.args.includes("--all-channels");
+}
+
+/**
+ * 这条单注册是否覆盖整台机器。Claude Code 的 local/project scope 只对一个目录生效，codex 的项目级
+ * config.toml 同理——那样的 `--all-channels` 不能当作「已迁好」：其它项目的旧注册一删就永久失联
+ * （codex stop-time review on f5c7bfc 抓到的，owner 机器上实测 `party` 真落在了 local scope）。
+ */
+export function isMachineWideSingle(reg: McpRegistration, globalCodexHome: string): boolean {
+  if (!isSingleRegistration(reg)) return false;
+  return registrationHarness(reg) === "codex" ? reg.codexHome === globalCodexHome : reg.scope === "user";
 }
 
 function readServerFromConfig(configPath: string): string | null {
@@ -83,25 +97,31 @@ function readJson(path: string): unknown | undefined {
 
 /** 真机依赖：两边注册表都读，删/加都走 harness 自己的 CLI。 */
 export function defaultMigrateDeps(home: string = homedir()): MigrateDeps {
+  const scopes = codexRegistryScopes(process.env, process.cwd(), home);
+  const globalCodexHome = scopes.find((sc) => sc.kind === "global")?.codexHome ?? join(home, ".codex");
   return {
     home,
+    globalCodexHome,
     registrations: () => [
       ...parseClaudeMcpRegistrations(readJson(join(home, ".claude.json")) ?? null),
-      ...readCodexMcpRegistrations(codexRegistryScopes(process.env, process.cwd(), home)),
+      ...readCodexMcpRegistrations(scopes),
     ],
     readServer: readServerFromConfig,
     recordDefault: (server, channel, configPath) => recordChannelDefault(server, channel, configPath),
-    remove: (reg) => {
-      if (registrationHarness(reg) === "codex") return codexMcpRemove(reg);
-      const res = spawnSync("claude", ["mcp", "remove", reg.name], { encoding: "utf8" });
-      if (res.error) return { ok: false, detail: res.error.message };
-      if (res.status !== 0) return { ok: false, detail: (res.stderr ?? "").trim() || `exit ${String(res.status)}` };
-      return { ok: true, detail: (res.stdout ?? "").trim() };
-    },
-    addSingle: (harness, sample) => {
-      const bin = harness === "codex" ? "codex" : "claude";
-      const env = harness === "codex" && sample.codexHome ? { ...process.env, CODEX_HOME: sample.codexHome } : process.env;
-      const res = spawnSync(bin, ["mcp", "add", SINGLE_NAME, "--", "party", "mcp", "--all-channels"], { encoding: "utf8", env });
+    // 删除复用 prune 的实现：它按注册所属 scope 切 cwd / 加 --scope user。不带 scope 的
+    // `claude mcp remove` 在别的目录里找不到那个名字**也返回 0**——上一版就是这样把 26 条
+    // 一条没删却全报了 ✓。
+    remove: harnessMcpRemove,
+    addSingle: (harness) => {
+      const res = harness === "codex"
+        ? spawnSync("codex", ["mcp", "add", SINGLE_NAME, "--", "party", "mcp", "--all-channels"], {
+            encoding: "utf8",
+            env: { ...process.env, CODEX_HOME: globalCodexHome },
+          })
+        : spawnSync("claude", ["mcp", "add", "--scope", "user", SINGLE_NAME, "--", "party", "mcp", "--all-channels"], {
+            encoding: "utf8",
+            cwd: home,
+          });
       if (res.error) return { ok: false, detail: res.error.message };
       if (res.status !== 0) return { ok: false, detail: (res.stderr ?? "").trim() || `exit ${String(res.status)}` };
       return { ok: true, detail: (res.stdout ?? "").trim() };
@@ -121,7 +141,8 @@ export function planMcpMigrate(deps: MigrateDeps): MigratePlan {
     if (!isPartyMcpRegistration(reg)) continue;
     const harness = registrationHarness(reg);
     if (isSingleRegistration(reg)) {
-      alreadySingle.add(harness);
+      if (isMachineWideSingle(reg, deps.globalCodexHome)) alreadySingle.add(harness);
+      else skipped.push({ reg, reason: "是 --all-channels 但只在 local/project scope，覆盖不了整台机器；会另加一条 user/global 的" });
       continue;
     }
     const channel = registrationChannel(reg);
@@ -154,24 +175,62 @@ export interface MigrateResult {
   addFailed: { harness: RegistrationHarness; detail: string }[];
 }
 
+function hasMachineWideSingle(deps: MigrateDeps, harness: RegistrationHarness): boolean {
+  return deps.registrations().some((r) => registrationHarness(r) === harness && isMachineWideSingle(r, deps.globalCodexHome));
+}
+
+function stillRegistered(deps: MigrateDeps, reg: McpRegistration): boolean {
+  return deps.registrations().some(
+    (r) => registrationHarness(r) === registrationHarness(reg) && r.scope === reg.scope && r.name === reg.name,
+  );
+}
+
 /**
- * 执行迁移。返回码非 0 只有一种情况：**有 harness 的新注册没加上**——那时用户可能处在
- * 「旧的删了、新的没加上」的空档，必须显眼。单条旧注册删失败不算（它只是多留一个进程）。
+ * 执行迁移。顺序是**先加后删**：单条注册加不上（或加上了但读回来不在 user/global scope）的
+ * harness，一条旧注册都不删——绝不让用户处在「旧的删了、新的没加上」的空档。返回码非 0 只有
+ * 这一种情况。每一步都读回注册表验证，不信 harness CLI 的退出码。
  */
 export function runMcpMigrate(plan: MigratePlan, deps: MigrateDeps, log: (line: string) => void): MigrateResult {
   const moved: LegacyRegistration[] = [];
   const failed: MigrateResult["failed"] = [];
-  const harnesses = new Set<RegistrationHarness>();
+  const added: RegistrationHarness[] = [];
+  const addFailed: MigrateResult["addFailed"] = [];
+
   // 同一 (server, channel) 有多条旧注册且指向**不同**身份时，不能默默挑一个当默认——老模型下这两个
-  // 身份本来就同时在跑（两个 MCP 进程、两套工具前缀），迁移后按调用解析会失败关闭并列出候选，
-  // 这是对的：让人选，而不是替人选。owner 那台机器上 #bug-7744 / #welcome 就是这种情况。
+  // 身份本来就同时在跑，迁移后按调用解析会失败关闭并列出候选：让人选，而不是替人选。
   const identitiesByChannel = new Map<string, Set<string>>();
   for (const item of plan.legacy) {
     const key = JSON.stringify([item.server, item.channel]);
     identitiesByChannel.set(key, (identitiesByChannel.get(key) ?? new Set()).add(item.configPath));
   }
+
+  // 1) 每个涉及的 harness：先把单条注册加到 user/global，读回确认
+  const harnesses = new Set(plan.legacy.map((l) => l.harness));
+  const covered = new Set<RegistrationHarness>();
+  for (const harness of harnesses) {
+    if (plan.alreadySingle.has(harness)) {
+      covered.add(harness);
+      continue;
+    }
+    const res = deps.addSingle(harness);
+    if (res.ok && hasMachineWideSingle(deps, harness)) {
+      covered.add(harness);
+      added.push(harness);
+      log(`  ✓ ${harness}：已在 user/global scope 加一条 \`party mcp --all-channels\`（读回确认）`);
+    } else {
+      const detail = res.ok ? "命令返回 0，但读回注册表时它不在 user/global scope" : res.detail;
+      addFailed.push({ harness, detail });
+      log(`  ✗ ${harness}：单条注册没加上（${detail}）——该 harness 的旧注册一条都不动。手工加：`);
+      log(harness === "codex"
+        ? `      codex mcp add ${SINGLE_NAME} -- party mcp --all-channels`
+        : `      claude mcp add --scope user ${SINGLE_NAME} -- party mcp --all-channels`);
+    }
+  }
+
+  // 2) 记默认 + 删旧（只对已覆盖的 harness），每条删完读回验证
   const warned = new Set<string>();
   for (const item of plan.legacy) {
+    if (!covered.has(item.harness)) continue;
     const key = JSON.stringify([item.server, item.channel]);
     const contenders = identitiesByChannel.get(key)!;
     if (contenders.size > 1) {
@@ -180,46 +239,32 @@ export function runMcpMigrate(plan: MigratePlan, deps: MigrateDeps, log: (line: 
         log(`  ! #${item.channel} 有 ${contenders.size} 份不同身份的旧注册，不设默认；迁移后调用时传 identity，或用 party join 重新绑定其中一个`);
       }
     } else {
-      // 1) 先记默认——记不下来就不删，否则迁完这个频道会从「能用」变成「歧义」。
       try {
         deps.recordDefault(item.server, item.channel, item.configPath);
       } catch (e) {
         failed.push({ reg: item.reg, step: "default", detail: e instanceof Error ? e.message : String(e) });
-        continue;
+        continue; // 记不下来就不删，否则这个频道从「能用」变「歧义」
       }
     }
-    // 2) 删旧
     const removed = deps.remove(item.reg);
     if (!removed.ok) {
       failed.push({ reg: item.reg, step: "remove", detail: removed.detail });
       continue;
     }
+    if (stillRegistered(deps, item.reg)) {
+      // harness CLI 返回 0 但注册还在：不带 scope 的 remove 在别的目录里就是这样。
+      failed.push({ reg: item.reg, step: "remove", detail: "命令返回 0，但读回注册表时它还在（scope 没对上？）" });
+      continue;
+    }
     moved.push(item);
-    harnesses.add(item.harness);
     log(
       contenders.size > 1
         ? `  ✓ #${item.channel} 的注册 ${item.reg.name} 已收进单条注册（未设默认）`
         : `  ✓ #${item.channel} 的注册 ${item.reg.name} 已收进单条注册（默认身份：${item.configPath}）`,
     );
   }
-  // 3) 每个涉及的 harness 补一条 --all-channels（已有就不加）
-  const added: RegistrationHarness[] = [];
-  const addFailed: MigrateResult["addFailed"] = [];
-  for (const harness of harnesses) {
-    if (plan.alreadySingle.has(harness)) continue;
-    const sample = plan.legacy.find((l) => l.harness === harness)!.reg;
-    const res = deps.addSingle(harness, sample);
-    if (res.ok) {
-      added.push(harness);
-      log(`  ✓ ${harness}：已加一条 \`party mcp --all-channels\``);
-    } else {
-      addFailed.push({ harness, detail: res.detail });
-      log(`  ✗ ${harness}：新注册没加上（${res.detail}）——旧注册已删，请立刻手工加：`);
-      log(`      ${harness} mcp add ${SINGLE_NAME} -- party mcp --all-channels`);
-    }
-  }
   for (const f of failed) {
-    log(`  ! ${f.reg.name}：${f.step === "default" ? "记默认身份失败，未删" : "删除失败"}（${f.detail}）`);
+    log(`  ! ${f.reg.name}：${f.step === "default" ? "记默认身份失败，未删" : "删除失败，仍保留"}（${f.detail}）`);
   }
   return { code: addFailed.length > 0 ? 1 : 0, moved, failed, added, addFailed };
 }

--- a/cli/src/commands/mcp-prune.ts
+++ b/cli/src/commands/mcp-prune.ts
@@ -174,7 +174,9 @@ export const harnessMcpRemove: RemoveFn = (reg) =>
 export const claudeMcpRemove: RemoveFn = (reg) => {
   const args = ["mcp", "remove", reg.name];
   const cwd = reg.scope === "user" ? (process.env.HOME ?? homedir()) : reg.scope;
-  if (reg.scope === "user") args.push("--scope", "user");
+  // scope 必须显式给：user 级与项目级同名时，不带 scope 的 remove 会拒绝并打一句提示、退出码仍是 0，
+  // 什么都没删（#1083 迁移实测）。projects[path].mcpServers 里的就是 local scope。
+  args.push("--scope", reg.scope === "user" ? "user" : "local");
   const res = spawnSync("claude", args, { cwd, encoding: "utf8" });
   if (res.error !== undefined && res.error !== null) return { ok: false, detail: res.error.message };
   if (res.status !== 0) return { ok: false, detail: (res.stderr ?? "").trim() || `exit ${String(res.status)}` };

--- a/cli/src/commands/mcp.ts
+++ b/cli/src/commands/mcp.ts
@@ -70,6 +70,7 @@ import { EXIT_ALREADY_WATCHING, runWatch } from "./watch";
 import { settleClaudeDeliveryRecovery } from "../delivery-recovery-journal";
 
 const HELP = `usage: party mcp [--channel <slug> | --all-channels] [--identity <label>]
+       party mcp migrate [--dry-run] [--yes]
        party mcp prune [--yes] [--check-remote] [--json]
        party mcp identities [--channel C] [--server S] [--keep NAME] [--yes] [--json]
 
@@ -87,6 +88,9 @@ Options:
                      identity is used — that always comes from AGENTPARTY_CONFIG.
 
 Subcommands:
+  migrate merge legacy one-registration-per-channel entries into a single
+          \`party mcp --all-channels\` (#1083). Interactive party commands run
+          this once automatically; here is the manual / dry-run entry.
   prune   remove Claude Code MCP registrations that point at AgentParty
           identities which no longer exist (dry run unless --yes; never touches
           MCP servers belonging to other tools). See 'party mcp prune --help'.
@@ -1890,6 +1894,10 @@ export async function run(argv: string[]): Promise<number> {
     return runManagedMcp(argv[1]);
   }
   // #898 方案 C 第 2 件：清理指向已删身份/已失效 config 的注册。默认 dry-run。
+  if (argv[0] === "migrate") {
+    const { runMigrateCli } = await import("./mcp-migrate");
+    return runMigrateCli(argv.slice(1));
+  }
   if (argv[0] === "prune") {
     const { runPruneCli } = await import("./mcp-prune");
     return runPruneCli(argv.slice(1));

--- a/cli/src/commands/mcp.ts
+++ b/cli/src/commands/mcp.ts
@@ -116,7 +116,9 @@ Boundary:
 
 Example (name the server per agent — a shared name like "party" lets agents in the
 same directory overwrite each other's env-pinned identity):
-  claude mcp add party-<agent-name> --env AGENTPARTY_CONFIG=<config.json> -- party mcp --channel <slug>
+  claude mcp add --scope user party -- party mcp --all-channels   # one registration, every channel
+  (legacy per-channel form: claude mcp add party-<name> --env AGENTPARTY_CONFIG=<config.json> -- party mcp --channel <slug>;
+   'party mcp migrate' folds those into the single registration)
 
 Tools:
   party_whoami

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -136,6 +136,14 @@ async function dispatch(argv: string[]): Promise<number> {
     console.log(VERSION);
     return 0;
   }
+  // #1083：老用户机器上旧式「一频道一注册」的 MCP 注册，在第一次跑交互式命令时自动合并成一条。
+  // 一次性标记、失败限频；进程内入口（mcp/hook/serve…）在函数里自己排除。任何异常都不能挡住命令本身。
+  try {
+    const { maybeAutoMigrate } = await import("./commands/mcp-migrate");
+    maybeAutoMigrate(cmd);
+  } catch {
+    /* 迁移是附赠的，绝不成为命令的单点故障 */
+  }
   switch (cmd) {
     case "login":
       return (await import("./commands/login")).run(rest);

--- a/cli/test/join-fixture.ts
+++ b/cli/test/join-fixture.ts
@@ -3,6 +3,7 @@
 // 只桩 claude/codex 二进制（spawnSync）与几个探活注入点；init / hook / send 走**真实**实现打到
 // rest-mock，收尾判定读**真实盘状态**——反假绿纪律：桩得越少，测试越接近真机。
 import { mkdtempSync, rmSync } from "node:fs";
+import type { McpRegistration } from "../src/mcp-registry";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { JoinDeps, JoinOptions } from "../src/commands/join";
@@ -22,6 +23,8 @@ export interface SpawnBehavior {
   noBinary?: boolean; // 二进制不存在（ENOENT）
   mcpAlreadyRegistered?: boolean; // mcp get 返回 0（已注册）
   failMcpAdd?: boolean; // mcp add 返回非 0
+  /** #1083：预置的 MCP 注册表（比如一条同名的旧式 per-channel 注册）。 */
+  mcpRegistry?: McpRegistration[];
   /**
    * 本机已装的 claude 插件版本（#961）：省略＝与 CLI 同版；null＝没装；"0.2.203" 这类＝旧版。
    * 桩是**有状态**的，照真机行为走：`plugin install` 对已装的只回 already installed（**不升级**），
@@ -63,6 +66,8 @@ function compareSemverLoose(a: string, b: string): number {
 
 interface PluginState {
   installed: string | null;
+  /** #1083：MCP 注册表桩。mcpAlreadyRegistered 时预置两条 user/global 的 --all-channels。 */
+  registry: McpRegistration[];
   /** 还要让多少次 `plugin list` 读失败（pluginListFailsAfterUpdate 用）。 */
   listFailuresLeft?: number;
 }
@@ -78,7 +83,27 @@ export function fakeSpawn(record: string[][], behavior: SpawnBehavior, state: Pl
       return { ...base, status: behavior.mcpAlreadyRegistered ? 0 : 1 };
     }
     if (args[0] === "mcp" && args[1] === "add") {
-      return { ...base, status: behavior.failMcpAdd ? 1 : 0 };
+      if (behavior.failMcpAdd) return { ...base, status: 1 };
+      // #1083：桩是有状态的——加进去的注册在 registrations() 里读得到，不然读回验证恒失败。
+      const name = args.includes("--scope") ? args[args.indexOf("--scope") + 2]! : args[2]!;
+      const dash = args.indexOf("--");
+      const rest = dash === -1 ? [] : args.slice(dash + 1);
+      state.registry.push({
+        scope: cmd === "codex" ? join(process.env.CODEX_HOME ?? "", "config.toml") : args.includes("--scope") ? args[args.indexOf("--scope") + 1]! : process.cwd(),
+        name,
+        command: rest[0] ?? "party",
+        args: rest.slice(1),
+        env: {},
+        harness: cmd === "codex" ? "codex" : "claude",
+        codexHome: cmd === "codex" ? process.env.CODEX_HOME : undefined,
+      });
+      return { ...base, status: 0 };
+    }
+    if (args[0] === "mcp" && args[1] === "remove") {
+      const name = args[2]!;
+      const i = state.registry.findIndex((r) => r.name === name && (r.harness ?? "claude") === (cmd === "codex" ? "codex" : "claude"));
+      if (i !== -1) state.registry.splice(i, 1);
+      return { ...base, status: 0 };
     }
     if (cmd === "claude" && args[0] === "--version") return { ...base, status: 0, stdout: "2.1.200 (Claude Code)\n" };
     if (cmd === "claude" && args[0] === "plugin" && args[1] === "list") {
@@ -150,11 +175,18 @@ export function joinEnv(): { setup: () => string; teardown: () => void } {
 export function joinDeps(tmp: string, record: string[][], behavior: SpawnBehavior, logs: string[]): JoinDeps {
   const state: PluginState = {
     installed: behavior.installedPluginVersion === undefined ? RUNNING_VERSION : behavior.installedPluginVersion,
+    registry: behavior.mcpAlreadyRegistered
+      ? [
+          { scope: "user", name: "party", command: "party", args: ["mcp", "--all-channels"], env: {}, harness: "claude" },
+          { scope: join(process.env.CODEX_HOME ?? "", "config.toml"), name: "party", command: "party", args: ["mcp", "--all-channels"], env: {}, harness: "codex", codexHome: process.env.CODEX_HOME },
+        ]
+      : [...(behavior.mcpRegistry ?? [])],
   };
   const spawn = fakeSpawn(record, behavior, state);
   const clock = { t: 1_000_000 };
   return {
     spawn,
+    mcpRegistrations: () => [...state.registry],
     initRun,
     hookRun,
     sendRun,

--- a/cli/test/join.test.ts
+++ b/cli/test/join.test.ts
@@ -92,13 +92,13 @@ describe("party join —— 一条命令跑完整段接入（#944）", () => {
     const bindings = JSON.parse(readFileSync(bindingsPath(), "utf8")) as { bindings: { harness: string; channel: string }[] };
     expect(bindings.bindings.some((b) => b.harness === "claude" && b.channel === "dev")).toBe(true);
 
-    // 4) MCP 注册落地（先探后加，#898）：claude mcp get 探到未注册 → claude mcp add 带 --identity。
-    expect(record).toContainEqual(["claude", "mcp", "get", "party-bot"]);
+    // 4) MCP 注册落地（先探后加，#898）：探的是**唯一那条** `party`，加的是 user scope 的
+    //    `party mcp --all-channels`（#1083：join 不再每频道各注册一条，那正是进程膨胀的源头）。
+    expect(record).toContainEqual(["claude", "mcp", "get", "party"]);
     const add = record.find((r) => r[0] === "claude" && r[1] === "mcp" && r[2] === "add");
     expect(add).toBeDefined();
-    expect(add).toContain("party-bot");
-    expect(add).toContain("--identity");
-    expect(add).toContain("dev");
+    expect(add).toEqual(["claude", "mcp", "add", "--scope", "user", "party", "--", "party", "mcp", "--all-channels"]);
+    expect(add).not.toContain("--channel"); // 频道不再绑在注册上，由每次调用传入
     // token 绝不出现在任何 spawn 的 argv 里（#676）。
     expect(record.flat().some((a) => a.includes("ap_bot_secret"))).toBe(false);
 

--- a/cli/test/join.test.ts
+++ b/cli/test/join.test.ts
@@ -94,7 +94,6 @@ describe("party join —— 一条命令跑完整段接入（#944）", () => {
 
     // 4) MCP 注册落地（先探后加，#898）：探的是**唯一那条** `party`，加的是 user scope 的
     //    `party mcp --all-channels`（#1083：join 不再每频道各注册一条，那正是进程膨胀的源头）。
-    expect(record).toContainEqual(["claude", "mcp", "get", "party"]);
     const add = record.find((r) => r[0] === "claude" && r[1] === "mcp" && r[2] === "add");
     expect(add).toBeDefined();
     expect(add).toEqual(["claude", "mcp", "add", "--scope", "user", "party", "--", "party", "mcp", "--all-channels"]);
@@ -707,10 +706,42 @@ describe("party join —— 一条命令跑完整段接入（#944）", () => {
     const code = await runJoin(baseOpts({ harnessFlag: "claude", verbose: true }), deps(record, { mcpAlreadyRegistered: true }, logs));
 
     expect(code).toBe(0);
-    // 探到了（get 跑过），但**没有** add——每个注册在每个会话里都是一个常驻进程。
-    expect(record.some((r) => r[0] === "claude" && r[2] === "get")).toBe(true);
+    // 注册表里已有 user 级的 --all-channels ⇒ **没有** add——每个注册在每个会话里都是一个常驻进程。
     expect(record.some((r) => r[0] === "claude" && r[2] === "add")).toBe(false);
     expect(logs.join("\n")).toMatch(/(已注册|already)/i);
+  });
+
+  // codex stop-time review on c15a030：「存在同名注册」≠「所有频道已可用」。判据必须是读注册表看有没有
+  // user/global 的 --all-channels，而不是 `mcp get party` 有没有返回 0。
+  test("本机只有一条同名的旧式 party --channel（user 级）⇒ join 把它换成 --all-channels，而不是跳过", async () => {
+    mock = startRestMock();
+    const record: string[][] = [];
+    const logs: string[] = [];
+    const legacy = {
+      scope: "user", name: "party", command: "party", args: ["mcp", "--channel", "king", "--identity", "king-claude"],
+      env: {}, harness: "claude" as const,
+    };
+    const code = await runJoin(baseOpts({ harnessFlag: "claude", verbose: true }), deps(record, { mcpRegistry: [legacy] }, logs));
+    expect(code).toBe(0);
+    // 先删同名旧的，再加 user 级 --all-channels
+    const rm = record.findIndex((r) => r[0] === "claude" && r[1] === "mcp" && r[2] === "remove" && r[3] === "party");
+    const add = record.findIndex((r) => r[0] === "claude" && r[1] === "mcp" && r[2] === "add");
+    expect(rm).toBeGreaterThan(-1);
+    expect(add).toBeGreaterThan(rm);
+    expect(record[add]).toEqual(["claude", "mcp", "add", "--scope", "user", "party", "--", "party", "mcp", "--all-channels"]);
+    expect(logs.join("\n")).toContain("已换成 --all-channels");
+  });
+
+  test("只有某个项目 local 的 party --all-channels ⇒ 仍要加 user 级一条，不能当作已覆盖", async () => {
+    mock = startRestMock();
+    const record: string[][] = [];
+    const logs: string[] = [];
+    const localOnly = { scope: "/some/other/project", name: "party", command: "party", args: ["mcp", "--all-channels"], env: {}, harness: "claude" as const };
+    const code = await runJoin(baseOpts({ harnessFlag: "claude", verbose: true }), deps(record, { mcpRegistry: [localOnly] }, logs));
+    expect(code).toBe(0);
+    const add = record.find((r) => r[0] === "claude" && r[1] === "mcp" && r[2] === "add");
+    expect(add).toEqual(["claude", "mcp", "add", "--scope", "user", "party", "--", "party", "mcp", "--all-channels"]);
+    expect(record.some((r) => r[0] === "claude" && r[2] === "remove")).toBe(false); // local 的不是冲突，不动它
   });
 
   test("MCP 注册失败：如实报出来，不冒充成功", async () => {

--- a/cli/test/mcp-migrate.test.ts
+++ b/cli/test/mcp-migrate.test.ts
@@ -1,11 +1,15 @@
 // #1083：老用户的自动迁移——一频道一注册 → 一条 `party mcp --all-channels`。
 // 用例重点是失败关闭：任何一步失败都不能让用户处在「旧的删了、新的没加上」的空档。
+// 注册表在夹具里是**可变的**：迁移的每一步都要读回验证，不信 harness CLI 的退出码
+//（codex stop-time review on f5c7bfc：不带 scope 的 `claude mcp remove` 在别的目录里
+// 找不到名字也返回 0，上一版把 26 条一条没删却全报了 ✓）。
 import { describe, expect, test } from "bun:test";
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { McpRegistration } from "../src/mcp-registry";
+import type { McpRegistration, RegistrationHarness } from "../src/mcp-registry";
 import {
+  isMachineWideSingle,
   maybeAutoMigrate,
   migrateMarkerPath,
   migrationDone,
@@ -16,48 +20,75 @@ import {
 } from "../src/commands/mcp-migrate";
 
 const NOW = 1_800_000_000_000;
+const GLOBAL_CODEX = "/home/.codex";
 
 function reg(over: Partial<McpRegistration> & { name: string }): McpRegistration {
   return {
-    scope: "user",
+    scope: "/home/.codex/config.toml",
     command: "party",
     args: ["mcp", "--channel", "dev", "--identity", over.name],
     env: { AGENTPARTY_CONFIG: `/cfg/${over.name}.json` },
     harness: "codex",
-    codexHome: "/home/.codex",
+    codexHome: GLOBAL_CODEX,
     ...over,
   };
+}
+
+/** 已经加好的、覆盖整台机器的单条注册。 */
+function single(harness: RegistrationHarness, over: Partial<McpRegistration> = {}): McpRegistration {
+  return harness === "codex"
+    ? reg({ name: "party", args: ["mcp", "--all-channels"], env: {}, ...over })
+    : reg({ name: "party", args: ["mcp", "--all-channels"], env: {}, harness: "claude", scope: "user", codexHome: undefined, ...over });
 }
 
 interface Trace {
   defaults: [string, string, string][];
   removed: string[];
-  added: string[];
+  added: RegistrationHarness[];
+  /** 记录调用顺序：add / remove 交错的先后。 */
+  order: string[];
 }
 
-function deps(
-  registrations: McpRegistration[],
-  over: Partial<MigrateDeps> & { servers?: Record<string, string | null> } = {},
-): { deps: MigrateDeps; trace: Trace } {
-  const trace: Trace = { defaults: [], removed: [], added: [] };
-  const servers = over.servers ?? {};
+interface Knobs extends Partial<MigrateDeps> {
+  servers?: Record<string, string | null>;
+  /** addSingle 是否真的把单注册放进注册表（缺省放进 user/global）。 */
+  addLands?: "global" | "project" | "none";
+  /** remove 返回 ok 但实际不删（模拟 scope 没对上的 `claude mcp remove`）。 */
+  removeLies?: boolean;
+}
+
+function deps(initial: McpRegistration[], knobs: Knobs = {}): { deps: MigrateDeps; trace: Trace; registry: McpRegistration[] } {
+  const registry = [...initial];
+  const trace: Trace = { defaults: [], removed: [], added: [], order: [] };
+  const servers = knobs.servers ?? {};
+  const { servers: _s, addLands, removeLies, ...over } = knobs;
   const d: MigrateDeps = {
     home: "/home",
-    registrations: () => registrations,
+    globalCodexHome: GLOBAL_CODEX,
+    registrations: () => [...registry],
     readServer: (p) => (p in servers ? servers[p]! : "https://s1"),
     recordDefault: (server, channel, path) => void trace.defaults.push([server, channel, path]),
     remove: (r) => {
       trace.removed.push(r.name);
+      trace.order.push(`remove:${r.name}`);
+      if (removeLies !== true) {
+        const i = registry.findIndex((x) => x.scope === r.scope && x.name === r.name && (x.harness ?? "claude") === (r.harness ?? "claude"));
+        if (i !== -1) registry.splice(i, 1);
+      }
       return { ok: true, detail: "" };
     },
     addSingle: (h) => {
       trace.added.push(h);
+      trace.order.push(`add:${h}`);
+      const lands = addLands ?? "global";
+      if (lands === "global") registry.push(single(h));
+      if (lands === "project") registry.push(single(h, h === "codex" ? { scope: "/proj/.codex/config.toml", codexHome: "/proj/.codex" } : { scope: "/proj" }));
       return { ok: true, detail: "" };
     },
     now: () => NOW,
     ...over,
   };
-  return { deps: d, trace };
+  return { deps: d, trace, registry };
 }
 
 describe("planMcpMigrate —— 只收「一频道一注册」的形状", () => {
@@ -89,11 +120,18 @@ describe("planMcpMigrate —— 只收「一频道一注册」的形状", () => 
     expect(plan.skipped[0]!.reason).toContain("prune");
   });
 
-  test("已有 --all-channels 的 harness 记进 alreadySingle，且那条不算 legacy", () => {
-    const { deps: d } = deps([reg({ name: "party", args: ["mcp", "--all-channels"], env: {} }), reg({ name: "party-a" })]);
-    const plan = planMcpMigrate(d);
-    expect([...plan.alreadySingle]).toEqual(["codex"]);
-    expect(plan.legacy.map((l) => l.reg.name)).toEqual(["party-a"]);
+  test("user/global 的 --all-channels 记进 alreadySingle；只在 local/project 的不算覆盖", () => {
+    const { deps: d } = deps([single("codex"), reg({ name: "party-a" })]);
+    expect([...planMcpMigrate(d).alreadySingle]).toEqual(["codex"]);
+
+    const projectOnly = single("claude", { scope: "/some/project" });
+    const { deps: d2 } = deps([projectOnly, reg({ name: "party-c", harness: "claude", scope: "/some/project", codexHome: undefined })]);
+    const plan = planMcpMigrate(d2);
+    expect(plan.alreadySingle.size).toBe(0);
+    expect(plan.skipped[0]!.reason).toContain("local/project");
+    expect(isMachineWideSingle(projectOnly, GLOBAL_CODEX)).toBe(false);
+    expect(isMachineWideSingle(single("claude"), GLOBAL_CODEX)).toBe(true);
+    expect(isMachineWideSingle(single("codex", { codexHome: "/proj/.codex" }), GLOBAL_CODEX)).toBe(false);
   });
 
   test("不是 party 的注册一概不碰", () => {
@@ -104,22 +142,60 @@ describe("planMcpMigrate —— 只收「一频道一注册」的形状", () => 
   });
 });
 
-describe("runMcpMigrate —— 顺序与失败关闭", () => {
-  test("正常路径：先记默认、再删旧、最后每个 harness 加一条；默认身份就是旧注册用的那份", () => {
-    const { deps: d, trace } = deps([
+describe("runMcpMigrate —— 先加后删、读回验证", () => {
+  test("正常路径：每个 harness 先加单注册并读回确认，再记默认、再删旧；默认身份就是旧注册用的那份", () => {
+    const { deps: d, trace, registry } = deps([
       reg({ name: "party-a" }),
-      reg({ name: "party-c", harness: "claude", codexHome: undefined, args: ["mcp", "--channel", "web"] }),
+      reg({ name: "party-c", harness: "claude", scope: "/proj/web", codexHome: undefined, args: ["mcp", "--channel", "web"] }),
     ]);
-    const lines: string[] = [];
-    const r = runMcpMigrate(planMcpMigrate(d), d, (l) => lines.push(l));
+    const r = runMcpMigrate(planMcpMigrate(d), d, () => undefined);
     expect(r.code).toBe(0);
+    expect(trace.added.sort()).toEqual(["claude", "codex"]);
+    expect(trace.removed.sort()).toEqual(["party-a", "party-c"]);
+    // 先加后删：每个 add 都排在所有 remove 前面
+    const firstRemove = trace.order.findIndex((x) => x.startsWith("remove:"));
+    expect(trace.order.slice(0, firstRemove).every((x) => x.startsWith("add:"))).toBe(true);
     expect(trace.defaults).toEqual([
       ["https://s1", "dev", "/cfg/party-a.json"],
       ["https://s1", "web", "/cfg/party-c.json"],
     ]);
-    expect(trace.removed).toEqual(["party-a", "party-c"]);
-    expect(trace.added.sort()).toEqual(["claude", "codex"]);
+    // 迁完注册表里只剩两条 user/global 的单注册
+    expect(registry.map((x) => x.name)).toEqual(["party", "party"]);
     expect(r.moved).toHaveLength(2);
+  });
+
+  // 整个模块最重要的断言：单注册加不上 ⇒ 该 harness 的旧注册一条都不删，非零退出，印手工命令。
+  test("单注册加不上 ⇒ 一条旧注册都不删、退出码非 0、印出手工加回的命令（含 --scope user）", () => {
+    const { deps: d, trace } = deps(
+      [reg({ name: "party-a" }), reg({ name: "party-c", harness: "claude", scope: "/proj", codexHome: undefined })],
+      { addSingle: (h) => (h === "claude" ? { ok: false, detail: "claude: command not found" } : (trace.added.push(h), { ok: true, detail: "" })) },
+    );
+    // codex 那边 addSingle 被覆盖后不会把单注册放进注册表 ⇒ 读回也不在 ⇒ 同样按失败处理
+    const lines: string[] = [];
+    const r = runMcpMigrate(planMcpMigrate(d), d, (l) => lines.push(l));
+    expect(r.code).toBe(1);
+    expect(trace.removed).toEqual([]);
+    expect(lines.join("\n")).toContain("claude mcp add --scope user party -- party mcp --all-channels");
+    expect(lines.join("\n")).toContain("codex mcp add party -- party mcp --all-channels");
+  });
+
+  test("addSingle 返回 0 但读回只在 project scope ⇒ 按没加上处理，不删旧", () => {
+    const { deps: d, trace } = deps([reg({ name: "party-a" })], { addLands: "project" });
+    const r = runMcpMigrate(planMcpMigrate(d), d, () => undefined);
+    expect(r.code).toBe(1);
+    expect(r.addFailed[0]!.detail).toContain("不在 user/global scope");
+    expect(trace.removed).toEqual([]);
+  });
+
+  test("remove 返回 0 但注册还在 ⇒ 记为删除失败，不算迁走", () => {
+    const { deps: d } = deps([reg({ name: "party-a" })], { removeLies: true });
+    const lines: string[] = [];
+    const r = runMcpMigrate(planMcpMigrate(d), d, (l) => lines.push(l));
+    expect(r.code).toBe(0); // 单注册加上了，用户没失联；只是旧的多留了一个进程
+    expect(r.moved).toEqual([]);
+    expect(r.failed[0]).toMatchObject({ step: "remove" });
+    expect(r.failed[0]!.detail).toContain("还在");
+    expect(lines.join("\n")).toContain("仍保留");
   });
 
   test("记默认失败 ⇒ 那条不删（否则频道从「能用」变「歧义」）", () => {
@@ -131,29 +207,42 @@ describe("runMcpMigrate —— 顺序与失败关闭", () => {
     const r = runMcpMigrate(planMcpMigrate(d), d, () => undefined);
     expect(trace.removed).toEqual([]);
     expect(r.failed[0]).toMatchObject({ step: "default" });
-    expect(trace.added).toEqual([]); // 一条都没迁成，就不加新的
     expect(r.code).toBe(0);
   });
 
-  test("已经有 --all-channels 的 harness 不重复加", () => {
-    const { deps: d, trace } = deps([reg({ name: "party", args: ["mcp", "--all-channels"], env: {} }), reg({ name: "party-a" })]);
+  test("已经有 user/global 的 --all-channels ⇒ 不重复加，直接删旧", () => {
+    const { deps: d, trace } = deps([single("codex"), reg({ name: "party-a" })]);
     const r = runMcpMigrate(planMcpMigrate(d), d, () => undefined);
     expect(r.code).toBe(0);
-    expect(trace.removed).toEqual(["party-a"]);
     expect(trace.added).toEqual([]);
+    expect(trace.removed).toEqual(["party-a"]);
   });
+});
 
-  // 这条是整个模块最重要的断言：旧的删了、新的没加上 ⇒ 所有 agent 一起静默失联。必须非零退出、
-  // 必须把手工命令印出来。
-  test("新注册加不上 ⇒ 退出码非 0，并印出手工加回的命令", () => {
-    const { deps: d } = deps([reg({ name: "party-a" })], {
-      addSingle: () => ({ ok: false, detail: "codex: command not found" }),
-    });
+// owner 那台机器的真实情况：#bug-7744 与 #welcome 各有两条旧注册、两份不同身份。迁移时按顺序
+// 写默认等于最后一条赢——那是替人选身份。这种频道不设默认，让 --all-channels 失败关闭并列候选。
+describe("同一频道多份不同身份的旧注册 ⇒ 不设默认", () => {
+  test("两份不同身份：都删、都不记默认、给一条提示；单身份的频道照常记", () => {
+    const { deps: d, trace } = deps([
+      reg({ name: "party-a1", args: ["mcp", "--channel", "dup"], env: { AGENTPARTY_CONFIG: "/cfg/a1.json" } }),
+      reg({ name: "party-a2", args: ["mcp", "--channel", "dup"], env: { AGENTPARTY_CONFIG: "/cfg/a2.json" } }),
+      reg({ name: "party-solo", args: ["mcp", "--channel", "solo"] }),
+    ]);
     const lines: string[] = [];
     const r = runMcpMigrate(planMcpMigrate(d), d, (l) => lines.push(l));
-    expect(r.code).toBe(1);
-    expect(r.addFailed[0]!.harness).toBe("codex");
-    expect(lines.join("\n")).toContain("codex mcp add party -- party mcp --all-channels");
+    expect(r.code).toBe(0);
+    expect(trace.removed.sort()).toEqual(["party-a1", "party-a2", "party-solo"]);
+    expect(trace.defaults).toEqual([["https://s1", "solo", "/cfg/party-solo.json"]]);
+    expect(lines.filter((l) => l.includes("不设默认"))).toHaveLength(1);
+  });
+
+  test("两条旧注册指向**同一份**身份（重复注册）⇒ 不算多身份，照常记默认", () => {
+    const { deps: d, trace } = deps([
+      reg({ name: "party-x", args: ["mcp", "--channel", "dup"], env: { AGENTPARTY_CONFIG: "/cfg/same.json" } }),
+      reg({ name: "party-y", args: ["mcp", "--channel", "dup"], env: { AGENTPARTY_CONFIG: "/cfg/same.json" } }),
+    ]);
+    runMcpMigrate(planMcpMigrate(d), d, () => undefined);
+    expect(trace.defaults.map((x) => x[1])).toEqual(["dup", "dup"]);
   });
 });
 
@@ -175,7 +264,7 @@ describe("maybeAutoMigrate —— 一次性、失败限频、进程内路径不�
 
     const second = maybeAutoMigrate("who", { deps: d, agentpartyHome: h });
     expect(second.ran).toBe(false);
-    expect(trace.removed).toEqual(["party-a"]); // 没再删
+    expect(trace.removed).toEqual(["party-a"]);
     rmSync(h, { recursive: true, force: true });
   });
 
@@ -193,7 +282,7 @@ describe("maybeAutoMigrate —— 一次性、失败限频、进程内路径不�
   test("mcp / hook / serve 这些进程内入口绝不触发", () => {
     const h = home();
     let reads = 0;
-    const { deps: d } = deps([reg({ name: "party-a" })], { registrations: () => (reads += 1, [reg({ name: "party-a" })]) });
+    const { deps: d } = deps([], { registrations: () => (reads += 1, [reg({ name: "party-a" })]) });
     for (const cmd of ["mcp", "hook", "serve", "daemon", "watch"]) {
       expect(maybeAutoMigrate(cmd, { deps: d, agentpartyHome: h }).ran).toBe(false);
     }
@@ -223,32 +312,5 @@ describe("maybeAutoMigrate —— 一次性、失败限频、进程内路径不�
     expect(maybeAutoMigrate("who", { deps: d, agentpartyHome: h }).ran).toBe(false);
     expect(migrationDone(h)).toBe(false);
     rmSync(h, { recursive: true, force: true });
-  });
-});
-
-// owner 那台机器的真实情况：#bug-7744 与 #welcome 各有两条旧注册、两份不同身份。迁移时按顺序
-// 写默认等于最后一条赢——那是替人选身份。这种频道不设默认，让 --all-channels 失败关闭并列候选。
-describe("同一频道多份不同身份的旧注册 ⇒ 不设默认", () => {
-  test("两份不同身份：都删、都不记默认、给一条提示；单身份的频道照常记", () => {
-    const { deps: d, trace } = deps([
-      reg({ name: "party-a1", args: ["mcp", "--channel", "dup"], env: { AGENTPARTY_CONFIG: "/cfg/a1.json" } }),
-      reg({ name: "party-a2", args: ["mcp", "--channel", "dup"], env: { AGENTPARTY_CONFIG: "/cfg/a2.json" } }),
-      reg({ name: "party-solo", args: ["mcp", "--channel", "solo"] }),
-    ]);
-    const lines: string[] = [];
-    const r = runMcpMigrate(planMcpMigrate(d), d, (l) => lines.push(l));
-    expect(r.code).toBe(0);
-    expect(trace.removed.sort()).toEqual(["party-a1", "party-a2", "party-solo"]);
-    expect(trace.defaults).toEqual([["https://s1", "solo", "/cfg/party-solo.json"]]);
-    expect(lines.filter((l) => l.includes("不设默认"))).toHaveLength(1);
-  });
-
-  test("两条旧注册指向**同一份**身份（重复注册）⇒ 不算多身份，照常记默认", () => {
-    const { deps: d, trace } = deps([
-      reg({ name: "party-x", args: ["mcp", "--channel", "dup"], env: { AGENTPARTY_CONFIG: "/cfg/same.json" } }),
-      reg({ name: "party-y", args: ["mcp", "--channel", "dup"], env: { AGENTPARTY_CONFIG: "/cfg/same.json" } }),
-    ]);
-    runMcpMigrate(planMcpMigrate(d), d, () => undefined);
-    expect(trace.defaults.map((x) => x[1])).toEqual(["dup", "dup"]);
   });
 });

--- a/cli/test/mcp-migrate.test.ts
+++ b/cli/test/mcp-migrate.test.ts
@@ -1,0 +1,254 @@
+// #1083：老用户的自动迁移——一频道一注册 → 一条 `party mcp --all-channels`。
+// 用例重点是失败关闭：任何一步失败都不能让用户处在「旧的删了、新的没加上」的空档。
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { McpRegistration } from "../src/mcp-registry";
+import {
+  maybeAutoMigrate,
+  migrateMarkerPath,
+  migrationDone,
+  planMcpMigrate,
+  runMcpMigrate,
+  writeMigrateMarkerForTest,
+  type MigrateDeps,
+} from "../src/commands/mcp-migrate";
+
+const NOW = 1_800_000_000_000;
+
+function reg(over: Partial<McpRegistration> & { name: string }): McpRegistration {
+  return {
+    scope: "user",
+    command: "party",
+    args: ["mcp", "--channel", "dev", "--identity", over.name],
+    env: { AGENTPARTY_CONFIG: `/cfg/${over.name}.json` },
+    harness: "codex",
+    codexHome: "/home/.codex",
+    ...over,
+  };
+}
+
+interface Trace {
+  defaults: [string, string, string][];
+  removed: string[];
+  added: string[];
+}
+
+function deps(
+  registrations: McpRegistration[],
+  over: Partial<MigrateDeps> & { servers?: Record<string, string | null> } = {},
+): { deps: MigrateDeps; trace: Trace } {
+  const trace: Trace = { defaults: [], removed: [], added: [] };
+  const servers = over.servers ?? {};
+  const d: MigrateDeps = {
+    home: "/home",
+    registrations: () => registrations,
+    readServer: (p) => (p in servers ? servers[p]! : "https://s1"),
+    recordDefault: (server, channel, path) => void trace.defaults.push([server, channel, path]),
+    remove: (r) => {
+      trace.removed.push(r.name);
+      return { ok: true, detail: "" };
+    },
+    addSingle: (h) => {
+      trace.added.push(h);
+      return { ok: true, detail: "" };
+    },
+    now: () => NOW,
+    ...over,
+  };
+  return { deps: d, trace };
+}
+
+describe("planMcpMigrate —— 只收「一频道一注册」的形状", () => {
+  test("有 --channel + AGENTPARTY_CONFIG 且 config 读得出 server ⇒ 进 legacy", () => {
+    const { deps: d } = deps([reg({ name: "party-a" }), reg({ name: "party-b", args: ["mcp", "--channel", "ops"] })]);
+    const plan = planMcpMigrate(d);
+    expect(plan.legacy.map((l) => [l.reg.name, l.channel])).toEqual([["party-a", "dev"], ["party-b", "ops"]]);
+    expect(plan.skipped).toHaveLength(0);
+  });
+
+  test("裸 `party mcp`（没 --channel）不动——它靠 cwd 绑定工作，不是本次要收的", () => {
+    const { deps: d } = deps([reg({ name: "party", args: ["mcp"] })]);
+    const plan = planMcpMigrate(d);
+    expect(plan.legacy).toHaveLength(0);
+    expect(plan.skipped[0]!.reason).toContain("--channel");
+  });
+
+  test("没 AGENTPARTY_CONFIG 的不动——不知道它用哪份身份，删了就丢身份", () => {
+    const { deps: d } = deps([reg({ name: "party-x", env: {} })]);
+    const plan = planMcpMigrate(d);
+    expect(plan.legacy).toHaveLength(0);
+    expect(plan.skipped[0]!.reason).toContain("AGENTPARTY_CONFIG");
+  });
+
+  test("config 读不出（TMPDIR 被清）⇒ 跳过并指向 prune，不在这里删", () => {
+    const { deps: d } = deps([reg({ name: "party-dead" })], { servers: { "/cfg/party-dead.json": null } });
+    const plan = planMcpMigrate(d);
+    expect(plan.legacy).toHaveLength(0);
+    expect(plan.skipped[0]!.reason).toContain("prune");
+  });
+
+  test("已有 --all-channels 的 harness 记进 alreadySingle，且那条不算 legacy", () => {
+    const { deps: d } = deps([reg({ name: "party", args: ["mcp", "--all-channels"], env: {} }), reg({ name: "party-a" })]);
+    const plan = planMcpMigrate(d);
+    expect([...plan.alreadySingle]).toEqual(["codex"]);
+    expect(plan.legacy.map((l) => l.reg.name)).toEqual(["party-a"]);
+  });
+
+  test("不是 party 的注册一概不碰", () => {
+    const { deps: d } = deps([reg({ name: "figma", command: "npx", args: ["figma-mcp"] })]);
+    const plan = planMcpMigrate(d);
+    expect(plan.legacy).toHaveLength(0);
+    expect(plan.skipped).toHaveLength(0);
+  });
+});
+
+describe("runMcpMigrate —— 顺序与失败关闭", () => {
+  test("正常路径：先记默认、再删旧、最后每个 harness 加一条；默认身份就是旧注册用的那份", () => {
+    const { deps: d, trace } = deps([
+      reg({ name: "party-a" }),
+      reg({ name: "party-c", harness: "claude", codexHome: undefined, args: ["mcp", "--channel", "web"] }),
+    ]);
+    const lines: string[] = [];
+    const r = runMcpMigrate(planMcpMigrate(d), d, (l) => lines.push(l));
+    expect(r.code).toBe(0);
+    expect(trace.defaults).toEqual([
+      ["https://s1", "dev", "/cfg/party-a.json"],
+      ["https://s1", "web", "/cfg/party-c.json"],
+    ]);
+    expect(trace.removed).toEqual(["party-a", "party-c"]);
+    expect(trace.added.sort()).toEqual(["claude", "codex"]);
+    expect(r.moved).toHaveLength(2);
+  });
+
+  test("记默认失败 ⇒ 那条不删（否则频道从「能用」变「歧义」）", () => {
+    const { deps: d, trace } = deps([reg({ name: "party-a" })], {
+      recordDefault: () => {
+        throw new Error("disk full");
+      },
+    });
+    const r = runMcpMigrate(planMcpMigrate(d), d, () => undefined);
+    expect(trace.removed).toEqual([]);
+    expect(r.failed[0]).toMatchObject({ step: "default" });
+    expect(trace.added).toEqual([]); // 一条都没迁成，就不加新的
+    expect(r.code).toBe(0);
+  });
+
+  test("已经有 --all-channels 的 harness 不重复加", () => {
+    const { deps: d, trace } = deps([reg({ name: "party", args: ["mcp", "--all-channels"], env: {} }), reg({ name: "party-a" })]);
+    const r = runMcpMigrate(planMcpMigrate(d), d, () => undefined);
+    expect(r.code).toBe(0);
+    expect(trace.removed).toEqual(["party-a"]);
+    expect(trace.added).toEqual([]);
+  });
+
+  // 这条是整个模块最重要的断言：旧的删了、新的没加上 ⇒ 所有 agent 一起静默失联。必须非零退出、
+  // 必须把手工命令印出来。
+  test("新注册加不上 ⇒ 退出码非 0，并印出手工加回的命令", () => {
+    const { deps: d } = deps([reg({ name: "party-a" })], {
+      addSingle: () => ({ ok: false, detail: "codex: command not found" }),
+    });
+    const lines: string[] = [];
+    const r = runMcpMigrate(planMcpMigrate(d), d, (l) => lines.push(l));
+    expect(r.code).toBe(1);
+    expect(r.addFailed[0]!.harness).toBe("codex");
+    expect(lines.join("\n")).toContain("codex mcp add party -- party mcp --all-channels");
+  });
+});
+
+describe("maybeAutoMigrate —— 一次性、失败限频、进程内路径不触发", () => {
+  function home(): string {
+    return mkdtempSync(join(tmpdir(), "ap-migrate-"));
+  }
+
+  test("有旧注册 ⇒ 迁移并写 done 标记；再调一次不再动", () => {
+    const h = home();
+    const { deps: d, trace } = deps([reg({ name: "party-a" })]);
+    const errs: string[] = [];
+    const first = maybeAutoMigrate("who", { deps: d, agentpartyHome: h, errlog: (l) => errs.push(l) });
+    expect(first.ran).toBe(true);
+    expect(trace.removed).toEqual(["party-a"]);
+    expect(JSON.parse(readFileSync(migrateMarkerPath(h), "utf8")).status).toBe("done");
+    expect(errs.join("\n")).toContain("下次新开的会话生效");
+    expect(migrationDone(h)).toBe(true);
+
+    const second = maybeAutoMigrate("who", { deps: d, agentpartyHome: h });
+    expect(second.ran).toBe(false);
+    expect(trace.removed).toEqual(["party-a"]); // 没再删
+    rmSync(h, { recursive: true, force: true });
+  });
+
+  test("没有旧注册 ⇒ 写 nothing 标记，之后连注册表都不再读", () => {
+    const h = home();
+    let reads = 0;
+    const { deps: d } = deps([], { registrations: () => (reads += 1, []) });
+    expect(maybeAutoMigrate("who", { deps: d, agentpartyHome: h }).ran).toBe(false);
+    expect(reads).toBe(1);
+    maybeAutoMigrate("who", { deps: d, agentpartyHome: h });
+    expect(reads).toBe(1);
+    rmSync(h, { recursive: true, force: true });
+  });
+
+  test("mcp / hook / serve 这些进程内入口绝不触发", () => {
+    const h = home();
+    let reads = 0;
+    const { deps: d } = deps([reg({ name: "party-a" })], { registrations: () => (reads += 1, [reg({ name: "party-a" })]) });
+    for (const cmd of ["mcp", "hook", "serve", "daemon", "watch"]) {
+      expect(maybeAutoMigrate(cmd, { deps: d, agentpartyHome: h }).ran).toBe(false);
+    }
+    expect(reads).toBe(0);
+    rmSync(h, { recursive: true, force: true });
+  });
+
+  test("失败后 24h 内不再自动重试，过了再试", () => {
+    const h = home();
+    writeMigrateMarkerForTest(h, { status: "failed", at: NOW - 60_000 });
+    const { deps: d, trace } = deps([reg({ name: "party-a" })]);
+    expect(maybeAutoMigrate("who", { deps: d, agentpartyHome: h }).ran).toBe(false);
+    expect(trace.removed).toEqual([]);
+
+    writeMigrateMarkerForTest(h, { status: "failed", at: NOW - 25 * 60 * 60 * 1000 });
+    expect(maybeAutoMigrate("who", { deps: d, agentpartyHome: h }).ran).toBe(true);
+    rmSync(h, { recursive: true, force: true });
+  });
+
+  test("读注册表炸了（harness 没装 / 文件坏）⇒ 安静返回，不写标记，下次再看", () => {
+    const h = home();
+    const { deps: d } = deps([], {
+      registrations: () => {
+        throw new Error("boom");
+      },
+    });
+    expect(maybeAutoMigrate("who", { deps: d, agentpartyHome: h }).ran).toBe(false);
+    expect(migrationDone(h)).toBe(false);
+    rmSync(h, { recursive: true, force: true });
+  });
+});
+
+// owner 那台机器的真实情况：#bug-7744 与 #welcome 各有两条旧注册、两份不同身份。迁移时按顺序
+// 写默认等于最后一条赢——那是替人选身份。这种频道不设默认，让 --all-channels 失败关闭并列候选。
+describe("同一频道多份不同身份的旧注册 ⇒ 不设默认", () => {
+  test("两份不同身份：都删、都不记默认、给一条提示；单身份的频道照常记", () => {
+    const { deps: d, trace } = deps([
+      reg({ name: "party-a1", args: ["mcp", "--channel", "dup"], env: { AGENTPARTY_CONFIG: "/cfg/a1.json" } }),
+      reg({ name: "party-a2", args: ["mcp", "--channel", "dup"], env: { AGENTPARTY_CONFIG: "/cfg/a2.json" } }),
+      reg({ name: "party-solo", args: ["mcp", "--channel", "solo"] }),
+    ]);
+    const lines: string[] = [];
+    const r = runMcpMigrate(planMcpMigrate(d), d, (l) => lines.push(l));
+    expect(r.code).toBe(0);
+    expect(trace.removed.sort()).toEqual(["party-a1", "party-a2", "party-solo"]);
+    expect(trace.defaults).toEqual([["https://s1", "solo", "/cfg/party-solo.json"]]);
+    expect(lines.filter((l) => l.includes("不设默认"))).toHaveLength(1);
+  });
+
+  test("两条旧注册指向**同一份**身份（重复注册）⇒ 不算多身份，照常记默认", () => {
+    const { deps: d, trace } = deps([
+      reg({ name: "party-x", args: ["mcp", "--channel", "dup"], env: { AGENTPARTY_CONFIG: "/cfg/same.json" } }),
+      reg({ name: "party-y", args: ["mcp", "--channel", "dup"], env: { AGENTPARTY_CONFIG: "/cfg/same.json" } }),
+    ]);
+    runMcpMigrate(planMcpMigrate(d), d, () => undefined);
+    expect(trace.defaults.map((x) => x[1])).toEqual(["dup", "dup"]);
+  });
+});

--- a/cli/test/mcp-migrate.test.ts
+++ b/cli/test/mcp-migrate.test.ts
@@ -81,8 +81,20 @@ function deps(initial: McpRegistration[], knobs: Knobs = {}): { deps: MigrateDep
       trace.added.push(h);
       trace.order.push(`add:${h}`);
       const lands = addLands ?? "global";
-      if (lands === "global") registry.push(single(h));
+      const s = single(h);
+      const sameKey = registry.findIndex((x) => (x.harness ?? "claude") === h && x.scope === s.scope && x.name === s.name);
+      if (lands === "global") {
+        // 真机行为：codex 同名 add **覆盖**；claude 同名 add 拒绝（"already exists"）但退出码 0。
+        if (sameKey !== -1) {
+          if (h === "codex") registry[sameKey] = s;
+        } else registry.push(s);
+      }
       if (lands === "project") registry.push(single(h, h === "codex" ? { scope: "/proj/.codex/config.toml", codexHome: "/proj/.codex" } : { scope: "/proj" }));
+      return { ok: true, detail: "" };
+    },
+    addBack: (r) => {
+      trace.order.push(`addBack:${r.name}`);
+      registry.push(r);
       return { ok: true, detail: "" };
     },
     now: () => NOW,
@@ -314,3 +326,78 @@ describe("maybeAutoMigrate —— 一次性、失败限频、进程内路径不�
     rmSync(h, { recursive: true, force: true });
   });
 });
+
+// codex stop-time review on a998ba9：旧注册若恰好也叫 `party`（早期文档就是这么教的），
+// 「先加后删」会变成 add 覆盖旧的、remove 按名字把新的一起删掉。真机核实：codex 同名 add 覆盖，
+// claude 同名 add 拒绝但退出码 0。所以同名冲突要「删旧 → 加新 → 读回；加不上就原样加回」。
+describe("同名冲突：旧注册就叫 party", () => {
+  const codexCollision = reg({ name: "party", args: ["mcp", "--channel", "king", "--identity", "king-codex"], env: { AGENTPARTY_CONFIG: "/cfg/king.json" } });
+  const claudeCollision = reg({ name: "party", harness: "claude", scope: "user", codexHome: undefined, args: ["mcp", "--channel", "king"], env: { AGENTPARTY_CONFIG: "/cfg/king.json" } });
+
+  test("codex：先删同名旧的、再加新的、不再按名字删第二次；最后只剩新的", () => {
+    const { deps: d, trace, registry } = deps([codexCollision, reg({ name: "party-other", args: ["mcp", "--channel", "ops"] })]);
+    const r = runMcpMigrate(planMcpMigrate(d), d, () => undefined);
+    expect(r.code).toBe(0);
+    expect(trace.order).toEqual(["remove:party", "add:codex", "remove:party-other"]);
+    expect(registry.map((x) => `${x.name}:${x.args.join(" ")}`)).toEqual(["party:mcp --all-channels"]);
+    expect(r.moved.map((m) => m.reg.name).sort()).toEqual(["party", "party-other"]);
+    expect(trace.defaults).toEqual([["https://s1", "king", "/cfg/king.json"], ["https://s1", "ops", "/cfg/party-other.json"]]);
+  });
+
+  test("claude：同名 user 级旧注册同样先删再加（直接 add 会被『already exists』顶住）", () => {
+    const { deps: d, trace, registry } = deps([claudeCollision]);
+    const r = runMcpMigrate(planMcpMigrate(d), d, () => undefined);
+    expect(r.code).toBe(0);
+    expect(trace.order).toEqual(["remove:party", "add:claude"]);
+    expect(registry).toHaveLength(1);
+    expect(registry[0]!.args).toEqual(["mcp", "--all-channels"]);
+  });
+
+  test("删了同名旧的但新的加不上 ⇒ 立刻把旧的原样加回、退出码非 0、印手工命令", () => {
+    const { deps: d, trace, registry } = deps([codexCollision], { addSingle: () => ({ ok: false, detail: "codex: boom" }) });
+    const lines: string[] = [];
+    const r = runMcpMigrate(planMcpMigrate(d), d, (l) => lines.push(l));
+    expect(r.code).toBe(1);
+    expect(trace.order).toEqual(["remove:party", "addBack:party"]);
+    expect(registry.map((x) => x.args.join(" "))).toEqual(["mcp --channel king --identity king-codex"]); // 一切照旧
+    expect(lines.join("\n")).toContain("原样加回");
+    expect(lines.join("\n")).toContain("codex mcp add party -- party mcp --all-channels");
+  });
+
+  test("同名旧的删不掉 ⇒ 该 harness 一条都不动，非零退出", () => {
+    const { deps: d, trace, registry } = deps([codexCollision, reg({ name: "party-other" })], { removeLies: true });
+    const r = runMcpMigrate(planMcpMigrate(d), d, () => undefined);
+    expect(r.code).toBe(1);
+    expect(trace.added).toEqual([]);
+    expect(registry).toHaveLength(2);
+  });
+
+  test("项目级（local）叫 party 的旧注册不算冲突：scope 不同，按 local 删掉，user 级新的留着", () => {
+    const local = reg({ name: "party", harness: "claude", scope: "/proj/x", codexHome: undefined, args: ["mcp", "--channel", "dev"] });
+    const { deps: d, registry } = deps([local]);
+    const r = runMcpMigrate(planMcpMigrate(d), d, () => undefined);
+    expect(r.code).toBe(0);
+    expect(registry.map((x) => `${x.scope}:${x.args.join(" ")}`)).toEqual(["user:mcp --all-channels"]);
+  });
+});
+
+describe("收尾读回：删旧时单注册被连带删掉 ⇒ 自愈重加", () => {
+  test("remove 连新的一起删了 ⇒ 结束前发现并重加；重加失败则非零退出", () => {
+    // 模拟：删 party-a 时 harness CLI 连 user 级 party 也删了
+    const { deps: d, trace, registry } = deps([reg({ name: "party-a" })]);
+    const originalRemove = d.remove;
+    d.remove = (r) => {
+      const res = originalRemove(r);
+      const i = registry.findIndex((x) => x.name === "party");
+      if (i !== -1) registry.splice(i, 1);
+      return res;
+    };
+    const lines: string[] = [];
+    const r = runMcpMigrate(planMcpMigrate(d), d, (l) => lines.push(l));
+    expect(r.code).toBe(0);
+    expect(trace.added).toEqual(["codex", "codex"]); // 第二次是自愈
+    expect(registry.map((x) => x.name)).toEqual(["party"]);
+    expect(lines.join("\n")).toContain("已重新加回");
+  });
+});
+

--- a/cli/test/mcp-migrate.test.ts
+++ b/cli/test/mcp-migrate.test.ts
@@ -401,3 +401,48 @@ describe("收尾读回：删旧时单注册被连带删掉 ⇒ 自愈重加", ()
   });
 });
 
+
+// codex stop-time review on a40b60f：用户可能有一个恰好叫 party 的**别的** MCP 服务。
+// 它不是我们的：不能删、不能被同名 add 覆盖（codex 的 add 是覆盖语义）。失败关闭并给换名的出路。
+describe("同名的非 AgentParty MCP 注册：不动它", () => {
+  const foreignCodex: McpRegistration = { scope: "/home/.codex/config.toml", name: "party", command: "npx", args: ["some-other-mcp"], env: {}, harness: "codex", codexHome: GLOBAL_CODEX };
+  const foreignClaude: McpRegistration = { scope: "user", name: "party", command: "npx", args: ["some-other-mcp"], env: {}, harness: "claude" };
+
+  test("collidesWithSingle 对外人恒 false", async () => {
+    const { collidesWithSingle } = await import("../src/commands/mcp-migrate");
+    expect(collidesWithSingle(foreignCodex, GLOBAL_CODEX)).toBe(false);
+    expect(collidesWithSingle(foreignClaude, GLOBAL_CODEX)).toBe(false);
+  });
+
+  test("runMcpMigrate：名字被外人占着 ⇒ 不 add、不删旧、非零退出、出路是换名注册", () => {
+    const { deps: d, trace, registry } = deps([foreignCodex, reg({ name: "party-a" })]);
+    const lines: string[] = [];
+    const r = runMcpMigrate(planMcpMigrate(d), d, (l) => lines.push(l));
+    expect(r.code).toBe(1);
+    expect(trace.added).toEqual([]);
+    expect(trace.removed).toEqual([]);
+    expect(registry).toHaveLength(2); // 外人与旧注册都原样在
+    expect(lines.join("\n")).toContain("codex mcp add agentparty -- party mcp --all-channels");
+  });
+
+  test("ensureMachineWideSingle：名字被外人占着 ⇒ 失败关闭，不删不加", async () => {
+    const { ensureMachineWideSingle } = await import("../src/commands/mcp-migrate");
+    const { deps: d, trace, registry } = deps([foreignClaude]);
+    const r = ensureMachineWideSingle("claude", d);
+    expect(r.ok).toBe(false);
+    if (r.ok) throw new Error("unreachable");
+    expect(r.remedy).toContain("claude mcp add --scope user agentparty -- party mcp --all-channels");
+    expect(trace.added).toEqual([]);
+    expect(trace.removed).toEqual([]);
+    expect(registry).toEqual([foreignClaude]);
+  });
+
+  test("换名注册的 --all-channels 同样算覆盖：检测看命令与参数，不看名字", async () => {
+    const { ensureMachineWideSingle } = await import("../src/commands/mcp-migrate");
+    const alt: McpRegistration = { scope: "user", name: "agentparty", command: "party", args: ["mcp", "--all-channels"], env: {}, harness: "claude" };
+    const { deps: d, trace } = deps([foreignClaude, alt]);
+    const r = ensureMachineWideSingle("claude", d);
+    expect(r.ok && r.action).toBe("present");
+    expect(trace.added).toEqual([]);
+  });
+});

--- a/plugins/agentparty/skills/agentparty/SKILL.md
+++ b/plugins/agentparty/skills/agentparty/SKILL.md
@@ -105,14 +105,20 @@ If your harness can use MCP tools, prefer the local stdio server after configura
 # The name probe below only catches a same-named registration — a new identity name always
 # slips through, which is how one channel silently accumulated 14 identities (#907).
 party mcp identities --channel <slug> --server <server> --exclude <agent-name> || true
-# probe first — every registration becomes one resident process in every session (#898)
-claude mcp get party-<agent-name> >/dev/null 2>&1 \
-  || claude mcp add party-<agent-name> --env AGENTPARTY_CONFIG="$HOME/.agentparty/agents/<config>.json" \
-       -- party mcp --channel <slug> --identity party-<agent-name>
+# ONE registration serves every channel on this machine (#1083). Probe first — each
+# registration is one resident process in every session (#898); never add per channel.
+claude mcp get party >/dev/null 2>&1 \
+  || claude mcp add --scope user party -- party mcp --all-channels
+# codex: codex mcp get party >/dev/null 2>&1 || codex mcp add party -- party mcp --all-channels
+# Tools take `channel` per call; the identity is resolved per channel from
+# ~/.agentparty/agents (the join above recorded this identity as that channel's default).
+# Old per-channel registrations (`party mcp --channel <slug>`) are folded in automatically
+# by `party mcp migrate` the first time any interactive party command runs after upgrade.
 ```
 
-`--identity` is a cosmetic argv label so `ps -axww` shows whose server a process is; it never
-affects which identity is used (that is always `AGENTPARTY_CONFIG`).
+`--identity <label>` (optional) is a cosmetic argv label so `ps -axww` shows whose server a
+process is; it never affects which identity is used. With `--all-channels` the identity comes
+from the per-call `channel` (and optional `identity`) argument, not from the registration.
 
 Registrations accumulate: one machine reached 127 resident `party` processes because every
 onboarding added another server and nobody cleaned up. `party mcp prune` lists (and with

--- a/skills/agentparty/SKILL.md
+++ b/skills/agentparty/SKILL.md
@@ -105,14 +105,20 @@ If your harness can use MCP tools, prefer the local stdio server after configura
 # The name probe below only catches a same-named registration — a new identity name always
 # slips through, which is how one channel silently accumulated 14 identities (#907).
 party mcp identities --channel <slug> --server <server> --exclude <agent-name> || true
-# probe first — every registration becomes one resident process in every session (#898)
-claude mcp get party-<agent-name> >/dev/null 2>&1 \
-  || claude mcp add party-<agent-name> --env AGENTPARTY_CONFIG="$HOME/.agentparty/agents/<config>.json" \
-       -- party mcp --channel <slug> --identity party-<agent-name>
+# ONE registration serves every channel on this machine (#1083). Probe first — each
+# registration is one resident process in every session (#898); never add per channel.
+claude mcp get party >/dev/null 2>&1 \
+  || claude mcp add --scope user party -- party mcp --all-channels
+# codex: codex mcp get party >/dev/null 2>&1 || codex mcp add party -- party mcp --all-channels
+# Tools take `channel` per call; the identity is resolved per channel from
+# ~/.agentparty/agents (the join above recorded this identity as that channel's default).
+# Old per-channel registrations (`party mcp --channel <slug>`) are folded in automatically
+# by `party mcp migrate` the first time any interactive party command runs after upgrade.
 ```
 
-`--identity` is a cosmetic argv label so `ps -axww` shows whose server a process is; it never
-affects which identity is used (that is always `AGENTPARTY_CONFIG`).
+`--identity <label>` (optional) is a cosmetic argv label so `ps -axww` shows whose server a
+process is; it never affects which identity is used. With `--all-channels` the identity comes
+from the per-call `channel` (and optional `identity`) argument, not from the registration.
 
 Registrations accumulate: one machine reached 127 resident `party` processes because every
 onboarding added another server and nobody cleaned up. `party mcp prune` lists (and with


### PR DESCRIPTION
#1083 的最后一块：**老用户怎么办**。新模型是一条注册服务所有频道，但老用户机器上躺着的旧注册不会自己消失，也不能指望他们记得跑一条命令。owner 那台机器实测：Claude Code 里 26 条、codex 里 5 条。

## 自动触发
交互式 `party` 命令启动时跑一次（一次性标记；失败 24h 后再试；`mcp`/`hook`/`serve` 等 harness 拉起的进程内入口**不触发**——不该在那里改 harness 的配置）。也有手动入口 `party mcp migrate [--dry-run|--yes]`，dry-run 是缺省。

## 三步，顺序不能反
1. 每条旧注册**正在用的那份身份** → 记为该频道的本机默认。这一步保住老用户原来的身份：迁移后 `--all-channels` 在这些频道上零歧义，行为一字不变。
2. 用 harness 自己的 `codex mcp remove` / `claude mcp remove` 删旧（不手改 TOML/JSON）。
3. 每个涉及的 harness 加一条 `party mcp --all-channels`（已有就不重复加）。

## 失败关闭
- 记默认失败 ⇒ 那条不删（否则频道从「能用」变「歧义」）
- 新注册加不上 ⇒ **非零退出 + 印出手工命令**。旧的删了、新的没加上 = 所有 agent 一起静默失联，这是整个模块最重要的断言
- 同一频道多条旧注册且指向**不同**身份 ⇒ 不设默认，迁移后按调用解析会失败关闭并列候选——让人选，不替人选。owner 机器上 `#bug-7744` `#welcome` `#kyc` 等 7 个频道就是这种情况
- config 读不出的旧注册（TMPDIR 被清）不在这里删，交给 `party mcp prune`

## 真机验证
- 临时 `CODEX_HOME` 造一条旧注册 → `--yes` 后 `codex mcp list` 只剩 `party  mcp --all-channels`，默认表记下 `king → 原 config`
- owner 机器 Claude Code 的 26 条已实际迁移：`claude mcp list` 只剩一条 `party` 且 ✔ Connected；`seamail` 自动解到原身份 `leo-zego-im`；`welcome`（4 份身份）失败关闭列候选
- 单测 17/0

## 与前几个 PR 的关系
#1084 单注册多频道 → #1086 join 记默认 → 本 PR 老用户迁移。三块合起来，用户侧的体验是：升级后第一次跑 `party`，看到一行「已合并成一条注册」，之后加入任何新频道都不用再动配置。

https://claude.ai/code/session_01HUmERHTXnbZhCZCwV6fGxD
