### PR TITLE
fix(cli): 自动迁移每次都看注册表，标记只限频失败重试（#1083）

### DIFF
--- a/cli/src/commands/mcp-migrate.ts
+++ b/cli/src/commands/mcp-migrate.ts
@@ -519,7 +519,9 @@ export function maybeAutoMigrate(
   const errlog = opts.errlog ?? ((line: string) => console.error(line));
   const marker = readMarker(markerPath);
   const now = deps.now();
-  if (marker !== null && marker.status !== "failed") return { ran: false };
+  // 标记**只用来限频失败重试**，不用来「做过一次就永不再看」：codex 的项目级注册表是按 cwd 往上找的，
+  // 在别的目录跑时看不见——owner 机器上就有一条项目级旧注册在标记写下「done」之后才被发现，
+  // 之后再也没人替它迁。读两个注册表只是几次文件读取，每次交互式命令都做一遍是划算的。
   if (marker !== null && marker.status === "failed" && now - marker.at < RETRY_AFTER_MS) return { ran: false };
 
   let plan: MigratePlan;
@@ -530,7 +532,8 @@ export function maybeAutoMigrate(
     return { ran: false };
   }
   if (plan.legacy.length === 0) {
-    writeMarker(markerPath, { status: "nothing", at: now });
+    // 没东西可迁就什么都不写：留着 failed 标记也没意义（下次有东西时照常试）。
+    if (marker?.status === "failed") writeMarker(markerPath, { status: "nothing", at: now });
     return { ran: false };
   }
   errlog(

--- a/cli/test/mcp-migrate.test.ts
+++ b/cli/test/mcp-migrate.test.ts
@@ -263,7 +263,7 @@ describe("maybeAutoMigrate —— 一次性、失败限频、进程内路径不�
     return mkdtempSync(join(tmpdir(), "ap-migrate-"));
   }
 
-  test("有旧注册 ⇒ 迁移并写 done 标记；再调一次不再动", () => {
+  test("有旧注册 ⇒ 迁移并写 done 标记；再调一次时注册表已空，不再动", () => {
     const h = home();
     const { deps: d, trace } = deps([reg({ name: "party-a" })]);
     const errs: string[] = [];
@@ -280,14 +280,25 @@ describe("maybeAutoMigrate —— 一次性、失败限频、进程内路径不�
     rmSync(h, { recursive: true, force: true });
   });
 
-  test("没有旧注册 ⇒ 写 nothing 标记，之后连注册表都不再读", () => {
+  // 标记不再是「做过一次就永不再看」：codex 项目级注册表按 cwd 往上找，在别的目录跑时看不见，
+  // owner 机器上就有一条项目级旧注册在标记写下 done 之后才被发现。每次都读（几次文件读取），有就迁。
+  test("done 之后又出现旧注册（比如换到有项目级 codex 注册的目录）⇒ 照样迁", () => {
+    const h = home();
+    writeMigrateMarkerForTest(h, { status: "done", at: NOW - 60_000 });
+    const { deps: d, trace } = deps([reg({ name: "party-late" })]);
+    expect(maybeAutoMigrate("who", { deps: d, agentpartyHome: h }).ran).toBe(true);
+    expect(trace.removed).toEqual(["party-late"]);
+    rmSync(h, { recursive: true, force: true });
+  });
+
+  test("没有旧注册 ⇒ 每次都会读一遍注册表（便宜），不动任何东西", () => {
     const h = home();
     let reads = 0;
     const { deps: d } = deps([], { registrations: () => (reads += 1, []) });
     expect(maybeAutoMigrate("who", { deps: d, agentpartyHome: h }).ran).toBe(false);
-    expect(reads).toBe(1);
     maybeAutoMigrate("who", { deps: d, agentpartyHome: h });
-    expect(reads).toBe(1);
+    expect(reads).toBe(2);
+    expect(migrationDone(h)).toBe(false); // 没写标记
     rmSync(h, { recursive: true, force: true });
   });
 


### PR DESCRIPTION
v0.2.262 装机后在真机上发现的缺口：自动迁移的标记是「做过一次就永不再看」，但 codex 的**项目级** `config.toml` 是按 cwd 往上找的，在别的目录跑时看不见。我这台机器上 `~/github.com/agentparty/.codex/config.toml` 里的 `party-claude-test` 就是在标记写下 `done` 之后才被发现的，此后再也没人替它迁，只能手工 `party mcp migrate --yes`。

改法：每次交互式命令都读一遍两个注册表（几次文件读取，便宜），有就迁；没东西可迁什么都不写；`failed` 标记仍然 24h 内不重试。

测试：`done` 之后又出现旧注册 ⇒ 照样迁；没有旧注册 ⇒ 每次都读、不写标记。migrate 相关 85/0。

https://claude.ai/code/session_01HUmERHTXnbZhCZCwV6fGxD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改进**
  - 自动迁移现在会在每次交互式命令启动时重新检查注册信息，后续发现符合条件的迁移内容时仍可执行迁移。
  - 失败状态仅在 24 小时内限制重试，避免永久跳过后续迁移机会。
  - 没有可迁移内容时，不再默认写入永久性“无迁移”标记。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->