### PR TITLE
feat(plugin,cli): 插件自带的 MCP 改为 --all-channels，装了插件的机器不再多起一个 party 进程 (#1089)

### DIFF
--- a/cli/src/commands/mcp-migrate.ts
+++ b/cli/src/commands/mcp-migrate.ts
@@ -16,7 +16,7 @@
 //
 // 触发：任何交互式 `party` 命令启动时（不含 mcp/hook/serve 这些进程内路径）检查一次，
 // 一次性标记；也提供 `party mcp migrate [--dry-run|--yes]` 让人先看再动。
-import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { mkdirSync, readdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
@@ -43,6 +43,8 @@ export interface LegacyRegistration {
 export interface MigratePlan {
   /** 要迁走的旧式注册：有 --channel、有 AGENTPARTY_CONFIG、config 读得出 server。 */
   legacy: LegacyRegistration[];
+  /** #1089：插件已提供 --all-channels 时多余的 `party` 单注册，要收掉。 */
+  redundant: McpRegistration[];
   /** party 的注册但不动它：说明为什么。 */
   skipped: { reg: McpRegistration; reason: string }[];
   /** 已经有 --all-channels 注册的 harness。 */
@@ -61,7 +63,47 @@ export interface MigrateDeps {
   addSingle: (harness: RegistrationHarness) => { ok: boolean; detail: string };
   /** 回滚：把一条刚删掉的旧注册按原 scope / args / env 原样加回去。 */
   addBack: (reg: McpRegistration) => { ok: boolean; detail: string };
+  /**
+   * #1089：AgentParty 插件（claude / codex）自带的 MCP 是否已是 --all-channels。插件注册不在
+   * ~/.claude.json / config.toml 里（随插件提供），注册表读不到；但它同样是一条覆盖整台机器的单注册。
+   */
+  pluginCovers: (harness: RegistrationHarness) => boolean;
   now: () => number;
+}
+
+function manifestHasAllChannels(path: string): boolean {
+  const raw = readJson(path) as { mcpServers?: Record<string, { command?: unknown; args?: unknown }> } | undefined;
+  if (raw === undefined || raw === null || typeof raw !== "object") return false;
+  return Object.values(raw.mcpServers ?? {}).some((srv) => {
+    if (typeof srv?.command !== "string" || !Array.isArray(srv.args)) return false;
+    const base = srv.command.split("/").pop() ?? "";
+    return (base === "party" || base === "agentparty-runtime") && srv.args[0] === "mcp" && srv.args.includes("--all-channels");
+  });
+}
+
+/** 真机判定：读 harness 自己的插件安装记录 / 缓存，看装着的 AgentParty 插件的 MCP 是不是 --all-channels。 */
+export function defaultPluginCovers(home: string = homedir()): (harness: RegistrationHarness) => boolean {
+  return (harness) => {
+    try {
+      if (harness === "claude") {
+        const installed = readJson(join(home, ".claude", "plugins", "installed_plugins.json")) as
+          | { plugins?: Record<string, { scope?: string; installPath?: string }[]> }
+          | undefined;
+        for (const [key, entries] of Object.entries(installed?.plugins ?? {})) {
+          if (!key.startsWith("agentparty@")) continue;
+          for (const e of entries ?? []) {
+            if (typeof e.installPath === "string" && manifestHasAllChannels(join(e.installPath, "claude-mcp.json"))) return true;
+          }
+        }
+        return false;
+      }
+      const cacheDir = join(home, ".codex", "plugins", "cache", "agentparty", "agentparty");
+      const versions = readdirSync(cacheDir).filter((v) => /^\d+\.\d+\.\d+$/.test(v));
+      return versions.some((v) => manifestHasAllChannels(join(cacheDir, v, ".mcp.json")));
+    } catch {
+      return false;
+    }
+  };
 }
 
 /** 这条旧注册与单注册同名同 scope：加新会覆盖它（codex）或被它顶住（claude），删它会连新的一起删。 */
@@ -161,6 +203,7 @@ export function defaultMigrateDeps(home: string = homedir(), spawn: typeof spawn
       if (res.status !== 0) return { ok: false, detail: (res.stderr ?? "").trim() || (res.stdout ?? "").trim() || `exit ${String(res.status)}` };
       return { ok: true, detail: (res.stdout ?? "").trim() };
     },
+    pluginCovers: defaultPluginCovers(home),
     now: () => Date.now(),
   };
 }
@@ -172,7 +215,8 @@ export function planMcpMigrate(deps: MigrateDeps): MigratePlan {
   const legacy: LegacyRegistration[] = [];
   const skipped: MigratePlan["skipped"] = [];
   const alreadySingle = new Set<RegistrationHarness>();
-  for (const reg of deps.registrations()) {
+  const all = deps.registrations();
+  for (const reg of all) {
     if (!isPartyMcpRegistration(reg)) continue;
     const harness = registrationHarness(reg);
     if (isSingleRegistration(reg)) {
@@ -199,7 +243,7 @@ export function planMcpMigrate(deps: MigrateDeps): MigratePlan {
     }
     legacy.push({ reg, harness, channel, configPath, server });
   }
-  return { legacy, skipped, alreadySingle };
+  return { legacy, skipped, alreadySingle, redundant: redundantSingles(deps, all) };
 }
 
 export interface MigrateResult {
@@ -228,7 +272,16 @@ function foreignRemedy(harness: RegistrationHarness, foreign: McpRegistration): 
 }
 
 function hasMachineWideSingle(deps: MigrateDeps, harness: RegistrationHarness): boolean {
+  if (deps.pluginCovers(harness)) return true;
   return deps.registrations().some((r) => registrationHarness(r) === harness && isMachineWideSingle(r, deps.globalCodexHome));
+}
+
+/** 插件已提供 --all-channels 时，我们自己加的那条 `party` 单注册就是多余的一个进程（#1089）。 */
+function redundantSingles(deps: MigrateDeps, all: McpRegistration[]): McpRegistration[] {
+  return all.filter((r) => {
+    const harness = registrationHarness(r);
+    return deps.pluginCovers(harness) && isMachineWideSingle(r, deps.globalCodexHome) && r.name === SINGLE_NAME;
+  });
 }
 
 function stillRegistered(deps: MigrateDeps, reg: McpRegistration): boolean {
@@ -280,8 +333,8 @@ export function runMcpMigrate(plan: MigratePlan, deps: MigrateDeps, log: (line: 
   const covered = new Set<RegistrationHarness>();
   const replaced = new Set<McpRegistration>();
   for (const harness of harnesses) {
-    if (plan.alreadySingle.has(harness)) {
-      covered.add(harness);
+    if (plan.alreadySingle.has(harness) || deps.pluginCovers(harness)) {
+      covered.add(harness); // 注册表里已有，或插件自带 --all-channels（#1089）：都不用再加
       continue;
     }
     const foreign = foreignSameKey(deps, harness);
@@ -399,6 +452,17 @@ export function runMcpMigrate(plan: MigratePlan, deps: MigrateDeps, log: (line: 
       addFailed.push({ harness, detail: "删旧注册后单条注册消失，重加失败" });
       log(`  ✗ ${harness}：删旧注册后单条注册消失，重加失败——现在没有 party，请立刻手工加：`);
       log(manualAdd(harness));
+    }
+  }
+  // 4) #1089：插件已提供 --all-channels ⇒ 我们自己那条 `party` 是多余的一个进程，收掉（读回验证）。
+  for (const r of plan.redundant) {
+    const harness = registrationHarness(r);
+    const removed = deps.remove(r);
+    if (removed.ok && !stillRegistered(deps, r)) {
+      log(`  ✓ ${harness}：插件已自带 \`party mcp --all-channels\`，多余的单注册 ${r.name} 已收掉`);
+    } else {
+      failed.push({ reg: r, step: "remove", detail: removed.ok ? "命令返回 0，但读回注册表时它还在" : removed.detail });
+      log(`  ! ${harness}：多余的单注册 ${r.name} 没删掉（${removed.ok ? "读回还在" : removed.detail}），多留一个进程而已`);
     }
   }
   return { code: addFailed.length > 0 ? 1 : 0, moved, failed, added, addFailed };
@@ -531,7 +595,7 @@ export function maybeAutoMigrate(
     // 读注册表都炸了（harness 没装 / 文件坏）：不打扰，下次再看。
     return { ran: false };
   }
-  if (plan.legacy.length === 0) {
+  if (plan.legacy.length === 0 && plan.redundant.length === 0) {
     // 没东西可迁就什么都不写：留着 failed 标记也没意义（下次有东西时照常试）。
     if (marker?.status === "failed") writeMarker(markerPath, { status: "nothing", at: now });
     return { ran: false };
@@ -572,7 +636,7 @@ export async function runMigrateCli(argv: string[], deps: MigrateDeps = defaultM
   }
   const yes = argv.includes("--yes");
   const plan = planMcpMigrate(deps);
-  if (plan.legacy.length === 0) {
+  if (plan.legacy.length === 0 && plan.redundant.length === 0) {
     console.log("没有旧式「一频道一注册」的 party 注册，无需迁移。");
     for (const s of plan.skipped) console.log(`  · 跳过 ${s.reg.name}：${s.reason}`);
     return 0;
@@ -580,6 +644,7 @@ export async function runMigrateCli(argv: string[], deps: MigrateDeps = defaultM
   console.log(`${yes ? "迁移" : "计划迁移"} ${plan.legacy.length} 条旧注册：`);
   for (const l of plan.legacy) console.log(`  · ${l.harness}  ${l.reg.name}  #${l.channel}  ← ${l.configPath}`);
   for (const s of plan.skipped) console.log(`  · 跳过 ${s.reg.name}：${s.reason}`);
+  for (const r of plan.redundant) console.log(`  · 多余（插件已自带 --all-channels）：${registrationHarness(r)}  ${r.name}`);
   if (!yes) {
     console.log("（未改任何东西。执行：party mcp migrate --yes）");
     return 0;

--- a/cli/src/commands/mcp.ts
+++ b/cli/src/commands/mcp.ts
@@ -486,10 +486,9 @@ function wrapToolsWithPerCallIdentity(server: McpServer, defaultChannel: string 
     originalResource(name as any, uriOrTemplate as any, meta as any, (async (uri: any, variables: any, ...rest: any[]) => {
       const rawVar = variables?.channel;
       const fromTemplate = Array.isArray(rawVar) ? rawVar[0] : rawVar;
-      const channel = typeof fromTemplate === "string" && fromTemplate !== "" ? fromTemplate : defaultChannel;
-      if (channel === undefined || channel === "") {
-        throw new Error("这条 MCP 服务本机所有频道，请读 party://<channel>/charter 指明是哪一个");
-      }
+      const channel = typeof fromTemplate === "string" && fromTemplate !== "" ? fromTemplate : undefined;
+      // 模板没给频道（具体的 party://charter）⇒ 老路：绑定频道 + 进程级身份。
+      if (channel === undefined) return cb(uri, variables, ...rest);
       const resolved = resolveChannelIdentity({ channel });
       if (!resolved.ok) throw new Error(resolved.message);
       return withMcpIdentity(resolved.config.path, () => cb(uri, variables, ...rest));
@@ -505,7 +504,10 @@ function wrapToolsWithPerCallIdentity(server: McpServer, defaultChannel: string 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const input = (spec as any)?.inputSchema;
     const extra = {
-      channel: z.string().describe("channel slug — 这条 MCP 服务本机所有频道，必须指明是哪一个"),
+      channel: z
+        .string()
+        .optional()
+        .describe("channel slug。省略＝当前目录绑定的频道（与不带 --all-channels 时完全相同）；给了就按频道解析身份"),
       identity: z.string().optional().describe("同一频道在本机有多份身份时，指定用哪一个（party who --all 可查）"),
       server: z.string().optional().describe("同名频道分属多个实例时，用实例 URL 限定（party who --all 可查）"),
     };
@@ -524,14 +526,20 @@ function wrapToolsWithPerCallIdentity(server: McpServer, defaultChannel: string 
     }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return original(name as any, spec as any, (async (args: any, extra: any) => {
-      const channel = typeof args?.channel === "string" && args.channel !== "" ? args.channel : defaultChannel;
-      if (channel === undefined || channel === "") {
-        // 聚合档下频道不是可省的：省了就没有身份，没有身份就没有「我是谁」。
-        return fail(
-          `这条 MCP 服务本机所有频道，请在参数里给出 channel（工具 ${name}）。` +
-            `本机有哪些频道：party who --all`,
-        );
+      const explicit = typeof args?.channel === "string" && args.channel !== "" ? args.channel : undefined;
+      if (explicit === undefined) {
+        // #1089：不传 channel ⇒ **完全**退回不带 --all-channels 时的老路（cwd 绑定 / --channel 默认 /
+        // 进程级身份）。这样 --all-channels 是老行为的严格超集，插件自带的 MCP 才能直接换成它：
+        // 在绑定过频道的目录里工具照旧不用传 channel，跨频道时再传。
+        if (resolveChannel(defaultChannel) === null) {
+          return fail(
+            `这条 MCP 服务本机所有频道，当前目录没有绑定频道，请在参数里给出 channel（工具 ${name}）。` +
+              `本机有哪些频道：party who --all`,
+          );
+        }
+        return handler(args, extra);
       }
+      const channel = explicit;
       const resolved = resolveChannelIdentity({
         channel,
         identity: typeof args?.identity === "string" && args.identity !== "" ? args.identity : undefined,

--- a/cli/test/mcp-migrate.test.ts
+++ b/cli/test/mcp-migrate.test.ts
@@ -55,13 +55,15 @@ interface Knobs extends Partial<MigrateDeps> {
   addLands?: "global" | "project" | "none";
   /** remove 返回 ok 但实际不删（模拟 scope 没对上的 `claude mcp remove`）。 */
   removeLies?: boolean;
+  /** #1089：插件已自带 --all-channels 的 harness。 */
+  pluginCoversHarnesses?: RegistrationHarness[];
 }
 
 function deps(initial: McpRegistration[], knobs: Knobs = {}): { deps: MigrateDeps; trace: Trace; registry: McpRegistration[] } {
   const registry = [...initial];
   const trace: Trace = { defaults: [], removed: [], added: [], order: [] };
   const servers = knobs.servers ?? {};
-  const { servers: _s, addLands, removeLies, ...over } = knobs;
+  const { servers: _s, addLands, removeLies, pluginCoversHarnesses, ...over } = knobs;
   const d: MigrateDeps = {
     home: "/home",
     globalCodexHome: GLOBAL_CODEX,
@@ -97,6 +99,7 @@ function deps(initial: McpRegistration[], knobs: Knobs = {}): { deps: MigrateDep
       registry.push(r);
       return { ok: true, detail: "" };
     },
+    pluginCovers: (h) => (pluginCoversHarnesses ?? []).includes(h),
     now: () => NOW,
     ...over,
   };
@@ -457,3 +460,44 @@ describe("同名的非 AgentParty MCP 注册：不动它", () => {
     expect(trace.added).toEqual([]);
   });
 });
+
+// #1089：AgentParty 插件自带的 MCP 改成 --all-channels 之后，它就是一条覆盖整台机器的单注册。
+// 装了插件的用户：join 不该再加 `party`；迁移只删旧注册不加新的；已有的 `party` 是多余进程，收掉。
+describe("插件已自带 --all-channels", () => {
+  test("ensureMachineWideSingle ⇒ present，不加任何注册", async () => {
+    const { ensureMachineWideSingle } = await import("../src/commands/mcp-migrate");
+    const { deps: d, trace } = deps([], { pluginCoversHarnesses: ["claude", "codex"] });
+    expect(ensureMachineWideSingle("claude", d)).toMatchObject({ ok: true, action: "present" });
+    expect(trace.added).toEqual([]);
+  });
+
+  test("迁移旧注册：只删旧、不加 party（插件已覆盖）", () => {
+    const { deps: d, trace, registry } = deps([reg({ name: "party-a" })], { pluginCoversHarnesses: ["codex"] });
+    const r = runMcpMigrate(planMcpMigrate(d), d, () => undefined);
+    expect(r.code).toBe(0);
+    expect(trace.added).toEqual([]);
+    expect(trace.removed).toEqual(["party-a"]);
+    expect(registry).toEqual([]);
+  });
+
+  test("已有的 party 单注册在插件覆盖后是多余的 ⇒ 收掉并读回", () => {
+    const { deps: d, trace, registry } = deps([single("claude"), single("codex")], { pluginCoversHarnesses: ["claude"] });
+    const plan = planMcpMigrate(d);
+    expect(plan.redundant.map((r) => r.harness)).toEqual(["claude"]); // codex 没插件覆盖，留着
+    const lines: string[] = [];
+    const r = runMcpMigrate(plan, d, (l) => lines.push(l));
+    expect(r.code).toBe(0);
+    expect(trace.removed).toEqual(["party"]);
+    expect(registry.map((x) => x.harness)).toEqual(["codex"]);
+    expect(lines.join("\n")).toContain("多余的单注册 party 已收掉");
+  });
+
+  test("插件覆盖 + 没有多余单注册 ⇒ 自动迁移什么都不做", () => {
+    const h = mkdtempSync(join(tmpdir(), "ap-migrate-"));
+    const { deps: d, trace } = deps([], { pluginCoversHarnesses: ["claude", "codex"] });
+    expect(maybeAutoMigrate("who", { deps: d, agentpartyHome: h }).ran).toBe(false);
+    expect(trace.removed).toEqual([]);
+    rmSync(h, { recursive: true, force: true });
+  });
+});
+

--- a/plugins/agentparty/.mcp.json
+++ b/plugins/agentparty/.mcp.json
@@ -4,7 +4,8 @@
       "command": "./bin/agentparty-runtime",
       "cwd": ".",
       "args": [
-        "mcp"
+        "mcp",
+        "--all-channels"
       ]
     }
   }

--- a/plugins/agentparty/claude-mcp.json
+++ b/plugins/agentparty/claude-mcp.json
@@ -3,7 +3,8 @@
     "agentparty": {
       "command": "${CLAUDE_PLUGIN_ROOT}/bin/agentparty-runtime",
       "args": [
-        "mcp"
+        "mcp",
+        "--all-channels"
       ]
     },
     "agentparty-channel": {

--- a/plugins/agentparty/skills/agentparty/SKILL.md
+++ b/plugins/agentparty/skills/agentparty/SKILL.md
@@ -105,6 +105,9 @@ If your harness can use MCP tools, prefer the local stdio server after configura
 # The name probe below only catches a same-named registration — a new identity name always
 # slips through, which is how one channel silently accumulated 14 identities (#907).
 party mcp identities --channel <slug> --server <server> --exclude <agent-name> || true
+# Machines with the AgentParty plugin (claude / codex) need NO registration: the plugin's own
+# `agentparty` MCP is already `party mcp --all-channels` (#1089). The lines below are for
+# machines without the plugin.
 # ONE registration serves every channel on this machine (#1083). Probe first — each
 # registration is one resident process in every session (#898); never add per channel.
 claude mcp get party >/dev/null 2>&1 \

--- a/scripts/agentparty-plugin.test.ts
+++ b/scripts/agentparty-plugin.test.ts
@@ -53,7 +53,7 @@ describe("AgentParty marketplace plugin", () => {
         agentparty: {
           command: "./bin/agentparty-runtime",
           cwd: ".",
-          args: ["mcp"],
+          args: ["mcp", "--all-channels"],
         },
       },
     });
@@ -64,7 +64,7 @@ describe("AgentParty marketplace plugin", () => {
       mcpServers: {
         agentparty: {
           command: claudeRuntimeCommand,
-          args: ["mcp"],
+          args: ["mcp", "--all-channels"],
         },
         "agentparty-channel": {
           command: claudeRuntimeCommand,
@@ -237,7 +237,7 @@ describe("AgentParty marketplace plugin", () => {
         }
       }
       // mcp / claude-channel 这些常驻入口不受影响：它们本来就只在被显式启动时才跑。
-      for (const argv of [["mcp"], ["claude-channel", "--require-launch-opt-in"], ["--version"]]) {
+      for (const argv of [["mcp"], ["mcp", "--all-channels"], ["claude-channel", "--require-launch-opt-in"], ["--version"]]) {
         const { home, marker } = stubHome();
         try {
           spawnSync(runtimeLauncher, argv, { env: { HOME: home, PATH: "/usr/bin:/bin" }, encoding: "utf8" });

--- a/scripts/verify-agentparty-plugin-install.test.ts
+++ b/scripts/verify-agentparty-plugin-install.test.ts
@@ -23,7 +23,7 @@ function installedEntry(installPath: string, enabled: boolean) {
     mcpServers: {
       agentparty: {
         command: "${CLAUDE_PLUGIN_ROOT}/bin/agentparty-runtime",
-        args: ["mcp"],
+        args: ["mcp", "--all-channels"],
       },
       "agentparty-channel": {
         command: "${CLAUDE_PLUGIN_ROOT}/bin/agentparty-runtime",

--- a/scripts/verify-agentparty-plugin-install.ts
+++ b/scripts/verify-agentparty-plugin-install.ts
@@ -239,7 +239,7 @@ export function inspectAgentPartyPluginInstall(
   const expectedMcp = {
     agentparty: {
       command: "${CLAUDE_PLUGIN_ROOT}/bin/agentparty-runtime",
-      args: ["mcp"],
+      args: ["mcp", "--all-channels"],
     },
     "agentparty-channel": {
       command: "${CLAUDE_PLUGIN_ROOT}/bin/agentparty-runtime",

--- a/skills/agentparty/SKILL.md
+++ b/skills/agentparty/SKILL.md
@@ -105,6 +105,9 @@ If your harness can use MCP tools, prefer the local stdio server after configura
 # The name probe below only catches a same-named registration — a new identity name always
 # slips through, which is how one channel silently accumulated 14 identities (#907).
 party mcp identities --channel <slug> --server <server> --exclude <agent-name> || true
+# Machines with the AgentParty plugin (claude / codex) need NO registration: the plugin's own
+# `agentparty` MCP is already `party mcp --all-channels` (#1089). The lines below are for
+# machines without the plugin.
 # ONE registration serves every channel on this machine (#1083). Probe first — each
 # registration is one resident process in every session (#898); never add per channel.
 claude mcp get party >/dev/null 2>&1 \


### PR DESCRIPTION
Closes #1089。#1083 剩下的那一半进程。

装了 AgentParty 插件的用户每会话仍是两个 party MCP 进程：插件随 `plugin.json` 注册的 `agentparty`（裸 `party mcp`，cwd 绑定）+ 我们确保的 `party`（`--all-channels`）。

## 改动
1. **`--all-channels` 改成老行为的严格超集**：不传 `channel` ⇒ 完全退回不带该旗标时的老路（cwd 绑定 / `--channel` 默认 / 进程级身份）；传了才按频道解析身份。资源同理。这一条让插件的 MCP 能直接换成它：绑定过频道的目录里工具照旧不用传 channel，跨频道时再传。
2. 插件 manifest（`claude-mcp.json` / `.mcp.json`）的 `agentparty` 改为 `mcp --all-channels`。
3. 迁移/join 新增 `pluginCovers`：读 harness 的插件安装记录/缓存里的 manifest，插件已是 `--all-channels` 就算整台机器已覆盖——`join` 不再加 `party`，迁移只删旧不加新，**已有的 `party` 单注册作为多余进程收掉**（读回验证）。
4. SKILL.md：装了插件的机器不用注册。

## 验证
- 真机：在绑定了 #ocs 的目录里起 `party mcp --all-channels`，不传 channel 的 `party_whoami` 走老路解到 `leomacbook`
- `verify-cli-binary.ts --plugin-root plugins/agentparty`：passed
- cli 相关 150/0；scripts（plugin manifest / install / verify-cli-binary / skill）37/0；插件镜像同步

## 发版后的验收
装了插件的机器 `claude plugin update agentparty` 后新开会话，`ps` 里 party MCP 进程恰好 1 个；`party mcp migrate --yes` 收掉多余的 `party`。我这台机器发版后做。

https://claude.ai/code/session_01HUmERHTXnbZhCZCwV6fGxD