### PR TITLE
fix(cli): party mcp 被同宿主下更新的同名 server 顶替时自己退场——进程泄漏的真正大头 (#1083)

### DIFF
--- a/cli/src/commands/mcp.ts
+++ b/cli/src/commands/mcp.ts
@@ -26,6 +26,7 @@ import {
 import { jsonFrame } from "../json";
 import { applyMcpProcessTitle, parseMcpServerArgv } from "../mcp-registry";
 import { watchParentLiveness } from "../parent-liveness";
+import { watchSuperseded } from "../mcp-superseded";
 import { resolveChannelIdentity } from "../mcp-channel-identity";
 import { withMcpIdentity } from "../mcp-identity-context";
 import { reportWakeSelfCheck } from "../wake-reachability";
@@ -1956,5 +1957,8 @@ export async function run(argv: string[]): Promise<number> {
     // 那个 pipe 不一定会关（claude-channel 那边实测就没关，孤儿跑了 21 小时）。父进程
     // 存活探测不依赖任何 fd 状态，宿主一死就收口。
     watchParentLiveness({ label: "party mcp", terminate: () => resolve(0) });
+    // #1083 第三道闸：宿主活着、stdin 也没关，但宿主重载 MCP 配置时起了一个命令行一模一样的新 server
+    // 而没收旧的（codex / ChatGPT 桌面版实测：一个会话名下 39 个、597 MB）。被顶替的自己退场。
+    watchSuperseded({ label: "party mcp", terminate: () => resolve(0) });
   });
 }

--- a/cli/src/mcp-superseded.ts
+++ b/cli/src/mcp-superseded.ts
@@ -61,15 +61,16 @@ export function listProcesses(spawn: typeof spawnSync = spawnSync): ProcessRow[]
 export function findYoungerTwin(selfPid: number, rows: readonly ProcessRow[]): ProcessRow | null | undefined {
   const me = rows.find((r) => r.pid === selfPid);
   if (me === undefined) return undefined;
-  // 「更年轻」的判定要确定性：etime 只有秒级，宿主重载时一批 server 常在同一秒内起来。同秒
-  // 之内按 pid 定序（pid 单调递增，回绕极罕见且同秒内不可能）——否则两个同秒兄弟互相判不出，
-  // 永远留两个。
-  const younger = (r: ProcessRow): boolean =>
-    r.ageSeconds < me.ageSeconds || (r.ageSeconds === me.ageSeconds && r.pid > me.pid);
-  const twins = rows.filter((r) => r.pid !== me.pid && r.ppid === me.ppid && r.command === me.command && younger(r));
+  // 只认**严格**更年轻的（etime 只有秒级）。同一秒内起的双胞胎谁都不退：曾想按 pid 定序打破平局，
+  // 但 pid 会回绕，回绕时新进程可能拿到更小的 pid，按 pid 判会让宿主**正在用的**那个退出——
+  // 误退当前 server 比多留一个进程严重得多（codex stop-time review）。同秒双胞胎会在宿主下一次
+  // 重载时（都比新的老）一起退出，只是晚一轮。
+  const twins = rows.filter(
+    (r) => r.pid !== me.pid && r.ppid === me.ppid && r.command === me.command && r.ageSeconds < me.ageSeconds,
+  );
   if (twins.length === 0) return null;
-  // 最年轻的那个就是宿主现在在用的（同秒按 pid 大者）
-  return twins.reduce((a, b) => (b.ageSeconds < a.ageSeconds || (b.ageSeconds === a.ageSeconds && b.pid > a.pid) ? b : a));
+  // 最年轻的那个就是宿主现在在用的
+  return twins.reduce((a, b) => (b.ageSeconds < a.ageSeconds ? b : a));
 }
 
 export const SUPERSEDED_POLL_MS_ENV = "AGENTPARTY_SUPERSEDED_POLL_MS";

--- a/cli/src/mcp-superseded.ts
+++ b/cli/src/mcp-superseded.ts
@@ -61,12 +61,15 @@ export function listProcesses(spawn: typeof spawnSync = spawnSync): ProcessRow[]
 export function findYoungerTwin(selfPid: number, rows: readonly ProcessRow[]): ProcessRow | null | undefined {
   const me = rows.find((r) => r.pid === selfPid);
   if (me === undefined) return undefined;
-  const twins = rows.filter(
-    (r) => r.pid !== me.pid && r.ppid === me.ppid && r.command === me.command && r.ageSeconds < me.ageSeconds,
-  );
+  // 「更年轻」的判定要确定性：etime 只有秒级，宿主重载时一批 server 常在同一秒内起来。同秒
+  // 之内按 pid 定序（pid 单调递增，回绕极罕见且同秒内不可能）——否则两个同秒兄弟互相判不出，
+  // 永远留两个。
+  const younger = (r: ProcessRow): boolean =>
+    r.ageSeconds < me.ageSeconds || (r.ageSeconds === me.ageSeconds && r.pid > me.pid);
+  const twins = rows.filter((r) => r.pid !== me.pid && r.ppid === me.ppid && r.command === me.command && younger(r));
   if (twins.length === 0) return null;
-  // 最年轻的那个就是宿主现在在用的
-  return twins.reduce((a, b) => (b.ageSeconds < a.ageSeconds ? b : a));
+  // 最年轻的那个就是宿主现在在用的（同秒按 pid 大者）
+  return twins.reduce((a, b) => (b.ageSeconds < a.ageSeconds || (b.ageSeconds === a.ageSeconds && b.pid > a.pid) ? b : a));
 }
 
 export const SUPERSEDED_POLL_MS_ENV = "AGENTPARTY_SUPERSEDED_POLL_MS";

--- a/cli/src/mcp-superseded.ts
+++ b/cli/src/mcp-superseded.ts
@@ -1,0 +1,117 @@
+// 被顶替的 MCP server 自己退场（#1083 的最后一块）。
+//
+// 真机现场（2026-09-05）：一个开了 4 小时的 codex 会话名下挂着 39 个 party MCP 子进程、597 MB——
+// 同样的命令行一遍遍重复，最老 4 小时。codex / ChatGPT 桌面版每次重载 MCP 配置（`codex mcp add/remove`、
+// 插件更新、会话内 reload）都会拉起一批新的 server，旧的既不 kill、也不关它们的 stdin，于是
+// #908 的宿主探活（宿主还活着）和 stdin EOF（pipe 没关）两道闸都拦不住。这批孤儿才是
+// 「29 个进程 / 298 MB」的大头，合并注册只解决了乘数里的一个因子。
+//
+// 判据只有一条，而且是确定性的：**同一宿主（ppid）下存在一个命令行完全相同、启动更晚的进程**
+// ⇒ 我已被顶替，宿主只会跟最新那个说话，我退出。不同命令行（插件的 agentparty-runtime 与
+// 手工注册的 party、不同 --channel）不算兄弟；同宿主起两个一模一样的 server 只在重载时发生。
+// 这里绝不去 kill 别人——只管自己退，和 #908 同一纪律。
+import { spawnSync } from "node:child_process";
+
+export interface ProcessRow {
+  pid: number;
+  ppid: number;
+  /** 已运行秒数（ps 的 etime 解析而来）。越小越年轻。 */
+  ageSeconds: number;
+  command: string;
+}
+
+/** 解析 ps 的 etime：`[[dd-]hh:]mm:ss`。解析不出返回 null（宁可判不出，也不猜）。 */
+export function parseEtime(raw: string): number | null {
+  const m = /^(?:(\d+)-)?(?:(\d{1,2}):)?(\d{1,2}):(\d{2})$/.exec(raw.trim());
+  if (m === null) return null;
+  const days = m[1] !== undefined ? Number(m[1]) : 0;
+  const hours = m[2] !== undefined ? Number(m[2]) : 0;
+  return ((days * 24 + hours) * 60 + Number(m[3])) * 60 + Number(m[4]);
+}
+
+/** `ps -axo pid=,ppid=,etime=,command=` 的一行 → ProcessRow；坏行丢弃。 */
+export function parsePsLine(line: string): ProcessRow | null {
+  const m = /^\s*(\d+)\s+(\d+)\s+(\S+)\s+(.*)$/.exec(line);
+  if (m === null) return null;
+  const age = parseEtime(m[3]!);
+  if (age === null) return null;
+  return { pid: Number(m[1]), ppid: Number(m[2]), ageSeconds: age, command: m[4]!.trim() };
+}
+
+export type ListProcesses = () => ProcessRow[];
+
+/** 真机：一次 ps 列全表。失败返回空表——判不出就当没被顶替，绝不因为 ps 抽风把自己退掉。 */
+export function listProcesses(spawn: typeof spawnSync = spawnSync): ProcessRow[] {
+  try {
+    const res = spawn("ps", ["-axo", "pid=,ppid=,etime=,command="], { encoding: "utf8", timeout: 10_000 });
+    if (res.error !== undefined || res.status !== 0 || typeof res.stdout !== "string") return [];
+    return res.stdout
+      .split("\n")
+      .map(parsePsLine)
+      .filter((row): row is ProcessRow => row !== null);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * 我（selfPid）有没有被同宿主下一个**命令行完全相同、更年轻**的进程顶替。
+ * 自己那一行找不到（ps 没列出来 / 解析失败）⇒ null（判不出）；找得到才给出 true/false。
+ */
+export function findYoungerTwin(selfPid: number, rows: readonly ProcessRow[]): ProcessRow | null | undefined {
+  const me = rows.find((r) => r.pid === selfPid);
+  if (me === undefined) return undefined;
+  const twins = rows.filter(
+    (r) => r.pid !== me.pid && r.ppid === me.ppid && r.command === me.command && r.ageSeconds < me.ageSeconds,
+  );
+  if (twins.length === 0) return null;
+  // 最年轻的那个就是宿主现在在用的
+  return twins.reduce((a, b) => (b.ageSeconds < a.ageSeconds ? b : a));
+}
+
+export const SUPERSEDED_POLL_MS_ENV = "AGENTPARTY_SUPERSEDED_POLL_MS";
+export const SUPERSEDED_POLL_MS = 60_000;
+
+export function supersededPollMs(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = env[SUPERSEDED_POLL_MS_ENV];
+  const n = raw === undefined ? NaN : Number(raw);
+  return Number.isFinite(n) && n >= 200 ? n : SUPERSEDED_POLL_MS;
+}
+
+export interface WatchSupersededOptions {
+  label: string;
+  selfPid?: number;
+  list?: ListProcesses;
+  pollMs?: number;
+  log?: (line: string) => void;
+  terminate: () => void;
+  schedule?: (fn: () => void, ms: number) => { stop: () => void };
+}
+
+function defaultSchedule(fn: () => void, ms: number): { stop: () => void } {
+  const timer = setInterval(fn, ms);
+  timer.unref?.();
+  return { stop: () => clearInterval(timer) };
+}
+
+/** 每 pollMs 查一次；发现被顶替就打一行说明并 terminate。返回句柄可停。 */
+export function watchSuperseded(opts: WatchSupersededOptions): { stop: () => void } {
+  const selfPid = opts.selfPid ?? process.pid;
+  const list = opts.list ?? listProcesses;
+  const log = opts.log ?? ((line: string) => console.error(line));
+  const schedule = opts.schedule ?? defaultSchedule;
+  let stopped = false;
+  const handle = schedule(() => {
+    if (stopped) return;
+    const twin = findYoungerTwin(selfPid, list());
+    if (twin === null || twin === undefined) return;
+    stopped = true;
+    handle.stop();
+    log(
+      `reaping: ${opts.label} 已被同宿主下更新的同名 server（pid=${String(twin.pid)}）顶替——` +
+        `宿主重载 MCP 配置时不收旧进程；本进程退场，不再占内存（#1083）`,
+    );
+    opts.terminate();
+  }, opts.pollMs ?? supersededPollMs());
+  return { stop: () => { stopped = true; handle.stop(); } };
+}

--- a/cli/test/mcp-superseded.test.ts
+++ b/cli/test/mcp-superseded.test.ts
@@ -61,6 +61,13 @@ describe("findYoungerTwin —— 只认同宿主 + 同命令行 + 更年轻", ()
     expect(findYoungerTwin(100, rows)).toBeNull();
   });
 
+  // CodeRabbit on #1092：etime 只有秒级，重载时一批 server 常在同一秒内起来，只比年龄会互相判不出。
+  test("同秒起的兄弟按 pid 定序：pid 大的算更年轻，小的退", () => {
+    const rows = [row(100, 1, 30, "party mcp --all-channels"), row(101, 1, 30, "party mcp --all-channels")];
+    expect(findYoungerTwin(100, rows)?.pid).toBe(101);
+    expect(findYoungerTwin(101, rows)).toBeNull();
+  });
+
   test("自己那行不在表里 ⇒ undefined（判不出，绝不误退）", () => {
     expect(findYoungerTwin(100, [row(101, 1, 30, "party mcp --all-channels")])).toBeUndefined();
   });

--- a/cli/test/mcp-superseded.test.ts
+++ b/cli/test/mcp-superseded.test.ts
@@ -1,0 +1,124 @@
+// #1083 最后一块：宿主重载 MCP 配置时不收旧 server，旧的自己发现被同参数的新兄弟顶替就退出。
+// 真机现场：一个 codex 会话名下 39 个 party MCP、597 MB，最老 4 小时。
+import { describe, expect, test } from "bun:test";
+import {
+  findYoungerTwin,
+  parseEtime,
+  parsePsLine,
+  supersededPollMs,
+  watchSuperseded,
+  type ProcessRow,
+} from "../src/mcp-superseded";
+
+const row = (pid: number, ppid: number, ageSeconds: number, command: string): ProcessRow => ({ pid, ppid, ageSeconds, command });
+
+describe("parseEtime", () => {
+  test("四种形态都认；坏的返回 null 而不是猜", () => {
+    expect(parseEtime("00:39")).toBe(39);
+    expect(parseEtime("02:10:33")).toBe(2 * 3600 + 10 * 60 + 33);
+    expect(parseEtime("1-04:00:58")).toBe(24 * 3600 + 4 * 3600 + 58);
+    expect(parseEtime("12-00:00:01")).toBe(12 * 86400 + 1);
+    expect(parseEtime("")).toBeNull();
+    expect(parseEtime("abc")).toBeNull();
+    expect(parseEtime("1:2:3:4")).toBeNull();
+  });
+});
+
+describe("parsePsLine", () => {
+  test("pid ppid etime command，命令保留全部参数", () => {
+    const r = parsePsLine("  7977 45506 36:04 party mcp --all-channels");
+    expect(r).toEqual({ pid: 7977, ppid: 45506, ageSeconds: 36 * 60 + 4, command: "party mcp --all-channels" });
+  });
+  test("etime 解析不出的行丢弃", () => {
+    expect(parsePsLine("1 2 ??? party mcp")).toBeNull();
+  });
+});
+
+describe("findYoungerTwin —— 只认同宿主 + 同命令行 + 更年轻", () => {
+  const me = row(100, 1, 600, "party mcp --all-channels");
+
+  test("有更年轻的同名兄弟 ⇒ 返回最年轻那个", () => {
+    const rows = [me, row(101, 1, 300, "party mcp --all-channels"), row(102, 1, 30, "party mcp --all-channels")];
+    expect(findYoungerTwin(100, rows)?.pid).toBe(102);
+  });
+
+  test("兄弟都比我老 ⇒ null（我就是最新的，留下）", () => {
+    const rows = [me, row(90, 1, 900, "party mcp --all-channels")];
+    expect(findYoungerTwin(100, rows)).toBeNull();
+  });
+
+  test("不同宿主的同名进程不算", () => {
+    expect(findYoungerTwin(100, [me, row(101, 2, 30, "party mcp --all-channels")])).toBeNull();
+  });
+
+  test("同宿主但命令行不同（插件那条 / 不同 --channel）不算", () => {
+    const rows = [
+      me,
+      row(101, 1, 30, "/x/bin/agentparty-runtime mcp --all-channels"),
+      row(102, 1, 30, "party mcp --channel king"),
+      row(103, 1, 30, "party mcp"),
+    ];
+    expect(findYoungerTwin(100, rows)).toBeNull();
+  });
+
+  test("自己那行不在表里 ⇒ undefined（判不出，绝不误退）", () => {
+    expect(findYoungerTwin(100, [row(101, 1, 30, "party mcp --all-channels")])).toBeUndefined();
+  });
+});
+
+describe("watchSuperseded", () => {
+  test("发现被顶替 ⇒ 打一行、terminate 一次、停止轮询", () => {
+    let tick: (() => void) | null = null;
+    let stopped = 0;
+    const logs: string[] = [];
+    let terminated = 0;
+    let rows: ProcessRow[] = [row(100, 1, 600, "party mcp --all-channels")];
+    watchSuperseded({
+      label: "party mcp",
+      selfPid: 100,
+      list: () => rows,
+      log: (l) => logs.push(l),
+      terminate: () => void (terminated += 1),
+      schedule: (fn) => {
+        tick = fn;
+        return { stop: () => void (stopped += 1) };
+      },
+    });
+    tick!();
+    expect(terminated).toBe(0); // 还没兄弟
+    rows = [...rows, row(101, 1, 5, "party mcp --all-channels")];
+    tick!();
+    tick!();
+    expect(terminated).toBe(1);
+    expect(stopped).toBe(1);
+    expect(logs[0]).toContain("pid=101");
+    expect(logs[0]).toContain("顶替");
+  });
+
+  test("ps 抽风（空表）⇒ 不退", () => {
+    let tick: (() => void) | null = null;
+    let terminated = 0;
+    watchSuperseded({
+      label: "x",
+      selfPid: 100,
+      list: () => [],
+      log: () => undefined,
+      terminate: () => void (terminated += 1),
+      schedule: (fn) => {
+        tick = fn;
+        return { stop: () => undefined };
+      },
+    });
+    tick!();
+    expect(terminated).toBe(0);
+  });
+});
+
+describe("supersededPollMs", () => {
+  test("缺省 60s；env 覆盖但不低于 200ms", () => {
+    expect(supersededPollMs({})).toBe(60_000);
+    expect(supersededPollMs({ AGENTPARTY_SUPERSEDED_POLL_MS: "1000" })).toBe(1000);
+    expect(supersededPollMs({ AGENTPARTY_SUPERSEDED_POLL_MS: "5" })).toBe(60_000);
+    expect(supersededPollMs({ AGENTPARTY_SUPERSEDED_POLL_MS: "x" })).toBe(60_000);
+  });
+});

--- a/cli/test/mcp-superseded.test.ts
+++ b/cli/test/mcp-superseded.test.ts
@@ -61,11 +61,20 @@ describe("findYoungerTwin —— 只认同宿主 + 同命令行 + 更年轻", ()
     expect(findYoungerTwin(100, rows)).toBeNull();
   });
 
-  // CodeRabbit on #1092：etime 只有秒级，重载时一批 server 常在同一秒内起来，只比年龄会互相判不出。
-  test("同秒起的兄弟按 pid 定序：pid 大的算更年轻，小的退", () => {
+  // codex stop-time review on #1092：pid 会回绕，回绕时新进程可能拿到更小的 pid——按 pid 打破同秒平局
+  // 会让宿主正在用的那个退出。所以同秒双胞胎谁都不退（失败安全），下一次重载时一起退。
+  test("同秒起的兄弟：谁都不退，不按 pid 猜新旧（pid 回绕会误退当前 server）", () => {
     const rows = [row(100, 1, 30, "party mcp --all-channels"), row(101, 1, 30, "party mcp --all-channels")];
-    expect(findYoungerTwin(100, rows)?.pid).toBe(101);
+    expect(findYoungerTwin(100, rows)).toBeNull();
     expect(findYoungerTwin(101, rows)).toBeNull();
+    // 回绕形态：老进程 pid 大、新进程 pid 小但同秒——同样谁都不退
+    const wrapped = [row(99990, 1, 30, "party mcp --all-channels"), row(12, 1, 30, "party mcp --all-channels")];
+    expect(findYoungerTwin(99990, wrapped)).toBeNull();
+    expect(findYoungerTwin(12, wrapped)).toBeNull();
+    // 下一轮重载：两个同秒的都比新的老 ⇒ 都退
+    const next = [...wrapped, row(13, 1, 1, "party mcp --all-channels")];
+    expect(findYoungerTwin(99990, next)?.pid).toBe(13);
+    expect(findYoungerTwin(12, next)?.pid).toBe(13);
   });
 
   test("自己那行不在表里 ⇒ undefined（判不出，绝不误退）", () => {


### PR DESCRIPTION
#1083 收口后在 owner 机器上 `ps` 抓到的真正大头：

```
宿主 45506（codex 会话，开了 4h）: 39 个 party MCP, 597 MB
宿主 32581（ChatGPT.app 的 codex app-server）: 10 个, 176 MB
```

同样的命令行一遍遍重复，最老 4 小时。codex / ChatGPT 桌面版每次重载 MCP 配置（`codex mcp add/remove`、插件更新、会话内 reload）都拉起一批新 server，**旧的既不 kill、也不关它们的 stdin**——#908 的宿主探活（宿主还活着）和 stdin EOF（pipe 没关）两道闸都拦不住。合并注册（#1084/#1091）只解决了乘数里的一个因子。

## 改动
新增第三道闸 `watchSuperseded`：每 60s 一次 `ps`，**同一宿主（ppid）下存在命令行完全相同、启动更晚的进程** ⇒ 我已被顶替（宿主只跟最新那个说话），打一行说明后退出。
- 不同命令行不算兄弟（插件的 `agentparty-runtime` 与手工注册的 `party`、不同 `--channel`），同宿主起两个一模一样的 server 只在重载时发生
- 绝不 kill 别人，只管自己退——与 #908 同一纪律
- `ps` 抽风 / 自己那行找不到 ⇒ 判不出就不退
- 年龄用 `etime` 解析（macOS 没有 `etimes`——今天就被这个坑过一次）

## 验证
- 真机：同一 shell 下起两个一模一样的 `bun src/index.ts mcp --all-channels`（stdin 都保持打开），1s 轮询，旧的几秒内打出 `reaping: … 已被同宿主下更新的同名 server（pid=…）顶替` 退出，新的留下且无 reaping
- 单测 15/0：etime 四种形态、只认同宿主+同命令行+更年轻、自己不在表里不误退、ps 空表不退

## 发版后验收
owner 机器上那个 codex 会话下次重载 MCP 后，旧 server 应在 60s 内自行退出，`ps` 里同参数的只剩 1 个。

https://claude.ai/code/session_01HUmERHTXnbZhCZCwV6fGxD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - MCP 服务器检测到同一主机上存在更新的相同实例时，将自动退出，避免旧进程持续运行。
  - MCP 服务器继续支持通过标准输入结束和父进程存活状态进行退出管理。

- **测试**
  - 补充了进程识别、顶替检测、轮询配置及安全退出行为的测试覆盖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->